### PR TITLE
feat: quota state durability + realtime probe-on-open (#2495)

### DIFF
--- a/src/auth/broker/account-eligibility.test.ts
+++ b/src/auth/broker/account-eligibility.test.ts
@@ -165,6 +165,39 @@ describe("snapshotShouldClearMark — self-heal", () => {
     const mark: ExhaustionMark = { exhausted_until: NOW + 1000, marked_at: NOW };
     expect(snapshotShouldClearMark(snap(4, 20, 10 * 60_000), mark, NOW)).toBe(false);
   });
+  it("#2495 nit B — NEVER clears a mark on a THIN probe (no util headers)", () => {
+    // A headerless probe coalesces both windows to 0% — which reads as
+    // "clearly healthy" but is NOT evidence of health. Refuse to self-heal a
+    // real exhaustion mark off it.
+    const mark: ExhaustionMark = { exhausted_until: NOW + 7 * 24 * 60 * 60 * 1000, marked_at: NOW - 60_000 };
+    const thin: QuotaSnapshot = {
+      fiveHourUtilizationPct: 0,
+      sevenDayUtilizationPct: 0,
+      capturedAt: NOW,
+      fiveHourUtilPresent: false,
+      sevenDayUtilPresent: false,
+    };
+    expect(snapshotShouldClearMark(thin, mark, NOW)).toBe(false);
+    // Contrast: a probe that ACTUALLY measured 0% on both (markers present)
+    // is real health → DOES clear (regression anchor).
+    const real: QuotaSnapshot = {
+      fiveHourUtilizationPct: 0,
+      sevenDayUtilizationPct: 0,
+      capturedAt: NOW,
+      fiveHourUtilPresent: true,
+      sevenDayUtilPresent: true,
+    };
+    expect(snapshotShouldClearMark(real, mark, NOW)).toBe(true);
+    // And a partial probe (5h present, 7d absent) is NOT thin → clears.
+    const partial: QuotaSnapshot = {
+      fiveHourUtilizationPct: 4,
+      sevenDayUtilizationPct: 0,
+      capturedAt: NOW,
+      fiveHourUtilPresent: true,
+      sevenDayUtilPresent: false,
+    };
+    expect(snapshotShouldClearMark(partial, mark, NOW)).toBe(true);
+  });
   it("NEVER clears a mark off an out_of_credits account, even at 0% util", () => {
     // The 2026-06-20 self-heal bug: a fresh low-util probe must NOT un-exhaust a
     // credits-dead account. Low util ≠ healthy when overage is serve-blocking.

--- a/src/auth/broker/account-eligibility.ts
+++ b/src/auth/broker/account-eligibility.ts
@@ -18,6 +18,8 @@
  * PURE — no I/O, no clock except the injected `now`. Fully unit-tested.
  */
 
+import { isProbeThin } from "../quota.js";
+
 /**
  * Utilization at/above this on either window is a hard wall. Matches
  * `EXHAUSTION_PCT` in consumer-quota-sensor.ts and `classifyHealth`'s
@@ -82,6 +84,12 @@ export interface QuotaSnapshot {
    *  THIS is the serve-blocking discriminator: `out_of_credits` is dead,
    *  `org_level_disabled` is benign. See SERVE_BLOCKING_OVERAGE_REASONS. */
   overageDisabledReason?: string | null;
+  /** #2494 Bug C — which util windows the probe actually carried. A probe
+   *  with BOTH false is "thin" (no real signal, 0%-coalesced) and must NOT be
+   *  trusted to self-heal a real exhaustion mark (#2495 folded nit B). Unset
+   *  means "predates the flag" → treated as a real probe. */
+  fiveHourUtilPresent?: boolean;
+  sevenDayUtilPresent?: boolean;
 }
 
 /**
@@ -169,6 +177,12 @@ export function snapshotShouldClearMark(
   if (!mark) return false;
   if (!snapshotFresh(snapshot, now)) return false;
   if (snapshot.capturedAt < (mark.marked_at ?? 0)) return false;
+  // #2495 folded nit B — a THIN probe (no util headers, both windows coalesced
+  // to 0) is NOT evidence of health: `snapshotClearlyHealthy` reads it as 0%/0%
+  // and would clear a real exhaustion mark off a headerless response. Refuse to
+  // self-heal a mark on a thin probe; require a probe that actually measured at
+  // least one window before clearing.
+  if (isProbeThin(snapshot)) return false;
   // A serve-blocking overage (out_of_credits) is an exhaustion in its own
   // right — never let a 0%-util-but-credits-dead probe self-heal a mark off
   // such an account (that's exactly the live-probe re-clear the 2026-06-20

--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -232,6 +232,16 @@ export interface ProbeQuotaEntry {
         };
       }
     | { ok: false; reason: string };
+  /**
+   * #2495 Change 2 — how this result was sourced. `"live"` = a fresh upstream
+   * probe; `"cache"` = served from the durable cache (TTL-hit or probe-failure
+   * fallback). Absent on legacy responses. When `"cache"`, `capturedAt` carries
+   * the snapshot age so the card can stamp "⚠ cached Nm ago" instead of a false
+   * live stamp.
+   */
+  served?: "live" | "cache";
+  /** Unix ms the served snapshot was captured (set when `served === "cache"`). */
+  capturedAt?: number;
 }
 
 export interface ProbeQuotaData {
@@ -448,6 +458,7 @@ export class AuthBrokerClient {
   async probeQuota(
     accounts: readonly string[],
     timeoutMs?: number,
+    forceLive?: boolean,
   ): Promise<ProbeQuotaData> {
     const data = await this.send({
       v: PROTOCOL_VERSION,
@@ -455,6 +466,7 @@ export class AuthBrokerClient {
       op: "probe-quota",
       accounts: [...accounts],
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      ...(forceLive ? { forceLive: true } : {}),
     });
     // JSON.parse does not revive Date. The broker serialises
     // fiveHourResetAt/sevenDayResetAt as Date → ISO string on the wire,

--- a/src/auth/broker/protocol.ts
+++ b/src/auth/broker/protocol.ts
@@ -339,6 +339,15 @@ export const ProbeQuotaRequestSchema = z.object({
   accounts: z.array(z.string().min(1)).min(1).max(32),
   /** Override probe timeout per account (ms). Defaults to 10s. */
   timeoutMs: z.number().int().positive().max(60_000).optional(),
+  /**
+   * #2495 Change 2/3 — bypass the probe-on-open TTL gate and force a live
+   * upstream probe. Used by the proactive quota-watch alarm path, which must
+   * CORROBORATE a stale-snapshot transition with a true live probe before
+   * alarming — a TTL-hit cache read would defeat the corroboration. Normal
+   * card-open renders leave this unset (TTL-gated). Single-flight coalescing
+   * still applies even when forced.
+   */
+  forceLive: z.boolean().optional(),
 });
 
 /**

--- a/src/auth/broker/server-quota-durable.test.ts
+++ b/src/auth/broker/server-quota-durable.test.ts
@@ -1,0 +1,272 @@
+/**
+ * #2495 — auth-broker quota state durability + realtime probe-on-open.
+ *
+ * Covers:
+ *   - Change 1: durable quota cache (write → reload → identical incl. markers).
+ *   - Change 2: probe-on-open TTL (a fresh cache hit serves cache, skips the
+ *     upstream probe) + single-flight (two concurrent probe-quota → one call)
+ *     + stale-fallback labeling (a failed probe is served `cache`, not `live`).
+ *   - Change 2/3: forceLive bypasses the TTL gate (the quota-watch
+ *     corroboration probe is a TRUE live probe).
+ *
+ * Strategy mirrors server.test.ts: a tmpdir broker reachable over a real UDS,
+ * probes injected via `_testFetchQuota`. Never touches `~/.switchroom`.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as net from "node:net";
+
+import { AuthBroker } from "./server.js";
+import { decodeResponse, encodeRequest } from "./protocol.js";
+import type { SwitchroomConfig } from "../../config/schema.js";
+import { writeAccountCredentials } from "../account-store.js";
+
+interface Harness {
+  tmp: string;
+  home: string;
+  agentsDir: string;
+  stateDir: string;
+  socketRoot: string;
+}
+
+let harnesses: Harness[] = [];
+
+function makeHarness(): Harness {
+  const tmp = mkdtempSync(join(tmpdir(), "auth-broker-quota-"));
+  const home = join(tmp, "home");
+  const agentsDir = join(home, ".switchroom", "agents");
+  const stateDir = join(home, ".switchroom", "state", "auth-broker");
+  const socketRoot = join(tmp, "run", "switchroom", "auth-broker");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(agentsDir, { recursive: true });
+  const h: Harness = { tmp, home, agentsDir, stateDir, socketRoot };
+  harnesses.push(h);
+  return h;
+}
+
+afterEach(() => {
+  for (const h of harnesses) {
+    try { rmSync(h.tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  harnesses = [];
+});
+
+function makeConfig(h: Harness, active: string): SwitchroomConfig {
+  return ({
+    switchroom: { version: 1, agents_dir: h.agentsDir },
+    telegram: {},
+    agents: { ziggy: {} },
+    auth: { active },
+    google_workspace: undefined,
+  } as unknown) as SwitchroomConfig;
+}
+
+function seedAccount(h: Harness, label: string): void {
+  writeAccountCredentials(
+    label,
+    {
+      claudeAiOauth: {
+        accessToken: `at-${label}`,
+        refreshToken: `rt-${label}`,
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+      },
+    },
+    h.home,
+  );
+}
+
+async function rpc(socketPath: string, req: object): Promise<any> {
+  return await new Promise<unknown>((resolveP, rejectP) => {
+    const c = net.createConnection(socketPath);
+    let buf = "";
+    let settled = false;
+    const settle = (v: unknown, err?: Error): void => {
+      if (settled) return;
+      settled = true;
+      try { c.destroy(); } catch { /* ignore */ }
+      if (err) rejectP(err); else resolveP(v);
+    };
+    c.on("connect", () => {
+      c.write(encodeRequest(req as Parameters<typeof encodeRequest>[0]));
+    });
+    c.on("data", (chunk) => {
+      buf += chunk.toString("utf-8");
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        try { settle(decodeResponse(buf.slice(0, nl))); } catch (err) { settle(null, err as Error); }
+      }
+    });
+    c.on("error", (err) => settle(null, err));
+    setTimeout(() => settle(null, new Error("rpc timeout")), 3000);
+  });
+}
+
+const okProbe = (five: number, seven: number) => ({
+  ok: true as const,
+  data: {
+    fiveHourUtilizationPct: five,
+    sevenDayUtilizationPct: seven,
+    fiveHourResetAt: new Date(Date.now() + 60 * 60 * 1000),
+    sevenDayResetAt: null,
+    representativeClaim: null,
+    overageStatus: null,
+    overageDisabledReason: null,
+    fiveHourUtilPresent: true,
+    sevenDayUtilPresent: true,
+  },
+});
+
+describe("#2495 Change 1 — durable quota cache", () => {
+  it("write → reload → identical snapshot incl. presence markers", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    const broker = new AuthBroker(makeConfig(h, "default"), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async () => okProbe(42, 7),
+    });
+    await broker.start();
+    // A live probe populates AND persists the cache.
+    await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1, id: "1", op: "probe-quota", accounts: ["default"],
+    });
+    const before = broker._state().lastQuotaCache["default"];
+    expect(before?.fiveHourUtilizationPct).toBe(42);
+    expect(before?.fiveHourUtilPresent).toBe(true);
+    expect(before?.sevenDayUtilPresent).toBe(true);
+    expect(typeof before?.capturedAt).toBe("number");
+    // The durable file exists on disk.
+    expect(existsSync(join(h.stateDir, "last-quota.json"))).toBe(true);
+    broker.stop();
+
+    // A FRESH broker reloads it — serving last-known instead of blank.
+    const broker2 = new AuthBroker(makeConfig(h, "default"), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async () => okProbe(99, 99), // would differ if it re-probed
+    });
+    await broker2.start();
+    const reloaded = broker2._state().lastQuotaCache["default"];
+    expect(reloaded).toEqual(before); // identical, markers and capturedAt included
+    broker2.stop();
+  });
+
+  it("on-disk file matches the in-memory cache byte-for-byte", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    const broker = new AuthBroker(makeConfig(h, "default"), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async () => okProbe(12, 34),
+    });
+    await broker.start();
+    await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1, id: "1", op: "probe-quota", accounts: ["default"],
+    });
+    const onDisk = JSON.parse(readFileSync(join(h.stateDir, "last-quota.json"), "utf-8"));
+    expect(onDisk["default"]).toEqual(broker._state().lastQuotaCache["default"]);
+    broker.stop();
+  });
+});
+
+describe("#2495 Change 2 — probe-on-open TTL + single-flight", () => {
+  it("a fresh cache hit serves cache and skips the upstream probe (TTL gate)", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    let calls = 0;
+    const broker = new AuthBroker(makeConfig(h, "default"), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async () => { calls++; return okProbe(50, 5); },
+    });
+    await broker.start();
+    // First probe goes live.
+    const r1: any = await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1, id: "1", op: "probe-quota", accounts: ["default"],
+    });
+    expect(calls).toBe(1);
+    expect(r1.data.results[0].served).toBe("live");
+    // Second probe within the TTL serves cache — no new upstream call.
+    const r2: any = await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1, id: "2", op: "probe-quota", accounts: ["default"],
+    });
+    expect(calls).toBe(1);
+    expect(r2.data.results[0].served).toBe("cache");
+    expect(typeof r2.data.results[0].capturedAt).toBe("number");
+    broker.stop();
+  });
+
+  it("single-flight: two concurrent probes (cold cache) trigger ONE upstream call", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const broker = new AuthBroker(makeConfig(h, "default"), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      // TTL disabled so both requests reach the single-flight layer (cold cache).
+      _testFetchQuota: async () => { calls++; await gate; return okProbe(60, 6); },
+    });
+    process.env.SWITCHROOM_QUOTA_PROBE_TTL_MS = "0";
+    await broker.start();
+    const sock = join(h.socketRoot, "ziggy", "sock");
+    const p1 = rpc(sock, { v: 1, id: "1", op: "probe-quota", accounts: ["default"] });
+    const p2 = rpc(sock, { v: 1, id: "2", op: "probe-quota", accounts: ["default"] });
+    // Let both requests reach the in-flight coalescer before the probe resolves.
+    await new Promise((r) => setTimeout(r, 50));
+    release();
+    const [a, b]: any[] = await Promise.all([p1, p2]);
+    expect(calls).toBe(1); // coalesced
+    expect(a.data.results[0].result.ok).toBe(true);
+    expect(b.data.results[0].result.ok).toBe(true);
+    delete process.env.SWITCHROOM_QUOTA_PROBE_TTL_MS;
+    broker.stop();
+  });
+
+  it("stale-fallback labeling: a failed probe is served from cache, tagged `cache`", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    let mode: "ok" | "fail" = "ok";
+    const broker = new AuthBroker(makeConfig(h, "default"), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async () => (mode === "ok" ? okProbe(33, 3) : { ok: false as const, reason: "HTTP 503" }),
+    });
+    process.env.SWITCHROOM_QUOTA_PROBE_TTL_MS = "0"; // force live attempt every time
+    await broker.start();
+    const sock = join(h.socketRoot, "ziggy", "sock");
+    // Seed the cache with a good snapshot.
+    await rpc(sock, { v: 1, id: "1", op: "probe-quota", accounts: ["default"] });
+    // Now the live probe fails — we must fall back to the cached snapshot,
+    // tagged `cache` so the card stamps "⚠ cached Nm ago".
+    mode = "fail";
+    const r: any = await rpc(sock, { v: 1, id: "2", op: "probe-quota", accounts: ["default"] });
+    expect(r.data.results[0].served).toBe("cache");
+    expect(r.data.results[0].result.ok).toBe(true); // served the prior good data
+    expect(r.data.results[0].result.data.fiveHourUtilizationPct).toBe(33);
+    delete process.env.SWITCHROOM_QUOTA_PROBE_TTL_MS;
+    broker.stop();
+  });
+
+  it("forceLive bypasses the TTL gate (quota-watch corroboration goes live)", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    let calls = 0;
+    const broker = new AuthBroker(makeConfig(h, "default"), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async () => { calls++; return okProbe(70, 7); },
+    });
+    await broker.start();
+    const sock = join(h.socketRoot, "ziggy", "sock");
+    await rpc(sock, { v: 1, id: "1", op: "probe-quota", accounts: ["default"] });
+    expect(calls).toBe(1);
+    // A normal probe within TTL would serve cache (calls stays 1)...
+    await rpc(sock, { v: 1, id: "2", op: "probe-quota", accounts: ["default"] });
+    expect(calls).toBe(1);
+    // ...but forceLive must hit the upstream regardless of the fresh cache.
+    const r: any = await rpc(sock, { v: 1, id: "3", op: "probe-quota", accounts: ["default"], forceLive: true });
+    expect(calls).toBe(2);
+    expect(r.data.results[0].served).toBe("live");
+    broker.stop();
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -166,13 +166,42 @@ interface NotificationClaims {
 const NOTIFICATION_CLAIM_MAX_AGE_MS = 86_400_000;
 
 /**
+ * #2495 Change 2 — probe-on-open TTL. A `probe-quota` request whose cached
+ * snapshot is younger than this serves the cache instead of paying for a live
+ * upstream call. 45s is short enough that an opened /auth or /usage card is
+ * effectively realtime, but long enough that a render storm (a fleet boot, a
+ * user mashing Refresh, several agents' cards opening at once) doesn't multiply
+ * into one billable probe per render.
+ *
+ * COST: each live probe is a billable POST /v1/messages that consumes a sliver
+ * of the account's own quota (the only source of real ratelimit headers — see
+ * quota.ts). TTL + single-flight together cap probe volume to at most one
+ * upstream call per account per TTL window, no matter how many cards render.
+ *
+ * Env override: SWITCHROOM_QUOTA_PROBE_TTL_MS (ms). 0 disables the TTL gate
+ * (every probe-quota goes live — only single-flight coalescing remains).
+ */
+const DEFAULT_QUOTA_PROBE_TTL_MS = 45_000;
+
+function quotaProbeTtlMs(): number {
+  const raw = process.env.SWITCHROOM_QUOTA_PROBE_TTL_MS;
+  if (raw == null || raw === "") return DEFAULT_QUOTA_PROBE_TTL_MS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : DEFAULT_QUOTA_PROBE_TTL_MS;
+}
+
+/**
  * Per-account cached utilization snapshot, written after each successful
  * `opProbeQuota` call. Consumed by `opListState` so callers (quota-watch
  * loop) can classify account health without triggering a live probe.
- * In-memory only — intentionally not persisted. The cache populates from
- * `/auth`, auto-fallback, and boot-card probes; on broker restart it is
- * empty until the next such event (watchers treat absent entries as
- * "unknown" and skip — acceptable cold-start gap).
+ *
+ * #2495 Change 1 — durable. Mirrored to disk (`last-quota.json`) alongside
+ * the exhaustion ledger (`quota.json`) on every `cacheQuotaSnapshot` and
+ * reloaded on boot, so a broker restart serves last-known (age-stamped via
+ * `capturedAt`) utilization instead of a blank/`unknown` card until the next
+ * fleet tick repopulates it. The presence markers (`fiveHourUtilPresent` /
+ * `sevenDayUtilPresent`, added in #2494) round-trip too so a thin reloaded
+ * snapshot is still recognisably thin.
  */
 interface LastQuotaEntry {
   fiveHourUtilizationPct: number;
@@ -238,6 +267,29 @@ export interface AuthBrokerOptions {
 }
 
 /* ───────────────────────── Helpers ───────────────────────── */
+
+/**
+ * #2495 Change 2 — reconstruct a probe-shaped `QuotaResult` from a durable
+ * cache entry, so a TTL-hit / probe-failure fallback can be served on the same
+ * wire shape as a live probe. The ISO reset strings are revived to Date for
+ * the in-process consumers; the client revives again on the wire (harmless).
+ */
+function cachedSnapshotToResult(s: LastQuotaEntry): QuotaResult {
+  return {
+    ok: true,
+    data: {
+      fiveHourUtilizationPct: s.fiveHourUtilizationPct,
+      sevenDayUtilizationPct: s.sevenDayUtilizationPct,
+      fiveHourResetAt: s.fiveHourResetAt ? new Date(s.fiveHourResetAt) : null,
+      sevenDayResetAt: s.sevenDayResetAt ? new Date(s.sevenDayResetAt) : null,
+      representativeClaim: s.representativeClaim,
+      overageStatus: s.overageStatus,
+      overageDisabledReason: s.overageDisabledReason,
+      fiveHourUtilPresent: s.fiveHourUtilPresent,
+      sevenDayUtilPresent: s.sevenDayUtilPresent,
+    },
+  };
+}
 
 function sha256Hex(content: string): string {
   return createHash("sha256").update(content).digest("hex");
@@ -329,8 +381,13 @@ export class AuthBroker {
 
   // In-memory state mirrored to disk.
   private quota: QuotaState = {};
-  /** In-memory utilization cache (not persisted). Populated by opProbeQuota. */
+  /** Utilization cache. Populated by opProbeQuota; mirrored to disk
+   *  (`last-quota.json`) and reloaded on boot — #2495 Change 1. */
   private lastQuotaCache: LastQuotaCache = {};
+  /** #2495 Change 2 — single-flight: in-flight live probes keyed by account
+   *  label. Concurrent `probe-quota` requests for the same label share the one
+   *  pending upstream call (a render storm = 1 API call per account, not N). */
+  private probeInFlight = new Map<string, Promise<QuotaResult>>();
   private shaIndex: ShaIndex = {};
   private thresholdViolations: ThresholdViolations = {};
   /** Fleet notification-dedup claims: key → unix-ms of last grant.
@@ -973,6 +1030,7 @@ export class AuthBroker {
             identity,
             req.accounts,
             req.timeoutMs,
+            req.forceLive,
           );
           break;
         case "claim-notification":
@@ -1253,12 +1311,29 @@ export class AuthBroker {
     identity: Identity,
     accounts: readonly string[],
     timeoutMs?: number,
+    forceLive?: boolean,
   ): Promise<void> {
+    // #2495 Change 2/3 — forceLive (quota-watch corroboration) bypasses the
+    // TTL gate so the alarm decision is taken off a true live probe, not a
+    // possibly-stale cache read. Single-flight still applies.
+    const ttlMs = forceLive ? 0 : quotaProbeTtlMs();
     const results = await Promise.all(
-      accounts.map(async (label): Promise<{ label: string; result: QuotaResult }> => {
+      accounts.map(async (label): Promise<{ label: string; result: QuotaResult; served?: "live" | "cache"; capturedAt?: number }> => {
+        // #2495 Change 2 — TTL gate: a cached snapshot younger than the TTL
+        // serves the cache, skipping the billable upstream probe entirely.
+        const cached = this.lastQuotaCache[label];
+        if (ttlMs > 0 && cached && this.now() - cached.capturedAt < ttlMs) {
+          return { label, result: cachedSnapshotToResult(cached), served: "cache", capturedAt: cached.capturedAt };
+        }
+
         const creds = readAccountCredentials(label, this.home);
         const token = creds?.claudeAiOauth?.accessToken;
         if (!token) {
+          // No live creds. If we have ANY prior snapshot, serve it stale rather
+          // than render a blank card; otherwise surface the failure.
+          if (cached) {
+            return { label, result: cachedSnapshotToResult(cached), served: "cache", capturedAt: cached.capturedAt };
+          }
           const result: QuotaResult = {
             ok: false,
             reason: "no credentials for account in broker store",
@@ -1266,7 +1341,10 @@ export class AuthBroker {
           this.audit({ op: "probe-quota", identity, account: label, accountKind: "claude", ok: false, error: "missing-credentials" });
           return { label, result };
         }
-        const result = await this.fetchQuotaImpl({ accessToken: token, timeoutMs });
+
+        // #2495 Change 2 — single-flight: concurrent renders for the same label
+        // share one in-flight upstream probe (a render storm = 1 API call).
+        const result = await this.probeQuotaSingleFlight(label, token, timeoutMs);
         this.audit({
           op: "probe-quota",
           identity,
@@ -1278,11 +1356,43 @@ export class AuthBroker {
         // Cache the utilization snapshot for listState consumers (quota-watch
         // loop). Only update on success — a failed probe should not evict a
         // valid previous snapshot.
-        if (result.ok) this.cacheQuotaSnapshot(label, result);
-        return { label, result };
+        if (result.ok) {
+          this.cacheQuotaSnapshot(label, result);
+          return { label, result, served: "live" };
+        }
+        // #2495 Change 2 — probe FAILED. If we have a prior snapshot, serve it
+        // age-stamped (served:"cache") so the card renders an explicit
+        // "⚠ cached Nm ago" warning instead of a false live stamp.
+        if (cached) {
+          return { label, result: cachedSnapshotToResult(cached), served: "cache", capturedAt: cached.capturedAt };
+        }
+        return { label, result, served: "live" };
       }),
     );
     socket.write(encodeSuccess(id, { results }));
+  }
+
+  /**
+   * #2495 Change 2 — single-flight wrapper around a live quota probe. The
+   * first caller for a label starts the upstream `fetchQuota`; concurrent
+   * callers await the SAME promise. The entry is cleared when it settles, so
+   * the next probe-on-open (after the TTL window) starts a fresh call.
+   */
+  private probeQuotaSingleFlight(
+    label: string,
+    token: string,
+    timeoutMs?: number,
+  ): Promise<QuotaResult> {
+    const existing = this.probeInFlight.get(label);
+    if (existing) return existing;
+    const pending = this.fetchQuotaImpl({ accessToken: token, timeoutMs })
+      .finally(() => {
+        // Only clear if WE are still the registered in-flight promise (a later
+        // probe could have replaced it after we settled).
+        if (this.probeInFlight.get(label) === pending) this.probeInFlight.delete(label);
+      });
+    this.probeInFlight.set(label, pending);
+    return pending;
   }
 
   /** Store a successful quota probe in the in-memory cache that `list-state`
@@ -1303,6 +1413,9 @@ export class AuthBroker {
       sevenDayUtilPresent: result.data.sevenDayUtilPresent,
     };
     this.lastQuotaCache[label] = snapshot;
+    // #2495 Change 1 — persist the cache so a broker restart serves this
+    // last-known snapshot (age-stamped via capturedAt) instead of blank.
+    this.persistLastQuotaCache();
     // Self-heal: a fresh, clearly-healthy probe (both windows well under the
     // wall) that is newer than the mark CLEARS the persisted mark — so a
     // misfired/expired exhaustion can't linger on disk and survive restarts
@@ -2514,6 +2627,9 @@ export class AuthBroker {
     this.shaIndex = this.readJson<ShaIndex>("sha-index.json") ?? {};
     this.thresholdViolations = this.readJson<ThresholdViolations>("threshold-violations.json") ?? {};
     this.notificationClaims = this.readJson<NotificationClaims>("notification-claims.json") ?? {};
+    // #2495 Change 1 — reload the durable utilization cache so a restart
+    // serves last-known (age-stamped) quota, not a blank card.
+    this.lastQuotaCache = this.readJson<LastQuotaCache>("last-quota.json") ?? {};
   }
 
   private readJson<T>(name: string): T | null {
@@ -2523,6 +2639,9 @@ export class AuthBroker {
   }
 
   private persistQuota(): void { atomicWriteJsonSync(join(this.stateDir, "quota.json"), this.quota, 0o600); }
+  /** #2495 Change 1 — mirror the utilization cache to disk so it survives
+   *  a broker restart. Same atomic-write pattern as the exhaustion ledger. */
+  private persistLastQuotaCache(): void { atomicWriteJsonSync(join(this.stateDir, "last-quota.json"), this.lastQuotaCache, 0o600); }
   private persistNotificationClaims(): void { atomicWriteJsonSync(join(this.stateDir, "notification-claims.json"), this.notificationClaims, 0o600); }
   private persistShaIndex(): void { atomicWriteJsonSync(join(this.stateDir, "sha-index.json"), this.shaIndex, 0o600); }
   private persistThresholdViolations(): void { atomicWriteJsonSync(join(this.stateDir, "threshold-violations.json"), this.thresholdViolations, 0o600); }
@@ -2738,12 +2857,15 @@ export class AuthBroker {
     shaIndex: ShaIndex;
     thresholdViolations: ThresholdViolations;
     listeners: string[];
+    /** #2495 Change 1 — durable utilization cache (in-memory view). */
+    lastQuotaCache: LastQuotaCache;
   } {
     return {
       quota: { ...this.quota },
       shaIndex: { ...this.shaIndex },
       thresholdViolations: { ...this.thresholdViolations },
       listeners: [...this.listeners.keys()],
+      lastQuotaCache: structuredClone(this.lastQuotaCache),
     };
   }
 

--- a/telegram-plugin/auth-snapshot-format.ts
+++ b/telegram-plugin/auth-snapshot-format.ts
@@ -202,6 +202,14 @@ export interface SnapshotRenderOpts {
   /** Refresh stamp shown in the footer; usually `Date.now()` of the
    *  most recent live probe. Omit to suppress. */
   liveProbedAtMs?: number;
+  /**
+   * #2495 Change 2 — the probe-on-open attempted a live refresh but it
+   * FAILED, so the card is rendered off the durable cache. When set, the
+   * footer shows an explicit "⚠ cached Nm ago" warning (age measured from
+   * this `capturedAt`) instead of a false "Live · refreshed 0s ago" stamp.
+   * Takes precedence over `liveProbedAtMs`.
+   */
+  staleCachedAtMs?: number;
 }
 
 /**
@@ -335,6 +343,14 @@ function renderAccountRow(
  * `buildSnapshotKeyboard` below) — keep the formatting and the
  * keyboard in lockstep so the buttons always reflect current state.
  */
+/** Relative-age stamp shared by the live + degraded footers: "0s ago",
+ *  "3m ago". Measured against `now` (defaults to wall-clock) so tests with
+ *  an injected clock get deterministic output. */
+function formatAgeStamp(atMs: number, now: Date = new Date()): string {
+  const ageSec = Math.max(0, Math.round((now.getTime() - atMs) / 1000));
+  return ageSec < 60 ? `${ageSec}s ago` : `${Math.round(ageSec / 60)}m ago`;
+}
+
 export function renderAuthSnapshotFormat2(
   snapshots: AccountSnapshot[],
   opts: SnapshotRenderOpts = {},
@@ -372,10 +388,13 @@ export function renderAuthSnapshotFormat2(
   lines.push('');
   lines.push('────────────────────────────');
   lines.push(`<i>${recommendation(snapshots, now)}</i>`);
-  if (opts.liveProbedAtMs != null) {
-    const ageSec = Math.max(0, Math.round((Date.now() - opts.liveProbedAtMs) / 1000));
-    const ageStr = ageSec < 60 ? `${ageSec}s ago` : `${Math.round(ageSec / 60)}m ago`;
-    lines.push(`<i>Live · refreshed ${ageStr}</i>`);
+  // #2495 Change 2 — a failed probe-on-open renders an explicit "cached Nm
+  // ago" warning, never a false live stamp. The degraded variant takes
+  // precedence over the live stamp.
+  if (opts.staleCachedAtMs != null) {
+    lines.push(`<i>⚠ cached ${formatAgeStamp(opts.staleCachedAtMs, now)}</i>`);
+  } else if (opts.liveProbedAtMs != null) {
+    lines.push(`<i>Live · refreshed ${formatAgeStamp(opts.liveProbedAtMs, now)}</i>`);
   } else {
     lines.push('<i>Live</i>');
   }
@@ -655,6 +674,10 @@ export interface SnapshotKeyboardOpts {
   /** Limit how many "Switch → X" buttons we render. Beyond this, the
    *  user can drill in via /usage. Default 3. */
   maxSwitchButtons?: number;
+  /** #2495 folded nit A — clock for health classification, threaded so the
+   *  keyboard agrees with the card body instead of defaulting to a second
+   *  `new Date()`. Defaults to wall-clock. */
+  now?: Date;
 }
 
 /**
@@ -673,14 +696,15 @@ export function buildSnapshotKeyboard(
   opts: SnapshotKeyboardOpts = {},
 ): KeyboardRow[] {
   const max = opts.maxSwitchButtons ?? 3;
+  const now = opts.now ?? new Date();
   const rows: KeyboardRow[] = [];
 
   // Switch buttons — healthy non-active first, then throttling
   // non-active. Skip blocked entirely.
   const switchTargets = snapshots
     .filter((s) => !s.isActive)
-    .sort((a, b) => switchPriority(a) - switchPriority(b))
-    .filter((s) => classifyHealth(s) !== 'blocked' && classifyHealth(s) !== 'unknown')
+    .sort((a, b) => switchPriority(a, now) - switchPriority(b, now))
+    .filter((s) => classifyHealth(s, now) !== 'blocked' && classifyHealth(s, now) !== 'unknown')
     .slice(0, max);
 
   for (const t of switchTargets) {
@@ -702,8 +726,8 @@ export function buildSnapshotKeyboard(
 }
 
 /** Lower number = higher priority for "switch to me" button. */
-function switchPriority(s: AccountSnapshot): number {
-  const h = classifyHealth(s);
+function switchPriority(s: AccountSnapshot, now: Date = new Date()): number {
+  const h = classifyHealth(s, now);
   if (h === 'healthy') return 0;
   if (h === 'throttling') return 1;
   if (h === 'unknown') return 2;

--- a/telegram-plugin/gateway/auth-broker-client.ts
+++ b/telegram-plugin/gateway/auth-broker-client.ts
@@ -32,8 +32,8 @@ export function createAuthBrokerClient(): {
     refreshAccount: (label: string) => broker.refreshAccount(label),
     setOverride: (agent: string, account: string | null) =>
       broker.setOverride(agent, account),
-    probeQuota: (accounts: readonly string[], timeoutMs?: number) =>
-      broker.probeQuota(accounts, timeoutMs),
+    probeQuota: (accounts: readonly string[], timeoutMs?: number, forceLive?: boolean) =>
+      broker.probeQuota(accounts, timeoutMs, forceLive),
     claimNotification: (key: string, windowMs: number) =>
       broker.claimNotification(key, windowMs),
   }

--- a/telegram-plugin/gateway/auth-command.ts
+++ b/telegram-plugin/gateway/auth-command.ts
@@ -237,7 +237,19 @@ export interface AuthBrokerClient {
   probeQuota(
     accounts: readonly string[],
     timeoutMs?: number,
-  ): Promise<{ results: Array<{ label: string; result: import('../quota-check.js').QuotaResult }> }>
+    /** #2495 Change 2/3 — bypass the broker's probe-on-open TTL (quota-watch
+     *  alarm corroboration). Normal card opens omit it (TTL-gated). */
+    forceLive?: boolean,
+  ): Promise<{
+    results: Array<{
+      label: string
+      result: import('../quota-check.js').QuotaResult
+      /** #2495 Change 2 — how this result was sourced ("live" vs "cache"). */
+      served?: 'live' | 'cache'
+      /** Unix ms the served snapshot was captured (set when served==="cache"). */
+      capturedAt?: number
+    }>
+  }>
   /**
    * Fleet notification-dedup claim (quota-watch). First caller of `key`
    * inside `windowMs` gets `granted: true` and sends; everyone else
@@ -280,9 +292,22 @@ export interface AuthCommandContext {
    */
   liveQuotas?: (
     accounts: AccountState[],
-  ) => Promise<import('../quota-check.js').QuotaResult[]>
+  ) => Promise<LiveQuotasResult>
   /** Operator timezone forwarded to the Format 2 renderer. */
   tz?: string
+}
+
+/**
+ * #2495 Change 2 — the enriched probe result. `quotas` stays parallel to
+ * `state.accounts` (the contract `buildSnapshotsFromState` relies on);
+ * `staleCachedAtMs` is set when ANY account was served from the durable cache
+ * (probe-on-open TTL hit OR a failed live probe falling back to cache) — it
+ * carries the OLDEST such snapshot's `capturedAt` so the footer stamps
+ * "⚠ cached Nm ago" instead of a false "Live · refreshed 0s ago".
+ */
+export interface LiveQuotasResult {
+  quotas: import('../quota-check.js').QuotaResult[]
+  staleCachedAtMs?: number
 }
 
 export interface AuthCommandReply {
@@ -345,10 +370,18 @@ export async function handleAuthCommand(
       const state = await ctx.client.listState()
       let liveQuotas: import('../quota-check.js').QuotaResult[] | undefined
       let liveProbedAtMs: number | undefined
+      let staleCachedAtMs: number | undefined
       if (ctx.liveQuotas && state.accounts.length > 0) {
         try {
-          liveQuotas = await ctx.liveQuotas(state.accounts)
-          liveProbedAtMs = Date.now()
+          const enriched = await ctx.liveQuotas(state.accounts)
+          liveQuotas = enriched.quotas
+          // #2495 Change 2 — only claim a live "refreshed Ns ago" stamp when
+          // NOTHING was served from cache; otherwise show "⚠ cached Nm ago".
+          if (enriched.staleCachedAtMs != null) {
+            staleCachedAtMs = enriched.staleCachedAtMs
+          } else {
+            liveProbedAtMs = Date.now()
+          }
         } catch {
           // Live probe failed — fall back to legacy table silently.
           liveQuotas = undefined
@@ -361,13 +394,14 @@ export async function handleAuthCommand(
       let keyboard: AuthCommandReply['keyboard']
       if (liveQuotas && liveQuotas.length === state.accounts.length) {
         const snapshots = buildSnapshotsFromState(state, liveQuotas)
-        keyboard = buildSnapshotKeyboard(snapshots)
+        keyboard = buildSnapshotKeyboard(snapshots, { now: new Date() })
       }
       return {
         text: renderShowText(state, Date.now(), {
           liveQuotas,
           tz: ctx.tz,
           liveProbedAtMs,
+          staleCachedAtMs,
         }),
         html: true,
         keyboard,
@@ -709,6 +743,10 @@ export interface RenderShowOpts {
   /** Wall-clock ms when the live probes returned, used for "refreshed
    *  Ns ago" footer. Omit to suppress that footer line. */
   liveProbedAtMs?: number
+  /** #2495 Change 2 — set when the render was served from the durable cache
+   *  (probe-on-open TTL hit or failed probe). Renders "⚠ cached Nm ago" in
+   *  the footer (takes precedence over liveProbedAtMs). */
+  staleCachedAtMs?: number
 }
 
 /**
@@ -745,6 +783,7 @@ export function renderShowText(
         tz: opts.tz,
         now: new Date(now),
         liveProbedAtMs: opts.liveProbedAtMs,
+        staleCachedAtMs: opts.staleCachedAtMs,
       }),
     )
   } else {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -469,6 +469,7 @@ import {
   resolveQuotaWatchTuning,
   buildQuotaClaimKey,
   QUOTA_WATCH_CLAIM_WINDOW_MS,
+  isLiveCorroboration,
 } from '../quota-watch.js'
 import { buildSnapshotsFromState, buildSnapshotsFromCachedState } from '../auth-snapshot-format.js'
 import {
@@ -16150,7 +16151,11 @@ async function runQuotaWatch(opts: { bootTick?: boolean } = {}): Promise<void> {
   // numbers for the notification message bodies. One batched RPC for all
   // crossing accounts (typically 1, rarely 2+).
   const crossingLabels = pendingTransitions.map(t => t.accountLabel)
-  let freshProbeMap = new Map<string, Awaited<ReturnType<typeof brokerClient.probeQuota>>['results'][number]['result']>()
+  // #2495 BLOCKER fix — store the FULL entry (result + `served` tag), not just
+  // `entry.result`. The corroboration gate below needs `served` to tell a true
+  // live probe apart from a failed-probe cache fallback (which is `ok:true`
+  // but `served:"cache"` — vacuous corroboration).
+  let freshProbeMap = new Map<string, Awaited<ReturnType<typeof brokerClient.probeQuota>>['results'][number]>()
   try {
     // #2495 Change 3 — forceLive bypasses the broker's probe-on-open TTL so the
     // DECISION to alarm is corroborated by a TRUE live probe, never a cache hit.
@@ -16160,7 +16165,7 @@ async function runQuotaWatch(opts: { bootTick?: boolean } = {}): Promise<void> {
     // transition.
     const probeData = await brokerClient.probeQuota(crossingLabels, 8000, true)
     for (const entry of probeData.results) {
-      freshProbeMap.set(entry.label, entry.result)
+      freshProbeMap.set(entry.label, entry)
     }
   } catch (err) {
     process.stderr.write(`telegram gateway: quota-watch: probe for crossing accounts failed: ${err}\n`)
@@ -16192,17 +16197,25 @@ async function runQuotaWatch(opts: { bootTick?: boolean } = {}): Promise<void> {
   for (const { accountLabel, snapIndex, decision } of pendingTransitions) {
     // Re-evaluate with fresh probe data to get an accurate message body.
     // If the fresh probe succeeded, replace the snap's quota with live data.
-    const freshResult = freshProbeMap.get(accountLabel)
+    const freshEntry = freshProbeMap.get(accountLabel)
     let enrichedDecision = decision
     // pendingTransitions only ever holds notify decisions (pushed under
     // `decision.kind !== 'skip'` / `!== 'reconcile'`). Narrow explicitly so
     // `decision.transition` type-checks below; this continue never fires
     // at runtime.
     if (decision.kind !== 'notify') continue
-    if (freshResult && freshResult.ok && snapIndex >= 0) {
+    // #2495 BLOCKER fix — only a GENUINE live probe corroborates the alarm. A
+    // forceLive entry that is `ok:true` but `served:"cache"` (the broker's
+    // failed-probe cache fallback) is NOT corroboration: the upstream probe
+    // failed, so we have no live confirmation that the throttling crossing is
+    // real right now. Treat it exactly like a probe failure → fall through to
+    // the defer branch below (state untouched, re-evaluated next tick). This
+    // also guarantees the "Live-probe corroborated (#2495)" footnote is only
+    // ever stamped on a real live probe.
+    if (isLiveCorroboration(freshEntry) && freshEntry!.result.ok && snapIndex >= 0) {
       // Live numbers replace the cache — and capturedAtMs is cleared so the
       // staleness gate never misfires on data we JUST probed.
-      const enrichedSnap = { ...snapshots[snapIndex]!, quota: freshResult.data, capturedAtMs: undefined }
+      const enrichedSnap = { ...snapshots[snapIndex]!, quota: freshEntry!.result.data, capturedAtMs: undefined }
       const prev = watchState[accountLabel] ?? emptyAccountState()
       const re = evaluateQuotaWatchAccount({ agentName, snap: enrichedSnap, prev, now, bootTick, tuning })
       // If the fresh probe still shows the same transition, use the

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -16152,7 +16152,13 @@ async function runQuotaWatch(opts: { bootTick?: boolean } = {}): Promise<void> {
   const crossingLabels = pendingTransitions.map(t => t.accountLabel)
   let freshProbeMap = new Map<string, Awaited<ReturnType<typeof brokerClient.probeQuota>>['results'][number]['result']>()
   try {
-    const probeData = await brokerClient.probeQuota(crossingLabels, 8000)
+    // #2495 Change 3 — forceLive bypasses the broker's probe-on-open TTL so the
+    // DECISION to alarm is corroborated by a TRUE live probe, never a cache hit.
+    // Only the transition-to-alarm pays for this; steady-state polls stay on the
+    // cheap cached listState read (no probe). Honors the existing fleet/consumer
+    // probe knobs upstream — this re-evaluation never fires without a detected
+    // transition.
+    const probeData = await brokerClient.probeQuota(crossingLabels, 8000, true)
     for (const entry of probeData.results) {
       freshProbeMap.set(entry.label, entry.result)
     }
@@ -16661,18 +16667,27 @@ bot.command("auth", async ctx => {
     liveQuotas: async (accounts) => {
       try {
         const { results } = await client.probeQuota(accounts.map((a) => a.label))
+        // #2495 Change 2 — the broker tags each result `served:"live"|"cache"`
+        // (TTL hit or failed-probe fallback). When ANY account was served from
+        // cache, surface the OLDEST snapshot's capturedAt so the card stamps
+        // "⚠ cached Nm ago" instead of a false live stamp.
+        let staleCachedAtMs: number | undefined
         // Preserve input order (broker also preserves it, but be defensive).
-        return accounts.map((a) => {
+        const quotas = accounts.map((a) => {
           const hit = results.find((r) => r.label === a.label)
           if (!hit) return { ok: false as const, reason: "broker returned no result for account" }
+          if (hit.served === 'cache' && hit.capturedAt != null) {
+            staleCachedAtMs = staleCachedAtMs == null ? hit.capturedAt : Math.min(staleCachedAtMs, hit.capturedAt)
+          }
           return hit.result
         })
+        return { quotas, staleCachedAtMs }
       } catch (err) {
         // Surface a uniform per-account failure so the dashboard renders
         // gracefully (label badge stays UNKNOWN) instead of falling back
         // to the legacy table.
         const reason = `broker probe-quota failed: ${(err as Error)?.message ?? String(err)}`
-        return accounts.map(() => ({ ok: false as const, reason }))
+        return { quotas: accounts.map(() => ({ ok: false as const, reason })) }
       }
     },
     tz: process.env.SWITCHROOM_TIMEZONE ?? process.env.TZ,
@@ -19039,9 +19054,17 @@ bot.command('usage', async ctx => {
       const state = await client.listState()
       if (state.accounts.length > 0) {
         // Broker-routed probe (#1336) — see gateway.ts:8910 for diagnosis.
+        // #2495 Change 2 — the broker applies a probe-on-open TTL + single-
+        // flight; a TTL-hit or failed-probe fallback is tagged served:"cache",
+        // which we surface as a "⚠ cached Nm ago" footer instead of a false
+        // live stamp.
         const probeResp = await client.probeQuota(state.accounts.map((a) => a.label)).catch(() => ({ results: [] }))
+        let staleCachedAtMs: number | undefined
         const quotas = state.accounts.map((a) => {
           const hit = probeResp.results.find((r) => r.label === a.label)
+          if (hit?.served === 'cache' && hit.capturedAt != null) {
+            staleCachedAtMs = staleCachedAtMs == null ? hit.capturedAt : Math.min(staleCachedAtMs, hit.capturedAt)
+          }
           return hit?.result ?? { ok: false as const, reason: 'broker returned no result for account' }
         })
         const { renderAuthSnapshotFormat2, buildSnapshotsFromState } = await import(
@@ -19052,7 +19075,7 @@ bot.command('usage', async ctx => {
         const text = renderAuthSnapshotFormat2(snapshots, {
           tz,
           now: new Date(),
-          liveProbedAtMs: Date.now(),
+          ...(staleCachedAtMs != null ? { staleCachedAtMs } : { liveProbedAtMs: Date.now() }),
         })
         await switchroomReply(ctx, text, { html: true })
         return

--- a/telegram-plugin/quota-watch.ts
+++ b/telegram-plugin/quota-watch.ts
@@ -30,6 +30,13 @@
  * IPC call (cheap). `probeQuota` is only called on state-change (when
  * we're going to send a message anyway) to get fresh numbers for the
  * notification body. On no-change polls, only `listState` is called.
+ *
+ * #2495 Change 3 — the transition-to-alarm probe is `forceLive` (bypasses
+ * the broker's probe-on-open TTL), so the DECISION to alarm is corroborated
+ * by a TRUE live probe of the affected account, not a possibly-stale cache
+ * read. The re-evaluation with fresh numbers can suppress an alarm whose
+ * stale-snapshot transition no longer holds. Steady state stays cheap: a
+ * no-change poll never probes. Cost is one live probe per transition edge.
  */
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
@@ -493,7 +500,7 @@ function buildThrottlingMessage(agentName: string, snap: AccountSnapshot): strin
     `Binding window: ${winLabel}${resetStr}`,
     `${activeNote}${altNote}`,
     ``,
-    `<i>Threshold: ${THROTTLING_THRESHOLD_PCT}% on either window. Source: broker quota cache.</i>`,
+    `<i>Threshold: ${THROTTLING_THRESHOLD_PCT}% on either window. Live-probe corroborated (#2495).</i>`,
     `<i>Run /auth for full fleet status or /usage for the active account.</i>`,
   ]
     .join("\n")

--- a/telegram-plugin/quota-watch.ts
+++ b/telegram-plugin/quota-watch.ts
@@ -183,6 +183,51 @@ export type QuotaWatchDecision =
   | { kind: "skip"; accountLabel: string; reason: string };
 
 /**
+ * #2495 BLOCKER fix — the corroboration probe result, as the gateway's
+ * runQuotaWatch sees it from `brokerClient.probeQuota(..., forceLive=true)`.
+ * Structurally a subset of `ProbeQuotaEntry` (src/auth/broker/client.ts): a
+ * `result` discriminated on `ok`, plus a `served` tag the broker stamps to
+ * say HOW the result was sourced.
+ *
+ * The trap this guards: under `forceLive`, when the upstream live probe FAILS
+ * and the broker holds a prior snapshot, it returns `cachedSnapshotToResult`
+ * — `result.ok === true` but `served === "cache"` (server.ts opProbeQuota).
+ * A naive `result.ok` check then treats that stale cache read as a live
+ * corroboration, fires the alarm, and stamps the false "Live-probe
+ * corroborated (#2495)" footnote. The acceptance criterion is the opposite:
+ * an alarm must be backed by a LIVE probe, not a stale cache read.
+ */
+export type CorroborationProbe = {
+  result: { ok: true } | { ok: false };
+  /**
+   * How the result was sourced. `"live"` = fresh upstream probe (genuine
+   * corroboration). `"cache"` = served from the durable cache (TTL-hit or
+   * probe-failure fallback) — NOT corroboration. Absent on legacy responses,
+   * which we treat as NOT corroborated (fail-closed: never claim a live
+   * corroboration we can't prove).
+   */
+  served?: "live" | "cache";
+};
+
+/**
+ * #2495 BLOCKER fix — decide whether a forceLive corroboration probe counts
+ * as a genuine LIVE corroboration of the alarm.
+ *
+ * Genuine corroboration requires BOTH `result.ok` AND `served === "live"`.
+ * A result that is `ok:true` but `served:"cache"` (the failed-probe
+ * cache-fallback) is treated EXACTLY like a probe failure: it is NOT
+ * corroboration, so the caller must DEFER — leave watch state untouched and
+ * re-evaluate next tick when a true live probe can be obtained. A missing
+ * entry (`undefined`) is likewise not corroboration.
+ *
+ * Pure + total so it can be unit-tested at the seam without standing up the
+ * broker or the gateway loop.
+ */
+export function isLiveCorroboration(entry: CorroborationProbe | undefined): boolean {
+  return entry?.result.ok === true && entry.served === "live";
+}
+
+/**
  * Evaluate one account's quota state against its last-notified health.
  *
  * Transition table (after the staleness gate — a cached snapshot older

--- a/telegram-plugin/tests/auth-command-format2.test.ts
+++ b/telegram-plugin/tests/auth-command-format2.test.ts
@@ -127,7 +127,8 @@ describe('handleAuthCommand — keyboard attachment', () => {
   it('attaches a smart keyboard when liveQuotas yields one result per account', async () => {
     const reply = await handleAuthCommand(
       { kind: 'show' },
-      makeCtx({ liveQuotas: async () => FIXTURE_QUOTAS, tz: 'UTC' }),
+      // #2495 Change 2 — the enricher now returns { quotas, staleCachedAtMs? }.
+      makeCtx({ liveQuotas: async () => ({ quotas: FIXTURE_QUOTAS }), tz: 'UTC' }),
     );
     expect(reply.keyboard).toBeDefined();
     const allButtonText = reply.keyboard!.flat().map((b) => b.text);
@@ -152,5 +153,29 @@ describe('handleAuthCommand — keyboard attachment', () => {
     );
     expect(reply.keyboard).toBeUndefined();
     expect(reply.text).toContain('ACCOUNT'); // legacy table fallback
+  });
+
+  it('#2495 Change 2 — stamps "⚠ cached Nm ago" when the enricher reports a cache fallback', async () => {
+    const reply = await handleAuthCommand(
+      { kind: 'show' },
+      makeCtx({
+        liveQuotas: async () => ({
+          quotas: FIXTURE_QUOTAS,
+          staleCachedAtMs: Date.now() - 5 * 60_000, // 5 min old cache
+        }),
+        tz: 'UTC',
+      }),
+    );
+    expect(reply.text).toContain('⚠ cached');
+    expect(reply.text).not.toContain('Live · refreshed');
+  });
+
+  it('#2495 Change 2 — stamps a live refresh when the enricher reports no cache fallback', async () => {
+    const reply = await handleAuthCommand(
+      { kind: 'show' },
+      makeCtx({ liveQuotas: async () => ({ quotas: FIXTURE_QUOTAS }), tz: 'UTC' }),
+    );
+    expect(reply.text).toContain('Live · refreshed');
+    expect(reply.text).not.toContain('⚠ cached');
   });
 });

--- a/telegram-plugin/tests/auth-snapshot-format.test.ts
+++ b/telegram-plugin/tests/auth-snapshot-format.test.ts
@@ -247,9 +247,29 @@ describe('renderAuthSnapshotFormat2', () => {
   it('renders refresh stamp when liveProbedAtMs given', () => {
     const out = renderAuthSnapshotFormat2(fixtureSnaps.slice(0, 1), {
       now: NOW,
-      liveProbedAtMs: Date.now() - 12_000,
+      liveProbedAtMs: NOW.getTime() - 12_000,
     });
     expect(out).toMatch(/<i>Live · refreshed \d+s ago<\/i>/);
+  });
+
+  it('#2495 Change 2 — renders "⚠ cached Nm ago" (NOT a live stamp) on staleCachedAtMs', () => {
+    const out = renderAuthSnapshotFormat2(fixtureSnaps.slice(0, 1), {
+      now: NOW,
+      staleCachedAtMs: NOW.getTime() - 3 * 60_000, // 3 min old cache
+    });
+    expect(out).toMatch(/<i>⚠ cached 3m ago<\/i>/);
+    // Crucially: no false live stamp.
+    expect(out).not.toContain('Live · refreshed');
+  });
+
+  it('#2495 Change 2 — staleCachedAtMs takes precedence over liveProbedAtMs', () => {
+    const out = renderAuthSnapshotFormat2(fixtureSnaps.slice(0, 1), {
+      now: NOW,
+      liveProbedAtMs: NOW.getTime(),
+      staleCachedAtMs: NOW.getTime() - 90_000,
+    });
+    expect(out).toContain('⚠ cached');
+    expect(out).not.toContain('Live · refreshed');
   });
 });
 
@@ -394,6 +414,31 @@ describe('buildSnapshotKeyboard', () => {
     const rows = buildSnapshotKeyboard(snaps, { maxSwitchButtons: 2 });
     const switchRows = rows.slice(0, -1);
     expect(switchRows.length).toBe(2);
+  });
+
+  it('#2495 nit A — threads `now` so a refilled-since-snapshot account is offered as a switch target', () => {
+    // refilled@x reads 100% on 5h, but its reset is in the PAST relative to the
+    // threaded `now` → refill-normalized to 0% → healthy → a valid switch
+    // target. With a default `new Date()` (well after the fixture epoch) the
+    // normalization still treats it as refilled, so to prove the THREADING we
+    // compare two explicit clocks.
+    const resetAt = new Date('2026-05-15T00:00:00Z'); // before `now`
+    const snaps: AccountSnapshot[] = [
+      snap({ label: 'active@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 5 }) }),
+      snap({
+        label: 'refilled@x',
+        quota: quota({ fiveHourUtilizationPct: 100, fiveHourResetAt: resetAt }),
+      }),
+    ];
+    // `now` AFTER the reset → refilled@x normalizes to healthy → offered.
+    const after = buildSnapshotKeyboard(snaps, { now: new Date('2026-05-15T00:53:00Z') })
+      .flat().map((b) => b.text);
+    expect(after).toContain('Switch fleet → refilled@x');
+    // `now` BEFORE the reset → still walled → NOT offered. Proves the threaded
+    // clock actually drives classification (a default-`now` impl would ignore it).
+    const before = buildSnapshotKeyboard(snaps, { now: new Date('2026-05-14T23:00:00Z') })
+      .flat().map((b) => b.text);
+    expect(before).not.toContain('Switch fleet → refilled@x');
   });
 });
 

--- a/telegram-plugin/tests/quota-watch.test.ts
+++ b/telegram-plugin/tests/quota-watch.test.ts
@@ -18,6 +18,8 @@ import {
   patchQuotaWatchState,
   emptyQuotaWatchState,
   emptyAccountState,
+  isLiveCorroboration,
+  type CorroborationProbe,
 } from "../quota-watch.js";
 import type { AccountSnapshot } from "../auth-snapshot-format.js";
 import type { QuotaUtilization } from "../quota-check.js";
@@ -285,6 +287,79 @@ describe("evaluateQuotaWatchAccount — message content", () => {
     expect(d.kind).toBe("notify");
     if (d.kind !== "notify") return;
     expect(d.message).toContain("refills in");
+  });
+});
+
+// ── corroboration gate (#2495 BLOCKER) ───────────────────────────────────────
+
+describe("isLiveCorroboration — only a genuine live probe corroborates (#2495 BLOCKER)", () => {
+  // A successful upstream live probe.
+  const LIVE_OK: CorroborationProbe = { result: { ok: true }, served: "live" };
+  // The trap: under forceLive, when the upstream probe FAILS but the broker
+  // holds a prior snapshot, opProbeQuota returns cachedSnapshotToResult →
+  // result.ok === true but served === "cache". Vacuous corroboration.
+  const CACHE_FALLBACK_AFTER_PROBE_FAIL: CorroborationProbe = {
+    result: { ok: true },
+    served: "cache",
+  };
+  // A hard probe failure with no prior snapshot to fall back on.
+  const PROBE_FAILED: CorroborationProbe = { result: { ok: false }, served: "live" };
+
+  it("a genuine live probe (ok:true, served:'live') corroborates", () => {
+    expect(isLiveCorroboration(LIVE_OK)).toBe(true);
+  });
+
+  it("a failed-probe cache fallback (ok:true, served:'cache') does NOT corroborate", () => {
+    // This is the BLOCKER: a stale cache read must NOT be mistaken for a live
+    // corroboration, even though result.ok is true.
+    expect(isLiveCorroboration(CACHE_FALLBACK_AFTER_PROBE_FAIL)).toBe(false);
+  });
+
+  it("a failed probe (ok:false) does NOT corroborate", () => {
+    expect(isLiveCorroboration(PROBE_FAILED)).toBe(false);
+  });
+
+  it("a missing entry (probe absent from batch result) does NOT corroborate", () => {
+    expect(isLiveCorroboration(undefined)).toBe(false);
+  });
+
+  it("a legacy entry with no `served` tag does NOT corroborate (fail-closed)", () => {
+    expect(isLiveCorroboration({ result: { ok: true } })).toBe(false);
+  });
+
+  // Simulate the gateway gate (runQuotaWatch). The gate fires the alarm and
+  // stamps the "Live-probe corroborated" footnote ONLY when
+  // isLiveCorroboration is true; otherwise it DEFERS (state untouched).
+  function gateDecision(entry: CorroborationProbe | undefined): {
+    fired: boolean;
+    message: string | null;
+  } {
+    if (isLiveCorroboration(entry)) {
+      // Genuine corroboration → re-evaluate and notify with the live numbers.
+      const d = evaluateQuotaWatchAccount({
+        agentName: "lawgpt",
+        snap: THROTTLING_5H,
+        prev: PREV_NEVER_NOTIFIED,
+        now: NOW,
+      });
+      return { fired: true, message: d.kind === "notify" ? d.message : null };
+    }
+    // Not corroborated → defer. No alarm, no footnote.
+    return { fired: false, message: null };
+  }
+
+  it("failed-probe cache fallback → alarm DEFERRED, no false 'Live-probe corroborated' footnote", () => {
+    const decision = gateDecision(CACHE_FALLBACK_AFTER_PROBE_FAIL);
+    expect(decision.fired).toBe(false);
+    expect(decision.message).toBeNull();
+    // The false footnote must NOT be produced on this path.
+    expect(decision.message ?? "").not.toContain("Live-probe corroborated");
+  });
+
+  it("genuine live probe → alarm FIRES and stamps the 'Live-probe corroborated' footnote", () => {
+    const decision = gateDecision(LIVE_OK);
+    expect(decision.fired).toBe(true);
+    expect(decision.message).toContain("Live-probe corroborated");
   });
 });
 

--- a/telegram-plugin/tests/quota-watch.test.ts
+++ b/telegram-plugin/tests/quota-watch.test.ts
@@ -217,6 +217,22 @@ describe("evaluateQuotaWatchAccount — message content", () => {
     expect(d.message).toContain("5-hour");
   });
 
+  it("#2495 Change 3 — throttling alarm advertises live-probe corroboration, not a raw cache read", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: THROTTLING_5H,
+      prev: PREV_NEVER_NOTIFIED,
+      now: NOW,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    // The alarm body's source-of-truth footnote must reflect that the gateway
+    // corroborates the alarm with a forceLive probe (the broker re-probe at
+    // gateway.ts runQuotaWatch), not "Source: broker quota cache".
+    expect(d.message).toContain("Live-probe corroborated");
+    expect(d.message).not.toContain("Source: broker quota cache");
+  });
+
   it("recovery message contains account label and percentages", () => {
     const d = evaluateQuotaWatchAccount({
       agentName: "lawgpt",


### PR DESCRIPTION
Implements PR2 of the quota accuracy stack — closes #2495. Stacks on PR1 (#2496, merged 5b71c5c); branched off fresh `main` and builds on PR1's `isProbeThin` / `refillNormalizedUtils` helpers + presence markers.

**JTBD:** `track-plan-quota-live` (hold-the-leash). PR1 made classification honest; PR2 makes the underlying data **durable** (survives a broker restart) and **realtime** (short-TTL probe-on-open), with proactive alarms now **live-verified**.

## Change 1 — durable quota cache
`broker.lastQuotaCache` was in-memory only, wiped on every restart until the next 10-min fleet tick. Now mirrored to disk and reloaded on boot, so `/auth` immediately serves last-known (age-stamped) quota after a restart instead of blank/`unknown`. `capturedAt` + the #2494 presence markers round-trip.

- `src/auth/broker/server.ts` — `persistLastQuotaCache()` writes `last-quota.json` (same `atomicWriteJsonSync` + reload pattern as the exhaustion ledger `quota.json`); `loadStateFromDisk()` reloads it; `cacheQuotaSnapshot()` persists on every write.

## Change 2 — probe-on-open TTL + single-flight
`/auth` and `/usage` attempted live but silently fell back to stale cache on probe failure and still rendered a clean live-looking card. Now:
- On card open the broker forces a live probe **only** when the cached snapshot age exceeds a short TTL (**45 s**, env knob **`SWITCHROOM_QUOTA_PROBE_TTL_MS`**, `0` disables the gate); otherwise it serves cache.
- **Single-flight**: concurrent `probe-quota` requests for one account share one in-flight upstream call (a render storm = 1 API call per account, not N), keyed by account label.
- On probe failure the cached snapshot is served tagged `served:"cache"`, so the footer stamps **`⚠ cached Nm ago`** instead of a false `Live · refreshed 0s ago`.

- `src/auth/broker/server.ts` — TTL gate + `probeQuotaSingleFlight()` + `cachedSnapshotToResult()`; `forceLive` honored.
- `src/auth/broker/protocol.ts` / `client.ts` — `forceLive` request flag; `served` / `capturedAt` on `ProbeQuotaEntry`.
- `telegram-plugin/auth-snapshot-format.ts` — `staleCachedAtMs` render opt + `formatAgeStamp()`; degraded `⚠ cached Nm ago` footer (takes precedence over the live stamp).
- `telegram-plugin/gateway/auth-command.ts` — `LiveQuotasResult` ({ quotas, staleCachedAtMs }); threads the stamp through `renderShowText`.
- `telegram-plugin/gateway/gateway.ts` — `/auth` enricher + `/usage` path compute the oldest cache `capturedAt` and pass `staleCachedAtMs`.
- `telegram-plugin/gateway/auth-broker-client.ts` — adapter forwards `forceLive`.

## Change 3 — proactive push corroborates before alarming
The quota-watch transition-to-alarm probe is now **`forceLive`** (bypasses the probe-on-open TTL), so the **decision** to alarm is taken off a true live probe of the affected account, never a possibly-stale cache read. Steady-state polls stay cache-only (cheap); only the alarm edge pays for one probe. Respects the existing `SWITCHROOM_DISABLE_FLEET_QUOTA_PROBE` / `SWITCHROOM_CONSUMER_QUOTA_PROBE_MS` knobs.

- `telegram-plugin/gateway/gateway.ts` — `runQuotaWatch` corroboration probe passes `forceLive: true`.
- `telegram-plugin/quota-watch.ts` — alarm footnote now "Live-probe corroborated (#2495)"; module docstring updated.

## Folded review nits from #2496
- **A** — `auth-snapshot-format.ts` `buildSnapshotKeyboard` + `switchPriority` now thread `now` into `classifyHealth` instead of defaulting to a second `new Date()`, so the keyboard agrees with the card body.
- **B** — broker self-heal `snapshotShouldClearMark` (`account-eligibility.ts`) now refuses to clear an exhaustion mark on a THIN probe (via `isProbeThin`): a headerless 0%-coalesced probe read as "clearly healthy" and could un-exhaust a real wall. Real latent correctness gap, guarded.

## Cost guardrails
Each live probe is a billable `POST /v1/messages` that consumes a sliver of the account's own quota (the only ratelimit-header source — `quota.ts`). TTL + single-flight together cap probe volume to **≤1 upstream call per account per TTL window** regardless of render count. The chosen TTL (45 s) and the per-probe cost are documented in code comments.

## Tests
- Persistence round-trip — write → reload → identical incl. markers + on-disk-matches-memory (`server-quota-durable.test.ts`).
- TTL gate — a fresh cache hit serves cache, skips the upstream probe.
- Single-flight — two concurrent probes (cold cache) trigger exactly one upstream call.
- Stale-fallback labeling — a failed probe is served `cache`; card stamps `⚠ cached Nm ago` (`auth-snapshot-format.test.ts`, `auth-command-format2.test.ts`).
- `forceLive` bypasses the TTL gate.
- Thin probe does NOT clear an exhaustion mark; a real / partial probe does (`account-eligibility.test.ts`).
- Nit A — keyboard threads `now` (refilled-since-snapshot account offered/withheld by clock).
- Alarm corroboration footnote (`quota-watch.test.ts`).

`tsc --noEmit` + `npm run lint` (incl. plugin-references, bot-api-wrapping, bun-test-imports) green. All touched test files pass under both vitest and bun. The remaining repo-suite failures are pre-existing sandbox-only baseline failures (install/scaffold/hook/token-helper tests that need a real install env) — verified identical on clean `main`; no new regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)