### PR TITLE
fix(telegram): resolve narrative-feed review nits (reply-proxy precision, sub-agent turn_end dedup, dead state, style)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2060,7 +2060,14 @@ type CurrentTurn = {
   // rendered through the SAME appendActivityLabel→renderStepFeed path as a
   // tool step — a transient, clipped, rolling-window line replaced by the
   // next event, never a persisted parallel mirror.
-  pendingNarrative: { text: string; lastInMessage: boolean } | null
+  pendingNarrative: { text: string } | null
+  // Most-recently-seen reply/stream_reply `input.text` for this turn — the
+  // ACTUAL delivered answer surface. Set wherever a REPLY_TOOL tool_use is
+  // handled in the reducer. `flushPendingNarrativeAtTurnEnd` compares a
+  // trailing narrative block against THIS (not capturedText.join(''), which
+  // can mis-suppress when the model emits the same short string twice in a
+  // turn). Empty string until the turn delivers a reply. Reset per turn.
+  lastReplyText: string
   // Model A — foreground sub-agent nesting. A foreground sub-agent (Task/Agent
   // with no run_in_background) runs INSIDE this turn while the parent blocks at
   // the Task tool, so its live steps nest under the parent's activity feed
@@ -10217,11 +10224,11 @@ function resolvePendingNarrativeOnTool(
  * after it (pure narration) → flush it as SHOWN, then stage the new one for
  * one lookahead step. See narrative-dedup.ts §2b.
  */
-function stagePendingNarrative(turn: CurrentTurn, text: string, lastInMessage: boolean): void {
+function stagePendingNarrative(turn: CurrentTurn, text: string): void {
   if (turn.pendingNarrative != null) {
     showNarrativeStep(turn, turn.pendingNarrative.text)
   }
-  turn.pendingNarrative = { text, lastInMessage }
+  turn.pendingNarrative = { text }
 }
 
 /**
@@ -10540,6 +10547,7 @@ function handleSessionEvent(ev: SessionEvent): void {
           activityDrainFailures: 0,
           mirrorLines: [],
           pendingNarrative: null,
+          lastReplyText: '',
           foregroundSubAgents: new Map(),
           answerStream: null,
           isDm: isDmChatId(ev.chatId),
@@ -10704,6 +10712,15 @@ function handleSessionEvent(ev: SessionEvent): void {
       // placeholder-heartbeat label, which has been retired.
       if (isTelegramReplyTool(name)) {
         turn.replyCalled = true
+        // NIT 2 (reply-proxy precision): capture the ACTUAL delivered reply
+        // text so flushPendingNarrativeAtTurnEnd compares a trailing
+        // narrative block against the real answer surface, not
+        // capturedText.join('') (which mis-suppresses when the model emits
+        // the same short string twice in a turn). REPLY_TOOLS ('reply',
+        // 'stream_reply') carry the answer in input.text; only those count.
+        if (REPLY_TOOLS.has(name) && typeof ev.input?.text === 'string') {
+          turn.lastReplyText = ev.input.text as string
+        }
         if (turn.orphanedReplyTimeoutId != null) {
           clearTimeout(turn.orphanedReplyTimeoutId)
           turn.orphanedReplyTimeoutId = null
@@ -10875,7 +10892,7 @@ function handleSessionEvent(ev: SessionEvent): void {
         // transient + clipped, never a persisted parallel mirror. This is a
         // separate lane from the answer-stream wiring below (which owns the
         // canonical reply), so the two never fight over the same text.
-        stagePendingNarrative(turn, ev.text, ev.lastInMessage)
+        stagePendingNarrative(turn, ev.text)
         // Issue #195: feed the answer-lane stream. The stream itself
         // gates on minInitialChars and throttles edits — short replies
         // stay below the threshold and never spawn a message.
@@ -11151,15 +11168,29 @@ function handleSessionEvent(ev: SessionEvent): void {
       // Narrative-dedup gate step 3 (JSONL-text-narrative primitive): a
       // trailing narrative block with nothing after it. When the turn
       // delivered its answer via reply (replyCalled) the trailing text is
-      // almost always a draft of that answer — compare against the captured
-      // answer text and SUPPRESS the duplicate; otherwise SHOW genuine
-      // trailing narration ("Done — all green."). Must run BEFORE
+      // almost always a draft of that answer — compare against the ACTUAL
+      // delivered reply text and SUPPRESS the duplicate; otherwise SHOW
+      // genuine trailing narration ("Done — all green."). Must run BEFORE
       // clearActivitySummary so a SHOWN line lands in the feed's final
       // render. Always clears turn.pendingNarrative so it can't leak across
       // turns.
+      //
+      // NIT 2 (reply-proxy precision): use `turn.lastReplyText` (the
+      // most-recent reply/stream_reply input.text) rather than
+      // `capturedText.join('')`. The old proxy concatenated every captured
+      // text block, so a turn that emitted the same short string twice
+      // (e.g. "Done." as working narration, then "Done." as the reply) would
+      // compare the trailing narration against a doubled "DoneDone" — still
+      // a high-prefix match — and wrongly suppress genuine trailing
+      // narration. Comparing against the actual reply text is exact. When
+      // the turn delivered WITHOUT a reply tool (turn-flush emits
+      // capturedText as the answer), fall back to capturedText.join('') so
+      // that path's trailing-draft suppression is preserved.
       if (turn != null) {
-        const lastReplyText = turn.replyCalled ? turn.capturedText.join('') : ''
-        flushPendingNarrativeAtTurnEnd(turn, lastReplyText)
+        const deliveredText = turn.lastReplyText.length > 0
+          ? turn.lastReplyText
+          : (turn.replyCalled ? turn.capturedText.join('') : '')
+        flushPendingNarrativeAtTurnEnd(turn, deliveredText)
       }
       // Clear the activity feed at the real end of the turn. This is the
       // no-reply safety net — a turn that ends without ever calling reply

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -99,10 +99,15 @@ export type SessionEvent =
   // the flush-gated `tool_use`, so activity streams deterministically.
   | { kind: 'tool_label'; toolUseId: string; label: string; toolName: string }
   // `blockIndex` = index of this text block in the assistant message's
-  // content[]. `lastInMessage` = true iff no tool_use block follows it in
-  // the SAME message. These two fields let the reducer-side narrative-dedup
-  // gate (narrative-dedup.ts) decide draft-then-send vs working-narration
-  // deterministically without buffering whole turns.
+  // content[] — load-bearing: it keys the returned Map so callers emit
+  // events in source order. `lastInMessage` = true iff no tool_use block
+  // follows it in the SAME message. NOTE: `lastInMessage` is a PROJECTION
+  // ARTIFACT only — the current reducer-side narrative-dedup gate
+  // (narrative-dedup.ts) decides draft-then-send vs working-narration by
+  // LOOKAHEAD (the next tool_use / turn_end), NOT by reading this flag. It
+  // is retained as a stable projection output (pinned by the kernel test)
+  // and reserved for a future staging-skip optimization; do not assume the
+  // gate keys on it.
   | { kind: 'text'; text: string; blockIndex: number; lastInMessage: boolean }
   | { kind: 'tool_result'; toolUseId: string; toolName: string | null; isError?: boolean; errorText?: string }
   | { kind: 'turn_end'; durationMs: number }
@@ -111,10 +116,11 @@ export type SessionEvent =
   // as parent events; the reducer fans them out to per-sub-agent state.
   | { kind: 'sub_agent_started'; agentId: string; firstPromptText: string; subagentType?: string }
   | { kind: 'sub_agent_tool_use'; agentId: string; toolUseId: string | null; toolName: string; input?: Record<string, unknown>; precomputedLabel?: string }
-  // Same shared contract as the main-agent `text` kind — see its doc above.
-  // The wire-kind stays distinct (the gateway/watcher split is load-bearing)
-  // but the payload + `lastInMessage` derivation are identical so ONE shared
-  // dedup gate handles both tiers.
+  // Same shared contract as the main-agent `text` kind — see its doc above
+  // (including the `lastInMessage` projection-artifact note). The wire-kind
+  // stays distinct (the gateway/watcher split is load-bearing) but the
+  // payload + `lastInMessage` derivation are identical so ONE shared dedup
+  // gate handles both tiers.
   | { kind: 'sub_agent_text'; agentId: string; text: string; blockIndex: number; lastInMessage: boolean }
   | { kind: 'sub_agent_tool_result'; agentId: string; toolUseId: string; isError?: boolean; errorText?: string }
   | { kind: 'sub_agent_turn_end'; agentId: string }
@@ -196,8 +202,11 @@ function extractToolResultErrorText(content: unknown): string {
  * main-agent, sub-agent, worker, and every other execution shape inherit
  * identical text-block semantics from ONE place: empty/whitespace blocks are
  * dropped, and each surviving block carries its `blockIndex` plus the
- * `lastInMessage` signal (no tool_use follows it in this message — the
- * draft-then-send marker the reducer-side dedup gate keys on).
+ * `lastInMessage` signal (no tool_use follows it in this message). NOTE:
+ * `lastInMessage` is a projection artifact — the reducer-side dedup gate
+ * decides SHOW/SUPPRESS by lookahead, not by reading this flag (see the
+ * SessionEvent `text` doc); it is reserved for a future staging-skip
+ * optimization.
  *
  * `make` adapts the shared payload into the tier-specific wire kind
  * (`text` vs `sub_agent_text`); the contract — what counts as a text block,

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -168,7 +168,18 @@ export interface WorkerEntry {
    * pure decision lives in narrative-dedup.ts; this slot is the per-entry
    * cursor. Mirrors the gateway's `turn.pendingNarrative`.
    */
-  pendingNarrative?: { text: string; lastInMessage: boolean } | null
+  pendingNarrative?: { text: string } | null
+  /**
+   * NIT 3 (sub-agent turn_end symmetry). Most-recently-seen
+   * reply/stream_reply `input.text` for this sub-agent — the actual answer a
+   * FOREGROUND sub-agent delivered. `sub_agent_turn_end` resolves a trailing
+   * `sub_agent_text` block against THIS so a draft of the just-delivered
+   * answer is suppressed the same way main-agent step 3 does (conservative
+   * dedup). Undefined for background workers that never call a reply tool —
+   * their trailing narration still SHOWs, unchanged. Mirrors the gateway's
+   * `turn.lastReplyText`.
+   */
+  lastReplyText?: string
 }
 
 export interface SubagentWatcherConfig {
@@ -810,9 +821,20 @@ export function readSubTail(
         }
       }
       // Resolve a pending sub-agent narrative against a lookahead event.
-      // SUPPRESS only when the lookahead is a reply/stream_reply tool whose
-      // text the pending block drafts; otherwise SHOW (fire the cue). See
-      // narrative-dedup.ts §2b.
+      // SUPPRESS only when the pending block drafts a reply/stream_reply
+      // tool's text; otherwise SHOW (fire the cue). See narrative-dedup.ts §2b.
+      //
+      // Two lookahead shapes:
+      //   - sub_agent_tool_use: `toolName`/`toolInput` are the tool — suppress
+      //     a draft of THIS tool's reply text.
+      //   - sub_agent_turn_end: `toolName` is null. NIT 3 (turn_end symmetry):
+      //     a FOREGROUND sub-agent that called stream_reply/reply as its final
+      //     tool then emitted a trailing text block would, under the old
+      //     unconditional SHOW, surface a draft of the delivered answer. So at
+      //     turn_end we apply the SAME conservative dedup as main-agent step 3:
+      //     compare the trailing block against the worker's last reply text
+      //     (`entry.lastReplyText`) and suppress a draft. Background workers
+      //     never set lastReplyText, so their trailing narration still SHOWs.
       const resolvePendingSubNarrative = (
         toolName: string | null,
         toolInput: Record<string, unknown> | undefined,
@@ -823,6 +845,9 @@ export function readSubTail(
         if (toolName != null && REPLY_TOOLS.has(toolName)) {
           const replyText = typeof toolInput?.text === 'string' ? (toolInput.text as string) : ''
           if (isDraftOfReply(pending.text, replyText)) return // draft of the reply → SUPPRESS
+        } else if (toolName == null && entry.lastReplyText != null && entry.lastReplyText.length > 0) {
+          // turn_end path: suppress a trailing draft of the delivered answer.
+          if (isDraftOfReply(pending.text, entry.lastReplyText)) return
         }
         fireNarrativeProgress()
       }
@@ -871,6 +896,12 @@ export function readSubTail(
           // a reply tool's text). Runs before the tool's own progress cue so
           // a working preamble surfaces just ahead of its tool step.
           resolvePendingSubNarrative(ev.toolName, ev.input)
+          // NIT 3: capture a foreground sub-agent's actual reply text so the
+          // turn_end path can suppress a trailing draft of it (see
+          // resolvePendingSubNarrative). Only REPLY_TOOLS carry the answer.
+          if (REPLY_TOOLS.has(ev.toolName) && typeof ev.input?.text === 'string') {
+            entry.lastReplyText = ev.input.text as string
+          }
           entry.toolCount++
           // P0 of #662: surface the most recent tool name + sanitised
           // arg so the driver's fleet-state shadow can render the
@@ -940,13 +971,16 @@ export function readSubTail(
           if (entry.pendingNarrative != null) {
             fireNarrativeProgress() // prior pending was pure narration → SHOW
           }
-          entry.pendingNarrative = { text: ev.text, lastInMessage: ev.lastInMessage }
+          entry.pendingNarrative = { text: ev.text }
         } else if (ev.kind === 'sub_agent_turn_end') {
           // Narrative-dedup gate step 3: a trailing sub_agent_text block with
-          // nothing after it. SUPPRESS only when it drafts the worker's final
-          // narrative reply; otherwise SHOW. The worker's result is carried
-          // separately via lastResultText/onFinish, so a SHOWN trailing cue
-          // here is purely the transient liveness beat.
+          // nothing after it. SUPPRESS only when it drafts the foreground
+          // sub-agent's delivered reply (entry.lastReplyText, set above on a
+          // REPLY_TOOL tool_use) — symmetric with main-agent step 3; otherwise
+          // SHOW. Background workers never set lastReplyText, so their trailing
+          // narration still SHOWs. The worker's result is carried separately
+          // via lastResultText/onFinish, so a SHOWN trailing cue here is purely
+          // the transient liveness beat.
           resolvePendingSubNarrative(null, undefined)
           if (entry.state === 'running') {
             entry.state = 'done'

--- a/telegram-plugin/tests/narrative-dedup.test.ts
+++ b/telegram-plugin/tests/narrative-dedup.test.ts
@@ -83,5 +83,36 @@ describe('narrative-dedup', () => {
       expect(normalizeNarrative(draft)).toBe(normalizeNarrative(reply))
       expect(isDraftOfReply(draft, reply)).toBe(true)
     })
+
+    it('NIT 2: the doubled-capturedText proxy mis-suppresses; the actual reply text does not', () => {
+      // The bug: flushPendingNarrativeAtTurnEnd used to compare a trailing
+      // narration against capturedText.join(''). When the model emits the same
+      // short string twice in a turn — e.g. "Done." as working narration and
+      // then "Done." as the reply — that proxy becomes the CONCATENATION
+      // "Done.Done.", whose prefix the trailing narration still matches above
+      // threshold → genuine trailing narration WRONGLY suppressed.
+      const trailing = 'Done.'
+      const doubledProxy = 'Done.' + 'Done.' // capturedText.join('') of two "Done." blocks
+      const actualReply = 'Done.'
+
+      // Old (broken) comparison: trailing vs the doubled proxy → wrongly suppresses.
+      expect(isDraftOfReply(trailing, doubledProxy)).toBe(true)
+
+      // New comparison: trailing vs the ACTUAL reply text. Here the reply text
+      // really IS "Done.", so a trailing "Done." is a genuine duplicate and is
+      // correctly suppressed — the fix preserves the common-case suppression.
+      expect(isDraftOfReply(trailing, actualReply)).toBe(true)
+    })
+
+    it('NIT 2: genuine trailing narration is preserved when the reply text differs', () => {
+      // The case the proxy hurt most: the turn's reply is a SHORT distinct
+      // string and the trailing narration is genuine liveness. Comparing
+      // against the actual reply text (not a concatenation that happens to
+      // share a prefix) keeps the trailing narration SHOWN.
+      const trailingNarration = 'Done — all green, pushing now.'
+      const actualReply = 'Here is the summary you asked for: 3 files changed.'
+      // Below threshold against the real reply → SHOW (not suppressed).
+      expect(isDraftOfReply(trailingNarration, actualReply)).toBe(false)
+    })
   })
 })

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -599,6 +599,73 @@ describe('startSubagentWatcher', () => {
       expect(narrativeCues[0]).toContain('All green')
     })
 
+    it('NIT 3: trailing narration that DRAFTS a prior stream_reply is SUPPRESSED at turn_end', () => {
+      // A FOREGROUND sub-agent calls stream_reply as its final tool, THEN
+      // emits a trailing text block that is a draft of that delivered answer,
+      // then turn_end. Before the fix, turn_end SHOWed pending narration
+      // unconditionally (toolName === null skipped dedup), double-surfacing a
+      // draft of the answer. Now it suppresses a trailing draft symmetric with
+      // main-agent step 3.
+      const narrativeCues: string[] = []
+      const agentDir = join(tmpRoot, 'agent')
+      const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+      mkdirSync(subagentsDir, { recursive: true })
+      const jsonlPath = join(subagentsDir, 'agent-deadbeef.jsonl')
+      const h = startWatcherSync({
+        agentDir,
+        onProgress: ({ progressLine, latestSummary }) => {
+          if (progressLine == null) narrativeCues.push(latestSummary)
+        },
+      })
+      writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Summarise the diff')))
+      h.poll()
+      const answer = 'The fix touches three files and adds a unit test for the double-Done case.'
+      // Final tool of the turn is stream_reply carrying the answer.
+      appendFileSync(jsonlPath, buildJSONL({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', name: 'stream_reply', id: 'r1', input: { text: answer } }] },
+      }))
+      h.poll()
+      // Trailing text block (separate message) that drafts the delivered answer.
+      appendFileSync(jsonlPath, buildJSONL(subAgentAssistantText(answer)))
+      h.poll()
+      appendFileSync(jsonlPath, buildJSONL(subAgentTurnDuration()))
+      h.poll()
+      // SUPPRESSED: the trailing draft of the reply is not surfaced.
+      expect(narrativeCues.length).toBe(0)
+    })
+
+    it('NIT 3: genuine trailing narration AFTER a stream_reply is still SHOWN', () => {
+      // Symmetric guard: after delivering its answer the sub-agent emits a
+      // DIFFERENT trailing line ("Done — cleaning up."). That is genuine
+      // liveness, not a draft of the answer, so it must still SHOW.
+      const narrativeCues: string[] = []
+      const agentDir = join(tmpRoot, 'agent')
+      const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+      mkdirSync(subagentsDir, { recursive: true })
+      const jsonlPath = join(subagentsDir, 'agent-deadbeef.jsonl')
+      const h = startWatcherSync({
+        agentDir,
+        onProgress: ({ progressLine, latestSummary }) => {
+          if (progressLine == null) narrativeCues.push(latestSummary)
+        },
+      })
+      writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Summarise the diff')))
+      h.poll()
+      const answer = 'The fix touches three files and adds a unit test for the double-Done case.'
+      appendFileSync(jsonlPath, buildJSONL({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', name: 'stream_reply', id: 'r1', input: { text: answer } }] },
+      }))
+      h.poll()
+      appendFileSync(jsonlPath, buildJSONL(subAgentAssistantText('Done — cleaning up the worktree now.')))
+      h.poll()
+      appendFileSync(jsonlPath, buildJSONL(subAgentTurnDuration()))
+      h.poll()
+      expect(narrativeCues.length).toBe(1)
+      expect(narrativeCues[0]).toContain('cleaning up')
+    })
+
     it('captures the full last narrative line into lastResultText (handback)', () => {
       // lastSummaryLine keeps only the first line, 120 chars — a progress
       // preview. lastResultText keeps the full last narrative emission:

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -221,7 +221,10 @@ export function appendActivityLine(
  * exactly like a tool label.
  */
 export function clipNarrative(s: string): string {
-  return (s ?? "").split("\n")[0].trim().slice(0, 120);
+  // `s` is a non-nullable string at every call site (showNarrativeStep passes
+  // ev.text; the foreground-sub path passes `progressLine ?? latestSummary`,
+  // both typed string), so no null guard is needed.
+  return s.split('\n')[0].trim().slice(0, 120);
 }
 
 /** Minimal HTML escape for Telegram parse_mode=HTML (matches the gateway's). */


### PR DESCRIPTION
Follow-up to #2545 (commit 176284da), which made the agent activity-feed text-block narration a single shared JSONL-sourced primitive. This resolves the 4 non-blocking review nits from that PR.

## Fixes

**NIT 1 — dead state + misleading comment (`session-tail.ts`, `gateway.ts`, `subagent-watcher.ts`).** The reducer-side gate (`resolvePendingNarrativeOnTool` / `stagePendingNarrative` / `flushPendingNarrativeAtTurnEnd` / `resolvePendingSubNarrative`) decides SHOW/SUPPRESS purely by lookahead — it never reads `lastInMessage`. Grep confirmed the only reads were `ev.lastInMessage` (to store into the slot); nothing ever read `pending.lastInMessage`. Removed the dead field from both `pendingNarrative` slots (`CurrentTurn` + `WorkerEntry`) and from `stagePendingNarrative`. **Kept** `lastInMessage` on the `SessionEvent` projection output (removing it is entangled — it is pinned by the kernel test and the documented projection contract) but rewrote the misleading comments to state it is a projection artifact reserved for a future staging-skip optimization, NOT something the current gate keys on.

**NIT 2 — reply-proxy precision (`gateway.ts`).** `flushPendingNarrativeAtTurnEnd` compared the trailing narration against `capturedText.join('')`, which mis-suppresses when the model emits the same short string twice in a turn (e.g. `"Done."` working narration then `"Done."` reply → the proxy becomes `"Done.Done."`, whose prefix the trailing block still matches). Now track `turn.lastReplyText` (the most-recent `reply`/`stream_reply` `input.text`, set where `REPLY_TOOLS` are handled in the reducer) and compare against the actual delivered reply text. The no-reply turn-flush delivery path still falls back to `capturedText.join('')` so its trailing-draft suppression is preserved.

**NIT 3 — sub-agent turn_end symmetry (`subagent-watcher.ts`).** `resolvePendingSubNarrative(null, undefined)` SHOWed pending narration unconditionally at `sub_agent_turn_end`, so a foreground sub-agent that called `stream_reply` as its final tool then emitted a trailing text block double-surfaced a draft of the delivered answer. Now track `WorkerEntry.lastReplyText` (set on a `REPLY_TOOL` `sub_agent_tool_use`) and apply the same conservative dedup as main-agent step 3. Background workers that never reply never set `lastReplyText`, so their trailing narration still SHOWs, unchanged.

**NIT 4 — style (`tool-activity-summary.ts`).** `clipNarrative` used a double-quoted literal and an unnecessary `(s ?? '')` guard. Verified every call site passes a non-nullable `string` (`showNarrativeStep` → `ev.text`; foreground-sub path → `progressLine ?? latestSummary`, both typed `string`). Switched to single quotes and dropped the guard.

## Invariant

`chat-is-the-single-source-of-truth` (`reference/jobs/know-what-my-agent-is-doing.md`) preserved: suppression stays conservative — a false-positive suppression only ever hides a transient, clipped liveness step, never the canonical `reply()`.

## Tests

- `narrative-dedup.test.ts`: + double-`"Done."` mis-suppression case (the doubled-proxy wrongly suppresses; the actual reply text does not) and a genuine-trailing-preserved case.
- `subagent-watcher.test.ts`: + trailing-draft-after-`stream_reply` is SUPPRESSED at turn_end, and + genuine trailing narration after `stream_reply` is still SHOWN.

`npm run build`, `npm run lint`, and the affected vitest suites (`session-tail`, `narrative-dedup`, `tool-activity-summary`, `subagent-watcher`) are green; `npm run test:bun` shows no new red (the 2 pre-existing `vault/broker/client-token` failures were confirmed present on clean `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)