### PR TITLE
fix(compose): change restart policy from unless-stopped to always

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1077,12 +1077,12 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`    labels:`);
   lines.push(`      switchroom.role: "broker"`);
   lines.push(`      switchroom.fleet: "${containerNamePrefix}"`);
-  lines.push(`    restart: unless-stopped`);
+  lines.push(`    restart: always`);
   // Liveness probe — bind-presence. The broker creates per-agent
   // socket directories at startup and binds `<dir>/sock` for each
   // configured agent. If at least one bind has happened, the daemon
   // is alive enough to take work; if every bind has gone away, the
-  // daemon is wedged or dead and `restart: unless-stopped` should
+  // daemon is wedged or dead and `restart: always` should
   // recycle it. This catches the silent-down failure mode where the
   // broker exits cleanly (compose then sees process-gone) AS WELL AS
   // a hung daemon that's still holding the process slot but stopped
@@ -1307,7 +1307,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`    labels:`);
   lines.push(`      switchroom.role: "kernel"`);
   lines.push(`      switchroom.fleet: "${containerNamePrefix}"`);
-  lines.push(`    restart: unless-stopped`);
+  lines.push(`    restart: always`);
   // Mirror the broker's bind-presence healthcheck — same failure-mode
   // surface (kernel binds per-agent sockets at
   // /run/switchroom/kernel/<agent>/sock; silently exits or hangs the
@@ -1399,7 +1399,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`    labels:`);
   lines.push(`      switchroom.role: "auth-broker"`);
   lines.push(`      switchroom.fleet: "${containerNamePrefix}"`);
-  lines.push(`    restart: unless-stopped`);
+  lines.push(`    restart: always`);
   // Bind-presence healthcheck — same probe pattern as vault-broker /
   // approval-kernel (PR #898). Empty-fleet trade-off applies: a
   // switchroom install with zero agents and zero consumers reports
@@ -1628,7 +1628,7 @@ function emitAgentService(
   } else {
     lines.push(`    network_mode: host`);
   }
-  lines.push(`    restart: unless-stopped`);
+  lines.push(`    restart: always`);
   lines.push(`    init: false`);
   // PTY allocation — claude's interactive mode requires a TTY at stdin
   // (the alt-screen UI, autoaccept-poll keystrokes, and the `--print`

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -159,7 +159,7 @@ services:
   hostd:
     image: ghcr.io/switchroom/switchroom-hostd:${imageTag}
     container_name: switchroom-hostd
-    restart: unless-stopped
+    restart: always
     user: "0:0"
     # tini handles SIGTERM forwarding; node's main.ts shutdown handler
     # closes UDS listeners and exits cleanly. 15s grace matches the

--- a/src/cli/webd.ts
+++ b/src/cli/webd.ts
@@ -141,7 +141,7 @@ services:
   web:
     image: ghcr.io/switchroom/switchroom-web:${imageTag}
     container_name: switchroom-web
-    restart: unless-stopped
+    restart: always
     # The server MUST own host loopback 127.0.0.1:8080 — the cloudflared
     # tunnel (GitHub webhooks) and \`tailscale serve\` (dashboard) both
     # reach it there, and the dashboard CSRF gate trusts the

--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -73,7 +73,7 @@ export function generateDockerComposeSnippet(
     ...envLines,
     "  volumes:",
     "    - hindsight-data:/home/hindsight/.pg0",
-    "  restart: unless-stopped",
+    "  restart: always",
   ].join("\n");
 }
 

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -448,7 +448,7 @@ export function startHindsight(ports?: { apiPort: number; uiPort: number }): voi
   const args = [
     "run", "-d",
     "--name", "switchroom-hindsight",
-    "--restart", "unless-stopped",
+    "--restart", "always",
     // Container resource caps (memory + pids only; CPU uncapped —
     // see HINDSIGHT_DEFAULT_MEM_LIMIT constant for the v0.13.22 → v0.13.23
     // unwind rationale).
@@ -633,7 +633,7 @@ export function generateHindsightComposeSnippet(): string {
     `      - ${HINDSIGHT_BROKER_SOCK_VOLUME}:/run/switchroom/auth-broker`,
     "    tmpfs:",
     `      - /run/claude-creds:rw,mode=0700,uid=${HINDSIGHT_DEFAULT_UID},gid=${HINDSIGHT_DEFAULT_UID}`,
-    "    restart: unless-stopped",
+    "    restart: always",
     "",
     "volumes:",
     "  switchroom-hindsight-data:",

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -73,7 +73,7 @@ describe("generateDockerComposeSnippet", () => {
     expect(yaml).toContain("LLM_PROVIDER=openai");
     expect(yaml).toContain("EMBEDDING_MODEL=text-embedding-3-small");
     expect(yaml).toContain("hindsight-data:/home/hindsight/.pg0");
-    expect(yaml).toContain("restart: unless-stopped");
+    expect(yaml).toContain("restart: always");
   });
 
   it("omits EMBEDDING_MODEL when model is not set", () => {
@@ -235,7 +235,7 @@ describe("generateHindsightComposeSnippet (broker-fed, #1245)", () => {
     expect(snippet).toContain("switchroom-hindsight");
     expect(snippet).toContain("image: ghcr.io/switchroom/switchroom-hindsight:latest");
     expect(snippet).toContain("switchroom-hindsight-data:/home/hindsight/.pg0");
-    expect(snippet).toContain("restart: unless-stopped");
+    expect(snippet).toContain("restart: always");
     // Upstream image is NOT used — switchroom-hindsight extends it with
     // claude-agent-sdk + the claude CLI for the claude-code provider.
     expect(snippet).not.toContain("ghcr.io/vectorize-io/hindsight:latest");


### PR DESCRIPTION
## Summary
- Changes all switchroom container `restart: unless-stopped` to `restart: always` across compose generator and all service definitions (hostd, webd, hindsight ×2)

## Why
`unless-stopped` does NOT restart containers that were in a stopped/crashed state when the Docker daemon stopped (e.g. a system reboot). If a broker crashes *before* the host is rebooted, Docker records it as "not running at shutdown time" and `unless-stopped` never brings it back up.

Incident: auth-broker and vault-broker crashed during an `/auth add` flow, PC was rebooted, both stayed down after reboot. All agent containers were also in exited state and came back, confirming this is a systemic policy issue.

`always` restarts every switchroom container unconditionally when the Docker daemon starts — which is the correct behaviour for a 24/7 always-on fleet.

## Test plan
- [x] `tests/docker/compose-generator.test.ts` passes (176 tests)
- [x] `unless-stopped` has no remaining occurrences in the 5 changed files
- [x] Running containers already updated live via `docker update --restart=always` as an immediate fix

## Risk
Low — this is a more aggressive restart policy. The only downside is containers will restart after a `docker stop`, but switchroom containers are never manually stopped in normal operation; lifecycle is managed via `switchroom agent restart` / `apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01FyWpHaQHJn3A2yJpbiPGob