### PR TITLE
chore: bump package.json version to 0.16.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.16.10",
+  "version": "0.16.11",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Follow-up to #2630 — the release commit missed the package.json bump (pattern since #2600). Publish to npm is already done; this lands the version on main for consistency.