### PR TITLE
fix(uat): switch reactions-dm from push to poll (#2502)

### DIFF
--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -368,6 +368,15 @@ export class Driver {
    * - Custom emojis (`reactionCustomEmoji`) are skipped — scenarios
    *   that need them aren't in scope and parsing them would require
    *   resolving the document id to an alias.
+   *
+   * **DM / bot-reaction limitation:** when a BOT calls
+   * `setMessageReaction` on a DM, Telegram's MTProto server does NOT
+   * deliver `updateMessageReactions` to the human user's account.
+   * The server only delivers `updateBotMessageReaction` to the BOT's
+   * own update stream, so `onRawUpdate` never fires for the driver.
+   * For DM bot-reaction assertions, use {@link pollReactions} instead
+   * — it calls `messages.getMessagesReactions` directly (pull, not
+   * push) to read the current reaction set on any message.
    */
   observeReactions(
     chatId: number,
@@ -579,6 +588,41 @@ export class Driver {
     const msg = results[0];
     if (!msg) return null;
     return toObserved(msg, false);
+  }
+
+  /**
+   * Poll the current set of emoji reactions on a message by making a
+   * direct `messages.getMessagesReactions` MTProto call.
+   *
+   * Unlike {@link observeReactions}, this is a **pull** operation —
+   * it does not depend on push updates from the Telegram server. This
+   * makes it the correct verification method for DM bot-reaction
+   * scenarios: when a bot calls `setMessageReaction` on a DM, Telegram
+   * does not deliver `updateMessageReactions` to the user account, but
+   * the reaction IS queryable via this API.
+   *
+   * Returns an array of emoji strings currently on the message
+   * (e.g. `["👍"]`, `["👀", "🤔"]`). Returns an empty array when
+   * no reactions are set, or when `getMessageReactionsById` returns
+   * null (message deleted / not visible).
+   *
+   * Custom-emoji reactions are excluded (the documentId can't be
+   * trivially shown as a string without resolving it).
+   */
+  async pollReactions(chatId: number, messageId: number): Promise<string[]> {
+    const c = this.requireClient();
+    const results = await c.getMessageReactionsById(chatId, [messageId]);
+    const msgReactions = results[0];
+    if (!msgReactions) return [];
+    const emojis: string[] = [];
+    for (const rc of msgReactions.reactions) {
+      const emoji = rc.emoji;
+      if (typeof emoji === "string") {
+        emojis.push(emoji);
+      }
+      // Long (custom emoji document id) — skip, can't stringify cheaply
+    }
+    return emojis;
   }
 
   /**

--- a/telegram-plugin/uat/scenarios/reactions-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/reactions-dm.test.ts
@@ -18,28 +18,37 @@
  *
  * What we assert (in priority order):
  *
- *  1. Within the turn, the driver sees AT LEAST ONE `+` reaction
- *     op (the L1 "I'm alive" signal). Fast turns may collapse
- *     intermediate states, so we only require *one* add, not a
- *     specific emoji.
+ *  1. Within the turn, the bot places AT LEAST ONE reaction on the
+ *     inbound message (the L1 "I'm alive" signal). We poll via
+ *     `driver.pollReactions()` rather than subscribing to push
+ *     events — see the DM limitation note below.
  *  2. By the time the bot has sent a final reply (+ a short tail
- *     for Telegram to deliver the terminal-emoji replace), the
- *     LAST observed `+` op is in the `done` set (`👍 / 💯 / 🎉`).
+ *     for Telegram to apply the terminal-emoji replace), the LAST
+ *     reaction on the inbound message is in the `done` set
+ *     (`👍 / 💯 / 🎉`).
  *
- * Why "last `+` op wins" rather than `expectReaction(['👍'])` with
- * a literal sequence: `setMessageReaction` REPLACES the prior emoji
- * atomically. mtcute's update stream can deliver the replace as a
- * `-prev` followed by a `+next`, or as a single coalesced event,
- * depending on server batching. The "last add wins" shape matches
- * the production semantics — whatever's *currently* on the message
- * is what the user actually sees.
+ * Why polling instead of `observeReactions`:
  *
- * The observer must be attached BEFORE the reply lands so we
- * capture the queued / working reactions, not just the terminal
- * one. Pattern: `observeReactions` immediately after `sendDM`
- * returns the messageId, drain into a trail array while we wait
- * for the reply, then run a short tail to catch the terminal
- * after the reply.
+ *   When a BOT calls `setMessageReaction` on a DM, Telegram's
+ *   MTProto server does NOT deliver `updateMessageReactions` to the
+ *   human user's account. Telegram only delivers
+ *   `updateBotMessageReaction` to the BOT's own update stream.
+ *   `observeReactions` hooks `onRawUpdate` and would correctly handle
+ *   the update if it arrived — but it never does for DMs where the
+ *   reactor is a bot. The gateway log confirms `setMessageReaction`
+ *   returns `status=ok`, so the reaction IS applied on Telegram's
+ *   side; we just can't observe it via push. Polling with
+ *   `driver.pollReactions()` (wraps `messages.getMessagesReactions`)
+ *   queries the current reaction state directly and is not affected
+ *   by the push-delivery gap. Fixes #2502.
+ *
+ * Polling strategy:
+ *   - Poll every `POLL_INTERVAL_MS` until either a reaction appears
+ *     OR the bot has replied AND `TAIL_AFTER_REPLY_MS` has elapsed.
+ *   - After the reply arrives, keep polling through the tail window
+ *     so the terminal emoji (👍) has time to replace the working
+ *     emoji (👀/🤔). In practice the replace happens within 1-2s
+ *     of the reply on a healthy bot; the 8s ceiling absorbs jitter.
  *
  * Requires the same env as `smoke-dm-reply.test.ts` (see
  * `uat/SETUP.md` §6).
@@ -49,15 +58,10 @@ import { describe, expect, it } from "vitest";
 import { spinUp } from "../harness.js";
 
 const TERMINAL_DONE_EMOJI = new Set(["👍", "💯", "🎉"]);
+const POLL_INTERVAL_MS = 1_000;
 const TAIL_AFTER_REPLY_MS = 8_000;
 
 const INBOUND = (): string => `uat-reactions ${new Date().toISOString()}`;
-
-interface ObservedOp {
-  emoji: string;
-  op: "+" | "-";
-  at: number;
-}
 
 describe("uat: reaction lifecycle on driver DM", () => {
   it(
@@ -67,71 +71,74 @@ describe("uat: reaction lifecycle on driver DM", () => {
       try {
         const sent = await sc.sendDM(INBOUND());
 
-        // Attach the observer immediately so the queued (👀) and
-        // working reactions don't fire before the listener exists.
-        const trail: ObservedOp[] = [];
-        const iter = sc.driver
-          .observeReactions(sc.botUserId, { messageId: sent.messageId })
-          [Symbol.asyncIterator]();
-        let pump: Promise<void> | null = null;
-        let stopPump = false;
-        pump = (async () => {
-          while (!stopPump) {
-            const next = await iter.next();
-            if (next.done === true) return;
-            trail.push({
-              emoji: next.value.emoji,
-              op: next.value.op,
-              at: Date.now(),
-            });
-          }
-        })();
+        // Poll the reaction state on the sent message. We use polling
+        // rather than `observeReactions` because Telegram does not
+        // deliver `updateMessageReactions` push updates to user accounts
+        // when a bot sets a reaction in a DM — see module docblock.
+        const reactionHistory: string[][] = [];
+        let replyReceived = false;
+        let replyReceivedAt = 0;
 
-        try {
-          // Wait for the bot's reply (any content). Gives the L1
-          // lifecycle time to traverse queued → working → done.
-          const reply = await sc.expectMessage(/\S/, {
-            from: "bot",
-            timeout: 60_000,
+        // Wait for the bot's reply (any content). We start polling
+        // concurrently so we capture intermediate reactions during
+        // the turn.
+        const replyPromise = sc
+          .expectMessage(/\S/, { from: "bot", timeout: 60_000 })
+          .then((reply) => {
+            expect(reply.text.length).toBeGreaterThan(0);
+            replyReceived = true;
+            replyReceivedAt = Date.now();
+            return reply;
           });
-          expect(reply.text.length).toBeGreaterThan(0);
 
-          // Tail after the reply for Telegram to deliver the
-          // terminal-emoji replace. In practice <1s on a healthy bot;
-          // 8s ceiling absorbs server batching jitter.
-          await new Promise((resolve) =>
-            setTimeout(resolve, TAIL_AFTER_REPLY_MS),
-          );
-        } finally {
-          stopPump = true;
-          await iter.return?.();
-          if (pump) {
-            await pump.catch(() => {
-              /* generator return triggers rejection on pending iter.next() — ignore */
-            });
+        // Polling loop: sample reactions while waiting for the reply,
+        // then continue for TAIL_AFTER_REPLY_MS after the reply lands.
+        const poll = async (): Promise<void> => {
+          const deadline = Date.now() + 90_000; // safety ceiling
+          while (Date.now() < deadline) {
+            const emojis = await sc.driver.pollReactions(
+              sc.botUserId,
+              sent.messageId,
+            );
+            if (emojis.length > 0) {
+              reactionHistory.push([...emojis]);
+            }
+            if (
+              replyReceived &&
+              Date.now() - replyReceivedAt >= TAIL_AFTER_REPLY_MS
+            ) {
+              break;
+            }
+            await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
           }
-        }
+        };
 
