### PR TITLE
Add messaging copy kit, traced to product-spec outcomes

### DIFF
--- a/messaging/copy-kit.md
+++ b/messaging/copy-kit.md
@@ -1,0 +1,128 @@
+---
+title: Switchroom copy kit
+source: vision.md (canonical), live LinkedIn copy, external evidence brief 2026-06-23
+audience: anyone writing public-facing copy (landing page, posts, decks, README)
+---
+
+# Switchroom: the copy kit
+
+How we say it. Ready-to-lift language for any surface.
+
+Every block traces to a `reference/product-spec.md` outcome, noted per
+pillar. The design contract owns *what we build*; this owns *how we talk
+about it*. If the two ever conflict, the contract wins and this gets fixed.
+
+Voice follows `vision.md`: plain, direct, opinionated. Lead with what it
+feels like to have the team, not the machinery. No em dashes, no hype, no
+filler. Say what it deliberately doesn't do. The restraint is the point.
+
+---
+
+## Tagline
+
+**A team of always-on assistants you text. On a leash.**
+
+## Standfirst (the elevator version)
+
+Switchroom turns the Claude subscription you already pay for into a team
+of always-on assistants you text on Telegram. Each one has a name,
+remembers you, and does the actual work. They stop and ask before
+anything with consequences, and only your tap says go.
+
+## What it is
+
+Switchroom turns your Claude subscription into a team of always-on
+assistants you talk to on Telegram. Not coding bots. A marketer, an EA, a
+health coach, a writing partner. Whatever job you give them.
+
+It feels like texting a person who knows you, not poking at a black box.
+Each assistant has a name, remembers you, and actually does the work. You
+never need to know there's Claude Code under the hood. My wife doesn't 😉.
+
+---
+
+## The three pillars
+
+### 1. A real team, not a chatbot
+*Outcomes `standing-team` + `always-available`.*
+
+One specialist per job, each with its own name, memory, and tools. They
+live in Telegram, survive reboots, and are there the second you reach for
+them. It feels like a colleague who knows your context, not a chat window
+that forgets you every session.
+
+### 2. On a leash
+*Outcome `hold-the-leash`.*
+
+Your assistants don't roam. They act only on what you ask or the
+schedules you set, then stop at anything with consequences and ask first.
+You get an Allow or Deny card in Telegram, and only your authenticated tap
+grants it. No agent can self-elevate or route around you.
+
+### 3. The rest of your Claude subscription
+*Outcome `subscription-honest`.*
+
+It runs on the Pro or Max plan you already pay for, the same login as the
+desktop. No API meter, no second invoice, no setup project. It works out
+of the box, on your own machine, on your terms.
+
+---
+
+## How it's different (the wedge)
+
+Most agent tools are built to act first. They're pitched to run
+unsupervised, and one day one helpfully does something you never asked
+for. Switchroom is built the other way. It asks first.
+
+Agents only move on your say-so or a schedule you set. Every credential,
+skill, and tool is a deliberate grant you approve. The control isn't a
+setting. It's the design.
+
+---
+
+## Social hooks / post openers
+
+- Claude Code is great at your desk. You're not always at your desk.
+- You wouldn't give a new hire your passwords on day one. Why give an AI agent the keys?
+- My wife runs her marketing through an AI assistant. She has no idea it's Claude Code underneath. That's the point.
+- Every AI agent tool is coding-shaped. Most of life isn't code.
+- An always-on assistant that acts without asking is a liability. One that asks first is a teammate.
+
+---
+
+## Boilerplate (the one-paragraph "about")
+
+Switchroom turns your Claude Pro or Max subscription into a team of
+always-on, Telegram-native assistants. Each is a named specialist that
+remembers you and does real work, but stops and asks before anything with
+consequences. It runs the unmodified Claude CLI on the plan you already
+pay for, self-hosted on your own machine. Open source. Always on. On a
+leash.
+
+---
+
+## Evidence behind the claims
+
+The pains each pillar names are externally supported. Cite the theme, not
+a fabricated stat. Full brief and sources: external evidence brief,
+2026-06-23.
+
+- **Pillar 1.** People want always-on assistants in the apps they already
+  use (52% comfortable relying on personal AI assistants for everyday
+  tasks, Zendesk/YouGov 2025). Today's agent tooling is coder-shaped (84%
+  of agent use is software development, Stack Overflow 2025). The
+  "it forgets me" frustration is widely voiced (qualitative, no clean
+  stat).
+- **Pillar 2.** Our strongest, best-sourced ground. 90% of agents are
+  over-permissioned (Obsidian 2025); 53% of enterprises report agents
+  exceeding their remit (CSA 2025); OWASP ranks prompt injection the #1
+  LLM risk and prescribes human-in-the-loop for high-impact actions; PwC
+  2025 names "lack of trust in agents," not the tech, as the top adoption
+  barrier.
+- **Pillar 3.** Self-hosted alternatives are an assembly project
+  (competitor reviews concede 10 to 20 hours of setup). The flat-plan,
+  no-meter benefit is stated as a benefit, not a price comparison.
+
+**Do not overclaim.** No fabricated "X% require human-in-the-loop" stat.
+No public Claude subscriber count. Competitor incidents are directional
+colour, not customer-facing copy, until traced to a primary source.

--- a/reference/README.md
+++ b/reference/README.md
@@ -32,6 +32,7 @@ is by folder + frontmatter, not by two separate trees.
 | [`product-spec.md`](product-spec.md) | *What does it deliver, and how does it function?* — the four outcomes + the job index |
 | Job specs ([`jobs/`](jobs/), `job:` frontmatter) | *Did it do the user's job?* — outcome-focused, UAT-verifiable, one per job |
 | RFCs ([`rfcs/`](rfcs/), `status:` / `artefact:` frontmatter) | *How do we build/ship this change?* — ship-coupled proposals + design records |
+| [`../messaging/copy-kit.md`](../messaging/copy-kit.md) | *How do we say it?* — ready-to-lift public copy (tagline, pillars, boilerplate), each block traced to a product-spec outcome |
 
 The first three are the **anchors**; `product-spec.md` is the product layer
 *beneath* them (it owns the job list); the job specs sit beneath that. The


### PR DESCRIPTION
## What

A new external-facing **copy kit** at `messaging/copy-kit.md`: ready-to-lift public language (tagline, standfirst, the three pillars, the "how it's different" wedge, social hooks, boilerplate), plus an evidence section with overclaim guardrails.

## Why

We had no single source for *how we say it*. `reference/` owns *what we build*; this gives copy a home so public language stays consistent and on-message instead of being re-invented per post.

## Traceability

Each pillar traces to a `product-spec.md` outcome (`standing-team` + `always-available`, `hold-the-leash`, `subscription-honest`), so the copy never drifts from the design contract. If the two conflict, the contract wins. Linked from `reference/README.md`.

Copy is lifted from the live LinkedIn description and grounded in a 2026-06-23 external evidence brief; the evidence section keeps the guardrails (no fabricated human-in-the-loop stat, no subscriber count, competitor incidents kept out of public copy until traced to a primary source).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>