### PR TITLE
chore: bump package.json version to 0.16.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.16.8",
+  "version": "0.16.9",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Follow-up to the v0.16.9 release — keeps package.json version in sync with the tag.