### PR TITLE
fix(rollout): mount /etc/machine-id in hostd; make litellm passphrase-null non-fatal

### DIFF
--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -292,24 +292,26 @@ export async function provisionLiteLLMKeys(
   // and bail rather than emitting N confusing per-agent denials.
   const passphrase = await resolveOperatorVaultPassphrase(ctx.home ?? homedir());
   if (passphrase === null) {
-    for (const { name } of optedIn) {
-      failures.push({
-        agent: name,
-        message:
-          `litellm: cannot write virtual key — no operator vault passphrase available ` +
-          `(set SWITCHROOM_VAULT_PASSPHRASE, or enable auto-unlock with ` +
-          `'switchroom vault broker enable-auto-unlock'). The broker refuses new keys ` +
-          `without operator attestation.`,
-      });
-    }
+    // Vault passphrase is unavailable (no SWITCHROOM_VAULT_PASSPHRASE env and
+    // machine-id auto-unlock blob is missing or undecryptable). This blocks
+    // writing NEW virtual keys, but agents that were already provisioned on a
+    // prior interactive apply still have their keys in the vault — a rollout
+    // doesn't need to re-provision them. Emit a warning and return without
+    // counting this as scaffold failures: making every rollout fail because the
+    // hostd container couldn't derive the auto-unlock key defeats the purpose
+    // of autonomous fleet updates. First-time provisioning requires an
+    // interactive `switchroom apply` with vault access (operator console or
+    // SWITCHROOM_VAULT_PASSPHRASE env). Note: adding /etc/machine-id:ro to the
+    // hostd compose fixes the root cause on this host (PR #NNNN).
     const targets = [
       ...optedIn.map(({ name }) => name),
       ...(needsHindsight ? ["hindsight (service)"] : []),
     ];
     ctx.writeErr(
-      chalk.red(
-        `  x litellm: no operator vault passphrase — skipping provisioning for ` +
-        `${targets.join(", ")}. They will NOT get routing env until a key exists.\n`,
+      chalk.yellow(
+        `  ⚠ litellm: vault passphrase unavailable — skipping new-key provisioning for ` +
+        `${targets.join(", ")}. Already-provisioned keys are unaffected; ` +
+        `run \`switchroom apply\` interactively to provision new agents.\n`,
       ),
     );
     return;

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -302,7 +302,7 @@ export async function provisionLiteLLMKeys(
     // of autonomous fleet updates. First-time provisioning requires an
     // interactive `switchroom apply` with vault access (operator console or
     // SWITCHROOM_VAULT_PASSPHRASE env). Note: adding /etc/machine-id:ro to the
-    // hostd compose fixes the root cause on this host (PR #NNNN).
+    // hostd compose fixes the root cause on this host (PR #2679).
     const targets = [
       ...optedIn.map(({ name }) => name),
       ...(needsHindsight ? ["hindsight (service)"] : []),

--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -54,6 +54,9 @@ describe("renderHostdComposeFile", () => {
     );
     // docker.sock is a fixed host path; bind-mount is host-home-agnostic.
     expect(out).toContain("/var/run/docker.sock:/var/run/docker.sock:rw");
+    // machine-id must be mounted so resolveOperatorVaultPassphrase can
+    // decrypt the auto-unlock blob and provision LiteLLM keys during rollout.
+    expect(out).toContain("/etc/machine-id:/etc/machine-id:ro");
   });
 
   it("exports SWITCHROOM_HOST_HOME = the REAL host home (so in-container apply emits host bind sources, not /host-home)", () => {

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -203,6 +203,14 @@ services:
       # have it, but hostd (auditing every shell-out via run-hook.sh's
       # pattern) is the controlled chokepoint.
       - /var/run/docker.sock:/var/run/docker.sock:rw
+      # /etc/machine-id passthrough — the vault auto-unlock blob
+      # (~/.switchroom/vault-auto-unlock) is encrypted with a key derived
+      # from the host machine-id. Without this mount, readAutoUnlockFile
+      # inside switchroom apply (called by rollout) cannot derive the
+      # decryption key, resolveOperatorVaultPassphrase returns null, LiteLLM
+      # provisioning fails for all agents, and rollout stops at apply.
+      # Same mount the vault-broker compose carries (compose.ts:1364).
+      - /etc/machine-id:/etc/machine-id:ro
     environment:
       # Hostd resolves homedir() to set the per-agent socket dir; pin
       # it inside the container to /host-home (which bind-mounts to the


### PR DESCRIPTION
## Summary

- Adds `/etc/machine-id:/etc/machine-id:ro` to the hostd compose volumes — same mount the vault-broker already carries
- Changes `provisionLiteLLMKeys` passphrase-null path from hard failure (pushing all agents to `failures` → `process.exit(1)`) to a yellow warning that returns early without counting as failures

## Why

Root cause of all recent agent-initiated rollout failures (audit log seq 7748/15630 — June 29 and June 30 attempts to v0.16.16 and v0.16.25):

1. **Missing `/etc/machine-id` in hostd**: `resolveOperatorVaultPassphrase` reads the auto-unlock blob at `~/.switchroom/vault-auto-unlock` and decrypts it with a key derived from `/etc/machine-id`. The vault-broker mounts this file (`compose.ts:1364`). Hostd did not, so decryption failed and passphrase returned `null`.

2. **passphrase-null → failures.push for all agents**: `provisionLiteLLMKeys` responded to `passphrase === null` by pushing every LiteLLM-opted agent (12 agents) into the `failures` array. The comment at line 1188–1190 says these failures should be "non-fatal", but the passphrase check violated that — triggering `process.exit(1)` and stopping rollout at apply before any agent was restarted. The agents' existing virtual keys in the vault were unaffected.

The June 24 rollouts (earlier in the audit log) succeeded because LiteLLM wasn't configured yet on those versions (v0.15.60–v0.15.64). LiteLLM was enabled around v0.16.0, after which every rollout from hostd has failed at apply.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run src/cli/hostd.test.ts` — 23/23 pass (new assertion for `/etc/machine-id` mount)
- [x] `vitest run src/cli/` — 975/975 pass
- [x] `vitest run tests/docker/compose-generator.test.ts` — 186/186 pass

## Risk

Low. The `/etc/machine-id` mount is read-only and already present on every agent container and the vault-broker — adding it to hostd is minimal surface expansion. The passphrase-null change makes a hard failure into a warning; already-provisioned agents continue to work; first-time provisioning still requires an interactive `switchroom apply` with vault access.

After deploy: run `switchroom hostd install` to regenerate the hostd compose with the new mount. The next overlord-initiated rollout should complete without stopping at apply.