### PR TITLE
fix(telegram): ship SWITCHROOM_STATUS_NO_TRUNCATE + close status-surface UAT gaps

### DIFF
--- a/telegram-plugin/status-no-truncate.ts
+++ b/telegram-plugin/status-no-truncate.ts
@@ -1,0 +1,37 @@
+/**
+ * Feature flag: SWITCHROOM_STATUS_NO_TRUNCATE
+ *
+ * When ON (the default), activity-feed cards show ALL accumulated lines and
+ * full-width lines — no cosmetic line-count or per-line-length caps. The only
+ * ceiling in no-truncate mode is Telegram's 4096-char message limit.
+ *
+ * When OFF (env var set to '0'), preserves the original capped behaviour:
+ * MIRROR_MAX_LINES / NESTED_MAX_LINES / NESTED_LINE_MAX / NARRATIVE_MAX_LINES
+ * all apply exactly as before.
+ *
+ * Semantics: noTruncate = env !== '0'  →  DEFAULT TRUE (no truncation).
+ *
+ * This is a tiny shared module so both renderer files can import it and tests
+ * can flip the flag by setting/deleting process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+ * without scattering process.env reads across files.
+ */
+
+/**
+ * Returns true when status cards should show all accumulated lines (no
+ * cosmetic truncation). Reads the env var at call time so tests can flip it
+ * with set/delete on process.env without module re-imports.
+ *
+ * Default: true (no truncation). Set SWITCHROOM_STATUS_NO_TRUNCATE=0 to
+ * restore the original capped behaviour.
+ */
+export function statusNoTruncate(): boolean {
+  return process.env.SWITCHROOM_STATUS_NO_TRUNCATE !== '0'
+}
+
+/**
+ * The safe char budget for rendered Telegram messages in no-truncate mode.
+ * Telegram's hard cap is 4096; we use 4000 to leave 96 chars of headroom for
+ * HTML framing, emoji, and escape expansion — matching the convention in
+ * pending-work-progress.ts (TELEGRAM_MSG_CAP = 4000).
+ */
+export const STATUS_CARD_CHAR_BUDGET = 4000

--- a/telegram-plugin/tests/activity-ever-opened-sticky.test.ts
+++ b/telegram-plugin/tests/activity-ever-opened-sticky.test.ts
@@ -1,0 +1,47 @@
+/**
+ * M-2: `activityEverOpened` sticky-true invariant — structural assertion.
+ *
+ * `activityEverOpened` is set to `true` exactly once, when the activity feed
+ * posts its first message (the `sendMessage` path in `drainActivitySummary`).
+ * It must NEVER be reset to false or cleared — unlike `activityMessageId`, which
+ * is nulled by `clearActivitySummary` to indicate that the persistent message was
+ * finalized/deleted. The sticky-true invariant lets the turn-end DEGRADED check
+ * (`detectStatusSurfaceDegraded`) distinguish "feed never opened" (the
+ * resume-400 signature) from "feed opened + finalized".
+ *
+ * Load-bearing constraints:
+ *   1. `activityEverOpened = true` is set exactly ONCE in gateway.ts (at the
+ *      send-message success site in drainActivitySummary).
+ *   2. `turn.activityEverOpened = false` NEVER appears in gateway.ts (it is only
+ *      initialised to `false` in the turn-initialiser object literal, never reset
+ *      via a standalone assignment).
+ *
+ * These are STRUCTURAL (source-read) assertions. Pattern: silence-liveness-wiring.test.ts.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const gatewaySrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf-8',
+)
+
+describe('M-2: activityEverOpened sticky-true invariant', () => {
+  it('activityEverOpened = true appears exactly once (set at send-message success)', () => {
+    const setTrueMatches = [...gatewaySrc.matchAll(/activityEverOpened\s*=\s*true/g)]
+    expect(setTrueMatches).toHaveLength(1)
+  })
+
+  it('turn.activityEverOpened = false never appears (no standalone reset)', () => {
+    // The only `false` value must be in the object literal initialiser
+    // (e.g. `activityEverOpened: false`), never a standalone reassignment.
+    const resetMatches = [...gatewaySrc.matchAll(/turn\.activityEverOpened\s*=\s*false/g)]
+    expect(resetMatches).toHaveLength(0)
+  })
+
+  it('activityEverOpened is initialised false in the turn object literal (per-turn reset)', () => {
+    // The object literal form `activityEverOpened: false` must exist (per-turn init).
+    expect(gatewaySrc).toMatch(/activityEverOpened:\s*false/)
+  })
+})

--- a/telegram-plugin/tests/feed-heartbeat-liveness-open.test.ts
+++ b/telegram-plugin/tests/feed-heartbeat-liveness-open.test.ts
@@ -1,0 +1,72 @@
+/**
+ * H-1: feedHeartbeatTick liveness-open threshold — structural assertions.
+ *
+ * Pins three load-bearing constraints of the "liveness-open" branch inside
+ * `feedHeartbeatTick` (gateway.ts):
+ *
+ *   1. The SWITCHROOM_FEED_LIVENESS_OPEN kill-switch (default ON, i.e. `!== '0'`)
+ *      gates the liveness-open path — operators can disable it with =0.
+ *   2. FEED_LIVENESS_OPEN_MS is parsed from env with a sane default (12 000 ms).
+ *   3. The `age < FEED_LIVENESS_OPEN_MS` return-guard fires BEFORE the feed opens —
+ *      a turn that hasn't yet passed the threshold returns early and the liveness
+ *      feed stays closed.
+ *
+ * These are STRUCTURAL (source-read) assertions; the gateway IIFE can't be
+ * instantiated in-process.  Pattern matches silence-liveness-wiring.test.ts.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const gatewaySrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf-8',
+)
+
+/** Return the source text of `feedHeartbeatTick` (everything up to the next top-level function). */
+function feedHeartbeatTickSrc(): string {
+  const after = gatewaySrc.split('function feedHeartbeatTick(): void {')[1] ?? ''
+  // Stop at the next top-level function definition.
+  return after.split('\nfunction ')[0] ?? after
+}
+
+describe('H-1: feedHeartbeatTick liveness-open threshold', () => {
+  it('SWITCHROOM_FEED_LIVENESS_OPEN kill-switch uses !== "0" semantic (default ON)', () => {
+    // Must be defined as `!== '0'` so that an unset env var is truthy (default on).
+    expect(gatewaySrc).toMatch(
+      /FEED_LIVENESS_OPEN_ENABLED\s*=\s*process\.env\.SWITCHROOM_FEED_LIVENESS_OPEN\s*!==\s*'0'/,
+    )
+  })
+
+  it('FEED_LIVENESS_OPEN_MS defaults to 12_000 ms when env is unset', () => {
+    // The IIFE initialiser `const FEED_LIVENESS_OPEN_MS = (() => { ... })()` must
+    // contain the fallback 12_000. Split on the const definition (not the comment).
+    const afterConst = gatewaySrc.split('const FEED_LIVENESS_OPEN_MS')[1] ?? ''
+    // The IIFE closes with `})()` — take everything before that.
+    const initBlock = afterConst.split('})()')[0] ?? ''
+    expect(initBlock).toMatch(/12[_]?000/)
+  })
+
+  it('age < FEED_LIVENESS_OPEN_MS return-guard exists inside feedHeartbeatTick', () => {
+    const body = feedHeartbeatTickSrc()
+    expect(body).toMatch(/if\s*\(age\s*<\s*FEED_LIVENESS_OPEN_MS\)\s*return/)
+  })
+
+  it('FEED_LIVENESS_OPEN_ENABLED check precedes the drainActivitySummary call in feedHeartbeatTick', () => {
+    const body = feedHeartbeatTickSrc()
+    const enabledIdx = body.indexOf('FEED_LIVENESS_OPEN_ENABLED')
+    // Use the actual call site (assignment to activityInFlight) not the comment mention.
+    const drainCallIdx = body.indexOf('turn.activityInFlight = drainActivitySummary')
+    expect(enabledIdx).toBeGreaterThan(-1)
+    expect(drainCallIdx).toBeGreaterThan(enabledIdx)
+  })
+
+  it('age < FEED_LIVENESS_OPEN_MS guard precedes the drainActivitySummary call (early-return before open)', () => {
+    const body = feedHeartbeatTickSrc()
+    const guardIdx = body.indexOf('age < FEED_LIVENESS_OPEN_MS')
+    // Use the actual call site (assignment to activityInFlight) not the comment mention.
+    const drainCallIdx = body.indexOf('turn.activityInFlight = drainActivitySummary')
+    expect(guardIdx).toBeGreaterThan(-1)
+    expect(drainCallIdx).toBeGreaterThan(guardIdx)
+  })
+})

