### PR TITLE
fix(hostd): defer refresh-hostd/refresh-web when update_apply runs in hostd-context (#2458)

### DIFF
--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -8,7 +8,16 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { planUpdate, runUpdate, isGitCheckout, rebuildRefusalMessage } from "./update.js";
+import {
+  planUpdate,
+  runUpdate,
+  isGitCheckout,
+  rebuildRefusalMessage,
+  isHostdContext,
+  encodeUpdateResultLine,
+  parseUpdateResultLine,
+  UPDATE_RESULT_SENTINEL,
+} from "./update.js";
 
 function fakeRunner() {
   const calls: Array<{ cmd: string; args: string[] }> = [];
@@ -981,5 +990,217 @@ describe("isGitCheckout", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
+  });
+});
+
+// ── #2458 hostd-context deferral ──────────────────────────────────────────────
+
+describe("isHostdContext", () => {
+  it("returns true when SWITCHROOM_HOSTD_CONTEXT is '1'", () => {
+    expect(isHostdContext({ SWITCHROOM_HOSTD_CONTEXT: "1" })).toBe(true);
+  });
+
+  it("returns false when SWITCHROOM_HOSTD_CONTEXT is absent", () => {
+    expect(isHostdContext({})).toBe(false);
+  });
+
+  it("returns false when SWITCHROOM_HOSTD_CONTEXT is set to another value", () => {
+    expect(isHostdContext({ SWITCHROOM_HOSTD_CONTEXT: "true" })).toBe(false);
+    expect(isHostdContext({ SWITCHROOM_HOSTD_CONTEXT: "0" })).toBe(false);
+  });
+});
+
+describe("encodeUpdateResultLine / parseUpdateResultLine", () => {
+  it("round-trips { ok: true, deferred: ['refresh-hostd', 'refresh-web'] }", () => {
+    const payload = { ok: true, deferred: ["refresh-hostd", "refresh-web"] };
+    const line = encodeUpdateResultLine(payload);
+    expect(line.startsWith(UPDATE_RESULT_SENTINEL)).toBe(true);
+    const parsed = parseUpdateResultLine(line);
+    expect(parsed).toEqual(payload);
+  });
+
+  it("round-trips { ok: false, deferred: ['refresh-hostd'] }", () => {
+    const payload = { ok: false, deferred: ["refresh-hostd"] };
+    const line = encodeUpdateResultLine(payload);
+    const parsed = parseUpdateResultLine(line);
+    expect(parsed).toEqual(payload);
+  });
+
+  it("returns null for stdout with no sentinel", () => {
+    expect(parseUpdateResultLine("no sentinel here\n")).toBeNull();
+    expect(parseUpdateResultLine("")).toBeNull();
+  });
+
+  it("returns null for malformed JSON after the sentinel", () => {
+    expect(parseUpdateResultLine(`${UPDATE_RESULT_SENTINEL}not-json`)).toBeNull();
+  });
+
+  it("returns null for JSON missing required fields", () => {
+    expect(
+      parseUpdateResultLine(`${UPDATE_RESULT_SENTINEL}{"ok":true}`),
+    ).toBeNull();
+    expect(
+      parseUpdateResultLine(`${UPDATE_RESULT_SENTINEL}{"deferred":[]}`),
+    ).toBeNull();
+  });
+
+  it("finds the LAST sentinel line when stdout has multiple occurrences", () => {
+    const first = encodeUpdateResultLine({ ok: false, deferred: ["refresh-hostd"] });
+    const second = encodeUpdateResultLine({ ok: true, deferred: ["refresh-hostd", "refresh-web"] });
+    const combined = `some preamble\n${first}\nmore output\n${second}\n`;
+    const parsed = parseUpdateResultLine(combined);
+    // Must return the LAST sentinel (ok: true), not the first (ok: false).
+    expect(parsed?.ok).toBe(true);
+    expect(parsed?.deferred).toEqual(["refresh-hostd", "refresh-web"]);
+  });
+});
+
+describe("planUpdate — hostdContext deferral (#2458)", () => {
+  it("refresh-hostd gets skipReason containing 'deferred' when hostdContext=true and hostControlEnabled=true", () => {
+    const steps = planUpdate({
+      hostControlEnabled: true,
+      webServiceManaged: false,
+      memoryBackendHindsight: false,
+      skipImages: false,
+      hostdContext: true,
+    });
+    const step = steps.find((s) => s.name === "refresh-hostd")!;
+    expect(step).toBeDefined();
+    expect(step.skipReason).toMatch(/deferred/);
+    expect(step.skipReason).toMatch(/#2458/);
+  });
+
+  it("refresh-web gets skipReason containing 'deferred' when hostdContext=true and webServiceManaged=true", () => {
+    const steps = planUpdate({
+      hostControlEnabled: false,
+      webServiceManaged: true,
+      memoryBackendHindsight: false,
+      skipImages: false,
+      hostdContext: true,
+    });
+    const step = steps.find((s) => s.name === "refresh-web")!;
+    expect(step).toBeDefined();
+    expect(step.skipReason).toMatch(/deferred/);
+    expect(step.skipReason).toMatch(/#2458/);
+  });
+
+  it("refresh-hostd still skips with existing reason when hostControlEnabled=false (hostdContext is not checked)", () => {
+    const steps = planUpdate({
+      hostControlEnabled: false,
+      webServiceManaged: false,
+      memoryBackendHindsight: false,
+      skipImages: false,
+      hostdContext: true,
+    });
+    const step = steps.find((s) => s.name === "refresh-hostd")!;
+    expect(step.skipReason).toMatch(/host_control.enabled is not true/);
+    expect(step.skipReason).not.toMatch(/deferred/);
+  });
+
+  it("refresh-hostd has NO skipReason when hostdContext=false and hostControlEnabled=true", () => {
+    const steps = planUpdate({
+      hostControlEnabled: true,
+      webServiceManaged: false,
+      memoryBackendHindsight: false,
+      skipImages: false,
+      hostdContext: false,
+    });
+    const step = steps.find((s) => s.name === "refresh-hostd")!;
+    expect(step.skipReason).toBeUndefined();
+  });
+
+  it("--skip-images reason still wins over hostdContext deferral", () => {
+    const steps = planUpdate({
+      hostControlEnabled: true,
+      webServiceManaged: true,
+      memoryBackendHindsight: false,
+      skipImages: true,
+      hostdContext: true,
+    });
+    const hostd = steps.find((s) => s.name === "refresh-hostd")!;
+    const web = steps.find((s) => s.name === "refresh-web")!;
+    expect(hostd.skipReason).toBe("--skip-images flag set");
+    expect(web.skipReason).toBe("--skip-images flag set");
+  });
+});
+
+describe("runUpdate — hostdContext sentinel emission (#2458)", () => {
+  it("emits SWITCHROOM_UPDATE_RESULT sentinel with deferred steps on success", async () => {
+    const lines: string[] = [];
+    const code = await runUpdate({
+      hostControlEnabled: true,
+      webServiceManaged: true,
+      memoryBackendHindsight: false,
+      skipImages: false,
+      hostdContext: true,
+      // Supply a no-op runner so pull-images / apply-config etc. succeed without docker.
+      runner: () => ({ status: 0 }),
+      // Provide a composePath so the pull-images step doesn't skip on missing file.
+      composePath: "/dev/null",
+      // Prevent sync-bundled-skills from writing to real ~/.switchroom.
+      syncBundledSkillsFn: () => {},
+      // Prevent stamp-restart-marker from reading real config.
+      agentNamesFn: () => [],
+      writeMarkerFn: () => {},
+      stdout: (s) => lines.push(s),
+      stderr: () => {},
+    });
+    expect(code).toBe(0);
+    const allOut = lines.join("");
+    expect(allOut).toContain(UPDATE_RESULT_SENTINEL);
+    const parsed = parseUpdateResultLine(allOut);
+    expect(parsed?.ok).toBe(true);
+    expect(parsed?.deferred).toContain("refresh-hostd");
+    expect(parsed?.deferred).toContain("refresh-web");
+  });
+
+  it("does NOT emit sentinel when hostdContext=false (no deferred steps)", async () => {
+    const lines: string[] = [];
+    await runUpdate({
+      hostControlEnabled: false,
+      webServiceManaged: false,
+      memoryBackendHindsight: false,
+      skipImages: false,
+      hostdContext: false,
+      runner: () => ({ status: 0 }),
+      composePath: "/dev/null",
+      syncBundledSkillsFn: () => {},
+      agentNamesFn: () => [],
+      writeMarkerFn: () => {},
+      stdout: (s) => lines.push(s),
+      stderr: () => {},
+    });
+    const allOut = lines.join("");
+    expect(allOut).not.toContain(UPDATE_RESULT_SENTINEL);
+  });
+
+  it("emits sentinel with ok=false when a non-deferred step fails mid-run", async () => {
+    const lines: string[] = [];
+    let callCount = 0;
+    const code = await runUpdate({
+      hostControlEnabled: true,
+      webServiceManaged: false,
+      memoryBackendHindsight: false,
+      skipImages: false,
+      hostdContext: true,
+      runner: () => {
+        // Fail only the first real step (pull-images) to trigger the failure path.
+        callCount++;
+        return { status: callCount === 1 ? 1 : 0 };
+      },
+      composePath: "/dev/null",
+      syncBundledSkillsFn: () => {},
+      agentNamesFn: () => [],
+      writeMarkerFn: () => {},
+      stdout: (s) => lines.push(s),
+      stderr: () => {},
+    });
+    expect(code).toBe(1);
+    const allOut = lines.join("");
+    // Sentinel IS emitted on failure when there are deferred steps.
+    expect(allOut).toContain(UPDATE_RESULT_SENTINEL);
+    const parsed = parseUpdateResultLine(allOut);
+    expect(parsed?.ok).toBe(false);
+    expect(parsed?.deferred).toContain("refresh-hostd");
   });
 });

--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -1056,7 +1056,7 @@ describe("encodeUpdateResultLine / parseUpdateResultLine", () => {
 });
 
 describe("planUpdate — hostdContext deferral (#2458)", () => {
-  it("refresh-hostd gets skipReason containing 'deferred' when hostdContext=true and hostControlEnabled=true", () => {
+  it("refresh-hostd gets skipReason containing 'deferred' and isHostdDeferred=true when hostdContext=true and hostControlEnabled=true", () => {
     const steps = planUpdate({
       hostControlEnabled: true,
       webServiceManaged: false,
@@ -1068,9 +1068,10 @@ describe("planUpdate — hostdContext deferral (#2458)", () => {
     expect(step).toBeDefined();
     expect(step.skipReason).toMatch(/deferred/);
     expect(step.skipReason).toMatch(/#2458/);
+    expect(step.isHostdDeferred).toBe(true);
   });
 
-  it("refresh-web gets skipReason containing 'deferred' when hostdContext=true and webServiceManaged=true", () => {
+  it("refresh-web gets skipReason containing 'deferred' and isHostdDeferred=true when hostdContext=true and webServiceManaged=true", () => {
     const steps = planUpdate({
       hostControlEnabled: false,
       webServiceManaged: true,
@@ -1082,6 +1083,7 @@ describe("planUpdate — hostdContext deferral (#2458)", () => {
     expect(step).toBeDefined();
     expect(step.skipReason).toMatch(/deferred/);
     expect(step.skipReason).toMatch(/#2458/);
+    expect(step.isHostdDeferred).toBe(true);
   });
 
   it("refresh-hostd still skips with existing reason when hostControlEnabled=false (hostdContext is not checked)", () => {
@@ -1095,9 +1097,10 @@ describe("planUpdate — hostdContext deferral (#2458)", () => {
     const step = steps.find((s) => s.name === "refresh-hostd")!;
     expect(step.skipReason).toMatch(/host_control.enabled is not true/);
     expect(step.skipReason).not.toMatch(/deferred/);
+    expect(step.isHostdDeferred).toBeFalsy();
   });
 
-  it("refresh-hostd has NO skipReason when hostdContext=false and hostControlEnabled=true", () => {
+  it("refresh-hostd has NO skipReason and isHostdDeferred is falsy when hostdContext=false and hostControlEnabled=true", () => {
     const steps = planUpdate({
       hostControlEnabled: true,
       webServiceManaged: false,
@@ -1107,9 +1110,10 @@ describe("planUpdate — hostdContext deferral (#2458)", () => {
     });
     const step = steps.find((s) => s.name === "refresh-hostd")!;
     expect(step.skipReason).toBeUndefined();
+    expect(step.isHostdDeferred).toBeFalsy();
   });
 
-  it("--skip-images reason still wins over hostdContext deferral", () => {
+  it("--skip-images reason still wins over hostdContext deferral; isHostdDeferred is false", () => {
     const steps = planUpdate({
       hostControlEnabled: true,
       webServiceManaged: true,
@@ -1121,6 +1125,38 @@ describe("planUpdate — hostdContext deferral (#2458)", () => {
     const web = steps.find((s) => s.name === "refresh-web")!;
     expect(hostd.skipReason).toBe("--skip-images flag set");
     expect(web.skipReason).toBe("--skip-images flag set");
+    // --skip-images is not a hostd-context deferral; isHostdDeferred must be false
+    expect(hostd.isHostdDeferred).toBeFalsy();
+    expect(web.isHostdDeferred).toBeFalsy();
+  });
+
+  it("deferred sentinel uses isHostdDeferred flag (not skipReason string match) to identify deferred steps", async () => {
+    // This test ensures the sentinel emitted by runUpdate correctly identifies
+    // deferred steps via the explicit isHostdDeferred flag, not string coupling.
+    const lines: string[] = [];
+    const code = await runUpdate({
+      hostControlEnabled: true,
+      webServiceManaged: true,
+      memoryBackendHindsight: false,
+      skipImages: false,
+      hostdContext: true,
+      runner: () => ({ status: 0 }),
+      composePath: "/dev/null",
+      syncBundledSkillsFn: () => {},
+      agentNamesFn: () => [],
+      writeMarkerFn: () => {},
+      stdout: (s) => lines.push(s),
+      stderr: () => {},
+    });
+    expect(code).toBe(0);
+    const allOut = lines.join("");
+    const parsed = parseUpdateResultLine(allOut);
+    // The deferred list must contain exactly the isHostdDeferred=true steps
+    expect(parsed?.deferred).toContain("refresh-hostd");
+    expect(parsed?.deferred).toContain("refresh-web");
+    // Steps whose skipReason doesn't include "deferred" must NOT appear
+    expect(parsed?.deferred).not.toContain("pull-images");
+    expect(parsed?.deferred).not.toContain("apply-config");
   });
 });
 

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -129,6 +129,22 @@ interface UpdateOptions {
   /** Config path for the default pin persister (default: resolved
    *  switchroom.yaml). Test seam. */
   configPath?: string;
+  /**
+   * True when this update run is driven by the hostd `update_apply` RPC
+   * (i.e. the process was spawned with `SWITCHROOM_HOSTD_CONTEXT=1`).
+   *
+   * In this context the update driver CANNOT recreate the hostd container
+   * (that would SIGKILL itself mid-run) or the web container (same compose
+   * project risk). Both steps are given a `skipReason` so they are deferred
+   * and the sentinel line at the end tells the server which steps were
+   * deferred. The operator must finish those host-side via
+   * `switchroom hostd install` / `webd install`.
+   *
+   * Default: auto-detected via `isHostdContext()` (checks
+   * `process.env.SWITCHROOM_HOSTD_CONTEXT === "1"`). Test seam: supply
+   * `true`/`false` explicitly to avoid touching the real process env.
+   */
+  hostdContext?: boolean;
 }
 
 interface UpdateStep {
@@ -231,6 +247,78 @@ export function rebuildRefusalMessage(scriptPath: string): string | null {
 }
 
 /**
+ * True when the running update was spawned BY the hostd `update_apply`
+ * RPC handler — hostd injects `SWITCHROOM_HOSTD_CONTEXT=1` into the
+ * child's env to signal this. In that context the driver must NOT
+ * recreate the hostd container (it would SIGKILL itself) or the web
+ * container (same compose-project risk). Both steps are deferred and
+ * the caller is expected to finish them host-side.
+ *
+ * Accepts the env as an optional arg so unit tests can exercise it
+ * without mutating the real process env.
+ *
+ * Exported so the server and tests can import it directly.
+ */
+export function isHostdContext(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.SWITCHROOM_HOSTD_CONTEXT === "1";
+}
+
+/**
+ * The sentinel prefix emitted as the LAST stdout line by `runUpdate`
+ * when one or more steps were deferred due to running in hostd-context
+ * (#2458). The server parses this line to extract structured
+ * `{ ok, deferred }` without scraping human output.
+ *
+ * Format: `SWITCHROOM_UPDATE_RESULT:<json>`
+ */
+export const UPDATE_RESULT_SENTINEL = "SWITCHROOM_UPDATE_RESULT:";
+
+/**
+ * Encode a `{ ok, deferred }` result into the sentinel line that
+ * `runUpdate` emits and the server parses.
+ */
+export function encodeUpdateResultLine(payload: {
+  ok: boolean;
+  deferred: string[];
+}): string {
+  return `${UPDATE_RESULT_SENTINEL}${JSON.stringify(payload)}`;
+}
+
+/**
+ * Parse the sentinel line from the captured stdout of a spawned update
+ * driver. Returns `null` when the sentinel is absent (non-hostd-context
+ * run, older driver) or malformed.
+ *
+ * Searches from the END of stdout so intermediate "SWITCHROOM_UPDATE_RESULT:"
+ * substrings in step output can't shadow the final sentinel.
+ */
+export function parseUpdateResultLine(stdout: string): {
+  ok: boolean;
+  deferred: string[];
+} | null {
+  const idx = stdout.lastIndexOf(UPDATE_RESULT_SENTINEL);
+  if (idx === -1) return null;
+  const raw = stdout.slice(idx + UPDATE_RESULT_SENTINEL.length).split("\n")[0];
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      "ok" in parsed &&
+      "deferred" in parsed &&
+      typeof (parsed as { ok: unknown }).ok === "boolean" &&
+      Array.isArray((parsed as { deferred: unknown }).deferred)
+    ) {
+      return parsed as { ok: boolean; deferred: string[] };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Build the ordered list of update steps. Pure function — no side
  * effects. The action handler iterates this list and either prints
  * (--check) or executes (default).
@@ -240,6 +328,12 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
   const runner = opts.runner ?? defaultRunner;
   const scriptPath = opts.scriptPath ?? process.argv[1] ?? "";
   const steps: UpdateStep[] = [];
+  // Resolve whether we are running inside the hostd container. When true,
+  // refresh-hostd and refresh-web are deferred (cannot recreate the very
+  // container that spawned us — SIGKILL mid-run). The sentinel line at the
+  // end of runUpdate tells the server which steps were deferred.
+  const hostdContext =
+    typeof opts.hostdContext === "boolean" ? opts.hostdContext : isHostdContext();
 
   // When --channel / --pin is set, the resolved image tag in compose
   // needs to change BEFORE pull-images runs (so `docker compose pull`
@@ -391,7 +485,9 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
       ? "host_control.enabled is not true — daemon not in use"
       : opts.skipImages
         ? "--skip-images flag set"
-        : undefined,
+        : hostdContext
+          ? "deferred (hostd-context): finish host-side via `switchroom hostd install` — update_apply cannot recreate its own hostd container without SIGKILLing itself (#2458)"
+          : undefined,
     run: () => {
       const r = runner(process.execPath, [scriptPath, "hostd", "install"]);
       if (r.status !== 0) throw new Error("switchroom hostd install failed");
@@ -432,7 +528,9 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
       ? "web_service.managed is not true — web container not in use (legacy systemd unit)"
       : opts.skipImages
         ? "--skip-images flag set"
-        : undefined,
+        : hostdContext
+          ? "deferred (hostd-context): finish host-side via `switchroom webd install` — update_apply cannot recreate the web container without SIGKILLing the hostd container it shares a compose project with (#2458)"
+          : undefined,
     run: () => {
       const r = runner(process.execPath, [scriptPath, "webd", "install"]);
       if (r.status !== 0) throw new Error("switchroom webd install failed");
@@ -1016,10 +1114,26 @@ async function runUpdate(opts: UpdateOptions): Promise<number> {
       stderr(
         chalk.red(`✗ ${step.name} failed: ${(err as Error).message}\n`),
       );
+      // Even on failure, emit the sentinel if any deferred steps exist so
+      // the server can record which steps were left pending (#2458).
+      const deferredOnFailure = steps
+        .filter((s) => s.skipReason?.includes("deferred"))
+        .map((s) => s.name);
+      if (deferredOnFailure.length > 0) {
+        stdout(encodeUpdateResultLine({ ok: false, deferred: deferredOnFailure }) + "\n");
+      }
       return 1;
     }
   }
   stdout(chalk.green("\n✓ update complete\n"));
+  // Emit the structured sentinel when any steps were deferred so the server
+  // can populate StatusEntry.deferred without parsing human output (#2458).
+  const deferred = steps
+    .filter((s) => s.skipReason?.includes("deferred"))
+    .map((s) => s.name);
+  if (deferred.length > 0) {
+    stdout(encodeUpdateResultLine({ ok: true, deferred }) + "\n");
+  }
   return 0;
 }
 

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -152,6 +152,13 @@ interface UpdateStep {
   description: string;
   /** When true, step is skipped entirely (e.g. --skip-images). */
   skipReason?: string;
+  /**
+   * True when this step was deferred because the CLI is running inside the
+   * hostd container and cannot recreate itself or its compose siblings.
+   * Used as the machine-readable sentinel for the deferred-steps list —
+   * prefer this over string-matching `skipReason`.
+   */
+  isHostdDeferred?: boolean;
   /** Invoked when not in --check mode. Throws on failure. */
   run: () => void;
 }
@@ -488,6 +495,7 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
         : hostdContext
           ? "deferred (hostd-context): finish host-side via `switchroom hostd install` — update_apply cannot recreate its own hostd container without SIGKILLing itself (#2458)"
           : undefined,
+    isHostdDeferred: hostControlEnabled && !opts.skipImages && hostdContext,
     run: () => {
       const r = runner(process.execPath, [scriptPath, "hostd", "install"]);
       if (r.status !== 0) throw new Error("switchroom hostd install failed");
@@ -531,6 +539,7 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
         : hostdContext
           ? "deferred (hostd-context): finish host-side via `switchroom webd install` — update_apply cannot recreate the web container without SIGKILLing the hostd container it shares a compose project with (#2458)"
           : undefined,
+    isHostdDeferred: webServiceManaged && !opts.skipImages && hostdContext,
     run: () => {
       const r = runner(process.execPath, [scriptPath, "webd", "install"]);
       if (r.status !== 0) throw new Error("switchroom webd install failed");
@@ -1117,7 +1126,7 @@ async function runUpdate(opts: UpdateOptions): Promise<number> {
       // Even on failure, emit the sentinel if any deferred steps exist so
       // the server can record which steps were left pending (#2458).
       const deferredOnFailure = steps
-        .filter((s) => s.skipReason?.includes("deferred"))
+        .filter((s) => s.isHostdDeferred)
         .map((s) => s.name);
       if (deferredOnFailure.length > 0) {
         stdout(encodeUpdateResultLine({ ok: false, deferred: deferredOnFailure }) + "\n");
@@ -1129,7 +1138,7 @@ async function runUpdate(opts: UpdateOptions): Promise<number> {
   // Emit the structured sentinel when any steps were deferred so the server
   // can populate StatusEntry.deferred without parsing human output (#2458).
   const deferred = steps
-    .filter((s) => s.skipReason?.includes("deferred"))
+    .filter((s) => s.isHostdDeferred)
     .map((s) => s.name);
   if (deferred.length > 0) {
     stdout(encodeUpdateResultLine({ ok: true, deferred }) + "\n");

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -2410,6 +2410,7 @@ export class HostdServer {
             ...(entry.channel !== undefined ? { channel: entry.channel } : {}),
           }
         : null;
+    const payload = rolloutPayload ?? (updatePayload ? JSON.stringify(updatePayload) : undefined);
     return {
       v: 1,
       request_id,
@@ -2418,8 +2419,7 @@ export class HostdServer {
       duration_ms: (entry.finished_at ?? Date.now()) - entry.started_at,
       stdout_tail: entry.stdout_tail || undefined,
       stderr_tail: entry.stderr_tail || undefined,
-      ...(rolloutPayload ? { payload: rolloutPayload } : {}),
-      ...(updatePayload ? { payload: JSON.stringify(updatePayload) } : {}),
+      ...(payload ? { payload } : {}),
       error: entry.error,
     };
   }

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -57,6 +57,7 @@ import { socketPathToIdentity, type SocketIdentity } from "./peercred.js";
 import { redact } from "../secret-detect/redact.js";
 import { detectInstallType, type InstallType } from "../cli/install-detect.js";
 import { parseRolloutResultLine } from "../cli/rollout.js";
+import { parseUpdateResultLine } from "../cli/update.js";
 import { parseAuditLine } from "./audit-reader.js";
 import {
   validateConfigEdit,
@@ -198,6 +199,14 @@ interface StatusEntry {
   failed_step?: string;
   /** Agent that failed the version assert (when failed_step is restart). */
   failed_agent?: string;
+  /** Actual version detected on failed_agent (null = unreachable). BONUS #2458 got-field gap. */
+  got?: string | null;
+  // ─── Update-apply deferral result (#2458) ──────────────────────────
+  // Steps that were deferred because the update ran in hostd-context
+  // (SWITCHROOM_HOSTD_CONTEXT=1). Populated by parsing the
+  // SWITCHROOM_UPDATE_RESULT sentinel from the child's stdout. Absent
+  // when no steps were deferred (non-hostd-context run or older driver).
+  deferred?: string[];
 }
 
 /**
@@ -1261,7 +1270,12 @@ export class HostdServer {
       request_id: req.request_id,
       started_at: started,
     };
-    this.spawnFleetMutation(req.op, args, entry);
+    // Inject SWITCHROOM_HOSTD_CONTEXT=1 so the update driver knows it is
+    // running inside the hostd container and must defer the refresh-hostd /
+    // refresh-web steps rather than attempting to recreate the very container
+    // it is running in (#2458). The driver emits a SWITCHROOM_UPDATE_RESULT
+    // sentinel line that we parse below to populate entry.deferred.
+    this.spawnFleetMutation(req.op, args, entry, { SWITCHROOM_HOSTD_CONTEXT: "1" });
     return {
       v: 1,
       request_id: req.request_id,
@@ -2243,14 +2257,25 @@ export class HostdServer {
     op: "update_apply" | "apply" | "rollout",
     args: string[],
     entry: StatusEntry,
+    extraEnv?: Record<string, string>,
   ): void {
-    this.runSwitchroom(args)
+    this.runSwitchroom(args, extraEnv)
       .then((res) => {
         entry.result = res.exit_code === 0 ? "completed" : "error";
         entry.exit_code = res.exit_code;
         entry.finished_at = Date.now();
         entry.stdout_tail = tail(res.stdout);
         entry.stderr_tail = tail(res.stderr);
+        // Parse the deferral sentinel emitted by the update driver when
+        // one or more steps were deferred due to hostd-context (#2458).
+        // Only relevant for update_apply (apply/rollout don't emit it), but
+        // parseUpdateResultLine is a no-op / returns null on absent sentinel.
+        if (op === "update_apply") {
+          const parsed = parseUpdateResultLine(res.stdout);
+          if (parsed && parsed.deferred.length > 0) {
+            entry.deferred = parsed.deferred;
+          }
+        }
       })
       .catch((err) => {
         entry.result = "error";
@@ -2301,6 +2326,11 @@ export class HostdServer {
           entry.rolled = parsed.rolled;
           if (parsed.failedStep) entry.failed_step = parsed.failedStep;
           if (parsed.failedAgent) entry.failed_agent = parsed.failedAgent;
+          // BONUS (#2458 got-field gap): the sentinel carries `got` (the
+          // actual version detected on the failed agent, or null when
+          // unreachable). Preserve it so get_status readers can surface the
+          // mismatch without scraping stdout.
+          if (parsed.got !== undefined) entry.got = parsed.got;
           // Structured `ok` is the authority; exit code corroborates.
           entry.result = parsed.ok ? "completed" : "error";
         } else {
@@ -2363,9 +2393,23 @@ export class HostdServer {
             rolled: entry.rolled ?? [],
             ...(entry.failed_step ? { failedStep: entry.failed_step } : {}),
             ...(entry.failed_agent ? { failedAgent: entry.failed_agent } : {}),
+            // BONUS (#2458 got-field gap): include `got` when present.
+            ...(entry.got !== undefined ? { got: entry.got } : {}),
             ...(entry.pin ? { pin: entry.pin } : {}),
           })
         : undefined;
+    // Update-apply (#2458) payload: deferred steps + channel/pin enrichment.
+    const updatePayload: Record<string, unknown> | null =
+      entry.op === "update_apply" &&
+      (entry.deferred !== undefined ||
+        entry.channel !== undefined ||
+        entry.pin !== undefined)
+        ? {
+            ...(entry.deferred !== undefined ? { deferred: entry.deferred } : {}),
+            ...(entry.pin !== undefined ? { pin: entry.pin } : {}),
+            ...(entry.channel !== undefined ? { channel: entry.channel } : {}),
+          }
+        : null;
     return {
       v: 1,
       request_id,
@@ -2375,6 +2419,7 @@ export class HostdServer {
       stdout_tail: entry.stdout_tail || undefined,
       stderr_tail: entry.stderr_tail || undefined,
       ...(rolloutPayload ? { payload: rolloutPayload } : {}),
+      ...(updatePayload ? { payload: JSON.stringify(updatePayload) } : {}),
       error: entry.error,
     };
   }
@@ -2514,6 +2559,10 @@ export class HostdServer {
       ...(entry.rolled ? { rolled: entry.rolled } : {}),
       ...(entry.failed_step ? { failed_step: entry.failed_step } : {}),
       ...(entry.failed_agent ? { failed_agent: entry.failed_agent } : {}),
+      // BONUS (#2458 got-field gap): version detected on failed agent.
+      ...(entry.got !== undefined ? { got: entry.got } : {}),
+      // Update-apply deferral result (#2458) — only on update_apply rows.
+      ...(entry.deferred ? { deferred: entry.deferred } : {}),
     });
   }
 

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -1864,3 +1864,249 @@ describe("hostd server — orphaned-started-row reconcile (#2487)", () => {
     expect(synthRows).toHaveLength(1); // exactly one, not two
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #2458 — update_apply hostd-context deferral
+//
+// Asserts: (1) SWITCHROOM_HOSTD_CONTEXT=1 is injected for update_apply
+//          (2) `apply` does NOT get that env var
+//          (3) a child emitting the deferral sentinel populates
+//              StatusEntry.deferred and surfaces in get_status payload
+// ─────────────────────────────────────────────────────────────────────────────
+describe("hostd server — update_apply hostd-context deferral (#2458)", () => {
+  /** Set up a server whose switchroomBin echoes its env/argv to a recording
+   *  file and optionally emits a deferral sentinel. Returns the admin socket
+   *  path and the recording-file path. */
+  async function freshDeferralServer(opts: {
+    emitSentinel?: boolean;
+    sentinelOk?: boolean;
+    deferred?: string[];
+  } = {}): Promise<{ sock: string; recOut: string; assets: string }> {
+    if (server) await server.stop();
+
+    // Create apply-time assets so the preflight doesn't deny the request.
+    // These dirs don't need to be executable, so they live in the test tmpdir.
+    const assets = join(tmp, `assets-deferral-${Date.now()}`);
+    mkdirSync(join(assets, "profiles", "default"), { recursive: true });
+    mkdirSync(join(assets, "vendor", "hindsight-memory"), { recursive: true });
+
+    // The stub SCRIPT and its recording file must live on a filesystem that
+    // allows exec — /tmp is noexec in this container, but /var/tmp is exec.
+    const execTmp = mkdtempSync(join("/var/tmp", "hostd-deferral-"));
+    const recOut = join(execTmp, `rec.txt`);
+    const deferred = opts.deferred ?? ["refresh-hostd", "refresh-web"];
+    const sentinel =
+      opts.emitSentinel !== false
+        ? `SWITCHROOM_UPDATE_RESULT:${JSON.stringify({ ok: opts.sentinelOk ?? true, deferred })}`
+        : "";
+
+    const recStub = join(execTmp, `stub.sh`);
+    writeFileSync(
+      recStub,
+      `#!/bin/sh\n` +
+        `echo "argv: $@" >> "${recOut}"\n` +
+        `echo "ctx: $SWITCHROOM_HOSTD_CONTEXT" >> "${recOut}"\n` +
+        (sentinel ? `echo '${sentinel}'\n` : "") +
+        `exit 0\n`,
+    );
+    chmodSync(recStub, 0o755);
+
+    server = new (await import("../../src/host-control/server.js")).HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: recStub,
+      auditLogPath: join(tmp, "audit.log"),
+      applyAssetsRoot: assets,
+      allowNonLinux: true,
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+    return { sock, recOut, assets };
+  }
+
+  it("update_apply: spawns child with SWITCHROOM_HOSTD_CONTEXT=1", async () => {
+    const { sock, recOut } = await freshDeferralServer();
+
+    const started = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "update_apply", request_id: "ua-ctx-1", args: {} },
+    );
+    expect(started.result).toBe("started");
+
+    await new Promise((r) => setTimeout(r, 300));
+
+    const rec = readFileSync(recOut, "utf8");
+    // The stub echoes "ctx: $SWITCHROOM_HOSTD_CONTEXT" — must be "1".
+    expect(rec).toContain("ctx: 1");
+    expect(rec).toContain("argv: update");
+  });
+
+  it("apply: does NOT inject SWITCHROOM_HOSTD_CONTEXT", async () => {
+    const { sock, recOut } = await freshDeferralServer({ emitSentinel: false });
+
+    const started = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "apply", request_id: "ap-ctx-1", args: {} },
+    );
+    expect(started.result).toBe("started");
+
+    await new Promise((r) => setTimeout(r, 300));
+
+    const rec = readFileSync(recOut, "utf8");
+    // For `apply`, SWITCHROOM_HOSTD_CONTEXT must NOT be "1" (env var absent → empty).
+    expect(rec).not.toContain("ctx: 1");
+  });
+
+  it("sentinel parsed from child stdout populates StatusEntry.deferred in get_status payload", async () => {
+    const { sock } = await freshDeferralServer({
+      emitSentinel: true,
+      sentinelOk: true,
+      deferred: ["refresh-hostd", "refresh-web"],
+    });
+
+    await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "update_apply", request_id: "ua-sent-1", args: {} },
+    );
+    await new Promise((r) => setTimeout(r, 300));
+
+    const poll = await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "get_status",
+        request_id: "ua-sent-poll",
+        args: { target_request_id: "ua-sent-1" },
+      },
+    );
+    expect(poll.result).toBe("completed");
+    expect(poll.payload).toBeDefined();
+    const payload = JSON.parse(poll.payload!) as { deferred: string[] };
+    expect(payload.deferred).toContain("refresh-hostd");
+    expect(payload.deferred).toContain("refresh-web");
+  });
+
+  it("deferred list also appears in the terminal audit row", async () => {
+    const { sock } = await freshDeferralServer({
+      emitSentinel: true,
+      sentinelOk: true,
+      deferred: ["refresh-hostd", "refresh-web"],
+    });
+
+    await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "update_apply", request_id: "ua-audit-1", args: {} },
+    );
+    await new Promise((r) => setTimeout(r, 300));
+
+    const rows = readFileSync(join(tmp, "audit.log"), "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    const terminal = rows.find(
+      (r) => r.request_id === "ua-audit-1" && r.phase === "terminal",
+    );
+    expect(terminal).toBeDefined();
+    expect(terminal!.deferred).toEqual(["refresh-hostd", "refresh-web"]);
+  });
+
+  it("no sentinel → no payload.deferred (non-hostd-context update_apply)", async () => {
+    const { sock } = await freshDeferralServer({ emitSentinel: false });
+
+    await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "update_apply", request_id: "ua-nosent-1", args: {} },
+    );
+    await new Promise((r) => setTimeout(r, 300));
+
+    const poll = await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "get_status",
+        request_id: "ua-nosent-poll",
+        args: { target_request_id: "ua-nosent-1" },
+      },
+    );
+    expect(poll.result).toBe("completed");
+    // No deferred steps → either no payload or payload without deferred.
+    if (poll.payload) {
+      const payload = JSON.parse(poll.payload!) as Record<string, unknown>;
+      expect(payload.deferred).toBeUndefined();
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BONUS: rollout `got`-field gap (#2458)
+//
+// The ROLLOUT_RESULT sentinel includes `got` (actual version on the failed
+// agent) but spawnRollout was previously dropping it. Assert the fix:
+// `got` appears in the get_status payload AND the terminal audit row.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("hostd server — rollout got-field gap fix (BONUS #2458)", () => {
+  it("got field from sentinel appears in get_status payload and terminal audit", async () => {
+    // failStub must be executable — use /var/tmp (not /tmp which is noexec in this container)
+    const execTmpBonus = mkdtempSync(join("/var/tmp", "hostd-bonus-rollout-"));
+    const failStub = join(execTmpBonus, "stub.sh");
+    writeFileSync(
+      failStub,
+      `#!/bin/sh\n` +
+        `echo 'SWITCHROOM_ROLLOUT_RESULT:{"ok":false,"rolled":[],"failedStep":"restart-agent","failedAgent":"canary","got":"0.15.17","warnings":[]}'\n` +
+        `exit 1\n`,
+    );
+    chmodSync(failStub, 0o755);
+
+    const assets = join(tmp, `assets-rollout-got-${Date.now()}`);
+    mkdirSync(join(assets, "profiles", "default"), { recursive: true });
+    mkdirSync(join(assets, "vendor", "hindsight-memory"), { recursive: true });
+
+    if (server) await server.stop();
+    server = new (await import("../../src/host-control/server.js")).HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: failStub,
+      auditLogPath: join(tmp, "audit.log"),
+      applyAssetsRoot: assets,
+      allowNonLinux: true,
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+    await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "rollout", request_id: "ro-got-1", args: { pin: "v0.15.18" } },
+    );
+    await new Promise((r) => setTimeout(r, 300));
+
+    const poll = await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "get_status",
+        request_id: "ro-got-poll",
+        args: { target_request_id: "ro-got-1" },
+      },
+    );
+    expect(poll.result).toBe("error");
+    expect(poll.payload).toBeDefined();
+    const payload = JSON.parse(poll.payload!) as { failedAgent: string; got: string };
+    // BONUS: `got` must be in the payload.
+    expect(payload.failedAgent).toBe("canary");
+    expect(payload.got).toBe("0.15.17");
+
+    const rows = readFileSync(join(tmp, "audit.log"), "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    const terminal = rows.find(
+      (r) => r.request_id === "ro-got-1" && r.phase === "terminal",
+    );
+    expect(terminal).toBeDefined();
+    // BONUS: `got` must also be in the durable audit row.
+    expect(terminal!.got).toBe("0.15.17");
+    expect(terminal!.failed_agent).toBe("canary");
+  });
+});


### PR DESCRIPTION
## Summary

- **Core bug**: when `update_apply` spawns `switchroom update` inside the hostd container, the `refresh-hostd` step recreates the container mid-execution, sending SIGKILL to the running driver and breaking the update.
- **Fix**: inject `SWITCHROOM_HOSTD_CONTEXT=1` into the child env for `update_apply` spawns (not for `apply`). The update driver detects this via `isHostdContext()` and sets a `deferred` skipReason on `refresh-hostd` and `refresh-web`. A machine-readable `SWITCHROOM_UPDATE_RESULT:` sentinel line is emitted at the end of stdout; the server parses it to populate `StatusEntry.deferred`, which flows into the `get_status` response payload and the durable terminal audit row.
- **BONUS** (rollout got-field gap): `parseRolloutResultLine` already parsed the `got` field (actual version on failed agent) but `spawnRollout` was silently dropping it. Now captured in `StatusEntry.got` and exposed in `get_status` payload and terminal audit.

## Changes

| File | What changed |
|------|-------------|
| \`src/cli/update.ts\` | \`isHostdContext()\`, \`UPDATE_RESULT_SENTINEL\`, \`encodeUpdateResultLine\`, \`parseUpdateResultLine\`; \`hostdContext?\` in \`UpdateOptions\`; deferred \`skipReason\` on \`refresh-hostd\`/\`refresh-web\`; sentinel emission in \`runUpdate\` |
| \`src/host-control/server.ts\` | \`extraEnv\` threading through \`spawnFleetMutation\`; \`SWITCHROOM_HOSTD_CONTEXT=1\` injected for \`update_apply\`; sentinel parsing to \`StatusEntry.deferred\`; \`updatePayload\` in \`statusEntryToResponse\`; \`deferred\` in \`writeTerminalAudit\`; BONUS: \`got\` field captured and exposed |
| \`src/cli/update.test.ts\` | 4 new describe blocks: \`isHostdContext\`, sentinel encode/parse round-trip, \`planUpdate\` deferred skipReason, \`runUpdate\` sentinel emission |
| \`tests/host-control/server.test.ts\` | 5 new tests for update_apply hostd-context deferral; 1 new BONUS test for rollout \`got\`-field |

## Test plan

- [x] \`npm run lint\` — clean (tsc + all script checks)
- [x] \`src/cli/update.test.ts\` — 61/61 pass (4 new describe blocks, 13 new tests)
- [x] \`tests/host-control/server.test.ts\` — 49 pass (6 new tests all green); 25 pre-existing failures are \`/tmp noexec\` mount failures unrelated to this PR (all new tests use \`/var/tmp\` as workaround)

🤖 Generated with [Claude Code](https://claude.com/claude-code)