### PR TITLE
feat(hostd): safe staggered rollout as agent-reachable MCP verb (#2487 PR1)

### DIFF
--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -16,7 +16,11 @@ import {
   planRollout,
   formatRolloutPlan,
   executeRollout,
+  encodeRolloutResultLine,
+  parseRolloutResultLine,
+  ROLLOUT_RESULT_SENTINEL,
   type RolloutDeps,
+  type RolloutResult,
   type RolloutStep,
 } from "./rollout.js";
 
@@ -217,5 +221,141 @@ describe("executeRollout", () => {
     // target carries the v-prefix; in-container version does not.
     const r = executeRollout(steps, "v0.15.18", deps);
     expect(r.ok).toBe(true);
+  });
+});
+
+// ── #2487 hostd/MCP-path ordering + structured result + deferral ──────────
+
+describe("planRollout — hostd context (#2487)", () => {
+  const TARGET = "v0.15.18";
+
+  it("persists the pin AFTER the canary, not before", () => {
+    const steps = planRollout(["clerk", "test-harness"], {
+      pinToPersist: TARGET,
+      hostdContext: true,
+    });
+    const kinds = steps.map((s) =>
+      s.kind === "restart-agent" ? `r:${s.agent}` : s.kind,
+    );
+    // apply → canary (test-harness) → persist-pin → rest → sweep.
+    expect(kinds).toEqual([
+      "apply",
+      "r:test-harness",
+      "persist-pin",
+      "r:clerk",
+      "sweep",
+    ]);
+    // persist-pin comes strictly AFTER the canary restart.
+    const persistIdx = kinds.indexOf("persist-pin");
+    const canaryIdx = kinds.indexOf("r:test-harness");
+    expect(persistIdx).toBeGreaterThan(canaryIdx);
+  });
+
+  it("DROPS the hostd/web refresh steps (deferred — would SIGKILL itself)", () => {
+    const kinds = planRollout(["clerk", "marko"], {
+      pinToPersist: TARGET,
+      hostdContext: true,
+    }).map((s) => s.kind);
+    expect(kinds).not.toContain("refresh-web");
+    expect(kinds).not.toContain("refresh-hostd");
+  });
+
+  it("host-shell path is unchanged — persist FIRST, web/hostd present", () => {
+    const kinds = planRollout(["clerk", "test-harness"], {
+      pinToPersist: TARGET,
+    }).map((s) => s.kind);
+    expect(kinds[0]).toBe("persist-pin"); // FIRST, deliberate
+    expect(kinds).toContain("refresh-web");
+    expect(kinds).toContain("refresh-hostd");
+  });
+});
+
+describe("executeRollout — hostd context (#2487)", () => {
+  const TARGET = "v0.15.18";
+
+  it("apply uses one-shot --pin (pin not yet persisted before canary)", () => {
+    const steps = planRollout(["clerk", "test-harness"], {
+      pinToPersist: TARGET,
+      hostdContext: true,
+    });
+    const { deps, runs } = harness({
+      versions: { clerk: "0.15.18", "test-harness": "0.15.18" },
+    });
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+    expect(r.ok).toBe(true);
+    expect(runs[0]).toEqual(["apply", "--pin", TARGET]);
+  });
+
+  it("does NOT persist the pin when the canary FAILS its version assert", () => {
+    const steps = planRollout(["test-harness", "clerk"], {
+      pinToPersist: TARGET,
+      hostdContext: true,
+    });
+    const { deps, persisted, runs } = harness({
+      // canary (test-harness) comes back stale → roll STOPS before persist.
+      versions: { "test-harness": "0.15.17", clerk: "0.15.18" },
+    });
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+    expect(r.ok).toBe(false);
+    expect(r.failedAgent).toBe("test-harness");
+    expect(r.rolled).toEqual([]);
+    // The brick-scenario-#2 guard: a failed canary leaves NO persisted pin.
+    expect(persisted).toEqual([]);
+    // clerk was never touched.
+    expect(runs).not.toContainEqual(["agent", "restart", "clerk", "--wait", "--force"]);
+  });
+
+  it("persists the pin once the canary is GREEN, then rolls the rest", () => {
+    const steps = planRollout(["test-harness", "clerk"], {
+      pinToPersist: TARGET,
+      hostdContext: true,
+    });
+    const { deps, persisted } = harness({
+      versions: { "test-harness": "0.15.18", clerk: "0.15.18" },
+    });
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+    expect(r.ok).toBe(true);
+    expect(r.rolled).toEqual(["test-harness", "clerk"]);
+    expect(persisted).toEqual([TARGET]); // persisted exactly once, after canary
+  });
+});
+
+describe("rollout structured-result sentinel (#2487)", () => {
+  it("round-trips a successful result through encode/parse", () => {
+    const result: RolloutResult = {
+      ok: true,
+      rolled: ["test-harness", "clerk"],
+      warnings: ["hostd/web refresh deferred"],
+    };
+    const line = encodeRolloutResultLine(result);
+    expect(line.startsWith(ROLLOUT_RESULT_SENTINEL)).toBe(true);
+    const parsed = parseRolloutResultLine("noise\n" + line + "\nmore noise");
+    expect(parsed).toEqual({
+      ok: true,
+      rolled: ["test-harness", "clerk"],
+      warnings: ["hostd/web refresh deferred"],
+    });
+  });
+
+  it("round-trips a FAILED result with failedAgent/failedStep", () => {
+    const result: RolloutResult = {
+      ok: false,
+      rolled: ["test-harness"],
+      failedStep: "restart-agent",
+      failedAgent: "clerk",
+      got: "0.15.17",
+      warnings: [],
+    };
+    const parsed = parseRolloutResultLine(encodeRolloutResultLine(result));
+    expect(parsed).toMatchObject({
+      ok: false,
+      rolled: ["test-harness"],
+      failedStep: "restart-agent",
+      failedAgent: "clerk",
+    });
+  });
+
+  it("returns null when no sentinel line is present (child died early)", () => {
+    expect(parseRolloutResultLine("Rolling 3 agents…\napply\n")).toBeNull();
   });
 });

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -39,6 +39,7 @@ import { getConfig, getConfigPath } from "./helpers.js";
 import { setReleasePinInConfig } from "./release-yaml.js";
 import { resolveOperatorUid } from "./operator-uid.js";
 import { writeConfigFileSync } from "../util/atomic.js";
+import { compareReleaseTags } from "../config/release-resolve.js";
 
 /** One ordered step of a rollout plan. Pure data so it unit-tests. */
 export type RolloutStep =
@@ -60,6 +61,26 @@ export interface RolloutPlanOpts {
    * to persist).
    */
   pinToPersist?: string;
+  /**
+   * hostd/MCP path (#2487). When true the plan is reshaped for the
+   * unattended, agent-invoked rollout:
+   *
+   *   1. persist-pin moves from FIRST to AFTER the canary agent confirms
+   *      the target version (so a failed canary never leaves a persisted-
+   *      but-unverified pin that the next reconcile rolls fleet-wide —
+   *      brick scenario #2). The canary is rolled on a one-shot `--pin`
+   *      image ref via `apply`'s reading of the env-passed target; the
+   *      durable pin is only written once the canary is green.
+   *   2. the web + hostd refresh steps are DROPPED entirely — an
+   *      agent-invoked rollout must not synchronously recreate its own
+   *      hostd container (it would SIGKILL the in-flight rollout, which
+   *      is hostd's own child — brick scenario #1). The executor reports
+   *      "hostd/web refresh deferred — run host-side" instead.
+   *
+   * Gating the new ordering behind this explicit flag (not euid) keeps the
+   * host-shell path's persist-first behavior a deliberate choice.
+   */
+  hostdContext?: boolean;
 }
 
 /**
@@ -102,9 +123,39 @@ export function planRollout(
   opts: RolloutPlanOpts = {},
 ): RolloutStep[] {
   const steps: RolloutStep[] = [];
+  const ordered = orderAgentsCanaryFirst(agents);
+
+  if (opts.hostdContext) {
+    // hostd/MCP path (#2487): persist the pin AFTER the canary confirms,
+    // and DROP the hostd/web refresh (defer to host-side). The bare
+    // `apply` reads the env-passed one-shot target, so the canary rolls
+    // on the target image WITHOUT a durable pin write first.
+    steps.push({ kind: "apply" });
+    const [canary, ...rest] = ordered;
+    if (canary !== undefined) {
+      steps.push({ kind: "restart-agent", agent: canary });
+      // Durable pin is written only once the canary is green — a failed
+      // canary returns from executeRollout BEFORE this step is reached.
+      if (opts.pinToPersist) {
+        steps.push({ kind: "persist-pin", pin: opts.pinToPersist });
+      }
+      for (const agent of rest) {
+        steps.push({ kind: "restart-agent", agent });
+      }
+    } else if (opts.pinToPersist) {
+      // No agents to roll (shouldn't happen — caller guards) but keep
+      // the persist intent consistent.
+      steps.push({ kind: "persist-pin", pin: opts.pinToPersist });
+    }
+    steps.push({ kind: "sweep" });
+    return steps;
+  }
+
+  // Host-shell path: persist-FIRST (durable before any restart), then
+  // the web + hostd refresh — unchanged, deliberate.
   if (opts.pinToPersist) steps.push({ kind: "persist-pin", pin: opts.pinToPersist });
   steps.push({ kind: "apply" });
-  for (const agent of orderAgentsCanaryFirst(agents)) {
+  for (const agent of ordered) {
     steps.push({ kind: "restart-agent", agent });
   }
   if (!opts.skipWeb) {
@@ -180,15 +231,93 @@ export interface RolloutResult {
 }
 
 /**
+ * True when this `switchroom rollout` was spawned by the host-control
+ * daemon on behalf of an agent MCP call (#2487). hostd sets
+ * `SWITCHROOM_HOSTD_CONTEXT=1` on the child env. The flag flips three
+ * deliberate behaviors versus the host-shell path:
+ *   - persist the durable pin AFTER the canary, not before (planRollout);
+ *   - defer the hostd/web self-refresh (planRollout drops those steps);
+ *   - suppress "Run with sudo" guidance + soften the persistPin chown-back
+ *     (we're already euid 0 inside the hostd container, not via sudo).
+ */
+export function isHostdContext(): boolean {
+  return process.env.SWITCHROOM_HOSTD_CONTEXT === "1";
+}
+
+/**
+ * Sentinel prefix for the machine-readable rollout result line. hostd
+ * parses this off the spawned child's stdout to populate STRUCTURED
+ * status fields (`rolled[]`, `failedStep`, `failedAgent`) instead of
+ * flattening the outcome into a stdout tail (#2487 item 4). Emitted only
+ * on the hostd-context path; harmless on the host-shell path (we don't
+ * emit it there).
+ */
+export const ROLLOUT_RESULT_SENTINEL = "SWITCHROOM_ROLLOUT_RESULT:";
+
+/** Serialize a result for the sentinel line hostd parses. */
+export function encodeRolloutResultLine(result: RolloutResult): string {
+  return (
+    ROLLOUT_RESULT_SENTINEL +
+    JSON.stringify({
+      ok: result.ok,
+      rolled: result.rolled,
+      ...(result.failedStep ? { failedStep: result.failedStep } : {}),
+      ...(result.failedAgent ? { failedAgent: result.failedAgent } : {}),
+      ...(result.got !== undefined ? { got: result.got } : {}),
+      warnings: result.warnings,
+    })
+  );
+}
+
+/** Parse the last sentinel line out of a rollout child's stdout. Returns
+ *  null when no sentinel was emitted (e.g. the child died before
+ *  finishing). hostd uses this to recover structured fields. */
+export function parseRolloutResultLine(
+  stdout: string,
+): {
+  ok: boolean;
+  rolled: string[];
+  failedStep?: string;
+  failedAgent?: string;
+  got?: string | null;
+  warnings: string[];
+} | null {
+  const lines = stdout.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]!.trim();
+    if (line.startsWith(ROLLOUT_RESULT_SENTINEL)) {
+      try {
+        return JSON.parse(line.slice(ROLLOUT_RESULT_SENTINEL.length));
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * Execute a rollout plan. STOPS at the first failure that can strand the
  * fleet (apply failure, or an agent that doesn't return on the target
  * version). web/hostd refresh failures are non-fatal warnings — the agents
  * are already rolled; a stale dashboard/daemon doesn't strand them.
  */
+export interface RolloutExecOpts {
+  /**
+   * hostd/MCP path (#2487). When true, the durable pin is NOT yet
+   * persisted at the `apply` step (it's persisted after the canary), so
+   * `apply` is given the one-shot `--pin <target>` to regenerate compose
+   * against the target image. On the host-shell path the pin is already
+   * persisted, so a bare `apply` reads it from config.
+   */
+  hostdContext?: boolean;
+}
+
 export function executeRollout(
   steps: RolloutStep[],
   target: string,
   deps: RolloutDeps,
+  execOpts: RolloutExecOpts = {},
 ): RolloutResult {
   const targetNorm = normalizeVersion(target);
   const rolled: string[] = [];
@@ -197,8 +326,9 @@ export function executeRollout(
   for (const step of steps) {
     switch (step.kind) {
       case "persist-pin": {
-        // Persist FIRST so the subsequent bare `apply` (and restart / web /
-        // hostd) all read the same durable pin — no one-shot --pin needed.
+        // On the hostd path this runs AFTER the canary is green; on the
+        // host-shell path it runs FIRST. Either way: durably persist so
+        // subsequent reconciles read the same pin.
         deps.log(`→ persist release.pin=${step.pin} to switchroom.yaml`);
         if (deps.persistPin) {
           deps.persistPin(step.pin);
@@ -208,9 +338,14 @@ export function executeRollout(
         break;
       }
       case "apply": {
-        // Bare apply — it reads release.pin from the (now-persisted) config.
+        // hostd path: pin not yet persisted (it follows the canary), so
+        // pass the one-shot --pin so compose regenerates on the target.
+        // host-shell path: pin already persisted → bare apply reads it.
         deps.log(`→ apply — regenerating compose for ${target}`);
-        const r = deps.run(["apply"]);
+        const applyArgs = execOpts.hostdContext
+          ? ["apply", "--pin", target]
+          : ["apply"];
+        const r = deps.run(applyArgs);
         if (r.status !== 0) {
           return { ok: false, rolled, failedStep: "apply", warnings };
         }
@@ -263,11 +398,13 @@ export function executeRollout(
 }
 
 export function registerRolloutCommand(program: Command): void {
+  const hostdCtx = isHostdContext();
   program
     .command("rollout")
     .description(
       "Deploy a pinned version to the fleet, safely (staggered restart + " +
-        "per-agent version assert + web/hostd refresh). Run with sudo.",
+        "per-agent version assert + web/hostd refresh)." +
+        (hostdCtx ? "" : " Run with sudo."),
     )
     .option(
       "--pin <version>",
@@ -300,6 +437,26 @@ export function registerRolloutCommand(program: Command): void {
         process.exitCode = 2;
         return;
       }
+      // #2487 item 9 — reject DOWNGRADE pins on the agent-reachable
+      // (hostd) path specifically. `--agents <list>` + arbitrary `--pin`
+      // is a more surgical abuse surface than update_apply (targeted
+      // downgrade); downgrade-as-rollback is deferred to PR2's operator-
+      // tapped rollback verb. compareReleaseTags is conservative: it only
+      // refuses a clean vX.Y.Z → older-vX.Y.Z move, never a channel/sha.
+      if (hostdCtx && opts.pin) {
+        const current = config.release?.pin;
+        const cmp = compareReleaseTags(opts.pin, current);
+        if (cmp !== null && cmp < 0) {
+          process.stderr.write(
+            `rollout (hostd path) refuses a DOWNGRADE: ${opts.pin} is older ` +
+              `than the current pin ${current}. Downgrade/rollback is an ` +
+              `operator-tapped verb (deferred to PR2), not an agent rollout. ` +
+              `Nothing was changed.\n`,
+          );
+          process.exitCode = 2;
+          return;
+        }
+      }
       const allAgents = Object.keys(config.agents ?? {});
       const requested = opts.agents
         ? opts.agents.split(",").map((s) => s.trim()).filter(Boolean)
@@ -321,6 +478,7 @@ export function registerRolloutCommand(program: Command): void {
       const steps = planRollout(requested, {
         skipWeb: opts.skipWeb,
         pinToPersist: opts.pin ?? undefined,
+        hostdContext: hostdCtx,
       });
 
       if (opts.dryRun) {
@@ -355,13 +513,31 @@ export function registerRolloutCommand(program: Command): void {
           // in-place rewrite on EBUSY/EXDEV/EINVAL (single-file bind mount
           // inside the hostd container rejects rename over the mount point).
           writeConfigFileSync(configPath, after, statSync(configPath).mode & 0o777);
-          // rollout self-elevates via sudo; a root write would leave the
-          // operator-owned config root-owned and EACCES-lock other yaml verbs
-          // (and erode the read-only-operator-config foundation). chown back.
+          // chown-back rationale differs by path:
+          //   host-shell: rollout self-elevates via sudo; a root write
+          //     would leave the operator-owned config root-owned and
+          //     EACCES-lock other yaml verbs. chown back to the operator.
+          //   hostd: we're euid 0 inside the hostd container's mount
+          //     namespace (NOT via sudo). The config is a bind-mounted
+          //     single file at /state/config/switchroom.yaml whose
+          //     on-disk owner is the operator on the host. resolveOperatorUid()
+          //     must resolve the operator's uid for the chown to be
+          //     meaningful; if it can't, we SKIP the chown rather than
+          //     chown to a wrong/garbage uid — leaving the host's existing
+          //     ownership intact is safer than corrupting it (#2487 item 8).
           try {
             if (typeof process.geteuid === "function" && process.geteuid() === 0) {
               const uid = resolveOperatorUid();
-              if (uid !== undefined) chownSync(configPath, uid, uid);
+              if (uid !== undefined) {
+                chownSync(configPath, uid, uid);
+              } else if (hostdCtx) {
+                process.stderr.write(
+                  "⚠️  rollout (hostd path): could not resolve operator uid; " +
+                    "skipping config chown-back to avoid leaving switchroom.yaml " +
+                    "root-owned. Verify ownership host-side if other yaml verbs " +
+                    "EACCES.\n",
+                );
+              }
             }
           } catch {
             /* dev hosts may lack CAP_CHOWN — best-effort */
@@ -370,9 +546,26 @@ export function registerRolloutCommand(program: Command): void {
       };
 
       process.stdout.write(`Rolling ${requested.length} agent(s) to ${target}…\n`);
-      const result = executeRollout(steps, target, deps);
+      const result = executeRollout(steps, target, deps, { hostdContext: hostdCtx });
+
+      // hostd path: the hostd/web refresh was intentionally dropped from
+      // the plan (it would SIGKILL this very process). Surface that as a
+      // deferral note so the operator knows to refresh host-side.
+      if (hostdCtx) {
+        result.warnings.push(
+          "hostd/web refresh deferred — run host-side (`switchroom webd install` " +
+            "/ `switchroom hostd install`). An agent-invoked rollout cannot " +
+            "recreate its own hostd container without killing itself.",
+        );
+      }
 
       for (const w of result.warnings) process.stderr.write(`⚠️  ${w}\n`);
+
+      // hostd parses this sentinel to populate STRUCTURED status fields
+      // (rolled[]/failedStep/failedAgent) instead of a flattened tail.
+      if (hostdCtx) {
+        process.stdout.write(encodeRolloutResultLine(result) + "\n");
+      }
 
       if (!result.ok) {
         process.stderr.write(

--- a/src/host-control/audit-reader.ts
+++ b/src/host-control/audit-reader.ts
@@ -43,6 +43,13 @@ export interface AuditEntry {
     install_type: string;
     detected_at: string;
   };
+  // ─── Rollout-flow structured result (#2487) ────────────────────────
+  /** Agents confirmed on the target version, in order (rollout rows). */
+  rolled?: string[];
+  /** Step that stopped the rollout (rollout rows). */
+  failed_step?: string;
+  /** Agent that failed the version assert (rollout rows). */
+  failed_agent?: string;
 }
 
 export interface AuditFilters {
@@ -122,6 +129,11 @@ export function parseAuditLine(line: string): AuditEntry | null {
       };
     }
   }
+  if (Array.isArray(o.rolled) && o.rolled.every((x) => typeof x === "string")) {
+    entry.rolled = o.rolled as string[];
+  }
+  if (typeof o.failed_step === "string") entry.failed_step = o.failed_step;
+  if (typeof o.failed_agent === "string") entry.failed_agent = o.failed_agent;
   return entry;
 }
 

--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -143,6 +143,41 @@ export const ApplyRequestSchema = z.object({
   args: z.object({}).optional(),
 });
 
+// ─── PR1 (#2487) — agent-reachable safe staggered rollout ─────────────────
+//
+// `rollout` exposes `switchroom rollout` — the staggered canary +
+// per-agent version-assert + stop-on-mismatch verb — over the wire so an
+// admin agent can run a SAFE fleet roll behind a single operator approval
+// card (the verb is deliberately omitted from HOSTD_MCP_TOOLS in
+// scaffold.ts, so any agent call surfaces a Telegram approval).
+//
+// Wire-layer safety: `pin` is SEMVER-ONLY here (`^v\d+\.\d+\.\d+$`),
+// rejecting `sha-…` pins at decode. A sha pin is a valid release.pin but
+// is NOT version-assertable (the in-container `switchroom --version`
+// always prints the semver), so it would "mismatch" on agent #1 and stop
+// the roll with a confusing message. update_apply still accepts sha pins
+// (it doesn't assert versions); rollout does not.
+export const RolloutRequestSchema = z.object({
+  ...RequestEnvelope,
+  op: z.literal("rollout"),
+  args: z
+    .object({
+      /** Semver target to roll the fleet to (e.g. v0.15.18). Required:
+       *  a staggered version-assert roll has nothing to assert against
+       *  without a concrete tag. SHA pins are rejected at the wire. */
+      pin: z.string().regex(/^v\d+\.\d+\.\d+$/),
+      /** Comma-free explicit subset of agents to roll. Omit ⇒ all
+       *  configured agents (canary-first ordering still applies). */
+      agents: z.array(AgentNameSchema).min(1).optional(),
+      /** Skip the web + hostd refresh step. On the hostd/MCP path the
+       *  hostd/web refresh is ALWAYS deferred regardless (it would
+       *  SIGKILL the in-flight rollout — hostd's own child); this flag
+       *  is forwarded for parity but the deferral is unconditional. */
+      skip_web: z.boolean().optional(),
+    })
+    .required({ pin: true }),
+});
+
 export const AgentStartRequestSchema = z.object({
   ...RequestEnvelope,
   op: z.literal("agent_start"),
@@ -368,6 +403,7 @@ export const RequestSchema = z.discriminatedUnion("op", [
   UpdateCheckRequestSchema,
   UpdateApplyRequestSchema,
   ApplyRequestSchema,
+  RolloutRequestSchema,
   AgentStartRequestSchema,
   AgentStopRequestSchema,
   AgentLogsRequestSchema,
@@ -385,6 +421,7 @@ export type GetStatusRequest = z.infer<typeof GetStatusRequestSchema>;
 export type UpdateCheckRequest = z.infer<typeof UpdateCheckRequestSchema>;
 export type UpdateApplyRequest = z.infer<typeof UpdateApplyRequestSchema>;
 export type ApplyRequest = z.infer<typeof ApplyRequestSchema>;
+export type RolloutRequest = z.infer<typeof RolloutRequestSchema>;
 export type AgentStartRequest = z.infer<typeof AgentStartRequestSchema>;
 export type AgentStopRequest = z.infer<typeof AgentStopRequestSchema>;
 export type AgentLogsRequest = z.infer<typeof AgentLogsRequestSchema>;

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -56,6 +56,8 @@ import { chainRow, seedChain, type ChainState } from "../util/audit-hashchain.js
 import { socketPathToIdentity, type SocketIdentity } from "./peercred.js";
 import { redact } from "../secret-detect/redact.js";
 import { detectInstallType, type InstallType } from "../cli/install-detect.js";
+import { parseRolloutResultLine } from "../cli/rollout.js";
+import { parseAuditLine } from "./audit-reader.js";
 import {
   validateConfigEdit,
   assertSelfScopedAllowEdit,
@@ -184,6 +186,18 @@ interface StatusEntry {
     install_type: InstallType;
     detected_at: string;
   };
+  // ─── Rollout-flow structured result (#2487) ────────────────────────
+  // Populated only on `rollout` rows. The staggered rollout's outcome is
+  // preserved as STRUCTURED fields (not flattened into a stdout tail) so
+  // a `get_status` reader / the gateway can show exactly which agents
+  // rolled and where it stopped. Parsed from the spawned child's
+  // sentinel line (see parseRolloutResultLine in cli/rollout.ts).
+  /** Agents confirmed on the target version, in order. */
+  rolled?: string[];
+  /** Step that stopped the rollout (e.g. "restart-agent", "apply"). */
+  failed_step?: string;
+  /** Agent that failed the version assert (when failed_step is restart). */
+  failed_agent?: string;
 }
 
 /**
@@ -385,6 +399,17 @@ const STATUS_MAX_ENTRIES = 256;
 /** Tail length for stdout/stderr in audit + response frames. */
 const TAIL_BYTES = 4096;
 
+/**
+ * #2487 item 7 — minimum age before a `started` fleet-mutation row with no
+ * terminal counterpart is treated as ORPHANED on hostd boot. A normal
+ * mutation completes (and writes its terminal row) well under this; only a
+ * mutation whose process died without finishing (SIGKILL mid-rollout)
+ * leaves a `started` row this stale. Conservative (15 min) so an in-flight
+ * mutation that legitimately spans a quick hostd restart isn't falsely
+ * flagged. Exported so the boot-reconcile test can pin the threshold.
+ */
+export const ORPHAN_RECONCILE_AGE_MS = 15 * 60 * 1000;
+
 export class HostdServer {
   // One Server per bound socket path. `node:net.Server.listen` can
   // only be called once per instance — to bind N agent sockets we
@@ -424,7 +449,11 @@ export class HostdServer {
    * common "fleet boot in parallel" case for no real safety win.
    */
   private fleetMutationInFlight:
-    | { op: "update_apply" | "apply"; request_id: string; started_at: number }
+    | {
+        op: "update_apply" | "apply" | "rollout";
+        request_id: string;
+        started_at: number;
+      }
     | null = null;
 
   constructor(private opts: ServerOptions) {}
@@ -544,6 +573,108 @@ export class HostdServer {
     } catch (err) {
       await this.stop();
       throw err;
+    }
+
+    // #2487 item 7 — orphaned-`started`-row reconcile guard. A fleet
+    // mutation (update_apply / apply / rollout) records a synchronous
+    // `started` audit row, then a `terminal` row when the spawned child
+    // finishes. If hostd is SIGKILLed mid-mutation (e.g. a rollout's
+    // hostd-refresh recreated this very container — brick scenario #1),
+    // the terminal row never lands: the fleet is left half-rolled and the
+    // status shows a perpetual `started`. On the next boot we scan for
+    // such orphans and emit a LOUD terminal failure row so the gap is
+    // detectable (via /audit hostd / get_status) instead of silently
+    // hanging forever. Best-effort: never throws, never blocks boot.
+    await this.reconcileOrphanedFleetMutations().catch((e) => {
+      process.stderr.write(
+        `hostd: orphan-reconcile sweep failed (non-fatal): ${(e as Error).message}\n`,
+      );
+    });
+  }
+
+  /**
+   * Scan the audit log for fleet-mutation `started` rows with no matching
+   * `terminal` row, older than {@link ORPHAN_RECONCILE_AGE_MS}, and append
+   * a loud terminal failure row for each (#2487 item 7). Emits
+   * `rollout_orphaned` for rollout ops and `update_failed` for
+   * update_apply/apply — the gateway / audit reader can branch on op +
+   * this synthetic phase to alert the operator. A row that ALREADY has a
+   * terminal counterpart, or that we already reconciled (its synthetic
+   * row exists), is skipped — the sweep is idempotent across reboots.
+   */
+  private async reconcileOrphanedFleetMutations(): Promise<void> {
+    const path = this.auditLogPath();
+    if (!existsSync(path)) return;
+    let raw: string;
+    try {
+      raw = readFileSync(path, "utf-8");
+    } catch {
+      return;
+    }
+    const FLEET_OPS = new Set(["update_apply", "apply", "rollout"]);
+    // request_id → started row info; cleared when a terminal/orphan row
+    // for the same request_id is seen.
+    const startedRows = new Map<
+      string,
+      { op: string; ts: number; caller_name?: string }
+    >();
+    for (const line of raw.split("\n")) {
+      const e = parseAuditLine(line);
+      if (!e) continue;
+      // Our synthetic orphan row (op=rollout_orphaned/update_failed,
+      // phase=orphan_reconciled) carries the ORIGINAL request_id and
+      // resolves the started — checked BEFORE the FLEET_OPS filter since
+      // its own op is not a fleet op. This makes the sweep idempotent.
+      if (e.phase === "orphan_reconciled") {
+        startedRows.delete(e.request_id);
+        continue;
+      }
+      if (!FLEET_OPS.has(e.op)) continue;
+      // A terminal row resolves the started.
+      if (e.phase === "terminal") {
+        startedRows.delete(e.request_id);
+        continue;
+      }
+      // Synchronous request-path `started` row (no phase).
+      if (e.result === "started" && e.phase === undefined) {
+        const tsMs = Date.parse(e.ts);
+        startedRows.set(e.request_id, {
+          op: e.op,
+          ts: Number.isFinite(tsMs) ? tsMs : Date.now(),
+          caller_name: e.caller.kind === "agent" ? e.caller.name : undefined,
+        });
+      }
+    }
+    const now = Date.now();
+    for (const [request_id, info] of startedRows) {
+      if (now - info.ts < ORPHAN_RECONCILE_AGE_MS) continue; // too fresh
+      const synthOp = info.op === "rollout" ? "rollout_orphaned" : "update_failed";
+      process.stderr.write(
+        `hostd: ORPHANED ${info.op} (request_id=${request_id}, ` +
+          `started ${Math.floor((now - info.ts) / 60000)}m ago, no terminal ` +
+          `row) — emitting ${synthOp}. The fleet may be half-rolled; verify ` +
+          `host-side.\n`,
+      );
+      await this.appendAuditRow({
+        ts: new Date().toISOString(),
+        op: synthOp,
+        phase: "orphan_reconciled",
+        // Carry the ORIGINAL request_id so the terminal row resolves the
+        // orphan on the next boot's sweep (idempotency).
+        request_id,
+        original_op: info.op,
+        caller: info.caller_name
+          ? { kind: "agent", name: info.caller_name }
+          : { kind: "operator" },
+        result: "error",
+        exit_code: null,
+        duration_ms: now - info.ts,
+        error:
+          `${info.op} left a perpetual 'started' status with no terminal row ` +
+          `(hostd likely SIGKILLed mid-mutation — brick scenario #1). ` +
+          `Reconciled to a failure on hostd boot. The fleet may be ` +
+          `half-rolled; verify versions host-side and re-run if needed.`,
+      });
     }
   }
 
@@ -694,6 +825,9 @@ export class HostdServer {
         case "apply":
           resp = this.handleApply(req, caller, started);
           break;
+        case "rollout":
+          resp = this.handleRollout(req, caller, started);
+          break;
         case "agent_start":
           resp = await this.handleAgentStart(req, started);
           break;
@@ -802,10 +936,15 @@ export class HostdServer {
         return null;
       case "update_apply":
       case "apply":
+      case "rollout":
         // Fleet-wide mutations. Require admin: a non-admin agent
         // accidentally regenerating compose / pulling images on the
         // whole fleet is the obvious foot-gun. Operator is always
         // allowed (kind === "operator" already returned null above).
+        // `rollout` (#2487) is additionally kept OUT of HOSTD_MCP_TOOLS
+        // in scaffold.ts, so an agent's call surfaces a Telegram approval
+        // card — the human tap is the real boundary; this admin gate is
+        // the wire-side floor.
         return callerAdmin
           ? null
           : `${req.op} requires admin: true on caller "${caller.name}"`;
@@ -1169,6 +1308,78 @@ export class HostdServer {
       started_at: started,
     };
     this.spawnFleetMutation(req.op, args, entry);
+    return {
+      v: 1,
+      request_id: req.request_id,
+      result: "started",
+      exit_code: null,
+      duration_ms: Date.now() - started,
+    };
+  }
+
+  /**
+   * Mutating + long-running: `switchroom rollout` — the SAFE staggered
+   * canary + per-agent version-assert + stop-on-mismatch fleet deploy
+   * (#2487). Modeled on handleUpdateApply (shares the fleet-mutation lock
+   * + apply-asset preflight) but with three load-bearing differences:
+   *
+   *   1. The spawned CLI runs with `SWITCHROOM_HOSTD_CONTEXT=1`, which
+   *      flips the rollout to (a) persist the durable pin AFTER the canary
+   *      confirms (not before — brick scenario #2), and (b) DROP the
+   *      hostd/web self-refresh (it would SIGKILL this very rollout, which
+   *      is hostd's own child — brick scenario #1).
+   *   2. The outcome (`rolled[]` / `failedStep` / `failedAgent`) is
+   *      preserved into STRUCTURED status fields, parsed from the child's
+   *      sentinel line — NOT flattened into a stdout tail.
+   *   3. `pin` is semver-only (already enforced at the wire schema).
+   *
+   * Returns `started`; default wire timeout (no long override) — same
+   * async fire-and-forget pattern as update_apply.
+   */
+  private handleRollout(
+    req: Extract<HostdRequest, { op: "rollout" }>,
+    caller: SocketIdentity,
+    started: number,
+  ): HostdResponse {
+    const denied = this.checkFleetMutationLock(req.op, req.request_id, started);
+    if (denied) return denied;
+
+    const assetDenied = this.applyAssetPreflight(req.request_id, started);
+    if (assetDenied) return assetDenied;
+
+    const args = ["rollout", "--pin", req.args.pin];
+    if (req.args.agents && req.args.agents.length > 0) {
+      args.push("--agents", req.args.agents.join(","));
+    }
+    if (req.args.skip_web) args.push("--skip-web");
+
+    const installCtx = readCachedInstallType(
+      this.opts.bindRoot ?? this.opts.homeDir,
+    );
+
+    const entry: StatusEntry = {
+      request_id: req.request_id,
+      caller,
+      op: req.op,
+      result: "started",
+      exit_code: null,
+      started_at: started,
+      finished_at: null,
+      stdout_tail: "",
+      stderr_tail: "",
+      pin: req.args.pin,
+      install_context: {
+        install_type: installCtx.install_type,
+        detected_at: installCtx.detected_at,
+      },
+    };
+    this.recordStatus(entry);
+    this.fleetMutationInFlight = {
+      op: "rollout",
+      request_id: req.request_id,
+      started_at: started,
+    };
+    this.spawnRollout(args, entry);
     return {
       v: 1,
       request_id: req.request_id,
@@ -2008,7 +2219,7 @@ export class HostdServer {
   }
 
   private checkFleetMutationLock(
-    op: "update_apply" | "apply",
+    op: "update_apply" | "apply" | "rollout",
     request_id: string,
     started: number,
   ): HostdResponse | null {
@@ -2029,7 +2240,7 @@ export class HostdServer {
    *  Updates the status entry on completion AND releases the
    *  fleet-mutation lock (success or fail). */
   private spawnFleetMutation(
-    op: "update_apply" | "apply",
+    op: "update_apply" | "apply" | "rollout",
     args: string[],
     entry: StatusEntry,
   ): void {
@@ -2070,6 +2281,52 @@ export class HostdServer {
       });
   }
 
+  /**
+   * Fire-and-forget spawn for `rollout` (#2487). Distinct from
+   * spawnFleetMutation: it injects the `SWITCHROOM_HOSTD_CONTEXT=1`
+   * sentinel into the child env and parses the child's STRUCTURED result
+   * sentinel off stdout into the status entry's `rolled[]` / `failed_step`
+   * / `failed_agent` fields — instead of relying on a flattened stdout
+   * tail. Releases the fleet-mutation lock on completion (success/fail).
+   */
+  private spawnRollout(args: string[], entry: StatusEntry): void {
+    this.runSwitchroom(args, { SWITCHROOM_HOSTD_CONTEXT: "1" })
+      .then((res) => {
+        entry.exit_code = res.exit_code;
+        entry.finished_at = Date.now();
+        entry.stdout_tail = tail(res.stdout);
+        entry.stderr_tail = tail(res.stderr);
+        const parsed = parseRolloutResultLine(res.stdout);
+        if (parsed) {
+          entry.rolled = parsed.rolled;
+          if (parsed.failedStep) entry.failed_step = parsed.failedStep;
+          if (parsed.failedAgent) entry.failed_agent = parsed.failedAgent;
+          // Structured `ok` is the authority; exit code corroborates.
+          entry.result = parsed.ok ? "completed" : "error";
+        } else {
+          // No sentinel — the child died before finishing (e.g. SIGKILL).
+          // Fall back to the exit code; structured fields stay unset so a
+          // reader can tell the outcome wasn't cleanly captured.
+          entry.result = res.exit_code === 0 ? "completed" : "error";
+        }
+      })
+      .catch((err) => {
+        entry.result = "error";
+        entry.exit_code = null;
+        entry.finished_at = Date.now();
+        entry.error = (err as Error).message;
+      })
+      .finally(() => {
+        void this.writeTerminalAudit(entry);
+        if (
+          this.fleetMutationInFlight &&
+          this.fleetMutationInFlight.request_id === entry.request_id
+        ) {
+          this.fleetMutationInFlight = null;
+        }
+      });
+  }
+
   private handleGetStatus(
     req: Extract<HostdRequest, { op: "get_status" }>,
     _caller: SocketIdentity,
@@ -2093,6 +2350,22 @@ export class HostdServer {
     request_id: string,
     entry: StatusEntry,
   ): HostdResponse {
+    // Rollout (#2487) surfaces its STRUCTURED outcome via `payload` so a
+    // get_status reader gets rolled[]/failedStep/failedAgent as data, not
+    // a stdout-tail it has to grep. Only emitted on rollout entries that
+    // actually captured structured fields.
+    const rolloutPayload =
+      entry.op === "rollout" &&
+      (entry.rolled !== undefined ||
+        entry.failed_step !== undefined ||
+        entry.failed_agent !== undefined)
+        ? JSON.stringify({
+            rolled: entry.rolled ?? [],
+            ...(entry.failed_step ? { failedStep: entry.failed_step } : {}),
+            ...(entry.failed_agent ? { failedAgent: entry.failed_agent } : {}),
+            ...(entry.pin ? { pin: entry.pin } : {}),
+          })
+        : undefined;
     return {
       v: 1,
       request_id,
@@ -2101,6 +2374,7 @@ export class HostdServer {
       duration_ms: (entry.finished_at ?? Date.now()) - entry.started_at,
       stdout_tail: entry.stdout_tail || undefined,
       stderr_tail: entry.stderr_tail || undefined,
+      ...(rolloutPayload ? { payload: rolloutPayload } : {}),
       error: entry.error,
     };
   }
@@ -2236,18 +2510,26 @@ export class HostdServer {
       ...(entry.pin ? { pin: entry.pin } : {}),
       ...(entry.resolved_sha ? { resolved_sha: entry.resolved_sha } : {}),
       ...(entry.install_context ? { install_context: entry.install_context } : {}),
+      // Rollout structured result (#2487) — only present on rollout rows.
+      ...(entry.rolled ? { rolled: entry.rolled } : {}),
+      ...(entry.failed_step ? { failed_step: entry.failed_step } : {}),
+      ...(entry.failed_agent ? { failed_agent: entry.failed_agent } : {}),
     });
   }
 
-  /** Spawn the host switchroom CLI and capture stdout/stderr. */
+  /** Spawn the host switchroom CLI and capture stdout/stderr. An
+   *  optional `extraEnv` is merged onto the inherited env — used by the
+   *  rollout path to flip the in-container `SWITCHROOM_HOSTD_CONTEXT`
+   *  sentinel (#2487). */
   private runSwitchroom(
     args: string[],
+    extraEnv?: Record<string, string>,
   ): Promise<{ exit_code: number; stdout: string; stderr: string }> {
     return new Promise((resolve, reject) => {
       const bin = this.opts.switchroomBin ?? "switchroom";
       const child = spawn(bin, args, {
         stdio: ["ignore", "pipe", "pipe"],
-        env: { ...process.env },
+        env: { ...process.env, ...(extraEnv ?? {}) },
       });
       let stdout = "";
       let stderr = "";

--- a/src/mcp/hostd/server.test.ts
+++ b/src/mcp/hostd/server.test.ts
@@ -74,6 +74,7 @@ describe("TOOLS export", () => {
       "agent_stop",
       "config_propose_edit", // PR 1a (admin-agent-config-edit) — flag-gated stub
       "get_status",     // PR B — read last terminal update_apply audit row
+      "rollout",        // #2487 — safe staggered canary fleet roll
       "update_apply",
       "update_check",
     ]);
@@ -178,6 +179,53 @@ describe("dispatchTool — happy path", () => {
 
   it("update_apply rejects malformed pin without hitting the wire", async () => {
     const res = await dispatchTool("update_apply", { pin: "not-a-pin" });
+    expect(res.isError).toBe(true);
+    expect(hostdRequestMock).not.toHaveBeenCalled();
+  });
+
+  // ── #2487 rollout dispatch ───────────────────────────────────────────
+  it("rollout sends a rollout request with a semver pin", async () => {
+    hostdRequestMock.mockResolvedValueOnce(ok({ result: "started" }));
+    const res = await dispatchTool("rollout", { pin: "v0.15.18" });
+    expect(res.isError).toBeFalsy();
+    const sent = hostdRequestMock.mock.calls[0]![1];
+    expect(sent.op).toBe("rollout");
+    expect(sent.args).toEqual({ pin: "v0.15.18" });
+    expect(sent.request_id).toMatch(/^mcp-rollout-/);
+    expect(sent.v).toBe(1);
+  });
+
+  it("rollout forwards agents + skip_web", async () => {
+    hostdRequestMock.mockResolvedValueOnce(ok({ result: "started" }));
+    await dispatchTool("rollout", {
+      pin: "v0.15.18",
+      agents: ["test-harness", "clerk"],
+      skip_web: true,
+    });
+    const sent = hostdRequestMock.mock.calls[0]![1];
+    expect(sent.args).toEqual({
+      pin: "v0.15.18",
+      agents: ["test-harness", "clerk"],
+      skip_web: true,
+    });
+  });
+
+  it("rollout rejects a sha- pin at the wire boundary (semver-only)", async () => {
+    const res = await dispatchTool("rollout", { pin: "sha-abc1234" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toMatch(/SHA pins are rejected|invalid/);
+    expect(hostdRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("rollout rejects a missing pin without hitting the wire", async () => {
+    const res = await dispatchTool("rollout", {});
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toMatch(/pin is required/);
+    expect(hostdRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("rollout rejects an empty agents array without hitting the wire", async () => {
+    const res = await dispatchTool("rollout", { pin: "v0.15.18", agents: [] });
     expect(res.isError).toBe(true);
     expect(hostdRequestMock).not.toHaveBeenCalled();
   });

--- a/src/mcp/hostd/server.ts
+++ b/src/mcp/hostd/server.ts
@@ -86,10 +86,18 @@ interface ToolArgs {
   // update_apply release-override (PR B)
   channel?: "dev" | "rc" | "latest";
   pin?: string;
+  // rollout (#2487)
+  agents?: string[];
+  skip_web?: boolean;
   // config_propose_edit args
   unified_diff?: string;
   target_path?: string;
 }
+
+/** Semver-only pin matcher for the rollout verb (#2487). Rejects `sha-…`
+ *  pins at the wire — a sha is a valid release.pin but is NOT
+ *  version-assertable, so it would stop the staggered roll on agent #1. */
+const ROLLOUT_SEMVER_PIN_RE = /^v\d+\.\d+\.\d+$/;
 
 export const TOOLS = [
   {
@@ -261,6 +269,56 @@ export const TOOLS = [
             "One-shot release-pin override (sha-<7-40 hex> or " +
             "v<semver>). Mirrors `switchroom update --pin`. Mutually " +
             "exclusive with `channel`.",
+        },
+      },
+    },
+  },
+  {
+    name: "rollout",
+    description:
+      "SAFELY roll the fleet to a pinned SEMVER version, staggered and " +
+      "canary-gated (#2487). Unlike update_apply (a blunt all-at-once " +
+      "recreate), this restarts agents one at a time canary-first, asserts " +
+      "each agent's in-container `switchroom --version` matches the target, " +
+      "and STOPS on the first mismatch — so a bad build fails on the canary " +
+      "before touching the rest of the fleet. The durable release.pin is " +
+      "persisted only AFTER the canary confirms (a failed canary never " +
+      "strands a bad pin). `pin` MUST be a tagged semver (vX.Y.Z) — sha " +
+      "pins are rejected because the version assert needs a semver to " +
+      "compare against. The hostd/web self-refresh is DEFERRED on this path " +
+      "(an agent-invoked rollout cannot recreate its own hostd container " +
+      "without killing itself); run that host-side. Downgrade pins are " +
+      "rejected (rollback is an operator-tapped verb, not an agent " +
+      "rollout). Admin-only at the wire layer AND deliberately NOT pre-" +
+      "approved — every call surfaces a Telegram approval card for the " +
+      "operator to tap. Returns `started`; poll get_status for the " +
+      "structured outcome (which agents rolled / where it stopped).",
+    inputSchema: {
+      type: "object" as const,
+      required: ["pin"],
+      properties: {
+        pin: {
+          type: "string",
+          pattern: "^v\\d+\\.\\d+\\.\\d+$",
+          description:
+            "Target semver to roll to, e.g. v0.15.18. SHA pins are " +
+            "rejected — the staggered roll asserts the in-container " +
+            "semver version.",
+        },
+        agents: {
+          type: "array",
+          items: { type: "string", pattern: "^[a-zA-Z0-9][a-zA-Z0-9_-]*$" },
+          minItems: 1,
+          description:
+            "Explicit subset of agents to roll (default: all configured). " +
+            "Canary-first ordering still applies.",
+        },
+        skip_web: {
+          type: "boolean",
+          description:
+            "Skip the web + hostd refresh step. NB: on this (hostd) path " +
+            "the hostd/web refresh is deferred regardless; this flag is " +
+            "forwarded for parity.",
         },
       },
     },
@@ -468,6 +526,42 @@ export async function dispatchTool(
           ...(args.rebuild ? { rebuild: true } : {}),
           ...(args.channel ? { channel: args.channel } : {}),
           ...(args.pin ? { pin: args.pin } : {}),
+        },
+      };
+      break;
+    }
+    case "rollout": {
+      // Semver-only pin, rejected at the MCP boundary (fail fast with a
+      // friendly message rather than round-tripping a wire-decode error).
+      // A sha pin is NOT version-assertable and would stop the roll on
+      // agent #1 — so it's rejected here, not just at the daemon.
+      if (!args.pin || typeof args.pin !== "string") {
+        return errorText("rollout: pin is required (a semver like v0.15.18).");
+      }
+      if (!ROLLOUT_SEMVER_PIN_RE.test(args.pin)) {
+        return errorText(
+          `rollout: pin "${args.pin}" is invalid. Must be a tagged semver ` +
+            `(vX.Y.Z). SHA pins are rejected — the staggered roll asserts ` +
+            `the in-container semver version.`,
+        );
+      }
+      if (
+        args.agents !== undefined &&
+        (!Array.isArray(args.agents) || args.agents.length === 0)
+      ) {
+        return errorText(
+          "rollout: agents, when provided, must be a non-empty array of " +
+            "agent names.",
+        );
+      }
+      req = {
+        v: 1,
+        op: "rollout",
+        request_id: makeRequestId("mcp-rollout"),
+        args: {
+          pin: args.pin,
+          ...(args.agents ? { agents: args.agents } : {}),
+          ...(args.skip_web ? { skip_web: true } : {}),
         },
       };
       break;

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -4,8 +4,8 @@
  * `switchroomBin` to a small shell script the test writes.
  */
 
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
-import { mkdtempSync, writeFileSync, chmodSync, rmSync, mkdirSync, statSync } from "node:fs";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync, mkdirSync, statSync, appendFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
@@ -996,6 +996,190 @@ describe("hostd server — Phase 2 fleet mutations + lock", () => {
     expect(execRow!.stderr_tail).toBeUndefined();
   });
 
+  // ── #2487 rollout (safe staggered canary fleet roll) ─────────────────
+  it("rollout: requires admin (denied for non-admin caller)", async () => {
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/bob/sock"))!;
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "rollout", request_id: "ro-deny", args: { pin: "v0.15.18" } },
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/rollout requires admin/);
+  });
+
+  it("rollout: rejects a sha- pin at wire decode (semver-only)", async () => {
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      // sha pin is a valid update_apply pin but NOT a valid rollout pin.
+      { v: 1, op: "rollout", request_id: "ro-sha", args: { pin: "sha-abc1234" } } as never,
+    );
+    // Wire schema rejects it before dispatch → denied bad-request.
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/bad request/);
+  });
+
+  it("rollout: returns started for admin, spawns with --pin + SWITCHROOM_HOSTD_CONTEXT", async () => {
+    // Stub that records its env + argv so we can prove the context
+    // sentinel + flags are plumbed, and emits the structured sentinel.
+    const recStub = join(tmp, "switchroom-rollout-stub.sh");
+    const recOut = join(tmp, "rollout-rec.txt");
+    writeFileSync(
+      recStub,
+      `#!/bin/sh\n` +
+        `echo "argv: $@" >> "${recOut}"\n` +
+        `echo "ctx: $SWITCHROOM_HOSTD_CONTEXT" >> "${recOut}"\n` +
+        // Emit the structured result sentinel the daemon parses.
+        `echo 'Rolling 2 agents…'\n` +
+        `echo 'SWITCHROOM_ROLLOUT_RESULT:{"ok":true,"rolled":["test-harness","klanker"],"warnings":["hostd/web refresh deferred"]}'\n` +
+        `exit 0\n`,
+    );
+    chmodSync(recStub, 0o755);
+    await server.stop();
+    server = new (await import("../../src/host-control/server.js")).HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: recStub,
+      auditLogPath: join(tmp, "audit.log"),
+      allowNonLinux: true,
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+    const started = await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "rollout",
+        request_id: "ro-ok",
+        args: { pin: "v0.15.18", agents: ["test-harness", "klanker"] },
+      },
+    );
+    expect(started.result).toBe("started");
+    expect(started.exit_code).toBeNull();
+
+    await new Promise((r) => setTimeout(r, 300));
+
+    const { readFileSync } = await import("node:fs");
+    const rec = readFileSync(recOut, "utf8");
+    // --pin + --agents plumbed; SWITCHROOM_HOSTD_CONTEXT set on the child.
+    expect(rec).toContain("argv: rollout --pin v0.15.18 --agents test-harness,klanker");
+    expect(rec).toContain("ctx: 1");
+
+    // get_status surfaces the STRUCTURED outcome via `payload`, not a tail.
+    const poll = await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "get_status",
+        request_id: "ro-poll",
+        args: { target_request_id: "ro-ok" },
+      },
+    );
+    expect(poll.result).toBe("completed");
+    expect(poll.payload).toBeDefined();
+    const payload = JSON.parse(poll.payload!);
+    expect(payload.rolled).toEqual(["test-harness", "klanker"]);
+
+    // Terminal audit row carries the structured rolled[] too.
+    const rows = readFileSync(join(tmp, "audit.log"), "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    const terminal = rows.find(
+      (r) => r.request_id === "ro-ok" && r.phase === "terminal",
+    );
+    expect(terminal).toBeDefined();
+    expect(terminal!.op).toBe("rollout");
+    expect(terminal!.rolled).toEqual(["test-harness", "klanker"]);
+  });
+
+  it("rollout: a FAILED canary surfaces failed_agent in the terminal row + status", async () => {
+    const failStub = join(tmp, "switchroom-rollout-fail-stub.sh");
+    writeFileSync(
+      failStub,
+      `#!/bin/sh\n` +
+        `echo 'SWITCHROOM_ROLLOUT_RESULT:{"ok":false,"rolled":[],"failedStep":"restart-agent","failedAgent":"test-harness","got":"0.15.17","warnings":[]}'\n` +
+        `exit 1\n`,
+    );
+    chmodSync(failStub, 0o755);
+    await server.stop();
+    server = new (await import("../../src/host-control/server.js")).HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: failStub,
+      auditLogPath: join(tmp, "audit.log"),
+      allowNonLinux: true,
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+    await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "rollout", request_id: "ro-fail", args: { pin: "v0.15.18" } },
+    );
+    await new Promise((r) => setTimeout(r, 300));
+
+    const poll = await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "get_status",
+        request_id: "ro-fail-poll",
+        args: { target_request_id: "ro-fail" },
+      },
+    );
+    expect(poll.result).toBe("error");
+    const payload = JSON.parse(poll.payload!);
+    expect(payload.failedAgent).toBe("test-harness");
+    expect(payload.failedStep).toBe("restart-agent");
+
+    const { readFileSync } = await import("node:fs");
+    const terminal = readFileSync(join(tmp, "audit.log"), "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as Record<string, unknown>)
+      .find((r) => r.request_id === "ro-fail" && r.phase === "terminal");
+    expect(terminal!.failed_agent).toBe("test-harness");
+    expect(terminal!.failed_step).toBe("restart-agent");
+  });
+
+  it("rollout: shares the fleet-mutation lock with update_apply/apply", async () => {
+    const slowStub = join(tmp, "switchroom-rollout-slow.sh");
+    writeFileSync(slowStub, `#!/bin/sh\nsleep 1\nexit 0\n`);
+    chmodSync(slowStub, 0o755);
+    await server.stop();
+    server = new (await import("../../src/host-control/server.js")).HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: slowStub,
+      auditLogPath: join(tmp, "audit.log"),
+      allowNonLinux: true,
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+    const first = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "rollout", request_id: "ro-lock-1", args: { pin: "v0.15.18" } },
+    );
+    expect(first.result).toBe("started");
+
+    // A concurrent update_apply is blocked by the SAME shared lock.
+    const blocked = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "update_apply", request_id: "ro-lock-2", args: {} },
+    );
+    expect(blocked.result).toBe("denied");
+    expect(blocked.error).toMatch(/fleet-mutation lock held/);
+    expect(blocked.error).toMatch(/ro-lock-1/);
+
+    await new Promise((r) => setTimeout(r, 1500));
+  });
+
   // ── Phase 3 admin observability — agent_logs / agent_exec ─────────────
   it("agent_logs: shells out to docker and returns stdout_tail (admin cross-agent)", async () => {
     // Swap to a "docker" stub that echoes its argv so we can assert
@@ -1518,5 +1702,165 @@ describe("hostd server — dashboard read-ops (agent_status / agent_schedule)", 
       { v: 1, op: "agent_schedule", request_id: "ro-sc-3", args: {} },
     );
     expect(resp.result).toBe("denied");
+  });
+});
+
+// ── #2487 item 7 — orphaned-`started`-row reconcile guard on boot ─────────
+describe("hostd server — orphaned-started-row reconcile (#2487)", () => {
+  let otmp: string;
+  let ostub: string;
+  let auditPath: string;
+
+  function seedRow(row: Record<string, unknown>): void {
+    appendFileSync(auditPath, JSON.stringify(row) + "\n");
+  }
+
+  function readRows(): Record<string, unknown>[] {
+    return readFileSync(auditPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+  }
+
+  beforeEach(() => {
+    otmp = mkdtempSync(join(tmpdir(), "hostd-orphan-"));
+    ostub = join(otmp, "stub.sh");
+    writeFileSync(ostub, `#!/bin/sh\nexit 0\n`);
+    chmodSync(ostub, 0o755);
+    auditPath = join(otmp, "audit.log");
+  });
+
+  afterEach(async () => {
+    if (server) await server.stop();
+    rmSync(otmp, { recursive: true, force: true });
+  });
+
+  async function bootServer(): Promise<void> {
+    server = new HostdServer({
+      homeDir: otmp,
+      agentUids: { klanker: 10001 },
+      config: { agents: { klanker: { admin: true } } },
+      switchroomBin: ostub,
+      auditLogPath: auditPath,
+      allowNonLinux: true,
+    });
+    await server.start();
+  }
+
+  it("emits a rollout_orphaned terminal row for a stale rollout `started` with no terminal", async () => {
+    const old = new Date(Date.now() - 30 * 60 * 1000).toISOString(); // 30m ago
+    seedRow({
+      ts: old,
+      op: "rollout",
+      caller: { kind: "agent", name: "klanker" },
+      request_id: "orphan-1",
+      result: "started",
+      exit_code: null,
+      duration_ms: 0,
+    });
+
+    await bootServer();
+
+    const synth = readRows().find(
+      (r) => r.request_id === "orphan-1" && r.phase === "orphan_reconciled",
+    );
+    expect(synth).toBeDefined();
+    expect(synth!.op).toBe("rollout_orphaned");
+    expect(synth!.result).toBe("error");
+    expect(synth!.original_op).toBe("rollout");
+  });
+
+  it("emits update_failed for a stale update_apply orphan", async () => {
+    const old = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    seedRow({
+      ts: old,
+      op: "update_apply",
+      caller: { kind: "operator" },
+      request_id: "orphan-ua",
+      result: "started",
+      exit_code: null,
+      duration_ms: 0,
+    });
+
+    await bootServer();
+
+    const synth = readRows().find(
+      (r) => r.request_id === "orphan-ua" && r.phase === "orphan_reconciled",
+    );
+    expect(synth).toBeDefined();
+    expect(synth!.op).toBe("update_failed");
+  });
+
+  it("does NOT flag a started row that already has a terminal row", async () => {
+    const old = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    seedRow({
+      ts: old,
+      op: "rollout",
+      caller: { kind: "agent", name: "klanker" },
+      request_id: "done-1",
+      result: "started",
+      exit_code: null,
+      duration_ms: 0,
+    });
+    seedRow({
+      ts: old,
+      op: "rollout",
+      phase: "terminal",
+      caller: { kind: "agent", name: "klanker" },
+      request_id: "done-1",
+      result: "completed",
+      exit_code: 0,
+      duration_ms: 1000,
+    });
+
+    await bootServer();
+
+    const synth = readRows().find(
+      (r) => r.request_id === "done-1" && r.phase === "orphan_reconciled",
+    );
+    expect(synth).toBeUndefined();
+  });
+
+  it("does NOT flag a started row that is too fresh (< 15m)", async () => {
+    const recent = new Date(Date.now() - 60 * 1000).toISOString(); // 1m ago
+    seedRow({
+      ts: recent,
+      op: "rollout",
+      caller: { kind: "agent", name: "klanker" },
+      request_id: "fresh-1",
+      result: "started",
+      exit_code: null,
+      duration_ms: 0,
+    });
+
+    await bootServer();
+
+    const synth = readRows().find(
+      (r) => r.request_id === "fresh-1" && r.phase === "orphan_reconciled",
+    );
+    expect(synth).toBeUndefined();
+  });
+
+  it("is idempotent — a second boot does NOT re-emit for an already-reconciled orphan", async () => {
+    const old = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    seedRow({
+      ts: old,
+      op: "rollout",
+      caller: { kind: "agent", name: "klanker" },
+      request_id: "orphan-idem",
+      result: "started",
+      exit_code: null,
+      duration_ms: 0,
+    });
+
+    await bootServer();
+    await server.stop();
+    await bootServer(); // second boot
+
+    const synthRows = readRows().filter(
+      (r) => r.request_id === "orphan-idem" && r.phase === "orphan_reconciled",
+    );
+    expect(synthRows).toHaveLength(1); // exactly one, not two
   });
 });

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -710,6 +710,11 @@ describe("scaffoldAgent", () => {
       "mcp__hostd__agent_start",
       "mcp__hostd__agent_stop",
       "mcp__hostd__agent_logs",
+      // #2487: the safe staggered rollout is mutating + a more surgical
+      // abuse surface (--agents + arbitrary --pin) than update_apply, so
+      // it MUST stay out of the pre-approved set — every agent call
+      // surfaces a Telegram approval card.
+      "mcp__hostd__rollout",
     ]) {
       expect(allow).not.toContain(verb);
     }


### PR DESCRIPTION
Fixes #2487 (PR1 scope — fleet-only, canary-gated).

## Summary

Exposes `mcp__hostd__rollout` — the staggered canary + per-agent version-assert + stop-on-mismatch fleet deploy (`switchroom rollout`) — over the host-control wire so an admin agent gets the SAFE sequence, not just the blunt all-at-once `update_apply`. Gated by the operator Telegram tap (deliberately omitted from `HOSTD_MCP_TOOLS`, so every call surfaces an approval card).

This was designed + adversarially reviewed before build; the review found the naive write path unsafe (two brick scenarios). Both are mitigated here.

## PR1 scope items (1–9)

1. **New `rollout` MCP verb** — semver-only `pin` (sha- rejected at the wire so the roll doesn't stop on agent #1), `agents?`, `skip_web?`. Returns `started`, default 10s wire. Kept OUT of `HOSTD_MCP_TOOLS`.
2. **Protocol** — `RolloutRequestSchema` + union member + `RolloutRequest` type export.
3. **Gate** — `rollout` added to the admin+operator fleet-mutation gate; fleet-mutation lock union widened to include `"rollout"`.
4. **`handleRollout`** — modeled on `handleUpdateApply` (reuses lock + apply-asset preflight) but preserves `RolloutResult.{rolled,failedStep,failedAgent}` into STRUCTURED status fields (parsed from a stdout sentinel), surfaced via `get_status` `payload` + the terminal audit row — NOT flattened into a stdout tail.
5. **Persist pin AFTER canary success** — inverted ordering gated by a `SWITCHROOM_HOSTD_CONTEXT` sentinel; host-shell path keeps persist-first deliberately. Canary rolls on a one-shot `apply --pin`; durable pin written only once the canary confirms; then the rest roll. (Brick scenario #2.)
6. **Defer hostd/web self-refresh on the MCP path** — an agent-invoked rollout cannot synchronously recreate its own hostd container (it would SIGKILL the in-flight rollout, hostd's own child). Fleet-agent roll only; reports "hostd/web refresh deferred — run host-side." (Brick scenario #1.)
7. **Orphaned-`started`-row reconcile guard on boot** — scans for stale fleet-mutation `started` rows with no terminal row (>15m) and emits a loud `rollout_orphaned`/`update_failed` audit row (idempotent across reboots).
8. **In-container exec gating** — suppresses "Run with sudo" guidance under hostd context; skips (rather than mis-chowns) the `persistPin` chown-back when `resolveOperatorUid()` can't resolve, so switchroom.yaml is never left root-owned.
9. **Reject downgrade pins on the agent path** — first real caller for `compareReleaseTags`; rollback stays a PR2 operator-tapped verb.

PR2 items (rollback verb, auto-watcher repoint) are explicitly NOT in this PR.

## Test plan

- `src/cli/rollout.test.ts` — hostd-context plan ordering (persist-after-canary), web/hostd deferral, exec one-shot `--pin`, failed-canary-no-persist, structured-result sentinel round-trip.
- `src/mcp/hostd/server.test.ts` — rollout dispatch, semver-only sha rejection, missing/empty-agents rejection, TOOLS list.
- `tests/host-control/server.test.ts` — admin gate, wire sha rejection, started+structured surfacing, failed-canary surfacing, shared fleet-mutation lock, orphaned-row recovery (emit/skip-terminal/skip-fresh/idempotent).
- `tests/scaffold.test.ts` — `mcp__hostd__rollout` HOSTD_MCP_TOOLS-omission invariant.

`tsc --noEmit` is green. The targeted vitest files pass except for tests whose stubs spawn a subprocess — those fail in the sandboxed CI runner used here with `spawn … EACCES`, an environmental block that ALSO fails the identical pre-existing `update_apply`/`apply`/`config_propose_edit` subprocess tests on clean `origin/main`. The pure-logic + schema + gate + orphan-reconcile tests (which don't spawn) all pass.

## Risk

The verb is admin-gated at the wire AND omitted from the pre-approved tool set, so every invocation requires an operator tap. The two brick scenarios from review are mitigated. The host-shell `switchroom rollout` behavior is unchanged (new ordering gated behind the explicit `SWITCHROOM_HOSTD_CONTEXT` sentinel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)