### PR TITLE
fix(auth-card): split the reset sub-line onto two lines

### DIFF
--- a/docs/telegram-features.md
+++ b/docs/telegram-features.md
@@ -169,9 +169,10 @@ When the auth-broker is reachable and the fleet has one or more
 accounts, `/usage` renders the **fleet snapshot**: every account in the
 broker's known set, live-probed in parallel, grouped by health
 (blocked-first, then throttling, then healthy). Each account row shows
-its `5h` and `7d` utilisation percentages plus a per-window reset line
-("5h refills 11:00 AM (in 6m) · 7d resets Sun 11:00 AM"). The
-fleet-active account is marked. This is the same renderer `/auth show`
+its `5h` and `7d` utilisation percentages plus two per-window reset
+lines, one per line so the second segment doesn't wrap mid-line on a
+narrow phone ("5h refills 11:00 AM (in 6m)" on one line, "7d resets Sun
+11:00 AM" on the next). The fleet-active account is marked. This is the same renderer `/auth show`
 uses, so the two commands speak one dialect.
 
 If the broker is unreachable (boot timing, broken socket), `/usage`

--- a/telegram-plugin/auth-snapshot-format.ts
+++ b/telegram-plugin/auth-snapshot-format.ts
@@ -246,11 +246,13 @@ const HEALTH_TITLE: Record<AccountHealth, string> = {
  * One-line per-account summary inside its health group.
  *
  *   you@example.com  ● 8% / 20%
- *     5h refills 11:00 AM (in 6m)  ·  7d resets Sun 11:00 AM
+ *     5h refills 11:00 AM (in 6m)
+ *     7d resets Sun 11:00 AM
  *
- * Two lines actually: the label/percent line and a sub-line with the
- * reset details. The blocked variant replaces the sub-line with the
- * recovery countdown.
+ * Three lines for a healthy/throttling row: the label/percent line plus
+ * two reset sub-lines (each window on its own line so the 7d segment
+ * doesn't wrap mid-line on a narrow phone). The blocked variant replaces
+ * the sub-lines with a single recovery countdown.
  */
 function renderAccountRow(
   snap: AccountSnapshot,
@@ -303,9 +305,10 @@ function renderAccountRow(
   }
 
   // Healthy / throttling: show whichever window is closer to refresh
-  // first, then the other on the same line. Reverses the screenshot's
+  // first, then the other on the next line. Reverses the screenshot's
   // "5h then 7d" ordering when 7d is the more pressing one — the user
-  // wants the imminent number first.
+  // wants the imminent number first. Each window gets its own line so the
+  // second segment doesn't wrap mid-line on a narrow phone screen.
   const fiveResetIn = q.fiveHourResetAt ? q.fiveHourResetAt.getTime() - now.getTime() : Infinity;
   const sevenResetIn = q.sevenDayResetAt ? q.sevenDayResetAt.getTime() - now.getTime() : Infinity;
   const fiveFirst = fiveResetIn <= sevenResetIn;
@@ -315,7 +318,8 @@ function renderAccountRow(
   const sevenSeg = q.sevenDayResetAt
     ? `7d resets ${formatAbsolute(q.sevenDayResetAt, tz)} (in ${formatRelative(q.sevenDayResetAt, now)})`
     : '7d resets —';
-  lines.push(`  <i>${fiveFirst ? fiveSeg : sevenSeg}  ·  ${fiveFirst ? sevenSeg : fiveSeg}</i>`);
+  lines.push(`  <i>${fiveFirst ? fiveSeg : sevenSeg}</i>`);
+  lines.push(`  <i>${fiveFirst ? sevenSeg : fiveSeg}</i>`);
   // Informational overage annotation: if out_of_credits (no overage headroom),
   // surface it as a sub-line on a healthy/throttling row — NOT a blocked badge.
   if (q.overageDisabledReason != null && OVERAGE_EXHAUSTED_REASONS.has(q.overageDisabledReason)) {

--- a/telegram-plugin/tests/auth-snapshot-format.test.ts
+++ b/telegram-plugin/tests/auth-snapshot-format.test.ts
@@ -214,9 +214,18 @@ describe('renderAuthSnapshotFormat2', () => {
   it('puts the imminent window first on healthy/throttling rows', () => {
     const out = renderAuthSnapshotFormat2(fixtureSnaps, { now: NOW, tz: 'UTC' });
     // you: 5h reset is in 7m, 7d reset is in 2d. 5h should come first.
-    const pixRow = out.split('\n').find((l) => l.includes('5h refills') && l.includes('7d resets'));
-    expect(pixRow).toBeDefined();
-    expect(pixRow!.indexOf('5h refills')).toBeLessThan(pixRow!.indexOf('7d resets'));
+    // The two reset segments now render on SEPARATE lines (so the 7d
+    // segment doesn't wrap mid-line on a narrow phone) — the imminent 5h
+    // line must precede the 7d line, each on its own line.
+    const lines = out.split('\n');
+    const fiveLine = lines.findIndex((l) => l.includes('5h refills'));
+    const sevenLine = lines.findIndex((l) => l.includes('7d resets'));
+    expect(fiveLine).toBeGreaterThanOrEqual(0);
+    expect(sevenLine).toBeGreaterThanOrEqual(0);
+    // Distinct lines, 5h before 7d.
+    expect(fiveLine).toBeLessThan(sevenLine);
+    expect(lines[fiveLine]).not.toContain('7d resets');
+    expect(lines[sevenLine]).not.toContain('5h refills');
   });
 
   it('emits a recommendation footer that names a healthy alternative when active is throttling', () => {


### PR DESCRIPTION
## Summary

The **Auth — fleet status** card rendered each account's reset sub-line as a single line joining the 5h and 7d segments with `  ·  `. On a narrow phone screen the second segment ("7d resets …") wrapped mid-line and looked broken. This splits the two windows onto **two separate lines** — the window closer to refresh first (preserving the existing `fiveFirst` ordering), the other on the next line — and drops the `  ·  ` separator.

Before:
```
  5h refills 11:00 AM (in 6m)  ·  7d resets Sun 11:00 AM
```
After:
```
  5h refills 11:00 AM (in 6m)
  7d resets Sun 11:00 AM
```

Each line keeps the two-space indent + `<i>…</i>` wrapping. Blocked/exhausted/probe-failed variants are untouched.

## Why

Serves **"track my plan quota live, without a dashboard"** (`reference/jobs/track-plan-quota-live.md`) — the quota/auth card has to read *at a glance* on the phone where the operator actually reads it. A segment that wraps mid-line is the opposite of glanceable.

## Changes

- `telegram-plugin/auth-snapshot-format.ts` — two `lines.push` instead of one joined line in `renderAccountRow`; updated the doc-comment example to the two-line layout.
- `telegram-plugin/tests/auth-snapshot-format.test.ts` — updated the "imminent window first" assertion to check the two segments are on distinct lines, 5h before 7d (not weakened — strengthened: also asserts each line excludes the other segment).
- `docs/telegram-features.md` — `/usage` fleet-snapshot description updated to the two-line layout.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `bun test` on auth-snapshot-format / auth-command-format2 / auth-command-vernacular / quota-watch — 176 pass, 0 fail
- [x] Full `telegram-plugin/tests/` sweep — no new failures introduced (pre-existing broker/auth-session/fake-claude-binary failures are environmental in the sandbox and reproduce identically on pristine `main`)

## Risk

Low. Pure presentation change to one card sub-line; ordering logic (`fiveFirst`) and all other row variants unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)