### PR TITLE
refactor(telegram): emission-authority façade seam (no-op) (PR-4a)

### DIFF
--- a/telegram-plugin/gateway/emission-authority.ts
+++ b/telegram-plugin/gateway/emission-authority.ts
@@ -1,0 +1,174 @@
+/**
+ * Per-foreground-turn EMISSION-AUTHORITY façade (kill-switched no-op seam).
+ *
+ * This is the SEAM the message-emission-determinism refactor (PR-4 series,
+ * `docs/message-emission-determinism.md` §9 "deeper architectural move") routes
+ * the foreground-lane card/ping emission call sites through. It mirrors the
+ * one-concern-per-file precedent of `feed-open-gate.ts`: a single place that
+ * will eventually OWN the WHEN of foreground emission. The gateway constructs
+ * exactly ONE instance per foreground turn, alongside the `CurrentTurn` object,
+ * and passes the chat/thread key in EXPLICITLY (even though today it is sourced
+ * from the `currentTurn` singleton) — that explicit key is the seam PR-4e uses
+ * to swap the singleton for a per-topic map. The façade must NOT persist across
+ * turns: it is per-turn only, because cross-turn persistence would pre-empt the
+ * per-chat scoping decision PR-4e owns.
+ *
+ * ## PR-4a is a behaviourally-IDENTICAL no-op
+ *
+ * In PR-4a NO decision logic moves in. Every method is a THIN DELEGATE: it
+ * invokes the same statements the call site ran before, via an `apply` thunk
+ * the caller hands in (so the load-bearing literals — `drainActivitySummary`,
+ * `clearActivitySummary`, `decideOverPing`, the `finalAnswerEverDelivered`
+ * latch-set — stay AT THE CALL SITE and remain visible to the source-read
+ * wiring oracles). Framing (A) "construct-but-bypass": each method body branches
+ * on the kill-switch, and in PR-4a BOTH branches execute the SAME delegate, so
+ * the seam is a provable no-op even when the flag is ON. The flag's real teeth
+ * (moving `mayOpenActivityCard` / `decideOverPing` decisions INTO the façade)
+ * start in PR-4b — NOT here.
+ *
+ * ## PR-4d deadlock invariant (ship as a standing doc-comment)
+ *
+ * `mayDrain` is a PURE READ; it must NOT acquire `chatLock`. PR-4d acquires
+ * `chatLock` strictly INSIDE the deliver-before-drain gate decision (gateway.ts
+ * component-1, ref ~`:2730`), never the reverse, because a synthetic represent
+ * turn starts `finalAnswerDelivered=false` and would wedge the gate (ref
+ * ~`:1646`) if a card OPEN held the lock across the gate's release. Keep
+ * `mayDrain` lock-free so PR-4d has a clean read to build on.
+ */
+
+/**
+ * Kill-switch. Read ONCE at module top, `=== '1'` (default OFF), following the
+ * existing flag convention (`SWITCHROOM_FEED_HEARTBEAT` etc. in gateway.ts's
+ * flag region). In PR-4a this gates nothing behaviourally — both branches of
+ * every façade method run the same delegate — so unset and set are identical.
+ * It exists now so the seam is in place; PR-4b is where ON starts to differ.
+ */
+export const EMISSION_AUTHORITY_ENABLED =
+  process.env.SWITCHROOM_EMISSION_AUTHORITY === '1'
+
+/** Which producer triggered a card OPEN/EDIT — carried for the PR-4b seam. */
+export type EmissionProducer = 'narrative' | 'tool' | 'liveness'
+
+/**
+ * The minimal per-turn surface the façade needs. A structural subset of
+ * `CurrentTurn` — keeps this module decoupled from gateway.ts's giant turn type
+ * (and out of an import cycle) while still typing the reads it performs.
+ */
+export interface EmissionTurnView {
+  /** Single-flight slot: a drain Promise is in flight when non-null. */
+  activityInFlight: Promise<void> | null
+}
+
+/** Inputs to the over-ping claim/downgrade decision (carried for PR-4b). */
+export interface PingClaimInput {
+  /** The model asked for a device ping (`disable_notification: false`). */
+  modelRequestedPing: boolean
+  /** This reply is a substantive final answer (`isSubstantiveFinalReply`). */
+  substantive: boolean
+}
+
+/**
+ * Per-foreground-turn emission-authority façade.
+ *
+ * Constructed once per turn with the chat/thread key passed in explicitly (the
+ * PR-4e seam). In PR-4a every method just runs the caller's delegate — no
+ * decision logic lives here yet.
+ */
+export class EmissionAuthority {
+  /**
+   * @param chatKey  The chat/thread key this façade governs, passed in
+   *   EXPLICITLY by the gateway (today sourced from the `currentTurn`
+   *   singleton). PR-4e swaps the singleton for a per-topic map keyed on this.
+   *   Unused in PR-4a beyond being held — it is the seam, not yet a decision
+   *   input.
+   */
+  constructor(private readonly chatKey: string) {}
+
+  /** The chat/thread key this façade was constructed for (PR-4e seam read). */
+  get key(): string {
+    return this.chatKey
+  }
+
+  /**
+   * Card OPEN-or-EDIT for the foreground turn (delegates to
+   * `drainActivitySummary` at the call site via `apply`).
+   *
+   * PR-4a: a pure pass-through. The `producer` is carried for the PR-4b OPEN
+   * gate but consulted nowhere yet; both kill-switch branches run `apply`
+   * unchanged, so the drain happens exactly as before. The delegate keeps the
+   * `turn.activityInFlight = drainActivitySummary(turn, <producer>)` assignment
+   * AT THE CALL SITE so the source-read wiring oracles still see it.
+   */
+  openOrEditCard(
+    _producer: EmissionProducer,
+    apply: () => void,
+  ): void {
+    if (EMISSION_AUTHORITY_ENABLED) {
+      // PR-4b will gate the OPEN here via `mayOpenActivityCard` using
+      // `_producer`. PR-4a: identical to the disabled branch — just delegate.
+      apply()
+      return
+    }
+    apply()
+  }
+
+  /**
+   * Finalize the card before a substantive reply send (delegates to
+   * `clearActivitySummary` at the call site via `apply`).
+   *
+   * PR-4a: a pure pass-through. Both branches run `apply`.
+   */
+  finalizeCard(apply: () => void): void {
+    if (EMISSION_AUTHORITY_ENABLED) {
+      apply()
+      return
+    }
+    apply()
+  }
+
+  /**
+   * Mark that a substantive final answer was delivered this turn — the sticky
+   * lever-1 latch (delegates to the `finalAnswerEverDelivered = true` set at the
+   * call site via `apply`).
+   *
+   * PR-4a: a pure pass-through. Both branches run `apply`.
+   */
+  markSubstantiveFinalDelivered(apply: () => void): void {
+    if (EMISSION_AUTHORITY_ENABLED) {
+      apply()
+      return
+    }
+    apply()
+  }
+
+  /**
+   * Claim-or-downgrade the turn's one notification ping (wraps the existing
+   * `decideOverPing` block via `apply`).
+   *
+   * PR-4a: a pure pass-through. The `_input` is carried for the PR-4b seam but
+   * consulted nowhere yet; both branches run `apply`, which executes the
+   * existing over-ping block verbatim (the `decideOverPing` call, the stderr
+   * log, the metric emit, the `firstPingAt` / `firstPingWasSubstantive`
+   * mutations, and the `disableNotification` / `wasOverPingSuppressed`
+   * assignments the call site consumes). Nothing about the decision moves here.
+   */
+  claimOrDowngradePing(_input: PingClaimInput, apply: () => void): void {
+    if (EMISSION_AUTHORITY_ENABLED) {
+      apply()
+      return
+    }
+    apply()
+  }
+
+  /**
+   * Single-flight read: may a drain start? Returns `turn.activityInFlight ==
+   * null` — the EXACT guard every drain call site already performs.
+   *
+   * PURE READ, NO lock acquisition (see the PR-4d deadlock invariant in this
+   * module's header). PR-4d needs this read clean so it can acquire `chatLock`
+   * elsewhere without the lattice inverting.
+   */
+  mayDrain(turn: EmissionTurnView): boolean {
+    return turn.activityInFlight == null
+  }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -336,6 +336,7 @@ import { decideInboundDelivery } from './inbound-delivery-gate.js'
 import { mayDrainBufferedInbound, shouldArmNoReplyDrain } from './serialize-drain-gate.js'
 import { decideFeedReopen } from './feed-reopen-gate.js'
 import { mayOpenActivityCard, type FeedOpenProducer } from './feed-open-gate.js'
+import { EmissionAuthority } from './emission-authority.js'
 import { resolveAnswerThreadId } from './answer-thread-resolve.js'
 import {
   createDeliveryQueue,
@@ -2133,9 +2134,34 @@ type CurrentTurn = {
   // gates on minInitialChars). Materialized and cleared at turn_end.
   answerStream: AnswerStreamHandle | null
   isDm: boolean
+  // PR-4a (message-emission-determinism, `emission-authority.ts`). The
+  // per-foreground-turn emission-authority façade the foreground-lane card/ping
+  // emission call sites route through. Constructed ONCE per turn in the ctor
+  // with the chat/thread key passed in explicitly (the PR-4e seam). Per-turn
+  // only — a fresh `CurrentTurn` literal gets a fresh façade, so it never
+  // persists across turns. Optional in the type so the bounded recently-ended
+  // registry's older entries (and any hand-built test turn) tolerate its
+  // absence; `emissionAuthorityFor` lazily backfills one when missing.
+  emissionAuthority?: EmissionAuthority
 }
 
 let currentTurn: CurrentTurn | null = null
+
+/**
+ * Accessor for a turn's per-foreground-turn emission-authority façade (PR-4a).
+ * Returns the façade constructed at the turn ctor; lazily backfills one (keyed
+ * on the turn's chat/thread) for any turn that predates the field or was built
+ * outside the ctor. Per-turn: the memoized instance lives on the turn object,
+ * so it is discarded with the turn and never persists across turns.
+ */
+function emissionAuthorityFor(turn: CurrentTurn): EmissionAuthority {
+  if (turn.emissionAuthority == null) {
+    turn.emissionAuthority = new EmissionAuthority(
+      statusKey(turn.sessionChatId, turn.sessionThreadId),
+    )
+  }
+  return turn.emissionAuthority
+}
 
 // Component 3 (turn-origin reply routing). Recently-ended turns retained
 // by `turnId` so a LATE reply (the Brevo answer landing ~42s after
@@ -7780,45 +7806,55 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
         text: rawText,
         disableNotification: modelDisableNotification,
       })
