### PR TITLE
fix(context-budget): defer agent-config + hindsight MCP, suppress own CLAUDE.md injection

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -318,6 +318,12 @@ export TELEGRAM_STATE_DIR="{{agentDir}}/telegram"
 # basename(process.cwd()) inside the plugin because Claude Code spawns
 # MCP servers with cwd = $HOME regardless of the parent's cwd.
 export SWITCHROOM_AGENT_NAME="{{name}}"
+# SWITCHROOM_AGENT_START_CWD is the agent's real start directory (the dir this
+# script cd's into and where the agent's own CLAUDE.md lives). The
+# repo-context-pretool hook reads it to suppress re-injection of the agent's
+# own CLAUDE.md (already in the system prompt) while still injecting markers
+# for worktree repos the agent navigates into mid-session.
+export SWITCHROOM_AGENT_START_CWD="{{agentDir}}"
 {{#if switchroomConfigPathQ}}
 # SWITCHROOM_CONFIG lets the agent's own shell tool invoke `switchroom`
 # without passing `--config` every time. The telegram-plugin MCP server

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3421,8 +3421,11 @@ export function scaffoldAgent(
           SWITCHROOM_AGENT_NAME: name,
           SWITCHROOM_CONFIG: resolvedConfigPath,
         },
-        // Framework read-only server (4 tools) — keep loaded under tool search.
-        alwaysLoad: true,
+        // Deferred: 4-tool read-only server loads on demand via tool search.
+        // Agents invoke agent-config tools only occasionally (schedule adds,
+        // skill installs, config reads) — pinning it server-wide (~4 tools)
+        // burned always-on context budget for no first-turn benefit.
+        alwaysLoad: false,
       },
     };
 
@@ -5722,8 +5725,11 @@ export function reconcileAgent(
           SWITCHROOM_AGENT_NAME: name,
           SWITCHROOM_CONFIG: resolvedConfigPath,
         },
-        // Framework read-only server (4 tools) — keep loaded under tool search.
-        alwaysLoad: true,
+        // Deferred: 4-tool read-only server loads on demand via tool search.
+        // Agents invoke agent-config tools only occasionally (schedule adds,
+        // skill installs, config reads) — pinning it server-wide (~4 tools)
+        // burned always-on context budget for no first-turn benefit.
+        alwaysLoad: false,
       },
     };
 

