### PR TITLE
feat(self-improve): slice 1 — correct-once gate, forked review, tiers, eval gate

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -223,6 +223,16 @@ RUN chmod 0755 /opt/switchroom/hooks/notion-write-pretool.mjs
 COPY dist/cli/skill-validate-pretool.mjs /opt/switchroom/hooks/skill-validate-pretool.mjs
 RUN chmod 0755 /opt/switchroom/hooks/skill-validate-pretool.mjs
 
+# Agent self-improvement Stop gate (RFC reference/rfcs/agent-self-improvement.md
+# slice 1). A cheap deterministic per-turn triage; on a learning signal
+# it injects a forked review turn via the gateway socket (inject_inbound,
+# not claude -p). Deliberately NOT in the security-plugin: it's a quality
+# loop, not a load-bearing safety control, and it only reads the
+# transcript + injects an in-session review the agent itself runs within
+# its own trust domain. The kill switch is SWITCHROOM_SELF_IMPROVE=0.
+COPY dist/cli/self-improve-stop.mjs /opt/switchroom/hooks/self-improve-stop.mjs
+RUN chmod 0755 /opt/switchroom/hooks/self-improve-stop.mjs
+
 # Image-baked security-hooks plugin (sec WS8-F1 / #1416). A separate,
 # minimal --plugin-dir holding ONLY the load-bearing PreToolUse safety
 # hooks (secret-exfil guard + Drive-write approval gate). Loaded from

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -175,9 +175,61 @@ For a switchroom-bundled fleet-default skill (every agent regardless of role):
 
 1. **Don't auto-install.** Add it as a developer-pool skill instead and let operators opt in via `defaults.skills`. Auto-injecting into every agent's tool list adds cognitive overhead per turn for users who'll never call it. The `role: foreman` opt-in is the right escape hatch for the operator-skill case.
 
+## Self-improvement (agents fix their own skills)
+
+Agents get better the longer they run: when a correction recurs, or the
+same manual fix shows up twice, the agent can land a small, tested,
+reversible edit to a skill **it already owns** — silently — and surface
+anything bigger as a proposal. This is on by default (opt-out), built on
+the skill-authoring path above. See the
+[RFC](../reference/rfcs/agent-self-improvement.md) and
+[job spec](../reference/jobs/get-better-the-longer-they-run.md).
+
+How it works (slice 1):
+
+1. **Gate (cheap, every turn).** A switchroom-owned async **Stop hook**
+   (`self-improve-stop`) runs a *deterministic* triage over the
+   just-finished turn — an operator correction, a repeated manual fix, or
+   a standing rule that didn't bind. A turn with no signal costs ~nothing
+   (no model call, no IO beyond the transcript read). The second
+   occurrence trips ("correct once, never again").
+2. **Forked review (only when the gate trips).** The hook injects a
+   review turn into the live session (`inject_inbound`, the same
+   primitive cron uses — never a new `claude -p` spawn, keeping it
+   subscription-honest). The review is restricted to memory + skill
+   read/write tools and runs off the reply path.
+3. **Tier router.** The review classifies the change by blast radius —
+   **T1** (small, reversible, single-file edit to an owned skill) lands
+   automatically; **T2/T3** (medium / shared / new-cron / new-skill /
+   cross-agent / irreversible) are written to a per-agent
+   pending-suggestions queue and never auto-applied.
+4. **Eval gate on T1.** Before a T1 edit lands, the skill's
+   `evals/evals.json` runs through the skill-creator grader +
+   `aggregate_benchmark.py`; the edit lands only if evals pass and don't
+   regress baseline. A skill with no evals downgrades to a T2 proposal.
+5. **Audit/rollback.** T1 edits go through the existing skill-write path,
+   so the validator hook + git history are the audit and rollback. The
+   only new state is the pending-queue file.
+
+Defaults (tunable via env; first measured on `clerk`):
+
+| Knob | Env | Default |
+|---|---|---|
+| Disable entirely | `SWITCHROOM_SELF_IMPROVE` | `1` (set `0` to opt out) |
+| Repetition threshold | `SWITCHROOM_SELF_IMPROVE_THRESHOLD` | `2` |
+| T1 auto-apply diff cap (lines) | `SWITCHROOM_SELF_IMPROVE_T1_MAX_LINES` | `30` |
+| Max auto-applies/day | `SWITCHROOM_SELF_IMPROVE_MAX_AUTO_PER_DAY` | `3` |
+| Max outstanding pending | `SWITCHROOM_SELF_IMPROVE_MAX_PENDING` | `5` |
+
+Pending suggestions live at `<stateDir>/self-improve-pending.jsonl`
+(one-tap Telegram / Linear surfacing is a later slice).
+
 ## Related code
 
 - `src/agents/scaffold.ts:installSwitchroomSkills` — auto-install of `switchroom-*` skills
 - `src/agents/scaffold.ts:syncGlobalSkills` — user-managed skill symlinking from `skills_dir`
+- `src/agents/scaffold.ts:buildSettingsHooksBlock` — wires the `self-improve-stop` Stop gate
+- `src/cli/self-improve-stop.ts` — the gate hook (bundled to `dist/cli/self-improve-stop.mjs`)
+- `src/self-improve/` — gate, tier router, eval gate, pending queue, rate limit, review prompt
 - `src/config/schema.ts` — `defaults.skills` + `agents.<name>.skills` schema
 - `examples/switchroom.yaml` — example config showing both forms

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -197,6 +197,23 @@ if (skillHookEscape.changed) {
   console.log(`[build] ASCII-escaped ${skillHookEscape.nonAsciiCount} non-ASCII code units in dist/cli/skill-validate-pretool.mjs`);
 }
 
+// Bundle the self-improve-stop hook — RFC reference/rfcs/agent-self-improvement.md
+// slice 1. Turn-end GATE: a self-contained .mjs the agent container runs
+// via node from the bundled-hooks path. It imports the src/self-improve/*
+// gate/router/prompt modules + node:net, none of which resolve from the
+// raw .mjs hooks dir inside the agent image — so bundle to one file.
+console.log("[build] bundling src/cli/self-improve-stop.ts -> dist/cli/self-improve-stop.mjs");
+execSync(
+  `bun build ${JSON.stringify(resolve(root, "src/cli/self-improve-stop.ts"))} --outfile ${JSON.stringify(resolve(outDir, "self-improve-stop.mjs"))} --target node`,
+  { stdio: "inherit", cwd: root }
+);
+const selfImproveHookOutFile = resolve(outDir, "self-improve-stop.mjs");
+chmodSync(selfImproveHookOutFile, 0o755);
+const selfImproveHookEscape = escapeBundleNonAscii(selfImproveHookOutFile);
+if (selfImproveHookEscape.changed) {
+  console.log(`[build] ASCII-escaped ${selfImproveHookEscape.nonAsciiCount} non-ASCII code units in dist/cli/self-improve-stop.mjs`);
+}
+
 // Bundle the autoaccept-poll entrypoint. The agent unit's ExecStartPost
 // invokes this in the background to dispatch first-run TUI prompts via
 // `tmux capture-pane` + `tmux send-keys`. Must ship in dist/ because

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -4308,6 +4308,22 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
       timeout: 5,
       async: true,
     });
+    // Agent self-improvement GATE — RFC
+    // reference/rfcs/agent-self-improvement.md slice 1. A cheap,
+    // deterministic per-turn triage; on a learning signal it injects a
+    // forked review turn (inject_inbound, NOT claude -p). Async so it
+    // never sits on the turn-end reply path; bundled from
+    // src/cli/self-improve-stop.ts (imports src/self-improve/* + node:net),
+    // hence DOCKER_BUNDLED_HOOKS_PATH like skill-validate-pretool.
+    stopHooks.push({
+      type: "command",
+      command: wrap(
+        "hook:self-improve-stop",
+        `node "${join(DOCKER_BUNDLED_HOOKS_PATH, "self-improve-stop.mjs")}"`,
+      ),
+      timeout: 10,
+      async: true,
+    });
   }
   const switchroomStop = stopHooks.length > 0 ? [{ hooks: stopHooks }] : [];
 

