### PR TITLE
fix(security): scan personal-skill bundles for secrets before write/mirror

### DIFF
--- a/src/cli/skill-common.ts
+++ b/src/cli/skill-common.ts
@@ -20,6 +20,14 @@
  */
 
 import { parse as parseYaml } from "yaml";
+// Genuine reuse of the maintained/tested detector that already backs the
+// Telegram inbound/outbound secret gate. The `telegram-plugin/` tree is
+// bun-bundled (not in tsconfig `include`), but src already imports across
+// this boundary the other direction (telegram-plugin/secret-detect/
+// vault-write.ts imports src/vault/broker/client.js), and tsc follows the
+// import edge, so this type-checks. Keep this the single detector — do not
+// fork the pattern list. See telegram-plugin/secret-detect/patterns.ts.
+import { detectSecrets } from "../../telegram-plugin/secret-detect/index.js";
 
 /** Per-agent skill cap (matches install cap). Not enforced in PR A. */
 export const MAX_SKILLS_PER_AGENT = 20;
@@ -370,4 +378,88 @@ export function validateSkillBundle(
   }
 
   return { ok: errors.length === 0, errors };
+}
+
+/**
+ * Human-readable names for detector rule ids, used in the refusal message.
+ * Falls back to the raw rule_id for any rule not listed here (so a new
+ * detector pattern still produces a sensible error without a code change).
+ */
+const SECRET_RULE_LABELS: Record<string, string> = {
+  anthropic_api_key: "Anthropic API key (sk-ant-…)",
+  anthropic_oauth_code: "Anthropic OAuth code",
+  openai_api_key: "API key (sk-…)",
+  github_pat_classic: "GitHub personal access token (ghp_…)",
+  github_pat_fine_grained: "GitHub fine-grained PAT (github_pat_…)",
+  slack_token: "Slack token (xox…)",
+  slack_app_token: "Slack app token (xapp-…)",
+  google_api_key: "Google API key (AIza…)",
+  aws_access_key: "AWS access key (AKIA…)",
+  aws_temp_access_key: "AWS temporary access key (ASIA…)",
+  jwt: "JWT",
+  pem_private_key: "PEM private-key block",
+  env_key_value: "KEY=value secret assignment",
+  json_secret_field: "JSON secret field",
+  bearer_auth_header: "Authorization: Bearer token",
+  bearer_loose: "Bearer token",
+  cli_flag: "secret CLI flag",
+  laravel_sanctum_token: "personal access token (id|token)",
+  telegram_bot_token: "Telegram bot token",
+  telegram_bot_token_prefixed: "Telegram bot token",
+  generic_high_entropy: "high-entropy string (likely a credential)",
+};
+
+/**
+ * Describes one secret-bearing file. Carries the rule label and offset, but
+ * NEVER the matched secret bytes — callers render this and the value must
+ * not leak into logs, mirrors, or the agent's chat transcript.
+ */
+export interface SecretScanFinding {
+  /** Skill-relative file path (e.g. "SKILL.md"). */
+  file: string;
+  /** Human-readable description of what matched. */
+  pattern: string;
+  /** Detector rule id (stable identifier for the matched pattern). */
+  rule_id: string;
+  /** Byte offset of the match within the file (for the operator to locate). */
+  offset: number;
+}
+
+/**
+ * Scan the FULL content of every file in a skill bundle for embedded
+ * secrets/credentials — SKILL.md body included, not just scripts. This is
+ * the security gate on the personal-skill write path: a secret pasted into
+ * a SKILL.md body would otherwise land on disk AND mirror into the
+ * operator's git config repo. The caller MUST fail closed (refuse the
+ * write, no mirror) on any finding.
+ *
+ * Reuses the maintained `detectSecrets` engine from
+ * telegram-plugin/secret-detect — including its high-entropy fallback
+ * (generic_high_entropy) for prefix-less generic keys — so the skill path
+ * stays in lock-step with the Telegram gate's coverage.
+ *
+ * The returned findings deliberately omit the matched secret value; only
+ * the file, rule, and offset are surfaced so the error can name the
+ * offending file + pattern without echoing the credential.
+ *
+ * TODO(#2670): PII rules (email/phone/address) are intentionally NOT run
+ * here yet — they await an operator decision on aggressiveness
+ * (false-positive risk). When that lands, route the PII rule set through
+ * detectSecrets (or a sibling detector) at this same call site; the
+ * fail-closed contract below already covers it as a clean drop-in.
+ */
+export function scanBundleForSecrets(files: SkillFileMap): SecretScanFinding[] {
+  const findings: SecretScanFinding[] = [];
+  for (const [file, content] of Object.entries(files)) {
+    if (typeof content !== "string" || content.length === 0) continue;
+    for (const d of detectSecrets(content)) {
+      findings.push({
+        file,
+        pattern: SECRET_RULE_LABELS[d.rule_id] ?? d.rule_id,
+        rule_id: d.rule_id,
+        offset: d.start,
+      });
+    }
+  }
+  return findings;
 }

