### PR TITLE
docs: fix stale CLAUDE.md pointers + align Telegram formatting steer to Bot API 10.1 rich messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,8 +325,15 @@ telegram-plugin/        The enhanced MCP Telegram plugin (own Bun tests)
   card-format.ts        Shared status-card formatters (progress card
                         rendered via stream-reply-handler.ts + subagent-watcher.ts)
   tool-labels.ts        Tool-use label formatting
-  auth-slot-parser.ts   /auth router (add/use/list/rm)
+  rich-send.ts          Rich-message send/edit helpers (Bot API 10.1) —
+                        `richMessage(md)` → `{ markdown }`, the ONE render
+                        path through `sendRichMessage`/`editMessageText`
+  format.ts             GFM markdown normalizer + `escapeMarkdown`
   auto-fallback.ts      Quota-exhaustion auto-fallback
+  gateway/              Gateway core. `/auth` chat-command routing lives in
+                        gateway/auth-command.ts (parse + handle); the old
+                        auth-slot-parser.ts / auth-dashboard.ts were deleted
+                        (RFC H §7.3)
   tests/                Bun tests
 
 docker/                 Dockerfiles (base, agent, broker, kernel). Built via
@@ -366,7 +373,12 @@ The generated compose file lives at
 bun install              # install deps (project uses bun.lock)
 bun run dev -- <args>    # run the CLI directly from src/ via bin/switchroom.ts
 npm run build            # compile src/ + telegram-plugin/ → dist/
-npm run lint             # tsc --noEmit (type-check only, no emit)
+npm run lint             # tsc --noEmit + 8 structural guard scripts:
+                         #   plugin-references, bot-api-wrapping,
+                         #   bun-test-imports, no-pii-secrets,
+                         #   vault-test-hermeticity, no-broadcast-delivery,
+                         #   stale-tool-descriptions, web-subscription-honest
+                         # (see scripts/check-*.{mjs,sh})
 npm test                 # vitest (src/) + bun test (telegram-plugin/)
 npm run test:vitest      # src/ only
 npm run test:bun         # telegram-plugin/ only
@@ -375,6 +387,21 @@ npm run test:watch       # vitest --watch
 
 The build output (`dist/`) is what `switchroom` resolves when installed
 globally. During local work on src/, prefer `bun run dev` over rebuilding.
+
+## Telegram formatting capability — source of truth
+
+The **Telegram Bot API changelog** is the authority on what renders, not
+our recollection: <https://core.telegram.org/bots/api-changelog>. As of
+**rich messages (Bot API 10.1, June 2026)** every outbound message goes
+through `sendRichMessage` with raw GFM-style Markdown — so **tables,
+headings (`#`), thematic rules (`---`), task lists (`- [x]`), `==highlight==`,
+blockquotes, and ordered/unordered lists all render**. Documented limits:
+**32768 chars, 500 blocks, 16 nesting levels, 20 columns per table**. The
+ONE GFM construct that still falls back to literal text is **sub/superscript**
+(`H~2~O`, `x^2^`) — avoid it. The agent-facing steer is the floor card in
+`src/agents/scaffold.ts` (`TELEGRAM_FORMATTING_FLOOR_CARD`), mirrored in
+`reference/telegram-formatting-guide.md`. When the changelog moves, update
+both.
 
 ## CI
 
@@ -1049,7 +1076,9 @@ invariants, job specs — see "Design contract" above.)
   NOT source the header from `subagent-watcher.ts`. E2E gate:
   `telegram-plugin/uat/scenarios/jtbd-worker-activity-feed-dm.test.ts`.
 - **Auth** → `src/auth/accounts.ts` (slots) + `src/auth/manager.ts`
-  (OAuth). Telegram `/auth` routing: `telegram-plugin/auth-slot-parser.ts`.
+  (OAuth). Telegram `/auth` routing: `telegram-plugin/gateway/auth-command.ts`
+  (`parseAuthCommand` + `handleAuthCommand`; the old `auth-slot-parser.ts`
+  was deleted in RFC H §7.3).
 - **Runtime inspection** → `switchroom debug turn <agent>` (prompt
   layering) and `switchroom workspace render <agent>` (bootstrap block).
 - **Compose generation** → `src/agents/compose.ts:generateCompose()`,

