### PR TITLE
test(telegram): align stale root tool-label test with #2516 surface-tool suppression

### DIFF
--- a/tests/tool-label-pretool.test.ts
+++ b/tests/tool-label-pretool.test.ts
@@ -228,10 +228,12 @@ describe("tool-label-pretool.mjs", () => {
   });
 
   it("MCP allowlist (telegram + hindsight)", () => {
+    // NOTE (#2516): the switchroom-telegram SURFACE tools (reply, stream_reply,
+    // react, edit_message) are now suppressed key-agnostically — they ARE the
+    // conversation, so they don't get an activity-feed label. They're asserted
+    // in the "genuinely-suppressed tools" test below. Only the read-only /
+    // non-surface MCP tools get a label here.
     const cases: Array<[string, Record<string, unknown>, string]> = [
-      ["mcp__switchroom-telegram__reply", { text: "hi" }, "Replying"],
-      ["mcp__switchroom-telegram__stream_reply", { text: "hi" }, "Replying"],
-      ["mcp__switchroom-telegram__react", { emoji: "👍" }, "Reacting 👍"],
       ["mcp__switchroom-telegram__get_recent_messages", {}, "Reading chat history"],
       ["mcp__hindsight__recall", { query: "x" }, "Searching memory"],
       ["mcp__hindsight__reflect", { query: "x" }, "Searching memory"],
@@ -275,12 +277,19 @@ describe("tool-label-pretool.mjs", () => {
     });
   });
 
-  it("genuinely-suppressed tools (send_typing, sync_retain) still emit nothing", () => {
+  it("genuinely-suppressed tools (surface/control tools) still emit nothing", () => {
     // NOTE (#2111): an "exotic" mcp__ tool is NO LONGER suppressed — operator
     // MCP servers (perplexity, webkite, …) now get a generic label so research
     // turns surface in the live activity feed. Only the surface/control tools
     // below stay silent.
+    // NOTE (#2516): the switchroom-telegram surface tools (reply / stream_reply /
+    // react / edit_message) are the conversation itself and are suppressed
+    // key-agnostically — they emit no sidecar label.
     const cases: Array<[string, Record<string, unknown>]> = [
+      ["mcp__switchroom-telegram__reply", { text: "hi" }],
+      ["mcp__switchroom-telegram__stream_reply", { text: "hi" }],
+      ["mcp__switchroom-telegram__react", { emoji: "👍" }],
+      ["mcp__switchroom-telegram__edit_message", { text: "hi" }],
       ["mcp__switchroom-telegram__send_typing", {}],
       ["mcp__hindsight__sync_retain", {}],
     ];


### PR DESCRIPTION
## Summary

`tests/tool-label-pretool.test.ts` was **stale**: it expected the switchroom-telegram surface tools (`reply`/`stream_reply`/`react`) to emit labels, but **#2516** ("key-agnostic surface-tool suppression") changed the hook to **suppress** them and added a *new* test (`telegram-plugin/tests/tool-label-pretool.test.ts:46`, `reply → toBeNull()`) — while leaving this old root test un-updated. It passed CI only because the changed-files shards rarely ran it; #2531 (a docs PR with a broad run) surfaced it, blocking that PR.

## Verification (current origin/main hook)
`reply` / `stream_reply` / `react` / `edit_message` → **suppressed** (no sidecar); `get_recent_messages` → "Reading chat history". So this is **aligning the stale test with the verified, intended behavior** — confirmed by the newer test — not pinning a regression.

## Change
Move the four surface tools from the "labeled" cases to the existing "genuinely-suppressed tools" case in the same file. Test-only.

## Test plan
- [x] `vitest run tests/tool-label-pretool.test.ts` — **25/25 pass** (was 1 failed)
- [x] `npm run lint` clean (incl. check-no-pii-secrets)

Unblocks #2531 (which will be rebased onto this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)