### PR TITLE
fix(memory): use dynamic port in hindsight healthcheck for LiteLLM host-network mode

### DIFF
--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -502,7 +502,9 @@ export function startHindsight(
     // Restart a wedged API: docker had no liveness signal for hindsight,
     // so an unresponsive server (or a never-booting one) stayed "up"
     // forever. python3 is always present in the image; curl/wget are not.
-    "--health-cmd", HINDSIGHT_HEALTHCHECK_CMD,
+    "--health-cmd", litellm
+      ? `python3 -c 'import urllib.request,sys; sys.exit(0 if urllib.request.urlopen("http://localhost:${apiPort}/health",timeout=4).getcode()==200 else 1)'`
+      : HINDSIGHT_HEALTHCHECK_CMD,
     "--health-interval", "30s",
     "--health-timeout", "5s",
     "--health-retries", "3",


### PR DESCRIPTION
## Summary

- Hindsight runs `--network host` with `ANTHROPIC_BASE_URL` when LiteLLM config is provided, which also sets `HINDSIGHT_API_PORT=18888` (vs upstream default 8888).
- The Docker healthcheck was hardcoded to probe `localhost:8888`, so the container always reported **unhealthy** even though hindsight was serving correctly at port 18888.
- Fix: pass the resolved `apiPort` into the health-cmd string when the `litellm` arg is present.

## Test plan

- [ ] `bun run dev -- memory setup --recreate` with litellm config → container health transitions from `unhealthy` to `healthy` within 90s
- [ ] Without litellm config (standard path) → still uses `HINDSIGHT_HEALTHCHECK_CMD` (port 8888)

## Risk

Tiny — one conditional in the healthcheck string build. No logic change outside the healthcheck.