### PR TITLE
fix(hostd): bind symlinked ~/.switchroom/skills pool into hostd

### DIFF
--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -7,11 +7,15 @@
  * running `install` in these tests.
  */
 
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   renderHostdComposeFile,
   resolveHostdHostHome,
   resolveHostdImageTag,
+  resolveHostdSkillsTarget,
 } from "./hostd.js";
 
 describe("renderHostdComposeFile", () => {
@@ -120,10 +124,45 @@ describe("renderHostdComposeFile", () => {
     expect(withUid).toContain("SWITCHROOM_CONFIG: /state/config/switchroom.yaml");
   });
 
-  it("byte-deterministic for the same inputs", () => {
+  it("emits the skills bind mount only when skillsTarget is provided", () => {
+    // Symlinked skills pool (operator keeps skills in a sibling git-tracked
+    // repo): without this bind the symlink dangles inside hostd and
+    // `switchroom apply` skips every agent's skills. The direct bind onto the
+    // resolved real target forces docker to follow it host-side at mount time.
+    const withTarget = renderHostdComposeFile({
+      hostHome: "/home/alice",
+      imageTag: "latest",
+      skillsTarget: "/home/alice/.switchroom-config/skills",
+    });
+    expect(withTarget).toContain(
+      "/home/alice/.switchroom-config/skills:/host-home/.switchroom/skills:rw",
+    );
+    // rw to match the ~/.switchroom mount, never ro.
+    expect(withTarget).not.toContain(
+      "/home/alice/.switchroom-config/skills:/host-home/.switchroom/skills:ro",
+    );
+
+    // No skillsTarget (real dir / absent / dangling) → true no-op: no skills
+    // bind line at all, so existing operators are unaffected.
+    const without = renderHostdComposeFile({ hostHome: "/home/alice", imageTag: "latest" });
+    expect(without).not.toContain("/host-home/.switchroom/skills");
+  });
+
+  it("byte-deterministic for the same inputs (incl. skillsTarget)", () => {
     const a = renderHostdComposeFile({ hostHome: "/h", imageTag: "v1" });
     const b = renderHostdComposeFile({ hostHome: "/h", imageTag: "v1" });
     expect(a).toBe(b);
+    const c = renderHostdComposeFile({
+      hostHome: "/h",
+      imageTag: "v1",
+      skillsTarget: "/cfg/skills",
+    });
+    const d = renderHostdComposeFile({
+      hostHome: "/h",
+      imageTag: "v1",
+      skillsTarget: "/cfg/skills",
+    });
+    expect(c).toBe(d);
   });
 
   it("warns about no operator hand-edits at the top of the file", () => {
@@ -188,6 +227,40 @@ describe("resolveHostdHostHome (in-container /host-home guard, #2279 gap)", () =
   it("accepts a real host home unchanged", () => {
     expect(resolveHostdHostHome({}, "/home/operator")).toBe("/home/operator");
     expect(resolveHostdHostHome({ SWITCHROOM_HOST_HOME: "/root" }, "/home/x")).toBe("/root");
+  });
+});
+
+describe("resolveHostdSkillsTarget (symlinked skills-pool bind, this fix)", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "hostd-skills-"));
+    mkdirSync(join(tmp, ".switchroom"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns undefined when skills is a real dir (covered by parent mount)", () => {
+    mkdirSync(join(tmp, ".switchroom", "skills"));
+    expect(resolveHostdSkillsTarget(tmp)).toBeUndefined();
+  });
+
+  it("returns the resolved absolute target when skills is a symlink to an existing dir", () => {
+    const realPool = join(tmp, ".switchroom-config", "skills");
+    mkdirSync(realPool, { recursive: true });
+    symlinkSync(realPool, join(tmp, ".switchroom", "skills"));
+    expect(resolveHostdSkillsTarget(tmp)).toBe(realPool);
+  });
+
+  it("returns undefined (and warns) for a dangling symlink", () => {
+    symlinkSync(join(tmp, "nonexistent-pool"), join(tmp, ".switchroom", "skills"));
+    expect(resolveHostdSkillsTarget(tmp)).toBeUndefined();
+  });
+
+  it("returns undefined when there is no skills entry at all", () => {
+    expect(resolveHostdSkillsTarget(tmp)).toBeUndefined();
   });
 });
 

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -23,7 +23,17 @@
 
 import type { Command } from "commander";
 import chalk from "chalk";
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, statSync, copyFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  statSync,
+  lstatSync,
+  realpathSync,
+  copyFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -137,8 +147,27 @@ export function renderHostdComposeFile(opts: {
    * will fall through to the UTC fallback warning, prompting the operator.
    */
   hostTz?: string;
+  /**
+   * Resolved REAL host-side target of `~/.switchroom/skills` when that path
+   * is a symlink (e.g. into a git-tracked config repo at
+   * `~/.switchroom-config/skills`). The parent `~/.switchroom` bind mount
+   * preserves the symlink AS a symlink inside the container, so its target
+   * dangles there and `switchroom apply` (shelled out by rollout/update from
+   * inside hostd) cannot find the bundled-skills pool `<skills>/_bundled` —
+   * it logs "bundled skills pool dir not found" and SKIPS every agent's
+   * skills. Binding the resolved real target directly onto the container
+   * path forces docker to follow the symlink host-side at mount time, the
+   * same precedent as the switchroom.yaml mount above. Omitted when skills
+   * is a real dir (already covered by the parent mount) or absent (nothing
+   * to mount) → no extra volume line is emitted.
+   */
+  skillsTarget?: string;
 }): string {
-  const { hostHome, imageTag, operatorUid, hostTz } = opts;
+  const { hostHome, imageTag, operatorUid, hostTz, skillsTarget } = opts;
+  const skillsMount =
+    skillsTarget !== undefined && skillsTarget.length > 0
+      ? `\n      # ~/.switchroom/skills is a symlink on this host (typically into a\n      # separate git-tracked config repo). The parent ~/.switchroom bind\n      # above preserves it AS a symlink, so its target dangles inside the\n      # container and \`switchroom apply\` (shelled out by rollout/update from\n      # inside hostd) can't find the bundled-skills pool <skills>/_bundled —\n      # it logs "bundled skills pool dir not found" and skips every agent's\n      # skills. Binding the resolved real target directly forces docker to\n      # follow the symlink host-side at mount time. Same precedent as the\n      # switchroom.yaml mount above; rw to match the ~/.switchroom mount.\n      - ${skillsTarget}:/host-home/.switchroom/skills:rw`
+      : "";
   const operatorUidEnv =
     operatorUid !== undefined
       ? `\n      # Hostd chowns ~/.switchroom/hostd/operator/sock to this so the\n      # host operator's \\\`switchroom doctor\\\` (et al.) can connect; the\n      # rest of hostd is only reachable agent→hostd. Mirrors\n      # SWITCHROOM_BROKER_OPERATOR_UID.\n      SWITCHROOM_HOSTD_OPERATOR_UID: "${operatorUid}"`
@@ -198,7 +227,7 @@ services:
       # (E_RECONCILE_FAILED_ROLLED_BACK) — agents could never amend the yaml.
       # Agents themselves still mount it ro; only hostd, the tap-gated writer,
       # gets rw. The in-place writer preserves the file's owner/mode.
-      - ${hostHome}/.switchroom/switchroom.yaml:/state/config/switchroom.yaml:rw
+      - ${hostHome}/.switchroom/switchroom.yaml:/state/config/switchroom.yaml:rw${skillsMount}
       # docker.sock is the whole reason hostd exists — agents shouldn't
       # have it, but hostd (auditing every shell-out via run-hook.sh's
       # pattern) is the controlled chokepoint.
@@ -287,6 +316,61 @@ export function resolveHostdHostHome(
     );
   }
   return resolved;
+}
+
+/**
+ * Resolve the REAL host-side target of `~/.switchroom/skills` for the hostd
+ * compose bind, but ONLY when it's a symlink that needs following.
+ *
+ * Many operators keep their skills pool in a separate git-tracked config repo
+ * and symlink `~/.switchroom/skills` → `~/.switchroom-config/skills`. The
+ * parent `~/.switchroom` bind mount preserves that symlink AS a symlink inside
+ * the hostd container, so its target dangles there: `switchroom apply` (shelled
+ * out by rollout/update from inside hostd) can't find the bundled-skills pool
+ * `<skills>/_bundled`, logs "bundled skills pool dir not found", and SKIPS every
+ * agent's skills — making rollout/update unsafe on such hosts. Returning the
+ * resolved real target lets the generator emit a direct bind that docker
+ * follows host-side at mount time (same precedent as the switchroom.yaml mount).
+ *
+ * - Not present / not a symlink → undefined. A real dir is already covered by
+ *   the parent `~/.switchroom` mount; a missing entry has nothing to mount.
+ * - Symlink → `realpathSync` it (handles relative + chained symlinks). If the
+ *   resolved target doesn't exist, return undefined and warn — emitting a
+ *   dangling bind source would make docker auto-create an empty dir.
+ */
+export function resolveHostdSkillsTarget(hostHome: string): string | undefined {
+  const skillsPath = join(hostHome, ".switchroom", "skills");
+  let st;
+  try {
+    st = lstatSync(skillsPath);
+  } catch {
+    // No skills entry at all — nothing to mount.
+    return undefined;
+  }
+  if (!st.isSymbolicLink()) {
+    // A real dir is already covered by the parent ~/.switchroom mount.
+    return undefined;
+  }
+  let target: string;
+  try {
+    target = realpathSync(skillsPath);
+  } catch {
+    console.warn(
+      `switchroom hostd install: ~/.switchroom/skills is a symlink whose target ` +
+        `does not resolve (dangling) — skipping the skills bind mount. Bundled ` +
+        `skills will be unavailable to rollout/update until the symlink is fixed.`,
+    );
+    return undefined;
+  }
+  if (!existsSync(target)) {
+    console.warn(
+      `switchroom hostd install: ~/.switchroom/skills resolves to "${target}", ` +
+        `which does not exist — skipping the skills bind mount. Bundled skills ` +
+        `will be unavailable to rollout/update until the symlink target exists.`,
+    );
+    return undefined;
+  }
+  return target;
 }
 
 function hostdDir(): string {
@@ -382,13 +466,20 @@ async function doInstall(opts: InstallOptions, program: Command): Promise<void> 
     );
   }
 
