### PR TITLE
test(uat): extend /model menu expectMessage to 60s

### DIFF
--- a/telegram-plugin/uat/scenarios/jtbd-model-litellm-sr-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-model-litellm-sr-dm.test.ts
@@ -42,9 +42,11 @@ describe("uat: /model sr-* LiteLLM routing — section headers + session switch 
       const sc = await spinUp({ agent: AGENT });
       try {
         await sc.sendDM("/model");
+        // 60s — if an obligation turn is being processed when /model lands,
+        // the menu may be buffered until the turn drains (~40s max).
         const menu = await sc.expectMessage(/Default \(new sessions\):/i, {
           from: "bot",
-          timeout: 30_000,
+          timeout: 60_000,
         });
 
         // ── 1. Section headers ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

The sr-* obligation cascade fix (PR #2624, shipped in v0.16.10) closes the root cause, but there's a race: if a stale obligation is still draining when `/model` lands, the menu response is buffered until the turn finishes (~40s max). The previous 30s window was reliably too tight.

Extends the first `expectMessage` timeout from 30s → 60s with an explanatory comment.

## Test plan

- [x] One-line diff, no logic change
- [ ] CI green (uat/ is excluded from gating)
- [ ] Confirmed manually: UAT now completes cleanly post-v0.16.10 rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01SXGDSGArnajHNjcf8Vr17T