### PR TITLE
fix(hostd/approval): show reason on gated-verb cards + deterministic TTL resume

### DIFF
--- a/reference/rfcs/host-control-daemon.md
+++ b/reference/rfcs/host-control-daemon.md
@@ -297,10 +297,10 @@ Verb set (v1, closed):
 | Verb | Args | Effect | Trust |
 |---|---|---|---|
 | `agent_restart` | `name`, `reason`, `force?` | runs `switchroom agent restart <name> [--force]` on host | self → any agent; cross-agent → admin |
-| `agent_start` | `name` | `switchroom agent start <name>` | admin |
-| `agent_stop` | `name` | `switchroom agent stop <name>` | admin |
+| `agent_start` | `name`, `reason?` | `switchroom agent start <name>` | admin |
+| `agent_stop` | `name`, `reason?` | `switchroom agent stop <name>` | admin |
 | `update_check` | (none) | `switchroom update --check`, returns plan | admin |
-| `update_apply` | `skip_images?`, `rebuild?` | `switchroom update --apply [flags]` | admin + operator-attest (see §5.4) |
+| `update_apply` | `skip_images?`, `rebuild?`, `reason?` | `switchroom update --apply [flags]` | admin + operator-attest (see §5.4) |
 | `apply` | `non_interactive: true` (forced) | `switchroom apply --non-interactive` | admin + operator-attest |
 | `upgrade_status` | (none) | `switchroom update --status` | any |
 | `reconcile` | `agent?` | `switchroom reconcile [<agent>]` | admin |
@@ -309,6 +309,15 @@ Verb set (v1, closed):
 Anything not in this table is rejected with `result: "denied",
 error: "verb not in v1 allowlist"`. New verbs land via RFC + table
 addition.
+
+**Optional `reason` on gated verbs.** Every operator-gated verb accepts an
+optional `reason` (≤512 chars). It is NOT forwarded to the spawned CLI — it
+exists solely to populate the Telegram approval card's `why:` line so the
+operator can decide in context. The card reads the caller-supplied `reason`
+arg only, never the tool's static schema description (#2469). Agents are
+instructed (via tool description) to always pass a one-line `reason`; absent,
+the card renders `why: not provided`. Schema declares `reason` FIRST so it
+survives Claude Code's ~200-char `input_preview` truncation.
 
 **`get_status` in v1, not streamed progress.** Reviewer-flagged
 (load-bearing): the long-running verbs (`update_apply` at 20–60s,

--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -133,6 +133,10 @@ export const UpdateApplyRequestSchema = z.object({
         .regex(/^(sha-[0-9a-f]{7,40}|v\d+\.\d+\.\d+)$/)
         .nullable()
         .optional(),
+      /** Optional operator-facing rationale, surfaced on the approval
+       *  card's `why:` line (#2469 contract — the card reads ONLY this
+       *  caller-supplied arg, never the schema description). */
+      reason: z.string().max(512).optional(),
     })
     .optional(),
 });
@@ -183,6 +187,9 @@ export const RolloutRequestSchema = z.object({
        * unchanged. Absent ⇒ false (downgrade rejected as before).
        */
       allow_downgrade: z.boolean().optional(),
+      /** Optional operator-facing rationale, surfaced on the approval
+       *  card's `why:` line (#2469 contract — caller-supplied only). */
+      reason: z.string().max(512).optional(),
     })
     .required({ pin: true }),
 });
@@ -192,6 +199,9 @@ export const AgentStartRequestSchema = z.object({
   op: z.literal("agent_start"),
   args: z.object({
     name: AgentNameSchema,
+    /** Optional operator-facing rationale, surfaced on the approval
+     *  card's `why:` line (#2469 contract — caller-supplied only). */
+    reason: z.string().max(512).optional(),
   }),
 });
 
@@ -207,6 +217,9 @@ export const AgentStopRequestSchema = z.object({
     // to reject the unknown option and the verb to exit non-zero. If
     // drain-skip semantics get added to the CLI later, reintroduce the
     // field here in lockstep.
+    /** Optional operator-facing rationale, surfaced on the approval
+     *  card's `why:` line (#2469 contract — caller-supplied only). */
+    reason: z.string().max(512).optional(),
   }),
 });
 
@@ -229,6 +242,9 @@ export const AgentLogsRequestSchema = z.object({
     name: AgentNameSchema,
     /** Number of trailing lines to return (default 100, max 2000). */
     tail: z.number().int().positive().max(2000).optional(),
+    /** Optional operator-facing rationale, surfaced on the approval
+     *  card's `why:` line (#2469 contract — caller-supplied only). */
+    reason: z.string().max(512).optional(),
   }),
 });
 
@@ -249,6 +265,9 @@ export const AgentExecRequestSchema = z.object({
      *  schema stays permissive-but-bounded; the security charclass is
      *  enforced at dispatch so the denial carries a clear reason. */
     argv: z.array(z.string().min(1)).min(1).max(32),
+    /** Optional operator-facing rationale, surfaced on the approval
+     *  card's `why:` line (#2469 contract — caller-supplied only). */
+    reason: z.string().max(512).optional(),
   }),
 });
 

--- a/src/mcp/hostd/server.test.ts
+++ b/src/mcp/hostd/server.test.ts
@@ -244,6 +244,58 @@ describe("dispatchTool — happy path", () => {
     expect(sent.args.allow_downgrade).toBeUndefined();
   });
 
