### PR TITLE
fix(auth): use real Claude Code OAuth client_id for token refresh

### DIFF
--- a/src/auth/account-refresh.test.ts
+++ b/src/auth/account-refresh.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  refreshAccountIfNeeded,
+  DEFAULT_CLIENT_ID,
+} from "./account-refresh.js";
+import { writeAccountCredentials } from "./account-store.js";
+
+// Hermetic: every test points `home` at its own tmpdir — never ~/.switchroom.
+const tmpHomes: string[] = [];
+function freshHome(): string {
+  const h = mkdtempSync(join(tmpdir(), "sr-acct-refresh-"));
+  tmpHomes.push(h);
+  return h;
+}
+afterEach(() => {
+  while (tmpHomes.length) {
+    try {
+      rmSync(tmpHomes.pop()!, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+});
+
+/** Seed a near-expiry credential (with a refresh token) so the refresh fires. */
+function seedExpiringAccount(home: string, label: string): void {
+  writeAccountCredentials(
+    label,
+    {
+      claudeAiOauth: {
+        accessToken: "at-" + "expiring",
+        refreshToken: "rt-" + "valid",
+        // Expired an hour ago → below threshold → refresh path taken.
+        expiresAt: Date.now() - 60 * 60 * 1000,
+        scopes: ["user:inference"],
+      },
+    } as never,
+    home,
+  );
+}
+
+/** A fetcher that captures the request body and returns a canned token. */
+function capturingFetcher(captured: { body?: string }) {
+  return async (_url: string, init: { body?: string }) => {
+    captured.body = init.body;
+    return {
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          access_token: "at-" + "new",
+          refresh_token: "rt-" + "new",
+          expires_in: 28800,
+          token_type: "Bearer",
+        }),
+    };
+  };
+}
+
+describe("account-refresh client_id", () => {
+  it("is the Claude Code OAuth client (NOT the legacy 9d1cd16e value)", () => {
+    // Regression guard for the latent bug: every account was a long-lived
+    // setup-token that never refreshed, so the wrong id (9d1cd16e-…) 400'd
+    // only once a short-lived session token was added. Pin the correct value.
+    expect(DEFAULT_CLIENT_ID).toBe("9d1c250a-e61b-44d9-88ed-5944d1962f5e");
+    expect(DEFAULT_CLIENT_ID).not.toBe("9d1cd16e-bcb9-40c9-a915-196412f27aa6");
+  });
+
+  it("sends the default client_id in the refresh exchange body", async () => {
+    const home = freshHome();
+    seedExpiringAccount(home, "alice@example.com");
+    const captured: { body?: string } = {};
+    const res = await refreshAccountIfNeeded("alice@example.com", {
+      home,
+      fetcher: capturingFetcher(captured),
+    });
+    expect(res.kind).toBe("refreshed");
+    const body = JSON.parse(captured.body ?? "{}");
+    expect(body.grant_type).toBe("refresh_token");
+    expect(body.client_id).toBe(DEFAULT_CLIENT_ID);
+  });
+
+  it("honors an explicit clientId override", async () => {
+    const home = freshHome();
+    seedExpiringAccount(home, "bob@example.com");
+    const captured: { body?: string } = {};
+    await refreshAccountIfNeeded("bob@example.com", {
+      home,
+      clientId: "override-" + "client-id",
+      fetcher: capturingFetcher(captured),
+    });
+    const body = JSON.parse(captured.body ?? "{}");
+    expect(body.client_id).toBe("override-client-id");
+  });
+});

--- a/src/auth/account-refresh.ts
+++ b/src/auth/account-refresh.ts
@@ -32,9 +32,27 @@ const DEFAULT_TOKEN_URL =
   process.env.SWITCHROOM_OAUTH_TOKEN_URL ??
   "https://console.anthropic.com/v1/oauth/token";
 
-const DEFAULT_CLIENT_ID =
+/**
+ * The Claude Code OAuth client_id — the public client the subscription
+ * OAuth tokens switchroom serves are issued under. The refresh exchange MUST
+ * present the SAME client_id the token was minted with, or Anthropic's
+ * `/v1/oauth/token` rejects it: `400 invalid_request: Client with id <id> not
+ * found`.
+ *
+ * This is the client the `claude` CLI's own login / setup-token flow uses
+ * (visible in the `client_id=` of the OAuth URL it prints). The prior value
+ * (`9d1cd16e-…`) was wrong and had been since this primitive landed
+ * (#621 / #1254) — but the bug was LATENT: every historical switchroom account
+ * was a long-lived `setup-token` (`user:inference`, ~1y expiry) that never
+ * hits the refresh path, so the dead code was never exercised. The first full
+ * Claude-Code session token (broad scopes, ~8h expiry) added to the broker
+ * surfaced it: the refresh 400'd every ~8h and the account silently expired.
+ * Empirically verified — refresh succeeds with this id. Public identifier (not
+ * a secret); override via `SWITCHROOM_OAUTH_CLIENT_ID`.
+ */
+export const DEFAULT_CLIENT_ID =
   process.env.SWITCHROOM_OAUTH_CLIENT_ID ??
-  "9d1cd16e-bcb9-40c9-a915-196412f27aa6";
+  "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 
 interface AnthropicRefreshResponse {
   access_token?: string;


### PR DESCRIPTION
## Summary

`src/auth/account-refresh.ts` presented the wrong `client_id` (`9d1cd16e-…`) on the OAuth refresh exchange, so Anthropic rejected every refresh with `400 invalid_request: Client with id … not found`. Corrected to the real Claude Code OAuth client `9d1c250a-…` (the one the `claude` CLI's own login/setup-token flow uses).

## Why it went unnoticed

The wrong id had been here since the primitive landed (#621/#1254), but the bug was **latent**: every historical switchroom account was a long-lived `setup-token` (`user:inference`, ~1y expiry) that **never hits the refresh path**. The first full Claude-Code **session token** (broad scopes, ~8h expiry) added to the broker exercised the dead code — refresh `400`'d every ~8h and the account silently expired.

**Real incident:** `ken@autograb.com.au` (2026-06-26) — active account, token expired, manual `switchroom auth refresh` reproduced the 400. Swapping to `9d1c250a-…` made the refresh succeed immediately (verified live).

## Changes

- `src/auth/account-refresh.ts` — `DEFAULT_CLIENT_ID` → `9d1c250a-…`, exported, with a header doc explaining the latent-bug history. `SWITCHROOM_OAUTH_CLIENT_ID` env override preserved.
- `src/auth/account-refresh.test.ts` (new) — pins the value, asserts the refresh **request body** carries it (hermetic tmp-home + capturing fetcher), and verifies the env/opts override.

## Test plan

- [x] `vitest run src/auth/account-refresh.test.ts` — 3 pass
- [x] `tsc --noEmit` clean
- [x] `check-no-pii-secrets`, `check-bun-test-imports` clean
- [x] Live: refresh on the real broker now succeeds with the corrected id

## Risk

Low. `client_id` is a public identifier, not a secret. The other accounts never refresh (long-lived setup-tokens), so the only behavioral change is that short-lived session tokens can now actually refresh. No invariant touched (still the subscription OAuth, no API/SDK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)