### PR TITLE
fix(rollout): refuse a roll when the driving CLI is older than --pin (#2542)

### DIFF
--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -19,6 +19,8 @@ import {
   encodeRolloutResultLine,
   parseRolloutResultLine,
   shouldRefuseDowngrade,
+  shouldRefuseStaleCli,
+  PREFLIGHT_STALE_CLI_STEP,
   ROLLOUT_RESULT_SENTINEL,
   type RolloutDeps,
   type RolloutResult,
@@ -392,6 +394,50 @@ describe("shouldRefuseDowngrade (#2487 PR2)", () => {
 
   it("never refuses when pin is absent (target comes from config, not --pin)", () => {
     expect(shouldRefuseDowngrade(true, undefined, CURRENT, undefined)).toBe(false);
+  });
+});
+
+// ── shouldRefuseStaleCli — driving CLI older than the target (#2542) ────────
+
+describe("shouldRefuseStaleCli (#2542)", () => {
+  it("refuses when the driving CLI is strictly older than the target", () => {
+    // The exact incident: hostd CLI 0.15.48 driving a roll to v0.15.59.
+    expect(shouldRefuseStaleCli("0.15.48", "v0.15.59")).toBe(true);
+  });
+
+  it("normalizes the v-prefix on both sides (build-info has no v, --pin does)", () => {
+    expect(shouldRefuseStaleCli("v0.15.48", "v0.15.59")).toBe(true);
+    expect(shouldRefuseStaleCli("0.15.48", "0.15.59")).toBe(true);
+  });
+
+  it("allows when the CLI is the same version as the target", () => {
+    expect(shouldRefuseStaleCli("0.15.59", "v0.15.59")).toBe(false);
+  });
+
+  it("allows when the CLI is NEWER than the target (a downgrade — other guard's job)", () => {
+    expect(shouldRefuseStaleCli("0.15.59", "v0.15.48")).toBe(false);
+  });
+
+  it("never fires when either side is unorderable (dev/sha/channel/garbage)", () => {
+    expect(shouldRefuseStaleCli("sha-abc1234", "v0.15.59")).toBe(false);
+    expect(shouldRefuseStaleCli("0.15.48", "latest")).toBe(false);
+    expect(shouldRefuseStaleCli("dev", "v0.15.59")).toBe(false);
+    expect(shouldRefuseStaleCli("not-a-version", "v0.15.59")).toBe(false);
+  });
+
+  it("never fires when the CLI version is missing", () => {
+    expect(shouldRefuseStaleCli(undefined, "v0.15.59")).toBe(false);
+    expect(shouldRefuseStaleCli("", "v0.15.59")).toBe(false);
+  });
+
+  it("compares across minor/major boundaries, not lexically", () => {
+    expect(shouldRefuseStaleCli("0.9.9", "v0.15.0")).toBe(true); // 0.9 < 0.15 (not string compare)
+    expect(shouldRefuseStaleCli("0.15.9", "v0.15.10")).toBe(true); // patch 9 < 10
+    expect(shouldRefuseStaleCli("1.0.0", "v0.15.59")).toBe(false); // major 1 > 0
+  });
+
+  it("the refusal step label is the stable structured-status value", () => {
+    expect(PREFLIGHT_STALE_CLI_STEP).toBe("preflight-stale-cli");
   });
 });
 

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -40,6 +40,7 @@ import { setReleasePinInConfig } from "./release-yaml.js";
 import { resolveOperatorUid } from "./operator-uid.js";
 import { writeConfigFileSync } from "../util/atomic.js";
 import { compareReleaseTags } from "../config/release-resolve.js";
+import { SWITCHROOM_VERSION } from "./resolve-version.js";
 
 /** One ordered step of a rollout plan. Pure data so it unit-tests. */
 export type RolloutStep =
@@ -256,6 +257,46 @@ export function shouldRefuseDowngrade(
 }
 
 /**
+ * `failedStep` label for a roll refused up-front because the DRIVING CLI is
+ * older than the target (#2542). Surfaced via the sentinel → hostd status row
+ * so `get_status` shows the cause structurally, not just in a stderr tail.
+ */
+export const PREFLIGHT_STALE_CLI_STEP = "preflight-stale-cli";
+
+/**
+ * Pure guard: returns true when the roll must be refused because the CLI
+ * DRIVING the rollout is OLDER than the target it's being asked to deploy.
+ *
+ * Why this is fatal, not a warning (#2542): the rollout's `apply` +
+ * per-agent-restart steps regenerate the compose file using THIS CLI's own
+ * generator code and version stamp. An older CLI cannot produce a newer
+ * target's compose correctly — even when `--pin` resolves the image tag, the
+ * compose schema/stamp is the old CLI's — so the roll boots agents on the
+ * stale version, fails the canary, and leaves compose drifted to a version
+ * older than what's running (a downgrade landmine). The only safe outcome is
+ * to refuse BEFORE the first mutation; there is no "work correctly" branch for
+ * an old CLI driving a new target.
+ *
+ * Conservative, mirroring the downgrade guard: refuses ONLY when both the CLI
+ * version and the target are clean `vX.Y.Z` semvers and the CLI is strictly
+ * older. A dev/sha/channel/unparseable version on either side is unorderable
+ * (`compareReleaseTags` → null) and never blocks.
+ *
+ * Exported for unit testing.
+ */
+export function shouldRefuseStaleCli(
+  cliVersion: string | undefined,
+  target: string,
+): boolean {
+  if (!cliVersion) return false;
+  const cmp = compareReleaseTags(
+    `v${normalizeVersion(cliVersion)}`,
+    `v${normalizeVersion(target)}`,
+  );
+  return cmp !== null && cmp < 0;
+}
+
+/**
  * True when this `switchroom rollout` was spawned by the host-control
  * daemon on behalf of an agent MCP call (#2487). hostd sets
  * `SWITCHROOM_HOSTD_CONTEXT=1` on the child env. The flag flips three
@@ -465,6 +506,47 @@ export function registerRolloutCommand(program: Command): void {
             `semver), so the target must be a tagged release like v0.15.18 — ` +
             `\`${target}\` isn't version-assertable. Pass --pin vX.Y.Z.\n`,
         );
+        process.exitCode = 2;
+        return;
+      }
+      // #2542 — stale-CLI guard: refuse up-front when the CLI DRIVING this
+      // roll is older than the target. An older CLI regenerates compose with
+      // its own stale generator + version stamp (the roll's apply +
+      // per-agent-restart steps), which boots agents on the stale version,
+      // fails the canary, and leaves compose downgraded below what's running.
+      // Refuse BEFORE the first mutation — there is no safe "work correctly"
+      // path for an old CLI driving a new target. Applies to BOTH the hostd
+      // path (the incident: source-unlinked hostd CLI behind the tag) and the
+      // host-shell path (an operator on a stale CLI). Conservative: only a
+      // clean vX.Y.Z < vX.Y.Z comparison blocks (dev/sha/channel never do).
+      if (shouldRefuseStaleCli(SWITCHROOM_VERSION, target)) {
+        const cli = normalizeVersion(SWITCHROOM_VERSION);
+        const refusal =
+          `rollout refused: the driving switchroom CLI is v${cli}, OLDER than ` +
+          `the --pin target ${target}. An older CLI regenerates the compose file ` +
+          `with its own (stale) generator and version stamp, which would boot ` +
+          `agents on v${cli}, fail the canary, and leave compose downgraded ` +
+          `below what's running. ` +
+          (hostdCtx
+            ? `Refresh hostd's CLI first — host-side: \`switchroom hostd install ` +
+              `--tag ${target}\` — then re-run the roll.`
+            : `Upgrade this CLI to >= ${target} first (e.g. \`switchroom update ` +
+              `--pin ${target}\`, or rebuild your checkout), then re-run.`) +
+          ` Nothing was changed.`;
+        process.stderr.write(refusal + "\n");
+        // Surface the cause STRUCTURALLY on the hostd path so get_status / the
+        // audit row show failed_step + got, not just a stderr tail (#2542 AC4).
+        if (hostdCtx) {
+          process.stdout.write(
+            encodeRolloutResultLine({
+              ok: false,
+              rolled: [],
+              failedStep: PREFLIGHT_STALE_CLI_STEP,
+              got: cli,
+              warnings: [refusal],
+            }) + "\n",
+          );
+        }
         process.exitCode = 2;
         return;
       }


### PR DESCRIPTION
Fixes #2542.

## Summary

`mcp__hostd__rollout` drives the roll with **hostd's own linked `switchroom` CLI**. When that CLI is **older** than the `--pin` target, the roll's `apply` + per-agent-restart steps regenerate `docker-compose.yml` using the **old CLI's generator and version stamp** — booting agents on the stale version, failing the canary, and leaving compose drifted *below* what's running (a downgrade landmine), after partially bumping other services. (Real incident 2026-06-23: hostd CLI `0.15.48` rolling `--pin v0.15.59` → compose stamped `0.15.48`, canary mismatch, 0 agents rolled, compose left drifted.)

This adds a **stale-CLI pre-flight guard** that refuses such a roll up-front, before any mutation.

## Why refuse (not "make it work")

AC#1 allows either. But there is no safe "work correctly" branch: an older CLI cannot generate a newer target's compose, and self-refreshing hostd mid-roll SIGKILLs the in-flight rollout (the documented #2487/#2458 brick scenario). The only safe outcome is to refuse before the first mutation. This matches the documented release flow, where the **driving CLI is updated to the target before rolling** (CLAUDE.md release step 7 "Update local host CLI" precedes step 10 "Fleet rollout"); the fix makes the hostd path enforce the same precondition instead of silently poisoning compose.

## How it maps to the acceptance criteria

- **AC1 (refuse up-front, clear error):** new pure guard `shouldRefuseStaleCli(cliVersion, target)` (mirrors the existing `shouldRefuseDowngrade`); wired into the rollout action *after* `isVersionAssertable` and *before* the downgrade guard / `planRollout`. Clear stderr: _"the driving switchroom CLI is v0.15.48, OLDER than the --pin target v0.15.59 … Refresh hostd's CLI first … Nothing was changed."_
- **AC2 (no compose drift on a stopped roll):** the guard `return`s before `persist-pin` / `apply` / `restart` — nothing is mutated. Stamp-only-on-the-correct-version by construction.
- **AC3 (singleton-reconcile must not bump ahead):** `apply` never runs, so the broker-trio singleton-reconcile never runs.
- **AC4 (cause visible in get_status / audit):** on the hostd path it emits the rollout result sentinel with `failedStep="preflight-stale-cli"` + `got=<cli version>`, which `spawnRollout` already maps into the `get_status` / audit row (`failed_step`, `got`); the refusal text also lands in `stderr_tail`.

## Design notes

- Uses `SWITCHROOM_VERSION` (the authoritative runtime version from `resolve-version.ts` — same value `switchroom --version` reports and the canary asserts), so the guard's "my version" equals the in-container assert and dodges the stale-baked-build-info trap.
- Conservative, mirroring the downgrade guard: refuses **only** when both sides are clean `vX.Y.Z` semvers and the CLI is strictly older. dev/sha/channel/garbage are unorderable (`compareReleaseTags → null`) and never block.
- Orthogonal to the downgrade guard: CLI-newer-than-target (a rollback) is unaffected here and still handled by `shouldRefuseDowngrade`.
- Applies to both the hostd path (the incident) and the host-shell path (an operator on a stale CLI).

## Workflow implication (intentional)

After this, a roll requires the driving CLI ≥ target. Overlord/operator must refresh hostd's CLI to the target (host-side `switchroom hostd install --tag vNEW`) before `rollout --pin vNEW`. The error message states exactly this. This is the safe precondition the incident lacked.

## Test plan

- [x] `tsc --noEmit` clean
- [x] full lint chain (9 checks) clean
- [x] `src/cli/rollout.test.ts` — +9 tests for `shouldRefuseStaleCli` (the exact incident `0.15.48`→`v0.15.59`, v-prefix normalization, equal/newer no-op, unorderable never-fires, missing version, semver-not-lexical ordering, stable step label). 46 rollout tests + 83 across adjacent suites (deploy-version-guard, host-control) green.

## Risk

Low. Pure-function guard + an early `return` on a single new condition; no change to the executor, the planner, or any mutation primitive. The only behavioral change is refusing a roll that was already broken.

## Rollout

None — overlord owns rollouts. Not rolling to the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)