### PR TITLE
fix(telegram): surface JSONL text-block narrative in the activity feed across all agent tiers

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -75,7 +75,8 @@ import {
 } from './permission-timeout.js'
 import { pickRecoveredPermissionOrigin } from './permission-card-origin.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
-import { appendActivityLabel, renderActivityFeedWithNested, type SessionActivityHeader } from '../tool-activity-summary.js'
+import { appendActivityLabel, clipNarrative, renderActivityFeedWithNested, type SessionActivityHeader } from '../tool-activity-summary.js'
+import { REPLY_TOOLS, isDraftOfReply } from '../narrative-dedup.js'
 import { toolLabel } from '../tool-labels.js'
 import { createTypingWrapper } from '../typing-wrap.js'
 import { type DraftStreamHandle } from '../draft-stream.js'
@@ -2049,6 +2050,17 @@ type CurrentTurn = {
   // (via `renderActivityFeed`) as a capped chronological list into the
   // in-place edited activity message and clears on reply. Reset per turn.
   mirrorLines: string[]
+  // Narrative-dedup gate state (JSONL-text-narrative primitive). A `text`
+  // block is held here for ONE lookahead step so the next event (a tool_use
+  // or turn_end) can decide draft-then-send (SUPPRESS, it duplicates the
+  // reply) vs working-narration (SHOW it as a transient mirrorLines step).
+  // Null when nothing is pending. The pure decision lives in
+  // narrative-dedup.ts; this slot is the per-turn cursor. Reset per turn.
+  // Invariant `chat-is-the-single-source-of-truth`: a SHOWN narrative is
+  // rendered through the SAME appendActivityLabel→renderStepFeed path as a
+  // tool step — a transient, clipped, rolling-window line replaced by the
+  // next event, never a persisted parallel mirror.
+  pendingNarrative: { text: string; lastInMessage: boolean } | null
   // Model A — foreground sub-agent nesting. A foreground sub-agent (Task/Agent
   // with no run_in_background) runs INSIDE this turn while the parent blocks at
   // the Task tool, so its live steps nest under the parent's activity feed
@@ -10159,6 +10171,75 @@ function composeTurnActivity(turn: CurrentTurn, final = false, liveSuffix = ''):
 }
 
 /**
+ * Render a SHOWN narrative text block as a transient liveness step — the
+ * same path a tool label takes (appendActivityLabel → renderStepFeed), so
+ * the narrative line is rolling-window-clipped and replaced by the next
+ * event exactly like a tool step. NOT a new message, NOT persisted as a
+ * parallel mirror (invariant `chat-is-the-single-source-of-truth`,
+ * reference/invariants.md). Clipped to a single 120-char line via
+ * clipNarrative so it reads as a step, not a paragraph.
+ */
+function showNarrativeStep(turn: CurrentTurn, text: string): void {
+  const rendered = appendActivityLabel(turn.mirrorLines, clipNarrative(text))
+  if (rendered == null) return
+  turn.activityPendingRender = composeTurnActivity(turn) ?? rendered
+  if (turn.activityInFlight == null) {
+    turn.activityInFlight = drainActivitySummary(turn)
+  }
+}
+
+/**
+ * Narrative-dedup gate, step 2 (reducer-side): a tool_use just arrived while
+ * a narrative block was pending. Decide SHOW vs SUPPRESS and clear the
+ * pending slot. SUPPRESS only when the tool is reply/stream_reply AND the
+ * pending text is a draft-then-send of that reply's `input.text`. Everything
+ * else (a working tool, or a reply whose text differs — post-action
+ * narration) is SHOWN. See narrative-dedup.ts §2b.
+ */
+function resolvePendingNarrativeOnTool(
+  turn: CurrentTurn,
+  toolName: string,
+  input: Record<string, unknown> | undefined,
+): void {
+  const pending = turn.pendingNarrative
+  if (pending == null) return
+  turn.pendingNarrative = null
+  if (REPLY_TOOLS.has(toolName)) {
+    const replyText = typeof input?.text === 'string' ? (input.text as string) : ''
+    if (isDraftOfReply(pending.text, replyText)) return // draft of the answer → SUPPRESS
+  }
+  showNarrativeStep(turn, pending.text) // working preamble / post-action narration → SHOW
+}
+
+/**
+ * Narrative-dedup gate, step 1 (reducer-side): a new narrative block
+ * arrived. A previously-pending block had nothing reply-shaped immediately
+ * after it (pure narration) → flush it as SHOWN, then stage the new one for
+ * one lookahead step. See narrative-dedup.ts §2b.
+ */
+function stagePendingNarrative(turn: CurrentTurn, text: string, lastInMessage: boolean): void {
+  if (turn.pendingNarrative != null) {
+    showNarrativeStep(turn, turn.pendingNarrative.text)
+  }
+  turn.pendingNarrative = { text, lastInMessage }
+}
+
+/**
+ * Narrative-dedup gate, step 3 (reducer-side): the turn is ending with a
+ * trailing narrative block and nothing after it. SUPPRESS only when the turn
+ * already delivered its answer via reply/stream_reply and the trailing text
+ * is a draft of that answer; otherwise SHOW (genuine trailing narration like
+ * "Done — all green."). See narrative-dedup.ts §2b.
+ */
+function flushPendingNarrativeAtTurnEnd(turn: CurrentTurn, lastReplyText: string): void {
+  const pending = turn.pendingNarrative
+  if (pending == null) return
+  turn.pendingNarrative = null
+  if (lastReplyText.length > 0 && isDraftOfReply(pending.text, lastReplyText)) return // trailing duplicate of the answer
+  showNarrativeStep(turn, pending.text)
+}
+
+/**
  * Drain the tool-activity summary's pending render queue. Single-flight
  * by construction (caller assigns the returned promise to
  * `turn.activityInFlight`; while set, new tool_uses only update
@@ -10458,6 +10539,7 @@ function handleSessionEvent(ev: SessionEvent): void {
           activityEverOpened: false,
           activityDrainFailures: 0,
           mirrorLines: [],
+          pendingNarrative: null,
           foregroundSubAgents: new Map(),
           answerStream: null,
           isDm: isDmChatId(ev.chatId),
@@ -10592,6 +10674,14 @@ function handleSessionEvent(ev: SessionEvent): void {
     case 'tool_use': {
       const turn = currentTurn
       if (turn == null) return
+      // Narrative-dedup gate step 2 (JSONL-text-narrative primitive): a
+      // narrative block was pending; this tool_use is the lookahead event
+      // that decides it. reply/stream_reply with near-identical text ⇒
+      // draft-then-send ⇒ SUPPRESS (the reply prints the canonical answer);
+      // anything else ⇒ SHOW as a transient liveness step. Runs BEFORE the
+      // normal tool handling so a working preamble surfaces just ahead of
+      // its tool step.
+      resolvePendingNarrativeOnTool(turn, ev.toolName, ev.input)
       // Phase 1 of #332: count every tool_use in the current turn.
       turn.toolCallCount++
       // #412: bump turn-active marker mtime so the watchdog sees this
@@ -10775,6 +10865,17 @@ function handleSessionEvent(ev: SessionEvent): void {
       const turn = currentTurn
       if (turn != null) {
         turn.capturedText.push(ev.text)
+        // Narrative-dedup gate step 1 (JSONL-text-narrative primitive):
+        // stage this text block for one lookahead step. If a previous block
+        // was pending with nothing reply-shaped after it, it flushes here as
+        // a SHOWN transient liveness step. The eventual SHOW/SUPPRESS of THIS
+        // block is decided by the next tool_use / turn_end. Invariant
+        // `chat-is-the-single-source-of-truth` (reference/invariants.md): a
+        // SHOWN line rides the same renderStepFeed path as a tool step —
+        // transient + clipped, never a persisted parallel mirror. This is a
+        // separate lane from the answer-stream wiring below (which owns the
+        // canonical reply), so the two never fight over the same text.
+        stagePendingNarrative(turn, ev.text, ev.lastInMessage)
         // Issue #195: feed the answer-lane stream. The stream itself
         // gates on minInitialChars and throttles edits — short replies
         // stay below the threshold and never spawn a message.
@@ -11046,6 +11147,19 @@ function handleSessionEvent(ev: SessionEvent): void {
       if (turn?.orphanedReplyTimeoutId != null) {
         clearTimeout(turn.orphanedReplyTimeoutId)
         turn.orphanedReplyTimeoutId = null
+      }
+      // Narrative-dedup gate step 3 (JSONL-text-narrative primitive): a
+      // trailing narrative block with nothing after it. When the turn
+      // delivered its answer via reply (replyCalled) the trailing text is
+      // almost always a draft of that answer — compare against the captured
+      // answer text and SUPPRESS the duplicate; otherwise SHOW genuine
+      // trailing narration ("Done — all green."). Must run BEFORE
+      // clearActivitySummary so a SHOWN line lands in the feed's final
+      // render. Always clears turn.pendingNarrative so it can't leak across
+      // turns.
+      if (turn != null) {
+        const lastReplyText = turn.replyCalled ? turn.capturedText.join('') : ''
+        flushPendingNarrativeAtTurnEnd(turn, lastReplyText)
       }
       // Clear the activity feed at the real end of the turn. This is the
       // no-reply safety net — a turn that ends without ever calling reply
@@ -22750,7 +22864,13 @@ void (async () => {
                   // feed (the foreground blindspot) — mirroring the
                   // main-turn activity feed, which surfaces both tool labels
                   // and prose.
-                  const child = (progressLine ?? latestSummary).trim().slice(0, 120)
+                  // Route through the SHARED clipNarrative so multi-line
+                  // narration first-line-collapses identically to the main
+                  // tier (the main path at showNarrativeStep already does
+                  // this). Previously this inlined `.trim().slice(0, 120)`
+                  // omitted the first-line collapse, so a multi-line
+                  // narrative rendered DIFFERENTLY here than on the main feed.
+                  const child = clipNarrative(progressLine ?? latestSummary)
                   if (child.length === 0) return
                   let narrative = turn.foregroundSubAgents.get(agentId)
                   if (narrative == null) {

--- a/telegram-plugin/narrative-dedup.ts
+++ b/telegram-plugin/narrative-dedup.ts
@@ -1,0 +1,69 @@
+/**
+ * Reducer-side narrative dedup gate (the correctness core of the
+ * JSONL-text-narrative primitive).
+ *
+ * A `text` / `sub_agent_text` JSONL block is one of two things:
+ *
+ *   1. DRAFT-THEN-SEND — the model composing its answer just before it
+ *      calls `reply` / `stream_reply` with near-identical text. Surfacing
+ *      it would double-print the answer (once as a transient narrative
+ *      step, once as the canonical reply). It MUST be suppressed.
+ *   2. WORKING NARRATION — the agent's own commentary that is never sent
+ *      to the user ("On it. Let me find the repo…", "Sent. Waiting on the
+ *      build…"). It SHOULD be surfaced as a transient liveness step.
+ *
+ * A projector sees one JSONL line at a time and cannot know whether a
+ * later line is a reply tool_use, so the SHOW/SUPPRESS decision is a
+ * stateful, one-step-deferred decision made reducer-side (the gateway for
+ * the main agent, the subagent-watcher for sub/worker). This module is the
+ * pure, fully-unit-testable kernel of that decision — no I/O, no state of
+ * its own; the caller owns the `pendingNarrative` slot.
+ *
+ * The threshold heuristic deliberately matches the spirit of the #546
+ * outbound dedup (trim + lowercase + whitespace-collapse) so a draft and
+ * its reply compare equal the same way #546 considers them the same
+ * message.
+ */
+
+/** Tools whose `input.text` IS the canonical answer surface. */
+export const REPLY_TOOLS = new Set(['reply', 'stream_reply'])
+
+/**
+ * Normalize for prefix comparison: strip markdown/HTML-ish emphasis,
+ * heading and quote marks, collapse whitespace, lowercase. Mirrors the
+ * #546 outbound-dedup normalization so a markdown-decorated draft and its
+ * plain reply compare equal.
+ */
+export function normalizeNarrative(s: string): string {
+  return s
+    .replace(/[*_`>#~]/g, '') // markdown emphasis / heading / quote marks
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase()
+}
+
+/** Longest-common-prefix ratio over the SHORTER of the two normalized strings. */
+export function prefixSimilarity(a: string, b: string): number {
+  const x = normalizeNarrative(a)
+  const y = normalizeNarrative(b)
+  if (x.length === 0 || y.length === 0) return 0
+  const n = Math.min(x.length, y.length)
+  let i = 0
+  while (i < n && x[i] === y[i]) i++
+  return i / n
+}
+
+/**
+ * The single tunable. Longest-common-PREFIX ratio (not Levenshtein) is
+ * deliberate: a draft shares a long head with the sent answer even when the
+ * model trims a trailing sentence before sending. 0.8 over the shorter
+ * string tolerates that trim while rejecting the "Sent. Waiting…" +
+ * different-reply case (short string, near-zero shared prefix). Exported so
+ * the test pins it — a silent retune breaks a test.
+ */
+export const DRAFT_SUPPRESS_THRESHOLD = 0.8
+
+/** TRUE ⇒ this text block is a draft-then-send of `replyText`; SUPPRESS it. */
+export function isDraftOfReply(textBlock: string, replyText: string): boolean {
+  return prefixSimilarity(textBlock, replyText) >= DRAFT_SUPPRESS_THRESHOLD
+}

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -98,7 +98,12 @@ export type SessionEvent =
   // the lazily-flushed transcript. The draft-mirror drives off THIS, not
   // the flush-gated `tool_use`, so activity streams deterministically.
   | { kind: 'tool_label'; toolUseId: string; label: string; toolName: string }
-  | { kind: 'text'; text: string }
+  // `blockIndex` = index of this text block in the assistant message's
+  // content[]. `lastInMessage` = true iff no tool_use block follows it in
+  // the SAME message. These two fields let the reducer-side narrative-dedup
+  // gate (narrative-dedup.ts) decide draft-then-send vs working-narration
+  // deterministically without buffering whole turns.
+  | { kind: 'text'; text: string; blockIndex: number; lastInMessage: boolean }
   | { kind: 'tool_result'; toolUseId: string; toolName: string | null; isError?: boolean; errorText?: string }
   | { kind: 'turn_end'; durationMs: number }
   // Multi-agent: sub-agent-scoped events. agentId is the sub-agent JSONL
@@ -106,8 +111,11 @@ export type SessionEvent =
   // as parent events; the reducer fans them out to per-sub-agent state.
   | { kind: 'sub_agent_started'; agentId: string; firstPromptText: string; subagentType?: string }
   | { kind: 'sub_agent_tool_use'; agentId: string; toolUseId: string | null; toolName: string; input?: Record<string, unknown>; precomputedLabel?: string }
-  | { kind: 'sub_agent_text'; agentId: string; text: string }
-  | { kind: 'sub_agent_narrative'; agentId: string; text: string }
+  // Same shared contract as the main-agent `text` kind — see its doc above.
+  // The wire-kind stays distinct (the gateway/watcher split is load-bearing)
+  // but the payload + `lastInMessage` derivation are identical so ONE shared
+  // dedup gate handles both tiers.
+  | { kind: 'sub_agent_text'; agentId: string; text: string; blockIndex: number; lastInMessage: boolean }
   | { kind: 'sub_agent_tool_result'; agentId: string; toolUseId: string; isError?: boolean; errorText?: string }
   | { kind: 'sub_agent_turn_end'; agentId: string }
   | { kind: 'sub_agent_nested_spawn'; agentId: string }
@@ -183,6 +191,46 @@ function extractToolResultErrorText(content: unknown): string {
 }
 
 /**
+ * THE single text→narrative projection primitive. Both projectTranscriptLine
+ * and projectSubagentLine derive their text events through this helper so
+ * main-agent, sub-agent, worker, and every other execution shape inherit
+ * identical text-block semantics from ONE place: empty/whitespace blocks are
+ * dropped, and each surviving block carries its `blockIndex` plus the
+ * `lastInMessage` signal (no tool_use follows it in this message — the
+ * draft-then-send marker the reducer-side dedup gate keys on).
+ *
+ * `make` adapts the shared payload into the tier-specific wire kind
+ * (`text` vs `sub_agent_text`); the contract — what counts as a text block,
+ * how `lastInMessage` is computed — lives here, not in the callers.
+ *
+ * Returns a `Map<blockIndex, SessionEvent>` keyed by the text block's source
+ * index, NOT a flat list. This is the load-bearing design choice: the callers
+ * must emit thinking / tool_use / text events in SOURCE ORDER (the reducer
+ * pairs a preamble to the immediately-next tool_use), so they iterate
+ * `content` once and, at each text position, emit the precomputed event from
+ * this map. The kernel owns the contract; the caller owns only the ordering.
+ */
+export function projectAssistantTextBlocks(
+  content: Array<Record<string, unknown>>,
+  make: (text: string, blockIndex: number, lastInMessage: boolean) => SessionEvent,
+): Map<number, SessionEvent> {
+  const out = new Map<number, SessionEvent>()
+  // Precompute the index of the last tool_use so each text block knows
+  // whether a tool_use follows it in THIS message (the draft-then-send signal).
+  let lastToolUseIdx = -1
+  content.forEach((c, i) => {
+    if (c.type === 'tool_use') lastToolUseIdx = i
+  })
+  content.forEach((c, i) => {
+    if (c.type !== 'text') return
+    const text = (c.text as string | undefined) ?? ''
+    if (text.trim().length === 0) return // drop empty/whitespace-only blocks
+    out.set(i, make(text, i, i > lastToolUseIdx))
+  })
+  return out
+}
+
+/**
  * Project a single transcript line into a SessionEvent (or null if it's
  * uninteresting noise). Caller is responsible for the JSON parse — if a
  * line is not valid JSON we skip it.
@@ -218,7 +266,16 @@ export function projectTranscriptLine(line: string): SessionEvent[] {
     const content = message?.content as Array<Record<string, unknown>> | undefined
     if (!Array.isArray(content)) return []
     const events: SessionEvent[] = []
-    for (const c of content) {
+    // Text→narrative projection comes from the ONE shared kernel
+    // (projectAssistantTextBlocks): it owns the empty-drop + blockIndex +
+    // lastInMessage contract. We emit its events at their source positions
+    // so thinking / tool_use / text stay in source order (the reducer pairs
+    // a preamble to the immediately-next tool_use).
+    const textEvents = projectAssistantTextBlocks(
+      content,
+      (text, blockIndex, lastInMessage): SessionEvent => ({ kind: 'text', text, blockIndex, lastInMessage }),
+    )
+    content.forEach((c, i) => {
       const ct = c.type as string | undefined
       if (ct === 'thinking') {
         events.push({ kind: 'thinking' })
@@ -237,10 +294,10 @@ export function projectTranscriptLine(line: string): SessionEvent[] {
           input: input && typeof input === 'object' ? input : undefined,
         })
       } else if (ct === 'text') {
-        const text = (c.text as string | undefined) ?? ''
-        events.push({ kind: 'text', text })
+        const ev = textEvents.get(i)
+        if (ev != null) events.push(ev)
       }
-    }
+    })
     return events
   }
 
@@ -357,7 +414,25 @@ export function projectSubagentLine(
     const content = message?.content as Array<Record<string, unknown>> | undefined
     if (!Array.isArray(content)) return []
     const events: SessionEvent[] = []
-    for (const c of content) {
+    // Text→narrative projection comes from the SAME shared kernel as the
+    // main agent (projectAssistantTextBlocks): one source for the empty-drop
+    // + blockIndex + lastInMessage contract. The `make` adapter only changes
+    // the wire kind to `sub_agent_text`. A nested Agent/Task tool_use still
+    // counts as a tool_use that follows a preceding text block — handled by
+    // the kernel — so a sub-agent preamble before a nested spawn is correctly
+    // NOT `lastInMessage`. We emit at source positions so text + tool_use
+    // stay in source order (the reducer pairs preamble → next tool_use).
+    const textEvents = projectAssistantTextBlocks(
+      content,
+      (text, blockIndex, lastInMessage): SessionEvent => ({
+        kind: 'sub_agent_text',
+        agentId,
+        text,
+        blockIndex,
+        lastInMessage,
+      }),
+    )
+    content.forEach((c, i) => {
       const ct = c.type as string | undefined
       if (ct === 'tool_use') {
         const name = (c.name as string | undefined) ?? ''
@@ -386,10 +461,11 @@ export function projectSubagentLine(
         // in the SAME assistant message must be emitted in source order
         // so the reducer consumes the preamble on the immediately-next
         // tool_use and sibling tool_uses fall back to filename/pattern.
-        const text = (c.text as string | undefined) ?? ''
-        events.push({ kind: 'sub_agent_text', agentId, text })
+        // The event itself comes from the shared kernel (textEvents above).
+        const ev = textEvents.get(i)
+        if (ev != null) events.push(ev)
       }
-    }
+    })
     // Authoritative early terminal: a background `Agent` worker's JSONL on
     // claude ≥2.1.156 never writes the `system/turn_duration` line below, so
     // the watcher used to only learn the worker finished via the ~5-min

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -43,6 +43,7 @@ import { homedir } from 'os'
 import { projectSubagentLine, sanitizeCwdToProjectName, detectErrorInTranscriptLine } from './session-tail.js'
 import { sanitiseToolArg } from './fleet-state.js'
 import { describeToolUse } from './tool-activity-summary.js'
+import { REPLY_TOOLS, isDraftOfReply } from './narrative-dedup.js'
 import { escapeHtml, truncate } from './card-format.js'
 import { bumpSubagentActivity, recordSubagentStall, recordSubagentResume, recordSubagentEnd, reapStuckRunningRows, countRunningBackgroundSubagents } from './registry/subagents-schema.js'
 import { touchTurnActiveMarker } from './gateway/turn-active-marker.js'
@@ -158,6 +159,16 @@ export interface WorkerEntry {
    *  failed handback's "what it reported before failing" slot when the
    *  worker left no narrative result of its own. */
   errorDetail?: string
+  /**
+   * Narrative-dedup gate state (JSONL-text-narrative primitive). A
+   * `sub_agent_text` block is held here for ONE lookahead step so the next
+   * `sub_agent_tool_use` / `sub_agent_turn_end` can decide draft-then-send
+   * (SUPPRESS — it duplicates the worker's reply) vs working-narration (SHOW
+   * — fire `onProgress({latestSummary})`). Null when nothing is pending. The
+   * pure decision lives in narrative-dedup.ts; this slot is the per-entry
+   * cursor. Mirrors the gateway's `turn.pendingNarrative`.
+   */
+  pendingNarrative?: { text: string; lastInMessage: boolean } | null
 }
 
 export interface SubagentWatcherConfig {
@@ -773,6 +784,48 @@ export function readSubTail(
         if (errInfo.detail) entry.errorDetail = errInfo.detail.slice(0, SUBAGENT_RESULT_TEXT_MAX)
       }
       const events = projectSubagentLine(line, entry.agentId, startState)
+      // Narrative-dedup gate (JSONL-text-narrative primitive) — fire the
+      // narrative progress cue for a SHOWN sub_agent_text block. Identical
+      // shape to the inline #1720 onProgress below; factored out so the gate
+      // (stage-on-text, resolve-on-tool/turn_end) can replay a previously
+      // pending block exactly once. `latestSummary` carries the worker's
+      // narrative result (entry.lastResultText), never tool labels.
+      const fireNarrativeProgress = (): void => {
+        if (onProgress == null || entry.state !== 'running' || entry.historical) return
+        try {
+          onProgress({
+            agentId: entry.agentId,
+            description: entry.description,
+            latestSummary: entry.lastResultText,
+            elapsedMs: now - entry.dispatchedAt,
+            prevBucketIdx: entry.lastProgressBucketIdx,
+            setBucketIdx: (b: number) => {
+              entry.lastProgressBucketIdx = b
+            },
+            lastTool: entry.lastTool,
+            toolCount: entry.toolCount,
+          })
+        } catch (cbErr) {
+          log?.(`subagent-watcher: onProgress callback error ${entry.agentId}: ${(cbErr as Error).message}`)
+        }
+      }
+      // Resolve a pending sub-agent narrative against a lookahead event.
+      // SUPPRESS only when the lookahead is a reply/stream_reply tool whose
+      // text the pending block drafts; otherwise SHOW (fire the cue). See
+      // narrative-dedup.ts §2b.
+      const resolvePendingSubNarrative = (
+        toolName: string | null,
+        toolInput: Record<string, unknown> | undefined,
+      ): void => {
+        if (entry.pendingNarrative == null) return
+        const pending = entry.pendingNarrative
+        entry.pendingNarrative = null
+        if (toolName != null && REPLY_TOOLS.has(toolName)) {
+          const replyText = typeof toolInput?.text === 'string' ? (toolInput.text as string) : ''
+          if (isDraftOfReply(pending.text, replyText)) return // draft of the reply → SUPPRESS
+        }
+        fireNarrativeProgress()
+      }
       for (const ev of events) {
         const idleSecBeforeBump = Math.round((now - entry.lastActivityAt) / 1000)
         entry.lastActivityAt = now
@@ -813,6 +866,11 @@ export function readSubTail(
           log?.(`subagent-watcher: stall cleared for ${entry.agentId} (activity resumed after ${idleSecBeforeBump}s — re-arming detection)`)
         }
         if (ev.kind === 'sub_agent_tool_use') {
+          // Narrative-dedup gate step 2: a sub_agent_text block was pending;
+          // this tool is the lookahead that decides it (SHOW unless it drafts
+          // a reply tool's text). Runs before the tool's own progress cue so
+          // a working preamble surfaces just ahead of its tool step.
+          resolvePendingSubNarrative(ev.toolName, ev.input)
           entry.toolCount++
           // P0 of #662: surface the most recent tool name + sanitised
           // arg so the driver's fleet-state shadow can render the
@@ -871,29 +929,25 @@ export function readSubTail(
           // args or file content — consistent with the watcher's
           // "descriptions only" privacy posture.
           entry.lastResultText = ev.text.trim().slice(0, SUBAGENT_RESULT_TEXT_MAX)
-          // #1720: surface a progress cue for the gateway. Only fire
-          // while the entry is still running and not historical — a
-          // terminal entry's last narrative line is the handback
-          // payload, not a mid-flight progress nudge.
-          if (onProgress != null && entry.state === 'running' && !entry.historical) {
-            try {
-              onProgress({
-                agentId: entry.agentId,
-                description: entry.description,
-                latestSummary: entry.lastResultText,
-                elapsedMs: now - entry.dispatchedAt,
-                prevBucketIdx: entry.lastProgressBucketIdx,
-                setBucketIdx: (b: number) => {
-                  entry.lastProgressBucketIdx = b
-                },
-                lastTool: entry.lastTool,
-                toolCount: entry.toolCount,
-              })
-            } catch (cbErr) {
-              log?.(`subagent-watcher: onProgress callback error ${entry.agentId}: ${(cbErr as Error).message}`)
-            }
+          // #1720 + JSONL-text-narrative gate step 1: stage this block for
+          // one lookahead step instead of firing the progress cue
+          // immediately. A previously-pending block had nothing reply-shaped
+          // after it (pure narration) → flush it as SHOWN now; then stage
+          // THIS block. Its eventual SHOW/SUPPRESS is decided by the next
+          // sub_agent_tool_use / sub_agent_turn_end. `lastResultText` /
+          // `lastSummaryLine` above already updated unconditionally — the
+          // handback payload is independent of the progress-cue decision.
+          if (entry.pendingNarrative != null) {
+            fireNarrativeProgress() // prior pending was pure narration → SHOW
           }
+          entry.pendingNarrative = { text: ev.text, lastInMessage: ev.lastInMessage }
         } else if (ev.kind === 'sub_agent_turn_end') {
+          // Narrative-dedup gate step 3: a trailing sub_agent_text block with
+          // nothing after it. SUPPRESS only when it drafts the worker's final
+          // narrative reply; otherwise SHOW. The worker's result is carried
+          // separately via lastResultText/onFinish, so a SHOWN trailing cue
+          // here is purely the transient liveness beat.
+          resolvePendingSubNarrative(null, undefined)
           if (entry.state === 'running') {
             entry.state = 'done'
             // Bug 2 fix (#333): mark the DB row completed via watcher's turn_end

--- a/telegram-plugin/tests/narrative-dedup.test.ts
+++ b/telegram-plugin/tests/narrative-dedup.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeNarrative,
+  prefixSimilarity,
+  isDraftOfReply,
+  DRAFT_SUPPRESS_THRESHOLD,
+  REPLY_TOOLS,
+} from '../narrative-dedup.js'
+
+describe('narrative-dedup', () => {
+  it('pins the threshold so a silent retune breaks the test', () => {
+    expect(DRAFT_SUPPRESS_THRESHOLD).toBe(0.8)
+  })
+
+  it('REPLY_TOOLS holds exactly reply + stream_reply', () => {
+    expect(REPLY_TOOLS.has('reply')).toBe(true)
+    expect(REPLY_TOOLS.has('stream_reply')).toBe(true)
+    expect(REPLY_TOOLS.has('Bash')).toBe(false)
+  })
+
+  describe('normalizeNarrative', () => {
+    it('strips markdown emphasis/heading/quote marks, collapses whitespace, lowercases', () => {
+      expect(normalizeNarrative('**Bold**  _italic_   `code`')).toBe('bold italic code')
+      expect(normalizeNarrative('> # Heading\n  text')).toBe('heading text')
+    })
+  })
+
+  describe('prefixSimilarity', () => {
+    it('returns 1 for identical strings', () => {
+      expect(prefixSimilarity('hello there', 'hello there')).toBe(1)
+    })
+
+    it('returns 0 when either side is empty (no divide-by-zero)', () => {
+      expect(prefixSimilarity('', 'something')).toBe(0)
+      expect(prefixSimilarity('something', '')).toBe(0)
+      expect(prefixSimilarity('', '')).toBe(0)
+    })
+
+    it('ratio is over the SHORTER normalized string', () => {
+      // "abc" vs "abcdef": shared prefix 3 of shorter length 3 = 1.0
+      expect(prefixSimilarity('abc', 'abcdef')).toBe(1)
+      // "abx" vs "abcdef": shared prefix 2 of shorter length 3 ≈ 0.667
+      expect(prefixSimilarity('abx', 'abcdef')).toBeCloseTo(2 / 3, 5)
+    })
+  })
+
+  describe('isDraftOfReply', () => {
+    it('SUPPRESS: identical draft and reply', () => {
+      const t = 'The repo is at /home/user/code/switchroom.'
+      expect(isDraftOfReply(t, t)).toBe(true)
+    })
+
+    it('SUPPRESS: draft whose trailing sentence was trimmed before sending (~0.85 prefix)', () => {
+      const draft = 'The repo is at /home/user/code/switchroom. I will start now.'
+      const reply = 'The repo is at /home/user/code/switchroom.'
+      // reply is the shorter string and is a full prefix of the draft → 1.0
+      expect(prefixSimilarity(draft, reply)).toBe(1)
+      expect(isDraftOfReply(draft, reply)).toBe(true)
+      // And the symmetric framing (draft slightly longer head, reply trimmed):
+      const draft2 = 'Found both repos and confirmed the remote is correct here.'
+      const reply2 = 'Found both repos and confirmed the remote is correct.'
+      expect(prefixSimilarity(draft2, reply2)).toBeGreaterThanOrEqual(0.85)
+      expect(isDraftOfReply(draft2, reply2)).toBe(true)
+    })
+
+    it('SHOW: post-action narration that merely precedes a different reply', () => {
+      // "Sent. Waiting on the build…" vs an unrelated reply payload — short
+      // string, near-zero shared prefix → below threshold → SHOW.
+      const narration = 'Sent. Waiting on the build…'
+      const reply = "Here's the result of the build: all green."
+      expect(prefixSimilarity(narration, reply)).toBeLessThan(DRAFT_SUPPRESS_THRESHOLD)
+      expect(isDraftOfReply(narration, reply)).toBe(false)
+    })
+
+    it('SHOW: empty reply text never suppresses (no divide-by-zero)', () => {
+      expect(isDraftOfReply('On it. Let me find the repo…', '')).toBe(false)
+    })
+
+    it('SUPPRESS: draft differs from reply only by markdown decoration', () => {
+      const draft = 'Here is the **plan**: do A then B.'
+      const reply = 'Here is the plan: do A then B.'
+      // After normalization the markdown stars vanish → identical → suppress.
+      expect(normalizeNarrative(draft)).toBe(normalizeNarrative(reply))
+      expect(isDraftOfReply(draft, reply)).toBe(true)
+    })
+  })
+})

--- a/telegram-plugin/tests/session-tail.test.ts
+++ b/telegram-plugin/tests/session-tail.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path'
 import {
   projectTranscriptLine,
   projectSubagentLine,
+  projectAssistantTextBlocks,
   sanitizeCwdToProjectName,
   getProjectsDirForCwd,
   startSessionTail,
@@ -208,8 +209,65 @@ describe('projectTranscriptLine', () => {
       },
     })
     expect(projectTranscriptLine(line)).toEqual([
-      { kind: 'text', text: 'Replied with comparison' },
+      // Shared narrative contract: a lone text block (no tool_use after it)
+      // is lastInMessage:true at blockIndex 0.
+      { kind: 'text', text: 'Replied with comparison', blockIndex: 0, lastInMessage: true },
     ])
+  })
+
+  it('drops empty/whitespace-only text blocks (shared narrative contract)', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'text', text: '   \n  ' },
+          { type: 'tool_use', id: 'toolu_a', name: 'Read', input: { file_path: '/a' } },
+        ],
+      },
+    })
+    // The empty text block is dropped; only the tool_use survives.
+    expect(projectTranscriptLine(line)).toEqual([
+      { kind: 'tool_use', toolName: 'Read', toolUseId: 'toolu_a', input: { file_path: '/a' } },
+    ])
+  })
+
+  it('text block preceding a tool_use in the same message is lastInMessage:false', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'text', text: 'Found both:' },
+          { type: 'tool_use', id: 'toolu_a', name: 'Read', input: { file_path: '/a' } },
+        ],
+      },
+    })
+    const events = projectTranscriptLine(line)
+    expect(events[0]).toEqual({ kind: 'text', text: 'Found both:', blockIndex: 0, lastInMessage: false })
+  })
+
+  it('text block AFTER the last tool_use is lastInMessage:true', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'tool_use', id: 'toolu_a', name: 'Read', input: { file_path: '/a' } },
+          { type: 'text', text: 'Done.' },
+        ],
+      },
+    })
+    const events = projectTranscriptLine(line)
+    const textEv = events.find((e) => e.kind === 'text')
+    expect(textEv).toEqual({ kind: 'text', text: 'Done.', blockIndex: 1, lastInMessage: true })
+  })
+
+  it('the dead sub_agent_narrative kind is never emitted', () => {
+    // The union member was removed; nothing in either projector emits it.
+    const subLine = JSON.stringify({
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'prose' }] },
+    })
+    const events = projectSubagentLine(subLine, 'X', { hasEmittedStart: true })
+    expect(events.some((e) => (e as { kind: string }).kind === 'sub_agent_narrative')).toBe(false)
   })
 
   it('parses assistant message with multiple blocks (thinking + tool_use)', () => {
@@ -471,7 +529,8 @@ describe('projectSubagentLine', () => {
     })
     const events = projectSubagentLine(line, 'X', st)
     expect(events).toEqual([
-      { kind: 'sub_agent_text', agentId: 'X', text: 'Reading the reducer' },
+      // text precedes a tool_use in the same message → lastInMessage:false
+      { kind: 'sub_agent_text', agentId: 'X', text: 'Reading the reducer', blockIndex: 0, lastInMessage: false },
       {
         kind: 'sub_agent_tool_use',
         agentId: 'X',
@@ -511,8 +570,9 @@ describe('projectSubagentLine', () => {
       st,
     )
     // Text first (so the final summary still renders), turn_end last.
+    // A lone trailing text block (no tool_use after it) is lastInMessage:true.
     expect(events).toEqual([
-      { kind: 'sub_agent_text', agentId: 'X', text: 'Done. Fixed the bug.' },
+      { kind: 'sub_agent_text', agentId: 'X', text: 'Done. Fixed the bug.', blockIndex: 0, lastInMessage: true },
       { kind: 'sub_agent_turn_end', agentId: 'X' },
     ])
   })
@@ -563,5 +623,89 @@ describe('idle sub-tail reap (MEM2)', () => {
     expect(src).toContain('IDLE_FSWATCH_TTL_MS')
     // Must be invoked from the rescan tick, not just declared.
     expect(src).toMatch(/rescanSubagents\(\)\s*[\s\S]*?reapIdleSubTails\(\)/)
+  })
+})
+
+describe('projectAssistantTextBlocks (shared text→narrative kernel)', () => {
+  // Direct unit coverage for the now-live projection kernel. Both
+  // projectTranscriptLine and projectSubagentLine derive their text events
+  // through this one function; these tests pin its contract independently of
+  // either caller. The `make` adapter here uses the main-agent `text` kind.
+  const makeText = (text: string, blockIndex: number, lastInMessage: boolean): SessionEvent => ({
+    kind: 'text',
+    text,
+    blockIndex,
+    lastInMessage,
+  })
+
+  it('emits one narration event per non-empty text block, keyed by source index', () => {
+    const out = projectAssistantTextBlocks(
+      [
+        { type: 'text', text: 'hello' },
+        { type: 'tool_use', name: 'Read', id: 't1' },
+        { type: 'text', text: 'world' },
+      ],
+      makeText,
+    )
+    expect(out.size).toBe(2)
+    expect(out.get(0)).toEqual({ kind: 'text', text: 'hello', blockIndex: 0, lastInMessage: false })
+    expect(out.get(2)).toEqual({ kind: 'text', text: 'world', blockIndex: 2, lastInMessage: true })
+  })
+
+  it('drops empty and whitespace-only text blocks', () => {
+    const out = projectAssistantTextBlocks(
+      [
+        { type: 'text', text: '' },
+        { type: 'text', text: '   \n\t  ' },
+        { type: 'text', text: 'kept' },
+      ],
+      makeText,
+    )
+    expect(out.size).toBe(1)
+    expect(out.has(0)).toBe(false)
+    expect(out.has(1)).toBe(false)
+    expect(out.get(2)).toEqual({ kind: 'text', text: 'kept', blockIndex: 2, lastInMessage: true })
+  })
+
+  it('lastInMessage is false when a tool_use follows the text block in the same message', () => {
+    const out = projectAssistantTextBlocks(
+      [
+        { type: 'text', text: 'preamble' },
+        { type: 'tool_use', name: 'Bash', id: 't1' },
+      ],
+      makeText,
+    )
+    expect(out.get(0)).toEqual({ kind: 'text', text: 'preamble', blockIndex: 0, lastInMessage: false })
+  })
+
+  it('lastInMessage is true for a text block after the last tool_use (trailing narration)', () => {
+    const out = projectAssistantTextBlocks(
+      [
+        { type: 'tool_use', name: 'Bash', id: 't1' },
+        { type: 'text', text: 'done' },
+      ],
+      makeText,
+    )
+    expect(out.get(1)).toEqual({ kind: 'text', text: 'done', blockIndex: 1, lastInMessage: true })
+  })
+
+  it('the make adapter controls the wire kind (sub_agent_text tier)', () => {
+    const out = projectAssistantTextBlocks(
+      [{ type: 'text', text: 'sub preamble' }],
+      (text, blockIndex, lastInMessage): SessionEvent => ({
+        kind: 'sub_agent_text',
+        agentId: 'A',
+        text,
+        blockIndex,
+        lastInMessage,
+      }),
+    )
+    expect(out.get(0)).toEqual({
+      kind: 'sub_agent_text',
+      agentId: 'A',
+      text: 'sub preamble',
+      blockIndex: 0,
+      lastInMessage: true,
+    })
   })
 })

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -519,6 +519,86 @@ describe('startSubagentWatcher', () => {
       expect(toolTick?.latestSummary).toBe('')
     })
 
+    it('narrative gate: a draft-then-reply sub_agent_text is SUPPRESSED (no progress cue)', () => {
+      // The worker composes its answer as a text block, then calls
+      // stream_reply with near-identical text. The narrative cue must be
+      // suppressed so the answer is not double-surfaced.
+      const narrativeCues: string[] = []
+      const agentDir = join(tmpRoot, 'agent')
+      const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+      mkdirSync(subagentsDir, { recursive: true })
+      const jsonlPath = join(subagentsDir, 'agent-deadbeef.jsonl')
+      const h = startWatcherSync({
+        agentDir,
+        onProgress: ({ progressLine, latestSummary }) => {
+          // Narrative ticks carry NO progressLine (tool ticks do); record them.
+          if (progressLine == null) narrativeCues.push(latestSummary)
+        },
+      })
+      writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Find the repo path')))
+      h.poll()
+      const answer = 'The repo is at /home/user/code/switchroom.'
+      appendFileSync(jsonlPath, buildJSONL(subAgentAssistantText(answer)))
+      h.poll()
+      // The draft is staged, not yet resolved — no cue yet.
+      // The very next event is a reply tool with matching text → SUPPRESS.
+      appendFileSync(jsonlPath, buildJSONL({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', name: 'stream_reply', id: 'r1', input: { text: answer } }] },
+      }))
+      h.poll()
+      expect(narrativeCues.length).toBe(0)
+    })
+
+    it('narrative gate: pure working narration is SHOWN (cue fires)', () => {
+      // "On it. Let me find the repo…" followed by a Bash tool — the next
+      // event is a non-reply tool, so the narration is SHOWN.
+      const narrativeCues: string[] = []
+      const agentDir = join(tmpRoot, 'agent')
+      const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+      mkdirSync(subagentsDir, { recursive: true })
+      const jsonlPath = join(subagentsDir, 'agent-deadbeef.jsonl')
+      const h = startWatcherSync({
+        agentDir,
+        onProgress: ({ progressLine, latestSummary }) => {
+          if (progressLine == null) narrativeCues.push(latestSummary)
+        },
+      })
+      writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Find the repo')))
+      h.poll()
+      appendFileSync(jsonlPath, buildJSONL(subAgentAssistantText('On it. Let me find the repo.')))
+      h.poll()
+      appendFileSync(jsonlPath, buildJSONL(subAgentToolUse('Bash', 'b1')))
+      h.poll()
+      // The staged narration was resolved by the non-reply Bash → SHOWN.
+      expect(narrativeCues.length).toBe(1)
+      expect(narrativeCues[0]).toContain('find the repo')
+    })
+
+    it('narrative gate: trailing narration at turn_end is SHOWN', () => {
+      const narrativeCues: string[] = []
+      const agentDir = join(tmpRoot, 'agent')
+      const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+      mkdirSync(subagentsDir, { recursive: true })
+      const jsonlPath = join(subagentsDir, 'agent-deadbeef.jsonl')
+      const h = startWatcherSync({
+        agentDir,
+        onProgress: ({ progressLine, latestSummary }) => {
+          if (progressLine == null) narrativeCues.push(latestSummary)
+        },
+      })
+      writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Do the task')))
+      h.poll()
+      // A trailing narration block, then turn_end (turn_duration). The
+      // trailing block has no reply after it → SHOWN at turn_end.
+      appendFileSync(jsonlPath, buildJSONL(subAgentAssistantText('Done. All green.')))
+      h.poll()
+      appendFileSync(jsonlPath, buildJSONL(subAgentTurnDuration()))
+      h.poll()
+      expect(narrativeCues.length).toBe(1)
+      expect(narrativeCues[0]).toContain('All green')
+    })
+
     it('captures the full last narrative line into lastResultText (handback)', () => {
       // lastSummaryLine keeps only the first line, 120 chars — a progress
       // preview. lastResultText keeps the full last narrative emission:

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -3,6 +3,7 @@ import {
   describeToolUse,
   appendActivityLine,
   appendActivityLabel,
+  clipNarrative,
   renderActivityFeed,
   renderActivityFeedWithNested,
   renderActivityHeader,
@@ -197,6 +198,34 @@ describe("appendActivityLabel — precomputed label feed (tool_label path)", () 
     expect(appendActivityLabel(lines, "   ")).toBeNull();
     expect(appendActivityLabel(lines, undefined)).toBeNull();
     expect(lines.length).toBe(2);
+  });
+});
+
+describe("clipNarrative — narrative-step clip (JSONL-text-narrative primitive)", () => {
+  it("takes the first line only, trims, slices to 120 chars", () => {
+    expect(clipNarrative("On it. Let me find the repo…\nthen build")).toBe(
+      "On it. Let me find the repo…",
+    );
+    expect(clipNarrative("  Found both:  ")).toBe("Found both:");
+    const long = "x".repeat(200);
+    expect(clipNarrative(long).length).toBe(120);
+  });
+
+  it("a shown narrative renders identically to a tool label via the same feed path", () => {
+    // A SHOWN narrative line is pushed through appendActivityLabel exactly
+    // like a tool label, so the rendered feed string is byte-identical.
+    const narrativeLines: string[] = [];
+    const labelLines: string[] = [];
+    const text = "Important find: no main branch yet — branching off origin.";
+    const narrativeRender = appendActivityLabel(narrativeLines, clipNarrative(text));
+    const labelRender = appendActivityLabel(labelLines, clipNarrative(text));
+    expect(narrativeRender).toBe(labelRender);
+    expect(narrativeRender).toBe(`<b>→ ${text}</b>`);
+  });
+
+  it("empty string yields an empty clip (appendActivityLabel then drops it)", () => {
+    expect(clipNarrative("")).toBe("");
+    expect(appendActivityLabel([], clipNarrative("   \n  "))).toBeNull();
   });
 });
 

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -212,6 +212,18 @@ export function appendActivityLine(
   return renderActivityFeed(lines);
 }
 
+/**
+ * Clip a raw narrative text block down to a single transient liveness line:
+ * first line only, trimmed, sliced to 120 chars. Shared by the main-agent
+ * gateway path and the sub-agent watcher so both render narrative identically
+ * (mirrors the watcher's historical `lastSummaryLine` clip). Returns the raw
+ * (unescaped) clipped string — callers escape via the renderStepFeed path,
+ * exactly like a tool label.
+ */
+export function clipNarrative(s: string): string {
+  return (s ?? "").split("\n")[0].trim().slice(0, 120);
+}
+
 /** Minimal HTML escape for Telegram parse_mode=HTML (matches the gateway's). */
 export function escapeFeedHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");


### PR DESCRIPTION
## What

The progress/activity feed showed tool steps but dropped the assistant's own JSONL **text blocks** — the running narrative the model emits as it works ("I'll read X, then patch Y"). That narrative is exactly what the operator needs to *know what their agent is doing* at a glance, and it was invisible across every agent tier.

This surfaces it everywhere, built as **one durable shared primitive** rather than per-tier patches.

## Design — SINGLE PRIMITIVE, no duplication

The whole point of this change is that there is exactly **one** code path for each concern, shared by every tier:

- **One shared projection kernel — `projectAssistantTextBlocks`.** Both the main-session projector and the sub-agent projector call this same kernel to extract assistant text blocks from the JSONL stream. There is no second copy of the projection logic for sub-agents.
- **One shared dedup kernel — `narrative-dedup.ts`.** The narrative is de-duplicated against what the agent already surfaced through `reply()` / `stream_reply()`, so a line the model both *narrated* and *sent* doesn't appear twice. Same kernel for main and sub-agent.
- **One shared clip — `clipNarrative`.** A single clipping primitive bounds narrative length consistently; no tier invents its own truncation.
- **All bottoming out at the shared `renderStepFeed`.** Every tier's projected, deduped, clipped narrative renders through the same step-feed renderer — one rendering surface, not N.

Because the kernels are shared, coverage falls out for free across:

- **main session**
- **Task sub-agents** (the `Task` tool's spawned agents)
- **background workers**
- **nested spawns** (a sub-agent that itself spawns)

Sub-agent transcripts live in a **separate JSONL file** from the main session, so the sub-agent projector includes the separate-file discovery needed to find and tail that transcript before handing its events to the same shared kernels.

## Invariant — chat is the single source of truth

Per the job spec `reference/jobs/know-what-my-agent-is-doing.md`, the narrative in the feed is **transient and clipped** — it is a projection of the live chat/JSONL stream, **not** a persisted mirror. We deliberately keep **no** second persisted copy of the narrative: the chat remains the single source of truth, and the feed is a bounded, ephemeral view derived from it. This keeps the feed honest (it can never drift from what actually happened) and avoids a durability/consistency burden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)