### PR TITLE
fix(telegram): stack card bodies so bullets render like a reply

### DIFF
--- a/telegram-plugin/card-format.ts
+++ b/telegram-plugin/card-format.ts
@@ -36,6 +36,54 @@ import { escapeMarkdown } from './format.js'
 export { escapeMarkdown }
 
 /**
+ * Join a card's pre-rendered, single-line entries so they STACK in the
+ * Bot API 10.1 rich-message renderer (#2669) — the same visual result the
+ * main reply path gets after `normalizeParagraphBreaks`.
+ *
+ * Why this exists: the rich GFM renderer treats a LONE `\n` between two
+ * non-blank lines as a SOFT break and collapses them onto one visual line
+ * (this is the exact reason `normalizeParagraphBreaks` promotes prose `\n`
+ * to a hard break on the reply path). Status / worker / issues / boot
+ * cards build a list of styled prose lines (`_✓ step_`, `**→ step**`,
+ * header lines, a `─────` rule) and join them with `\n`. Sent verbatim via
+ * `richMessage`, those lines collapse into a run-on blob — the long-standing
+ * "progress-card bullets collapse into one line" bug.
+ *
+ * Each card line is a SINGLE styled line with no internal newline (steps are
+ * pre-clipped to one line, headers are emitted one-per-array-entry), so we
+ * can deterministically promote EVERY inter-line break to a GFM hard break
+ * (`  \n`, two trailing spaces) without risking a list/table/code corruption:
+ * card lines are never GFM block-structure lines (no leading `-`/`*`/`|`/```),
+ * they are inline-styled prose. A blank entry (intentional `\n\n` gap, if a
+ * caller ever inserts one) is preserved as a real paragraph break.
+ *
+ * This is the card-surface analogue of the reply path's
+ * `normalizeParagraphBreaks`: it guarantees a card authored as stacked
+ * bullet/step lines renders identically to a normal reply.
+ */
+export function stackCardLines(lines: string[]): string {
+  const pieces: string[] = []
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    pieces.push(line)
+    if (i === lines.length - 1) break
+    const cur = line.trim()
+    const next = lines[i + 1].trim()
+    // A blank current or next line is a genuine `\n\n` paragraph gap — leave
+    // the separator a plain newline so the blank entry reconstructs the gap.
+    if (cur === '' || next === '') {
+      pieces.push('\n')
+      continue
+    }
+    // Strip any trailing whitespace the line already carried so we emit
+    // exactly one `  \n` hard break (never accumulate spaces on a re-run).
+    pieces[pieces.length - 1] = line.replace(/[ \t\r]+$/, '')
+    pieces.push('  \n')
+  }
+  return pieces.join('')
+}
+
+/**
  * Render a millisecond duration as `<n>ms` for sub-second values, or
  * `MM:SS` thereafter. Output contains no markdown-special characters, so
  * callers can interpolate it into a markdown card without escaping.

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -51,7 +51,7 @@ import {
   AGENT_LIVE_WINDOW_MS,
   AGENT_LIVE_POLL_INTERVAL_MS,
 } from './boot-probes.js'
-import { escapeMarkdown } from '../card-format.js'
+import { escapeMarkdown, stackCardLines } from '../card-format.js'
 import {
   loadCache as loadBootIssueCache,
   diffProbes as diffBootProbes,
@@ -468,7 +468,12 @@ export function renderBootCard(opts: RenderBootCardOpts): string {
     sections.push('', ...configChangeRows)
   }
   if (sections.length === 1) return ack
-  return sections.join('\n')
+  // Stack rows with GFM hard breaks so the boot card's styled prose rows don't
+  // collapse onto one visual line in the rich-message renderer (#2669). A
+  // section entry may itself carry an internal newline (a multi-line `ack`, an
+  // update-outcome blob), so flatten to single lines first — see stackCardLines.
+  const flatLines = sections.flatMap((s) => s.split('\n'))
+  return stackCardLines(flatLines)
 }
 
 /**

--- a/telegram-plugin/issues-card.ts
+++ b/telegram-plugin/issues-card.ts
@@ -17,7 +17,7 @@
  */
 
 import { readFileSync, writeFileSync } from "node:fs";
