### PR TITLE
fix(model): graceful restart for menu-button sr-* → Claude switch

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -275,6 +275,7 @@ import {
   handleModelCommand,
   buildModelMenu,
   handleModelMenuCallback,
+  isSrToClaudeTransition,
   MODEL_CALLBACK_PREFIX,
   MODEL_CALLBACK_HEADER,
   type ModelMenuDeps,
@@ -20808,6 +20809,7 @@ bot.on('callback_query:data', async ctx => {
     }
     await ctx.answerCallbackQuery({ text: 'Switching…' }).catch(() => {})
     try {
+      const prevSessionModel = activeSessionModelOverride
       const outcome = await handleModelMenuCallback(data, modelDeps)
       // Record a successful session switch so /status reflects what's
       // actually running. In-memory only → clears when the gateway (and thus
@@ -20818,6 +20820,35 @@ bot.on('callback_query:data', async ctx => {
       // toastOnly: a no-op outcome that should not disturb the menu (defence
       // in depth — the isBusy() short-circuit above is the live path).
       if (outcome.toastOnly) return
+
+      // sr-* → Claude transition via the model menu: trigger a graceful restart.
+      // Switching FROM an sr-* (LiteLLM/OpenRouter) model BACK to a Claude model
+      // via the picker requires a session restart — the picker-select only changes
+      // the session model label, but the sr-* LiteLLM routing context persists
+      // until the session is torn down. Same mechanism as the /restart command.
+      if (outcome.selectedModel && isSrToClaudeTransition(prevSessionModel, outcome.selectedModel)) {
+        const agentName = getMyAgentName()
+        // Replace the menu with a restart notice (no buttons — session is ending).
+        await ctx
+          .editMessageText(
+            `🔄 Switching from <b>${escapeHtmlForTg(prevSessionModel!)}</b> back to Claude — restarting session cleanly. Claude will be ready in ~30s.`,
+            { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
+          )
+          .catch(() => {})
+        // Write the restart marker so the post-restart boot card edits into this chat.
+        writeRestartMarker({ chat_id: cbChatId, thread_id: cbThreadId ?? null, ack_message_id: null, ts: Date.now() })
+        stampUserRestartReason('user: sr-to-claude model switch (menu)')
+        if (turnInFlightForGate()) {
+          // Defer restart until the in-flight turn completes (same gate as /restart).
+          pendingRestarts.set(agentName, Date.now())
+        } else {
+          void sweepBeforeSelfRestart().finally(() =>
+            triggerSelfRestart(agentName, 'sr-to-claude-model-switch', 1500),
+          )
+        }
+        return
+      }
+
       await ctx
         .editMessageText(outcome.reply.text, {
           parse_mode: 'HTML',

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -609,6 +609,20 @@ export async function handleModelMenuCallback(
 }
 
 /**
+ * True when the transition from `prevModel` to `nextModel` is a switch FROM
+ * an sr-* (LiteLLM/OpenRouter) model BACK TO a native Claude model. This
+ * signals that a session restart is required — an in-place model-picker select
+ * cannot undo the LiteLLM routing that the sr-* switch established in the live
+ * session. Null / undefined prev means no prior sr-* session — not a transition.
+ */
+export function isSrToClaudeTransition(
+  prevModel: string | null | undefined,
+  nextModel: string,
+): boolean {
+  return !!prevModel?.startsWith('sr-') && !nextModel.startsWith('sr-')
+}
+
+/**
  * Pull the model NAME out of claude's session-switch confirmation so it can
  * be shown in `/status` as the live session model. claude phrases it as
  * "Set model to <name> for this session only" (or "Switched to <name>").

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -354,6 +354,7 @@ import {
   MODEL_CALLBACK_HEADER,
   MODEL_CALLBACK_SR,
   SR_MODEL_LABELS,
+  isSrToClaudeTransition,
   type ModelMenuDeps,
 } from "../gateway/model-command.js";
 import { labelTag } from "../../src/agents/model-picker.js";
@@ -672,5 +673,31 @@ describe("handleModelMenuCallback — sr-* selection", () => {
     const { deps } = makeMenuDepsWithSr();
     const out = await handleModelMenuCallback(`${MODEL_CALLBACK_SR}bad name with spaces`, deps);
     expect(out.answer).toBe("Invalid model name");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSrToClaudeTransition helper (used by gateway callback handler)
+// ---------------------------------------------------------------------------
+
+describe("isSrToClaudeTransition", () => {
+  it("true when prev is sr-* and next is not sr-*", () => {
+    expect(isSrToClaudeTransition("sr-gemini-2.5-pro", "Haiku 4.5")).toBe(true);
+    expect(isSrToClaudeTransition("sr-deepseek-r1", "Fable 5")).toBe(true);
+    expect(isSrToClaudeTransition("sr-deepseek-r1", "claude-opus-4-8")).toBe(true);
+  });
+
+  it("false when prev is not sr-* (Claude → Claude)", () => {
+    expect(isSrToClaudeTransition("Opus 4.8", "Haiku 4.5")).toBe(false);
+    expect(isSrToClaudeTransition(null, "Sonnet")).toBe(false);
+    expect(isSrToClaudeTransition(undefined, "Sonnet")).toBe(false);
+  });
+
+  it("false when prev is sr-* but next is also sr-* (sr-* → sr-*)", () => {
+    expect(isSrToClaudeTransition("sr-gemini-2.5-pro", "sr-deepseek-r1")).toBe(false);
+  });
+
+  it("false when switching to sr-* from Claude (Claude → sr-*)", () => {
+    expect(isSrToClaudeTransition("Sonnet", "sr-gemini-2.5-pro")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #2619 (merged), which covered the text-command path (`/model opus` while session is on sr-*).

This PR covers the **model-menu button-tap path** — when a user taps a Claude model button in the inline `/model` menu while the live session is on an sr-* (OpenRouter/LiteLLM) model.

Without this, the picker-select successfully re-labels the session as the new Claude model (updating `activeSessionModelOverride`), but the LiteLLM routing context persists until the session is torn down. An in-place picker select cannot undo that routing — only a restart can.

**What changes:**
- `model-command.ts`: export `isSrToClaudeTransition(prevModel, nextModel)` helper. Thin pure function so the gateway owns the restart timing/mechanism.
- `gateway.ts`: In the model-menu callback handler, capture `prevSessionModel` before processing the outcome. If `isSrToClaudeTransition(prevSessionModel, outcome.selectedModel)`, replace the menu with a restart notice, write the restart marker (so the post-restart boot card edits into the originating chat), and trigger restart via `pendingRestarts` / `triggerSelfRestart` — same gate and mechanism as `/restart`.
- `tests`: 4 new `isSrToClaudeTransition` unit tests; 60 total, all pass; tsc clean.

## What's NOT covered here (by design)

- `mdl:sr:` tap (switching TO sr-*) — no restart needed; text-inject path is fine.
- Refresh tap — no model switch; no restart needed.
- Claude → Claude switch — already handled; no restart.

## Test plan

- [x] `bun test telegram-plugin/tests/model-command.test.ts` — 60 pass
- [x] `tsc --noEmit` — clean
- [x] `check-bot-api-wrapping.sh` — clean
- [ ] UAT: tap a Claude model button while session is on sr-gemini-2.5-pro — expect restart notice and agent comes back on Claude ~30s later

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXGDSGArnajHNjcf8Vr17T