### PR TITLE
fix(telegram): role-aware terminal honesty on bridge crash (#2527 follow-up)

### DIFF
--- a/telegram-plugin/gateway/disconnect-flush.ts
+++ b/telegram-plugin/gateway/disconnect-flush.ts
@@ -27,7 +27,7 @@
  * needing to spin up the whole gateway.
  */
 
-export interface DisconnectFlushDeps<Ctrl extends { finalize: (reason?: 'done' | 'error') => void }, Stream extends { isFinal: () => boolean; finalize: () => Promise<void> }> {
+export interface DisconnectFlushDeps<Ctrl extends { finalize: (reason?: 'done' | 'undelivered' | 'error') => void }, Stream extends { isFinal: () => boolean; finalize: () => Promise<void> }> {
   /** The disconnecting client's agentName. `null` ⇒ anonymous (never registered). */
   agentName: string | null
 
@@ -67,6 +67,18 @@ export interface DisconnectFlushDeps<Ctrl extends { finalize: (reason?: 'done' |
 
   /** Logger — receives the one-line decision trace. */
   log: (msg: string) => void
+
+  /**
+   * #2527 — role-aware terminal honesty on a bridge crash/restart. For each
+   * swept reaction key, returns the terminal reason: `'undelivered'` (😐) when
+   * that key is a USER turn that crashed without delivering an answer, else
+   * `'done'` (👍). Optional + defaults to `'done'` so a crash on a turn we
+   * can't classify (or a delivered / system / NO_REPLY turn) keeps the prior
+   * clean-terminal behaviour — a bridge death must never get STUCK on a
+   * working emoji, but a user turn it killed undelivered must not read as
+   * "answered" either (matches the main `turn_end` gate in gateway.ts).
+   */
+  resolveDisposition?: (key: string) => 'done' | 'undelivered'
 }
 
 /**
@@ -75,7 +87,7 @@ export interface DisconnectFlushDeps<Ctrl extends { finalize: (reason?: 'done' |
  * client). The boolean is for tests + observability — callers can ignore it.
  */
 export function flushOnAgentDisconnect<
-  Ctrl extends { finalize: (reason?: 'done' | 'error') => void },
+  Ctrl extends { finalize: (reason?: 'done' | 'undelivered' | 'error') => void },
   Stream extends { isFinal: () => boolean; finalize: () => Promise<void> },
 >(deps: DisconnectFlushDeps<Ctrl, Stream>): boolean {
   const {
@@ -89,6 +101,7 @@ export function flushOnAgentDisconnect<
     clearActiveReactions,
     disposeProgressDriver,
     onDanglingTurnsSwept,
+    resolveDisposition,
     log,
   } = deps
 
@@ -100,14 +113,22 @@ export function flushOnAgentDisconnect<
   }
 
   // Real agent disconnect (e.g. the claude bridge crashed/restarted). Flush
-  // all in-flight status reactions to 👍 so user messages don't stay stuck on
-  // intermediate emoji (🤔, 🔥, etc.) after an agent crash/restart.
+  // all in-flight status reactions to a TERMINAL emoji so user messages don't
+  // stay stuck on intermediate emoji (🤔, 🔥, etc.) after an agent crash/restart.
   // #1713: route through finalize() — single terminal path for the
   // status-reaction controller. Disconnect implies the agent bridge
   // died mid-turn; treat as a clean terminal so the user's emoji
   // doesn't stay stuck on an intermediate working state.
+  //
+  // #2527: but a USER turn the bridge killed WITHOUT delivering an answer must
+  // not read as 👍 ("done") — that's the false-done bug in its crash/restart
+  // variant. `resolveDisposition` paints 😐 ('undelivered') for those and 👍
+  // for everything else (delivered / system / NO_REPLY / unclassifiable). If a
+  // restart resumes the turn and it then delivers, the resume's own reply
+  // re-finalizes 👍; if it never delivers, 😐 stays honest. Default 'done'
+  // preserves the prior behaviour when the resolver isn't wired.
   for (const [key, ctrl] of activeStatusReactions.entries()) {
-    ctrl.finalize('done')
+    ctrl.finalize(resolveDisposition?.(key) ?? 'done')
     activeStatusReactions.delete(key)
     activeReactionMsgIds.delete(key)
     activeTurnStartedAt.delete(key)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6332,6 +6332,22 @@ const ipcServer: IpcServer = createIpcServer({
           currentTurn = null
         }
       },
+      // #2527 — role-aware terminal honesty on a bridge crash, mirroring the
+      // main turn_end gate. Only the in-flight turn is classifiable here
+      // (currentTurn); a `user` turn the bridge killed undelivered paints 😐
+      // not 👍. No worker-hold carve-out — the bridge died, so nothing is
+      // still legitimately working. Unclassifiable keys default to 'done'.
+      resolveDisposition: (key) => {
+        const turn = currentTurn
+        if (turn == null || statusKey(turn.sessionChatId, turn.sessionThreadId) !== key) {
+          return 'done'
+        }
+        return decideTerminalReason({
+          enabled: LIVENESS_TERMINAL_HONESTY,
+          role: turn.role,
+          finalAnswerDelivered: turn.finalAnswerDelivered,
+        })
+      },
       log: (msg) => process.stderr.write(`${msg}\n`),
     })
   },

--- a/telegram-plugin/tests/gateway-disconnect-flush.test.ts
+++ b/telegram-plugin/tests/gateway-disconnect-flush.test.ts
@@ -22,7 +22,8 @@ import { flushOnAgentDisconnect } from '../gateway/disconnect-flush.js'
 interface FakeCtrl {
   // #1713: disconnect-flush now routes through finalize() — single
   // terminal path for the status-reaction controller.
-  finalize: (reason?: 'done' | 'error') => void
+  // #2527: 'undelivered' (😐) added for the role-aware crash terminal.
+  finalize: (reason?: 'done' | 'undelivered' | 'error') => void
 }
 interface FakeStream {
   isFinal: () => boolean
@@ -117,6 +118,36 @@ describe('flushOnAgentDisconnect — anonymous clients (the regression scenario)
     flushOnAgentDisconnect(deps)
     expect(spies.setDoneA).toHaveBeenCalledTimes(0)
     expect(spies.setDoneB).toHaveBeenCalledTimes(0)
+  })
+})
+
+describe('flushOnAgentDisconnect — #2527 role-aware terminal honesty on crash', () => {
+  it('defaults to finalize("done") when no resolveDisposition is wired (back-compat)', () => {
+    const { spies, deps } = makeDeps('clerk')
+    flushOnAgentDisconnect(deps)
+    expect(spies.setDoneA).toHaveBeenCalledWith('done')
+    expect(spies.setDoneB).toHaveBeenCalledWith('done')
+  })
+
+  it('paints 😐 (undelivered) for a user turn the bridge killed undelivered, 👍 for the rest', () => {
+    const { spies, deps } = makeDeps('clerk')
+    // Key A = an undelivered user turn; key B = delivered / system / NO_REPLY.
+    flushOnAgentDisconnect({
+      ...deps,
+      resolveDisposition: (key) =>
+        key === 'chat1:thr1:msg1' ? 'undelivered' : 'done',
+    })
+    expect(spies.setDoneA).toHaveBeenCalledWith('undelivered') // no false 👍
+    expect(spies.setDoneB).toHaveBeenCalledWith('done')
+    // Maps still cleared exactly as before — a crash never leaves a stuck emoji.
+    expect(deps.activeStatusReactions.size).toBe(0)
+  })
+
+  it('still finalizes every reaction (no key left stuck on a working emoji)', () => {
+    const { spies, deps } = makeDeps('clerk')
+    flushOnAgentDisconnect({ ...deps, resolveDisposition: () => 'undelivered' })
+    expect(spies.setDoneA).toHaveBeenCalledTimes(1)
+    expect(spies.setDoneB).toHaveBeenCalledTimes(1)
   })
 })
 


