### PR TITLE
fix(telegram): surface post-answer background sub-agent activity (restore #2547 visibility under determinism gate)

### DIFF
--- a/telegram-plugin/gateway/feed-open-gate.ts
+++ b/telegram-plugin/gateway/feed-open-gate.ts
@@ -104,6 +104,14 @@ export interface FeedOpenInput {
    *  below the earlier reply). A normal foreground turn passes `false` (or omits
    *  it), so lever 4 is inert there. Defaults to `false`. */
   crossTurnAnswerDelivered?: boolean
+  /** Post-answer real activity exception (restore #2547 visibility under
+   *  determinism gate). When true AND `producer === 'tool'`, lever 1's blanket
+   *  OPEN-block is lifted: genuine new sub-agent/tool activity detected AFTER
+   *  the answer (via `lastToolLabelAt > finalAnswerDeliveredAt`) is allowed to
+   *  OPEN a card below the prior reply. Idle thinking-gaps (no new
+   *  `lastToolLabelAt` advance) never set this, so the suppression of
+   *  idle-liveness-after-final is preserved. Defaults to `false`. */
+  postAnswerRealActivity?: boolean
 }
 
 /**
@@ -116,6 +124,11 @@ export interface FeedOpenInput {
  *    no card may open below it (any producer). Checked FIRST.
  *  - finalAnswerEverDelivered → false: lever 1. A substantive final already
  *    landed THIS turn; no card may open below it (any producer).
+ *    EXCEPTION: when `postAnswerRealActivity` is true AND `producer === 'tool'`,
+ *    lever 1 is lifted — genuine new sub-agent/tool work detected after the
+ *    answer is allowed to OPEN a card below the prior reply (restores #2547
+ *    visibility). Idle liveness (`producer !== 'tool'` or no `lastToolLabelAt`
+ *    advance) still cannot open after a final — idle-gap suppression preserved.
  *  - producer 'narrative' && labeledToolCount === 0 → false: lever 5 base case.
  *    Narration alone on a 0-tool turn may not open a card (the triplication).
  *  - producer 'tool' → true (unless lever 1/4): a real tool dispatched → open.
@@ -129,7 +142,15 @@ export function mayOpenActivityCard(input: FeedOpenInput): boolean {
   // synthetic surfaces by the caller so it can never fire on a foreground turn.
   if (input.crossTurnAnswerDelivered) return false
   // Lever 1 — sticky: nothing opens after a substantive final answer.
-  if (input.finalAnswerEverDelivered) return false
+  // EXCEPTION: genuine post-answer real tool activity (sub-agent/background
+  // work that actually dispatched a new tool AFTER the answer) may open a card
+  // below the reply — restoring #2547 visibility under the #2564 gate. The
+  // caller sets `postAnswerRealActivity` only when `lastToolLabelAt` has
+  // advanced past `finalAnswerDeliveredAt`, so idle thinking-gaps after the
+  // answer continue to be suppressed (idle-gap suppression preserved).
+  if (input.finalAnswerEverDelivered) {
+    if (!(input.postAnswerRealActivity === true && input.producer === 'tool')) return false
+  }
   // Lever 5 base case — narrative SHOW alone on a 0-tool turn may not OPEN.
   if (input.producer === 'narrative' && input.labeledToolCount === 0) return false
   return true

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2021,6 +2021,14 @@ type CurrentTurn = {
   // false ONLY at turn start, mirroring `activityEverOpened`'s sticky-true
   // contract.
   finalAnswerEverDelivered: boolean
+  // Wall-clock ms at which the sticky `finalAnswerEverDelivered` latch was
+  // set (i.e. when the substantive final answer was delivered). Used by the
+  // post-answer liveness branch of `feedHeartbeatTick` to detect GENUINE
+  // new sub-agent/tool activity after the answer: if `lastToolLabelAt` has
+  // advanced past this timestamp, real new work occurred post-answer and a
+  // liveness card should surface. null until `finalAnswerEverDelivered` is
+  // first set; never cleared (mirrors the sticky-latch semantics).
+  finalAnswerDeliveredAt: number | null
   // #1675 (over-ping safety net): wall-clock ms of the first reply
   // this turn that landed with `disable_notification: false` (a real
   // device ping). The conversational-pacing contract
@@ -8341,6 +8349,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
       const ea = emissionAuthorityFor(finalizeTurn)
       ea.markSubstantiveFinalDelivered(() => {
         finalizeTurn.finalAnswerEverDelivered = true
+        finalizeTurn.finalAnswerDeliveredAt ??= Date.now()
       })
       ea.finalizeCard(() => {
         clearActivitySummary(finalizeTurn)
@@ -8468,6 +8477,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
             // Sticky ordering latch (lever 1): a substantive final closes the
             // card OPEN gate for the rest of the turn. NEVER cleared by reopen.
             if (turn.finalAnswerSubstantive) turn.finalAnswerEverDelivered = true
+            if (turn.finalAnswerSubstantive) turn.finalAnswerDeliveredAt ??= Date.now()
             if (turn.finalAnswerSubstantive) closeObligationOnSubstantiveReply(args, turn, replyRoutedOriginTurn)
           }
           outboundDedup.record(
@@ -8816,6 +8826,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
       // never cleared by reopen. The card OPEN gate keys on this, not the
       // mutable finalAnswerDelivered above (which reopen toggles).
       if (turn.finalAnswerSubstantive) turn.finalAnswerEverDelivered = true
+      if (turn.finalAnswerSubstantive) turn.finalAnswerDeliveredAt ??= Date.now()
       // #1728: release the buffer gate + emit terminal 👍. Mid-turn
       // acks bypass this branch and remain non-events for the
       // reaction (preserves #1713). The full turn-state teardown
@@ -9068,6 +9079,7 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
     const ea = emissionAuthorityFor(turn)
     ea.markSubstantiveFinalDelivered(() => {
       turn.finalAnswerEverDelivered = true
+      turn.finalAnswerDeliveredAt ??= Date.now()
     })
     ea.finalizeCard(() => {
       clearActivitySummary(turn)
@@ -9231,6 +9243,7 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
     // Sticky ordering latch (lever 1): set once a SUBSTANTIVE final lands;
     // never cleared by reopen. The card OPEN gate keys on this sticky latch.
     if (turn.finalAnswerSubstantive) turn.finalAnswerEverDelivered = true
+    if (turn.finalAnswerSubstantive) turn.finalAnswerDeliveredAt ??= Date.now()
     if (turn.finalAnswerSubstantive) closeObligationOnSubstantiveReply(args, turn, streamRoutedOriginTurn)
     // #1744 follow-up — stream_reply edge case. The first-emit gate at
     // L5178 only clears silent-end state on the FIRST emit of a stream.
@@ -10786,6 +10799,8 @@ async function drainActivitySummary(
   // gate is unaffected. Narrative-SHOW and liveness callers pass their producer
   // explicitly.
   producer: FeedOpenProducer = 'tool',
+  // Additional OPEN-gate options for callers with exceptional context.
+  opts: { postAnswerRealActivity?: boolean } = {},
 ): Promise<void> {
   try {
     while (turn.activityPendingRender !== turn.activityLastSentRender) {
@@ -10833,6 +10848,7 @@ async function drainActivitySummary(
           finalAnswerEverDelivered: turn.finalAnswerEverDelivered,
           labeledToolCount: turn.labeledToolCount,
           crossTurnAnswerDelivered,
+          postAnswerRealActivity: opts.postAnswerRealActivity,
         })
       ) {
         break
@@ -10911,23 +10927,47 @@ function feedHeartbeatTick(): void {
   const turn = currentTurn
   if (turn == null) return
   if (turn.finalAnswerDelivered) {
-    // PR1 Item-3a (DORMANT — DEAD by default). Post-answer work is silent today:
-    // once the answer landed the feed has handed off and we return here. When a
-    // future Item-3 decision opts an agent into a "still tidying…" post-answer
-    // liveness line, `SWITCHROOM_POST_ANSWER_LIVENESS_MS>0` is the escape hatch —
-    // it would, past that threshold of post-answer silence, fall through to emit
-    // a guarded liveness EDIT/line here instead of returning. UNSET/0 ⇒ this
-    // branch is never taken and behaviour is byte-identical to today. The actual
-    // surface is intentionally NOT built (no card OPEN, no message) — this is
-    // only the plumbing so enabling it later needs no redesign.
-    if (POST_ANSWER_LIVENESS_MS <= 0) return // default: silent post-answer (today)
-    // `lastToolLabelAt` (set each time a tool step renders) is the closest
-    // existing anchor for "how long has post-answer work been running"; absent
-    // any post-answer tool it stays at the pre-answer value, so the threshold is
-    // only crossed by genuine ongoing work. The Item-3 surface lands here once
-    // decided; until then we stay silent even when the flag is set.
-    const since = turn.lastToolLabelAt != null ? Date.now() - turn.lastToolLabelAt : 0
-    if (since < POST_ANSWER_LIVENESS_MS) return // not yet past the threshold
+    // Post-answer liveness: surface a card below the reply when genuine new
+    // sub-agent/tool activity is detected AFTER the substantive final answer
+    // (restores #2547 visibility under the #2564 determinism gate). "Genuine"
+    // means `lastToolLabelAt` has advanced past `finalAnswerDeliveredAt` —
+    // deterministic state-delta signal, NOT wall-clock age alone. Idle thinking-
+    // gaps after the answer continue to be suppressed (idle-gap invariant).
+    if (POST_ANSWER_LIVENESS_MS <= 0) return // operator opt-out (=0): silent post-answer
+    if (turn.sessionChatId == null) return
+    if (turn.finalAnswerDeliveredAt == null) return
+    if (turn.lastToolLabelAt == null) return
+    // Only surface when a tool label has rendered AFTER the answer (genuine new
+    // post-answer work). If `lastToolLabelAt` is still at or before the answer
+    // timestamp, no real work occurred post-answer — skip (idle suppression).
+    if (turn.lastToolLabelAt <= turn.finalAnswerDeliveredAt) return
+    // Require the post-answer label to have been stale for at least
+    // POST_ANSWER_LIVENESS_MS (same role as FEED_HEARTBEAT_MIN_STALE_MS for the
+    // labelled-feed heartbeat): a tool that just fired should not immediately
+    // open a card; we wait until the step has been running long enough to
+    // be worth surfacing.
+    const postAnswerElapsed = Date.now() - turn.lastToolLabelAt
+    if (postAnswerElapsed < POST_ANSWER_LIVENESS_MS) return
+    // Genuine post-answer real activity confirmed. Open or maintain a card with
+    // the current tool feed. Route as producer 'tool' so Lever 1's blanket
+    // post-final block is lifted by the postAnswerRealActivity exception.
+    const rendered = composeTurnActivity(turn, false, ` · ${formatFeedElapsed(postAnswerElapsed)}`)
+    if (rendered == null) return
+    turn.activityPendingRender = rendered
+    const ea = emissionAuthorityFor(turn)
+    // PR-4d: route through the centralized chatLock-serialized card-drain gate.
+    cardDrainGate(turn, ea, () => {
+    if (ea.mayDrain(turn)) {
+      // Producer 'tool': genuine post-answer sub-agent/tool work. The
+      // postAnswerRealActivity flag allows Lever 1 to be bypassed in the
+      // drain's feed-open-gate check so the card can OPEN below the reply.
+      // An EDIT of an already-open card (activityMessageId != null) is
+      // always allowed — this only matters for the OPEN case.
+      ea.openOrEditCard('tool', () => {
+        turn.activityInFlight = drainActivitySummary(turn, 'tool', { postAnswerRealActivity: true })
+      })
+    }
+    })
     return
   }
 
@@ -11152,6 +11192,8 @@ function handleSessionEvent(ev: SessionEvent): void {
           finalAnswerSubstantive: false,
           // Sticky latch — reset ONLY here (turn start), never by reopen.
           finalAnswerEverDelivered: false,
+          // Set alongside finalAnswerEverDelivered; null until latch fires.
+          finalAnswerDeliveredAt: null,
           firstPingAt: null,
           // Notification ownership (R8 / PR-2): no slot claimed yet, so the
           // "claimer was substantive" flag starts false. Set atomically with

--- a/telegram-plugin/tests/emission-authority-facade.test.ts
+++ b/telegram-plugin/tests/emission-authority-facade.test.ts
@@ -350,8 +350,9 @@ describe('the 6 drain sites route through the façade with producers preserved v
 
   it('every routed drain site guards the single-flight via ea.mayDrain(turn), not a bare activityInFlight read', () => {
     const mayDrainGuards = [...gatewaySrc.matchAll(/if \(ea\.mayDrain\(turn\)\)/g)]
-    // narrative + 2 liveness + tool + 2 sub-agent = 6 routed single-flight gates.
-    expect(mayDrainGuards).toHaveLength(6)
+    // narrative + 2 liveness + tool + 2 sub-agent + 1 post-answer = 7 routed
+    // single-flight gates. (Post-answer branch added by fix #2547/#2564 restore.)
+    expect(mayDrainGuards).toHaveLength(7)
   })
 })
 
@@ -478,10 +479,11 @@ describe('mayDrainCardNow — PR-4d card-drain gate (pure read; gateway holds th
     expect(ctxFn).toMatch(/turnInFlight:\s*turnInFlightForGate\(\)/)
   })
 
-  it('the 6 card-drain sites each route their guarded block through cardDrainGate (single-flight gate stays byte-identical)', () => {
-    // Option A: the 6 `if (ea.mayDrain(turn))` guards + drainActivitySummary
+  it('the 7 card-drain sites each route their guarded block through cardDrainGate (single-flight gate stays byte-identical)', () => {
+    // Option A: the 7 `if (ea.mayDrain(turn))` guards + drainActivitySummary
     // thunks stay byte-identical, wrapped by the centralized helper.
+    // (Post-answer branch added by fix restoring #2547/#2564 visibility.)
     const wraps = [...gatewaySrc.matchAll(/cardDrainGate\(turn, ea, \(\) => \{/g)]
-    expect(wraps).toHaveLength(6)
+    expect(wraps).toHaveLength(7)
   })
 })

--- a/telegram-plugin/tests/emission-determinism-wiring.test.ts
+++ b/telegram-plugin/tests/emission-determinism-wiring.test.ts
@@ -155,7 +155,9 @@ describe('lever 2 — finalize the card BEFORE a substantive reply send', () => 
     expect(clearIdx).toBeGreaterThan(-1)
     expect(sendIdx).toBeGreaterThan(-1)
     expect(clearIdx).toBeLessThan(sendIdx)
-    const window = src.slice(Math.max(0, clearIdx - 500), clearIdx)
+    // Use 700-char window (extended from 500 to accommodate the
+    // `finalAnswerDeliveredAt` stamp added alongside finalAnswerEverDelivered).
+    const window = src.slice(Math.max(0, clearIdx - 700), clearIdx)
     expect(window).toMatch(/isSubstantiveFinalReply/)
   })
 

--- a/telegram-plugin/tests/feed-heartbeat-liveness-open.test.ts
+++ b/telegram-plugin/tests/feed-heartbeat-liveness-open.test.ts
@@ -1,8 +1,9 @@
 /**
  * H-1: feedHeartbeatTick liveness-open threshold — structural assertions.
  *
- * Pins three load-bearing constraints of the "liveness-open" branch inside
- * `feedHeartbeatTick` (gateway.ts):
+ * Pins the load-bearing constraints of the "liveness-open" branch AND the
+ * restored post-answer background-activity branch inside `feedHeartbeatTick`
+ * (gateway.ts):
  *
  *   1. The SWITCHROOM_FEED_LIVENESS_OPEN kill-switch (default ON, i.e. `!== '0'`)
  *      gates the liveness-open path — operators can disable it with =0.
@@ -10,6 +11,11 @@
  *   3. The `age < FEED_LIVENESS_OPEN_MS` return-guard fires BEFORE the feed opens —
  *      a turn that hasn't yet passed the threshold returns early and the liveness
  *      feed stays closed.
+ *   4. The post-answer branch gates on `lastToolLabelAt > finalAnswerDeliveredAt`
+ *      (deterministic real-activity signal) before opening a card.
+ *   5. The post-answer branch routes as producer 'tool' with postAnswerRealActivity
+ *      so Lever 1's blanket block is correctly lifted only for real tool work.
+ *   6. Idle post-answer liveness (no new tool label since answer) remains suppressed.
  *
  * These are STRUCTURAL (source-read) assertions; the gateway IIFE can't be
  * instantiated in-process.  Pattern matches silence-liveness-wiring.test.ts.
@@ -52,21 +58,56 @@ describe('H-1: feedHeartbeatTick liveness-open threshold', () => {
     expect(body).toMatch(/if\s*\(age\s*<\s*FEED_LIVENESS_OPEN_MS\)\s*return/)
   })
 
-  it('FEED_LIVENESS_OPEN_ENABLED check precedes the drainActivitySummary call in feedHeartbeatTick', () => {
+  it('FEED_LIVENESS_OPEN_ENABLED check precedes the liveness-open drainActivitySummary call in feedHeartbeatTick', () => {
     const body = feedHeartbeatTickSrc()
     const enabledIdx = body.indexOf('FEED_LIVENESS_OPEN_ENABLED')
-    // Use the actual call site (assignment to activityInFlight) not the comment mention.
-    const drainCallIdx = body.indexOf('turn.activityInFlight = drainActivitySummary')
+    // Use the LIVENESS-specific call site (producer 'liveness', mirrorLines path),
+    // not a generic indexOf which now finds the post-answer drain call first.
+    const drainCallIdx = body.indexOf("drainActivitySummary(turn, 'liveness')")
     expect(enabledIdx).toBeGreaterThan(-1)
     expect(drainCallIdx).toBeGreaterThan(enabledIdx)
   })
 
-  it('age < FEED_LIVENESS_OPEN_MS guard precedes the drainActivitySummary call (early-return before open)', () => {
+  it('age < FEED_LIVENESS_OPEN_MS guard precedes the liveness-open drainActivitySummary call (early-return before open)', () => {
     const body = feedHeartbeatTickSrc()
     const guardIdx = body.indexOf('age < FEED_LIVENESS_OPEN_MS')
-    // Use the actual call site (assignment to activityInFlight) not the comment mention.
-    const drainCallIdx = body.indexOf('turn.activityInFlight = drainActivitySummary')
+    // Use the LIVENESS-specific call site (producer 'liveness', mirrorLines path),
+    // not a generic indexOf which now finds the post-answer drain call first.
+    const drainCallIdx = body.indexOf("drainActivitySummary(turn, 'liveness')")
     expect(guardIdx).toBeGreaterThan(-1)
     expect(drainCallIdx).toBeGreaterThan(guardIdx)
+  })
+})
+
+describe('H-2: feedHeartbeatTick post-answer real-activity branch (restore #2547 visibility)', () => {
+  it('post-answer branch guards on lastToolLabelAt > finalAnswerDeliveredAt (deterministic state delta, not wall-clock)', () => {
+    // The branch must use `lastToolLabelAt <= finalAnswerDeliveredAt` (or <=) as
+    // the idle-suppression guard — idle thinking-gaps after the answer are
+    // suppressed by checking that no new tool label has rendered since the answer.
+    const body = feedHeartbeatTickSrc()
+    expect(body).toMatch(/turn\.lastToolLabelAt\s*<=\s*turn\.finalAnswerDeliveredAt/)
+  })
+
+  it('post-answer drain routes as producer tool with postAnswerRealActivity:true (lifts Lever 1 for real work)', () => {
+    // The drain call for post-answer work must pass producer='tool' AND
+    // { postAnswerRealActivity: true } so the feed-open-gate exception is applied.
+    const body = feedHeartbeatTickSrc()
+    expect(body).toMatch(/drainActivitySummary\(turn,\s*'tool',\s*\{\s*postAnswerRealActivity:\s*true\s*\}/)
+  })
+
+  it('POST_ANSWER_LIVENESS_MS <= 0 returns early (operator opt-out for silent post-answer)', () => {
+    // When POST_ANSWER_LIVENESS_MS is 0 (operator opted out), the post-answer
+    // branch must return immediately so no card opens. This preserves the
+    // operator kill-switch contract.
+    const body = feedHeartbeatTickSrc()
+    expect(body).toMatch(/POST_ANSWER_LIVENESS_MS\s*<=\s*0.*return/)
+  })
+
+  it('post-answer branch requires finalAnswerDeliveredAt to be non-null (prevents stale pre-answer tick)', () => {
+    // The branch must check that finalAnswerDeliveredAt is non-null before
+    // comparing it — guards against a race where the tick fires before the
+    // latch is set.
+    const body = feedHeartbeatTickSrc()
+    expect(body).toMatch(/turn\.finalAnswerDeliveredAt\s*==\s*null/)
   })
 })

--- a/telegram-plugin/tests/feed-open-gate.test.ts
+++ b/telegram-plugin/tests/feed-open-gate.test.ts
@@ -107,6 +107,95 @@ describe('mayOpenActivityCard — lever 1 (no OPEN after a substantive final)', 
   })
 })
 
+describe('mayOpenActivityCard — post-answer real activity exception (restore #2547 visibility)', () => {
+  // Lever 1 blocks all OPENs after finalAnswerEverDelivered by default.
+  // The postAnswerRealActivity + producer='tool' exception lifts it for genuine
+  // new background sub-agent/tool work AFTER the answer, while keeping idle
+  // liveness (producer 'liveness' or no real activity) suppressed.
+
+  it('post-answer REAL sub-agent activity DOES open a card (producer tool + postAnswerRealActivity)', () => {
+    // This is the restored #2547 case: a sub-agent keeps doing tool work AFTER
+    // the substantive answer. The feed should surface as a card below the reply.
+    expect(
+      mayOpenActivityCard({
+        producer: 'tool',
+        finalAnswerEverDelivered: true,
+        labeledToolCount: 3,
+        postAnswerRealActivity: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('post-answer IDLE liveness does NOT open after a substantive final (idle-gap suppression preserved)', () => {
+    // The idle-gap invariant: a liveness timer firing post-answer (no new
+    // lastToolLabelAt advance) must still be suppressed. Only genuine tool
+    // activity gets the exception.
+    expect(
+      mayOpenActivityCard({
+        producer: 'liveness',
+        finalAnswerEverDelivered: true,
+        labeledToolCount: 0,
+        postAnswerRealActivity: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('postAnswerRealActivity without producer=tool does NOT lift lever 1 (not a real tool dispatch)', () => {
+    // Even if postAnswerRealActivity is set, only producer='tool' unlocks the
+    // exception. Liveness/narrative stays blocked after a final answer.
+    expect(
+      mayOpenActivityCard({
+        producer: 'liveness',
+        finalAnswerEverDelivered: true,
+        labeledToolCount: 1,
+        postAnswerRealActivity: true,
+      }),
+    ).toBe(false)
+    expect(
+      mayOpenActivityCard({
+        producer: 'narrative',
+        finalAnswerEverDelivered: true,
+        labeledToolCount: 2,
+        postAnswerRealActivity: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('without postAnswerRealActivity, tool producer is still blocked after final (original lever 1 preserved)', () => {
+    // Regression guard: postAnswerRealActivity omitted/false means lever 1
+    // still blocks a tool OPEN — no accidental leak of the exception.
+    expect(
+      mayOpenActivityCard({
+        producer: 'tool',
+        finalAnswerEverDelivered: true,
+        labeledToolCount: 3,
+      }),
+    ).toBe(false)
+    expect(
+      mayOpenActivityCard({
+        producer: 'tool',
+        finalAnswerEverDelivered: true,
+        labeledToolCount: 3,
+        postAnswerRealActivity: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('cross-turn lever 4 still blocks post-answer real activity on synthetic surfaces (lever 4 wins)', () => {
+    // Lever 4 is checked FIRST — even a genuine post-answer tool OPEN is
+    // blocked on a cross-turn synthetic surface that already has an answer.
+    expect(
+      mayOpenActivityCard({
+        producer: 'tool',
+        finalAnswerEverDelivered: true,
+        labeledToolCount: 2,
+        crossTurnAnswerDelivered: true,
+        postAnswerRealActivity: true,
+      }),
+    ).toBe(false)
+  })
+})
+
 describe('mayOpenActivityCard — lever 4 (no OPEN below an EARLIER turn answer; race C/D)', () => {
   // The cross-turn case: a synthetic represent/owed-reply turn starts with a
   // CLEARED per-turn `finalAnswerEverDelivered` latch even though a substantive

--- a/telegram-plugin/tests/turn-liveness-floor.test.ts
+++ b/telegram-plugin/tests/turn-liveness-floor.test.ts
@@ -20,6 +20,7 @@ import {
   decideTerminalReason,
   midTurnFloorEnabled,
   parsePostAnswerLivenessMs,
+  POST_ANSWER_LIVENESS_DEFAULT_MS,
   DEFAULT_FLOOR_THRESHOLD_MS,
   type MidTurnFloorInput,
 } from '../turn-liveness-floor.js'
@@ -170,26 +171,31 @@ describe('midTurnFloorEnabled — default-on kill switch', () => {
   })
 })
 
-describe('parsePostAnswerLivenessMs — PR1 Item-3a DORMANT escape hatch (default OFF)', () => {
-  // The load-bearing contract: UNSET ⇒ 0 ⇒ behaviour byte-identical to today
-  // (the guarded post-answer branch in feedHeartbeatTick is dead). No surface
-  // ships enabled in this PR; this only pins that nothing changes by default.
-  it('UNSET (undefined) ⇒ 0 — exactly today’s silent post-answer behaviour', () => {
-    expect(parsePostAnswerLivenessMs(undefined)).toBe(0)
+describe('parsePostAnswerLivenessMs — post-answer liveness threshold (default ON, 6000ms)', () => {
+  // The restored contract: UNSET ⇒ POST_ANSWER_LIVENESS_DEFAULT_MS (6 000 ms)
+  // so the post-answer branch in feedHeartbeatTick runs out of the box and
+  // genuine background sub-agent activity surfaces as a card below the reply
+  // (restores #2547 visibility under #2564 determinism gate). Operators who
+  // prefer silent post-answer behaviour set =0.
+  it('UNSET (undefined) ⇒ default 6 000 ms — post-answer activity card enabled by default', () => {
+    expect(parsePostAnswerLivenessMs(undefined)).toBe(POST_ANSWER_LIVENESS_DEFAULT_MS)
   })
 
-  it('empty / whitespace / non-numeric ⇒ 0 (dormant)', () => {
-    expect(parsePostAnswerLivenessMs('')).toBe(0)
+  it('empty ⇒ default 6 000 ms (same as unset)', () => {
+    expect(parsePostAnswerLivenessMs('')).toBe(POST_ANSWER_LIVENESS_DEFAULT_MS)
+  })
+
+  it('non-numeric ⇒ 0 (invalid value treated as opt-out)', () => {
     expect(parsePostAnswerLivenessMs('   ')).toBe(0)
     expect(parsePostAnswerLivenessMs('nope')).toBe(0)
   })
 
-  it('0 and negative ⇒ 0 (dormant — never enables a post-answer surface)', () => {
+  it('0 and negative ⇒ 0 (explicit operator opt-out — silent post-answer)', () => {
     expect(parsePostAnswerLivenessMs('0')).toBe(0)
     expect(parsePostAnswerLivenessMs('-5000')).toBe(0)
   })
 
-  it('a positive integer ⇒ that threshold in ms (the opt-in future surface)', () => {
+  it('a positive integer ⇒ that threshold in ms (operator override)', () => {
     expect(parsePostAnswerLivenessMs('8000')).toBe(8000)
     expect(parsePostAnswerLivenessMs('45000')).toBe(45000)
   })

--- a/telegram-plugin/turn-liveness-floor.ts
+++ b/telegram-plugin/turn-liveness-floor.ts
@@ -161,23 +161,30 @@ export function midTurnFloorEnabled(): boolean {
 }
 
 /**
- * PR1 Item-3a — parse the DORMANT post-answer liveness window
- * (`SWITCHROOM_POST_ANSWER_LIVENESS_MS`). This is the escape-hatch plumbing for a
- * future per-agent "still tidying…" liveness line on POST-answer work; see the
- * Item-3 decision in `docs/message-emission-determinism.md` §10 R2. Today
- * post-answer work is silent by design (lever 1 refuses any card OPEN once a
- * substantive final landed), and this knob ships DORMANT:
+ * Parse the post-answer liveness window (`SWITCHROOM_POST_ANSWER_LIVENESS_MS`).
  *
- *   - UNSET, empty, non-numeric, 0, or negative ⇒ **0** = today's behaviour
- *     (no post-answer surface; the guarded branch in `feedHeartbeatTick` is dead).
- *   - a positive integer ⇒ the threshold (ms of post-answer silence) at which a
- *     future Item-3 surface WOULD fire. No surface ships enabled in this PR.
+ * This is the threshold (in ms) after the substantive final answer at which
+ * `feedHeartbeatTick` will surface a post-answer background-activity card when
+ * genuine new sub-agent/tool activity is detected (i.e. `lastToolLabelAt` has
+ * advanced past the answer-delivery timestamp). This restores the #2547
+ * visibility outcome under the #2564 determinism gate.
  *
- * Extracted as a pure function so the default-off contract is unit-testable
+ *   - UNSET or empty ⇒ **6 000 ms** (default on, matching the
+ *     `FEED_HEARTBEAT_MIN_STALE_MS` cadence constant in gateway.ts — after one
+ *     heartbeat interval of post-answer real-tool activity the card surfaces).
+ *   - a positive integer ⇒ that threshold in ms (operator override).
+ *   - 0 or negative ⇒ **0** = silent post-answer behaviour (opt-out).
+ *   - non-numeric or "0" ⇒ treated as 0 (silent).
+ *
+ * Extracted as a pure function so the contract is unit-testable
  * (gateway.ts is not importable in isolation — top-level side effects). Mirrors
  * `parseVisibleAnswerStreamEnabled`'s pattern.
  */
