### PR TITLE
fix(compose): bind-mount zoneinfo onto /etc/localtime for per-agent timezone

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -27,6 +27,7 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, lstatSync, readlinkSync } from "node:fs";
 import { join, isAbsolute, dirname, resolve } from "node:path";
 import type { SwitchroomConfig, AgentConfig, AgentBindMount } from "../config/schema.js";
+import { isValidTimezone } from "../config/schema.js";
 import { scheduleNeedsCronSession } from "../scheduler/cron-routing.js";
 import { applyDefaultTier } from "../scheduler/tier-selector.js";
 import { resolveAgentConfig } from "../config/merge.js";
@@ -2033,6 +2034,36 @@ function emitAgentService(
     lines.push(
       `      - ${homePrefix}/.switchroom/fleet:${homePrefix}/.switchroom/fleet:ro`,
     );
+  }
+  // /etc/localtime passthrough — keep the system clock zone in sync with
+  // the resolved per-agent timezone (#1198 follow-up). `TZ` /
+  // `SWITCHROOM_TIMEZONE` (emitted in `emitAgentServiceEnv`) already
+  // cover everything that reads the `TZ` env var — glibc `date(1)`,
+  // Node `Intl`, Python, cron. But statically-linked Go binaries and
+  // some Java runtimes ignore `TZ` and read `/etc/localtime` directly,
+  // so without this they see the base image's UTC regardless of the
+  // operator's declared zone. We CANNOT fix this from inside start.sh:
+  // the agent process runs as the unprivileged uid (Dockerfile.agent
+  // `USER 10001`, compose `user: <uid>:<uid>`) on a `read_only: true`
+  // rootfs with `cap_drop: ALL` + `no-new-privileges`, so `ln -sf
+  // /etc/localtime` would hard-fail. A docker-daemon bind mount is
+  // applied by the daemon (root) BEFORE the entrypoint and is exempt
+  // from the read-only rootfs — the right layer for this. Source is the
+  // host's zoneinfo file for the resolved zone. `a.timezone` is IANA-
+  // validated on the config-sourced branches, but `resolveTimezone`'s
+  // server-detection fallback (`/etc/timezone` contents / `/etc/localtime`
+  // symlink tail) is NOT run through `isValidTimezone` — so re-validate
+  // here before interpolating into a path, keeping a stray `..` out of
+  // the bind source regardless of how the zone was resolved. Only
+  // `/etc/localtime` is synced (not `/etc/timezone`); the Go/JVM readers
+  // this targets read `/etc/localtime`, and the rest honor `TZ`.
+  // existsSync-guarded because docker compose `up` hard-fails on a missing
+  // bind source and an exotic host may lack tzdata — when absent we skip
+  // and fall back to the env-var path (the cosmetic 95% case). Same host
+  // path inside the container, so a plain absolute bind with no
+  // `homePrefix` rewrite.
+  if (isValidTimezone(a.timezone) && existsSync(`/usr/share/zoneinfo/${a.timezone}`)) {
+    lines.push(`      - /usr/share/zoneinfo/${a.timezone}:/etc/localtime:ro`);
   }
   // PER-AGENT credentials mount (sec WS6-F2, #1390). Previously the
   // ENTIRE `~/.switchroom/credentials/` dir was bind-mounted `:ro`

