### PR TITLE
fix(cli): in-place fallback for config pin write on EBUSY bind-mount (#2457)

### DIFF
--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -38,7 +38,7 @@ import type { Command } from "commander";
 import { getConfig, getConfigPath } from "./helpers.js";
 import { setReleasePinInConfig } from "./release-yaml.js";
 import { resolveOperatorUid } from "./operator-uid.js";
-import { atomicWriteFileSync } from "../util/atomic.js";
+import { writeConfigFileSync } from "../util/atomic.js";
 
 /** One ordered step of a rollout plan. Pure data so it unit-tests. */
 export type RolloutStep =
@@ -351,10 +351,10 @@ export function registerRolloutCommand(program: Command): void {
           const before = readFileSync(configPath, "utf8");
           const after = setReleasePinInConfig(before, pin);
           if (after === before) return; // idempotent no-op
-          // Crash-safe atomic write (fsync + unique tmp + rename), preserving
-          // the file's existing mode — switchroom.yaml is the fleet's single
-          // source of truth; a crash mid-write mustn't corrupt or truncate it.
-          atomicWriteFileSync(configPath, after, statSync(configPath).mode & 0o777);
+          // Config-file write: tries atomic rename(2) first; falls back to
+          // in-place rewrite on EBUSY/EXDEV/EINVAL (single-file bind mount
+          // inside the hostd container rejects rename over the mount point).
+          writeConfigFileSync(configPath, after, statSync(configPath).mode & 0o777);
           // rollout self-elevates via sudo; a root write would leave the
           // operator-owned config root-owned and EACCES-lock other yaml verbs
           // (and erode the read-only-operator-config foundation). chown back.

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -45,7 +45,7 @@ import { loadConfig, findConfigFile } from "../config/loader.js";
 import { writeRestartReasonMarker } from "../agents/lifecycle.js";
 import { setReleasePinInConfig } from "./release-yaml.js";
 import { resolveOperatorUid } from "./operator-uid.js";
-import { atomicWriteFileSync } from "../util/atomic.js";
+import { writeConfigFileSync } from "../util/atomic.js";
 
 /**
  * Default durable-pin persister for `update --pin`: comment-preserving,
@@ -60,8 +60,10 @@ function defaultPersistPin(configPath?: string): (pin: string) => void {
     const before = readFileSync(path, "utf8");
     const after = setReleasePinInConfig(before, pin);
     if (after === before) return; // idempotent no-op
-    // Crash-safe atomic write, preserving the file's existing mode.
-    atomicWriteFileSync(path, after, statSync(path).mode & 0o777);
+    // Config-file write: tries atomic rename(2) first; falls back to
+    // in-place rewrite on EBUSY/EXDEV/EINVAL (single-file bind mount
+    // inside the hostd container rejects rename over the mount point).
+    writeConfigFileSync(path, after, statSync(path).mode & 0o777);
     try {
       if (typeof process.geteuid === "function" && process.geteuid() === 0) {
         const uid = resolveOperatorUid();

--- a/src/util/atomic.test.ts
+++ b/src/util/atomic.test.ts
@@ -2,53 +2,62 @@
  * atomic — sec #1410 (TOCTOU follow-up to CRITICAL #1393). The two
  * brokers run as ROOT through this primitive, so the symlink-safety
  * guarantees matter. Pre-#1410 atomic.ts had no direct test.
+ *
+ * writeConfigFileSync (#2457): EBUSY/EXDEV/EINVAL fallback for single-file
+ * bind mounts inside the hostd container where rename(2) is rejected.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import {
-  mkdtempSync,
-  rmSync,
-  writeFileSync,
-  symlinkSync,
-  readFileSync,
-  lstatSync,
-  readdirSync,
-  statSync,
-} from "node:fs";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { atomicWriteFileSync, atomicWriteJsonSync } from "./atomic.js";
+// Mock node:fs so we can spy on renameSync for the writeConfigFileSync EBUSY
+// tests while leaving all other functions as real implementations. The existing
+// atomicWriteFileSync tests never touch the mock (mockImplementationOnce is
+// only set in the writeConfigFileSync EBUSY describe block).
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    renameSync: vi.fn().mockImplementation(actual.renameSync),
+  };
+});
+
+import { atomicWriteFileSync, atomicWriteJsonSync, writeConfigFileSync } from "./atomic.js";
 
 describe("atomicWriteFileSync", () => {
   let dir: string;
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "atomic-"));
+    dir = fs.mkdtempSync(join(tmpdir(), "atomic-"));
   });
   afterEach(() => {
-    rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true });
+    // Only clear call counts/instances; the mock's real-implementation
+    // wrapping must stay in place for subsequent tests.
+    vi.clearAllMocks();
   });
 
   it("writes content at 0600 by default and leaves no tempfile", () => {
     const p = join(dir, "secret.json");
     atomicWriteFileSync(p, "hello");
-    expect(readFileSync(p, "utf8")).toBe("hello");
-    expect(statSync(p).mode & 0o777).toBe(0o600);
+    expect(fs.readFileSync(p, "utf8")).toBe("hello");
+    expect(fs.statSync(p).mode & 0o777).toBe(0o600);
     // No `.tmp-` leak on the success path.
-    expect(readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+    expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
   });
 
   it("atomically replaces an existing regular file", () => {
     const p = join(dir, "f");
-    writeFileSync(p, "OLD");
+    fs.writeFileSync(p, "OLD");
     atomicWriteFileSync(p, "NEW");
-    expect(readFileSync(p, "utf8")).toBe("NEW");
+    expect(fs.readFileSync(p, "utf8")).toBe("NEW");
   });
 
   it("atomicWriteJsonSync writes pretty JSON + trailing newline", () => {
     const p = join(dir, "c.json");
     atomicWriteJsonSync(p, { a: 1 });
-    expect(readFileSync(p, "utf8")).toBe('{\n  "a": 1\n}\n');
+    expect(fs.readFileSync(p, "utf8")).toBe('{\n  "a": 1\n}\n');
   });
 
   // THE security property (#1393/#1410): if the destination is an
@@ -57,22 +66,113 @@ describe("atomicWriteFileSync", () => {
   // at victim is never modified and dest becomes a real file.
   it("does not write through a symlinked destination (no symlink-follow)", () => {
     const victim = join(dir, "victim-secret");
-    writeFileSync(victim, "SECRET-UNTOUCHED");
+    fs.writeFileSync(victim, "SECRET-UNTOUCHED");
     const dest = join(dir, "dest");
-    symlinkSync(victim, dest);
-    expect(lstatSync(dest).isSymbolicLink()).toBe(true);
+    fs.symlinkSync(victim, dest);
+    expect(fs.lstatSync(dest).isSymbolicLink()).toBe(true);
 
     atomicWriteFileSync(dest, "ATTACKER-CONTROLLED-PAYLOAD");
 
     // dest is now a regular file with the new bytes …
-    expect(lstatSync(dest).isSymbolicLink()).toBe(false);
-    expect(readFileSync(dest, "utf8")).toBe("ATTACKER-CONTROLLED-PAYLOAD");
+    expect(fs.lstatSync(dest).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(dest, "utf8")).toBe("ATTACKER-CONTROLLED-PAYLOAD");
     // … and the symlink's victim was NEVER written through.
-    expect(readFileSync(victim, "utf8")).toBe("SECRET-UNTOUCHED");
+    expect(fs.readFileSync(victim, "utf8")).toBe("SECRET-UNTOUCHED");
   });
 
   it("propagates errors fail-closed (bad dir → throws, dest untouched)", () => {
     const p = join(dir, "nope", "deep", "x");
     expect(() => atomicWriteFileSync(p, "data")).toThrow();
+  });
+});
+
+describe("writeConfigFileSync (#2457 — EBUSY bind-mount fallback)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(join(tmpdir(), "config-write-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    // Only clear call counts/instances; the mock's real-implementation
+    // wrapping must stay in place for subsequent tests.
+    vi.clearAllMocks();
+  });
+
+  it("happy path: uses rename(2) and the file ends up with the new contents", () => {
+    const p = join(dir, "switchroom.yaml");
+    fs.writeFileSync(p, "agents: {}\n");
+    writeConfigFileSync(p, "agents: { foo: {} }\n");
+    expect(fs.readFileSync(p, "utf8")).toBe("agents: { foo: {} }\n");
+    // renameSync must have been called at least once on the happy path
+    expect(vi.mocked(fs.renameSync)).toHaveBeenCalled();
+    // No tempfile left behind
+    expect(fs.readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  it("EBUSY: falls back to in-place rewrite and file ends up with new contents", () => {
+    const p = join(dir, "switchroom.yaml");
+    fs.writeFileSync(p, "agents: {}\n", { mode: 0o644 });
+
+    // Simulate EBUSY on the first rename call (single-file bind mount)
+    vi.mocked(fs.renameSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error("EBUSY: resource busy or locked"), { code: "EBUSY" });
+    });
+
+    writeConfigFileSync(p, "agents: { bar: {} }\n");
+
+    // Despite the rename failure, the in-place fallback wrote the new content
+    expect(fs.readFileSync(p, "utf8")).toBe("agents: { bar: {} }\n");
+  });
+
+  it("EXDEV: falls back to in-place rewrite and file ends up with new contents", () => {
+    const p = join(dir, "switchroom.yaml");
+    fs.writeFileSync(p, "old: true\n", { mode: 0o644 });
+
+    vi.mocked(fs.renameSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error("EXDEV: cross-device link not permitted"), { code: "EXDEV" });
+    });
+
+    writeConfigFileSync(p, "new: true\n");
+
+    expect(fs.readFileSync(p, "utf8")).toBe("new: true\n");
+  });
+
+  it("EINVAL: falls back to in-place rewrite and file ends up with new contents", () => {
+    const p = join(dir, "switchroom.yaml");
+    fs.writeFileSync(p, "old: true\n", { mode: 0o644 });
+
+    vi.mocked(fs.renameSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error("EINVAL: invalid argument"), { code: "EINVAL" });
+    });
+
+    writeConfigFileSync(p, "new: true\n");
+
+    expect(fs.readFileSync(p, "utf8")).toBe("new: true\n");
+  });
+
+  it("non-EBUSY rename error is re-thrown (atomicity not silently swallowed)", () => {
+    const p = join(dir, "switchroom.yaml");
+    fs.writeFileSync(p, "agents: {}\n");
+
+    vi.mocked(fs.renameSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error("EPERM: operation not permitted"), { code: "EPERM" });
+    });
+
+    expect(() => writeConfigFileSync(p, "new content\n")).toThrow("EPERM");
+    // The original file must be untouched (the rename errored, in-place was not attempted)
+    expect(fs.readFileSync(p, "utf8")).toBe("agents: {}\n");
+  });
+
+  it("propagates in-place fallback write errors (bad path on fallback)", () => {
+    // Trigger EBUSY so we enter the fallback path, but the fallback itself fails
+    // because the destination doesn't exist (no pre-created file to O_TRUNC).
+    const p = join(dir, "nonexistent.yaml");
+
+    vi.mocked(fs.renameSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error("EBUSY: resource busy or locked"), { code: "EBUSY" });
+    });
+
+    // openSync(p, O_WRONLY|O_TRUNC) on a nonexistent file throws ENOENT
+    expect(() => writeConfigFileSync(p, "content\n")).toThrow();
   });
 });

--- a/src/util/atomic.test.ts
+++ b/src/util/atomic.test.ts
@@ -175,4 +175,48 @@ describe("writeConfigFileSync (#2457 — EBUSY bind-mount fallback)", () => {
     // openSync(p, O_WRONLY|O_TRUNC) on a nonexistent file throws ENOENT
     expect(() => writeConfigFileSync(p, "content\n")).toThrow();
   });
+
+  it("EBUSY fallback: preserves the file's existing inode permissions (mode unchanged)", () => {
+    // Create the file with a restrictive mode so we can verify it is left intact
+    // after an in-place rewrite. O_TRUNC without O_CREAT does not touch the mode.
+    const p = join(dir, "restricted.yaml");
+    fs.writeFileSync(p, "old: true\n", { mode: 0o600 });
+    expect(fs.statSync(p).mode & 0o777).toBe(0o600);
+
+    vi.mocked(fs.renameSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error("EBUSY: resource busy or locked"), { code: "EBUSY" });
+    });
+
+    writeConfigFileSync(p, "new: true\n");
+
+    expect(fs.readFileSync(p, "utf8")).toBe("new: true\n");
+    // The in-place fallback must not alter the inode's permission bits.
+    expect(fs.statSync(p).mode & 0o777).toBe(0o600);
+  });
+
+  it("EBUSY fallback: fsyncSync throwing EIO propagates the error and closes the fd (no leak)", () => {
+    const p = join(dir, "switchroom.yaml");
+    fs.writeFileSync(p, "agents: {}\n", { mode: 0o644 });
+
+    // First: enter the fallback path via a mocked EBUSY on rename.
+    vi.mocked(fs.renameSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error("EBUSY: resource busy or locked"), { code: "EBUSY" });
+    });
+
+    // Spy on closeSync so we can assert it is called even when fsyncSync throws.
+    const closeSpy = vi.spyOn(fs, "closeSync");
+    // Make fsyncSync throw EIO once (simulates a hardware/kernel I/O error after
+    // the file has been opened with O_TRUNC).
+    const fsyncSpy = vi.spyOn(fs, "fsyncSync").mockImplementationOnce(() => {
+      throw Object.assign(new Error("EIO: i/o error"), { code: "EIO" });
+    });
+
+    expect(() => writeConfigFileSync(p, "new content\n")).toThrow("EIO");
+
+    // The fd must have been closed despite the fsyncSync failure — no leak.
+    expect(closeSpy).toHaveBeenCalled();
+
+    fsyncSpy.mockRestore();
+    closeSpy.mockRestore();
+  });
 });

--- a/src/util/atomic.ts
+++ b/src/util/atomic.ts
@@ -91,3 +91,58 @@ export function atomicWriteJsonSync(
 ): void {
   atomicWriteFileSync(destPath, JSON.stringify(value, null, 2) + "\n", mode);
 }
+
+/**
+ * Config-file variant of atomicWriteFileSync for non-secret config files
+ * (e.g. switchroom.yaml) that may live on single-file bind mounts inside
+ * the hostd container.
+ *
+ * On a single-file bind mount the kernel rejects rename(2) with EBUSY (and
+ * occasionally EXDEV or EINVAL on some container runtimes) because the bind
+ * mount point IS the inode — you cannot atomically swap it out from under
+ * the mount entry.  The standard atomic pattern therefore fails before any
+ * fleet change reaches the file.  For a non-secret config file the narrow
+ * non-atomic window of an in-place rewrite is acceptable: the file holds no
+ * secret material and concurrent readers will see either the old bytes or
+ * the new bytes — a partial read is the only risk, and it is bounded by a
+ * single write(2) + fsync(2) on a file that is kilobytes in size.
+ *
+ * Strategy:
+ *   1. Try the fully-atomic rename path first (identical to atomicWriteFileSync).
+ *   2. If rename(2) throws EBUSY | EXDEV | EINVAL, fall back to an in-place
+ *      rewrite: open with O_WRONLY | O_TRUNC, write, fsync, close.
+ *   3. Any other error is re-thrown unchanged (atomicity is NOT silently
+ *      swallowed for any other failure class).
+ *
+ * Do NOT use this function for secret-bearing files (vault entries, OAuth
+ * credentials) — those must always go through atomicWriteFileSync.
+ */
+export function writeConfigFileSync(
+  destPath: string,
+  contents: string | Buffer,
+  mode = 0o644,
+): void {
+  try {
+    atomicWriteFileSync(destPath, contents, mode);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "EBUSY" && code !== "EXDEV" && code !== "EINVAL") {
+      throw err;
+    }
+    // Bind-mount target — fall back to in-place rewrite.
+    const buf = typeof contents === "string" ? Buffer.from(contents, "utf-8") : contents;
+    let fd: number | null = null;
+    try {
+      fd = openSync(destPath, constants.O_WRONLY | constants.O_TRUNC, mode);
+      writeSync(fd, buf, 0, buf.length, 0);
+      fsyncSync(fd);
+      closeSync(fd);
+      fd = null;
+    } catch (fallbackErr) {
+      if (fd !== null) {
+        try { closeSync(fd); } catch { /* already closed */ }
+      }
+      throw fallbackErr;
+    }
+  }
+}

--- a/src/util/atomic.ts
+++ b/src/util/atomic.ts
@@ -114,6 +114,14 @@ export function atomicWriteJsonSync(
  *   3. Any other error is re-thrown unchanged (atomicity is NOT silently
  *      swallowed for any other failure class).
  *
+ * **DATA-LOSS WINDOW (accepted risk):** If write(2) fails after O_TRUNC has
+ * already truncated the file, the file is left EMPTY — not merely partially
+ * written, but zero bytes.  A concurrent reader or config loader that opens
+ * the file in this window will see an empty YAML document and may error or
+ * revert to defaults.  This risk is accepted and bounded: it only materialises
+ * on the EBUSY/EXDEV/EINVAL fallback path (i.e. single-file bind mounts), and
+ * only for non-secret config files — never for vault entries or OAuth tokens.
+ *
  * Do NOT use this function for secret-bearing files (vault entries, OAuth
  * credentials) — those must always go through atomicWriteFileSync.
  */
@@ -133,6 +141,9 @@ export function writeConfigFileSync(
     const buf = typeof contents === "string" ? Buffer.from(contents, "utf-8") : contents;
     let fd: number | null = null;
     try {
+      // `mode` is only consulted by the kernel when O_CREAT is set; without
+      // O_CREAT it is ignored and the file's existing inode permissions are
+      // preserved — which is the desired behaviour for an in-place rewrite.
       fd = openSync(destPath, constants.O_WRONLY | constants.O_TRUNC, mode);
       writeSync(fd, buf, 0, buf.length, 0);
       fsyncSync(fd);


### PR DESCRIPTION
Fixes #2457.

## Problem
`switchroom --pin` persists `release.pin` to `switchroom.yaml` via `atomicWriteFileSync` (write-temp-then-`rename(2)`). Inside the hostd container `switchroom.yaml` is a single-file bind mount; `rename(2)` over a file-level bind mount returns `EBUSY` (the inode IS the mount point), so the pin step fails before any fleet change.

## Fix
New `writeConfigFileSync(path, contents, mode?)` in `src/util/atomic.ts`: tries `atomicWriteFileSync` first, and on `EBUSY|EXDEV|EINVAL` only, falls back to an in-place `O_WRONLY|O_TRUNC` + write + fsync rewrite. Any other error re-throws unchanged — atomicity is not silently downgraded. Wired into **both** pin-write sites: `defaultPersistPin` (update.ts) and `RolloutDeps.persistPin` (rollout.ts). The shared `atomicWriteFileSync` is untouched, so vault/auth-broker/OAuth callers keep full rename atomicity.

## Tests
6 new cases in `atomic.test.ts`: happy path uses rename; EBUSY/EXDEV/EINVAL each fall back to in-place with correct content; non-EBUSY errors propagate and leave the file untouched; fallback propagates its own write errors. **55 tests pass, tsc clean.**

## Review follow-ups (minor, no blockers — from reviewer pass)
- Add a comment that `mode` on the `O_TRUNC` open (no `O_CREAT`) is ignored by the kernel; existing inode perms are preserved.
- Strengthen JSDoc: if `write(2)` fails after `O_TRUNC`, the file is left empty (not just partially read) — accepted, bounded risk; state it plainly.
- Add a mode-preservation assertion and an `fsyncSync`-failure test on the fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)