### PR TITLE
fix(telegram): background-agent reliability — registry busy_timeout + foreground-feed liveness

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -22628,6 +22628,16 @@ void (async () => {
                     if (turn.activityInFlight == null) {
                       turn.activityInFlight = drainActivitySummary(turn)
                     }
+                    // A foreground sub-agent's nested activity IS user-visible
+                    // production — count it so the silence-poke clock resets,
+                    // exactly like the parent activity-render path (10665). Without
+                    // this, a long tools-only foreground sub-agent (no prose) lets
+                    // the 300s framework fallback (and the #2527 mid-turn floor)
+                    // measure silence against a turn that is visibly working,
+                    // risking a premature tear-down / unwanted liveness beat.
+                    if (SILENCE_LIVENESS_PRODUCTION && currentTurn === turn) {
+                      silencePoke.noteProduction(statusKey(turn.sessionChatId, turn.sessionThreadId), Date.now())
+                    }
                   }
                   return
                 }

--- a/telegram-plugin/hooks/subagent-tracker-posttool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-posttool.mjs
@@ -74,6 +74,12 @@ function resolveSyncSqlite() {
       const { Database } = require('bun:sqlite')
       return function BunDatabaseSyncAdapter(p) {
         const d = new Database(p)
+        // Concurrency: this hook writes the registry from a separate process
+        // that contends with the gateway's subagent-watcher. Without a
+        // busy_timeout the write fails immediately with SQLITE_BUSY
+        // ("database is locked") when several sub-agents dispatch at once.
+        // Wait-and-retry instead (per-connection PRAGMA).
+        try { d.exec('PRAGMA busy_timeout = 5000') } catch { /* best-effort */ }
         return {
           exec: (sql) => d.exec(sql),
           prepare: (sql) => d.prepare(sql),

--- a/telegram-plugin/hooks/subagent-tracker-posttool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-posttool.mjs
@@ -74,12 +74,6 @@ function resolveSyncSqlite() {
       const { Database } = require('bun:sqlite')
       return function BunDatabaseSyncAdapter(p) {
         const d = new Database(p)
-        // Concurrency: this hook writes the registry from a separate process
-        // that contends with the gateway's subagent-watcher. Without a
-        // busy_timeout the write fails immediately with SQLITE_BUSY
-        // ("database is locked") when several sub-agents dispatch at once.
-        // Wait-and-retry instead (per-connection PRAGMA).
-        try { d.exec('PRAGMA busy_timeout = 5000') } catch { /* best-effort */ }
         return {
           exec: (sql) => d.exec(sql),
           prepare: (sql) => d.prepare(sql),
@@ -319,6 +313,11 @@ function updateRow(dbPath, { id, status, resultSummary, now, asyncLaunch }, done
     setImmediate(() => {
       try {
         const db = new SnapDatabaseSync(snapDbPath)
+        // Concurrency: per-connection busy_timeout so this hook's writes
+        // wait-and-retry instead of failing with SQLITE_BUSY under concurrent
+        // sub-agent dispatch. Set on the real open so BOTH the node:sqlite
+        // (production) and bun:sqlite branches are armed (#2535 review).
+        try { db.exec('PRAGMA busy_timeout = 5000') } catch { /* best-effort */ }
         const row = db.prepare(SELECT_SQL).get(snapId)
         const isBackground = row != null && row.background === 1
         if (isBackground) {

--- a/telegram-plugin/hooks/subagent-tracker-pretool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-pretool.mjs
@@ -123,6 +123,12 @@ function resolveSyncSqlite() {
       // sufficient — we only need the call-site shape.
       return function BunDatabaseSyncAdapter(p) {
         const d = new Database(p)
+        // Concurrency: this hook writes the registry from a separate process
+        // that contends with the gateway's subagent-watcher. Without a
+        // busy_timeout the write fails immediately with SQLITE_BUSY
+        // ("database is locked") when several sub-agents dispatch at once,
+        // dropping the row. Wait-and-retry instead (per-connection PRAGMA).
+        try { d.exec('PRAGMA busy_timeout = 5000') } catch { /* best-effort */ }
         return {
           exec: (sql) => d.exec(sql),
           prepare: (sql) => d.prepare(sql),

--- a/telegram-plugin/hooks/subagent-tracker-pretool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-pretool.mjs
@@ -123,12 +123,6 @@ function resolveSyncSqlite() {
       // sufficient — we only need the call-site shape.
       return function BunDatabaseSyncAdapter(p) {
         const d = new Database(p)
-        // Concurrency: this hook writes the registry from a separate process
-        // that contends with the gateway's subagent-watcher. Without a
-        // busy_timeout the write fails immediately with SQLITE_BUSY
-        // ("database is locked") when several sub-agents dispatch at once,
-        // dropping the row. Wait-and-retry instead (per-connection PRAGMA).
-        try { d.exec('PRAGMA busy_timeout = 5000') } catch { /* best-effort */ }
         return {
           exec: (sql) => d.exec(sql),
           prepare: (sql) => d.prepare(sql),
@@ -190,6 +184,14 @@ function writeRow(dbPath, { id, parentSessionId, parentTurnKey, agentType, descr
     setImmediate(() => {
       try {
         const db = new SnapDatabaseSync(snapDbPath)
+        // Concurrency: this hook writes registry.db from a separate process
+        // that contends with the gateway's subagent-watcher + the PostToolUse
+        // hook. Without a busy_timeout, the contending write fails IMMEDIATELY
+        // with SQLITE_BUSY ("database is locked") when several sub-agents
+        // dispatch at once, dropping the row → NULL jsonl_agent_id/parent_turn_key.
+        // Per-connection PRAGMA, set on the real open so BOTH the node:sqlite
+        // (production) and bun:sqlite branches are armed.
+        try { db.exec('PRAGMA busy_timeout = 5000') } catch { /* best-effort */ }
         db.exec(snapSchemaSql)
         // Migrate older DBs that pre-date jsonl_agent_id.
         const hasJsonlCol = db.prepare(snapMigrateSql).get()

--- a/telegram-plugin/registry/turns-schema.test.ts
+++ b/telegram-plugin/registry/turns-schema.test.ts
@@ -24,6 +24,30 @@ import {
 } from './turns-schema.js'
 
 // ---------------------------------------------------------------------------
+// Concurrency PRAGMAs — applySchema must arm busy_timeout so concurrent
+// writers (the subagent-tracker hooks + the gateway watcher) wait-and-retry
+// instead of failing with SQLITE_BUSY ("database is locked").
+// ---------------------------------------------------------------------------
+
+describe('registry concurrency PRAGMAs', () => {
+  it('arms busy_timeout (5000ms) on every opened connection', () => {
+    const db = openTurnsDbInMemory()
+    const row = db.prepare('PRAGMA busy_timeout').get() as { timeout: number }
+    expect(row.timeout).toBe(5000)
+    db.close()
+  })
+
+  it('uses WAL journal mode for concurrent readers', () => {
+    const db = openTurnsDbInMemory()
+    const row = db.prepare('PRAGMA journal_mode').get() as { journal_mode: string }
+    // `:memory:` reports 'memory'; a file DB reports 'wal'. Either way the
+    // exec ran without error — the file-path open (openTurnsDb) yields 'wal'.
+    expect(['wal', 'memory']).toContain(String(row.journal_mode).toLowerCase())
+    db.close()
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Test 1 — empty DB
 // ---------------------------------------------------------------------------
 

--- a/telegram-plugin/registry/turns-schema.ts
+++ b/telegram-plugin/registry/turns-schema.ts
@@ -172,6 +172,15 @@ const PHASE2_MIGRATIONS = [
 function applySchema(db: SqliteDatabase): void {
   db.exec('PRAGMA journal_mode = WAL')
   db.exec('PRAGMA synchronous = NORMAL')
+  // Concurrency: multiple writers contend on this registry (the PreToolUse
+  // subagent-tracker hook, the gateway's subagent-watcher backfill, the turns
+  // writer) — especially when several sub-agents dispatch at once. Without a
+  // busy_timeout, bun:sqlite/better-sqlite3 default to 0ms and the second
+  // contending write fails IMMEDIATELY with SQLITE_BUSY ("database is locked"),
+  // which the watcher swallows → jsonl_agent_id / parent_turn_key left NULL →
+  // worker card mis-routes to the operator DM + false silent-stall synthesis.
+  // 5s of wait-and-retry serializes the contenders instead of dropping writes.
+  db.exec('PRAGMA busy_timeout = 5000')
   db.exec(SCHEMA_SQL)
   // Run migrations. SQLite doesn't support "ADD COLUMN IF NOT EXISTS", so
   // we swallow the "duplicate column" error to stay idempotent on


### PR DESCRIPTION
## Summary

Two pre-existing background-agent fragilities surfaced by UAT against v0.15.57 — **neither a #2530 regression** (verified: the mid-turn floor never fired and #2530 doesn't touch these paths; the investigation that flagged #2 of these as a same-day #2530 regression was over-attributed — see the adversarial-verification note below).

### Fix 1 — `SQLITE_BUSY` ("database is locked") under concurrent sub-agent dispatch
`registry.db` has **three** writer connections — the gateway watcher (`openTurnsDb`), the PreToolUse `subagent-tracker-pretool.mjs`, and the PostToolUse `subagent-tracker-posttool.mjs` — and **none** armed a `busy_timeout`. bun:sqlite defaults to 0ms, so the second contending write fails immediately; the watcher swallows it (`subagent-watcher.ts` catch) → `jsonl_agent_id`/`parent_turn_key` left **NULL** → **worker card mis-routes to the operator DM** + false silent-stall synthesis. **Fix:** `PRAGMA busy_timeout = 5000` on all three connections (it's per-connection), so writers wait-and-retry. + a `turns-schema` test asserting it's armed.

### Fix 2 — foreground sub-agent nested-activity didn't reset the silence clock
The #2032 foreground-nesting render path never called `silencePoke.noteProduction`, so a long **tools-only** foreground sub-agent (no prose) lets the 300s framework fallback (and the #2527 floor) measure silence against a visibly-working turn. **Fix:** add `noteProduction`, copied verbatim from the proven **parent** activity-render path (`gateway.ts:10665`), same `SILENCE_LIVENESS_PRODUCTION` gate. *This is a defensive correctness fix — the #2032 UAT failure itself is **model-behavior** (the model did the check inline rather than dispatching a foreground sub-agent), not this gap.*

## NOT in this PR (filed as an issue)
A third finding — `onStallTerminal` is a no-op because `progressDriver` is null since #1122 — turned out **murkier than the investigation claimed**: the no-op fall-through to `onFinish` is *designed*, and `session-tail` plausibly already releases the deferred-completion gate via its own synthesized `sub_agent_turn_end` (so the dead `progressDriver.ingest` is redundant). Blind-fixing incident-scarred deferred-completion logic carries double-fire risk, so it's filed for a dedicated, careful PR rather than rushed here.

## Test plan
- [x] `npm run lint` clean (incl. strict plugin-references tsc)
- [x] `node --check` both hook .mjs files
- [x] **90 bun** registry/subagent tests (incl. the new busy_timeout assertion)
- [x] Full `vitest run telegram-plugin/` — **4300 pass / 0 fail**
- [ ] Concurrent-dispatch UAT post-merge (4 sub-agents at once → no "database is locked" in logs; `jsonl_agent_id`/`parent_turn_key` populated)

## Risk
Low. `busy_timeout` is a standard concurrency PRAGMA (wait-and-retry, no behaviour change otherwise). The `noteProduction` add is copied from an existing proven site with the same kill-switch gate. The hooks reach the fleet via the next image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)