### PR TITLE
feat(telegram): silence status-class messages, keep answers + gating cards loud

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5737,6 +5737,15 @@ silencePoke.startTimer({
     // get_status snapshot → pure formatter. Any hostd unavailability
     // degrades silently to the existing generic text (zero regression).
     let text: string | null = null
+    // Hoisted out of the generic-fallback branch below because the send site
+    // gates `disable_notification` on it: when the turn is parked on an
+    // approval card, the fallback TEXT is a user-gating re-ping ("waiting for
+    // your approval — tap Approve or Deny …"), and that must stay LOUD so the
+    // user knows the ball is in their court. The reaction controller tracks the
+    // park via setAwaiting on the permission-request.
+    const blockedOnApproval = activeStatusReactions
+      .get(statusKey(ctx.chatId, ctx.threadId))
+      ?.isAwaiting() ?? false
     const upd = inFlightUpdate
     if (upd != null) {
       try {
@@ -5758,9 +5767,6 @@ silencePoke.startTimer({
       // benign "wedge" class — claude is alive, waiting on the operator's
       // tap), say so instead of "still working…". The reaction controller
       // already tracks this (setAwaiting on the permission-request park).
-      const blockedOnApproval = activeStatusReactions
-        .get(statusKey(ctx.chatId, ctx.threadId))
-        ?.isAwaiting() ?? false
       text = silencePoke.formatFrameworkFallbackText(
         ctx.fallbackKind,
         ctx.silenceMs,
@@ -5781,10 +5787,13 @@ silencePoke.startTimer({
       await robustApiCall(
         () => bot.api.sendMessage(ctx.chatId, text, {
           ...(ctx.threadId != null ? { message_thread_id: ctx.threadId } : {}),
-          // Status notice ("still working…"), not the user's answer —
-          // silenced (BORDERLINE: was a deliberate loud liveness ping;
-          // see PR description — revert just this literal to restore it).
-          disable_notification: true,
+          // Conditional: the pure-liveness "still working…" notice is a status
+          // surface and stays SILENT. But when the turn is parked on an
+          // approval card, this same fallback carries a user-gating re-ping
+          // ("waiting for your approval — tap Approve or Deny …") — that must
+          // PING, because the user is the one being waited on. Gate on the same
+          // `blockedOnApproval` signal that selects the re-ping text above.
+          disable_notification: blockedOnApproval ? false : true,
         }),
         { chat_id: ctx.chatId, ...(ctx.threadId != null ? { threadId: ctx.threadId } : {}) },
       )

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2669,7 +2669,10 @@ function postQueuedStatus(chatId: string, bufferedThread: number, inFlightThread
   void (async () => {
     const sent = await swallowingApiCall(
       () =>
-        bot.api.sendMessage(chatId, text, { message_thread_id: bufferedThread }),
+        // Queued-placeholder status, not the user's answer — silence the
+        // open ping (BORDERLINE: it's a "your message is queued" notice;
+        // see PR description).
+        bot.api.sendMessage(chatId, text, { message_thread_id: bufferedThread, disable_notification: true }),
       { chat_id: chatId, verb: 'queued-status.post', threadId: bufferedThread },
     )
     const messageId = (sent as { message_id?: number } | undefined)?.message_id
@@ -5778,8 +5781,10 @@ silencePoke.startTimer({
       await robustApiCall(
         () => bot.api.sendMessage(ctx.chatId, text, {
           ...(ctx.threadId != null ? { message_thread_id: ctx.threadId } : {}),
-          // Framework fallback pings — user genuinely needs to know.
-          disable_notification: false,
+          // Status notice ("still working…"), not the user's answer —
+          // silenced (BORDERLINE: was a deliberate loud liveness ping;
+          // see PR description — revert just this literal to restore it).
+          disable_notification: true,
         }),
         { chat_id: ctx.chatId, ...(ctx.threadId != null ? { threadId: ctx.threadId } : {}) },
       )
@@ -14976,6 +14981,9 @@ function notifyDetachedFailure(
         lockedBot.api.sendMessage(chatId, text, {
           parse_mode: 'HTML',
           link_preview_options: { is_disabled: true },
+          // Detached restart/update child-failure notice — status, not
+          // the user's answer. Silence the open ping.
+          disable_notification: true,
           ...(threadId != null ? { message_thread_id: threadId } : {}),
         }),
       {
@@ -15988,6 +15996,9 @@ bot.command('restart', async ctx => {
         (tid) =>
           lockedBot.api.sendMessage(chatId, ackText, {
             parse_mode: 'HTML', link_preview_options: { is_disabled: true },
+            // Restart acknowledgement is a status notice — silence the
+            // open ping (the "restarted — ready" follow-up is what matters).
+            disable_notification: true,
             ...(tid != null ? { message_thread_id: tid } : {}),
           }),
         { threadId, chat_id: chatId, verb: 'restart.ack' },
@@ -16129,6 +16140,9 @@ async function handleNewCommand(ctx: Context): Promise<void> {
       (tid) =>
         lockedBot.api.sendMessage(chatId, ackText, {
           parse_mode: 'HTML', link_preview_options: { is_disabled: true },
+          // /new /reset acknowledgement is a status notice — silence the
+          // open ping (the post-restart greeting card is what matters).
+          disable_notification: true,
           ...(tid != null ? { message_thread_id: tid } : {}),
         }),
       { threadId, chat_id: chatId, verb: 'new-or-reset.ack' },
@@ -16331,6 +16345,9 @@ bot.command('update', async ctx => {
         lockedBot.api.sendMessage(chatId, ackText, {
           parse_mode: 'HTML',
           link_preview_options: { is_disabled: true },
+          // "update started" acknowledgement is a status notice — silence
+          // the open ping (the post-restart greeting card is what matters).
+          disable_notification: true,
           ...(tid != null ? { message_thread_id: tid } : {}),
         }),
       { threadId, chat_id: chatId, verb: 'update.ack' },
@@ -16996,7 +17013,9 @@ async function doFireFleetAutoFallback(triggerAgent: string, untilMs?: number): 
     // wrap in swallowingApiCall anyway per the codebase rule.
     const access = loadAccess()
     if (access.allowFrom.length === 0) return outcome.kind === 'switched'
-    const opts = { parse_mode: 'HTML' as const }
+    // Account-switch / all-blocked announcement is a system status notice,
+    // not the user's answer — silence the open ping.
+    const opts = { parse_mode: 'HTML' as const, disable_notification: true }
     for (const chat_id of access.allowFrom) {
       void swallowingApiCall(
         () => bot.api.sendMessage(chat_id, outcome.announcement, opts),
@@ -17090,6 +17109,9 @@ async function runCreditWatch(): Promise<void> {
         bot.api.sendMessage(chat_id, decision.message, {
           parse_mode: 'HTML',
           link_preview_options: { is_disabled: true },
+          // Credit/quota warning is a system status notice — silence the
+          // open ping (the user isn't waiting to tap anything).
+          disable_notification: true,
         }),
       { chat_id, verb: 'credit-watch.notify' },
     )
@@ -17229,6 +17251,8 @@ async function runQuotaWatch(opts: { bootTick?: boolean } = {}): Promise<void> {
             bot.api.sendMessage(chat_id, fleetDecision.message, {
               parse_mode: 'HTML',
               link_preview_options: { is_disabled: true },
+              // Quota status notice — silence the open ping.
+              disable_notification: true,
             }),
           { chat_id, verb: 'quota-watch.fleet-all-exhausted' },
         )
@@ -17450,6 +17474,8 @@ async function runQuotaWatch(opts: { bootTick?: boolean } = {}): Promise<void> {
           bot.api.sendMessage(chat_id, message, {
             parse_mode: 'HTML',
             link_preview_options: { is_disabled: true },
+            // Quota throttling status notice — silence the open ping.
+            disable_notification: true,
           }),
         { chat_id, verb: 'quota-watch.notify' },
       )

--- a/telegram-plugin/issues-card.ts
+++ b/telegram-plugin/issues-card.ts
@@ -328,6 +328,10 @@ export function createIssuesCardHandle(
       const sendOpts: Record<string, unknown> = {
         parse_mode: "HTML",
         disable_web_page_preview: true,
+        // Status card, not the user's answer — silence the open ping.
+        // (editMessageText ignores disable_notification, so the shared
+        // edit path below is unaffected.)
+        disable_notification: true,
         ...(opts.threadId != null ? { message_thread_id: opts.threadId } : {}),
       };
 

--- a/telegram-plugin/slot-banner-driver.ts
+++ b/telegram-plugin/slot-banner-driver.ts
@@ -110,6 +110,9 @@ export async function refreshBanner(
       sent = await args.bot.api.sendMessage(args.ownerChatId, action.text, {
         parse_mode: 'HTML',
         link_preview_options: { is_disabled: true },
+        // OAuth slot banner is a status notice — silence the open ping.
+        // (the pin below is already silent; the edit path doesn't ping.)
+        disable_notification: true,
       });
     } catch (err) {
       args.onError?.('pin', err);

--- a/telegram-plugin/tests/silence-liveness-wiring.test.ts
+++ b/telegram-plugin/tests/silence-liveness-wiring.test.ts
@@ -64,4 +64,22 @@ describe('silence-poke production-liveness — heartbeat safety', () => {
   it('production-liveness is behind the default-ON SWITCHROOM_SILENCE_LIVENESS_PRODUCTION kill switch', () => {
     expect(gatewaySrc).toMatch(/SWITCHROOM_SILENCE_LIVENESS_PRODUCTION !== '0'/)
   })
+
+  it('the 300s fallback send gates disable_notification on blockedOnApproval (approval re-ping pings, liveness stays silent)', () => {
+    // The 300s fallback is normally a pure-liveness "still working…" status
+    // notice and stays SILENT. But the SAME send carries a user-gating re-ping
+    // ("waiting for your approval — tap Approve or Deny …") when the turn is
+    // parked on an approval card — that must PING. The send site must therefore
+    // gate disable_notification on blockedOnApproval, NOT hard-code `true`.
+    // Structural guard so a refactor can't silently re-silence the re-ping
+    // (the gateway IIFE can't be instantiated in-process — same pattern as the
+    // heartbeat-safety assertions above).
+    const block = between(gatewaySrc, 'onFrameworkFallback: async (ctx) => {', '\nfunction trackRedeliveredInbound')
+    expect(block.length).toBeGreaterThan(100) // sanity: slice found the handler body
+    // The signal is derived once, hoisted above the update-status branch so it's
+    // in scope at the send site.
+    expect(block).toMatch(/const blockedOnApproval = activeStatusReactions/)
+    // The send gates on it rather than hard-coding silent.
+    expect(block).toMatch(/disable_notification: blockedOnApproval \? false : true/)
+  })
 })

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -287,6 +287,11 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     return {
       parse_mode: 'HTML',
       disable_web_page_preview: true,
+      // Sub-agent progress card is a status surface, never the user's
+      // answer — silence the open ping. (editMessageText ignores
+      // disable_notification, so this is a no-op on the in-place edits
+      // that share these opts.)
+      disable_notification: true,
       ...(h.threadId != null ? { message_thread_id: h.threadId } : {}),
     }
   }


### PR DESCRIPTION
## Summary

Status-class Telegram messages currently **ping the user's device** on their first send. On a phone that trains the user to mute the agent. Real answers and user-gating cards (approvals, `ask_user`, vault requests) are the only things that should buzz.

This PR adds `disable_notification: true` to the **initial send (open)** of each status surface. Telegram rule: `editMessageText` never pings — only the first send of a message pings when `disable_notification` is omitted/false. So **only OPEN paths are touched**; in-place card edits are unaffected (the shared-opts sites are a no-op on the edit path).

Hardcoded per Ken's call — **no config knob**.

**Serves:** vision outcome #2 "You hold the leash" (awareness + control without notification noise). Job spec: `reference/jobs/` status-surface / progress-visibility jobs — the leash should keep the user *aware*, not *buzzed*, for non-actionable status.

## What was silenced

### Card-opens (3)
| Surface | File | Site |
|---|---|---|
| Worker activity feed (sub-agent progress card) | `worker-activity-feed.ts` | `sendOptsFor` (shared by open + edit; edit is a no-op) |
| Issues card | `issues-card.ts` | `sendOpts` (shared by open/re-post + edit) |
| OAuth slot banner | `slot-banner-driver.ts` | the `pin` action's `sendMessage` open (the pin itself was already silent) |

### System status notices (gateway.ts)
| Notice | `verb` |
|---|---|
| Failover / account-switch announcement | `fleet-fallback:notify` |
| Credit / quota warning | `credit-watch.notify` |
| Quota fleet-all-exhausted | `quota-watch.fleet-all-exhausted` |
| Quota throttling transition | `quota-watch.notify` |
| Detached restart/update child-failure notice | `notifyDetachedFailure` |
| Restart acknowledgement | `restart.ack` |
| `/new` `/reset` acknowledgement | `new-or-reset.ack` |
| `/update` "update started" acknowledgement | `update.ack` |
| Queued-placeholder status ⚠️ **borderline** | `queued-status.post` |
| 300s framework "still working" fallback ⚠️ **conditional — see below** | silence-poke `onFrameworkFallback` |

> Note: `quota-watch.ts` / `credits-watch.ts` are pure decision modules — they don't send; the actual `bot.api.sendMessage` calls all live in `gateway.ts` (the three quota/credit verbs above).
>
> Note on the cron status notice from the investigation: the cron **session** is already status-silent (`reference/rfcs/cheap-cron-sessions.md` §2.4 — it sets no `currentTurn`, posts no visible status). There is **no separate pinging cron-status send** in current code, so nothing additional was changed there. The cron **deliverable** (`cron-action-send`, and cron content flowing through `executeReply`) is intentionally left **loud**.

### ⚠️ Borderline / conditional (flagged so they're easy to reason about independently)
1. **Queued-placeholder** (`queued-status.post`) — it's a "⏳ Queued — replying in another topic first" status. Silenced, but it's a judgement call since it tells the user something about *their* message.
2. **300s framework fallback — now CONDITIONAL (fixed in `b7785dc5`).** This send's *text* has a branch: in the pure-liveness case it reads "still working… (no update in N min)" — a non-actionable status that is correctly silenced. But when the turn is parked on an approval card (`blockedOnApproval`), the same send carries a **user-gating re-ping** ("waiting for your approval — tap Approve or Deny on the card above (N min)"). The first revision silenced this send unconditionally; that would mute a card the user is being asked to tap. Fixed: `disable_notification` is now gated on `blockedOnApproval` (`blockedOnApproval ? false : true`) — **silent for pure liveness, loud when approval-blocked.** The quieter early "mid-turn floor" liveness beat was already silent and is unchanged.

## MUST STAY LOUD — confirmed untouched

Verified via `git diff` that none of these appear in the change:

- **Real final answer:** `executeReply` chunked / no-quote sends.
- **Answer-stream materialize:** the `purpose === 'materialize'` gate (`const silent = params?.purpose !== 'materialize'`) — the model's final answer stays loud (unchanged).
- **`stream_reply` MCP handler** final answer.
- **Cron deliverable** (e.g. a morning briefing) — flows through the same `executeReply` answer path; only cron *status* meta is silent, content is loud.
- **User-gating cards** (user is waiting to tap): approval / permission cards, `ask_user`, vault/secret request cards — and now also the **approval-blocked 300s re-ping** (see #2 above).
- **Owed-reply / `obligation_represent` escalation** — the "you got dropped" backstop stays loud.
- The `agent-restarting-notice` ("your message is queued and will be processed when it reconnects") was **not** in the task's enumerated set, so it was deliberately left as-is.

## Test plan

- [x] `npm run build` — green (exit 0).
- [x] `tsc --noEmit` (lint) — green.
- [x] `node scripts/check-plugin-references.mjs` — clean.
- [x] `bash scripts/check-bot-api-wrapping.sh` — clean (edits added `disable_notification` literals to already-wrapped sends; no new raw callsites).
- [x] `bun test` (telegram-plugin): `silence-poke` (53/53) and the three card-surface suites pass. Added a structural assertion in `silence-liveness-wiring.test.ts` pinning the new gate — **approval-blocked poke pings, pure-liveness poke stays silent** — bringing that file to 6/6. The `formatFrameworkFallbackText` approval-blocked wording is already covered in `silence-poke.test.ts`.
- [x] **Residual local `bun test` failures are pre-existing, environment-dependent sandbox failures unrelated to this PR.** A clean comparison (this branch vs `origin/main`, my diff stashed) shows the **same 74 failures with the same signature on both** — they are vault-broker / grants-DB tests that cannot open their SQLite DB / write under the sandboxed test FS (`SQLITE_CANTOPEN` / a couple `EACCES` / vault-passphrase-decrypt). This PR touches **only 4 `telegram-plugin/` files** (gateway + 3 card surfaces) and **zero** `src/vault/**` or grants-DB code, so it cannot have introduced them; they pass in CI's writable environment. **Zero deterministic regressions from this PR.**

## Risk

Low. Behavior change is limited to the *notification* flag on status-class **opens**; message content, routing, threading, retry/wrapping, and edit-in-place are all unchanged. The queued-placeholder borderline is called out above; the 300s fallback now correctly stays loud when (and only when) the turn is approval-blocked.