-import { escapeMarkdown } from "./card-format.js";
+import { escapeMarkdown, stackCardLines } from "./card-format.js";
 import type { IssueEvent, IssueSeverity } from "../src/issues/index.js";
 
 export interface BotApiForIssuesCard {
@@ -99,26 +99,31 @@ export function renderIssuesCard(opts: RenderIssuesCardOpts): string | null {
   const overflow = sorted.length - visible.length;
 
   const now = opts.now ?? Date.now();
-  const rows = visible.map((e) => {
+  // Build a flat list of SINGLE lines (a row may contribute a head line plus a
+  // remediation line) so stackCardLines can promote every inter-line break to a
+  // GFM hard break — otherwise the rows collapse onto one visual line in the
+  // rich-message renderer (the same bug stackCardLines fixes for status cards).
+  const rowLines: string[] = [];
+  for (const e of visible) {
     const emoji = SEVERITY_EMOJI[e.severity];
     const occ = e.occurrences > 1 ? ` _(×${e.occurrences})_` : "";
     const ago = relTime(now - e.last_seen);
-    const head = `${emoji} \`${e.fingerprint}\`  ${escapeMarkdown(e.summary)}${occ} — _${ago}_`;
+    rowLines.push(`${emoji} \`${e.fingerprint}\`  ${escapeMarkdown(e.summary)}${occ} — _${ago}_`);
     // Render the `detail` line below the summary when present and short
     // enough to be a remediation hint (not a multi-line stderr tail).
     // Convention from the cron prompt template: agents put "Fix: <cmd>"
     // or "→ <cmd>" in detail. Long stderr details are omitted from the
     // card to keep the layout tight; users can run /issues to see them.
     const remediation = formatRemediation(e.detail);
-    return remediation == null ? head : `${head}\n  → _${escapeMarkdown(remediation)}_`;
-  });
+    if (remediation != null) rowLines.push(`  → _${escapeMarkdown(remediation)}_`);
+  }
 
-  const lines = [header, "", ...rows];
+  const lines = [header, "", ...rowLines];
   if (overflow > 0) {
     lines.push("");
     lines.push(`_+${overflow} more not shown — run \`/issues\`_`);
   }
-  return lines.join("\n");
+  return stackCardLines(lines);
 }
 
 /**

--- a/telegram-plugin/tests/card-format.test.ts
+++ b/telegram-plugin/tests/card-format.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   cleanWorkerResultParagraph,
   formatDuration,
+  stackCardLines,
   stripMarkdown,
   truncate,
 } from '../card-format.js'
@@ -94,5 +95,55 @@ describe('escapeMarkdown / truncate', () => {
   it('truncates with an ellipsis', () => {
     expect(truncate('abcdef', 4)).toBe('abc…')
     expect(truncate('abc', 4)).toBe('abc')
+  })
+})
+
+describe('stackCardLines — card bodies stack like the reply path', () => {
+  // The bug this fixes: the rich-message renderer (#2669) treats a LONE `\n`
+  // between two non-blank lines as a SOFT break and collapses them onto one
+  // visual line. A card built as a list of styled prose lines and joined with
+  // `\n` therefore renders as a run-on blob. stackCardLines promotes every
+  // inter-line break to a GFM hard break (`  \n`) so the lines stack — the
+  // same end-state the reply path reaches via normalizeParagraphBreaks.
+
+  it('promotes every inter-line break to a GFM hard break so bullets stack', () => {
+    const out = stackCardLines(['_✓ Reading a.ts_', '_✓ Searching memory_', '**→ List workspace**'])
+    expect(out).toBe('_✓ Reading a.ts_  \n_✓ Searching memory_  \n**→ List workspace**')
+    // No LONE `\n` survives between non-blank lines — every break is a hard break.
+    expect(out.replace(/ {2}\n/g, '')).not.toContain('\n')
+  })
+
+  it('single line is returned verbatim (no trailing hard break)', () => {
+    expect(stackCardLines(['**→ Reading a.ts**'])).toBe('**→ Reading a.ts**')
+  })
+
+  it('preserves an intentional blank-line paragraph gap', () => {
+    // A blank entry is a genuine `\n\n` gap (e.g. boot card header → rows);
+    // it must NOT become a hard-break run — the blank reconstructs the gap.
+    const out = stackCardLines(['🔔 **Header**', '', '_✓ row one_', '_✓ row two_'])
+    expect(out).toBe('🔔 **Header**\n\n_✓ row one_  \n_✓ row two_')
+  })
+
+  it('does not accumulate trailing spaces on a re-run (idempotent breaks)', () => {
+    const once = stackCardLines(['a.', 'b.', 'c.'])
+    // Feeding the stacked output back in (split on hard break) yields the same.
+    const twice = stackCardLines(once.split('  \n'))
+    expect(twice).toBe(once)
+  })
+
+  it('keeps bold, code-spans and the worker-result rule intact (only breaks change)', () => {
+    const out = stackCardLines([
+      '🛠 **Worker** · _build_',
+      '_✓ Running `git push`_',
+      '─────',
+      '✅ _Fixed the **bug** in `foo.ts`_',
+    ])
+    // Inline markup is untouched — bold, code spans, the rule line all survive.
+    expect(out).toContain('**Worker**')
+    expect(out).toContain('`git push`')
+    expect(out).toContain('Fixed the **bug** in `foo.ts`')
+    expect(out).toContain('─────')
+    // And the four lines stack (three hard breaks, no soft breaks).
+    expect(out.match(/ {2}\n/g)?.length).toBe(3)
   })
 })

--- a/telegram-plugin/tests/issues-card.test.ts
+++ b/telegram-plugin/tests/issues-card.test.ts
@@ -175,6 +175,30 @@ describe("renderIssuesCard", () => {
     expect(out).toContain("`<x>::<y>`");
     expect(out).toContain("<dangerous & stuff>");
   });
+
+  it("stacks issue rows with GFM hard breaks so they don't collapse onto one line (#2669)", () => {
+    // Card-body regression: the rich-message renderer collapses lone-`\n`
+    // separated rows into a run-on blob. The issues card now routes its rows
+    // through stackCardLines, so each issue row is separated by a hard break.
+    const events = [
+      makeEvent({ fingerprint: "a::1", code: "1", severity: "critical", summary: "alpha down", detail: "Fix: restart alpha" }),
+      makeEvent({ fingerprint: "a::2", code: "2", severity: "error", summary: "beta slow" }),
+    ];
+    const out = renderIssuesCard({ agentName: "klanker", events, now: 1_700_000_000_000 })!;
+    // Header → rows is a genuine paragraph gap (blank line preserved).
+    expect(out).toContain("\n\n");
+    // Each adjacent issue row (and its remediation line) is hard-broken, not
+    // soft — so no two non-blank body lines are glued by a LONE `\n`.
+    const softBreaks = out.split("\n\n").flatMap((block) => {
+      // Within a block, every internal `\n` must be a hard break (` \n`).
+      return [...block.matchAll(/(?<! {2})\n/g)];
+    });
+    expect(softBreaks.length).toBe(0);
+    // Both rows + the remediation line all rendered, stacked.
+    expect(out).toContain("alpha down");
+    expect(out).toContain("→ _restart alpha_");
+    expect(out).toContain("beta slow");
+  });
 });
 
 // ─── createIssuesCardHandle (lifecycle) ──────────────────────────────────────

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -84,10 +84,10 @@ describe("appendActivityLine + renderActivityFeed — accumulating activity feed
       "**→ Reading gateway.ts**",
     );
     expect(appendActivityLine(lines, "mcp__hindsight__reflect", { query: "x" })).toBe(
-      "_✓ Reading gateway.ts_\n**→ Searching memory**",
+      "_✓ Reading gateway.ts_  \n**→ Searching memory**",
     );
     expect(appendActivityLine(lines, "Bash", { command: "ls", description: "List workspace" })).toBe(
-      "_✓ Reading gateway.ts_\n_✓ Searching memory_\n**→ List workspace**",
+      "_✓ Reading gateway.ts_  \n_✓ Searching memory_  \n**→ List workspace**",
     );
   });
 
@@ -110,7 +110,7 @@ describe("appendActivityLine + renderActivityFeed — accumulating activity feed
     const lines = Array.from({ length: total }, (_, i) => `Action ${i + 1}`);
     const out = renderActivityFeed(lines)!;
     const hidden = total - STATUS_ROLLING_LINES;
-    expect(out.startsWith(`_✓ +${hidden} earlier…_\n`)).toBe(true);
+    expect(out.startsWith(`_✓ +${hidden} earlier…_  \n`)).toBe(true);
     // Only the last STATUS_ROLLING_LINES actions are shown; older ones collapsed.
     const firstVisible = total - STATUS_ROLLING_LINES + 1;
     expect(out).toContain(`_✓ Action ${firstVisible}_`);
@@ -145,7 +145,7 @@ describe("appendActivityLine + renderActivityFeed — accumulating activity feed
     const lines = ["Reading a.ts", "Searching memory", "Running a command"];
     const out = renderActivityFeed(lines, true)!;
     expect(out).toBe(
-      "_✓ Reading a.ts_\n_✓ Searching memory_\n_✓ Running a command_",
+      "_✓ Reading a.ts_  \n_✓ Searching memory_  \n_✓ Running a command_",
     );
     expect(out).not.toContain("→"); // no in-progress arrow anywhere
   });
@@ -164,7 +164,7 @@ describe("appendActivityLine + renderActivityFeed — accumulating activity feed
   describe("liveSuffix (heartbeat)", () => {
     it("appends the suffix to the newest in-progress line only", () => {
       expect(renderActivityFeed(["Reading a.ts", "Running a command"], false, " · 18s")).toBe(
-        "_✓ Reading a.ts_\n**→ Running a command · 18s**",
+        "_✓ Reading a.ts_  \n**→ Running a command · 18s**",
       );
     });
     it("single live line gets the suffix", () => {
@@ -176,7 +176,7 @@ describe("appendActivityLine + renderActivityFeed — accumulating activity feed
       const out = renderActivityFeed(["Reading a.ts", "Running a command"], true, " · 18s")!;
       expect(out).not.toContain("·");
       expect(out).not.toContain("→");
-      expect(out).toBe("_✓ Reading a.ts_\n_✓ Running a command_");
+      expect(out).toBe("_✓ Reading a.ts_  \n_✓ Running a command_");
     });
     it("default empty suffix is byte-identical to no suffix", () => {
       expect(renderActivityFeed(["Reading a.ts"], false, "")).toBe(
@@ -191,7 +191,7 @@ describe("appendActivityLabel — precomputed label feed (tool_label path)", () 
     const lines: string[] = [];
     expect(appendActivityLabel(lines, "Searching memory")).toBe("**→ Searching memory**");
     expect(appendActivityLabel(lines, "List workspace")).toBe(
-      "_✓ Searching memory_\n**→ List workspace**",
+      "_✓ Searching memory_  \n**→ List workspace**",
     );
     // consecutive dup collapses
     appendActivityLabel(lines, "List workspace");
@@ -381,7 +381,7 @@ describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A
   it("stepCount footer appears on final=true with no children (delegates to flat render)", () => {
     const out = renderActivityFeedWithNested(["Reading a.ts"], [], true, "", 3)!;
     expect(out).toContain("_✓ 3 steps_");
-    expect(out).toBe("_✓ Reading a.ts_\n_✓ 3 steps_");
+    expect(out).toBe("_✓ Reading a.ts_  \n_✓ 3 steps_");
   });
 
   // Liveness-driven feed open (dark-turn fix): a turn that emits no tool_label
@@ -845,5 +845,43 @@ describe("describeToolUse — surface-tool suppression is key-agnostic", () => {
   it("returns null for telegram edit_message and react under any key", () => {
     expect(describeToolUse("mcp__clerk-telegram__edit_message", {})).toBeNull();
     expect(describeToolUse("mcp__clerk-telegram__react", {})).toBeNull();
+  });
+});
+
+describe("status-card body stacks like a reply (#2669 rich-message renderer)", () => {
+  // The single most-seen surface: the operator's progress card. Its step lines
+  // are styled prose (`_✓ …_`, `**→ …**`), NOT GFM list items, so a lone `\n`
+  // between them is a SOFT break the renderer collapses — bullets ran together
+  // into one line. The card now joins via stackCardLines (hard breaks), so the
+  // bullets stack exactly as the reply path renders them.
+
+  it("multiple step bullets stack on their own lines (no soft-break collapse)", () => {
+    const out = renderActivityFeed(["Reading a.ts", "Searching memory", "Running tests"], true)!;
+    const lines = out.split("  \n");
+    expect(lines).toEqual(["_✓ Reading a.ts_", "_✓ Searching memory_", "_✓ Running tests_"]);
+    // Not a single lone `\n` survives to collapse two bullets.
+    expect(out).not.toMatch(/(?<! {2})\n/);
+  });
+
+  it("the collapsed-inline-bullet case is fixed on a card body specifically", () => {
+    // Three labels that, joined by a lone `\n`, would render as a single run-on
+    // visual line in the rich renderer. After stacking, each renders distinctly.
+    const out = renderActivityFeed(["Editing foo.ts", "Editing bar.ts", "Writing baz.ts"])!;
+    // Every adjacent pair is separated by a hard break.
+    expect(out.match(/ {2}\n/g)?.length).toBe(2);
+    // The newest is the in-progress bold step; earlier are done — all visible.
+    expect(out).toContain("_✓ Editing foo.ts_");
+    expect(out).toContain("_✓ Editing bar.ts_");
+    expect(out).toContain("**→ Writing baz.ts**");
+  });
+
+  it("stacking does not corrupt the card's own italic/bold wrapper markup", () => {
+    // The status card wraps each step in `_…_` (done) or `**→ …**` (live). The
+    // stacking pass only changes the SEPARATOR between lines — the per-line
+    // wrapper markup must be byte-identical. (Step TEXT is stripped to plain
+    // prose by escapeStepLine; the inline-markup-survives case is covered by
+    // the stackCardLines unit test, which operates on pre-rendered lines.)
+    const out = renderActivityFeed(["Reading a.ts", "Running tests"], false)!;
+    expect(out).toBe("_✓ Reading a.ts_  \n**→ Running tests**");
   });
 });

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -177,7 +177,7 @@ import {
   STATUS_LINE_MAX,
   NESTED_PREFIX,
 } from './status-no-truncate.js'
-import { escapeMarkdown, stripMarkdown, truncate } from './card-format.js'
+import { escapeMarkdown, stripMarkdown, truncate, stackCardLines } from './card-format.js'
 import { isTelegramSurfaceTool } from './tool-names.js'
 
 /**
@@ -429,7 +429,10 @@ export function renderStatusCard(opts: StatusCardOpts): string | null {
   // out always carries the two header lines, so it is never empty — but guard
   // against a degenerate header-less future caller.
   if (out.length === 0) return null
-  const joined = out.join('\n')
+  // Stack lines with GFM hard breaks (`  \n`) so the card's styled prose lines
+  // don't collapse onto one visual line in the rich-message renderer — see
+  // stackCardLines. This is what makes a card render identically to a reply.
+  const joined = stackCardLines(out)
   if (joined.length <= STATUS_CARD_CHAR_BUDGET) return joined
   return fitCardToBudget(opts, headerLines)
 }
@@ -482,7 +485,7 @@ function fitCardToBudget(opts: StatusCardOpts, headerLines: string[]): string {
     const lastIdx = shown.length - 1
     shown.forEach((esc, i) => lines.push(buildBullet(esc, i === lastIdx)))
     lines.push(...footerLines)
-    const candidate = lines.join('\n')
+    const candidate = stackCardLines(lines)
     if (candidate.length <= STATUS_CARD_CHAR_BUDGET) return candidate
   }
 
@@ -508,7 +511,7 @@ function fitCardToBudget(opts: StatusCardOpts, headerLines: string[]): string {
   if (parentMarker != null) lines.push(parentMarker)
   lines.push(newestLine)
   lines.push(...footerLines)
-  return lines.join('\n')
+  return stackCardLines(lines)
 }
 
 /**

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -158,8 +158,10 @@ export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): st
     return `🛠 **Worker** · _starting…_`
   }
   if (!finished && steps.length === 0) {
-    // Header-only running render → append the starting placeholder.
-    return `${card}\n_starting…_`
+    // Header-only running render → append the starting placeholder with a GFM
+    // hard break (`  \n`) so it stacks under the header instead of collapsing
+    // onto the header line in the rich-message renderer (matches stackCardLines).
+    return `${card}  \n_starting…_`
   }
   return card
 }


### PR DESCRIPTION
## Summary

Every **card** surface (progress/status card, worker activity feed, issues card, boot/config-summary greeting card) assembled a list of styled prose lines (`_✓ step_`, `**→ step**`, issue rows) and joined them with a lone `\n`, then sent the body verbatim via `richMessage`. The Bot API 10.1 rich-message renderer (#2669) treats a lone `\n` between two non-blank lines as a **soft break** and collapses them onto one visual line — so card bullets rendered as a run-on blob. The main reply path doesn't have this bug because it routes through `normalizeParagraphBreaks` (lone prose `\n` → GFM hard break).

This adds `stackCardLines` to `card-format.ts` — the card-surface analogue of the reply path's normalizer — and routes every card **body** through it so a card authored as stacked bullet/step lines renders identically to a normal reply.

## Why

Consolidates all card bodies onto one deterministic line-joining rule, matching the reply path. Fixes the long-standing "progress-card bullets collapse into one line" report (the surface the operator sees most).

## What changed

- `card-format.ts`: new `stackCardLines(lines)` — promotes every inter-line break to a GFM hard break (`  \n`), preserves intentional `\n\n` gaps. Idempotent. Non-formatting helpers (`truncate`, `formatDuration`, `stripMarkdown`, `cleanWorkerResultParagraph`) unchanged.
- `tool-activity-summary.ts` (`renderStatusCard` + `fitCardToBudget`): the status/progress card **and** the worker activity feed both funnel through here → both fixed at the source.
- `worker-activity-feed.ts`: the header-only "starting…" placeholder now hard-breaks under the header.
- `issues-card.ts` (`renderIssuesCard`): rows flattened to single lines, then stacked.
- `gateway/boot-card.ts`: boot/config-summary sections flattened + stacked.

## Deliberately NOT changed

- **Permission / ask-user card** (`formatPermissionCardBody`): security surface, frozen byte-for-byte (**zero diff**). Its body is already single styled lines with no collapsible markdown-bullet body — nothing to consolidate without restructuring, which the safety constraint forbids.
- **Slot banner** (`slot-banner-driver.ts`): its text is a single joined line (no bullet body to stack). Wrapping its decoupled, fake-bot-tested send path in `robustApiCall` is a structural refactor of a separate module — **left as follow-up** rather than risked in this body-formatting PR.
- **config-snapshot.ts**: produces single-line rows consumed by the boot card (covered there); no standalone send.

## Test plan

- [x] New `stackCardLines` unit tests (stack, single line, blank-gap preserved, idempotent, inline markup intact).
- [x] New card-body stacking tests: status card (bullets stack, collapsed-inline case fixed on a card body, wrapper markup intact) and issues card (rows + remediation stacked, no soft breaks).
- [x] Existing card assertions updated to the hard-break separator (the behavior this PR intentionally changes).
- [x] Full plugin `tests/` suite green: **5036 pass / 0 fail** (bun + vitest). Root `tsc --noEmit` clean. The 154 UAT-scenario failures are pre-existing (missing `TELEGRAM_API_ID`; uat/** is excluded from gating CI) and reproduce identically on a clean sibling branch.

## Risk

Low. Pure body line-joining change; no send-path, gating, or structure changes. The permission card (security surface) is untouched.

## Relationship to #2687

**Independent** of #2687 (`splitCollapsedInlineBullets`, not yet merged to `main`). This PR branches off `upstream/main` and touches only `card-format.ts` / card builders — it does **not** touch `format.ts`, so there is **no merge conflict** with #2687. When #2687 lands, card bodies that ever carry collapsed inline bullets will additionally benefit from its `normalizeParagraphBreaks` Step 0 on the reply path; the two changes compose cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)