### PR TITLE
fix(gateway): strip stale permission card keyboards on gateway restart

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -78,6 +78,7 @@ import {
   STALE_TAP_NOTICE,
   type PermissionCardRef,
 } from './permission-timeout.js'
+import { createPermissionCardStore } from './permission-card-store.js'
 import { pickRecoveredPermissionOrigin } from './permission-card-origin.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { appendActivityLabel, clipNarrative, renderActivityFeedWithNested, type SessionActivityHeader } from '../tool-activity-summary.js'
@@ -599,6 +600,7 @@ process.on('beforeExit', () => {
 
 // ─── Env + state dir ──────────────────────────────────────────────────────
 const STATE_DIR = process.env.TELEGRAM_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'telegram')
+const permCardStore = createPermissionCardStore(STATE_DIR)
 const ACCESS_FILE = join(STATE_DIR, 'access.json')
 const APPROVED_DIR = join(STATE_DIR, 'approved')
 const ENV_FILE = join(STATE_DIR, '.env')
@@ -5024,6 +5026,7 @@ const pendingStateReaper = setInterval(() => {
         `${timeoutMinutes}m)\n`,
       )
       pendingPermissions.delete(k)
+      permCardStore.remove(k)
     }
   }
   // Drop no-repeat suppression entries past the safety-cap window (the primary
@@ -7118,6 +7121,14 @@ const ipcServer: IpcServer = createIpcServer({
         const pend = pendingPermissions.get(requestId)
         if (pend && sent && typeof sent.message_id === 'number') {
           pend.cards.push({ chatId, messageId: sent.message_id })
+          permCardStore.add({
+            requestId,
+            chatId,
+            messageId: sent.message_id,
+            startedAt: pend.startedAt,
+            toolName: pend.tool_name,
+            cardText: pend.card_text,
+          })
         }
       }).catch(e => {
         process.stderr.write(`telegram gateway: permission_request send to ${chatId} failed: ${e}\n`)
@@ -17165,6 +17176,7 @@ async function handlePermissionSlash(ctx: Context, behavior: 'allow' | 'deny'): 
     action: naturalAction(details.tool_name, details.input_preview),
   })
   pendingPermissions.delete(request_id)
+  permCardStore.remove(request_id)
   process.stderr.write(
     `[telegram gateway] slash-${behavior} request_id=${request_id} tool=${details.tool_name} by=${senderId}\n`,
   )
