### PR TITLE
docs(reference): pivot fleet dashboard to Hermes-Desktop adapter (admin console out of telegram-only scope)

### DIFF
--- a/reference/invariants.md
+++ b/reference/invariants.md
@@ -120,19 +120,28 @@ Slack, Discord, or Teams. Auxiliary services (e.g. voice transcription) are
 opt-in helpers, not second channels.
 
 - **By-construction test:** does this add a second human-facing chat
-  channel? If yes, it is out.
+  channel **for the people the team serves** — a bridge to WhatsApp, Signal,
+  Slack, Discord, Teams, or the like? If yes, it is out. This invariant is
+  about the *principal's* channel: there is exactly one, Telegram, done
+  properly. It is **not** a ban on operator/admin tooling.
 
-### Operator-console carve-out
+### Scope: the admin console is not a channel
 
-An **operator-only** management console (e.g. a Hermes-Desktop client pointed
-at a Switchroom adapter) MAY let the operator send a turn to one of their own
-agents from outside Telegram — **iff** all four hold:
+An **operator/admin** management console (e.g. a Hermes-Desktop client pointed
+at a Switchroom adapter) is **out of this invariant's scope** — it is admin
+tooling for the person who runs the box, not a chat channel for the people the
+team serves. `telegram-only` stays strictly true: it governs *principal*
+channels, and the admin console is not one.
 
-1. **Operator audience only.** The console is authenticated, single-tenant,
-   and never reachable by a principal as their way to talk to an agent. It is
-   the operator's workshop view, not a second front door for the people the
-   team serves. (This is the same "audience is the whole line" reasoning that
-   keeps an operator surface clear of `chat-is-the-single-source-of-truth`.)
+The console MAY let the operator send a turn to one of their own agents from
+outside Telegram. To stay admin tooling (and not quietly become a second
+channel or a hidden conversation), it must hold all four:
+
+1. **Operator/admin audience only.** Authenticated, single-tenant, never
+   reachable by a principal as *their* way to talk to an agent. It is the
+   operator's workshop view, not a second front door for the people the team
+   serves. (Same "audience is the whole line" reasoning that keeps an operator
+   surface clear of `chat-is-the-single-source-of-truth`.)
 2. **One canonical record.** Every operator turn and the agent's reply
    **mirror into that agent's Telegram thread.** The console is another way
    *in*, never a separate conversation the Telegram thread can't see — so
@@ -147,11 +156,10 @@ agents from outside Telegram — **iff** all four hold:
    sole approval surface (`no-self-escalation`). A console that wires
    approvals is out.
 
-This is telegram-only by construction: there is still one channel of record
-(Telegram) and one trust anchor for consequential actions (the Telegram tap).
-The carve-out admits an operator *input surface* that feeds the one thread —
-not a second human-facing channel with its own audience and its own history.
-The detail contract is [`rfcs/fleet-dashboard.md`](rfcs/fleet-dashboard.md).
+The line that *would* cross `telegram-only` is a **principal-facing** bridge —
+giving the people the team serves a second way to chat (WhatsApp, Signal, a
+public web chat). That is still out. The detail contract for the admin console
+is [`rfcs/fleet-dashboard.md`](rfcs/fleet-dashboard.md).
 
 ## `chat-is-the-single-source-of-truth`
 

--- a/reference/invariants.md
+++ b/reference/invariants.md
@@ -122,6 +122,37 @@ opt-in helpers, not second channels.
 - **By-construction test:** does this add a second human-facing chat
   channel? If yes, it is out.
 
+### Operator-console carve-out
+
+An **operator-only** management console (e.g. a Hermes-Desktop client pointed
+at a Switchroom adapter) MAY let the operator send a turn to one of their own
+agents from outside Telegram — **iff** all four hold:
+
+1. **Operator audience only.** The console is authenticated, single-tenant,
+   and never reachable by a principal as their way to talk to an agent. It is
+   the operator's workshop view, not a second front door for the people the
+   team serves. (This is the same "audience is the whole line" reasoning that
+   keeps an operator surface clear of `chat-is-the-single-source-of-truth`.)
+2. **One canonical record.** Every operator turn and the agent's reply
+   **mirror into that agent's Telegram thread.** The console is another way
+   *in*, never a separate conversation the Telegram thread can't see — so
+   there is still exactly one record, and `chat-is-the-single-source-of-truth`
+   holds.
+3. **Same path, not a parallel runtime.** The operator turn is injected
+   through the existing synthesized-inbound path (the cron / `inject_inbound`
+   pattern), landing as an ordinary turn in the one agent session. No second
+   agent loop, no second inference path.
+4. **Approvals stay on Telegram.** The console never gains an
+   approve/deny/grant action; the human-validated Telegram tap remains the
+   sole approval surface (`no-self-escalation`). A console that wires
+   approvals is out.
+
+This is telegram-only by construction: there is still one channel of record
+(Telegram) and one trust anchor for consequential actions (the Telegram tap).
+The carve-out admits an operator *input surface* that feeds the one thread —
+not a second human-facing channel with its own audience and its own history.
+The detail contract is [`rfcs/fleet-dashboard.md`](rfcs/fleet-dashboard.md).
+
 ## `chat-is-the-single-source-of-truth`
 
 Status and progress never live in a surface running *parallel* to the

