### PR TITLE
fix(telegram): strikethrough done steps in status cards

### DIFF
--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -84,10 +84,10 @@ describe("appendActivityLine + renderActivityFeed — accumulating activity feed
       "**→ Reading gateway.ts**",
     );
     expect(appendActivityLine(lines, "mcp__hindsight__reflect", { query: "x" })).toBe(
-      "_✓ Reading gateway.ts_  \n**→ Searching memory**",
+      "~~_✓ Reading gateway.ts_~~  \n**→ Searching memory**",
     );
     expect(appendActivityLine(lines, "Bash", { command: "ls", description: "List workspace" })).toBe(
-      "_✓ Reading gateway.ts_  \n_✓ Searching memory_  \n**→ List workspace**",
+      "~~_✓ Reading gateway.ts_~~  \n~~_✓ Searching memory_~~  \n**→ List workspace**",
     );
   });
 
@@ -113,11 +113,11 @@ describe("appendActivityLine + renderActivityFeed — accumulating activity feed
     expect(out.startsWith(`_✓ +${hidden} earlier…_  \n`)).toBe(true);
     // Only the last STATUS_ROLLING_LINES actions are shown; older ones collapsed.
     const firstVisible = total - STATUS_ROLLING_LINES + 1;
-    expect(out).toContain(`_✓ Action ${firstVisible}_`);
+    expect(out).toContain(`~~_✓ Action ${firstVisible}_~~`);
     expect(out).not.toContain(`Action ${firstVisible - 1}<`);
     // The newest action is the in-progress step (bold →); the rest are done (✓).
     expect(out).toContain(`**→ Action ${total}**`);
-    expect(out).toContain(`_✓ Action ${total - 1}_`);
+    expect(out).toContain(`~~_✓ Action ${total - 1}_~~`);
     expect(out).not.toContain(`**→ Action ${total - 1}**`);
   });
 
@@ -145,17 +145,37 @@ describe("appendActivityLine + renderActivityFeed — accumulating activity feed
     const lines = ["Reading a.ts", "Searching memory", "Running a command"];
     const out = renderActivityFeed(lines, true)!;
     expect(out).toBe(
-      "_✓ Reading a.ts_  \n_✓ Searching memory_  \n_✓ Running a command_",
+      "~~_✓ Reading a.ts_~~  \n~~_✓ Searching memory_~~  \n~~_✓ Running a command_~~",
     );
     expect(out).not.toContain("→"); // no in-progress arrow anywhere
   });
 
   it("final=true on a single line is also done (✓)", () => {
-    expect(renderActivityFeed(["Reading a.ts"], true)).toBe("_✓ Reading a.ts_");
+    expect(renderActivityFeed(["Reading a.ts"], true)).toBe("~~_✓ Reading a.ts_~~");
   });
 
   it("final defaults false (live render keeps the → in-progress newest line)", () => {
     expect(renderActivityFeed(["Reading a.ts"])).toBe("**→ Reading a.ts**");
+  });
+
+  // Strikethrough contract (operator request): done (✓) step lines render with
+  // GFM strikethrough wrapping the italic so completed items visually recede,
+  // while the active (→ bold) line is never struck.
+  it("done step lines are struck (~~) AND italic; the active → line is not struck", () => {
+    const out = renderActivityFeed(["Reading a.ts", "Searching memory"])!;
+    // earlier step is done → struck italic
+    expect(out).toContain("~~_✓ Reading a.ts_~~");
+    // newest step is active → bold, NOT struck
+    expect(out).toContain("**→ Searching memory**");
+    expect(out).not.toContain("~~_✓ Searching memory_~~");
+    expect(out).not.toContain("~~**→");
+    // the meta/footer count lines stay UNSTRUCK (kept legible as meta)
+    const overflow = Array.from({ length: STATUS_ROLLING_LINES + 2 }, (_, i) => `Action ${i + 1}`);
+    const finalOut = renderActivityFeed(overflow, true, "", overflow.length)!;
+    expect(finalOut).toContain(`_✓ +${overflow.length - STATUS_ROLLING_LINES} earlier…_`);
+    expect(finalOut).toContain(`_✓ ${overflow.length} steps_`);
+    expect(finalOut).not.toContain(`~~_✓ +`);
+    expect(finalOut).not.toContain(`~~_✓ ${overflow.length} steps_~~`);
   });
 
   // liveSuffix (PR1 heartbeat): appended INSIDE the newest in-progress line so a