+export const POST_ANSWER_LIVENESS_DEFAULT_MS = 6_000
+
 export function parsePostAnswerLivenessMs(raw: string | undefined): number {
-  const n = raw ? Number(raw) : NaN
-  return Number.isFinite(n) && n > 0 ? n : 0
+  if (raw == null || raw === '') return POST_ANSWER_LIVENESS_DEFAULT_MS
+  const n = Number(raw)
+  if (!Number.isFinite(n) || n <= 0) return 0
+  return n
 }


### PR DESCRIPTION
## Outcome

Background sub-agent/workflow activity that runs AFTER a substantive answer was delivered now surfaces as an activity card below the prior reply. Operators see their agents' post-answer cleanup/sub-agent work again (the regression reported as 'background agent stuff seems gone' after v0.16.x).

Idle thinking-gaps and pure silence after the answer remain suppressed — the reply-is-last and idle-gap-suppression invariants from #2557/#2564 are fully preserved.

## Root Cause

Three compounding issues from the June 25 determinism wave:

1. **Dormant post-answer branch** (`feedHeartbeatTick`): the branch guarded by `turn.finalAnswerDelivered` reached the threshold check then hit a bare `return` with no implementation. No card was ever opened or maintained post-answer.

2. **`POST_ANSWER_LIVENESS_MS` defaulted to 0**: `parsePostAnswerLivenessMs(undefined)` returned `0`, so `POST_ANSWER_LIVENESS_MS <= 0` fired immediately and the branch returned before any detection logic ran.

