### PR TITLE
test(uat): bump header-row test menu timeout 60s→90s

### DIFF
--- a/telegram-plugin/uat/scenarios/jtbd-model-litellm-sr-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-model-litellm-sr-dm.test.ts
@@ -140,11 +140,11 @@ describe("uat: /model sr-* LiteLLM routing — section headers + session switch 
       const sc = await spinUp({ agent: AGENT });
       try {
         await sc.sendDM("/model");
-        // 60s — test 2 runs after test 1's restore restart, which takes ~15s.
-        // If the restart is still finishing when /model lands, it may be queued.
+        // 90s — test 2 runs after test 1's restore restart. The model-switch
+        // restart can take 30–60s to fully boot; 90s gives comfortable margin.
         const menu = await sc.expectMessage(/Default \(new sessions\):/i, {
           from: "bot",
-          timeout: 60_000,
+          timeout: 90_000,
         });
         const kb = await sc.driver.getKeyboard(sc.botUserId, menu.messageId);
         const flat = (kb ?? []).flat();


### PR DESCRIPTION
## Summary
- Increases the `/model` menu wait timeout in the header-row UAT test (test 2) from 60s to 90s.

## Why
Test 2 runs immediately after test 1's restore restart. The model-switch restart fires `agent restart`, which can take 30–60s to fully boot. The 60s window was too tight — the `/model` menu arrived after it expired and the test failed with `expectMessage: no matching message within 60000ms`. No product code changes; test-only timing fix.

## Test plan
- [x] Test 1 (sr-* E2E routing + Bug D fallback) already passed in the v0.16.13 UAT run (356s, sr-deepseek-v3 end-to-end)
- [ ] Test 2 passes with the widened 90s window on next UAT run