--- a/reference/telegram-formatting-guide.md
+++ b/reference/telegram-formatting-guide.md
@@ -48,12 +48,21 @@ need none of them.
 - Bulleted list — 3+ parallel items the reader will scan or compare. Never for a single
   thought or a flowing narrative.
 - Numbered list — ordered steps or ranked items.
-- Tables — 2-D data only (rows × columns): per-account usage, status fields. Overkill
-  for a flat list.
-- Headings — only in a long, multi-section answer. Clutter on a short reply.
+- Task lists (`- [x]` / `- [ ]`) — progress on a checklist of steps the reader is
+  tracking. Renders as real checkboxes; reserve for genuine done/not-done state.
+- Tables — 2-D data only (rows × columns): per-account usage, status fields. Render as
+  real tables (up to 20 columns). Overkill for a flat list.
+- Headings (`#`) — only in a long, multi-section answer. Clutter on a short reply.
 - Blockquotes (`>`) — quoted text or indented continuation. Telegram drops leading
   spaces, so use `>`, never literal indentation.
+- `==highlight==` — a single word or value the reader's eye must land on. Stronger
+  than bold; use at most once per message.
 - Dividers (`---`) — between genuinely separate sections. Heavy; use sparingly.
+
+Tables, headings, dividers, task lists, lists, blockquotes and `==highlight==` all
+render as rich blocks (Bot API 10.1) — reach for whichever cuts the reader's scanning
+effort. The ONE exception: sub/superscript (`H~2~O`, `x^2^`) falls back to literal
+text, so don't use it.
 
 ### The why
 Structure exists for the reader, not the writer. A two-item bullet list is worse than a
@@ -85,8 +94,8 @@ Bot API 10.1 rich messages.
 | Spoiler | `\|\|text\|\|` | Hidden until tapped — surprises, long-answer punchlines. |
 | Highlight / marked | `==text==` | The `=` is an `escapeMarkdown` special, so dynamic text won't trigger it by accident. |
 | Inline code | `` `text` `` | Identifiers, tap-to-copy. Content is literal — no escaping inside. |
-| Subscript | `~text~` (single tilde) | Math/chemistry. Distinct from `~~strike~~` (double). |
-| Superscript | `^text^` | Footnote markers, exponents. |
+| Subscript | `~text~` (single tilde) | **Falls back to literal text** in rich messages (Bot API 10.1) — the only GFM construct that doesn't render. Avoid. |
+| Superscript | `^text^` | **Falls back to literal text** in rich messages — avoid (use words, e.g. "squared"). |
 | Custom emoji | Telegram premium custom-emoji entity | Premium-only; renders as a normal emoji for non-premium viewers. Don't rely on it conveying meaning. |
 | Inline math | `$ … $` | LaTeX-style inline math (Bot API 10.1). |
 | Link | `[label](https://…)` | Standard GFM link. |
@@ -117,9 +126,10 @@ Bot API 10.1 rich messages.
   separate sections. Use sparingly.
 - **Footnotes** — GFM `[^1]` reference + `[^1]: …` definition.
 
-> Reach for the exotic spans (spoiler, sub/superscript, highlight, math, custom emoji)
-> only when they genuinely serve the reader. The floor card's "why" applies: structure
-> for the reader, not the writer.
+> Reach for the exotic spans (spoiler, highlight, math, custom emoji) only when they
+> genuinely serve the reader. The floor card's "why" applies: structure for the reader,
+> not the writer. Note sub/superscript is the one exception — it does NOT render (falls
+> back to literal text), so don't use it.
 
 ### Escaping rules
 

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -382,12 +382,21 @@ need none of them.
 - Bulleted list — 3+ parallel items the reader will scan or compare. Never for a single
   thought or a flowing narrative.
 - Numbered list — ordered steps or ranked items.
