### PR TITLE
fix(hermes): session.create fallback + pet.info stub for Hermes v0.17

### DIFF
--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -772,7 +772,16 @@ export async function onHermesMessage(ctx: HermesWsContext, raw: string) {
     case "session.resume":
     case "session.activate": {
       // Map to an existing agent — Switchroom agents are always live.
-      const sessionId = String(params.session_id ?? params.name ?? "");
+      // session.create from Hermes v0.17+ may omit session_id (profile-based new-chat
+      // flow); fall back to the active session on this WS connection, then the most
+      // recently active agent.
+      let sessionId = String(params.session_id ?? params.name ?? "");
+      if (!sessionId && ctx.activeSessionId) sessionId = ctx.activeSessionId;
+      if (!sessionId) {
+        const all = await handleGetAgents(config);
+        const latest = all.sort((a, b) => (b.lastTurnAt ?? 0) - (a.lastTurnAt ?? 0))[0];
+        if (latest) sessionId = latest.name;
+      }
       if (!isKnownSession(config, sessionId)) {
         sendResponse(ctx, rpcErr(id, -32602, `Unknown session: ${sessionId}`));
         break;
@@ -905,6 +914,15 @@ export async function onHermesMessage(ctx: HermesWsContext, raw: string) {
         break;
       }
       sendResponse(ctx, rpcOk(id, { ok: true }));
+      break;
+    }
+
+    case "pet.info":
+    case "pet.info.meta":
+    case "pet.gallery": {
+      // Hermes "pet" companion feature — not supported by Switchroom; signal disabled
+      // so Hermes stops retrying instead of looping on -32601.
+      sendResponse(ctx, rpcOk(id, { enabled: false }));
       break;
     }
 


### PR DESCRIPTION
## Summary

- `session.create` with no `session_id`/`name` (Hermes v0.17+ "new chat" flow) now falls back to `ctx.activeSessionId` then most-recent agent by `lastTurnAt`, instead of returning "Unknown session: "
- `pet.info` / `pet.info.meta` / `pet.gallery` stub returning `{enabled:false}` stops a retry storm that spammed the WS connection every ~5s

## Why

Hermes v0.17.0 calls `session.resume {session_id: "clerk"}` on connect (works), then `session.create {cols:96, profile:"default"}` when the user tries to send a message (was failing). Diagnosed via WS proxy capture of live Windows Hermes traffic.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] WS proxy confirms `session.create` → succeeds and `pet.info` → `{enabled:false}`
- [ ] User can send message to klanker from Windows Hermes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01PAXUuc7S9pq7pQJvC7vooa