### PR TITLE
feat(model): sr-* LiteLLM model selection in /model Telegram menu (Ship D)

### DIFF
--- a/reference/rfcs/litellm-max-subscription-invariants.md
+++ b/reference/rfcs/litellm-max-subscription-invariants.md
@@ -1,0 +1,211 @@
+---
+serves: subscription-honest
+backs: subscription-honest
+artefact: litellm-max-subscription-invariants
+---
+
+# LiteLLM Max Subscription Invariants
+
+**Context:** Switchroom routes the unmodified `claude` CLI through a self-hosted
+LiteLLM proxy (`ANTHROPIC_BASE_URL=http://127.0.0.1:4010`). The subscription
+invariant (pillar 3 of `reference/vision.md`) says Anthropic models MUST be paid
+via the operator's Claude Max OAuth credential — never via an `ANTHROPIC_API_KEY`.
+LiteLLM is scaffolding around the CLI, not a billing bypass.
+
+Source: https://docs.litellm.ai/docs/tutorials/claude_code_max_subscription
+
+---
+
+## I1 — OAuth forwarding MUST be per-model via `model_group_settings`, never global
+
+**Rule:** OAuth header forwarding MUST be set per-model in `model_group_settings`,
+not in `litellm_settings`. The `litellm_settings.forward_client_headers_to_llm_api`
+field is `Optional[bool]` — a list value (e.g. a list of model names) is coerced
+to `true` (truthy), making forwarding global. That leaks the OAuth token to
+OpenRouter, OpenAI, VoyageAI, etc.
+
+```yaml
+# CORRECT — per-model scoping via model_group_settings
+model_group_settings:
+  claude-opus-4-8:
+    forward_client_headers_to_llm_api: true
+  claude-sonnet-4-6:
+    forward_client_headers_to_llm_api: true
+  claude-haiku-4-5-20251001:
+    forward_client_headers_to_llm_api: true
+
+# WRONG — global; OAuth token forwarded to ALL providers
+litellm_settings:
+  forward_client_headers_to_llm_api: true
+
+# ALSO WRONG — list value in litellm_settings is coerced to true (truthy) → global
+litellm_settings:
+  forward_client_headers_to_llm_api:
+    - claude-opus-4-8    # non-empty list = truthy bool = forwards everywhere
+```
+
+**Why:** Global forwarding sends the Anthropic OAuth Bearer token to every
+upstream provider configured in the proxy. OpenRouter, OpenAI, and VoyageAI
+will reject or mis-attribute it; worse, it leaks the credential outside Anthropic.
+
+**How to apply:** Every time a new Anthropic model is added to `model_list`, add
+a matching `model_group_settings.<model_name>.forward_client_headers_to_llm_api: true`
+entry. Omitting it causes that model to send without OAuth → 401.
+
+---
+
+## I2 — Anthropic OAuth models MUST NOT carry an `api_key`
+
+**Rule:** Any `model_list` entry whose upstream is `anthropic/claude-*` and that
+relies on Max OAuth MUST omit `api_key` entirely.
+
+```yaml
+# CORRECT — credential comes from forwarded Authorization header
+- model_name: claude-sonnet-4-6
+  litellm_params:
+    model: anthropic/claude-sonnet-4-6   # no api_key
+
+# WRONG — overrides the forwarded OAuth; fails unless ANTHROPIC_API_KEY is set
+- model_name: claude-sonnet-4-6
+  litellm_params:
+    model: anthropic/claude-sonnet-4-6
+    api_key: os.environ/ANTHROPIC_API_KEY
+```
+
+**Why:** An explicit `api_key` on the LiteLLM side takes precedence over the
+forwarded client `Authorization` header, breaking the Max subscription path and
+potentially routing to a paid API endpoint instead.
+
+---
+
+## I3 — All non-Anthropic models MUST have an explicit `api_key`
+
+**Rule:** OpenRouter, OpenAI, VoyageAI, and any other non-Anthropic upstream
+MUST have `api_key: os.environ/<KEY>` in their `litellm_params`.
+
+**Why:** Without an explicit key, LiteLLM falls back to looking for the forwarded
+client header (or a global env fallback). For non-Anthropic providers, the OAuth
+token is meaningless and will result in a 401.
+
+---
+
+## I4 — Model names MUST exactly match what Claude Code sends on the wire
+
+**Rule:** `model_name` in `model_list` and entries in
+`forward_client_headers_to_llm_api` must be the literal string Claude Code
+places in the `model` field of its API requests — NOT prefixed with `anthropic/`.
+
+```yaml
+# CORRECT — Claude Code sends "claude-sonnet-4-6"
+- model_name: claude-sonnet-4-6
+  litellm_params:
+    model: anthropic/claude-sonnet-4-6   # litellm_params CAN have the prefix
+
+# WRONG — Claude Code never sends "anthropic/claude-sonnet-4-6" as the model name
+- model_name: anthropic/claude-sonnet-4-6
+```
+
+**Current verified list (2026-06-28):**
+- `claude-opus-4-8`
+- `claude-sonnet-4-6`
+- `claude-haiku-4-5-20251001`
+
+Update this list (and `forward_client_headers_to_llm_api`) whenever the CLI
+ships a new model. The CLI's `/model` picker is the authoritative source.
+
+---
+
+## I5 — Virtual key header format is `x-litellm-api-key: Bearer <key>`
+
+**Rule:** `ANTHROPIC_CUSTOM_HEADERS` in `start.sh` must send the virtual key in
+the `x-litellm-api-key` header with the literal `Bearer ` prefix.
+
+```bash
+export ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: Bearer $sr_ll_key
+x-litellm-customer-id: $SWITCHROOM_AGENT_NAME
+x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:-default}"
+```
+
+**Why:** This is the format specified in the LiteLLM Claude Code tutorial.
+The Claude CLI forwards these as literal HTTP headers. LiteLLM reads
+`x-litellm-api-key` to authenticate the virtual key (budget/rate tracking)
+separately from the `Authorization` header (the OAuth credential for Anthropic).
+
+**Two-header model (must both succeed):**
+
+| Header | Value | Used by |
+|--------|-------|---------|
+| `x-litellm-api-key` | `Bearer <virtual-key>` | LiteLLM (gateway auth, spend tracking) |
+| `Authorization` | `Bearer <oauth-token>` | Anthropic API (Max subscription billing) |
+
+---
+
+## I6 — Model-alias redirect MUST NOT forward OAuth to non-Anthropic upstreams
+
+**Rule:** When Ship D's virtual-key `model_aliases` redirect a Claude model name
+(e.g. `claude-sonnet-4-6`) to a non-Anthropic target (e.g.
+`openrouter/google/gemini-2.5-pro`), the OAuth token MUST NOT be forwarded to
+the OpenRouter endpoint.
+
+**Status:** UNVERIFIED at time of writing (2026-06-28). LiteLLM's
+`forward_client_headers_to_llm_api` scoping is against `model_name` entries in
+the proxy config. The critical question is whether the forwarding check runs
+against the *requested* model name (before alias resolution) or the *resolved*
+upstream target (after alias). If before, a `claude-sonnet-4-6` request aliased
+to `openrouter/google/gemini-2.5-pro` would forward the OAuth token to
+OpenRouter — a credential leak.
+
+**Required pre-check before enabling Ship D model aliases in production:**
+1. Set a test alias `claude-haiku-4-5-20251001 → openrouter/google/gemini-2.5-flash`
+   on a test agent's virtual key.
+2. Send a `claude-haiku-4-5-20251001` request through the proxy.
+3. Inspect LiteLLM logs (`log_raw_request_response: true` is already set) to
+   confirm the outbound call to OpenRouter does NOT carry the `Authorization`
+   header with the Anthropic OAuth token.
+4. If it does forward, mitigation is to remove the aliased model from
+   `forward_client_headers_to_llm_api` dynamically — or do not use model
+   aliases for Anthropic model names; use a separate non-Claude `model_name`
+   as the alias target instead (e.g. `sr-gemini` → `openrouter/google/gemini-2.5-pro`)
+   so there is no entry in the forwarding list to match.
+
+---
+
+## I7 — Fallback to direct OAuth on proxy unreachable (availability invariant)
+
+**Rule:** `start.sh` MUST fall back to direct Anthropic OAuth (no proxy) when:
+- The virtual key is absent from vault, OR
+- The proxy is unreachable at `$ANTHROPIC_BASE_URL`
+
+This is the current implementation (the `sr_ll_ok` gate in start.sh). Do NOT
+remove this fallback — it is the availability guarantee that prevents a proxy
+outage from silencing the fleet.
+
+**What the fallback loses:** spend tracking, guardrails, model alias routing,
+per-agent virtual key budget limits. Log line emitted so the operator knows.
+
+---
+
+## Checklist for adding a new Anthropic model
+
+1. Add entry to `model_list` (no `api_key`):
+   ```yaml
+   - model_name: claude-<id>
+     litellm_params:
+       model: anthropic/claude-<id>
+   ```
+2. Add `claude-<id>` to `forward_client_headers_to_llm_api` list.
+3. Reload LiteLLM (`docker restart litellm-<service>`).
+4. Verify: `curl /v1/models` shows the new name; a test request returns 200
+   and spend logs show the Anthropic model, not a fallback.
+
+## Checklist for adding a new non-Anthropic model (OpenRouter, etc.)
+
+1. Add entry to `model_list` WITH `api_key: os.environ/<KEY>`:
+   ```yaml
+   - model_name: openrouter/<provider>/<model>
+     litellm_params:
+       model: openrouter/<provider>/<model>
+       api_key: os.environ/OPENROUTER_API_KEY
+   ```
+2. Do NOT add to `forward_client_headers_to_llm_api`.
+3. Reload LiteLLM. Verify via `/v1/models`.

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -233,6 +233,44 @@ export interface ModelMenuReply {
 export const MODEL_CALLBACK_PREFIX = 'mdl:'
 const MODEL_CALLBACK_SELECT = 'mdl:s:'
 export const MODEL_CALLBACK_REFRESH = 'mdl:r'
+/** Callback prefix for sr-* (LiteLLM non-Anthropic) model selection. */
+export const MODEL_CALLBACK_SR = 'mdl:sr:'
+
+/**
+ * Friendly display names for sr-* synthetic model names. An sr-* model in
+ * LiteLLM has no entry in `model_group_settings.*.forward_client_headers_to_llm_api`
+ * so the Anthropic OAuth credential is NEVER forwarded — safe to route to
+ * OpenRouter. Names here are display-only; the raw `sr-*` id is what gets
+ * injected into the agent's session. See reference/rfcs/litellm-max-subscription-invariants.md § I6.
+ */
+export const SR_MODEL_LABELS: Record<string, string> = {
+  'sr-gemini-2.5-pro': 'Gemini 2.5 Pro',
+  'sr-gemini-2.5-flash': 'Gemini 2.5 Flash',
+  'sr-deepseek-r1': 'DeepSeek R1',
+  'sr-deepseek-v3': 'DeepSeek V3',
+  'sr-glm-5': 'GLM-5',
+}
+
+function srFriendlyLabel(srName: string): string {
+  return SR_MODEL_LABELS[srName] ?? srName.replace(/^sr-/, '').replace(/-/g, ' ')
+}
+
+/**
+ * Split picker-discovered options into native Claude options and sr-*
+ * (LiteLLM non-Anthropic) options. Options with "/" in the label or
+ * other non-native prefixes (e.g., "openrouter/...", "gpt-4") are
+ * silently dropped — they're internal LiteLLM routing paths, not
+ * user-facing switching targets.
+ */
+export function classifyDiscoveredOptions(options: ModelPickerOption[]): {
+  claude: ModelPickerOption[]
+  sr: ModelPickerOption[]
+} {
+  return {
+    claude: options.filter((o) => !o.label.startsWith('sr-') && !o.label.includes('/')),
+    sr: options.filter((o) => o.label.startsWith('sr-')),
+  }
+}
 
 export function modelSelectCallbackData(label: string): string {
   // Identity is the label's hash, not its index — a tap re-discovers
@@ -249,15 +287,29 @@ function busyReply(deps: Pick<ModelMenuDeps, 'escapeHtml'>): ModelMenuReply {
   }
 }
 
-function menuKeyboard(options: ModelPickerOption[]): ModelMenuKeyboardButton[][] {
+function menuKeyboard(
+  claudeOptions: ModelPickerOption[],
+  srOptions: ModelPickerOption[],
+): ModelMenuKeyboardButton[][] {
   // One option per row (labels + ✔ render cleanly at full width on
   // mobile), refresh on a trailing row.
-  const rows: ModelMenuKeyboardButton[][] = options.map((o) => [
+  const rows: ModelMenuKeyboardButton[][] = claudeOptions.map((o) => [
     {
       text: o.current ? `✅ ${o.label}` : o.label,
       callback_data: modelSelectCallbackData(o.label),
     },
   ])
+  // sr-* models are non-Anthropic (routed via LiteLLM → OpenRouter).
+  // Selection uses text-inject rather than cursor-nav — more reliable
+  // when the picker has many models (GATEWAY_MODEL_DISCOVERY=1).
+  for (const o of srOptions) {
+    rows.push([
+      {
+        text: `🌐 ${srFriendlyLabel(o.label)}`,
+        callback_data: `${MODEL_CALLBACK_SR}${o.label}`,
+      },
+    ])
+  }
   rows.push([{ text: '🔄 Refresh', callback_data: MODEL_CALLBACK_REFRESH }])
   return rows
 }
@@ -292,7 +344,8 @@ export async function buildModelMenu(
   // or a prior session switch). Labelling the ✔ row "Now:" was misleading —
   // it could read "Opus 4.8" while the live session is on Fable. Call it what
   // it is, and tell the operator a switch applies to the live session.
-  const current = discovered.options.find((o) => o.current)
+  const { claude: claudeOptions, sr: srOptions } = classifyDiscoveredOptions(discovered.options)
+  const current = claudeOptions.find((o) => o.current)
   const lines: string[] = [`<b>Model — ${deps.escapeHtml(deps.getAgentName())}</b>`]
   if (discovered.dismissFailed) {
     lines.push('⚠️ <i>The picker may still be open on the agent pane — check it before switching.</i>')
@@ -305,9 +358,10 @@ export async function buildModelMenu(
   }
   if (quota) lines.push(`Quota: ${deps.escapeHtml(quota)}`)
   lines.push('', 'Tap a model to switch the <b>live session</b>:')
+  if (srOptions.length > 0) lines.push('🌐 = non-Anthropic via LiteLLM (session only)')
   lines.push(PERSIST_NOTE)
 
-  return { text: lines.join('\n'), html: true, keyboard: menuKeyboard(discovered.options) }
+  return { text: lines.join('\n'), html: true, keyboard: menuKeyboard(claudeOptions, srOptions) }
 }
 
 export interface ModelCallbackOutcome {
@@ -346,6 +400,54 @@ export async function handleModelMenuCallback(
   if (data === MODEL_CALLBACK_REFRESH) {
     return { answer: 'Refreshed', reply: await buildModelMenu(deps) }
   }
+
+  // sr-* model tap: text-inject `/model sr-<name>` rather than cursor-nav.
+  // Text-inject is more reliable when the picker has many models; sr-* names
+  // are safe (no entry in model_group_settings → no OAuth forwarding). See I6.
+  if (data.startsWith(MODEL_CALLBACK_SR)) {
+    const srName = data.slice(MODEL_CALLBACK_SR.length)
+    if (!isValidModelArg(srName)) {
+      return { answer: 'Invalid model name', reply: await buildModelMenu(deps) }
+    }
+    if (deps.isBusy()) {
+      return {
+        answer: '⏳ Agent is mid-turn — tap again when it’s idle',
+        reply: busyReply(deps),
+        toastOnly: true,
+      }
+    }
+    let srResult: InjectResult
+    try {
+      srResult = await deps.inject(deps.getAgentName(), `/model ${srName}`)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      return {
+        answer: 'Switch failed',
+        reply: await menuWithBanner(deps, `❌ Switch to <b>${deps.escapeHtml(srName)}</b> failed: ${deps.escapeHtml(msg)}`),
+      }
+    }
+    if (srResult.outcome === 'ok') {
+      const friendlyName = srFriendlyLabel(srName)
+      const confirmation =
+        srResult.output
+          .split('\n')
+          .map((l) => l.trim())
+          .find((l) => /set model|switched/i.test(l)) ?? `Switched to ${friendlyName} (session)`
+      return {
+        answer: confirmation,
+        reply: await menuWithBanner(deps, `✅ ${deps.escapeHtml(confirmation)}`),
+        selectedModel: srName,
+      }
+    }
+    return {
+      answer: 'Switch failed',
+      reply: await menuWithBanner(
+        deps,
+        `❌ Switch to <b>${deps.escapeHtml(srFriendlyLabel(srName))}</b> failed — agent may be mid-turn`,
+      ),
+    }
+  }
+
   if (!data.startsWith(MODEL_CALLBACK_SELECT)) {
     return { answer: 'Unknown action', reply: await buildModelMenu(deps) }
   }

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -267,7 +267,16 @@ export function classifyDiscoveredOptions(options: ModelPickerOption[]): {
   sr: ModelPickerOption[]
 } {
   return {
-    claude: options.filter((o) => !o.label.startsWith('sr-') && !o.label.includes('/')),
+    // Native Claude picker labels start with an uppercase letter (e.g.
+    // "Default (recommended)", "Opus", "Sonnet") or with "claude-" for full
+    // model IDs. This excludes sr-* names, internal routing paths
+    // ("openrouter/..."), and non-Claude models exposed by GATEWAY_MODEL_DISCOVERY
+    // ("gpt-4", "gpt-4o", "voyage-law-2", etc.) — those are LiteLLM internals
+    // not meant as user-facing switching targets.
+    claude: options.filter(
+      (o) => !o.label.startsWith('sr-') && !o.label.includes('/') &&
+        (/^[A-Z]/.test(o.label) || o.label.startsWith('claude-')),
+    ),
     sr: options.filter((o) => o.label.startsWith('sr-')),
   }
 }

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -437,15 +437,26 @@ const OPTIONS_WITH_SR = [
   { index: 4, label: "sr-deepseek-r1", detail: "", current: false },
   // internal path — should be filtered out
   { index: 5, label: "openrouter/google/gemini-2.5-pro", detail: "", current: false },
+  // bare OpenAI models from GATEWAY_MODEL_DISCOVERY — should also be filtered out
+  { index: 6, label: "gpt-4", detail: "", current: false },
+  { index: 7, label: "gpt-4o", detail: "", current: false },
+  { index: 8, label: "voyage-law-2", detail: "", current: false },
+  // full claude ID — should be in claude bucket
+  { index: 9, label: "claude-opus-4-8", detail: "", current: false },
 ];
 
 describe("classifyDiscoveredOptions", () => {
   it("puts native Claude options in claude, sr-* in sr, drops others", () => {
     const { claude, sr } = classifyDiscoveredOptions(OPTIONS_WITH_SR);
-    expect(claude.map((o) => o.label)).toEqual(["Default (recommended)", "Sonnet"]);
+    expect(claude.map((o) => o.label)).toEqual([
+      "Default (recommended)", "Sonnet", "claude-opus-4-8",
+    ]);
     expect(sr.map((o) => o.label)).toEqual(["sr-gemini-2.5-pro", "sr-deepseek-r1"]);
-    // openrouter/* not present in either
-    expect([...claude, ...sr].find((o) => o.label.includes("openrouter"))).toBeUndefined();
+    // openrouter/*, gpt-*, voyage-* not present in either bucket
+    const all = [...claude, ...sr];
+    expect(all.find((o) => o.label.includes("openrouter"))).toBeUndefined();
+    expect(all.find((o) => o.label.startsWith("gpt-"))).toBeUndefined();
+    expect(all.find((o) => o.label.startsWith("voyage-"))).toBeUndefined();
   });
 
   it("handles a list with no sr-* models", () => {

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -253,7 +253,10 @@ import {
   handleModelMenuCallback,
   modelSelectCallbackData,
   sessionModelFromConfirmation,
+  classifyDiscoveredOptions,
   MODEL_CALLBACK_REFRESH,
+  MODEL_CALLBACK_SR,
+  SR_MODEL_LABELS,
   type ModelMenuDeps,
 } from "../gateway/model-command.js";
 import { labelTag } from "../../src/agents/model-picker.js";
@@ -420,5 +423,125 @@ describe("sessionModelFromConfirmation", () => {
     expect(out.answer).toBe("Refreshed");
     expect(calls.discover).toBe(1);
     expect(out.reply.keyboard).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ship D — sr-* (LiteLLM non-Anthropic) model support
+// ---------------------------------------------------------------------------
+
+const OPTIONS_WITH_SR = [
+  { index: 1, label: "Default (recommended)", detail: "Opus 4.8 with 1M context", current: false },
+  { index: 2, label: "Sonnet", detail: "Sonnet 4.6", current: true },
+  { index: 3, label: "sr-gemini-2.5-pro", detail: "", current: false },
+  { index: 4, label: "sr-deepseek-r1", detail: "", current: false },
+  // internal path — should be filtered out
+  { index: 5, label: "openrouter/google/gemini-2.5-pro", detail: "", current: false },
+];
+
+describe("classifyDiscoveredOptions", () => {
+  it("puts native Claude options in claude, sr-* in sr, drops others", () => {
+    const { claude, sr } = classifyDiscoveredOptions(OPTIONS_WITH_SR);
+    expect(claude.map((o) => o.label)).toEqual(["Default (recommended)", "Sonnet"]);
+    expect(sr.map((o) => o.label)).toEqual(["sr-gemini-2.5-pro", "sr-deepseek-r1"]);
+    // openrouter/* not present in either
+    expect([...claude, ...sr].find((o) => o.label.includes("openrouter"))).toBeUndefined();
+  });
+
+  it("handles a list with no sr-* models", () => {
+    const { claude, sr } = classifyDiscoveredOptions(OPTIONS);
+    expect(claude).toHaveLength(3);
+    expect(sr).toHaveLength(0);
+  });
+});
+
+describe("SR_MODEL_LABELS", () => {
+  it("has friendly names for the standard sr-* models", () => {
+    expect(SR_MODEL_LABELS["sr-gemini-2.5-pro"]).toBe("Gemini 2.5 Pro");
+    expect(SR_MODEL_LABELS["sr-deepseek-r1"]).toBe("DeepSeek R1");
+  });
+});
+
+describe("buildModelMenu — with sr-* models", () => {
+  function makeMenuDepsWithSr(overrides: Partial<ModelMenuDeps> = {}) {
+    return makeMenuDeps({
+      discover: async () => ({
+        ok: true as const,
+        options: OPTIONS_WITH_SR,
+        currentLabel: "Sonnet",
+      }),
+      ...overrides,
+    });
+  }
+
+  it("shows 🌐 buttons for sr-* models, normal buttons for claude models", async () => {
+    const { deps } = makeMenuDepsWithSr();
+    const menu = await buildModelMenu(deps);
+    expect(menu.keyboard).toBeDefined();
+    const allButtons = menu.keyboard!.flat();
+    // 🌐 buttons for sr-*
+    expect(allButtons.find((b) => b.text === "🌐 Gemini 2.5 Pro")).toBeDefined();
+    expect(allButtons.find((b) => b.text === "🌐 DeepSeek R1")).toBeDefined();
+    // Regular buttons for Claude models
+    expect(allButtons.find((b) => b.text === "Default (recommended)")).toBeDefined();
+    // openrouter/* not shown at all
+    expect(allButtons.find((b) => b.text.includes("openrouter"))).toBeUndefined();
+  });
+
+  it("sr-* buttons use mdl:sr: callback prefix", async () => {
+    const { deps } = makeMenuDepsWithSr();
+    const menu = await buildModelMenu(deps);
+    const srButton = menu.keyboard!.flat().find((b) => b.text === "🌐 Gemini 2.5 Pro");
+    expect(srButton?.callback_data).toBe(`${MODEL_CALLBACK_SR}sr-gemini-2.5-pro`);
+  });
+
+  it("shows 🌐 = non-Anthropic legend when sr-* models are present", async () => {
+    const { deps } = makeMenuDepsWithSr();
+    const menu = await buildModelMenu(deps);
+    expect(menu.text).toContain("🌐 = non-Anthropic");
+  });
+
+  it("no legend when no sr-* models in picker", async () => {
+    const { deps } = makeMenuDeps();
+    const menu = await buildModelMenu(deps);
+    expect(menu.text).not.toContain("🌐 = non-Anthropic");
+  });
+});
+
+describe("handleModelMenuCallback — sr-* selection", () => {
+  function makeMenuDepsWithSr(overrides: Partial<ModelMenuDeps> = {}) {
+    return makeMenuDeps({
+      discover: async () => ({
+        ok: true as const,
+        options: OPTIONS_WITH_SR,
+        currentLabel: "Sonnet",
+      }),
+      ...overrides,
+    });
+  }
+
+  it("sr-* tap uses inject path, not cursor nav", async () => {
+    const { deps, calls, injectCalls } = makeMenuDepsWithSr();
+    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_SR}sr-gemini-2.5-pro`, deps);
+    // inject was called with the raw /model command
+    expect(injectCalls).toContainEqual({ agent: "klanker", command: "/model sr-gemini-2.5-pro" });
+    // select (cursor nav) was NOT called
+    expect(calls.select).toHaveLength(0);
+    expect(out.answer).toContain("Set model to sonnet");
+    expect(out.selectedModel).toBe("sr-gemini-2.5-pro");
+    expect(out.reply.keyboard).toBeDefined();
+  });
+
+  it("sr-* tap while busy returns toast-only with no inject", async () => {
+    const { deps, injectCalls } = makeMenuDepsWithSr({ isBusy: () => true });
+    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_SR}sr-gemini-2.5-pro`, deps);
+    expect(out.toastOnly).toBe(true);
+    expect(injectCalls).toHaveLength(0);
+  });
+
+  it("rejects malformed sr-* callback data", async () => {
+    const { deps } = makeMenuDepsWithSr();
+    const out = await handleModelMenuCallback(`${MODEL_CALLBACK_SR}bad name with spaces`, deps);
+    expect(out.answer).toBe("Invalid model name");
   });
 });


### PR DESCRIPTION
## Summary

- Extends the Telegram `/model` command to surface sr-* synthetic model names (Gemini 2.5 Pro, DeepSeek R1, etc.) when `litellm.enabled: true` routes Claude Code through the operator's LiteLLM proxy
- `classifyDiscoveredOptions()` splits picker-discovered options into native Claude options and sr-* options, silently dropping internal paths (`openrouter/*`, `gpt-*`) not intended for user-facing switching
- sr-* models appear as 🌐-prefixed buttons in the inline keyboard using the new `mdl:sr:` callback prefix; native Claude models use the existing cursor-nav path
- sr-* selection uses **text-inject** (`/model sr-gemini-2.5-pro`) rather than picker cursor-navigation — more reliable when the picker has many models from GATEWAY_MODEL_DISCOVERY
- `SR_MODEL_LABELS` maps sr-* API names to friendly display labels ("Gemini 2.5 Pro", "DeepSeek R1", etc.)

## Why

`CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` (already set in `start.sh.hbs` when LiteLLM is enabled) causes Claude Code to enumerate all models from LiteLLM's `/v1/models` endpoint. This includes sr-* names alongside native Claude models, and also internal routing paths (`openrouter/*`) that shouldn't be user-facing. This PR makes the Telegram menu filter and present these correctly.

**I6 invariant preserved:** sr-* names have no entry in `model_group_settings.*.forward_client_headers_to_llm_api` so the Anthropic OAuth credential is never forwarded to OpenRouter. See `reference/rfcs/litellm-max-subscription-invariants.md` § I6 (added in the prior docs commit on this branch).

## Test plan

- [x] `classifyDiscoveredOptions()` — correctly splits claude/sr/drops others
- [x] `buildModelMenu()` with sr-* — renders 🌐 buttons, shows legend, no openrouter/* buttons
- [x] `handleModelMenuCallback()` with `mdl:sr:` — uses inject path, not cursor nav; busy-guard works; malformed name rejected
- [x] `SR_MODEL_LABELS` — friendly names for standard sr-* models
- [x] All 45 tests pass under vitest and bun test
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZnNdwFupjXpDS6tXNXumj