### PR TITLE
fix(telegram): deliver idle auto-clear notice silently

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3264,6 +3264,7 @@ async function postIdleClearNotice(idleClearMs: number): Promise<void> {
       () =>
         bot.api.sendMessage(chatId, text, {
           parse_mode: 'HTML',
+          disable_notification: true,
           ...(threadId != null ? { message_thread_id: threadId } : {}),
         }),
       { chat_id: chatId, verb: 'idleAutoClear.notice' },


### PR DESCRIPTION
## What

The gateway's idle auto-clear notice — `🧹 Cleared after Nh idle — fresh slate next message; long-term memory is in Hindsight.` — is posted to Telegram with a push notification. This makes a passive housekeeping message ping the operator's device.

This adds `disable_notification: true` to the `sendMessage` options in `postIdleClearNotice()` so the notice is delivered silently. That is the entire functional change (one field).

```diff
         bot.api.sendMessage(chatId, text, {
           parse_mode: 'HTML',
+          disable_notification: true,
           ...(threadId != null ? { message_thread_id: threadId } : {}),
         }),
```

## Why / JTBD

**Vision outcome:** Visibility (without noise) — the notice still appears pinned/in-topic, it just doesn't ping. A purely informational "your context was reset" message has no actionable urgency, so a silent delivery is the correct default. This is consistent with other passive/silent gateway notices (boot card silent on operator, silent-end).

**Invariants:** No breach — telegram-only delivery unchanged, chat remains the single source of truth, no self-escalation, claude-native.

## Testing

- `npm run lint` (tsc --noEmit + all guard scripts incl. `check-bot-api-wrapping`) — clean. The call remains inside `swallowingApiCall`.
- Ran existing silent-delivery tests (`silent-end.test.ts`, `boot-card-silent-on-operator.test.ts`) — 46 pass / 0 fail.
- No existing test covers `postIdleClearNotice` directly; per the switchroom skill's guidance, no new test was added for a one-field flag change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)