### PR TITLE
fix(telegram): substantive final answer owns the turn's notification ping (R8/PR-2)

### DIFF
--- a/telegram-plugin/final-answer-detect.ts
+++ b/telegram-plugin/final-answer-detect.ts
@@ -103,12 +103,17 @@ export function isFinalAnswerReply(input: FinalAnswerReplyInput): boolean {
  * otherwise the silent-end re-prompt would spuriously fire and the agent
  * would re-deliver a duplicate / garbled answer.
  *
- * Residual: a reply that is genuinely the final answer yet is BOTH short
- * (<200 chars) AND pinging (e.g. "Done!") is indistinguishable here from
- * an ack, so post-answer housekeeping after it still re-opens the feed.
- * That is much rarer than the housekeeping-after-long-answer case this
- * predicate protects, and is kill-switchable via
- * `SWITCHROOM_FEED_REOPEN_AFTER_ACK=0`.
+ * Residual (pre-existing, predates PR-2 — a conscious accept, no regression):
+ * a reply that is genuinely the final answer yet is BOTH short (<200 chars)
+ * AND pinging (e.g. "Done!") is indistinguishable here from an ack. So when
+ * such an answer arrives AFTER an ack has already pinged this turn, it
+ * classifies as an ack and its ping is suppressed (and post-answer
+ * housekeeping after it still re-opens the feed). PR-2's slot-ownership
+ * upgrade does NOT rescue this case — the upgrade only fires for a
+ * *substantive* answer, and this answer reads as non-substantive by the
+ * ≥200-char test. That is much rarer than the housekeeping-after-long-answer
+ * case this predicate protects, and the feed-reopen half is kill-switchable
+ * via `SWITCHROOM_FEED_REOPEN_AFTER_ACK=0`.
  */
 export function isSubstantiveFinalReply(input: FinalAnswerReplyInput): boolean {
   if (input.done === true) return true

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -7698,11 +7698,15 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     const turn = currentTurn
     if (turn != null) {
       const now = Date.now()
-      // Notification ownership (R8 / PR-2): classify on the MODEL's original
-      // intent (`modelDisableNotification`), not the possibly-downgraded
-      // `disableNotification`, mirroring the #2533 final-answer decoupling.
-      // `reply` carries no `done`, so substantiveness here is the ≥200-char
-      // length backstop.
+      // Notification ownership (R8 / PR-2): on the `reply` path,
+      // substantiveness is purely the ≥200-char (or `done`) backstop —
+      // `isSubstantiveFinalReply` is `done === true || text.length >= 200`
+      // and ignores the notification flag entirely. `reply` carries no
+      // `done`, so it reduces to the ≥200-char length test. We still pass
+      // `modelDisableNotification` (the MODEL's original intent, not the
+      // possibly-downgraded `disableNotification`) to mirror the #2533
+      // final-answer decoupling call shape, but that arg does NOT
+      // participate in classification here — it is inert on this path.
       const replySubstantive = isSubstantiveFinalReply({
         text: rawText,
         disableNotification: modelDisableNotification,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1964,6 +1964,18 @@ type CurrentTurn = {
   // the framework. Null until the first ping lands. Reset on every
   // fresh-turn enqueue.
   firstPingAt: number | null
+  // Notification ownership (R8 / PR-2 — design `docs/message-emission-
+  // determinism.md` §over-ping). Whether the send that CLAIMED this turn's
+  // ping slot (`firstPingAt`) was itself a *substantive* final answer
+  // (`isSubstantiveFinalReply`) as opposed to a short interim ACK. The
+  // over-ping safety net keys on this so a substantive answer pinging AFTER
+  // an ack already pinged is UPGRADED (let through, owns the slot) rather
+  // than silenced — otherwise "the reply is last but the phone never buzzed
+  // for the answer." Set ATOMICALLY with `firstPingAt` (same synchronous
+  // block, no await between) on a claim/upgrade so a racing second reply
+  // reads a consistent pair. Init false; reset to false on every fresh-turn
+  // enqueue alongside `firstPingAt`.
+  firstPingWasSubstantive: boolean
   // #1677 silent-reply auto-edit. The first silent reply of a turn
   // captures `silentAnchorMessageId` + `silentAnchorText`; subsequent
   // silent replies in the SAME turn editMessageText that anchor
@@ -7686,9 +7698,20 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     const turn = currentTurn
     if (turn != null) {
       const now = Date.now()
+      // Notification ownership (R8 / PR-2): classify on the MODEL's original
+      // intent (`modelDisableNotification`), not the possibly-downgraded
+      // `disableNotification`, mirroring the #2533 final-answer decoupling.
+      // `reply` carries no `done`, so substantiveness here is the ≥200-char
+      // length backstop.
+      const replySubstantive = isSubstantiveFinalReply({
+        text: rawText,
+        disableNotification: modelDisableNotification,
+      })
       const decision = decideOverPing({
         modelRequestedPing: !disableNotification,
         firstPingAt: turn.firstPingAt,
+        substantive: replySubstantive,
+        firstPingWasSubstantive: turn.firstPingWasSubstantive,
         nowMs: now,
       })
       if (decision.suppress) {
@@ -7710,7 +7733,18 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
         disableNotification = true
         wasOverPingSuppressed = true
       } else if (decision.claimSlot) {
+        // Claim (first ping) OR upgrade (substantive answer pinging over an
+        // ack's slot). Set firstPingAt AND firstPingWasSubstantive ATOMICALLY
+        // (no await between) so a racing second reply reads a consistent pair.
         turn.firstPingAt = now
+        turn.firstPingWasSubstantive = replySubstantive
+        if (decision.upgrade) {
+          process.stderr.write(
+            `telegram gateway: reply over-ping safety net — ` +
+            `UPGRADE: substantive answer pings over an ack's slot ` +
+            `(chat=${chat_id} thread=${args.message_thread_id ?? '-'})\n`,
+          )
+        }
       }
     }
   }
@@ -10639,6 +10673,10 @@ function handleSessionEvent(ev: SessionEvent): void {
           // Sticky latch — reset ONLY here (turn start), never by reopen.
           finalAnswerEverDelivered: false,
           firstPingAt: null,
+          // Notification ownership (R8 / PR-2): no slot claimed yet, so the
+          // "claimer was substantive" flag starts false. Set atomically with
+          // firstPingAt at the over-ping decision site.
+          firstPingWasSubstantive: false,
           silentAnchorMessageId: null,
           silentAnchorText: '',
           capturedText: [],

--- a/telegram-plugin/over-ping-safety-net.ts
+++ b/telegram-plugin/over-ping-safety-net.ts
@@ -25,7 +25,29 @@
  *     the decision says CLAIM the slot — caller sets `firstPingAt`.
  *   - When the model requested silent, this module is a no-op.
  *
+ * Notification ownership (R8 / PR-2). The bare "first ping wins" rule
+ * above has a residual failure: an interim ACK that pings first claims
+ * the turn's single slot, and the later SUBSTANTIVE answer is then
+ * downgraded to silent — "the reply is last but the phone never buzzed
+ * for the answer." To fix that without re-introducing model double-pings,
+ * the decision is now aware of WHO holds the slot and WHO is asking:
+ *
+ *   - A SUBSTANTIVE final asking to ping while the slot is held by a
+ *     NON-substantive (ack) send ⇒ do NOT suppress; let the answer ping
+ *     and UPGRADE the slot to substantive (the answer owns the ping even
+ *     though the ack already buzzed once — a deliberate, bounded second
+ *     ping so the user is notified of the actual answer).
+ *   - An ACK asking to ping while the slot is held by a SUBSTANTIVE send
+ *     ⇒ suppress (no spurious double-ping AFTER the real answer).
+ *   - A SUBSTANTIVE asking while the slot is held by a SUBSTANTIVE ⇒
+ *     suppress (preserves the #1674 model-double-ping guard: answer +
+ *     wrap-up should be one beep, not two).
+ *   - An ACK while the slot is held by an ACK ⇒ suppress (unchanged).
+ *
  * The slot is claimed BEFORE the actual send (caller responsibility).
+ * On a CLAIM or an UPGRADE the caller MUST set `firstPingAt` AND
+ * `firstPingWasSubstantive` ATOMICALLY (same synchronous block, no await
+ * between) so a racing second reply reads a consistent pair.
  * Trade-off documented inline in `gateway.ts:executeReply`.
  */
 
@@ -39,6 +61,18 @@ export interface OverPingDecisionInput {
    *  has landed yet. Caller threads this through from
    *  `CurrentTurn.firstPingAt`. */
   firstPingAt: number | null
+  /** True iff THIS reply is a substantive final answer (stream `done`,
+   *  or text length ≥ FINAL_ANSWER_MIN_CHARS) — as opposed to a short
+   *  interim ack. Caller computes via `isSubstantiveFinalReply`. Defaults
+   *  to `false` (treat as a non-substantive ack) when omitted, which
+   *  preserves the pre-PR-2 "first ping wins, the rest suppress" behaviour
+   *  for callers that don't yet thread it. */
+  substantive?: boolean
+  /** True iff the send that CLAIMED the turn's ping slot was itself a
+   *  substantive final answer. Caller threads this through from
+   *  `CurrentTurn.firstPingWasSubstantive`. Meaningless (and ignored)
+   *  when `firstPingAt == null`. Defaults to `false`. */
+  firstPingWasSubstantive?: boolean
   /** Deterministic clock for tests; defaults to Date.now() in callers. */
   nowMs: number
 }
@@ -49,8 +83,18 @@ export interface OverPingDecision {
    *  violation by the model — caller should log + emit a metric. */
   suppress: boolean
   /** True iff the caller should claim the slot —
-   *  `turn.firstPingAt = nowMs`. Mutually exclusive with `suppress`. */
+   *  `turn.firstPingAt = nowMs` AND
+   *  `turn.firstPingWasSubstantive = substantive`. Mutually exclusive
+   *  with `suppress`. Set both on a fresh claim (no prior ping) and on
+   *  an UPGRADE (a substantive answer pinging over an ack's slot). */
   claimSlot: boolean
+  /** True iff this is an UPGRADE — a substantive final answer claiming
+   *  the ping slot that was previously held by a NON-substantive ack.
+   *  The answer pings even though the ack already buzzed once. Implied
+   *  by `claimSlot && firstPingAt != null` but surfaced explicitly so
+   *  the caller can log/meter the (intentional) second ping distinctly
+   *  from a normal first claim. Always false on a suppress or a no-op. */
+  upgrade: boolean
   /** When `suppress` is true, how long the first ping has been
    *  "active" (ms since `firstPingAt`). Caller surfaces this in the
    *  log + metric for forensic analysis (e.g. tight rapid double-pings
@@ -63,18 +107,40 @@ export interface OverPingDecision {
  * No mutation, no IO, deterministic under a fixed `nowMs`.
  */
 export function decideOverPing(input: OverPingDecisionInput): OverPingDecision {
+  const substantive = input.substantive === true
+  const firstPingWasSubstantive = input.firstPingWasSubstantive === true
+
   if (!input.modelRequestedPing) {
     // Model already chose silent — nothing for the safety net to do.
-    return { suppress: false, claimSlot: false, sinceFirstPingMs: null }
+    return { suppress: false, claimSlot: false, upgrade: false, sinceFirstPingMs: null }
   }
   if (input.firstPingAt != null) {
-    // Slot already claimed by an earlier ping this turn — suppress.
+    // The turn's ping slot is already held. WHO holds it and WHO is
+    // asking decides whether this is a notification-ownership UPGRADE or
+    // a double-ping to suppress (see the module doc-comment for the full
+    // matrix).
+    if (substantive && !firstPingWasSubstantive) {
+      // The substantive ANSWER is pinging over a slot held by an ack.
+      // Let it ping and upgrade the slot to substantive — the answer
+      // owns the turn's notification, not the earlier ack.
+      return {
+        suppress: false,
+        claimSlot: true,
+        upgrade: true,
+        sinceFirstPingMs: null,
+      }
+    }
+    // Every other slot-held case is a double-ping to suppress:
+    //   - ack over substantive: a spurious wrap-up after the real answer
+    //   - substantive over substantive: the #1674 answer+wrap-up guard
+    //   - ack over ack: the original one-ping-per-turn behaviour
     return {
       suppress: true,
       claimSlot: false,
+      upgrade: false,
       sinceFirstPingMs: input.nowMs - input.firstPingAt,
     }
   }
   // First ping this turn — let it through and claim the slot.
-  return { suppress: false, claimSlot: true, sinceFirstPingMs: null }
+  return { suppress: false, claimSlot: true, upgrade: false, sinceFirstPingMs: null }
 }

--- a/telegram-plugin/tests/over-ping-final-answer-decoupling.test.ts
+++ b/telegram-plugin/tests/over-ping-final-answer-decoupling.test.ts
@@ -23,7 +23,7 @@
 
 import { describe, it, expect } from 'vitest'
 import { decideOverPing } from '../over-ping-safety-net.js'
-import { isFinalAnswerReply } from '../final-answer-detect.js'
+import { isFinalAnswerReply, isSubstantiveFinalReply } from '../final-answer-detect.js'
 
 describe('#2533 — over-ping downgrade must not pollute final-answer classification', () => {
   // The midturn-silent-dm failing sequence: an interim ack pings, then a
@@ -77,5 +77,118 @@ describe('#2533 — over-ping downgrade must not pollute final-answer classifica
     // the bug only ever bit SHORT over-ping-suppressed finals (the #2533 case).
     expect(isFinalAnswerReply({ text: long, disableNotification: true })).toBe(true)
     expect(isFinalAnswerReply({ text: long, disableNotification: false })).toBe(true)
+  })
+})
+
+/**
+ * Notification ownership (R8 / PR-2 — design `docs/message-emission-
+ * determinism.md` §over-ping). The substantive final answer must OWN the
+ * turn's single device ping. The residual the bare "first ping wins" rule
+ * left: an interim ack pings first and claims the slot, so the later
+ * substantive answer is downgraded to silent — "the reply is last but the
+ * phone never buzzed for the answer." `decideOverPing` is now aware of WHO
+ * holds the slot (`firstPingWasSubstantive`) and WHO is asking
+ * (`substantive`) and UPGRADES a substantive answer over an ack's slot,
+ * while still suppressing every double-ping the #1674 guard exists for.
+ *
+ * The 2×2 ownership matrix (model wants to ping, slot already held):
+ *
+ *   incoming \ slot held by │ ACK (non-substantive) │ SUBSTANTIVE
+ *   ────────────────────────┼───────────────────────┼─────────────
+ *   SUBSTANTIVE answer       │ UPGRADE (ping, claim)  │ suppress (#1674)
+ *   ACK                      │ suppress (orig)        │ suppress
+ */
+describe('R8 / PR-2 — substantive final answer OWNS the turn ping (upgrade matrix)', () => {
+  const SUBSTANTIVE = 'x'.repeat(300) // ≥200 → isSubstantiveFinalReply true
+  const ACK = 'On it.' // <200, non-done → ack
+
+  it('row 1 — substantive answer pinging over an ACK-held slot ⇒ UPGRADE (not suppressed)', () => {
+    // The ack pinged first (claimed the slot, non-substantive).
+    const ack = decideOverPing({
+      modelRequestedPing: true,
+      firstPingAt: null,
+      substantive: isSubstantiveFinalReply({ text: ACK, disableNotification: false }),
+      nowMs: 1_000,
+    })
+    expect(ack.claimSlot).toBe(true)
+    expect(ack.upgrade).toBe(false)
+    // Now the substantive answer wants to ping; the slot is ack-held.
+    const answer = decideOverPing({
+      modelRequestedPing: true,
+      firstPingAt: 1_000,
+      substantive: isSubstantiveFinalReply({ text: SUBSTANTIVE, disableNotification: false }),
+      firstPingWasSubstantive: false, // the ack
+      nowMs: 2_000,
+    })
+    expect(answer.suppress).toBe(false) // the ANSWER pings — phone buzzes for the answer
+    expect(answer.claimSlot).toBe(true) // slot upgraded to substantive
+    expect(answer.upgrade).toBe(true)
+  })
+
+  it('row 2 — ACK pinging over a SUBSTANTIVE-held slot ⇒ suppress (no double-ping after the answer)', () => {
+    const d = decideOverPing({
+      modelRequestedPing: true,
+      firstPingAt: 1_000,
+      substantive: isSubstantiveFinalReply({ text: ACK, disableNotification: false }),
+      firstPingWasSubstantive: true, // the real answer already owned the slot
+      nowMs: 2_000,
+    })
+    expect(d.suppress).toBe(true)
+    expect(d.claimSlot).toBe(false)
+    expect(d.upgrade).toBe(false)
+  })
+
+  it('row 3 — SUBSTANTIVE over a SUBSTANTIVE-held slot ⇒ suppress (preserves the #1674 model-double-ping guard)', () => {
+    // The reproducer #1674 targeted: a substantive answer pinged, then a
+    // substantive wrap-up also wants to ping. One beep, not two.
+    const d = decideOverPing({
+      modelRequestedPing: true,
+      firstPingAt: 30_000,
+      substantive: isSubstantiveFinalReply({ text: SUBSTANTIVE, disableNotification: false }),
+      firstPingWasSubstantive: true,
+      nowMs: 36_000,
+    })
+    expect(d.suppress).toBe(true)
+    expect(d.upgrade).toBe(false)
+    expect(d.sinceFirstPingMs).toBe(6_000)
+  })
+
+  it('row 4 — ACK over an ACK-held slot ⇒ suppress (original one-ping-per-turn behaviour, unchanged)', () => {
+    const d = decideOverPing({
+      modelRequestedPing: true,
+      firstPingAt: 1_000,
+      substantive: isSubstantiveFinalReply({ text: ACK, disableNotification: false }),
+      firstPingWasSubstantive: false,
+      nowMs: 2_000,
+    })
+    expect(d.suppress).toBe(true)
+    expect(d.claimSlot).toBe(false)
+    expect(d.upgrade).toBe(false)
+  })
+
+  it('the upgrade fires AT MOST once: after an upgrade, a further ack does NOT re-upgrade', () => {
+    // ack pings (slot=ack) → answer upgrades (slot=substantive) → a trailing
+    // ack must now suppress, not ping a third time.
+    const trailingAck = decideOverPing({
+      modelRequestedPing: true,
+      firstPingAt: 2_000, // upgraded slot timestamp
+      substantive: false,
+      firstPingWasSubstantive: true, // slot now substantive after the upgrade
+      nowMs: 3_000,
+    })
+    expect(trailingAck.suppress).toBe(true)
+    expect(trailingAck.upgrade).toBe(false)
+  })
+
+  it('a substantive FIRST ping still claims (no upgrade flag) — upgrade is strictly the second-ping case', () => {
+    const d = decideOverPing({
+      modelRequestedPing: true,
+      firstPingAt: null, // no prior ping this turn
+      substantive: true,
+      nowMs: 1_000,
+    })
+    expect(d.claimSlot).toBe(true)
+    expect(d.upgrade).toBe(false) // first ping is a claim, not an upgrade
+    expect(d.suppress).toBe(false)
   })
 })

--- a/telegram-plugin/tests/over-ping-safety-net.test.ts
+++ b/telegram-plugin/tests/over-ping-safety-net.test.ts
@@ -38,7 +38,7 @@ describe('decideOverPing — at-most-one-ping-per-turn safety net', () => {
       firstPingAt: null,
       nowMs: 1_000,
     })
-    expect(d1).toEqual({ suppress: false, claimSlot: false, sinceFirstPingMs: null })
+    expect(d1).toEqual({ suppress: false, claimSlot: false, upgrade: false, sinceFirstPingMs: null })
 
     // Prior ping already landed — silent reply still no-op, NOT claimed
     const d2 = decideOverPing({
@@ -46,7 +46,7 @@ describe('decideOverPing — at-most-one-ping-per-turn safety net', () => {
       firstPingAt: 1_000,
       nowMs: 5_000,
     })
-    expect(d2).toEqual({ suppress: false, claimSlot: false, sinceFirstPingMs: null })
+    expect(d2).toEqual({ suppress: false, claimSlot: false, upgrade: false, sinceFirstPingMs: null })
   })
 
   it('handles the edge case where firstPingAt equals nowMs (instant double-call)', () => {

--- a/telegram-plugin/uat/assertions.ts
+++ b/telegram-plugin/uat/assertions.ts
@@ -155,6 +155,32 @@ export function assertReplyIsLast(
   }
 }
 
+/**
+ * Assert NOTIFICATION OWNERSHIP (R8 / PR-2 — design
+ * `docs/message-emission-determinism.md` §over-ping): the turn's SUBSTANTIVE
+ * answer must have buzzed the device. mtcute surfaces Telegram's `silent`
+ * flag on every message (`ObservedMessage.silent`, set from the sender's
+ * `disable_notification`); a substantive answer must NOT be silent.
+ *
+ * This guards the residual the bare "first ping wins" rule left: when an
+ * interim ack pings first and claims the turn's single ping slot, the later
+ * substantive answer used to be downgraded to silent — "the reply is last
+ * but the phone never buzzed for the answer." After PR-2 the answer UPGRADES
+ * over the ack's slot and arrives non-silent.
+ *
+ * Throws (rather than returning false) so a scenario reads as a plain
+ * assertion; the message text + silent flag are in the error for triage.
+ */
+export function assertAnswerPinged(answer: ObservedMessage): void {
+  if (answer.silent) {
+    throw new Error(
+      `assertAnswerPinged: the substantive answer arrived SILENT (no device ping) ` +
+        `— an earlier ack-ping downgraded the answer (R8 / PR-2 regression). ` +
+        `answer msg=${answer.messageId} ${JSON.stringify(answer.text.slice(0, 80))}`,
+    );
+  }
+}
+
 export interface PollOptions {
   /** Hard deadline; the predicate must resolve truthy before this. */
   timeout: number;

--- a/telegram-plugin/uat/scenarios/jtbd-answer-pings.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-answer-pings.test.ts
@@ -16,6 +16,16 @@
  *
  * Runs under CI `uat-gate`; the full live MTProto run needs the test-harness
  * agent + a vault session, so locally this self-skips green (no driver).
+ *
+ * Scope caveat: this end-to-end scenario only exercises PR-2's upgrade code
+ * path when the harness model delivers its final answer via the `reply` tool.
+ * If the model answers via `stream_reply` instead, that path bypasses the
+ * over-ping safety net entirely (it never reaches `decideOverPing`), so the
+ * upgrade-over-ack logic is never touched. The model's tool choice isn't
+ * forceable here, which makes this scenario a WEAKER backstop than the unit
+ * matrix — the real proof of the upgrade behaviour lives in the deterministic
+ * unit tests in `over-ping-final-answer-decoupling.test.ts`. Treat this as a
+ * live smoke-test of the happy path, not the source of truth.
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { spinUp, type Scenario } from "../harness.js";

--- a/telegram-plugin/uat/scenarios/jtbd-answer-pings.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-answer-pings.test.ts
@@ -1,0 +1,84 @@
+/**
+ * JTBD: "the answer pings" — notification ownership (R8 / PR-2; design
+ * `docs/message-emission-determinism.md` §over-ping).
+ *
+ * The residual the bare one-ping-per-turn safety net left: when a turn opens
+ * with an interim ACK that pings first, the ack claims the turn's single ping
+ * slot and the LATER substantive answer used to be downgraded to silent — the
+ * reply is last on screen, but the user's phone never buzzed for the actual
+ * answer. PR-2 makes `decideOverPing` aware of WHO holds the slot and lets a
+ * substantive answer UPGRADE over an ack's slot, so the answer pings.
+ *
+ * This scenario drives the exact sequence end-to-end: an "On it" style ack
+ * (pings, claims the slot) followed by a ≥300-char substantive answer, and
+ * asserts the ANSWER arrived non-silent via `assertAnswerPinged`
+ * (mtcute's `ObservedMessage.silent`).
+ *
+ * Runs under CI `uat-gate`; the full live MTProto run needs the test-harness
+ * agent + a vault session, so locally this self-skips green (no driver).
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { spinUp, type Scenario } from "../harness.js";
+import { assertAnswerPinged, isAnswer } from "../assertions.js";
+import { collectTurn } from "../real-work-prompts.js";
+
+/** Overall budget for the ack-then-answer turn. */
+const TURN_BUDGET_MS = 130_000;
+/** The answer must clear the substantive-length backstop (≥200). */
+const MIN_ANSWER_CHARS = 200;
+
+describe("uat: the substantive answer pings even after an ack pinged (DM)", () => {
+  let sc: Scenario | null = null;
+
+  beforeAll(async () => {
+    try {
+      sc = await spinUp({ agent: "test-harness" });
+      await sc.driver.primeDialogs();
+    } catch (err) {
+      console.warn(
+        `[answer-pings] no live driver — self-skipping green: ${(err as Error).message}`,
+      );
+      sc = null;
+    }
+  });
+
+  it(
+    "an ack pings first, then the substantive answer also pings (R8 / PR-2 upgrade)",
+    async () => {
+      if (sc == null) return; // self-skip green
+      const { driver, botUserId, driverUserId } = sc;
+
+      // Prompt the model into the ack-then-answer cadence: a quick pinging
+      // "On it" reply, then — after a beat — a thorough ≥300-character answer
+      // as a fresh (also pinging) reply. The model's exact wording isn't
+      // forceable, so we accept any substantive (≥200-char) answer that lands;
+      // collectTurn skips the short ack (below minAnswerChars) and latches onto
+      // the real answer.
+      const obs = await collectTurn(
+        driver,
+        botUserId,
+        driverUserId,
+        "First send a very short interim reply 'On it.' (pinging — do NOT set " +
+          "disable_notification). THEN, as a separate second reply, give me a " +
+          "thorough answer of at least 300 characters explaining what a Telegram " +
+          "supergroup is, how forum topics partition it, and how a bot routes a " +
+          "reply back to the topic a question came from. The long second reply is " +
+          "your final answer.",
+        { timeoutMs: TURN_BUDGET_MS, minAnswerChars: MIN_ANSWER_CHARS, settleMs: 12_000 },
+      );
+
+      if (obs.answer == null) {
+        console.warn("[answer-pings] INCONCLUSIVE — no substantive answer landed in budget.");
+        return;
+      }
+
+      // Sanity: this is the answer lane, not a feed surface.
+      expect(isAnswer(obs.answer, driverUserId)).toBe(true);
+
+      // The load-bearing assertion: the substantive answer is non-silent. If an
+      // earlier ack-ping had downgraded it (the pre-PR-2 residual), this throws.
+      assertAnswerPinged(obs.answer);
+    },
+    TURN_BUDGET_MS + 30_000,
+  );
+});


### PR DESCRIPTION
## What & why (R8 / PR-2 / Item 2 from `docs/message-emission-determinism.md`)

The over-ping safety net (#1674) enforces at-most-one device ping per turn: the first pinging reply claims a per-turn slot, every subsequent ping is downgraded to silent. That bare **"first ping wins"** rule left a residual **notification-ownership** bug:

> When a turn opens with an interim **ACK that pings first**, the ack claims the slot — and the later **substantive answer is downgraded to silent**. The reply is last on screen, but **the phone never buzzed for the actual answer**.

That is the "reply is last but the device never pinged for the answer" failure R8 names. This PR makes the substantive final reply own the turn's single ping.

## Note-stale finding (card cannot steal the ping)

The design note's feared in-turn **"a card stole the ping"** vector **cannot happen on current main**: framework card sends already pass `disable_notification`, so a card never claims the over-ping slot, and `decideOverPing`'s only consumer is `executeReply`. No machinery was added for that non-problem. (Also corrected: the note claimed three `decideOverPing` call sites — there is exactly **one** (`executeReply`). `executeStreamReply` does not run the over-ping net; it passes the model's `disable_notification` straight through.)

## The fix — ownership-aware decision matrix

`decideOverPing` now knows **who holds the slot** (`firstPingWasSubstantive`) and **who is asking** (`substantive`):

| incoming ↓ \ slot held by → | ACK (non-substantive) | SUBSTANTIVE |
|---|---|---|
| **SUBSTANTIVE answer** | **UPGRADE** — ping + re-claim slot | suppress (#1674 answer+wrap-up guard) |
| **ACK** | suppress (original behaviour) | suppress (no double-ping after the answer) |

The predicate stays **pure**. New inputs (`substantive`, `firstPingWasSubstantive`) default to `false`, preserving the exact pre-PR-2 behaviour for any caller that doesn't thread them.

`CurrentTurn` gains `firstPingWasSubstantive` (init `false`, reset per turn). On a claim or an upgrade, `executeReply` sets `firstPingAt` **and** `firstPingWasSubstantive` **atomically** (same synchronous block, no await between) so a racing second reply reads a consistent pair. Substantiveness is classified on the **model's original intent** (`modelDisableNotification`), mirroring the #2533 decoupling, not the over-ping-downgraded send value.

Grep-confirmed: `firstPingAt` / `firstPingWasSubstantive` are assigned in **exactly one** place (the executeReply over-ping block) plus the turn ctor literal — no other path mutates them.

## Tests

- **Unit** — extended `over-ping-final-answer-decoupling.test.ts` with the full ack/substantive × slot-held-by-{ack,substantive} matrix (4 rows + upgrade-fires-at-most-once + substantive-first-ping-is-a-claim-not-upgrade). Updated `over-ping-safety-net.test.ts` `toEqual` shapes for the new `upgrade` field.
- **UAT** — new `assertAnswerPinged(answer)` in `uat/assertions.ts` asserting the substantive answer's mtcute `silent` flag is false; new scenario `uat/scenarios/jtbd-answer-pings.test.ts` (ack pings → 300-char substantive answer → assert the **answer** arrived non-silent). Self-skips green when no MTProto harness, matching the existing UAT scenarios.

## Verification

- `vitest run` on `over-ping*`, `final-answer-detect`, `feed-reopen-gate`, `represent-guard` — **47/47 green**.
- UAT scenarios self-skip green (no driver).
- `npm run lint` (tsc --noEmit + 8 guards) — clean.
- `npm run build` — compiles; reverted the `src/build-info.ts` auto-regen.
- Did **not** touch card ordering, lever 1/2, reopen, or represent (orthogonal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)