### PR TITLE
Telegram formatting bundle: paragraph normalizer, char-cap consistency, boot-injected formatting floor card

### DIFF
--- a/reference/telegram-formatting-guide.md
+++ b/reference/telegram-formatting-guide.md
@@ -1,0 +1,216 @@
+# Telegram formatting guide
+
+Two tiers:
+
+- **Floor card** — compact, boot-injected into every agent's system prompt
+  (`--append-system-prompt`, cached, model-independent). This is the deterministic
+  floor: every bot *knows* the toolkit and the craft, every session, with no model
+  in the loop deciding whether to load it.
+- **Depth reference** — this file in full, loaded on demand for edge cases
+  (the rich extras, escaping rules, chunking behaviour).
+
+The floor card teaches judgment, not a syntax menu. The model keeps its own call on
+what a given message needs; the card guarantees it knows what's available and why
+each tool exists.
+
+> **Single source of truth for the floor card.** The "FLOOR CARD (boot-injected)"
+> section below is kept VERBATIM in sync with the TypeScript constant
+> `TELEGRAM_FORMATTING_FLOOR_CARD` in `src/agents/scaffold.ts`, which is the
+> string actually injected into every agent's `--append-system-prompt`. This
+> `reference/*.md` file is NOT shipped into the agent image, so it can't be
+> imported at runtime — when you change the floor card, edit BOTH this section
+> and the constant together. (The constant's doc comment points back here.)
+
+---
+
+## FLOOR CARD (boot-injected)
+
+You're writing for a phone screen in Telegram. Every reply renders as rich Markdown
+(Bot API 10.1). Format to make the message **scannable and easy to read**, not
+decorated. These are communication tools — use them with judgment. Most short replies
+need none of them.
+
+### Mechanical rules (always)
+- Separate paragraphs with a blank line (`\n\n`). A single newline collapses onto the
+  same line and reads as a wall of text.
+- Keep paragraphs short — 1 to 4 lines. Break before the reader has to work for it.
+- Hard cap is 32768 characters. Long before that, ask whether a wall of text is the
+  right answer at all.
+
+### The toolkit, and when to reach for each
+- **Bold** — the one key fact or the answer. Not every noun. If everything is bold,
+  nothing is.
+- *Italic* — light emphasis, asides, labels.
+- `code spans` — every identifier: filenames, commands, config keys, agent / account /
+  slot names, error codes. Tap-to-copy, and visually distinct from prose.
+- Code fences — multi-line output: diffs, logs, command blocks, JSON. Add a language
+  hint (` ```diff `, ` ```json `) when it sharpens the render.
+- Bulleted list — 3+ parallel items the reader will scan or compare. Never for a single
+  thought or a flowing narrative.
+- Numbered list — ordered steps or ranked items.
+- Tables — 2-D data only (rows × columns): per-account usage, status fields. Overkill
+  for a flat list.
+- Headings — only in a long, multi-section answer. Clutter on a short reply.
+- Blockquotes (`>`) — quoted text or indented continuation. Telegram drops leading
+  spaces, so use `>`, never literal indentation.
+- Dividers (`---`) — between genuinely separate sections. Heavy; use sparingly.
+
+### The why
+Structure exists for the reader, not the writer. A two-item bullet list is worse than a
+sentence. A heading on a three-line reply is noise. Reach for structure only when it
+**reduces the reader's effort** — parallel options, scannable data, ordered steps — and
+stay in prose when the thought is connected. When in doubt: shorter and plainer wins.
+
+---
+
+## DEPTH REFERENCE (on-demand)
+
+Everything below is for edge cases the floor card doesn't cover: the full rich
+vocabulary, the exact escaping rules, and the framework's send-time behaviour
+(chunking + the paragraph-break normalizer). The render path for every outbound
+message is `telegram-plugin/rich-send.ts` `richMessage(md)` → `{ markdown }` →
+`sendRichMessage` / `editMessageText({ markdown })` — one path, raw GFM markdown,
+Bot API 10.1 rich messages.
+
+### Full rich vocabulary
+
+**Inline spans**
+
+| Effect | Markdown | Notes |
+| --- | --- | --- |
+| Bold | `**text**` | The one key fact, not decoration. |
+| Italic | `*text*` or `_text_` | Light emphasis, labels, asides. |
+| Underline | `__text__` | Bot API 10.1 GFM extension. Use sparingly — reads like a link. |
+| Strikethrough | `~~text~~` | Retractions, "was X now Y". |
+| Spoiler | `\|\|text\|\|` | Hidden until tapped — surprises, long-answer punchlines. |
+| Highlight / marked | `==text==` | The `=` is an `escapeMarkdown` special, so dynamic text won't trigger it by accident. |
+| Inline code | `` `text` `` | Identifiers, tap-to-copy. Content is literal — no escaping inside. |
+| Subscript | `~text~` (single tilde) | Math/chemistry. Distinct from `~~strike~~` (double). |
+| Superscript | `^text^` | Footnote markers, exponents. |
+| Custom emoji | Telegram premium custom-emoji entity | Premium-only; renders as a normal emoji for non-premium viewers. Don't rely on it conveying meaning. |
+| Inline math | `$ … $` | LaTeX-style inline math (Bot API 10.1). |
+| Link | `[label](https://…)` | Standard GFM link. |
+
+**Block types**
+
+- **Code fence** — ` ```lang ` … ` ``` `. Multi-line literal output (diffs, logs, JSON,
+  command blocks). The language hint (`diff`, `json`, `bash`, …) sharpens syntax
+  rendering. Content inside is verbatim — never escape it; the only hazard is an
+  embedded ` ``` ` closing the block early (see `preBlock` in `shared/bot-runtime.ts`,
+  which defuses that).
+- **Bulleted list** — `- item` (also `*` / `+`). 3+ parallel items only.
+- **Numbered list** — `1. item`. Ordered steps or ranked items.
+- **Table** — GFM pipe table (`| col | col |` + `| --- | --- |` separator). 2-D data
+  only. Chunk-safe — `splitMarkdownChunks` never bisects a row.
+- **Blockquote** — `> quoted`. Quoted text or indented continuation; the right way to
+  indent because Telegram drops leading whitespace.
+- **Pull-quote / expandable blockquote** — `**> …`** (Bot API 10.1 expandable
+  blockquote). A long quote the reader can collapse/expand.
+- **Section heading** — `#` … `######`. Only in a genuinely long, multi-section answer.
+- **Preformatted block** — a code fence with no language, for fixed-width non-code
+  (ASCII tables, aligned columns).
+- **Details / collapsible** — Bot API 10.1 collapsible section. For optional depth the
+  reader can expand (full logs under a one-line summary).
+- **Collage / slideshow** — multiple images grouped in one message (album / media
+  group). Send via the attachment path, not markdown.
+- **Divider** — `---` (thematic break). Heavy horizontal rule between genuinely
+  separate sections. Use sparingly.
+- **Footnotes** — GFM `[^1]` reference + `[^1]: …` definition.
+
+> Reach for the exotic spans (spoiler, sub/superscript, highlight, math, custom emoji)
+> only when they genuinely serve the reader. The floor card's "why" applies: structure
+> for the reader, not the writer.
+
+### Escaping rules
+
+Dynamic content (filenames, ids, arbitrary user text) interpolated into a hand-built
+markdown card must be escaped so it renders LITERALLY instead of being parsed as
+formatting. Use `escapeMarkdown(value)` from `telegram-plugin/format.ts`.
+
+`escapeMarkdown` escapes exactly the characters that trigger INLINE formatting in
+rich markdown — backslash, `` ` ``, `*`, `_`, `~`, `=`, `[`, `]`, `|` — i.e. the set
+`` \`*_~=[]| ``. The backslash is escaped first so it never double-escapes a following
+special.
+
+It deliberately does **not** escape `.` `-` `+` `#` `(` `)` `{` `}` `!` `>`: those are
+only meaningful at line-start (headings, lists, quotes) or in link/structure context,
+and escaping them mid-word would litter filenames (`foo.ts`), versions (`v1.2-rc`), and
+URLs with visible backslashes.
+
+Two consequences worth internalising:
+
+- **Bold/italic a dynamic value:** `` `**${escapeMarkdown(value)}**` ``.
+- **Code-span a dynamic value:** `` `\`${value}\`` `` — code spans need NO escaping,
+  because backtick content is already literal. This is the preferred way to render any
+  identifier safely.
+
+(The legacy `escapeHtmlForTg` name in `shared/bot-runtime.ts` is the same
+markdown-special escaper kept under the old name so callers don't churn — it is NOT
+HTML escaping any more.)
+
+### The 32768 chunking behaviour
+
+The rich-message wire cap is `RICH_MESSAGE_MAX_CHARS = 32768` (empirically exact:
+32768 accepted, 32769 → `RICH_MESSAGE_TEXT_TOO_LONG`). It is the single constant —
+never re-derive it.
+
+A body longer than the cap is split by `splitMarkdownChunks(text, maxLen = 32768)` in
+`telegram-plugin/format.ts` before send:
+
+- It cuts at the largest safe boundary `<= maxLen`, preferring a blank line, then a
+  single newline, then a space.
+- It **never bisects a fenced code block** — `backOffOpenFence` retreats the cut to
+  before an open ` ``` ` so a chunk never carries an unbalanced fence (an unterminated
+  fence would swallow the next chunk's text).
+- It **never bisects a table row** — `backOffTableRow` retreats to the start of any
+  line containing `|`, so a half-row never ships.
+- A single indivisible region larger than the cap (e.g. a giant fence with no interior
+  boundary) is emitted whole rather than looping forever — Telegram then rejects it,
+  which is louder and more debuggable than a hang.
+
+**Length-error recovery (send time).** If a single pre-computed chunk still exceeds the
+cap (the indivisible-region case above), Telegram answers with
+`RICH_MESSAGE_TEXT_TOO_LONG` / `MESSAGE_TOO_LONG`. This is classified as a LENGTH error
+(`isMessageTooLongError` in `retry-api-call.ts`, `isLengthError` in `rich-send.ts`) —
+distinct from a markdown-parse reject. The reply path re-splits the offending chunk and,
+as a last resort, `hardSliceToCap` cuts it on raw character count so every delivered
+piece is `<= 32768`. A length error is therefore never misclassified as a parse reject
+(which would resend the same oversized body as plain text) or surfaced raw.
+
+### The paragraph-break normalizer
+
+GFM (the rich render path) treats a LONE `\n` as a *soft* break: two lines collapse
+onto the same visual line. A model that separates paragraphs with a single newline
+would produce a cramped wall of text. (The old markdown→HTML path rendered every `\n`
+as a hard break, which masked the habit; the rich path no longer does.)
+
+`normalizeParagraphBreaks(text)` in `telegram-plugin/format.ts` fixes this
+deterministically, running on the outbound body right after `repairEscapedWhitespace`
+on the `reply`, `stream_reply`, and (non-literal) `edit_message` paths. On
+code-masked text it does exactly two things:
+
+1. **Collapse runs of 3+ newlines down to exactly `\n\n`** — never collapses a genuine
+   `\n\n` paragraph gap.
+2. **Promote a LONE `\n` into a GFM hard break (`  \n`, two trailing spaces)** — but
+   ONLY when it is a genuine prose paragraph break.
+
+The promotion heuristic is deliberately CONSERVATIVE — it prefers a **false negative**
+(leave a break un-promoted, two prose lines stay cramped) over a **false positive**
+(double-space a tight list or table). A break is promoted only when ALL hold:
+
+- The preceding line ends in sentence-terminal punctuation — `.`, `!`, `?`, `:`, or a
+  closing `)` / `"` / `'` / `’` / `”` / `]` that itself follows such a terminator
+  (e.g. `He said "go."`).
+- The preceding line is NOT itself a marker line.
+- The NEXT line starts with a non-marker character.
+
+A "marker line" (never reflowed around) is a list item (`-`/`*`/`+`/`1.`/`1)`, incl.
+indented), a table row (`|` or ` | `), a blockquote (`>`), an ATX heading (`#`), a code
+fence delimiter, a thematic break (`---`/`***`/`___`), or a standalone masked code
+block. Fenced code and inline code are masked out (shared `maskCodeRegions` masker, the
+same one `repairEscapedWhitespace` uses) before any of this runs, so their interior
+newlines are never touched.
+
+Net effect: prose paragraphs separated by a single newline get a real visual break,
+while lists, tables, code, and existing `\n\n` gaps are left exactly as the model wrote
+them. When in doubt, the normalizer leaves the break alone.

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -200,8 +200,10 @@ value back into chat.
 
 ### Formatting — make it scannable
 
