### PR TITLE
fix: quota display accuracy (refill-aware, honest summary, recoverable exhaustion) (#2494)

### DIFF
--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -155,6 +155,14 @@ export interface LastQuotaSnapshot {
   overageDisabledReason: string | null;
   /** Unix ms when this snapshot was captured by the broker. */
   capturedAt: number;
+  /**
+   * #2494 Bug C — which utilization windows were actually present in the probe
+   * headers. Optional: a snapshot that predates the field (or a real probe
+   * that measured 0%) leaves them unset, which is read as "present". A thin
+   * probe (both explicitly false) renders as `unknown`, never a confident 0%.
+   */
+  fiveHourUtilPresent?: boolean;
+  sevenDayUtilPresent?: boolean;
 }
 
 export interface AccountState {
@@ -218,6 +226,9 @@ export interface ProbeQuotaEntry {
           representativeClaim: string | null;
           overageStatus: string | null;
           overageDisabledReason: string | null;
+          // #2494 Bug C — header-presence markers (see LastQuotaSnapshot).
+          fiveHourUtilPresent?: boolean;
+          sevenDayUtilPresent?: boolean;
         };
       }
     | { ok: false; reason: string };

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -185,6 +185,9 @@ interface LastQuotaEntry {
   overageDisabledReason: string | null;
   /** Unix ms when this snapshot was captured. */
   capturedAt: number;
+  /** #2494 Bug C — which util windows were present in the probe headers. */
+  fiveHourUtilPresent?: boolean;
+  sevenDayUtilPresent?: boolean;
 }
 
 interface LastQuotaCache {
@@ -1296,6 +1299,8 @@ export class AuthBroker {
       overageStatus: result.data.overageStatus,
       overageDisabledReason: result.data.overageDisabledReason,
       capturedAt: this.now(),
+      fiveHourUtilPresent: result.data.fiveHourUtilPresent,
+      sevenDayUtilPresent: result.data.sevenDayUtilPresent,
     };
     this.lastQuotaCache[label] = snapshot;
     // Self-heal: a fresh, clearly-healthy probe (both windows well under the

--- a/src/auth/quota.ts
+++ b/src/auth/quota.ts
@@ -48,7 +48,34 @@ export type QuotaUtilization = {
   representativeClaim: string | null;
   overageStatus: string | null;
   overageDisabledReason: string | null;
+  /**
+   * #2494 Bug C — header-presence markers. The two utilization fields are
+   * always numeric (a missing header coalesces to 0 for back-compat), so on
+   * their own they cannot distinguish "genuinely 0% used" from "the probe
+   * came back thin / headerless and we filled 0". These flags carry that
+   * distinction so renderers can show `unknown` for an absent window instead
+   * of a confident `0%`. Optional (default-true semantics) so cached
+   * snapshots / hand-built fixtures that predate the field still read as a
+   * real probe — a snapshot that genuinely measured 0% leaves them unset.
+   */
+  fiveHourUtilPresent?: boolean;
+  sevenDayUtilPresent?: boolean;
 };
+
+/**
+ * #2494 Bug C — is this probe "thin" (no real utilization signal)? True only
+ * when BOTH windows are explicitly marked absent. A probe with at least one
+ * present window (the existing "7d missing, 5h present" case) is NOT thin.
+ * When the markers are unset (cached snapshot / legacy fixture) we treat the
+ * probe as real, never thin — absence of the flag means "predates the flag",
+ * not "headerless".
+ */
+export function isProbeThin(q: {
+  fiveHourUtilPresent?: boolean;
+  sevenDayUtilPresent?: boolean;
+}): boolean {
+  return q.fiveHourUtilPresent === false && q.sevenDayUtilPresent === false;
+}
 
 export type QuotaResult =
   | { ok: true; data: QuotaUtilization }
@@ -92,14 +119,69 @@ export function parseQuotaHeaders(headers: Headers): QuotaResult {
   return {
     ok: true,
     data: {
+      // #2494 Bug C — we still coalesce a missing window header to 0 so the
+      // numeric fields stay non-null for back-compat, but record which
+      // windows were actually present so renderers can tell a real 0% from a
+      // filled-0. (Both-absent already returned ok:false above, so at least
+      // one of these is true here.)
       fiveHourUtilizationPct: (fiveHour ?? 0) * 100,
       sevenDayUtilizationPct: (sevenDay ?? 0) * 100,
+      fiveHourUtilPresent: fiveHour != null,
+      sevenDayUtilPresent: sevenDay != null,
       fiveHourResetAt: parseEpochHeader(headers, "anthropic-ratelimit-unified-5h-reset"),
       sevenDayResetAt: parseEpochHeader(headers, "anthropic-ratelimit-unified-7d-reset"),
       representativeClaim: headers.get("anthropic-ratelimit-unified-representative-claim"),
       overageStatus: headers.get("anthropic-ratelimit-unified-overage-status"),
       overageDisabledReason: headers.get("anthropic-ratelimit-unified-overage-disabled-reason"),
     },
+  };
+}
+
+// ── #2494 Bug A — refill-aware utilization normalization ──────────────────
+//
+// A cached/probed snapshot carries its window RESET timestamps alongside the
+// utilization. When `now` has crossed a window's reset, that window has rolled
+// since capture and its old utilization is stale — the window is empty again.
+// Every classifier (card `classifyHealth`, `auth schedule` `classifyState`,
+// the fleet `recommendation`) must read through this normalization so a
+// just-refilled account self-corrects across the refill boundary with zero
+// extra probes, regardless of snapshot age.
+
+export interface RefillNormalizedUtils {
+  fiveHourUtilizationPct: number;
+  sevenDayUtilizationPct: number;
+  /** True when the 5h window's reset has passed (treated as refilled → 0%). */
+  fiveHourRefilled: boolean;
+  /** True when the 7d window's reset has passed (treated as refilled → 0%). */
+  sevenDayRefilled: boolean;
+}
+
+/**
+ * Given a snapshot's per-window utilization + reset timestamps and the
+ * current clock, return utilization normalized for refills: any window whose
+ * `resetAt` is non-null and `<= now` is treated as `0%` (the window rolled
+ * after the snapshot was captured). Windows without a reset timestamp, or
+ * whose reset is still in the future, pass through unchanged.
+ */
+export function refillNormalizedUtils(
+  q: {
+    fiveHourUtilizationPct: number;
+    sevenDayUtilizationPct: number;
+    fiveHourResetAt: Date | null;
+    sevenDayResetAt: Date | null;
+  },
+  now: Date,
+): RefillNormalizedUtils {
+  const nowMs = now.getTime();
+  const fiveHourRefilled =
+    q.fiveHourResetAt != null && q.fiveHourResetAt.getTime() <= nowMs;
+  const sevenDayRefilled =
+    q.sevenDayResetAt != null && q.sevenDayResetAt.getTime() <= nowMs;
+  return {
+    fiveHourUtilizationPct: fiveHourRefilled ? 0 : q.fiveHourUtilizationPct,
+    sevenDayUtilizationPct: sevenDayRefilled ? 0 : q.sevenDayUtilizationPct,
+    fiveHourRefilled,
+    sevenDayRefilled,
   };
 }
 

--- a/src/cli/auth-schedule.test.ts
+++ b/src/cli/auth-schedule.test.ts
@@ -30,6 +30,8 @@ const NONE: WindowSnapshot = {
   weeklyResetAt: null,
   source: "none",
   overageServeBlocking: false,
+  overageReason: null,
+  probeThin: false,
 };
 
 describe("formatDuration", () => {
@@ -169,6 +171,109 @@ describe("classifyState — the 5h-vs-weekly distinction", () => {
         now: NOW,
       }),
     ).toBe("healthy");
+  });
+
+  // ── #2494 Bug A — refill-aware classification ──────────────────────────
+  it("Bug A: a pre-refill snapshot read AFTER its 5h reset → healthy", () => {
+    // Snapshot captured at 100% on a 5h window whose reset is 5 min IN THE PAST
+    // relative to `now`: the window has rolled, so it must read healthy.
+    const pastReset = new Date(NOW.getTime() - 5 * 60_000);
+    expect(
+      classifyState({
+        exhausted: true,
+        exhaustedUntil: pastReset,
+        window: win({ fiveHourPct: 100, fiveHourResetAt: pastReset, weeklyPct: 1, source: "live" }),
+        now: NOW,
+      }),
+    ).toBe("healthy");
+  });
+
+  it("Bug A: a maxed weekly whose reset has PASSED → healthy (window refilled)", () => {
+    const pastWeekly = new Date(NOW.getTime() - 60_000);
+    expect(
+      classifyState({
+        exhausted: false,
+        exhaustedUntil: null,
+        window: win({ weeklyPct: 100, weeklyResetAt: pastWeekly, fiveHourPct: 2, source: "live" }),
+        now: NOW,
+      }),
+    ).toBe("healthy");
+  });
+
+  // ── #2494 Bug C — recoverable quota-exhausted vs billing-dead ──────────
+  it("Bug C: maxed 5h with a FUTURE reset → quota-exhausted (recoverable), NOT out-of-credits", () => {
+    expect(
+      classifyState({
+        exhausted: false,
+        exhaustedUntil: null,
+        window: win({ fiveHourPct: 100, fiveHourResetAt: FIVE_RESET, weeklyPct: 10, source: "live" }),
+        now: NOW,
+      }),
+    ).toBe("quota-exhausted");
+  });
+
+  it("Bug C: out_of_credits (billing-dead) is distinct from quota-exhausted", () => {
+    // Same maxed 5h window, but a serve-blocking overage reason: billing-dead wins.
+    expect(
+      classifyState({
+        exhausted: false,
+        exhaustedUntil: null,
+        window: win({
+          fiveHourPct: 100,
+          fiveHourResetAt: FIVE_RESET,
+          overageServeBlocking: true,
+          overageReason: "out_of_credits",
+        }),
+        now: NOW,
+      }),
+    ).toBe("out-of-credits");
+  });
+
+  it("Bug C: a thin/headerless probe → unprobed (renders unknown), never a confident 0%", () => {
+    expect(
+      classifyState({
+        exhausted: false,
+        exhaustedUntil: null,
+        window: win({ fiveHourPct: 0, weeklyPct: 0, source: "live", probeThin: true }),
+        now: NOW,
+      }),
+    ).toBe("unprobed");
+  });
+});
+
+describe("#2494 — formatStateCell quota-exhausted vs billing-dead, cells refill/thin-aware", () => {
+  const baseRow = (window: WindowSnapshot, state: ScheduleRow["state"]): ScheduleRow => ({
+    label: "x",
+    isActive: false,
+    fallbackRank: 2,
+    window,
+    exhausted: false,
+    exhaustedUntil: null,
+    state,
+  });
+
+  it("quota-exhausted shows a 5h reset countdown", () => {
+    const cell = formatStateCell(
+      baseRow(
+        { ...NONE, fiveHourPct: 100, fiveHourResetAt: FIVE_RESET, source: "live" },
+        "quota-exhausted",
+      ),
+      NOW,
+    );
+    expect(cell).toContain("quota-exhausted");
+    expect(cell).toMatch(/\d+[hm]/); // has a countdown
+  });
+
+  it("thin probe renders 5h/weekly cells as 'unknown', not 0%", () => {
+    const w: WindowSnapshot = { ...NONE, fiveHourPct: 0, weeklyPct: 0, source: "live", probeThin: true };
+    expect(formatFiveHourCell(w, NOW)).toBe("unknown");
+    expect(formatWeeklyCell(w, NOW)).toBe("unknown");
+  });
+
+  it("refilled 5h cell reads 0% even when the snapshot captured 100%", () => {
+    const pastReset = new Date(NOW.getTime() - 60_000);
+    const w: WindowSnapshot = { ...NONE, fiveHourPct: 100, fiveHourResetAt: pastReset, source: "live" };
+    expect(formatFiveHourCell(w, NOW)).toContain("0%");
   });
 });
 
