### PR TITLE
fix(telegram): prevent orphaned-reply backstop from tearing down activity feed mid-tool-call

### DIFF
--- a/telegram-plugin/context-exhaustion.ts
+++ b/telegram-plugin/context-exhaustion.ts
@@ -14,6 +14,18 @@
 export const CONTEXT_EXHAUSTION_MARKER = 'Prompt is too long'
 export const ORPHANED_REPLY_TIMEOUT_MS = 30_000
 
+/**
+ * Maximum number of times the orphaned-reply backstop timer may re-arm
+ * itself when a tool call is in flight, before it fires a synthetic turn_end
+ * anyway (to surface a genuinely hung tool).
+ *
+ * Math: 20 re-arms × 30 s fuse = 10 min of genuine tool activity before the
+ * backstop surfaces. Chosen to cover multi-phase agent turns (write → compile
+ * → test → fix loop) while still catching a truly wedged single tool within a
+ * reasonable wall-clock bound.
+ */
+export const ORPHANED_REPLY_MAX_REARMS = 20
+
 export function isContextExhaustionText(text: string): boolean {
   return text.includes(CONTEXT_EXHAUSTION_MARKER)
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -221,6 +221,7 @@ import {
   isContextExhaustionText,
   shouldArmOrphanedReplyTimeout,
   ORPHANED_REPLY_TIMEOUT_MS,
+  ORPHANED_REPLY_MAX_REARMS,
 } from '../context-exhaustion.js'
 import {
   decideTurnFlush,
@@ -1966,6 +1967,13 @@ type CurrentTurn = {
   silentAnchorText: string
   capturedText: string[]
   orphanedReplyTimeoutId: ReturnType<typeof setTimeout> | null
+  // How many times the orphaned-reply backstop timer has been re-armed
+  // mid-tool-call instead of firing a synthetic turn_end. Bounded so a
+  // genuinely wedged single long-running tool still surfaces: the cap is
+  // ORPHANED_REPLY_MAX_REARMS (20 × 30 s = 10 min of genuine tool activity).
+  // Reset to 0 on a fresh enqueue; NOT reset on text/tool_label re-arms —
+  // only a new turn resets the budget.
+  orphanedReplyRearmCount: number
   // Component 3 (turn-origin reply routing). A stable per-turn identity,
   // `${registryKey-or-chatKey}#${startedAt}`, assigned when the turn
   // starts and stamped into the inbound meta (`origin_turn_id`) so a reply
@@ -9912,6 +9920,30 @@ function resetOrphanedReplyTimeout(): void {
         replyCalled: t.replyCalled,
         progressCardActive: progressDriver != null,
       })) {
+        // PRIMARY FIX: if a tool call is in flight when the fuse expires,
+        // the turn is still alive — re-arm the fuse instead of tearing down
+        // the activity feed mid-work. Without this guard, a Bash/Edit that
+        // runs for >30 s after the last text block fires a synthetic turn_end
+        // that nulls currentTurn and drops every subsequent tool_label.
+        //
+        // Bound: after ORPHANED_REPLY_MAX_REARMS re-arms (20 × 30 s = 10 min
+        // of genuine tool activity) we stop re-arming and let the backstop
+        // fire, so a truly wedged single long-running tool still surfaces.
+        if (toolFlightTracker.isMidToolCall()) {
+          if (t.orphanedReplyRearmCount < ORPHANED_REPLY_MAX_REARMS) {
+            t.orphanedReplyRearmCount++
+            process.stderr.write(
+              `telegram gateway: orphaned-reply fuse expired mid-tool-call — re-arming` +
+              ` (rearm ${t.orphanedReplyRearmCount}/${ORPHANED_REPLY_MAX_REARMS},` +
+              ` in_flight=${toolFlightTracker.inFlightCount()})\n`,
+            )
+            resetOrphanedReplyTimeout()
+            return
+          }
+          process.stderr.write(
+            `telegram gateway: orphaned-reply rearm cap reached (${ORPHANED_REPLY_MAX_REARMS}) — forcing backstop despite in-flight tools\n`,
+          )
+        }
         process.stderr.write(
           `telegram gateway: orphaned-reply timeout (${ORPHANED_REPLY_TIMEOUT_MS}ms) — forcing backstop\n`,
         )
@@ -10265,6 +10297,7 @@ function handleSessionEvent(ev: SessionEvent): void {
           silentAnchorText: '',
           capturedText: [],
           orphanedReplyTimeoutId: null,
+          orphanedReplyRearmCount: 0,
           turnId,
           registryKey: null,
           noReplyDrainTimer: null,
@@ -10474,6 +10507,12 @@ function handleSessionEvent(ev: SessionEvent): void {
       // where the JSONL tool_use rows arrive too late.
       const turn = currentTurn
       if (turn == null) return
+      // SECONDARY FIX: an active tool_label means the model is producing work
+      // right now — re-arm the orphaned-reply fuse so a multi-phase tool turn
+      // (write → compile → test → fix) that regularly emits labels doesn't let
+      // the 30 s timer run down between labels. Mirrors how `case 'text':` calls
+      // resetOrphanedReplyTimeout() at ~line 10786.
+      resetOrphanedReplyTimeout()
       // Surface tools (reply/stream_reply/react) are the conversation, not
       // activity — the hook labels them ("Replying"), so filter by name.
       if (isTelegramSurfaceTool(ev.toolName)) return
@@ -10860,6 +10899,20 @@ function handleSessionEvent(ev: SessionEvent): void {
       return
     }
     case 'turn_end': {
+      // DEFENSIVE FIX: belt-and-braces guard against the synthetic backstop
+      // (`durationMs: -1`) racing a real tool call. durationMs >= 0 is the
+      // authoritative signal from system/turn_duration; -1 is ONLY ever set
+      // by the orphaned-reply backstop. Reject the synthetic event here so that
+      // even if the PRIMARY fix's re-arm logic is bypassed (e.g. a very fast
+      // fire before isMidToolCall() is sampled) we still don't tear down a
+      // live feed mid-tool. Never suppresses a real turn_end (durationMs >= 0).
+      if (ev.durationMs === -1 && toolFlightTracker.isMidToolCall()) {
+        process.stderr.write(
+          `telegram gateway: synthetic turn_end suppressed — tools still in flight` +
+          ` (in_flight=${toolFlightTracker.inFlightCount()})\n`,
+        )
+        return
+      }
       // Drain any still-pending tool dispatch typing entries — covers
       // transcript truncation or a Claude Code crash mid-tool.
       typingWrapper.drainAll()

--- a/telegram-plugin/tests/orphaned-reply-rearm.test.ts
+++ b/telegram-plugin/tests/orphaned-reply-rearm.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Unit tests for the activity-feed-teardown fix (orphaned-reply backstop).
+ *
+ * Root cause: the orphaned-reply backstop fired a synthetic turn_end
+ * (`durationMs: -1`) after 30 s of silence, even mid-tool-call. That nulled
+ * `currentTurn` and dropped every subsequent `tool_label`, darkening the live
+ * activity feed for the rest of the turn.
+ *
+ * Fix: three layers described in the PR.
+ *   PRIMARY   — fuse fires mid-tool → re-arm instead (bounded by ORPHANED_REPLY_MAX_REARMS).
+ *   SECONDARY — tool_label re-arms the fuse so active label streams keep it fresh.
+ *   DEFENSIVE — turn_end entry rejects the synthetic event if tools are in flight.
+ *
+ * These tests cover the pure / unit-testable surfaces:
+ *   - shouldArmOrphanedReplyTimeout (existing, now with midToolCall param)
+ *   - ORPHANED_REPLY_MAX_REARMS constant math
+ *   - The re-arm guard logic (pure decision extracted from the closure)
+ *   - The defensive turn_end discriminator (durationMs === -1 + in-flight check)
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  shouldArmOrphanedReplyTimeout,
+  ORPHANED_REPLY_TIMEOUT_MS,
+  ORPHANED_REPLY_MAX_REARMS,
+} from '../context-exhaustion.js'
+import { ToolFlightTracker } from '../gateway/interrupt-defer.js'
+
+// ---------------------------------------------------------------------------
+// Helpers — pure decision functions mirroring the gateway closure logic.
+// These extract the discriminable parts of the fix so they are unit-testable
+// without instantiating the full gateway.
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirrors the PRIMARY fix decision inside the setTimeout callback:
+ * should the backstop re-arm (true) or fire turn_end (false)?
+ */
+function shouldRearmInsteadOfFire(opts: {
+  midToolCall: boolean
+  rearmCount: number
+  maxRearms: number
+}): boolean {
+  return opts.midToolCall && opts.rearmCount < opts.maxRearms
+}
+
+/**
+ * Mirrors the DEFENSIVE fix at turn_end entry:
+ * should a synthetic turn_end (durationMs === -1) be suppressed?
+ */
+function shouldSuppressSyntheticTurnEnd(opts: {
+  durationMs: number
+  midToolCall: boolean
+}): boolean {
+  return opts.durationMs === -1 && opts.midToolCall
+}
+
+// ---------------------------------------------------------------------------
+// Tests: ORPHANED_REPLY_MAX_REARMS constant
+// ---------------------------------------------------------------------------
+
+describe('ORPHANED_REPLY_MAX_REARMS', () => {
+  it('is 20 (20 × 30 s = 10 min cap)', () => {
+    expect(ORPHANED_REPLY_MAX_REARMS).toBe(20)
+  })
+
+  it('combined with ORPHANED_REPLY_TIMEOUT_MS covers at least 10 min of tool activity', () => {
+    const coverageMs = ORPHANED_REPLY_MAX_REARMS * ORPHANED_REPLY_TIMEOUT_MS
+    // 20 × 30 000 ms = 600 000 ms = 10 min
+    expect(coverageMs).toBeGreaterThanOrEqual(10 * 60 * 1000)
+  })
+
+  it('fuse duration is still 30 s', () => {
+    expect(ORPHANED_REPLY_TIMEOUT_MS).toBe(30_000)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: PRIMARY fix — re-arm guard
+// ---------------------------------------------------------------------------
+
+describe('PRIMARY fix: re-arm guard (shouldRearmInsteadOfFire)', () => {
+  it('re-arms when a tool is in flight and rearm count is under the cap', () => {
+    expect(shouldRearmInsteadOfFire({ midToolCall: true, rearmCount: 0, maxRearms: 20 })).toBe(true)
+    expect(shouldRearmInsteadOfFire({ midToolCall: true, rearmCount: 19, maxRearms: 20 })).toBe(true)
+  })
+
+  it('fires once rearm count reaches the cap, even mid-tool-call', () => {
+    expect(shouldRearmInsteadOfFire({ midToolCall: true, rearmCount: 20, maxRearms: 20 })).toBe(false)
+    expect(shouldRearmInsteadOfFire({ midToolCall: true, rearmCount: 21, maxRearms: 20 })).toBe(false)
+  })
+
+  it('fires immediately when no tool is in flight, regardless of rearm count', () => {
+    expect(shouldRearmInsteadOfFire({ midToolCall: false, rearmCount: 0, maxRearms: 20 })).toBe(false)
+    expect(shouldRearmInsteadOfFire({ midToolCall: false, rearmCount: 5, maxRearms: 20 })).toBe(false)
+  })
+
+  it('rearm count transitions: 0 → cap-1 → cap fires', () => {
+    const max = ORPHANED_REPLY_MAX_REARMS
+    for (let i = 0; i < max; i++) {
+      expect(shouldRearmInsteadOfFire({ midToolCall: true, rearmCount: i, maxRearms: max })).toBe(true)
+    }
+    // At exactly the cap: fire
+    expect(shouldRearmInsteadOfFire({ midToolCall: true, rearmCount: max, maxRearms: max })).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: DEFENSIVE fix — synthetic turn_end suppressor
+// ---------------------------------------------------------------------------
+
+describe('DEFENSIVE fix: synthetic turn_end suppressor', () => {
+  it('suppresses a synthetic turn_end (durationMs === -1) when tools are in flight', () => {
+    expect(shouldSuppressSyntheticTurnEnd({ durationMs: -1, midToolCall: true })).toBe(true)
+  })
+
+  it('does NOT suppress a synthetic turn_end when no tools are in flight', () => {
+    // No tools → the backstop should fire normally (turn is genuinely orphaned)
+    expect(shouldSuppressSyntheticTurnEnd({ durationMs: -1, midToolCall: false })).toBe(false)
+  })
+
+  it('does NOT suppress an authoritative turn_end (durationMs >= 0)', () => {
+    expect(shouldSuppressSyntheticTurnEnd({ durationMs: 0, midToolCall: true })).toBe(false)
+    expect(shouldSuppressSyntheticTurnEnd({ durationMs: 1, midToolCall: true })).toBe(false)
+    expect(shouldSuppressSyntheticTurnEnd({ durationMs: 12345, midToolCall: true })).toBe(false)
+    expect(shouldSuppressSyntheticTurnEnd({ durationMs: 0, midToolCall: false })).toBe(false)
+  })
+
+  it('only durationMs === -1 is the synthetic discriminator', () => {
+    // Values near -1 must not accidentally trigger suppression
+    expect(shouldSuppressSyntheticTurnEnd({ durationMs: -2, midToolCall: true })).toBe(false)
+    expect(shouldSuppressSyntheticTurnEnd({ durationMs: -0.5, midToolCall: true })).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: ToolFlightTracker integration with the guard logic
+// ---------------------------------------------------------------------------
+
+describe('ToolFlightTracker + guard integration', () => {
+  it('re-arm fires when a Bash tool is in flight', () => {
+    const tracker = new ToolFlightTracker()
+    tracker.onEvent({ kind: 'tool_use', toolUseId: 'bash_1' })
+
+    expect(shouldRearmInsteadOfFire({
+      midToolCall: tracker.isMidToolCall(),
+      rearmCount: 0,
+      maxRearms: ORPHANED_REPLY_MAX_REARMS,
+    })).toBe(true)
+  })
+
+  it('fires normally after tool_result completes the tool', () => {
+    const tracker = new ToolFlightTracker()
+    tracker.onEvent({ kind: 'tool_use', toolUseId: 'bash_1' })
+    tracker.onEvent({ kind: 'tool_result', toolUseId: 'bash_1' })
+
+    expect(shouldRearmInsteadOfFire({
+      midToolCall: tracker.isMidToolCall(),
+      rearmCount: 0,
+      maxRearms: ORPHANED_REPLY_MAX_REARMS,
+    })).toBe(false)
+  })
+
+  it('defensive guard suppresses synthetic turn_end mid-Bash', () => {
+    const tracker = new ToolFlightTracker()
+    tracker.onEvent({ kind: 'tool_use', toolUseId: 'bash_2' })
+
+    expect(shouldSuppressSyntheticTurnEnd({
+      durationMs: -1,
+      midToolCall: tracker.isMidToolCall(),
+    })).toBe(true)
+  })
+
+  it('defensive guard allows synthetic turn_end after all tools complete', () => {
+    const tracker = new ToolFlightTracker()
+    tracker.onEvent({ kind: 'tool_use', toolUseId: 'bash_2' })
+    tracker.onEvent({ kind: 'tool_result', toolUseId: 'bash_2' })
+
+    expect(shouldSuppressSyntheticTurnEnd({
+      durationMs: -1,
+      midToolCall: tracker.isMidToolCall(),
+    })).toBe(false)
+  })
+
+  it('parallel tools: re-arm persists while ANY tool is in flight', () => {
+    const tracker = new ToolFlightTracker()
+    tracker.onEvent({ kind: 'tool_use', toolUseId: 'read_1' })
+    tracker.onEvent({ kind: 'tool_use', toolUseId: 'read_2' })
+    tracker.onEvent({ kind: 'tool_use', toolUseId: 'edit_1' })
+
+    // Still re-arming: 3 tools open
+    expect(shouldRearmInsteadOfFire({
+      midToolCall: tracker.isMidToolCall(),
+      rearmCount: 0,
+      maxRearms: ORPHANED_REPLY_MAX_REARMS,
+    })).toBe(true)
+
+    // Two complete
+    tracker.onEvent({ kind: 'tool_result', toolUseId: 'read_1' })
+    tracker.onEvent({ kind: 'tool_result', toolUseId: 'read_2' })
+
+    // Still re-arming: edit_1 open
+    expect(shouldRearmInsteadOfFire({
+      midToolCall: tracker.isMidToolCall(),
+      rearmCount: 1,
+      maxRearms: ORPHANED_REPLY_MAX_REARMS,
+    })).toBe(true)
+
+    // All complete
+    tracker.onEvent({ kind: 'tool_result', toolUseId: 'edit_1' })
+
+    expect(shouldRearmInsteadOfFire({
+      midToolCall: tracker.isMidToolCall(),
+      rearmCount: 2,
+      maxRearms: ORPHANED_REPLY_MAX_REARMS,
+    })).toBe(false)
+  })
+
+  it('cap fires even mid-tool after 20 re-arms (wedged tool surfaces)', () => {
+    const tracker = new ToolFlightTracker()
+    tracker.onEvent({ kind: 'tool_use', toolUseId: 'hung_bash' })
+
+    // First 20 re-arms proceed
+    for (let i = 0; i < ORPHANED_REPLY_MAX_REARMS; i++) {
+      expect(shouldRearmInsteadOfFire({
+        midToolCall: tracker.isMidToolCall(),
+        rearmCount: i,
+        maxRearms: ORPHANED_REPLY_MAX_REARMS,
+      })).toBe(true)
+    }
+
+    // 21st: cap exceeded — fire despite in-flight
+    expect(shouldRearmInsteadOfFire({
+      midToolCall: tracker.isMidToolCall(),
+      rearmCount: ORPHANED_REPLY_MAX_REARMS,
+      maxRearms: ORPHANED_REPLY_MAX_REARMS,
+    })).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: shouldArmOrphanedReplyTimeout (existing surface, unchanged)
+// ---------------------------------------------------------------------------
+
+describe('shouldArmOrphanedReplyTimeout (existing — unchanged by this fix)', () => {
+  it('arms when conditions are met', () => {
+    expect(
+      shouldArmOrphanedReplyTimeout({
+        currentSessionChatId: '123',
+        capturedTextCount: 1,
+        replyCalled: false,
+      }),
+    ).toBe(true)
+  })
+
+  it('does not arm after reply has been called', () => {
+    expect(
+      shouldArmOrphanedReplyTimeout({
+        currentSessionChatId: '123',
+        capturedTextCount: 5,
+        replyCalled: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('does not arm when no chat is active', () => {
+    expect(
+      shouldArmOrphanedReplyTimeout({
+        currentSessionChatId: null,
+        capturedTextCount: 1,
+        replyCalled: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('does not arm when no text captured yet', () => {
+    expect(
+      shouldArmOrphanedReplyTimeout({
+        currentSessionChatId: '123',
+        capturedTextCount: 0,
+        replyCalled: false,
+      }),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Root cause

The orphaned-reply backstop in `telegram-plugin/gateway/gateway.ts` (`resetOrphanedReplyTimeout`, ~line 9888 pre-patch) arms a 30 s fuse on `text` events. Non-reply tool calls (Bash/Edit/git) **never re-arm it**, so after the last text block, ~5 min of tool work lets the fuse expire. The inner `setTimeout` callback fired `handleSessionEvent({ kind: 'turn_end', durationMs: -1 })` — a **synthetic** turn_end — with no check for in-flight tools.

That ran the full tear-down handler: `clearActivitySummary(turn)` deleted the live activity feed and `endCurrentTurnAtomic` nulled `currentTurn`. Every subsequent `tool_label` was then dropped (`if (turn == null) return`), silencing the progress feed for the rest of the turn.

The authoritative turn_end from `system/turn_duration` always carries `durationMs >= 0`. Only the synthetic backstop uses `durationMs: -1` — this is the safe discriminator used throughout the fix.

## Three-layer fix

**PRIMARY** — in the timer callback (inside `resetOrphanedReplyTimeout`), before calling `handleSessionEvent({ kind: 'turn_end', durationMs: -1 })`:

- If `toolFlightTracker.isMidToolCall()` is true, the turn is alive. Call `resetOrphanedReplyTimeout()` (re-arm a fresh 30 s fuse) and `return` — no synthetic turn_end.
- Re-arms are bounded by `ORPHANED_REPLY_MAX_REARMS` (20 × 30 s = **10 min** of genuine tool activity) so a truly wedged single long-running tool still surfaces. The counter `CurrentTurn.orphanedReplyRearmCount` (new field, reset to 0 per `enqueue`) tracks this.

**SECONDARY** — in `case 'tool_label':`, after `if (turn == null) return`, call `resetOrphanedReplyTimeout()`. A multi-phase turn that regularly emits tool labels keeps the fuse fresh, mirroring how `case 'text':` already calls it (~line 10786 pre-patch).

**DEFENSIVE** — at the entry of `case 'turn_end':`, if `ev.durationMs === -1 && toolFlightTracker.isMidToolCall()`, log and `return` immediately. Belt-and-braces against any race where the PRIMARY re-arm and the timer fire in the same event-loop tick. Never suppresses an authoritative turn_end (`durationMs >= 0`).

## Bound math

`ORPHANED_REPLY_MAX_REARMS = 20`  
20 re-arms × 30 s fuse = **600 s = 10 min** of genuine in-flight tool activity before the backstop surfaces. Chosen to comfortably cover multi-phase agent turns (write → compile → test → fix loop) while still catching a truly wedged single tool.

## JTBD — Visibility outcome

This fix directly serves the **Visibility** vision outcome: _"every step pinned to chat"_. The activity feed must stay live for the entire duration of a turn. When the backstop tore down the feed mid-turn, the agent went dark for the remainder of all tool work — the user saw nothing until the final reply arrived.

**Also fixed for free** (same turn_end signal path):
- Nested sub-agent block (foreground Task nesting) — parent feed was also cleared mid-sub-agent work
- Status-reactions done-glyph — was applied prematurely on synthetic turn_end
- Pending-work-progress surfaces — `endCurrentTurnAtomic` also clears these

## Files changed

| File | Change |
|---|---|
| `telegram-plugin/context-exhaustion.ts` | Add `ORPHANED_REPLY_MAX_REARMS = 20` constant with bound math comment |
| `telegram-plugin/gateway/gateway.ts` | PRIMARY + SECONDARY + DEFENSIVE fixes; `orphanedReplyRearmCount` field on `CurrentTurn`; import `ORPHANED_REPLY_MAX_REARMS` |
| `telegram-plugin/tests/orphaned-reply-rearm.test.ts` | 21 new unit tests (vitest) |

## Test plan

- [x] `npm run lint` — clean (tsc --noEmit + all lint scripts pass)
- [x] `npm run test:bun` — 915 pass / 2 skip / 2 pre-existing fail (vault broker token tests, unrelated)
- [x] New test file `orphaned-reply-rearm.test.ts` — 21/21 pass
- [x] Existing `context-exhaustion.test.ts` — 13/13 pass (unchanged surface)
- [x] `npm run build` — clean compile
- [ ] Telegram UAT (live MTProto) — not runnable in this environment; lint + bun test + build is the local bar per spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)