### PR TITLE
fix(release): bump package.json to 0.16.4 + remove stale version comment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "switchroom",
-  "//version": "NOT the release version — source of truth is the git tag (see CLAUDE.md > Standard release process). This field is stale by design and only a fallback for scripts/build.mjs + src/cli/resolve-version.ts; do not assume it reflects the current release and do not bump it expecting a release to pick it up.",
-  "version": "0.15.48",
+  "version": "0.16.4",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Bumps `package.json` `"version"` to `"0.16.4"` and removes the `"//version"` comment that instructed maintainers to leave it stale.

## Why

`npm publish <tarball>` uses the version in `package.json` inside the tarball — the git tag alone doesn't propagate to npm. The stale comment caused releases since v0.15.45 to not correctly publish to npm. Going forward: bump `package.json` to match the release version each time.

## Risk

Minimal — one-line change.