@@ -320,6 +425,8 @@ describe("formatStateCell horizon", () => {
         weeklyResetAt: new Date("2026-06-09T19:00:00Z"),
         source: "live",
         overageServeBlocking: false,
+        overageReason: null,
+        probeThin: false,
       },
       exhausted: true,
       exhaustedUntil: new Date("2026-06-07T06:27:00Z"),
@@ -331,17 +438,28 @@ describe("formatStateCell horizon", () => {
     expect(cell).not.toContain("27m");
   });
 
-  it("renders the out-of-credits state (no countdown horizon)", () => {
+  it("renders the out-of-credits state as billing-dead with the real reason (no timer)", () => {
+    // #2494 Bug C — billing-dead renders "billing disabled (<reason>)", NOT a
+    // countdown: it does not recover on a window roll.
     const row: ScheduleRow = {
       label: "x",
       isActive: false,
       fallbackRank: 2,
-      window: { ...NONE, fiveHourPct: 0, weeklyPct: 0, source: "live", overageServeBlocking: true },
+      window: {
+        ...NONE,
+        fiveHourPct: 0,
+        weeklyPct: 0,
+        source: "live",
+        overageServeBlocking: true,
+        overageReason: "out_of_credits",
+      },
       exhausted: false,
       exhaustedUntil: null,
       state: "out-of-credits",
     };
-    expect(formatStateCell(row, NOW)).toBe("out-of-credits");
+    const cell = formatStateCell(row, NOW);
+    expect(cell).toBe("billing disabled (out_of_credits)");
+    expect(cell).not.toMatch(/\d+[dhm]/); // no countdown
   });
 });
 

--- a/src/cli/auth-schedule.ts
+++ b/src/cli/auth-schedule.ts
@@ -33,6 +33,7 @@ import type {
   ProbeQuotaData,
 } from "../auth/broker/client.js";
 import { SERVE_BLOCKING_OVERAGE_REASONS } from "../auth/broker/account-eligibility.js";
+import { refillNormalizedUtils } from "../auth/quota.js";
 
 // ─── Pure model ──────────────────────────────────────────────────────────
 
@@ -50,6 +51,18 @@ export interface WindowSnapshot {
    * REASONS); `org_level_disabled` / null / unknown are benign → false.
    */
   overageServeBlocking: boolean;
+  /**
+   * #2494 Bug C — the live overage-disabled reason carried by the probe/cache,
+   * when serve-blocking. Surfaced verbatim by the renderer so a billing-dead
+   * account names the real reason ("out_of_credits"), not just a state word.
+   */
+  overageReason: string | null;
+  /**
+   * #2494 Bug C — true when the probe came back thin/headerless (no real
+   * utilization signal). Distinct from a genuine 0% so the renderer can show
+   * "unknown" rather than a confident "0%".
+   */
+  probeThin: boolean;
 }
 
 /** Is a probe/cache overage reason serve-blocking? Mirrors the broker's
@@ -60,6 +73,10 @@ function overageReasonBlocks(reason: string | null | undefined): boolean {
 
 export type AccountWindowState =
   | "out-of-credits"
+  // #2494 Bug C — recoverable quota exhaustion: a util window is maxed but the
+  // account comes back when that window rolls. Distinct from the terminal
+  // billing-dead "out-of-credits"; carries a reset countdown.
+  | "quota-exhausted"
   | "healthy"
   | "5h-walled"
   | "weekly-walled"
@@ -95,6 +112,8 @@ export function resolveWindow(
       weeklyResetAt: d.sevenDayResetAt,
       source: "live",
       overageServeBlocking: overageReasonBlocks(d.overageDisabledReason),
+      overageReason: d.overageDisabledReason ?? null,
+      probeThin: isThin(d),
     };
   }
   const lq = account.last_quota;
@@ -106,6 +125,8 @@ export function resolveWindow(
       weeklyResetAt: lq.sevenDayResetAt ? new Date(lq.sevenDayResetAt) : null,
       source: "cached",
       overageServeBlocking: overageReasonBlocks(lq.overageDisabledReason),
+      overageReason: lq.overageDisabledReason ?? null,
+      probeThin: isThin(lq),
     };
   }
   return {
@@ -115,7 +136,20 @@ export function resolveWindow(
     weeklyResetAt: null,
     source: "none",
     overageServeBlocking: false,
+    overageReason: null,
+    probeThin: false,
   };
+}
+
+/**
+ * #2494 Bug C — a probe is thin when BOTH window utilization headers were
+ * explicitly absent. Markers unset (legacy snapshot / fixture) → not thin.
+ */
+function isThin(d: {
+  fiveHourUtilPresent?: boolean;
+  sevenDayUtilPresent?: boolean;
+}): boolean {
+  return d.fiveHourUtilPresent === false && d.sevenDayUtilPresent === false;
 }
 
 /**
@@ -131,11 +165,28 @@ export function classifyState(args: {
   now: Date;
 }): AccountWindowState {
   const { exhausted, exhaustedUntil, window, now } = args;
-  // A serve-blocking overage (out_of_credits) means the account is dead even at
-  // 0% util — it wins over every util-based verdict (healthy/weekly/5h). Same
-  // strict-allowlist semantics as the broker; org_level_disabled is benign and
-  // never sets window.overageServeBlocking.
+  // #2494 Bug C — a serve-blocking overage (out_of_credits) means the account
+  // is billing-dead even at 0% util — it wins over every util-based verdict.
+  // This is genuine "out-of-credits": NOT a timer, recovers only when billing
+  // is fixed. Same strict-allowlist semantics as the broker.
   if (window.overageServeBlocking) return "out-of-credits";
+  // #2494 Bug C — a thin/headerless probe carries no real utilization; it must
+  // not pose as a confident reading. Treat as unprobed (renders "unknown").
+  if (window.probeThin) return "unprobed";
+  // #2494 Bug A — read utilization through refill normalization: a window
+  // whose reset has already passed has rolled since capture, so its stale high
+  // util is treated as 0%. A just-refilled account self-corrects to healthy.
+  const norm = refillNormalizedUtils(
+    {
+      fiveHourUtilizationPct: window.fiveHourPct ?? 0,
+      sevenDayUtilizationPct: window.weeklyPct ?? 0,
+      fiveHourResetAt: window.fiveHourResetAt,
+      sevenDayResetAt: window.weeklyResetAt,
+    },
+    now,
+  );
+  const fivePct = window.fiveHourPct === null ? null : norm.fiveHourUtilizationPct;
+  const weeklyPct = window.weeklyPct === null ? null : norm.sevenDayUtilizationPct;
   const hasWindowData =
     window.fiveHourPct !== null ||
     window.weeklyPct !== null ||
@@ -145,13 +196,24 @@ export function classifyState(args: {
   // ledger: even when `exhausted_until` points at a sooner 5h reset, once that
   // 5h window clears the weekly cap still blocks the account until its (days-
   // away) reset. So a near-100% weekly takes precedence over "5h-walled".
+  // (Refill-normalized weeklyPct is already 0 once the weekly reset passes.)
   if (
-    window.weeklyPct !== null &&
-    window.weeklyPct >= WEEKLY_WALL_PCT &&
+    weeklyPct !== null &&
+    weeklyPct >= WEEKLY_WALL_PCT &&
     window.weeklyResetAt !== null &&
     window.weeklyResetAt.getTime() > now.getTime()
   ) {
     return "weekly-walled";
+  }
+  // #2494 Bug C — a maxed 5h window with a future reset is recoverable quota
+  // exhaustion (comes back when the window rolls), distinct from billing-dead.
+  if (
+    fivePct !== null &&
+    fivePct >= WEEKLY_WALL_PCT &&
+    window.fiveHourResetAt !== null &&
+    window.fiveHourResetAt.getTime() > now.getTime()
+  ) {
+    return "quota-exhausted";
   }
   if (!exhausted) {
     // No exhaustion ledger AND no probe/cache data → we genuinely don't know.
@@ -232,19 +294,29 @@ export function formatResetDay(d: Date, tz?: string): string {
   return `${dow} ${hm}`;
 }
 
-/** 5h cell, raw (uncolored): "40% · 1h 2m" or "—". */
+/** 5h cell, raw (uncolored): "40% · 1h 2m", "unknown", or "—".
+ *  #2494 — refill-aware (a passed reset reads 0%) and thin-aware. */
 export function formatFiveHourCell(w: WindowSnapshot, now: Date): string {
+  if (w.probeThin) return "unknown";
   if (w.fiveHourPct === null) return EM_DASH;
+  const refilled =
+    w.fiveHourResetAt !== null && w.fiveHourResetAt.getTime() <= now.getTime();
+  const pct = refilled ? 0 : w.fiveHourPct;
   const reset = w.fiveHourResetAt
     ? ` · ${formatDuration(w.fiveHourResetAt.getTime() - now.getTime())}`
     : "";
-  return `${Math.round(w.fiveHourPct)}%${reset}`;
+  return `${Math.round(pct)}%${reset}`;
 }
 
-/** Weekly cell, raw (uncolored): "8% · Sun 11:00 (5d 3h)" or "—". */
+/** Weekly cell, raw (uncolored): "8% · Sun 11:00 (5d 3h)", "unknown", or "—".
+ *  #2494 — refill-aware and thin-aware. */
 export function formatWeeklyCell(w: WindowSnapshot, now: Date, tz?: string): string {
+  if (w.probeThin) return "unknown";
   if (w.weeklyPct === null && w.weeklyResetAt === null) return EM_DASH;
-  const pct = w.weeklyPct === null ? EM_DASH : `${Math.round(w.weeklyPct)}%`;
+  const refilled =
+    w.weeklyResetAt !== null && w.weeklyResetAt.getTime() <= now.getTime();
+  const pct =
+    w.weeklyPct === null ? EM_DASH : `${Math.round(refilled ? 0 : w.weeklyPct)}%`;
   if (!w.weeklyResetAt) return pct;
   const rel = formatDuration(w.weeklyResetAt.getTime() - now.getTime());
   return `${pct} · ${formatResetDay(w.weeklyResetAt, tz)} (${rel})`;
@@ -264,15 +336,22 @@ export function formatStateCell(row: ScheduleRow, now: Date): string {
   const horizon =
     row.state === "weekly-walled"
       ? (row.window.weeklyResetAt ?? row.exhaustedUntil)
-      : row.state === "5h-walled"
+      : row.state === "5h-walled" || row.state === "quota-exhausted"
         ? (row.window.fiveHourResetAt ?? row.exhaustedUntil)
         : row.exhaustedUntil;
   const rel = horizon ? ` · ${formatDuration(horizon.getTime() - now.getTime())}` : "";
   switch (row.state) {
     case "out-of-credits":
-      // No util-window reset to count down to — overage is off until billing
-      // is fixed, not until a window rolls. State name carries the meaning.
-      return "out-of-credits";
+      // #2494 Bug C — billing-dead. No util-window reset to count down to —
+      // overage is off until billing is fixed, not until a window rolls. Name
+      // the real reason so it reads distinctly from a recoverable exhaustion.
+      return row.window.overageReason
+        ? `billing disabled (${row.window.overageReason})`
+        : "billing disabled";
+    case "quota-exhausted":
+      // #2494 Bug C — recoverable: comes back when the 5h window rolls. Carries
+      // the reset countdown, unlike the terminal billing-dead state above.
+      return `quota-exhausted${rel}`;
     case "healthy":
       return "healthy";
     case "unprobed":
@@ -313,6 +392,9 @@ function colorState(text: string, state: AccountWindowState, color: boolean): st
       return chalk.red(text);
     case "weekly-walled":
       return chalk.red(text);
+    case "quota-exhausted":
+      // Recoverable — amber, not the terminal red of billing-dead.
+      return chalk.yellow(text);
     case "5h-walled":
       return chalk.yellow(text);
     default:

--- a/telegram-plugin/auth-snapshot-format.ts
+++ b/telegram-plugin/auth-snapshot-format.ts
@@ -19,6 +19,7 @@
  */
 
 import type { QuotaResult, QuotaUtilization } from './quota-check.js';
+import { isProbeThin, refillNormalizedUtils } from '../src/auth/quota.js';
 import type { AccountState, LastQuotaSnapshot, ListStateData } from '../src/auth/broker/client.js';
 
 // ── shared types ─────────────────────────────────────────────────────
@@ -84,19 +85,48 @@ const SERVE_BLOCKING_OVERAGE_REASONS = new Set<string>(['out_of_credits']);
  *   - everything else → healthy
  *   - probe failure → unknown
  */
-export function classifyHealth(snap: AccountSnapshot): AccountHealth {
+export function classifyHealth(snap: AccountSnapshot, now: Date = new Date()): AccountHealth {
   if (!snap.quota) return 'unknown';
   const q = snap.quota;
+  // #2494 Bug C — a thin/headerless probe (no real utilization signal on
+  // EITHER window) must not masquerade as a confident 0% / healthy. Treat it
+  // as unknown so the card surfaces a data-quality gap, not "healthy".
+  if (isProbeThin(q)) return 'unknown';
   // A serve-blocking overage reason wins over the util gate: a credits-dead
   // account reads 0% util but 429s on every call, so it must show 'blocked'
   // (drives the display, quota-watch, and the auto-fallback idempotency guard).
   if (q.overageDisabledReason != null && SERVE_BLOCKING_OVERAGE_REASONS.has(q.overageDisabledReason)) {
     return 'blocked';
   }
-  const max = Math.max(q.fiveHourUtilizationPct, q.sevenDayUtilizationPct);
+  // #2494 Bug A — read utilization through the refill normalization: a window
+  // whose reset has already passed has rolled since the snapshot was captured,
+  // so its stale high utilization must be treated as 0%. A just-refilled
+  // account self-corrects to healthy without an extra probe.
+  const norm = refillNormalizedUtils(q, now);
+  const max = Math.max(norm.fiveHourUtilizationPct, norm.sevenDayUtilizationPct);
   if (max >= 99.5) return 'blocked';
   if (max >= THROTTLING_THRESHOLD_PCT) return 'throttling';
   return 'healthy';
+}
+
+/**
+ * #2494 Bug C — why is a BLOCKED account blocked? Two materially different
+ * causes that the card must render distinctly:
+ *   - 'billing-dead' — a genuine serve-blocking `overageDisabledReason`
+ *     (out_of_credits). NOT a timer: it stays dead until billing is fixed.
+ *   - 'quota-exhausted' — a util window is maxed but recovers when that window
+ *     rolls. Show the reset countdown.
+ * Returns null for non-blocked accounts.
+ */
+export type BlockedReason = 'billing-dead' | 'quota-exhausted';
+
+export function blockedReason(snap: AccountSnapshot, now: Date = new Date()): BlockedReason | null {
+  if (classifyHealth(snap, now) !== 'blocked') return null;
+  const q = snap.quota!;
+  if (q.overageDisabledReason != null && SERVE_BLOCKING_OVERAGE_REASONS.has(q.overageDisabledReason)) {
+    return 'billing-dead';
+  }
+  return 'quota-exhausted';
 }
 
 /**
@@ -232,21 +262,41 @@ function renderAccountRow(
   }
 
   const q = snap.quota;
-  const fiveStr = fmtPct(q.fiveHourUtilizationPct);
-  const sevenStr = fmtPct(q.sevenDayUtilizationPct);
+  // #2494 Bug C — a thin/headerless probe carries no real utilization; render
+  // it as a data-quality gap, never a confident "0% / 0%".
+  if (isProbeThin(q)) {
+    lines.push(
+      `${marker}<code>${escapeHtml(snap.label)}</code>  <i>quota unknown (thin probe)</i>`,
+    );
+    return lines;
+  }
+  // #2494 Bug A — show refill-normalized utilization so a window that has
+  // already reset reads its true post-refill 0%, not the stale capture value.
+  const norm = refillNormalizedUtils(q, now);
+  const fiveStr = fmtPct(norm.fiveHourUtilizationPct);
+  const sevenStr = fmtPct(norm.sevenDayUtilizationPct);
   lines.push(
     `${marker}<code>${escapeHtml(snap.label)}</code>  ${fiveStr} / ${sevenStr}`,
   );
 
-  const health = classifyHealth(snap);
+  const health = classifyHealth(snap, now);
   if (health === 'blocked') {
-    // Surface only the recovery countdown — the binding window's reset
-    // is the only thing that matters until then.
+    const reason = blockedReason(snap, now);
+    if (reason === 'billing-dead') {
+      // #2494 Bug C — billing-dead is NOT a timer. Surface the real reason and
+      // make clear it does not recover on a window roll.
+      lines.push(
+        `  <i>billing disabled (${escapeHtml(q.overageDisabledReason ?? 'out_of_credits')}) — won't recover until billing is fixed</i>`,
+      );
+      return lines;
+    }
+    // quota-exhausted (recoverable): surface only the recovery countdown — the
+    // binding window's reset is the only thing that matters until then.
     const win = bindingWindow(q);
     const reset = win === '5h' ? q.fiveHourResetAt : q.sevenDayResetAt;
     const winLabel = win === '5h' ? '5-hour' : '7-day';
     lines.push(
-      `  <i>back ${formatAbsolute(reset, tz)} (in ${formatRelative(reset, now)}, ${winLabel} cap)</i>`,
+      `  <i>quota exhausted — back ${formatAbsolute(reset, tz)} (in ${formatRelative(reset, now)}, ${winLabel} cap)</i>`,
     );
     return lines;
   }
@@ -300,7 +350,7 @@ export function renderAuthSnapshotFormat2(
   const order: AccountHealth[] = ['blocked', 'throttling', 'healthy', 'unknown'];
   const grouped = new Map<AccountHealth, AccountSnapshot[]>();
   for (const s of snapshots) {
-    const h = classifyHealth(s);
+    const h = classifyHealth(s, now);
     if (!grouped.has(h)) grouped.set(h, []);
     grouped.get(h)!.push(s);
   }
@@ -346,9 +396,9 @@ export function renderAuthSnapshotFormat2(
 export function recommendation(snapshots: AccountSnapshot[], now: Date = new Date()): string {
   const active = snapshots.find((s) => s.isActive);
   if (!active) return 'No active account set.';
-  const activeHealth = classifyHealth(active);
+  const activeHealth = classifyHealth(active, now);
   const others = snapshots.filter((s) => !s.isActive);
-  const healthyAlt = others.find((s) => classifyHealth(s) === 'healthy');
+  const healthyAlt = others.find((s) => classifyHealth(s, now) === 'healthy');
 
   if (activeHealth === 'healthy') {
     return `Recommendation: stay on ${active.label}.`;
@@ -365,18 +415,78 @@ export function recommendation(snapshots: AccountSnapshot[], now: Date = new Dat
     if (healthyAlt) {
       return `Recommendation: active ${active.label} is BLOCKED — switch to ${healthyAlt.label} now.`;
     }
-    // No healthy alternative; surface the earliest recovery time.
-    const earliestRecovery = pickEarliestRecovery(snapshots, now);
-    if (earliestRecovery) {
-      return `All accounts blocked. Earliest recovery: ${earliestRecovery.label} in ${formatRelative(earliestRecovery.at, now)}.`;
-    }
-    return `All accounts blocked. Run /auth add to attach another subscription.`;
+    // #2494 Bug B — no healthy alternative. Do NOT collapse to "All accounts
+    // blocked": that's only honest when EVERY account is truly walled with no
+    // usable or imminently-refilling slot. Distinguish the buckets first.
+    return summarizeNoHealthyAlt(snapshots, now);
   }
 
   // unknown
   return `Active ${active.label}: quota probe failed; broker last_seen unknown.`;
 }
 
+/**
+ * #2494 Bug B — honest fleet summary when the active account is blocked and no
+ * fully-healthy alternative exists. Buckets every account so the summary never
+ * claims "all blocked" while a throttling / imminently-refilling / usable slot
+ * exists. Surfaces the soonest refill ETA across the fleet.
+ */
+function summarizeNoHealthyAlt(snapshots: AccountSnapshot[], now: Date): string {
+  let throttlingLabel: string | null = null;
+  let allTrulyBlocked = true;
+  for (const s of snapshots) {
+    const h = classifyHealth(s, now);
+    if (h === 'throttling') {
+      // A throttling account is still usable.
+      if (!throttlingLabel) throttlingLabel = s.label;
+      allTrulyBlocked = false;
+    } else if (h === 'healthy' || h === 'unknown') {
+      // Healthy is handled by the caller; unknown is not provably blocked.
+      allTrulyBlocked = false;
+    } else if (h === 'blocked' && blockedReason(s, now) === 'quota-exhausted') {
+      // Quota-exhausted recovers WHEN its window rolls — but only counts as
+      // "refilling" (not terminal) if it actually carries a future reset on the
+      // binding window. A maxed window with no reset timestamp has no imminent
+      // recovery and stays in the truly-blocked bucket (Bug B: "blocked = ≥99.5%
+      // AND no imminent reset").
+      if (s.quota) {
+        const win = bindingWindow(s.quota);
+        const at = win === '5h' ? s.quota.fiveHourResetAt : s.quota.sevenDayResetAt;
+        if (at && at.getTime() > now.getTime()) allTrulyBlocked = false;
+      }
+    }
+  }
+
+  const earliestRecovery = pickEarliestRecovery(snapshots, now);
+
+  if (throttlingLabel) {
+    // A usable (throttling) slot exists — recommend it, with the soonest refill.
+    const eta = earliestRecovery
+      ? ` Soonest full refill: ${earliestRecovery.label} in ${formatRelative(earliestRecovery.at, now)}.`
+      : '';
+    return `No fully-healthy account; ${throttlingLabel} is throttling but still usable.${eta}`;
+  }
+
+  if (!allTrulyBlocked) {
+    // No usable slot now, but at least one account is refilling — not all dead.
+    if (earliestRecovery) {
+      return `All accounts at capacity; soonest refill: ${earliestRecovery.label} in ${formatRelative(earliestRecovery.at, now)}.`;
+    }
+    return `All accounts at capacity — waiting on a window refill.`;
+  }
+
+  // Genuinely all blocked (billing-dead with no upcoming reset, or no data).
+  if (earliestRecovery) {
+    return `All accounts blocked. Earliest recovery: ${earliestRecovery.label} in ${formatRelative(earliestRecovery.at, now)}.`;
+  }
+  return `All accounts blocked. Run /auth add to attach another subscription.`;
+}
+
+/**
+ * Earliest refill ETA across the fleet. #2494 Bug A/B — only counts a future
+ * reset on the binding window; a window whose reset has already passed has
+ * refilled (handled by refill normalization) and is not "recovery pending".
+ */
 function pickEarliestRecovery(
   snapshots: AccountSnapshot[],
   now: Date,
@@ -384,6 +494,7 @@ function pickEarliestRecovery(
   let best: { label: string; at: Date } | null = null;
   for (const s of snapshots) {
     if (!s.quota) continue;
+    if (isProbeThin(s.quota)) continue;
     const win = bindingWindow(s.quota);
     const at = win === '5h' ? s.quota.fiveHourResetAt : s.quota.sevenDayResetAt;
     if (!at || at.getTime() <= now.getTime()) continue;
@@ -656,6 +767,10 @@ export function reviveLastQuota(snap: LastQuotaSnapshot | null | undefined): Quo
     representativeClaim: snap.representativeClaim,
     overageStatus: snap.overageStatus,
     overageDisabledReason: snap.overageDisabledReason,
+    // #2494 Bug C — forward the header-presence markers so a cached thin probe
+    // still renders as `unknown`, not a confident 0%.
+    fiveHourUtilPresent: snap.fiveHourUtilPresent,
+    sevenDayUtilPresent: snap.sevenDayUtilPresent,
   };
 }
 

--- a/telegram-plugin/auto-fallback-fleet.ts
+++ b/telegram-plugin/auto-fallback-fleet.ts
@@ -186,7 +186,11 @@ export async function runFleetAutoFallback(
   // Idempotency guard: don't swap a healthy active account, even if
   // the trigger event said quota_exhausted. The event may be stale
   // (event posted, window rolled over, gateway picked it up late).
-  const oldHealth = classifyHealth(oldSnap);
+  // #2494 Bug A — classify against this run's `now` so the refill
+  // normalization uses the same clock as the rest of the decision (a default
+  // `new Date()` would diverge from `deps.now` and could mis-zero a window
+  // whose reset is still future relative to the event's clock).
+  const oldHealth = classifyHealth(oldSnap, now);
   if (oldHealth === 'healthy') {
     return {
       kind: 'no-eligible-target',

--- a/telegram-plugin/quota-check.ts
+++ b/telegram-plugin/quota-check.ts
@@ -54,6 +54,15 @@ export type QuotaUtilization = {
   representativeClaim: string | null;
   overageStatus: string | null;
   overageDisabledReason: string | null;
+  /**
+   * #2494 Bug C — header-presence markers. Mirror of the field in
+   * `src/auth/quota.ts` (kept in sync across the bundle boundary). The
+   * utilization fields are always numeric (a missing header coalesces to 0),
+   * so on their own they cannot tell a genuine 0% from a filled-0 thin probe.
+   * Optional → unset means "real probe" (legacy snapshots / fixtures).
+   */
+  fiveHourUtilPresent?: boolean;
+  sevenDayUtilPresent?: boolean;
 };
 
 export type QuotaResult =
@@ -120,8 +129,12 @@ export function parseQuotaHeaders(headers: Headers): QuotaResult {
   return {
     ok: true,
     data: {
+      // #2494 Bug C — coalesce missing window to 0 for back-compat but record
+      // which windows were actually present (both-absent returned ok:false).
       fiveHourUtilizationPct: (fiveHour ?? 0) * 100,
       sevenDayUtilizationPct: (sevenDay ?? 0) * 100,
+      fiveHourUtilPresent: fiveHour != null,
+      sevenDayUtilPresent: sevenDay != null,
       fiveHourResetAt: parseEpochHeader(headers, "anthropic-ratelimit-unified-5h-reset"),
       sevenDayResetAt: parseEpochHeader(headers, "anthropic-ratelimit-unified-7d-reset"),
       representativeClaim: headers.get("anthropic-ratelimit-unified-representative-claim"),

--- a/telegram-plugin/quota-watch.ts
+++ b/telegram-plugin/quota-watch.ts
@@ -224,7 +224,11 @@ export function evaluateQuotaWatchAccount(args: {
     return { kind: "skip", accountLabel: label, reason: "stale-snapshot" };
   }
 
-  const currentHealth = classifyHealth(snap);
+  // #2494 Bug A — classify against THIS tick's clock so the refill
+  // normalization uses the same `now` the rest of the decision does (the
+  // default `new Date()` would diverge from a frozen test clock / a replayed
+  // tick and mis-zero a still-future reset window).
+  const currentHealth = classifyHealth(snap, new Date(now));
 
   // Unknown (probe failed) or blocked — skip entirely.
   if (currentHealth === "unknown" || currentHealth === "blocked") {

--- a/telegram-plugin/tests/auth-snapshot-format.test.ts
+++ b/telegram-plugin/tests/auth-snapshot-format.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   classifyHealth,
+  blockedReason,
   bindingWindow,
   formatRelative,
   formatAbsolute,
@@ -557,13 +558,26 @@ describe('buildSnapshotsFromCachedState', () => {
 // ── recommendation logic edge cases ──────────────────────────────────
 
 describe('recommendation', () => {
-  it('warns "all blocked" when no healthy alternative exists', () => {
+  it('#2494 Bug B: does NOT say "all blocked" when an alternative is refilling', () => {
+    // a@x is maxed with no reset (truly blocked); b@x is maxed but its weekly
+    // window resets in ~2d (refilling). The honest summary must surface the
+    // refill, not collapse to a false "All accounts blocked".
     const snaps: AccountSnapshot[] = [
       snap({ label: 'a@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 100 }) }),
       snap({ label: 'b@x', quota: quota({ sevenDayUtilizationPct: 100, sevenDayResetAt: new Date('2026-05-17T00:00:00Z') }) }),
     ];
     const out = recommendation(snaps, NOW);
-    expect(out).toMatch(/All accounts blocked\. Earliest recovery: b@x in 1d/);
+    expect(out).not.toContain('All accounts blocked');
+    expect(out).toMatch(/soonest refill: b@x in 1d/);
+  });
+
+  it('#2494 Bug B: says "all blocked" only when EVERY account is truly walled (no reset)', () => {
+    const snaps: AccountSnapshot[] = [
+      snap({ label: 'a@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 100 }) }),
+      snap({ label: 'b@x', quota: quota({ sevenDayUtilizationPct: 100 }) }),
+    ];
+    const out = recommendation(snaps, NOW);
+    expect(out).toContain('All accounts blocked');
   });
 
   it('reports throttling-with-no-alt when active is throttling and others are too', () => {
@@ -573,5 +587,122 @@ describe('recommendation', () => {
     ];
     const out = recommendation(snaps, NOW);
     expect(out).toContain('throttling; no healthy alternative');
+  });
+
+  it('#2494 Bug B: mixed blocked-active + throttling-other → recommends the throttling slot, never "all blocked"', () => {
+    const snaps: AccountSnapshot[] = [
+      snap({ label: 'a@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 100 }) }),
+      snap({ label: 'b@x', quota: quota({ fiveHourUtilizationPct: 85 }) }), // throttling, usable
+    ];
+    const out = recommendation(snaps, NOW);
+    expect(out).not.toContain('All accounts blocked');
+    expect(out).toContain('b@x is throttling but still usable');
+  });
+});
+
+// ── #2494 Bug A — refill-aware classification ───────────────────────────
+
+describe('#2494 Bug A — refill-aware classifyHealth', () => {
+  it('a pre-refill snapshot read AFTER its 5h reset classifies healthy', () => {
+    // Captured at 100% on a 5h window whose reset is 3 min in the PAST → rolled.
+    const pastReset = new Date(NOW.getTime() - 3 * 60_000);
+    const s = snap({
+      isActive: true,
+      quota: quota({ fiveHourUtilizationPct: 100, fiveHourResetAt: pastReset, sevenDayUtilizationPct: 1 }),
+    });
+    expect(classifyHealth(s, NOW)).toBe('healthy');
+  });
+
+  it('a maxed weekly whose reset has PASSED classifies healthy', () => {
+    const pastWeekly = new Date(NOW.getTime() - 60_000);
+    const s = snap({ quota: quota({ sevenDayUtilizationPct: 100, sevenDayResetAt: pastWeekly, fiveHourUtilizationPct: 2 }) });
+    expect(classifyHealth(s, NOW)).toBe('healthy');
+  });
+
+  it('a maxed window with a FUTURE reset still classifies blocked (not yet refilled)', () => {
+    const futureReset = new Date(NOW.getTime() + 60 * 60_000);
+    const s = snap({ quota: quota({ fiveHourUtilizationPct: 100, fiveHourResetAt: futureReset }) });
+    expect(classifyHealth(s, NOW)).toBe('blocked');
+  });
+
+  it('the just-refilled lone active account is not falsely "all blocked" in the summary', () => {
+    const pastReset = new Date(NOW.getTime() - 3 * 60_000);
+    const snaps: AccountSnapshot[] = [
+      snap({ label: 'a@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 100, fiveHourResetAt: pastReset, sevenDayUtilizationPct: 1 }) }),
+    ];
+    expect(recommendation(snaps, NOW)).toContain('stay on a@x');
+  });
+});
+
+// ── #2494 Bug C — quota-exhausted vs billing-dead, thin probe ────────────
+
+describe('#2494 Bug C — blockedReason + thin probe', () => {
+  it('out_of_credits → billing-dead', () => {
+    const s = snap({ quota: quota({ fiveHourUtilizationPct: 0, overageDisabledReason: 'out_of_credits' }) });
+    expect(classifyHealth(s, NOW)).toBe('blocked');
+    expect(blockedReason(s, NOW)).toBe('billing-dead');
+  });
+
+  it('a maxed window (no overage reason) → quota-exhausted (recoverable)', () => {
+    const futureReset = new Date(NOW.getTime() + 30 * 60_000);
+    const s = snap({ quota: quota({ fiveHourUtilizationPct: 100, fiveHourResetAt: futureReset }) });
+    expect(blockedReason(s, NOW)).toBe('quota-exhausted');
+  });
+
+  it('blockedReason is null for a non-blocked account', () => {
+    expect(blockedReason(snap({ quota: quota({ fiveHourUtilizationPct: 10 }) }), NOW)).toBeNull();
+  });
+
+  it('a thin/headerless probe classifies unknown, never a confident 0%/healthy', () => {
+    const s = snap({
+      quota: quota({ fiveHourUtilizationPct: 0, sevenDayUtilizationPct: 0, fiveHourUtilPresent: false, sevenDayUtilPresent: false }),
+    });
+    expect(classifyHealth(s, NOW)).toBe('unknown');
+  });
+
+  it('a real 0%/0% probe (both windows present) stays healthy', () => {
+    const s = snap({
+      quota: quota({ fiveHourUtilizationPct: 0, sevenDayUtilizationPct: 0, fiveHourUtilPresent: true, sevenDayUtilPresent: true }),
+    });
+    expect(classifyHealth(s, NOW)).toBe('healthy');
+  });
+
+  it('a single-window probe (7d header missing) is NOT thin → governed by util', () => {
+    const s = snap({
+      quota: quota({ fiveHourUtilizationPct: 50, sevenDayUtilizationPct: 0, fiveHourUtilPresent: true, sevenDayUtilPresent: false }),
+    });
+    expect(classifyHealth(s, NOW)).toBe('healthy');
+  });
+});
+
+// ── #2494 — row rendering distinguishes the states ──────────────────────
+
+describe('#2494 — renderAuthSnapshotFormat2 row rendering', () => {
+  it('billing-dead row says "billing disabled" with the reason, no timer', () => {
+    const out = renderAuthSnapshotFormat2(
+      [snap({ label: 'dead@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 0, overageDisabledReason: 'out_of_credits' }) })],
+      { now: NOW },
+    );
+    expect(out).toContain('billing disabled (out_of_credits)');
+    expect(out).not.toContain('quota exhausted');
+  });
+
+  it('quota-exhausted row shows a recovery countdown, not "billing disabled"', () => {
+    const futureReset = new Date(NOW.getTime() + 45 * 60_000);
+    const out = renderAuthSnapshotFormat2(
+      [snap({ label: 'ex@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 100, fiveHourResetAt: futureReset }) })],
+      { now: NOW },
+    );
+    expect(out).toContain('quota exhausted');
+    expect(out).not.toContain('billing disabled');
+  });
+
+  it('thin probe row renders "quota unknown", not "0% / 0%"', () => {
+    const out = renderAuthSnapshotFormat2(
+      [snap({ label: 'thin@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 0, sevenDayUtilizationPct: 0, fiveHourUtilPresent: false, sevenDayUtilPresent: false }) })],
+      { now: NOW },
+    );
+    expect(out).toContain('quota unknown');
+    expect(out).not.toContain('0% / 0%');
   });
 });


### PR DESCRIPTION
Closes #2494 (PR1 — accuracy fixes only; durability + realtime probing is PR2/#2495).

## Summary
Three correctness bugs in the auth/usage quota surfaces, all pure classification/display logic — no probe-cost change, no probe-on-open, no cache persistence.

**Bug A — refill-blind classification → false "All accounts blocked".** A shared refill-aware normalization zeroes any window whose `resetAt` has already passed relative to `now`. A just-refilled account self-corrects to healthy with zero extra probes, even from a 10-min-old cached snapshot.

**Bug B — summary conflated throttling/refilling with blocked.** `recommendation()` no longer says "All accounts blocked" while any account is throttling / refilling / usable; it buckets the fleet and surfaces the soonest refill ETA. "All accounts blocked" is reserved for every-account-maxed-with-no-imminent-reset.

**Bug C — recoverable quota-exhausted state + thin-probe marker.** A recoverable `quota-exhausted` state (with reset countdown) is now distinct from billing-dead. `out-of-credits` / "billing disabled" is reserved for a genuine serve-blocking `overageDisabledReason` and rendered with the real reason (not a timer). Header-presence markers carry a thin/headerless probe through as `unknown` instead of a confident `0%·0%`; a real `0%·0%` probe (both headers present, no overage reason) stays healthy.

## Job / outcome
Serves the **subscription-honest and predictable** vision outcome and the auth/quota visibility job — the fleet status surface must report each account's true recoverability.

## File-by-file
- **`src/auth/quota.ts`** — new shared `refillNormalizedUtils(q, now)` helper + `isProbeThin(q)`; `parseQuotaHeaders` now records `fiveHourUtilPresent`/`sevenDayUtilPresent` while still coalescing a missing window to 0 for back-compat (Bug A + C).
- **`telegram-plugin/quota-check.ts`** — mirror of the `QuotaUtilization` presence markers + the `parseQuotaHeaders` change (the parallel plugin-side copy).
- **`telegram-plugin/auth-snapshot-format.ts`** — `classifyHealth` now refill-aware + thin-aware and takes `now`; new `blockedReason()` (billing-dead vs quota-exhausted); card row renders the two distinctly + thin probes as "quota unknown"; `recommendation()` honest summary via new `summarizeNoHealthyAlt`; `pickEarliestRecovery` skips thin probes; `reviveLastQuota` forwards the markers (Bug A/B/C).
- **`telegram-plugin/quota-watch.ts`** — passes the tick's `now` into `classifyHealth` so refill normalization uses the same clock (Bug A).
- **`telegram-plugin/auto-fallback-fleet.ts`** — passes the run's `now` into the idempotency-guard `classifyHealth` (Bug A).
- **`src/cli/auth-schedule.ts`** — `classifyState` refill-aware + thin-aware; new recoverable `quota-exhausted` state distinct from `out-of-credits`; `WindowSnapshot` carries `overageReason`/`probeThin`; `formatStateCell` renders billing-dead as "billing disabled (<reason>)" (no timer) and quota-exhausted with a countdown; 5h/weekly cells refill- and thin-aware (Bug A/C).
- **`src/auth/broker/client.ts`** / **`src/auth/broker/server.ts`** — thread the header-presence markers through `LastQuotaSnapshot` / `ProbeQuotaEntry` and the broker's in-memory cache so the live `auth schedule` path gets thin detection.
- **Tests** — `src/cli/auth-schedule.test.ts` and `telegram-plugin/tests/auth-snapshot-format.test.ts` extended with: refill boundary (pre-refill snapshot read post-refill → healthy), mixed throttling+blocked summary (no false all-blocked), quota-exhausted vs out-of-credits, thin/headerless probe → unknown, real-0% stays healthy, single-window probe not thin. Two existing tests that pinned the old (buggy) "All accounts blocked" / "out-of-credits" wording were updated to the corrected behavior.

## Test plan
- [x] `tsc --noEmit` clean (whole project)
- [x] vitest quota/auth suites green (auth-schedule, consumer-quota-sensor, quota-preflight, auth-quota-util-cell, broker server)
- [x] bun quota/auth suites green (auth-snapshot-format, quota-watch, quota-check, auto-fallback-fleet, quota-cache)
- [x] lint gates clean: check-plugin-references, check-bun-test-imports, check-vault-test-hermeticity
- [x] Confirmed the repo's pre-existing sandbox-env test failures (install/scaffold/hook/docker/UAT) are identical with and without this change — zero introduced regressions

## Out of scope (PR2 / #2495)
Cache persistence, probe-on-open TTL/single-flight, proactive-push live corroboration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)