--- a/reference/jobs/see-my-whole-fleet-from-one-screen.md
+++ b/reference/jobs/see-my-whole-fleet-from-one-screen.md
@@ -1,6 +1,6 @@
 ---
 job: see and manage my whole fleet from one operator screen
-outcome: The operator can open one browser surface and see every agent's live state, health, quota, history, sessions, memory, workspace, and approval/audit trail, and run fleet ops (start/stop/restart, config edits) — without any secret reaching the browser and without the surface ever becoming the principal's source of truth or a second chat channel.
+outcome: The operator can open one management console and see every agent's live state, health, quota, history, sessions, memory, workspace, and approval/audit trail, run fleet ops (restart, config edits), and drive an agent with a turn from the console — without any secret reaching the client, without approvals ever leaving Telegram, and without the surface becoming the principal's source of truth or a separate conversation record (operator turns mirror into the agent's Telegram thread).
 stakes: An operator running a standing fleet 24/7 needs a place to glance across all of it at once — the chat is per-agent and per-topic, so a fleet-wide problem (a stuck agent, a quota wall, a drifted config, a failing memory backend) is invisible until a principal complains. Without a fleet view the operator debugs blind, one `docker exec` at a time. But a dashboard is also the easiest place to accidentally rebuild the retired progress card, leak a token, or grow a second approval path — so the screen earns its place only by staying an operator tool, never a principal one.
 serves: hold-the-leash
 invariants: [chat-is-the-single-source-of-truth, telegram-only, no-self-escalation, single-tenant, claude-native]
@@ -8,10 +8,11 @@ invariants: [chat-is-the-single-source-of-truth, telegram-only, no-self-escalati
 
 # Job Spec: see and manage my whole fleet from one operator screen
 
-> A durable Job Spec. The *how* — the `switchroom-web` service, its read
-> adapters, the auth gate, the compose wiring — lives in the design artifact
-> `reference/rfcs/fleet-dashboard.md` and the code under `src/web/`. That
-> implementation churns; this job does not.
+> A durable Job Spec. The *how* — the Hermes-Desktop adapter (REST + JSON-RPC
+> WebSocket) served from `switchroom-web`, the unmodified Hermes Desktop run
+> in remote mode, the `inject_inbound` mirror, the auth gate — lives in the
+> design artifact `reference/rfcs/fleet-dashboard.md` and the code under
+> `src/web/`. That implementation churns; this job does not.
 
 ## Who this is for — read this first
 
@@ -57,10 +58,15 @@ channel or a second approval path.
 - The approval/grant trail is visible as a **read-only audit feed** across
   the fleet, plus what's currently pending — so the operator can see the
   leash state at a glance.
-- Fleet ops the operator already does from the CLI — start / stop / restart,
-  and operator config edits — are available from the screen, routed through
-  the same operator-authored, hostd/CLI-enforced paths, never a new
-  privileged backdoor.
+- Fleet ops the operator already does from the CLI — restart, and operator
+  config edits — are available from the screen, routed through the same
+  operator-authored, hostd/CLI-enforced paths, never a new privileged
+  backdoor.
+- The operator can send a turn to one of their own agents from the console,
+  and that turn plus the agent's reply **mirror into the agent's Telegram
+  thread** — the console is another way *in*, never a separate conversation
+  the Telegram thread can't see. The turn rides the same synthesized-inbound
+  path as cron, landing in the one agent session.
 - Off by default, binds loopback by default, refuses to serve
   unauthenticated when bound to a non-loopback address; Tailscale is the
   documented remote path.
@@ -84,8 +90,12 @@ channel or a second approval path.
   human-validated Telegram tap; the trust anchor stays there
   (`no-self-escalation`). The web may *display* pending approvals and
   history; the decision never happens here.
-- A **second human-facing chat channel** — a web prompt box that talks to an
-  agent as a new conversation surface. That crosses `telegram-only`.
+- A **principal-facing** way in from the console, or an operator turn that
+  does **not** mirror into the Telegram thread (a hidden side-channel
+  conversation). The operator-console carve-out to `telegram-only` holds only
+  while the console is operator-only and every turn surfaces in the one
+  Telegram record. A prompt box the principal uses, or an unmirrored aside,
+  crosses `telegram-only`.
 - Any secret reaching the browser, an API response, or a log
   (`credentials.json`, vault values, OAuth/bot tokens).
 - A mutating path that lets the web grant access the operator's config
@@ -112,10 +122,14 @@ principal's chat jobs). Pin:
 - **Leash visible, never operated** — pending approvals + the grant/audit
   trail render read-only. *Invariant:* there is no approve/deny endpoint;
   the only approval action in the whole product is the Telegram tap.
-- **Fleet ops, not backdoors** — start/stop/restart and config edits route
-  through the existing hostd/CLI operator paths. *Invariant:* the web grants
-  no access the operator's config didn't already authorize; no path mutates
-  the vault or resolves an approval.
+- **Fleet ops, not backdoors** — restart and config edits route through the
+  existing hostd/CLI operator paths. *Invariant:* the console grants no access
+  the operator's config didn't already authorize; no path mutates the vault or
+  resolves an approval.
+- **Operator turn = one record** — a turn sent from the console produces a
+  real turn in the target agent's Telegram thread (turn and reply observable
+  there). *Invariant:* the console never opens a conversation the Telegram
+  thread can't see; the operator-console carve-out holds.
 - **Exposure floor** — off by default; loopback bind default; unauthenticated
   non-loopback bind is refused. *Invariant:* a network-accessible bind
   without auth never serves.
@@ -149,5 +163,8 @@ principal's chat jobs). Pin:
 ---
 
 > **Implementation:** `reference/rfcs/fleet-dashboard.md` (the design
-> artifact, `serves:` this job) and `src/web/` (the `switchroom-web`
-> service). Those churn; this job outlives them.
+> artifact, `serves:` this job) — the Hermes-Desktop adapter served from
+> `src/web/` (`switchroom-web`), with unmodified Hermes Desktop run in remote
+> mode as the client. The `telegram-only` operator-console carve-out that
+> makes operator-chat legal lives in `reference/invariants.md`. Those churn;
+> this job outlives them.

