### PR TITLE
feat(observability): structured debug logging for silent-turn failure mode

### DIFF
--- a/telegram-plugin/gateway/disconnect-flush.ts
+++ b/telegram-plugin/gateway/disconnect-flush.ts
@@ -157,10 +157,12 @@ export function flushOnAgentDisconnect<
   // dangling-sweep above for activeTurnStartedAt.
   if (claudeBusyKeys.size > 0) {
     const orphanCount = claudeBusyKeys.size
+    const orphanKeys = [...claudeBusyKeys]
     claudeBusyKeys.clear()
     log(
       `telegram gateway: disconnect-flush cleared ${orphanCount} orphan claudeBusyKeys ` +
-      `entr${orphanCount === 1 ? 'y' : 'ies'} (synthetic-inbound deliveries that never turn_ended)`,
+      `entr${orphanCount === 1 ? 'y' : 'ies'} (synthetic-inbound deliveries that never turn_ended)` +
+      ` keys=${orphanKeys.join(',')}`,
     )
   }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1399,6 +1399,21 @@ const activeTurnStartedAt = new Map<string, number>()
 const claudeBusyKeys = new Set<string>()
 
 /**
+ * #2527 observability: count emoji transitions per status-reaction controller
+ * so `turn_no_reply_warn` can report how many reaction changes happened while
+ * producing zero text. Keyed by statusKey(chatId, threadId); cleared in
+ * purgeReactionTracking alongside the controller itself.
+ */
+const reactionTransitionCounts = new Map<string, number>()
+
+/**
+ * #2527 observability: tracks which (chatId:threadId) keys have already emitted
+ * a `turn_reply_timing` event this turn so we only fire it on the FIRST text
+ * reply. Cleared in purgeReactionTracking at turn-end alongside the controller.
+ */
+const firstTextReplyLogged = new Set<string>()
+
+/**
  * Helper: stamp a claudeBusyKeys entry for an inbound about to be
  * handed to claude. Pulls the thread id from the top-level field if
  * present, otherwise falls back to meta.message_thread_id (cron and
@@ -2746,6 +2761,10 @@ function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
   // the markClaudeBusyForInbound on the delivery path. Safe no-op
   // when the key was never marked (synthetic purge from a sweep).
   claudeBusyKeys.delete(key)
+  // #2527: clear the per-key reaction-transition counter and first-reply
+  // sentinel alongside the controller so we don't leak state across turns.
+  reactionTransitionCounts.delete(key)
+  firstTextReplyLogged.delete(key)
   // Human-feel UX: stop the turn-long `typing…` indicator started in
   // the turn-start block. `purgeReactionTracking` is the canonical
   // turn-end, so this is the single owner of the stop. (If an abnormal
@@ -3371,6 +3390,17 @@ function finalizeStatusReaction(
   if (reason === 'done' && deferredDoneReactions.tryDefer(key, ctrl)) return
   deferredDoneReactions.drop(key)
   ctrl.finalize(reason)
+  // #2527: log controller dispose so the lifecycle end is observable. Use
+  // activeReactionMsgIds to reconstruct the turnId token before purge clears it.
+  const msgInfo = activeReactionMsgIds.get(key)
+  if (msgInfo != null) {
+    logStreamingEvent({
+      kind: 'status_reaction_dispose',
+      chatId,
+      turnId: `${chatId}:${msgInfo.messageId}`,
+      reason,
+    })
+  }
   purgeReactionTracking(key)
 }
 
@@ -5314,6 +5344,14 @@ silencePoke.startTimer({
         `turn ended cleanly during silence window ` +
         `chat=${ctx.chatId} thread=${ctx.threadId ?? '-'} silence_ms=${ctx.silenceMs}\n`,
       )
+      // #2527: structured skip event so the late-fire race is machine-readable.
+      logStreamingEvent({
+        kind: 'silence_poke_skip',
+        chatId: ctx.chatId,
+        threadId: ctx.threadId ?? undefined,
+        silenceMs: ctx.silenceMs,
+        skipReason: 'turn_ended_cleanly_during_window',
+      })
       // Tell silence-poke this chat-thread is finished so the next
       // arming doesn't carry stale state.
       silencePoke.endTurn(ctx.key)
@@ -5358,6 +5396,15 @@ silencePoke.startTimer({
         blockedOnApproval,
       )
     }
+    // #2527: log the actual poke fire with structured data before sending,
+    // so the event is visible even if the send fails.
+    logStreamingEvent({
+      kind: 'silence_poke_fire',
+      chatId: ctx.chatId,
+      threadId: ctx.threadId ?? undefined,
+      silenceMs: ctx.silenceMs,
+      fallbackKind: ctx.fallbackKind,
+    })
     try {
       await robustApiCall(
         () => bot.api.sendMessage(ctx.chatId, text, {
@@ -7447,6 +7494,23 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     }
   }
   process.stderr.write(`telegram channel: reply: invoked chatId=${chat_id} charCount=${text.length} preview=${JSON.stringify(text.slice(0, 80))}\n`)
+  // #2527: emit time_to_first_text_reply_ms on the FIRST text reply of each
+  // turn so operators can see how long users waited for any visible output.
+  // Only fires once per turn (firstTextReplyLogged guards the repeat).
+  if (turn != null) {
+    const threadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
+    const replyKey = statusKey(chat_id, threadId)
+    if (!firstTextReplyLogged.has(replyKey)) {
+      firstTextReplyLogged.add(replyKey)
+      logStreamingEvent({
+        kind: 'turn_reply_timing',
+        chatId: chat_id,
+        threadId,
+        turnId: turn.turnId,
+        timeToFirstTextReplyMs: Date.now() - turn.gatewayReceiveAt,
+      })
+    }
+  }
 
   // #546 dedup check: was this content just sent via turn-flush or
   // a sibling reply path? Skip the actual send and return a
@@ -8391,6 +8455,19 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       // PR3b-cutover: feed lastOutboundAt to the delivery machine (see
       // executeReply) so its TTL tick suppresses an active-turn fallback.
       shadowEmit({ kind: 'modelOutbound', key: sKey as _ChatKey, at: Date.now() })
+      // #2527: emit turn_reply_timing on the first stream_reply of the turn,
+      // mirroring the same gate in executeReply. Guards with firstTextReplyLogged
+      // so a turn that calls reply first and stream_reply second doesn't double-emit.
+      if (turn != null && !firstTextReplyLogged.has(sKey)) {
+        firstTextReplyLogged.add(sKey)
+        logStreamingEvent({
+          kind: 'turn_reply_timing',
+          chatId: streamChatId,
+          threadId: streamThreadId,
+          turnId: turn.turnId,
+          timeToFirstTextReplyMs: Date.now() - turn.gatewayReceiveAt,
+        })
+      }
       // #1741 — see executeReply for the rationale: only a plausibly-
       // final stream_reply clears the silent-end state. An interim
       // ack via stream_reply must NOT clear; the Stop hook needs
@@ -11096,6 +11173,17 @@ function handleSessionEvent(ev: SessionEvent): void {
             ` chat=${chatId} turnStartedAt=${turn.startedAt} replyCalled=false capturedText=empty` +
             ` — the progress card steps were the only thing the user saw (#45)\n`,
           )
+          // #2527: emit structured WARN so the reaction-only failure mode is
+          // machine-readable in the streaming-metrics channel.
+          const tKey = statusKey(chatId, threadId)
+          logStreamingEvent({
+            kind: 'turn_no_reply_warn',
+            chatId,
+            threadId,
+            turnId: turn.turnId,
+            turnDurationMs: turn.startedAt > 0 ? Date.now() - turn.startedAt : 0,
+            reactionCount: reactionTransitionCounts.get(tKey) ?? 0,
+          })
         }
       }
 
@@ -11972,6 +12060,9 @@ function maybeEarlyAckReaction(ctx: Context, from: NonNullable<Context['from']>)
   void bot.api.setMessageReaction(chatId, msgId, [
     { type: 'emoji', emoji: '👀' as ReactionTypeEmoji['emoji'] },
   ]).catch(() => {})
+  // #2527: log the early-ack fire so operators can see how often the
+  // fast pre-coalesce DM path triggers vs. the controller path.
+  logStreamingEvent({ kind: 'early_ack_reaction', chatId, messageId: msgId, emoji: '👀' })
   // #553 PR 3: also fire the native "typing…" indicator. Bridges the
   // visual gap between the early-ack 👀 reaction and the first real
   // model text. No fake content — Telegram clients render this natively
@@ -12885,17 +12976,42 @@ async function handleInbound(
         if (!chatAvailableReactions.has(chat_id)) {
           probeAvailableReactions(chat_id)
         }
+        // #2527: use inbound msgId as a stable per-turn reaction identifier.
+        // The controller is created before currentTurn.turnId is assigned
+        // (that happens in handleSessionEvent's enqueue branch), so we capture
+        // msgId here and use it as the reaction-session token in log events.
+        const ctrlTurnToken = `${chat_id}:${msgId}`
         const ctrl = new StatusReactionController(async (emoji) => {
           await bot.api.setMessageReaction(chat_id, msgId, [
             { type: 'emoji', emoji: emoji as ReactionTypeEmoji['emoji'] },
           ])
           // #203: every status-reaction transition is a user-visible signal.
           signalTracker.noteSignal(key, Date.now())
-        }, allowedReactions)
+        }, allowedReactions, {
+          // #2527: emit a structured transition event on each emoji change so
+          // the reaction lifecycle is visible in streaming-metrics logs. Also
+          // increment the per-key counter for the turn_no_reply_warn metric.
+          onTransition: (emoji) => {
+            reactionTransitionCounts.set(key, (reactionTransitionCounts.get(key) ?? 0) + 1)
+            logStreamingEvent({
+              kind: 'status_reaction_transition',
+              chatId: chat_id,
+              turnId: ctrlTurnToken,
+              emoji,
+            })
+          },
+        })
         activeStatusReactions.set(key, ctrl)
         activeReactionMsgIds.set(key, { chatId: chat_id, messageId: msgId })
         activeTurnStartedAt.set(key, Date.now())
         progressUpdateTurnCount.set(key, 0)  // Reset turn counter
+        // #2527: log controller install so the lifecycle start is observable.
+        logStreamingEvent({
+          kind: 'status_reaction_install',
+          chatId: chat_id,
+          turnId: ctrlTurnToken,
+          messageId: msgId,
+        })
         ctrl.setQueued()
         // #203: time-to-ack metric — setQueued() triggers the initial 👀 reaction
         // asynchronously through the controller chain.

--- a/telegram-plugin/status-reactions.ts
+++ b/telegram-plugin/status-reactions.ts
@@ -115,6 +115,14 @@ export interface StatusReactionConfig {
   stallHardMs?: number
   /** Optional logger for debugging — receives a single string per event. */
   log?: (msg: string) => void
