### PR TITLE
chore: release v0.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.16.3 — fix OAuth token refresh (correct Claude Code client_id)
+
+The auth-broker presented the wrong OAuth `client_id` (`9d1cd16e-…`) on the
+token-refresh exchange, so Anthropic rejected every refresh with
+`400 invalid_request: Client with id … not found`.
+
+- **Correct client_id** (#2594). Refresh now uses the real Claude Code OAuth
+  client (`9d1c250a-…`, the one the `claude` CLI's own login / setup-token flow
+  uses). The wrong value had been in place since the refresh primitive landed
+  (#621 / #1254) but the bug was **latent**: every historical account was a
+  long-lived `setup-token` (`user:inference`, ~1y expiry) that never hits the
+  refresh path. The first full Claude-Code session token (broad scopes, ~8h
+  expiry) added to the broker surfaced it — refresh 400'd every ~8h and the
+  account silently expired (real incident: `ken@autograb.com.au`). Override
+  remains available via `SWITCHROOM_OAUTH_CLIENT_ID`. New
+  `account-refresh.test.ts` pins the value, the refresh request body, and the
+  override path.
+
 ## v0.16.2 — opt-in overage, /auth add TTY fix, feed + turn liveness
 
 This release adds an operator opt-in to spend an account's Anthropic overage


### PR DESCRIPTION
## Summary

Release v0.16.3 — CHANGELOG-only (version is tag-driven). Ships the single fix merged since v0.16.2:

- **#2594** fix(auth): use the real Claude Code OAuth client_id for token refresh — corrects the `400 Client … not found` that silently expired short-lived session-token accounts (e.g. `ken@autograb.com.au`).

## Why

#2594 was independently reviewed (fresh-process reviewer, APPROVE) and merged on green required-CI. This PR consolidates the CHANGELOG and cuts the tag so the fix ships in the fleet images (replacing a live broker `SWITCHROOM_OAUTH_CLIENT_ID` env stopgap).

## Test plan

- [x] `node scripts/build.mjs` exits 0; `dist/cli/switchroom.js` present (~3.35MB)
- [x] CHANGELOG section added under `## v0.16.3`
- [ ] CI green (10 required checks)

## Risk

Low — CHANGELOG-only diff; the code change in #2594 only affects the refresh path (long-lived setup-tokens never refresh), public client_id, no invariant touched.