### PR TITLE
fix(cron): export LiteLLM virtual key in cron-session.sh before tmux launch

### DIFF
--- a/profiles/_base/cron-session.sh.hbs
+++ b/profiles/_base/cron-session.sh.hbs
@@ -86,6 +86,39 @@ CRON_APPEND_PROMPT="You are the cheap background cron worker for {{name}}. You r
 # (no --continue) — low context by construction. cd into the workspace so
 # claude's project key matches the pre-seeded trust state (.claude-cron).
 cd "{{agentDir}}" || exit 1
+
+# LiteLLM routing for the cron session — mirrors start.sh's boot block.
+# IMPORTANT: the vault key is provisioned under the BASE agent name ({{name}}),
+# NOT the cron identity ({{name}}-cron). Use the Handlebars template var so the
+# lookup is a compile-time literal — no fragile runtime suffix-stripping.
+# Attribution headers carry $SWITCHROOM_AGENT_NAME (= {{name}}-cron) so LiteLLM
+# can distinguish cron spend from main-session spend per agent.
+# FAIL-OPEN: missing key OR unreachable proxy → strip routing env, fall back to
+# direct OAuth. An outage must never take the cron session dark.
+if [ -n "$SWITCHROOM_LITELLM" ] && command -v switchroom >/dev/null 2>&1; then
+  sr_ll_key="$(switchroom vault get "litellm/{{name}}/api-key" 2>/dev/null || true)"
+  sr_ll_ok=""
+  if [ -z "$sr_ll_key" ]; then
+    echo "litellm: no virtual key for cron '{{name}}' — falling back to direct OAuth (no tracking/guardrail)" >&2
+  elif command -v curl >/dev/null 2>&1 && [ -n "$ANTHROPIC_BASE_URL" ] \
+       && ! curl -fsS -m 5 -o /dev/null "${ANTHROPIC_BASE_URL%/}/health/liveliness" 2>/dev/null; then
+    echo "litellm: proxy unreachable at $ANTHROPIC_BASE_URL — falling back to direct OAuth (no tracking/guardrail this session)" >&2
+  else
+    sr_ll_ok="1"
+  fi
+  if [ -n "$sr_ll_ok" ]; then
+    export ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: Bearer $sr_ll_key
+x-litellm-customer-id: $SWITCHROOM_AGENT_NAME
+x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:-default}"
+    export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
+  else
+    # Fail-open: drop every routing var so the claude CLI talks to Anthropic
+    # directly on its OAuth credential (subscription path), unproxied.
+    unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM
+  fi
+  unset sr_ll_key sr_ll_ok
+fi
+
 # Create the cron tmux session DETACHED (-d), not in attach mode. This is a
 # SUPERVISED BACKGROUND sidecar (start.sh forks it with `&`) with no controlling
 # TTY — the MAIN session owns the container's foreground TTY. The attach flag

--- a/tests/cheap-cron-session-render.test.ts
+++ b/tests/cheap-cron-session-render.test.ts
@@ -138,6 +138,47 @@ describe("cron-session.sh launcher — compliance + identity", () => {
   });
 });
 
+describe("cron-session.sh LiteLLM routing — mirrors start.sh boot block", () => {
+  const src = readFileSync(CRON_SH, "utf-8");
+  const out = renderTemplate(CRON_SH, baseCtx);
+
+  it("vault lookup uses the BASE name ({{name}} → marko), never the cron identity", () => {
+    // The virtual key is provisioned under litellm/marko/api-key, NOT
+    // litellm/marko-cron/api-key. The template var bakes the base name at
+    // scaffold time — no fragile runtime suffix-stripping.
+    expect(out).toContain('switchroom vault get "litellm/marko/api-key"');
+    expect(out).not.toContain("marko-cron/api-key");
+    // Template source must use {{name}}, not a hardcoded literal or runtime strip.
+    expect(src).toContain('litellm/{{name}}/api-key');
+  });
+
+  it("is gated on SWITCHROOM_LITELLM — inert when not set", () => {
+    expect(out).toContain('if [ -n "$SWITCHROOM_LITELLM" ]');
+  });
+
+  it("exports ANTHROPIC_CUSTOM_HEADERS and CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY on success", () => {
+    expect(out).toContain("x-litellm-api-key: Bearer $sr_ll_key");
+    expect(out).toContain("x-litellm-customer-id: $SWITCHROOM_AGENT_NAME");
+    expect(out).toContain("x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME");
+    expect(out).toContain("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1");
+  });
+
+  it("fail-open: unsets ALL routing vars so claude falls back to direct OAuth", () => {
+    expect(out).toContain(
+      "unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM",
+    );
+    expect(out).toContain("falling back to direct OAuth");
+  });
+
+  it("LiteLLM block appears BEFORE the tmux new-session call", () => {
+    const litellmIdx = out.indexOf("SWITCHROOM_LITELLM");
+    const tmuxIdx = out.indexOf("tmux -L");
+    expect(litellmIdx, "SWITCHROOM_LITELLM not found in rendered output").toBeGreaterThanOrEqual(0);
+    expect(tmuxIdx, "tmux -L not found in rendered output").toBeGreaterThan(0);
+    expect(litellmIdx, "LiteLLM block must precede the tmux launch").toBeLessThan(tmuxIdx);
+  });
+});
+
 describe("scheduleNeedsCronSession drives the gate", () => {
   it("no fresh entry → false (the whole fleet today)", () => {
     expect(scheduleNeedsCronSession([{ kind: "poll" }, {}], { cheapCronEnabled: true })).toBe(false);


### PR DESCRIPTION
## Summary

- `cron-session.sh.hbs` was launching `claude` via tmux without `ANTHROPIC_CUSTOM_HEADERS`, causing 401 errors when the cron claude hit the LiteLLM proxy (observed as `clerk-cron` PID 35 in container)
- Adds the same LiteLLM key-fetch block that `start.sh.hbs` already has, placed before the `tmux new-session` call so tmux inherits the exported env

## Key design choices

- **Vault path uses `litellm/{{name}}/api-key`** (Handlebars template var, resolved to base name at scaffold time). Keys are provisioned under the base agent name (`marko`), not the cron identity (`marko-cron`). No runtime suffix-stripping needed.
- **Attribution headers use `$SWITCHROOM_AGENT_NAME`** (= `<name>-cron`) so LiteLLM can distinguish cron spend from main-session spend per agent in the usage logs.
- **Fail-open mirrors start.sh exactly**: missing key OR unreachable proxy → `unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM`, log loudly to stderr, fall back to direct OAuth. Cron availability > guardrails.
- **`CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`** exported on success (parity with start.sh).

## Test plan

- [x] 5 new assertions in `tests/cheap-cron-session-render.test.ts` covering: base-name vault path, `SWITCHROOM_LITELLM` gate, headers set correctly, fail-open unset, ordering before tmux call
- [x] `./node_modules/.bin/vitest run tests/cheap-cron-session-render.test.ts tests/scaffold.litellm-failopen.test.ts` — 15 tests pass (all 19 in cron test, 1 in litellm failopen test)
- [x] No regressions in the two affected test files

## Risk

Low. The block is gated on `$SWITCHROOM_LITELLM` — for the majority of fleet agents without LiteLLM enabled, the block is completely inert. Agents with LiteLLM enabled gain the same key-fetch behaviour their main session already had.

Serves: job/orchestrate-reliable-agents (cron fires completing without 401 proxy errors)