+  /**
+   * Optional structured callback fired on every emoji transition (after the
+   * API call succeeds). Used by the gateway to emit `status_reaction_transition`
+   * streaming-metrics events for #2527 observability. Kept out of the main
+   * `log` callback so callers that only want the human-readable log string
+   * don't need to parse it.
+   */
+  onTransition?: (emoji: string) => void
 }
 
 /**
@@ -152,6 +160,7 @@ export class StatusReactionController {
   private readonly stallSoftMs: number
   private readonly stallHardMs: number
   private readonly log?: (msg: string) => void
+  private readonly onTransition?: (emoji: string) => void
 
   constructor(
     private readonly emit: ReactionEmitter,
@@ -163,6 +172,7 @@ export class StatusReactionController {
     this.stallSoftMs = config.stallSoftMs ?? 30000
     this.stallHardMs = config.stallHardMs ?? 90000
     this.log = config.log
+    this.onTransition = config.onTransition
   }
 
   /** 👀 — message received and queued for processing. Bypasses debounce. */
@@ -348,6 +358,7 @@ export class StatusReactionController {
         this.currentEmoji = emoji
         if (this.pendingEmoji === emoji) this.pendingEmoji = null
         this.log?.(`reaction → ${emoji}`)
+        this.onTransition?.(emoji)
       } catch (err) {
         this.log?.(`reaction emit failed (${emoji}): ${(err as Error).message}`)
       }

