### PR TITLE
fix(telegram): split collapsed inline bullet lists onto separate lines

### DIFF
--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -190,11 +190,63 @@ function maskCodeRegions(text: string, nonce: string): MaskedCode {
  * Code fences and inline code are masked out before any of this runs, so their
  * interior `\n`s are never touched.
  */
+/**
+ * Split a collapsed inline bullet list onto separate lines.
+ *
+ * Agents sometimes emit an entire bullet list on ONE line using interior
+ * `•`/`·` separators, e.g.:
+ *
+ *   • Master Bath 1, clean • <b>Master Bath 2</b>, 33% loss • Cabinet, clean
+ *
+ * which renders as a single run-on line instead of stacked bullets (the GFM
+ * rich path treats `•`/`·` as ordinary text, not list syntax, so nothing
+ * stacks). This deterministically inserts a newline before each interior
+ * unicode-bullet separator so each bullet lands on its own line.
+ *
+ * Conservative by construction:
+ *  - Only a line that STARTS (after optional leading whitespace) with a bullet
+ *    marker (`•`, `·`, `-`, or `*` followed by a space) is eligible — prose
+ *    with a mid-sentence `•` is left untouched.
+ *  - Only the unicode bullets `•`/`·` are split on (an interior whitespace +
+ *    `•`/`·` + whitespace). `-`/`*` are NEVER used as interior split points —
+ *    too many false positives (hyphens, ranges, "a * b" multiplication).
+ *    They are only accepted as the LEADING marker.
+ *  - The bullet glyphs are left as-is; we only insert `\n` before each split
+ *    bullet and normalize the inter-bullet whitespace to a single space.
+ *  - Idempotent: once split, each bullet begins its own line, so the
+ *    interior-separator pattern (whitespace + bullet + whitespace) no longer
+ *    matches anywhere on those lines.
+ *
+ * Runs on already-code-masked text, so a `•` inside a code span/fence is safe.
+ */
+export function splitCollapsedInlineBullets(text: string): string {
+  if (!/[•·]/.test(text)) return text
+  // Leading marker: optional indent, then • · - or * followed by a space.
+  // Interior separator to split on: whitespace + • or · + whitespace.
+  const interiorSep = /[ \t]+([•·])[ \t]+/g
+  return text
+    .split('\n')
+    .map((line) => {
+      if (!/^[ \t]*[•·*-] /.test(line)) return line
+      if (!/[ \t][•·][ \t]/.test(line)) return line
+      return line.replace(interiorSep, '\n$1 ')
+    })
+    .join('\n')
+}
+
 export function normalizeParagraphBreaks(text: string): string {
-  if (!text.includes('\n')) return text
+  // A text with no newline still needs the inline-bullet split (a collapsed
+  // bullet list is a SINGLE line). Only bail early when there is neither a
+  // newline nor a unicode bullet to potentially split.
+  if (!text.includes('\n') && !/[•·]/.test(text)) return text
 
   const nonce = Math.random().toString(36).slice(2)
-  const { masked, restore, placeholder } = maskCodeRegions(text, nonce)
+  const { masked: maskedRaw, restore, placeholder } = maskCodeRegions(text, nonce)
+
+  // Step 0: split a collapsed inline bullet list onto separate lines. Done on
+  // the code-masked text so a `•` inside a fenced block or inline code span is
+  // never touched. See splitCollapsedInlineBullets for the exact rule.
+  const masked = splitCollapsedInlineBullets(maskedRaw)
 
   // Step 1: collapse 3+ newlines to exactly two. This also normalizes runs that
   // contain interleaved spaces only between the newlines is NOT done here —

--- a/telegram-plugin/tests/paragraph-normalizer.test.ts
+++ b/telegram-plugin/tests/paragraph-normalizer.test.ts
@@ -9,7 +9,7 @@
  * (un-promoted break) are preferred over false positives (double-spaced list).
  */
 import { describe, test, expect } from 'vitest'
-import { normalizeParagraphBreaks } from '../format.js'
+import { normalizeParagraphBreaks, splitCollapsedInlineBullets } from '../format.js'
 
 describe('normalizeParagraphBreaks', () => {
   test('promotes a lone prose paragraph break (prev ends with `.`, next is prose)', () => {
@@ -269,5 +269,99 @@ describe('normalizeParagraphBreaks', () => {
     // of that item, not breakout prose — it must NOT gain a blank line.
     const input = '- first item\n    continued text of the first item'
     expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// splitCollapsedInlineBullets — stack an inline-collapsed bullet list
+// ---------------------------------------------------------------------------
+
+describe('splitCollapsedInlineBullets', () => {
+  test('splits the bath-bulb run-on (4 inline bullets → 4 lines)', () => {
+    const input =
+      '• Master Bath 1, clean • Master Bath 2, 33% packet loss • Master Bath 3, clean • Cabinet, clean'
+    expect(splitCollapsedInlineBullets(input)).toBe(
+      '• Master Bath 1, clean\n• Master Bath 2, 33% packet loss\n• Master Bath 3, clean\n• Cabinet, clean',
+    )
+  })
+
+  test('a bold segment inside one bullet survives the split', () => {
+    const input = '• A, clean • **Master Bath 2** (192.168.5.252), **33% loss** • C, clean'
+    expect(splitCollapsedInlineBullets(input)).toBe(
+      '• A, clean\n• **Master Bath 2** (192.168.5.252), **33% loss**\n• C, clean',
+    )
+  })
+
+  test('a <b> segment inside one bullet survives the split', () => {
+    const input = '• A, clean • <b>Master Bath 2</b>, <b>33% packet loss</b> • C, clean'
+    expect(splitCollapsedInlineBullets(input)).toBe(
+      '• A, clean\n• <b>Master Bath 2</b>, <b>33% packet loss</b>\n• C, clean',
+    )
+  })
+
+  test('splits on the middle-dot `·` separator too, and a `·`-led line', () => {
+    const input = '· one · two · three'
+    expect(splitCollapsedInlineBullets(input)).toBe('· one\n· two\n· three')
+  })
+
+  test('accepts a `-` or `*` leading marker (but only splits unicode interior bullets)', () => {
+    expect(splitCollapsedInlineBullets('- lead marker • two • three')).toBe(
+      '- lead marker\n• two\n• three',
+    )
+    expect(splitCollapsedInlineBullets('* lead marker • two')).toBe('* lead marker\n• two')
+  })
+
+  test('prose containing a mid-sentence `•` (line does not start with a bullet) is untouched', () => {
+    const input = 'The plan uses A • B notation throughout the design doc.'
+    expect(splitCollapsedInlineBullets(input)).toBe(input)
+  })
+
+  test('does NOT split on interior `-`/`*` (hyphens, ranges, multiplication)', () => {
+    const input = '• range 1-3 and a * b product stay on one bullet'
+    // No interior unicode bullet → line is returned unchanged.
+    expect(splitCollapsedInlineBullets(input)).toBe(input)
+  })
+
+  test('is idempotent on the bath-bulb input', () => {
+    const input =
+      '• Master Bath 1, clean • Master Bath 2, 33% packet loss • Master Bath 3, clean • Cabinet, clean'
+    const once = splitCollapsedInlineBullets(input)
+    const twice = splitCollapsedInlineBullets(once)
+    expect(twice).toBe(once)
+  })
+
+  test('an already-correct multi-line bullet list passes through unchanged', () => {
+    const input = '• Master Bath 1, clean\n• Master Bath 2, 33% loss\n• Cabinet, clean'
+    expect(splitCollapsedInlineBullets(input)).toBe(input)
+  })
+})
+
+describe('normalizeParagraphBreaks — inline bullet split integration', () => {
+  test('splits the bath-bulb run-on as part of the full outbound pass', () => {
+    const input =
+      '• Master Bath 1, clean • Master Bath 2, 33% packet loss • Master Bath 3, clean • Cabinet, clean'
+    expect(normalizeParagraphBreaks(input)).toBe(
+      '• Master Bath 1, clean\n• Master Bath 2, 33% packet loss\n• Master Bath 3, clean\n• Cabinet, clean',
+    )
+  })
+
+  test('a `•` inside an inline code span is NOT split (code masked)', () => {
+    const input = '`• a • b • c` is a code span'
+    // The line does not start with a bullet marker (it starts with the masked
+    // code placeholder), and the bullets live inside masked code regardless.
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
+  test('a `•` inside a fenced code block is NOT split', () => {
+    const input = '```\n• a • b • c\n```'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
+  test('idempotent through the full pass on the bath-bulb input', () => {
+    const input =
+      '• Master Bath 1, clean • Master Bath 2, 33% packet loss • Cabinet, clean'
+    const once = normalizeParagraphBreaks(input)
+    const twice = normalizeParagraphBreaks(once)
+    expect(twice).toBe(once)
   })
 })


### PR DESCRIPTION
## Summary

Telegram messages whose bullet list was emitted **inline on a single line** with `•`/`·` separators render as a run-on line instead of stacked bullets, e.g.

> • Master Bath 1, clean • **Master Bath 2** (192.168.5.252), **33% packet loss** • Master Bath 3, clean • Cabinet, clean

Bullets already on their own lines stack fine — only the inline-collapsed case is broken. On the current GFM rich-message path (post Bot API 10.1 migration, #2669) `•`/`·` are ordinary text, not list syntax, so nothing stacks.

This adds a **deterministic** code fix (not model guidance), applied to every outbound message.

## Why here, not `sanitizeForTelegram`

The task brief targeted `sanitizeForTelegram` in `format.ts`, but that function — and the entire markdown→HTML/HTML-sanitizer pipeline — was **removed in the Bot API 10.1 migration (#2669)**. The universal deterministic outbound normalizer is now `normalizeParagraphBreaks` (`format.ts`), called as `normalizeParagraphBreaks(repairEscapedWhitespace(...))` in `gateway.ts`, `stream-reply-handler.ts`, and the edit path. The new rule lives there, as **Step 0**, running on **code-masked** text (the modern equivalent of the old Phase-1 `<code>`/`<pre>` placeholder exclusion).

## The rule

New `splitCollapsedInlineBullets(text)`:

- Eligible line: starts (after optional whitespace) with a bullet marker — `^[ \t]*[•·*-] ` — AND contains an interior unicode-bullet separator `[ \t][•·][ \t]`.
- Replacement: `line.replace(/[ \t]+([•·])[ \t]+/g, '\n$1 ')` — insert `\n` before each interior `•`/`·`, normalize whitespace to one space, leave the glyph as-is.
- Leading marker may be any of `•·-*`; **interior splits are unicode-bullet-only** (never `-`/`*` — too many false positives: hyphens, ranges, `a * b`).
- Runs on code-masked text → a `•` inside `code`/```` ``` ```` is untouched.
- Idempotent: once split, bullets start their own lines and no longer match the interior-separator pattern.

The `normalizeParagraphBreaks` early-return guard was relaxed (`!\n && !•·` → bail) so a single-line collapsed list still reaches the split.

## Test plan

Added to `telegram-plugin/tests/paragraph-normalizer.test.ts`:

- [x] Bath-bulb case: 4 inline bullets → 4 lines
- [x] `**bold**` segment survives the split
- [x] `<b>` segment survives the split
- [x] `·` separator + `·`-led line
- [x] `-`/`*` leading marker accepted; interior `-`/`*` NOT split (hyphens, ranges, multiplication)
- [x] mid-sentence `•` in prose (line not starting with a bullet) untouched
- [x] idempotency on bath-bulb input (unit + full-pass)
- [x] already-correct multi-line list unchanged
- [x] `•` inside inline code span / fenced block NOT split (via `normalizeParagraphBreaks`)

`vitest` + `bun test`: **76 + 42 pass, 0 fail**. `tsc --noEmit` (project config) clean.

## Risk

Low. Conservative by construction; only acts on lines that begin with a bullet marker and contain interior unicode bullets. Code/pre excluded via existing masking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)