### PR TITLE
feat(telegram): deterministic activity-card OPEN gating + reply-is-last ordering (#2556)

### DIFF
--- a/telegram-plugin/gateway/feed-open-gate.ts
+++ b/telegram-plugin/gateway/feed-open-gate.ts
@@ -43,11 +43,13 @@ export type FeedOpenProducer =
   /** Narrative SHOW (producer A): plain assistant text, no tool, no time
    *  threshold. May only EDIT, never OPEN, while the turn has 0 tool labels. */
   | 'narrative'
-  /** Tool label (producer B): the model dispatched a tool. Always OPEN-eligible.
+  /** Tool label (producer B): the model dispatched a tool. OPEN-eligible unless a
+   *  substantive final already landed (lever 1).
    *  Foreground sub-agent renders (a Task tool) are tool work too → 'tool'. */
   | 'tool'
   /** Liveness timer (producer C): a genuine ≥12s thinking-gap open, or the
-   *  labelled-feed heartbeat maintaining an open card. Always OPEN-eligible. */
+   *  labelled-feed heartbeat maintaining an open card. OPEN-eligible unless a
+   *  substantive final already landed (lever 1). */
   | 'liveness'
 
 export interface FeedOpenInput {

--- a/telegram-plugin/gateway/feed-open-gate.ts
+++ b/telegram-plugin/gateway/feed-open-gate.ts
@@ -1,0 +1,83 @@
+/**
+ * Feed-OPEN gate (deterministic activity-card OPEN gating).
+ *
+ * Pure decision: the activity-card drain (`drainActivitySummary`) is about to
+ * OPEN a brand-new card (`activityMessageId == null` → a fresh `sendMessage`).
+ * Should it be allowed to? This module encodes the two OPEN-suppression levers
+ * from `docs/message-emission-determinism.md` §9, so the gateway has ONE place
+ * to reason about WHEN a card may first appear on screen.
+ *
+ * Only the OPEN (first `sendMessage`) is gated. An EDIT of an already-open card
+ * (`activityMessageId != null`) is never blocked — once a card exists it must
+ * keep rendering, and an edit never reorders on screen.
+ *
+ * ## Lever 1 — no card OPEN after a substantive final (§9 lever 1, race A/B/E)
+ *
+ * Once a *substantive* final answer has been delivered this turn, no new card
+ * may open — it would land below the reply (higher message_id) and break the
+ * scoped "reply is last" invariant (§6). This keys on the STICKY
+ * `finalAnswerEverDelivered` latch, NOT the mutable `finalAnswerDelivered`
+ * (which the ack-reopen path clears mid-turn, `feed-reopen-gate.ts:157`). Keying
+ * on the mutable flag would be a no-op on exactly the ack-first turn where the
+ * reorder originates (design §9 preamble / R0). The sticky latch is set once a
+ * substantive final lands and is never cleared by reopen — so an "On it…" ack
+ * (non-substantive) does NOT trip it and the #2141 ack-then-work feed still
+ * opens.
+ *
+ * ## Lever 5 base case — narrative-SHOW alone must not OPEN (§9 lever 5, G1)
+ *
+ * The triplication: a 0-tool conversational turn opened a full card from
+ * narration text alone. Rule: the narrative-SHOW producer (A) may only EDIT an
+ * already-open card, never OPEN one. Only a tool label (producer B) or the
+ * liveness timer (producer C, a genuine ≥12s thinking-gap) may OPEN a card.
+ *
+ * So a narrative-SHOW-triggered OPEN is refused while the turn has surfaced ZERO
+ * tool labels (`labeledToolCount === 0`). Once a tool label arrives
+ * (`labeledToolCount > 0`) the card opens and the accumulated narration renders;
+ * a turn that starts conversational then dispatches a tool DOES open (R4). The
+ * liveness path (producer C) is exempt — it owns the genuine thinking-gap open.
+ */
+
+/** Which producer triggered this drain — determines lever-5 OPEN eligibility. */
+export type FeedOpenProducer =
+  /** Narrative SHOW (producer A): plain assistant text, no tool, no time
+   *  threshold. May only EDIT, never OPEN, while the turn has 0 tool labels. */
+  | 'narrative'
+  /** Tool label (producer B): the model dispatched a tool. Always OPEN-eligible.
+   *  Foreground sub-agent renders (a Task tool) are tool work too → 'tool'. */
+  | 'tool'
+  /** Liveness timer (producer C): a genuine ≥12s thinking-gap open, or the
+   *  labelled-feed heartbeat maintaining an open card. Always OPEN-eligible. */
+  | 'liveness'
+
+export interface FeedOpenInput {
+  /** Which producer triggered the drain (see FeedOpenProducer). */
+  producer: FeedOpenProducer
+  /** Sticky latch: has a *substantive* final answer ever been delivered this
+   *  turn? Set once and never cleared by reopen (lever 1 / R0). */
+  finalAnswerEverDelivered: boolean
+  /** Count of surfaced tool steps this turn (`turn.labeledToolCount`). 0 means
+   *  no tool has ever produced a label — pure conversation / thinking. */
+  labeledToolCount: number
+}
+
+/**
+ * Pure. Given the drain is about to OPEN a fresh card, returns true when the
+ * OPEN is allowed. An EDIT (caller has a non-null `activityMessageId`) does NOT
+ * consult this — only the OPEN branch does.
+ *
+ *  - finalAnswerEverDelivered → false: lever 1. A substantive final already
+ *    landed; no card may open below it (any producer).
+ *  - producer 'narrative' && labeledToolCount === 0 → false: lever 5 base case.
+ *    Narration alone on a 0-tool turn may not open a card (the triplication).
+ *  - producer 'tool' → true (unless lever 1): a real tool dispatched → open.
+ *  - producer 'liveness' → true (unless lever 1): the genuine thinking-gap open
+ *    (producer C) is untouched by lever 5.
+ */
+export function mayOpenActivityCard(input: FeedOpenInput): boolean {
+  // Lever 1 — sticky: nothing opens after a substantive final answer.
+  if (input.finalAnswerEverDelivered) return false
+  // Lever 5 base case — narrative SHOW alone on a 0-tool turn may not OPEN.
+  if (input.producer === 'narrative' && input.labeledToolCount === 0) return false
+  return true
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -10356,7 +10356,13 @@ async function drainActivitySummary(
       // stays pending so a later OPEN-eligible producer (a tool label, or
       // liveness) renders it. An EDIT (activityMessageId != null) is never
       // gated. Enforced HERE so it covers BOTH the inline producers AND the
-      // detached heartbeat setInterval drain (R7/concurrency).
+      // detached heartbeat setInterval drain (R7/concurrency). The gate guards
+      // gate EVALUATION, not an in-flight send: it is not a hard mutex — a send
+      // already PAST this check and suspended at its `await robustApiCall(
+      // sendMessage)` when a substantive final lands still completes and opens a
+      // card; that residual is reconciled by lever-2's `clearActivitySummary`
+      // chaining its finalize onto `turn.activityInFlight` (the suspended drain)
+      // and editing the card in place, not by this gate blocking it.
       if (
         turn.activityMessageId == null
         && !mayOpenActivityCard({

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -335,6 +335,7 @@ import { purgeStaleTurnsForChat } from './turn-state-purge.js'
 import { decideInboundDelivery } from './inbound-delivery-gate.js'
 import { mayDrainBufferedInbound, shouldArmNoReplyDrain } from './serialize-drain-gate.js'
 import { decideFeedReopen } from './feed-reopen-gate.js'
+import { mayOpenActivityCard, type FeedOpenProducer } from './feed-open-gate.js'
 import { resolveAnswerThreadId } from './answer-thread-resolve.js'
 import {
   createDeliveryQueue,
@@ -1940,6 +1941,18 @@ type CurrentTurn = {
   // Reset to false on every fresh-turn enqueue alongside
   // `finalAnswerDelivered`.
   finalAnswerSubstantive: boolean
+  // Sticky "a substantive final answer has been delivered this turn" latch
+  // (design `docs/message-emission-determinism.md` §9 preamble / R0). Distinct
+  // from the MUTABLE `finalAnswerDelivered`, which the ack-reopen path clears
+  // mid-turn (`feed-reopen-gate.ts:157`) so an "On it…" ack keeps a live feed
+  // (#2141). Ordering gates (the no-OPEN-after-final card gate, lever 1) MUST
+  // key on this sticky latch, not the mutable flag — keying on the mutable flag
+  // is a no-op on exactly the ack-first turn where the reorder originates. Set
+  // true ONLY at the points that set `finalAnswerDelivered = true` AND only when
+  // the reply is `isSubstantiveFinalReply`; NEVER cleared by reopen. Reset to
+  // false ONLY at turn start, mirroring `activityEverOpened`'s sticky-true
+  // contract.
+  finalAnswerEverDelivered: boolean
   // #1675 (over-ping safety net): wall-clock ms of the first reply
   // this turn that landed with `disable_notification: false` (a real
   // device ping). The conversational-pacing contract
@@ -7889,6 +7902,26 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     clearSilentEndState(statusKey(chat_id, threadId))
   }
 
+  // Lever 2 (design §9 lever 2): finalize the activity card BEFORE the reply
+  // chunks send, so the card keeps its (lower) message_id and the reply is
+  // structurally last on screen. ONLY for a *substantive* final — for an ack
+  // (non-substantive) do NOTHING: finalizing an ack early would
+  // close → reopen → emit MORE messages (the #2141 ack-then-work feed, R3).
+  // `clearActivitySummary` edits the existing card in place (no new send) and
+  // nulls `activityMessageId`; combined with the sticky latch set here it
+  // prevents any post-reply re-OPEN below the answer. Idempotent with the
+  // tool_use-event clear at the first-reply handoff (the existing backstop).
+  {
+    const finalizeTurn = currentTurn
+    if (
+      finalizeTurn != null
+      && isSubstantiveFinalReply({ text: rawText, disableNotification: modelDisableNotification })
+    ) {
+      finalizeTurn.finalAnswerEverDelivered = true
+      clearActivitySummary(finalizeTurn)
+    }
+  }
+
   if (previewMessageId != null && reply_to != null && replyMode !== 'off') {
     await deleteStalePreview(previewMessageId)
     previewMessageId = null
@@ -8006,6 +8039,9 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
               text: decision.mergedText,
               disableNotification: modelDisableNotification,
             })
+            // Sticky ordering latch (lever 1): a substantive final closes the
+            // card OPEN gate for the rest of the turn. NEVER cleared by reopen.
+            if (turn.finalAnswerSubstantive) turn.finalAnswerEverDelivered = true
             if (turn.finalAnswerSubstantive) closeObligationOnSubstantiveReply(args, turn, replyRoutedOriginTurn)
           }
           outboundDedup.record(
@@ -8350,6 +8386,10 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
       // (≥200 chars or stream-done — not a short pinging ack) so post-answer
       // housekeeping tool work does NOT re-open the feed / trip silent-end.
       turn.finalAnswerSubstantive = isSubstantiveFinalReply({ text: rawText, disableNotification: modelDisableNotification })
+      // Sticky ordering latch (lever 1): set once a SUBSTANTIVE final lands;
+      // never cleared by reopen. The card OPEN gate keys on this, not the
+      // mutable finalAnswerDelivered above (which reopen toggles).
+      if (turn.finalAnswerSubstantive) turn.finalAnswerEverDelivered = true
       // #1728: release the buffer gate + emit terminal 👍. Mid-turn
       // acks bypass this branch and remain non-events for the
       // reaction (preserves #1713). The full turn-state teardown
@@ -8582,6 +8622,25 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
     }
   }
 
+  // Lever 2 (design §9 lever 2): finalize the activity card BEFORE the stream
+  // send so the card keeps its lower message_id and the reply is structurally
+  // last. ONLY for a *substantive* final (a stream_reply done=true or ≥200
+  // chars) — for a short pinging interim chunk do NOTHING (finalizing an ack
+  // early would close → reopen → emit more, the #2141 ack-then-work feed, R3).
+  // `clearActivitySummary` edits in place + nulls activityMessageId; the sticky
+  // latch set here blocks any post-reply re-OPEN below the answer.
+  if (
+    turn != null
+    && isSubstantiveFinalReply({
+      text: (args.text as string | undefined) ?? '',
+      disableNotification: args.disable_notification === true,
+      done: args.done === true,
+    })
+  ) {
+    turn.finalAnswerEverDelivered = true
+    clearActivitySummary(turn)
+  }
+
   const result = await handleStreamReply(
     {
       chat_id: streamChatId,
@@ -8736,6 +8795,9 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       disableNotification: args.disable_notification === true,
       done: args.done === true,
     })
+    // Sticky ordering latch (lever 1): set once a SUBSTANTIVE final lands;
+    // never cleared by reopen. The card OPEN gate keys on this sticky latch.
+    if (turn.finalAnswerSubstantive) turn.finalAnswerEverDelivered = true
     if (turn.finalAnswerSubstantive) closeObligationOnSubstantiveReply(args, turn, streamRoutedOriginTurn)
     // #1744 follow-up — stream_reply edge case. The first-emit gate at
     // L5178 only clears silent-end state on the FIRST emit of a stream.
@@ -10197,7 +10259,12 @@ function showNarrativeStep(turn: CurrentTurn, text: string): void {
   if (rendered == null) return
   turn.activityPendingRender = composeTurnActivity(turn) ?? rendered
   if (turn.activityInFlight == null) {
-    turn.activityInFlight = drainActivitySummary(turn)
+    // Producer A (narrative SHOW): may only EDIT an already-open card, never
+    // OPEN one on a 0-tool turn (design §9 lever 5 base case — the
+    // triplication). The OPEN gate in the drain enforces this; accumulation
+    // into mirrorLines still happens so the narration renders once a tool
+    // label or liveness opens the card.
+    turn.activityInFlight = drainActivitySummary(turn, 'narrative')
   }
 }
 
@@ -10269,11 +10336,37 @@ function flushPendingNarrativeAtTurnEnd(turn: CurrentTurn, lastReplyText: string
  * doesn't corrupt the next turn's atom — late writes land on the
  * captured `turn` (already-completed turn, harmless).
  */
-async function drainActivitySummary(turn: CurrentTurn): Promise<void> {
+async function drainActivitySummary(
+  turn: CurrentTurn,
+  // Which producer triggered this drain (design §9 levers 1 + 5). Gates the
+  // OPEN (first sendMessage) branch via `mayOpenActivityCard`; EDITs of an
+  // already-open card are never gated. Defaults to 'tool' — the historically
+  // unconditional OPEN behaviour — so any caller that does not opt into the
+  // gate is unaffected. Narrative-SHOW and liveness callers pass their producer
+  // explicitly.
+  producer: FeedOpenProducer = 'tool',
+): Promise<void> {
   try {
     while (turn.activityPendingRender !== turn.activityLastSentRender) {
       const target = turn.activityPendingRender
       if (target == null) break
+      // OPEN gate (design §9 levers 1 + 5): when this drain would OPEN a fresh
+      // card (activityMessageId == null), consult the pure gate. Refusing an
+      // OPEN must NOT advance activityLastSentRender — the accumulated render
+      // stays pending so a later OPEN-eligible producer (a tool label, or
+      // liveness) renders it. An EDIT (activityMessageId != null) is never
+      // gated. Enforced HERE so it covers BOTH the inline producers AND the
+      // detached heartbeat setInterval drain (R7/concurrency).
+      if (
+        turn.activityMessageId == null
+        && !mayOpenActivityCard({
+          producer,
+          finalAnswerEverDelivered: turn.finalAnswerEverDelivered,
+          labeledToolCount: turn.labeledToolCount,
+        })
+      ) {
+        break
+      }
       // `renderActivityFeed` already emitted ready Telegram HTML with per-line
       // markup (<b>→ current</b> / <i>✓ done</i>) and escaped each label's
       // <,>,& itself (#1942 class) — send verbatim, do NOT re-escape or
@@ -10368,7 +10461,10 @@ function feedHeartbeatTick(): void {
     if (rendered == null) return
     turn.activityPendingRender = rendered
     if (turn.activityInFlight == null) {
-      turn.activityInFlight = drainActivitySummary(turn)
+      // Producer C (liveness timer): the genuine ≥12s thinking-gap open. This
+      // is the ONE producer that may OPEN a 0-tool card (design §9 lever 5
+      // preserves it). The sticky-latch (lever 1) still gates it in the drain.
+      turn.activityInFlight = drainActivitySummary(turn, 'liveness')
     }
     return
   }
@@ -10382,7 +10478,9 @@ function feedHeartbeatTick(): void {
   if (rendered == null) return
   turn.activityPendingRender = rendered
   if (turn.activityInFlight == null) {
-    turn.activityInFlight = drainActivitySummary(turn)
+    // Maintains an already-open card (guarded above on activityMessageId !=
+    // null) → only ever EDITs. 'liveness' is correct either way.
+    turn.activityInFlight = drainActivitySummary(turn, 'liveness')
   }
 }
 if (!STATIC && FEED_HEARTBEAT_ENABLED) {
@@ -10532,6 +10630,8 @@ function handleSessionEvent(ev: SessionEvent): void {
           replyCalled: false,
           finalAnswerDelivered: false,
           finalAnswerSubstantive: false,
+          // Sticky latch — reset ONLY here (turn start), never by reopen.
+          finalAnswerEverDelivered: false,
           firstPingAt: null,
           silentAnchorMessageId: null,
           silentAnchorText: '',
@@ -10860,7 +10960,11 @@ function handleSessionEvent(ev: SessionEvent): void {
         // == the flat render when no foreground sub-agent is active.
         turn.activityPendingRender = composeTurnActivity(turn) ?? rendered
         if (turn.activityInFlight == null) {
-          turn.activityInFlight = drainActivitySummary(turn)
+          // Producer B (tool label): always OPEN-eligible (labeledToolCount was
+          // incremented just above). A turn that started conversational and now
+          // dispatches a tool opens here, rendering any narration accumulated
+          // by the suppressed narrative-SHOW drains (design §9 lever 5 / R4).
+          turn.activityInFlight = drainActivitySummary(turn, 'tool')
         }
       }
       return

--- a/telegram-plugin/tests/emission-determinism-wiring.test.ts
+++ b/telegram-plugin/tests/emission-determinism-wiring.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Emission-determinism wiring — structural (source-read) assertions for the
+ * deterministic activity-card OPEN gating + reply-is-last ordering changes
+ * (design `docs/message-emission-determinism.md` §9 levers 1, 2, 5; #2556).
+ *
+ * The gateway IIFE can't be instantiated in-process, so these pin the
+ * load-bearing wiring by reading gateway.ts source — same pattern as
+ * activity-ever-opened-sticky.test.ts / feed-heartbeat-liveness-open.test.ts.
+ * The pure decision logic (mayOpenActivityCard) is exercised behaviourally in
+ * feed-open-gate.test.ts; this file guards that the gateway is wired to it.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const gatewaySrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf-8',
+)
+
+/** Source of `drainActivitySummary` up to the next top-level function. */
+function drainSrc(): string {
+  const after = gatewaySrc.split('async function drainActivitySummary(')[1] ?? ''
+  return after.split('\nasync function ')[0]?.split('\nfunction ')[0] ?? after
+}
+
+describe('sticky finalAnswerEverDelivered latch (lever 1 precondition / R0)', () => {
+  it('is initialised false in the turn object literal (per-turn reset at turn start)', () => {
+    expect(gatewaySrc).toMatch(/finalAnswerEverDelivered:\s*false/)
+  })
+
+  it('is reset to false in exactly ONE place — the turn initialiser (never cleared by reopen)', () => {
+    // Mirrors activityEverOpened's sticky-true contract: the only `false` is the
+    // per-turn init. A standalone `= false` reassignment would let reopen clear
+    // the latch and reintroduce the reorder (the R0 correction).
+    const initFalse = [...gatewaySrc.matchAll(/finalAnswerEverDelivered:\s*false/g)]
+    expect(initFalse).toHaveLength(1)
+    const resetFalse = [...gatewaySrc.matchAll(/finalAnswerEverDelivered\s*=\s*false/g)]
+    expect(resetFalse).toHaveLength(0)
+  })
+
+  it('feed-reopen-gate.ts resets only the MUTABLE flag, never the sticky latch (#2141 preserved)', () => {
+    const reopenSrc = readFileSync(
+      resolve(__dirname, '..', 'gateway', 'feed-reopen-gate.ts'),
+      'utf-8',
+    )
+    expect(reopenSrc).toMatch(/finalAnswerDelivered:\s*false/)
+    expect(reopenSrc).not.toMatch(/finalAnswerEverDelivered/)
+  })
+
+  it('every site that sets the sticky latch true gates on finalAnswerSubstantive', () => {
+    // The latch is set true only at the points that set finalAnswerDelivered=true,
+    // and only when the reply was substantive — so an ack never latches it.
+    const setTrue = [...gatewaySrc.matchAll(/finalAnswerEverDelivered\s*=\s*true/g)]
+    // executeReply, executeStreamReply, silent-anchor merge, + the two lever-2
+    // finalize blocks (which are themselves substantive-gated).
+    expect(setTrue.length).toBeGreaterThanOrEqual(3)
+    // Each `finalAnswerEverDelivered = true` must sit in a substantive context:
+    // either guarded by `if (turn.finalAnswerSubstantive)` or inside an
+    // `isSubstantiveFinalReply(...)` branch. Assert the substantive-gating
+    // token co-occurs (no bare unconditional latch set).
+    const bareUnconditional = [
+      ...gatewaySrc.matchAll(/\n\s*(?:turn|finalizeTurn)\.finalAnswerEverDelivered\s*=\s*true/g),
+    ]
+    for (const m of bareUnconditional) {
+      const idx = m.index ?? 0
+      const window = gatewaySrc.slice(Math.max(0, idx - 600), idx)
+      expect(
+        /finalAnswerSubstantive/.test(window) || /isSubstantiveFinalReply/.test(window),
+      ).toBe(true)
+    }
+  })
+})
+
+describe('drainActivitySummary OPEN gate (levers 1 + 5, heartbeat-covered)', () => {
+  it('consults mayOpenActivityCard in the OPEN branch (activityMessageId == null)', () => {
+    const src = drainSrc()
+    expect(src).toMatch(/mayOpenActivityCard\(/)
+    // The gate is keyed on the sticky latch + labeledToolCount + producer.
+    expect(src).toMatch(/finalAnswerEverDelivered:\s*turn\.finalAnswerEverDelivered/)
+    expect(src).toMatch(/labeledToolCount:\s*turn\.labeledToolCount/)
+    expect(src).toMatch(/producer/)
+  })
+
+  it('refusing an OPEN does NOT advance activityLastSentRender (break, not mark-sent)', () => {
+    // The gate check must `break` out of the drain loop when an OPEN is refused,
+    // BEFORE the activityLastSentRender = target write — otherwise the
+    // accumulated render is marked sent and a later OPEN-eligible producer
+    // (a tool label) skips it via the `pending !== lastSent` guard.
+    const src = drainSrc()
+    const gateIdx = src.indexOf('mayOpenActivityCard(')
+    const lastSentIdx = src.indexOf('activityLastSentRender = target')
+    expect(gateIdx).toBeGreaterThan(-1)
+    expect(lastSentIdx).toBeGreaterThan(-1)
+    expect(gateIdx).toBeLessThan(lastSentIdx)
+    // A `break` follows the gate check.
+    const afterGate = src.slice(gateIdx, lastSentIdx)
+    expect(afterGate).toMatch(/break/)
+  })
+
+  it('the gate only applies to the OPEN branch — guarded on activityMessageId == null', () => {
+    const src = drainSrc()
+    const gateIdx = src.indexOf('mayOpenActivityCard(')
+    const window = src.slice(Math.max(0, gateIdx - 200), gateIdx)
+    expect(window).toMatch(/activityMessageId == null/)
+  })
+})
+
+describe('drain producers — narrative may not OPEN, liveness + tool may', () => {
+  it('showNarrativeStep drains with producer "narrative" (lever 5 base case)', () => {
+    const after = gatewaySrc.split('function showNarrativeStep(')[1] ?? ''
+    const body = after.split('\nfunction ')[0] ?? after
+    expect(body).toMatch(/drainActivitySummary\(turn,\s*'narrative'\)/)
+  })
+
+  it('the liveness-open path drains with producer "liveness" (producer C preserved)', () => {
+    const after = gatewaySrc.split('function feedHeartbeatTick(')[1] ?? ''
+    const body = after.split('\nfunction ')[0] ?? after
+    expect(body).toMatch(/drainActivitySummary\(turn,\s*'liveness'\)/)
+  })
+
+  it('the tool_label path drains with producer "tool" (always OPEN-eligible)', () => {
+    expect(gatewaySrc).toMatch(/drainActivitySummary\(turn,\s*'tool'\)/)
+  })
+})
+
+describe('lever 2 — finalize the card BEFORE a substantive reply send', () => {
+  /** executeReply body up to executeStreamReply. */
+  function executeReplySrc(): string {
+    const after = gatewaySrc.split('async function executeReply(')[1] ?? ''
+    return after.split('async function executeStreamReply(')[0] ?? after
+  }
+  /** executeStreamReply body up to the next top-level function. */
+  function executeStreamReplySrc(): string {
+    const after = gatewaySrc.split('async function executeStreamReply(')[1] ?? ''
+    return after.split('\nasync function ')[0]?.split('\nfunction ')[0] ?? after
+  }
+
+  it('executeReply finalizes (clearActivitySummary) before the chunk loop, gated on substantive', () => {
+    const src = executeReplySrc()
+    const clearIdx = src.indexOf('clearActivitySummary(')
+    const loopIdx = src.indexOf('for (let i = 0; i < chunks.length')
+    expect(clearIdx).toBeGreaterThan(-1)
+    expect(loopIdx).toBeGreaterThan(-1)
+    expect(clearIdx).toBeLessThan(loopIdx)
+    // The finalize is substantive-gated (acks do nothing — R3/#2141).
+    const window = src.slice(Math.max(0, clearIdx - 500), clearIdx)
+    expect(window).toMatch(/isSubstantiveFinalReply/)
+  })
+
+  it('executeStreamReply finalizes before handleStreamReply, gated on substantive', () => {
+    const src = executeStreamReplySrc()
+    const clearIdx = src.indexOf('clearActivitySummary(')
+    const sendIdx = src.indexOf('const result = await handleStreamReply(')
+    expect(clearIdx).toBeGreaterThan(-1)
+    expect(sendIdx).toBeGreaterThan(-1)
+    expect(clearIdx).toBeLessThan(sendIdx)
+    const window = src.slice(Math.max(0, clearIdx - 500), clearIdx)
+    expect(window).toMatch(/isSubstantiveFinalReply/)
+  })
+
+  it('acks do NOT finalize early — no unconditional clearActivitySummary before the reply send', () => {
+    // Both lever-2 finalize sites sit inside an isSubstantiveFinalReply guard.
+    // An ack (non-substantive) falls through and never finalizes early, so the
+    // reopen path keeps owning the card (the #2141 ack-then-work feed).
+    const replySrc = (() => {
+      const after = gatewaySrc.split('async function executeReply(')[1] ?? ''
+      return after.split('async function executeStreamReply(')[0] ?? after
+    })()
+    // The pre-loop clearActivitySummary must be the substantive-gated one.
+    const preLoop = replySrc.split('for (let i = 0; i < chunks.length')[0] ?? ''
+    const clears = [...preLoop.matchAll(/clearActivitySummary\(/g)]
+    expect(clears).toHaveLength(1)
+  })
+})

--- a/telegram-plugin/tests/feed-open-gate.test.ts
+++ b/telegram-plugin/tests/feed-open-gate.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+
+import { mayOpenActivityCard } from '../gateway/feed-open-gate.js'
+
+/**
+ * Feed-OPEN gate — pure decision (design `docs/message-emission-determinism.md`
+ * §9 levers 1 + 5). Gates WHEN the activity card may first OPEN (fresh
+ * sendMessage). An EDIT of an already-open card is never routed through this
+ * (the drain only consults it when activityMessageId == null).
+ *
+ * Lever 5 base case (the triplication fix): a narrative-SHOW producer alone on
+ * a 0-tool turn must NOT open a card. A tool label DOES open. The liveness
+ * timer (genuine ≥12s thinking-gap) still opens a 0-tool card.
+ *
+ * Lever 1 (reply-is-last): once a SUBSTANTIVE final answer has been delivered
+ * (the sticky finalAnswerEverDelivered latch), no card may open below it — for
+ * ANY producer. The latch is NOT the mutable finalAnswerDelivered (reopen
+ * clears that mid-turn, #2141); an ack does not set it, so the ack-then-work
+ * feed still opens.
+ */
+describe('mayOpenActivityCard — lever 5 base case (narrative-SHOW alone must not OPEN)', () => {
+  it('narrative SHOW on a 0-tool turn does NOT open a card (the triplication)', () => {
+    expect(
+      mayOpenActivityCard({
+        producer: 'narrative',
+        finalAnswerEverDelivered: false,
+        labeledToolCount: 0,
+      }),
+    ).toBe(false)
+  })
+
+  it('a tool label DOES open a card (producer B)', () => {
+    expect(
+      mayOpenActivityCard({
+        producer: 'tool',
+        finalAnswerEverDelivered: false,
+        labeledToolCount: 1,
+      }),
+    ).toBe(true)
+  })
+
+  it('the liveness timer DOES open a 0-tool thinking-gap card (producer C, preserved)', () => {
+    expect(
+      mayOpenActivityCard({
+        producer: 'liveness',
+        finalAnswerEverDelivered: false,
+        labeledToolCount: 0,
+      }),
+    ).toBe(true)
+  })
+
+  it('narrative SHOW once a tool label has landed DOES open (the accumulated narration renders; R4)', () => {
+    // A turn that starts conversational then dispatches a tool: labeledToolCount
+    // is now > 0, so even a narrative-driven drain may open and render the
+    // accumulated narration.
+    expect(
+      mayOpenActivityCard({
+        producer: 'narrative',
+        finalAnswerEverDelivered: false,
+        labeledToolCount: 1,
+      }),
+    ).toBe(true)
+  })
+})
+
+describe('mayOpenActivityCard — lever 1 (no OPEN after a substantive final)', () => {
+  it('blocks a tool-label OPEN after a substantive final (race A/B/E)', () => {
+    expect(
+      mayOpenActivityCard({
+        producer: 'tool',
+        finalAnswerEverDelivered: true,
+        labeledToolCount: 3,
+      }),
+    ).toBe(false)
+  })
+
+  it('blocks a liveness OPEN after a substantive final', () => {
+    expect(
+      mayOpenActivityCard({
+        producer: 'liveness',
+        finalAnswerEverDelivered: true,
+        labeledToolCount: 0,
+      }),
+    ).toBe(false)
+  })
+
+  it('blocks a narrative OPEN after a substantive final', () => {
+    expect(
+      mayOpenActivityCard({
+        producer: 'narrative',
+        finalAnswerEverDelivered: true,
+        labeledToolCount: 2,
+      }),
+    ).toBe(false)
+  })
+
+  it('does NOT block when no substantive final yet — an ack (latch false) leaves opening allowed (#2141)', () => {
+    // An ack sets finalAnswerDelivered (mutable) but NOT the sticky latch, so
+    // a post-ack tool label still opens the reopened feed.
+    expect(
+      mayOpenActivityCard({
+        producer: 'tool',
+        finalAnswerEverDelivered: false,
+        labeledToolCount: 1,
+      }),
+    ).toBe(true)
+  })
+})

--- a/telegram-plugin/tests/reply-terminal-reaction.test.ts
+++ b/telegram-plugin/tests/reply-terminal-reaction.test.ts
@@ -81,7 +81,12 @@ describe('#1713 + #1728 — reply tool reaction contract', () => {
     )
     const anchor = src.indexOf("fresh sendMessage from reply tool is a user-visible")
     expect(anchor).toBeGreaterThan(-1)
-    const slice = src.slice(anchor, anchor + 3000)
+    // Window widened 3000 → 4000 (#2556): the deterministic-emission lever-1
+    // sticky-latch set + comment lives inside the post-send isFinalAnswerReply
+    // branch between this anchor and finalizeStatusReaction, growing the block
+    // past the old 3000-char window. The assertion's INTENT is unchanged —
+    // finalize present, gated by isFinalAnswerReply, and after the gate.
+    const slice = src.slice(anchor, anchor + 4000)
     // The finalize MUST appear in the post-send block.
     expect(slice).toMatch(/finalizeStatusReaction\(/)
     // It MUST be gated by isFinalAnswerReply (the classifier prevents

--- a/telegram-plugin/uat/assertions.ts
+++ b/telegram-plugin/uat/assertions.ts
@@ -66,6 +66,95 @@ export function isActivityFeedMessage(m: ObservedMessage): boolean {
   return lines.every((l) => ACTIVITY_FEED_LINE_RE.test(l));
 }
 
+/**
+ * True when `m` is the agent's actual answer (the foreground reply) — sender is
+ * the bot (not the driver), it's an original send (not an edit), and it is
+ * neither a worker-feed nor an activity-feed surface, with non-empty text.
+ * Promoted here from the cross-surface fuzz scenario so `assertReplyIsLast` and
+ * any scenario can share one definition of "this is the answer lane".
+ */
+export function isAnswer(m: ObservedMessage, driverUserId: number): boolean {
+  return (
+    m.senderUserId !== driverUserId &&
+    !m.edited &&
+    !isWorkerFeedMessage(m) &&
+    !isActivityFeedMessage(m) &&
+    m.text.trim().length > 0
+  );
+}
+
+export interface ReplyIsLastOptions {
+  /**
+   * The answer message that must be last in its foreground turn. The turn is
+   * scoped as the half-open window `[turn.messageId, nextDriverMessageId)` —
+   * i.e. everything from the answer up to (but excluding) the NEXT message the
+   * driver sent. Activity/worker-feed surfaces inside that window belong to
+   * this turn; a legitimately later surface (a background worker card, an
+   * obligation-represent nudge, an error envelope, or the next turn's feed)
+   * sits OUTSIDE it and is correctly NOT flagged.
+   *
+   * Pass the answer ObservedMessage returned by `expectMessage` (or pulled
+   * from `getHistory`).
+   */
+  turn: ObservedMessage;
+}
+
+/**
+ * Assert the scoped "reply is last" invariant (design §6/§11): within a single
+ * foreground turn, NO activity-card / worker-feed surface opens AFTER that
+ * turn's reply. Operates on a server-send-order `history` pull
+ * (`driver.getHistory`) so it sees surfaces that may have landed before any
+ * live observer started — required to catch a post-reply card across a
+ * re-prompt boundary.
+ *
+ * Deliberately NOT a naive cross-surface "answer has the max message_id":
+ * legitimate background / represent / error surfaces land later and would
+ * false-positive. We filter to the activity + answer LANES of the SAME
+ * foreground turn (`opts.turn`), reusing `isActivityFeedMessage` /
+ * `isWorkerFeedMessage` / `isAnswer`.
+ *
+ * Throws with the offending feed message when an activity/worker-feed surface
+ * for this turn has a HIGHER message_id than the reply.
+ */
+export function assertReplyIsLast(
+  history: ObservedMessage[],
+  driverUserId: number,
+  opts: ReplyIsLastOptions,
+): void {
+  const answer = opts.turn;
+  // Turn window upper bound: the first driver (user) message strictly after the
+  // answer. Anything at/after that belongs to a later turn and is out of scope.
+  const nextDriverAfter = history
+    .filter((m) => m.senderUserId === driverUserId && m.messageId > answer.messageId)
+    .reduce<number | null>(
+      (acc, m) => (acc == null || m.messageId < acc ? m.messageId : acc),
+      null,
+    );
+
+  const inThisTurn = (m: ObservedMessage): boolean =>
+    m.messageId >= answer.messageId &&
+    (nextDriverAfter == null || m.messageId < nextDriverAfter);
+
+  // The reply must be the last ACTIVITY/ANSWER-LANE surface of its turn: no
+  // activity-card or worker-feed message in-turn may have a higher id than it.
+  const offenders = history.filter(
+    (m) =>
+      inThisTurn(m) &&
+      m.messageId > answer.messageId &&
+      (isActivityFeedMessage(m) || isWorkerFeedMessage(m)),
+  );
+
+  if (offenders.length > 0) {
+    const detail = offenders
+      .map((m) => `msg=${m.messageId} ${JSON.stringify(m.text.slice(0, 60))}`)
+      .join("; ");
+    throw new Error(
+      `assertReplyIsLast: an activity/feed surface opened AFTER the reply ` +
+        `(answer msg=${answer.messageId}) in the same foreground turn: ${detail}`,
+    );
+  }
+}
+
 export interface PollOptions {
   /** Hard deadline; the predicate must resolve truthy before this. */
   timeout: number;

--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -591,6 +591,30 @@ export class Driver {
   }
 
   /**
+   * Pull a window of chat history in SERVER SEND-ORDER (ascending message_id —
+   * the actual on-screen order). The Phase-3 helper the `observeMessages`
+   * doc-comment references: unlike the new+edit observer stream, this is a pull
+   * that sees ALL messages already in the chat, including ones that landed
+   * before the observer started — required to assert ordering across a
+   * re-prompt boundary (`jtbd-reply-is-last-dm`, design §11 cases 3 & 4).
+   *
+   * mtcute's `getHistory` returns newest-first by default (and `reverse=true`
+   * needs an offset, returning [] otherwise), so we fetch then sort ascending
+   * by message_id to recover send-order. Each entry is mapped to the same
+   * `ObservedMessage` shape the assertions/predicates consume.
+   */
+  async getHistory(
+    chatId: number,
+    limit = 100,
+  ): Promise<ObservedMessage[]> {
+    const c = this.requireClient();
+    const messages = await c.getHistory(chatId, { limit });
+    return messages
+      .map((m) => toObserved(m, false))
+      .sort((a, b) => a.messageId - b.messageId);
+  }
+
+  /**
    * Poll the current set of emoji reactions on a message by making a
    * direct `messages.getMessagesReactions` MTProto call.
    *

--- a/telegram-plugin/uat/scenarios/jtbd-reply-is-last-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-reply-is-last-dm.test.ts
@@ -1,0 +1,202 @@
+/**
+ * JTBD: "the reply is last" + "a conversational turn opens no card" — the
+ * CI-enforced form of the deterministic emission invariants (design
+ * `docs/message-emission-determinism.md` §11; #2556).
+ *
+ * Four cases, each pulled from server SEND-ORDER history (`driver.getHistory`)
+ * so a post-reply card that landed before any live observer started is still
+ * caught. The ordering assertion is the SCOPED one (§6): within a single
+ * foreground turn, no activity-card / worker-feed surface opens after that
+ * turn's reply — NOT a naive "answer has the max message_id" (that would
+ * false-positive on a legitimate later background / represent / error surface).
+ * `assertReplyIsLast` filters to the activity/answer lanes of the SAME turn.
+ *
+ *   1. Conversational, zero-tool ("Reply with only: pong") — NO activity card
+ *      opens in this turn at all (lever 5 base case / G1, the triplication).
+ *   2. Tool-heavy (a REAL_WORK activity-surface prompt) — a card opened AND no
+ *      card for this turn sits below the substantive reply (lever 1 / races
+ *      A/B/E).
+ *   3. Short-pinging final ("Reply 'Done!' then write one memory") — the
+ *      currently-reordering case; green only once lever 2 lands (G5).
+ *   4. Two-turn backstop — a prompt that ends a turn without a qualifying reply
+ *      (forcing the silent-end re-prompt); no card opens below the final answer
+ *      across the re-prompt boundary (G3/C). Needs `getHistory`.
+ *
+ * Runs under CI `uat-gate`; the full live MTProto run needs the test-harness
+ * agent + a vault session, so locally this self-skips green (no driver).
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { spinUp, type Scenario } from "../harness.js";
+import {
+  assertReplyIsLast,
+  isAnswer,
+  isActivityFeedMessage,
+  isWorkerFeedMessage,
+} from "../assertions.js";
+import { collectTurn } from "../real-work-prompts.js";
+import type { ObservedMessage } from "../driver.js";
+
+/** Per-case overall budget. */
+const TURN_BUDGET_MS = 130_000;
+/** History pull depth — comfortably covers a multi-surface two-turn exchange. */
+const HISTORY_LIMIT = 80;
+
+describe("uat: reply-is-last + conversational-turn-opens-no-card (DM)", () => {
+  let sc: Scenario | null = null;
+
+  beforeAll(async () => {
+    try {
+      sc = await spinUp({ agent: "test-harness" });
+      await sc.driver.primeDialogs();
+    } catch (err) {
+      console.warn(
+        `[reply-is-last] no live driver — self-skipping green: ${(err as Error).message}`,
+      );
+      sc = null;
+    }
+  });
+
+  // Case 1 — conversational, zero-tool: NO activity card opens at all.
+  it(
+    "case 1: a conversational 0-tool turn opens NO activity card (lever 5 / G1)",
+    async () => {
+      if (sc == null) return; // self-skip green
+      const { driver, botUserId, driverUserId } = sc;
+
+      const obs = await collectTurn(
+        driver,
+        botUserId,
+        driverUserId,
+        "Reply with only this exact word and nothing else, using no tools at all: pong",
+        { timeoutMs: TURN_BUDGET_MS, minAnswerChars: 1, settleMs: 8_000 },
+      );
+
+      expect(obs.answer, "the pong answer must land").not.toBeNull();
+
+      // Pull send-order history and confirm: no activity-card surface opened in
+      // this turn. We scope to surfaces at/after the answer's turn by reusing
+      // assertReplyIsLast, AND additionally assert the live collector saw no
+      // activity feed for this minimal turn.
+      const history = await driver.getHistory(botUserId, HISTORY_LIMIT);
+      assertReplyIsLast(history, driverUserId, { turn: obs.answer! });
+
+      // The strong G1 assertion: a 0-tool conversational turn must produce no
+      // activity feed at all (neither open nor edit).
+      expect(
+        obs.sawActivityFeed,
+        "a 0-tool conversational turn must not open an activity card (the triplication)",
+      ).toBe(false);
+    },
+    TURN_BUDGET_MS + 30_000,
+  );
+
+  // Case 2 — tool-heavy: a card opens, but none below the substantive reply.
+  it(
+    "case 2: a tool-heavy turn opens a card but none below the reply (lever 1 / races A/B/E)",
+    async () => {
+      if (sc == null) return; // self-skip green
+      const { driver, botUserId, driverUserId } = sc;
+
+      const obs = await collectTurn(
+        driver,
+        botUserId,
+        driverUserId,
+        "Use your Bash tool to run `uname -a`, then tell me in one sentence what " +
+          "operating system this machine is running. Keep the answer substantive " +
+          "(a few sentences explaining what the output means).",
+        { timeoutMs: TURN_BUDGET_MS, minAnswerChars: 60, settleMs: 8_000 },
+      );
+
+      if (obs.answer == null) {
+        console.warn("[reply-is-last] case 2 INCONCLUSIVE — no answer landed in budget.");
+        return;
+      }
+      if (!obs.sawActivityFeed && !obs.sawWorkerFeed) {
+        console.warn(
+          "[reply-is-last] case 2 INCONCLUSIVE — the agent answered without a " +
+            "tool feed; the reorder vector this guards was not exercised.",
+        );
+        return;
+      }
+
+      const history = await driver.getHistory(botUserId, HISTORY_LIMIT);
+      // The scoped invariant: no activity/worker-feed surface for this turn
+      // lands below the substantive reply.
+      assertReplyIsLast(history, driverUserId, { turn: obs.answer });
+    },
+    TURN_BUDGET_MS + 30_000,
+  );
+
+  // Case 3 — short-pinging final: the case the lever-2 ordering fix makes pass.
+  it(
+    "case 3: a short-pinging final stays last even with post-reply tool work (lever 2 / G5)",
+    async () => {
+      if (sc == null) return; // self-skip green
+      const { driver, botUserId, driverUserId } = sc;
+
+      const obs = await collectTurn(
+        driver,
+        botUserId,
+        driverUserId,
+        "Reply with only the single word 'Done!' (with the exclamation mark) — " +
+          "then, AFTER that reply, save a one-line memory noting you completed " +
+          "this test. The short reply is your final answer.",
+        // The "Done!" reply is short; accept it as the answer.
+        { timeoutMs: TURN_BUDGET_MS, minAnswerChars: 1, settleMs: 10_000 },
+      );
+
+      if (obs.answer == null) {
+        console.warn("[reply-is-last] case 3 INCONCLUSIVE — no answer landed in budget.");
+        return;
+      }
+
+      const history = await driver.getHistory(botUserId, HISTORY_LIMIT);
+      // The post-'Done!' memory write must NOT have reopened a card BELOW the
+      // reply. Before lever 2 this reorders (the named G5 residual); after, the
+      // card is finalized before the send and stays above.
+      assertReplyIsLast(history, driverUserId, { turn: obs.answer });
+    },
+    TURN_BUDGET_MS + 30_000,
+  );
+
+  // Case 4 — two-turn backstop: no card below the final answer across the
+  // silent-end re-prompt boundary.
+  it(
+    "case 4: no card opens below the final answer across a re-prompt boundary (G3/C)",
+    async () => {
+      if (sc == null) return; // self-skip green
+      const { driver, botUserId, driverUserId } = sc;
+
+      // A prompt that nudges the model to write its answer as prose first
+      // (no reply tool) — forcing the silent-end re-prompt, then a real answer
+      // on the re-prompted turn. The model's exact path isn't forceable, so the
+      // ordering assertion is the durable part; the re-prompt is best-effort.
+      const obs = await collectTurn(
+        driver,
+        botUserId,
+        driverUserId,
+        "Think out loud briefly, then give me a thorough multi-sentence answer " +
+          "(at least 220 characters) explaining what a Telegram supergroup is and " +
+          "how forum topics work inside one.",
+        { timeoutMs: TURN_BUDGET_MS, minAnswerChars: 200, settleMs: 12_000 },
+      );
+
+      if (obs.answer == null) {
+        console.warn("[reply-is-last] case 4 INCONCLUSIVE — no answer landed in budget.");
+        return;
+      }
+
+      // Pull full send-order history (the re-prompt may have produced a second
+      // card before the live observer in collectTurn caught it) and assert the
+      // final answer's turn has no feed surface below it.
+      const history = await driver.getHistory(botUserId, HISTORY_LIMIT);
+      assertReplyIsLast(history, driverUserId, { turn: obs.answer });
+
+      // Sanity: the answer is a genuine answer-lane message (not a feed).
+      expect(isAnswer(obs.answer, driverUserId)).toBe(true);
+      expect(isActivityFeedMessage(obs.answer)).toBe(false);
+      expect(isWorkerFeedMessage(obs.answer)).toBe(false);
+    },
+    TURN_BUDGET_MS + 30_000,
+  );
+});


### PR DESCRIPTION
First PR from the **message-emission-determinism** design note (`docs/message-emission-determinism.md`, #2556). Four coherent changes, all about **WHEN** the activity card may OPEN and how the reply stays structurally last within a foreground turn. Gateway-touching and concurrency-sensitive; the OPEN gate is enforced at the single `sendMessage` site inside the shared drain, so it covers both the inline producers **and** the detached heartbeat `setInterval` drain.

## The four changes

**(1) Sticky ordering latch — precondition (design §9 preamble / R0).** Adds a new per-turn `finalAnswerEverDelivered` field, reset **only** at turn start (alongside the other per-turn resets), set `true` at the same points as `finalAnswerDelivered` **but gated on `isSubstantiveFinalReply`**. The existing `finalAnswerDelivered` is *mutable* — the ack-reopen path clears it mid-turn (`feed-reopen-gate.ts:157`) so an "On it…" ack keeps a live feed (#2141). Keying an ordering gate on that mutable flag is a no-op on exactly the ack-first turn where the reorder originates. The new sticky latch is **never cleared by reopen** (mirrors `activityEverOpened`). **#2141 ack-reopen is preserved** — `feed-reopen-gate.ts` still resets only the mutable flag.

**(2) Lever 1 — no card OPEN after a substantive final (races A/B/E).** The OPEN branch of `drainActivitySummary` (and the liveness-open path, which routes through the same drain) refuses a fresh `sendMessage` once the **sticky** latch is set. An existing card may still be edited.

**(3) Lever 5 base case — narrative-SHOW alone must not OPEN (the triplication, G1).** A producer signal (`narrative` | `tool` | `liveness`) is threaded into `drainActivitySummary`. A narrative-SHOW drain on a **0-tool** turn accumulates into `mirrorLines` but does **not** OPEN; only a tool label (producer B) or the liveness timer (producer C, genuine ≥12s thinking-gap) may OPEN. A turn that starts conversational then dispatches a tool **does** open (R4); the genuine thinking-gap liveness open is untouched. Refusing an OPEN does **not** advance `activityLastSentRender`, so the accumulated narration renders once a tool label / liveness opens the card.

**(4) Lever 2 — finalize the card BEFORE a substantive reply send.** `executeReply` / `executeStreamReply` call `clearActivitySummary` (edit-in-place → lower message_id) before the chunk send when the reply is substantive, so the reply is structurally last. **Acks do NOTHING** — finalizing an ack early would close→reopen→emit more messages (R3/#2141). The existing `tool_use`-event clear remains the idempotent backstop.

## Deliberate behaviour change

- **0-tool conversational turns no longer open an activity card** (closes the triplication).
- **A substantive reply is finalized-before-send** so it stays last on screen.
- **Preserves #2141** ack-reopen (verified — the ack-then-work feed still opens/edits).

## Design contract

- **Vision outcome:** *visibility* — deterministic, non-noisy progress surfacing.
- **JTBD:** the "deterministic UX control" job behind the design note (triplication + reply-not-last symptoms, §1/§8).
- **Invariants:** sits near `chat-is-the-single-source-of-truth`; no new emission authority, only OPEN-time gating + ordering.

## Tests

- `tests/feed-open-gate.test.ts` — pure lever 1 + 5 decision (`mayOpenActivityCard`).
- `tests/emission-determinism-wiring.test.ts` — structural: sticky-latch reset-only-at-turn-start (never cleared by reopen), the drain OPEN gate (break-not-mark-sent), the per-producer drains, and lever-2 finalize-before-send in both reply paths.
- Widened the `reply-terminal-reaction.test.ts` slice window 3000→4000 (intent unchanged) — the lever-1 latch set lives in that post-send `isFinalAnswerReply` branch.
- Kept green: `tool-activity-summary`, `worker-activity-feed`, `feed-survival`, `represent-guard`, `feed-reopen-gate` (incl. the #2141 reopen tests), `activity-ever-opened-sticky`, `feed-heartbeat-liveness-open`, `final-answer-detect`.

## UAT (design §11)

- `driver.getHistory(chatId, limit)` — server send-order pull (the planned Phase-3 helper).
- `assertReplyIsLast(history, driverUserId, {turn})` — **scoped** to the same foreground turn's activity/answer lanes (reuses `isActivityFeedMessage` / `isWorkerFeedMessage` / `isAnswer`); deliberately **not** a naive cross-surface max-message_id assert.
- `uat/scenarios/jtbd-reply-is-last-dm.test.ts` — the four §11 cases (conversational 0-tool → no card; tool-heavy → no card below the reply; short-pinging final → reply-is-last; two-turn backstop → no card below the final). Self-skips green without the live MTProto harness.

## CI gates

`ci-tests-plugin` + `uat-gate`.

Local: `bun test` (targeted) + full `npx vitest run` of the touched dirs green except a pre-existing env-dependent `auth-add-flow.test.ts` (8 fake-claude-binary subprocess failures, confirmed failing on clean `origin/main`). `npm run lint` (tsc --noEmit + all check scripts) clean. `npm run build` compiles. `src/build-info.ts` auto-regen reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)