--- a/src/memory/scaffold-integration.ts
+++ b/src/memory/scaffold-integration.ts
@@ -33,10 +33,14 @@ export function getHindsightSettingsEntry(
   const collection = getCollectionForAgent(agentName, config);
   const mcpConfig = generateHindsightMcpConfig(collection, memoryConfig);
 
-  // Keep hindsight's tools loaded under tool search — recall/reflect/retain
-  // are framework memory tools the agent is told to use proactively; deferring
-  // them would add a ToolSearch round-trip to every memory write.
-  return { key: "hindsight", value: { ...mcpConfig, alwaysLoad: true } };
+  // Defer hindsight's 32 MCP tools via tool search. Auto-recall (recall.py
+  // via UserPromptSubmit hook) and auto-retain (retain.py via Stop hook) call
+  // Hindsight directly over HTTP at 127.0.0.1:18888 — they do NOT go through
+  // the MCP server. Only the agent's interactive mcp__hindsight__* calls use
+  // the MCP server, and those load on demand. Live-validated: /health → 200,
+  // bank read works, recall/retain are urllib calls over the HTTP API.
+  // Deferring reclaims ~32 tool schemas (~8k tokens) from the always-on budget.
+  return { key: "hindsight", value: { ...mcpConfig, alwaysLoad: false } };
 }
 
 /**

--- a/telegram-plugin/hooks/repo-context-pretool.mjs
+++ b/telegram-plugin/hooks/repo-context-pretool.mjs
@@ -297,6 +297,32 @@ async function main() {
   const markerPath = findNearestMarker(targetDir)
   if (markerPath == null) process.exit(0)
 
+  // Own-agent marker guard: suppress the agent's own CLAUDE.md / AGENTS.md /
+  // AGENT.md so it is never injected as additionalContext. The agent's own
+  // marker is already in the system prompt (baked by start.sh via
+  // --append-system-prompt); re-injecting it wastes ~30KB per session.
+  //
+  // The existing isUnderAgentWorkspace guard only blocks paths under the
+  // agent's workspace/ subdirectory. It misses the agent's start cwd
+  // (/home/.../.switchroom/agents/<name>) because that guard computes against
+  // workspace/, not agentDir itself. This marker-path check closes that gap.
+  //
+  // We do NOT add a "targetDir under startCwd" directory guard because that
+  // would wrongly suppress a legitimate worktree repo the operator has checked
+  // out inside the agent dir (e.g. agentDir/workspace/ repos) — the directory
+  // guard would catch those too. The marker-path equality check is surgical:
+  // only the exact CLAUDE.md / AGENTS.md / AGENT.md at agentDir root is blocked;
+  // any nested repo's marker injects normally.
+  if (agentName) {
+    const startCwd = normalize(
+      process.env.SWITCHROOM_AGENT_START_CWD ??
+        join(home, '.switchroom', 'agents', agentName),
+    )
+    for (const m of MARKER_FILES) {
+      if (markerPath === join(startCwd, m)) process.exit(0)
+    }
+  }
+
   const state = readSessionState(sessionId)
 
   // Already-loaded dedup — the load-once-per-repo-per-session invariant.

--- a/telegram-plugin/tests/repo-context-pretool.test.ts
+++ b/telegram-plugin/tests/repo-context-pretool.test.ts
@@ -420,6 +420,68 @@ describe('repo-context-pretool e2e', () => {
     expect(res.stdout ?? '').toBe('')
   })
 
+  it('suppresses the agent own CLAUDE.md when SWITCHROOM_AGENT_START_CWD is set', () => {
+    // The agent's own CLAUDE.md is already in the system prompt — re-injecting
+    // it wastes ~30KB per session. The marker-path guard must exit 0 silently.
+    const agentDir = join(sb.root, '.switchroom', 'agents', 'myagent')
+    const agentWorkspace = join(agentDir, 'workspace')
+    mkdirSync(agentWorkspace, { recursive: true })
+    writeFileSync(join(agentDir, 'CLAUDE.md'), '# own agent claude md')
+    writeFileSync(join(agentWorkspace, 'note.md'), 'x')
+
+    const sid = `e2e-own-marker-${Date.now()}`
+    repoStateDir(sid)
+    const res = runHook(
+      {
+        session_id: sid,
+        cwd: agentDir,
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Read',
+        tool_input: { file_path: join(agentDir, 'workspace', 'note.md') },
+      },
+      {
+        home: sb.root,
+        agent: 'myagent',
+        env: { SWITCHROOM_AGENT_START_CWD: agentDir },
+      },
+    )
+    expect(res.code).toBe(0)
+    // Own CLAUDE.md must NOT be injected
+    expect(res.stdout).toBe('')
+  })
+
+  it('still injects a worktree repo CLAUDE.md even when SWITCHROOM_AGENT_START_CWD is set', () => {
+    // A repo checked out outside the agent start dir must still inject.
+    const agentDir = join(sb.root, '.switchroom', 'agents', 'myagent')
+    mkdirSync(agentDir, { recursive: true })
+    writeFileSync(join(agentDir, 'CLAUDE.md'), '# own agent')
+    const worktree = join(sb.root, 'workspace', 'myrepo')
+    mkdirSync(worktree, { recursive: true })
+    writeFileSync(join(worktree, 'CLAUDE.md'), '# worktree repo')
+    writeFileSync(join(worktree, 'src.ts'), 'x')
+
+    const sid = `e2e-worktree-${Date.now()}`
+    repoStateDir(sid)
+    const res = runHook(
+      {
+        session_id: sid,
+        cwd: worktree,
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Read',
+        tool_input: { file_path: join(worktree, 'src.ts') },
+      },
+      {
+        home: sb.root,
+        agent: 'myagent',
+        env: { SWITCHROOM_AGENT_START_CWD: agentDir },
+      },
+    )
+    expect(res.code).toBe(0)
+    expect(res.stdout.length).toBeGreaterThan(0)
+    const parsed = JSON.parse(res.stdout)
+    expect(parsed.hookSpecificOutput.additionalContext).toContain('# worktree repo')
+  })
+
   it('no marker → no output', () => {
     // tmpdir, no CLAUDE.md anywhere up the chain
     const file = join(sb.root, 'nothing.ts')

--- a/tests/scaffold.tool-search.test.ts
+++ b/tests/scaffold.tool-search.test.ts
@@ -6,7 +6,10 @@
  * window every turn. Two halves must stay wired:
  *   1. the ENABLE_TOOL_SEARCH env var (default `auto`, kill-switchable);
  *   2. The LOAD-BEARING tools never defer (the orphaned-reply hazard).
- *      - hindsight + agent-config: pinned server-wide via `alwaysLoad: true`.
+ *      - hindsight + agent-config: deferred via `alwaysLoad: false`.
+ *        hindsight auto-recall/retain use HTTP directly (not MCP), so
+ *        deferring the 32 MCP tools is safe. agent-config (4 tools) is
+ *        used only occasionally — no first-turn benefit from pinning.
  *      - switchroom-telegram (P4): NO LONGER pinned server-wide
  *        (`alwaysLoad: false`); the bridge pins only the hot tools (reply /
  *        stream_reply / get_recent_messages / react / …) per-tool via
@@ -63,12 +66,17 @@ describe("tool-search wiring (source guards)", () => {
     }
   });
 
-  it("agent-config + hindsight stay pinned server-wide (alwaysLoad:true)", () => {
-    const agentConfig = scaffoldSrc.split('"agent-config": {')[1]?.slice(0, 500) ?? "";
-    expect(agentConfig).toMatch(/alwaysLoad: true/);
-    // hindsight pinned in scaffold-integration.ts.
+  it("agent-config + hindsight are deferred via tool search (alwaysLoad:false)", () => {
+    // Both agent-config blocks (scaffold + reconcile paths) must agree.
+    const blocks = scaffoldSrc.split('"agent-config": {').slice(1);
+    expect(blocks.length).toBe(2);
+    for (const b of blocks) {
+      const m = b.slice(0, 700).match(/alwaysLoad: (true|false)/);
+      expect(m?.[1]).toBe("false");
+    }
+    // hindsight deferred in scaffold-integration.ts.
     const integ = readFileSync(resolve(__dirname, "..", "src", "memory", "scaffold-integration.ts"), "utf-8");
-    expect(integ).toMatch(/key: "hindsight", value: \{ \.\.\.mcpConfig, alwaysLoad: true \}/);
+    expect(integ).toMatch(/key: "hindsight", value: \{ \.\.\.mcpConfig, alwaysLoad: false \}/);
   });
 
   it("switchroom-telegram is NO LONGER pinned server-wide (P4-B: alwaysLoad:false)", () => {


### PR DESCRIPTION
## Problem

Every switchroom agent carries three MCP servers with `alwaysLoad: true` — meaning their full tool schema lists are injected into every turn's context window whether or not the agent ever uses them that turn:

- **agent-config** (4 tools): read-only broker for config/schedule/skill queries. Used occasionally, not every turn.
- **hindsight** (32 tools): the memory MCP. Auto-recall and auto-retain already run over direct HTTP (not MCP), so the 32 tool schemas sit in the window doing nothing most turns.
- **repo-context hook**: the agent's own ~30KB CLAUDE.md was being injected as `additionalContext` on the first tool call per session because the existing `isUnderAgentWorkspace` guard only blocked the `workspace/` subdirectory, not the agent's start cwd where CLAUDE.md actually lives.

Combined impact: ~8k+ tokens of always-on baseline overhead per agent per turn.

## Three Changes

### A — Defer agent-config MCP (`alwaysLoad: true → false`)

Both writer sites in `src/agents/scaffold.ts` (scaffold path ~line 3425, reconcile path ~line 5726) flipped to `alwaysLoad: false`. The 4 tools load on demand via tool search when an agent first calls `schedule_add`, `cron_list`, etc.

### B — Defer hindsight MCP (`alwaysLoad: true → false`)

`src/memory/scaffold-integration.ts` line 39 flipped to `alwaysLoad: false`.

**Empirical validation**: Auto-recall (`recall.py`, fired on UserPromptSubmit) and auto-retain (`retain.py`, fired on Stop) call Hindsight directly over HTTP at `127.0.0.1:18888` using `urllib` — they do **not** go through the MCP server at all. Only interactive `mcp__hindsight__*` calls from the agent model use the MCP path. Live-verified: `/health` → 200, bank read works, recall/retain functions are HTTP calls. Deferring the 32 MCP tool schemas is safe.

### C — repo-context hook: suppress own CLAUDE.md

`telegram-plugin/hooks/repo-context-pretool.mjs`: Added a marker-path equality guard after `findNearestMarker`. If `markerPath === join(startCwd, m)` for any `m` in `MARKER_FILES`, exit 0 with no injection. The agent's own CLAUDE.md is already baked into the system prompt via `start.sh --append-system-prompt`; re-injecting it wastes ~30KB per session.

**Design decision — marker-path equality, not directory guard**: A directory-based guard (`targetDir.startsWith(startCwd)`) would wrongly suppress a legitimate worktree repo checked out under the agent dir. The marker-path check is surgical: only the exact CLAUDE.md/AGENTS.md/AGENT.md at the agent's root is blocked; any nested repo's own marker still injects.

**Before/after validation matrix**:
| Scenario | Before | After |
|---|---|---|
| Agent reads own CLAUDE.md | injected (redundant ~30KB) | suppressed |
| Agent reads repo CLAUDE.md at e.g. `~/workspace/myrepo` | injected | injected (unchanged) |
| Same-session repeat for same repo | deduped | deduped (unchanged) |
| Own AGENTS.md / AGENT.md | injected | suppressed |

### C-supplement — export SWITCHROOM_AGENT_START_CWD from start.sh

`profiles/_base/start.sh.hbs`: Added `export SWITCHROOM_AGENT_START_CWD="{{agentDir}}"` after the SWITCHROOM_AGENT_NAME export. This lets the hook use the exact agent dir as set by the scaffold generator rather than the homedir-based fallback path. The env var is inherited by the claude process and all MCP hooks running under it.

## Test Changes

**`tests/scaffold.tool-search.test.ts`** (vitest): Updated the test name and assertions for the agent-config/hindsight block from `alwaysLoad: true` to `alwaysLoad: false`. Also widened the regex window from 500→700 chars to accommodate the expanded comment block before `alwaysLoad` in scaffold.ts. Test was previously a positive guard ("these stay pinned"); now it's a deferral guard ("these are deferred").

**`telegram-plugin/tests/repo-context-pretool.test.ts`** (bun): Added 2 new e2e spawn tests:
- `suppresses the agent own CLAUDE.md when SWITCHROOM_AGENT_START_CWD is set` — creates agent dir with CLAUDE.md, sets the env var, asserts no injection.
- `still injects a worktree repo CLAUDE.md even when SWITCHROOM_AGENT_START_CWD is set` — creates a separate worktree repo with its own CLAUDE.md, asserts it still injects.

## Vision outcome + job spec

Serves **outcome 3: subscription-honest and predictable** — the plan is the ceiling. Context-budget bloat forces earlier context compaction, pushing agents closer to their subscription ceiling on every turn.

Cited job spec: **`reference/jobs/keep-my-subscription-honest.md`**
> "The agents run on the user's Claude Pro or Max subscription, transparently and compliantly... If the product quietly routes to paid API or mixes billing models, the user loses trust."
Context waste is the internal equivalent: every unnecessary token burned on schema overhead is a token taken from real work, accelerating quota exhaustion.

## Invariant check

Crosses **no invariant**:
- `claude-native`: no model calls, no API usage, purely config generation changes.
- `no-self-escalation`: no access control changes.
- `on-leash`: no autonomous behavior.
- `single-tenant`: no multi-tenant concerns.
- `telegram-only`: no channel changes.
- `chat-is-the-single-source-of-truth`: no UI surface changes.

## Fleet-wide impact

Takes effect as agents reconcile or restart — no manual per-agent action needed. The change is in the scaffold/reconcile generator (`scaffold.ts`) and the hook file (ships with the agent image). Both alwaysLoad flips are backward-safe: deferred tools still work on demand, they just don't occupy the context window until called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)