### PR TITLE
fix(auth-broker): push failover creds to consumer mirror_dir on exhaustion

### DIFF
--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -65,7 +65,7 @@ function makeConfig(h: Harness, overrides: Partial<{
    *  set on their per-agent block. Mirrors the unified admin source
    *  of truth (per-agent flag, not a top-level list). */
   admin_agents: string[];
-  consumers: Array<{ name: string; account: string; uid?: number }>;
+  consumers: Array<{ name: string; account: string; uid?: number; mirror_dir?: string }>;
   agents: Record<string, { auth?: { override?: string }; admin?: boolean }>;
   /** Phase 3b.2b — set to enable Google provider registration. */
   google_workspace: { google_client_id: string; google_client_secret: string };
@@ -2934,6 +2934,371 @@ describe("AuthBroker — claim-notification (fleet notification dedup)", () => {
     ]) as Array<{ ok: boolean; data: { granted: boolean } }>;
     const grants = [a, b].filter((r) => r.data.granted).length;
     expect(grants).toBe(1);
+    broker.stop();
+  });
+});
+
+// ─── consumer mirror_dir — the 2026-06-25 fix ───────────────────────────────
+//
+// The 2026-06-25 outage: the consumer-quota-sensor correctly marked `me@`
+// exhausted (10 min cadence), but hindsight's mounted /run/claude-creds/.credentials.json
+// was never re-pointed — it only re-fetches via get-credentials on its 30-min
+// background loop. The sensor ≤10min + loop ≤30min = up to 40min window. In
+// practice >1hr because the loop had recently run.
+//
+// Fix: consumers with a `mirror_dir` get their .credentials.json pushed
+// immediately when the broker marks exhaustion (sensor OR mark-exhausted RPC)
+// and when the effective account's creds are refreshed. Auto-revert (pinned
+// account becomes healthy again) is also pushed.
+//
+// Tests: (1) consumer mirror is re-written to fallback on sensor exhaustion
+//        (2) mirror reverts to pinned account when mark is cleared
+//        (3) attribution/mark-exhausted still targets the pinned account
+//        (4) agents' existing fanout behavior is unchanged
+//        (5) boot fanout writes consumer mirror alongside agent mirrors
+describe("AuthBroker — consumer mirror_dir (2026-06-25 push-on-exhaustion fix)", () => {
+  // ── (1) Regression: sensor marks exhausted → mirror is immediately re-written ──
+  //
+  // This is the exact incident path. Without the fix: sensor marks `me@`
+  // exhausted but the mirror file keeps pointing at the exhausted account until
+  // the 30-min pull loop fires. With the fix: broker pushes fallback creds
+  // immediately.
+  it("consumer-quota-sensor marks exhausted → mirror_dir is re-written to fallback (regression test)", async () => {
+    const h = makeHarness();
+    const mirrorDir = join(h.tmp, "consumer-creds");
+    const config = makeConfig(h, {
+      active: "default",
+      fallback_order: ["default", "secondary"],
+      consumers: [{ name: "hindsight", account: "secondary", mirror_dir: mirrorDir }],
+      // NOTE: no agent on `secondary` — exact incident shape
+    });
+    seedAccount(h, "default");
+    seedAccount(h, "secondary");
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      _testFetchQuota: async ({ accessToken }) =>
+        (accessToken as string).includes("secondary")
+          ? {
+              ok: true,
+              data: {
+                fiveHourUtilizationPct: 100,
+                sevenDayUtilizationPct: 10,
+                fiveHourResetAt: new Date(Date.now() + 60 * 60 * 1000),
+                sevenDayResetAt: null,
+                representativeClaim: "five_hour",
+                overageStatus: null,
+                overageDisabledReason: null,
+              },
+            }
+          : {
+              ok: true,
+              data: {
+                fiveHourUtilizationPct: 5,
+                sevenDayUtilizationPct: 5,
+                fiveHourResetAt: null,
+                sevenDayResetAt: null,
+                representativeClaim: null,
+                overageStatus: null,
+                overageDisabledReason: null,
+              },
+            },
+    });
+    await broker.start();
+
+    // Boot fanout already wrote the mirror with `secondary` creds (correct —
+    // secondary is not exhausted yet at boot time).
+    expect(existsSync(join(mirrorDir, ".credentials.json"))).toBe(true);
+    const mirrorAtBoot = JSON.parse(readFileSync(join(mirrorDir, ".credentials.json"), "utf-8"));
+    expect(mirrorAtBoot.claudeAiOauth.accessToken).toBe("at-secondary");
+
+    // Drive one sensor tick — marks `secondary` exhausted AND pushes fallback creds.
+    await broker.consumerQuotaProbeTick();
+
+    // Mirror must now contain the FALLBACK account's creds (pivoted from secondary to default).
+    expect(existsSync(join(mirrorDir, ".credentials.json"))).toBe(true);
+    const mirror = JSON.parse(readFileSync(join(mirrorDir, ".credentials.json"), "utf-8"));
+    // `default` account's access token is "at-default" (from seedAccount).
+    expect(mirror.claudeAiOauth.accessToken).toBe("at-default");
+
+    // get-credentials also returns the fallback account (existing behavior unchanged).
+    const resp = await rpc(join(h.socketRoot, "hindsight", "sock"), {
+      v: 1, id: "1", op: "get-credentials",
+    }) as { ok: boolean; data: { account: string } };
+    expect(resp.ok).toBe(true);
+    expect(resp.data.account).toBe("default");
+
+    broker.stop();
+  });
+
+  // ── (1b) mark-exhausted RPC path (agent on the same account reports a 429) ──
+  it("mark-exhausted on the consumer's pinned account also pushes fallback creds to mirror_dir", async () => {
+    const h = makeHarness();
+    const mirrorDir = join(h.tmp, "consumer-creds");
+    const config = makeConfig(h, {
+      active: "default",
+      fallback_order: ["default", "secondary"],
+      consumers: [{ name: "hindsight", account: "secondary", mirror_dir: mirrorDir }],
+      agents: { marker: { auth: { override: "secondary" } } },
+    });
+    seedAccount(h, "default");
+    seedAccount(h, "secondary");
+    mkdirSync(join(h.agentsDir, "marker"), { recursive: true });
+
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    // An agent on `secondary` reports a 429 — should push fallback to consumer mirror.
+    await rpc(join(h.socketRoot, "marker", "sock"), {
+      v: 1, id: "1", op: "mark-exhausted", until: Date.now() + 60_000,
+    });
+
+    // Mirror must now contain `default` creds.
+    expect(existsSync(join(mirrorDir, ".credentials.json"))).toBe(true);
+    const mirror = JSON.parse(readFileSync(join(mirrorDir, ".credentials.json"), "utf-8"));
+    expect(mirror.claudeAiOauth.accessToken).toBe("at-default");
+
+    broker.stop();
+  });
+
+  // ── (2) Auto-revert: when the exhaustion mark is cleared, mirror reverts to pinned account ──
+  it("mirror reverts to pinned account when the exhaustion mark is cleared by a healthy probe", async () => {
+    const h = makeHarness();
+    const mirrorDir = join(h.tmp, "consumer-creds");
+    // Track probe call count so we can switch from walled → healthy.
+    let probeCount = 0;
+    const config = makeConfig(h, {
+      active: "default",
+      fallback_order: ["default", "secondary"],
+      consumers: [{ name: "hindsight", account: "secondary", mirror_dir: mirrorDir }],
+    });
+    seedAccount(h, "default");
+    seedAccount(h, "secondary");
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      _testFetchQuota: async ({ accessToken }) => {
+        probeCount++;
+        // First probe: `secondary` is walled. Subsequent: healthy.
+        const walled = probeCount <= 1 && (accessToken as string).includes("secondary");
+        return walled
+          ? {
+              ok: true,
+              data: {
+                fiveHourUtilizationPct: 100,
+                sevenDayUtilizationPct: 10,
+                fiveHourResetAt: new Date(Date.now() + 60 * 60 * 1000),
+                sevenDayResetAt: null,
+                representativeClaim: "five_hour",
+                overageStatus: null,
+                overageDisabledReason: null,
+              },
+            }
+          : {
+              ok: true,
+              data: {
+                fiveHourUtilizationPct: 30,
+                sevenDayUtilizationPct: 10,
+                fiveHourResetAt: null,
+                sevenDayResetAt: null,
+                representativeClaim: null,
+                overageStatus: null,
+                overageDisabledReason: null,
+              },
+            };
+      },
+    });
+    await broker.start();
+
+    // First tick: secondary is walled → mirror writes `default` creds.
+    await broker.consumerQuotaProbeTick();
+    const mirrorAfterExhaustion = JSON.parse(
+      readFileSync(join(mirrorDir, ".credentials.json"), "utf-8"),
+    );
+    expect(mirrorAfterExhaustion.claudeAiOauth.accessToken).toBe("at-default");
+
+    // Second tick: secondary is healthy → mark is cleared → mirror reverts to `secondary`.
+    await broker.consumerQuotaProbeTick();
+    const mirrorAfterRevert = JSON.parse(
+      readFileSync(join(mirrorDir, ".credentials.json"), "utf-8"),
+    );
+    expect(mirrorAfterRevert.claudeAiOauth.accessToken).toBe("at-secondary");
+
+    broker.stop();
+  });
+
+  // ── (3) Attribution invariant: mark-exhausted always targets pinned account ──
+  //
+  // Even when the consumer is being SERVED a fallback account (its mirror points
+  // at `default`), a mark-exhausted from that consumer must target `secondary`
+  // (the pinned account) — never `default`. Unchanged behavior; regression guard.
+  it("attribution stays pinned: a consumer with mirror cannot poison the fallback account", async () => {
+    const h = makeHarness();
+    const mirrorDir = join(h.tmp, "consumer-creds");
+    const config = makeConfig(h, {
+      active: "default",
+      fallback_order: ["default", "secondary"],
+      consumers: [{ name: "hindsight", account: "secondary", mirror_dir: mirrorDir }],
+      agents: { marker: { auth: { override: "secondary" } } },
+    });
+    seedAccount(h, "default");
+    seedAccount(h, "secondary");
+    mkdirSync(join(h.agentsDir, "marker"), { recursive: true });
+
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    // Exhaust secondary (via an agent) → consumer failover active, mirror points at `default`.
+    await rpc(join(h.socketRoot, "marker", "sock"), {
+      v: 1, id: "1", op: "mark-exhausted", until: Date.now() + 60_000,
+    });
+    expect(existsSync(join(mirrorDir, ".credentials.json"))).toBe(true);
+    const mirrorBeforeConsumerMark = JSON.parse(
+      readFileSync(join(mirrorDir, ".credentials.json"), "utf-8"),
+    );
+    expect(mirrorBeforeConsumerMark.claudeAiOauth.accessToken).toBe("at-default");
+
+    // Consumer now calls mark-exhausted — must mark its PINNED account (secondary),
+    // never the served fallback (default).
+    await rpc(join(h.socketRoot, "hindsight", "sock"), {
+      v: 1, id: "2", op: "mark-exhausted", until: Date.now() + 120_000,
+    });
+
+    // `default` must remain healthy (not exhausted by the consumer).
+    const quota = JSON.parse(readFileSync(join(h.stateDir, "quota.json"), "utf-8"));
+    expect((quota["default"]?.exhausted_until ?? 0) > Date.now()).toBe(false);
+    // `secondary` is marked.
+    expect(quota["secondary"].exhausted_until > Date.now()).toBe(true);
+
+    broker.stop();
+  });
+
+  // ── (4) Agents' existing fanout is unaffected ──
+  it("agents' existing failover fanout is unchanged when consumers also have mirror_dir", async () => {
+    const h = makeHarness();
+    const mirrorDir = join(h.tmp, "consumer-creds");
+    const config = makeConfig(h, {
+      active: "default",
+      fallback_order: ["default", "secondary"],
+      consumers: [{ name: "hindsight", account: "hindsight-acct", mirror_dir: mirrorDir }],
+      agents: { ziggy: {} },
+    });
+    seedAccount(h, "default");
+    seedAccount(h, "secondary");
+    seedAccount(h, "hindsight-acct");
+    mkdirSync(join(h.agentsDir, "ziggy"), { recursive: true });
+
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    // Agent `ziggy` is on `default` (auth.active). Exhaust `default` via ziggy
+    // — agents should roll over to `secondary`.
+    await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1, id: "1", op: "mark-exhausted", until: Date.now() + 60_000,
+    });
+
+    // Agent now gets `secondary` (unchanged).
+    const agentResp = await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1, id: "2", op: "get-credentials",
+    }) as { ok: boolean; data: { account: string } };
+    expect(agentResp.ok).toBe(true);
+    expect(agentResp.data.account).toBe("secondary");
+
+    // Consumer's pinned account (`hindsight-acct`) is unaffected — it has no
+    // relationship to the exhausted `default`. Mirror should NOT have been written
+    // (consumer wasn't affected by the agent's exhaustion event).
+    // (If mirror was spuriously written, it would contain hindsight-acct creds, which
+    //  is also acceptable — but it must NOT contain `secondary` or `default` creds.)
+    if (existsSync(join(mirrorDir, ".credentials.json"))) {
+      const mirrorContent = JSON.parse(readFileSync(join(mirrorDir, ".credentials.json"), "utf-8"));
+      // The mirror must contain the consumer's OWN effective account creds, not an
+      // unrelated agent's account.
+      expect(mirrorContent.claudeAiOauth.accessToken).toBe("at-hindsight-acct");
+    }
+
+    broker.stop();
+  });
+
+  // ── (5) Boot fanout writes consumer mirror ──
+  it("boot fanout (fanoutAll) writes the consumer mirror alongside agent mirrors", async () => {
+    const h = makeHarness();
+    const mirrorDir = join(h.tmp, "consumer-creds");
+    const config = makeConfig(h, {
+      active: "default",
+      consumers: [{ name: "hindsight", account: "default", mirror_dir: mirrorDir }],
+      agents: { ziggy: {} },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "ziggy"), { recursive: true });
+
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    // Boot fanout must have written the consumer mirror.
+    expect(existsSync(join(mirrorDir, ".credentials.json"))).toBe(true);
+    const mirror = JSON.parse(readFileSync(join(mirrorDir, ".credentials.json"), "utf-8"));
+    expect(mirror.claudeAiOauth.accessToken).toBe("at-default");
+
+    broker.stop();
+  });
+
+  // ── No mirror_dir → no file written (opt-in, not opt-out) ──
+  it("a consumer WITHOUT mirror_dir gets no pushed file (pull-only behavior preserved)", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      fallback_order: ["default", "secondary"],
+      consumers: [{ name: "hindsight", account: "secondary" }], // no mirror_dir
+    });
+    seedAccount(h, "default");
+    seedAccount(h, "secondary");
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      _testFetchQuota: async () => ({
+        ok: true,
+        data: {
+          fiveHourUtilizationPct: 100,
+          sevenDayUtilizationPct: 10,
+          fiveHourResetAt: new Date(Date.now() + 60 * 60 * 1000),
+          sevenDayResetAt: null,
+          representativeClaim: "five_hour",
+          overageStatus: null,
+          overageDisabledReason: null,
+        },
+      }),
+    });
+    await broker.start();
+    await broker.consumerQuotaProbeTick();
+
+    // The sensor marked secondary exhausted, BUT since there's no mirror_dir,
+    // no file should be written to the tmp dir.
+    expect(existsSync(join(h.tmp, ".credentials.json"))).toBe(false);
+
+    // get-credentials still returns the fallback (pull-path still works).
+    const resp = await rpc(join(h.socketRoot, "hindsight", "sock"), {
+      v: 1, id: "1", op: "get-credentials",
+    }) as { ok: boolean; data: { account: string } };
+    expect(resp.ok).toBe(true);
+    expect(resp.data.account).toBe("default");
+
     broker.stop();
   });
 });

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -1530,6 +1530,11 @@ export class AuthBroker {
       process.stdout.write(
         `auth-broker: live probe shows ${label} healthy (5h=${snapshot.fiveHourUtilizationPct}% 7d=${snapshot.sevenDayUtilizationPct}%) — cleared stale exhaustion mark\n`,
       );
+      // Re-mirror any consumer whose pinned account is `label` — now that the
+      // exhaustion mark is cleared the serving path reverts to the pinned
+      // account, so push the revert immediately rather than waiting for the
+      // consumer's next pull-loop tick. This is the auto-revert path.
+      this.fanoutToAffectedConsumers(label);
     }
   }
 
@@ -1609,6 +1614,13 @@ export class AuthBroker {
       process.stdout.write(
         `auth-broker: consumer-quota-sensor marked ${label} exhausted until ${new Date(exhaustedUntil).toISOString()} — consumer(s) fail over\n`,
       );
+      // Push failover creds immediately to any consumer with a mirror_dir.
+      // Without this push the consumer sits on stale credentials until its
+      // next pull-loop tick (up to 30 min). This is the fix for the
+      // 2026-06-25 hindsight outage: the sensor correctly detected exhaustion
+      // but the consumer never got a push, so it stayed dead on the exhausted
+      // account until the 30-min refresh loop happened to fire.
+      this.fanoutToAffectedConsumers(label);
     }
   }
 
@@ -1638,6 +1650,10 @@ export class AuthBroker {
     };
     this.config = cfg;
     const fanned = this.fanoutToAffectedAgents(account);
+    // Push updated creds to any consumer mirror whose effective account is now
+    // `account` (e.g. a consumer whose failover just resolved to this account
+    // because its pinned account was exhausted and this is the healthy fallback).
+    this.fanoutAllConsumers();
     this.audit({ op: "set-active", identity, account, accountKind: "claude", ok: true });
     socket.write(encodeSuccess(id, { active: account, fanned }));
   }