--- a/reference/jobs/see-my-whole-fleet-from-one-screen.md
+++ b/reference/jobs/see-my-whole-fleet-from-one-screen.md
@@ -92,9 +92,9 @@ channel or a second approval path.
   history; the decision never happens here.
 - A **principal-facing** way in from the console, or an operator turn that
   does **not** mirror into the Telegram thread (a hidden side-channel
-  conversation). The operator-console carve-out to `telegram-only` holds only
-  while the console is operator-only and every turn surfaces in the one
-  Telegram record. A prompt box the principal uses, or an unmirrored aside,
+  conversation). The admin console stays out of `telegram-only`'s scope only
+  while it is operator-only and every turn surfaces in the one Telegram
+  record. A prompt box the principal uses, or a bridge to WhatsApp/Signal,
   crosses `telegram-only`.
 - Any secret reaching the browser, an API response, or a log
   (`credentials.json`, vault values, OAuth/bot tokens).
@@ -129,7 +129,7 @@ principal's chat jobs). Pin:
 - **Operator turn = one record** — a turn sent from the console produces a
   real turn in the target agent's Telegram thread (turn and reply observable
   there). *Invariant:* the console never opens a conversation the Telegram
-  thread can't see; the operator-console carve-out holds.
+  thread can't see; the admin console stays out of telegram-only's scope.
 - **Exposure floor** — off by default; loopback bind default; unauthenticated
   non-loopback bind is refused. *Invariant:* a network-accessible bind
   without auth never serves.
@@ -165,6 +165,7 @@ principal's chat jobs). Pin:
 > **Implementation:** `reference/rfcs/fleet-dashboard.md` (the design
 > artifact, `serves:` this job) — the Hermes-Desktop adapter served from
 > `src/web/` (`switchroom-web`), with unmodified Hermes Desktop run in remote
-> mode as the client. The `telegram-only` operator-console carve-out that
-> makes operator-chat legal lives in `reference/invariants.md`. Those churn;
-> this job outlives them.
+> mode as the client. `reference/invariants.md` records why the admin console
+> is out of `telegram-only`'s scope (it governs principal channels, not admin
+> tooling) and the conditions that keep it so. Those churn; this job outlives
+> them.

--- a/reference/rfcs/fleet-dashboard.md
+++ b/reference/rfcs/fleet-dashboard.md
@@ -1,208 +1,216 @@
 ---
-artefact: Fleet dashboard — operator web surface, scope + invariant gates
+artefact: Fleet dashboard — Hermes-Desktop adapter for the operator console
 serves: jobs/see-my-whole-fleet-from-one-screen.md
-status: rfc — draft. Records the alignment review of an externally-authored
-  "Hermes-class dashboard" plan and re-scopes it against the dashboard that
-  already ships (`src/web/`, `switchroom-web` compose project).
+status: rfc — draft. Pivoted from "build our own SPA" to "expose the
+  Hermes-Desktop contract from a Switchroom adapter and run the unmodified
+  desktop in remote mode." Carries the alignment review of the original
+  external plan.
 relates: "jobs/know-what-my-agent-is-doing.md jobs/track-plan-quota-live.md
-  jobs/restart-and-know-what-im-running.md rfcs/conversational-pacing.md
-  rfcs/host-control-daemon.md rfcs/access-model.md #1122"
+  jobs/restart-and-know-what-im-running.md jobs/steer-or-queue-mid-flight.md
+  rfcs/conversational-pacing.md rfcs/host-control-daemon.md
+  rfcs/access-model.md invariants.md #1122"
 ---
 
-# Fleet dashboard — operator web surface
+# Fleet dashboard — Hermes-Desktop adapter for the operator console
 
 ## TL;DR
 
-An external plan proposed building a "Hermes-class" management dashboard for
-Switchroom. The plan was written **blind to the source** (GitHub blocked the
-`src/` read), so its central premise is wrong: **the dashboard already
-exists.** `src/web/` is served by the `switchroom-web` compose project (its
-own project, pinned GHCR image — memory `project_web_dashboard_local_hotfix_deploy`)
-and already does fleet list + restart (start/stop deferred to a follow-up
-approval PR), logs, turns, sub-agents, accounts/quota, system + memory
-health, schedule, approvals + grants (read), connections, and config edits
-via hostd.
+The operator wants a Hermes-class management surface. Rather than build our
+own SPA, **Switchroom exposes the Hermes-Desktop integration contract** and
+the operator runs the **unmodified, MIT-licensed Hermes Desktop** (NousResearch
+`hermes-agent/apps/desktop`) in its **remote-gateway mode**, pointed at a
+Switchroom adapter. The adapter speaks the desktop's two transports — REST
+`/api/*` and **JSON-RPC-2.0-over-WebSocket** `/api/ws` — backed by
+Switchroom's own artifacts and IPC.
 
