### PR TITLE
fix(telegram): null meta.json guard + raw-truncate before HTML escape in worker feed

### DIFF
--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -503,13 +503,14 @@ interface FsLike {
  * Backfill `jsonl_agent_id` for a sub-agent row that was inserted by the
  * PreToolUse hook (keyed on tool_use_id) but didn't yet know the JSONL stem.
  *
- * Strategy: read the `agent-<id>.meta.json` sibling Claude Code writes next
- * to each sub-agent JSONL. It carries `{ agentType, description, toolUseId }`
- * where `toolUseId` is the primary key of the `subagents` row (written by
- * `subagent-tracker-pretool.mjs` from `event.tool_use_id`). We use the direct
- * `toolUseId` lookup first (exact PK match, race-safe); fall back to the fuzzy
- * `(agentType, description)` match only when `toolUseId` is absent (older
- * Claude Code versions that pre-date this field in the meta).
+ * Strategy: read the `agent-<id>.meta.json` sibling that the Claude Code
+ * binary writes next to each sub-agent JSONL. It carries `{ agentType,
+ * description, toolUseId }` where `toolUseId` is the primary key of the
+ * `subagents` row — the same `event.tool_use_id` value the pretool hook
+ * (`subagent-tracker-pretool.mjs`) uses when it inserts the DB row. We use
+ * the direct `toolUseId` lookup first (exact PK match, race-safe); fall back
+ * to the fuzzy `(agentType, description)` match only when `toolUseId` is
+ * absent (older Claude Code versions that pre-date this field in the meta).
  *
  * Edge cases:
  *   - meta.json missing or unreadable: no-op (the row stays unlinked; liveness
@@ -531,7 +532,7 @@ export function backfillJsonlAgentId(
   log?: (msg: string) => void,
 ): void {
   const metaPath = jsonlPath.replace(/\.jsonl$/, '.meta.json')
-  let meta: { agentType?: string; description?: string; toolUseId?: string }
+  let meta: { agentType?: string; description?: string; toolUseId?: string } | null
   try {
     const raw = readFileSync(metaPath, 'utf8')
     meta = JSON.parse(raw)
@@ -539,7 +540,7 @@ export function backfillJsonlAgentId(
     log?.(`subagent-watcher: backfill skip ${agentId} — meta.json not readable at ${metaPath}`)
     return
   }
-  if (!meta.agentType && !meta.description && !meta.toolUseId) {
+  if (!meta || (!meta.agentType && !meta.description && !meta.toolUseId)) {
     log?.(`subagent-watcher: backfill skip ${agentId} — meta.json has no agentType/description/toolUseId`)
     return
   }

--- a/telegram-plugin/tests/subagent-watcher-parent-turn-key.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-parent-turn-key.test.ts
@@ -264,3 +264,44 @@ describe('backfillJsonlAgentId — overlapping windows / hook precedence (#2081)
     expect(row?.parent_turn_key).toBe('-100:7:1400')
   })
 })
+
+// ─── #2506: null meta.json guard ─────────────────────────────────────────────
+// JSON.parse('null') succeeds and returns null. Before the fix, the enclosing
+// try/catch only covered the read+parse, so execution fell through to
+// `if (!meta.agentType …)` which threw TypeError: Cannot read properties of
+// null. The fix guards with `if (!meta || …)` so a literal-null meta.json
+// degrades to the same clean skip as any other "no usable fields" case.
+describe('backfillJsonlAgentId — null meta.json guard (#2506)', () => {
+  it('meta.json containing literal null → clean skip, no throw, row stays unlinked', () => {
+    insertSub({ id: 'toolu_null_meta', agentType: 'worker', description: 'task', startedAt: 1000 })
+
+    const jsonlPath = join(tempDir, 'null_meta_worker.jsonl')
+    writeFileSync(join(tempDir, 'null_meta_worker.meta.json'), 'null')
+
+    const logs: string[] = []
+    // Must not throw — before the fix this crashed with TypeError: Cannot read
+    // properties of null (reading 'agentType').
+    expect(() => backfillJsonlAgentId(db, jsonlPath, 'agentstem_null_meta', (m) => logs.push(m))).not.toThrow()
+
+    // Row must remain unlinked (the skip path, not the link path).
+    const row = readSub('toolu_null_meta')
+    expect(row?.jsonl_agent_id).toBeNull()
+
+    // A skip log must have been emitted (not a misleading 'backfill error').
+    expect(logs.some((l) => l.includes('backfill skip') && l.includes('agentstem_null_meta'))).toBe(true)
+  })
+
+  it('meta.json containing literal null → skip log does NOT contain "error"', () => {
+    // The outer try/catch in registerAgent would have surfaced this as a
+    // "backfill error" before the fix; now it should be a clean "backfill skip".
+    const jsonlPath = join(tempDir, 'null_meta_worker2.jsonl')
+    writeFileSync(join(tempDir, 'null_meta_worker2.meta.json'), 'null')
+
+    const logs: string[] = []
+    backfillJsonlAgentId(db, jsonlPath, 'agentstem_null_meta2', (m) => logs.push(m))
+
+    // Should have a skip log, not an error log.
+    expect(logs.some((l) => l.toLowerCase().includes('error'))).toBe(false)
+    expect(logs.some((l) => l.includes('backfill skip'))).toBe(true)
+  })
+})

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -672,15 +672,28 @@ describe('SWITCHROOM_STATUS_NO_TRUNCATE — createWorkerActivityFeed narrative a
 // the oversized line then immediately splice it out, making the narrative empty
 // and the step vanish from the rendered output.
 
-/** Cheap valid-HTML checker: balanced <b>/<i> tags and no partial entity. */
+/**
+ * Cheap valid-HTML checker: balanced <b>/<i> tags and no dangling/partial entity.
+ * Checks for partial entities (e.g. `&am`, `&l`, `&amp` without trailing `;`)
+ * as produced by naive slicing of already-escaped HTML at an entity boundary.
+ */
 function isValidWorkerHtml(s: string): boolean {
   const bOpen = (s.match(/<b>/g) ?? []).length
   const bClose = (s.match(/<\/b>/g) ?? []).length
   const iOpen = (s.match(/<i>/g) ?? []).length
   const iClose = (s.match(/<\/i>/g) ?? []).length
   if (bOpen !== bClose || iOpen !== iClose) return false
-  // No partial entity (e.g. &amp without semicolon at end or mid-string).
-  if (/&[a-z]+$/.test(s)) return false
+  // Check every `&` occurrence: the run of letters after it must end with `;`.
+  // A partial entity like `&am`, `&l`, or `&amp` (no ;) would fail this.
+  // We scan every `&` manually so there's no regex backtracking ambiguity.
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] !== '&') continue
+    let j = i + 1
+    while (j < s.length && s[j] >= 'a' && s[j] <= 'z') j++
+    // j is now at the character after the letter run.
+    // If there were letters and the next char isn't ';', it's a broken entity.
+    if (j > i + 1 && (j >= s.length || s[j] !== ';')) return false
+  }
   return true
 }
 
