### PR TITLE
fix(self-improve): break the review-gate infinite re-fire loop (#2462)

### DIFF
--- a/src/cli/self-improve-stop.ts
+++ b/src/cli/self-improve-stop.ts
@@ -31,11 +31,17 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 
 import { runGate } from "../self-improve/gate.js";
-import { buildReviewPrompt, REVIEW_SOURCE } from "../self-improve/review-prompt.js";
+import {
+  buildReviewPrompt,
+  REVIEW_SOURCE,
+  isReviewInjectedText,
+} from "../self-improve/review-prompt.js";
 import { selfImproveEnabled } from "../self-improve/config.js";
 import {
   writeReviewContext,
   clearReviewContext,
+  hasFiredForSession,
+  markFiredForSession,
 } from "../self-improve/review-context.js";
 import type { TurnMessage } from "../self-improve/types.js";
 
@@ -231,21 +237,36 @@ function main(): void {
 
   // Review-turn detection FIRST — BEFORE the gate check, and independent of
   // it. A turn we injected is itself a transcript whose most-recent user
-  // message starts with the "[self-improvement review]" banner. On such a
-  // turn we (a) clear the review-context marker so the apply-guard stops
-  // enforcing on later NORMAL turns, and (b) never recurse by reviewing a
-  // review. This MUST run before `!gate.tripped` returns: a well-behaved
-  // review (the review prompt + a benign skill edit) trips NO learning
-  // signal, so if the clear sat after the gate check the marker would leak
-  // after every real review — wrongly blocking later normal-turn edits and,
-  // worse, letting a normal-turn edit auto-apply against a STALE benchmark.
-  const lastUser = [...messages].reverse().find((m) => m.role === "user");
-  if (lastUser && lastUser.text.startsWith("[self-improvement review]")) {
+  // message is the review prompt. On such a turn we (a) clear the
+  // review-context marker so the apply-guard stops enforcing on later NORMAL
+  // turns, and (b) never recurse by reviewing a review. This MUST run before
+  // `!gate.tripped` returns: a well-behaved review (the review prompt + a
+  // benign skill edit) trips NO learning signal, so if the clear sat after
+  // the gate check the marker would leak after every real review.
+  //
+  // The injected inbound returns CHANNEL-WRAPPED, so its transcript text is
+  //   <channel source="self_improve_review" ...>[self-improvement review] …</channel>
+  // NOT the bare banner. The old `startsWith("[self-improvement review]")`
+  // never matched the wrapped form → infinite re-fire loop (issue #2462).
+  // `isReviewInjectedText` matches the channel envelope's REVIEW_SOURCE and
+  // the banner substring, catching both forms. We also no longer rely on the
+  // *last* user message only: if ANY recent user message is a review we
+  // injected, this is (or follows) a review turn — guard it.
+  if (messages.some((m) => m.role === "user" && isReviewInjectedText(m.text))) {
     clearReviewContext(resolveStateDir());
     process.exit(0);
   }
 
-  const gate = runGate(messages);
+  // Layer 2: drop any self-injected review turns from the gate scan, so the
+  // review prompt's own embedded evidence can never re-count as a signal
+  // (the climbing-count amplifier in issue #2462). Belt-and-suspenders with
+  // the guard above — even if a review slips past detection, its content is
+  // never fed back into runGate.
+  const scanMessages = messages.filter(
+    (m) => !(m.role === "user" && isReviewInjectedText(m.text)),
+  );
+
+  const gate = runGate(scanMessages);
 
   // Cost guarantee: no signal → return immediately, zero added work.
   if (!gate.tripped) process.exit(0);
@@ -253,12 +274,19 @@ function main(): void {
   const agentName = process.env.SWITCHROOM_AGENT_NAME ?? "";
   if (!agentName) process.exit(0); // can't route without identity — fail-open
 
+  // Layer 3 — per-session re-fire breaker (issue #2462). Once we've injected
+  // a review for THIS session, never inject again for the same session, even
+  // if the review-turn guard above regresses. One tripped session yields at
+  // most one review. Persisted in a sibling state file keyed by session_id.
+  const stateDir = resolveStateDir();
+  if (hasFiredForSession(stateDir, sessionId)) process.exit(0);
+
   // Drop the review-context marker BEFORE injecting, so the apply-guard in
   // the forked review turn enforces the deterministic T1 gate on any skill
   // edit the review attempts. Best-effort: a marker failure must not stop
   // the review from being injected (the guard then simply no-ops).
   try {
-    writeReviewContext(resolveStateDir(), {
+    writeReviewContext(stateDir, {
       created_at: new Date().toISOString(),
       triggering_session: sessionId,
       chat_id: resolveChatId(),
@@ -267,6 +295,11 @@ function main(): void {
   } catch {
     /* marker best-effort; review still injects */
   }
+
+  // Arm the per-session breaker BEFORE injecting — so the very next Stop in
+  // this session (e.g. the review turn itself) is blocked from re-firing
+  // regardless of guard/scan behaviour.
+  markFiredForSession(stateDir, sessionId);
 
   const prompt = buildReviewPrompt(gate.signals);
   injectReview(agentName, prompt, sessionId);

--- a/src/self-improve/review-context.ts
+++ b/src/self-improve/review-context.ts
@@ -36,6 +36,18 @@ import type { LearningSignal } from "./types.js";
 
 export const REVIEW_CONTEXT_FILE = "self-improve-review-context.json";
 
+/**
+ * Sibling state file recording which sessions have already had a review
+ * INJECTED. Belt-and-suspenders per-session re-fire breaker (issue #2462):
+ * once a review fires for a given session, a subsequent Stop in that same
+ * session must NOT inject again, even if the review-turn guard logic
+ * regresses. Keyed by `session_id`; bounded so it can't grow unbounded.
+ */
+export const FIRED_SESSIONS_FILE = "self-improve-fired-sessions.json";
+
+/** Cap on remembered fired sessions (newest kept). */
+const FIRED_SESSIONS_MAX = 200;
+
 export interface ReviewContext {
   /** ISO timestamp the review was injected. */
   created_at: string;
@@ -97,5 +109,58 @@ export function clearReviewContext(stateDir: string): void {
     rmSync(contextPath(stateDir), { force: true });
   } catch {
     /* nothing to do */
+  }
+}
+
+function firedSessionsPath(stateDir: string): string {
+  return join(stateDir, FIRED_SESSIONS_FILE);
+}
+
+/** Read the recorded fired-session ids (newest last), or [] on any error. */
+function readFiredSessions(stateDir: string): string[] {
+  const p = firedSessionsPath(stateDir);
+  if (!existsSync(p)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(p, "utf-8")) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed.filter((x): x is string => typeof x === "string");
+    }
+  } catch {
+    /* malformed — treat as empty */
+  }
+  return [];
+}
+
+/**
+ * True iff a review has ALREADY been injected for this session. The Stop
+ * hook consults this before injecting, so one tripped session yields at
+ * most one review even if the review-turn guard misses (issue #2462).
+ */
+export function hasFiredForSession(stateDir: string, sessionId: string): boolean {
+  if (!sessionId || sessionId === "unknown") return false;
+  return readFiredSessions(stateDir).includes(sessionId);
+}
+
+/**
+ * Record that a review has been injected for `sessionId`. Best-effort,
+ * deduped, and bounded to the most recent `FIRED_SESSIONS_MAX` ids.
+ */
+export function markFiredForSession(stateDir: string, sessionId: string): void {
+  if (!sessionId || sessionId === "unknown") return;
+  try {
+    if (!existsSync(stateDir)) {
+      mkdirSync(stateDir, { recursive: true, mode: 0o755 });
+    }
+    const seen = readFiredSessions(stateDir).filter((s) => s !== sessionId);
+    seen.push(sessionId);
+    const bounded =
+      seen.length > FIRED_SESSIONS_MAX ? seen.slice(-FIRED_SESSIONS_MAX) : seen;
+    writeFileSync(
+      firedSessionsPath(stateDir),
+      JSON.stringify(bounded),
+      "utf-8",
+    );
+  } catch {
+    /* best-effort breaker; injection still proceeds */
   }
 }

--- a/src/self-improve/review-prompt.ts
+++ b/src/self-improve/review-prompt.ts
@@ -29,6 +29,39 @@ import { resolveSelfImproveConfig } from "./config.js";
 /** The `meta.source` stamped on the synthesized review inbound. */
 export const REVIEW_SOURCE = "self_improve_review";
 
+/** The leading banner of a review prompt (see `buildReviewPrompt`). */
+export const REVIEW_MARKER = "[self-improvement review]";
+
+/**
+ * True iff `text` is (the transcript form of) a review turn WE injected.
+ *
+ * The injected inbound comes back through the gateway CHANNEL-WRAPPED, so
+ * the stored user text is NOT the bare banner — it looks like:
+ *
+ *   <channel source="self_improve_review" ...>[self-improvement review] …</channel>
+ *
+ * The original guard used `text.startsWith(REVIEW_MARKER)`, which never
+ * matches the wrapped form → infinite re-fire loop (issue #2462). We match
+ * robustly on EITHER the channel envelope's `source="self_improve_review"`
+ * attribute OR a substring of the banner, so both the wrapped form and the
+ * bare form (older transcripts / tests) are caught.
+ */
+export function isReviewInjectedText(text: string): boolean {
+  if (typeof text !== "string" || text.length === 0) return false;
+  // Channel-wrapped form: `<channel ... source="self_improve_review" ...>`.
+  // The attribute can appear with single or double quotes; match either,
+  // only inside a leading `<channel ...>` envelope to avoid false positives
+  // from an operator quoting the string.
+  const sourceAttr = new RegExp(
+    `^\\s*<channel\\b[^>]*\\bsource\\s*=\\s*["']?${REVIEW_SOURCE}\\b`,
+    "i",
+  );
+  if (sourceAttr.test(text)) return true;
+  // Bare / embedded banner (older transcripts, unit tests): a substring
+  // check — NOT startsWith — so a channel-stripped variant still matches.
+  return text.includes(REVIEW_MARKER);
+}
+
 /**
  * Build the review prompt text. `signals` is the gate's output; the
  * prompt is bounded (signals are already capped by the gate).

--- a/tests/self-improve-review-context.test.ts
+++ b/tests/self-improve-review-context.test.ts
@@ -8,6 +8,8 @@ import {
   readReviewContext,
   reviewIsPending,
   clearReviewContext,
+  hasFiredForSession,
+  markFiredForSession,
   REVIEW_CONTEXT_FILE,
   type ReviewContext,
 } from "../src/self-improve/review-context.js";
@@ -73,6 +75,27 @@ describe("self-improve review-context marker", () => {
     writeFileSync(join(stateDir, REVIEW_CONTEXT_FILE), "{ not json", "utf-8");
     expect(readReviewContext(stateDir)).toBeNull();
     expect(reviewIsPending(stateDir)).toBe(false);
+  });
+
+  it("per-session breaker: records and recalls a fired session (issue #2462)", () => {
+    expect(hasFiredForSession(stateDir, "sess-A")).toBe(false);
+    markFiredForSession(stateDir, "sess-A");
+    expect(hasFiredForSession(stateDir, "sess-A")).toBe(true);
+    // A different session is unaffected.
+    expect(hasFiredForSession(stateDir, "sess-B")).toBe(false);
+    markFiredForSession(stateDir, "sess-B");
+    expect(hasFiredForSession(stateDir, "sess-A")).toBe(true);
+    expect(hasFiredForSession(stateDir, "sess-B")).toBe(true);
+    // Idempotent — re-marking doesn't break recall.
+    markFiredForSession(stateDir, "sess-A");
+    expect(hasFiredForSession(stateDir, "sess-A")).toBe(true);
+  });
+
+  it("per-session breaker: ignores empty / unknown session ids", () => {
+    markFiredForSession(stateDir, "");
+    markFiredForSession(stateDir, "unknown");
+    expect(hasFiredForSession(stateDir, "")).toBe(false);
+    expect(hasFiredForSession(stateDir, "unknown")).toBe(false);
   });
 
   it("defaults signals to [] when the marker omits them", () => {

--- a/tests/self-improve-review-prompt.test.ts
+++ b/tests/self-improve-review-prompt.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 
-import { buildReviewPrompt, REVIEW_SOURCE } from "../src/self-improve/review-prompt.js";
+import {
+  buildReviewPrompt,
+  REVIEW_SOURCE,
+  REVIEW_MARKER,
+  isReviewInjectedText,
+} from "../src/self-improve/review-prompt.js";
 import type { LearningSignal } from "../src/self-improve/types.js";
 
 const signals: LearningSignal[] = [
@@ -38,5 +43,38 @@ describe("forked-review prompt", () => {
   it("states that new crons / new skills are never self-served", () => {
     const p = buildReviewPrompt(signals);
     expect(p.toLowerCase()).toContain("never auto-create");
+  });
+});
+
+describe("isReviewInjectedText — robust review-turn detection (issue #2462)", () => {
+  it("matches the CHANNEL-WRAPPED form (the shape that broke startsWith)", () => {
+    const wrapped =
+      `<channel source="${REVIEW_SOURCE}" chat_id="1" ts="1">` +
+      `${REVIEW_MARKER} blah evidence: no, that's wrong</channel>`;
+    expect(isReviewInjectedText(wrapped)).toBe(true);
+  });
+
+  it("matches single-quoted and attribute-reordered channel envelopes", () => {
+    expect(
+      isReviewInjectedText(
+        `<channel chat_id="1" source='${REVIEW_SOURCE}'>${REVIEW_MARKER} x</channel>`,
+      ),
+    ).toBe(true);
+  });
+
+  it("matches the BARE banner (older transcripts / unit tests)", () => {
+    expect(isReviewInjectedText(`${REVIEW_MARKER} the gate detected a signal`)).toBe(true);
+  });
+
+  it("matches the banner even when not at the very start (not startsWith)", () => {
+    expect(isReviewInjectedText(`leading noise ${REVIEW_MARKER} ...`)).toBe(true);
+  });
+
+  it("does NOT match an ordinary operator turn", () => {
+    expect(isReviewInjectedText("No, that's wrong — exclude drafts")).toBe(false);
+    expect(isReviewInjectedText("")).toBe(false);
+    expect(
+      isReviewInjectedText('<channel source="telegram" chat_id="1">hi</channel>'),
+    ).toBe(false);
   });
 });

--- a/tests/self-improve-stop-hook.test.ts
+++ b/tests/self-improve-stop-hook.test.ts
@@ -5,10 +5,12 @@ import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { buildReviewPrompt } from "../src/self-improve/review-prompt.js";
+import { buildReviewPrompt, REVIEW_SOURCE } from "../src/self-improve/review-prompt.js";
 import {
   writeReviewContext,
   reviewIsPending,
+  hasFiredForSession,
+  markFiredForSession,
 } from "../src/self-improve/review-context.js";
 
 // Drive the hook through `bun` against source (mirrors
@@ -119,6 +121,9 @@ describe("self-improve-stop hook — fires the forked review on a real signal", 
         SWITCHROOM_AGENT_NAME: "test-agent",
         SWITCHROOM_GATEWAY_SOCKET: socketPath,
         SWITCHROOM_SELF_IMPROVE_CHAT_ID: "1234",
+        // Isolate the per-session breaker's state file to this test's tmp dir
+        // (issue #2462) so it doesn't touch the shared default state dir.
+        TELEGRAM_STATE_DIR: join(tmp, "state-inject"),
       });
       expect(r.status).toBe(0);
 
@@ -137,7 +142,7 @@ describe("self-improve-stop hook — fires the forked review on a real signal", 
     }
   });
 
-  it("does NOT recurse: a review turn does not re-trip the gate", () => {
+  it("does NOT recurse: a BARE review turn does not re-trip the gate", () => {
     if (!bunOk) return;
     const socketPath = join(tmp, "gw2.sock");
     // The last user message is a review prompt we previously injected.
@@ -155,6 +160,104 @@ describe("self-improve-stop hook — fires the forked review on a real signal", 
       SWITCHROOM_GATEWAY_SOCKET: socketPath, // no server listening — connect would fail anyway
     });
     expect(r.status).toBe(0);
+  });
+
+  // Regression for issue #2462: the injected review returns CHANNEL-WRAPPED,
+  // so its transcript text is `<channel source="self_improve_review" ...>
+  // [self-improvement review] …</channel>`, NOT the bare banner. The old
+  // `startsWith("[self-improvement review]")` guard never matched this form,
+  // so the gate re-scanned, re-tripped on the embedded correction evidence,
+  // and re-injected forever. With a live server we assert NOTHING is injected.
+  it("does NOT re-fire on the CHANNEL-WRAPPED review turn (issue #2462)", async () => {
+    if (!bunOk) return;
+
+    const socketPath = join(tmp, "gw-wrapped.sock");
+    const received: string[] = [];
+    const server: Server = await new Promise((resolve) => {
+      const s = createServer((conn) => {
+        conn.on("data", (d) => received.push(d.toString("utf-8")));
+      });
+      s.listen(socketPath, () => resolve(s));
+    });
+
+    try {
+      // The exact shape that broke it: the channel envelope wraps the banner
+      // AND the original correction evidence the gate would otherwise re-count.
+      const wrapped =
+        `<channel source="${REVIEW_SOURCE}" chat_id="1234" ts="1718000000">` +
+        "[self-improvement review] The turn-end gate detected a learning signal. " +
+        "evidence: No, that's wrong. That's not what I asked, I told you to exclude drafts." +
+        "</channel>";
+      // The window still contains the ORIGINAL two operator corrections that
+      // first tripped the gate, PLUS the injected review (channel-wrapped) as
+      // the latest user turn. Under the OLD `startsWith` guard this re-trips
+      // and re-injects (the infinite loop). The fixed guard must catch the
+      // wrapped review and exit without injecting.
+      const tp = writeTranscript("wrapped-review.jsonl", [
+        { role: "user", text: "Send the digest." },
+        { role: "assistant", text: "Sent." },
+        { role: "user", text: "No, that's wrong — you included drafts again." },
+        { role: "assistant", text: "Fixed." },
+        { role: "user", text: "That's not what I asked, I told you to exclude drafts." },
+        { role: "assistant", text: "Apologies, corrected." },
+        { role: "user", text: wrapped },
+        { role: "assistant", text: "Recorded a pending suggestion." },
+      ]);
+      const r = run(JSON.stringify({ session_id: "s-wrapped", transcript_path: tp }), {
+        SWITCHROOM_AGENT_NAME: "test-agent",
+        SWITCHROOM_GATEWAY_SOCKET: socketPath,
+        TELEGRAM_STATE_DIR: join(tmp, "state-wrapped"),
+      });
+      expect(r.status).toBe(0);
+
+      // Give any (errant) async write a moment, then assert NONE landed.
+      await new Promise((res) => setTimeout(res, 250));
+      expect(received.join("")).toBe("");
+    } finally {
+      await new Promise<void>((res) => server.close(() => res()));
+    }
+  });
+
+  // Layer-3 breaker: once a review has been injected for a session, a second
+  // Stop in the SAME session must not inject again — even with a fresh
+  // tripping transcript that would otherwise trip the gate (issue #2462).
+  it("per-session breaker prevents a SECOND injection in the same session", async () => {
+    if (!bunOk) return;
+
+    const socketPath = join(tmp, "gw-breaker.sock");
+    const stateDir = mkdtempSync(join(tmpdir(), "self-improve-stop-breaker-"));
+    const received: string[] = [];
+    const server: Server = await new Promise((resolve) => {
+      const s = createServer((conn) => {
+        conn.on("data", (d) => received.push(d.toString("utf-8")));
+      });
+      s.listen(socketPath, () => resolve(s));
+    });
+
+    try {
+      // Pre-arm the breaker as the first injection would have.
+      markFiredForSession(stateDir, "s-breaker");
+      expect(hasFiredForSession(stateDir, "s-breaker")).toBe(true);
+
+      // A transcript that DOES trip the gate (two operator corrections).
+      const tp = writeTranscript("breaker.jsonl", [
+        { role: "user", text: "No, that's wrong — you included drafts again." },
+        { role: "assistant", text: "Fixed." },
+        { role: "user", text: "That's not what I asked, I told you to exclude drafts." },
+      ]);
+      const r = run(JSON.stringify({ session_id: "s-breaker", transcript_path: tp }), {
+        SWITCHROOM_AGENT_NAME: "test-agent",
+        SWITCHROOM_GATEWAY_SOCKET: socketPath,
+        TELEGRAM_STATE_DIR: stateDir,
+      });
+      expect(r.status).toBe(0);
+
+      await new Promise((res) => setTimeout(res, 250));
+      expect(received.join("")).toBe(""); // breaker held — no second injection
+    } finally {
+      await new Promise<void>((res) => server.close(() => res()));
+      rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("clears the review-context marker at the end of a REAL review turn (regression: no leak)", () => {


### PR DESCRIPTION
Closes #2462.

> **Heads-up for review:** PR #2465 (also open, same author) fixes the same issue with layers 1, 2 and a wrapped-form regression test. **This PR overlaps it deliberately and adds the one layer #2465 lacks: the per-session re-fire breaker (defense-in-depth).** Pick whichever you prefer — merge this and close #2465, fold the breaker into #2465, or cherry-pick. I did not enable auto-merge.

## RCA

The self-improve Stop hook tried to avoid reviewing its own injected review turn with:

```ts
lastUser.text.startsWith("[self-improvement review]")
```

But the gateway wraps every injected inbound in a `<channel source="self_improve_review" ...>...</channel>` envelope before it lands in the transcript. The `[self-improvement review]` banner is therefore **never at offset 0**, so `startsWith` never matched, the guard never tripped, and the gate re-injected a review on every Stop — an **infinite re-fire loop** (observed live on agent `clerk`, 2026-06-20 ~05:15–05:32 UTC).

Compounding it: each re-fire left the prior review prompt inside the 40-message scan window, so the directive detector re-counted the review's own embedded `evidence:` line as a freshly restated rule — the count climbed unbounded (`evidence: evidence: evidence: ...`).

## The four-layer fix

1. **Robust review-turn guard.** New `isReviewInjectedText(text)` in `review-prompt.ts` matches **both** the channel-wrapped form (the envelope's `source="self_improve_review"` attribute, via the `REVIEW_SOURCE` constant — not hardcoded twice) **and** the `[self-improvement review]` banner as a substring (not `startsWith`). The hook now checks **any** recent user message, not just the last, so a batched real+review inbound still trips the guard.
2. **Drop self-injected turns from the gate scan.** The hook filters review turns out of the window before `runGate`, so the review prompt's embedded evidence can never re-count as a signal — kills the climbing-count amplifier independently of layer 1.
3. **Per-session re-fire breaker (defense-in-depth).** A sibling state file keyed by `session_id` (`hasFiredForSession` / `markFiredForSession` in `review-context.ts`, bounded to the last 200 sessions) ensures one tripped session injects **at most one** review, even if the guard logic ever regresses.
4. **Regression tests** using the exact **channel-wrapped** transcript shape that broke it, plus the bare form and the breaker.

No change to the cost guarantee or the real-signal path: a clean turn still returns immediately; a genuine operator correction still fires the review exactly once.

## Files changed

- `src/cli/self-improve-stop.ts` — robust guard, scan-window filter, per-session breaker wiring
- `src/self-improve/review-prompt.ts` — `REVIEW_MARKER` + `isReviewInjectedText()`
- `src/self-improve/review-context.ts` — `hasFiredForSession` / `markFiredForSession`
- `tests/self-improve-stop-hook.test.ts` — channel-wrapped regression + breaker tests
- `tests/self-improve-review-prompt.test.ts` — `isReviewInjectedText` unit coverage
- `tests/self-improve-review-context.test.ts` — breaker unit coverage

## Test evidence

- **Targeted suites:** `self-improve-stop-hook`, `self-improve-review-context`, `self-improve-review-prompt`, `self-improve-gate`, `self-improve-apply-guard` — **49 passed**.
- **Channel-wrapped regression proven against old code:** reverting the guard to the original `startsWith` (keeping the new test) makes the wrapped-form test **fail** — the hook re-injects an `inject_inbound` envelope whose evidence is literally the wrapped review (`pushed back 3×`, the `evidence: <channel ...>` amplifier). With the fix it **passes** (no injection).
- **Typecheck:** `tsc --noEmit` — clean (exit 0).
- **Lint:** `npm run lint` — clean (all 8 checks pass).
- **Build:** `bun run build` — clean.
- Full `vitest run` has 2 pre-existing failing files (`tests/host-control/server.test.ts`, `tests/install/static-binary.test.ts`) that fail identically on a pristine `main` checkout — environment/infra tests unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)