### PR TITLE
fix(web): accept ?token= and X-Hermes-Session-Token for Hermes Desktop auth

### DIFF
--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -285,6 +285,13 @@ function extractBearerToken(req: Request): string | null {
     const idx = parts.indexOf("bearer");
     if (idx >= 0 && idx + 1 < parts.length) return parts[idx + 1];
   }
+  // Hermes Desktop sends token as ?token= query param on WS upgrade and
+  // X-Hermes-Session-Token header on REST calls.
+  const url = new URL(req.url);
+  const queryToken = url.searchParams.get("token");
+  if (queryToken) return queryToken;
+  const hermesHeader = req.headers.get("X-Hermes-Session-Token");
+  if (hermesHeader) return hermesHeader;
   return null;
 }
 


### PR DESCRIPTION
## Summary

- `extractBearerToken` now checks `?token=` query param (Hermes Desktop WS upgrade path) and `X-Hermes-Session-Token` request header (Hermes Desktop REST path) in addition to the existing `Authorization: Bearer` and `Sec-WebSocket-Protocol: bearer,<token>` paths.
- Via Tailscale serve this path is already bypassed (`isTailscaleIdentified` short-circuits before token extraction), so the change has zero effect on the existing Tailscale dashboard flow.

## Why

Hermes Desktop constructs its WS URL as `wss://<host>/api/ws?token=<token>` (see `apps/desktop/electron/connection-config.cjs:buildGatewayWsUrl`). Without this fix, a non-Tailscale Hermes Desktop connection would always 401.

## Test plan

- [x] `npm run lint` clean
- [ ] Connect Hermes Desktop to `https://pixsoul-ubuntu.taild78f7.ts.net:8443` via Tailscale (existing path — works without this PR)
- [ ] Verify `/api/status` probe succeeds and Hermes Desktop shows agent list

## Risk

Low — additive only. Two extra branches in `extractBearerToken`, no logic changes to existing paths.