### PR TITLE
fix(auth): plug quota-plane leaks found in #2498 review — rm-account ghost cache + auth schedule live stamp

### DIFF
--- a/src/auth/broker/server-quota-durable.test.ts
+++ b/src/auth/broker/server-quota-durable.test.ts
@@ -1,5 +1,6 @@
 /**
  * #2495 — auth-broker quota state durability + realtime probe-on-open.
+ * #2509 — rm-account must prune lastQuotaCache (in-memory + disk).
  *
  * Covers:
  *   - Change 1: durable quota cache (write → reload → identical incl. markers).
@@ -8,6 +9,8 @@
  *     + stale-fallback labeling (a failed probe is served `cache`, not `live`).
  *   - Change 2/3: forceLive bypasses the TTL gate (the quota-watch
  *     corroboration probe is a TRUE live probe).
+ *   - #2509: rm-account removes lastQuotaCache entry in-memory AND on disk;
+ *     a fresh broker reload does not revive the removed label.
  *
  * Strategy mirrors server.test.ts: a tmpdir broker reachable over a real UDS,
  * probes injected via `_testFetchQuota`. Never touches `~/.switchroom`.
@@ -54,11 +57,19 @@ afterEach(() => {
   harnesses = [];
 });
 
-function makeConfig(h: Harness, active: string): SwitchroomConfig {
+function makeConfig(
+  h: Harness,
+  active: string,
+  opts: { adminAgents?: string[]; nonActiveAccounts?: string[] } = {},
+): SwitchroomConfig {
+  const agents: Record<string, object> = { ziggy: {} };
+  for (const name of opts.adminAgents ?? []) {
+    agents[name] = { admin: true };
+  }
   return ({
     switchroom: { version: 1, agents_dir: h.agentsDir },
     telegram: {},
-    agents: { ziggy: {} },
+    agents,
     auth: { active },
     google_workspace: undefined,
   } as unknown) as SwitchroomConfig;
@@ -268,5 +279,80 @@ describe("#2495 Change 2 — probe-on-open TTL + single-flight", () => {
     expect(calls).toBe(2);
     expect(r.data.results[0].served).toBe("live");
     broker.stop();
+  });
+});
+
+describe("#2509 — rm-account prunes lastQuotaCache (in-memory + disk + reload)", () => {
+  it("rm-account removes the label from lastQuotaCache in-memory", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    seedAccount(h, "spare");
+    const broker = new AuthBroker(makeConfig(h, "default", { adminAgents: ["clerk"] }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async () => okProbe(30, 3),
+    });
+    await broker.start();
+    const probeSock = join(h.socketRoot, "ziggy", "sock");
+    const adminSock = join(h.socketRoot, "clerk", "sock");
+    // Seed the cache for both accounts.
+    await rpc(probeSock, { v: 1, id: "1", op: "probe-quota", accounts: ["default", "spare"] });
+    expect(broker._state().lastQuotaCache["spare"]).toBeDefined();
+    // rm-account "spare" via admin socket — "spare" is not fleet active.
+    const rmResp: any = await rpc(adminSock, { v: 1, id: "2", op: "rm-account", label: "spare" });
+    expect(rmResp.ok).toBe(true);
+    // In-memory cache must no longer contain "spare".
+    expect(broker._state().lastQuotaCache["spare"]).toBeUndefined();
+    // "default" must be untouched.
+    expect(broker._state().lastQuotaCache["default"]).toBeDefined();
+    broker.stop();
+  });
+
+  it("rm-account removes the label from last-quota.json on disk", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    seedAccount(h, "spare");
+    const broker = new AuthBroker(makeConfig(h, "default", { adminAgents: ["clerk"] }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async () => okProbe(20, 2),
+    });
+    await broker.start();
+    const probeSock = join(h.socketRoot, "ziggy", "sock");
+    const adminSock = join(h.socketRoot, "clerk", "sock");
+    await rpc(probeSock, { v: 1, id: "1", op: "probe-quota", accounts: ["default", "spare"] });
+    // Confirm "spare" is in the on-disk file.
+    const beforeFile = JSON.parse(readFileSync(join(h.stateDir, "last-quota.json"), "utf-8"));
+    expect(beforeFile["spare"]).toBeDefined();
+    await rpc(adminSock, { v: 1, id: "2", op: "rm-account", label: "spare" });
+    // After removal the file must not contain "spare".
+    const afterFile = JSON.parse(readFileSync(join(h.stateDir, "last-quota.json"), "utf-8"));
+    expect(afterFile["spare"]).toBeUndefined();
+    expect(afterFile["default"]).toBeDefined();
+    broker.stop();
+  });
+
+  it("rm-account entry stays gone across a broker reload (loadStateFromDisk does not revive it)", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    seedAccount(h, "spare");
+    const broker = new AuthBroker(makeConfig(h, "default", { adminAgents: ["clerk"] }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async () => okProbe(15, 5),
+    });
+    await broker.start();
+    const probeSock = join(h.socketRoot, "ziggy", "sock");
+    const adminSock = join(h.socketRoot, "clerk", "sock");
+    await rpc(probeSock, { v: 1, id: "1", op: "probe-quota", accounts: ["default", "spare"] });
+    await rpc(adminSock, { v: 1, id: "2", op: "rm-account", label: "spare" });
+    broker.stop();
+
+    // A fresh broker reloads from disk — "spare" must NOT come back.
+    const broker2 = new AuthBroker(makeConfig(h, "default", { adminAgents: ["clerk"] }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async () => okProbe(99, 99),
+    });
+    await broker2.start();
+    expect(broker2._state().lastQuotaCache["spare"]).toBeUndefined();
+    expect(broker2._state().lastQuotaCache["default"]).toBeDefined();
+    broker2.stop();
   });
 });

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -1724,9 +1724,11 @@ export class AuthBroker {
     delete this.quota[label];
     delete this.thresholdViolations[label];
     this.lastWrittenExpiresAt.delete(label);
+    delete this.lastQuotaCache[label];
     this.persistShaIndex();
     this.persistQuota();
     this.persistThresholdViolations();
+    this.persistLastQuotaCache();
     this.audit({ op: "rm-account", identity, account: label, accountKind: "claude", ok: true });
     socket.write(encodeSuccess(id, { label }));
   }

--- a/src/cli/auth-schedule.test.ts
+++ b/src/cli/auth-schedule.test.ts
@@ -17,6 +17,7 @@ const {
   formatWeeklyCell,
   formatStateCell,
   formatScheduleRows,
+  formatFooter,
 } = _testing;
 
 const NOW = new Date("2026-06-07T06:00:00.000Z"); // Sunday
@@ -497,5 +498,63 @@ describe("formatScheduleRows (no-color)", () => {
     expect(lines[2]).toContain("5h-walled");
     expect(lines[3]).toContain("weekly-walled");
     expect(lines[3]).toContain("excluded");
+  });
+});
+
+// ── #2500 — formatFooter probedLive correctness ───────────────────────────
+//
+// These tests exercise the probedLive flag at the footer level (the pure
+// helper). The CLI wiring path is: `probedLive = live && probe !== undefined &&
+// probe.results.some(r => r.served === "live")` — a TTL cache-hit or
+// failed-probe fallback must NOT stamp "probed live".
+
+describe("#2500 — formatFooter does not stamp 'probed live' on a cache-served result", () => {
+  const emptyRows: ScheduleRow[] = [];
+
+  it("a probe with all results served='live' stamps probed live", () => {
+    const liveProbe: ProbeQuotaData = {
+      results: [
+        { label: "default", result: { ok: true, data: { fiveHourUtilizationPct: 10, sevenDayUtilizationPct: 5, fiveHourResetAt: FIVE_RESET, sevenDayResetAt: WEEKLY_RESET, representativeClaim: null, overageStatus: null, overageDisabledReason: null } }, served: "live" },
+      ],
+    };
+    // Simulate the CLI wiring: probedLive requires at least one served==="live".
+    const probedLive = liveProbe.results.some((r) => r.served === "live");
+    expect(probedLive).toBe(true);
+    const footer = formatFooter(emptyRows, { liveRequested: true, probedLive }, NOW);
+    expect(footer[0]).toContain("probed live");
+  });
+
+  it("a probe with all results served='cache' does NOT stamp probed live", () => {
+    const cacheProbe: ProbeQuotaData = {
+      results: [
+        { label: "default", result: { ok: true, data: { fiveHourUtilizationPct: 10, sevenDayUtilizationPct: 5, fiveHourResetAt: FIVE_RESET, sevenDayResetAt: WEEKLY_RESET, representativeClaim: null, overageStatus: null, overageDisabledReason: null } }, served: "cache", capturedAt: Date.now() - 30_000 },
+      ],
+    };
+    // CLI wiring: served='cache' on all results → probedLive = false.
+    const probedLive = cacheProbe.results.some((r) => r.served === "live");
+    expect(probedLive).toBe(false);
+    const footer = formatFooter(emptyRows, { liveRequested: true, probedLive }, NOW);
+    expect(footer[0]).not.toContain("probed live");
+    // Should show the stale/unavailable variant instead.
+    expect(footer[0]).toContain("cached");
+  });
+
+  it("a probe with no served field (legacy response) is treated as not-live", () => {
+    // Legacy broker responses omit `served` entirely. Guard: undefined is not "live".
+    const legacyProbe: ProbeQuotaData = {
+      results: [
+        { label: "default", result: { ok: true, data: { fiveHourUtilizationPct: 10, sevenDayUtilizationPct: 5, fiveHourResetAt: FIVE_RESET, sevenDayResetAt: WEEKLY_RESET, representativeClaim: null, overageStatus: null, overageDisabledReason: null } } },
+      ],
+    };
+    const probedLive = legacyProbe.results.some((r) => r.served === "live");
+    expect(probedLive).toBe(false);
+    const footer = formatFooter(emptyRows, { liveRequested: true, probedLive }, NOW);
+    expect(footer[0]).not.toContain("probed live");
+  });
+
+  it("--cached path (liveRequested=false) always shows cached-snapshot footer regardless of served", () => {
+    const footer = formatFooter(emptyRows, { liveRequested: false, probedLive: false }, NOW);
+    expect(footer[0]).toContain("cached snapshot");
+    expect(footer[0]).not.toContain("probed live");
   });
 });

--- a/src/cli/auth-schedule.ts
+++ b/src/cli/auth-schedule.ts
@@ -503,7 +503,11 @@ export function registerAuthScheduleSubcommands(
 
         const now = new Date();
         const rows = buildScheduleRows(state, probe, now);
-        const probedLive = live && probe !== undefined;
+        // #2500 — only stamp "probed live" when the probe actually hit the upstream.
+        // probe.results carry served:"live"|"cache" (added in #2498). A TTL cache-hit
+        // or failed-probe fallback returns served:"cache"; that must not be presented
+        // as a live read. Require at least one result that was genuinely live.
+        const probedLive = live && probe !== undefined && probe.results.some((r) => r.served === "live");
         console.log();
         for (const l of formatScheduleRows(rows, now)) console.log(l);
         console.log();


### PR DESCRIPTION
## Summary

Two low-severity quota-plane hygiene fixes surfaced during the review of #2498 (quota durability + realtime probe-on-open). Neither is an active failover bug.

- **Fix 1 (#2509):** `opRmAccount` left `lastQuotaCache[label]` in memory and in `last-quota.json` after account removal. Ghost entry was visible in `opListState` (`last_quota` field / `/auth show`) and reloaded on broker restart. Not a failover risk (re-checks credentials first), but unbounded growth across repeated add/remove.
- **Fix 2 (#2500):** `auth schedule` CLI stamped "probed live" even when the broker returned a TTL-cache-served result (`served:"cache"`). Gateway consumers already checked `served` correctly; this was CLI-only and cosmetic (≤45s stale data presented as live).

## Changes

| File | What changed |
|---|---|
| `src/auth/broker/server.ts` | `opRmAccount`: add `delete this.lastQuotaCache[label]` + `this.persistLastQuotaCache()` alongside existing deletions |
| `src/cli/auth-schedule.ts` | `probedLive`: require `probe.results.some(r => r.served === "live")` in addition to `probe !== undefined` |
| `src/auth/broker/server-quota-durable.test.ts` | 3 new tests: in-memory gone, disk gone, stays gone across reload |
| `src/cli/auth-schedule.test.ts` | 4 new tests: live stamps, cache doesn't stamp, legacy (no served) treated as not-live, --cached path |

## Test plan

- [x] `vitest run src/auth/broker/server-quota-durable.test.ts` — 9/9 pass (6 existing + 3 new)
- [x] `vitest run src/cli/auth-schedule.test.ts` — 38/38 pass (34 existing + 4 new)
- [x] `tsc --noEmit` — clean
- [x] Full `vitest run src/auth/broker/` — 332/333 pass (1 timeout on `claude-compat(6)` is pre-existing load-dependent flakiness, passes in isolation and on main without our changes)
- [x] Full `vitest run src/cli/` — 943/943 pass

Closes #2509
Closes #2500
Found in review of #2498

🤖 Generated with [Claude Code](https://claude.com/claude-code)