### PR TITLE
fix(auth-failover): resume the turn after auto-switch + parse time-only session-cap reset

### DIFF
--- a/src/agents/wedge-watchdog.ts
+++ b/src/agents/wedge-watchdog.ts
@@ -142,26 +142,88 @@ export function parseWeeklyReset(text: string, nowMs: number = Date.now()): numb
   const m = text.match(
     /resets\s+([A-Za-z]{3,9})\s+(\d{1,2}),?\s+(\d{1,2})(?::(\d{2}))?\s*([ap]m)?\s*(?:\(([^)]+)\))?/i,
   );
-  if (!m) return null;
-  const mon = MONTHS[m[1].slice(0, 3).toLowerCase()];
-  if (mon === undefined) return null;
-  const day = Number(m[2]);
-  let hour = Number(m[3]);
-  const minute = m[4] ? Number(m[4]) : 0;
-  const ampm = m[5]?.toLowerCase();
-  if (ampm === "pm" && hour < 12) hour += 12;
-  if (ampm === "am" && hour === 12) hour = 0;
-  if (!Number.isFinite(day) || !Number.isFinite(hour) || day < 1 || day > 31 || hour > 23) {
+  if (m) {
+    const mon = MONTHS[m[1].slice(0, 3).toLowerCase()];
+    // A leading word that ISN'T a month (e.g. "resets at 5pm" would never reach
+    // here because of the \d requirement; but "resets soon 5pm" would) → fall
+    // through to the time-only branch rather than returning null.
+    if (mon !== undefined) {
+      const day = Number(m[2]);
+      let hour = Number(m[3]);
+      const minute = m[4] ? Number(m[4]) : 0;
+      const ampm = m[5]?.toLowerCase();
+      if (ampm === "pm" && hour < 12) hour += 12;
+      if (ampm === "am" && hour === 12) hour = 0;
+      if (Number.isFinite(day) && Number.isFinite(hour) && day >= 1 && day <= 31 && hour <= 23) {
+        const tz = m[6]?.trim();
+        // Resolve the year as the next occurrence (roll forward if M/D already passed).
+        const probeYear = new Date(nowMs).getUTCFullYear();
+        for (const year of [probeYear, probeYear + 1]) {
+          const epoch = wallClockToEpoch(year, mon, day, hour, minute, tz);
+          if (epoch != null && epoch > nowMs - 60_000) return epoch;
+        }
+        return null;
+      }
+    }
+  }
+
+  // SESSION-cap wording: a bare time of day with NO month/day —
+  // "resets 5pm (Australia/Melbourne)" / "resets 8:50am" / "resets 17:00".
+  // This frees in HOURS, so it MUST resolve to the next occurrence of that
+  // wall-clock time, NOT the weekly fallback. Without this branch the caller
+  // substitutes now+7d and benches a session-capped account for a full week.
+  // The negative lookahead rejects a month name so a date-bearing string can
+  // never reach here (it's handled above).
+  const tm = text.match(
+    /resets\s+(?:at\s+)?(?!(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\b)(\d{1,2})(?::(\d{2}))?\s*([ap]m)?\s*(?:\(([^)]+)\))?/i,
+  );
+  if (tm) {
+    let hour = Number(tm[1]);
+    const minute = tm[2] ? Number(tm[2]) : 0;
+    const ampm = tm[3]?.toLowerCase();
+    if (ampm === "pm" && hour < 12) hour += 12;
+    if (ampm === "am" && hour === 12) hour = 0;
+    if (!Number.isFinite(hour) || hour > 23 || hour < 0 || !Number.isFinite(minute) || minute > 59) {
+      return null;
+    }
+    const tz = tm[4]?.trim();
+    // Walk today + the next two days (DST-safe) IN THE TARGET TZ and pick the
+    // first occurrence strictly in the future.
+    for (let dayOffset = 0; dayOffset <= 2; dayOffset++) {
+      const dp = tzDateParts(new Date(nowMs + dayOffset * 86_400_000), tz);
+      if (dp == null) return null;
+      const epoch = wallClockToEpoch(dp.year, dp.month, dp.day, hour, minute, tz);
+      if (epoch != null && epoch > nowMs) return epoch;
+    }
     return null;
   }
-  const tz = m[6]?.trim();
-  // Resolve the year as the next occurrence (roll forward if M/D already passed).
-  const probeYear = new Date(nowMs).getUTCFullYear();
-  for (const year of [probeYear, probeYear + 1]) {
-    const epoch = wallClockToEpoch(year, mon, day, hour, minute, tz);
-    if (epoch != null && epoch > nowMs - 60_000) return epoch;
-  }
+
   return null;
+}
+
+/** The y/m/d of `d` as seen in `tz` (UTC when tz omitted). Null on bad tz. */
+function tzDateParts(
+  d: Date,
+  tz: string | undefined,
+): { year: number; month: number; day: number } | null {
+  if (!tz) {
+    return { year: d.getUTCFullYear(), month: d.getUTCMonth(), day: d.getUTCDate() };
+  }
+  try {
+    const fmt = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz, year: "numeric", month: "2-digit", day: "2-digit",
+    });
+    const parts = Object.fromEntries(
+      fmt.formatToParts(d).filter((p) => p.type !== "literal").map((p) => [p.type, p.value]),
+    );
+    return {
+      year: Number(parts.year),
+      month: Number(parts.month) - 1,
+      day: Number(parts.day),
+    };
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/telegram-plugin/fleet-fallback-resume.ts
+++ b/telegram-plugin/fleet-fallback-resume.ts
@@ -39,6 +39,12 @@
  *      repeated quota event) within the same window does NOT re-arm. Only ONE
  *      restart fires per swap. Without this a swap-storm could loop-restart the
  *      agent.
+ *      NOTE: this latch is IN-MEMORY and does NOT survive the self-restart it
+ *      arms — so it only dedups multiple swaps within a SINGLE process
+ *      lifetime; it cannot by itself bound a cross-restart loop. Cross-restart
+ *      loops are bounded separately, broker-side, by account exhaustion:
+ *      `markExhausted` persists across restarts, so once every spare is benched
+ *      the outcome becomes all-blocked, which does NOT restart.
  *   3. Staleness failsafe — an ancient interrupted turn is NOT resurrected. If
  *      the failed turn started longer ago than `maxAgeMs` (default 3h, matching
  *      the boot-resume RESUME_MAX_AGE_MS failsafe), `decide()` returns