### PR DESCRIPTION
## Summary

Follow-up to #2530. Auditing **every** reaction-finalize path (asked: do the resume/disconnect terminal paths inherit the #2527 fix?) surfaced one real gap: **`disconnect-flush.ts:110`** sweeps all in-flight reactions to **👍 unconditionally** when the claude bridge crashes/restarts mid-turn. That's the false-done bug in its **crash/restart variant** — a user turn killed mid-flight, never delivered, painted 👍 — and it's against the job spec ("crashes/restarts must not read as done"). #2530 only made the main `turn_end` handler honest.

## Fix
- **disconnect-flush.ts** — optional `resolveDisposition(key)` dep; the bridge-death sweep finalizes **😐 (`undelivered`)** for a user turn killed undelivered, **👍** otherwise. Defaults to `'done'` (back-compat + the "never leave a stuck working emoji" guarantee is preserved). Both `Ctrl` generic constraints widened to admit `'undelivered'`.
- **gateway.ts** — wires `resolveDisposition` through the **same pure `decideTerminalReason`** the main gate uses, keyed on the in-flight `currentTurn`. No worker-hold carve-out (a crashed bridge has nothing still working); unclassifiable keys → `'done'`. If a restart resumes and the turn then delivers, the resume's reply re-finalizes 👍; if it never delivers, 😐 stays honest.

## Audit result (the other paths are fine)
- `8260` reply executor → 👍 = delivered (correct)
- `11197` NO_REPLY/HEARTBEAT_OK → 👍 = legitimate silence (correct)
- `11494` turn-flush backstop → a flush sets `finalAnswerDelivered=true` (correct)
- `reaction-defer.ts:84` → downstream of an already-decided `'done'` (worker-hold; accepted)
- **`disconnect-flush.ts:110` → the one gap, fixed here**

## Test plan
- [x] 3 new `gateway-disconnect-flush.test.ts` cases (default-done back-compat; role-aware undelivered/done split; every-key-still-finalized)
- [x] `npm run lint` clean (incl. strict plugin-references tsc — caught + fixed a second generic-constraint site)
- [x] Full `vitest run telegram-plugin/` — 4303 pass / 0 fail
- [x] kill-switch `SWITCHROOM_TG_TERMINAL_HONESTY=0` still reverts (via `decideTerminalReason(enabled:false)`)

## Risk
Low — additive, default-`'done'` (no behaviour change unless the resolver fires), only repaints undelivered user turns on a crash, and kill-switchable. disconnect-flush is incident-scarred (5min-restart-wedge), but the map-clearing/sweep behaviour is untouched — only the finalize *reason* changes for undelivered user turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)