--- a/src/cli/self-improve-stop.ts
+++ b/src/cli/self-improve-stop.ts
@@ -1,0 +1,242 @@
+/**
+ * Stop hook — agent self-improvement GATE (RFC
+ * `reference/rfcs/agent-self-improvement.md`, slice 1).
+ *
+ * Fires at turn end (alongside the handoff / secret-scrub / tool-label
+ * Stop hooks). Reads the just-finished transcript, runs the cheap
+ * DETERMINISTIC gate (`src/self-improve/gate.ts`), and — only when a
+ * learning signal crosses the repetition threshold — injects a forked
+ * review turn into the live session via the gateway IPC socket
+ * (`inject_inbound`, the same primitive cron uses). NO model call here:
+ * the review is the synthesized turn, which keeps us on the
+ * claude-native / subscription-honest path (no `claude -p`).
+ *
+ * Cost guarantee (the whole point): a turn with NO signal returns in a
+ * single transcript pass with zero IO beyond the read — no socket
+ * connect, no model, no allocation storm. The gate is pure.
+ *
+ * Bundled to a self-contained `.mjs` at build time (like
+ * skill-validate-pretool / drive-write-pretool) because it imports the
+ * src/self-improve/* modules + node:net, none of which resolve from the
+ * raw .mjs hooks dir inside the agent image.
+ *
+ * Claude Code Stop-hook protocol: JSON on stdin
+ * ({ session_id, transcript_path, ... }); output ignored; exit 0 always
+ * (fail-open — a triage hook must never be the reason a turn fails).
+ */
+
+import { readFileSync } from "node:fs";
+import { createConnection } from "node:net";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+import { runGate } from "../self-improve/gate.js";
+import { buildReviewPrompt, REVIEW_SOURCE } from "../self-improve/review-prompt.js";
+import { selfImproveEnabled } from "../self-improve/config.js";
+import type { TurnMessage } from "../self-improve/types.js";
+
+/** Newest-last window of messages to scan. Bounds the gate's cost and
+ *  matches "this turn + a little context" — repetition across a long
+ *  session is the operator's job, not the per-turn gate's. */
+const SCAN_WINDOW = 40;
+
+function readStdin(): string {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Flatten one Claude Code transcript entry's content to text. Handles
+ * the nested `{type, message:{role, content}}` shape and the flat
+ * `{role, content}` shape; content may be a string or a list of parts
+ * ({type:"text",text} / {type:"tool_use",name,input} /
+ * {type:"tool_result",...}). Tool calls are flattened to a compact
+ * `Name(arg)` form so the gate's fix-fingerprint patterns can match.
+ */
+function flatten(entry: unknown): TurnMessage | null {
+  if (!entry || typeof entry !== "object") return null;
+  const e = entry as Record<string, unknown>;
+  let msg: Record<string, unknown> | null = null;
+  if ((e.type === "user" || e.type === "assistant") && e.message && typeof e.message === "object") {
+    msg = e.message as Record<string, unknown>;
+  } else if (typeof e.role === "string" && "content" in e) {
+    msg = e;
+  }
+  if (!msg) return null;
+  const role = typeof msg.role === "string" ? msg.role : "";
+  if (role !== "user" && role !== "assistant") return null;
+
+  const content = msg.content;
+  let text = "";
+  if (typeof content === "string") {
+    text = content;
+  } else if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const part of content) {
+      if (!part || typeof part !== "object") continue;
+      const p = part as Record<string, unknown>;
+      if (p.type === "text" && typeof p.text === "string") {
+        parts.push(p.text);
+      } else if (p.type === "tool_use" && typeof p.name === "string") {
+        // Compact "Name(primary-arg)" — enough for the gate's
+        // Edit(...)/Bash(...) fix fingerprints without dumping payloads.
+        const input = (p.input ?? {}) as Record<string, unknown>;
+        const arg =
+          (typeof input.file_path === "string" && input.file_path) ||
+          (typeof input.command === "string" && input.command) ||
+          (typeof input.path === "string" && input.path) ||
+          "";
+        parts.push(`${p.name}(${arg})`);
+      }
+    }
+    text = parts.join(" ");
+  }
+  return { role, text };
+}
+
+function readTranscript(path: string): TurnMessage[] {
+  if (!path) return [];
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return [];
+  }
+  const out: TurnMessage[] = [];
+  for (const line of raw.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      const m = flatten(JSON.parse(t));
+      if (m && m.text) out.push(m);
+    } catch {
+      /* skip malformed line */
+    }
+  }
+  // Bounded tail.
+  return out.length > SCAN_WINDOW ? out.slice(-SCAN_WINDOW) : out;
+}
+
+function resolveSocketPath(): string {
+  if (process.env.SWITCHROOM_GATEWAY_SOCKET) {
+    return process.env.SWITCHROOM_GATEWAY_SOCKET;
+  }
+  const stateDir =
+    process.env.TELEGRAM_STATE_DIR ?? join(homedir(), ".claude", "channels", "telegram");
+  return join(stateDir, "gateway.sock");
+}
+
+/** The chat the review turn nominally belongs to. The review is off the
+ *  reply path (the prompt forbids replying), so this is context only;
+ *  inject_inbound does not gate on chat. Prefer an explicit override. */
+function resolveChatId(): string {
+  return (
+    process.env.SWITCHROOM_SELF_IMPROVE_CHAT_ID ??
+    process.env.SWITCHROOM_DEFAULT_CHAT_ID ??
+    "self-improve"
+  );
+}
+
+/**
+ * Fire-and-forget the inject_inbound envelope at the gateway socket.
+ * Best-effort: a short connect timeout, write, end. Never throws.
+ */
+function injectReview(agentName: string, text: string, sessionId: string): void {
+  const socketPath = resolveSocketPath();
+  const chatId = resolveChatId();
+  const now = Date.now();
+  const envelope = {
+    type: "inject_inbound",
+    agentName,
+    inbound: {
+      type: "inbound",
+      chatId,
+      messageId: now,
+      user: "self-improve",
+      userId: 0,
+      ts: now,
+      text,
+      meta: {
+        source: REVIEW_SOURCE,
+        triggering_session: sessionId,
+      } as Record<string, string>,
+    },
+  };
+
+  let settled = false;
+  const sock = createConnection(socketPath);
+  const done = (): void => {
+    if (settled) return;
+    settled = true;
+    try {
+      sock.end();
+    } catch {
+      /* nothing to do */
+    }
+    try {
+      sock.destroy();
+    } catch {
+      /* nothing to do */
+    }
+    process.exit(0);
+  };
+  const timer = setTimeout(done, 3000);
+  timer.unref?.();
+  sock.on("connect", () => {
+    try {
+      sock.write(JSON.stringify(envelope) + "\n", () => done());
+    } catch {
+      done();
+    }
+  });
+  sock.on("error", () => done());
+}
+
+function main(): void {
+  // Opt-out kill switch (RFC: ships on by default, per-agent disable).
+  if (!selfImproveEnabled()) process.exit(0);
+
+  const raw = readStdin().trim();
+  if (!raw) process.exit(0);
+
+  let event: { transcript_path?: unknown; session_id?: unknown };
+  try {
+    event = JSON.parse(raw);
+  } catch {
+    process.exit(0); // Claude protocol error — not ours.
+  }
+
+  const transcriptPath =
+    typeof event.transcript_path === "string" ? event.transcript_path : "";
+  const sessionId =
+    typeof event.session_id === "string" ? event.session_id : "unknown";
+
+  const messages = readTranscript(transcriptPath);
+  const gate = runGate(messages);
+
+  // Cost guarantee: no signal → return immediately, zero added work.
+  if (!gate.tripped) process.exit(0);
+
+  // Don't recurse: a review turn we injected is itself a transcript; if
+  // its own messages somehow trip the gate, we'd loop. The injected
+  // turn's first user message carries meta.source=self_improve_review;
+  // the transcript flattening drops meta, but the visible prompt starts
+  // with the "[self-improvement review]" banner — bail if the most
+  // recent user message is one of ours.
+  const lastUser = [...messages].reverse().find((m) => m.role === "user");
+  if (lastUser && lastUser.text.startsWith("[self-improvement review]")) {
+    process.exit(0);
+  }
+
+  const agentName = process.env.SWITCHROOM_AGENT_NAME ?? "";
+  if (!agentName) process.exit(0); // can't route without identity — fail-open
+
+  const prompt = buildReviewPrompt(gate.signals);
+  injectReview(agentName, prompt, sessionId);
+  // injectReview calls process.exit(0) on completion / timeout / error.
+}
+
+main();

--- a/src/self-improve/config.ts
+++ b/src/self-improve/config.ts
@@ -1,0 +1,58 @@
+/**
+ * Agent self-improvement — starting defaults (RFC §"Starting defaults",
+ * tuned on the `clerk` agent first). Centralised + overridable via env
+ * so they're easy to tune without a code edit, per the RFC's
+ * "make it easy to tune" requirement. Slice 1 keeps the gate
+ * deterministic (no small-model triage) — that's a later option.
+ */
+
+/** Parse a positive integer env override, falling back to `def`. */
+function intEnv(name: string, def: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return def;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : def;
+}
+
+export interface SelfImproveConfig {
+  /**
+   * Repetition threshold — the Nth occurrence of a signal trips the
+   * gate. Default 2 ("correct once, never again": the SECOND time a
+   * correction/fix recurs, we act).
+   */
+  repetitionThreshold: number;
+  /**
+   * T1 auto-apply diff cap — an edit larger than this (changed lines)
+   * is NOT a T1; it downgrades to a T2 proposal.
+   */
+  t1MaxChangedLines: number;
+  /** Max T1 auto-applies per agent per day. */
+  maxAutoAppliesPerDay: number;
+  /** Max outstanding (un-actioned) pending suggestions before we stop queueing. */
+  maxOutstandingPending: number;
+}
+
+/**
+ * Resolve the effective config. Env overrides let the operator tune on
+ * `clerk` without a rebuild:
+ *   SWITCHROOM_SELF_IMPROVE_THRESHOLD
+ *   SWITCHROOM_SELF_IMPROVE_T1_MAX_LINES
+ *   SWITCHROOM_SELF_IMPROVE_MAX_AUTO_PER_DAY
+ *   SWITCHROOM_SELF_IMPROVE_MAX_PENDING
+ */
+export function resolveSelfImproveConfig(): SelfImproveConfig {
+  return {
+    repetitionThreshold: Math.max(
+      2,
+      intEnv("SWITCHROOM_SELF_IMPROVE_THRESHOLD", 2),
+    ),
+    t1MaxChangedLines: intEnv("SWITCHROOM_SELF_IMPROVE_T1_MAX_LINES", 30),
+    maxAutoAppliesPerDay: intEnv("SWITCHROOM_SELF_IMPROVE_MAX_AUTO_PER_DAY", 3),
+    maxOutstandingPending: intEnv("SWITCHROOM_SELF_IMPROVE_MAX_PENDING", 5),
+  };
+}
+
+/** Whether self-improvement is enabled (opt-OUT, on by default per RFC). */
+export function selfImproveEnabled(): boolean {
+  return process.env.SWITCHROOM_SELF_IMPROVE !== "0";
+}

