### PR TITLE
feat(self-improve): slice 2 — close the T1 apply loop (deterministic guard)

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -233,6 +233,16 @@ RUN chmod 0755 /opt/switchroom/hooks/skill-validate-pretool.mjs
 COPY dist/cli/self-improve-stop.mjs /opt/switchroom/hooks/self-improve-stop.mjs
 RUN chmod 0755 /opt/switchroom/hooks/self-improve-stop.mjs
 
+# Agent self-improvement APPLY-GUARD (RFC reference/rfcs/agent-self-improvement.md
+# slice 2). The DETERMINISTIC T1 gate, a PreToolUse hook on Write/Edit/
+# MultiEdit. No-op on a normal turn; when a self-improve review is pending
+# (marker present) it enforces own-skill + diff-cap + evals-pass + rate-cap
+# on any skill edit, or BLOCKS it and downgrades to a pending proposal. Like
+# the Stop gate it's a quality loop within the agent's own trust domain, so
+# it lives here, not in the security-plugin. Kill switch SWITCHROOM_SELF_IMPROVE=0.
+COPY dist/cli/self-improve-apply-guard-pretool.mjs /opt/switchroom/hooks/self-improve-apply-guard-pretool.mjs
+RUN chmod 0755 /opt/switchroom/hooks/self-improve-apply-guard-pretool.mjs
+
 # Image-baked security-hooks plugin (sec WS8-F1 / #1416). A separate,
 # minimal --plugin-dir holding ONLY the load-bearing PreToolUse safety
 # hooks (secret-exfil guard + Drive-write approval gate). Loaded from

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -214,6 +214,24 @@ if (selfImproveHookEscape.changed) {
   console.log(`[build] ASCII-escaped ${selfImproveHookEscape.nonAsciiCount} non-ASCII code units in dist/cli/self-improve-stop.mjs`);
 }
 
