### PR TITLE
fix(hermes): add activeSessionId fallback to session.status handler

### DIFF
--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -752,7 +752,7 @@ export async function onHermesMessage(ctx: HermesWsContext, raw: string) {
     }
 
     case "session.status": {
-      const sessionId = String(params.session_id ?? "");
+      const sessionId = String(params.session_id ?? ctx.activeSessionId ?? "");
       if (!isKnownSession(config, sessionId)) {
         sendResponse(ctx, rpcErr(id, -32602, `Unknown session: ${sessionId}`));
         break;


### PR DESCRIPTION
**Problem:** Hermes Desktop v0.17.0 calls `session.status` after `session.activate` without re-sending `session_id`. `session.status` was the only WS method missing the `ctx.activeSessionId` fallback — every other handler (session.history, session.usage, prompt.submit, etc.) already has it. This hit the empty-string path and returned `Unknown session: `, showing 'Session unavailable' in the chat view.

**Fix:** One-line: `params.session_id ?? ctx.activeSessionId ?? ""`

**Test plan:**
- [ ] All 193 web unit tests pass
- [ ] Connect Hermes Desktop v0.17.0 → chat with an agent without 'Session unavailable'