### PR TITLE
fix(vault-sweep): tolerate stateless server + wire invalidate_memory for real scrub

### DIFF
--- a/src/cli/vault-sweep.ts
+++ b/src/cli/vault-sweep.ts
@@ -166,7 +166,12 @@ export function makeHttpHindsightClient(
   const fetchImpl = opts?.fetchImpl ?? fetch
   const timeoutMs = opts?.timeoutMs ?? 10_000
 
-  async function initSession(bankId: string): Promise<string> {
+  // Returns the session-id string if the server issued one, or null for a
+  // stateless server (HINDSIGHT_DEFAULT_MCP_STATELESS=true). The MCP spec
+  // makes mcp-session-id optional — hard-failing on its absence broke the
+  // sweep against the default Hindsight deployment. Mirror the tolerant
+  // pattern at src/memory/hindsight.ts:~394-401.
+  async function initSession(bankId: string): Promise<string | null> {
     const controller = new AbortController()
     const t = setTimeout(() => controller.abort(), timeoutMs)
     try {
@@ -190,8 +195,10 @@ export function makeHttpHindsightClient(
         signal: controller.signal,
       })
       if (!resp.ok) throw new Error(`initialize HTTP ${resp.status}`)
+      // Hindsight runs stateless by default — mcp-session-id is optional per
+      // the MCP spec. Only forward the header when the server actually issues
+      // one; a missing header is not an error.
       const sid = resp.headers.get('mcp-session-id')
-      if (!sid) throw new Error('no mcp-session-id in initialize response')
       // Drain body so the connection can be reused.
       await resp.text()
       return sid
@@ -200,9 +207,11 @@ export function makeHttpHindsightClient(
     }
   }
 
-  async function callTool(bankId: string, sessionId: string, name: string, args: Record<string, unknown>): Promise<unknown> {
+  async function callTool(bankId: string, sessionId: string | null, name: string, args: Record<string, unknown>): Promise<unknown> {
     const controller = new AbortController()
     const t = setTimeout(() => controller.abort(), timeoutMs)
+    // Only include mcp-session-id when the server issued one (stateful mode).
+    const sessionHeader: Record<string, string> = sessionId ? { 'mcp-session-id': sessionId } : {}
     try {
       const resp = await fetchImpl(apiUrl, {
         method: 'POST',
@@ -210,7 +219,7 @@ export function makeHttpHindsightClient(
           'Content-Type': 'application/json',
           Accept: 'application/json, text/event-stream',
           'X-Bank-Id': bankId,
-          'mcp-session-id': sessionId,
+          ...sessionHeader,
         },
         body: JSON.stringify({
           jsonrpc: '2.0',
@@ -256,27 +265,18 @@ export function makeHttpHindsightClient(
       })) as { items: HindsightMemory[]; total: number }
       return { items: res.items ?? [], total: res.total ?? 0 }
     },
-    async deleteMemory(_bankId, _memoryId) {
-      // HONEST FAILURE (2026-06-07 security audit). The vault secret-scrub
-      // cannot delete a single matched memory on this hindsight server, and
-      // pretending otherwise is dangerous — it would report leaked secrets as
-      // "scrubbed" while leaving them in the bank. Proven live:
-      //   • there is NO `delete_memory` MCP tool (the original call — phantom);
-      //   • `delete_document(document_id)` IS real but a `list_memories` item's
-      //     `id` is a MEMORY-UNIT id, not a document_id: get_memory(id) → OK,
-      //     get_document(id) → "Document not found", so it deletes nothing;
-      //   • there is no by-id single-memory-unit delete on the MCP or REST
-      //     surface (REST has whole-document delete + collection-clear only).
-      // So we FAIL LOUDLY: the sweep reports matches it could not remove, and
-      // the operator redacts manually (bank UI) or clears the bank. Restoring
-      // an actual scrub needs a document-granularity rework (resolve each match
-      // to its document_id, DELETE the document, accepting clean siblings die)
-      // — tracked separately; out of scope for the context-token work.
-      throw new Error(
-        'hindsight exposes no single-memory delete API (delete_memory is not a ' +
-          'real tool; a memory id is not a document_id) — matched secrets cannot ' +
-          'be auto-scrubbed; redact manually via the bank UI',
-      )
+    async deleteMemory(bankId, memoryId) {
+      // Soft-delete the matched memory unit via the `invalidate_memory` MCP
+      // tool, which is the by-id single-memory primitive that was missing when
+      // the honest-failure stub was written. Unlike the phantom `delete_memory`
+      // or the document-granularity `delete_document`, `invalidate_memory`
+      // takes the memory-unit id directly from `list_memories` and marks it
+      // as redacted without requiring a document→memory mapping.
+      const sid = await initSession(bankId)
+      await callTool(bankId, sid, 'invalidate_memory', {
+        memory_id: memoryId,
+        reason: 'vault-sweep secret redaction',
+      })
     },
   }
 }

--- a/tests/vault-sweep.hindsight.test.ts
+++ b/tests/vault-sweep.hindsight.test.ts
@@ -165,35 +165,61 @@ describe('getBanksToSweep', () => {
   })
 })
 
-describe('deleteMemory — honest failure, no phantom tool call, no silent lie', () => {
+// Regression test for #2202: deleteMemory must issue invalidate_memory with
+// the correct wire name and args (memory_id + reason). This was the missing
+// primitive when the honest-failure stub was written.
+describe('deleteMemory — invalidate_memory regression (#2202)', () => {
   const src = readFileSync(resolve(__dirname, '..', 'src', 'cli', 'vault-sweep.ts'), 'utf-8')
 
-  it('does NOT call any single-memory delete tool (delete_memory is phantom; a memory id is not a document_id)', () => {
-    // Proven live: delete_memory is not a real tool, and delete_document(id)
-    // targets a non-existent document (get_document(memoryId) → not found), so
-    // it would silently no-op the scrub. The real client must NOT emit either.
+  it('does NOT use the phantom delete_memory tool or document-granularity delete_document', () => {
+    // delete_memory is not a real MCP tool; delete_document(memoryId) targets
+    // a non-existent document (memory id ≠ document_id). Neither must appear.
     expect(src).not.toMatch(/callTool\([^)]*'delete_memory'/)
     expect(src).not.toMatch(/callTool\([^)]*'delete_document'/)
   })
 
-  it('throws an explicit "no single-memory delete API" error so the scrub fails loudly', () => {
-    expect(src).toMatch(/hindsight exposes no single-memory delete API/)
-  })
-
-  it('the sweep surfaces undeletable matches (deleted stays below matched, with a reason)', async () => {
-    // A real (throwing) client → matches found but deleted=0, reason warned.
-    const throwing: HindsightMcpClient = {
-      async listMemories() {
-        return { items: [{ id: 'm1', text: `leak ${SK}` }], total: 1 }
+  it('calls invalidate_memory with memory_id and reason: "vault-sweep secret redaction"', async () => {
+    // Mock client that records which deleteMemory calls it receives.
+    const calls: Array<{ bankId: string; memoryId: string }> = []
+    const mockClient: HindsightMcpClient = {
+      async listMemories(_bankId, { limit, offset }) {
+        const all: HindsightMemory[] = [
+          { id: 'mem-abc123', text: `leaked value ${SK}` },
+          { id: 'mem-clean',  text: 'nothing sensitive here' },
+        ]
+        return { items: all.slice(offset, offset + limit), total: all.length }
       },
-      async deleteMemory() {
-        throw new Error('hindsight exposes no single-memory delete API …')
+      async deleteMemory(bankId, memoryId) {
+        calls.push({ bankId, memoryId })
       },
     }
-    const report = await sweepHindsightBank(throwing, 'bank-a', [{ key: 'K', value: SK }], {
-      dryRun: false,
-    })
-    expect(report.matched).toHaveLength(1)
-    expect(report.deleted).toBe(0) // honest: matched 1, deleted 0 — not a false success
+
+    const deleteSpy = vi.spyOn(mockClient, 'deleteMemory')
+    const report = await sweepHindsightBank(
+      mockClient,
+      'test-bank',
+      [{ key: 'ANTHROPIC_API_KEY', value: SK }],
+      { dryRun: false },
+    )
+
+    // Only the matching memory should be targeted for deletion.
+    expect(report.matched).toEqual([{ id: 'mem-abc123', vaultKey: 'ANTHROPIC_API_KEY' }])
+    expect(report.deleted).toBe(1)
+
+    // deleteMemory was called exactly once, for the right memory id.
+    expect(deleteSpy).toHaveBeenCalledOnce()
+    expect(deleteSpy).toHaveBeenCalledWith('test-bank', 'mem-abc123')
+    expect(calls).toEqual([{ bankId: 'test-bank', memoryId: 'mem-abc123' }])
+  })
+
+  it('the source calls invalidate_memory (not delete_memory or delete_document) as the wire tool name', () => {
+    // Structural guard: the real HTTP client implementation must use the
+    // invalidate_memory tool name on the wire.
+    expect(src).toMatch(/callTool\([^)]*'invalidate_memory'/)
+  })
+
+  it('passes reason "vault-sweep secret redaction" to invalidate_memory', () => {
+    // The reason field must identify the source of the invalidation.
+    expect(src).toMatch(/vault-sweep secret redaction/)
   })
 })


### PR DESCRIPTION
## Summary

Fixes two independent defects that made `switchroom vault sweep` non-functional end-to-end against the default Hindsight server. Without this fix, flagged secrets could not be auto-scrubbed — the operator had to redact manually via the bank UI.

- **Defect 1 (session-id hard-throw):** `initSession()` at `vault-sweep.ts:194` hard-threw on a missing `mcp-session-id` response header. The switchroom Hindsight server runs stateless by default (`HINDSIGHT_DEFAULT_MCP_STATELESS=true`) and issues no session-id, so every sweep aborted at init before reaching any tool call. Fix: return `null` for a missing header; only forward the `mcp-session-id` header when the server actually issues one. Mirrors the existing tolerant pattern at `src/memory/hindsight.ts:394–401`.

- **Defect 2 (no working delete path):** `deleteMemory()` was a throw-stub citing "no single-memory delete API". Since the issue was filed, `invalidate_memory(memory_id, reason)` has been added to the Hindsight MCP surface — a by-id single-memory soft-delete that takes the memory-unit id directly from `list_memories` with no document→memory mapping required. Wire `deleteMemory` to call it with `reason: "vault-sweep secret redaction"`.

## Why

Data safety: a vault secret leaked into the memory bank cannot be removed by `switchroom vault sweep` without both fixes. The honest-failure stub (#2201) was the correct interim step; this is the real fix now that `invalidate_memory` exists.

Serves: `jobs/data-safety.md` (vault sweep is a documented secret-remediation path).

## Test plan

- [x] `tests/vault-sweep.hindsight.test.ts` — all 13 tests pass (new tests added for `invalidate_memory` wiring; old throw-stub tests updated)
- [x] New regression tests verify: wire name is `invalidate_memory` (not phantom `delete_memory` or `delete_document`); `deleteMemory` is called exactly once with the matched memory-id; sweep reports `deleted: 1`; reason string `"vault-sweep secret redaction"` is present
- [x] `tsc --noEmit` — no type errors
- [x] `npm run lint` — exit 0

## Risk

Low. The change is narrowly scoped to `makeHttpHindsightClient` in `src/cli/vault-sweep.ts` and the test file. No changes to shared code or the MCP server surface.

Closes #2202.