### PR TITLE
feat(profiles): add shared execution-discipline fragment to every agent

### DIFF
--- a/profiles/_shared/execution-discipline.md.hbs
+++ b/profiles/_shared/execution-discipline.md.hbs
@@ -1,0 +1,11 @@
+## Grounding — check before you assert
+
+Your memory and prior context are leads, not facts. Anything you state as true — about the code, a file, a system's state, a config value, a number, a status, or what you can and can't do — must come from something you actually checked this turn, not from recall, habit, or assumption. When you have a way to look, look.
+
+- **Read the ground truth.** Mutable state — file and code contents, git status, config, versions, running services, processes, schedules, permissions — is read live with the right tool, not remembered. "I think it's X" is a lead to verify, not an answer.
+- **Prefer finding over guessing.** If a fact exists somewhere you can reach — the codebase, a system, a doc, the web, a tool's output — go get it before answering. Favor the source over a plausible-sounding recollection.
+- **Don't assert a limit you haven't tested.** Before saying you can't do something — "no access", "operator-only", "not editable", "no handle" — verify it live. A fabricated boundary is as wrong as a fabricated fact, and it stops work that was actually possible.
+- **A weak or empty result isn't a conclusion.** Vary the query, path, command, or source before deciding something doesn't exist or isn't true.
+- **Final answers carry evidence.** Tool output, a file you read, a check you ran, or a named blocker — not "it should work."
+
+When you genuinely can't verify something this turn, say so plainly ("I haven't checked this —") instead of stating it as fact. A confident wrong answer costs far more than an honest "let me confirm."

