### PR TITLE
fix(model): graceful restart when switching from sr-* back to Claude

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -16043,6 +16043,10 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
      */
     scheduleRestart: async (reason: string) => {
       const name = getMyAgentName()
+      // Debounce: mirror the /restart command's 15 s guard to prevent
+      // double-dispatch on a rapid double-tap of /model <claude-alias>.
+      const existing = readRestartMarker()
+      if (existing && Date.now() - existing.ts < 15_000) return
       if (restartCtx) {
         writeRestartMarker({
           chat_id: restartCtx.chatId,
@@ -16068,6 +16072,14 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
             restartCtx?.threadId ?? null,
             `restart ${name}`,
           ),
+        )
+        return
+      }
+      // hostd is configured but returned an error/denied result.
+      if (hostdResp.result !== 'started' && hostdResp.result !== 'completed') {
+        clearRestartMarker()
+        throw new Error(
+          `hostd restart failed (result=${hostdResp.result}): ${hostdResp.error ?? '(no details)'}`,
         )
       }
     },

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -15978,7 +15978,12 @@ bot.command('clear', async ctx => {
 // text. The typed argument form rides the allowlisted inject
 // primitive unchanged. Implementation in model-command.ts so it's
 // unit-testable without booting the bot.
-function buildModelDeps(): ModelMenuDeps & ModelCommandDeps {
+interface ModelDepsRestartContext {
+  chatId: string
+  threadId: number | undefined
+}
+
+function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & ModelCommandDeps {
   return {
     discover: (a) => discoverModels(a),
     discoverSrModels: async () => {
@@ -16029,6 +16034,43 @@ function buildModelDeps(): ModelMenuDeps & ModelCommandDeps {
     },
     escapeHtml: escapeHtmlForTg,
     preBlock,
+    getActiveSessionModel: () => activeSessionModelOverride,
+    /**
+     * Graceful restart for sr-* → Claude model switch. Same mechanism as
+     * the /restart command: writes a restart marker (so the post-restart
+     * greeting lands in the originating chat), stamps the reason, and
+     * dispatches via hostd (or legacy detached spawn as fallback).
+     */
+    scheduleRestart: async (reason: string) => {
+      const name = getMyAgentName()
+      if (restartCtx) {
+        writeRestartMarker({
+          chat_id: restartCtx.chatId,
+          thread_id: restartCtx.threadId ?? null,
+          ack_message_id: null,
+          ts: Date.now(),
+        })
+      }
+      stampUserRestartReason(reason)
+      await sweepBeforeSelfRestart()
+      const hostdResp = await tryHostdDispatch(name, {
+        v: 1,
+        op: 'agent_restart',
+        request_id: hostdRequestId('gw-model-restart'),
+        args: { name, force: true, reason },
+      })
+      if (hostdResp === 'not-configured') {
+        warnLegacySpawnIfHostdDisabled('agent_restart')
+        spawnSwitchroomDetached(
+          ['agent', 'restart', name, '--force'],
+          notifyDetachedFailure(
+            restartCtx?.chatId ?? '',
+            restartCtx?.threadId ?? null,
+            `restart ${name}`,
+          ),
+        )
+      }
+    },
   }
 }
 
@@ -16046,7 +16088,9 @@ bot.command('model', async ctx => {
   if (!isAuthorizedSender(ctx)) return
   const text = ctx.message?.text ?? ctx.channelPost?.text ?? ''
   const parsed = parseModelCommand(text) ?? { kind: 'show' as const }
-  const deps = buildModelDeps()
+  const chatId = String(ctx.chat!.id)
+  const threadId = resolveThreadId(chatId, ctx.message?.message_thread_id)
+  const deps = buildModelDeps({ chatId, threadId })
   if (parsed.kind === 'show' && process.env.SWITCHROOM_MODEL_MENU !== '0') {
     const menu = await buildModelMenu(deps)
     await switchroomReply(ctx, menu.text, { html: true, reply_markup: modelMenuReplyMarkup(menu) })
@@ -20726,7 +20770,9 @@ bot.on('callback_query:data', async ctx => {
         .catch(() => {})
       return
     }
-    const modelDeps = buildModelDeps()
+    const cbChatId = String(ctx.chat?.id ?? '')
+    const cbThreadId = resolveThreadId(cbChatId, ctx.callbackQuery?.message?.message_thread_id)
+    const modelDeps = buildModelDeps({ chatId: cbChatId, threadId: cbThreadId })
     // Mid-turn refusal is INSTANT (a sync isBusy() check, no picker drive),
     // so handle it before the "Working…" ack: toast WHY and leave the menu
     // message untouched (buttons intact) so the operator taps again when

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -62,6 +62,23 @@ export function isValidModelArg(arg: string): boolean {
   return MODEL_ARG_RE.test(arg)
 }
 
+/** True when `name` is an sr-* (LiteLLM/OpenRouter) model identifier. */
+export function isSrModel(name: string): boolean {
+  return name.startsWith('sr-')
+}
+
+/**
+ * True when `name` is a Claude model — either a well-known alias or a
+ * full `claude-*` id (including `[1m]` variants). This is intentionally
+ * broader than MODEL_ALIASES: any `claude-…` string from claude's own
+ * picker (e.g. `claude-opus-4-8`) qualifies.
+ */
+export function isClaudeModel(name: string): boolean {
+  const lower = name.toLowerCase()
+  if ((MODEL_ALIASES as readonly string[]).includes(lower)) return true
+  return lower.startsWith('claude-')
+}
+
 export type ParsedModelCommand =
   | { kind: 'show' }
   | { kind: 'set'; model: string }
@@ -100,6 +117,22 @@ export interface ModelCommandDeps {
   getConfiguredModel: () => string | null
   escapeHtml: (s: string) => string
   preBlock: (s: string) => string
+  /**
+   * The active session-model override set by a prior `/model` switch.
+   * Null when no session override is active (using configured/default model).
+   * Used to detect whether the current session is on an sr-* (OpenRouter)
+   * model so a switch back to Claude can trigger a graceful restart instead
+   * of an in-place inject (which would leave stale sr-* routing in place).
+   */
+  getActiveSessionModel: () => string | null
+  /**
+   * Schedule a graceful restart of this agent. Called instead of inject
+   * when switching from an sr-* model back to Claude — the restart clears
+   * the sr-* session context cleanly, whereas an in-place inject would
+   * leave LiteLLM routing active. The gateway wires this to the same
+   * mechanism as the `/restart` command (hostd-first, SIGTERM fallback).
+   */
+  scheduleRestart: (reason: string) => Promise<void>
 }
 
 export interface ModelCommandReply {
@@ -148,6 +181,32 @@ export async function handleModelCommand(
   if (!isValidModelArg(parsed.model)) {
     return helpText(deps, `not a valid model name: ${parsed.model}`)
   }
+
+  // sr-* → Claude: an in-place `/model` inject would leave LiteLLM routing
+  // active in the live session because the sr-* model context was set by
+  // the proxy at session start, not by claude's own REPL. A graceful restart
+  // is the only clean path back to the native OAuth route. This matches the
+  // behaviour of the `/restart` command (same mechanism, same marker logic).
+  const currentSession = deps.getActiveSessionModel()
+  if (currentSession !== null && isSrModel(currentSession) && isClaudeModel(parsed.model)) {
+    try {
+      await deps.scheduleRestart(`user: /model ${parsed.model} (sr-to-claude restart)`)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      return {
+        text: `❌ Could not schedule restart: ${deps.escapeHtml(msg)}`,
+        html: true,
+      }
+    }
+    return {
+      text: [
+        `Switching from <code>${deps.escapeHtml(currentSession)}</code> back to Claude — restarting session cleanly. Claude will be ready in ~30s.`,
+        PERSIST_NOTE,
+      ].join('\n'),
+      html: true,
+    }
+  }
+
   const verbHtml = `<code>/model ${deps.escapeHtml(parsed.model)}</code>`
   let result: InjectResult
   try {

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -18,6 +18,8 @@ import {
   parseModelCommand,
   handleModelCommand,
   isValidModelArg,
+  isSrModel,
+  isClaudeModel,
   MODEL_ALIASES,
   type ModelCommandDeps,
 } from "../gateway/model-command.js";
@@ -35,6 +37,7 @@ function okResult(output: string): InjectResult {
 
 function makeDeps(overrides: Partial<ModelCommandDeps> = {}) {
   const calls: Array<{ agent: string; command: string }> = [];
+  const restartCalls: string[] = [];
   const deps: ModelCommandDeps = {
     inject: async (agent, command) => {
       calls.push({ agent, command });
@@ -45,9 +48,11 @@ function makeDeps(overrides: Partial<ModelCommandDeps> = {}) {
     escapeHtml: (s) =>
       s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;"),
     preBlock: (s) => `<pre>${s}</pre>`,
+    getActiveSessionModel: () => null,
+    scheduleRestart: async (reason) => { restartCalls.push(reason); },
     ...overrides,
   };
-  return { deps, calls };
+  return { deps, calls, restartCalls };
 }
 
 describe("parseModelCommand", () => {
@@ -234,6 +239,97 @@ describe("handleModelCommand — set", () => {
     });
     const reply = await handleModelCommand({ kind: "set", model: "sonnet" }, deps);
     expect(reply.text).toContain("boom");
+  });
+});
+
+describe("isSrModel / isClaudeModel helpers", () => {
+  it("isSrModel is true only for sr-* names", () => {
+    expect(isSrModel("sr-gemini-2.5-pro")).toBe(true);
+    expect(isSrModel("sr-deepseek-r1")).toBe(true);
+    expect(isSrModel("claude-sonnet-4-6")).toBe(false);
+    expect(isSrModel("sonnet")).toBe(false);
+    expect(isSrModel("")).toBe(false);
+  });
+
+  it("isClaudeModel is true for aliases and claude-* ids", () => {
+    for (const alias of MODEL_ALIASES) {
+      expect(isClaudeModel(alias), alias).toBe(true);
+    }
+    expect(isClaudeModel("claude-opus-4-8")).toBe(true);
+    expect(isClaudeModel("claude-sonnet-4-6[1m]")).toBe(true);
+    expect(isClaudeModel("sr-gemini-2.5-pro")).toBe(false);
+    expect(isClaudeModel("gpt-4")).toBe(false);
+  });
+});
+
+describe("handleModelCommand — sr-* → Claude graceful restart", () => {
+  it("schedules restart instead of injecting when session is on sr-* and target is Claude alias", async () => {
+    const { deps, calls, restartCalls } = makeDeps({
+      getActiveSessionModel: () => "sr-gemini-2.5-pro",
+    });
+    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
+    // Must NOT inject
+    expect(calls).toHaveLength(0);
+    // Must schedule a restart
+    expect(restartCalls).toHaveLength(1);
+    expect(restartCalls[0]).toContain("opus");
+    expect(restartCalls[0]).toContain("sr-to-claude");
+    // Reply mentions the sr-* model and ~30s
+    expect(reply.text).toContain("sr-gemini-2.5-pro");
+    expect(reply.text).toContain("30s");
+    expect(reply.html).toBe(true);
+  });
+
+  it("schedules restart when session is on sr-* and target is a full claude-* id", async () => {
+    const { deps, calls, restartCalls } = makeDeps({
+      getActiveSessionModel: () => "sr-deepseek-r1",
+    });
+    const reply = await handleModelCommand({ kind: "set", model: "claude-opus-4-8" }, deps);
+    expect(calls).toHaveLength(0);
+    expect(restartCalls).toHaveLength(1);
+    expect(reply.text).toContain("sr-deepseek-r1");
+    expect(reply.text).toContain("30s");
+  });
+
+  it("does NOT restart when switching between Claude models (no sr-* session)", async () => {
+    const { deps, calls, restartCalls } = makeDeps({
+      getActiveSessionModel: () => "Opus 4.8",
+    });
+    const reply = await handleModelCommand({ kind: "set", model: "sonnet" }, deps);
+    // Normal inject path: still injects, no restart
+    expect(calls).toHaveLength(1);
+    expect(restartCalls).toHaveLength(0);
+    expect(reply.text).toContain("Set model to sonnet");
+  });
+
+  it("does NOT restart when switching from Claude to sr-* (no session override)", async () => {
+    const { deps, calls, restartCalls } = makeDeps({
+      getActiveSessionModel: () => null,
+    });
+    await handleModelCommand({ kind: "set", model: "sr-gemini-2.5-pro" }, deps);
+    // sr-* is not a Claude model — no restart
+    expect(restartCalls).toHaveLength(0);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("surfaces scheduleRestart failures without propagating the error", async () => {
+    const { deps, calls } = makeDeps({
+      getActiveSessionModel: () => "sr-deepseek-r1",
+      scheduleRestart: async () => { throw new Error("hostd unreachable"); },
+    });
+    const reply = await handleModelCommand({ kind: "set", model: "sonnet" }, deps);
+    expect(calls).toHaveLength(0);
+    expect(reply.text).toContain("Could not schedule restart");
+    expect(reply.text).toContain("hostd unreachable");
+  });
+
+  it("null session model (no prior override) still uses normal inject path for Claude target", async () => {
+    const { deps, calls, restartCalls } = makeDeps({
+      getActiveSessionModel: () => null,
+    });
+    await handleModelCommand({ kind: "set", model: "opus" }, deps);
+    expect(calls).toHaveLength(1);
+    expect(restartCalls).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- Detects the sr-* → Claude model switch in `handleModelCommand` and schedules a graceful restart instead of an in-place inject
- An in-place `/model` inject can't restore the native Claude OAuth path when the session was started under an sr-* (LiteLLM/OpenRouter) model — the routing context lives in the live session, not just a config flag. Restart is the only clean path back.
- Reuses the exact same restart mechanism as `/restart` (hostd-first, SIGTERM/systemctl fallback, restart marker so the post-restart greeting lands in the originating chat)
- Switching between Claude models (opus → sonnet) and switching Claude → sr-* are unchanged — normal inject path

## What changed

**`telegram-plugin/gateway/model-command.ts`**
- `ModelCommandDeps`: two new fields — `getActiveSessionModel()` (returns the current session override or null) and `scheduleRestart(reason)` (wired to the gateway's restart mechanism)
- New exported helpers `isSrModel` / `isClaudeModel` (tested, covers aliases + full `claude-*` ids)
- `handleModelCommand` kind='set': checks for sr-* session + Claude target; if true, calls `scheduleRestart` and returns an informational message instead of injecting

**`telegram-plugin/gateway/gateway.ts`**
- `buildModelDeps` now accepts an optional `restartCtx: { chatId, threadId }` and wires `getActiveSessionModel` + `scheduleRestart` using the same restart flow as `bot.command('restart')`
- Both callers (`bot.command('model')` and the `mdl:*` callback handler) pass their chat context

**`telegram-plugin/tests/model-command.test.ts`**
- 8 new tests covering: sr-* → alias restart, sr-* → full claude-* id restart, Claude → Claude no restart, Claude → sr-* no restart, scheduleRestart failure surfacing, null session no restart

## Test plan

- [x] All 56 model-command bun tests pass
- [x] `tsc --noEmit` clean
- [x] `check-bot-api-wrapping.sh` clean

## Risk

Low. The restart path is the same code the `/restart` command exercises; the new conditional is guarded by both `isSrModel(currentSession)` AND `isClaudeModel(target)`, so it only fires in the specific sr-* → Claude case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXGDSGArnajHNjcf8Vr17T