### PR TITLE
fix(auth): suppress refresh_token_missing for long-lived subscription tokens (#2507)

### DIFF
--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -82,6 +82,19 @@ const SEVERITY_RANK: Record<AuthSeverity, number> = {
 };
 
 /**
+ * Warn about a missing refresh token only when the access token is
+ * actually expiring soon. Modern Claude Pro/Max subscription OAuth
+ * issues long-lived access tokens (~317 days) with NO refresh token by
+ * design — this is the current steady state for every subscription-
+ * authenticated agent. Emitting a "renew before they expire" warning on
+ * every boot for a token valid for ~10 months is noise, not signal.
+ *
+ * 14 days gives the operator comfortable runway to re-auth before the
+ * token lapses while keeping boots quiet for the common long-lived case.
+ */
+const REFRESH_TOKEN_WARN_WITHIN_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
+
+/**
  * Inspect an agent's `.credentials.json` and return a structured
  * diagnosis. Pure read; no side effects. Used by the boot-self-test
  * issue card path and by `tests/auth-heal-diagnose.test.ts`.
@@ -166,7 +179,16 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
             summary: "credentials file has invalid expiry — send /auth in this chat to reset",
           });
         }
-        if (!oauth.refreshToken || oauth.refreshToken.length === 0) {
+        // Only warn about a missing refresh token when the access token
+        // is actually expiring soon. Long-lived subscription OAuth tokens
+        // (~317 days, no refresh token by design) should not trigger this
+        // warning on every boot — it fires only when renewal is genuinely
+        // imminent (within REFRESH_TOKEN_WARN_WITHIN_MS).
+        const expiresAtValid =
+          typeof expiresAt === "number" && Number.isFinite(expiresAt);
+        const expiringSoon =
+          !expiresAtValid || expiresAt < Date.now() + REFRESH_TOKEN_WARN_WITHIN_MS;
+        if ((!oauth.refreshToken || oauth.refreshToken.length === 0) && expiringSoon) {
           findings.push({
             code: "refresh_token_missing",
             severity: "warn",

--- a/tests/auth-heal-diagnose.test.ts
+++ b/tests/auth-heal-diagnose.test.ts
@@ -11,12 +11,13 @@ import { diagnoseAuthState } from "../src/cli/auth.js";
  * every state transition without spawning subprocesses.
  *
  * Severity rules under test:
- *   - everything missing on disk           → error
- *   - .credentials.json missing, .oauth-token present → warn
- *   - .credentials.json malformed/corrupt  → error
- *   - access token expired                 → error
- *   - refreshToken missing                 → warn
- *   - everything healthy + future expiry   → ok
+ *   - everything missing on disk                          → error
+ *   - .credentials.json missing, .oauth-token present     → warn
+ *   - .credentials.json malformed/corrupt                 → error
+ *   - access token expired                                → error
+ *   - refreshToken missing + token expiring within 14d    → warn
+ *   - refreshToken missing + long-lived token (>14d out)  → ok (no false positive)
+ *   - everything healthy + future expiry                  → ok
  */
 
 let configDir: string;
@@ -105,7 +106,8 @@ describe("diagnoseAuthState", () => {
     expect(expired!.summary).toMatch(/\/auth/);
   });
 
-  it("flags missing refreshToken as warn/refresh_token_missing", () => {
+  it("flags missing refreshToken as warn/refresh_token_missing when token expires soon (1h)", () => {
+    // Token expiring in 1 hour with no refresh token → genuine renewal risk → warn.
     writeCreds({
       claudeAiOauth: {
         accessToken: "tok",
@@ -118,6 +120,36 @@ describe("diagnoseAuthState", () => {
     expect(
       r.findings.find((f) => f.code === "refresh_token_missing"),
     ).toBeDefined();
+  });
+
+  it("flags missing refreshToken as warn/refresh_token_missing when token expires within 14d (3d)", () => {
+    // Token expiring in 3 days with no refresh token → still within the warning window → warn.
+    writeCreds({
+      claudeAiOauth: {
+        accessToken: "tok",
+        expiresAt: Date.now() + 3 * 86_400_000, // 3 days
+      },
+    });
+    const r = diagnoseAuthState(configDir);
+    expect(r.severity).toBe("warn");
+    expect(r.findings.find((f) => f.code === "refresh_token_missing")).toBeDefined();
+  });
+
+  it("suppresses refresh_token_missing for long-lived subscription token (300d, no refreshToken)", () => {
+    // Regression: Claude Pro/Max subscription OAuth issues ~317-day tokens with
+    // no refresh token by design. This warning was firing on every boot for every
+    // agent, which is misleading when the token is valid for ~10 months.
+    // expiresAt = 300 days out, no refreshToken → severity ok, no findings.
+    writeCreds({
+      claudeAiOauth: {
+        accessToken: "tok",
+        expiresAt: Date.now() + 300 * 86_400_000, // 300 days
+      },
+    });
+    const r = diagnoseAuthState(configDir);
+    expect(r.severity).toBe("ok");
+    expect(r.findings).toHaveLength(0);
+    expect(r.recommendation).toHaveLength(0);
   });
 
   it("returns ok with no findings when state is fully healthy", () => {


### PR DESCRIPTION
## Summary

- `diagnoseAuthState` was unconditionally flagging absent `refreshToken` as a warn, regardless of how far the access token is from expiry
- Claude Pro/Max subscription OAuth issues ~317-day access tokens with **no refresh token by design** — this is the current steady state for every subscription-authenticated agent
- This caused a misleading "renew credentials before they expire" auth card to fire on every boot for every agent, even when credentials are valid for ~10 months

Fixes #2507.

## Why

The warning's own rationale — "works today, breaks later — renew before they expire" — does not hold when the access token expires in ~317 days. The warning was noise, not signal, for the modern subscription OAuth model.

## Change

**`src/cli/auth.ts`**

Added `REFRESH_TOKEN_WARN_WITHIN_MS = 14 * 24 * 60 * 60 * 1000` (14 days) and gate the `refresh_token_missing` finding:

```ts
const expiresAtValid = typeof expiresAt === "number" && Number.isFinite(expiresAt);
const expiringSoon = !expiresAtValid || expiresAt < Date.now() + REFRESH_TOKEN_WARN_WITHIN_MS;
if ((!oauth.refreshToken || oauth.refreshToken.length === 0) && expiringSoon) {
  findings.push({ code: "refresh_token_missing", ... });
}
```

- No refreshToken + unknown/invalid expiresAt → still warns (can't tell when it expires)
- No refreshToken + token within 14d of expiry → still warns (genuine renewal risk)
- No refreshToken + long-lived token (>14d) → **no finding** (suppressed false positive)
- `token_expired` path: unchanged (already-expired tokens still emit the error)

14 days chosen as it gives comfortable runway while keeping boots quiet for the ~317-day subscription-token common case.

## Test plan

- [x] New test: long-lived token (300d), no refreshToken → `severity: ok`, no findings (regression gate)
- [x] New test: soon-expiring (3d), no refreshToken → still emits `refresh_token_missing` warn
- [x] Existing test: 1h expiry, no refreshToken → still warns (1h < 14d)
- [x] Existing test: expired token + no refreshToken → both `token_expired` + `refresh_token_missing` (two findings, aggregate error)
- [x] Existing test: long-lived token WITH refreshToken → ok (unchanged)
- [x] `tsc --noEmit` clean
- [x] `vitest run tests/auth-heal-diagnose.test.ts` → 12/12 pass

## Risk

Low. Pure guard narrowing — only tightens the condition for an existing warn. All error paths (`token_expired`, `credentials_missing`, `credentials_malformed`) unchanged.