### PR TITLE
fix(gateway): drop Telegram idle-clear notice, keep stderr log

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3603,7 +3603,6 @@ function maybeIdleClear(): void {
   // could arrive between the gate check and the tmux send; /clear then lands in
   // claude's prompt buffer and runs at the next idle prompt (inject.ts FUTURE-GAP).
   void injectSlashCommandImpl(agentName, '/clear')
-    .then(() => { void postIdleClearNotice(idleClearMs); })
     .catch((err: unknown) => {
       process.stderr.write(
         `telegram gateway: idle /clear inject failed for ` +
@@ -3611,36 +3610,6 @@ function maybeIdleClear(): void {
       );
     })
     .finally(() => { idleClearDispatching = false; });
-}
-
-/** Subtle one-line notice so the operator knows the session was auto-cleared. */
-async function postIdleClearNotice(idleClearMs: number): Promise<void> {
-  try {
-    const chatId = loadAccess().allowFrom[0];
-    if (!chatId) return;
-    const threadId = topicForRecipient({
-      recipientChatId: chatId,
-      resolvedTopic:
-        resolveAgentOutboundTopic({ kind: 'compact-watchdog' })
-        ?? chatThreadMap.get(chatId),
-      supergroupChatId: resolveAgentSupergroupChatId(),
-    });
-    const hrs = Math.round((idleClearMs / 3_600_000) * 10) / 10;
-    const text =
-      `🧹 <b>Cleared after ${hrs}h idle</b> — fresh slate next message; ` +
-      `long-term memory is in Hindsight.`;
-    await swallowingApiCall(
-      () =>
-        bot.api.sendMessage(chatId, text, {
-          parse_mode: 'HTML',
-          disable_notification: true,
-          ...(threadId != null ? { message_thread_id: threadId } : {}),
-        }),
-      { chat_id: chatId, verb: 'idleAutoClear.notice' },
-    );
-  } catch {
-    /* best-effort notice — the /clear itself still happened */
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary

On idle auto-`/clear`, the gateway posted a `🧹 Cleared after Nh idle` Telegram message into the operator's chat. The operator wants it gone — it creates an unread badge with no actionable value for a routine session-hygiene event.

This removes the `postIdleClearNotice(idleClearMs)` call in `maybeIdleClear()` and deletes the now-unused `postIdleClearNotice` function. No other callers existed (grepped: the call site + the definition were its only references). The helpers it used (`loadAccess`, `topicForRecipient`, `resolveAgentOutboundTopic`, `resolveAgentSupergroupChatId`, `swallowingApiCall`, `bot`) are all still referenced extensively elsewhere, so nothing else became dead.

## Idle-clear is still observable (logged to stderr)

The required logging is untouched. `maybeIdleClear()` still emits, before the `/clear` inject:

```
telegram gateway: idle auto-/clear for <agent> (idle >= Nm)
```

Only the Telegram chat message is removed; observability via logs is unchanged.

## Scope

- One file changed: `telegram-plugin/gateway/gateway.ts` (31 deletions).
- The pure `decideIdleClear()` state-machine logic is **unchanged**; its tests (`telegram-plugin/tests/idle-clear.test.ts`) still pass. No test asserted the notice was sent, so no test edits were needed.

## JTBD

Serves **`reference/jobs/know-what-my-agent-is-doing.md`** (`serves: hold-the-leash`). That job's standing principle is that the signal reaching the operator's chat must carry value, not noise — the same rationale that retired the parallel progress card (#1122): "a surface running beside the conversation always devolved into redundant noise." A contentless idle-clear badge is exactly that kind of noise; removing it while keeping the stderr log sharpens signal-to-noise without losing any information the operator can act on.

## Invariants

Crosses none. `chat-is-the-single-source-of-truth` is preserved — the idle-clear is a system lifecycle event, not conversational content, and it remains recorded (in logs). No claude-native / on-leash / single-tenant / telegram-only surface is affected.

## Test plan

- `npm run lint` (tsc --noEmit + all check scripts) — pass.
- `npm run build` — pass.
- `bun test` idle suite (`idle-clear`, `idle-footer`, `idle-footer-wiring`) — 22 pass / 0 fail.
- Full `npm run test:bun`: the idle/gateway tests pass; the only failures are pre-existing `SQLITE_CANTOPEN` vault-broker tests that fail identically on pristine `origin/main` in this sandbox (a filesystem limitation, unrelated to this change). CI runs them in a proper environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)