3. **Lever 1 applied a blanket block** (`feed-open-gate.ts`): `mayOpenActivityCard` blocked ALL producers after `finalAnswerEverDelivered`, with no exception for genuine real tool activity occurring post-answer.

## Deterministic-Signal Approach

This fix drives off state deltas, not wall-clock age alone:

- **New `finalAnswerDeliveredAt: number | null`** field on `CurrentTurn`, stamped alongside `finalAnswerEverDelivered = true` at every site. Provides a deterministic anchor for "was this tool label before or after the answer?"

- **`feedHeartbeatTick` post-answer branch** now: gates on `lastToolLabelAt > finalAnswerDeliveredAt` (a tool label rendered genuinely after the answer). Idle liveness (no new label since answer) never sets this — idle-gap suppression is preserved by construction.

- **`POST_ANSWER_LIVENESS_MS` default changed to 6 000 ms** (matching `FEED_HEARTBEAT_MIN_STALE_MS` — after one heartbeat interval of post-answer real-tool activity, a card surfaces). Operators who prefer silent post-answer behaviour set `SWITCHROOM_POST_ANSWER_LIVENESS_MS=0`.

- **`mayOpenActivityCard` Lever 1 exception**: new `postAnswerRealActivity?: boolean` field. When `postAnswerRealActivity === true && producer === 'tool'`, the blanket block is lifted. Only the post-answer heartbeat branch sets this — idle producers (`liveness`, `narrative`) remain blocked after the final answer.

