### PR TITLE
feat(litellm): enriched spend tags + gateway model discovery + scheduleName in audit JSONL

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -811,9 +811,18 @@ if [ -n "$SWITCHROOM_LITELLM" ] && command -v switchroom >/dev/null 2>&1; then
   fi
   if [ -n "$sr_ll_ok" ]; then
     # Newline-separated Name: Value pairs (claude CLI ANTHROPIC_CUSTOM_HEADERS format).
+    # Tags: agent:<name> for per-agent spend tracking; profile:<profile> for
+    # fleet-level cost breakdown by role. Per-turn tags (cron vs telegram) are
+    # NOT achievable here — ANTHROPIC_CUSTOM_HEADERS is fixed per process and
+    # the claude CLI sends no session id. Use scheduler.jsonl ↔ /spend/logs
+    # time-window correlation for cron attribution instead.
     export ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: Bearer $sr_ll_key
 x-litellm-customer-id: $SWITCHROOM_AGENT_NAME
-x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME"
+x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:-default}"
+    # Let Claude Code enumerate models from the LiteLLM gateway so non-Claude
+    # models configured in the proxy appear in the /model picker and can be
+    # selected via --model. Without this, the CLI only knows its bundled list.
+    export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
   else
     # Fail-open: drop every routing var so the claude CLI talks to Anthropic
     # directly on its OAuth credential (subscription path), unproxied.

--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -194,6 +194,7 @@ export function recoverPendingEscalations(opts: {
         finishedAt: opts.now(),
         tier: esc.tier === "cheap" ? "cheap" : "main",
         ...(esc.cronModel ? { modelUsed: esc.cronModel } : {}),
+        ...(entry.name ? { scheduleName: entry.name } : {}),
       });
     } catch (e) {
       opts.log(`pending-escalation recovery failed for '${entry.poll.state_key}': ${(e as Error).message}`);
@@ -278,6 +279,7 @@ export function registerAgentSchedule(opts: RegisterOptions): RegisteredTask[] {
             outputSummary: summary,
             startedAt,
             finishedAt: now(),
+            ...(entry.name ? { scheduleName: entry.name } : {}),
           });
           if (more) {
             let handle: { cancel: () => void };
@@ -314,6 +316,7 @@ export function registerAgentSchedule(opts: RegisterOptions): RegisteredTask[] {
           finishedAt: now(),
           tier: fields.tier,
           ...(fields.modelUsed ? { modelUsed: fields.modelUsed } : {}),
+          ...(entry.name ? { scheduleName: entry.name } : {}),
         });
 
       // ── Tier 0: deterministic poll, no model ──────────────────────────
@@ -750,6 +753,7 @@ export async function main(): Promise<void> {
               startedAt,
               finishedAt: Date.now(),
               tier: "action",
+              ...(m.entry.name ? { scheduleName: m.entry.name } : {}),
             });
             continue;
           }
@@ -768,6 +772,7 @@ export async function main(): Promise<void> {
               startedAt,
               finishedAt: Date.now(),
               tier: "poll",
+              ...(m.entry.name ? { scheduleName: m.entry.name } : {}),
             });
             continue;
           }
@@ -787,6 +792,7 @@ export async function main(): Promise<void> {
               : "replay attempted but gateway not connected",
             startedAt,
             finishedAt: Date.now(),
+            ...(m.entry.name ? { scheduleName: m.entry.name } : {}),
           });
         }
       }
@@ -852,6 +858,7 @@ export async function main(): Promise<void> {
                 "not executed",
               startedAt: s.expectedFireMs,
               finishedAt: s.expectedFireMs,
+              ...(s.entry.name ? { scheduleName: s.entry.name } : {}),
             });
           }
         }

--- a/src/scheduler/dispatch.ts
+++ b/src/scheduler/dispatch.ts
@@ -144,6 +144,15 @@ export interface DispatchResult {
   startedAt: number;
   finishedAt: number;
   /**
+   * Human-readable schedule name sourced from the overlay file's `# name:`
+   * comment (or a meaningful filename). Absent for base-config crons and
+   * hash-only overlay filenames. Present in audit JSONL for LiteLLM
+   * cost-correlation: join by agent + time window [startedAt, finishedAt]
+   * against LiteLLM's /spend/logs endpoint to identify which cron schedule
+   * drove a given API request.
+   */
+  scheduleName?: string;
+  /**
    * Cheap-cron observability (reference/rfcs/cheap-cron-sessions.md §5). Which
    * tier this fire took and the model it ran at, so `switchroom schedule
    * report` can show the cost breakdown. Absent on legacy audit rows and


### PR DESCRIPTION
## Summary

- **`start.sh`**: adds `profile:<name>` to `x-litellm-tags` so the LiteLLM UI/Prometheus can break down spend by agent role; adds `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` so Claude Code queries `/v1/models` from the proxy and surfaces non-Claude models (Gemini, DeepSeek, GLM) in the native picker
- **`dispatch.ts`**: adds `scheduleName?: string` to `DispatchResult` — sourced from overlay file `# name:` comment (same title the scheduler UI tab shows); absent for base-config crons and hash-named overlays
- **`agent-scheduler/index.ts`**: propagates `entry.name → scheduleName` on all 7 `recordFire` callsites (main record helper, quota-defer, action/poll/regular replay, stale-skip, pending-escalation recovery)

**Why:** Per-agent virtual keys already attribute API spend to an agent. This adds the schedule name so you can join `scheduler.jsonl` (by agent + `[startedAt, finishedAt]`) against LiteLLM's `/spend/logs` to see which specific cron schedule triggered each request. The `profile:` tag enables fleet-level cost breakdown by agent role (clerk, gymbro, ...).

**Not in this PR:** The `litellm-config.yaml` change (remove `openrouter/*` wildcard, add 8 explicit named models: Gemini 2.5 Pro/Flash, DeepSeek R1/V3, GLM-5/5.1, Codex gpt-5/5.2) was applied directly to the host config and does not live in this repo.

## Test plan

- [ ] `tsc --noEmit` passes (no new type errors in dispatch.ts / index.ts)
- [ ] Vitest passes for `src/scheduler/` — `scheduleName` is an optional field; no existing test assertions break
- [ ] Manual: after fleet restart, confirm LiteLLM UI shows `profile:` tag in spend logs for a test turn
- [ ] Manual: confirm `scheduler.jsonl` rows for named schedules include `scheduleName` field after next cron fire

## Risk

Low. All 3 changes are additive — optional field on an interface, env var in start.sh, spread on existing record calls. No existing behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)