### PR TITLE
fix(gateway): suppress boot-resume on clean shutdown

### DIFF
--- a/telegram-plugin/gateway/clean-shutdown-marker.ts
+++ b/telegram-plugin/gateway/clean-shutdown-marker.ts
@@ -181,3 +181,47 @@ export function resolveShutdownMarker(
   }
   return { ts: now, signal, reason: EXTERNAL_RESTART_FALLBACK_REASON };
 }
+
+/**
+ * Pure decision: should the boot-resume path SUPPRESS the active
+ * resume_interrupted inbound because the prior shutdown was clean?
+ *
+ * A clean marker present and fresh (<= maxAgeMs, default 60s) means the
+ * prior shutdown was operator/roll/CLI-initiated — NOT a crash. In that
+ * case auto-resuming interrupted work is wasteful: the agent was asked to
+ * stop, it stopped cleanly, and the "interrupted" turn was implicitly
+ * abandoned by that decision. Burning a full model turn to replay it on
+ * every operator restart wastes subscription quota for no user benefit.
+ *
+ * Returns true ONLY when:
+ *   - a clean marker is present, AND
+ *   - the marker is younger than maxAgeMs (default 60s), AND
+ *   - the SWITCHROOM_BOOT_RESUME_ALWAYS escape hatch is not set.
+ *
+ * Returns false when:
+ *   - no marker (crash / OOM / unexpected kill — resume normally), OR
+ *   - marker is stale (>= maxAgeMs — something stalled; treat as crash), OR
+ *   - forceAlways is true (the escape hatch is active).
+ *
+ * The forceAlways parameter maps to the env var
+ * SWITCHROOM_BOOT_RESUME_ALWAYS=1, which restores the pre-gate behaviour
+ * unconditionally. Pass it in as a parsed boolean so this function stays
+ * pure and testable without touching process.env.
+ *
+ * Keeping this pure makes the decision unit-testable in bun test without
+ * spinning up the gateway.
+ */
+export function shouldSuppressBootResume(
+  marker: CleanShutdownMarker | null,
+  now: number,
+  { maxAgeMs = DEFAULT_MAX_AGE_MS, forceAlways = false }: {
+    maxAgeMs?: number;
+    forceAlways?: boolean;
+  } = {},
+): boolean {
+  if (forceAlways) return false;
+  if (marker === null) return false;
+  const age = now - marker.ts;
+  if (age < 0) return false; // clock skew defence — treat as stale
+  return age < maxAgeMs;
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -428,6 +428,7 @@ import {
   // preceding shutdown only" semantics.
   clearCleanShutdownMarker,
   shouldSuppressRecoveryBanner,
+  shouldSuppressBootResume,
   resolveShutdownMarker,
   DEFAULT_MAX_AGE_MS as CLEAN_SHUTDOWN_MAX_AGE_MS,
 } from './clean-shutdown-marker.js'
@@ -1146,43 +1147,70 @@ try {
   const pending = findLatestTurnIfInterrupted(turnsDb)
   const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? ''
   if (pending != null && selfAgent) {
-    // 3h staleness failsafe (operator spec, 2026-06-03): never AUTO-resume
-    // interrupted work older than RESUME_MAX_AGE_MS — selectResumeBuilder
-    // downgrades a stale 'resume' to the passive 'report' so the user is told
-    // ("I was working on X ~Nh ago") but nothing replays unprompted. Env
-    // override SWITCHROOM_RESUME_MAX_AGE_MS (ms); set very high to disable.
-    const RESUME_MAX_AGE_MS = (() => {
-      const v = Number(process.env.SWITCHROOM_RESUME_MAX_AGE_MS)
-      return Number.isFinite(v) && v > 0 ? v : 10_800_000 // 3h
-    })()
-    const kind = selectResumeBuilder(pending.ended_via, {
-      ageMs: Math.max(0, Date.now() - pending.started_at),
-      maxAgeMs: RESUME_MAX_AGE_MS,
+    // Clean-shutdown gate: suppress auto-resume when the prior shutdown was
+    // operator/roll/CLI-initiated (clean). A clean-shutdown marker present and
+    // fresh means the agent was asked to stop; the "interrupted" turn was
+    // abandoned by that decision. Replaying it on every planned restart wastes
+    // subscription quota for no user benefit. Only unclean exits (crash/OOM/
+    // unexpected kill) should auto-resume.
+    //
+    // NOTE: GATEWAY_CLEAN_SHUTDOWN_MARKER_PATH is defined lower in this file
+    // (module-init order); we compute the path inline here using the same
+    // formula so we can read it at boot-resume time.
+    // SWITCHROOM_BOOT_RESUME_ALWAYS=1 is an escape hatch that restores
+    // unconditional resume if needed.
+    const bootResumeMarkerPath =
+      process.env.SWITCHROOM_GATEWAY_CLEAN_SHUTDOWN_MARKER ?? join(STATE_DIR, 'clean-shutdown.json')
+    const bootResumeCleanMarker = readCleanShutdownMarker(bootResumeMarkerPath)
+    const bootResumeForceAlways = process.env.SWITCHROOM_BOOT_RESUME_ALWAYS === '1'
+    const bootResumeSuppressed = shouldSuppressBootResume(bootResumeCleanMarker, Date.now(), {
+      forceAlways: bootResumeForceAlways,
     })
-    if (kind === 'resume') {
-      bootResumeInbound = { agent: selfAgent, msg: buildResumeInterruptedInbound({ turn: pending }) }
-    } else if (kind === 'report') {
-      // idleMs: this boot's measured marker age if it just classified this
-      // turn; otherwise recover it from the persisted interrupt_reason (a
-      // later boot, marker already swept); else fall back to total runtime.
-      let idleMs = pending.turn_key === timeoutTurnKey && markerAgeMs != null ? markerAgeMs : null
-      if (idleMs == null && pending.interrupt_reason) {
-        try {
-          const parsed = JSON.parse(pending.interrupt_reason) as { idleMs?: unknown }
-          if (typeof parsed.idleMs === 'number' && Number.isFinite(parsed.idleMs)) idleMs = parsed.idleMs
-        } catch { /* malformed snapshot — fall through */ }
-      }
-      if (idleMs == null) idleMs = Math.max(0, Date.now() - pending.started_at)
-      bootResumeInbound = {
-        agent: selfAgent,
-        msg: buildResumeWatchdogReportInbound({ turn: pending, idleMs }),
-      }
-    }
-    if (bootResumeInbound != null) {
+    if (bootResumeSuppressed) {
       process.stderr.write(
-        `telegram gateway: boot-resume queued kind=${kind} turnKey=${pending.turn_key} ` +
-        `endedVia=${pending.ended_via ?? 'open'} chat=${pending.chat_id}\n`,
+        `telegram gateway: boot-resume suppressed (clean shutdown` +
+        `${bootResumeCleanMarker?.reason ? ` reason=${JSON.stringify(bootResumeCleanMarker.reason)}` : ''}` +
+        `) — unclean exits still resume turnKey=${pending.turn_key}\n`,
       )
+    } else {
+      // 3h staleness failsafe (operator spec, 2026-06-03): never AUTO-resume
+      // interrupted work older than RESUME_MAX_AGE_MS — selectResumeBuilder
+      // downgrades a stale 'resume' to the passive 'report' so the user is told
+      // ("I was working on X ~Nh ago") but nothing replays unprompted. Env
+      // override SWITCHROOM_RESUME_MAX_AGE_MS (ms); set very high to disable.
+      const RESUME_MAX_AGE_MS = (() => {
+        const v = Number(process.env.SWITCHROOM_RESUME_MAX_AGE_MS)
+        return Number.isFinite(v) && v > 0 ? v : 10_800_000 // 3h
+      })()
+      const kind = selectResumeBuilder(pending.ended_via, {
+        ageMs: Math.max(0, Date.now() - pending.started_at),
+        maxAgeMs: RESUME_MAX_AGE_MS,
+      })
+      if (kind === 'resume') {
+        bootResumeInbound = { agent: selfAgent, msg: buildResumeInterruptedInbound({ turn: pending }) }
+      } else if (kind === 'report') {
+        // idleMs: this boot's measured marker age if it just classified this
+        // turn; otherwise recover it from the persisted interrupt_reason (a
+        // later boot, marker already swept); else fall back to total runtime.
+        let idleMs = pending.turn_key === timeoutTurnKey && markerAgeMs != null ? markerAgeMs : null
+        if (idleMs == null && pending.interrupt_reason) {
+          try {
+            const parsed = JSON.parse(pending.interrupt_reason) as { idleMs?: unknown }
+            if (typeof parsed.idleMs === 'number' && Number.isFinite(parsed.idleMs)) idleMs = parsed.idleMs
+          } catch { /* malformed snapshot — fall through */ }
+        }
+        if (idleMs == null) idleMs = Math.max(0, Date.now() - pending.started_at)
+        bootResumeInbound = {
+          agent: selfAgent,
+          msg: buildResumeWatchdogReportInbound({ turn: pending, idleMs }),
+        }
+      }
+      if (bootResumeInbound != null) {
+        process.stderr.write(
+          `telegram gateway: boot-resume queued kind=${kind} turnKey=${pending.turn_key} ` +
+          `endedVia=${pending.ended_via ?? 'open'} chat=${pending.chat_id}\n`,
+        )
+      }
     }
   }
 

--- a/telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts
+++ b/telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts
@@ -35,6 +35,7 @@ import {
   readCleanShutdownMarker,
   clearCleanShutdownMarker,
   shouldSuppressRecoveryBanner,
+  shouldSuppressBootResume,
   resolveShutdownMarker,
   DEFAULT_MAX_AGE_MS,
   EXTERNAL_RESTART_FALLBACK_REASON,
@@ -341,6 +342,122 @@ describe("resolveShutdownMarker (SIGTERM-handler sequencing)", () => {
     // Load-bearing constant — if the two windows drift out of sync, the
     // CLI-stamps-then-SIGTERM race gets harder to reason about. Pin it.
     expect(REASON_PRESERVE_MAX_AGE_MS).toBe(30_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Boot-resume gate: shouldSuppressBootResume
+// ---------------------------------------------------------------------------
+
+describe("shouldSuppressBootResume", () => {
+  // Core contract: clean shutdown (fresh marker) → suppress; crash (no marker
+  // or stale) → do not suppress; forceAlways override → never suppress.
+
+  it("returns false when no marker is present (crash/OOM — resume as before)", () => {
+    expect(shouldSuppressBootResume(null, Date.now())).toBe(false);
+  });
+
+  it("returns true for a fresh clean-shutdown marker (operator/roll restart — suppress)", () => {
+    const now = 1_700_000_000_000;
+    const marker: CleanShutdownMarker = { ts: now - 5_000, signal: "SIGTERM" };
+    expect(shouldSuppressBootResume(marker, now)).toBe(true);
+  });
+
+  it("returns true at age=0 (marker written right before boot)", () => {
+    const now = 1_700_000_000_000;
+    const marker: CleanShutdownMarker = { ts: now, signal: "SIGTERM" };
+    expect(shouldSuppressBootResume(marker, now)).toBe(true);
+  });
+
+  it("returns false when marker age equals maxAgeMs (boundary is exclusive)", () => {
+    const now = 1_700_000_000_000;
+    const marker: CleanShutdownMarker = { ts: now - DEFAULT_MAX_AGE_MS, signal: "SIGTERM" };
+    expect(shouldSuppressBootResume(marker, now)).toBe(false);
+  });
+
+  it("returns false for a stale marker (drain took >60s — treat as crash)", () => {
+    const now = 1_700_000_000_000;
+    const marker: CleanShutdownMarker = { ts: now - 90_000, signal: "SIGTERM" };
+    expect(shouldSuppressBootResume(marker, now)).toBe(false);
+  });
+
+  it("treats clock skew (future ts) as stale to avoid false suppression", () => {
+    const now = 1_700_000_000_000;
+    const marker: CleanShutdownMarker = { ts: now + 10_000, signal: "SIGTERM" };
+    expect(shouldSuppressBootResume(marker, now)).toBe(false);
+  });
+
+  it("respects a custom maxAgeMs", () => {
+    const now = 1_700_000_000_000;
+    const marker: CleanShutdownMarker = { ts: now - 30_000, signal: "SIGTERM" };
+    expect(shouldSuppressBootResume(marker, now, { maxAgeMs: 60_000 })).toBe(true);
+    expect(shouldSuppressBootResume(marker, now, { maxAgeMs: 10_000 })).toBe(false);
+  });
+
+  it("forceAlways=true disables suppression even for a fresh clean marker (escape hatch)", () => {
+    // SWITCHROOM_BOOT_RESUME_ALWAYS=1 must restore unconditional resume.
+    const now = 1_700_000_000_000;
+    const marker: CleanShutdownMarker = { ts: now - 1_000, signal: "SIGTERM" };
+    expect(shouldSuppressBootResume(marker, now, { forceAlways: true })).toBe(false);
+  });
+
+  it("forceAlways=false has no effect (default behaviour is the gate)", () => {
+    const now = 1_700_000_000_000;
+    const marker: CleanShutdownMarker = { ts: now - 1_000, signal: "SIGTERM" };
+    expect(shouldSuppressBootResume(marker, now, { forceAlways: false })).toBe(true);
+  });
+
+  it("works for SIGTERM and SIGINT (signal value is opaque)", () => {
+    const now = 1_700_000_000_000;
+    expect(shouldSuppressBootResume({ ts: now, signal: "SIGTERM" }, now)).toBe(true);
+    expect(shouldSuppressBootResume({ ts: now, signal: "SIGINT" }, now)).toBe(true);
+  });
+
+  it("works with a marker that carries a reason field (rollout attribution is preserved)", () => {
+    const now = 1_700_000_000_000;
+    const marker: CleanShutdownMarker = {
+      ts: now - 2_000,
+      signal: "SIGTERM",
+      reason: "operator: switchroom update",
+    };
+    expect(shouldSuppressBootResume(marker, now)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Boot-resume gate: gateway wiring (source-level)
+// ---------------------------------------------------------------------------
+
+describe("gateway.ts boot-resume clean-shutdown gate (source-level)", () => {
+  // Source-grep pins ensure the gate wiring in gateway.ts stays present
+  // after refactors. Pure unit tests on shouldSuppressBootResume cover the
+  // decision logic; these cover the wiring.
+  const gatewaySource = readFileSync(
+    join(import.meta.dir, "..", "gateway", "gateway.ts"),
+    "utf8",
+  );
+
+  it("imports shouldSuppressBootResume from clean-shutdown-marker", () => {
+    expect(gatewaySource).toContain("shouldSuppressBootResume");
+  });
+
+  it("reads the clean-shutdown marker before building the boot-resume inbound", () => {
+    expect(gatewaySource).toContain("bootResumeCleanMarker");
+    expect(gatewaySource).toContain("readCleanShutdownMarker(bootResumeMarkerPath)");
+  });
+
+  it("calls shouldSuppressBootResume with the marker, now, and forceAlways", () => {
+    expect(gatewaySource).toContain("shouldSuppressBootResume(bootResumeCleanMarker, Date.now()");
+    expect(gatewaySource).toContain("forceAlways: bootResumeForceAlways");
+  });
+
+  it("provides the SWITCHROOM_BOOT_RESUME_ALWAYS escape hatch", () => {
+    expect(gatewaySource).toContain("SWITCHROOM_BOOT_RESUME_ALWAYS");
+    expect(gatewaySource).toContain("=== '1'");
+  });
+
+  it("logs a diagnostic when boot-resume is suppressed", () => {
+    expect(gatewaySource).toContain("boot-resume suppressed (clean shutdown");
   });
 });
 


### PR DESCRIPTION
## Summary

- **Problem:** On every agent boot, the gateway queues a `resume_interrupted` inbound that re-runs the last interrupted turn — even after clean operator restarts, fleet rolls, or `switchroom update`. The agent was asked to stop, stopped cleanly, and the \"interrupted\" turn was implicitly abandoned by that decision. Replaying it on every planned restart wastes subscription quota for no user benefit.
- **Fix:** Gate the boot-resume block on the clean-shutdown marker. When `clean-shutdown.json` is fresh (<60s, written by the SIGTERM/SIGINT handler), skip queueing the `resume_interrupted` inbound. Unclean exits (crash / OOM / unexpected kill) leave no marker and continue to auto-resume exactly as before.
- **Escape hatch:** `SWITCHROOM_BOOT_RESUME_ALWAYS=1` restores unconditional resume if needed.

## Why

Serves the **subscription-honest** vision outcome (`reference/jobs/keep-my-subscription-honest.md`): the plan is the ceiling; don't spend a full model turn re-running work the operator deliberately stopped.

Preserves the **always-on** invariant via `reference/jobs/survive-reboots-and-real-life.md`: crash recovery is untouched — only the clean-shutdown path is gated. The absence of a clean-shutdown marker is precisely the signal for \"this was not planned\".

## Changes

**`telegram-plugin/gateway/clean-shutdown-marker.ts`**
- Added `shouldSuppressBootResume(marker, now, { maxAgeMs, forceAlways })` — a pure function with the same shape as the existing `shouldSuppressRecoveryBanner`. Returns `true` only when a fresh clean-shutdown marker is present and `forceAlways` is not set.

**`telegram-plugin/gateway/gateway.ts`**
- In the boot-resume block (~line 1144): reads the clean-shutdown marker inline using `STATE_DIR` (in scope; `GATEWAY_CLEAN_SHUTDOWN_MARKER_PATH` is defined later in module-init order so cannot be referenced). Calls `shouldSuppressBootResume`; if suppressed, logs `boot-resume suppressed (clean shutdown reason=...)` and skips queueing the inbound. The existing 3h-staleness failsafe and `report`-kind behaviour are unchanged for unclean exits.
- Added `shouldSuppressBootResume` to the import from `clean-shutdown-marker.js`.

**`telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts`**
- 11 new bun tests: `shouldSuppressBootResume` pure logic (fresh/stale/no-marker/clock-skew/forceAlways) + source-grep pins on gateway wiring (imports, reads, calls, escape hatch, log line).

## Wake-audit sentinel

The `.wake-audit-pending` sentinel is written unconditionally in the generated `start.sh` shell script — before the gateway even starts. Gating it on the clean-shutdown marker would require modifying `profiles/_base/start.sh.hbs` and re-scaffolding all agents, which is fragile and out of scope for this PR. The 90% token win is the `resume_interrupted` inbound suppression; the wake-audit is a follow-up.

## Test plan

- [x] `npm run lint` — clean (tsc --noEmit exit 0)
- [x] `npm run test:bun` — 1036 pass, 2 skip, 2 pre-existing fail (vault broker token-rejection tests unrelated to this change)
- [x] `bun test telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts` — 48 pass, 0 fail (includes 11 new tests for `shouldSuppressBootResume`)
- [x] `npm run build` — clean
- [x] `bash scripts/check-bot-api-wrapping.sh` — clean

## Risk

Low. The gate only fires when a fresh clean-shutdown marker is on disk — a file that is already written on every clean SIGTERM/SIGINT today. Unclean exits (crash/OOM/SIGKILL/unexpected kill) do not write the marker, so crash-recovery auto-resume is fully preserved. The `SWITCHROOM_BOOT_RESUME_ALWAYS=1` env escape hatch restores old behaviour in any production incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)