### PR TITLE
fix(gateway): unify activity-feed survival across both teardown timers (feed-survival primitive)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5224,6 +5224,11 @@ function parsePositiveMsEnv(name: string, fallbackMs: number): number {
 }
 const SILENCE_FALLBACK_MS = parsePositiveMsEnv('SWITCHROOM_SILENCE_FALLBACK_MS', 300_000)
 const SILENCE_FALLBACK_HARD_MS = parsePositiveMsEnv('SWITCHROOM_SILENCE_FALLBACK_HARD_MS', 900_000)
+// SILENCE_DEFER_INFLIGHT_TOOLS: previously an opt-in (=1). The new
+// isLegitimatelyWorking callback supersedes this — defer is now the DEFAULT
+// when the callback is wired. The legacy flag is kept so `=0` still lets
+// operators force-disable the defer (handled inside silence-poke.ts tick()).
+// The old `=1` path is kept for back-compat but is now redundant.
 const SILENCE_DEFER_INFLIGHT_TOOLS = process.env.SWITCHROOM_SILENCE_DEFER_INFLIGHT_TOOLS === '1'
 // Production-liveness (2026-06-05 UAT finding). Count an activity-feed render or
 // an answer-stream draft update as liveness for the silence clock, so a long
@@ -5232,9 +5237,55 @@ const SILENCE_DEFER_INFLIGHT_TOOLS = process.env.SWITCHROOM_SILENCE_DEFER_INFLIG
 // restores the legacy "only a real reply resets the clock" behaviour.
 const SILENCE_LIVENESS_PRODUCTION = process.env.SWITCHROOM_SILENCE_LIVENESS_PRODUCTION !== '0'
 
