### PR TITLE
fix(self-improve): content-aware repeated-manual-fix fingerprint (#2462 follow-up)

### DIFF
--- a/src/cli/self-improve-stop.ts
+++ b/src/cli/self-improve-stop.ts
@@ -57,6 +57,20 @@ function readStdin(): string {
 }
 
 /**
+ * Cheap, stable, non-crypto string hash (djb2) → short base36 digest. Used
+ * only to make Edit/Write fix fingerprints content-aware (NOT a security
+ * primitive): two distinct edits to the same file get distinct fingerprints,
+ * an identical re-applied edit gets the same one.
+ */
+function shortHash(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  }
+  return (h >>> 0).toString(36);
+}
+
+/**
  * Flatten one Claude Code transcript entry's content to text. Handles
  * the nested `{type, message:{role, content}}` shape and the flat
  * `{role, content}` shape; content may be a string or a list of parts
@@ -89,14 +103,37 @@ function flatten(entry: unknown): TurnMessage | null {
       if (p.type === "text" && typeof p.text === "string") {
         parts.push(p.text);
       } else if (p.type === "tool_use" && typeof p.name === "string") {
-        // Compact "Name(primary-arg)" — enough for the gate's
-        // Edit(...)/Bash(...) fix fingerprints without dumping payloads.
+        // Compact "Name(arg)" — enough for the gate's Edit(...)/Bash(...) fix
+        // fingerprints without dumping payloads.
         const input = (p.input ?? {}) as Record<string, unknown>;
-        const arg =
+        const file =
           (typeof input.file_path === "string" && input.file_path) ||
-          (typeof input.command === "string" && input.command) ||
           (typeof input.path === "string" && input.path) ||
           "";
+        let arg: string;
+        if (typeof input.command === "string") {
+          // Bash: the command IS the fix content — keep it whole so an
+          // identical remediation re-run still fingerprints as a repeat.
+          arg = input.command;
+        } else if (file) {
+          // Edit/Write/MultiEdit: the repeated-manual-fix signal must
+          // fingerprint the FIX (the actual change), NOT just the file path.
+          // A path-only fingerprint mis-reads normal iterative editing — a
+          // few DISTINCT edits to one file in a turn — as "the same fix
+          // applied N×" (issue #2462 follow-up). Append a short content hash
+          // so only a genuinely identical re-applied edit recurs.
+          const editish = [
+            typeof input.old_string === "string" ? input.old_string : "",
+            typeof input.new_string === "string" ? input.new_string : "",
+            typeof input.content === "string" ? input.content : "",
+            input.edits !== undefined ? JSON.stringify(input.edits) : "",
+          ];
+          arg = editish.some((x) => x.length > 0)
+            ? `${file} #${shortHash(editish.join(" "))}`
+            : file;
+        } else {
+          arg = "";
+        }
         parts.push(`${p.name}(${arg})`);
       }
     }

--- a/tests/self-improve-stop-hook.test.ts
+++ b/tests/self-improve-stop-hook.test.ts
@@ -55,6 +55,30 @@ function writeTranscript(name: string, msgs: Array<{ role: string; text: string 
   return p;
 }
 
+/**
+ * Write a transcript whose entries may be either plain text OR a list of
+ * `tool_use` parts (the real assistant-message shape), so the gate's
+ * Edit/Bash fix-fingerprinting can be exercised faithfully.
+ */
+type Entry =
+  | { role: "user" | "assistant"; text: string }
+  | {
+      role: "assistant";
+      tools: Array<{ name: string; input: Record<string, unknown> }>;
+    };
+function writeToolTranscript(name: string, entries: Entry[]): string {
+  const p = join(tmp, name);
+  const lines = entries.map((e) => {
+    const content =
+      "tools" in e
+        ? e.tools.map((t) => ({ type: "tool_use", name: t.name, input: t.input }))
+        : e.text;
+    return JSON.stringify({ type: e.role, message: { role: e.role, content } });
+  });
+  writeFileSync(p, lines.join("\n") + "\n");
+  return p;
+}
+
 describe("self-improve-stop hook — fail-open + cost guarantee", () => {
   it("exits 0 silently on empty / non-JSON stdin", () => {
     if (!bunOk) return;
@@ -298,6 +322,89 @@ describe("self-improve-stop hook — fires the forked review on a real signal", 
       expect(reviewIsPending(stateDir)).toBe(false); // marker cleared — no leak
     } finally {
       rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// #2462 follow-up: the repeated-manual-fix detector fingerprinted an Edit by
+// FILE PATH only, so several DISTINCT edits to one file in a normal turn
+// mis-read as "the same fix applied N×" and tripped a review. The fingerprint
+// is now content-aware: only a genuinely identical re-applied edit recurs.
+describe("self-improve-stop hook — repeated-manual-fix is content-aware (#2462 follow-up)", () => {
+  function injectedNothing(received: string[]): boolean {
+    return received.join("") === "";
+  }
+
+  it("does NOT fire on several DISTINCT edits to the same file (normal iteration)", async () => {
+    if (!bunOk) return;
+    const socketPath = join(tmp, "gw-distinct.sock");
+    const received: string[] = [];
+    const server: Server = await new Promise((resolve) => {
+      const s = createServer((conn) => {
+        conn.on("data", (d) => received.push(d.toString("utf-8")));
+      });
+      s.listen(socketPath, () => resolve(s));
+    });
+    try {
+      // Three real, DIFFERENT edits to the same path — exactly what iterating
+      // on a fix looks like. Path-only fingerprinting tripped here; content-
+      // aware fingerprinting must not.
+      const file = "/repo/src/self-improve/review-prompt.ts";
+      const tp = writeToolTranscript("distinct-edits.jsonl", [
+        { role: "user", text: "Make the change." },
+        {
+          role: "assistant",
+          tools: [
+            { name: "Edit", input: { file_path: file, old_string: "const A = 1;", new_string: "const A = 2;" } },
+            { name: "Edit", input: { file_path: file, old_string: "foo(bar)", new_string: "foo(baz)" } },
+            { name: "Edit", input: { file_path: file, old_string: "// todo", new_string: "// done" } },
+          ],
+        },
+        { role: "user", text: "thanks" },
+      ]);
+      const r = run(JSON.stringify({ session_id: "distinct", transcript_path: tp }), {
+        SWITCHROOM_AGENT_NAME: "test-agent",
+        SWITCHROOM_GATEWAY_SOCKET: socketPath,
+      });
+      expect(r.status).toBe(0);
+      await new Promise((res) => setTimeout(res, 200));
+      expect(injectedNothing(received)).toBe(true); // no false repeated-manual-fix
+    } finally {
+      await new Promise<void>((res) => server.close(() => res()));
+    }
+  });
+
+  it("STILL fires on a genuinely identical remediation re-applied (signal preserved)", async () => {
+    if (!bunOk) return;
+    const socketPath = join(tmp, "gw-identical.sock");
+    const received: string[] = [];
+    const server: Server = await new Promise((resolve) => {
+      const s = createServer((conn) => {
+        conn.on("data", (d) => received.push(d.toString("utf-8")));
+      });
+      s.listen(socketPath, () => resolve(s));
+    });
+    try {
+      // The SAME Bash remediation run twice — the real "I had to redo the same
+      // fix" signal the detector exists to catch. Must still trip.
+      const cmd = "rm -f /tmp/stale.lock && systemctl restart worker";
+      const tp = writeToolTranscript("identical-fix.jsonl", [
+        { role: "user", text: "It's stuck." },
+        { role: "assistant", tools: [{ name: "Bash", input: { command: cmd } }] },
+        { role: "user", text: "stuck again." },
+        { role: "assistant", tools: [{ name: "Bash", input: { command: cmd } }] },
+      ]);
+      const r = run(JSON.stringify({ session_id: "identical", transcript_path: tp }), {
+        SWITCHROOM_AGENT_NAME: "test-agent",
+        SWITCHROOM_GATEWAY_SOCKET: socketPath,
+        SWITCHROOM_SELF_IMPROVE_CHAT_ID: "9",
+      });
+      expect(r.status).toBe(0);
+      await new Promise((res) => setTimeout(res, 200));
+      const envelope = JSON.parse(received.join("").trim());
+      expect(envelope.inbound.text).toContain("repeated-manual-fix");
+    } finally {
+      await new Promise<void>((res) => server.close(() => res()));
     }
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #2462 / #2465. Fixes a second false-positive in the self-improve gate: the `repeated-manual-fix` detector fingerprinted an `Edit` by **file path only**, so several *distinct* edits to one file during normal iteration mis-read as "the same fix applied N×" and tripped a spurious review. (Surfaced live while fixing the re-fire loop — the gate flagged my own iterative editing of the fix files.)

## Why

`flatten()` in the Stop hook compacts a tool call to `Name(primary-arg)`, and for `Edit` the primary arg was just `file_path`. The gate's `repeated-manual-fix` clusters identical fingerprints, so two edits to the same path collided regardless of content — and since an identical `old_string→new_string` can't even apply twice (the second match is gone), the Edit path of this detector was *almost always* a false positive.

## What changed

`src/cli/self-improve-stop.ts` `flatten()`:
- **Edit / Write / MultiEdit** now append a short, non-crypto content hash (djb2 → base36) of the actual change (`old_string` + `new_string` + `content` + `edits`). Distinct edits to one file → distinct fingerprints (no false trip); a genuinely identical re-applied edit → same fingerprint (still caught).
- **Bash** keeps its full command as the fix content — an identical remediation re-run still fingerprints as a repeat (the real "I had to redo the same fix" signal).

No change to the gate logic itself, the cost guarantee, or the other two signal classes.

## Test plan

- [x] New: three **distinct** edits to one file → **no** injection (this test fails against the old path-only code — bug pinned, verified by reverting `flatten`).
- [x] New: an **identical** Bash remediation run twice → still injects a `repeated-manual-fix` review (signal preserved).
- [x] Full self-improve suite green (83 tests); `tsc --noEmit` clean.

## Risk

Low. Strictly narrows when `repeated-manual-fix` fires (distinct edits no longer collide); the genuine duplicate-fix case is unchanged. Hash is presentation-only (fingerprint discriminator), never persisted or trusted.
