### PR TITLE
docs(release): clarify version source of truth; stop bumping package.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -636,9 +636,25 @@ cd ~/code/switchroom-rel-<vX.Y.Z>
 rm -rf node_modules && cp -a ~/code/switchroom-sec-1417/node_modules ./node_modules
 ```
 
-**2. Bump `package.json` + CHANGELOG.**
+**2. CHANGELOG only — do NOT hand-bump `package.json`'s `version`.**
 
-- `package.json` `"version": "X.Y.Z"`.
+> **Version source of truth = the git tag, resolved by
+> `scripts/build.mjs:resolveVersion()`.** Priority order (#2526):
+> `TAG_VERSION` env (set by `docker-images.yml`) → `GITHUB_REF`
+> (`refs/tags/vX.Y.Z`) → `git describe --tags --exact-match HEAD` →
+> `package.json` `"version"` (**dev / non-tag fallback ONLY**). A
+> mis-stamp guard aborts the build if the git-derived version disagrees
+> with `TAG_VERSION`. The resolved version is stamped into
+> `src/build-info.ts` at build time; `src/cli/resolve-version.ts` reads it
+> (with a shipped-`package.json` walk-up as a secondary source).
+>
+> So the committed `package.json` `"version"` is a **stale placeholder**
+> (it has read `0.15.48` across many tagged releases, v0.15.49…v0.15.57+):
+> it is deliberately *not* bumped per release, and **editing it does
+> nothing for a release** — it's only the Layer-4 fallback for a non-tag
+> dev build. A release is just: tag a main commit and push the tag
+> (step 5); the tag flows through `resolveVersion()` automatically.
+
 - `CHANGELOG.md`: consolidate any `## unreleased — …` sections under
   a single `## vX.Y.Z — <theme>` header. For multi-PR releases,
   group entries under `### PR <letter> — <title> (#NNNN)` subsections.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "switchroom",
+  "//version": "NOT the release version — source of truth is the git tag (see CLAUDE.md > Standard release process). This field is stale by design and only a fallback for scripts/build.mjs + src/cli/resolve-version.ts; do not assume it reflects the current release and do not bump it expecting a release to pick it up.",
   "version": "0.15.48",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",


### PR DESCRIPTION
## Summary

The committed \`package.json\` \`version\` is a **stale dev-only fallback** (\`0.15.48\` across many tagged releases up to v0.15.57) — it confused an agent into nearly hand-bumping it mid-release. The real source of truth is the **git tag**, resolved by \`scripts/build.mjs:resolveVersion()\` (priority: \`TAG_VERSION\` → \`GITHUB_REF\` → \`git describe --exact-match\` → \`package.json\` fallback), with a mis-stamp guard (#2526). The mechanism is sound and single-source; only the stale value + misleading docs were the problem.

## Changes
- **CLAUDE.md**: replace the wrong "Bump \`package.json\` version" release step with an accurate **Version source of truth** note (documents \`resolveVersion()\`'s priority; a release = tag a main commit + push the tag).
- **package.json**: add a \`//version\` self-doc key warning the field is a stale Layer-4 fallback, not the release version — so it can't mislead in-place.

## Why not a mechanism change
The resolver is already correct (git-tag-driven). Changing \`build.mjs\`/\`resolve-version.ts\` is incident-prone (the v0.15.40→0.15.39 mis-report) and unnecessary — the fix is making the value + docs honest.

## Test plan
- [x] \`node -e\` confirms package.json is valid JSON; \`version\` still readable; \`//version\` present
- [x] \`node scripts/build.mjs\` exits 0 and stamps the correct tag version (0.15.57)
- [x] \`npm run lint\` clean (tsc + all checks)
- [x] Docs-only + comment key — no runtime/logic change

## Risk
Minimal — no mechanism change. The \`//version\` key is a standard ignored-comment convention; npm/build.mjs/resolve-version all read \`version\` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)