### PR TITLE
feat(cron): self-describing cron_list + write-time dupe guard + cron doctor

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -36,9 +36,14 @@ switchroom schedule remove --cron-hash 1a2b3c4d5e6f
 
 # Read the agent's resolved schedule as JSON
 switchroom cron list
+
+# Health-check the schedule (duplicate crons, name conflicts) as JSON
+switchroom cron doctor
 ```
 
 This same surface is exposed over the **agent-config MCP broker**, so an agent can manage *its own* schedule when you ask it in chat ("set up a daily 8am briefing"). Identity is pinned to `$SWITCHROOM_AGENT_NAME`; cross-agent writes are denied (exit 7). Run `switchroom schedule --help` for the full flag list.
+
+**`cron list` is self-describing.** Each entry carries, alongside its original fields: `source` (`base-config` for a `switchroom.yaml` entry, `overlay` for a `schedule.d/` one), `file` (the on-disk path), the resolved `tier`/`context` (which session a fire takes — see "Controlling per-fire cost" below), and a `duplicate_of` back-reference naming any *other* entry that shares the same cron expression. The agent can read where each cron lives and whether it owns a duplicate, instead of inferring it from prose. `cron doctor` (and the `cron_doctor` MCP tool) returns the same findings as a `{healthy, findings[]}` report — duplicate cron expressions (the double-fire hazard), base-vs-overlay name conflicts, and entries whose tier can't be resolved.
 
 Either way, a schedule change takes effect **automatically, without a restart**. The in-container scheduler **hot-reloads**: it re-reads `switchroom.yaml` + the `schedule.d` overlay on a short poll (default 30s, `SWITCHROOM_SCHEDULER_RELOAD_POLL_MS`) and, when the effective schedule changes, swaps the live cron timers in place — the tmux/agent session is untouched. So a removed entry stops firing and a new one starts within ~30s. An agent that authors its *first* cron (previously schedule-less) restarts its own scheduler sibling once to activate (a clean ~1s self-restart, no container bounce). A restart is no longer required for schedule edits to take effect.
 
@@ -70,11 +75,12 @@ Operator-authored entries in `switchroom.yaml` are trusted. Entries written thro
 | Gate | Code | Rule |
 |---|---|---|
 | Too frequent | `E_CRON_TOO_FREQUENT` (9) | minimum 5-minute interval |
+| Duplicate | `E_CRON_DUPLICATE` (9) | the agent already owns an overlay entry with the same cron expression or the same `--name` — prevents the silent double-fire |
 | Too many | `E_QUOTA_EXCEEDED` (9) | at most 20 entries per agent |
 | Secrets escalation | `E_OVERLAY_SECRETS_REQUIRES_APPROVAL` (9) | an overlay entry may **not** grant itself vault `secrets:` |
 | Bad input | `E_INVALID_CRON` / `E_INVALID_PROMPT` (1) | malformed cron or prompt |
 
-With `--stage-on-reject` (the MCP path uses this), a gated entry is staged under `.pending/` and surfaced to the operator via `switchroom schedule pending` instead of being rejected outright. Overlay entries can only *append*; they cannot override or replace operator-declared entries.
+With `--stage-on-reject` (the MCP path uses this), a *security*-gated entry (`E_OVERLAY_SECRETS_REQUIRES_APPROVAL`, `E_CRON_TOO_FREQUENT`, `E_QUOTA_EXCEEDED`) is staged under `.pending/` and surfaced to the operator via `switchroom schedule pending` instead of being rejected outright. `E_CRON_DUPLICATE` is a *fix-it* error, not an approval gate — it hard-rejects on both paths so the agent removes the conflicting entry rather than queuing a second one for approval. Overlay entries can only *append*; they cannot override or replace operator-declared entries.
 
 ## How it works
 

--- a/src/cli/agent-config-write.test.ts
+++ b/src/cli/agent-config-write.test.ts
@@ -169,6 +169,59 @@ describe("scheduleAdd — security gates", () => {
   });
 });
 
+describe("scheduleAdd — duplicate guard (#cron-dupe)", () => {
+  it("rejects a second entry sharing the same cron expression (double-fire)", () => {
+    // The gymbro incident: same time, DIFFERENT prompt → different slug,
+    // so the content-hash overwrite misses it. The cron-expr guard catches it.
+    const first = scheduleAdd({ cronExpr: "0 20 * * 0", prompt: "review v1", root });
+    expect(first.ok).toBe(true);
+    const dup = scheduleAdd({ cronExpr: "0 20 * * 0", prompt: "review v2", root });
+    expect(dup.ok).toBe(false);
+    if (dup.ok) return;
+    expect(dup.code).toBe("E_CRON_DUPLICATE");
+    expect(dup.exit).toBe(9);
+    expect(dup.message).toMatch(/0 20 \* \* 0/);
+    expect(dup.meta?.conflicting_slug).toBeDefined();
+  });
+
+  it("treats whitespace-different cron exprs as the same (still rejected)", () => {
+    scheduleAdd({ cronExpr: "0 20 * * 0", prompt: "a", root });
+    const dup = scheduleAdd({ cronExpr: "0  20  *  *  0", prompt: "b", root });
+    expect(dup.ok).toBe(false);
+    if (dup.ok) return;
+    expect(dup.code).toBe("E_CRON_DUPLICATE");
+  });
+
+  it("rejects a second entry sharing the same name", () => {
+    scheduleAdd({ cronExpr: "0 8 * * *", prompt: "p", name: "digest", root });
+    const dup = scheduleAdd({ cronExpr: "0 9 * * *", prompt: "p2", name: "digest", root });
+    expect(dup.ok).toBe(false);
+    if (dup.ok) return;
+    expect(dup.code).toBe("E_CRON_DUPLICATE");
+    expect(dup.message).toMatch(/digest/);
+  });
+
+  it("allows distinct cron expressions + names", () => {
+    expect(scheduleAdd({ cronExpr: "0 8 * * *", prompt: "a", name: "morning", root }).ok).toBe(true);
+    expect(scheduleAdd({ cronExpr: "0 20 * * *", prompt: "b", name: "evening", root }).ok).toBe(true);
+  });
+
+  it("re-adding the identical cron+prompt is an overwrite, not a dupe reject", () => {
+    const first = scheduleAdd({ cronExpr: "0 8 * * *", prompt: "same", root });
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+    // Identical cron AND prompt → same content-hash slug. The cron-expr
+    // guard would match the existing file, but the intent is idempotent
+    // overwrite of the SAME logical cron. We still reject (the agent should
+    // see "already exists") — assert the clear signal rather than a silent
+    // double-write.
+    const again = scheduleAdd({ cronExpr: "0 8 * * *", prompt: "same", root });
+    expect(again.ok).toBe(false);
+    if (again.ok) return;
+    expect(again.code).toBe("E_CRON_DUPLICATE");
+  });
+});
+
 describe("scheduleRemove", () => {
   it("removes by cron_hash", () => {
     const add = scheduleAdd({ cronExpr: "0 9 * * *", prompt: "p", root });

--- a/src/cli/agent-config-write.ts
+++ b/src/cli/agent-config-write.ts
@@ -44,7 +44,9 @@ import {
   writeOverlayEntry,
   deleteOverlayEntry,
   listOverlayEntries,
+  type ListedOverlayEntry,
 } from "../config/overlay-writer.js";
+import { normalizeCronExpr } from "../scheduler/cron-introspect.js";
 import { filterOverlaySecrets } from "../config/overlay-secrets-filter.js";
 import { cronUnitName, cronUnitHash } from "../agents/cron-unit-name.js";
 import { dryRunReconcile, violatesMinInterval } from "../agents/reconcile-dry-run.js";
@@ -157,6 +159,7 @@ export function checkOperatorContext(
 type ErrorCode =
   | "E_OVERLAY_SECRETS_REQUIRES_APPROVAL"
   | "E_CRON_TOO_FREQUENT"
+  | "E_CRON_DUPLICATE"
   | "E_QUOTA_EXCEEDED"
   | "E_WRITE_REQUIRES_RECREATE"
   | "E_INVALID_CRON"
@@ -230,6 +233,7 @@ function exitCodeFor(code: ErrorCode): number {
   switch (code) {
     case "E_OVERLAY_SECRETS_REQUIRES_APPROVAL":
     case "E_CRON_TOO_FREQUENT":
+    case "E_CRON_DUPLICATE":
     case "E_QUOTA_EXCEEDED":
     case "E_WRITE_REQUIRES_RECREATE":
     case "E_SLUG_COLLISION":
@@ -333,6 +337,35 @@ export interface ScheduleStagedResult {
  * structured result so callers can decide how to surface it (CLI prints
  * + exits; tests assert).
  */
+/**
+ * Extract the cron expression + human name from a single on-disk overlay
+ * file. The name comes from the `# name: <title>` header the writer stamps
+ * (or an explicit `name:` field if a hand-written file carries one); the
+ * cron from the first `schedule[].cron`. Best-effort — a malformed file
+ * yields `{ cron: undefined, name: undefined }` so it can't false-positive
+ * a dupe match.
+ */
+export function parseOverlayCronAndName(e: ListedOverlayEntry): {
+  cron?: string;
+  name?: string;
+} {
+  let cron: string | undefined;
+  let name: string | undefined;
+  const headerMatch = e.raw.match(/^#[^\S\n]*name:[^\S\n]*(\S.*?)[^\S\n]*$/m);
+  if (headerMatch) name = headerMatch[1];
+  try {
+    const doc = parseYaml(e.raw) as { schedule?: { cron?: unknown; name?: unknown }[] } | null;
+    const first = doc?.schedule?.[0];
+    if (first) {
+      if (typeof first.cron === "string") cron = first.cron;
+      if (!name && typeof first.name === "string") name = first.name;
+    }
+  } catch {
+    /* malformed file — leave fields unset */
+  }
+  return { cron, name };
+}
+
 export function scheduleAdd(opts: AddOpts): ScheduleAddResult | ScheduleErrorResult {
   let agent: string;
   try {
@@ -422,6 +455,42 @@ export function scheduleAdd(opts: AddOpts): ScheduleAddResult | ScheduleErrorRes
       exit: 9,
       meta: { current: existing.length },
     };
+  }
+
+  // Duplicate-guard (#cron-dupe) — the write-time check that would have
+  // prevented the gymbro double-fire (two `weekly-review` overlays both
+  // firing `0 20 * * 0`). Reject when the agent already owns an overlay
+  // entry with the SAME cron expression or the SAME name. Compared against
+  // every existing overlay file the agent owns; the slug-content-hash
+  // collision path (identical cron AND prompt) is handled separately as an
+  // overwrite below, so this catches the more dangerous "same time, different
+  // prompt" case the hash misses.
+  const wantExpr = normalizeCronExpr(opts.cronExpr);
+  for (const e of existing) {
+    const parsed = parseOverlayCronAndName(e);
+    if (opts.name && parsed.name && parsed.name === opts.name) {
+      return {
+        ok: false,
+        code: "E_CRON_DUPLICATE",
+        message:
+          `an overlay cron named "${opts.name}" already exists ` +
+          `(${e.slug}.yaml) — remove it first or choose a different name`,
+        exit: 9,
+        meta: { conflicting_slug: e.slug, conflicting_name: parsed.name },
+      };
+    }
+    if (wantExpr && parsed.cron && normalizeCronExpr(parsed.cron) === wantExpr) {
+      return {
+        ok: false,
+        code: "E_CRON_DUPLICATE",
+        message:
+          `an overlay cron with expression "${wantExpr}" already exists ` +
+          `(${e.slug}.yaml${parsed.name ? `, name "${parsed.name}"` : ""}) — ` +
+          `adding another would double-fire. Remove the existing one first.`,
+        exit: 9,
+        meta: { conflicting_slug: e.slug, conflicting_cron: wantExpr },
+      };
+    }
   }
 
   const hash = cronUnitHash(opts.cronExpr, opts.prompt);

--- a/src/cli/agent-config.test.ts
+++ b/src/cli/agent-config.test.ts
@@ -279,12 +279,23 @@ describe("registered commands", () => {
     expect(stderr).toMatch(/cross-agent read denied/);
   });
 
-  it("cron list returns configured schedule", async () => {
+  it("cron list returns self-describing schedule rows", async () => {
     process.env.SWITCHROOM_AGENT_NAME = "a";
     const program = buildProgram();
     await program.parseAsync(["node", "switchroom", "cron", "list"]);
     const parsed = JSON.parse(stdout.trim());
-    expect(parsed).toEqual([{ name: "ping", at: "0 * * * *" }]);
+    // Original fields preserved (backward compat) + introspection fields
+    // ADDED. The fixture entry uses `at` (no `cron`), so it labels as
+    // base-config with no duplicate and resolves to the main tier.
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toMatchObject({
+      name: "ping",
+      at: "0 * * * *",
+      source: "base-config",
+      file: "switchroom.yaml",
+      tier: "main",
+    });
+    expect(parsed[0].duplicate_of).toBeUndefined();
   });
 
   it("skill list returns skills + bundled_skills", async () => {

--- a/src/cli/agent-config.ts
+++ b/src/cli/agent-config.ts
@@ -33,6 +33,8 @@ import { withConfigError, getConfig } from "./helpers.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { resolveAgentConfig } from "../config/merge.js";
 import { checkAclByAgent } from "../vault/broker/acl.js";
+import { buildCronList, cronDoctor } from "../scheduler/cron-introspect.js";
+import { isCheapCronEnabled } from "../scheduler/cron-routing.js";
 
 // Per-agent audit path. We deliberately do NOT share one log file across
 // all agents — that would let any agent read every other agent's audit
@@ -471,12 +473,53 @@ export function registerAgentConfigCommands(program: Command): void {
         const cfg = getConfig(program);
         try {
           const slice = getAgentSlice(cfg, agent) as { schedule?: unknown[] };
-          const tasks = stripSecretValues(slice.schedule ?? []);
+          // Self-describing rows (#cron-dupe): source/file/tier/context +
+          // duplicate_of cross-links, computed from the overlay-merge
+          // Symbols BEFORE the secret-strip pass roundtrips them away.
+          const rows = buildCronList(slice.schedule ?? [], {
+            cheapCronEnabled: isCheapCronEnabled(),
+          });
+          const tasks = stripSecretValues(rows);
           process.stdout.write(JSON.stringify(tasks) + "\n");
           appendAudit(agent, "cron.list", { ...opts }, 0);
         } catch (err) {
           process.stderr.write(`${(err as Error).message}\n`);
           appendAudit(agent, "cron.list", { ...opts }, 1);
+          process.exit(1);
+        }
+      }),
+    );
+
+  // switchroom cron doctor — read-only health report
+  cron
+    .command("doctor")
+    .description(
+      "Report cron health: duplicate cron expressions, base-vs-overlay " +
+        "name conflicts, and entries missing a resolved tier/context. " +
+        "Read-only.",
+    )
+    .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
+    .action(
+      withConfigError(async (opts: { agent?: string }) => {
+        let agent: string;
+        try {
+          agent = resolveTargetAgent(opts.agent);
+        } catch (err) {
+          process.stderr.write(`${(err as Error).message}\n`);
+          appendAudit(opts.agent ?? "<unknown>", "cron.doctor", { ...opts }, 7);
+          process.exit(7);
+        }
+        const cfg = getConfig(program);
+        try {
+          const slice = getAgentSlice(cfg, agent) as { schedule?: unknown[] };
+          const report = cronDoctor(agent, slice.schedule ?? [], {
+            cheapCronEnabled: isCheapCronEnabled(),
+          });
+          process.stdout.write(JSON.stringify(report) + "\n");
+          appendAudit(agent, "cron.doctor", { ...opts }, 0);
+        } catch (err) {
+          process.stderr.write(`${(err as Error).message}\n`);
+          appendAudit(agent, "cron.doctor", { ...opts }, 1);
           process.exit(1);
         }
       }),

--- a/src/mcp/agent-config/server.test.ts
+++ b/src/mcp/agent-config/server.test.ts
@@ -36,6 +36,7 @@ describe("TOOLS export", () => {
     expect(names).toEqual([
       "audit_tail",
       "config_get",
+      "cron_doctor",          // read-only cron health report
       "cron_list",
       "peers_list",            // identity / peer-awareness
       "schedule_add",
@@ -98,6 +99,16 @@ describe("dispatchTool — happy path", () => {
       skills: ["s"],
       bundled_skills: {},
     });
+  });
+
+  it("cron_doctor shells `cron doctor` and parses the JSON report", () => {
+    const report = { agent: "a", entry_count: 0, findings: [], healthy: true };
+    okCall(JSON.stringify(report) + "\n");
+    const res = dispatchTool("cron_doctor", { agent: "a" });
+    expect(res.isError).toBeFalsy();
+    expect(JSON.parse(res.content[0]!.text)).toEqual(report);
+    const [, args] = spawnSyncMock.mock.calls[0]!;
+    expect(args).toEqual(["cron", "doctor", "--agent", "a"]);
   });
 
   it("peers_list shells out with no --agent flag (caller identity is env-pinned)", () => {

--- a/src/mcp/agent-config/server.ts
+++ b/src/mcp/agent-config/server.ts
@@ -132,7 +132,28 @@ export const TOOLS = [
   {
     name: "cron_list",
     description:
-      "List the agent's scheduled cron entries (schedule array) as JSON.",
+      "List the agent's scheduled cron entries (schedule array) as JSON. " +
+      "Each entry is self-describing: `source` (base-config vs overlay), " +
+      "`file` (switchroom.yaml or the schedule.d path), resolved " +
+      "`tier`/`context`, and a `duplicate_of` back-reference when another " +
+      "entry shares the same cron expression. Original entry fields are " +
+      "preserved.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "cron_doctor",
+    description:
+      "Read-only cron health report: duplicate cron expressions (the " +
+      "double-fire hazard), base-config-vs-overlay name conflicts, and " +
+      "entries missing a resolved tier/context. Returns " +
+      "{agent, entry_count, healthy, findings[]}. Call this BEFORE adding " +
+      "a cron, or when a schedule misbehaves (firing twice, removing the " +
+      "wrong entry).",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -461,6 +482,10 @@ export function dispatchTool(
       break;
     case "cron_list":
       cliArgs = buildArgs(["cron", "list"], args);
+      parseMode = "json";
+      break;
+    case "cron_doctor":
+      cliArgs = buildArgs(["cron", "doctor"], args);
       parseMode = "json";
       break;
     case "skill_list":

--- a/src/scheduler/cron-introspect.test.ts
+++ b/src/scheduler/cron-introspect.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for cron introspection — self-describing list rows + the
+ * read-only doctor report. Covers the gymbro double-fire scenario:
+ * two overlay entries sharing a cron expression must be cross-linked
+ * (`duplicate_of`) and flagged by the doctor.
+ */
+import { describe, it, expect } from "vitest";
+import { buildCronList, cronDoctor, normalizeCronExpr } from "./cron-introspect.js";
+import { OVERLAY_SOURCE, OVERLAY_TITLE } from "../config/overlay-loader.js";
+
+/** Forge an overlay-stamped entry the way the loader does (non-enumerable Symbols). */
+function overlayEntry(
+  fields: Record<string, unknown>,
+  title?: string,
+): Record<string, unknown> {
+  const e = { ...fields };
+  Object.defineProperty(e, OVERLAY_SOURCE, { value: true, enumerable: false });
+  if (title !== undefined) {
+    Object.defineProperty(e, OVERLAY_TITLE, { value: title, enumerable: false });
+  }
+  return e;
+}
+
+const FLAG = { cheapCronEnabled: true };
+
+describe("normalizeCronExpr", () => {
+  it("collapses whitespace and trims", () => {
+    expect(normalizeCronExpr("  0   20  *  *  0 ")).toBe("0 20 * * 0");
+  });
+  it("returns null for non-strings / empty", () => {
+    expect(normalizeCronExpr(undefined)).toBeNull();
+    expect(normalizeCronExpr("   ")).toBeNull();
+    expect(normalizeCronExpr(42)).toBeNull();
+  });
+});
+
+describe("buildCronList — source labelling", () => {
+  it("labels base-config and overlay entries with file + source", () => {
+    const rows = buildCronList(
+      [
+        { cron: "0 8 * * *", prompt: "morning" },
+        overlayEntry({ cron: "0 20 * * 0", prompt: "review" }, "weekly-review"),
+      ],
+      FLAG,
+    );
+    expect(rows[0]).toMatchObject({
+      source: "base-config",
+      file: "switchroom.yaml",
+      cron: "0 8 * * *",
+    });
+    expect(rows[1]).toMatchObject({
+      source: "overlay",
+      file: "schedule.d/weekly-review.yaml",
+      name: "weekly-review",
+    });
+  });
+
+  it("preserves the original entry fields (backward compat)", () => {
+    const rows = buildCronList([{ cron: "0 8 * * *", prompt: "p", kind: "prompt" }], FLAG);
+    expect(rows[0].cron).toBe("0 8 * * *");
+    expect(rows[0].prompt).toBe("p");
+    expect(rows[0].kind).toBe("prompt");
+  });
+
+  it("resolves tier/context from the routing FSM", () => {
+    const rows = buildCronList(
+      [
+        { cron: "0 8 * * *", prompt: "p", model: "sonnet" }, // cheap → fresh
+        { cron: "0 9 * * *", prompt: "p" }, // default → main/agent
+      ],
+      FLAG,
+    );
+    expect(rows[0]).toMatchObject({ tier: "cheap", context: "fresh" });
+    expect(rows[1]).toMatchObject({ tier: "main", context: "agent" });
+  });
+});
+
+describe("buildCronList — duplicate cross-linking", () => {
+  it("cross-links two entries sharing a cron expression (the double-fire)", () => {
+    const rows = buildCronList(
+      [
+        overlayEntry({ cron: "0 20 * * 0", prompt: "review v1" }, "weekly-review"),
+        overlayEntry({ cron: "0 20 * * 0", prompt: "review v2" }, "weekly-review-2"),
+      ],
+      FLAG,
+    );
+    expect(rows[0].duplicate_of).toEqual([
+      { name: "weekly-review-2", file: "schedule.d/weekly-review-2.yaml" },
+    ]);
+    expect(rows[1].duplicate_of).toEqual([
+      { name: "weekly-review", file: "schedule.d/weekly-review.yaml" },
+    ]);
+  });
+
+  it("leaves duplicate_of unset for a unique cron expression", () => {
+    const rows = buildCronList(
+      [
+        { cron: "0 8 * * *", prompt: "a" },
+        { cron: "0 9 * * *", prompt: "b" },
+      ],
+      FLAG,
+    );
+    expect(rows[0].duplicate_of).toBeUndefined();
+    expect(rows[1].duplicate_of).toBeUndefined();
+  });
+
+  it("treats whitespace-different exprs as the same cron", () => {
+    const rows = buildCronList(
+      [
+        { cron: "0 20 * * 0", prompt: "a" },
+        { cron: "0  20  *  *  0", prompt: "b" },
+      ],
+      FLAG,
+    );
+    expect(rows[0].duplicate_of).toHaveLength(1);
+  });
+});
+
+describe("cronDoctor", () => {
+  it("reports healthy for a clean schedule", () => {
+    const r = cronDoctor("gymbro", [{ cron: "0 8 * * *", prompt: "p" }], FLAG);
+    expect(r.healthy).toBe(true);
+    expect(r.findings).toEqual([]);
+    expect(r.entry_count).toBe(1);
+  });
+
+  it("flags duplicate cron expressions as an error", () => {
+    const r = cronDoctor(
+      "gymbro",
+      [
+        overlayEntry({ cron: "0 20 * * 0", prompt: "v1" }, "weekly-review"),
+        overlayEntry({ cron: "0 20 * * 0", prompt: "v2" }, "weekly-review-2"),
+      ],
+      FLAG,
+    );
+    expect(r.healthy).toBe(false);
+    const dup = r.findings.find((f) => f.kind === "duplicate_cron");
+    expect(dup).toBeDefined();
+    expect(dup!.severity).toBe("error");
+    expect(dup!.cron).toBe("0 20 * * 0");
+    expect(dup!.entries).toHaveLength(2);
+  });
+
+  it("flags a base-vs-overlay name conflict as a warning", () => {
+    const r = cronDoctor(
+      "gymbro",
+      [
+        { cron: "0 8 * * *", prompt: "p", name: "digest" },
+        overlayEntry({ cron: "0 9 * * *", prompt: "p" }, "digest"),
+      ],
+      FLAG,
+    );
+    const conflict = r.findings.find((f) => f.kind === "name_conflict");
+    expect(conflict).toBeDefined();
+    expect(conflict!.severity).toBe("warn");
+    expect(conflict!.conflicting_name).toBe("digest");
+  });
+
+  it("flags an entry with no valid cron expression as missing_tier", () => {
+    const r = cronDoctor("gymbro", [{ prompt: "p", name: "broken" }], FLAG);
+    const miss = r.findings.find((f) => f.kind === "missing_tier");
+    expect(miss).toBeDefined();
+    expect(miss!.entries[0]!.name).toBe("broken");
+  });
+});

--- a/src/scheduler/cron-introspect.test.ts
+++ b/src/scheduler/cron-introspect.test.ts
@@ -7,6 +7,16 @@
 import { describe, it, expect } from "vitest";
 import { buildCronList, cronDoctor, normalizeCronExpr } from "./cron-introspect.js";
 import { OVERLAY_SOURCE, OVERLAY_TITLE } from "../config/overlay-loader.js";
+import { cronUnitHash } from "../agents/cron-unit-name.js";
+
+/**
+ * The REAL on-disk overlay path the writer (`writeOverlayEntry`) produces for
+ * a (cron, prompt). The `--name`/title NEVER becomes the filename — it's a
+ * `# name:` header inside the file — so `file` must be the content-hash slug.
+ */
+function overlayFile(cron: string, prompt: string): string {
+  return `schedule.d/cron-${cronUnitHash(cron, prompt)}.yaml`;
+}
 
 /** Forge an overlay-stamped entry the way the loader does (non-enumerable Symbols). */
 function overlayEntry(
@@ -50,9 +60,24 @@ describe("buildCronList — source labelling", () => {
     });
     expect(rows[1]).toMatchObject({
       source: "overlay",
-      file: "schedule.d/weekly-review.yaml",
+      // `file` is the REAL on-disk slug, NOT `schedule.d/weekly-review.yaml`.
+      file: overlayFile("0 20 * * 0", "review"),
       name: "weekly-review",
     });
+  });
+
+  it("reports the real on-disk slug for `file`, not the human name (regression)", () => {
+    // A named overlay write produces `cron-<hash>.yaml` on disk; the `--name`
+    // is only a header inside it. `file` must point at the path that actually
+    // exists so the agent can find/remove the cron deterministically.
+    const cron = "0 20 * * 0";
+    const prompt = "review";
+    const rows = buildCronList([overlayEntry({ cron, prompt }, "weekly-review")], FLAG);
+    expect(rows[0].file).toBe(overlayFile(cron, prompt));
+    expect(rows[0].file).toMatch(/^schedule\.d\/cron-[0-9a-f]{12}\.yaml$/);
+    expect(rows[0].file).not.toContain("weekly-review");
+    // The human name is still available — just not in `file`.
+    expect(rows[0].name).toBe("weekly-review");
   });
 
   it("preserves the original entry fields (backward compat)", () => {
@@ -85,10 +110,10 @@ describe("buildCronList — duplicate cross-linking", () => {
       FLAG,
     );
     expect(rows[0].duplicate_of).toEqual([
-      { name: "weekly-review-2", file: "schedule.d/weekly-review-2.yaml" },
+      { name: "weekly-review-2", file: overlayFile("0 20 * * 0", "review v2") },
     ]);
     expect(rows[1].duplicate_of).toEqual([
-      { name: "weekly-review", file: "schedule.d/weekly-review.yaml" },
+      { name: "weekly-review", file: overlayFile("0 20 * * 0", "review v1") },
     ]);
   });
 

--- a/src/scheduler/cron-introspect.ts
+++ b/src/scheduler/cron-introspect.ts
@@ -21,6 +21,7 @@
 
 import { OVERLAY_SOURCE, OVERLAY_TITLE } from "../config/overlay-loader.js";
 import { resolveCronRouting, type CronTier } from "./cron-routing.js";
+import { cronUnitHash } from "../agents/cron-unit-name.js";
 
 /** Where a cron entry was defined. */
 export type CronSource = "base-config" | "overlay";
@@ -114,12 +115,16 @@ function attributeEntry(raw: unknown): RawEntry {
       typeof overlayTitle === "string" && overlayTitle.trim() !== ""
         ? overlayTitle
         : explicitName;
-    // The overlay file basename: prefer the title-derived name, else the
-    // generic content-hash slug isn't known here, so label it generically.
-    const file =
-      typeof overlayTitle === "string" && overlayTitle.trim() !== ""
-        ? `schedule.d/${overlayTitle}.yaml`
-        : "schedule.d/<overlay>.yaml";
+    // `file` MUST name the REAL on-disk path. `writeOverlayEntry` always
+    // writes `schedule.d/cron-<cronUnitHash(cron, prompt)>.yaml` — the
+    // `--name` only becomes a `# name:` header INSIDE the file, never the
+    // filename. So we recompute the same content hash the writer uses; a
+    // `<title>.yaml` path would not exist on disk and would defeat the
+    // whole point ("tell the agent deterministically where its cron lives").
+    // The human name is surfaced separately via `name`/`title`, never `file`.
+    const cron = typeof entry.cron === "string" ? entry.cron : "";
+    const prompt = typeof entry.prompt === "string" ? entry.prompt : undefined;
+    const file = `schedule.d/cron-${cronUnitHash(cron, prompt)}.yaml`;
     return { entry, source: "overlay", file, name: title };
   }
   return { entry, source: "base-config", file: "switchroom.yaml", name: explicitName };

--- a/src/scheduler/cron-introspect.ts
+++ b/src/scheduler/cron-introspect.ts
@@ -1,0 +1,277 @@
+/**
+ * Cron introspection — self-describing `cron list` views + health checks.
+ *
+ * The duplicate-`weekly-review` incident (gymbro, two overlay entries both
+ * firing `0 20 * * 0` → double-fire) showed that prose in CLAUDE.md is not
+ * enough: an agent couldn't tell where its crons lived (base
+ * `switchroom.yaml` vs `schedule.d/` overlay) or that a duplicate existed.
+ * Determinism has to live in the tool layer, so this module turns the merged
+ * schedule array into a self-describing shape and a read-only health report.
+ *
+ * Inputs: the merged `schedule` array from a resolved agent slice. Overlay
+ * entries are stamped (non-enumerably) by `overlay-loader.ts` with
+ * {@link OVERLAY_SOURCE} (boolean) and {@link OVERLAY_TITLE} (the file's
+ * human title). Those Symbols survive in-process but are invisible to
+ * JSON-serialisation — so this module reads them *before* any strip pass and
+ * folds them into plain, serialisable fields.
+ *
+ * Pure: no IO, no clock. The CLI resolves the config (which runs the overlay
+ * merge) and the cheap-cron flag, then hands the array + flag here.
+ */
+
+import { OVERLAY_SOURCE, OVERLAY_TITLE } from "../config/overlay-loader.js";
+import { resolveCronRouting, type CronTier } from "./cron-routing.js";
+
+/** Where a cron entry was defined. */
+export type CronSource = "base-config" | "overlay";
+
+/**
+ * One self-describing cron entry. Spreads the original entry's enumerable
+ * fields (backward compat — `cron`, `prompt`, `kind`, … all preserved) and
+ * adds the introspection fields below.
+ */
+export interface CronListEntry {
+  /** Resolved display name: explicit overlay title, else `name` field, else null. */
+  name: string | null;
+  /** "base-config" (switchroom.yaml) or "overlay" (schedule.d/<file>.yaml). */
+  source: CronSource;
+  /** "switchroom.yaml" for base entries, or the overlay file basename. */
+  file: string;
+  /** Resolved tier for this fire: poll | action | cheap | main. */
+  tier: CronTier;
+  /** Resolved session context: "fresh" (cheap session) | "agent" (live) | null (model-free). */
+  context: "fresh" | "agent" | null;
+  /**
+   * When this entry shares its cron expression with one or more OTHER
+   * entries, the names/files of those siblings (so each dupe points at the
+   * other). Absent when the entry's cron expression is unique.
+   */
+  duplicate_of?: { name: string | null; file: string }[];
+  /** Original entry fields, preserved verbatim for backward compat. */
+  [key: string]: unknown;
+}
+
+/** A single health finding from {@link cronDoctor}. */
+export interface CronHealthFinding {
+  kind: "duplicate_cron" | "name_conflict" | "missing_tier";
+  severity: "warn" | "error";
+  message: string;
+  /** Entries implicated, by display name + file. */
+  entries: { name: string | null; file: string }[];
+  /** The shared cron expression (duplicate_cron) or name (name_conflict). */
+  cron?: string;
+  conflicting_name?: string;
+}
+
+export interface CronDoctorReport {
+  agent: string;
+  entry_count: number;
+  findings: CronHealthFinding[];
+  /** true when `findings` is empty. */
+  healthy: boolean;
+}
+
+interface RawEntry {
+  entry: Record<string, unknown>;
+  source: CronSource;
+  file: string;
+  /** Resolved display name. */
+  name: string | null;
+}
+
+/** A schedule entry's raw shape (only the fields we read directly). */
+type ScheduleLike = Record<string, unknown> & {
+  cron?: string;
+  prompt?: string;
+  name?: string;
+  kind?: "poll" | "prompt" | "action";
+  model?: string;
+  context?: "fresh" | "agent";
+};
+
+/** Normalise a cron expression for equality (collapse internal whitespace). */
+export function normalizeCronExpr(expr: unknown): string | null {
+  if (typeof expr !== "string") return null;
+  const t = expr.trim();
+  if (t === "") return null;
+  return t.replace(/\s+/g, " ");
+}
+
+/**
+ * Lift the per-entry attribution (source + file + display name) from the
+ * overlay Symbols stamped by the loader. Base-config entries carry no
+ * Symbols, so they fall through to the "base-config" / "switchroom.yaml"
+ * defaults.
+ */
+function attributeEntry(raw: unknown): RawEntry {
+  const entry = (raw ?? {}) as ScheduleLike;
+  const isOverlay = (entry as Record<symbol, unknown>)[OVERLAY_SOURCE] === true;
+  const overlayTitle = (entry as Record<symbol, unknown>)[OVERLAY_TITLE];
+  const explicitName =
+    typeof entry.name === "string" && entry.name.trim() !== "" ? entry.name : null;
+  if (isOverlay) {
+    const title =
+      typeof overlayTitle === "string" && overlayTitle.trim() !== ""
+        ? overlayTitle
+        : explicitName;
+    // The overlay file basename: prefer the title-derived name, else the
+    // generic content-hash slug isn't known here, so label it generically.
+    const file =
+      typeof overlayTitle === "string" && overlayTitle.trim() !== ""
+        ? `schedule.d/${overlayTitle}.yaml`
+        : "schedule.d/<overlay>.yaml";
+    return { entry, source: "overlay", file, name: title };
+  }
+  return { entry, source: "base-config", file: "switchroom.yaml", name: explicitName };
+}
+
+/**
+ * Resolve a single entry's tier + context via the pure cron-routing FSM.
+ * `null` context means the fire is model-free (poll/action) and has no
+ * session context.
+ */
+function resolveTierContext(
+  entry: ScheduleLike,
+  cheapCronEnabled: boolean,
+): { tier: CronTier; context: "fresh" | "agent" | null } {
+  const routing = resolveCronRouting(
+    { kind: entry.kind, model: entry.model, context: entry.context },
+    { cheapCronEnabled },
+  );
+  // Tier 0 fires (poll/action) are model-free → no session context.
+  const ctx =
+    routing.tier === "poll" || routing.tier === "action"
+      ? null
+      : routing.session === "cron"
+        ? "fresh"
+        : "agent";
+  return { tier: routing.tier, context: ctx };
+}
+
+/**
+ * Build the self-describing `cron list` rows from a merged schedule array.
+ * Each row spreads the original entry, adds `source`/`file`/`name`/`tier`/
+ * `context`, and a `duplicate_of` back-reference when another entry shares
+ * its cron expression.
+ */
+export function buildCronList(
+  schedule: unknown[],
+  opts: { cheapCronEnabled: boolean },
+): CronListEntry[] {
+  const raws = (schedule ?? []).map(attributeEntry);
+
+  // Group by normalised cron expression so we can cross-link duplicates.
+  const byExpr = new Map<string, number[]>();
+  raws.forEach((r, i) => {
+    const expr = normalizeCronExpr((r.entry as ScheduleLike).cron);
+    if (expr === null) return;
+    const arr = byExpr.get(expr);
+    if (arr) arr.push(i);
+    else byExpr.set(expr, [i]);
+  });
+
+  return raws.map((r, i) => {
+    const { tier, context } = resolveTierContext(r.entry as ScheduleLike, opts.cheapCronEnabled);
+    const expr = normalizeCronExpr((r.entry as ScheduleLike).cron);
+    const out: CronListEntry = {
+      // Original fields first (backward compat), then the introspection
+      // fields override the labels where they collide (e.g. `name`).
+      ...(r.entry as Record<string, unknown>),
+      name: r.name,
+      source: r.source,
+      file: r.file,
+      tier,
+      context,
+    };
+    if (expr !== null) {
+      const siblings = (byExpr.get(expr) ?? []).filter((j) => j !== i);
+      if (siblings.length > 0) {
+        out.duplicate_of = siblings.map((j) => ({ name: raws[j]!.name, file: raws[j]!.file }));
+      }
+    }
+    return out;
+  });
+}
+
+/**
+ * Read-only health report over a merged schedule array. Surfaces:
+ *   - duplicate cron expressions (the gymbro double-fire),
+ *   - base-vs-overlay name collisions,
+ *   - entries with no resolvable tier/context.
+ */
+export function cronDoctor(
+  agent: string,
+  schedule: unknown[],
+  opts: { cheapCronEnabled: boolean },
+): CronDoctorReport {
+  const raws = (schedule ?? []).map(attributeEntry);
+  const findings: CronHealthFinding[] = [];
+
+  // ── Duplicate cron expressions ──────────────────────────────────────
+  const byExpr = new Map<string, RawEntry[]>();
+  for (const r of raws) {
+    const expr = normalizeCronExpr((r.entry as ScheduleLike).cron);
+    if (expr === null) continue;
+    const arr = byExpr.get(expr);
+    if (arr) arr.push(r);
+    else byExpr.set(expr, [r]);
+  }
+  for (const [expr, group] of byExpr) {
+    if (group.length > 1) {
+      findings.push({
+        kind: "duplicate_cron",
+        severity: "error",
+        message:
+          `${group.length} entries share cron expression "${expr}" — they will ` +
+          `all fire together (double-fire). Remove the redundant one(s).`,
+        cron: expr,
+        entries: group.map((r) => ({ name: r.name, file: r.file })),
+      });
+    }
+  }
+
+  // ── Base-vs-overlay name conflicts ──────────────────────────────────
+  const byName = new Map<string, RawEntry[]>();
+  for (const r of raws) {
+    if (r.name === null) continue;
+    const arr = byName.get(r.name);
+    if (arr) arr.push(r);
+    else byName.set(r.name, [r]);
+  }
+  for (const [name, group] of byName) {
+    const sources = new Set(group.map((r) => r.source));
+    if (group.length > 1 && sources.size > 1) {
+      findings.push({
+        kind: "name_conflict",
+        severity: "warn",
+        message:
+          `name "${name}" is used by both a base-config and an overlay entry — ` +
+          `removing by name is ambiguous.`,
+        conflicting_name: name,
+        entries: group.map((r) => ({ name: r.name, file: r.file })),
+      });
+    }
+  }
+
+  // ── Entries missing a resolvable tier/context ───────────────────────
+  for (const r of raws) {
+    const expr = normalizeCronExpr((r.entry as ScheduleLike).cron);
+    if (expr === null) {
+      findings.push({
+        kind: "missing_tier",
+        severity: "warn",
+        message:
+          `entry ${r.name ? `"${r.name}"` : "(unnamed)"} has no valid cron ` +
+          `expression, so its tier/context cannot be resolved.`,
+        entries: [{ name: r.name, file: r.file }],
+      });
+    }
+  }
+
+  return {
+    agent,
+    entry_count: raws.length,
+    findings,
+    healthy: findings.length === 0,
+  };
+}

--- a/telegram-plugin/permission-title.ts
+++ b/telegram-plugin/permission-title.ts
@@ -46,6 +46,7 @@ const MCP_TOOL_DESCRIPTIONS: Record<string, string> = {
   // agent-config — every agent's self-service surface (#1163, #1215)
   "mcp__agent-config__config_get": "Read its own merged config",
   "mcp__agent-config__cron_list": "List its own scheduled tasks",
+  "mcp__agent-config__cron_doctor": "Health-check its own cron schedule",
   "mcp__agent-config__skill_list": "List its own installed skills",
   "mcp__agent-config__audit_tail": "Read its own recent tool-call audit log",
   "mcp__agent-config__peers_list": "List the other agents on this instance",


### PR DESCRIPTION
## Summary

Pushes cron determinism into the tool layer so an agent can't repeat the **gymbro double-fire** (two `weekly-review` overlays both firing `0 20 * * 0`). Prose in CLAUDE.md is probabilistic; the tools now answer "where does this cron live?" and "do I already own a duplicate?" deterministically.

Three changes:

1. **`cron_list` is self-describing.** Each entry ADDS `source` (`base-config` vs `overlay`), `file` (`switchroom.yaml` or the `schedule.d/` path), resolved `tier`/`context`, and a `duplicate_of` back-reference when another entry shares the same cron expression. Original fields are preserved — the overlay-merge Symbols (`OVERLAY_SOURCE`/`OVERLAY_TITLE`) are read **before** the secret-strip pass that would roundtrip them away.
2. **`schedule_add` guards at write time.** New `E_CRON_DUPLICATE` (exit 9, existing `E_*` style) rejects when the agent already owns an overlay entry with the same cron expression **or** the same `--name`. This is the change that prevents the double-fire. It is a *fix-it* error, not an approval gate, so it hard-rejects on the `--stage-on-reject` MCP path too.
3. **`cron doctor` / `cron_doctor`** — read-only health verb returning `{healthy, findings[]}`: duplicate cron expressions, base-vs-overlay name conflicts, entries with no resolvable tier/context.

New pure module `src/scheduler/cron-introspect.ts` is the single source of truth (normalization, source labelling, dupe detection), reused by all three. Tier/context resolves via the existing pure `resolveCronRouting` FSM.

## Why

Job: **scheduled work should cost the minimum that does it** (`reference/jobs/crons-use-the-model-only-when-it-earns-it.md`) — serves *subscription-honest* + *on-leash*. A silent duplicate cron is a silent double-bill and a leash failure; the agent now sees and blocks it itself.

## Test plan

- [x] `src/scheduler/cron-introspect.test.ts` — dupe cross-linking, source/file labelling, tier resolution, doctor findings (duplicate_cron / name_conflict / missing_tier)
- [x] `src/cli/agent-config-write.test.ts` — `E_CRON_DUPLICATE` by expr, by name, whitespace-normalised match, distinct-allowed, overwrite case
- [x] `src/cli/agent-config.test.ts` — updated `cron list` self-describing shape
- [x] `src/mcp/agent-config/server.test.ts` — tool surface + `cron_doctor` dispatch
- [x] `tsc --noEmit` clean; `node scripts/build.mjs` green; affected vitest + plugin bun tests green
- [x] `docs/scheduling.md` + `telegram-plugin/permission-title.ts` updated (Docs / Consistency checks)

## Risk

Low. `cron_list` output gains fields (additive); the one downstream contract that asserted exact `cron list` equality is updated in this PR. `E_CRON_DUPLICATE` only triggers on a genuine duplicate the agent owns; identical cron+prompt already collided on the content-hash slug, so the new path mainly catches the dangerous "same time, different prompt" case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)