### PR TITLE
fix(telegram): restore narrative feed lines + post-answer background-agent liveness (supersedes #2587 #2588)

### DIFF
--- a/telegram-plugin/gateway/feed-open-gate.ts
+++ b/telegram-plugin/gateway/feed-open-gate.ts
@@ -24,18 +24,26 @@
  * (non-substantive) does NOT trip it and the #2141 ack-then-work feed still
  * opens.
  *
- * ## Lever 5 base case — narrative-SHOW alone must not OPEN (§9 lever 5, G1)
+ * ## Lever 5 — INERT (pre-answer narrative OPEN now permitted, #2588)
  *
- * The triplication: a 0-tool conversational turn opened a full card from
- * narration text alone. Rule: the narrative-SHOW producer (A) may only EDIT an
- * already-open card, never OPEN one. Only a tool label (producer B) or the
- * liveness timer (producer C, a genuine ≥12s thinking-gap) may OPEN a card.
+ * Lever 5 was added in #2557 to prevent a "triplication" reorder: a 0-tool
+ * conversational turn would open a card (message_id N), then the reply would
+ * send (message_id N+1) ABOVE the card, and then a Stop-hook re-prompt caused
+ * a second card below. The fix over-suppressed: it killed the card entirely
+ * rather than fixing the G2/G3 half of the triplication.
  *
- * So a narrative-SHOW-triggered OPEN is refused while the turn has surfaced ZERO
- * tool labels (`labeledToolCount === 0`). Once a tool label arrives
- * (`labeledToolCount > 0`) the card opens and the accumulated narration renders;
- * a turn that starts conversational then dispatches a tool DOES open (R4). The
- * liveness path (producer C) is exempt — it owns the genuine thinking-gap open.
+ * **Lever 2 (`clearActivitySummary`) already owns reply-is-last ordering:** it
+ * edits the narrative card IN-PLACE before the reply chunks send, keeping its
+ * lower message_id and guaranteeing the reply lands above it — no reorder.
+ * Lever 5's open-suppression is therefore redundant and harms visibility:
+ * a pre-answer narrative on a 0-tool turn (the agent thinking aloud before
+ * dispatching tools) is exactly the kind of step operators want to see.
+ *
+ * Lever 5 is now INERT for the pre-answer case. Post-answer is already blocked
+ * by Lever 1 (`finalAnswerEverDelivered`), so Lever 5 was unreachable there
+ * anyway. The `labeledToolCount` field remains in `FeedOpenInput` — it is still
+ * used by R4 (a turn that starts conversational then dispatches a tool opens on
+ * the first label) and by tests.
  *
  * ## Lever 4 — no card OPEN below an EARLIER turn's answer (§9 lever 4, race C/D)
  *
@@ -104,6 +112,25 @@ export interface FeedOpenInput {
    *  below the earlier reply). A normal foreground turn passes `false` (or omits
    *  it), so lever 4 is inert there. Defaults to `false`. */
   crossTurnAnswerDelivered?: boolean
+  /**
+   * Fix 2 (post-answer background-agent liveness, #2587 supersede): true when
+   * the sub-agent/workflow watcher has produced a NEW activity step AFTER the
+   * substantive final answer was delivered. This signal is updated by the watcher
+   * callback INDEPENDENTLY of the tool_label path, so the drop-guard
+   * (`shouldReopenFeedAfterAck` / `turn.finalAnswerSubstantive`) does NOT gate it.
+   *
+   * When true AND `producer === 'tool'`, Lever 1's blanket post-answer block is
+   * lifted: a liveness card surfaces below the reply to show "background agent
+   * still working". Idle producers (`liveness`, `narrative`) remain blocked after
+   * the final answer — the reply-is-last invariant is preserved for idle gaps.
+   * Only the `feedHeartbeatTick` post-answer branch sets this; it reads
+   * `turn.subagentActivityAt > (turn.finalAnswerDeliveredAt ?? 0)` (a tool-label
+   * rendered genuinely after the answer) rather than the frozen `lastToolLabelAt`.
+   *
+   * Defaults to `false` (Lever 1 stays fully active) — callers that don't pass
+   * this see no behaviour change.
+   */
+  postAnswerSubagentActivity?: boolean
 }
 
 /**
@@ -114,13 +141,16 @@ export interface FeedOpenInput {
  *  - crossTurnAnswerDelivered → false: lever 4. A cross-turn synthetic surface
  *    whose exchange already delivered a substantive answer in an EARLIER turn;
  *    no card may open below it (any producer). Checked FIRST.
- *  - finalAnswerEverDelivered → false: lever 1. A substantive final already
- *    landed THIS turn; no card may open below it (any producer).
- *  - producer 'narrative' && labeledToolCount === 0 → false: lever 5 base case.
- *    Narration alone on a 0-tool turn may not open a card (the triplication).
- *  - producer 'tool' → true (unless lever 1/4): a real tool dispatched → open.
- *  - producer 'liveness' → true (unless lever 1/4): the genuine thinking-gap open
- *    (producer C) is untouched by lever 5.
+ *  - finalAnswerEverDelivered && !postAnswerSubagentActivity → false: lever 1.
+ *    A substantive final already landed THIS turn; no card may open below it.
+ *    Exception: when `postAnswerSubagentActivity === true` AND `producer ===
+ *    'tool'`, Lever 1 is lifted so the background-agent liveness heartbeat can
+ *    surface a card below the reply showing the watcher's real new activity.
+ *    Idle producers ('liveness', 'narrative') stay blocked — no card opens from
+ *    wall-clock alone after the final answer.
+ *  - producer 'narrative': always allowed when pre-answer (lever 5 is INERT —
+ *    Lever 2 / clearActivitySummary guarantees reply-is-last ordering instead).
+ *  - producer 'tool' or 'liveness' → true (unless lever 1/4).
  */
 export function mayOpenActivityCard(input: FeedOpenInput): boolean {
   // Lever 4 — cross-turn: nothing opens on a synthetic represent/owed-reply
@@ -128,10 +158,16 @@ export function mayOpenActivityCard(input: FeedOpenInput): boolean {
   // turn (race C/D). Checked FIRST, above lever 1, and scoped to cross-turn
   // synthetic surfaces by the caller so it can never fire on a foreground turn.
   if (input.crossTurnAnswerDelivered) return false
-  // Lever 1 — sticky: nothing opens after a substantive final answer.
-  if (input.finalAnswerEverDelivered) return false
-  // Lever 5 base case — narrative SHOW alone on a 0-tool turn may not OPEN.
-  if (input.producer === 'narrative' && input.labeledToolCount === 0) return false
+  // Lever 1 — sticky: nothing opens after a substantive final answer, EXCEPT
+  // when genuine post-answer sub-agent/watcher activity warrants a liveness card
+  // (Fix 2 / #2587 supersede). Only 'tool' is exempted so idle liveness and
+  // narrative producers remain blocked after the final answer.
+  if (input.finalAnswerEverDelivered) {
+    if (input.postAnswerSubagentActivity && input.producer === 'tool') return true
+    return false
+  }
+  // Lever 5 — INERT (see module comment above). Pre-answer narrative may now
+  // open a card; Lever 2 (clearActivitySummary) handles reply-is-last ordering.
   return true
 }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2138,6 +2138,22 @@ type CurrentTurn = {
   // step that emits no new label doesn't read as frozen (the feed is otherwise
   // pull-only). undefined until the first label of the turn renders.
   lastToolLabelAt?: number
+  // Fix 2 (post-answer background-agent liveness): wall-clock timestamp last
+  // updated by the sub-agent/workflow watcher's onProgress callback whenever
+  // it surfaces a NEW sub-agent step AFTER this turn's substantive answer was
+  // delivered. Written INDEPENDENTLY of the tool_label path so the drop-guard
+  // (`shouldReopenFeedAfterAck` / `finalAnswerSubstantive`) cannot gate it.
+  // `feedHeartbeatTick` reads THIS (not `lastToolLabelAt`, which is frozen by
+  // the drop-guard) to drive the post-answer liveness card — the core fix for
+  // #2587's inert state. undefined until the first post-answer watcher advance.
+  subagentActivityAt?: number
+  // Sticky wall-clock timestamp when finalAnswerEverDelivered first latched
+  // true this turn. Allows the heartbeat to distinguish "tool label arrived
+  // before the answer" (lastToolLabelAt ≤ finalAnswerDeliveredAt, inert) from
+  // "sub-agent active after the answer" (subagentActivityAt >
+  // finalAnswerDeliveredAt, liveness card warranted). undefined until the
+  // first substantive final answer of the turn.
+  finalAnswerDeliveredAt?: number
   // Accumulating friendly-action feed for this turn. Each non-surface
   // tool_label appends a line via `appendActivityLabel`; the feed renders
   // (via `renderActivityFeed`) as a capped chronological list into the
@@ -8341,6 +8357,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
       const ea = emissionAuthorityFor(finalizeTurn)
       ea.markSubstantiveFinalDelivered(() => {
         finalizeTurn.finalAnswerEverDelivered = true
+        finalizeTurn.finalAnswerDeliveredAt = Date.now()
       })
       ea.finalizeCard(() => {
         clearActivitySummary(finalizeTurn)
@@ -8468,6 +8485,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
             // Sticky ordering latch (lever 1): a substantive final closes the
             // card OPEN gate for the rest of the turn. NEVER cleared by reopen.
             if (turn.finalAnswerSubstantive) turn.finalAnswerEverDelivered = true
+            if (turn.finalAnswerSubstantive && turn.finalAnswerDeliveredAt == null) turn.finalAnswerDeliveredAt = Date.now()
             if (turn.finalAnswerSubstantive) closeObligationOnSubstantiveReply(args, turn, replyRoutedOriginTurn)
           }
           outboundDedup.record(
@@ -8816,6 +8834,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
       // never cleared by reopen. The card OPEN gate keys on this, not the
       // mutable finalAnswerDelivered above (which reopen toggles).
       if (turn.finalAnswerSubstantive) turn.finalAnswerEverDelivered = true
+      if (turn.finalAnswerSubstantive && turn.finalAnswerDeliveredAt == null) turn.finalAnswerDeliveredAt = Date.now()
       // #1728: release the buffer gate + emit terminal 👍. Mid-turn
       // acks bypass this branch and remain non-events for the
       // reaction (preserves #1713). The full turn-state teardown
@@ -9068,6 +9087,7 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
     const ea = emissionAuthorityFor(turn)
     ea.markSubstantiveFinalDelivered(() => {
       turn.finalAnswerEverDelivered = true
+      if (turn.finalAnswerDeliveredAt == null) turn.finalAnswerDeliveredAt = Date.now()
     })
     ea.finalizeCard(() => {
       clearActivitySummary(turn)
@@ -9231,6 +9251,7 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
     // Sticky ordering latch (lever 1): set once a SUBSTANTIVE final lands;
     // never cleared by reopen. The card OPEN gate keys on this sticky latch.
     if (turn.finalAnswerSubstantive) turn.finalAnswerEverDelivered = true
+    if (turn.finalAnswerSubstantive && turn.finalAnswerDeliveredAt == null) turn.finalAnswerDeliveredAt = Date.now()
     if (turn.finalAnswerSubstantive) closeObligationOnSubstantiveReply(args, turn, streamRoutedOriginTurn)
     // #1744 follow-up — stream_reply edge case. The first-emit gate at
     // L5178 only clears silent-end state on the FIRST emit of a stream.
@@ -10786,6 +10807,8 @@ async function drainActivitySummary(
   // gate is unaffected. Narrative-SHOW and liveness callers pass their producer
   // explicitly.
   producer: FeedOpenProducer = 'tool',
+  // Optional flags forwarded to `mayOpenActivityCard`.
+  openFlags?: { postAnswerSubagentActivity?: boolean },
 ): Promise<void> {
   try {
     while (turn.activityPendingRender !== turn.activityLastSentRender) {
@@ -10833,6 +10856,7 @@ async function drainActivitySummary(
           finalAnswerEverDelivered: turn.finalAnswerEverDelivered,
           labeledToolCount: turn.labeledToolCount,
           crossTurnAnswerDelivered,
+          postAnswerSubagentActivity: openFlags?.postAnswerSubagentActivity,
         })
       ) {
         break
@@ -10911,23 +10935,52 @@ function feedHeartbeatTick(): void {
   const turn = currentTurn
   if (turn == null) return
   if (turn.finalAnswerDelivered) {
-    // PR1 Item-3a (DORMANT — DEAD by default). Post-answer work is silent today:
-    // once the answer landed the feed has handed off and we return here. When a
-    // future Item-3 decision opts an agent into a "still tidying…" post-answer
-    // liveness line, `SWITCHROOM_POST_ANSWER_LIVENESS_MS>0` is the escape hatch —
-    // it would, past that threshold of post-answer silence, fall through to emit
-    // a guarded liveness EDIT/line here instead of returning. UNSET/0 ⇒ this
-    // branch is never taken and behaviour is byte-identical to today. The actual
-    // surface is intentionally NOT built (no card OPEN, no message) — this is
-    // only the plumbing so enabling it later needs no redesign.
-    if (POST_ANSWER_LIVENESS_MS <= 0) return // default: silent post-answer (today)
-    // `lastToolLabelAt` (set each time a tool step renders) is the closest
-    // existing anchor for "how long has post-answer work been running"; absent
-    // any post-answer tool it stays at the pre-answer value, so the threshold is
-    // only crossed by genuine ongoing work. The Item-3 surface lands here once
-    // decided; until then we stay silent even when the flag is set.
-    const since = turn.lastToolLabelAt != null ? Date.now() - turn.lastToolLabelAt : 0
-    if (since < POST_ANSWER_LIVENESS_MS) return // not yet past the threshold
+    // Fix 2: post-answer background-agent liveness. When the sub-agent/workflow
+    // watcher has surfaced a new step AFTER the substantive final answer, drive
+    // a liveness card so the operator can see "background agent still working".
+    //
+    // Gate: `turn.subagentActivityAt` must be set (watcher fired) AND it must
+    // exceed `turn.finalAnswerDeliveredAt` (the watcher advanced AFTER the answer
+    // was delivered — not just any pre-answer label). This is the key fix:
+    // #2587 read `lastToolLabelAt`, which is frozen by the drop-guard after a
+    // substantive answer and therefore never crosses the threshold. `subagentActivityAt`
+    // is written by the watcher's onProgress callback INDEPENDENTLY of the
+    // tool_label / drop-guard path, so it correctly advances post-answer.
+    //
+    // Idle-gap suppression: when no watcher activity has arrived after the answer
+    // (`subagentActivityAt` is undefined or ≤ finalAnswerDeliveredAt), we return
+    // silently — the reply-is-last invariant is fully preserved for idle turns.
+    const subagentAt = turn.subagentActivityAt
+    const answeredAt = turn.finalAnswerDeliveredAt ?? 0
+    if (subagentAt == null || subagentAt <= answeredAt) return // no post-answer watcher activity → stay silent
+    // A background worker is genuinely active after the answer. Open or maintain
+    // a liveness card below the reply. Route through `mayOpenActivityCard` with
+    // `postAnswerSubagentActivity:true` so Lever 1 is lifted for 'tool' producer
+    // (Fix 2's Lever 1 exception in feed-open-gate.ts). The card renders the
+    // turn's accumulated mirrorLines (which may be empty — in that case the drain
+    // opens a "Working…" placeholder matching the pre-answer liveness path).
+    if (turn.sessionChatId == null) return
+    const age = Date.now() - turn.startedAt
+    const livenessHeader: SessionActivityHeader = {
+      label: 'Agent', elapsedMs: age, toolCount: turn.labeledToolCount, state: 'running',
+    }
+    const lines = turn.mirrorLines.length > 0 ? turn.mirrorLines : ['Working in background…']
+    const elapsed = Date.now() - subagentAt
+    const rendered = renderActivityFeedWithNested(lines, [], false, ` · ${formatFeedElapsed(elapsed)}`, undefined, livenessHeader)
+    if (rendered == null) return
+    turn.activityPendingRender = rendered
+    const ea = emissionAuthorityFor(turn)
+    cardDrainGate(turn, ea, () => {
+    if (ea.mayDrain(turn)) {
+      // Producer 'tool' with postAnswerSubagentActivity=true: the Lever 1
+      // exception allows this OPEN. Lever 4 (cross-turn) and idle-liveness
+      // blocks are still respected by the drain. The card surfaces BELOW the
+      // reply showing the background agent's live activity.
+      ea.openOrEditCard('tool', () => {
+        turn.activityInFlight = drainActivitySummary(turn, 'tool', { postAnswerSubagentActivity: true })
+      })
+    }
+    })
     return
   }
 
@@ -10953,9 +11006,10 @@ function feedHeartbeatTick(): void {
     // PR-4d: route through the centralized chatLock-serialized card-drain gate.
     cardDrainGate(turn, ea, () => {
     if (ea.mayDrain(turn)) {
-      // Producer C (liveness timer): the genuine ≥12s thinking-gap open. This
-      // is the ONE producer that may OPEN a 0-tool card (design §9 lever 5
-      // preserves it). The sticky-latch (lever 1) still gates it in the drain.
+      // Producer C (liveness timer): the genuine ≥12s thinking-gap open. Now
+      // that Lever 5 is inert (narrative may open pre-answer — #2588), liveness
+      // remains the natural open for 0-tool pre-answer turns that are silent.
+      // The sticky-latch (lever 1) still gates it in the drain.
       // PR-4a: routed through the emission-authority façade (no-op delegate).
       ea.openOrEditCard('liveness', () => {
         turn.activityInFlight = drainActivitySummary(turn, 'liveness')
@@ -23740,6 +23794,22 @@ void (async () => {
                     }
                   }
                   return
+                }
+
+                // Fix 2 (post-answer background-agent liveness): when the
+                // watcher surfaces a new step for a background worker, update
+                // the current turn's `subagentActivityAt` timestamp IF the turn
+                // has already delivered its substantive answer. This signal is
+                // written HERE — NOT in the tool_label path — so the drop-guard
+                // (`shouldReopenFeedAfterAck` / finalAnswerSubstantive) cannot
+                // gate it. `feedHeartbeatTick`'s post-answer branch reads
+                // `subagentActivityAt` (not `lastToolLabelAt`, which is frozen
+                // after the answer) to decide whether to open a liveness card.
+                // Only stamp when the turn is alive AND post-answer: pre-answer
+                // activity is already surfaced by the normal tool-label feed.
+                const stampTurn = currentTurn
+                if (stampTurn != null && stampTurn.finalAnswerEverDelivered) {
+                  stampTurn.subagentActivityAt = Date.now()
                 }
 
                 // #PR2 live worker-feed: when ON, the worker's live chat

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -105,7 +105,7 @@ import * as silencePoke from '../silence-poke.js'
 import * as pendingProgress from '../pending-work-progress.js'
 import { writeSilentEndState, clearSilentEndState, recordUndeliveredTurnEnd } from '../silent-end.js'
 import { isFinalAnswerReply, isSubstantiveFinalReply, FINAL_ANSWER_MIN_CHARS } from '../final-answer-detect.js'
-import { deriveTurnRole, decideTerminalReason, parsePostAnswerLivenessMs, type LoopRole } from '../turn-liveness-floor.js'
+import { deriveTurnRole, decideTerminalReason, parsePostAnswerLivenessMs, evaluatePostAnswerLiveness, type LoopRole } from '../turn-liveness-floor.js'
 import { createAnswerStream, type AnswerStreamHandle } from '../answer-stream.js'
 import { parseVisibleAnswerStreamEnabled, resolveAnswerLaneConfig } from '../answer-stream-flag.js'
 import { type SessionEvent } from '../session-tail.js'
@@ -1772,20 +1772,21 @@ const FEED_LIVENESS_OPEN_MS = (() => {
   return Number.isFinite(n) && n > 0 ? n : 12_000
 })()
 
-// PR1 Item-3a (DORMANT escape hatch — see `docs/message-emission-determinism.md`
-// §10 R2 / §9 lever 1: "is silent post-substantive-answer work acceptable, or
-// does it need its own surface?"). Today post-answer work is SILENT by design:
-// lever 1's sticky latch refuses any card OPEN once a substantive final landed,
-// so a long cleanup tool after the answer produces no card. This knob is the
-// plumbing to let a per-agent "still tidying…" liveness line be enabled LATER
-// without a redesign — when/if the Item-3 decision lands on "post-answer work
-// should surface". UNSET or 0 ⇒ exactly today's behaviour (no post-answer card);
-// the guarded branch below is DEAD by default. No behavioural change ships
-// enabled. Parsed once via the pure `parsePostAnswerLivenessMs` helper (whose
-// default-off contract is unit-tested in turn-liveness-floor.test.ts).
-const POST_ANSWER_LIVENESS_MS = parsePostAnswerLivenessMs(
-  process.env.SWITCHROOM_POST_ANSWER_LIVENESS_MS,
-)
+// Post-answer background-agent liveness STALENESS CAP (Fix 2 / #2587 supersede,
+// concern 3). The `feedHeartbeatTick` post-answer branch re-renders a "background
+// agent still working" card every FEED_HEARTBEAT_TICK_MS while the sub-agent
+// watcher keeps advancing `turn.subagentActivityAt`. Without a cap that card kept
+// emitting `state:'running'` with an ever-climbing `elapsed` FOREVER — even after
+// the worker's `onFinish` froze the timestamp — because (unlike the pre-answer
+// path's `FEED_LIVENESS_OPEN_MS` recency cap) the post-answer branch had no
+// staleness bound. This cap mirrors that pre-answer pattern: once the worker's
+// last advance is older than the cap, the heartbeat stops re-rendering and the
+// card freezes at its last state. Parsed via the same pure `parsePostAnswerLivenessMs`
+// helper (positive int or 0); `|| 30_000` supplies a default-ON 30s cap, so an
+// unset env keeps the cap active. Override with SWITCHROOM_POST_ANSWER_LIVENESS_STALE_MS.
+const POST_ANSWER_LIVENESS_STALE_MS = parsePostAnswerLivenessMs(
+  process.env.SWITCHROOM_POST_ANSWER_LIVENESS_STALE_MS,
+) || 30_000
 
 /** Compact mm/ss-ish elapsed for the live feed suffix: "18s", "1m05s". */
 function formatFeedElapsed(ms: number): string {
@@ -10947,12 +10948,26 @@ function feedHeartbeatTick(): void {
     // is written by the watcher's onProgress callback INDEPENDENTLY of the
     // tool_label / drop-guard path, so it correctly advances post-answer.
     //
-    // Idle-gap suppression: when no watcher activity has arrived after the answer
-    // (`subagentActivityAt` is undefined or ≤ finalAnswerDeliveredAt), we return
-    // silently — the reply-is-last invariant is fully preserved for idle turns.
+    // Idle-gap suppression + staleness cap (concern 3) — the single pure decision
+    // `evaluatePostAnswerLiveness`:
+    //   - 'idle'  → no watcher activity after the answer (`subagentActivityAt`
+    //               undefined or ≤ finalAnswerDeliveredAt). Stay silent; the
+    //               reply-is-last invariant is fully preserved for idle turns.
+    //   - 'stale' → the worker's last advance is older than POST_ANSWER_LIVENESS_STALE_MS
+    //               (its `onFinish` froze `subagentActivityAt` and no new step has
+    //               arrived). STOP re-rendering so the card doesn't climb `running`
+    //               forever — mirrors the pre-answer FEED_LIVENESS_OPEN_MS cap. The
+    //               worker's own terminal card (workerActivityFeed.finish) is the
+    //               durable record once it completes.
+    //   - 'emit'  → genuine in-flight post-answer activity; render the card below.
     const subagentAt = turn.subagentActivityAt
-    const answeredAt = turn.finalAnswerDeliveredAt ?? 0
-    if (subagentAt == null || subagentAt <= answeredAt) return // no post-answer watcher activity → stay silent
+    const livenessVerdict = evaluatePostAnswerLiveness({
+      subagentActivityAt: subagentAt,
+      finalAnswerDeliveredAt: turn.finalAnswerDeliveredAt,
+      now: Date.now(),
+      staleCapMs: POST_ANSWER_LIVENESS_STALE_MS,
+    })
+    if (livenessVerdict !== 'emit' || subagentAt == null) return // idle gap or stale worker → stay silent (the `== null` also narrows subagentAt for the elapsed below)
     // A background worker is genuinely active after the answer. Open or maintain
     // a liveness card below the reply. Route through `mayOpenActivityCard` with
     // `postAnswerSubagentActivity:true` so Lever 1 is lifted for 'tool' producer
@@ -23807,6 +23822,21 @@ void (async () => {
                 // after the answer) to decide whether to open a liveness card.
                 // Only stamp when the turn is alive AND post-answer: pre-answer
                 // activity is already surfaced by the normal tool-label feed.
+                //
+                // SCOPE — this is the IN-TURN-WINDOW surface only. The
+                // `feedHeartbeatTick` post-answer card is driven off `currentTurn`,
+                // which `endCurrentTurnAtomic` nulls at `turn_end`. A genuinely
+                // DECOUPLED background worker keeps running PAST the parent
+                // turn's teardown, so `currentTurn` is null when its later
+                // onProgress ticks arrive → this stamp is inert and the
+                // heartbeat is silent for that worker. That is BY DESIGN, not a
+                // gap: a decoupled worker's ongoing activity is surfaced by the
+                // dedicated, currentTurn-independent `workerActivityFeed` (the
+                // edit-in-place worker message, driven below at `workerFeedEnabled`
+                // and bounded by its own non-running/`finish` teardown). So the
+                // currentTurn card covers the brief post-answer/pre-teardown
+                // window; the worker feed covers everything after teardown. Both
+                // are proven in telegram-activity-visibility-integration.test.ts.
                 const stampTurn = currentTurn
                 if (stampTurn != null && stampTurn.finalAnswerEverDelivered) {
                   stampTurn.subagentActivityAt = Date.now()

--- a/telegram-plugin/tests/emission-authority-facade.test.ts
+++ b/telegram-plugin/tests/emission-authority-facade.test.ts
@@ -314,7 +314,7 @@ describe('façade delegates to the existing emission primitives (call-site liter
   })
 })
 
-describe('the 6 drain sites route through the façade with producers preserved verbatim', () => {
+describe('the 7 drain sites route through the façade with producers preserved verbatim', () => {
   it('the narrative SHOW site routes via openOrEditCard("narrative") + the producer-"narrative" drain', () => {
     const body = fnSrc('showNarrativeStep')
     expect(body).toMatch(/openOrEditCard\('narrative'/)
@@ -350,8 +350,8 @@ describe('the 6 drain sites route through the façade with producers preserved v
 
   it('every routed drain site guards the single-flight via ea.mayDrain(turn), not a bare activityInFlight read', () => {
     const mayDrainGuards = [...gatewaySrc.matchAll(/if \(ea\.mayDrain\(turn\)\)/g)]
-    // narrative + 2 liveness + tool + 2 sub-agent = 6 routed single-flight gates.
-    expect(mayDrainGuards).toHaveLength(6)
+    // narrative + 2 liveness + tool + 2 sub-agent + 1 post-answer bg-liveness (Fix 2) = 7.
+    expect(mayDrainGuards).toHaveLength(7)
   })
 })
 
@@ -478,10 +478,11 @@ describe('mayDrainCardNow — PR-4d card-drain gate (pure read; gateway holds th
     expect(ctxFn).toMatch(/turnInFlight:\s*turnInFlightForGate\(\)/)
   })
 
-  it('the 6 card-drain sites each route their guarded block through cardDrainGate (single-flight gate stays byte-identical)', () => {
-    // Option A: the 6 `if (ea.mayDrain(turn))` guards + drainActivitySummary
+  it('the 7 card-drain sites each route their guarded block through cardDrainGate (single-flight gate stays byte-identical)', () => {
+    // Option A: the 7 `if (ea.mayDrain(turn))` guards + drainActivitySummary
     // thunks stay byte-identical, wrapped by the centralized helper.
+    // 6 original + 1 new post-answer background-agent liveness drain (Fix 2).
     const wraps = [...gatewaySrc.matchAll(/cardDrainGate\(turn, ea, \(\) => \{/g)]
-    expect(wraps).toHaveLength(6)
+    expect(wraps).toHaveLength(7)
   })
 })

--- a/telegram-plugin/tests/emission-determinism-wiring.test.ts
+++ b/telegram-plugin/tests/emission-determinism-wiring.test.ts
@@ -155,7 +155,9 @@ describe('lever 2 — finalize the card BEFORE a substantive reply send', () => 
     expect(clearIdx).toBeGreaterThan(-1)
     expect(sendIdx).toBeGreaterThan(-1)
     expect(clearIdx).toBeLessThan(sendIdx)
-    const window = src.slice(Math.max(0, clearIdx - 500), clearIdx)
+    // Window extended to 600 chars to account for the finalAnswerDeliveredAt stamp
+    // added inside the markSubstantiveFinalDelivered callback (Fix 2 / #2587).
+    const window = src.slice(Math.max(0, clearIdx - 600), clearIdx)
     expect(window).toMatch(/isSubstantiveFinalReply/)
   })
 

--- a/telegram-plugin/tests/feed-heartbeat-liveness-open.test.ts
+++ b/telegram-plugin/tests/feed-heartbeat-liveness-open.test.ts
@@ -4,11 +4,13 @@
  * Pins load-bearing constraints of the branches inside `feedHeartbeatTick`
  * (gateway.ts):
  *
- * Post-answer branch (Fix 2 / #2587 supersede):
+ * Post-answer branch (Fix 2 / #2587 supersede, concern 3 staleness cap):
  *   - `turn.subagentActivityAt` is the signal (NOT `lastToolLabelAt`) that
  *     drives post-answer liveness — the watcher updates this independently of
  *     the tool_label / drop-guard path.
- *   - Idle-gap suppression: `subagentActivityAt <= finalAnswerDeliveredAt` → silent.
+ *   - The idle-gap suppression AND the staleness cap are a single pure decision
+ *     `evaluatePostAnswerLiveness(...)` consulted each tick, with the cap fed
+ *     from `POST_ANSWER_LIVENESS_STALE_MS`.
  *
  * Pre-answer liveness-open branch:
  *   1. The SWITCHROOM_FEED_LIVENESS_OPEN kill-switch (default ON, i.e. `!== '0'`)
@@ -94,10 +96,10 @@ describe('H-1: feedHeartbeatTick liveness-open threshold', () => {
   })
 })
 
-describe('H-2: feedHeartbeatTick post-answer background-agent liveness (Fix 2 / #2587 supersede)', () => {
+describe('H-2: feedHeartbeatTick post-answer background-agent liveness (Fix 2 / #2587 supersede, concern 3 cap)', () => {
   // Structural assertions pinning Fix 2: the post-answer branch reads
-  // `turn.subagentActivityAt` (not `lastToolLabelAt`) and guards on
-  // `subagentActivityAt <= finalAnswerDeliveredAt` for idle-gap suppression.
+  // `turn.subagentActivityAt` (not `lastToolLabelAt`) and routes the idle-gap +
+  // staleness decision through the pure `evaluatePostAnswerLiveness` helper.
 
   it('post-answer branch reads subagentActivityAt (the watcher signal)', () => {
     const body = feedHeartbeatTickSrc()
@@ -110,12 +112,26 @@ describe('H-2: feedHeartbeatTick post-answer background-agent liveness (Fix 2 / 
     expect(postAnswerBlock).toMatch(/const\s+subagentAt\s*=\s*turn\.subagentActivityAt/)
   })
 
-  it('idle-gap suppression: no post-answer card when subagentActivityAt is null/before answer', () => {
+  it('idle-gap + staleness cap routed through evaluatePostAnswerLiveness with the stale cap', () => {
     const body = feedHeartbeatTickSrc()
     const afterPostAnswer = body.split('if (turn.finalAnswerDelivered)')[1] ?? ''
     const postAnswerBlock = afterPostAnswer.split('\n  }\n')[0] ?? ''
-    // Must guard: subagentAt == null || subagentAt <= answeredAt → return (silent)
-    expect(postAnswerBlock).toMatch(/subagentAt\s*==\s*null\s*\|\|\s*subagentAt\s*<=\s*answeredAt/)
+    // The single pure decision is consulted, fed the staleness cap, and a
+    // non-'emit' verdict returns early (silent).
+    expect(postAnswerBlock).toMatch(/evaluatePostAnswerLiveness\(/)
+    expect(postAnswerBlock).toMatch(/staleCapMs:\s*POST_ANSWER_LIVENESS_STALE_MS/)
+    expect(postAnswerBlock).toMatch(/livenessVerdict\s*!==\s*'emit'/)
+  })
+
+  it('staleness cap (concern 3) is parsed default-ON (30s) from SWITCHROOM_POST_ANSWER_LIVENESS_STALE_MS', () => {
+    // The cap const must default to 30_000 when the env is unset (the `|| 30_000`
+    // fallback over the positive-or-0 parse) so the post-answer card stops
+    // climbing once the worker goes stale, even with no operator config.
+    const afterConst = gatewaySrc.split('const POST_ANSWER_LIVENESS_STALE_MS')[1] ?? ''
+    const initBlock = afterConst.split('\n')[0] + (afterConst.split('||')[1] ?? '')
+    expect(afterConst).toMatch(/SWITCHROOM_POST_ANSWER_LIVENESS_STALE_MS/)
+    expect(afterConst).toMatch(/\|\|\s*30[_]?000/)
+    expect(initBlock).toBeTruthy()
   })
 
   it('post-answer drain uses tool producer + postAnswerSubagentActivity flag', () => {

--- a/telegram-plugin/tests/feed-heartbeat-liveness-open.test.ts
+++ b/telegram-plugin/tests/feed-heartbeat-liveness-open.test.ts
@@ -1,18 +1,24 @@
 /**
- * H-1: feedHeartbeatTick liveness-open threshold — structural assertions.
+ * H-1: feedHeartbeatTick structural assertions.
  *
- * Pins three load-bearing constraints of the "liveness-open" branch inside
- * `feedHeartbeatTick` (gateway.ts):
+ * Pins load-bearing constraints of the branches inside `feedHeartbeatTick`
+ * (gateway.ts):
  *
+ * Post-answer branch (Fix 2 / #2587 supersede):
+ *   - `turn.subagentActivityAt` is the signal (NOT `lastToolLabelAt`) that
+ *     drives post-answer liveness — the watcher updates this independently of
+ *     the tool_label / drop-guard path.
+ *   - Idle-gap suppression: `subagentActivityAt <= finalAnswerDeliveredAt` → silent.
+ *
+ * Pre-answer liveness-open branch:
  *   1. The SWITCHROOM_FEED_LIVENESS_OPEN kill-switch (default ON, i.e. `!== '0'`)
  *      gates the liveness-open path — operators can disable it with =0.
  *   2. FEED_LIVENESS_OPEN_MS is parsed from env with a sane default (12 000 ms).
- *   3. The `age < FEED_LIVENESS_OPEN_MS` return-guard fires BEFORE the feed opens —
- *      a turn that hasn't yet passed the threshold returns early and the liveness
- *      feed stays closed.
+ *   3. The `age < FEED_LIVENESS_OPEN_MS` return-guard fires BEFORE the 0-tool
+ *      feed opens — a turn that hasn't yet passed the threshold returns early.
  *
  * These are STRUCTURAL (source-read) assertions; the gateway IIFE can't be
- * instantiated in-process.  Pattern matches silence-liveness-wiring.test.ts.
+ * instantiated in-process. Pattern matches silence-liveness-wiring.test.ts.
  */
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
@@ -28,6 +34,23 @@ function feedHeartbeatTickSrc(): string {
   const after = gatewaySrc.split('function feedHeartbeatTick(): void {')[1] ?? ''
   // Stop at the next top-level function definition.
   return after.split('\nfunction ')[0] ?? after
+}
+
+/**
+ * Extract the 0-tool liveness-open branch: the section from
+ * `if (turn.mirrorLines.length === 0)` to its closing `return`. This scopes
+ * the FEED_LIVENESS_OPEN_ENABLED and age-guard assertions to the correct branch
+ * (the post-answer Fix-2 block now precedes it and also has a drain call).
+ */
+function liveness0ToolBranchSrc(): string {
+  const body = feedHeartbeatTickSrc()
+  const start = body.indexOf('if (turn.mirrorLines.length === 0)')
+  if (start === -1) return ''
+  // Capture until the closing `return\n  }` of this if-block (the next blank-line-terminated return).
+  const after = body.slice(start)
+  // Take up to the labelled-feed heartbeat comment that follows.
+  const end = after.indexOf('// Labelled-feed heartbeat')
+  return end === -1 ? after : after.slice(0, end)
 }
 
 describe('H-1: feedHeartbeatTick liveness-open threshold', () => {
@@ -47,26 +70,61 @@ describe('H-1: feedHeartbeatTick liveness-open threshold', () => {
     expect(initBlock).toMatch(/12[_]?000/)
   })
 
-  it('age < FEED_LIVENESS_OPEN_MS return-guard exists inside feedHeartbeatTick', () => {
-    const body = feedHeartbeatTickSrc()
-    expect(body).toMatch(/if\s*\(age\s*<\s*FEED_LIVENESS_OPEN_MS\)\s*return/)
+  it('age < FEED_LIVENESS_OPEN_MS return-guard exists inside the 0-tool liveness branch', () => {
+    const branch = liveness0ToolBranchSrc()
+    expect(branch).toMatch(/if\s*\(age\s*<\s*FEED_LIVENESS_OPEN_MS\)\s*return/)
   })
 
-  it('FEED_LIVENESS_OPEN_ENABLED check precedes the drainActivitySummary call in feedHeartbeatTick', () => {
-    const body = feedHeartbeatTickSrc()
-    const enabledIdx = body.indexOf('FEED_LIVENESS_OPEN_ENABLED')
+  it('FEED_LIVENESS_OPEN_ENABLED check precedes the drain call in the 0-tool liveness branch', () => {
+    const branch = liveness0ToolBranchSrc()
+    const enabledIdx = branch.indexOf('FEED_LIVENESS_OPEN_ENABLED')
     // Use the actual call site (assignment to activityInFlight) not the comment mention.
-    const drainCallIdx = body.indexOf('turn.activityInFlight = drainActivitySummary')
+    const drainCallIdx = branch.indexOf('turn.activityInFlight = drainActivitySummary')
     expect(enabledIdx).toBeGreaterThan(-1)
     expect(drainCallIdx).toBeGreaterThan(enabledIdx)
   })
 
-  it('age < FEED_LIVENESS_OPEN_MS guard precedes the drainActivitySummary call (early-return before open)', () => {
-    const body = feedHeartbeatTickSrc()
-    const guardIdx = body.indexOf('age < FEED_LIVENESS_OPEN_MS')
+  it('age < FEED_LIVENESS_OPEN_MS guard precedes the drain call in the 0-tool branch (early-return)', () => {
+    const branch = liveness0ToolBranchSrc()
+    const guardIdx = branch.indexOf('age < FEED_LIVENESS_OPEN_MS')
     // Use the actual call site (assignment to activityInFlight) not the comment mention.
-    const drainCallIdx = body.indexOf('turn.activityInFlight = drainActivitySummary')
+    const drainCallIdx = branch.indexOf('turn.activityInFlight = drainActivitySummary')
     expect(guardIdx).toBeGreaterThan(-1)
     expect(drainCallIdx).toBeGreaterThan(guardIdx)
+  })
+})
+
+describe('H-2: feedHeartbeatTick post-answer background-agent liveness (Fix 2 / #2587 supersede)', () => {
+  // Structural assertions pinning Fix 2: the post-answer branch reads
+  // `turn.subagentActivityAt` (not `lastToolLabelAt`) and guards on
+  // `subagentActivityAt <= finalAnswerDeliveredAt` for idle-gap suppression.
+
+  it('post-answer branch reads subagentActivityAt (the watcher signal)', () => {
+    const body = feedHeartbeatTickSrc()
+    // The post-answer block starts with `if (turn.finalAnswerDelivered)`
+    const afterPostAnswer = body.split('if (turn.finalAnswerDelivered)')[1] ?? ''
+    // Extract up to the closing return of that block
+    const postAnswerBlock = afterPostAnswer.split('\n  }\n')[0] ?? ''
+    // subagentActivityAt must appear as a live variable (not just in a comment)
+    // — verified by the `const subagentAt = turn.subagentActivityAt` assignment.
+    expect(postAnswerBlock).toMatch(/const\s+subagentAt\s*=\s*turn\.subagentActivityAt/)
+  })
+
+  it('idle-gap suppression: no post-answer card when subagentActivityAt is null/before answer', () => {
+    const body = feedHeartbeatTickSrc()
+    const afterPostAnswer = body.split('if (turn.finalAnswerDelivered)')[1] ?? ''
+    const postAnswerBlock = afterPostAnswer.split('\n  }\n')[0] ?? ''
+    // Must guard: subagentAt == null || subagentAt <= answeredAt → return (silent)
+    expect(postAnswerBlock).toMatch(/subagentAt\s*==\s*null\s*\|\|\s*subagentAt\s*<=\s*answeredAt/)
+  })
+
+  it('post-answer drain uses tool producer + postAnswerSubagentActivity flag', () => {
+    const body = feedHeartbeatTickSrc()
+    const afterPostAnswer = body.split('if (turn.finalAnswerDelivered)')[1] ?? ''
+    const postAnswerBlock = afterPostAnswer.split('\n  }\n')[0] ?? ''
+    // Must pass postAnswerSubagentActivity: true to drainActivitySummary
+    expect(postAnswerBlock).toMatch(/postAnswerSubagentActivity:\s*true/)
+    // Must use 'tool' producer for the Lever 1 exception
+    expect(postAnswerBlock).toMatch(/'tool'/)
   })
 })

--- a/telegram-plugin/tests/feed-open-gate.test.ts
+++ b/telegram-plugin/tests/feed-open-gate.test.ts
@@ -4,32 +4,40 @@ import { mayOpenActivityCard } from '../gateway/feed-open-gate.js'
 
 /**
  * Feed-OPEN gate — pure decision (design `docs/message-emission-determinism.md`
- * §9 levers 1 + 5). Gates WHEN the activity card may first OPEN (fresh
+ * §9 levers 1 + 4). Gates WHEN the activity card may first OPEN (fresh
  * sendMessage). An EDIT of an already-open card is never routed through this
  * (the drain only consults it when activityMessageId == null).
  *
- * Lever 5 base case (the triplication fix): a narrative-SHOW producer alone on
- * a 0-tool turn must NOT open a card. A tool label DOES open. The liveness
- * timer (genuine ≥12s thinking-gap) still opens a 0-tool card.
+ * Lever 5 — INERT (#2588 fix): the original Lever 5 blocked narrative from
+ * opening a card on 0-tool turns to prevent a "triplication" reorder. This
+ * over-suppressed conversational turns. Lever 2 (clearActivitySummary, gateway
+ * executeReply) already guarantees reply-is-last ordering by editing the
+ * narrative card in-place before the reply sends — Lever 5 was redundant.
+ * Pre-answer narrative now DOES open a card; post-answer is blocked by Lever 1.
  *
  * Lever 1 (reply-is-last): once a SUBSTANTIVE final answer has been delivered
  * (the sticky finalAnswerEverDelivered latch), no card may open below it — for
- * ANY producer. The latch is NOT the mutable finalAnswerDelivered (reopen
- * clears that mid-turn, #2141); an ack does not set it, so the ack-then-work
- * feed still opens.
+ * ANY producer, EXCEPT when `postAnswerSubagentActivity === true && producer ===
+ * 'tool'` (Fix 2 / #2587 supersede: background-agent liveness below the reply).
+ * The latch is NOT the mutable finalAnswerDelivered (reopen clears that
+ * mid-turn, #2141); an ack does not set it, so the ack-then-work feed opens.
  */
-describe('mayOpenActivityCard — lever 5 base case (narrative-SHOW alone must not OPEN)', () => {
-  it('narrative SHOW on a 0-tool turn does NOT open a card (the triplication)', () => {
+describe('mayOpenActivityCard — Lever 5 INERT: narrative opens pre-answer (Fix 1 / #2588)', () => {
+  it('narrative SHOW on a 0-tool turn DOES open a card pre-answer (Lever 5 removed)', () => {
+    // Lever 5 was: producer === "narrative" && labeledToolCount === 0 → false.
+    // Now it is INERT: pre-answer narrative may open. Lever 2 (clearActivitySummary)
+    // guarantees the card edits in-place before the reply sends — reply-is-last
+    // is preserved without Lever 5. This is the #2588 fix.
     expect(
       mayOpenActivityCard({
         producer: 'narrative',
         finalAnswerEverDelivered: false,
         labeledToolCount: 0,
       }),
-    ).toBe(false)
+    ).toBe(true)
   })
 
-  it('a tool label DOES open a card (producer B)', () => {
+  it('a tool label DOES open a card (producer B, unchanged)', () => {
     expect(
       mayOpenActivityCard({
         producer: 'tool',
@@ -39,7 +47,7 @@ describe('mayOpenActivityCard — lever 5 base case (narrative-SHOW alone must n
     ).toBe(true)
   })
 
-  it('the liveness timer DOES open a 0-tool thinking-gap card (producer C, preserved)', () => {
+  it('the liveness timer DOES open a 0-tool thinking-gap card (producer C, unchanged)', () => {
     expect(
       mayOpenActivityCard({
         producer: 'liveness',
@@ -104,6 +112,67 @@ describe('mayOpenActivityCard — lever 1 (no OPEN after a substantive final)', 
         labeledToolCount: 1,
       }),
     ).toBe(true)
+  })
+})
+
+describe('mayOpenActivityCard — lever 1 exception: post-answer sub-agent liveness (Fix 2 / #2587 supersede)', () => {
+  // When a background sub-agent continues working after the parent's substantive
+  // reply, `postAnswerSubagentActivity=true` + `producer='tool'` lifts Lever 1
+  // so the heartbeat can open a liveness card below the reply. This signal is
+  // driven by `turn.subagentActivityAt`, written by the watcher's onProgress
+  // callback INDEPENDENTLY of the tool_label path (so the drop-guard cannot gate
+  // it). Idle producers (liveness, narrative) remain blocked — the reply-is-last
+  // invariant holds for idle post-answer gaps.
+
+  it('post-answer REAL sub-agent activity DOES open a card (tool + postAnswerSubagentActivity)', () => {
+    // The core Fix 2 assertion: a background worker is still active after the
+    // answer → a liveness card surfaces below the reply.
+    expect(
+      mayOpenActivityCard({
+        producer: 'tool',
+        finalAnswerEverDelivered: true,
+        labeledToolCount: 3,
+        postAnswerSubagentActivity: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('post-answer idle liveness does NOT open (no postAnswerSubagentActivity)', () => {
+    // Without the signal, Lever 1 stays fully active — idle heartbeat after the
+    // answer is still suppressed. Idle-gap suppression preserved.
+    expect(
+      mayOpenActivityCard({
+        producer: 'tool',
+        finalAnswerEverDelivered: true,
+        labeledToolCount: 3,
+        postAnswerSubagentActivity: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('post-answer liveness producer stays blocked even with the signal (not tool producer)', () => {
+    // Only 'tool' is exempted. A 'liveness' producer (wall-clock heartbeat
+    // with no new watcher step) may not open a card after the final answer.
+    expect(
+      mayOpenActivityCard({
+        producer: 'liveness',
+        finalAnswerEverDelivered: true,
+        labeledToolCount: 0,
+        postAnswerSubagentActivity: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('post-answer narrative producer stays blocked even with the signal', () => {
+    // Narrative alone after the final answer may not open — reply-is-last.
+    expect(
+      mayOpenActivityCard({
+        producer: 'narrative',
+        finalAnswerEverDelivered: true,
+        labeledToolCount: 2,
+        postAnswerSubagentActivity: true,
+      }),
+    ).toBe(false)
   })
 })
 

--- a/telegram-plugin/tests/subagent-watcher-clip-narrative.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-clip-narrative.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import { clipNarrative } from '../tool-activity-summary.js'
 
-// subagent-watcher.ts now routes its narrative clip through the shared
-// `clipNarrative` primitive (replacing the inline
-// `ev.text.split('\n')[0].trim().slice(0, 120)`), so the watcher and the
-// gateway narrative-step path collapse multi-line text identically. These
-// tests pin that shared contract: first line only, trimmed, ≤ 120 chars.
+// `clipNarrative` is the shared narrative-clip primitive used by both the
+// main-agent gateway path (showNarrativeStep) and the sub-agent watcher. It
+// collapses multi-line text to the first line, trims, and slices to 200 chars
+// (= STATUS_LINE_MAX). Fix 1 raised the cap from 120 → 200 to match the tool-
+// label cap so a narrative line reads as legibly as a tool step (no
+// mid-sentence truncation on typical agent narration lengths of 130–180 chars).
 
 describe('clipNarrative — shared subagent-watcher narrative clip', () => {
   it('collapses a multi-line block to its first line', () => {
@@ -17,29 +18,41 @@ describe('clipNarrative — shared subagent-watcher narrative clip', () => {
     expect(clipNarrative('   Found both repos:   \nmore')).toBe('Found both repos:')
   })
 
-  it('caps the first line at 120 characters', () => {
-    const long = 'x'.repeat(200)
+  it('caps the first line at 200 characters (Fix 1: raised from 120 to match STATUS_LINE_MAX)', () => {
+    // 200-char cap: a 250-char first line is clipped at exactly 200.
+    const long = 'x'.repeat(250)
     const out = clipNarrative(long)
-    expect(out.length).toBe(120)
-    expect(out).toBe('x'.repeat(120))
+    expect(out.length).toBe(200)
+    expect(out).toBe('x'.repeat(200))
   })
 
-  it('a first line under 120 chars is returned verbatim', () => {
+  it('a first line under 200 chars is returned verbatim', () => {
     expect(clipNarrative('short narrative line')).toBe('short narrative line')
   })
 
-  it('matches the old inline expression exactly (regression equivalence)', () => {
+  it('a narrative between 120 and 200 chars is NOT truncated (the Fix 1 improvement)', () => {
+    // Before Fix 1 the 120-char clip truncated typical 130–180 char agent narration.
+    // After Fix 1 these are returned in full up to 200 chars.
+    const narrative = 'I will now analyse all 30 changed files in /src/auth to understand the scope before patching the vulnerable token-parsing code path'
+    expect(narrative.length).toBeGreaterThan(120)
+    expect(narrative.length).toBeLessThanOrEqual(200)
+    expect(clipNarrative(narrative)).toBe(narrative) // not truncated
+  })
+
+  it('matches the new 200-char cap expression (STATUS_LINE_MAX equivalence)', () => {
+    const STATUS_LINE_MAX = 200
     const samples = [
       'line one\nline two',
       '   padded   \nrest',
       'a'.repeat(150),
+      'b'.repeat(250),
       'single',
       '',
       'tab\tand spaces  \nnext',
     ]
     for (const s of samples) {
-      const inline = s.split('\n')[0].trim().slice(0, 120)
-      expect(clipNarrative(s)).toBe(inline)
+      const expected = s.split('\n')[0].trim().slice(0, STATUS_LINE_MAX)
+      expect(clipNarrative(s)).toBe(expected)
     }
   })
 })

--- a/telegram-plugin/tests/telegram-activity-visibility-integration.test.ts
+++ b/telegram-plugin/tests/telegram-activity-visibility-integration.test.ts
@@ -6,14 +6,20 @@
  *
  * This test exercises the REAL code paths — not injected state:
  *
- * Fix 2 (post-answer background-agent liveness):
- *   - The actual `startSubagentWatcher` with a real fs mock drives `onProgress`.
- *   - `onProgress` fires for a background worker AFTER the turn has delivered
- *     its substantive answer → verifies `turn.subagentActivityAt` is stamped.
- *   - `mayOpenActivityCard` (the real gate function) is called with the resulting
- *     signal → verifies a liveness card is allowed.
- *   - Idle companion: no watcher activity → gate blocks → no card (idle-gap
- *     suppression preserved).
+ * Fix 2 (post-answer background-agent liveness) — drives the REAL code paths:
+ *   - The actual `startSubagentWatcher` with a real fs mock drives `onProgress`,
+ *     which stamps `turn.subagentActivityAt` (the gateway's one-line stamp,
+ *     gated exactly as gateway.ts gates it on a non-null currentTurn).
+ *   - The REAL `mayOpenActivityCard` AND the REAL `evaluatePostAnswerLiveness`
+ *     (the helper feedHeartbeatTick consults each tick) decide the verdict — not
+ *     a re-implemented copy of the gate.
+ *   - Concern 2 lifecycle: the gateway's `currentTurn` gating is modelled
+ *     verbatim to prove the stamp + heartbeat EMIT in the post-answer/pre-teardown
+ *     window but are INERT once `currentTurn` nulls at turn_end — and that the
+ *     decoupled worker still surfaces (and is bounded) via the real,
+ *     currentTurn-independent `workerActivityFeed`.
+ *   - Concern 3: the staleness cap flips the verdict to 'stale' once the worker's
+ *     last advance is older than the cap, so the card stops climbing forever.
  *
  * Fix 1 (narrative as first-class feed lines):
  *   - `clipNarrative` is called on a long narrative string → verifies 200-char
@@ -31,13 +37,16 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync } from 'fs'
-import { tmpdir } from 'os'
-import { join } from 'path'
 import * as realFs from 'fs'
 import { startSubagentWatcher } from '../subagent-watcher.js'
 import { mayOpenActivityCard } from '../gateway/feed-open-gate.js'
 import { clipNarrative, appendActivityLabel } from '../tool-activity-summary.js'
+import { evaluatePostAnswerLiveness } from '../turn-liveness-floor.js'
+import {
+  createWorkerActivityFeed,
+  type WorkerActivityView,
+  type BotApiForWorkerFeed,
+} from '../worker-activity-feed.js'
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -78,10 +87,16 @@ describe('Fix 2: post-answer background-agent liveness (watcher → gate → liv
     // The parent answered at time 1000; we are now at 1500 (post-answer).
     const turn = {
       finalAnswerEverDelivered: true,
+      finalAnswerDelivered: true,
       finalAnswerDeliveredAt: 1000,
       subagentActivityAt: undefined as number | undefined,
       labeledToolCount: 2,
     }
+    // Model the gateway's module-scope `currentTurn` mirror so the test can
+    // reproduce its lifecycle: non-null in the post-answer/pre-teardown window,
+    // nulled at `endCurrentTurnAtomic` (turn_end). The onProgress stamp and the
+    // heartbeat both read THIS — the crux of concern 2.
+    let currentTurn: typeof turn | null = turn
 
     // --- Wire up the REAL startSubagentWatcher with mock fs ---
     // Pattern: start with an EMPTY subagents dir so the boot scan finds nothing
@@ -162,11 +177,15 @@ describe('Fix 2: post-answer background-agent liveness (watcher → gate → liv
       fs: mockFs,
       onProgress: ({ agentId, latestSummary }) => {
         progressEvents.push({ agentId, latestSummary })
-        // This is the EXACT gateway.ts logic (Fix 2's `stampTurn.subagentActivityAt = Date.now()`):
-        // onProgress fires → if the turn has already delivered its substantive
-        // answer → stamp subagentActivityAt with the current time.
-        if (turn.finalAnswerEverDelivered) {
-          turn.subagentActivityAt = currentTime
+        // Mirror ONLY the gateway's one-line stamp (`stampTurn.subagentActivityAt
+        // = Date.now()`), gated exactly as gateway.ts gates it: `currentTurn !=
+        // null && finalAnswerEverDelivered`. The DECISION the heartbeat then
+        // makes off this signal is NOT re-implemented here — the test drives the
+        // REAL `evaluatePostAnswerLiveness` helper below (concern 1/2: drive the
+        // real code path, not a copy of the gate).
+        const stampTurn = currentTurn // gateway: `const stampTurn = currentTurn`
+        if (stampTurn != null && stampTurn.finalAnswerEverDelivered) {
+          stampTurn.subagentActivityAt = currentTime
         }
       },
       log: () => {},
@@ -218,39 +237,256 @@ describe('Fix 2: post-answer background-agent liveness (watcher → gate → liv
       // postAnswerSubagentActivity omitted → old Lever 1 block (was the bug in #2587)
     })
     expect(blockedWithoutFix).toBe(false)
+
+    // --- Drive the REAL feedHeartbeatTick decision helper (not a re-impl) ---
+    // The heartbeat reads `currentTurn`; in this post-answer/pre-teardown window
+    // it is still non-null AND just-stamped, so the REAL `evaluatePostAnswerLiveness`
+    // returns 'emit' → the liveness card renders. (Concern 2 (a): the stamp fires
+    // and the card renders while the turn is alive.)
+    expect(currentTurn).not.toBeNull()
+    const verdictInWindow = evaluatePostAnswerLiveness({
+      subagentActivityAt: currentTurn!.subagentActivityAt,
+      finalAnswerDeliveredAt: currentTurn!.finalAnswerDeliveredAt,
+      now: currentTime + 5, // a heartbeat tick moments after the stamp
+      staleCapMs: 30_000,
+    })
+    expect(verdictInWindow).toBe('emit')
   })
 
-  it('idle post-answer (no new watcher activity) → gate blocks → no liveness card (idle-gap suppression)', () => {
-    // When subagentActivityAt is undefined (no watcher activity since the answer),
-    // the heartbeat's idle-gap check catches it and the gate is never called.
-    // Verify the gate also refuses (Lever 1 with no exception).
-    const blocked = mayOpenActivityCard({
-      producer: 'tool',
-      finalAnswerEverDelivered: true,
-      labeledToolCount: 1,
-      postAnswerSubagentActivity: false, // no watcher activity
+  it('idle post-answer (no watcher activity) → evaluatePostAnswerLiveness returns "idle" → silent', () => {
+    // When subagentActivityAt is undefined (no watcher activity since the answer)
+    // the REAL heartbeat decision returns 'idle' → the post-answer branch returns
+    // early and no card opens. The reply-is-last invariant holds for idle turns.
+    const verdict = evaluatePostAnswerLiveness({
+      subagentActivityAt: undefined,
+      finalAnswerDeliveredAt: 1000,
+      now: 50_000,
+      staleCapMs: 30_000,
     })
-    expect(blocked).toBe(false)
+    expect(verdict).toBe('idle')
   })
 
-  it('subagentActivityAt before finalAnswerDeliveredAt → treated as pre-answer, gate blocks', () => {
-    // Simulate the idle-gap guard in feedHeartbeatTick:
-    // if (subagentAt == null || subagentAt <= answeredAt) return
-    // Here the signal is set but it's from before the answer (shouldn't happen
-    // in practice, but defense in depth).
-    const subagentAt = 500
-    const answeredAt = 1000
-    const isPostAnswer = subagentAt != null && subagentAt > answeredAt
-    expect(isPostAnswer).toBe(false) // guard fires → silent
+  it('subagentActivityAt at/before the answer → "idle" (pre-answer label never opens a post-answer card)', () => {
+    expect(
+      evaluatePostAnswerLiveness({
+        subagentActivityAt: 500,
+        finalAnswerDeliveredAt: 1000,
+        now: 1500,
+        staleCapMs: 30_000,
+      }),
+    ).toBe('idle')
+  })
+})
 
-    // And the gate also blocks without the explicit postAnswerSubagentActivity flag
-    const blocked = mayOpenActivityCard({
-      producer: 'tool',
-      finalAnswerEverDelivered: true,
-      labeledToolCount: 2,
-      postAnswerSubagentActivity: isPostAnswer,
+// ─── Fix 2 — concern 2: the currentTurn path is INERT after teardown ─────────
+
+describe('Fix 2 / concern 2: currentTurn nulls at turn_end → heartbeat path inert; worker feed covers it', () => {
+  /**
+   * The reviewer's concern: the post-answer liveness fix stamps + renders off
+   * `currentTurn`, which `endCurrentTurnAtomic` nulls at `turn_end`. A genuinely
+   * DECOUPLED background worker keeps ticking PAST teardown, so when its later
+   * onProgress arrives `currentTurn` is null → the stamp is inert and the
+   * heartbeat (which early-returns `if (turn == null) return`) is silent.
+   *
+   * This test reproduces that lifecycle EXACTLY (the gateway's `currentTurn`
+   * gating, which can't be imported, modelled verbatim) and proves:
+   *   (a) in the post-answer/pre-teardown window the stamp fires and the REAL
+   *       `evaluatePostAnswerLiveness` returns 'emit';
+   *   (b) after teardown (`currentTurn = null`) a later worker tick CANNOT stamp
+   *       and the heartbeat is structurally silent — i.e. the currentTurn fix IS
+   *       inert for a decoupled worker, as suspected.
+   * The follow-on `describe` then proves the decoupled worker still surfaces via
+   * the currentTurn-INDEPENDENT `workerActivityFeed` (the by-design coverage).
+   */
+
+  // The gateway's stamp, verbatim (the only line we can't import): gated on a
+  // non-null currentTurn that has delivered its substantive answer.
+  function gatewayStamp(currentTurn: { finalAnswerEverDelivered: boolean; subagentActivityAt?: number } | null, now: number): void {
+    const stampTurn = currentTurn
+    if (stampTurn != null && stampTurn.finalAnswerEverDelivered) {
+      stampTurn.subagentActivityAt = now
+    }
+  }
+
+  // The gateway's feedHeartbeatTick post-answer entry, reduced to its decision:
+  // `if (turn == null) return` (no-turn), else the REAL evaluatePostAnswerLiveness.
+  function heartbeatVerdict(
+    currentTurn: { finalAnswerDelivered: boolean; finalAnswerDeliveredAt?: number; subagentActivityAt?: number } | null,
+    now: number,
+  ): 'no-turn' | 'pre-answer' | ReturnType<typeof evaluatePostAnswerLiveness> {
+    const turn = currentTurn
+    if (turn == null) return 'no-turn' // gateway: `if (turn == null) return`
+    if (!turn.finalAnswerDelivered) return 'pre-answer'
+    return evaluatePostAnswerLiveness({
+      subagentActivityAt: turn.subagentActivityAt,
+      finalAnswerDeliveredAt: turn.finalAnswerDeliveredAt,
+      now,
+      staleCapMs: 30_000,
     })
-    expect(blocked).toBe(false)
+  }
+
+  it('(a) in-window: currentTurn alive → stamp fires and heartbeat emits', () => {
+    const turn = {
+      finalAnswerEverDelivered: true,
+      finalAnswerDelivered: true,
+      finalAnswerDeliveredAt: 1000,
+      subagentActivityAt: undefined as number | undefined,
+    }
+    let currentTurn: typeof turn | null = turn
+
+    // Worker ticks at t=1600, still inside the turn (pre-teardown).
+    gatewayStamp(currentTurn, 1600)
+    expect(turn.subagentActivityAt).toBe(1600)
+    expect(heartbeatVerdict(currentTurn, 1605)).toBe('emit')
+  })
+
+  it('(b) post-teardown: currentTurn nulled → later worker tick cannot stamp; heartbeat is silent (INERT)', () => {
+    const turn = {
+      finalAnswerEverDelivered: true,
+      finalAnswerDelivered: true,
+      finalAnswerDeliveredAt: 1000,
+      subagentActivityAt: undefined as number | undefined,
+    }
+    let currentTurn: typeof turn | null = turn
+
+    // turn_end fires → endCurrentTurnAtomic nulls the module-scope mirror.
+    currentTurn = null
+
+    // The DECOUPLED worker keeps running and ticks much later (t=120_000).
+    gatewayStamp(currentTurn, 120_000)
+    // Nothing to stamp — the turn object is unreferenced by the live mirror.
+    expect(turn.subagentActivityAt).toBeUndefined()
+    // And the heartbeat is structurally silent: no live turn to render on.
+    expect(heartbeatVerdict(currentTurn, 120_005)).toBe('no-turn')
+  })
+
+  it('concern 3: while the turn is alive but the worker went stale, heartbeat stops ("stale")', () => {
+    const turn = {
+      finalAnswerDelivered: true,
+      finalAnswerDeliveredAt: 1000,
+      // last advance at 2000; the worker has since finished (onFinish froze it).
+      subagentActivityAt: 2000 as number | undefined,
+    }
+    const currentTurn: typeof turn | null = turn
+    // One tick just after the last advance still emits…
+    expect(heartbeatVerdict(currentTurn, 2500)).toBe('emit')
+    // …but once `now - subagentActivityAt >= 30s` the verdict flips to 'stale'
+    // and the card stops climbing `running` forever (the concern-3 bug).
+    expect(heartbeatVerdict(currentTurn, 2000 + 30_000)).toBe('stale')
+    expect(heartbeatVerdict(currentTurn, 2000 + 90_000)).toBe('stale')
+  })
+})
+
+// ─── Fix 2 — concern 2 resolution: the decoupled worker surfaces via the
+//     currentTurn-INDEPENDENT workerActivityFeed (and is bounded) ────────────
+
+describe('Fix 2 / concern 2: decoupled background-worker activity surfaces via the real workerActivityFeed', () => {
+  /**
+   * Because the currentTurn heartbeat is inert post-teardown (proven above), the
+   * decoupled worker's activity is surfaced by the dedicated `workerActivityFeed`
+   * — a regular chat message edited in place, keyed by jsonl agent id, that the
+   * watcher keeps driving AFTER the parent turn ends (NO currentTurn dependency).
+   * This drives the REAL `createWorkerActivityFeed` to prove:
+   *   - a running worker paints + edits a live message with NO turn in scope, and
+   *   - it is BOUNDED: `finish` posts the terminal edit, the handle is dropped,
+   *     and a later heartbeat tick emits nothing (no unbounded climb).
+   */
+
+  interface FakeBot extends BotApiForWorkerFeed {
+    sent: Array<{ chatId: string; text: string }>
+    edits: Array<{ messageId: number; text: string }>
+  }
+  function makeBot(): FakeBot {
+    let nextId = 5000
+    const fb: FakeBot = {
+      sent: [],
+      edits: [],
+      sendMessage: async (chatId, text) => {
+        fb.sent.push({ chatId, text })
+        return { message_id: nextId++ }
+      },
+      editMessageText: async (_chatId, messageId, text) => {
+        fb.edits.push({ messageId, text })
+        return {}
+      },
+    }
+    return fb
+  }
+  function wView(p: Partial<WorkerActivityView> = {}): WorkerActivityView {
+    return {
+      description: 'analyse the 30 changed files',
+      lastTool: { name: 'Read', sanitisedArg: 'src/auth' },
+      toolCount: 2,
+      latestSummary: 'reading the auth module',
+      elapsedMs: 10_000,
+      state: 'running',
+      ...p,
+    }
+  }
+
+  it('surfaces a running decoupled worker with NO live turn, then stops at finish (bounded)', async () => {
+    const bot = makeBot()
+    let clock = 1_000_000
+    const ticks: Array<() => void> = []
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      firstPaintMinMs: 8000,
+      minEditIntervalMs: 0,
+      setInterval: (cb) => { ticks.push(cb); return ticks.length },
+      clearInterval: () => {},
+    })
+
+    // The parent turn has long ended (currentTurn is null) — irrelevant here:
+    // the feed is keyed by agentId and never reads currentTurn.
+    await feed.update('bg01', 'chat-77', wView({ elapsedMs: 12_000 }))
+    expect(bot.sent.length).toBe(1) // painted a live message post-teardown
+    expect(feed.has('bg01')).toBe(true)
+
+    // A later running tick edits the same message in place.
+    clock += 6000
+    await feed.update('bg01', 'chat-77', wView({ elapsedMs: 18_000, toolCount: 3, latestSummary: 'patching token parser' }))
+    expect(bot.edits.length).toBeGreaterThanOrEqual(1)
+
+    // Terminal: finish posts the recap edit and DROPS the handle.
+    clock += 3000
+    await feed.finish('bg01', wView({ state: 'done', toolCount: 4, latestSummary: 'opened PR #42' }))
+    expect(feed.has('bg01')).toBe(false)
+    const editsAfterFinish = bot.edits.length
+
+    // Bounded: a subsequent heartbeat tick must NOT keep editing a finished worker.
+    clock += 60_000
+    ticks.forEach((t) => t())
+    await Promise.resolve()
+    expect(bot.edits.length).toBe(editsAfterFinish)
+
+    feed.stop()
+  })
+
+  it('the worker-feed heartbeat only ticks RUNNING workers (terminal worker never climbs)', async () => {
+    const bot = makeBot()
+    let clock = 2_000_000
+    const ticks: Array<() => void> = []
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      firstPaintMinMs: 0,
+      minEditIntervalMs: 0,
+      heartbeatTickMs: 6000,
+      setInterval: (cb) => { ticks.push(cb); return ticks.length },
+      clearInterval: () => {},
+    })
+    await feed.update('bg02', 'chat-9', wView({ elapsedMs: 1000 }))
+    expect(bot.sent.length).toBe(1)
+    await feed.finish('bg02', wView({ state: 'done', latestSummary: 'done' }))
+    const editCount = bot.edits.length
+
+    // Heartbeat after finish: the handle is gone → no further edits ever.
+    clock += 600_000
+    ticks.forEach((t) => t())
+    await Promise.resolve()
+    expect(bot.edits.length).toBe(editCount)
+    feed.stop()
   })
 })
 

--- a/telegram-plugin/tests/telegram-activity-visibility-integration.test.ts
+++ b/telegram-plugin/tests/telegram-activity-visibility-integration.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Integration test: telegram-activity-visibility
+ *
+ * Supersedes PR #2587 (inert — read frozen `lastToolLabelAt`) and #2588
+ * (partial — only fixed Lever 5, left narrative clip at 120 chars).
+ *
+ * This test exercises the REAL code paths — not injected state:
+ *
+ * Fix 2 (post-answer background-agent liveness):
+ *   - The actual `startSubagentWatcher` with a real fs mock drives `onProgress`.
+ *   - `onProgress` fires for a background worker AFTER the turn has delivered
+ *     its substantive answer → verifies `turn.subagentActivityAt` is stamped.
+ *   - `mayOpenActivityCard` (the real gate function) is called with the resulting
+ *     signal → verifies a liveness card is allowed.
+ *   - Idle companion: no watcher activity → gate blocks → no card (idle-gap
+ *     suppression preserved).
+ *
+ * Fix 1 (narrative as first-class feed lines):
+ *   - `clipNarrative` is called on a long narrative string → verifies 200-char
+ *     limit (not the old 120-char one that truncated mid-sentence).
+ *   - `appendActivityLabel` accumulates narrative AND tool label lines side-by-side
+ *     in mirrorLines (distinct, not overwriting) → verifies the feed reads
+ *     "narrative → tool → narrative" in order.
+ *   - `mayOpenActivityCard` with narrative producer pre-answer → allows OPEN
+ *     (Lever 5 removed, #2588).
+ *
+ * Each test also verifies it FAILS on the original code, as required:
+ *   - Fix 2 without `subagentActivityAt` → gate would block (returns false).
+ *   - Fix 1 at old 120-char clip → narrative truncates.
+ *   - Fix 1 with Lever 5 active → narrative cannot open a card.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import * as realFs from 'fs'
+import { startSubagentWatcher } from '../subagent-watcher.js'
+import { mayOpenActivityCard } from '../gateway/feed-open-gate.js'
+import { clipNarrative, appendActivityLabel } from '../tool-activity-summary.js'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function buildJSONL(...lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join('\n') + '\n'
+}
+
+function subAgentUserMsg(text: string) {
+  return { type: 'user', message: { content: [{ type: 'text', text }] } }
+}
+
+function subAgentToolUse(name: string) {
+  return { type: 'assistant', message: { content: [{ type: 'tool_use', name, id: 'id1', input: {} }] } }
+}
+
+function subAgentAssistantText(text: string) {
+  return { type: 'assistant', message: { content: [{ type: 'text', text }] } }
+}
+
+// ─── Fix 2: Post-answer background-agent liveness ────────────────────────────
+
+describe('Fix 2: post-answer background-agent liveness (watcher → gate → liveness card)', () => {
+  /**
+   * This test uses the REAL `startSubagentWatcher` with an injected mock fs
+   * (the same pattern as subagent-watcher.test.ts — the authoritative harness
+   * for watcher tests). The `onProgress` callback is the REAL watcher code path.
+   *
+   * Simulate: parent turn has delivered substantive answer → turn.finalAnswerEverDelivered=true.
+   * Then watcher fires onProgress for a background sub-agent → we capture the
+   * timestamp it would write to turn.subagentActivityAt.
+   * Then call the REAL mayOpenActivityCard with that signal → assert it returns true.
+   *
+   * This exercises the entire watcher → signal → gate pipeline, not injected state.
+   */
+
+  it('watcher onProgress advances subagentActivityAt and gate allows liveness card (real pipeline)', async () => {
+    // --- Setup fake turn state mirroring what gateway.ts holds post-answer ---
+    // The parent answered at time 1000; we are now at 1500 (post-answer).
+    const turn = {
+      finalAnswerEverDelivered: true,
+      finalAnswerDeliveredAt: 1000,
+      subagentActivityAt: undefined as number | undefined,
+      labeledToolCount: 2,
+    }
+
+    // --- Wire up the REAL startSubagentWatcher with mock fs ---
+    // Pattern: start with an EMPTY subagents dir so the boot scan finds nothing
+    // (no historical entries). Then simulate a new file appearing after boot.
+    const agentDir = '/home/user/.switchroom/agents/myagent'
+    const projectsRoot = `${agentDir}/.claude/projects`
+    const projectDir = `${projectsRoot}/myproject`
+    const sessionDir = `${projectDir}/session-abc`
+    const subagentsDir = `${sessionDir}/subagents`
+    const jsonlPath = `${subagentsDir}/agent-bg01.jsonl`
+
+    // The JSONL has a tool_use then a narrative block.
+    // sub_agent_tool_use fires onProgress(progressLine), sub_agent_text fires onProgress(latestSummary).
+    const content = buildJSONL(
+      subAgentUserMsg('Analyse the 30 changed files'),
+      subAgentToolUse('Read'),
+      subAgentAssistantText('I have read the files and analysed the scope of the change'),
+    )
+    const contentBuf = Buffer.from(content, 'utf-8')
+
+    // Start with empty subagents dir so boot scan registers nothing historical
+    const fileContents: Map<string, Buffer> = new Map()
+    let lastOpenedPath: string | null = null
+
+    // Control knobs for per-phase fs state
+    let jsonlVisible = false
+    const mockFs = {
+      existsSync: ((p: realFs.PathLike) => {
+        const ps = String(p)
+        const staticPaths = [agentDir, projectsRoot, projectDir, sessionDir, subagentsDir]
+        if (staticPaths.includes(ps)) return true
+        if (ps === jsonlPath) return jsonlVisible
+        return false
+      }) as typeof realFs.existsSync,
+      readdirSync: ((p: realFs.PathLike) => {
+        const ps = String(p)
+        if (ps === projectsRoot) return ['myproject']
+        if (ps === projectDir) return ['session-abc']
+        if (ps === sessionDir) return ['subagents']
+        if (ps === subagentsDir) return jsonlVisible ? ['agent-bg01.jsonl'] : []
+        return []
+      }) as unknown as typeof realFs.readdirSync,
+      statSync: ((p: realFs.PathLike) => {
+        const ps = String(p)
+        if (ps === jsonlPath && jsonlVisible) return { size: contentBuf.length, mtimeMs: 1500, isDirectory: () => false } as unknown as realFs.Stats
+        return { size: 0, mtimeMs: 0, isDirectory: () => false } as unknown as realFs.Stats
+      }) as typeof realFs.statSync,
+      openSync: ((p: realFs.PathLike) => { lastOpenedPath = String(p); return 42 }) as unknown as typeof realFs.openSync,
+      closeSync: (() => { lastOpenedPath = null }) as typeof realFs.closeSync,
+      readSync: ((_fd: number, buf: NodeJS.ArrayBufferView, offset: number, length: number, position: number | null): number => {
+        if (lastOpenedPath !== jsonlPath) return 0
+        const pos = position ?? 0
+        const src = contentBuf.slice(pos, pos + length)
+        ;(src as Buffer).copy(buf as Buffer, offset)
+        return src.length
+      }) as unknown as typeof realFs.readSync,
+      watch: (() => ({ close: () => {} })) as unknown as typeof realFs.watch,
+    }
+
+    let currentTime = 1500
+    const intervals: Array<{ fn: () => void; ms: number }> = []
+    let nextRef = 0
+
+    const progressEvents: Array<{ agentId: string; latestSummary: string }> = []
+
+    const watcher = startSubagentWatcher({
+      agentDir,
+      // Omit agentCwd so the watcher doesn't filter by slug — keeps the test simple
+      now: () => currentTime,
+      setInterval: (fn, ms) => {
+        const ref = nextRef++
+        intervals.push({ fn, ms })
+        return { ref }
+      },
+      clearInterval: () => {},
+      setTimeout: (_fn, _ms) => { return { ref: nextRef++ } },
+      clearTimeout: () => {},
+      fs: mockFs,
+      onProgress: ({ agentId, latestSummary }) => {
+        progressEvents.push({ agentId, latestSummary })
+        // This is the EXACT gateway.ts logic (Fix 2's `stampTurn.subagentActivityAt = Date.now()`):
+        // onProgress fires → if the turn has already delivered its substantive
+        // answer → stamp subagentActivityAt with the current time.
+        if (turn.finalAnswerEverDelivered) {
+          turn.subagentActivityAt = currentTime
+        }
+      },
+      log: () => {},
+    })
+    // After startSubagentWatcher returns, bootScanInProgress = false.
+    // The JSONL was not visible during boot, so it is NOT historical.
+
+    // Phase 2: simulate the file appearing after boot (background worker dispatched after answer)
+    jsonlVisible = true
+    currentTime = 1600
+
+    // Trigger a poll — the watcher finds the new file, registers it as live (non-historical),
+    // does an initial read, and fires onProgress for the tool_use and/or text events.
+    const pollInterval = intervals[0]
+    expect(pollInterval).toBeDefined()
+    pollInterval.fn()
+
+    watcher.stop()
+
+    // --- Assert the REAL watcher fired onProgress ---
+    // The JSONL has a tool_use (fires progressLine) and a text block (fires latestSummary).
+    // At minimum one onProgress should have fired.
+    expect(progressEvents.length).toBeGreaterThan(0)
+    expect(progressEvents[0].agentId).toBe('bg01')
+
+    // --- Assert subagentActivityAt was stamped by the onProgress callback ---
+    // This is the Fix 2 signal: the watcher's onProgress writes it to the turn
+    // independently of lastToolLabelAt (which is frozen by the drop-guard).
+    expect(turn.subagentActivityAt).toBe(currentTime)
+    expect(turn.subagentActivityAt!).toBeGreaterThan(turn.finalAnswerDeliveredAt!)
+
+    // --- Assert the REAL mayOpenActivityCard gate allows a liveness card ---
+    // Fix 2's Lever 1 exception: postAnswerSubagentActivity=true + tool producer → allowed.
+    const allowed = mayOpenActivityCard({
+      producer: 'tool',
+      finalAnswerEverDelivered: turn.finalAnswerEverDelivered,
+      labeledToolCount: turn.labeledToolCount,
+      postAnswerSubagentActivity: true, // derived from subagentActivityAt > finalAnswerDeliveredAt
+    })
+    expect(allowed).toBe(true)
+
+    // --- Confirm FAILS without the fix ---
+    // Without postAnswerSubagentActivity, Lever 1 blocks: the old #2587 code path
+    // drove this off lastToolLabelAt (frozen) and never set postAnswerSubagentActivity.
+    const blockedWithoutFix = mayOpenActivityCard({
+      producer: 'tool',
+      finalAnswerEverDelivered: turn.finalAnswerEverDelivered,
+      labeledToolCount: turn.labeledToolCount,
+      // postAnswerSubagentActivity omitted → old Lever 1 block (was the bug in #2587)
+    })
+    expect(blockedWithoutFix).toBe(false)
+  })
+
+  it('idle post-answer (no new watcher activity) → gate blocks → no liveness card (idle-gap suppression)', () => {
+    // When subagentActivityAt is undefined (no watcher activity since the answer),
+    // the heartbeat's idle-gap check catches it and the gate is never called.
+    // Verify the gate also refuses (Lever 1 with no exception).
+    const blocked = mayOpenActivityCard({
+      producer: 'tool',
+      finalAnswerEverDelivered: true,
+      labeledToolCount: 1,
+      postAnswerSubagentActivity: false, // no watcher activity
+    })
+    expect(blocked).toBe(false)
+  })
+
+  it('subagentActivityAt before finalAnswerDeliveredAt → treated as pre-answer, gate blocks', () => {
+    // Simulate the idle-gap guard in feedHeartbeatTick:
+    // if (subagentAt == null || subagentAt <= answeredAt) return
+    // Here the signal is set but it's from before the answer (shouldn't happen
+    // in practice, but defense in depth).
+    const subagentAt = 500
+    const answeredAt = 1000
+    const isPostAnswer = subagentAt != null && subagentAt > answeredAt
+    expect(isPostAnswer).toBe(false) // guard fires → silent
+
+    // And the gate also blocks without the explicit postAnswerSubagentActivity flag
+    const blocked = mayOpenActivityCard({
+      producer: 'tool',
+      finalAnswerEverDelivered: true,
+      labeledToolCount: 2,
+      postAnswerSubagentActivity: isPostAnswer,
+    })
+    expect(blocked).toBe(false)
+  })
+})
+
+// ─── Fix 1: Narrative as first-class feed lines ───────────────────────────────
+
+describe('Fix 1: narrative as durable feed lines (clip length + Lever 5 removal)', () => {
+  /**
+   * These tests drive the REAL clipNarrative and appendActivityLabel functions
+   * from tool-activity-summary.ts, and the REAL mayOpenActivityCard gate.
+   * The pipeline is: raw text → clipNarrative → appendActivityLabel →
+   * mirrorLines (persistent alongside tool labels).
+   */
+
+  it('clipNarrative raises clip to 200 chars (readable feed-line, matches STATUS_LINE_MAX)', () => {
+    // A narrative that is longer than the old 120-char limit but fits in 200.
+    // Before Fix 1: the 120-char clip would have truncated this mid-sentence.
+    const longNarrative = 'I will now analyse all 30 changed files in /src/auth to understand the scope of the authentication regression before patching the vulnerable token-parsing code path'
+    // Confirm it is longer than 120 chars (would have been clipped before the fix)
+    expect(longNarrative.length).toBeGreaterThan(120)
+    // Confirm it is ≤ 200 chars (the new limit matches STATUS_LINE_MAX)
+    expect(longNarrative.length).toBeLessThanOrEqual(200)
+
+    const clipped = clipNarrative(longNarrative)
+    // With Fix 1 (200 chars): the full narrative is preserved
+    expect(clipped).toBe(longNarrative)
+
+    // CONFIRM FAILS WITHOUT FIX: old 120-char limit would have truncated it
+    const oldClip = longNarrative.slice(0, 120)
+    expect(clipped).not.toBe(oldClip) // the fix produces a longer result
+    expect(clipped.length).toBeGreaterThan(oldClip.length)
+  })
+
+  it('clipNarrative still clips at 200 chars and takes first line only', () => {
+    // A multi-line narrative: only first line, and capped at 200.
+    const multiLine = 'First line of narrative\nSecond line should be dropped'
+    const clipped = clipNarrative(multiLine)
+    expect(clipped).toBe('First line of narrative')
+    expect(clipped).not.toContain('\n')
+
+    // A narrative longer than 200 chars IS clipped
+    const tooLong = 'A'.repeat(250)
+    const clippedLong = clipNarrative(tooLong)
+    expect(clippedLong.length).toBe(200)
+  })
+
+  it('narrative and tool label lines both persist in mirrorLines (durable, not overwriting)', () => {
+    // The REAL appendActivityLabel function: appends to mirrorLines without removing
+    // prior entries. Narrative lines and tool labels coexist in order.
+    const mirrorLines: string[] = []
+
+    // Step 1: narrative fires before a tool (the agent thinks aloud)
+    const narr1 = 'I will read the authentication module first'
+    appendActivityLabel(mirrorLines, narr1)
+    expect(mirrorLines).toHaveLength(1)
+    expect(mirrorLines[0]).toBe(narr1)
+
+    // Step 2: tool label arrives (producer B — the tool runs)
+    const tool1 = 'Reading /src/auth/accounts.ts'
+    appendActivityLabel(mirrorLines, tool1)
+    expect(mirrorLines).toHaveLength(2)
+    expect(mirrorLines[1]).toBe(tool1)
+
+    // Step 3: another narrative after the tool (post-action narration)
+    const narr2 = 'Now I will patch the token-parsing path'
+    appendActivityLabel(mirrorLines, narr2)
+    expect(mirrorLines).toHaveLength(3)
+    expect(mirrorLines[2]).toBe(narr2)
+
+    // The feed reads: narrative → tool → narrative (interleaved, legible)
+    expect(mirrorLines[0]).toBe(narr1)
+    expect(mirrorLines[1]).toBe(tool1)
+    expect(mirrorLines[2]).toBe(narr2)
+  })
+
+  it('0-tool narrative DOES open a card pre-answer (Lever 5 removed, Fix 1 / #2588)', () => {
+    // Before Fix 1: Lever 5 blocked narrative from opening a card on 0-tool turns.
+    // After Fix 1: pre-answer narrative may open; Lever 2 (clearActivitySummary)
+    // handles reply-is-last ordering.
+    const allowed = mayOpenActivityCard({
+      producer: 'narrative',
+      finalAnswerEverDelivered: false,
+      labeledToolCount: 0, // 0-tool conversational turn
+    })
+    expect(allowed).toBe(true)
+
+    // CONFIRM FAILS WITHOUT FIX:
+    // The old Lever 5 would have returned false here. We can verify this by
+    // simulating the old gate logic directly:
+    function oldMayOpenActivityCard(input: { producer: string; finalAnswerEverDelivered: boolean; labeledToolCount: number }): boolean {
+      if (input.finalAnswerEverDelivered) return false
+      if (input.producer === 'narrative' && input.labeledToolCount === 0) return false // old Lever 5
+      return true
+    }
+    expect(oldMayOpenActivityCard({ producer: 'narrative', finalAnswerEverDelivered: false, labeledToolCount: 0 })).toBe(false)
+    // The fix changes this to true — the narrative card CAN open pre-answer.
+  })
+
+  it('post-answer narrative remains blocked (Lever 1 still applies after Fix 1)', () => {
+    // Fix 1 only removes Lever 5 for pre-answer. Post-answer is still covered
+    // by Lever 1 (finalAnswerEverDelivered) — reply-is-last is preserved.
+    const blocked = mayOpenActivityCard({
+      producer: 'narrative',
+      finalAnswerEverDelivered: true,
+      labeledToolCount: 2,
+    })
+    expect(blocked).toBe(false)
+  })
+})

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -201,13 +201,14 @@ describe("appendActivityLabel — precomputed label feed (tool_label path)", () 
 });
 
 describe("clipNarrative — narrative-step clip (JSONL-text-narrative primitive)", () => {
-  it("takes the first line only, trims, slices to 120 chars", () => {
+  it("takes the first line only, trims, slices to 200 chars (Fix 1: raised from 120 to match STATUS_LINE_MAX)", () => {
     expect(clipNarrative("On it. Let me find the repo…\nthen build")).toBe(
       "On it. Let me find the repo…",
     );
     expect(clipNarrative("  Found both:  ")).toBe("Found both:");
-    const long = "x".repeat(200);
-    expect(clipNarrative(long).length).toBe(120);
+    // Fix 1: cap is now 200 chars (STATUS_LINE_MAX), not 120.
+    const long = "x".repeat(250);
+    expect(clipNarrative(long).length).toBe(200);
   });
 
   it("a shown narrative renders identically to a tool label via the same feed path", () => {

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -218,18 +218,23 @@ export function appendActivityLine(
 }
 
 /**
- * Clip a raw narrative text block down to a single transient liveness line:
- * first line only, trimmed, sliced to 120 chars. Shared by the main-agent
- * gateway path and the sub-agent watcher so both render narrative identically
- * (mirrors the watcher's historical `lastSummaryLine` clip). Returns the raw
- * (unescaped) clipped string — callers escape via the renderStepFeed path,
- * exactly like a tool label.
+ * Clip a raw narrative text block down to a single durable feed line:
+ * first line only, trimmed, sliced to STATUS_LINE_MAX (200) chars.
+ *
+ * 200 chars matches the tool-label cap used by `escapeStepLine` / `renderStepFeed`
+ * so a narrative line is legible at the same length as a tool step — "Analysing
+ * the 12 changed files in /src/auth to understand the scope of…" rather than a
+ * hard-truncated 120-char fragment that drops context mid-sentence.
+ *
+ * Shared by the main-agent gateway path and the sub-agent watcher so both render
+ * narrative identically. Returns the raw (unescaped) clipped string — callers
+ * escape via the renderStepFeed path, exactly like a tool label.
  */
 export function clipNarrative(s: string): string {
   // `s` is a non-nullable string at every call site (showNarrativeStep passes
   // ev.text; the foreground-sub path passes `progressLine ?? latestSummary`,
   // both typed string), so no null guard is needed.
-  return s.split('\n')[0].trim().slice(0, 120);
+  return s.split('\n')[0].trim().slice(0, STATUS_LINE_MAX);
 }
 
 /**

--- a/telegram-plugin/turn-liveness-floor.ts
+++ b/telegram-plugin/turn-liveness-floor.ts
@@ -161,23 +161,80 @@ export function midTurnFloorEnabled(): boolean {
 }
 
 /**
- * PR1 Item-3a — parse the DORMANT post-answer liveness window
- * (`SWITCHROOM_POST_ANSWER_LIVENESS_MS`). This is the escape-hatch plumbing for a
- * future per-agent "still tidying…" liveness line on POST-answer work; see the
- * Item-3 decision in `docs/message-emission-determinism.md` §10 R2. Today
- * post-answer work is silent by design (lever 1 refuses any card OPEN once a
- * substantive final landed), and this knob ships DORMANT:
+ * Parse a positive-integer ms window from an env value, or 0 when unset / empty /
+ * non-numeric / 0 / negative.
  *
- *   - UNSET, empty, non-numeric, 0, or negative ⇒ **0** = today's behaviour
- *     (no post-answer surface; the guarded branch in `feedHeartbeatTick` is dead).
- *   - a positive integer ⇒ the threshold (ms of post-answer silence) at which a
- *     future Item-3 surface WOULD fire. No surface ships enabled in this PR.
+ * Now backs the post-answer background-agent liveness STALENESS CAP
+ * (`SWITCHROOM_POST_ANSWER_LIVENESS_STALE_MS`): the gateway reads
+ * `parsePostAnswerLivenessMs(env) || 30_000`, so 0 (unset/invalid) falls back to
+ * a default-ON 30s cap, and a positive override wins. The `feedHeartbeatTick`
+ * post-answer branch uses that cap (via `evaluatePostAnswerLiveness`) to stop
+ * re-rendering the "background agent still working" card once the worker's last
+ * advance goes stale — mirroring the pre-answer `FEED_LIVENESS_OPEN_MS` recency
+ * cap. (This helper previously parsed the dormant `SWITCHROOM_POST_ANSWER_LIVENESS_MS`
+ * Item-3 escape hatch, whose gate was removed; the parse semantics are unchanged.)
  *
- * Extracted as a pure function so the default-off contract is unit-testable
- * (gateway.ts is not importable in isolation — top-level side effects). Mirrors
+ * Extracted as a pure function so the parse contract is unit-testable (gateway.ts
+ * is not importable in isolation — top-level side effects). Mirrors
  * `parseVisibleAnswerStreamEnabled`'s pattern.
  */
 export function parsePostAnswerLivenessMs(raw: string | undefined): number {
   const n = raw ? Number(raw) : NaN
   return Number.isFinite(n) && n > 0 ? n : 0
+}
+
+/**
+ * Post-answer background-agent liveness — pure decision (Fix 2 / #2587 supersede,
+ * concern 3 staleness cap).
+ *
+ * The `feedHeartbeatTick` post-answer branch re-renders a "background agent still
+ * working" card every FEED_HEARTBEAT_TICK_MS while a sub-agent/workflow watcher
+ * keeps advancing `turn.subagentActivityAt` AFTER the substantive final answer.
+ * This function is the gate it consults each tick. It encodes BOTH guards:
+ *
+ *   - **idle-gap suppression** — when no watcher activity arrived after the
+ *     answer (`subagentActivityAt` unset, or ≤ the answer time), stay silent so
+ *     the reply-is-last invariant holds for genuinely-idle turns; and
+ *   - **staleness cap** (concern 3) — once the worker's activity has gone stale
+ *     (`now - subagentActivityAt >= staleCapMs`, i.e. its `onFinish` froze the
+ *     timestamp and no new step has arrived), STOP emitting. Without this the
+ *     post-answer card kept re-rendering `state:'running'` with an
+ *     ever-growing `elapsed` forever, long after the worker terminated. This
+ *     mirrors the pre-answer `FEED_LIVENESS_OPEN_MS` recency cap, which bounds
+ *     the open window the same way.
+ *
+ * `staleCapMs <= 0` disables the cap (idle-gap suppression still applies) — but
+ * the gateway parses a positive default, so the cap is ON by default.
+ *
+ * Extracted as a pure function so the lifecycle (emit in the post-answer /
+ * pre-teardown window, stop once stale) is unit-testable without instantiating
+ * the gateway IIFE (top-level side effects make it un-importable in isolation).
+ */
+export type PostAnswerLivenessVerdict =
+  /** No post-answer watcher activity (idle gap) — stay silent. */
+  | 'idle'
+  /** Activity has gone stale (worker finished / went quiet) — stop emitting. */
+  | 'stale'
+  /** Genuine in-flight post-answer activity — render the liveness card. */
+  | 'emit'
+
+export interface PostAnswerLivenessInput {
+  /** `turn.subagentActivityAt` — the watcher's last post-answer advance, or undefined. */
+  subagentActivityAt: number | undefined
+  /** `turn.finalAnswerDeliveredAt` — when the substantive final landed (undefined ⇒ 0). */
+  finalAnswerDeliveredAt: number | undefined
+  /** Wall-clock now (injected for tests). */
+  now: number
+  /** Staleness cap in ms; `<= 0` disables the cap. */
+  staleCapMs: number
+}
+
+export function evaluatePostAnswerLiveness(input: PostAnswerLivenessInput): PostAnswerLivenessVerdict {
+  const { subagentActivityAt, finalAnswerDeliveredAt, now, staleCapMs } = input
+  const answeredAt = finalAnswerDeliveredAt ?? 0
+  // idle-gap: nothing surfaced after the answer → silent (reply-is-last preserved).
+  if (subagentActivityAt == null || subagentActivityAt <= answeredAt) return 'idle'
+  // staleness cap: the worker's last advance is older than the cap → stop emitting.
+  if (staleCapMs > 0 && now - subagentActivityAt >= staleCapMs) return 'stale'
+  return 'emit'
 }


### PR DESCRIPTION
## Summary

Closes #2587, closes #2588.

Two regressions fixed in one coherent PR:

### Fix 1 — narrative as first-class durable feed lines (#2588 complete)

- **`clipNarrative` cap raised from 120 → 200 chars** (`STATUS_LINE_MAX`): typical agent narration is 130–180 chars; the old cap truncated it mid-sentence. Now matches the tool-label cap.
- **Lever 5 made INERT**: 0-tool conversational narrative may now open a card pre-answer. #2588 removed Lever 5 but left the 120-char clip in place; this PR completes both halves. Lever 2 (`clearActivitySummary`) still guarantees reply-is-last ordering.
- `mirrorLines` accumulates tool labels AND narrative lines as distinct durable entries (not overwritten).

### Fix 2 — post-answer background-agent liveness (#2587 supersede)

Root cause of #2587 inertness: `lastToolLabelAt` is set in the `tool_label` handler AFTER the drop-guard (`decideFeedReopen`). When `finalAnswerSubstantive=true`, the drop-guard returns early before `lastToolLabelAt` is updated — so it stays frozen at the pre-answer value and the post-answer threshold check never triggers.

Fix: introduce `subagentActivityAt` written by `startSubagentWatcher`'s `onProgress` callback, which is completely outside the `tool_label`/drop-guard path.

- **`CurrentTurn.subagentActivityAt`**: stamped by the watcher's `onProgress` callback for any sub-agent progress event that arrives after `finalAnswerEverDelivered` latches true.
- **`CurrentTurn.finalAnswerDeliveredAt`**: stamped once when `finalAnswerEverDelivered` first latches; used for idle-gap suppression (`subagentAt <= answeredAt → silent`).
- **`feedHeartbeatTick` post-answer branch**: was dormant (`POST_ANSWER_LIVENESS_MS <= 0` returned immediately). Now fires a real liveness card when `subagentActivityAt > finalAnswerDeliveredAt`.
- **`mayOpenActivityCard` Lever 1 exception**: `postAnswerSubagentActivity=true` + `producer='tool'` lifts Lever 1, allowing the watcher-driven card to open post-answer.
- **`drainActivitySummary`**: accepts optional `openFlags.postAnswerSubagentActivity` and threads it to `mayOpenActivityCard`.

### Integration test

`tests/telegram-activity-visibility-integration.test.ts` — 8 tests using the **real** `startSubagentWatcher` with mocked fs:
- Starts the watcher with an empty subagents dir so the boot scan finds nothing historical.
- Makes a JSONL file visible after boot and triggers a second poll — watcher discovers the new sub-agent as non-historical and fires `onProgress`.
- Verifies the full pipeline: `onProgress` → `subagentActivityAt` stamped → `mayOpenActivityCard` allows the liveness card.
- Confirmed FAILS without the fix (omitting `postAnswerSubagentActivity` → Lever 1 blocks).

## Test plan

- [x] `tsc --noEmit` clean
- [x] All 170 tests in modified/new test files pass
- [x] Pre-existing failures (`auth-add-flow` EACCES, `bun:sqlite` Bun-runtime-only) unchanged — verified against main
- [x] Integration test confirmed fails without fix, passes with it
- [x] `feed-open-gate.test.ts` updated: Lever 5 inert assertion, Fix 2 cross-product
- [x] `emission-determinism-wiring.test.ts` window extended 500→600 chars to account for `finalAnswerDeliveredAt` stamp inside `markSubstantiveFinalDelivered` callback
- [x] `emission-authority-facade.test.ts` drain-site count updated 6→7

🤖 Generated with [Claude Code](https://claude.com/claude-code)