@@ -728,6 +741,112 @@ describe('extreme-edge: single oversized narrative line (no-truncate ON)', () =>
     // Step must be present in some form (truncated is fine, absent is not).
     const hasBullet = out.includes('→') || out.includes('✓')
     expect(hasBullet).toBe(true)
+
+    expect(out.length).toBeLessThanOrEqual(4096)
+    expect(isValidWorkerHtml(out)).toBe(true)
+  })
+})
+
+// ─── Bug 2: _fitWorkerBodyToCharBudget must not slice already-escaped HTML ───
+//
+// Before the fix, the extreme fallback in _fitWorkerBodyToCharBudget sliced
+// directly into the already-HTML-escaped newest line string. If the slice
+// boundary landed inside an HTML entity (&amp;, &lt;, &gt;), the output
+// contained a broken entity fragment (&am, &l, &amp without ;), which
+// Telegram Bot API rejects with HTTP 400 on parse_mode:'HTML'.
+//
+// The fix mirrors _fitToCharBudget (tool-activity-summary.ts): truncate RAW
+// content first, then escape, then wrap, re-checking post-escape because
+// escaping can expand the string (&→&amp; etc.).
+//
+// These tests place entity characters (&, <, >) at positions that, under the
+// old naive slice, would produce exactly the broken fragments the issue
+// identified (&am, &l). They assert the output is valid HTML and within budget.
+
+describe('Bug 2 (#2506): _fitWorkerBodyToCharBudget does not split HTML entities', () => {
+  afterEach(() => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+  })
+
+  /**
+   * Build a narrative line that, after HTML-escaping, has the entity boundary
+   * at a precise position so a naive `escaped.slice(3, 3 + N)` would split it.
+   *
+   * Strategy: fill with 'x' characters up to a budget, then append an entity
+   * character so the entity starts right where the slice would land.
+   */
+  function buildEntityBoundaryLine(entityChar: string, charBudget: number): string {
+    // The fitter computes sliceAt ≈ charBudget - tagOverhead - closingTag.length.
+    // After the "→ " prefix (2 chars) and <b>…</b> wrapper (7 chars total overhead
+    // in the old code), the inner slice window is roughly charBudget - 9.
+    // Place the entity character so it lands at the very start of where the
+    // naive slice would begin — i.e., fill with (charBudget - 9) 'x's then '&'.
+    const fillLen = Math.max(0, charBudget - 9)
+    return 'x'.repeat(fillLen) + entityChar + 'y'.repeat(50)
+  }
+
+  it('& at entity boundary: output is valid HTML (no &am, &amp without ; etc.)', () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+    // A line that places '&' right at the slice boundary so naive cut → &am
+    const line = buildEntityBoundaryLine('&', 4096)
+    expect(line.length).toBeGreaterThan(100) // sanity: line is substantial
+
+    const out = renderWorkerActivity(view({ narrativeLines: [line] }))
+
+    expect(out.length).toBeLessThanOrEqual(4096)
+    expect(isValidWorkerHtml(out)).toBe(true)
+    // No partial entity fragments that the old code produced.
+    expect(out).not.toMatch(/&amp$/)   // incomplete &amp; at end
+    expect(out).not.toMatch(/&am[^p]/) // &am followed by non-p (e.g. &amy)
+    expect(out).not.toMatch(/&[lg]t?[^;]/) // &l, &lt without semicolon
+  })
+
+  it('< at entity boundary: output is valid HTML (no &l, &lt without ; etc.)', () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+    const line = buildEntityBoundaryLine('<', 4096)
+
+    const out = renderWorkerActivity(view({ narrativeLines: [line] }))
+
+    expect(out.length).toBeLessThanOrEqual(4096)
+    expect(isValidWorkerHtml(out)).toBe(true)
+    expect(out).not.toMatch(/&lt$/)    // incomplete &lt; at end
+    expect(out).not.toMatch(/&l[^t;]/) // &l followed by non-t
+  })
+
+  it('> at entity boundary: output is valid HTML (no &g, &gt without ; etc.)', () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+    const line = buildEntityBoundaryLine('>', 4096)
+
+    const out = renderWorkerActivity(view({ narrativeLines: [line] }))
+
+    expect(out.length).toBeLessThanOrEqual(4096)
+    expect(isValidWorkerHtml(out)).toBe(true)
+    expect(out).not.toMatch(/&gt$/)    // incomplete &gt; at end
+    expect(out).not.toMatch(/&g[^t;]/) // &g followed by non-t
+  })
+
+  it('entity-dense line (& < > interleaved): output ≤ budget and valid HTML', () => {
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+    // Mix entity characters throughout so any slice position is dangerous.
+    const chunk = '&' + 'x'.repeat(3) + '<' + 'y'.repeat(3) + '>' + 'z'.repeat(3)
+    const line = chunk.repeat(500) // ~10k chars raw → well over budget after escape
+    expect(line.length).toBeGreaterThan(4000)
+
+    const out = renderWorkerActivity(view({ narrativeLines: [line] }))
+
+    expect(out.length).toBeLessThanOrEqual(4096)
+    expect(isValidWorkerHtml(out)).toBe(true)
+  })
+
+  it('single & alone in the line: valid HTML and within budget', () => {
+    // Regression: a one-char entity line is a degenerate case the while-loop
+    // must handle without infinite-looping or returning empty content.
+    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+    // Build a huge line: filler xs then '&' then more xs
+    const line = 'x'.repeat(3000) + '&' + 'x'.repeat(1000)
+    expect(line.length).toBeGreaterThan(4000)
+
+    const out = renderWorkerActivity(view({ narrativeLines: [line] }))
 
     expect(out.length).toBeLessThanOrEqual(4096)
     expect(isValidWorkerHtml(out)).toBe(true)

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -165,9 +165,9 @@ export function describeToolUse(
 // exact-duplicates collapsed, capped to the most recent MIRROR_MAX_LINES
 // with a "+N earlier" header so a heavy turn stays readable.
 //
-// When SWITCHROOM_STATUS_NO_TRUNCATE is not '0' (the default), all cosmetic
-// caps are lifted and the full feed is shown, bounded only by the 4096-char
-// Telegram limit via STATUS_CARD_CHAR_BUDGET.
+// When SWITCHROOM_STATUS_NO_TRUNCATE is not '0' (the default), per-line "…"
+// clips and overflow headers are dropped; only the last STATUS_ROLLING_LINES
+// steps are shown in full, bounded by the 4096-char limit (STATUS_CARD_CHAR_BUDGET).
 
 import { statusNoTruncate, STATUS_CARD_CHAR_BUDGET, STATUS_ROLLING_LINES } from './status-no-truncate.js'
 
@@ -418,9 +418,6 @@ function _fitNestedToCharBudget(
     const out: string[] = [];
     if (pDrop > 0) out.push(`<i>✓ +${pDrop} earlier…</i>`);
     for (const l of shownP) out.push(`<i>✓ ${escapeFeedHtml(l)}</i>`);
-    if (children.length > 0) out.push(`${NESTED_PREFIX}<i>+0 earlier…</i>`); // placeholder (unconditional pop below — children is guaranteed non-empty here; this pair is a size-estimation probe kept structurally symmetric with the cDrop loop)
-    // Actually render children at full length.
-    out.pop(); // remove placeholder (children guaranteed non-empty at this call site)
     const lastChildIdx = children.length - 1;
     children.forEach((l, i) => {
       const esc = escapeFeedHtml(l);

--- a/telegram-plugin/uat/scenarios/reactions-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/reactions-dm.test.ts
@@ -10,41 +10,23 @@
  * of the bot's final reply — otherwise the user looks at their
  * inbound, sees it still wearing 🤔, and asks "you done?").
  *
- * History: this scenario was previously `describe.skip` with a
- * rationale that the pinned progress card "renders INSTEAD of
- * reactions". The card was retired in #1126; the card-vs-reaction
- * branch in the gateway is dead. We can now exercise the full
- * lifecycle end-to-end without the two-agent split.
- *
  * What we assert (in priority order):
  *
  *  1. Within the turn, the bot places AT LEAST ONE reaction on the
  *     inbound message (the L1 "I'm alive" signal). We poll via
  *     `driver.pollReactions()` rather than subscribing to push
- *     events — see the DM limitation note below.
+ *     events — Telegram does not deliver `updateMessageReactions`
+ *     push events to the human account when a bot sets a reaction
+ *     in a DM (fixes #2502).
  *  2. By the time the bot has sent a final reply (+ a short tail
- *     for Telegram to apply the terminal-emoji replace), the LAST
- *     reaction on the inbound message is in the `done` set
- *     (`👍 / 💯 / 🎉`).
- *
- * Why polling instead of `observeReactions`:
- *
- *   When a BOT calls `setMessageReaction` on a DM, Telegram's
- *   MTProto server does NOT deliver `updateMessageReactions` to the
- *   human user's account. Telegram only delivers
- *   `updateBotMessageReaction` to the BOT's own update stream.
- *   `observeReactions` hooks `onRawUpdate` and would correctly handle
- *   the update if it arrived — but it never does for DMs where the
- *   reactor is a bot. The gateway log confirms `setMessageReaction`
- *   returns `status=ok`, so the reaction IS applied on Telegram's
- *   side; we just can't observe it via push. Polling with
- *   `driver.pollReactions()` (wraps `messages.getMessagesReactions`)
- *   queries the current reaction state directly and is not affected
- *   by the push-delivery gap. Fixes #2502.
+ *     for Telegram to apply the terminal-emoji replace), the reaction
+ *     on the inbound message is in the `done` set (`👍 / 💯 / 🎉`).
  *
  * Polling strategy:
- *   - Poll every `POLL_INTERVAL_MS` until either a reaction appears
- *     OR the bot has replied AND `TAIL_AFTER_REPLY_MS` has elapsed.
+ *   - Poll every `POLL_INTERVAL_MS` until a terminal-done emoji
+ *     appears OR the bot has replied AND `TAIL_AFTER_REPLY_MS` has
+ *     elapsed. Bail immediately on reply-timeout so CI doesn't burn
+ *     the full 90s safety ceiling.
  *   - After the reply arrives, keep polling through the tail window
  *     so the terminal emoji (👍) has time to replace the working
  *     emoji (👀/🤔). In practice the replace happens within 1-2s
@@ -82,6 +64,7 @@ describe("uat: reaction lifecycle on driver DM", () => {
         // Wait for the bot's reply (any content). We start polling
         // concurrently so we capture intermediate reactions during
         // the turn.
+        let replyTimedOut = false;
         const replyPromise = sc
           .expectMessage(/\S/, { from: "bot", timeout: 60_000 })
           .then((reply) => {
@@ -89,6 +72,12 @@ describe("uat: reaction lifecycle on driver DM", () => {
             replyReceived = true;
             replyReceivedAt = Date.now();
             return reply;
+          })
+          .catch((err: unknown) => {
+            // expectMessage timeout → mark so the poll loop exits immediately
+            // instead of burning the full 90s safety ceiling on CI failure.
+            replyTimedOut = true;
+            throw err;
           });
 
         // Polling loop: sample reactions while waiting for the reply,
@@ -96,6 +85,8 @@ describe("uat: reaction lifecycle on driver DM", () => {
         const poll = async (): Promise<void> => {
           const deadline = Date.now() + 90_000; // safety ceiling
           while (Date.now() < deadline) {
+            // Bail early if the reply timed out — no point polling further.
+            if (replyTimedOut) break;
             const emojis = await sc.driver.pollReactions(
               sc.botUserId,
               sent.messageId,
@@ -131,7 +122,15 @@ describe("uat: reaction lifecycle on driver DM", () => {
         // terminal-done emoji. `setMessageReaction` replaces atomically,
         // so the last snapshot holds whatever is currently on the message.
         const lastSnapshot = reactionHistory[reactionHistory.length - 1];
-        const lastEmoji = lastSnapshot[lastSnapshot.length - 1];
+        // The bot uses setMessageReaction (replace, not append) — exactly one
+        // emoji should be set at any time. Assert the invariant so we catch
+        // accidental multi-emoji states, then check the terminal-done value.
+        expect(
+          lastSnapshot.length,
+          `expected exactly 1 reaction in the final snapshot, got [${lastSnapshot.join(",")}]. ` +
+            `All snapshots: ${reactionHistory.map((s) => `[${s.join(",")}]`).join(" ")}`,
+        ).toBe(1);
+        const lastEmoji = lastSnapshot[0];
         expect(
           TERMINAL_DONE_EMOJI.has(lastEmoji),
           `expected last reaction to be one of ${[

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -162,15 +162,18 @@ export function renderWorkerActivity(v: WorkerActivityView): string {
   const header = `🛠 <b>Worker</b> · <i>${escapeHtml(desc)}</i>`
   const finished = v.state === 'done' || v.state === 'failed'
 
-  const steps = (v.narrativeLines ?? [])
-    // A narrative entry can itself be multi-line (e.g. a worker's final
-    // "Done.\n\n## Summary\n…"). Collapse to one visual line so a step
-    // slot stays single-line after the per-line markdown strip.
+  // Clean narrative lines (strip Markdown, collapse whitespace) but keep the
+  // raw (pre-HTML-escape) strings so the char-budget fitter can truncate raw
+  // content first and then escape, avoiding broken HTML entities at the slice
+  // boundary (e.g. &amp; → &amp or &lt; → &l after a naive escaped-string cut).
+  const rawSteps = (v.narrativeLines ?? [])
     .map((s) => stripMarkdown(s).replace(/\s+/g, ' ').trim())
     .filter((s) => s.length > 0)
-    // In no-truncate mode each line renders in FULL (no per-line "…").
-    // In legacy mode the STEP_MAX clip is preserved exactly.
-    .map((s) => escapeHtml(noTruncate ? s : truncate(s, STEP_MAX)))
+  // Escape + clip (clip only in legacy mode) for the rendered feed.
+  const steps = rawSteps.map((s) => escapeHtml(noTruncate ? s : truncate(s, STEP_MAX)))
+  // Newest raw step: used by _fitWorkerBodyToCharBudget's extreme fallback to
+  // truncate raw text before escaping (mirrors _fitToCharBudget in tool-activity-summary.ts).
+  const rawNewestStep = rawSteps[rawSteps.length - 1] ?? ''
 
   if (finished) {
     const verb = v.state === 'done' ? 'completed' : 'failed'
@@ -185,7 +188,7 @@ export function renderWorkerActivity(v: WorkerActivityView): string {
       lines.push(`${emoji} <i>${escapeHtml(truncate(result, RESULT_MAX))}</i>`)
     }
     const body = lines.join('\n')
-    return noTruncate ? _fitWorkerBodyToCharBudget(body, lines) : body
+    return noTruncate ? _fitWorkerBodyToCharBudget(body, lines, rawNewestStep) : body
   }
 
   const lines = [header, `<i>running · ${elapsed} · ${v.toolCount} ${toolWord}</i>`]
@@ -196,13 +199,14 @@ export function renderWorkerActivity(v: WorkerActivityView): string {
     // the manager always supplies narrativeLines.
     const summary = stripMarkdown(v.latestSummary).replace(/\s+/g, ' ').trim()
     if (summary.length > 0) {
-      lines.push(`<b>→ ${escapeHtml(truncate(summary, STEP_MAX))}</b>`)
+      // In no-truncate mode, render in full (no STEP_MAX clip); legacy mode preserves the clip.
+      lines.push(`<b>→ ${escapeHtml(noTruncate ? summary : truncate(summary, STEP_MAX))}</b>`)
     } else {
       lines.push('<i>starting…</i>')
     }
   }
   const body = lines.join('\n')
-  return noTruncate ? _fitWorkerBodyToCharBudget(body, lines) : body
+  return noTruncate ? _fitWorkerBodyToCharBudget(body, lines, rawNewestStep) : body
 }
 
 /**
@@ -212,40 +216,52 @@ export function renderWorkerActivity(v: WorkerActivityView): string {
  * header + status line) are always kept.
  *
  * If the final (newest) feed line is itself oversized, it is hard-truncated so
- * at least some content survives — never returning a body with no step bullet.
+ * at least some step content survives — never returning a body with no step
+ * bullet. `rawNewestStep` is the raw (un-HTML-escaped) text of that newest step
+ * so the extreme fallback can truncate RAW content first, then escape and wrap.
+ *
+ * Never slice already-escaped HTML — that breaks entities (&amp; → &amp) and
+ * leaves dangling tags. Truncate the RAW content first, then escape and wrap,
+ * re-checking post-escape because escaping can expand (&→&amp;).
+ * Mirrors the identical strategy in `_fitToCharBudget` (tool-activity-summary.ts).
  */
-function _fitWorkerBodyToCharBudget(body: string, lines: string[]): string {
+function _fitWorkerBodyToCharBudget(body: string, lines: string[], rawNewestStep: string): string {
   if (body.length <= STATUS_CARD_CHAR_BUDGET) return body
   // lines[0] = header, lines[1] = status line, lines[2..] = step feed + optional rule/result
   const fixed = lines.slice(0, 2)
   const feed = lines.slice(2)
   // Try dropping oldest feed lines until the output fits (keeping the newest).
-  // Stop before dropping ALL lines — the extreme case below handles that.
   for (let drop = 1; drop < feed.length; drop++) {
     const kept = feed.slice(drop)
-    if (kept.length === 0) break // don't return a body with no step bullet here
     const candidate = [...fixed, ...kept].join('\n')
     if (candidate.length <= STATUS_CARD_CHAR_BUDGET) return candidate
   }
-  // Extreme: the newest feed line is itself oversized. Hard-truncate it to fit
-  // so at least some step content survives (a truncated step is better than none).
-  // The feed lines are already HTML-escaped; slice the escaped string and patch
-  // the closing tag so Telegram sees valid HTML.
+  // Extreme: the newest feed line is itself oversized. Never slice the already-
+  // escaped HTML string — that splits entities (&amp;lt; → &amp;l, &amp;am…).
+  // Instead: truncate the RAW step content first, then escape and wrap, checking
+  // post-escape because escaping can expand the length (&→&amp;).
   const newestLine = feed[feed.length - 1] ?? ''
   const fixedJoined = fixed.join('\n')
-  const overhead = fixedJoined.length + 1 // +1 for the \n between fixed and newest
+  const isBold = newestLine.startsWith('<b>')
+  const isItalic = newestLine.startsWith('<i>')
+  const openTag = isBold ? '<b>' : isItalic ? '<i>' : ''
+  const closeTag = isBold ? '</b>' : isItalic ? '</i>' : ''
+  const prefix = isBold ? '→ ' : isItalic ? '✓ ' : ''
+  const wrapperOverhead = openTag.length + prefix.length + closeTag.length
+  const overhead = fixedJoined.length + 1 // +1 for the \n joining fixed and newest
   const maxNewest = Math.max(0, STATUS_CARD_CHAR_BUDGET - overhead)
-  if (maxNewest > 10 && newestLine.length > 0) {
-    // Detect wrapper tags (<b>→ …</b> or <i>✓ …</i>) and re-close after truncation.
-    const isBold = newestLine.startsWith('<b>')
-    const isItalic = newestLine.startsWith('<i>')
-    const closingTag = isBold ? '</b>' : isItalic ? '</i>' : ''
-    const tagOverhead = isBold || isItalic ? (3 + closingTag.length) : 0 // <b> or <i> open tag
-    const sliceAt = maxNewest - closingTag.length - tagOverhead
-    if (sliceAt > 0) {
-      const inner = newestLine.slice(3, 3 + sliceAt) // strip opening tag
-      const truncated = (isBold ? '<b>' : isItalic ? '<i>' : '') + inner + closingTag
-      return [fixedJoined, truncated].join('\n')
+  if (maxNewest > wrapperOverhead && rawNewestStep.length > 0) {
+    const maxRaw = maxNewest - wrapperOverhead
+    let raw = rawNewestStep.slice(0, maxRaw)
+    let escaped = escapeHtml(raw)
+    // Re-check post-escape: escaping can expand the string (& → &amp; etc.).
+    while (raw.length > 0 && wrapperOverhead + escaped.length > maxNewest) {
+      const excess = wrapperOverhead + escaped.length - maxNewest
+      raw = raw.slice(0, Math.max(0, raw.length - excess - 1))
+      escaped = escapeHtml(raw)
+    }
+    if (escaped.length > 0) {
+      return [fixedJoined, `${openTag}${prefix}${escaped}${closeTag}`].join('\n')
     }
   }
   // Absolute last resort: just the fixed headers (budget too tight even for one char).
@@ -285,8 +301,10 @@ interface WorkerHandle {
   cooldownUntil: number
   /**
    * Accumulated narrative lines (oldest→newest), deduped against the
-   * immediately-preceding line and capped to NARRATIVE_MAX_LINES. Grows the
-   * live render so the feed reads like the main agent's answer.
+   * immediately-preceding line. In no-truncate mode capped to
+   * STATUS_ROLLING_LINES (rolling window); in legacy mode to
+   * NARRATIVE_MAX_LINES. Grows the live render so the feed reads like the
+   * main agent's answer.
    */
   narrative: string[]
   /** Per-worker serialization chain so ticks can't interleave sends. */


### PR DESCRIPTION
Closes #2506

Two confirmed correctness bugs + cosmetic nits from the adversarial review of #2503/#2504/#2505.

## Bug 1 — null meta.json guard (`subagent-watcher.ts` ~line 535)

`JSON.parse('null')` succeeds and returns `null`. The `try/catch` only covered the read+parse step, so a literal-null `meta.json` fell through to `if (!meta.agentType && !meta.description && !meta.toolUseId)` which threw `TypeError: Cannot read properties of null`. Absorbed by the outer catch in `registerAgent` as a misleading `'backfill error'` log (not a crash, but confusing). Fix: `if (!meta || (!meta.agentType …))`.

## Bug 2 — `_fitWorkerBodyToCharBudget` sliced already-escaped HTML (`worker-activity-feed.ts`)

The extreme-fallback hard-truncate path sliced directly into the HTML-escaped newest step string (`newestLine.slice(3, 3 + sliceAt)`). If the boundary landed inside an entity (`&amp;`, `&lt;`, `&gt;`), Telegram Bot API returned HTTP 400 on `parse_mode:'HTML'` → `editMessageText` threw → `doUpdate` catch nulled `messageId` and re-posted the same broken body next tick → loop. PR #2504 **unmasked** this: before #2504, lines were per-line clipped to `STEP_MAX` (~100 chars) so a single line could never reach the >4000-char fallback; now full-length lines can.

Fix: mirror `_fitToCharBudget` in `tool-activity-summary.ts` — truncate the **RAW** step content first, then escape, then wrap, re-checking post-escape because escaping expands (`&`→`&amp;`). The raw newest step is threaded from `renderWorkerActivity` into the fitter via a new `rawNewestStep` parameter.

Also fixes the back-compat `latestSummary` path (no longer clips to `STEP_MAX` in no-truncate mode).

## Cosmetic nits from #2506

- `subagent-watcher.ts` JSDoc: clarify that `meta.json` is written by Claude Code binary; pretool hook writes the DB row.
- `worker-activity-feed.ts` `WorkerHandle` JSDoc: `'capped to NARRATIVE_MAX_LINES'` → mode-aware wording.
- `tool-activity-summary.ts` module comment: `'all lines shown'` → `'last STATUS_ROLLING_LINES lines shown in full'`.
- `tool-activity-summary.ts` `_fitNestedToCharBudget`: remove dead push/pop probe (structurally symmetric placeholder + unconditional pop).
- `reactions-dm.test.ts`: trim stale `observeReactions` explanation in docblock; assert `lastSnapshot.length === 1` instead of `[len-1]`; bail poll loop early on reply-timeout so CI doesn't burn the full 90s safety ceiling.

## Tests

- `subagent-watcher-parent-turn-key.test.ts`: literal-null `meta.json` → no throw, clean skip log, row stays unlinked.
- `worker-activity-feed.test.ts`: entity-boundary cases (`&`, `<`, `>`) placed so naive slice would produce `&am`/`&l`; dense entity lines; updated `isValidWorkerHtml` to catch partial entities reliably (previous regex had backtracking ambiguity).

## Test results

```
✓ telegram-plugin/tests/worker-activity-feed.test.ts (51 tests)
✓ bun test subagent-watcher-parent-turn-key.test.ts (12 tests)
✓ tsc --noEmit (clean)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)