-- Tables — 2-D data only (rows × columns): per-account usage, status fields. Overkill
-  for a flat list.
-- Headings — only in a long, multi-section answer. Clutter on a short reply.
+- Task lists (\`- [x]\` / \`- [ ]\`) — progress on a checklist of steps the reader is
+  tracking. Renders as real checkboxes; reserve for genuine done/not-done state.
+- Tables — 2-D data only (rows × columns): per-account usage, status fields. Render as
+  real tables (up to 20 columns). Overkill for a flat list.
+- Headings (\`#\`) — only in a long, multi-section answer. Clutter on a short reply.
 - Blockquotes (\`>\`) — quoted text or indented continuation. Telegram drops leading
   spaces, so use \`>\`, never literal indentation.
+- \`==highlight==\` — a single word or value the reader's eye must land on. Stronger
+  than bold; use at most once per message.
 - Dividers (\`---\`) — between genuinely separate sections. Heavy; use sparingly.
+
+Tables, headings, dividers, task lists, lists, blockquotes and \`==highlight==\` all
+render as rich blocks (Bot API 10.1) — reach for whichever cuts the reader's scanning
+effort. The ONE exception: sub/superscript (\`H~2~O\`, \`x^2^\`) falls back to literal
+text, so don't use it.
 
 ### The why
 Structure exists for the reader, not the writer. A two-item bullet list is worse than a

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -288,8 +288,10 @@ export function normalizeParagraphBreaks(text: string): string {
   // Step 3: guarantee a blank line (`\n\n`) at BLOCK BOUNDARIES. The
   // prose-promotion above keeps lists/tables tight by leaving their single
   // `\n` separators alone — but GFM's rich renderer needs a blank line to
-  // START a new block, so a block that is glued to the previous line by a
-  // single `\n` fails to render (a table prints as literal pipe text, prose
+  // START a new block. A properly block-separated table DOES render as a
+  // real table (Bot API 10.1 rich messages); the failure mode this pass
+  // fixes is the *glued* case — a block joined to the previous line by a
+  // single `\n` (an un-separated table degrades to literal pipe text, prose
   // after a list is absorbed as a lazy list continuation). This pass inserts
   // the missing blank line at those transitions only, on the same masked text,
   // never touching code interiors, never collapsing/expanding existing `\n\n`,


### PR DESCRIPTION
## What & why

Two related docs/accuracy fixes, no runtime behavior change (docs, one injected guidance string, one code comment).

**JTBD:** operator/agent onboarding accuracy — passes the **docs test** (someone can orient from CLAUDE.md without reading stale paths or wrong formatting guidance). Advances the **visibility** outcome: agents format Telegram replies for scannability per current render capability.

### (A) Stale CLAUDE.md pointers
- `auth-slot-parser.ts` was deleted (RFC H §7.3); pointers now go to `telegram-plugin/gateway/auth-command.ts` (`parseAuthCommand` + `handleAuthCommand`).
- Documented `telegram-plugin/rich-send.ts` (the single rich-message render path) and `format.ts` in the layout block.
- `lint` corrected: it is `tsc --noEmit` + **8 structural guard scripts**, not just a type-check.
- Added a "Telegram formatting capability" steer citing the [Bot API changelog](https://core.telegram.org/bots/api-changelog) as source of truth (rich messages, Bot API 10.1: tables/headings/`---`/task-lists all render; limits 32768 chars / 500 blocks / 16 nesting levels / 20 columns per table; sub/superscript falls back to literal).

### (B) Formatting steer alignment
- `src/agents/scaffold.ts` `TELEGRAM_FORMATTING_FLOOR_CARD`: added task lists + `==highlight==`, noted the rich blocks all render, and called out the ONE exception (sub/superscript → literal). Voice/structure preserved.
- `telegram-plugin/format.ts`: fixed the "table prints as literal pipe text" comment — a block-separated table DOES render; literal pipes are only the glued/un-separated case the normalizer fixes.
- `reference/telegram-formatting-guide.md`: mirrored the floor-card edits (verbatim-sync contract) and corrected the sub/superscript depth-table rows.

## Testing
- `npm run lint` — clean (tsc + all 8 guards).
- `bun test` paragraph-normalizer + telegram-format — 95 pass / 0 fail.
- `vitest tests/scaffold.test.ts` — 195 pass; the 1 failing case is a pre-existing `/home/op` symlink-path assertion present on clean `main` in this sandbox (env-specific), untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)