### PR TITLE
fix(compose): trust host-rooted symlinks when target is outside hostd bind tree (#2512)

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -849,17 +849,19 @@ function conditionalMountPresent(
     if (!isAbsolute(target)) target = resolve(dirname(probePath), target);
     if (hostHome && probeHome && hostHome !== probeHome) {
       if (target.startsWith(hostHome + "/")) {
-        // The symlink target is host-home-rooted: it unambiguously points at a
-        // real host path. Prefer verifying the translated (probe-home) path
-        // when it's reachable. But if it isn't — e.g. hostd only mounts
-        // ~/.switchroom, not ~/.switchroom-config — trust the symlink anyway.
-        // Docker resolves symlinks host-side at bind-mount time, so the mount
-        // source is valid as long as the symlink itself exists (which lstatSync
-        // above already confirmed).
-        const translated = probeHome + target.slice(hostHome.length);
-        if (existsSync(translated)) return true;
-        // Translated path not reachable inside this container, but the symlink
-        // points at a host-rooted path — docker will find it at mount time.
+        // The symlink target is host-rooted, so docker will resolve it on the
+        // host at bind-mount time and the mount source is valid. The generator
+        // runs inside hostd, which only mounts ~/.switchroom/ and cannot stat
+        // the symlink's real host target — so we cannot distinguish a live
+        // target from a dangling one from here. "Trust it" is the only workable
+        // choice.
+        //
+        // ACCEPTED TRADEOFF: a symlink whose host target is genuinely missing
+        // will cause `docker compose up` to hard-fail (agent can't start)
+        // rather than silently drop the mount (agent starts without skills).
+        // That's intentional — switchroom reconcile manages these symlinks, so
+        // a dangling target is not a real production state, and a loud failure
+        // is preferable to a silent capability loss.
         return true;
       }
     }

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -823,6 +823,19 @@ function readStrippedCaps(agent: AgentConfig): string[] {
  * container-real home) and check THAT. The baked mount SOURCE stays the
  * host-home path, which docker resolves host-side at mount time. On the host
  * (`hostHome === probeHome`) this is identical to `existsSync`.
+ *
+ * Fallback (#2512): hostd only bind-mounts `~/.switchroom/` into its container
+ * (not `~/.switchroom-config/` or other operator dirs). A symlink like
+ * `~/.switchroom/skills -> /home/op/.switchroom-config/skills` has a
+ * `hostHome`-rooted target, and after translation the target becomes
+ * `/host-home/.switchroom-config/skills` — which still doesn't exist inside
+ * hostd because that directory isn't mounted there. The translated-existsSync
+ * path is a dead end for targets outside the hostd bind tree. If the symlink
+ * itself exists AND its target is an absolute path under `hostHome` (meaning
+ * it unambiguously refers to something on the host), that is sufficient
+ * evidence: docker resolves symlinks host-side at bind-mount time and will
+ * find the target. Trust the symlink; don't require the translated target to
+ * be probe-resolvable inside the container.
  */
 function conditionalMountPresent(
   probePath: string,
@@ -834,13 +847,21 @@ function conditionalMountPresent(
     if (!lstatSync(probePath).isSymbolicLink()) return false;
     let target = readlinkSync(probePath);
     if (!isAbsolute(target)) target = resolve(dirname(probePath), target);
-    if (
-      hostHome &&
-      probeHome &&
-      hostHome !== probeHome &&
-      target.startsWith(hostHome + "/")
-    ) {
-      target = probeHome + target.slice(hostHome.length);
+    if (hostHome && probeHome && hostHome !== probeHome) {
+      if (target.startsWith(hostHome + "/")) {
+        // The symlink target is host-home-rooted: it unambiguously points at a
+        // real host path. Prefer verifying the translated (probe-home) path
+        // when it's reachable. But if it isn't — e.g. hostd only mounts
+        // ~/.switchroom, not ~/.switchroom-config — trust the symlink anyway.
+        // Docker resolves symlinks host-side at bind-mount time, so the mount
+        // source is valid as long as the symlink itself exists (which lstatSync
+        // above already confirmed).
+        const translated = probeHome + target.slice(hostHome.length);
+        if (existsSync(translated)) return true;
+        // Translated path not reachable inside this container, but the symlink
+        // points at a host-rooted path — docker will find it at mount time.
+        return true;
+      }
     }
     return existsSync(target);
   } catch {

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -2834,6 +2834,36 @@ describe("conditional-mount probe home (in-hostd apply — marko meta_pages regr
     expect(yaml).toContain("/home/op/.switchroom/skills:/home/op/.switchroom/skills:ro");
   });
 
+  // #2512: hostd only mounts ~/.switchroom into its container — NOT
+  // ~/.switchroom-config or any other operator dir. A symlink like
+  //   ~/.switchroom/skills -> /home/op/.switchroom-config/skills
+  // points at a host-rooted path. The translated target becomes
+  // /host-home/.switchroom-config/skills which does NOT exist inside the
+  // container (because .switchroom-config isn't mounted). The #2387 fix
+  // translated the target and then checked existsSync on the translated path —
+  // still false → mount dropped again. The correct behaviour: a symlink whose
+  // target starts with hostHome is unambiguously host-rooted; docker resolves
+  // it host-side at bind-mount time regardless of whether the translated path
+  // is reachable inside the container.
+  it("keeps a symlinked skills dir even when the symlink target is not reachable in the container (#2512)", () => {
+    // Simulate the production setup: ~/.switchroom/skills is a symlink to
+    // /home/op/.switchroom-config/skills, but ~/.switchroom-config/ is NOT
+    // mounted into probeHomeDir (hostd only mounts ~/.switchroom).
+    // So the translated target /probeHomeDir/.switchroom-config/skills does not exist.
+    mkdirSync(join(tmpDir, ".switchroom"), { recursive: true });
+    // Only create the symlink, NOT the target inside tmpDir — mirrors hostd.
+    symlinkSync("/home/op/.switchroom-config/skills", join(tmpDir, ".switchroom", "skills"));
+    const yaml = generateCompose({
+      config: makeConfig({ klanker: {} }),
+      homeDir: "/home/op",
+      probeHomeDir: tmpDir,
+    });
+    // Symlink exists and its target is host-home-rooted → mount must be emitted.
+    // Docker resolves the symlink host-side; we must not drop it because the
+    // translated target happens to be outside the container's bind tree.
+    expect(yaml).toContain("/home/op/.switchroom/skills:/home/op/.switchroom/skills:ro");
+  });
+
   // #2383: a bundled-skills pool OUTSIDE ~/.switchroom/skills must bake a
   // HOST-rooted mount source, not the container-real /host-home path.
   it("bakes a host-rooted source for an out-of-skills bundled pool on in-hostd apply (#2383)", () => {


### PR DESCRIPTION
## Summary

Fleet-wide skills outage: every in-hostd reconcile (agent self-restart via `/restart`, `/update apply`, `config_propose_edit`, etc.) silently dropped the `~/.switchroom/skills` bind mount, causing all 12 agents to lose shared + bundled skills (compass, mail, calendar, pdf, xlsx, etc.).

- Root cause commit: `999271a6` — `fix(compose): probe container-real home for conditional mounts (#2382)`
- Partial fix: `6c766bef` — `fix(compose): keep symlinked + bundled-skills mounts on in-hostd apply (#2387, #2383)` — introduced `conditionalMountPresent` but left a gap
- This PR: closes the gap

## Root cause

`~/.switchroom/skills` is a symlink → `/home/kenthompson/.switchroom-config/skills` (absolute host path).

The `#2387` fix (`conditionalMountPresent`) correctly detected the symlink and translated its target from `hostHome`-rooted to `probeHome`-rooted, then called `existsSync` on the translated path. But hostd **only mounts `~/.switchroom/` into its container** — not `~/.switchroom-config/` or any other operator dir. So the translated path `/host-home/.switchroom-config/skills` does not exist inside the container; `existsSync` returns false; the mount is dropped.

Confirmed by inspecting the hostd container mounts (only `~/.switchroom → /host-home/.switchroom`), and by the Jun 20 backup (`docker-compose.yml.bak-20260620T150709Z`, generated by v0.15.46 post-#2387) having 0 skills mount lines despite the symlink existing on the host.

## Fix

In `conditionalMountPresent`: when the symlink target starts with `hostHome/` (unambiguously host-rooted), trust the symlink regardless of whether the translated path is reachable inside the container. Docker resolves symlinks host-side at bind-mount time and will find the target. The `lstatSync` call above already confirms the symlink exists; that is sufficient evidence.

The translated-`existsSync` check is retained as an optimistic fast-path for cases where the target IS also visible inside the container.

## Evidence

- `docker-compose.yml.bad-18e9d152-mount` (Jun 11, pre-`#2387`): 0 skills lines, `/host-home/` paths
- `docker-compose.yml.bak-20260620T150709Z` (Jun 20, v0.15.46, post-`#2387`): 0 skills lines, correct `/home/kenthompson/` paths — #2387 fixed the path prefix but the existsSync gap remained
- `docker-compose.yml.pre-sha-5c4a67f.bak` (good, pre-regression): 24 skills lines (2 per agent × 12 agents)
- Current live compose (manually patched Jun 21): 12 skills lines

## Test plan

- [x] New vitest case: `keeps a symlinked skills dir even when the symlink target is not reachable in the container (#2512)` — creates the symlink without the target inside `probeHomeDir` (mirrors the hostd mount tree), asserts the skills mount is emitted
- [x] Existing `#2387` test still passes (translated target present → existsSync fast-path still works)
- [x] All 173 compose-generator tests pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)