### PR TITLE
feat(hostd): rollback via allow_downgrade flag on rollout verb (#2487 PR2)

### DIFF
--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -18,6 +18,7 @@ import {
   executeRollout,
   encodeRolloutResultLine,
   parseRolloutResultLine,
+  shouldRefuseDowngrade,
   ROLLOUT_RESULT_SENTINEL,
   type RolloutDeps,
   type RolloutResult,
@@ -357,5 +358,83 @@ describe("rollout structured-result sentinel (#2487)", () => {
 
   it("returns null when no sentinel line is present (child died early)", () => {
     expect(parseRolloutResultLine("Rolling 3 agents…\napply\n")).toBeNull();
+  });
+});
+
+// ── shouldRefuseDowngrade — pure guard for the allow_downgrade flag ────────
+
+describe("shouldRefuseDowngrade (#2487 PR2)", () => {
+  const CURRENT = "v0.15.18";
+
+  it("refuses a concrete downgrade when hostdCtx=true and flag is absent", () => {
+    expect(shouldRefuseDowngrade(true, "v0.15.16", CURRENT, undefined)).toBe(true);
+  });
+
+  it("allows the same downgrade when allow_downgrade=true (operator approved)", () => {
+    expect(shouldRefuseDowngrade(true, "v0.15.16", CURRENT, true)).toBe(false);
+  });
+
+  it("never refuses an upgrade (newer pin)", () => {
+    expect(shouldRefuseDowngrade(true, "v0.15.20", CURRENT, undefined)).toBe(false);
+  });
+
+  it("never refuses when compareReleaseTags returns null (sha/channel pins)", () => {
+    // sha pin — compareReleaseTags returns null → guard never fires
+    expect(shouldRefuseDowngrade(true, "sha-abc1234", CURRENT, undefined)).toBe(false);
+    // channel/floating — also returns null
+    expect(shouldRefuseDowngrade(true, "latest", CURRENT, undefined)).toBe(false);
+  });
+
+  it("host-shell path (hostdCtx=false) is never gated regardless of pin vs current", () => {
+    expect(shouldRefuseDowngrade(false, "v0.15.16", CURRENT, undefined)).toBe(false);
+    expect(shouldRefuseDowngrade(false, "v0.15.16", CURRENT, false)).toBe(false);
+  });
+
+  it("never refuses when pin is absent (target comes from config, not --pin)", () => {
+    expect(shouldRefuseDowngrade(true, undefined, CURRENT, undefined)).toBe(false);
+  });
+});
+
+// ── ROLL_STEP prefix on per-step log lines (#2459) ─────────────────────────
+
+describe("executeRollout — ROLL_STEP greppable step markers (#2459)", () => {
+  const TARGET = "v0.15.18";
+
+  it("emits ROLL_STEP apply on the apply step", () => {
+    const steps = planRollout(["clerk"]);
+    const { deps, logs } = harness({ versions: { clerk: "0.15.18" } });
+    executeRollout(steps, TARGET, deps);
+    const applyLog = logs.find((l) => l.startsWith("ROLL_STEP apply"));
+    expect(applyLog).toBeTruthy();
+  });
+
+  it("emits ROLL_STEP restart-agent on each restart step", () => {
+    const steps = planRollout(["clerk", "marko"]);
+    const { deps, logs } = harness({ versions: { clerk: "0.15.18", marko: "0.15.18" } });
+    executeRollout(steps, TARGET, deps);
+    const restartLogs = logs.filter((l) => l.startsWith("ROLL_STEP restart-agent"));
+    expect(restartLogs.length).toBe(2);
+  });
+
+  it("emits ROLL_STEP refresh-web and ROLL_STEP refresh-hostd", () => {
+    const steps = planRollout(["clerk"]);
+    const { deps, logs } = harness({ versions: { clerk: "0.15.18" } });
+    executeRollout(steps, TARGET, deps);
+    expect(logs.some((l) => l.startsWith("ROLL_STEP refresh-web"))).toBe(true);
+    expect(logs.some((l) => l.startsWith("ROLL_STEP refresh-hostd"))).toBe(true);
+  });
+
+  it("emits ROLL_STEP sweep on the sweep step", () => {
+    const steps = planRollout(["clerk"]);
+    const { deps, logs } = harness({ versions: { clerk: "0.15.18" } });
+    executeRollout(steps, TARGET, deps);
+    expect(logs.some((l) => l.startsWith("ROLL_STEP sweep"))).toBe(true);
+  });
+
+  it("emits ROLL_STEP persist-pin when a pinToPersist step is present", () => {
+    const steps = planRollout(["clerk"], { pinToPersist: TARGET });
+    const { deps, logs } = harness({ versions: { clerk: "0.15.18" } });
+    executeRollout(steps, TARGET, deps);
+    expect(logs.some((l) => l.startsWith("ROLL_STEP persist-pin"))).toBe(true);
   });
 });

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -231,6 +231,31 @@ export interface RolloutResult {
 }
 
 /**
+ * Pure guard: returns true when the downgrade should be refused.
+ *
+ * Refuses only when ALL of:
+ *   - hostdContext is true (agent-invoked path, not host-shell),
+ *   - pin is supplied (not floating from config),
+ *   - allowDowngrade is falsy (operator hasn't authorized the rollback),
+ *   - compareReleaseTags returns a negative (concrete downgrade, not a
+ *     channel/sha which returns null).
+ *
+ * Exported for unit testing.
+ */
+export function shouldRefuseDowngrade(
+  hostdContext: boolean,
+  pin: string | undefined,
+  current: string | undefined,
+  allowDowngrade: boolean | undefined,
+): boolean {
+  if (!hostdContext) return false;
+  if (!pin) return false;
+  if (allowDowngrade) return false;
+  const cmp = compareReleaseTags(pin, current);
+  return cmp !== null && cmp < 0;
+}
+
+/**
  * True when this `switchroom rollout` was spawned by the host-control
  * daemon on behalf of an agent MCP call (#2487). hostd sets
  * `SWITCHROOM_HOSTD_CONTEXT=1` on the child env. The flag flips three
@@ -415,8 +440,14 @@ export function registerRolloutCommand(program: Command): void {
       "Comma-separated subset of agents to roll (default: all configured).",
     )
     .option("--skip-web", "Skip the web + hostd refresh step.")
+    .option(
+      "--allow-downgrade",
+      "Permit rolling to an older semver tag (operator-approved rollback path). " +
+        "When set, the downgrade guard is relaxed so --pin may be older than the " +
+        "current release.pin. All other safety rails apply unchanged.",
+    )
     .option("--dry-run", "Print the plan and exit without changing anything.")
-    .action(async (opts: { pin?: string; agents?: string; skipWeb?: boolean; dryRun?: boolean }) => {
+    .action(async (opts: { pin?: string; agents?: string; skipWeb?: boolean; allowDowngrade?: boolean; dryRun?: boolean }) => {
       const config = getConfig(program);
       const target = opts.pin ?? config.release?.pin;
       if (!target) {
@@ -437,25 +468,27 @@ export function registerRolloutCommand(program: Command): void {
         process.exitCode = 2;
         return;
       }
-      // #2487 item 9 — reject DOWNGRADE pins on the agent-reachable
-      // (hostd) path specifically. `--agents <list>` + arbitrary `--pin`
-      // is a more surgical abuse surface than update_apply (targeted
-      // downgrade); downgrade-as-rollback is deferred to PR2's operator-
-      // tapped rollback verb. compareReleaseTags is conservative: it only
-      // refuses a clean vX.Y.Z → older-vX.Y.Z move, never a channel/sha.
-      if (hostdCtx && opts.pin) {
+      // #2487 PR2 — downgrade guard: reject a version older than the
+      // current release.pin on the hostd path UNLESS --allow-downgrade is
+      // set (the operator-approved rollback path). compareReleaseTags is
+      // conservative: it only refuses a clean vX.Y.Z → older-vX.Y.Z move,
+      // never a channel/sha (those return null and never block).
+      if (shouldRefuseDowngrade(hostdCtx, opts.pin, config.release?.pin, opts.allowDowngrade)) {
         const current = config.release?.pin;
-        const cmp = compareReleaseTags(opts.pin, current);
-        if (cmp !== null && cmp < 0) {
-          process.stderr.write(
-            `rollout (hostd path) refuses a DOWNGRADE: ${opts.pin} is older ` +
-              `than the current pin ${current}. Downgrade/rollback is an ` +
-              `operator-tapped verb (deferred to PR2), not an agent rollout. ` +
-              `Nothing was changed.\n`,
-          );
-          process.exitCode = 2;
-          return;
-        }
+        process.stderr.write(
+          `rollout (hostd path) refuses a DOWNGRADE: ${opts.pin} is older ` +
+            `than the current pin ${current}. Pass --allow-downgrade to ` +
+            `authorize an operator-approved rollback to a known-good earlier ` +
+            `tag. Nothing was changed.\n`,
+        );
+        process.exitCode = 2;
+        return;
+      }
+      if (opts.allowDowngrade) {
+        const current = config.release?.pin;
+        process.stdout.write(
+          `⤵ DOWNGRADE authorized (operator-approved rollback): ${current ?? "<unpinned>"} → ${opts.pin ?? target}\n`,
+        );
       }
       const allAgents = Object.keys(config.agents ?? {});
       const requested = opts.agents
@@ -545,7 +578,9 @@ export function registerRolloutCommand(program: Command): void {
         },
       };
 
-      process.stdout.write(`Rolling ${requested.length} agent(s) to ${target}…\n`);
+      process.stdout.write(
+        `${opts.allowDowngrade ? "Rolling back" : "Rolling"} ${requested.length} agent(s) to ${target}…\n`,
+      );
       const result = executeRollout(steps, target, deps, { hostdContext: hostdCtx });
 
       // hostd path: the hostd/web refresh was intentionally dropped from

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -329,7 +329,7 @@ export function executeRollout(
         // On the hostd path this runs AFTER the canary is green; on the
         // host-shell path it runs FIRST. Either way: durably persist so
         // subsequent reconciles read the same pin.
-        deps.log(`→ persist release.pin=${step.pin} to switchroom.yaml`);
+        deps.log(`ROLL_STEP persist-pin — release.pin=${step.pin} to switchroom.yaml`);
         if (deps.persistPin) {
           deps.persistPin(step.pin);
         } else {
@@ -341,7 +341,7 @@ export function executeRollout(
         // hostd path: pin not yet persisted (it follows the canary), so
         // pass the one-shot --pin so compose regenerates on the target.
         // host-shell path: pin already persisted → bare apply reads it.
-        deps.log(`→ apply — regenerating compose for ${target}`);
+        deps.log(`ROLL_STEP apply — regenerating compose for ${target}`);
         const applyArgs = execOpts.hostdContext
           ? ["apply", "--pin", target]
           : ["apply"];
@@ -352,7 +352,7 @@ export function executeRollout(
         break;
       }
       case "restart-agent": {
-        deps.log(`→ restart ${step.agent} (--wait --force)`);
+        deps.log(`ROLL_STEP restart-agent — ${step.agent} (--wait --force)`);
         // `agent restart` can exit 0 while still "polling" on boot — do
         // NOT trust its status; the version assert is the real gate.
         deps.run(["agent", "restart", step.agent, "--wait", "--force"]);
@@ -373,19 +373,19 @@ export function executeRollout(
         break;
       }
       case "refresh-web": {
-        deps.log(`→ webd install --tag ${target}`);
+        deps.log(`ROLL_STEP refresh-web — webd install --tag ${target}`);
         const r = deps.run(["webd", "install", "--tag", target]);
         if (r.status !== 0) warnings.push(`web refresh failed (non-fatal); agents already rolled`);
         break;
       }
       case "refresh-hostd": {
-        deps.log(`→ hostd install --tag ${target}`);
+        deps.log(`ROLL_STEP refresh-hostd — hostd install --tag ${target}`);
         const r = deps.run(["hostd", "install", "--tag", target]);
         if (r.status !== 0) warnings.push(`hostd refresh failed (non-fatal); agents already rolled`);
         break;
       }
       case "sweep": {
-        deps.log(`→ sweep`);
+        deps.log(`ROLL_STEP sweep`);
         for (const a of rolled) {
           const v = deps.probeVersion(a);
           deps.log(`  ${a}: ${v ?? "<unreachable>"}`);

--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -174,6 +174,15 @@ export const RolloutRequestSchema = z.object({
        *  SIGKILL the in-flight rollout — hostd's own child); this flag
        *  is forwarded for parity but the deferral is unconditional. */
       skip_web: z.boolean().optional(),
+      /**
+       * Operator-approved rollback to a known-good earlier tag (#2487 PR2).
+       * When set, the downgrade guard in `switchroom rollout` is relaxed to
+       * permit `--pin <oldtag>` even when that tag is older than the current
+       * `release.pin`. All other safety rails (canary order, version-assert,
+       * stop-on-mismatch, persist-after-canary, hostd/web deferral) apply
+       * unchanged. Absent ⇒ false (downgrade rejected as before).
+       */
+      allow_downgrade: z.boolean().optional(),
     })
     .required({ pin: true }),
 });

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -1352,6 +1352,7 @@ export class HostdServer {
       args.push("--agents", req.args.agents.join(","));
     }
     if (req.args.skip_web) args.push("--skip-web");