+  // ── Bug 1: gated verbs forward an optional `reason` for the operator
+  //    approval card's `why:` line (#2469 keeps the card reading the
+  //    caller's arg, never the schema description). ──────────────────────
+  it("rollout forwards reason into the request args when provided", async () => {
+    hostdRequestMock.mockResolvedValueOnce(ok({ result: "started" }));
+    await dispatchTool("rollout", {
+      pin: "v0.15.18",
+      reason: "promote canary-green build to the fleet",
+    });
+    const sent = hostdRequestMock.mock.calls[0]![1];
+    expect(sent.args.reason).toBe("promote canary-green build to the fleet");
+  });
+
+  it("rollout omits the reason key when absent", async () => {
+    hostdRequestMock.mockResolvedValueOnce(ok({ result: "started" }));
+    await dispatchTool("rollout", { pin: "v0.15.18" });
+    const sent = hostdRequestMock.mock.calls[0]![1];
+    expect(sent.args).not.toHaveProperty("reason");
+  });
+
+  it("update_apply forwards reason when provided and omits it when absent", async () => {
+    hostdRequestMock.mockResolvedValueOnce(ok({ result: "started" }));
+    await dispatchTool("update_apply", {
+      pin: "v0.15.18",
+      reason: "ship the approval-card fix",
+    });
+    const withReason = hostdRequestMock.mock.calls[0]![1];
+    expect(withReason.args.reason).toBe("ship the approval-card fix");
+
+    hostdRequestMock.mockResolvedValueOnce(ok({ result: "started" }));
+    await dispatchTool("update_apply", { pin: "v0.15.18" });
+    const withoutReason = hostdRequestMock.mock.calls[1]![1];
+    expect(withoutReason.args).not.toHaveProperty("reason");
+  });
+
+  it("declares `reason` FIRST in each gated verb's inputSchema (truncation-safe)", () => {
+    for (const toolName of [
+      "rollout",
+      "update_apply",
+      "agent_start",
+      "agent_stop",
+      "agent_logs",
+      "agent_exec",
+    ]) {
+      const tool = TOOLS.find((t) => t.name === toolName);
+      expect(tool, `${toolName} should exist`).toBeTruthy();
+      const props = tool!.inputSchema.properties as Record<string, unknown>;
+      expect(props).toHaveProperty("reason");
+      expect(Object.keys(props)[0]).toBe("reason");
+    }
+  });
+
   it("agent_logs forwards tail when provided and omits it when not", async () => {
     hostdRequestMock.mockResolvedValueOnce(ok({ result: "completed" }));
     await dispatchTool("agent_logs", { name: "scribe", tail: 250 });

--- a/src/mcp/hostd/server.ts
+++ b/src/mcp/hostd/server.ts
@@ -139,11 +139,25 @@ export const TOOLS = [
     name: "agent_start",
     description:
       "Start a stopped agent. Self-targeting allowed; cross-agent " +
-      "requires admin. Equivalent to `switchroom agent start <name>`.",
+      "requires admin. Equivalent to `switchroom agent start <name>`. " +
+      "This is operator-gated — every call surfaces a Telegram approval " +
+      "card. ALWAYS pass a one-line `reason` explaining why you're " +
+      "starting this agent; it renders on the card's `why:` line so the " +
+      "operator can decide in context.",
     inputSchema: {
       type: "object" as const,
       required: ["name"],
+      // `reason` is FIRST so it survives Claude Code's ~200-char
+      // input_preview truncation on the operator approval card (same
+      // property-order rationale as config_propose_edit below).
       properties: {
+        reason: {
+          type: "string",
+          maxLength: 512,
+          description:
+            "One-line operator-facing rationale, rendered on the " +
+            "approval card's `why:` line.",
+        },
         name: {
           type: "string",
           pattern: "^[a-zA-Z0-9][a-zA-Z0-9_-]*$",
@@ -155,11 +169,24 @@ export const TOOLS = [
     name: "agent_stop",
     description:
       "Stop a running agent. Self-targeting allowed; cross-agent " +
-      "requires admin. Equivalent to `switchroom agent stop <name>`.",
+      "requires admin. Equivalent to `switchroom agent stop <name>`. " +
+      "This is operator-gated — every call surfaces a Telegram approval " +
+      "card. ALWAYS pass a one-line `reason` explaining why you're " +
+      "stopping this agent; it renders on the card's `why:` line so the " +
+      "operator can decide in context.",
     inputSchema: {
       type: "object" as const,
       required: ["name"],
+      // `reason` is FIRST so it survives the ~200-char input_preview
+      // truncation on the operator approval card.
       properties: {
+        reason: {
+          type: "string",
+          maxLength: 512,
+          description:
+            "One-line operator-facing rationale, rendered on the " +
+            "approval card's `why:` line.",
+        },
         name: {
           type: "string",
           pattern: "^[a-zA-Z0-9][a-zA-Z0-9_-]*$",
@@ -185,11 +212,23 @@ export const TOOLS = [
       "always allowed; cross-agent requires admin: true on the caller. " +
       "Returns the trailing `tail` lines (default 100, max 2000) as " +
       "`stdout_tail` / `stderr_tail` (each capped at 4 KiB). Use this " +
-      "for triage when a user reports a peer agent is misbehaving.",
+      "for triage when a user reports a peer agent is misbehaving. " +
+      "This is operator-gated — every call surfaces a Telegram approval " +
+      "card. ALWAYS pass a one-line `reason` explaining what you're " +
+      "triaging; it renders on the card's `why:` line.",
     inputSchema: {
       type: "object" as const,
       required: ["name"],
+      // `reason` is FIRST so it survives the ~200-char input_preview
+      // truncation on the operator approval card.
       properties: {
+        reason: {
+          type: "string",
+          maxLength: 512,
+          description:
+            "One-line operator-facing rationale, rendered on the " +
+            "approval card's `why:` line.",
+        },
         name: {
           type: "string",
           pattern: "^[a-zA-Z0-9][a-zA-Z0-9_-]*$",
@@ -212,11 +251,23 @@ export const TOOLS = [
       "ls, ps, pwd, stat, tail, uname, uptime, wc, whoami). Anything " +
       "outside the allowlist returns `denied` with a pointer to the " +
       "deferred host_os.exec approval-kernel scope. Returns stdout/" +
-      "stderr tails capped at 4 KiB each.",
+      "stderr tails capped at 4 KiB each. This is operator-gated — every " +
+      "call surfaces a Telegram approval card. ALWAYS pass a one-line " +
+      "`reason` explaining why you're running this inspection; it renders " +
+      "on the card's `why:` line so the operator can decide in context.",
     inputSchema: {
       type: "object" as const,
       required: ["name", "argv"],
+      // `reason` is FIRST so it survives the ~200-char input_preview
+      // truncation on the operator approval card.
       properties: {
+        reason: {
+          type: "string",
+          maxLength: 512,
+          description:
+            "One-line operator-facing rationale, rendered on the " +
+            "approval card's `why:` line.",
+        },
         name: {
           type: "string",
           pattern: "^[a-zA-Z0-9][a-zA-Z0-9_-]*$",
@@ -240,10 +291,22 @@ export const TOOLS = [
       "scaffolds, recreate containers. Admin-only at the wire layer. " +
       "Returns `started` once dispatched — the actual work runs " +
       "async on the host and the caller's own agent container will " +
-      "be recreated as part of the cycle.",
+      "be recreated as part of the cycle. This is operator-gated — every " +
+      "call surfaces a Telegram approval card. ALWAYS pass a one-line " +
+      "`reason` explaining why you're applying this update; it renders on " +
+      "the card's `why:` line so the operator can decide in context.",
     inputSchema: {
       type: "object" as const,
+      // `reason` is FIRST so it survives the ~200-char input_preview
+      // truncation on the operator approval card.
       properties: {
+        reason: {
+          type: "string",
+          maxLength: 512,
+          description:
+            "One-line operator-facing rationale, rendered on the " +
+            "approval card's `why:` line.",
+        },
         skip_images: {
           type: "boolean",
           description:
@@ -294,12 +357,24 @@ export const TOOLS = [
       "(canary order, version-assert, stop-on-mismatch) apply unchanged. " +
       "Admin-only at the wire layer AND deliberately NOT pre-approved — every " +
       "call surfaces a Telegram approval card for the operator to tap. " +
+      "ALWAYS pass a one-line `reason` explaining why you're rolling the " +
+      "fleet to this pin; it renders on the card's `why:` line so the " +
+      "operator can decide in context. " +
       "Returns `started`; poll get_status for the structured outcome " +
       "(which agents rolled / where it stopped).",
     inputSchema: {
       type: "object" as const,
       required: ["pin"],
+      // `reason` is FIRST so it survives the ~200-char input_preview
+      // truncation on the operator approval card.
       properties: {
+        reason: {
+          type: "string",
+          maxLength: 512,
+          description:
+            "One-line operator-facing rationale, rendered on the " +
+            "approval card's `why:` line.",
+        },
         pin: {
           type: "string",
           pattern: "^v\\d+\\.\\d+\\.\\d+$",
@@ -476,7 +551,10 @@ export async function dispatchTool(
         v: 1,
         op: "agent_start",
         request_id: makeRequestId("mcp-start"),
-        args: { name: args.name },
+        args: {
+          name: args.name,
+          ...(args.reason ? { reason: args.reason } : {}),
+        },
       };
       break;
     }
@@ -486,7 +564,10 @@ export async function dispatchTool(
         v: 1,
         op: "agent_stop",
         request_id: makeRequestId("mcp-stop"),
-        args: { name: args.name },
+        args: {
+          name: args.name,
+          ...(args.reason ? { reason: args.reason } : {}),
+        },
       };
       break;
     }
@@ -499,6 +580,7 @@ export async function dispatchTool(
         args: {
           name: args.name,
           ...(typeof args.tail === "number" ? { tail: args.tail } : {}),
+          ...(args.reason ? { reason: args.reason } : {}),
         },
       };
       break;
@@ -512,7 +594,11 @@ export async function dispatchTool(
         v: 1,
         op: "agent_exec",
         request_id: makeRequestId("mcp-exec"),
-        args: { name: args.name, argv: args.argv },
+        args: {
+          name: args.name,
+          argv: args.argv,
+          ...(args.reason ? { reason: args.reason } : {}),
+        },
       };
       break;
     }
@@ -547,6 +633,7 @@ export async function dispatchTool(
           ...(args.rebuild ? { rebuild: true } : {}),
           ...(args.channel ? { channel: args.channel } : {}),
           ...(args.pin ? { pin: args.pin } : {}),
+          ...(args.reason ? { reason: args.reason } : {}),
         },
       };
       break;
@@ -584,6 +671,7 @@ export async function dispatchTool(
           ...(args.agents ? { agents: args.agents } : {}),
           ...(args.skip_web ? { skip_web: true } : {}),
           ...(args.allow_downgrade ? { allow_downgrade: true } : {}),
+          ...(args.reason ? { reason: args.reason } : {}),
         },
       };
       break;

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -72,6 +72,11 @@ import {
   timeoutDenyMessage,
   duplicateDenyMessage,
   isRecentTimeoutDuplicate,
+  PERMISSION_TTL_MS,
+  ttlForTool,
+  buildTimedOutCardEdits,
+  STALE_TAP_NOTICE,
+  type PermissionCardRef,
 } from './permission-timeout.js'
 import { pickRecoveredPermissionOrigin } from './permission-card-origin.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
@@ -4313,8 +4318,10 @@ const STATUS_QUERY_RE = /^\s*status\??\s*$/i
 
 // ─── Permission handling ──────────────────────────────────────────────────
 const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
-const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; startedAt: number }>()
-const PERMISSION_TTL_MS = 10 * 60_000
+const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; startedAt: number; card_text: string; cards: { chatId: string; messageId: number }[] }>()
+// PERMISSION_TTL_MS / ttlForTool / the timed-out card builder now live in
+// ./permission-timeout.ts (pure + unit-testable). hostd gated verbs get a
+// 30-min window; everything else keeps the 10-min default.
 // No-repeat-on-timeout (marko Rentals-budget loop, 2026-06-17). When a card
 // auto-denies on TTL, the model is told it was a TIMEOUT (not a denial) so it
 // doesn't retry; if it retries the identical (tool, input) anyway while the
@@ -4945,7 +4952,10 @@ const pendingStateReaper = setInterval(() => {
     if (now - v.startedAt > VAULT_INPUT_TTL_MS) pendingVaultOps.delete(k)
   }
   for (const [k, v] of pendingPermissions) {
-    if (now - v.startedAt > PERMISSION_TTL_MS) {
+    // hostd gated fleet-mutation verbs get a longer (30-min) human-scale
+    // decision window than the 10-min default (Bug 2 fix #2).
+    const ttl = ttlForTool(v.tool_name)
+    if (now - v.startedAt > ttl) {
       // Don't just drop it: the claude turn is suspended INSIDE the MCP
       // permission call waiting for a verdict. A silent delete left it
       // wedged forever when the operator never tapped — permanent
@@ -4957,13 +4967,20 @@ const pendingStateReaper = setInterval(() => {
       // Carry a TIMEOUT reason to the model (claude renders it as "…the user
       // said: …") so it can tell a timeout from a real denial and not retry
       // the identical call — the duplicate-card loop this series closes.
-      const timeoutMinutes = Math.round(PERMISSION_TTL_MS / 60000)
+      const timeoutMinutes = Math.round(ttl / 60000)
       dispatchPermissionVerdict({
         type: 'permission',
         requestId: k,
         behavior: 'deny',
         message: timeoutDenyMessage(timeoutMinutes),
       })
+      // Strip the card's inline keyboard + mark it timed out (Bug 2 fix #1).
+      // Before this, the reaper deleted the pending entry but left a LIVE
+      // Approve button — a late operator tap then dispatched a verdict for an
+      // already-resolved/dead request_id, which Claude Code ignores, so the
+      // operator "approved" but work never continued. Stripping the keyboard
+      // makes the timeout legible and removes the stale tappable button.
+      void stripTimedOutPermissionCards(v.card_text, v.cards)
       // The auto-deny un-parks the suspended turn — flip 🙏 → working so
       // it doesn't sit on the awaiting glyph (or stall) after the timeout.
       resumeReactionAfterVerdict()
@@ -6566,6 +6583,32 @@ function buildPermissionActionRow(
   return kb
 }
 
+/**
+ * Strip the inline keyboard from one or more timed-out permission cards and
+ * append a "timed out — re-request to act" line (Bug 2 fix #1). Called from
+ * the pendingStateReaper, which has no grammy `ctx`, so it edits via the
+ * bot.api directly — routed through `swallowingApiCall` so a deleted card
+ * (operator removed the message) is swallowed rather than crashing the sweep.
+ *
+ * A single `editMessageText` re-renders the original card body plus a
+ * timed-out footer; omitting `reply_markup` drops the keyboard atomically
+ * with the text edit (same approach the normal tap finalizer uses, which
+ * strips the keyboard alongside its status-line edit). Best-effort: a failed
+ * edit never blocks the auto-deny that already fired.
+ */
+async function stripTimedOutPermissionCards(
+  cardText: string,
+  cards: PermissionCardRef[],
+): Promise<void> {
+  for (const edit of buildTimedOutCardEdits(cardText, cards)) {
+    await swallowingApiCall(
+      // allow-raw-bot-api: routed through swallowingApiCall (retry policy); message-id-targeted edit (no thread to lose). Passing {} as opts (no reply_markup) strips the stale Allow/Deny keyboard atomically with the text edit.
+      () => bot.api.editMessageText(edit.chatId, edit.messageId, richMessage(edit.text), {}),
+      { chat_id: edit.chatId, verb: 'permission_timeout.strip' },
+    )
+  }
+}
+
 function dispatchPermissionVerdict(ev: PermissionEvent): void {
   const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? ''
   const delivered = ipcServer.sendToAgent(selfAgent, ev)
@@ -6997,7 +7040,6 @@ const ipcServer: IpcServer = createIpcServer({
         return
       }
     }
-    pendingPermissions.set(requestId, { tool_name: toolName, description, input_preview: inputPreview, startedAt: Date.now() })
     // Natural-language card body — a plain sentence ("Gymbro wants to
     // edit: supplement-log.md" + a why-line), never a raw tool id.
     // The operator sees what is being requested and why at a glance.
@@ -7009,6 +7051,10 @@ const ipcServer: IpcServer = createIpcServer({
       description,
       agentName: _client.agentName,
     })
+    // `card_text` is retained so the TTL reaper can re-edit the SAME body
+    // with a "timed out" footer while stripping the keyboard atomically
+    // (Bug 2 fix #1) — the reaper has no grammy ctx to read the live text.
+    pendingPermissions.set(requestId, { tool_name: toolName, description, input_preview: inputPreview, startedAt: Date.now(), card_text: text, cards: [] })
     // Compact action row: ❌ Deny · ✅ Allow · 🔁 Always… — the scope of an
     // "always" grant stays hidden until the operator taps "🔁 Always…",
     // which swaps the row for a scope choice (this file / any file ⚠️). The
@@ -7043,7 +7089,17 @@ const ipcServer: IpcServer = createIpcServer({
             ...(tid != null ? { message_thread_id: tid } : {}),
           }),
         { threadId, chat_id: chatId, verb: 'permission_request' },
-      ).catch(e => {
+      ).then(sent => {
+        // Record the live card's (chat, message) so the TTL reaper can strip
+        // its inline keyboard on auto-deny — a stale Approve button left
+        // tappable dispatches a verdict for a dead request_id (Bug 2). The
+        // entry may already be gone (operator tapped before this resolved);
+        // guard the lookup.
+        const pend = pendingPermissions.get(requestId)
+        if (pend && sent && typeof sent.message_id === 'number') {
+          pend.cards.push({ chatId, messageId: sent.message_id })
+        }
+      }).catch(e => {
         process.stderr.write(`telegram gateway: permission_request send to ${chatId} failed: ${e}\n`)
       })
     }
@@ -21863,6 +21919,20 @@ bot.on('callback_query:data', async ctx => {
   // scopes (resolveTimeBox → null) and the disabled tier (ttl<=0) stay truly
   // once. The verdict is still dispatched WITHOUT a `rule` (below), so the
   // bridge never caches it untimed — the window lives only in scopedGrants.
+  // Stale-id tap (#2469 follow-up): the pendingStateReaper auto-DENIES a
+  // permission whose TTL expired and DELETES its pending entry — but a late
+  // operator tap on the (now keyboard-stripped, but possibly still-cached)
+  // card would otherwise dispatch a verdict for an already-resolved/dead
+  // request_id, which Claude Code silently ignores. Net: operator THINKS
+  // they approved, but the work was auto-denied and never continues. Be
+  // honest: tell the operator the request already resolved and do NOT
+  // dispatch a verdict for the dead id (no buffering, no resume message).
+  // LIVE ids fall through to the normal dispatch path below, preserving the
+  // dispatchPermissionVerdict buffering/offline-redelivery contract.
+  if (!pendingPermissions.has(request_id)) {
+    await ctx.answerCallbackQuery({ text: STALE_TAP_NOTICE }).catch(() => {})
+    return
+  }
   // Operator tapped a verdict ⇒ they are present; reset no-repeat suppression
   // so a later identical ask is shown fresh rather than silently short-circuited.
   clearPermissionTimeoutSuppression('operator answered a permission card')

--- a/telegram-plugin/gateway/permission-timeout.ts
+++ b/telegram-plugin/gateway/permission-timeout.ts
@@ -68,3 +68,79 @@ export function isRecentTimeoutDuplicate(
   const at = timeouts.get(sig)
   return at != null && now - at <= windowMs
 }
+
+// ─── Bug 2 — per-tool TTL + timed-out card hygiene + stale-tap honesty ──────
+
+/** Default operator approval-card lifetime. */
+export const PERMISSION_TTL_MS = 10 * 60_000
+
+/**
+ * hostd gated fleet-mutation verbs (rollout / update_apply / agent_* /
+ * config_propose_edit) surface an OPERATOR approval card and demand a
+ * human-scale decision window — 10 min is too tight when the operator is
+ * mid-task. The `mcp__hostd__*` family gets 30 min; everything else keeps
+ * the 10-min default.
+ */
+export const HOSTD_PERMISSION_TTL_MS = 30 * 60_000
+
+/** Per-tool approval-card TTL. */
+export function ttlForTool(toolName: string | undefined): number {
+  return toolName && toolName.startsWith('mcp__hostd__')
+    ? HOSTD_PERMISSION_TTL_MS
+    : PERMISSION_TTL_MS
+}
+
+/** Suffix appended to a card body when its approval window times out. */
+export const TIMED_OUT_FOOTER = '\n\n⏱ Timed out — re-request to act'
+
+export interface PermissionCardRef {
+  chatId: string
+  messageId: number
+}
+
+export interface TimedOutCardEdit {
+  chatId: string
+  messageId: number
+  /** New body text (original card body + the timed-out footer). */
+  text: string
+  /**
+   * Always true: the edit MUST drop the inline keyboard (omit reply_markup)
+   * so the stale Allow/Deny buttons are no longer tappable — the core of
+   * Bug 2 fix #1. A stale tappable Approve dispatches a verdict for an
+   * already-resolved request_id, which Claude Code ignores → "operator
+   * approved but work never continued".
+   */
+  stripKeyboard: true
+}
+
+/**
+ * Build the (pure) list of card edits the reaper applies on TTL auto-deny:
+ * re-render each recorded card's original body with the timed-out footer and
+ * mark it for keyboard-strip. One entry per card (a permission may have been
+ * broadcast to several operator surfaces).
+ */
+export function buildTimedOutCardEdits(
+  cardText: string,
+  cards: readonly PermissionCardRef[],
+): TimedOutCardEdit[] {
+  return cards.map(({ chatId, messageId }) => ({
+    chatId,
+    messageId,
+    text: `${cardText}${TIMED_OUT_FOOTER}`,
+    stripKeyboard: true,
+  }))
+}
+
+/**
+ * A tap on a permission card is STALE when no pending entry exists for its
+ * request_id — the reaper already auto-denied + deleted it on TTL. A stale
+ * tap must NOT dispatch a verdict (the dead id is ignored by Claude Code);
+ * the operator instead gets an honest "already resolved" notice.
+ */
+export function isStaleTap(hasPending: boolean): boolean {
+  return !hasPending
+}
+
+/** Operator-facing notice shown when a stale (timed-out) card is tapped. */
+export const STALE_TAP_NOTICE =
+  'This request already resolved (timed out) — ask again to act.'

--- a/telegram-plugin/permission-title.ts
+++ b/telegram-plugin/permission-title.ts
@@ -63,6 +63,9 @@ const MCP_TOOL_DESCRIPTIONS: Record<string, string> = {
   "mcp__hostd__agent_exec": "Run a read-only inspection inside another agent",
   "mcp__hostd__update_check": "Check what a fleet-wide update would do",
   "mcp__hostd__update_apply": "Apply a fleet-wide update (pull + recreate)",
+  "mcp__hostd__rollout": "Roll the fleet to a pinned version",
+  "mcp__hostd__config_propose_edit": "Propose an edit to switchroom.yaml",
+  "mcp__hostd__get_status": "Read the last fleet-update status",
   // hindsight — memory
   "mcp__hindsight__recall": "Recall relevant memories",
   "mcp__hindsight__retain": "Retain a memory",

--- a/telegram-plugin/tests/permission-no-repeat-wiring.test.ts
+++ b/telegram-plugin/tests/permission-no-repeat-wiring.test.ts
@@ -41,10 +41,20 @@ describe('no-repeat-on-timeout wiring', () => {
   })
 
   it('the TTL auto-deny attaches a timeout message and records the signature', () => {
-    // Within the pending-permission sweep block.
-    const sweep = slice(GATEWAY, 'for (const [k, v] of pendingPermissions)', 2200)
+    // Within the pending-permission sweep block. Span bumped (2200 → 3200)
+    // when Bug 2 added per-tool TTL + the timed-out keyboard-strip to this
+    // block — the signature-record line now sits further down but the wiring
+    // is intact.
+    const sweep = slice(GATEWAY, 'for (const [k, v] of pendingPermissions)', 3200)
     expect(sweep).toContain('timeoutDenyMessage(')
     expect(sweep).toContain('permissionTimeoutSignatures.set(')
+  })
+
+  it('the TTL auto-deny strips the timed-out card keyboard (Bug 2)', () => {
+    const sweep = slice(GATEWAY, 'for (const [k, v] of pendingPermissions)', 3200)
+    // Per-tool TTL + keyboard-strip are both wired into the sweep.
+    expect(sweep).toContain('ttlForTool(')
+    expect(sweep).toContain('stripTimedOutPermissionCards(')
   })
 
   it('onPermissionRequest short-circuits a recent-timeout duplicate before posting a card', () => {

--- a/telegram-plugin/tests/permission-timeout.test.ts
+++ b/telegram-plugin/tests/permission-timeout.test.ts
@@ -13,6 +13,13 @@ import {
   timeoutDenyMessage,
   duplicateDenyMessage,
   isRecentTimeoutDuplicate,
+  PERMISSION_TTL_MS,
+  HOSTD_PERMISSION_TTL_MS,
+  ttlForTool,
+  buildTimedOutCardEdits,
+  isStaleTap,
+  STALE_TAP_NOTICE,
+  TIMED_OUT_FOOTER,
 } from '../gateway/permission-timeout.js'
 
 describe('permissionSignature', () => {
@@ -83,5 +90,75 @@ describe('isRecentTimeoutDuplicate', () => {
     const m = new Map([[permissionSignature('t', 'Rentals'), NOW]])
     expect(isRecentTimeoutDuplicate(m, permissionSignature('t', 'Land'), NOW, WINDOW)).toBe(false)
     expect(isRecentTimeoutDuplicate(m, permissionSignature('t', 'Rentals'), NOW, WINDOW)).toBe(true)
+  })
+})
+
+// ─── Bug 2 — per-tool TTL, timed-out card hygiene, stale-tap honesty ────────
+
+describe('ttlForTool (Bug 2 fix #2)', () => {
+  it('gives hostd gated verbs a 30-min window', () => {
+    for (const tool of [
+      'mcp__hostd__rollout',
+      'mcp__hostd__update_apply',
+      'mcp__hostd__agent_restart',
+      'mcp__hostd__agent_exec',
+      'mcp__hostd__config_propose_edit',
+    ]) {
+      expect(ttlForTool(tool)).toBe(HOSTD_PERMISSION_TTL_MS)
+      expect(ttlForTool(tool)).toBe(30 * 60_000)
+    }
+  })
+
+  it('keeps the 10-min default for non-hostd tools', () => {
+    expect(ttlForTool('Bash')).toBe(PERMISSION_TTL_MS)
+    expect(ttlForTool('Bash')).toBe(10 * 60_000)
+    expect(ttlForTool('mcp__perplexity__search')).toBe(PERMISSION_TTL_MS)
+    expect(ttlForTool('mcp__agent-config__schedule_add')).toBe(PERMISSION_TTL_MS)
+    expect(ttlForTool(undefined)).toBe(PERMISSION_TTL_MS)
+  })
+
+  it('hostd TTL is strictly longer than the default', () => {
+    expect(HOSTD_PERMISSION_TTL_MS).toBeGreaterThan(PERMISSION_TTL_MS)
+  })
+})
+
+describe('buildTimedOutCardEdits (Bug 2 fix #1 — strip stale keyboard)', () => {
+  it('marks every recorded card for keyboard-strip and appends the footer', () => {
+    const cards = [
+      { chatId: '111', messageId: 5 },
+      { chatId: '222', messageId: 9 },
+    ]
+    const edits = buildTimedOutCardEdits('🔐 **Overlord** wants to roll the fleet', cards)
+    expect(edits).toHaveLength(2)
+    for (const [i, edit] of edits.entries()) {
+      // The keyboard MUST be stripped — a live Approve on a dead request_id is
+      // exactly the bug.
+      expect(edit.stripKeyboard).toBe(true)
+      expect(edit.chatId).toBe(cards[i]!.chatId)
+      expect(edit.messageId).toBe(cards[i]!.messageId)
+      expect(edit.text).toContain('roll the fleet')
+      expect(edit.text).toContain('Timed out — re-request to act')
+      expect(edit.text.endsWith(TIMED_OUT_FOOTER)).toBe(true)
+    }
+  })
+
+  it('returns no edits when there were no recorded cards', () => {
+    expect(buildTimedOutCardEdits('body', [])).toEqual([])
+  })
+})
+
+describe('isStaleTap (Bug 2 fix #3 — do not dispatch a verdict for a dead id)', () => {
+  it('is stale when no pending entry exists for the tapped request_id', () => {
+    // hasPending=false ⇒ the reaper already auto-denied + deleted it.
+    expect(isStaleTap(false)).toBe(true)
+  })
+
+  it('is NOT stale (live id) when a pending entry still exists', () => {
+    expect(isStaleTap(true)).toBe(false)
+  })
+
+  it('exposes an honest operator notice for the stale path', () => {
+    expect(STALE_TAP_NOTICE).toMatch(/already resolved/i)
+    expect(STALE_TAP_NOTICE).toMatch(/ask again/i)
   })
 })

--- a/telegram-plugin/tests/permission-title.test.ts
+++ b/telegram-plugin/tests/permission-title.test.ts
@@ -368,6 +368,49 @@ describe('formatPermissionCardBody', () => {
   })
 })
 
+// Bug 1: the hostd rollout verb gained an optional `reason` (which the agent
+// can now actually supply) and a curated MCP_TOOL_DESCRIPTIONS title, so the
+// card stops rendering the generic "rollout (Hostd)" with "why: not provided".
+describe('formatPermissionCardBody — hostd rollout (Bug 1)', () => {
+  test('renders the caller-supplied reason on the why: line', () => {
+    const body = formatPermissionCardBody({
+      toolName: 'mcp__hostd__rollout',
+      inputPreview: JSON.stringify({
+        reason: 'promote canary-green v0.16.24 to the fleet',
+        pin: 'v0.16.24',
+      }),
+      description: 'SAFELY roll the fleet to a pinned SEMVER version …',
+      agentName: 'overlord',
+    })
+    expect(body).toContain('why: _promote canary-green v0.16.24 to the fleet_')
+    // #2469: never the schema description.
+    expect(body).not.toContain('SAFELY roll the fleet')
+  })
+
+  test('renders the clean MCP_TOOL_DESCRIPTIONS title, not the raw tool id', () => {
+    const body = formatPermissionCardBody({
+      toolName: 'mcp__hostd__rollout',
+      inputPreview: JSON.stringify({
+        reason: 'rollback to last-good tag',
+        pin: 'v0.16.20',
+      }),
+      description: 'desc',
+      agentName: 'overlord',
+    })
+    const firstLine = body.split('\n')[0]
+    // Curated phrase from MCP_TOOL_DESCRIPTIONS["mcp__hostd__rollout"].
+    expect(firstLine).toBe('🔐 **Overlord** wants to roll the fleet to a pinned version')
+    expect(firstLine).not.toContain('mcp__hostd__rollout')
+    expect(firstLine).not.toMatch(/rollout \(Hostd\)/i)
+  })
+
+  test('naturalAction surfaces the curated title for the rollout verb', () => {
+    expect(naturalAction('mcp__hostd__rollout', undefined)).toBe(
+      'roll the fleet to a pinned version',
+    )
+  })
+})
+
 describe('describeGrant — phrased from the chosen scope', () => {
   test('MCP server wildcard → "use any <Server> tool"', () => {
     expect(describeGrant('mcp__perplexity__search', undefined, opt('mcp__perplexity__*'))).toBe(

--- a/tests/host-control/protocol.test.ts
+++ b/tests/host-control/protocol.test.ts
@@ -29,6 +29,26 @@ describe("hostd protocol — framing & schema", () => {
     expect(decoded).toEqual(req);
   });
 
+  // Bug 1: the gated verbs gained an optional `reason` (for the operator
+  // approval card's `why:` line). Assert the wire schema PERMITS it on each —
+  // a `.object()` that doesn't declare `reason` would strip it on decode and
+  // the forwarded rationale would silently vanish.
+  it("preserves an optional `reason` on each gated verb's request args", () => {
+    const cases: HostdRequest[] = [
+      { v: 1, op: "rollout", request_id: "r-1", args: { pin: "v0.16.24", reason: "promote canary" } },
+      { v: 1, op: "update_apply", request_id: "ua-1", args: { pin: "v0.16.24", reason: "ship fix" } },
+      { v: 1, op: "agent_start", request_id: "as-1", args: { name: "scribe", reason: "bring it up" } },
+      { v: 1, op: "agent_stop", request_id: "ast-1", args: { name: "scribe", reason: "drain it" } },
+      { v: 1, op: "agent_logs", request_id: "al-1", args: { name: "scribe", reason: "triage wedge" } },
+      { v: 1, op: "agent_exec", request_id: "ae-1", args: { name: "scribe", argv: ["ls"], reason: "inspect" } },
+    ];
+    for (const req of cases) {
+      const decoded = decodeRequest(encodeRequest(req).trimEnd());
+      expect(decoded).toEqual(req);
+      expect((decoded as { args?: { reason?: string } }).args?.reason).toBeTruthy();
+    }
+  });
+
   it("round-trips an upgrade_status request without args", () => {
     const req: HostdRequest = {
       v: 1,


### PR DESCRIPTION
## What & why

Two operator-approval-card bugs on the hostd gated-verb path. **JTBD:** visibility (every step pinned to chat) + always-on (work resumes after the operator approves). **Contract:** `reference/rfcs/host-control-daemon.md` host-control-daemon verb table (extended for the new optional `reason` arg) and #2469 (the card's `why:` line reads the caller's arg, never the schema description — preserved, not changed).

### Bug 1 — gated verbs showed `why: _not provided_`
The card's `why:` line sources from `callerSuppliedReason` (the tool input's `reason`/`why` key) and deliberately never falls back to the schema description (#2469). But `rollout`, `update_apply`, `agent_start/stop/logs/exec` had **no `reason` param**, so the agent could never supply one and the card always rendered "not provided".

- `src/mcp/hostd/server.ts` — add an optional `reason` (`maxLength: 512`, declared **FIRST** in `properties` so it survives Claude Code's ~200-char `input_preview` truncation, mirroring the `config_propose_edit` / `agent_restart` rationale) to all six verbs; forward it in each request `args` builder; instruct the agent to pass a one-line `reason` in each tool description.
- `src/host-control/protocol.ts` — widen each verb's request-args zod schema to permit `reason` so the forwarded value isn't stripped on decode.
- `telegram-plugin/permission-title.ts` — add clean `MCP_TOOL_DESCRIPTIONS` titles for `rollout` / `config_propose_edit` / `get_status` so the card title isn't the generic "rollout (Hostd)".
- `reference/rfcs/host-control-daemon.md` — document the optional `reason` on the verb table.

### Bug 2 — approve/deny did not deterministically resume work
The TTL reaper auto-denied a permission pending >TTL and deleted the pending entry, **but left the card's Approve button live**. A late operator tap then dispatched a verdict for an already-resolved/dead `request_id` (Claude Code ignores it) → operator "approved", agent was already auto-denied, work never continued.

All in `telegram-plugin/gateway/gateway.ts` + a new pure helper module `telegram-plugin/gateway/permission-timeout.ts`:
1. **Strip the keyboard on TTL auto-deny** — record each card's `(chat, message)` at send time; on timeout, re-edit the body with a "⏱ Timed out — re-request to act" line and drop the inline keyboard (same atomic strip the normal tap finalizer uses).
2. **30-min TTL for hostd gated verbs** — `ttlForTool()` special-cases `mcp__hostd__*` to a human-scale 30-min window; everything else keeps the 10-min default.
3. **Honest stale-id tap** — a tap on a `request_id` with no pending entry answers "This request already resolved (timed out) — ask again to act." and dispatches **no** verdict. Live ids keep the `dispatchPermissionVerdict` buffering / offline-redelivery contract intact.

The "synthesize a fresh inbound to re-trigger work" path is deliberately **not** built here (explicit follow-up).

The pure TTL / card-edit / stale-tap logic lives in `permission-timeout.ts` so it's unit-testable (gateway.ts has import-time side effects and isn't unit-importable).

## Tests
- `src/mcp/hostd/server.test.ts` — `rollout` forwards `reason` when provided / omits it when absent; `update_apply` parity; `reason` declared first in every gated verb's schema.
- `tests/host-control/protocol.test.ts` — `reason` survives wire round-trip on all six verbs (would be stripped if the schema didn't declare it).
- `telegram-plugin/tests/permission-title.test.ts` — card renders the passed `reason` on `why:` for `mcp__hostd__rollout` and the clean curated title (not the raw tool id / "rollout (Hostd)").
- `telegram-plugin/tests/permission-timeout.test.ts` — `ttlForTool` (30-min hostd / 10-min default), `buildTimedOutCardEdits` strips the keyboard + appends the footer, `isStaleTap` + honest notice.
- `telegram-plugin/tests/permission-no-repeat-wiring.test.ts` — bumped the source-pin span and added a pin for the new keyboard-strip wiring.

## Local verification
- `npm run lint` (tsc --noEmit + all guard scripts): clean.
- `npm run build`: clean.
- Targeted vitest (mcp + protocol + dispatch) and bun (permission-*): all green. The 27/31 `tests/host-control/server.test.ts` failures and the 154 `uat:`/`uat fuzz:` bun failures are **pre-existing on clean main** (they spawn the real `switchroom` CLI / need live MTProto creds) — identical counts before/after this change; `uat-gate` CI + the test-harness agent own that surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)