@@ -55,9 +61,11 @@ export interface FleetFallbackResumeOptions {
   /** Time source (overridable in tests). */
   nowFn?: () => number;
   /** Cooldown after an armed resume during which a second swap will NOT
-   *  re-arm. Defends against a 429 storm loop-restarting the agent. Default
-   *  60s — comfortably longer than a restart + boot takes, so the in-flight
-   *  restart settles before another resume can arm. */
+   *  re-arm. Dedups a 429 storm WITHIN one process lifetime (this latch is
+   *  in-memory and does not survive the restart it arms — cross-restart loops
+   *  are bounded broker-side by persisted account exhaustion, not here).
+   *  Default 60s — comfortably longer than a restart + boot takes, so the
+   *  in-flight restart settles before another resume can arm. */
   singleFlightMs?: number;
 }
 

--- a/telegram-plugin/fleet-fallback-resume.ts
+++ b/telegram-plugin/fleet-fallback-resume.ts
@@ -1,0 +1,123 @@
+/**
+ * Resume-the-turn-after-swap gate (THE load-bearing half of the
+ * auth-failover-stall fix).
+ *
+ * Background — the stall this kills:
+ *   When a Claude account hits a rate limit MID-TURN (HTTP 429, including a
+ *   *session* cap like "You've hit your session limit · resets 5pm"), the
+ *   failover machinery correctly detects it (session-tail → model-unavailable
+ *   → gateway.fireFleetAutoFallback → doFireFleetAutoFallback) and swaps the
+ *   fleet to a spare account. But the swap only takes effect on the NEXT
+ *   claude invocation — the turn that died on the 429 is never resumed. The
+ *   agent goes silent until the user manually sends a fresh message
+ *   ("Resume"). Symptom: a mid-conversation stall that needs a manual re-poke.
+ *
+ * The fix: after a SUCCESSFUL swap (outcome.kind === 'switched'), the gateway
+ * re-runs the dead turn on the freshly-active account.
+ *
+ * Mechanism choice — restart, NOT redeliver:
+ *   The inbound that died on the 429 was already DELIVERED (the turn started,
+ *   then the model rejected it). It is therefore NOT sitting in the
+ *   pending-inbound buffer (`redeliverBufferedInbound` only drains inbounds
+ *   that never reached a live bridge). The canonical way to re-run an
+ *   already-delivered, interrupted turn is `triggerSelfRestart`: on the next
+ *   boot the gateway's boot-resume path re-injects the LATEST interrupted turn
+ *   from the turn registry — exactly the turn the 429 killed — and the fresh
+ *   claude process picks up the swapped-to account. `redeliverBufferedInbound`
+ *   would have nothing to redeliver here, so it is the wrong seam.
+ *
+ * This module owns ONLY the decision + the guards, kept pure so it is testable
+ * without restarting a process (the gateway module-state pattern mirrors
+ * `fleet-fallback-gate.ts`). The gateway wires the actual `triggerSelfRestart`
+ * call to `decide()` returning `'resume'`.
+ *
+ * Guards (all REQUIRED by the fix spec):
+ *   1. all-blocked / no-swap no-op — `decide()` is only ever consulted by the
+ *      caller on `outcome.kind === 'switched'`; on any other outcome the caller
+ *      does not call us, preserving the existing all-blocked cooldown path.
+ *   2. Single-flight — once a resume is armed, a second swap (a 429 storm, a
+ *      repeated quota event) within the same window does NOT re-arm. Only ONE
+ *      restart fires per swap. Without this a swap-storm could loop-restart the
+ *      agent.
+ *   3. Staleness failsafe — an ancient interrupted turn is NOT resurrected. If
+ *      the failed turn started longer ago than `maxAgeMs` (default 3h, matching
+ *      the boot-resume RESUME_MAX_AGE_MS failsafe), `decide()` returns
+ *      `'skip-stale'` so a day-old buffered turn isn't replayed unprompted.
+ *      `null` failedTurnStartedAtMs (no turn timestamp known) is treated as
+ *      "resume" — the boot-resume path applies its own 3h guard as a second
+ *      line of defence.
+ */
+
+export interface FleetFallbackResumeOptions {
+  /** Max age of the failed turn before a resume is suppressed as stale.
+   *  Default 3h — mirrors the gateway boot-resume RESUME_MAX_AGE_MS. */
+  maxAgeMs?: number;
+  /** Time source (overridable in tests). */
+  nowFn?: () => number;
+  /** Cooldown after an armed resume during which a second swap will NOT
+   *  re-arm. Defends against a 429 storm loop-restarting the agent. Default
+   *  60s — comfortably longer than a restart + boot takes, so the in-flight
+   *  restart settles before another resume can arm. */
+  singleFlightMs?: number;
+}
+
+export type ResumeDecision =
+  /** Fire the resume (restart so the boot path replays the dead turn). */
+  | 'resume'
+  /** Suppressed: a resume is already in flight (single-flight guard). */
+  | 'skip-inflight'
+  /** Suppressed: the failed turn is older than maxAgeMs (staleness guard). */
+  | 'skip-stale';
+
+export interface FleetFallbackResumeGate {
+  /**
+   * Decide whether to resume the dead turn after a successful swap. Call ONLY
+   * when the swap outcome was `'switched'`. Records the arm time on a 'resume'
+   * verdict so a follow-on swap within `singleFlightMs` is suppressed.
+   *
+   * @param failedTurnStartedAtMs epoch-ms the failed turn began, or null when
+   *        unknown (then the staleness guard is deferred to the boot path).
+   */
+  decide(failedTurnStartedAtMs: number | null): ResumeDecision;
+  /** Test seam — reset to fresh state. Production code should not call this. */
+  reset(): void;
+  /** Test/debug — current internal state. */
+  inspect(): { lastResumedAtMs: number };
+}
+
+export const DEFAULT_RESUME_MAX_AGE_MS = 10_800_000; // 3h
+export const DEFAULT_RESUME_SINGLE_FLIGHT_MS = 60_000; // 60s
+
+export function createFleetFallbackResumeGate(
+  opts: FleetFallbackResumeOptions = {},
+): FleetFallbackResumeGate {
+  const nowFn = opts.nowFn ?? (() => Date.now());
+  const maxAgeMs = opts.maxAgeMs ?? DEFAULT_RESUME_MAX_AGE_MS;
+  const singleFlightMs = opts.singleFlightMs ?? DEFAULT_RESUME_SINGLE_FLIGHT_MS;
+  // -Infinity = never resumed. A concrete value arms the single-flight window.
+  let lastResumedAtMs = Number.NEGATIVE_INFINITY;
+
+  function decide(failedTurnStartedAtMs: number | null): ResumeDecision {
+    const now = nowFn();
+    // Guard 2 — single-flight. A second swap within the window does not
+    // re-arm; the in-flight restart owns the resume.
+    if (now - lastResumedAtMs < singleFlightMs) return 'skip-inflight';
+    // Guard 3 — staleness. A known-old failed turn is not resurrected. An
+    // unknown (null) timestamp defers to the boot-resume 3h failsafe.
+    if (failedTurnStartedAtMs != null && now - failedTurnStartedAtMs > maxAgeMs) {
+      return 'skip-stale';
+    }
+    lastResumedAtMs = now;
+    return 'resume';
+  }
+
+  return {
+    decide,
+    reset() {
+      lastResumedAtMs = Number.NEGATIVE_INFINITY;
+    },
+    inspect() {
+      return { lastResumedAtMs };
+    },
+  };
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -134,6 +134,7 @@ import {
 } from './microsoft-connect-flow.js'
 import { resolveAuthBrokerSocketPath } from '../../src/auth/broker/client.js'
 import { createFleetFallbackGate } from '../fleet-fallback-gate.js'
+import { createFleetFallbackResumeGate } from '../fleet-fallback-resume.js'
 import { resolveExhaustUntil } from './exhaust-until.js'
 import {
   pendingAuthAddFlows,
@@ -16588,6 +16589,36 @@ const fleetFallbackGate = createFleetFallbackGate({
   brokerReachable: isAuthBrokerSocketReachable,
 })
 
+/**
+ * Resume-after-swap gate (auth-failover-stall fix). Owns the single-flight +
+ * staleness decision for re-running the turn a mid-turn 429 killed. See
+ * fleet-fallback-resume.ts. Wired into doFireFleetAutoFallback below: on a
+ * 'switched' outcome we restart so the boot-resume path replays the dead turn
+ * on the freshly-active account. 3h staleness mirrors the boot-resume
+ * RESUME_MAX_AGE_MS failsafe (gateway boot path); single-flight stops a 429
+ * storm from loop-restarting the agent.
+ */
+const fleetFallbackResumeGate = createFleetFallbackResumeGate({
+  maxAgeMs: (() => {
+    const v = Number(process.env.SWITCHROOM_RESUME_MAX_AGE_MS)
+    return Number.isFinite(v) && v > 0 ? v : 10_800_000 // 3h, matches boot-resume
+  })(),
+})
+
+/**
+ * The start time (epoch-ms) of the most-recently-started active turn — the
+ * staleness signal for the resume gate. `activeTurnStartedAt` is stamped on
+ * inbound receipt (see its declaration), so the newest entry is the turn the
+ * 429 just killed. Returns null when no turn is tracked (then the resume gate
+ * defers staleness to the boot-resume 3h failsafe). */
+function newestActiveTurnStartedAtMs(): number | null {
+  let newest: number | null = null
+  for (const ms of activeTurnStartedAt.values()) {
+    if (newest == null || ms > newest) newest = ms
+  }
+  return newest
+}
+
 function wouldFireFleetAutoFallback(): boolean {
   return fleetFallbackGate.wouldFire()
 }
@@ -16768,6 +16799,34 @@ async function doFireFleetAutoFallback(triggerAgent: string, untilMs?: number): 
         () => bot.api.sendMessage(chat_id, outcome.announcement, opts),
         { chat_id, verb: 'fleet-fallback:notify' },
       )
+    }
+    // ── Resume the dead turn (auth-failover-stall fix) ──────────────────────
+    // A mid-turn 429 killed a turn; the swap above moved the fleet to a healthy
+    // account, but that only takes effect on the NEXT claude invocation. Re-run
+    // the dead turn via triggerSelfRestart: the boot-resume path (gateway boot,
+    // findLatestTurnIfInterrupted → buildResumeInterruptedInbound) replays the
+    // LATEST interrupted turn on the freshly-active account. We restart rather
+    // than redeliver because the failed inbound was already DELIVERED (the turn
+    // started, then the model 429'd) so it is NOT in pendingInboundBuffer —
+    // redeliverBufferedInbound would find nothing. Guards live in
+    // fleetFallbackResumeGate: single-flight (a 429 storm cannot loop-restart)
+    // + 3h staleness (an ancient interrupted turn is not resurrected). Only
+    // reached on 'switched'; all-blocked / no-op outcomes never get here, so the
+    // all-blocked cooldown path above is preserved.
+    if (outcome.kind === 'switched') {
+      const verdict = fleetFallbackResumeGate.decide(newestActiveTurnStartedAtMs())
+      if (verdict === 'resume') {
+        const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? triggerAgent
+        process.stderr.write(
+          `telegram gateway: [fleet-fallback] resuming dead turn via self-restart ` +
+          `agent=${selfAgent} (swap ${outcome.oldLabel}→${outcome.newLabel})\n`,
+        )
+        triggerSelfRestart(selfAgent, 'fleet-fallback-resume')
+      } else {
+        process.stderr.write(
+          `telegram gateway: [fleet-fallback] resume suppressed (${verdict}) agent=${triggerAgent}\n`,
+        )
+      }
     }
     return outcome.kind === 'switched'
   } catch (err) {

--- a/telegram-plugin/model-unavailable.ts
+++ b/telegram-plugin/model-unavailable.ts
@@ -84,6 +84,13 @@ export function detectModelUnavailable(
     // resets 8:50am (Australia/Melbourne)".
     'hit your limit',
     'hit the limit',
+    // SESSION-cap wording: "You've hit your session limit · resets 5pm".
+    // A session cap is a quota exhaustion that frees in HOURS (its reset is a
+    // bare time-of-day, see parseResetTime's time-only branch) — recognising
+    // it here is what lets the time-only reset parse fire and keeps a
+    // session-capped account from the +7d weekly bench.
+    'session limit',
+    'session cap',
   ]
   if (quotaSignals.some(s => lower.includes(s))) {
     const resetAt = parseResetTime(sample)
@@ -192,7 +199,124 @@ function parseResetTime(text: string, parseTimeNow: Date = new Date()): Date | u
     if (!Number.isNaN(d.getTime())) return d
   }
 
+  // "resets 5pm (Australia/Melbourne)" / "resets 8:50am" / "resets 17:00 (UTC)"
+  // SESSION-cap wording: a time of day with NO month/day. This frees in
+  // HOURS, not a week — without this branch it falls through to undefined,
+  // and the 429 inference path then applies resolveExhaustUntil's +7d weekly
+  // floor, benching a session-capped account for a week. Must sit AFTER the
+  // calendar branch so "resets May 3, 11am" never matches here. The leading
+  // negative lookahead `(?!...)` rejects a month name so a date-bearing
+  // string can't fall into this time-only branch.
+  const timeOnly = text.match(
+    /resets?\s+(?!(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\b)(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*(?:\(([^)]+)\))?/i,
+  )
+  if (timeOnly) {
+    const d = resolveNextWallClock(
+      Number(timeOnly[1]),
+      timeOnly[2] ? Number(timeOnly[2]) : 0,
+      timeOnly[3]?.toLowerCase(),
+      timeOnly[4]?.trim(),
+      parseTimeNow,
+    )
+    if (d != null) return d
+  }
+
   return undefined
+}
+
+/**
+ * Resolve a bare wall-clock time ("5pm", "8:50am", "17:00") to the NEXT
+ * occurrence of that time, tz-aware. Returns the soonest future Date (rolls
+ * to tomorrow when the time has already passed today). Null on bad input
+ * (out-of-range hour/minute or an unknown tz). When `tz` is omitted the
+ * time is interpreted in UTC (best-effort) — Anthropic's strings normally
+ * carry the IANA tz in parens, e.g. "(Australia/Melbourne)".
+ */
+function resolveNextWallClock(
+  hour12or24: number,
+  minute: number,
+  ampm: string | undefined,
+  tz: string | undefined,
+  nowDate: Date,
+): Date | undefined {
+  let hour = hour12or24
+  if (ampm === 'pm' && hour < 12) hour += 12
+  if (ampm === 'am' && hour === 12) hour = 0
+  if (!Number.isFinite(hour) || hour > 23 || hour < 0) return undefined
+  if (!Number.isFinite(minute) || minute > 59 || minute < 0) return undefined
+  const nowMs = nowDate.getTime()
+  // Walk today and the next two days (DST-safe span) and pick the first
+  // occurrence strictly in the future relative to now.
+  const base = new Date(nowMs)
+  for (let dayOffset = 0; dayOffset <= 2; dayOffset++) {
+    // Derive the y/m/d for `dayOffset` days from now IN THE TARGET TZ, so the
+    // wall-clock date we resolve is the tz's calendar date, not the container's.
+    const dateParts = tzDateParts(new Date(nowMs + dayOffset * 86_400_000), tz)
+    if (dateParts == null) return undefined
+    const epoch = wallClockToEpoch(
+      dateParts.year, dateParts.month, dateParts.day, hour, minute, tz,
+    )
+    if (epoch != null && epoch > nowMs) return new Date(epoch)
+  }
+  // Fallback: shouldn't happen, but keep the function total.
+  void base
+  return undefined
+}
+
+/** The y/m/d of `d` as seen in `tz` (UTC when tz omitted). Null on bad tz. */
+function tzDateParts(
+  d: Date,
+  tz: string | undefined,
+): { year: number; month: number; day: number } | null {
+  if (!tz) {
+    return { year: d.getUTCFullYear(), month: d.getUTCMonth(), day: d.getUTCDate() }
+  }
+  try {
+    const fmt = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit',
+    })
+    const parts = Object.fromEntries(
+      fmt.formatToParts(d).filter((p) => p.type !== 'literal').map((p) => [p.type, p.value]),
+    )
+    return {
+      year: Number(parts.year),
+      month: Number(parts.month) - 1,
+      day: Number(parts.day),
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Convert a wall-clock time in an IANA tz to epoch-ms (null if the tz is
+ * unknown). Resolves the tz's offset AT that date via Intl, so it is correct
+ * across DST — NOT `new Date(localString)`, which assumes the container TZ.
+ * Mirrors wedge-watchdog.ts's helper of the same name (kept local to keep
+ * this module dependency-free / pure-testable).
+ */
+function wallClockToEpoch(
+  year: number, month: number, day: number, hour: number, minute: number, tz: string | undefined,
+): number | null {
+  const asUtc = Date.UTC(year, month, day, hour, minute, 0)
+  if (!tz) return asUtc // no tz given → best-effort UTC
+  try {
+    const fmt = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+    })
+    const parts = Object.fromEntries(
+      fmt.formatToParts(new Date(asUtc)).filter((p) => p.type !== 'literal').map((p) => [p.type, p.value]),
+    )
+    const shown = Date.UTC(
+      Number(parts.year), Number(parts.month) - 1, Number(parts.day),
+      Number(parts.hour) % 24, Number(parts.minute), Number(parts.second),
+    )
+    const offset = shown - asUtc // how far ahead the tz wall clock is of UTC
+    return asUtc - offset
+  } catch {
+    return null // unknown tz
+  }
 }
 
 function parseRelativeDuration(s: string): number | null {

--- a/telegram-plugin/model-unavailable.ts
+++ b/telegram-plugin/model-unavailable.ts
@@ -208,7 +208,7 @@ function parseResetTime(text: string, parseTimeNow: Date = new Date()): Date | u
   // negative lookahead `(?!...)` rejects a month name so a date-bearing
   // string can't fall into this time-only branch.
   const timeOnly = text.match(
-    /resets?\s+(?!(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\b)(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*(?:\(([^)]+)\))?/i,
+    /resets?\s+(?:at\s+)?(?!(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\b)(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*(?:\(([^)]+)\))?/i,
   )
   if (timeOnly) {
     const d = resolveNextWallClock(

--- a/telegram-plugin/tests/fleet-fallback-resume.test.ts
+++ b/telegram-plugin/tests/fleet-fallback-resume.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for the resume-after-swap gate (auth-failover-stall Fix 1).
+ *
+ * The gate owns the decision the gateway consults in doFireFleetAutoFallback
+ * after a SUCCESSFUL swap: should we restart to resume the turn the mid-turn
+ * 429 killed? It must:
+ *   - return 'resume' on the first switched outcome (so exactly one restart
+ *     fires), recorded so a follow-on swap is suppressed;
+ *   - return 'skip-inflight' on a SECOND swap within the single-flight window
+ *     (a 429 storm cannot loop-restart the agent);
+ *   - return 'skip-stale' when the failed turn is older than maxAgeMs (an
+ *     ancient interrupted turn is not resurrected);
+ *   - never be consulted on all-blocked (verified by the gateway-seam test
+ *     below, which only calls decide() on 'switched').
+ *
+ * The gate is pure (no process restart), so these tests run with a fake clock
+ * and never touch a real process — the restart itself is a separate seam
+ * (triggerSelfRestart) that the gateway wires to a 'resume' verdict.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createFleetFallbackResumeGate,
+  DEFAULT_RESUME_MAX_AGE_MS,
+  DEFAULT_RESUME_SINGLE_FLIGHT_MS,
+} from '../fleet-fallback-resume.js'
+
+function fakeClock(start = 1_000_000) {
+  let t = start
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms
+    },
+    set: (ms: number) => {
+      t = ms
+    },
+  }
+}
+
+describe('createFleetFallbackResumeGate — resume verdict', () => {
+  it("returns 'resume' on the first switched outcome", () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({ nowFn: clk.now })
+    // Failed turn started just now → fresh, not stale.
+    expect(gate.decide(clk.now())).toBe('resume')
+  })
+
+  it("treats a null (unknown) failed-turn timestamp as resumable", () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({ nowFn: clk.now })
+    // null defers staleness to the boot-resume 3h failsafe → resume here.
+    expect(gate.decide(null)).toBe('resume')
+  })
+})
+
+describe('createFleetFallbackResumeGate — single-flight guard', () => {
+  it('suppresses a SECOND swap inside the single-flight window (no double-resume)', () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({
+      nowFn: clk.now,
+      singleFlightMs: DEFAULT_RESUME_SINGLE_FLIGHT_MS,
+    })
+    expect(gate.decide(clk.now())).toBe('resume')
+    // A 429 storm: a second swap fires 1s later. Must NOT re-arm.
+    clk.advance(1_000)
+    expect(gate.decide(clk.now())).toBe('skip-inflight')
+    // Still suppressed near the end of the window.
+    clk.advance(DEFAULT_RESUME_SINGLE_FLIGHT_MS - 2_000)
+    expect(gate.decide(clk.now())).toBe('skip-inflight')
+  })
+
+  it('re-arms once the single-flight window has fully elapsed', () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({ nowFn: clk.now, singleFlightMs: 60_000 })
+    expect(gate.decide(clk.now())).toBe('resume')
+    clk.advance(60_001)
+    // A genuinely new swap after the window resumes again (one per swap).
+    expect(gate.decide(clk.now())).toBe('resume')
+  })
+
+  it('a rapid burst of N swaps yields exactly ONE resume', () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({ nowFn: clk.now, singleFlightMs: 60_000 })
+    let resumes = 0
+    for (let i = 0; i < 10; i++) {
+      if (gate.decide(clk.now()) === 'resume') resumes++
+      clk.advance(500) // 0.5s between storm events, all inside the window
+    }
+    expect(resumes).toBe(1)
+  })
+})
+
+describe('createFleetFallbackResumeGate — staleness guard', () => {
+  it("suppresses ('skip-stale') a failed turn older than maxAgeMs", () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({ nowFn: clk.now })
+    const ancientStart = clk.now() - (DEFAULT_RESUME_MAX_AGE_MS + 60_000)
+    expect(gate.decide(ancientStart)).toBe('skip-stale')
+  })
+
+  it('a stale verdict does NOT arm the single-flight window', () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({ nowFn: clk.now })
+    expect(gate.decide(clk.now() - (DEFAULT_RESUME_MAX_AGE_MS + 1))).toBe('skip-stale')
+    // A subsequent FRESH turn must still resume — the stale skip must not have
+    // recorded an arm time.
+    expect(gate.decide(clk.now())).toBe('resume')
+  })
+
+  it('a turn just under maxAgeMs still resumes', () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({ nowFn: clk.now, maxAgeMs: 10_800_000 })
+    expect(gate.decide(clk.now() - (10_800_000 - 1_000))).toBe('resume')
+  })
+
+  it('honours a custom maxAgeMs', () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({ nowFn: clk.now, maxAgeMs: 60_000 })
+    expect(gate.decide(clk.now() - 61_000)).toBe('skip-stale')
+    expect(gate.decide(clk.now() - 30_000)).toBe('resume')
+  })
+})
+
+describe('createFleetFallbackResumeGate — reset / inspect seams', () => {
+  it('reset() clears the single-flight arm', () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({ nowFn: clk.now })
+    expect(gate.decide(clk.now())).toBe('resume')
+    expect(gate.decide(clk.now())).toBe('skip-inflight')
+    gate.reset()
+    expect(gate.inspect().lastResumedAtMs).toBe(Number.NEGATIVE_INFINITY)
+    expect(gate.decide(clk.now())).toBe('resume')
+  })
+})
+
+/**
+ * Gateway-seam contract test. Mirrors how doFireFleetAutoFallback consults the
+ * gate: it calls decide() ONLY on outcome.kind === 'switched', and translates a
+ * 'resume' verdict into exactly one restart. We mock the restart as a counter,
+ * so no process is touched. This pins the "all-blocked is a no-op" and
+ * "exactly-once" contracts at the call-site shape.
+ */
+describe('gateway seam — decide() consulted only on switched, restart fires once', () => {
+  type Outcome = { kind: 'switched' | 'all-blocked' }
+
+  function simulateDispatch(
+    gate: ReturnType<typeof createFleetFallbackResumeGate>,
+    outcome: Outcome,
+    failedTurnStartedAtMs: number | null,
+    restart: () => void,
+  ): void {
+    // The actual gateway code path: resume is reached ONLY on 'switched'.
+    if (outcome.kind === 'switched') {
+      if (gate.decide(failedTurnStartedAtMs) === 'resume') restart()
+    }
+  }
+
+  it('switched → restart fires exactly once', () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({ nowFn: clk.now })
+    let restarts = 0
+    simulateDispatch(gate, { kind: 'switched' }, clk.now(), () => restarts++)
+    expect(restarts).toBe(1)
+  })
+
+  it('all-blocked → decide() is never consulted, restart never fires', () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({ nowFn: clk.now })
+    let restarts = 0
+    simulateDispatch(gate, { kind: 'all-blocked' }, clk.now(), () => restarts++)
+    expect(restarts).toBe(0)
+    // The gate stayed unarmed, so a subsequent real switch still resumes.
+    simulateDispatch(gate, { kind: 'switched' }, clk.now(), () => restarts++)
+    expect(restarts).toBe(1)
+  })
+
+  it('a 429 storm of switched outcomes restarts exactly once', () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({ nowFn: clk.now, singleFlightMs: 60_000 })
+    let restarts = 0
+    for (let i = 0; i < 5; i++) {
+      simulateDispatch(gate, { kind: 'switched' }, clk.now(), () => restarts++)
+      clk.advance(1_000)
+    }
+    expect(restarts).toBe(1)
+  })
+
+  it('a stale switched outcome does not restart', () => {
+    const clk = fakeClock()
+    const gate = createFleetFallbackResumeGate({ nowFn: clk.now })
+    let restarts = 0
+    const ancient = clk.now() - (DEFAULT_RESUME_MAX_AGE_MS + 1)
+    simulateDispatch(gate, { kind: 'switched' }, ancient, () => restarts++)
+    expect(restarts).toBe(0)
+  })
+})

