### PR TITLE
test(telegram): pin the over-ping/final-answer decoupling contract (#2533 follow-up)

### DIFF
--- a/telegram-plugin/tests/over-ping-final-answer-decoupling.test.ts
+++ b/telegram-plugin/tests/over-ping-final-answer-decoupling.test.ts
@@ -29,7 +29,7 @@ describe('#2533 — over-ping downgrade must not pollute final-answer classifica
   // The midturn-silent-dm failing sequence: an interim ack pings, then a
   // SHORT final answer the model also intended to ping.
   const ACK = { text: 'On it.', modelWantsPing: true }
-  const FINAL = { text: 'Hostname is pixsoul-ubuntu.', modelWantsPing: true } // 27 chars, <200
+  const FINAL = { text: 'Hostname is example-host.', modelWantsPing: true } // <200 chars
 
   it('reproduces the sequence: ack claims the ping slot, the short final gets over-ping-suppressed', () => {
     // Beat 1 — the ack pings; first ping of the turn claims the slot (not suppressed).

--- a/telegram-plugin/tests/over-ping-final-answer-decoupling.test.ts
+++ b/telegram-plugin/tests/over-ping-final-answer-decoupling.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression contract for #2533: the over-ping anti-spam downgrade MUST NOT
+ * pollute final-answer classification.
+ *
+ * The bug (surfaced by the `midturn-silent-dm` UAT against v0.15.57): in
+ * `executeReply`, the #1675 over-ping safety net reassigns the local
+ * `disableNotification` to `true` to silence a 2nd+ ping in a turn, and the
+ * final-answer classifier was then read with that *downgraded* value. So a
+ * final answer the model INTENDED to ping but the anti-spam net silenced was
+ * misclassified as not-final → `finalAnswerDelivered` stayed false → a
+ * spurious silent-end re-prompt (#1664) AND a false 'undelivered' 😐 (#2530).
+ *
+ * The contract this pins (what `executeStreamReply` already did, and what
+ * #2533 made `executeReply` do): final-answer classification keys on the
+ * MODEL'S ORIGINAL INTENT (`args.disable_notification`), not the
+ * over-ping-downgraded send value. The actual SEND still honours the
+ * downgrade — only the classification is decoupled.
+ *
+ * `executeReply` itself isn't unit-callable (it lives in the 22k-line
+ * gateway), so this ties the two real pure modules together to reproduce the
+ * exact failing sequence and assert the invariant.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { decideOverPing } from '../over-ping-safety-net.js'
+import { isFinalAnswerReply } from '../final-answer-detect.js'
+
+describe('#2533 — over-ping downgrade must not pollute final-answer classification', () => {
+  // The midturn-silent-dm failing sequence: an interim ack pings, then a
+  // SHORT final answer the model also intended to ping.
+  const ACK = { text: 'On it.', modelWantsPing: true }
+  const FINAL = { text: 'Hostname is pixsoul-ubuntu.', modelWantsPing: true } // 27 chars, <200
+
+  it('reproduces the sequence: ack claims the ping slot, the short final gets over-ping-suppressed', () => {
+    // Beat 1 — the ack pings; first ping of the turn claims the slot (not suppressed).
+    const ackDecision = decideOverPing({ modelRequestedPing: ACK.modelWantsPing, firstPingAt: null, nowMs: 1_000 })
+    expect(ackDecision.suppress).toBe(false)
+    expect(ackDecision.claimSlot).toBe(true)
+    const firstPingAt = 1_000
+
+    // Beat 2 — the real final answer also wants to ping, but the slot is taken → SUPPRESS.
+    const finalDecision = decideOverPing({ modelRequestedPing: FINAL.modelWantsPing, firstPingAt, nowMs: 2_000 })
+    expect(finalDecision.suppress).toBe(true) // the gateway would downgrade disable_notification:false → true
+  })
+
+  it('classifying on the MODEL INTENT marks the suppressed short final as final (correct)', () => {
+    // This is what the gateway MUST do (#2533): use args.disable_notification,
+    // NOT the over-ping-downgraded value.
+    const modelDisableNotification = !FINAL.modelWantsPing // model wanted to ping → false
+    expect(
+      isFinalAnswerReply({ text: FINAL.text, disableNotification: modelDisableNotification }),
+    ).toBe(true) // delivered final → finalAnswerDelivered=true → no spurious re-prompt, no false 😐
+  })
+
+  it('classifying on the DOWNGRADED value misclassifies it as not-final (the bug #2533 fixed)', () => {
+    // The over-ping net forced disable_notification → true. If classification
+    // reads THAT (the pre-#2533 bug), the short non-done final is seen as an
+    // interim ack → finalAnswerDelivered stays false → spurious re-prompt + 😐.
+    const downgradedDisableNotification = true
+    expect(
+      isFinalAnswerReply({ text: FINAL.text, disableNotification: downgradedDisableNotification }),
+    ).toBe(false) // <-- this WRONG classification is exactly what the gateway must NOT produce
+  })
+
+  it('a genuinely-silent interim ack (model set disable_notification:true) is still NOT final — fix does not over-correct', () => {
+    // The decoupling must not turn EVERY reply final: a short reply the MODEL
+    // marked silent (a real interim ack) still classifies non-final on model intent.
+    const modelSilentAck = true
+    expect(
+      isFinalAnswerReply({ text: 'looking into that…', disableNotification: modelSilentAck }),
+    ).toBe(false)
+  })
+
+  it('a long over-ping-suppressed answer was already final regardless (length backstop) — fix matters for SHORT finals', () => {
+    const long = 'x'.repeat(250)
+    // Even classifying on the downgraded value, length ≥200 makes it final — so
+    // the bug only ever bit SHORT over-ping-suppressed finals (the #2533 case).
+    expect(isFinalAnswerReply({ text: long, disableNotification: true })).toBe(true)
+    expect(isFinalAnswerReply({ text: long, disableNotification: false })).toBe(true)
+  })
+})


### PR DESCRIPTION
Adds the regression guard the #2533 reviewer flagged as missing. `executeReply` isn't unit-callable, so this ties the real `decideOverPing` + `isFinalAnswerReply` modules together to reproduce the `midturn-silent-dm` failing sequence and pin the invariant: a short final the model intended to ping but the over-ping net silenced classifies **final on model intent**, and would **wrongly** classify not-final on the downgraded value. Also pins that the fix doesn't over-correct. 5 tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)