### PR TITLE
fix(installer): remove stale singleton container before compose up to prevent name conflicts

### DIFF
--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -31,6 +31,7 @@ import { getConfig, withConfigError } from "./helpers.js";
 import { resolveOperatorUid } from "./operator-uid.js";
 import { resolveImageTag, resolveRelease, type ReleaseBlockShape } from "../config/release-resolve.js";
 import { checkDowngrade } from "./deploy-version-guard.js";
+import { removeStaleContainerIfNeeded } from "./singleton-stale-cleanup.js";
 import {
   defaultAuditLogPath,
   formatForCli,
@@ -350,6 +351,15 @@ async function doInstall(opts: InstallOptions, program: Command): Promise<void> 
     );
     process.exit(1);
   }
+
+  // Stale-container reconciliation: if a container named switchroom-hostd
+  // exists under a DIFFERENT compose project (e.g. old containerized-path
+  // install), `compose up` would try to CREATE (not RECREATE) it and fail
+  // with a name conflict. Remove the stale container first so the create
+  // succeeds. Idempotent and logged. See singleton-stale-cleanup.ts.
+  removeStaleContainerIfNeeded("switchroom-hostd", HOSTD_COMPOSE_PROJECT, (line) =>
+    console.log(chalk.dim(line)),
+  );
 
   console.log(chalk.dim(`    Bringing up daemon…`));
   const up = runDocker(["compose", "-p", HOSTD_COMPOSE_PROJECT, "-f", composePath, "up", "-d"]);

