### PR TITLE
fix(plugin): retire the "no update from agent" stall stop-gap

### DIFF
--- a/reference/rfcs/conversational-pacing.md
+++ b/reference/rfcs/conversational-pacing.md
@@ -100,13 +100,14 @@ fallbackFired, inFlightTools }`. Polled every 5s.
 
 | Threshold | Action | Wire |
 |---|---|---|
-| 300s | Framework fallback: gateway sends a user-visible *"still working… (no update from agent in N min)"* or *"still thinking…"* **and** unwedges the turn (clears `activeTurnStartedAt`, nulls `currentTurn`, drains buffered inbound). Pings once. | `silencePoke.startTimer.onFrameworkFallback` callback |
+| 300s | Framework fallback: gateway **unwedges the turn** (clears `activeTurnStartedAt`, nulls `currentTurn`, drains buffered inbound). The generic *"still working… (no update from agent in N min)"* / *"still thinking…"* stall message is **no longer sent** — it was a stop-gap from before the live-updating draft carried the progress beats natively, and is the exact cadence-based "still working" update the Anti-patterns section bans (retired in the stall-stop-gap PR). The fallback now sends a user-visible message in only two honest cases: an in-flight `update_apply` carries hostd's real phase/elapsed, or the turn is parked on an approval card (the loud *"waiting for your approval — tap Approve or Deny…"* re-ping). The `silence_poke_fire` event is still logged regardless, so observability + the wedge accounting are unchanged. | `silencePoke.startTimer.onFrameworkFallback` callback |
 
 The fallback fires purely on the silence clock — `now -
 (lastOutboundAt ?? turnStartedAt) >= 300s` — and once per turn
 (`fallbackFired`). It is **not a nudge**: it does not append a
 `<system-reminder>` hoping the model will speak; it speaks *for* the
-framework and breaks the wedge. That unwedge is the one job the
+framework (only when there's something honest to say — see the two
+cases above) and breaks the wedge. That unwedge is the one job the
 live-updating draft genuinely can't do (a turn that produced no
 output at all has no draft to watch), which is why this single beat
 survived the nudge-ladder retirement (see the blockquote under "Three
@@ -117,19 +118,19 @@ clock, so a turn that's visibly composing never trips it.
 update `lastThinkingAt`. If the framework fallback fires within 30s
 of a thinking event, wording switches to *"still thinking…"*.
 
-**Tool-aware enrichment (#1292):** the gateway tracks in-flight tools
-in `inFlightTools` (`noteToolStart` / `noteToolEnd` / `noteToolLabel`
-off the session stream). When the fallback fires, it names the
-longest-running tool — *"running Grep \"foo\" for 4m"* — instead of
-the generic string. Tool churn enriches the *text* only; it never
-moves the 300s timing.
+**Tool-aware enrichment (#1292) — retired with the stall notice.** The
+gateway still tracks in-flight tools in `inFlightTools`
+(`noteToolStart` / `noteToolEnd` / `noteToolLabel` off the session
+stream) for metrics, but the *"running Grep \"foo\" for 4m"* enrichment
+of the stall message is gone along with the stall message itself: a
+timer-fired tool-narration ping is the same banned cadence-based update.
+Tool churn never moved the 300s timing and still doesn't.
 
 **Wording is load-bearing.** Exact strings live in
-`silence-poke.ts:formatFrameworkFallbackText`. The parenthetical
-*"(no update from agent in N min)"* is honest — it distinguishes the
-framework speaking from "the agent said something", so users learn to
-trust real agent messages. N is derived from `ctx.silenceMs`, not
-hard-coded.
+`silence-poke.ts:formatFrameworkFallbackText`, which now returns `null`
+for every stall variant (the stop-gap is retired) and a string only for
+the approval-blocked re-ping. The parenthetical *"(N min)"* on that
+re-ping is honest — N is derived from `ctx.silenceMs`, not hard-coded.
 
 **Kill switch:** `SWITCHROOM_DISABLE_SILENCE_POKE=1` disables the
 whole subsystem. The conversational-pacing prompt still applies; only

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5612,11 +5612,14 @@ function ensureIssuesCard(chatId: string, threadId: number | undefined): void {
 
 // #1122: framework safety-net for "model is silent to the user for >5min."
 // Starts a single setInterval poll that walks active turns; at 300s of
-// silence the framework itself sends a user-visible "still working… /
-// still thinking…" message AND unwedges the turn. The model-targeted
-// nudge ladder (ack/soft/firm) and the 60s awareness ping were retired
-// once the live-updating reply/draft took over the pacing job — only
-// this single unwedge fallback remains. Honours
+// silence the framework unwedges the turn. The generic "still working… /
+// still thinking…" stall message it used to send was a stop-gap from
+// before the live draft carried the progress beats and has been retired
+// (the stall-stop-gap PR) — the surviving user-visible sends are the
+// deterministic update_apply phase line and the approval-blocked re-ping.
+// The model-targeted nudge ladder (ack/soft/firm) and the 60s awareness
+// ping were retired earlier once the live-updating reply/draft took over
+// the pacing job — only this single unwedge fallback remains. Honours
 // SWITCHROOM_DISABLE_SILENCE_POKE=1 kill switch (no-op if set).
 // Set when this gateway dispatches an `update_apply` to hostd that
 // returns `started`; cleared when the dispatch poll resolves (terminal
@@ -5752,6 +5755,14 @@ silencePoke.startTimer({
       ctx.inFlightTools,
       blockedOnApproval,
     )
+    // The stall-notice stop-gap is retired: `formatFrameworkFallbackText`
+    // returns null for the pure-liveness "still working / running <Tool>"
+    // beat (the only string it still emits is the approval-blocked re-ping).
+    // The early quiet floor beat existed ONLY to surface that stall notice, so
+    // with the notice gone there is nothing to send here unless the turn is
+    // parked on an approval card. Skip silently otherwise; the live draft +
+    // the model's own pacing beats carry progress.
+    if (text == null) return
     try {
       await robustApiCall(
         () => bot.api.sendMessage(ctx.chatId, text, {
@@ -5849,7 +5860,10 @@ silencePoke.startTimer({
       )
     }
     // #2527: log the actual poke fire with structured data before sending,
-    // so the event is visible even if the send fails.
+    // so the event is visible even if the send fails. The stall-notice
+    // stop-gap is retired (the user-visible send below is now gated), but the
+    // fire event is still logged so observability + the unwedge accounting are
+    // unchanged — mirrors PR #2641 (drop the chat badge, keep the log).
     logStreamingEvent({
       kind: 'silence_poke_fire',
       chatId: ctx.chatId,
@@ -5857,24 +5871,34 @@ silencePoke.startTimer({
       silenceMs: ctx.silenceMs,
       fallbackKind: ctx.fallbackKind,
     })
-    try {
-      await robustApiCall(
-        () => bot.api.sendMessage(ctx.chatId, text, {
-          ...(ctx.threadId != null ? { message_thread_id: ctx.threadId } : {}),
-          // Conditional: the pure-liveness "still working…" notice is a status
-          // surface and stays SILENT. But when the turn is parked on an
-          // approval card, this same fallback carries a user-gating re-ping
-          // ("waiting for your approval — tap Approve or Deny …") — that must
-          // PING, because the user is the one being waited on. Gate on the same
-          // `blockedOnApproval` signal that selects the re-ping text above.
-          disable_notification: blockedOnApproval ? false : true,
-        }),
-        { chat_id: ctx.chatId, ...(ctx.threadId != null ? { threadId: ctx.threadId } : {}) },
-      )
-    } catch (err) {
-      process.stderr.write(
-        `silence-poke fallback sendMessage failed chat=${ctx.chatId} thread=${ctx.threadId}: ${err}\n`,
-      )
+    // Send a user-visible message ONLY when there's something honest to say:
+    //   - a deterministic in-flight update_apply phase (`text` set above), or
+    //   - the approval-blocked re-ping (`formatFrameworkFallbackText` returns a
+    //     string only for that case).
+    // The generic "still working… (no update from agent in N min)" stall notice
+    // is retired — `formatFrameworkFallbackText` returns null for it, so `text`
+    // stays null and we skip the send. The turn-teardown below (the unwedge —
+    // the one job the live draft can't do, per the conversational-pacing RFC)
+    // still runs unconditionally.
+    if (text != null) {
+      try {
+        await robustApiCall(
+          () => bot.api.sendMessage(ctx.chatId, text, {
+            ...(ctx.threadId != null ? { message_thread_id: ctx.threadId } : {}),
+            // Conditional: when the turn is parked on an approval card, this
+            // fallback carries a user-gating re-ping ("waiting for your
+            // approval — tap Approve or Deny …") — that must PING, because the
+            // user is the one being waited on. The deterministic update-status
+            // line stays SILENT (a status surface). Gate on `blockedOnApproval`.
+            disable_notification: blockedOnApproval ? false : true,
+          }),
+          { chat_id: ctx.chatId, ...(ctx.threadId != null ? { threadId: ctx.threadId } : {}) },
+        )
+      } catch (err) {
+        process.stderr.write(
+          `silence-poke fallback sendMessage failed chat=${ctx.chatId} thread=${ctx.threadId}: ${err}\n`,
+        )
+      }
     }
     // #1122 follow-up: end the wedged turn AFTER the fallback fires.
     // Without this, `activeTurnStartedAt` stays set, every subsequent

--- a/telegram-plugin/silence-poke.ts
+++ b/telegram-plugin/silence-poke.ts
@@ -377,17 +377,20 @@ export function silenceMsForKey(key: string, now: number): number | null {
 }
 
 /**
- * Verbatim framework-fallback text — the user-visible "still working / still
- * thinking" message the gateway sends at the 300s threshold when the model
- * hasn't broken its own silence. Wording is load-bearing (see
- * `reference/rfcs/conversational-pacing.md` § Safety net). Two principles:
+ * Framework-fallback text for the 300s silence threshold. Returns `null` for
+ * the pure-stall cases (the "still working / still thinking" / "running <Tool>
+ * for Nm" notice) — that timer-fired stall ping was a stop-gap from before the
+ * live-updating reply/draft carried the progress beats natively, and the
+ * operator has retired it (it's the exact cadence-based "still working" update
+ * the conversational-pacing RFC's Anti-patterns section bans). The 300s
+ * fallback's surviving job — unwedging a turn that produced no output at all —
+ * is the gateway's turn-teardown after this call, NOT a user-visible message,
+ * so dropping the stall send keeps the safety net's real work intact (see
+ * `reference/rfcs/conversational-pacing.md` § Silence-poke fallback).
  *
- *   1. The parenthetical `(no update from agent in N min)` is honest —
- *      distinguishes from "the agent said something" so users learn to trust
- *      real agent messages. `N` is derived from `silenceMs`, never hard-coded.
- *   2. The verb is `working` by default, `thinking` only when the session
- *      stream has emitted a `kind: 'thinking'` event in the last 30s. Picked
- *      by the caller via `fallbackKind`; this helper just formats.
+ * The ONE case that still returns a string is `blockedOnApproval`: the turn is
+ * parked on an approval card waiting for YOUR tap. That is not a stall — it
+ * tells the user the ball is in their court — so it keeps pinging.
  *
  * Extracted from the gateway's `onFrameworkFallback` callback so the wording
  * can be snapshot-tested in isolation. CC-4 in `docs/status-ask-cause-classes.md`.
@@ -397,73 +400,27 @@ export function formatFrameworkFallbackText(
   silenceMs: number,
   inFlightTools: ToolSnapshot[] = [],
   blockedOnApproval = false,
-): string {
+): string | null {
   const minutes = Math.max(1, Math.round(silenceMs / 60_000))
   // The turn isn't stalled — it's parked on an approval card waiting for YOUR
   // tap (the dominant live "wedge" class is benign approval-latency, not a
   // hang). Saying "still working…" here actively lies; name the real blocker so
   // the operator knows the ball is in their court. Takes precedence over the
-  // in-flight-tool framing (a tool awaiting approval isn't "running").
+  // in-flight-tool framing (a tool awaiting approval isn't "running"). This is
+  // the only branch that still emits a user-visible message.
   if (blockedOnApproval) {
     return `waiting for your approval — tap Approve or Deny on the card above (${minutes} min)`
   }
-  const suffix = `(no update from agent in ${minutes} min)`
-  // #1292 case (a): tools in flight. Name the longest-running one
-  // (entry[0] — caller pre-sorts by startedAt ascending). Avoid the
-  // "still working" framing #1292 explicitly calls out as dishonest:
-  // the agent IS doing work, we can see the tool. Format:
-  //   running Grep "foo" for 4m (no update from agent in 5 min)
-  //   running Grep "foo" + 2 more (4m) (no update from agent in 5 min)
-  //   running Grep (no label) for 4m (no update from agent in 5 min)
-  //
-  // Raw MCP tool names (`mcp__server__tool`) are technical identifiers
-  // and look like a leak when surfaced to a user. When the tool name
-  // matches that shape AND a human-friendly label is available, drop
-  // the raw name and lead with the label instead:
-  //   Searching memory for 4m (no update from agent in 5 min)
-  // Built-in tool names (Grep, Read, Bash) stay as-is — they ARE
-  // human-readable, and the label is supplementary detail (e.g. the
-  // search pattern) that reads naturally after the verb.
-  if (inFlightTools.length > 0) {
-    const longest = inFlightTools[0]!
-    const dur = formatDurationShort(longest.durationMs)
-    const labelTail = longest.label && longest.label.length > 0
-      ? ` ${truncateLabel(longest.label)}`
-      : ''
-    const more = inFlightTools.length > 1
-      ? ` + ${inFlightTools.length - 1} more`
-      : ''
-    const isMcpRawName = /^mcp__/.test(longest.name)
-    if (isMcpRawName && labelTail !== '') {
-      // Label-only: "Searching memory for 4m (…)". Drop the raw
-      // `mcp__server__tool` and the leading "running" because the
-      // label already reads as a gerund phrase.
-      return `${truncateLabel(longest.label!)}${more} for ${dur} ${suffix}`
-    }
-    return `running ${longest.name}${labelTail}${more} for ${dur} ${suffix}`
-  }
-  return fallbackKind === 'thinking'
-    ? `still thinking… ${suffix}`
-    : `still working… ${suffix}`
-}
-
-/** Compact m/s rendering for the fallback message. Anything under a
- *  minute reads as `${s}s`, otherwise `${m}m`. Always rounds toward the
- *  user-honest direction — "4m" for 4m 30s, "5m" for 4m 45s. */
-function formatDurationShort(ms: number): string {
-  const totalSec = Math.max(0, Math.round(ms / 1000))
-  if (totalSec < 60) return `${totalSec}s`
-  const minutes = Math.round(totalSec / 60)
-  return `${minutes}m`
-}
-
-/** Telegram lines are short on mobile. Clip the label to keep the
- *  fallback message readable. Truncation point is generous (60 chars)
- *  because tool labels are pre-truncated by `toolLabel()` already. */
-function truncateLabel(label: string): string {
-  const MAX = 60
-  if (label.length <= MAX) return label
-  return label.slice(0, MAX - 1) + '…'
+  // Stop-gap retired: the "still working… (no update from agent in N min)" /
+  // "running <Tool> for Nm" stall notice (including the #1292 tool-aware
+  // enrichment) no longer sends. The live draft + the model's own pacing beats
+  // carry progress; a timer-fired stall ping on top of that is the banned
+  // cadence-based update. `fallbackKind` and `inFlightTools` are now unused for
+  // the stall path but kept on the signature so the gateway's call sites — and
+  // the deterministic update-status / unwedge paths around them — are untouched.
+  void fallbackKind
+  void inFlightTools
+  return null
 }
 
 /** Snapshot in-flight tools sorted longest-running first — for the honest

--- a/telegram-plugin/tests/silence-poke.test.ts
+++ b/telegram-plugin/tests/silence-poke.test.ts
@@ -251,80 +251,52 @@ describe('silence-poke — #1292 tool-aware framework fallback', () => {
     expect(ctx.inFlightTools[0]!.durationMs).toBe(305_000 - 30_000)
   })
 
-  it('formatFrameworkFallbackText names the longest-running tool with duration', () => {
-    const text = formatFrameworkFallbackText('working', 305_000, [
-      { name: 'Grep', label: '"foo"', durationMs: 275_000 },
-    ])
-    expect(text).toBe(
-      'running Grep "foo" for 5m (no update from agent in 5 min)',
-    )
-  })
+  // The "no update from agent in N min" stall notice is a retired stop-gap
+  // (operator: obsolete now that the live draft + the model's own pacing beats
+  // carry progress). `formatFrameworkFallbackText` now returns null for every
+  // stall variant — the generic "still working / still thinking" notice AND the
+  // #1292 tool-aware enrichment — so the gateway sends nothing for a plain
+  // stall (it still runs the unwedge teardown). Only `blockedOnApproval`
+  // still produces a user-visible string. The tests below pin that contract.
 
-  it('multiple in-flight tools render as "+ N more"', () => {
-    const text = formatFrameworkFallbackText('working', 305_000, [
-      { name: 'Grep', label: '"foo"', durationMs: 275_000 },
-      { name: 'Read', label: 'config.ts', durationMs: 120_000 },
-      { name: 'Bash', label: null, durationMs: 60_000 },
-    ])
-    expect(text).toBe(
-      'running Grep "foo" + 2 more for 5m (no update from agent in 5 min)',
-    )
-  })
-
-  it('tool with no label renders the bare name', () => {
-    const text = formatFrameworkFallbackText('working', 305_000, [
-      { name: 'Bash', label: null, durationMs: 305_000 },
-    ])
-    expect(text).toBe(
-      'running Bash for 5m (no update from agent in 5 min)',
-    )
-  })
-
-  it('raw mcp__ tool name with a human label drops the technical name and leads with the label', () => {
-    // mcp__hindsight__reflect is the internal MCP identifier — looks
-    // like a leak when surfaced to a user. The label table emits
-    // "Searching memory" for it (see hooks/tool-label-pretool.mjs);
-    // the fallback message should lead with the label, not concatenate
-    // both.
-    const text = formatFrameworkFallbackText('working', 305_000, [
-      { name: 'mcp__hindsight__reflect', label: 'Searching memory', durationMs: 305_000 },
-    ])
-    expect(text).toBe(
-      'Searching memory for 5m (no update from agent in 5 min)',
-    )
-  })
-
-  it('raw mcp__ tool name with NO label falls back to the bare name (no leak-but-no-better-option)', () => {
-    const text = formatFrameworkFallbackText('working', 305_000, [
-      { name: 'mcp__some-third-party__do_thing', label: null, durationMs: 305_000 },
-    ])
-    expect(text).toBe(
-      'running mcp__some-third-party__do_thing for 5m (no update from agent in 5 min)',
-    )
-  })
-
-  it('built-in tool (Grep) with a label keeps the prior "running Name label" shape — name is already human-readable', () => {
-    const text = formatFrameworkFallbackText('working', 305_000, [
-      { name: 'Grep', label: 'foo', durationMs: 305_000 },
-    ])
-    expect(text).toBe(
-      'running Grep foo for 5m (no update from agent in 5 min)',
-    )
-  })
-
-  it('empty inFlightTools falls back to the base "still working" wording', () => {
+  it('stall notice (in-flight tool) returns null — no user-visible send', () => {
     expect(
-      formatFrameworkFallbackText('working', 305_000, []),
-    ).toBe('still working… (no update from agent in 5 min)')
-    expect(
-      formatFrameworkFallbackText('thinking', 305_000, []),
-    ).toBe('still thinking… (no update from agent in 5 min)')
-    expect(
-      formatFrameworkFallbackText('working', 305_000),
-    ).toBe('still working… (no update from agent in 5 min)')
+      formatFrameworkFallbackText('working', 305_000, [
+        { name: 'Grep', label: '"foo"', durationMs: 275_000 },
+      ]),
+    ).toBeNull()
   })
 
-  it('blockedOnApproval names the real blocker instead of the dishonest "still working…"', () => {
+  it('stall notice (multiple in-flight tools) returns null', () => {
+    expect(
+      formatFrameworkFallbackText('working', 305_000, [
+        { name: 'Grep', label: '"foo"', durationMs: 275_000 },
+        { name: 'Read', label: 'config.ts', durationMs: 120_000 },
+        { name: 'Bash', label: null, durationMs: 60_000 },
+      ]),
+    ).toBeNull()
+  })
+
+  it('stall notice (raw mcp__ tool, with or without label) returns null', () => {
+    expect(
+      formatFrameworkFallbackText('working', 305_000, [
+        { name: 'mcp__hindsight__reflect', label: 'Searching memory', durationMs: 305_000 },
+      ]),
+    ).toBeNull()
+    expect(
+      formatFrameworkFallbackText('working', 305_000, [
+        { name: 'mcp__some-third-party__do_thing', label: null, durationMs: 305_000 },
+      ]),
+    ).toBeNull()
+  })
+
+  it('generic stall notice (empty inFlightTools, working AND thinking) returns null', () => {
+    expect(formatFrameworkFallbackText('working', 305_000, [])).toBeNull()
+    expect(formatFrameworkFallbackText('thinking', 305_000, [])).toBeNull()
+    expect(formatFrameworkFallbackText('working', 305_000)).toBeNull()
+  })
+
+  it('blockedOnApproval still names the real blocker (the one surviving user-visible send)', () => {
     expect(
       formatFrameworkFallbackText('working', 305_000, [], true),
     ).toBe('waiting for your approval — tap Approve or Deny on the card above (5 min)')
@@ -338,18 +310,10 @@ describe('silence-poke — #1292 tool-aware framework fallback', () => {
     ).toBe('waiting for your approval — tap Approve or Deny on the card above (5 min)')
   })
 
-  it('blockedOnApproval=false keeps the existing wording (default, back-compat)', () => {
+  it('blockedOnApproval=false is a stall → returns null (stop-gap retired)', () => {
     expect(
       formatFrameworkFallbackText('working', 305_000, [], false),
-    ).toBe('still working… (no update from agent in 5 min)')
-  })
-
-  it('tool-aware wording wins over "thinking" — the actual observable beats the inferred kind', () => {
-    const text = formatFrameworkFallbackText('thinking', 305_000, [
-      { name: 'Grep', label: '"foo"', durationMs: 305_000 },
-    ])
-    expect(text.startsWith('running Grep')).toBe(true)
-    expect(text).not.toContain('still thinking')
+    ).toBeNull()
   })
 
   it('tool completed before the fallback → empty snapshot → base wording', () => {
@@ -450,22 +414,21 @@ describe('silence-poke — #1292 tool-aware framework fallback', () => {
     expect(__getStateForTests('k')!.inFlightTools.size).toBe(0)
   })
 
-  it('formatFrameworkFallbackText sub-minute durations render as "Ns"', () => {
-    const text = formatFrameworkFallbackText('working', 305_000, [
-      { name: 'Grep', label: 'foo', durationMs: 12_000 },
-    ])
-    expect(text).toBe(
-      'running Grep foo for 12s (no update from agent in 5 min)',
-    )
-  })
-
-  it('formatFrameworkFallbackText truncates very long labels', () => {
+  it('in-flight tool stall (any duration/label) returns null — stop-gap retired', () => {
+    // Previously rendered "running Grep foo for 12s (…)" / truncated long
+    // labels. The whole tool-aware stall enrichment is gone now, so the
+    // duration + label formatting paths no longer surface — they return null.
+    expect(
+      formatFrameworkFallbackText('working', 305_000, [
+        { name: 'Grep', label: 'foo', durationMs: 12_000 },
+      ]),
+    ).toBeNull()
     const longLabel = '"' + 'x'.repeat(120) + '"'
-    const text = formatFrameworkFallbackText('working', 305_000, [
-      { name: 'Grep', label: longLabel, durationMs: 305_000 },
-    ])
-    expect(text.length).toBeLessThan(120)
-    expect(text).toContain('…')
+    expect(
+      formatFrameworkFallbackText('working', 305_000, [
+        { name: 'Grep', label: longLabel, durationMs: 305_000 },
+      ]),
+    ).toBeNull()
   })
 })
 
@@ -528,38 +491,38 @@ describe('silence-poke — fallback handler errors do not break timer', () => {
 })
 
 // CC-4 from `docs/status-ask-cause-classes.md`: wording is load-bearing
-// (`reference/rfcs/conversational-pacing.md` § Safety net). Snapshot the exact
-// strings here so a refactor that drops a key phrase fails loud at test
-// time. If you genuinely need to change the wording, update the snapshot
-// AND the design doc together.
+// (`reference/rfcs/conversational-pacing.md` § Safety net). The stall notice is
+// a retired stop-gap — its wording is gone (returns null). The ONE surviving
+// user-visible string is the approval-blocked re-ping; snapshot it here so a
+// refactor that drops the phrase fails loud. The `N min` parenthetical is still
+// derived from silenceMs (honest), so pin that too.
 describe('silence-poke — wording snapshots (CC-4)', () => {
-  it('framework fallback — working at 300s', () => {
-    expect(formatFrameworkFallbackText('working', 300_000)).toMatchInlineSnapshot(
-      `"still working… (no update from agent in 5 min)"`,
+  it('framework fallback — generic stall (working/thinking) emits no message', () => {
+    expect(formatFrameworkFallbackText('working', 300_000)).toBeNull()
+    expect(formatFrameworkFallbackText('thinking', 300_000)).toBeNull()
+  })
+
+  it('approval-blocked re-ping — exact wording', () => {
+    expect(formatFrameworkFallbackText('working', 300_000, [], true)).toMatchInlineSnapshot(
+      `"waiting for your approval — tap Approve or Deny on the card above (5 min)"`,
     )
   })
 
-  it('framework fallback — thinking at 300s', () => {
-    expect(formatFrameworkFallbackText('thinking', 300_000)).toMatchInlineSnapshot(
-      `"still thinking… (no update from agent in 5 min)"`,
+  it('approval-blocked — minutes derived from silenceMs, not hard-coded', () => {
+    expect(formatFrameworkFallbackText('working', 360_000, [], true)).toBe(
+      'waiting for your approval — tap Approve or Deny on the card above (6 min)',
+    )
+    expect(formatFrameworkFallbackText('working', 600_000, [], true)).toBe(
+      'waiting for your approval — tap Approve or Deny on the card above (10 min)',
     )
   })
 
-  it('framework fallback — minutes derived from silenceMs, not hard-coded', () => {
-    expect(formatFrameworkFallbackText('working', 360_000)).toBe(
-      'still working… (no update from agent in 6 min)',
+  it('approval-blocked — minutes floor at 1 even when silenceMs is small', () => {
+    expect(formatFrameworkFallbackText('working', 30_000, [], true)).toBe(
+      'waiting for your approval — tap Approve or Deny on the card above (1 min)',
     )
-    expect(formatFrameworkFallbackText('working', 600_000)).toBe(
-      'still working… (no update from agent in 10 min)',
-    )
-  })
-
-  it('framework fallback — minutes floor at 1 even when silenceMs is small', () => {
-    expect(formatFrameworkFallbackText('working', 30_000)).toBe(
-      'still working… (no update from agent in 1 min)',
-    )
-    expect(formatFrameworkFallbackText('working', 0)).toBe(
-      'still working… (no update from agent in 1 min)',
+    expect(formatFrameworkFallbackText('working', 0, [], true)).toBe(
+      'waiting for your approval — tap Approve or Deny on the card above (1 min)',
     )
   })
 })


### PR DESCRIPTION
## Summary

Retires the 300s silence-poke **stall notice** — the user-visible *"still working… (no update from agent in N min)"* / *"still thinking…"* / *"running &lt;Tool&gt; for Nm"* message the gateway sent at the silence threshold. `formatFrameworkFallbackText` now returns `null` for every stall variant; the two send sites (`onFrameworkFallback`, `onMidTurnFloor`) skip the Telegram send when text is null.

## Why

Operator (project owner) asked for this directly: it's *"a stop gap"* that should be disabled now that real streaming status updates work. The live-updating reply/draft + the model's own pacing beats carry progress natively — a timer-fired *"still working"* ping on top of that is the exact **cadence-based update the `conversational-pacing.md` Anti-patterns section bans**.

## What's preserved (deliberately)

- **`blockedOnApproval` re-ping** — *"waiting for your approval — tap Approve or Deny on the card above (N min)"* still sends, and still **pings** (LOUD). This is NOT a stop-gap: it tells the user the ball is in their court. Untouched.
- **Deterministic `update_apply` phase line** — when this gateway dispatched an in-flight `update_apply`, the fallback still substitutes hostd's real phase + elapsed (the klanker-incident fix). Real status, not a stall — kept.
- **The unwedge** — the turn-teardown that clears `activeTurnStartedAt`, nulls `currentTurn`, and drains buffered inbound still runs **unconditionally** after the (now-usually-skipped) send. Per the RFC, breaking a turn that produced no output at all is the one job the live draft genuinely can't do, and is why this beat survived the nudge-ladder retirement.

## How it reconciles with `conversational-pacing.md`

Full-remove of the **message** (not a default-OFF flag) is the right cut, and it's consistent with the RFC rather than against it:

- The RFC's *Anti-patterns* explicitly bans *"Cadence-based 'still working' updates"* — the stall notice is exactly that.
- The RFC's *Safety net* row says the surviving job of the 300s fallback is the **unwedge**, and notes the live draft now carries the acknowledgement/progress beats. The unwedge is gateway turn-teardown, not a chat message — so dropping the message keeps the documented safety net fully intact.
- Mirrors **PR #2641** ("drop Telegram idle-clear notice, keep stderr log"): only the user-facing send is dropped; the `silence_poke_fire` structured event still logs, so observability + wedge accounting are unchanged.

Updated the RFC in the same PR (Silence-poke fallback table, tool-aware-enrichment paragraph, wording-is-load-bearing note) so the design doc matches the code.

Serves **`reference/jobs/know-what-my-agent-is-doing.md`** (`serves: hold-the-leash`): removing a dishonest/redundant status surface improves "the user can see what the agent is up to without asking" by not training them to distrust framework-spoken noise.

## Test plan

- [x] `telegram-plugin/tests/silence-poke.test.ts` rewritten to pin the new contract: every stall variant (generic working/thinking, in-flight tool, multi-tool, raw `mcp__` name, sub-minute/long-label) → `null`; `blockedOnApproval` → unchanged exact string with honest N-min derivation + floor-at-1. **48 tests pass under both vitest AND `bun test`.**
- [x] Related callers green: `turn-liveness-invariant`, `feed-survival`, `silence-liveness-wiring` (97 tests total).
- [x] `tsc --noEmit` clean.
- [x] `scripts/check-bot-api-wrapping.sh` clean (touched gateway.ts).

## Risk

Low. Behavior change is *fewer* outbound messages; no new send path. The unwedge and all approval/update-status sends are unchanged. The formatter's now-unused `fallbackKind`/`inFlightTools` params are retained on the signature (voided) so no call site moves. Removed two now-dead private helpers (`formatDurationShort`, `truncateLabel`) — no external callers. UAT `silent-end-recovery-dm` only asserts *some* reply lands (covered by the unwedge + model replies) and merely logs the fallback wording, so it stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)