### PR TITLE
fix(model): discover sr-* models from LiteLLM, not claude picker

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -15981,6 +15981,27 @@ bot.command('clear', async ctx => {
 function buildModelDeps(): ModelMenuDeps & ModelCommandDeps {
   return {
     discover: (a) => discoverModels(a),
+    discoverSrModels: async () => {
+      const base = process.env.ANTHROPIC_BASE_URL
+      const headers = process.env.ANTHROPIC_CUSTOM_HEADERS
+      if (!base || !headers) return []
+      const keyMatch = headers.match(/x-litellm-api-key:\s*Bearer\s*(\S+)/)
+      if (!keyMatch) return []
+      try {
+        const res = await fetch(`${base.replace(/\/$/, '')}/model/info`, {
+          headers: { Authorization: `Bearer ${keyMatch[1]}` },
+          signal: AbortSignal.timeout(5000),
+        })
+        if (!res.ok) return []
+        const data = (await res.json()) as { data?: Array<{ model_name: string }> }
+        return (data.data ?? [])
+          .map((m) => m.model_name)
+          .filter((n) => n.startsWith('sr-'))
+          .sort()
+      } catch {
+        return []
+      }
+    },
     select: (a, label) => selectModel(a, label),
     isBusy: () => currentTurn !== null,
     getAgentName: getMyAgentName,

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -214,6 +214,11 @@ export interface ModelMenuDeps {
   getAgentName: () => string
   /** One-line quota summary (e.g. "29% / 5h · 33% / 7d") or null. */
   getQuotaBrief: () => Promise<string | null>
+  /**
+   * Fetch sr-* model names available via LiteLLM for this agent.
+   * Returns [] when LiteLLM is not configured or the probe fails.
+   */
+  discoverSrModels: () => Promise<string[]>
   escapeHtml: (s: string) => string
 }
 
@@ -344,9 +349,10 @@ export async function buildModelMenu(
 ): Promise<ModelMenuReply> {
   if (deps.isBusy()) return busyReply(deps)
 
-  const [discovered, quota] = await Promise.all([
+  const [discovered, quota, srNames] = await Promise.all([
     deps.discover(deps.getAgentName()),
     deps.getQuotaBrief().catch(() => null),
+    deps.discoverSrModels().catch(() => [] as string[]),
   ])
 
   if (!discovered.ok) {
@@ -364,7 +370,10 @@ export async function buildModelMenu(
   // or a prior session switch). Labelling the ✔ row "Now:" was misleading —
   // it could read "Opus 4.8" while the live session is on Fable. Call it what
   // it is, and tell the operator a switch applies to the live session.
-  const { claude: claudeOptions, sr: srOptions } = classifyDiscoveredOptions(discovered.options)
+  // sr-* models come from LiteLLM (/model/info via discoverSrModels), not the
+  // claude picker — the CLI only knows Anthropic models.
+  const { claude: claudeOptions } = classifyDiscoveredOptions(discovered.options)
+  const srOptions: ModelPickerOption[] = srNames.map((name, i) => ({ index: i, label: name, detail: '', current: false }))
   const current = claudeOptions.find((o) => o.current)
   const lines: string[] = [`<b>Model — ${deps.escapeHtml(deps.getAgentName())}</b>`]
   if (discovered.dismissFailed) {

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -283,6 +283,7 @@ function makeMenuDeps(overrides: Partial<ModelMenuDeps> = {}) {
     },
     isBusy: () => false,
     getQuotaBrief: async () => "29% / 5h · 33% / 7d",
+    discoverSrModels: async () => [],
     ...overrides,
   };
   return { deps, calls, injectCalls: base.calls };
@@ -475,13 +476,10 @@ describe("SR_MODEL_LABELS", () => {
 });
 
 describe("buildModelMenu — with sr-* models", () => {
+  // sr-* models now come from discoverSrModels (LiteLLM), not the claude picker.
   function makeMenuDepsWithSr(overrides: Partial<ModelMenuDeps> = {}) {
     return makeMenuDeps({
-      discover: async () => ({
-        ok: true as const,
-        options: OPTIONS_WITH_SR,
-        currentLabel: "Sonnet",
-      }),
+      discoverSrModels: async () => ["sr-gemini-2.5-pro", "sr-deepseek-r1"],
       ...overrides,
     });
   }
@@ -550,11 +548,7 @@ describe("buildModelMenu — with sr-* models", () => {
 describe("handleModelMenuCallback — sr-* selection", () => {
   function makeMenuDepsWithSr(overrides: Partial<ModelMenuDeps> = {}) {
     return makeMenuDeps({
-      discover: async () => ({
-        ok: true as const,
-        options: OPTIONS_WITH_SR,
-        currentLabel: "Sonnet",
-      }),
+      discoverSrModels: async () => ["sr-gemini-2.5-pro", "sr-deepseek-r1"],
       ...overrides,
     });
   }

--- a/telegram-plugin/uat/scenarios/jtbd-model-litellm-sr-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-model-litellm-sr-dm.test.ts
@@ -1,0 +1,147 @@
+/**
+ * UAT — /model with LiteLLM sr-* (OpenRouter) model switching + spend tracking.
+ *
+ * Covers:
+ *   1. /model menu shows section headers ("Claude (Max / Pro subscription)" and
+ *      "OpenRouter / external") when sr-* models are available.
+ *   2. Tapping an sr-* button switches the live session (text-inject path,
+ *      not cursor-nav) and the confirmation banner appears.
+ *   3. After switching, the agent replies on the new model, and LiteLLM
+ *      spend logs show agent:test-harness attribution.
+ *   4. Session resets to the configured model on restart (out of scope for
+ *      this test — asserted in jtbd-always-on-after-restart-dm).
+ *
+ * Self-skips green when:
+ *   - SWITCHROOM_UAT_DRIVER_SESSION is not set (no Telegram driver)
+ *   - LiteLLM admin key unavailable (SWITCHROOM_UAT_LITELLM_ADMIN_KEY unset)
+ *   - No sr-* buttons found in the menu (agent not LiteLLM-enabled or no
+ *     sr-* models registered in LiteLLM)
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+const AGENT = "test-harness";
+const LITELLM_URL = process.env.SWITCHROOM_UAT_LITELLM_URL ?? "http://127.0.0.1:4010";
+const LITELLM_ADMIN_KEY = process.env.SWITCHROOM_UAT_LITELLM_ADMIN_KEY ?? "";
+
+async function getLiteLLMSpendForAgent(agent: string): Promise<number> {
+  if (!LITELLM_ADMIN_KEY) return -1;
+  const res = await fetch(`${LITELLM_URL}/spend/tags`, {
+    headers: { Authorization: `Bearer ${LITELLM_ADMIN_KEY}` },
+  }).catch(() => null);
+  if (!res?.ok) return -1;
+  const tags: Array<{ individual_request_tag: string; log_count: number }> = await res.json();
+  return tags.find((t) => t.individual_request_tag === `agent:${agent}`)?.log_count ?? 0;
+}
+
+describe("uat: /model sr-* LiteLLM routing — section headers + session switch + spend attribution", () => {
+  it(
+    "menu shows Claude/OpenRouter section headers, sr-* tap switches session and LiteLLM logs the request",
+    async () => {
+      const sc = await spinUp({ agent: AGENT });
+      try {
+        await sc.sendDM("/model");
+        const menu = await sc.expectMessage(/Default \(new sessions\):/i, {
+          from: "bot",
+          timeout: 30_000,
+        });
+
+        // ── 1. Section headers ──────────────────────────────────────────
+        const kb = await sc.driver.getKeyboard(sc.botUserId, menu.messageId);
+        const flat = (kb ?? []).flat().filter((b) => b.callbackData);
+
+        const claudeHeader = flat.find(
+          (b) => b.text.includes("Claude") && b.text.includes("subscription") && b.callbackData === "mdl:h",
+        );
+        const openrouterHeader = flat.find(
+          (b) => b.text.includes("OpenRouter") && b.callbackData === "mdl:h",
+        );
+        const srButton = flat.find((b) => b.callbackData?.startsWith("mdl:sr:"));
+
+        if (!srButton) {
+          console.log("No sr-* buttons in menu — agent not LiteLLM-enabled or no sr-* models registered. Skipping.");
+          return;
+        }
+
+        expect(claudeHeader, "Claude (Max / Pro subscription) header row").toBeDefined();
+        expect(openrouterHeader, "OpenRouter / external header row").toBeDefined();
+        expect(menu.text).toContain("Max/Pro subscription");
+        expect(menu.text).toContain("OpenRouter");
+
+        // ── 2. sr-* switch ─────────────────────────────────────────────
+        const spendBefore = await getLiteLLMSpendForAgent(AGENT);
+        const srName = srButton.callbackData!.replace("mdl:sr:", "");
+
+        await sc.driver.pressButton(sc.botUserId, menu.messageId, srButton.callbackData!);
+        // Allow text-inject + claude's /model response to propagate
+        await new Promise((r) => setTimeout(r, 8_000));
+
+        const afterMenu = await sc.driver.getMessage(sc.botUserId, menu.messageId);
+        expect(afterMenu?.text ?? "", "confirmation banner after sr-* tap").toMatch(
+          /Set model to|Switched|session/i,
+        );
+        // Card must keep its buttons (#2270 — no dead card)
+        const kbAfter = await sc.driver.getKeyboard(sc.botUserId, menu.messageId);
+        expect((kbAfter ?? []).flat().length, "menu keeps buttons after sr-* tap").toBeGreaterThan(0);
+
+        // ── 3. Send a quick message to generate a LiteLLM-routed turn ──
+        await sc.sendDM("Just reply with the word OK.");
+        await sc.expectMessage(/ok/i, { from: "bot", timeout: 60_000 });
+
+        // ── 4. LiteLLM spend attribution ────────────────────────────────
+        if (spendBefore >= 0) {
+          // Give LiteLLM a moment to flush the log
+          await new Promise((r) => setTimeout(r, 3_000));
+          const spendAfter = await getLiteLLMSpendForAgent(AGENT);
+          expect(spendAfter, `agent:${AGENT} log_count increased after turn`).toBeGreaterThan(spendBefore);
+        }
+
+        // ── Restore: switch back to configured model ────────────────────
+        const currentKb = await sc.driver.getKeyboard(sc.botUserId, menu.messageId);
+        const restoreBtn = (currentKb ?? []).flat().find(
+          (b) => b.callbackData?.startsWith("mdl:s:") && /Default|Sonnet|claude-sonnet/i.test(b.text),
+        );
+        if (restoreBtn?.callbackData) {
+          await sc.driver.pressButton(sc.botUserId, menu.messageId, restoreBtn.callbackData);
+          await new Promise((r) => setTimeout(r, 4_000));
+        }
+
+        console.log(`✅ sr-* model switch (${srName}) verified end-to-end through LiteLLM`);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    180_000,
+  );
+
+  it(
+    "header row tap shows toast without switching model or opening picker",
+    async () => {
+      const sc = await spinUp({ agent: AGENT });
+      try {
+        await sc.sendDM("/model");
+        const menu = await sc.expectMessage(/Default \(new sessions\):/i, {
+          from: "bot",
+          timeout: 30_000,
+        });
+        const kb = await sc.driver.getKeyboard(sc.botUserId, menu.messageId);
+        const flat = (kb ?? []).flat();
+        const headerBtn = flat.find((b) => b.callbackData === "mdl:h");
+        if (!headerBtn) {
+          console.log("No header row — agent not LiteLLM-enabled. Skipping.");
+          return;
+        }
+        // Pressing the header should NOT change the menu text
+        const textBefore = menu.text;
+        await sc.driver.pressButton(sc.botUserId, menu.messageId, "mdl:h");
+        await new Promise((r) => setTimeout(r, 3_000));
+        const after = await sc.driver.getMessage(sc.botUserId, menu.messageId);
+        expect(after?.text ?? "").toBe(textBefore);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    60_000,
+  );
+});


### PR DESCRIPTION
## Summary

- The `/model` menu was showing only Claude subscription models even for LiteLLM-enabled agents. The root cause: sr-* model names were classified from claude's native picker output, which never includes them (the CLI only knows Anthropic models).
- Fix: adds `discoverSrModels()` dep to `ModelMenuDeps`. The gateway impl calls `GET /model/info` on the LiteLLM proxy using the virtual key from `ANTHROPIC_CUSTOM_HEADERS`, filters `sr-*` names, and merges them into the menu. Fails open (returns `[]`) when LiteLLM is not configured or unreachable.
- Adds UAT scenario `jtbd-model-litellm-sr-dm` covering section headers, sr-* session switch, and LiteLLM spend attribution.

## Test plan

- [x] `vitest run telegram-plugin/tests/model-command.test.ts` — 45 tests pass
- [x] `tsc --noEmit` — clean
- [x] `check-bot-api-wrapping.sh` — clean
- [ ] UAT: `bun run --cwd telegram-plugin test:uat jtbd-model-litellm-sr-dm` against test-harness after deploy
- [ ] Manual: `/model` in overlord shows `── Claude (Max / Pro subscription) ──` and `── OpenRouter / external ──` sections

## Risk

Low. `discoverSrModels` is fail-open: any fetch error returns `[]`, so agents without LiteLLM show unchanged Claude-only menus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZnNdwFupjXpDS6tXNXumj