### PR TITLE
fix(telegram): finish rich-markdown card pass + escaper de-dup

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -267,6 +267,8 @@ schedule:
       headers: { authorization: "Bearer {{status_token}}" }
 ```
 
+The action `text` is rendered as full GFM markdown (`**bold**`, `_italic_`, `` `code` ``, `~~strikethrough~~`, links) — so a literal `*` or `_` in fixed text becomes formatting unless you set `parse_mode: text`, which sends the string verbatim (the escape hatch).
+
 `telegram-message` posts only to the agent's **own** chat (no `chat_id` field — fenced by construction) and substitutes only the deterministic `{{date}}`/`{{time}}`/`{{agent}}` placeholders — **no vault secrets in a message body, no model output**. `webhook` reuses the poll egress allowlist + host-pinned secret bindings. Anything that needs the model to *write* something (a summary, a Linear issue body) is not an action — use `kind: poll` + an escalation prompt, or `reaction_dispatch`.
 
 ## Managing the scheduler

--- a/profiles/_shared/agent-self-service.md.hbs
+++ b/profiles/_shared/agent-self-service.md.hbs
@@ -43,7 +43,9 @@ tools is to let you do the edit yourself.
     still shares your memory + tools but drops your accumulated conversation
     context). A **daily/weekly** cron defaults to a **full turn in your live
     session** (Tier 2: your model, your whole context). So routine frequent
-    checks are already cheap without you doing anything.
+    checks are already cheap without you doing anything. Cron-fresh sessions
+    render rich markdown too, so scheduled/digest/daily-memory output should
+    use **bold** section headers + `code` for identifiers, just like a live reply.
   - *`model: "sonnet"` / `context: "fresh"`* — force the cheap Tier-1 session
     even for a **daily/weekly** self-contained job (summarise a feed, format a
     digest) — overrides the cadence default. *`context: "agent"`* does the
@@ -53,7 +55,10 @@ tools is to let you do the edit yourself.
     ping — text fully determined, no thinking) — ask the **operator** for a
     **`kind: action`**: it runs **model-free, zero tokens** (no session at all),
     posting your fixed/templated text or firing a fixed request. The cheapest
-    tier there is.
+    tier there is. The action `text` is rendered as full GFM markdown
+    (**bold**, _italic_, `code`, ~~strikethrough~~, links) — so a literal `*`
+    or `_` in fixed text becomes formatting unless you set `parse_mode: text`,
+    which sends the string verbatim (the escape hatch).
   - *"Only act when X changes"* — don't poll with a frequent prompt cron (every
     fire is a wasted turn when nothing changed). Ask the **operator** for a
     **`kind: poll`** (model-free check, e.g. a webpage/API — only a *change*

--- a/telegram-plugin/auth-snapshot-format.ts
+++ b/telegram-plugin/auth-snapshot-format.ts
@@ -15,13 +15,14 @@
  *
  * No HTML escaping at the boundary — callers pass already-trusted
  * label strings (broker-vetted account labels). If that ever changes
- * the per-line `escapeHtml` helper below is the place to gate.
+ * the per-line `escapeMarkdown` helper (imported from card-format) is the place to gate.
  */
 
 import type { QuotaResult, QuotaUtilization } from './quota-check.js';
 import { isProbeThin, refillNormalizedUtils } from '../src/auth/quota.js';
 import type { AccountState, LastQuotaSnapshot, ListStateData } from '../src/auth/broker/client.js';
 import { maskEmail } from './demo-mask.js';
+import { escapeMarkdown } from './card-format.js';
 
 // ── shared types ─────────────────────────────────────────────────────
 
@@ -284,10 +285,10 @@ function renderAccountRow(
 
   if (!snap.quota) {
     lines.push(
-      `${marker}\`${escapeHtml(label)}\`  _quota probe failed_`,
+      `${marker}\`${escapeMarkdown(label)}\`  _quota probe failed_`,
     );
     if (snap.quotaError) {
-      lines.push(`  _${escapeHtml(snap.quotaError)}_`);
+      lines.push(`  _${escapeMarkdown(snap.quotaError)}_`);
     }
     return lines;
   }
