### PR TITLE
fix(telegram): /clear inject no longer renders raw TUI chrome

### DIFF
--- a/src/agents/inject.test.ts
+++ b/src/agents/inject.test.ts
@@ -17,6 +17,7 @@ import {
   dedupeInjectQueue,
   injectSlashCommand,
   injectSlashCommandWith,
+  isTuiChromeLine,
   normalizeInjectCommand,
   validateInjectCommand,
   type TmuxRunner,
@@ -102,10 +103,10 @@ describe("INJECT_COMMANDS metadata", () => {
     );
   });
 
-  it("/clear has expectsOutput=false and no silentNote", () => {
+  it("/clear has expectsOutput=false and silentNote 'context cleared — fresh slate'", () => {
     const meta = INJECT_COMMANDS.get("/clear");
     expect(meta?.expectsOutput).toBe(false);
-    expect(meta?.silentNote).toBeUndefined();
+    expect(meta?.silentNote).toBe("context cleared — fresh slate");
   });
 });
 
@@ -188,6 +189,129 @@ some-narrative
     expect(r.output).toContain("new line C");
     expect(r.output).toContain("new line D");
     expect(r.anchored).toBe(false);
+  });
+});
+
+describe("isTuiChromeLine — chrome predicate", () => {
+  // Lines that must be filtered (chrome)
+  it("identifies box-drawing rule lines as chrome", () => {
+    expect(isTuiChromeLine("─────────────────────────────")).toBe(true);
+    expect(isTuiChromeLine("│")).toBe(true);
+    expect(isTuiChromeLine("╭──────────────────────╮")).toBe(true);
+    expect(isTuiChromeLine("╰──────────────────────╯")).toBe(true);
+    expect(isTuiChromeLine("______________________________")).toBe(true);
+    expect(isTuiChromeLine("------------------------------")).toBe(true);
+  });
+
+  it("identifies bare prompt-glyph lines as chrome", () => {
+    expect(isTuiChromeLine("❯")).toBe(true);
+    expect(isTuiChromeLine(">")).toBe(true);
+    expect(isTuiChromeLine(")")).toBe(true);
+    expect(isTuiChromeLine("  ❯  ")).toBe(true);
+    expect(isTuiChromeLine("│ ❯ │")).toBe(true);
+  });
+
+  it("identifies footer hint lines as chrome", () => {
+    expect(isTuiChromeLine("▶▶ accept edits on (shift+tab to cycle) · ← for agents")).toBe(true);
+    expect(isTuiChromeLine("shift+tab to cycle modes")).toBe(true);
+    expect(isTuiChromeLine("← for agents")).toBe(true);
+    expect(isTuiChromeLine("? for shortcuts")).toBe(true);
+    expect(isTuiChromeLine("bypassing permissions")).toBe(true);
+  });
+
+  it("identifies the copy affordance as chrome", () => {
+    expect(isTuiChromeLine("copy")).toBe(true);
+  });
+
+  // Lines that must NOT be filtered (real content)
+  it("does NOT strip real output lines", () => {
+    expect(isTuiChromeLine("Total cost: $1.23")).toBe(false);
+    expect(isTuiChromeLine("Session cost: $0.05")).toBe(false);
+    expect(isTuiChromeLine("  Model: claude-opus-4  ")).toBe(false);
+    expect(isTuiChromeLine("Context window: 3%")).toBe(false);
+    expect(isTuiChromeLine("No hooks configured")).toBe(false);
+    expect(isTuiChromeLine("  Cache creation: 1234 tokens")).toBe(false);
+  });
+});
+
+describe("diffPane — /clear post-clear TUI chrome filtering", () => {
+  // Realistic post-/clear capture: command-echo ABSENT (wiped), fresh input-box chrome visible
+  const clearBefore = `  Some earlier output line
+  Another earlier line
+❯ /clear`;
+
+  const clearAfter = `╭──────────────────────────────────────────────────────────────────────╮
+│ ❯                                                                    │
+╰──────────────────────────────────────────────────────────────────────╯
+▶▶ accept edits on (shift+tab to cycle) · ← for agents`;
+
+  it("falls back to set-diff when /clear echo is absent", () => {
+    const r = diffPane(clearBefore, clearAfter, "/clear");
+    expect(r.anchored).toBe(false);
+  });
+
+  it("strips all chrome lines in the fallback path — output is empty", () => {
+    const r = diffPane(clearBefore, clearAfter, "/clear");
+    expect(r.output).toBe("");
+  });
+
+  it("anchored /cost path is unaffected — real content passes through", () => {
+    const before = "❯ /cost\n";
+    const after = `❯ /cost
+  Total cost: $0.42
+  Session: $0.12 (3 turns)`;
+    const r = diffPane(before, after, "/cost");
+    expect(r.anchored).toBe(true);
+    expect(r.output).toContain("Total cost: $0.42");
+    expect(r.output).toContain("$0.12");
+  });
+
+  it("fallback does NOT strip real output lines that happen to appear without an anchor", () => {
+    const before = "old line\n";
+    const after = "old line\nTotal cost: $1.23\nContext window: 5%\n";
+    const r = diffPane(before, after, "/cost");
+    expect(r.anchored).toBe(false);
+    expect(r.output).toContain("Total cost: $1.23");
+    expect(r.output).toContain("Context window: 5%");
+  });
+});
+
+describe("injectSlashCommandWith — /clear produces ok_no_output (not ok with chrome)", () => {
+  it("post-clear pane with only TUI chrome → outcome=ok_no_output, output empty", async () => {
+    // Simulate what happens after /clear: pre-snapshot has content,
+    // post-capture has only fresh input-box chrome (no command-echo line).
+    const before = `  Some earlier session output
+  Another line of output
+❯ /clear`;
+    const clearChrome = `╭───────────────────────────────────────────────────────────────╮
+│ ❯                                                             │
+╰───────────────────────────────────────────────────────────────╯
+▶▶ accept edits on (shift+tab to cycle) · ← for agents`;
+
+    let callCount = 0;
+    const runner: TmuxRunner = {
+      hasSession: () => true,
+      capture: () => {
+        callCount += 1;
+        // First capture (before send) returns the pre-snapshot.
+        // Subsequent captures (after send) return the post-clear chrome.
+        return callCount === 1 ? before : clearChrome;
+      },
+      send: () => {},
+    };
+
+    const r = await injectSlashCommandWith(runner, {
+      socket: "switchroom-test",
+      session: "test",
+      command: "/clear",
+      settleMs: 50,
+      timeoutMs: 200,
+    });
+
+    expect(r.outcome).toBe("ok_no_output");
+    expect(r.output).toBe("");
+    expect(r.command).toBe("/clear");
+    expect(r.meta?.silentNote).toBe("context cleared — fresh slate");
   });
 });
 

