### PR TITLE
fix(hostd): no blank/duplicate cards, no frozen agents on config_propose_edit

### DIFF
--- a/src/agents/wedge-watchdog.ts
+++ b/src/agents/wedge-watchdog.ts
@@ -109,6 +109,43 @@ export const CONFIRM_MODAL_SIGNATURE =
   /Change\s+effort\s+level|(?=[\s\S]*\b1\.\s*Yes\b)(?=[\s\S]*\b2\.\s*No\b)/i;
 
 /**
+ * Per-tool PERMISSION-PROMPT TUI signature (config_propose_edit / hostd
+ * mutating-verb freeze).
+ *
+ * When a non-pre-approved MCP tool's permission prompt renders as Claude
+ * Code's INTERACTIVE confirmation TUI instead of emitting the channel
+ * notification that becomes a Telegram approval card, nothing arms the
+ * gateway's TTL auto-deny and the turn parks FOREVER — fleet-wide freeze
+ * (real incident: carrie froze indefinitely on a `config_propose_edit`
+ * permission prompt until a manual restart, 2026-06). The pane looks like:
+ *
+ *   Do you want to proceed?
+ *   ❯ 1. Yes
+ *     2. Yes, and don't ask again this session
+ *     3. No, and tell Claude what to do differently (esc)
+ *
+ * Critically, none of the existing signatures match this:
+ *   - WEDGE_FOOTER_SIGNATURE wants "to select"/"to navigate"/↑↓ in the
+ *     footer — this prompt has none.
+ *   - CONFIRM_MODAL_SIGNATURE wants a "1. Yes … / 2. No …" pair — here
+ *     option 2 is "Yes, and don't ask again", so `2.\s*No` never matches.
+ *
+ * Two INDEPENDENT anchors, both required, so it can never false-positive on
+ * normal model output:
+ *   (a) the "Do you want to proceed?" question Claude Code prints for every
+ *       per-tool permission prompt, AND
+ *   (b) a "don't ask again" affordance (the option-2 row unique to this
+ *       prompt family) — the load-bearing discriminator that separates a
+ *       permission prompt from any other yes/no modal.
+ *
+ * Remedy is Esc, which Claude Code treats as "decline" (== a safe DENY) —
+ * it can NEVER auto-select option 1 ("Yes") or 2 ("Yes, and don't ask
+ * again"), preserving the human-in-the-loop boundary for the hostd verbs.
+ */
+export const PERMISSION_PROMPT_SIGNATURE =
+  /(?=[\s\S]*Do you want to proceed\?)(?=[\s\S]*don['’]t ask again)/i;
+
+/**
  * #2471 — semantic NO-PROGRESS signature. A turn that is "Manifesting"
  * (or otherwise spinning under the working footer) AND has a Stop-hook
  * error visible ("Stop hook error occurred" / "running stop hooks 0/N")
@@ -272,6 +309,12 @@ const DEFAULT_COOLDOWN_MS = 60_000;
 //     stop-hook error anyway).
 const DEFAULT_CONFIRM_MODAL_POLLS = 3;
 const DEFAULT_MANIFEST_STALL_POLLS = 60;
+// A per-tool permission prompt must be PRESENT for this many consecutive
+// polls before Esc. Same shape-persistence rationale as CONFIRM_MODAL:
+// the Ink-rendered prompt repaints so it's not byte-stable. 3 polls ≈ 15s
+// @ 5s — a wedged permission prompt never clears on its own (no human),
+// so even a short streak is conclusive while staying clear of a transient.
+const DEFAULT_PERMISSION_PROMPT_POLLS = 3;
 
 function envInt(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -341,6 +384,24 @@ export interface WedgeWatchdogOptions {
    */
   confirmModalPolls?: number;
   /**
+   * Per-tool permission-prompt TUI signature, detected by SHAPE
+   * persistence (the prompt continuously PRESENT across polls), same as
+   * the confirmation modal. Catches a non-pre-approved MCP tool's
+   * "Do you want to proceed?" permission prompt that rendered as Claude
+   * Code's interactive TUI instead of emitting the channel notification —
+   * which leaves the turn frozen forever with no TTL auto-deny (the
+   * config_propose_edit / hostd-verb freeze). On a shape-persistent match
+   * the watchdog Escs it; Esc == "decline" == a SAFE DENY (never selects
+   * option 1/2 "Yes"), so the human-in-the-loop boundary is preserved.
+   * `null` disables this branch.
+   */
+  permissionPromptSignature?: RegExp | null;
+  /**
+   * Consecutive polls a permission prompt must be PRESENT before Esc.
+   * Default `SWITCHROOM_WEDGE_PERMISSION_POLLS` or 3.
+   */
+  permissionPromptPolls?: number;
+  /**
    * #2471 — semantic no-progress: a "Manifesting" + Stop-hook-error state
    * that persists past `manifestStallPolls`. The in-pane Esc evidently
    * could not clear it (the turn never ends), so this escalates to a clean
@@ -384,6 +445,9 @@ export interface WedgeWatchdogResult {
   /** #2471 — subset of `fires` that dismissed a confirmation modal detected
    *  by SHAPE persistence (the `/effort`-class wedge). */
   confirmModalFires: number;
+  /** Subset of `fires` that dismissed a per-tool permission-prompt TUI
+   *  (the config_propose_edit / hostd-verb freeze) with a safe Esc-decline. */
+  permissionPromptFires: number;
   /** #2471 — count of manifest-stall escalations (kill + handoff restart). */
   restartEscalations: number;
   /** Total polls executed (bounded only in tests via maxPolls). */
@@ -433,6 +497,15 @@ export async function runWedgeWatchdog(
       : (opts.confirmModalSignature ?? CONFIRM_MODAL_SIGNATURE);
   const confirmModalPolls =
     opts.confirmModalPolls ?? envInt("SWITCHROOM_WEDGE_CONFIRM_POLLS", DEFAULT_CONFIRM_MODAL_POLLS);
+  // Per-tool permission-prompt TUI freeze (config_propose_edit / hostd verbs).
+  // `null` disables the branch; `undefined` → default on.
+  const permissionPromptSignature =
+    opts.permissionPromptSignature === null
+      ? null
+      : (opts.permissionPromptSignature ?? PERMISSION_PROMPT_SIGNATURE);
+  const permissionPromptPolls =
+    opts.permissionPromptPolls ??
+    envInt("SWITCHROOM_WEDGE_PERMISSION_POLLS", DEFAULT_PERMISSION_PROMPT_POLLS);
   const manifestStallSignature =
     opts.manifestStallSignature === null
       ? null
@@ -452,13 +525,16 @@ export async function runWedgeWatchdog(
   let fires = 0;
   let rateLimitFires = 0;
   let confirmModalFires = 0;
+  let permissionPromptFires = 0;
   let restartEscalations = 0;
   let polls = 0;
   // #2471 — shape-persistence counters (independent of the byte-stable
   // `stableCount`): how many CONSECUTIVE polls each shape has been PRESENT.
   let confirmModalPresent = 0;
+  let permissionPromptPresent = 0;
   let manifestStallPresent = 0;
   let confirmCooldownUntil = 0;
+  let permissionCooldownUntil = 0;
 
   while (polls < maxPolls) {
     polls++;
@@ -492,14 +568,27 @@ export async function runWedgeWatchdog(
     // wording), so there is no collision to defer for. The watchdog's
     // remedy here (Esc) is also identical to the autoaccept effort rule, so
     // even an overlap would be harmless.
+    // Per-tool permission-prompt TUI ("Do you want to proceed?" + a
+    // "don't ask again" affordance) — the config_propose_edit / hostd-verb
+    // freeze. Precedence above the confirm-modal branch: its shape
+    // ("1. Yes / 2. Yes, and don't ask again / 3. No") is a SUPERSET match
+    // risk, so we classify it first and Esc-decline it (safe DENY).
+    const isPermissionPrompt =
+      !isRateLimitMenu &&
+      !!text &&
+      permissionPromptSignature !== null &&
+      permissionPromptSignature.test(text);
+
     const isConfirmModal =
       !isRateLimitMenu &&
+      !isPermissionPrompt &&
       !!text &&
       confirmModalSignature !== null &&
       confirmModalSignature.test(text);
 
     const isBlockingModal =
       !isRateLimitMenu &&
+      !isPermissionPrompt &&
       !isConfirmModal &&
       !!text &&
       signature.test(text) &&
@@ -591,6 +680,38 @@ export async function runWedgeWatchdog(
         stableCount = 0;
         lastKey = null;
       }
+    } else if (isPermissionPrompt) {
+      // SHAPE persistence (the Ink-rendered prompt repaints, so it is not
+      // byte-stable). Count consecutive polls the prompt has been PRESENT.
+      permissionPromptPresent++;
+      // Keep the byte-stable machinery neutral so a later wedge starts fresh.
+      stableCount = 0;
+      lastKey = null;
+      if (permissionPromptPresent >= permissionPromptPolls && now() >= permissionCooldownUntil) {
+        console.error(
+          `[wedge-watchdog] ${opts.agentName}: dismissing stuck per-tool ` +
+            `permission prompt (Esc == decline == safe DENY) after ` +
+            `${permissionPromptPresent} polls present ` +
+            `(~${Math.round((permissionPromptPresent * pollIntervalMs) / 1000)}s) — ` +
+            `the prompt rendered as an interactive TUI with no TTL auto-deny, ` +
+            `freezing the turn; no human to answer it`,
+        );
+        // Esc ONLY — Claude Code treats Esc as "user declined", which is the
+        // safe DENY for a non-pre-approved verb. It can NEVER land on option
+        // 1/2 ("Yes" / "Yes, and don't ask again"), so the human-in-the-loop
+        // boundary for the hostd verbs is preserved. Never send Enter/numeric.
+        try {
+          send(opts.agentName, ["Escape"]);
+        } catch (err) {
+          console.error(
+            `[wedge-watchdog] ${opts.agentName}: send threw: ${(err as Error).message}`,
+          );
+        }
+        fires++;
+        permissionPromptFires++;
+        permissionCooldownUntil = now() + cooldownMs;
+        permissionPromptPresent = 0;
+      }
     } else if (isConfirmModal) {
       // #2471 — SHAPE persistence, not byte-stability: count consecutive
       // polls the modal has been PRESENT. A flickering modal (timer
@@ -598,9 +719,11 @@ export async function runWedgeWatchdog(
       // branch never would.
       confirmModalPresent++;
       // Modal cleared the byte-stable streak machinery — keep it neutral so
-      // a later byte-stable wedge starts fresh.
+      // a later byte-stable wedge starts fresh. A different shape is showing,
+      // so drop any permission-prompt streak too.
       stableCount = 0;
       lastKey = null;
+      permissionPromptPresent = 0;
       if (confirmModalPresent >= confirmModalPolls && now() >= confirmCooldownUntil) {
         console.error(
           `[wedge-watchdog] ${opts.agentName}: dismissing stuck confirmation modal ` +
@@ -658,6 +781,8 @@ export async function runWedgeWatchdog(
       // #2471 — the confirmation modal is gone; reset its shape-present
       // streak so a re-armed modal must re-accumulate from scratch.
       confirmModalPresent = 0;
+      // Same for the permission-prompt streak — gone means re-accumulate.
+      permissionPromptPresent = 0;
     }
 
     await sleep(pollIntervalMs);
@@ -667,6 +792,7 @@ export async function runWedgeWatchdog(
     fires,
     rateLimitFires,
     confirmModalFires,
+    permissionPromptFires,
     restartEscalations,
     polls,
     reason: "max-polls",

--- a/src/cli/autoaccept-poll.ts
+++ b/src/cli/autoaccept-poll.ts
@@ -116,7 +116,7 @@ async function main(): Promise<void> {
       requestRestart: requestWedgeRestart,
     });
     console.error(
-      `[autoaccept-poll] ${agentName}: wedge-watchdog returned reason=${res.reason} fires=${res.fires} rateLimitFires=${res.rateLimitFires} confirmModalFires=${res.confirmModalFires} restartEscalations=${res.restartEscalations}`,
+      `[autoaccept-poll] ${agentName}: wedge-watchdog returned reason=${res.reason} fires=${res.fires} rateLimitFires=${res.rateLimitFires} confirmModalFires=${res.confirmModalFires} permissionPromptFires=${res.permissionPromptFires} restartEscalations=${res.restartEscalations}`,
     );
   } catch (err) {
     console.error(

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2986,9 +2986,10 @@ export const HostdConfigSchema = z.object({
     .describe(
       "Per-requesting-agent rate cap for `config_propose_edit` cards " +
       "(RFC admin-agent-config-edit §5). Default 3 cards/hour; min 1, " +
-      "max 20. Configurable now, but the rate limiter is not yet enforced " +
-      "(no `E_RATE_LIMITED` is currently raised); the field is reserved so " +
-      "operators can pin the cap ahead of the limiter going live.",
+      "max 20. ENFORCED server-side: a caller exceeding this in a sliding " +
+      "1-hour window is rejected with `E_RATE_LIMITED` (carrying a " +
+      "`retry_after` fix) instead of posting another operator approval " +
+      "card — so a looping agent is throttled rather than spamming the chat.",
     ),
 });
 

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -1587,7 +1587,7 @@ export class HostdServer {
    * `config_propose_edit` — full apply path (#1623 / RFC §3.3-3.4).
    *
    * Deliberately OUT of scope per operator decision (single-operator
-   * single-host posture, see PR description): rate limiter,
+   * single-host posture, see PR description):
    * crash-recovery journal, Prometheus metrics, TOCTOU re-validation,
    * literal `flock` on the config file (the in-process mutex is
    * sufficient — hostd is the only writer), attachment fallback for
@@ -1697,6 +1697,65 @@ export class HostdServer {
       );
       return await pending;
     }
+    // ── Server-side rate limit (circuit-breaker) ────────────────────
+    // A looping agent that re-fires DISTINCT diffs (any whitespace/context
+    // drift defeats the byte-exact dedup above) would otherwise post a
+    // fresh operator card every time. Throttle per-caller via the existing
+    // `config_edit_rate_per_hour` config field so the operator sees at most
+    // N cards/hour from any one agent. (#config-edit-hardening)
+    const rate = this.checkConfigEditRate(callerName, Date.now());
+    if (!rate.ok) {
+      const retryAtIso = new Date(rate.retryAtMs).toISOString();
+      process.stderr.write(
+        `hostd: config_propose_edit — RATE-LIMITED ${callerName} ` +
+          `(>${rate.limit}/hour); next slot ${retryAtIso}\n`,
+      );
+      // Leave a trail so the operator can retroactively see the throttle.
+      void this.appendAuditRow({
+        ts: new Date().toISOString(),
+        op: "config_propose_edit",
+        phase: "rate_limited",
+        request_id: req.request_id,
+        caller:
+          caller.kind === "agent"
+            ? { kind: "agent", name: caller.name }
+            : { kind: "operator" },
+        result: "denied",
+        exit_code: null,
+        duration_ms: Date.now() - started,
+        error: `E_RATE_LIMITED: >${rate.limit} config_propose_edit cards/hour`,
+      });
+      return err(
+        "E_RATE_LIMITED",
+        `config_propose_edit rate limit exceeded (max ${rate.limit}/hour for this agent)`,
+      )
+        .why(`next slot opens at ${retryAtIso}`)
+        .fixRetryAfter(retryAtIso)
+        .op("config_propose_edit")
+        .caller(caller.kind === "agent" ? "agent" : "operator")
+        .agentName(caller.kind === "agent" ? caller.name : undefined)
+        .asDenied()
+        .build(req.request_id, Date.now() - started);
+    }
+    // ── Audit at card-post time (item 5) ────────────────────────────
+    // config_propose_edit otherwise writes NO audit row until the apply
+    // path (which only runs on Allow). A loop that never reaches apply —
+    // or one parked 10 min awaiting an operator tap — left no trail. Emit
+    // a `requested` row NOW so an operator can retroactively see "agent
+    // fired Nx" even for proposals that time out or get denied.
+    void this.appendAuditRow({
+      ts: new Date().toISOString(),
+      op: "config_propose_edit",
+      phase: "requested",
+      request_id: req.request_id,
+      caller:
+        caller.kind === "agent"
+          ? { kind: "agent", name: caller.name }
+          : { kind: "operator" },
+      result: "started",
+      exit_code: null,
+      duration_ms: Date.now() - started,
+    });
     const run = this.runConfigProposeApprovalAndApply(
       req,
       caller,
@@ -1715,6 +1774,50 @@ export class HostdServer {
 
   /** In-flight config_propose_edit proposals, keyed by caller+diff hash. */
   private inflightConfigProposals = new Map<string, Promise<HostdResponse>>();
+
+  /**
+   * Per-caller sliding-window of config_propose_edit CARD-POST timestamps
+   * (epoch-ms), keyed by caller name. Enforces `config_edit_rate_per_hour`
+   * so a looping agent is throttled SERVER-SIDE rather than spamming the
+   * operator with approval cards. Only counts proposals that reach the
+   * card path (a fresh, validated, non-deduped diff) — validation errors
+   * and collapsed in-flight duplicates don't consume the budget.
+   */
+  private configEditPostTimes = new Map<string, number[]>();
+
+  /** Default cards/hour cap when `hostd.config_edit_rate_per_hour` is unset.
+   *  Mirrors the schema default (RFC admin-agent-config-edit §5). */
+  private static readonly DEFAULT_CONFIG_EDIT_RATE_PER_HOUR = 3;
+
+  /**
+   * Record a card-post for `callerName` and report whether it stays within
+   * the per-hour cap. Prunes timestamps older than 1h, then admits iff the
+   * window count is below the cap. On admit the new timestamp is recorded;
+   * on reject nothing is recorded (so a throttled caller doesn't push its
+   * own reset further out by hammering).
+   */
+  private checkConfigEditRate(
+    callerName: string,
+    now: number,
+  ): { ok: true } | { ok: false; limit: number; retryAtMs: number } {
+    const limit =
+      this.opts.config.hostd?.config_edit_rate_per_hour ??
+      HostdServer.DEFAULT_CONFIG_EDIT_RATE_PER_HOUR;
+    const windowMs = 60 * 60 * 1000;
+    const cutoff = now - windowMs;
+    const prior = (this.configEditPostTimes.get(callerName) ?? []).filter(
+      (t) => t > cutoff,
+    );
+    if (prior.length >= limit) {
+      // Oldest in-window timestamp frees a slot one window after it landed.
+      const retryAtMs = prior[0]! + windowMs;
+      this.configEditPostTimes.set(callerName, prior);
+      return { ok: false, limit, retryAtMs };
+    }
+    prior.push(now);
+    this.configEditPostTimes.set(callerName, prior);
+    return { ok: true };
+  }
 
   /**
    * The approval-card + mutex-serialized apply phase of

--- a/src/mcp/hostd/server.ts
+++ b/src/mcp/hostd/server.ts
@@ -361,16 +361,16 @@ export const TOOLS = [
       "to asking the operator to hand-edit the yaml.",
     inputSchema: {
       type: "object" as const,
-      required: ["unified_diff", "reason", "target_path"],
+      // Property ORDER is load-bearing: Claude Code serializes the tool input
+      // in declaration order and truncates the operator-card `input_preview`
+      // to ~200 chars. `reason` (+ `target_path`) MUST precede the big
+      // `unified_diff` blob so they survive inside the truncated prefix —
+      // otherwise the approval card renders "why: not provided" (the diff
+      // pushes the reason past the cut, and the truncated JSON is unparseable).
+      // Paired with the lenient regex fallback in telegram-plugin's
+      // `extractReasonFromRaw`; both are needed.
+      required: ["reason", "target_path", "unified_diff"],
       properties: {
-        unified_diff: {
-          type: "string",
-          minLength: 1,
-          description:
-            "Unified diff against switchroom.yaml. Any context level (a " +
-            "zero-context diff is fine); single-file, no path-traversal. " +
-            "LF-only, ≤1 MB.",
-        },
         reason: {
           type: "string",
           minLength: 1,
@@ -386,6 +386,14 @@ export const TOOLS = [
             "Must be the literal string '/state/config/switchroom.yaml'. " +
             "Future-proofs against multi-file diffs and gives the validator " +
             "a single canonical path to anchor on.",
+        },
+        unified_diff: {
+          type: "string",
+          minLength: 1,
+          description:
+            "Unified diff against switchroom.yaml. Any context level (a " +
+            "zero-context diff is fine); single-file, no path-traversal. " +
+            "LF-only, ≤1 MB.",
         },
       },
     },

--- a/telegram-plugin/gateway/config-approval-handler.test.ts
+++ b/telegram-plugin/gateway/config-approval-handler.test.ts
@@ -44,13 +44,28 @@ function fakeDeps(overrides: Partial<Parameters<typeof handleRequestConfigApprov
     chatId: number | string;
     messageId: number;
     text: string;
+    stripKeyboard?: boolean;
   }> = [];
   const deps = {
     agentName: "klanker",
     loadTargetChat: () => ({ chatId: 42 }),
     postCard: vi.fn(async () => ({ messageId: 1001 })),
-    buildKeyboard: () => ({ inline_keyboard: [] }),
-    editCard: async (a: { chatId: number | string; messageId: number; text: string }) => {
+    // Deterministic epoch so callback_data is assertable in tests.
+    mintEpoch: () => "cafe1234",
+    buildKeyboard: (requestId: string, epoch: string) => ({
+      inline_keyboard: [
+        [
+          { text: "✅ Approve", callback_data: `cfg:${requestId}:${epoch}:approve` },
+          { text: "🚫 Deny", callback_data: `cfg:${requestId}:${epoch}:deny` },
+        ],
+      ],
+    }),
+    editCard: async (a: {
+      chatId: number | string;
+      messageId: number;
+      text: string;
+      stripKeyboard?: boolean;
+    }) => {
       editCalls.push(a);
     },
     log: () => {},
@@ -227,9 +242,11 @@ describe("resolvePendingConfigApproval — double-tap and verdict propagation", 
     const verdicts = sent.filter((s) => s.type === "config_approval_resolved");
     expect(verdicts.length).toBe(1);
     expect(verdicts[0]!.verdict).toBe("approve");
-    // Card edited once to the interim 'Applying' state.
+    // Card edited once to the interim 'Applying' state, with the keyboard
+    // stripped so the buttons stop being tappable.
     expect(editCalls.length).toBe(1);
     expect(editCalls[0]!.text).toMatch(/Applying/);
+    expect(editCalls[0]!.stripKeyboard).toBe(true);
   });
 
   it("returns false when no entry exists (unknown requestId)", async () => {
@@ -261,6 +278,8 @@ describe("timeout path", () => {
       expect(verdicts.length).toBe(1);
       expect(verdicts[0]!.verdict).toBe("timeout");
       expect(editCalls[0]!.text).toMatch(/Expired/);
+      // Expired card must also strip the keyboard (no stale tappable buttons).
+      expect(editCalls[0]!.stripKeyboard).toBe(true);
     } finally {
       vi.useRealTimers();
     }
@@ -437,7 +456,20 @@ describe("oversize diff → attachment fallback (#1762)", () => {
 });
 
 describe("parseConfigApprovalCallback", () => {
-  it("parses well-formed callbacks", () => {
+  it("parses the new epoch-bearing form cfg:<requestId>:<epoch>:<choice>", () => {
+    expect(parseConfigApprovalCallback("cfg:abc:cafe1234:approve")).toEqual({
+      requestId: "abc",
+      epoch: "cafe1234",
+      choice: "approve",
+    });
+    expect(parseConfigApprovalCallback("cfg:deadbeef:00ff:deny")).toEqual({
+      requestId: "deadbeef",
+      epoch: "00ff",
+      choice: "deny",
+    });
+  });
+
+  it("still parses the legacy 3-segment form (no epoch, back-compat)", () => {
     expect(parseConfigApprovalCallback("cfg:abc:approve")).toEqual({
       requestId: "abc",
       choice: "approve",
@@ -453,5 +485,60 @@ describe("parseConfigApprovalCallback", () => {
     expect(parseConfigApprovalCallback("cfg:")).toBeNull();
     expect(parseConfigApprovalCallback("cfg:abc:bogus")).toBeNull();
     expect(parseConfigApprovalCallback("cfg::approve")).toBeNull();
+  });
+});
+
+describe("stale-tap rejection via per-card epoch", () => {
+  it("bakes the minted epoch into the posted card's callback_data", async () => {
+    const { client, deps } = fakeDeps();
+    await handleRequestConfigApproval(client, baseMsg, deps);
+    const postCard = deps.postCard as ReturnType<typeof vi.fn>;
+    const kb = postCard.mock.calls[0]![0].replyMarkup as {
+      inline_keyboard: Array<Array<{ callback_data: string }>>;
+    };
+    expect(kb.inline_keyboard[0]![0]!.callback_data).toBe(
+      "cfg:req-1:cafe1234:approve",
+    );
+    expect(kb.inline_keyboard[0]![1]!.callback_data).toBe(
+      "cfg:req-1:cafe1234:deny",
+    );
+  });
+
+  it("resolves when the tap epoch matches the live card", async () => {
+    const { client, deps } = fakeDeps();
+    await handleRequestConfigApproval(client, baseMsg, deps);
+    const ok = await resolvePendingConfigApproval(
+      "req-1",
+      "approve",
+      deps,
+      "cafe1234",
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("rejects a stale tap whose epoch does NOT match the live card", async () => {
+    const { client, sent, deps, editCalls } = fakeDeps();
+    await handleRequestConfigApproval(client, baseMsg, deps);
+    // A tap carrying a DIFFERENT (stale) epoch must be a no-op — no verdict
+    // crosses the wire, no card edit happens, and the request stays live.
+    const stale = await resolvePendingConfigApproval(
+      "req-1",
+      "approve",
+      deps,
+      "deadbeef",
+    );
+    expect(stale).toBe(false);
+    expect(sent.filter((s) => s.type === "config_approval_resolved")).toEqual(
+      [],
+    );
+    expect(editCalls).toEqual([]);
+    // The correct (live) epoch still resolves it.
+    const live = await resolvePendingConfigApproval(
+      "req-1",
+      "approve",
+      deps,
+      "cafe1234",
+    );
+    expect(live).toBe(true);
   });
 });

--- a/telegram-plugin/gateway/config-approval-handler.ts
+++ b/telegram-plugin/gateway/config-approval-handler.ts
@@ -2,6 +2,7 @@
 // card, resolves the verdict back to hostd over IPC, and flips the card to
 // a terminal state on finalize.
 
+import { randomBytes } from "node:crypto";
 import type { IpcClient } from "./ipc-server.js";
 import type {
   RequestConfigApprovalMessage,
@@ -12,6 +13,15 @@ import { truncateRawToFit } from "./oversize-card-body.js";
 /** Pending approval state — in-memory only (no SQLite per RFC §3.4). */
 interface PendingConfigApproval {
   requestId: string;
+  /**
+   * Per-card nonce embedded in the callback_data (`cfg:<requestId>:<epoch>:
+   * <choice>`). hostd's `approvalId` is only randomBytes(4)=32 bits and the
+   * callback_data carried no epoch, so a stale tap on a never-stripped old
+   * card could in principle resolve a same-id LIVE request. A tap whose epoch
+   * doesn't match the live pending entry is rejected as stale (see
+   * `resolvePendingConfigApproval`).
+   */
+  epoch: string;
   client: Pick<IpcClient, "send">;
   chatId: number | string;
   threadId?: number;
@@ -24,6 +34,12 @@ interface PendingConfigApproval {
 }
 
 const pending = new Map<string, PendingConfigApproval>();
+
+/** Default per-card nonce: 8 hex chars (32 bits) — enough to make a stale
+ *  tap's epoch effectively never collide with a live card's. */
+function defaultEpoch(): string {
+  return randomBytes(4).toString("hex");
+}
 
 // Injected deps — gateway.ts wires these from the existing surface.
 
@@ -43,13 +59,26 @@ export interface ConfigApprovalHandlerDeps {
     /** grammy InlineKeyboard, passed through verbatim. */
     replyMarkup: unknown;
   }) => Promise<{ messageId: number } | null>;
-  /** Build the inline keyboard with [✅ Approve] [🚫 Deny] buttons. */
-  buildKeyboard: (requestId: string) => unknown;
-  /** Edit a posted card to a new body. Best-effort — failures logged. */
+  /**
+   * Build the inline keyboard with [✅ Approve] [🚫 Deny] buttons. The
+   * `epoch` is a per-card nonce baked into the callback_data so a stale tap
+   * on an old card can never match a live request (see PendingConfigApproval).
+   */
+  buildKeyboard: (requestId: string, epoch: string) => unknown;
+  /** Mint a per-card nonce. Default: a short random hex (test seam). */
+  mintEpoch?: () => string;
+  /**
+   * Edit a posted card to a new body. Best-effort — failures logged.
+   * When `stripKeyboard` is set, the inline keyboard is removed so the
+   * [✅ Approve] [🚫 Deny] buttons stop being tappable on a card that has
+   * reached a terminal/interim state — a stale tap must never resolve a
+   * request (defense-in-depth alongside the per-card epoch in callback_data).
+   */
   editCard: (args: {
     chatId: number | string;
     messageId: number;
     text: string;
+    stripKeyboard?: boolean;
   }) => Promise<void>;
   /**
    * Send the full diff as a `.patch` document attachment when the
@@ -278,7 +307,11 @@ export async function handleRequestConfigApproval(
   // builder's structured `truncated` flag instead of substring-
   // matching the sentinel string (#1767 nit).
   const oversize = prelim !== msg.unifiedDiff || built.truncated;
-  const replyMarkup = deps.buildKeyboard(msg.requestId);
+  // Per-card nonce — baked into callback_data so a stale tap on a previously
+  // posted card (e.g. one already finalized/expired) can never match a live
+  // pending request even if hostd minted the same 32-bit requestId.
+  const epoch = (deps.mintEpoch ?? defaultEpoch)();
+  const replyMarkup = deps.buildKeyboard(msg.requestId, epoch);
 
   const posted = await deps.postCard({
     chatId: target.chatId,
@@ -296,6 +329,7 @@ export async function handleRequestConfigApproval(
 
   const entry: PendingConfigApproval = {
     requestId: msg.requestId,
+    epoch,
     client,
     chatId: target.chatId,
     ...(target.threadId !== undefined ? { threadId: target.threadId } : {}),
@@ -328,14 +362,30 @@ export async function handleRequestConfigApproval(
  *
  * Returns true if THIS call resolved the request (first call wins),
  * false if it was already resolved.
+ *
+ * `expectedEpoch` guards an OPERATOR tap: the callback_data carries the
+ * per-card nonce, which must match the live pending entry's `epoch`. A
+ * mismatch means the tap came from a STALE card (already finalized/expired,
+ * keyboard should have been stripped) — reject it as a no-op so it can never
+ * resolve a different live request that happens to share the 32-bit
+ * requestId. Internal callers (the per-request timeout timer, finalize) pass
+ * `undefined` to skip the check — they already hold the authoritative entry.
  */
 export async function resolvePendingConfigApproval(
   requestId: string,
   verdict: "approve" | "deny" | "timeout",
   deps: Pick<ConfigApprovalHandlerDeps, "editCard" | "log">,
+  expectedEpoch?: string,
 ): Promise<boolean> {
   const entry = pending.get(requestId);
   if (!entry || entry.resolved) return false;
+  if (expectedEpoch !== undefined && entry.epoch !== expectedEpoch) {
+    deps.log?.(
+      `config approval stale-tap rejected (requestId=${requestId}): ` +
+        `epoch mismatch (tap=${expectedEpoch} live=${entry.epoch})`,
+    );
+    return false;
+  }
   entry.resolved = true;
   if (entry.timer !== null) {
     clearTimeout(entry.timer);
@@ -364,10 +414,14 @@ export async function resolvePendingConfigApproval(
         ? "🚫 <b>Denied</b>"
         : "⏱ <b>Expired</b>";
   try {
+    // Strip the keyboard: once resolved (approve/deny/timeout) the buttons
+    // must not stay tappable — a stale tap could otherwise re-hit the
+    // callback path.
     await deps.editCard({
       chatId: entry.chatId,
       messageId: entry.messageId,
       text: interim,
+      stripKeyboard: true,
     });
   } catch (err) {
     deps.log?.(
@@ -425,10 +479,12 @@ export async function handleRequestConfigFinalize(
       ? `✅ <b>Applied</b>${msg.detail ? `\n${escapeHtml(msg.detail)}` : ""}${liveNote}`
       : `⚠️ <b>Reconcile failed; rolled back</b>${msg.detail ? `\n${escapeHtml(msg.detail)}` : ""}`;
   try {
+    // Finalize is terminal — strip the keyboard so the buttons are gone.
     await deps.editCard({
       chatId: entry.chatId,
       messageId: entry.messageId,
       text: body,
+      stripKeyboard: true,
     });
   } catch (err) {
     deps.log?.(
@@ -483,20 +539,45 @@ export function _peekPendingConfigApprovalForTest(
 }
 
 /**
- * Parse `cfg:<requestId>:<choice>` callback data. Returns null on
+ * Parse `cfg:<requestId>:<epoch>:<choice>` callback data. Returns null on
  * malformed input. The callback handler in gateway.ts uses this +
- * resolvePendingConfigApproval to drive the tap → resolve flow.
+ * resolvePendingConfigApproval (passing the parsed `epoch`) to drive the
+ * tap → resolve flow; the epoch is verified against the live pending entry
+ * so a stale tap can never resolve a same-id live request.
+ *
+ * The 3-segment legacy form `cfg:<requestId>:<choice>` (no epoch) is still
+ * parsed for back-compat with cards posted before this change — `epoch` is
+ * undefined there, so the resolver skips the epoch check (degrades to the
+ * keyboard-strip protection alone). New cards always carry an epoch.
  */
 export function parseConfigApprovalCallback(
   data: string,
-): { requestId: string; choice: "approve" | "deny" } | null {
+): { requestId: string; epoch?: string; choice: "approve" | "deny" } | null {
   if (!data.startsWith("cfg:")) return null;
   const rest = data.slice(4);
-  const colon = rest.lastIndexOf(":");
-  if (colon < 0) return null;
-  const requestId = rest.slice(0, colon);
-  const choice = rest.slice(colon + 1);
-  if (requestId.length === 0 || requestId.length > 64) return null;
+  const lastColon = rest.lastIndexOf(":");
+  if (lastColon < 0) return null;
+  const choice = rest.slice(lastColon + 1);
   if (choice !== "approve" && choice !== "deny") return null;
-  return { requestId, choice };
+  const head = rest.slice(0, lastColon);
+  // New form carries an epoch as the segment before the choice:
+  // <requestId>:<epoch>. The epoch is hex (no colon), so split on the LAST
+  // remaining colon to separate it from a requestId (which is also hex).
+  const epochColon = head.lastIndexOf(":");
+  let requestId: string;
+  let epoch: string | undefined;
+  if (epochColon >= 0) {
+    requestId = head.slice(0, epochColon);
+    epoch = head.slice(epochColon + 1);
+    if (epoch.length === 0 || epoch.length > 32 || !/^[0-9a-fA-F]+$/.test(epoch)) {
+      // Not a well-formed epoch — treat the whole head as the legacy
+      // requestId (back-compat for ids that themselves contain a colon).
+      requestId = head;
+      epoch = undefined;
+    }
+  } else {
+    requestId = head;
+  }
+  if (requestId.length === 0 || requestId.length > 64) return null;
+  return { requestId, ...(epoch !== undefined ? { epoch } : {}), choice };
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -7267,10 +7267,10 @@ const ipcServer: IpcServer = createIpcServer({
           ...(cfgTopic != null ? { threadId: cfgTopic } : {}),
         }
       },
-      buildKeyboard: (requestId) =>
+      buildKeyboard: (requestId, epoch) =>
         new InlineKeyboard()
-          .text('✅ Approve', `cfg:${requestId}:approve`)
-          .text('🚫 Deny', `cfg:${requestId}:deny`),
+          .text('✅ Approve', `cfg:${requestId}:${epoch}:approve`)
+          .text('🚫 Deny', `cfg:${requestId}:${epoch}:deny`),
       postCard: async (args) => {
         try {
           const sent = await robustApiCall(
@@ -7302,6 +7302,9 @@ const ipcServer: IpcServer = createIpcServer({
             () =>
               bot.api.editMessageText(args.chatId, args.messageId, args.text, {
                 parse_mode: 'HTML',
+                // Strip the inline keyboard on a terminal/interim edit so the
+                // [Approve]/[Deny] buttons stop being tappable on a resolved card.
+                ...(args.stripKeyboard ? { reply_markup: { inline_keyboard: [] } } : {}),
               }),
             { chat_id: String(args.chatId), verb: 'config-approval-edit' },
           )
@@ -7371,6 +7374,8 @@ const ipcServer: IpcServer = createIpcServer({
             () =>
               bot.api.editMessageText(args.chatId, args.messageId, args.text, {
                 parse_mode: 'HTML',
+                // Finalize is terminal — drop the keyboard so buttons are gone.
+                ...(args.stripKeyboard ? { reply_markup: { inline_keyboard: [] } } : {}),
               }),
             { chat_id: String(args.chatId), verb: 'config-approval-finalize' },
           )
@@ -20712,6 +20717,8 @@ bot.on('callback_query:data', async ctx => {
             await robustApiCall(() =>
               bot.api.editMessageText(args.chatId, args.messageId, args.text, {
                 parse_mode: 'HTML',
+                // Resolved on tap — strip the keyboard so it can't be re-tapped.
+                ...(args.stripKeyboard ? { reply_markup: { inline_keyboard: [] } } : {}),
               }),
             )
           } catch {
@@ -20721,6 +20728,9 @@ bot.on('callback_query:data', async ctx => {
         log: (m) =>
           process.stderr.write(`telegram gateway: config-approval cb — ${m}\n`),
       },
+      // Verify the per-card epoch from the callback_data against the live
+      // pending entry — a stale tap (mismatched epoch) is rejected.
+      parsed.epoch,
     )
     await ctx.answerCallbackQuery({
       text: resolved

--- a/telegram-plugin/permission-title.ts
+++ b/telegram-plugin/permission-title.ts
@@ -551,8 +551,43 @@ function readString(input: Record<string, unknown>, key: string): string | null 
  */
 function callerSuppliedReason(inputPreview: string | undefined): string | null {
   const input = parseInput(inputPreview);
-  if (!input) return null;
-  return readString(input, "reason") ?? readString(input, "why");
+  if (input) {
+    const fromJson = readString(input, "reason") ?? readString(input, "why");
+    if (fromJson) return fromJson;
+  }
+  // Truncation fallback (#2580 follow-up): upstream Claude Code truncates
+  // `inputPreview` to ~200 chars. For a tool whose first/largest key is a
+  // big blob (e.g. config_propose_edit's `unified_diff`), the truncated JSON
+  // is unparseable and the schema-required `reason` is lost — the card then
+  // renders "why: not provided" even though a reason WAS supplied. Mirror the
+  // `extractFilePathFromRaw` lenient-regex fallback so a `reason`/`why` value
+  // surviving in the truncated prefix is still recovered. (Reordering the
+  // schema so `reason` precedes the blob keeps it inside the 200-char prefix;
+  // this regex is what then reads it back out.)
+  if (inputPreview) {
+    const r = extractReasonFromRaw(inputPreview);
+    if (r) return r;
+  }
+  return null;
+}
+
+/**
+ * Regex-based fallback to extract a `reason` or `why` value from a raw
+ * (possibly truncated / invalid-JSON) inputPreview string. Mirrors
+ * `extractFilePathFromRaw`: JSON-unescapes the captured value so a reason
+ * with quotes/backslashes/unicode escapes is returned correctly. Returns
+ * null when neither key is present or the captured value is empty/whitespace.
+ */
+export function extractReasonFromRaw(raw: string): string | null {
+  // Match the first occurrence of "reason" or "why".
+  const m = /"(?:reason|why)"\s*:\s*"((?:[^"\\]|\\.)*)"/.exec(raw);
+  if (!m) return null;
+  try {
+    const value = JSON.parse(`"${m[1]}"`) as string;
+    return typeof value === "string" && value.trim().length > 0 ? value : null;
+  } catch {
+    return null;
+  }
 }
 
 function skillBasenameFromPath(input: Record<string, unknown>): string | null {

--- a/telegram-plugin/tests/permission-title.test.ts
+++ b/telegram-plugin/tests/permission-title.test.ts
@@ -222,6 +222,50 @@ describe('formatPermissionCardBody', () => {
     expect(body).toContain('why: <i>first second paragraph</i>')
   })
 
+  // config-edit-hardening: upstream Claude Code truncates `inputPreview`
+  // to ~200 chars. For config_propose_edit the (NEW-ordered) reason lands
+  // inside the surviving prefix, but the truncated JSON is unparseable —
+  // the lenient `extractReasonFromRaw` regex fallback must still recover it
+  // so the card no longer renders "why: not provided".
+  test('recovers reason from a >200-char truncated config_propose_edit input', () => {
+    // reason FIRST (the reordered schema), then a huge unified_diff that
+    // gets cut by the 200-char truncation → invalid JSON, no closing brace.
+    const reason = 'widen klanker tools.allow for the new skill'
+    const fullDiff =
+      '--- a/switchroom.yaml\n+++ b/switchroom.yaml\n' +
+      Array.from({ length: 40 }, (_, i) => `+    - "Bash(tool-${i}:*)"`).join('\n')
+    const full = JSON.stringify({
+      reason,
+      target_path: '/state/config/switchroom.yaml',
+      unified_diff: fullDiff,
+    })
+    const truncated = full.slice(0, 200) // mirror the upstream cut
+    expect(() => JSON.parse(truncated)).toThrow() // precondition: unparseable
+    const body = formatPermissionCardBody({
+      toolName: 'config_propose_edit',
+      inputPreview: truncated,
+      description: 'Propose a unified-diff patch against switchroom.yaml.',
+      agentName: 'klanker',
+    })
+    expect(body).toContain(`why: <i>${reason}</i>`)
+    expect(body).not.toContain('not provided')
+  })
+
+  test('recovers reason even when unified_diff precedes it (legacy order)', () => {
+    // Even with the OLD key order (diff first), the regex finds reason if it
+    // survives the cut — proving the fallback is order-independent.
+    const reason = 'self-scope allow rule add'
+    const raw =
+      '{"unified_diff":"--- a/x\\n+++ b/x\\n+ small","reason":"' + reason + '"}'
+    const body = formatPermissionCardBody({
+      toolName: 'config_propose_edit',
+      inputPreview: raw,
+      description: 'desc',
+      agentName: 'klanker',
+    })
+    expect(body).toContain(`why: <i>${reason}</i>`)
+  })
+
   // #2469: hostd agent_* cards must name WHICH agent is targeted, pulled
   // from the `name` input arg — not the static curated phrase.
   test('hostd agent_restart names the target agent in the title (#2469)', () => {

--- a/tests/host-control/config-propose-edit-rate-limit.test.ts
+++ b/tests/host-control/config-propose-edit-rate-limit.test.ts
@@ -1,0 +1,201 @@
+/**
+ * hostd `config_propose_edit` — SERVER-SIDE RATE LIMIT + audit-at-card-post.
+ *
+ * Loop-not-fully-closed recap: the in-flight dedupe is byte-exact on the
+ * unified_diff, so a looping agent re-firing DISTINCT diffs (any whitespace
+ * / context drift) posts a fresh operator card every time. The
+ * `config_edit_rate_per_hour` config field existed but was never enforced.
+ * These tests pin:
+ *
+ *   1. A caller exceeding `config_edit_rate_per_hour` distinct proposals in
+ *      the sliding hour is rejected with `E_RATE_LIMITED` BEFORE another
+ *      approval card is raised (the operator stops getting spammed).
+ *   2. A `requested` audit row is emitted at card-post time, so an operator
+ *      can retroactively see "agent fired Nx" even for proposals that never
+ *      reach the apply path; and a `rate_limited` row is emitted on throttle.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, chmodSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HostdServer } from "../../src/host-control/server.js";
+import { hostdRequest } from "../../src/host-control/client.js";
+import type {
+  ApprovalGateway,
+  ApprovalRequest,
+  ApprovalResult,
+} from "../../src/host-control/approval-gateway.js";
+
+let tmp: string;
+let server: HostdServer;
+let stubBin: string;
+let configPath: string;
+let auditPath: string;
+
+const VALID_BASE_YAML =
+  "switchroom:\n" +
+  "  version: 1\n" +
+  "telegram:\n" +
+  '  bot_token: "x"\n' +
+  '  forum_chat_id: "1"\n' +
+  "agents: {}\n";
+
+// N distinct-but-clean diffs (each touches the version line differently, so
+// the byte-exact dedupe never collapses them — exactly the loop case).
+function distinctDiff(tag: string): string {
+  return (
+    "--- a/switchroom.yaml\n" +
+    "+++ b/switchroom.yaml\n" +
+    "@@ -1,3 +1,3 @@\n" +
+    " switchroom:\n" +
+    "-  version: 1\n" +
+    `+  version: 1  # ${tag}\n` +
+    " telegram:\n"
+  );
+}
+
+// A gateway that DENIES every card immediately (so the file is never mutated
+// and each distinct diff keeps validating). Counts the cards raised.
+function denyingGateway() {
+  const requests: ApprovalRequest[] = [];
+  const gw: ApprovalGateway = {
+    async requestApproval(req): Promise<ApprovalResult> {
+      requests.push(req);
+      return { verdict: "deny", denySource: "operator", finalize: async () => {} };
+    },
+  };
+  return { gw, requests };
+}
+
+function makeServer(gw: ApprovalGateway, ratePerHour?: number) {
+  return new HostdServer({
+    homeDir: tmp,
+    agentUids: { klanker: 10001 },
+    config: {
+      agents: { klanker: { admin: true } },
+      hostd: {
+        config_edit_enabled: true,
+        ...(ratePerHour !== undefined ? { config_edit_rate_per_hour: ratePerHour } : {}),
+      },
+    },
+    switchroomBin: stubBin,
+    auditLogPath: auditPath,
+    allowNonLinux: true,
+    configPath,
+    approvalGateway: gw,
+  });
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "hostd-cpe-rate-"));
+  stubBin = join(tmp, "switchroom-stub.sh");
+  writeFileSync(stubBin, `#!/bin/sh\necho "stub: $@"\nexit 0\n`);
+  chmodSync(stubBin, 0o755);
+  configPath = join(tmp, "switchroom.yaml");
+  writeFileSync(configPath, VALID_BASE_YAML);
+  auditPath = join(tmp, "audit.log");
+});
+
+afterEach(async () => {
+  if (server) await server.stop();
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function sock(owner = "klanker"): string {
+  return server.getBoundPaths().find((p) => p.endsWith(`/${owner}/sock`))!;
+}
+
+function send(unified_diff: string, request_id: string) {
+  return hostdRequest(
+    { socketPath: sock(), timeoutMs: 60_000 },
+    {
+      v: 1,
+      op: "config_propose_edit",
+      request_id,
+      args: { unified_diff, reason: "loop test", target_path: "/state/config/switchroom.yaml" },
+    },
+  );
+}
+
+function readAuditRows(): Array<Record<string, unknown>> {
+  if (!existsSync(auditPath)) return [];
+  return readFileSync(auditPath, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+describe("config_propose_edit — server-side rate limit (#config-edit-hardening)", () => {
+  it("throttles a looping agent after config_edit_rate_per_hour distinct cards", async () => {
+    const { gw, requests } = denyingGateway();
+    server = makeServer(gw, 3); // 3 cards/hour
+    await server.start();
+
+    // Three DISTINCT proposals all reach a card (and get denied).
+    const r1 = await send(distinctDiff("a"), "rl-1");
+    const r2 = await send(distinctDiff("b"), "rl-2");
+    const r3 = await send(distinctDiff("c"), "rl-3");
+    // The fourth distinct proposal trips the limiter — NO fourth card.
+    const r4 = await send(distinctDiff("d"), "rl-4");
+
+    expect(r1.result).toBe("denied");
+    expect(r2.result).toBe("denied");
+    expect(r3.result).toBe("denied");
+    // The throttled one is denied with the rate-limit code, and crucially
+    // never reached the gateway (no fourth card spammed at the operator).
+    expect(r4.result).toBe("denied");
+    expect(r4.error ?? "").toMatch(/E_RATE_LIMITED|rate limit/i);
+    expect(requests.length).toBe(3);
+  });
+
+  it("uses the schema default (3/hour) when config_edit_rate_per_hour is unset", async () => {
+    const { gw, requests } = denyingGateway();
+    server = makeServer(gw); // no explicit rate → default 3
+    await server.start();
+
+    for (const tag of ["a", "b", "c"]) await send(distinctDiff(tag), `def-${tag}`);
+    const over = await send(distinctDiff("d"), "def-d");
+    expect(over.error ?? "").toMatch(/E_RATE_LIMITED|rate limit/i);
+    expect(requests.length).toBe(3);
+  });
+});
+
+describe("config_propose_edit — audit at card-post time (#config-edit-hardening item 5)", () => {
+  it("emits a `requested` row when a card is posted (visible before apply)", async () => {
+    const { gw } = denyingGateway();
+    server = makeServer(gw, 5);
+    await server.start();
+
+    await send(distinctDiff("a"), "aud-1");
+    // Give the best-effort audit append a tick to flush.
+    await new Promise<void>((r) => setTimeout(r, 30));
+
+    const rows = readAuditRows();
+    const requested = rows.filter(
+      (r) => r.op === "config_propose_edit" && r.phase === "requested",
+    );
+    expect(requested.length).toBe(1);
+    expect(requested[0]!.request_id).toBe("aud-1");
+    expect(requested[0]!.result).toBe("started");
+    expect((requested[0]!.caller as { name?: string }).name).toBe("klanker");
+  });
+
+  it("emits a `rate_limited` row when a proposal is throttled", async () => {
+    const { gw } = denyingGateway();
+    server = makeServer(gw, 1); // 1/hour → second is throttled
+    await server.start();
+
+    await send(distinctDiff("a"), "rlr-1");
+    await send(distinctDiff("b"), "rlr-2"); // throttled
+    await new Promise<void>((r) => setTimeout(r, 30));
+
+    const rows = readAuditRows();
+    const throttled = rows.filter(
+      (r) => r.op === "config_propose_edit" && r.phase === "rate_limited",
+    );
+    expect(throttled.length).toBe(1);
+    expect(throttled[0]!.request_id).toBe("rlr-2");
+    expect(throttled[0]!.result).toBe("denied");
+  });
+});

--- a/tests/wedge-watchdog.test.ts
+++ b/tests/wedge-watchdog.test.ts
@@ -8,6 +8,7 @@ import {
   parseWeeklyReset,
   WEDGE_FOOTER_SIGNATURE,
   CONFIRM_MODAL_SIGNATURE,
+  PERMISSION_PROMPT_SIGNATURE,
   STOP_HOOK_ERROR_SIGNATURE,
   MANIFESTING_SIGNATURE,
 } from "../src/agents/wedge-watchdog.js";
@@ -431,6 +432,124 @@ describe("#2471 runWedgeWatchdog — manifest-stall escalation", () => {
     expect(res.restartEscalations).toBe(1);
     expect(errSpy).toHaveBeenCalled();
     errSpy.mockRestore();
+  });
+});
+
+// ─── Per-tool permission-prompt TUI freeze (config_propose_edit / hostd) ──────
+//
+// A non-pre-approved MCP tool's permission prompt that renders as Claude
+// Code's interactive TUI (instead of emitting the channel notification that
+// becomes a Telegram card) arms no TTL auto-deny and parks the turn forever
+// — the carrie freeze. The watchdog must detect it by SHAPE persistence and
+// dismiss it with Esc (a SAFE decline/deny), never selecting option 1/2.
+
+// The real per-tool permission prompt, rendered TWO ways so a byte-stable
+// gate would never fire (the spinner / cursor jitter between paints).
+const PERMISSION_PROMPT_A =
+  "config_propose_edit(reason: widen tools.allow)\n" +
+  "Do you want to proceed?\n" +
+  "❯ 1. Yes\n" +
+  "  2. Yes, and don't ask again this session\n" +
+  "  3. No, and tell Claude what to do differently (esc)";
+const PERMISSION_PROMPT_B = PERMISSION_PROMPT_A + "\n ";
+
+describe("PERMISSION_PROMPT_SIGNATURE", () => {
+  it("matches the per-tool permission prompt (proceed? + don't-ask-again)", () => {
+    expect(PERMISSION_PROMPT_SIGNATURE.test(PERMISSION_PROMPT_A)).toBe(true);
+  });
+
+  it("does NOT match the /effort confirm modal or a plain yes/no", () => {
+    // The effort modal has no "Do you want to proceed?" + "don't ask again".
+    expect(PERMISSION_PROMPT_SIGNATURE.test(EFFORT_MODAL_A)).toBe(false);
+    expect(
+      PERMISSION_PROMPT_SIGNATURE.test("Do you want to proceed?\n 1. Yes\n 2. No"),
+    ).toBe(false);
+  });
+
+  it("does NOT match idle / working / plain panes", () => {
+    for (const text of [
+      "⏵⏵ accept edits on · esc to interrupt\n> ",
+      "Here is the answer. Done.",
+      "Thinking… (12s · esc to interrupt)",
+      "",
+    ]) {
+      expect(PERMISSION_PROMPT_SIGNATURE.test(text), `matched: ${text}`).toBe(
+        false,
+      );
+    }
+  });
+});
+
+describe("runWedgeWatchdog — permission-prompt freeze", () => {
+  it("dismisses a FLICKERING permission prompt with Esc (safe deny)", async () => {
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "carrie",
+      permissionPromptPolls: 3,
+      // isolate the permission-prompt branch.
+      rateLimitSignature: null,
+      confirmModalSignature: null,
+      manifestStallSignature: null,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 3,
+      capture: captureFlicker([
+        PERMISSION_PROMPT_A,
+        PERMISSION_PROMPT_B,
+        PERMISSION_PROMPT_A,
+      ]),
+      send,
+    });
+    expect(res.permissionPromptFires).toBe(1);
+    expect(res.fires).toBe(1);
+    // ESC ONLY — never an Enter or a "1"/"2" numeric (would auto-approve).
+    expect(calls).toEqual([["Escape"]]);
+  });
+
+  it("does NOT fire before the present-streak threshold", async () => {
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "carrie",
+      permissionPromptPolls: 3,
+      rateLimitSignature: null,
+      confirmModalSignature: null,
+      manifestStallSignature: null,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 2, // one short
+      capture: captureFlicker([PERMISSION_PROMPT_A, PERMISSION_PROMPT_B]),
+      send,
+    });
+    expect(res.permissionPromptFires).toBe(0);
+    expect(calls).toEqual([]);
+  });
+
+  it("resets the streak when the prompt clears (no fire on intermittent)", async () => {
+    const idle = "⏵⏵ accept edits on · esc to interrupt\n> ";
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "carrie",
+      permissionPromptPolls: 3,
+      rateLimitSignature: null,
+      confirmModalSignature: null,
+      manifestStallSignature: null,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 5,
+      capture: captureFlicker([
+        PERMISSION_PROMPT_A,
+        PERMISSION_PROMPT_B,
+        idle,
+        PERMISSION_PROMPT_A,
+        PERMISSION_PROMPT_B,
+      ]),
+      send,
+    });
+    expect(res.permissionPromptFires).toBe(0);
+    expect(calls).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Outcome (operator-visible)

Admin agents calling `config_propose_edit` (and other non-pre-approved hostd mutating verbs) caused two operator-visible failures: a wall of approval cards all reading **"why: not provided"**, and an agent (carrie) that **FROZE indefinitely** on a permission prompt until manually restarted. After this PR: cards show the agent's reason, no agent freezes on a permission prompt, stale cards can't be re-tapped, and a looping agent is throttled server-side instead of spamming the chat.

**Serves** `reference/jobs/approve-what-my-agent-can-touch.md` (hold-the-leash; invariants `no-self-escalation`, `claude-native`): the operator grants/denies with one *informed* tap, the agent can ask but never self-grant, the raw diff/secret never leaks, and the gate can't be spammed. No verb is added to the pre-approval allowlist — the human-in-the-loop tap stays the boundary.

## Fixes

**1 — Blank reason on cards (truncation).** Claude Code truncates `input_preview` to ~200 chars; for `config_propose_edit` the large `unified_diff` pushed the schema-required `reason` past the cut and the truncated JSON was unparseable.
- `telegram-plugin/permission-title.ts:552` — add `extractReasonFromRaw` lenient regex (mirrors `extractFilePathFromRaw:496`), wired into `callerSuppliedReason` as the fallback when `parseInput` returns null. Matches `reason`/`why`.
- `src/mcp/hostd/server.ts:362` — reorder the `config_propose_edit` inputSchema so `reason` + `target_path` precede `unified_diff` (declaration order = serialization order), landing the reason inside the surviving prefix. Both changes are needed. Confirmed in `src/host-control/protocol.ts:62` that the daemon idempotency key defaults to `request_id` (not a diff hash), so reordering is safe.

**2 — Frozen permission prompt (fleet-wide freeze).** A non-pre-approved MCP tool's permission prompt rendered as Claude Code's interactive TUI (`Do you want to proceed? 1. Yes / 2. Yes, and don't ask again / 3. No`) arms no TTL auto-deny and parks the turn forever. None of the existing wedge-watchdog signatures matched it.
- `src/agents/wedge-watchdog.ts` — add `PERMISSION_PROMPT_SIGNATURE` (anchored on `Do you want to proceed?` + a `don't ask again` affordance) and an `isPermissionPrompt` branch alongside `isConfirmModal` (~495-661), shape-persistence poll pattern, default-on. Dismissed with **Esc** (Claude Code treats Esc as decline == safe DENY; never selects option 1/2). Closes the freeze for ALL non-pre-approved hostd verbs at once. `src/cli/autoaccept-poll.ts` log line updated.

**3 — Stale tappable cards.** A finalized/expired/denied card kept its inline keyboard, and the 32-bit `approvalId` (`src/host-control/server.ts:325`) in `callback_data` had no epoch.
- `telegram-plugin/gateway/config-approval-handler.ts` + `gateway.ts:7270,7299,20710` — strip the inline keyboard on every terminal/interim card edit (`reply_markup: { inline_keyboard: [] }`), and add a per-card epoch nonce to `callback_data` (`cfg:<requestId>:<epoch>:<choice>`). `resolvePendingConfigApproval` verifies the tap epoch against the live entry and rejects a mismatch (`config-approval-handler.ts:360`). Legacy 3-segment callbacks still parse.

**4 — Loop not fully closed + no rate limit.** The in-flight dedup (`server.ts:1690`) is byte-exact on the diff, so a re-fire with whitespace drift posted a fresh card. `config_edit_rate_per_hour` existed (`src/config/schema.ts:2980`) but had zero enforcement.
- `src/host-control/server.ts` — `checkConfigEditRate` (per-caller sliding hour) gates the card path; over-limit returns `E_RATE_LIMITED` (with a `retry_after` fix) instead of another card. Default 3/hour when unset. `schema.ts` doc updated to "enforced".

**5 — Audit invisibility.** `config_propose_edit` wrote no audit row until the apply path (`server.ts:1727`), so a loop that never reached apply left no trail.
- `src/host-control/server.ts` — emit a `requested` audit row at card-post time, and a `rate_limited` row on throttle, so an operator can retroactively see "agent fired Nx".

## Tests
- `telegram-plugin/tests/permission-title.test.ts` — reason renders for a >200-char truncated input (+ order-independent regex).
- `tests/wedge-watchdog.test.ts` — `PERMISSION_PROMPT_SIGNATURE` matches the permission TUI (and not the effort modal / idle / plain); watchdog fires exactly one Esc on shape-persistence; resets when it clears.
- `telegram-plugin/gateway/config-approval-handler.test.ts` — keyboard stripped on resolve/finalize/expire; epoch baked into `callback_data`; stale-epoch tap rejected; new + legacy callback parsing.
- `tests/host-control/config-propose-edit-rate-limit.test.ts` — throttle after cap, default 3/hour, `requested` + `rate_limited` audit rows.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `node scripts/build.mjs` clean
- [x] `check-plugin-references.mjs` + `check-bot-api-wrapping.sh` clean
- [x] New/changed suites green: `wedge-watchdog`, `permission-title`, `config-approval-handler`, `config-propose-edit-rate-limit`
- [x] Full `vitest run`: no new failures vs `origin/main` (the 20 failing files are pre-existing sandbox env-bound tests needing git-apply/docker/binaries — identical set on base; CI runs them in a clean env)

## Nothing deferred
All five surfaces (1-3 mandatory, 4-5 strongly preferred) are implemented.

## Risk
Low. Watchdog branch only adds Esc (non-destructive, defense-in-depth). Schema reorder is serialization-order only — wire validation is order-independent zod. Rate limiter uses the existing config field with the schema's own default. Keyboard-strip + epoch are additive; legacy callbacks still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)