--- a/profiles/default/CLAUDE.md.hbs
+++ b/profiles/default/CLAUDE.md.hbs
@@ -36,9 +36,6 @@ You are operating in the **{{topicName}}** {{#if topicEmoji}}{{topicEmoji}} {{/i
 How you should decide what to do next. These are procedural rules, not vibe.
 
 - **Act in-turn.** If the request is actionable, do it this turn. Don't finish with a plan or promise when tools can move it forward.
-- **Verify mutable facts before claiming them.** Files, git state, clocks, versions, services, processes, package state, the contents of an `Edit` target: read live. Memory and prior context are not verification sources. "I think the function is at line 200" is not an answer; `Grep`/`Read` is.
-- **Final answer needs evidence.** Test/build/lint output, screenshot, inspection, tool output, or a named blocker. "It should work" is not a finalization.
-- **Weak or empty tool result is not a conclusion.** Vary the query, path, command, or source before deciding the thing isn't there.
 - **Non-final turn:** use tools to advance, or ask the one clarifying question that unblocks safe progress. One question, not five.
 
 {{!--

--- a/src/agents/profiles.test.ts
+++ b/src/agents/profiles.test.ts
@@ -395,3 +395,88 @@ describe("agent-self-service partial — cron/skill MCP discoverability (#1163)"
     expect(fragment.length).toBeGreaterThan(500);
   });
 });
+
+describe("execution-discipline partial — fleet-wide grounding / verify-before-assert", () => {
+  // Background: the grounding rules ("verify mutable facts before
+  // claiming them", "final answer needs evidence", "weak result isn't a
+  // conclusion") only lived in the DEFAULT profile's CLAUDE.md, so
+  // coding / executive-assistant / health-coach — and every future
+  // profile — shipped without them. Serves the "feel-like-a-colleague"
+  // job ("verifies before claiming"). This fragment is the
+  // unconditional-append carrier that puts the posture on EVERY agent on
+  // EVERY profile. These tests pin the contract.
+
+  it("tells the agent to read ground truth rather than answer from memory", async () => {
+    const { renderExecutionDisciplineFragment } = await import("./profiles.js");
+    const fragment = renderExecutionDisciplineFragment();
+    expect(fragment.toLowerCase()).toContain("ground truth");
+    expect(fragment.toLowerCase()).toMatch(/read live|leads, not facts|memory/);
+  });
+
+  it("requires final answers to carry evidence", async () => {
+    const { renderExecutionDisciplineFragment } = await import("./profiles.js");
+    const fragment = renderExecutionDisciplineFragment();
+    expect(fragment.toLowerCase()).toContain("evidence");
+    expect(fragment.toLowerCase()).toContain("it should work");
+  });
+
+  it("warns against asserting an untested limit (fabricated boundaries)", async () => {
+    // A confabulated "I can't do that" is as wrong as a confabulated
+    // fact and stops work that was actually possible — the fragment must
+    // tell the agent to verify a claimed limit before stating it.
+    const { renderExecutionDisciplineFragment } = await import("./profiles.js");
+    const fragment = renderExecutionDisciplineFragment();
+    expect(fragment.toLowerCase()).toMatch(/limit you haven't tested|fabricated boundary/);
+  });
+
+  it("says a weak or empty result isn't a conclusion", async () => {
+    const { renderExecutionDisciplineFragment } = await import("./profiles.js");
+    const fragment = renderExecutionDisciplineFragment();
+    expect(fragment.toLowerCase()).toMatch(/weak or empty/);
+  });
+
+  it("is non-empty (file present and rendered)", async () => {
+    const { renderExecutionDisciplineFragment } = await import("./profiles.js");
+    const fragment = renderExecutionDisciplineFragment();
+    expect(fragment.length).toBeGreaterThan(500);
+  });
+
+  it("is appended to a scaffolded CLAUDE.md regardless of profile", async () => {
+    // The core claim: the grounding posture reaches EVERY agent on EVERY
+    // profile, not just default. We rebuild the exact compose the
+    // scaffold does (profile CLAUDE.md.hbs render + unconditional append
+    // of the three shared fragments) for two structurally different
+    // profiles and assert the execution-discipline text appears in BOTH.
+    const {
+      renderExecutionDisciplineFragment,
+      renderVaultProtocolFragment,
+      renderAgentSelfServiceFragment,
+    } = await import("./profiles.js");
+    const Handlebars = (await import("handlebars")).default;
+
+    const marker = "Grounding — check before you assert";
+
+    const composeForProfile = (profileName: string): string => {
+      const profileDir = getProfilePath(profileName);
+      const hbsPath = join(profileDir, "CLAUDE.md.hbs");
+      let rendered = Handlebars.compile(readFileSync(hbsPath, "utf-8"), {
+        noEscape: true,
+      })({});
+      // Mirror scaffold.ts append order: vault, self-service, discipline.
+      for (const frag of [
+        renderVaultProtocolFragment(),
+        renderAgentSelfServiceFragment(),
+        renderExecutionDisciplineFragment(),
+      ]) {
+        if (frag) rendered = rendered.trimEnd() + "\n\n" + frag + "\n";
+      }
+      return rendered;
+    };
+
+    const defaultClaude = composeForProfile("default");
+    const codingClaude = composeForProfile("coding");
+
+    expect(defaultClaude).toContain(marker);
+    expect(codingClaude).toContain(marker);
+  });
+});

--- a/src/agents/profiles.ts
+++ b/src/agents/profiles.ts
@@ -171,7 +171,7 @@ Handlebars.registerHelper("isNumber", (value: unknown) => {
 // The _shared/ directory is underscore-prefixed (like _base/) and is not
 // listed by listAvailableProfiles() — it's framework-internal.
 const SHARED_FRAGMENTS_DIR = resolve(PROFILES_ROOT, "_shared");
-const SHARED_FRAGMENTS = ["vault-protocol", "agent-self-service"] as const;
+const SHARED_FRAGMENTS = ["vault-protocol", "agent-self-service", "execution-discipline"] as const;
 for (const name of SHARED_FRAGMENTS) {
   const fragPath = join(SHARED_FRAGMENTS_DIR, `${name}.md.hbs`);
   if (existsSync(fragPath)) {
@@ -220,6 +220,32 @@ export function renderAgentSelfServiceFragment(
   profilesRoot: string = PROFILES_ROOT,
 ): string {
   const fragPath = join(resolve(profilesRoot, "_shared"), "agent-self-service.md.hbs");
+  if (!existsSync(fragPath)) return "";
+  const source = readFileSync(fragPath, "utf-8");
+  const template = Handlebars.compile(source, { noEscape: true });
+  return template(context).trimEnd();
+}
+
+/**
+ * Render the execution-discipline fragment standalone for unconditional
+ * append to every agent's CLAUDE.md. Same pattern as
+ * {@link renderVaultProtocolFragment} — the grounding / verify-before-
+ * assert posture is fleet-wide work-quality guidance (serves the
+ * "feel-like-a-colleague" job: "verifies before claiming"). It must
+ * reach EVERY agent on EVERY profile, not just the default profile's
+ * CLAUDE.md — so it rides the unconditional-append carrier rather than
+ * living in a single profile template that the coding /
+ * executive-assistant / health-coach profiles never inherit.
+ *
+ * Returns the rendered Markdown, or an empty string if the fragment
+ * file is missing (e.g. partial install).
+ */
+export function renderExecutionDisciplineFragment(
+  context: Record<string, unknown> = {},
+  /** Override the profiles root; used by tests. */
+  profilesRoot: string = PROFILES_ROOT,
+): string {
+  const fragPath = join(resolve(profilesRoot, "_shared"), "execution-discipline.md.hbs");
   if (!existsSync(fragPath)) return "";
   const source = readFileSync(fragPath, "utf-8");
   const template = Handlebars.compile(source, { noEscape: true });

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -500,6 +500,7 @@ import {
   renderProfileClaudeTemplate,
   renderVaultProtocolFragment,
   renderAgentSelfServiceFragment,
+  renderExecutionDisciplineFragment,
 } from "./profiles.js";
 import {
   getHindsightSettingsEntry,
@@ -3558,6 +3559,16 @@ export function scaffoldAgent(
             if (selfService) {
               rendered = rendered.trimEnd() + "\n\n" + selfService + "\n";
             }
+            // Execution-discipline fragment — the fleet-wide grounding /
+            // verify-before-assert posture (serves the
+            // "feel-like-a-colleague" job: "verifies before claiming").
+            // Same unconditional-append pattern as the two above so it
+            // reaches EVERY agent on EVERY profile, not just the default
+            // profile's CLAUDE.md.
+            const executionDiscipline = renderExecutionDisciplineFragment(context);
+            if (executionDiscipline) {
+              rendered = rendered.trimEnd() + "\n\n" + executionDiscipline + "\n";
+            }
           }
           if (dest === "CLAUDE.md" && agentConfig.claude_md_raw) {
             rendered = rendered.trimEnd() + "\n\n" + agentConfig.claude_md_raw + "\n";
@@ -5312,6 +5323,14 @@ export function reconcileAgent(
       const selfService = renderAgentSelfServiceFragment(claudeContext);
       if (selfService) {
         rendered = rendered.trimEnd() + "\n\n" + selfService + "\n";
+      }
+      // Execution-discipline fragment — fleet-wide grounding posture.
+      // ORDER must mirror the first-scaffold path above (vault protocol,
+      // then agent-self-service, then execution-discipline) or the
+      // diff-abort below trips on every reconcile.
+      const executionDiscipline = renderExecutionDisciplineFragment(claudeContext);
+      if (executionDiscipline) {
+        rendered = rendered.trimEnd() + "\n\n" + executionDiscipline + "\n";
       }
       let composed = composeWithSidecar(rendered, claudeCustomPath);
 


### PR DESCRIPTION
## What

Moves the universal **"ground before you assert"** invariant out of the `default` profile and into a new `_shared` fragment that's appended to **every** agent's `CLAUDE.md`, on every profile, every boot — the same mechanism as `vault-protocol` and `agent-self-service`.

## Why

The grounding rules (verify mutable facts, evidence before final answer) lived **only** in `profiles/default/CLAUDE.md.hbs`. Profile selection picks a *single* profile dir and renders only its `CLAUDE.md.hbs` — `extends:` is a config cascade, it does **not** layer prompt files. So `coding` / `executive-assistant` / `health-coach` agents, and every future profile, silently missed the rule. `_shared` is the only true fleet-wide prompt floor.

This is general epistemic discipline, not a permissions patch: don't assert what you haven't checked, prefer going to the source (code, systems, files, web), and capability/permission claims are one instance of it.

## Changes

- New `profiles/_shared/execution-discipline.md.hbs`.
- Register `"execution-discipline"` in `SHARED_FRAGMENTS`.
- `renderExecutionDisciplineFragment()` + append at both scaffold sites (mirrors `vault-protocol`).
- Remove now-redundant grounding bullets from the default profile (no double-injection).
- Test asserting the fragment lands in every profile's rendered output.

## Verification

- `tsc --noEmit`: clean
- `vitest run src/agents/profiles.test.ts`: 41/41 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)