### PR TITLE
fix(setup): detect/prompt/write switchroom.timezone so a fresh install never silently runs UTC

### DIFF
--- a/examples/minimal.yaml
+++ b/examples/minimal.yaml
@@ -12,6 +12,7 @@
 
 switchroom:
   version: 1
+  # timezone: "Region/City"  # agents' local time + cron evaluation; defaults to UTC if unset
 
 telegram:
   bot_token: "vault:telegram-bot-token"

--- a/examples/switchroom.yaml
+++ b/examples/switchroom.yaml
@@ -26,6 +26,7 @@ switchroom:
   version: 1
   agents_dir: ~/.switchroom/agents
   skills_dir: ~/.switchroom/skills           # shared skill pool (symlinked per agent)
+  # timezone: "Region/City"  # agents' local time + cron evaluation; defaults to UTC if unset
 
 telegram:
   # Single-agent fallback ONLY. This is the bot the one shipped agent

--- a/src/cli/doctor-timezone.test.ts
+++ b/src/cli/doctor-timezone.test.ts
@@ -1,0 +1,100 @@
+/**
+ * #2483 — runTimezoneChecks doctor probe. Pins: warn (not fail) when the
+ * resolved zone is UTC purely via server detection; ok when an explicit
+ * switchroom.timezone is set; ok when a per-agent override is present;
+ * never fails (a legitimately-UTC fleet is valid).
+ */
+import { describe, it, expect } from "vitest";
+import type { SwitchroomConfig } from "../config/schema.js";
+import { runTimezoneChecks, checkTimezone } from "./doctor-timezone.js";
+
+// Force server detection to resolve to UTC, deterministically, regardless of
+// the CI host's /etc — both probes report "nothing found" so the resolver's
+// final fallback ("UTC") fires.
+const FORCE_UTC = {
+  readEtcTimezone: () => undefined,
+  readLocaltimeLink: () => undefined,
+};
+// Force a real detected zone via the /etc/timezone probe.
+const FORCE_MELBOURNE = {
+  readEtcTimezone: () => "Australia/Melbourne",
+  readLocaltimeLink: () => undefined,
+};
+
+function configWith(
+  over: Partial<SwitchroomConfig>,
+): SwitchroomConfig {
+  return {
+    switchroom: { version: 1, agents_dir: "/agents", skills_dir: "/skills" },
+    telegram: { bot_token: "x", forum_chat_id: "-1001234567890" },
+    vault: { path: "/v.enc" },
+    defaults: {},
+    agents: { assistant: { topic_name: "A" } },
+    ...over,
+  } as unknown as SwitchroomConfig;
+}
+
+describe("runTimezoneChecks (#2483)", () => {
+  it("warns (not fails) when no zone is set anywhere and detection lands on UTC", () => {
+    const cfg = configWith({});
+    const r = runTimezoneChecks(cfg, FORCE_UTC);
+    expect(r).toHaveLength(1);
+    expect(r[0].status).toBe("warn");
+    expect(r[0].name).toBe("timezone configured");
+    expect(r[0].detail).toMatch(/UTC/);
+    expect(r[0].fix).toMatch(/switchroom\.timezone/);
+  });
+
+  it("stays ok when detection finds a real zone (no explicit value, non-UTC host)", () => {
+    const cfg = configWith({});
+    const r = checkTimezone(cfg, FORCE_MELBOURNE);
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("Australia/Melbourne");
+  });
+
+  it("ok with detail when an explicit switchroom.timezone is set, even on a UTC host", () => {
+    const cfg = configWith({
+      switchroom: {
+        version: 1,
+        agents_dir: "/agents",
+        skills_dir: "/skills",
+        timezone: "Australia/Melbourne",
+      } as never,
+    });
+    const r = checkTimezone(cfg, FORCE_UTC);
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("Australia/Melbourne");
+  });
+
+  it("ok when a per-agent timezone override is present (source !== detected)", () => {
+    const cfg = configWith({
+      agents: {
+        assistant: { topic_name: "A", timezone: "Asia/Tokyo" } as never,
+      },
+    });
+    const r = checkTimezone(cfg, FORCE_UTC);
+    expect(r.status).toBe("ok");
+  });
+
+  it("no-agents bootstrap: warns on detected-UTC, never fails", () => {
+    const cfg = configWith({ agents: {} as never });
+    const r = checkTimezone(cfg, FORCE_UTC);
+    expect(r.status).toBe("warn");
+    expect(r.status).not.toBe("fail");
+  });
+
+  it("no-agents bootstrap: global explicit zone produces an ok row even on a UTC host", () => {
+    const cfg = configWith({
+      switchroom: {
+        version: 1,
+        agents_dir: "/agents",
+        skills_dir: "/skills",
+        timezone: "Europe/London",
+      } as never,
+      agents: {} as never,
+    });
+    const r = checkTimezone(cfg, FORCE_UTC);
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("Europe/London");
+  });
+});

