### PR TITLE
fix(telegram): filter workflows/ descent to real directories

### DIFF
--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.15.48";
-export const COMMIT_SHA: string | null = "5262be25";
-export const COMMIT_DATE: string | null = "2026-06-21T23:25:16+10:00";
-export const LATEST_PR: number | null = 2511;
-export const COMMITS_AHEAD_OF_TAG: number | null = 0;
+export const COMMIT_SHA: string | null = "ffb0f02";
+export const COMMIT_DATE: string | null = "2026-06-24T16:30:05+10:00";
+export const LATEST_PR: number | null = 2546;
+export const COMMITS_AHEAD_OF_TAG: number | null = null;

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -1612,7 +1612,11 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
           for (const wfDir of wfDirs) {
             try {
               const wfPath = join(workflowsPath, wfDir)
-              fs.statSync(wfPath) // throws if not a directory-like entry
+              // Only descend into actual directories. statSync succeeds on
+              // regular files too (e.g. a stray journal.jsonl or lock file
+              // sitting directly in workflows/), so check isDirectory()
+              // explicitly rather than relying on a throw that never comes.
+              if (!fs.statSync(wfPath).isDirectory()) continue
               watchAndScan(wfPath)
             } catch { /* skip entries we can't stat or watch */ }
           }

--- a/telegram-plugin/tests/subagent-watcher-workflow-visibility.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-workflow-visibility.test.ts
@@ -174,4 +174,52 @@ describe('workflow sub-agent feed visibility', () => {
     // Exactly the three agents, no journals
     expect(watcher.getRegistry().size).toBe(3)
   })
+
+  it('skips a stray non-directory file sitting directly in workflows/', () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'switchroom-workflow-stray-test-'))
+    const agentDir = join(tmpRoot, 'agent')
+
+    const workflowsBase = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents', 'workflows')
+    mkdirSync(workflowsBase, { recursive: true })
+    // A stray regular file directly under workflows/ (e.g. an index/lock the
+    // Workflow tool might drop there). statSync succeeds on it, so without the
+    // isDirectory() guard it would be handed to watchAndScan and open a wasted
+    // fs.watch. It must be skipped — not registered — and not crash the scan.
+    writeFileSync(join(workflowsBase, 'index.json'), '{"runs":[]}')
+
+    // A real workflow agent alongside the stray file must still register
+    const wfDir = join(workflowsBase, 'wf_real')
+    mkdirSync(wfDir, { recursive: true })
+    const agentId = 'feedface00001111'
+    writeFileSync(join(wfDir, `agent-${agentId}.jsonl`), minimalAgentJsonl())
+
+    const { poll, watcher } = startWatcher(agentDir)
+    poll()
+
+    expect(watcher.getRegistry().get(agentId), 'real workflow agent should register').toBeDefined()
+    // Only the real agent — the stray file produced no entry
+    expect(watcher.getRegistry().size).toBe(1)
+  })
+
+  it('discovers a wf_* dir created AFTER the watcher starts (runtime poll)', () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'switchroom-workflow-late-test-'))
+    const agentDir = join(tmpRoot, 'agent')
+
+    // Session + subagents dir present at boot, but no workflows/ run yet
+    const subagents = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+    mkdirSync(subagents, { recursive: true })
+
+    const { poll, watcher } = startWatcher(agentDir)
+    poll() // boot scan: nothing to register
+    expect(watcher.getRegistry().size).toBe(0)
+
+    // A workflow run begins after the watcher is already live
+    const wfDir = join(subagents, 'workflows', 'wf_late')
+    mkdirSync(wfDir, { recursive: true })
+    const agentId = 'lateb00b1234abcd'
+    writeFileSync(join(wfDir, `agent-${agentId}.jsonl`), minimalAgentJsonl())
+
+    poll() // next poll tick re-descends workflows/ and picks it up
+    expect(watcher.getRegistry().get(agentId), 'late workflow agent should be discovered on poll').toBeDefined()
+  })
 })


### PR DESCRIPTION
Follow-up to #2547 (review nit from the combined feed-changes review).

## What
`rescanSubagentDirs()`'s descent into `subagents/workflows/*/` used `fs.statSync(wfPath)` only for its throw to skip non-directory entries — but `statSync` succeeds on regular files, it only throws on ENOENT/EACCES. A stray regular file dropped directly in `workflows/` (a lock/index file) would therefore be passed to `watchAndScan` and open a wasted `fs.watch` FD held for the watcher's lifetime. Harm was bounded (no wrong registration — `scanSubagentsDir` no-ops on a non-dir) but the guard's comment was inaccurate and the behavior would worsen as the workflows/ layout grows.

## Fix
Check `isDirectory()` explicitly: `if (!fs.statSync(wfPath).isDirectory()) continue`. The surrounding try/catch still skips entries that can't be stat'd (ENOENT race).

## Tests
Two new cases in `subagent-watcher-workflow-visibility.test.ts`:
- a stray non-dir file directly in `workflows/` is skipped while a real `wf_*/` agent alongside still registers;
- a `wf_*/` dir created *after* the watcher starts is discovered on the next poll tick (runtime discovery, previously untested).

## Verdict
- Vision outcome: **Visibility** (workflow sub-agent activity in the feed).
- Job spec: same as #2547 (worker/sub-agent activity surfaced to chat).
- Invariants: none crossed. lint + targeted bun tests green locally (5/5 in the workflow-visibility file).