--- a/src/agents/inject.ts
+++ b/src/agents/inject.ts
@@ -66,7 +66,11 @@ export const INJECT_COMMANDS: ReadonlyMap<string, InjectCommandMeta> = new Map([
   // non-interactively via the `--effort` CLI flag at session start.
   [
     "/clear",
-    { description: "Clear session screen", expectsOutput: false },
+    {
+      description: "Clear session screen",
+      expectsOutput: false,
+      silentNote: "context cleared — fresh slate",
+    },
   ],
   [
     "/compact",
@@ -368,6 +372,44 @@ export interface DiffPaneResult {
  * command-echo anchor is found in the post-capture, fall back to
  * line-set diff so unusual TUI shapes still surface something.
  */
+
+/**
+ * Returns true for lines that are pure Claude Code TUI chrome — input-box
+ * borders, prompt glyphs, footer hints, and copy affordances that appear
+ * after `/clear` wipes the screen. Applied only in the FALLBACK (anchor-
+ * missing) path of `diffPane` to prevent input-box furniture from being
+ * classified as command output. Conservative by design: a real output line
+ * (e.g. "Total cost: $1.23") must never match.
+ *
+ * Patterns matched:
+ *   - box-drawing / rule lines: only border/rule glyphs, underscores, dashes, pipes
+ *   - bare prompt glyphs: trimmed content is only `>`, `)`, or `❯` (with optional box chars)
+ *   - footer hints: lines containing the known footer phrases
+ *   - copy affordance: trimmed content is exactly "copy"
+ */
+export function isTuiChromeLine(line: string): boolean {
+  const t = line.trim();
+  if (t.length === 0) return false;
+
+  // box-drawing / rule lines: only border glyphs, underscores, dashes, pipes, spaces
+  if (/^[\s\-_│─╭╮╰╯┌┐└┘|]+$/.test(t)) return true;
+
+  // bare prompt-glyph lines
+  if (/^[╭╮╰╯│\s]*[>)❯][╭╮╰╯│\s]*$/.test(t)) return true;
+
+  // footer hints
+  if (/accept edits on/i.test(t)) return true;
+  if (/shift\+tab to cycle/i.test(t)) return true;
+  if (/for agents/i.test(t)) return true;
+  if (/\? for shortcuts/i.test(t)) return true;
+  if (/bypassing permissions/i.test(t)) return true;
+
+  // copy affordance
+  if (t === "copy") return true;
+
+  return false;
+}
+
 export function diffPane(before: string, after: string, command?: string): DiffPaneResult {
   if (command) {
     const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -400,13 +442,18 @@ export function diffPane(before: string, after: string, command?: string): DiffP
       // Anchor found but tail is empty — fall through to set-diff.
     }
   }
-  // Fallback: line-set diff against pre-snapshot.
+  // Fallback: line-set diff against pre-snapshot, then strip TUI chrome.
+  // The chrome filter is applied here (fallback only) because `/clear`
+  // wipes the screen so the command-echo anchor is gone — the post-capture
+  // contains only fresh input-box furniture that isn't in the pre-snapshot
+  // and would otherwise be classified as command output.
   const beforeSet = new Set(before.split("\n").map((l) => l.trimEnd()));
   const newLines: string[] = [];
   for (const raw of after.split("\n")) {
     const line = raw.trimEnd();
     if (line.length === 0) continue;
     if (beforeSet.has(line)) continue;
+    if (isTuiChromeLine(line)) continue;
     newLines.push(line);
   }
   return { output: newLines.join("\n"), anchored: false };

--- a/telegram-plugin/gateway/inject-handler.test.ts
+++ b/telegram-plugin/gateway/inject-handler.test.ts
@@ -152,12 +152,13 @@ describe('handleInjectCommand — outcome=ok_no_output', () => {
     expect(replies[0].text).toContain('empty capture')
   })
 
-  it('bare ack with accent=done when expectsOutput=false and no silentNote (/clear)', async () => {
+  it('uses silentNote for /clear (context cleared — fresh slate)', async () => {
     const inject = vi.fn().mockResolvedValue(noOutputResult('/clear'))
     const { deps, replies } = makeDeps({ getArgs: () => '/clear', inject })
     await handleInjectCommand(fakeCtx(), deps)
     expect(replies[0].opts?.accent).toBe('done')
     expect(replies[0].text).toContain('<code>/clear</code>')
+    expect(replies[0].text).toContain('context cleared')
     expect(replies[0].text).not.toContain('empty capture')
     expect(replies[0].text).not.toContain('<pre>')
   })


### PR DESCRIPTION
## Root cause

After `/clear` wipes the screen, the command-echo line (`❯ /clear`) is gone from the post-capture. `diffPane` found no anchor, fell back to a line-set diff against the pre-snapshot, and returned the freshly-rendered input-box chrome (box-drawing borders, prompt glyph, footer hints) as command output. That output classified as `outcome: 'ok'` and `shapeReply` rendered it verbatim in the Telegram card — the user saw raw TUI furniture instead of a clean confirmation.

## Fix (two parts)

**1. `isTuiChromeLine` predicate + fallback-path filter** (`src/agents/inject.ts`)

Adds a new exported `isTuiChromeLine(line: string): boolean` predicate that recognises:
- Box-drawing / rule lines: only border glyphs, underscores, dashes, pipes
- Bare prompt-glyph lines: trimmed content is only `>`, `)`, or `❯` (with optional box chars/whitespace)
- Footer hints: lines matching `accept edits on`, `shift+tab to cycle`, `for agents`, `? for shortcuts`, `bypassing permissions`
- Copy affordance: trimmed content is exactly `copy`

Applied **only in the fallback (anchor-missing) path** of `diffPane` — the anchored path (used by `/cost`, `/status`, etc.) is unchanged. After filtering, `/clear`'s post-clear capture produces empty output → `outcome: 'ok_no_output'`.

**2. `silentNote` on `/clear`** (`src/agents/inject.ts`)

Adds `silentNote: "context cleared — fresh slate"` to the `/clear` entry in `INJECT_COMMANDS`. With `outcome: 'ok_no_output'` and a `silentNote`, `shapeReply` renders `✅ /clear — context cleared — fresh slate` — the same clean pattern `/compact` already uses.

## Tests added

- `isTuiChromeLine` unit tests: chrome patterns recognised; real output lines (`Total cost: $1.23`, `Context window: 5%`, etc.) NOT stripped.
- `diffPane` — `/clear` post-clear scenario: realistic chrome-only post-capture → empty output; anchored `/cost` path unaffected; fallback does not strip real content.
- `injectSlashCommandWith` integration test: pre-snapshot with content + post-clear chrome-only pane (no echo line) → `outcome: 'ok_no_output'`, `meta.silentNote` set.
- `inject-handler.test.ts`: updated `/clear` `ok_no_output` test to exercise the `silentNote` branch and assert `"context cleared"` in the reply.

## Job spec

Serves `jtbd-inject-slash-command` (visibility outcome) — the operator's `/clear` card must be a clean confirmation, not raw TUI furniture.

## Test plan

- [x] `vitest run src/agents/inject.test.ts` — 59 tests, all pass
- [x] `vitest run telegram-plugin/gateway/inject-handler.test.ts` — 13 tests, all pass
- [x] `tsc --noEmit` — clean