--- a/src/cli/doctor-timezone.ts
+++ b/src/cli/doctor-timezone.ts
@@ -1,0 +1,160 @@
+/**
+ * Timezone health check for `switchroom doctor` (#2483).
+ *
+ * A fresh `switchroom setup` never sets `switchroom.timezone`, so
+ * `resolveTimezone()` falls through to `detectServerTimezone()`, which
+ * returns "UTC" on a bare cloud VM. Compose then stamps `TZ=UTC` and
+ * cron is evaluated in UTC — `0 8 * * *` fires hours off the operator's
+ * actual local time. This is a correctness bug, not cosmetic.
+ *
+ * The setup wizard now prompts/writes an explicit zone, and apply prints
+ * a one-off warning. But installs that bypassed the wizard (hand-written
+ * config, restored backup, pre-#2483 fleet) still silently run UTC. This
+ * doctor check is the durable surface that catches them: it reuses the
+ * exact `classifyTimezoneSource()` + `resolveTimezone()` cascade the
+ * runtime uses, and WARNs (never fails — a legitimately-UTC fleet is
+ * valid) when the resolved zone is UTC purely because it fell through to
+ * server detection with no explicit value at any layer.
+ *
+ * Pure renderer over the config — no I/O beyond the cheap server probe
+ * the resolver already does. Mirrors the shape/registration of the other
+ * `doctor-*.ts` modules.
+ */
+
+import type { SwitchroomConfig } from "../config/schema.js";
+import type { CheckStatus } from "./doctor-status.js";
+import { resolveAgentConfig } from "../config/merge.js";
+import {
+  classifyTimezoneSource,
+  resolveTimezone,
+  type ResolveTimezoneOpts,
+} from "../config/timezone.js";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+/**
+ * One doctor row for the fleet's timezone posture.
+ *
+ * The cascade (agent → profile/defaults → switchroom.timezone → server
+ * detection) is per-agent, but the only failure mode worth surfacing is
+ * fleet-wide: NO explicit zone anywhere AND server detection landed on
+ * UTC. When that holds, every agent that lacks an explicit override
+ * resolves to UTC-by-accident. We pick any agent (they all share the
+ * global + detection layers) — or, with no agents, classify against an
+ * empty agent so the global-vs-detected distinction still holds.
+ *
+ * `tzOpts` injects the server-detection probes (so a test can force the
+ * detected-UTC condition without depending on the host's /etc);
+ * production callers omit it and the real /etc probes run.
+ *
+ * Exported for unit testing.
+ */
+export function checkTimezone(
+  config: SwitchroomConfig,
+  tzOpts: ResolveTimezoneOpts = {},
+): CheckResult {
+  const agentEntries = Object.entries(config.agents ?? {});
+
+  // Resolve against a representative agent. Any agent shares the global
+  // + server-detection tail of the cascade; an agent-level override only
+  // makes the verdict *better* (source !== "detected"), so if even one
+  // agent has no override and we land on detected-UTC, that's the case
+  // we want to flag. Check every agent and warn if ANY resolves to
+  // detected-UTC; report the explicit global when one is set.
+  if (agentEntries.length === 0) {
+    // No agents yet (fresh bootstrap). Classify the bare cascade so the
+    // operator still sees whether a global zone is set.
+    const emptyAgent = {} as Parameters<typeof resolveTimezone>[1];
+    const source = classifyTimezoneSource(config, emptyAgent);
+    const resolved = resolveTimezone(config, emptyAgent, tzOpts);
+    return timezoneVerdict(source, resolved);
+  }
+
+  let detectedUtcAgents = 0;
+  let explicitGlobal: string | undefined;
+  let sampleResolved = "UTC";
+  for (const [, agentConfigRaw] of agentEntries) {
+    const agentConfig = resolveAgentConfig(
+      config.defaults,
+      config.profiles,
+      agentConfigRaw,
+    );
+    const source = classifyTimezoneSource(config, agentConfig);
+    const resolved = resolveTimezone(config, agentConfig, tzOpts);
+    if (source === "detected" && resolved === "UTC") {
+      detectedUtcAgents++;
+    }
+    if (source === "global") explicitGlobal = resolved;
+    sampleResolved = resolved;
+  }
+
+  if (detectedUtcAgents > 0) {
+    return {
+      name: "timezone configured",
+      status: "warn",
+      detail:
+        `${detectedUtcAgents} agent(s) resolve to UTC via server detection — ` +
+        "no explicit timezone at any config layer. The host has no local zone " +
+        "(typical bare cloud VM), so agents' per-turn time hint and cron " +
+        "evaluation run in UTC, often hours off the operator's real time.",
+      fix:
+        "Set `switchroom.timezone: <Region/City>` (e.g. \"Australia/Melbourne\") " +
+        "in switchroom.yaml, then `switchroom apply`. Per-agent overrides go " +
+        "under agents.<name>.timezone.",
+    };
+  }
+
+  if (explicitGlobal) {
+    return {
+      name: "timezone configured",
+      status: "ok",
+      detail: `switchroom.timezone: ${explicitGlobal}`,
+    };
+  }
+
+  return {
+    name: "timezone configured",
+    status: "ok",
+    detail: `resolved to ${sampleResolved}`,
+  };
+}
+
+/** Render a verdict from a pre-computed source + resolved zone (no-agents path). */
+function timezoneVerdict(
+  source: "agent" | "global" | "detected",
+  resolved: string,
+): CheckResult {
+  if (source === "detected" && resolved === "UTC") {
+    return {
+      name: "timezone configured",
+      status: "warn",
+      detail:
+        "no explicit timezone set and server detection resolved to UTC — " +
+        "agents will run in UTC (often hours off the operator's real time).",
+      fix:
+        "Set `switchroom.timezone: <Region/City>` (e.g. \"Australia/Melbourne\") " +
+        "in switchroom.yaml, then `switchroom apply`.",
+    };
+  }
+  return {
+    name: "timezone configured",
+    status: "ok",
+    detail:
+      source === "global"
+        ? `switchroom.timezone: ${resolved}`
+        : `resolved to ${resolved}`,
+  };
+}
+
+/** Section entry point for doctor.ts — returns the single timezone row. */
+export function runTimezoneChecks(
+  config: SwitchroomConfig,
+  tzOpts: ResolveTimezoneOpts = {},
+): CheckResult[] {
+  return [checkTimezone(config, tzOpts)];
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -46,6 +46,7 @@ import { runInlinedSecretChecks } from "./doctor-inlined-secrets.js";
 import { runAuditIntegrityChecks } from "./doctor-audit-integrity.js";
 import { runAgentSmokeChecks } from "./doctor-agent-smoke.js";
 import { runVaultBrokerDurabilityChecks } from "./doctor-vault-broker-durability.js";
+import { runTimezoneChecks } from "./doctor-timezone.js";
 
 /**
  * Result of a single doctor check.
@@ -2759,6 +2760,7 @@ export function registerDoctorCommand(program: Command): void {
           { title: "Skills Prerequisites", results: checkSkillsPrerequisites() },
           { title: "Manifest Drift", results: await checkManifestDrift() },
           { title: "Configuration", results: checkConfig(config, configPath) },
+          { title: "Timezone", results: runTimezoneChecks(config) },
           {
             title: "Config secrets (WS6-F3)",
             results: runInlinedSecretChecks(config, { configPath }),

--- a/src/cli/setup-timezone.test.ts
+++ b/src/cli/setup-timezone.test.ts
@@ -1,0 +1,146 @@
+/**
+ * #2483 — writeDetectedTimezone (the setup-wizard detect-and-write step).
+ *
+ * Pins the four install-time branches:
+ *   (a) detected a real non-UTC zone → write switchroom.timezone verbatim
+ *   (b) detected UTC + interactive   → prompt, validate, write the answer
+ *   (c) detected UTC + interactive, empty answer → NO write + loud warn
+ *   (d) detected UTC + headless      → NO write + one loud warn, no hang
+ *
+ * Uses a real temp file (read-mutate-write is part of the contract) with
+ * injected detect()/prompt() so the test never touches the host /etc or a
+ * live TTY. Synthetic config only — no PII/secrets.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parse } from "yaml";
+
+// Mock the vault module so importing setup.ts (which statically imports
+// vault-broker.js → broker/server.ts → grants-db.ts → bun:sqlite, plus
+// dynamic-imports vault.ts) doesn't transitively load bun:sqlite — vitest
+// doesn't ship the bun:sqlite shim. Mirrors tests/setup.test.ts. None of
+// these are reached by writeDetectedTimezone, so a bare stub is enough.
+vi.mock("../vault/vault.js", () => ({
+  openVault: vi.fn(),
+  createVault: vi.fn(),
+  setStringSecret: vi.fn(),
+  getStringSecret: vi.fn(),
+}));
+vi.mock("./vault-broker.js", () => ({
+  promptPassphrase: vi.fn(),
+}));
+
+import { writeDetectedTimezone } from "./setup.js";
+
+const FRESH_CONFIG = `switchroom:
+  version: 1
+  agents_dir: ~/.switchroom/agents
+telegram:
+  bot_token: "vault:telegram-bot-token"
+  forum_chat_id: "0"
+agents:
+  assistant:
+    topic_name: "Assistant"
+`;
+
+let dir: string;
+let cfgPath: string;
+let errSpy: ReturnType<typeof vi.spyOn>;
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+function tzOf(): string | undefined {
+  return parse(readFileSync(cfgPath, "utf-8")).switchroom.timezone;
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "sr-tz-"));
+  cfgPath = join(dir, "switchroom.yaml");
+  writeFileSync(cfgPath, FRESH_CONFIG);
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errSpy.mockRestore();
+  logSpy.mockRestore();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("writeDetectedTimezone (#2483)", () => {
+  it("(a) writes the detected zone when detection is a real non-UTC zone", async () => {
+    const promptCalls: string[] = [];
+    await writeDetectedTimezone(
+      cfgPath,
+      /* nonInteractive */ false,
+      () => "Australia/Melbourne",
+      async (q) => {
+        promptCalls.push(q);
+        return "";
+      },
+    );
+    expect(tzOf()).toBe("Australia/Melbourne");
+    // never prompts when detection already gave a real zone
+    expect(promptCalls).toEqual([]);
+  });
+
+  it("(b) interactive UTC → prompts, validates, and writes the answer", async () => {
+    await writeDetectedTimezone(
+      cfgPath,
+      false,
+      () => "UTC",
+      async () => "Asia/Tokyo",
+    );
+    expect(tzOf()).toBe("Asia/Tokyo");
+  });
+
+  it("(b') interactive UTC → invalid answer is NOT written, warns instead", async () => {
+    await writeDetectedTimezone(
+      cfgPath,
+      false,
+      () => "UTC",
+      async () => "EST", // three-letter alias — rejected by the validator
+    );
+    expect(tzOf()).toBeUndefined();
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("(c) interactive UTC → empty answer skips the write + warns once", async () => {
+    await writeDetectedTimezone(
+      cfgPath,
+      false,
+      () => "UTC",
+      async () => "   ", // whitespace-only ⟹ declined
+    );
+    expect(tzOf()).toBeUndefined();
+    expect(errSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("(d) headless UTC → never writes, emits one loud stderr line, no hang", async () => {
+    let prompted = false;
+    await writeDetectedTimezone(
+      cfgPath,
+      /* nonInteractive */ true,
+      () => "UTC",
+      async () => {
+        prompted = true; // the headless path must NOT prompt (would hang in CI)
+        return "Asia/Tokyo";
+      },
+    );
+    expect(tzOf()).toBeUndefined();
+    expect(prompted).toBe(false);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(String(errSpy.mock.calls[0][0])).toMatch(/UTC/);
+  });
+
+  it("never persists UTC even when headless and detection is UTC", async () => {
+    await writeDetectedTimezone(cfgPath, true, () => "UTC");
+    expect(readFileSync(cfgPath, "utf-8")).not.toMatch(/timezone:\s*UTC/);
+  });
+
+  it("headless with a real detected zone writes it without prompting", async () => {
+    await writeDetectedTimezone(cfgPath, true, () => "Europe/London");
+    expect(tzOf()).toBe("Europe/London");
+  });
+});

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -49,6 +49,9 @@ import {
   isValidSupergroupChatId,
   setAgentSupergroupChatId,
 } from "./supergroup-setup-yaml.js";
+import { setSwitchroomTimezone } from "./timezone-setup-yaml.js";
+import { detectServerTimezone } from "../config/timezone.js";
+import { isValidTimezone } from "../config/schema.js";
 
 const STEP_PENDING = chalk.gray("○");
 const STEP_ACTIVE = chalk.blue("->");
@@ -268,12 +271,103 @@ async function copyExampleConfig(
     chalk.yellow(`  Edit ${destFile} to customize, then re-run switchroom setup.`),
   );
 
+  // Timezone safe-default (#2483). A fresh config never sets
+  // `switchroom.timezone`, so `resolveTimezone()` falls through to
+  // `detectServerTimezone()` → "UTC" on a bare cloud VM, and every
+  // agent's per-turn time hint + cron evaluation silently runs hours
+  // off. Make the choice explicit at install instead of leaving it to
+  // the invisible fallback. NEVER persist "UTC" (the thing we're
+  // avoiding) — only a confidently-real detected zone, else prompt
+  // (interactive) or warn loudly (headless).
+  await writeDetectedTimezone(destFile, nonInteractive);
+
   const config = loadConfig(destFile);
   console.log(
     chalk.green(`  ${STEP_DONE} Config loaded`) +
       chalk.gray(` (${Object.keys(config.agents).length} agents)`),
   );
   return { config, configPath: resolve(destFile) };
+}
+
+/**
+ * Detect the host timezone and persist an explicit `switchroom.timezone`
+ * into the freshly-bootstrapped config (#2483). Three branches:
+ *
+ *   - detected a REAL non-UTC zone  → write it (no prompt needed)
+ *   - detected UTC + interactive    → prompt for the real zone, validate,
+ *                                     write it; on empty/declined input,
+ *                                     skip the write + warn once
+ *   - detected UTC + headless       → skip the write, emit ONE loud
+ *                                     stderr line, degrade to today's
+ *                                     UTC-fallback behaviour (no hang)
+ *
+ * NEVER writes "UTC": that's the silent-wrong-time fallback this whole
+ * step exists to avoid. The atomic read-mutate-write mirrors the
+ * setAgentSupergroupChatId / setAuthActive pattern.
+ *
+ * Exported for tests; production callers reach it via copyExampleConfig.
+ * `detect` and `prompt` are injectable so tests don't depend on the
+ * host's /etc or a live TTY.
+ */
+export async function writeDetectedTimezone(
+  destFile: string,
+  nonInteractive: boolean,
+  detect: () => string = detectServerTimezone,
+  prompt: (question: string, defaultValue?: string) => Promise<string> = ask,
+): Promise<void> {
+  const detected = detect();
+
+  if (detected !== "UTC" && isValidTimezone(detected)) {
+    // A confidently-real host zone — persist it verbatim, visible/editable.
+    const before = readFileSync(destFile, "utf-8");
+    const after = setSwitchroomTimezone(before, detected);
+    if (after !== before) writeFileSync(destFile, after);
+    console.log(
+      chalk.green(`  Detected timezone ${detected} — wrote switchroom.timezone.`),
+    );
+    return;
+  }
+
+  // detected === "UTC" (or an unparseable detection we won't trust).
+  if (nonInteractive) {
+    console.error(
+      chalk.yellow(
+        "  ⚠ timezone unspecified — agents will use UTC; set switchroom.timezone " +
+          "(e.g. \"Australia/Melbourne\") in switchroom.yaml or agents will run hours off.",
+      ),
+    );
+    return;
+  }
+
+  // Interactive UTC case — likely a bare cloud VM. Ask for the real zone.
+  const answer = await prompt(
+    "  Timezone? [detected: UTC — likely wrong; e.g. Australia/Melbourne]",
+    "",
+  );
+  const zone = answer.trim();
+  if (zone.length === 0) {
+    console.error(
+      chalk.yellow(
+        "  ⚠ No timezone set — agents will use UTC and run hours off. " +
+          "Set switchroom.timezone in switchroom.yaml when you know your zone.",
+      ),
+    );
+    return;
+  }
+  if (!isValidTimezone(zone) || zone === "UTC") {
+    console.error(
+      chalk.yellow(
+        `  ⚠ "${zone}" is not a valid IANA zone (expected Region/City like ` +
+          "\"Australia/Melbourne\"). Skipping — agents will use UTC. " +
+          "Edit switchroom.timezone in switchroom.yaml by hand.",
+      ),
+    );
+    return;
+  }
+  const before = readFileSync(destFile, "utf-8");
+  const after = setSwitchroomTimezone(before, zone);
+  if (after !== before) writeFileSync(destFile, after);
+  console.log(chalk.green(`  Wrote switchroom.timezone: ${zone}.`));
 }
 
 // ─── Step 2: Bot Tokens ─────────────────────────────────────────────────────

--- a/src/cli/timezone-setup-yaml.test.ts
+++ b/src/cli/timezone-setup-yaml.test.ts
@@ -1,0 +1,80 @@
+/**
+ * #2483 — setSwitchroomTimezone YAML writer. Pins: writes the zone under
+ * the root switchroom: block preserving siblings + comments; idempotent;
+ * refuses UTC and malformed zones; produces schema-valid config.
+ */
+import { describe, it, expect } from "vitest";
+import { parseDocument, parse } from "yaml";
+import { setSwitchroomTimezone } from "./timezone-setup-yaml.js";
+import { SwitchroomConfigSchema } from "../config/schema.js";
+
+const BASE = `# top-level comment
+switchroom:
+  version: 1
+  agents_dir: ~/.switchroom/agents
+telegram:
+  bot_token: "vault:telegram-bot-token"
+  forum_chat_id: "0"
+agents:
+  assistant:
+    topic_name: "Assistant"
+`;
+
+describe("setSwitchroomTimezone", () => {
+  it("writes timezone under the root switchroom: block, preserving siblings", () => {
+    const out = setSwitchroomTimezone(BASE, "Australia/Melbourne");
+    const doc = parseDocument(out);
+    expect(doc.getIn(["switchroom", "timezone"])).toBe("Australia/Melbourne");
+    // siblings survive
+    expect(doc.getIn(["switchroom", "version"])).toBe(1);
+    expect(doc.getIn(["switchroom", "agents_dir"])).toBe("~/.switchroom/agents");
+    // surrounding blocks + comment survive
+    expect(out).toMatch(/^# top-level comment/m);
+    expect(out).toContain("agents:");
+  });
+
+  it("accepts a three-segment IANA zone", () => {
+    const out = setSwitchroomTimezone(BASE, "America/Argentina/Buenos_Aires");
+    expect(parseDocument(out).getIn(["switchroom", "timezone"])).toBe(
+      "America/Argentina/Buenos_Aires",
+    );
+  });
+
+  it("is idempotent — same value returns input verbatim", () => {
+    const once = setSwitchroomTimezone(BASE, "Europe/London");
+    const twice = setSwitchroomTimezone(once, "Europe/London");
+    expect(twice).toBe(once);
+  });
+
+  it("updates an existing timezone in place", () => {
+    const withTz = setSwitchroomTimezone(BASE, "Europe/London");
+    const out = setSwitchroomTimezone(withTz, "Asia/Tokyo");
+    expect(parseDocument(out).getIn(["switchroom", "timezone"])).toBe("Asia/Tokyo");
+    expect(out).not.toMatch(/Europe\/London/);
+  });
+
+  it("refuses to persist UTC (the silent fallback this write avoids)", () => {
+    expect(() => setSwitchroomTimezone(BASE, "UTC")).toThrow(/refusing to persist UTC/);
+  });
+
+  it("rejects malformed zones (offsets, three-letter aliases, empty)", () => {
+    for (const bad of ["EST", "PST", "UTC+10", "+10:00", ""]) {
+      expect(() => setSwitchroomTimezone(BASE, bad)).toThrow();
+    }
+  });
+
+  it("throws on a non-map YAML root (defensive)", () => {
+    expect(() => setSwitchroomTimezone("- a\n- b\n", "Asia/Tokyo")).toThrow(/not a map/);
+  });
+
+  it("ensures a trailing newline", () => {
+    const out = setSwitchroomTimezone(BASE.trimEnd(), "Asia/Tokyo");
+    expect(out.endsWith("\n")).toBe(true);
+  });
+
+  it("produces a config the schema accepts", () => {
+    const out = setSwitchroomTimezone(BASE, "Australia/Melbourne");
+    const cfg = SwitchroomConfigSchema.parse(parse(out));
+    expect(cfg.switchroom.timezone).toBe("Australia/Melbourne");
+  });
+});

--- a/src/cli/timezone-setup-yaml.ts
+++ b/src/cli/timezone-setup-yaml.ts
@@ -1,0 +1,79 @@
+/**
+ * YAML editor for the top-level `switchroom.timezone: <zone>` field.
+ *
+ * Pure module — string-in / string-out — so the setup wizard can read
+ * the freshly-bootstrapped config, mutate, and atomic-write the result
+ * without losing comments or surrounding formatting. Mirrors the pattern
+ * in `auth-active-yaml.ts` / `supergroup-setup-yaml.ts`.
+ *
+ * One caller today: `switchroom setup` (#2483). After scaffolding a
+ * brand-new `~/.switchroom/switchroom.yaml`, the wizard detects the
+ * host timezone and persists a *real* (non-UTC) detected zone — or, in
+ * the UTC case, an operator-supplied zone — into the root `switchroom:`
+ * block. Making the choice visible/editable beats leaving it to the
+ * invisible `detectServerTimezone()` fallback that silently resolves to
+ * UTC and stamps every agent's clock wrong (the bug this fixes).
+ *
+ * NEVER call this with "UTC" — the whole point is to avoid persisting
+ * the platform-default UTC as if it were a deliberate choice. The caller
+ * gates on that; this module also rejects it defensively.
+ */
+
+import { parseDocument, isMap } from "yaml";
+import { isValidTimezone } from "../config/schema.js";
+
+/**
+ * Set `switchroom.timezone: <zone>` in the YAML text. The root
+ * `switchroom:` map is required by the schema and present in every
+ * bootstrapped example, so we patch its `timezone` child while
+ * preserving siblings (version, agents_dir, …) and comments. Idempotent
+ * — returns the input verbatim when the value already matches.
+ *
+ * Rejects `UTC` and any value the schema's timezone validator rejects,
+ * so the wizard never writes a malformed or pointless value to disk.
+ *
+ * Returns the new YAML text. Caller owns the atomic-write to disk and
+ * any mode preservation.
+ */
+export function setSwitchroomTimezone(yamlText: string, zone: string): string {
+  if (typeof zone !== "string" || zone.length === 0) {
+    throw new Error("setSwitchroomTimezone: zone must be a non-empty string");
+  }
+  if (zone === "UTC") {
+    throw new Error(
+      "setSwitchroomTimezone: refusing to persist UTC — UTC is the silent " +
+        "fallback this write exists to avoid (#2483)",
+    );
+  }
+  if (!isValidTimezone(zone)) {
+    throw new Error(
+      `setSwitchroomTimezone: "${zone}" is not a valid IANA zone name ` +
+        `(expected Region/City like "Australia/Melbourne")`,
+    );
+  }
+
+  const doc = parseDocument(yamlText);
+  const root = doc.contents;
+  if (!isMap(root)) {
+    throw new Error("setSwitchroomTimezone: YAML root is not a map");
+  }
+
+  const existing = root.get("switchroom", true);
+  if (isMap(existing)) {
+    if (existing.get("timezone") === zone) {
+      return yamlText; // idempotent
+    }
+    // Map exists with other siblings (version, agents_dir, …) — patch
+    // only the `timezone` key so siblings + comments survive.
+    doc.setIn(["switchroom", "timezone"], zone);
+  } else {
+    // `switchroom:` absent, null (bare key), or scalar. `setIn` crashes
+    // on null/scalar — replace the whole value with a fresh map. The
+    // schema requires the block, so this branch only fires on a
+    // hand-mangled config; there are no siblings to preserve.
+    doc.set("switchroom", { timezone: zone });
+  }
+
+  const out = String(doc);
+  return out.endsWith("\n") ? out : out + "\n";
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1260,6 +1260,17 @@ export const ChannelsSchema = z
  */
 const TIMEZONE_REGEX = /^UTC$|^[A-Z][A-Za-z0-9_+-]+(\/[A-Z][A-Za-z0-9_+-]+){1,2}$/;
 
+/**
+ * Public predicate over the same `TIMEZONE_REGEX` the `timezone` zod
+ * fields validate with. Exported so non-schema callers (the setup
+ * wizard's interactive timezone prompt, #2483) validate a hand-typed
+ * IANA zone against the exact same rule the config schema enforces,
+ * instead of re-deriving a looser one that drifts.
+ */
+export function isValidTimezone(value: string): boolean {
+  return TIMEZONE_REGEX.test(value);
+}
+
 const ApproverIdSchema = z.union([z.number(), z.string().regex(/^\d+$/)]);
 
 /**


### PR DESCRIPTION
Fixes #2483

## Problem

A new `switchroom setup` never set `switchroom.timezone`, so `resolveTimezone()` fell through to `detectServerTimezone()` → `"UTC"` on a bare cloud VM. Compose then stamped `TZ=UTC` and cron was evaluated in UTC — `0 8 * * *` fired hours off the operator's real local time. A correctness bug, not cosmetic (the live fleet stamped agent-facing times ~10h off until `switchroom.timezone` was set by hand).

Detection cannot fix it — the host genuinely has no local zone to find — so the fix makes the absence loud or forces an explicit choice at install.

## Change (layered safe-default)

1. **Setup detect-and-write** — `src/cli/setup.ts` `writeDetectedTimezone()` (called from `copyExampleConfig`): after the example is scaffolded, detect the host zone and persist a REAL (non-UTC) detected zone into the root `switchroom:` block via a new atomic YAML writer `setSwitchroomTimezone` (`src/cli/timezone-setup-yaml.ts`), mirroring `setAuthActive` / `setAgentSupergroupChatId`. **Never persists `UTC`.**
2. **Interactive UTC prompt** — when detection is UTC and the wizard is interactive, prompt for the real zone, validate it against the schema's timezone rule (new exported `isValidTimezone`, reusing `TIMEZONE_REGEX`), and write it. Empty/invalid answer → skip the write + one loud stderr warning.
3. **Headless UTC** — skip the write, emit one loud stderr line, degrade to today's UTC-fallback behaviour. No prompt, no hang.
4. **Doctor check** — new `src/cli/doctor-timezone.ts` (registered in `doctor.ts`) reuses `classifyTimezoneSource()` + `resolveTimezone()` and **warns** (never fails) when the resolved zone is UTC purely via server detection. Catches installs that bypassed the wizard and the existing-fleet failure mode.
5. **Example configs** — commented `# timezone: "Region/City"  # agents' local time + cron evaluation; defaults to UTC if unset` under the `switchroom:` block in both `examples/switchroom.yaml` and `examples/minimal.yaml`.

No per-turn prompt-hook warning (cries wolf for legitimately-UTC fleets) — the doctor check is the durable surface.

## Blast radius

Install/doctor-side only. The setup write affects only the **first** scaffold of a brand-new config (existing installs short-circuit before `copyExampleConfig`). The doctor check is read-only; the example edits are inert comments. Nothing touches the gateway hot path.

## Tests

- `src/cli/timezone-setup-yaml.test.ts` — writer: write under `switchroom:` preserving siblings/comments, idempotent, refuses `UTC`, rejects offsets/aliases, schema-valid output.
- `src/cli/setup-timezone.test.ts` — `writeDetectedTimezone` across all four install branches: real-zone write, interactive-UTC prompt+write, interactive empty/invalid → no write + warn, headless UTC → no write + one warn + no prompt (no hang).
- `src/cli/doctor-timezone.test.ts` — warn on detected-UTC, ok on explicit global/per-agent zone, never fail.

Synthetic ids only.

## Test plan

```
npx tsc --noEmit                         # clean
npx vitest run src/cli/timezone-setup-yaml.test.ts \
  src/cli/doctor-timezone.test.ts src/cli/setup-timezone.test.ts   # 22 passed
npx vitest run tests/setup.test.ts       # 38 passed (no regression)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)