### PR TITLE
fix(telegram): count tools off the tool_label sidecar and persist total in activity feed (#2461)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1962,6 +1962,14 @@ type CurrentTurn = {
   // Phase 1 of #332: count of tool_use events in the current turn, for
   // the tool_call_count column in the turns registry.
   toolCallCount: number
+  // Count of tool_label events that passed the isTelegramSurfaceTool guard
+  // this turn — the deterministic, surface-tool-excluded step count used by
+  // the `✓ N steps` activity-feed total and the `tools=` lifecycle log.
+  // Incremented in `case 'tool_label':` AFTER the surface-tool guard so
+  // reply/stream_reply/edit_message/react are never counted. send_typing and
+  // sync_retain are suppressed at the hook (computeLabel returns null) and
+  // never arrive as tool_label events — excluded automatically.
+  labeledToolCount: number
   // Tool-activity summary — mirrors Claude Code's native chat-UI
   // rendering ("Ran 5 commands, read a file"). Counters are
   // incremented in `case 'tool_use'`; `activityMessageId` holds the
@@ -9882,7 +9890,11 @@ function composeTurnActivity(turn: CurrentTurn, final = false, liveSuffix = ''):
   for (const narrative of turn.foregroundSubAgents.values()) {
     childLines.push(...narrative)
   }
-  return renderActivityFeedWithNested(turn.mirrorLines, childLines, final, liveSuffix)
+  // Pass labeledToolCount as stepCount only on the terminal (final) render so
+  // the persisted feed record shows a `✓ N steps` total. The live in-progress
+  // feed omits it (stepCount undefined) to stay clean and minimal.
+  const stepCount = final ? turn.labeledToolCount : undefined
+  return renderActivityFeedWithNested(turn.mirrorLines, childLines, final, liveSuffix, stepCount)
 }
 
 /**
@@ -10137,6 +10149,7 @@ function handleSessionEvent(ev: SessionEvent): void {
           lastAssistantMsgId: null,
           lastAssistantDone: false,
           toolCallCount: 0,
+          labeledToolCount: 0,
           activityMessageId: null,
           activityInFlight: null,
           activityPendingRender: null,
@@ -10342,6 +10355,12 @@ function handleSessionEvent(ev: SessionEvent): void {
       // Surface tools (reply/stream_reply/react) are the conversation, not
       // activity — the hook labels them ("Replying"), so filter by name.
       if (isTelegramSurfaceTool(ev.toolName)) return
+      // Count surfaced tool steps. This is the single source of truth for the
+      // `tools=` lifecycle field and the `✓ N steps` activity-feed total.
+      // Placed AFTER the surface-tool guard so reply/stream_reply/edit_message/
+      // react are never counted. send_typing and sync_retain are suppressed at
+      // the hook level (computeLabel returns null) so they never arrive here.
+      turn.labeledToolCount++
       // Stop feeding once the FINAL answer has landed — the hand-off where
       // `clearActivitySummary` deletes the feed so the answer is the
       // authoritative surface. Gating on `replyCalled` (any reply) killed the

--- a/telegram-plugin/gateway/status-surface-log.test.ts
+++ b/telegram-plugin/gateway/status-surface-log.test.ts
@@ -12,6 +12,7 @@ function turn(overrides: Partial<StatusSurfaceTurnView> = {}): StatusSurfaceTurn
     sessionThreadId: undefined,
     startedAt: 1_780_000_000_000,
     toolCallCount: 0,
+    labeledToolCount: 0,
     activityMessageId: null,
     activityEverOpened: false,
     activityDrainFailures: 0,
@@ -35,7 +36,7 @@ describe('formatTurnLifecycle', () => {
     const line = formatTurnLifecycle(
       'clear',
       'turn_end',
-      turn({ sessionThreadId: 3, toolCallCount: 5, activityMessageId: 42, activityEverOpened: true, replyCalled: true, finalAnswerDelivered: true }),
+      turn({ sessionThreadId: 3, toolCallCount: 5, labeledToolCount: 5, activityMessageId: 42, activityEverOpened: true, replyCalled: true, finalAnswerDelivered: true }),
       1_780_000_300_000, // +300s
     )
     expect(line).toContain('turn-lifecycle clear reason=turn_end')
@@ -63,7 +64,7 @@ describe('formatTurnLifecycle', () => {
 describe('detectStatusSurfaceDegraded', () => {
   it('flags a turn that did tool work but never opened the feed due to send failures (the resume-400 signature)', () => {
     const d = detectStatusSurfaceDegraded(
-      turn({ toolCallCount: 3, activityEverOpened: false, activityDrainFailures: 10 }),
+      turn({ toolCallCount: 3, labeledToolCount: 3, activityEverOpened: false, activityDrainFailures: 10 }),
     )
     expect(d).not.toBeNull()
     expect(d!.reason).toBe('feed-never-opened')
@@ -75,7 +76,7 @@ describe('detectStatusSurfaceDegraded', () => {
     // the sticky activityEverOpened keeps this from false-positiving.
     expect(
       detectStatusSurfaceDegraded(
-        turn({ toolCallCount: 4, activityMessageId: null, activityEverOpened: true, activityDrainFailures: 0 }),
+        turn({ toolCallCount: 4, labeledToolCount: 4, activityMessageId: null, activityEverOpened: true, activityDrainFailures: 0 }),
       ),
     ).toBeNull()
   })
@@ -83,7 +84,7 @@ describe('detectStatusSurfaceDegraded', () => {
   it('does NOT flag a turn that never attempted a feed send (e.g. ack-first suppression)', () => {
     expect(
       detectStatusSurfaceDegraded(
-        turn({ toolCallCount: 2, activityEverOpened: false, activityDrainFailures: 0 }),
+        turn({ toolCallCount: 2, labeledToolCount: 2, activityEverOpened: false, activityDrainFailures: 0 }),
       ),
     ).toBeNull()
   })

--- a/telegram-plugin/gateway/status-surface-log.ts
+++ b/telegram-plugin/gateway/status-surface-log.ts
@@ -30,6 +30,17 @@ export interface StatusSurfaceTurnView {
   sessionThreadId: number | undefined
   startedAt: number
   toolCallCount: number
+  /**
+   * Count of tool_label events that passed the surface-tool guard this turn —
+   * i.e. the number of surfaced (non-surface, non-suppressed) tool steps. This
+   * is the deterministic single source of truth for the `tools=` lifecycle
+   * field and the `✓ N steps` activity-feed total. Incremented in
+   * `case 'tool_label':` AFTER the `isTelegramSurfaceTool` guard so that
+   * reply/stream_reply/edit_message/react are never counted. send_typing and
+   * sync_retain are suppressed at the hook level (computeLabel returns null)
+   * and never arrive as tool_label events, so they are excluded automatically.
+   */
+  labeledToolCount: number
   /** Live activity-feed message id; null until the first send captures it. */
   activityMessageId: number | null
   /**
@@ -67,7 +78,7 @@ export function formatTurnLifecycle(
   return (
     `turn-lifecycle ${action} reason=${reason} turnId=${t.turnId} ` +
     `chat=${t.sessionChatId} thread=${t.sessionThreadId ?? '-'} ` +
-    `tools=${t.toolCallCount} activityMsgId=${t.activityMessageId ?? 'none'} ` +
+    `tools=${t.labeledToolCount} activityMsgId=${t.activityMessageId ?? 'none'} ` +
     `feedOpened=${t.activityEverOpened} drainFailures=${t.activityDrainFailures} ` +
     `replyCalled=${t.replyCalled} finalAnswer=${t.finalAnswerDelivered} age_ms=${ageMs}`
   )
@@ -89,13 +100,13 @@ export function formatTurnLifecycle(
 export function detectStatusSurfaceDegraded(
   t: StatusSurfaceTurnView,
 ): { reason: string; detail: string } | null {
-  if (t.toolCallCount === 0) return null
+  if (t.labeledToolCount === 0) return null
   if (t.activityEverOpened) return null
   if (t.activityDrainFailures === 0) return null
   return {
     reason: 'feed-never-opened',
     detail:
-      `tools=${t.toolCallCount} drainFailures=${t.activityDrainFailures} ` +
+      `tools=${t.labeledToolCount} drainFailures=${t.activityDrainFailures} ` +
       `activityMsgId=none — the live activity feed failed every send this turn ` +
       `(card was dark despite tool work)`,
   }

--- a/telegram-plugin/tests/status-surface-log.test.ts
+++ b/telegram-plugin/tests/status-surface-log.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import { formatTurnLifecycle, detectStatusSurfaceDegraded } from '../gateway/status-surface-log.js'
+import type { StatusSurfaceTurnView } from '../gateway/status-surface-log.js'
+
+/**
+ * Tests for status-surface-log.ts (issue #2461).
+ *
+ * Verifies that:
+ *   - `formatTurnLifecycle` uses `labeledToolCount` (not `toolCallCount`) for
+ *     the `tools=` lifecycle log field — so the log reflects the accurate
+ *     surfaced count, not the raw tool_use count that includes surface tools.
+ *   - `detectStatusSurfaceDegraded` uses `labeledToolCount` to determine
+ *     whether to check for the feed-never-opened degraded state.
+ */
+
+function makeTurn(overrides: Partial<StatusSurfaceTurnView> = {}): StatusSurfaceTurnView {
+  return {
+    turnId: 'turn-abc',
+    sessionChatId: '123456',
+    sessionThreadId: undefined,
+    startedAt: 1000,
+    toolCallCount: 10,      // raw tool_use count — includes surface tools
+    labeledToolCount: 5,    // surfaced count — only non-surface, non-suppressed
+    activityMessageId: null,
+    activityEverOpened: false,
+    activityDrainFailures: 0,
+    replyCalled: false,
+    finalAnswerDelivered: false,
+    ...overrides,
+  }
+}
+
+describe('formatTurnLifecycle — tools= field uses labeledToolCount (#2461)', () => {
+  it('set action: tools= reports labeledToolCount, not toolCallCount', () => {
+    const t = makeTurn({ toolCallCount: 10, labeledToolCount: 5 })
+    const line = formatTurnLifecycle('set', 'enqueue', t, 1000)
+    expect(line).toContain('tools=5')
+    // The raw toolCallCount (10) must NOT appear in the tools= field.
+    expect(line).not.toMatch(/tools=10/)
+  })
+
+  it('clear action: tools= also uses labeledToolCount', () => {
+    const t = makeTurn({ toolCallCount: 7, labeledToolCount: 3 })
+    const line = formatTurnLifecycle('clear', 'turn_end', t, 2000)
+    expect(line).toContain('tools=3')
+    expect(line).not.toMatch(/tools=7/)
+  })
+
+  it('clear action: age_ms is computed from startedAt', () => {
+    const t = makeTurn({ startedAt: 1000 })
+    const line = formatTurnLifecycle('clear', 'turn_end', t, 3500)
+    expect(line).toContain('age_ms=2500')
+  })
+
+  it('set action: age_ms is always 0', () => {
+    const t = makeTurn({ startedAt: 1000 })
+    const line = formatTurnLifecycle('set', 'enqueue', t, 9999)
+    expect(line).toContain('age_ms=0')
+  })
+
+  it('includes turnId, chat, thread, feedOpened, drainFailures, replyCalled, finalAnswer', () => {
+    const t = makeTurn({
+      turnId: 'turn-xyz',
+      sessionChatId: '777',
+      sessionThreadId: 42,
+      activityMessageId: 99,
+      activityEverOpened: true,
+      activityDrainFailures: 2,
+      replyCalled: true,
+      finalAnswerDelivered: true,
+    })
+    const line = formatTurnLifecycle('clear', 'turn_end', t, 2000)
+    expect(line).toContain('turnId=turn-xyz')
+    expect(line).toContain('chat=777')
+    expect(line).toContain('thread=42')
+    expect(line).toContain('activityMsgId=99')
+    expect(line).toContain('feedOpened=true')
+    expect(line).toContain('drainFailures=2')
+    expect(line).toContain('replyCalled=true')
+    expect(line).toContain('finalAnswer=true')
+  })
+
+  it('thread=- when sessionThreadId is undefined', () => {
+    const t = makeTurn({ sessionThreadId: undefined })
+    const line = formatTurnLifecycle('set', 'enqueue', t, 1000)
+    expect(line).toContain('thread=-')
+  })
+
+  it('labeledToolCount=0 reports tools=0', () => {
+    const t = makeTurn({ labeledToolCount: 0, toolCallCount: 3 })
+    const line = formatTurnLifecycle('set', 'enqueue', t, 1000)
+    expect(line).toContain('tools=0')
+  })
+})
+
+describe('detectStatusSurfaceDegraded — uses labeledToolCount (#2461)', () => {
+  it('returns null when labeledToolCount=0 (no surfaced tool work this turn)', () => {
+    // Even if the raw toolCallCount is non-zero (surface-only tools like
+    // reply/react fired), labeledToolCount=0 means nothing to surface → null.
+    const t = makeTurn({ labeledToolCount: 0, toolCallCount: 5 })
+    expect(detectStatusSurfaceDegraded(t)).toBeNull()
+  })
+
+  it('returns null when feed opened fine (activityEverOpened=true)', () => {
+    const t = makeTurn({ labeledToolCount: 3, activityEverOpened: true, activityDrainFailures: 2 })
+    expect(detectStatusSurfaceDegraded(t)).toBeNull()
+  })
+
+  it('returns null when no drain failures (feed never tried to open — not degraded)', () => {
+    const t = makeTurn({ labeledToolCount: 3, activityEverOpened: false, activityDrainFailures: 0 })
+    expect(detectStatusSurfaceDegraded(t)).toBeNull()
+  })
+
+  it('returns degraded when labeledToolCount>0, feed never opened, and drain failures>0', () => {
+    const t = makeTurn({
+      labeledToolCount: 4,
+      toolCallCount: 6,
+      activityEverOpened: false,
+      activityDrainFailures: 3,
+    })
+    const result = detectStatusSurfaceDegraded(t)
+    expect(result).not.toBeNull()
+    expect(result!.reason).toBe('feed-never-opened')
+    // detail uses labeledToolCount, not toolCallCount
+    expect(result!.detail).toContain('tools=4')
+    expect(result!.detail).not.toMatch(/tools=6/)
+    expect(result!.detail).toContain('drainFailures=3')
+  })
+})

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -193,6 +193,66 @@ describe("appendActivityLabel — precomputed label feed (tool_label path)", () 
   });
 });
 
