### PR TITLE
fix(gateway): don't re-fire obligation_represent after a reply satisfies it (#2472)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -326,6 +326,7 @@ import {
 } from './obligation-ledger.js'
 import { loadObligations, persistObligations } from './obligation-store.js'
 import { driveEscalation } from './escalation-drive.js'
+import { shouldSuppressRepresent } from './represent-guard.js'
 import { createInboundSpool } from './inbound-spool.js'
 import { purgeStaleTurnsForChat } from './turn-state-purge.js'
 import { decideInboundDelivery } from './inbound-delivery-gate.js'
@@ -5797,6 +5798,34 @@ function obligationSweep(): void {
     return
   }
   if (decision.action === 'represent') {
+    // Fix #2472 — duplicate-represent guard. Before re-presenting AGAIN, check
+    // whether the agent has ALREADY delivered a substantive outbound reply to
+    // this chat SINCE the obligation was most recently re-presented. If so the
+    // obligation is satisfied-but-misdetected (the reply landed but its routing
+    // didn't resolve back to this origin, so the normal close path missed it) —
+    // close silently and do NOT re-fire, which is what produced the near-identical
+    // duplicate in #2472 (reply 10608 answered represent_count=1, yet
+    // represent_count=2 fired anyway → duplicate 10609).
+    //
+    // The cutoff is `lastRepresentedAt` (the time of the PREVIOUS represent), NOT
+    // `openedAt`. This is load-bearing: the genuine "agent wrote a plain-text
+    // answer and never called reply" case must still represent ONCE. On the first
+    // represent `lastRepresentedAt` is undefined, so this guard is a no-op and the
+    // single represent fires as before. Only the SECOND-and-later represent is
+    // gated — exactly where a reply that landed between fires must suppress the
+    // re-ask. Falls back to false (never suppresses) if history is unavailable.
+    if (
+      shouldSuppressRepresent(o, {
+        historyEnabled: HISTORY_ENABLED,
+        hasOutboundDeliveredSince,
+      })
+    ) {
+      process.stderr.write(
+        `telegram gateway: obligation closed silently — reply delivered since last represent (no re-fire) origin=${o.originTurnId}\n`,
+      )
+      obligationLedger.close(o.originTurnId)
+      return
+    }
     // Re-present goes through the bridge → buffer. Only the represent path is
     // gated on an empty buffer (let the existing drain run first, avoid
     // double-presenting). Escalation below is NOT gated on the buffer — it is a

--- a/telegram-plugin/gateway/represent-guard.ts
+++ b/telegram-plugin/gateway/represent-guard.ts
@@ -1,0 +1,64 @@
+/**
+ * represent-guard.ts — the duplicate-represent guard for the obligation sweep,
+ * extracted from obligationSweep so the "satisfied-but-misdetected obligation
+ * must NOT re-fire" decision (#2472) is EXECUTABLE in a pure unit test.
+ *
+ * The bug (#2472): obligation_represent re-fired for the same origin_turn_id even
+ * after the agent had already answered represent_count=1 with a reply tool call,
+ * producing a second near-identical message. The reply landed but its routing did
+ * not resolve back to the origin, so the ledger's normal close path missed it —
+ * and the represent branch (unlike the escalate branch) had no belt-and-braces
+ * outbound-history check before re-firing.
+ *
+ * This helper is the decision the sweep's represent branch now consults. PURE —
+ * no Telegram, no SQLite; the gateway injects `hasOutboundDeliveredSince` as a
+ * predicate. The single load-bearing subtlety lives here in one testable place:
+ *
+ *   The cutoff is `lastRepresentedAt` (the time of the PREVIOUS represent), NOT
+ *   `openedAt`. On the FIRST represent (`lastRepresentedAt` undefined) the guard
+ *   is a no-op, so the genuine "agent wrote a plain-text answer and never called
+ *   the reply tool" case still re-presents ONCE. Only the SECOND-and-later
+ *   represent is gated — exactly where a reply that landed BETWEEN fires must
+ *   suppress the re-ask. A reply that predates the last represent (e.g. the
+ *   original plain-text answer) does not count, because it is not evidence the
+ *   most recent represent was answered.
+ */
+
+/** The obligation fields the represent guard inspects. */
+export interface RepresentGuardObligation {
+  readonly originTurnId: string
+  readonly chatId: string
+  readonly threadId?: number
+  /** Wall-clock ms this obligation was most recently re-presented, if ever. */
+  readonly lastRepresentedAt?: number
+}
+
+export interface RepresentGuardDeps {
+  /** True when history is available to query (else the guard never suppresses). */
+  historyEnabled: boolean
+  /**
+   * Has a SUBSTANTIVE assistant reply been delivered to this chat (optionally
+   * scoped to thread) at or after `sinceMs`? Wraps history.hasOutboundDeliveredSince.
+   */
+  hasOutboundDeliveredSince: (chatId: string, sinceMs: number, threadId?: number) => boolean
+}
+
+/**
+ * Decide whether a represent for `o` should be SUPPRESSED because the agent has
+ * already delivered a reply since the obligation was last re-presented.
+ *
+ * Returns true ⇒ the obligation is satisfied-but-misdetected; the caller closes
+ * it silently and does NOT re-fire. Returns false ⇒ proceed with the represent
+ * (first represent always proceeds; a represent with no reply since the last one
+ * proceeds; an unavailable history proceeds — never suppress on doubt).
+ */
+export function shouldSuppressRepresent(
+  o: RepresentGuardObligation,
+  deps: RepresentGuardDeps,
+): boolean {
+  if (!deps.historyEnabled) return false
+  // First represent: nothing to compare against — let the single re-ask fire so
+  // the genuine plain-text-no-reply case is preserved.
+  if (o.lastRepresentedAt == null) return false
+  return deps.hasOutboundDeliveredSince(o.chatId, o.lastRepresentedAt, o.threadId)
+}

--- a/telegram-plugin/tests/represent-guard.test.ts
+++ b/telegram-plugin/tests/represent-guard.test.ts
@@ -11,8 +11,8 @@ import { ObligationLedger } from "../gateway/obligation-ledger.js";
 // duplicate), while the genuine "plain text, never replied" case still represents
 // ONCE and the represent_count cap is honored.
 
-const CHAT = "8248703757";
-const ORIGIN = "8248703757:_#10605";
+const CHAT = "12345";
+const ORIGIN = "12345:_#10605";
 
 function obligation(over: Partial<RepresentGuardObligation> = {}): RepresentGuardObligation {
   return { originTurnId: ORIGIN, chatId: CHAT, ...over };

--- a/telegram-plugin/tests/represent-guard.test.ts
+++ b/telegram-plugin/tests/represent-guard.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  shouldSuppressRepresent,
+  type RepresentGuardObligation,
+} from "../gateway/represent-guard.js";
+import { ObligationLedger } from "../gateway/obligation-ledger.js";
+
+// Executable verification of the #2472 fix: obligation_represent must NOT re-fire
+// for an origin_turn_id that has already been answered by a reply since the last
+// represent (the satisfied-but-misdetected case that produced the near-identical
+// duplicate), while the genuine "plain text, never replied" case still represents
+// ONCE and the represent_count cap is honored.
+
+const CHAT = "8248703757";
+const ORIGIN = "8248703757:_#10605";
+
+function obligation(over: Partial<RepresentGuardObligation> = {}): RepresentGuardObligation {
+  return { originTurnId: ORIGIN, chatId: CHAT, ...over };
+}
+
+/** A hasOutboundDeliveredSince stub that returns true only for queries whose
+ *  cutoff falls at/after `replyTs` — modelling a reply delivered at replyTs. */
+function replyDeliveredAt(replyTs: number) {
+  return (_chat: string, sinceMs: number) => replyTs >= sinceMs;
+}
+
+describe("shouldSuppressRepresent — #2472 duplicate-represent guard", () => {
+  it("suppresses the SECOND represent once a reply landed since the FIRST represent", () => {
+    // The exact #2472 sequence: represent_count=1 fired at t=1000, the agent
+    // answered with a reply at t=1500, the sweep is about to fire count=2.
+    const o = obligation({ lastRepresentedAt: 1000 });
+    const suppress = shouldSuppressRepresent(o, {
+      historyEnabled: true,
+      hasOutboundDeliveredSince: replyDeliveredAt(1500),
+    });
+    expect(suppress).toBe(true); // do NOT re-fire → no duplicate 10609
+  });
+
+  it("does NOT suppress the FIRST represent — genuine plain-text-no-reply still represents once", () => {
+    // First represent: lastRepresentedAt is undefined. Even though an assistant
+    // message (the original plain-text answer) exists in history, the single
+    // re-ask must still fire — the agent never called the reply tool.
+    const o = obligation({ lastRepresentedAt: undefined });
+    const suppress = shouldSuppressRepresent(o, {
+      historyEnabled: true,
+      // history WOULD report an outbound exists, but the first represent ignores it
+      hasOutboundDeliveredSince: () => true,
+    });
+    expect(suppress).toBe(false); // represent fires exactly once
+  });
+
+  it("does NOT suppress a later represent when NO reply landed since the last one", () => {
+    // count=1 fired at t=1000, nothing answered it → count=2 must still fire.
+    const o = obligation({ lastRepresentedAt: 1000 });
+    const suppress = shouldSuppressRepresent(o, {
+      historyEnabled: true,
+      hasOutboundDeliveredSince: () => false,
+    });
+    expect(suppress).toBe(false);
+  });
+
+  it("a reply that PREDATES the last represent does not count (cutoff is lastRepresentedAt, not openedAt)", () => {
+    // The original plain-text answer landed at t=500, before the represent at
+    // t=1000. That is not evidence the represent itself was answered → fire.
+    const o = obligation({ lastRepresentedAt: 1000 });
+    const suppress = shouldSuppressRepresent(o, {
+      historyEnabled: true,
+      hasOutboundDeliveredSince: replyDeliveredAt(500),
+    });
+    expect(suppress).toBe(false);
+  });
+
+  it("never suppresses when history is unavailable (safe: re-ask rather than silently drop)", () => {
+    const o = obligation({ lastRepresentedAt: 1000 });
+    const suppress = shouldSuppressRepresent(o, {
+      historyEnabled: false,
+      hasOutboundDeliveredSince: () => true,
+    });
+    expect(suppress).toBe(false);
+  });
+});
+
+describe("represent_count cap is honored by the ledger — a misdetected obligation cannot loop", () => {
+  it("escalates (stops re-presenting) once representCount reaches maxRepresents", () => {
+    const L = new ObligationLedger(2); // maxRepresents = 2
+    L.openIfAbsent({
+      originTurnId: ORIGIN,
+      chatId: CHAT,
+      messageId: 10605,
+      text: "Check there was a bug raised…",
+      openedAt: 0,
+    });
+
+    // count 0 -> represent
+    expect(L.decideAtIdle().action).toBe("represent");
+    L.markRepresented(ORIGIN, 1000);
+    // count 1 -> represent
+    expect(L.decideAtIdle().action).toBe("represent");
+    L.markRepresented(ORIGIN, 2000);
+    // count 2 == cap -> escalate, NOT another represent
+    expect(L.decideAtIdle().action).toBe("escalate");
+
+    // and the ladder terminates: closing on escalate ends it
+    L.close(ORIGIN);
+    expect(L.decideAtIdle().action).toBe("none");
+  });
+});


### PR DESCRIPTION
Fixes #2472

## Problem
`obligation_represent` re-fired for the same `origin_turn_id` even after the agent had already answered it with a `reply` tool call, producing a second near-identical message. Observed live in chat `8248703757`: reply `10608` answered `represent_count=1`, yet `represent_count=2` fired anyway → duplicate `10609`.

## Root cause
The obligation sweep's **represent** branch had no belt-and-braces outbound-history check before re-firing. The **escalate** branch already consulted `hasOutboundDeliveredSince`; the represent branch did not. When a reply lands but its routing doesn't resolve back to the origin, the ledger's normal close path misses it and the next represent fires regardless.

## Fix
Before re-presenting **again**, check whether a substantive assistant reply was delivered to the chat **since the obligation was most recently re-presented**. If so, close the obligation silently and do **not** re-fire.

The cutoff is `lastRepresentedAt` (**not** `openedAt`) — this is load-bearing:
- **Genuine case** (agent wrote plain text, never called `reply`): on the first represent `lastRepresentedAt` is undefined → guard is a no-op → the single re-ask still fires.
- **Duplicate case**: on the second-and-later represent, a reply that landed since the previous represent suppresses the re-ask.

The `represent_count` cap (`OBLIGATION_REPRESENT_MAX = 2` → escalate → close) was already enforced by `decideAtIdle` and is unchanged; this adds the satisfied-check that bounds a *misdetected-but-answered* obligation.

## Changes
- `telegram-plugin/gateway/represent-guard.ts` (new) — pure `shouldSuppressRepresent` decision, mirroring the `escalation-drive.ts` extraction pattern so it's unit-testable in isolation.
- `telegram-plugin/gateway/gateway.ts` — the obligation sweep's represent branch now consults the guard; on suppression it closes silently and returns instead of re-firing.
- `telegram-plugin/tests/represent-guard.test.ts` (new) — 6 cases: suppresses the second represent once a reply lands; first represent still fires; a reply predating the last represent does not count; never suppresses when history is unavailable; and the `represent_count` cap is honored by the real `ObligationLedger`.

## Tests
- `vitest run` represent-guard + obligation-ledger + obligation-determinism + escalation-drive + obligation-store: **75 passed**.
- `tsc --noEmit`: clean.
- `node scripts/build.mjs`: success.

## Heads-up
This touches the **gateway reply-enforcement hot path** (the idle obligation sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)