### PR TITLE
fix(rollout): thread --pin target through agent restart so canary gets the right image (#2558)

### DIFF
--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { Option, type Command } from "commander";
 import chalk from "chalk";
 import { join, resolve } from "node:path";
 import { rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -11,6 +11,7 @@ import type { SwitchroomConfig } from "../config/schema.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 import { scaffoldAgent, reconcileAgent, buildSettingsHooksBlock, detectHooksDrift, SWITCHROOM_DEFAULT_MAIN_MODEL, SWITCHROOM_DEFAULT_THINKING_EFFORT } from "../agents/scaffold.js";
 import { writeComposeFile } from "./write-compose.js";
+import type { ReleaseBlockShape } from "../config/release-resolve.js";
 import { bareClonePath } from "../repos/bare-clone.js";
 import { removeAgentWorktree } from "../repos/agent-worktree.js";
 import { listAvailableProfiles } from "../agents/profiles.js";
@@ -544,6 +545,18 @@ export interface ReconcileAndRestartOpts {
   force?: boolean;
   /** Override the compose path (tests). Defaults to DEFAULT_COMPOSE_PATH. */
   composePath?: string;
+  /**
+   * One-shot image-tag override for the compose regeneration step.
+   * Passed from `agent restart --pin <vX.Y.Z>` (and from the rollout's
+   * restart-agent step on the hostd path). When set, this WINS over
+   * `release.pin` in the loaded config — required because on the hostd
+   * rollout path the durable pin is not persisted to switchroom.yaml
+   * until AFTER the canary confirms the new version. Without this, the
+   * in-restart `writeComposeFile` re-reads the stale `release.pin` and
+   * overwrites the compose file that `apply --pin` just correctly wrote,
+   * putting the agent on the old image (#2558).
+   */
+  releaseOverride?: ReleaseBlockShape;
 }
 
 /**
@@ -695,6 +708,11 @@ export async function reconcileAndRestartAgent(
       config,
       composePath: opts.composePath ?? composeFilePath(),
       switchroomConfigPath: configPath,
+      // Thread the one-shot pin through so that on the hostd rollout path
+      // (where `release.pin` in switchroom.yaml is still the OLD value until
+      // the canary passes) the compose regeneration emits the TARGET image
+      // tag and not the stale pin. Fixes #2558.
+      releaseOverride: opts.releaseOverride,
     });
     if (r.changed) {
       const tagNote =
@@ -1170,6 +1188,15 @@ export function registerAgentCommand(program: Command): void {
       "--force-locked",
       "Restart even when bot_token is a vault: reference and the vault is locked (the agent will fail to reach Telegram until the vault is unlocked)"
     )
+    .addOption(
+      new Option(
+        "--pin <p>",
+        "One-shot image-tag override for the compose regeneration step of this restart. " +
+        "Overrides `release.pin` from switchroom.yaml for THIS restart only — used by " +
+        "`switchroom rollout` on the hostd path where the durable pin has not yet been " +
+        "persisted. Format: v<semver> or sha-<hex>.",
+      ),
+    )
     .action(
       withConfigError(
         async (
@@ -1180,6 +1207,7 @@ export function registerAgentCommand(program: Command): void {
             waitTimeout?: string;
             gracefulRestart?: boolean;
             forceLocked?: boolean;
+            pin?: string;
           }
         ) => {
           const config = getConfig(program);
@@ -1392,7 +1420,14 @@ export function registerAgentCommand(program: Command): void {
                 config,
                 agentsDir,
                 getConfigPath(program),
-                { graceful: opts.gracefulRestart, force: opts.force },
+                {
+                  graceful: opts.gracefulRestart,
+                  force: opts.force,
+                  // Thread the one-shot --pin through to writeComposeFile so
+                  // the compose regeneration uses the target image tag and not
+                  // the stale release.pin in config (#2558).
+                  releaseOverride: opts.pin ? { pin: opts.pin } : undefined,
+                },
               );
 
               if (opts.gracefulRestart) {

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -325,6 +325,49 @@ describe("executeRollout — hostd context (#2487)", () => {
     expect(r.rolled).toEqual(["test-harness", "clerk"]);
     expect(persisted).toEqual([TARGET]); // persisted exactly once, after canary
   });
+
+  // Regression guard for #2558:
+  // The restart-agent step on the hostd path must pass --pin <target> to
+  // `agent restart` so the in-restart compose regeneration uses the TARGET
+  // image tag and not the stale release.pin still in switchroom.yaml (the
+  // durable persist-pin step runs AFTER the canary on this path).
+  it("restart-agent passes --pin <target> on the hostd path (#2558 regression)", () => {
+    const steps = planRollout(["test-harness", "clerk"], {
+      pinToPersist: TARGET,
+      hostdContext: true,
+    });
+    const { deps, runs } = harness({
+      versions: { "test-harness": "0.15.18", clerk: "0.15.18" },
+    });
+    executeRollout(steps, TARGET, deps, { hostdContext: true });
+    // Every restart-agent invocation on the hostd path must carry --pin.
+    const restartRuns = runs.filter((a) => a[0] === "agent" && a[1] === "restart");
+    expect(restartRuns.length).toBeGreaterThan(0);
+    for (const run of restartRuns) {
+      expect(run).toContain("--pin");
+      expect(run).toContain(TARGET);
+    }
+  });
+
+  // Belt-and-braces: on the HOST-SHELL path the pin is persisted BEFORE
+  // apply, so bare restart reads the correct pin from config. Passing --pin
+  // there is harmless, but the contract is bare restart (no --pin flag) so
+  // the operator's PATH is unaffected.
+  it("restart-agent does NOT pass --pin on the host-shell path (pin already persisted)", () => {
+    const steps = planRollout(["test-harness", "clerk"], {
+      pinToPersist: TARGET,
+      // hostdContext NOT set → host-shell path
+    });
+    const { deps, runs } = harness({
+      versions: { "test-harness": "0.15.18", clerk: "0.15.18" },
+    });
+    executeRollout(steps, TARGET, deps);
+    const restartRuns = runs.filter((a) => a[0] === "agent" && a[1] === "restart");
+    expect(restartRuns.length).toBeGreaterThan(0);
+    for (const run of restartRuns) {
+      expect(run).not.toContain("--pin");
+    }
+  });
 });
 
 describe("rollout structured-result sentinel (#2487)", () => {

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -423,7 +423,19 @@ export function executeRollout(
         deps.log(`ROLL_STEP restart-agent — ${step.agent} (--wait --force)`);
         // `agent restart` can exit 0 while still "polling" on boot — do
         // NOT trust its status; the version assert is the real gate.
-        deps.run(["agent", "restart", step.agent, "--wait", "--force"]);
+        //
+        // hostd path: pass --pin <target> so the compose regeneration step
+        // inside `agent restart` uses the target image tag. Without this,
+        // `reconcileAndRestartAgent` re-reads the stale `release.pin` from
+        // config and overwrites the correct compose that `apply --pin` just
+        // wrote — putting the canary/agent on the old image (#2558). On the
+        // host-shell path the pin is already persisted before `apply` runs,
+        // so bare restart reads the correct pin from config; passing --pin
+        // there is harmless but unnecessary.
+        const restartArgs = execOpts.hostdContext
+          ? ["agent", "restart", step.agent, "--wait", "--force", "--pin", target]
+          : ["agent", "restart", step.agent, "--wait", "--force"];
+        deps.run(restartArgs);
         const got = deps.probeVersion(step.agent);
         if (got === null || normalizeVersion(got) !== targetNorm) {
           deps.log(`  ✗ ${step.agent} → ${got ?? "<unreachable>"} (expected ${target}) — STOPPING`);

--- a/src/cli/write-compose.test.ts
+++ b/src/cli/write-compose.test.ts
@@ -31,6 +31,37 @@ describe("writeComposeFile", () => {
     expect(content).toContain("switchroom-agent:v0.14.92");
   });
 
+  // Regression guard for #2558:
+  // On the hostd rollout path, `apply --pin vX` correctly wrote the compose
+  // with the target tag. But the subsequent `agent restart <canary> --wait
+  // --force` called `writeComposeFile` WITHOUT `releaseOverride`, re-reading
+  // the stale `release.pin` from config and overwriting the compose — putting
+  // the canary on the old image. The fix: thread `releaseOverride` through
+  // `ReconcileAndRestartOpts` so `reconcileAndRestartAgent` can pass it to
+  // `writeComposeFile`, and have the rollout's restart-agent step supply it
+  // on the hostd path.
+  it("releaseOverride pin wins over stale release.pin in config (#2558 regression)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "wc-2558-"));
+    const composePath = join(dir, "docker-compose.yml");
+    // Config has the OLD pin (v0.15.59); the rollout target is v0.15.61.
+    const config = mkConfig("v0.15.59");
+    const r = await writeComposeFile({
+      config,
+      composePath,
+      switchroomConfigPath: undefined,
+      releaseOverride: { pin: "v0.15.61" },
+    });
+    expect(r.imageTag).toBe("v0.15.61");
+    const content = readFileSync(composePath, "utf8");
+    // Every agent image ref must use the TARGET pin, not the stale config pin.
+    expect(content).toContain("switchroom-agent:v0.15.61");
+    expect(content).not.toContain("switchroom-agent:v0.15.59");
+    // Singleton images must also use the target (belt-and-braces — singletons
+    // honor --pin via a separate reconcile path but the compose must be consistent).
+    expect(content).toContain("switchroom-broker:v0.15.61");
+    expect(content).not.toContain("switchroom-broker:v0.15.59");
+  });
+
   it("reports the previous image tag + changed=true when the pin moves", async () => {
     const dir = mkdtempSync(join(tmpdir(), "wc-"));
     const composePath = join(dir, "docker-compose.yml");


### PR DESCRIPTION
## Problem

On the **hostd rollout path**, `switchroom rollout --pin vX` orchestrates:

1. `apply --pin vX` — writes the compose file with the correct target image tag ✅
2. `agent restart <canary> --wait --force` — **bug here**

Step 2 calls `reconcileAndRestartAgent`, which calls `writeComposeFile` **without a `releaseOverride`**. It re-reads `config.release.pin` from `switchroom.yaml` — which is still the **old value** (the durable pin is only persisted after the canary confirms the new version). This overwrites the correctly-written compose, reverting the canary's image to the old tag. The canary starts on the wrong image, version-check fails, rollout stops dead.

Fixes #2558

## Root cause

`reconcileAndRestartAgent` (called by both `agent restart` CLI and by `executeRollout`) lacked a `releaseOverride` parameter. All callers passed nothing, so the compose regeneration inside always read from config — which on the hostd path is stale at the restart-agent step.

## Fix

Three-point change, no interface breaks:

**`src/cli/agent.ts`**
- Add `releaseOverride?: ReleaseBlockShape` to `ReconcileAndRestartOpts` (with doc comment explaining the hostd timing constraint)
- Thread it through to the `writeComposeFile` call inside `reconcileAndRestartAgent`
- Add `--pin <p>` option to `switchroom agent restart` via Commander's `Option` class
- Pass `releaseOverride: opts.pin ? { pin: opts.pin } : undefined` in the restart action

**`src/cli/rollout.ts`**
- In the `restart-agent` case of `executeRollout`, conditionally pass `--pin <target>` on the hostd path; bare restart on host-shell path (where `persist-pin` already ran before `apply`, so config is up to date)

## Regression tests

**`src/cli/write-compose.test.ts`** — `"releaseOverride pin wins over stale release.pin in config (#2558 regression)"`
- Config has `release.pin: v0.15.59`; call `writeComposeFile` with `releaseOverride: { pin: "v0.15.61" }`
- Asserts `r.imageTag === "v0.15.61"` and that every image ref in the compose uses `v0.15.61`, not `v0.15.59`

**`src/cli/rollout.test.ts`** — two new tests inside `describe("executeRollout — hostd context (#2487)")`:
- `"restart-agent passes --pin <target> on the hostd path (#2558 regression)"` — every `agent restart` run on the hostd path must include `--pin` and the target version
- `"restart-agent does NOT pass --pin on the host-shell path (pin already persisted)"` — confirms the host-shell path stays clean

## Local results

```
bun tsc --noEmit          → clean (exit 0)
vitest run src/cli/       → 62 files, 961 passed, 1 pre-existing skip
```

---
_Do NOT merge — CI gates this._