### PR TITLE
fix(inject): strip TUI chrome in anchored diffPane path (v2.1.185 /clear regression)

### DIFF
--- a/src/agents/inject.test.ts
+++ b/src/agents/inject.test.ts
@@ -255,7 +255,48 @@ describe("diffPane — /clear post-clear TUI chrome filtering", () => {
     expect(r.output).toBe("");
   });
 
-  it("anchored /cost path is unaffected — real content passes through", () => {
+  // Regression test for the v2.1.185 bug: after /clear, the command-echo
+  // line `❯ /clear` SURVIVES in capture-pane output, so the anchored path
+  // runs — but it was returning the trailing chrome raw. The fix adds
+  // isTuiChromeLine filtering to the anchored path as well. After filtering,
+  // the tail is empty, so the code falls through to set-diff (anchored=false)
+  // which is also empty → output="" → ok_no_output. Either way, the critical
+  // invariant is that output is empty (no chrome leaks to Telegram).
+  //
+  // This is the exact `after` pane from the live reproduction capture at
+  // /state/agent/home/workspace/clearfix-evidence/after.txt (trimmed to the
+  // relevant tail after the startup banner).
+  it("anchored path: /clear echo present + trailing chrome → output empty (v2.1.185 regression)", () => {
+    const before = `❯ /clear`;
+    const after = `❯ /clear
+
+────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────
+  ⏵⏵ accept edits on (shift+tab to cycle) · ← for agents`;
+    const r = diffPane(before, after, "/clear");
+    expect(r.output, "chrome-only tail must yield empty output — no chrome leaks to Telegram").toBe("");
+  });
+
+  it("anchored /cost path with trailing chrome — real content passes, chrome is stripped", () => {
+    const before = "❯ /cost\n";
+    const after = `❯ /cost
+  Total cost: $1.23
+  Session: $0.12 (3 turns)
+────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────
+  ⏵⏵ accept edits on (shift+tab to cycle) · ← for agents`;
+    const r = diffPane(before, after, "/cost");
+    expect(r.anchored).toBe(true);
+    expect(r.output).toContain("Total cost: $1.23");
+    expect(r.output).toContain("$0.12");
+    expect(r.output).not.toContain("────────────────────────────────────────────────────────────────────────────────");
+    expect(r.output).not.toContain("accept edits on");
+    expect(r.output).not.toMatch(/^❯\s*$/m);
+  });
+
+  it("anchored /cost path is unaffected by fix — real content passes through (no chrome present)", () => {
     const before = "❯ /cost\n";
     const after = `❯ /cost
   Total cost: $0.42
@@ -277,7 +318,7 @@ describe("diffPane — /clear post-clear TUI chrome filtering", () => {
 });
 
 describe("injectSlashCommandWith — /clear produces ok_no_output (not ok with chrome)", () => {
-  it("post-clear pane with only TUI chrome → outcome=ok_no_output, output empty", async () => {
+  it("post-clear pane with only TUI chrome (anchor absent) → outcome=ok_no_output, output empty", async () => {
     // Simulate what happens after /clear: pre-snapshot has content,
     // post-capture has only fresh input-box chrome (no command-echo line).
     const before = `  Some earlier session output
@@ -296,6 +337,46 @@ describe("injectSlashCommandWith — /clear produces ok_no_output (not ok with c
         // First capture (before send) returns the pre-snapshot.
         // Subsequent captures (after send) return the post-clear chrome.
         return callCount === 1 ? before : clearChrome;
+      },
+      send: () => {},
+    };
+
+    const r = await injectSlashCommandWith(runner, {
+      socket: "switchroom-test",
+      session: "test",
+      command: "/clear",
+      settleMs: 50,
+      timeoutMs: 200,
+    });
+
+    expect(r.outcome).toBe("ok_no_output");
+    expect(r.output).toBe("");
+    expect(r.command).toBe("/clear");
+    expect(r.meta?.silentNote).toBe("context cleared — fresh slate");
+  });
+
+  // Regression test for the v2.1.185 bug: the command-echo `❯ /clear`
+  // survives in tmux capture-pane after /clear runs, so the anchored path
+  // runs and previously returned trailing chrome verbatim. With the fix the
+  // anchored path also strips chrome, leaving an empty tail → ok_no_output.
+  it("post-clear pane with command-echo anchor + trailing chrome → outcome=ok_no_output (v2.1.185 regression)", async () => {
+    const before = `  Some earlier session output
+  Another line of output
+❯ /clear`;
+    // Exact shape from the live reproduction capture: echo survives, chrome follows.
+    const afterWithAnchor = `❯ /clear
+
+────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────
+  ⏵⏵ accept edits on (shift+tab to cycle) · ← for agents`;
+
+    let callCount = 0;
+    const runner: TmuxRunner = {
+      hasSession: () => true,
+      capture: () => {
+        callCount += 1;
+        return callCount === 1 ? before : afterWithAnchor;
       },
       send: () => {},
     };

--- a/src/agents/inject.ts
+++ b/src/agents/inject.ts
@@ -427,6 +427,7 @@ export function diffPane(before: string, after: string, command?: string): DiffP
       for (const raw of tail) {
         const line = raw.trimEnd();
         if (line.length === 0 && trimmed.length === 0) continue;
+        if (isTuiChromeLine(line)) continue;
         trimmed.push(line);
       }
       while (trimmed.length > 0 && trimmed[trimmed.length - 1].length === 0) {
@@ -443,10 +444,9 @@ export function diffPane(before: string, after: string, command?: string): DiffP
     }
   }
   // Fallback: line-set diff against pre-snapshot, then strip TUI chrome.
-  // The chrome filter is applied here (fallback only) because `/clear`
-  // wipes the screen so the command-echo anchor is gone — the post-capture
-  // contains only fresh input-box furniture that isn't in the pre-snapshot
-  // and would otherwise be classified as command output.
+  // Chrome is also filtered in the anchored path above; both paths strip it
+  // so that `/clear`'s input-box furniture never reaches Telegram regardless
+  // of whether the command-echo anchor is present in the post-capture.
   const beforeSet = new Set(before.split("\n").map((l) => l.trimEnd()));
   const newLines: string[] = [];
   for (const raw of after.split("\n")) {


### PR DESCRIPTION
## Summary

- **Root cause:** On Claude Code v2.1.185 the command-echo line `❯ /clear` survives in `tmux capture-pane` output after `/clear` runs. This causes `diffPane`'s ANCHORED path (not the fallback) to handle `/clear`. PR #2538 added `isTuiChromeLine` filtering only in the FALLBACK path, so the anchored path returned the trailing input-box chrome — box rules, bare `❯` prompt, and the `⏵⏵ accept edits on (shift+tab to cycle) · ← for agents` footer — verbatim to Telegram.
- **Fix:** One line added to the anchored path's tail-building loop: `if (isTuiChromeLine(line)) continue;` — mirroring the filter already in the fallback. After filtering, `/clear`'s tail is empty → the existing "anchor found but tail empty → fall through to set-diff" path runs → set-diff is also empty → `outcome=ok_no_output`, which renders the clean `silentNote` ("context cleared — fresh slate") instead of chrome.
- **Safe for all anchored commands:** chrome lines (box rules, bare prompt glyphs, footer hints) are never legitimate command output. Real output from `/cost`, `/status`, etc. is preserved; only furniture is dropped. Confirmed by a new test pinning the `/cost`-with-trailing-chrome case.

**Vision outcome:** Visibility — every step pinned to chat must be legible, not raw terminal furniture.  
**Job spec:** `know-what-my-agent-is-doing` — the user sees what the agent is actually doing; `/clear` outputting TUI chrome is a legibility failure.

Fixes the /clear chrome leak that #2538 only partially addressed (anchored path was left unfiltered); reproduced live on Claude Code v2.1.185.

## Test plan

New tests in `src/agents/inject.test.ts`:

- [ ] `diffPane`: `/clear` echo present + trailing chrome → `output=""` (the v2.1.185 regression case — this is the test that would have caught the bug)
- [ ] `diffPane`: anchored `/cost` path with trailing chrome → real content passes, chrome lines do NOT appear in output
- [ ] `injectSlashCommandWith`: command-echo anchor present + trailing chrome → `outcome=ok_no_output`, `output=""` (end-to-end regression gate)
- [ ] All 62 existing `inject.test.ts` tests pass

**Before fix:** the new v2.1.185 regression test would fail (chrome leaks through anchored path).  
**After fix:** all 62 tests pass. `npm run lint` (tsc --noEmit) clean. `npm run build` clean.