--- a/telegram-plugin/tests/permission-card-origin-kill-switch.test.ts
+++ b/telegram-plugin/tests/permission-card-origin-kill-switch.test.ts
@@ -1,0 +1,42 @@
+/**
+ * M-1: SWITCHROOM_PERMISSION_CARD_ORIGIN_RECOVERY kill-switch — structural assertion.
+ *
+ * The permission-card origin-recovery feature (fixes the "marko Rentals-budget"
+ * incident: permission cards fanning out to operator DMs instead of the forum
+ * topic the operator is working in) must be gated by a kill switch so operators
+ * can opt out of the recovery behaviour if it causes issues.
+ *
+ * Load-bearing constraint: the kill switch must use `!== '0'` semantics (default
+ * ON — recovery is active unless explicitly disabled). This is a structural
+ * assertion — pattern matches silence-liveness-wiring.test.ts.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const gatewaySrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf-8',
+)
+
+describe('M-1: SWITCHROOM_PERMISSION_CARD_ORIGIN_RECOVERY kill-switch', () => {
+  it('kill-switch env var name is SWITCHROOM_PERMISSION_CARD_ORIGIN_RECOVERY', () => {
+    expect(gatewaySrc).toContain('SWITCHROOM_PERMISSION_CARD_ORIGIN_RECOVERY')
+  })
+
+  it('kill-switch constant is defined with !== "0" semantic (default ON)', () => {
+    expect(gatewaySrc).toMatch(
+      /PERMISSION_CARD_ORIGIN_RECOVERY_ENABLED[\s\S]{0,10}=[\s\S]{0,10}process\.env\.SWITCHROOM_PERMISSION_CARD_ORIGIN_RECOVERY\s*!==\s*'0'/,
+    )
+  })
+
+  it('kill-switch gates the origin-recovery call site in gateway.ts', () => {
+    // There must be at least two occurrences: the const definition and the gate site.
+    const matches = [...gatewaySrc.matchAll(/PERMISSION_CARD_ORIGIN_RECOVERY_ENABLED/g)]
+    expect(matches.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('kill-switch is checked with if (PERMISSION_CARD_ORIGIN_RECOVERY_ENABLED)', () => {
+    expect(gatewaySrc).toMatch(/if\s*\(\s*PERMISSION_CARD_ORIGIN_RECOVERY_ENABLED\s*\)/)
+  })
+})

--- a/telegram-plugin/tests/status-surface-log.test.ts
+++ b/telegram-plugin/tests/status-surface-log.test.ts
@@ -101,6 +101,23 @@ describe('detectStatusSurfaceDegraded — uses labeledToolCount (#2461)', () => 
     expect(detectStatusSurfaceDegraded(t)).toBeNull()
   })
 
+  it('H-2: reply-only turn — all tools surface-suppressed, drain failures present — no false-positive DEGRADED', () => {
+    // Scenario: agent sent a reply but all 5 tool_uses were surface tools
+    // (reply/react/etc) so labeledToolCount=0. Three activity-feed drain
+    // failures occurred (e.g. Telegram 400s from a stale anchor), but since
+    // there was nothing to surface, DEGRADED must NOT fire — the exemption is
+    // `labeledToolCount === 0`. This is the critical missing coverage case for
+    // the `labeledToolCount === 0` short-circuit in detectStatusSurfaceDegraded.
+    const t = makeTurn({
+      toolCallCount: 5,
+      labeledToolCount: 0,
+      activityDrainFailures: 3,
+      activityEverOpened: false,
+      replyCalled: true,
+    })
+    expect(detectStatusSurfaceDegraded(t)).toBeNull()
+  })
+
   it('returns null when feed opened fine (activityEverOpened=true)', () => {
     const t = makeTurn({ labeledToolCount: 3, activityEverOpened: true, activityDrainFailures: 2 })
     expect(detectStatusSurfaceDegraded(t)).toBeNull()

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import {
   describeToolUse,
   appendActivityLine,
@@ -101,7 +101,9 @@ describe("appendActivityLine + renderActivityFeed — accumulating activity feed
     expect(lines).toEqual([]);
   });
 
-  it("caps to the last MIRROR_MAX_LINES with a '✓ +N earlier…' header", () => {
+  it("caps to the last MIRROR_MAX_LINES with a '✓ +N earlier…' header (no-truncate OFF)", () => {
+    // This test exercises the capping behaviour that is active when the flag is OFF.
+    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = "0";
     const lines = Array.from({ length: 9 }, (_, i) => `Action ${i + 1}`);
     const out = renderActivityFeed(lines)!;
     expect(out.startsWith("<i>✓ +3 earlier…</i>\n")).toBe(true);
@@ -112,6 +114,7 @@ describe("appendActivityLine + renderActivityFeed — accumulating activity feed
     expect(out).toContain("<b>→ Action 9</b>");
     expect(out).toContain("<i>✓ Action 8</i>");
     expect(out).not.toContain("<b>→ Action 8</b>");
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
   });
 
   it("HTML-escapes &, <, > in action text (no double-escaping by callers)", () => {
@@ -230,12 +233,15 @@ describe("renderActivityFeed — ✓ N steps total (final render, issue #2461)",
     expect(out).toContain("<i>✓ 1 steps</i>");
   });
 
-  it("footer appears even when the feed overflows MIRROR_MAX_LINES", () => {
+  it("footer appears even when the feed overflows MIRROR_MAX_LINES (no-truncate OFF)", () => {
+    // This test exercises the overflow-header behaviour that is active when the flag is OFF.
+    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = "0";
     const lines = Array.from({ length: 9 }, (_, i) => `Action ${i + 1}`);
     const out = renderActivityFeed(lines, true, "", 9)!;
     expect(out).toContain("<i>✓ +3 earlier…</i>");
     expect(out).toContain("<i>✓ 9 steps</i>");
     expect(out.endsWith("<i>✓ 9 steps</i>")).toBe(true);
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
   });
 
   it("stepCount is surface-tool-excluded: reply/react count 0, Read+mcp count correctly", () => {
@@ -274,7 +280,9 @@ describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A
     expect(out).toContain("   ↳ <b>→ Looking for foreign keys</b>");
   });
 
-  it("caps the nested block to NESTED_MAX_LINES with a '↳ +N earlier…' header", () => {
+  it("caps the nested block to NESTED_MAX_LINES with a '↳ +N earlier…' header (no-truncate OFF)", () => {
+    // This test exercises the capping behaviour that is active when the flag is OFF.
+    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = "0";
     const child = Array.from({ length: NESTED_MAX_LINES + 3 }, (_, i) => `step ${i + 1}`);
     const out = renderActivityFeedWithNested(["Delegating: x"], child)!;
     expect(out).toContain("   ↳ <i>+3 earlier…</i>");
@@ -282,6 +290,7 @@ describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A
     expect(out).toContain(`   ↳ <b>→ step ${NESTED_MAX_LINES + 3}</b>`);
     // the oldest (collapsed) lines are not rendered verbatim
     expect(out).not.toContain("step 1<");
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
   });
 
   it("renders the child block even when the parent feed is empty", () => {
@@ -390,5 +399,240 @@ describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A
       // to render on an ack-first turn → null → finalize would no-op.
       expect(renderActivityFeedWithNested([], [], true)).toBeNull();
     });
+  });
+});
+
+// ─── SWITCHROOM_STATUS_NO_TRUNCATE feature flag tests ───────────────────────
+
+describe("SWITCHROOM_STATUS_NO_TRUNCATE — renderActivityFeed", () => {
+  afterEach(() => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+  });
+
+  it("no-truncate ON (default): a feed > MIRROR_MAX_LINES renders ALL lines", () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE; // default = ON
+    const lines = Array.from({ length: MIRROR_MAX_LINES + 5 }, (_, i) => `Action ${i + 1}`);
+    const out = renderActivityFeed(lines)!;
+    // All lines must appear (oldest = ✓ done, newest = → in-progress).
+    for (let i = 1; i <= MIRROR_MAX_LINES + 5; i++) {
+      expect(out).toContain(`Action ${i}`);
+    }
+    // No spurious "+N earlier" when all lines fit.
+    expect(out).not.toContain("earlier");
+    // Newest is still the in-progress step.
+    expect(out).toContain(`<b>→ Action ${MIRROR_MAX_LINES + 5}</b>`);
+  });
+
+  it("no-truncate ON: setting env to '1' (or any non-'0') is also ON", () => {
+    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = "1";
+    const lines = Array.from({ length: MIRROR_MAX_LINES + 2 }, (_, i) => `Step ${i + 1}`);
+    const out = renderActivityFeed(lines)!;
+    expect(out).toContain(`Step 1`);
+    expect(out).toContain(`Step ${MIRROR_MAX_LINES + 2}`);
+    expect(out).not.toContain("earlier");
+  });
+
+  it("no-truncate OFF (=0): existing truncation behaviour preserved (cap to MIRROR_MAX_LINES)", () => {
+    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = "0";
+    const lines = Array.from({ length: 9 }, (_, i) => `Action ${i + 1}`);
+    const out = renderActivityFeed(lines)!;
+    expect(out.startsWith("<i>✓ +3 earlier…</i>\n")).toBe(true);
+    expect(out).toContain("<i>✓ Action 4</i>");
+    expect(out).not.toContain("Action 3");
+    expect(out).toContain("<b>→ Action 9</b>");
+  });
+
+  it("no-truncate ON + pathologically huge feed (500 long lines): output ≤ 4096 chars and oldest lines are clipped with header", () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE; // default ON
+    // 500 lines of ~20 chars each → well over 4000 chars rendered.
+    const lines = Array.from({ length: 500 }, (_, i) => `Action step number ${i + 1}`);
+    const out = renderActivityFeed(lines)!;
+    // Hard invariant: output must not exceed Telegram's 4096-char limit.
+    expect(out.length).toBeLessThanOrEqual(4096);
+    // Clip header must be present (oldest lines were dropped).
+    expect(out).toContain("earlier…");
+    // The newest line must still be present.
+    expect(out).toContain("Action step number 500");
+  });
+
+  it("no-truncate ON: no spurious '+N earlier' header when feed is small enough to fit", () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+    const lines = Array.from({ length: 3 }, (_, i) => `Short step ${i + 1}`);
+    const out = renderActivityFeed(lines)!;
+    expect(out).not.toContain("earlier");
+  });
+});
+
+describe("SWITCHROOM_STATUS_NO_TRUNCATE — renderActivityFeedWithNested", () => {
+  afterEach(() => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+  });
+
+  it("no-truncate ON: parent > MIRROR_MAX_LINES shows all parent lines", () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+    const parent = Array.from({ length: MIRROR_MAX_LINES + 3 }, (_, i) => `Parent ${i + 1}`);
+    const child = ["Child step A", "Child step B"];
+    const out = renderActivityFeedWithNested(parent, child)!;
+    for (let i = 1; i <= MIRROR_MAX_LINES + 3; i++) {
+      expect(out).toContain(`Parent ${i}`);
+    }
+    expect(out).not.toContain("+3 earlier"); // no parent truncation header
+    expect(out).toContain("   ↳ <b>→ Child step B</b>");
+  });
+
+  it("no-truncate ON: child > NESTED_MAX_LINES shows all child lines", () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+    const parent = ["Delegating: big task"];
+    const child = Array.from({ length: NESTED_MAX_LINES + 4 }, (_, i) => `Child ${i + 1}`);
+    const out = renderActivityFeedWithNested(parent, child)!;
+    for (let i = 1; i <= NESTED_MAX_LINES + 4; i++) {
+      expect(out).toContain(`Child ${i}`);
+    }
+    expect(out).not.toContain("+4 earlier"); // no child truncation header
+    expect(out).toContain(`   ↳ <b>→ Child ${NESTED_MAX_LINES + 4}</b>`);
+  });
+
+  it("no-truncate ON: a line longer than NESTED_LINE_MAX renders in full (no '…' truncation)", () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+    const longLine = "x".repeat(120); // well over the 90-char NESTED_LINE_MAX
+    const out = renderActivityFeedWithNested(["Delegating"], [longLine])!;
+    // The full long line must appear untruncated (no '…' from NESTED_LINE_MAX).
+    expect(out).toContain(longLine);
+    expect(out).not.toContain(longLine.slice(0, 89) + "…");
+  });
+
+  it("no-truncate OFF (=0): per-line NESTED_LINE_MAX cap is still applied", () => {
+    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = "0";
+    const longLine = "x".repeat(120);
+    const out = renderActivityFeedWithNested(["Delegating"], [longLine])!;
+    expect(out).toContain("…");
+    expect(out).not.toContain(longLine);
+  });
+
+  it("no-truncate ON + huge nested feed: output ≤ 4096 chars with oldest-lines-dropped header", () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+    // 150 parent + 150 child lines of ~25 chars each → well over 4000 chars rendered.
+    const parent = Array.from({ length: 150 }, (_, i) => `Parent activity step ${i + 1}`);
+    const child = Array.from({ length: 150 }, (_, i) => `Child activity step ${i + 1}`);
+    const out = renderActivityFeedWithNested(parent, child)!;
+    // Hard invariant: output must not exceed Telegram's 4096-char limit.
+    expect(out.length).toBeLessThanOrEqual(4096);
+    // Clip header must be present (oldest lines were dropped).
+    expect(out).toContain("earlier…");
+    // The newest child line must still be present.
+    expect(out).toContain(`Child activity step 150`);
+  });
+});
+
+// ─── Extreme-edge: single oversized line with HTML-special chars ─────────────
+// These tests cover the _fitToCharBudget and _fitNestedToCharBudget fallback
+// paths that are reachable in no-truncate mode when a Bash label contains
+// special chars (e.g. && is extremely common) and is longer than the budget.
+
+/** Cheap valid-HTML checker: balanced tags + no partial entity. */
+function isValidHtml(s: string): boolean {
+  // No partial entity: must not end with &[a-z]* lacking semicolon.
+  if (/&[a-z]+$/.test(s)) return false;
+  if (/&[a-z]+[^;]$/.test(s)) return false;
+  // Every &...; must be complete.
+  const entityRe = /&([^;]*)/g;
+  let m: RegExpExecArray | null;
+  while ((m = entityRe.exec(s)) !== null) {
+    if (!s.slice(m.index).startsWith("&") || s[m.index + m[0].length] !== ";") {
+      // Check if this entity is actually terminated
+      const entityStart = m.index;
+      const semiIdx = s.indexOf(";", entityStart + 1);
+      if (semiIdx === -1) return false; // no closing semicolon
+    }
+  }
+  // All opening tags have a corresponding close (simple check for <b>/<i>).
+  const bOpen = (s.match(/<b>/g) ?? []).length;
+  const bClose = (s.match(/<\/b>/g) ?? []).length;
+  const iOpen = (s.match(/<i>/g) ?? []).length;
+  const iClose = (s.match(/<\/i>/g) ?? []).length;
+  return bOpen === bClose && iOpen === iClose;
+}
+
+describe("extreme-edge: single oversized line with &, <, >, && (no-truncate ON)", () => {
+  afterEach(() => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+  });
+
+  it("renderActivityFeed: single ~4100-char line with special chars → ≤ budget and valid HTML", () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+    // Build a raw line >4000 chars with &, <, >, and a trailing &&.
+    // The && will escape to &amp;&amp; (5 chars each), exercising the expansion guard.
+    const base = "Run script with args: foo=bar && baz=<qux> & corge=1 ";
+    const bigLine = base.repeat(80) + "&&";
+    expect(bigLine.length).toBeGreaterThan(4000);
+
+    const out = renderActivityFeed([bigLine])!;
+    expect(out).not.toBeNull();
+    expect(out.length).toBeLessThanOrEqual(4000); // STATUS_CARD_CHAR_BUDGET
+    expect(isValidHtml(out)).toBe(true);
+    // Must be wrapped in <b>…</b> (live/non-final) — no dangling tag.
+    expect(out.startsWith("<b>→ ")).toBe(true);
+    expect(out.endsWith("</b>")).toBe(true);
+  });
+
+  it("renderActivityFeed final=true: single ~4100-char line → ≤ budget and valid HTML", () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+    const base = "Deploy build && upload && notify && cleanup: ";
+    const bigLine = base.repeat(90) + "done";
+    expect(bigLine.length).toBeGreaterThan(4000);
+
+    const out = renderActivityFeed([bigLine], true)!;
+    expect(out).not.toBeNull();
+    expect(out.length).toBeLessThanOrEqual(4000);
+    expect(isValidHtml(out)).toBe(true);
+    expect(out.startsWith("<i>✓ ")).toBe(true);
+    expect(out.endsWith("</i>")).toBe(true);
+  });
+
+  it("renderActivityFeedWithNested: single ~4100-char parent line → ≤ budget and valid HTML", () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+    const base = "Parent action with & < > special chars && bash: ";
+    const bigLine = base.repeat(85);
+    expect(bigLine.length).toBeGreaterThan(4000);
+
+    const out = renderActivityFeedWithNested([bigLine], [])!;
+    expect(out).not.toBeNull();
+    expect(out.length).toBeLessThanOrEqual(4000);
+    expect(isValidHtml(out)).toBe(true);
+  });
+
+  it("renderActivityFeedWithNested: single ~4100-char child line → ≤ budget and valid HTML", () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+    const base = "Child step: run build && test && deploy with <args> & flags=1 ";
+    const bigChild = base.repeat(65) + "&&";
+    expect(bigChild.length).toBeGreaterThan(4000);
+
+    const out = renderActivityFeedWithNested(["Delegating: big job"], [bigChild])!;
+    expect(out).not.toBeNull();
+    expect(out.length).toBeLessThanOrEqual(4000);
+    expect(isValidHtml(out)).toBe(true);
+    // Must contain the nested prefix.
+    expect(out).toContain("   ↳ ");
+    // Regression guard: an operator-precedence bug made wrapperOverhead a string
+    // (NESTED_PREFIX + n) → NaN budget → slice(0, NaN) === "" → the child content
+    // was silently discarded, leaving only "   ↳ <b>→ </b>". The empty-wrapper
+    // output still satisfies the toContain("   ↳ ") check above, so assert that
+    // real child content actually survives.
+    expect(out).toContain("Child step");
+    expect(out.length).toBeGreaterThan(100);
+  });
+
+  it("renderActivityFeedWithNested final=true: single ~4100-char child line → ≤ budget and valid HTML", () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+    const base = "Final child: compile && link && package & ship: ";
+    const bigChild = base.repeat(85);
+    expect(bigChild.length).toBeGreaterThan(4000);
+
+    const out = renderActivityFeedWithNested(["Delegating: big job"], [bigChild], true)!;
+    expect(out).not.toBeNull();
+    expect(out.length).toBeLessThanOrEqual(4000);
+    expect(isValidHtml(out)).toBe(true);
+    // final=true → nested line renders done (italic, no →).
+    expect(out).not.toContain("→");
   });
 });

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import {
   renderWorkerActivity,
   createWorkerActivityFeed,
   isWorkerActivityFeedEnabled,
+  NARRATIVE_MAX_LINES,
   type WorkerActivityView,
   type BotApiForWorkerFeed,
 } from '../worker-activity-feed.js'
@@ -153,7 +154,9 @@ describe('renderWorkerActivity', () => {
     expect(stepCount(out)).toBe(2)
   })
 
-  it('shows an overflow header when the feed exceeds the cap', () => {
+  it('shows an overflow header when the feed exceeds the cap (no-truncate OFF)', () => {
+    // This test exercises the capping behaviour that is active when the flag is OFF.
+    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = '0'
     const lines = Array.from({ length: 9 }, (_, i) => `step ${i + 1}`)
     const out = renderWorkerActivity(view({ narrativeLines: lines }))
     expect(out).toContain('<i>✓ +3 earlier…</i>')
@@ -162,6 +165,7 @@ describe('renderWorkerActivity', () => {
     expect(out).toContain('<b>→ step 9</b>')
     // 6 visible step lines (the overflow header is not itself a step).
     expect(out.match(/step \d/g) ?? []).toHaveLength(6)
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
   })
 
   it('strips Markdown markup from narrative + description + result', () => {
@@ -391,7 +395,9 @@ describe('createWorkerActivityFeed', () => {
     expect(last.text.match(/[✓→]/g) ?? []).toHaveLength(1)
   })
 
-  it('caps the narrative block to the last 6 lines', async () => {
+  it('caps the narrative block to the last 6 lines (no-truncate OFF)', async () => {
+    // This test exercises the capping behaviour that is active when the flag is OFF.
+    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = '0'
     const bot = makeFakeBot()
     let clock = 10_000
     const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
@@ -408,6 +414,7 @@ describe('createWorkerActivityFeed', () => {
     expect(last.text).not.toContain('line 3')
     expect(last.text).toContain('line 4')
     expect(last.text).toContain('line 9')
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
   })
 
   it('grows the narrative even while throttled (line surfaces on next edit)', async () => {
@@ -499,5 +506,178 @@ describe('createWorkerActivityFeed — log sink', () => {
     clock = 3000
     await feed.update('w1', 'chat', view({ elapsedMs: 3000 }))
     expect(logs.some((l) => l.startsWith('worker-feed: paint'))).toBe(false)
+  })
+})
+
+// ─── SWITCHROOM_STATUS_NO_TRUNCATE feature flag tests ────────────────────────
+
+describe('SWITCHROOM_STATUS_NO_TRUNCATE — renderWorkerActivity', () => {
+  afterEach(() => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+  })
+
+  it('no-truncate ON (default): a narrative with > NARRATIVE_MAX_LINES renders ALL lines', () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE // default = ON
+    const narrativeLines = Array.from({ length: NARRATIVE_MAX_LINES + 4 }, (_, i) => `step ${i + 1}`)
+    const out = renderWorkerActivity(view({ narrativeLines }))
+    for (let i = 1; i <= NARRATIVE_MAX_LINES + 4; i++) {
+      expect(out).toContain(`step ${i}`)
+    }
+    // No spurious overflow header when all steps fit in the budget.
+    expect(out).not.toContain('+4 earlier')
+    expect(out).toContain(`<b>→ step ${NARRATIVE_MAX_LINES + 4}</b>`)
+  })
+
+  it('no-truncate OFF (=0): existing NARRATIVE_MAX_LINES cap is preserved', () => {
+    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = '0'
+    const narrativeLines = Array.from({ length: 9 }, (_, i) => `step ${i + 1}`)
+    const out = renderWorkerActivity(view({ narrativeLines }))
+    expect(out).toContain('<i>✓ +3 earlier…</i>')
+    expect(out).not.toContain('step 1')
+    expect(out).toContain('step 4')
+    expect(out).toContain('<b>→ step 9</b>')
+    expect(out.match(/step \d/g) ?? []).toHaveLength(6)
+  })
+
+  it('no-truncate ON + pathologically huge narrative (500 lines): rendered output ≤ 4096 chars', () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+    const narrativeLines = Array.from({ length: 500 }, (_, i) => `step number ${i + 1}`)
+    const out = renderWorkerActivity(view({ narrativeLines }))
+    // Hard invariant: must never exceed Telegram's 4096 char limit.
+    expect(out.length).toBeLessThanOrEqual(4096)
+    // Oldest lines should have been clipped with a header.
+    expect(out).toContain('earlier…')
+    // The newest step must still be present.
+    expect(out).toContain('step number 500')
+  })
+})
+
+describe('SWITCHROOM_STATUS_NO_TRUNCATE — createWorkerActivityFeed narrative accumulation', () => {
+  afterEach(() => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+  })
+
+  it('no-truncate ON: narrative accumulates more than NARRATIVE_MAX_LINES distinct lines', async () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+
+    // Push more lines than NARRATIVE_MAX_LINES into the feed.
+    for (let i = 1; i <= NARRATIVE_MAX_LINES + 4; i++) {
+      clock += 1000
+      await feed.update('w1', 'chat', view({ toolCount: i, latestSummary: `line ${i}` }))
+    }
+
+    const last = bot.edits.at(-1)!
+    // All accumulated lines should be present (not spliced to NARRATIVE_MAX_LINES).
+    for (let i = 1; i <= NARRATIVE_MAX_LINES + 4; i++) {
+      expect(last.text).toContain(`line ${i}`)
+    }
+    // No overflow header for a small feed that fits in the budget.
+    expect(last.text).not.toContain('+4 earlier')
+    expect(last.text).toContain(`<b>→ line ${NARRATIVE_MAX_LINES + 4}</b>`)
+  })
+
+  it('no-truncate OFF (=0): narrative is still spliced to NARRATIVE_MAX_LINES (original behaviour)', async () => {
+    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = '0'
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+
+    for (let i = 1; i <= 9; i++) {
+      clock += 1000
+      await feed.update('w1', 'chat', view({ toolCount: i, latestSummary: `line ${i}` }))
+    }
+
+    const last = bot.edits.at(-1)!
+    expect(last.text.match(/[✓→]/g) ?? []).toHaveLength(6)
+    expect(last.text).not.toContain('line 1')
+    expect(last.text).not.toContain('line 3')
+    expect(last.text).toContain('line 4')
+    expect(last.text).toContain('line 9')
+  })
+
+  it('no-truncate ON: env-flip seam works (set/delete per test)', () => {
+    // Verify the seam: after setting '0', the flag reads as OFF.
+    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = '0'
+    const lines = Array.from({ length: NARRATIVE_MAX_LINES + 2 }, (_, i) => `s ${i + 1}`)
+    const offOut = renderWorkerActivity(view({ narrativeLines: lines }))
+    expect(offOut).toContain('+2 earlier')
+
+    // After deleting, the flag reads as ON (default).
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+    const onOut = renderWorkerActivity(view({ narrativeLines: lines }))
+    expect(onOut).not.toContain('+2 earlier')
+    for (let i = 1; i <= NARRATIVE_MAX_LINES + 2; i++) {
+      expect(onOut).toContain(`s ${i}`)
+    }
+  })
+})
+
+// ─── Extreme-edge: single oversized narrative line (no-truncate ON) ──────────
+// Reproduces the bug where accumulateNarrative's char-budget splice would push
+// the oversized line then immediately splice it out, making the narrative empty
+// and the step vanish from the rendered output.
+
+/** Cheap valid-HTML checker: balanced <b>/<i> tags and no partial entity. */
+function isValidWorkerHtml(s: string): boolean {
+  const bOpen = (s.match(/<b>/g) ?? []).length
+  const bClose = (s.match(/<\/b>/g) ?? []).length
+  const iOpen = (s.match(/<i>/g) ?? []).length
+  const iClose = (s.match(/<\/i>/g) ?? []).length
+  if (bOpen !== bClose || iOpen !== iClose) return false
+  // No partial entity (e.g. &amp without semicolon at end or mid-string).
+  if (/&[a-z]+$/.test(s)) return false
+  return true
+}
+
+describe('extreme-edge: single oversized narrative line (no-truncate ON)', () => {
+  afterEach(() => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+  })
+
+  it('no-truncate ON: one ~4100-char step is shown (truncated) not discarded, output ≤ budget and valid HTML', async () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+
+    // Build a latestSummary > STATUS_CARD_CHAR_BUDGET chars with && and special chars.
+    const base = 'run build && deploy && notify with <args> & flags=1 '
+    const hugeStep = base.repeat(80) + '&&'
+    expect(hugeStep.length).toBeGreaterThan(4000)
+
+    await feed.update('w1', 'chat', view({ toolCount: 1, latestSummary: hugeStep }))
+    expect(bot.sent).toHaveLength(1)
+    const out = bot.sent[0].text
+
+    // The step must NOT have vanished — some portion must appear.
+    // Since the step is huge it will be truncated, but the worker card itself
+    // must contain a step bullet (→ or ✓).
+    const hasBullet = out.includes('→') || out.includes('✓')
+    expect(hasBullet).toBe(true)
+
+    // Wire safety: output must be within the Telegram char budget.
+    expect(out.length).toBeLessThanOrEqual(4096)
+
+    // Valid HTML: balanced tags and no partial entity.
+    expect(isValidWorkerHtml(out)).toBe(true)
+  })
+
+  it('no-truncate ON: one ~4100-char step via renderWorkerActivity directly → ≤ budget and valid HTML', () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+    const base = 'compile && link && package && ship: action=deploy env=<prod> flag=1 '
+    const hugeStep = base.repeat(65)
+    expect(hugeStep.length).toBeGreaterThan(4000)
+
+    const out = renderWorkerActivity(view({ narrativeLines: [hugeStep] }))
+
+    // Step must be present in some form (truncated is fine, absent is not).
+    const hasBullet = out.includes('→') || out.includes('✓')
+    expect(hasBullet).toBe(true)
+
+    expect(out.length).toBeLessThanOrEqual(4096)
+    expect(isValidWorkerHtml(out)).toBe(true)
   })
 })

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -164,6 +164,12 @@ export function describeToolUse(
 // cleared on reply. Chronological (oldest first, newest last), consecutive
 // exact-duplicates collapsed, capped to the most recent MIRROR_MAX_LINES
 // with a "+N earlier" header so a heavy turn stays readable.
+//
+// When SWITCHROOM_STATUS_NO_TRUNCATE is not '0' (the default), all cosmetic
+// caps are lifted and the full feed is shown, bounded only by the 4096-char
+// Telegram limit via STATUS_CARD_CHAR_BUDGET.
+
+import { statusNoTruncate, STATUS_CARD_CHAR_BUDGET } from './status-no-truncate.js'
 
 export const MIRROR_MAX_LINES = 6;
 
@@ -211,8 +217,18 @@ export function renderActivityFeed(
   stepCount?: number,
 ): string | null {
   if (lines.length === 0) return null;
-  const shown = lines.slice(-MIRROR_MAX_LINES);
-  const hidden = lines.length - shown.length;
+  const noTruncate = statusNoTruncate();
+  // When no-truncate is ON, show all lines; when OFF, cap to MIRROR_MAX_LINES.
+  // In both modes we may need to trim oldest lines to fit the Telegram budget.
+  let shown: string[];
+  let hidden: number;
+  if (noTruncate) {
+    shown = lines;
+    hidden = 0;
+  } else {
+    shown = lines.slice(-MIRROR_MAX_LINES);
+    hidden = lines.length - shown.length;
+  }
   const out: string[] = [];
   if (hidden > 0) out.push(`<i>✓ +${hidden} earlier…</i>`);
   const lastIdx = shown.length - 1;
@@ -234,7 +250,58 @@ export function renderActivityFeed(
   if (final && stepCount != null && stepCount > 0) {
     out.push(`<i>✓ ${stepCount} steps</i>`);
   }
-  return out.join("\n");
+  const result = out.join("\n");
+  // No-truncate mode: enforce the Telegram char budget by trimming oldest
+  // lines first until the output fits, then prepend a "+N earlier…" header.
+  if (noTruncate && result.length > STATUS_CARD_CHAR_BUDGET) {
+    return _fitToCharBudget(lines, final, liveSuffix, stepCount);
+  }
+  return result;
+}
+
+/**
+ * Internal helper: called only in no-truncate mode when the full render
+ * exceeds STATUS_CARD_CHAR_BUDGET. Drops oldest lines one at a time until
+ * the rendered output fits, prepending a "+N earlier…" header to surface
+ * the clip. The caller is responsible for not re-calling this recursively
+ * (the budget is wide enough that a "+N" header itself never causes overflow).
+ */
+function _fitToCharBudget(
+  lines: string[],
+  final: boolean,
+  liveSuffix: string,
+  stepCount?: number,
+): string | null {
+  for (let drop = 1; drop < lines.length; drop++) {
+    const shown = lines.slice(drop);
+    const out: string[] = [`<i>✓ +${drop} earlier…</i>`];
+    const lastIdx = shown.length - 1;
+    shown.forEach((l, i) => {
+      const esc = escapeFeedHtml(l);
+      out.push(i === lastIdx && !final ? `<b>→ ${esc}${liveSuffix}</b>` : `<i>✓ ${esc}</i>`);
+    });
+    if (final && stepCount != null && stepCount > 0) {
+      out.push(`<i>✓ ${stepCount} steps</i>`);
+    }
+    const candidate = out.join("\n");
+    if (candidate.length <= STATUS_CARD_CHAR_BUDGET) return candidate;
+  }
+  // Rare but reachable with long Bash labels containing special chars (e.g. &&).
+  // Never slice already-escaped HTML — that breaks entities (&amp; → &amp) and
+  // leaves dangling tags. Instead truncate the RAW content first, then escape
+  // and wrap, re-checking post-escape because escaping can expand (&→&amp;).
+  const wrapperOverhead = final
+    ? "<i>✓ </i>".length
+    : ("<b>→ </b>".length + liveSuffix.length);
+  const maxRaw = Math.max(0, STATUS_CARD_CHAR_BUDGET - wrapperOverhead);
+  let raw = lines[lines.length - 1].slice(0, maxRaw);
+  let newest = escapeFeedHtml(raw);
+  while (raw.length > 0 && wrapperOverhead + newest.length > STATUS_CARD_CHAR_BUDGET) {
+    const excess = wrapperOverhead + newest.length - STATUS_CARD_CHAR_BUDGET;
+    raw = raw.slice(0, Math.max(0, raw.length - excess - 1));
+    newest = escapeFeedHtml(raw);
+  }
+  return final ? `<i>✓ ${newest}</i>` : `<b>→ ${newest}${liveSuffix}</b>`;
 }
 
 // ─── Foreground sub-agent nesting (Model A) ─────────────────────────────────
@@ -276,21 +343,26 @@ export function renderActivityFeedWithNested(
   const children = childLines.map((s) => s.trim()).filter((s) => s.length > 0);
   if (children.length === 0) return renderActivityFeed(lines, final, liveSuffix, stepCount);
 
+  const noTruncate = statusNoTruncate();
   const out: string[] = [];
-  const shownParent = lines.slice(-MIRROR_MAX_LINES);
+
+  // Parent lines: when no-truncate is ON show all; when OFF cap to MIRROR_MAX_LINES.
+  const shownParent = noTruncate ? lines : lines.slice(-MIRROR_MAX_LINES);
   const hiddenParent = lines.length - shownParent.length;
   if (hiddenParent > 0) out.push(`<i>✓ +${hiddenParent} earlier…</i>`);
   for (const l of shownParent) out.push(`<i>✓ ${escapeFeedHtml(l)}</i>`);
 
-  const shownChild = children.slice(-NESTED_MAX_LINES);
+  // Child lines: when no-truncate is ON show all; when OFF cap to NESTED_MAX_LINES.
+  const shownChild = noTruncate ? children : children.slice(-NESTED_MAX_LINES);
   const hiddenChild = children.length - shownChild.length;
   if (hiddenChild > 0) out.push(`${NESTED_PREFIX}<i>+${hiddenChild} earlier…</i>`);
   const lastChildIdx = shownChild.length - 1;
   // `final`: the nested newest step also renders done (✓) so the left-behind
   // feed reads as completed, not stuck on a "→ in-progress" child step.
   // `liveSuffix` (heartbeat): appended to the nested newest in-progress step.
+  // NESTED_LINE_MAX per-line cap: only applied when no-truncate is OFF.
   shownChild.forEach((l, i) => {
-    const t = l.length > NESTED_LINE_MAX ? l.slice(0, NESTED_LINE_MAX - 1) + "…" : l;
+    const t = (!noTruncate && l.length > NESTED_LINE_MAX) ? l.slice(0, NESTED_LINE_MAX - 1) + "…" : l;
     const esc = escapeFeedHtml(t);
     out.push(
       i === lastChildIdx && !final
@@ -302,7 +374,88 @@ export function renderActivityFeedWithNested(
   if (final && stepCount != null && stepCount > 0) {
     out.push(`<i>✓ ${stepCount} steps</i>`);
   }
-  return out.length > 0 ? out.join("\n") : null;
+  if (out.length === 0) return null;
+  const result = out.join("\n");
+  // No-truncate mode: enforce the Telegram char budget by trimming oldest
+  // parent lines first, then oldest child lines, until the output fits.
+  if (noTruncate && result.length > STATUS_CARD_CHAR_BUDGET) {
+    return _fitNestedToCharBudget(lines, children, final, liveSuffix, stepCount);
+  }
+  return result;
+}
+
+/**
+ * Internal helper: called only in no-truncate mode when the full nested render
+ * exceeds STATUS_CARD_CHAR_BUDGET. Trims oldest parent lines first, then
+ * oldest child lines, until the output fits, surfacing a "+N earlier…" header
+ * for each dropped group.
+ */
+function _fitNestedToCharBudget(
+  lines: string[],
+  children: string[],
+  final: boolean,
+  liveSuffix: string,
+  stepCount?: number,
+): string | null {
+  // Try dropping parent lines first (oldest first), keeping all children.
+  for (let pDrop = 1; pDrop <= lines.length; pDrop++) {
+    const shownP = lines.slice(pDrop);
+    const out: string[] = [];
+    if (pDrop > 0) out.push(`<i>✓ +${pDrop} earlier…</i>`);
+    for (const l of shownP) out.push(`<i>✓ ${escapeFeedHtml(l)}</i>`);
+    if (children.length > 0) out.push(`${NESTED_PREFIX}<i>+0 earlier…</i>`); // placeholder (unconditional pop below — children is guaranteed non-empty here; this pair is a size-estimation probe kept structurally symmetric with the cDrop loop)
+    // Actually render children at full length.
+    out.pop(); // remove placeholder (children guaranteed non-empty at this call site)
+    const lastChildIdx = children.length - 1;
+    children.forEach((l, i) => {
+      const esc = escapeFeedHtml(l);
+      out.push(
+        i === lastChildIdx && !final
+          ? `${NESTED_PREFIX}<b>→ ${esc}${liveSuffix}</b>`
+          : `${NESTED_PREFIX}<i>${esc}</i>`,
+      );
+    });
+    if (final && stepCount != null && stepCount > 0) out.push(`<i>✓ ${stepCount} steps</i>`);
+    const candidate = out.join("\n");
+    if (candidate.length <= STATUS_CARD_CHAR_BUDGET) return candidate;
+  }
+  // Parent fully dropped; now also drop child lines oldest first.
+  for (let cDrop = 1; cDrop < children.length; cDrop++) {
+    const shownC = children.slice(cDrop);
+    const out: string[] = [
+      `<i>✓ +${lines.length} earlier…</i>`,
+      `${NESTED_PREFIX}<i>+${cDrop} earlier…</i>`,
+    ];
+    const lastChildIdx = shownC.length - 1;
+    shownC.forEach((l, i) => {
+      const esc = escapeFeedHtml(l);
+      out.push(
+        i === lastChildIdx && !final
+          ? `${NESTED_PREFIX}<b>→ ${esc}${liveSuffix}</b>`
+          : `${NESTED_PREFIX}<i>${esc}</i>`,
+      );
+    });
+    if (final && stepCount != null && stepCount > 0) out.push(`<i>✓ ${stepCount} steps</i>`);
+    const candidate = out.join("\n");
+    if (candidate.length <= STATUS_CARD_CHAR_BUDGET) return candidate;
+  }
+  // Rare but reachable with long Bash labels containing special chars (e.g. &&).
+  // Never slice already-escaped HTML — that breaks entities and leaves dangling tags.
+  // Truncate RAW content first, then escape and wrap, re-checking post-escape.
+  const wrapperOverhead = final
+    ? (NESTED_PREFIX + "<i></i>").length
+    : (NESTED_PREFIX + "<b>→ </b>").length + liveSuffix.length;
+  const maxRaw = Math.max(0, STATUS_CARD_CHAR_BUDGET - wrapperOverhead);
+  let raw = children[children.length - 1].slice(0, maxRaw);
+  let newest = escapeFeedHtml(raw);
+  while (raw.length > 0 && wrapperOverhead + newest.length > STATUS_CARD_CHAR_BUDGET) {
+    const excess = wrapperOverhead + newest.length - STATUS_CARD_CHAR_BUDGET;
+    raw = raw.slice(0, Math.max(0, raw.length - excess - 1));
+    newest = escapeFeedHtml(raw);
+  }
+  return final
+    ? `${NESTED_PREFIX}<i>${newest}</i>`
+    : `${NESTED_PREFIX}<b>→ ${newest}${liveSuffix}</b>`;
 }
 
 /**

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -39,6 +39,7 @@ import {
   stripMarkdown,
   truncate,
 } from './card-format.js'
+import { statusNoTruncate, STATUS_CARD_CHAR_BUDGET } from './status-no-truncate.js'
 
 /** Worker-activity feed is ON by default; an operator opts out with
  *  SWITCHROOM_WORKER_ACTIVITY_FEED=0. */
@@ -97,7 +98,7 @@ const RULE = '─────'
  * caps message length and a wall of stale lines buries the live one. Six
  * keeps recent context without dominating the chat.
  */
-const NARRATIVE_MAX_LINES = 6
+export const NARRATIVE_MAX_LINES = 6
 
 /**
  * Append the accumulated step feed to `lines`, mirroring the main agent's
@@ -105,10 +106,13 @@ const NARRATIVE_MAX_LINES = 6
  * the newest renders in-progress (`→`, bold) unless `allDone`, and an overflow
  * header (`✓ +N earlier…`) appears when the feed exceeds NARRATIVE_MAX_LINES.
  * `steps` are already cleaned + escaped HTML.
+ *
+ * When `noTruncate` is true (SWITCHROOM_STATUS_NO_TRUNCATE != '0'), all steps
+ * are shown — the caller is responsible for trimming to the char budget after.
  */
-function appendStepFeed(lines: string[], steps: string[], allDone: boolean): void {
+function appendStepFeed(lines: string[], steps: string[], allDone: boolean, noTruncate = false): void {
   if (steps.length === 0) return
-  const shown = steps.slice(-NARRATIVE_MAX_LINES)
+  const shown = noTruncate ? steps : steps.slice(-NARRATIVE_MAX_LINES)
   const hidden = steps.length - shown.length
   if (hidden > 0) lines.push(`<i>✓ +${hidden} earlier…</i>`)
   const lastIdx = shown.length - 1
@@ -140,6 +144,7 @@ function appendStepFeed(lines: string[], steps: string[], allDone: boolean): voi
  *   ✅ <i>{cleaned result paragraph}</i>
  */
 export function renderWorkerActivity(v: WorkerActivityView): string {
+  const noTruncate = statusNoTruncate()
   const desc = truncate(stripMarkdown(v.description).trim() || 'background task', DESC_MAX)
   const elapsed = formatDuration(v.elapsedMs)
   const toolWord = v.toolCount === 1 ? 'tool' : 'tools'
@@ -157,7 +162,7 @@ export function renderWorkerActivity(v: WorkerActivityView): string {
   if (finished) {
     const verb = v.state === 'done' ? 'completed' : 'failed'
     const lines = [header, `<i>finished · ${verb} · ${v.toolCount} ${toolWord} · ${elapsed}</i>`]
-    appendStepFeed(lines, steps, true)
+    appendStepFeed(lines, steps, true, noTruncate)
     // On terminal, latestSummary carries the worker's final result text
     // (gateway onFinish), distinct from the running narrative steps.
     const result = cleanWorkerResultParagraph(v.latestSummary)
@@ -166,12 +171,13 @@ export function renderWorkerActivity(v: WorkerActivityView): string {
       lines.push(RULE)
       lines.push(`${emoji} <i>${escapeHtml(truncate(result, RESULT_MAX))}</i>`)
     }
-    return lines.join('\n')
+    const body = lines.join('\n')
+    return noTruncate ? _fitWorkerBodyToCharBudget(body, lines) : body
   }
 
   const lines = [header, `<i>running · ${elapsed} · ${v.toolCount} ${toolWord}</i>`]
   if (steps.length > 0) {
-    appendStepFeed(lines, steps, false)
+    appendStepFeed(lines, steps, false, noTruncate)
   } else {
     // Back-compat for direct render callers that pass only latestSummary;
     // the manager always supplies narrativeLines.
@@ -182,7 +188,30 @@ export function renderWorkerActivity(v: WorkerActivityView): string {
       lines.push('<i>starting…</i>')
     }
   }
-  return lines.join('\n')
+  const body = lines.join('\n')
+  return noTruncate ? _fitWorkerBodyToCharBudget(body, lines) : body
+}
+
+/**
+ * Internal helper: when no-truncate mode produces a body that exceeds the
+ * Telegram char budget, drop the oldest step-feed lines (the ones after the
+ * two fixed header lines) until it fits, prepending a "+N earlier…" header.
+ * The two fixed header lines (🛠 Worker header + status line) are always kept.
+ */
+function _fitWorkerBodyToCharBudget(body: string, lines: string[]): string {
+  if (body.length <= STATUS_CARD_CHAR_BUDGET) return body
+  // lines[0] = header, lines[1] = status line, lines[2..] = step feed + optional rule/result
+  const fixed = lines.slice(0, 2)
+  const feed = lines.slice(2)
+  for (let drop = 1; drop < feed.length; drop++) {
+    const kept = feed.slice(drop)
+    const candidate = [...fixed, `<i>✓ +${drop} earlier…</i>`, ...kept].join('\n')
+    if (candidate.length <= STATUS_CARD_CHAR_BUDGET) return candidate
+  }
+  // Extreme: only fixed headers fit. They are pre-escaped HTML but bounded
+  // by DESC_MAX (~80 raw chars), so the joined string is well under the
+  // budget in practice. Return as-is — never slice escaped HTML.
+  return fixed.join('\n')
 }
 
 export interface WorkerActivityFeedOpts {
@@ -290,8 +319,21 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     // same narrative across ticks while a tool runs; we only grow on change.
     if (h.narrative[h.narrative.length - 1] === line) return
     h.narrative.push(line)
-    if (h.narrative.length > NARRATIVE_MAX_LINES) {
-      h.narrative.splice(0, h.narrative.length - NARRATIVE_MAX_LINES)
+    if (statusNoTruncate()) {
+      // No-truncate mode: bound memory with a generous COUNT cap so a single
+      // oversized line can never empty the array (a char-budget splice would
+      // push then immediately splice the only line, discarding it silently).
+      // Render-time (_fitWorkerBodyToCharBudget) enforces the wire limit.
+      // 200 lines × ~100 chars ≈ 20 KB in memory — a safe ceiling.
+      const NARRATIVE_MEM_CAP = 200
+      if (h.narrative.length > NARRATIVE_MEM_CAP) {
+        h.narrative.splice(0, h.narrative.length - NARRATIVE_MEM_CAP)
+      }
+    } else {
+      // Truncate mode: hard cap to NARRATIVE_MAX_LINES (original behaviour).
+      if (h.narrative.length > NARRATIVE_MAX_LINES) {
+        h.narrative.splice(0, h.narrative.length - NARRATIVE_MAX_LINES)
+      }
     }
   }
 


### PR DESCRIPTION
Bundles the stranded full-status-card flag with the status-surface test-coverage gaps found during v0.15.48 fuzzy UAT.

## 1. Ship `SWITCHROOM_STATUS_NO_TRUNCATE` (cherry-pick of 2e4fb93c)

The activity-feed / worker status cards truncate in production — 6/4 lines and 90 chars/line hard caps — because the flag that lifts them (`SWITCHROOM_STATUS_NO_TRUNCATE`, default ON, authored in 2e4fb93c) only ever landed on `feat/bg-detached-visibility` and was never merged. This cherry-picks it onto the shipping line:

- `status-no-truncate.ts`: `statusNoTruncate()` (env read at call time, default true) + `STATUS_CARD_CHAR_BUDGET=4000` (headroom under Telegram's 4096 wire limit).
- `tool-activity-summary.ts`: gates `MIRROR_MAX_LINES` / `NESTED_MAX_LINES` / `NESTED_LINE_MAX` behind the flag; `_fitToCharBudget` / `_fitNestedToCharBudget` enforce the budget by dropping oldest lines with a `+N earlier` header.
- `worker-activity-feed.ts`: gates `NARRATIVE_MAX_LINES`; 200-line narrative memory cap; render-time budget fit.

Set `SWITCHROOM_STATUS_NO_TRUNCATE=0` to restore the capped UX.

## 2. Close status-surface UAT coverage gaps (H-1/H-2/M-1/M-2)

Found during the v0.15.48 fuzzy-UAT pass (the full Telegram harness can't run headless; this is the unit/structural layer):
- **H-1** `feed-heartbeat-liveness-open.test.ts` — `feedHeartbeatTick` liveness-open threshold: kill-switch `SWITCHROOM_FEED_LIVENESS_OPEN !== '0'`, `FEED_LIVENESS_OPEN_MS` 12s default, `age < threshold` early-return guard.
- **H-2** `status-surface-log.test.ts` — reply-only turn (`toolCallCount=5, labeledToolCount=0, drainFailures=3`) returns null: the `labeledToolCount===0` exemption fires even with drain failures (no false-positive DEGRADED).
- **M-1** `permission-card-origin-kill-switch.test.ts` — `SWITCHROOM_PERMISSION_CARD_ORIGIN_RECOVERY !== '0'` gate.
- **M-2** `activity-ever-opened-sticky.test.ts` — `activityEverOpened` set once, never reset.

## Tests
Status-surface + truncation suite: 121 pass / 0 fail; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)