@@ -21747,6 +21759,7 @@ bot.on('callback_query:data', async ctx => {
     }
 
     pendingPermissions.delete(request_id)
+    permCardStore.remove(request_id)
 
     // (2) Dispatch the in-flight permission verdict IMMEDIATELY — before
     // any host round-trip — so the turn never blocks on persistence.
@@ -21970,6 +21983,7 @@ bot.on('callback_query:data', async ctx => {
     : null
   const grantAgent = selfAgentName()
   pendingPermissions.delete(request_id)
+  permCardStore.remove(request_id)
   if (timeBox && grantAgent) {
     recordScopedGrant(scopedGrants, grantAgent, timeBox.rule, Date.now(), scopedTtl)
     process.stderr.write(
@@ -23567,6 +23581,40 @@ void (async () => {
         // tool_use (e.g. dispatching the worker), so the marker
         // tracks the live turn from there.
         try { removeTurnActiveMarker(STATE_DIR) } catch { /* best-effort */ }
+
+        // Strip stale permission cards from prior gateway session. Any entry
+        // still in the store was never resolved (gateway died before the
+        // operator tapped or the reaper ran). The operator might have seen
+        // those cards and tapped them — if so, they got STALE_TAP_NOTICE
+        // ("already resolved") which is misleading. Edit the messages to
+        // remove the keyboard and show a clear "restarted" notice instead.
+        void (async () => {
+          const stale = permCardStore.loadAll()
+          if (stale.length === 0) return
+          process.stderr.write(
+            `telegram gateway: boot-sweep: stripping ${stale.length} stale permission card(s) from prior gateway session\n`,
+          )
+          for (const card of stale) {
+            const toolLabel = card.toolName ?? 'unknown tool'
+            const notice = `🔒 **${toolLabel}**\n\n⚠️ *Gateway restarted — this request is no longer active. Ask your agent to try again if needed.*`
+            try {
+              // allow-raw-bot-api: targeted by message_id; no thread needed; fire-and-forget boot sweep
+              await bot.api.editMessageText(
+                card.chatId,
+                card.messageId,
+                richMessage(notice),
+                { reply_markup: { inline_keyboard: [] } },
+              )
+            } catch (err) {
+              // Card may already be deleted, edited, or in an inaccessible chat — benign
+              process.stderr.write(
+                `telegram gateway: boot-sweep: stale-card strip failed ` +
+                `${card.chatId}:${card.messageId}: ${(err as Error).message}\n`,
+              )
+            }
+          }
+          permCardStore.clear()
+        })()
 
         // Boot-time pin sweep
         try {

--- a/telegram-plugin/gateway/permission-card-store.ts
+++ b/telegram-plugin/gateway/permission-card-store.ts
@@ -1,0 +1,104 @@
+/**
+ * Persistence store for in-flight permission card references.
+ *
+ * Problem: `pendingPermissions` is in-memory. When the gateway restarts
+ * (gateway crash OR container restart), all entries are lost. Old permission
+ * cards in Telegram keep their [Allow][Deny] inline keyboard buttons.
+ * When the operator taps one, they get STALE_TAP_NOTICE ("already resolved
+ * (timed out)"), which is misleading — the request wasn't resolved, it was
+ * lost. Operators interpret this as "my approval didn't work."
+ *
+ * Fix: persist the (chatId, messageId) references for every posted card to a
+ * JSON file in STATE_DIR. On each resolution (allow/deny/TTL-expire), remove
+ * the entry. On gateway boot, load any surviving entries (they were never
+ * resolved — the gateway crashed) and strip their inline keyboards + add a
+ * "gateway restarted" footer so the operator sees a clear explanation instead
+ * of a tappable-but-dead button.
+ *
+ * File format: JSON array of PersistedPermCard objects. Kept small (one file,
+ * written synchronously to avoid interleaving on concurrent card posts).
+ * Production rate: a few cards per permission request; file stays tiny.
+ */
+
+import { readFileSync, writeFileSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+
+export interface PersistedPermCard {
+  requestId: string
+  chatId: string
+  messageId: number
+  startedAt: number
+  toolName: string
+  cardText: string
+}
+
+export interface PermissionCardStore {
+  /** Record a newly-posted card. Idempotent on requestId+messageId. */
+  add(entry: PersistedPermCard): void
+  /** Remove all entries for this request (resolved — allow, deny, TTL). */
+  remove(requestId: string): void
+  /** Return all persisted entries (for boot-time stale-strip sweep). */
+  loadAll(): PersistedPermCard[]
+  /** Delete the backing file entirely (after boot sweep completes). */
+  clear(): void
+}
+
+export function createPermissionCardStore(stateDir: string): PermissionCardStore {
+  const filePath = join(stateDir, 'pending-perm-cards.json')
+
+  function read(): PersistedPermCard[] {
+    try {
+      const raw = readFileSync(filePath, 'utf-8')
+      const parsed = JSON.parse(raw)
+      return Array.isArray(parsed) ? (parsed as PersistedPermCard[]) : []
+    } catch {
+      return []
+    }
+  }
+
+  function write(entries: PersistedPermCard[]): void {
+    try {
+      writeFileSync(filePath, JSON.stringify(entries), { encoding: 'utf-8', mode: 0o600 })
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: permission-card-store write failed: ${(err as Error).message}\n`,
+      )
+    }
+  }
+
+  return {
+    add(entry) {
+      const entries = read()
+      // Replace existing entry for same (requestId, messageId) if present
+      const idx = entries.findIndex(
+        e => e.requestId === entry.requestId && e.messageId === entry.messageId,
+      )
+      if (idx >= 0) {
+        entries[idx] = entry
+      } else {
+        entries.push(entry)
+      }
+      write(entries)
+    },
+
+    remove(requestId) {
+      const entries = read()
+      const filtered = entries.filter(e => e.requestId !== requestId)
+      if (filtered.length !== entries.length) {
+        write(filtered)
+      }
+    },
+
+    loadAll() {
+      return read()
+    },
+
+    clear() {
+      try {
+        unlinkSync(filePath)
+      } catch {
+        // File may not exist — that's fine
+      }
+    },
+  }
+}

--- a/telegram-plugin/tests/permission-card-store.test.ts
+++ b/telegram-plugin/tests/permission-card-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'

--- a/telegram-plugin/tests/permission-card-store.test.ts
+++ b/telegram-plugin/tests/permission-card-store.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { createPermissionCardStore } from '../gateway/permission-card-store.js'
+
+function makeTmpDir() {
+  return mkdtempSync(join(tmpdir(), 'perm-card-store-test-'))
+}
+
+describe('createPermissionCardStore', () => {
+  let dir: string
+
+  beforeEach(() => { dir = makeTmpDir() })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('starts empty', () => {
+    const store = createPermissionCardStore(dir)
+    expect(store.loadAll()).toEqual([])
+  })
+
+  it('add and loadAll returns the entry', () => {
+    const store = createPermissionCardStore(dir)
+    const entry = {
+      requestId: 'aabcd',
+      chatId: '12345',
+      messageId: 999,
+      startedAt: Date.now(),
+      toolName: 'mcp__shell__run',
+      cardText: 'Run shell command',
+    }
+    store.add(entry)
+    expect(store.loadAll()).toEqual([entry])
+  })
+
+  it('add multiple entries for same requestId (different messageIds)', () => {
+    const store = createPermissionCardStore(dir)
+    store.add({ requestId: 'aabcd', chatId: '111', messageId: 1, startedAt: 1000, toolName: 't', cardText: 'c' })
+    store.add({ requestId: 'aabcd', chatId: '222', messageId: 2, startedAt: 1000, toolName: 't', cardText: 'c' })
+    const all = store.loadAll()
+    expect(all.length).toBe(2)
+  })
+
+  it('does not duplicate same requestId+messageId', () => {
+    const store = createPermissionCardStore(dir)
+    const entry = { requestId: 'aabcd', chatId: '111', messageId: 1, startedAt: 1000, toolName: 't', cardText: 'c' }
+    store.add(entry)
+    store.add(entry)
+    expect(store.loadAll().length).toBe(1)
+  })
+
+  it('remove clears all entries for a requestId', () => {
+    const store = createPermissionCardStore(dir)
+    store.add({ requestId: 'aabcd', chatId: '111', messageId: 1, startedAt: 1000, toolName: 't', cardText: 'c' })
+    store.add({ requestId: 'aabcd', chatId: '222', messageId: 2, startedAt: 1000, toolName: 't', cardText: 'c' })
+    store.add({ requestId: 'xyzab', chatId: '333', messageId: 3, startedAt: 1000, toolName: 't', cardText: 'c' })
+    store.remove('aabcd')
+    const all = store.loadAll()
+    expect(all.length).toBe(1)
+    expect(all[0].requestId).toBe('xyzab')
+  })
+
+  it('remove is idempotent when entry not present', () => {
+    const store = createPermissionCardStore(dir)
+    expect(() => store.remove('nonexistent')).not.toThrow()
+  })
+
+  it('clear empties the store', () => {
+    const store = createPermissionCardStore(dir)
+    store.add({ requestId: 'aabcd', chatId: '111', messageId: 1, startedAt: 1000, toolName: 't', cardText: 'c' })
+    store.clear()
+    expect(store.loadAll()).toEqual([])
+  })
+
+  it('survives re-instantiation (data persists across instances)', () => {
+    createPermissionCardStore(dir).add({
+      requestId: 'aabcd', chatId: '111', messageId: 1, startedAt: 1000, toolName: 't', cardText: 'c',
+    })
+    const all = createPermissionCardStore(dir).loadAll()
+    expect(all.length).toBe(1)
+    expect(all[0].requestId).toBe('aabcd')
+  })
+})


### PR DESCRIPTION
## Summary

- **Root cause:** `pendingPermissions` is in-memory. Gateway restart (e.g. from `scheduleGrantRestart` after an Always Allow tap) clears it. Old permission cards retain their \[Allow\]\[Deny\] buttons, but tapping them shows `STALE_TAP_NOTICE` ("already resolved (timed out)") — misleading because the request was *lost*, not resolved. Agents time out and get auto-denied.
- **Fix:** Persist `(chatId, messageId)` references for every posted permission card to `STATE_DIR/pending-perm-cards.json`. At each resolution site (allow / deny / TTL-expire / slash command), remove the entry. On boot (after `getMe` succeeds, inside `didOneTimeSetup`), load any surviving entries and edit each message to remove the inline keyboard and show a clear "gateway restarted — request no longer active" notice.
- **Scope is correct:** Only card refs are persisted, not the full `pendingPermissions` state. On container restart, Claude Code also restarted and the old `request_id`s are dead — restoring them would cause false-positive approvals or confuse the next IPC session.

## Files changed

- `telegram-plugin/gateway/permission-card-store.ts` — new module: `createPermissionCardStore(stateDir)` with `add/remove/loadAll/clear` backed by a JSON file at `STATE_DIR/pending-perm-cards.json`
- `telegram-plugin/gateway/gateway.ts` — 6 integration points:
  1. `permCardStore = createPermissionCardStore(STATE_DIR)` after `STATE_DIR` definition
  2. `permCardStore.add(...)` after `pend.cards.push(...)` (async send callback)
  3. `permCardStore.remove(k)` in TTL reaper
  4. `permCardStore.remove(request_id)` in slash-command `/approve|/deny` handler
  5. `permCardStore.remove(request_id)` in `asb/asn` (always-allow) path
  6. `permCardStore.remove(request_id)` in main allow/deny button handler
  7. Boot-sweep in `didOneTimeSetup`: load stale cards, edit each to strip keyboard + show restart notice, then `permCardStore.clear()`
- `telegram-plugin/tests/permission-card-store.test.ts` — 8 new unit tests

## Test plan

- [x] `bun test telegram-plugin/tests/permission-card-store.test.ts` — 8/8 pass
- [x] `bun test telegram-plugin/tests/` — 5076/5076 pass (8 new)
- [x] `tsc --noEmit` — clean
- [x] `check-bot-api-wrapping.sh` — clean (boot-sweep `editMessageText` carries `allow-raw-bot-api` comment)
- [ ] UAT: `jtbd-fast-trivial-dm` + `jtbd-always-on-after-restart-dm`

## Risk

Low. New module is a thin JSON read/write. Write errors are logged + swallowed (non-fatal). Boot sweep is fire-and-forget (does not block gateway startup). Edit failures on stale cards are caught (card may already be deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXGDSGArnajHNjcf8Vr17T