### PR TITLE
fix(telegram): classify final-answer by model ping intent, not over-ping-downgraded flag

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -7544,6 +7544,15 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // existing call-sites and the typical "final answer" reply keep their
   // current behaviour without an explicit flag.
   let disableNotification = args.disable_notification === true
+  // #2527/#1664 — the over-ping safety net below may downgrade
+  // `disableNotification` ping→silent for ANTI-SPAM (one ping per turn). That
+  // delivery-channel decision must NOT pollute final-answer CLASSIFICATION: a
+  // final answer the model intended to ping is STILL the final answer even when
+  // the framework silences the actual ping. Classify on the model's original
+  // intent (what executeStreamReply already does), so an over-ping-silenced
+  // final answer sets finalAnswerDelivered=true — fixing both a spurious
+  // silent-end re-prompt and a false 'undelivered' (😐) terminal reaction.
+  const modelDisableNotification = args.disable_notification === true
 
   // #1675 over-ping safety net. The conversational-pacing contract
   // (`reference/rfcs/conversational-pacing.md` beat 5) says EXACTLY ONE
@@ -7786,7 +7795,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // clear; the main turn-end path also re-writes the state when
   // finalAnswerDelivered=false, so this is a belt-and-braces gate
   // for the turn_end-missing case (#1741).
-  if (isFinalAnswerReply({ text: rawText, disableNotification })) {
+  if (isFinalAnswerReply({ text: rawText, disableNotification: modelDisableNotification })) {
     clearSilentEndState(statusKey(chat_id, threadId))
   }
 
@@ -7897,7 +7906,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
             turn != null
             && isFinalAnswerReply({
               text: decision.mergedText,
-              disableNotification,
+              disableNotification: modelDisableNotification,
             })
           ) {
             turn.finalAnswerDelivered = true
@@ -7905,7 +7914,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
             // answer must NOT re-open the feed on post-answer housekeeping.
             turn.finalAnswerSubstantive = isSubstantiveFinalReply({
               text: decision.mergedText,
-              disableNotification,
+              disableNotification: modelDisableNotification,
             })
             if (turn.finalAnswerSubstantive) closeObligationOnSubstantiveReply(args, turn, replyRoutedOriginTurn)
           }
@@ -8245,12 +8254,12 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     //
     // #1664 — `turn.finalAnswerDelivered = true` keeps the silent-
     // end re-prompt from spuriously firing on a delivered final.
-    if (turn != null && isFinalAnswerReply({ text: rawText, disableNotification })) {
+    if (turn != null && isFinalAnswerReply({ text: rawText, disableNotification: modelDisableNotification })) {
       turn.finalAnswerDelivered = true
       // Feed-reopen refinement: track whether this final was substantive
       // (≥200 chars or stream-done — not a short pinging ack) so post-answer
       // housekeeping tool work does NOT re-open the feed / trip silent-end.
-      turn.finalAnswerSubstantive = isSubstantiveFinalReply({ text: rawText, disableNotification })
+      turn.finalAnswerSubstantive = isSubstantiveFinalReply({ text: rawText, disableNotification: modelDisableNotification })
       // #1728: release the buffer gate + emit terminal 👍. Mid-turn
       // acks bypass this branch and remain non-events for the
       // reaction (preserves #1713). The full turn-state teardown


### PR DESCRIPTION
## Summary

`executeReply` ran the over-ping safety net (#1675), which **reassigns `disableNotification = true`** (gateway.ts:7598) to silence a 2nd+ ping, then classified the reply with `isFinalAnswerReply({ disableNotification })` using that **downgraded** value. So a final answer the model intended to ping but the anti-spam net silenced was **misclassified as not-final** → `finalAnswerDelivered` stayed false. Two effects:
- a **spurious silent-end re-prompt** (#1664) on a turn that *did* deliver, and
- **since #2530, a false 'undelivered' 😐** terminal reaction on that delivered turn.

`executeStreamReply` was already correct — it classifies on `args.disable_notification === true` (the model's original intent) at 8464/8614/8624. This PR makes `executeReply` match.

## Found by
The `midturn-silent-dm` UAT against the live v0.15.57 fleet: the model pinged an interim **"On it."**, the over-ping net silenced the real final answer, and `finalAnswerDelivered` went false. (The UAT asserts pings, not the emoji — analysing the failure surfaced the false-😐.)

## Fix
Capture the model's original intent once (`const modelDisableNotification = args.disable_notification === true`) and use it at `executeReply`'s 5 classification call sites. The actual **send still uses the downgraded `disableNotification`**, so anti-spam pacing is unchanged — only the final-answer *classification* is corrected.

## Test plan
- [x] `npm run lint` clean (incl. strict plugin-references tsc)
- [x] Full `vitest run telegram-plugin/` — **4300 pass / 0 fail**
- [x] `executeStreamReply` already uses model intent → this aligns the two paths
- [ ] Re-run `midturn-silent-dm` UAT post-merge (model-pacing-dependent; the over-ping path now classifies correctly)

## Risk
Low + strictly more correct: reduces spurious silent-end re-prompts and removes the false 😐, with zero change to anti-spam send behaviour. Kill-switch for the 😐 specifically remains `SWITCHROOM_TG_TERMINAL_HONESTY=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)