### PR TITLE
fix(telegram): convert markdown in the answer-stream lane

### DIFF
--- a/telegram-plugin/answer-stream.ts
+++ b/telegram-plugin/answer-stream.ts
@@ -93,6 +93,24 @@ export interface AnswerStreamConfig {
   ) => Promise<unknown>
   deleteMessage?: (chatId: string, messageId: number) => Promise<unknown>
 
+  /**
+   * Render the raw assistant transcript text into the wire format used for
+   * `parse_mode: 'HTML'` sends/edits. Every OTHER outbound lane in the gateway
+   * (handleStreamReply, the reply handler, the turn-flush backstop, the PTY
+   * partial handler) converts markdown → Telegram HTML via
+   * `sanitizeTelegramHtml(markdownToHtml(...))` before sending. The
+   * answer-stream lane historically shipped the RAW transcript under
+   * `parse_mode: 'HTML'`, so `**bold**` reached the user as literal asterisks
+   * and agent narration read as unformatted text.
+   *
+   * Injected as a dependency (mirroring `renderText` on the PTY partial
+   * handler) rather than hard-importing `format`/`html-sanitize` here, so this
+   * module stays free of a grammy/format dependency and remains fully
+   * testable. When absent, text is sent verbatim — preserving the old
+   * behaviour for callers (and tests) that don't wire it.
+   */
+  renderText?: (text: string) => string
+
   /** Called when a late edit/send resolves but this stream has been superseded. */
   onSuperseded?: OnSupersededCallback
   log?: (msg: string) => void
@@ -179,6 +197,7 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
     replyToMessageId,
     sendMessage,
     editMessageText,
+    renderText,
     onSuperseded,
     log,
     warn,
@@ -187,6 +206,13 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
     recordDedup,
     recordOutbound,
   } = config
+
+  /**
+   * Convert raw transcript text to the wire format before any
+   * `parse_mode: 'HTML'` send/edit. Falls back to the verbatim text when no
+   * renderer is injected (old behaviour / unwired tests).
+   */
+  const render = (text: string): string => (renderText != null ? renderText(text) : text)
 
   const effectiveThrottle = Math.max(250, throttleMs)
 
