### PR TITLE
feat(model): group /model menu by subscription tier with section headers

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -276,6 +276,7 @@ import {
   buildModelMenu,
   handleModelMenuCallback,
   MODEL_CALLBACK_PREFIX,
+  MODEL_CALLBACK_HEADER,
   type ModelMenuDeps,
   type ModelCommandDeps,
   type ModelMenuReply,
@@ -20721,6 +20722,11 @@ bot.on('callback_query:data', async ctx => {
     // drive behind the pane lock. A callback can only be answered once, so
     // the rich result (what was set / why it failed) is conveyed by the
     // message edit — which now ALWAYS keeps the menu buttons.
+    // Header rows are section labels — informational, no model switch.
+    if (data === MODEL_CALLBACK_HEADER) {
+      await ctx.answerCallbackQuery({ text: 'Tap a model in this section to switch' }).catch(() => {})
+      return
+    }
     await ctx.answerCallbackQuery({ text: 'Switching…' }).catch(() => {})
     try {
       const outcome = await handleModelMenuCallback(data, modelDeps)

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -235,6 +235,8 @@ const MODEL_CALLBACK_SELECT = 'mdl:s:'
 export const MODEL_CALLBACK_REFRESH = 'mdl:r'
 /** Callback prefix for sr-* (LiteLLM non-Anthropic) model selection. */
 export const MODEL_CALLBACK_SR = 'mdl:sr:'
+/** Callback for section-header rows — shows an informational toast, no action. */
+export const MODEL_CALLBACK_HEADER = 'mdl:h'
 
 /**
  * Friendly display names for sr-* synthetic model names. An sr-* model in
@@ -296,29 +298,38 @@ function busyReply(deps: Pick<ModelMenuDeps, 'escapeHtml'>): ModelMenuReply {
   }
 }
 
+function headerRow(label: string): ModelMenuKeyboardButton[] {
+  return [{ text: label, callback_data: MODEL_CALLBACK_HEADER }]
+}
+
 function menuKeyboard(
   claudeOptions: ModelPickerOption[],
   srOptions: ModelPickerOption[],
 ): ModelMenuKeyboardButton[][] {
-  // One option per row (labels + ✔ render cleanly at full width on
-  // mobile), refresh on a trailing row.
-  const rows: ModelMenuKeyboardButton[][] = claudeOptions.map((o) => [
-    {
+  const hasBothGroups = claudeOptions.length > 0 && srOptions.length > 0
+  const rows: ModelMenuKeyboardButton[][] = []
+
+  if (hasBothGroups) rows.push(headerRow('── Claude (Max / Pro subscription) ──'))
+  for (const o of claudeOptions) {
+    rows.push([{
       text: o.current ? `✅ ${o.label}` : o.label,
       callback_data: modelSelectCallbackData(o.label),
-    },
-  ])
+    }])
+  }
+
   // sr-* models are non-Anthropic (routed via LiteLLM → OpenRouter).
   // Selection uses text-inject rather than cursor-nav — more reliable
   // when the picker has many models (GATEWAY_MODEL_DISCOVERY=1).
-  for (const o of srOptions) {
-    rows.push([
-      {
+  if (srOptions.length > 0) {
+    rows.push(headerRow('── OpenRouter / external ──'))
+    for (const o of srOptions) {
+      rows.push([{
         text: `🌐 ${srFriendlyLabel(o.label)}`,
         callback_data: `${MODEL_CALLBACK_SR}${o.label}`,
-      },
-    ])
+      }])
+    }
   }
+
   rows.push([{ text: '🔄 Refresh', callback_data: MODEL_CALLBACK_REFRESH }])
   return rows
 }
@@ -367,7 +378,9 @@ export async function buildModelMenu(
   }
   if (quota) lines.push(`Quota: ${deps.escapeHtml(quota)}`)
   lines.push('', 'Tap a model to switch the <b>live session</b>:')
-  if (srOptions.length > 0) lines.push('🌐 = non-Anthropic via LiteLLM (session only)')
+  if (srOptions.length > 0) {
+    lines.push('Claude models use your Max/Pro subscription. 🌐 models are billed separately via OpenRouter.')
+  }
   lines.push(PERSIST_NOTE)
 
   return { text: lines.join('\n'), html: true, keyboard: menuKeyboard(claudeOptions, srOptions) }
@@ -408,6 +421,11 @@ export async function handleModelMenuCallback(
 ): Promise<ModelCallbackOutcome> {
   if (data === MODEL_CALLBACK_REFRESH) {
     return { answer: 'Refreshed', reply: await buildModelMenu(deps) }
+  }
+
+  if (data === MODEL_CALLBACK_HEADER) {
+    // Section-header row — informational only, no action.
+    return { answer: 'Tap a model in this section to switch', reply: await buildModelMenu(deps), toastOnly: true }
   }
 
   // sr-* model tap: text-inject `/model sr-<name>` rather than cursor-nav.

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -424,8 +424,10 @@ export async function handleModelMenuCallback(
   }
 
   if (data === MODEL_CALLBACK_HEADER) {
-    // Section-header row — informational only, no action.
-    return { answer: 'Tap a model in this section to switch', reply: await buildModelMenu(deps), toastOnly: true }
+    // Section-header row — the gateway handles this with a direct answerCallbackQuery
+    // before calling this function, so this branch is dead in practice. Guard
+    // for callers that skip gateway.ts (tests, future refactors).
+    return { answer: 'Tap a model in this section to switch', reply: { text: '', html: true }, toastOnly: true }
   }
 
   // sr-* model tap: text-inject `/model sr-<name>` rather than cursor-nav.

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -525,6 +525,14 @@ describe("buildModelMenu — with sr-* models", () => {
     expect(headers.length).toBe(0);
   });
 
+  it("header-row tap returns toastOnly without inject or model change", async () => {
+    const { deps, injectCalls } = makeMenuDepsWithSr();
+    const out = await handleModelMenuCallback(MODEL_CALLBACK_HEADER, deps);
+    expect(out.toastOnly).toBe(true);
+    expect(out.selectedModel).toBeUndefined();
+    expect(injectCalls).toHaveLength(0);
+  });
+
   it("shows subscription/OpenRouter legend when sr-* models are present", async () => {
     const { deps } = makeMenuDepsWithSr();
     const menu = await buildModelMenu(deps);

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -255,6 +255,7 @@ import {
   sessionModelFromConfirmation,
   classifyDiscoveredOptions,
   MODEL_CALLBACK_REFRESH,
+  MODEL_CALLBACK_HEADER,
   MODEL_CALLBACK_SR,
   SR_MODEL_LABELS,
   type ModelMenuDeps,
@@ -506,16 +507,35 @@ describe("buildModelMenu — with sr-* models", () => {
     expect(srButton?.callback_data).toBe(`${MODEL_CALLBACK_SR}sr-gemini-2.5-pro`);
   });
 
-  it("shows 🌐 = non-Anthropic legend when sr-* models are present", async () => {
+  it("shows section header rows when both claude and sr-* models present", async () => {
     const { deps } = makeMenuDepsWithSr();
     const menu = await buildModelMenu(deps);
-    expect(menu.text).toContain("🌐 = non-Anthropic");
+    const allButtons = menu.keyboard!.flat();
+    const headers = allButtons.filter((b) => b.callback_data === MODEL_CALLBACK_HEADER);
+    expect(headers.length).toBe(2);
+    expect(headers[0].text).toContain("Claude");
+    expect(headers[1].text).toContain("OpenRouter");
+  });
+
+  it("no section headers when only claude models (no sr-*)", async () => {
+    const { deps } = makeMenuDeps();
+    const menu = await buildModelMenu(deps);
+    const allButtons = (menu.keyboard ?? []).flat();
+    const headers = allButtons.filter((b) => b.callback_data === MODEL_CALLBACK_HEADER);
+    expect(headers.length).toBe(0);
+  });
+
+  it("shows subscription/OpenRouter legend when sr-* models are present", async () => {
+    const { deps } = makeMenuDepsWithSr();
+    const menu = await buildModelMenu(deps);
+    expect(menu.text).toContain("Max/Pro subscription");
+    expect(menu.text).toContain("OpenRouter");
   });
 
   it("no legend when no sr-* models in picker", async () => {
     const { deps } = makeMenuDeps();
     const menu = await buildModelMenu(deps);
-    expect(menu.text).not.toContain("🌐 = non-Anthropic");
+    expect(menu.text).not.toContain("OpenRouter");
   });
 });
 


### PR DESCRIPTION
## Summary

- `/model` keyboard now groups models into two clearly labelled sections when both Claude and OpenRouter models are available
- Section header rows ("── Claude (Max / Pro subscription) ──" / "── OpenRouter / external ──") use a `MODEL_CALLBACK_HEADER` callback that shows a toast if tapped — no dead taps
- Body text updated: "Claude models use your Max/Pro subscription. 🌐 models are billed separately via OpenRouter." replaces the terse legend footnote
- Headers are suppressed when only Claude models exist (no sr-* options) — clean for non-LiteLLM agents

## Why

Operators couldn't tell at a glance which models draw from their Claude subscription vs. external billing. Explicit section headers make the tier boundary obvious without reading fine print.

## Test plan

- [x] 47 model-command.test.ts tests pass (3 new tests: header rows present, absent, callback)
- [ ] `/model` in a LiteLLM-enabled agent (e.g. clerk) shows both sections with headers
- [ ] Tapping a header row shows toast "Tap a model in this section to switch", menu unchanged
- [ ] Non-LiteLLM agent shows no headers (just flat Claude list)

## Risk

Display-only change. No selection logic altered. Worst case: an extra non-selectable row the user ignores.