--- a/src/cli/singleton-cleanup-callsite.test.ts
+++ b/src/cli/singleton-cleanup-callsite.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Callsite regression guard for singleton stale-container cleanup.
+ *
+ * WHAT THIS TESTS
+ * ───────────────
+ * `removeStaleContainerIfNeeded` in singleton-stale-cleanup.ts accepts an
+ * injectable DockerRunner for testing, but `doInstall` in hostd.ts and
+ * webd.ts is a private (non-exported) function that hardwires the real
+ * spawnSync-backed runner — there is no injection seam in the call chain
+ * reachable without invoking docker at runtime.
+ *
+ * Because we cannot intercept docker calls through `doInstall`, these tests
+ * are STRUCTURAL: they read the source text and assert the invariants that a
+ * behavioral test would exercise. Specifically:
+ *
+ *   1. The stale-cleanup call appears in source BEFORE the `compose ... up`
+ *      call (ordering guard — a future reorder would fail this).
+ *   2. The container name passed to `removeStaleContainerIfNeeded` is the
+ *      same string literal as the one used in `container_name:` inside the
+ *      compose template (constant-mismatch guard).
+ *   3. The project name passed to `removeStaleContainerIfNeeded` is the same
+ *      string literal as the one passed to `compose -p` for the `up` command
+ *      (wrong-project-constant guard).
+ *
+ * These are the exact two regression scenarios named in the PR review:
+ *   a) a future reorder puts cleanup AFTER `compose up` (silent breakage)
+ *   b) a wrong-constant edit passes a different project to cleanup vs `up`
+ *
+ * If a future refactor adds a docker-runner injection seam to `doInstall`,
+ * replace these structural assertions with behavioral ones and note the
+ * improved coverage.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readSource(filename: string): string {
+  return readFileSync(join(__dirname, filename), "utf8");
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Return the character index of the FIRST occurrence of `needle` in `src`,
+ * or throw so the test fails with a clear message rather than a confusing
+ * -1 comparison.
+ */
+function indexOf(src: string, needle: string, label: string): number {
+  const idx = src.indexOf(needle);
+  if (idx === -1) {
+    throw new Error(`Could not find ${label} in source:\n  pattern: ${JSON.stringify(needle)}`);
+  }
+  return idx;
+}
+
+// ─── hostd.ts ────────────────────────────────────────────────────────────────
+
+describe("hostd.ts callsite: removeStaleContainerIfNeeded before compose up", () => {
+  const src = readSource("hostd.ts");
+
+  it("calls removeStaleContainerIfNeeded with container name 'switchroom-hostd'", () => {
+    // The call must name the container exactly; a wrong constant goes
+    // undetected by the unit tests in singleton-stale-cleanup.test.ts.
+    expect(src).toContain('removeStaleContainerIfNeeded("switchroom-hostd"');
+  });
+
+  it("HOSTD_COMPOSE_PROJECT constant equals 'switchroom-hostd'", () => {
+    // Verify the constant declaration itself — the project name the
+    // singleton is installed under.
+    expect(src).toContain('const HOSTD_COMPOSE_PROJECT = "switchroom-hostd"');
+  });
+
+  it("passes HOSTD_COMPOSE_PROJECT (not a different literal) as the targetProject arg", () => {
+    // The second argument to removeStaleContainerIfNeeded must be the
+    // SAME constant that is passed to `compose -p`.  We assert the call
+    // site uses the identifier, not a re-typed string literal that could
+    // diverge from the constant.
+    expect(src).toContain('removeStaleContainerIfNeeded("switchroom-hostd", HOSTD_COMPOSE_PROJECT');
+  });
+
+  it("compose -p for the up command uses HOSTD_COMPOSE_PROJECT (same constant)", () => {
+    // Both the cleanup and the up command must reference the same project.
+    // This pattern matches the `up -d` invocation that uses the constant.
+    expect(src).toContain('"compose", "-p", HOSTD_COMPOSE_PROJECT');
+  });
+
+  it("removeStaleContainerIfNeeded call appears BEFORE the compose up call in source", () => {
+    // Ordering guard: cleanup must precede the up step.  A reorder
+    // (even accidentally, e.g. cut-paste) would flip these indices and
+    // fail this test.
+    const cleanupIdx = indexOf(
+      src,
+      'removeStaleContainerIfNeeded("switchroom-hostd"',
+      "removeStaleContainerIfNeeded call",
+    );
+    // The `up -d` invocation — use the unique `"up", "-d"` args.
+    const upIdx = indexOf(
+      src,
+      '"up", "-d"',
+      'compose up -d call',
+    );
+    expect(cleanupIdx).toBeLessThan(upIdx);
+  });
+
+  it("container_name in compose template matches the literal passed to removeStaleContainerIfNeeded", () => {
+    // The compose template must declare the same name the cleanup probes,
+    // or the cleanup targets the wrong container.
+    expect(src).toContain("container_name: switchroom-hostd");
+  });
+});
+
+// ─── webd.ts ─────────────────────────────────────────────────────────────────
+
+describe("webd.ts callsite: removeStaleContainerIfNeeded before compose up", () => {
+  const src = readSource("webd.ts");
+
+  it("calls removeStaleContainerIfNeeded with container name 'switchroom-web'", () => {
+    expect(src).toContain('removeStaleContainerIfNeeded("switchroom-web"');
+  });
+
+  it("WEB_COMPOSE_PROJECT constant equals 'switchroom-web'", () => {
+    expect(src).toContain('const WEB_COMPOSE_PROJECT = "switchroom-web"');
+  });
+
+  it("passes WEB_COMPOSE_PROJECT (not a different literal) as the targetProject arg", () => {
+    expect(src).toContain('removeStaleContainerIfNeeded("switchroom-web", WEB_COMPOSE_PROJECT');
+  });
+
+  it("compose -p for the up command uses WEB_COMPOSE_PROJECT (same constant)", () => {
+    expect(src).toContain('"compose", "-p", WEB_COMPOSE_PROJECT');
+  });
+
+  it("removeStaleContainerIfNeeded call appears BEFORE the compose up call in source", () => {
+    const cleanupIdx = indexOf(
+      src,
+      'removeStaleContainerIfNeeded("switchroom-web"',
+      "removeStaleContainerIfNeeded call",
+    );
+    const upIdx = indexOf(
+      src,
+      '"up", "-d"',
+      'compose up -d call',
+    );
+    expect(cleanupIdx).toBeLessThan(upIdx);
+  });
+
+  it("container_name in compose template matches the literal passed to removeStaleContainerIfNeeded", () => {
+    expect(src).toContain("container_name: switchroom-web");
+  });
+});

--- a/src/cli/singleton-stale-cleanup.test.ts
+++ b/src/cli/singleton-stale-cleanup.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for singleton stale-container reconciliation.
+ *
+ * Scenario reproduced: during `switchroom update`, the refresh-hostd /
+ * refresh-web steps invoke `docker compose up -d` for each singleton in
+ * its own compose project. When a singleton was previously installed from
+ * a DIFFERENT compose project (e.g. old containerized-path install:
+ * project `hostd`, workdir `/wd/hostd`), docker compose treats the setups
+ * as different instances and tries to CREATE (not RECREATE) the container.
+ * The CREATE fails with a container-name conflict because the stale old
+ * container still holds the name, aborting the whole update.
+ *
+ * Fix: `removeStaleContainerIfNeeded` detects a stale container (one whose
+ * `com.docker.compose.project` label differs from the target project) and
+ * force-removes it before the `compose up -d` runs. Idempotent and logged.
+ *
+ * Broke the v0.15.48 rollout for both hostd and web.
+ */
+
+import { describe, it, expect } from "vitest";
+import { removeStaleContainerIfNeeded, type DockerRunner } from "./singleton-stale-cleanup.js";
+
+/** Build a mock DockerRunner from a map of args[0..] → result. */
+function mockDocker(calls: Array<{ args: string[]; ok: boolean; stdout: string; stderr: string }>): {
+  runner: DockerRunner;
+  recorded: string[][];
+} {
+  const recorded: string[][] = [];
+  const runner: DockerRunner = (args) => {
+    recorded.push(args);
+    const match = calls.find(
+      (c) => c.args.length === args.length && c.args.every((a, i) => a === args[i]),
+    );
+    if (!match) {
+      throw new Error(`Unexpected docker call: ${JSON.stringify(args)}`);
+    }
+    return { ok: match.ok, stdout: match.stdout, stderr: match.stderr };
+  };
+  return { runner, recorded };
+}
+
+describe("removeStaleContainerIfNeeded", () => {
+  it("is a no-op when the container does not exist (inspect fails)", () => {
+    const { runner, recorded } = mockDocker([
+      {
+        args: ["inspect", "--format", '{{index .Config.Labels "com.docker.compose.project"}}', "switchroom-hostd"],
+        ok: false,
+        stdout: "",
+        stderr: "No such container: switchroom-hostd",
+      },
+    ]);
+    const logs: string[] = [];
+    const result = removeStaleContainerIfNeeded("switchroom-hostd", "switchroom-hostd", (l) => logs.push(l), runner);
+
+    expect(result.removed).toBe(false);
+    expect(result.oldProject).toBeUndefined();
+    expect(result.error).toBeUndefined();
+    // Only the inspect call was made — no rm.
+    expect(recorded).toHaveLength(1);
+    expect(logs).toHaveLength(0);
+  });
+
+  it("is a no-op when the container exists and belongs to the target project (will RECREATE cleanly)", () => {
+    const { runner, recorded } = mockDocker([
+      {
+        args: ["inspect", "--format", '{{index .Config.Labels "com.docker.compose.project"}}', "switchroom-hostd"],
+        ok: true,
+        stdout: "switchroom-hostd\n",
+        stderr: "",
+      },
+    ]);
+    const logs: string[] = [];
+    const result = removeStaleContainerIfNeeded("switchroom-hostd", "switchroom-hostd", (l) => logs.push(l), runner);
+
+    expect(result.removed).toBe(false);
+    expect(result.oldProject).toBeUndefined();
+    // No rm issued.
+    expect(recorded).toHaveLength(1);
+    expect(logs).toHaveLength(0);
+  });
+
+  it("removes a stale container that belongs to a different old project (the v0.15.48 scenario for hostd)", () => {
+    // Old containerized-path install had project="hostd"; new target is "switchroom-hostd".
+    const { runner, recorded } = mockDocker([
+      {
+        args: ["inspect", "--format", '{{index .Config.Labels "com.docker.compose.project"}}', "switchroom-hostd"],
+        ok: true,
+        stdout: "hostd\n",
+        stderr: "",
+      },
+      {
+        args: ["rm", "-f", "switchroom-hostd"],
+        ok: true,
+        stdout: "switchroom-hostd\n",
+        stderr: "",
+      },
+    ]);
+    const logs: string[] = [];
+    const result = removeStaleContainerIfNeeded("switchroom-hostd", "switchroom-hostd", (l) => logs.push(l), runner);
+
+    expect(result.removed).toBe(true);
+    expect(result.containerName).toBe("switchroom-hostd");
+    expect(result.oldProject).toBe("hostd");
+    expect(result.error).toBeUndefined();
+    // Both inspect and rm were called.
+    expect(recorded).toHaveLength(2);
+    expect(recorded[1]).toEqual(["rm", "-f", "switchroom-hostd"]);
+    // A log line was emitted mentioning the old project.
+    expect(logs.some((l) => l.includes("hostd"))).toBe(true);
+    expect(logs.some((l) => l.includes("switchroom-hostd"))).toBe(true);
+  });
+
+  it("removes a stale container that belongs to a different old project (the v0.15.48 scenario for web)", () => {
+    // Old project="web", new target="switchroom-web".
+    const { runner, recorded } = mockDocker([
+      {
+        args: ["inspect", "--format", '{{index .Config.Labels "com.docker.compose.project"}}', "switchroom-web"],
+        ok: true,
+        stdout: "web\n",
+        stderr: "",
+      },
+      {
+        args: ["rm", "-f", "switchroom-web"],
+        ok: true,
+        stdout: "switchroom-web\n",
+        stderr: "",
+      },
+    ]);
+    const logs: string[] = [];
+    const result = removeStaleContainerIfNeeded("switchroom-web", "switchroom-web", (l) => logs.push(l), runner);
+
+    expect(result.removed).toBe(true);
+    expect(result.containerName).toBe("switchroom-web");
+    expect(result.oldProject).toBe("web");
+    expect(result.error).toBeUndefined();
+    expect(recorded).toHaveLength(2);
+    expect(recorded[1]).toEqual(["rm", "-f", "switchroom-web"]);
+  });
+
+  it("removes a stale container with NO compose project label (manually-created container holding the name)", () => {
+    // A container created with `docker run --name switchroom-hostd ...` has no
+    // compose.project label — inspect returns an empty string.
+    const { runner, recorded } = mockDocker([
+      {
+        args: ["inspect", "--format", '{{index .Config.Labels "com.docker.compose.project"}}', "switchroom-hostd"],
+        ok: true,
+        stdout: "\n",
+        stderr: "",
+      },
+      {
+        args: ["rm", "-f", "switchroom-hostd"],
+        ok: true,
+        stdout: "switchroom-hostd\n",
+        stderr: "",
+      },
+    ]);
+    const logs: string[] = [];
+    const result = removeStaleContainerIfNeeded("switchroom-hostd", "switchroom-hostd", (l) => logs.push(l), runner);
+
+    expect(result.removed).toBe(true);
+    expect(result.oldProject).toBe("");
+    expect(recorded).toHaveLength(2);
+    // Log should mention "(none)" since the old project label was empty.
+    expect(logs.some((l) => l.includes("(none)"))).toBe(true);
+  });
+
+  it("surfaces an error (but does not throw) when docker rm fails", () => {
+    const { runner } = mockDocker([
+      {
+        args: ["inspect", "--format", '{{index .Config.Labels "com.docker.compose.project"}}', "switchroom-hostd"],
+        ok: true,
+        stdout: "old-project\n",
+        stderr: "",
+      },
+      {
+        args: ["rm", "-f", "switchroom-hostd"],
+        ok: false,
+        stdout: "",
+        stderr: "permission denied",
+      },
+    ]);
+    const logs: string[] = [];
+    const result = removeStaleContainerIfNeeded("switchroom-hostd", "switchroom-hostd", (l) => logs.push(l), runner);
+
+    expect(result.removed).toBe(false);
+    expect(result.error).toMatch(/permission denied/);
+    // The warning was logged, not thrown.
+    expect(logs.some((l) => l.includes("warning"))).toBe(true);
+  });
+
+  it("is idempotent: calling twice when the first call already removed the container", () => {
+    // Second call: inspect returns non-zero (container gone) → no-op.
+    const { runner, recorded } = mockDocker([
+      {
+        args: ["inspect", "--format", '{{index .Config.Labels "com.docker.compose.project"}}', "switchroom-hostd"],
+        ok: false,
+        stdout: "",
+        stderr: "No such container: switchroom-hostd",
+      },
+    ]);
+    const logs: string[] = [];
+    const result = removeStaleContainerIfNeeded("switchroom-hostd", "switchroom-hostd", (l) => logs.push(l), runner);
+
+    expect(result.removed).toBe(false);
+    expect(recorded).toHaveLength(1);
+    expect(logs).toHaveLength(0);
+  });
+});

--- a/src/cli/singleton-stale-cleanup.ts
+++ b/src/cli/singleton-stale-cleanup.ts
@@ -1,0 +1,115 @@
+/**
+ * Stale-container reconciliation for singleton compose projects.
+ *
+ * Background: each singleton (`switchroom-hostd`, `switchroom-web`) runs in
+ * its OWN compose project (e.g. project `switchroom-hostd`, workdir
+ * `~/.switchroom/hostd`). When a host previously ran the singleton from a
+ * DIFFERENT working directory or project (e.g. an old containerized-path
+ * install: project `hostd`, workdir `/wd/hostd`), docker compose treats the
+ * two setups as DIFFERENT project instances and tries to CREATE — not
+ * RECREATE — the container, because the old container isn't part of the
+ * target project. That CREATE then fails with a container-name conflict
+ * ("the container name /switchroom-hostd is already in use") because the
+ * stale old container still holds the name.
+ *
+ * Fix: before `docker compose up -d` for a singleton, probe whether a
+ * container holding the target `container_name` exists but belongs to a
+ * different compose project. If so, force-remove the stale container so the
+ * create succeeds. The operation is logged and idempotent.
+ *
+ * Broke the v0.15.48 rollout for both hostd and web; operator had to
+ * manually `docker rm switchroom-hostd switchroom-web` to unblock it.
+ */
+
+import { spawnSync } from "node:child_process";
+
+/**
+ * Result of probing for a stale container.
+ */
+export interface StaleContainerProbeResult {
+  /** Whether a stale container was found and removed. */
+  removed: boolean;
+  /** Container name that was (or wasn't) cleaned up. */
+  containerName: string;
+  /** The old project it belonged to, if stale. */
+  oldProject?: string;
+  /** Error message if the probe or removal failed. */
+  error?: string;
+}
+
+/**
+ * Run a docker command and return stdout/stderr/ok.
+ * Exported for testing via dependency injection.
+ */
+export type DockerRunner = (args: string[]) => { ok: boolean; stdout: string; stderr: string };
+
+export function makeDockerRunner(): DockerRunner {
+  return (args) => {
+    const r = spawnSync("docker", args, { encoding: "utf8" });
+    return {
+      ok: r.status === 0,
+      stdout: r.stdout ?? "",
+      stderr: r.stderr ?? "",
+    };
+  };
+}
+
+/**
+ * Probe for a stale container and remove it if found.
+ *
+ * A container is considered "stale" if:
+ *   - It exists (docker inspect succeeds), AND
+ *   - Its `com.docker.compose.project` label differs from `targetProject`.
+ *
+ * When stale, force-removes it so the subsequent `docker compose up -d`
+ * can CREATE the container under the target project without a name conflict.
+ *
+ * Idempotent: if the container doesn't exist, or belongs to the target
+ * project already, this is a no-op.
+ *
+ * @param containerName  The docker container_name to check (e.g. "switchroom-hostd").
+ * @param targetProject  The compose project name we're about to `up` into.
+ * @param log            Progress emitter (caller decides where to write).
+ * @param docker         Docker runner (injectable for tests).
+ */
+export function removeStaleContainerIfNeeded(
+  containerName: string,
+  targetProject: string,
+  log: (line: string) => void,
+  docker: DockerRunner = makeDockerRunner(),
+): StaleContainerProbeResult {
+  // Inspect the named container — fails (non-zero) if it doesn't exist.
+  const inspect = docker([
+    "inspect",
+    "--format",
+    "{{index .Config.Labels \"com.docker.compose.project\"}}",
+    containerName,
+  ]);
+
+  if (!inspect.ok) {
+    // Container doesn't exist — nothing to do.
+    return { removed: false, containerName };
+  }
+
+  const existingProject = inspect.stdout.trim();
+
+  if (existingProject === targetProject) {
+    // Already owned by our project — compose will RECREATE it correctly.
+    return { removed: false, containerName };
+  }
+
+  // Stale: container exists under a different project (or no project label at all).
+  log(
+    `  removing stale container ${containerName} from old project "${existingProject || "(none)"}" before recreate`,
+  );
+
+  const rm = docker(["rm", "-f", containerName]);
+  if (!rm.ok) {
+    const error = `docker rm -f ${containerName} failed: ${rm.stderr.trim()}`;
+    log(`  warning: ${error}`);
+    return { removed: false, containerName, oldProject: existingProject, error };
+  }
+
+  log(`  removed stale container ${containerName} (was project "${existingProject || "(none)"}")`);
+  return { removed: true, containerName, oldProject: existingProject };
+}

--- a/src/cli/webd.ts
+++ b/src/cli/webd.ts
@@ -47,6 +47,7 @@ import { getConfig, withConfigError } from "./helpers.js";
 import { resolveOperatorUid } from "./operator-uid.js";
 import { resolveImageTag, resolveRelease, type ReleaseBlockShape } from "../config/release-resolve.js";
 import { checkDowngrade } from "./deploy-version-guard.js";
+import { removeStaleContainerIfNeeded } from "./singleton-stale-cleanup.js";
 
 /**
  * Resolve the web image tag for an install.
@@ -312,6 +313,15 @@ async function doInstall(opts: InstallOptions, program: Command): Promise<void> 
     );
     process.exit(1);
   }
+
+  // Stale-container reconciliation: if a container named switchroom-web
+  // exists under a DIFFERENT compose project (e.g. old containerized-path
+  // install), `compose up` would try to CREATE (not RECREATE) it and fail
+  // with a name conflict. Remove the stale container first so the create
+  // succeeds. Idempotent and logged. See singleton-stale-cleanup.ts.
+  removeStaleContainerIfNeeded("switchroom-web", WEB_COMPOSE_PROJECT, (line) =>
+    console.log(chalk.dim(line)),
+  );
 
   console.log(chalk.dim(`    Bringing up web service…`));
   const up = runDocker(["compose", "-p", WEB_COMPOSE_PROJECT, "-f", composePath, "up", "-d"]);


### PR DESCRIPTION
## Problem

During `switchroom update`, the `refresh-hostd` and `refresh-web` steps create each singleton in its **own compose project**. When a singleton was previously installed from a *different* compose project (e.g. an old containerised-path install: project `hostd`, workdir `/wd/hostd`), docker compose tries to **CREATE rather than RECREATE** the container because the old one isn't part of the target project. The CREATE fails with:

```
the container name "/switchroom-hostd" is already in use by container ...
```

aborting the update mid-roll. **This broke the v0.15.48 rollout** for both `hostd` and `web` — recovery required the operator to manually `docker rm switchroom-hostd switchroom-web` to unblock it.

## Fix

New `removeStaleContainerIfNeeded` (`src/cli/singleton-stale-cleanup.ts`): before `compose up -d`, inspect the target `container_name`, read its `com.docker.compose.project` label, and force-remove the container **only if** the project label differs from the target project (logging `removing stale <name> from old project <X> before recreate`). Wired into `hostd.ts` and `webd.ts` immediately before their `compose up` call.

Idempotent: no-op if the container doesn't exist or already belongs to the target project (the normal RECREATE path is untouched). The `DockerRunner` is injectable so tests make no real docker calls.

## Tests

`src/cli/singleton-stale-cleanup.test.ts` — 7 cases: no container, same project (no-op), stale hostd project (the v0.15.48 scenario), stale web project, missing compose label, `docker rm` failure, idempotency. Existing `hostd.test.ts` (23) + `webd.test.ts` (16) still pass; `tsc --noEmit` clean.

## Scope
4 files, +343. No behavior change on the happy path — only adds stale-container reconciliation before create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)