+  const hostHome = resolveHostdHostHome();
   const yaml = renderHostdComposeFile({
-    hostHome: resolveHostdHostHome(),
+    hostHome,
     imageTag,
     // SUDO_UID-aware (install often runs under sudo); undefined on
     // non-POSIX → operator listener simply not bound.
     operatorUid: resolveOperatorUid(),
     hostTz,
+    // When ~/.switchroom/skills is a symlink (skills kept in a separate
+    // config repo), the parent ~/.switchroom mount preserves it as a
+    // dangling symlink inside hostd; bind the resolved real target directly
+    // so the bundled-skills pool is reachable to rollout/update. Undefined
+    // (real dir / absent / dangling) → no extra mount emitted.
+    skillsTarget: resolveHostdSkillsTarget(hostHome),
   });
 
   if (opts.dryRun) {


### PR DESCRIPTION
## Summary

hostd's compose generator only bind-mounts the parent `~/.switchroom` dir into the hostd container. When `~/.switchroom/skills` is a **symlink** to a separate tree (e.g. `~/.switchroom-config/skills`, common when operators keep skills in a git-tracked config repo), docker preserves the symlink AS a symlink inside hostd, so its target **dangles** there. `switchroom apply` — shelled out by `rollout`/`update` from inside hostd — then can't find the bundled-skills pool `<skills>/_bundled`, logs `bundled skills pool dir not found`, and **SKIPS every agent's skills**, making rollout/update unsafe on such hosts.

The generator already solves the identical problem for the `switchroom.yaml` symlink via a direct file bind that docker resolves host-side at mount time. This applies the same precedent to the skills pool.

## Why / which job

Serves the **always-on** vision outcome (job: keep the fleet current) — rollout and update must apply skills correctly on every host shape, not silently skip them on symlinked-skills hosts.

## Changes

- **`src/cli/hostd.ts`**
  - `renderHostdComposeFile` gains an optional `skillsTarget?: string`. When set, it emits ONE extra rw volume line binding the resolved real target onto the container path — `${skillsTarget}:/host-home/.switchroom/skills:rw` — mirroring the `switchroom.yaml` precedent and matching the rw mode of the `~/.switchroom` mount. When undefined it emits nothing.
  - New exported helper `resolveHostdSkillsTarget(hostHome): string | undefined` — `lstatSync` the skills path; returns `undefined` if it's absent or a real dir (already covered by the parent mount); if it's a symlink, `realpathSync` it (handles relative + chained symlinks) and returns the absolute target, or `undefined` + a `console.warn` for a dangling target (never emit a dangling bind source docker would auto-create as an empty dir).
  - `doInstall` resolves the host home once and passes `skillsTarget: resolveHostdSkillsTarget(hostHome)` into the generator (host context, where the symlink resolves).

- **`src/cli/hostd.test.ts`**
  - `renderHostdComposeFile`: `skillsTarget` set → skills bind line present (rw, never ro); omitted → no skills bind line (true no-op); determinism preserved incl. `skillsTarget`.
  - `resolveHostdSkillsTarget` against a tmpdir: real dir → undefined; symlink to existing dir → resolved absolute target; dangling symlink → undefined (+ warns); no skills entry → undefined.

## Test plan

- [x] `vitest run src/cli/hostd.test.ts` — 28 passed (28)
- [x] `tsc --noEmit` clean
- [x] No-symlink case is a verified true no-op (asserted in test): existing operators with a real `skills` dir or no skills entry get a byte-identical compose file.

## Risk

Low. The new behaviour is gated on `~/.switchroom/skills` being a symlink; on every other host shape the generated compose is unchanged (byte-determinism preserved). Worst case for a dangling symlink is a warning + the prior (skip) behaviour.

## Deploy / bootstrap note

This fix only takes effect after the host CLI is upgraded **and** `switchroom hostd install` is run **from the HOST** (regenerating the compose), **AND** the hostd container is recreated. Regenerating the compose alone is insufficient — the running daemon loaded its mounts at container start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)