-      const decision = decideOverPing({
-        modelRequestedPing: !disableNotification,
-        firstPingAt: turn.firstPingAt,
-        substantive: replySubstantive,
-        firstPingWasSubstantive: turn.firstPingWasSubstantive,
-        nowMs: now,
-      })
-      if (decision.suppress) {
-        process.stderr.write(
-          `telegram gateway: reply over-ping safety net — ` +
-          `downgrading disable_notification:false → true ` +
-          `(chat=${chat_id} thread=${args.message_thread_id ?? '-'} ` +
-          `firstPingAt=${turn.firstPingAt} sinceFirstPing_ms=${decision.sinceFirstPingMs})\n`,
-        )
-        // Observability: surface to the unified runtime-metrics
-        // fan-out so the cadence dashboard can track fleet-wide
-        // over-ping rate (leading indicator of model pacing drift).
-        emitRuntimeMetric({
-          kind: 'over_ping_suppressed',
-          key: statusKey(chat_id, args.message_thread_id != null
-            ? Number(args.message_thread_id) : undefined),
-          sinceFirstPingMs: decision.sinceFirstPingMs ?? 0,
-        })
-        disableNotification = true
-        wasOverPingSuppressed = true
-      } else if (decision.claimSlot) {
-        // Claim (first ping) OR upgrade (substantive answer pinging over an
-        // ack's slot). Set firstPingAt AND firstPingWasSubstantive ATOMICALLY
-        // (no await between) so a racing second reply reads a consistent pair.
-        turn.firstPingAt = now
-        turn.firstPingWasSubstantive = replySubstantive
-        if (decision.upgrade) {
-          process.stderr.write(
-            `telegram gateway: reply over-ping safety net — ` +
-            `UPGRADE: substantive answer pings over an ack's slot ` +
-            `(chat=${chat_id} thread=${args.message_thread_id ?? '-'})\n`,
-          )
-        }
-      }
+      // PR-4a: routed through the emission-authority façade (no-op delegate —
+      // the `decideOverPing` decision, the stderr logs, the metric emit, the
+      // `firstPingAt`/`firstPingWasSubstantive` mutations, and the
+      // `disableNotification`/`wasOverPingSuppressed` outer-scope writes the
+      // send path consumes all run exactly as before, inside the delegate).
+      emissionAuthorityFor(turn).claimOrDowngradePing(
+        { modelRequestedPing: !disableNotification, substantive: replySubstantive },
+        () => {
+          const decision = decideOverPing({
+            modelRequestedPing: !disableNotification,
+            firstPingAt: turn.firstPingAt,
+            substantive: replySubstantive,
+            firstPingWasSubstantive: turn.firstPingWasSubstantive,
+            nowMs: now,
+          })
+          if (decision.suppress) {
+            process.stderr.write(
+              `telegram gateway: reply over-ping safety net — ` +
+              `downgrading disable_notification:false → true ` +
+              `(chat=${chat_id} thread=${args.message_thread_id ?? '-'} ` +
+              `firstPingAt=${turn.firstPingAt} sinceFirstPing_ms=${decision.sinceFirstPingMs})\n`,
+            )
+            // Observability: surface to the unified runtime-metrics
+            // fan-out so the cadence dashboard can track fleet-wide
+            // over-ping rate (leading indicator of model pacing drift).
+            emitRuntimeMetric({
+              kind: 'over_ping_suppressed',
+              key: statusKey(chat_id, args.message_thread_id != null
+                ? Number(args.message_thread_id) : undefined),
+              sinceFirstPingMs: decision.sinceFirstPingMs ?? 0,
+            })
+            disableNotification = true
+            wasOverPingSuppressed = true
+          } else if (decision.claimSlot) {
+            // Claim (first ping) OR upgrade (substantive answer pinging over an
+            // ack's slot). Set firstPingAt AND firstPingWasSubstantive ATOMICALLY
+            // (no await between) so a racing second reply reads a consistent pair.
+            turn.firstPingAt = now
+            turn.firstPingWasSubstantive = replySubstantive
+            if (decision.upgrade) {
+              process.stderr.write(
+                `telegram gateway: reply over-ping safety net — ` +
+                `UPGRADE: substantive answer pings over an ack's slot ` +
+                `(chat=${chat_id} thread=${args.message_thread_id ?? '-'})\n`,
+              )
+            }
+          }
+        },
+      )
     }
   }
 
