### PR TITLE
fix(telegram): unescape literal \n in mixed real+literal-newline messages (#2456)

### DIFF
--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -563,34 +563,54 @@ function escapeUnescapedEntities(inner: string): string {
  * The message then ships to Telegram intact and the user sees literal
  * `\n\n` in the chat instead of paragraph breaks.
  *
- * Heuristic: if the text contains ZERO real newlines AND has at least one
- * literal `\n`, `\r`, or `\t` escape sequence, the caller almost certainly
- * intended those as real whitespace and the client serializer ate them.
- * Unescape them (also `\\` and `\"`). If the text has any real newline,
- * trust the caller exactly as given and do nothing — legitimate content
- * may contain a literal `\n` inside a shell snippet or regex.
+ * Unescape literal `\n`, `\r`, `\t`, and `\"` sequences everywhere EXCEPT
+ * inside code spans (inline backtick spans and fenced ``` blocks). Those
+ * regions are masked with placeholders before the unescape pass so that a
+ * literal `\n` a user typed inside a shell snippet or regex is preserved
+ * verbatim. The genuine escaped-backslash sequence `\\n` (which the user
+ * intended as a literal backslash + n, not a newline) is handled by
+ * protecting `\\` before touching `\n`.
  *
- * This is intentionally narrow: it only fires on the clear bug signature
- * (multi-line-looking content collapsed to one physical line). False
- * positives on a single-line message that legitimately contains `\n` are
- * possible but rare — users writing single-line shell snippets typically
- * wrap them in backticks, and this runs before markdown→HTML so the
- * unescape has no effect on text inside fenced code blocks if it already
- * has real newlines around them.
+ * This deliberately fires even when the message contains real newlines —
+ * the old whole-message heuristic ("bail if any real newline exists") was
+ * too broad and prevented repair of mixed messages that had both real
+ * newlines and stray literal `\n` escape sequences outside code spans.
  */
 export function repairEscapedWhitespace(text: string): string {
-  if (text.includes('\n') || text.includes('\r')) return text
   if (!/\\[nrt"\\]/.test(text)) return text
-  // Order matters: protect existing `\\` first so `\\n` stays as `\n`
-  // literal and doesn't become a newline.
+
+  // Mask fenced code blocks (``` ... ```) and inline code spans (` ... `)
+  // so the unescape pass never touches their content.
+  const codeMasks: string[] = []
+  const CODE_MASK_PH = '\x00REPMASK'
+
+  const masked = text
+    // Fenced code blocks first (may span real newlines or literal \n sequences)
+    .replace(/```[\s\S]*?```/g, (m) => {
+      const idx = codeMasks.length
+      codeMasks.push(m)
+      return `${CODE_MASK_PH}${idx}\x00`
+    })
+    // Inline code spans (single backtick, non-greedy, no embedded backticks)
+    .replace(/`[^`]*`/g, (m) => {
+      const idx = codeMasks.length
+      codeMasks.push(m)
+      return `${CODE_MASK_PH}${idx}\x00`
+    })
+
+  // Order matters: protect existing `\\` first so `\\n` stays as a literal
+  // backslash + n and doesn't become a newline.
   const BACKSLASH_PH = '\x00BKSL\x00'
-  return text
+  const unescaped = masked
     .replace(/\\\\/g, BACKSLASH_PH)
     .replace(/\\n/g, '\n')
     .replace(/\\r/g, '\r')
     .replace(/\\t/g, '\t')
     .replace(/\\"/g, '"')
     .replace(new RegExp(BACKSLASH_PH, 'g'), '\\')
+
+  // Restore masked code spans verbatim.
+  return unescaped.replace(new RegExp(`${CODE_MASK_PH}(\\d+)\x00`, 'g'), (_m, idx) => codeMasks[Number(idx)])
 }
 
 // ---------------------------------------------------------------------------

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -579,20 +579,37 @@ function escapeUnescapedEntities(inner: string): string {
 export function repairEscapedWhitespace(text: string): string {
   if (!/\\[nrt"\\]/.test(text)) return text
 
+  // Per-call random nonce prevents sentinel collision: if user text happens to
+  // contain our placeholder bytes, the restore step would look up an out-of-range
+  // index and produce "undefined" in the Telegram output. A nonce that is unique
+  // per invocation makes the sentinel statistically impossible to collide with.
+  const nonce = Math.random().toString(36).slice(2)
+  const CODE_MASK_PH = `\x00RM${nonce}_`
+  const BACKSLASH_PH = `\x00BK${nonce}_`
+
   // Mask fenced code blocks (``` ... ```) and inline code spans (` ... `)
   // so the unescape pass never touches their content.
+  //
+  // Fenced blocks are extracted first. Only CLOSED fenced blocks (with a
+  // matching closing ```) are masked — an unclosed fence is left as-is so the
+  // inline-code pass below won't misparse the two leading backticks as an empty
+  // inline span and expose the block's interior.
+  //
+  // Inline code uses `[^\`\n]+` (one or more non-backtick, non-newline chars)
+  // matching the same definition that markdownToHtml uses, so the masked regions
+  // are consistent with what the downstream pipeline treats as code.
   const codeMasks: string[] = []
-  const CODE_MASK_PH = '\x00REPMASK'
 
   const masked = text
-    // Fenced code blocks first (may span real newlines or literal \n sequences)
+    // Closed fenced code blocks only (``` ... ``` with a matching closer).
     .replace(/```[\s\S]*?```/g, (m) => {
       const idx = codeMasks.length
       codeMasks.push(m)
       return `${CODE_MASK_PH}${idx}\x00`
     })
-    // Inline code spans (single backtick, non-greedy, no embedded backticks)
-    .replace(/`[^`]*`/g, (m) => {
+    // Inline code spans: at least one character between backticks, no embedded
+    // backtick or newline (matches markdownToHtml's /`([^`\n]+)`/ definition).
+    .replace(/`[^`\n]+`/g, (m) => {
       const idx = codeMasks.length
       codeMasks.push(m)
       return `${CODE_MASK_PH}${idx}\x00`
@@ -600,17 +617,17 @@ export function repairEscapedWhitespace(text: string): string {
 
   // Order matters: protect existing `\\` first so `\\n` stays as a literal
   // backslash + n and doesn't become a newline.
-  const BACKSLASH_PH = '\x00BKSL\x00'
   const unescaped = masked
     .replace(/\\\\/g, BACKSLASH_PH)
     .replace(/\\n/g, '\n')
     .replace(/\\r/g, '\r')
     .replace(/\\t/g, '\t')
     .replace(/\\"/g, '"')
-    .replace(new RegExp(BACKSLASH_PH, 'g'), '\\')
+    .replace(new RegExp(BACKSLASH_PH.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), '\\')
 
   // Restore masked code spans verbatim.
-  return unescaped.replace(new RegExp(`${CODE_MASK_PH}(\\d+)\x00`, 'g'), (_m, idx) => codeMasks[Number(idx)])
+  const restoreRe = new RegExp(`${CODE_MASK_PH.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\d+)\x00`, 'g')
+  return unescaped.replace(restoreRe, (_m, idx) => codeMasks[Number(idx)] ?? _m)
 }
 
 // ---------------------------------------------------------------------------

--- a/telegram-plugin/tests/telegram-format.test.ts
+++ b/telegram-plugin/tests/telegram-format.test.ts
@@ -695,12 +695,57 @@ describe('repairEscapedWhitespace', () => {
     expect(isLikelyTelegramHtml(repaired)).toBe(true)
   })
 
-  test('leaves text alone when it already contains real newlines', () => {
-    // If the caller provided real newlines, we trust them completely and
-    // don't touch literal `\n` that may appear inside their content (e.g.
-    // a regex or shell snippet).
-    const input = 'Real newline here\nand a literal \\n in a regex example'
-    expect(repairEscapedWhitespace(input)).toBe(input)
+  test('unescapes literal \\n in prose even when real newlines are present (mixed-message fix, #2456)', () => {
+    // The old implementation bailed entirely when any real newline was present.
+    // The new implementation unescapes literal \\n outside code spans regardless,
+    // so a mixed message (real newlines + stray literal \\n in prose) is repaired.
+    const input = 'Real newline here\nand a literal \\n escape in prose'
+    const out = repairEscapedWhitespace(input)
+    // The literal \n in prose becomes a real newline; the existing real newline is preserved.
+    expect(out).toBe('Real newline here\nand a literal \n escape in prose')
+  })
+
+  test('preserves literal \\n inside inline code span when mixed with real newlines (#2456)', () => {
+    // The structurally safe version: a \\n inside backticks must stay verbatim,
+    // even in a message that also has real newlines and literal \\n in prose.
+    const input = 'First line\nUse `grep -P \\n` for newlines\nand prose \\n here'
+    const out = repairEscapedWhitespace(input)
+    // Inline code span preserved verbatim (\\n inside backticks untouched).
+    expect(out).toContain('`grep -P \\n`')
+    // The literal \\n in prose is unescaped to a real newline.
+    expect(out).toContain('and prose \n here')
+    // The original real newlines are preserved.
+    expect(out).toContain('First line\n')
+  })
+
+  test('preserves literal \\n inside fenced code block (#2456)', () => {
+    // A fenced code block containing a literal \\n (e.g. a regex or shell snippet)
+    // must not be unescaped.
+    const input = 'Prose \\n here\n```bash\necho "line1\\nline2"\n```\nMore \\n prose'
+    const out = repairEscapedWhitespace(input)
+    // The \\n inside the fenced block stays verbatim.
+    expect(out).toContain('```bash\necho "line1\\nline2"\n```')
+    // The \\n in prose is unescaped.
+    expect(out).toContain('Prose \n here')
+    expect(out).toContain('More \n prose')
+  })
+
+  test('pure no-real-newline case still unescapes (backward compat)', () => {
+    // Original pre-#2456 case: message with NO real newlines and literal \\n.
+    const input = 'Line one\\nLine two\\nLine three'
+    expect(repairEscapedWhitespace(input)).toBe('Line one\nLine two\nLine three')
+  })
+
+  test('genuine escaped backslash (\\\\n) stays literal even in mixed-newline message (#2456)', () => {
+    // \\\\n in the source is the two-char sequence \\ then n — the user typed
+    // a backslash followed by the letter n, NOT a newline.  The protect-\\
+    // phase must still work inside mixed messages.
+    const input = 'Windows path: C:\\\\temp\\\\file.txt\\nnext line\nreal newline too'
+    const out = repairEscapedWhitespace(input)
+    // The \\n becomes a real newline.
+    expect(out).toContain('C:\\temp\\file.txt\nnext line')
+    // The real newline is preserved.
+    expect(out).toContain('real newline too')
   })
 
   test('leaves single-line text alone when it has no escape sequences', () => {

--- a/telegram-plugin/tests/telegram-format.test.ts
+++ b/telegram-plugin/tests/telegram-format.test.ts
@@ -785,6 +785,56 @@ describe('repairEscapedWhitespace', () => {
     // Literal \n must not survive anywhere.
     expect(html).not.toContain('\\n')
   })
+
+  // ── Sentinel-collision safety (reviewer blocker) ─────────────────────────
+
+  test('does not produce "undefined" when input contains NUL-byte sequences (#2456)', () => {
+    // A per-call random nonce makes sentinel collision statistically impossible.
+    // Confirm that a message containing NUL bytes (which could match a hardcoded
+    // sentinel) is passed through safely rather than emitting literal "undefined".
+    // We craft a string that would have matched the OLD hardcoded sentinel \x00REPMASK0\x00
+    // to prove it no longer causes corruption.
+    const dangerous = 'hello \x00REPMASK0\x00 world \\n end'
+    const out = repairEscapedWhitespace(dangerous)
+    // Must not produce the string "undefined" in output.
+    expect(out).not.toContain('undefined')
+    // The \\n in prose must be unescaped.
+    expect(out).toContain(' end')
+    expect(out).not.toContain('\\n')
+  })
+
+  // ── Unclosed fenced block (reviewer major) ────────────────────────────────
+
+  test('handles unclosed fenced block gracefully: \\n in trailing content is still unescaped', () => {
+    // An unclosed ``` is not matched by the fenced-block regex (it requires a
+    // closing ```). Content after the unmatched opening is treated as prose, so
+    // literal \\n there gets unescaped — which is the least-surprising outcome
+    // for malformed input (the alternative would be silently swallowing content).
+    const input = 'Prose \\n here\n```bash\necho "line1\\nline2"\n'
+    const out = repairEscapedWhitespace(input)
+    // \\n in prose before the unclosed fence is unescaped.
+    expect(out).toContain('Prose \n here')
+    // The function must not throw and must return a string.
+    expect(typeof out).toBe('string')
+  })
+
+  // ── \\t and CRLF in mixed-newline messages (reviewer gaps) ────────────────
+
+  test('unescapes \\t in prose even when real newlines are also present (#2456)', () => {
+    const input = 'First line\nCol1\\tCol2\\tCol3\nthird'
+    const out = repairEscapedWhitespace(input)
+    expect(out).toContain('Col1\tCol2\tCol3')
+    expect(out).toContain('First line\n')
+    expect(out).toContain('\nthird')
+  })
+
+  test('unescapes \\r in prose when real newlines are also present (#2456)', () => {
+    // A message that mixes real newlines and a literal \\r escape in prose.
+    const input = 'First line\nsome \\r carriage return in prose'
+    const out = repairEscapedWhitespace(input)
+    expect(out).toContain('some \r carriage return in prose')
+    expect(out).toContain('First line\n')
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2456.

## Problem
`repairEscapedWhitespace()` short-circuited the entire repair the moment a message contained any real newline (`if (text.includes('\n') || text.includes('\r')) return text`). A message mixing real newlines with literal `\n`/`\r`/`\t` escape sequences shipped the literal escapes to the user unrepaired.

## Fix
Drop the all-or-nothing gate. Mask fenced code blocks and inline `code` spans into placeholders, run the existing unescape chain over the non-code text only, then restore the masked spans verbatim. Literal `\n` in prose is now always unescaped even when real newlines are present, while literal `\n` inside code is preserved structurally.

## Hardening (from review)
- Collision-proof placeholders: code-mask and backslash placeholders use a per-call `Math.random()` nonce; sentinel regex-escaped in the restore.
- Unclosed fence / empty span: inline regex tightened to match `markdownToHtml`'s own `` /`[^`\n]+`/ `` definition so an empty match can't peel backticks off a triple-backtick opener.

## Tests
Mixed prose; literal `\n` in inline + fenced code preserved; escaped backslash stays literal; `\t`/`\r` mixed-newline; sentinel-collision (NUL input); unclosed fence pass-through. 157 tests pass, tsc clean, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)