## Invariants Preserved

- Reply-is-last: idle post-answer liveness still cannot open a card (producer !== 'tool' stays blocked)
- #2141 ack-then-work feed: `finalAnswerEverDelivered` is only set on substantive finals (not acks), so the reopen path is unaffected
- Cross-turn Lever 4: still checked first, beats the new exception
- All pre-existing #2557/#2564 determinism tests remain green

## Test Plan

- [x] `feed-open-gate.test.ts`: added "post-answer REAL sub-agent activity DOES open a card" + "idle liveness does NOT open after final" + exception-boundary tests
- [x] `feed-heartbeat-liveness-open.test.ts`: added H-2 structural suite pinning the deterministic guards (`lastToolLabelAt <= finalAnswerDeliveredAt`), producer routing (`'tool'` + `postAnswerRealActivity:true`), and operator kill-switch
- [x] `turn-liveness-floor.test.ts`: updated to reflect new default-ON contract (6 000 ms default)
- [x] `emission-authority-facade.test.ts`: updated drain-site count 6→7
- [x] `emission-determinism-wiring.test.ts`: window size extended to accommodate new latch line
- [x] Full bun test suite: 5021 pass, 11 fail (all 11 pre-existing on baseline, zero new failures)
- [x] `tsc --noEmit`: clean

Ref: #2547 (background agent visibility), #2557 (levers/determinism), #2564 (cross-turn gate + post-answer hook)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>