### PR TITLE
fix(telegram): restore conversational-turn narrative card with reply-supersede ordering (revisit Lever 5 / #2545)

### DIFF
--- a/telegram-plugin/gateway/feed-open-gate.ts
+++ b/telegram-plugin/gateway/feed-open-gate.ts
@@ -24,18 +24,32 @@
  * (non-substantive) does NOT trip it and the #2141 ack-then-work feed still
  * opens.
  *
- * ## Lever 5 base case — narrative-SHOW alone must not OPEN (§9 lever 5, G1)
+ * ## Lever 5 — narrative-SHOW OPEN on 0-tool turns (#2545 / #2557 / #2587)
  *
- * The triplication: a 0-tool conversational turn opened a full card from
- * narration text alone. Rule: the narrative-SHOW producer (A) may only EDIT an
- * already-open card, never OPEN one. Only a tool label (producer B) or the
- * liveness timer (producer C, a genuine ≥12s thinking-gap) may OPEN a card.
+ * ### Pre-answer: OPEN is allowed (restores #2545)
  *
- * So a narrative-SHOW-triggered OPEN is refused while the turn has surfaced ZERO
- * tool labels (`labeledToolCount === 0`). Once a tool label arrives
- * (`labeledToolCount > 0`) the card opens and the accumulated narration renders;
- * a turn that starts conversational then dispatches a tool DOES open (R4). The
- * liveness path (producer C) is exempt — it owns the genuine thinking-gap open.
+ * When `finalAnswerEverDelivered === false`, a narrative producer on a 0-tool
+ * conversational turn MAY open a card. Reply-is-last ordering is preserved by
+ * Lever 2 (`clearActivitySummary` in `executeReply`) — that path edits the card
+ * in-place BEFORE the reply chunks send, so the card keeps its lower message_id
+ * and the reply (higher message_id) is structurally last on screen regardless of
+ * whether there were tool labels. The "triplication" bug from #2557 was G1+G2+G3
+ * (prose leaking as a feed step + second card on the Stop-hook re-prompt), which
+ * was already a separate G2/G3 problem — not a G1 open problem. Lever 5 over-
+ * suppressed: it blocked a legitimate conversational narrative card to avoid a
+ * reorder that Lever 2 already prevents.
+ *
+ * ### Post-answer: OPEN is already blocked by Lever 1
+ *
+ * When `finalAnswerEverDelivered === true`, Lever 1 blocks all OPENs (any
+ * producer) regardless of Lever 5 — so the post-answer case is unaffected.
+ *
+ * ### Tool-turn accumulated narration: unchanged (R4 preserved)
+ *
+ * A turn that starts conversational then dispatches a tool already allowed OPEN
+ * via `labeledToolCount > 0` (R4); that path is unaffected by this change.
+ * The liveness path (producer C, genuine ≥12s thinking-gap) was never gated by
+ * Lever 5 and remains unchanged.
  *
  * ## Lever 4 — no card OPEN below an EARLIER turn's answer (§9 lever 4, race C/D)
  *
@@ -75,7 +89,8 @@
 /** Which producer triggered this drain — determines lever-5 OPEN eligibility. */
 export type FeedOpenProducer =
   /** Narrative SHOW (producer A): plain assistant text, no tool, no time
-   *  threshold. May only EDIT, never OPEN, while the turn has 0 tool labels. */
+   *  threshold. May OPEN before the final answer (Lever 5 pre-answer); may only
+   *  EDIT after the final answer (Lever 1 blocks). */
   | 'narrative'
   /** Tool label (producer B): the model dispatched a tool. OPEN-eligible unless a
    *  substantive final already landed (lever 1).
@@ -129,8 +144,13 @@ export interface FeedOpenInput {
  *    answer is allowed to OPEN a card below the prior reply (restores #2547
  *    visibility). Idle liveness (`producer !== 'tool'` or no `lastToolLabelAt`
  *    advance) still cannot open after a final — idle-gap suppression preserved.
- *  - producer 'narrative' && labeledToolCount === 0 → false: lever 5 base case.
- *    Narration alone on a 0-tool turn may not open a card (the triplication).
+ *  - producer 'narrative' && labeledToolCount === 0 && finalAnswerEverDelivered:
+ *    lever 5 post-answer guard. When the answer has already landed, this case
+ *    is already blocked by lever 1 above — lever 5 is thus inert post-answer.
+ *    Pre-answer (finalAnswerEverDelivered === false): narrative MAY OPEN a card
+ *    on a 0-tool conversational turn — the reply-is-last ordering is preserved
+ *    by Lever 2 (clearActivitySummary edits the card in-place BEFORE the reply
+ *    sends; see gateway.ts §9 lever 2). This restores #2545 visibility.
  *  - producer 'tool' → true (unless lever 1/4): a real tool dispatched → open.
  *  - producer 'liveness' → true (unless lever 1/4): the genuine thinking-gap open
  *    (producer C) is untouched by lever 5.
@@ -151,8 +171,15 @@ export function mayOpenActivityCard(input: FeedOpenInput): boolean {
   if (input.finalAnswerEverDelivered) {
     if (!(input.postAnswerRealActivity === true && input.producer === 'tool')) return false
   }
-  // Lever 5 base case — narrative SHOW alone on a 0-tool turn may not OPEN.
-  if (input.producer === 'narrative' && input.labeledToolCount === 0) return false
+  // Lever 5 — narrative-SHOW pre-answer open (restores #2545, revisits #2557):
+  // When finalAnswerEverDelivered is false (answer not yet delivered), a
+  // narrative producer on a 0-tool conversational turn MAY open a card. Lever 2
+  // (clearActivitySummary in executeReply) edits the card in-place BEFORE the
+  // reply sends, preserving reply-is-last ordering without this gate needing to
+  // suppress the open. When finalAnswerEverDelivered is true, Lever 1 above
+  // already blocked the open — so Lever 5 is only reached pre-answer, where it
+  // must now allow the open.
+  // No suppression needed here: return true for all remaining cases.
   return true
 }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -10709,11 +10709,12 @@ function showNarrativeStep(turn: CurrentTurn, text: string): void {
   // card-drain gate (chatLock-serialized under the flag; verbatim block OFF).
   cardDrainGate(turn, ea, () => {
   if (ea.mayDrain(turn)) {
-    // Producer A (narrative SHOW): may only EDIT an already-open card, never
-    // OPEN one on a 0-tool turn (design §9 lever 5 base case — the
-    // triplication). The OPEN gate in the drain enforces this; accumulation
-    // into mirrorLines still happens so the narration renders once a tool
-    // label or liveness opens the card.
+    // Producer A (narrative SHOW): pre-answer, may OPEN a card on a 0-tool
+    // conversational turn (restores #2545; lever 5 revised in #2587 follow-up).
+    // Reply-is-last ordering preserved by Lever 2 (clearActivitySummary edits
+    // the card in-place BEFORE the reply sends). Post-answer, Lever 1 blocks
+    // the open. Accumulation into mirrorLines still happens on tool turns so
+    // the narration renders once a tool label opens the card (R4 preserved).
     // PR-4a: routed through the emission-authority façade (no-op delegate).
     ea.openOrEditCard('narrative', () => {
       turn.activityInFlight = drainActivitySummary(turn, 'narrative')

--- a/telegram-plugin/tests/feed-open-gate.test.ts
+++ b/telegram-plugin/tests/feed-open-gate.test.ts
@@ -8,9 +8,11 @@ import { mayOpenActivityCard } from '../gateway/feed-open-gate.js'
  * sendMessage). An EDIT of an already-open card is never routed through this
  * (the drain only consults it when activityMessageId == null).
  *
- * Lever 5 base case (the triplication fix): a narrative-SHOW producer alone on
- * a 0-tool turn must NOT open a card. A tool label DOES open. The liveness
- * timer (genuine ≥12s thinking-gap) still opens a 0-tool card.
+ * Lever 5 revised (#2545 / #2557 / #2587 follow-up): a narrative-SHOW producer
+ * on a 0-tool conversational turn MAY open a card PRE-ANSWER. Reply-is-last
+ * ordering is preserved by Lever 2 (clearActivitySummary edits the card in-place
+ * BEFORE the reply sends, so the card keeps its lower message_id). Post-answer,
+ * Lever 1 blocks the open for ANY producer.
  *
  * Lever 1 (reply-is-last): once a SUBSTANTIVE final answer has been delivered
  * (the sticky finalAnswerEverDelivered latch), no card may open below it — for
@@ -18,12 +20,30 @@ import { mayOpenActivityCard } from '../gateway/feed-open-gate.js'
  * clears that mid-turn, #2141); an ack does not set it, so the ack-then-work
  * feed still opens.
  */
-describe('mayOpenActivityCard — lever 5 base case (narrative-SHOW alone must not OPEN)', () => {
-  it('narrative SHOW on a 0-tool turn does NOT open a card (the triplication)', () => {
+describe('mayOpenActivityCard — lever 5 (narrative-SHOW on 0-tool conversational turns)', () => {
+  it('narrative SHOW on a 0-tool turn DOES open a card pre-answer (restores #2545 conversational visibility)', () => {
+    // Lever 5 revised: narrative is allowed to open a card before the answer
+    // lands. Lever 2 (clearActivitySummary before the reply sends) preserves
+    // reply-is-last ordering without Lever 5 needing to suppress the open.
     expect(
       mayOpenActivityCard({
         producer: 'narrative',
         finalAnswerEverDelivered: false,
+        labeledToolCount: 0,
+      }),
+    ).toBe(true)
+  })
+
+  it('narrative SHOW on a 0-tool turn does NOT open AFTER the final answer (Lever 1 blocks it, ordering preserved)', () => {
+    // Post-answer, Lever 1 (finalAnswerEverDelivered === true) blocks the open
+    // for any producer — the reply-supersedes-narrative ordering invariant holds
+    // because clearActivitySummary already ran (editing the card in-place) before
+    // the reply sent. This is the supersede mechanism: the card is finalized
+    // before the reply, so no reorder occurs.
+    expect(
+      mayOpenActivityCard({
+        producer: 'narrative',
+        finalAnswerEverDelivered: true,
         labeledToolCount: 0,
       }),
     ).toBe(false)
@@ -60,6 +80,28 @@ describe('mayOpenActivityCard — lever 5 base case (narrative-SHOW alone must n
         labeledToolCount: 1,
       }),
     ).toBe(true)
+  })
+
+  it('narrative card is superseded by the reply: no OPEN after final, so reply stays last (no out-of-order card below the answer)', () => {
+    // The supersede mechanism: on a conversational turn, narrative opens a card
+    // (msg_id N). When the substantive reply arrives, Lever 2 calls
+    // clearActivitySummary, which edits/closes the card in-place (still msg_id N)
+    // BEFORE the reply sends (msg_id N+1). The reply is structurally last.
+    // This gate's post-answer block (via Lever 1) ensures no new card can open
+    // after the reply — so the out-of-order-card-below-answer scenario is
+    // prevented. This test pins the invariant: once finalAnswerEverDelivered is
+    // true, no narrative (or any other) producer may open a new card.
+    const postAnswerInputs = [
+      { producer: 'narrative' as const, labeledToolCount: 0 },
+      { producer: 'narrative' as const, labeledToolCount: 2 },
+      { producer: 'tool' as const, labeledToolCount: 2 },
+      { producer: 'liveness' as const, labeledToolCount: 0 },
+    ]
+    for (const extra of postAnswerInputs) {
+      expect(
+        mayOpenActivityCard({ ...extra, finalAnswerEverDelivered: true }),
+      ).toBe(false)
+    }
   })
 })
 


### PR DESCRIPTION
## Outcome

Conversational turns where the agent emits narrative text blocks (type `text`, zero tool calls) now surface a visible activity card in Telegram — restoring the behavior from #2545. Operators experiencing "I only see tool updates" on conversational turns will see the agent's narration in a card again.

## Root cause

PR #2557's **Lever 5** in `mayOpenActivityCard` (`telegram-plugin/gateway/feed-open-gate.ts`) suppressed the narrative producer from opening a card on 0-tool turns:

```ts
// OLD (suppressed all narrative opens on 0-tool turns)
if (input.producer === 'narrative' && input.labeledToolCount === 0) return false
```

This was added to prevent a "triplication" reorder: a narrative card would open (message_id N), then the reply would send (message_id N+1), then the card would sit above the reply in Telegram — correct order, but then a Stop-hook re-prompt caused a second card (G2+G3 in the determinism doc). The fix over-suppressed: it killed the card entirely rather than fixing the G2/G3 half of the triplication.

## The fix: Lever 2 already handles the reorder

The reply-is-last ordering is guaranteed by **Lever 2** (`clearActivitySummary` in `executeReply`, `gateway.ts` line 8332–8357), which edits the narrative card **in-place BEFORE the reply chunks send**. The card keeps its lower message_id; the reply (higher message_id) is structurally last. No new mechanism needed.

Fix: remove the Lever 5 open-suppression in the **pre-answer case**. The gate now:

- **Pre-answer** (`finalAnswerEverDelivered === false`): narrative producer may OPEN on a 0-tool turn. Lever 2 supersedes/finalizes the card before the reply.
- **Post-answer** (`finalAnswerEverDelivered === true`): Lever 1 already blocks all producers — Lever 5 was unreachable here anyway.

The `labeledToolCount` field remains in `FeedOpenInput` (used by the R4 path: tool turns still accumulate narration and open once a tool label arrives). Lever 5 is now documented as "inert" rather than removed, since the post-answer case is covered by Lever 1.

## Why it's deterministic

The decision is keyed only on `finalAnswerEverDelivered` (sticky latch, set once, never cleared) and `producer` — both deterministic inputs. No timers as truth. Same inputs → same gate verdict on every run.

## Tests

- Replaced the old "0-tool narrative must NOT open" assertion (pinned the old Lever 5 block) with the revised contract: **"0-tool narrative DOES open pre-answer"** (restores #2545).
- Added a **supersede/no-reorder test**: pins that `finalAnswerEverDelivered === true` blocks all producers (narrative, tool, liveness) — meaning no card can open after the reply sends, so the reply-is-last invariant holds. This is the gate-side complement of Lever 2's in-place edit.
- All existing lever 1, lever 4, #2547 post-answer real activity, and #2141 ack-then-work tests remain GREEN.
- Fix B's new post-answer-background-liveness tests (from `fix/telegram-post-answer-bg-liveness`) remain GREEN (confirmed: same 1036 pass / 2 pre-existing unrelated vault failures as base branch).

**Test counts:** 21 pass (was 19; +2 new tests), 0 fail, 0 changes to other test files.

## Stacking note

This PR is stacked on **#2587** (`fix/telegram-post-answer-bg-liveness`) and should merge AFTER it. Both touch `feed-open-gate.ts`; this PR's diff is clean on top of that branch.

## References

- Restores: #2545 (surface JSONL text-block narrative)
- Regressed by: #2557 (Lever 5 addition)
- Stacks on: #2587 (post-answer bg liveness)
- Related: #2547 (post-answer real activity exception)

---

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>