### PR TITLE
fix(docker): bump claude-code 2.1.185→2.1.195 + bake channelsEnabled managed-settings

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -154,7 +154,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # (`--build-arg CLAUDE_CODE_VERSION=<latest>`) to build a throwaway image on the
 # next version and prove it boots BEFORE the pin is bumped. Keep this default in
 # lockstep with docker/Dockerfile.hindsight's CLAUDE_CODE_VERSION (#1978).
-ARG CLAUDE_CODE_VERSION=2.1.185
+ARG CLAUDE_CODE_VERSION=2.1.195
 # Fail-fast: if the npm install or the resulting binary is broken we
 # want the image build to die here, not produce a base that ships
 # downstream and explodes at agent boot. Previously this had a
@@ -176,6 +176,13 @@ RUN --mount=type=cache,target=/root/.npm,sharing=locked \
     echo "cache-bust=${CACHE_BUST}" > /dev/null \
  && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
  && claude --version >&2
+
+# Bake managed settings so all agents load the telegram plugin without the
+# --dangerously-load-development-channels flag (channelsEnabled lifted the
+# gate in v2.1.185+). /etc/claude-code/managed-settings.json is the Linux
+# endpoint-managed-settings path; highest precedence over user/project settings.
+RUN mkdir -p /etc/claude-code \
+ && printf '{"channelsEnabled":true}\n' > /etc/claude-code/managed-settings.json
 
 # Phase 1b: install bun. The broker server (src/vault/broker/server.ts)
 # imports `bun:sqlite` and `bun:ffi` directly; those modules don't exist

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -51,7 +51,7 @@ USER root
 # claude bundle as the agent containers — a version skew here could reintroduce
 # the thinking-block / thinking-effort class of failures on memory reflection
 # (see #1978). The canary overrides it the same way base does.
-ARG CLAUDE_CODE_VERSION=2.1.185
+ARG CLAUDE_CODE_VERSION=2.1.195
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
  && claude --version >&2
 


### PR DESCRIPTION
## Summary

- Bump `CLAUDE_CODE_VERSION` from `2.1.185` → `2.1.195` in `Dockerfile.base` and `Dockerfile.hindsight` (kept in lockstep per comment at Dockerfile.base:155 / #1978)
- Bake `/etc/claude-code/managed-settings.json` (`{"channelsEnabled":true}`) into the base image — all agent images inherit it

## Why

Claude Code v2.1.185 introduced a gate that blocks `--dangerously-load-development-channels` (the flag `start.sh` uses to load the switchroom telegram plugin) unless `channelsEnabled: true` appears in endpoint-managed settings. Before this fix, pulling any image built with ≥2.1.185 would silently strand all agents — gateway never loads, agents stop responding in Telegram.

The managed-settings bake is the durable fix: it survives image upgrades without per-agent manual intervention. `/etc/claude-code/managed-settings.json` is the Linux endpoint-managed-settings path and has the highest precedence over user/project settings.

## Test plan

- [ ] `build-base` CI goes green (claude --version logs 2.1.195 in layer output)
- [ ] `build-dependents` (agent, broker, kernel, auth-broker, hostd) go green
- [ ] After image pull: `docker exec switchroom-<agent> sh -lc 'claude --version'` → 2.1.195
- [ ] `docker exec switchroom-<agent> sh -lc 'cat /etc/claude-code/managed-settings.json'` → `{"channelsEnabled":true}`
- [ ] Gateway log shows telegram plugin loaded (no `channels not enabled` error)

## Risk

Low — version bump is mechanical; managed-settings bake is additive (a new file in the image, no existing behavior changed). Fail-safe: if the file ever causes issues, it can be overridden at user or project settings level.