--- a/src/self-improve/eval-gate.ts
+++ b/src/self-improve/eval-gate.ts
@@ -1,0 +1,199 @@
+/**
+ * Agent self-improvement — the EVAL GATE on T1 (RFC §"Per-skill eval").
+ *
+ * Before any T1 edit lands, the candidate skill's `evals/evals.json` is
+ * run through the skill-creator harness — the `agents/grader.md` grader
+ * subagent (cheap model) produces per-run `grading.json`, and
+ * `scripts/aggregate_benchmark.py` produces a `benchmark.json` with
+ * pass-rate mean ± stddev for the candidate ("with_skill") vs the
+ * pre-edit baseline ("without_skill" / "baseline"). The edit lands ONLY
+ * if its evals pass AND don't regress baseline.
+ *
+ * Slice-1 scope of THIS module: it does NOT spawn the grader subagent
+ * (that runs in the forked review's session, which has the model). This
+ * module is the deterministic DECISION layer:
+ *   - `skillHasEvals()` — precondition: a T1 with no evals.json must NOT
+ *     auto-apply; it downgrades to a T2 proposal (RFC "If the skill has
+ *     no evals.json yet … downgrade it to a T2 proposal instead").
+ *   - `aggregateBenchmark()` — shells out to the real
+ *     `scripts/aggregate_benchmark.py`, the same script skill-creator
+ *     uses (no new eval engine).
+ *   - `evalVerdict()` — reads a benchmark.json and decides
+ *     pass / regress against baseline.
+ *
+ * Keeping the verdict logic pure + the harness call thin is what lets
+ * the "eval gate blocks a regressing edit" test run without a model.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { resolveSelfImproveConfig, type SelfImproveConfig } from "./config.js";
+
+/** Path to a skill's evals.json, given the skill dir. */
+export function evalsJsonPath(skillDir: string): string {
+  return join(skillDir, "evals", "evals.json");
+}
+
+/**
+ * Precondition gate: does this skill carry runnable evals? A T1 with no
+ * evals must downgrade to T2 (we never auto-apply an unmeasured edit).
+ */
+export function skillHasEvals(skillDir: string): boolean {
+  const p = evalsJsonPath(skillDir);
+  if (!existsSync(p)) return false;
+  try {
+    const parsed = JSON.parse(readFileSync(p, "utf-8")) as {
+      evals?: unknown;
+    };
+    return Array.isArray(parsed.evals) && parsed.evals.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export interface BenchmarkResult {
+  ok: boolean;
+  /** Path to the generated benchmark.json (when ok). */
+  benchmarkJson?: string;
+  /** Raw stderr/stdout on failure. */
+  error?: string;
+}
+
+/**
+ * Run the real `aggregate_benchmark.py` over a benchmark dir of
+ * `grading.json` files (produced by the grader subagent). Reuses the
+ * skill-creator script verbatim — no new eval engine.
+ *
+ * `repoRoot` locates `skills/skill-creator/scripts/aggregate_benchmark.py`.
+ */
+export function aggregateBenchmark(
+  benchmarkDir: string,
+  repoRoot: string,
+  pythonBin = process.env.SWITCHROOM_PYTHON ?? "python3",
+): BenchmarkResult {
+  const script = join(
+    repoRoot,
+    "skills",
+    "skill-creator",
+    "scripts",
+    "aggregate_benchmark.py",
+  );
+  if (!existsSync(script)) {
+    return { ok: false, error: `aggregate_benchmark.py not found at ${script}` };
+  }
+  const r = spawnSync(pythonBin, [script, benchmarkDir], {
+    encoding: "utf-8",
+    timeout: 120_000,
+  });
+  if (r.status !== 0) {
+    return {
+      ok: false,
+      error: `aggregate_benchmark exited ${r.status}: ${(r.stderr ?? "").trim()}`,
+    };
+  }
+  return { ok: true, benchmarkJson: join(benchmarkDir, "benchmark.json") };
+}
+
+export type EvalVerdict =
+  | { pass: true; candidatePassRate: number; baselinePassRate: number }
+  | {
+      pass: false;
+      reason: string;
+      candidatePassRate?: number;
+      baselinePassRate?: number;
+    };
+
+interface RunSummaryStat {
+  mean?: number;
+  stddev?: number;
+}
+interface ConfigSummary {
+  pass_rate?: RunSummaryStat;
+}
+interface Benchmark {
+  run_summary?: Record<string, ConfigSummary | unknown>;
+}
+
+/** The benchmark configs we treat as "the edited skill". */
+const CANDIDATE_CONFIGS = ["with_skill", "candidate", "new_skill", "after"];
+/** The benchmark configs we treat as "the pre-edit baseline". */
+const BASELINE_CONFIGS = ["without_skill", "baseline", "old_skill", "before"];
+
+function pickPassRate(
+  summary: Record<string, unknown>,
+  names: string[],
+): number | undefined {
+  for (const n of names) {
+    const c = summary[n] as ConfigSummary | undefined;
+    if (c && c.pass_rate && typeof c.pass_rate.mean === "number") {
+      return c.pass_rate.mean;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Decide whether a T1 edit may land, from a benchmark.json.
+ *
+ * Rules (RFC "lands only if its evals pass and don't regress baseline"):
+ *   - The candidate must reach an absolute floor (default 1.0 — evals
+ *     must pass; tune via SWITCHROOM_SELF_IMPROVE_EVAL_FLOOR).
+ *   - The candidate must NOT score below baseline beyond a small noise
+ *     band (default 0.0 — any regression blocks; the band absorbs
+ *     stddev jitter, tune via SWITCHROOM_SELF_IMPROVE_EVAL_REGRESS_BAND).
+ *   - If there is no baseline config, the floor alone decides.
+ */
+export function evalVerdict(
+  benchmarkJson: string,
+  _cfg: SelfImproveConfig = resolveSelfImproveConfig(),
+): EvalVerdict {
+  let bench: Benchmark;
+  try {
+    bench = JSON.parse(readFileSync(benchmarkJson, "utf-8")) as Benchmark;
+  } catch (err) {
+    return { pass: false, reason: `unreadable benchmark.json: ${(err as Error).message}` };
+  }
+  const summary = (bench.run_summary ?? {}) as Record<string, unknown>;
+
+  const candidate = pickPassRate(summary, CANDIDATE_CONFIGS);
+  if (candidate === undefined) {
+    return { pass: false, reason: "no candidate pass-rate in benchmark.json" };
+  }
+  const baseline = pickPassRate(summary, BASELINE_CONFIGS);
+
+  const floor = floatEnv("SWITCHROOM_SELF_IMPROVE_EVAL_FLOOR", 1.0);
+  const regressBand = floatEnv("SWITCHROOM_SELF_IMPROVE_EVAL_REGRESS_BAND", 0.0);
+
+  if (candidate < floor) {
+    return {
+      pass: false,
+      reason: `candidate pass-rate ${candidate.toFixed(2)} below floor ${floor.toFixed(2)}`,
+      candidatePassRate: candidate,
+      baselinePassRate: baseline,
+    };
+  }
+
+  if (baseline !== undefined && candidate < baseline - regressBand) {
+    return {
+      pass: false,
+      reason: `regression: candidate ${candidate.toFixed(2)} < baseline ${baseline.toFixed(2)} (band ${regressBand.toFixed(2)})`,
+      candidatePassRate: candidate,
+      baselinePassRate: baseline,
+    };
+  }
+
+  return {
+    pass: true,
+    candidatePassRate: candidate,
+    baselinePassRate: baseline ?? candidate,
+  };
+}
+
+function floatEnv(name: string, def: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return def;
+  const n = Number.parseFloat(raw);
+  return Number.isFinite(n) ? n : def;
+}

--- a/src/self-improve/gate.ts
+++ b/src/self-improve/gate.ts
@@ -1,0 +1,283 @@
+/**
+ * Agent self-improvement — the GATE (RFC §"Solution Space" / "Be
+ * gate-first"). A cheap, DETERMINISTIC per-turn triage that decides
+ * whether the expensive forked review runs at all.
+ *
+ * This is the load-bearing cost guarantee: a turn with no learning
+ * signal must incur ~no extra work — the gate is pure, allocation-light,
+ * and returns immediately on a clean turn (`Cost × idle turn` UAT in the
+ * job spec). NO model call, NO IO. Slice 1 detects three signal classes:
+ *
+ *   1. operator-correction — the operator's last messages contain a
+ *      correction pattern ("no, that's wrong", "I told you …", "stop
+ *      doing X", "that's not what I asked"). Repetition = the operator
+ *      had to say it more than once.
+ *   2. repeated-manual-fix — the same fix (an identical Edit old→new, or
+ *      an identical Bash remediation) recurs within the turn window.
+ *   3. directive-not-bound — the operator restates a standing rule
+ *      ("always …", "every time …", "remember to …") they have already
+ *      stated, i.e. it didn't bind.
+ *
+ * Repetition threshold = 2 by default ("correct once, never again"): the
+ * SECOND occurrence trips. No signal → `{tripped:false, signals:[]}`.
+ */
+
+import type {
+  GateResult,
+  LearningSignal,
+  LearningSignalKind,
+  TurnMessage,
+} from "./types.js";
+import { resolveSelfImproveConfig } from "./config.js";
+
+/** Cap on evidence excerpt length stored in a signal. */
+const EVIDENCE_MAX = 160;
+
+function excerpt(s: string): string {
+  const t = s.replace(/\s+/g, " ").trim();
+  return t.length > EVIDENCE_MAX ? t.slice(0, EVIDENCE_MAX - 1) + "…" : t;
+}
+
+/**
+ * Correction phrases the operator uses to push back on the agent.
+ * Anchored to whole words to avoid matching substrings ("not" inside
+ * "note"). Case-insensitive, applied to user-role text only.
+ */
+const CORRECTION_PATTERNS: RegExp[] = [
+  /\bno,? that'?s (?:not right|wrong|incorrect|not what)\b/i,
+  /\bthat'?s (?:not right|wrong|incorrect)\b/i,
+  /\bthat'?s not what i (?:asked|wanted|meant|said)\b/i,
+  /\bi (?:already )?told you\b/i,
+  /\bi keep telling you\b/i,
+  /\b(?:stop|don'?t) (?:doing|do) (?:that|this)\b/i,
+  /\bwhy did you\b.*\b(?:again|still)\b/i,
+  /\byou (?:keep|always) (?:doing|getting)\b/i,
+  /\bnot again\b/i,
+  /\byou got it wrong\b/i,
+];
+
+/**
+ * "Standing rule" phrases — the operator stating a durable directive.
+ * The directive-not-bound signal fires when the SAME rule is restated
+ * (an "always do X" that evidently didn't bind, so they're saying it
+ * again).
+ */
+const DIRECTIVE_PATTERNS: RegExp[] = [
+  /\b(?:always|never|every time|from now on|going forward|remember to|make sure (?:to|you))\b/i,
+];
+
+/** Stopwords removed when normalising a directive for dup-detection. */
+const DIRECTIVE_STOPWORDS = new Set([
+  "always",
+  "never",
+  "every",
+  "time",
+  "from",
+  "now",
+  "on",
+  "going",
+  "forward",
+  "remember",
+  "to",
+  "make",
+  "sure",
+  "you",
+  "the",
+  "a",
+  "an",
+  "please",
+  "and",
+  "do",
+  "don't",
+  "dont",
+  "that",
+  "this",
+  "is",
+  "be",
+  "i",
+  "your",
+  "my",
+]);
+
+/**
+ * Content-word set of a directive sentence: lowercase, strip the
+ * directive cue + stopwords. Two restatements of the same rule —
+ * "always dedupe the email recipients" vs "remember to dedupe the
+ * recipients" — share most of these words.
+ */
+function directiveContentWords(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s'-]/g, " ")
+      .split(/\s+/)
+      .filter((w) => w.length > 2 && !DIRECTIVE_STOPWORDS.has(w)),
+  );
+}
+
+/** Jaccard overlap of two word sets (0..1). */
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let inter = 0;
+  for (const w of a) if (b.has(w)) inter += 1;
+  return inter / (a.size + b.size - inter);
+}
+
+/** Two directives are "the same rule restated" when their content-word
+ *  sets overlap at least this much. Tolerant of re-wording, strict
+ *  enough that two unrelated rules don't cluster. */
+const DIRECTIVE_SIM_THRESHOLD = 0.5;
+
+interface DirectiveStatement {
+  words: Set<string>;
+  sample: string;
+}
+
+/** Extract directive-bearing sentence(s) from a user message. */
+function directiveStatements(text: string): DirectiveStatement[] {
+  const out: DirectiveStatement[] = [];
+  for (const sentence of text.split(/(?<=[.!?\n])\s+/)) {
+    if (DIRECTIVE_PATTERNS.some((re) => re.test(sentence))) {
+      const words = directiveContentWords(sentence);
+      if (words.size > 0) out.push({ words, sample: sentence.trim() });
+    }
+  }
+  return out;
+}
+
+/**
+ * Pull a normalised "fix fingerprint" from an assistant tool-bearing
+ * message text. The Stop hook flattens tool calls into the message
+ * text; we look for repeated Edit/Write/Bash remediations by fingerprint.
+ *
+ * We intentionally only fingerprint Edit (old→new) and Bash, the two
+ * shapes that signal "the agent had to redo the same fix". The
+ * fingerprint is the normalised concatenation; collisions across turns
+ * mean the same fix recurred.
+ */
+const FIX_PATTERNS: RegExp[] = [
+  // Tool-label flattened forms (see telegram-plugin/tool-labels.ts and
+  // the transcript flattening in the Stop hook): "Edit(<path>)", with a
+  // following diff body, or a "Bash(<cmd>)".
+  /\bEdit\(([^)]+)\)/g,
+  /\bBash\(([^)]+)\)/g,
+];
+
+function fixFingerprints(text: string): string[] {
+  const out: string[] = [];
+  for (const re of FIX_PATTERNS) {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      const inner = (m[1] ?? "").replace(/\s+/g, " ").trim().toLowerCase();
+      if (inner.length >= 3) out.push(`${m[0].split("(")[0]}::${inner}`);
+    }
+  }
+  return out;
+}
+
+/**
+ * Run the gate over a finished turn's messages.
+ *
+ * `messages` is the bounded transcript tail the Stop hook hands us
+ * (user + assistant, newest last). The gate is O(messages × patterns)
+ * with no IO — on a clean turn it walks the messages once and returns
+ * `tripped:false`.
+ */
+export function runGate(
+  messages: TurnMessage[],
+  cfg = resolveSelfImproveConfig(),
+): GateResult {
+  const threshold = cfg.repetitionThreshold;
+  const signals: LearningSignal[] = [];
+
+  // Fast path: nothing to look at.
+  if (!messages || messages.length === 0) {
+    return { tripped: false, signals };
+  }
+
+  // --- 1. operator-correction: count correction-bearing user messages.
+  let correctionCount = 0;
+  let lastCorrection = "";
+  // --- 3. directive-not-bound: cluster restatements of the same rule by
+  //         content-word similarity (tolerant of re-wording).
+  const directiveClusters: { words: Set<string>; count: number; sample: string }[] = [];
+  // --- 2. repeated-manual-fix: count identical fix fingerprints.
+  const fixCounts = new Map<string, number>();
+
+  for (const m of messages) {
+    const text = typeof m.text === "string" ? m.text : "";
+    if (text.length === 0) continue;
+
+    if (m.role === "user") {
+      if (CORRECTION_PATTERNS.some((re) => re.test(text))) {
+        correctionCount += 1;
+        lastCorrection = text;
+      }
+      for (const stmt of directiveStatements(text)) {
+        const hit = directiveClusters.find(
+          (c) => jaccard(c.words, stmt.words) >= DIRECTIVE_SIM_THRESHOLD,
+        );
+        if (hit) {
+          hit.count += 1;
+          // Keep the longest sample as the most descriptive evidence.
+          if (stmt.sample.length > hit.sample.length) hit.sample = stmt.sample;
+        } else {
+          directiveClusters.push({ words: stmt.words, count: 1, sample: stmt.sample });
+        }
+      }
+    } else if (m.role === "assistant") {
+      for (const fp of fixFingerprints(text)) {
+        fixCounts.set(fp, (fixCounts.get(fp) ?? 0) + 1);
+      }
+    }
+  }
+
+  if (correctionCount >= threshold) {
+    signals.push(
+      buildSignal(
+        "operator-correction",
+        `Operator pushed back ${correctionCount}× this turn — the same correction recurred`,
+        correctionCount,
+        lastCorrection,
+      ),
+    );
+  }
+
+  for (const { count, sample } of directiveClusters) {
+    if (count >= threshold) {
+      signals.push(
+        buildSignal(
+          "directive-not-bound",
+          `A standing rule was restated ${count}× — it isn't binding where the action runs`,
+          count,
+          sample,
+        ),
+      );
+    }
+  }
+
+  for (const [fp, count] of fixCounts) {
+    if (count >= threshold) {
+      signals.push(
+        buildSignal(
+          "repeated-manual-fix",
+          `The same manual fix was applied ${count}× — codify it so it stops recurring`,
+          count,
+          fp,
+        ),
+      );
+    }
+  }
+
+  return { tripped: signals.length > 0, signals };
+}
+
+function buildSignal(
+  kind: LearningSignalKind,
+  reason: string,
+  occurrences: number,
+  evidence: string,
+): LearningSignal {
+  return { kind, reason, occurrences, evidence: excerpt(evidence) };
+}

--- a/src/self-improve/pending-queue.ts
+++ b/src/self-improve/pending-queue.ts
@@ -1,0 +1,142 @@
+/**
+ * Agent self-improvement — the pending-suggestions QUEUE (RFC §"Promotion
+ * store: there isn't one"). The ONLY new state slice 1 introduces.
+ *
+ * T2/T3 candidates are not auto-applied; they're appended here as one
+ * line of JSON per suggestion, under the agent's state dir. Agent-
+ * agnostic on purpose: a later slice surfaces these as Telegram one-tap
+ * cards / Linear issues, but the backing store is this simple file so
+ * the feature ships without a broker.
+ *
+ * Storage layout (mirrors src/issues/store.ts):
+ *   <stateDir>/self-improve-pending.jsonl  — append-only, one JSON/line.
+ *   <stateDir>/self-improve-pending.lock   — flock for the read cap.
+ *
+ * Append-only (vs the issues sink's collapse-on-write) because a
+ * suggestion is an event the operator actions out-of-band; we keep the
+ * full proposal history and mark entries actioned in place is NOT needed
+ * for slice 1 (surfacing is deferred). We DO enforce the outstanding-cap
+ * so the queue can't grow without bound (RFC: ≤5 outstanding).
+ */
+
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  writeSync,
+} from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import type { Tier } from "./types.js";
+import { resolveSelfImproveConfig } from "./config.js";
+
+export const PENDING_FILE = "self-improve-pending.jsonl";
+
+export interface PendingSuggestion {
+  /** Stable id (for a later one-tap surface to reference). */
+  id: string;
+  /** ISO timestamp when proposed. */
+  created_at: string;
+  /** T2 or T3 — T0/T1 never reach the queue. */
+  tier: Exclude<Tier, "T0" | "T1">;
+  /** The lesson in one line. */
+  lesson: string;
+  /** The smallest change that would make the lesson bind. */
+  proposed_change: string;
+  /** Why the router chose this tier (operator-facing). */
+  tier_reason: string;
+  /** Target skill slug, when applicable. */
+  skill_slug?: string;
+  /** The signal kind(s) that triggered the review. */
+  triggered_by: string[];
+  /** Set true once the operator actions it (reserved for a later slice). */
+  actioned?: boolean;
+}
+
+function pendingPath(stateDir: string): string {
+  return join(stateDir, PENDING_FILE);
+}
+
+/** Read every line; skip malformed (best-effort, like the issues sink). */
+export function readPending(stateDir: string): PendingSuggestion[] {
+  const p = pendingPath(stateDir);
+  if (!existsSync(p)) return [];
+  let raw: string;
+  try {
+    raw = readFileSync(p, "utf-8");
+  } catch {
+    return [];
+  }
+  const out: PendingSuggestion[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as PendingSuggestion;
+      if (parsed && typeof parsed.id === "string" && parsed.tier) {
+        out.push(parsed);
+      }
+    } catch {
+      /* skip malformed line */
+    }
+  }
+  return out;
+}
+
+/** Count outstanding (not-yet-actioned) suggestions. */
+export function outstandingCount(stateDir: string): number {
+  return readPending(stateDir).filter((s) => s.actioned !== true).length;
+}
+
+export type EnqueueResult =
+  | { ok: true; suggestion: PendingSuggestion }
+  | { ok: false; reason: "cap-reached"; outstanding: number; cap: number };
+
+/**
+ * Append a suggestion, enforcing the outstanding cap. Returns the stored
+ * record (with id + timestamp) or a cap-reached refusal so the caller
+ * can degrade gracefully (the gate logs "queue full, not queueing"
+ * rather than dropping silently).
+ */
+export function enqueuePending(
+  stateDir: string,
+  input: Omit<PendingSuggestion, "id" | "created_at" | "actioned">,
+  opts: { now?: () => number; cap?: number } = {},
+): EnqueueResult {
+  const cfg = resolveSelfImproveConfig();
+  const cap = opts.cap ?? cfg.maxOutstandingPending;
+  const now = opts.now ?? Date.now;
+
+  ensureDir(stateDir);
+
+  const outstanding = outstandingCount(stateDir);
+  if (outstanding >= cap) {
+    return { ok: false, reason: "cap-reached", outstanding, cap };
+  }
+
+  const suggestion: PendingSuggestion = {
+    id: randomUUID(),
+    created_at: new Date(now()).toISOString(),
+    ...input,
+  };
+
+  // Atomic single-line append via O_APPEND. One writev of a complete
+  // line is atomic for PIPE_BUF-sized writes on local fs; a suggestion
+  // line is well under that, and even a torn append only corrupts its
+  // own line (readPending skips malformed lines).
+  const fd = openSync(pendingPath(stateDir), "a");
+  try {
+    writeSync(fd, JSON.stringify(suggestion) + "\n");
+  } finally {
+    closeSync(fd);
+  }
+  return { ok: true, suggestion };
+}
+
+function ensureDir(stateDir: string): void {
+  if (!existsSync(stateDir)) {
+    mkdirSync(stateDir, { recursive: true, mode: 0o755 });
+  }
+}

