### PR TITLE
fix(web): stub missing Hermes Desktop endpoints (settings + profiles render crash)

### DIFF
--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -345,6 +345,14 @@ export async function handleHermesRest(
     if (pathname.includes("sessions")) {
       return { status: 200, body: { sessions: [], total: 0, limit: 0, offset: 0 } };
     }
+    // /api/profiles — ProfilesResponse: { profiles: ProfileInfo[] }
+    if (pathname === "/api/profiles") {
+      return { status: 200, body: { profiles: [] } };
+    }
+    // /api/profiles/:name/soul — { content: string; exists: boolean }
+    if (pathname.endsWith("/soul")) {
+      return { status: 200, body: { content: "", exists: false } };
+    }
     return { status: 200, body: {} };
   }
 

--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -357,6 +357,21 @@ export async function handleHermesRest(
     return { status: 200, body: { cwd: null, branch: null } };
   }
 
+  // GET /api/env — API keys / env-var panel; no agent env vars to surface
+  if (method === "GET" && pathname === "/api/env") {
+    return { status: 200, body: {} };
+  }
+
+  // POST /api/providers/validate — credential check; switchroom has no API keys
+  if (method === "POST" && pathname === "/api/providers/validate") {
+    return { status: 200, body: { ok: true, model: null } };
+  }
+
+  // GET /api/auth/providers — OAuth provider listing (only needed in OAuth mode)
+  if (method === "GET" && pathname === "/api/auth/providers") {
+    return { status: 200, body: { providers: [] } };
+  }
+
   return null;
 }
 


### PR DESCRIPTION
## Summary

- Three settings-panel endpoints returning 404 → now stubbed (settings lazy, not boot-critical):
  - `GET /api/env` → `{}` (no API keys to surface)
  - `POST /api/providers/validate` → `{ok:true, model:null}`
  - `GET /api/auth/providers` → `{providers:[]}`
- `GET /api/profiles` returned `{}` instead of `{profiles:[]}` → **render crash** on first paint after remote backend connected (`TypeError: Cannot read properties of undefined (reading 'length')`). Fixed to return `{profiles:[]}`.
- `GET /api/profiles/:name/soul` → `{content:'',exists:false}` stub.

## Why

Discovered via headless Electron boot test on Linux against the live switchroom web server. Backend connected successfully but the React renderer crashed on first paint because `ProfilesResponse.profiles` was `undefined`.

## Test plan

- [x] Bun test suite: 5106 pass, 0 fail
- [x] Hermes Desktop boot log: 'Remote Hermes backend is ready' then no render-process-gone crash