-        // L1 alive signal: at least one `+` op landed during the turn.
-        const adds = trail.filter((o) => o.op === "+");
+        // Run both concurrently; wait for both to settle.
+        await Promise.all([replyPromise, poll()]);
+
+        // L1 alive signal: at least one non-empty reaction set was
+        // observed during the turn.
+        const allSeen = reactionHistory.flat();
+        const uniqueSeen = [...new Set(allSeen)];
         expect(
-          adds.length,
-          `expected at least one reaction-add during the turn, got 0. ` +
-            `Full trail: ${trail.map((o) => `${o.op}${o.emoji}`).join(" ") || "(empty)"}`,
+          reactionHistory.length,
+          `expected at least one reaction poll to show a reaction during the ` +
+            `turn, but all ${reactionHistory.length > 0 ? "polls returned nothing with emojis" : "polls returned empty"}. ` +
+            `History snapshots: ${reactionHistory.map((s) => `[${s.join(",")}]`).join(" ") || "(none)"}`,
         ).toBeGreaterThan(0);
 
-        // L1 terminal: the LAST `+` op should be a terminal-done emoji.
-        // Extra `-` ops after the final `+` are tolerated (Telegram
-        // sometimes emits a bare clean-up `-`); the last `+` is what
-        // the user actually sees.
-        const lastAdd = adds[adds.length - 1];
+        // L1 terminal: the LAST non-empty snapshot should contain a
+        // terminal-done emoji. `setMessageReaction` replaces atomically,
+        // so the last snapshot holds whatever is currently on the message.
+        const lastSnapshot = reactionHistory[reactionHistory.length - 1];
+        const lastEmoji = lastSnapshot[lastSnapshot.length - 1];
         expect(
-          TERMINAL_DONE_EMOJI.has(lastAdd.emoji),
-          `expected last reaction-add to be one of ${[
+          TERMINAL_DONE_EMOJI.has(lastEmoji),
+          `expected last reaction to be one of ${[
             ...TERMINAL_DONE_EMOJI,
-          ].join(", ")}, got ${lastAdd.emoji}. Full trail: ${trail
-            .map((o) => `${o.op}${o.emoji}`)
-            .join(" ")}`,
+          ].join(", ")}, got ${lastEmoji}. ` +
+            `All snapshots: ${reactionHistory.map((s) => `[${s.join(",")}]`).join(" ")}. ` +
+            `Unique emojis seen: ${uniqueSeen.join(", ") || "(none)"}`,
         ).toBe(true);
       } finally {
         await sc.tearDown();


### PR DESCRIPTION
## Summary

- `reactions-dm` UAT was failing 2/2 runs: the driver observed 0 reactions on every run
- Root cause: Telegram does not deliver `updateMessageReactions` push updates to user MTProto accounts when a BOT calls `setMessageReaction` on a DM — the server only delivers `updateBotMessageReaction` to the bot's own update stream
- Fix: replace the push-based `observeReactions()` approach with polling via `driver.pollReactions()` (wraps `messages.getMessagesReactions`), which reads the current reaction state directly

## What changed

**`telegram-plugin/uat/driver.ts`**
- Added `pollReactions(chatId, messageId): Promise<string[]>` — wraps mtcute's `getMessageReactionsById` to return the current emoji set on a message without relying on push delivery
- Added DM limitation note to `observeReactions()` JSDoc: push does not fire for bot-set reactions in DMs

**`telegram-plugin/uat/scenarios/reactions-dm.test.ts`**
- Replaced `observeReactions` async-iterator pump with a polling loop (`pollReactions` every 1s)
- Polls concurrently while waiting for the bot reply, then tails 8s for the terminal emoji
- Same assertions as before: at least one reaction observed during the turn; last reaction in the terminal-done set (`👍`/`💯`/`🎉`)

## Why this is correct

The gateway log confirms `setMessageReaction` returns `status=ok` — the bot IS reacting correctly. The bug is entirely in the UAT observation layer. The CLAUDE.md already documented this as a known limitation:

> "mtcute also CANNOT observe drafts or reactions — the activity/worker feeds are real `sendMessage`/`editMessageText` (observable), but draft-transport and reaction surfaces must be checked via the gateway log, not mtcute."

The fix makes the test match that documented reality.

## Test plan

- [x] `bun run --cwd telegram-plugin test:uat reactions-dm` — GREEN run 1 (36s)
- [x] `bun run --cwd telegram-plugin test:uat reactions-dm` — GREEN run 2 (34s)
- [x] `tsc --noEmit` — clean
- [x] `check-plugin-references.mjs` — clean
- [x] `check-bot-api-wrapping.sh` — clean

Closes #2502

🤖 Generated with [Claude Code](https://claude.com/claude-code)