-\`reply\` and \`stream_reply\` render Markdown as Telegram HTML for you, so
-\`**bold**\` becomes bold and backtick-wrapped text becomes monospace. Use it.
+\`reply\` and \`stream_reply\` render rich Markdown (Bot API 10.1) for you, so
+\`**bold**\` becomes bold and backtick-wrapped text becomes monospace. Your full
+formatting floor card — the toolkit and when to reach for each — is injected
+into your system prompt every session; this is the conversational summary.
 
 - **A one- or two-line conversational reply needs almost no markup.** Keep
   bold for the single fact that matters, never for decoration. "on it, pulling
@@ -223,11 +225,9 @@ value back into chat.
   • flag anything user-facing
 
   **Back in** ~2 min with a synthesized summary.
-- Bullets stay one level deep — Telegram flattens nested lists awkwardly. Use
-  backtick-wrapped \`inline code\` for filenames, commands, and identifiers.
-- Don't use Markdown headings (\`#\` / \`##\`) in a reply — bold the label
-  instead (\`**Blockers**\`, not \`## Blockers\`). Keep lines short; long
-  unwrapped lines are hard to read on a phone.
+- Use backtick-wrapped \`inline code\` for filenames, commands, and
+  identifiers. Keep lines short; long unwrapped lines are hard to read on a
+  phone.
 
 Every turn that answers a user message ends with a user-visible
 \`reply\` (or \`stream_reply\` done=true) — Telegram is all the user
@@ -339,6 +339,65 @@ belongs in plain config, not the vault. If a tool call is **blocked for
 containing a vaulted secret**, report that exact block message to the
 operator and stop — don't theorise about auth or tokens; it just means
 a stored value reached a tool argument.`;
