### PR TITLE
feat(metrics): Ship C — tag exporter + turn JSONL + agent turn Grafana panels

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -811,9 +811,18 @@ if [ -n "$SWITCHROOM_LITELLM" ] && command -v switchroom >/dev/null 2>&1; then
   fi
   if [ -n "$sr_ll_ok" ]; then
     # Newline-separated Name: Value pairs (claude CLI ANTHROPIC_CUSTOM_HEADERS format).
+    # Tags: agent:<name> for per-agent spend tracking; profile:<profile> for
+    # fleet-level cost breakdown by role. Per-turn tags (cron vs telegram) are
+    # NOT achievable here — ANTHROPIC_CUSTOM_HEADERS is fixed per process and
+    # the claude CLI sends no session id. Use scheduler.jsonl ↔ /spend/logs
+    # time-window correlation for cron attribution instead.
     export ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: Bearer $sr_ll_key
 x-litellm-customer-id: $SWITCHROOM_AGENT_NAME
-x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME"
+x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:-default}"
+    # Let Claude Code enumerate models from the LiteLLM gateway so non-Claude
+    # models configured in the proxy appear in the /model picker and can be
+    # selected via --model. Without this, the CLI only knows its bundled list.
+    export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
   else
     # Fail-open: drop every routing var so the claude CLI talks to Anthropic
     # directly on its OAuth credential (subscription path), unproxied.

--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -194,6 +194,7 @@ export function recoverPendingEscalations(opts: {
         finishedAt: opts.now(),
         tier: esc.tier === "cheap" ? "cheap" : "main",
         ...(esc.cronModel ? { modelUsed: esc.cronModel } : {}),
+        ...(entry.name ? { scheduleName: entry.name } : {}),
       });
     } catch (e) {
       opts.log(`pending-escalation recovery failed for '${entry.poll.state_key}': ${(e as Error).message}`);
@@ -278,6 +279,7 @@ export function registerAgentSchedule(opts: RegisterOptions): RegisteredTask[] {
             outputSummary: summary,
             startedAt,
             finishedAt: now(),
+            ...(entry.name ? { scheduleName: entry.name } : {}),
           });
           if (more) {
             let handle: { cancel: () => void };
@@ -314,6 +316,7 @@ export function registerAgentSchedule(opts: RegisterOptions): RegisteredTask[] {
           finishedAt: now(),
           tier: fields.tier,
           ...(fields.modelUsed ? { modelUsed: fields.modelUsed } : {}),
+          ...(entry.name ? { scheduleName: entry.name } : {}),
         });
 
       // ── Tier 0: deterministic poll, no model ──────────────────────────
@@ -750,6 +753,7 @@ export async function main(): Promise<void> {
               startedAt,
               finishedAt: Date.now(),
               tier: "action",
+              ...(m.entry.name ? { scheduleName: m.entry.name } : {}),
             });
             continue;
           }
@@ -768,6 +772,7 @@ export async function main(): Promise<void> {
               startedAt,
               finishedAt: Date.now(),
               tier: "poll",
+              ...(m.entry.name ? { scheduleName: m.entry.name } : {}),
             });
             continue;
           }
@@ -787,6 +792,7 @@ export async function main(): Promise<void> {
               : "replay attempted but gateway not connected",
             startedAt,
             finishedAt: Date.now(),
+            ...(m.entry.name ? { scheduleName: m.entry.name } : {}),
           });
         }
       }
@@ -852,6 +858,7 @@ export async function main(): Promise<void> {
                 "not executed",
               startedAt: s.expectedFireMs,
               finishedAt: s.expectedFireMs,
+              ...(s.entry.name ? { scheduleName: s.entry.name } : {}),
             });
           }
         }

--- a/src/scheduler/dispatch.ts
+++ b/src/scheduler/dispatch.ts
@@ -144,6 +144,15 @@ export interface DispatchResult {
   startedAt: number;
   finishedAt: number;
   /**
+   * Human-readable schedule name sourced from the overlay file's `# name:`
+   * comment (or a meaningful filename). Absent for base-config crons and
+   * hash-only overlay filenames. Present in audit JSONL for LiteLLM
+   * cost-correlation: join by agent + time window [startedAt, finishedAt]
+   * against LiteLLM's /spend/logs endpoint to identify which cron schedule
+   * drove a given API request.
+   */
+  scheduleName?: string;
+  /**
    * Cheap-cron observability (reference/rfcs/cheap-cron-sessions.md §5). Which
    * tier this fire took and the model it ran at, so `switchroom schedule
    * report` can show the cost breakdown. Absent on legacy audit rows and

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3317,6 +3317,23 @@ function releaseTurnBufferGate(key: string, endingTurn?: CurrentTurn): void {
  * Idempotent: a second purge is a no-op `.delete()` on a key already
  * gone — handlers that already purge elsewhere are unharmed.
  */
+function emitTurnRecord(turn: CurrentTurn, endedAt: number): void {
+  try {
+    const rec =
+      JSON.stringify({
+        ts: Math.floor(endedAt / 1000),
+        agent: process.env.SWITCHROOM_AGENT_NAME ?? 'unknown',
+        duration_ms: turn.startedAt > 0 ? endedAt - turn.startedAt : 0,
+        tools: turn.toolCallCount ?? 0,
+        status: turn.finalAnswerDelivered ? 'complete' : 'no_reply',
+        turn_id: turn.turnId,
+      }) + '\n'
+    appendFileSync('/state/agent/turns.jsonl', rec)
+  } catch {
+    // best-effort — never let metrics emission break turn teardown
+  }
+}
+
 function endCurrentTurnAtomic(turn: CurrentTurn): void {
   // PR-4e — keyed liveness + keyed clear (leak-close-at-origin). Flag-OFF: the
   // guard is `currentTurn === turn` and the clear nulls the singleton, verbatim.
@@ -3331,9 +3348,11 @@ function endCurrentTurnAtomic(turn: CurrentTurn): void {
   // Status-surface observability: one line at every turn CLEAR (with how far
   // the turn got), plus a DEGRADED warning when the turn did tool work but the
   // live feed never opened because its sends failed (the resume-400 signature).
+  const turnEndedAt = Date.now()
   process.stderr.write(
-    `telegram gateway: ${formatTurnLifecycle('clear', 'turn_end', turn, Date.now())}\n`,
+    `telegram gateway: ${formatTurnLifecycle('clear', 'turn_end', turn, turnEndedAt)}\n`,
   )
+  emitTurnRecord(turn, turnEndedAt)
   const degraded = detectStatusSurfaceDegraded(turn)
   if (degraded != null) {
     process.stderr.write(


### PR DESCRIPTION
## Summary

Ship C of the LiteLLM observability stack: closes the per-tag and per-turn visibility gaps identified in the CPO-level fleet dashboard work.

- **`gateway.ts`**: `emitTurnRecord()` appended at `endCurrentTurnAtomic` — writes a JSON line to `/state/agent/turns.jsonl` at every turn end. Fields: `ts`, `agent`, `duration_ms`, `tools`, `status` (`complete` | `no_reply`), `turn_id`. Failure is swallowed — never breaks turn teardown.
- **`profiles/_base/start.sh.hbs`** (prior commit): adds `profile:<name>` tag to `x-litellm-tags` + enables gateway model discovery.
- **`src/agent-scheduler/index.ts` + `dispatch.ts`** (prior commit): `scheduleName` propagated through cron JSONL for time-window join against spend logs.

## Infrastructure (deployed alongside, not in this repo)

Two Coolify sidecar services added to the LiteLLM compose project:

| Container | Image | Port | What it exposes |
|-----------|-------|------|-----------------|
| `litellm-tag-exporter` | `python:3.12-alpine` | 9092 | `litellm_tag_{input,output,total}_tokens{tag,window}` + `litellm_tag_requests{tag,window}` from `LiteLLM_SpendLogs.request_tags` |
| `switchroom-metrics` | `python:3.12-alpine` | 9093 | `switchroom_turns_24h`, `switchroom_avg_turn_duration_ms`, `switchroom_avg_tools_per_turn`, `switchroom_turn_errors_24h` from `~/.switchroom/agents/*/turns.jsonl` |

Both scrape jobs are registered in `prometheus.yml` and all four targets are `up`.

Grafana dashboard `litellm-agent-usage` updated: replaced placeholder "About Per-Tag Spend" text panel with real per-tag barcharts + detail table, and added "Agent Turn Activity" row (turns/agent + avg duration timeseries).

## Why

CPO-level outcome: which agents are doing how much work, and how often do they reply? This closes the gap between "total tokens per agent" (already available) and "what's actually happening per turn / per tag."

## Test plan

- [x] `tsc --noEmit` clean (0 errors)
- [x] `vitest run telegram-plugin/tests/` — 257 files, 4250 tests pass
- [x] All 4 Prometheus targets `up` on first scrape
- [ ] Verify `turns.jsonl` populates on next agent turn (will populate on fleet restart or next real turn)

## Risk

Low. `emitTurnRecord` catches all exceptions — cannot affect turn teardown. The textfile approach means a missing or corrupt line is silently skipped by the aggregator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)