### PR TITLE
fix(gateway): close obligation at turn_end when replyCalled=true

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3375,15 +3375,24 @@ function endCurrentTurnAtomic(turn: CurrentTurn): void {
   // finalAnswerDelivered===false → stays open → re-presented (the intended
   // catch). close() is a no-op for synthetic turns (turnId not in the ledger).
   // No-op when the flag is off.
+  //
+  // #2624 — sr-* model short-reply cascade fix. When the model routes through
+  // LiteLLM (sr-* path), the claude CLI calls reply("OK", {disable_notification:
+  // true}) for short answers — below the 200-char backstop and notification-
+  // suppressed, so isFinalAnswerReply returns false and finalAnswerDelivered stays
+  // false. This triggers a cascade: obligation re-presents with growing 25k-token
+  // context, blocking the agent for minutes. The ack-then-ghost case that
+  // obligations are designed to catch ends via silence_fallback, NOT turn_end.
+  // At turn_end with replyCalled=true the model explicitly signalled completion
+  // AND replied, so the obligation is satisfied regardless of finalAnswerDelivered.
   if (OBLIGATION_LEDGER_ENABLED) {
-    if (turn.finalAnswerDelivered) {
+    if (turn.finalAnswerDelivered || turn.replyCalled) {
       obligationLedger.close(turn.turnId)
     } else {
-      // Turn ended WITHOUT a final answer. If this turn was handling an open
-      // obligation, stamp its grace clock so the idle sweep waits before
-      // re-presenting/escalating — a slow/worker answer may still be in flight
-      // (the over-escalation fix). No-op when turn.turnId isn't an open
-      // obligation (synthetic / already-closed turn).
+      // Turn ended WITHOUT any reply (no ack, no answer). If this turn was
+      // handling an open obligation, stamp its grace clock so the idle sweep
+      // waits before re-presenting/escalating. No-op when turn.turnId isn't
+      // in the ledger (synthetic / already-closed turn).
       obligationLedger.noteTurnEnded(turn.turnId, Date.now())
     }
   }


### PR DESCRIPTION
## Summary

- **Root cause**: sr-* model (LiteLLM/OpenRouter) turns end with `finalAnswerDelivered=false` because claude calls `reply("OK", {disable_notification: true})` for short answers. The 200-char backstop + notification-suppressed path means `isFinalAnswerReply` returns false.
- **Effect**: Obligation cascade — each re-present sends the full 25k-token conversation context to the flash model, which responds again (~20-30s per call), which again sets `finalAnswerDelivered=false`, looping until max attempts and then escalating. Blocks the agent for minutes after any sr-* turn with a short reply.
- **Fix**: At `turn_end` (explicit claude completion signal), close the obligation when `finalAnswerDelivered || replyCalled`. The ack-then-ghost case that obligations are designed to catch ends via `silence_fallback`, not `turn_end`, so this distinction is safe.

## Why `turn_end` + `replyCalled=true` is safe to close

`silence_fallback` fires when the model goes silent — it's the gateway's detection of ack-then-ghost. `turn_end` fires when claude explicitly signals the session is complete. If the model signalled completion AND replied, the obligation is satisfied even if the reply was short/silent.

The only dangerous edge case would be: model sends an interim ack ("On it!") and then fires `turn_end` without actually answering. In practice: (1) this doesn't happen in normal claude operation, (2) the obligation system's purpose is to catch silent ghosts — if the model explicitly closes the turn, we accept that as closure.

## Test plan

- [x] `bun test telegram-plugin/tests/` — 5079 pass, 0 fail
- [x] tsc --noEmit — clean
- [ ] UAT: `bun run --cwd telegram-plugin test:uat jtbd-model-litellm-sr-dm` should pass both tests cleanly after rollout (obligation cascade no longer fires after sr-* short replies)
- [ ] CI green

## Risk

Low. The `silence_fallback` path is unchanged. Only `turn_end` + `replyCalled` is affected, and those turns have always reliably replied. Worst case: a model fires `turn_end` without a real answer after an ack — obligation doesn't re-present. That's a rare edge case and preferable to the current cascade.

Serves: job/model-selection (sr-* reliability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01SXGDSGArnajHNjcf8Vr17T