--- a/src/self-improve/rate-limit.ts
+++ b/src/self-improve/rate-limit.ts
@@ -1,0 +1,84 @@
+/**
+ * Agent self-improvement — T1 auto-apply rate limit (RFC: ≤3
+ * auto-applies/day). A tiny per-agent counter file under the state dir,
+ * keyed by UTC day. Distinct from the validator-hook/git audit (which is
+ * the change-content audit/rollback) — this is purely the
+ * how-many-today budget so a runaway can't churn the skill dir.
+ *
+ *   <stateDir>/self-improve-applies.jsonl — one line per auto-apply,
+ *   {ts, day} — append-only; the day-bucket count is derived on read.
+ */
+
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  writeSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { resolveSelfImproveConfig } from "./config.js";
+
+export const APPLIES_FILE = "self-improve-applies.jsonl";
+
+interface ApplyRecord {
+  ts: number;
+  day: string; // YYYY-MM-DD (UTC)
+}
+
+function appliesPath(stateDir: string): string {
+  return join(stateDir, APPLIES_FILE);
+}
+
+function utcDay(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+/** Count auto-applies recorded for the given UTC day. */
+export function appliesToday(stateDir: string, now: () => number = Date.now): number {
+  const p = appliesPath(stateDir);
+  if (!existsSync(p)) return 0;
+  let raw: string;
+  try {
+    raw = readFileSync(p, "utf-8");
+  } catch {
+    return 0;
+  }
+  const today = utcDay(now());
+  let count = 0;
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const rec = JSON.parse(line) as ApplyRecord;
+      if (rec.day === today) count += 1;
+    } catch {
+      /* skip */
+    }
+  }
+  return count;
+}
+
+/** True iff another T1 auto-apply is within today's budget. */
+export function canAutoApply(
+  stateDir: string,
+  now: () => number = Date.now,
+  cap = resolveSelfImproveConfig().maxAutoAppliesPerDay,
+): boolean {
+  return appliesToday(stateDir, now) < cap;
+}
+
+/** Record one auto-apply. Call only AFTER an edit actually lands. */
+export function recordAutoApply(stateDir: string, now: () => number = Date.now): void {
+  if (!existsSync(stateDir)) {
+    mkdirSync(stateDir, { recursive: true, mode: 0o755 });
+  }
+  const ms = now();
+  const fd = openSync(appliesPath(stateDir), "a");
+  try {
+    writeSync(fd, JSON.stringify({ ts: ms, day: utcDay(ms) } as ApplyRecord) + "\n");
+  } finally {
+    closeSync(fd);
+  }
+}

