### PR TITLE
chore: release v0.16.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.16.6 — /model menu grouped by subscription tier
+
+- `/model` inline keyboard now shows two labelled sections when both Claude and
+  OpenRouter models are available:
+  `── Claude (Max / Pro subscription) ──` and `── OpenRouter / external ──`
+- Body text updated to read "Claude models use your Max/Pro subscription.
+  🌐 models are billed separately via OpenRouter." for clarity.
+- Section header rows show an informational toast if tapped; no selection occurs.
+- Headers are suppressed for agents without LiteLLM sr-* options (clean list).
+- Hindsight Docker healthcheck now probes the correct port (18888) when running
+  in LiteLLM host-network mode instead of the hardcoded upstream default (8888).
+
 ## v0.16.5 — LiteLLM spend enrichment + hindsight routing + sr-* model switching
 
 ### PR A — Enriched LiteLLM spend tags + gateway model discovery (#2601)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.16.4",
+  "version": "0.16.6",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v0.16.6 — /model menu grouping by subscription tier + hindsight healthcheck port fix. PRs #2609 #2610.