### PR TITLE
chore: release v0.16.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.16.16 — answer-stream lane now renders markdown; quieter idle-clear
+
+Agent narration sent through the answer-stream lane is now converted from
+markdown to Telegram HTML before going on the wire, matching every other
+outbound lane (the reply handler, the turn-flush backstop, the PTY partial
+handler). Previously this lane shipped the raw transcript under
+`parse_mode: 'HTML'`, so `**bold**` reached the user as literal asterisks and
+agent narration read as unformatted text. The renderer
+(`sanitizeTelegramHtml(markdownToHtml(...))`) is injected as a dependency, so
+dedup/comparison logic still runs on the raw text and only the outbound payload
+is converted. (#2628)
+
+The Telegram idle-clear notice is no longer posted to chat — the idle clear is
+now a stderr-only log, removing a noisy message from topics while keeping the
+event observable to operators. (#2641)
+
 ## v0.16.15 — fix sr-* success reply showing spurious "picker unavailable"
 
 After a successful sr-* model tap the reply now shows a clean ✅ banner

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.16.10",
+  "version": "0.16.16",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v0.16.16.

## Covers
- #2628 — fix(telegram): convert markdown in the answer-stream lane (the one outbound lane that was shipping raw transcript under `parse_mode: 'HTML'`).
- #2641 — fix(gateway): drop Telegram idle-clear notice, keep stderr log.

## Changes in this commit
- Adds the `v0.16.16` CHANGELOG.md stanza at the top, matching existing format.
- Bumps `package.json` `version` 0.16.10 → 0.16.16, fixing the long-standing version lag (the repo was already tagged through v0.16.15 while package.json trailed). This supersedes the stale version-bump PRs #2631 / #2623, now closed.

JTBD: release hygiene — keeps the published version, the git tag, and CHANGELOG in lockstep (maintainer-facing always-on operability).