--- a/src/cli/skill-personal.test.ts
+++ b/src/cli/skill-personal.test.ts
@@ -867,3 +867,153 @@ describe("clone-to-personal skips non-allowlisted source files (#1847)", () => {
     }, 2);
   });
 });
+
+// ─── Secret-scan gate (security fix: skill bodies were unscanned) ─────
+//
+// The personal-skill write path runs scanBundleForSecrets BEFORE writing
+// to disk and (therefore) before mirroring into the operator's config
+// repo. A secret embedded ANYWHERE in the bundle — SKILL.md body included,
+// not just scripts — must refuse the write with exit 3, name the offending
+// file + matched pattern, and never echo the secret value.
+//
+// Token fixtures are built by concatenation so this source file never
+// contains a contiguous real-looking token (GitHub Push Protection).
+describe("scanBundleForSecrets gate (init-personal)", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = tmpAgentsRoot();
+  });
+
+  afterEach(() => {
+    try { rmSync(root, { recursive: true, force: true }); } catch { /**/ }
+  });
+
+  // Capture both the exit code AND stderr so we can assert the message
+  // shape (names file, never leaks the secret).
+  function runCaptureExit(fn: () => void): { code: number | undefined; stderr: string } {
+    const origExit = process.exit.bind(process);
+    let caught: number | undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process as any).exit = (code?: number): never => {
+      caught = code;
+      throw new Error(`__test_exit_${code}__`);
+    };
+    let stderr = "";
+    const origErr = console.error;
+    console.error = (...args: unknown[]): void => {
+      stderr += args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" ") + "\n";
+    };
+    try {
+      try {
+        fn();
+      } catch (e: unknown) {
+        const err = e as { message?: string };
+        if (!err.message?.startsWith("__test_exit_")) throw e;
+      }
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (process as any).exit = origExit;
+      console.error = origErr;
+    }
+    return { code: caught, stderr };
+  }
+
+  function skillMdWithBody(name: string, body: string): string {
+    return `---\nname: ${name}\ndescription: A test skill\n---\n# ${name}\n\n${body}\n`;
+  }
+
+  function initWithBody(name: string, body: string): { code: number | undefined; stderr: string } {
+    const skillFile = join(root, "input.md");
+    writeFileSync(skillFile, skillMdWithBody(name, body));
+    return runCaptureExit(() => {
+      initPersonalAction(name, { agent: AGENT, from: skillFile, root });
+    });
+  }
+
+  // Fixtures: assembled at runtime so no contiguous token literal exists.
+  const SK_ANT = ["sk-ant-", "Apq13yqRnPzx4MxK0TfAbY98Qw22"].join("");
+  const GHP = ["ghp_", "Abcdef1234567890Abcdef1234567890abcd"].join("");
+  const AKIA = ["AKIA", "IOSFODNN7EXAMPLE"].join("");
+  const PEM = [
+    "-----BEGIN PRIVATE KEY-----",
+    "MIIBVwIBADANBgkqhkiG9w0BAQEFAASCAUEwggE9AgEAAkEA0Zm9abcdEFGHijkl",
+    "mnopQRSTuvwx0123456789ABCDefghIJKLmnopQRSTuvwx0123456789ABCDefgh",
+    "-----END PRIVATE KEY-----",
+  ].join("\n");
+  // Prefix-less high-entropy blob: ≥28 [A-Za-z0-9], ≥18 distinct, has a
+  // digit — exercises the generic_high_entropy fallback.
+  const HIGH_ENTROPY = ["a", "Z7", "qW3", "rT9bN2", "kL5pX8mC4vH1jD6sQ0fG"].join("");
+
+  const cases: Array<[string, string, RegExp]> = [
+    ["sk-ant token", `Here is my key ${SK_ANT} keep it safe`, /Anthropic API key/],
+    ["ghp token", `token: ${GHP}`, /GitHub personal access token/],
+    ["AKIA key", `aws id ${AKIA} done`, /AWS access key/],
+    ["PEM private key block", PEM, /PEM private-key block/],
+    ["prefix-less high-entropy key", `apikey ${HIGH_ENTROPY} end`, /high-entropy/],
+  ];
+
+  for (const [label, body, patternRe] of cases) {
+    it(`refuses a ${label} embedded in the SKILL.md body`, () => {
+      const { code, stderr } = initWithBody("secretskill", body);
+      // Fail closed.
+      expect(code).toBe(3);
+      // Names the offending file.
+      expect(stderr).toContain("SKILL.md");
+      // Names the matched pattern.
+      expect(stderr).toMatch(patternRe);
+      // Never echoes the secret value.
+      const secret = body.match(/[A-Za-z0-9_+/.=-]{16,}/g) ?? [];
+      // The longest token in the body is the secret payload; ensure no
+      // run of it appears in the error output.
+      for (const tok of secret) {
+        if (tok.length >= 20) expect(stderr).not.toContain(tok);
+      }
+      // The skill must NOT have landed on disk.
+      const target = join(root, AGENT, ".claude/skills/personal-secretskill");
+      expect(existsSync(target)).toBe(false);
+    });
+  }
+
+  it("PASSES a clean, normal skill (no false positive)", () => {
+    const body = [
+      "This skill formats a daily digest. It reads recent GitHub activity",
+      "and produces a summary. Use the run_digest helper and pass the",
+      "org-name and the get_user_profile_by_org lookup. No credentials live",
+      "in this file — fetch them with `switchroom vault get github/token`.",
+    ].join("\n");
+    const out = captureStdout(() => {
+      const skillFile = join(root, "clean.md");
+      writeFileSync(skillFile, skillMdWithBody("cleanskill", body));
+      initPersonalAction("cleanskill", { agent: AGENT, from: skillFile, root });
+    });
+    const parsed = JSON.parse(out);
+    expect(parsed.ok).toBe(true);
+    const target = join(root, AGENT, ".claude/skills/personal-cleanskill/SKILL.md");
+    expect(existsSync(target)).toBe(true);
+  });
+
+  it("a secret-bearing skill never reaches the mirror (config repo)", () => {
+    // Point the mirror at a real, existing tmpdir so mirrorToConfigRepo
+    // WOULD write there if it were ever reached. Pre-create the
+    // agents/<agent>/personal-skills path so the only reason it stays
+    // empty is the scan refusing before writePersonalSkill/mirror.
+    const mirrorRoot = mkdtempSync(join(tmpdir(), "skill-mirror-"));
+    const saved = process.env.SWITCHROOM_CONFIG_DIR;
+    process.env.SWITCHROOM_CONFIG_DIR = mirrorRoot;
+    const mirrorDir = join(mirrorRoot, "agents", AGENT, "personal-skills");
+    mkdirSync(mirrorDir, { recursive: true });
+    try {
+      const { code } = initWithBody("leakyskill", `key ${SK_ANT} here`);
+      expect(code).toBe(3);
+      // Nothing mirrored.
+      expect(readdirSync(mirrorDir)).toHaveLength(0);
+      // Nothing on disk either.
+      expect(existsSync(join(root, AGENT, ".claude/skills/personal-leakyskill"))).toBe(false);
+    } finally {
+      if (saved === undefined) delete process.env.SWITCHROOM_CONFIG_DIR;
+      else process.env.SWITCHROOM_CONFIG_DIR = saved;
+      try { rmSync(mirrorRoot, { recursive: true, force: true }); } catch { /**/ }
+    }
+  });
+});