--- a/telegram-plugin/tests/model-unavailable.test.ts
+++ b/telegram-plugin/tests/model-unavailable.test.ts
@@ -151,6 +151,111 @@ describe('detectModelUnavailable — reset-time extraction', () => {
   })
 })
 
+// ─── SESSION-cap (time-only) reset parsing — auth-failover-stall Fix 2 ─────────
+//
+// A session cap surfaces as "resets <time>" with NO month/day. Pre-fix this
+// was unparseable → resetAt undefined → the 429 inference path applied the +7d
+// weekly floor, benching the account for a WEEK. The new branch resolves it to
+// the NEXT occurrence of that wall-clock time (hours away), tz-aware.
+describe('detectModelUnavailable — time-only session-cap reset (Fix 2)', () => {
+  const HOUR = 3600_000
+  const WEEK = 7 * 24 * HOUR
+
+  // Next occurrence of a wall-clock time in a tz must be ≤24h away — and
+  // crucially NOT the +7d weekly floor.
+  function expectHoursAway(d: Date | undefined): void {
+    expect(d).toBeInstanceOf(Date)
+    const deltaMs = (d as Date).getTime() - Date.now()
+    expect(deltaMs).toBeGreaterThan(0)
+    expect(deltaMs).toBeLessThanOrEqual(24 * HOUR + 60_000)
+    // The whole point: never the weekly floor.
+    expect(deltaMs).toBeLessThan(WEEK - HOUR)
+  }
+
+  // The next wall-clock occurrence of `hour:minute` in `tz` should land on
+  // that exact minute (sanity that we resolved the time, not a fudge).
+  function expectWallClock(d: Date | undefined, tz: string, hour: number, minute = 0): void {
+    expect(d).toBeInstanceOf(Date)
+    const parts = Object.fromEntries(
+      new Intl.DateTimeFormat('en-US', {
+        timeZone: tz, hour: '2-digit', minute: '2-digit', hour12: false,
+      })
+        .formatToParts(d as Date)
+        .filter((p) => p.type !== 'literal')
+        .map((p) => [p.type, p.value]),
+    )
+    expect(Number(parts.hour) % 24).toBe(hour)
+    expect(Number(parts.minute)).toBe(minute)
+  }
+
+  it('parses "resets 5pm (Australia/Melbourne)" to the next 17:00 there, hours away (NOT +7d)', () => {
+    const d = detectModelUnavailable(
+      "You've hit your session limit · resets 5pm (Australia/Melbourne)",
+    )
+    expect(d?.kind).toBe('quota_exhausted')
+    expectHoursAway(d?.resetAt)
+    expectWallClock(d?.resetAt, 'Australia/Melbourne', 17, 0)
+  })
+
+  it('parses am times — "resets 8:50am (Australia/Melbourne)"', () => {
+    const d = detectModelUnavailable("You've hit your limit · resets 8:50am (Australia/Melbourne)")
+    expect(d?.kind).toBe('quota_exhausted')
+    expectHoursAway(d?.resetAt)
+    expectWallClock(d?.resetAt, 'Australia/Melbourne', 8, 50)
+  })
+
+  it('parses a time WITHOUT minutes — "resets 9am (UTC)"', () => {
+    const d = detectModelUnavailable('hit your limit · resets 9am (UTC)')
+    expect(d?.kind).toBe('quota_exhausted')
+    expectHoursAway(d?.resetAt)
+    expectWallClock(d?.resetAt, 'UTC', 9, 0)
+  })
+
+  it('parses a time WITHOUT a tz label (best-effort UTC) — "resets 11pm"', () => {
+    const d = detectModelUnavailable('usage limit hit · resets 11pm')
+    expect(d?.kind).toBe('quota_exhausted')
+    expectHoursAway(d?.resetAt)
+    expectWallClock(d?.resetAt, 'UTC', 23, 0)
+  })
+
+  it('parses 24-hour clock times — "resets 17:00 (UTC)"', () => {
+    const d = detectModelUnavailable('hit your limit · resets 17:00 (UTC)')
+    expect(d?.kind).toBe('quota_exhausted')
+    expectHoursAway(d?.resetAt)
+    expectWallClock(d?.resetAt, 'UTC', 17, 0)
+  })
+
+  it('STILL parses a bare ISO-8601 reset (calendar-path regression guard)', () => {
+    const d = detectModelUnavailable('quota exhausted, retry at 2026-05-03T11:00:00Z')
+    expect(d?.resetAt?.toISOString()).toBe('2026-05-03T11:00:00.000Z')
+  })
+
+  it('a month/day "resets" string is NOT hijacked into the time-only branch', () => {
+    // The negative lookahead must reject "May"/"Jun" so a date-bearing string
+    // never resolves to "tomorrow at HH:MM". (The month/day+time calendar form
+    // itself does not currently resolve to a Date — that is pre-existing
+    // behaviour; the load-bearing guard is that the time-only branch leaves it
+    // alone rather than producing a WRONG hours-away time.)
+    const may = detectModelUnavailable("You're out of extra usage · resets May 3, 11am")
+    expect(may?.kind).toBe('quota_exhausted')
+    // If the time-only branch had wrongly fired, resetAt would be ≤24h away.
+    if (may?.resetAt) {
+      const deltaMs = may.resetAt.getTime() - Date.now()
+      // A genuine May-3 resolution is many days away (or in the past); never the
+      // bare next-11am-tomorrow the time-only branch would have produced.
+      expect(Math.abs(deltaMs)).toBeGreaterThan(2 * 24 * HOUR)
+    }
+    const jun = detectModelUnavailable(
+      "hit your limit · resets Jun 9, 5am (Australia/Melbourne)",
+    )
+    expect(jun?.kind).toBe('quota_exhausted')
+    if (jun?.resetAt) {
+      const deltaMs = jun.resetAt.getTime() - Date.now()
+      expect(Math.abs(deltaMs)).toBeGreaterThan(2 * 24 * HOUR)
+    }
+  })
+})
+
 // ─── formatModelUnavailableCard ──────────────────────────────────────────────
 
 describe('formatModelUnavailableCard — actionable card', () => {

--- a/telegram-plugin/tests/model-unavailable.test.ts
+++ b/telegram-plugin/tests/model-unavailable.test.ts
@@ -197,6 +197,19 @@ describe('detectModelUnavailable — time-only session-cap reset (Fix 2)', () =>
     expectWallClock(d?.resetAt, 'Australia/Melbourne', 17, 0)
   })
 
+  it('parses the "at"-prefixed form — "resets at 5pm (Australia/Melbourne)" (parity with wedge-watchdog parseWeeklyReset)', () => {
+    // wedge-watchdog's parseWeeklyReset time-only regex accepts an optional
+    // "(?:at\s+)?" token; this parser must accept the IDENTICAL grammar or the
+    // "at"-prefixed string falls through to the +7d weekly floor — the
+    // week-long-bench bug this PR exists to kill.
+    const d = detectModelUnavailable(
+      "You've hit your session limit · resets at 5pm (Australia/Melbourne)",
+    )
+    expect(d?.kind).toBe('quota_exhausted')
+    expectHoursAway(d?.resetAt)
+    expectWallClock(d?.resetAt, 'Australia/Melbourne', 17, 0)
+  })
+
   it('parses am times — "resets 8:50am (Australia/Melbourne)"', () => {
     const d = detectModelUnavailable("You've hit your limit · resets 8:50am (Australia/Melbourne)")
     expect(d?.kind).toBe('quota_exhausted')

--- a/tests/wedge-watchdog.test.ts
+++ b/tests/wedge-watchdog.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   runWedgeWatchdog,
+  parseWeeklyReset,
   WEDGE_FOOTER_SIGNATURE,
   CONFIRM_MODAL_SIGNATURE,
   STOP_HOOK_ERROR_SIGNATURE,
@@ -430,5 +431,89 @@ describe("#2471 runWedgeWatchdog — manifest-stall escalation", () => {
     expect(res.restartEscalations).toBe(1);
     expect(errSpy).toHaveBeenCalled();
     errSpy.mockRestore();
+  });
+});
+
+// ─── parseWeeklyReset — time-only SESSION-cap branch (auth-failover Fix 2) ─────
+//
+// The weekly-quota MENU path threads parseWeeklyReset → resolveExhaustUntil.
+// Pre-fix, a SESSION cap ("resets 5pm", time-only, no month/day) returned null,
+// forcing the caller's now+7d weekly fallback — benching a session-capped
+// account for a WEEK. The new branch resolves it to the next occurrence of that
+// wall-clock time (hours away), tz-aware, while leaving the month/day form
+// untouched.
+describe("parseWeeklyReset — time-only session-cap branch (Fix 2)", () => {
+  const HOUR = 3600_000;
+  const WEEK = 7 * 24 * HOUR;
+  // A fixed anchor: 2026-06-25T00:00:00Z (a Thursday). Deterministic so the
+  // "next occurrence" maths is reproducible regardless of when the suite runs.
+  const NOW = Date.UTC(2026, 5, 25, 0, 0, 0);
+
+  function wallClockOf(epoch: number, tz: string): { hour: number; minute: number } {
+    const parts = Object.fromEntries(
+      new Intl.DateTimeFormat("en-US", {
+        timeZone: tz, hour: "2-digit", minute: "2-digit", hour12: false,
+      })
+        .formatToParts(new Date(epoch))
+        .filter((p) => p.type !== "literal")
+        .map((p) => [p.type, p.value]),
+    );
+    return { hour: Number(parts.hour) % 24, minute: Number(parts.minute) };
+  }
+
+  it('resolves "resets 5pm (Australia/Melbourne)" to the next 17:00 there, hours away (NOT +7d)', () => {
+    const epoch = parseWeeklyReset("resets 5pm (Australia/Melbourne)", NOW);
+    expect(epoch).not.toBeNull();
+    const delta = (epoch as number) - NOW;
+    expect(delta).toBeGreaterThan(0);
+    expect(delta).toBeLessThanOrEqual(24 * HOUR);
+    expect(delta).toBeLessThan(WEEK - HOUR); // the whole point: not the weekly floor
+    expect(wallClockOf(epoch as number, "Australia/Melbourne")).toEqual({ hour: 17, minute: 0 });
+  });
+
+  it('resolves an am time with minutes — "resets 8:50am (Australia/Melbourne)"', () => {
+    const epoch = parseWeeklyReset("resets 8:50am (Australia/Melbourne)", NOW);
+    expect(epoch).not.toBeNull();
+    expect((epoch as number) - NOW).toBeLessThanOrEqual(24 * HOUR);
+    expect(wallClockOf(epoch as number, "Australia/Melbourne")).toEqual({ hour: 8, minute: 50 });
+  });
+
+  it('resolves a time without a tz label (best-effort UTC) — "resets 11pm"', () => {
+    const epoch = parseWeeklyReset("resets 11pm", NOW);
+    expect(epoch).not.toBeNull();
+    expect((epoch as number) - NOW).toBeLessThanOrEqual(24 * HOUR);
+    expect(wallClockOf(epoch as number, "UTC")).toEqual({ hour: 23, minute: 0 });
+  });
+
+  it('resolves a 24-hour clock time — "resets 17:00 (UTC)"', () => {
+    const epoch = parseWeeklyReset("resets 17:00 (UTC)", NOW);
+    expect(epoch).not.toBeNull();
+    expect(wallClockOf(epoch as number, "UTC")).toEqual({ hour: 17, minute: 0 });
+  });
+
+  it("STILL resolves the month/day WEEKLY form (regression guard)", () => {
+    // "resets Jun 27, 5am (UTC)" — two days ahead of NOW.
+    const epoch = parseWeeklyReset("resets Jun 27, 5am (UTC)", NOW);
+    expect(epoch).not.toBeNull();
+    const asDate = new Date(epoch as number);
+    expect(asDate.getUTCMonth()).toBe(5); // Jun
+    expect(asDate.getUTCDate()).toBe(27);
+    expect(wallClockOf(epoch as number, "UTC")).toEqual({ hour: 5, minute: 0 });
+  });
+
+  it("a month/day string never falls into the time-only branch", () => {
+    // The negative lookahead must keep "Jun 9, 5pm" on the calendar branch, so
+    // its resolved date is Jun 9 (a month away → roughly weekly-scale), NOT the
+    // next 5pm tomorrow.
+    const epoch = parseWeeklyReset("resets Jun 9, 5pm (UTC)", NOW);
+    expect(epoch).not.toBeNull();
+    const asDate = new Date(epoch as number);
+    // Jun 9 already passed in 2026 relative to NOW (Jun 25) → rolls to next year.
+    expect(asDate.getUTCMonth()).toBe(5); // Jun
+    expect(asDate.getUTCDate()).toBe(9);
+  });
+
+  it("returns null on an unparseable line", () => {
+    expect(parseWeeklyReset("nothing here", NOW)).toBeNull();
   });
 });


### PR DESCRIPTION
## What this fixes

Two bugs in the auth-failover path, surfaced by a live, root-caused incident.

### Fix 1 — resume the turn after a successful swap (the load-bearing fix)

When a Claude account hits a rate limit **mid-turn** (HTTP 429 — including a *session* cap like "You've hit your session limit · resets 5pm"), the failover machinery already detects it and swaps the fleet to a spare account. But the swap only took effect on the **next** claude invocation — the turn that died on the 429 was never resumed, so the agent went **silent until the user manually sent a new message** ("Resume"). Symptom: a mid-conversation stall that needs a manual re-poke.

Now, in `doFireFleetAutoFallback`, after the swap announcement is broadcast and the outcome is `'switched'`, the gateway resumes the dead turn.

**Redeliver vs restart — why restart.** The inbound that died on the 429 was already *delivered* (the turn started, then the model rejected it), so it is **not** sitting in `pendingInboundBuffer` — `redeliverBufferedInbound` only drains inbounds that never reached a live bridge and would find nothing here. The canonical way to re-run an already-delivered, interrupted turn is `triggerSelfRestart`: on the next boot the gateway's boot-resume path (`findLatestTurnIfInterrupted` → `buildResumeInterruptedInbound`) re-injects the **latest interrupted turn** — exactly the turn the 429 killed — and the fresh claude process picks up the swapped-to account. This is documented in a code comment at the call site and in `fleet-fallback-resume.ts`.

**Guards** (all in the new pure, unit-tested `fleet-fallback-resume.ts`):
- **Single-flight** — once a resume is armed, a second swap (a 429 storm / repeated quota event) within the window does **not** re-arm. Exactly one restart per swap, so a swap-storm can't loop-restart the agent.
- **Staleness (3h)** — an interrupted turn older than `SWITCHROOM_RESUME_MAX_AGE_MS` (default 3h, mirroring the boot-resume `RESUME_MAX_AGE_MS` failsafe) is **not** resurrected. A `null` (unknown) turn timestamp defers to the boot-resume 3h guard as a second line of defence.
- **all-blocked no-op** — the resume decision is only ever consulted on `outcome.kind === 'switched'`; the all-blocked branch (and its cooldown) is reached before the resume and is preserved unchanged.

### Fix 2 — parse the time-only session-cap reset (stops the +7d over-penalty)

The reset string `"resets 5pm"` (time-only, no date) wasn't parsed, so a **session cap** (frees in *hours*) fell through to the **+7-day weekly floor** and benched the account for a week.

Added a tz-aware branch matching `resets <H>(:MM)? (am|pm)? (<tz>)?` to **both** `parseResetTime` (`model-unavailable.ts`) and `parseWeeklyReset` (`wedge-watchdog.ts`). It resolves to the **next occurrence** of that wall-clock time in the named timezone (DST-correct via `Intl`), so session caps now resolve to an hours-scale `until` via `resolveExhaustUntil` instead of the 7-day floor. The existing month/day branch is intact, and a negative-lookahead keeps a date-bearing string out of the time-only branch. Also added `"session limit"` / `"session cap"` quota signals so the session-cap wording is detected in the first place.

## The detection chain is unchanged

`session-tail.ts` (429 → `quota-exhausted`) and `model-unavailable.ts`'s `resolveModelUnavailableFromOperatorEvent` (`quota-exhausted` → `quota_exhausted`) are **not** touched. The only `model-unavailable.ts` edits are: new quota signals in `detectModelUnavailable`, and the new time-only branch (plus tz helpers) in the private `parseResetTime`.

## Tests

- `telegram-plugin/tests/fleet-fallback-resume.test.ts` (new, 14 tests) — resume fires once on `switched`; suppressed `skip-inflight` on a repeated 429 (single-flight); suppressed `skip-stale` for an old turn; never consulted / no restart on `all-blocked`. Mocked at the gate seam — no process is restarted.
- `telegram-plugin/tests/model-unavailable.test.ts` — time-only parse: `"resets 5pm (Australia/Melbourne)"` → an until that is hours away (next 17:00 there), **not** +7d; am/pm, with/without minutes, with/without tz, 24h clock; month/day & ISO regression guards.
- `tests/wedge-watchdog.test.ts` — same matrix against `parseWeeklyReset` with a pinned clock; month/day weekly form regression guard.

All touched/affected suites are green (160/160 single-fork). `npm run lint` (tsc + all check scripts) is clean. The wider suite has pre-existing, environment-only failures (subprocess/network/exec-sandbox) that reproduce identically on unmodified `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)