-So this is an **extend, not a build-new**. This RFC (a) records the
-alignment review of the plan against `vision` / `principles` / `invariants`,
-(b) keeps the genuinely good parts of the plan, (c) **hard-gates the one
-piece that crosses an invariant** (a live progress-card mirror), and (d)
-lists the net-new work worth doing on top of the existing dashboard.
+The connection is **observe + operator-chat, approvals stay on Telegram**:
 
-The plan's compliance instincts (no API/SDK, no token egress, untrusted-
-content escaping, jailed file browser) are **excellent and adopted wholesale**
-— they restate `claude-native` / `no-self-escalation` correctly.
+- **Observe.** Implement the read/list/event subset so the desktop renders
+  the fleet, sessions, history, and a live per-agent activity stream.
+- **Operator chat.** Implement `prompt.submit` by routing the operator's turn
+  through Switchroom's existing **synthesized-inbound path** (`inject_inbound`
+  / cron pattern). The operator's turn **and the agent's reply mirror into
+  that agent's Telegram thread** — one canonical record.
+- **Approvals stay on Telegram.** We simply **do not implement** the approval
+  methods/events; per the desktop's graceful-degradation behaviour that panel
+  just stays empty. The Telegram tap remains the sole approval surface.
 
-## Alignment review of the external plan
+This crosses one hard invariant (`telegram-only`), handled by the new
+**operator-console carve-out** added to `invariants.md` in this change. No
+desktop fork is maintained — we track upstream by implementing its contract.
 
-### What the plan got right (keep)
+## Decisions (owner-ratified)
 
-- **I1 / I3 (no API-SDK, no secret egress).** Exact match for `claude-native`
-  + `no-self-escalation`. The dashboard reads Switchroom's own artifacts and
-  CLI verbs, never `api.anthropic.com`, never a token. Keep as the PR gate.
-- **I4 (untrusted content).** Escape everything; jail + traversal-test the
-  file browser. Correct and not yet fully proven in `src/web/` — adopt as
-  net-new test work (see Net-new §).
-- **Exposure floor.** Off by default, loopback bind default, refuse
-  unauthenticated non-loopback. This already exists (`src/cli/web.ts` warns
-  on LAN bind; `server.ts` token-gates `/api/*`) — keep and make the refusal
-  hard, not a warning.
-- **Aggregator pattern.** A single per-host service sibling to the fleet is
-  the right shape, and is what already ships.
+These were settled with the owner before this draft (see the carve-out in
+`invariants.md`):
 
-### Where the plan diverges from reality (correct before coding)
+1. **No return of the progress card.** This is not the retired #1122 card
+   rebuilt anywhere. The live desktop activity stream is an **operator**
+   surface; the Telegram chat prompt is untouched, so the model still
+   narrates to the principal (no crutch).
+2. **Unmodified Hermes Desktop, remote mode.** Adapter-only. No fork.
+3. **Observe + operator chat; approvals Telegram-only.**
+4. **Operator turns + replies mirror into Telegram.**
+5. **`src/web` is additive-and-decide-later** — the existing dashboard keeps
+   shipping; whether it's eventually redundant to the Hermes path is revisited
+   once the adapter is proven, not pre-committed.
 
-1. **"`switchroom web` is likely a stub" — false.** It is a substantial
-   React SPA + Bun server (`src/web/server.ts`, `api.ts`, `ui/`) shipping as
-   `switchroom-web`. The plan's Phase 0 "extend vs replace" is already
-   decided: **extend.** Read `src/web/` first; most Phase-1 endpoints in the
-   plan already exist (`/api/agents`, `/api/summary`, `/api/system-health`,
-   `/api/memory-health`, `/api/schedule`, `/api/approvals`, `/api/grants`,
-   `/api/accounts`).
-2. **"Phase 1 strictly read-only / zero web mutations" — stricter than
-   shipped reality, and not what the invariants require.** The existing
-   dashboard already restarts agents, refreshes quota, sets connection
-   access, and edits config via hostd. `telegram-only` is about a second
-   **human-facing chat channel**, not operator fleet ops; `no-self-escalation`
-   permits any action that flows from operator config / an operator tap and
-   is enforced where the agent can't rewrite it. So **operator fleet ops on
-   the web are in scope** — provided they route through the existing
-   hostd/CLI operator-authored paths (`host-control-daemon.md`) and never the
-   one thing that is reserved: **approvals.**
-3. **Approvals: the plan is right, restate it as the hard line.** No
-   Allow/Deny on the web, ever. Approvals are the human-validated Telegram
-   tap — the trust anchor of `no-self-escalation`. Web *displays* pending +
-   history; the decision is Telegram-only. (The existing `/api/approvals` /
-   `/api/grants` are read-only — keep them that way; never add a resolve
-   endpoint.)
-4. **Stale stack facts.** The plan cites Buildkite CI (retired 2026-05-15,
-   now GHA), changesets (this repo uses Conventional Commits + `CHANGELOG.md`,
-   no changesets), and the systemd model (Docker Compose is current). Ignore
-   those.
+## The integration contract (from a source read of `hermes-agent`)
 
