### PR TITLE
fix(gateway): sr-* model chat_id routing — fallback + obligation meta

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -7972,8 +7972,25 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // module-scope currentTurn, which a future refactor could let roll over
   // mid-call.
   const turn = currentTurn
-  const chat_id = String(args.chat_id ?? '')
-  if (!chat_id) throw new Error('reply: chat_id is required')
+  const _rawChatId = String(args.chat_id ?? '')
+  if (!_rawChatId) throw new Error('reply: chat_id is required')
+  // Non-Claude models (e.g. Gemini via LiteLLM sr-* routing) sometimes pass a
+  // chat_id that is not in the allowlist — either an int/string mismatch, or
+  // the model echoing the wrong identifier from context. When the raw value
+  // fails the allowlist check and the active turn has a validated sessionChatId,
+  // fall back to the turn's origin chat so the reply still lands correctly.
+  const chat_id = (() => {
+    const _a = loadAccess()
+    if (_a.allowFrom.includes(_rawChatId) || _rawChatId in _a.groups) return _rawChatId
+    if (turn?.sessionChatId && (_a.allowFrom.includes(turn.sessionChatId) || turn.sessionChatId in _a.groups)) {
+      process.stderr.write(
+        `telegram gateway: reply: model passed chat_id "${_rawChatId}" (not allowlisted) — ` +
+          `routing to active turn chat "${turn.sessionChatId}"\n`,
+      )
+      return turn.sessionChatId
+    }
+    return _rawChatId // let assertAllowedChat below throw the human-readable error
+  })()
   const rawText = args.text as string | undefined
   if (rawText == null || rawText === '') throw new Error('reply: text is required and cannot be empty')
   let text = repairEscapedWhitespace(rawText)

--- a/telegram-plugin/gateway/obligation-ledger.ts
+++ b/telegram-plugin/gateway/obligation-ledger.ts
@@ -381,6 +381,7 @@ export function buildObligationRepresentInbound(o: Obligation, now: number): Inb
       source: 'obligation_represent',
       origin_turn_id: o.originTurnId,
       represent_count: String(o.representCount + 1),
+      chat_id: o.chatId,
     },
   }
 }

--- a/telegram-plugin/tests/obligation-ledger.test.ts
+++ b/telegram-plugin/tests/obligation-ledger.test.ts
@@ -184,6 +184,7 @@ describe("buildObligationRepresentInbound", () => {
     expect(m.meta.origin_turn_id).toBe("-100123:3#715");
     expect(m.meta.source).toBe("obligation_represent"); // synthetic → not tracked, no new obligation
     expect(m.meta.represent_count).toBe("1");
+    expect(m.meta.chat_id).toBe("-100123"); // Bug C fix: chat_id in meta drives the <channel> tag
     expect(m.text).toContain("do the Meta report");
     expect(m.text).toMatch(/answer it now|reply tool/i);
   });


### PR DESCRIPTION
## Summary

- **Bug B — executeReply chat_id fallback**: Non-Claude models (Gemini via LiteLLM sr-* routing) sometimes pass an unexpected `chat_id` to the reply tool. When the model-supplied id fails `assertAllowedChat` but the active turn has a validated `sessionChatId`, `executeReply` now falls back to that turn's chat. The fallback is safe: `turn.sessionChatId` was already validated at inbound receipt. A `stderr` log line marks every fallback for operator visibility.

- **Bug C — obligation represent meta missing chat_id**: `buildObligationRepresentInbound` set `chatId` on the root `InboundMessage` but omitted it from `meta`. The bridge builds the `<channel>` XML from `meta`, so obligation re-presents had no `chat_id` attribute — the model had nothing to pass back. Fix: add `chat_id: o.chatId` to `meta`, matching the pattern in `resume-inbound-builder.ts`.

Both bugs manifested together on the `jtbd-model-litellm-sr-dm` UAT: Bug C caused obligation re-presents to lack a routing signal, then Bug B caused the original turn's reply to also fail when Gemini passed the wrong `chat_id`.

## Test plan

- [ ] `bun test telegram-plugin/tests/obligation-ledger.test.ts` — new assertion on `meta.chat_id`
- [ ] `bun test telegram-plugin/tests/gateway-bridge.test.ts`
- [ ] `tsc --noEmit` — clean
- [ ] UAT: `jtbd-model-litellm-sr-dm` Test 1 passes within 120s on test-harness

## Risk

Low. Bug B fallback only fires when the model's chat_id fails the allowlist — on Claude models the chat_id is always correct so the fallback is never reached. Bug C only affects obligation re-present meta, not the primary inbound path.

Serves: `reference/jobs/reply-arrives.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXGDSGArnajHNjcf8Vr17T