### PR TITLE
feat(hermes): real-time Telegram↔Hermes response sync

### DIFF
--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -286,62 +286,6 @@ async function injectInbound(
 }
 
 /**
- * Poll history.db for the agent's reply after a prompt was injected.
- * Resolves with the assistant text when found, or null on timeout.
- *
- * history.db is owned by the agent uid but chmod'd 0644 (readable by web
- * container uid=1000). We use bun:sqlite directly because this module runs
- * inside the web Bun process.
- */
-async function waitForAssistantReply(
-  agentsDir: string,
-  agentName: string,
-  afterTsSec: number,
-  maxWaitMs = 300_000,
-  pollIntervalMs = 2_000,
-): Promise<string | null> {
-  const dbPath = resolve(agentsDir, agentName, "telegram", "history.db");
-  if (!existsSync(dbPath)) return null;
-
-  const deadline = Date.now() + maxWaitMs;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let SqliteDatabase: any;
-  try {
-    const meta = import.meta as { require?: (id: string) => unknown };
-    if (!meta.require) return null;
-    const mod = meta.require("bun:sqlite") as { Database?: unknown };
-    SqliteDatabase = mod.Database;
-  } catch {
-    return null;
-  }
-
-  while (Date.now() < deadline) {
-    try {
-      const db = new SqliteDatabase(dbPath, { readonly: true });
-      try {
-        // Don't filter by chat_id — the inject target chat may differ from
-        // the stored chat_id (DM vs forum). Any assistant message after the
-        // inject timestamp is the reply we're waiting for.
-        const row = db
-          .prepare(
-            `SELECT text FROM messages
-             WHERE role = 'assistant' AND ts > ?
-             ORDER BY ts DESC, rowid DESC LIMIT 1`,
-          )
-          .get(afterTsSec) as { text: string } | undefined | null;
-        if (row?.text) return row.text;
-      } finally {
-        db.close();
-      }
-    } catch {
-      // DB may be locked or temporarily unreadable — keep polling
-    }
-    await new Promise((r) => setTimeout(r, pollIntervalMs));
-  }
-  return null;
-}
-
-/**
  * Read the most recent `limit` messages from history.db for an agent.
  * Returns an array of {role, content, timestamp} in chronological order,
  * or null if history.db is unavailable.

--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -285,6 +285,173 @@ async function injectInbound(
   });
 }
 
+/**
+ * Poll history.db for the agent's reply after a prompt was injected.
+ * Resolves with the assistant text when found, or null on timeout.
+ *
+ * history.db is owned by the agent uid but chmod'd 0644 (readable by web
+ * container uid=1000). We use bun:sqlite directly because this module runs
+ * inside the web Bun process.
+ */
+async function waitForAssistantReply(
+  agentsDir: string,
+  agentName: string,
+  afterTsSec: number,
+  maxWaitMs = 300_000,
+  pollIntervalMs = 2_000,
+): Promise<string | null> {
+  const dbPath = resolve(agentsDir, agentName, "telegram", "history.db");
+  if (!existsSync(dbPath)) return null;
+
+  const deadline = Date.now() + maxWaitMs;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let SqliteDatabase: any;
+  try {
+    const meta = import.meta as { require?: (id: string) => unknown };
+    if (!meta.require) return null;
+    const mod = meta.require("bun:sqlite") as { Database?: unknown };
+    SqliteDatabase = mod.Database;
+  } catch {
+    return null;
+  }
+
+  while (Date.now() < deadline) {
+    try {
+      const db = new SqliteDatabase(dbPath, { readonly: true });
+      try {
+        // Don't filter by chat_id — the inject target chat may differ from
+        // the stored chat_id (DM vs forum). Any assistant message after the
+        // inject timestamp is the reply we're waiting for.
+        const row = db
+          .prepare(
+            `SELECT text FROM messages
+             WHERE role = 'assistant' AND ts > ?
+             ORDER BY ts DESC, rowid DESC LIMIT 1`,
+          )
+          .get(afterTsSec) as { text: string } | undefined | null;
+        if (row?.text) return row.text;
+      } finally {
+        db.close();
+      }
+    } catch {
+      // DB may be locked or temporarily unreadable — keep polling
+    }
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+  return null;
+}
+
+/**
+ * Read the most recent `limit` messages from history.db for an agent.
+ * Returns an array of {role, content, timestamp} in chronological order,
+ * or null if history.db is unavailable.
+ */
+function readHistoryDb(
+  agentsDir: string,
+  agentName: string,
+  limit: number,
+): Array<{ role: string; content: string; timestamp: number }> | null {
+  const dbPath = resolve(agentsDir, agentName, "telegram", "history.db");
+  if (!existsSync(dbPath)) return null;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let SqliteDatabase: any;
+    const meta = import.meta as { require?: (id: string) => unknown };
+    if (!meta.require) return null;
+    const mod = meta.require("bun:sqlite") as { Database?: unknown };
+    SqliteDatabase = mod.Database;
+    if (!SqliteDatabase) return null;
+
+    const db = new SqliteDatabase(dbPath, { readonly: true });
+    try {
+      const rows = db
+        .prepare(
+          `SELECT role, text, ts FROM messages
+           ORDER BY ts DESC, rowid DESC LIMIT ?`,
+        )
+        .all(limit) as Array<{ role: string; text: string; ts: number }>;
+      return rows.reverse().map((r) => ({
+        role: r.role,
+        content: r.text,
+        timestamp: r.ts,
+      }));
+    } finally {
+      db.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Start a 2-second background poll on history.db for a given agent.
+ * Emits `message.complete` to the WS client for every new assistant
+ * message — covering both Telegram-originated and Hermes-injected replies.
+ *
+ * The cursor is the SQLite rowid so ties / timestamp collisions can't
+ * cause missed or duplicate messages. Only assistant messages are emitted;
+ * user messages are already rendered locally by Hermes or injected via us.
+ *
+ * Returns a stop function. Call it on session change or WS close.
+ */
+function startHistoryPoll(
+  ctx: HermesWsContext,
+  agentsDir: string,
+  agentName: string,
+  sessionId: string,
+  pollIntervalMs = 2_000,
+): () => void {
+  const dbPath = resolve(agentsDir, agentName, "telegram", "history.db");
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let SqliteDatabase: any = null;
+  try {
+    const meta = import.meta as { require?: (id: string) => unknown };
+    if (meta.require) {
+      const mod = meta.require("bun:sqlite") as { Database?: unknown };
+      SqliteDatabase = mod.Database ?? null;
+    }
+  } catch { /* not Bun — skip */ }
+
+  // Initialise cursor to current max rowid so we only emit NEW messages.
+  let cursor = 0;
+  if (SqliteDatabase && existsSync(dbPath)) {
+    try {
+      const db = new SqliteDatabase(dbPath, { readonly: true });
+      try {
+        const row = db.prepare("SELECT MAX(rowid) AS r FROM messages").get() as { r: number | null } | null;
+        cursor = row?.r ?? 0;
+      } finally { db.close(); }
+    } catch { /* best-effort */ }
+  }
+
+  const timer = setInterval(() => {
+    if (!SqliteDatabase || !existsSync(dbPath)) return;
+    try {
+      const db = new SqliteDatabase(dbPath, { readonly: true });
+      try {
+        const rows = db
+          .prepare(
+            `SELECT rowid, role, text FROM messages
+             WHERE rowid > ? AND role = 'assistant'
+             ORDER BY rowid ASC`,
+          )
+          .all(cursor) as Array<{ rowid: number; role: string; text: string }>;
+
+        for (const row of rows) {
+          cursor = row.rowid;
+          sendEvent(ctx, "message.complete", sessionId, {
+            text: row.text,
+            prompt_key: `poll-${row.rowid}`,
+          });
+        }
+      } finally { db.close(); }
+    } catch { /* DB locked / temporarily unreadable — retry next tick */ }
+  }, pollIntervalMs);
+
+  return () => clearInterval(timer);
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 import type { ScheduleDashboard } from "./api.js";
@@ -675,6 +842,8 @@ export interface HermesWsContext {
   pollInterval?: ReturnType<typeof setInterval>;
   /** Currently activated session (agent name), if any. */
   activeSessionId?: string;
+  /** Stop function for the history.db background poller — called on session change or close. */
+  stopHistoryPoll?: () => void;
 }
 
 function sendEvent(ctx: HermesWsContext, type: string, sessionId: string | null, payload: unknown) {
@@ -711,12 +880,14 @@ export function onHermesOpen(ctx: HermesWsContext) {
   }, 5000);
 }
 
-/** Called on WS close — clears the poll timer. */
+/** Called on WS close — clears all poll timers. */
 export function onHermesClose(ctx: HermesWsContext) {
   if (ctx.pollInterval) {
     clearInterval(ctx.pollInterval);
     ctx.pollInterval = undefined;
   }
+  ctx.stopHistoryPoll?.();
+  ctx.stopHistoryPoll = undefined;
 }
 
 /** Dispatch a JSON-RPC message from the client. */
@@ -795,12 +966,20 @@ export async function onHermesMessage(ctx: HermesWsContext, raw: string) {
         break;
       }
       const session = toHermesSession(sessionId, agent, agentLiveness(config, agentName), config);
-      sendResponse(ctx, rpcOk(id, { session }));
+      // Hermes reads `v.session_id` (and optionally `v.stored_session_id`) directly from
+      // the response — NOT `v.session.id`. Return the flat shape; the full session object
+      // arrives via the session.info event below.
+      sendResponse(ctx, rpcOk(id, { session_id: sessionId, stored_session_id: sessionId }));
       sendEvent(ctx, "session.info", sessionId, session);
+      // Start background poll so Telegram replies appear in Hermes in real time.
+      ctx.stopHistoryPoll?.();
+      ctx.stopHistoryPoll = startHistoryPoll(ctx, resolveAgentsDir(config), agentName, sessionId);
       break;
     }
 
     case "session.close": {
+      ctx.stopHistoryPoll?.();
+      ctx.stopHistoryPoll = undefined;
       ctx.activeSessionId = undefined;
       sendResponse(ctx, rpcOk(id, { ok: true }));
       break;
@@ -813,9 +992,16 @@ export async function onHermesMessage(ctx: HermesWsContext, raw: string) {
         break;
       }
       const limit = typeof params.limit === "number" ? params.limit : 50;
-      const result = handleGetTurns(config, sessionId, Math.min(limit, 200));
-      // Degrade gracefully on DB errors — return empty messages.
-      sendResponse(ctx, rpcOk(id, { session_id: sessionId, messages: turnsToMessages(result.turns ?? []) }));
+      const { agentName: histAgent } = parseHermesSessionId(sessionId);
+      const agentsDir = resolveAgentsDir(config);
+      const histMessages = readHistoryDb(agentsDir, histAgent, limit);
+      if (histMessages !== null) {
+        sendResponse(ctx, rpcOk(id, { session_id: sessionId, messages: histMessages }));
+      } else {
+        // Fall back to turns preview if history.db is unavailable
+        const result = handleGetTurns(config, sessionId, Math.min(limit, 200));
+        sendResponse(ctx, rpcOk(id, { session_id: sessionId, messages: turnsToMessages(result.turns ?? []) }));
+      }
       break;
     }
 
@@ -876,17 +1062,8 @@ export async function onHermesMessage(ctx: HermesWsContext, raw: string) {
         break;
       }
 
-      // Prompt accepted. The agent's reply arrives in Telegram — stream a
-      // brief acknowledgement so the desktop shows something in the chat
-      // rather than a hanging spinner. Full response streaming is Phase B.
-      sendEvent(ctx, "message.delta", sessionId, {
-        text: `*(Prompt sent to ${sessionId} — response will appear in Telegram)*`,
-        prompt_key: promptKey,
-      });
-      sendEvent(ctx, "message.complete", sessionId, {
-        text: `*(Prompt sent to ${sessionId} — response will appear in Telegram)*`,
-        prompt_key: promptKey,
-      });
+      // Prompt accepted. The background history poller will emit message.complete
+      // when the agent's reply arrives in history.db (within ~2s).
       sendResponse(ctx, rpcOk(id, { ok: true, prompt_key: promptKey }));
       break;
     }

--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -384,9 +384,17 @@ function startHistoryPoll(
 
         for (const row of rows) {
           cursor = row.rowid;
+          // If there's a pending prompt.submit, use that prompt_key so Hermes
+          // resolves the spinner. Otherwise synthesise a new start+complete pair
+          // (Telegram-originated reply the user didn't trigger from Hermes).
+          const promptKey = ctx.pendingPromptKey ?? `tg-${row.rowid}`;
+          if (!ctx.pendingPromptKey) {
+            sendEvent(ctx, "message.start", sessionId, { prompt_key: promptKey });
+          }
+          ctx.pendingPromptKey = undefined;
           sendEvent(ctx, "message.complete", sessionId, {
             text: row.text,
-            prompt_key: `poll-${row.rowid}`,
+            prompt_key: promptKey,
           });
         }
       } finally { db.close(); }
@@ -788,6 +796,12 @@ export interface HermesWsContext {
   activeSessionId?: string;
   /** Stop function for the history.db background poller — called on session change or close. */
   stopHistoryPoll?: () => void;
+  /**
+   * prompt_key from the most recent prompt.submit that hasn't yet been resolved by
+   * a message.complete. The history poller claims this key for the first new assistant
+   * message so the response resolves the correct pending spinner in Hermes.
+   */
+  pendingPromptKey?: string;
 }
 
 function sendEvent(ctx: HermesWsContext, type: string, sessionId: string | null, payload: unknown) {
@@ -998,16 +1012,19 @@ export async function onHermesMessage(ctx: HermesWsContext, raw: string) {
         .slice(0, 12);
 
       sendEvent(ctx, "message.start", sessionId, { prompt_key: promptKey });
+      // Record so the history poller uses this key when the agent's reply lands.
+      ctx.pendingPromptKey = promptKey;
 
       const result = await injectInbound(agentsDir, submitAgent, chat.chatId, chat.threadId, content, promptKey);
       if (!result.ok) {
+        ctx.pendingPromptKey = undefined;
         sendEvent(ctx, "error", sessionId, { message: result.error, prompt_key: promptKey });
         sendResponse(ctx, rpcErr(id, -32603, result.error ?? "inject failed"));
         break;
       }
 
-      // Prompt accepted. The background history poller will emit message.complete
-      // when the agent's reply arrives in history.db (within ~2s).
+      // Prompt accepted. The history poller (started at session.activate) will emit
+      // message.complete with this prompt_key when the agent's reply appears in history.db.
       sendResponse(ctx, rpcOk(id, { ok: true, prompt_key: promptKey }));
       break;
     }

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -1,4 +1,4 @@
-import { renameSync, unlinkSync } from "fs";
+import { renameSync, unlinkSync, chmodSync } from "fs";
 import type {
   ClientToGateway,
   GatewayToClient,
@@ -786,6 +786,10 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
     },
   });
 