--- a/src/self-improve/review-prompt.ts
+++ b/src/self-improve/review-prompt.ts
@@ -1,0 +1,88 @@
+/**
+ * Agent self-improvement — the forked-review PROMPT (RFC §"Run the review
+ * forked, async, restricted toolset").
+ *
+ * Constraint (CLAUDE.md "claude-native, subscription-funded"): the review
+ * is a model call, so it MUST go through the interactive session as a
+ * synthesized turn (`inject_inbound`) — NOT a new `claude -p` spawn. The
+ * gate (a Stop hook) therefore does not call the model itself; it builds
+ * this prompt and injects it as an inbound, the same primitive cron uses.
+ * The injected turn runs forked/async, off the operator's reply path.
+ *
+ * The prompt:
+ *   - States the toolset restriction (memory + skill read/write only) so
+ *     the review stays in its lane.
+ *   - Hands the review the detected signals (the gate's evidence).
+ *   - Tells it the EXACT contract: diagnose the lesson, the smallest
+ *     binding change, the blast-radius tier; for T1 run the per-skill
+ *     eval gate before landing; T2/T3 → queue a pending suggestion, do
+ *     NOT apply.
+ *
+ * The synthesized inbound carries `meta.source = "self_improve_review"`
+ * so the gateway / audit can distinguish it (mirrors cron's
+ * `meta.source` convention).
+ */
+
+import type { LearningSignal } from "./types.js";
+import { resolveSelfImproveConfig } from "./config.js";
+
+/** The `meta.source` stamped on the synthesized review inbound. */
+export const REVIEW_SOURCE = "self_improve_review";
+
+/**
+ * Build the review prompt text. `signals` is the gate's output; the
+ * prompt is bounded (signals are already capped by the gate).
+ */
+export function buildReviewPrompt(signals: LearningSignal[]): string {
+  const cfg = resolveSelfImproveConfig();
+  const lines: string[] = [];
+
+  lines.push(
+    "[self-improvement review] The turn-end gate detected a learning " +
+      "signal — a correction or pattern that should bind on future runs. " +
+      "Run a focused, forked review. Use ONLY memory tools (recall/retain/" +
+      "directives) and skill read/write tools (Read/Write/Edit under your " +
+      "own .claude/skills/, skill_* / skill-personal). Do NOT touch " +
+      "anything else, do NOT reply to the operator, and end the turn when " +
+      "done.",
+  );
+  lines.push("");
+  lines.push("Signals detected this turn:");
+  for (const s of signals) {
+    lines.push(`  - [${s.kind}] ${s.reason}`);
+    if (s.evidence) lines.push(`      evidence: ${s.evidence}`);
+  }
+  lines.push("");
+  lines.push("Diagnose and act, strictly within these rules:");
+  lines.push(
+    "  1. State the lesson in one line and the SMALLEST change that makes " +
+      "it bind (prefer the strongest deterministic layer: a skill edit " +
+      "over a Hindsight directive).",
+  );
+  lines.push(
+    `  2. Classify the change's blast radius. T1 = a small (<= ${cfg.t1MaxChangedLines} ` +
+      "changed lines, single file) reversible edit to a skill you ALREADY " +
+      "own. Anything medium / shared / new-cron / new-skill / cross-agent " +
+      "/ irreversible is T2 or T3.",
+  );
+  lines.push(
+    "  3. For a T1: BEFORE editing, confirm the skill has evals/evals.json " +
+      "and that your edit passes them without regressing baseline (the " +
+      "skill-creator grader + aggregate_benchmark.py). Land the edit via " +
+      "the native skill-write path (Write/Edit) only if the evals pass. " +
+      "If the skill has no evals.json, do NOT auto-apply — treat it as T2.",
+  );
+  lines.push(
+    "  4. For T2/T3: do NOT apply anything. Record a one-line pending " +
+      "suggestion (the operator actions it later). Never auto-create a " +
+      "cron or a new skill, never edit a shared/other-agent skill.",
+  );
+  lines.push("");
+  lines.push(
+    `Rate limits in effect: <= ${cfg.maxAutoAppliesPerDay} auto-applies/day, ` +
+      `<= ${cfg.maxOutstandingPending} outstanding pending suggestions. If a ` +
+      "limit is reached, stop and leave a note rather than forcing the change.",
+  );
+
+  return lines.join("\n");
+}

--- a/src/self-improve/tier-router.ts
+++ b/src/self-improve/tier-router.ts
@@ -1,0 +1,100 @@
+/**
+ * Agent self-improvement — the TIER router (RFC §"Solution Space",
+ * graduated autonomy). Classifies a candidate change by blast radius:
+ *
+ *   T1 — small, reversible edit to a skill the agent ALREADY owns
+ *        (single file, ≤ diff cap). Auto-applied (after the eval gate),
+ *        silently and reversibly, via the native skill-write path.
+ *   T2 — medium / shared-skill change. PROPOSE (one-tap), never
+ *        auto-apply in slice 1.
+ *   T3 — new cron, new skill, cross-agent, or irreversible. ASK
+ *        explicitly. Also queued as a pending suggestion in slice 1.
+ *   T0 — nothing actionable.
+ *
+ * The router is the on-leash guarantee in code: ANY of {new cron, new
+ * skill, cross-agent, irreversible} forces T3 — no path lets those
+ * auto-apply. This mirrors the `no-self-escalation` / `on-leash`
+ * invariants the job spec names as its kill-clause.
+ */
+
+import type { ChangeCandidate, Tier } from "./types.js";
+import { resolveSelfImproveConfig, type SelfImproveConfig } from "./config.js";
+
+export interface TierDecision {
+  tier: Tier;
+  /** Human-readable rationale (operator-facing + audit). */
+  reason: string;
+}
+
+/**
+ * Classify a candidate change. Pure function of the candidate + config.
+ *
+ * Decision order is deliberate — the most-restrictive gate wins:
+ *   1. Irreversible / cross-agent / new-cron / new-skill → T3 (hard).
+ *   2. No skill target, or a skill the agent does NOT own → T2 (propose).
+ *   3. Multi-file or over the diff cap → T2 (too big to auto-apply).
+ *   4. Otherwise → T1 (small, reversible, owned, single-file).
+ */
+export function classifyTier(
+  candidate: ChangeCandidate,
+  cfg: SelfImproveConfig = resolveSelfImproveConfig(),
+): TierDecision {
+  // (0) Nothing to do.
+  if (!candidate.proposedChange || candidate.proposedChange.trim() === "") {
+    return { tier: "T0", reason: "no actionable change proposed" };
+  }
+
+  // (1) Hard T3 — the on-leash floor. Never auto-applied.
+  if (candidate.irreversible) {
+    return { tier: "T3", reason: "irreversible change — operator must decide" };
+  }
+  if (candidate.crossAgent) {
+    return {
+      tier: "T3",
+      reason: "cross-agent change — operator must decide (no self-escalation)",
+    };
+  }
+  if (candidate.touchesCron) {
+    return {
+      tier: "T3",
+      reason: "creates/edits a cron — never self-served (on-leash)",
+    };
+  }
+  if (candidate.createsNewSkill) {
+    return {
+      tier: "T3",
+      reason: "creates a new skill — proposed, never auto-created",
+    };
+  }
+
+  // (2) No owned-skill target → can't be a silent own-skill edit.
+  if (!candidate.skillSlug || candidate.ownsSkill !== true) {
+    return {
+      tier: "T2",
+      reason: candidate.skillSlug
+        ? `targets skill "${candidate.skillSlug}" the agent does not own — propose, don't auto-apply`
+        : "no own-skill target — surface as a one-tap suggestion",
+    };
+  }
+
+  // (3) Too big to auto-apply silently.
+  if (candidate.multiFile === true) {
+    return {
+      tier: "T2",
+      reason: "touches more than one skill file — over the T1 single-file bound",
+    };
+  }
+  const lines = candidate.changedLines ?? 0;
+  if (lines > cfg.t1MaxChangedLines) {
+    return {
+      tier: "T2",
+      reason: `${lines} changed lines exceeds the T1 cap of ${cfg.t1MaxChangedLines}`,
+    };
+  }
+
+  // (4) Small, reversible, owned, single-file → T1.
+  return {
+    tier: "T1",
+    reason: `small (${lines} line${lines === 1 ? "" : "s"}) reversible edit to owned skill "${candidate.skillSlug}"`,
+  };
+}

--- a/src/self-improve/types.ts
+++ b/src/self-improve/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Agent self-improvement — shared types (RFC
+ * `reference/rfcs/agent-self-improvement.md`, slice 1).
+ *
+ * The job (`reference/jobs/get-better-the-longer-they-run.md`): when an
+ * agent is corrected, or finds a path it will reuse, that lesson should
+ * bind on every future run without re-teaching — and without the agent
+ * manufacturing skills/crons. Slice 1 builds the foundational vertical:
+ * a cheap deterministic GATE on the turn-end Stop hook, a forked review
+ * (routed through `inject_inbound`, not `claude -p`), a blast-radius
+ * TIER router, an eval gate on T1, and a per-agent pending-suggestions
+ * queue for everything heavier.
+ *
+ * These are pure, dependency-light types so the gate / router / queue /
+ * eval-gate modules stay unit-testable without the gateway, the broker,
+ * or a live `claude` process.
+ */
+
+/** A normalised conversation message, shape-compatible with the Claude
+ *  Code transcript (`{role, content}`) the Stop hook reads. `content`
+ *  is the flattened text — the gate works on text, not tool payloads. */
+export interface TurnMessage {
+  role: "user" | "assistant" | string;
+  /** Flattened text of the message (list-content shapes are joined). */
+  text: string;
+}
+
+/** The kinds of deterministic learning signal the gate detects. */
+export type LearningSignalKind =
+  /** Operator said "no / wrong / that's not it / I told you …". */
+  | "operator-correction"
+  /** The same manual fix (e.g. an identical Edit) recurred. */
+  | "repeated-manual-fix"
+  /** A standing directive ("always do X") the agent did not honour. */
+  | "directive-not-bound";
+
+/** One detected signal with the evidence that tripped it. */
+export interface LearningSignal {
+  kind: LearningSignalKind;
+  /** Short human-readable reason (goes into the forked-review prompt). */
+  reason: string;
+  /** How many occurrences were counted (≥ threshold when it trips). */
+  occurrences: number;
+  /** A short verbatim excerpt of the triggering text (capped). */
+  evidence: string;
+}
+
+/** Result of running the gate over a finished turn. */
+export interface GateResult {
+  /** True iff at least one signal crossed the repetition threshold. */
+  tripped: boolean;
+  /** Every signal at/above threshold (empty when not tripped). */
+  signals: LearningSignal[];
+}
+
+/** Blast-radius tier for a candidate self-improvement change. */
+export type Tier =
+  /** Nothing to do (most turns). */
+  | "T0"
+  /** Small, reversible edit to a skill the agent already owns → auto. */
+  | "T1"
+  /** Medium / shared-skill → propose (one-tap), do not auto-apply. */
+  | "T2"
+  /** New cron / new skill / cross-agent / irreversible → ask explicitly. */
+  | "T3";
+
+/**
+ * A candidate change the forked review proposes. The router consumes
+ * this to assign a tier; the eval gate consumes it before a T1 lands.
+ */
+export interface ChangeCandidate {
+  /** The lesson, in one line (operator-readable). */
+  lesson: string;
+  /** The smallest change that makes the lesson bind. */
+  proposedChange: string;
+  /** Target skill slug, when the change edits a skill the agent owns. */
+  skillSlug?: string;
+  /** True iff `skillSlug` names a skill in the agent's OWN writable dir. */
+  ownsSkill?: boolean;
+  /** Estimated changed-line count for the edit (single skill file). */
+  changedLines?: number;
+  /** True iff the change touches more than one skill file. */
+  multiFile?: boolean;
+  /** True iff the change creates a NEW skill (vs editing an existing one). */
+  createsNewSkill?: boolean;
+  /** True iff the change creates / edits a cron schedule. */
+  touchesCron?: boolean;
+  /** True iff the change reaches another agent. */
+  crossAgent?: boolean;
+  /** True iff the change is not cleanly reversible (git/validator can't undo). */
+  irreversible?: boolean;
+}

--- a/tests/reconcile-hooks-drift.test.ts
+++ b/tests/reconcile-hooks-drift.test.ts
@@ -53,6 +53,38 @@ describe("buildSettingsHooksBlock", () => {
     expect(stopCmds.some((c) => c.includes("user-profile-refresh-hook.sh"))).toBe(false);
   });
 
+  it("wires the agent self-improvement Stop gate when the telegram plugin is on", () => {
+    // RFC reference/rfcs/agent-self-improvement.md slice 1: the turn-end
+    // gate attaches as a switchroom-owned async Stop hook, alongside
+    // handoff / secret-scrub / tool-label. Gated on useSwitchroomPlugin
+    // because it needs the gateway socket to inject the forked review.
+    const withPlugin = buildSettingsHooksBlock({
+      agentName: "test-agent",
+      agentConfig: makeAgentConfig(),
+      hindsightEnabled: false,
+      useSwitchroomPlugin: true,
+    });
+    const stopWith = (withPlugin.Stop ?? []) as Array<{
+      hooks: Array<{ command: string; async?: boolean }>;
+    }>;
+    const selfImprove = stopWith
+      .flatMap((e) => e.hooks)
+      .find((h) => h.command.includes("self-improve-stop.mjs"));
+    expect(selfImprove).toBeDefined();
+    expect(selfImprove?.async).toBe(true);
+
+    // Without the plugin, no gateway socket → the gate is not wired.
+    const noPlugin = buildSettingsHooksBlock({
+      agentName: "test-agent",
+      agentConfig: makeAgentConfig(),
+      hindsightEnabled: false,
+      useSwitchroomPlugin: false,
+    });
+    const stopNo = (noPlugin.Stop ?? []) as Array<{ hooks: Array<{ command: string }> }>;
+    const stopNoCmds = stopNo.flatMap((e) => e.hooks.map((h) => h.command));
+    expect(stopNoCmds.some((c) => c.includes("self-improve-stop.mjs"))).toBe(false);
+  });
+
   it("with telegram plugin adds PreToolUse and PostToolUse hooks", () => {
     const agentConfig = makeAgentConfig({
       plugin: "switchroom-telegram",

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2543,6 +2543,12 @@ describe("scaffoldAgent with global defaults cascade", () => {
             timeout: 5,
             async: true,
           },
+          {
+            type: "command",
+            command: expect.stringContaining("self-improve-stop.mjs"),
+            timeout: 10,
+            async: true,
+          },
         ],
       },
     ]);

--- a/tests/self-improve-eval-gate.test.ts
+++ b/tests/self-improve-eval-gate.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  skillHasEvals,
+  evalsJsonPath,
+  evalVerdict,
+  aggregateBenchmark,
+} from "../src/self-improve/eval-gate.js";
+
+const cfg = {
+  repetitionThreshold: 2,
+  t1MaxChangedLines: 30,
+  maxAutoAppliesPerDay: 3,
+  maxOutstandingPending: 5,
+};
+
+const pythonOk = spawnSync("python3", ["--version"], { encoding: "utf-8" }).status === 0;
+const repoRoot = process.cwd();
+
+let tmp: string;
+beforeAll(() => {
+  tmp = mkdtempSync(join(tmpdir(), "self-improve-eval-"));
+});
+afterAll(() => {
+  if (tmp && existsSync(tmp)) rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeBenchmark(name: string, body: unknown): string {
+  const p = join(tmp, name);
+  writeFileSync(p, JSON.stringify(body));
+  return p;
+}
+
+describe("eval-gate — skillHasEvals precondition (no evals → T1 must downgrade)", () => {
+  it("is false when evals/evals.json is absent", () => {
+    const skillDir = join(tmp, "no-evals-skill");
+    mkdirSync(skillDir, { recursive: true });
+    expect(skillHasEvals(skillDir)).toBe(false);
+  });
+
+  it("is false when evals.json has an empty evals array", () => {
+    const skillDir = join(tmp, "empty-evals-skill");
+    mkdirSync(join(skillDir, "evals"), { recursive: true });
+    writeFileSync(evalsJsonPath(skillDir), JSON.stringify({ skill_name: "x", evals: [] }));
+    expect(skillHasEvals(skillDir)).toBe(false);
+  });
+
+  it("is true when evals.json has at least one eval", () => {
+    const skillDir = join(tmp, "has-evals-skill");
+    mkdirSync(join(skillDir, "evals"), { recursive: true });
+    writeFileSync(
+      evalsJsonPath(skillDir),
+      JSON.stringify({ skill_name: "x", evals: [{ id: 1, prompt: "do x", expectations: ["x"] }] }),
+    );
+    expect(skillHasEvals(skillDir)).toBe(true);
+  });
+});
+
+describe("eval-gate — verdict from benchmark.json", () => {
+  it("PASSES when candidate scores 1.0 and meets/beats baseline", () => {
+    const p = writeBenchmark("pass.json", {
+      run_summary: {
+        with_skill: { pass_rate: { mean: 1.0, stddev: 0.0 } },
+        without_skill: { pass_rate: { mean: 0.6, stddev: 0.1 } },
+      },
+    });
+    const v = evalVerdict(p, cfg);
+    expect(v.pass).toBe(true);
+  });
+
+  it("BLOCKS a regression: candidate below baseline", () => {
+    const p = writeBenchmark("regress.json", {
+      run_summary: {
+        with_skill: { pass_rate: { mean: 0.7, stddev: 0.05 } },
+        without_skill: { pass_rate: { mean: 0.9, stddev: 0.05 } },
+      },
+    });
+    const v = evalVerdict(p, cfg);
+    expect(v.pass).toBe(false);
+    if (!v.pass) {
+      // either floor or regression; with floor=1.0 default it's the floor,
+      // but the candidate is also < baseline — both are correct blocks.
+      expect(v.reason).toMatch(/regression|floor/);
+    }
+  });
+
+  it("BLOCKS when candidate is below the absolute pass floor", () => {
+    const p = writeBenchmark("floor.json", {
+      run_summary: {
+        with_skill: { pass_rate: { mean: 0.8, stddev: 0.0 } },
+        // No baseline config → floor alone decides.
+      },
+    });
+    const v = evalVerdict(p, cfg);
+    expect(v.pass).toBe(false);
+    if (!v.pass) expect(v.reason).toContain("floor");
+  });
+
+  it("BLOCKS when there is no candidate pass-rate at all", () => {
+    const p = writeBenchmark("nobody.json", { run_summary: {} });
+    const v = evalVerdict(p, cfg);
+    expect(v.pass).toBe(false);
+  });
+
+  it("BLOCKS on an unreadable benchmark.json (fail-closed for the apply gate)", () => {
+    const v = evalVerdict(join(tmp, "does-not-exist.json"), cfg);
+    expect(v.pass).toBe(false);
+  });
+});
+
+describe("eval-gate — reuses the real aggregate_benchmark.py", () => {
+  it("aggregates grading.json files and the verdict blocks a regressing edit", () => {
+    if (!pythonOk) return; // python3 absent — skip the harness integration leg.
+
+    // Build the workspace layout aggregate_benchmark.py expects:
+    //   <bench>/eval-1/with_skill/run-1/grading.json   (regressed)
+    //   <bench>/eval-1/without_skill/run-1/grading.json (baseline higher)
+    const bench = join(tmp, "bench-regress");
+    const mk = (config: string, passRate: number, passed: number, total: number) => {
+      const dir = join(bench, "eval-1", config, "run-1");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "grading.json"),
+        JSON.stringify({
+          expectations: [],
+          summary: { passed, failed: total - passed, total, pass_rate: passRate },
+        }),
+      );
+    };
+    // Candidate ("with_skill") regresses vs baseline ("without_skill").
+    mk("with_skill", 0.5, 1, 2);
+    mk("without_skill", 1.0, 2, 2);
+
+    const agg = aggregateBenchmark(bench, repoRoot);
+    expect(agg.ok).toBe(true);
+    expect(agg.benchmarkJson).toBeDefined();
+
+    const v = evalVerdict(agg.benchmarkJson!, cfg);
+    expect(v.pass).toBe(false); // the eval gate blocks the regressing edit
+  });
+
+  it("aggregates a passing, non-regressing edit to a PASS verdict", () => {
+    if (!pythonOk) return;
+
+    const bench = join(tmp, "bench-pass");
+    const mk = (config: string, passRate: number) => {
+      const dir = join(bench, "eval-1", config, "run-1");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "grading.json"),
+        JSON.stringify({
+          expectations: [],
+          summary: { passed: passRate === 1 ? 2 : 1, failed: passRate === 1 ? 0 : 1, total: 2, pass_rate: passRate },
+        }),
+      );
+    };
+    mk("with_skill", 1.0);
+    mk("without_skill", 0.5);
+
+    const agg = aggregateBenchmark(bench, repoRoot);
+    expect(agg.ok).toBe(true);
+    const v = evalVerdict(agg.benchmarkJson!, cfg);
+    expect(v.pass).toBe(true);
+  });
+});

--- a/tests/self-improve-gate.test.ts
+++ b/tests/self-improve-gate.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+
+import { runGate } from "../src/self-improve/gate.js";
+import type { TurnMessage } from "../src/self-improve/types.js";
+
+const cfg = { repetitionThreshold: 2, t1MaxChangedLines: 30, maxAutoAppliesPerDay: 3, maxOutstandingPending: 5 };
+
+function user(text: string): TurnMessage {
+  return { role: "user", text };
+}
+function assistant(text: string): TurnMessage {
+  return { role: "assistant", text };
+}
+
+describe("self-improve gate — cost guarantee (no signal → no trip)", () => {
+  it("returns tripped:false on an empty transcript", () => {
+    const r = runGate([], cfg);
+    expect(r.tripped).toBe(false);
+    expect(r.signals).toEqual([]);
+  });
+
+  it("does NOT fire on a clean, productive turn", () => {
+    const r = runGate(
+      [
+        user("Can you summarise the latest deploy logs?"),
+        assistant("Sure. Read(/var/log/deploy.log) — here's the summary: all green."),
+        user("Great, thanks!"),
+      ],
+      cfg,
+    );
+    expect(r.tripped).toBe(false);
+    expect(r.signals).toEqual([]);
+  });
+
+  it("does NOT fire on a SINGLE correction (correct-once: 2nd occurrence trips)", () => {
+    const r = runGate(
+      [
+        user("Format the date as ISO."),
+        assistant("Done."),
+        user("No, that's wrong — I wanted DD/MM."),
+      ],
+      cfg,
+    );
+    // One correction < threshold of 2.
+    expect(r.tripped).toBe(false);
+  });
+
+  it("does NOT fire on a single non-repeated directive", () => {
+    const r = runGate(
+      [user("Always use British spelling going forward."), assistant("Understood.")],
+      cfg,
+    );
+    expect(r.tripped).toBe(false);
+  });
+});
+
+describe("self-improve gate — fires on a real learning signal", () => {
+  it("trips operator-correction on the SECOND correction", () => {
+    const r = runGate(
+      [
+        user("Send the digest."),
+        assistant("Sent."),
+        user("No, that's wrong — you included drafts again."),
+        assistant("Fixed."),
+        user("That's not what I asked, I told you to exclude drafts."),
+      ],
+      cfg,
+    );
+    expect(r.tripped).toBe(true);
+    const kinds = r.signals.map((s) => s.kind);
+    expect(kinds).toContain("operator-correction");
+    const sig = r.signals.find((s) => s.kind === "operator-correction")!;
+    expect(sig.occurrences).toBeGreaterThanOrEqual(2);
+    expect(sig.evidence.length).toBeGreaterThan(0);
+  });
+
+  it("trips directive-not-bound when the SAME rule is restated", () => {
+    const r = runGate(
+      [
+        user("Always dedupe the email recipients before sending."),
+        assistant("Will do."),
+        user("You sent dupes — remember to always dedupe the recipients before sending."),
+      ],
+      cfg,
+    );
+    expect(r.tripped).toBe(true);
+    expect(r.signals.map((s) => s.kind)).toContain("directive-not-bound");
+  });
+
+  it("trips repeated-manual-fix on an identical Edit fingerprint", () => {
+    const r = runGate(
+      [
+        user("Fix the config."),
+        assistant("Edit(/etc/app/config.yaml) — patched the timeout."),
+        user("It broke again."),
+        assistant("Edit(/etc/app/config.yaml) — patched the timeout once more."),
+      ],
+      cfg,
+    );
+    expect(r.tripped).toBe(true);
+    expect(r.signals.map((s) => s.kind)).toContain("repeated-manual-fix");
+  });
+
+  it("does NOT trip repeated-manual-fix for DIFFERENT files edited once each", () => {
+    const r = runGate(
+      [
+        assistant("Edit(/a.txt) — change A."),
+        assistant("Edit(/b.txt) — change B."),
+      ],
+      cfg,
+    );
+    expect(r.tripped).toBe(false);
+  });
+
+  it("honours a higher threshold (3) without tripping at 2", () => {
+    const cfg3 = { ...cfg, repetitionThreshold: 3 };
+    const two = runGate(
+      [user("No, that's wrong."), user("No, that's wrong again.")],
+      cfg3,
+    );
+    expect(two.tripped).toBe(false);
+    const three = runGate(
+      [
+        user("No, that's wrong."),
+        user("No, that's wrong again."),
+        user("No, that's incorrect a third time."),
+      ],
+      cfg3,
+    );
+    expect(three.tripped).toBe(true);
+  });
+});

