### PR TITLE
fix(quota-watch): add clock-skew guard to exhaustionLiveCorroborated

### DIFF
--- a/telegram-plugin/quota-watch.ts
+++ b/telegram-plugin/quota-watch.ts
@@ -419,7 +419,12 @@ function exhaustionLiveCorroborated(
   const lq = account.last_quota;
   if (!lq) return false;
   if (lq.overageDisabledReason === "out_of_credits") return true;
-  return now - lq.capturedAt <= maxStaleMs;
+  // Mirror `snapshotFresh`'s clock-skew guard: a future-dated `capturedAt`
+  // makes `now - capturedAt` negative and would slip past the staleness gate,
+  // so a skewed snapshot reads as fresh. Reject snapshots dated more than the
+  // broker's 60_000 ms tolerance ahead of `now` (matches the inline literal in
+  // `snapshotFresh`, src/auth/broker/account-eligibility.ts).
+  return now - lq.capturedAt <= maxStaleMs && lq.capturedAt <= now + 60_000;
 }
 
 function buildAllExhaustedMessage(

--- a/telegram-plugin/tests/quota-watch.test.ts
+++ b/telegram-plugin/tests/quota-watch.test.ts
@@ -427,6 +427,40 @@ describe("evaluateFleetAllExhausted", () => {
     if (d.kind === "skip") expect(d.reason).toBe("probe-blind");
   });
 
+  it("skips (probe-blind) when a probe is FUTURE-dated beyond the clock-skew tolerance (#2479 nit)", () => {
+    // A future-dated capturedAt makes `now - capturedAt` negative, which would
+    // slip under the staleness ceiling and read as fresh. The clock-skew guard
+    // (mirrored from broker `snapshotFresh`: capturedAt <= now + 60_000) must
+    // reject it so a skewed snapshot does NOT corroborate exhaustion.
+    const futureProbe = () => ({ capturedAt: NOW + 60_000 + 1 }); // 1ms past tolerance
+    const d = evaluateFleetAllExhausted({
+      accounts: [
+        { label: "a", exhausted: true, exhausted_until: NOW + 5_000, last_quota: futureProbe() },
+      ],
+      prev: notAlerting,
+      now: NOW,
+      tuning: gate,
+    });
+    expect(d.kind).toBe("skip");
+    if (d.kind === "skip") expect(d.reason).toBe("probe-blind");
+  });
+
+  it("notifies (entered) when a probe is future-dated WITHIN the skew tolerance (boundary)", () => {
+    // Exactly +60_000 ms is within tolerance and still negative-age fresh — it
+    // must count as a fresh live probe (proves the guard is a future-dating
+    // skew allowance, not an outright rejection of any future timestamp).
+    const d = evaluateFleetAllExhausted({
+      accounts: [
+        { label: "a", exhausted: true, exhausted_until: NOW + 5_000, last_quota: { capturedAt: NOW + 60_000 } },
+      ],
+      prev: notAlerting,
+      now: NOW,
+      tuning: gate,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind === "notify") expect(d.transition).toBe("entered");
+  });
+
   it("notifies (entered) on a genuine serve-blocking overage (out_of_credits) with a fresh probe", () => {
     const d = evaluateFleetAllExhausted({
       accounts: [


### PR DESCRIPTION
## Summary

Follow-up to **#2478 / #2479** (reviewer nit on just-merged commit `35f3403`).

The `exhaustionLiveCorroborated` helper added in #2479 checks probe freshness as `now - lq.capturedAt <= maxStaleMs` but **omits the clock-skew guard** that the broker's mirror function `snapshotFresh` has (`src/auth/broker/account-eligibility.ts`):

```ts
return !!s && now - s.capturedAt <= maxAgeMs && s.capturedAt <= now + 60_000;
//                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ future-dating guard
```

Without it, a **future-dated** `capturedAt` makes `now - capturedAt` negative, so it passes the freshness gate and a clock-skewed snapshot is treated as a fresh live probe — wrongly corroborating fleet exhaustion and risking a false "all accounts exhausted" alert.

## The fix

One-line guard mirroring the broker's **exact** `60_000` ms tolerance (an inline literal in `snapshotFresh` — there is no named constant, so this reuses the same value, no new magic number):

```ts
return now - lq.capturedAt <= maxStaleMs && lq.capturedAt <= now + 60_000;
```

- The `out_of_credits` serve-blocking branch is unaffected (age-independent).
- The `maxStaleMs === 0` kill-switch and all existing cases are intact.

## Tests

Two added to `telegram-plugin/tests/quota-watch.test.ts`:
1. A probe future-dated **beyond** the skew tolerance (`NOW + 60_000 + 1`) on an otherwise-exhausted account does **not** corroborate → fleet alert still `skip: probe-blind`.
2. Boundary: a probe future-dated **exactly at** `NOW + 60_000` still counts as fresh → `entered` (proves the guard is a skew allowance, not a blanket rejection of any future timestamp).

Synthetic ids only.

## Verification

```
$ npx tsc --noEmit
TSC_EXIT=0

$ npx vitest run telegram-plugin/tests/quota-watch.test.ts
 ✓ telegram-plugin/tests/quota-watch.test.ts (53 tests) 20ms
 Test Files  1 passed (1)
      Tests  53 passed (53)   # 51 existing + 2 new
```

`scripts/check-no-pii-secrets.mjs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)