### PR TITLE
docs(reference): align switchroom as the ProductOS working example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ switchroom-macos-*
 switchroom-checksums.txt
 
 .test-tmp/
+
+# Synology NAS thumbnail artifacts
+@eaDir/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,7 +244,7 @@ Three checks. A "no" on any one is a redesign, not a follow-up:
 
 1. **Docs test** — can someone use this without opening `docs/`?
 2. **Defaults test** — does it work on a fresh `switchroom setup` with zero config?
-3. **Consistency test** — same CLI shape, cascade, vault syntax, progress card as adjacent features?
+3. **Consistency test** — same CLI shape, cascade, vault syntax, chat-as-artifact as adjacent features?
 
 **Invariants — `reference/invariants.md`** — *are we even allowed?*
 The lines we won't cross by construction (claude-native,
@@ -257,7 +257,7 @@ The four outcomes in full, how the product functions at a high level,
 and the job index (the single source of truth for which jobs exist).
 
 **Job specs — `reference/jobs/<job>.md`** — *did it do the user's job?*
-19 outcome-focused jobs, each with `job: / outcome: / stakes: / serves:
+20 outcome-focused jobs, each with `job: / outcome: / stakes: / serves:
 / invariants:` frontmatter. Survey cheaply: `head -7 reference/jobs/*.md`.
 Read in full only the job spec(s) the change touches; the body is
 **Good / bad** (dual-audience decision aid), **Prove it** (UAT wired to
@@ -276,8 +276,9 @@ invariant it details (e.g. `access-model.md` backs `no-self-escalation`).
 ### Verdict rule
 
 A change ships when it (a) advances one of the four outcomes,
-(b) satisfies its job spec, (c) passes all three principle checks, and
-(d) crosses no invariant. Anything else is out of scope, however clever.
+(b) satisfies its job spec — proven by its outcome UAT, (c) passes all three
+principle checks, and (d) crosses no invariant. Anything else is out of
+scope, however clever.
 
 ## Repo layout
 

--- a/reference/README.md
+++ b/reference/README.md
@@ -86,6 +86,28 @@ There is no other class. `job:` **always** means a job spec — nothing else
 uses that key. The line, the outcome, and the how are three separate docs (an
 invariant, a job spec, a design record), never collapsed into one.
 
+## How this repo instantiates ProductOS
+
+Switchroom is the canonical worked example of the [ProductOS method](../../ProductOS/).
+The map from each reference doc to its method anchor or template:
+
+| Reference doc | ProductOS anchor / template |
+|---|---|
+| [`vision.md`](vision.md) | `anchors/product-vision.md` |
+| [`principles.md`](principles.md) | `anchors/product-principles.md` |
+| [`invariants.md`](invariants.md) | `anchors/invariants.md` — switchroom is cited as the worked example in the method guide |
+| [`product-spec.md`](product-spec.md) | `templates/product-spec.md` — owns the four outcomes, signals, and job index |
+| [`jobs/*.md`](jobs/) | `templates/job-spec.md` — one file per job, outcome-focused |
+| [`rfcs/*.md`](rfcs/) | `templates/rfc.md` — in two classes, told apart by frontmatter (see below) |
+
+### Where switchroom deliberately diverges
+
+These are considered improvements over the base method, not defects:
+
+- **RFCs are terse design docs, not job-spec hybrids.** Failure-mode thinking (the "Good / bad" section) lives in the job spec. Mechanism lives in the RFC. The two never collapse into one doc.
+- **Two RFC doc-classes, one folder.** A `serves:` key means a ship-coupled RFC delivering a specific job. A `backs:` key means a standing design record defending an invariant. Both live in `rfcs/`; frontmatter tells them apart.
+- **No STRATEGY, decisions, or job-links artefacts.** A single-operator subscription product has no accounts, renewals, or stakeholder portfolios to join across. Those templates exist in the method for multi-product organisations; they add no signal here.
+
 ## `rfcs/` holds two kinds of doc — that's intended
 
 `rfcs/` is the single home for the churny "how" layer. Most files are RFCs

--- a/reference/README.md
+++ b/reference/README.md
@@ -41,7 +41,8 @@ they are **not** a durable contract tier of their own.
 
 The **verdict rule** (also in `CLAUDE.md` → "Design contract"): a change ships
 only when it (a) advances one of the four outcomes, (b) satisfies its job
-spec, (c) passes all three principle checks, and (d) crosses no invariant.
+spec — proven by its outcome UAT, (c) passes all three principle checks, and
+(d) crosses no invariant.
 
 ## The job index lives in the product spec
 

--- a/reference/product-spec.md
+++ b/reference/product-spec.md
@@ -37,6 +37,10 @@ it. The coding specialist is the same thesis, not an exception. Add a
 specialist in ten lines of YAML; you don't fork the product. Memory serves
 this outcome; it isn't the pitch.
 
+**Signal:** continuity — you rarely re-explain. The share of turns that act
+on stored context, rather than re-asking for what the agent should already
+know, trends to near-zero re-onboarding.
+
 ### `hold-the-leash` — controlled, purposeful, never roaming
 
 Agents act, but only with what you gave them. A specialist sees only the
@@ -47,11 +51,19 @@ mid-flight. Awareness and control, not a tool-call log to babysit. (The hard
 floor under this outcome is the `no-self-escalation` and `on-leash`
 invariants.)
 
+**Signal:** approval coverage — every consequential action passes an
+explicit, human-only approval, each one audited and logged, behind an ACL
+only a human can edit. Unapproved consequential actions: zero.
+
 ### `subscription-honest` — the plan is the ceiling
 
 Cost is the subscription you chose, not a meter you can't forecast. Need more
 throughput, pool accounts with automatic failover. One bill, the one you
 already pay. (The hard floor is the `claude-native` invariant.)
+
+**Signal:** zero off-plan callsites — every model call runs through the stock
+Claude CLI on your OAuth subscription. No API-meter path, no `claude -p`
+headless billing, enforced in CI.
 
 ### `always-available` — there when you want it
 
@@ -59,6 +71,10 @@ Each specialist is a long-running service. It survives reboots, network
 drops, your laptop closing. It runs its scheduled work and it's there the
 second you reach for it, anywhere your phone has signal. Available and
 punctual, not autonomous.
+
+**Signal:** always-on and reactive — no turn silently dropped, every turn
+surfaces its work in Telegram, and the agent acts only on your message or a
+cron you created. Median ack within seconds.
 
 ## How it functions, at a high level
 

--- a/reference/rfcs/admin-agent-config-edit.md
+++ b/reference/rfcs/admin-agent-config-edit.md
@@ -1,3 +1,9 @@
+---
+artefact: admin-agent config edit via approval-gated hostd verb
+serves: jobs/approve-what-my-agent-can-touch.md
+status: Draft v1
+---
+
 # RFC: Admin-agent edits to switchroom.yaml via approval-gated hostd verb
 
 Status: Draft v1

--- a/reference/rfcs/agent-managed-skills-phase0-findings.md
+++ b/reference/rfcs/agent-managed-skills-phase0-findings.md
@@ -1,3 +1,9 @@
+---
+artefact: agent-managed skills phase 0 findings
+serves: jobs/extend-without-forking.md
+status: design decisions, ready to drive PR-3 implementation
+---
+
 # Phase 0 findings — agent-managed-skills (RFC #1814)
 
 Status: design decisions, ready to drive PR-3 implementation

--- a/reference/rfcs/agent-managed-skills.md
+++ b/reference/rfcs/agent-managed-skills.md
@@ -1,3 +1,9 @@
+---
+artefact: agent-managed skills — fleet capability lifecycle
+serves: jobs/extend-without-forking.md
+status: Historical — shipped (Phase 1 + 3); Phase 2a superseded
+---
+
 # RFC: Agent-managed skills — fleet capability lifecycle
 
 Status: **Historical** — Phase 1 (personal-skill autonomy) shipped in

--- a/reference/rfcs/agent-self-improvement.md
+++ b/reference/rfcs/agent-self-improvement.md
@@ -1,3 +1,9 @@
+---
+artefact: agents that improve themselves, on the leash
+serves: jobs/get-better-the-longer-they-run.md
+status: Draft
+---
+
 # RFC: Agents that improve themselves, on the leash
 
 Status: Draft

--- a/reference/rfcs/approval-kernel.md
+++ b/reference/rfcs/approval-kernel.md
@@ -1,3 +1,9 @@
+---
+artefact: unified human-approval kernel
+backs: no-self-escalation
+status: Draft v4 — partially shipped; hard-boundary direction descoped for single-tenant
+---
+
 # RFC B: Unified human-approval kernel
 
 Status: Draft v4 — **partially shipped; hard-boundary direction descoped for single-tenant (2026-06-02)**

--- a/reference/rfcs/ask-peer.md
+++ b/reference/rfcs/ask-peer.md
@@ -1,3 +1,9 @@
+---
+artefact: ask_peer — operator-allowlisted visible cross-agent handoff
+serves: jobs/run-a-fleet-of-specialists.md
+status: Draft v1
+---
+
 # RFC: `ask_peer` — operator-allowlisted, visible cross-agent handoff
 
 Status: Draft v1

--- a/reference/rfcs/auth-broker.md
+++ b/reference/rfcs/auth-broker.md
@@ -1,3 +1,9 @@
+---
+artefact: switchroom-auth-broker — single-writer OAuth credential plane
+serves: jobs/share-auth-across-the-fleet.md
+status: Draft v1
+---
+
 # RFC H: `switchroom-auth-broker` — single-writer OAuth credential plane
 
 Status: Draft v1

--- a/reference/rfcs/bot-token-to-vault.md
+++ b/reference/rfcs/bot-token-to-vault.md
@@ -1,3 +1,9 @@
+---
+artefact: complete the bot-token-to-vault migration
+serves: jobs/approve-what-my-agent-can-touch.md
+status: Draft v2 — hygiene, not a boundary
+---
+
 # RFC A: Complete the bot-token-to-vault migration
 
 Status: Draft v2 — **hygiene, not a boundary (2026-06-02)**

--- a/reference/rfcs/bridge-presence.md
+++ b/reference/rfcs/bridge-presence.md
@@ -1,3 +1,9 @@
+---
+artefact: bridge presence — guaranteeing always-on inbound delivery
+serves: jobs/survive-reboots-and-real-life.md
+status: draft v1
+---
+
 # RFC: Bridge presence — guaranteeing always-on inbound delivery
 
 > Status: **draft v1** — design contract for the real fix to the

--- a/reference/rfcs/cheap-cron-sessions.md
+++ b/reference/rfcs/cheap-cron-sessions.md
@@ -1,3 +1,9 @@
+---
+artefact: cheap cron — deterministic polls + per-agent Sonnet cron session
+serves: jobs/crons-use-the-model-only-when-it-earns-it.md
+status: Draft, post-review (rev 2)
+---
+
 # RFC — Cheap cron: deterministic polls + a per-agent Sonnet cron session
 
 **Status:** Draft, post-review (rev 2)

--- a/reference/rfcs/cold-start-ttfo.md
+++ b/reference/rfcs/cold-start-ttfo.md
@@ -1,3 +1,9 @@
+---
+artefact: cold-start TTFO — minimising time to first outbound after restart
+serves: jobs/survive-reboots-and-real-life.md
+status: draft v1
+---
+
 # RFC — Cold-start TTFO
 
 > Status: draft v1 — scoping cold-start latency optimization. Companion to `reference/vision.md` (always-on specialist exec-assistants) and the wedge-cluster JTBD ("agent feels continuous across restarts").

--- a/reference/rfcs/doc-connection-completion.md
+++ b/reference/rfcs/doc-connection-completion.md
@@ -1,3 +1,9 @@
+---
+artefact: make Google Drive a real collaboration surface
+serves: jobs/act-in-my-tools-with-an-identity.md
+status: Draft v3 — implementation pivot in §4.2
+---
+
 # RFC E: Make Google Drive a real collaboration surface
 
 Status: Draft v3 (v3.1 amendment 2026-05-15 — implementation pivot in §4.2)

--- a/reference/rfcs/draft-mirror-preview.md
+++ b/reference/rfcs/draft-mirror-preview.md
@@ -1,3 +1,9 @@
+---
+artefact: draft-stream mirror preview + real-time activity feed
+serves: jobs/know-what-my-agent-is-doing.md
+status: Implemented — flag retired
+---
+
 # RFC: Draft-stream mirror preview (model narration, ephemeral) + reply as commit
 
 **Status:** Implemented — flag retired

--- a/reference/rfcs/eliminate-claude-p.md
+++ b/reference/rfcs/eliminate-claude-p.md
@@ -1,3 +1,9 @@
+---
+artefact: eliminate claude -p (programmatic usage) from switchroom
+serves: jobs/keep-my-subscription-honest.md
+status: accepted — shipped in #1625 and #1626
+---
+
 # RFC — Eliminate `claude -p` (programmatic usage) from switchroom
 
 > Status: accepted — 2026-05-21 (Workstream A shipped in #1625;

--- a/reference/rfcs/gdrive-mcp.md
+++ b/reference/rfcs/gdrive-mcp.md
@@ -1,3 +1,9 @@
+---
+artefact: Google Drive MCP integration
+serves: jobs/act-in-my-tools-with-an-identity.md
+status: Implemented in v0.6.0
+---
+
 # RFC D: Google Drive MCP integration
 
 Status: **Implemented in v0.6.0** (2026-05-06). Originally drafted as "RFC C" — renumbered to D after `host-control-daemon.md` claimed the C slot in v0.7.x. This document is retained as the design record; the implementation is the source of truth.

--- a/reference/rfcs/google-workspace-generalization.md
+++ b/reference/rfcs/google-workspace-generalization.md
@@ -1,3 +1,9 @@
+---
+artefact: Google Workspace as a first-class agent capability
+serves: jobs/act-in-my-tools-with-an-identity.md
+status: Draft v3
+---
+
 # RFC G: Google Workspace as a first-class agent capability
 
 Status: Draft v3

--- a/reference/rfcs/host-control-daemon.md
+++ b/reference/rfcs/host-control-daemon.md
@@ -1,3 +1,9 @@
+---
+artefact: host-control daemon (switchroom-hostd)
+serves: jobs/idempotent-update-and-restart.md
+status: Draft v3 (docker-first correction)
+---
+
 # RFC C: Host-control daemon (`switchroom-hostd`)
 
 Status: Draft v3 (docker-first correction)

--- a/reference/rfcs/inbound-delivery-state-machine.md
+++ b/reference/rfcs/inbound-delivery-state-machine.md
@@ -1,3 +1,9 @@
+---
+artefact: InboundDeliveryStateMachine
+serves: jobs/survive-reboots-and-real-life.md
+status: draft v1
+---
+
 # RFC — InboundDeliveryStateMachine
 
 > Status: draft v1 — design contract for Phase 2b of the wedge-cluster remediation. Closes the architectural class of bugs that v0.12.22 (#1573) patched at the symptom level.

--- a/reference/rfcs/microsoft-workspace.md
+++ b/reference/rfcs/microsoft-workspace.md
@@ -1,3 +1,9 @@
+---
+artefact: Microsoft 365 integration (OneDrive + Office files + Mail + Calendar)
+serves: jobs/act-in-my-tools-with-an-identity.md
+status: Draft
+---
+
 # RFC: Microsoft 365 integration (OneDrive + Office files + Mail + Calendar)
 
 **Status:** Draft

--- a/reference/rfcs/notion-integration.md
+++ b/reference/rfcs/notion-integration.md
@@ -1,3 +1,9 @@
+---
+artefact: Notion integration
+serves: jobs/act-in-my-tools-with-an-identity.md
+status: Draft
+---
+
 # RFC: Notion integration
 
 **Status:** Draft

--- a/reference/rfcs/secret-request-vault-save.md
+++ b/reference/rfcs/secret-request-vault-save.md
@@ -1,3 +1,9 @@
+---
+artefact: agent-requested secrets — secure save-card to vault (no chat paste)
+serves: jobs/approve-what-my-agent-can-touch.md
+status: Draft
+---
+
 # RFC: Agent-requested secrets — secure save-card → vault (no chat paste)
 
 **Status:** Draft (needs operator product decision on §6)

--- a/reference/rfcs/skill-authoring-native.md
+++ b/reference/rfcs/skill-authoring-native.md
@@ -1,3 +1,9 @@
+---
+artefact: native-by-default skill authoring
+serves: jobs/extend-without-forking.md
+status: Implemented (Phase 1 + 3); Phase 2a superseded
+---
+
 # RFC: Native-by-default skill authoring
 
 > **SUPERSEDED IN PART (post-implementation).** Phase 1 (native

--- a/reference/rfcs/status-card-design.md
+++ b/reference/rfcs/status-card-design.md
@@ -1,5 +1,6 @@
 ---
 artefact: Telegram progress card
+serves: jobs/know-what-my-agent-is-doing.md
 status: archived — superseded
 supersededBy: conversational-pacing.md
 ---

--- a/reference/rfcs/supergroup-easy-defaults.md
+++ b/reference/rfcs/supergroup-easy-defaults.md
@@ -1,3 +1,9 @@
+---
+artefact: supergroup easy-mode defaults (zero-config "agent owns a working room")
+serves: jobs/talk-to-agents-from-anywhere.md
+status: Phase 1 implemented
+---
+
 # RFC: Supergroup easy-mode defaults (zero-config "agent owns a working room")
 
 **Status:** Phase 1 implemented (this PR)

--- a/reference/rfcs/supergroup-mode.md
+++ b/reference/rfcs/supergroup-mode.md
@@ -1,3 +1,9 @@
+---
+artefact: per-agent Telegram supergroup mode
+serves: jobs/talk-to-agents-from-anywhere.md
+status: Draft for ratification
+---
+
 # RFC: Per-agent Telegram supergroup mode
 
 **Status:** Draft for ratification

--- a/reference/rfcs/vault-approval-hard-boundary.md
+++ b/reference/rfcs/vault-approval-hard-boundary.md
@@ -1,3 +1,9 @@
+---
+artefact: hard-boundary operator approvals (no agent self-elevation)
+backs: no-self-escalation
+status: Draft for operator review
+---
+
 # RFC: Hard-boundary operator approvals (no agent self-elevation)
 
 - Status: **Draft for operator review**

--- a/reference/rfcs/vault-broker-resilience.md
+++ b/reference/rfcs/vault-broker-resilience.md
@@ -1,3 +1,9 @@
+---
+artefact: vault-broker resilience and default auto-unlock
+serves: jobs/survive-reboots-and-real-life.md
+status: Draft v1
+---
+
 # RFC J: Vault-broker resilience & default auto-unlock
 
 Status: Draft v1

--- a/reference/rfcs/webhook-cloudflare-edge-lock.md
+++ b/reference/rfcs/webhook-cloudflare-edge-lock.md
@@ -1,3 +1,9 @@
+---
+artefact: Cloudflare-only edge lock for webhook ingest
+backs: no-self-escalation
+status: Draft v1
+---
+
 # RFC: Cloudflare-only edge lock for webhook ingest
 
 Status: Draft v1

--- a/reference/rfcs/webhook-via-gateway-socket.md
+++ b/reference/rfcs/webhook-via-gateway-socket.md
@@ -1,3 +1,9 @@
+---
+artefact: webhook ingest writes via the agent gateway socket
+backs: no-self-escalation
+status: Draft v1
+---
+
 # RFC: Webhook ingest writes via the agent gateway socket
 
 Status: Draft v1

--- a/reference/vision.md
+++ b/reference/vision.md
@@ -121,5 +121,6 @@ specific PR or design:
   frontmatter) each `serves:` one outcome.
 
 A change lands when it (a) advances one of the four outcomes, (b) satisfies
-its job spec, (c) passes all three principle checks, and (d) crosses no
-invariant. Anything else is out of scope, however clever.
+its job spec — proven by its outcome UAT, (c) passes all three principle
+checks, and (d) crosses no invariant. Anything else is out of scope, however
+clever.


### PR DESCRIPTION
Makes switchroom the readable, machine-checkable working example of the ProductOS method.

## What
- **Signals on the four outcomes** + verdict-rule wording aligned (`product-spec.md`, `vision.md`, `CLAUDE.md`, `reference/README.md`).
- **README "How this repo instantiates ProductOS" section** — maps each reference doc to its method anchor/template and states the three deliberate divergences (terse RFCs, two RFC doc-classes by frontmatter, no strategy/decisions/job-links artefacts in a personal subscription product).
- **Backfilled `serves:`/`backs:` ladder frontmatter on 29 RFCs** that lacked a machine-checkable key. Every doc now visibly ladders to an outcome (`serves:` a job) or defends an invariant (`backs:`). Closes the verdict-rule gap at the how-layer; jobs already carried this.
- Added `@eaDir/` to `.gitignore` (Synology thumbnail artefacts).

## Notes
Two ladder slugs were judgement calls: `host-control-daemon` → `serves: idempotent-update-and-restart` (vs survive-reboots), and `webhook-cloudflare-edge-lock` → `backs: no-self-escalation` (threat model is unauthorized access, not uptime). Both defensible; easy to reslot.

Companion change lands in the ProductOS method repo (promotes per-outcome signals to the default vision shape, wires the verdict rule + invariants into the RFC template, adds a product-spec template and the `backs:` design-record class).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>