+describe("renderActivityFeed — ✓ N steps total (final render, issue #2461)", () => {
+  it("appends '✓ N steps' footer when final=true and stepCount > 0", () => {
+    const lines = ["Reading CLAUDE.md", "Searching memory", "Running a command"];
+    const out = renderActivityFeed(lines, true, "", 5)!;
+    // All lines are done (✓) and the footer is appended.
+    expect(out).toContain("<i>✓ Running a command</i>");
+    expect(out).toContain("<i>✓ 5 steps</i>");
+    expect(out.endsWith("<i>✓ 5 steps</i>")).toBe(true);
+  });
+
+  it("stepCount=0 → no footer (no tools fired that were surfaced)", () => {
+    const lines = ["Reading CLAUDE.md"];
+    const out = renderActivityFeed(lines, true, "", 0)!;
+    expect(out).not.toContain("steps");
+    expect(out).toBe("<i>✓ Reading CLAUDE.md</i>");
+  });
+
+  it("stepCount undefined → no footer (live/non-final callers omit it)", () => {
+    const lines = ["Reading CLAUDE.md"];
+    const out = renderActivityFeed(lines, true)!;
+    expect(out).not.toContain("steps");
+  });
+
+  it("stepCount present but final=false → no footer (live in-progress feed stays clean)", () => {
+    const lines = ["Reading CLAUDE.md", "Running a command"];
+    const out = renderActivityFeed(lines, false, "", 7)!;
+    expect(out).not.toContain("steps");
+    // The newest line is still the live in-progress step.
+    expect(out).toContain("<b>→ Running a command</b>");
+  });
+
+  it("stepCount=1 footer reads '✓ 1 steps' (no special-casing)", () => {
+    const lines = ["Reading CLAUDE.md"];
+    const out = renderActivityFeed(lines, true, "", 1)!;
+    expect(out).toContain("<i>✓ 1 steps</i>");
+  });
+
+  it("footer appears even when the feed overflows MIRROR_MAX_LINES", () => {
+    const lines = Array.from({ length: 9 }, (_, i) => `Action ${i + 1}`);
+    const out = renderActivityFeed(lines, true, "", 9)!;
+    expect(out).toContain("<i>✓ +3 earlier…</i>");
+    expect(out).toContain("<i>✓ 9 steps</i>");
+    expect(out.endsWith("<i>✓ 9 steps</i>")).toBe(true);
+  });
+
+  it("stepCount is surface-tool-excluded: reply/react count 0, Read+mcp count correctly", () => {
+    // This test documents the counting contract: stepCount is incremented
+    // after the isTelegramSurfaceTool guard in case 'tool_label', so surface
+    // tools (reply/stream_reply/edit_message/react) are never counted. The
+    // rendered footer reflects only the surfaced non-surface steps.
+    const lines = ["Reading CLAUDE.md", "Searching memory"]; // 2 non-surface labels
+    // stepCount=2 (Read + mcp__hindsight__recall) — reply is NOT counted.
+    const out = renderActivityFeed(lines, true, "", 2)!;
+    expect(out).toContain("<i>✓ 2 steps</i>");
+    // stepCount=0 would mean only surface tools fired — no footer.
+    const outSurfaceOnly = renderActivityFeed(["Reading CLAUDE.md"], true, "", 0)!;
+    expect(outSurfaceOnly).not.toContain("steps");
+  });
+});
+
 describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A)", () => {
   it("with no child lines, is identical to the flat feed", () => {
     const lines = ["Searching memory", "Delegating: review the migration"];
@@ -265,6 +325,26 @@ describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A
     expect(renderActivityFeedWithNested(["Reading a.ts"], [], false, " · 9s")).toBe(
       "<b>→ Reading a.ts · 9s</b>",
     );
+  });
+
+  it("stepCount footer appears on final=true with children present", () => {
+    const parent = ["Delegating: review the migration"];
+    const child = ["Reading schema.ts", "Looking for foreign keys"];
+    const out = renderActivityFeedWithNested(parent, child, true, "", 5)!;
+    expect(out).toContain("<i>✓ 5 steps</i>");
+    expect(out.endsWith("<i>✓ 5 steps</i>")).toBe(true);
+    expect(out).not.toContain("→");
+  });
+
+  it("stepCount footer appears on final=true with no children (delegates to flat render)", () => {
+    const out = renderActivityFeedWithNested(["Reading a.ts"], [], true, "", 3)!;
+    expect(out).toContain("<i>✓ 3 steps</i>");
+    expect(out).toBe("<i>✓ Reading a.ts</i>\n<i>✓ 3 steps</i>");
+  });
+
+  it("stepCount=0 → no footer even on final=true", () => {
+    const out = renderActivityFeedWithNested(["Reading a.ts"], [], true, "", 0)!;
+    expect(out).not.toContain("steps");
   });
 
   // Pins the invariant the gateway's foreground handoff-clear path relies on:

--- a/telegram-plugin/tests/tool-label-sidecar.test.ts
+++ b/telegram-plugin/tests/tool-label-sidecar.test.ts
@@ -147,4 +147,48 @@ describe('tool-label-sidecar', () => {
     expect(s.getLabel('A')).toBe('first')
     s.stop()
   })
+
+  /**
+   * Issue #2461: the sidecar's `onLabel` callback exposes `toolName` so the
+   * gateway can filter surface tools (reply/stream_reply/edit_message/react)
+   * from the surfaced step count. This test pins that the toolName flows
+   * through correctly for both non-surface and surface-tool entries, so the
+   * gateway's `isTelegramSurfaceTool(ev.toolName)` guard works as the single
+   * filter that keeps reply/react out of `labeledToolCount`.
+   *
+   * Note: send_typing and sync_retain never appear here because
+   * computeLabel returns null for them → hook never writes to the sidecar.
+   */
+  it('toolName flows through onLabel so callers can exclude surface tools from counts', () => {
+    const sessionId = 'sess-count'
+    const sched = makeManualScheduler()
+    const f = join(stateDir, `tool-labels-${sessionId}.jsonl`)
+    writeFileSync(
+      f,
+      // Non-surface tools — should be counted.
+      JSON.stringify({ ts: 1, tool_use_id: 'R1', agent_id: null, label: 'Reading CLAUDE.md', tool_name: 'Read' }) + '\n' +
+      JSON.stringify({ ts: 2, tool_use_id: 'M1', agent_id: null, label: 'Searching memory', tool_name: 'mcp__hindsight__recall' }) + '\n' +
+      // Surface tool — must NOT be counted.
+      JSON.stringify({ ts: 3, tool_use_id: 'RP', agent_id: null, label: 'Replying', tool_name: 'mcp__switchroom-telegram__reply' }) + '\n' +
+      // Another non-surface.
+      JSON.stringify({ ts: 4, tool_use_id: 'B1', agent_id: null, label: 'List workspace', tool_name: 'Bash' }) + '\n',
+    )
+    const s = createToolLabelSidecar({ stateDir, sessionId, scheduler: sched })
+
+    const SURFACE_TOOLS = new Set([
+      'mcp__switchroom-telegram__reply',
+      'mcp__switchroom-telegram__stream_reply',
+      'mcp__switchroom-telegram__edit_message',
+      'mcp__switchroom-telegram__react',
+    ])
+
+    let surfacedCount = 0
+    s.onLabel((_id, _label, toolName) => {
+      if (!SURFACE_TOOLS.has(toolName)) surfacedCount++
+    })
+
+    // Read + mcp__hindsight__recall + Bash = 3 surfaced; reply = 0.
+    expect(surfacedCount).toBe(3)
+    s.stop()
+  })
 })