@@ -229,6 +255,10 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
   }
 
   async function sendOrEditViaMessage(trimmed: string, gen: number, prevText: string): Promise<void> {
+    // Convert raw transcript markdown → Telegram HTML before sending under
+    // parse_mode: 'HTML'. Without this, `**bold**` ships as literal asterisks
+    // (the answer-stream-raw-markdown bug). Mirrors every other outbound lane.
+    const rendered = render(trimmed)
     if (typeof streamMsgId === 'number') {
       // Edit existing message
       const editParams: Parameters<typeof editMessageText>[3] = {
@@ -237,7 +267,7 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
       }
       if (threadId != null) editParams.message_thread_id = threadId
       try {
-        await editMessageText(chatId, streamMsgId, trimmed, editParams)
+        await editMessageText(chatId, streamMsgId, rendered, editParams)
         onMetric?.({ kind: 'answer_lane_update', chatId, messageId: streamMsgId, charCount: trimmed.length, transport: 'edit' })
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
@@ -266,7 +296,7 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
       }
       if (threadId != null) sendParams.message_thread_id = threadId
       if (replyToMessageId != null) sendParams.reply_parameters = { message_id: replyToMessageId }
-      const sent = await sendMessage(chatId, trimmed, sendParams)
+      const sent = await sendMessage(chatId, rendered, sendParams)
       const sentId = sent?.message_id
       if (typeof sentId !== 'number' || !Number.isFinite(sentId)) {
         warn?.('answer-stream: sendMessage returned no message_id')
@@ -424,7 +454,11 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
       // nested quote that looks wrong.
 
       try {
-        const sent = await sendMessage(chatId, textToSend, sendParams)
+        // Render markdown → Telegram HTML for the wire send. The dedup /
+        // silent-marker / history checks above all run on the raw textToSend
+        // (so they match the comparisons the other lanes make on raw text);
+        // only the actual outbound payload is converted.
+        const sent = await sendMessage(chatId, render(textToSend), sendParams)
         const sentId = sent?.message_id
         if (typeof sentId === 'number' && Number.isFinite(sentId)) {
           streamMsgId = sentId

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -189,6 +189,7 @@ const SILENT_END_FALLBACK_TEXT =
   '⚠️ The agent finished working but didn’t send a reply — your last ' +
   'message may not have been answered. Please try asking again.'
 import { markdownToHtml, splitHtmlChunks, repairEscapedWhitespace, telegramHtmlToPlainText } from '../format.js'
+import { sanitizeTelegramHtml } from '../html-sanitize.js'
 import { scrubVoice } from '../text-voice-scrub.js'
 import {
   validateInlineKeyboard,
@@ -11667,6 +11668,15 @@ function handleSessionEvent(ev: SessionEvent): void {
             //   (no flash). The draft transport is permanently retired — both modes
             //   use sendMessage + editMessageText for any message that does open.
             minInitialChars: ANSWER_LANE.minInitialChars,
+            // Render raw assistant transcript markdown → Telegram HTML before
+            // any parse_mode:'HTML' send/edit, matching every other outbound
+            // lane (handleStreamReply, the reply handler, the turn-flush
+            // backstop, handlePtyPartial). Without this the answer-stream lane
+            // shipped raw text — `**bold**` arrived as literal asterisks and
+            // agent narration read unformatted (the answer-stream-raw-markdown
+            // bug). Injected as a dependency (same pattern as the PTY partial
+            // handler's `renderText`) so answer-stream.ts stays format-free.
+            renderText: (text: string) => sanitizeTelegramHtml(markdownToHtml(text)),
             // #1075: route through robustApiCall so flood-wait,
             // benign-400, and THREAD_NOT_FOUND are handled uniformly
             // instead of crashing the answer-stream loop on a deleted

--- a/telegram-plugin/tests/answer-stream.test.ts
+++ b/telegram-plugin/tests/answer-stream.test.ts
@@ -4,6 +4,15 @@ import {
   MIN_INITIAL_CHARS,
 } from '../answer-stream.js'
 import { resolveAnswerLaneConfig, ANSWER_LANE_NEVER_OPENS } from '../answer-stream-flag.js'
+import { markdownToHtml } from '../format.js'
+import { sanitizeTelegramHtml } from '../html-sanitize.js'
+
+/**
+ * The exact renderer the gateway injects into createAnswerStream — markdown →
+ * Telegram HTML, then HTML sanitize. Mirrors gateway.ts so the test pins the
+ * real conversion, not a hand-rolled one.
+ */
+const renderText = (text: string): string => sanitizeTelegramHtml(markdownToHtml(text))
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -131,6 +140,115 @@ describe('answer-stream — minInitialChars threshold', () => {
       expect.objectContaining({ parse_mode: 'HTML' }),
     )
     expect(editMessageText).not.toHaveBeenCalled()
+  })
+})
+
+describe('answer-stream — markdown → HTML conversion (renderText)', () => {
+  // Regression for the answer-stream-raw-markdown bug: this lane historically
+  // shipped the RAW assistant transcript under parse_mode:'HTML', so `**bold**`
+  // arrived as literal asterisks while every other lane converted. The fix
+  // injects the same renderText the other lanes use; these tests assert the
+  // wire payload is converted, not raw.
+
+  it('converts **bold** to <b>bold</b> on the opening sendMessage', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      minInitialChars: 10,
+      throttleMs: 250,
+      renderText,
+      sendMessage,
+      editMessageText,
+    })
+
+    stream.update('Here is some **bold** narration text for the user.')
+    await flushMicrotasks()
+
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    const sentText = sendMessage.mock.calls[0][1] as string
+    expect(sentText).toContain('<b>bold</b>')
+    expect(sentText).not.toContain('**bold**')
+    expect(sendMessage).toHaveBeenCalledWith(
+      'chat1',
+      expect.stringContaining('<b>bold</b>'),
+      expect.objectContaining({ parse_mode: 'HTML' }),
+    )
+  })
+
+  it('converts **bold** to <b>bold</b> on a follow-up editMessageText', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      minInitialChars: 10,
+      throttleMs: 250,
+      renderText,
+      sendMessage,
+      editMessageText,
+    })
+
+    // First update opens the message.
+    stream.update('first chunk of the answer arriving')
+    await flushMicrotasks()
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+
+    // Second update (past the throttle window) edits in place with markdown.
+    vi.advanceTimersByTime(300)
+    stream.update('first chunk of the answer arriving with **bold** added')
+    vi.advanceTimersByTime(300)
+    await flushMicrotasks()
+
+    expect(editMessageText).toHaveBeenCalled()
+    const editText = editMessageText.mock.calls.at(-1)![2] as string
+    expect(editText).toContain('<b>bold</b>')
+    expect(editText).not.toContain('**bold**')
+  })
+
+  it('converts **bold** to <b>bold</b> on materialize', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      minInitialChars: 10,
+      throttleMs: 250,
+      renderText,
+      sendMessage,
+      editMessageText,
+    })
+
+    stream.update('The final answer is **definitely** forty-two.')
+    await flushMicrotasks()
+    // Opening send already converted; capture how many sends precede materialize.
+    const sendsBeforeMaterialize = sendMessage.mock.calls.length
+
+    const id = await stream.materialize()
+    expect(typeof id).toBe('number')
+    // materialize always sends a fresh message for the push notification.
+    expect(sendMessage.mock.calls.length).toBe(sendsBeforeMaterialize + 1)
+    const sentText = sendMessage.mock.calls.at(-1)![1] as string
+    expect(sentText).toContain('<b>definitely</b>')
+    expect(sentText).not.toContain('**definitely**')
+  })
+
+  it('sends raw text verbatim when no renderText is injected (back-compat)', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      minInitialChars: 10,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+    })
+
+    stream.update('Here is some **bold** narration text for the user.')
+    await flushMicrotasks()
+
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    const sentText = sendMessage.mock.calls[0][1] as string
+    // No renderer → unchanged (preserves prior behaviour for unwired callers).
+    expect(sentText).toContain('**bold**')
   })
 })
 