+    if (req.args.allow_downgrade) args.push("--allow-downgrade");
 
     const installCtx = readCachedInstallType(
       this.opts.bindRoot ?? this.opts.homeDir,

--- a/src/mcp/hostd/server.test.ts
+++ b/src/mcp/hostd/server.test.ts
@@ -230,6 +230,20 @@ describe("dispatchTool — happy path", () => {
     expect(hostdRequestMock).not.toHaveBeenCalled();
   });
 
+  it("rollout forwards allow_downgrade when true", async () => {
+    hostdRequestMock.mockResolvedValueOnce(ok({ result: "started" }));
+    await dispatchTool("rollout", { pin: "v0.15.16", allow_downgrade: true });
+    const sent = hostdRequestMock.mock.calls[0]![1];
+    expect(sent.args.allow_downgrade).toBe(true);
+  });
+
+  it("rollout omits allow_downgrade when not set (default upgrade path)", async () => {
+    hostdRequestMock.mockResolvedValueOnce(ok({ result: "started" }));
+    await dispatchTool("rollout", { pin: "v0.15.18" });
+    const sent = hostdRequestMock.mock.calls[0]![1];
+    expect(sent.args.allow_downgrade).toBeUndefined();
+  });
+
   it("agent_logs forwards tail when provided and omits it when not", async () => {
     hostdRequestMock.mockResolvedValueOnce(ok({ result: "completed" }));
     await dispatchTool("agent_logs", { name: "scribe", tail: 250 });

--- a/src/mcp/hostd/server.ts
+++ b/src/mcp/hostd/server.ts
@@ -89,6 +89,7 @@ interface ToolArgs {
   // rollout (#2487)
   agents?: string[];
   skip_web?: boolean;
+  allow_downgrade?: boolean;
   // config_propose_edit args
   unified_diff?: string;
   target_path?: string;
@@ -287,12 +288,14 @@ export const TOOLS = [
       "pins are rejected because the version assert needs a semver to " +
       "compare against. The hostd/web self-refresh is DEFERRED on this path " +
       "(an agent-invoked rollout cannot recreate its own hostd container " +
-      "without killing itself); run that host-side. Downgrade pins are " +
-      "rejected (rollback is an operator-tapped verb, not an agent " +
-      "rollout). Admin-only at the wire layer AND deliberately NOT pre-" +
-      "approved — every call surfaces a Telegram approval card for the " +
-      "operator to tap. Returns `started`; poll get_status for the " +
-      "structured outcome (which agents rolled / where it stopped).",
+      "without killing itself); run that host-side. By default downgrade pins " +
+      "are rejected — pass `allow_downgrade: true` for the operator-approved " +
+      "rollback path to a known-good earlier tag; all other safety rails " +
+      "(canary order, version-assert, stop-on-mismatch) apply unchanged. " +
+      "Admin-only at the wire layer AND deliberately NOT pre-approved — every " +
+      "call surfaces a Telegram approval card for the operator to tap. " +
+      "Returns `started`; poll get_status for the structured outcome " +
+      "(which agents rolled / where it stopped).",
     inputSchema: {
       type: "object" as const,
       required: ["pin"],
@@ -319,6 +322,16 @@ export const TOOLS = [
             "Skip the web + hostd refresh step. NB: on this (hostd) path " +
             "the hostd/web refresh is deferred regardless; this flag is " +
             "forwarded for parity.",
+        },
+        allow_downgrade: {
+          type: "boolean",
+          description:
+            "Operator-approved rollback to a known-good earlier tag (#2487 PR2). " +
+            "When true, the downgrade guard is relaxed so `pin` may be older " +
+            "than the current release.pin. All other safety rails (canary order, " +
+            "version-assert, stop-on-mismatch, persist-after-canary, " +
+            "hostd/web deferral) apply unchanged. Still gated by the operator " +
+            "approval card — not pre-approved.",
         },
       },
     },
@@ -562,6 +575,7 @@ export async function dispatchTool(
           pin: args.pin,
           ...(args.agents ? { agents: args.agents } : {}),
           ...(args.skip_web ? { skip_web: true } : {}),
+          ...(args.allow_downgrade ? { allow_downgrade: true } : {}),
         },
       };
       break;

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -1180,6 +1180,87 @@ describe("hostd server — Phase 2 fleet mutations + lock", () => {
     await new Promise((r) => setTimeout(r, 1500));
   });
 
+  it("rollout: forwards --allow-downgrade to the spawned CLI argv when set", async () => {
+    // Mirror the existing argv-assertion pattern: stub records its argv
+    // to a file, then we assert --allow-downgrade is present.
+    const recStub = join(tmp, "switchroom-rollout-downgrade-stub.sh");
+    const recOut = join(tmp, "rollout-downgrade-rec.txt");
+    writeFileSync(
+      recStub,
+      `#!/bin/sh\n` +
+        `echo "argv: $@" >> "${recOut}"\n` +
+        `echo 'SWITCHROOM_ROLLOUT_RESULT:{"ok":true,"rolled":["klanker"],"warnings":[]}'\n` +
+        `exit 0\n`,
+    );
+    chmodSync(recStub, 0o755);
+    await server.stop();
+    server = new (await import("../../src/host-control/server.js")).HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: recStub,
+      auditLogPath: join(tmp, "audit.log"),
+      allowNonLinux: true,
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+    await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "rollout",
+        request_id: "ro-downgrade",
+        args: { pin: "v0.15.16", allow_downgrade: true },
+      },
+    );
+    await new Promise((r) => setTimeout(r, 300));
+
+    const { readFileSync } = await import("node:fs");
+    const rec = readFileSync(recOut, "utf8");
+    expect(rec).toContain("--allow-downgrade");
+    expect(rec).toContain("--pin v0.15.16");
+  });
+
+  it("rollout: does NOT include --allow-downgrade in argv when omitted (default path)", async () => {
+    const recStub = join(tmp, "switchroom-rollout-nod-stub.sh");
+    const recOut = join(tmp, "rollout-nod-rec.txt");
+    writeFileSync(
+      recStub,
+      `#!/bin/sh\n` +
+        `echo "argv: $@" >> "${recOut}"\n` +
+        `echo 'SWITCHROOM_ROLLOUT_RESULT:{"ok":true,"rolled":["klanker"],"warnings":[]}'\n` +
+        `exit 0\n`,
+    );
+    chmodSync(recStub, 0o755);
+    await server.stop();
+    server = new (await import("../../src/host-control/server.js")).HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: recStub,
+      auditLogPath: join(tmp, "audit.log"),
+      allowNonLinux: true,
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+    await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "rollout",
+        request_id: "ro-nod",
+        args: { pin: "v0.15.18" },
+      },
+    );
+    await new Promise((r) => setTimeout(r, 300));
+
+    const { readFileSync } = await import("node:fs");
+    const rec = readFileSync(recOut, "utf8");
+    expect(rec).not.toContain("--allow-downgrade");
+  });
+
   // ── Phase 3 admin observability — agent_logs / agent_exec ─────────────
   it("agent_logs: shells out to docker and returns stdout_tail (admin cross-agent)", async () => {
     // Swap to a "docker" stub that echoes its argv so we can assert


### PR DESCRIPTION
## Summary

- **Rollback is now a flag, not a new verb.** Pass `--allow-downgrade` (CLI) or `allow_downgrade: true` (MCP) to `rollout` to permit rolling to an older semver tag. No new verb, no new surface.
- **Guard relaxation only.** The downgrade guard in `registerRolloutCommand` is gated on `!opts.allowDowngrade` (via the new `shouldRefuseDowngrade()` pure helper). When the flag is absent the guard is unchanged; when set, a positive log line is emitted: `⤵ DOWNGRADE authorized (operator-approved rollback): <current> → <pin>`.
- **All safety rails preserved.** Canary order, per-agent version-assert, stop-on-mismatch, persist-after-canary, and hostd/web deferral are untouched — a downgrade gets identical safety to an upgrade.
- **Approval card still fires.** The rollout verb is deliberately NOT in HOSTD_MCP_TOOLS (established in PR1); allow_downgrade: true does not change that — every invocation surfaces a Telegram approval card for the operator to tap.

## Wire-through (four layers)

1. **src/host-control/protocol.ts** — `RolloutRequestSchema`: added `allow_downgrade: z.boolean().optional()` after `skip_web`.
2. **src/mcp/hostd/server.ts** — rollout tool def: `allow_downgrade` boolean added to `inputSchema.properties`; description updated to explain the operator-approved rollback path; dispatch case threads `allow_downgrade` into req.args when set.
3. **src/host-control/server.ts** — `handleRollout`: appends `--allow-downgrade` to the spawned CLI argv when `req.args.allow_downgrade` is set (after skip_web push, before spawnRollout).
4. **src/cli/rollout.ts** — `.option("--allow-downgrade", ...)` registered; action opts type widened with `allowDowngrade?: boolean`; `shouldRefuseDowngrade()` pure helper exported; guard uses it; "Rolling back" label replaces "Rolling" when flag is set.

## Also in this PR: ROLL_STEP greppable step markers (#2459 visibility)

Each per-step `deps.log` line in `executeRollout` now begins with `ROLL_STEP <kind>` (e.g. `ROLL_STEP apply`, `ROLL_STEP restart-agent`, `ROLL_STEP refresh-web`, `ROLL_STEP sweep`, `ROLL_STEP persist-pin`). String-format change only — no control-flow change. Shipped as a separate first commit so the grep contract is independently greppable in log history.

## Test results

All three affected test files: **144 passed, 1 pre-existing failure** (unrelated operator-socket test; reproduces identically on origin/main).

- `src/cli/rollout.test.ts`: 38 passed (new: `shouldRefuseDowngrade` unit tests covering all guard branches; ROLL_STEP prefix assertions on each step kind)
- `src/mcp/hostd/server.test.ts`: 37 passed (new: `allow_downgrade` forwarded when true; omitted by default)
- `tests/host-control/server.test.ts`: 69 passed, 1 pre-existing fail (new: argv stub assertions for `--allow-downgrade` present and absent; mirrors existing argv-assertion pattern)

`npm run lint` (`tsc --noEmit`) clean. Strict TS, no `any`.

## Pre-existing failure ruled out

`hostd server — operator socket > is bound when the env is set` fails on origin/main (57 passed, 1 failed) and identically on this branch. Not introduced by this PR.

Closes #2487 (PR2).