### PR TITLE
fix(telegram): status feed shows last 5 lines in full, not all-lines-clipped

### DIFF
--- a/telegram-plugin/status-no-truncate.ts
+++ b/telegram-plugin/status-no-truncate.ts
@@ -1,15 +1,17 @@
 /**
  * Feature flag: SWITCHROOM_STATUS_NO_TRUNCATE
  *
- * When ON (the default), activity-feed cards show ALL accumulated lines and
- * full-width lines — no cosmetic line-count or per-line-length caps. The only
- * ceiling in no-truncate mode is Telegram's 4096-char message limit.
+ * When ON (the default), the activity-feed card shows a **rolling window of
+ * the last STATUS_ROLLING_LINES narrative lines**, each rendered in FULL —
+ * no per-line length cap ("…"). Message height stays fixed (≤5 lines) while
+ * content stays complete. The ONLY remaining ceiling is `STATUS_CARD_CHAR_BUDGET`
+ * (Telegram's 4096-char wire limit backstop).
  *
  * When OFF (env var set to '0'), preserves the original capped behaviour:
  * MIRROR_MAX_LINES / NESTED_MAX_LINES / NESTED_LINE_MAX / NARRATIVE_MAX_LINES
- * all apply exactly as before.
+ * all apply exactly as before (per-line clip + line-count cap).
  *
- * Semantics: noTruncate = env !== '0'  →  DEFAULT TRUE (no truncation).
+ * Semantics: noTruncate = env !== '0'  →  DEFAULT TRUE (rolling-5-full mode).
  *
  * This is a tiny shared module so both renderer files can import it and tests
  * can flip the flag by setting/deleting process.env.SWITCHROOM_STATUS_NO_TRUNCATE
@@ -17,11 +19,11 @@
  */
 
 /**
- * Returns true when status cards should show all accumulated lines (no
- * cosmetic truncation). Reads the env var at call time so tests can flip it
- * with set/delete on process.env without module re-imports.
+ * Returns true when status cards should show a rolling window of full-content
+ * lines (no per-line truncation). Reads the env var at call time so tests can
+ * flip it with set/delete on process.env without module re-imports.
  *
- * Default: true (no truncation). Set SWITCHROOM_STATUS_NO_TRUNCATE=0 to
+ * Default: true (rolling-5-full mode). Set SWITCHROOM_STATUS_NO_TRUNCATE=0 to
  * restore the original capped behaviour.
  */
 export function statusNoTruncate(): boolean {
@@ -29,9 +31,19 @@ export function statusNoTruncate(): boolean {
 }
 
 /**
+ * Number of trailing narrative lines shown in no-truncate mode.
+ * The feed is a fixed-height rolling window: oldest drops off as new arrive.
+ * Each of the STATUS_ROLLING_LINES lines renders in FULL (no per-line "…").
+ */
+export const STATUS_ROLLING_LINES = 5
+
+/**
  * The safe char budget for rendered Telegram messages in no-truncate mode.
  * Telegram's hard cap is 4096; we use 4000 to leave 96 chars of headroom for
  * HTML framing, emoji, and escape expansion — matching the convention in
  * pending-work-progress.ts (TELEGRAM_MSG_CAP = 4000).
+ *
+ * With STATUS_ROLLING_LINES=5 full lines (~750 chars total), this backstop
+ * effectively never fires in practice but is kept as a wire-limit safety net.
  */
 export const STATUS_CARD_CHAR_BUDGET = 4000

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -8,6 +8,7 @@ import {
   MIRROR_MAX_LINES,
   NESTED_MAX_LINES,
 } from "../tool-activity-summary.js";
+import { STATUS_ROLLING_LINES } from "../status-no-truncate.js";
 
 describe("describeToolUse — friendly per-tool rendering (draft-mirror)", () => {
   it("Bash uses the model-authored description verbatim, never the command", () => {
@@ -403,33 +404,58 @@ describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A
 });
 
 // ─── SWITCHROOM_STATUS_NO_TRUNCATE feature flag tests ───────────────────────
+// New contract (rolling-5-full):
+//   ON  → last STATUS_ROLLING_LINES lines rendered in FULL; no overflow header;
+//          char-budget backstop is the only ceiling.
+//   OFF → MIRROR_MAX_LINES / NESTED_MAX_LINES + per-line clips (legacy, unchanged).
 
 describe("SWITCHROOM_STATUS_NO_TRUNCATE — renderActivityFeed", () => {
   afterEach(() => {
     delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
   });
 
-  it("no-truncate ON (default): a feed > MIRROR_MAX_LINES renders ALL lines", () => {
+  it("no-truncate ON (default): with 12 lines, exactly the last STATUS_ROLLING_LINES render", () => {
     delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE; // default = ON
-    const lines = Array.from({ length: MIRROR_MAX_LINES + 5 }, (_, i) => `Action ${i + 1}`);
+    // Use a prefix that makes substring matches impossible (e.g. "XAct-001" won't match "XAct-010").
+    const lines = Array.from({ length: 12 }, (_, i) => `XAct-${String(i + 1).padStart(3, '0')}`);
     const out = renderActivityFeed(lines)!;
-    // All lines must appear (oldest = ✓ done, newest = → in-progress).
-    for (let i = 1; i <= MIRROR_MAX_LINES + 5; i++) {
-      expect(out).toContain(`Action ${i}`);
+    const firstVisible = 12 - STATUS_ROLLING_LINES + 1;
+    // The last STATUS_ROLLING_LINES lines must appear.
+    for (let i = firstVisible; i <= 12; i++) {
+      expect(out).toContain(`XAct-${String(i).padStart(3, '0')}`);
     }
-    // No spurious "+N earlier" when all lines fit.
-    expect(out).not.toContain("earlier");
+    // Earlier lines must NOT appear.
+    for (let i = 1; i < firstVisible; i++) {
+      expect(out).not.toContain(`XAct-${String(i).padStart(3, '0')}`);
+    }
+    // No overflow header in no-truncate mode.
+    expect(out).not.toContain("earlier…");
     // Newest is still the in-progress step.
-    expect(out).toContain(`<b>→ Action ${MIRROR_MAX_LINES + 5}</b>`);
+    expect(out).toContain(`<b>→ XAct-012</b>`);
+  });
+
+  it("no-truncate ON: a 150-char line renders in FULL (no '…' per-line truncation)", () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+    const longLine = "a".repeat(75) + " " + "b".repeat(74); // 150 chars
+    const out = renderActivityFeed([longLine])!;
+    expect(out).toContain(longLine);
+    expect(out).not.toContain("…");
+  });
+
+  it("no-truncate ON: no '✓ +N earlier…' overflow header even with many lines", () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+    const lines = Array.from({ length: 20 }, (_, i) => `Action ${i + 1}`);
+    const out = renderActivityFeed(lines)!;
+    expect(out).not.toContain("earlier…");
   });
 
   it("no-truncate ON: setting env to '1' (or any non-'0') is also ON", () => {
     process.env.SWITCHROOM_STATUS_NO_TRUNCATE = "1";
     const lines = Array.from({ length: MIRROR_MAX_LINES + 2 }, (_, i) => `Step ${i + 1}`);
     const out = renderActivityFeed(lines)!;
-    expect(out).toContain(`Step 1`);
-    expect(out).toContain(`Step ${MIRROR_MAX_LINES + 2}`);
+    // Rolling window: last STATUS_ROLLING_LINES visible, no overflow header.
     expect(out).not.toContain("earlier");
+    expect(out).toContain(`Step ${MIRROR_MAX_LINES + 2}`);
   });
 
   it("no-truncate OFF (=0): existing truncation behaviour preserved (cap to MIRROR_MAX_LINES)", () => {
@@ -442,20 +468,20 @@ describe("SWITCHROOM_STATUS_NO_TRUNCATE — renderActivityFeed", () => {
     expect(out).toContain("<b>→ Action 9</b>");
   });
 
-  it("no-truncate ON + pathologically huge feed (500 long lines): output ≤ 4096 chars and oldest lines are clipped with header", () => {
+  it("no-truncate ON + pathologically oversized lines: char-budget backstop fires, output ≤ 4096 chars", () => {
     delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE; // default ON
-    // 500 lines of ~20 chars each → well over 4000 chars rendered.
-    const lines = Array.from({ length: 500 }, (_, i) => `Action step number ${i + 1}`);
+    // STATUS_ROLLING_LINES lines of ~900 chars each → well over 4000 chars rendered.
+    const bigLine = "z".repeat(900);
+    const lines = Array.from({ length: STATUS_ROLLING_LINES }, () => bigLine);
     const out = renderActivityFeed(lines)!;
     // Hard invariant: output must not exceed Telegram's 4096-char limit.
     expect(out.length).toBeLessThanOrEqual(4096);
-    // Clip header must be present (oldest lines were dropped).
-    expect(out).toContain("earlier…");
-    // The newest line must still be present.
-    expect(out).toContain("Action step number 500");
+    // The newest line must still be present (some portion of it).
+    const hasBullet = out.includes("→") || out.includes("✓");
+    expect(hasBullet).toBe(true);
   });
 
-  it("no-truncate ON: no spurious '+N earlier' header when feed is small enough to fit", () => {
+  it("no-truncate ON: no spurious overflow header when feed is small", () => {
     delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
     const lines = Array.from({ length: 3 }, (_, i) => `Short step ${i + 1}`);
     const out = renderActivityFeed(lines)!;
@@ -468,31 +494,43 @@ describe("SWITCHROOM_STATUS_NO_TRUNCATE — renderActivityFeedWithNested", () =>
     delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
   });
 
-  it("no-truncate ON: parent > MIRROR_MAX_LINES shows all parent lines", () => {
+  it("no-truncate ON: with many parent lines, only the last STATUS_ROLLING_LINES render (no overflow header)", () => {
     delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
     const parent = Array.from({ length: MIRROR_MAX_LINES + 3 }, (_, i) => `Parent ${i + 1}`);
     const child = ["Child step A", "Child step B"];
     const out = renderActivityFeedWithNested(parent, child)!;
-    for (let i = 1; i <= MIRROR_MAX_LINES + 3; i++) {
+    const totalParent = MIRROR_MAX_LINES + 3;
+    const firstVisible = totalParent - STATUS_ROLLING_LINES + 1;
+    for (let i = firstVisible; i <= totalParent; i++) {
       expect(out).toContain(`Parent ${i}`);
     }
-    expect(out).not.toContain("+3 earlier"); // no parent truncation header
+    for (let i = 1; i < firstVisible; i++) {
+      expect(out).not.toContain(`Parent ${i}`);
+    }
+    // No overflow header in no-truncate mode.
+    expect(out).not.toContain("earlier…");
     expect(out).toContain("   ↳ <b>→ Child step B</b>");
   });
 
-  it("no-truncate ON: child > NESTED_MAX_LINES shows all child lines", () => {
+  it("no-truncate ON: with many child lines, only the last STATUS_ROLLING_LINES child lines render", () => {
     delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
     const parent = ["Delegating: big task"];
     const child = Array.from({ length: NESTED_MAX_LINES + 4 }, (_, i) => `Child ${i + 1}`);
     const out = renderActivityFeedWithNested(parent, child)!;
-    for (let i = 1; i <= NESTED_MAX_LINES + 4; i++) {
+    const totalChild = NESTED_MAX_LINES + 4;
+    const firstVisible = totalChild - STATUS_ROLLING_LINES + 1;
+    for (let i = firstVisible; i <= totalChild; i++) {
       expect(out).toContain(`Child ${i}`);
     }
-    expect(out).not.toContain("+4 earlier"); // no child truncation header
-    expect(out).toContain(`   ↳ <b>→ Child ${NESTED_MAX_LINES + 4}</b>`);
+    for (let i = 1; i < firstVisible; i++) {
+      expect(out).not.toContain(`Child ${i}`);
+    }
+    // No overflow header in no-truncate mode.
+    expect(out).not.toContain("earlier…");
+    expect(out).toContain(`   ↳ <b>→ Child ${totalChild}</b>`);
   });
 
-  it("no-truncate ON: a line longer than NESTED_LINE_MAX renders in full (no '…' truncation)", () => {
+  it("no-truncate ON: a child line longer than NESTED_LINE_MAX renders in full (no '…' truncation)", () => {
     delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
     const longLine = "x".repeat(120); // well over the 90-char NESTED_LINE_MAX
     const out = renderActivityFeedWithNested(["Delegating"], [longLine])!;
@@ -501,7 +539,7 @@ describe("SWITCHROOM_STATUS_NO_TRUNCATE — renderActivityFeedWithNested", () =>
     expect(out).not.toContain(longLine.slice(0, 89) + "…");
   });
 
-  it("no-truncate OFF (=0): per-line NESTED_LINE_MAX cap is still applied", () => {
+  it("no-truncate OFF (=0): per-line NESTED_LINE_MAX cap is still applied (regression guard)", () => {
     process.env.SWITCHROOM_STATUS_NO_TRUNCATE = "0";
     const longLine = "x".repeat(120);
     const out = renderActivityFeedWithNested(["Delegating"], [longLine])!;
@@ -509,18 +547,17 @@ describe("SWITCHROOM_STATUS_NO_TRUNCATE — renderActivityFeedWithNested", () =>
     expect(out).not.toContain(longLine);
   });
 
-  it("no-truncate ON + huge nested feed: output ≤ 4096 chars with oldest-lines-dropped header", () => {
+  it("no-truncate ON + huge nested feed: char-budget backstop fires, output ≤ 4096 chars", () => {
     delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
-    // 150 parent + 150 child lines of ~25 chars each → well over 4000 chars rendered.
-    const parent = Array.from({ length: 150 }, (_, i) => `Parent activity step ${i + 1}`);
-    const child = Array.from({ length: 150 }, (_, i) => `Child activity step ${i + 1}`);
+    // STATUS_ROLLING_LINES parent + STATUS_ROLLING_LINES child lines of ~900 chars each.
+    const bigLine = "w".repeat(900);
+    const parent = Array.from({ length: STATUS_ROLLING_LINES }, () => bigLine);
+    const child = Array.from({ length: STATUS_ROLLING_LINES }, () => bigLine);
     const out = renderActivityFeedWithNested(parent, child)!;
     // Hard invariant: output must not exceed Telegram's 4096-char limit.
     expect(out.length).toBeLessThanOrEqual(4096);
-    // Clip header must be present (oldest lines were dropped).
-    expect(out).toContain("earlier…");
-    // The newest child line must still be present.
-    expect(out).toContain(`Child activity step 150`);
+    // The newest child line must still be present (some portion of it).
+    expect(out).toContain("   ↳ ");
   });
 });
 

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -7,6 +7,7 @@ import {
   type WorkerActivityView,
   type BotApiForWorkerFeed,
 } from '../worker-activity-feed.js'
+import { STATUS_ROLLING_LINES } from '../status-no-truncate.js'
 
 describe('isWorkerActivityFeedEnabled (default ON)', () => {
   it('defaults to true when the env var is unset', () => {
@@ -510,28 +511,56 @@ describe('createWorkerActivityFeed — log sink', () => {
 })
 
 // ─── SWITCHROOM_STATUS_NO_TRUNCATE feature flag tests ────────────────────────
+// New contract (rolling-5-full):
+//   ON  → last STATUS_ROLLING_LINES lines rendered in FULL; no overflow header;
+//          char-budget backstop (_fitWorkerBodyToCharBudget) is the only ceiling.
+//   OFF → NARRATIVE_MAX_LINES cap + STEP_MAX per-line clip (legacy, unchanged).
 
 describe('SWITCHROOM_STATUS_NO_TRUNCATE — renderWorkerActivity', () => {
   afterEach(() => {
     delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
   })
 
-  it('no-truncate ON (default): a narrative with > NARRATIVE_MAX_LINES renders ALL lines', () => {
+  it('no-truncate ON (default): with 12 narrative lines, exactly the last STATUS_ROLLING_LINES render', () => {
     delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE // default = ON
-    const narrativeLines = Array.from({ length: NARRATIVE_MAX_LINES + 4 }, (_, i) => `step ${i + 1}`)
+    // Use zero-padded numbers so "stp-001" cannot be a substring of "stp-010".
+    const narrativeLines = Array.from({ length: 12 }, (_, i) => `stp-${String(i + 1).padStart(3, '0')}`)
     const out = renderWorkerActivity(view({ narrativeLines }))
-    for (let i = 1; i <= NARRATIVE_MAX_LINES + 4; i++) {
-      expect(out).toContain(`step ${i}`)
+    // The last STATUS_ROLLING_LINES lines must appear.
+    const firstVisible = 12 - STATUS_ROLLING_LINES + 1
+    for (let i = firstVisible; i <= 12; i++) {
+      expect(out).toContain(`stp-${String(i).padStart(3, '0')}`)
     }
-    // No spurious overflow header when all steps fit in the budget.
-    expect(out).not.toContain('+4 earlier')
-    expect(out).toContain(`<b>→ step ${NARRATIVE_MAX_LINES + 4}</b>`)
+    // The first (12 - STATUS_ROLLING_LINES) lines must NOT appear.
+    for (let i = 1; i < firstVisible; i++) {
+      expect(out).not.toContain(`stp-${String(i).padStart(3, '0')}`)
+    }
+    // No overflow header in no-truncate mode.
+    expect(out).not.toContain('earlier…')
+    expect(out).toContain('<b>→ stp-012</b>')
   })
 
-  it('no-truncate OFF (=0): existing NARRATIVE_MAX_LINES cap is preserved', () => {
+  it('no-truncate ON: a 150-char line renders in FULL (no "…" mid-line truncation)', () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+    const longLine = 'a'.repeat(75) + ' ' + 'b'.repeat(74) // 150 chars total
+    const out = renderWorkerActivity(view({ narrativeLines: [longLine] }))
+    // Must appear without "…" from per-line STEP_MAX clip.
+    expect(out).toContain(longLine)
+    expect(out).not.toContain('…')
+  })
+
+  it('no-truncate ON: no "✓ +N earlier…" overflow header', () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+    const narrativeLines = Array.from({ length: 20 }, (_, i) => `step ${i + 1}`)
+    const out = renderWorkerActivity(view({ narrativeLines }))
+    expect(out).not.toContain('earlier…')
+  })
+
+  it('no-truncate OFF (=0): existing NARRATIVE_MAX_LINES cap + STEP_MAX clip are preserved', () => {
     process.env.SWITCHROOM_STATUS_NO_TRUNCATE = '0'
     const narrativeLines = Array.from({ length: 9 }, (_, i) => `step ${i + 1}`)
     const out = renderWorkerActivity(view({ narrativeLines }))
+    // Overflow header must appear (legacy cap active).
     expect(out).toContain('<i>✓ +3 earlier…</i>')
     expect(out).not.toContain('step 1')
     expect(out).toContain('step 4')
@@ -539,16 +568,26 @@ describe('SWITCHROOM_STATUS_NO_TRUNCATE — renderWorkerActivity', () => {
     expect(out.match(/step \d/g) ?? []).toHaveLength(6)
   })
 
-  it('no-truncate ON + pathologically huge narrative (500 lines): rendered output ≤ 4096 chars', () => {
+  it('no-truncate OFF (=0): a 150-char line is clipped at STEP_MAX (regression guard)', () => {
+    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = '0'
+    const longLine = 'x'.repeat(150)
+    const out = renderWorkerActivity(view({ narrativeLines: [longLine] }))
+    // Per-line clip must apply when flag is OFF.
+    expect(out).toContain('…')
+    expect(out).not.toContain(longLine)
+  })
+
+  it('no-truncate ON + pathologically oversized body: char-budget backstop fires, output ≤ 4096 chars', () => {
     delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
-    const narrativeLines = Array.from({ length: 500 }, (_, i) => `step number ${i + 1}`)
+    // 5 huge lines × ~900 chars each → well over 4000 chars rendered.
+    const bigLine = 'z'.repeat(900)
+    const narrativeLines = Array.from({ length: 5 }, () => bigLine)
     const out = renderWorkerActivity(view({ narrativeLines }))
     // Hard invariant: must never exceed Telegram's 4096 char limit.
     expect(out.length).toBeLessThanOrEqual(4096)
-    // Oldest lines should have been clipped with a header.
-    expect(out).toContain('earlier…')
-    // The newest step must still be present.
-    expect(out).toContain('step number 500')
+    // The newest step must still be present (some portion of it).
+    const hasBullet = out.includes('→') || out.includes('✓')
+    expect(hasBullet).toBe(true)
   })
 })
 
@@ -557,26 +596,31 @@ describe('SWITCHROOM_STATUS_NO_TRUNCATE — createWorkerActivityFeed narrative a
     delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
   })
 
-  it('no-truncate ON: narrative accumulates more than NARRATIVE_MAX_LINES distinct lines', async () => {
+  it('no-truncate ON: rolling window — with 12 pushes, only the last STATUS_ROLLING_LINES appear in render', async () => {
     delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
     const bot = makeFakeBot()
     let clock = 10_000
     const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
 
-    // Push more lines than NARRATIVE_MAX_LINES into the feed.
-    for (let i = 1; i <= NARRATIVE_MAX_LINES + 4; i++) {
+    // Use zero-padded names to avoid substring collisions (ln-001 vs ln-010).
+    for (let i = 1; i <= 12; i++) {
       clock += 1000
-      await feed.update('w1', 'chat', view({ toolCount: i, latestSummary: `line ${i}` }))
+      await feed.update('w1', 'chat', view({ toolCount: i, latestSummary: `ln-${String(i).padStart(3, '0')}` }))
     }
 
     const last = bot.edits.at(-1)!
-    // All accumulated lines should be present (not spliced to NARRATIVE_MAX_LINES).
-    for (let i = 1; i <= NARRATIVE_MAX_LINES + 4; i++) {
-      expect(last.text).toContain(`line ${i}`)
+    const firstVisible = 12 - STATUS_ROLLING_LINES + 1
+    // The last STATUS_ROLLING_LINES lines must be present.
+    for (let i = firstVisible; i <= 12; i++) {
+      expect(last.text).toContain(`ln-${String(i).padStart(3, '0')}`)
     }
-    // No overflow header for a small feed that fits in the budget.
-    expect(last.text).not.toContain('+4 earlier')
-    expect(last.text).toContain(`<b>→ line ${NARRATIVE_MAX_LINES + 4}</b>`)
+    // Earlier lines must have rolled off.
+    for (let i = 1; i < firstVisible; i++) {
+      expect(last.text).not.toContain(`ln-${String(i).padStart(3, '0')}`)
+    }
+    // No overflow header in no-truncate mode.
+    expect(last.text).not.toContain('earlier…')
+    expect(last.text).toContain('<b>→ ln-012</b>')
   })
 
   it('no-truncate OFF (=0): narrative is still spliced to NARRATIVE_MAX_LINES (original behaviour)', async () => {
@@ -599,18 +643,26 @@ describe('SWITCHROOM_STATUS_NO_TRUNCATE — createWorkerActivityFeed narrative a
   })
 
   it('no-truncate ON: env-flip seam works (set/delete per test)', () => {
-    // Verify the seam: after setting '0', the flag reads as OFF.
+    // Verify the seam: after setting '0', the flag reads as OFF (legacy cap).
     process.env.SWITCHROOM_STATUS_NO_TRUNCATE = '0'
-    const lines = Array.from({ length: NARRATIVE_MAX_LINES + 2 }, (_, i) => `s ${i + 1}`)
+    // Use zero-padded names to avoid substring collisions.
+    const total = NARRATIVE_MAX_LINES + 2
+    const lines = Array.from({ length: total }, (_, i) => `sv-${String(i + 1).padStart(3, '0')}`)
     const offOut = renderWorkerActivity(view({ narrativeLines: lines }))
     expect(offOut).toContain('+2 earlier')
 
-    // After deleting, the flag reads as ON (default).
+    // After deleting, the flag reads as ON (rolling-5-full).
     delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
     const onOut = renderWorkerActivity(view({ narrativeLines: lines }))
-    expect(onOut).not.toContain('+2 earlier')
-    for (let i = 1; i <= NARRATIVE_MAX_LINES + 2; i++) {
-      expect(onOut).toContain(`s ${i}`)
+    // No overflow header in no-truncate mode.
+    expect(onOut).not.toContain('earlier…')
+    // Only the last STATUS_ROLLING_LINES lines should be visible.
+    const firstVisible = total - STATUS_ROLLING_LINES + 1
+    for (let i = firstVisible; i <= total; i++) {
+      expect(onOut).toContain(`sv-${String(i).padStart(3, '0')}`)
+    }
+    for (let i = 1; i < firstVisible; i++) {
+      expect(onOut).not.toContain(`sv-${String(i).padStart(3, '0')}`)
     }
   })
 })

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -169,7 +169,7 @@ export function describeToolUse(
 // caps are lifted and the full feed is shown, bounded only by the 4096-char
 // Telegram limit via STATUS_CARD_CHAR_BUDGET.
 
-import { statusNoTruncate, STATUS_CARD_CHAR_BUDGET } from './status-no-truncate.js'
+import { statusNoTruncate, STATUS_CARD_CHAR_BUDGET, STATUS_ROLLING_LINES } from './status-no-truncate.js'
 
 export const MIRROR_MAX_LINES = 6;
 
@@ -206,6 +206,11 @@ function escapeFeedHtml(s: string): string {
  * `✓ +N earlier…` header when the turn ran longer. Returns null when empty.
  * Callers send the result verbatim — do NOT re-escape or re-wrap it.
  *
+ * When SWITCHROOM_STATUS_NO_TRUNCATE is on (default), shows only the last
+ * STATUS_ROLLING_LINES lines in full (no per-line "…"), with NO overflow
+ * header. The only remaining ceiling is STATUS_CARD_CHAR_BUDGET (wire-limit
+ * backstop via `_fitToCharBudget`).
+ *
  * `stepCount` (optional): when `final=true` and `stepCount > 0`, appends a
  * `✓ N steps` footer line so the persisted feed record shows an accurate
  * total of surfaced (non-surface-tool) steps for the turn.
@@ -218,19 +223,18 @@ export function renderActivityFeed(
 ): string | null {
   if (lines.length === 0) return null;
   const noTruncate = statusNoTruncate();
-  // When no-truncate is ON, show all lines; when OFF, cap to MIRROR_MAX_LINES.
-  // In both modes we may need to trim oldest lines to fit the Telegram budget.
+  // No-truncate ON: rolling STATUS_ROLLING_LINES window, no overflow header.
+  // No-truncate OFF: cap to MIRROR_MAX_LINES with overflow header.
   let shown: string[];
-  let hidden: number;
+  const out: string[] = [];
   if (noTruncate) {
-    shown = lines;
-    hidden = 0;
+    shown = lines.slice(-STATUS_ROLLING_LINES);
+    // Suppress the overflow header in no-truncate mode — strictly the rolling window.
   } else {
     shown = lines.slice(-MIRROR_MAX_LINES);
-    hidden = lines.length - shown.length;
+    const hidden = lines.length - shown.length;
+    if (hidden > 0) out.push(`<i>✓ +${hidden} earlier…</i>`);
   }
-  const out: string[] = [];
-  if (hidden > 0) out.push(`<i>✓ +${hidden} earlier…</i>`);
   const lastIdx = shown.length - 1;
   // Newest line = in-progress step (bold, →); earlier = done (italic, ✓).
   // `final` (turn complete, feed left as a record): ALL lines render done (✓)
@@ -251,8 +255,9 @@ export function renderActivityFeed(
     out.push(`<i>✓ ${stepCount} steps</i>`);
   }
   const result = out.join("\n");
-  // No-truncate mode: enforce the Telegram char budget by trimming oldest
-  // lines first until the output fits, then prepend a "+N earlier…" header.
+  // No-truncate mode: enforce the Telegram char budget as the only ceiling.
+  // With STATUS_ROLLING_LINES=5 full lines (~750 chars) this effectively never
+  // fires, but keep it as the wire-limit safety net.
   if (noTruncate && result.length > STATUS_CARD_CHAR_BUDGET) {
     return _fitToCharBudget(lines, final, liveSuffix, stepCount);
   }
@@ -346,16 +351,25 @@ export function renderActivityFeedWithNested(
   const noTruncate = statusNoTruncate();
   const out: string[] = [];
 
-  // Parent lines: when no-truncate is ON show all; when OFF cap to MIRROR_MAX_LINES.
-  const shownParent = noTruncate ? lines : lines.slice(-MIRROR_MAX_LINES);
-  const hiddenParent = lines.length - shownParent.length;
-  if (hiddenParent > 0) out.push(`<i>✓ +${hiddenParent} earlier…</i>`);
+  // Parent lines:
+  //   no-truncate ON  → rolling STATUS_ROLLING_LINES window, no overflow header.
+  //   no-truncate OFF → cap to MIRROR_MAX_LINES with overflow header.
+  const shownParent = noTruncate ? lines.slice(-STATUS_ROLLING_LINES) : lines.slice(-MIRROR_MAX_LINES);
+  if (!noTruncate) {
+    const hiddenParent = lines.length - shownParent.length;
+    if (hiddenParent > 0) out.push(`<i>✓ +${hiddenParent} earlier…</i>`);
+  }
   for (const l of shownParent) out.push(`<i>✓ ${escapeFeedHtml(l)}</i>`);
 
-  // Child lines: when no-truncate is ON show all; when OFF cap to NESTED_MAX_LINES.
-  const shownChild = noTruncate ? children : children.slice(-NESTED_MAX_LINES);
-  const hiddenChild = children.length - shownChild.length;
-  if (hiddenChild > 0) out.push(`${NESTED_PREFIX}<i>+${hiddenChild} earlier…</i>`);
+  // Child lines:
+  //   no-truncate ON  → rolling STATUS_ROLLING_LINES window, no overflow header,
+  //                     each line in FULL (no NESTED_LINE_MAX "…").
+  //   no-truncate OFF → cap to NESTED_MAX_LINES with overflow header + NESTED_LINE_MAX clip.
+  const shownChild = noTruncate ? children.slice(-STATUS_ROLLING_LINES) : children.slice(-NESTED_MAX_LINES);
+  if (!noTruncate) {
+    const hiddenChild = children.length - shownChild.length;
+    if (hiddenChild > 0) out.push(`${NESTED_PREFIX}<i>+${hiddenChild} earlier…</i>`);
+  }
   const lastChildIdx = shownChild.length - 1;
   // `final`: the nested newest step also renders done (✓) so the left-behind
   // feed reads as completed, not stuck on a "→ in-progress" child step.
@@ -376,8 +390,9 @@ export function renderActivityFeedWithNested(
   }
   if (out.length === 0) return null;
   const result = out.join("\n");
-  // No-truncate mode: enforce the Telegram char budget by trimming oldest
-  // parent lines first, then oldest child lines, until the output fits.
+  // No-truncate mode: enforce the Telegram char budget as the only ceiling.
+  // With STATUS_ROLLING_LINES=5 full lines (~750 chars) this effectively never
+  // fires, but keep it as the wire-limit safety net.
   if (noTruncate && result.length > STATUS_CARD_CHAR_BUDGET) {
     return _fitNestedToCharBudget(lines, children, final, liveSuffix, stepCount);
   }

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -39,7 +39,7 @@ import {
   stripMarkdown,
   truncate,
 } from './card-format.js'
-import { statusNoTruncate, STATUS_CARD_CHAR_BUDGET } from './status-no-truncate.js'
+import { statusNoTruncate, STATUS_CARD_CHAR_BUDGET, STATUS_ROLLING_LINES } from './status-no-truncate.js'
 
 /** Worker-activity feed is ON by default; an operator opts out with
  *  SWITCHROOM_WORKER_ACTIVITY_FEED=0. */
@@ -105,16 +105,27 @@ export const NARRATIVE_MAX_LINES = 6
  * activity card (`renderActivityFeed`): prior steps render done (`✓`, italic),
  * the newest renders in-progress (`→`, bold) unless `allDone`, and an overflow
  * header (`✓ +N earlier…`) appears when the feed exceeds NARRATIVE_MAX_LINES.
- * `steps` are already cleaned + escaped HTML.
+ * `steps` are already cleaned + escaped HTML (but NOT per-line clipped when
+ * noTruncate is true — full content is preserved).
  *
- * When `noTruncate` is true (SWITCHROOM_STATUS_NO_TRUNCATE != '0'), all steps
- * are shown — the caller is responsible for trimming to the char budget after.
+ * When `noTruncate` is true (SWITCHROOM_STATUS_NO_TRUNCATE != '0'):
+ *   - Shows only the LAST STATUS_ROLLING_LINES steps (rolling window).
+ *   - No `✓ +N earlier…` overflow header — strictly the rolling window.
+ *   - Each line renders in FULL (no per-line "…" — clip must NOT be applied
+ *     before passing steps to this function in noTruncate mode).
+ * The only remaining ceiling is the char-budget backstop in the caller.
  */
 function appendStepFeed(lines: string[], steps: string[], allDone: boolean, noTruncate = false): void {
   if (steps.length === 0) return
-  const shown = noTruncate ? steps : steps.slice(-NARRATIVE_MAX_LINES)
-  const hidden = steps.length - shown.length
-  if (hidden > 0) lines.push(`<i>✓ +${hidden} earlier…</i>`)
+  let shown: string[]
+  if (noTruncate) {
+    // Rolling window: last STATUS_ROLLING_LINES lines, no overflow header.
+    shown = steps.slice(-STATUS_ROLLING_LINES)
+  } else {
+    shown = steps.slice(-NARRATIVE_MAX_LINES)
+    const hidden = steps.length - shown.length
+    if (hidden > 0) lines.push(`<i>✓ +${hidden} earlier…</i>`)
+  }
   const lastIdx = shown.length - 1
   shown.forEach((s, i) => {
     lines.push(!allDone && i === lastIdx ? `<b>→ ${s}</b>` : `<i>✓ ${s}</i>`)
@@ -157,7 +168,9 @@ export function renderWorkerActivity(v: WorkerActivityView): string {
     // slot stays single-line after the per-line markdown strip.
     .map((s) => stripMarkdown(s).replace(/\s+/g, ' ').trim())
     .filter((s) => s.length > 0)
-    .map((s) => escapeHtml(truncate(s, STEP_MAX)))
+    // In no-truncate mode each line renders in FULL (no per-line "…").
+    // In legacy mode the STEP_MAX clip is preserved exactly.
+    .map((s) => escapeHtml(noTruncate ? s : truncate(s, STEP_MAX)))
 
   if (finished) {
     const verb = v.state === 'done' ? 'completed' : 'failed'
@@ -195,23 +208,48 @@ export function renderWorkerActivity(v: WorkerActivityView): string {
 /**
  * Internal helper: when no-truncate mode produces a body that exceeds the
  * Telegram char budget, drop the oldest step-feed lines (the ones after the
- * two fixed header lines) until it fits, prepending a "+N earlier…" header.
- * The two fixed header lines (🛠 Worker header + status line) are always kept.
+ * two fixed header lines) until it fits. The two fixed header lines (🛠 Worker
+ * header + status line) are always kept.
+ *
+ * If the final (newest) feed line is itself oversized, it is hard-truncated so
+ * at least some content survives — never returning a body with no step bullet.
  */
 function _fitWorkerBodyToCharBudget(body: string, lines: string[]): string {
   if (body.length <= STATUS_CARD_CHAR_BUDGET) return body
   // lines[0] = header, lines[1] = status line, lines[2..] = step feed + optional rule/result
   const fixed = lines.slice(0, 2)
   const feed = lines.slice(2)
+  // Try dropping oldest feed lines until the output fits (keeping the newest).
+  // Stop before dropping ALL lines — the extreme case below handles that.
   for (let drop = 1; drop < feed.length; drop++) {
     const kept = feed.slice(drop)
-    const candidate = [...fixed, `<i>✓ +${drop} earlier…</i>`, ...kept].join('\n')
+    if (kept.length === 0) break // don't return a body with no step bullet here
+    const candidate = [...fixed, ...kept].join('\n')
     if (candidate.length <= STATUS_CARD_CHAR_BUDGET) return candidate
   }
-  // Extreme: only fixed headers fit. They are pre-escaped HTML but bounded
-  // by DESC_MAX (~80 raw chars), so the joined string is well under the
-  // budget in practice. Return as-is — never slice escaped HTML.
-  return fixed.join('\n')
+  // Extreme: the newest feed line is itself oversized. Hard-truncate it to fit
+  // so at least some step content survives (a truncated step is better than none).
+  // The feed lines are already HTML-escaped; slice the escaped string and patch
+  // the closing tag so Telegram sees valid HTML.
+  const newestLine = feed[feed.length - 1] ?? ''
+  const fixedJoined = fixed.join('\n')
+  const overhead = fixedJoined.length + 1 // +1 for the \n between fixed and newest
+  const maxNewest = Math.max(0, STATUS_CARD_CHAR_BUDGET - overhead)
+  if (maxNewest > 10 && newestLine.length > 0) {
+    // Detect wrapper tags (<b>→ …</b> or <i>✓ …</i>) and re-close after truncation.
+    const isBold = newestLine.startsWith('<b>')
+    const isItalic = newestLine.startsWith('<i>')
+    const closingTag = isBold ? '</b>' : isItalic ? '</i>' : ''
+    const tagOverhead = isBold || isItalic ? (3 + closingTag.length) : 0 // <b> or <i> open tag
+    const sliceAt = maxNewest - closingTag.length - tagOverhead
+    if (sliceAt > 0) {
+      const inner = newestLine.slice(3, 3 + sliceAt) // strip opening tag
+      const truncated = (isBold ? '<b>' : isItalic ? '<i>' : '') + inner + closingTag
+      return [fixedJoined, truncated].join('\n')
+    }
+  }
+  // Absolute last resort: just the fixed headers (budget too tight even for one char).
+  return fixedJoined
 }
 
 export interface WorkerActivityFeedOpts {
@@ -320,14 +358,11 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     if (h.narrative[h.narrative.length - 1] === line) return
     h.narrative.push(line)
     if (statusNoTruncate()) {
-      // No-truncate mode: bound memory with a generous COUNT cap so a single
-      // oversized line can never empty the array (a char-budget splice would
-      // push then immediately splice the only line, discarding it silently).
-      // Render-time (_fitWorkerBodyToCharBudget) enforces the wire limit.
-      // 200 lines × ~100 chars ≈ 20 KB in memory — a safe ceiling.
-      const NARRATIVE_MEM_CAP = 200
-      if (h.narrative.length > NARRATIVE_MEM_CAP) {
-        h.narrative.splice(0, h.narrative.length - NARRATIVE_MEM_CAP)
+      // No-truncate mode: rolling window — keep only the last STATUS_ROLLING_LINES
+      // in memory. The render always shows exactly those lines (full content, no
+      // per-line clip). _fitWorkerBodyToCharBudget is the wire-limit backstop.
+      if (h.narrative.length > STATUS_ROLLING_LINES) {
+        h.narrative.splice(0, h.narrative.length - STATUS_ROLLING_LINES)
       }
     } else {
       // Truncate mode: hard cap to NARRATIVE_MAX_LINES (original behaviour).


### PR DESCRIPTION
## Root cause — the inverted flag

SWITCHROOM_STATUS_NO_TRUNCATE shipped in #2488 (v0.15.49) with an implementation that was the inverse of its docstring: it removed the *line-count* cap (letting the feed grow to ~18 lines) but **still** applied the 100-char per-line STEP_MAX clip. Result: unbounded line count with clipped content. The operator wanted the opposite: fixed height with full content.

## New semantics (flag ON, the default)

- **Line count**: last 5 lines (rolling window) — not all accumulated lines
- **Per-line content**: full content, no per-line "…" clip
- **Overflow header**: suppressed (strictly the rolling window)
- **Wire-limit backstop**: `_fitWorkerBodyToCharBudget` / `_fitToCharBudget` unchanged — still present as the only ceiling

When the flag is OFF (=0): legacy behaviour is byte-identical.

## Before / after render (12 narrative lines)

**Before**: all 12 lines rendered, each clipped at 100 chars with mid-word "…"

**After**: last 5 lines rendered, each in full content (no "…")

## Files changed

- `telegram-plugin/status-no-truncate.ts` — add `STATUS_ROLLING_LINES = 5` export; updated docstring
- `telegram-plugin/worker-activity-feed.ts` — rolling-5 window in `appendStepFeed`; no per-line clip in noTruncate; `accumulateNarrative` caps at `STATUS_ROLLING_LINES`; `_fitWorkerBodyToCharBudget` never returns a body with no step bullet
- `telegram-plugin/tool-activity-summary.ts` — rolling-5 window in `renderActivityFeed` and `renderActivityFeedWithNested`; no `NESTED_LINE_MAX` clip in noTruncate

## Test plan

- [x] With 12 narrative lines and flag ON, exactly the last 5 render; lines 1-7 do not
- [x] A 150-char line renders in FULL (no "…") when flag is ON
- [x] No `✓ +N earlier…` overflow header when flag is ON
- [x] Flag OFF preserves legacy cap + clip behaviour (regression guard)
- [x] Char-budget backstop still trims a pathologically oversized body
- [x] 109 targeted unit tests pass; TypeScript clean; all lint scripts pass

Rides the next release — do not merge until release cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)