### PR TITLE
fix(self-improve): stop the review-gate infinite re-fire loop (#2462)

### DIFF
--- a/src/cli/self-improve-stop.ts
+++ b/src/cli/self-improve-stop.ts
@@ -31,7 +31,11 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 
 import { runGate } from "../self-improve/gate.js";
-import { buildReviewPrompt, REVIEW_SOURCE } from "../self-improve/review-prompt.js";
+import {
+  buildReviewPrompt,
+  isReviewTurn,
+  REVIEW_SOURCE,
+} from "../self-improve/review-prompt.js";
 import { selfImproveEnabled } from "../self-improve/config.js";
 import {
   writeReviewContext,
@@ -231,21 +235,35 @@ function main(): void {
 
   // Review-turn detection FIRST — BEFORE the gate check, and independent of
   // it. A turn we injected is itself a transcript whose most-recent user
-  // message starts with the "[self-improvement review]" banner. On such a
-  // turn we (a) clear the review-context marker so the apply-guard stops
-  // enforcing on later NORMAL turns, and (b) never recurse by reviewing a
-  // review. This MUST run before `!gate.tripped` returns: a well-behaved
-  // review (the review prompt + a benign skill edit) trips NO learning
-  // signal, so if the clear sat after the gate check the marker would leak
-  // after every real review — wrongly blocking later normal-turn edits and,
-  // worse, letting a normal-turn edit auto-apply against a STALE benchmark.
+  // message is the review prompt. On such a turn we (a) clear the
+  // review-context marker so the apply-guard stops enforcing on later NORMAL
+  // turns, and (b) never recurse by reviewing a review. This MUST run before
+  // `!gate.tripped` returns: a well-behaved review (the review prompt + a
+  // benign skill edit) trips NO learning signal, so if the clear sat after
+  // the gate check the marker would leak after every real review — wrongly
+  // blocking later normal-turn edits and, worse, letting a normal-turn edit
+  // auto-apply against a STALE benchmark.
+  //
+  // `isReviewTurn` (not a bare `startsWith`) is load-bearing: the gateway
+  // wraps every injected inbound in a `<channel …>` envelope before it lands
+  // in the transcript, so the banner is NOT at offset 0. The old prefix check
+  // never matched the real shape → the guard never fired → the review
+  // re-injected every turn in an unbounded loop (issue #2462).
   const lastUser = [...messages].reverse().find((m) => m.role === "user");
-  if (lastUser && lastUser.text.startsWith("[self-improvement review]")) {
+  if (lastUser && isReviewTurn(lastUser.text)) {
     clearReviewContext(resolveStateDir());
     process.exit(0);
   }
 
-  const gate = runGate(messages);
+  // Defense in depth (also #2462): never let the gate INGEST our own injected
+  // review prompts. They embed the prior turn's evidence, which the directive
+  // detector would re-count as a fresh "restated rule" — a self-amplifying
+  // feedback loop that climbs past threshold on every pass. Filtering them out
+  // of the scan window keeps the gate measuring the operator's turn, not its
+  // own output, even when a real message and a review inbound batch together
+  // (so `lastUser` above isn't the review and the short-circuit is missed).
+  const scanMessages = messages.filter((m) => !isReviewTurn(m.text));
+  const gate = runGate(scanMessages);
 
   // Cost guarantee: no signal → return immediately, zero added work.
   if (!gate.tripped) process.exit(0);

--- a/src/self-improve/review-prompt.ts
+++ b/src/self-improve/review-prompt.ts
@@ -30,6 +30,43 @@ import { resolveSelfImproveConfig } from "./config.js";
 export const REVIEW_SOURCE = "self_improve_review";
 
 /**
+ * The banner that opens every review prompt. Single source of truth so the
+ * builder (below) and the review-turn DETECTOR (`isReviewTurn`) can never
+ * drift apart — a drift there is exactly what let the re-fire loop through
+ * (the detector matched a string the builder no longer emitted at offset 0).
+ */
+export const REVIEW_BANNER = "[self-improvement review]";
+
+/**
+ * Is `text` the transcript of a review turn WE injected? Used by the Stop
+ * hook to (a) short-circuit so a review never reviews itself, and (b) drop
+ * our own injected prompts from the gate's scan window.
+ *
+ * Robust to the TWO shapes the review prompt takes in a transcript:
+ *   - bare banner — the raw `buildReviewPrompt` output (unit tests, and a
+ *     safety net), where the banner is at offset 0; and
+ *   - channel-wrapped — the REAL runtime shape. The gateway wraps every
+ *     injected inbound in a `<channel source="…" source="self_improve_review"
+ *     …>\n<prompt>` envelope before it lands in the transcript, so the banner
+ *     is NOT at offset 0. The brittle `startsWith(BANNER)` check missed this
+ *     entirely → the guard never fired → the gate re-injected every turn
+ *     (issue #2462). We match our own `meta.source` on the envelope, or the
+ *     banner immediately after the opening tag.
+ */
+export function isReviewTurn(text: string): boolean {
+  if (!text) return false;
+  if (text.startsWith(REVIEW_BANNER)) return true;
+  const env = /^<channel\b[^>]*>/i.exec(text);
+  if (env) {
+    if (env[0].includes(`source="${REVIEW_SOURCE}"`)) return true;
+    if (text.slice(env[0].length).replace(/^\s+/, "").startsWith(REVIEW_BANNER)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Build the review prompt text. `signals` is the gate's output; the
  * prompt is bounded (signals are already capped by the gate).
  */
@@ -38,7 +75,7 @@ export function buildReviewPrompt(signals: LearningSignal[]): string {
   const lines: string[] = [];
 
   lines.push(
-    "[self-improvement review] The turn-end gate detected a learning " +
+    `${REVIEW_BANNER} The turn-end gate detected a learning ` +
       "signal — a correction or pattern that should bind on future runs. " +
       "Run a focused, forked review. Use ONLY memory tools (recall/retain/" +
       "directives) and skill read/write tools (Read/Write/Edit under your " +

--- a/tests/self-improve-review-prompt.test.ts
+++ b/tests/self-improve-review-prompt.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 
-import { buildReviewPrompt, REVIEW_SOURCE } from "../src/self-improve/review-prompt.js";
+import {
+  buildReviewPrompt,
+  isReviewTurn,
+  REVIEW_BANNER,
+  REVIEW_SOURCE,
+} from "../src/self-improve/review-prompt.js";
 import type { LearningSignal } from "../src/self-improve/types.js";
 
 const signals: LearningSignal[] = [
@@ -38,5 +43,48 @@ describe("forked-review prompt", () => {
   it("states that new crons / new skills are never self-served", () => {
     const p = buildReviewPrompt(signals);
     expect(p.toLowerCase()).toContain("never auto-create");
+  });
+
+  it("opens with the shared banner constant (builder/detector single source)", () => {
+    expect(buildReviewPrompt(signals).startsWith(REVIEW_BANNER)).toBe(true);
+  });
+});
+
+describe("isReviewTurn — review-turn detector (issue #2462)", () => {
+  const prompt = buildReviewPrompt(signals);
+
+  it("detects the bare banner shape (unit/legacy)", () => {
+    expect(isReviewTurn(prompt)).toBe(true);
+    expect(isReviewTurn(REVIEW_BANNER + " anything")).toBe(true);
+  });
+
+  it("detects the REAL channel-wrapped runtime shape (the loop bug)", () => {
+    // The gateway wraps every injected inbound in a <channel …> envelope with
+    // our source marker before it lands in the transcript, so the banner is
+    // NOT at offset 0. The old `startsWith(BANNER)` missed this entirely.
+    const wrapped =
+      `<channel source="switchroom-telegram" source="${REVIEW_SOURCE}" ` +
+      `triggering_session="abc123">\n${prompt}`;
+    expect(wrapped.startsWith(REVIEW_BANNER)).toBe(false); // the trap the old code fell into
+    expect(isReviewTurn(wrapped)).toBe(true);
+  });
+
+  it("detects a wrapped turn via the banner even if the source marker moves", () => {
+    const wrapped = `<channel source="switchroom-telegram">\n${prompt}`;
+    expect(isReviewTurn(wrapped)).toBe(true);
+  });
+
+  it("does NOT misfire on a normal operator message or a non-review channel inbound", () => {
+    expect(isReviewTurn("Resolve bug 2462")).toBe(false);
+    expect(isReviewTurn("")).toBe(false);
+    expect(
+      isReviewTurn(
+        `<channel source="switchroom-telegram" source="cron">\nPriority mail watcher tick.`,
+      ),
+    ).toBe(false);
+    // A message that merely mentions the banner mid-text is not a review turn.
+    expect(
+      isReviewTurn("FYI the gate emits a [self-improvement review] turn when it trips."),
+    ).toBe(false);
   });
 });

--- a/tests/self-improve-stop-hook.test.ts
+++ b/tests/self-improve-stop-hook.test.ts
@@ -157,6 +157,99 @@ describe("self-improve-stop hook — fires the forked review on a real signal", 
     expect(r.status).toBe(0);
   });
 
+  // Regression for the infinite re-fire loop (issue #2462). The REAL runtime
+  // shape of an injected review turn is NOT the bare banner — the gateway
+  // wraps it in a `<channel …>` envelope first, so the banner is not at
+  // offset 0. With a live server listening we assert the hook injects
+  // NOTHING: it must recognise the wrapped review turn and short-circuit.
+  it("does NOT re-inject on a CHANNEL-WRAPPED review turn (the loop bug)", async () => {
+    if (!bunOk) return;
+    const socketPath = join(tmp, "gw-wrapped.sock");
+    const received: string[] = [];
+    const server: Server = await new Promise((resolve) => {
+      const s = createServer((conn) => {
+        conn.on("data", (d) => received.push(d.toString("utf-8")));
+      });
+      s.listen(socketPath, () => resolve(s));
+    });
+    try {
+      const prompt = buildReviewPrompt([
+        {
+          kind: "directive-not-bound",
+          reason: "A standing rule was restated 2× — it isn't binding",
+          occurrences: 2,
+          evidence: "Lisa and JDLF emails are always relevant",
+        },
+      ]);
+      // Exactly how the gateway stores it: channel envelope + newline + prompt.
+      const wrapped =
+        `<channel source="switchroom-telegram" source="self_improve_review" ` +
+        `triggering_session="loop">\n${prompt}`;
+      const tp = writeTranscript("wrapped-review.jsonl", [
+        { role: "user", text: wrapped },
+        { role: "assistant", text: "Bound the directive. Ending the turn." },
+      ]);
+      const r = run(JSON.stringify({ session_id: "loop", transcript_path: tp }), {
+        SWITCHROOM_AGENT_NAME: "test-agent",
+        SWITCHROOM_GATEWAY_SOCKET: socketPath,
+      });
+      expect(r.status).toBe(0);
+      await new Promise((res) => setTimeout(res, 200));
+      expect(received.join("")).toBe(""); // no inject — loop broken
+    } finally {
+      await new Promise<void>((res) => server.close(() => res()));
+    }
+  });
+
+  // Defense in depth (issue #2462): even when the review turn is NOT last —
+  // e.g. a wrapped review prompt earlier in the window plus a benign normal
+  // message last — the gate must not COUNT the review prompt's embedded
+  // evidence as a fresh restated rule and re-fire. The scan filter drops our
+  // own injected prompts before the gate runs.
+  it("does NOT re-fire from a review prompt sitting in the scan window", async () => {
+    if (!bunOk) return;
+    const socketPath = join(tmp, "gw-window.sock");
+    const received: string[] = [];
+    const server: Server = await new Promise((resolve) => {
+      const s = createServer((conn) => {
+        conn.on("data", (d) => received.push(d.toString("utf-8")));
+      });
+      s.listen(socketPath, () => resolve(s));
+    });
+    try {
+      // Two wrapped review prompts carrying the SAME directive evidence — left
+      // in the scan, the directive detector would cluster them (count ≥ 2) and
+      // re-fire. They must be filtered out.
+      const mk = (n: number) =>
+        `<channel source="switchroom-telegram" source="self_improve_review" ` +
+        `triggering_session="w${n}">\n` +
+        buildReviewPrompt([
+          {
+            kind: "directive-not-bound",
+            reason: "A standing rule was restated — always dedupe the recipients",
+            occurrences: 2,
+            evidence: "always dedupe the recipients",
+          },
+        ]);
+      const tp = writeTranscript("window-review.jsonl", [
+        { role: "user", text: mk(1) },
+        { role: "assistant", text: "Bound it." },
+        { role: "user", text: mk(2) },
+        { role: "assistant", text: "Already bound." },
+        { role: "user", text: "ok thanks" }, // benign normal turn is last
+      ]);
+      const r = run(JSON.stringify({ session_id: "window", transcript_path: tp }), {
+        SWITCHROOM_AGENT_NAME: "test-agent",
+        SWITCHROOM_GATEWAY_SOCKET: socketPath,
+      });
+      expect(r.status).toBe(0);
+      await new Promise((res) => setTimeout(res, 200));
+      expect(received.join("")).toBe(""); // filtered — no self-amplification
+    } finally {
+      await new Promise<void>((res) => server.close(() => res()));
+    }
+  });
+
   it("clears the review-context marker at the end of a REAL review turn (regression: no leak)", () => {
     if (!bunOk) return;
     const stateDir = mkdtempSync(join(tmpdir(), "self-improve-stop-marker-"));

--- a/tests/self-improve-stop-hook.test.ts
+++ b/tests/self-improve-stop-hook.test.ts
@@ -185,7 +185,17 @@ describe("self-improve-stop hook — fires the forked review on a real signal", 
       const wrapped =
         `<channel source="switchroom-telegram" source="self_improve_review" ` +
         `triggering_session="loop">\n${prompt}`;
+      // The window ALSO carries two genuine operator corrections (which the
+      // scan filter does NOT remove). This pins the short-circuit: if the
+      // `isReviewTurn(lastUser)` guard regressed, the gate would run on those
+      // corrections, trip, and inject — so the "no inject" assertion would
+      // fail. (Without these, a single sub-threshold directive made the test
+      // pass even against the buggy `startsWith` guard — a hollow regression.)
       const tp = writeTranscript("wrapped-review.jsonl", [
+        { role: "user", text: "No, that's wrong — you included drafts again." },
+        { role: "assistant", text: "Fixed." },
+        { role: "user", text: "That's not what I asked, I told you to exclude drafts." },
+        { role: "assistant", text: "Understood." },
         { role: "user", text: wrapped },
         { role: "assistant", text: "Bound the directive. Ending the turn." },
       ]);


### PR DESCRIPTION
## Summary

Fixes the self-improve review-gate **infinite re-fire loop** (#2462). Closes #2462.

The Stop hook tried to avoid reviewing its own injected review turn with:

```ts
lastUser.text.startsWith("[self-improvement review]")
```

But the gateway wraps every injected inbound in a `<channel …>` envelope before it lands in the transcript (verified live: stored as `<channel source="switchroom-telegram" source="self_improve_review" …>\n[self-improvement review] …`). The banner is therefore **never at offset 0**, the guard never matched, and the gate re-injected a review every single turn. Worse, each re-fire left the prior review prompt in the 40-message scan window, so the directive detector re-counted its own embedded `evidence:` line as a freshly "restated rule" — the count climbed unbounded (observed on agent `clerk`: 2× → 30×+, with the telltale `evidence: evidence: evidence: …` growth).

## Why

- **Root cause (loop):** brittle `startsWith` on a value that is always channel-wrapped at runtime. The pre-merge test used the *bare* banner string, so it never exercised the real shape — that's how it slipped through.
- **Root cause (climbing count):** the gate ingests its own output. Self-injected review prompts in the scan window are counted as operator turns.

## What changed

- **`isReviewTurn(text)`** in `review-prompt.ts` — robust detection of both shapes: the bare banner (unit/legacy + safety net) and the real channel-wrapped form (matched by our `meta.source` marker on the envelope, or the banner immediately after the opening tag). Used by the Stop hook's short-circuit.
- **Shared `REVIEW_BANNER` constant** — single source of truth so the prompt builder and the detector can't drift (the exact failure mode here).
- **Scan-window filter** in `self-improve-stop.ts` — drops self-injected review prompts before `runGate`, so their embedded evidence can never be re-counted as a fresh signal. This also covers the batched case (a real message + a review inbound arriving together, where `lastUser` isn't the review and the short-circuit is missed).

No behaviour change for the cost guarantee or the real-signal path — a clean turn still returns immediately; a genuine operator correction still fires the review exactly once.

## Test plan

- [x] `isReviewTurn` unit tests: bare banner, channel-wrapped (source-marker + banner-after-tag), and negative cases (normal message, non-review channel inbound, banner mentioned mid-text). Asserts the wrapped form is NOT caught by the old `startsWith` (pins the trap).
- [x] Stop-hook integration: drives the hook with the **channel-wrapped** review turn against a live socket and asserts **zero** re-injection (the loop regression).
- [x] Stop-hook integration: two wrapped review prompts in the scan window + a benign last message → asserts no re-fire (scan filter / self-amplification).
- [x] Full self-improve suite: 81/81 green. `tsc --noEmit` clean.

## Risk

Low. Detection is strictly more permissive than before for review turns (it now actually matches them) and strictly narrower for the gate's input (drops only our own injected prompts, never operator messages). Kill switch (`SWITCHROOM_SELF_IMPROVE=0`) and the marker-clear ordering from the slice-2 fix are unchanged.

## Note

This is the deployed slice merged in #2452/#2453/#2454. After merge, running agents need a restart to pick up the rebuilt hook; the immediate mitigation for an agent already looping is `SWITCHROOM_SELF_IMPROVE=0` + gateway bounce.