+/**
+ * Feed-survival predicate — the single source of truth for "is this turn
+ * legitimately working?" used by BOTH teardown timers (orphaned-reply fuse
+ * and silence-poke framework fallback).
+ *
+ * Returns true if ANY of the following hold for the given chat key:
+ *
+ *   (a) A foreground tool call is in flight in the current turn
+ *       (`toolFlightTracker.isMidToolCall()`). This covers most tools
+ *       including ask_user while it blocks awaiting a tap.
+ *
+ *   (b) Detached background work was dispatched in the current turn and has
+ *       not yet resolved — `pendingProgress.hasPendingAsyncDispatch(key)`.
+ *       Covers `Bash run_in_background:true` (which returns a near-instant
+ *       handle, emptying inFlight, while the background process keeps
+ *       running) and `Agent` / `Task` dispatches.
+ *
+ *   (c) A human-wait tool (`ask_user`) is open for this chat. A pending
+ *       ask_user IS already captured by (a) while the tool_use is in flight,
+ *       but we include the explicit pendingAskUser check for defence-in-depth
+ *       (e.g. after an unlikely inFlight clear without a tool_result).
+ *
+ * The key is `statusKey(chatId, threadId)` — the same key used by
+ * silencePoke / pendingProgress.
+ */
+function isLegitimatelyWorking(key: string): boolean {
+  // (a) foreground in-flight tool
+  if (toolFlightTracker.isMidToolCall()) return true
+  // (b) detached background work dispatched this turn
+  if (pendingProgress.hasPendingAsyncDispatch(key)) return true
+  // (c) ask_user open for this chat (defence-in-depth)
+  const { chatId: keyChatId } = parseKeyForSurvival(key)
+  for (const entry of pendingAskUser.values()) {
+    if (entry.chatId === keyChatId) return true
+  }
+  return false
+}
+
+/** Parse `<chatId>:<threadIdOrEmpty>` — mirrors silence-poke's parseKey.
+ *  Local copy so we don't need to re-export from silence-poke. */
+function parseKeyForSurvival(key: string): { chatId: string } {
+  const idx = key.indexOf(':')
+  return { chatId: idx < 0 ? key : key.slice(0, idx) }
+}
+
 silencePoke.startTimer({
   thresholdsMs: { fallback: SILENCE_FALLBACK_MS, fallbackHardCeiling: SILENCE_FALLBACK_HARD_MS },
   deferFallbackWhileToolInFlight: SILENCE_DEFER_INFLIGHT_TOOLS,
+  isLegitimatelyWorking: (key) => isLegitimatelyWorking(key),
   emitMetric: (event) => {
     // Re-emit through the unified runtime-metrics fan-out (PostHog + JSONL).
     emitRuntimeMetric(event)
@@ -9842,28 +9893,44 @@ function resetOrphanedReplyTimeout(): void {
         replyCalled: t.replyCalled,
         progressCardActive: progressDriver != null,
       })) {
-        // PRIMARY FIX: if a tool call is in flight when the fuse expires,
-        // the turn is still alive — re-arm the fuse instead of tearing down
-        // the activity feed mid-work. Without this guard, a Bash/Edit that
-        // runs for >30 s after the last text block fires a synthetic turn_end
-        // that nulls currentTurn and drops every subsequent tool_label.
+        // Feed-survival guard: re-arm the fuse while the turn is
+        // legitimately working — an in-flight tool, a detached background
+        // process (Bash run_in_background), or a human-wait tool (ask_user).
+        // This extends the original "isMidToolCall" guard to cover the
+        // detached-work cases that empty inFlight prematurely.
         //
-        // Bound: after ORPHANED_REPLY_MAX_REARMS re-arms (20 × 30 s = 10 min
-        // of genuine tool activity) we stop re-arming and let the backstop
-        // fire, so a truly wedged single long-running tool still surfaces.
-        if (toolFlightTracker.isMidToolCall()) {
-          if (t.orphanedReplyRearmCount < ORPHANED_REPLY_MAX_REARMS) {
+        // Cap logic:
+        //  • Foreground tools / detached background work: bound by
+        //    ORPHANED_REPLY_MAX_REARMS (20 × 30 s = 10 min). A genuinely
+        //    hung tool still surfaces after the cap.
+        //  • Human-wait tools (ask_user): NEVER forcibly backstop while
+        //    ask_user is open for this chat — the human simply hasn't
+        //    tapped yet. We keep re-arming unconditionally until the prompt
+        //    resolves (TTL or tap) and inFlight empties.
+        const turnKey = statusKey(t.sessionChatId, t.sessionThreadId)
+        const working = isLegitimatelyWorking(turnKey)
+        const humanWaiting = (() => {
+          for (const entry of pendingAskUser.values()) {
+            if (entry.chatId === t.sessionChatId) return true
+          }
+          return false
+        })()
+        if (working || humanWaiting) {
+          const underCap = t.orphanedReplyRearmCount < ORPHANED_REPLY_MAX_REARMS
+          if (humanWaiting || underCap) {
             t.orphanedReplyRearmCount++
             process.stderr.write(
-              `telegram gateway: orphaned-reply fuse expired mid-tool-call — re-arming` +
+              `telegram gateway: orphaned-reply fuse expired — re-arming` +
               ` (rearm ${t.orphanedReplyRearmCount}/${ORPHANED_REPLY_MAX_REARMS},` +
-              ` in_flight=${toolFlightTracker.inFlightCount()})\n`,
+              ` in_flight=${toolFlightTracker.inFlightCount()},` +
+              ` human_wait=${humanWaiting},` +
+              ` bg_work=${pendingProgress.hasPendingAsyncDispatch(turnKey)})\n`,
             )
             resetOrphanedReplyTimeout()
             return
           }
           process.stderr.write(
-            `telegram gateway: orphaned-reply rearm cap reached (${ORPHANED_REPLY_MAX_REARMS}) — forcing backstop despite in-flight tools\n`,
+            `telegram gateway: orphaned-reply rearm cap reached (${ORPHANED_REPLY_MAX_REARMS}) — forcing backstop despite working state\n`,
           )
         }
         process.stderr.write(
@@ -10786,18 +10853,26 @@ function handleSessionEvent(ev: SessionEvent): void {
     }
     case 'turn_end': {
       // DEFENSIVE FIX: belt-and-braces guard against the synthetic backstop
-      // (`durationMs: -1`) racing a real tool call. durationMs >= 0 is the
+      // (`durationMs: -1`) racing live work. durationMs >= 0 is the
       // authoritative signal from system/turn_duration; -1 is ONLY ever set
       // by the orphaned-reply backstop. Reject the synthetic event here so that
       // even if the PRIMARY fix's re-arm logic is bypassed (e.g. a very fast
-      // fire before isMidToolCall() is sampled) we still don't tear down a
-      // live feed mid-tool. Never suppresses a real turn_end (durationMs >= 0).
-      if (ev.durationMs === -1 && toolFlightTracker.isMidToolCall()) {
-        process.stderr.write(
-          `telegram gateway: synthetic turn_end suppressed — tools still in flight` +
-          ` (in_flight=${toolFlightTracker.inFlightCount()})\n`,
-        )
-        return
+      // fire before isLegitimatelyWorking() is sampled) we still don't tear
+      // down a live feed mid-work. Extended from the original isMidToolCall()
+      // check to the full isLegitimatelyWorking predicate so detached background
+      // work and human-wait tools (ask_user) are also protected.
+      // INVARIANT: a REAL turn_end (durationMs >= 0) is NEVER suppressed.
+      if (ev.durationMs === -1) {
+        const turn = currentTurn
+        const key = turn != null ? statusKey(turn.sessionChatId, turn.sessionThreadId) : ''
+        if (isLegitimatelyWorking(key)) {
+          process.stderr.write(
+            `telegram gateway: synthetic turn_end suppressed — legitimately working` +
+            ` (in_flight=${toolFlightTracker.inFlightCount()},` +
+            ` bg_work=${turn != null ? pendingProgress.hasPendingAsyncDispatch(key) : false})\n`,
+          )
+          return
+        }
       }
       // Drain any still-pending tool dispatch typing entries — covers
       // transcript truncation or a Claude Code crash mid-tool.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5263,7 +5263,12 @@ const SILENCE_LIVENESS_PRODUCTION = process.env.SWITCHROOM_SILENCE_LIVENESS_PROD
  * silencePoke / pendingProgress.
  */
 function isLegitimatelyWorking(key: string): boolean {
-  // (a) foreground in-flight tool
+  // (a) foreground in-flight tool.
+  // NOTE: toolFlightTracker is GLOBAL, not per-key. In a hypothetical
+  // multi-chat agent a tool in flight for chat A would make this return
+  // true for chat B's key. Accepted: the gateway runs one Claude session
+  // (one turn in flight at a time); true multi-chat concurrency is not
+  // currently supported. (b) and (c) below are correctly per-key.
   if (toolFlightTracker.isMidToolCall()) return true
   // (b) detached background work dispatched this turn
   if (pendingProgress.hasPendingAsyncDispatch(key)) return true

--- a/telegram-plugin/pending-work-progress.ts
+++ b/telegram-plugin/pending-work-progress.ts
@@ -285,6 +285,18 @@ export function noteTurnEnd(key: string): void {
 }
 
 /**
+ * True when the current turn for `key` dispatched async background work
+ * (Agent / Task / Bash run_in_background:true) but the turn has not yet ended
+ * with a cleared pending flag.  Used by the feed-survival predicate so the
+ * orphaned-reply backstop and silence-poke teardown are deferred while a
+ * detached background process is still running — even after inFlight empties
+ * when the near-instant tool_result (e.g. the Bash background handle) returns.
+ */
+export function hasPendingAsyncDispatch(key: string): boolean {
+  return stateByKey.get(key)?.pending === true
+}
+
+/**
  * Clear pending-progress for a chat — reasons:
  *   'inbound'   — user sent a new message, they're re-engaged
  *   'handback'  — switchroom injected a subagent_handback channel turn

--- a/telegram-plugin/silence-poke.ts
+++ b/telegram-plugin/silence-poke.ts
@@ -141,18 +141,25 @@ export interface SilencePokeDeps {
   /** Poll interval (tests). */
   pollIntervalMs?: number
   /**
-   * Fix A — when true, the 300s framework fallback is DEFERRED while a parent
-   * tool is genuinely in flight (`inFlightTools` non-empty): the agent is
-   * demonstrably working, and since #2162 the live activity feed shows that
-   * work, so nulling `currentTurn` (which the fallback does) would darken a feed
-   * the user is actively watching. The defer is bounded by
-   * `thresholdsMs.fallbackHardCeiling` so a hung-mid-tool turn still unwedges; a
-   * turn with NO in-flight tool fires at the base threshold exactly as before.
-   * Default false (legacy behaviour) — enable per-agent to canary.
+   * Feed-survival predicate callback. When provided, the 300s framework
+   * fallback is DEFERRED while this function returns true: the agent is
+   * demonstrably working (in-flight tool, detached background process, or a
+   * human-wait tool like ask_user), and since #2162 the live activity feed
+   * shows that work, so nulling `currentTurn` would darken a feed the user is
+   * actively watching. The defer is bounded by `thresholdsMs.fallbackHardCeiling`
+   * so a hung-or-missing-work-signal turn still unwedges eventually.
    *
-   * A crashed agent is recovered independently by the bridge-disconnect sweep
-   * (`onDanglingTurnsSwept`), so deferring here does not reintroduce the #1556
-   * dangling-turn wedge for the crash case.
+   * This supersedes `deferFallbackWhileToolInFlight`. When present it is ALWAYS
+   * consulted (no extra env flag required). Set SWITCHROOM_SILENCE_DEFER_INFLIGHT_TOOLS=0
+   * in the environment to force-disable the defer even when this callback is wired.
+   */
+  isLegitimatelyWorking?: (key: string) => boolean
+  /**
+   * Legacy boolean flag — honoured when `isLegitimatelyWorking` is absent.
+   * When true, the 300s fallback is deferred while `inFlightTools` is non-empty,
+   * bounded by `thresholdsMs.fallbackHardCeiling`.
+   * @deprecated Prefer `isLegitimatelyWorking` which covers detached work and
+   * human-wait tools in addition to foreground in-flight tool calls.
    */
   deferFallbackWhileToolInFlight?: boolean
 }
@@ -424,19 +431,34 @@ function tick(now: number): void {
     if (silence < 0) continue
 
     if (!s.fallbackFired && silence >= thresholds.fallback) {
-      // Fix A: defer the unwedge while a parent tool is genuinely in flight —
-      // the agent is demonstrably working and the live activity feed is showing
-      // it, so firing here (which nulls currentTurn) would darken that feed
-      // mid-work. Bounded by the hard ceiling so a hung-mid-tool turn still
-      // unwedges. `continue` WITHOUT setting fallbackFired so the next tick
-      // re-checks — once the tool ends and the turn stays silent past the base
-      // threshold, or the ceiling is crossed, it fires normally.
-      if (
-        activeDeps.deferFallbackWhileToolInFlight === true &&
-        s.inFlightTools.size > 0 &&
-        silence < (thresholds.fallbackHardCeiling ?? Number.POSITIVE_INFINITY)
-      ) {
-        continue
+      // Feed-survival defer: hold back the unwedge while the agent is
+      // demonstrably working — an in-flight tool, a detached background process,
+      // or a human-wait tool (ask_user). Since #2162 the live activity feed
+      // renders that work, so nulling currentTurn would darken a feed the user
+      // is actively watching. Bounded by fallbackHardCeiling so a
+      // hung-or-leaked-signal turn still unwedges eventually.
+      //
+      // Two defer paths (tried in priority order):
+      //   1. `isLegitimatelyWorking(key)` — new single source of truth covering
+      //      foreground in-flight tools, detached background work, and human-wait
+      //      tools. Active by default when the callback is wired; force-disabled
+      //      by SWITCHROOM_SILENCE_DEFER_INFLIGHT_TOOLS=0.
+      //   2. Legacy `deferFallbackWhileToolInFlight` boolean — covers only
+      //      `inFlightTools.size > 0`; kept for test fixtures that set it
+      //      directly without wiring the callback.
+      //
+      // In both cases: `continue` WITHOUT setting fallbackFired so the next
+      // tick re-checks. Once the work signal clears and the turn stays silent
+      // past the base threshold, or the ceiling is crossed, the fallback fires.
+      const ceiling = thresholds.fallbackHardCeiling ?? Number.POSITIVE_INFINITY
+      const underCeiling = silence < ceiling
+      if (underCeiling) {
+        const forceDisable = process.env.SWITCHROOM_SILENCE_DEFER_INFLIGHT_TOOLS === '0'
+        if (!forceDisable && activeDeps.isLegitimatelyWorking != null) {
+          if (activeDeps.isLegitimatelyWorking(key)) continue
+        } else if (!forceDisable && activeDeps.deferFallbackWhileToolInFlight === true && s.inFlightTools.size > 0) {
+          continue
+        }
       }
       s.fallbackFired = true
       const { chatId, threadId } = parseKey(key)

--- a/telegram-plugin/tests/feed-survival.test.ts
+++ b/telegram-plugin/tests/feed-survival.test.ts
@@ -36,6 +36,7 @@ import {
 import {
   noteAsyncDispatch,
   hasPendingAsyncDispatch,
+  noteOutbound as ppNoteOutbound,
   noteTurnEnd as ppNoteTurnEnd,
   startTurn as ppStartTurn,
   clearPending,
@@ -124,6 +125,20 @@ describe('hasPendingAsyncDispatch', () => {
     ppNoteTurnEnd('chat:0')
     expect(hasPendingAsyncDispatch('chat:0')).toBe(false)
   })
+
+  it('cross-turn: dispatch + outbound anchor + turn-end → pending PERSISTS (the core feed-survival path)', () => {
+    // The critical production scenario: the agent dispatches detached
+    // background work (run_in_background Bash / Agent / Task), posts a reply
+    // (capturing an anchor), and the turn ends — but the bg work is still
+    // running. pending+anchor at turn_end activates rather than deletes, so
+    // hasPendingAsyncDispatch stays true and both teardown timers keep
+    // deferring while the detached work runs.
+    ppStartTurn('chat:0')
+    noteAsyncDispatch('chat:0')
+    ppNoteOutbound('chat:0', { messageId: 4242, text: 'kicked off the build, polling…', parseMode: 'HTML' })
+    ppNoteTurnEnd('chat:0')
+    expect(hasPendingAsyncDispatch('chat:0')).toBe(true)
+  })
 })
 
 // ─── Silence-poke: isLegitimatelyWorking callback defer ──────────────────────
@@ -170,7 +185,7 @@ describe('silence-poke — isLegitimatelyWorking callback (default-on defer)', (
     expect(f.fallbacks).toHaveLength(1) // bounded — still unwedges
   })
 
-  it('callback takes priority over legacy deferFallbackWhileToolInFlight (both set)', () => {
+  it('wired callback returns false → fallback fires even with inFlightTools non-empty (callback supersedes legacy flag)', () => {
     // When isLegitimatelyWorking is wired, it is consulted; the legacy flag
     // is not consulted for the new path. Verify by having callback=false and
     // inFlightTools non-empty — the fallback fires because the callback says "no".

--- a/telegram-plugin/tests/feed-survival.test.ts
+++ b/telegram-plugin/tests/feed-survival.test.ts
@@ -1,0 +1,511 @@
+/**
+ * feed-survival.test.ts — unit tests for the feed-survival primitive.
+ *
+ * Tests the three gaps identified in the audit:
+ *
+ *   Gap 1 — detached background work (Bash run_in_background, Agent/Task)
+ *            empties inFlight on near-instant tool_result, but the work is
+ *            still running. Both orphaned-reply timer and silence-poke must
+ *            not tear down the feed while hasPendingAsyncDispatch is true.
+ *
+ *   Gap 2 — silence-poke defer was gated on SWITCHROOM_SILENCE_DEFER_INFLIGHT_TOOLS=1
+ *            (default OFF). The new isLegitimatelyWorking callback makes the
+ *            defer the DEFAULT when wired, without requiring the env var.
+ *
+ *   Gap 3 — ask_user with TTL >10min hit ORPHANED_REPLY_MAX_REARMS and was
+ *            force-closed mid-human-wait. Now exempt from the cap.
+ *
+ * Regression: a truly idle turn (no work) still backstops/tears down as before.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  startTurn,
+  noteOutbound,
+  noteToolStart,
+  noteToolEnd,
+  endTurn,
+  __tickForTests,
+  __setDepsForTests,
+  __getStateForTests,
+  __resetAllForTests,
+  DEFAULT_THRESHOLDS,
+  type SilencePokeMetric,
+  type FrameworkFallbackContext,
+} from '../silence-poke.js'
+import {
+  noteAsyncDispatch,
+  hasPendingAsyncDispatch,
+  noteTurnEnd as ppNoteTurnEnd,
+  startTurn as ppStartTurn,
+  clearPending,
+  __resetAllForTests as ppReset,
+  __setDepsForTests as ppSetDeps,
+} from '../pending-work-progress.js'
+import { ToolFlightTracker } from '../gateway/interrupt-defer.js'
+import {
+  ORPHANED_REPLY_TIMEOUT_MS,
+  ORPHANED_REPLY_MAX_REARMS,
+} from '../context-exhaustion.js'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+interface SilenceFixtures {
+  emitted: SilencePokeMetric[]
+  fallbacks: FrameworkFallbackContext[]
+}
+
+function setupSilenceDeps(opts?: {
+  thresholds?: Partial<typeof DEFAULT_THRESHOLDS> & { fallbackHardCeiling?: number }
+  isLegitimatelyWorking?: (key: string) => boolean
+}): SilenceFixtures {
+  const fixtures: SilenceFixtures = { emitted: [], fallbacks: [] }
+  __setDepsForTests({
+    emitMetric: (e) => fixtures.emitted.push(e),
+    onFrameworkFallback: (ctx) => { fixtures.fallbacks.push(ctx) },
+    thresholdsMs: {
+      ...DEFAULT_THRESHOLDS,
+      ...(opts?.thresholds ?? {}),
+    },
+    ...(opts?.isLegitimatelyWorking != null
+      ? { isLegitimatelyWorking: opts.isLegitimatelyWorking }
+      : {}),
+  })
+  return fixtures
+}
+
+beforeEach(() => {
+  __resetAllForTests()
+  ppReset()
+})
+
+afterEach(() => {
+  __resetAllForTests()
+  ppReset()
+  delete process.env.SWITCHROOM_SILENCE_DEFER_INFLIGHT_TOOLS
+})
+
+// ─── hasPendingAsyncDispatch ──────────────────────────────────────────────────
+
+describe('hasPendingAsyncDispatch', () => {
+  beforeEach(() => {
+    ppSetDeps({
+      editMessage: async () => {},
+    })
+  })
+
+  it('returns false before any dispatch is noted', () => {
+    ppStartTurn('chat:0')
+    expect(hasPendingAsyncDispatch('chat:0')).toBe(false)
+  })
+
+  it('returns true after noteAsyncDispatch (Bash run_in_background / Agent / Task)', () => {
+    ppStartTurn('chat:0')
+    noteAsyncDispatch('chat:0')
+    expect(hasPendingAsyncDispatch('chat:0')).toBe(true)
+  })
+
+  it('returns false after clearPending (inbound clears the flag)', () => {
+    ppStartTurn('chat:0')
+    noteAsyncDispatch('chat:0')
+    clearPending('chat:0', 'inbound')
+    expect(hasPendingAsyncDispatch('chat:0')).toBe(false)
+  })
+
+  it('returns false for an unknown key', () => {
+    expect(hasPendingAsyncDispatch('never-started')).toBe(false)
+  })
+
+  it('returns true during active turn after dispatch, false after turn-end clears', () => {
+    ppStartTurn('chat:0')
+    noteAsyncDispatch('chat:0')
+    expect(hasPendingAsyncDispatch('chat:0')).toBe(true)
+    // Turn ends with pending+no-anchor → state is deleted
+    ppNoteTurnEnd('chat:0')
+    expect(hasPendingAsyncDispatch('chat:0')).toBe(false)
+  })
+})
+
+// ─── Silence-poke: isLegitimatelyWorking callback defer ──────────────────────
+
+describe('silence-poke — isLegitimatelyWorking callback (default-on defer)', () => {
+  it('defers the 300s fallback when the callback returns true', () => {
+    let working = true
+    const f = setupSilenceDeps({
+      thresholds: { fallback: 300_000, fallbackHardCeiling: 900_000 },
+      isLegitimatelyWorking: () => working,
+    })
+    startTurn('chat:0', 0)
+    __tickForTests(300_000) // would fire without the callback
+    expect(f.fallbacks).toHaveLength(0)
+
+    __tickForTests(500_000) // still working
+    expect(f.fallbacks).toHaveLength(0)
+
+    working = false // work done
+    __tickForTests(500_001) // silence was already past threshold
+    expect(f.fallbacks).toHaveLength(1)
+  })
+
+  it('does NOT defer when the callback returns false (genuinely idle turn)', () => {
+    const f = setupSilenceDeps({
+      thresholds: { fallback: 300_000, fallbackHardCeiling: 900_000 },
+      isLegitimatelyWorking: () => false,
+    })
+    startTurn('chat:0', 0)
+    __tickForTests(300_000)
+    // Idle turn: no work, fallback fires immediately
+    expect(f.fallbacks).toHaveLength(1)
+  })
+
+  it('fires at the hard ceiling even when callback keeps returning true (hung-signal)', () => {
+    const f = setupSilenceDeps({
+      thresholds: { fallback: 300_000, fallbackHardCeiling: 900_000 },
+      isLegitimatelyWorking: () => true, // signal never clears
+    })
+    startTurn('chat:0', 0)
+    __tickForTests(300_000)
+    expect(f.fallbacks).toHaveLength(0) // deferred
+    __tickForTests(900_000) // crosses ceiling
+    expect(f.fallbacks).toHaveLength(1) // bounded — still unwedges
+  })
+
+  it('callback takes priority over legacy deferFallbackWhileToolInFlight (both set)', () => {
+    // When isLegitimatelyWorking is wired, it is consulted; the legacy flag
+    // is not consulted for the new path. Verify by having callback=false and
+    // inFlightTools non-empty — the fallback fires because the callback says "no".
+    const f = setupSilenceDeps({
+      thresholds: { fallback: 300_000, fallbackHardCeiling: 900_000 },
+      isLegitimatelyWorking: () => false,
+    })
+    startTurn('chat:0', 0)
+    noteToolStart('chat:0', 't1', 'Bash', 'audit', 10_000)
+    __tickForTests(300_000)
+    // callback says false → no defer, fallback fires
+    expect(f.fallbacks).toHaveLength(1)
+  })
+
+  it('SWITCHROOM_SILENCE_DEFER_INFLIGHT_TOOLS=0 force-disables the defer even with callback wired', () => {
+    process.env.SWITCHROOM_SILENCE_DEFER_INFLIGHT_TOOLS = '0'
+    const f = setupSilenceDeps({
+      thresholds: { fallback: 300_000, fallbackHardCeiling: 900_000 },
+      isLegitimatelyWorking: () => true,
+    })
+    startTurn('chat:0', 0)
+    __tickForTests(300_000)
+    expect(f.fallbacks).toHaveLength(1) // force-disabled: fallback fires
+  })
+})
+
+// ─── Silence-poke: detached background work (Gap 1) ──────────────────────────
+
+describe('silence-poke — detached Bash run_in_background keeps feed alive', () => {
+  beforeEach(() => {
+    ppSetDeps({ editMessage: async () => {} })
+  })
+
+  it('defers the 300s fallback while hasPendingAsyncDispatch is true', () => {
+    // Simulate: model calls Bash(run_in_background:true), gets back instant
+    // handle (tool_result), turn ends, but background process is running.
+    // pendingProgress.pending stays true.
+    ppStartTurn('chat:0')
+    noteAsyncDispatch('chat:0') // Bash dispatched
+
+    const f = setupSilenceDeps({
+      thresholds: { fallback: 300_000, fallbackHardCeiling: 900_000 },
+      isLegitimatelyWorking: (key) => hasPendingAsyncDispatch(key),
+    })
+    startTurn('chat:0', 0)
+    __tickForTests(300_000) // inFlight is empty but bg work is pending
+    expect(f.fallbacks).toHaveLength(0)
+
+    __tickForTests(500_000) // still pending
+    expect(f.fallbacks).toHaveLength(0)
+
+    // Background work completes: pendingProgress cleared
+    clearPending('chat:0', 'inbound')
+    __tickForTests(500_001)
+    expect(f.fallbacks).toHaveLength(1) // now fires
+  })
+
+  it('a truly idle turn (no background work, no tool in flight) still fires at 300s', () => {
+    const f = setupSilenceDeps({
+      thresholds: { fallback: 300_000, fallbackHardCeiling: 900_000 },
+      isLegitimatelyWorking: (key) => hasPendingAsyncDispatch(key),
+    })
+    startTurn('chat:0', 0)
+    __tickForTests(300_000)
+    expect(f.fallbacks).toHaveLength(1) // no work: still backstops
+  })
+})
+
+// ─── Orphaned-reply: ask_user exemption from ORPHANED_REPLY_MAX_REARMS ───────
+
+/**
+ * Pure decision functions mirroring the orphaned-reply guard logic in gateway.ts.
+ * Extracted so the ask_user-exempt path can be tested without the full gateway.
+ */
+function shouldRearmOrphanedReply(opts: {
+  isLegitimatelyWorking: boolean
+  humanWaiting: boolean
+  rearmCount: number
+  maxRearms: number
+}): 'rearm' | 'fire' {
+  const { isLegitimatelyWorking: working, humanWaiting, rearmCount, maxRearms } = opts
+  if (working || humanWaiting) {
+    // ask_user: exempt from cap — keep re-arming as long as human-wait is open
+    if (humanWaiting) return 'rearm'
+    // Other work: honour cap
+    if (rearmCount < maxRearms) return 'rearm'
+    // Cap exceeded: fire backstop (a genuinely hung tool must surface)
+    return 'fire'
+  }
+  return 'fire'
+}
+
+describe('orphaned-reply: ask_user exempt from ORPHANED_REPLY_MAX_REARMS', () => {
+  it('re-arms indefinitely while ask_user is open (humanWaiting=true)', () => {
+    // Even at count === ORPHANED_REPLY_MAX_REARMS, humanWaiting=true → still rearms
+    for (let i = 0; i <= ORPHANED_REPLY_MAX_REARMS + 5; i++) {
+      expect(shouldRearmOrphanedReply({
+        isLegitimatelyWorking: false,
+        humanWaiting: true,
+        rearmCount: i,
+        maxRearms: ORPHANED_REPLY_MAX_REARMS,
+      })).toBe('rearm')
+    }
+  })
+
+  it('fires once ask_user closes (humanWaiting=false, no other work)', () => {
+    expect(shouldRearmOrphanedReply({
+      isLegitimatelyWorking: false,
+      humanWaiting: false,
+      rearmCount: 0,
+      maxRearms: ORPHANED_REPLY_MAX_REARMS,
+    })).toBe('fire')
+  })
+
+  it('standard foreground tool: still bound by ORPHANED_REPLY_MAX_REARMS', () => {
+    // Under cap: rearm
+    expect(shouldRearmOrphanedReply({
+      isLegitimatelyWorking: true,
+      humanWaiting: false,
+      rearmCount: ORPHANED_REPLY_MAX_REARMS - 1,
+      maxRearms: ORPHANED_REPLY_MAX_REARMS,
+    })).toBe('rearm')
+    // At cap: fire
+    expect(shouldRearmOrphanedReply({
+      isLegitimatelyWorking: true,
+      humanWaiting: false,
+      rearmCount: ORPHANED_REPLY_MAX_REARMS,
+      maxRearms: ORPHANED_REPLY_MAX_REARMS,
+    })).toBe('fire')
+  })
+
+  it('ask_user combined with other work: cap still bypassed (humanWaiting wins)', () => {
+    expect(shouldRearmOrphanedReply({
+      isLegitimatelyWorking: true,
+      humanWaiting: true,
+      rearmCount: ORPHANED_REPLY_MAX_REARMS + 100,
+      maxRearms: ORPHANED_REPLY_MAX_REARMS,
+    })).toBe('rearm')
+  })
+})
+
+// ─── Orphaned-reply: detached work (Gap 1) ───────────────────────────────────
+
+describe('orphaned-reply: detached background work keeps feed alive past 30s', () => {
+  it('re-arms while isLegitimatelyWorking=true (bg work in flight)', () => {
+    // Mirrors the gateway guard logic
+    function rearmDecision(working: boolean, humanWaiting: boolean, count: number): 'rearm' | 'fire' {
+      return shouldRearmOrphanedReply({
+        isLegitimatelyWorking: working,
+        humanWaiting,
+        rearmCount: count,
+        maxRearms: ORPHANED_REPLY_MAX_REARMS,
+      })
+    }
+
+    // Bash run_in_background: inFlight empty, hasPendingAsyncDispatch=true
+    expect(rearmDecision(true, false, 0)).toBe('rearm')
+    expect(rearmDecision(true, false, ORPHANED_REPLY_MAX_REARMS - 1)).toBe('rearm')
+    // Cap hit: fire (the bg process must have been stuck for 10min+)
+    expect(rearmDecision(true, false, ORPHANED_REPLY_MAX_REARMS)).toBe('fire')
+  })
+
+  it('fires immediately when no work at all (truly idle turn)', () => {
+    expect(shouldRearmOrphanedReply({
+      isLegitimatelyWorking: false,
+      humanWaiting: false,
+      rearmCount: 0,
+      maxRearms: ORPHANED_REPLY_MAX_REARMS,
+    })).toBe('fire')
+  })
+})
+
+// ─── Synthetic turn_end suppressor with isLegitimatelyWorking ─────────────────
+
+/**
+ * Mirrors the DEFENSIVE FIX in gateway.ts turn_end handler.
+ * Now uses isLegitimatelyWorking instead of just isMidToolCall().
+ */
+function shouldSuppressSyntheticTurnEnd(opts: {
+  durationMs: number
+  isLegitimatelyWorking: boolean
+}): boolean {
+  return opts.durationMs === -1 && opts.isLegitimatelyWorking
+}
+
+describe('DEFENSIVE FIX: synthetic turn_end suppressor (extended predicate)', () => {
+  it('suppresses when durationMs=-1 and bg work is pending (detached Bash)', () => {
+    expect(shouldSuppressSyntheticTurnEnd({
+      durationMs: -1,
+      isLegitimatelyWorking: true, // hasPendingAsyncDispatch returned true
+    })).toBe(true)
+  })
+
+  it('suppresses when durationMs=-1 and ask_user is open (human-wait)', () => {
+    expect(shouldSuppressSyntheticTurnEnd({
+      durationMs: -1,
+      isLegitimatelyWorking: true, // pendingAskUser has entry for chat
+    })).toBe(true)
+  })
+
+  it('does NOT suppress when durationMs=-1 but no work (genuinely idle)', () => {
+    expect(shouldSuppressSyntheticTurnEnd({
+      durationMs: -1,
+      isLegitimatelyWorking: false,
+    })).toBe(false)
+  })
+
+  it('does NOT suppress a REAL turn_end (durationMs >= 0)', () => {
+    expect(shouldSuppressSyntheticTurnEnd({ durationMs: 0, isLegitimatelyWorking: true })).toBe(false)
+    expect(shouldSuppressSyntheticTurnEnd({ durationMs: 1, isLegitimatelyWorking: true })).toBe(false)
+    expect(shouldSuppressSyntheticTurnEnd({ durationMs: 12345, isLegitimatelyWorking: true })).toBe(false)
+    expect(shouldSuppressSyntheticTurnEnd({ durationMs: 0, isLegitimatelyWorking: false })).toBe(false)
+  })
+
+  it('only durationMs === -1 is the synthetic discriminator (near-miss values)', () => {
+    expect(shouldSuppressSyntheticTurnEnd({ durationMs: -2, isLegitimatelyWorking: true })).toBe(false)
+    expect(shouldSuppressSyntheticTurnEnd({ durationMs: -0.5, isLegitimatelyWorking: true })).toBe(false)
+  })
+})
+
+// ─── Regression: idle turns still backstop as before ─────────────────────────
+
+describe('REGRESSION: idle turn (no work) still backstops', () => {
+  it('silence-poke fires at 300s for a genuinely idle turn (callback wired)', () => {
+    const f = setupSilenceDeps({
+      thresholds: { fallback: 300_000, fallbackHardCeiling: 900_000 },
+      isLegitimatelyWorking: () => false, // nothing working
+    })
+    startTurn('chat:0', 0)
+    __tickForTests(300_000)
+    expect(f.fallbacks).toHaveLength(1)
+  })
+
+  it('silence-poke fires at 300s for an idle turn (no callback, no legacy defer)', () => {
+    const f = setupSilenceDeps() // nothing wired
+    startTurn('chat:0', 0)
+    __tickForTests(300_000)
+    expect(f.fallbacks).toHaveLength(1)
+  })
+
+  it('orphaned-reply fires for an idle turn (no work, no human wait)', () => {
+    expect(shouldRearmOrphanedReply({
+      isLegitimatelyWorking: false,
+      humanWaiting: false,
+      rearmCount: 0,
+      maxRearms: ORPHANED_REPLY_MAX_REARMS,
+    })).toBe('fire')
+  })
+
+  it('ToolFlightTracker empty → not legitimately working via isMidToolCall', () => {
+    const tracker = new ToolFlightTracker()
+    expect(tracker.isMidToolCall()).toBe(false)
+  })
+
+  it('ToolFlightTracker with tool in flight → legitimately working', () => {
+    const tracker = new ToolFlightTracker()
+    tracker.onEvent({ kind: 'tool_use', toolUseId: 'bg-bash' })
+    expect(tracker.isMidToolCall()).toBe(true)
+    // After tool_result (instant handle return for run_in_background):
+    tracker.onEvent({ kind: 'tool_result', toolUseId: 'bg-bash' })
+    expect(tracker.isMidToolCall()).toBe(false)
+    // But hasPendingAsyncDispatch should still signal the bg work is running
+  })
+})
+
+// ─── Combined: isLegitimatelyWorking integrates all three signals ─────────────
+
+describe('isLegitimatelyWorking — all three signals', () => {
+  beforeEach(() => {
+    ppSetDeps({ editMessage: async () => {} })
+  })
+
+  it('true when only isMidToolCall (foreground tool)', () => {
+    const tracker = new ToolFlightTracker()
+    tracker.onEvent({ kind: 'tool_use', toolUseId: 't1' })
+    // Simulate the predicate
+    const working = tracker.isMidToolCall() || hasPendingAsyncDispatch('chat:0') || false
+    expect(working).toBe(true)
+  })
+
+  it('true when only hasPendingAsyncDispatch (Bash run_in_background)', () => {
+    const tracker = new ToolFlightTracker()
+    // tool_use fired then instantly tool_result came back
+    tracker.onEvent({ kind: 'tool_use', toolUseId: 'bash1' })
+    tracker.onEvent({ kind: 'tool_result', toolUseId: 'bash1' })
+    ppStartTurn('chat:0')
+    noteAsyncDispatch('chat:0')
+    const working = tracker.isMidToolCall() || hasPendingAsyncDispatch('chat:0') || false
+    expect(tracker.isMidToolCall()).toBe(false) // inFlight cleared
+    expect(hasPendingAsyncDispatch('chat:0')).toBe(true) // bg work pending
+    expect(working).toBe(true)
+  })
+
+  it('true when only human-wait (ask_user open)', () => {
+    const tracker = new ToolFlightTracker()
+    // ask_user tool_use is in inFlight while waiting; here we simulate
+    // the defence-in-depth path where inFlight was cleared unexpectedly
+    const askUserInFlight = true // pendingAskUser.size > 0 for this chat
+    const working = tracker.isMidToolCall() || hasPendingAsyncDispatch('chat:0') || askUserInFlight
+    expect(working).toBe(true)
+  })
+
+  it('false when all three signals are clear (genuinely idle)', () => {
+    const tracker = new ToolFlightTracker()
+    const working = tracker.isMidToolCall() || hasPendingAsyncDispatch('chat:0') || false
+    expect(working).toBe(false)
+  })
+})
+
+// ─── Silence-poke: hard ceiling is correctly applied ─────────────────────────
+
+describe('silence-poke — hard ceiling bounds the defer', () => {
+  it('fires at ceiling even when isLegitimatelyWorking stays true (leak-guard)', () => {
+    const f = setupSilenceDeps({
+      thresholds: { fallback: 300_000, fallbackHardCeiling: 600_000 },
+      isLegitimatelyWorking: () => true, // signal never clears
+    })
+    startTurn('chat:0', 0)
+    __tickForTests(300_000)
+    expect(f.fallbacks).toHaveLength(0)
+    __tickForTests(599_000)
+    expect(f.fallbacks).toHaveLength(0)
+    __tickForTests(600_000) // at ceiling
+    expect(f.fallbacks).toHaveLength(1)
+  })
+
+  it('fallbackFired is true after ceiling fire (no double-fire)', () => {
+    const f = setupSilenceDeps({
+      thresholds: { fallback: 300_000, fallbackHardCeiling: 600_000 },
+      isLegitimatelyWorking: () => true,
+    })
+    startTurn('chat:0', 0)
+    __tickForTests(600_000)
+    __tickForTests(700_000) // additional tick after ceiling
+    expect(f.fallbacks).toHaveLength(1) // only fires once
+    expect(__getStateForTests('chat:0')!.fallbackFired).toBe(true)
+  })
+})


### PR DESCRIPTION
## Problem

#2519 hardened the **orphaned-reply** fuse so it re-arms while a top-level tool is in flight. A full audit (10 execution shapes, adversarially verified + corroborated against ~75 min of live fleet logs) found that wasn't enough for a durable primitive:

1. **Two independent teardown timers exist; #2519 only hardened one.** The **silence-poke framework fallback** (`silence-poke.ts`) tears the activity lane after 5 min of *output silence*, gated purely on a silence clock — not on whether work is in flight. `SWITCHROOM_SILENCE_DEFER_INFLIGHT_TOOLS` defaulted off, so a busy-but-quiet turn got torn down regardless of #2519.
2. **Detached work is invisible to both guards.** A `Bash(run_in_background:true)` launch (and background workers / detached workflow agents) returns its handle as a near-instant `tool_result`, so `inFlight` empties while the work runs → fuse fires in the poll gap.
3. **`ask_user` >10min TTL** hit `ORPHANED_REPLY_MAX_REARMS` (20×30s=10min) and force-closed mid-human-wait.

Foreground sub-agents (incl. researcher/reviewer/Explore, and **nested depth ≥2**) are already covered: the parent's `Task` tool_use stays in `inFlight` for the whole wait. Confirmed in code + in prod (marko: 26 successful re-arms kept its feed alive).

## Fix — one shared predicate, fed into both timers

`isLegitimatelyWorking(key)` = `toolFlightTracker.isMidToolCall()` OR `hasPendingAsyncDispatch(key)` (detached bg work latched until completion) OR an `ask_user` parked for the chat.

- **Orphaned-reply re-arm guard** and **synthetic-turn_end reject** now consult the predicate, not bare `isMidToolCall()`. A real `turn_end` (`durationMs >= 0`) is still **never** suppressed.
- **silence-poke fallback** defers on the predicate by default (env override `SWITCHROOM_SILENCE_DEFER_INFLIGHT_TOOLS=0` still force-disables), bounded by the existing `fallbackHardCeiling` so a genuinely wedged turn still surfaces.
- **`ask_user`** is exempt from the rearm cap (keep re-arming while the human-wait tool is parked).

## Tests

New `feed-survival.test.ts` (+ extends orphaned-reply-rearm / silence-poke suites), incl. **regression: a truly idle turn still backstops at 300s** (turns are not made immortal). vitest + bun both green on touched files; lint/tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)