--- a/src/cli/skill-personal.ts
+++ b/src/cli/skill-personal.ts
@@ -22,6 +22,12 @@
  * (`validateSkillBundle` covers name regex, path allowlist, SKILL.md
  * frontmatter, bundle size caps, and the `claude -p` content scan).
  *
+ * Security gate: `scanBundleForSecrets` (skill-common.ts) runs over the
+ * FULL content of EVERY file — SKILL.md body included — BEFORE the write
+ * and the config-repo mirror, failing closed (exit 3) on any embedded
+ * secret/credential so a pasted key never lands on disk or mirrors into
+ * the operator's git config repo.
+ *
  * Behavioural validation (`bash -n`, `python -m py_compile`) runs
  * synchronously per file; failures surface as structured CLI errors
  * the MCP wrapper renders back to the calling agent.
@@ -58,6 +64,7 @@ import {
   type SkillFileMap,
   validateRelPath,
   validateSkillBundle,
+  scanBundleForSecrets,
 } from "./skill-common.js";
 import { withConfigError } from "./helpers.js";
 import { appendAudit } from "./agent-config.js";
@@ -564,6 +571,30 @@ function loadValidateWrite(
     console.error(chalk.red("Behavioural validation failed:"));
     for (const e of behavioral) {
       console.error(chalk.red(`  - ${e}`));
+    }
+    process.exit(3);
+  }
+
+  // Security gate — scan the FULL content of every file (SKILL.md body
+  // included, not just scripts) for embedded secrets/credentials. This runs
+  // BEFORE writePersonalSkill and (therefore) before mirrorToConfigRepo in
+  // every caller, so a secret-bearing skill never lands on disk and never
+  // mirrors into the operator's git config repo. Fail closed on any hit; the
+  // message names the offending file + matched pattern but NEVER echoes the
+  // secret value itself.
+  // TODO(#2670): PII rules (email/phone/address) pending operator decision —
+  // they drop in at scanBundleForSecrets (see skill-common.ts) without
+  // changing this fail-closed wiring.
+  const secretFindings = scanBundleForSecrets(files);
+  if (secretFindings.length > 0) {
+    console.error(chalk.red("Secret scan failed — refusing to write skill:"));
+    for (const f of secretFindings) {
+      console.error(
+        chalk.red(
+          `  - ${f.file}: ${f.pattern} detected (at byte offset ${f.offset}). ` +
+          `Remove the secret from the skill content and use the vault instead.`,
+        ),
+      );
     }
     process.exit(3);
   }


