### PR TITLE
chore(compose): raise per-profile memory defaults (default/conversational 3g, coding 4g, klanker 8g)

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -118,15 +118,20 @@ export interface ResourceDefaults {
 //   - cpus           CPU quota (Docker `cpus`).
 //
 // These are starting points; operators override per-agent via the
-// schema's `resources` block (PR #1190). Total host commitment under
-// the canonical 9-agent fleet (1 klanker + 8 conversational): 6 + 8×1.5
-// = 18 GB hard cap; 4 + 8×0.256 = ~6 GB protected from reclaim. Well
-// under the 60 GB host capacity, leaves plenty for Coolify co-tenants.
+// schema's `resources` block (PR #1190). memLimit is a hard cap
+// (cgroup memory.max), NOT a reservation — agents won't OOM-kill unless
+// they actually hit the ceiling. Raised 2026-06-25 after the 2026-06-24
+// incident where the 1.5g default cap OOM-killed the claude process
+// mid-turn during in-container bun+vitest builds. Worst-case total under
+// a 9-agent fleet (1 klanker + 8 conversational): 8 + 8×3 = 32 GB hard
+// cap; 4 + 8×0.256 = ~6 GB protected from reclaim. Well under the 60 GB
+// host capacity; overlord and other per-agent overrides are set separately
+// in switchroom.yaml and are not reflected here.
 const RESOURCE_BY_PROFILE: Record<string, ResourceDefaults> = {
-  klanker: { memLimit: "6g", memReservation: "4g", pidsLimit: 2000, cpus: 2.0 },
+  klanker: { memLimit: "8g", memReservation: "4g", pidsLimit: 2000, cpus: 2.0 },
   // Conversational profiles — clerk, finn, carrie, coach, etc.
   conversational: {
-    memLimit: "1.5g",
+    memLimit: "3g",
     memReservation: "256m",
     pidsLimit: 500,
     cpus: 1.0,
@@ -140,14 +145,14 @@ const RESOURCE_BY_PROFILE: Record<string, ResourceDefaults> = {
   },
   // Coding/worker/researcher.
   coding: {
-    memLimit: "2g",
+    memLimit: "4g",
     memReservation: "512m",
     pidsLimit: 1000,
     cpus: 2.0,
   },
   // Catch-all default.
   default: {
-    memLimit: "1.5g",
+    memLimit: "3g",
     memReservation: "256m",
     pidsLimit: 500,
     cpus: 1.0,

--- a/tests/cheap-cron-trim-resources.test.ts
+++ b/tests/cheap-cron-trim-resources.test.ts
@@ -92,13 +92,13 @@ describe("parseMemToMib", () => {
 describe("resolveResourceDefaults — cron-session bump", () => {
   it("no bump without cronSession (fleet default — byte-identical)", () => {
     const r = resolveResourceDefaults("clerk", "default");
-    expect(r.memLimit).toBe("1.5g");
+    expect(r.memLimit).toBe("3g");
     expect(r.pidsLimit).toBe(500);
   });
 
   it("bumps mem +512M and pids +128 for a cron-session agent on defaults", () => {
     const r = resolveResourceDefaults("clerk", "default", undefined, { cronSession: true });
-    expect(r.memLimit).toBe("2048m"); // 1536 + 512
+    expect(r.memLimit).toBe("3584m"); // 3072 + 512
     expect(r.pidsLimit).toBe(628); // 500 + 128
   });
 

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -327,17 +327,17 @@ describe("generateCompose", () => {
     expect(m).toBeLessThan(z);
   });
 
-  it("klanker gets 6g/4g reservation, 2000 PIDs, 2.0 cpus", () => {
+  it("klanker gets 8g/4g reservation, 2000 PIDs, 2.0 cpus", () => {
     const out = generateCompose({ config: makeConfig({ klanker: {} }) });
-    expect(out).toMatch(/agent-klanker:[\s\S]*?mem_limit: 6g/);
+    expect(out).toMatch(/agent-klanker:[\s\S]*?mem_limit: 8g/);
     expect(out).toMatch(/agent-klanker:[\s\S]*?mem_reservation: 4g/);
     expect(out).toMatch(/agent-klanker:[\s\S]*?pids_limit: 2000/);
     expect(out).toMatch(/agent-klanker:[\s\S]*?cpus: 2\.0/);
   });
 
-  it("conversational profile → 1.5g/256m, 500 PIDs, 1.0", () => {
+  it("conversational profile → 3g/256m, 500 PIDs, 1.0", () => {
     const out = generateCompose({ config: makeConfig({ coach: { extends: "conversational" } }) });
-    expect(out).toMatch(/agent-coach:[\s\S]*?mem_limit: 1\.5g/);
+    expect(out).toMatch(/agent-coach:[\s\S]*?mem_limit: 3g/);
     expect(out).toMatch(/agent-coach:[\s\S]*?mem_reservation: 256m/);
     expect(out).toMatch(/agent-coach:[\s\S]*?pids_limit: 500/);
     expect(out).toMatch(/agent-coach:[\s\S]*?cpus: 1\.0/);
@@ -351,17 +351,17 @@ describe("generateCompose", () => {
     expect(out).toMatch(/agent-ziggy:[\s\S]*?cpus: 0\.5/);
   });
 
-  it("coding profile → 2g/512m, 1000 PIDs, 2.0", () => {
+  it("coding profile → 4g/512m, 1000 PIDs, 2.0", () => {
     const out = generateCompose({ config: makeConfig({ worker: { extends: "coding" } }) });
-    expect(out).toMatch(/agent-worker:[\s\S]*?mem_limit: 2g/);
+    expect(out).toMatch(/agent-worker:[\s\S]*?mem_limit: 4g/);
     expect(out).toMatch(/agent-worker:[\s\S]*?mem_reservation: 512m/);
     expect(out).toMatch(/agent-worker:[\s\S]*?pids_limit: 1000/);
     expect(out).toMatch(/agent-worker:[\s\S]*?cpus: 2\.0/);
   });
 
-  it("unknown profile → default 1.5g/256m, 500 PIDs, 1.0", () => {
+  it("unknown profile → default 3g/256m, 500 PIDs, 1.0", () => {
     const out = generateCompose({ config: makeConfig({ misc: { extends: "made-up" } }) });
-    expect(out).toMatch(/agent-misc:[\s\S]*?mem_limit: 1\.5g/);
+    expect(out).toMatch(/agent-misc:[\s\S]*?mem_limit: 3g/);
     expect(out).toMatch(/agent-misc:[\s\S]*?mem_reservation: 256m/);
     expect(out).toMatch(/agent-misc:[\s\S]*?pids_limit: 500/);
     expect(out).toMatch(/agent-misc:[\s\S]*?cpus: 1\.0/);
@@ -384,7 +384,7 @@ describe("generateCompose", () => {
     });
     expect(out).toMatch(/agent-klanker:[\s\S]*?mem_reservation: 4g/);
     // and the existing mem_limit/cpus are still emitted
-    expect(out).toMatch(/agent-klanker:[\s\S]*?mem_limit: 6g/);
+    expect(out).toMatch(/agent-klanker:[\s\S]*?mem_limit: 8g/);
     expect(out).toMatch(/agent-klanker:[\s\S]*?cpus: 2\.0/);
   });
 
@@ -430,8 +430,8 @@ describe("generateCompose", () => {
     expect(out).toMatch(/agent-alice:[\s\S]*?mem_reservation: 192m/);
     expect(out).toMatch(/agent-alice:[\s\S]*?pids_limit: 300/);
     // memory still defaults — "tight" isn't in RESOURCE_BY_PROFILE so
-    // it falls through to the catch-all default 1.5g.
-    expect(out).toMatch(/agent-alice:[\s\S]*?mem_limit: 1\.5g/);
+    // it falls through to the catch-all default 3g.
+    expect(out).toMatch(/agent-alice:[\s\S]*?mem_limit: 3g/);
   });
 
   it("agent.resources.cpus overrides profile (fractional accepted)", () => {


### PR DESCRIPTION
## Summary

- Raises `memLimit` for four profiles in `RESOURCE_BY_PROFILE` (`src/agents/compose.ts`): `klanker` 6g→8g, `conversational` 1.5g→3g, `coding` 2g→4g, `default` 1.5g→3g. `lightweight` (1g) and all `memReservation`/`pidsLimit`/`cpus` values are unchanged.
- Updates the explanatory comment block above the map with accurate ceiling math and a note about the 2026-06-24 incident.
- Updates test assertions in `compose-generator.test.ts` and `cheap-cron-trim-resources.test.ts` to match the new values.

## Why

**2026-06-24 incident:** the 1.5g `memLimit` on the `default` profile OOM-killed the `claude` process mid-turn while agents ran in-container `bun+vitest` builds (agents run `@worker` build/test jobs inside their own containers). The hard cap was too tight for a full vitest run plus the agent's idle working set.

`memLimit` is a cgroup `memory.max` **ceiling**, not a reservation — the agent only hits it if it actually uses that much RAM. Raising it gives headroom without pre-allocating anything.

**Worst-case fleet ceiling** under the canonical 9-agent fleet (1 klanker + 8 conversational): 8 + 8×3 = **32 GB hard cap**. Well under the 60 GB host. The protected reservation total is unchanged (4 + 8×0.256 ≈ 6 GB).

**Per-agent overrides are unaffected.** `overlord` and other agents with explicit `resources:` blocks in `switchroom.yaml` supersede this map — do not touch those here.

**These defaults only take effect once released and a `switchroom apply` regenerates the compose file.**

## Test plan

- [x] `npm run lint` — clean (tsc + all lint scripts pass)
- [x] `vitest run tests/docker/compose-generator.test.ts tests/cheap-cron-trim-resources.test.ts` — 192 tests pass
- [x] `npm run build` — clean build
- [ ] CI required checks: `lint`, `vitest`, `bun-test`, `build-base`, `build-dependents ×5`

## Notes

- The `parseMemToMib` test cases (`"1.5g"` → 1536, `"6g"` → 6144) test the parser function and are deliberately unchanged.
- The cron-session +512 MiB bump on the `default` profile now yields `"3584m"` (3072 + 512) instead of `"2048m"` (1536 + 512) — updated in the test.
- Pre-existing failures in `scaffold.test.ts`, `doctor.mff.test.ts`, and `pending-inbound-buffer.test.ts` are environment-related (mount syscalls, git init inside container) and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)