### PR TITLE
fix(quota-watch): gate fleet all-exhausted alert behind live probe corroboration (#2478)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -16000,6 +16000,10 @@ async function runQuotaWatch(opts: { bootTick?: boolean } = {}): Promise<void> {
       accounts: listStateData.accounts,
       prev: fleetPrev,
       now,
+      // #2478: the same staleness ceiling the per-account loop uses. Gates the
+      // `entered` alert behind live corroboration so a probe blackout's stale
+      // marks can't false-fire 🔴 All accounts exhausted.
+      tuning,
     })
     if (fleetDecision.kind === 'notify') {
       for (const chat_id of access.allowFrom) {

--- a/telegram-plugin/quota-watch.ts
+++ b/telegram-plugin/quota-watch.ts
@@ -324,22 +324,58 @@ export type FleetAllExhaustedDecision =
  * cases the trigger-based interactive all-blocked card misses: a quiet period
  * (no agent happens to 429 into the wall) and the consumer/cron paths.
  *
- * Authoritative source: the broker's per-account `exhausted` flag (set by
- * mark-exhausted via failover + the consumer sensor), NOT probe-derived health
- * — so there is no probe-failure false-alarm. Requires at least one account;
- * an empty fleet never alerts.
+ * Source: the broker's per-account `exhausted` flag (set by mark-exhausted via
+ * failover + the consumer sensor). That flag is NOT purely live — `isAccountBlocked`
+ * (src/auth/broker/account-eligibility.ts) falls back to the persisted
+ * `exhausted_until` mark whenever there is no fresh live snapshot. During a
+ * broker-unreachable / probe-timeout blackout, short-lived auto-fallback marks
+ * can make `every(a.exhausted)` momentarily true with ZERO live corroboration
+ * (#2478, klanker 2026-06-20). So the `entered` alert requires POSITIVE LIVE
+ * CORROBORATION: an account counts toward "all exhausted" only when its
+ * `exhausted` flag is backed by a FRESH live snapshot (last_quota.capturedAt
+ * within `maxStaleMs`) OR a serve-blocking overage (out_of_credits at any util).
+ * If ANY account's exhaustion rests solely on a stale/absent-probe mark we are
+ * probe-blind and return `skip: "probe-blind"` — no false fleet alert. The
+ * guarantee is "no false alarm off stale marks during a probe blackout", NOT
+ * blanket probe-failure immunity. The `recovered` transition is unguarded so a
+ * legitimately-fired alert is never stranded. Requires at least one account; an
+ * empty fleet never alerts.
  */
 export function evaluateFleetAllExhausted(args: {
-  accounts: Array<{ label: string; exhausted: boolean; exhausted_until?: number }>;
+  accounts: Array<{
+    label: string;
+    exhausted: boolean;
+    exhausted_until?: number;
+    /** Most-recent live probe snapshot, used to corroborate `exhausted`. */
+    last_quota?: {
+      capturedAt: number;
+      overageDisabledReason?: string | null;
+    } | null;
+  }>;
   prev: QuotaWatchAccountState;
   now: number;
+  /** Staleness ceiling for "fresh probe"; 0 disables the gate (legacy callers/tests). */
+  tuning?: Pick<QuotaWatchTuning, "maxStaleMs">;
 }): FleetAllExhaustedDecision {
   const { accounts, prev, now } = args;
+  const maxStaleMs = args.tuning?.maxStaleMs ?? 0;
   const allExhausted = accounts.length > 0 && accounts.every((a) => a.exhausted);
   // "throttling" doubles as the "currently alerting all-exhausted" marker.
   const wasAlerting = prev.lastNotifiedHealth === "throttling";
 
   if (allExhausted && !wasAlerting) {
+    // Probe-blind guard (#2478): only fire `entered` if EVERY account's
+    // exhaustion is backed by live evidence — a fresh snapshot or a
+    // serve-blocking overage. An account exhausted solely on a stale/absent
+    // mark means we have no live corroboration → skip rather than false-alarm.
+    if (maxStaleMs > 0) {
+      const allLiveCorroborated = accounts.every((a) =>
+        exhaustionLiveCorroborated(a, now, maxStaleMs),
+      );
+      if (!allLiveCorroborated) {
+        return { kind: "skip", reason: "probe-blind" };
+      }
+    }
     return {
       kind: "notify",
       message: buildAllExhaustedMessage(accounts, now),
@@ -356,6 +392,34 @@ export function evaluateFleetAllExhausted(args: {
     };
   }
   return { kind: "skip", reason: allExhausted ? "still-all-exhausted" : "not-all-exhausted" };
+}
+
+/**
+ * Is an account's `exhausted` flag backed by live evidence (#2478)?
+ *
+ * True when the most-recent live probe is FRESH (`capturedAt` within
+ * `maxStaleMs`) — that fresh probe is what set/upholds the broker's blocked
+ * verdict — OR when the snapshot reports a serve-blocking overage
+ * (`out_of_credits`), which is an exhaustion in its own right at any util.
+ * False when there is no `last_quota` at all, or the snapshot is stale: the
+ * `exhausted` flag then rests solely on a persisted mark with no live backing,
+ * which is exactly the probe-blind condition that false-fires the fleet alert.
+ *
+ * Mirrors `isOverageServeBlocking` / `snapshotFresh` in
+ * src/auth/broker/account-eligibility.ts (the serving-side authority); kept as
+ * a local check so the decision layer carries no broker dependency.
+ */
+function exhaustionLiveCorroborated(
+  account: {
+    last_quota?: { capturedAt: number; overageDisabledReason?: string | null } | null;
+  },
+  now: number,
+  maxStaleMs: number,
+): boolean {
+  const lq = account.last_quota;
+  if (!lq) return false;
+  if (lq.overageDisabledReason === "out_of_credits") return true;
+  return now - lq.capturedAt <= maxStaleMs;
 }
 
 function buildAllExhaustedMessage(

--- a/telegram-plugin/tests/quota-watch.test.ts
+++ b/telegram-plugin/tests/quota-watch.test.ts
@@ -369,24 +369,96 @@ describe("patchQuotaWatchState", () => {
 describe("evaluateFleetAllExhausted", () => {
   const notAlerting = { lastNotifiedHealth: null, lastNotifiedAt: 0 };
   const alerting = { lastNotifiedHealth: "throttling" as const, lastNotifiedAt: 1000 };
+  // Use a realistic "now" so a fresh probe (capturedAt near NOW) and a stale
+  // probe (capturedAt older than maxStaleMs) are unambiguous.
+  const NOW = 10_000_000_000;
+  const STALE = DEFAULT_QUOTA_WATCH_MAX_STALE_MS;
+  const gate = { maxStaleMs: STALE };
+  /** A fresh live snapshot captured `ageMs` ago (default: just now). */
+  const freshProbe = (ageMs = 0) => ({ capturedAt: NOW - ageMs });
+  /** A stale snapshot, captured just past the staleness ceiling. */
+  const staleProbe = () => ({ capturedAt: NOW - STALE - 1 });
 
-  it("notifies (entered) when every account is exhausted and we weren't alerting", () => {
+  it("notifies (entered) when every exhausted account is backed by a FRESH probe", () => {
     const d = evaluateFleetAllExhausted({
       accounts: [
-        { label: "a", exhausted: true, exhausted_until: 5_000 },
-        { label: "b", exhausted: true, exhausted_until: 9_000 },
+        { label: "a", exhausted: true, exhausted_until: NOW + 5_000, last_quota: freshProbe() },
+        { label: "b", exhausted: true, exhausted_until: NOW + 9_000, last_quota: freshProbe(60_000) },
       ],
       prev: notAlerting,
-      now: 1_000,
+      now: NOW,
+      tuning: gate,
     });
     expect(d.kind).toBe("notify");
     if (d.kind === "notify") {
       expect(d.transition).toBe("entered");
       expect(d.newState.lastNotifiedHealth).toBe("throttling");
       expect(d.message).toContain("All accounts exhausted");
-      // earliest reset is the 5_000 one
+      // earliest reset is the +5_000 one
       expect(d.message).toContain("Earliest reset");
     }
+  });
+
+  it("skips (probe-blind) when all exhausted rests on STALE marks with no fresh probe (#2478)", () => {
+    const d = evaluateFleetAllExhausted({
+      accounts: [
+        { label: "a", exhausted: true, exhausted_until: NOW + 5_000, last_quota: staleProbe() },
+        { label: "b", exhausted: true, exhausted_until: NOW + 9_000, last_quota: null },
+      ],
+      prev: notAlerting,
+      now: NOW,
+      tuning: gate,
+    });
+    expect(d.kind).toBe("skip");
+    if (d.kind === "skip") expect(d.reason).toBe("probe-blind");
+  });
+
+  it("skips (probe-blind) on MIXED freshness — one stale-mark-only account is enough (#2478)", () => {
+    const d = evaluateFleetAllExhausted({
+      accounts: [
+        { label: "a", exhausted: true, exhausted_until: NOW + 5_000, last_quota: freshProbe() },
+        { label: "b", exhausted: true, exhausted_until: NOW + 9_000, last_quota: staleProbe() },
+      ],
+      prev: notAlerting,
+      now: NOW,
+      tuning: gate,
+    });
+    expect(d.kind).toBe("skip");
+    if (d.kind === "skip") expect(d.reason).toBe("probe-blind");
+  });
+
+  it("notifies (entered) on a genuine serve-blocking overage (out_of_credits) with a fresh probe", () => {
+    const d = evaluateFleetAllExhausted({
+      accounts: [
+        {
+          label: "a",
+          exhausted: true,
+          last_quota: { capturedAt: NOW, overageDisabledReason: "out_of_credits" },
+        },
+      ],
+      prev: notAlerting,
+      now: NOW,
+      tuning: gate,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind === "notify") expect(d.transition).toBe("entered");
+  });
+
+  it("out_of_credits corroborates exhaustion even when the snapshot is past the staleness ceiling", () => {
+    // A serve-blocking overage is exhaustion in its own right — age-independent.
+    const d = evaluateFleetAllExhausted({
+      accounts: [
+        {
+          label: "a",
+          exhausted: true,
+          last_quota: { capturedAt: NOW - STALE - 1, overageDisabledReason: "out_of_credits" },
+        },
+      ],
+      prev: notAlerting,
+      now: NOW,
+      tuning: gate,
+    });
+    expect(d.kind).toBe("notify");
   });
 
   it("skips (still) when all exhausted and already alerting — no re-spam", () => {
@@ -394,15 +466,19 @@ describe("evaluateFleetAllExhausted", () => {
       accounts: [{ label: "a", exhausted: true }, { label: "b", exhausted: true }],
       prev: alerting,
       now: 2_000,
+      tuning: gate,
     });
     expect(d.kind).toBe("skip");
   });
 
-  it("notifies (recovered) when one account frees after we were alerting", () => {
+  it("notifies (recovered) when one account frees after we were alerting — UNGUARDED by probe-blind", () => {
+    // Recovery must fire even when freshness data is absent, so a legitimately
+    // fired alert is never stranded (#2478 scope: gate only the `entered` edge).
     const d = evaluateFleetAllExhausted({
       accounts: [{ label: "a", exhausted: false }, { label: "b", exhausted: true }],
       prev: alerting,
       now: 3_000,
+      tuning: gate,
     });
     expect(d.kind).toBe("notify");
     if (d.kind === "notify") {
@@ -413,20 +489,51 @@ describe("evaluateFleetAllExhausted", () => {
     }
   });
 
+  it("entered then recovered: a legit fire (fresh probes) is followed by a working recovery edge", () => {
+    const entered = evaluateFleetAllExhausted({
+      accounts: [
+        { label: "a", exhausted: true, last_quota: freshProbe() },
+        { label: "b", exhausted: true, last_quota: freshProbe() },
+      ],
+      prev: notAlerting,
+      now: NOW,
+      tuning: gate,
+    });
+    expect(entered.kind).toBe("notify");
+    if (entered.kind !== "notify") return;
+    expect(entered.transition).toBe("entered");
+    // Feed the persisted state forward; one account frees.
+    const recovered = evaluateFleetAllExhausted({
+      accounts: [
+        { label: "a", exhausted: false, last_quota: freshProbe() },
+        { label: "b", exhausted: true, last_quota: freshProbe() },
+      ],
+      prev: entered.newState,
+      now: NOW + 60_000,
+      tuning: gate,
+    });
+    expect(recovered.kind).toBe("notify");
+    if (recovered.kind === "notify") expect(recovered.transition).toBe("recovered");
+  });
+
   it("skips (not-all) when some account is healthy and we weren't alerting", () => {
     const d = evaluateFleetAllExhausted({
       accounts: [{ label: "a", exhausted: false }, { label: "b", exhausted: true }],
       prev: notAlerting,
       now: 4_000,
+      tuning: gate,
     });
     expect(d.kind).toBe("skip");
   });
 
   it("never alerts on an empty fleet", () => {
-    expect(evaluateFleetAllExhausted({ accounts: [], prev: notAlerting, now: 1 }).kind).toBe("skip");
+    expect(
+      evaluateFleetAllExhausted({ accounts: [], prev: notAlerting, now: 1, tuning: gate }).kind,
+    ).toBe("skip");
   });
 
-  it("shows reset-unknown when no exhausted_until is present", () => {
+  it("with the gate disabled (maxStaleMs 0) the legacy bare-mark behaviour is preserved", () => {
+    // Kill-switch parity: tuning omitted / 0 → fire on bare marks (pre-#2478).
     const d = evaluateFleetAllExhausted({
       accounts: [{ label: "a", exhausted: true }],
       prev: notAlerting,


### PR DESCRIPTION
Fixes #2478

## Problem
The `🔴 All accounts exhausted` operator alert false-fires during a broker probe blackout when the fleet is actually healthy. `evaluateFleetAllExhausted` decided the alert via `accounts.every(a => a.exhausted)`, reading the broker's `list-state` `exhausted` flag — which is **not** purely live: `isAccountBlocked` (`src/auth/broker/account-eligibility.ts`) falls back to the persisted `exhausted_until` mark when there is no fresh live snapshot. During a probe-timeout window, short-lived auto-fallback marks make `every(a.exhausted)` momentarily true with zero live corroboration, emitting the loud fleet push even though serving/failover are fine. Confirmed on klanker 2026-06-20 (08:05Z→10:20Z, bracketed by live-throttling transitions and an `AuthBrokerUnreachableError` at 10:20:39Z).

## Fix
Apply the staleness gate the per-account loop already has (`quota-watch.ts:219`) to the fleet `entered` decision:

- An account counts toward "all exhausted" only when its `exhausted` flag is backed by a **fresh** live snapshot (`last_quota.capturedAt` within `maxStaleMs`) **or** a serve-blocking overage (`out_of_credits` at any util — mirrors `isOverageServeBlocking`).
- If **any** account's exhaustion rests solely on a stale/absent-probe mark → `skip: "probe-blind"`, no alert.
- A genuine all-exhausted (fresh probes show every account blocked) still fires.

### Scope / safety
- Only the fleet `entered` edge is gated. The `recovered` transition stays **unguarded** so a legitimately-fired alert is never stranded.
- No change to serving/failover logic or the per-account 🟡/🟢/recovery alerts.
- Reuses the existing `maxStaleMs` tuning (`SWITCHROOM_QUOTA_WATCH_MAX_STALE_MS`); `0` is a kill-switch back to the legacy bare-mark behaviour.
- Corrected the module header that wrongly claimed blanket probe-failure immunity.

### End-to-end trace
broker probe outage → `isAccountBlocked` falls back to unexpired marks → `list-state.exhausted=true` on every account → `evaluateFleetAllExhausted` now checks `exhaustionLiveCorroborated` per account → no fresh `last_quota` / no `out_of_credits` → returns `skip: "probe-blind"` → gateway caller sees `kind !== "notify"` → **no `buildAllExhaustedMessage`, no `bot.api.sendMessage`**. A real wall (fresh probes blocked, or `out_of_credits`) passes the gate and still fires.

## Tests
`telegram-plugin/tests/quota-watch.test.ts` — added coverage for stale-marks→`probe-blind`, fresh-probes→fire, mixed→`probe-blind`, `out_of_credits`→fire, entered→recovered round-trip, plus a kill-switch parity case. Synthetic ids only.

```
tsc --noEmit                         → PASS (exit 0)
vitest run quota-watch.test.ts       → 51 passed (51)
check-no-pii-secrets                 → clean (2141 files)
check-plugin-references              → clean
node scripts/build.mjs               → done
```

## Rollout note
This touches the gateway quota-watch path (the operator-notification hot path). Recommend a **staggered rollout** rather than a fleet-wide bounce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)