### PR TITLE
fix(telegram): guard blocked cap-line against unknown reset time

### DIFF
--- a/telegram-plugin/auth-snapshot-format.ts
+++ b/telegram-plugin/auth-snapshot-format.ts
@@ -319,7 +319,9 @@ function renderAccountRow(
     const reset = win === '5h' ? q.fiveHourResetAt : q.sevenDayResetAt;
     const winLabel = win === '5h' ? '5-hour' : '7-day';
     lines.push(
-      `  _quota exhausted — back ${formatAbsolute(reset, tz)} (\`in ${formatRelative(reset, now)}\`, ${winLabel} cap)_`,
+      reset
+        ? `  _quota exhausted — back ${formatAbsolute(reset, tz)} (\`in ${formatRelative(reset, now)}\`, ${winLabel} cap)_`
+        : `  _quota exhausted — ${winLabel} cap, reset time unknown_`,
     );
     return lines;
   }

--- a/telegram-plugin/tests/auth-snapshot-format.test.ts
+++ b/telegram-plugin/tests/auth-snapshot-format.test.ts
@@ -223,6 +223,22 @@ describe('renderAuthSnapshotFormat2', () => {
     expect(capLine!.trim().endsWith('_')).toBe(true);
   });
 
+  it('drops the ETA code-span on a blocked account with no known reset time', () => {
+    // Blocked on 7d but the binding window has no reset epoch — must NOT
+    // render a `in —` code-span; falls back to plain "reset time unknown".
+    const noReset = [
+      snap({ label: 'norst@example.com', isActive: true, quota: quota({ sevenDayUtilizationPct: 100 }) }),
+    ];
+    const out = renderAuthSnapshotFormat2(noReset, { now: NOW, tz: 'UTC' });
+    const capLine = out.split('\n').find((l) => l.includes('quota exhausted'));
+    expect(capLine).toBeDefined();
+    expect(capLine).not.toContain('`in —`');
+    expect(capLine).not.toContain('—`');
+    expect(capLine).toContain('reset time unknown');
+    expect(capLine!.trim().startsWith('_quota exhausted')).toBe(true);
+    expect(capLine!.trim().endsWith('_')).toBe(true);
+  });
+
   it('wraps both the 5h-refills and 7d-resets ETAs in `code` spans', () => {
     const out = renderAuthSnapshotFormat2(fixtureSnaps, { now: NOW, tz: 'UTC' });
     const lines = out.split('\n');


### PR DESCRIPTION
## What
Folds in the actionable NIT from the adversarial review of #2695. The blocked-account quota cap-line wrapped its ETA in a `code` span unconditionally, so a null binding-window reset would render a bare `` `in —` `` span. Now mirrors the refills branch's existing null-guard — falls back to plain `reset time unknown` (no code-span) when the reset epoch is absent. Cosmetic-only (never a parse break), but it makes the cap-line consistent with the refills lines.

Adds a focused test for the null-reset blocked case (asserts no `` `in —` `` span, plain fallback, italic wrapper preserved).

## Review NITs deliberately NOT changed (with reasons)
- **`slot-banner.ts` local escaper** — byte-identical to canonical, but the module documents an intentional *dependency-free, testable-in-isolation* contract. Consolidating would trade a documented invariant for marginal DRY. Left as-is by design.
- **`operator-events.ts` "zero grammy/gateway deps" comment** — still accurate: `format.ts` is a zero-import leaf util, neither grammy nor gateway, so the import doesn't violate the stated contract.
- **No server-render proof for strikethrough** — addressed by the release, not code: overlord's own progress cards become the live proof once it's on the new build.

## Tests
`auth-snapshot-format.test.ts`: 77 pass / 0 fail (incl. the new null-reset case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)