### PR DESCRIPTION
## Summary

The personal-skill write path now scans the **full content of every file**
in a bundle (SKILL.md body included, not just `scripts/*`) for embedded
secrets/credentials, **before** the file is written and before it mirrors to
the operator's git config repo. On any hit it **fails closed** (exit 3) with
a message naming the offending file + matched pattern — never echoing the
secret value.

## Why (security)

Skill bodies were **unscanned**. The only content check was a `claude -p`
banned-phrase scan scoped to `scripts/*.{sh,py}`. A secret pasted into a
`SKILL.md` body:

1. landed on disk in the agent's workspace, and
2. **mirrored into the operator's `~/.switchroom-config` git repo** via
   `mirrorToConfigRepo` — a live plaintext-credential leak.

This also **gates #2670 (skill-synthesis-from-memory)**, which will write
skill bodies sourced from recall and must not be able to synthesize a secret
onto disk.

Serves `reference/jobs/approve-what-my-agent-can-touch.md` — *"approve what
my agent can touch, without ever leaking the secret"* (the raw credential
must never escape into a mirror/repo).

## What changed

- **`src/cli/skill-common.ts`** — `scanBundleForSecrets()` reuses the
  maintained `telegram-plugin/secret-detect` engine (`detectSecrets`), the
  same detector behind the Telegram inbound/outbound gate. **Genuine reuse,
  not a fork:** `src/` already imports across this boundary the other
  direction (`telegram-plugin/secret-detect/vault-write.ts` imports
  `src/vault/broker/client.js`) and tsc follows the import edge, so it
  type-checks without a tsconfig change. A rule→label map produces readable
  refusals.
