### PR TITLE
fix(build): arm the version mis-stamp guard (TAG_VERSION + GITHUB_REF cross-check)

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -71,6 +71,11 @@ jobs:
           bun-version: latest
 
       - name: Install deps + build dist/
+        env:
+          # Arms the mis-stamp guard in scripts/build.mjs: on a tag build this is
+          # the tag (e.g. v0.15.56); on non-tag builds it is empty so the guard
+          # stays silent and dev builds fall back to package.json.
+          TAG_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
         run: |
           bun install
           npm run build
@@ -189,6 +194,11 @@ jobs:
           bun-version: latest
 
       - name: Install deps + build dist/
+        env:
+          # Arms the mis-stamp guard in scripts/build.mjs: on a tag build this is
+          # the tag (e.g. v0.15.56); on non-tag builds it is empty so the guard
+          # stays silent and dev builds fall back to package.json.
+          TAG_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
         run: |
           bun install
           npm run build

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -83,26 +83,37 @@ function resolveVersion(inGit) {
 }
 
 /**
- * Mis-stamp guard: when we resolved a version from a tag AND TAG_VERSION is
- * set (i.e. CI knows what the tag is), verify they agree. A mismatch means
- * the build environment is inconsistent — abort rather than ship the wrong
- * version string silently.
+ * Mis-stamp guard: cross-check the resolved version against every INDEPENDENT
+ * tag signal CI provides (TAG_VERSION env and GITHUB_REF). On a tag build these
+ * are set by GitHub Actions from the same ref, so they must agree with what we
+ * stamped. A mismatch means the build environment is inconsistent — abort
+ * rather than ship the wrong version string silently.
  *
- * This guard is intentionally STRICT on release builds (TAG_VERSION set) and
- * silent on dev builds (no TAG_VERSION) so it never blocks local work.
+ * Note: TAG_VERSION is also Layer 1 of resolveVersion(), so when only it is set
+ * the check is tautological. The value comes from ALSO checking GITHUB_REF: if
+ * TAG_VERSION (Layer 1) is wrong while GITHUB_REF carries the real tag, resolved
+ * matches TAG_VERSION but not GITHUB_REF, and we catch it. The guard is silent
+ * on dev builds (no tag signals) so it never blocks local work.
  */
 function assertVersionConsistency(resolvedVersion, source) {
+  const signals = [];
   const tagVersionEnv = process.env.TAG_VERSION?.trim();
-  if (!tagVersionEnv) return; // not a CI tag build — skip
-  const expected = tagVersionEnv.replace(/^v/, "");
-  if (resolvedVersion !== expected) {
-    console.error(
-      `[build] ERROR: version mis-stamp detected!\n` +
-      `  TAG_VERSION env says:  ${expected}\n` +
-      `  Resolved version (${source}): ${resolvedVersion}\n` +
-      `  Aborting build to prevent shipping the wrong version.`
-    );
-    process.exit(1);
+  if (tagVersionEnv) signals.push(["TAG_VERSION", tagVersionEnv.replace(/^v/, "")]);
+  const githubRef = process.env.GITHUB_REF?.trim();
+  if (githubRef && githubRef.startsWith("refs/tags/v")) {
+    signals.push(["GITHUB_REF", githubRef.replace(/^refs\/tags\/v/, "")]);
+  }
+  if (signals.length === 0) return; // not a CI tag build — skip
+  for (const [name, expected] of signals) {
+    if (resolvedVersion !== expected) {
+      console.error(
+        `[build] ERROR: version mis-stamp detected!\n` +
+        `  ${name} says:           ${expected}\n` +
+        `  Resolved version (${source}): ${resolvedVersion}\n` +
+        `  Aborting build to prevent shipping the wrong version.`
+      );
+      process.exit(1);
+    }
   }
 }
 


### PR DESCRIPTION
## What
Follow-up to #2525. Makes the version mis-stamp guard actually protective.

## Why
#2525 added `assertVersionConsistency` but it was inert:
1. `docker-images.yml` never set `TAG_VERSION` (the workflow-scope env line was reverted — no `workflow` OAuth scope at the time).
2. Even with `TAG_VERSION` set, the guard was **tautological**: the resolved version comes *from* `TAG_VERSION` (Layer 1 of `resolveVersion`), so `resolved !== TAG_VERSION` can never fire.

## Changes
- **`docker-images.yml`**: set `TAG_VERSION` on both `Install deps + build dist/` steps (build-base + build-dependents), **conditionally**: `${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}` — the tag on tag builds, empty otherwise so non-tag/main builds fall back to package.json instead of stamping `main`.
- **`scripts/build.mjs` `assertVersionConsistency`**: cross-check the resolved version against **every** independent tag signal (`TAG_VERSION` *and* `GITHUB_REF`). A wrong `TAG_VERSION` now gets caught because it disagrees with `GITHUB_REF`.

## Verification (all run locally)
- Tag build (`TAG_VERSION=v0.15.56`, `GITHUB_REF=refs/tags/v0.15.56`) → stamps `0.15.56`, exit 0. build-info.ts VERSION = `0.15.56`.
- Main build (no/empty `TAG_VERSION`, `GITHUB_REF=refs/heads/main`) → package.json fallback, no `main` mis-stamp, exit 0.
- Mis-stamp (`TAG_VERSION=v0.15.99` vs real `GITHUB_REF=refs/tags/v0.15.56`) → **guard aborts, exit 1**.
- `tsc --noEmit` clean; `tests/resolve-version.test.ts` + `src/cli/deploy-version-guard.test.ts` = 14/14 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)