### PR TITLE
fix(auth): demote out_of_credits from serve-block to informational overage flag

### DIFF
--- a/src/auth/broker/account-eligibility.test.ts
+++ b/src/auth/broker/account-eligibility.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect } from "vitest";
 import {
   isAccountBlocked,
+  hasNoOverageHeadroom,
   isOverageServeBlocking,
   snapshotShouldClearMark,
   clampMarkExpiry,
   snapshotFresh,
   snapshotWalled,
   snapshotClearlyHealthy,
+  OVERAGE_EXHAUSTED_REASONS,
   SERVE_BLOCKING_OVERAGE_REASONS,
   WALL_PCT,
   HEALTHY_CLEAR_PCT,
@@ -53,38 +55,54 @@ describe("snapshot predicates", () => {
   });
 });
 
-describe("isOverageServeBlocking — strict allowlist on the DISABLED REASON", () => {
-  it("out_of_credits → true (the credits-dead account)", () => {
-    expect(isOverageServeBlocking(snap(0, 0, 0, { reason: "out_of_credits" }))).toBe(true);
+describe("hasNoOverageHeadroom — informational allowlist on the DISABLED REASON", () => {
+  it("out_of_credits → true (no overage headroom, informational only)", () => {
+    expect(hasNoOverageHeadroom(snap(0, 0, 0, { reason: "out_of_credits" }))).toBe(true);
     // rejected status alongside it must not change the verdict (we key on reason)
     expect(
-      isOverageServeBlocking(snap(0, 0, 0, { status: "rejected", reason: "out_of_credits" })),
+      hasNoOverageHeadroom(snap(0, 0, 0, { status: "rejected", reason: "out_of_credits" })),
     ).toBe(true);
   });
   it("org_level_disabled → false (MANDATORY non-regression: the live active fleet account)", () => {
-    // This account serves fine off subscription; overage is merely off. It even
-    // reports overageStatus:"rejected" — must STILL be benign.
+    // This account serves fine off subscription; overage is merely off.
     expect(
-      isOverageServeBlocking(snap(75, 40, 0, { status: "rejected", reason: "org_level_disabled" })),
+      hasNoOverageHeadroom(snap(75, 40, 0, { status: "rejected", reason: "org_level_disabled" })),
     ).toBe(false);
   });
   it("null reason → false (deny-by-omission)", () => {
-    expect(isOverageServeBlocking(snap(0, 0, 0, { reason: null }))).toBe(false);
-    expect(isOverageServeBlocking(snap(0, 0, 0))).toBe(false); // field absent
+    expect(hasNoOverageHeadroom(snap(0, 0, 0, { reason: null }))).toBe(false);
+    expect(hasNoOverageHeadroom(snap(0, 0, 0))).toBe(false); // field absent
   });
   it("unknown reason (payment_failed) → false (deny-by-omission)", () => {
-    expect(isOverageServeBlocking(snap(0, 0, 0, { reason: "payment_failed" }))).toBe(false);
+    expect(hasNoOverageHeadroom(snap(0, 0, 0, { reason: "payment_failed" }))).toBe(false);
   });
   it("the allowlist contains ONLY out_of_credits", () => {
-    expect([...SERVE_BLOCKING_OVERAGE_REASONS]).toEqual(["out_of_credits"]);
+    expect([...OVERAGE_EXHAUSTED_REASONS]).toEqual(["out_of_credits"]);
+  });
+  it("SERVE_BLOCKING_OVERAGE_REASONS is an alias for OVERAGE_EXHAUSTED_REASONS (backwards compat)", () => {
+    expect(SERVE_BLOCKING_OVERAGE_REASONS).toBe(OVERAGE_EXHAUSTED_REASONS);
+  });
+  it("isOverageServeBlocking is an alias for hasNoOverageHeadroom (backwards compat)", () => {
+    // Both should return true for out_of_credits
+    expect(isOverageServeBlocking(snap(0, 0, 0, { reason: "out_of_credits" }))).toBe(true);
+    expect(isOverageServeBlocking(snap(0, 0, 0, { reason: "org_level_disabled" }))).toBe(false);
   });
 });
 
-describe("isAccountBlocked — overage serve-blocking is exhaustion too", () => {
-  it("out_of_credits at 0% util, fresh, no mark ⇒ TRUE (idle-but-unusable)", () => {
+describe("isAccountBlocked — out_of_credits is NOT serve-blocking (demoted to informational)", () => {
+  it("out_of_credits at 0% util, fresh, no mark ⇒ FALSE (eligible failover target)", () => {
+    // THE KEY CHANGE: out_of_credits is informational, NOT a block. An account
+    // at 0% util with out_of_credits serves fine from quota. This reverses the
+    // 2026-06-20 guard which was the defect.
     expect(
       isAccountBlocked({ snapshot: snap(0, 0, 30_000, { reason: "out_of_credits" }), now: NOW }),
-    ).toBe(true);
+    ).toBe(false);
+  });
+  it("out_of_credits at 0% util is a valid failover target (the pixsoul@gmail.com scenario)", () => {
+    // pixsoul@gmail.com: 5h=0%, 7d=2%, out_of_credits. MUST be eligible.
+    expect(
+      isAccountBlocked({ snapshot: snap(0, 2, 30_000, { status: "rejected", reason: "out_of_credits" }), now: NOW }),
+    ).toBe(false);
   });
   it("org_level_disabled at 75% util, fresh, no mark ⇒ FALSE (MANDATORY catastrophic-regression guard)", () => {
     // The live fleet account. Below the 99.5% wall, benign overage reason →
@@ -102,7 +120,7 @@ describe("isAccountBlocked — overage serve-blocking is exhaustion too", () => 
     ).toBe(false);
   });
   it("out_of_credits on a STALE snapshot (>24h) ⇒ ignored, falls back to the mark", () => {
-    // Stale overage data must not block on its own; only the mark governs.
+    // Stale overage data must not affect eligibility; only the mark governs.
     const staleAge = SNAPSHOT_STALE_AGE_MS + 60_000;
     expect(
       isAccountBlocked({
@@ -118,6 +136,36 @@ describe("isAccountBlocked — overage serve-blocking is exhaustion too", () => 
         now: NOW,
       }),
     ).toBe(true); // unexpired mark governs
+  });
+  it("out_of_credits at HIGH util (>=99.5%) IS blocked — the util wall fires, not the credits flag", () => {
+    // Still blocked when actually quota-walled. The block comes from snapshotWalled,
+    // not from the out_of_credits flag.
+    expect(
+      isAccountBlocked({ snapshot: snap(99.6, 0, 30_000, { reason: "out_of_credits" }), now: NOW }),
+    ).toBe(true);
+    expect(
+      isAccountBlocked({ snapshot: snap(0, 99.6, 30_000, { reason: "out_of_credits" }), now: NOW }),
+    ).toBe(true);
+  });
+});
+
+describe("isAccountBlocked — real 429 → mark-exhausted path remains the safety net", () => {
+  it("an active mark blocks the account regardless of out_of_credits (mark is the safety net)", () => {
+    // A real 429 raises mark-exhausted. That mark blocks until expiry.
+    // out_of_credits alone does not block, but the MARK does.
+    const mark: ExhaustionMark = { exhausted_until: NOW + FIVE_H, marked_at: NOW - 1000 };
+    expect(
+      isAccountBlocked({
+        mark,
+        snapshot: snap(0, 0, 30_000, { reason: "out_of_credits" }),
+        now: NOW,
+      }),
+    ).toBe(true); // mark governs when mark is newer than snapshot
+  });
+  it("a mark NEWER than the snapshot wins (a just-seen 429 beats an older probe)", () => {
+    const mark: ExhaustionMark = { exhausted_until: NOW + FIVE_H, marked_at: NOW - 1_000 };
+    // snapshot captured 10min ago showed healthy, but the 429 mark is newer
+    expect(isAccountBlocked({ mark, snapshot: snap(10, 10, 10 * 60_000), now: NOW })).toBe(true);
   });
 });
 
@@ -143,11 +191,6 @@ describe("isAccountBlocked — live truth is authoritative over the mark", () =>
     const mark: ExhaustionMark = { exhausted_until: NOW + 1000, marked_at: NOW - 1000 };
     // even a healthy-looking but 25h-old snapshot must not un-block a live mark
     expect(isAccountBlocked({ mark, snapshot: snap(4, 20, SNAPSHOT_STALE_AGE_MS + 60_000), now: NOW })).toBe(true);
-  });
-  it("a mark NEWER than the snapshot wins (a just-seen 429 beats an older probe)", () => {
-    const mark: ExhaustionMark = { exhausted_until: NOW + FIVE_H, marked_at: NOW - 1_000 };
-    // snapshot captured 10min ago showed healthy, but the 429 mark is newer
-    expect(isAccountBlocked({ mark, snapshot: snap(10, 10, 10 * 60_000), now: NOW })).toBe(true);
   });
 });
 
@@ -198,19 +241,28 @@ describe("snapshotShouldClearMark — self-heal", () => {
     };
     expect(snapshotShouldClearMark(partial, mark, NOW)).toBe(true);
   });
-  it("NEVER clears a mark off an out_of_credits account, even at 0% util", () => {
-    // The 2026-06-20 self-heal bug: a fresh low-util probe must NOT un-exhaust a
-    // credits-dead account. Low util ≠ healthy when overage is serve-blocking.
+  it("out_of_credits at 0% util DOES clear a mark — a healthy low-util probe self-heals normally", () => {
+    // THE KEY CHANGE from the 2026-06-20 guard: out_of_credits is informational.
+    // A 0%-util probe is genuinely healthy; it should clear a misfired mark.
+    // The real safety net for a dead account is mark-exhausted via 429, not here.
     const mark: ExhaustionMark = { exhausted_until: NOW + 7 * 24 * 60 * 60 * 1000, marked_at: NOW - 60_000 };
     expect(
       snapshotShouldClearMark(snap(2, 5, 0, { reason: "out_of_credits" }), mark, NOW),
-    ).toBe(false);
-    // Contrast: the SAME util with a null reason DOES clear (regression anchor).
+    ).toBe(true); // CHANGED: was false, now true — healthy util self-heals
+    // Same behavior as null reason (regression anchor — should be identical now)
     expect(snapshotShouldClearMark(snap(2, 5, 0, { reason: null }), mark, NOW)).toBe(true);
-    // And org_level_disabled at low util is benign → also clears.
+    // org_level_disabled is still benign → also clears.
     expect(
       snapshotShouldClearMark(snap(2, 5, 0, { reason: "org_level_disabled" }), mark, NOW),
     ).toBe(true);
+  });
+  it("out_of_credits at HIGH util does NOT clear (the util wall prevents it)", () => {
+    // Even though out_of_credits is now informational, a walled util still blocks
+    // clearing. The snapshotClearlyHealthy check (both windows < 80%) prevents it.
+    const mark: ExhaustionMark = { exhausted_until: NOW + 7 * 24 * 60 * 60 * 1000, marked_at: NOW - 60_000 };
+    expect(
+      snapshotShouldClearMark(snap(85, 20, 0, { reason: "out_of_credits" }), mark, NOW),
+    ).toBe(false); // 85% >= 80% → not clearly healthy → no clear
   });
 });
 

--- a/src/auth/broker/account-eligibility.test.ts
+++ b/src/auth/broker/account-eligibility.test.ts
@@ -98,8 +98,8 @@ describe("isAccountBlocked — out_of_credits is NOT serve-blocking (demoted to 
       isAccountBlocked({ snapshot: snap(0, 0, 30_000, { reason: "out_of_credits" }), now: NOW }),
     ).toBe(false);
   });
-  it("out_of_credits at 0% util is a valid failover target (the pixsoul@gmail.com scenario)", () => {
-    // pixsoul@gmail.com: 5h=0%, 7d=2%, out_of_credits. MUST be eligible.
+  it("out_of_credits at 0% util is a valid failover target (the carol@example.com scenario)", () => {
+    // carol@example.com: 5h=0%, 7d=2%, out_of_credits. MUST be eligible.
     expect(
       isAccountBlocked({ snapshot: snap(0, 2, 30_000, { status: "rejected", reason: "out_of_credits" }), now: NOW }),
     ).toBe(false);

--- a/src/auth/broker/account-eligibility.ts
+++ b/src/auth/broker/account-eligibility.ts
@@ -44,30 +44,54 @@ export const HEALTHY_CLEAR_PCT = 80;
 export const SNAPSHOT_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 
 /**
- * STRICT ALLOWLIST of `overageDisabledReason` values that mean the account
- * cannot serve right now and must be treated as exhausted / blocked —
- * regardless of utilization %.
+ * INFORMATIONAL ALLOWLIST of `overageDisabledReason` values that mean the
+ * account has no overage headroom (credits balance is zero or disabled). These
+ * are **NOT serve-blocking** for a Claude Pro Max subscription fleet: the fleet
+ * runs on quota, not on overage credits. An account whose quota utilization is
+ * low (e.g. 5h=0%, 7d=2%) serves perfectly fine even when `out_of_credits` is
+ * set — that flag describes overage-past-quota availability only.
  *
- * The 2026-06-20 lesson: the broker captured Anthropic's overage headers per
- * account but no failover/exhaustion/health decision consulted them, so an
- * idle-but-unusable account (`overageDisabledReason:"out_of_credits"` at 0%
- * util) read healthy, got picked as a failover target, 429'd, and the
- * live-probe self-heal cleared any exhaustion mark on it.
+ * DESIGN RATIONALE (Jun 2026 incident reversal):
+ *   The 2026-06-20 incident (#2455) added `out_of_credits` as a serve-block to
+ *   guard against an idle-but-429ing account. That guard was structurally wrong:
+ *   it confused overage (credits past the subscription quota) with quota itself.
+ *   An account at 0% util is NOT 429ing due to `out_of_credits` — it 429s only
+ *   when its quota window is actually walled (≥99.5%). Failover safety is
+ *   preserved via the EXISTING `mark-exhausted` path: agents raise mark-
+ *   exhausted on a real 429, which blocks that account until the mark expires.
+ *   We do NOT need to proxy the credits flag for this.
+ *
+ *   The structurally identical `org_level_disabled` (also overage-off, also
+ *   reports `overageStatus:"rejected"`) was always treated as benign/healthy.
+ *   Both are "overage off" — the asymmetric treatment of `out_of_credits` was
+ *   the defect.
+ *
+ * USAGE — call `hasNoOverageHeadroom(snapshot)` to detect this informational
+ * condition. MUST NEVER gate serving or failover eligibility. May be surfaced
+ * as an informational annotation (e.g. "overage off (out_of_credits) — serving
+ * from quota") alongside a healthy/throttling display row.
  *
  * CRITICAL — discriminate on the DISABLED REASON, never on `overageStatus`:
- *  - `"out_of_credits"`  → SERVE-BLOCKING (account is dead; treat as exhausted).
- *  - `"org_level_disabled"` → BENIGN. This is the LIVE, ACTIVE, WORKING fleet
- *    account: overage is merely switched off org-wide, but it serves fine off
- *    the subscription. Marking it exhausted takes down the fleet. NOT here.
- *  - `null` / unknown / any unseen value → BENIGN (deny-by-omission).
+ *  - `"out_of_credits"`  → informational "no overage headroom". Does NOT block.
+ *  - `"org_level_disabled"` → BENIGN (identical to out_of_credits semantically
+ *    for a subscription fleet). Already treated correctly.
+ *  - `null` / unknown / any unseen value → benign (deny-by-omission).
  *
  * Keying on `overageStatus === "rejected"` is WRONG — the active, healthy
  * account reports `rejected` too. Only the disabled-reason discriminates.
  *
- * Any NEW reason added here is a production-affecting change: confirm with the
- * operator (which serve state Anthropic actually means by it) before adding.
+ * Any NEW reason added here is informational only. Adding it does NOT gate
+ * serving — that is an explicit design constraint, not an accident.
  */
-export const SERVE_BLOCKING_OVERAGE_REASONS = new Set<string>(["out_of_credits"]);
+export const OVERAGE_EXHAUSTED_REASONS = new Set<string>(["out_of_credits"]);
+
+/**
+ * @deprecated Use OVERAGE_EXHAUSTED_REASONS. This alias exists so callers that
+ * imported the old name still compile; it will be removed in a future cleanup.
+ * The semantics changed: these reasons are INFORMATIONAL (no overage headroom),
+ * NOT serve-blocking. See OVERAGE_EXHAUSTED_REASONS doc comment.
+ */
+export const SERVE_BLOCKING_OVERAGE_REASONS = OVERAGE_EXHAUSTED_REASONS;
 
 /** The minimal live-snapshot shape the eligibility decision needs. */
 export interface QuotaSnapshot {
@@ -76,13 +100,14 @@ export interface QuotaSnapshot {
   /** Unix ms when this snapshot was captured by a live probe. */
   capturedAt: number;
   /** Anthropic's `anthropic-ratelimit-unified-overage-status` header, when the
-   *  probe carried it. Captured for transparency; NOT the discriminator (see
-   *  SERVE_BLOCKING_OVERAGE_REASONS) — the active healthy account reports
-   *  `rejected` here too. */
+   *  probe carried it. Captured for transparency; NOT a serving discriminator —
+   *  the active healthy account reports `rejected` here too. See
+   *  OVERAGE_EXHAUSTED_REASONS for the informational disabled-reason list. */
   overageStatus?: string | null;
   /** Anthropic's `anthropic-ratelimit-unified-overage-disabled-reason` header.
-   *  THIS is the serve-blocking discriminator: `out_of_credits` is dead,
-   *  `org_level_disabled` is benign. See SERVE_BLOCKING_OVERAGE_REASONS. */
+   *  Informational only: `out_of_credits` means no overage headroom, NOT that
+   *  the account cannot serve from quota. `org_level_disabled` is benign.
+   *  See OVERAGE_EXHAUSTED_REASONS. MUST NOT gate serving or failover. */
   overageDisabledReason?: string | null;
   /** #2494 Bug C — which util windows the probe actually carried. A probe
    *  with BOTH false is "thin" (no real signal, 0%-coalesced) and must NOT be
@@ -93,15 +118,24 @@ export interface QuotaSnapshot {
 }
 
 /**
- * Is this snapshot's overage state serve-blocking? True only when the live
- * `overageDisabledReason` is on the strict allowlist (`out_of_credits`). An
- * account at 0% util that is out of credits is unusable and must be treated as
- * exhausted; `org_level_disabled` / null / unknown are benign (deny-by-
- * omission). PURE — no I/O.
+ * Does this snapshot indicate the account has no overage headroom? True when
+ * `overageDisabledReason` is on the informational allowlist (`out_of_credits`).
+ * This is a display/annotation flag ONLY — it MUST NOT gate serving or failover
+ * eligibility. An account with `out_of_credits` at low util serves fine from
+ * quota. `org_level_disabled` / null / unknown are benign (deny-by-omission).
+ * PURE — no I/O.
+ */
+export function hasNoOverageHeadroom(snapshot: QuotaSnapshot): boolean {
+  const reason = snapshot.overageDisabledReason;
+  return reason != null && OVERAGE_EXHAUSTED_REASONS.has(reason);
+}
+
+/**
+ * @deprecated Use hasNoOverageHeadroom. The semantics changed: this no longer
+ * implies serve-blocking. Kept for callers that import the old name.
  */
 export function isOverageServeBlocking(snapshot: QuotaSnapshot): boolean {
-  const reason = snapshot.overageDisabledReason;
-  return reason != null && SERVE_BLOCKING_OVERAGE_REASONS.has(reason);
+  return hasNoOverageHeadroom(snapshot);
 }
 
 /** A persisted exhaustion mark. `markedAt` is when it was written (added
@@ -155,8 +189,9 @@ export function isAccountBlocked(opts: {
     const markedAt = mark?.marked_at ?? 0;
     if (snapshot.capturedAt >= markedAt) {
       // Live truth is the newer signal → it decides, mark ignored. Walled on
-      // util OR serve-blocked by overage (out_of_credits at any util) → blocked.
-      return snapshotWalled(snapshot) || isOverageServeBlocking(snapshot);
+      // util → blocked. Overage (out_of_credits) is informational only and does
+      // NOT gate serving; failover safety is preserved via mark-exhausted on 429.
+      return snapshotWalled(snapshot);
     }
   }
   // No usable live truth (or the mark is newer) → trust the mark.
@@ -183,11 +218,11 @@ export function snapshotShouldClearMark(
   // self-heal a mark on a thin probe; require a probe that actually measured at
   // least one window before clearing.
   if (isProbeThin(snapshot)) return false;
-  // A serve-blocking overage (out_of_credits) is an exhaustion in its own
-  // right — never let a 0%-util-but-credits-dead probe self-heal a mark off
-  // such an account (that's exactly the live-probe re-clear the 2026-06-20
-  // bug exploited). Util being low does NOT make it "clearly healthy".
-  if (isOverageServeBlocking(snapshot)) return false;
+  // out_of_credits is informational (no overage headroom), NOT a serve-block.
+  // A 0%-util account with out_of_credits is healthy from a quota standpoint and
+  // SHOULD self-heal a misfired mark. The 2026-06-20 guard here was the defect:
+  // it prevented a healthy account from being restored to the failover pool.
+  // Failover safety is preserved via mark-exhausted on a real 429, not here.
   return snapshotClearlyHealthy(snapshot);
 }
 

--- a/src/auth/broker/consumer-quota-sensor.test.ts
+++ b/src/auth/broker/consumer-quota-sensor.test.ts
@@ -78,9 +78,11 @@ describe("quotaIndicatesExhaustion", () => {
     expect(quotaIndicatesExhaustion(failed)).toEqual({ exhausted: false, until: null });
   });
 
-  it("out_of_credits at 0% util ⇒ exhausted (until=null, no util-window reset)", () => {
-    // The consumer pinned to a credits-dead account would 429 on every call
-    // despite 0% util — the sensor must mark it exhausted.
+  it("out_of_credits at 0% util ⇒ NOT exhausted (informational only — serves fine from quota)", () => {
+    // THE KEY CHANGE: out_of_credits is informational. A consumer pinned to a
+    // 0%-util out_of_credits account serves fine from quota. Exhaustion is only
+    // via a real util wall (≥99.5%), not via the credits flag.
+    // Failover safety is preserved via mark-exhausted on a real 429.
     expect(
       quotaIndicatesExhaustion(ok({
         fiveHourUtilizationPct: 0,
@@ -88,7 +90,7 @@ describe("quotaIndicatesExhaustion", () => {
         overageStatus: "rejected",
         overageDisabledReason: "out_of_credits",
       })),
-    ).toEqual({ exhausted: true, until: null });
+    ).toEqual({ exhausted: false, until: null });
   });
 
   it("org_level_disabled at 75% util ⇒ NOT exhausted (benign — live active account)", () => {

--- a/src/auth/broker/consumer-quota-sensor.ts
+++ b/src/auth/broker/consumer-quota-sensor.ts
@@ -15,7 +15,6 @@
  */
 
 import type { QuotaResult } from "../quota.js";
-import { isOverageServeBlocking } from "./account-eligibility.js";
 
 /**
  * Utilization at/above this on the binding window counts as a hard wall.
@@ -55,23 +54,11 @@ export interface ExhaustionDecision {
 export function quotaIndicatesExhaustion(result: QuotaResult): ExhaustionDecision {
   if (!result.ok) return { exhausted: false, until: null };
   const d = result.data;
-  // A serve-blocking overage (out_of_credits) means the account is dead even at
-  // 0% util — a consumer pinned to it would 429 on every call. Mark exhausted.
-  // The reason discriminator (not overageStatus) lives in account-eligibility;
-  // org_level_disabled / null / unknown are benign and do NOT trip this. Carry
-  // no reset (the wall isn't a util window) → caller uses its default window.
-  if (isOverageServeBlocking({
-    fiveHourUtilizationPct: d.fiveHourUtilizationPct,
-    sevenDayUtilizationPct: d.sevenDayUtilizationPct,
-    // Throwaway snapshot used only for the pure overage check, which keys
-    // solely on overageDisabledReason and ignores capturedAt. This `0` is a
-    // placeholder, NOT a real 1970 timestamp.
-    capturedAt: 0,
-    overageStatus: d.overageStatus,
-    overageDisabledReason: d.overageDisabledReason,
-  })) {
-    return { exhausted: true, until: null };
-  }
+  // out_of_credits is informational only (no overage headroom) — it does NOT
+  // mean the account is dead. A consumer pinned to a 0%-util out_of_credits
+  // account serves fine from quota. Mark exhausted only when a util window is
+  // actually walled (≥99.5%). Failover safety is preserved via mark-exhausted
+  // on a real 429 from the gateway, not by proxying the credits flag here.
   const fiveBlocked = d.fiveHourUtilizationPct >= EXHAUSTION_PCT;
   const sevenBlocked = d.sevenDayUtilizationPct >= EXHAUSTION_PCT;
   if (!fiveBlocked && !sevenBlocked) return { exhausted: false, until: null };

--- a/src/auth/broker/overage-allowlist-drift.test.ts
+++ b/src/auth/broker/overage-allowlist-drift.test.ts
@@ -2,21 +2,22 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { SERVE_BLOCKING_OVERAGE_REASONS } from "./account-eligibility.js";
+import { OVERAGE_EXHAUSTED_REASONS } from "./account-eligibility.js";
 
 /**
- * DRIFT GUARD for the duplicated `SERVE_BLOCKING_OVERAGE_REASONS` allowlist.
+ * DRIFT GUARD for the duplicated `OVERAGE_EXHAUSTED_REASONS` allowlist.
  *
- * The strict allowlist of serve-blocking `overageDisabledReason` values is
- * declared in TWO places because they live in different packages and the
- * telegram-plugin can't cleanly import across the broker package boundary:
+ * The informational allowlist of `overageDisabledReason` values that indicate
+ * "no overage headroom" (NOT serve-blocking) is declared in TWO places because
+ * the telegram-plugin can't import across the broker package boundary cleanly:
  *   - src/auth/broker/account-eligibility.ts      (broker, the source of truth)
  *   - telegram-plugin/auth-snapshot-format.ts     (plugin, a verbatim replica)
  *
- * They are textually identical today, guarded only by a cross-reference
- * comment. This test FAILS if a future author edits one literal without the
- * other (adding/removing a reason in just one copy), so the divergence is
- * caught in `npm run lint`/vitest rather than in production failover.
+ * These reasons are informational only — they MUST NOT gate serving or failover.
+ *
+ * This test FAILS if a future author edits one literal without the other
+ * (adding/removing a reason in just one copy), so the divergence is caught in
+ * `npm run lint`/vitest rather than in production failover.
  */
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -25,17 +26,17 @@ const pluginSrc = resolve(here, "../../../telegram-plugin/auth-snapshot-format.t
 
 /**
  * Extract the string members of the FIRST
- * `SERVE_BLOCKING_OVERAGE_REASONS = new Set([...])` literal in a source file.
+ * `OVERAGE_EXHAUSTED_REASONS = new Set([...])` literal in a source file.
  * Order-insensitive: returns a Set so comparison ignores ordering/whitespace.
  */
 function extractAllowlistLiteral(filePath: string): Set<string> {
   const text = readFileSync(filePath, "utf8");
   const m = text.match(
-    /SERVE_BLOCKING_OVERAGE_REASONS\s*=\s*new Set<[^>]*>\(\s*\[([^\]]*)\]/,
+    /OVERAGE_EXHAUSTED_REASONS\s*=\s*new Set<[^>]*>\(\s*\[([^\]]*)\]/,
   );
   if (!m) {
     throw new Error(
-      `Could not find a SERVE_BLOCKING_OVERAGE_REASONS = new Set([...]) literal in ${filePath}`,
+      `Could not find a OVERAGE_EXHAUSTED_REASONS = new Set([...]) literal in ${filePath}`,
     );
   }
   const inner = m[1];
@@ -43,7 +44,7 @@ function extractAllowlistLiteral(filePath: string): Set<string> {
   return new Set(members);
 }
 
-describe("SERVE_BLOCKING_OVERAGE_REASONS cross-package drift guard", () => {
+describe("OVERAGE_EXHAUSTED_REASONS cross-package drift guard", () => {
   it("broker and telegram-plugin source literals are identical sets", () => {
     const brokerLiteral = extractAllowlistLiteral(brokerSrc);
     const pluginLiteral = extractAllowlistLiteral(pluginSrc);
@@ -53,7 +54,7 @@ describe("SERVE_BLOCKING_OVERAGE_REASONS cross-package drift guard", () => {
 
   it("the broker's runtime Set matches its own source literal (sanity)", () => {
     expect(extractAllowlistLiteral(brokerSrc)).toEqual(
-      SERVE_BLOCKING_OVERAGE_REASONS,
+      OVERAGE_EXHAUSTED_REASONS,
     );
   });
 
@@ -61,6 +62,6 @@ describe("SERVE_BLOCKING_OVERAGE_REASONS cross-package drift guard", () => {
     const expected = new Set(["out_of_credits"]);
     expect(extractAllowlistLiteral(brokerSrc)).toEqual(expected);
     expect(extractAllowlistLiteral(pluginSrc)).toEqual(expected);
-    expect(SERVE_BLOCKING_OVERAGE_REASONS).toEqual(expected);
+    expect(OVERAGE_EXHAUSTED_REASONS).toEqual(expected);
   });
 });

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -2519,8 +2519,12 @@ describe("AuthBroker — agent serving-failover (Layer 2, #2218 weekly-wall dura
     broker.stop();
   });
 
-  // ── Overage serve-blocking (2026-06-20: out_of_credits at 0% util) ─────────
-  it("(a) out_of_credits active @0% ⇒ list-state exhausted:true AND serves the healthy fallback", async () => {
+  // ── out_of_credits is INFORMATIONAL (fix/out-of-credits-serve-block) ────────
+  it("(a) out_of_credits active @0% ⇒ list-state exhausted:false AND still served (NOT a serve-block)", async () => {
+    // NEW CONTRACT: out_of_credits is demoted to informational. An account at
+    // 0% util with out_of_credits is classified HEALTHY by isAccountBlocked →
+    // exhausted:false in list-state, and get-credentials keeps serving it.
+    // Failover safety is preserved via mark-exhausted on a real 429 (not here).
     let clock = Date.UTC(2026, 5, 20, 7, 0, 0);
     const h = makeHarness();
     const config = makeConfig(h, { active: "default", fallback_order: ["default", "secondary"], agents: { clerk: {} } });
@@ -2529,7 +2533,7 @@ describe("AuthBroker — agent serving-failover (Layer 2, #2218 weekly-wall dura
     const broker = new AuthBroker(config, {
       home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
       now: () => clock,
-      // default idle-but-credits-dead (0% util, out_of_credits); secondary healthy.
+      // default: 0% util + out_of_credits (informational only); secondary healthy.
       _testFetchQuota: liveQuota({
         default: { five: 0, seven: 0, overageStatus: "rejected", overageReason: "out_of_credits" },
         secondary: { five: 5, seven: 10 },
@@ -2539,12 +2543,12 @@ describe("AuthBroker — agent serving-failover (Layer 2, #2218 weekly-wall dura
     try {
       await broker.start();
       await broker.fleetQuotaProbeTick();
-      // list-state: default reads exhausted purely from the overage reason.
+      // list-state: default is NOT exhausted — out_of_credits is informational only.
       const acct = (await new AuthBrokerClient({ socket: clerkSock }).listState()).accounts.find((a) => a.label === "default");
-      expect(acct?.exhausted).toBe(true);
-      // get-credentials must fail over to the healthy secondary, not serve the dead account.
+      expect(acct?.exhausted).toBe(false);
+      // get-credentials must keep serving default — no spurious failover.
       const resp = (await rpc(clerkSock, { v: 1, id: "1", op: "get-credentials" })) as { data: { account: string } };
-      expect(resp.data.account).toBe("secondary");
+      expect(resp.data.account).toBe("default");
     } finally { broker.stop(); }
   });
 
@@ -2576,13 +2580,16 @@ describe("AuthBroker — agent serving-failover (Layer 2, #2218 weekly-wall dura
     } finally { broker.stop(); }
   });
 
-  it("(c) a pre-seeded mark survives a 0%/out_of_credits probe (NOT self-healed); contrast 0%/null clears it", async () => {
+  it("(c) a pre-seeded mark IS self-healed by a fresh 0%/out_of_credits probe (informational, not blocking); 0%/null also clears it", async () => {
+    // NEW CONTRACT (fix/out-of-credits-serve-block): out_of_credits does NOT
+    // prevent snapshotShouldClearMark from clearing a misfired mark.
+    // A genuinely healthy (0% util) probe DOES clear the mark regardless of the
+    // out_of_credits flag. Failover safety is via mark-exhausted on a real 429.
     let clock = Date.UTC(2026, 5, 20, 7, 0, 0);
     const h = makeHarness();
     const config = makeConfig(h, { active: "default", fallback_order: ["default", "secondary"], agents: { clerk: {} } });
     seedAccount(h, "default"); seedAccount(h, "secondary");
     mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
-    // out_of_credits build: a fresh healthy-looking (0%) probe must NOT clear the mark.
     const broker = new AuthBroker(config, {
       home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
       now: () => clock,
@@ -2595,13 +2602,14 @@ describe("AuthBroker — agent serving-failover (Layer 2, #2218 weekly-wall dura
     try {
       await broker.start();
       await rpc(clerkSock, { v: 1, id: "1", op: "mark-exhausted", until: clock + 3600_000 });
-      await broker.fleetQuotaProbeTick(); // 0% probe — but out_of_credits → must NOT self-heal
+      await broker.fleetQuotaProbeTick(); // 0% probe with out_of_credits → DOES self-heal
       const acct = (await new AuthBrokerClient({ socket: clerkSock }).listState()).accounts.find((a) => a.label === "default");
-      expect(acct?.exhausted).toBe(true);
-      expect(acct?.exhausted_until).toBeDefined();
+      // Mark IS cleared: out_of_credits is informational, 0% util = genuinely healthy.
+      expect(acct?.exhausted).toBe(false);
+      expect(acct?.exhausted_until).toBeUndefined();
     } finally { broker.stop(); }
 
-    // Contrast: SAME 0% util with a NULL overage reason DOES self-heal the mark.
+    // Same behavior with NULL overage reason — both clear the mark (regression anchor).
     let clock2 = Date.UTC(2026, 5, 20, 7, 0, 0);
     const h2 = makeHarness();
     const config2 = makeConfig(h2, { active: "default", fallback_order: ["default", "secondary"], agents: { clerk: {} } });
@@ -2616,7 +2624,7 @@ describe("AuthBroker — agent serving-failover (Layer 2, #2218 weekly-wall dura
     try {
       await broker2.start();
       await rpc(clerkSock2, { v: 1, id: "1", op: "mark-exhausted", until: clock2 + 3600_000 });
-      await broker2.fleetQuotaProbeTick(); // 0% + null reason → clears
+      await broker2.fleetQuotaProbeTick(); // 0% + null reason → clears (unchanged behavior)
       const acct = (await new AuthBrokerClient({ socket: clerkSock2 }).listState()).accounts.find((a) => a.label === "default");
       expect(acct?.exhausted).toBe(false);
       expect(acct?.exhausted_until).toBeUndefined();

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.15.43";
-export const COMMIT_SHA: string | null = "86f56acb";
-export const COMMIT_DATE: string | null = "2026-06-19T02:04:40Z";
-export const LATEST_PR: number | null = 2437;
+export const VERSION: string = "0.15.48";
+export const COMMIT_SHA: string | null = "5262be25";
+export const COMMIT_DATE: string | null = "2026-06-21T23:25:16+10:00";
+export const LATEST_PR: number | null = 2511;
 export const COMMITS_AHEAD_OF_TAG: number | null = 0;

--- a/src/cli/auth-schedule.test.ts
+++ b/src/cli/auth-schedule.test.ts
@@ -139,8 +139,10 @@ describe("classifyState — the 5h-vs-weekly distinction", () => {
     ).toBe("healthy");
   });
 
-  it("overageServeBlocking (out_of_credits) → out-of-credits, WINS over healthy util", () => {
-    // 0% util would otherwise classify healthy; the dead-credits signal wins.
+  it("overageServeBlocking (out_of_credits) at 0% util → healthy (informational only, DOES NOT BLOCK)", () => {
+    // THE KEY CHANGE: out_of_credits is no longer a state that beats healthy.
+    // A 0%-util account with out_of_credits serves fine. The annotation appears
+    // in formatStateCell, not as a separate classified state.
     expect(
       classifyState({
         exhausted: false,
@@ -148,10 +150,12 @@ describe("classifyState — the 5h-vs-weekly distinction", () => {
         window: win({ fiveHourPct: 0, weeklyPct: 0, overageServeBlocking: true }),
         now: NOW,
       }),
-    ).toBe("out-of-credits");
+    ).toBe("healthy"); // CHANGED: was "out-of-credits", now "healthy"
   });
 
-  it("overageServeBlocking wins over a maxed weekly window too", () => {
+  it("overageServeBlocking with maxed weekly window → weekly-walled (util wall governs, not overage)", () => {
+    // When the weekly util IS actually walled, the state is weekly-walled.
+    // overageServeBlocking is just an annotation on top of the util-driven verdict.
     expect(
       classifyState({
         exhausted: true,
@@ -159,7 +163,7 @@ describe("classifyState — the 5h-vs-weekly distinction", () => {
         window: win({ weeklyPct: 100, weeklyResetAt: WEEKLY_RESET, overageServeBlocking: true }),
         now: NOW,
       }),
-    ).toBe("out-of-credits");
+    ).toBe("weekly-walled"); // CHANGED: was "out-of-credits", now driven by util
   });
 
   it("org_level_disabled at 75% (overageServeBlocking false) → unchanged (healthy)", () => {
@@ -201,8 +205,8 @@ describe("classifyState — the 5h-vs-weekly distinction", () => {
     ).toBe("healthy");
   });
 
-  // ── #2494 Bug C — recoverable quota-exhausted vs billing-dead ──────────
-  it("Bug C: maxed 5h with a FUTURE reset → quota-exhausted (recoverable), NOT out-of-credits", () => {
+  // ── #2494 Bug C — recoverable quota-exhausted, thin probe ──────────
+  it("Bug C: maxed 5h with a FUTURE reset → quota-exhausted (recoverable)", () => {
     expect(
       classifyState({
         exhausted: false,
@@ -213,8 +217,9 @@ describe("classifyState — the 5h-vs-weekly distinction", () => {
     ).toBe("quota-exhausted");
   });
 
-  it("Bug C: out_of_credits (billing-dead) is distinct from quota-exhausted", () => {
-    // Same maxed 5h window, but a serve-blocking overage reason: billing-dead wins.
+  it("Bug C: out_of_credits with maxed 5h window → quota-exhausted (util wall governs, overage is annotation)", () => {
+    // THE KEY CHANGE: out_of_credits no longer wins over util-based classification.
+    // If the util wall fires, quota-exhausted is returned (not "out-of-credits").
     expect(
       classifyState({
         exhausted: false,
@@ -227,7 +232,7 @@ describe("classifyState — the 5h-vs-weekly distinction", () => {
         }),
         now: NOW,
       }),
-    ).toBe("out-of-credits");
+    ).toBe("quota-exhausted"); // CHANGED: was "out-of-credits", now "quota-exhausted"
   });
 
   it("Bug C: a thin/headerless probe → unprobed (renders unknown), never a confident 0%", () => {
@@ -242,7 +247,7 @@ describe("classifyState — the 5h-vs-weekly distinction", () => {
   });
 });
 
-describe("#2494 — formatStateCell quota-exhausted vs billing-dead, cells refill/thin-aware", () => {
+describe("#2494 — formatStateCell: out_of_credits informational annotation, not billing-dead state", () => {
   const baseRow = (window: WindowSnapshot, state: ScheduleRow["state"]): ScheduleRow => ({
     label: "x",
     isActive: false,
@@ -263,6 +268,28 @@ describe("#2494 — formatStateCell quota-exhausted vs billing-dead, cells refil
     );
     expect(cell).toContain("quota-exhausted");
     expect(cell).toMatch(/\d+[hm]/); // has a countdown
+  });
+
+  it("healthy with out_of_credits → shows 'healthy (overage off: out_of_credits)' annotation", () => {
+    // THE KEY CHANGE: out_of_credits is an informational annotation on a healthy row
+    const cell = formatStateCell(
+      baseRow(
+        { ...NONE, fiveHourPct: 0, weeklyPct: 0, source: "live", overageServeBlocking: true, overageReason: "out_of_credits" },
+        "healthy",
+      ),
+      NOW,
+    );
+    expect(cell).toBe("healthy (overage off: out_of_credits)");
+    expect(cell).not.toContain("billing disabled");
+    expect(cell).not.toContain("out-of-credits");
+  });
+
+  it("healthy WITHOUT out_of_credits → shows just 'healthy' with no annotation", () => {
+    const cell = formatStateCell(
+      baseRow({ ...NONE, fiveHourPct: 0, weeklyPct: 0, source: "live", overageServeBlocking: false }, "healthy"),
+      NOW,
+    );
+    expect(cell).toBe("healthy");
   });
 
   it("thin probe renders 5h/weekly cells as 'unknown', not 0%", () => {
@@ -439,9 +466,9 @@ describe("formatStateCell horizon", () => {
     expect(cell).not.toContain("27m");
   });
 
-  it("renders the out-of-credits state as billing-dead with the real reason (no timer)", () => {
-    // #2494 Bug C — billing-dead renders "billing disabled (<reason>)", NOT a
-    // countdown: it does not recover on a window roll.
+  it("out_of_credits at 0% util with healthy state → shows annotation, NOT billing-dead", () => {
+    // THE KEY CHANGE: overageServeBlocking no longer produces a "billing disabled"
+    // state. It is an informational annotation on a healthy/throttling row.
     const row: ScheduleRow = {
       label: "x",
       isActive: false,
@@ -456,11 +483,12 @@ describe("formatStateCell horizon", () => {
       },
       exhausted: false,
       exhaustedUntil: null,
-      state: "out-of-credits",
+      state: "healthy", // CHANGED: was "out-of-credits", now "healthy"
     };
     const cell = formatStateCell(row, NOW);
-    expect(cell).toBe("billing disabled (out_of_credits)");
-    expect(cell).not.toMatch(/\d+[dhm]/); // no countdown
+    expect(cell).toBe("healthy (overage off: out_of_credits)");
+    expect(cell).not.toContain("billing disabled");
+    expect(cell).not.toMatch(/^\d+[dhm]/); // no leading countdown
   });
 });
 

--- a/src/cli/auth-schedule.ts
+++ b/src/cli/auth-schedule.ts
@@ -32,7 +32,7 @@ import type {
   AccountState,
   ProbeQuotaData,
 } from "../auth/broker/client.js";
-import { SERVE_BLOCKING_OVERAGE_REASONS } from "../auth/broker/account-eligibility.js";
+import { OVERAGE_EXHAUSTED_REASONS } from "../auth/broker/account-eligibility.js";
 import { refillNormalizedUtils } from "../auth/quota.js";
 
 // ─── Pure model ──────────────────────────────────────────────────────────
@@ -45,16 +45,17 @@ export interface WindowSnapshot {
   /** Where the numbers came from: a live probe, the broker's cache, or nothing. */
   source: "live" | "cached" | "none";
   /**
-   * True when the probe/cache carried a serve-blocking `overageDisabledReason`
-   * (`out_of_credits`) — the account is dead even at 0% util. Discriminated on
-   * the same strict allowlist the broker uses (see SERVE_BLOCKING_OVERAGE_
-   * REASONS); `org_level_disabled` / null / unknown are benign → false.
+   * True when the probe/cache carried an `overageDisabledReason` on the
+   * informational allowlist (`out_of_credits`). Informational only — this flag
+   * means "no overage headroom", NOT that the account is dead or serve-blocked.
+   * Use `overageReason` to annotate the display; never use this to block serving.
+   * `org_level_disabled` / null / unknown are benign → false.
    */
   overageServeBlocking: boolean;
   /**
-   * #2494 Bug C — the live overage-disabled reason carried by the probe/cache,
-   * when serve-blocking. Surfaced verbatim by the renderer so a billing-dead
-   * account names the real reason ("out_of_credits"), not just a state word.
+   * The live overage-disabled reason carried by the probe/cache, when on the
+   * informational allowlist. Surfaced verbatim by the renderer as an annotation
+   * on a healthy/throttling row ("out_of_credits") — NOT as a blocked state.
    */
   overageReason: string | null;
   /**
@@ -65,23 +66,31 @@ export interface WindowSnapshot {
   probeThin: boolean;
 }
 
-/** Is a probe/cache overage reason serve-blocking? Mirrors the broker's
- *  isOverageServeBlocking using the shared strict allowlist. */
+/** Does a probe/cache overage reason appear on the informational allowlist?
+ *  Informational only — MUST NOT gate serving. Mirrors OVERAGE_EXHAUSTED_REASONS. */
 function overageReasonBlocks(reason: string | null | undefined): boolean {
-  return reason != null && SERVE_BLOCKING_OVERAGE_REASONS.has(reason);
+  return reason != null && OVERAGE_EXHAUSTED_REASONS.has(reason);
 }
 
 export type AccountWindowState =
-  | "out-of-credits"
   // #2494 Bug C — recoverable quota exhaustion: a util window is maxed but the
-  // account comes back when that window rolls. Distinct from the terminal
-  // billing-dead "out-of-credits"; carries a reset countdown.
+  // account comes back when that window rolls. Carries a reset countdown.
   | "quota-exhausted"
   | "healthy"
   | "5h-walled"
   | "weekly-walled"
   | "walled"
   | "unprobed";
+
+/**
+ * "out-of-credits" is no longer a state that blocks serving. An account with
+ * `out_of_credits` at low util is healthy — `overageServeBlocking` is surfaced
+ * as an informational annotation on the row, not as a separate wall state.
+ * This alias exists so any code that references the old state string still
+ * compiles during the transition; treat it as "healthy" semantically.
+ * @deprecated — kept for backwards compat only; do not add new references.
+ */
+export type LegacyOutOfCreditsState = "out-of-credits";
 
 /** Weekly utilization at/above this is treated as walled (mirrors the broker's sensor). */
 const WEEKLY_WALL_PCT = 99.5;
@@ -157,6 +166,11 @@ function isThin(d: {
  * load-bearing distinction. When we have window reset timestamps we match
  * `exhausted_until` against them precisely; otherwise we fall back to a
  * duration heuristic (a 5h wall resets within hours, a weekly wall in days).
+ *
+ * NOTE: `overageServeBlocking` (out_of_credits) is NOT a wall state. An account
+ * with out_of_credits at low util serves fine from quota — it is healthy. The
+ * renderer surfaces it as an informational annotation ("overage off") on the
+ * row, not as a separate state. Do NOT add a return "out-of-credits" here.
  */
 export function classifyState(args: {
   exhausted: boolean;
@@ -165,11 +179,6 @@ export function classifyState(args: {
   now: Date;
 }): AccountWindowState {
   const { exhausted, exhaustedUntil, window, now } = args;
-  // #2494 Bug C — a serve-blocking overage (out_of_credits) means the account
-  // is billing-dead even at 0% util — it wins over every util-based verdict.
-  // This is genuine "out-of-credits": NOT a timer, recovers only when billing
-  // is fixed. Same strict-allowlist semantics as the broker.
-  if (window.overageServeBlocking) return "out-of-credits";
   // #2494 Bug C — a thin/headerless probe carries no real utilization; it must
   // not pose as a confident reading. Treat as unprobed (renders "unknown").
   if (window.probeThin) return "unprobed";
@@ -206,7 +215,7 @@ export function classifyState(args: {
     return "weekly-walled";
   }
   // #2494 Bug C — a maxed 5h window with a future reset is recoverable quota
-  // exhaustion (comes back when the window rolls), distinct from billing-dead.
+  // exhaustion (comes back when the window rolls).
   if (
     fivePct !== null &&
     fivePct >= WEEKLY_WALL_PCT &&
@@ -328,7 +337,9 @@ function poolLabel(row: ScheduleRow): string {
   return "excluded";
 }
 
-/** State cell, raw (uncolored): "healthy" / "5h-walled · 2h 18m" / etc. */
+/** State cell, raw (uncolored): "healthy" / "5h-walled · 2h 18m" / etc.
+ *  When the account has no overage headroom (out_of_credits), appends an
+ *  informational annotation: "healthy (overage off: out_of_credits)". */
 export function formatStateCell(row: ScheduleRow, now: Date): string {
   // Show the horizon that actually matters for the classified wall — the
   // weekly reset for a weekly wall, the 5h reset for a 5h wall — not just the
@@ -340,22 +351,24 @@ export function formatStateCell(row: ScheduleRow, now: Date): string {
         ? (row.window.fiveHourResetAt ?? row.exhaustedUntil)
         : row.exhaustedUntil;
   const rel = horizon ? ` · ${formatDuration(horizon.getTime() - now.getTime())}` : "";
+  // Informational overage annotation — shown on healthy/throttling/unprobed
+  // rows when out_of_credits is set. MUST NOT change the state verdict; only
+  // appended to the text label so the operator is aware of the overage flag.
+  const overageNote =
+    row.window.overageServeBlocking && row.window.overageReason
+      ? ` (overage off: ${row.window.overageReason})`
+      : row.window.overageServeBlocking
+        ? " (overage off)"
+        : "";
   switch (row.state) {
-    case "out-of-credits":
-      // #2494 Bug C — billing-dead. No util-window reset to count down to —
-      // overage is off until billing is fixed, not until a window rolls. Name
-      // the real reason so it reads distinctly from a recoverable exhaustion.
-      return row.window.overageReason
-        ? `billing disabled (${row.window.overageReason})`
-        : "billing disabled";
     case "quota-exhausted":
-      // #2494 Bug C — recoverable: comes back when the 5h window rolls. Carries
-      // the reset countdown, unlike the terminal billing-dead state above.
+      // Recoverable: comes back when the 5h window rolls. Carries the reset
+      // countdown. No overage annotation — quota exhaustion is the binding cause.
       return `quota-exhausted${rel}`;
     case "healthy":
-      return "healthy";
+      return `healthy${overageNote}`;
     case "unprobed":
-      return "no recent probe";
+      return `no recent probe${overageNote}`;
     case "5h-walled":
       return `5h-walled${rel}`;
     case "weekly-walled":
@@ -388,12 +401,9 @@ function colorState(text: string, state: AccountWindowState, color: boolean): st
   switch (state) {
     case "healthy":
       return chalk.green(text);
-    case "out-of-credits":
-      return chalk.red(text);
     case "weekly-walled":
       return chalk.red(text);
     case "quota-exhausted":
-      // Recoverable — amber, not the terminal red of billing-dead.
       return chalk.yellow(text);
     case "5h-walled":
       return chalk.yellow(text);

--- a/telegram-plugin/auth-snapshot-format.ts
+++ b/telegram-plugin/auth-snapshot-format.ts
@@ -61,29 +61,39 @@ export interface AccountSnapshot {
 export const THROTTLING_THRESHOLD_PCT = 80;
 
 /**
- * STRICT ALLOWLIST of serve-blocking `overageDisabledReason` values. Replicated
- * verbatim from the broker's `SERVE_BLOCKING_OVERAGE_REASONS`
- * (src/auth/broker/account-eligibility.ts) because the plugin can't import
- * across the package boundary cleanly — keep the two in sync.
+ * INFORMATIONAL ALLOWLIST of `overageDisabledReason` values that mean the
+ * account has no overage headroom. Replicated from the broker's
+ * `OVERAGE_EXHAUSTED_REASONS` (src/auth/broker/account-eligibility.ts) because
+ * the plugin can't import across the package boundary — keep the two in sync.
  *
- * `out_of_credits` → blocked (the account is dead even at 0% util).
- * `org_level_disabled` → BENIGN (the live active fleet account: overage off but
- * still serving off subscription). `null` / unknown → benign (deny-by-omission).
+ * These are NOT serve-blocking: the fleet runs on quota, not credits. An account
+ * with `out_of_credits` at low util serves fine. `org_level_disabled` → benign
+ * (the live active fleet account: overage off but serving fine off subscription).
+ * `null` / unknown → benign (deny-by-omission).
+ *
+ * MUST NEVER gate serving or failover eligibility — informational annotation
+ * only (e.g. "overage off (out_of_credits) — serving from quota").
  * Do NOT key on `overageStatus` ("rejected" appears on the healthy account too).
- * Any new reason here is production-affecting — confirm with the operator first.
+ * The drift test (overage-allowlist-drift.test.ts) guards these two copies stay
+ * in sync — update BOTH when this list changes.
  */
-const SERVE_BLOCKING_OVERAGE_REASONS = new Set<string>(['out_of_credits']);
+const OVERAGE_EXHAUSTED_REASONS = new Set<string>(['out_of_credits']);
 
 /**
- * Decide the health verdict for one account. The two "binding" facts:
- *   - overageDisabledReason is serve-blocking (out_of_credits) → blocked,
- *     even at 0% util (the account is dead until billing is fixed)
- *   - 5h or 7d utilization >= 100% (or `representativeClaim` non-null
- *     plus utilization >= 99.5%) → blocked
- *   - either window above 80%, or representativeClaim set with > 50% →
- *     throttling
+ * Decide the health verdict for one account. Binding facts (in order):
+ *   - probe failure → unknown
+ *   - thin/headerless probe → unknown (no real utilization signal)
+ *   - 5h or 7d utilization >= 99.5% → blocked (quota wall)
+ *   - either window above 80% → throttling
  *   - everything else → healthy
  *   - probe failure → unknown
+ *
+ * NOTE: `out_of_credits` (overageDisabledReason) is NOT a serve-block here.
+ * The fleet runs on quota, not on overage credits. An account with `out_of_credits`
+ * at low util (e.g. pixsoul@gmail.com at 5h=0%, 7d=2%) serves fine and is a
+ * valid failover target. Overage fields are informational only — surfaced as an
+ * annotation on healthy/throttling rows, never as a blocked verdict.
+ * Failover safety against a real 429 is preserved via the mark-exhausted path.
  */
 export function classifyHealth(snap: AccountSnapshot, now: Date = new Date()): AccountHealth {
   if (!snap.quota) return 'unknown';
@@ -92,12 +102,6 @@ export function classifyHealth(snap: AccountSnapshot, now: Date = new Date()): A
   // EITHER window) must not masquerade as a confident 0% / healthy. Treat it
   // as unknown so the card surfaces a data-quality gap, not "healthy".
   if (isProbeThin(q)) return 'unknown';
-  // A serve-blocking overage reason wins over the util gate: a credits-dead
-  // account reads 0% util but 429s on every call, so it must show 'blocked'
-  // (drives the display, quota-watch, and the auto-fallback idempotency guard).
-  if (q.overageDisabledReason != null && SERVE_BLOCKING_OVERAGE_REASONS.has(q.overageDisabledReason)) {
-    return 'blocked';
-  }
   // #2494 Bug A — read utilization through the refill normalization: a window
   // whose reset has already passed has rolled since the snapshot was captured,
   // so its stale high utilization must be treated as 0%. A just-refilled
@@ -110,22 +114,20 @@ export function classifyHealth(snap: AccountSnapshot, now: Date = new Date()): A
 }
 
 /**
- * #2494 Bug C — why is a BLOCKED account blocked? Two materially different
- * causes that the card must render distinctly:
- *   - 'billing-dead' — a genuine serve-blocking `overageDisabledReason`
- *     (out_of_credits). NOT a timer: it stays dead until billing is fixed.
+ * Why is a BLOCKED account blocked? Only one cause now: quota exhaustion.
  *   - 'quota-exhausted' — a util window is maxed but recovers when that window
  *     rolls. Show the reset countdown.
+ *
+ * NOTE: 'billing-dead' has been removed. `out_of_credits` accounts are now
+ * healthy (not blocked) — they appear in the HEALTHY group with an informational
+ * overage annotation. See classifyHealth for the rationale.
+ *
  * Returns null for non-blocked accounts.
  */
-export type BlockedReason = 'billing-dead' | 'quota-exhausted';
+export type BlockedReason = 'quota-exhausted';
 
 export function blockedReason(snap: AccountSnapshot, now: Date = new Date()): BlockedReason | null {
   if (classifyHealth(snap, now) !== 'blocked') return null;
-  const q = snap.quota!;
-  if (q.overageDisabledReason != null && SERVE_BLOCKING_OVERAGE_REASONS.has(q.overageDisabledReason)) {
-    return 'billing-dead';
-  }
   return 'quota-exhausted';
 }
 
@@ -289,15 +291,6 @@ function renderAccountRow(
 
   const health = classifyHealth(snap, now);
   if (health === 'blocked') {
-    const reason = blockedReason(snap, now);
-    if (reason === 'billing-dead') {
-      // #2494 Bug C — billing-dead is NOT a timer. Surface the real reason and
-      // make clear it does not recover on a window roll.
-      lines.push(
-        `  <i>billing disabled (${escapeHtml(q.overageDisabledReason ?? 'out_of_credits')}) — won't recover until billing is fixed</i>`,
-      );
-      return lines;
-    }
     // quota-exhausted (recoverable): surface only the recovery countdown — the
     // binding window's reset is the only thing that matters until then.
     const win = bindingWindow(q);
@@ -323,6 +316,13 @@ function renderAccountRow(
     ? `7d resets ${formatAbsolute(q.sevenDayResetAt, tz)} (in ${formatRelative(q.sevenDayResetAt, now)})`
     : '7d resets —';
   lines.push(`  <i>${fiveFirst ? fiveSeg : sevenSeg}  ·  ${fiveFirst ? sevenSeg : fiveSeg}</i>`);
+  // Informational overage annotation: if out_of_credits (no overage headroom),
+  // surface it as a sub-line on a healthy/throttling row — NOT a blocked badge.
+  if (q.overageDisabledReason != null && OVERAGE_EXHAUSTED_REASONS.has(q.overageDisabledReason)) {
+    lines.push(
+      `  <i>overage off (${escapeHtml(q.overageDisabledReason)}) — serving from quota</i>`,
+    );
+  }
   return lines;
 }
 
@@ -494,7 +494,7 @@ function summarizeNoHealthyAlt(snapshots: AccountSnapshot[], now: Date): string 
     return `All accounts at capacity — waiting on a window refill.`;
   }
 
-  // Genuinely all blocked (billing-dead with no upcoming reset, or no data).
+  // Genuinely all blocked (quota-exhausted with no upcoming reset, or no data).
   if (earliestRecovery) {
     return `All accounts blocked. Earliest recovery: ${earliestRecovery.label} in ${formatRelative(earliestRecovery.at, now)}.`;
   }

--- a/telegram-plugin/auth-snapshot-format.ts
+++ b/telegram-plugin/auth-snapshot-format.ts
@@ -90,7 +90,7 @@ const OVERAGE_EXHAUSTED_REASONS = new Set<string>(['out_of_credits']);
  *
  * NOTE: `out_of_credits` (overageDisabledReason) is NOT a serve-block here.
  * The fleet runs on quota, not on overage credits. An account with `out_of_credits`
- * at low util (e.g. pixsoul@gmail.com at 5h=0%, 7d=2%) serves fine and is a
+ * at low util (e.g. carol@example.com at 5h=0%, 7d=2%) serves fine and is a
  * valid failover target. Overage fields are informational only — surfaced as an
  * annotation on healthy/throttling rows, never as a blocked verdict.
  * Failover safety against a real 429 is preserved via the mark-exhausted path.

--- a/telegram-plugin/quota-watch.ts
+++ b/telegram-plugin/quota-watch.ts
@@ -389,8 +389,8 @@ export type FleetAllExhaustedDecision =
  * (#2478, klanker 2026-06-20). So the `entered` alert requires POSITIVE LIVE
  * CORROBORATION: an account counts toward "all exhausted" only when its
  * `exhausted` flag is backed by a FRESH live snapshot (last_quota.capturedAt
- * within `maxStaleMs`) OR a serve-blocking overage (out_of_credits at any util).
- * If ANY account's exhaustion rests solely on a stale/absent-probe mark we are
+ * within `maxStaleMs`). If ANY account's exhaustion rests solely on a
+ * stale/absent-probe mark we are
  * probe-blind and return `skip: "probe-blind"` — no false fleet alert. The
  * guarantee is "no false alarm off stale marks during a probe blackout", NOT
  * blanket probe-failure immunity. The `recovered` transition is unguarded so a
@@ -421,9 +421,9 @@ export function evaluateFleetAllExhausted(args: {
 
   if (allExhausted && !wasAlerting) {
     // Probe-blind guard (#2478): only fire `entered` if EVERY account's
-    // exhaustion is backed by live evidence — a fresh snapshot or a
-    // serve-blocking overage. An account exhausted solely on a stale/absent
-    // mark means we have no live corroboration → skip rather than false-alarm.
+    // exhaustion is backed by live evidence — a fresh snapshot. An account
+    // exhausted solely on a stale/absent mark means we have no live
+    // corroboration → skip rather than false-alarm.
     if (maxStaleMs > 0) {
       const allLiveCorroborated = accounts.every((a) =>
         exhaustionLiveCorroborated(a, now, maxStaleMs),
@@ -455,15 +455,19 @@ export function evaluateFleetAllExhausted(args: {
  *
  * True when the most-recent live probe is FRESH (`capturedAt` within
  * `maxStaleMs`) — that fresh probe is what set/upholds the broker's blocked
- * verdict — OR when the snapshot reports a serve-blocking overage
- * (`out_of_credits`), which is an exhaustion in its own right at any util.
- * False when there is no `last_quota` at all, or the snapshot is stale: the
- * `exhausted` flag then rests solely on a persisted mark with no live backing,
- * which is exactly the probe-blind condition that false-fires the fleet alert.
+ * verdict. False when there is no `last_quota` at all, or the snapshot is
+ * stale: the `exhausted` flag then rests solely on a persisted mark with no
+ * live backing, which is exactly the probe-blind condition that false-fires
+ * the fleet alert.
  *
- * Mirrors `isOverageServeBlocking` / `snapshotFresh` in
- * src/auth/broker/account-eligibility.ts (the serving-side authority); kept as
- * a local check so the decision layer carries no broker dependency.
+ * NOTE: `out_of_credits` is NOT treated as corroboration here. Per
+ * fix/out-of-credits-serve-block, out_of_credits is INFORMATIONAL — it is
+ * not exhaustion in its own right at any util. Corroboration requires a
+ * genuinely fresh quota snapshot (real 429 / util-wall path).
+ *
+ * Mirrors `snapshotFresh` in src/auth/broker/account-eligibility.ts (the
+ * serving-side authority); kept as a local check so the decision layer
+ * carries no broker dependency.
  */
 function exhaustionLiveCorroborated(
   account: {
@@ -474,7 +478,6 @@ function exhaustionLiveCorroborated(
 ): boolean {
   const lq = account.last_quota;
   if (!lq) return false;
-  if (lq.overageDisabledReason === "out_of_credits") return true;
   // Mirror `snapshotFresh`'s clock-skew guard: a future-dated `capturedAt`
   // makes `now - capturedAt` negative and would slip past the staleness gate,
   // so a skewed snapshot reads as fresh. Reject snapshots dated more than the

--- a/telegram-plugin/tests/auth-snapshot-format.test.ts
+++ b/telegram-plugin/tests/auth-snapshot-format.test.ts
@@ -68,10 +68,12 @@ describe('classifyHealth', () => {
   it('returns unknown when quota probe failed', () => {
     expect(classifyHealth(snap({ quota: null, quotaError: 'HTTP 401' }))).toBe('unknown');
   });
-  it('out_of_credits overage at 0% util → blocked (the credits-dead account)', () => {
+  it('out_of_credits overage at 0% util → healthy (demoted to informational — serves fine from quota)', () => {
+    // THE KEY CHANGE: out_of_credits is no longer serve-blocking. An account at
+    // 0% util with out_of_credits is a valid failover target (pixsoul scenario).
     expect(
       classifyHealth(snap({ quota: quota({ fiveHourUtilizationPct: 0, sevenDayUtilizationPct: 0, overageStatus: 'rejected', overageDisabledReason: 'out_of_credits' }) })),
-    ).toBe('blocked');
+    ).toBe('healthy');
   });
   it('org_level_disabled at 75% util → unchanged/healthy (MANDATORY non-regression: live active account)', () => {
     // overageStatus:"rejected" + the benign reason must NOT flip it to blocked.
@@ -679,13 +681,22 @@ describe('#2494 Bug A — refill-aware classifyHealth', () => {
   });
 });
 
-// ── #2494 Bug C — quota-exhausted vs billing-dead, thin probe ────────────
+// ── #2494 Bug C — quota-exhausted vs thin probe (billing-dead demoted) ────────
 
-describe('#2494 Bug C — blockedReason + thin probe', () => {
-  it('out_of_credits → billing-dead', () => {
+describe('#2494 Bug C — blockedReason + thin probe (out_of_credits now informational)', () => {
+  it('out_of_credits at 0% util → healthy (demoted from billing-dead to informational)', () => {
+    // THE KEY CHANGE: out_of_credits is no longer a blocked state.
     const s = snap({ quota: quota({ fiveHourUtilizationPct: 0, overageDisabledReason: 'out_of_credits' }) });
+    expect(classifyHealth(s, NOW)).toBe('healthy');
+    expect(blockedReason(s, NOW)).toBeNull(); // not blocked → no blocked reason
+  });
+
+  it('out_of_credits at HIGH util is still blocked (via util wall, not credits)', () => {
+    // blocked because 5h>=99.5%, NOT because of out_of_credits
+    const futureReset = new Date(NOW.getTime() + 30 * 60_000);
+    const s = snap({ quota: quota({ fiveHourUtilizationPct: 100, fiveHourResetAt: futureReset, overageDisabledReason: 'out_of_credits' }) });
     expect(classifyHealth(s, NOW)).toBe('blocked');
-    expect(blockedReason(s, NOW)).toBe('billing-dead');
+    expect(blockedReason(s, NOW)).toBe('quota-exhausted'); // blocked by quota, not billing
   });
 
   it('a maxed window (no overage reason) → quota-exhausted (recoverable)', () => {
@@ -696,6 +707,12 @@ describe('#2494 Bug C — blockedReason + thin probe', () => {
 
   it('blockedReason is null for a non-blocked account', () => {
     expect(blockedReason(snap({ quota: quota({ fiveHourUtilizationPct: 10 }) }), NOW)).toBeNull();
+  });
+
+  it('org_level_disabled behavior is unchanged — still healthy', () => {
+    const s = snap({ quota: quota({ fiveHourUtilizationPct: 75, sevenDayUtilizationPct: 40, overageStatus: 'rejected', overageDisabledReason: 'org_level_disabled' }) });
+    expect(classifyHealth(s, NOW)).toBe('healthy');
+    expect(blockedReason(s, NOW)).toBeNull();
   });
 
   it('a thin/headerless probe classifies unknown, never a confident 0%/healthy', () => {
@@ -720,19 +737,39 @@ describe('#2494 Bug C — blockedReason + thin probe', () => {
   });
 });
 
-// ── #2494 — row rendering distinguishes the states ──────────────────────
+// ── #2494 — row rendering: out_of_credits as informational annotation ─────────
 
-describe('#2494 — renderAuthSnapshotFormat2 row rendering', () => {
-  it('billing-dead row says "billing disabled" with the reason, no timer', () => {
+describe('#2494 — renderAuthSnapshotFormat2 row rendering (out_of_credits demoted)', () => {
+  it('out_of_credits at 0% util → healthy row with informational overage annotation, NOT blocked', () => {
+    // THE KEY CHANGE: pixsoul scenario — 0% util, out_of_credits → healthy group
+    // with an informational sub-line "overage off (out_of_credits) — serving from quota"
     const out = renderAuthSnapshotFormat2(
       [snap({ label: 'dead@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 0, overageDisabledReason: 'out_of_credits' }) })],
       { now: NOW },
     );
-    expect(out).toContain('billing disabled (out_of_credits)');
+    // Must be in HEALTHY group, not BLOCKED
+    expect(out).toContain('🟢 <b>HEALTHY</b>');
+    expect(out).not.toContain('🔴 <b>BLOCKED</b>');
+    // Must have informational annotation
+    expect(out).toContain('overage off (out_of_credits) — serving from quota');
+    // Must NOT have old blocked framing
+    expect(out).not.toContain('billing disabled');
+    expect(out).not.toContain("won't recover until billing is fixed");
     expect(out).not.toContain('quota exhausted');
   });
 
-  it('quota-exhausted row shows a recovery countdown, not "billing disabled"', () => {
+  it('out_of_credits account is a valid failover target (appears in buildSnapshotKeyboard switch buttons)', () => {
+    // A 0%-util out_of_credits account must be offerable as a switch target
+    const snaps: AccountSnapshot[] = [
+      snap({ label: 'a@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 100 }) }), // blocked, active
+      snap({ label: 'pixsoul@gmail.com', quota: quota({ fiveHourUtilizationPct: 0, overageDisabledReason: 'out_of_credits' }) }), // healthy
+    ];
+    const rows = buildSnapshotKeyboard(snaps);
+    const allText = rows.flat().map((b) => b.text);
+    expect(allText).toContain('Switch fleet → pixsoul@gmail.com');
+  });
+
+  it('quota-exhausted row shows a recovery countdown, not "billing disabled" or overage annotation', () => {
     const futureReset = new Date(NOW.getTime() + 45 * 60_000);
     const out = renderAuthSnapshotFormat2(
       [snap({ label: 'ex@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 100, fiveHourResetAt: futureReset }) })],
@@ -740,6 +777,7 @@ describe('#2494 — renderAuthSnapshotFormat2 row rendering', () => {
     );
     expect(out).toContain('quota exhausted');
     expect(out).not.toContain('billing disabled');
+    expect(out).not.toContain('overage off');
   });
 
   it('thin probe row renders "quota unknown", not "0% / 0%"', () => {
@@ -749,5 +787,27 @@ describe('#2494 — renderAuthSnapshotFormat2 row rendering', () => {
     );
     expect(out).toContain('quota unknown');
     expect(out).not.toContain('0% / 0%');
+  });
+
+  it('org_level_disabled at 85% util has no overage annotation (only in OVERAGE_EXHAUSTED_REASONS)', () => {
+    // org_level_disabled is NOT on the OVERAGE_EXHAUSTED_REASONS list → no annotation
+    const out = renderAuthSnapshotFormat2(
+      [snap({ label: 'org@x', isActive: false, quota: quota({ fiveHourUtilizationPct: 85, overageDisabledReason: 'org_level_disabled' }) })],
+      { now: NOW },
+    );
+    expect(out).toContain('🟡 <b>THROTTLING</b>');
+    expect(out).not.toContain('overage off');
+  });
+
+  it('recommendation treats out_of_credits 0%-util account as healthy alternative', () => {
+    // The active account is blocked (quota), the out_of_credits 0%-util account
+    // is the only alternative — it must be recommended as the switch target.
+    const snaps: AccountSnapshot[] = [
+      snap({ label: 'main@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 100 }) }), // blocked
+      snap({ label: 'pixsoul@gmail.com', quota: quota({ fiveHourUtilizationPct: 0, overageDisabledReason: 'out_of_credits' }) }), // healthy
+    ];
+    const out = recommendation(snaps, NOW);
+    expect(out).toContain('switch to pixsoul@gmail.com');
+    expect(out).not.toContain('All accounts blocked');
   });
 });

--- a/telegram-plugin/tests/auth-snapshot-format.test.ts
+++ b/telegram-plugin/tests/auth-snapshot-format.test.ts
@@ -70,7 +70,7 @@ describe('classifyHealth', () => {
   });
   it('out_of_credits overage at 0% util → healthy (demoted to informational — serves fine from quota)', () => {
     // THE KEY CHANGE: out_of_credits is no longer serve-blocking. An account at
-    // 0% util with out_of_credits is a valid failover target (pixsoul scenario).
+    // 0% util with out_of_credits is a valid failover target (carol scenario).
     expect(
       classifyHealth(snap({ quota: quota({ fiveHourUtilizationPct: 0, sevenDayUtilizationPct: 0, overageStatus: 'rejected', overageDisabledReason: 'out_of_credits' }) })),
     ).toBe('healthy');
@@ -741,7 +741,7 @@ describe('#2494 Bug C — blockedReason + thin probe (out_of_credits now informa
 
 describe('#2494 — renderAuthSnapshotFormat2 row rendering (out_of_credits demoted)', () => {
   it('out_of_credits at 0% util → healthy row with informational overage annotation, NOT blocked', () => {
-    // THE KEY CHANGE: pixsoul scenario — 0% util, out_of_credits → healthy group
+    // THE KEY CHANGE: carol scenario — 0% util, out_of_credits → healthy group
     // with an informational sub-line "overage off (out_of_credits) — serving from quota"
     const out = renderAuthSnapshotFormat2(
       [snap({ label: 'dead@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 0, overageDisabledReason: 'out_of_credits' }) })],
@@ -762,11 +762,11 @@ describe('#2494 — renderAuthSnapshotFormat2 row rendering (out_of_credits demo
     // A 0%-util out_of_credits account must be offerable as a switch target
     const snaps: AccountSnapshot[] = [
       snap({ label: 'a@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 100 }) }), // blocked, active
-      snap({ label: 'pixsoul@gmail.com', quota: quota({ fiveHourUtilizationPct: 0, overageDisabledReason: 'out_of_credits' }) }), // healthy
+      snap({ label: 'carol@example.com', quota: quota({ fiveHourUtilizationPct: 0, overageDisabledReason: 'out_of_credits' }) }), // healthy
     ];
     const rows = buildSnapshotKeyboard(snaps);
     const allText = rows.flat().map((b) => b.text);
-    expect(allText).toContain('Switch fleet → pixsoul@gmail.com');
+    expect(allText).toContain('Switch fleet → carol@example.com');
   });
 
   it('quota-exhausted row shows a recovery countdown, not "billing disabled" or overage annotation', () => {
@@ -804,10 +804,10 @@ describe('#2494 — renderAuthSnapshotFormat2 row rendering (out_of_credits demo
     // is the only alternative — it must be recommended as the switch target.
     const snaps: AccountSnapshot[] = [
       snap({ label: 'main@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 100 }) }), // blocked
-      snap({ label: 'pixsoul@gmail.com', quota: quota({ fiveHourUtilizationPct: 0, overageDisabledReason: 'out_of_credits' }) }), // healthy
+      snap({ label: 'carol@example.com', quota: quota({ fiveHourUtilizationPct: 0, overageDisabledReason: 'out_of_credits' }) }), // healthy
     ];
     const out = recommendation(snaps, NOW);
-    expect(out).toContain('switch to pixsoul@gmail.com');
+    expect(out).toContain('switch to carol@example.com');
     expect(out).not.toContain('All accounts blocked');
   });
 });

--- a/telegram-plugin/tests/auto-fallback-fleet.test.ts
+++ b/telegram-plugin/tests/auto-fallback-fleet.test.ts
@@ -135,14 +135,39 @@ describe('runFleetAutoFallback', () => {
     expect(out.announcement).toContain('Stale event?');
   });
 
-  it('out_of_credits active account ⇒ swap fires (classifyHealth=blocked, not idempotent-skip)', async () => {
-    // The active account is at 0% util but credits-dead. classifyHealth must
-    // read 'blocked' so the idempotency guard does NOT skip — the swap fires.
+  it('out_of_credits active account ⇒ NO swap (informational, not a serve-block)', async () => {
+    // NEW CONTRACT (fix/out-of-credits-serve-block): out_of_credits is
+    // INFORMATIONAL. An active account at 0% util with out_of_credits is
+    // classified HEALTHY by classifyHealth(), so the idempotency guard fires
+    // and the swap is skipped. out_of_credits must NEVER on its own cause a
+    // fleet auto-fallback swap.
     const failover = vi.fn(async () => ({ rolledTo: 'bob@example.com', rolled: ['alice@example.com'] }));
     const out = await runFleetAutoFallback({
       state: state('alice@example.com', ['alice@example.com', 'bob@example.com']),
       quotas: [
         qOk({ fiveHourUtilizationPct: 0, sevenDayUtilizationPct: 0, overageStatus: 'rejected', overageDisabledReason: 'out_of_credits' }),
+        qOk({ fiveHourUtilizationPct: 8, sevenDayUtilizationPct: 20 }),
+      ],
+      failover,
+      triggerAgent: 'carrie',
+      now: NOW,
+      tz: 'UTC',
+    });
+
+    // out_of_credits at 0% util → classifyHealth='healthy' → idempotency guard
+    // returns no-eligible-target WITHOUT calling failover.
+    expect(out.kind).toBe('no-eligible-target');
+    expect(failover).not.toHaveBeenCalled();
+  });
+
+  it('genuine quota wall (100% 5h util) ⇒ swap fires (failover safety preserved)', async () => {
+    // Failover on a REAL quota wall must still work. This anchors the safety
+    // contract: only out_of_credits is demoted, genuine exhaustion still swaps.
+    const failover = vi.fn(async () => ({ rolledTo: 'bob@example.com', rolled: ['alice@example.com'] }));
+    const out = await runFleetAutoFallback({
+      state: state('alice@example.com', ['alice@example.com', 'bob@example.com']),
+      quotas: [
+        qOk({ fiveHourUtilizationPct: 100, fiveHourResetAt: new Date('2026-05-15T05:50:00Z'), representativeClaim: 'five_hour' }),
         qOk({ fiveHourUtilizationPct: 8, sevenDayUtilizationPct: 20 }),
       ],
       failover,

--- a/telegram-plugin/tests/quota-watch.test.ts
+++ b/telegram-plugin/tests/quota-watch.test.ts
@@ -552,7 +552,12 @@ describe("evaluateFleetAllExhausted", () => {
     if (d.kind === "notify") expect(d.transition).toBe("entered");
   });
 
-  it("notifies (entered) on a genuine serve-blocking overage (out_of_credits) with a fresh probe", () => {
+  it("notifies (entered) when out_of_credits account has a FRESH probe (freshness drives corroboration, not the credits flag)", () => {
+    // NEW CONTRACT (fix/out-of-credits-serve-block): out_of_credits is
+    // informational — it does NOT corroborate exhaustion on its own. But a
+    // genuinely fresh probe (capturedAt within maxStaleMs) still corroborates.
+    // Result: still notifies — for the right reason (fresh snapshot), not the
+    // credits reason.
     const d = evaluateFleetAllExhausted({
       accounts: [
         {
@@ -569,8 +574,13 @@ describe("evaluateFleetAllExhausted", () => {
     if (d.kind === "notify") expect(d.transition).toBe("entered");
   });
 
-  it("out_of_credits corroborates exhaustion even when the snapshot is past the staleness ceiling", () => {
-    // A serve-blocking overage is exhaustion in its own right — age-independent.
+  it("out_of_credits does NOT corroborate exhaustion when the snapshot is past the staleness ceiling (probe-blind)", () => {
+    // NEW CONTRACT (fix/out-of-credits-serve-block): out_of_credits is
+    // informational, NOT exhaustion in its own right at any util. A stale
+    // snapshot with only out_of_credits provides no live corroboration →
+    // probe-blind → skip (no false fleet alert). Contrast with the test above:
+    // a FRESH probe with out_of_credits still notifies via freshness, not the
+    // credits flag.
     const d = evaluateFleetAllExhausted({
       accounts: [
         {
@@ -583,7 +593,8 @@ describe("evaluateFleetAllExhausted", () => {
       now: NOW,
       tuning: gate,
     });
-    expect(d.kind).toBe("notify");
+    expect(d.kind).toBe("skip");
+    if (d.kind === "skip") expect(d.reason).toBe("probe-blind");
   });
 
   it("skips (still) when all exhausted and already alerting — no re-spam", () => {


### PR DESCRIPTION
## Problem

The fleet runs on **Claude Pro Max subscription quota**. Overage credits are a separate billing mechanism that switchroom does not use. An account with `overageDisabledReason === "out_of_credits"` at 0% utilisation was being **blocked from serving and excluded from failover rotation** — purely because its overage balance was zero, even though its full quota was available.

This caused the **Jun 20 incident** (#2455): `pixsoul@gmail.com` at 5h=0%/7d=2% was showing 🔴 BLOCKED and never receiving requests, defeating the entire purpose of the failover pool.

**Before (pixsoul@gmail.com at 0%/2% util):**
```
🔴 BLOCKED (1)
  billing disabled (out_of_credits) — won't recover until billing is fixed
```

**After:**
```
🟢 HEALTHY (1) / 0% / 2%
  overage off (out_of_credits) — serving from quota
```

## Root Cause

`out_of_credits` was a member of `SERVE_BLOCKING_OVERAGE_REASONS`, treated identically to a util wall (≥99.5%). The structurally identical `org_level_disabled` reason (also overage-off) was correctly benign — this asymmetry was the defect.

## Fix

Pure semantic demotion: `out_of_credits` is now **informational only**. It appears as an annotation on healthy rows but never gates serving or failover eligibility.

### Key changes

| File | Change |
|---|---|
| `account-eligibility.ts` | Renamed `SERVE_BLOCKING_OVERAGE_REASONS` → `OVERAGE_EXHAUSTED_REASONS` (deprecated alias kept); `hasNoOverageHeadroom()` replaces `isOverageServeBlocking()` as primary; `isAccountBlocked()` fresh-snapshot branch drops `|| isOverageServeBlocking()` — now only `snapshotWalled()` (util ≥99.5%) blocks; `snapshotShouldClearMark()` drops the credits guard — 0%-util probe self-heals normally |
| `consumer-quota-sensor.ts` | `quotaIndicatesExhaustion()`: removes `out_of_credits` early-return; exhaustion only via util wall |
| `auth-snapshot-format.ts` | `classifyHealth()`: `out_of_credits` → `healthy` not `blocked`; `BlockedReason` reduced to `'quota-exhausted'`; removes `billing-dead` row framing; adds informational sub-line on healthy rows |
| `auth-schedule.ts` | Removes `"out-of-credits"` state; shows `(overage off: out_of_credits)` annotation on healthy/unprobed cells |
| `overage-allowlist-drift.test.ts` | Updated drift guard for the new `OVERAGE_EXHAUSTED_REASONS` name in both packages |

### Failover safety is preserved

Failover safety relies on the **existing `mark-exhausted` path**: agents raise `mark-exhausted` when the gateway sees a real 429. That is the correct signal for quota exhaustion. Using the overage credits flag as a proxy for quota exhaustion was always wrong — an account with 0% utilisation *cannot* return a quota 429.

### Backwards compatibility

Deprecated alias exports (`SERVE_BLOCKING_OVERAGE_REASONS`, `isOverageServeBlocking`) are retained so no external callers break at compile time.

### Two-package replica pattern

`telegram-plugin` can't import from `broker`, so `OVERAGE_EXHAUSTED_REASONS` is duplicated with a cross-package drift guard test (`overage-allowlist-drift.test.ts`).

## Tests

157 tests pass across all five changed test files; `tsc --noEmit` clean.

- `src/auth/broker/account-eligibility.test.ts` — `out_of_credits at 0% util → not blocked`, pixsoul scenario, mark-exhausted path tests
- `src/auth/broker/consumer-quota-sensor.test.ts` — `out_of_credits at 0% util ⇒ NOT exhausted`
- `src/auth/broker/overage-allowlist-drift.test.ts` — drift guard updated for new name
- `src/cli/auth-schedule.test.ts` — `overageServeBlocking at 0% util → healthy`; annotation tests
- `telegram-plugin/tests/auth-snapshot-format.test.ts` — `out_of_credits → healthy`; informational annotation; failover target eligibility

## Related PRs

- **Supersedes #2513** — display-only reframe; should be closed in favour of this PR which fixes the actual gate
- **Reverses #2455** (Jun 20 incident) with a correct gate: util-wall governs serving, not the credits availability flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)