### PR TITLE
fix(model): suppress spurious picker-unavailable on sr-* success

### DIFF
--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -560,7 +560,11 @@ export async function handleModelMenuCallback(
           .find((l) => /set model|switched/i.test(l)) ?? `Switched to ${friendlyName} (session)`
       return {
         answer: confirmation,
-        reply: await menuWithBanner(deps, `✅ ${deps.escapeHtml(confirmation)}`),
+        // Use the static (no-discover) path — after a text-inject the picker
+        // is in flux and discover() reliably fails, producing a spurious
+        // "(picker unavailable)" line that reads as an error when the switch
+        // actually succeeded.
+        reply: await menuWithBannerStatic(deps, `✅ ${deps.escapeHtml(confirmation)}`),
         selectedModel: srName,
       }
     }
@@ -681,5 +685,22 @@ async function menuWithBanner(
     text: [banner, '', fresh.text].join('\n'),
     html: true,
     ...(fresh.keyboard ? { keyboard: fresh.keyboard } : {}),
+  }
+}
+
+// Static variant — skips discover() entirely and uses the v1 text path.
+// Use after a text-inject where the picker state is inherently uncertain:
+// discover() reliably fails immediately post-inject, producing a spurious
+// "(picker unavailable)" warning that reads as an error.
+async function menuWithBannerStatic(
+  deps: ModelMenuDeps & ModelCommandDeps,
+  banner: string,
+): Promise<ModelMenuReply> {
+  const v1 = await handleModelCommand({ kind: 'show' }, deps)
+  return {
+    text: [banner, '', v1.text].join('\n'),
+    html: true,
+    // No keyboard — picker state is unknown after a text-inject; operator
+    // can tap /model to get a fresh interactive menu.
   }
 }

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -713,7 +713,13 @@ describe("handleModelMenuCallback — sr-* selection", () => {
     expect(calls.select).toHaveLength(0);
     expect(out.answer).toContain("Set model to sonnet");
     expect(out.selectedModel).toBe("sr-gemini-2.5-pro");
-    expect(out.reply.keyboard).toBeDefined();
+    // No keyboard on success: static reply path skips discover() to avoid the
+    // spurious "(picker unavailable)" line that discover() reliably produces
+    // immediately after an inject. Operator taps /model for a fresh menu.
+    expect(out.reply.keyboard).toBeUndefined();
+    // Banner present and text doesn't contain picker-unavailable noise
+    expect(out.reply.text).toContain('✅');
+    expect(out.reply.text).not.toContain('picker unavailable');
   });
 
   it("sr-* tap while busy returns toast-only with no inject", async () => {


### PR DESCRIPTION
## Summary
- After tapping an sr-* model button, the model switch works ✅ but the message shows `(picker unavailable: picker did not render — agent may be mid-turn or the CLI changed its /model UI)` which looks like an error

## Root cause
`menuWithBanner` calls `buildModelMenu` → `discover()`. Immediately after a text-inject, the picker is in an uncertain state and `discover()` reliably fails, prepending the spurious `(picker unavailable...)` line to what is otherwise a clean success reply.

## Fix
For the sr-* success path only, use `menuWithBannerStatic` (new helper) — it uses the static `handleModelCommand({ kind: 'show' })` path which needs no picker discovery. The reply is: ✅ banner + agent name/configured model/switch hints. No `(picker unavailable)` noise.

The operator can tap `/model` to get a fresh interactive menu with buttons after switching.

## Test plan
- [x] 66/66 bun model-command tests pass
- [x] Updated existing sr-* success test to assert `keyboard` is `undefined` (no buttons on static reply) and `text` doesn't contain "picker unavailable"