### PR TITLE
chore: release v0.16.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.16.8 — gateway LiteLLM key fix (ANTHROPIC_CUSTOM_HEADERS in outer block)
+
+- Gateway sidecar now inherits `ANTHROPIC_CUSTOM_HEADERS` at startup so
+  `/model` menu correctly shows OpenRouter (`sr-*`) models. Root cause: the
+  key was fetched only in the inner tmux shell (after re-exec), never reaching
+  the outer-block sidecars (gateway, agent-scheduler). Fix: fetch once in the
+  outer block before any sidecar fork — all child processes inherit it
+  automatically. cron-session and inner-block fetches become defense-in-depth.
+- Hermes-Desktop adapter: operator console JSON-RPC 2.0 gateway (`/web/hermes`).
+
 ## v0.16.7 — sr-* model discovery + cron LiteLLM key fix
 
 - `/model` menu now shows OpenRouter (`sr-*`) models by querying LiteLLM

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.16.6",
+  "version": "0.16.8",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Gateway outer-block LiteLLM key fix (PR #2617) — gateway sidecar now gets `ANTHROPIC_CUSTOM_HEADERS`, enabling sr-* model discovery in `/model` menu
- Hermes-Desktop adapter (PR #2616) — operator console JSON-RPC 2.0 gateway

## CHANGELOG
See CHANGELOG.md — v0.16.8 section.

## Test plan
- [ ] CI green
- [ ] After merge: restart test-harness, verify gateway process has `ANTHROPIC_CUSTOM_HEADERS`
- [ ] `/model` in test-harness shows sr-* section
- [ ] UAT `jtbd-model-litellm-sr-dm` passes (not skipped)