--- a/telegram-plugin/streaming-metrics.ts
+++ b/telegram-plugin/streaming-metrics.ts
@@ -93,6 +93,97 @@ export type StreamingEvent =
       chatId: string
       messageId: number | undefined
     }
+  /**
+   * Emitted when maybeEarlyAckReaction fires the 👀 pre-coalesce reaction
+   * for a private-chat inbound. Lets operators see how often the fast-ack
+   * path triggers vs. the regular StatusReactionController path (#553 F2).
+   */
+  | {
+      kind: 'early_ack_reaction'
+      chatId: string
+      messageId: number
+      emoji: string
+    }
+  /**
+   * Emitted when a fresh StatusReactionController is installed for a new turn
+   * (group / non-DM path where the controller manages the whole reaction lifecycle).
+   */
+  | {
+      kind: 'status_reaction_install'
+      chatId: string
+      turnId: string
+      messageId: number
+    }
+  /**
+   * Emitted on every emoji transition inside a StatusReactionController.
+   * Lets operators trace the full queued→thinking→tool→done lifecycle and
+   * see how many state changes occur in a silent turn.
+   */
+  | {
+      kind: 'status_reaction_transition'
+      chatId: string
+      turnId: string
+      emoji: string
+    }
+  /**
+   * Emitted when StatusReactionController.finalize() / setDone() runs
+   * (controller disposed at turn_end or disconnect-flush). Terminal event.
+   */
+  | {
+      kind: 'status_reaction_dispose'
+      chatId: string
+      turnId: string
+      reason: 'done' | 'error' | 'disconnect'
+    }
+  /**
+   * Emitted when the FIRST text reply (reply or stream_reply) of a turn is
+   * sent to the user. `timeToFirstTextReplyMs` is the wall-clock delta from
+   * the inbound-received timestamp to the moment this reply tool fires.
+   * Issue #2527 instrumentation: reveals when a turn is reaction-only.
+   */
+  | {
+      kind: 'turn_reply_timing'
+      chatId: string
+      threadId: number | undefined
+      turnId: string
+      timeToFirstTextReplyMs: number
+    }
+  /**
+   * Emitted at turn_end when the turn produced ZERO text replies (only
+   * reaction-emoji transitions). This is the primary observable for the
+   * #2527 failure mode — the user sees only an emoji and the turn is done.
+   */
+  | {
+      kind: 'turn_no_reply_warn'
+      chatId: string
+      threadId: number | undefined
+      turnId: string
+      turnDurationMs: number
+      reactionCount: number
+    }
+  /**
+   * Emitted when the silence-poke framework-fallback fires and sends its
+   * "still working…" ping. Records the silence duration so operators can
+   * correlate with reaction-only turns.
+   */
+  | {
+      kind: 'silence_poke_fire'
+      chatId: string
+      threadId: number | undefined
+      silenceMs: number
+      fallbackKind: string
+    }
+  /**
+   * Emitted when the silence-poke handler short-circuits because the turn
+   * already ended cleanly during the silence window (the late-fire race).
+   */
+  | {
+      kind: 'silence_poke_skip'
+      chatId: string
+      threadId: number | undefined
+      silenceMs: number
+      skipReason: string
+    }
 
 /**
  * True iff the env gate is on. Re-read on every call so tests can toggle


### PR DESCRIPTION
## Summary

Refs #2527 — logging-only instrumentation, no behavior change.

Adds 8 new structured `StreamingEvent` kinds to make the #2527 failure mode
(DM and group agents leave an ack reaction but send no text reply) machine-readable
in the `[streaming-metrics]` JSONL channel. All events are gated on the existing
`SWITCHROOM_STREAMING_METRICS=1` env flag, so production stays quiet by default.

**New event kinds:**

| Kind | What it captures |
|---|---|
| `early_ack_reaction` | DM pre-coalesce 👀 fire (maybeEarlyAckReaction path) |
| `status_reaction_install` | Fresh StatusReactionController installed for a new turn |
| `status_reaction_transition` | Every emoji transition inside the controller |
| `status_reaction_dispose` | Controller finalized at turn_end / disconnect |
| `turn_reply_timing` | Time-to-first-text-reply in ms (first `reply` / `stream_reply`) |
| `turn_no_reply_warn` | Turn ended with zero text replies (the #2527 smoking gun) |
| `silence_poke_fire` | Framework-fallback "still working…" ping sent |
| `silence_poke_skip` | Late-fire race: turn ended cleanly during silence window |

**Mechanism:**
- `StatusReactionConfig` gains an optional `onTransition?: (emoji: string) => void` callback (wired in `enqueue`). The gateway wires this to emit `status_reaction_transition` and increment a `reactionTransitionCounts` map keyed by `statusKey`.
- `firstTextReplyLogged` Set (per `statusKey`) guards `turn_reply_timing` so it fires exactly once per turn. Cleared in `purgeReactionTracking`.
- `reactionTransitionCounts` is included in `turn_no_reply_warn` so operators can see how many emoji changes happened during a fully silent turn.
- Orphan claudeBusyKeys log line in disconnect-flush gains a `keys=` field for per-turn greppability.

## Why

The evidence: inbound at 19:33:13 → only `setMessageReaction` calls for ~2m49s → first `reply: invoked` at 19:36:02. User saw only an emoji and assumed the turn was done. Without instrumentation, the gap is invisible in logs. These events make the reaction-only window directly observable as a `turn_no_reply_warn` + matching `turn_reply_timing` pair.

## Vision outcome / job spec

Serves the **hold-the-leash** outcome.
Job spec: `reference/jobs/know-what-my-agent-is-doing.md`
> *"At any moment during a turn, the user can see what the agent is up to and why, without asking."*

This PR does not change what the user sees — it instruments what operators see in logs, enabling the follow-on fix (PR for the actual behavior change) to be root-caused from evidence rather than guesswork.

## Test plan

- [x] `npm run lint` — clean (tsc + all script checks)
- [x] `npm run build` — exits 0
- [x] `bun test telegram-plugin/tests/status-reactions-allowed-filter.test.ts telegram-plugin/tests/gateway-disconnect-flush.test.ts telegram-plugin/tests/silence-poke.test.ts telegram-plugin/tests/e2e.test.ts` — 83 pass, 0 fail
- [x] Pre-existing bun test failures (2 vault token tests, `createBrokerClient`) confirmed pre-existing on `main` before this branch
- [x] No new test failures introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)