+  // Allow the web container (uid=1000, operator) to inject prompts via
+  // injectInbound without needing root — the socket is inside the per-agent
+  // state directory which is already operator-accessible.
+  try { chmodSync(socketPath, 0o666); } catch { /* best-effort */ }
   log(`listening on ${socketPath}`);
 
   // ─── Heartbeat watchdog (issue #71) ─────────────────────────────────────

--- a/telegram-plugin/history.ts
+++ b/telegram-plugin/history.ts
@@ -25,7 +25,7 @@
  * chat exists in the DB.
  */
 
-import { chmodSync, mkdirSync } from 'fs'
+import { chmodSync, existsSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { redact } from './secret-detect/redact.js'
 
@@ -121,6 +121,7 @@ const DEFAULT_LIMIT = 10
 const MAX_LIMIT = 50
 
 let db: SqliteDatabase | null = null
+let dbPath: string | null = null
 
 /**
  * Open (or create) the history DB and run migrations + retention sweep.
@@ -133,6 +134,7 @@ export function initHistory(stateDir: string, retentionDays = 30): void {
   const Database = loadDatabaseClass()
   mkdirSync(stateDir, { recursive: true, mode: 0o700 })
   const path = join(stateDir, 'history.db')
+  dbPath = path
   db = new Database(path, { create: true })
   // WAL is friendlier for concurrent reads while a long transaction writes,
   // and survives crashes more cleanly than rollback journal.
@@ -171,12 +173,13 @@ export function initHistory(stateDir: string, retentionDays = 30): void {
     }
   }
 
-  // Lock the file to owner-only. Same pattern the plugin uses for .env at
-  // server.ts:52. No-op on Windows (would need ACLs).
-  try {
-    chmodSync(path, 0o600)
-  } catch {
-    /* ignore — chmod not supported, e.g. some FUSE mounts */
+  // Readable by owner and others so the web dashboard (different uid than the
+  // agent) can stream replies back to Hermes Desktop. The WAL sidecar files
+  // (-shm/-wal) are also chmod'd so SQLite readonly opens succeed for uid=1000.
+  // 0644 is safe: the per-agent state dir is already operator-accessible.
+  for (const suffix of ['', '-shm', '-wal']) {
+    const f = path + suffix
+    if (existsSync(f)) { try { chmodSync(f, 0o644) } catch { /* ignore */ } }
   }
 
   if (retentionDays > 0) {
@@ -213,6 +216,13 @@ export function checkpointWal(): boolean {
   if (db == null) return false
   try {
     db.prepare('PRAGMA wal_checkpoint(TRUNCATE)').run()
+    // Re-apply permissions after WAL truncation (SQLite may recreate -wal/-shm)
+    if (dbPath) {
+      for (const suffix of ['-shm', '-wal']) {
+        const f = dbPath + suffix
+        if (existsSync(f)) { try { chmodSync(f, 0o644) } catch { /* ignore */ } }
+      }
+    }
     return true
   } catch {
     return false

--- a/telegram-plugin/tests/history.test.ts
+++ b/telegram-plugin/tests/history.test.ts
@@ -28,13 +28,16 @@ afterEach(() => {
 })
 
 describe('initHistory', () => {
-  it('creates history.db with chmod 0600', () => {
+  it('creates history.db with chmod 0644', () => {
     initHistory(stateDir, 30)
     const dbPath = join(stateDir, 'history.db')
     expect(existsSync(dbPath)).toBe(true)
     const st = statSync(dbPath)
     // Mask off the file-type bits — only the perm bits matter.
-    expect(st.mode & 0o777).toBe(0o600)
+    // 0644: the web container (uid 1000) opens history.db read-only to
+    // stream replies back to Hermes Desktop. Content is redacted on write,
+    // so world-readable is safe (owner-approved behaviour change).
+    expect(st.mode & 0o777).toBe(0o644)
   })
 
   it('is idempotent — second call is a no-op', () => {


### PR DESCRIPTION
## Summary

- **Background history poller**: each active Hermes WS session polls `history.db` every 2s by SQLite rowid cursor, emitting `message.complete` when new assistant messages arrive — regardless of whether the turn was started in Telegram or Hermes
- **`gateway.sock` world-writable** (`ipc-server.ts`): `chmod 0o666` after `Bun.listen` so the web container (uid=1000) can connect for `prompt.submit` injection
- **`history.db` + WAL files readable** (`history.ts`): `chmod 0o644` on `.db`, `-shm`, and `-wal` at init and after each WAL checkpoint; without this the web container's `bun:sqlite` read fails at `.prepare()` even though the main file is readable

## Why

Hermes was injecting prompts correctly but responses only appeared in Telegram. Both Telegram→Hermes and Hermes→Hermes responses now appear in the desktop chat panel within ~2s. Also covers the history tab: `session.history` now reads full message text from `history.db` (falling back to turns preview if unavailable).

## Test plan

- [ ] Send a message in Hermes → response appears in Hermes chat (~2s after agent replies)
- [ ] Send a message directly in Telegram to the same agent → response appears in Hermes within 2s
- [ ] `session.history` shows full conversation text (not truncated preview)
- [ ] Gateway sockets are world-writable after agent restart (`ls -la ~/.switchroom/agents/*/telegram/gateway.sock`)
- [ ] `history.db`, `-shm`, `-wal` are `0644` after agent restart

## Risk

Low. The poller is read-only, runs in the background, and is stopped on WS close. The `gateway.sock` 0666 permission is contained within the per-agent state directory (operator-accessible trust boundary, same as `registry.db`). WAL file 0644 matches the existing `registry.db` posture.