@@ -164,7 +184,7 @@ describe("appendActivityLine + renderActivityFeed — accumulating activity feed
   describe("liveSuffix (heartbeat)", () => {
     it("appends the suffix to the newest in-progress line only", () => {
       expect(renderActivityFeed(["Reading a.ts", "Running a command"], false, " · 18s")).toBe(
-        "_✓ Reading a.ts_  \n**→ Running a command · 18s**",
+        "~~_✓ Reading a.ts_~~  \n**→ Running a command · 18s**",
       );
     });
     it("single live line gets the suffix", () => {
@@ -176,7 +196,7 @@ describe("appendActivityLine + renderActivityFeed — accumulating activity feed
       const out = renderActivityFeed(["Reading a.ts", "Running a command"], true, " · 18s")!;
       expect(out).not.toContain("·");
       expect(out).not.toContain("→");
-      expect(out).toBe("_✓ Reading a.ts_  \n_✓ Running a command_");
+      expect(out).toBe("~~_✓ Reading a.ts_~~  \n~~_✓ Running a command_~~");
     });
     it("default empty suffix is byte-identical to no suffix", () => {
       expect(renderActivityFeed(["Reading a.ts"], false, "")).toBe(
@@ -191,7 +211,7 @@ describe("appendActivityLabel — precomputed label feed (tool_label path)", () 
     const lines: string[] = [];
     expect(appendActivityLabel(lines, "Searching memory")).toBe("**→ Searching memory**");
     expect(appendActivityLabel(lines, "List workspace")).toBe(
-      "_✓ Searching memory_  \n**→ List workspace**",
+      "~~_✓ Searching memory_~~  \n**→ List workspace**",
     );
     // consecutive dup collapses
     appendActivityLabel(lines, "List workspace");
@@ -238,7 +258,7 @@ describe("renderActivityFeed — ✓ N steps total (final render, issue #2461)",
     const lines = ["Reading CLAUDE.md", "Searching memory", "Running a command"];
     const out = renderActivityFeed(lines, true, "", 5)!;
     // All lines are done (✓) and the footer is appended.
-    expect(out).toContain("_✓ Running a command_");
+    expect(out).toContain("~~_✓ Running a command_~~");
     expect(out).toContain("_✓ 5 steps_");
     expect(out.endsWith("_✓ 5 steps_")).toBe(true);
   });
@@ -247,7 +267,7 @@ describe("renderActivityFeed — ✓ N steps total (final render, issue #2461)",
     const lines = ["Reading CLAUDE.md"];
     const out = renderActivityFeed(lines, true, "", 0)!;
     expect(out).not.toContain("steps");
-    expect(out).toBe("_✓ Reading CLAUDE.md_");
+    expect(out).toBe("~~_✓ Reading CLAUDE.md_~~");
   });
 
   it("stepCount undefined → no footer (live/non-final callers omit it)", () => {
@@ -307,11 +327,11 @@ describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A
     const child = ["Reading schema.ts", "Looking for foreign keys"];
     const out = renderActivityFeedWithNested(parent, child)!;
     // Parent is blocked at the Task tool → none of its lines is the live step.
-    expect(out).toContain("_✓ Searching memory_");
-    expect(out).toContain("_✓ Delegating: review the migration_");
+    expect(out).toContain("~~_✓ Searching memory_~~");
+    expect(out).toContain("~~_✓ Delegating: review the migration_~~");
     expect(out).not.toContain("**→ Delegating");
     // The live → step is the newest nested child line; earlier child = italic.
-    expect(out).toContain("   ↳ _Reading schema.ts_");
+    expect(out).toContain("   ↳ ~~_Reading schema.ts_~~");
     expect(out).toContain("   ↳ **→ Looking for foreign keys**");
   });
 
@@ -342,13 +362,13 @@ describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A
       ["Reading schema.ts", "Looking for foreign keys"],
       true,
     )!;
-    expect(out).toContain("   ↳ _Looking for foreign keys_"); // newest now italic done
+    expect(out).toContain("   ↳ ~~_Looking for foreign keys_~~"); // newest now struck italic done
     expect(out).not.toContain("→"); // no in-progress arrow in the finalized feed
   });
 
   it("final=true with no children delegates to the finalized flat render", () => {
     expect(renderActivityFeedWithNested(["Reading a.ts"], [], true)).toBe(
-      "_✓ Reading a.ts_",
+      "~~_✓ Reading a.ts_~~",
     );
   });
 
@@ -381,7 +401,7 @@ describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A
   it("stepCount footer appears on final=true with no children (delegates to flat render)", () => {
     const out = renderActivityFeedWithNested(["Reading a.ts"], [], true, "", 3)!;
     expect(out).toContain("_✓ 3 steps_");
-    expect(out).toBe("_✓ Reading a.ts_  \n_✓ 3 steps_");
+    expect(out).toBe("~~_✓ Reading a.ts_~~  \n_✓ 3 steps_");
   });
 
   // Liveness-driven feed open (dark-turn fix): a turn that emits no tool_label
@@ -398,7 +418,7 @@ describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A
 
     it("finalizes the placeholder to a done record (no frozen → line)", () => {
       expect(renderActivityFeedWithNested(["Working…"], [], true)).toBe(
-        "_✓ Working…_",
+        "~~_✓ Working…_~~",
       );
     });
 
@@ -612,8 +632,8 @@ describe("extreme-edge: single oversized line with markdown specials & && _ *", 
     expect(out).not.toBeNull();
     expect(out.length).toBeLessThanOrEqual(4000);
     expect(isValidMarkdown(out)).toBe(true);
-    expect(out.startsWith("_✓ ")).toBe(true);
-    expect(out.endsWith("_")).toBe(true);
+    expect(out.startsWith("~~_✓ ")).toBe(true);
+    expect(out.endsWith("_~~")).toBe(true);
   });
 
   it("renderActivityFeedWithNested: single ~4100-char parent line → ≤ budget and valid markdown", () => {
@@ -770,7 +790,7 @@ describe("renderActivityFeed — header param (main-session card fix)", () => {
     expect(out).toContain("🤖 **Agent**");
     expect(out).toContain("_15s · 7 tools_");
     // Step feed follows the header.
-    expect(out).toContain("_✓ Reading CLAUDE.md_");
+    expect(out).toContain("~~_✓ Reading CLAUDE.md_~~");
     expect(out).toContain("**→ Searching memory**");
   });
 
@@ -784,7 +804,7 @@ describe("renderActivityFeed — header param (main-session card fix)", () => {
     const out = renderActivityFeed(["Reading CLAUDE.md"], true, "", undefined, header)!;
     expect(out).toContain("🤖 **Agent**");
     expect(out).toContain("_done · 3 tools · 1m05s_");
-    expect(out).toContain("_✓ Reading CLAUDE.md_");
+    expect(out).toContain("~~_✓ Reading CLAUDE.md_~~");
     // No in-progress arrow (final=true).
     expect(out).not.toContain("→");
   });
@@ -824,7 +844,7 @@ describe("renderActivityFeed — header param (main-session card fix)", () => {
     expect(out).toContain("🤖 **Agent**");
     expect(out).toContain("_30s · 5 tools_");
     // Parent step is done-styled (child is the live step).
-    expect(out).toContain("_✓ Delegating: review_");
+    expect(out).toContain("~~_✓ Delegating: review_~~");
     // Child step is the in-progress step.
     expect(out).toContain("   ↳ **→ Reading schema.ts**");
   });
@@ -850,7 +870,7 @@ describe("describeToolUse — surface-tool suppression is key-agnostic", () => {
 
 describe("status-card body stacks like a reply (#2669 rich-message renderer)", () => {
   // The single most-seen surface: the operator's progress card. Its step lines
-  // are styled prose (`_✓ …_`, `**→ …**`), NOT GFM list items, so a lone `\n`
+  // are styled prose (`~~_✓ …_~~`, `**→ …**`), NOT GFM list items, so a lone `\n`
   // between them is a SOFT break the renderer collapses — bullets ran together
   // into one line. The card now joins via stackCardLines (hard breaks), so the
   // bullets stack exactly as the reply path renders them.
@@ -858,7 +878,7 @@ describe("status-card body stacks like a reply (#2669 rich-message renderer)", (
   it("multiple step bullets stack on their own lines (no soft-break collapse)", () => {
     const out = renderActivityFeed(["Reading a.ts", "Searching memory", "Running tests"], true)!;
     const lines = out.split("  \n");
-    expect(lines).toEqual(["_✓ Reading a.ts_", "_✓ Searching memory_", "_✓ Running tests_"]);
+    expect(lines).toEqual(["~~_✓ Reading a.ts_~~", "~~_✓ Searching memory_~~", "~~_✓ Running tests_~~"]);
     // Not a single lone `\n` survives to collapse two bullets.
     expect(out).not.toMatch(/(?<! {2})\n/);
   });
@@ -870,8 +890,8 @@ describe("status-card body stacks like a reply (#2669 rich-message renderer)", (
     // Every adjacent pair is separated by a hard break.
     expect(out.match(/ {2}\n/g)?.length).toBe(2);
     // The newest is the in-progress bold step; earlier are done — all visible.
-    expect(out).toContain("_✓ Editing foo.ts_");
-    expect(out).toContain("_✓ Editing bar.ts_");
+    expect(out).toContain("~~_✓ Editing foo.ts_~~");
+    expect(out).toContain("~~_✓ Editing bar.ts_~~");
     expect(out).toContain("**→ Writing baz.ts**");
   });
 
@@ -882,6 +902,6 @@ describe("status-card body stacks like a reply (#2669 rich-message renderer)", (
     // prose by escapeStepLine; the inline-markup-survives case is covered by
     // the stackCardLines unit test, which operates on pre-rendered lines.)
     const out = renderActivityFeed(["Reading a.ts", "Running tests"], false)!;
-    expect(out).toBe("_✓ Reading a.ts_  \n**→ Running tests**");
+    expect(out).toBe("~~_✓ Reading a.ts_~~  \n**→ Running tests**");
   });
 });

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -115,7 +115,7 @@ describe('renderWorkerActivity', () => {
     expect(out).toContain('─────')
     expect(out).toContain('✅ _PR #21 opened_')
     // latestSummary is the RESULT on the finished path, never also a step.
-    expect(out).not.toContain('_✓ PR #21 opened_')
+    expect(out).not.toContain('~~_✓ PR #21 opened_~~')
   })
 
   it('renders a failed terminal recap', () => {
@@ -155,8 +155,8 @@ describe('renderWorkerActivity', () => {
         narrativeLines: ['read the brief', 'scanned vendor A', 'scanned vendor B'],
       }),
     )
-    expect(out).toContain('_✓ read the brief_')
-    expect(out).toContain('_✓ scanned vendor A_')
+    expect(out).toContain('~~_✓ read the brief_~~')
+    expect(out).toContain('~~_✓ scanned vendor A_~~')
     expect(out).toContain('**→ scanned vendor B**')
     // The single-line latestSummary fallback is NOT used when a block is present.
     expect(out).not.toContain('newest only')
@@ -171,7 +171,7 @@ describe('renderWorkerActivity', () => {
 
   it('drops blank narrative lines from the feed', () => {
     const out = renderWorkerActivity(view({ narrativeLines: ['kept', '   ', 'also kept'] }))
-    expect(out).toContain('_✓ kept_')
+    expect(out).toContain('~~_✓ kept_~~')
     expect(out).toContain('**→ also kept**')
     expect(stepCount(out)).toBe(2)
   })
@@ -183,7 +183,7 @@ describe('renderWorkerActivity', () => {
     expect(out).toContain(`_✓ +${total - STATUS_ROLLING_LINES} earlier…_`)
     expect(out).not.toContain('step 1<')
     const firstVisible = total - STATUS_ROLLING_LINES + 1
-    expect(out).toContain(`_✓ step ${firstVisible}_`)
+    expect(out).toContain(`~~_✓ step ${firstVisible}_~~`)
     expect(out).toContain(`**→ step ${total}**`)
     // STATUS_ROLLING_LINES visible step lines (the overflow header isn't a step).
     expect(out.match(/step \d/g) ?? []).toHaveLength(STATUS_ROLLING_LINES)
@@ -191,7 +191,7 @@ describe('renderWorkerActivity', () => {
 
   it('strips the CONTENT Markdown markup (the card keeps its own ** / _ wrappers, #2669)', () => {
     // Post-#2669 the card itself is rich markdown — the header is **Worker**
-    // and steps are _✓ …_ / **→ …**. The per-line pipeline still runs
+    // and steps are ~~_✓ …_~~ / **→ …**. The per-line pipeline still runs
     // stripMarkdown over the user-supplied CONTENT so a model-authored
     // `**full**` / `` `git push` `` doesn't inject extra emphasis, but the
     // card's own wrapper markup is expected.
@@ -406,8 +406,8 @@ describe('createWorkerActivityFeed', () => {
     await feed.update('w1', 'chat', view({ toolCount: 3, latestSummary: 'scanned vendor B' }))
 
     const last = bot.edits.at(-1)!
-    expect(last.text).toContain('_✓ read the brief_')
-    expect(last.text).toContain('_✓ scanned vendor A_')
+    expect(last.text).toContain('~~_✓ read the brief_~~')
+    expect(last.text).toContain('~~_✓ scanned vendor A_~~')
     expect(last.text).toContain('**→ scanned vendor B**')
     expect(last.text.match(/[✓→]/g) ?? []).toHaveLength(3)
   })
@@ -462,8 +462,8 @@ describe('createWorkerActivityFeed', () => {
     clock = 13_000
     await feed.update('w1', 'chat', view({ toolCount: 3, latestSummary: 'line C' }))
     const last = bot.edits.at(-1)!
-    expect(last.text).toContain('_✓ line A_')
-    expect(last.text).toContain('_✓ line B_')
+    expect(last.text).toContain('~~_✓ line A_~~')
+    expect(last.text).toContain('~~_✓ line B_~~')
     expect(last.text).toContain('**→ line C**')
   })
 

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -304,7 +304,7 @@ function escapeStepLine(raw: string): string {
  *
  * `out`        — accumulator mutated in place
  * `steps`      — pre-cleaned + pre-escaped HTML step strings
- * `allDone`    — when true ALL steps render done (✓ italic); when false the
+ * `allDone`    — when true ALL steps render done (✓ struck italic); when false the
  *                newest renders in-progress (→ bold)
  * `liveSuffix` — appended INSIDE the newest in-progress line (heartbeat tick)
  */
@@ -320,7 +320,7 @@ export function renderStepFeed(
   if (hidden > 0) out.push(`_✓ +${hidden} earlier…_`)
   const lastIdx = shown.length - 1
   shown.forEach((s, i) => {
-    out.push(!allDone && i === lastIdx ? `**→ ${s}${liveSuffix}**` : `_✓ ${s}_`)
+    out.push(!allDone && i === lastIdx ? `**→ ${s}${liveSuffix}**` : `~~_✓ ${s}_~~`)
   })
 }
 
@@ -400,7 +400,7 @@ export function renderStatusCard(opts: StatusCardOpts): string | null {
     const shownParent = steps.slice(-STATUS_ROLLING_LINES)
     const hiddenParent = steps.length - shownParent.length
     if (hiddenParent > 0) out.push(`_✓ +${hiddenParent} earlier…_`)
-    for (const s of shownParent) out.push(`_✓ ${s}_`)
+    for (const s of shownParent) out.push(`~~_✓ ${s}_~~`)
     // Child block.
     const shownChild = children.slice(-STATUS_ROLLING_LINES)
     const hiddenChild = children.length - shownChild.length
@@ -410,7 +410,7 @@ export function renderStatusCard(opts: StatusCardOpts): string | null {
       out.push(
         i === lastChildIdx && !final
           ? `${NESTED_PREFIX}**→ ${s}${liveSuffix}**`
-          : `${NESTED_PREFIX}_${s}_`,
+          : `${NESTED_PREFIX}~~_${s}_~~`,
       )
     })
   } else {

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -98,13 +98,13 @@ const DESC_MAX = 80
  * Layout (running):
  *   🛠 <b>Worker</b> · <i>{description}</i>
  *   <i>{elapsed} · {n} tools</i>
- *   <i>✓ {earlier step}</i>
+ *   <s><i>✓ {earlier step}</i></s>
  *   <b>→ {newest step}</b>
  *
  * Layout (finished): the feed renders all-done, then a rule + cleaned result:
  *   🛠 <b>Worker</b> · <i>{description}</i>
  *   <i>done · {n} tools · {elapsed}</i>
- *   <i>✓ {step}</i>
+ *   <s><i>✓ {step}</i></s>
  *   ─────
  *   ✅ <i>{cleaned result paragraph}</i>
  */


### PR DESCRIPTION
## What
Render completed (`✓`) step lines in the Telegram activity/status cards with **strikethrough** in addition to italic, so done items visually recede and the active (`→`) step + headers stand out. Operator-requested (Ken, 2026-06-30).

Before: `_✓ step_` (italic) · After: `~~_✓ step_~~` (struck + italic). Active `**→ step**` and headers unchanged. Meta/footer count lines (`✓ +N earlier…`, `✓ N steps`) left unstruck — they're summary counts, not done items.

## Why this is a one-line-class change
Post-#2669 the status-card feed is sent **verbatim as GFM markdown** via `sendRichMessage(chat, richMessage(text))` — Telegram parses the markup server-side. There is no custom markdown→HTML converter or sanitizer in the path, so strikethrough is just the GFM `~~…~~` token. No converter, no sanitizer, no HTML, no new dependency. (Also fixed a stale gateway comment that claimed the feed emits 'ready Telegram HTML'.)

## Sample
```
~~_✓ Reading gateway.ts_~~
~~_✓ Searching memory_~~
**→ List workspace**
```

## JTBD / vision
Serves **visibility** (reference/vision.md #1) — the pinned progress card is the headline surface; sharpening the done/active contrast makes in-flight work easier to read at a glance. Job spec: the foreground progress-card feed.

## Tests
- New contract test in `tool-activity-summary.test.ts`: done lines struck **and** italic; active `→` not struck; meta/footer not struck.
- Updated existing per-step/nested expectations.
- `npm run test:bun`: renderer files 142 pass / 0 fail. Lint clean (no new tsc errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)