-### The one invariant collision — gate it
+The desktop is **Electron + React + nanostores**; it embeds no backend in the
+renderer and supports a documented **remote-gateway** mode
+(`apps/desktop/electron/connection-config.cjs`). It talks to a backend two ways:
 
-**Phase 2 of the plan ("live step-stream timeline / Hermes-style progress
-cards") crosses `chat-is-the-single-source-of-truth`.** It proposes
-reconstructing the progress card — last-N steps, elapsed timers, sub-agent
-nesting, `(1/N)` — as a live web surface running parallel to the
-conversation. That surface is the **retired #1122 card**, rebuilt on the web.
-The job [`know-what-my-agent-is-doing`](../jobs/know-what-my-agent-is-doing.md)
-names it explicitly under "never ship this": *"A separate progress surface
-running parallel to the chat… covers for a model that won't talk."*
+- **REST `/api/*`** via `apps/desktop/src/hermes.ts` — sessions, status,
+  config, model/provider info, etc. (CRUD + reads).
+- **JSON-RPC 2.0 over WebSocket `/api/ws`** via
+  `apps/shared/src/json-rpc-gateway.ts` — the live turn + control. Requests
+  `{jsonrpc,id,method,params}`; server→client events are notifications with a
+  fixed method `"event"` and `params:{type, session_id, payload}`. The first
+  frame after open is always `gateway.ready`.
 
-The collision is not "a dashboard is bad." It is specifically the **live
-parallel mirror of an in-flight turn**. The distinction this RFC draws:
+Canonical data types live in `apps/desktop/src/types/hermes.ts`. Auth is
+**token mode** by default (`X-Hermes-Session-Token` header on REST, `?token=`
+on WS) — which maps cleanly onto Switchroom's existing `switchroom-web` token
++ Tailscale setup. Per the research, **features we don't implement degrade
+that panel only; they don't block chat.**
 
-- **Allowed — post-hoc operator review of durable artifacts.** History,
-  session transcripts, the `card-events.jsonl` audit trail, sub-agent
-  records. The operator inspects what an agent *did*. This is observability
-  over already-persisted state, not a live state mirror, and it does not
-  substitute for the model talking in chat.
-- **Gated — a live, auto-updating "what is the agent doing right now" card**
-  that an operator (or worse, a principal) watches *instead of* the chat.
-  That is the card. Do not build it. If live freshness is wanted, it is
-  bounded to coarse operator status (up / working / idle / recovering) on the
-  fleet grid — a liveness dot, not a step-by-step turn mirror — and it is
-  never presented to a principal.
+### Adapter surface — MVP
 
-The gateway event-bus refactor the plan proposes (Phase 2 §6) exists to feed
-that gated card, so it is **out of scope** here. If a future need for a
-structured operator event stream appears, it gets its own RFC and its own
-invariant check; it does not ride in on this one.
+**WS methods to implement (the chat + observe core):**
+
+| Method | Switchroom backing |
+|---|---|
+| `session.create` / `session.resume` / `session.activate` / `session.close` | map to the agent's claude session; "session" ≈ a Switchroom agent/turn context |
+| `session.list` / `session.most_recent` / `session.history` / `session.status` / `session.usage` | per-agent SQLite inbound buffer + session JSONL + `auth list --json` (quota) |
+| `prompt.submit` (and `prompt.background`) | **route through `inject_inbound`**; mirror to Telegram (see below) |
+| `session.interrupt` / `session.steer` | map to the existing interrupt / steer-or-queue path (`steer-or-queue-mid-flight`) |
+
+**WS events to emit during a turn** (subset of the desktop's vocabulary):
+`gateway.ready`, `session.info`, `message.start` / `message.delta` /
+`message.complete`, `status.update`, `tool.start` / `tool.complete`,
+`error`, `background.complete`.
+
+**NOT implemented (panels degrade empty, by design):**
+`approval.request` / `approval.respond`, `sudo.*`, `secret.*` (approvals stay
+Telegram); plus `pet.*`, `billing.*`, `moa.*`, `voice.*`, computer-use,
+messaging-platforms (Hermes's own chat gateway — irrelevant to us).
+
+**REST subset to implement:** `/api/sessions*`, `/api/status`,
+`/api/logs`, `/api/analytics/usage`, `/api/config` (read; secrets redacted).
+Model/provider/env endpoints return Switchroom's claude-native truth
+(single provider, OAuth-slot health as metadata) — never a token.
+
+### The mirror (the load-bearing bit)
+
+`prompt.submit` must not open a private side-channel. Implementation:
+
+1. Operator turn → adapter → `inject_inbound` to the target agent's gateway,
+   tagged with an operator-console source (analogous to `meta.source="cron"`).
+2. The agent processes it as an ordinary turn in its **one** session.
+3. The agent's reply is delivered to the agent's **Telegram thread** as
+   normal; the adapter relays the same stream to the desktop via
+   `message.delta` so the desktop is live too.
+
+Result: exactly one record (Telegram), the desktop is an input + live view,
+nothing is hidden. This is what keeps the `telegram-only` carve-out honest.
+
+## Alignment review of the original external plan (still valid)
+
+The external plan was written **blind to source**. Findings that still hold:
+
+- **The card is gated.** The plan's "live progress-card step-stream timeline"
+  was the retired #1122 card. We are not rebuilding it in Telegram. The
+  desktop's live stream is allowed only as an **operator** surface (audience
+  is the whole line; chat prompt untouched).
+- **`src/web` already exists** (the plan assumed `switchroom web` was a stub).
+  It ships as the `switchroom-web` compose project with fleet list + restart
+  (start/stop deferred to a follow-up approval PR), logs, turns, sub-agents,
+  accounts/quota, health, schedule, approvals + grants (read), connections,
+  config edits via hostd. The Hermes adapter is **additive** to it.
+- **Stale stack facts:** the plan cited Buildkite (retired 2026-05-15, now
+  GHA) and changesets (this repo uses Conventional Commits + `CHANGELOG.md`).
+  Ignore those.
+- **Compliance instincts adopted wholesale:** no Anthropic API/SDK, no token
+  egress, escape all untrusted content, jail the file browser.
+
+## Where the adapter lives
+
+Recommended: **extend the existing `src/web` server** to also serve the Hermes
+contract (`/api/ws` JSON-RPC + the `/api/*` REST subset) rather than stand up
+a new service. `src/web` already has a Bun HTTP+WS server, the `/api/*` token
+gate, loopback-default bind, and the Tailscale serve path
+(`project_web_dashboard_local_hotfix_deploy`). Adding the Hermes routes there
+reuses auth, exposure, and the compose wiring, and keeps one operator service
+to deploy. Confirm in implementation that the JSON-RPC `/api/ws` namespace
+doesn't collide with the existing live-log WS.
 
 ## Scope
 
-**Already shipped (verify, harden — do not rebuild):** fleet list + status,
-restart (start/stop deferred to a follow-up approval PR), logs, turns,
-sub-agents, accounts/quota health, system +
-memory health, schedule, approvals + grants (read), connections, config edit
-via hostd, token auth on `/api/*`, loopback-default bind.
+**In scope:** the adapter (WS MVP + REST subset above), the `prompt.submit`→
+`inject_inbound`→Telegram-mirror path, token auth reuse, compose wiring so the
+adapter survives `switchroom apply`, and a docs note on pointing Hermes
+Desktop at the Switchroom URL.
 
-**Net-new worth doing (on top of the existing dashboard):**
-
-1. **History browser** — per-agent SQLite inbound buffer, read-only (WAL,
-   separate read connection, last-write-wins tolerant), with cron-tagged
-   turns (`meta.source="cron"`) labelled distinctly.
-2. **Sessions view** — JSONL transcripts with continuity-mode awareness
-   (handoff vs continue vs cold) and a wake-audit / recovery indicator, so a
-   fresh-session-with-handoff is not mislabelled as a continued transcript.
-   This is the operator-side mirror of
-   [`restart-and-know-what-im-running`](../jobs/restart-and-know-what-im-running.md).
-3. **Workspace / worktree file browser** — sandboxed, canonicalised, jailed
-   to the agent workspace root, size-capped previews, binaries refused. Never
-   serves arbitrary host paths.
-4. **Audit feed** — `card-events.jsonl` rendered read-only across the fleet
-   (rotation / partial-trailing-line tolerant tailer), beside the existing
-   pending-approvals view.
-5. **Security hardening pass** — XSS audit of every rendered field
-   (message/tool/file/memory content is untrusted), path-traversal tests on
-   the file API, a secret-redaction test asserting no response body ever
-   contains token-shaped material, and turning the non-loopback-without-auth
-   case from a warning into a hard refusal.
-
-**Out of scope (gated):**
-
-- The live progress-card / step-stream timeline and its gateway event-bus
-  refactor (crosses `chat-is-the-single-source-of-truth` — see above).
-- Any web Allow/Deny / approval-resolve action (`no-self-escalation`).
-- A web prompt box that opens a new conversation surface to an agent
-  (`telegram-only`). Routing an operator prompt through the existing
-  synthesized-inbound path is a *separate* future RFC with its own invariant
-  review — not assumed here.
-- Anything the principal is meant to open to know what their agent is doing
-  or where their quota stands — those stay in chat
-  (`know-what-my-agent-is-doing`, `track-plan-quota-live`).
+**Out of scope:** any approval/grant action in the console
+(`no-self-escalation`); a desktop fork; implementing the Hermes inference /
+agent runtime (we only emit its event stream + answer its RPCs); the PTY /
+embedded-terminal path; Hermes's own messaging-platform gateway; deprecating
+`src/web` (decide later).
 
 ## Principle checks
 
-- **Docs test:** the dashboard is an operator power tool; it does not replace
-  any self-teaching CLI/chat surface and does not become required reading for
-  a principal. The CLI (`switchroom web`) prints its bind + exposure state
-  inline. Pass.
-- **Defaults test:** off by default, loopback by default, zero config to run.
-  A fresh `switchroom setup` fleet works with no dashboard. Pass.
-- **Consistency test:** reuses the config cascade, the vault model (reads
-  *metadata*, never values), the hostd operator-action path, and the same
-  agent nouns as the CLI. No new interaction idiom for the principal. Pass —
-  *provided* the gated live-card is not built, which would reintroduce the
-  retired parallel-surface idiom.
+- **Docs test:** operator power tool; one docs line to point the desktop at
+  the URL. The principal never touches it. Pass.
+- **Defaults test:** off by default, loopback default, token-gated, zero
+  config to a working fleet without it. Pass.
+- **Consistency test:** reuses the `src/web` server, the token/Tailscale
+  exposure model, the `inject_inbound` turn path, the vault metadata-only
+  rule, and the same agent nouns. The operator turn rides the *same*
+  conversational pacing because it becomes an ordinary Telegram-thread turn.
+  Pass.
 
 ## Invariant checks
 
 | Invariant | Verdict |
 |---|---|
-| `claude-native` | Pass — reads artifacts + CLI verbs only; no API/SDK/token. |
-| `no-self-escalation` | Pass — mutations route through hostd/CLI operator paths; **no web approval action**; web grants nothing the config didn't authorize. |
-| `chat-is-the-single-source-of-truth` | Pass **only with the live-card gated out**. Post-hoc artifact review is fine; a live parallel turn mirror is not. |
-| `telegram-only` | Pass — operator observability + fleet ops are not a second chat channel; a web prompt box would be, and is out of scope. |
-| `single-tenant` | Pass — one operator, one deployment, auth-gated, loopback default. |
+| `claude-native` | Pass — adapter emits events + answers RPCs over Switchroom's own data/IPC; no API/SDK/token; the agent runtime is still the unmodified CLI. |
+| `no-self-escalation` | Pass — approval methods are not implemented; the Telegram tap stays the sole approval surface. |
+| `chat-is-the-single-source-of-truth` | Pass — operator-audience surface; chat prompt untouched (no crutch); turns + replies mirror into the one Telegram thread. |
+| `telegram-only` | Pass **under the new operator-console carve-out** (`invariants.md`): one channel of record, operator-only input, same inbound path, approvals on Telegram. |
+| `single-tenant` | Pass — one operator, auth-gated, single deployment. |
 
 ## Testing
 
-- Web/integration tests under `src/web/*.test.ts` (the existing pattern), not
-  the Telegram mtcute UAT corpus.
-- Unit: jsonl tailer (rotation / partial line), SQLite read adapter
-  (concurrent-write tolerance), path-traversal jail, secret-redaction.
-- Security: XSS payloads in message/tool/file content render inert; traversal
-  attempts on the file API are refused; no response body carries token-shaped
-  material; non-loopback bind without auth refuses to serve.
+- Web/integration tests under `src/web/*.test.ts`.
+- Contract tests: the adapter's `/api/ws` answers a recorded Hermes-Desktop
+  handshake (`gateway.ready`) and a `session.list` / `prompt.submit` exchange;
+  emitted event frames match the `{type,session_id,payload}` shape.
+- **Mirror test:** an operator `prompt.submit` produces a real turn in the
+  target agent's Telegram thread (the turn and reply are observable there),
+  not just on the WS — the load-bearing carve-out condition.
+- **No-approval test:** the adapter exposes no approve/deny method; an
+  `approval.respond` call is rejected/absent.
+- Secret-redaction: no REST/WS payload ever carries token-shaped material.
 
 ## Deployment
 
-`switchroom-web` is its own compose project (`~/.switchroom/web/docker-compose.yml`,
-pinned GHCR image — code baked in, no source mount), reached via
-`tailscale serve` → `127.0.0.1:8080`. A merged `src/web/` change does **not**
-update the live dashboard without an image rebuild + recreate (memory
-`project_web_dashboard_local_hotfix_deploy`). New work must keep the service
+The adapter ships in the `switchroom-web` service (its own compose project,
+pinned GHCR image — `project_web_dashboard_local_hotfix_deploy`), reached via
+`tailscale serve` → `127.0.0.1:8080`. The operator points Hermes Desktop's
+remote-gateway config at that URL with the service token. Keep the service
 rendered from config so it survives `switchroom apply` — never hand-edited
 into the generated compose file.
 
 ## Open questions
 
-1. Confirm with the owner that the **live progress-card mirror stays gated**
-   out — this is the one place the external plan and the invariants disagree,
-   and the invariant wins unless the owner explicitly revisits #1122.
-2. Confirm the **coarse fleet-grid liveness dot** (up/working/idle/recovering)
-   is acceptable as the only "live" element, distinct from a step mirror.
-3. Net-new priority order: history → sessions → files → audit, or reorder?
+1. Session model mapping: Hermes "sessions" are first-class, multi-per-profile;
+   Switchroom has one live claude session per agent + a turn/inbound history.
+   Confirm the cleanest mapping (agent = profile, session = a resumable
+   turn-context vs the single live session) during the spike.
+2. Live stream source: which Switchroom seam feeds `message.delta` /
+   `tool.start` cleanly for the operator view without touching the Telegram
+   output path? (Same seam the worker-activity feed already taps may suffice.)
+3. Does the operator-console source tag need to be visible in the Telegram
+   mirror (so a principal sees "operator asked: …"), or is it silent? Default
+   assume a light attribution; confirm with owner.

--- a/reference/rfcs/fleet-dashboard.md
+++ b/reference/rfcs/fleet-dashboard.md
@@ -35,14 +35,19 @@ The connection is **observe + operator-chat, approvals stay on Telegram**:
   methods/events; per the desktop's graceful-degradation behaviour that panel
   just stays empty. The Telegram tap remains the sole approval surface.
 
-This crosses one hard invariant (`telegram-only`), handled by the new
-**operator-console carve-out** added to `invariants.md` in this change. No
+**`telegram-only` is not crossed.** That invariant governs the *principal's*
+channel — it bars a second chat channel for the people the team serves
+(WhatsApp, Signal, Slack). The dashboard is an **admin component** of
+switchroom, not a principal channel, so it is out of that invariant's scope.
+This change clarifies that scope in `invariants.md` and pins the conditions
+that keep the admin console from quietly becoming a second channel (operator
+audience, mirrored to the one Telegram thread, approvals on Telegram). No
 desktop fork is maintained — we track upstream by implementing its contract.
 
 ## Decisions (owner-ratified)
 
-These were settled with the owner before this draft (see the carve-out in
-`invariants.md`):
+These were settled with the owner before this draft (see the admin-console
+scope note under `telegram-only` in `invariants.md`):
 
 1. **No return of the progress card.** This is not the retired #1122 card
    rebuilt anywhere. The live desktop activity stream is an **operator**
@@ -113,7 +118,7 @@ Model/provider/env endpoints return Switchroom's claude-native truth
    `message.delta` so the desktop is live too.
 
 Result: exactly one record (Telegram), the desktop is an input + live view,
-nothing is hidden. This is what keeps the `telegram-only` carve-out honest.
+nothing is hidden. This is what keeps the admin console out of `telegram-only`'s scope (an input that feeds the one thread, not a second channel).
 
 ## Alignment review of the original external plan (still valid)
 
@@ -177,7 +182,7 @@ embedded-terminal path; Hermes's own messaging-platform gateway; deprecating
 | `claude-native` | Pass — adapter emits events + answers RPCs over Switchroom's own data/IPC; no API/SDK/token; the agent runtime is still the unmodified CLI. |
 | `no-self-escalation` | Pass — approval methods are not implemented; the Telegram tap stays the sole approval surface. |
 | `chat-is-the-single-source-of-truth` | Pass — operator-audience surface; chat prompt untouched (no crutch); turns + replies mirror into the one Telegram thread. |
-| `telegram-only` | Pass **under the new operator-console carve-out** (`invariants.md`): one channel of record, operator-only input, same inbound path, approvals on Telegram. |
+| `telegram-only` | Pass — **not crossed.** The invariant governs *principal* channels; the dashboard is an admin component, out of scope. The admin-console conditions (operator audience, mirrored to the one Telegram thread, approvals on Telegram) keep it from becoming a second channel. A principal-facing bridge (WhatsApp/Signal/web chat) would still be out. |
 | `single-tenant` | Pass — one operator, auth-gated, single deployment. |
 
 ## Testing
@@ -188,7 +193,7 @@ embedded-terminal path; Hermes's own messaging-platform gateway; deprecating
   emitted event frames match the `{type,session_id,payload}` shape.
 - **Mirror test:** an operator `prompt.submit` produces a real turn in the
   target agent's Telegram thread (the turn and reply are observable there),
-  not just on the WS — the load-bearing carve-out condition.
+  not just on the WS — the load-bearing admin-console condition.
 - **No-approval test:** the adapter exposes no approve/deny method; an
   `approval.respond` call is rejected/absent.
 - Secret-redaction: no REST/WS payload ever carries token-shaped material.


### PR DESCRIPTION
## Summary

Follow-up to #2602. Reframes the operator-dashboard design per owner alignment, and lands the one hard-invariant change it requires.

- **`reference/rfcs/fleet-dashboard.md`** — rewritten: Switchroom exposes the **Hermes-Desktop integration contract** (REST `/api/*` + JSON-RPC-over-WebSocket `/api/ws`); operator runs the **unmodified, MIT-licensed Hermes Desktop** in remote mode. Contract documented from a source read of `NousResearch/hermes-agent`.
- **`reference/invariants.md`** — adds the **operator-console carve-out** to `telegram-only` (mirrors the existing LiteLLM gateway carve-out).
- **`reference/jobs/see-my-whole-fleet-from-one-screen.md`** — updated for operator-chat-via-console.

## The design (owner-aligned)

- **Observe + operator chat; approvals Telegram-only.** `prompt.submit` routes through the existing `inject_inbound` path. Approval methods are **not implemented** — that desktop panel just degrades empty — so the Telegram tap stays the sole approval surface.
- **Mirror.** Operator turns *and* the agent's replies mirror into the agent's Telegram thread → one canonical record. The console is another way *in*, not a hidden side-channel.
- **Adapter-only, no fork.** Tracks upstream Hermes Desktop by implementing its contract.
- **No card.** The live desktop stream is operator-audience only; the Telegram chat prompt is untouched (no return of the retired #1122 card).

## Invariant posture

| Invariant | Verdict |
|---|---|
| `claude-native` | Pass — adapter over Switchroom's own data/IPC; runtime is still the unmodified CLI. |
| `no-self-escalation` | Pass — approvals not implemented; Telegram tap remains sole approval surface. |
| `chat-is-the-single-source-of-truth` | Pass — operator audience; chat prompt untouched; turns + replies mirror to the one thread. |
| `telegram-only` | Pass **under the new operator-console carve-out** (one record, operator-only input, same inbound path, approvals on Telegram). |
| `single-tenant` | Pass. |

## Test plan

- [x] Docs-only.
- [x] Carve-out mirrors the established LiteLLM carve-out structure.
- [x] Hermes contract claims sourced from a real read of the repo (cited file paths in the RFC).

## Risk

Medium for a docs change — it amends a hard invariant (`telegram-only`). The carve-out is tightly bounded (operator-only, mirrored, approvals stay Telegram) and ratified with the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)