@@ -1677,6 +1693,16 @@ export class AuthBroker {
       this.config.auth?.fallback_order ?? [],
     );
     const rolled = this.fanoutFailoverTo(account, rolledTo);
+    // Fan out to any consumer whose pinned account == `account` AND that
+    // has a `mirror_dir`. This eliminates the pull-latency gap: without
+    // this push the consumer only gets failover creds at its next
+    // scheduled get-credentials loop tick (up to 30 min). The serving
+    // path (accountWithFailover) is already failover-aware — we just need
+    // to push the resulting creds immediately rather than waiting for a
+    // pull. Attribution stays attribution-true (servingAccountForConsumer
+    // uses accountWithFailover, never the raw pinned account), so a consumer
+    // cannot poison the fallback account.
+    this.fanoutToAffectedConsumers(account);
     // `rolledTo` is the account the fleet rolled TO — same selection the fanout
     // used. Lets a non-admin caller (the agent that just 429'd, via
     // auto-fallback) report an accurate "switched to <X>" without a follow-up
@@ -2492,6 +2518,10 @@ export class AuthBroker {
         this.persistShaIndex();
         // Fan out to every agent whose effective account == this label.
         this.fanoutToAffectedAgents(label);
+        // Fan out to every consumer mirror whose effective account == this
+        // label (so a consumer on a failover account gets the refreshed creds
+        // pushed without waiting for its pull-loop tick).
+        this.fanoutToAffectedConsumers(label);
         return { kind: "refreshed", newExpiresAt };
       }
       if (outcome.kind === "failed") {
@@ -2508,11 +2538,17 @@ export class AuthBroker {
 
   /* ─── Fanout ────────────────────────────────────────────────── */
 
-  /** Walk every agent and re-mirror their effective-account credentials. */
+  /** Walk every agent and every consumer-mirror and re-mirror their effective-account credentials. */
   private fanoutAll(): string[] {
     const out: string[] = [];
     for (const name of Object.keys(this.config.agents ?? {})) {
       if (this.fanoutForAgent(name)) out.push(name);
+    }
+    // Boot fanout for consumers with mirror_dir — same "re-point after restart"
+    // guarantee agents get, so a broker restart doesn't leave a consumer stuck on
+    // pre-restart creds until its next pull-loop tick.
+    for (const consumerName of this.fanoutAllConsumers()) {
+      out.push(`consumer:${consumerName}`);
     }
     return out;
   }
@@ -2533,10 +2569,111 @@ export class AuthBroker {
         if (this.fanoutForAgent(name)) fanned.push(name);
       }
     }
-    // Also fan out to any pinned consumers — they write to a host path
-    // we don't own (their compose mounts their socket), so we only mirror
-    // account-creds-on-disk; consumers fetch via get-credentials.
     return fanned;
+  }
+
+  /**
+   * Fan out to every consumer whose effective (failover-resolved) account ==
+   * label AND that has a `mirror_dir` configured.
+   *
+   * The consumer model is pull-based by default: hindsight calls
+   * `get-credentials` on a periodic loop (default 30 min). Without a push,
+   * a consumer pinned to an account that just became exhausted keeps running
+   * on stale credentials for up to 30 min — the 2026-06-25 incident where
+   * the consumer-quota-sensor correctly marked `me@` exhausted, but hindsight
+   * didn't re-fetch until the next loop tick and stayed dead on a 429.
+   *
+   * `mirror_dir` closes the gap: the broker writes
+   * `<mirror_dir>/.credentials.json` immediately when it detects exhaustion
+   * (sensor tick or a mark-exhausted RPC on the pinned account) and on any
+   * credential refresh. The consumer container bind-mounts `mirror_dir` from
+   * a host-accessible path so both sides can reach the same file.
+   *
+   * Attribution invariant is preserved: `mirrorAccountToConsumer` uses the
+   * SERVING account (post exhaustion-failover), never the raw pinned account,
+   * so stale exhausted creds are never re-mirrored onto the consumer.
+   *
+   * Returns the list of consumer names whose mirror was successfully updated.
+   */
+  private fanoutToAffectedConsumers(label: string): string[] {
+    const fanned: string[] = [];
+    for (const consumer of this.config.auth?.consumers ?? []) {
+      if (!consumer.mirror_dir) continue;
+      // A consumer is affected when EITHER:
+      //   (a) its pinned account is `label` — the pinned account may have just
+      //       been marked exhausted; re-mirror with the failover account so the
+      //       consumer doesn't wait for its next pull tick.
+      //   (b) its EFFECTIVE (serving) account is `label` — the effective account
+      //       just had its creds refreshed; push the fresh creds immediately.
+      // In both cases we write the current serving account (post failover), never
+      // the raw pinned one, preserving the attribution invariant.
+      const isPinned = consumer.account === label;
+      const effective = this.servingAccountForConsumer(consumer.name);
+      const isEffective = effective === label;
+      if (!isPinned && !isEffective) continue;
+      const toMirror = effective ?? consumer.account;
+      if (this.mirrorAccountToConsumer(toMirror, consumer)) {
+        fanned.push(consumer.name);
+      }
+    }
+    return fanned;
+  }
+
+  /**
+   * Walk every consumer with a `mirror_dir` and re-mirror their
+   * effective-account credentials. Used at boot and after a global
+   * state change (e.g. set-active).
+   */
+  private fanoutAllConsumers(): string[] {
+    const out: string[] = [];
+    for (const consumer of this.config.auth?.consumers ?? []) {
+      if (!consumer.mirror_dir) continue;
+      const effective = this.servingAccountForConsumer(consumer.name);
+      if (!effective) continue;
+      if (this.mirrorAccountToConsumer(effective, consumer)) out.push(consumer.name);
+    }
+    return out;
+  }
+
+  /**
+   * The serving (failover-resolved) account for a named consumer. Extracted
+   * as a helper so fanoutToAffectedConsumers can call it without building a
+   * synthetic Identity object.
+   */
+  private servingAccountForConsumer(name: string): string | null {
+    const c = (this.config.auth?.consumers ?? []).find((x) => x.name === name);
+    if (!c) return null;
+    return this.accountWithFailover(c.account);
+  }
+
+  /**
+   * Write the effective-account credentials to a consumer's `mirror_dir`.
+   * Atomic (temp + rename). Chown to `consumer.uid` (default 0) — swallowed
+   * when CAP_CHOWN is absent (dev hosts, tests).
+   *
+   * Returns true on success, false on any failure (logged, never throws).
+   */
+  private mirrorAccountToConsumer(label: string, consumer: { name: string; uid?: number; mirror_dir?: string }): boolean {
+    const mirrorDir = consumer.mirror_dir;
+    if (!mirrorDir) return false;
+    const targetPath = join(mirrorDir, ".credentials.json");
+    const credsPath = accountCredentialsPath(label, this.home);
+    if (!existsSync(credsPath)) return false;
+    const mirrorContent = enrichMirrorContent(readFileSync(credsPath, "utf-8"));
+    try {
+      mkdirSync(mirrorDir, { recursive: true, mode: 0o700 });
+      atomicWriteFileSync(targetPath, mirrorContent, 0o600);
+      try {
+        const uid = consumer.uid ?? 0;
+        chownSync(targetPath, uid, uid);
+      } catch (err) {
+        this.warnCapChownMissing(err);
+      }
+      return true;
+    } catch (err) {
+      this.logErr(`consumer-mirror ${consumer.name} <- ${label}: ${(err as Error).message}`);
+      return false;
+    }
   }
 
   /**

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.15.48";
-export const COMMIT_SHA: string | null = "ffb0f02";
-export const COMMIT_DATE: string | null = "2026-06-24T16:30:05+10:00";
-export const LATEST_PR: number | null = 2546;
-export const COMMITS_AHEAD_OF_TAG: number | null = null;
+export const COMMIT_SHA: string | null = "af8f346d";
+export const COMMIT_DATE: string | null = "2026-06-25T15:23:31+10:00";
+export const LATEST_PR: number | null = 2572;
+export const COMMITS_AHEAD_OF_TAG: number | null = 2;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3127,6 +3127,23 @@ export const SwitchroomConfigSchema = z.object({
                 "Optional UID to chown the consumer socket to (defaults to 0 = root, " +
                 "suitable for sibling containers running as root).",
               ),
+            mirror_dir: z
+              .string()
+              .optional()
+              .describe(
+                "Optional host-side directory path. When set, the broker actively " +
+                "writes the consumer's effective-account `.credentials.json` mirror " +
+                "here — in addition to serving creds on demand via `get-credentials`. " +
+                "Use this to eliminate the pull-latency gap: without a mirror the " +
+                "consumer only gets failover creds at its next scheduled re-fetch " +
+                "(up to 30 min). With a mirror the broker pushes failover creds " +
+                "immediately when it detects exhaustion (consumer-quota-sensor tick, " +
+                "or a mark-exhausted RPC on the pinned account). The directory must " +
+                "be accessible to the broker container (bind-mounted from the host) " +
+                "and to the consumer container; the broker writes " +
+                "`<mirror_dir>/.credentials.json` atomically. Chown is attempted to " +
+                "`uid` (default 0) — swallowed when CAP_CHOWN is absent.",
+              ),
           }),
         )
         .optional()


### PR DESCRIPTION
## Problem

On 2026-06-25 hindsight (an `AuthConsumer` pinned to the `outlook` account) stalled fleet-wide for >1 hr when that account hit its weekly quota. Root cause (confirmed in code):

- `consumerQuotaProbeTick()` calls `markExhausted(label)` which sets `this.quota[label].exhausted_until` — this enables `accountWithFailover()` on the **next** `get-credentials` call from the consumer  
- The consumer's background refresh loop runs every 1800 s (default `SWITCHROOM_HINDSIGHT_REFRESH_S`)  
- Worst case gap: 10 min sensor delay + 30 min pull cycle = **40 min before auto-recovery** (the incident exceeded 1 hr because the loop had just run when exhaustion hit)  
- The broker **cannot** write directly to the consumer's cred file at `/run/claude-creds/.credentials.json` — it lives on a tmpfs inside the container  

The broker already pushes failover creds to **agent** mirrors (`fanoutFailoverTo`, `fanoutToAffectedAgents`) on exhaustion events. Consumers had no equivalent push path.

## Fix

Add an optional `mirror_dir` field to the consumer config schema — a host-accessible directory the broker can write to and the consumer can bind-mount instead of the tmpfs.

When set, the broker immediately pushes `<mirror_dir>/.credentials.json` on:

| Trigger | Method |
|---|---|
| Boot fanout | `fanoutAll` → `fanoutAllConsumers` |
| Sensor marks exhausted | `consumerQuotaProbeTick` → `fanoutToAffectedConsumers` |
| `mark-exhausted` RPC | `opMarkExhausted` → `fanoutToAffectedConsumers` |
| Exhaustion clears (healthy probe) | `cacheQuotaSnapshot` → `fanoutToAffectedConsumers` |
| Account credential refresh | `refreshOneAccount` → `fanoutToAffectedConsumers` |
| `set-active` | `opSetActive` → `fanoutAllConsumers` |

Attribution invariant is preserved: `mirrorAccountToConsumer` resolves the account via `servingAccountForConsumer` → `accountWithFailover`, never the raw pinned label. Consumers without `mirror_dir` keep pull-only behaviour unchanged.

## Tests (7 new)

1. `consumer-quota-sensor marks exhausted → mirror_dir re-written to fallback` — regression test for this incident
2. `mark-exhausted on the consumer's pinned account pushes fallback creds to mirror_dir`
3. `mirror reverts to pinned account when exhaustion mark clears (healthy probe)`
4. `attribution stays pinned: consumer with mirror cannot poison the fallback account`
5. `agents' existing failover fanout unchanged when consumers also have mirror_dir`
6. `boot fanout (fanoutAll) writes consumer mirror alongside agent mirrors`
7. `consumer WITHOUT mirror_dir gets no pushed file (pull-only behavior preserved)`

All 85 broker tests pass. Lint clean. Build clean.

## JTBD

`share-auth-across-the-fleet` — "log into Anthropic once per account, not once per agent." Specifically: when an account hits its cap, every consumer on that account fails over within seconds — not one pull cycle later.

This is a `#2194` follow-up: consumer failover detected exhaustion but never re-mirrored the consumer's creds onto the fallback.

> NOTE: a stopgap manual repoint of hindsight to `outlook` is already live in the running config. This PR is the durable code fix — do not merge until CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)