- **`src/cli/skill-personal.ts`** — the scan runs inside `loadValidateWrite`
  after behavioural validation and **before** `writePersonalSkill`. Because
  `mirrorToConfigRepo` runs *after* `loadValidateWrite` in all three callers
  (init / edit / clone-to-personal), a secret-bearing skill can never reach
  the mirror.
- **MCP wrapper** relays the refusal unchanged — `dispatchTool` already
  surfaces a non-zero CLI exit's stderr as a clean error, and the message
  carries no secret value.

## High-entropy coverage

The prefix-less generic-key case is covered by the detector's existing,
tested `generic_high_entropy` fallback (`telegram-plugin/secret-detect/
generic-entropy.ts`): a `[A-Za-z0-9]{28,}` run with **≥18 distinct chars**
and **≥1 digit**. Those three composable filters are the false-positive
tuning — they break snake/kebab/path identifiers into sub-28 runs, exclude
hex/SHA (≤16 distinct) and CamelCase-without-digits, so normal skill prose
and code don't trip it. Reusing it keeps the skill path in lock-step with
the Telegram gate rather than introducing a second, drifting entropy heuristic.

## Covered vs deferred

- **Covered:** `sk-ant-`, `sk-`, `ghp_`, `github_pat_`, `AKIA`, `AIza`,
  `xox*`, JWT, `env_key_value`, `json_secret_field`, `bearer_*`, PEM
  private-key blocks, and prefix-less high-entropy keys — over **all** bundle
  files.
- **Deferred (intentional):** PII rules (email/phone/address) await an
  operator decision on aggressiveness (false-positive risk). The scan is
  structured so a PII rule set drops in at the same call site without
  changing the fail-closed wiring — `TODO(#2670)` markers left at both the
  scanner and the wiring point. No synthesis feature / approval card / cron
  here; that's the next PR.

## Test plan

`src/cli/skill-personal.test.ts` (vitest):
- [x] refuse `sk-ant-` token in a SKILL.md body
- [x] refuse `ghp_` token
- [x] refuse `AKIA…`
- [x] refuse a `-----BEGIN PRIVATE KEY-----` block
- [x] refuse a prefix-less high-entropy key (generic fallback)
- [x] a clean, normal skill **passes** (no false positive)
- [x] error names the file (`SKILL.md`) and **never** contains the secret value
- [x] a secret-bearing skill **never reaches the mirror** (config-repo dir stays empty) and never lands on disk

Local: `vitest run src/cli/skill-personal.test.ts` → 44 passed. Full
`npm run lint` (tsc + plugin-references + check-no-pii-secrets + all guards)
clean. Detector's own bun tests still green. Token fixtures are built by
runtime concatenation to satisfy GitHub Push Protection.

## Risk

Low. The scan only **adds** a refusal path on the write side; clean skills
are unaffected. The shared detector is unchanged (no behaviour change to the
Telegram gate). The high-entropy fallback's false-positive profile is the
already-tuned, already-shipping one. The new cross-module import is in the
direction tsc already resolves and is exercised by `npm run lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)