--- a/tests/self-improve-pending-queue.test.ts
+++ b/tests/self-improve-pending-queue.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  enqueuePending,
+  readPending,
+  outstandingCount,
+} from "../src/self-improve/pending-queue.js";
+
+let stateDir: string;
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "self-improve-pending-"));
+});
+afterEach(() => {
+  if (stateDir && existsSync(stateDir)) rmSync(stateDir, { recursive: true, force: true });
+});
+
+const base = {
+  tier: "T2" as const,
+  lesson: "exclude drafts",
+  proposed_change: "add a draft filter",
+  tier_reason: "no own-skill target",
+  triggered_by: ["operator-correction"],
+};
+
+describe("pending-suggestions queue", () => {
+  it("starts empty", () => {
+    expect(readPending(stateDir)).toEqual([]);
+    expect(outstandingCount(stateDir)).toBe(0);
+  });
+
+  it("appends a suggestion with id + timestamp", () => {
+    const r = enqueuePending(stateDir, base, { now: () => 1_700_000_000_000 });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.suggestion.id).toMatch(/[0-9a-f-]{36}/);
+      expect(r.suggestion.created_at).toBe(new Date(1_700_000_000_000).toISOString());
+      expect(r.suggestion.tier).toBe("T2");
+    }
+    const all = readPending(stateDir);
+    expect(all.length).toBe(1);
+    expect(outstandingCount(stateDir)).toBe(1);
+  });
+
+  it("persists multiple suggestions as JSON lines", () => {
+    enqueuePending(stateDir, base);
+    enqueuePending(stateDir, { ...base, tier: "T3", lesson: "new cron asked" });
+    const all = readPending(stateDir);
+    expect(all.length).toBe(2);
+    expect(all.map((s) => s.tier).sort()).toEqual(["T2", "T3"]);
+  });
+
+  it("enforces the outstanding cap (default 5) and refuses gracefully", () => {
+    for (let i = 0; i < 5; i++) {
+      const r = enqueuePending(stateDir, { ...base, lesson: `lesson ${i}` }, { cap: 5 });
+      expect(r.ok).toBe(true);
+    }
+    const refused = enqueuePending(stateDir, { ...base, lesson: "one too many" }, { cap: 5 });
+    expect(refused.ok).toBe(false);
+    if (!refused.ok) {
+      expect(refused.reason).toBe("cap-reached");
+      expect(refused.outstanding).toBe(5);
+      expect(refused.cap).toBe(5);
+    }
+    // Nothing extra was written.
+    expect(readPending(stateDir).length).toBe(5);
+  });
+
+  it("tolerates a malformed line without losing valid entries", () => {
+    const r = enqueuePending(stateDir, base);
+    expect(r.ok).toBe(true);
+    // Hand-corrupt by appending junk.
+    const fs = require("node:fs") as typeof import("node:fs");
+    fs.appendFileSync(join(stateDir, "self-improve-pending.jsonl"), "{not json\n");
+    expect(readPending(stateDir).length).toBe(1);
+  });
+});

--- a/tests/self-improve-rate-limit.test.ts
+++ b/tests/self-improve-rate-limit.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  appliesToday,
+  canAutoApply,
+  recordAutoApply,
+} from "../src/self-improve/rate-limit.js";
+
+let stateDir: string;
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "self-improve-rl-"));
+});
+afterEach(() => {
+  if (stateDir && existsSync(stateDir)) rmSync(stateDir, { recursive: true, force: true });
+});
+
+const DAY1 = Date.parse("2026-06-20T09:00:00Z");
+const DAY1_LATER = Date.parse("2026-06-20T23:00:00Z");
+const DAY2 = Date.parse("2026-06-21T01:00:00Z");
+
+describe("T1 auto-apply rate limit (<=3/day)", () => {
+  it("starts at zero and allows applying", () => {
+    expect(appliesToday(stateDir, () => DAY1)).toBe(0);
+    expect(canAutoApply(stateDir, () => DAY1, 3)).toBe(true);
+  });
+
+  it("counts applies within the same UTC day and blocks at the cap", () => {
+    recordAutoApply(stateDir, () => DAY1);
+    recordAutoApply(stateDir, () => DAY1);
+    recordAutoApply(stateDir, () => DAY1_LATER);
+    expect(appliesToday(stateDir, () => DAY1)).toBe(3);
+    expect(canAutoApply(stateDir, () => DAY1, 3)).toBe(false);
+  });
+
+  it("resets across a UTC day boundary", () => {
+    recordAutoApply(stateDir, () => DAY1);
+    recordAutoApply(stateDir, () => DAY1);
+    recordAutoApply(stateDir, () => DAY1);
+    expect(canAutoApply(stateDir, () => DAY1, 3)).toBe(false);
+    // Next day: budget restored.
+    expect(appliesToday(stateDir, () => DAY2)).toBe(0);
+    expect(canAutoApply(stateDir, () => DAY2, 3)).toBe(true);
+  });
+});

--- a/tests/self-improve-review-prompt.test.ts
+++ b/tests/self-improve-review-prompt.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+
+import { buildReviewPrompt, REVIEW_SOURCE } from "../src/self-improve/review-prompt.js";
+import type { LearningSignal } from "../src/self-improve/types.js";
+
+const signals: LearningSignal[] = [
+  {
+    kind: "operator-correction",
+    reason: "Operator pushed back 2x this turn",
+    occurrences: 2,
+    evidence: "no, that's wrong — exclude drafts",
+  },
+];
+
+describe("forked-review prompt", () => {
+  it("names the source discriminator", () => {
+    expect(REVIEW_SOURCE).toBe("self_improve_review");
+  });
+
+  it("restricts the toolset and forbids replying", () => {
+    const p = buildReviewPrompt(signals);
+    expect(p).toContain("[self-improvement review]");
+    expect(p.toLowerCase()).toContain("only memory tools");
+    expect(p.toLowerCase()).toContain("skill");
+    expect(p.toLowerCase()).toContain("do not reply");
+  });
+
+  it("carries the detected signals and the tier contract", () => {
+    const p = buildReviewPrompt(signals);
+    expect(p).toContain("operator-correction");
+    expect(p).toContain("T1");
+    expect(p).toContain("T2");
+    expect(p).toContain("T3");
+    // Eval gate is part of the contract handed to the review.
+    expect(p).toContain("evals.json");
+  });
+
+  it("states that new crons / new skills are never self-served", () => {
+    const p = buildReviewPrompt(signals);
+    expect(p.toLowerCase()).toContain("never auto-create");
+  });
+});

