### PR TITLE
fix(agents): stop supervisor respawning autoaccept clean exit-0 (churn)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -67,6 +67,22 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
   # lifecycle. Ampersand-backgrounded by callers below.
   _switchroom_supervise() {
     local _name="$1"; local _logfile="$2"; shift 2
+    # Optional `--oneshot-ok` flag (must directly follow the logfile):
+    # marks a sidecar that can LEGITIMATELY complete. For such a sidecar
+    # a clean exit 0 means "job done" → stop supervising, no respawn.
+    # This is the autoaccept sidecar's case: under
+    # SWITCHROOM_WEDGE_WATCHDOG=0 it dispatches the first-run prompts and
+    # exits 0 by design (and if the watch loop ever returns cleanly, that
+    # too is a completed job, not a crash). Without this flag the old
+    # supervisor respawned that clean exit every 60s forever — pure
+    # restart/log churn with zero productive work (klanker, #2471 wedge
+    # diagnosis: 192 status=0 respawns). A must-always-run sidecar (the
+    # gateway, the scheduler) must NOT pass this flag — a clean exit
+    # there IS abnormal and must still restart.
+    local _oneshot_ok=0
+    if [ "${1:-}" = "--oneshot-ok" ]; then
+      _oneshot_ok=1; shift
+    fi
     local _cap=60
     local _delay=1
     local _attempt=0
@@ -86,6 +102,15 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
       # be terminal for an always-on agent.
       if [ $_exit -eq 78 ]; then
         echo "[supervise] $_name exit 78 (EX_CONFIG) — quarantined, not restarting. Operator action required." >> "$_logfile"
+        return 0
+      fi
+      # Clean completion of an opt-in one-shot-capable sidecar: the job
+      # finished successfully, so do NOT respawn (respawning a
+      # legitimately-completed exit-0 is the churn this guard removes).
+      # A non-zero exit still falls through to the indefinite backoff
+      # below — a crash always self-heals.
+      if [ $_oneshot_ok -eq 1 ] && [ $_exit -eq 0 ]; then
+        echo "[supervise] $_name completed cleanly (exit 0) — one-shot-ok, not respawning." >> "$_logfile"
         return 0
       fi
       # A run that stayed up for at least the backoff cap means the
@@ -139,7 +164,13 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
   #    keeps a flaky run from busy-looping. Set SWITCHROOM_WEDGE_WATCHDOG=0
   #    to restore the legacy boot-only single-shot behaviour.
   if [ -f /opt/switchroom/autoaccept-poll.js ] && command -v bun >/dev/null 2>&1; then
-    _switchroom_supervise autoaccept /var/log/switchroom/autoaccept.log \
+    # --oneshot-ok: this sidecar can legitimately complete (exit 0) — the
+    # boot-only mode (SWITCHROOM_WEDGE_WATCHDOG=0) dispatches the first-run
+    # prompts then exits, and a clean watch-loop return is also a finished
+    # job, not a crash. Marking it one-shot-ok stops the supervisor from
+    # respawning that clean exit every 60s forever (the #2471-diagnosed
+    # churn). A genuine crash (non-zero) still backs off + retries.
+    _switchroom_supervise autoaccept /var/log/switchroom/autoaccept.log --oneshot-ok \
       bun /opt/switchroom/autoaccept-poll.js "{{name}}" &
   fi
 

--- a/tests/gateway-supervisor-backoff.test.ts
+++ b/tests/gateway-supervisor-backoff.test.ts
@@ -89,6 +89,59 @@ describe("gateway supervisor — RFC J Phase 2 backoff", () => {
     expect(l).not.toMatch(/giving up|hit 10 restarts/i);
   }, 20_000);
 
+  it("--oneshot-ok: a clean exit 0 stops supervising (no respawn, no churn)", () => {
+    // Regression guard for the #2471 wedge-diagnosis churn: the autoaccept
+    // sidecar legitimately exits 0 (boot-only mode, or a clean watch-loop
+    // return). Without --oneshot-ok the supervisor respawned that exit
+    // every 60s forever (klanker: 192 status=0 respawns). With the flag a
+    // clean exit returns 0 immediately and never retries.
+    const log = join(dir, "oneshot.log");
+    const cnt = join(dir, "oneshot.cnt");
+    writeFileSync(cnt, "0");
+    const out = runBash(
+      `_switchroom_supervise tOS ${JSON.stringify(log)} --oneshot-ok sh -c '
+         n=$(cat ${JSON.stringify(cnt)}); n=$((n+1)); echo $n > ${JSON.stringify(cnt)}
+         exit 0'; echo "RC=$?"`,
+      10_000,
+    );
+    expect(out).toContain("RC=0");
+    // Ran exactly once — not respawned.
+    expect(readFileSync(cnt, "utf-8").trim()).toBe("1");
+    const l = readFileSync(log, "utf-8");
+    expect(l).toContain("completed cleanly (exit 0) — one-shot-ok, not respawning");
+    expect(l).not.toContain("retrying in");
+  });
+
+  it("--oneshot-ok: a NON-zero exit still backs off and retries (crash self-heals)", () => {
+    // The flag must only short-circuit clean completion. A crash (exit 1)
+    // from a one-shot-ok sidecar must still retry indefinitely — otherwise
+    // a flaky autoaccept boot would never recover.
+    const log = join(dir, "oneshot-crash.log");
+    runBash(
+      `_switchroom_supervise tOSC ${JSON.stringify(log)} --oneshot-ok sh -c 'exit 1' & SPID=$!
+       sleep 4; kill "$SPID" 2>/dev/null; wait "$SPID" 2>/dev/null; true`,
+      15_000,
+    );
+    const l = readFileSync(log, "utf-8");
+    expect(l).toContain("attempt=1) — retrying in 1s");
+    expect(l).toContain("attempt=2) — retrying in 2s");
+    expect(l).not.toContain("one-shot-ok, not respawning");
+  }, 15_000);
+
+  it("WITHOUT --oneshot-ok: a clean exit 0 is treated as a crash and respawns", () => {
+    // The default (gateway / scheduler) contract is unchanged: a clean
+    // exit 0 there is abnormal and must restart.
+    const log = join(dir, "default-exit0.log");
+    runBash(
+      `_switchroom_supervise tD0 ${JSON.stringify(log)} sh -c 'exit 0' & SPID=$!
+       sleep 4; kill "$SPID" 2>/dev/null; wait "$SPID" 2>/dev/null; true`,
+      15_000,
+    );
+    const l = readFileSync(log, "utf-8");
+    expect(l).toContain("attempt=1) — retrying in 1s");
+    expect(l).not.toContain("one-shot-ok");
+  }, 15_000);
+
   it("a run lasting >= cap resets the backoff (attempt back to 1)", () => {
     const log = join(dir, "c.log");
     const cnt = join(dir, "c.cnt");


### PR DESCRIPTION
Fixes #2481

## Summary

The `_switchroom_supervise` respawn loop in `profiles/_base/start.sh.hbs` respawned the supervised command on **any** non-`78` exit, including a clean **exit 0**. The autoaccept sidecar legitimately exits 0 when its job is done (boot-only mode under `SWITCHROOM_WEDGE_WATCHDOG=0`, or a clean watch-loop return), so the supervisor respawned that completion every 60s forever — pure restart/log churn with zero productive work. Surfaced during the #2471 wedge work while diagnosing agent `klanker` (192 `status=0` respawns, `attempt` after `attempt`).

## Why

Crash-restart should fire on *failure* (non-zero), not on *clean completion*. There was no equivalent to the exit-78 (EX_CONFIG) non-retry path for a sidecar that can legitimately finish with exit 0.

## Change

- `_switchroom_supervise` gains an opt-in `--oneshot-ok` flag (placed directly after the logfile arg). For a sidecar so marked, a clean exit 0 = "job done → stop supervising" (no respawn). A non-zero exit still backs off and retries indefinitely (a crash always self-heals).
- The autoaccept sidecar invocation passes `--oneshot-ok`. The gateway and scheduler (must-always-run) do **not** — a clean exit there is abnormal and must still restart.
- The exit-78 quarantine path and #2475's wedge-watchdog logic are untouched. Behind the existing `SWITCHROOM_WEDGE_WATCHDOG` kill-switch (boot-only mode is exactly the clean-exit path this de-churns); genuine wedge detection is unchanged.

## Test plan

`tests/gateway-supervisor-backoff.test.ts` (the canonical supervisor harness, extracts the pure-shell function and drives it):
- [x] `--oneshot-ok`: a clean exit 0 stops supervising — runs exactly once, logs "completed cleanly … not respawning", never "retrying in".
- [x] `--oneshot-ok`: a NON-zero exit still backs off + retries (crash self-heals).
- [x] WITHOUT `--oneshot-ok`: a clean exit 0 is still treated as a crash and respawns (gateway/scheduler contract unchanged).
- [x] Existing exit-78 quarantine + indefinite-backoff + cap-reset tests still pass.

Commands run from an exec-capable worktree (vitest):
- `vitest run tests/gateway-supervisor-backoff.test.ts` → 6 passed
- `vitest run tests/wedge-watchdog.test.ts tests/autoaccept.test.ts tests/wedge-detect-posttool.test.ts` → 64 passed (#2475 logic intact)
- `vitest run tests/scaffold.regenerate-start-sh.test.ts tests/scaffold.hot-reload-stable.test.ts tests/reconcile.skip-profile-templates.test.ts` → 19 passed
- `tsc --noEmit` → exit 0

(Two failures in `tests/scaffold.test.ts` `$HOME/.switchroom` symlink and `tests/autoaccept-poll-bundled.test.ts` dist-exists are **pre-existing on clean `main`** in a no-build worktree — confirmed by stashing this change; not introduced here.)

## Risk / rollout

The autoaccept watchdog sidecar runs **continuously per container** → this touches a per-agent always-on process. Flag for **staggered rollout**, not a bulk fleet recreate. Pure shell template change (+ a test); no TS runtime behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)