### PR TITLE
fix(gateway): catch frozen grammy runner when getMe passes but getUpdates stalls

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -785,6 +785,26 @@ const AGENT_ADMIN = process.env.SWITCHROOM_AGENT_ADMIN === 'true'
 const bot = new Bot(TOKEN)
 installTgPostLogger(bot)
 
+// ─── getUpdates heartbeat ─────────────────────────────────────────────────
+// Tracks the last time getUpdates completed (success OR error). Used by
+// the poll health check as a secondary stall signal: if getMe succeeds but
+// getUpdates hasn't responded in a while, the grammy runner loop is frozen
+// without the network being down (2026-06-30: clerk/klanker deaf for 2h
+// after a single timeout — getMe stayed green so the getMe-only check
+// never fired). Initialized to now so the first health-check interval
+// doesn't false-positive before the runner makes its first poll.
+let lastGetUpdatesHeartbeatMs = Date.now()
+bot.api.config.use(async (prev, method, payload, signal) => {
+  try {
+    const result = await prev(method, payload, signal)
+    if (method === 'getUpdates') lastGetUpdatesHeartbeatMs = Date.now()
+    return result
+  } catch (err) {
+    if (method === 'getUpdates') lastGetUpdatesHeartbeatMs = Date.now()
+    throw err
+  }
+})
+
 const GRAMMY_VERSION: string = (() => {
   try {
     const raw = readFileSync(new URL('../../node_modules/grammy/package.json', import.meta.url), 'utf8')
@@ -23319,7 +23339,23 @@ const POLL_HEALTH_THRESHOLD = Number(
 let pollHealthCheck: PollHealthCheckHandle | null = null
 if (POLL_HEALTH_INTERVAL_MS > 0) {
   pollHealthCheck = createPollHealthCheck({
-    ping: () => bot.api.getMe(),
+    ping: async () => {
+      await bot.api.getMe()
+      // Secondary: if getMe passes but getUpdates hasn't responded in
+      // `threshold × interval` ms, the grammy runner loop is frozen without
+      // the network being down. Throw so the failure counter increments and
+      // stall recovery fires after `failureThreshold` consecutive misses.
+      // (2026-06-30 incident: one getUpdates TimeoutError → runner silently
+      // froze; getMe stayed green; fleet deaf for 2 h until manual restart.)
+      const staleMs = Date.now() - lastGetUpdatesHeartbeatMs
+      const staleThresholdMs = POLL_HEALTH_INTERVAL_MS * POLL_HEALTH_THRESHOLD
+      if (staleMs > staleThresholdMs) {
+        throw new Error(
+          `getUpdates heartbeat stale: last seen ${Math.round(staleMs / 1000)}s ago ` +
+          `(threshold ${Math.round(staleThresholdMs / 1000)}s) — runner loop frozen`,
+        )
+      }
+    },
     onStall: async () => {
       // Exit non-zero → _switchroom_supervise restarts the gateway sidecar
       // with a fresh runner. Never awaits runnerHandle.stop() (it hangs on a

--- a/telegram-plugin/tests/poll-health.test.ts
+++ b/telegram-plugin/tests/poll-health.test.ts
@@ -68,6 +68,70 @@ describe("createPollHealthCheck", () => {
     hc.stop();
   });
 
+  it("detects stall when getMe passes but getUpdates heartbeat is stale", async () => {
+    // Simulates the 2026-06-30 incident: one getUpdates TimeoutError left the
+    // grammy runner loop frozen. getMe kept succeeding so the original
+    // getMe-only health check never fired. Fleet was deaf for 2 h.
+    // The fix: ping() also checks lastGetUpdatesHeartbeatMs; if stale, throws
+    // so the failure counter increments and stall recovery fires.
+    const onStall = vi.fn().mockResolvedValue(undefined);
+    let tickFn: () => void = () => {};
+    let lastGetUpdatesMs = Date.now() - 999_999; // very stale
+    const staleThresholdMs = 180_000; // 3 min (threshold × interval)
+
+    const hc = createPollHealthCheck({
+      ping: async () => {
+        // getMe succeeds (network fine):
+        // (no throw from network layer)
+        // heartbeat stale check (mirrors gateway.ts logic):
+        const staleMs = Date.now() - lastGetUpdatesMs;
+        if (staleMs > staleThresholdMs) {
+          throw new Error(
+            `getUpdates heartbeat stale: last seen ${Math.round(staleMs / 1000)}s ago — runner loop frozen`,
+          );
+        }
+      },
+      onStall,
+      failureThreshold: 3,
+      setIntervalFn: (fn) => { tickFn = fn; return 1 as unknown as ReturnType<typeof setInterval>; },
+      clearIntervalFn: () => {},
+      log: () => {},
+    });
+    hc.start();
+    tickFn(); await Promise.resolve();
+    tickFn(); await Promise.resolve();
+    tickFn(); await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onStall).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT stall when getUpdates heartbeat is fresh", async () => {
+    const onStall = vi.fn().mockResolvedValue(undefined);
+    let tickFn: () => void = () => {};
+    let lastGetUpdatesMs = Date.now(); // fresh
+    const staleThresholdMs = 180_000;
+
+    const hc = createPollHealthCheck({
+      ping: async () => {
+        const staleMs = Date.now() - lastGetUpdatesMs;
+        if (staleMs > staleThresholdMs) {
+          throw new Error("getUpdates heartbeat stale");
+        }
+      },
+      onStall,
+      failureThreshold: 3,
+      setIntervalFn: (fn) => { tickFn = fn; return 1 as unknown as ReturnType<typeof setInterval>; },
+      clearIntervalFn: () => {},
+      log: () => {},
+    });
+    hc.start();
+    for (let i = 0; i < 5; i++) {
+      tickFn(); await Promise.resolve();
+    }
+    expect(onStall).not.toHaveBeenCalled();
+    hc.stop();
+  });
+
   it("stop() cancels the interval", () => {
     const onStall = vi.fn();
     let cleared = false;


### PR DESCRIPTION
## Summary

- Adds a `getUpdates` heartbeat tracker (grammy API transformer) that records the last time any `getUpdates` call completed (success or error)
- Augments the poll health check `ping` to also throw if `getUpdates` hasn't responded in `threshold × interval` ms (default: 3 min), even when `getMe` succeeds
- Adds 2 tests to `poll-health.test.ts` covering the stale-heartbeat stall path and the fresh-heartbeat no-stall path

## Why

**Incident 2026-06-30**: clerk and klanker were deaf for ~2 h. A single `getUpdates` TimeoutError at 22:40 UTC left the grammy runner loop silently frozen. `getMe` kept succeeding throughout, so the existing health check never triggered stall recovery.

**Root cause gap**: PR #2432 fixed "network outage → `getMe` fails → exit+restart." This is a new variant: network is fine, `getMe` passes, but the grammy runner's `getUpdates` loop is frozen after a transient timeout. The health check had no signal for it.

**With this fix**: detection latency drops from potentially hours to ≤6 min (3 min stale threshold + 3 × 60s failure threshold).

## Test plan

- [x] `vitest run telegram-plugin/tests/poll-health.test.ts` — 6 tests pass
- [x] `tsc --noEmit` — clean
- [x] `check-bot-api-wrapping.sh` — clean

## Risk

Low. The heartbeat transformer is passive (updates a timestamp, always re-throws errors unchanged). The stale check runs inside the existing `ping()` — same failure counter and recovery path as before. The stale threshold (3 min) is generous enough to avoid false positives during legitimate startup or heavy load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXGDSGArnajHNjcf8Vr17T