### PR TITLE
chore: bump Claude Code CLI pin 2.1.177 → 2.1.185

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -154,7 +154,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # (`--build-arg CLAUDE_CODE_VERSION=<latest>`) to build a throwaway image on the
 # next version and prove it boots BEFORE the pin is bumped. Keep this default in
 # lockstep with docker/Dockerfile.hindsight's CLAUDE_CODE_VERSION (#1978).
-ARG CLAUDE_CODE_VERSION=2.1.177
+ARG CLAUDE_CODE_VERSION=2.1.185
 # Fail-fast: if the npm install or the resulting binary is broken we
 # want the image build to die here, not produce a base that ships
 # downstream and explodes at agent boot. Previously this had a

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -51,7 +51,7 @@ USER root
 # claude bundle as the agent containers — a version skew here could reintroduce
 # the thinking-block / thinking-effort class of failures on memory reflection
 # (see #1978). The canary overrides it the same way base does.
-ARG CLAUDE_CODE_VERSION=2.1.177
+ARG CLAUDE_CODE_VERSION=2.1.185
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
  && claude --version >&2
 


### PR DESCRIPTION
## What changed

Bumped the `CLAUDE_CODE_VERSION` build-arg default in two Dockerfiles (kept in lockstep per #1978):

| File | Change |
|---|---|
| `docker/Dockerfile.base` | `ARG CLAUDE_CODE_VERSION=2.1.177` → `2.1.185` |
| `docker/Dockerfile.hindsight` | `ARG CLAUDE_CODE_VERSION=2.1.177` → `2.1.185` |

No other references were canonical version pins. Three other occurrences were left intentionally unchanged (historical changelog prose, a test comment, and a tool-filter comment — none are version-controlling the build).

## Why

Pick up Anthropic's safety and behaviour fixes shipped between 2.1.177 and 2.1.185:

- **2.1.183 auto-mode safety gate** — blocks destructive git operations in auto mode without explicit confirmation: `reset --hard`, `clean -fd`, unrequested `commit --amend`, and terraform/pulumi/cdk `destroy`. This is the most significant behaviour change to flag.
- Various stability and bug fixes through 2.1.185.
- Versions 178, 180, 182, 184 were never published to npm — expected; 2.1.185 is the latest published stable (`npm view @anthropic-ai/claude-code@2.1.185 version` → `2.1.185`).

## Behaviour change to flag

**2.1.183 blocks destructive git in auto mode.** Specifically, `reset --hard`, `clean -fd`, unrequested `commit --amend`, and terraform/pulumi/cdk `destroy` no longer execute without explicit user confirmation when the CLI is running in auto mode. This affects the fleet agents running `claude` headlessly — they will surface a permission prompt rather than silently executing these destructive operations. This is the intended safety behaviour from Anthropic.

## JTBD / vision alignment

Subscription-honest / always-on (vision.md pillar 3 + 4). The fleet runs the unmodified `claude` CLI 24/7; keeping it current on Anthropic's published safety fixes is a core operational responsibility. This change is a straight version pin bump — no switchroom code changes, no new features, no behaviour changes to switchroom itself.

## Validation

- **`npm run lint`** (tsc --noEmit + 8 check scripts): **clean**
- **`npm test`** (vitest + bun test): 10,686 tests pass; 79 pre-existing infrastructure failures (require a live docker daemon / bun compile artefact / network contract test) — confirmed pre-existing on unmodified `main`, unrelated to this diff.
- **`npm view @anthropic-ai/claude-code@2.1.185 version`** → `2.1.185` (published)
- **CI docker-build jobs** (`build-base`, `build-hindsight`, `build-dependents ×5`) are the real validation that 2.1.185 installs cleanly into all 6 images — local can't replicate the full image build. These are the required gating checks for this PR.

## Test plan

- [ ] CI `lint` check passes
- [ ] CI `bun-test` and `vitest` checks pass
- [ ] CI `build-base` passes (verifies `npm install -g @anthropic-ai/claude-code@2.1.185` succeeds in the base image)
- [ ] CI `build-hindsight` passes (same, for the hindsight image)
- [ ] CI `build-dependents` (×5) passes (agent, broker, kernel, auth-broker, hostd — all inherit from base)
- [ ] Canary on `test-harness` after merge + tag: `switchroom update --pin vX.Y.Z`, tail gateway log, observe ≥1 real DM round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)