--- a/tests/self-improve-stop-hook.test.ts
+++ b/tests/self-improve-stop-hook.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import { createServer, type Server } from "node:net";
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Drive the hook through `bun` against source (mirrors
+// tests/skill-validate-pretool.test.ts) so the test doesn't depend on
+// build order. Skip cleanly if bun is absent.
+const bunOk = spawnSync("which", ["bun"], { encoding: "utf-8" }).status === 0;
+const HOOK = join(process.cwd(), "src", "cli", "self-improve-stop.ts");
+
+let tmp: string;
+beforeAll(() => {
+  tmp = mkdtempSync(join(tmpdir(), "self-improve-stop-"));
+});
+afterAll(() => {
+  if (tmp && existsSync(tmp)) rmSync(tmp, { recursive: true, force: true });
+});
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function run(stdin: string, env: Record<string, string> = {}): RunResult {
+  const r = spawnSync("bun", [HOOK], {
+    input: stdin,
+    encoding: "utf-8",
+    timeout: 30000,
+    env: { ...process.env, ...env },
+  });
+  return {
+    status: r.status ?? 1,
+    stdout: (r.stdout ?? "").trim(),
+    stderr: r.stderr ?? "",
+  };
+}
+
+/** Write a Claude-Code-shaped JSONL transcript and return its path. */
+function writeTranscript(name: string, msgs: Array<{ role: string; text: string }>): string {
+  const p = join(tmp, name);
+  const lines = msgs.map((m) =>
+    JSON.stringify({ type: m.role, message: { role: m.role, content: m.text } }),
+  );
+  writeFileSync(p, lines.join("\n") + "\n");
+  return p;
+}
+
+describe("self-improve-stop hook — fail-open + cost guarantee", () => {
+  it("exits 0 silently on empty / non-JSON stdin", () => {
+    if (!bunOk) return;
+    for (const bad of ["", "not-json"]) {
+      const r = run(bad);
+      expect(r.status).toBe(0);
+      expect(r.stdout).toBe("");
+    }
+  });
+
+  it("exits 0 with no socket activity on a CLEAN turn (no signal)", () => {
+    if (!bunOk) return;
+    const tp = writeTranscript("clean.jsonl", [
+      { role: "user", text: "Summarise the logs." },
+      { role: "assistant", text: "Done — all green." },
+      { role: "user", text: "Thanks!" },
+    ]);
+    const r = run(JSON.stringify({ session_id: "s1", transcript_path: tp }), {
+      SWITCHROOM_AGENT_NAME: "test-agent",
+      SWITCHROOM_GATEWAY_SOCKET: join(tmp, "nonexistent.sock"),
+    });
+    expect(r.status).toBe(0);
+  });
+
+  it("respects the opt-out kill switch (SWITCHROOM_SELF_IMPROVE=0)", () => {
+    if (!bunOk) return;
+    const tp = writeTranscript("disabled.jsonl", [
+      { role: "user", text: "No, that's wrong." },
+      { role: "user", text: "That's not what I asked, I told you." },
+    ]);
+    const r = run(JSON.stringify({ session_id: "s2", transcript_path: tp }), {
+      SWITCHROOM_SELF_IMPROVE: "0",
+      SWITCHROOM_AGENT_NAME: "test-agent",
+      SWITCHROOM_GATEWAY_SOCKET: join(tmp, "nonexistent.sock"),
+    });
+    expect(r.status).toBe(0);
+  });
+});
+
+describe("self-improve-stop hook — fires the forked review on a real signal", () => {
+  it("connects to the gateway socket and injects a self_improve_review inbound", async () => {
+    if (!bunOk) return;
+
+    const socketPath = join(tmp, "gw.sock");
+    const received: string[] = [];
+    const server: Server = await new Promise((resolve) => {
+      const s = createServer((conn) => {
+        conn.on("data", (d) => received.push(d.toString("utf-8")));
+      });
+      s.listen(socketPath, () => resolve(s));
+    });
+
+    try {
+      const tp = writeTranscript("tripping.jsonl", [
+        { role: "user", text: "Send the digest." },
+        { role: "assistant", text: "Sent." },
+        { role: "user", text: "No, that's wrong — you included drafts again." },
+        { role: "assistant", text: "Fixed." },
+        { role: "user", text: "That's not what I asked, I told you to exclude drafts." },
+      ]);
+      const r = run(JSON.stringify({ session_id: "s3", transcript_path: tp }), {
+        SWITCHROOM_AGENT_NAME: "test-agent",
+        SWITCHROOM_GATEWAY_SOCKET: socketPath,
+        SWITCHROOM_SELF_IMPROVE_CHAT_ID: "1234",
+      });
+      expect(r.status).toBe(0);
+
+      // Give the async write a moment to land on the server side.
+      await new Promise((res) => setTimeout(res, 200));
+      const payload = received.join("");
+      expect(payload.length).toBeGreaterThan(0);
+      const envelope = JSON.parse(payload.trim());
+      expect(envelope.type).toBe("inject_inbound");
+      expect(envelope.agentName).toBe("test-agent");
+      expect(envelope.inbound.meta.source).toBe("self_improve_review");
+      expect(envelope.inbound.chatId).toBe("1234");
+      expect(envelope.inbound.text).toContain("[self-improvement review]");
+    } finally {
+      await new Promise<void>((res) => server.close(() => res()));
+    }
+  });
+
+  it("does NOT recurse: a review turn does not re-trip the gate", () => {
+    if (!bunOk) return;
+    const socketPath = join(tmp, "gw2.sock");
+    // The last user message is a review prompt we previously injected.
+    const tp = writeTranscript("review.jsonl", [
+      {
+        role: "user",
+        text:
+          "[self-improvement review] The turn-end gate detected a learning signal. " +
+          "No, that's wrong. That's not what I asked, I told you.",
+      },
+      { role: "assistant", text: "Recorded a pending suggestion." },
+    ]);
+    const r = run(JSON.stringify({ session_id: "s4", transcript_path: tp }), {
+      SWITCHROOM_AGENT_NAME: "test-agent",
+      SWITCHROOM_GATEWAY_SOCKET: socketPath, // no server listening — connect would fail anyway
+    });
+    expect(r.status).toBe(0);
+  });
+});

--- a/tests/self-improve-tier-router.test.ts
+++ b/tests/self-improve-tier-router.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+
+import { classifyTier } from "../src/self-improve/tier-router.js";
+import type { ChangeCandidate } from "../src/self-improve/types.js";
+
+const cfg = {
+  repetitionThreshold: 2,
+  t1MaxChangedLines: 30,
+  maxAutoAppliesPerDay: 3,
+  maxOutstandingPending: 5,
+};
+
+function candidate(over: Partial<ChangeCandidate>): ChangeCandidate {
+  return {
+    lesson: "exclude drafts from the digest",
+    proposedChange: "add a draft filter to the digest skill",
+    ...over,
+  };
+}
+
+describe("tier router — T1 (auto, silent)", () => {
+  it("classifies a small reversible owned single-file edit as T1", () => {
+    const d = classifyTier(
+      candidate({ skillSlug: "digest", ownsSkill: true, changedLines: 8 }),
+      cfg,
+    );
+    expect(d.tier).toBe("T1");
+  });
+
+  it("treats a one-line owned edit as T1", () => {
+    const d = classifyTier(
+      candidate({ skillSlug: "digest", ownsSkill: true, changedLines: 1 }),
+      cfg,
+    );
+    expect(d.tier).toBe("T1");
+  });
+});
+
+describe("tier router — T2 (propose, never auto-apply in slice 1)", () => {
+  it("downgrades to T2 when the agent does NOT own the skill", () => {
+    const d = classifyTier(
+      candidate({ skillSlug: "shared-thing", ownsSkill: false, changedLines: 5 }),
+      cfg,
+    );
+    expect(d.tier).toBe("T2");
+  });
+
+  it("downgrades to T2 when there is no skill target at all", () => {
+    const d = classifyTier(candidate({}), cfg);
+    expect(d.tier).toBe("T2");
+  });
+
+  it("downgrades to T2 when the diff exceeds the T1 cap", () => {
+    const d = classifyTier(
+      candidate({ skillSlug: "digest", ownsSkill: true, changedLines: 31 }),
+      cfg,
+    );
+    expect(d.tier).toBe("T2");
+    expect(d.reason).toContain("31");
+  });
+
+  it("downgrades to T2 when the edit spans multiple files", () => {
+    const d = classifyTier(
+      candidate({ skillSlug: "digest", ownsSkill: true, changedLines: 4, multiFile: true }),
+      cfg,
+    );
+    expect(d.tier).toBe("T2");
+  });
+});
+
+describe("tier router — T3 (ask explicitly; the on-leash floor)", () => {
+  it("forces T3 for a new cron, even if otherwise tiny + owned", () => {
+    const d = classifyTier(
+      candidate({ skillSlug: "digest", ownsSkill: true, changedLines: 2, touchesCron: true }),
+      cfg,
+    );
+    expect(d.tier).toBe("T3");
+  });
+
+  it("forces T3 for a new skill", () => {
+    const d = classifyTier(
+      candidate({ skillSlug: "brand-new", ownsSkill: true, changedLines: 2, createsNewSkill: true }),
+      cfg,
+    );
+    expect(d.tier).toBe("T3");
+  });
+
+  it("forces T3 for a cross-agent change", () => {
+    const d = classifyTier(
+      candidate({ skillSlug: "digest", ownsSkill: true, changedLines: 2, crossAgent: true }),
+      cfg,
+    );
+    expect(d.tier).toBe("T3");
+  });
+
+  it("forces T3 for an irreversible change", () => {
+    const d = classifyTier(
+      candidate({ skillSlug: "digest", ownsSkill: true, changedLines: 2, irreversible: true }),
+      cfg,
+    );
+    expect(d.tier).toBe("T3");
+  });
+});
+
+describe("tier router — T0", () => {
+  it("returns T0 when nothing is proposed", () => {
+    const d = classifyTier(candidate({ proposedChange: "" }), cfg);
+    expect(d.tier).toBe("T0");
+  });
+});


### PR DESCRIPTION
## Summary

First vertical of the **agent self-improvement** feature — agents get better the longer they run. When a correction recurs (or the same manual fix shows up twice), the agent lands a small, tested, reversible edit to a skill **it already owns** — silently — and surfaces anything bigger as a proposal. Ships **opt-out** (on by default), costs **~nothing on idle turns**, and **never** auto-creates a cron / new skill / cross-agent or irreversible change.

- RFC: `reference/rfcs/agent-self-improvement.md` (#2452) — also included on this branch.
- Job spec: `reference/jobs/get-better-the-longer-they-run.md` → outcome `standing-team`, kill-clause `no-self-escalation` / `on-leash`.

## What slice 1 delivers

**A) Gate (deterministic, cheap).** A new switchroom-owned **async Stop hook** (`src/cli/self-improve-stop.ts` → `dist/cli/self-improve-stop.mjs`), wired into `buildSettingsHooksBlock` alongside handoff / secret-scrub / tool-label. It detects three signal classes over the just-finished turn — **operator correction**, **repeated manual fix**, **directive-not-bound** — with **repetition threshold = 2** ("correct once, never again"). No signal → returns immediately: no model call, no IO beyond the transcript read. That idle-turn cost guarantee is the whole point, so the gate is pure.

**B) Forked review (restricted toolset, async, off the reply path).** On a trip the hook injects a review turn via the gateway **`inject_inbound`** socket — the same primitive cron uses, **not** a new `claude -p` spawn (keeps it subscription-honest per the claude-native invariant). The prompt restricts the review to **memory + skill read/write** tools, forbids replying, and carries the tier + eval contract. `meta.source=self_improve_review`; a recursion guard stops a review turn re-tripping the gate.

**C) Tier router (T0–T3).** `src/self-improve/tier-router.ts`. **T1** = small (≤30 changed lines, single file), reversible edit to a skill the agent **already owns** → implemented fully. **T2/T3** (medium / shared / new-cron / new-skill / cross-agent / irreversible) → written to a per-agent pending-suggestions queue, never auto-applied. Any on-leash trigger forces T3.

**D) Eval gate on T1.** `src/self-improve/eval-gate.ts` reuses skill-creator's **real** `aggregate_benchmark.py` + the `grader.md` subagent. A T1 lands only if its evals pass and **don't regress baseline**. A skill with **no `evals.json`** downgrades to a T2 proposal.

**E) Audit/rollback.** T1 edits go through the existing skill-write path, so the **validator hook + git history** are the audit and rollback. The only new state is the pending-queue JSONL file (`<stateDir>/self-improve-pending.jsonl`) plus a tiny T1 rate-limit ledger.

### Starting defaults (tunable via env; first measured on `clerk`)

| Knob | Env | Default |
|---|---|---|
| Disable entirely | `SWITCHROOM_SELF_IMPROVE` | `1` (set `0` to opt out) |
| Repetition threshold | `SWITCHROOM_SELF_IMPROVE_THRESHOLD` | `2` |
| T1 auto-apply diff cap (lines) | `SWITCHROOM_SELF_IMPROVE_T1_MAX_LINES` | `30` |
| Max auto-applies/day | `SWITCHROOM_SELF_IMPROVE_MAX_AUTO_PER_DAY` | `3` |
| Max outstanding pending | `SWITCHROOM_SELF_IMPROVE_MAX_PENDING` | `5` |

## Deferred to later slices

- **T2/T3 surfacing** — Telegram one-tap / Linear issue from the pending queue (slice 1 only writes the queue file).
- **Small-model triage** — gate stays deterministic; a tiny-model escalation is an explicit later option.
- **The review session executing the apply** — slice 1 provides the gate, router, eval-gate decision layer, and queue; the review turn that runs the grader subagent and lands the T1 edit is the model-side follow-up.

## Test plan

`tsc --noEmit` clean; full lint chain clean (`check-plugin-references`, `check-bot-api-wrapping`, `check-bun-test-imports`, `check-no-pii-secrets`, `check-vault-test-hermeticity`, `check-no-broadcast-delivery`, `check-stale-tool-descriptions`, `check-web-subscription-honest`). Full build emits `dist/cli/self-improve-stop.mjs`.

```
 ✓ tests/self-improve-gate.test.ts (9 tests)
 ✓ tests/self-improve-tier-router.test.ts (11 tests)
 ✓ tests/self-improve-eval-gate.test.ts (10 tests)   # incl. real aggregate_benchmark.py blocking a regression
 ✓ tests/self-improve-pending-queue.test.ts (5 tests)
 ✓ tests/self-improve-rate-limit.test.ts (3 tests)
 ✓ tests/self-improve-review-prompt.test.ts (4 tests)
 ✓ tests/self-improve-stop-hook.test.ts (5 tests)    # fails open; injects self_improve_review over a real socket
 ✓ tests/reconcile-hooks-drift.test.ts (16 tests)    # gate wired iff plugin on
 ✓ tests/docker/dockerfile-agent-bakes.test.ts (20 tests)
 Test Files  9 passed (9)
      Tests  83 passed (83)
```

Coverage maps to the job spec's three "Prove it" gaps: **gate fires only on a real signal**, **gate stays silent on a clean turn (cost × idle)**, **tier classification (anti-sprawl)**, and **eval gate blocks a regressing edit**.

> Note: one pre-existing, environment-specific failure in `tests/scaffold.test.ts` (the `$HOME=/home/op` symlink-render test) is unrelated to this change and reproduces on clean `main` in the same sandbox.

## Risk

Low. Opt-out kill switch; the gate is pure/fail-open; the forked review is restricted-toolset and off the reply path; T1 is the only auto-apply path and is gated by tier + diff-cap + eval + rate-limit; nothing irreversible/cross-agent can auto-apply by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)