--- a/telegram-plugin/tests/tool-labels.test.ts
+++ b/telegram-plugin/tests/tool-labels.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { toolLabel, isHumanDescription } from '../tool-labels.js'
+import { isTelegramSurfaceTool } from '../tool-names.js'
 
 describe('toolLabel', () => {
   it('Read: uses basename of file_path', () => {
@@ -379,5 +380,71 @@ describe('isHumanDescription', () => {
   it('missing or non-object input → false', () => {
     expect(isHumanDescription('Bash', undefined)).toBe(false)
     expect(isHumanDescription('Bash')).toBe(false)
+  })
+})
+
+/**
+ * Surface-tool exclusion contract (#2461).
+ *
+ * The gateway's `labeledToolCount` is incremented in `case 'tool_label':` AFTER
+ * `isTelegramSurfaceTool(ev.toolName)` returns false — so the count reflects
+ * only non-surface tools. This describe block pins that contract by verifying
+ * which tool names are classified as surface tools (never counted) vs
+ * non-surface tools (counted when they produce a label).
+ *
+ * send_typing and sync_retain are excluded at the hook level: `computeLabel`
+ * returns null for them → no sidecar line → no tool_label event → never reach
+ * the `labeledToolCount++` path. That suppression is tested in
+ * tool-label-sidecar.test.ts (the sidecar never gets those entries).
+ */
+describe('isTelegramSurfaceTool — surface-tool exclusion for labeledToolCount (#2461)', () => {
+  it('reply and stream_reply are surface tools — never counted', () => {
+    expect(isTelegramSurfaceTool('mcp__switchroom-telegram__reply')).toBe(true)
+    expect(isTelegramSurfaceTool('mcp__switchroom-telegram__stream_reply')).toBe(true)
+  })
+
+  it('edit_message and react are surface tools — never counted', () => {
+    expect(isTelegramSurfaceTool('mcp__switchroom-telegram__edit_message')).toBe(true)
+    expect(isTelegramSurfaceTool('mcp__switchroom-telegram__react')).toBe(true)
+  })
+
+  it('Read tool is NOT a surface tool — counted when it produces a label', () => {
+    expect(isTelegramSurfaceTool('Read')).toBe(false)
+  })
+
+  it('mcp__hindsight__* tools are NOT surface tools — counted', () => {
+    expect(isTelegramSurfaceTool('mcp__hindsight__recall')).toBe(false)
+    expect(isTelegramSurfaceTool('mcp__hindsight__retain')).toBe(false)
+    expect(isTelegramSurfaceTool('mcp__hindsight__reflect')).toBe(false)
+  })
+
+  it('Bash, Edit, Write, Grep are NOT surface tools — counted', () => {
+    expect(isTelegramSurfaceTool('Bash')).toBe(false)
+    expect(isTelegramSurfaceTool('Edit')).toBe(false)
+    expect(isTelegramSurfaceTool('Write')).toBe(false)
+    expect(isTelegramSurfaceTool('Grep')).toBe(false)
+  })
+
+  it('operator MCP tools (perplexity, webkite, etc.) are NOT surface tools — counted', () => {
+    expect(isTelegramSurfaceTool('mcp__perplexity__perplexity_search')).toBe(false)
+    expect(isTelegramSurfaceTool('mcp__webkite__read')).toBe(false)
+    expect(isTelegramSurfaceTool('mcp__google-workspace__list_events')).toBe(false)
+  })
+
+  it('other switchroom-telegram tools (get_recent_messages, send_typing) are NOT surface tools', () => {
+    // get_recent_messages is a read/query tool — not a conversation surface tool.
+    expect(isTelegramSurfaceTool('mcp__switchroom-telegram__get_recent_messages')).toBe(false)
+    // send_typing is suppressed at the hook level (computeLabel returns null),
+    // so it never generates a tool_label event. But isTelegramSurfaceTool itself
+    // does NOT classify it as a surface tool — the two suppression mechanisms
+    // are orthogonal. The hook suppression is the right gate for send_typing.
+    expect(isTelegramSurfaceTool('mcp__switchroom-telegram__send_typing')).toBe(false)
+  })
+
+  it('clerk-telegram prefix also works (legacy registration key)', () => {
+    expect(isTelegramSurfaceTool('mcp__clerk-telegram__reply')).toBe(true)
+    expect(isTelegramSurfaceTool('mcp__clerk-telegram__stream_reply')).toBe(true)
+    expect(isTelegramSurfaceTool('mcp__clerk-telegram__edit_message')).toBe(true)
+    expect(isTelegramSurfaceTool('mcp__clerk-telegram__react')).toBe(true)
   })
 })

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -199,11 +199,16 @@ function escapeFeedHtml(s: string): string {
  * are italic with a `✓`. Capped to the last MIRROR_MAX_LINES with a dim
  * `✓ +N earlier…` header when the turn ran longer. Returns null when empty.
  * Callers send the result verbatim — do NOT re-escape or re-wrap it.
+ *
+ * `stepCount` (optional): when `final=true` and `stepCount > 0`, appends a
+ * `✓ N steps` footer line so the persisted feed record shows an accurate
+ * total of surfaced (non-surface-tool) steps for the turn.
  */
 export function renderActivityFeed(
   lines: string[],
   final = false,
   liveSuffix = "",
+  stepCount?: number,
 ): string | null {
   if (lines.length === 0) return null;
   const shown = lines.slice(-MIRROR_MAX_LINES);
@@ -223,6 +228,12 @@ export function renderActivityFeed(
     const esc = escapeFeedHtml(l);
     out.push(i === lastIdx && !final ? `<b>→ ${esc}${liveSuffix}</b>` : `<i>✓ ${esc}</i>`);
   });
+  // Final total: append a `✓ N steps` footer when the turn has a non-zero
+  // surfaced step count. Only shown on the persisted terminal render
+  // (`final=true`) so the live in-progress feed stays clean.
+  if (final && stepCount != null && stepCount > 0) {
+    out.push(`<i>✓ ${stepCount} steps</i>`);
+  }
   return out.join("\n");
 }
 
@@ -251,15 +262,19 @@ const NESTED_PREFIX = "   ↳ ";
  * and the child block is indented, newest = bold `→`, earlier = italic, with
  * a `↳ +N earlier…` header when it overflows. Returns ready Telegram HTML
  * (callers must NOT re-escape) or null when there is nothing to show.
+ *
+ * `stepCount` (optional): forwarded to `renderActivityFeed` for the `✓ N steps`
+ * footer on the persisted terminal render (`final=true`).
  */
 export function renderActivityFeedWithNested(
   lines: string[],
   childLines: string[],
   final = false,
   liveSuffix = "",
+  stepCount?: number,
 ): string | null {
   const children = childLines.map((s) => s.trim()).filter((s) => s.length > 0);
-  if (children.length === 0) return renderActivityFeed(lines, final, liveSuffix);
+  if (children.length === 0) return renderActivityFeed(lines, final, liveSuffix, stepCount);
 
   const out: string[] = [];
   const shownParent = lines.slice(-MIRROR_MAX_LINES);
@@ -283,6 +298,10 @@ export function renderActivityFeedWithNested(
         : `${NESTED_PREFIX}<i>${esc}</i>`,
     );
   });
+  // Final total: same `✓ N steps` footer as the flat render.
+  if (final && stepCount != null && stepCount > 0) {
+    out.push(`<i>✓ ${stepCount} steps</i>`);
+  }
   return out.length > 0 ? out.join("\n") : null;
 }
 


### PR DESCRIPTION
Fixes #2461.

## Problem
The in-session activity feed undercounted tool calls: `toolCallCount++` on `case 'tool_use'` read transcript JSONL not yet flushed at turn-end, and impurely counted telegram surface tools (reply/stream_reply/edit_message/react).

## Fix
- Count off the synchronous `tool_label` sidecar (`case 'tool_label'`), incrementing a new `labeledToolCount` field AFTER the `isTelegramSurfaceTool` guard so surface tools are excluded.
- Surface that count in the turn-lifecycle `tools=` field (status-surface-log.ts).
- Persist an accurate `✓ N steps` total in the final feed render (tool-activity-summary.ts), gated on `final=true`.
- The old `toolCallCount` (case 'tool_use') is left intact — it serves the separate #332 turn-registry column; no double-count.

## Tests
- tool-activity-summary.test.ts (44), status-surface-log.test.ts (11, new), tool-label-sidecar.test.ts (8), tool-labels.test.ts (63) — 126/126 pass.
- Build clean; full suite unaffected (pre-existing env failures only).

Reviewed independently (build + targeted suites run green) before merge.