@@ -8024,8 +8060,15 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
       finalizeTurn != null
       && isSubstantiveFinalReply({ text: rawText, disableNotification: modelDisableNotification })
     ) {
-      finalizeTurn.finalAnswerEverDelivered = true
-      clearActivitySummary(finalizeTurn)
+      // PR-4a: routed through the emission-authority façade (no-op delegates —
+      // the latch-set and the finalize run exactly as before).
+      const ea = emissionAuthorityFor(finalizeTurn)
+      ea.markSubstantiveFinalDelivered(() => {
+        finalizeTurn.finalAnswerEverDelivered = true
+      })
+      ea.finalizeCard(() => {
+        clearActivitySummary(finalizeTurn)
+      })
     }
   }
 
@@ -8744,8 +8787,15 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       done: args.done === true,
     })
   ) {
-    turn.finalAnswerEverDelivered = true
-    clearActivitySummary(turn)
+    // PR-4a: routed through the emission-authority façade (no-op delegates —
+    // the latch-set and the finalize run exactly as before).
+    const ea = emissionAuthorityFor(turn)
+    ea.markSubstantiveFinalDelivered(() => {
+      turn.finalAnswerEverDelivered = true
+    })
+    ea.finalizeCard(() => {
+      clearActivitySummary(turn)
+    })
   }
 
   const result = await handleStreamReply(
@@ -10365,13 +10415,17 @@ function showNarrativeStep(turn: CurrentTurn, text: string): void {
   const rendered = appendActivityLabel(turn.mirrorLines, clipNarrative(text))
   if (rendered == null) return
   turn.activityPendingRender = composeTurnActivity(turn) ?? rendered
-  if (turn.activityInFlight == null) {
+  const ea = emissionAuthorityFor(turn)
+  if (ea.mayDrain(turn)) {
     // Producer A (narrative SHOW): may only EDIT an already-open card, never
     // OPEN one on a 0-tool turn (design §9 lever 5 base case — the
     // triplication). The OPEN gate in the drain enforces this; accumulation
     // into mirrorLines still happens so the narration renders once a tool
     // label or liveness opens the card.
-    turn.activityInFlight = drainActivitySummary(turn, 'narrative')
+    // PR-4a: routed through the emission-authority façade (no-op delegate).
+    ea.openOrEditCard('narrative', () => {
+      turn.activityInFlight = drainActivitySummary(turn, 'narrative')
+    })
   }
 }
 
@@ -10616,11 +10670,15 @@ function feedHeartbeatTick(): void {
     const rendered = renderActivityFeedWithNested(['Working…'], [], false, ` · ${formatFeedElapsed(age)}`, undefined, livenessHeader)
     if (rendered == null) return
     turn.activityPendingRender = rendered
-    if (turn.activityInFlight == null) {
+    const ea = emissionAuthorityFor(turn)
+    if (ea.mayDrain(turn)) {
       // Producer C (liveness timer): the genuine ≥12s thinking-gap open. This
       // is the ONE producer that may OPEN a 0-tool card (design §9 lever 5
       // preserves it). The sticky-latch (lever 1) still gates it in the drain.
-      turn.activityInFlight = drainActivitySummary(turn, 'liveness')
+      // PR-4a: routed through the emission-authority façade (no-op delegate).
+      ea.openOrEditCard('liveness', () => {
+        turn.activityInFlight = drainActivitySummary(turn, 'liveness')
+      })
     }
     return
   }
@@ -10633,10 +10691,14 @@ function feedHeartbeatTick(): void {
   const rendered = composeTurnActivity(turn, false, ` · ${formatFeedElapsed(elapsed)}`)
   if (rendered == null) return
   turn.activityPendingRender = rendered
-  if (turn.activityInFlight == null) {
+  const ea = emissionAuthorityFor(turn)
+  if (ea.mayDrain(turn)) {
     // Maintains an already-open card (guarded above on activityMessageId !=
     // null) → only ever EDITs. 'liveness' is correct either way.
-    turn.activityInFlight = drainActivitySummary(turn, 'liveness')
+    // PR-4a: routed through the emission-authority façade (no-op delegate).
+    ea.openOrEditCard('liveness', () => {
+      turn.activityInFlight = drainActivitySummary(turn, 'liveness')
+    })
   }
 }
 if (!STATIC && FEED_HEARTBEAT_ENABLED) {
@@ -10834,6 +10896,13 @@ function handleSessionEvent(ev: SessionEvent): void {
           foregroundSubAgents: new Map(),
           answerStream: null,
           isDm: isDmChatId(ev.chatId),
+          // PR-4a — construct ONE emission-authority façade per turn, passing
+          // the chat/thread key in EXPLICITLY (the PR-4e seam; today equal to
+          // the singleton-sourced key). Per-turn: born with this turn literal,
+          // discarded with it — never persists across turns.
+          emissionAuthority: new EmissionAuthority(
+            statusKey(ev.chatId, enqThreadIdNum),
+          ),
         }
         currentTurn = next
         markIdleActivity() // any turn start (main session) is activity — re-arm idle clear
@@ -11136,12 +11205,16 @@ function handleSessionEvent(ev: SessionEvent): void {
         // is preserved when the parent appends its own step. composeTurnActivity
         // == the flat render when no foreground sub-agent is active.
         turn.activityPendingRender = composeTurnActivity(turn) ?? rendered
-        if (turn.activityInFlight == null) {
+        const ea = emissionAuthorityFor(turn)
+        if (ea.mayDrain(turn)) {
           // Producer B (tool label): always OPEN-eligible (labeledToolCount was
           // incremented just above). A turn that started conversational and now
           // dispatches a tool opens here, rendering any narration accumulated
           // by the suppressed narrative-SHOW drains (design §9 lever 5 / R4).
-          turn.activityInFlight = drainActivitySummary(turn, 'tool')
+          // PR-4a: routed through the emission-authority façade (no-op delegate).
+          ea.openOrEditCard('tool', () => {
+            turn.activityInFlight = drainActivitySummary(turn, 'tool')
+          })
         }
       }
       return
@@ -22981,8 +23054,14 @@ void (async () => {
                       const rendered = composeTurnActivity(turn)
                       if (rendered != null) {
                         turn.activityPendingRender = rendered
-                        if (turn.activityInFlight == null) {
-                          turn.activityInFlight = drainActivitySummary(turn)
+                        // PR-4a: routed through the emission-authority façade
+                        // (no-op delegate). Producer made explicit ('tool' — the
+                        // drain default this foreground sub-agent render used).
+                        const ea = emissionAuthorityFor(turn)
+                        if (ea.mayDrain(turn)) {
+                          ea.openOrEditCard('tool', () => {
+                            turn.activityInFlight = drainActivitySummary(turn, 'tool')
+                          })
                         }
                       }
                     }
@@ -23212,8 +23291,14 @@ void (async () => {
                   const rendered = composeTurnActivity(turn)
                   if (rendered != null) {
                     turn.activityPendingRender = rendered
-                    if (turn.activityInFlight == null) {
-                      turn.activityInFlight = drainActivitySummary(turn)
+                    // PR-4a: routed through the emission-authority façade (no-op
+                    // delegate). Producer made explicit ('tool' — the drain
+                    // default this foreground sub-agent render used).
+                    const ea = emissionAuthorityFor(turn)
+                    if (ea.mayDrain(turn)) {
+                      ea.openOrEditCard('tool', () => {
+                        turn.activityInFlight = drainActivitySummary(turn, 'tool')
+                      })
                     }
                     // A foreground sub-agent's nested activity IS user-visible
                     // production — count it so the silence-poke clock resets,

--- a/telegram-plugin/tests/emission-authority-facade.test.ts
+++ b/telegram-plugin/tests/emission-authority-facade.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Emission-authority façade — structural (source-read) assertions for PR-4a of
+ * the message-emission-determinism refactor.
+ *
+ * PR-4a introduces a kill-switched, behaviourally-IDENTICAL no-op seam: a
+ * per-foreground-turn emission-authority façade (`emission-authority.ts`) that
+ * the foreground-lane card/ping emission call sites route through. In PR-4a
+ * EVERY façade method is a thin delegate — no decision logic moves in (that is
+ * PR-4b-4e). These tests pin that the seam is wired AND that it is still a
+ * no-op:
+ *
+ *   1. The 6 drain sites + 2 finalize blocks + the over-ping block now reference
+ *      the façade methods, with the per-site producer args preserved verbatim.
+ *   2. The façade's disabled and enabled branches are behaviourally identical in
+ *      PR-4a (no decision token like `mayOpenActivityCard` has moved into the
+ *      façade yet — that is PR-4b).
+ *   3. `SWITCHROOM_EMISSION_AUTHORITY` parses default-OFF (`=== '1'`).
+ *   4. The seam delegates to the existing
+ *      `drainActivitySummary`/`clearActivitySummary`/`decideOverPing` — the
+ *      load-bearing literals stay AT THE CALL SITE.
+ *
+ * Pure source-reads (the gateway IIFE can't be instantiated in-process; the
+ * pattern mirrors emission-determinism-wiring.test.ts). NO sqlite import, so
+ * this runs cleanly under vitest (the bun/vitest split gotcha).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const facadeSrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'emission-authority.ts'),
+  'utf-8',
+)
+/**
+ * The façade source with comment lines stripped, so "no executable reference to
+ * X" assertions don't trip on a legitimate prose mention of a primitive name in
+ * a doc-comment (the seam is heavily documented). Drops `//`/`*`/`/**`-style
+ * comment lines; keeps real code.
+ */
+const facadeCode = facadeSrc
+  .split('\n')
+  .filter((l) => {
+    const t = l.trim()
+    return !(t.startsWith('*') || t.startsWith('//') || t.startsWith('/*'))
+  })
+  .join('\n')
+const gatewaySrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf-8',
+)
+
+/** Source of a named gateway function up to the next top-level definition. */
+function fnSrc(name: string): string {
+  const after = gatewaySrc.split(`function ${name}(`)[1] ?? ''
+  return after.split('\nasync function ')[0]?.split('\nfunction ')[0] ?? after
+}
+
+describe('SWITCHROOM_EMISSION_AUTHORITY kill-switch (default OFF)', () => {
+  it('parses with `=== "1"` semantic so an unset env var is OFF (default off)', () => {
+    expect(facadeSrc).toMatch(
+      /EMISSION_AUTHORITY_ENABLED\s*=\s*process\.env\.SWITCHROOM_EMISSION_AUTHORITY\s*===\s*'1'/,
+    )
+  })
+
+  it('is read ONCE at module top, not per-call (a single module-level const)', () => {
+    const reads = [...facadeSrc.matchAll(/process\.env\.SWITCHROOM_EMISSION_AUTHORITY/g)]
+    expect(reads).toHaveLength(1)
+    // The const initialiser sits at module scope (no leading indentation),
+    // mirroring the gateway flag region convention.
+    expect(facadeSrc).toMatch(/\nexport const EMISSION_AUTHORITY_ENABLED =/)
+  })
+})
+
+describe('façade is a no-op in PR-4a — both kill-switch branches delegate identically', () => {
+  /** Body of a façade method up to the next method/`}` at method indentation. */
+  function methodBody(name: string): string {
+    const after = facadeSrc.split(`${name}(`)[1] ?? ''
+    // Stop at the next method declaration (two-space indent + identifier + `(`)
+    // or the class close.
+    return after.split(/\n  [A-Za-z]+[(<]/)[0] ?? after
+  }
+
+  for (const m of [
+    'openOrEditCard',
+    'finalizeCard',
+    'markSubstantiveFinalDelivered',
+    'claimOrDowngradePing',
+  ]) {
+    it(`${m} runs the SAME delegate in the enabled and disabled branch (identical no-op)`, () => {
+      const body = methodBody(m)
+      // The enabled branch is gated on the flag and, in PR-4a, just runs apply()
+      // exactly like the disabled fall-through. Assert BOTH an
+      // `if (EMISSION_AUTHORITY_ENABLED)` branch and a bare `apply()` exist, and
+      // that NO decision token has leaked into the façade yet.
+      expect(body).toMatch(/if\s*\(EMISSION_AUTHORITY_ENABLED\)/)
+      const applyCalls = [...body.matchAll(/apply\(\)/g)]
+      // One in the enabled branch, one in the disabled fall-through.
+      expect(applyCalls.length).toBeGreaterThanOrEqual(2)
+    })
+  }
+
+  it('no PR-4b decision token (mayOpenActivityCard / a card-open verdict) has moved into the façade', () => {
+    // PR-4a moves NO decision logic in. The OPEN gate stays in the drain;
+    // `mayOpenActivityCard` must NOT be CALLED or IMPORTED in the façade yet
+    // (a prose mention in a doc-comment is fine — it documents the future seam).
+    expect(facadeSrc).not.toMatch(/import .*mayOpenActivityCard/)
+    expect(facadeCode).not.toMatch(/mayOpenActivityCard\(/)
+  })
+
+  it('mayDrain is a PURE READ — returns activityInFlight == null, acquires no lock', () => {
+    const after = facadeSrc.split('mayDrain(')[1] ?? ''
+    const body = after.split('\n}')[0] ?? after
+    expect(body).toMatch(/activityInFlight == null/)
+    // PR-4d invariant: mayDrain must not acquire chatLock. No lock token in body.
+    expect(body).not.toMatch(/chatLock|acquire|lock\(/i)
+  })
+
+  it('the PR-4d deadlock invariant is documented verbatim-ish in the module header', () => {
+    expect(facadeSrc).toMatch(/mayDrain` is a (pure|PURE) read/i)
+    expect(facadeSrc).toMatch(/must NOT acquire `chatLock`/)
+  })
+})
+
+describe('façade delegates to the existing emission primitives (call-site literals preserved)', () => {
+  it('openOrEditCard / mayDrain wrap drainActivitySummary at the call sites (not CALLED inside the façade)', () => {
+    // The façade does NOT IMPORT or CALL drainActivitySummary — the delegate
+    // thunk at the call site does, so the existing wiring oracle still sees it.
+    // (A prose mention in a doc-comment is fine.)
+    expect(facadeSrc).not.toMatch(/import .*drainActivitySummary/)
+    expect(facadeCode).not.toMatch(/drainActivitySummary\(/)
+    // The drain call literal is preserved inside an openOrEditCard delegate
+    // thunk: `openOrEditCard('<producer>', () => { turn.activityInFlight =
+    // drainActivitySummary(...) })`.
+    expect(gatewaySrc).toMatch(
+      /openOrEditCard\('[a-z]+', \(\) => \{\s*\n\s*turn\.activityInFlight = drainActivitySummary/,
+    )
+  })
+
+  it('finalizeCard wraps clearActivitySummary at the call sites (not CALLED inside the façade)', () => {
+    expect(facadeSrc).not.toMatch(/import .*clearActivitySummary/)
+    expect(facadeCode).not.toMatch(/clearActivitySummary\(/)
+    expect(gatewaySrc).toMatch(/finalizeCard\(\(\) => \{\s*\n\s*clearActivitySummary\(/)
+  })
+
+  it('claimOrDowngradePing wraps the decideOverPing block at the call site (not CALLED inside the façade)', () => {
+    expect(facadeSrc).not.toMatch(/import .*decideOverPing/)
+    expect(facadeCode).not.toMatch(/decideOverPing\(/)
+    // The decideOverPing call now lives inside a claimOrDowngradePing delegate.
+    const pingIdx = gatewaySrc.indexOf('claimOrDowngradePing(')
+    expect(pingIdx).toBeGreaterThan(-1)
+    const window = gatewaySrc.slice(pingIdx, pingIdx + 1200)
+    expect(window).toMatch(/decideOverPing\(/)
+  })
+})
+
+describe('the 6 drain sites route through the façade with producers preserved verbatim', () => {
+  it('the narrative SHOW site routes via openOrEditCard("narrative") + the producer-"narrative" drain', () => {
+    const body = fnSrc('showNarrativeStep')
+    expect(body).toMatch(/openOrEditCard\('narrative'/)
+    // The drain literal (producer arg verbatim) is preserved in the delegate.
+    expect(body).toMatch(/drainActivitySummary\(turn,\s*'narrative'\)/)
+    // The single-flight read is routed through the pure mayDrain.
+    expect(body).toMatch(/ea\.mayDrain\(turn\)/)
+  })
+
+  it('both liveness sites in feedHeartbeatTick route via openOrEditCard("liveness") + producer-"liveness" drains', () => {
+    const body = fnSrc('feedHeartbeatTick')
+    const opens = [...body.matchAll(/openOrEditCard\('liveness'/g)]
+    expect(opens).toHaveLength(2)
+    const drains = [...body.matchAll(/drainActivitySummary\(turn,\s*'liveness'\)/g)]
+    expect(drains).toHaveLength(2)
+    // The literal the feed-heartbeat oracle greps must still be present.
+    expect(body).toMatch(/turn\.activityInFlight = drainActivitySummary/)
+  })
+
+  it('the tool_label site routes via openOrEditCard("tool") + the producer-"tool" drain', () => {
+    expect(gatewaySrc).toMatch(/openOrEditCard\('tool',\s*\(\) => \{\s*\n\s*turn\.activityInFlight = drainActivitySummary\(turn,\s*'tool'\)/)
+  })
+
+  it('both foreground sub-agent drains route via openOrEditCard("tool") with producer made EXPLICIT', () => {
+    // Previously these called drainActivitySummary(turn) with the implicit
+    // 'tool' default; PR-4a makes 'tool' explicit at both, per the plan.
+    const opens = [...gatewaySrc.matchAll(/ea\.openOrEditCard\('tool', \(\) => \{\s*\n\s*turn\.activityInFlight = drainActivitySummary\(turn, 'tool'\)/g)]
+    // tool_label site (1) + the two sub-agent drains (2) = 3 'tool' openers.
+    expect(opens.length).toBeGreaterThanOrEqual(3)
+    // No foreground drain still uses the bare implicit-producer form.
+    expect(gatewaySrc).not.toMatch(/turn\.activityInFlight = drainActivitySummary\(turn\)\n/)
+  })
+
+  it('every routed drain site guards the single-flight via ea.mayDrain(turn), not a bare activityInFlight read', () => {
+    const mayDrainGuards = [...gatewaySrc.matchAll(/if \(ea\.mayDrain\(turn\)\)/g)]
+    // narrative + 2 liveness + tool + 2 sub-agent = 6 routed single-flight gates.
+    expect(mayDrainGuards).toHaveLength(6)
+  })
+})
+
+describe('the 2 lever-2 finalize blocks route through the façade', () => {
+  it('executeReply finalize routes via markSubstantiveFinalDelivered + finalizeCard (latch + clear preserved)', () => {
+    const after = gatewaySrc.split('async function executeReply(')[1] ?? ''
+    const body = after.split('async function executeStreamReply(')[0] ?? after
+    expect(body).toMatch(/markSubstantiveFinalDelivered\(\(\) => \{\s*\n\s*finalizeTurn\.finalAnswerEverDelivered = true/)
+    expect(body).toMatch(/finalizeCard\(\(\) => \{\s*\n\s*clearActivitySummary\(finalizeTurn\)/)
+  })
+
+  it('executeStreamReply finalize routes via markSubstantiveFinalDelivered + finalizeCard (latch + clear preserved)', () => {
+    const after = gatewaySrc.split('async function executeStreamReply(')[1] ?? ''
+    const body = after.split('\nasync function ')[0]?.split('\nfunction ')[0] ?? after
+    expect(body).toMatch(/markSubstantiveFinalDelivered\(\(\) => \{\s*\n\s*turn\.finalAnswerEverDelivered = true/)
+    expect(body).toMatch(/finalizeCard\(\(\) => \{\s*\n\s*clearActivitySummary\(turn\)/)
+  })
+})
+
+describe('per-turn construction — one façade per turn, explicit chat/thread key (PR-4e seam)', () => {
+  it('the turn ctor constructs a fresh EmissionAuthority with the explicit statusKey', () => {
+    // Per-turn: born in the CurrentTurn object literal so it is discarded with
+    // the turn and never persists across turns.
+    expect(gatewaySrc).toMatch(/emissionAuthority: new EmissionAuthority\(\s*\n\s*statusKey\(/)
+  })
+
+  it('the façade constructor takes the chat/thread key EXPLICITLY (the PR-4e map seam)', () => {
+    expect(facadeSrc).toMatch(/constructor\(private readonly chatKey: string\)/)
+  })
+
+  it('the accessor lazily backfills a per-turn façade keyed on the turn\'s statusKey', () => {
+    const body = fnSrc('emissionAuthorityFor')
+    expect(body).toMatch(/new EmissionAuthority\(\s*\n\s*statusKey\(turn\.sessionChatId, turn\.sessionThreadId\)/)
+  })
+})


### PR DESCRIPTION
## What

PR-4a of the message-emission-determinism refactor. Introduces a per-foreground-turn **emission-authority façade** (`telegram-plugin/gateway/emission-authority.ts`) and routes the foreground-lane card/ping emission call sites through it. It is a **kill-switched, behaviourally-IDENTICAL no-op seam** — "introduce the interface, wire the call sites, change nothing." No decision logic moves in (that is PR-4b–4e).

The gateway constructs ONE `EmissionAuthority` per foreground turn, alongside the `CurrentTurn` object, with the chat/thread key passed in **explicitly** (the seam PR-4e uses to swap the `currentTurn` singleton for a per-topic map). The façade is **per-turn only** — it never persists across turns (cross-turn persistence would pre-empt PR-4e's per-chat scoping).

## Method surface (all thin delegates in 4a)

Each method takes an `apply` thunk so the load-bearing literals (`drainActivitySummary`, `clearActivitySummary`, `decideOverPing`, the `finalAnswerEverDelivered` latch-set) stay **at the call site** and the source-read oracles still see them:

- `openOrEditCard(producer, apply)` → wraps `drainActivitySummary`
- `finalizeCard(apply)` → wraps `clearActivitySummary`
- `markSubstantiveFinalDelivered(apply)` → wraps the sticky-latch set
- `claimOrDowngradePing(input, apply)` → wraps the `decideOverPing` block
- `mayDrain(turn)` → **pure read** of `activityInFlight == null`, NO lock (the PR-4d deadlock invariant is documented verbatim-ish in the module header)

Kill-switch `SWITCHROOM_EMISSION_AUTHORITY` (read once, `=== '1'`, default **OFF**). Framing (A) "construct-but-bypass": both flag branches run the same delegate in 4a, so the seam is a no-op even with the flag **ON**. The flag's teeth start in 4b.

## Routed call sites

6 drains + 2 finalize blocks + the over-ping block: narrative-SHOW drain, the two `feedHeartbeatTick` liveness drains, the tool_label drain, the two foreground sub-agent drains (producer `'tool'` made **explicit**), the `executeReply` / `executeStreamReply` lever-2 finalize blocks, and the `executeReply` over-ping block.

**Not routed** (stay direct — they only consult shared state, never the façade): teardown `clearActivitySummary` calls and every background surface (obligation_represent, the watchers, error-envelope, idle-clear, boot-card, slot-banner, worker-activity-feed).

## No-op proof

- The existing **`emission-determinism-wiring.test.ts`** (the no-op oracle) passes **UNCHANGED**, along with `feed-heartbeat-liveness-open`, `feed-open-gate`, `cross-turn-card-gate`, `over-ping-safety-net`, `over-ping-final-answer-decoupling`, `represent-guard`, `feed-reopen-gate` — all green, all byte-unchanged.
- New **`emission-authority-facade.test.ts`** (pure source-read, no sqlite): pins the wiring, the identical disabled/enabled branches, the default-off flag, and the delegate-to-existing-primitives contract.

## JTBD

`know-what-my-agent-is-doing` (the live progress card / activity feed). Advances the **Visibility** vision outcome by laying the seam toward a deterministic emission authority **without changing any current behaviour**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)