### PR TITLE
fix(model): show in-message working state for sr-* model taps

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -20855,11 +20855,18 @@ bot.on('callback_query:data', async ctx => {
     // menu immediately to show a "working on it" state so the operator isn't
     // left looking at a stale menu with no feedback. The final edit (✅/❌)
     // replaces this once the inject returns.
+    // NOTE: this await yields the event loop, so a new inbound turn could
+    // start between here and handleModelMenuCallback's inner isBusy() check.
+    // We track whether we applied the interim edit so we can skip the
+    // toastOnly short-circuit if we did — a toastOnly return after the interim
+    // edit would leave the menu stuck button-less.
+    let didInterimSrEdit = false
     if (data.startsWith(MODEL_CALLBACK_SR)) {
       const srLabel = escapeHtmlForTg(srFriendlyLabel(data.slice(MODEL_CALLBACK_SR.length)))
       await ctx
         .editMessageText(`⏳ Switching session to <b>${srLabel}</b>…`, { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } })
         .catch(() => {})
+      didInterimSrEdit = true
     }
     try {
       const prevSessionModel = activeSessionModelOverride
@@ -20870,9 +20877,11 @@ bot.on('callback_query:data', async ctx => {
       if (outcome.selectedModel) {
         activeSessionModelOverride = outcome.selectedModel
       }
-      // toastOnly: a no-op outcome that should not disturb the menu (defence
-      // in depth — the isBusy() short-circuit above is the live path).
-      if (outcome.toastOnly) return
+      // toastOnly: leave the menu untouched — but only if we haven't already
+      // cleared its buttons with the interim sr-* edit. If we have, fall
+      // through to the final edit so the message is recovered (busyReply or
+      // the full menu) rather than left permanently button-less.
+      if (outcome.toastOnly && !didInterimSrEdit) return
 
       // sr-* → Claude transition via the model menu: trigger a graceful restart.
       // Switching FROM an sr-* (LiteLLM/OpenRouter) model BACK to a Claude model

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -278,6 +278,8 @@ import {
   isSrToClaudeTransition,
   MODEL_CALLBACK_PREFIX,
   MODEL_CALLBACK_HEADER,
+  MODEL_CALLBACK_SR,
+  srFriendlyLabel,
   type ModelMenuDeps,
   type ModelCommandDeps,
   type ModelMenuReply,
@@ -20849,6 +20851,16 @@ bot.on('callback_query:data', async ctx => {
       return
     }
     await ctx.answerCallbackQuery({ text: 'Switching…' }).catch(() => {})
+    // sr-* inject waits for claude to respond (can take 10-30s). Edit the
+    // menu immediately to show a "working on it" state so the operator isn't
+    // left looking at a stale menu with no feedback. The final edit (✅/❌)
+    // replaces this once the inject returns.
+    if (data.startsWith(MODEL_CALLBACK_SR)) {
+      const srLabel = escapeHtmlForTg(srFriendlyLabel(data.slice(MODEL_CALLBACK_SR.length)))
+      await ctx
+        .editMessageText(`⏳ Switching session to <b>${srLabel}</b>…`, { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } })
+        .catch(() => {})
+    }
     try {
       const prevSessionModel = activeSessionModelOverride
       const outcome = await handleModelMenuCallback(data, modelDeps)

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -345,7 +345,7 @@ export function expandSrAlias(arg: string): string {
   return SR_MODEL_ALIASES[arg.toLowerCase()] ?? arg
 }
 
-function srFriendlyLabel(srName: string): string {
+export function srFriendlyLabel(srName: string): string {
   return SR_MODEL_LABELS[srName] ?? srName.replace(/^sr-/, '').replace(/-/g, ' ')
 }
 


### PR DESCRIPTION
## Summary
- When tapping an sr-* model button, immediately edit the menu message to **⏳ Switching session to X…** (buttons cleared while in-flight) so the operator sees clear feedback.
- Once the inject returns (10-30s), the final ✅/❌ edit replaces it in-place with the full menu + banner.
- Exports `srFriendlyLabel` from `model-command.ts` so `gateway.ts` can show the human-readable model name in the interim message.

## Why
The sr-* inject path blocks on a full `/model` round-trip through the agent session (10-30s for fast models, longer for Gemini in thinking mode). The previous UX: 3-5s toast then silence until done. Operators couldn't tell if their tap registered, and error banners appeared with no indication anything had been processing.

## Test plan
- [x] `bun test telegram-plugin/tests/model-command.test.ts` — 66/66 pass
- [x] `check-bot-api-wrapping.sh` — clean
- [ ] CI lint + vitest
- [ ] UAT `jtbd-model-litellm-sr-dm` — sr-* tap shows ⏳ before ✅/❌