--- a/tests/docker/compose-generator-localtime.test.ts
+++ b/tests/docker/compose-generator-localtime.test.ts
@@ -1,0 +1,104 @@
+/**
+ * compose-generator-localtime.test.ts
+ *
+ * Verifies that the compose generator bind-mounts the host zoneinfo
+ * file onto /etc/localtime for the agent service, derived from the
+ * resolved per-agent timezone (#1198 follow-up).
+ *
+ * Rationale: `TZ` / `SWITCHROOM_TIMEZONE` env vars cover every tool that
+ * reads `TZ`, but statically-linked Go binaries and some Java runtimes
+ * read `/etc/localtime` directly and ignore `TZ`. The agent process runs
+ * unprivileged on a read-only rootfs, so it cannot fix the symlink from
+ * inside start.sh — a docker-daemon bind mount is the correct layer.
+ *
+ * Pure compose-string assertions — no docker invocation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateCompose } from "../../src/agents/compose.js";
+import type { SwitchroomConfig } from "../../src/config/schema.js";
+
+function makeConfig(timezone?: string): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+      timezone,
+    },
+    telegram: { bot_token: "x" },
+    defaults: undefined,
+    profiles: undefined,
+    agents: {
+      coach: {
+        extends: undefined,
+        settings_raw: undefined,
+        admin: undefined,
+        env: undefined,
+        schedule: [],
+        tools: { allow: [], deny: [] },
+        hooks: undefined,
+        channels: undefined,
+      } as unknown as SwitchroomConfig["agents"][string],
+    },
+    drive: undefined as unknown as SwitchroomConfig["drive"],
+  } as unknown as SwitchroomConfig;
+}
+
+let tmpHome: string;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "compose-localtime-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("compose-generator — /etc/localtime zoneinfo bind mount", () => {
+  it("mounts the resolved zoneinfo file onto /etc/localtime read-only", () => {
+    // UTC is present in tzdata on every Debian/Ubuntu host (the CI base
+    // and the production agent image both ship tzdata). Guard anyway so
+    // the suite is hermetic on an exotic host that lacks the file.
+    if (!existsSync("/usr/share/zoneinfo/UTC")) return;
+    const out = generateCompose({ config: makeConfig("UTC"), homeDir: tmpHome });
+    expect(out).toContain("- /usr/share/zoneinfo/UTC:/etc/localtime:ro");
+  });
+
+  it("uses the operator-declared zone, not a hardcoded one", () => {
+    if (!existsSync("/usr/share/zoneinfo/Australia/Melbourne")) return;
+    const out = generateCompose({
+      config: makeConfig("Australia/Melbourne"),
+      homeDir: tmpHome,
+    });
+    expect(out).toContain(
+      "- /usr/share/zoneinfo/Australia/Melbourne:/etc/localtime:ro",
+    );
+  });
+
+  it("omits the mount when the host lacks the zoneinfo file", () => {
+    // A bogus zone the host can't have — docker compose `up` would
+    // hard-fail on a missing bind source, so the generator must skip it.
+    const out = generateCompose({
+      config: makeConfig("Mars/Olympus_Mons"),
+      homeDir: tmpHome,
+    });
+    expect(out).not.toContain(":/etc/localtime:ro");
+  });
+
+  it("rejects a non-IANA / traversal zone before it reaches the bind source", () => {
+    // `resolveTimezone` returns `switchroom.timezone` verbatim — the
+    // server-detection fallback is NOT re-validated — so the generator
+    // must guard with `isValidTimezone` before interpolating into the
+    // mount path. A `..` zone must never appear in the bind source.
+    const out = generateCompose({
+      config: makeConfig("../../etc/hostname"),
+      homeDir: tmpHome,
+    });
+    expect(out).not.toContain(":/etc/localtime:ro");
+    expect(out).not.toContain("/usr/share/zoneinfo/../");
+  });
+});


### PR DESCRIPTION
## Problem

The agent container's `/etc/localtime` stays at the base image's **UTC** regardless of the operator's declared timezone, so any tool that reads `/etc/localtime` directly (ignoring `TZ`) reports the wrong zone.

`TZ` / `SWITCHROOM_TIMEZONE` (#1198) already cover everything that honors the `TZ` env var — glibc `date(1)`, Node `Intl`, Python, cron. The gap is **statically-linked Go binaries and some Java runtimes**, which read `/etc/localtime` directly. Cosmetic for ~95% of cases; real for any Go-based tooling in the container.

## Why the in-entrypoint fix doesn't work

An `ln -sf /usr/share/zoneinfo/$TZ /etc/localtime` in `start.sh` was the obvious suggestion, on the assumption start.sh runs as root. It doesn't — and that premise is the bug:

- `Dockerfile.agent` sets `USER 10001`; compose sets `user: "<uid>:<uid>"` → the entrypoint runs **unprivileged**.
- The agent service is `read_only: true` with `cap_drop: ALL` and `no-new-privileges`.

So `/etc` is read-only to the agent and `ln -sf` hard-fails — exactly the reported symptom.

## Fix

A docker-daemon bind mount in `compose.ts`, applied by the daemon (root) **before** the entrypoint and exempt from the read-only rootfs:

```yaml
- /usr/share/zoneinfo/<a.timezone>:/etc/localtime:ro
```

- Source derived from the already-resolved per-agent `a.timezone` (validated IANA, resolver fallback `"UTC"`) — automatic fleet-wide, no per-agent hardcoding.
- `existsSync`-guarded because `docker compose up` hard-fails on a missing bind source; when the host lacks the zone file we skip the mount and fall back to the env-var path. (Absolute system path, so a plain `existsSync` rather than the home-relative `conditionalMountPresent` helper used by the skills/fleet mounts.)
- Same absolute path inside the container, so a plain bind with no `homePrefix` rewrite.

## Tests

New `tests/docker/compose-generator-localtime.test.ts` (3 cases): mount emitted `:ro` onto `/etc/localtime`; uses the operator-declared zone (not hardcoded); omitted when the host lacks the zoneinfo file.

Rebased on latest `main` (d44b71b9). `tsc --noEmit` clean; `tests/docker/` + timezone suites green (336 passed, 38 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)