### PR TITLE
docs: correct stale fork-workflow guidance to canonical-only model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,23 +497,21 @@ should know up front (so a session doesn't have to be *told* each time):
 
 ## Repo model & dev flow
 
-Switchroom uses a **fork + canonical** model. Read this before pushing.
+Switchroom uses a **canonical-only** model. Read this before pushing.
 
-- **`switchroom/switchroom`** — canonical public repo, source of truth
+- **`switchroom/switchroom`** — the one canonical repo, source of truth
   for releases. All `npm publish` output comes from here. Tagged
-  versions (`v0.X.Y`) live here.
-- **Your fork** (e.g. `<your-username>/switchroom`) — where you work.
-  Feature branches + PRs on the fork for iteration; release-time PRs
-  from the fork's `main` → `switchroom:main`.
+  versions (`v0.X.Y`) live here. You push feature branches **directly**
+  to this repo and open PRs against its `main` — there is no personal
+  fork in the loop.
 
 **Local git remotes** should be:
-- `origin` → your fork (for push)
-- `upstream` → `switchroom/switchroom` (for pulling canonical updates)
+- `origin` → `switchroom/switchroom` (for both push and pull)
 
-Agent working on this repo: when you open a PR, **target
-`switchroom/switchroom:main`** as the base, not the fork's main. The fork
-is a staging area for your own iteration; the canonical repo is where
-review + merge + release happens.
+Agent working on this repo: push your feature branch to `origin`
+(`switchroom/switchroom`) and **target `switchroom/switchroom:main`** as
+the PR base. There is no fork staging area — review + merge + release all
+happen on this one canonical repo.
 
 ### Standard dev process
 
@@ -521,15 +519,15 @@ This is the **mandatory** path for any non-trivial change. Skip steps
 only with an explicit operator instruction (e.g. "no review", "ship
 without UAT").
 
-**1. Branch off `upstream/main`, in a fresh worktree.**
+**1. Branch off `origin/main`, in a fresh worktree.**
 
 Multiple agents share this server and can collide on the same checkout.
 Always work in a per-task worktree:
 
 ```
-git fetch upstream
+git fetch origin
 git worktree add ~/code/switchroom-<short-task-slug> \
-  -b feat/<branch-name> upstream/main
+  -b feat/<branch-name> origin/main
 cd ~/code/switchroom-<short-task-slug>
 ln -s ~/code/switchroom/node_modules node_modules   # donor: any stable checkout
 ```
@@ -592,8 +590,8 @@ locally cover the load-bearing subset.
   by concatenation (`"sk-ant-" + "fake" + "-xyz"`), never a single
   literal. Pattern: `telegram-plugin/tests/secret-detect-secretlint.test.ts`.
 
-**4. Commit with Conventional Commits, push to fork, open PR against
-`upstream/main`.**
+**4. Commit with Conventional Commits, push the branch to `origin`, open
+PR against `origin/main`.**
 
 ```
 git commit -m "feat(scope): short imperative summary
@@ -603,7 +601,7 @@ Longer body explaining the why and any non-obvious tradeoffs.
 Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
 git push -u origin feat/<branch-name>
 gh pr create --repo switchroom/switchroom --base main \
-  --head <your-fork-user>:feat/<branch-name> --title "..." --body "..."
+  --head feat/<branch-name> --title "..." --body "..."
 ```
 
 PR title under 70 chars. Body covers: Summary, Why, Test plan
@@ -639,15 +637,15 @@ Required before fleet rollout.
 ### Standard release process
 
 Cut a release **only** after the relevant feature PRs have merged to
-`upstream/main` and you have at least one passing UAT (or an explicit
+`origin/main` and you have at least one passing UAT (or an explicit
 no-UAT directive).
 
-**1. Release worktree off `upstream/main`.**
+**1. Release worktree off `origin/main`.**
 
 ```
-git fetch upstream
+git fetch origin
 git worktree add ~/code/switchroom-rel-<vX.Y.Z> \
-  -b chore/release-v<X.Y.Z> upstream/main
+  -b chore/release-v<X.Y.Z> origin/main
 cd ~/code/switchroom-rel-<vX.Y.Z>
 # Release worktree needs a REAL node_modules, not the dev-worktree
 # symlink. `bun build` doesn't resolve through certain symlink shapes
@@ -699,7 +697,7 @@ git commit -m "chore: release vX.Y.Z"
 ```
 git push -u origin chore/release-v<X.Y.Z>
 gh pr create --repo switchroom/switchroom --base main \
-  --head <your-fork-user>:chore/release-v<X.Y.Z> \
+  --head chore/release-v<X.Y.Z> \
   --title "chore: release vX.Y.Z" --body "..."
 gh pr merge <PR#> --repo switchroom/switchroom --auto --squash
 ```
@@ -711,9 +709,9 @@ properly reviewed.
 **5. Tag the merged commit + push the tag.**
 
 ```
-git fetch upstream && git reset --hard upstream/main
+git fetch origin && git reset --hard origin/main
 git tag vX.Y.Z <merge-commit-sha>
-git push upstream vX.Y.Z
+git push origin vX.Y.Z
 ```
 
 The tag push triggers the `docker-images` workflow, which builds

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,38 +1,31 @@
 # Contributing to Switchroom
 
 Switchroom is MIT-licensed and welcomes contributions. This guide covers the
-fork-and-PR flow, local dev loop, and what we look for in PRs.
+branch-and-PR flow, local dev loop, and what we look for in PRs.
 
 ## Repo layout
 
-- **`switchroom/switchroom`** — the canonical public repo. Source of truth for
-  releases. All `npm publish` output comes from here. Tagged versions
-  (`v0.X.Y`) live here.
-- **Your fork (e.g. `<your-username>/switchroom`)** — where you do your work.
-  Feature branches land on your fork; PRs target the canonical repo's `main`.
+- **`switchroom/switchroom`** — the one canonical public repo. Source of truth
+  for releases. All `npm publish` output comes from here. Tagged versions
+  (`v0.X.Y`) live here. You branch off `main`, push your branch directly to
+  this repo, and open PRs against its `main` — there is no separate fork.
 
-Switchroom uses the standard GitHub fork workflow. You do not need commit
-access to `switchroom/switchroom` to contribute.
+Switchroom uses a canonical-only branch-and-PR workflow: clone the repo, push
+a feature branch, open a PR against `main`.
 
 ## Getting started
 
-1. **Fork** `switchroom/switchroom` via the GitHub UI (top-right → Fork).
-   Keep the name `switchroom` under your username.
-2. **Clone** your fork locally:
+1. **Clone** `switchroom/switchroom` locally:
    ```
-   git clone https://github.com/<your-username>/switchroom.git
+   git clone https://github.com/switchroom/switchroom.git
    cd switchroom
    ```
-3. **Add upstream** so you can pull canonical changes:
-   ```
-   git remote add upstream https://github.com/switchroom/switchroom.git
-   ```
-4. **Install deps** and build:
+2. **Install deps** and build:
    ```
    bun install
    bun run build
    ```
-5. **Run the tests**:
+3. **Run the tests**:
    ```
    bun run test
    ```
@@ -73,7 +66,7 @@ When the canonical `switchroom/switchroom:main` is ready to ship:
 # 5. Publish: npm publish
 ```
 
-npm publishes come from the canonical repo only. Forks don't publish.
+npm publishes come from the canonical repo only.
 
 ### 3. Local deploy (optional)
 
@@ -83,8 +76,9 @@ your agents are on the latest code.
 
 ## Submitting a PR
 
-1. Branch off your fork's `main`:
+1. Branch off `main`:
    ```
+   git checkout main && git pull
    git checkout -b feature/my-feature
    ```
 2. Keep PRs focused. One concern per PR. If you find yourself writing
@@ -92,10 +86,11 @@ your agents are on the latest code.
 3. Add tests for new behavior. Bug fixes should include a regression test
    that would have caught the bug.
 4. Run `bun run lint` (tsc noEmit) and `bun run test` before pushing.
-5. Push to your fork and open a PR against `switchroom/switchroom:main`:
+5. Push the branch to `origin` and open a PR against `switchroom/switchroom:main`:
    ```
+   git push -u origin feature/my-feature
    gh pr create --repo switchroom/switchroom --base main \
-     --head <your-username>:feature/my-feature
+     --head feature/my-feature
    ```
    Or use the GitHub UI.
 6. PR title: conventional prefix (`feat:`, `fix:`, `chore:`, `docs:`,

--- a/scripts/drift-audit/EXAMPLE.md
+++ b/scripts/drift-audit/EXAMPLE.md
@@ -166,8 +166,8 @@ mechanism is in-place reply streaming.
 ## Phase 3 — Fix agent applies the batch
 
 A Phase 3 agent receives the batch file, branches off
-`origin/main` (or `upstream/main` in fork mode), applies each `Edit`
-operation, and runs `tsc --noEmit` (clean because no `src/` edits).
+`origin/main` (the canonical `switchroom/switchroom`), applies each
+`Edit` operation, and runs `tsc --noEmit` (clean because no `src/` edits).
 It opens one PR titled "docs(drift-audit): remove pinned progress
 card references from JTBDs" with the batch findings linked in the
 body and the reviewer checkbox unchecked.

--- a/scripts/drift-audit/README.md
+++ b/scripts/drift-audit/README.md
@@ -25,7 +25,7 @@ or the vision needs to retreat.
 | 0 — Inventory | Operator (one-off per run) | Decide which units this run covers | `manifest.yaml` (pilot included) |
 | 1 — Audit | Many parallel agents | One agent per unit; lists claims, verifies against code, emits verdicts | `audit/<date>/findings/<unit-id>.yaml` |
 | 2 — Triage | One coordinator agent | Reads all findings, groups into fix-batches, escalates ambiguous cases | `audit/<date>/{summary.md, fix-batches/*.md, escalations.md}` |
-| 3 — Fix | Many parallel agents | One agent per fix-batch; applies actions, opens PR | One PR per batch (fork or direct-origin) |
+| 3 — Fix | Many parallel agents | One agent per fix-batch; applies actions, opens PR | One PR per batch (branch pushed direct to origin) |
 | 4 — Re-verify | One agent | Re-runs Phase 1 on touched units after PRs merge | `audit/<date>/regressions.md` |
 
 ## Invocation (Claude Code session, this repo)
@@ -128,10 +128,9 @@ Phase 3 agents push branches and open PRs following the standard dev
 process in `CLAUDE.md`. A reviewer agent must APPROVE before you enable
 auto-merge.
 
-In environments where `gh` isn't available or the remote is direct-
-origin (no fork), Phase 3 falls back to pushing the branch and
-reporting a pre-filled GitHub compare URL for the operator to open
-the PR via web.
+In environments where `gh` isn't available, Phase 3 falls back to
+pushing the branch to origin (`switchroom/switchroom`) and reporting a
+pre-filled GitHub compare URL for the operator to open the PR via web.
 
 ## Why this exists in-repo
 

--- a/scripts/drift-audit/prompts/03-fix.md
+++ b/scripts/drift-audit/prompts/03-fix.md
@@ -25,26 +25,24 @@ stop.
 
 ### Step 1 — branch off main
 
-If `origin` is the canonical repo (`switchroom/switchroom`) and the
-working directory is the live checkout, branch off `origin/main`:
+`origin` is the canonical repo (`switchroom/switchroom`) — there is no
+personal fork. From the live checkout, branch off `origin/main`:
 
 ```
 git fetch origin
 git checkout -b chore/drift-{{batch_slug}} origin/main
 ```
 
-If `origin` is your fork and `upstream` is the canonical, follow the
-standard worktree flow from `CLAUDE.md` "Standard dev process":
+For an isolated worktree (recommended when sharing the host), follow the
+worktree flow from `CLAUDE.md` "Standard dev process":
 
 ```
-git fetch upstream
+git fetch origin
 git worktree add ~/code/switchroom-drift-{{batch_slug}} \
-  -b chore/drift-{{batch_slug}} upstream/main
+  -b chore/drift-{{batch_slug}} origin/main
 cd ~/code/switchroom-drift-{{batch_slug}}
 ln -s ~/code/switchroom-sec-1417/node_modules node_modules
 ```
-
-Run `git remote -v` first to detect which mode you're in.
 
 ### Step 2 — apply the findings
 

--- a/scripts/drift-audit/prompts/04-reverify.md
+++ b/scripts/drift-audit/prompts/04-reverify.md
@@ -1,8 +1,8 @@
 # Phase 4 — Re-verify prompt
 
 Self-contained prompt for the single re-verify agent. Dispatched
-after Phase 3 PRs merge to `upstream/main` (or `origin/main` in
-direct-origin setups). Confirms the drift the audit identified is
+after Phase 3 PRs merge to `origin/main` (the canonical
+`switchroom/switchroom`). Confirms the drift the audit identified is
 actually gone and surfaces anything that came back or was missed.
 
 ---
@@ -28,7 +28,7 @@ gone.
 ### Step 1 — sync to main
 
 ```
-git fetch origin    # or `upstream` in fork-mode
+git fetch origin    # origin is the canonical switchroom/switchroom
 git log origin/main --oneline --since="{{run_date}}" \
   --grep="drift-audit" | tee /tmp/drift-audit-merged.txt
 ```


### PR DESCRIPTION
## Summary

The repo moved from a **fork + canonical** git model to a **canonical-only** model: contributors and agents clone `switchroom/switchroom`, branch, push the branch **directly** to that repo (no personal fork remote), and open PRs against its `main`. Several agent/dev docs still described the old fork + `upstream`-remote setup, which can misdirect a future agent into pushing to a dead fork remote (`origin → your fork`) that no longer exists, causing push errors.

This is documentation hygiene only — **no code or behavior change**.

## Files changed & what was stale

- **`CLAUDE.md`** — "Repo model & dev flow":
  - Before: "Switchroom uses a **fork + canonical** model"; remotes `origin → your fork`, `upstream → switchroom/switchroom`; "the fork is a staging area".
  - After: "**canonical-only** model"; single remote `origin → switchroom/switchroom`; push branch direct, PR base `switchroom/switchroom:main`.
  - Dev + release process: `git fetch upstream` / branch off `upstream/main` / `git push upstream` / `--head <your-fork-user>:branch` → all rewritten to `origin` / `origin/main` / `--head branch`.
- **`CONTRIBUTING.md`**:
  - Before: "fork-and-PR flow"; "Your fork (e.g. `<your-username>/switchroom`)"; Fork via GitHub UI, clone the fork, `git remote add upstream …`; "Branch off your fork's main"; "Push to your fork".
  - After: "branch-and-PR flow"; clone `switchroom/switchroom` directly; branch off `main`; `git push -u origin`; `--head feature/my-feature` (no fork prefix).
- **`scripts/drift-audit/README.md`** — "One PR per batch (fork or direct-origin)" → "(branch pushed direct to origin)"; removed the "remote is direct-origin (no fork)" fallback framing.
- **`scripts/drift-audit/EXAMPLE.md`** — "branches off `origin/main` (or `upstream/main` in fork mode)" → "(the canonical `switchroom/switchroom`)".
- **`scripts/drift-audit/prompts/03-fix.md`** — removed the "If `origin` is your fork and `upstream` is the canonical …" dead branch and the `git remote -v` mode-detection; canonical-only worktree flow off `origin/main`.
- **`scripts/drift-audit/prompts/04-reverify.md`** — "merge to `upstream/main` (or `origin/main` …)" and `git fetch origin # or upstream in fork-mode` → canonical `origin/main` only.

Note: `AGENT.md` and `AGENTS.md` are symlinks to `CLAUDE.md`, so they inherit the fix.

## Deliberately left untouched (not the stale switchroom-fork model)

- The vendored **telegram-plugin** "fork" prose (`docs/telegram-plugin.md`, `docs/compliance-attestation.md`) — a real shipped plugin fork, not a git contribution remote.
- OpenClaw / stock-`claude`-CLI "not a fork" comparisons (`README.md`, `docs/vs-openclaw.md`, `docs/architecture.md`).
- GitHub Actions external-fork-PR cache-token gating (`CLAUDE.md` CI section, `docs/operators/claude-cli-updates.md`) — genuine CI behavior.
- Process `fork()` semantics (sidecars in `start.sh`, topology diagrams).
- `docs/install-validation-2026-05-17.md` — a dated historical log recording a past `upstream/main` remote state; editing it would falsify a record and it isn't forward-looking guidance.

No `telegram-upstream` git-remote / vendored-sync instructions exist in the repo, so none were affected.

## Verification

Re-grepped the touched docs post-edit: no remaining "your fork", fork-push, fork-remote, or `upstream/main`-workflow guidance. The only surviving `upstream/main` reference in docs is the dated validation log above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)