+// Bundle the self-improve-apply-guard-pretool hook — RFC
+// reference/rfcs/agent-self-improvement.md slice 2. The DETERMINISTIC T1
+// apply-guard: a self-contained .mjs the agent runs via node from the
+// bundled-hooks path. Imports the src/self-improve/* apply-guard / eval-gate
+// / tier-router / pending-queue / review-context modules, none of which
+// resolve from the raw .mjs hooks dir — so bundle to one file.
+console.log("[build] bundling src/cli/self-improve-apply-guard-pretool.ts -> dist/cli/self-improve-apply-guard-pretool.mjs");
+execSync(
+  `bun build ${JSON.stringify(resolve(root, "src/cli/self-improve-apply-guard-pretool.ts"))} --outfile ${JSON.stringify(resolve(outDir, "self-improve-apply-guard-pretool.mjs"))} --target node`,
+  { stdio: "inherit", cwd: root }
+);
+const selfImproveGuardOutFile = resolve(outDir, "self-improve-apply-guard-pretool.mjs");
+chmodSync(selfImproveGuardOutFile, 0o755);
+const selfImproveGuardEscape = escapeBundleNonAscii(selfImproveGuardOutFile);
+if (selfImproveGuardEscape.changed) {
+  console.log(`[build] ASCII-escaped ${selfImproveGuardEscape.nonAsciiCount} non-ASCII code units in dist/cli/self-improve-apply-guard-pretool.mjs`);
+}
+
 // Bundle the autoaccept-poll entrypoint. The agent unit's ExecStartPost
 // invokes this in the background to dispatch first-run TUI prompts via
 // `tmux capture-pane` + `tmux send-keys`. Must ship in dist/ because

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -4470,6 +4470,29 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
           ],
         },
         {
+          // Agent self-improvement APPLY-GUARD — RFC
+          // reference/rfcs/agent-self-improvement.md slice 2. The
+          // DETERMINISTIC T1 gate: when a self-improve review is pending
+          // (the Stop hook dropped a review-context marker), any skill-file
+          // Write/Edit must clear own-skill + diff-cap + evals-present +
+          // evals-pass (no baseline regression) + the daily auto-apply cap,
+          // or it is BLOCKED and downgraded to a T2/T3 pending proposal.
+          // No-op on a normal turn (no marker) — the advisory linter above
+          // still runs. Bundled like skill-validate-pretool because it
+          // imports src/self-improve/*.
+          matcher: "^(Write|Edit|MultiEdit)$",
+          hooks: [
+            {
+              type: "command",
+              command: wrap(
+                "hook:self-improve-apply-guard-pretool",
+                `node "${join(DOCKER_BUNDLED_HOOKS_PATH, "self-improve-apply-guard-pretool.mjs")}"`,
+              ),
+              timeout: 30,
+            },
+          ],
+        },
+        {
           // Catch-all PreToolUse: deterministic tool-call labels (#783).
           // Hook always exits 0; never emits stdout JSON; writes one line
           // to $TELEGRAM_STATE_DIR/tool-labels-${session_id}.jsonl.

--- a/src/cli/self-improve-apply-guard-pretool.ts
+++ b/src/cli/self-improve-apply-guard-pretool.ts
@@ -1,0 +1,211 @@
+/**
+ * PreToolUse hook — agent self-improvement APPLY-GUARD (RFC
+ * `reference/rfcs/agent-self-improvement.md`, slice 2).
+ *
+ * Fires on Write / Edit / MultiEdit. It is a NO-OP on a normal turn: it
+ * only acts when a self-improve review is pending (the Stop hook dropped a
+ * review-context marker at injection time — see
+ * `src/self-improve/review-context.ts`) AND the target is a skill-bundle
+ * file. In that case it ENFORCES the T1 conditions deterministically,
+ * out-of-process — the safety lives in CODE, not in the review prompt the
+ * model could ignore:
+ *
+ *   own-skill ∧ single-file ∧ diff-cap ∧ evals.json present ∧ evals pass
+ *   (no baseline regression) ∧ under the daily auto-apply cap
+ *
+ * If every check passes the write is ALLOWED (and one auto-apply is
+ * recorded against the daily cap). If ANY check fails the write is
+ * BLOCKED and the change is DOWNGRADED to a T2/T3 pending suggestion
+ * (`src/self-improve/pending-queue.ts`) — an unchecked edit never lands.
+ *
+ * Ordering vs the advisory skill-validate-pretool linter: this hook is a
+ * SEPARATE PreToolUse entry. Claude Code runs all matching PreToolUse
+ * hooks; the first `decision:"block"` wins. The linter is advisory (only
+ * blocks the byte-cap), so this guard's block is authoritative for the
+ * self-improve path.
+ *
+ * Claude Code PreToolUse protocol (v1), mirrors skill-validate-pretool:
+ *   Input:  JSON on stdin — { session_id, tool_name, tool_input, ... }
+ *   Output: exit 0 + empty stdout                       → allow.
+ *           exit 0 + {"decision":"block","reason":...}  → block.
+ *
+ * Fail-OPEN on anything that is NOT a deliberate guard decision (stdin
+ * parse error, no marker, non-skill write, missing state dir): a quality
+ * loop's guard must never be the reason a legitimate, non-review write
+ * fails. The only blocks are the explicit downgrade refusals.
+ *
+ * Bundled to a self-contained `.mjs` at build time (like
+ * skill-validate-pretool / self-improve-stop) because it imports the
+ * src/self-improve/* modules, none of which resolve from the raw .mjs
+ * hooks dir inside the agent image.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+import { selfImproveEnabled } from "../self-improve/config.js";
+import {
+  readReviewContext,
+  type ReviewContext,
+} from "../self-improve/review-context.js";
+import {
+  decideApply,
+  parseSkillTarget,
+} from "../self-improve/apply-guard.js";
+import { recordAutoApply } from "../self-improve/rate-limit.js";
+import { enqueuePending } from "../self-improve/pending-queue.js";
+
+const EDIT_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
+
+function readStdin(): string {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function allow(): never {
+  process.exit(0);
+}
+
+function block(reason: string): never {
+  const safe = String(reason)
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x1f\x7f]/g, " ")
+    .slice(0, 300);
+  process.stdout.write(JSON.stringify({ decision: "block", reason: safe }));
+  process.exit(0);
+}
+
+/** Agent state dir — set by start.sh; same fallback as self-improve-stop. */
+function resolveStateDir(): string {
+  return (
+    process.env.TELEGRAM_STATE_DIR ??
+    join(homedir(), ".claude", "channels", "telegram")
+  );
+}
+
+function main(): void {
+  // Opt-out kill switch (RFC: ships on by default, per-agent disable).
+  if (!selfImproveEnabled()) allow();
+
+  const raw = readStdin().trim();
+  if (!raw) allow();
+
+  let event: { tool_name?: unknown; tool_input?: unknown };
+  try {
+    event = JSON.parse(raw);
+  } catch {
+    allow(); // Claude protocol error — not ours to police.
+  }
+
+  const toolName = typeof event.tool_name === "string" ? event.tool_name : "";
+  if (!EDIT_TOOLS.has(toolName)) allow();
+
+  const input =
+    event.tool_input && typeof event.tool_input === "object"
+      ? (event.tool_input as Record<string, unknown>)
+      : {};
+  const filePath = typeof input.file_path === "string" ? input.file_path : "";
+  if (!filePath) allow();
+
+  // Only a skill-bundle write is in scope.
+  if (!parseSkillTarget(filePath)) allow();
+
+  const stateDir = resolveStateDir();
+
+  // The marker is the seam: NO pending review → this is a normal turn, the
+  // apply-guard stays out of the way entirely (advisory linter still runs).
+  let ctx: ReviewContext | null = null;
+  try {
+    ctx = readReviewContext(stateDir);
+  } catch {
+    ctx = null;
+  }
+  if (!ctx) allow();
+
+  // A review is pending — ENFORCE. Freshness floor = the review's start, so
+  // a stale benchmark from a prior edit can't wave a new edit through.
+  let freshAfterMs: number | undefined;
+  const t = Date.parse(ctx.created_at);
+  if (Number.isFinite(t)) freshAfterMs = t;
+
+  let decision;
+  try {
+    decision = decideApply({
+      toolName,
+      input,
+      filePath,
+      stateDir,
+      freshAfterMs,
+    });
+  } catch {
+    // A guard failure must not silently let an unchecked edit land:
+    // fail-CLOSED for the apply path. Downgrade to a proposal and block.
+    safeDowngrade(stateDir, ctx, filePath, "apply-guard internal error");
+    block(
+      "self-improve apply-guard: internal error evaluating the edit — " +
+        "downgraded to a pending proposal, write blocked (fail-closed).",
+    );
+  }
+
+  if (decision.action === "allow") {
+    // Record the auto-apply against the daily cap BEFORE the write lands —
+    // the edit is about to be applied by Claude Code on our allow.
+    try {
+      recordAutoApply(stateDir);
+    } catch {
+      /* cap accounting best-effort; never block a verified T1 on it */
+    }
+    allow();
+  }
+
+  // Block + downgrade to the pending queue.
+  let capNote = "";
+  try {
+    const q = enqueuePending(stateDir, {
+      tier: decision.downgradeTier,
+      lesson: decision.candidate.lesson,
+      proposed_change: decision.candidate.proposedChange,
+      tier_reason: decision.reason,
+      skill_slug: decision.candidate.skillSlug,
+      triggered_by: (ctx.signals ?? []).map((s) => s.kind),
+    });
+    if (!q.ok) {
+      // Queue full — the proposal is dropped; surface it rather than lose
+      // the lesson silently. The write stays blocked regardless.
+      capNote = ` (pending queue full ${q.outstanding}/${q.cap} — proposal not recorded)`;
+    }
+  } catch {
+    /* queue best-effort — still block the unchecked write */
+  }
+  block(`self-improve apply-guard: ${decision.reason}${capNote}`);
+}
+
+/** Best-effort downgrade used only on the fail-closed internal-error path. */
+function safeDowngrade(
+  stateDir: string,
+  ctx: ReviewContext,
+  filePath: string,
+  reason: string,
+): void {
+  try {
+    const target = parseSkillTarget(filePath);
+    enqueuePending(stateDir, {
+      tier: "T2",
+      lesson: target
+        ? `Bind the recurring lesson into skill "${target.slug}"`
+        : "self-improve review edit (guard error)",
+      proposed_change: filePath,
+      tier_reason: reason,
+      skill_slug: target?.slug,
+      triggered_by: (ctx.signals ?? []).map((s) => s.kind),
+    });
+  } catch {
+    /* nothing to do */
+  }
+}
+
+main();

--- a/src/cli/self-improve-stop.ts
+++ b/src/cli/self-improve-stop.ts
@@ -33,6 +33,10 @@ import { homedir } from "node:os";
 import { runGate } from "../self-improve/gate.js";
 import { buildReviewPrompt, REVIEW_SOURCE } from "../self-improve/review-prompt.js";
 import { selfImproveEnabled } from "../self-improve/config.js";
+import {
+  writeReviewContext,
+  clearReviewContext,
+} from "../self-improve/review-context.js";
 import type { TurnMessage } from "../self-improve/types.js";
 
 /** Newest-last window of messages to scan. Bounds the gate's cost and
@@ -118,6 +122,15 @@ function readTranscript(path: string): TurnMessage[] {
   }
   // Bounded tail.
   return out.length > SCAN_WINDOW ? out.slice(-SCAN_WINDOW) : out;
+}
+
+/** Agent state dir — set by start.sh; same fallback as the apply-guard
+ *  hook so both agree on where the review-context marker lives. */
+function resolveStateDir(): string {
+  return (
+    process.env.TELEGRAM_STATE_DIR ??
+    join(homedir(), ".claude", "channels", "telegram")
+  );
 }
 
 function resolveSocketPath(): string {
@@ -215,24 +228,45 @@ function main(): void {
     typeof event.session_id === "string" ? event.session_id : "unknown";
 
   const messages = readTranscript(transcriptPath);
+
+  // Review-turn detection FIRST — BEFORE the gate check, and independent of
+  // it. A turn we injected is itself a transcript whose most-recent user
+  // message starts with the "[self-improvement review]" banner. On such a
+  // turn we (a) clear the review-context marker so the apply-guard stops
+  // enforcing on later NORMAL turns, and (b) never recurse by reviewing a
+  // review. This MUST run before `!gate.tripped` returns: a well-behaved
+  // review (the review prompt + a benign skill edit) trips NO learning
+  // signal, so if the clear sat after the gate check the marker would leak
+  // after every real review — wrongly blocking later normal-turn edits and,
+  // worse, letting a normal-turn edit auto-apply against a STALE benchmark.
+  const lastUser = [...messages].reverse().find((m) => m.role === "user");
+  if (lastUser && lastUser.text.startsWith("[self-improvement review]")) {
+    clearReviewContext(resolveStateDir());
+    process.exit(0);
+  }
+
   const gate = runGate(messages);
 
   // Cost guarantee: no signal → return immediately, zero added work.
   if (!gate.tripped) process.exit(0);
 
-  // Don't recurse: a review turn we injected is itself a transcript; if
-  // its own messages somehow trip the gate, we'd loop. The injected
-  // turn's first user message carries meta.source=self_improve_review;
-  // the transcript flattening drops meta, but the visible prompt starts
-  // with the "[self-improvement review]" banner — bail if the most
-  // recent user message is one of ours.
-  const lastUser = [...messages].reverse().find((m) => m.role === "user");
-  if (lastUser && lastUser.text.startsWith("[self-improvement review]")) {
-    process.exit(0);
-  }
-
   const agentName = process.env.SWITCHROOM_AGENT_NAME ?? "";
   if (!agentName) process.exit(0); // can't route without identity — fail-open
+
+  // Drop the review-context marker BEFORE injecting, so the apply-guard in
+  // the forked review turn enforces the deterministic T1 gate on any skill
+  // edit the review attempts. Best-effort: a marker failure must not stop
+  // the review from being injected (the guard then simply no-ops).
+  try {
+    writeReviewContext(resolveStateDir(), {
+      created_at: new Date().toISOString(),
+      triggering_session: sessionId,
+      chat_id: resolveChatId(),
+      signals: gate.signals,
+    });
+  } catch {
+    /* marker best-effort; review still injects */
+  }
 
   const prompt = buildReviewPrompt(gate.signals);
   injectReview(agentName, prompt, sessionId);

--- a/src/self-improve/apply-guard.ts
+++ b/src/self-improve/apply-guard.ts
@@ -1,0 +1,399 @@
+/**
+ * Agent self-improvement — the DETERMINISTIC apply-guard (slice 2).
+ *
+ * This is the SAFETY, in CODE, not in the prompt (RFC §"Gate every apply
+ * (incl. T1) behind a per-skill eval before it lands"; job-spec invariant
+ * "reversible + audited", kill-clause `no-self-escalation` / `on-leash`).
+ * The slice-1 review prompt TELLS the model to self-certify a T1 edit; the
+ * apply-guard does NOT trust that. When a self-improve review turn tries to
+ * Write/Edit a skill file, the PreToolUse hook calls `decideApply()` here,
+ * which ENFORCES — out of process, deterministically — every T1 condition:
+ *
+ *   1. own-skill   — the target is a skill the agent ALREADY owns (a real
+ *                    dir under its own `.claude/skills/`, not a symlinked
+ *                    bundled/shared skill). Else → not T1.
+ *   2. single-file — the change must be one skill file (the review edits
+ *                    one file per write; the guard runs per-write).
+ *   3. diff-cap    — changed lines ≤ the configured T1 cap (config.ts).
+ *   4. has-evals   — the skill carries `evals/evals.json` (eval-gate.ts).
+ *   5. eval-pass   — a FRESH benchmark.json (produced by the review's
+ *                    grader subagent + aggregate_benchmark.py, dated after
+ *                    the review began) shows the edit passes AND does not
+ *                    regress baseline (eval-gate.ts `evalVerdict`).
+ *   6. rate-cap    — ≤ N auto-applies/day (rate-limit.ts).
+ *
+ * If ANY check fails the write is BLOCKED and the change DOWNGRADES to a
+ * T2/T3 pending suggestion (pending-queue.ts). An unchecked edit never
+ * lands. The classification reuses the slice-1 tier-router so "what makes
+ * it not-T1" stays single-sourced.
+ *
+ * Pure-ish: filesystem reads + (in the eval leg) a spawn of the real
+ * aggregate verdict reader. No model, no network. That's what lets the
+ * apply / downgrade tests run without a live `claude`.
+ */
+
+import { existsSync, lstatSync, readFileSync, statSync } from "node:fs";
+import { join, resolve, sep } from "node:path";
+
+import { resolveSelfImproveConfig, type SelfImproveConfig } from "./config.js";
+import { classifyTier } from "./tier-router.js";
+import { skillHasEvals, evalVerdict } from "./eval-gate.js";
+import { appliesToday } from "./rate-limit.js";
+import type { ChangeCandidate, Tier } from "./types.js";
+
+/** Segment that marks a skill-bundle write (mirrors skill-validate-pretool). */
+export const SKILLS_SEGMENT = "/.claude/skills/";
+
+/** Subdir under the state dir where the review writes per-skill benchmarks. */
+export const BENCHMARK_SUBDIR = "self-improve-benchmarks";
+
+/** Where the apply-guard expects the review to have written the benchmark
+ *  for a given skill slug. The review prompt/skill points the grader's
+ *  aggregate output here so the guard can find + verify it. */
+export function benchmarkJsonForSkill(stateDir: string, slug: string): string {
+  return join(stateDir, BENCHMARK_SUBDIR, slug, "benchmark.json");
+}
+
+/** Parse `<...>/.claude/skills/<slug>/<rel>` from a write target.
+ *  Returns null when the path is not a skill-bundle file write. */
+export interface SkillTarget {
+  /** Absolute path to the skill bundle dir (`<...>/.claude/skills/<slug>`). */
+  skillDir: string;
+  /** The skill slug. */
+  slug: string;
+  /** The bundle-relative path (e.g. `SKILL.md`, `scripts/x.sh`). */
+  relPath: string;
+}
+
+export function parseSkillTarget(filePath: string): SkillTarget | null {
+  if (typeof filePath !== "string" || filePath.length === 0) return null;
+  const segIdx = filePath.indexOf(SKILLS_SEGMENT);
+  if (segIdx < 0) return null;
+  const after = filePath.slice(segIdx + SKILLS_SEGMENT.length);
+  const segs = after.split("/").filter((s) => s.length > 0);
+  if (segs.length < 2) return null; // skills root or a bare slug dir
+  const slug = segs[0]!;
+  const relPath = segs.slice(1).join("/");
+  const skillDir = filePath.slice(0, segIdx + SKILLS_SEGMENT.length) + slug;
+  return { skillDir, slug, relPath };
+}
+
+/** A plain skill-bundle slug: no traversal, no path separators, no dotfiles. */
+const SAFE_SLUG = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/;
+
+/**
+ * Path-safety gate. The apply-guard's "own-skill" contract is meaningless
+ * if the bytes land OUTSIDE the bundle, so reject any non-canonical target
+ * the review model could craft to escape — `parseSkillTarget` deliberately
+ * still RECOGNISES such paths (so the guard engages and blocks rather than
+ * the hook waving them through as "not a skill write"), and this function
+ * is what turns them into a refusal.
+ *
+ * Rejects: a slug that isn't a plain bundle name (covers `.` / `..` /
+ * separators); any empty / `.` / `..` / null-byte segment in relPath; and,
+ * defense-in-depth, any relPath whose resolved absolute path leaves the
+ * bundle dir.
+ */
+export function skillTargetEscapes(target: SkillTarget): boolean {
+  if (!SAFE_SLUG.test(target.slug)) return true;
+  for (const s of target.relPath.split("/")) {
+    if (s === "" || s === "." || s === ".." || s.includes("\0")) return true;
+  }
+  const base = resolve(target.skillDir);
+  const resolved = resolve(target.skillDir, target.relPath);
+  return resolved !== base && !resolved.startsWith(base + sep);
+}
+
+/**
+ * Does the agent OWN this skill? Ownership = a real directory under the
+ * agent's own writable `.claude/skills/` (the native-authoring path).
+ * Bundled / shared / globally-mounted skills are SYMLINKS into a read-only
+ * pool — editing one is never a T1 (it would escape the agent's trust
+ * domain → tier-router forces T2). We treat a symlinked skill dir, or a
+ * skill dir that does not exist on disk, as NOT owned.
+ */
+export function ownsSkill(skillDir: string): boolean {
+  try {
+    const st = lstatSync(skillDir);
+    if (st.isSymbolicLink()) return false; // shared/bundled pool symlink
+    return st.isDirectory();
+  } catch {
+    return false; // not on disk → can't own it
+  }
+}
+
+/**
+ * Estimate the changed-line count for a Write/Edit/MultiEdit.
+ *
+ *   - Write: lines in the new content that differ from the current file
+ *     (added + removed, like `diff`). For a brand-new file it's the line
+ *     count of the new content.
+ *   - Edit: added + removed lines across the single old→new replacement.
+ *   - MultiEdit: summed across edits.
+ *
+ * Deterministic and dependency-free — a line-multiset diff, not an LCS.
+ * Good enough for the cap (we only need "is this small"); it never
+ * UNDER-counts a large change (a multiset diff is ≥ the true minimal edit
+ * for the cap's purpose of catching big writes).
+ */
+export function estimateChangedLines(
+  toolName: string,
+  input: Record<string, unknown>,
+  filePath: string,
+): number {
+  const splitLines = (s: string): string[] =>
+    s.length === 0 ? [] : s.replace(/\r\n/g, "\n").split("\n");
+
+  const multisetDiff = (before: string[], after: string[]): number => {
+    const counts = new Map<string, number>();
+    for (const l of before) counts.set(l, (counts.get(l) ?? 0) + 1);
+    let added = 0;
+    for (const l of after) {
+      const c = counts.get(l) ?? 0;
+      if (c > 0) counts.set(l, c - 1);
+      else added += 1;
+    }
+    let removed = 0;
+    for (const c of counts.values()) removed += c;
+    return added + removed;
+  };
+
+  const readCurrent = (): string => {
+    try {
+      return readFileSync(filePath, "utf-8");
+    } catch {
+      return "";
+    }
+  };
+
+  if (toolName === "Write") {
+    const content = typeof input.content === "string" ? input.content : "";
+    return multisetDiff(splitLines(readCurrent()), splitLines(content));
+  }
+
+  if (toolName === "Edit") {
+    const oldS = typeof input.old_string === "string" ? input.old_string : "";
+    const newS = typeof input.new_string === "string" ? input.new_string : "";
+    return multisetDiff(splitLines(oldS), splitLines(newS));
+  }
+
+  if (toolName === "MultiEdit") {
+    const edits = Array.isArray(input.edits) ? input.edits : [];
+    let total = 0;
+    for (const e of edits) {
+      if (!e || typeof e !== "object") continue;
+      const ed = e as Record<string, unknown>;
+      const oldS = typeof ed.old_string === "string" ? ed.old_string : "";
+      const newS = typeof ed.new_string === "string" ? ed.new_string : "";
+      total += multisetDiff(splitLines(oldS), splitLines(newS));
+    }
+    return total;
+  }
+
+  return 0;
+}
+
+export type ApplyDecision =
+  | {
+      /** Allow the write to proceed (a verified T1). */
+      action: "allow";
+      tier: "T1";
+      changedLines: number;
+      candidatePassRate: number;
+      baselinePassRate: number;
+      reason: string;
+    }
+  | {
+      /** Block the write and downgrade to a pending suggestion. */
+      action: "block";
+      /** The tier the downgrade is recorded as (T2 by default; T3 when the
+       *  classification floor says so). */
+      downgradeTier: Exclude<Tier, "T0" | "T1">;
+      /** Operator-facing reason the auto-apply was refused. */
+      reason: string;
+      /** A change candidate suitable for enqueuePending(). */
+      candidate: ChangeCandidate;
+    };
+
+export interface DecideApplyParams {
+  toolName: string;
+  input: Record<string, unknown>;
+  filePath: string;
+  /** Agent state dir (TELEGRAM_STATE_DIR) — for the benchmark + rate-cap. */
+  stateDir: string;
+  cfg?: SelfImproveConfig;
+  now?: () => number;
+  /** Test seam: override "is the skill owned" (default = real fs check). */
+  ownsSkillFn?: (skillDir: string) => boolean;
+  /** Test seam: override the freshness floor (ms). Defaults to the review
+   *  context's created_at when one is supplied. */
+  freshAfterMs?: number;
+}
+
+/** Build the downgrade candidate that the apply-guard hands the queue. */
+function downgradeCandidate(
+  target: SkillTarget,
+  owns: boolean,
+  changedLines: number,
+  lesson: string,
+): ChangeCandidate {
+  return {
+    lesson,
+    proposedChange: `Edit ${target.relPath} in skill "${target.slug}" (auto-apply refused — see reason)`,
+    skillSlug: target.slug,
+    ownsSkill: owns,
+    changedLines,
+    multiFile: false,
+  };
+}
+
+/**
+ * THE decision. Given a skill-file write attempted inside a self-improve
+ * review turn, decide allow (verified T1) vs block+downgrade.
+ *
+ * Order mirrors the cheapest-first / most-restrictive-wins shape of the
+ * tier-router: ownership → single-file → diff-cap → evals-present →
+ * eval-verdict → rate-cap. The FIRST failing check decides the downgrade
+ * reason. Only when every check passes does the write land.
+ */
+export function decideApply(p: DecideApplyParams): ApplyDecision {
+  const cfg = p.cfg ?? resolveSelfImproveConfig();
+  const now = p.now ?? Date.now;
+
+  const target = parseSkillTarget(p.filePath);
+  // Not a skill-bundle file → the guard should not have been asked; treat
+  // as a non-T1 downgrade with a generic candidate (the hook only calls us
+  // for skill writes, so this is defensive).
+  if (!target) {
+    return {
+      action: "block",
+      downgradeTier: "T2",
+      reason: "write target is not an own-skill bundle file",
+      candidate: {
+        lesson: "self-improve review attempted a non-skill write",
+        proposedChange: p.filePath,
+        multiFile: false,
+      },
+    };
+  }
+
+  // Path-safety BEFORE any ownership/eval decision: a crafted slug or
+  // relPath (".." traversal, separators, null bytes) could make the bytes
+  // land outside the bundle while the guard reasons about the legit skill.
+  // Refuse deterministically.
+  if (skillTargetEscapes(target)) {
+    return {
+      action: "block",
+      downgradeTier: "T2",
+      reason: `skill write path escapes the bundle (slug="${target.slug}", rel="${target.relPath}") — refused`,
+      candidate: {
+        lesson: `Bind the recurring lesson into skill "${target.slug}"`,
+        proposedChange: `Edit ${target.relPath} in skill "${target.slug}" (path escapes bundle — refused)`,
+        skillSlug: target.slug,
+        ownsSkill: false,
+        changedLines: 0,
+        multiFile: false,
+      },
+    };
+  }
+
+  const owns = (p.ownsSkillFn ?? ownsSkill)(target.skillDir);
+  const changedLines = estimateChangedLines(p.toolName, p.input, p.filePath);
+  const lesson = `Bind the recurring lesson into skill "${target.slug}"`;
+
+  // (1) own-skill — and let the tier-router be the single source of truth
+  //     for "is this even a T1 shape". If the router says anything but T1,
+  //     downgrade with the router's reason (this captures own-skill +
+  //     diff-cap + multi-file in one place).
+  const routed = classifyTier(
+    {
+      lesson,
+      proposedChange: "skill edit",
+      skillSlug: target.slug,
+      ownsSkill: owns,
+      changedLines,
+      multiFile: false,
+    },
+    cfg,
+  );
+  if (routed.tier !== "T1") {
+    return {
+      action: "block",
+      downgradeTier: routed.tier === "T3" ? "T3" : "T2",
+      reason: `not a T1 auto-apply: ${routed.reason}`,
+      candidate: downgradeCandidate(target, owns, changedLines, lesson),
+    };
+  }
+
+  // (4) has-evals — a T1 with no evals.json must NOT auto-apply.
+  if (!skillHasEvals(target.skillDir)) {
+    return {
+      action: "block",
+      downgradeTier: "T2",
+      reason: `skill "${target.slug}" has no evals/evals.json — can't measure the edit; downgraded to a proposal`,
+      candidate: downgradeCandidate(target, owns, changedLines, lesson),
+    };
+  }
+
+  // (5) eval-pass — a FRESH benchmark.json from the review's grader run
+  //     must exist and clear evalVerdict. Missing / stale / failing → block.
+  const benchPath = benchmarkJsonForSkill(p.stateDir, target.slug);
+  if (!existsSync(benchPath)) {
+    return {
+      action: "block",
+      downgradeTier: "T2",
+      reason: `no eval result for skill "${target.slug}" — the per-skill eval did not run/pass; downgraded to a proposal`,
+      candidate: downgradeCandidate(target, owns, changedLines, lesson),
+    };
+  }
+  // Freshness: the benchmark must post-date the start of this review (so a
+  // stale benchmark from a prior, different edit can't wave a new edit
+  // through). When `freshAfterMs` is given, enforce it.
+  if (typeof p.freshAfterMs === "number") {
+    let mtime = 0;
+    try {
+      mtime = statSync(benchPath).mtimeMs;
+    } catch {
+      mtime = 0;
+    }
+    if (mtime < p.freshAfterMs) {
+      return {
+        action: "block",
+        downgradeTier: "T2",
+        reason: `eval result for "${target.slug}" is stale (predates this review) — re-run evals; downgraded to a proposal`,
+        candidate: downgradeCandidate(target, owns, changedLines, lesson),
+      };
+    }
+  }
+  const verdict = evalVerdict(benchPath, cfg);
+  if (!verdict.pass) {
+    return {
+      action: "block",
+      downgradeTier: "T2",
+      reason: `eval gate blocked the edit to "${target.slug}": ${verdict.reason}`,
+      candidate: downgradeCandidate(target, owns, changedLines, lesson),
+    };
+  }
+
+  // (6) rate-cap — ≤ N auto-applies/day.
+  const used = appliesToday(p.stateDir, now);
+  if (used >= cfg.maxAutoAppliesPerDay) {
+    return {
+      action: "block",
+      downgradeTier: "T2",
+      reason: `daily auto-apply cap reached (${used}/${cfg.maxAutoAppliesPerDay}) — downgraded to a proposal`,
+      candidate: downgradeCandidate(target, owns, changedLines, lesson),
+    };
+  }
+
+  // All checks pass — a verified, small, reversible, eval-passing,
+  // under-cap edit to an owned skill. Let it land.
+  return {
+    action: "allow",
+    tier: "T1",
+    changedLines,
+    candidatePassRate: verdict.candidatePassRate,
+    baselinePassRate: verdict.baselinePassRate,
+    reason: `verified T1: ${changedLines} changed line${changedLines === 1 ? "" : "s"} to owned skill "${target.slug}", evals ${verdict.candidatePassRate.toFixed(2)} ≥ baseline ${verdict.baselinePassRate.toFixed(2)}, ${used + 1}/${cfg.maxAutoAppliesPerDay} today`,
+  };
+}

--- a/src/self-improve/review-context.ts
+++ b/src/self-improve/review-context.ts
@@ -1,0 +1,101 @@
+/**
+ * Agent self-improvement — the REVIEW-CONTEXT marker (slice 2).
+ *
+ * Slice 1 injects a forked review turn (the Stop hook → `inject_inbound`);
+ * slice 2 makes that turn's skill edits land SAFELY behind a deterministic
+ * PreToolUse apply-guard. The guard runs out-of-process and cannot read the
+ * injected inbound's `meta.source` (that arrives in the prompt text the
+ * model sees, not in the hook's stdin). So the Stop hook drops a small
+ * marker file at injection time recording "a self-improve review is now
+ * pending"; the apply-guard reads it to decide whether to enforce the T1
+ * gate.
+ *
+ *   <stateDir>/self-improve-review-context.json
+ *
+ * The marker is the seam between the two hooks. When ABSENT, the
+ * apply-guard is a no-op (a normal turn's skill write is governed only by
+ * the advisory linter, exactly as before). When PRESENT, the apply-guard
+ * enforces: own-skill, diff-cap, evals pass, rate-cap — and on ANY failure
+ * BLOCKS the write and downgrades the change to a T2/T3 pending suggestion.
+ *
+ * Keeping this a tiny pure module (write / read / clear) lets both hooks
+ * agree on one shape, and lets the apply-guard tests construct a marker
+ * without the gateway.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import type { LearningSignal } from "./types.js";
+
+export const REVIEW_CONTEXT_FILE = "self-improve-review-context.json";
+
+export interface ReviewContext {
+  /** ISO timestamp the review was injected. */
+  created_at: string;
+  /** The session that triggered the review (audit only). */
+  triggering_session: string;
+  /** The chat the review nominally belongs to (context only). */
+  chat_id: string;
+  /** The gate's detected signals — carried so the apply-guard can record
+   *  an accurate `triggered_by` on any downgraded proposal. */
+  signals: LearningSignal[];
+}
+
+function contextPath(stateDir: string): string {
+  return join(stateDir, REVIEW_CONTEXT_FILE);
+}
+
+/**
+ * Write the marker. Called by the Stop hook at injection time, so the
+ * apply-guard in the forked review turn can find it. Best-effort: a marker
+ * write failure must not stop the review from being injected (the guard
+ * then simply no-ops, which is fail-OPEN for the marker but the eval gate
+ * inside the review prompt is still the model's instruction).
+ */
+export function writeReviewContext(stateDir: string, ctx: ReviewContext): void {
+  if (!existsSync(stateDir)) {
+    mkdirSync(stateDir, { recursive: true, mode: 0o755 });
+  }
+  writeFileSync(contextPath(stateDir), JSON.stringify(ctx, null, 2), "utf-8");
+}
+
+/** Read the marker, or null if absent / unreadable / malformed. */
+export function readReviewContext(stateDir: string): ReviewContext | null {
+  const p = contextPath(stateDir);
+  if (!existsSync(p)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(p, "utf-8")) as ReviewContext;
+    if (parsed && typeof parsed.created_at === "string") {
+      if (!Array.isArray(parsed.signals)) parsed.signals = [];
+      return parsed;
+    }
+  } catch {
+    /* malformed — treat as absent */
+  }
+  return null;
+}
+
+/** True iff a review is currently pending (marker present + readable). */
+export function reviewIsPending(stateDir: string): boolean {
+  return readReviewContext(stateDir) !== null;
+}
+
+/**
+ * Remove the marker. Called by the Stop hook at the END of a review turn
+ * (so a single review can't keep enforcing across later normal turns), and
+ * defensively by the apply-guard's tests. Best-effort.
+ */
+export function clearReviewContext(stateDir: string): void {
+  try {
+    rmSync(contextPath(stateDir), { force: true });
+  } catch {
+    /* nothing to do */
+  }
+}

--- a/tests/reconcile-hooks-drift.test.ts
+++ b/tests/reconcile-hooks-drift.test.ts
@@ -133,6 +133,15 @@ describe("buildSettingsHooksBlock", () => {
       e.hooks.some(h => h.command.includes("repo-context-pretool.mjs")),
     );
     expect(repoContextEntry?.matcher).toBe("^(Read|Edit|Write|MultiEdit|NotebookEdit|Bash)$");
+
+    // RFC agent-self-improvement slice 2: the deterministic apply-guard
+    // PreToolUse hook is registered and scoped to the file-write tools (it
+    // no-ops unless a self-improve review marker is present).
+    expect(preCmds.some(c => c.includes("self-improve-apply-guard-pretool.mjs"))).toBe(true);
+    const applyGuardEntry = preHooks.find(e =>
+      e.hooks.some(h => h.command.includes("self-improve-apply-guard-pretool.mjs")),
+    );
+    expect(applyGuardEntry?.matcher).toBe("^(Write|Edit|MultiEdit)$");
   });
 
   it("with user hooks declared merges them with switchroom-owned hooks", () => {

--- a/tests/self-improve-apply-guard-pretool.test.ts
+++ b/tests/self-improve-apply-guard-pretool.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+
+import { benchmarkJsonForSkill } from "../src/self-improve/apply-guard.js";
+import { evalsJsonPath } from "../src/self-improve/eval-gate.js";
+import { writeReviewContext } from "../src/self-improve/review-context.js";
+import { readPending } from "../src/self-improve/pending-queue.js";
+import { appliesToday } from "../src/self-improve/rate-limit.js";
+
+// Drive the hook through `bun` against source (mirrors the stop-hook test)
+// so it doesn't depend on build order. Skip cleanly if bun is absent.
+const bunOk = spawnSync("which", ["bun"], { encoding: "utf-8" }).status === 0;
+const HOOK = join(process.cwd(), "src", "cli", "self-improve-apply-guard-pretool.ts");
+
+const SLUG = "myskill";
+let agentDir: string;
+let stateDir: string;
+
+function skillDir(): string {
+  return join(agentDir, ".claude", "skills", SLUG);
+}
+function skillFile(): string {
+  return join(skillDir(), "SKILL.md");
+}
+function makeOwnedSkill(withEvals: boolean): void {
+  mkdirSync(skillDir(), { recursive: true });
+  if (withEvals) {
+    mkdirSync(dirname(evalsJsonPath(skillDir())), { recursive: true });
+    writeFileSync(
+      evalsJsonPath(skillDir()),
+      JSON.stringify({ skill_name: SLUG, evals: [{ name: "e1", prompt: "p" }] }),
+    );
+  }
+}
+function writeBenchmark(candidate: number, baseline: number): void {
+  const p = benchmarkJsonForSkill(stateDir, SLUG);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(
+    p,
+    JSON.stringify({
+      run_summary: {
+        with_skill: { pass_rate: { mean: candidate, stddev: 0.0 } },
+        without_skill: { pass_rate: { mean: baseline, stddev: 0.0 } },
+      },
+    }),
+  );
+}
+function putMarker(): void {
+  writeReviewContext(stateDir, {
+    // Past timestamp so a benchmark written 'now' counts as fresh.
+    created_at: new Date(Date.now() - 60_000).toISOString(),
+    triggering_session: "sess-1",
+    chat_id: "c",
+    signals: [],
+  });
+}
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+function run(toolName: string, filePath: string, content: string, env: Record<string, string> = {}): RunResult {
+  const payload = JSON.stringify({
+    tool_name: toolName,
+    tool_input: { file_path: filePath, content },
+  });
+  const r = spawnSync("bun", [HOOK], {
+    input: payload,
+    encoding: "utf-8",
+    env: { ...process.env, TELEGRAM_STATE_DIR: stateDir, ...env },
+  });
+  return { status: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+beforeEach(() => {
+  agentDir = mkdtempSync(join(tmpdir(), "self-improve-pt-agent-"));
+  stateDir = mkdtempSync(join(tmpdir(), "self-improve-pt-state-"));
+});
+afterEach(() => {
+  for (const d of [agentDir, stateDir]) {
+    if (d && existsSync(d)) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe("self-improve apply-guard PreToolUse hook", () => {
+  it("no marker present → allow (no-op on a normal turn)", () => {
+    if (!bunOk) return;
+    makeOwnedSkill(false); // no marker written
+    const r = run("Write", skillFile(), "anything\n");
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe(""); // allow = empty stdout
+  });
+
+  it("kill switch SWITCHROOM_SELF_IMPROVE=0 → allow even with a marker", () => {
+    if (!bunOk) return;
+    makeOwnedSkill(false);
+    putMarker();
+    const r = run("Write", skillFile(), "x\n", { SWITCHROOM_SELF_IMPROVE: "0" });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("");
+  });
+
+  it("marker + owned skill + evals-passing + fresh benchmark → allow, records an apply", () => {
+    if (!bunOk) return;
+    makeOwnedSkill(true);
+    writeBenchmark(1.0, 0.9);
+    putMarker();
+    const r = run("Write", skillFile(), "small\nedit\n");
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe(""); // allowed
+    expect(appliesToday(stateDir)).toBe(1); // one auto-apply recorded
+    expect(readPending(stateDir)).toEqual([]); // nothing downgraded
+  });
+
+  it("marker + owned skill but NO evals → block + downgrade to a pending proposal", () => {
+    if (!bunOk) return;
+    makeOwnedSkill(false); // no evals.json
+    putMarker();
+    const r = run("Write", skillFile(), "x\n");
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('"decision":"block"');
+    expect(r.stdout.toLowerCase()).toContain("no evals");
+    const pending = readPending(stateDir);
+    expect(pending.length).toBe(1);
+    expect(pending[0]?.skill_slug).toBe(SLUG);
+    expect(appliesToday(stateDir)).toBe(0); // blocked → no apply recorded
+  });
+
+  it("marker present but a non-skill write → allow (out of scope)", () => {
+    if (!bunOk) return;
+    makeOwnedSkill(true);
+    putMarker();
+    const r = run("Write", join(agentDir, "notes.md"), "hello\n");
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("");
+  });
+});

--- a/tests/self-improve-apply-guard.test.ts
+++ b/tests/self-improve-apply-guard.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+
+import {
+  decideApply,
+  parseSkillTarget,
+  ownsSkill,
+  estimateChangedLines,
+  benchmarkJsonForSkill,
+  skillTargetEscapes,
+} from "../src/self-improve/apply-guard.js";
+import { evalsJsonPath } from "../src/self-improve/eval-gate.js";
+import { recordAutoApply } from "../src/self-improve/rate-limit.js";
+import type { SelfImproveConfig } from "../src/self-improve/config.js";
+
+const CFG: SelfImproveConfig = {
+  repetitionThreshold: 2,
+  t1MaxChangedLines: 30,
+  maxAutoAppliesPerDay: 3,
+  maxOutstandingPending: 5,
+};
+
+const NOW = 1_700_000_000_000;
+const now = (): number => NOW;
+
+let agentDir: string;
+let stateDir: string;
+const SLUG = "myskill";
+
+function skillDir(): string {
+  return join(agentDir, ".claude", "skills", SLUG);
+}
+function skillFile(rel = "SKILL.md"): string {
+  return join(skillDir(), rel);
+}
+
+function makeOwnedSkill(withEvals: boolean): void {
+  mkdirSync(skillDir(), { recursive: true });
+  if (withEvals) {
+    mkdirSync(dirname(evalsJsonPath(skillDir())), { recursive: true });
+    writeFileSync(
+      evalsJsonPath(skillDir()),
+      JSON.stringify({ skill_name: SLUG, evals: [{ name: "e1", prompt: "p" }] }),
+    );
+  }
+}
+
+function writeBenchmark(candidate: number, baseline: number): void {
+  const p = benchmarkJsonForSkill(stateDir, SLUG);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(
+    p,
+    JSON.stringify({
+      run_summary: {
+        with_skill: { pass_rate: { mean: candidate, stddev: 0.0 } },
+        without_skill: { pass_rate: { mean: baseline, stddev: 0.0 } },
+      },
+    }),
+  );
+}
+
+beforeEach(() => {
+  agentDir = mkdtempSync(join(tmpdir(), "self-improve-agent-"));
+  stateDir = mkdtempSync(join(tmpdir(), "self-improve-state-"));
+});
+afterEach(() => {
+  for (const d of [agentDir, stateDir]) {
+    if (d && existsSync(d)) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe("apply-guard helpers", () => {
+  it("parseSkillTarget extracts slug + relPath + skillDir", () => {
+    const t = parseSkillTarget("/home/a/.claude/skills/foo/scripts/x.sh");
+    expect(t).not.toBeNull();
+    expect(t?.slug).toBe("foo");
+    expect(t?.relPath).toBe("scripts/x.sh");
+    expect(t?.skillDir).toBe("/home/a/.claude/skills/foo");
+  });
+
+  it("parseSkillTarget returns null for non-skill paths and bare slug dirs", () => {
+    expect(parseSkillTarget("/home/a/notes/x.md")).toBeNull();
+    expect(parseSkillTarget("/home/a/.claude/skills/foo")).toBeNull(); // no rel
+    expect(parseSkillTarget("")).toBeNull();
+  });
+
+  it("ownsSkill: true for a real dir, false for a symlink or missing", () => {
+    makeOwnedSkill(false);
+    expect(ownsSkill(skillDir())).toBe(true);
+
+    const link = join(agentDir, ".claude", "skills", "linked");
+    symlinkSync(skillDir(), link);
+    expect(ownsSkill(link)).toBe(false); // shared/bundled pool symlink
+
+    expect(ownsSkill(join(agentDir, ".claude", "skills", "ghost"))).toBe(false);
+  });
+
+  it("skillTargetEscapes flags traversal / unsafe slugs, allows clean paths", () => {
+    const dir = "/h/.claude/skills/foo";
+    expect(skillTargetEscapes({ skillDir: dir, slug: "foo", relPath: "SKILL.md" })).toBe(false);
+    expect(skillTargetEscapes({ skillDir: dir, slug: "foo", relPath: "scripts/x.sh" })).toBe(false);
+    // traversal in relPath
+    expect(skillTargetEscapes({ skillDir: dir, slug: "foo", relPath: "../../../etc/passwd" })).toBe(true);
+    expect(skillTargetEscapes({ skillDir: dir, slug: "foo", relPath: "a/../../b" })).toBe(true);
+    // unsafe slug (".." bundle name → escapes the skills root)
+    expect(skillTargetEscapes({ skillDir: "/h/.claude/skills/..", slug: "..", relPath: "settings.json" })).toBe(true);
+    // empty / null-byte segments
+    expect(skillTargetEscapes({ skillDir: dir, slug: "foo", relPath: "a//b" })).toBe(true);
+  });
+
+  it("estimateChangedLines counts Write/Edit/MultiEdit diffs", () => {
+    // New file Write: every content line is added.
+    expect(estimateChangedLines("Write", { content: "a\nb\nc" }, "/nope")).toBe(3);
+    // Edit: one line changes → 1 added + 1 removed.
+    expect(
+      estimateChangedLines("Edit", { old_string: "x\ny", new_string: "x\nz" }, "/nope"),
+    ).toBe(2);
+    // MultiEdit sums across edits.
+    expect(
+      estimateChangedLines(
+        "MultiEdit",
+        { edits: [{ old_string: "a", new_string: "b" }, { old_string: "c", new_string: "c\nd" }] },
+        "/nope",
+      ),
+    ).toBe(3);
+  });
+});
+
+describe("decideApply — the deterministic T1 gate", () => {
+  it("ALLOWS a small, owned, evals-passing edit under the rate cap", () => {
+    makeOwnedSkill(true);
+    writeBenchmark(1.0, 0.9);
+    const d = decideApply({
+      toolName: "Write",
+      input: { content: "line1\nline2\n" },
+      filePath: skillFile(),
+      stateDir,
+      cfg: CFG,
+      now,
+    });
+    expect(d.action).toBe("allow");
+    if (d.action === "allow") {
+      expect(d.tier).toBe("T1");
+      expect(d.candidatePassRate).toBe(1.0);
+      expect(d.changedLines).toBeLessThanOrEqual(CFG.t1MaxChangedLines);
+    }
+  });
+
+  it("BLOCKS (T2) a skill the agent does not own", () => {
+    makeOwnedSkill(true);
+    writeBenchmark(1.0, 0.9);
+    const d = decideApply({
+      toolName: "Write",
+      input: { content: "x\n" },
+      filePath: skillFile(),
+      stateDir,
+      cfg: CFG,
+      now,
+      ownsSkillFn: () => false,
+    });
+    expect(d.action).toBe("block");
+    if (d.action === "block") {
+      expect(d.downgradeTier).toBe("T2");
+      expect(d.reason).toMatch(/not a T1/i);
+    }
+  });
+
+  it("BLOCKS (T2) an edit over the diff cap", () => {
+    makeOwnedSkill(true);
+    writeBenchmark(1.0, 0.9);
+    const big = Array.from({ length: 50 }, (_, i) => `l${i}`).join("\n");
+    const d = decideApply({
+      toolName: "Write",
+      input: { content: big },
+      filePath: skillFile(),
+      stateDir,
+      cfg: CFG,
+      now,
+    });
+    expect(d.action).toBe("block");
+    if (d.action === "block") expect(d.downgradeTier).toBe("T2");
+  });
+
+  it("BLOCKS (T2) when the skill has no evals.json", () => {
+    makeOwnedSkill(false); // no evals
+    writeBenchmark(1.0, 0.9);
+    const d = decideApply({
+      toolName: "Write",
+      input: { content: "x\n" },
+      filePath: skillFile(),
+      stateDir,
+      cfg: CFG,
+      now,
+    });
+    expect(d.action).toBe("block");
+    if (d.action === "block") expect(d.reason).toMatch(/no evals/i);
+  });
+
+  it("BLOCKS (T2) when no benchmark exists (eval did not run)", () => {
+    makeOwnedSkill(true); // evals present, but no benchmark written
+    const d = decideApply({
+      toolName: "Write",
+      input: { content: "x\n" },
+      filePath: skillFile(),
+      stateDir,
+      cfg: CFG,
+      now,
+    });
+    expect(d.action).toBe("block");
+    if (d.action === "block") expect(d.reason).toMatch(/no eval result/i);
+  });
+
+  it("BLOCKS (T2) when the benchmark regresses / fails the floor", () => {
+    makeOwnedSkill(true);
+    writeBenchmark(0.5, 1.0); // candidate below the 1.0 floor
+    const d = decideApply({
+      toolName: "Write",
+      input: { content: "x\n" },
+      filePath: skillFile(),
+      stateDir,
+      cfg: CFG,
+      now,
+    });
+    expect(d.action).toBe("block");
+    if (d.action === "block") expect(d.reason).toMatch(/eval gate blocked/i);
+  });
+
+  it("BLOCKS (T2) when a stale benchmark predates the review", () => {
+    makeOwnedSkill(true);
+    writeBenchmark(1.0, 0.9); // written 'now' in wall-clock
+    const d = decideApply({
+      toolName: "Write",
+      input: { content: "x\n" },
+      filePath: skillFile(),
+      stateDir,
+      cfg: CFG,
+      now,
+      // Freshness floor far in the future → the on-disk benchmark is "stale".
+      freshAfterMs: Date.now() + 60_000,
+    });
+    expect(d.action).toBe("block");
+    if (d.action === "block") expect(d.reason).toMatch(/stale/i);
+  });
+
+  it("BLOCKS a path-traversal write even for an owned, evals-passing skill", () => {
+    makeOwnedSkill(true);
+    writeBenchmark(1.0, 0.9);
+    // String-concat (not join) so the literal ".." survives into the path.
+    const evil = skillFile().replace(/SKILL\.md$/, "../../evil.md");
+    const d = decideApply({
+      toolName: "Write",
+      input: { content: "x\n" },
+      filePath: evil,
+      stateDir,
+      cfg: CFG,
+      now,
+    });
+    expect(d.action).toBe("block");
+    if (d.action === "block") expect(d.reason).toMatch(/escapes the bundle/i);
+  });
+
+  it("BLOCKS (T2) once the daily auto-apply cap is reached", () => {
+    makeOwnedSkill(true);
+    writeBenchmark(1.0, 0.9);
+    for (let i = 0; i < CFG.maxAutoAppliesPerDay; i++) recordAutoApply(stateDir, now);
+    const d = decideApply({
+      toolName: "Write",
+      input: { content: "x\n" },
+      filePath: skillFile(),
+      stateDir,
+      cfg: CFG,
+      now,
+    });
+    expect(d.action).toBe("block");
+    if (d.action === "block") expect(d.reason).toMatch(/cap reached/i);
+  });
+});

--- a/tests/self-improve-review-context.test.ts
+++ b/tests/self-improve-review-context.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  writeReviewContext,
+  readReviewContext,
+  reviewIsPending,
+  clearReviewContext,
+  REVIEW_CONTEXT_FILE,
+  type ReviewContext,
+} from "../src/self-improve/review-context.js";
+
+let stateDir: string;
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "self-improve-ctx-"));
+});
+afterEach(() => {
+  if (stateDir && existsSync(stateDir)) rmSync(stateDir, { recursive: true, force: true });
+});
+
+const sample: ReviewContext = {
+  created_at: new Date(1_700_000_000_000).toISOString(),
+  triggering_session: "sess-123",
+  chat_id: "12345",
+  signals: [
+    {
+      kind: "operator-correction",
+      reason: "operator corrected the same thing twice",
+      occurrences: 2,
+      evidence: "no, not that",
+    },
+  ],
+};
+
+describe("self-improve review-context marker", () => {
+  it("is absent on a fresh state dir", () => {
+    expect(readReviewContext(stateDir)).toBeNull();
+    expect(reviewIsPending(stateDir)).toBe(false);
+  });
+
+  it("write → read round-trips the marker", () => {
+    writeReviewContext(stateDir, sample);
+    expect(existsSync(join(stateDir, REVIEW_CONTEXT_FILE))).toBe(true);
+    const got = readReviewContext(stateDir);
+    expect(got).not.toBeNull();
+    expect(got?.created_at).toBe(sample.created_at);
+    expect(got?.triggering_session).toBe("sess-123");
+    expect(got?.signals.map((s) => s.kind)).toEqual(["operator-correction"]);
+    expect(reviewIsPending(stateDir)).toBe(true);
+  });
+
+  it("creates the state dir if missing", () => {
+    const nested = join(stateDir, "deep", "nested");
+    writeReviewContext(nested, sample);
+    expect(reviewIsPending(nested)).toBe(true);
+  });
+
+  it("clear removes the marker (so enforcement stops after the review turn)", () => {
+    writeReviewContext(stateDir, sample);
+    expect(reviewIsPending(stateDir)).toBe(true);
+    clearReviewContext(stateDir);
+    expect(reviewIsPending(stateDir)).toBe(false);
+    expect(readReviewContext(stateDir)).toBeNull();
+  });
+
+  it("clear on an absent marker is a no-op (best-effort)", () => {
+    expect(() => clearReviewContext(stateDir)).not.toThrow();
+  });
+
+  it("treats a malformed marker as absent (fail-open)", () => {
+    writeFileSync(join(stateDir, REVIEW_CONTEXT_FILE), "{ not json", "utf-8");
+    expect(readReviewContext(stateDir)).toBeNull();
+    expect(reviewIsPending(stateDir)).toBe(false);
+  });
+
+  it("defaults signals to [] when the marker omits them", () => {
+    writeFileSync(
+      join(stateDir, REVIEW_CONTEXT_FILE),
+      JSON.stringify({ created_at: sample.created_at, triggering_session: "s", chat_id: "c" }),
+      "utf-8",
+    );
+    const got = readReviewContext(stateDir);
+    expect(got).not.toBeNull();
+    expect(got?.signals).toEqual([]);
+  });
+});

--- a/tests/self-improve-stop-hook.test.ts
+++ b/tests/self-improve-stop-hook.test.ts
@@ -5,6 +5,12 @@ import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { buildReviewPrompt } from "../src/self-improve/review-prompt.js";
+import {
+  writeReviewContext,
+  reviewIsPending,
+} from "../src/self-improve/review-context.js";
+
 // Drive the hook through `bun` against source (mirrors
 // tests/skill-validate-pretool.test.ts) so the test doesn't depend on
 // build order. Skip cleanly if bun is absent.
@@ -149,5 +155,46 @@ describe("self-improve-stop hook — fires the forked review on a real signal", 
       SWITCHROOM_GATEWAY_SOCKET: socketPath, // no server listening — connect would fail anyway
     });
     expect(r.status).toBe(0);
+  });
+
+  it("clears the review-context marker at the end of a REAL review turn (regression: no leak)", () => {
+    if (!bunOk) return;
+    const stateDir = mkdtempSync(join(tmpdir(), "self-improve-stop-marker-"));
+    try {
+      // Arm the marker exactly as the Stop hook would at injection time.
+      writeReviewContext(stateDir, {
+        created_at: new Date(Date.now() - 60_000).toISOString(),
+        triggering_session: "prev",
+        chat_id: "c",
+        signals: [],
+      });
+      expect(reviewIsPending(stateDir)).toBe(true);
+
+      // A real review turn: the last user message is the ACTUAL review
+      // prompt (built from a benign signal). It trips NO gate signal — the
+      // precise case the leak bug missed — yet the marker must still clear,
+      // because review-turn detection now runs BEFORE the gate check.
+      const prompt = buildReviewPrompt([
+        {
+          kind: "directive-not-bound",
+          reason: "standing rule not honoured",
+          occurrences: 2,
+          evidence: "always exclude drafts",
+        },
+      ]);
+      const tp = writeTranscript("real-review.jsonl", [
+        { role: "user", text: prompt },
+        { role: "assistant", text: "Edited the skill and recorded the change." },
+      ]);
+      const r = run(JSON.stringify({ session_id: "rev", transcript_path: tp }), {
+        SWITCHROOM_AGENT_NAME: "test-agent",
+        TELEGRAM_STATE_DIR: stateDir,
+        SWITCHROOM_GATEWAY_SOCKET: join(tmp, "no-server.sock"),
+      });
+      expect(r.status).toBe(0);
+      expect(reviewIsPending(stateDir)).toBe(false); // marker cleared — no leak
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Stacked on #2453 (slice 1). Closes the **T1 auto-apply loop** that slice 1 only decided. The safety is enforced in **code**, not in the review prompt.

## What this delivers
- **Deterministic apply-guard** (`src/self-improve/apply-guard.ts`) — `decideApply()` enforces, per skill-file write: own-skill ∧ single-file ∧ diff-cap ∧ evals-present ∧ evals-pass (no baseline regression) ∧ under the daily auto-apply cap. The first failing check **blocks the write and downgrades** to a T2/T3 pending proposal. Reuses the slice-1 tier-router / eval-gate / rate-limit / pending-queue (single-sourced).
- **Review-context marker** (`src/self-improve/review-context.ts`) — the seam between the Stop hook and the guard. Written at review injection, cleared when the review turn ends. **No marker → the guard is a strict no-op** (normal turns unaffected).
- **PreToolUse hook** (`src/cli/self-improve-apply-guard-pretool.ts`) — fail-**open** on a normal turn / parse error / non-skill write; fail-**closed** on the apply path (guard error → block + downgrade). Records one auto-apply against the daily cap on allow.
- **Wiring** — Stop hook writes/clears the marker; `scaffold.ts` registers the guard as a `Write|Edit|MultiEdit` PreToolUse hook; `build.mjs` bundles it; `Dockerfile.agent` bakes it.

## Tests (all green)
- `decideApply` matrix: allow + every downgrade (not-owned, over-cap, no-evals, no-benchmark, regression, stale, rate-cap) + helpers.
- review-context round-trip.
- bun-driven **subprocess** test of the actual hook: no-marker→allow, kill-switch→allow, passing→allow + records apply, no-evals→block + queued, non-skill→allow.
- hook-drift assertion for the new PreToolUse entry.

`tsc` + full lint chain clean; the new hook bundles cleanly. (One pre-existing, unrelated `scaffold.test.ts` `\$HOME=/home/op` start.sh failure — proven to fail identically on the clean base; not caused by this change.)

## Deferred to slice 3
T2/T3 one-tap surfacing (Telegram/Linear) and the proactive recurring-work scan.

## Refs
- RFC `reference/rfcs/agent-self-improvement.md` (#2452)
- Slice 1 #2453