@@ -297,7 +298,7 @@ function renderAccountRow(
   // it as a data-quality gap, never a confident "0% / 0%".
   if (isProbeThin(q)) {
     lines.push(
-      `${marker}\`${escapeHtml(label)}\`  _quota unknown (thin probe)_`,
+      `${marker}\`${escapeMarkdown(label)}\`  _quota unknown (thin probe)_`,
     );
     return lines;
   }
@@ -307,7 +308,7 @@ function renderAccountRow(
   const fiveStr = fmtPct(norm.fiveHourUtilizationPct);
   const sevenStr = fmtPct(norm.sevenDayUtilizationPct);
   lines.push(
-    `${marker}\`${escapeHtml(label)}\`  ${fiveStr} / ${sevenStr}`,
+    `${marker}\`${escapeMarkdown(label)}\`  ${fiveStr} / ${sevenStr}`,
   );
 
   const health = classifyHealth(snap, now);
@@ -318,7 +319,7 @@ function renderAccountRow(
     const reset = win === '5h' ? q.fiveHourResetAt : q.sevenDayResetAt;
     const winLabel = win === '5h' ? '5-hour' : '7-day';
     lines.push(
-      `  _quota exhausted — back ${formatAbsolute(reset, tz)} (in ${formatRelative(reset, now)}, ${winLabel} cap)_`,
+      `  _quota exhausted — back ${formatAbsolute(reset, tz)} (\`in ${formatRelative(reset, now)}\`, ${winLabel} cap)_`,
     );
     return lines;
   }
@@ -332,10 +333,10 @@ function renderAccountRow(
   const sevenResetIn = q.sevenDayResetAt ? q.sevenDayResetAt.getTime() - now.getTime() : Infinity;
   const fiveFirst = fiveResetIn <= sevenResetIn;
   const fiveSeg = q.fiveHourResetAt
-    ? `5h refills ${formatAbsolute(q.fiveHourResetAt, tz)} (in ${formatRelative(q.fiveHourResetAt, now)})`
+    ? `5h refills ${formatAbsolute(q.fiveHourResetAt, tz)} (\`in ${formatRelative(q.fiveHourResetAt, now)}\`)`
     : '5h refills —';
   const sevenSeg = q.sevenDayResetAt
-    ? `7d resets ${formatAbsolute(q.sevenDayResetAt, tz)} (in ${formatRelative(q.sevenDayResetAt, now)})`
+    ? `7d resets ${formatAbsolute(q.sevenDayResetAt, tz)} (\`in ${formatRelative(q.sevenDayResetAt, now)}\`)`
     : '7d resets —';
   lines.push(`  _${fiveFirst ? fiveSeg : sevenSeg}_`);
   lines.push(`  _${fiveFirst ? sevenSeg : fiveSeg}_`);
@@ -343,7 +344,7 @@ function renderAccountRow(
   // surface it as a sub-line on a healthy/throttling row — NOT a blocked badge.
   if (q.overageDisabledReason != null && OVERAGE_EXHAUSTED_REASONS.has(q.overageDisabledReason)) {
     lines.push(
-      `  _overage off (${escapeHtml(q.overageDisabledReason)}) — serving from quota_`,
+      `  _overage off (${escapeMarkdown(q.overageDisabledReason)}) — serving from quota_`,
     );
   }
   return lines;
@@ -615,10 +616,10 @@ export function renderFallbackAnnouncement(input: FallbackAnnouncementInput): st
     // same per-account row + earliest-recovery helpers the /auth table uses so
     // the formatting stays consistent with the rest of the auth surface.
     lines.push(
-      `🔴 **All accounts blocked · ${headerLimit} on ${escapeHtml(input.oldLabel)}**`,
+      `🔴 **All accounts blocked · ${headerLimit} on ${escapeMarkdown(input.oldLabel)}**`,
     );
     lines.push('');
-    lines.push(`Triggered by: agent **${escapeHtml(input.triggerAgent)}**`);
+    lines.push(`Triggered by: agent **${escapeMarkdown(input.triggerAgent)}**`);
 
     const fleet = input.fleetSnapshots ?? [];
     if (fleet.length > 0) {
@@ -639,7 +640,7 @@ export function renderFallbackAnnouncement(input: FallbackAnnouncementInput): st
       if (earliest) {
         lines.push('');
         lines.push(
-          `Earliest recovery: \`${escapeHtml(earliest.label)}\` ` +
+          `Earliest recovery: \`${escapeMarkdown(earliest.label)}\` ` +
             `${formatAbsolute(earliest.at, tz)} (in ${formatRelative(earliest.at, now)})`,
         );
       }
@@ -648,7 +649,7 @@ export function renderFallbackAnnouncement(input: FallbackAnnouncementInput): st
       const recovery = recoveryAtFor(input.oldQuota);
       if (recovery) {
         lines.push(
-          `${escapeHtml(input.oldLabel)} recovers ${formatAbsolute(recovery, tz)} ` +
+          `${escapeMarkdown(input.oldLabel)} recovers ${formatAbsolute(recovery, tz)} ` +
             `(in ${formatRelative(recovery, now)})`,
         );
       }
@@ -663,20 +664,20 @@ export function renderFallbackAnnouncement(input: FallbackAnnouncementInput): st
 
   // Successful swap.
   lines.push(
-    `✓ **Switched fleet · ${headerLimit} on ${escapeHtml(input.oldLabel)}**`,
+    `✓ **Switched fleet · ${headerLimit} on ${escapeMarkdown(input.oldLabel)}**`,
   );
   lines.push('');
   lines.push(
-    `\`${escapeHtml(input.oldLabel)}\` → \`${escapeHtml(input.newLabel)}\``,
+    `\`${escapeMarkdown(input.oldLabel)}\` → \`${escapeMarkdown(input.newLabel)}\``,
   );
-  lines.push(`Triggered by: agent **${escapeHtml(input.triggerAgent)}**`);
+  lines.push(`Triggered by: agent **${escapeMarkdown(input.triggerAgent)}**`);
   lines.push('');
 
   if (input.oldQuota) {
     const recovery = recoveryAtFor(input.oldQuota);
     if (recovery) {
       lines.push(
-        `\`${escapeHtml(input.oldLabel)}\` recovers ` +
+        `\`${escapeMarkdown(input.oldLabel)}\` recovers ` +
           `${formatAbsolute(recovery, tz)} (in ${formatRelative(recovery, now)})`,
       );
     }
@@ -690,7 +691,7 @@ export function renderFallbackAnnouncement(input: FallbackAnnouncementInput): st
       input.newQuota.sevenDayUtilizationPct < THROTTLING_THRESHOLD_PCT;
     const headroomStr = hasHeadroom ? '_(plenty of headroom)_' : '_(near limit — watch this)_';
     lines.push(
-      `\`${escapeHtml(input.newLabel)}\` now: ${fiveStr} of 5h · ${sevenStr} of 7d ${headroomStr}`,
+      `\`${escapeMarkdown(input.newLabel)}\` now: ${fiveStr} of 5h · ${sevenStr} of 7d ${headroomStr}`,
     );
   } else {
     lines.push(
@@ -806,10 +807,6 @@ function switchPriority(s: AccountSnapshot, now: Date = new Date()): number {
 }
 
 // ── shared HTML escape ───────────────────────────────────────────────
-
-function escapeHtml(s: string): string {
-  return s.replace(/([\\`*_~=\[\]|])/g, '\\$1');
-}
 
 // ── snapshot assembly helper ─────────────────────────────────────────
 

--- a/telegram-plugin/auto-fallback-fleet.ts
+++ b/telegram-plugin/auto-fallback-fleet.ts
@@ -35,6 +35,7 @@
  */
 
 import type { QuotaResult, QuotaUtilization } from './quota-check.js';
+import { escapeMarkdown } from './card-format.js';
 import type { ListStateData } from '../src/auth/broker/client.js';
 import {
   renderFallbackAnnouncement,
@@ -54,14 +55,10 @@ import {
  */
 export function renderFallbackFailureNotice(triggerAgent: string, reason: string): string {
   return (
-    `⚠️ **Auto-failover could not run** (trigger: **${escFailureHtml(triggerAgent)}**)\n` +
-    `${escFailureHtml(reason)}\n\n` +
+    `⚠️ **Auto-failover could not run** (trigger: **${escapeMarkdown(triggerAgent)}**)\n` +
+    `${escapeMarkdown(reason)}\n\n` +
     `_Switch manually with \`/auth use <label>\`, or \`/auth\` for fleet status._`
   );
-}
-
-function escFailureHtml(s: string): string {
-  return s.replace(/([\\`*_~=\[\]|])/g, '\\$1');
 }
 
 /**

--- a/telegram-plugin/credits-watch.ts
+++ b/telegram-plugin/credits-watch.ts
@@ -23,6 +23,7 @@
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
+import { escapeMarkdown } from "./card-format.js";
 
 const STATE_FILE = "credits-watch.json";
 
@@ -157,7 +158,7 @@ export function evaluateCreditState(args: {
   if (!currentIsFatal && prevIsFatal) {
     return {
       kind: "notify",
-      message: `✅ **${escapeHtml(agentName)}**: credits restored — agent should resume normal operation.`,
+      message: `✅ **${escapeMarkdown(agentName)}**: credits restored — agent should resume normal operation.`,
       newState: { lastNotifiedReason: null, lastNotifiedAt: now },
       transition: "exited",
     };
@@ -193,12 +194,12 @@ export function evaluateCreditState(args: {
 function buildEntryMessage(agentName: string, reason: string): string {
   const desc = humanizeReason(reason);
   return [
-    `⚠️ **${escapeHtml(agentName)}**: ${desc}`,
+    `⚠️ **${escapeMarkdown(agentName)}**: ${desc}`,
     ``,
     `Cron tasks and inbound replies will fail until this is resolved. Check`,
     `your subscription or pre-paid usage at [console.anthropic.com](https://console.anthropic.com).`,
     ``,
-    `_Source: Claude CLI cache (cachedExtraUsageDisabledReason=${escapeHtml(reason)})_`,
+    `_Source: Claude CLI cache (cachedExtraUsageDisabledReason=${escapeMarkdown(reason)})_`,
   ].join("\n");
 }
 
@@ -215,10 +216,6 @@ function humanizeReason(reason: string): string {
     default:
       return `usage disabled (${reason})`;
   }
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(/([\\`*_~=\[\]|])/g, "\\$1");
 }
 
 // ─── State persistence ───────────────────────────────────────────────────────

--- a/telegram-plugin/gateway/approval-card.ts
+++ b/telegram-plugin/gateway/approval-card.ts
@@ -14,6 +14,7 @@
  *     param  = (for ttl) 1h | 24h | 7d
  */
 
+import { escapeMarkdown } from '../format.js';
 import { InlineKeyboard } from "grammy";
 
 export interface ApprovalCardOptions {
@@ -37,7 +38,7 @@ export interface BuiltApprovalCard {
  */
 export function buildApprovalCard(opts: ApprovalCardOptions): BuiltApprovalCard {
   const lines: string[] = [];
-  lines.push(`🔐 **${escapeHtml(opts.agent)}** wants approval`);
+  lines.push(`🔐 **${escapeMarkdown(opts.agent)}** wants approval`);
   // The scope rides in a `code span` — content there is LITERAL, so it must
   // NOT be markdown-escaped (escaping would leak visible backslashes, e.g.
   // `secret:OPENAI\_API\_KEY`). Only an embedded backtick could break out of
@@ -45,7 +46,7 @@ export function buildApprovalCard(opts: ApprovalCardOptions): BuiltApprovalCard 
   lines.push(`\`${codeSpanSafe(opts.scope_humanized)}\``);
   if (opts.why && opts.why.trim().length > 0) {
     lines.push("");
-    lines.push(escapeHtml(opts.why.trim()));
+    lines.push(escapeMarkdown(opts.why.trim()));
   }
   const text = lines.join("\n");
 
@@ -121,10 +122,6 @@ export function ttlMsFromToken(token: string): number | null {
   if (unit === "h") return n * 60 * 60 * 1000;
   if (unit === "d") return n * 24 * 60 * 60 * 1000;
   return null;
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(/([\\`*_~=\[\]|])/g, "\\$1");
 }
 
 /**

--- a/telegram-plugin/gateway/approvals-commands.ts
+++ b/telegram-plugin/gateway/approvals-commands.ts
@@ -13,6 +13,7 @@
  * add on top of the same client. Tracked in the migration TODO inline.
  */
 
+import { escapeMarkdown } from '../format.js';
 import type { Bot, Context } from "grammy";
 import { richMessage } from "../rich-send.js";
 import {
@@ -65,7 +66,7 @@ export function registerApprovalsCommands(
       const byAgent = new Map<string, number>();
       for (const d of decisions) byAgent.set(d.agent_unit, (byAgent.get(d.agent_unit) ?? 0) + 1);
       const summary = Array.from(byAgent.entries())
-        .map(([a, n]) => `• **${escapeHtml(a)}**: ${n}`)
+        .map(([a, n]) => `• **${escapeMarkdown(a)}**: ${n}`)
         .join("\n");
       const detail = decisions
         .slice(0, 20)
@@ -76,10 +77,10 @@ export function registerApprovalsCommands(
               : `until ${new Date(d.ttl_expires_at).toISOString().slice(0, 16).replace("T", " ")}`;
           return (
             `\`${d.id.slice(0, 8)}\` ` +
-            `${escapeHtml(d.agent_unit)} → ` +
+            `${escapeMarkdown(d.agent_unit)} → ` +
             `\`${d.scope}\` ` +
-            `(${escapeHtml(d.action)}, ${ttl}) ` +
-            `· /approvals revoke ${escapeHtml(d.id)}`
+            `(${escapeMarkdown(d.action)}, ${ttl}) ` +
+            `· /approvals revoke ${escapeMarkdown(d.id)}`
           );
         })
         .join("\n");
@@ -113,8 +114,4 @@ export function registerApprovalsCommands(
       `(\`add\` and \`stats\` are coming in a follow-up.)`,
     ));
   });
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(/([\\`*_~=\[\]|])/g, "\\$1");
 }

--- a/telegram-plugin/gateway/auth-command.ts
+++ b/telegram-plugin/gateway/auth-command.ts
@@ -28,6 +28,7 @@
  * rather than throwing.
  */
 
+import { escapeMarkdown } from '../format.js'
 import type { ListStateData, AccountState } from './auth-line.js'
 import {
   buildSnapshotsFromState,
@@ -158,7 +159,7 @@ export function parseAuthCommand(text: string): ParsedAuthCommand | null {
       if (tail.length > 0) {
         return {
           kind: 'help',
-          reason: `Unknown \`rm\` modifier: \`${escapeHtml(tail)}\`. Use \`/auth rm <label> confirm\` to confirm.`,
+          reason: `Unknown \`rm\` modifier: \`${escapeMarkdown(tail)}\`. Use \`/auth rm <label> confirm\` to confirm.`,
         }
       }
       return { kind: 'rm-prompt', label }
@@ -180,7 +181,7 @@ export function parseAuthCommand(text: string): ParsedAuthCommand | null {
       if (sub !== 'override') {
         return {
           kind: 'help',
-          reason: `Unknown \`agent\` subcommand: \`${escapeHtml(sub || '(none)')}\`. Try \`/auth agent override <agent> <label|clear>\`.`,
+          reason: `Unknown \`agent\` subcommand: \`${escapeMarkdown(sub || '(none)')}\`. Try \`/auth agent override <agent> <label|clear>\`.`,
         }
       }
       const agent = parts[2]
@@ -201,7 +202,7 @@ export function parseAuthCommand(text: string): ParsedAuthCommand | null {
     case 'help':
       return { kind: 'help' }
     default:
-      return { kind: 'help', reason: `Unknown verb: \`${escapeHtml(verb)}\`` }
+      return { kind: 'help', reason: `Unknown verb: \`${escapeMarkdown(verb)}\`` }
   }
 }
 
@@ -417,7 +418,7 @@ export async function handleAuthCommand(
       }
     } catch (err) {
       return {
-        text: `**/auth show failed:** ${escapeHtml((err as Error)?.message ?? String(err))}`,
+        text: `**/auth show failed:** ${escapeMarkdown((err as Error)?.message ?? String(err))}`,
         html: true,
       }
     }
@@ -432,7 +433,7 @@ export async function handleAuthCommand(
       if (!agent) {
         return {
           text:
-            `**/auth show:** no agent named \`${escapeHtml(agentName)}\` in broker view.\n` +
+            `**/auth show:** no agent named \`${escapeMarkdown(agentName)}\` in broker view.\n` +
             `Run \`/auth show\` for the fleet snapshot.`,
           html: true,
         }
@@ -440,7 +441,7 @@ export async function handleAuthCommand(
       return { text: renderAgentDetail(state, agent), html: true }
     } catch (err) {
       return {
-        text: `**/auth show failed:** ${escapeHtml((err as Error)?.message ?? String(err))}`,
+        text: `**/auth show failed:** ${escapeMarkdown((err as Error)?.message ?? String(err))}`,
         html: true,
       }
     }
@@ -476,13 +477,13 @@ export async function handleAuthCommand(
       const result = await ctx.client.setActive(parsed.label)
       return {
         text:
-          `**Active account →** \`${escapeHtml(result.active)}\`\n` +
+          `**Active account →** \`${escapeMarkdown(result.active)}\`\n` +
           `Re-mirrored credentials for ${result.fanned.length} agent${result.fanned.length === 1 ? '' : 's'}.`,
         html: true,
       }
     } catch (err) {
       return {
-        text: `**/auth use failed:** ${escapeHtml((err as Error)?.message ?? String(err))}`,
+        text: `**/auth use failed:** ${escapeMarkdown((err as Error)?.message ?? String(err))}`,
         html: true,
       }
     }
@@ -504,13 +505,13 @@ export async function handleAuthCommand(
       const result = await ctx.client.setActive(nextLabel)
       return {
         text:
-          `**Rotated:** active → \`${escapeHtml(result.active)}\`\n` +
+          `**Rotated:** active → \`${escapeMarkdown(result.active)}\`\n` +
           `Re-mirrored credentials for ${result.fanned.length} agent${result.fanned.length === 1 ? '' : 's'}.`,
         html: true,
       }
     } catch (err) {
       return {
-        text: `**/auth rotate failed:** ${escapeHtml((err as Error)?.message ?? String(err))}`,
+        text: `**/auth rotate failed:** ${escapeMarkdown((err as Error)?.message ?? String(err))}`,
         html: true,
       }
     }
@@ -525,7 +526,7 @@ export async function handleAuthCommand(
       state = await ctx.client.listState()
     } catch (err) {
       return {
-        text: `**/auth rm failed:** ${escapeHtml((err as Error)?.message ?? String(err))}`,
+        text: `**/auth rm failed:** ${escapeMarkdown((err as Error)?.message ?? String(err))}`,
         html: true,
       }
     }
@@ -533,7 +534,7 @@ export async function handleAuthCommand(
     if (!exists) {
       return {
         text:
-          `**/auth rm:** no account named \`${escapeHtml(parsed.label)}\`. ` +
+          `**/auth rm:** no account named \`${escapeMarkdown(parsed.label)}\`. ` +
           `Run \`/auth show\` for the current list.`,
         html: true,
       }
@@ -541,7 +542,7 @@ export async function handleAuthCommand(
     if (state.active === parsed.label) {
       return {
         text:
-          `**/auth rm refused.** \`${escapeHtml(parsed.label)}\` is the fleet active. ` +
+          `**/auth rm refused.** \`${escapeMarkdown(parsed.label)}\` is the fleet active. ` +
           `Switch with \`/auth use <other>\` or \`/auth rotate\` first.`,
         html: true,
       }
@@ -560,9 +561,9 @@ export async function handleAuthCommand(
     }
     return {
       text:
-        `**⚠ /auth rm** — about to remove \`${escapeHtml(parsed.label)}\` from the broker.\n` +
-        `The fleet active is unchanged. Any agent override pointing at \`${escapeHtml(parsed.label)}\` will stop working.\n\n` +
-        `Send \`/auth rm ${escapeHtml(parsed.label)} confirm\` within ${Math.round(
+        `**⚠ /auth rm** — about to remove \`${escapeMarkdown(parsed.label)}\` from the broker.\n` +
+        `The fleet active is unchanged. Any agent override pointing at \`${escapeMarkdown(parsed.label)}\` will stop working.\n\n` +
+        `Send \`/auth rm ${escapeMarkdown(parsed.label)} confirm\` within ${Math.round(
           AUTH_RM_CONFIRM_TTL_MS / 1000,
         )}s to proceed.`,
       html: true,
@@ -578,8 +579,8 @@ export async function handleAuthCommand(
       }
       return {
         text:
-          `**/auth rm:** no pending confirm for \`${escapeHtml(parsed.label)}\` (expired or not started). ` +
-          `Send \`/auth rm ${escapeHtml(parsed.label)}\` first.`,
+          `**/auth rm:** no pending confirm for \`${escapeMarkdown(parsed.label)}\` (expired or not started). ` +
+          `Send \`/auth rm ${escapeMarkdown(parsed.label)}\` first.`,
         html: true,
       }
     }
@@ -589,12 +590,12 @@ export async function handleAuthCommand(
     try {
       const data = await ctx.client.rmAccount(parsed.label)
       return {
-        text: `**Removed** \`${escapeHtml(data.label)}\` from the broker.`,
+        text: `**Removed** \`${escapeMarkdown(data.label)}\` from the broker.`,
         html: true,
       }
     } catch (err) {
       return {
-        text: `**/auth rm failed:** ${escapeHtml((err as Error)?.message ?? String(err))}`,
+        text: `**/auth rm failed:** ${escapeMarkdown((err as Error)?.message ?? String(err))}`,
         html: true,
       }
     }
@@ -609,7 +610,7 @@ export async function handleAuthCommand(
       if (parsed.label && targets.length === 0) {
         return {
           text:
-            `**/auth refresh:** no account named \`${escapeHtml(parsed.label)}\`.`,
+            `**/auth refresh:** no account named \`${escapeMarkdown(parsed.label)}\`.`,
           html: true,
         }
       }
@@ -629,13 +630,13 @@ export async function handleAuthCommand(
           ])
         } catch (err) {
           failures.push(
-            `${label}: ${escapeHtml((err as Error)?.message ?? String(err))}`,
+            `${label}: ${escapeMarkdown((err as Error)?.message ?? String(err))}`,
           )
         }
       }
       const head =
         targets.length === 1
-          ? `**Refreshed** \`${escapeHtml(targets[0]!)}\``
+          ? `**Refreshed** \`${escapeMarkdown(targets[0]!)}\``
           : `**Refreshed** ${rows.length - 1}/${targets.length} account${targets.length === 1 ? '' : 's'}`
       const table = rows.length > 1
         ? "\n```\n" + alignTable(rows) + "\n```"
@@ -646,7 +647,7 @@ export async function handleAuthCommand(
       return { text: head + table + failBlock, html: true }
     } catch (err) {
       return {
-        text: `**/auth refresh failed:** ${escapeHtml((err as Error)?.message ?? String(err))}`,
+        text: `**/auth refresh failed:** ${escapeMarkdown((err as Error)?.message ?? String(err))}`,
         html: true,
       }
     }
@@ -657,13 +658,13 @@ export async function handleAuthCommand(
       const data = await ctx.client.setOverride(parsed.agent, parsed.label)
       return {
         text:
-          `**Override set.** \`${escapeHtml(data.agent)}\` is now pinned to ` +
-          `\`${escapeHtml(data.account ?? parsed.label)}\`.`,
+          `**Override set.** \`${escapeMarkdown(data.agent)}\` is now pinned to ` +
+          `\`${escapeMarkdown(data.account ?? parsed.label)}\`.`,
         html: true,
       }
     } catch (err) {
       return {
-        text: `**/auth agent override failed:** ${escapeHtml((err as Error)?.message ?? String(err))}`,
+        text: `**/auth agent override failed:** ${escapeMarkdown((err as Error)?.message ?? String(err))}`,
         html: true,
       }
     }
@@ -674,13 +675,13 @@ export async function handleAuthCommand(
       const data = await ctx.client.setOverride(parsed.agent, null)
       return {
         text:
-          `**Override cleared** on \`${escapeHtml(data.agent)}\` ` +
+          `**Override cleared** on \`${escapeMarkdown(data.agent)}\` ` +
           `— back to fleet active.`,
         html: true,
       }
     } catch (err) {
       return {
-        text: `**/auth agent override failed:** ${escapeHtml((err as Error)?.message ?? String(err))}`,
+        text: `**/auth agent override failed:** ${escapeMarkdown((err as Error)?.message ?? String(err))}`,
         html: true,
       }
     }
@@ -852,7 +853,7 @@ function formatAccountsTable(state: ListStateData, now: number, demo = false): s
         ? formatRelativeMs(acc.exhausted_until - now)
         : '—'
     rows.push([
-      `${marker} ${escapeHtml(demo ? maskEmail(acc.label) : acc.label)}`,
+      `${marker} ${escapeMarkdown(demo ? maskEmail(acc.label) : acc.label)}`,
       status,
       expires,
       formatQuotaUtilCell(acc, now),
@@ -892,7 +893,7 @@ function formatAgentsTable(state: ListStateData, demo = false): string {
       : a.account === state.active
         ? 'fleet-active'
         : 'pinned'
-    rows.push([escapeHtml(a.name), escapeHtml(demo ? maskEmail(a.account) : a.account), source])
+    rows.push([escapeMarkdown(a.name), escapeMarkdown(demo ? maskEmail(a.account) : a.account), source])
   }
   return alignTable(rows)
 }
@@ -909,10 +910,10 @@ export function renderAgentDetail(
   now: number = Date.now(),
 ): string {
   const lines: string[] = []
-  lines.push(`**${escapeHtml(agent.name)}**`)
+  lines.push(`**${escapeMarkdown(agent.name)}**`)
   const source = agent.override ? 'override' : 'fleet-active'
   lines.push(
-    `Active account: \`${escapeHtml(agent.account)}\` (${source})`,
+    `Active account: \`${escapeMarkdown(agent.account)}\` (${source})`,
   )
   const acct = state.accounts.find((a) => a.label === agent.account)
   if (acct) {
@@ -948,16 +949,12 @@ function formatConsumersTable(state: ListStateData, now: number, demo = false): 
       c.last_seen_at == null
         ? 'socket bound'
         : `socket bound (last seen ${formatRelativeMs(now - c.last_seen_at)} ago)`
-    rows.push([escapeHtml(c.name), escapeHtml(demo ? maskEmail(c.account) : c.account), status])
+    rows.push([escapeMarkdown(c.name), escapeMarkdown(demo ? maskEmail(c.account) : c.account), status])
   }
   return alignTable(rows)
 }
 
 // ─── Plain-text helpers ────────────────────────────────────────────────────
-
-function escapeHtml(s: string): string {
-  return s.replace(/([\\`*_~=\[\]|])/g, '\\$1')
-}
 
 function formatRelativeMs(ms: number): string {
   if (ms <= 0) return '0s'

--- a/telegram-plugin/gateway/config-approval-handler.ts
+++ b/telegram-plugin/gateway/config-approval-handler.ts
@@ -2,6 +2,7 @@
 // card, resolves the verdict back to hostd over IPC, and flips the card to
 // a terminal state on finalize.
 
+import { escapeMarkdown } from '../format.js';
 import { randomBytes } from "node:crypto";
 import type { IpcClient } from "./ipc-server.js";
 import type {
@@ -180,10 +181,6 @@ const REASON_ELLIPSIS = "…";
  */
 export const DIFF_SENTINEL = "\n[… diff continues, see attached file]";
 
-function escapeMd(s: string): string {
-  return s.replace(/([\\`*_~=\[\]|])/g, "\\$1");
-}
-
 function clipReason(reason: string): string {
   if (reason.length <= REASON_MAX_CHARS) return reason;
   return reason.slice(0, REASON_MAX_CHARS - REASON_ELLIPSIS.length) +
@@ -214,7 +211,7 @@ export function buildConfigApprovalCardBody(args: {
   const render = (diff: string): string =>
     `🛠 **Config edit proposed**\n` +
     `Agent: \`${args.agentName}\`\n` +
-    `Reason: ${escapeMd(safeReason)}\n\n` +
+    `Reason: ${escapeMarkdown(safeReason)}\n\n` +
     "```\n" + diff + "\n```";
 
   return truncateRawToFit({
@@ -447,8 +444,8 @@ export function buildLiveNote(affectedAgents?: string[], fleetWide?: boolean): s
   }
   const agents = (affectedAgents ?? []).filter((a) => typeof a === "string" && a.length > 0);
   if (agents.length === 0) return "";
-  const list = agents.map(escapeMd).join(", ");
-  const cmds = agents.map((a) => `/restart ${escapeMd(a)}`).join(" · ");
+  const list = agents.map(escapeMarkdown).join(", ");
+  const cmds = agents.map((a) => `/restart ${escapeMarkdown(a)}`).join(" · ");
   return `\n\n🔄 Not live until restart — affects: **${list}**\n${cmds}`;
 }
 
@@ -476,8 +473,8 @@ export async function handleRequestConfigFinalize(
     msg.outcome === "applied" ? buildLiveNote(msg.affectedAgents, msg.fleetWide) : "";
   const body =
     msg.outcome === "applied"
-      ? `✅ **Applied**${msg.detail ? `\n${escapeMd(msg.detail)}` : ""}${liveNote}`
-      : `⚠️ **Reconcile failed; rolled back**${msg.detail ? `\n${escapeMd(msg.detail)}` : ""}`;
+      ? `✅ **Applied**${msg.detail ? `\n${escapeMarkdown(msg.detail)}` : ""}${liveNote}`
+      : `⚠️ **Reconcile failed; rolled back**${msg.detail ? `\n${escapeMarkdown(msg.detail)}` : ""}`;
   try {
     // Finalize is terminal — strip the keyboard so the buttons are gone.
     await deps.editCard({

--- a/telegram-plugin/gateway/diff-preview-card.ts
+++ b/telegram-plugin/gateway/diff-preview-card.ts
@@ -21,6 +21,7 @@
  * single-shot "do this edit now" intent.
  */
 
+import { escapeMarkdown } from '../format.js';
 import { InlineKeyboard } from "grammy";
 import type { DiffPreview } from "../../src/drive/diff-preview.js";
 
@@ -88,9 +89,9 @@ export function buildDiffPreviewCard(
   // The 📍 + line-count rows are surfaced verbatim — they're
   // wrapper-attested and the agent has no input into their content.
   const bodyLines: string[] = [];
-  bodyLines.push(`**${escapeHtml(preview.title)}**`);
+  bodyLines.push(`**${escapeMarkdown(preview.title)}**`);
   for (const line of preview.lines) {
-    bodyLines.push(escapeHtml(line.text));
+    bodyLines.push(escapeMarkdown(line.text));
   }
   const text = bodyLines.join("\n");
 
@@ -160,8 +161,4 @@ export function buildDiffPreviewCard(
   }
 
   return { text, reply_markup: kb };
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(/([\\`*_~=\[\]|])/g, "\\$1");
 }

--- a/telegram-plugin/gateway/linear-activity.ts
+++ b/telegram-plugin/gateway/linear-activity.ts
@@ -15,6 +15,7 @@
  * agent to `vault_request_access` for that key rather than failing opaquely.
  */
 
+import { escapeMarkdown } from '../format.js'
 import {
   getViaBrokerStructured,
   putViaBroker,
@@ -30,10 +31,6 @@ export type LinearAuthDeadReason = 'no_bundle' | 'revoked'
 /** Minimal GFM-markdown escape (#2669). Kept local so the message builder is
  *  self-contained + unit-testable without reaching into a gateway-only
  *  escaper (the bug that shipped the first cut of this alert). */
-function escapeMarkdownMin(s: string): string {
-  return s.replace(/([\\`*_~=\[\]|])/g, '\\$1')
-}
-
 /**
  * Build the operator-facing Telegram alert (GFM markdown) for an un-healable
  * Linear auth failure. Pure + self-escaping so it can be unit-tested directly.
@@ -42,7 +39,7 @@ function escapeMarkdownMin(s: string): string {
 export function buildLinearAuthDeadMessage(agent: string, reason: LinearAuthDeadReason): string {
   // Inside `code` spans the agent slug is literal (no escaping); in prose it
   // is markdown-escaped.
-  const aEsc = escapeMarkdownMin(agent)
+  const aEsc = escapeMarkdown(agent)
   const why =
     reason === 'no_bundle'
       ? `no refresh credentials are stored (\`linear/${agent}/oauth\` is missing), so its daily-expiring token can't renew`

--- a/telegram-plugin/idle-footer.ts
+++ b/telegram-plugin/idle-footer.ts
@@ -58,8 +58,8 @@ export function formatIdleFooter(rows: ReadonlyArray<TurnRow>, now: number): str
   const latest = rows.reduce((best, row) => (row.startedAt > best.startedAt ? row : best));
 
   if (latest.endedAt == null) {
-    return `⚙️ working since ${formatAgo(latest.startedAt, now)}`;
+    return `⚙️ working since **${formatAgo(latest.startedAt, now)}**`;
   }
 
-  return `🟢 idle · last reply ${formatAgo(latest.endedAt, now)}`;
+  return `🟢 idle · last reply **${formatAgo(latest.endedAt, now)}**`;
 }

--- a/telegram-plugin/model-unavailable.ts
+++ b/telegram-plugin/model-unavailable.ts
@@ -27,6 +27,7 @@
  */
 
 import { formatResetRelative } from './quota-check.js'
+import { escapeMarkdown } from './card-format.js'
 
 // ─── Public types ────────────────────────────────────────────────────────────
 
@@ -366,10 +367,10 @@ export function formatModelUnavailableCard(
   opts: FormatCardOptions = {},
 ): string {
   const now = opts.now ?? new Date()
-  const slotPart = opts.slot ? ` (slot **${escHtml(opts.slot)}**)` : ''
+  const slotPart = opts.slot ? ` (slot **${escapeMarkdown(opts.slot)}**)` : ''
   const reason = formatReason(detection, now)
   const lines = [
-    `⚠️ **Model unavailable** on agent **${escHtml(agent)}**${slotPart}`,
+    `⚠️ **Model unavailable** on agent **${escapeMarkdown(agent)}**${slotPart}`,
     `Reason: ${reason}`,
     '',
   ]
@@ -469,7 +470,3 @@ export function resolveModelUnavailableFromOperatorEvent(
 }
 
 // ─── HTML escape (mirrors operator-events.ts) ────────────────────────────────
-
-function escHtml(text: string): string {
-  return text.replace(/([\\`*_~=\[\]|])/g, '\\$1')
-}

--- a/telegram-plugin/operator-events.ts
+++ b/telegram-plugin/operator-events.ts
@@ -12,6 +12,8 @@
  *    including the quota-exhausted strings migrated from auto-fallback.ts.
  */
 
+import { escapeMarkdown } from './format.js'
+
 // ─── Taxonomy ────────────────────────────────────────────────────────────────
 
 export type OperatorEventKind =
@@ -210,8 +212,8 @@ export interface RenderResult {
  * `:` or other delimiter characters.
  */
 export function renderOperatorEvent(ev: OperatorEvent): RenderResult {
-  const agent = escHtml(ev.agent)
-  const detail = escHtml(ev.detail)
+  const agent = escapeMarkdown(ev.agent)
+  const detail = escapeMarkdown(ev.detail)
 
   switch (ev.kind) {
     case 'credentials-expired':
@@ -412,7 +414,3 @@ export function resetAllCooldowns(): void {
 }
 
 // ─── Markdown escape (#2669) ──────────────────────────────────────────────────
-
-function escHtml(text: string): string {
-  return text.replace(/([\\`*_~=\[\]|])/g, '\\$1')
-}

--- a/telegram-plugin/quota-check.ts
+++ b/telegram-plugin/quota-check.ts
@@ -253,10 +253,10 @@ export function formatQuotaBlock(q: QuotaUtilization, now: Date = new Date()): s
   lines.push("**Claude plan quota**");
   lines.push("");
   lines.push(
-    `**5h window**  ${Math.round(q.fiveHourUtilizationPct)}% · ${formatResetRelative(q.fiveHourResetAt, now)}`,
+    `**5h window**  \`${Math.round(q.fiveHourUtilizationPct)}%\` · \`${formatResetRelative(q.fiveHourResetAt, now)}\``,
   );
   lines.push(
-    `**7d window**  ${Math.round(q.sevenDayUtilizationPct)}% · ${formatResetRelative(q.sevenDayResetAt, now)}`,
+    `**7d window**  \`${Math.round(q.sevenDayUtilizationPct)}%\` · \`${formatResetRelative(q.sevenDayResetAt, now)}\``,
   );
   if (q.representativeClaim) {
     lines.push("");

--- a/telegram-plugin/quota-watch.ts
+++ b/telegram-plugin/quota-watch.ts
@@ -51,6 +51,7 @@ import {
   fmtPct,
 } from "./auth-snapshot-format.js";
 import type { QuotaUtilization } from "./quota-check.js";
+import { escapeMarkdown } from "./card-format.js";
 
 const STATE_FILE = "quota-watch.json";
 
@@ -511,7 +512,7 @@ function buildFleetRecoveredMessage(
   accounts: Array<{ label: string; exhausted: boolean }>,
 ): string {
   const healthy = accounts.filter((a) => !a.exhausted).map((a) => a.label);
-  const which = healthy.length > 0 ? ` (\`${escapeHtml(healthy[0]!)}\`)` : "";
+  const which = healthy.length > 0 ? ` (\`${escapeMarkdown(healthy[0]!)}\`)` : "";
   return [
     `🟢 **Fleet recovered** — at least one account is healthy again${which}.`,
     ``,
@@ -535,14 +536,14 @@ function buildThrottlingMessage(agentName: string, snap: AccountSnapshot): strin
 
   const activeNote = snap.isActive
     ? ""
-    : `\nThis is a non-active account. Consider \`/auth use ${escapeHtml(snap.label)}\` to switch, or keep it as a fallback reserve.`;
+    : `\nThis is a non-active account. Consider \`/auth use ${escapeMarkdown(snap.label)}\` to switch, or keep it as a fallback reserve.`;
 
   const altNote = snap.isActive
     ? `\nConsider \`/auth use <other-account>\` if you have a healthier account, or wait for the ${winLabel} window to refill${resetStr}.`
     : "";
 
   return [
-    `🟡 **Quota approaching limit** — \`${escapeHtml(snap.label)}\``,
+    `🟡 **Quota approaching limit** — \`${escapeMarkdown(snap.label)}\``,
     ``,
     `${fiveStr} of 5h  ·  ${sevenStr} of 7d`,
     `Binding window: ${winLabel}${resetStr}`,
@@ -563,16 +564,12 @@ function buildRecoveryMessage(agentName: string, snap: AccountSnapshot): string 
     : "Current quota data unavailable.";
 
   return [
-    `🟢 **Quota back in healthy range** — \`${escapeHtml(snap.label)}\``,
+    `🟢 **Quota back in healthy range** — \`${escapeMarkdown(snap.label)}\``,
     ``,
     utilLine,
     ``,
     `_Below ${THROTTLING_THRESHOLD_PCT}% on both windows._`,
   ].join("\n");
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(/([\\`*_~=\[\]|])/g, "\\$1");
 }
 
 // ─── State persistence ────────────────────────────────────────────────────────

--- a/telegram-plugin/tests/auth-command-vernacular.test.ts
+++ b/telegram-plugin/tests/auth-command-vernacular.test.ts
@@ -140,6 +140,22 @@ describe('parseAuthCommand — new verbs', () => {
     expect((p as { reason?: string }).reason).toMatch(/confirm/i)
   })
 
+  // Boundary-escaping (#2695 escaper de-dup): the help/reason strings now
+  // escape dynamic user input via the consolidated `escapeMarkdown` import.
+  // A metacharacter-laden verb must come back backslash-escaped, proving the
+  // import swap preserved escaping at this call-site.
+  it('escapes a metacharacter-laden unknown verb in the help reason', () => {
+    const p = parseAuthCommand('/auth a_b*c')
+    expect(p?.kind).toBe('help')
+    expect((p as { reason?: string }).reason).toContain('a\\_b\\*c')
+  })
+
+  it('escapes a metacharacter-laden rm modifier in the help reason', () => {
+    const p = parseAuthCommand('/auth rm spare x_y*z')
+    expect(p?.kind).toBe('help')
+    expect((p as { reason?: string }).reason).toContain('x\\_y\\*z')
+  })
+
   it('rejects /auth rm with no label', () => {
     const p = parseAuthCommand('/auth rm')
     expect(p?.kind).toBe('help')

--- a/telegram-plugin/tests/auth-snapshot-format.test.ts
+++ b/telegram-plugin/tests/auth-snapshot-format.test.ts
@@ -227,6 +227,9 @@ describe('renderAuthSnapshotFormat2', () => {
     expect(fiveLine).toBeLessThan(sevenLine);
     expect(lines[fiveLine]).not.toContain('7d resets');
     expect(lines[sevenLine]).not.toContain('5h refills');
+    // The ETA value is wrapped in a `code` span so the countdown pops.
+    expect(lines[fiveLine]).toMatch(/\(`in .+?`\)/);
+    expect(lines[sevenLine]).toMatch(/\(`in .+?`\)/);
   });
 
   it('emits a recommendation footer that names a healthy alternative when active is throttling', () => {

--- a/telegram-plugin/tests/auth-snapshot-format.test.ts
+++ b/telegram-plugin/tests/auth-snapshot-format.test.ts
@@ -212,6 +212,29 @@ describe('renderAuthSnapshotFormat2', () => {
     expect(out).toMatch(/bob@example\.com[\s\S]*back .* 7-day cap/);
   });
 
+  it('wraps the cap-line ETA in a `code` span while keeping the surrounding _italic_', () => {
+    const out = renderAuthSnapshotFormat2(fixtureSnaps, { now: NOW, tz: 'UTC' });
+    const capLine = out.split('\n').find((l) => l.includes('quota exhausted'));
+    expect(capLine).toBeDefined();
+    // ETA backtick code-span: "(`in …`, 7-day cap)"
+    expect(capLine).toMatch(/\(`in .+?`, 7-day cap\)/);
+    // The whole sub-line stays italic-wrapped.
+    expect(capLine!.trim().startsWith('_quota exhausted')).toBe(true);
+    expect(capLine!.trim().endsWith('_')).toBe(true);
+  });
+
+  it('wraps both the 5h-refills and 7d-resets ETAs in `code` spans', () => {
+    const out = renderAuthSnapshotFormat2(fixtureSnaps, { now: NOW, tz: 'UTC' });
+    const lines = out.split('\n');
+    const fiveLine = lines.find((l) => l.includes('5h refills') && l.includes('`in '));
+    const sevenLine = lines.find((l) => l.includes('7d resets') && l.includes('`in '));
+    expect(fiveLine).toBeDefined();
+    expect(sevenLine).toBeDefined();
+    // Each ETA value sits in a backtick code-span, inside the italic sub-line.
+    expect(fiveLine).toMatch(/5h refills .+ \(`in .+?`\)/);
+    expect(sevenLine).toMatch(/7d resets .+ \(`in .+?`\)/);
+  });
+
   it('puts the imminent window first on healthy/throttling rows', () => {
     const out = renderAuthSnapshotFormat2(fixtureSnaps, { now: NOW, tz: 'UTC' });
     // you: 5h reset is in 7m, 7d reset is in 2d. 5h should come first.
@@ -372,6 +395,28 @@ describe('renderFallbackAnnouncement', () => {
       tz: 'UTC',
     });
     expect(out7).toContain('7-day limit on me@x');
+  });
+
+  // Boundary-escaping after the #2695 escaper de-dup: the announcement escapes
+  // dynamic labels + the trigger agent via the consolidated `escapeMarkdown`
+  // import (was a local `escapeHtml` copy). Metacharacter-laden values must come
+  // back backslash-escaped, proving the import swap preserved escaping here.
+  it('escapes metacharacter-laden labels and trigger agent in the swap announcement (#2695)', () => {
+    const out = renderFallbackAnnouncement({
+      oldLabel: 'old_a*x',
+      oldQuota: KEN_5H_BLOWN,
+      newLabel: 'new_b*y',
+      newQuota: YOU_HEALTHY,
+      triggerAgent: 'agent_z*q',
+      now: NOW,
+      tz: 'UTC',
+    });
+    expect(out).toContain('old\\_a\\*x');
+    expect(out).toContain('new\\_b\\*y');
+    expect(out).toContain('agent\\_z\\*q');
+    // And the raw (unescaped) forms must NOT leak through.
+    expect(out).not.toContain('old_a*x');
+    expect(out).not.toContain('agent_z*q');
   });
 
   it('names the triggering agent + recovery countdown for the old account', () => {

--- a/telegram-plugin/tests/credits-watch.test.ts
+++ b/telegram-plugin/tests/credits-watch.test.ts
@@ -188,6 +188,24 @@ describe("evaluateCreditState — transition decisions (machinery, explicit fata
     // The underscore is escaped so it can't open an italic run inside **…**.
     expect(d.message).toContain("ev\\_il");
   });
+
+  // Boundary-escaping after the #2695 escaper de-dup: the entry message escapes
+  // BOTH the agent name and the raw reason via the consolidated `escapeMarkdown`
+  // import. A metacharacter-laden value through each site proves the import swap
+  // preserved escaping at this call-site.
+  it("escapes metacharacters in both the agent name and the cached reason (#2695)", () => {
+    const d = evaluateCreditState({
+      agentName: "a_b*c",
+      currentReason: "weird_reason*x",
+      prev: HEALTHY,
+      now: NOW,
+      fatalReasons: new Set(["weird_reason*x"]),
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    expect(d.message).toContain("a\\_b\\*c");
+    expect(d.message).toContain("weird\\_reason\\*x");
+  });
 });
 
 describe("evaluateCreditState — subscription-only default (the fix)", () => {

--- a/telegram-plugin/tests/idle-footer.test.ts
+++ b/telegram-plugin/tests/idle-footer.test.ts
@@ -20,39 +20,39 @@ describe("formatIdleFooter", () => {
 
   it("single old turn ended 1h ago → idle 1h ago", () => {
     const r = row({ startedAt: NOW - 70 * 60_000, endedAt: NOW - 60 * 60_000 });
-    expect(formatIdleFooter([r], NOW)).toBe("🟢 idle · last reply 1h ago");
+    expect(formatIdleFooter([r], NOW)).toBe("🟢 idle · last reply **1h ago**");
   });
 
   it("single turn ended 3m ago → idle 3m ago", () => {
     const r = row({ startedAt: NOW - 5 * 60_000, endedAt: NOW - 3 * 60_000 });
-    expect(formatIdleFooter([r], NOW)).toBe("🟢 idle · last reply 3m ago");
+    expect(formatIdleFooter([r], NOW)).toBe("🟢 idle · last reply **3m ago**");
   });
 
   it("single turn ended 10s ago → idle <1m ago", () => {
     const r = row({ startedAt: NOW - 30_000, endedAt: NOW - 10_000 });
-    expect(formatIdleFooter([r], NOW)).toBe("🟢 idle · last reply <1m ago");
+    expect(formatIdleFooter([r], NOW)).toBe("🟢 idle · last reply **<1m ago**");
   });
 
-  it("currently running turn started 2m ago → working since 2m ago", () => {
+  it("currently running turn started 2m ago → working since **2m ago**", () => {
     const r = row({ startedAt: NOW - 2 * 60_000 });
-    expect(formatIdleFooter([r], NOW)).toBe("⚙️ working since 2m ago");
+    expect(formatIdleFooter([r], NOW)).toBe("⚙️ working since **2m ago**");
   });
 
   it("multiple turns, most recent is running → working since recent", () => {
     const old = row({ turnKey: "t1", startedAt: NOW - 10 * 60_000, endedAt: NOW - 8 * 60_000 });
     const running = row({ turnKey: "t2", startedAt: NOW - 90_000 }); // 1m 30s ago
-    expect(formatIdleFooter([old, running], NOW)).toBe("⚙️ working since 1m ago");
+    expect(formatIdleFooter([old, running], NOW)).toBe("⚙️ working since **1m ago**");
   });
 
   it("multiple turns, most recent is ended → idle last reply", () => {
     const old = row({ turnKey: "t1", startedAt: NOW - 30 * 60_000, endedAt: NOW - 28 * 60_000 });
     const recent = row({ turnKey: "t2", startedAt: NOW - 6 * 60_000, endedAt: NOW - 4 * 60_000 });
-    expect(formatIdleFooter([old, recent], NOW)).toBe("🟢 idle · last reply 4m ago");
+    expect(formatIdleFooter([old, recent], NOW)).toBe("🟢 idle · last reply **4m ago**");
   });
 
   it("day-old turn → 1d ago", () => {
     const r = row({ startedAt: NOW - 26 * 3_600_000, endedAt: NOW - 25 * 3_600_000 });
-    expect(formatIdleFooter([r], NOW)).toBe("🟢 idle · last reply 1d ago");
+    expect(formatIdleFooter([r], NOW)).toBe("🟢 idle · last reply **1d ago**");
   });
 
   it("unsorted rows — picks max startedAt", () => {
@@ -61,6 +61,6 @@ describe("formatIdleFooter", () => {
     const r2 = row({ turnKey: "t2", startedAt: NOW - 5 * 60_000, endedAt: NOW - 2 * 60_000 });
     const r3 = row({ turnKey: "t3", startedAt: NOW - 40 * 60_000, endedAt: NOW - 38 * 60_000 });
     // r2 has the largest startedAt, endedAt is 2m ago
-    expect(formatIdleFooter([r1, r2, r3], NOW)).toBe("🟢 idle · last reply 2m ago");
+    expect(formatIdleFooter([r1, r2, r3], NOW)).toBe("🟢 idle · last reply **2m ago**");
   });
 });

--- a/telegram-plugin/tests/idle-footer.test.ts
+++ b/telegram-plugin/tests/idle-footer.test.ts
@@ -55,6 +55,50 @@ describe("formatIdleFooter", () => {
     expect(formatIdleFooter([r], NOW)).toBe("🟢 idle · last reply **1d ago**");
   });
 
+  it("no-data (quiet) state carries NO ** markup", () => {
+    const out = formatIdleFooter([], NOW);
+    expect(out).toBe("🟡 quiet · no turns yet");
+    expect(out).not.toContain("**");
+  });
+
+  it("working state bolds ONLY the elapsed value, not the whole line", () => {
+    const r = row({ startedAt: NOW - 4 * 60_000 });
+    const out = formatIdleFooter([r], NOW);
+    // The bold span wraps the time and only the time.
+    const bold = out.match(/\*\*(.+?)\*\*/);
+    expect(bold).not.toBeNull();
+    expect(bold![1]).toBe("4m ago");
+    // The label "⚙️ working since " is outside the bold span.
+    expect(out).toBe("⚙️ working since **4m ago**");
+    // Exactly one bold span (two `**` delimiters).
+    expect((out.match(/\*\*/g) ?? []).length).toBe(2);
+  });
+
+  it("idle state bolds ONLY the last-reply value, not the whole line", () => {
+    const r = row({ startedAt: NOW - 6 * 60_000, endedAt: NOW - 3 * 60_000 });
+    const out = formatIdleFooter([r], NOW);
+    const bold = out.match(/\*\*(.+?)\*\*/);
+    expect(bold).not.toBeNull();
+    expect(bold![1]).toBe("3m ago");
+    expect(out).toBe("🟢 idle · last reply **3m ago**");
+    expect((out.match(/\*\*/g) ?? []).length).toBe(2);
+  });
+
+  // Table-driven across elapsed magnitudes: a future change to formatAgo that
+  // drops the bold (or widens it past the time value) is caught here.
+  it.each([
+    { label: "seconds", deltaMs: 10_000, ago: "<1m ago" },
+    { label: "minutes", deltaMs: 7 * 60_000, ago: "7m ago" },
+    { label: "hours", deltaMs: 5 * 3_600_000, ago: "5h ago" },
+    { label: "days", deltaMs: 3 * 86_400_000, ago: "3d ago" },
+  ])("idle footer bolds the $label-magnitude elapsed value", ({ deltaMs, ago }) => {
+    const r = row({ startedAt: NOW - deltaMs - 1000, endedAt: NOW - deltaMs });
+    const out = formatIdleFooter([r], NOW);
+    expect(out).toBe(`🟢 idle · last reply **${ago}**`);
+    const bold = out.match(/\*\*(.+?)\*\*/);
+    expect(bold![1]).toBe(ago);
+  });
+
   it("unsorted rows — picks max startedAt", () => {
     // rows in reverse chronological order; function must not assume sorted
     const r1 = row({ turnKey: "t1", startedAt: NOW - 20 * 60_000, endedAt: NOW - 18 * 60_000 });

--- a/telegram-plugin/tests/quota-check.test.ts
+++ b/telegram-plugin/tests/quota-check.test.ts
@@ -97,6 +97,13 @@ describe('formatQuotaBlock', () => {
     expect(block).toContain('Binding window: five hour')
     // overage=allowed should not be surfaced
     expect(block).not.toContain('Overage:')
+    // Both windows: the **bold label** stays bold AND the percentage +
+    // reset ETA are each wrapped in a `code` span. Locks the nit-fix that
+    // the value moved into backticks without dropping the label markup.
+    const fiveLine = block.split('\n').find((l) => l.includes('5h window'))!
+    const sevenLine = block.split('\n').find((l) => l.includes('7d window'))!
+    expect(fiveLine).toMatch(/^\*\*5h window\*\*\s+`\d+%` · `resets in .+?`$/)
+    expect(sevenLine).toMatch(/^\*\*7d window\*\*\s+`\d+%` · `resets in .+?`$/)
   })
 
   it('surfaces overage status when not allowed', () => {

--- a/telegram-plugin/tests/quota-check.test.ts
+++ b/telegram-plugin/tests/quota-check.test.ts
@@ -92,8 +92,8 @@ describe('formatQuotaBlock', () => {
       now,
     )
     expect(block).toContain('**Claude plan quota**')
-    expect(block).toContain('**5h window**  29% · resets in 2h 30m')
-    expect(block).toContain('**7d window**  33% · resets in 3d')
+    expect(block).toContain('**5h window**  `29%` · `resets in 2h 30m`')
+    expect(block).toContain('**7d window**  `33%` · `resets in 3d`')
     expect(block).toContain('Binding window: five hour')
     // overage=allowed should not be surfaced
     expect(block).not.toContain('Overage:')

--- a/telegram-plugin/tests/telegram-format.test.ts
+++ b/telegram-plugin/tests/telegram-format.test.ts
@@ -65,6 +65,26 @@ describe('escapeMarkdown', () => {
     // `\*` in the input is backslash + star → both get escaped exactly once.
     expect(escapeMarkdown('\\*')).toBe('\\\\\\*')
   })
+
+  // The de-dup pass (#2695) replaced ~12 local escaper copies with this one
+  // canonical function. Every consolidated caller now depends on this exact
+  // contract: the FULL metacharacter set in a single string, each escaped.
+  test('escapes the full metacharacter set in one combined string', () => {
+    // Backslash placed last so it doesn't re-escape the chars after it.
+    expect(escapeMarkdown('`*_~=[]|\\')).toBe('\\`\\*\\_\\~\\=\\[\\]\\|\\\\')
+  })
+
+  test('already-safe text passes through unchanged', () => {
+    const safe = 'Switched fleet to alice (5h window 29% resets in 2h)'
+    expect(escapeMarkdown(safe)).toBe(safe)
+  })
+
+  // card-format.ts re-exports this same symbol; the consolidated callers
+  // import from one or the other. Lock that they are the identical function.
+  test('card-format re-exports the identical canonical escaper', async () => {
+    const cardFormat = await import('../card-format.js')
+    expect(cardFormat.escapeMarkdown).toBe(escapeMarkdown)
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Post-#2669 finishing pass surfaced by a formatting audit. All low-risk, behavior-preserving except the intended visual tweaks.

- **idle-footer** (`idle-footer.ts`): bold the relative-time value — `last reply **3m ago**` — the one scannable datum on an otherwise plain line.
- **auth-snapshot + quota** (`auth-snapshot-format.ts`, `quota-check.ts`): `code`-span the ETAs/percentages so the numbers pop against the prose.
- **escaper de-dup**: ~12 copy-pasted markdown escapers (all byte-for-behavior identical to canonical `escapeMarkdown` in `format.ts` / re-exported by `card-format.ts`) replaced with an import. Diverged copies (real HTML escaper in `skill-proposal-card.ts`), contractually-standalone ones (`slot-banner.ts`, `bot-runtime.ts`), and the backtick-aware `escapeActionMarkdown` were deliberately left alone.
- **docs**: document that `kind: action` cron `text` renders full GFM (and `parse_mode: text` is the literal escape hatch), plus a one-line nudge that cron/digest output should use bold headers + `code` identifiers.

## Why
Serves **visibility** (reference/vision.md #1): the cards are the headline surface; sharper number/value contrast makes them faster to read. The de-dup is a durability fix — independent escaper copies could drift.

## Tests
Existing renderer tests updated (idle-footer, quota-check) + an ETA-code-span assertion added to auth-snapshot. Zero test deltas vs clean main (lint + bun-test identical to baseline). **Follow-up commit incoming on this branch to broaden coverage** per reviewer request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)