### PR TITLE
voice: detect GPU at setup, record local-vs-cloud engine verdict

### DIFF
--- a/src/cli/setup-voice-engine.test.ts
+++ b/src/cli/setup-voice-engine.test.ts
@@ -1,0 +1,115 @@
+/**
+ * setup wizard Step 7 (Voice engine) — asserts the verdict is recorded to
+ * host-capabilities.json AND the right inline message branch fires (voice
+ * PR-B1). The detector is mocked so the test never touches a real GPU; HOME
+ * is an isolated tmpdir so the writer never hits the operator's
+ * ~/.switchroom/ (vault/shared-state test discipline).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// setup.ts statically imports vault-broker → broker/server → grants-db →
+// bun:sqlite, which vitest can't resolve. Mock the same chain tests/setup.test.ts does.
+vi.mock("../vault/vault.js", () => ({
+  openVault: vi.fn(),
+  createVault: vi.fn(),
+  setStringSecret: vi.fn(),
+  getStringSecret: vi.fn(),
+}));
+vi.mock("../vault/grants-db.ts", () => ({}));
+vi.mock("../vault/broker/server.js", () => ({
+  VaultBroker: vi.fn(),
+  registerShutdownHandlers: vi.fn(),
+}));
+
+// The injectable seam for this test: mock the detector so we drive each branch.
+import * as gpuDetect from "../setup/gpu-detect.js";
+import { stepVoiceEngine } from "./setup.js";
+
+let home: string;
+let prevHome: string | undefined;
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "switchroom-voice-step-"));
+  prevHome = process.env.HOME;
+  process.env.HOME = home;
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  vi.restoreAllMocks();
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+function output(): string {
+  return logSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n");
+}
+
+function persisted(): { engine: string; gpuPresent: boolean; containerToolkit: boolean } {
+  const path = join(home, ".switchroom", "host-capabilities.json");
+  expect(existsSync(path)).toBe(true);
+  return JSON.parse(readFileSync(path, "utf-8")).voice;
+}
+
+describe("stepVoiceEngine", () => {
+  it("GPU + toolkit → records local verdict + prints the local message", () => {
+    vi.spyOn(gpuDetect, "detectGpuCapabilities").mockReturnValue({
+      gpuPresent: true,
+      containerToolkit: true,
+      engine: "local",
+      reason: "GPU detected — voice will run locally (free, private, on-device).",
+    });
+
+    stepVoiceEngine();
+
+    expect(persisted().engine).toBe("local");
+    expect(output()).toMatch(/run locally/i);
+  });
+
+  it("GPU, no toolkit → records cloud verdict + prints the install-hint message", () => {
+    vi.spyOn(gpuDetect, "detectGpuCapabilities").mockReturnValue({
+      gpuPresent: true,
+      containerToolkit: false,
+      engine: "cloud",
+      reason:
+        "GPU detected but nvidia-container-toolkit isn't installed — install it to run voice locally, " +
+        "or voice will use cloud providers. See: https://example.invalid/install",
+    });
+
+    stepVoiceEngine();
+
+    const p = persisted();
+    expect(p.engine).toBe("cloud");
+    expect(p.gpuPresent).toBe(true);
+    expect(output()).toMatch(/nvidia-container-toolkit/i);
+  });
+
+  it("no GPU → records cloud verdict + prints the no-GPU message", () => {
+    vi.spyOn(gpuDetect, "detectGpuCapabilities").mockReturnValue({
+      gpuPresent: false,
+      containerToolkit: false,
+      engine: "cloud",
+      reason: "No GPU detected — voice will use cloud providers if you enable it.",
+    });
+
+    stepVoiceEngine();
+
+    expect(persisted().engine).toBe("cloud");
+    expect(output()).toMatch(/no gpu detected/i);
+  });
+
+  it("detector throwing degrades to a recorded cloud verdict (setup never breaks)", () => {
+    vi.spyOn(gpuDetect, "detectGpuCapabilities").mockImplementation(() => {
+      throw new Error("probe blew up");
+    });
+
+    expect(() => stepVoiceEngine()).not.toThrow();
+    expect(persisted().engine).toBe("cloud");
+  });
+});

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -26,6 +26,8 @@ import {
   writeAgentEnv,
   saveUserConfig,
 } from "../setup/onboarding.js";
+import { detectGpuCapabilities } from "../setup/gpu-detect.js";
+import { saveVoiceCapability } from "../setup/host-capabilities.js";
 import {
   isDockerAvailable,
   isHindsightRunning,
@@ -128,7 +130,10 @@ export function registerSetupCommand(program: Command): void {
         // ── Step 6: Memory backend ───────────────────────────────
         await stepMemoryBackend(config, nonInteractive, switchroomConfigPath);
 
-        // ── Step 7: Scaffold agents ──────────────────────────────
+        // ── Step 7: Voice engine (GPU detection + verdict) ───────
+        stepVoiceEngine();
+
+        // ── Step 8: Scaffold agents ──────────────────────────────
         await stepScaffoldAgents(
           config,
           agentBots,
@@ -137,19 +142,19 @@ export function registerSetupCommand(program: Command): void {
           switchroomConfigPath,
         );
 
-        // ── Step 8: Vault auto-unlock at boot ────────────────────
+        // ── Step 9: Vault auto-unlock at boot ────────────────────
         await stepAutoUnlock(config, switchroomConfigPath, nonInteractive);
 
-        // ── Step 9: Dangerous mode ──────────────────────────────
+        // ── Step 10: Dangerous mode ─────────────────────────────
         await stepDangerousMode(config, nonInteractive);
 
-        // ── Step 10: Agent onboarding guidance ───────────────────
+        // ── Step 11: Agent onboarding guidance ───────────────────
         await stepOnboardingGuidance(config, nonInteractive);
 
-        // ── Step 11: Optional Google Workspace connection (RFC G §4.6) ─
+        // ── Step 12: Optional Google Workspace connection (RFC G §4.6) ─
         await stepGoogleWorkspace(config, nonInteractive);
 
-        // ── Step 12: Verification ────────────────────────────────
+        // ── Step 13: Verification ────────────────────────────────
         await stepVerification(config, nonInteractive);
 
         await captureEvent("setup_completed", {
@@ -1061,7 +1066,74 @@ async function stepMemoryBackend(
   }
 }
 
-// ─── Step 7: Scaffold Agents ─────────────────────────────────────────────────
+// ─── Step 7: Voice engine (GPU detection + verdict) ──────────────────────────
+
+/**
+ * Detect the host's GPU capabilities, derive the local-vs-cloud voice-engine
+ * verdict, persist it to `~/.switchroom/host-capabilities.json`, and print
+ * the decision inline (principles.md #1 — the user learns the decision and
+ * its *why* at setup, not from docs).
+ *
+ * Switchroom runs voice on LOCAL GPU models by default WHEN a GPU is usable
+ * from a container, falling back to cloud providers otherwise. PR-B2 reads
+ * the persisted verdict to decide whether to emit the GPU voice sidecar.
+ * This step is the same in interactive and non-interactive mode — detection
+ * needs no prompt; it's a pure host probe.
+ *
+ * Detection failures must never break setup: a probe error degrades to the
+ * cloud verdict (the safe, always-available default).
+ */
+export function stepVoiceEngine(): void {
+  stepHeader(7, "Voice engine", STEP_ACTIVE);
+
+  let caps;
+  try {
+    caps = detectGpuCapabilities();
+  } catch (err) {
+    // A probe that threw (unexpected — the probes are defensive) must not
+    // sink setup. Fall back to the cloud verdict and say so.
+    console.log(
+      chalk.yellow(
+        `  Could not probe GPU (${err instanceof Error ? err.message : String(err)}) — ` +
+          "assuming no GPU; voice will use cloud providers if you enable it.",
+      ),
+    );
+    caps = {
+      gpuPresent: false,
+      containerToolkit: false,
+      engine: "cloud" as const,
+      reason:
+        "No GPU detected — voice will use cloud providers if you enable it.",
+    };
+  }
+
+  // Persist the verdict so update / doctor / compose-gen (PR-B2) re-read it
+  // without re-probing every boot. A write failure is non-fatal — re-detect
+  // is always possible.
+  try {
+    saveVoiceCapability(caps);
+  } catch (err) {
+    console.log(
+      chalk.yellow(
+        `  Detected the verdict but could not persist host-capabilities.json: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      ),
+    );
+  }
+
+  // Inline decision messaging — the three branches from the verdict.
+  if (caps.engine === "local") {
+    console.log(chalk.green(`  ${STEP_DONE} ${caps.reason}`));
+  } else if (caps.gpuPresent) {
+    // GPU present but toolkit missing — actionable, so warn (yellow) with
+    // the install hint that `reason` already carries.
+    console.log(chalk.yellow(`  ${caps.reason}`));
+  } else {
+    console.log(chalk.gray(`  ${STEP_DONE} ${caps.reason}`));
+  }
+}
+
+// ─── Step 8: Scaffold Agents ─────────────────────────────────────────────────
 
 async function stepScaffoldAgents(
   config: SwitchroomConfig,
@@ -1075,7 +1147,7 @@ async function stepScaffoldAgents(
   // `writeAccessJson` lands a deterministic value and the still-required
   // `telegram.forum_chat_id` schema field remains honest.
   const forumChatId = "0";
-  stepHeader(7, "Scaffold agents", STEP_ACTIVE);
+  stepHeader(8, "Scaffold agents", STEP_ACTIVE);
 
   const agentsDir = resolveAgentsDir(config);
   const agentNames = Object.keys(config.agents);
@@ -1292,7 +1364,7 @@ async function stepAutoUnlock(
   switchroomConfigPath: string,
   nonInteractive: boolean,
 ): Promise<void> {
-  stepHeader(8, "Vault auto-unlock at boot", STEP_ACTIVE);
+  stepHeader(9, "Vault auto-unlock at boot", STEP_ACTIVE);
 
   const envPass = process.env.SWITCHROOM_VAULT_PASSPHRASE;
   if (nonInteractive && !(envPass && envPass.length > 0)) {
@@ -1460,7 +1532,7 @@ async function stepDangerousMode(
   config: SwitchroomConfig,
   nonInteractive: boolean,
 ): Promise<void> {
-  stepHeader(9, "Auto-approve mode", STEP_ACTIVE);
+  stepHeader(10, "Auto-approve mode", STEP_ACTIVE);
 
   let enableDangerous = false;
 
@@ -1523,7 +1595,7 @@ async function stepOnboardingGuidance(
   config: SwitchroomConfig,
   nonInteractive: boolean,
 ): Promise<void> {
-  stepHeader(10, "Agent onboarding", STEP_ACTIVE);
+  stepHeader(11, "Agent onboarding", STEP_ACTIVE);
 
   const agentsDir = resolveAgentsDir(config);
   const agentNames = Object.keys(config.agents);
@@ -1601,7 +1673,7 @@ async function stepGoogleWorkspace(
   config: SwitchroomConfig,
   nonInteractive: boolean,
 ): Promise<void> {
-  stepHeader(11, "Optional: Google Workspace", STEP_ACTIVE);
+  stepHeader(12, "Optional: Google Workspace", STEP_ACTIVE);
 
   if (nonInteractive) {
     console.log(chalk.gray("  Skipping in non-interactive mode."));
@@ -1685,7 +1757,7 @@ async function stepVerification(
   config: SwitchroomConfig,
   nonInteractive: boolean,
 ): Promise<void> {
-  stepHeader(12, "Verification", STEP_ACTIVE);
+  stepHeader(13, "Verification", STEP_ACTIVE);
 
   const agentNames = Object.keys(config.agents);
   const firstName = agentNames[0];

--- a/src/setup/gpu-detect.test.ts
+++ b/src/setup/gpu-detect.test.ts
@@ -1,0 +1,58 @@
+/**
+ * gpu-detect: install-time GPU detection + the local-vs-cloud voice-engine
+ * verdict (voice PR-B1). These pin all three verdict branches via the
+ * injectable probes — NO real `nvidia-smi` / `docker` shellout.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  detectGpuCapabilities,
+  NVIDIA_TOOLKIT_INSTALL_HINT,
+  type GpuDetectDeps,
+} from "./gpu-detect.js";
+
+function deps(gpu: boolean, toolkit: boolean): GpuDetectDeps {
+  return {
+    probeGpu: () => gpu,
+    probeContainerToolkit: () => toolkit,
+  };
+}
+
+describe("detectGpuCapabilities", () => {
+  it("GPU + toolkit present → engine local", () => {
+    const caps = detectGpuCapabilities(deps(true, true));
+    expect(caps.gpuPresent).toBe(true);
+    expect(caps.containerToolkit).toBe(true);
+    expect(caps.engine).toBe("local");
+    expect(caps.reason).toMatch(/run locally/i);
+    expect(caps.reason).toMatch(/free, private, on-device/i);
+  });
+
+  it("GPU present, toolkit missing → engine cloud with install hint in reason", () => {
+    const caps = detectGpuCapabilities(deps(true, false));
+    expect(caps.gpuPresent).toBe(true);
+    expect(caps.containerToolkit).toBe(false);
+    expect(caps.engine).toBe("cloud");
+    expect(caps.reason).toMatch(/nvidia-container-toolkit/i);
+    expect(caps.reason).toContain(NVIDIA_TOOLKIT_INSTALL_HINT);
+  });
+
+  it("no GPU → engine cloud, no install hint, toolkit probe NOT run", () => {
+    const toolkitProbe = vi.fn(() => true);
+    const caps = detectGpuCapabilities({
+      probeGpu: () => false,
+      probeContainerToolkit: toolkitProbe,
+    });
+    expect(caps.gpuPresent).toBe(false);
+    expect(caps.containerToolkit).toBe(false);
+    expect(caps.engine).toBe("cloud");
+    expect(caps.reason).toMatch(/no gpu detected/i);
+    // No point interrogating docker on a GPU-less host.
+    expect(toolkitProbe).not.toHaveBeenCalled();
+  });
+
+  it("local verdict requires BOTH probes true (gpu-only is not enough)", () => {
+    expect(detectGpuCapabilities(deps(true, false)).engine).toBe("cloud");
+    expect(detectGpuCapabilities(deps(false, false)).engine).toBe("cloud");
+    expect(detectGpuCapabilities(deps(true, true)).engine).toBe("local");
+  });
+});

--- a/src/setup/gpu-detect.ts
+++ b/src/setup/gpu-detect.ts
@@ -1,0 +1,145 @@
+/**
+ * Install-time GPU capability detection + the local-vs-cloud voice-engine
+ * verdict (voice feature PR-B1).
+ *
+ * Switchroom runs voice (STT/TTS) on LOCAL GPU models by default WHEN a GPU
+ * is usable from a container, and falls back to cloud providers otherwise.
+ * This module is the single source of that decision: it probes the host for
+ * (a) an NVIDIA GPU and (b) the nvidia-container-toolkit (so Docker can
+ * actually pass the GPU INTO a sidecar container), then derives an `engine`
+ * verdict.
+ *
+ * BOTH must be present for a `local` verdict — a GPU the container runtime
+ * can't reach is useless to the voice sidecar (which lands in PR-B2).
+ *
+ * The probes are INJECTABLE (`GpuDetectDeps`) so tests never shell out to a
+ * real `nvidia-smi` / `docker`. The default implementations mirror the
+ * shell-out style + 8s timeout used by `doctor-docker.ts`'s
+ * `defaultListContainers`.
+ *
+ * This PR establishes detection + verdict + persistence + setup messaging
+ * only. It deliberately does NOT emit a compose sidecar or touch the
+ * gateway — that's PR-B2, which re-reads the persisted verdict.
+ */
+
+import { spawnSync } from "node:child_process";
+
+/** The voice engine the host will use, derived from capability probes. */
+export type VoiceEngine = "local" | "cloud";
+
+/** Structured detection result — persisted (sans `reason` derivation) + surfaced at setup. */
+export interface GpuCapabilities {
+  /** An NVIDIA GPU is present (nvidia-smi exited 0). */
+  gpuPresent: boolean;
+  /** The nvidia-container-toolkit is wired so Docker can pass the GPU into a container. */
+  containerToolkit: boolean;
+  /** `local` only when BOTH gpuPresent AND containerToolkit; else `cloud`. */
+  engine: VoiceEngine;
+  /** Human-readable one-liner explaining the verdict (for setup output / doctor). */
+  reason: string;
+}
+
+/**
+ * Injectable probes. Each returns a plain boolean; the default
+ * implementations shell out, but tests pass stubs so the suite never
+ * depends on the host having (or lacking) a GPU.
+ */
+export interface GpuDetectDeps {
+  /** True if an NVIDIA GPU is present — default probes `nvidia-smi` (exit 0). */
+  probeGpu: () => boolean;
+  /**
+   * True if Docker can pass a GPU into a container — default checks for the
+   * `nvidia` runtime in `docker info`. Only meaningful when a GPU is present.
+   */
+  probeContainerToolkit: () => boolean;
+}
+
+/** Default (real) GPU probe — `nvidia-smi` exiting 0 means a usable driver+GPU. */
+function defaultProbeGpu(): boolean {
+  const r = spawnSync("nvidia-smi", ["-L"], { stdio: "pipe", timeout: 8000 });
+  // r.error → binary absent (ENOENT); non-zero status → driver/GPU problem.
+  return !r.error && r.status === 0;
+}
+
+/**
+ * Default (real) container-toolkit probe.
+ *
+ * The load-bearing question is "can Docker pass the GPU into a container",
+ * not merely "is some toolkit package installed". The most reliable
+ * cheap signal is whether the Docker daemon advertises the `nvidia`
+ * runtime, which the nvidia-container-toolkit registers. We read
+ * `docker info` and look for it. A GPU with the driver but no toolkit
+ * registration will NOT show the runtime — exactly the case we must
+ * route to cloud.
+ */
+function defaultProbeContainerToolkit(): boolean {
+  const r = spawnSync(
+    "docker",
+    ["info", "--format", "{{json .Runtimes}}"],
+    { stdio: "pipe", timeout: 8000 },
+  );
+  if (r.error || r.status !== 0) return false;
+  const out = r.stdout.toString().toLowerCase();
+  // {{json .Runtimes}} → an object keyed by runtime name; `nvidia` present
+  // means the toolkit registered it with the daemon.
+  return out.includes("nvidia");
+}
+
+const DEFAULT_DEPS: GpuDetectDeps = {
+  probeGpu: defaultProbeGpu,
+  probeContainerToolkit: defaultProbeContainerToolkit,
+};
+
+/**
+ * Detect GPU capabilities and derive the voice-engine verdict.
+ *
+ * Verdict table:
+ *   - GPU + toolkit  → engine: "local"  (free, private, on-device)
+ *   - GPU, no toolkit → engine: "cloud" (toolkit missing — installable)
+ *   - no GPU          → engine: "cloud" (no local option)
+ *
+ * The container-toolkit probe is only run when a GPU is present — there's
+ * no reason to interrogate Docker's runtimes on a host that can't run
+ * local models at all, and skipping it keeps a GPU-less host from a
+ * needless `docker info` shell-out.
+ */
+export function detectGpuCapabilities(
+  deps: GpuDetectDeps = DEFAULT_DEPS,
+): GpuCapabilities {
+  const gpuPresent = deps.probeGpu();
+
+  if (!gpuPresent) {
+    return {
+      gpuPresent: false,
+      containerToolkit: false,
+      engine: "cloud",
+      reason:
+        "No GPU detected — voice will use cloud providers if you enable it.",
+    };
+  }
+
+  const containerToolkit = deps.probeContainerToolkit();
+
+  if (!containerToolkit) {
+    return {
+      gpuPresent: true,
+      containerToolkit: false,
+      engine: "cloud",
+      reason:
+        "GPU detected but nvidia-container-toolkit isn't installed — install it to run voice " +
+        "locally, or voice will use cloud providers. See: " +
+        NVIDIA_TOOLKIT_INSTALL_HINT,
+    };
+  }
+
+  return {
+    gpuPresent: true,
+    containerToolkit: true,
+    engine: "local",
+    reason: "GPU detected — voice will run locally (free, private, on-device).",
+  };
+}
+
+/** One-line install pointer surfaced when a GPU is present but the toolkit isn't. */
+export const NVIDIA_TOOLKIT_INSTALL_HINT =
+  "https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html";

--- a/src/setup/host-capabilities.test.ts
+++ b/src/setup/host-capabilities.test.ts
@@ -1,0 +1,98 @@
+/**
+ * host-capabilities: the persisted voice-engine verdict writer/reader
+ * (voice PR-B1). Round-trips the verdict through
+ * `~/.switchroom/host-capabilities.json`.
+ *
+ * Isolation: `resolveStatePath` derives the path from `process.env.HOME`,
+ * so each test points HOME at a fresh tmpdir — NEVER the operator's real
+ * `~/.switchroom/` (vault/shared-state test discipline).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, statSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  saveVoiceCapability,
+  loadHostCapabilities,
+  hostCapabilitiesPath,
+  HOST_CAPABILITIES_VERSION,
+} from "./host-capabilities.js";
+import type { GpuCapabilities } from "./gpu-detect.js";
+
+let home: string;
+let prevHome: string | undefined;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "switchroom-hostcaps-"));
+  prevHome = process.env.HOME;
+  process.env.HOME = home;
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+const LOCAL_CAPS: GpuCapabilities = {
+  gpuPresent: true,
+  containerToolkit: true,
+  engine: "local",
+  reason: "GPU detected — voice will run locally (free, private, on-device).",
+};
+
+const CLOUD_CAPS: GpuCapabilities = {
+  gpuPresent: false,
+  containerToolkit: false,
+  engine: "cloud",
+  reason: "No GPU detected — voice will use cloud providers if you enable it.",
+};
+
+describe("saveVoiceCapability / loadHostCapabilities", () => {
+  it("round-trips the local verdict with raw booleans + engine + timestamp", () => {
+    const fixed = new Date("2026-06-30T12:34:56.789Z");
+    const written = saveVoiceCapability(LOCAL_CAPS, () => fixed);
+
+    expect(written.version).toBe(HOST_CAPABILITIES_VERSION);
+    expect(written.voice).toEqual({
+      gpuPresent: true,
+      containerToolkit: true,
+      engine: "local",
+      detectedAt: "2026-06-30T12:34:56.789Z",
+    });
+
+    const loaded = loadHostCapabilities();
+    expect(loaded).toEqual(written);
+  });
+
+  it("round-trips the cloud verdict (no GPU)", () => {
+    saveVoiceCapability(CLOUD_CAPS);
+    const loaded = loadHostCapabilities();
+    expect(loaded?.voice.engine).toBe("cloud");
+    expect(loaded?.voice.gpuPresent).toBe(false);
+    expect(loaded?.voice.containerToolkit).toBe(false);
+    expect(typeof loaded?.voice.detectedAt).toBe("string");
+  });
+
+  it("writes under ~/.switchroom/host-capabilities.json with mode 0600", () => {
+    saveVoiceCapability(CLOUD_CAPS);
+    const path = hostCapabilitiesPath();
+    expect(path).toBe(join(home, ".switchroom", "host-capabilities.json"));
+    expect(existsSync(path)).toBe(true);
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+    // trailing newline, like the other state writers
+    expect(readFileSync(path, "utf-8").endsWith("}\n")).toBe(true);
+  });
+
+  it("loadHostCapabilities returns null when the file is absent", () => {
+    expect(loadHostCapabilities()).toBeNull();
+  });
+
+  it("loadHostCapabilities returns null on malformed JSON", () => {
+    const path = hostCapabilitiesPath();
+    // create the dir + a junk file
+    saveVoiceCapability(CLOUD_CAPS);
+    writeFileSync(path, "{ not json");
+    expect(loadHostCapabilities()).toBeNull();
+  });
+});

--- a/src/setup/host-capabilities.ts
+++ b/src/setup/host-capabilities.ts
@@ -1,0 +1,115 @@
+/**
+ * Persisted host capabilities (voice feature PR-B1).
+ *
+ * The GPU/voice-engine verdict (`src/setup/gpu-detect.ts`) is computed once
+ * at setup and written here so later phases — `update`, `doctor`, and the
+ * compose generator that emits (or doesn't) the voice sidecar in PR-B2 —
+ * can re-read the decision without re-probing `nvidia-smi`/`docker` on
+ * every boot.
+ *
+ * No existing host-state JSON file fit (the closest precedent,
+ * `~/.switchroom/user.json` written by `onboarding.ts:saveUserConfig`, is
+ * Telegram identity, not host hardware), so this adds a small
+ * `~/.switchroom/host-capabilities.json` writer in the same shape +
+ * convention: `resolveStatePath`, mode 0600, JSON with a trailing newline.
+ *
+ * On-disk shape (versioned for forward-compat):
+ *
+ *   {
+ *     "version": 1,
+ *     "voice": {
+ *       "gpuPresent": false,
+ *       "containerToolkit": false,
+ *       "engine": "cloud",
+ *       "detectedAt": "2026-06-30T12:34:56.789Z"
+ *     }
+ *   }
+ *
+ * `engine` is the derived verdict; the raw `gpuPresent`/`containerToolkit`
+ * booleans are persisted alongside so a reader can explain WHY without
+ * re-deriving. `detectedAt` is an ISO-8601 timestamp so a stale verdict
+ * (e.g. a GPU added after install) is visible.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { resolveStatePath } from "../config/paths.js";
+import type { GpuCapabilities, VoiceEngine } from "./gpu-detect.js";
+
+/** Current on-disk schema version. Bump when the shape changes. */
+export const HOST_CAPABILITIES_VERSION = 1;
+
+/** The persisted voice-engine verdict (raw booleans + derived engine + timestamp). */
+export interface PersistedVoiceCapability {
+  gpuPresent: boolean;
+  containerToolkit: boolean;
+  engine: VoiceEngine;
+  /** ISO-8601 timestamp of when the verdict was computed. */
+  detectedAt: string;
+}
+
+/** The full `host-capabilities.json` document. */
+export interface HostCapabilities {
+  version: number;
+  voice: PersistedVoiceCapability;
+}
+
+/** Absolute path to the persisted host-capabilities file. */
+export function hostCapabilitiesPath(): string {
+  return resolveStatePath("host-capabilities.json");
+}
+
+/**
+ * Persist the voice-engine verdict to `~/.switchroom/host-capabilities.json`.
+ *
+ * Writes the raw probe booleans, the derived `engine`, and a fresh
+ * `detectedAt` timestamp. `now` is injectable for deterministic tests.
+ * Returns the document that was written.
+ */
+export function saveVoiceCapability(
+  caps: GpuCapabilities,
+  now: () => Date = () => new Date(),
+): HostCapabilities {
+  const doc: HostCapabilities = {
+    version: HOST_CAPABILITIES_VERSION,
+    voice: {
+      gpuPresent: caps.gpuPresent,
+      containerToolkit: caps.containerToolkit,
+      engine: caps.engine,
+      detectedAt: now().toISOString(),
+    },
+  };
+
+  const path = hostCapabilitiesPath();
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(doc, null, 2) + "\n", {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  return doc;
+}
+
+/**
+ * Load the persisted host-capabilities document, or null if it doesn't
+ * exist / is unreadable / is malformed. A missing or corrupt file is not
+ * an error — callers (PR-B2 compose-gen, doctor) degrade by re-detecting
+ * or skipping.
+ */
+export function loadHostCapabilities(): HostCapabilities | null {
+  const path = hostCapabilitiesPath();
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "voice" in parsed &&
+      typeof (parsed as HostCapabilities).voice === "object"
+    ) {
+      return parsed as HostCapabilities;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

**PR-B1** of the voice feature. Voice runs on **LOCAL GPU models by default when a GPU is usable from a container**, and **falls back to cloud providers** otherwise. This PR is purely additive: it establishes the install-time capability detection + the persisted decision. **No compose sidecar, no Dockerfile, no gateway change** — those are PR-B2, which re-reads the persisted verdict to decide whether to emit the GPU voice sidecar.

PR-A (#2696, merged) vault-unified the STT key; this builds the host-capability layer that B2 keys off.

## Why

- **Serves vision outcome #4** — *always available, in Telegram, done properly.* Voice is part of "talk to my agents from anywhere": a voice note the user sends should be real input, acted on, not dropped (`reference/jobs/talk-to-agents-from-anywhere.md`, the *attachments are real input* row). Local-on-GPU keeps it free + private + on-device when the hardware allows; cloud fallback keeps it always-available when it doesn't.
- switchroom had **no GPU/nvidia/cuda detection anywhere** — this is net-new, modelled on the host-capability style of `src/cli/doctor-docker.ts` (injectable probes, 8s shell-out timeout).

## What changed

- **`src/setup/gpu-detect.ts`** — `detectGpuCapabilities(deps?)`. Injectable probes:
  - `probeGpu` → `nvidia-smi -L` exit 0.
  - `probeContainerToolkit` → Docker advertises the `nvidia` runtime (`docker info`), i.e. the toolkit is wired so the GPU can be **passed into a container**.
  - Returns `{ gpuPresent, containerToolkit, engine, reason }`. `engine: 'local'` **only when BOTH** are true — a GPU the container runtime can't reach is useless to the sidecar. The toolkit probe is skipped on a GPU-less host.
- **`src/setup/host-capabilities.ts`** — persists the verdict to **`~/.switchroom/host-capabilities.json`** (new file; no existing host-state JSON fit — closest precedent `user.json` is Telegram identity, not hardware). Shape (versioned):
  ```json
  { "version": 1, "voice": { "gpuPresent": false, "containerToolkit": false, "engine": "cloud", "detectedAt": "<ISO-8601>" } }
  ```
  Raw booleans + derived engine + timestamp, so a reader can explain *why* and spot a stale verdict. mode 0600, trailing newline — same convention as the other state writers. `loadHostCapabilities()` reader is in place for PR-B2/doctor.
- **`src/cli/setup.ts`** — new **Step 7 "Voice engine"**: runs detection, persists the verdict, prints the decision **inline** (principles.md #1, the docs test). Three branches:
  - GPU + toolkit → "GPU detected — voice will run locally (free, private, on-device)."
  - GPU, no toolkit → "GPU detected but nvidia-container-toolkit isn't installed — install it to run voice locally, or voice will use cloud providers. See: <hint>."
  - No GPU → "No GPU detected — voice will use cloud providers if you enable it."
  Detection/persist failures degrade to the cloud verdict — setup never breaks. Subsequent steps renumbered 8–13.

## Test plan

- [x] `src/setup/gpu-detect.test.ts` — all branches via the injectable runner (both→local, gpu-only→cloud+install-hint, neither→cloud, toolkit probe skipped on no-GPU). **No real `nvidia-smi`/`docker` shellout.**
- [x] `src/setup/host-capabilities.test.ts` — round-trips local + cloud verdicts; mode 0600; null on absent/malformed file. Isolated HOME tmpdir (never the operator's `~/.switchroom/`).
- [x] `src/cli/setup-voice-engine.test.ts` — Step 7 records the verdict + fires the right message branch (mocked detector); detector-throw degrades to a recorded cloud verdict.
- [x] `npm run lint` clean; `npm run test:vitest` for touched suites green (119 setup-area tests pass).

## Deferred to PR-B2

- The compose voice-sidecar service + Dockerfile + gateway wiring (kept strictly out of scope).
- A `doctor` line surfacing the persisted verdict — adding a doctor section is more than a small clean addition to `doctor-docker.ts` (section-assembly coupling), so deferred. The `loadHostCapabilities()` reader is already in place for it.

## Risk

Low — additive only. New setup step is a pure host probe with safe cloud-fallback on any error; new persistence file is independent of existing state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)