### PR TITLE
feat(telegram): unify agent+worker status cards into one renderStatusCard primitive + worker heartbeat

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5109,6 +5109,11 @@ const completeProgressCardTurn:
 // #1122 PR3: flushProgressCardsForShutdown deleted with the card. No
 // replacement needed — there are no pinned progress messages to flush.
 let subagentWatcher: SubagentWatcherHandle | null = null
+// Background-worker activity feed manager. Module-scoped so shutdown can stop()
+// its internal heartbeat interval (mirrors subagentWatcher). Recreated per
+// bridge connect; the stale handle's interval is unref'd, so a missed stop()
+// can't keep the process alive, but we stop() on shutdown for cleanliness.
+let workerActivityFeed: ReturnType<typeof createWorkerActivityFeed> | null = null
 
 // ─── IPC server ───────────────────────────────────────────────────────────
 const SOCKET_PATH = process.env.SWITCHROOM_GATEWAY_SOCKET ?? join(STATE_DIR, 'gateway.sock')
@@ -21762,6 +21767,11 @@ async function shutdown(signal: string): Promise<void> {
   subagentWatcher?.stop()
   subagentWatcher = null
 
+  // Worker-activity feed runs an internal heartbeat interval; stop it so no
+  // re-render fires during drain (mirrors subagentWatcher above).
+  workerActivityFeed?.stop()
+  workerActivityFeed = null
+
   // Issues watcher polls issues.jsonl on a setInterval (default 2s) and
   // edits the issues card on every tick. Without an explicit stop() the
   // poll keeps firing for the lifetime of the process and accumulates
@@ -22495,7 +22505,8 @@ void (async () => {
             // or the turn ended while it kept running — extended autonomous
             // work) is surfaced via the worker feed instead of vanishing.
             const orphanStatusEnabled = isOrphanSubagentStatusEnabled(process.env.SWITCHROOM_ORPHAN_SUBAGENT_STATUS)
-            const workerActivityFeed = createWorkerActivityFeed({
+            workerActivityFeed?.stop()
+            workerActivityFeed = createWorkerActivityFeed({
               bot: {
                 sendMessage: async (cid, text, sendOpts) => {
                   const sent = await robustApiCall(
@@ -22709,7 +22720,7 @@ void (async () => {
                       orphanStatusEnabled,
                     }) === 'worker-feed'
                   ) {
-                    void workerActivityFeed.finish(agentId, {
+                    void workerActivityFeed?.finish(agentId, {
                       description: dispatch.feedDescription,
                       lastTool: null,
                       toolCount,
@@ -22726,7 +22737,7 @@ void (async () => {
                 // 'orphan' is a stale boot row, not a fresh completion — map
                 // it to 'done' so an already-posted message still finalizes.
                 if (workerFeedEnabled) {
-                  void workerActivityFeed.finish(agentId, {
+                  void workerActivityFeed?.finish(agentId, {
                     description: dispatch.feedDescription,
                     lastTool: null,
                     toolCount,
@@ -22861,7 +22872,7 @@ void (async () => {
                   })
                   if (surface === 'worker-feed') {
                     const origin = resolveSubagentOriginChat(agentId)
-                    void workerActivityFeed.update(
+                    void workerActivityFeed?.update(
                       agentId,
                       origin?.chatId || fleetChatId || (loadAccess().allowFrom[0] ?? ''),
                       {
@@ -22948,7 +22959,7 @@ void (async () => {
                 // is gone — see resolveSubagentOriginChat).
                 if (workerFeedEnabled) {
                   const origin = resolveSubagentOriginChat(agentId)
-                  void workerActivityFeed.update(
+                  void workerActivityFeed?.update(
                     agentId,
                     origin?.chatId || fleetChatId || (loadAccess().allowFrom[0] ?? ''),
                     {

--- a/telegram-plugin/status-no-truncate.ts
+++ b/telegram-plugin/status-no-truncate.ts
@@ -1,49 +1,44 @@
 /**
- * Feature flag: SWITCHROOM_STATUS_NO_TRUNCATE
+ * Status-card shared constants.
  *
- * When ON (the default), the activity-feed card shows a **rolling window of
- * the last STATUS_ROLLING_LINES narrative lines**, each rendered in FULL —
- * no per-line length cap ("…"). Message height stays fixed (≤5 lines) while
- * content stays complete. The ONLY remaining ceiling is `STATUS_CARD_CHAR_BUDGET`
- * (Telegram's 4096-char wire limit backstop).
+ * Both status surfaces — the main-session agent activity card
+ * (`tool-activity-summary.ts`) and the background-worker activity feed
+ * (`worker-activity-feed.ts`) — render through the single
+ * `renderStatusCard` primitive in `tool-activity-summary.ts`. This module
+ * holds the tuning constants that primitive (and its internal helpers)
+ * read, so a forked renderer never re-derives them.
  *
- * When OFF (env var set to '0'), preserves the original capped behaviour:
- * MIRROR_MAX_LINES / NESTED_MAX_LINES / NESTED_LINE_MAX / NARRATIVE_MAX_LINES
- * all apply exactly as before (per-line clip + line-count cap).
- *
- * Semantics: noTruncate = env !== '0'  →  DEFAULT TRUE (rolling-5-full mode).
- *
- * This is a tiny shared module so both renderer files can import it and tests
- * can flip the flag by setting/deleting process.env.SWITCHROOM_STATUS_NO_TRUNCATE
- * without scattering process.env reads across files.
+ * The former `SWITCHROOM_STATUS_NO_TRUNCATE` feature flag was retired:
+ * rolling-window-with-char-budget is now the only behaviour. The per-line
+ * cap (`STATUS_LINE_MAX`) and rolling window (`STATUS_ROLLING_LINES`) apply
+ * universally on BOTH surfaces; the total char budget
+ * (`STATUS_CARD_CHAR_BUDGET`) is the wire-limit backstop.
  */
 
 /**
- * Returns true when status cards should show a rolling window of full-content
- * lines (no per-line truncation). Reads the env var at call time so tests can
- * flip it with set/delete on process.env without module re-imports.
- *
- * Default: true (rolling-5-full mode). Set SWITCHROOM_STATUS_NO_TRUNCATE=0 to
- * restore the original capped behaviour.
- */
-export function statusNoTruncate(): boolean {
-  return process.env.SWITCHROOM_STATUS_NO_TRUNCATE !== '0'
-}
-
-/**
- * Number of trailing narrative lines shown in no-truncate mode.
+ * Number of trailing narrative/step lines shown in the rolling window.
  * The feed is a fixed-height rolling window: oldest drops off as new arrive.
- * Each of the STATUS_ROLLING_LINES lines renders in FULL (no per-line "…").
+ * Overflow surfaces a `+N earlier…` header on BOTH surfaces.
  */
 export const STATUS_ROLLING_LINES = 5
 
 /**
- * The safe char budget for rendered Telegram messages in no-truncate mode.
- * Telegram's hard cap is 4096; we use 4000 to leave 96 chars of headroom for
- * HTML framing, emoji, and escape expansion — matching the convention in
+ * Per-line character cap, applied to every step + child step on BOTH
+ * surfaces before HTML-escaping (clip raw → escape last). A line longer
+ * than this is truncated with a trailing `…`.
+ */
+export const STATUS_LINE_MAX = 200
+
+/**
+ * The safe char budget for a rendered Telegram status card. Telegram's hard
+ * cap is 4096; we use 4000 to leave 96 chars of headroom for HTML framing,
+ * emoji, and escape expansion — matching the convention in
  * pending-work-progress.ts (TELEGRAM_MSG_CAP = 4000).
  *
- * With STATUS_ROLLING_LINES=5 full lines (~750 chars total), this backstop
- * effectively never fires in practice but is kept as a wire-limit safety net.
+ * With STATUS_ROLLING_LINES=5 lines each ≤ STATUS_LINE_MAX this backstop
+ * effectively never fires in practice, but is kept as a wire-limit safety net.
  */
 export const STATUS_CARD_CHAR_BUDGET = 4000
+
+/** Indent marker for a nested (foreground sub-agent) step line. */
+export const NESTED_PREFIX = '   ↳ '

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -42,7 +42,7 @@ import { basename, join } from 'path'
 import { homedir } from 'os'
 import { projectSubagentLine, sanitizeCwdToProjectName, detectErrorInTranscriptLine } from './session-tail.js'
 import { sanitiseToolArg } from './fleet-state.js'
-import { describeToolUse } from './tool-activity-summary.js'
+import { clipNarrative, describeToolUse } from './tool-activity-summary.js'
 import { REPLY_TOOLS, isDraftOfReply } from './narrative-dedup.js'
 import { escapeHtml, truncate } from './card-format.js'
 import { bumpSubagentActivity, recordSubagentStall, recordSubagentResume, recordSubagentEnd, reapStuckRunningRows, countRunningBackgroundSubagents } from './registry/subagents-schema.js'
@@ -949,7 +949,7 @@ export function readSubTail(
           // set at dispatch time (from the parent Agent/Task tool_use input)
           // and must remain stable. Overwriting it with the sub-agent's first
           // narrative line caused a race-condition-dependent display (issue #352).
-          entry.lastSummaryLine = ev.text.split('\n')[0].trim().slice(0, 120)
+          entry.lastSummaryLine = clipNarrative(ev.text)
           // Retain the full text of the most recent narrative emission —
           // for a worker the final such line before turn_end IS its
           // result summary (the worker prompt asks it to "return a

--- a/telegram-plugin/tests/status-card-budget-parity.test.ts
+++ b/telegram-plugin/tests/status-card-budget-parity.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { renderStatusCard } from '../tool-activity-summary.js'
+import { STATUS_CARD_CHAR_BUDGET } from '../status-no-truncate.js'
+
+// Both status surfaces (🤖 agent + 🛠 worker) render through the single
+// `renderStatusCard` primitive. Given the SAME raw steps, the rendered step
+// BODY (everything below the two-line header) must be byte-identical regardless
+// of the header emoji/label — the truncation pipeline, rolling window, and
+// char-budget backstop are surface-agnostic. This pins that parity so the two
+// surfaces can never drift apart again.
+
+/** Strip the two header lines, returning just the step/result body. */
+function body(card: string | null): string {
+  if (card == null) return ''
+  const lines = card.split('\n')
+  return lines.slice(2).join('\n')
+}
+
+function agent(steps: string[], final = false) {
+  return renderStatusCard({
+    header: { emoji: '🤖', label: 'Agent', elapsedMs: 12_000, toolCount: 4, state: final ? 'done' : 'running' },
+    steps,
+    final,
+  })
+}
+
+function worker(steps: string[], final = false) {
+  return renderStatusCard({
+    header: { emoji: '🛠', label: 'Worker', description: 'a task', elapsedMs: 12_000, toolCount: 4, state: final ? 'done' : 'running' },
+    steps,
+    final,
+  })
+}
+
+describe('status-card body byte-parity: agent vs worker', () => {
+  it('identical raw steps → identical body length and bytes (running)', () => {
+    const steps = ['read the brief', 'scanned vendor A', 'scanned vendor B']
+    const a = body(agent(steps))
+    const w = body(worker(steps))
+    expect(a).toBe(w)
+    expect(a.length).toBe(w.length)
+  })
+
+  it('identical raw steps → identical body (final)', () => {
+    const steps = ['compiled', 'linked', 'shipped']
+    expect(body(agent(steps, true))).toBe(body(worker(steps, true)))
+  })
+
+  it('overflow window → identical body + same +N earlier marker', () => {
+    const steps = Array.from({ length: 11 }, (_, i) => `step ${String(i + 1).padStart(2, '0')}`)
+    const a = body(agent(steps))
+    const w = body(worker(steps))
+    expect(a).toBe(w)
+    expect(a).toContain('earlier…')
+  })
+
+  it('char-budget backstop → identical body length under the fitter', () => {
+    const big = 'z'.repeat(900)
+    const steps = Array.from({ length: 6 }, () => big)
+    const a = agent(steps)!
+    const w = worker(steps)!
+    expect(body(a).length).toBe(body(w).length)
+    // Both whole cards stay within the wire budget.
+    expect(a.length).toBeLessThanOrEqual(STATUS_CARD_CHAR_BUDGET)
+    expect(w.length).toBeLessThanOrEqual(STATUS_CARD_CHAR_BUDGET)
+  })
+
+  it('escape parity: special chars escape identically on both surfaces', () => {
+    const steps = ['run build && deploy <prod> & verify']
+    expect(body(agent(steps))).toBe(body(worker(steps)))
+  })
+})

--- a/telegram-plugin/tests/subagent-watcher-clip-narrative.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-clip-narrative.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { clipNarrative } from '../tool-activity-summary.js'
+
+// subagent-watcher.ts now routes its narrative clip through the shared
+// `clipNarrative` primitive (replacing the inline
+// `ev.text.split('\n')[0].trim().slice(0, 120)`), so the watcher and the
+// gateway narrative-step path collapse multi-line text identically. These
+// tests pin that shared contract: first line only, trimmed, ≤ 120 chars.
+
+describe('clipNarrative — shared subagent-watcher narrative clip', () => {
+  it('collapses a multi-line block to its first line', () => {
+    const text = 'On it. Let me find the repo…\nthen build it\nand run the tests'
+    expect(clipNarrative(text)).toBe('On it. Let me find the repo…')
+  })
+
+  it('trims surrounding whitespace on the first line', () => {
+    expect(clipNarrative('   Found both repos:   \nmore')).toBe('Found both repos:')
+  })
+
+  it('caps the first line at 120 characters', () => {
+    const long = 'x'.repeat(200)
+    const out = clipNarrative(long)
+    expect(out.length).toBe(120)
+    expect(out).toBe('x'.repeat(120))
+  })
+
+  it('a first line under 120 chars is returned verbatim', () => {
+    expect(clipNarrative('short narrative line')).toBe('short narrative line')
+  })
+
+  it('matches the old inline expression exactly (regression equivalence)', () => {
+    const samples = [
+      'line one\nline two',
+      '   padded   \nrest',
+      'a'.repeat(150),
+      'single',
+      '',
+      'tab\tand spaces  \nnext',
+    ]
+    for (const s of samples) {
+      const inline = s.split('\n')[0].trim().slice(0, 120)
+      expect(clipNarrative(s)).toBe(inline)
+    }
+  })
+})

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   describeToolUse,
   appendActivityLine,
@@ -8,11 +8,9 @@ import {
   renderActivityFeedWithNested,
   renderActivityHeader,
   formatFeedElapsed,
-  MIRROR_MAX_LINES,
-  NESTED_MAX_LINES,
   type SessionActivityHeader,
 } from "../tool-activity-summary.js";
-import { STATUS_ROLLING_LINES } from "../status-no-truncate.js";
+import { STATUS_ROLLING_LINES, STATUS_LINE_MAX } from "../status-no-truncate.js";
 
 describe("describeToolUse — friendly per-tool rendering (draft-mirror)", () => {
   it("Bash uses the model-authored description verbatim, never the command", () => {
@@ -106,20 +104,21 @@ describe("appendActivityLine + renderActivityFeed — accumulating activity feed
     expect(lines).toEqual([]);
   });
 
-  it("caps to the last MIRROR_MAX_LINES with a '✓ +N earlier…' header (no-truncate OFF)", () => {
-    // This test exercises the capping behaviour that is active when the flag is OFF.
-    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = "0";
-    const lines = Array.from({ length: 9 }, (_, i) => `Action ${i + 1}`);
+  it("windows to the last STATUS_ROLLING_LINES with a '✓ +N earlier…' header on the AGENT surface", () => {
+    // The +N earlier header now appears on the AGENT surface too (flag retired).
+    const total = STATUS_ROLLING_LINES + 4;
+    const lines = Array.from({ length: total }, (_, i) => `Action ${i + 1}`);
     const out = renderActivityFeed(lines)!;
-    expect(out.startsWith("<i>✓ +3 earlier…</i>\n")).toBe(true);
-    // Only the last 6 actions are shown; the oldest 3 are collapsed.
-    expect(out).toContain("<i>✓ Action 4</i>");
-    expect(out).not.toContain("Action 3");
+    const hidden = total - STATUS_ROLLING_LINES;
+    expect(out.startsWith(`<i>✓ +${hidden} earlier…</i>\n`)).toBe(true);
+    // Only the last STATUS_ROLLING_LINES actions are shown; older ones collapsed.
+    const firstVisible = total - STATUS_ROLLING_LINES + 1;
+    expect(out).toContain(`<i>✓ Action ${firstVisible}</i>`);
+    expect(out).not.toContain(`Action ${firstVisible - 1}<`);
     // The newest action is the in-progress step (bold →); the rest are done (✓).
-    expect(out).toContain("<b>→ Action 9</b>");
-    expect(out).toContain("<i>✓ Action 8</i>");
-    expect(out).not.toContain("<b>→ Action 8</b>");
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+    expect(out).toContain(`<b>→ Action ${total}</b>`);
+    expect(out).toContain(`<i>✓ Action ${total - 1}</i>`);
+    expect(out).not.toContain(`<b>→ Action ${total - 1}</b>`);
   });
 
   it("HTML-escapes &, <, > in action text (no double-escaping by callers)", () => {
@@ -266,15 +265,13 @@ describe("renderActivityFeed — ✓ N steps total (final render, issue #2461)",
     expect(out).toContain("<i>✓ 1 steps</i>");
   });
 
-  it("footer appears even when the feed overflows MIRROR_MAX_LINES (no-truncate OFF)", () => {
-    // This test exercises the overflow-header behaviour that is active when the flag is OFF.
-    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = "0";
-    const lines = Array.from({ length: 9 }, (_, i) => `Action ${i + 1}`);
-    const out = renderActivityFeed(lines, true, "", 9)!;
-    expect(out).toContain("<i>✓ +3 earlier…</i>");
-    expect(out).toContain("<i>✓ 9 steps</i>");
-    expect(out.endsWith("<i>✓ 9 steps</i>")).toBe(true);
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+  it("footer appears even when the feed overflows the rolling window", () => {
+    const total = STATUS_ROLLING_LINES + 4;
+    const lines = Array.from({ length: total }, (_, i) => `Action ${i + 1}`);
+    const out = renderActivityFeed(lines, true, "", total)!;
+    expect(out).toContain(`<i>✓ +${total - STATUS_ROLLING_LINES} earlier…</i>`);
+    expect(out).toContain(`<i>✓ ${total} steps</i>`);
+    expect(out.endsWith(`<i>✓ ${total} steps</i>`)).toBe(true);
   });
 
   it("stepCount is surface-tool-excluded: reply/react count 0, Read+mcp count correctly", () => {
@@ -313,17 +310,15 @@ describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A
     expect(out).toContain("   ↳ <b>→ Looking for foreign keys</b>");
   });
 
-  it("caps the nested block to NESTED_MAX_LINES with a '↳ +N earlier…' header (no-truncate OFF)", () => {
-    // This test exercises the capping behaviour that is active when the flag is OFF.
-    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = "0";
-    const child = Array.from({ length: NESTED_MAX_LINES + 3 }, (_, i) => `step ${i + 1}`);
+  it("windows the nested block to STATUS_ROLLING_LINES with a '↳ +N earlier…' header", () => {
+    const total = STATUS_ROLLING_LINES + 3;
+    const child = Array.from({ length: total }, (_, i) => `step ${i + 1}`);
     const out = renderActivityFeedWithNested(["Delegating: x"], child)!;
-    expect(out).toContain("   ↳ <i>+3 earlier…</i>");
+    expect(out).toContain(`   ↳ <i>+${total - STATUS_ROLLING_LINES} earlier…</i>`);
     // newest nested line is the live → step
-    expect(out).toContain(`   ↳ <b>→ step ${NESTED_MAX_LINES + 3}</b>`);
+    expect(out).toContain(`   ↳ <b>→ step ${total}</b>`);
     // the oldest (collapsed) lines are not rendered verbatim
     expect(out).not.toContain("step 1<");
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
   });
 
   it("renders the child block even when the parent feed is empty", () => {
@@ -435,103 +430,69 @@ describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A
   });
 });
 
-// ─── SWITCHROOM_STATUS_NO_TRUNCATE feature flag tests ───────────────────────
-// New contract (rolling-5-full):
-//   ON  → last STATUS_ROLLING_LINES lines rendered in FULL; no overflow header;
-//          char-budget backstop is the only ceiling.
-//   OFF → MIRROR_MAX_LINES / NESTED_MAX_LINES + per-line clips (legacy, unchanged).
+// ─── Rolling-window + STATUS_LINE_MAX (flag retired) ────────────────────────
+// Contract (single mode, no flag):
+//   - last STATUS_ROLLING_LINES lines render; overflow → `+N earlier…` header
+//     on BOTH surfaces;
+//   - each line clipped to STATUS_LINE_MAX (200) chars then escaped;
+//   - char-budget backstop (fitCardToBudget) is the only wire-limit ceiling.
 
-describe("SWITCHROOM_STATUS_NO_TRUNCATE — renderActivityFeed", () => {
-  afterEach(() => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
-  });
-
-  it("no-truncate ON (default): with 12 lines, exactly the last STATUS_ROLLING_LINES render", () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE; // default = ON
-    // Use a prefix that makes substring matches impossible (e.g. "XAct-001" won't match "XAct-010").
+describe("rolling window + +N earlier — renderActivityFeed", () => {
+  it("with 12 lines, exactly the last STATUS_ROLLING_LINES render + a +N earlier header", () => {
     const lines = Array.from({ length: 12 }, (_, i) => `XAct-${String(i + 1).padStart(3, '0')}`);
     const out = renderActivityFeed(lines)!;
     const firstVisible = 12 - STATUS_ROLLING_LINES + 1;
-    // The last STATUS_ROLLING_LINES lines must appear.
     for (let i = firstVisible; i <= 12; i++) {
       expect(out).toContain(`XAct-${String(i).padStart(3, '0')}`);
     }
-    // Earlier lines must NOT appear.
     for (let i = 1; i < firstVisible; i++) {
       expect(out).not.toContain(`XAct-${String(i).padStart(3, '0')}`);
     }
-    // No overflow header in no-truncate mode.
-    expect(out).not.toContain("earlier…");
-    // Newest is still the in-progress step.
+    // Overflow header present on the AGENT surface now.
+    expect(out).toContain(`<i>✓ +${12 - STATUS_ROLLING_LINES} earlier…</i>`);
     expect(out).toContain(`<b>→ XAct-012</b>`);
   });
 
-  it("no-truncate ON: a 150-char line renders in FULL (no '…' per-line truncation)", () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
-    const longLine = "a".repeat(75) + " " + "b".repeat(74); // 150 chars
+  it("STATUS_LINE_MAX=200: a 250-char step is clipped to 200 with a trailing …", () => {
+    const longLine = "a".repeat(250);
     const out = renderActivityFeed([longLine])!;
-    expect(out).toContain(longLine);
+    expect(out).toContain("…");
+    // The full 250-char line must NOT survive; the clip is 200 (199 + …).
+    expect(out).not.toContain(longLine);
+    expect(out).toContain("a".repeat(STATUS_LINE_MAX - 1) + "…");
+  });
+
+  it("a line at exactly STATUS_LINE_MAX is NOT clipped", () => {
+    const exact = "b".repeat(STATUS_LINE_MAX);
+    const out = renderActivityFeed([exact])!;
+    expect(out).toContain(exact);
     expect(out).not.toContain("…");
   });
 
-  it("no-truncate ON: no '✓ +N earlier…' overflow header even with many lines", () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
-    const lines = Array.from({ length: 20 }, (_, i) => `Action ${i + 1}`);
+  it("no spurious overflow header when the feed fits the window", () => {
+    const lines = Array.from({ length: STATUS_ROLLING_LINES }, (_, i) => `Short ${i + 1}`);
     const out = renderActivityFeed(lines)!;
-    expect(out).not.toContain("earlier…");
-  });
-
-  it("no-truncate ON: setting env to '1' (or any non-'0') is also ON", () => {
-    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = "1";
-    const lines = Array.from({ length: MIRROR_MAX_LINES + 2 }, (_, i) => `Step ${i + 1}`);
-    const out = renderActivityFeed(lines)!;
-    // Rolling window: last STATUS_ROLLING_LINES visible, no overflow header.
     expect(out).not.toContain("earlier");
-    expect(out).toContain(`Step ${MIRROR_MAX_LINES + 2}`);
   });
 
-  it("no-truncate OFF (=0): existing truncation behaviour preserved (cap to MIRROR_MAX_LINES)", () => {
-    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = "0";
-    const lines = Array.from({ length: 9 }, (_, i) => `Action ${i + 1}`);
-    const out = renderActivityFeed(lines)!;
-    expect(out.startsWith("<i>✓ +3 earlier…</i>\n")).toBe(true);
-    expect(out).toContain("<i>✓ Action 4</i>");
-    expect(out).not.toContain("Action 3");
-    expect(out).toContain("<b>→ Action 9</b>");
-  });
-
-  it("no-truncate ON + pathologically oversized lines: char-budget backstop fires, output ≤ 4096 chars", () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE; // default ON
-    // STATUS_ROLLING_LINES lines of ~900 chars each → well over 4000 chars rendered.
+  it("pathologically oversized lines: char-budget backstop fires, output ≤ 4096 chars", () => {
+    // STATUS_ROLLING_LINES lines of ~900 chars each → over budget pre-clip, but
+    // each line is clipped to 200 first, so the budget should comfortably hold.
     const bigLine = "z".repeat(900);
     const lines = Array.from({ length: STATUS_ROLLING_LINES }, () => bigLine);
     const out = renderActivityFeed(lines)!;
-    // Hard invariant: output must not exceed Telegram's 4096-char limit.
     expect(out.length).toBeLessThanOrEqual(4096);
-    // The newest line must still be present (some portion of it).
     const hasBullet = out.includes("→") || out.includes("✓");
     expect(hasBullet).toBe(true);
   });
-
-  it("no-truncate ON: no spurious overflow header when feed is small", () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
-    const lines = Array.from({ length: 3 }, (_, i) => `Short step ${i + 1}`);
-    const out = renderActivityFeed(lines)!;
-    expect(out).not.toContain("earlier");
-  });
 });
 
-describe("SWITCHROOM_STATUS_NO_TRUNCATE — renderActivityFeedWithNested", () => {
-  afterEach(() => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
-  });
-
-  it("no-truncate ON: with many parent lines, only the last STATUS_ROLLING_LINES render (no overflow header)", () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
-    const parent = Array.from({ length: MIRROR_MAX_LINES + 3 }, (_, i) => `Parent ${i + 1}`);
+describe("rolling window + +N earlier — renderActivityFeedWithNested", () => {
+  it("many parent lines → only the last STATUS_ROLLING_LINES render with a +N earlier header", () => {
+    const totalParent = STATUS_ROLLING_LINES + 3;
+    const parent = Array.from({ length: totalParent }, (_, i) => `Parent ${i + 1}`);
     const child = ["Child step A", "Child step B"];
     const out = renderActivityFeedWithNested(parent, child)!;
-    const totalParent = MIRROR_MAX_LINES + 3;
     const firstVisible = totalParent - STATUS_ROLLING_LINES + 1;
     for (let i = firstVisible; i <= totalParent; i++) {
       expect(out).toContain(`Parent ${i}`);
@@ -539,17 +500,15 @@ describe("SWITCHROOM_STATUS_NO_TRUNCATE — renderActivityFeedWithNested", () =>
     for (let i = 1; i < firstVisible; i++) {
       expect(out).not.toContain(`Parent ${i}`);
     }
-    // No overflow header in no-truncate mode.
-    expect(out).not.toContain("earlier…");
+    expect(out).toContain(`<i>✓ +${totalParent - STATUS_ROLLING_LINES} earlier…</i>`);
     expect(out).toContain("   ↳ <b>→ Child step B</b>");
   });
 
-  it("no-truncate ON: with many child lines, only the last STATUS_ROLLING_LINES child lines render", () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
+  it("many child lines → only the last STATUS_ROLLING_LINES child lines render with a ↳ +N earlier header", () => {
     const parent = ["Delegating: big task"];
-    const child = Array.from({ length: NESTED_MAX_LINES + 4 }, (_, i) => `Child ${i + 1}`);
+    const totalChild = STATUS_ROLLING_LINES + 4;
+    const child = Array.from({ length: totalChild }, (_, i) => `Child ${i + 1}`);
     const out = renderActivityFeedWithNested(parent, child)!;
-    const totalChild = NESTED_MAX_LINES + 4;
     const firstVisible = totalChild - STATUS_ROLLING_LINES + 1;
     for (let i = firstVisible; i <= totalChild; i++) {
       expect(out).toContain(`Child ${i}`);
@@ -557,38 +516,24 @@ describe("SWITCHROOM_STATUS_NO_TRUNCATE — renderActivityFeedWithNested", () =>
     for (let i = 1; i < firstVisible; i++) {
       expect(out).not.toContain(`Child ${i}`);
     }
-    // No overflow header in no-truncate mode.
-    expect(out).not.toContain("earlier…");
+    expect(out).toContain(`   ↳ <i>+${totalChild - STATUS_ROLLING_LINES} earlier…</i>`);
     expect(out).toContain(`   ↳ <b>→ Child ${totalChild}</b>`);
   });
 
-  it("no-truncate ON: a child line longer than NESTED_LINE_MAX renders in full (no '…' truncation)", () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
-    const longLine = "x".repeat(120); // well over the 90-char NESTED_LINE_MAX
-    const out = renderActivityFeedWithNested(["Delegating"], [longLine])!;
-    // The full long line must appear untruncated (no '…' from NESTED_LINE_MAX).
-    expect(out).toContain(longLine);
-    expect(out).not.toContain(longLine.slice(0, 89) + "…");
-  });
-
-  it("no-truncate OFF (=0): per-line NESTED_LINE_MAX cap is still applied (regression guard)", () => {
-    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = "0";
-    const longLine = "x".repeat(120);
+  it("STATUS_LINE_MAX=200: a 250-char child line is clipped to 200 (both surfaces)", () => {
+    const longLine = "x".repeat(250);
     const out = renderActivityFeedWithNested(["Delegating"], [longLine])!;
     expect(out).toContain("…");
     expect(out).not.toContain(longLine);
+    expect(out).toContain("x".repeat(STATUS_LINE_MAX - 1) + "…");
   });
 
-  it("no-truncate ON + huge nested feed: char-budget backstop fires, output ≤ 4096 chars", () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
-    // STATUS_ROLLING_LINES parent + STATUS_ROLLING_LINES child lines of ~900 chars each.
+  it("huge nested feed: char-budget backstop fires, output ≤ 4096 chars", () => {
     const bigLine = "w".repeat(900);
     const parent = Array.from({ length: STATUS_ROLLING_LINES }, () => bigLine);
     const child = Array.from({ length: STATUS_ROLLING_LINES }, () => bigLine);
     const out = renderActivityFeedWithNested(parent, child)!;
-    // Hard invariant: output must not exceed Telegram's 4096-char limit.
     expect(out.length).toBeLessThanOrEqual(4096);
-    // The newest child line must still be present (some portion of it).
     expect(out).toContain("   ↳ ");
   });
 });
@@ -622,13 +567,8 @@ function isValidHtml(s: string): boolean {
   return bOpen === bClose && iOpen === iClose;
 }
 
-describe("extreme-edge: single oversized line with &, <, >, && (no-truncate ON)", () => {
-  afterEach(() => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
-  });
-
+describe("extreme-edge: single oversized line with &, <, >, &&", () => {
   it("renderActivityFeed: single ~4100-char line with special chars → ≤ budget and valid HTML", () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
     // Build a raw line >4000 chars with &, <, >, and a trailing &&.
     // The && will escape to &amp;&amp; (5 chars each), exercising the expansion guard.
     const base = "Run script with args: foo=bar && baz=<qux> & corge=1 ";
@@ -645,7 +585,6 @@ describe("extreme-edge: single oversized line with &, <, >, && (no-truncate ON)"
   });
 
   it("renderActivityFeed final=true: single ~4100-char line → ≤ budget and valid HTML", () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
     const base = "Deploy build && upload && notify && cleanup: ";
     const bigLine = base.repeat(90) + "done";
     expect(bigLine.length).toBeGreaterThan(4000);
@@ -659,7 +598,6 @@ describe("extreme-edge: single oversized line with &, <, >, && (no-truncate ON)"
   });
 
   it("renderActivityFeedWithNested: single ~4100-char parent line → ≤ budget and valid HTML", () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
     const base = "Parent action with & < > special chars && bash: ";
     const bigLine = base.repeat(85);
     expect(bigLine.length).toBeGreaterThan(4000);
@@ -671,7 +609,6 @@ describe("extreme-edge: single oversized line with &, <, >, && (no-truncate ON)"
   });
 
   it("renderActivityFeedWithNested: single ~4100-char child line → ≤ budget and valid HTML", () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
     const base = "Child step: run build && test && deploy with <args> & flags=1 ";
     const bigChild = base.repeat(65) + "&&";
     expect(bigChild.length).toBeGreaterThan(4000);
@@ -692,7 +629,6 @@ describe("extreme-edge: single oversized line with &, <, >, && (no-truncate ON)"
   });
 
   it("renderActivityFeedWithNested final=true: single ~4100-char child line → ≤ budget and valid HTML", () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE;
     const base = "Final child: compile && link && package & ship: ";
     const bigChild = base.repeat(85);
     expect(bigChild.length).toBeGreaterThan(4000);
@@ -740,6 +676,49 @@ describe("renderActivityHeader — two-line header builder", () => {
   it("HTML-escapes special chars in description and label", () => {
     const [h1] = renderActivityHeader("🤖", "Agent", "run <foo> & <bar>", 5_000, 1, "running");
     expect(h1).toContain("run &lt;foo&gt; &amp; &lt;bar&gt;");
+  });
+});
+
+describe("agent flat path routes through the shared step-feed primitive", () => {
+  it("flat renderActivityFeed === nested-with-empty-children (same window + +N output)", () => {
+    // The flat agent path and the nested path with NO children must produce the
+    // identical render — both flow through renderStatusCard's step feed.
+    const lines = Array.from({ length: STATUS_ROLLING_LINES + 3 }, (_, i) => `Step ${i + 1}`);
+    expect(renderActivityFeed(lines)).toBe(renderActivityFeedWithNested(lines, []));
+    expect(renderActivityFeed(lines, true, "", 9)).toBe(
+      renderActivityFeedWithNested(lines, [], true, "", 9),
+    );
+    // And the +N earlier marker is present on the flat agent surface.
+    expect(renderActivityFeed(lines)!).toContain(
+      `<i>✓ +${lines.length - STATUS_ROLLING_LINES} earlier…</i>`,
+    );
+  });
+});
+
+describe("escape entity is never split mid-clip (clip raw → escape last)", () => {
+  it("a step ending in '&' clipped at STATUS_LINE_MAX stays valid HTML", () => {
+    // Build a step exactly STATUS_LINE_MAX+1 chars ending in '&' so a naive
+    // escape-then-clip would split the &amp; entity at the boundary.
+    const line = "x".repeat(STATUS_LINE_MAX) + "&";
+    const out = renderActivityFeed([line])!;
+    // The clip keeps STATUS_LINE_MAX-1 chars + '…', then escapes — no stray entity.
+    expect(out).not.toMatch(/&amp$/);
+    expect(out).not.toMatch(/&am[^p]/);
+    expect(out).toContain("…");
+    // Whatever '&' survives must be a complete &amp;.
+    const ampCount = (out.match(/&amp;/g) ?? []).length;
+    const bareAmp = (out.match(/&(?!amp;|lt;|gt;)/g) ?? []).length;
+    expect(bareAmp).toBe(0);
+    expect(ampCount).toBeGreaterThanOrEqual(0);
+  });
+
+  it("a step ending in '<' clipped at STATUS_LINE_MAX stays valid HTML", () => {
+    const line = "y".repeat(STATUS_LINE_MAX) + "<";
+    const out = renderActivityFeed([line])!;
+    expect(out).not.toMatch(/&lt$/);
+    expect(out).not.toMatch(/&l[^t;]/);
+    const bareLt = (out.match(/&(?!amp;|lt;|gt;)/g) ?? []).length;
+    expect(bareLt).toBe(0);
   });
 });
 

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -1,13 +1,12 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import {
   renderWorkerActivity,
   createWorkerActivityFeed,
   isWorkerActivityFeedEnabled,
-  NARRATIVE_MAX_LINES,
   type WorkerActivityView,
   type BotApiForWorkerFeed,
 } from '../worker-activity-feed.js'
-import { STATUS_ROLLING_LINES } from '../status-no-truncate.js'
+import { STATUS_ROLLING_LINES, STATUS_LINE_MAX } from '../status-no-truncate.js'
 
 describe('isWorkerActivityFeedEnabled (default ON)', () => {
   it('defaults to true when the env var is unset', () => {
@@ -77,7 +76,8 @@ describe('renderWorkerActivity', () => {
   it('renders the native header + running status + step feed', () => {
     const out = renderWorkerActivity(view())
     expect(out).toContain('🛠 <b>Worker</b> · <i>research competitors</i>')
-    expect(out).toContain('running · ')
+    // Unified header: running shows "<elapsed> · N tools" (no "running ·" word).
+    expect(out).toContain('<i>10s · 3 tools</i>')
     expect(out).toContain('3 tools')
     // No narrativeLines → the latestSummary surfaces as the newest `→` step.
     expect(out).toContain('<b>→ scanning vendor pages</b>')
@@ -110,20 +110,24 @@ describe('renderWorkerActivity', () => {
       view({ state: 'done', toolCount: 5, latestSummary: 'PR #21 opened' }),
     )
     expect(out).toContain('🛠 <b>Worker</b> · <i>research competitors</i>')
-    expect(out).toContain('finished · completed · 5 tools · ')
+    // Unified done header: "done · N tools · <elapsed>".
+    expect(out).toContain('<i>done · 5 tools · ')
     expect(out).toContain('─────')
     expect(out).toContain('✅ <i>PR #21 opened</i>')
+    // latestSummary is the RESULT on the finished path, never also a step.
+    expect(out).not.toContain('<i>✓ PR #21 opened</i>')
   })
 
   it('renders a failed terminal recap', () => {
     const out = renderWorkerActivity(view({ state: 'failed', latestSummary: 'blew up' }))
-    expect(out).toContain('finished · failed · ')
+    // Failed maps to the "done" header word; the ⚠️ result carries the failure.
+    expect(out).toContain('<i>done · ')
     expect(out).toContain('⚠️ <i>blew up</i>')
   })
 
   it('omits the rule + result line when the terminal result is empty', () => {
     const out = renderWorkerActivity(view({ state: 'done', latestSummary: '   ' }))
-    expect(out).toContain('finished · completed · ')
+    expect(out).toContain('<i>done · ')
     expect(out).not.toContain('─────')
   })
 
@@ -155,18 +159,17 @@ describe('renderWorkerActivity', () => {
     expect(stepCount(out)).toBe(2)
   })
 
-  it('shows an overflow header when the feed exceeds the cap (no-truncate OFF)', () => {
-    // This test exercises the capping behaviour that is active when the flag is OFF.
-    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = '0'
-    const lines = Array.from({ length: 9 }, (_, i) => `step ${i + 1}`)
+  it('shows a "+N earlier…" header when the feed exceeds STATUS_ROLLING_LINES (worker surface)', () => {
+    const total = STATUS_ROLLING_LINES + 3
+    const lines = Array.from({ length: total }, (_, i) => `step ${i + 1}`)
     const out = renderWorkerActivity(view({ narrativeLines: lines }))
-    expect(out).toContain('<i>✓ +3 earlier…</i>')
-    expect(out).not.toContain('step 1')
-    expect(out).toContain('<i>✓ step 4</i>')
-    expect(out).toContain('<b>→ step 9</b>')
-    // 6 visible step lines (the overflow header is not itself a step).
-    expect(out.match(/step \d/g) ?? []).toHaveLength(6)
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+    expect(out).toContain(`<i>✓ +${total - STATUS_ROLLING_LINES} earlier…</i>`)
+    expect(out).not.toContain('step 1<')
+    const firstVisible = total - STATUS_ROLLING_LINES + 1
+    expect(out).toContain(`<i>✓ step ${firstVisible}</i>`)
+    expect(out).toContain(`<b>→ step ${total}</b>`)
+    // STATUS_ROLLING_LINES visible step lines (the overflow header isn't a step).
+    expect(out.match(/step \d/g) ?? []).toHaveLength(STATUS_ROLLING_LINES)
   })
 
   it('strips Markdown markup from narrative + description + result', () => {
@@ -283,7 +286,7 @@ describe('createWorkerActivityFeed', () => {
     clock = 10_500 // well within the throttle window
     await feed.finish('w1', view({ state: 'done', toolCount: 5 }))
     expect(bot.edits).toHaveLength(1)
-    expect(bot.edits[0].text).toContain('finished · completed · 5 tools')
+    expect(bot.edits[0].text).toContain('<i>done · 5 tools · ')
     // finish forgets the worker.
     expect(feed.has('w1')).toBe(false)
     expect(feed.size).toBe(0)
@@ -396,26 +399,22 @@ describe('createWorkerActivityFeed', () => {
     expect(last.text.match(/[✓→]/g) ?? []).toHaveLength(1)
   })
 
-  it('caps the narrative block to the last 6 lines (no-truncate OFF)', async () => {
-    // This test exercises the capping behaviour that is active when the flag is OFF.
-    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = '0'
+  it('rolls the narrative block to the last STATUS_ROLLING_LINES lines', async () => {
     const bot = makeFakeBot()
     let clock = 10_000
     const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
 
-    for (let i = 1; i <= 9; i++) {
+    const total = 9
+    for (let i = 1; i <= total; i++) {
       clock += 1000
-      await feed.update('w1', 'chat', view({ toolCount: i, latestSummary: `line ${i}` }))
+      await feed.update('w1', 'chat', view({ toolCount: i, latestSummary: `ln-${String(i).padStart(3, '0')}` }))
     }
 
     const last = bot.edits.at(-1)!
-    expect(last.text.match(/[✓→]/g) ?? []).toHaveLength(6)
-    // Oldest lines evicted; newest retained.
-    expect(last.text).not.toContain('line 1')
-    expect(last.text).not.toContain('line 3')
-    expect(last.text).toContain('line 4')
-    expect(last.text).toContain('line 9')
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+    expect(last.text.match(/[✓→]/g) ?? []).toHaveLength(STATUS_ROLLING_LINES)
+    const firstVisible = total - STATUS_ROLLING_LINES + 1
+    for (let i = 1; i < firstVisible; i++) expect(last.text).not.toContain(`ln-${String(i).padStart(3, '0')}`)
+    for (let i = firstVisible; i <= total; i++) expect(last.text).toContain(`ln-${String(i).padStart(3, '0')}`)
   })
 
   it('grows the narrative even while throttled (line surfaces on next edit)', async () => {
@@ -510,99 +509,64 @@ describe('createWorkerActivityFeed — log sink', () => {
   })
 })
 
-// ─── SWITCHROOM_STATUS_NO_TRUNCATE feature flag tests ────────────────────────
-// New contract (rolling-5-full):
-//   ON  → last STATUS_ROLLING_LINES lines rendered in FULL; no overflow header;
-//          char-budget backstop (_fitWorkerBodyToCharBudget) is the only ceiling.
-//   OFF → NARRATIVE_MAX_LINES cap + STEP_MAX per-line clip (legacy, unchanged).
+// ─── Rolling window + STATUS_LINE_MAX (flag retired) ─────────────────────────
+// Single mode: last STATUS_ROLLING_LINES lines render in full (clipped per-line
+// at STATUS_LINE_MAX=200), overflow → `+N earlier…` header on the worker surface,
+// char-budget backstop is the only wire-limit ceiling.
 
-describe('SWITCHROOM_STATUS_NO_TRUNCATE — renderWorkerActivity', () => {
-  afterEach(() => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
-  })
-
-  it('no-truncate ON (default): with 12 narrative lines, exactly the last STATUS_ROLLING_LINES render', () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE // default = ON
-    // Use zero-padded numbers so "stp-001" cannot be a substring of "stp-010".
+describe('rolling window + STATUS_LINE_MAX — renderWorkerActivity', () => {
+  it('with 12 narrative lines, exactly the last STATUS_ROLLING_LINES render + a +N earlier header', () => {
     const narrativeLines = Array.from({ length: 12 }, (_, i) => `stp-${String(i + 1).padStart(3, '0')}`)
     const out = renderWorkerActivity(view({ narrativeLines }))
-    // The last STATUS_ROLLING_LINES lines must appear.
     const firstVisible = 12 - STATUS_ROLLING_LINES + 1
     for (let i = firstVisible; i <= 12; i++) {
       expect(out).toContain(`stp-${String(i).padStart(3, '0')}`)
     }
-    // The first (12 - STATUS_ROLLING_LINES) lines must NOT appear.
     for (let i = 1; i < firstVisible; i++) {
       expect(out).not.toContain(`stp-${String(i).padStart(3, '0')}`)
     }
-    // No overflow header in no-truncate mode.
-    expect(out).not.toContain('earlier…')
+    // Overflow header now appears on the worker surface too.
+    expect(out).toContain(`<i>✓ +${12 - STATUS_ROLLING_LINES} earlier…</i>`)
     expect(out).toContain('<b>→ stp-012</b>')
   })
 
-  it('no-truncate ON: a 150-char line renders in FULL (no "…" mid-line truncation)', () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
-    const longLine = 'a'.repeat(75) + ' ' + 'b'.repeat(74) // 150 chars total
+  it('STATUS_LINE_MAX=200: a 250-char line is clipped to 200 with a trailing …', () => {
+    const longLine = 'a'.repeat(250)
     const out = renderWorkerActivity(view({ narrativeLines: [longLine] }))
-    // Must appear without "…" from per-line STEP_MAX clip.
-    expect(out).toContain(longLine)
+    expect(out).toContain('…')
+    expect(out).not.toContain(longLine)
+    expect(out).toContain('a'.repeat(STATUS_LINE_MAX - 1) + '…')
+  })
+
+  it('a line at exactly STATUS_LINE_MAX is NOT clipped', () => {
+    const exact = 'b'.repeat(STATUS_LINE_MAX)
+    const out = renderWorkerActivity(view({ narrativeLines: [exact] }))
+    expect(out).toContain(exact)
     expect(out).not.toContain('…')
   })
 
-  it('no-truncate ON: no "✓ +N earlier…" overflow header', () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
-    const narrativeLines = Array.from({ length: 20 }, (_, i) => `step ${i + 1}`)
+  it('no "+N earlier…" overflow header when the feed fits the window', () => {
+    const narrativeLines = Array.from({ length: STATUS_ROLLING_LINES }, (_, i) => `step ${i + 1}`)
     const out = renderWorkerActivity(view({ narrativeLines }))
     expect(out).not.toContain('earlier…')
   })
 
-  it('no-truncate OFF (=0): existing NARRATIVE_MAX_LINES cap + STEP_MAX clip are preserved', () => {
-    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = '0'
-    const narrativeLines = Array.from({ length: 9 }, (_, i) => `step ${i + 1}`)
-    const out = renderWorkerActivity(view({ narrativeLines }))
-    // Overflow header must appear (legacy cap active).
-    expect(out).toContain('<i>✓ +3 earlier…</i>')
-    expect(out).not.toContain('step 1')
-    expect(out).toContain('step 4')
-    expect(out).toContain('<b>→ step 9</b>')
-    expect(out.match(/step \d/g) ?? []).toHaveLength(6)
-  })
-
-  it('no-truncate OFF (=0): a 150-char line is clipped at STEP_MAX (regression guard)', () => {
-    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = '0'
-    const longLine = 'x'.repeat(150)
-    const out = renderWorkerActivity(view({ narrativeLines: [longLine] }))
-    // Per-line clip must apply when flag is OFF.
-    expect(out).toContain('…')
-    expect(out).not.toContain(longLine)
-  })
-
-  it('no-truncate ON + pathologically oversized body: char-budget backstop fires, output ≤ 4096 chars', () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
-    // 5 huge lines × ~900 chars each → well over 4000 chars rendered.
+  it('pathologically oversized body: char-budget backstop fires, output ≤ 4096 chars', () => {
     const bigLine = 'z'.repeat(900)
-    const narrativeLines = Array.from({ length: 5 }, () => bigLine)
+    const narrativeLines = Array.from({ length: STATUS_ROLLING_LINES }, () => bigLine)
     const out = renderWorkerActivity(view({ narrativeLines }))
-    // Hard invariant: must never exceed Telegram's 4096 char limit.
     expect(out.length).toBeLessThanOrEqual(4096)
-    // The newest step must still be present (some portion of it).
     const hasBullet = out.includes('→') || out.includes('✓')
     expect(hasBullet).toBe(true)
   })
 })
 
-describe('SWITCHROOM_STATUS_NO_TRUNCATE — createWorkerActivityFeed narrative accumulation', () => {
-  afterEach(() => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
-  })
-
-  it('no-truncate ON: rolling window — with 12 pushes, only the last STATUS_ROLLING_LINES appear in render', async () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
+describe('rolling window — createWorkerActivityFeed narrative accumulation', () => {
+  it('with 12 pushes, only the last STATUS_ROLLING_LINES appear in the render', async () => {
     const bot = makeFakeBot()
     let clock = 10_000
     const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
 
-    // Use zero-padded names to avoid substring collisions (ln-001 vs ln-010).
     for (let i = 1; i <= 12; i++) {
       clock += 1000
       await feed.update('w1', 'chat', view({ toolCount: i, latestSummary: `ln-${String(i).padStart(3, '0')}` }))
@@ -610,60 +574,137 @@ describe('SWITCHROOM_STATUS_NO_TRUNCATE — createWorkerActivityFeed narrative a
 
     const last = bot.edits.at(-1)!
     const firstVisible = 12 - STATUS_ROLLING_LINES + 1
-    // The last STATUS_ROLLING_LINES lines must be present.
     for (let i = firstVisible; i <= 12; i++) {
       expect(last.text).toContain(`ln-${String(i).padStart(3, '0')}`)
     }
-    // Earlier lines must have rolled off.
     for (let i = 1; i < firstVisible; i++) {
       expect(last.text).not.toContain(`ln-${String(i).padStart(3, '0')}`)
     }
-    // No overflow header in no-truncate mode.
+    // The manager caps the in-memory narrative at STATUS_ROLLING_LINES, so the
+    // render never sees overflow — no "+N earlier…" marker on the manager path
+    // (it surfaces only on direct renderWorkerActivity calls with >5 lines).
     expect(last.text).not.toContain('earlier…')
     expect(last.text).toContain('<b>→ ln-012</b>')
   })
+})
 
-  it('no-truncate OFF (=0): narrative is still spliced to NARRATIVE_MAX_LINES (original behaviour)', async () => {
-    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = '0'
+// ─── Worker heartbeat (option a — suffix-only, never opens a new message) ─────
+
+describe('createWorkerActivityFeed — heartbeat', () => {
+  it('(i) a tick fires a re-render with a climbing · Ns suffix on a stale worker', async () => {
     const bot = makeFakeBot()
     let clock = 10_000
-    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      minEditIntervalMs: 2500,
+      heartbeatTickMs: 6000,
+      // No real timer: drive ticks manually.
+      setInterval: () => 1,
+      clearInterval: () => {},
+    })
+    // First paint at elapsed 0 (firstPaintMin default 8000 — use 9000).
+    clock = 19_000
+    await feed.update('w1', 'chat', view({ elapsedMs: 9000, latestSummary: 'pulling data' }))
+    expect(bot.sent).toHaveLength(1)
+    const dispatchAt = clock - 9000
 
-    for (let i = 1; i <= 9; i++) {
-      clock += 1000
-      await feed.update('w1', 'chat', view({ toolCount: i, latestSummary: `line ${i}` }))
-    }
-
-    const last = bot.edits.at(-1)!
-    expect(last.text.match(/[✓→]/g) ?? []).toHaveLength(6)
-    expect(last.text).not.toContain('line 1')
-    expect(last.text).not.toContain('line 3')
-    expect(last.text).toContain('line 4')
-    expect(last.text).toContain('line 9')
+    // Advance past the staleness window so the heartbeat ticks.
+    clock = 26_000 // lastEditAt(19000) + 7000 ≥ heartbeatTickMs(6000) and ≥ minEditInterval
+    feed.heartbeatTick()
+    await feed.update('w1', 'chat', view({ elapsedMs: 16_000, latestSummary: 'pulling data' })).catch(() => {})
+    // Drain the chain.
+    await feed.update('w1', 'chat', view({ elapsedMs: 16_000, latestSummary: 'pulling data' }))
+    const edit1 = bot.edits.find((e) => /· \d+s<\/b>/.test(e.text))
+    expect(edit1).toBeDefined()
+    // The suffix reflects the LIVE elapsed (now - dispatchAt), not the stale view.
+    expect(edit1!.text).toContain(`· ${Math.floor((26_000 - dispatchAt) / 1000)}s`)
   })
 
-  it('no-truncate ON: env-flip seam works (set/delete per test)', () => {
-    // Verify the seam: after setting '0', the flag reads as OFF (legacy cap).
-    process.env.SWITCHROOM_STATUS_NO_TRUNCATE = '0'
-    // Use zero-padded names to avoid substring collisions.
-    const total = NARRATIVE_MAX_LINES + 2
-    const lines = Array.from({ length: total }, (_, i) => `sv-${String(i + 1).padStart(3, '0')}`)
-    const offOut = renderWorkerActivity(view({ narrativeLines: lines }))
-    expect(offOut).toContain('+2 earlier')
+  it('(ii) respects a 429 cooldown — no edit while cooldownUntil is in the future', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      minEditIntervalMs: 0,
+      heartbeatTickMs: 6000,
+      firstPaintMinMs: 0,
+      setInterval: () => 1,
+      clearInterval: () => {},
+    })
+    await feed.update('w1', 'chat', view({ elapsedMs: 1000, latestSummary: 'go' }))
+    expect(bot.sent).toHaveLength(1)
+    // Induce a cooldown by failing the next edit with a 429.
+    clock = 20_000
+    bot.failNextEditWith = { error_code: 429, parameters: { retry_after: 30 } }
+    await feed.update('w1', 'chat', view({ elapsedMs: 11_000, latestSummary: 'changed' }))
+    const editsAfterCooldown = bot.edits.length
+    // Tick while still inside the cooldown window → no new edit.
+    clock = 27_000
+    feed.heartbeatTick()
+    await feed.update('w1', 'chat', view({ elapsedMs: 18_000, latestSummary: 'changed' }))
+    expect(bot.edits.length).toBe(editsAfterCooldown)
+  })
 
-    // After deleting, the flag reads as ON (rolling-5-full).
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
-    const onOut = renderWorkerActivity(view({ narrativeLines: lines }))
-    // No overflow header in no-truncate mode.
-    expect(onOut).not.toContain('earlier…')
-    // Only the last STATUS_ROLLING_LINES lines should be visible.
-    const firstVisible = total - STATUS_ROLLING_LINES + 1
-    for (let i = firstVisible; i <= total; i++) {
-      expect(onOut).toContain(`sv-${String(i).padStart(3, '0')}`)
-    }
-    for (let i = 1; i < firstVisible; i++) {
-      expect(onOut).not.toContain(`sv-${String(i).padStart(3, '0')}`)
-    }
+  it('(iii) does not edit after the handle is removed on finish', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      minEditIntervalMs: 0,
+      heartbeatTickMs: 6000,
+      setInterval: () => 1,
+      clearInterval: () => {},
+    })
+    await feed.update('w1', 'chat', view({ latestSummary: 'go' }))
+    clock = 20_000
+    await feed.finish('w1', view({ state: 'done', toolCount: 2 }))
+    expect(feed.has('w1')).toBe(false)
+    const editsBefore = bot.edits.length
+    clock = 30_000
+    feed.heartbeatTick()
+    // No handle → tick is a no-op, no further edit.
+    expect(bot.edits.length).toBe(editsBefore)
+  })
+
+  it('(iv) stop() clears the interval and a tick on empty handles is a no-op (no leak)', () => {
+    let cleared = false
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      setInterval: () => 1,
+      clearInterval: () => { cleared = true },
+    })
+    // No handles yet → tick does nothing and does not throw.
+    expect(() => feed.heartbeatTick()).not.toThrow()
+    feed.stop()
+    expect(cleared).toBe(true)
+  })
+
+  it('(v) respects minEditInterval — a tick inside the throttle window does not edit', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      minEditIntervalMs: 2500,
+      heartbeatTickMs: 6000,
+      firstPaintMinMs: 0,
+      setInterval: () => 1,
+      clearInterval: () => {},
+    })
+    await feed.update('w1', 'chat', view({ elapsedMs: 1000, latestSummary: 'go' }))
+    expect(bot.sent).toHaveLength(1)
+    const editsBefore = bot.edits.length
+    // Tick only 1000ms after the paint — inside minEditInterval (2500) → no edit.
+    clock = 11_000
+    feed.heartbeatTick()
+    await feed.update('w1', 'chat', view({ elapsedMs: 2000, latestSummary: 'go' })).catch(() => {})
+    expect(bot.edits.length).toBe(editsBefore)
   })
 })
 
@@ -698,12 +739,7 @@ function isValidWorkerHtml(s: string): boolean {
 }
 
 describe('extreme-edge: single oversized narrative line (no-truncate ON)', () => {
-  afterEach(() => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
-  })
-
   it('no-truncate ON: one ~4100-char step is shown (truncated) not discarded, output ≤ budget and valid HTML', async () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
     const bot = makeFakeBot()
     let clock = 10_000
     const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
@@ -731,7 +767,6 @@ describe('extreme-edge: single oversized narrative line (no-truncate ON)', () =>
   })
 
   it('no-truncate ON: one ~4100-char step via renderWorkerActivity directly → ≤ budget and valid HTML', () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
     const base = 'compile && link && package && ship: action=deploy env=<prod> flag=1 '
     const hugeStep = base.repeat(65)
     expect(hugeStep.length).toBeGreaterThan(4000)
@@ -764,10 +799,6 @@ describe('extreme-edge: single oversized narrative line (no-truncate ON)', () =>
 // identified (&am, &l). They assert the output is valid HTML and within budget.
 
 describe('Bug 2 (#2506): _fitWorkerBodyToCharBudget does not split HTML entities', () => {
-  afterEach(() => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
-  })
-
   /**
    * Build a narrative line that, after HTML-escaping, has the entity boundary
    * at a precise position so a naive `escaped.slice(3, 3 + N)` would split it.
@@ -786,7 +817,6 @@ describe('Bug 2 (#2506): _fitWorkerBodyToCharBudget does not split HTML entities
   }
 
   it('& at entity boundary: output is valid HTML (no &am, &amp without ; etc.)', () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
     // A line that places '&' right at the slice boundary so naive cut → &am
     const line = buildEntityBoundaryLine('&', 4096)
     expect(line.length).toBeGreaterThan(100) // sanity: line is substantial
@@ -802,7 +832,6 @@ describe('Bug 2 (#2506): _fitWorkerBodyToCharBudget does not split HTML entities
   })
 
   it('< at entity boundary: output is valid HTML (no &l, &lt without ; etc.)', () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
     const line = buildEntityBoundaryLine('<', 4096)
 
     const out = renderWorkerActivity(view({ narrativeLines: [line] }))
@@ -814,7 +843,6 @@ describe('Bug 2 (#2506): _fitWorkerBodyToCharBudget does not split HTML entities
   })
 
   it('> at entity boundary: output is valid HTML (no &g, &gt without ; etc.)', () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
     const line = buildEntityBoundaryLine('>', 4096)
 
     const out = renderWorkerActivity(view({ narrativeLines: [line] }))
@@ -826,7 +854,6 @@ describe('Bug 2 (#2506): _fitWorkerBodyToCharBudget does not split HTML entities
   })
 
   it('entity-dense line (& < > interleaved): output ≤ budget and valid HTML', () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
     // Mix entity characters throughout so any slice position is dangerous.
     const chunk = '&' + 'x'.repeat(3) + '<' + 'y'.repeat(3) + '>' + 'z'.repeat(3)
     const line = chunk.repeat(500) // ~10k chars raw → well over budget after escape
@@ -841,7 +868,6 @@ describe('Bug 2 (#2506): _fitWorkerBodyToCharBudget does not split HTML entities
   it('single & alone in the line: valid HTML and within budget', () => {
     // Regression: a one-char entity line is a degenerate case the while-loop
     // must handle without infinite-looping or returning empty content.
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
     // Build a huge line: filler xs then '&' then more xs
     const line = 'x'.repeat(3000) + '&' + 'x'.repeat(1000)
     expect(line.length).toBeGreaterThan(4000)
@@ -853,78 +879,44 @@ describe('Bug 2 (#2506): _fitWorkerBodyToCharBudget does not split HTML entities
   })
 })
 
-// ─── Regression: header/status row survives char-budget trimming ─────────────
+// ─── Regression: header/status row + rolling overflow survive trimming ───────
 //
-// These tests assert that the "running · elapsed · tools" status row (lines[1])
-// is always present in the rendered output, even when _fitWorkerBodyToCharBudget
-// fires and drops oldest step lines to fit the 4000-char budget.
-//
-// Root-cause history:
-//   - 68f956a9 introduced _fitWorkerBodyToCharBudget WITH a "+N earlier" counter
-//   - d7d7d140 removed "+N earlier" from the fitting loop, breaking the card's
-//     visible "header row" of dropped-step context
-//   - 5262be25 (PR #2511) added a raw-then-escape extreme fallback, but
-//     introduced a regression where rawNewestStep='' returns only fixedJoined
-//     (the two header lines alone, with no step bullet)
-//
-// The fix restores "+N earlier" in the fitting loop and falls back to recovering
-// raw text from newestLine when rawNewestStep is empty.
+// The unified renderer clips every line to STATUS_LINE_MAX (200) BEFORE the
+// char-budget backstop, so ordinary "long step" turns fit the budget without
+// dropping any bullets. The two-line header always survives, and a rolling
+// "+N earlier…" marker appears when more than STATUS_ROLLING_LINES lines are
+// rendered directly. The char-budget backstop (fitCardToBudget) is exercised
+// only by genuinely pathological single oversized lines (covered elsewhere).
 
-describe('_fitWorkerBodyToCharBudget: header row and +N earlier counter regressions', () => {
-  afterEach(() => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
-  })
-
-  it('status line ("running · … · N tools") survives when budget fitter drops steps', () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
-    // Build 6 narrative lines where 5 of them are very long, forcing the budget
-    // fitter to drop some but keep at least one. The fixed header (2 lines) must
-    // always survive intact.
+describe('header row + rolling overflow survive in the unified worker render', () => {
+  it('the two-line header survives even with many long lines (clipped to STATUS_LINE_MAX)', () => {
     const bigLine = 'a'.repeat(700)
     const narrativeLines = Array.from({ length: 6 }, (_, i) =>
       i < 5 ? bigLine : 'final short step',
     )
     const out = renderWorkerActivity(view({ narrativeLines, toolCount: 7 }))
 
-    // The worker header (line 0) must be present.
     expect(out).toContain('🛠 <b>Worker</b>')
-    // The status line (line 1) must ALWAYS survive trimming.
-    expect(out).toContain('running · ')
+    // Unified running status line.
+    expect(out).toContain('<i>10s · 7 tools</i>')
     expect(out).toContain('7 tools')
-    // Output must be within Telegram's budget.
+    // Every rendered line was clipped to STATUS_LINE_MAX → output well within budget.
     expect(out.length).toBeLessThanOrEqual(4096)
+    // Newest bullet is the live → step.
+    expect(out).toContain('<b>→ final short step</b>')
   })
 
-  it('a "+N earlier" counter appears when the budget fitter drops oldest steps', () => {
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
-    // With no-truncate ON, appendStepFeed passes at most STATUS_ROLLING_LINES (5)
-    // lines to the body. To trigger _fitWorkerBodyToCharBudget's fitting loop, we
-    // need 5 lines that together exceed 4000 chars.
-    // Use 4 × 820-char lines + 1 short line: 4×820 = 3280 step chars plus
-    // markup overhead (~4×(5+5)=80) + headers (~80) = ~3440 chars, still under
-    // budget; but with the newest kept short, the 4 big lines dominate. To reliably
-    // overflow the budget, use lines large enough that even 2 lines exceed 4000:
-    // 5 × 800-char lines → 5×810 = 4050 step chars + headers ~80 → ~4130 > 4000.
-    const bigLine = 'b'.repeat(800)
-    const narrativeLines = Array.from({ length: 5 }, () => bigLine)
+  it('a "+N earlier…" rolling marker appears when more than STATUS_ROLLING_LINES lines render', () => {
+    const narrativeLines = Array.from({ length: STATUS_ROLLING_LINES + 2 }, (_, i) => `step ${i + 1}`)
     const out = renderWorkerActivity(view({ narrativeLines }))
 
     expect(out.length).toBeLessThanOrEqual(4096)
-    // The "+N earlier" overflow counter must appear between the header and steps.
     expect(out).toContain('earlier…')
-    // The worker header and status line are always in the fixed slice.
     expect(out).toContain('🛠 <b>Worker</b>')
-    expect(out).toContain('running · ')
+    expect(out).toContain('<i>10s · ')
   })
 
-  it('back-compat path (latestSummary only, empty narrativeLines) still shows a step bullet when budget is exceeded', () => {
-    // Regression from PR #2511: when narrativeLines is empty, rawNewestStep=''
-    // and the extreme fallback previously returned only fixedJoined (two header
-    // lines with no step bullet). The fix falls back to recovering raw text from
-    // the already-escaped newestLine when rawNewestStep=''.
-    delete process.env.SWITCHROOM_STATUS_NO_TRUNCATE
-    // Use latestSummary only (no narrativeLines) and make it huge enough to
-    // exceed the char budget even with just the 2 header lines + this one step.
+  it('back-compat path (latestSummary only) still shows a step bullet, clipped + valid HTML', () => {
     const hugeSummary = 'deploy service && run migrations && verify health checks '.repeat(80)
     expect(hugeSummary.length).toBeGreaterThan(4000)
 
@@ -933,13 +925,10 @@ describe('_fitWorkerBodyToCharBudget: header row and +N earlier counter regressi
     )
 
     expect(out.length).toBeLessThanOrEqual(4096)
-    // The step bullet MUST be present (regression guard: must not be only headers).
     const hasBullet = out.includes('→') || out.includes('✓')
     expect(hasBullet).toBe(true)
-    // Header rows must be present.
     expect(out).toContain('🛠 <b>Worker</b>')
-    expect(out).toContain('running · ')
-    // Valid HTML.
+    expect(out).toContain('<i>10s · ')
     expect(isValidWorkerHtml(out)).toBe(true)
   })
 })

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -120,9 +120,26 @@ describe('renderWorkerActivity', () => {
 
   it('renders a failed terminal recap', () => {
     const out = renderWorkerActivity(view({ state: 'failed', latestSummary: 'blew up' }))
-    // Failed maps to the "done" header word; the ⚠️ result carries the failure.
-    expect(out).toContain('<i>done · ')
+    // The header word reflects the failure (`failed · …`) AND the ⚠️ result
+    // block carries the detail — the two signals are complementary.
+    expect(out).toContain('<i>failed · ')
+    expect(out).not.toContain('<i>done · ')
     expect(out).toContain('⚠️ <i>blew up</i>')
+  })
+
+  it('a failed worker with EMPTY result is never byte-identical to a done worker (regression: #2553 failure-honesty)', () => {
+    // Detail-less terminal error: resultText === '' (subagent-watcher path).
+    const failed = renderWorkerActivity(view({ state: 'failed', latestSummary: '' }))
+    const done = renderWorkerActivity(view({ state: 'done', latestSummary: '' }))
+    // (a) The two renders must differ — the failure signal cannot vanish.
+    expect(failed).not.toBe(done)
+    // (b) The failed render carries a visible failure marker even with no
+    //     result block (the `failed` header word and/or the ⚠️ emoji).
+    expect(failed.includes('failed') || failed.includes('⚠️')).toBe(true)
+    expect(failed).toContain('<i>failed · ')
+    // The done render must NOT read as failed.
+    expect(done).toContain('<i>done · ')
+    expect(done).not.toContain('failed')
   })
 
   it('omits the rule + result line when the terminal result is empty', () => {

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -246,7 +246,8 @@ export function clipNarrative(s: string): string {
  * `description` — italicised task description (optional)
  * `elapsedMs`   — wall-clock elapsed, rendered via `formatFeedElapsed`
  * `toolCount`   — labeled tool calls this turn
- * `state`       — 'running' | 'done' (controls the status line wording)
+ * `state`       — 'running' | 'done' | 'failed' (controls the status line wording;
+ *                 'failed' renders `failed · …` so a failed worker never reads as done)
  *
  * Returns a two-element array of ready Telegram HTML lines (no trailing newline).
  */
@@ -256,15 +257,15 @@ export function renderActivityHeader(
   description: string,
   elapsedMs: number,
   toolCount: number,
-  state: 'running' | 'done',
+  state: 'running' | 'done' | 'failed',
 ): [string, string] {
   const toolWord = toolCount === 1 ? 'tool' : 'tools'
   const elapsed = formatFeedElapsed(elapsedMs)
   const descPart = description.length > 0 ? ` · <i>${escapeHtml(description)}</i>` : ''
   const line1 = `${emoji} <b>${escapeHtml(label)}</b>${descPart}`
-  const line2 = state === 'done'
-    ? `<i>done · ${toolCount} ${toolWord} · ${elapsed}</i>`
-    : `<i>${elapsed} · ${toolCount} ${toolWord}</i>`
+  const line2 = state === 'running'
+    ? `<i>${elapsed} · ${toolCount} ${toolWord}</i>`
+    : `<i>${state} · ${toolCount} ${toolWord} · ${elapsed}</i>`
   return [line1, line2]
 }
 
@@ -381,9 +382,11 @@ export function renderStatusCard(opts: StatusCardOpts): string | null {
         header.description ?? '',
         header.elapsedMs,
         header.toolCount,
-        // The header builder only distinguishes done vs running; map 'failed' → done
-        // (the result block carries the failure emoji/text).
-        header.state === 'running' ? 'running' : 'done',
+        // Thread the terminal state straight through so a failed worker reads
+        // `failed · …` on line 2 — never byte-identical to a done worker even
+        // when the result block is empty. The agent surface never passes
+        // 'failed', so only the worker card is affected.
+        header.state,
       )
     : []
 

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -163,14 +163,21 @@ export function describeToolUse(
 // Accumulates the turn's actions into a running feed — like Claude Code's
 // own UI — rendered into one Telegram message that edits in place and is
 // cleared on reply. Chronological (oldest first, newest last), consecutive
-// exact-duplicates collapsed, capped to the most recent MIRROR_MAX_LINES
-// with a "+N earlier" header so a heavy turn stays readable.
+// exact-duplicates collapsed.
 //
-// When SWITCHROOM_STATUS_NO_TRUNCATE is not '0' (the default), per-line "…"
-// clips and overflow headers are dropped; only the last STATUS_ROLLING_LINES
-// steps are shown in full, bounded by the 4096-char limit (STATUS_CARD_CHAR_BUDGET).
+// Both this surface (agent) and the worker feed render through the single
+// `renderStatusCard` primitive below: a rolling window of the last
+// STATUS_ROLLING_LINES steps, each capped at STATUS_LINE_MAX chars, with a
+// `+N earlier…` header when the feed overflows, bounded by the 4000-char
+// wire-limit backstop (STATUS_CARD_CHAR_BUDGET).
 
-import { statusNoTruncate, STATUS_CARD_CHAR_BUDGET, STATUS_ROLLING_LINES } from './status-no-truncate.js'
+import {
+  STATUS_CARD_CHAR_BUDGET,
+  STATUS_ROLLING_LINES,
+  STATUS_LINE_MAX,
+  NESTED_PREFIX,
+} from './status-no-truncate.js'
+import { escapeHtml, stripMarkdown, truncate } from './card-format.js'
 import { isTelegramSurfaceTool } from './tool-names.js'
 
 export const MIRROR_MAX_LINES = 6;
@@ -227,11 +234,6 @@ export function clipNarrative(s: string): string {
   return s.split('\n')[0].trim().slice(0, 120);
 }
 
-/** Minimal HTML escape for Telegram parse_mode=HTML (matches the gateway's). */
-export function escapeFeedHtml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-
 /**
  * Render a two-line header for the activity card, matching the worker card's
  * style. Used by both the main-session card and the worker card.
@@ -258,8 +260,8 @@ export function renderActivityHeader(
 ): [string, string] {
   const toolWord = toolCount === 1 ? 'tool' : 'tools'
   const elapsed = formatFeedElapsed(elapsedMs)
-  const descPart = description.length > 0 ? ` · <i>${escapeFeedHtml(description)}</i>` : ''
-  const line1 = `${emoji} <b>${escapeFeedHtml(label)}</b>${descPart}`
+  const descPart = description.length > 0 ? ` · <i>${escapeHtml(description)}</i>` : ''
+  const line1 = `${emoji} <b>${escapeHtml(label)}</b>${descPart}`
   const line2 = state === 'done'
     ? `<i>done · ${toolCount} ${toolWord} · ${elapsed}</i>`
     : `<i>${elapsed} · ${toolCount} ${toolWord}</i>`
@@ -274,66 +276,249 @@ export function formatFeedElapsed(ms: number): string {
   return `${m}m${(s % 60).toString().padStart(2, '0')}s`
 }
 
+// ─── Truncation pipeline (the single correctness-critical primitive) ────────
+//
+// Per RAW line, in this EXACT order:
+//   1. stripMarkdown(raw)
+//   2. .replace(/\s+/g, ' ').trim()
+//   3. truncate(_, STATUS_LINE_MAX)
+//   4. escapeHtml(_)   ← escape is ALWAYS the last per-line op.
+// Escaping last is load-bearing: clipping an already-escaped string can split
+// an HTML entity (&amp; → &amp), which Telegram's HTML parser rejects.
+
+/** Clean + clip + escape a single raw step line. Returns ready-to-wrap HTML. */
+function escapeStepLine(raw: string): string {
+  const cleaned = stripMarkdown(raw).replace(/\s+/g, ' ').trim()
+  return escapeHtml(truncate(cleaned, STATUS_LINE_MAX))
+}
+
 /**
- * Shared step-feed renderer used by both the main-session card and the worker
- * card. Appends `✓`/`→` bullet lines to `out` for the given pre-escaped
- * step strings.
+ * Shared step-feed emitter. Appends `✓`/`→` bullet lines to `out` for the
+ * given ALREADY-ESCAPED step strings, windowing to STATUS_ROLLING_LINES and
+ * prepending a `+N earlier…` header when the feed overflows the window (on
+ * BOTH surfaces now). The worker feed imports this directly.
  *
- * `steps`     — pre-HTML-escaped step strings (raw text NOT expected here;
- *               callers must escape before passing)
- * `allDone`   — when true ALL steps render done (✓ italic); when false the
- *               newest renders in-progress (→ bold)
- * `noTruncate`— when true: rolling STATUS_ROLLING_LINES window, no overflow
- *               header; when false: cap to MIRROR_MAX_LINES with overflow
- *               header (legacy mode)
- * `maxLines`  — cap in non-noTruncate mode (default MIRROR_MAX_LINES)
- *
- * Mutates `out` in place; returns nothing.
+ * `out`        — accumulator mutated in place
+ * `steps`      — pre-cleaned + pre-escaped HTML step strings
+ * `allDone`    — when true ALL steps render done (✓ italic); when false the
+ *                newest renders in-progress (→ bold)
+ * `liveSuffix` — appended INSIDE the newest in-progress line (heartbeat tick)
  */
 export function renderStepFeed(
   out: string[],
   steps: string[],
   allDone: boolean,
-  noTruncate: boolean,
-  maxLines = MIRROR_MAX_LINES,
   liveSuffix = '',
 ): void {
   if (steps.length === 0) return
-  let shown: string[]
-  if (noTruncate) {
-    shown = steps.slice(-STATUS_ROLLING_LINES)
-    // No overflow header in no-truncate mode — strictly the rolling window.
-  } else {
-    shown = steps.slice(-maxLines)
-    const hidden = steps.length - shown.length
-    if (hidden > 0) out.push(`<i>✓ +${hidden} earlier…</i>`)
-  }
+  const shown = steps.slice(-STATUS_ROLLING_LINES)
+  const hidden = steps.length - shown.length
+  if (hidden > 0) out.push(`<i>✓ +${hidden} earlier…</i>`)
   const lastIdx = shown.length - 1
   shown.forEach((s, i) => {
     out.push(!allDone && i === lastIdx ? `<b>→ ${s}${liveSuffix}</b>` : `<i>✓ ${s}</i>`)
   })
 }
 
+// ─── Unified status-card primitive ──────────────────────────────────────────
+//
+// Both status surfaces (🤖 agent + 🛠 worker) render through `renderStatusCard`.
+// It is the single place that runs the per-line truncation pipeline, windows
+// the rolling feed, prepends `+N earlier…`, wraps bullets, indents child
+// steps, and applies the total-budget backstop.
+
+/** Header block for a status card. Emoji 🤖 (agent) / 🛠 (worker). */
+export interface StatusCardHeader {
+  emoji: string
+  label: string
+  description?: string
+  elapsedMs: number
+  toolCount: number
+  state: 'running' | 'done' | 'failed'
+}
+
+/** Inputs to the unified status-card renderer. */
+export interface StatusCardOpts {
+  /** Optional two-line header. When omitted, the card is steps-only. */
+  header?: StatusCardHeader
+  /** RAW parent step strings (unstripped, unescaped). */
+  steps: string[]
+  /** RAW nested child step strings (foreground sub-agent), unstripped/unescaped. */
+  childSteps?: string[]
+  /** Terminal record render — newest line renders done (✓) and `liveSuffix` is ignored. */
+  final?: boolean
+  /** Heartbeat suffix appended INSIDE the newest in-progress line (live only). */
+  liveSuffix?: string
+  /** When `final` and > 0, appends a `✓ N steps` footer. */
+  stepCount?: number
+  /** Optional terminal result block (worker recap), already-cleaned text + emoji. */
+  result?: { emoji: string; text: string }
+}
+
+/**
+ * Render the unified status card as ready Telegram HTML, or null when there is
+ * no content to show (no header content, no steps, no children, no result).
+ *
+ * Pipeline: header → escape+clip every raw step/child → rolling-window each
+ * group with `+N earlier…` → wrap (parent done-styled when children present;
+ * newest-in-progress `→` bold else `✓` italic; NESTED_PREFIX for children) →
+ * optional `✓ N steps` footer → optional result block → fitCardToBudget.
+ */
+export function renderStatusCard(opts: StatusCardOpts): string | null {
+  const { header, final = false, liveSuffix = '', stepCount, result } = opts
+  const rawSteps = opts.steps.filter((s) => s != null)
+  const rawChildren = (opts.childSteps ?? []).map((s) => s.trim()).filter((s) => s.length > 0)
+  const hasChildren = rawChildren.length > 0
+
+  // Escape every line through the per-line pipeline (escape last).
+  const steps = rawSteps.map(escapeStepLine)
+  const children = rawChildren.map(escapeStepLine)
+
+  const headerLines = header != null
+    ? renderActivityHeader(
+        header.emoji,
+        header.label,
+        header.description ?? '',
+        header.elapsedMs,
+        header.toolCount,
+        // The header builder only distinguishes done vs running; map 'failed' → done
+        // (the result block carries the failure emoji/text).
+        header.state === 'running' ? 'running' : 'done',
+      )
+    : []
+
+  const out: string[] = [...headerLines]
+
+  if (hasChildren) {
+    // Parent lines all render done — the live → step lives in the nested block.
+    const shownParent = steps.slice(-STATUS_ROLLING_LINES)
+    const hiddenParent = steps.length - shownParent.length
+    if (hiddenParent > 0) out.push(`<i>✓ +${hiddenParent} earlier…</i>`)
+    for (const s of shownParent) out.push(`<i>✓ ${s}</i>`)
+    // Child block.
+    const shownChild = children.slice(-STATUS_ROLLING_LINES)
+    const hiddenChild = children.length - shownChild.length
+    if (hiddenChild > 0) out.push(`${NESTED_PREFIX}<i>+${hiddenChild} earlier…</i>`)
+    const lastChildIdx = shownChild.length - 1
+    shownChild.forEach((s, i) => {
+      out.push(
+        i === lastChildIdx && !final
+          ? `${NESTED_PREFIX}<b>→ ${s}${liveSuffix}</b>`
+          : `${NESTED_PREFIX}<i>${s}</i>`,
+      )
+    })
+  } else {
+    renderStepFeed(out, steps, final, liveSuffix)
+  }
+
+  if (final && stepCount != null && stepCount > 0) {
+    out.push(`<i>✓ ${stepCount} steps</i>`)
+  }
+
+  if (result != null && result.text.length > 0) {
+    out.push(WORKER_RESULT_RULE)
+    out.push(`${result.emoji} <i>${escapeHtml(truncate(result.text, WORKER_RESULT_MAX))}</i>`)
+  }
+
+  // out always carries the two header lines, so it is never empty — but guard
+  // against a degenerate header-less future caller.
+  if (out.length === 0) return null
+  const joined = out.join('\n')
+  if (joined.length <= STATUS_CARD_CHAR_BUDGET) return joined
+  return fitCardToBudget(opts, headerLines)
+}
+
+/** Subtle horizontal rule between the running feed and the finished result. */
+const WORKER_RESULT_RULE = '─────'
+/** Hard cap on the terminal result paragraph. */
+const WORKER_RESULT_MAX = 320
+
+/**
+ * Char-budget backstop. Keeps the header / footer / result block fixed and
+ * drops the oldest body bullets one at a time, re-inserting a `+N earlier…`
+ * marker, until the card fits STATUS_CARD_CHAR_BUDGET. In the extreme case
+ * (a single newest bullet that is itself oversized) it truncates the RAW
+ * newest text, THEN escapes, THEN wraps — never slicing already-escaped HTML.
+ */
+function fitCardToBudget(opts: StatusCardOpts, headerLines: string[]): string {
+  const { final = false, liveSuffix = '', stepCount, result } = opts
+  const rawSteps = opts.steps.filter((s) => s != null)
+  const rawChildren = (opts.childSteps ?? []).map((s) => s.trim()).filter((s) => s.length > 0)
+  const hasChildren = rawChildren.length > 0
+
+  // Fixed footer/result lines (always kept).
+  const footerLines: string[] = []
+  if (final && stepCount != null && stepCount > 0) footerLines.push(`<i>✓ ${stepCount} steps</i>`)
+  if (result != null && result.text.length > 0) {
+    footerLines.push(WORKER_RESULT_RULE)
+    footerLines.push(`${result.emoji} <i>${escapeHtml(truncate(result.text, WORKER_RESULT_MAX))}</i>`)
+  }
+  const fixedCost = [...headerLines, ...footerLines].join('\n').length
+
+  // The active "body" group whose oldest bullets we drop: children when
+  // present (parent collapses to a single "+N" marker), else parent steps.
+  const body = hasChildren ? rawChildren : rawSteps
+  const escapedBody = body.map(escapeStepLine)
+  const prefix = hasChildren ? NESTED_PREFIX : ''
+
+  const buildBullet = (esc: string, isLast: boolean): string =>
+    !final && isLast ? `${prefix}<b>→ ${esc}${liveSuffix}</b>` : `${prefix}<i>${esc}</i>`
+
+  // Parent-collapsed marker line when we are dropping children but parent steps exist.
+  const parentMarker =
+    hasChildren && rawSteps.length > 0 ? `<i>✓ +${rawSteps.length} earlier…</i>` : null
+
+  for (let drop = 1; drop < escapedBody.length; drop++) {
+    const shown = escapedBody.slice(drop)
+    const lines: string[] = [...headerLines]
+    if (parentMarker != null) lines.push(parentMarker)
+    lines.push(hasChildren ? `${NESTED_PREFIX}<i>+${drop} earlier…</i>` : `<i>✓ +${drop} earlier…</i>`)
+    const lastIdx = shown.length - 1
+    shown.forEach((esc, i) => lines.push(buildBullet(esc, i === lastIdx)))
+    lines.push(...footerLines)
+    const candidate = lines.join('\n')
+    if (candidate.length <= STATUS_CARD_CHAR_BUDGET) return candidate
+  }
+
+  // Extreme: the single newest bullet is itself oversized. Truncate the RAW
+  // newest text, then escape, then wrap — re-checking post-escape because
+  // escaping can expand the string (& → &amp;).
+  const rawNewest = body.length > 0 ? stripMarkdown(body[body.length - 1]).replace(/\s+/g, ' ').trim() : ''
+  const wrapperOverhead = final
+    ? (prefix + '<i>✓ </i>').length
+    : (prefix + '<b>→ </b>').length + liveSuffix.length
+  const headerFooterCost =
+    fixedCost + (fixedCost > 0 ? 1 : 0) + (parentMarker != null ? parentMarker.length + 1 : 0)
+  const budget = STATUS_CARD_CHAR_BUDGET - headerFooterCost - wrapperOverhead
+  let raw = rawNewest.slice(0, Math.max(0, budget))
+  let newest = escapeHtml(raw)
+  while (raw.length > 0 && wrapperOverhead + headerFooterCost + newest.length > STATUS_CARD_CHAR_BUDGET) {
+    const excess = wrapperOverhead + headerFooterCost + newest.length - STATUS_CARD_CHAR_BUDGET
+    raw = raw.slice(0, Math.max(0, raw.length - excess - 1))
+    newest = escapeHtml(raw)
+  }
+  const newestLine = final ? `${prefix}<i>✓ ${newest}</i>` : `${prefix}<b>→ ${newest}${liveSuffix}</b>`
+  const lines: string[] = [...headerLines]
+  if (parentMarker != null) lines.push(parentMarker)
+  lines.push(newestLine)
+  lines.push(...footerLines)
+  return lines.join('\n')
+}
+
 /**
  * Render the accumulated feed as ready Telegram HTML — one action per line,
  * newest last. The current (newest) step is bold with a `→`; finished steps
- * are italic with a `✓`. Capped to the last MIRROR_MAX_LINES with a dim
+ * are italic with a `✓`. Capped to the last STATUS_ROLLING_LINES with a dim
  * `✓ +N earlier…` header when the turn ran longer. Returns null when empty.
  * Callers send the result verbatim — do NOT re-escape or re-wrap it.
  *
- * When SWITCHROOM_STATUS_NO_TRUNCATE is on (default), shows only the last
- * STATUS_ROLLING_LINES lines in full (no per-line "…"), with NO overflow
- * header. The only remaining ceiling is STATUS_CARD_CHAR_BUDGET (wire-limit
- * backstop via `_fitToCharBudget`).
+ * Thin adapter over `renderStatusCard` (emoji 🤖, label 'Agent').
  *
  * `stepCount` (optional): when `final=true` and `stepCount > 0`, appends a
- * `✓ N steps` footer line so the persisted feed record shows an accurate
- * total of surfaced (non-surface-tool) steps for the turn.
+ * `✓ N steps` footer line.
  *
- * `header` (optional): when provided, prepends a two-line activity header
- * (matching the worker card's style) so the main-session card shows
- * elapsed time + tool count alongside the step feed. The gateway threads
- * `turn.startedAt` + `turn.labeledToolCount` into this.
+ * `header` (optional): when provided, the two-line activity header carries
+ * elapsed + tool count.
  */
 export function renderActivityFeed(
   lines: string[],
@@ -343,128 +528,21 @@ export function renderActivityFeed(
   header?: SessionActivityHeader,
 ): string | null {
   if (lines.length === 0 && header == null) return null;
-  const noTruncate = statusNoTruncate();
-  const out: string[] = [];
-
-  // Optional header block — mirrors the worker card's two-line header.
-  if (header != null) {
-    const [h1, h2] = renderActivityHeader(
-      '🤖',
-      header.label,
-      '',
-      header.elapsedMs,
-      header.toolCount,
-      header.state,
-    )
-    out.push(h1)
-    out.push(h2)
-  }
-
-  if (lines.length === 0) {
-    // Header-only (no steps yet) — only reachable when a header was supplied.
-    const result = out.join('\n')
-    return result.length > 0 ? result : null
-  }
-
-  // Escape all lines before passing to renderStepFeed.
-  const escaped = lines.map(escapeFeedHtml)
-
-  // No-truncate ON: rolling STATUS_ROLLING_LINES window, no overflow header.
-  // No-truncate OFF: cap to MIRROR_MAX_LINES with overflow header.
-  if (noTruncate) {
-    const shown = escaped.slice(-STATUS_ROLLING_LINES)
-    const lastIdx = shown.length - 1
-    shown.forEach((esc, i) => {
-      out.push(i === lastIdx && !final ? `<b>→ ${esc}${liveSuffix}</b>` : `<i>✓ ${esc}</i>`)
-    })
-  } else {
-    const shown = escaped.slice(-MIRROR_MAX_LINES)
-    const hidden = escaped.length - shown.length
-    if (hidden > 0) out.push(`<i>✓ +${hidden} earlier…</i>`)
-    const lastIdx = shown.length - 1
-    // Newest line = in-progress step (bold, →); earlier = done (italic, ✓).
-    // `final` (turn complete, feed left as a record): ALL lines render done (✓)
-    // so the persisted message doesn't freeze on a misleading "→ in-progress".
-    // `liveSuffix` (heartbeat): appended INSIDE the newest in-progress line only
-    // (e.g. " · 18s") so the feed visibly advances during a long single step that
-    // emits no new tool label — the feed is otherwise pull-only and freezes.
-    // Caller passes framework-generated, HTML-safe text; never final + suffix.
-    // Returns ready Telegram HTML — callers must NOT re-escape or re-wrap it.
-    shown.forEach((esc, i) => {
-      out.push(i === lastIdx && !final ? `<b>→ ${esc}${liveSuffix}</b>` : `<i>✓ ${esc}</i>`)
-    })
-  }
-
-  // Final total: append a `✓ N steps` footer when the turn has a non-zero
-  // surfaced step count. Only shown on the persisted terminal render
-  // (`final=true`) so the live in-progress feed stays clean.
-  if (final && stepCount != null && stepCount > 0) {
-    out.push(`<i>✓ ${stepCount} steps</i>`);
-  }
-  const result = out.join("\n");
-  // No-truncate mode: enforce the Telegram char budget as the only ceiling.
-  // With STATUS_ROLLING_LINES=5 full lines (~750 chars) this effectively never
-  // fires, but keep it as the wire-limit safety net.
-  if (noTruncate && result.length > STATUS_CARD_CHAR_BUDGET) {
-    return _fitToCharBudget(lines, final, liveSuffix, stepCount, header);
-  }
-  return result;
-}
-
-/**
- * Internal helper: called only in no-truncate mode when the full render
- * exceeds STATUS_CARD_CHAR_BUDGET. Drops oldest lines one at a time until
- * the rendered output fits, prepending a "+N earlier…" header to surface
- * the clip. The caller is responsible for not re-calling this recursively
- * (the budget is wide enough that a "+N" header itself never causes overflow).
- */
-function _fitToCharBudget(
-  lines: string[],
-  final: boolean,
-  liveSuffix: string,
-  stepCount?: number,
-  header?: SessionActivityHeader,
-): string | null {
-  // Pre-render the header block (if any) so we can measure its cost.
-  const headerLines: string[] = []
-  if (header != null) {
-    const [h1, h2] = renderActivityHeader('🤖', header.label, '', header.elapsedMs, header.toolCount, header.state)
-    headerLines.push(h1, h2)
-  }
-  const headerPrefix = headerLines.length > 0 ? headerLines.join('\n') + '\n' : ''
-  const headerCost = headerPrefix.length
-
-  for (let drop = 1; drop < lines.length; drop++) {
-    const shown = lines.slice(drop);
-    const out: string[] = [...headerLines, `<i>✓ +${drop} earlier…</i>`];
-    const lastIdx = shown.length - 1;
-    shown.forEach((l, i) => {
-      const esc = escapeFeedHtml(l);
-      out.push(i === lastIdx && !final ? `<b>→ ${esc}${liveSuffix}</b>` : `<i>✓ ${esc}</i>`);
-    });
-    if (final && stepCount != null && stepCount > 0) {
-      out.push(`<i>✓ ${stepCount} steps</i>`);
-    }
-    const candidate = out.join("\n");
-    if (candidate.length <= STATUS_CARD_CHAR_BUDGET) return candidate;
-  }
-  // Rare but reachable with long Bash labels containing special chars (e.g. &&).
-  // Never slice already-escaped HTML — that breaks entities (&amp; → &amp) and
-  // leaves dangling tags. Instead truncate the RAW content first, then escape
-  // and wrap, re-checking post-escape because escaping can expand (&→&amp;).
-  const wrapperOverhead = final
-    ? "<i>✓ </i>".length
-    : ("<b>→ </b>".length + liveSuffix.length);
-  const maxRaw = Math.max(0, STATUS_CARD_CHAR_BUDGET - wrapperOverhead - headerCost);
-  let raw = lines[lines.length - 1].slice(0, maxRaw);
-  let newest = escapeFeedHtml(raw);
-  while (raw.length > 0 && wrapperOverhead + headerCost + newest.length > STATUS_CARD_CHAR_BUDGET) {
-    const excess = wrapperOverhead + headerCost + newest.length - STATUS_CARD_CHAR_BUDGET;
-    raw = raw.slice(0, Math.max(0, raw.length - excess - 1));
-    newest = escapeFeedHtml(raw);
-  }
-  const newestLine = final ? `<i>✓ ${newest}</i>` : `<b>→ ${newest}${liveSuffix}</b>`
-  return headerPrefix.length > 0 ? `${headerPrefix}${newestLine}` : newestLine
+  return renderStatusCard({
+    header: header != null
+      ? {
+          emoji: '🤖',
+          label: header.label,
+          elapsedMs: header.elapsedMs,
+          toolCount: header.toolCount,
+          state: header.state,
+        }
+      : undefined,
+    steps: lines,
+    final,
+    liveSuffix,
+    stepCount,
+  })
 }
 
 // ─── Foreground sub-agent nesting (Model A) ─────────────────────────────────
@@ -479,10 +557,6 @@ function _fitToCharBudget(
 
 /** Trailing nested child lines kept visible (Telegram length + readability). */
 export const NESTED_MAX_LINES = 4;
-/** Hard cap on a single nested narrative line. */
-const NESTED_LINE_MAX = 90;
-/** Indent marker for a nested sub-agent step. */
-const NESTED_PREFIX = "   ↳ ";
 
 /**
  * Render the parent activity feed with an active foreground sub-agent's steps
@@ -493,12 +567,7 @@ const NESTED_PREFIX = "   ↳ ";
  * a `↳ +N earlier…` header when it overflows. Returns ready Telegram HTML
  * (callers must NOT re-escape) or null when there is nothing to show.
  *
- * `stepCount` (optional): forwarded to `renderActivityFeed` for the `✓ N steps`
- * footer on the persisted terminal render (`final=true`).
- *
- * `header` (optional): when provided, prepends a two-line activity header
- * (elapsed + tool count) matching the worker card's style. Forwarded to
- * `renderActivityFeed` when there are no child lines.
+ * Thin adapter over `renderStatusCard` (emoji 🤖, label 'Agent', childSteps).
  */
 export function renderActivityFeedWithNested(
   lines: string[],
@@ -510,150 +579,22 @@ export function renderActivityFeedWithNested(
 ): string | null {
   const children = childLines.map((s) => s.trim()).filter((s) => s.length > 0);
   if (children.length === 0) return renderActivityFeed(lines, final, liveSuffix, stepCount, header);
-
-  const noTruncate = statusNoTruncate();
-  const out: string[] = [];
-
-  // Optional header block — same two-line style as the worker card.
-  if (header != null) {
-    const [h1, h2] = renderActivityHeader('🤖', header.label, '', header.elapsedMs, header.toolCount, header.state)
-    out.push(h1)
-    out.push(h2)
-  }
-
-  // Parent lines:
-  //   no-truncate ON  → rolling STATUS_ROLLING_LINES window, no overflow header.
-  //   no-truncate OFF → cap to MIRROR_MAX_LINES with overflow header.
-  const shownParent = noTruncate ? lines.slice(-STATUS_ROLLING_LINES) : lines.slice(-MIRROR_MAX_LINES);
-  if (!noTruncate) {
-    const hiddenParent = lines.length - shownParent.length;
-    if (hiddenParent > 0) out.push(`<i>✓ +${hiddenParent} earlier…</i>`);
-  }
-  for (const l of shownParent) out.push(`<i>✓ ${escapeFeedHtml(l)}</i>`);
-
-  // Child lines:
-  //   no-truncate ON  → rolling STATUS_ROLLING_LINES window, no overflow header,
-  //                     each line in FULL (no NESTED_LINE_MAX "…").
-  //   no-truncate OFF → cap to NESTED_MAX_LINES with overflow header + NESTED_LINE_MAX clip.
-  const shownChild = noTruncate ? children.slice(-STATUS_ROLLING_LINES) : children.slice(-NESTED_MAX_LINES);
-  if (!noTruncate) {
-    const hiddenChild = children.length - shownChild.length;
-    if (hiddenChild > 0) out.push(`${NESTED_PREFIX}<i>+${hiddenChild} earlier…</i>`);
-  }
-  const lastChildIdx = shownChild.length - 1;
-  // `final`: the nested newest step also renders done (✓) so the left-behind
-  // feed reads as completed, not stuck on a "→ in-progress" child step.
-  // `liveSuffix` (heartbeat): appended to the nested newest in-progress step.
-  // NESTED_LINE_MAX per-line cap: only applied when no-truncate is OFF.
-  shownChild.forEach((l, i) => {
-    const t = (!noTruncate && l.length > NESTED_LINE_MAX) ? l.slice(0, NESTED_LINE_MAX - 1) + "…" : l;
-    const esc = escapeFeedHtml(t);
-    out.push(
-      i === lastChildIdx && !final
-        ? `${NESTED_PREFIX}<b>→ ${esc}${liveSuffix}</b>`
-        : `${NESTED_PREFIX}<i>${esc}</i>`,
-    );
-  });
-  // Final total: same `✓ N steps` footer as the flat render.
-  if (final && stepCount != null && stepCount > 0) {
-    out.push(`<i>✓ ${stepCount} steps</i>`);
-  }
-  // out.length > 0 is guaranteed if children.length > 0 (at least one child line).
-  // The `header != null` path above also ensures content, but an empty result
-  // with no header AND no parent AND no child lines can't happen (children filtered).
-  if (out.length === 0) return null;
-  const result = out.join("\n");
-  // No-truncate mode: enforce the Telegram char budget as the only ceiling.
-  // With STATUS_ROLLING_LINES=5 full lines (~750 chars) this effectively never
-  // fires, but keep it as the wire-limit safety net.
-  if (noTruncate && result.length > STATUS_CARD_CHAR_BUDGET) {
-    return _fitNestedToCharBudget(lines, children, final, liveSuffix, stepCount, header);
-  }
-  return result;
-}
-
-/**
- * Internal helper: called only in no-truncate mode when the full nested render
- * exceeds STATUS_CARD_CHAR_BUDGET. Trims oldest parent lines first, then
- * oldest child lines, until the output fits, surfacing a "+N earlier…" header
- * for each dropped group.
- */
-function _fitNestedToCharBudget(
-  lines: string[],
-  children: string[],
-  final: boolean,
-  liveSuffix: string,
-  stepCount?: number,
-  header?: SessionActivityHeader,
-): string | null {
-  // Pre-render the header block (if any) so we can include it as fixed lines.
-  const headerLines: string[] = []
-  if (header != null) {
-    const [h1, h2] = renderActivityHeader('🤖', header.label, '', header.elapsedMs, header.toolCount, header.state)
-    headerLines.push(h1, h2)
-  }
-
-  // Try dropping parent lines first (oldest first), keeping all children.
-  for (let pDrop = 1; pDrop <= lines.length; pDrop++) {
-    const shownP = lines.slice(pDrop);
-    const out: string[] = [...headerLines];
-    if (pDrop > 0) out.push(`<i>✓ +${pDrop} earlier…</i>`);
-    for (const l of shownP) out.push(`<i>✓ ${escapeFeedHtml(l)}</i>`);
-    const lastChildIdx = children.length - 1;
-    children.forEach((l, i) => {
-      const esc = escapeFeedHtml(l);
-      out.push(
-        i === lastChildIdx && !final
-          ? `${NESTED_PREFIX}<b>→ ${esc}${liveSuffix}</b>`
-          : `${NESTED_PREFIX}<i>${esc}</i>`,
-      );
-    });
-    if (final && stepCount != null && stepCount > 0) out.push(`<i>✓ ${stepCount} steps</i>`);
-    const candidate = out.join("\n");
-    if (candidate.length <= STATUS_CARD_CHAR_BUDGET) return candidate;
-  }
-  // Parent fully dropped; now also drop child lines oldest first.
-  for (let cDrop = 1; cDrop < children.length; cDrop++) {
-    const shownC = children.slice(cDrop);
-    const out: string[] = [
-      ...headerLines,
-      `<i>✓ +${lines.length} earlier…</i>`,
-      `${NESTED_PREFIX}<i>+${cDrop} earlier…</i>`,
-    ];
-    const lastChildIdx = shownC.length - 1;
-    shownC.forEach((l, i) => {
-      const esc = escapeFeedHtml(l);
-      out.push(
-        i === lastChildIdx && !final
-          ? `${NESTED_PREFIX}<b>→ ${esc}${liveSuffix}</b>`
-          : `${NESTED_PREFIX}<i>${esc}</i>`,
-      );
-    });
-    if (final && stepCount != null && stepCount > 0) out.push(`<i>✓ ${stepCount} steps</i>`);
-    const candidate = out.join("\n");
-    if (candidate.length <= STATUS_CARD_CHAR_BUDGET) return candidate;
-  }
-  // Rare but reachable with long Bash labels containing special chars (e.g. &&).
-  // Never slice already-escaped HTML — that breaks entities and leaves dangling tags.
-  // Truncate RAW content first, then escape and wrap, re-checking post-escape.
-  const headerCost = headerLines.length > 0 ? headerLines.join('\n').length + 1 : 0
-  const wrapperOverhead = final
-    ? (NESTED_PREFIX + "<i></i>").length
-    : (NESTED_PREFIX + "<b>→ </b>").length + liveSuffix.length;
-  const maxRaw = Math.max(0, STATUS_CARD_CHAR_BUDGET - wrapperOverhead - headerCost);
-  let raw = children[children.length - 1].slice(0, maxRaw);
-  let newest = escapeFeedHtml(raw);
-  while (raw.length > 0 && wrapperOverhead + headerCost + newest.length > STATUS_CARD_CHAR_BUDGET) {
-    const excess = wrapperOverhead + headerCost + newest.length - STATUS_CARD_CHAR_BUDGET;
-    raw = raw.slice(0, Math.max(0, raw.length - excess - 1));
-    newest = escapeFeedHtml(raw);
-  }
-  const newestLine = final
-    ? `${NESTED_PREFIX}<i>${newest}</i>`
-    : `${NESTED_PREFIX}<b>→ ${newest}${liveSuffix}</b>`
-  return headerLines.length > 0
-    ? [...headerLines, newestLine].join('\n')
-    : newestLine
+  return renderStatusCard({
+    header: header != null
+      ? {
+          emoji: '🤖',
+          label: header.label,
+          elapsedMs: header.elapsedMs,
+          toolCount: header.toolCount,
+          state: header.state,
+        }
+      : undefined,
+    steps: lines,
+    childSteps: children,
+    final,
+    liveSuffix,
+    stepCount,
+  })
 }
 
 /**

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -6,8 +6,8 @@
  * Each non-surface tool gets a human-friendly, present-tense line
  * ("Reading CLAUDE.md", "Searching memory", "Running a command"); the
  * feed renders them chronologically (oldest first, newest = the
- * in-progress step), consecutive duplicates collapsed, capped to the
- * most recent MIRROR_MAX_LINES with a "+N earlier" header.
+ * in-progress step), consecutive duplicates collapsed, windowed to the
+ * most recent STATUS_ROLLING_LINES with a "+N earlier…" overflow header.
  *
  * Two append entrypoints feed the same `lines: string[]` accumulator:
  *   - `appendActivityLabel` — for a pre-computed label from the
@@ -179,8 +179,6 @@ import {
 } from './status-no-truncate.js'
 import { escapeHtml, stripMarkdown, truncate } from './card-format.js'
 import { isTelegramSurfaceTool } from './tool-names.js'
-
-export const MIRROR_MAX_LINES = 6;
 
 /**
  * Optional header for the main-session activity card, matching the worker

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -34,13 +34,11 @@
 
 import {
   cleanWorkerResultParagraph,
-  escapeHtml,
-  formatDuration,
   stripMarkdown,
   truncate,
 } from './card-format.js'
-import { statusNoTruncate, STATUS_CARD_CHAR_BUDGET, STATUS_ROLLING_LINES } from './status-no-truncate.js'
-import { renderStepFeed } from './tool-activity-summary.js'
+import { STATUS_ROLLING_LINES } from './status-no-truncate.js'
+import { renderStatusCard, formatFeedElapsed } from './tool-activity-summary.js'
 
 /** Worker-activity feed is ON by default; an operator opts out with
  *  SWITCHROOM_WORKER_ACTIVITY_FEED=0. */
@@ -88,173 +86,88 @@ export interface BotApiForWorkerFeed {
   ): Promise<unknown>
 }
 
+/** Dispatch-time task description cap for the worker header. */
 const DESC_MAX = 80
-const STEP_MAX = 100
-const RESULT_MAX = 320
-/** Subtle horizontal rule between the running feed and the finished result. */
-const RULE = '─────'
 /**
- * How many trailing narrative lines the live feed keeps visible. The feed
- * grows like the main agent's answer but can't grow unbounded — Telegram
- * caps message length and a wall of stale lines buries the live one. Six
- * keeps recent context without dominating the chat.
+ * Legacy narrative-line cap, kept exported for back-compat with importers.
+ * The rolling window is now STATUS_ROLLING_LINES; this is no longer the active
+ * cap but remains a documented constant some callers/tests still reference.
  */
 export const NARRATIVE_MAX_LINES = 6
 
 /**
- * Append the accumulated step feed to `lines` using the shared `renderStepFeed`
- * from tool-activity-summary.ts. This thin wrapper preserves the worker-feed
- * call signature (passing `allDone` + `noTruncate`) while deleting the formerly
- * duplicated windowing logic. `steps` are already cleaned + escaped HTML.
- */
-function appendStepFeed(lines: string[], steps: string[], allDone: boolean, noTruncate = false): void {
-  renderStepFeed(lines, steps, allDone, noTruncate, NARRATIVE_MAX_LINES)
-}
-
-/**
- * Render the worker-activity message body as native Telegram HTML, matching
- * the main agent's activity card (`renderActivityFeed` in
- * tool-activity-summary.ts): a `🛠 Worker · <desc>` header, a one-line status,
- * then a `✓`/`→` step feed. Worker narration is authored as Markdown, so every
- * text fragment is run through `stripMarkdown` before escaping — without it the
- * raw `**`/`` ` ``/`---` leak through as literal characters (the "half-done"
- * look we're fixing).
+ * Thin adapter over the unified `renderStatusCard` primitive (emoji 🛠, label
+ * 'Worker'): builds the header, passes raw narrative steps (the primitive runs
+ * stripMarkdown → collapse ws → clip → escape per line), and on finish passes
+ * the cleaned result paragraph as the `result` block.
  *
  * Layout (running):
  *   🛠 <b>Worker</b> · <i>{description}</i>
- *   <i>running · {elapsed} · {n} tools</i>
+ *   <i>{elapsed} · {n} tools</i>
  *   <i>✓ {earlier step}</i>
  *   <b>→ {newest step}</b>
  *
  * Layout (finished): the feed renders all-done, then a rule + cleaned result:
  *   🛠 <b>Worker</b> · <i>{description}</i>
- *   <i>finished · completed · {n} tools · {elapsed}</i>
+ *   <i>done · {n} tools · {elapsed}</i>
  *   <i>✓ {step}</i>
  *   ─────
  *   ✅ <i>{cleaned result paragraph}</i>
  */
-export function renderWorkerActivity(v: WorkerActivityView): string {
-  const noTruncate = statusNoTruncate()
+export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): string {
   const desc = truncate(stripMarkdown(v.description).trim() || 'background task', DESC_MAX)
-  const elapsed = formatDuration(v.elapsedMs)
-  const toolWord = v.toolCount === 1 ? 'tool' : 'tools'
-  const header = `🛠 <b>Worker</b> · <i>${escapeHtml(desc)}</i>`
   const finished = v.state === 'done' || v.state === 'failed'
 
-  // Clean narrative lines (strip Markdown, collapse whitespace) but keep the
-  // raw (pre-HTML-escape) strings so the char-budget fitter can truncate raw
-  // content first and then escape, avoiding broken HTML entities at the slice
-  // boundary (e.g. &amp; → &amp or &lt; → &l after a naive escaped-string cut).
-  const rawSteps = (v.narrativeLines ?? [])
-    .map((s) => stripMarkdown(s).replace(/\s+/g, ' ').trim())
-    .filter((s) => s.length > 0)
-  // Escape + clip (clip only in legacy mode) for the rendered feed.
-  const steps = rawSteps.map((s) => escapeHtml(noTruncate ? s : truncate(s, STEP_MAX)))
-  // Newest raw step: used by _fitWorkerBodyToCharBudget's extreme fallback to
-  // truncate raw text before escaping (mirrors _fitToCharBudget in tool-activity-summary.ts).
-  const rawNewestStep = rawSteps[rawSteps.length - 1] ?? ''
+  // Raw narrative steps (unstripped/unescaped) — the unified renderer runs the
+  // full per-line pipeline (stripMarkdown → collapse ws → clip → escape).
+  const rawSteps = (v.narrativeLines ?? []).filter((s) => s != null && s.trim().length > 0)
 
-  if (finished) {
-    const verb = v.state === 'done' ? 'completed' : 'failed'
-    const lines = [header, `<i>finished · ${verb} · ${v.toolCount} ${toolWord} · ${elapsed}</i>`]
-    appendStepFeed(lines, steps, true, noTruncate)
-    // On terminal, latestSummary carries the worker's final result text
-    // (gateway onFinish), distinct from the running narrative steps.
-    const result = cleanWorkerResultParagraph(v.latestSummary)
-    if (result.length > 0) {
-      const emoji = v.state === 'done' ? '✅' : '⚠️'
-      lines.push(RULE)
-      lines.push(`${emoji} <i>${escapeHtml(truncate(result, RESULT_MAX))}</i>`)
-    }
-    const body = lines.join('\n')
-    return noTruncate ? _fitWorkerBodyToCharBudget(body, lines, rawNewestStep) : body
-  }
-
-  const lines = [header, `<i>running · ${elapsed} · ${v.toolCount} ${toolWord}</i>`]
-  if (steps.length > 0) {
-    appendStepFeed(lines, steps, false, noTruncate)
-  } else {
-    // Back-compat for direct render callers that pass only latestSummary;
-    // the manager always supplies narrativeLines.
+  // Back-compat for direct render callers that pass only latestSummary while
+  // RUNNING; the manager always supplies narrativeLines. On the FINISHED path
+  // latestSummary is the worker's RESULT (below), never a narrative step — so
+  // the fallback only applies while running.
+  let steps = rawSteps
+  if (steps.length === 0 && !finished) {
     const summary = stripMarkdown(v.latestSummary).replace(/\s+/g, ' ').trim()
-    if (summary.length > 0) {
-      // In no-truncate mode, render in full (no STEP_MAX clip); legacy mode preserves the clip.
-      lines.push(`<b>→ ${escapeHtml(noTruncate ? summary : truncate(summary, STEP_MAX))}</b>`)
-    } else {
-      lines.push('<i>starting…</i>')
-    }
+    if (summary.length > 0) steps = [v.latestSummary]
   }
-  const body = lines.join('\n')
-  return noTruncate ? _fitWorkerBodyToCharBudget(body, lines, rawNewestStep) : body
-}
 
-/**
- * Internal helper: when no-truncate mode produces a body that exceeds the
- * Telegram char budget, drop the oldest step-feed lines (the ones after the
- * two fixed header lines) until it fits. The two fixed header lines (🛠 Worker
- * header + status line) are always kept.
- *
- * If the final (newest) feed line is itself oversized, it is hard-truncated so
- * at least some step content survives — never returning a body with no step
- * bullet. `rawNewestStep` is the raw (un-HTML-escaped) text of that newest step
- * so the extreme fallback can truncate RAW content first, then escape and wrap.
- *
- * Never slice already-escaped HTML — that breaks entities (&amp; → &amp) and
- * leaves dangling tags. Truncate the RAW content first, then escape and wrap,
- * re-checking post-escape because escaping can expand (&→&amp;).
- * Mirrors the identical strategy in `_fitToCharBudget` (tool-activity-summary.ts).
- */
-function _fitWorkerBodyToCharBudget(body: string, lines: string[], rawNewestStep: string): string {
-  if (body.length <= STATUS_CARD_CHAR_BUDGET) return body
-  // lines[0] = header, lines[1] = status line, lines[2..] = step feed + optional rule/result
-  const fixed = lines.slice(0, 2)
-  const feed = lines.slice(2)
-  // Try dropping oldest feed lines until the output fits (keeping the newest).
-  // Re-insert a "+N earlier" overflow counter so users know steps were dropped —
-  // this also ensures the status line (lines[1], "running · elapsed · tools")
-  // is always preserved in `fixed` and never accidentally omitted from the output.
-  for (let drop = 1; drop < feed.length; drop++) {
-    const kept = feed.slice(drop)
-    const candidate = [...fixed, `<i>✓ +${drop} earlier…</i>`, ...kept].join('\n')
-    if (candidate.length <= STATUS_CARD_CHAR_BUDGET) return candidate
+  const header: Parameters<typeof renderStatusCard>[0]['header'] = {
+    emoji: '🛠',
+    label: 'Worker',
+    description: desc,
+    elapsedMs: v.elapsedMs,
+    toolCount: v.toolCount,
+    state: v.state,
   }
-  // Extreme: the newest feed line is itself oversized. Never slice the already-
-  // escaped HTML string — that splits entities (&amp;lt; → &amp;l, &amp;am…).
-  // Instead: truncate the RAW step content first, then escape and wrap, checking
-  // post-escape because escaping can expand the length (&→&amp;).
-  const newestLine = feed[feed.length - 1] ?? ''
-  const fixedJoined = fixed.join('\n')
-  const isBold = newestLine.startsWith('<b>')
-  const isItalic = newestLine.startsWith('<i>')
-  const openTag = isBold ? '<b>' : isItalic ? '<i>' : ''
-  const closeTag = isBold ? '</b>' : isItalic ? '</i>' : ''
-  const prefix = isBold ? '→ ' : isItalic ? '✓ ' : ''
-  const wrapperOverhead = openTag.length + prefix.length + closeTag.length
-  const overhead = fixedJoined.length + 1 // +1 for the \n joining fixed and newest
-  const maxNewest = Math.max(0, STATUS_CARD_CHAR_BUDGET - overhead)
-  // rawNewestStep may be '' on the back-compat path (latestSummary used instead
-  // of narrativeLines). In that case fall back to recovering raw text from the
-  // already-escaped newestLine by stripping its HTML tags.
-  const rawForTruncation =
-    rawNewestStep.length > 0
-      ? rawNewestStep
-      : newestLine.replace(/<[^>]+>/g, '').replace(/^[→✓]\s*/, '')
-  if (maxNewest > wrapperOverhead && rawForTruncation.length > 0) {
-    const maxRaw = maxNewest - wrapperOverhead
-    let raw = rawForTruncation.slice(0, maxRaw)
-    let escaped = escapeHtml(raw)
-    // Re-check post-escape: escaping can expand the string (& → &amp; etc.).
-    while (raw.length > 0 && wrapperOverhead + escaped.length > maxNewest) {
-      const excess = wrapperOverhead + escaped.length - maxNewest
-      raw = raw.slice(0, Math.max(0, raw.length - excess - 1))
-      escaped = escapeHtml(raw)
-    }
-    if (escaped.length > 0) {
-      return [fixedJoined, `${openTag}${prefix}${escaped}${closeTag}`].join('\n')
-    }
+
+  // Terminal: latestSummary carries the worker's final result text (gateway
+  // onFinish), distinct from the running narrative steps. Pass it as `result`.
+  let result: { emoji: string; text: string } | undefined
+  if (finished) {
+    const text = cleanWorkerResultParagraph(v.latestSummary)
+    if (text.length > 0) result = { emoji: v.state === 'done' ? '✅' : '⚠️', text }
   }
-  // Absolute last resort: just the fixed headers (budget too tight even for one char).
-  return fixedJoined
+
+  // `renderStatusCard` always returns content when a header is supplied. When
+  // running with no steps it shows just the header — append a "starting…" line
+  // for parity with the prior behaviour.
+  const card = renderStatusCard({
+    header,
+    steps,
+    final: finished,
+    liveSuffix: finished ? '' : liveSuffix,
+    result,
+  })
+  if (card == null) {
+    // Unreachable (header always present) — defensive.
+    return `🛠 <b>Worker</b> · <i>starting…</i>`
+  }
+  if (!finished && steps.length === 0) {
+    // Header-only running render → append the starting placeholder.
+    return `${card}\n<i>starting…</i>`
+  }
+  return card
 }
 
 export interface WorkerActivityFeedOpts {
@@ -277,6 +190,19 @@ export interface WorkerActivityFeedOpts {
   firstPaintMinMs?: number
   /** stderr-style log sink. Defaults to noop. */
   log?: (msg: string) => void
+  /**
+   * Heartbeat timer factory. Injectable for tests. Defaults to the real
+   * `setInterval`, `.unref()`'d so it never keeps the process alive.
+   */
+  setInterval?: (cb: () => void, ms: number) => unknown
+  /** Heartbeat timer disposer. Injectable for tests. Defaults to `clearInterval`. */
+  clearInterval?: (handle: unknown) => void
+  /**
+   * Heartbeat tick cadence in ms. On each tick a stale, running worker is
+   * re-rendered with a climbing `· Ns` suffix so a worker that emits no new
+   * narrative still visibly advances. Default 6000ms.
+   */
+  heartbeatTickMs?: number
 }
 
 interface WorkerHandle {
@@ -290,14 +216,20 @@ interface WorkerHandle {
   cooldownUntil: number
   /**
    * Accumulated narrative lines (oldest→newest), deduped against the
-   * immediately-preceding line. In no-truncate mode capped to
-   * STATUS_ROLLING_LINES (rolling window); in legacy mode to
-   * NARRATIVE_MAX_LINES. Grows the live render so the feed reads like the
-   * main agent's answer.
+   * immediately-preceding line. Rolling-window capped to STATUS_ROLLING_LINES.
+   * Grows the live render so the feed reads like the main agent's answer.
    */
   narrative: string[]
   /** Per-worker serialization chain so ticks can't interleave sends. */
   chain: Promise<void>
+  /** Last view rendered into the message (drives the heartbeat re-render). */
+  lastView: WorkerActivityView | null
+  /**
+   * Wall-clock ms the worker was dispatched, derived from `now - view.elapsedMs`
+   * on the first update. The heartbeat computes a live elapsed from this so the
+   * `· Ns` suffix climbs even when no fresh view arrives.
+   */
+  dispatchAtMs: number | null
 }
 
 const COOLDOWN_JITTER_MS = 500
@@ -331,6 +263,10 @@ export interface WorkerActivityFeed {
   finish(agentId: string, view: WorkerActivityView): Promise<void>
   /** Forget a worker's state without editing (e.g. error path). */
   drop(agentId: string): void
+  /** Clear the heartbeat interval (gateway shutdown). Idempotent. */
+  stop(): void
+  /** Manually fire one heartbeat tick (test hook). */
+  heartbeatTick(): void
   /** Number of tracked workers (test/inspection hook). */
   readonly size: number
 }
@@ -340,7 +276,18 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   const nowFn = opts.now ?? Date.now
   const minEditInterval = opts.minEditIntervalMs ?? 2500
   const firstPaintMin = opts.firstPaintMinMs ?? 8000
+  const heartbeatTickMs = opts.heartbeatTickMs ?? 6000
+  const setIntervalFn =
+    opts.setInterval ??
+    ((cb: () => void, ms: number): unknown => {
+      const t = setInterval(cb, ms)
+      // Never keep the process alive on the heartbeat alone.
+      ;(t as { unref?: () => void }).unref?.()
+      return t
+    })
+  const clearIntervalFn = opts.clearInterval ?? ((handle: unknown) => clearInterval(handle as ReturnType<typeof setInterval>))
   const handles = new Map<string, WorkerHandle>()
+  let heartbeatTimer: unknown = null
 
   function sendOptsFor(h: WorkerHandle): Record<string, unknown> {
     return {
@@ -364,27 +311,25 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     // same narrative across ticks while a tool runs; we only grow on change.
     if (h.narrative[h.narrative.length - 1] === line) return
     h.narrative.push(line)
-    if (statusNoTruncate()) {
-      // No-truncate mode: rolling window — keep only the last STATUS_ROLLING_LINES
-      // in memory. The render always shows exactly those lines (full content, no
-      // per-line clip). _fitWorkerBodyToCharBudget is the wire-limit backstop.
-      if (h.narrative.length > STATUS_ROLLING_LINES) {
-        h.narrative.splice(0, h.narrative.length - STATUS_ROLLING_LINES)
-      }
-    } else {
-      // Truncate mode: hard cap to NARRATIVE_MAX_LINES (original behaviour).
-      if (h.narrative.length > NARRATIVE_MAX_LINES) {
-        h.narrative.splice(0, h.narrative.length - NARRATIVE_MAX_LINES)
-      }
+    // Rolling window — keep only the last STATUS_ROLLING_LINES in memory. The
+    // render shows exactly those lines (clipped per-line by the unified pipeline);
+    // fitCardToBudget is the wire-limit backstop.
+    if (h.narrative.length > STATUS_ROLLING_LINES) {
+      h.narrative.splice(0, h.narrative.length - STATUS_ROLLING_LINES)
     }
   }
 
-  async function doUpdate(h: WorkerHandle, view: WorkerActivityView): Promise<void> {
+  async function doUpdate(h: WorkerHandle, view: WorkerActivityView, liveSuffix = ''): Promise<void> {
     // Accumulate before any gate so a throttled/cooled-down tick still grows
     // the narrative — the line surfaces on the next edit that does fire.
     accumulateNarrative(h, view)
+    // Stamp the dispatch wall-clock once so the heartbeat can climb a live
+    // elapsed even between fresh views. lastView feeds the heartbeat re-render.
+    const merged: WorkerActivityView = { ...view, narrativeLines: [...h.narrative] }
+    h.lastView = merged
+    if (h.dispatchAtMs == null) h.dispatchAtMs = nowFn() - view.elapsedMs
     if (nowFn() < h.cooldownUntil) return
-    const body = renderWorkerActivity({ ...view, narrativeLines: h.narrative })
+    const body = renderWorkerActivity(merged, liveSuffix)
 
     // First paint: hold off until the worker has run long enough to be
     // worth a message; trivial workers stay silent (handback covers them).
@@ -455,6 +400,44 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     }
   }
 
+  /**
+   * Heartbeat — option (a), suffix-only, NEVER opens a new message. For each
+   * handle with a posted message, enqueue a re-render through the existing
+   * chain → doUpdate path (never editMessageText directly). Skips:
+   *   - handles with no posted message (messageId == null),
+   *   - handles inside a 429 cooldown,
+   *   - handles edited within minEditInterval (no stampede),
+   *   - non-running handles (terminal/deleted).
+   * The `· Ns` liveSuffix is applied ONLY when the worker's current step is
+   * stale (now - lastEditAt >= heartbeatTickMs) so a normally-ticking worker is
+   * untouched and its body stays byte-stable for the dedup.
+   */
+  function heartbeatTick(): void {
+    const now = nowFn()
+    for (const h of handles.values()) {
+      if (h.messageId == null) continue
+      if (h.lastView == null) continue
+      if (h.lastView.state !== 'running') continue
+      if (now < h.cooldownUntil) continue
+      if (now - h.lastEditAt < minEditInterval) continue
+      const stale = now - h.lastEditAt >= heartbeatTickMs
+      if (!stale) continue
+      const liveElapsed = h.dispatchAtMs != null ? now - h.dispatchAtMs : h.lastView.elapsedMs
+      const liveSuffix = ' · ' + formatFeedElapsed(liveElapsed)
+      // Re-render THROUGH the chain + doUpdate path — never editMessageText directly.
+      const view = h.lastView
+      h.chain = h.chain
+        .then(() => doUpdate(h, view, liveSuffix))
+        .catch((err) => {
+          log(`worker-feed: heartbeat chain error ${h.agentId}: ${(err as Error).message}`)
+        })
+    }
+  }
+
+  // Arm the heartbeat once at construction. The real timer is `.unref()`'d so
+  // it never keeps the process alive; tests inject setInterval/clearInterval.
+  heartbeatTimer = setIntervalFn(heartbeatTick, heartbeatTickMs)
+
   return {
     has(agentId) {
       return handles.get(agentId)?.messageId != null
@@ -478,6 +461,8 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
           cooldownUntil: 0,
           narrative: [],
           chain: Promise.resolve(),
+          lastView: null,
+          dispatchAtMs: null,
         }
         handles.set(agentId, h)
       }
@@ -502,6 +487,13 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     },
     drop(agentId) {
       handles.delete(agentId)
+    },
+    heartbeatTick,
+    stop() {
+      if (heartbeatTimer != null) {
+        clearIntervalFn(heartbeatTimer)
+        heartbeatTimer = null
+      }
     },
   }
 }

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -88,12 +88,6 @@ export interface BotApiForWorkerFeed {
 
 /** Dispatch-time task description cap for the worker header. */
 const DESC_MAX = 80
-/**
- * Legacy narrative-line cap, kept exported for back-compat with importers.
- * The rolling window is now STATUS_ROLLING_LINES; this is no longer the active
- * cap but remains a documented constant some callers/tests still reference.
- */
-export const NARRATIVE_MAX_LINES = 6
 
 /**
  * Thin adapter over the unified `renderStatusCard` primitive (emoji 🛠, label


### PR DESCRIPTION
## Summary

Collapses the two live status surfaces — the 🤖 main-session **agent activity card** and the 🛠 background-**worker activity feed** — onto a single `renderStatusCard` primitive, and gives the worker a heartbeat so a long-running, quiet worker visibly advances.

**The collapse:**
- **One renderer, both surfaces call it.** `renderActivityFeed` / `renderActivityFeedWithNested` (agent) and `renderWorkerActivity` (worker) are now thin adapters over `renderStatusCard` in `tool-activity-summary.ts`. Header emoji 🤖 agent / 🛠 worker.
- **3 char-budget fitters → 1.** Deleted `_fitToCharBudget`, `_fitNestedToCharBudget`, and `_fitWorkerBodyToCharBudget`; one shared `fitCardToBudget`.
- **2 HTML escapers → 1.** Deleted `escapeFeedHtml` (byte-identical to `card-format.escapeHtml`); everything uses the one escaper.
- **`clipNarrative` dedup.** `subagent-watcher.ts` now routes its narrative clip through the shared `clipNarrative` primitive (was an inline `split('\n')[0].trim().slice(0,120)`).
- **Flag retired.** `SWITCHROOM_STATUS_NO_TRUNCATE` is gone — `statusNoTruncate()` deleted, `status-no-truncate.ts` is now a pure constants module (`STATUS_ROLLING_LINES=5`, `STATUS_LINE_MAX=200`, `STATUS_CARD_CHAR_BUDGET=4000`, `NESTED_PREFIX`).

**Deliberate default change** (called out per the principle checks): the rolling-window-with-`+N earlier…` behaviour and the per-line cap now apply on **BOTH** surfaces. The agent surface now shows `+N earlier…` on overflow (previously only the worker / legacy mode did), and **`STATUS_LINE_MAX=200` clips every line on both surfaces** in all modes (previously per-line clips were flag-gated, and the nested cap was 90).

**Truncation pipeline** (the #1 correctness risk — pinned by tests): per line, in order — `stripMarkdown` → collapse whitespace → `truncate(200)` → `escapeHtml`. **Escape is ALWAYS the last per-line op** so a clip can never split an HTML entity (`&amp;` → `&amp`). `fitCardToBudget`'s extreme single-oversized-line path truncates the RAW newest text, THEN escapes, THEN wraps, re-checking post-escape.

**Worker heartbeat** (option a — suffix-only, **never opens a new message**): one internal, `.unref()`'d `setInterval` (injectable for tests via `setInterval`/`clearInterval`/`heartbeatTickMs`) re-renders a stale, running worker **through the existing chain→doUpdate path** (never `editMessageText` directly) with a climbing ` · Ns` `liveSuffix`. Respects 429 cooldowns and `minEditInterval`; skips terminal/deleted handles; only applies the suffix when the current step is stale so a normally-ticking worker stays byte-stable for the dedup. Adds `WorkerActivityFeed.stop()`, wired into gateway shutdown (the feed is now module-scoped like `subagentWatcher`).

## Job / verdict

Serves **`reference/jobs/know-what-my-agent-is-doing.md`** (visibility outcome). Passes the consistency check by construction — the whole point is that the two status surfaces can no longer drift. No invariant crossed (`chat-is-the-single-source-of-truth` preserved: the heartbeat edits the existing message, opens nothing new).

## Test plan

- `cd telegram-plugin && bun test` (CI-scoped: `admin-commands gateway registry secret-detect tests channel-envelope-safety.test.ts`) — green; the affected + new files all pass.
- Updated `tests/tool-activity-summary.test.ts` and `tests/worker-activity-feed.test.ts`: deleted the legacy `='0'` mode tests, un-gated the rolling-window tests, asserted `+N earlier…` now appears on the AGENT surface, and pinned `STATUS_LINE_MAX=200` on both surfaces.
- New `tests/subagent-watcher-clip-narrative.test.ts`: multi-line narrative collapses to first line ≤120 via the shared `clipNarrative` (with a regression-equivalence check against the old inline expression).
- New `tests/status-card-budget-parity.test.ts`: same raw steps → byte-identical body on agent vs worker, including under the char-budget fitter.
- New escape-entity-not-split-mid-clip tests, an agent-flat-path-routes-through-the-shared-step-feed test, and the 5 worker-heartbeat scenarios (climbing suffix, 429 cooldown respected, cleared-on-finish, `stop()` clears + empty-tick no-op, `minEditInterval` respected) using the manual-clock + injected-timer pattern.
- Root `npm run lint` (tsc --noEmit + `check-plugin-references` full plugin tsc + bot-api wrapping) — clean.
- `npm run build` — compiles.

## CI gates

`ci-tests-plugin` + `uat-gate` are the relevant gates. The e2e / promote / uat-fuzz path-filtered jobs **skipping = pass** (this PR touches no docker/e2e paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)