### PR TITLE
fix(uat): sentinel text for Bot API 10.1 rich messages in mtcute driver

### DIFF
--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -843,8 +843,8 @@ function toObserved(msg: Message, edited: boolean): ObservedMessage {
   // message.message. Use a sentinel so text-based assertions still fire
   // until mtcute is updated to support the new TL constructor.
   const rawText = msg.text ?? "";
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const isRichMedia = rawText === "" && (msg.raw as any)?.media?._ === "messageMediaUnsupported";
+  const isRichMedia = rawText === "" &&
+    msg.raw._ === "message" && msg.raw.media?._ === "messageMediaUnsupported";
   return {
     chatId: msg.chat.id,
     messageId: msg.id,

--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -838,11 +838,18 @@ export class Driver {
 }
 
 function toObserved(msg: Message, edited: boolean): ObservedMessage {
+  // Bot API 10.1 sendRichMessage stores text in a new MTProto media type.
+  // mtcute 0.27.9 decodes this as messageMediaUnsupported with empty
+  // message.message. Use a sentinel so text-based assertions still fire
+  // until mtcute is updated to support the new TL constructor.
+  const rawText = msg.text ?? "";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const isRichMedia = rawText === "" && (msg.raw as any)?.media?._ === "messageMediaUnsupported";
   return {
     chatId: msg.chat.id,
     messageId: msg.id,
     threadId: msg.replyToMessage?.threadId ?? undefined,
-    text: msg.text ?? "",
+    text: isRichMedia ? "\x01" : rawText,
     senderUserId: msg.sender.id,
     fromBot: msg.sender.type === "user" && msg.sender.isBot === true,
     date: msg.date,


### PR DESCRIPTION
## Summary

- `toObserved` now detects `messageMediaUnsupported` with empty `message.message` and substitutes `\x01` (ASCII SOH) as a sentinel
- `sendRichMessage` (Bot API 10.1, grammy 1.44) stores message content in a new MTProto media constructor that mtcute 0.27.9 doesn't support — the real text is unreachable
- This unblocks the majority of UAT scenarios that check `/\S/` (non-empty reply) — they now fire correctly again

## Why

The `sendRichMessage` migration (#2669) broke the entire UAT harness: every bot reply arrived with `msg.text=""` because mtcute decoded the new rich-message media type as `messageMediaUnsupported`. Discovered during v0.16.28 fleet UAT — all scenarios were timing out even though the gateway log confirmed the bot was replying correctly (TTFO ~2.5s).

The sentinel is a holding pattern. The real fix is updating mtcute to a TL layer that knows about the new rich-message constructor. Text-content checks (`includes(TOKEN)` in `jtbd-memory-survives-restart-dm`) still won't work and need a separate solution.

## Test plan

- [x] `jtbd-fast-trivial-dm` — TTFO=2509ms ✅
- [x] `jtbd-always-on-after-restart-dm` ✅
- [ ] `jtbd-memory-survives-restart-dm` — still fails on content check (separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXGDSGArnajHNjcf8Vr17T