### PR TITLE
fix(telegram): open the working card + typing indicator at turn start (kill the 12s dead-air gap)

### DIFF
--- a/telegram-plugin/gateway/feed-open-gate.ts
+++ b/telegram-plugin/gateway/feed-open-gate.ts
@@ -135,7 +135,8 @@ export function shouldEarlyOpenLiveness(input: EarlyLivenessOpenInput): boolean 
 /** Which producer triggered this drain — determines lever-5 OPEN eligibility. */
 export type FeedOpenProducer =
   /** Narrative SHOW (producer A): plain assistant text, no tool, no time
-   *  threshold. May only EDIT, never OPEN, while the turn has 0 tool labels. */
+   *  threshold. Pre-answer it is OPEN-eligible (lever 5 INERT); after a
+   *  substantive final answer it is blocked by lever 1. */
   | 'narrative'
   /** Tool label (producer B): the model dispatched a tool. OPEN-eligible unless a
    *  substantive final already landed (lever 1).

--- a/telegram-plugin/gateway/feed-open-gate.ts
+++ b/telegram-plugin/gateway/feed-open-gate.ts
@@ -80,6 +80,58 @@
  *     already received.
  */
 
+/**
+ * Inputs for the liveness early-open WHEN-decision (`shouldEarlyOpenLiveness`).
+ * Separate from the OPEN-gate levers above: those answer *may* a card open at
+ * all (reply-is-last / cross-turn); this answers *is it time yet* for the
+ * minimal "Working…" placeholder on a 0-label turn. Both must say yes — the
+ * caller routes the actual open through `mayOpenActivityCard` after this clears.
+ */
+export interface EarlyLivenessOpenInput {
+  /** Feature flag (`SWITCHROOM_FEED_LIVENESS_OPEN`). Off ⇒ never early-open. */
+  enabled: boolean
+  /** Turn age in ms (`now - turn.startedAt`). Must be ≥ `thresholdMs`. */
+  ageMs: number
+  /** The early-open threshold (`FEED_LIVENESS_OPEN_MS`). */
+  thresholdMs: number
+  /** Count of surfaced tool steps this turn (`turn.mirrorLines.length`). >0 ⇒ a
+   *  real label already drives the labelled-feed heartbeat; the placeholder must
+   *  not fight it, so it never opens (unless `forceNarrative` — see below). */
+  mirrorLineCount: number
+  /** Single in-place card transport id. Non-null ⇒ a card is already OPEN, so
+   *  this is a maintain/no-op, not a fresh OPEN. */
+  activityMessageId: number | null
+  /** The session chat id. `null` ⇒ no surface to open on. */
+  sessionChatId: string | null
+}
+
+/**
+ * Pure: is the minimal "Working…" liveness placeholder due to OPEN for a 0-label
+ * turn? True iff the feature is on, the turn has a target chat, it has been alive
+ * past the threshold, and NO card is already open. Once `mirrorLineCount > 0` a
+ * real tool label drives the feed, EXCEPT the edge where narration staged
+ * `mirrorLines` but no card opened yet (`activityMessageId == null`) — there the
+ * accumulated narration should still render on the early open, so it is allowed.
+ *
+ * This is the WHEN gate. The caller still routes the OPEN through
+ * `mayOpenActivityCard` (lever 1/4) so a card never opens below a delivered
+ * answer or on a cross-turn synthetic surface. Two callers consult this — the
+ * enqueue-time early-open timer and the 6 s heartbeat — and because an already-
+ * open card returns false here (and the drain EDITs rather than re-OPENs), they
+ * can never double-open.
+ */
+export function shouldEarlyOpenLiveness(input: EarlyLivenessOpenInput): boolean {
+  if (!input.enabled) return false
+  if (input.sessionChatId == null) return false
+  // A card is already open → maintain via the drain's EDIT path, not a fresh
+  // OPEN. Never double-open. (Reaching past here implies `activityMessageId ==
+  // null`, so a non-zero `mirrorLineCount` is the "narration staged but no card
+  // opened yet" edge — allowed below so the accumulated narration renders.)
+  if (input.activityMessageId != null) return false
+  if (input.ageMs < input.thresholdMs) return false
+  return true
+}
+
 /** Which producer triggered this drain — determines lever-5 OPEN eligibility. */
 export type FeedOpenProducer =
   /** Narrative SHOW (producer A): plain assistant text, no tool, no time

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -10770,11 +10770,12 @@ function showNarrativeStep(turn: CurrentTurn, text: string): void {
   // card-drain gate (chatLock-serialized under the flag; verbatim block OFF).
   cardDrainGate(turn, ea, () => {
   if (ea.mayDrain(turn)) {
-    // Producer A (narrative SHOW): may only EDIT an already-open card, never
-    // OPEN one on a 0-tool turn (design §9 lever 5 base case — the
-    // triplication). The OPEN gate in the drain enforces this; accumulation
-    // into mirrorLines still happens so the narration renders once a tool
-    // label or liveness opens the card.
+    // Producer A (narrative SHOW): pre-answer narrative may now OPEN a card,
+    // not just EDIT one — lever 5 is INERT (see feed-open-gate.ts), and
+    // Lever 2 / clearActivitySummary guarantees reply-is-last ordering instead.
+    // Accumulation into mirrorLines still happens, so any narration staged
+    // before the card opened renders on the first OPEN (whichever producer
+    // wins the race — narrative here, or the enqueue/liveness timer).
     // PR-4a: routed through the emission-authority façade (no-op delegate).
     ea.openOrEditCard('narrative', () => {
       turn.activityInFlight = drainActivitySummary(turn, 'narrative')

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -79,6 +79,7 @@ import { appendActivityLabel, clipNarrative, renderActivityFeedWithNested, type 
 import { REPLY_TOOLS, isDraftOfReply } from '../narrative-dedup.js'
 import { toolLabel } from '../tool-labels.js'
 import { createTypingWrapper } from '../typing-wrap.js'
+import { createTurnTypingLoop } from './turn-typing-loop.js'
 import { type DraftStreamHandle } from '../draft-stream.js'
 import { handlePtyPartialPure, type PtyHandlerState } from '../pty-partial-handler.js'
 import { handleStreamReply } from '../stream-reply-handler.js'
@@ -344,6 +345,7 @@ import { decideFeedReopen } from './feed-reopen-gate.js'
 import {
   mayOpenActivityCard,
   computeCrossTurnAnswerDelivered,
+  shouldEarlyOpenLiveness,
   type FeedOpenProducer,
   type FeedOpenGateDeps,
 } from './feed-open-gate.js'
@@ -1768,14 +1770,25 @@ const FEED_HEARTBEAT_MIN_STALE_MS = 6_000
 // the 300s silence-poke (the #680 dark-turn). When a turn has been alive >=
 // FEED_LIVENESS_OPEN_MS with no feed yet, open a minimal "Working…" feed so the
 // user always has a live indicator; the first real tool label edits it with
-// real content. Runs on the heartbeat interval, so the effective open lands in
-// [threshold, threshold + FEED_HEARTBEAT_TICK_MS). Kill switch:
+// real content.
+//
+// Two callers reach the SAME open path (`openLivenessFeedIfDue`):
+//   1. an enqueue-time one-shot timer (`scheduleEarlyLivenessOpen`) fires at
+//      `FEED_LIVENESS_OPEN_MS` after turn start — this is the early-open that
+//      kills the dead-air gap (narration emitted before the first tool now
+//      surfaces ~`FEED_LIVENESS_OPEN_MS` after enqueue, not after a 6 s
+//      heartbeat phase + the old 12 s threshold);
+//   2. the 6 s heartbeat tick, which maintains/climbs the card and is the
+//      backstop if the one-shot ever missed (e.g. a clock skew).
+// The threshold dropped from 12 s → ~1.2 s so the "something is happening"
+// signal lands within a second or two of the inbound, matching the JTBD
+// `know-what-my-agent-is-doing` p95 ≤ ~1 s ambient-ack bar. Kill switch:
 // SWITCHROOM_FEED_LIVENESS_OPEN=0. Default on.
 const FEED_LIVENESS_OPEN_ENABLED = process.env.SWITCHROOM_FEED_LIVENESS_OPEN !== '0'
 const FEED_LIVENESS_OPEN_MS = (() => {
   const raw = process.env.SWITCHROOM_FEED_LIVENESS_OPEN_MS
   const n = raw ? Number(raw) : NaN
-  return Number.isFinite(n) && n > 0 ? n : 12_000
+  return Number.isFinite(n) && n > 0 ? n : 1_200
 })()
 
 // Post-answer background-agent liveness STALENESS CAP (Fix 2 / #2587 supersede,
@@ -3147,6 +3160,13 @@ function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
     const threadId = threadPart === '_' || threadPart === '' ? null : Number(threadPart)
     stopTurnTypingLoop(chatId, Number.isFinite(threadId) ? threadId : null)
   }
+  // Cancel the enqueue-time early-open timer (paired with
+  // `scheduleEarlyLivenessOpen` at turn start). `key` is the same status-key the
+  // timer was registered under, so this is the single owner of the cancel. A
+  // leaked timer would otherwise fire its `openLivenessFeedIfDue` against a
+  // successor turn; the timer's own turnId match is the second guard, this is
+  // the first. Idempotent — a no-op when no timer is registered.
+  stopEarlyLivenessOpen(key as string)
   if (msgInfo) {
     const agentDir = resolveAgentDirFromEnv()
     if (agentDir != null) removeActiveReaction(agentDir, msgInfo.chatId, msgInfo.messageId)
@@ -4101,33 +4121,31 @@ function stopTypingLoop(chat_id: string, thread_id: number | null = null): void 
   if (retry) { clearTimeout(retry); typingRetryTimers.delete(key) }
 }
 
-// Turn-level `typing…` indicator. Deliberately a SEPARATE interval map
-// from `typingIntervals` (which the reply handler and the tool-use
-// typing wrapper share and freely stop). If the turn loop lived in the
-// shared map, a mid-turn reply's `finally { stopTypingLoop }` would
-// kill it and the chat would go dark for the rest of the turn — the
-// exact black-box gap this is here to close. A dedicated map makes the
-// turn loop structurally immune to those stops: only `stopTurnTypingLoop`
-// (called at the canonical turn-end) clears it. The redundant `typing`
-// pings while a reply is mid-flight are harmless — same action, and
-// sendChatAction is cheap.
-const turnTypingIntervals = new Map<string, ReturnType<typeof setInterval>>()
+// Turn-level `typing…` indicator. The lifecycle (immediate fire, 4 s refresh,
+// stop-at-turn-end, no leak) lives in the testable `turn-typing-loop.ts`
+// factory; the gateway just injects the real `sendChatAction` + `chatKey`.
+// Deliberately a SEPARATE interval map from `typingIntervals` (the reply handler
+// + tool-use typing wrapper share that one and freely stop it). If the turn loop
+// lived in the shared map, a mid-turn reply's `finally { stopTypingLoop }` would
+// kill it and the chat would go dark for the rest of the turn — the exact
+// black-box gap this closes. The dedicated map (private to the factory) makes
+// the turn loop structurally immune to those stops: only the canonical turn-end
+// stop clears it. The redundant `typing` pings while a reply is mid-flight are
+// harmless — same action, and sendChatAction is cheap.
+const turnTypingLoop = createTurnTypingLoop({
+  sendChatAction: (chat_id, thread_id) => {
+    const sendOpts = thread_id != null ? { message_thread_id: thread_id } : undefined
+    void bot.api.sendChatAction(chat_id, 'typing', sendOpts).catch(() => {})
+  },
+  chatKey: (chat_id, thread_id) => chatKey(chat_id, thread_id) as string,
+})
 
 function startTurnTypingLoop(chat_id: string, thread_id: number | null = null): void {
-  stopTurnTypingLoop(chat_id, thread_id)
-  const key = chatKey(chat_id, thread_id) as string
-  const sendOpts = thread_id != null ? { message_thread_id: thread_id } : undefined
-  const send = () => {
-    void bot.api.sendChatAction(chat_id, 'typing', sendOpts).catch(() => {})
-  }
-  send()
-  turnTypingIntervals.set(key, setInterval(send, 4000))
+  turnTypingLoop.start(chat_id, thread_id)
 }
 
 function stopTurnTypingLoop(chat_id: string, thread_id: number | null = null): void {
-  const key = chatKey(chat_id, thread_id) as string
-  const iv = turnTypingIntervals.get(key)
-  if (iv) { clearInterval(iv); turnTypingIntervals.delete(key) }
+  turnTypingLoop.stop(chat_id, thread_id)
 }
 
 const typingWrapper = createTypingWrapper({
@@ -10957,6 +10975,105 @@ async function drainActivitySummary(
 }
 
 /**
+ * Open (or climb) the minimal "Working…" liveness card for a 0-label turn once
+ * it has been alive >= FEED_LIVENESS_OPEN_MS. The ONE place the liveness card
+ * may OPEN — both the enqueue-time early-open timer
+ * (`scheduleEarlyLivenessOpen`) and the 6 s heartbeat call through here, so a
+ * card opened by one caller is a clean no-op for the other:
+ *   - `drainActivitySummary` OPENs when `activityMessageId == null` and EDITs
+ *     once it is set, so a second call after an open just maintains the card;
+ *   - the `mirrorLines.length === 0` guard at the heartbeat call site (and the
+ *     drain's own gate) means once a real tool label lands this path is skipped
+ *     and the labelled-feed heartbeat takes over;
+ *   - the OPEN itself is still gated by `mayOpenActivityCard` (lever 1 / 4) via
+ *     `ea.openOrEditCard('liveness', …)`, so a card never opens below a
+ *     delivered answer or on a cross-turn synthetic surface.
+ *
+ * Renders the turn's accumulated narration when present (the §3 case: narration
+ * staged before the first tool via `mirrorLines`) so the early open is not a
+ * bare placeholder when there is real text to show; falls back to "Working…"
+ * for a genuinely silent thinking turn.
+ */
+function openLivenessFeedIfDue(turn: CurrentTurn): void {
+  const age = Date.now() - turn.startedAt
+  // The WHEN decision (pure, `feed-open-gate.ts`): feature on, target chat,
+  // past threshold, no card already open. Returns false once a card is open
+  // (the drain EDITs instead) so the two callers can never double-open.
+  if (!shouldEarlyOpenLiveness({
+    enabled: FEED_LIVENESS_OPEN_ENABLED,
+    ageMs: age,
+    thresholdMs: FEED_LIVENESS_OPEN_MS,
+    mirrorLineCount: turn.mirrorLines.length,
+    activityMessageId: turn.activityMessageId,
+    sessionChatId: turn.sessionChatId,
+  })) return
+  const lines = turn.mirrorLines.length > 0 ? turn.mirrorLines : ['Working…']
+  const livenessHeader: SessionActivityHeader = {
+    label: 'Agent', elapsedMs: age, toolCount: turn.labeledToolCount, state: 'running',
+  }
+  const rendered = renderActivityFeedWithNested(lines, [], false, ` · ${formatFeedElapsed(age)}`, undefined, livenessHeader)
+  if (rendered == null) return
+  turn.activityPendingRender = rendered
+  const ea = emissionAuthorityFor(turn)
+  // PR-4d: route through the centralized chatLock-serialized card-drain gate.
+  cardDrainGate(turn, ea, () => {
+    if (ea.mayDrain(turn)) {
+      // Producer C (liveness timer): the thinking-gap / early-open. Now that
+      // Lever 5 is inert (narrative may open pre-answer — #2588), liveness
+      // remains the natural open for 0-tool pre-answer turns that are silent.
+      // The sticky-latch (lever 1) still gates it in the drain.
+      // PR-4a: routed through the emission-authority façade (no-op delegate).
+      ea.openOrEditCard('liveness', () => {
+        turn.activityInFlight = drainActivitySummary(turn, 'liveness')
+      })
+    }
+  })
+}
+
+// Enqueue-time early-open timers, keyed by status-key. One per in-flight turn;
+// cleared at turn-end (`stopEarlyLivenessOpen`) so a leaked timer can never fire
+// against a successor turn. `unref()` so it never holds the process alive.
+const earlyLivenessOpenTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+/**
+ * Schedule the enqueue-time early-open of the "Working…" liveness card. Called
+ * once per fresh turn at the `enqueue` lifecycle event (the single chokepoint
+ * every real turn atom passes through — inbound, cron, subagent-handback,
+ * vault-resume, restart-marker; anonymous one-shot hook clients never emit
+ * `enqueue`, so they are excluded by construction). Fires `openLivenessFeedIfDue`
+ * once at `FEED_LIVENESS_OPEN_MS` after turn start so narration / thinking that
+ * happens BEFORE the first tool surfaces a card within ~a second — no more dead
+ * air until a tool label or the old 12 s threshold. A no-op if a tool/narrative
+ * already opened the card (the helper's own guards). The 6 s heartbeat remains
+ * the backstop + the climb.
+ */
+function scheduleEarlyLivenessOpen(turn: CurrentTurn): void {
+  if (STATIC || !FEED_HEARTBEAT_ENABLED || !FEED_LIVENESS_OPEN_ENABLED) return
+  if (turn.sessionChatId == null) return
+  const key = statusKey(turn.sessionChatId, turn.sessionThreadId)
+  stopEarlyLivenessOpen(key)
+  const t = setTimeout(() => {
+    earlyLivenessOpenTimers.delete(key)
+    // Re-resolve the live turn for this key: only open if THIS turn is still the
+    // live one for its topic (a successor turn would carry its own timer). Under
+    // flag OFF `get(key)` returns the singleton — same turn unless a successor
+    // already replaced it, which the turnId match below also guards.
+    const live = currentTurnMap.get(key)
+    if (live == null || live.turnId !== turn.turnId) return
+    openLivenessFeedIfDue(live)
+  }, FEED_LIVENESS_OPEN_MS)
+  t.unref?.()
+  earlyLivenessOpenTimers.set(key, t)
+}
+
+/** Cancel the enqueue-time early-open timer for a status-key (turn-end teardown
+ *  + re-arm guard). Idempotent. */
+function stopEarlyLivenessOpen(key: string): void {
+  const t = earlyLivenessOpenTimers.get(key)
+  if (t != null) { clearTimeout(t); earlyLivenessOpenTimers.delete(key) }
+}
+
+/**
  * Heartbeat tick (PR1): keep the live activity feed visibly advancing during a
  * long single step that emits no new tool_label. Re-renders the feed with a
  * climbing " · Ns" elapsed on the in-progress line through the SAME single-flight
@@ -11041,30 +11158,13 @@ function feedHeartbeatTick(): void {
   // over and its edit cleanly replaces the placeholder. drainActivitySummary
   // sends (opens) when activityMessageId is null and edits (maintains) once set
   // — so this one branch handles both the open and the climb.
+  //
+  // The open/climb logic lives in ONE place (`openLivenessFeedIfDue`) so the
+  // enqueue-time early-open timer (`scheduleEarlyLivenessOpen`) and this 6 s
+  // heartbeat both reach the same drain — there is exactly one path that can
+  // OPEN the liveness card, so the two callers can never double-open or race.
   if (turn.mirrorLines.length === 0) {
-    if (!FEED_LIVENESS_OPEN_ENABLED || turn.sessionChatId == null) return
-    const age = Date.now() - turn.startedAt
-    if (age < FEED_LIVENESS_OPEN_MS) return
-    const livenessHeader: SessionActivityHeader = {
-      label: 'Agent', elapsedMs: age, toolCount: 0, state: 'running',
-    }
-    const rendered = renderActivityFeedWithNested(['Working…'], [], false, ` · ${formatFeedElapsed(age)}`, undefined, livenessHeader)
-    if (rendered == null) return
-    turn.activityPendingRender = rendered
-    const ea = emissionAuthorityFor(turn)
-    // PR-4d: route through the centralized chatLock-serialized card-drain gate.
-    cardDrainGate(turn, ea, () => {
-    if (ea.mayDrain(turn)) {
-      // Producer C (liveness timer): the genuine ≥12s thinking-gap open. Now
-      // that Lever 5 is inert (narrative may open pre-answer — #2588), liveness
-      // remains the natural open for 0-tool pre-answer turns that are silent.
-      // The sticky-latch (lever 1) still gates it in the drain.
-      // PR-4a: routed through the emission-authority façade (no-op delegate).
-      ea.openOrEditCard('liveness', () => {
-        turn.activityInFlight = drainActivitySummary(turn, 'liveness')
-      })
-    }
-    })
+    openLivenessFeedIfDue(turn)
     return
   }
 
@@ -11298,6 +11398,15 @@ function handleSessionEvent(ev: SessionEvent): void {
         // the SAME statusKey the ctor's façade was constructed with just above.
         setCurrentTurn(next, statusKey(ev.chatId, enqThreadIdNum))
         markIdleActivity() // any turn start (main session) is activity — re-arm idle clear
+        // Early-open the "Working…" liveness card at turn start so narration /
+        // thinking emitted BEFORE the first tool surfaces within ~a second
+        // instead of after the old 12 s threshold (the dead-air gap). Fires the
+        // SAME `openLivenessFeedIfDue` the 6 s heartbeat uses — a no-op if a
+        // tool/narrative already opened the card, and gated by `mayOpenActivityCard`
+        // (lever 1/4) so it never opens below a delivered answer. Scoped to real
+        // turns by construction: only the `enqueue` lifecycle event reaches here,
+        // and anonymous one-shot hook clients (recall.py) never emit it.
+        scheduleEarlyLivenessOpen(next)
         // Status-surface observability: one line at every turn SET so a later
         // dark card is traceable to which turn/topic key it belonged to.
         process.stderr.write(
@@ -22798,8 +22907,9 @@ async function shutdown(signal: string): Promise<void> {
 
   for (const iv of [...typingIntervals.values()]) clearInterval(iv)
   typingIntervals.clear()
-  for (const iv of [...turnTypingIntervals.values()]) clearInterval(iv)
-  turnTypingIntervals.clear()
+  turnTypingLoop.stopAll()
+  for (const t of [...earlyLivenessOpenTimers.values()]) clearTimeout(t)
+  earlyLivenessOpenTimers.clear()
   for (const t of [...typingRetryTimers.values()]) clearTimeout(t)
   typingRetryTimers.clear()
 

--- a/telegram-plugin/gateway/turn-typing-loop.ts
+++ b/telegram-plugin/gateway/turn-typing-loop.ts
@@ -1,0 +1,102 @@
+/**
+ * Turn-level `typing…` indicator — the second "something is happening" signal.
+ *
+ * A person you message shows as typing the WHOLE time they compose, not just
+ * the split-second a message is transmitted. Telegram's `sendChatAction('typing')`
+ * auto-expires after ~5 s, so a single one-shot ping on inbound leaves the chat
+ * dark after 5 s for any turn that thinks or reads a file before replying — the
+ * exact black-box gap this closes. We hold a continuous `typing…` for the whole
+ * turn by re-firing the action every ~4 s, and stop cleanly at the canonical
+ * turn-end. It runs ALONGSIDE the activity card (the early-card-open is the
+ * other signal): both start at turn enqueue and stop at turn-end, so the two
+ * "alive" signals start and stop together.
+ *
+ * This is the SAME mechanism as the tool-use `typingIntervals` (`typing-wrap.ts`)
+ * but on a DELIBERATELY SEPARATE interval map: if the turn loop shared that map,
+ * a mid-turn reply's `finally { stopTypingLoop }` would kill it and the chat
+ * would go dark for the rest of the turn. A dedicated map makes the turn loop
+ * structurally immune to those stops — only `stop` (the canonical turn-end)
+ * clears it. The redundant `typing` pings while a reply is mid-flight are
+ * harmless (same action, and `sendChatAction` is cheap).
+ *
+ * Extracted into a factory so the lifecycle (fires on start, refreshes on the
+ * interval, stops on turn-end, NEVER leaks a refresh interval after the turn
+ * completes) has its own unit test (`tests/turn-typing-loop.test.ts`) without
+ * spinning up the whole gateway or the Telegram bot API. The gateway injects
+ * the real `sendChatAction` + the chat-key function; tests inject spies + fake
+ * timers.
+ */
+
+export interface TurnTypingLoopDeps {
+  /** Fire one `typing` chat action for (chatId, threadId). Errors are the
+   *  caller's concern (the gateway swallows them); the loop never throws. */
+  sendChatAction: (chatId: string, threadId: number | null) => void
+  /** Canonical chat:thread key (the gateway's `chatKey`), so a per-topic turn
+   *  loop is isolated from a sibling topic on the same chat. */
+  chatKey: (chatId: string, threadId: number | null) => string
+  /** Refresh cadence in ms. Telegram's `typing` auto-expires after ~5 s, so the
+   *  default 4 s keeps it continuously lit. Override for tests. */
+  refreshMs?: number
+}
+
+export interface TurnTypingLoop {
+  /** Start (or restart) the turn-long `typing…` loop for a chat/thread. Fires
+   *  one action immediately, then every `refreshMs`. Idempotent re-start: a
+   *  prior loop on the same key is stopped first, so this never leaks. */
+  start: (chatId: string, threadId?: number | null) => void
+  /** Stop the loop for a chat/thread and clear its interval. Idempotent — a
+   *  no-op when no loop is registered. The single owner of the stop is the
+   *  gateway's canonical turn-end. */
+  stop: (chatId: string, threadId?: number | null) => void
+  /** Stop EVERY live loop and clear the map — the gateway's shutdown-drain
+   *  cleanup (mirrors the other interval-map clears there). */
+  stopAll: () => void
+  /** Test/observability: how many loops are currently live (0 ⇒ none leaked). */
+  activeCount: () => number
+}
+
+/**
+ * Build a turn-typing loop over injected deps. The interval map is private to
+ * the returned closure — the SEPARATE map that makes the turn loop immune to
+ * the tool-use typing stops.
+ */
+export function createTurnTypingLoop(deps: TurnTypingLoopDeps): TurnTypingLoop {
+  const refreshMs = deps.refreshMs ?? 4000
+  const intervals = new Map<string, ReturnType<typeof setInterval>>()
+
+  function stop(chatId: string, threadId: number | null = null): void {
+    const key = deps.chatKey(chatId, threadId)
+    const iv = intervals.get(key)
+    if (iv != null) {
+      clearInterval(iv)
+      intervals.delete(key)
+    }
+  }
+
+  function start(chatId: string, threadId: number | null = null): void {
+    // Restart-safe: stop any prior loop on this key first so a re-start never
+    // leaks a second interval (the self-heal when an abnormal abort skipped the
+    // turn-end stop — the next turn's start clears the stray loop).
+    stop(chatId, threadId)
+    const key = deps.chatKey(chatId, threadId)
+    const send = () => deps.sendChatAction(chatId, threadId)
+    send() // fire immediately so "typing…" lands ~instantly, not after refreshMs
+    const iv = setInterval(send, refreshMs)
+    // unref so a live loop never holds the process open (mirrors the gateway's
+    // other interval timers). Guarded for environments without unref.
+    ;(iv as { unref?: () => void }).unref?.()
+    intervals.set(key, iv)
+  }
+
+  function stopAll(): void {
+    for (const iv of [...intervals.values()]) clearInterval(iv)
+    intervals.clear()
+  }
+
+  return {
+    start,
+    stop,
+    stopAll,
+    activeCount: () => intervals.size,
+  }
+}

--- a/telegram-plugin/tests/emission-authority-facade.test.ts
+++ b/telegram-plugin/tests/emission-authority-facade.test.ts
@@ -324,14 +324,29 @@ describe('the 7 drain sites route through the façade with producers preserved v
     expect(body).toMatch(/ea\.mayDrain\(turn\)/)
   })
 
-  it('both liveness sites in feedHeartbeatTick route via openOrEditCard("liveness") + producer-"liveness" drains', () => {
-    const body = fnSrc('feedHeartbeatTick')
-    const opens = [...body.matchAll(/openOrEditCard\('liveness'/g)]
+  it('both liveness sites route via openOrEditCard("liveness") + producer-"liveness" drains (one in openLivenessFeedIfDue, one in feedHeartbeatTick)', () => {
+    // The early-card-open refactor extracted the 0-tool liveness OPEN out of
+    // feedHeartbeatTick into the shared `openLivenessFeedIfDue` helper (so the
+    // 6 s heartbeat and the enqueue-time early-open timer reach ONE open path
+    // and never double-open). So the two liveness sites now live in:
+    //   - openLivenessFeedIfDue: the 0-tool early-open / climb;
+    //   - feedHeartbeatTick:     the labelled-feed stale-step maintain.
+    // Both must still route via the façade with the producer arg verbatim.
+    const earlyOpen = fnSrc('openLivenessFeedIfDue')
+    const heartbeat = fnSrc('feedHeartbeatTick')
+    const opens = [
+      ...earlyOpen.matchAll(/openOrEditCard\('liveness'/g),
+      ...heartbeat.matchAll(/openOrEditCard\('liveness'/g),
+    ]
     expect(opens).toHaveLength(2)
-    const drains = [...body.matchAll(/drainActivitySummary\(turn,\s*'liveness'\)/g)]
+    const drains = [
+      ...earlyOpen.matchAll(/drainActivitySummary\(turn,\s*'liveness'\)/g),
+      ...heartbeat.matchAll(/drainActivitySummary\(turn,\s*'liveness'\)/g),
+    ]
     expect(drains).toHaveLength(2)
-    // The literal the feed-heartbeat oracle greps must still be present.
-    expect(body).toMatch(/turn\.activityInFlight = drainActivitySummary/)
+    // The literal the feed-heartbeat oracle greps must still be present in both.
+    expect(earlyOpen).toMatch(/turn\.activityInFlight = drainActivitySummary/)
+    expect(heartbeat).toMatch(/turn\.activityInFlight = drainActivitySummary/)
   })
 
   it('the tool_label site routes via openOrEditCard("tool") + the producer-"tool" drain', () => {

--- a/telegram-plugin/tests/feed-heartbeat-liveness-open.test.ts
+++ b/telegram-plugin/tests/feed-heartbeat-liveness-open.test.ts
@@ -12,12 +12,22 @@
  *     `evaluatePostAnswerLiveness(...)` consulted each tick, with the cap fed
  *     from `POST_ANSWER_LIVENESS_STALE_MS`.
  *
- * Pre-answer liveness-open branch:
+ * Pre-answer liveness-open path (`openLivenessFeedIfDue`, the shared helper the
+ * heartbeat AND the enqueue-time early-open timer both call — early-card-open
+ * change):
  *   1. The SWITCHROOM_FEED_LIVENESS_OPEN kill-switch (default ON, i.e. `!== '0'`)
- *      gates the liveness-open path — operators can disable it with =0.
- *   2. FEED_LIVENESS_OPEN_MS is parsed from env with a sane default (12 000 ms).
- *   3. The `age < FEED_LIVENESS_OPEN_MS` return-guard fires BEFORE the 0-tool
- *      feed opens — a turn that hasn't yet passed the threshold returns early.
+ *      gates the liveness-open path — operators can disable it with =0. The
+ *      WHEN-gate (`shouldEarlyOpenLiveness`, feed-open-gate.ts) reads it.
+ *   2. FEED_LIVENESS_OPEN_MS is parsed from env with a sane default of ~1.2 s
+ *      (dropped from 12 s to kill the dead-air gap before the card opens).
+ *   3. The age-vs-threshold + already-open return-guards live in the pure
+ *      `shouldEarlyOpenLiveness` decision, consulted at the top of
+ *      `openLivenessFeedIfDue` BEFORE the drain — a turn that hasn't passed the
+ *      threshold, or one whose card is already open, returns early (no
+ *      double-open).
+ *   4. The 0-tool branch of `feedHeartbeatTick` delegates to that one shared
+ *      helper rather than inlining the open — so the heartbeat and the
+ *      enqueue-time timer can never double-open.
  *
  * These are STRUCTURAL (source-read) assertions; the gateway IIFE can't be
  * instantiated in-process. Pattern matches silence-liveness-wiring.test.ts.
@@ -38,21 +48,10 @@ function feedHeartbeatTickSrc(): string {
   return after.split('\nfunction ')[0] ?? after
 }
 
-/**
- * Extract the 0-tool liveness-open branch: the section from
- * `if (turn.mirrorLines.length === 0)` to its closing `return`. This scopes
- * the FEED_LIVENESS_OPEN_ENABLED and age-guard assertions to the correct branch
- * (the post-answer Fix-2 block now precedes it and also has a drain call).
- */
-function liveness0ToolBranchSrc(): string {
-  const body = feedHeartbeatTickSrc()
-  const start = body.indexOf('if (turn.mirrorLines.length === 0)')
-  if (start === -1) return ''
-  // Capture until the closing `return\n  }` of this if-block (the next blank-line-terminated return).
-  const after = body.slice(start)
-  // Take up to the labelled-feed heartbeat comment that follows.
-  const end = after.indexOf('// Labelled-feed heartbeat')
-  return end === -1 ? after : after.slice(0, end)
+/** Return the source text of `openLivenessFeedIfDue` (the shared open helper). */
+function openLivenessFeedIfDueSrc(): string {
+  const after = gatewaySrc.split('function openLivenessFeedIfDue(turn: CurrentTurn): void {')[1] ?? ''
+  return after.split('\nfunction ')[0] ?? after
 }
 
 describe('H-1: feedHeartbeatTick liveness-open threshold', () => {
@@ -63,36 +62,43 @@ describe('H-1: feedHeartbeatTick liveness-open threshold', () => {
     )
   })
 
-  it('FEED_LIVENESS_OPEN_MS defaults to 12_000 ms when env is unset', () => {
+  it('FEED_LIVENESS_OPEN_MS defaults to ~1.2 s (dropped from 12 s to kill the dead-air gap)', () => {
     // The IIFE initialiser `const FEED_LIVENESS_OPEN_MS = (() => { ... })()` must
-    // contain the fallback 12_000. Split on the const definition (not the comment).
+    // contain the new fallback 1_200. Split on the const definition (not the comment).
     const afterConst = gatewaySrc.split('const FEED_LIVENESS_OPEN_MS')[1] ?? ''
     // The IIFE closes with `})()` — take everything before that.
     const initBlock = afterConst.split('})()')[0] ?? ''
-    expect(initBlock).toMatch(/12[_]?000/)
+    expect(initBlock).toMatch(/1[_]?200/)
   })
 
-  it('age < FEED_LIVENESS_OPEN_MS return-guard exists inside the 0-tool liveness branch', () => {
-    const branch = liveness0ToolBranchSrc()
-    expect(branch).toMatch(/if\s*\(age\s*<\s*FEED_LIVENESS_OPEN_MS\)\s*return/)
+  it('the 0-tool liveness branch delegates to the shared openLivenessFeedIfDue helper', () => {
+    // The open logic lives in ONE place so the heartbeat and the enqueue-time
+    // early-open timer cannot double-open. The 0-tool branch must call the
+    // shared helper rather than inline its own open.
+    const body = feedHeartbeatTickSrc()
+    const start = body.indexOf('if (turn.mirrorLines.length === 0)')
+    expect(start).toBeGreaterThan(-1)
+    const branch = body.slice(start)
+    const end = branch.indexOf('// Labelled-feed heartbeat')
+    const scoped = end === -1 ? branch : branch.slice(0, end)
+    expect(scoped).toMatch(/openLivenessFeedIfDue\(turn\)/)
   })
 
-  it('FEED_LIVENESS_OPEN_ENABLED check precedes the drain call in the 0-tool liveness branch', () => {
-    const branch = liveness0ToolBranchSrc()
-    const enabledIdx = branch.indexOf('FEED_LIVENESS_OPEN_ENABLED')
-    // Use the actual call site (assignment to activityInFlight) not the comment mention.
-    const drainCallIdx = branch.indexOf('turn.activityInFlight = drainActivitySummary')
-    expect(enabledIdx).toBeGreaterThan(-1)
-    expect(drainCallIdx).toBeGreaterThan(enabledIdx)
+  it('the WHEN-gate (shouldEarlyOpenLiveness) precedes the drain call inside openLivenessFeedIfDue', () => {
+    const body = openLivenessFeedIfDueSrc()
+    const gateIdx = body.indexOf('shouldEarlyOpenLiveness(')
+    // Use the actual call site (assignment to activityInFlight) not a comment mention.
+    const drainCallIdx = body.indexOf('turn.activityInFlight = drainActivitySummary')
+    expect(gateIdx).toBeGreaterThan(-1)
+    expect(drainCallIdx).toBeGreaterThan(gateIdx)
   })
 
-  it('age < FEED_LIVENESS_OPEN_MS guard precedes the drain call in the 0-tool branch (early-return)', () => {
-    const branch = liveness0ToolBranchSrc()
-    const guardIdx = branch.indexOf('age < FEED_LIVENESS_OPEN_MS')
-    // Use the actual call site (assignment to activityInFlight) not the comment mention.
-    const drainCallIdx = branch.indexOf('turn.activityInFlight = drainActivitySummary')
-    expect(guardIdx).toBeGreaterThan(-1)
-    expect(drainCallIdx).toBeGreaterThan(guardIdx)
+  it('the early-open timer is scheduled at turn enqueue and torn down at turn-end', () => {
+    // The enqueue-time early-open (the dead-air fix): a one-shot timer fires the
+    // shared open helper at turn start, and it is cancelled at the canonical
+    // turn-end so a leaked timer can never fire against a successor turn.
+    expect(gatewaySrc).toMatch(/scheduleEarlyLivenessOpen\(next\)/)
+    expect(gatewaySrc).toMatch(/stopEarlyLivenessOpen\(key as string\)/)
   })
 })
 

--- a/telegram-plugin/tests/feed-open-gate.test.ts
+++ b/telegram-plugin/tests/feed-open-gate.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { mayOpenActivityCard } from '../gateway/feed-open-gate.js'
+import {
+  mayOpenActivityCard,
+  shouldEarlyOpenLiveness,
+} from '../gateway/feed-open-gate.js'
 
 /**
  * Feed-OPEN gate — pure decision (design `docs/message-emission-determinism.md`
@@ -172,6 +175,77 @@ describe('mayOpenActivityCard — lever 1 exception: post-answer sub-agent liven
         labeledToolCount: 2,
         postAnswerSubagentActivity: true,
       }),
+    ).toBe(false)
+  })
+})
+
+describe('shouldEarlyOpenLiveness — the early-open WHEN gate (enqueue + heartbeat)', () => {
+  // The minimal "Working…" placeholder is due to open for a 0-label turn once it
+  // has been alive past the threshold and NO card is open yet. Both the
+  // enqueue-time early-open timer and the 6 s heartbeat consult this, so an
+  // already-open card returns false (the drain EDITs instead) — they can never
+  // double-open. This is the fix for the 12 s dead-air gap before the card first
+  // appears on a thinking / pure-narration turn.
+
+  const base = {
+    enabled: true,
+    ageMs: 1_500,
+    thresholdMs: 1_200,
+    mirrorLineCount: 0,
+    activityMessageId: null as number | null,
+    sessionChatId: 'chat-1' as string | null,
+  }
+
+  it('opens at the liveness threshold for a 0-tool turn with no card yet', () => {
+    // The core change: a turn alive past the (now ~1.2 s) threshold with no tool
+    // label and no card opens the placeholder — narration before the first tool
+    // surfaces right away instead of after 12 s.
+    expect(shouldEarlyOpenLiveness({ ...base })).toBe(true)
+  })
+
+  it('is a NO-OP once a card is already open (never double-open / race)', () => {
+    // A tool/narrative drain already opened the card (activityMessageId set).
+    // Both callers see false here, so the second one maintains via EDIT, not a
+    // fresh OPEN.
+    expect(
+      shouldEarlyOpenLiveness({ ...base, activityMessageId: 4242 }),
+    ).toBe(false)
+  })
+
+  it('does not open before the threshold (turn still fresh)', () => {
+    expect(
+      shouldEarlyOpenLiveness({ ...base, ageMs: 300, thresholdMs: 1_200 }),
+    ).toBe(false)
+  })
+
+  it('opens exactly AT the threshold (>= boundary)', () => {
+    expect(
+      shouldEarlyOpenLiveness({ ...base, ageMs: 1_200, thresholdMs: 1_200 }),
+    ).toBe(true)
+  })
+
+  it('never opens when the feature flag is off', () => {
+    expect(shouldEarlyOpenLiveness({ ...base, enabled: false })).toBe(false)
+  })
+
+  it('never opens with no target chat (e.g. an anonymous / null-agent surface)', () => {
+    expect(shouldEarlyOpenLiveness({ ...base, sessionChatId: null })).toBe(false)
+  })
+
+  it('opens to render accumulated narration: mirrorLines staged but no card yet (§3 case)', () => {
+    // The edge the early open serves: narration was staged (mirrorLineCount > 0)
+    // but no card opened yet (activityMessageId == null). The placeholder opens
+    // and renders that accumulated narration rather than a bare "Working…".
+    expect(
+      shouldEarlyOpenLiveness({ ...base, mirrorLineCount: 3, activityMessageId: null }),
+    ).toBe(true)
+  })
+
+  it('does NOT fight the labelled feed once a card is open AND labels exist', () => {
+    // A real tool label drives the labelled-feed heartbeat (card open). The
+    // placeholder must not fight it → no fresh OPEN.
+    expect(
+      shouldEarlyOpenLiveness({ ...base, mirrorLineCount: 2, activityMessageId: 99 }),
     ).toBe(false)
   })
 })

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -397,6 +397,26 @@ describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A
         "<i>✓ Working…</i>",
       );
     });
+
+    it("early open renders ACCUMULATED narration, not a bare 'Working…' (§3 case)", () => {
+      // The early-open path (gateway `openLivenessFeedIfDue`) passes the turn's
+      // accumulated `mirrorLines` when non-empty instead of the bare "Working…"
+      // placeholder. This is the §3 case: narration emitted BEFORE the first
+      // tool was staged into mirrorLines, and the early open surfaces it on the
+      // card the instant it opens — so the pre-tool narration is visible
+      // immediately, not lost until a tool label lands.
+      const staged = [
+        "Let me check the migration history first",
+        "Now comparing against the live schema",
+      ];
+      const out = renderActivityFeedWithNested(staged, [], false, " · 1s")!;
+      // The live in-progress line carries the LAST staged narration line, and the
+      // earlier line is retained in the feed body — the accumulated narration
+      // renders, not "Working…".
+      expect(out).toContain("Now comparing against the live schema");
+      expect(out).toContain("Let me check the migration history first");
+      expect(out).not.toContain("Working…");
+    });
   });
 
   it("stepCount=0 → no footer even on final=true", () => {

--- a/telegram-plugin/tests/turn-typing-loop.test.ts
+++ b/telegram-plugin/tests/turn-typing-loop.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createTurnTypingLoop } from '../gateway/turn-typing-loop.js'
+
+/**
+ * Turn-level `typing…` indicator lifecycle — the second "something is happening"
+ * signal that runs alongside the early-card-open. Telegram's typing action
+ * auto-expires after ~5 s, so the loop must re-fire on a periodic refresh while
+ * the turn is in flight and stop cleanly at turn-end WITHOUT leaking a refresh
+ * interval. The factory is unit-tested over fake timers + a spy `sendChatAction`
+ * so the lifecycle is proven without the gateway or the bot API.
+ */
+
+function makeDeps(overrides: { refreshMs?: number } = {}) {
+  const sendChatAction =
+    vi.fn<(chatId: string, threadId: number | null) => void>()
+  // Mirror the gateway's chatKey null/0-collapse: undefined/null thread → '_'.
+  const chatKey = (chatId: string, threadId: number | null) =>
+    `${chatId}:${threadId == null ? '_' : threadId}`
+  return { sendChatAction, chatKey, refreshMs: overrides.refreshMs }
+}
+
+describe('createTurnTypingLoop — turn-long typing indicator lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fires a typing action immediately on turn start (no wait for the first refresh)', () => {
+    const deps = makeDeps()
+    const loop = createTurnTypingLoop(deps)
+    loop.start('chat-A')
+    expect(deps.sendChatAction).toHaveBeenCalledTimes(1)
+    expect(deps.sendChatAction).toHaveBeenCalledWith('chat-A', null)
+    expect(loop.activeCount()).toBe(1)
+  })
+
+  it('refreshes the typing action every refreshMs while the turn is in flight', () => {
+    const deps = makeDeps({ refreshMs: 4000 })
+    const loop = createTurnTypingLoop(deps)
+    loop.start('chat-A')
+    expect(deps.sendChatAction).toHaveBeenCalledTimes(1) // immediate
+    vi.advanceTimersByTime(4000)
+    expect(deps.sendChatAction).toHaveBeenCalledTimes(2) // first refresh
+    vi.advanceTimersByTime(8000)
+    expect(deps.sendChatAction).toHaveBeenCalledTimes(4) // two more refreshes
+  })
+
+  it('stops cleanly on turn end and leaks NO refresh interval afterwards', () => {
+    const deps = makeDeps({ refreshMs: 4000 })
+    const loop = createTurnTypingLoop(deps)
+    loop.start('chat-A')
+    vi.advanceTimersByTime(4000)
+    expect(deps.sendChatAction).toHaveBeenCalledTimes(2)
+    loop.stop('chat-A')
+    expect(loop.activeCount()).toBe(0)
+    // No further fires after the stop — the interval was cleared, not leaked.
+    vi.advanceTimersByTime(60_000)
+    expect(deps.sendChatAction).toHaveBeenCalledTimes(2)
+  })
+
+  it('stop is idempotent (a no-op when no loop is registered)', () => {
+    const deps = makeDeps()
+    const loop = createTurnTypingLoop(deps)
+    // Stop before any start — must not throw and must remain at zero loops.
+    expect(() => loop.stop('chat-A')).not.toThrow()
+    expect(loop.activeCount()).toBe(0)
+  })
+
+  it('restart on the same key never leaks a second interval (self-heal)', () => {
+    const deps = makeDeps({ refreshMs: 4000 })
+    const loop = createTurnTypingLoop(deps)
+    loop.start('chat-A') // turn 1
+    loop.start('chat-A') // turn 2 on the same key (abnormal abort skipped stop)
+    // Exactly one live loop, not two.
+    expect(loop.activeCount()).toBe(1)
+    // After one refresh window, only ONE refresh fired (plus the 2 immediates).
+    vi.advanceTimersByTime(4000)
+    // 2 immediates (one per start) + 1 refresh from the single live interval.
+    expect(deps.sendChatAction).toHaveBeenCalledTimes(3)
+  })
+
+  it('isolates per-(chat,thread): stopping topic A leaves topic B running', () => {
+    const deps = makeDeps({ refreshMs: 4000 })
+    const loop = createTurnTypingLoop(deps)
+    loop.start('chat-A', 17) // topic A
+    loop.start('chat-A', 23) // topic B — same chat, different thread, own lane
+    expect(loop.activeCount()).toBe(2)
+    expect(deps.sendChatAction).toHaveBeenNthCalledWith(1, 'chat-A', 17)
+    expect(deps.sendChatAction).toHaveBeenNthCalledWith(2, 'chat-A', 23)
+
+    loop.stop('chat-A', 17) // end topic A's turn only
+    expect(loop.activeCount()).toBe(1) // topic B still live
+
+    deps.sendChatAction.mockClear()
+    vi.advanceTimersByTime(4000)
+    // Only topic B refreshes; topic A is fully stopped.
+    expect(deps.sendChatAction).toHaveBeenCalledTimes(1)
+    expect(deps.sendChatAction).toHaveBeenCalledWith('chat-A', 23)
+  })
+
+  it('stopAll clears every live loop (shutdown-drain cleanup) and leaks none', () => {
+    const deps = makeDeps({ refreshMs: 4000 })
+    const loop = createTurnTypingLoop(deps)
+    loop.start('chat-A', 17)
+    loop.start('chat-B')
+    expect(loop.activeCount()).toBe(2)
+    loop.stopAll()
+    expect(loop.activeCount()).toBe(0)
+    deps.sendChatAction.mockClear()
+    vi.advanceTimersByTime(60_000)
+    expect(deps.sendChatAction).not.toHaveBeenCalled()
+  })
+
+  it('collapses undefined and null threadId to the same lane', () => {
+    const deps = makeDeps()
+    const loop = createTurnTypingLoop(deps)
+    loop.start('chat-A') // undefined thread
+    loop.start('chat-A', null) // null thread — same lane (restart, not a 2nd loop)
+    expect(loop.activeCount()).toBe(1)
+  })
+})


### PR DESCRIPTION
## Problem

The Telegram progress card did **not** open on a zero-tool turn. Narration / thinking emitted *before* the first tool call accumulated invisibly until the card opened, which waited on either the first tool label **or** the `FEED_LIVENESS_OPEN_MS` liveness timer (default **12000ms**). A new turn that thought or narrated before dispatching a tool therefore showed **nothing on Telegram for ~12s of dead air**.

The card composition was already fine (`tool-labels`, `tool-activity-summary`, `card-format`, `narrative-dedup` pass descriptions + narration through). The only bug was *when* the card first opens.

## JTBD + invariants

- **Serves the Visibility outcome** (`hold-the-leash`) via the **`know-what-my-agent-is-doing`** job spec: *"the user gets an ambient signal that the agent heard them, effectively instantly. No silent gap between 'I sent it' and 'something's happening'"* — production-readiness pins the ambient ack at p95 ≤ ~1s.
- **Invariant-safe.** The activity card here is the in-conversation, edit-in-place feed — **not** the retired pinned progress card (#1122). This strengthens both `telegram-only` and `chat-is-the-single-source-of-truth` (the signal lands in the conversation faster); it breaches neither. No new parallel status surface is added.

## What changed

### A. Open the working card immediately at turn start
Chose the **enqueue-time open gated through the shared liveness path** (the preferred option — keeps open logic in one place) **plus** a small threshold drop as the durable floor:

- Extracted the 0-tool liveness-open out of `feedHeartbeatTick` into a shared `openLivenessFeedIfDue(turn)` — exactly **one** path can OPEN the liveness card now.
- Added `scheduleEarlyLivenessOpen(turn)` at the `enqueue` lifecycle event (the single chokepoint every real turn atom passes through — inbound, cron, subagent-handback, vault-resume, restart-marker). Anonymous one-shot hook clients (`recall.py`) never emit `enqueue`, so they are excluded **by construction** (matches the `disconnect-flush.ts` anonymous no-op contract).
- Dropped the `FEED_LIVENESS_OPEN_MS` default **12000ms → ~1200ms** so the signal lands within a second or two — applies to **all** turn types durably (tool-bearing AND pure-narration / zero-tool), per the operator's ask.
- **No double-open / no race:** the WHEN decision is the pure `shouldEarlyOpenLiveness` (in `feed-open-gate.ts`) — returns false once a card is open (the drain EDITs instead of OPENing), and the OPEN is still gated by `mayOpenActivityCard` (lever 1/4), so nothing opens below a delivered answer or on a cross-turn synthetic surface. The early open renders the turn's **accumulated `mirrorLines` narration** (the pre-tool narration case), not a bare placeholder. The timer is torn down at turn-end and on shutdown drain — no leak.

### B. Fire the typing indicator as a second "something is happening" signal
The turn-long `typing…` loop already started at enqueue and stopped at turn-end on a dedicated interval map. Made it durable + testable:

- Extracted it into a `turn-typing-loop.ts` factory: immediate fire, **4s refresh** (Telegram's `typing` auto-expires ~5s), clean stop at turn-end, **no leaked interval**, per-`(chat,thread)` isolation, `stopAll()` for the shutdown drain.
- Wired to the **same enqueue / turn-end lifecycle** as (A), so the two "alive" signals start and stop together. Surface tools / instant turns are unaffected (the loop is turn-scoped, not tool-scoped).

## Adjacent paths audited
- `disconnect-flush.ts` — confirmed the enqueue-open is scoped to real turns; anonymous null-agent hook clients never reach the `enqueue` arm.
- `narrative-dedup.ts` — the early open renders only the dedup'd narration steps in `mirrorLines`; draft-then-send answer text is suppressed before it reaches `mirrorLines`, so no double-print of the answer.
- `card-format.ts` / `tool-activity-summary.ts` — the placeholder renders a sane `→ Working…` line (or the staged narration), never an empty card.
- idle-clear (#2641) — `markIdleActivity()` runs at enqueue before the early-open is scheduled; the idle `/clear` is a separate wall-clock mechanism and does not race the open.
- `worker-activity-feed.ts` — sub-agent (Task) work produces tool labels that populate `mirrorLines`, so the labelled-feed heartbeat takes over and the early placeholder steps aside (`shouldEarlyOpenLiveness` returns false once a card is open).

## Tests
- `feed-open-gate.test.ts` — `shouldEarlyOpenLiveness`: opens at the liveness threshold for a 0-tool turn, **no-op when a card is already open**, threshold boundary, flag-off, no-chat, and renders staged narration (§3 case).
- `tool-activity-summary.test.ts` — accumulated narration renders on the early open, not a bare "Working…".
- `turn-typing-loop.test.ts` — lifecycle: fires on start, refreshes every 4s, stops on turn-end with **no leaked interval**, restart self-heal, per-topic isolation, `stopAll`.
- Updated the structural oracles `feed-heartbeat-liveness-open.test.ts` + `emission-authority-facade.test.ts` for the moved liveness site + the new threshold default.

## Verification
- `tsc --noEmit` (full repo): clean.
- `npm run lint` (incl. plugin-references, bot-api-wrapping, bun-test-imports): clean.
- `bun test` on every touched + adjacent telegram-plugin suite (feed-open-gate, tool-activity-summary, turn-typing-loop, typing-wrap, feed-heartbeat-liveness-open, emission-authority-facade, emission-authority-open-gate, emission-authority-card-drain-gate, per-topic-current-turn, cross-turn-card-gate, subagent-watcher, gateway-bridge, progress-update): **all green**.
- Full `vitest run`: the telegram-plugin half I touch is green. The remaining failures are pre-existing, environment-dependent, and unrelated to this change (host-control docker socket, static-binary compile artifact, auth-broker on-disk claude binary, python-deps `EACCES` in the sandbox). The two telegram-plugin fuzz suites (`pending-inbound-buffer`, `worker-feed-dispatch`, `obligation-determinism`) that "failed" under the 4-fork parallel vitest budget pass cleanly in the bun runner (318k assertions) — they belong in the bun runner per `bun:sqlite`.
- Did **not** run the headless Telegram UAT (CI's uat-gate owns that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