### PR DESCRIPTION
## Summary

The Telegram gateway has several outbound-text lanes. Every lane converts
markdown → Telegram HTML via `markdownToHtml` (+ `sanitizeTelegramHtml`) before
sending under `parse_mode: 'HTML'` — **except** the answer-stream lane
(`createAnswerStream` in `telegram-plugin/answer-stream.ts`), which sent,
edited, and materialized the **raw** assistant transcript text with no
conversion.

Result: `**bold**` shipped to the user as literal asterisks, and agent
narration arrived as raw, unformatted text.

## Root cause

`sendOrEditViaMessage` and `materialize` in `answer-stream.ts` passed the raw
`trimmed` / `textToSend` straight to `editMessageText` / `sendMessage` under
`parse_mode: 'HTML'`. For contrast, the lanes that DO convert:

- `handleStreamReply` — `sanitizeTelegramHtml(deps.markdownToHtml(rawText))`
- the `reply` handler — `markdownToHtml(...)`
- the turn-flush backstop — `markdownToHtml(...)`
- `handlePtyPartialPure` / `handlePtyPartial` — receive a `renderText: markdownToHtml` dependency

The answer-stream lane simply never got the converter.

## Fix

Inject a `renderText` dependency into `AnswerStreamConfig`, mirroring the
existing dependency-injection pattern the PTY partial handler already uses
(`renderText`), rather than hard-importing `format` / `html-sanitize` into
`answer-stream.ts` (keeps that module format-free and fully testable).

- `answer-stream.ts`: new optional `renderText?: (text: string) => string`.
  A local `render()` helper applies it before **every** `editMessageText` /
  `sendMessage` in `sendOrEditViaMessage` and `materialize`. When `renderText`
  is absent it falls back to verbatim text (preserves prior behaviour for
  unwired callers / existing tests).
- `gateway/gateway.ts`: wires
  `renderText: (text) => sanitizeTelegramHtml(markdownToHtml(text))` into the
  `createAnswerStream` config — the exact converter the other lanes use.

The dedup, silent-marker, and SQLite-history checks in `materialize` still
operate on the **raw** text (so they keep matching the raw-text comparisons the
other lanes make); only the actual wire payload is converted.

## Test

Added a `answer-stream — markdown → HTML conversion (renderText)` describe block
to `telegram-plugin/tests/answer-stream.test.ts`, wiring the real
`sanitizeTelegramHtml(markdownToHtml(...))` renderer (mirroring how the existing
reply / stream_reply tests assert conversion):

- opening `sendMessage` converts `**bold**` → `<b>bold</b>` (and no longer contains `**bold**`)
- a follow-up `editMessageText` converts `**bold**` → `<b>bold</b>`
- `materialize` converts `**bold**` → `<b>bold</b>`
- back-compat: with no `renderText` injected, raw text is sent verbatim

## Test plan

- [x] `node scripts/build.mjs` — exit 0
- [x] `tsc --noEmit` — exit 0
- [x] `bun test telegram-plugin/tests/answer-stream.test.ts` — 26 pass
- [x] `vitest run telegram-plugin/tests/answer-stream.test.ts` — 26 pass
- [x] `vitest run` answer-stream-dedup + answer-stream-silent-markers — 14 pass (no regression)
- [x] `bash scripts/check-bot-api-wrapping.sh` — clean (gateway.ts import added; allowlist not shifted)

## Risk

Low. The change is additive — a new optional dependency with a verbatim
fallback. Only the answer-stream lane's wire payload changes; the
dedup/silent-marker/history logic is untouched (still on raw text).

Refs **KEN-87** (Linear).

## Follow-ups (not in this PR)

- **Central `renderOutbound(text, format)` helper** so all lanes share one
  converter (belt-and-suspenders against this recurring "one lane forgot to
  format" class). Deferred to keep this fix minimal and avoid touching the
  other already-correct lanes; this PR establishes the DI seam it would build on.
- **PTY-preview suppression timing.** The answer-stream lane is also
  non-deterministic under throttle/flush/suppress races (the preamble
  suppressor + throttle interplay). Not addressed here — it is a separate,
  riskier change orthogonal to the missing-conversion defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