+
+/**
+ * The Telegram formatting FLOOR CARD — boot-injected into EVERY agent's
+ * `claude` session via `--append-system-prompt` (model-independent, present
+ * in every session, see `systemPromptAppendShellQuoted` below). This is the
+ * deterministic floor: every bot knows the rich-Markdown toolkit and the craft
+ * of formatting for a phone screen, with no model in the loop deciding whether
+ * to load it.
+ *
+ * SINGLE SOURCE OF TRUTH. The depth reference doc
+ * `reference/telegram-formatting-guide.md` quotes this text VERBATIM in its
+ * "FLOOR CARD (boot-injected)" section (Ken approved this wording). The doc
+ * is a `reference/*.md` file NOT shipped into the agent image, so it cannot
+ * be imported at runtime — keep the two in sync by hand, and update both
+ * together. The guide's comment points back here.
+ *
+ * Keep it COMPACT — it is cached in every agent's prompt prefix.
+ */
+const TELEGRAM_FORMATTING_FLOOR_CARD = `## Formatting for Telegram
+
+You're writing for a phone screen in Telegram. Every reply renders as rich Markdown
+(Bot API 10.1). Format to make the message **scannable and easy to read**, not
+decorated. These are communication tools — use them with judgment. Most short replies
+need none of them.
+
+### Mechanical rules (always)
+- Separate paragraphs with a blank line (\`\\n\\n\`). A single newline collapses onto the
+  same line and reads as a wall of text.
+- Keep paragraphs short — 1 to 4 lines. Break before the reader has to work for it.
+- Hard cap is 32768 characters. Long before that, ask whether a wall of text is the
+  right answer at all.
+
+### The toolkit, and when to reach for each
+- **Bold** — the one key fact or the answer. Not every noun. If everything is bold,
+  nothing is.
+- *Italic* — light emphasis, asides, labels.
+- \`code spans\` — every identifier: filenames, commands, config keys, agent / account /
+  slot names, error codes. Tap-to-copy, and visually distinct from prose.
+- Code fences — multi-line output: diffs, logs, command blocks, JSON. Add a language
+  hint (\` \`\`\`diff \`, \` \`\`\`json \`) when it sharpens the render.
+- Bulleted list — 3+ parallel items the reader will scan or compare. Never for a single
+  thought or a flowing narrative.
+- Numbered list — ordered steps or ranked items.
+- Tables — 2-D data only (rows × columns): per-account usage, status fields. Overkill
+  for a flat list.
+- Headings — only in a long, multi-section answer. Clutter on a short reply.
+- Blockquotes (\`>\`) — quoted text or indented continuation. Telegram drops leading
+  spaces, so use \`>\`, never literal indentation.
+- Dividers (\`---\`) — between genuinely separate sections. Heavy; use sparingly.
+
+### The why
+Structure exists for the reader, not the writer. A two-item bullet list is worse than a
+sentence. A heading on a three-line reply is noise. Reach for structure only when it
+**reduces the reader's effort** — parallel options, scannable data, ordered steps — and
+stay in prose when the thought is connected. When in doubt: shorter and plainer wins.
+
+Every turn that answers a user message ends with a user-visible \`reply\` (or
+\`stream_reply\` done=true) — Telegram is all the user sees; your terminal output
+never reaches them.`;
 
 /**
  * Canonical rendering of the fleet invariants file written to
@@ -2492,12 +2551,20 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
       // `--add-dir` flag set in start.sh.hbs. See `renderFleetInvariants()`
       // at the top of this file.
       //
-      // What remains here: the operator's per-agent
+      // EXCEPTION — the Telegram formatting FLOOR CARD is injected here, into
+      // `--append-system-prompt`, deterministically for EVERY session (it must
+      // not depend on the model choosing to load a discovered file). Single
+      // source of truth: TELEGRAM_FORMATTING_FLOOR_CARD above.
+      //
+      // What also remains here: the operator's per-agent
       // `system_prompt_append` (yaml passthrough). Reserved for genuinely
       // per-agent system-prompt extensions; fleet-wide content goes in
       // `~/.switchroom/fleet/CLAUDE.md` (lane 2, operator-owned).
       const baseAppend = agentConfig.system_prompt_append ?? '';
-      return baseAppend.length > 0 ? shellSingleQuote(baseAppend) : undefined;
+      const combined = baseAppend.length > 0
+        ? `${TELEGRAM_FORMATTING_FLOOR_CARD}\n\n${baseAppend}`
+        : TELEGRAM_FORMATTING_FLOOR_CARD;
+      return shellSingleQuote(combined);
     })(),
     extraCliArgs: (() => {
       const parts: string[] = []
@@ -5214,8 +5281,16 @@ export function reconcileAgent(
         // and reach the model via Claude Code native CLAUDE.md
         // auto-discovery (start.sh.hbs passes `--add-dir ~/.switchroom/fleet`).
         // See the matching scaffoldAgent path above and renderFleetInvariants().
+        //
+        // EXCEPTION — the Telegram formatting FLOOR CARD is injected here, into
+        // `--append-system-prompt`, deterministically for EVERY session. Must
+        // stay in lockstep with the scaffoldAgent path above. Single source of
+        // truth: TELEGRAM_FORMATTING_FLOOR_CARD.
         const baseAppend = agentConfig.system_prompt_append ?? '';
-        return baseAppend.length > 0 ? shellSingleQuote(baseAppend) : undefined;
+        const combined = baseAppend.length > 0
+          ? `${TELEGRAM_FORMATTING_FLOOR_CARD}\n\n${baseAppend}`
+          : TELEGRAM_FORMATTING_FLOOR_CARD;
+        return shellSingleQuote(combined);
       })(),
       extraCliArgs: (() => {
         const parts: string[] = []

--- a/telegram-plugin/answer-stream.ts
+++ b/telegram-plugin/answer-stream.ts
@@ -368,12 +368,13 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
         return undefined
       }
 
-      // Telegram caps a single message at 4096 chars. The streaming path
-      // already guards on this in sendOrEdit; materialize must too, or
-      // long answers silently drop the final push notification (Telegram
-      // returns 400, the catch swallows). Per the JTBD anti-pattern
-      // "silent failure of any kind", warn and bail explicitly so the
-      // operator can correlate.
+      // Telegram caps a single rich message at TELEGRAM_MAX_CHARS (32768,
+      // the Bot API 10.1 rich-message wire cap post-#2669 — NOT the legacy
+      // 4096 plain-text limit). The streaming path already guards on this in
+      // sendOrEdit; materialize must too, or long answers silently drop the
+      // final push notification (Telegram returns 400, the catch swallows).
+      // Per the JTBD anti-pattern "silent failure of any kind", warn and bail
+      // explicitly so the operator can correlate.
       if (textToSend.length > TELEGRAM_MAX_CHARS) {
         warn?.(
           `answer-stream: materialize — text exceeds ${TELEGRAM_MAX_CHARS} chars (got ${textToSend.length}); skipping. ` +

--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -137,7 +137,7 @@ const TOOL_SCHEMAS = [
   {
     name: 'stream_reply',
     description:
-      'Post the final answer for this turn. The plugin renders an event-driven progress card (Plan → Run → Done with live tool bullets, elapsed time, and status emoji) for free while the turn is in-flight, so you do not need to narrate intermediate progress. Call `stream_reply` exactly once per turn with done=true and the complete answer text. Hard-stops at 4096 chars — longer text throws; fall back to `reply`, which chunks. Calling with done=false is an error in this environment (the progress card already owns the mid-turn surface). inline_keyboard adds tappable buttons under the final message — see `reply` for shape and constraints.',
+      'Post the final answer for this turn. The plugin renders an event-driven progress card (Plan → Run → Done with live tool bullets, elapsed time, and status emoji) for free while the turn is in-flight, so you do not need to narrate intermediate progress. Call `stream_reply` exactly once per turn with done=true and the complete answer text. Hard cap is 32768 chars (the rich-message wire limit) — longer text is dropped by a defensive guard, so use `reply` for anything that long (it chunks). Calling with done=false is an error in this environment (the progress card already owns the mid-turn surface). inline_keyboard adds tappable buttons under the final message — see `reply` for shape and constraints.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -233,7 +233,132 @@ export function normalizeParagraphBreaks(text: string): string {
   }
   out = pieces.join('')
 
+  // Step 3: guarantee a blank line (`\n\n`) at BLOCK BOUNDARIES. The
+  // prose-promotion above keeps lists/tables tight by leaving their single
+  // `\n` separators alone — but GFM's rich renderer needs a blank line to
+  // START a new block, so a block that is glued to the previous line by a
+  // single `\n` fails to render (a table prints as literal pipe text, prose
+  // after a list is absorbed as a lazy list continuation). This pass inserts
+  // the missing blank line at those transitions only, on the same masked text,
+  // never touching code interiors, never collapsing/expanding existing `\n\n`,
+  // and never splitting a table's header/delimiter/body rows apart.
+  out = ensureBlockBoundaries(out, placeholder)
+
   return restore(out)
+}
+
+// ---------------------------------------------------------------------------
+// Block-boundary blank-line guarantee (Step 3 of normalizeParagraphBreaks)
+// ---------------------------------------------------------------------------
+
+/** A line that begins a GFM list item (bullet or ordered), incl. leading indent. */
+function isListItemLine(line: string): boolean {
+  const t = line.trimStart()
+  return /^[-*+]\s/.test(t) || /^\d+[.)]\s/.test(t)
+}
+
+/** A GFM table body/header row: a line whose first non-space char is `|`. */
+function isTableRowLine(line: string): boolean {
+  return /^\s*\|/.test(line)
+}
+
+/**
+ * A GFM table delimiter row: optional leading pipe, then one or more
+ * `:?-{1,}:?` cells separated by pipes (e.g. `|---|---|`, `---|:--:`,
+ * `| :-- | --: |`). This is what turns the line ABOVE it into a table header.
+ */
+function isTableDelimiterLine(line: string): boolean {
+  return /^\s*\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)*\|?\s*$/.test(line)
+}
+
+/** A fenced-code OPEN line — either a literal ``` fence or a masked block. */
+function isFenceOpenLine(line: string, placeholder?: string): boolean {
+  const t = line.trimStart()
+  if (placeholder != null && placeholder.length > 0 && t.startsWith(placeholder)) return true
+  return t.startsWith('```')
+}
+
+/** A blockquote line. */
+function isBlockquoteLine(line: string): boolean {
+  return line.trimStart().startsWith('>')
+}
+
+/** An ATX heading line. */
+function isHeadingLine(line: string): boolean {
+  return /^#{1,6}\s/.test(line.trimStart())
+}
+
+/**
+ * Insert a blank line at block boundaries that are currently separated by
+ * exactly one `\n`. Operates line-by-line on already-code-masked text.
+ *
+ * A blank line is guaranteed:
+ *   - BEFORE the first row of a GFM table (a `|`-leading line that is itself a
+ *     delimiter row, OR a `|`-containing header line immediately followed by a
+ *     delimiter row) when the previous emitted line is non-blank and not part
+ *     of a table — never between a table's own header/delimiter/body rows.
+ *   - BEFORE a fenced-code open, a blockquote, or an ATX heading when the
+ *     previous line is non-blank and of a DIFFERENT block type.
+ *   - AFTER a list block: when a list-item line is followed by a non-blank
+ *     line that is NOT itself a list item and NOT an indented continuation of
+ *     the item (4+ leading spaces / a tab), so the prose breaks out of the list.
+ *
+ * Conservative: prefers a false negative (leave glued) over corrupting a valid
+ * block. Existing blank lines (empty entries from a `\n\n` gap) are preserved
+ * and short-circuit every rule — we never double up a gap.
+ */
+function ensureBlockBoundaries(text: string, placeholder?: string): string {
+  if (!text.includes('\n')) return text
+  const lines = text.split('\n')
+  const result: string[] = []
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const prev = result.length > 0 ? result[result.length - 1] : null
+    const prevNonBlank = prev != null && prev.trim() !== ''
+    const curBlank = line.trim() === ''
+
+    // ---- Rule A: blank line BEFORE a block that needs one to start ----
+    if (prevNonBlank && !curBlank) {
+      const next = i + 1 < lines.length ? lines[i + 1] : ''
+
+      // Table first row: either THIS line is a delimiter row (header was the
+      // prev line — but only treat as a table start when prev itself isn't
+      // already a table row), or THIS line is a `|`-bearing header whose NEXT
+      // line is a delimiter. We anchor the blank-line insertion on the HEADER
+      // line so header+delimiter+body stay contiguous.
+      const prevIsTable = isTableRowLine(prev)
+      const startsTableHere =
+        !prevIsTable &&
+        ((line.includes('|') && isTableDelimiterLine(next)) ||
+          (isTableRowLine(line) && isTableDelimiterLine(next)))
+
+      const startsFence = isFenceOpenLine(line, placeholder) && !isFenceOpenLine(prev, placeholder)
+      const startsQuote = isBlockquoteLine(line) && !isBlockquoteLine(prev)
+      const startsHeading = isHeadingLine(line) && !isHeadingLine(prev)
+
+      if (startsTableHere || startsFence || startsQuote || startsHeading) {
+        result.push('')
+      }
+    }
+
+    // ---- Rule B: blank line AFTER a list block, before breakout prose ----
+    if (prevNonBlank && !curBlank && isListItemLine(prev) && !isListItemLine(line)) {
+      // A 4+ space (or tab) indent means `line` is a lazy continuation of the
+      // list item's paragraph, NOT breakout prose — leave it glued.
+      const isIndentedContinuation = /^(\t| {4,})\S/.test(line)
+      // A table/fence/quote/heading start is already handled by Rule A above
+      // (its blank line was just inserted); avoid inserting a second one.
+      const alreadySeparated = result.length > 0 && result[result.length - 1].trim() === ''
+      if (!isIndentedContinuation && !alreadySeparated) {
+        result.push('')
+      }
+    }
+
+    result.push(line)
+  }
+
+  return result.join('\n')
 }
 
 /** Lines that introduce GFM block structure — never reflow around these. */

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -223,7 +223,9 @@ export function normalizeParagraphBreaks(text: string): string {
     if (promote) {
       // Strip any trailing whitespace the line already carried so we emit
       // exactly one `  \n` hard break (never accumulate spaces on a re-run).
-      line = line.replace(/[ \t]+$/, '')
+      // Include `\r` so a CRLF source ("Alpha.\r\nBravo.") doesn't strand a
+      // lone carriage return before the injected `  \n`.
+      line = line.replace(/[ \t\r]+$/, '')
     }
     pieces.push(line)
     if (isLast) break
@@ -236,6 +238,10 @@ export function normalizeParagraphBreaks(text: string): string {
 
 /** Lines that introduce GFM block structure — never reflow around these. */
 function isMarkerLine(line: string, placeholder?: string): boolean {
+  // CommonMark indented code block: 4+ leading spaces then a non-space char.
+  // Checked on the RAW (pre-trim) line — trimming would erase the very indent
+  // that makes it a code block, so we must look before `trimStart()`.
+  if (/^ {4,}\S/.test(line)) return true
   const t = line.trimStart()
   // A line that begins with the code-mask placeholder is a standalone masked
   // fenced block — treat it as a block marker so we never inject a hard break

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -16,6 +16,9 @@
  *   - splitMarkdownChunks: split a long markdown body into <=maxLen chunks
  *     at safe boundaries (never mid code-fence, never mid table row),
  *     defaulting maxLen to the rich-message cap of 32768.
+ *   - normalizeParagraphBreaks: promote a LONE prose `\n` into a GFM hard
+ *     break (`  \n`) so paragraph separation survives the rich GFM path,
+ *     while leaving lists / tables / code / `\n\n` untouched.
  *   - RICH_MESSAGE_MAX_CHARS: the rich-text wire cap (32768).
  */
 
@@ -80,36 +83,12 @@ export function repairEscapedWhitespace(text: string): string {
   // index and produce "undefined" in the Telegram output. A nonce that is unique
   // per invocation makes the sentinel statistically impossible to collide with.
   const nonce = Math.random().toString(36).slice(2)
-  const CODE_MASK_PH = `\x00RM${nonce}_`
   const BACKSLASH_PH = `\x00BK${nonce}_`
 
-  // Mask fenced code blocks (``` ... ```) and inline code spans (` ... `)
-  // so the unescape pass never touches their content.
-  //
-  // Fenced blocks are extracted first. Only CLOSED fenced blocks (with a
-  // matching closing ```) are masked — an unclosed fence is left as-is so the
-  // inline-code pass below won't misparse the two leading backticks as an empty
-  // inline span and expose the block's interior.
-  //
-  // Inline code uses `[^\`\n]+` (one or more non-backtick, non-newline chars)
-  // matching the same definition the chunker uses, so the masked regions are
-  // consistent with what the downstream pipeline treats as code.
-  const codeMasks: string[] = []
-
-  const masked = text
-    // Closed fenced code blocks only (``` ... ``` with a matching closer).
-    .replace(/```[\s\S]*?```/g, (m) => {
-      const idx = codeMasks.length
-      codeMasks.push(m)
-      return `${CODE_MASK_PH}${idx}\x00`
-    })
-    // Inline code spans: at least one character between backticks, no embedded
-    // backtick or newline.
-    .replace(/`[^`\n]+`/g, (m) => {
-      const idx = codeMasks.length
-      codeMasks.push(m)
-      return `${CODE_MASK_PH}${idx}\x00`
-    })
+  // Mask fenced code blocks and inline code spans so the unescape pass never
+  // touches their content (shared masker — see maskCodeRegions for the exact
+  // closed-fence / inline-span definitions).
+  const { masked, restore } = maskCodeRegions(text, nonce)
 
   // Order matters: protect existing `\\` first so `\\n` stays as a literal
   // backslash + n and doesn't become a newline.
@@ -122,8 +101,206 @@ export function repairEscapedWhitespace(text: string): string {
     .replace(new RegExp(BACKSLASH_PH.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), '\\')
 
   // Restore masked code spans verbatim.
-  const restoreRe = new RegExp(`${CODE_MASK_PH.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\d+)\x00`, 'g')
-  return unescaped.replace(restoreRe, (_m, idx) => codeMasks[Number(idx)] ?? _m)
+  return restore(unescaped)
+}
+
+// ---------------------------------------------------------------------------
+// Shared code-region masking (used by repairEscapedWhitespace AND
+// normalizeParagraphBreaks). Closed fenced blocks (``` … ```) and inline
+// code spans (` … `) are replaced with unique placeholders so neither pass
+// ever rewrites their interior; `restore` puts them back verbatim.
+// ---------------------------------------------------------------------------
+
+interface MaskedCode {
+  masked: string
+  restore: (s: string) => string
+  /** The placeholder prefix injected for each masked region (fence or span). */
+  placeholder: string
+}
+
+/**
+ * Mask fenced code blocks and inline code spans with collision-resistant
+ * placeholders. `nonce` is a per-call random string the caller already holds
+ * (so two maskers in one function share one nonce namespace cleanly).
+ *
+ * Fenced blocks are extracted FIRST and only when CLOSED (matching ```), so an
+ * unclosed fence is left intact rather than misparsed by the inline pass. Inline
+ * spans use `[^\`\n]+` — the same definition the chunker treats as code.
+ */
+function maskCodeRegions(text: string, nonce: string): MaskedCode {
+  const CODE_MASK_PH = `\x00RM${nonce}_`
+  const codeMasks: string[] = []
+
+  const masked = text
+    .replace(/```[\s\S]*?```/g, (m) => {
+      const idx = codeMasks.length
+      codeMasks.push(m)
+      return `${CODE_MASK_PH}${idx}\x00`
+    })
+    .replace(/`[^`\n]+`/g, (m) => {
+      const idx = codeMasks.length
+      codeMasks.push(m)
+      return `${CODE_MASK_PH}${idx}\x00`
+    })
+
+  const restoreRe = new RegExp(
+    `${CODE_MASK_PH.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\d+)\x00`,
+    'g',
+  )
+  const restore = (s: string): string =>
+    s.replace(restoreRe, (_m, idx) => codeMasks[Number(idx)] ?? _m)
+
+  return { masked, restore, placeholder: CODE_MASK_PH }
+}
+
+// ---------------------------------------------------------------------------
+// Paragraph-break normalizer — make lone prose newlines survive the GFM path
+// ---------------------------------------------------------------------------
+
+/**
+ * GFM (the rich-message render path) treats a LONE `\n` as a *soft* break: the
+ * two lines collapse onto the same visual line, so a model that separates its
+ * paragraphs with a single newline produces a cramped wall of text. The old
+ * markdown→HTML path rendered every `\n` as a hard break, which masked the
+ * habit; the rich path no longer does.
+ *
+ * This normalizer fixes that DETERMINISTICALLY without breaking GFM block
+ * syntax. It does exactly two things, on code-masked text:
+ *
+ *   1. Collapse runs of 3+ newlines down to exactly `\n\n` (never collapse a
+ *      genuine `\n\n` paragraph gap).
+ *   2. Promote a LONE `\n` (one not adjacent to another `\n`) into a GFM hard
+ *      break (`  \n`, two trailing spaces) — but ONLY when it is a genuine
+ *      prose paragraph break.
+ *
+ * The promotion heuristic is deliberately CONSERVATIVE — it prefers a false
+ * negative (leaving a break un-promoted, so two prose lines stay cramped) over
+ * a false positive (double-spacing a tight list or table). A break is promoted
+ * only when ALL of these hold:
+ *
+ *   - The preceding line ends in sentence-terminal punctuation: `.`, `!`, `?`,
+ *     `:`, or a closing `)` / `"` / `'` / `’` / `”` that itself follows such a
+ *     terminator (e.g. `...done.")`).
+ *   - The preceding line is NOT itself a marker line (list / table / quote /
+ *     heading).
+ *   - The NEXT line starts with a non-marker character: not a list bullet
+ *     (`-`/`*`/`+`/`\d+.`/`\d+)`, incl. indented), not a table row (`|` or
+ *     ` | `), not a blockquote (`>`), not a heading (`#`), not blank.
+ *
+ * Code fences and inline code are masked out before any of this runs, so their
+ * interior `\n`s are never touched.
+ */
+export function normalizeParagraphBreaks(text: string): string {
+  if (!text.includes('\n')) return text
+
+  const nonce = Math.random().toString(36).slice(2)
+  const { masked, restore, placeholder } = maskCodeRegions(text, nonce)
+
+  // Step 1: collapse 3+ newlines to exactly two. This also normalizes runs that
+  // contain interleaved spaces only between the newlines is NOT done here —
+  // we only touch pure newline runs so we never eat meaningful whitespace.
+  let out = masked.replace(/\n{3,}/g, '\n\n')
+
+  // Step 2: walk lines and promote lone prose breaks. We rebuild the string by
+  // joining lines with the right separator. A separator is "hard" (`  \n`) only
+  // when the break between this line and the next is a genuine prose paragraph
+  // break per the heuristic; otherwise it stays a plain `\n`. Blank lines (the
+  // `\n\n` gaps) are preserved as empty entries in the split, so we never
+  // promote a break that is adjacent to a blank line.
+  const lines = out.split('\n')
+  const pieces: string[] = []
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i]
+    const isLast = i === lines.length - 1
+    const next = isLast ? '' : lines[i + 1]
+    // A blank current or next line means this is part of a `\n\n` gap — leave
+    // the separator as a plain newline (the blank entry reconstructs the gap).
+    const promote =
+      !isLast &&
+      line.trim() !== '' &&
+      next.trim() !== '' &&
+      shouldPromoteBreak(line, next, placeholder)
+    if (promote) {
+      // Strip any trailing whitespace the line already carried so we emit
+      // exactly one `  \n` hard break (never accumulate spaces on a re-run).
+      line = line.replace(/[ \t]+$/, '')
+    }
+    pieces.push(line)
+    if (isLast) break
+    pieces.push(promote ? '  \n' : '\n')
+  }
+  out = pieces.join('')
+
+  return restore(out)
+}
+
+/** Lines that introduce GFM block structure — never reflow around these. */
+function isMarkerLine(line: string, placeholder?: string): boolean {
+  const t = line.trimStart()
+  // A line that begins with the code-mask placeholder is a standalone masked
+  // fenced block — treat it as a block marker so we never inject a hard break
+  // immediately before/after a code block. (An INLINE code span sits mid-line,
+  // so the line won't START with the placeholder and ordinary prose rules apply.)
+  if (placeholder != null && placeholder.length > 0 && t.startsWith(placeholder)) return true
+  return (
+    // Unordered list bullet: -, *, + followed by a space.
+    /^[-*+]\s/.test(t) ||
+    // Ordered list: `1.` or `1)` followed by a space.
+    /^\d+[.)]\s/.test(t) ||
+    // Blockquote / pull-quote.
+    t.startsWith('>') ||
+    // ATX heading.
+    /^#{1,6}\s/.test(t) ||
+    // Table row (leading pipe) or table-ish line (interior ` | `).
+    t.startsWith('|') ||
+    line.includes(' | ') ||
+    // Fenced code delimiter (defensive — fences are masked, but a lone/odd
+    // fence line can survive masking).
+    t.startsWith('```') ||
+    // Thematic break / divider.
+    /^(-{3,}|\*{3,}|_{3,})\s*$/.test(t)
+  )
+}
+
+/**
+ * Decide whether the lone `\n` between `prev` and `next` is a genuine prose
+ * paragraph break worth promoting to a GFM hard break. Conservative by design
+ * (see normalizeParagraphBreaks doc) — returns false on any doubt.
+ */
+function shouldPromoteBreak(prev: string, next: string, placeholder?: string): boolean {
+  if (isMarkerLine(prev, placeholder) || isMarkerLine(next, placeholder)) return false
+  // Next line must begin with ordinary prose, not a structural marker char.
+  const nextTrimmed = next.trimStart()
+  if (nextTrimmed.length === 0) return false
+  // The preceding line must read as a finished sentence/clause: it ends in a
+  // sentence-terminal punctuation mark, optionally wrapped by a closing quote
+  // or paren that itself follows such a terminator.
+  const prevTrimmed = prev.trimEnd()
+  // Strip up to one trailing closing-bracket/quote run to look at the real
+  // terminator (e.g. `He said "go."` or `(done.)`).
+  const unwrapped = prevTrimmed.replace(/[)"'’”\]]+$/, '')
+  const terminator = unwrapped.slice(-1)
+  return terminator === '.' || terminator === '!' || terminator === '?' || terminator === ':'
+}
+
+/**
+ * Last-resort hard slicer for a body that `splitMarkdownChunks` could not break
+ * (a single indivisible region larger than the cap — e.g. a giant fenced block
+ * with no interior boundary). Cuts on raw character count so every emitted
+ * piece is guaranteed `<= cap`, accepting that a cut MAY land inside a fence
+ * (which Telegram renders imperfectly) — a degraded-but-delivered message beats
+ * a hard `RICH_MESSAGE_TEXT_TOO_LONG` reject that drops the answer entirely.
+ *
+ * Returns the input as a single-element array when it already fits.
+ */
+export function hardSliceToCap(text: string, cap = RICH_MESSAGE_MAX_CHARS): string[] {
+  if (cap <= 0) return [text]
+  if (text.length <= cap) return [text]
+  const out: string[] = []
+  for (let i = 0; i < text.length; i += cap) {
+    out.push(text.slice(i, i + cap))
+  }
+  return out
 }
 
 // ---------------------------------------------------------------------------

--- a/telegram-plugin/gateway/drive-write-approval.test.ts
+++ b/telegram-plugin/gateway/drive-write-approval.test.ts
@@ -12,6 +12,7 @@ import {
   type DriveApprovalHandlerDeps,
   handleRequestDriveApproval,
 } from "./drive-write-approval.js";
+import { RICH_MESSAGE_MAX_CHARS } from "../format.js";
 
 // ────────────────────────────────────────────────────────────────────────
 // Fixtures
@@ -284,17 +285,16 @@ describe("handleRequestDriveApproval — TTL clamping", () => {
 // ────────────────────────────────────────────────────────────────────────
 
 describe("handleRequestDriveApproval — oversize card body fit (#1767)", () => {
-  it("truncates the rendered text under 4096 chars before posting", async () => {
+  it("truncates the rendered text under the rich-message cap before posting", async () => {
     const spy = makeSpy();
-    // buildCard returns a body well past Telegram's 4096-char limit
-    // (simulates a docTitle / anchor / summary whose HTML-escape
-    // inflated past the limit). Handler must shrink it before postCard.
+    // buildCard returns a body well past the rich-message wire cap
+    // (RICH_MESSAGE_MAX_CHARS, 32768 post-#2669 — simulates a docTitle /
+    // anchor / summary whose escape inflated past the limit). Handler must
+    // shrink it before postCard.
     const giantText =
       "<b>Title</b>\n" +
-      Array.from({ length: 200 }, (_, i) => `line-${i}-${"x".repeat(40)}`).join(
-        "\n",
-      );
-    expect(giantText.length).toBeGreaterThan(4096);
+      "x".repeat(RICH_MESSAGE_MAX_CHARS + 4000);
+    expect(giantText.length).toBeGreaterThan(RICH_MESSAGE_MAX_CHARS);
     await handleRequestDriveApproval(
       clientFor(spy),
       msgFor(),
@@ -304,7 +304,7 @@ describe("handleRequestDriveApproval — oversize card body fit (#1767)", () => 
       }),
     );
     expect(spy.posted).toHaveLength(1);
-    expect(spy.posted[0]!.text.length).toBeLessThanOrEqual(4096);
+    expect(spy.posted[0]!.text.length).toBeLessThanOrEqual(RICH_MESSAGE_MAX_CHARS);
     expect(spy.posted[0]!.text).toContain("preview truncated");
     // Card was successfully posted → ok:true response went back.
     expect(spy.sent[0]?.ok).toBe(true);
@@ -334,7 +334,7 @@ describe("handleRequestDriveApproval — oversize card body fit (#1767)", () => 
   it("post failure after truncation surfaces a structured reason", async () => {
     const spy = makeSpy();
     const giantText =
-      "<b>Title</b>\n" + "x".repeat(8000);
+      "<b>Title</b>\n" + "x".repeat(RICH_MESSAGE_MAX_CHARS + 4000);
     await handleRequestDriveApproval(
       clientFor(spy),
       msgFor(),

--- a/telegram-plugin/gateway/drive-write-approval.ts
+++ b/telegram-plugin/gateway/drive-write-approval.ts
@@ -31,6 +31,7 @@ import type {
   RequestDriveApprovalMessage,
 } from "./ipc-protocol.js";
 import { truncateRawToFit } from "./oversize-card-body.js";
+import { RICH_MESSAGE_MAX_CHARS } from "../format.js";
 
 // ────────────────────────────────────────────────────────────────────────
 // Injected deps — caller (gateway.ts) wires these from the existing
@@ -102,15 +103,20 @@ const MAX_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const MIN_TTL_MS = 30 * 1000; // 30 seconds
 
 /**
- * Telegram `sendMessage` hard limit. `buildDiffPreviewCard` HTML-
- * escapes the docTitle + every body line with no upstream length
- * cap, so an adversarial or just-unusually-long docTitle / anchor
- * displayName / agent-supplied summary can render past 4096 once
- * `&` / `<` / `>` inflate up to 5x. We rebuild a truncated body
- * keyed off the wrapper-attested fields when that happens. (#1767)
+ * Telegram rich-message hard limit. `buildDiffPreviewCard` escapes the
+ * docTitle + every body line with no upstream length cap, so an adversarial
+ * or just-unusually-long docTitle / anchor displayName / agent-supplied
+ * summary can render past the wire cap once escaping inflates it. We rebuild a
+ * truncated body keyed off the wrapper-attested fields when that happens.
+ * (#1767)
+ *
+ * Post-#2669 every card renders as GFM markdown via `sendRichMessage`, so the
+ * hard cap is `RICH_MESSAGE_MAX_CHARS` (32768), not the legacy 4096 plain-text
+ * limit. RENDERED_BODY_CAP keeps the proportional ~5% headroom under the hard
+ * cap that the original 3900-under-4096 budget carried.
  */
-const TELEGRAM_SENDMESSAGE_LIMIT = 4096;
-const RENDERED_BODY_CAP = 3900;
+const TELEGRAM_SENDMESSAGE_LIMIT = RICH_MESSAGE_MAX_CHARS;
+const RENDERED_BODY_CAP = RICH_MESSAGE_MAX_CHARS - 200;
 const OVERSIZE_SENTINEL = "\n[… preview truncated; open in Drive for full context]";
 
 /**

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -89,6 +89,7 @@ import {
   createSwallowingRetryApiCall,
   retryWithThreadFallback,
   isHtmlParseRejectError,
+  isMessageTooLongError,
 } from '../retry-api-call.js'
 import { installTgPostLogger, withTgPostTags } from '../shared/bot-runtime.js'
 import { buildAttachmentPath, assertInsideInbox } from '../attachment-path.js'
@@ -189,7 +190,7 @@ const REPLY_TO_TEXT_MAX = 200
 const SILENT_END_FALLBACK_TEXT =
   '⚠️ The agent finished working but didn’t send a reply — your last ' +
   'message may not have been answered. Please try asking again.'
-import { splitMarkdownChunks, repairEscapedWhitespace, escapeMarkdown, RICH_MESSAGE_MAX_CHARS } from '../format.js'
+import { splitMarkdownChunks, hardSliceToCap, repairEscapedWhitespace, normalizeParagraphBreaks, escapeMarkdown, RICH_MESSAGE_MAX_CHARS } from '../format.js'
 import { richMessage } from '../rich-send.js'
 import { scrubVoice } from '../text-voice-scrub.js'
 import {
@@ -8087,7 +8088,10 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   })()
   const rawText = args.text as string | undefined
   if (rawText == null || rawText === '') throw new Error('reply: text is required and cannot be empty')
-  let text = repairEscapedWhitespace(rawText)
+  // Repair LLM JSON-escape bungles, then promote lone prose paragraph breaks
+  // into GFM hard breaks so the rich path doesn't collapse them (lists/tables/
+  // code are left untouched — see normalizeParagraphBreaks).
+  let text = normalizeParagraphBreaks(repairEscapedWhitespace(rawText))
   // Outbound secret scrub (#2044): mask any secret the agent echoed BEFORE
   // the stderr preview below, the dedup key, the send, and the history
   // record. Mutates `text` so every downstream consumer sees the masked
@@ -8744,6 +8748,41 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
         return lockedBot.api.sendRichMessage(chat_id, richMessage(chunks[i]), richOpts as never)
       }
 
+      // Length-error recovery: a single pre-computed chunk can still exceed the
+      // wire cap when splitMarkdownChunks hit an indivisible region and emitted
+      // it whole (a giant fenced block, a no-boundary blob). Telegram answers
+      // with RICH_MESSAGE_TEXT_TOO_LONG / MESSAGE_TOO_LONG. Re-split this chunk
+      // at a harder boundary and send each piece, rather than misclassifying it
+      // as a parse-reject (which would resend the same oversized payload as
+      // plain text) or surfacing the raw 400.
+      const sendChunkResplit = async (opts: Record<string, unknown>): Promise<void> => {
+        // Re-split at the same cap; for a truly indivisible block this still
+        // yields one oversized piece, but a hard character-cut on the rendered
+        // markdown at least keeps each delivered piece under the wire cap.
+        const subPieces = splitMarkdownChunks(chunks[i], RICH_MESSAGE_MAX_CHARS)
+        const pieces =
+          subPieces.length > 1
+            ? subPieces
+            : hardSliceToCap(chunks[i], RICH_MESSAGE_MAX_CHARS)
+        for (let p = 0; p < pieces.length; p++) {
+          let sent: { message_id: number }
+          if (literalText) {
+            // allow-raw-bot-api: length-error re-split last resort (literal text); wrapping would re-enter the chunk-loop's own classification on an already-classified length failure.
+            sent = await lockedBot.api.sendMessage(chat_id, pieces[p], opts as never)
+          } else {
+            const ro = { ...opts }
+            delete (ro as { link_preview_options?: unknown }).link_preview_options
+            // allow-raw-bot-api: length-error re-split last resort (rich); wrapping would re-enter the chunk-loop's own classification on an already-classified length failure.
+            sent = await lockedBot.api.sendRichMessage(chat_id, richMessage(pieces[p]), ro as never)
+          }
+          sentIds.push(sent.message_id)
+          logOutbound('reply', chat_id, sent.message_id, pieces[p].length, `chunk=${i + 1}/${chunks.length} resplit=${p + 1}/${pieces.length}`)
+        }
+        process.stderr.write(
+          `telegram gateway: rich body too long — re-split chunk ${i + 1}/${chunks.length} into ${pieces.length} piece(s)\n`,
+        )
+      }
+
       try {
         const sent = await robustApiCall(() => sendChunk(sendOpts), { threadId, chat_id })
         sentIds.push(sent.message_id)
@@ -8757,10 +8796,14 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
             const sent = await sendChunk(retryOpts)
             sentIds.push(sent.message_id)
           } catch (retryErr) {
-            // Thread dropped, but the markdown is also unparseable — go plain.
-            if (isHtmlParseRejectError(retryErr)) await sendChunkPlainText(retryOpts)
+            // Thread dropped, AND another failure: length → re-split,
+            // parse-reject → plain text, else propagate.
+            if (isMessageTooLongError(retryErr)) await sendChunkResplit(retryOpts)
+            else if (isHtmlParseRejectError(retryErr)) await sendChunkPlainText(retryOpts)
             else throw retryErr
           }
+        } else if (isMessageTooLongError(err)) {
+          await sendChunkResplit(sendOpts)
         } else if (isHtmlParseRejectError(err)) {
           await sendChunkPlainText(sendOpts)
         } else {
@@ -9259,6 +9302,7 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       bot: lockedBot as unknown as { api: import('../stream-controller.js').StreamBotApi },
       retry: robustApiCall,
       repairEscapedWhitespace,
+      normalizeParagraphBreaks,
       assertAllowedChat,
       resolveThreadId,
       disableLinkPreview: access.disableLinkPreview !== false,
@@ -10508,7 +10552,11 @@ async function executeEditMessage(args: Record<string, unknown>): Promise<unknow
   // Single rich-markdown path (#2669): `format:'text'` edits as a literal
   // plain string; everything else edits via the rich-markdown path.
   const editLiteralText = editFormat === 'text'
+  // Match the reply path: repair JSON-escape bungles, then promote lone prose
+  // paragraph breaks for the rich path. A literal-text edit (`format:'text'`)
+  // skips paragraph normalization — it must edit byte-for-byte as given.
   let editRawText = repairEscapedWhitespace(args.text as string)
+  if (!editLiteralText) editRawText = normalizeParagraphBreaks(editRawText)
   // Outbound secret scrub (#2044): an edit must not re-introduce a raw
   // secret into a live bubble or the history row. Mask before scrub/send.
   editRawText = redactOutboundText(editRawText, 'edit_message')
@@ -14687,7 +14735,10 @@ function switchroomExecCombined(args: string[], timeoutMs = 15000): string {
   })
 }
 
-function formatSwitchroomOutput(output: string, maxLen = 4000): string {
+// Default truncation budget for CLI output bound for Telegram. The rich-message
+// wire cap is RICH_MESSAGE_MAX_CHARS (32768) post-#2669, not the legacy 4096
+// plain-text limit. Mirrors shared/bot-runtime.ts formatSwitchroomOutput.
+function formatSwitchroomOutput(output: string, maxLen = RICH_MESSAGE_MAX_CHARS): string {
   const trimmed = output.trim()
   if (trimmed.length <= maxLen) return trimmed
   return trimmed.slice(0, maxLen - 20) + '\n... (truncated)'

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -20,6 +20,7 @@ import type {
   ToolCallMessage,
   ToolCallResult,
 } from "./ipc-protocol.js";
+import { RICH_MESSAGE_MAX_CHARS } from "../format.js";
 
 export interface IpcServerOptions {
   socketPath: string;
@@ -270,10 +271,12 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
       if (typeof m.agentName !== "string"
         || !AGENT_NAME_RE.test(m.agentName as string)) return false;
       if (typeof m.chatId !== "string" || (m.chatId as string).length === 0) return false;
-      // text non-empty and bounded — Telegram caps a message at 4096 chars;
-      // reject over-long here (defense in depth against a malformed payload).
+      // text non-empty and bounded — the send_outbound handler posts via
+      // sendRichMessage (rich path), whose wire cap is RICH_MESSAGE_MAX_CHARS
+      // (32768) post-#2669, not the legacy 4096 plain-text limit. Reject
+      // over-long here (defense in depth against a malformed payload).
       if (typeof m.text !== "string" || (m.text as string).length === 0
-        || (m.text as string).length > 4096) return false;
+        || (m.text as string).length > RICH_MESSAGE_MAX_CHARS) return false;
       if (m.threadId !== undefined
         && (typeof m.threadId !== "number" || !Number.isInteger(m.threadId as number))) return false;
       if (m.parseMode !== undefined && m.parseMode !== "html" && m.parseMode !== "text") return false;

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -231,9 +231,11 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
     case "pty_partial":
       // Extracted reply text from PTY-tail. May be empty (the extractor
       // returns empty strings for "no text yet" snapshots — gateway
-      // handler dedups on lastPtyPreviewByChat). Capped at 8192 to
-      // give some headroom over Telegram's 4096-char wire limit while
-      // still bounding buffer growth from a runaway extractor.
+      // handler dedups on lastPtyPreviewByChat). Capped at 8192 — this is a
+      // preview-buffer bound on the PTY tail, not the outbound wire cap (which
+      // is now RICH_MESSAGE_MAX_CHARS / 32768 on the rich path post-#2669) —
+      // sized to bound buffer growth from a runaway extractor while still
+      // carrying a useful preview.
       return typeof m.text === "string"
         && (m.text as string).length <= 8192;
     case "update_placeholder":

--- a/telegram-plugin/retry-api-call.ts
+++ b/telegram-plugin/retry-api-call.ts
@@ -266,6 +266,10 @@ export async function retryWithThreadFallback<T>(
  */
 export function isHtmlParseRejectError(err: unknown): boolean {
   if (!(err instanceof GrammyError) || err.error_code !== 400) return false
+  // A too-long rejection is a LENGTH error (see isMessageTooLongError) — never
+  // route it through the plain-text parse-reject fallback, which would resend
+  // the same oversized body and fail again. The caller re-splits instead.
+  if (isMessageTooLongError(err)) return false
   const d = (err.description || '').toLowerCase()
   return (
     d.includes("can't parse entities") ||
@@ -280,5 +284,28 @@ export function isHtmlParseRejectError(err: unknown): boolean {
     d.includes('can’t find end of the entity') ||
     // covers both "expected end tag" and "unexpected end tag"
     d.includes('expected end tag')
+  )
+}
+
+/**
+ * True when Telegram rejected the message because the BODY WAS TOO LONG (over
+ * the rich-message wire cap), not because the markdown failed to parse.
+ *
+ * The rich path surfaces this as `RICH_MESSAGE_TEXT_TOO_LONG` (empirically the
+ * description for 32769+ chars); the legacy plain-text path used
+ * `MESSAGE_TOO_LONG` / "message is too long". A caller that hits this should
+ * re-split the body (`splitMarkdownChunks` at a smaller cap) and resend, NOT
+ * treat it as a parse-reject (which resends the same oversized payload as
+ * plain text). Mirrors rich-send.ts `isLengthError`.
+ */
+export function isMessageTooLongError(err: unknown): boolean {
+  if (!(err instanceof GrammyError) || err.error_code !== 400) return false
+  const d = (err.description || '').toLowerCase()
+  return (
+    d.includes('rich_message_text_too_long') ||
+    d.includes('message_too_long') ||
+    d.includes('text_too_long') ||
+    d.includes('message is too long') ||
+    d.includes('text is too long')
   )
 }

--- a/telegram-plugin/rich-send.ts
+++ b/telegram-plugin/rich-send.ts
@@ -39,6 +39,11 @@ export function richMessage(markdown: string): InputRichMessageMarkdown {
  */
 export function isParseEntitiesError(err: unknown): boolean {
   if (!(err instanceof GrammyError) || err.error_code !== 400) return false
+  // A too-long rejection is a LENGTH error, not a parse error — never let the
+  // length case fall through here (it would be "recovered" by resending the
+  // same oversized body as plain text, which fails again). Classify it
+  // separately via isLengthError so the caller re-splits instead.
+  if (isLengthError(err)) return false
   const d = (err.description || '').toLowerCase()
   return (
     d.includes("can't parse entities") ||
@@ -53,5 +58,29 @@ export function isParseEntitiesError(err: unknown): boolean {
     d.includes('unclosed start tag') ||
     // covers both "expected end tag" and "unexpected end tag"
     d.includes('expected end tag')
+  )
+}
+
+/**
+ * True when Telegram rejected the message because the BODY WAS TOO LONG (over
+ * the rich-message wire cap), as opposed to a markdown-parse failure.
+ *
+ * The rich path surfaces this distinctly: `RICH_MESSAGE_TEXT_TOO_LONG`
+ * (empirically the description for a body of 32769+ chars). The legacy
+ * plain-text path used `MESSAGE_TOO_LONG` / "message is too long" — both are
+ * matched here so a caller that hits either re-splits the body
+ * (`splitMarkdownChunks`) and resends, instead of misclassifying it as a parse
+ * error (and resending the same oversized payload as plain text) or surfacing
+ * the raw 400.
+ */
+export function isLengthError(err: unknown): boolean {
+  if (!(err instanceof GrammyError) || err.error_code !== 400) return false
+  const d = (err.description || '').toLowerCase()
+  return (
+    d.includes('rich_message_text_too_long') ||
+    d.includes('message_too_long') ||
+    d.includes('text_too_long') ||
+    d.includes('message is too long') ||
+    d.includes('text is too long')
   )
 }

--- a/telegram-plugin/shared/bot-runtime.ts
+++ b/telegram-plugin/shared/bot-runtime.ts
@@ -29,6 +29,7 @@ import { createHash } from 'crypto'
 import { AsyncLocalStorage } from 'async_hooks'
 import { clearStaleTelegramPollingState } from '../startup-reset.js'
 import { createRetryApiCall } from '../retry-api-call.js'
+import { RICH_MESSAGE_MAX_CHARS } from '../format.js'
 
 // ─── tg-post tag plumbing ─────────────────────────────────────────────────
 
@@ -179,7 +180,11 @@ export function stripAnsi(text: string): string {
   return text.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '')
 }
 
-export function formatSwitchroomOutput(output: string, maxLen = 4000): string {
+// Default truncation budget for CLI output bound for Telegram. Post-#2669 the
+// rich-message wire cap is RICH_MESSAGE_MAX_CHARS (32768), not the legacy 4096
+// plain-text limit; the preBlock fence framing (~8 chars) easily fits the
+// remaining headroom.
+export function formatSwitchroomOutput(output: string, maxLen = RICH_MESSAGE_MAX_CHARS): string {
   const trimmed = output.trim()
   if (trimmed.length <= maxLen) return trimmed
   return trimmed.slice(0, maxLen - 20) + '\n... (truncated)'

--- a/telegram-plugin/silent-reply-anchor.ts
+++ b/telegram-plugin/silent-reply-anchor.ts
@@ -38,8 +38,15 @@
  * the safety net off; reverts to per-reply fresh send.
  */
 
-/** Telegram caption / text limit. The accumulator stays under this. */
-export const TELEGRAM_MSG_CAP = 4000
+import { RICH_MESSAGE_MAX_CHARS } from './format.js'
+
+/**
+ * Telegram rich-message text limit. The accumulator stays under this before
+ * it rolls to a fresh anchor. Post-#2669 every reply renders as GFM markdown
+ * via `sendRichMessage`, so the cap is `RICH_MESSAGE_MAX_CHARS` (32768), not
+ * the legacy 4096 plain-text limit.
+ */
+export const TELEGRAM_MSG_CAP = RICH_MESSAGE_MAX_CHARS
 
 export interface SilentReplyAnchorDecisionInput {
   /** True when the model passed `disable_notification: true` for

--- a/telegram-plugin/status-no-truncate.ts
+++ b/telegram-plugin/status-no-truncate.ts
@@ -8,12 +8,18 @@
  * holds the tuning constants that primitive (and its internal helpers)
  * read, so a forked renderer never re-derives them.
  *
+ * Wire cap: since the Bot API 10.1 rich-message migration (#2669) every card
+ * renders as GFM markdown via `sendRichMessage`, whose limit is
+ * `RICH_MESSAGE_MAX_CHARS` (32768), not the legacy 4096 plain-text cap.
+ *
  * The former `SWITCHROOM_STATUS_NO_TRUNCATE` feature flag was retired:
  * rolling-window-with-char-budget is now the only behaviour. The per-line
  * cap (`STATUS_LINE_MAX`) and rolling window (`STATUS_ROLLING_LINES`) apply
  * universally on BOTH surfaces; the total char budget
  * (`STATUS_CARD_CHAR_BUDGET`) is the wire-limit backstop.
  */
+
+import { RICH_MESSAGE_MAX_CHARS } from './format.js'
 
 /**
  * Number of trailing narrative/step lines shown in the rolling window.
@@ -30,15 +36,15 @@ export const STATUS_ROLLING_LINES = 5
 export const STATUS_LINE_MAX = 200
 
 /**
- * The safe char budget for a rendered Telegram status card. Telegram's hard
- * cap is 4096; we use 4000 to leave 96 chars of headroom for HTML framing,
- * emoji, and escape expansion — matching the convention in
- * pending-work-progress.ts (TELEGRAM_MSG_CAP = 4000).
+ * The safe char budget for a rendered Telegram status card. The rich-message
+ * wire cap is `RICH_MESSAGE_MAX_CHARS` (32768) post-#2669 — the legacy 4096
+ * plain-text cap no longer applies on the rich path. We use the constant
+ * directly as the backstop.
  *
  * With STATUS_ROLLING_LINES=5 lines each ≤ STATUS_LINE_MAX this backstop
  * effectively never fires in practice, but is kept as a wire-limit safety net.
  */
-export const STATUS_CARD_CHAR_BUDGET = 4000
+export const STATUS_CARD_CHAR_BUDGET = RICH_MESSAGE_MAX_CHARS
 
 /** Indent marker for a nested (foreground sub-agent) step line. */
 export const NESTED_PREFIX = '   ↳ '

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -152,6 +152,12 @@ export interface StreamReplyDeps {
   retry?: RetryPolicy
   /** Whitespace repair applied to the raw caller text. */
   repairEscapedWhitespace: (text: string) => string
+  /**
+   * Promote lone prose paragraph breaks into GFM hard breaks so the rich
+   * path doesn't collapse them. Optional for backward compat; when omitted,
+   * the raw (repaired) text is sent unchanged.
+   */
+  normalizeParagraphBreaks?: (text: string) => string
   /** Validates the chat id against the access list. Throws on deny. */
   assertAllowedChat: (chatId: string) => void
   /** Resolves the effective thread id (explicit, last-inbound, or undefined). */
@@ -302,7 +308,9 @@ export async function handleStreamReply(
   deps: StreamReplyDeps,
 ): Promise<StreamReplyResult> {
   const chat_id = args.chat_id
-  const rawText = deps.repairEscapedWhitespace(args.text)
+  const rawText = deps.normalizeParagraphBreaks
+    ? deps.normalizeParagraphBreaks(deps.repairEscapedWhitespace(args.text))
+    : deps.repairEscapedWhitespace(args.text)
   const done = Boolean(args.done)
   const format = args.format ?? deps.defaultFormat
   if (done) {

--- a/telegram-plugin/tests/ipc-server-validate-send-outbound.test.ts
+++ b/telegram-plugin/tests/ipc-server-validate-send-outbound.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { validateClientMessage } from "../gateway/ipc-server.js";
+import { RICH_MESSAGE_MAX_CHARS } from "../format.js";
 
 const base = { type: "send_outbound", agentName: "clerk", chatId: "12345", text: "Daily heartbeat" };
 
@@ -38,8 +39,11 @@ describe("validateClientMessage — send_outbound", () => {
     expect(validateClientMessage({ ...base, text: undefined })).toBe(false);
     expect(validateClientMessage({ ...base, text: "" })).toBe(false);
     expect(validateClientMessage({ ...base, text: 5 })).toBe(false);
-    expect(validateClientMessage({ ...base, text: "x".repeat(4096) })).toBe(true); // at the cap
-    expect(validateClientMessage({ ...base, text: "x".repeat(4097) })).toBe(false); // over Telegram's limit
+    // send_outbound posts via sendRichMessage (rich path), so the cap is the
+    // rich-message wire limit (RICH_MESSAGE_MAX_CHARS, 32768) post-#2669, not
+    // the legacy 4096 plain-text limit.
+    expect(validateClientMessage({ ...base, text: "x".repeat(RICH_MESSAGE_MAX_CHARS) })).toBe(true); // at the cap
+    expect(validateClientMessage({ ...base, text: "x".repeat(RICH_MESSAGE_MAX_CHARS + 1) })).toBe(false); // over the cap
   });
 
   it("rejects a non-integer threadId", () => {

--- a/telegram-plugin/tests/length-error-classify.test.ts
+++ b/telegram-plugin/tests/length-error-classify.test.ts
@@ -12,7 +12,7 @@ import { describe, test, expect } from 'vitest'
 import { GrammyError } from 'grammy'
 import { isLengthError, isParseEntitiesError } from '../rich-send.js'
 import { isMessageTooLongError, isHtmlParseRejectError } from '../retry-api-call.js'
-import { hardSliceToCap, RICH_MESSAGE_MAX_CHARS } from '../format.js'
+import { hardSliceToCap, splitMarkdownChunks, RICH_MESSAGE_MAX_CHARS } from '../format.js'
 
 // Build a GrammyError with a given 400 description. GrammyError's constructor
 // takes (message, payload, method, parameters) in grammy 1.44.
@@ -93,5 +93,39 @@ describe('hardSliceToCap', () => {
     expect(pieces).toHaveLength(2)
     expect(pieces[0].length).toBe(RICH_MESSAGE_MAX_CHARS)
     expect(pieces[1].length).toBe(5)
+  })
+})
+
+// The gateway length-error recovery (gateway.ts sendChunkResplit, ~8758) re-splits
+// an oversized chunk with `splitMarkdownChunks` and falls back to `hardSliceToCap`
+// when the block is indivisible. These tests pin that seam at the function level:
+// a >RICH_MESSAGE_MAX_CHARS body is ALWAYS chunked into >=2 sends (each <= cap),
+// never silently dropped or resent whole on a RICH_MESSAGE_TEXT_TOO_LONG reject.
+describe('resplit-on-reject: oversized body chunks into >=2 sends', () => {
+  test('a >cap body with prose boundaries re-splits into >=2 chunks each <= cap', () => {
+    // A paragraph-separated body twice the cap: splitMarkdownChunks finds the
+    // `\n\n` boundaries and yields multiple chunks.
+    const para = 'x'.repeat(4000)
+    const body = Array.from({ length: 20 }, () => para).join('\n\n')
+    expect(body.length).toBeGreaterThan(RICH_MESSAGE_MAX_CHARS)
+    const pieces = splitMarkdownChunks(body, RICH_MESSAGE_MAX_CHARS)
+    expect(pieces.length).toBeGreaterThanOrEqual(2)
+    for (const p of pieces) expect(p.length).toBeLessThanOrEqual(RICH_MESSAGE_MAX_CHARS)
+  })
+
+  test('an indivisible >cap blob falls back through hardSliceToCap to >=2 chunks each <= cap', () => {
+    // A single boundary-free blob larger than the cap: splitMarkdownChunks
+    // cannot break it and emits it whole (length > cap), so the recovery path
+    // hands it to hardSliceToCap — mirroring sendChunkResplit's fallback.
+    const blob = 'z'.repeat(RICH_MESSAGE_MAX_CHARS + 5000)
+    const subPieces = splitMarkdownChunks(blob, RICH_MESSAGE_MAX_CHARS)
+    const pieces =
+      subPieces.length > 1 && subPieces.every((p) => p.length <= RICH_MESSAGE_MAX_CHARS)
+        ? subPieces
+        : hardSliceToCap(blob, RICH_MESSAGE_MAX_CHARS)
+    expect(pieces.length).toBeGreaterThanOrEqual(2)
+    for (const p of pieces) expect(p.length).toBeLessThanOrEqual(RICH_MESSAGE_MAX_CHARS)
+    // Nothing is dropped — the pieces reconstitute the original body.
+    expect(pieces.join('')).toBe(blob)
   })
 })

--- a/telegram-plugin/tests/length-error-classify.test.ts
+++ b/telegram-plugin/tests/length-error-classify.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the over-length error classification (task E of the Telegram-
+ * formatting bundle) and the hardSliceToCap last-resort slicer.
+ *
+ * The rich path rejects a 32769+ char body with `RICH_MESSAGE_TEXT_TOO_LONG`
+ * (and the legacy plain path with `MESSAGE_TOO_LONG`). That is a LENGTH error,
+ * not a markdown-parse error — it must be classified so the caller re-splits
+ * the body rather than (a) misclassifying it as a parse-reject and resending
+ * the same oversized payload as plain text, or (b) surfacing the raw 400.
+ */
+import { describe, test, expect } from 'vitest'
+import { GrammyError } from 'grammy'
+import { isLengthError, isParseEntitiesError } from '../rich-send.js'
+import { isMessageTooLongError, isHtmlParseRejectError } from '../retry-api-call.js'
+import { hardSliceToCap, RICH_MESSAGE_MAX_CHARS } from '../format.js'
+
+// Build a GrammyError with a given 400 description. GrammyError's constructor
+// takes (message, payload, method, parameters) in grammy 1.44.
+function grammy400(description: string): GrammyError {
+  return new GrammyError(
+    `Call to 'sendRichMessage' failed! (400: ${description})`,
+    { ok: false, error_code: 400, description },
+    'sendRichMessage',
+    {},
+  )
+}
+
+describe('length-error classification (rich-send.isLengthError)', () => {
+  test('RICH_MESSAGE_TEXT_TOO_LONG is a length error', () => {
+    const err = grammy400('RICH_MESSAGE_TEXT_TOO_LONG')
+    expect(isLengthError(err)).toBe(true)
+  })
+
+  test('legacy MESSAGE_TOO_LONG / "message is too long" are length errors', () => {
+    expect(isLengthError(grammy400('MESSAGE_TOO_LONG'))).toBe(true)
+    expect(isLengthError(grammy400('Bad Request: message is too long'))).toBe(true)
+  })
+
+  test('a parse-entities error is NOT a length error', () => {
+    expect(isLengthError(grammy400("can't parse entities: bad offset"))).toBe(false)
+  })
+
+  test('a length error is NOT misclassified as a parse-entities error', () => {
+    const err = grammy400('RICH_MESSAGE_TEXT_TOO_LONG')
+    expect(isParseEntitiesError(err)).toBe(false)
+  })
+
+  test('non-GrammyError and non-400 are neither', () => {
+    expect(isLengthError(new Error('boom'))).toBe(false)
+    const err403 = new GrammyError(
+      'forbidden',
+      { ok: false, error_code: 403, description: 'Forbidden: bot was blocked' },
+      'sendRichMessage',
+      {},
+    )
+    expect(isLengthError(err403)).toBe(false)
+  })
+})
+
+describe('length-error classification (retry-api-call.isMessageTooLongError)', () => {
+  test('RICH_MESSAGE_TEXT_TOO_LONG is a length error', () => {
+    expect(isMessageTooLongError(grammy400('RICH_MESSAGE_TEXT_TOO_LONG'))).toBe(true)
+  })
+
+  test('a length error is NOT misclassified as an html-parse-reject', () => {
+    const err = grammy400('RICH_MESSAGE_TEXT_TOO_LONG')
+    expect(isHtmlParseRejectError(err)).toBe(false)
+  })
+
+  test('a parse-reject error still classifies as a parse-reject (not length)', () => {
+    const err = grammy400("can't parse entities: unexpected end")
+    expect(isHtmlParseRejectError(err)).toBe(true)
+    expect(isMessageTooLongError(err)).toBe(false)
+  })
+})
+
+describe('hardSliceToCap', () => {
+  test('returns the input as one piece when it already fits', () => {
+    expect(hardSliceToCap('short', 100)).toEqual(['short'])
+  })
+
+  test('slices an oversized body into pieces each <= cap', () => {
+    const body = 'x'.repeat(250)
+    const pieces = hardSliceToCap(body, 100)
+    expect(pieces).toHaveLength(3)
+    for (const p of pieces) expect(p.length).toBeLessThanOrEqual(100)
+    expect(pieces.join('')).toBe(body)
+  })
+
+  test('defaults the cap to RICH_MESSAGE_MAX_CHARS', () => {
+    const body = 'y'.repeat(RICH_MESSAGE_MAX_CHARS + 5)
+    const pieces = hardSliceToCap(body)
+    expect(pieces).toHaveLength(2)
+    expect(pieces[0].length).toBe(RICH_MESSAGE_MAX_CHARS)
+    expect(pieces[1].length).toBe(5)
+  })
+})

--- a/telegram-plugin/tests/paragraph-normalizer.test.ts
+++ b/telegram-plugin/tests/paragraph-normalizer.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for normalizeParagraphBreaks (task A of the Telegram-formatting bundle).
+ *
+ * The rich GFM render path collapses a LONE `\n` (it's a soft break), so a model
+ * that separates paragraphs with one newline produces a cramped wall of text.
+ * normalizeParagraphBreaks promotes a lone *prose* `\n` into a GFM hard break
+ * (`  \n`) while leaving lists, tables, blockquotes, headings, code, and genuine
+ * `\n\n` gaps untouched. It is deliberately conservative — false negatives
+ * (un-promoted break) are preferred over false positives (double-spaced list).
+ */
+import { describe, test, expect } from 'vitest'
+import { normalizeParagraphBreaks } from '../format.js'
+
+describe('normalizeParagraphBreaks', () => {
+  test('promotes a lone prose paragraph break (prev ends with `.`, next is prose)', () => {
+    const input = 'First thought ends here.\nSecond thought starts here.'
+    expect(normalizeParagraphBreaks(input)).toBe(
+      'First thought ends here.  \nSecond thought starts here.',
+    )
+  })
+
+  test('promotes after ! ? and : terminators too', () => {
+    expect(normalizeParagraphBreaks('Done!\nNext line here.')).toBe('Done!  \nNext line here.')
+    expect(normalizeParagraphBreaks('Really?\nYes, really.')).toBe('Really?  \nYes, really.')
+    expect(normalizeParagraphBreaks('Steps follow:\nDo the thing.')).toBe(
+      'Steps follow:  \nDo the thing.',
+    )
+  })
+
+  test('promotes when the terminator is wrapped by a closing quote or paren', () => {
+    expect(normalizeParagraphBreaks('He said "go."\nThen we went.')).toBe(
+      'He said "go."  \nThen we went.',
+    )
+    expect(normalizeParagraphBreaks('(all done.)\nMoving on now.')).toBe(
+      '(all done.)  \nMoving on now.',
+    )
+  })
+
+  test('does NOT promote a lone mid-sentence soft wrap (prev has no terminator)', () => {
+    // A soft-wrapped sentence: the first line does not end in terminal
+    // punctuation, so we leave the break alone (false negative by design).
+    const input = 'this is a long sentence that wrapped\nonto a second line mid-thought'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
+  test('does NOT promote when the next line is a list item (tight list stays tight)', () => {
+    const input = 'Here are the steps.\n- first\n- second\n- third'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
+  test('does NOT promote between list items (ordered or unordered)', () => {
+    const ul = '- alpha.\n- beta.\n- gamma.'
+    const ol = '1. first.\n2. second.\n3. third.'
+    expect(normalizeParagraphBreaks(ul)).toBe(ul)
+    expect(normalizeParagraphBreaks(ol)).toBe(ol)
+  })
+
+  test('does NOT promote indented (nested) list items', () => {
+    const input = '- parent.\n    - child one.\n    - child two.'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
+  test('does NOT touch a markdown table', () => {
+    const input = '| col a | col b |\n| --- | --- |\n| r1a | r1b |\n| r2a | r2b |'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
+  test('does NOT promote into a blockquote or heading', () => {
+    expect(normalizeParagraphBreaks('As noted.\n> a quoted line')).toBe('As noted.\n> a quoted line')
+    expect(normalizeParagraphBreaks('Intro line.\n# Heading')).toBe('Intro line.\n# Heading')
+  })
+
+  test('preserves a fenced code block verbatim (interior newlines untouched)', () => {
+    const input = 'Look here.\n```js\nconst a = 1;\nconst b = 2;\n```\nDone.'
+    const out = normalizeParagraphBreaks(input)
+    // The fence body is preserved exactly — no hard break injected inside it.
+    expect(out).toContain('```js\nconst a = 1;\nconst b = 2;\n```')
+    // The fence start line is a marker, so the break before it is not promoted.
+    expect(out).toContain('Look here.\n```js')
+  })
+
+  test('preserves inline code spans verbatim', () => {
+    const input = 'Run `npm test` now.\nThen check the output.'
+    const out = normalizeParagraphBreaks(input)
+    expect(out).toContain('`npm test`')
+    // Prose break after a sentence ending in `.` is still promoted.
+    expect(out).toBe('Run `npm test` now.  \nThen check the output.')
+  })
+
+  test('preserves an existing `\\n\\n` paragraph gap (never collapses it)', () => {
+    const input = 'Paragraph one.\n\nParagraph two.'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
+  test('collapses 3+ newlines down to exactly `\\n\\n`', () => {
+    expect(normalizeParagraphBreaks('A.\n\n\nB.')).toBe('A.\n\nB.')
+    expect(normalizeParagraphBreaks('A.\n\n\n\n\nB.')).toBe('A.\n\nB.')
+  })
+
+  test('does not promote a break adjacent to a blank line', () => {
+    // The newline that is part of a `\n\n` gap must stay a plain newline, not
+    // become a `  \n` hard break.
+    const input = 'Done.\n\nMore prose.'
+    const out = normalizeParagraphBreaks(input)
+    expect(out).not.toContain('  \n\n')
+    expect(out).toBe('Done.\n\nMore prose.')
+  })
+
+  test('handles a mixed body: prose promoted, list left alone, fence preserved', () => {
+    const input = [
+      'Summary of the change.',
+      'It does two things now.',
+      '',
+      '- adds a normalizer',
+      '- lifts the char cap',
+      '',
+      '```ts',
+      'const x = 1',
+      '```',
+    ].join('\n')
+    const out = normalizeParagraphBreaks(input)
+    // The two prose lines get a hard break between them.
+    expect(out).toContain('Summary of the change.  \nIt does two things now.')
+    // The list stays tight.
+    expect(out).toContain('- adds a normalizer\n- lifts the char cap')
+    // The fence is intact.
+    expect(out).toContain('```ts\nconst x = 1\n```')
+  })
+
+  test('returns single-line input unchanged (no newline to consider)', () => {
+    expect(normalizeParagraphBreaks('just one line, no breaks')).toBe('just one line, no breaks')
+  })
+
+  test('does not double-promote an already-hard break', () => {
+    // A break already followed by two trailing spaces should not gain more.
+    const input = 'Done.  \nNext.'
+    const out = normalizeParagraphBreaks(input)
+    // prev line trimEnd() ends in `.`, so it promotes — but the result must not
+    // accumulate extra spaces beyond the single `  \n` hard break.
+    expect(out).toBe('Done.  \nNext.')
+  })
+})

--- a/telegram-plugin/tests/paragraph-normalizer.test.ts
+++ b/telegram-plugin/tests/paragraph-normalizer.test.ts
@@ -65,9 +65,17 @@ describe('normalizeParagraphBreaks', () => {
     expect(normalizeParagraphBreaks(input)).toBe(input)
   })
 
-  test('does NOT promote into a blockquote or heading', () => {
-    expect(normalizeParagraphBreaks('As noted.\n> a quoted line')).toBe('As noted.\n> a quoted line')
-    expect(normalizeParagraphBreaks('Intro line.\n# Heading')).toBe('Intro line.\n# Heading')
+  test('does NOT promote into a blockquote or heading (but DOES guarantee a block-start blank line)', () => {
+    // The lone `\n` is never promoted to a hard break (`  \n`) when the next
+    // line is a blockquote / heading marker — but Step 3 DOES guarantee the
+    // blank line a GFM block needs to start, so prose→quote and prose→heading
+    // transitions get a `\n\n` gap (the block renders correctly).
+    expect(normalizeParagraphBreaks('As noted.\n> a quoted line')).toBe(
+      'As noted.\n\n> a quoted line',
+    )
+    expect(normalizeParagraphBreaks('Intro line.\n# Heading')).toBe('Intro line.\n\n# Heading')
+    // No spurious hard break (`  \n`) is ever introduced at the boundary.
+    expect(normalizeParagraphBreaks('As noted.\n> a quoted line')).not.toContain('  \n')
   })
 
   test('preserves a fenced code block verbatim (interior newlines untouched)', () => {
@@ -75,8 +83,9 @@ describe('normalizeParagraphBreaks', () => {
     const out = normalizeParagraphBreaks(input)
     // The fence body is preserved exactly — no hard break injected inside it.
     expect(out).toContain('```js\nconst a = 1;\nconst b = 2;\n```')
-    // The fence start line is a marker, so the break before it is not promoted.
-    expect(out).toContain('Look here.\n```js')
+    // A blank line is guaranteed BEFORE the fence open so it starts a fresh
+    // GFM code block instead of being glued to the preceding prose line.
+    expect(out).toContain('Look here.\n\n```js')
   })
 
   test('preserves inline code spans verbatim', () => {
@@ -153,6 +162,112 @@ describe('normalizeParagraphBreaks', () => {
     // CommonMark indented code block (4+ leading spaces then non-space) is a
     // block marker — a break adjacent to it must NOT be promoted to a hard break.
     const input = 'Note:\n    indented code'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
+  // -------------------------------------------------------------------------
+  // Step 3 — block-boundary blank-line guarantee. A GFM block glued to the
+  // previous line by a single `\n` fails to render (a table prints as literal
+  // pipe text; prose after a list is absorbed as a lazy list continuation).
+  // These cases capture the two live-render bugs plus the regression guards
+  // that the tight-list / code / table-internals constraints depend on.
+  // -------------------------------------------------------------------------
+
+  test('inserts a blank line before a table header glued to a single-`\\n` text line (VERIFY 5)', () => {
+    // The live render showed the table printing as inline literal pipe text
+    // because only a single `\n` separated the preceding text line from the
+    // table's first row. A blank line must be inserted BEFORE the header, and
+    // header + delimiter + body rows must stay contiguous (single `\n`).
+    const input =
+      'VERIFY 5 — GFM table\n| Name | Role |\n|---|---|\n| Ada | Engineer |\n| Bob | Designer |'
+    expect(normalizeParagraphBreaks(input)).toBe(
+      'VERIFY 5 — GFM table\n\n| Name | Role |\n|---|---|\n| Ada | Engineer |\n| Bob | Designer |',
+    )
+  })
+
+  test('inserts a blank line before post-list prose, list stays tight, fence untouched (VERIFY 7)', () => {
+    // The live render showed "A prose line after the list." absorbed into the
+    // last bullet (GFM lazy continuation). A blank line must break it out of
+    // the list, while the bullets stay tight and the fence stays verbatim.
+    const input =
+      'VERIFY 7 — mixed\n' +
+      'This first prose sentence stands alone.\n' +
+      'This second prose sentence should show a gap above it.\n' +
+      '- bullet\n' +
+      '- list\n' +
+      'A prose line after the list.\n' +
+      '```\n' +
+      'echo hello.\n' +
+      'echo world.\n' +
+      '```'
+    const out = normalizeParagraphBreaks(input)
+    // The two leading prose sentences are promoted (each ends in `.`).
+    expect(out).toContain(
+      'This first prose sentence stands alone.  \nThis second prose sentence should show a gap above it.',
+    )
+    // The bullet items stay TIGHT — no blank line between same-list items.
+    expect(out).toContain('- bullet\n- list')
+    // The post-list prose is separated from the list by a blank line.
+    expect(out).toContain('- list\n\nA prose line after the list.')
+    // The fence interior is untouched and the fence is preceded by a blank line.
+    expect(out).toContain('```\necho hello.\necho world.\n```')
+    expect(out).toContain('A prose line after the list.\n\n```')
+  })
+
+  test('regression: a pure tight bullet list stays tight (no blank lines inserted)', () => {
+    const input = '- alpha\n- beta\n- gamma'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
+  test('regression: a pure tight numbered list stays tight (no blank lines inserted)', () => {
+    const input = '1. first\n2. second\n3. third'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
+  test('regression: existing `\\n\\n` paragraphs are unchanged (no extra gap)', () => {
+    const input = 'Para one.\n\nPara two.\n\nPara three.'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
+  test('regression: a fenced code block with `|` pipes / `-` lines is NOT treated as a table', () => {
+    // The pipes and dashes live INSIDE a fence — masking must keep them out of
+    // the table heuristic so no spurious blank line is injected inside or
+    // around the code, and the interior is byte-for-byte preserved.
+    const input = 'Header here.\n```\n| not | a | table |\n|---|---|---|\n--- dash line\n```'
+    const out = normalizeParagraphBreaks(input)
+    // The fence interior is verbatim — pipes and dashes untouched.
+    expect(out).toContain('```\n| not | a | table |\n|---|---|---|\n--- dash line\n```')
+    // The fence open gets its block-start blank line (it's a code block, not a
+    // table) but nothing inside it is reflowed.
+    expect(out).toBe(
+      'Header here.\n\n```\n| not | a | table |\n|---|---|---|\n--- dash line\n```',
+    )
+  })
+
+  test('a heading after prose gets its block-start blank line', () => {
+    expect(normalizeParagraphBreaks('Some intro prose.\n## Section')).toBe(
+      'Some intro prose.\n\n## Section',
+    )
+  })
+
+  test('a blockquote after prose gets its block-start blank line', () => {
+    expect(normalizeParagraphBreaks('Some intro prose.\n> quoted wisdom')).toBe(
+      'Some intro prose.\n\n> quoted wisdom',
+    )
+  })
+
+  test('does NOT split a table header from its delimiter or body rows', () => {
+    // A table already preceded by a blank line must keep all of its own rows
+    // contiguous (single `\n`) — the blank-line rule only fires BEFORE the
+    // header, never between header/delimiter/body.
+    const input = 'Intro.\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
+  test('list followed by an indented continuation line stays glued (no breakout)', () => {
+    // A 4-space indented line under a bullet is a lazy paragraph continuation
+    // of that item, not breakout prose — it must NOT gain a blank line.
+    const input = '- first item\n    continued text of the first item'
     expect(normalizeParagraphBreaks(input)).toBe(input)
   })
 })

--- a/telegram-plugin/tests/paragraph-normalizer.test.ts
+++ b/telegram-plugin/tests/paragraph-normalizer.test.ts
@@ -139,4 +139,20 @@ describe('normalizeParagraphBreaks', () => {
     // accumulate extra spaces beyond the single `  \n` hard break.
     expect(out).toBe('Done.  \nNext.')
   })
+
+  test('CRLF input promotes to a hard break with NO stranded `\\r`', () => {
+    // A CRLF source must not leave a lone carriage return before the injected
+    // `  \n`. The trailing-whitespace strip includes `\r` so the result is a
+    // clean `  \n` hard break, not `  \r\n` or `\r  \n`.
+    const out = normalizeParagraphBreaks('Alpha.\r\nBravo.')
+    expect(out).toBe('Alpha.  \nBravo.')
+    expect(out).not.toContain('\r')
+  })
+
+  test('does NOT promote a break adjacent to an indented code block', () => {
+    // CommonMark indented code block (4+ leading spaces then non-space) is a
+    // block marker — a break adjacent to it must NOT be promoted to a hard break.
+    const input = 'Note:\n    indented code'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
 })

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2825,6 +2825,77 @@ describe("scaffoldAgent with global defaults cascade", () => {
     expect(startSh).toContain('--append-system-prompt "$APPEND_PROMPT"');
   });
 
+  it("injects the Telegram formatting floor card into --append-system-prompt (scaffold path)", () => {
+    // The floor card (TELEGRAM_FORMATTING_FLOOR_CARD in scaffold.ts) is the
+    // model-independent formatting guidance baked into EVERY session's
+    // --append-system-prompt. It must land in start.sh's APPEND_PROMPT, and it
+    // must NOT depend on any per-agent config — a bare agent still gets it.
+    const config = makeAgentConfig({});
+    const result = scaffoldAgent(
+      "floor-card-agent",
+      config,
+      tmpDir,
+      telegramConfig,
+    );
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    // Stable distinctive substrings pulled verbatim from the floor card (none
+    // contain single quotes, so POSIX single-quote wrapping leaves them intact).
+    expect(startSh).toContain("## Formatting for Telegram");
+    expect(startSh).toContain("Hard cap is 32768 characters.");
+    expect(startSh).toContain("Every reply renders as rich Markdown");
+    // It rides the same --append-system-prompt var the operator passthrough uses.
+    expect(startSh).toContain('--append-system-prompt "$APPEND_PROMPT"');
+  });
+
+  it("prepends the floor card BEFORE the operator's system_prompt_append (not overwritten)", () => {
+    // When an operator sets system_prompt_append, the floor card must be
+    // PREPENDED — both the floor card and the operator's text must survive,
+    // proving the injection augments rather than replaces the passthrough.
+    const operatorText = "OPERATOR_PASSTHROUGH_MARKER_xyz";
+    const config = makeAgentConfig({ system_prompt_append: operatorText });
+    const result = scaffoldAgent(
+      "floor-card-plus-op-agent",
+      config,
+      tmpDir,
+      telegramConfig,
+    );
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    // Both present.
+    expect(startSh).toContain("Hard cap is 32768 characters.");
+    expect(startSh).toContain(operatorText);
+    // Order: the floor card's marker precedes the operator's marker (prepended).
+    const floorIdx = startSh.indexOf("## Formatting for Telegram");
+    const opIdx = startSh.indexOf(operatorText);
+    expect(floorIdx).toBeGreaterThanOrEqual(0);
+    expect(opIdx).toBeGreaterThan(floorIdx);
+  });
+
+  it("injects the Telegram formatting floor card on the reconcile path too", () => {
+    // The live `switchroom apply` recreates EXISTING agents via reconcileAgent,
+    // not scaffoldAgent — so the floor card must also survive the reconcile
+    // re-render of start.sh (the two paths are kept in lockstep).
+    const operatorText = "OPERATOR_RECONCILE_MARKER_xyz";
+    const config = makeAgentConfig({ system_prompt_append: operatorText });
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "floor-card-reconcile": config },
+    } as SwitchroomConfig;
+    scaffoldAgent("floor-card-reconcile", config, tmpDir, telegramConfig, switchroomConfig);
+    reconcileAgent("floor-card-reconcile", config, tmpDir, telegramConfig, switchroomConfig);
+    const startSh = readFileSync(
+      join(tmpDir, "floor-card-reconcile", "start.sh"),
+      "utf-8",
+    );
+    expect(startSh).toContain("## Formatting for Telegram");
+    expect(startSh).toContain("Hard cap is 32768 characters.");
+    // Operator passthrough still survives the reconcile path, prepended-after.
+    expect(startSh).toContain(operatorText);
+    const floorIdx = startSh.indexOf("## Formatting for Telegram");
+    const opIdx = startSh.indexOf(operatorText);
+    expect(opIdx).toBeGreaterThan(floorIdx);
+  });
+
   it("settings_raw deep-merges into the generated settings.json", () => {
     const agentConfig = makeAgentConfig({
       settings_raw: {


### PR DESCRIPTION
## Summary

A bundle of rich-Markdown formatting fixes on the Bot API 10.1 rich-message path (the #2669 follow-up), in three pieces:

1. **Paragraph-spacing normalizer** (`format.ts normalizeParagraphBreaks`) — promotes a LONE prose `\n` into a GFM hard break (`  \n`) so paragraph separation survives the GFM soft-break collapse, while leaving lists, tables, blockquotes, headings, code, indented code blocks, and genuine `\n\n` gaps untouched. Conservative by design (prefers false negatives). Wired into `reply` / `stream_reply` / `edit_message`.
2. **Char-cap consistency** — lifted stale `4000`/`4096` literals to `RICH_MESSAGE_MAX_CHARS` (`32768`) across the send/validate path, with over-length errors (`RICH_MESSAGE_TEXT_TOO_LONG` / `MESSAGE_TOO_LONG`) now classified as LENGTH errors and recovered by re-splitting instead of resending an oversized body as plain text.
3. **Boot-injected formatting floor card** — `TELEGRAM_FORMATTING_FLOOR_CARD` injected into every agent's `--append-system-prompt` (scaffold + reconcile paths), model-independent, prepended before the operator's `system_prompt_append`.

This second commit adds the edge-case fixes + the test-coverage the UAT-coverage audit flagged.

## Why — outcome served

**Visibility** — readable, scannable messages on a phone screen. A model that separates paragraphs with a single newline otherwise produces a cramped wall of text once GFM collapses the soft break. This is the **#2669 rich-message follow-up**: now that every reply renders as rich Markdown, the formatting floor has to be enforced so the rich path actually improves readability rather than regressing it.

## Edge-case fixes in this commit

- **CRLF stranded `\r`** — `normalizeParagraphBreaks`'s trailing-whitespace strip now includes `\r` (`/[ \t\r]+$/`), so a CRLF source (`"Alpha.\r\nBravo."`) no longer leaves a lone carriage return before the injected `  \n`.
- **Indented code block** — `isMarkerLine` now treats a CommonMark indented code block (4+ leading spaces then non-space, tested on the RAW pre-trim line via `/^ {4,}\S/`) as a block marker, so a break adjacent to it is NOT promoted.
- **Stale comment** — `ipc-server.ts` `pty_partial` comment corrected: the `8192` bound is a preview-buffer bound, not the wire cap (which is now `RICH_MESSAGE_MAX_CHARS` / `32768` on the rich path).

## New tests

- `telegram-plugin/tests/paragraph-normalizer.test.ts`:
  - CRLF input promotes to a hard break with NO stranded `\r`.
  - A break adjacent to an indented code block is NOT promoted.
- `tests/scaffold.test.ts` (floor-card injection — previously **zero** coverage):
  - Floor-card substrings land in `start.sh`'s `--append-system-prompt` on the **scaffold** path.
  - Floor card is **prepended before** the operator's `system_prompt_append` (not overwritten).
  - Same injection on the **reconcile** path (the live `switchroom apply` re-render).
- `telegram-plugin/tests/length-error-classify.test.ts` (resplit-on-reject):
  - A `>32768` body with prose boundaries re-splits into `>=2` chunks, each `<= RICH_MESSAGE_MAX_CHARS`.
  - An indivisible `>cap` blob falls back through `hardSliceToCap` to `>=2` chunks (nothing dropped — pieces reconstitute the original).

The **adversarial review verdict was SHIP**; this commit closes the one untested surface the UAT-coverage audit identified.

## Empirically-verified facts

- The exact rich-message cap is **32768** characters.
- `\n\n` renders a visible paragraph gap; a lone `\n` collapses onto the same line (the soft-break collapse the normalizer compensates for).

## Out of scope

Part 3 platform-card reformatting is intentionally **not** in this bundle — it's a separate collaborative pass.

## Coverage layer note

No MTProto UAT scenario is added: the UAT driver strips entities (`uat/driver.ts:845` returns plain `msg.text`), so a live formatting scenario is blind to rendering and would be a no-op. The unit / bun layer above is the correct, CI-enforceable coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)