### PR TITLE
fix(hostd): config_propose_edit card — surface reason + accept prefix-stripped diff headers (#2605)

### DIFF
--- a/src/host-control/config-edit-validator.ts
+++ b/src/host-control/config-edit-validator.ts
@@ -39,7 +39,7 @@
 
 import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, isAbsolute, normalize } from "node:path";
+import { join, isAbsolute, normalize, basename } from "node:path";
 import { spawnSync } from "node:child_process";
 import { isDeepStrictEqual } from "node:util";
 import {
@@ -114,7 +114,13 @@ function isTargetPathHeader(headerPath: string, targetBasename: string): boolean
   if (p.includes("..")) return false;
   const norm = normalize(p);
   if (norm.includes("..") || isAbsolute(norm)) return false;
-  return norm === targetBasename;
+  // Accept an exact basename match OR a relative path whose basename matches
+  // (e.g. `state/config/switchroom.yaml` after stripping `a/`). Agents
+  // writing diffs against the full config path produce headers like
+  // `a/state/config/switchroom.yaml`; the basename check accepts those
+  // without allowing path traversal (traversal is blocked above by the
+  // `..` and `isAbsolute` guards). (#2605)
+  return norm === targetBasename || basename(norm) === targetBasename;
 }
 
 /** Stage 1 — RFC §4.1. */

--- a/telegram-plugin/permission-title.ts
+++ b/telegram-plugin/permission-title.ts
@@ -212,6 +212,11 @@ export function naturalAction(
       return "update its task list";
     case "ExitPlanMode":
       return "exit plan mode";
+    // hostd config-edit verb (#2605) — not mcp__-prefixed (it's a direct
+    // wire call from the agent-config MCP server), so it falls through to
+    // the switch rather than naturalMcpAction. Give it a readable title.
+    case "config_propose_edit":
+      return "edit switchroom config";
     default:
       return `use ${toolName}`;
   }


### PR DESCRIPTION
## Summary

Fixes two bugs in the `config_propose_edit` MCP tool's operator approval card (issue #2605).

**Fix A — card title shows raw tool name**

`naturalAction()` in `telegram-plugin/permission-title.ts` hit the `default` case for `config_propose_edit` (it does not start with `mcp__`), producing "use config_propose_edit" as the card title. Added a dedicated case returning "edit switchroom config".

The `extractReasonFromRaw` regex fallback and the field order (`reason` before `unified_diff` in the MCP `inputSchema`) were already in place from prior work; this commit adds only the missing title case.

**Fix B — diffs with full-path headers rejected**

`isTargetPathHeader()` in `src/host-control/config-edit-validator.ts` compared `normalize(p)` (the header path after stripping `a/` or `b/`) against `targetBasename` (`switchroom.yaml`) with strict equality. A diff whose `---`/`+++` lines used the full path (e.g. `a/state/config/switchroom.yaml` → after strip: `state/config/switchroom.yaml`) would never match `switchroom.yaml`, causing `E_PATCH_INVALID_SHAPE`.

Fix: also accept when `path.basename(norm) === targetBasename`. All path-traversal guards (`..` + `isAbsolute`) remain in place before the basename check.

## Job spec

Serves `reference/jobs/jtbd-operator-control.md` — keeps the config-edit surface legible and usable for the operator.

## Test plan

- [x] `bun test telegram-plugin/tests/permission-title.test.ts` — 50 pass, 0 fail (includes the truncated-input reason-recovery tests)
- [x] `./node_modules/.bin/vitest run tests/host-control/config-edit-validator.test.ts` — 11 pass
- [x] `npm run lint` — clean (tsc, plugin-references, bot-api-wrapping, bun-test-imports, no-pii-secrets, vault-hermeticity, no-broadcast-delivery, stale-tool-descriptions, web-subscription-honest all clean)
- [x] Pre-existing failures in `boot-card-reason-to-render.test.ts` and `server.test.ts` confirmed pre-existing (reproduced on unmodified main)

Closes #2605