### PR TITLE
Fix approval card: show caller reason as why + name target agent (#2469)

### DIFF
--- a/telegram-plugin/permission-title.ts
+++ b/telegram-plugin/permission-title.ts
@@ -78,6 +78,21 @@ const INTERNAL_MCP_SERVERS = new Set([
 ]);
 
 /**
+ * hostd fleet verbs that take a target agent `name` as a required arg. The
+ * approval card MUST name WHICH agent is targeted (#2469) — "restart an
+ * agent" with no name leaves the operator blind. We interpolate the target
+ * into the curated phrase: "restart an agent in the fleet" → "restart agent
+ * `carrie` in the fleet". Stays generic when `name` is absent (never crash).
+ */
+const HOSTD_AGENT_TARGET_VERBS = new Set([
+  "mcp__hostd__agent_restart",
+  "mcp__hostd__agent_start",
+  "mcp__hostd__agent_stop",
+  "mcp__hostd__agent_logs",
+  "mcp__hostd__agent_exec",
+]);
+
+/**
  * Build the multi-line card body for an approval prompt.
  *
  *   🔐 <b>Gymbro</b> wants to edit: supplement-log.md
@@ -86,10 +101,23 @@ const INTERNAL_MCP_SERVERS = new Set([
  * Output is HTML-escaped for `parse_mode: 'HTML'`. The agent name is
  * capitalized for the sentence; dropped (with "wants to") when null —
  * the bridge client can be anonymous during early-boot edge cases.
+ *
+ * The `why:` line is the CALLER's stated rationale — the `reason`/`why`
+ * argument on the tool input, NOT the tool's static JSONSchema
+ * `description`. The schema description is documentation (it can contain
+ * literal tokens like `$SWITCHROOM_AGENT_NAME`), so surfacing it as the
+ * "why" reads like an un-interpolated variable and discards the agent's
+ * actual reason (#2469). We only fall back to "not provided" — never to
+ * the schema description.
  */
 export function formatPermissionCardBody(opts: {
   toolName: string;
   inputPreview: string | undefined;
+  /**
+   * The tool's static JSONSchema description. Retained for the signature
+   * (callers still pass it) but deliberately NOT used as the `why:` line —
+   * see #2469. The caller's rationale comes from the input args instead.
+   */
   description: string | undefined;
   agentName: string | null;
 }): string {
@@ -104,7 +132,10 @@ export function formatPermissionCardBody(opts: {
     lines.push(`🔐 ${escapeTgHtml(capFirst(action))}`);
   }
 
-  const rawWhy = (opts.description ?? "").replace(/\s+/g, " ").trim();
+  // why: the caller-supplied rationale (`reason`/`why` arg), never the
+  // static schema description (#2469).
+  const callerReason = callerSuppliedReason(opts.inputPreview);
+  const rawWhy = (callerReason ?? "").replace(/\s+/g, " ").trim();
   const truncatedWhy =
     rawWhy.length > DESCRIPTION_LINE_MAX
       ? rawWhy.slice(0, DESCRIPTION_LINE_MAX - 1) + "…"
@@ -194,7 +225,7 @@ function naturalMcpAction(
   const server = parts.length >= 2 ? parts[1]! : "";
   const curated = MCP_TOOL_DESCRIPTIONS[toolName];
   if (curated) {
-    const phrase = lowerFirst(curated);
+    const phrase = hostdAgentPhrase(toolName, input) ?? lowerFirst(curated);
     return INTERNAL_MCP_SERVERS.has(server)
       ? phrase
       : `${phrase} (${prettyMcpServer(server)})`;
@@ -215,6 +246,37 @@ function naturalMcpAction(
       : `${verb} (${prettyMcpServer(server)})`;
   }
   return `use ${toolName}`;
+}
+
+/**
+ * For the hostd `agent_*` fleet verbs, build an action phrase that NAMES the
+ * target agent (#2469) — "restart agent `carrie` in the fleet". The verb is
+ * derived from the tool name (`agent_restart` → "restart"); `agent_logs` /
+ * `agent_exec` get bespoke phrasing. Returns null when the tool isn't a
+ * name-targeted hostd verb or no `name` arg is present, so the caller falls
+ * back to the generic curated phrase (never crashes on a missing name).
+ */
+function hostdAgentPhrase(
+  toolName: string,
+  input: Record<string, unknown> | null,
+): string | null {
+  if (!HOSTD_AGENT_TARGET_VERBS.has(toolName)) return null;
+  const name = input ? readString(input, "name") : null;
+  if (!name) return null;
+  switch (toolName) {
+    case "mcp__hostd__agent_restart":
+      return `restart agent \`${name}\` in the fleet`;
+    case "mcp__hostd__agent_start":
+      return `start agent \`${name}\` in the fleet`;
+    case "mcp__hostd__agent_stop":
+      return `stop agent \`${name}\` in the fleet`;
+    case "mcp__hostd__agent_logs":
+      return `read agent \`${name}\`'s container logs`;
+    case "mcp__hostd__agent_exec":
+      return `run a read-only inspection inside agent \`${name}\``;
+    default:
+      return null;
+  }
 }
 
 /**
@@ -445,6 +507,19 @@ function parseInput(raw: string | undefined): Record<string, unknown> | null {
 function readString(input: Record<string, unknown>, key: string): string | null {
   const value = input[key];
   return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/**
+ * The caller's stated rationale for a tool call — the `reason` (or `why`)
+ * argument it passed. This is the agent's actual justification, which is
+ * what belongs on the `why:` line of the approval card. Returns null when
+ * no reason was supplied (caller renders "not provided") — we never fall
+ * back to the tool's static schema description (#2469).
+ */
+function callerSuppliedReason(inputPreview: string | undefined): string | null {
+  const input = parseInput(inputPreview);
+  if (!input) return null;
+  return readString(input, "reason") ?? readString(input, "why");
 }
 
 function skillBasenameFromPath(input: Record<string, unknown>): string | null {

--- a/telegram-plugin/tests/permission-title.test.ts
+++ b/telegram-plugin/tests/permission-title.test.ts
@@ -119,11 +119,11 @@ describe('naturalAction — MCP tools', () => {
 })
 
 describe('formatPermissionCardBody', () => {
-  test('renders "<Agent> wants to <action>" + why line', () => {
+  test('renders "<Agent> wants to <action>" + why line (why = caller reason)', () => {
     const body = formatPermissionCardBody({
       toolName: 'Edit',
-      inputPreview: JSON.stringify({ file_path: '/work/supplement-log.md' }),
-      description: 'logging today\'s lifts',
+      inputPreview: JSON.stringify({ file_path: '/work/supplement-log.md', reason: 'logging today\'s lifts' }),
+      description: 'Edit a file on disk.',
       agentName: 'gymbro',
     })
     expect(body).toBe(
@@ -131,11 +131,46 @@ describe('formatPermissionCardBody', () => {
     )
   })
 
-  test('shows "not provided" when description is missing or whitespace', () => {
+  // #2469: the `why:` line is the CALLER's reason, never the tool's static
+  // schema description (which can contain literal $SWITCHROOM_* tokens).
+  test('why is the caller-supplied reason, NOT the schema description (#2469)', () => {
+    const body = formatPermissionCardBody({
+      toolName: 'mcp__hostd__agent_restart',
+      inputPreview: JSON.stringify({ name: 'carrie', reason: 'gateway is wedged, bouncing it' }),
+      description: 'Restart an agent via the host-control daemon. cross-agent (`name` ≠ $SWITCHROOM_AGENT_NAME) …',
+      agentName: 'carrie',
+    })
+    expect(body).toContain('why: <i>gateway is wedged, bouncing it</i>')
+    expect(body).not.toContain('$SWITCHROOM_AGENT_NAME')
+    expect(body).not.toContain('host-control daemon')
+  })
+
+  test('why accepts a `why` arg as well as `reason`', () => {
+    const body = formatPermissionCardBody({
+      toolName: 'Bash',
+      inputPreview: JSON.stringify({ command: 'ls /tmp', why: 'listing temp files' }),
+      description: 'Run a shell command.',
+      agentName: 'gymbro',
+    })
+    expect(body).toContain('why: <i>listing temp files</i>')
+  })
+
+  test('shows "not provided" when no caller reason is present (never the description)', () => {
     const body = formatPermissionCardBody({
       toolName: 'Bash',
       inputPreview: JSON.stringify({ command: 'ls /tmp' }),
-      description: '   \n ',
+      description: 'Run a shell command on the host.',
+      agentName: 'gymbro',
+    })
+    expect(body).toContain('why: <i>not provided</i>')
+    expect(body).not.toContain('Run a shell command')
+  })
+
+  test('shows "not provided" when caller reason is whitespace only', () => {
+    const body = formatPermissionCardBody({
+      toolName: 'Bash',
+      inputPreview: JSON.stringify({ command: 'ls /tmp', reason: '   \n ' }),
+      description: 'Run a shell command.',
       agentName: 'gymbro',
     })
     expect(body).toContain('why: <i>not provided</i>')
@@ -144,18 +179,18 @@ describe('formatPermissionCardBody', () => {
   test('drops the agent prefix when agentName is null (early-boot edge)', () => {
     const body = formatPermissionCardBody({
       toolName: 'Skill',
-      inputPreview: JSON.stringify({ skill: 'mail' }),
-      description: 'do the thing',
+      inputPreview: JSON.stringify({ skill: 'mail', reason: 'do the thing' }),
+      description: 'Use a skill.',
       agentName: null,
     })
     expect(body).toBe(['🔐 Use the mail skill', 'why: <i>do the thing</i>'].join('\n'))
   })
 
-  test('HTML-escapes <, >, & in agentName / action / description', () => {
+  test('HTML-escapes <, >, & in agentName / action / reason', () => {
     const body = formatPermissionCardBody({
       toolName: 'Bash',
-      inputPreview: JSON.stringify({ command: 'echo "a < b && c > d"' }),
-      description: 'compare a < b & c > d',
+      inputPreview: JSON.stringify({ command: 'echo "a < b && c > d"', reason: 'compare a < b & c > d' }),
+      description: 'Run a shell command.',
       agentName: 'agent<test>',
     })
     expect(body).toContain('&lt;test&gt;')
@@ -165,25 +200,73 @@ describe('formatPermissionCardBody', () => {
     expect(body).toContain('<i>')
   })
 
-  test('truncates a very long description with an ellipsis', () => {
+  test('truncates a very long caller reason with an ellipsis', () => {
     const body = formatPermissionCardBody({
       toolName: 'Skill',
-      inputPreview: JSON.stringify({ skill: 'mail' }),
-      description: 'x'.repeat(500),
+      inputPreview: JSON.stringify({ skill: 'mail', reason: 'x'.repeat(500) }),
+      description: 'Use a skill.',
       agentName: 'clerk',
     })
     expect(body).toContain('xxxx…</i>')
     expect(body.split('\n')[0]).toBe('🔐 <b>Clerk</b> wants to use the mail skill')
   })
 
-  test('collapses internal whitespace in the description', () => {
+  test('collapses internal whitespace in the caller reason', () => {
     const body = formatPermissionCardBody({
       toolName: 'Skill',
-      inputPreview: JSON.stringify({ skill: 'mail' }),
-      description: 'first\n\nsecond\t\t paragraph',
+      inputPreview: JSON.stringify({ skill: 'mail', reason: 'first\n\nsecond\t\t paragraph' }),
+      description: 'Use a skill.',
       agentName: 'clerk',
     })
     expect(body).toContain('why: <i>first second paragraph</i>')
+  })
+
+  // #2469: hostd agent_* cards must name WHICH agent is targeted, pulled
+  // from the `name` input arg — not the static curated phrase.
+  test('hostd agent_restart names the target agent in the title (#2469)', () => {
+    const body = formatPermissionCardBody({
+      toolName: 'mcp__hostd__agent_restart',
+      inputPreview: JSON.stringify({ name: 'carrie', reason: 'wedged' }),
+      description: 'Restart an agent via the host-control daemon. $SWITCHROOM_AGENT_NAME …',
+      agentName: 'klanker',
+    })
+    expect(body.split('\n')[0]).toBe('🔐 <b>Klanker</b> wants to restart agent `carrie` in the fleet')
+  })
+
+  test('hostd start/stop/logs/exec each name the target agent (#2469)', () => {
+    const mk = (tool: string) =>
+      formatPermissionCardBody({
+        toolName: tool,
+        inputPreview: JSON.stringify({ name: 'pixel' }),
+        description: 'static schema doc',
+        agentName: 'klanker',
+      }).split('\n')[0]
+    expect(mk('mcp__hostd__agent_start')).toBe('🔐 <b>Klanker</b> wants to start agent `pixel` in the fleet')
+    expect(mk('mcp__hostd__agent_stop')).toBe('🔐 <b>Klanker</b> wants to stop agent `pixel` in the fleet')
+    expect(mk('mcp__hostd__agent_logs')).toBe("🔐 <b>Klanker</b> wants to read agent `pixel`'s container logs")
+    expect(mk('mcp__hostd__agent_exec')).toBe('🔐 <b>Klanker</b> wants to run a read-only inspection inside agent `pixel`')
+  })
+
+  test('hostd agent verb without a name arg falls back to the generic phrase (no crash) (#2469)', () => {
+    const body = formatPermissionCardBody({
+      toolName: 'mcp__hostd__agent_restart',
+      inputPreview: JSON.stringify({ reason: 'bouncing the fleet' }),
+      description: 'static schema doc',
+      agentName: 'klanker',
+    })
+    expect(body.split('\n')[0]).toBe('🔐 <b>Klanker</b> wants to restart an agent in the fleet')
+    expect(body).toContain('why: <i>bouncing the fleet</i>')
+  })
+
+  test('non-name-arg gated verb (update_apply) stays generic and does not break (#2469)', () => {
+    const body = formatPermissionCardBody({
+      toolName: 'mcp__hostd__update_apply',
+      inputPreview: JSON.stringify({ reason: 'rolling out v0.16' }),
+      description: 'static schema doc',
+      agentName: 'klanker',
+    })
+    expect(body.split('\n')[0]).toBe('🔐 <b>Klanker</b> wants to apply a fleet-wide update (pull + recreate)')
+    expect(body).toContain('why: <i>rolling out v0.16</i>')
   })
 
   // Clarity fix: the card gains a third "↳" line summarizing the REST
@@ -195,6 +278,7 @@ describe('formatPermissionCardBody', () => {
       toolName: 'mcp__brevo__post',
       inputPreview: JSON.stringify({
         path: '/smtp/email',
+        reason: 'sending the priority-access invite',
         body: { subject: 'Priority access', templateId: 12, to: [{ email: 'lisa@example.com' }] },
       }),
       description: 'HIGH RISK: write to the brevo API (POST).',
@@ -202,7 +286,7 @@ describe('formatPermissionCardBody', () => {
     })
     const lines = body.split('\n')
     expect(lines[0]).toBe('🔐 <b>Marko</b> wants to POST /smtp/email (Brevo)')
-    expect(lines[1]).toBe('why: <i>HIGH RISK: write to the brevo API (POST).</i>')
+    expect(lines[1]).toBe('why: <i>sending the priority-access invite</i>')
     // Third line: scalar keys show value; the nested `to` array shows key-only.
     expect(lines[2]).toContain('↳')
     expect(lines[2]).toContain('subject: Priority access')


### PR DESCRIPTION
Fixes #2469

## Problem
The operator approval card for gated hostd verbs (e.g. `mcp__hostd__agent_restart`) was broken two ways:

1. The `why:` line showed the tool's **static JSONSchema description** instead of the caller-supplied `reason`. For `agent_restart` that description contains the literal token `$SWITCHROOM_AGENT_NAME`, so the card read like an un-interpolated variable and discarded the agent's actual rationale.
2. The card **never named the target agent** — "wants to restart an agent in the fleet" with no indication of WHICH agent, though `name` is a required arg.

## Fix
All in `telegram-plugin/permission-title.ts` (the true source; `dist/` is gitignored build output):

- `formatPermissionCardBody` now sources `why:` from the caller's `reason`/`why` input arg via a new `callerSuppliedReason` helper, falling back to `not provided` only when truly absent — **never** to the schema description.
- For the hostd `agent_restart`/`agent_start`/`agent_stop`/`agent_logs`/`agent_exec` verbs, `naturalMcpAction` interpolates the target `name` from the input args into the action phrase (e.g. "restart agent \`carrie\` in the fleet") via a new `hostdAgentPhrase` helper. Stays generic and crash-safe when no `name` arg is present (falls back to the curated phrase).

## Tests
Extended `telegram-plugin/tests/permission-title.test.ts` (45 pass): caller reason shown as `why`, schema description / `$SWITCHROOM_*` token never surfaced, `why`/`reason` both accepted, target agent name appears for all five hostd verbs, absent-`name` verb falls back without breaking, non-name gated verb (`update_apply`) stays generic. Existing tests that conflated `description` with the reason were updated to pass `reason` in the input.

`tsc --noEmit`, full `npm run lint`, and the targeted vitest suite all pass.

## Notes
- Touches the gateway hot path (the permission approval card rendered on every gated tool call).
- No regenerated `dist` bundle in the diff — `dist/` is gitignored and rebuilt on publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)