### PR TITLE
fix(gateway): sr-* reply routing survives silence poke (Bug D)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2216,6 +2216,13 @@ type CurrentTurn = {
 // is never written and this is exactly the old singleton.
 let currentTurn: CurrentTurn | null = null
 const currentTurnMap = new CurrentTurnMap<CurrentTurn>()
+// Captures the most-recently-started turn's sessionChatId. Unlike currentTurn,
+// this is NOT cleared by the silence poke (firePoke/clearTurnStarted). It lets
+// the Bug B fallback in executeReply route to the correct chat even when the
+// model calls reply AFTER the silence poke has nulled currentTurn (Bug D).
+// Safe in single-tenant gateways: the fallback only fires when the raw chat_id
+// fails the allowlist, and this value was itself validated at inbound receipt.
+let lastActiveTurnChatId: string | undefined
 
 /**
  * Set the live turn for `key`. Flag-branches in ONE place (inside the map):
@@ -2227,6 +2234,7 @@ const currentTurnMap = new CurrentTurnMap<CurrentTurn>()
 function setCurrentTurn(turn: CurrentTurn, key: string): void {
   currentTurnMap.set(turn, key)
   currentTurn = currentTurnMap.get() // mirror most-recent-set (== `turn`)
+  lastActiveTurnChatId = turn.sessionChatId
 }
 
 /**
@@ -7977,17 +7985,23 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // Non-Claude models (e.g. Gemini via LiteLLM sr-* routing) sometimes pass a
   // chat_id that is not in the allowlist — either an int/string mismatch, or
   // the model echoing the wrong identifier from context. When the raw value
-  // fails the allowlist check and the active turn has a validated sessionChatId,
-  // fall back to the turn's origin chat so the reply still lands correctly.
+  // fails the allowlist check, fall back to the active (or last-known) turn's
+  // validated sessionChatId so the reply still lands correctly.
+  // Tier 1: live turn (currentTurn was non-null at reply entry).
+  // Tier 2: last-known turn (survives silence poke — Bug D fix; currentTurn is
+  //   null because clearTurnStarted fired ≥5 min of model silence, but the model
+  //   finally called reply after the poke).
   const chat_id = (() => {
     const _a = loadAccess()
     if (_a.allowFrom.includes(_rawChatId) || _rawChatId in _a.groups) return _rawChatId
-    if (turn?.sessionChatId && (_a.allowFrom.includes(turn.sessionChatId) || turn.sessionChatId in _a.groups)) {
+    const fallbackChatId = turn?.sessionChatId ?? lastActiveTurnChatId
+    if (fallbackChatId && (_a.allowFrom.includes(fallbackChatId) || fallbackChatId in _a.groups)) {
+      const tier = turn == null ? 'last-known' : 'active'
       process.stderr.write(
         `telegram gateway: reply: model passed chat_id "${_rawChatId}" (not allowlisted) — ` +
-          `routing to active turn chat "${turn.sessionChatId}"\n`,
+          `routing to ${tier} turn chat "${fallbackChatId}"\n`,
       )
-      return turn.sessionChatId
+      return fallbackChatId
     }
     return _rawChatId // let assertAllowedChat below throw the human-readable error
   })()

--- a/telegram-plugin/uat/scenarios/jtbd-model-litellm-sr-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-model-litellm-sr-dm.test.ts
@@ -59,10 +59,13 @@ describe("uat: /model sr-* LiteLLM routing — section headers + session switch 
         const openrouterHeader = flat.find(
           (b) => b.text.includes("OpenRouter") && b.callbackData === "mdl:h",
         );
-        // Prefer a fast non-reasoning model for the E2E test; reasoning models
-        // (deepseek-r1, o1, o3) take 2-5 min per response and hit the silence poke.
+        // Prefer deepseek-v3 (non-thinking, consistently fast) for the E2E test.
+        // gemini-2.5-flash may run in thinking mode via OpenRouter (5+ min latency),
+        // reasoning models (deepseek-r1, o1, o3) also take 2-5 min and hit the
+        // silence poke — both are OK now (Bug D fallback), but slow tests are painful.
         const srButton =
-          flat.find((b) => b.callbackData?.startsWith("mdl:sr:") && /flash/.test(b.callbackData)) ??
+          flat.find((b) => b.callbackData?.startsWith("mdl:sr:") && /deepseek-v3/.test(b.callbackData)) ??
+          flat.find((b) => b.callbackData?.startsWith("mdl:sr:") && /flash/.test(b.callbackData) && !/thinking/.test(b.callbackData)) ??
           flat.find((b) => b.callbackData?.startsWith("mdl:sr:") && !/r1|o1|o3|thinking/.test(b.callbackData)) ??
           flat.find((b) => b.callbackData?.startsWith("mdl:sr:"));
 
@@ -93,10 +96,12 @@ describe("uat: /model sr-* LiteLLM routing — section headers + session switch 
         expect((kbAfter ?? []).flat().length, "menu keeps buttons after sr-* tap").toBeGreaterThan(0);
 
         // ── 3. Send a quick message to generate a LiteLLM-routed turn ──
-        // Use 120s — fast models (gemini-flash, deepseek-v3) respond in <10s,
-        // but the request still has to go through the model switch inject + proxy.
+        // 480s budget: fast models (deepseek-v3) reply in <10s; Gemini 2.5 Flash
+        // may run thinking mode via OpenRouter and take 5+ min. The silence poke
+        // fires at 300s, which is OK — the Bug D fallback (lastActiveTurnChatId)
+        // routes the reply even when currentTurn was nulled by the poke.
         await sc.sendDM("Just reply with the word OK.");
-        await sc.expectMessage(/ok/i, { from: "bot", timeout: 120_000 });
+        await sc.expectMessage(/ok/i, { from: "bot", timeout: 480_000 });
 
         // ── 4. LiteLLM spend attribution ────────────────────────────────
         if (spendBefore >= 0) {
@@ -126,7 +131,7 @@ describe("uat: /model sr-* LiteLLM routing — section headers + session switch 
         await sc.tearDown();
       }
     },
-    210_000,
+    660_000,
   );
 
   it(


### PR DESCRIPTION
## Summary

- **Bug D — post-silence-poke chat_id fallback**: When an sr-* model (Gemini 2.5 Flash via LiteLLM/OpenRouter) takes longer than the 5-min silence threshold to call `reply`, the gateway fires its silence poke and nulls `currentTurn`. The Bug B fallback from #2632 reads `turn.sessionChatId` but `turn` is `null` at that point — so the fallback cannot fire and `assertAllowedChat("[PHONE]")` throws, silently dropping the reply.

  Fix: introduce `lastActiveTurnChatId` (set in `setCurrentTurn()`, **not** cleared by the silence poke). The `executeReply` fallback now uses `turn?.sessionChatId ?? lastActiveTurnChatId`, so a late reply routes correctly even after the poke. The tier (`active` vs `last-known`) is logged to stderr for operator visibility.

- **UAT timeout extension**: `jtbd-model-litellm-sr-dm` `expectMessage` → 480 s, overall test → 660 s. Gemini 2.5 Flash defaults to thinking mode on OpenRouter (5+ min latency). The Bug D fix ensures the late reply *lands*; the extended timeout ensures the UAT observes it. Also preference-reorders the sr-* button selection to prefer `deepseek-v3` first (genuinely non-thinking, <10 s) over `flash` (may use thinking).

## Root cause trace

```
11:21:02 — inbound "Just reply OK" → setTurnStarted, deliverToBridge
11:21:02 – 11:26:06 — Gemini thinking (streaming tokens → progress card)
11:26:06 — silence poke: firePoke + clearTurnStarted → currentTurn = null
11:26:22 — executeReply called: chat_id=[PHONE], turn=null
            → Bug B fallback: turn?.sessionChatId = undefined → no fallback
            → assertAllowedChat("[PHONE]") throws → reply dropped silently
```

With Bug D: step at 11:26:22 reads `lastActiveTurnChatId = "8248703757"` (set at 11:21:02, never cleared by poke) → routes correctly.

## Test plan

- [x] TypeScript: `tsc --noEmit` clean
- [x] `telegram-plugin/tests/gateway-bridge.test.ts` — 24/24 pass
- [x] `telegram-plugin/tests/model-command.test.ts` — 66/66 pass
- [x] `check-bot-api-wrapping.sh` clean
- [ ] UAT `jtbd-model-litellm-sr-dm` — requires deploy to test-harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXGDSGArnajHNjcf8Vr17T