### PR TITLE
feat(voice): local GPU STT sidecar — gateway consume + token injection (PR-B2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## unreleased — Voice PR-B2: local GPU STT sidecar (gateway consuming side + token injection)
+
+Wires the gateway's voice-in path to the local `voice-sidecar` GPU
+speech-to-text service when the host's PR-B1 voice verdict is `engine: local`.
+On such a host an inbound Telegram voice note is transcribed entirely
+on-box (faster-whisper) — no third-party STT key (vision #3,
+subscription-honest) and no cloud reachability dependency (vision #4,
+always-available). On a `cloud` verdict the existing OpenAI Whisper path is
+unchanged. Either way, any transcription failure falls back to the legacy
+`(voice message)` envelope — voice-in stays a non-critical UX enhancement.
+Serves `reference/jobs/talk-to-agents-from-anywhere.md`.
+
+- Gateway: new `transcribeViaSidecar` (POST audio → sidecar `/stt` with the
+  `X-Voice-Token` shared secret, mirroring `transcribeViaWhisper`'s
+  return-contract) and `maybeTranscribeVoiceLocal`. Engine selection reads
+  the persisted `loadHostCapabilities()` verdict; the local path needs no
+  `provider === 'openai'` gate (it has no API key). The Telegram download
+  is now a shared `downloadVoiceBytes` helper used by both paths.
+- Token: the sidecar's shared secret is resolved by BOTH ends from the vault
+  at `voice/sidecar-token`. The gateway resolves it at use-time via the
+  broker (`materializeSidecarToken`, mirroring `materializeVoiceKey`). At
+  `switchroom apply` (local verdict only), the token is seeded in the vault
+  if absent and written to the compose-adjacent `.env` (0600) so docker's
+  `${VOICE_SIDECAR_TOKEN}` interpolation populates the pure-Python sidecar's
+  env — the secret never lands in the generated YAML. A `cloud` verdict
+  removes any stale token `.env`.
+- Singleton reconcile + doctor now manage `voice-sidecar` as a
+  verdict-gated conditional singleton (`resolveSingletonServices`): tracked
+  for image-drift on a `local` host, never flagged missing/unhealthy on a
+  `cloud` host.
+
 ## v0.16.30 — Telegram deterministic formatting: reply-path bullet split + card-body normalization
 
 Deterministic Telegram formatting on two surfaces. On the reply path, collapsed inline bullet lists are now split onto separate lines (`splitCollapsedInlineBullets`) so bullets that arrived run-together render as a proper list. (#2687)

--- a/docker/Dockerfile.voice
+++ b/docker/Dockerfile.voice
@@ -1,0 +1,63 @@
+# switchroom/voice — local GPU speech-to-text sidecar (voice feature PR-B2).
+#
+# Wraps `faster-whisper` (CTranslate2) behind a tiny stdlib HTTP server
+# (docker/voice-sidecar/server.py) so the fleet can transcribe inbound
+# voice notes on a LOCAL GPU — no third-party STT key (vision #3,
+# subscription-honest) and no cloud dependency (vision #4,
+# always-available). Emitted into the compose file ONLY when the PR-B1
+# host-capabilities verdict is `engine: local` (see src/agents/compose.ts).
+#
+# Scope: STT only. TTS / Kokoro (`/tts`) lands in PR-C.
+#
+# Why a CUDA *runtime* base (not devel): CTranslate2 ships prebuilt CUDA
+# kernels in its wheel, so we only need the CUDA + cuDNN runtime libs at
+# image time — not the full toolkit. Keeps the image far smaller.
+#
+# Model weights are NOT baked in. They are fetched once on first boot into
+# the `voice-model-cache` named volume (compose mounts it at /models) and
+# reused thereafter. Baking them would bloat the image AND raise weight-
+# redistribution licensing questions; the model id is pinned via
+# VOICE_STT_MODEL and (optionally) checksum-verified fail-closed via
+# VOICE_STT_MODEL_SHA256. See server.py:_load_model.
+#
+# sec: pinned by digest — a CUDA `:runtime` tag from nvidia is mutable.
+# Dependabot tracks bumps. (Replace the digest when bumping the tag.)
+FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04
+
+LABEL org.opencontainers.image.title="switchroom-voice" \
+      org.opencontainers.image.description="Local GPU STT sidecar (faster-whisper)"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONUNBUFFERED=1 \
+    VOICE_MODEL_CACHE=/models \
+    HF_HOME=/models/hf
+
+# ffmpeg normalizes arbitrary inbound audio (OGG/Opus from Telegram, mp3,
+# m4a, …) to 16kHz mono WAV before whisper. python3 runs the server.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 python3-pip ffmpeg ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# faster-whisper pulls in ctranslate2 (with bundled CUDA kernels). Pin so
+# the image is reproducible; Dependabot bumps it.
+RUN pip3 install --no-cache-dir \
+        "faster-whisper==1.0.3"
+
+COPY docker/voice-sidecar/server.py /opt/voice-sidecar/server.py
+
+# Weights land in this volume on first boot; never baked into the image.
+VOLUME ["/models"]
+
+# STT listener. compose publishes this on the host-gateway-reachable
+# interface and gates access on the X-Voice-Token shared secret.
+EXPOSE 8126
+
+# Run as a non-root uid — the sidecar needs no privilege beyond the GPU
+# device (granted via the compose deploy.resources reservation) and write
+# access to the model-cache volume (compose sets ownership / the volume is
+# created writable on first run).
+USER 65532:65532
+
+ENTRYPOINT ["python3", "/opt/voice-sidecar/server.py"]

--- a/docker/voice-sidecar/server.py
+++ b/docker/voice-sidecar/server.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""
+switchroom voice STT sidecar (voice feature PR-B2).
+
+A tiny HTTP server that wraps `faster-whisper` (CTranslate2) for local,
+on-GPU speech-to-text. It exists so the fleet can transcribe inbound
+voice notes WITHOUT a third-party API key (vision #3 subscription-honest)
+and WITHOUT depending on cloud reachability (vision #4 always-available),
+WHEN the host has a usable GPU (the PR-B1 `engine='local'` verdict).
+
+Scope (PR-B2): STT only. TTS / Kokoro `/tts` lands in PR-C.
+
+HTTP contract
+-------------
+  POST /stt   multipart: audio=<bytes>, optional language=<iso-639-1>
+              header:    X-Voice-Token: <shared secret>
+              → 200 { ok: true,  text, language?, durationMs, audioSeconds }
+              → 4xx/5xx { ok: false, reason, detail }
+  GET  /healthz
+              → 200 only once the model is fully loaded (model cold-load
+                can take 30-90s; the compose healthcheck start_period is
+                generous to match).
+
+Design constraints (reviewed):
+  * Auth — every /stt call must carry the X-Voice-Token shared secret
+    (injected from the vault, see compose.ts). A missing/wrong token is
+    401. /healthz is unauthenticated (it leaks nothing).
+  * GPU serialization — concurrent fleet requests must not thrash / OOM
+    the GPU. A bounded semaphore (VOICE_STT_CONCURRENCY, default 1)
+    serializes the actual whisper inference; queued callers wait.
+  * Per-request timeout — a single request can't pin the GPU forever
+    (VOICE_STT_REQUEST_TIMEOUT_S, default 60s) → 503 timeout.
+  * Input normalization — Telegram voice is OGG/Opus; uploaded audio
+    varies. ffmpeg transcodes everything to 16kHz mono WAV before
+    whisper so the decoder never has to guess.
+  * Model weights are fetched ONCE on first boot into a named volume
+    (VOICE_MODEL_CACHE), never baked into the image (size + weight-
+    redistribution licensing). The model id is pinned; if a SHA256 of
+    the downloaded model dir is configured it is verified fail-closed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+# ── config (env-driven; compose injects these) ─────────────────────────
+MODEL_ID = os.environ.get("VOICE_STT_MODEL", "Systran/faster-whisper-base")
+MODEL_CACHE = os.environ.get("VOICE_MODEL_CACHE", "/models")
+MODEL_SHA256 = os.environ.get("VOICE_STT_MODEL_SHA256", "").strip()
+DEVICE = os.environ.get("VOICE_STT_DEVICE", "cuda")
+COMPUTE_TYPE = os.environ.get("VOICE_STT_COMPUTE_TYPE", "float16")
+CONCURRENCY = max(1, int(os.environ.get("VOICE_STT_CONCURRENCY", "1")))
+REQUEST_TIMEOUT_S = float(os.environ.get("VOICE_STT_REQUEST_TIMEOUT_S", "60"))
+LISTEN_PORT = int(os.environ.get("VOICE_STT_PORT", "8126"))
+SHARED_TOKEN = os.environ.get("VOICE_SIDECAR_TOKEN", "")
+# Reject inputs larger than this BEFORE transcoding (the gateway already
+# guards the Telegram 20MB cap; this is defence in depth).
+MAX_BYTES = int(os.environ.get("VOICE_STT_MAX_BYTES", str(25 * 1024 * 1024)))
+
+# ── model state (loaded once, in a background thread at boot) ───────────
+_model = None
+_model_lock = threading.Lock()
+_model_error: str | None = None
+# Bounds concurrent GPU inference so the fleet can't OOM/thrash the card.
+_gpu_sem = threading.Semaphore(CONCURRENCY)
+# A small pool so a per-request timeout can abandon a slow inference
+# without blocking the HTTP handler thread forever.
+_pool = ThreadPoolExecutor(max_workers=CONCURRENCY + 2)
+
+
+def _log(msg: str) -> None:
+    sys.stderr.write(f"voice-sidecar: {msg}\n")
+    sys.stderr.flush()
+
+
+def _dir_sha256(path: str) -> str:
+    """Stable SHA256 over a directory's file contents (sorted by relpath).
+    Used to pin the fetched model weights fail-closed."""
+    h = hashlib.sha256()
+    for root, _dirs, files in sorted(os.walk(path)):
+        for name in sorted(files):
+            fp = os.path.join(root, name)
+            rel = os.path.relpath(fp, path)
+            h.update(rel.encode("utf-8"))
+            with open(fp, "rb") as fh:
+                for chunk in iter(lambda: fh.read(1 << 20), b""):
+                    h.update(chunk)
+    return h.hexdigest()
+
+
+def _load_model() -> None:
+    """Fetch-once + load the whisper model. Runs in a background thread so
+    /healthz can report 'not ready' during the (slow) cold load."""
+    global _model, _model_error
+    try:
+        os.makedirs(MODEL_CACHE, exist_ok=True)
+        # faster-whisper downloads to download_root on first use and reuses
+        # the cached snapshot thereafter (the named volume persists it).
+        from faster_whisper import WhisperModel  # heavy import, deferred
+
+        _log(f"loading model {MODEL_ID} (device={DEVICE}, compute={COMPUTE_TYPE}) …")
+        model = WhisperModel(
+            MODEL_ID,
+            device=DEVICE,
+            compute_type=COMPUTE_TYPE,
+            download_root=MODEL_CACHE,
+        )
+
+        # Fail-closed checksum: if a pin is configured, verify the cached
+        # snapshot matches it. A mismatch means tampered / wrong weights —
+        # refuse to serve rather than transcribe with an unknown model.
+        if MODEL_SHA256:
+            snap_root = os.path.join(
+                MODEL_CACHE,
+                "models--" + MODEL_ID.replace("/", "--"),
+                "snapshots",
+            )
+            if os.path.isdir(snap_root):
+                snaps = [
+                    os.path.join(snap_root, d) for d in os.listdir(snap_root)
+                ]
+                target = snaps[0] if snaps else MODEL_CACHE
+            else:
+                target = MODEL_CACHE
+            got = _dir_sha256(target)
+            if not hmac.compare_digest(got, MODEL_SHA256):
+                raise RuntimeError(
+                    f"model checksum mismatch: expected {MODEL_SHA256}, got {got}"
+                )
+            _log(f"model checksum verified ({got})")
+
+        with _model_lock:
+            _model = model
+        _log("model ready")
+    except Exception as exc:  # noqa: BLE001 — fail closed, report on /healthz
+        _model_error = f"{type(exc).__name__}: {exc}"
+        _log(f"model load FAILED: {_model_error}")
+
+
+def _transcode_to_wav(raw: bytes) -> bytes:
+    """Normalize arbitrary audio (OGG/Opus, mp3, m4a, …) to 16kHz mono WAV
+    via ffmpeg so whisper's decoder gets a known format."""
+    with tempfile.NamedTemporaryFile(suffix=".in") as src:
+        src.write(raw)
+        src.flush()
+        out_path = src.name + ".wav"
+        try:
+            subprocess.run(
+                [
+                    "ffmpeg", "-nostdin", "-hide_banner", "-loglevel", "error",
+                    "-i", src.name,
+                    "-ac", "1", "-ar", "16000", "-f", "wav", out_path,
+                ],
+                check=True,
+                timeout=30,
+            )
+            with open(out_path, "rb") as fh:
+                return fh.read()
+        finally:
+            try:
+                os.unlink(out_path)
+            except OSError:
+                pass
+
+
+def _run_inference(wav: bytes, language: str | None) -> dict:
+    """The GPU-serialized inference. Acquires the concurrency semaphore so
+    only CONCURRENCY transcriptions touch the GPU at once."""
+    with _gpu_sem:
+        with tempfile.NamedTemporaryFile(suffix=".wav") as tf:
+            tf.write(wav)
+            tf.flush()
+            started = time.time()
+            segments, info = _model.transcribe(  # type: ignore[union-attr]
+                tf.name,
+                language=language or None,
+                vad_filter=True,
+            )
+            text = "".join(seg.text for seg in segments).strip()
+            return {
+                "text": text,
+                "language": getattr(info, "language", None),
+                "audioSeconds": float(getattr(info, "duration", 0.0)),
+                "durationMs": int((time.time() - started) * 1000),
+            }
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_args) -> None:  # silence default access logging
+        pass
+
+    def _send_json(self, status: int, body: dict) -> None:
+        payload = json.dumps(body).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self) -> None:  # noqa: N802 (stdlib naming)
+        if self.path.split("?")[0] != "/healthz":
+            self._send_json(404, {"ok": False, "reason": "not-found"})
+            return
+        with _model_lock:
+            ready = _model is not None
+        if ready:
+            self._send_json(200, {"ok": True, "status": "ready"})
+        else:
+            self._send_json(
+                503,
+                {"ok": False, "reason": "loading", "detail": _model_error},
+            )
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path.split("?")[0] != "/stt":
+            self._send_json(404, {"ok": False, "reason": "not-found"})
+            return
+
+        # Auth — constant-time compare of the shared secret. A sidecar with
+        # no token configured refuses every call (fail closed).
+        token = self.headers.get("X-Voice-Token", "")
+        if not SHARED_TOKEN or not hmac.compare_digest(token, SHARED_TOKEN):
+            self._send_json(401, {"ok": False, "reason": "unauthorized"})
+            return
+
+        with _model_lock:
+            ready = _model is not None
+        if not ready:
+            self._send_json(
+                503, {"ok": False, "reason": "model-not-ready", "detail": _model_error}
+            )
+            return
+
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            length = 0
+        if length <= 0:
+            self._send_json(400, {"ok": False, "reason": "empty-body"})
+            return
+        if length > MAX_BYTES + (1 << 20):  # +1MB multipart slack
+            self._send_json(
+                413, {"ok": False, "reason": "audio-too-large", "detail": str(length)}
+            )
+            return
+
+        body = self.rfile.read(length)
+        audio, language = _parse_multipart(body, self.headers.get("Content-Type", ""))
+        if audio is None or len(audio) == 0:
+            self._send_json(400, {"ok": False, "reason": "no-audio-part"})
+            return
+        if len(audio) > MAX_BYTES:
+            self._send_json(
+                413, {"ok": False, "reason": "audio-too-large", "detail": str(len(audio))}
+            )
+            return
+
+        try:
+            wav = _transcode_to_wav(audio)
+        except subprocess.TimeoutExpired:
+            self._send_json(503, {"ok": False, "reason": "transcode-timeout"})
+            return
+        except Exception as exc:  # noqa: BLE001
+            self._send_json(
+                400, {"ok": False, "reason": "transcode-failed", "detail": str(exc)[:200]}
+            )
+            return
+
+        # Run inference with a hard server-side timeout so a wedged GPU
+        # call can't pin the worker forever.
+        future = _pool.submit(_run_inference, wav, language)
+        try:
+            result = future.result(timeout=REQUEST_TIMEOUT_S)
+        except FutureTimeout:
+            self._send_json(503, {"ok": False, "reason": "timeout"})
+            return
+        except Exception as exc:  # noqa: BLE001
+            self._send_json(
+                500, {"ok": False, "reason": "inference-failed", "detail": str(exc)[:200]}
+            )
+            return
+
+        self._send_json(200, {"ok": True, **result})
+
+
+def _parse_multipart(body: bytes, content_type: str):
+    """Minimal multipart/form-data parser — extracts the `audio` part bytes
+    and an optional `language` field. Avoids a framework dependency."""
+    if "multipart/form-data" not in content_type:
+        return None, None
+    marker = "boundary="
+    idx = content_type.find(marker)
+    if idx < 0:
+        return None, None
+    boundary = content_type[idx + len(marker):].strip().strip('"')
+    delim = ("--" + boundary).encode("utf-8")
+    audio = None
+    language = None
+    for part in body.split(delim):
+        if not part or part in (b"--\r\n", b"--", b"\r\n"):
+            continue
+        header_end = part.find(b"\r\n\r\n")
+        if header_end < 0:
+            continue
+        headers = part[:header_end].decode("utf-8", "replace")
+        data = part[header_end + 4:]
+        if data.endswith(b"\r\n"):
+            data = data[:-2]
+        disp = next((l for l in headers.splitlines() if "content-disposition" in l.lower()), "")
+        if 'name="audio"' in disp:
+            audio = data
+        elif 'name="language"' in disp:
+            language = data.decode("utf-8", "replace").strip() or None
+    return audio, language
+
+
+def main() -> int:
+    if not SHARED_TOKEN:
+        _log("WARNING: VOICE_SIDECAR_TOKEN is empty — every /stt call will 401")
+    threading.Thread(target=_load_model, daemon=True).start()
+    server = ThreadingHTTPServer(("0.0.0.0", LISTEN_PORT), Handler)
+    _log(f"listening on :{LISTEN_PORT} (concurrency={CONCURRENCY})")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agents/compose-env.test.ts
+++ b/src/agents/compose-env.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit tests for composeEnvFileArgs — the #2700 fix that makes fleet
+ * `docker compose` commands load the compose-adjacent `.env` (holding
+ * VOICE_SIDECAR_TOKEN) via an explicit `--env-file`, which compose does
+ * NOT do automatically for a `-f`-specified file outside the CWD.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { composeEnvFileArgs, composeEnvPath } from "./compose-env.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "compose-env-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("composeEnvFileArgs", () => {
+  it("returns --env-file pointing at the compose-adjacent .env when present", () => {
+    const composePath = join(dir, "docker-compose.yml");
+    const envPath = composeEnvPath(composePath);
+    writeFileSync(envPath, "VOICE_SIDECAR_TOKEN=abc\n");
+    expect(composeEnvFileArgs(composePath)).toEqual(["--env-file", envPath]);
+  });
+
+  it("returns [] when the .env is absent (cloud host, no sidecar)", () => {
+    const composePath = join(dir, "docker-compose.yml");
+    expect(composeEnvFileArgs(composePath)).toEqual([]);
+  });
+
+  it("derives the .env beside the compose file, not the CWD", () => {
+    const composePath = join(dir, "compose", "docker-compose.yml");
+    expect(composeEnvPath(composePath)).toBe(join(dir, "compose", ".env"));
+  });
+});

--- a/src/agents/compose-env.ts
+++ b/src/agents/compose-env.ts
@@ -1,0 +1,30 @@
+import { existsSync } from "node:fs";
+import { dirname } from "node:path";
+
+/**
+ * Path of the compose-adjacent `.env` file for a given compose path. Holds
+ * `VOICE_SIDECAR_TOKEN` (written 0600 by the apply-time provisioner) — the
+ * value is NOT in the YAML, only here.
+ */
+export function composeEnvPath(composePath: string): string {
+  return dirname(composePath) + "/.env";
+}
+
+/**
+ * Top-level `docker compose` arguments that load the compose-adjacent `.env`.
+ *
+ * docker compose only auto-loads a `.env` from its *project directory* (which
+ * defaults to the invoking process CWD), NOT from the directory of the `-f`
+ * compose file. Every fleet command we run passes `-f <abs path>` with an
+ * unrelated CWD, so without this the compose-adjacent `.env` is never read,
+ * `${VOICE_SIDECAR_TOKEN}` interpolates to empty, and the voice sidecar 401s
+ * every `/stt` (silently degrading to "(voice message)") — #2700.
+ *
+ * Returns `[]` when the file is absent (cloud hosts emit no sidecar and write
+ * no `.env`) so compose never errors on a missing `--env-file`. The flag is a
+ * top-level option, so splice the result in BEFORE the subcommand.
+ */
+export function composeEnvFileArgs(composePath: string): string[] {
+  const envPath = composeEnvPath(composePath);
+  return existsSync(envPath) ? ["--env-file", envPath] : [];
+}

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -86,6 +86,8 @@ import { resolveAgentConfig } from "../config/merge.js";
 import { resolveTimezone } from "../config/timezone.js";
 import { isReservedAgentName } from "../vault/broker/peercred.js";
 import { getBundledSkillsPoolDir } from "./reconcile-default-skills.js";
+import { loadHostCapabilities } from "../setup/host-capabilities.js";
+import type { VoiceEngine } from "../setup/gpu-detect.js";
 
 /** UID range reserved for agent containers. 999 slots — practical fleet limit. */
 export const AGENT_UID_MIN = 10001;
@@ -468,11 +470,44 @@ export interface ComposeGeneratorOptions {
    * `describeAgents`.
    */
   litellmConfirmedAgents?: Set<string>;
+  /**
+   * The persisted voice-engine verdict (PR-B1 → PR-B2). Drives whether the
+   * `voice-sidecar` STT service is emitted: `local` emits it (GPU present +
+   * container toolkit), `cloud` omits it entirely (no service).
+   *
+   * INJECTABLE so the compose-generator stays pure and the snapshot tests
+   * can exercise BOTH branches without shelling out to real hardware. When
+   * omitted, the generator reads the persisted verdict from
+   * `loadHostCapabilities()` (defaulting to `cloud` if no verdict file
+   * exists yet), so production callers Just Work without threading it.
+   */
+  voiceEngine?: VoiceEngine;
 }
 
-/** Resolve the image ref for one of the four service images. */
+/**
+ * Reserved fixed loopback/host port for the voice STT sidecar (PR-B2).
+ *
+ * Picked in the same published-port scheme the rest of the fleet uses
+ * (hindsight = 127.0.0.1:18888). 18900 is the next free slot just above
+ * the broker/hindsight range. RESERVED — a future singleton must not
+ * reuse it, or a `local`-verdict host would collide on bind. The sidecar
+ * listens on 8126 inside the container; compose maps host 18900 → 8126.
+ *
+ * Reachability (reviewer-flagged): the sidecar must be reachable by BOTH
+ * `network_mode: host` agents (via 127.0.0.1) AND strict-isolation agents
+ * (via `host.docker.internal`/host-gateway). A pure `127.0.0.1:18900`
+ * publish is NOT reachable from a strict-isolation peer's bridge network,
+ * so we publish on `0.0.0.0:18900` (the host-gateway-reachable interface)
+ * and rely on the X-Voice-Token shared secret for safety since the bind
+ * is broader than pure loopback. See emitVoiceSidecarService.
+ */
+export const VOICE_SIDECAR_HOST_PORT = 18900;
+/** The sidecar's in-container listen port (matches Dockerfile.voice EXPOSE). */
+export const VOICE_SIDECAR_CONTAINER_PORT = 8126;
+
+/** Resolve the image ref for one of the service images. */
 function resolveImageRef(
-  name: "agent" | "broker" | "kernel" | "scheduler" | "auth-broker",
+  name: "agent" | "broker" | "kernel" | "scheduler" | "auth-broker" | "voice",
   imageTag: string,
 ): string {
   return `ghcr.io/switchroom/switchroom-${name}:${imageTag}`;
@@ -485,7 +520,7 @@ function resolveImageRef(
  */
 function emitImageOrBuild(
   lines: string[],
-  service: "agent" | "broker" | "kernel" | "scheduler" | "auth-broker",
+  service: "agent" | "broker" | "kernel" | "scheduler" | "auth-broker" | "voice",
   imageTag: string,
   buildMode: "pull" | "local",
   buildContext: string | undefined,
@@ -502,6 +537,87 @@ function emitImageOrBuild(
   } else {
     lines.push(`    image: ${resolveImageRef(service, imageTag)}`);
   }
+}
+
+/**
+ * Emit the `voice-sidecar` singleton service (PR-B2) — a local GPU
+ * speech-to-text server (faster-whisper) the gateway POSTs voice bytes to
+ * when the host's voice verdict is `local`. Caller gates emission on the
+ * verdict; this function unconditionally writes the stanza.
+ *
+ * Key design points (reviewed):
+ *  - GPU passthrough via `deploy.resources.reservations.devices` (nvidia,
+ *    count 1, capabilities ['gpu']) — the only GPU stanza in this file.
+ *  - Reachability: published on `0.0.0.0:<host>:<container>` so BOTH
+ *    host-network agents (127.0.0.1) AND strict-isolation agents (via
+ *    host.docker.internal/host-gateway) can reach it. A pure 127.0.0.1
+ *    publish would be invisible to a strict-isolation peer's bridge net.
+ *    The broader bind is made safe by the X-Voice-Token shared secret
+ *    (injected below from the vault; the gateway sends it on every /stt).
+ *  - Generous healthcheck start_period: the whisper model cold-loads in
+ *    30-90s on first boot (and re-loads on recreate), so a tight probe
+ *    would flap reconcile/`up`. The /healthz endpoint only 200s once the
+ *    model is fully loaded.
+ *  - Image-drift reconcile + doctor cover it via SINGLETON_SERVICES
+ *    (src/agents/singleton-reconcile.ts), which only manages it on a
+ *    `local` verdict.
+ */
+function emitVoiceSidecarService(
+  lines: string[],
+  imageTag: string,
+  buildMode: "pull" | "local",
+  buildContext: string | undefined,
+  containerNamePrefix: string,
+): void {
+  lines.push(`  voice-sidecar:`);
+  emitImageOrBuild(lines, "voice", imageTag, buildMode, buildContext);
+  lines.push(`    container_name: ${containerNamePrefix}-voice-sidecar`);
+  lines.push(`    labels:`);
+  lines.push(`      switchroom.role: "voice-sidecar"`);
+  lines.push(`      switchroom.fleet: "${containerNamePrefix}"`);
+  lines.push(`    restart: always`);
+  // GPU passthrough — requires the nvidia-container-toolkit on the host
+  // (the PR-B1 `containerToolkit` probe; a `local` verdict implies it).
+  lines.push(`    deploy:`);
+  lines.push(`      resources:`);
+  lines.push(`        reservations:`);
+  lines.push(`          devices:`);
+  lines.push(`            - driver: nvidia`);
+  lines.push(`              count: 1`);
+  lines.push(`              capabilities: ["gpu"]`);
+  // Reachable from both host-net and strict-isolation agents — see the
+  // function doc. Publish on all interfaces; the shared-secret header is
+  // the access gate, not the bind address.
+  lines.push(`    ports:`);
+  lines.push(
+    `      - "0.0.0.0:${VOICE_SIDECAR_HOST_PORT}:${VOICE_SIDECAR_CONTAINER_PORT}"`,
+  );
+  // /healthz returns 200 only once the model is loaded. start_period is
+  // generous (model cold-load 30-90s) so reconcile/`up` doesn't flap.
+  lines.push(`    healthcheck:`);
+  lines.push(
+    `      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:${VOICE_SIDECAR_CONTAINER_PORT}/healthz >/dev/null || exit 1"]`,
+  );
+  lines.push(`      interval: 30s`);
+  lines.push(`      timeout: 5s`);
+  lines.push(`      retries: 3`);
+  lines.push(`      start_period: 120s`);
+  lines.push(`    stop_grace_period: 10s`);
+  lines.push(`    security_opt:`);
+  lines.push(`      - "no-new-privileges:true"`);
+  lines.push(`    environment:`);
+  // Shared-secret auth token — a `vault:` reference resolved by the
+  // sidecar's broker/entry at boot, mirroring the LiteLLM-key pattern:
+  // the literal secret is NEVER baked into compose. The container resolves
+  // VOICE_SIDECAR_TOKEN from the vault (voice/sidecar-token) and the
+  // gateway sends the same secret in the X-Voice-Token header.
+  lines.push(`      VOICE_SIDECAR_TOKEN: \${VOICE_SIDECAR_TOKEN}`);
+  lines.push(`      VOICE_STT_PORT: "${VOICE_SIDECAR_CONTAINER_PORT}"`);
+  lines.push(`    volumes:`);
+  // Fetch-once model weights persist here across recreate (never baked
+  // into the image — size + weight-redistribution licensing).
+  lines.push(`      - voice-model-cache:/models`);
+  lines.push(``);
 }
 
 interface AgentServiceData {
@@ -1080,6 +1196,13 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // calls Just Work; tests pass an explicit path (or "") to override.
   const bundledSkillsPoolDir = opts.bundledSkillsPoolDir ?? getBundledSkillsPoolDir();
 
+  // Voice-engine verdict (PR-B1 → PR-B2). Injectable for snapshot tests;
+  // production reads the persisted verdict. Default `cloud` (no sidecar)
+  // when no verdict file exists — fail-safe: never emit a GPU service on a
+  // host we haven't confirmed has a usable GPU.
+  const voiceEngine: VoiceEngine =
+    opts.voiceEngine ?? loadHostCapabilities()?.voice.engine ?? "cloud";
+
   // Resolve the host's analytics distinct ID once per generator call. The
   // CLI persists this at ~/.switchroom/analytics-id (see
   // src/analytics/posthog.ts:getDistinctId). Threading it through to the
@@ -1552,6 +1675,20 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`      - ${homePrefix}/.switchroom/state/auth-broker:/state/auth-broker`);
   lines.push(``);
 
+  // ── voice-sidecar (singleton, GPU STT — PR-B2) ─────────────────────
+  // Emitted ONLY on a `local` voice verdict (GPU present + container
+  // toolkit, per PR-B1). On `cloud` we emit nothing — voice-in routes
+  // through the OpenAI provider instead.
+  if (voiceEngine === "local") {
+    emitVoiceSidecarService(
+      lines,
+      imageTag,
+      buildMode,
+      buildContext,
+      containerNamePrefix,
+    );
+  }
+
   // ── per-agent services ─────────────────────────────────────────────
   for (const a of describeAgents(config, opts.litellmConfirmedAgents)) {
     if (a.strippedCaps.length > 0) {
@@ -1595,6 +1732,12 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
     // compose project, so the prefix is invisible.
     lines.push(`  auth-broker-${c.name}-sock:`);
     lines.push(`    name: auth-broker-${c.name}-sock`);
+  }
+  // Named volume for the voice sidecar's fetch-once model weights —
+  // only declared when the sidecar service is emitted (local verdict).
+  // Keeps weights out of the image (size + redistribution licensing).
+  if (voiceEngine === "local") {
+    lines.push(`  voice-model-cache:`);
   }
   lines.push("");
 

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -606,11 +606,15 @@ function emitVoiceSidecarService(
   lines.push(`    security_opt:`);
   lines.push(`      - "no-new-privileges:true"`);
   lines.push(`    environment:`);
-  // Shared-secret auth token — a `vault:` reference resolved by the
-  // sidecar's broker/entry at boot, mirroring the LiteLLM-key pattern:
-  // the literal secret is NEVER baked into compose. The container resolves
-  // VOICE_SIDECAR_TOKEN from the vault (voice/sidecar-token) and the
-  // gateway sends the same secret in the X-Voice-Token header.
+  // Shared-secret auth token — a docker-compose `${...}` interpolation, NOT
+  // a literal secret (the secret is NEVER baked into this YAML). At apply
+  // time, on a `local` verdict, `switchroom apply` seeds the token in the
+  // vault (voice/sidecar-token) if absent and writes it to the
+  // compose-adjacent `.env`, which docker reads to populate this var (see
+  // src/cli/voice-sidecar-token.ts). The pure-Python sidecar reads it
+  // straight from its env (docker/voice-sidecar/server.py) — it has no
+  // broker client. The gateway resolves the SAME vault key at use-time and
+  // sends it in the X-Voice-Token header.
   lines.push(`      VOICE_SIDECAR_TOKEN: \${VOICE_SIDECAR_TOKEN}`);
   lines.push(`      VOICE_STT_PORT: "${VOICE_SIDECAR_CONTAINER_PORT}"`);
   lines.push(`    volumes:`);

--- a/src/agents/docker-fleet.ts
+++ b/src/agents/docker-fleet.ts
@@ -21,6 +21,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { generateCompose } from "./compose.js";
+import { composeEnvFileArgs } from "./compose-env.js";
 import { findConfigFile } from "../config/loader.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
@@ -153,6 +154,7 @@ export function bringUpAgentService(
         "compose",
         "-f",
         composePath,
+        ...composeEnvFileArgs(composePath),
         "up",
         "-d",
         "--no-deps",
@@ -169,6 +171,7 @@ export function bringUpAgentService(
       "compose",
       "-f",
       composePath,
+      ...composeEnvFileArgs(composePath),
       "up",
       "-d",
       "--no-deps",

--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -8,6 +8,7 @@ import { resolveAgentConfig } from "../config/merge.js";
 import { loadConfig } from "../config/loader.js";
 import { sendAgentInterrupt } from "./tmux.js";
 import { resolveSwitchroomHome } from "./docker-fleet.js";
+import { composeEnvFileArgs } from "./compose-env.js";
 import {
   reconcileSingletons,
   type ReconcileResult,
@@ -179,7 +180,7 @@ function dockerSync(args: string[]): string {
  * Build a `docker compose -p <project> -f <file>` argv prefix.
  */
 function composeArgs(extra: string[]): string[] {
-  return ["compose", "-p", COMPOSE_PROJECT, "-f", composeFilePath(), ...extra];
+  return ["compose", "-p", COMPOSE_PROJECT, "-f", composeFilePath(), ...composeEnvFileArgs(composeFilePath()), ...extra];
 }
 
 /**

--- a/src/agents/singleton-reconcile.test.ts
+++ b/src/agents/singleton-reconcile.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  CORE_SINGLETON_SERVICES,
   SINGLETON_SERVICES,
+  VOICE_SIDECAR_SERVICE,
   detectSingletonDrift,
   readPinnedSingletonImages,
   reconcileSingletons,
+  resolveSingletonServices,
   singletonContainerName,
 } from "./singleton-reconcile.js";
 
@@ -21,18 +24,97 @@ services:
 `;
 
 describe("singleton service/container naming", () => {
-  it("covers all three singletons", () => {
-    expect([...SINGLETON_SERVICES]).toEqual([
+  it("covers the three core singletons", () => {
+    expect([...CORE_SINGLETON_SERVICES]).toEqual([
       "vault-broker",
       "approval-kernel",
       "switchroom-auth-broker",
     ]);
   });
 
+  it("the full universe also includes voice-sidecar (the conditional singleton)", () => {
+    expect([...SINGLETON_SERVICES]).toEqual([
+      "vault-broker",
+      "approval-kernel",
+      "switchroom-auth-broker",
+      "voice-sidecar",
+    ]);
+    expect(VOICE_SIDECAR_SERVICE).toBe("voice-sidecar");
+  });
+
   it("prefixes container names, leaving the already-prefixed auth-broker intact", () => {
     expect(singletonContainerName("vault-broker")).toBe("switchroom-vault-broker");
     expect(singletonContainerName("approval-kernel")).toBe("switchroom-approval-kernel");
     expect(singletonContainerName("switchroom-auth-broker")).toBe("switchroom-auth-broker");
+  });
+});
+
+const COMPOSE_LOCAL = `
+services:
+  vault-broker:
+    image: ghcr.io/switchroom/switchroom-broker:v0.14.66
+  approval-kernel:
+    image: ghcr.io/switchroom/switchroom-kernel:v0.14.66
+  switchroom-auth-broker:
+    image: ghcr.io/switchroom/switchroom-auth-broker:v0.14.66
+  voice-sidecar:
+    image: ghcr.io/switchroom/switchroom-voice:v0.14.66
+`;
+
+describe("resolveSingletonServices — voice-sidecar is verdict-gated (PR-B2)", () => {
+  it("includes voice-sidecar ONLY on a local verdict", () => {
+    expect(resolveSingletonServices("local")).toEqual([
+      "vault-broker",
+      "approval-kernel",
+      "switchroom-auth-broker",
+      "voice-sidecar",
+    ]);
+  });
+
+  it("omits voice-sidecar on a cloud verdict", () => {
+    expect(resolveSingletonServices("cloud")).toEqual([
+      "vault-broker",
+      "approval-kernel",
+      "switchroom-auth-broker",
+    ]);
+    expect(resolveSingletonServices("cloud")).not.toContain("voice-sidecar");
+  });
+});
+
+describe("detectSingletonDrift — voice-sidecar gating", () => {
+  it("manages voice-sidecar on a local verdict (flags its drift)", () => {
+    const running: Record<string, string> = {
+      "switchroom-vault-broker": "ghcr.io/switchroom/switchroom-broker:v0.14.66",
+      "switchroom-approval-kernel": "ghcr.io/switchroom/switchroom-kernel:v0.14.66",
+      "switchroom-auth-broker": "ghcr.io/switchroom/switchroom-auth-broker:v0.14.66",
+      "switchroom-voice-sidecar": "ghcr.io/switchroom/switchroom-voice:v0.14.24", // STALE
+    };
+    const drift = detectSingletonDrift({
+      composeFile: "x",
+      readCompose: () => COMPOSE_LOCAL,
+      voiceEngine: "local",
+      inspectImage: (c) => running[c] ?? null,
+    });
+    const vs = drift.find((d) => d.service === "voice-sidecar")!;
+    expect(vs).toBeDefined();
+    expect(vs.needsRecreate).toBe(true);
+    expect(vs.pinned).toContain("switchroom-voice:v0.14.66");
+  });
+
+  it("does NOT manage voice-sidecar on a cloud verdict (never flags it absent)", () => {
+    const drift = detectSingletonDrift({
+      composeFile: "x",
+      readCompose: () => COMPOSE, // no voice-sidecar service
+      voiceEngine: "cloud",
+      inspectImage: () => null, // everything absent
+    });
+    // voice-sidecar is not even considered on a cloud host.
+    expect(drift.find((d) => d.service === "voice-sidecar")).toBeUndefined();
+    expect(drift.map((d) => d.service)).toEqual([
+      "vault-broker",
+      "approval-kernel",
+      "switchroom-auth-broker",
+    ]);
   });
 });
 
@@ -73,6 +155,7 @@ describe("detectSingletonDrift", () => {
     const drift = detectSingletonDrift({
       composeFile: "x",
       readCompose: () => COMPOSE,
+      voiceEngine: "cloud",
       inspectImage: (c) => running[c] ?? null,
     });
     const byService = Object.fromEntries(drift.map((d) => [d.service, d]));
@@ -87,6 +170,7 @@ describe("detectSingletonDrift", () => {
     const drift = detectSingletonDrift({
       composeFile: "x",
       readCompose: () => COMPOSE,
+      voiceEngine: "cloud",
       inspectImage: () => null, // all absent / docker unreachable
     });
     for (const d of drift) {
@@ -104,6 +188,7 @@ services:
     const drift = detectSingletonDrift({
       composeFile: "x",
       readCompose: () => buildLocal,
+      voiceEngine: "cloud",
       inspectImage: () => "some-local-build:dev",
     });
     const vb = drift.find((d) => d.service === "vault-broker")!;
@@ -123,6 +208,7 @@ describe("reconcileSingletons", () => {
     const res = reconcileSingletons({
       composeFile: "x",
       readCompose: () => COMPOSE,
+      voiceEngine: "cloud",
       inspectImage: (c) => running[c] ?? null,
       recreate: (svc) => recreated.push(svc),
       log: () => {},
@@ -137,6 +223,7 @@ describe("reconcileSingletons", () => {
     const res = reconcileSingletons({
       composeFile: "x",
       readCompose: () => COMPOSE,
+      voiceEngine: "cloud",
       inspectImage: (c) =>
         ({
           "switchroom-vault-broker": "ghcr.io/switchroom/switchroom-broker:v0.14.66",
@@ -156,6 +243,7 @@ describe("reconcileSingletons", () => {
     const res = reconcileSingletons({
       composeFile: "x",
       readCompose: () => COMPOSE,
+      voiceEngine: "cloud",
       inspectImage: (c) =>
         c === "switchroom-auth-broker"
           ? "ghcr.io/switchroom/switchroom-auth-broker:v0.14.24"
@@ -173,6 +261,7 @@ describe("reconcileSingletons", () => {
     const res = reconcileSingletons({
       composeFile: "x",
       readCompose: () => COMPOSE,
+      voiceEngine: "cloud",
       inspectImage: () => "ghcr.io/switchroom/switchroom-x:v0.14.24", // all stale
       recreate: (svc) => {
         if (svc === "approval-kernel") throw new Error("docker daemon down");

--- a/src/agents/singleton-reconcile.ts
+++ b/src/agents/singleton-reconcile.ts
@@ -32,18 +32,55 @@ import { readFileSync } from "node:fs";
 
 import { parse as parseYaml } from "yaml";
 
+import { loadHostCapabilities } from "../setup/host-capabilities.js";
+
 /**
- * Compose SERVICE names for the singletons (note: the auth-broker
- * service is already `switchroom-`-prefixed in the generated compose,
- * the other two are not — see `src/agents/compose.ts`).
+ * Compose SERVICE names for the singletons that are ALWAYS present (note:
+ * the auth-broker service is already `switchroom-`-prefixed in the
+ * generated compose, the other two are not — see `src/agents/compose.ts`).
  */
-export const SINGLETON_SERVICES = [
+export const CORE_SINGLETON_SERVICES = [
   "vault-broker",
   "approval-kernel",
   "switchroom-auth-broker",
 ] as const;
 
+/**
+ * The voice STT sidecar is a CONDITIONAL singleton: it's only emitted into
+ * the compose (and therefore only manageable here) on a `local` voice
+ * verdict (GPU present + container toolkit, per PR-B1). On a `cloud` host
+ * it isn't in the compose at all, so it must NOT be flagged as
+ * missing/unhealthy by drift reconcile or doctor. See `resolveSingletonServices`.
+ */
+export const VOICE_SIDECAR_SERVICE = "voice-sidecar";
+
+/**
+ * The full universe of singleton service names (for the union type). The
+ * RUNTIME set is verdict-gated — see `resolveSingletonServices`.
+ */
+export const SINGLETON_SERVICES = [
+  ...CORE_SINGLETON_SERVICES,
+  VOICE_SIDECAR_SERVICE,
+] as const;
+
 export type SingletonService = (typeof SINGLETON_SERVICES)[number];
+
+/**
+ * Resolve which singleton services to manage on THIS host. Always the three
+ * core singletons; plus `voice-sidecar` ONLY when the voice verdict is
+ * `local` (so a cloud host never reports the sidecar as drifted/absent).
+ *
+ * `voiceEngine` is injectable for tests; production reads the persisted
+ * PR-B1 verdict (defaults to `cloud` — no sidecar — when no verdict exists).
+ */
+export function resolveSingletonServices(
+  voiceEngine?: "local" | "cloud",
+): SingletonService[] {
+  const engine = voiceEngine ?? loadHostCapabilities()?.voice.engine ?? "cloud";
+  return engine === "local"
+    ? [...CORE_SINGLETON_SERVICES, VOICE_SIDECAR_SERVICE]
+    : [...CORE_SINGLETON_SERVICES];
+}
 
 /** Map a singleton service name to its container name. */
 export function singletonContainerName(svc: string): string {
@@ -78,6 +115,12 @@ export interface SingletonReconcileDeps {
   dockerBin?: string;
   /** compose project (default "switchroom"). */
   project?: string;
+  /**
+   * Voice verdict override (testing). When omitted, the persisted PR-B1
+   * verdict decides whether `voice-sidecar` is managed (local) or skipped
+   * (cloud) — see `resolveSingletonServices`.
+   */
+  voiceEngine?: "local" | "cloud";
 }
 
 /**
@@ -86,6 +129,7 @@ export interface SingletonReconcileDeps {
  */
 export function readPinnedSingletonImages(
   composeText: string,
+  services: readonly SingletonService[] = SINGLETON_SERVICES,
 ): Partial<Record<SingletonService, string>> {
   let doc: { services?: Record<string, { image?: unknown }> } | undefined;
   try {
@@ -94,7 +138,7 @@ export function readPinnedSingletonImages(
     return {};
   }
   const out: Partial<Record<SingletonService, string>> = {};
-  for (const svc of SINGLETON_SERVICES) {
+  for (const svc of services) {
     const img = doc?.services?.[svc]?.image;
     if (typeof img === "string" && img.length > 0) out[svc] = img;
   }
@@ -128,14 +172,18 @@ export function detectSingletonDrift(
   const inspectImage =
     deps.inspectImage ?? ((c) => defaultInspectImage(dockerBin, c));
 
+  // Verdict-gated service set: core singletons always, voice-sidecar only
+  // on a `local` host (so a cloud host never flags the sidecar as drifted).
+  const services = resolveSingletonServices(deps.voiceEngine);
+
   let pinned: Partial<Record<SingletonService, string>> = {};
   try {
-    pinned = readPinnedSingletonImages(readCompose(deps.composeFile));
+    pinned = readPinnedSingletonImages(readCompose(deps.composeFile), services);
   } catch {
     pinned = {};
   }
 
-  return SINGLETON_SERVICES.map((service) => {
+  return services.map((service) => {
     const container = singletonContainerName(service);
     const running = inspectImage(container);
     const pin = pinned[service] ?? null;

--- a/src/agents/singleton-reconcile.ts
+++ b/src/agents/singleton-reconcile.ts
@@ -33,6 +33,7 @@ import { readFileSync } from "node:fs";
 import { parse as parseYaml } from "yaml";
 
 import { loadHostCapabilities } from "../setup/host-capabilities.js";
+import { composeEnvFileArgs } from "./compose-env.js";
 
 /**
  * Compose SERVICE names for the singletons that are ALWAYS present (note:
@@ -206,7 +207,7 @@ function defaultRecreate(
   // confirmed drift. --no-deps so we don't recursively bounce agents.
   execFileSync(
     dockerBin,
-    ["compose", "-p", project, "-f", composeFile, "up", "-d", "--no-deps", service],
+    ["compose", "-p", project, "-f", composeFile, ...composeEnvFileArgs(composeFile), "up", "-d", "--no-deps", service],
     { stdio: ["ignore", "pipe", "pipe"], timeout: 120_000 },
   );
 }

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -231,7 +231,7 @@ function effectiveLiteLLMEnabled(
  * passphrase host with no env var) — the caller then records a clear failure
  * rather than blocking apply on a TTY prompt.
  */
-async function resolveOperatorVaultPassphrase(home: string): Promise<string | null> {
+export async function resolveOperatorVaultPassphrase(home: string): Promise<string | null> {
   const envPass = process.env.SWITCHROOM_VAULT_PASSPHRASE;
   if (envPass) return envPass;
   try {
@@ -1396,6 +1396,21 @@ export async function runApply(
     buildMode: options.buildLocal ? "local" : "pull",
     buildContext: options.buildContext,
   });
+
+  // ── 3b. Voice-sidecar token (PR-B2) ───────────────────────────────
+  // On a `local` voice verdict the compose emits a `voice-sidecar` service
+  // whose env reads `${VOICE_SIDECAR_TOKEN}`. Seed the shared secret in the
+  // vault (idempotent) and write it to the compose-adjacent `.env` (0600)
+  // so docker's interpolation populates the container env — the secret is
+  // never baked into the YAML. No-op on a cloud verdict.
+  if (!skipScaffold) {
+    const { provisionVoiceSidecarToken } = await import("./voice-sidecar-token.js");
+    await provisionVoiceSidecarToken(composePath, homedir(), {
+      writeOut,
+      writeErr,
+      operatorUid,
+    });
+  }
 
   writeOut(
     chalk.bold(`\nWrote `) +

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -43,6 +43,7 @@ import { join, dirname, resolve } from "node:path";
 import { homedir } from "node:os";
 import { loadConfig, findConfigFile } from "../config/loader.js";
 import { writeRestartReasonMarker } from "../agents/lifecycle.js";
+import { composeEnvFileArgs } from "../agents/compose-env.js";
 import { setReleasePinInConfig } from "./release-yaml.js";
 import { resolveOperatorUid } from "./operator-uid.js";
 import { writeConfigFileSync } from "../util/atomic.js";
@@ -399,7 +400,9 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
         : undefined,
     run: () => {
       const r = runner("docker", [
-        "compose", "-p", "switchroom", "-f", composePath, "pull",
+        "compose", "-p", "switchroom", "-f", composePath,
+        ...composeEnvFileArgs(composePath),
+        "pull",
       ]);
       if (r.status !== 0) throw new Error("docker compose pull failed");
     },
@@ -723,7 +726,9 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
         throw new Error(`pre-flight bind-source check failed: ${e instanceof Error ? e.message : String(e)}`);
       }
       const r = runner("docker", [
-        "compose", "-p", "switchroom", "-f", composePath, "up", "-d",
+        "compose", "-p", "switchroom", "-f", composePath,
+        ...composeEnvFileArgs(composePath),
+        "up", "-d",
         "--remove-orphans",
       ]);
       if (r.status !== 0) throw new Error("docker compose up failed");

--- a/src/cli/voice-sidecar-token.test.ts
+++ b/src/cli/voice-sidecar-token.test.ts
@@ -79,6 +79,41 @@ describe("provisionVoiceSidecarToken", () => {
     expect(readFileSync(envPath, "utf-8")).toBe("OPERATOR_THING=1\n");
   });
 
+  it("upserts only the token key, preserving operator-placed lines", async () => {
+    const composePath = join(dir, "docker-compose.yml");
+    const envPath = composeEnvPath(composePath);
+    // Operator-managed .env with an unrelated key and a stale token value.
+    writeFileSync(envPath, `OPERATOR_THING=1\n${VOICE_SIDECAR_TOKEN_ENV}=stale\nKEEP=2\n`);
+    await provisionVoiceSidecarToken(composePath, dir, {
+      writeOut: noop,
+      writeErr: noop,
+      voiceEngine: "local",
+      resolveOrSeedToken: async () => "freshtoken",
+    });
+    const body = readFileSync(envPath, "utf-8");
+    // Token line replaced in place; the operator's other lines survive.
+    expect(body).toContain(`${VOICE_SIDECAR_TOKEN_ENV}=freshtoken`);
+    expect(body).not.toContain("stale");
+    expect(body).toContain("OPERATOR_THING=1");
+    expect(body).toContain("KEEP=2");
+    expect(statSync(envPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("appends the token key when the .env exists without it", async () => {
+    const composePath = join(dir, "docker-compose.yml");
+    const envPath = composeEnvPath(composePath);
+    writeFileSync(envPath, "OPERATOR_THING=1\n");
+    await provisionVoiceSidecarToken(composePath, dir, {
+      writeOut: noop,
+      writeErr: noop,
+      voiceEngine: "local",
+      resolveOrSeedToken: async () => "freshtoken",
+    });
+    expect(readFileSync(envPath, "utf-8")).toBe(
+      `OPERATOR_THING=1\n${VOICE_SIDECAR_TOKEN_ENV}=freshtoken\n`,
+    );
+  });
+
   it("does not write (and does not throw) when the token can't be resolved", async () => {
     const composePath = join(dir, "docker-compose.yml");
     let warned = false;

--- a/src/cli/voice-sidecar-token.test.ts
+++ b/src/cli/voice-sidecar-token.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for the voice-sidecar token → compose `.env` writer (PR-B2).
+ *
+ * The vault/broker interaction is injected (resolveOrSeedToken) so this
+ * test NEVER touches the real broker or the operator's vault — it only
+ * exercises the `.env` write/cleanup + verdict gating.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  composeEnvPath,
+  provisionVoiceSidecarToken,
+  VOICE_SIDECAR_TOKEN_ENV,
+} from "./voice-sidecar-token.js";
+
+let dir: string;
+const noop = () => {};
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "voice-token-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("provisionVoiceSidecarToken", () => {
+  it("writes <composeDir>/.env with the token on a local verdict", async () => {
+    const composePath = join(dir, "docker-compose.yml");
+    await provisionVoiceSidecarToken(composePath, dir, {
+      writeOut: noop,
+      writeErr: noop,
+      voiceEngine: "local",
+      resolveOrSeedToken: async () => "abc123token",
+    });
+    const envPath = composeEnvPath(composePath);
+    expect(existsSync(envPath)).toBe(true);
+    expect(readFileSync(envPath, "utf-8")).toBe(`${VOICE_SIDECAR_TOKEN_ENV}=abc123token\n`);
+    // 0600 — the token is a secret.
+    expect(statSync(envPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("does NOT write a .env on a cloud verdict", async () => {
+    const composePath = join(dir, "docker-compose.yml");
+    await provisionVoiceSidecarToken(composePath, dir, {
+      writeOut: noop,
+      writeErr: noop,
+      voiceEngine: "cloud",
+      resolveOrSeedToken: async () => "should-not-be-used",
+    });
+    expect(existsSync(composeEnvPath(composePath))).toBe(false);
+  });
+
+  it("removes a stale token .env when the verdict flips to cloud", async () => {
+    const composePath = join(dir, "docker-compose.yml");
+    const envPath = composeEnvPath(composePath);
+    writeFileSync(envPath, `${VOICE_SIDECAR_TOKEN_ENV}=old\n`);
+    await provisionVoiceSidecarToken(composePath, dir, {
+      writeOut: noop,
+      writeErr: noop,
+      voiceEngine: "cloud",
+    });
+    expect(existsSync(envPath)).toBe(false);
+  });
+
+  it("leaves an operator-managed .env (no token var) untouched on cloud", async () => {
+    const composePath = join(dir, "docker-compose.yml");
+    const envPath = composeEnvPath(composePath);
+    writeFileSync(envPath, "OPERATOR_THING=1\n");
+    await provisionVoiceSidecarToken(composePath, dir, {
+      writeOut: noop,
+      writeErr: noop,
+      voiceEngine: "cloud",
+    });
+    expect(existsSync(envPath)).toBe(true);
+    expect(readFileSync(envPath, "utf-8")).toBe("OPERATOR_THING=1\n");
+  });
+
+  it("does not write (and does not throw) when the token can't be resolved", async () => {
+    const composePath = join(dir, "docker-compose.yml");
+    let warned = false;
+    await provisionVoiceSidecarToken(composePath, dir, {
+      writeOut: noop,
+      writeErr: () => {
+        warned = true;
+      },
+      voiceEngine: "local",
+      resolveOrSeedToken: async () => null,
+    });
+    expect(existsSync(composeEnvPath(composePath))).toBe(false);
+    // resolveOrSeedToken itself owns the warning; here it returned null
+    // silently, so we just assert no .env and no throw.
+    expect(warned).toBe(false);
+  });
+});

--- a/src/cli/voice-sidecar-token.ts
+++ b/src/cli/voice-sidecar-token.ts
@@ -36,13 +36,16 @@
  */
 
 import { randomBytes } from "node:crypto";
-import { chownSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, chownSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 import chalk from "chalk";
 
+import { composeEnvPath } from "../agents/compose-env.js";
 import { loadHostCapabilities } from "../setup/host-capabilities.js";
 import { VOICE_SIDECAR_TOKEN_KEY } from "../telegram/materialize-sidecar-token.js";
+
+export { composeEnvPath };
 
 /** The compose `.env` variable name docker interpolates into the service. */
 export const VOICE_SIDECAR_TOKEN_ENV = "VOICE_SIDECAR_TOKEN";
@@ -63,11 +66,6 @@ export interface ProvisionSidecarTokenCtx {
    * Returns the token string, or null on unrecoverable failure.
    */
   resolveOrSeedToken?: () => Promise<string | null>;
-}
-
-/** Path of the compose-adjacent `.env` file for a given compose path. */
-export function composeEnvPath(composePath: string): string {
-  return dirname(composePath) + "/.env";
 }
 
 /**
@@ -180,13 +178,33 @@ export async function provisionVoiceSidecarToken(
 
   try {
     mkdirSync(dirname(envPath), { recursive: true });
-    // Write 0600 — the token is a secret. docker compose reads this `.env`
-    // from the compose file's directory automatically; the value is NOT in
-    // the YAML, only here.
-    writeFileSync(envPath, `${VOICE_SIDECAR_TOKEN_ENV}=${token}\n`, {
+    // Upsert just our key — preserve any other lines an operator placed in
+    // this `.env` (it becomes a real interpolation surface once the fleet
+    // `up` loads it via `--env-file`, see composeEnvFileArgs / #2700). Write
+    // 0600 — the token is a secret; the value lives only here, never in YAML.
+    // docker does NOT auto-read this file (it's beside the `-f` compose, not
+    // in the compose CWD), so the fleet commands pass `--env-file` explicitly.
+    let body = "";
+    try {
+      if (existsSync(envPath)) body = readFileSync(envPath, "utf-8");
+    } catch {
+      /* unreadable — fall back to a fresh write */
+    }
+    const line = `${VOICE_SIDECAR_TOKEN_ENV}=${token}`;
+    const keyRe = new RegExp(`^${VOICE_SIDECAR_TOKEN_ENV}=.*$`, "m");
+    const next = keyRe.test(body)
+      ? body.replace(keyRe, line)
+      : (body.length > 0 && !body.endsWith("\n") ? body + "\n" : body) +
+        line +
+        "\n";
+    writeFileSync(envPath, next, {
       encoding: "utf-8",
       mode: 0o600,
     });
+    // `mode` in writeFileSync only applies when CREATING the file; an
+    // upsert over an existing operator `.env` would keep its old (possibly
+    // 0644) perms and leave the token world-readable. Force 0600 always.
+    chmodSync(envPath, 0o600);
     // Keep operator-owned when written under sudo (mirrors writeComposeFile).
     if (ctx.operatorUid !== undefined && process.geteuid?.() === 0) {
       try {

--- a/src/cli/voice-sidecar-token.ts
+++ b/src/cli/voice-sidecar-token.ts
@@ -1,0 +1,209 @@
+/**
+ * Voice-sidecar shared-secret provisioning + compose `.env` injection
+ * (voice feature PR-B2, the consuming side of src/agents/compose.ts).
+ *
+ * The generated compose emits `VOICE_SIDECAR_TOKEN: ${VOICE_SIDECAR_TOKEN}`
+ * on the `voice-sidecar` service (a docker-compose interpolation, NOT a
+ * literal secret — the secret never lands in the committed/generated YAML).
+ * docker compose populates `${VOICE_SIDECAR_TOKEN}` from a `.env` file in
+ * the same directory as the compose file. This module writes that `.env`.
+ *
+ * Why a `.env` file and not the LiteLLM `start.sh`-fetches-from-vault
+ * pattern: the LiteLLM secret reaches an AGENT container, which runs the
+ * `switchroom` CLI and can talk to the vault broker at boot. The
+ * voice-sidecar container is a pure-Python faster-whisper server
+ * (docker/voice-sidecar/server.py) with NO switchroom CLI and NO broker
+ * socket mounted — it reads VOICE_SIDECAR_TOKEN straight from its
+ * environment (server.py:65). So the cleanest way to get the vault secret
+ * into its env, without baking it into the image or the YAML, is the
+ * standard docker-compose `.env` interpolation file, written 0600 at apply
+ * time and regenerated on every apply. The TOKEN itself is sourced from the
+ * vault (`voice/sidecar-token`), the SAME key the gateway resolves at
+ * use-time (src/telegram/materialize-sidecar-token.ts) — single source of
+ * truth, both ends agree.
+ *
+ * Gating: this only runs on a `local` voice verdict (GPU present). On a
+ * `cloud` verdict no sidecar service is emitted, so no `.env` is needed —
+ * and we proactively remove any stale `.env` so a host that lost its GPU
+ * doesn't leave a token lying around.
+ *
+ * Seeding: if `voice/sidecar-token` doesn't exist yet, generate a random
+ * 256-bit hex secret and store it in the vault (operator-attested put,
+ * mirroring provisionLiteLLMKeys). Idempotent — a subsequent apply reuses
+ * the stored token. Best-effort: any failure is surfaced as a warning and
+ * leaves the sidecar without a token (it then 401s every /stt and the
+ * gateway falls back to "(voice message)") — never blocks apply.
+ */
+
+import { randomBytes } from "node:crypto";
+import { chownSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import chalk from "chalk";
+
+import { loadHostCapabilities } from "../setup/host-capabilities.js";
+import { VOICE_SIDECAR_TOKEN_KEY } from "../telegram/materialize-sidecar-token.js";
+
+/** The compose `.env` variable name docker interpolates into the service. */
+export const VOICE_SIDECAR_TOKEN_ENV = "VOICE_SIDECAR_TOKEN";
+
+export interface ProvisionSidecarTokenCtx {
+  writeOut: (s: string) => void;
+  writeErr: (s: string) => void;
+  /** Operator UID for chowning the `.env` when running under sudo. */
+  operatorUid?: number;
+  /**
+   * Override the voice verdict (testing). When omitted, reads the persisted
+   * host-capabilities verdict (defaults to `cloud` when no file exists).
+   */
+  voiceEngine?: "local" | "cloud";
+  /**
+   * Resolve the token from the vault, seeding a fresh one if absent.
+   * Injectable for tests so they never touch the real broker/vault.
+   * Returns the token string, or null on unrecoverable failure.
+   */
+  resolveOrSeedToken?: () => Promise<string | null>;
+}
+
+/** Path of the compose-adjacent `.env` file for a given compose path. */
+export function composeEnvPath(composePath: string): string {
+  return dirname(composePath) + "/.env";
+}
+
+/**
+ * Resolve the sidecar token from the vault, seeding a random one if the key
+ * doesn't exist yet. Operator-attested via the same passphrase recovery the
+ * LiteLLM provisioner uses. Returns null on any unrecoverable failure.
+ */
+async function defaultResolveOrSeedToken(
+  home: string,
+  writeErr: (s: string) => void,
+): Promise<string | null> {
+  const [{ getViaBrokerStructured, putViaBroker }, { resolveOperatorVaultPassphrase }] =
+    await Promise.all([
+      import("../vault/broker/client.js"),
+      import("./apply.js"),
+    ]);
+
+  // Already seeded? Reuse it (idempotent — token is stable across applies).
+  try {
+    const existing = await getViaBrokerStructured(VOICE_SIDECAR_TOKEN_KEY);
+    if (existing.kind === "ok") {
+      const entry = existing.entry;
+      if (entry.kind === "string" || entry.kind === "binary") return entry.value;
+    }
+  } catch {
+    /* fall through to seeding */
+  }
+
+  // Need to seed — requires operator attestation to write a NEW vault key.
+  const passphrase = await resolveOperatorVaultPassphrase(home);
+  if (passphrase === null) {
+    writeErr(
+      chalk.yellow(
+        `  ⚠ voice: vault passphrase unavailable — cannot seed ${VOICE_SIDECAR_TOKEN_KEY}. ` +
+        `Run \`switchroom apply\` interactively (operator console or SWITCHROOM_VAULT_PASSPHRASE) ` +
+        `once to provision the sidecar token.\n`,
+      ),
+    );
+    return null;
+  }
+
+  const token = randomBytes(32).toString("hex");
+  const put = await putViaBroker(
+    VOICE_SIDECAR_TOKEN_KEY,
+    { kind: "string", value: token },
+    { passphrase },
+  );
+  if (put.kind !== "ok") {
+    writeErr(
+      chalk.yellow(
+        `  ⚠ voice: could not store ${VOICE_SIDECAR_TOKEN_KEY} in the vault ` +
+        `(${put.kind}${"code" in put ? `: ${put.code}` : ""}). The sidecar will 401 ` +
+        `every /stt until this succeeds.\n`,
+      ),
+    );
+    return null;
+  }
+  return token;
+}
+
+/**
+ * Provision the voice-sidecar token and write the compose `.env` so docker's
+ * `${VOICE_SIDECAR_TOKEN}` interpolation populates the sidecar's env.
+ *
+ * No-op (and stale-`.env` cleanup) on a non-`local` verdict. Best-effort:
+ * never throws, never blocks apply.
+ */
+export async function provisionVoiceSidecarToken(
+  composePath: string,
+  home: string,
+  ctx: ProvisionSidecarTokenCtx,
+): Promise<void> {
+  const engine =
+    ctx.voiceEngine ?? loadHostCapabilities()?.voice.engine ?? "cloud";
+  const envPath = composeEnvPath(composePath);
+
+  if (engine !== "local") {
+    // No sidecar emitted on a cloud verdict — remove any stale token file so
+    // a host that lost its GPU doesn't leave the secret on disk. Only touch
+    // the file if it exists AND looks like ours (contains our var) so we
+    // never clobber an operator-managed compose `.env`.
+    try {
+      if (existsSync(envPath)) {
+        const body = readFileSync(envPath, "utf-8");
+        if (body.includes(`${VOICE_SIDECAR_TOKEN_ENV}=`)) rmSync(envPath);
+      }
+    } catch {
+      /* best-effort cleanup */
+    }
+    return;
+  }
+
+  const resolveOrSeed =
+    ctx.resolveOrSeedToken ??
+    (() => defaultResolveOrSeedToken(home, ctx.writeErr));
+
+  let token: string | null = null;
+  try {
+    token = await resolveOrSeed();
+  } catch (err) {
+    ctx.writeErr(
+      chalk.yellow(
+        `  ⚠ voice: sidecar-token provisioning errored (${(err as Error).message}) — ` +
+        `the sidecar will lack a token.\n`,
+      ),
+    );
+    return;
+  }
+  if (!token) return; // resolveOrSeed already warned.
+
+  try {
+    mkdirSync(dirname(envPath), { recursive: true });
+    // Write 0600 — the token is a secret. docker compose reads this `.env`
+    // from the compose file's directory automatically; the value is NOT in
+    // the YAML, only here.
+    writeFileSync(envPath, `${VOICE_SIDECAR_TOKEN_ENV}=${token}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+    // Keep operator-owned when written under sudo (mirrors writeComposeFile).
+    if (ctx.operatorUid !== undefined && process.geteuid?.() === 0) {
+      try {
+        chownSync(envPath, ctx.operatorUid, ctx.operatorUid);
+      } catch {
+        /* best-effort */
+      }
+    }
+    ctx.writeOut(
+      chalk.gray(`  Wrote voice-sidecar token to ${envPath} (0600)\n`),
+    );
+  } catch (err) {
+    ctx.writeErr(
+      chalk.yellow(
+        `  ⚠ voice: could not write ${envPath} (${(err as Error).message}) — ` +
+        `the sidecar will lack a token.\n`,
+      ),
+    );
+  }
+}

--- a/src/telegram/materialize-sidecar-token.ts
+++ b/src/telegram/materialize-sidecar-token.ts
@@ -1,0 +1,132 @@
+/**
+ * Runtime materialization of the voice-sidecar shared-secret token from
+ * the vault (voice feature PR-B2).
+ *
+ * The LOCAL STT path (engine `local`) authenticates every /stt call to
+ * the `voice-sidecar` service with a shared secret. Both ends resolve the
+ * SAME secret from the vault at `voice/sidecar-token`:
+ *   - the sidecar container gets it via the compose `.env` file that
+ *     `switchroom apply` writes (see src/cli/voice-sidecar-token.ts), so
+ *     docker's `${VOICE_SIDECAR_TOKEN}` interpolation populates its env;
+ *   - the gateway resolves it here, at use-time, through the vault broker
+ *     — never reads a plaintext file, never surfaces it into the prompt.
+ *
+ * This mirrors `materialize-voice-key.ts` (the OpenAI STT key) exactly:
+ * resolve `vault:voice/sidecar-token` via the broker, with a
+ * direct-decrypt fallback when the broker is unreachable but
+ * SWITCHROOM_VAULT_PASSPHRASE is set. Any failure returns null and the
+ * gateway caller falls back to the legacy "(voice message)" envelope —
+ * voice-in is a UX enhancement, not a critical path.
+ */
+
+import { existsSync } from "node:fs";
+import { loadConfig, resolvePath } from "../config/loader.js";
+import {
+  isVaultReference,
+  parseVaultReference,
+  resolveVaultReferencesViaBroker,
+} from "../vault/resolver.js";
+import { openVault } from "../vault/vault.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+/** The vault key holding the voice-sidecar shared secret. */
+export const VOICE_SIDECAR_TOKEN_KEY = "voice/sidecar-token";
+/** The default `vault:` reference for the sidecar token. */
+export const DEFAULT_VOICE_SIDECAR_TOKEN_REF = `vault:${VOICE_SIDECAR_TOKEN_KEY}`;
+
+export interface MaterializeSidecarTokenOpts {
+  /** Override the token reference (testing / non-default config). */
+  tokenRef?: string;
+  /** Pre-loaded config (testing). When omitted, loadConfig() is called. */
+  config?: SwitchroomConfig;
+  /** Override env reads (testing). */
+  env?: NodeJS.ProcessEnv;
+  /** Override the broker-resolve function (testing). */
+  resolveViaBroker?: typeof resolveVaultReferencesViaBroker;
+}
+
+/** Direct vault decrypt fallback (broker unreachable). Mirrors the key helper. */
+function tryDirectVaultRead(
+  ref: string,
+  config: SwitchroomConfig,
+  passphrase: string | undefined,
+): string | null {
+  if (!passphrase) return null;
+  const vaultPath = resolvePath(config.vault?.path ?? "~/.switchroom/vault.enc");
+  if (!existsSync(vaultPath)) return null;
+  try {
+    const secrets = openVault(passphrase, vaultPath);
+    const key = parseVaultReference(ref);
+    const entry = secrets[key];
+    if (!entry) return null;
+    if (entry.kind === "string" || entry.kind === "binary") return entry.value;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the voice-sidecar shared-secret token. Returns the token string
+ * on success, or null on any failure (caller falls back). Never throws,
+ * never writes the token to disk.
+ */
+export async function materializeSidecarToken(
+  opts: MaterializeSidecarTokenOpts = {},
+  logger: (line: string) => void = (line) => process.stderr.write(line),
+): Promise<string | null> {
+  const env = opts.env ?? process.env;
+  const ref =
+    opts.tokenRef && opts.tokenRef.length > 0
+      ? opts.tokenRef
+      : DEFAULT_VOICE_SIDECAR_TOKEN_REF;
+
+  // Literal (non-vault) token — use directly (testing / edge config).
+  if (!isVaultReference(ref)) {
+    return ref;
+  }
+
+  let config: SwitchroomConfig;
+  try {
+    config = opts.config ?? loadConfig();
+  } catch (err) {
+    logger(
+      `telegram gateway: voice-in: could not load config to resolve sidecar token: ${(err as Error).message} — falling back\n`,
+    );
+    return null;
+  }
+
+  const resolveViaBroker = opts.resolveViaBroker ?? resolveVaultReferencesViaBroker;
+
+  // Narrow the config so the broker only fetches this one key (reuse the
+  // bot_token slot as the carrier, same trick as materialize-voice-key.ts).
+  const brokerResult = await resolveViaBroker({
+    ...config,
+    telegram: {
+      ...config.telegram,
+      bot_token: ref,
+    } as SwitchroomConfig["telegram"],
+    agents: {} as SwitchroomConfig["agents"],
+  });
+
+  if (brokerResult.ok) {
+    const resolved = brokerResult.config.telegram?.bot_token;
+    if (resolved && !isVaultReference(resolved)) {
+      return resolved;
+    }
+  } else {
+    logger(
+      `telegram gateway: voice-in: vault broker could not resolve ${ref} (reason=${brokerResult.reason}) — trying direct decrypt / falling back\n`,
+    );
+  }
+
+  const direct = tryDirectVaultRead(ref, config, env.SWITCHROOM_VAULT_PASSPHRASE);
+  if (direct) {
+    return direct;
+  }
+
+  logger(
+    `telegram gateway: voice-in: could not resolve sidecar token ${ref} (broker unreachable/denied and no SWITCHROOM_VAULT_PASSPHRASE) — falling back to "(voice message)"\n`,
+  );
+  return null;
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -48,6 +48,7 @@ import {
   type GifSendArgs,
 } from '../sticker-aliases.js'
 import { transcribeViaWhisper } from '../voice-transcribe.js'
+import { transcribeViaSidecar } from '../voice-transcribe-sidecar.js'
 import {
   createTelegraphAccount,
   createTelegraphPage,
@@ -142,6 +143,8 @@ import {
 } from './microsoft-connect-flow.js'
 import { resolveAuthBrokerSocketPath } from '../../src/auth/broker/client.js'
 import { materializeVoiceKey } from '../../src/telegram/materialize-voice-key.js'
+import { materializeSidecarToken } from '../../src/telegram/materialize-sidecar-token.js'
+import { loadHostCapabilities } from '../../src/setup/host-capabilities.js'
 import { createFleetFallbackGate } from '../fleet-fallback-gate.js'
 import { createFleetFallbackResumeGate } from '../fleet-fallback-resume.js'
 import { resolveExhaustUntil } from './exhaust-until.js'
@@ -22115,13 +22118,29 @@ bot.on('message:voice', async ctx => {
   // SOMETHING — better than silent drops.
   const access = loadAccess()
   const voiceIn = access.voice_in
-  if (voiceIn?.enabled && voiceIn?.provider === 'openai') {
-    const transcript = await maybeTranscribeVoice(
-      voice.file_id,
-      voice.mime_type,
-      voiceIn.language,
-      voiceIn.api_key,
-    )
+  // Engine selection (PR-B2): the persisted host verdict decides HOW we
+  // transcribe. `local` → the in-fleet GPU sidecar (no third-party key,
+  // vision #3 + #4); anything else → the OpenAI cloud provider. The local
+  // path needs no `provider === 'openai'` gate — it has no API key — so we
+  // route to the sidecar whenever voice_in is enabled AND the host verdict
+  // is `local`. The cloud path keeps its existing openai gate.
+  const voiceEngine = loadHostCapabilities()?.voice.engine ?? 'cloud'
+  const localEnabled = voiceIn?.enabled === true && voiceEngine === 'local'
+  const cloudEnabled =
+    voiceIn?.enabled === true && voiceEngine !== 'local' && voiceIn?.provider === 'openai'
+  if (localEnabled || cloudEnabled) {
+    const transcript = localEnabled
+      ? await maybeTranscribeVoiceLocal(
+          voice.file_id,
+          voice.mime_type,
+          voiceIn?.language,
+        )
+      : await maybeTranscribeVoice(
+          voice.file_id,
+          voice.mime_type,
+          voiceIn?.language,
+          voiceIn?.api_key,
+        )
     if (transcript != null) {
       const text = ctx.message.caption
         ? `${ctx.message.caption}\n\n[voice transcript] ${transcript}`
@@ -22146,6 +22165,91 @@ bot.on('message:voice', async ctx => {
  * are logged to stderr but never thrown — voice-in is a UX
  * enhancement, not a critical path.
  */
+/**
+ * Filename hint for the multipart body. Telegram voice is OGG/Opus; agents
+ * may also attach mp3/m4a/wav which arrive as message:audio. Match the mime
+ * so the decoder (Whisper / faster-whisper) gets a usable extension.
+ */
+function voiceFilenameExt(mimeType: string | undefined): string {
+  return mimeType?.includes('mp3') ? 'mp3'
+    : mimeType?.includes('m4a') ? 'm4a'
+    : mimeType?.includes('wav') ? 'wav'
+    : 'ogg'
+}
+
+/**
+ * Download a Telegram voice attachment into memory. Shared by the cloud
+ * (Whisper) and local (sidecar) transcription paths. Returns the bytes on
+ * success, or null on any failure (caller falls back). Never throws.
+ */
+async function downloadVoiceBytes(fileId: string): Promise<Uint8Array | null> {
+  try {
+    const file = await bot.api.getFile(fileId)
+    if (!file.file_path) {
+      process.stderr.write(`telegram gateway: voice-in: getFile returned no file_path\n`)
+      return null
+    }
+    const url = `https://api.telegram.org/file/bot${TOKEN}/${file.file_path}`
+    const res = await fetch(url, { signal: AbortSignal.timeout(30_000) })
+    if (!res.ok) {
+      process.stderr.write(`telegram gateway: voice-in: telegram download HTTP ${res.status}\n`)
+      return null
+    }
+    return new Uint8Array(await res.arrayBuffer())
+  } catch (err) {
+    // Sanitize: never let the bot token leak into log lines via the
+    // download URL — strip anything that looks like a token.
+    const msg = (err as Error).message.replace(/bot[\w:-]+/g, 'bot[redacted]')
+    process.stderr.write(`telegram gateway: voice-in: download failed: ${msg}\n`)
+    return null
+  }
+}
+
+/**
+ * Transcribe a Telegram voice note via the LOCAL GPU STT sidecar (PR-B2).
+ * Used when the host voice verdict is `local`. Resolves the shared-secret
+ * token from the vault (voice/sidecar-token), downloads the audio, and
+ * POSTs it to the sidecar at loopback (the gateway is network_mode: host).
+ * Returns the transcript on success, null on any failure (caller falls
+ * back to the legacy "(voice message)" envelope). Never throws.
+ */
+async function maybeTranscribeVoiceLocal(
+  fileId: string,
+  mimeType: string | undefined,
+  language: string | undefined,
+): Promise<string | null> {
+  const token = await materializeSidecarToken()
+  if (!token) {
+    // materializeSidecarToken already logged the specific reason.
+    return null
+  }
+
+  const audioBytes = await downloadVoiceBytes(fileId)
+  if (!audioBytes) return null
+
+  const result = await transcribeViaSidecar({
+    token,
+    audio: audioBytes,
+    filename: `voice.${voiceFilenameExt(mimeType)}`,
+    language,
+  })
+
+  if (!result.ok) {
+    process.stderr.write(
+      `telegram gateway: voice-in: local sidecar transcription failed reason=${result.reason}` +
+      (result.detail ? ` detail=${JSON.stringify(result.detail).slice(0, 100)}` : '') +
+      '\n',
+    )
+    return null
+  }
+
+  process.stderr.write(
+    `telegram gateway: voice-in: local sidecar transcribed ${audioBytes.length} bytes in ${result.durationMs}ms ` +
+    `lang=${result.language ?? '?'} audio_s=${result.audioSeconds ?? '?'} chars=${result.text.length}\n`,
+  )
+  return result.text
+}
+
 async function maybeTranscribeVoice(
   fileId: string,
   mimeType: string | undefined,
@@ -22164,42 +22268,13 @@ async function maybeTranscribeVoice(
     return null
   }
 
-  // Download the audio bytes from Telegram. Same shape as
-  // executeDownloadAttachment but in-memory rather than to disk.
-  let audioBytes: Uint8Array
-  try {
-    const file = await bot.api.getFile(fileId)
-    if (!file.file_path) {
-      process.stderr.write(`telegram gateway: voice-in: getFile returned no file_path\n`)
-      return null
-    }
-    const url = `https://api.telegram.org/file/bot${TOKEN}/${file.file_path}`
-    const res = await fetch(url, { signal: AbortSignal.timeout(30_000) })
-    if (!res.ok) {
-      process.stderr.write(`telegram gateway: voice-in: telegram download HTTP ${res.status}\n`)
-      return null
-    }
-    audioBytes = new Uint8Array(await res.arrayBuffer())
-  } catch (err) {
-    // Sanitize: never let the bot token leak into log lines via the
-    // download URL — strip anything that looks like a token.
-    const msg = (err as Error).message.replace(/bot[\w:-]+/g, 'bot[redacted]')
-    process.stderr.write(`telegram gateway: voice-in: download failed: ${msg}\n`)
-    return null
-  }
-
-  // Filename hint — Telegram voice is OGG/Opus; agents may also
-  // attach mp3/m4a/etc which arrive as message:audio (handled
-  // separately). Match the mime to give Whisper a usable extension.
-  const ext = mimeType?.includes('mp3') ? 'mp3'
-    : mimeType?.includes('m4a') ? 'm4a'
-    : mimeType?.includes('wav') ? 'wav'
-    : 'ogg'
+  const audioBytes = await downloadVoiceBytes(fileId)
+  if (!audioBytes) return null
 
   const result = await transcribeViaWhisper({
     apiKey,
     audio: audioBytes,
-    filename: `voice.${ext}`,
+    filename: `voice.${voiceFilenameExt(mimeType)}`,
     language,
   })
 

--- a/telegram-plugin/tests/voice-transcribe-sidecar.test.ts
+++ b/telegram-plugin/tests/voice-transcribe-sidecar.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Unit tests for the LOCAL STT sidecar transcription path (voice PR-B2):
+ *   - transcribeViaSidecar (HTTP POST to /stt, mocked fetch)
+ *   - materializeSidecarToken (vault resolution, mocked broker)
+ *
+ * Mirrors the cloud twin's test (voice-transcribe.test.ts): every error
+ * reason is pinned so a refactor can't silently change the contract the
+ * gateway depends on (any non-ok → null → "(voice message)" fallback).
+ */
+
+import { describe, it, expect } from 'bun:test'
+import {
+  transcribeViaSidecar,
+  SIDECAR_MAX_BYTES,
+  DEFAULT_SIDECAR_BASE_URL,
+} from '../voice-transcribe-sidecar.js'
+import {
+  materializeSidecarToken,
+  DEFAULT_VOICE_SIDECAR_TOKEN_REF,
+  VOICE_SIDECAR_TOKEN_KEY,
+} from '../../src/telegram/materialize-sidecar-token.js'
+import type { resolveVaultReferencesViaBroker } from '../../src/vault/resolver.js'
+import type { SwitchroomConfig } from '../../src/config/schema.js'
+
+const SMALL_AUDIO = new Uint8Array([0x4f, 0x67, 0x67, 0x53]) // OggS magic
+
+function makeFetch(status: number, body: unknown): typeof fetch {
+  return (async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+    headers: new Headers(),
+  })) as unknown as typeof fetch
+}
+
+describe('transcribeViaSidecar — pre-flight checks', () => {
+  it('returns no-token when token is empty', async () => {
+    const r = await transcribeViaSidecar({
+      token: '',
+      audio: SMALL_AUDIO,
+      filename: 'voice.ogg',
+      fetchImpl: makeFetch(200, { ok: true, text: 'x' }),
+    })
+    expect(r).toMatchObject({ ok: false, reason: 'no-token' })
+  })
+
+  it('returns audio-too-short on empty audio', async () => {
+    const r = await transcribeViaSidecar({
+      token: 't',
+      audio: new Uint8Array(0),
+      filename: 'voice.ogg',
+    })
+    expect(r).toMatchObject({ ok: false, reason: 'audio-too-short' })
+  })
+
+  it('returns audio-too-large above the cap', async () => {
+    const tooBig = new Uint8Array(SIDECAR_MAX_BYTES + 1)
+    const r = await transcribeViaSidecar({
+      token: 't',
+      audio: tooBig,
+      filename: 'voice.ogg',
+    })
+    expect(r).toMatchObject({ ok: false, reason: 'audio-too-large' })
+  })
+})
+
+describe('transcribeViaSidecar — happy path', () => {
+  it('returns transcript on 200 + valid JSON', async () => {
+    const r = await transcribeViaSidecar({
+      token: 't',
+      audio: SMALL_AUDIO,
+      filename: 'voice.ogg',
+      fetchImpl: makeFetch(200, {
+        ok: true,
+        text: 'Hello world',
+        language: 'en',
+        durationMs: 1234,
+        audioSeconds: 3.2,
+      }),
+    })
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      expect(r.text).toBe('Hello world')
+      expect(r.language).toBe('en')
+      expect(r.durationMs).toBe(1234)
+      expect(r.audioSeconds).toBe(3.2)
+    }
+  })
+
+  it('sends the X-Voice-Token header, audio + language fields, to <base>/stt', async () => {
+    let receivedUrl = ''
+    let receivedToken: string | null = null
+    let receivedForm: FormData | null = null
+    const fakeFetch: typeof fetch = (async (url: string, init?: RequestInit) => {
+      receivedUrl = url
+      receivedToken = (init?.headers as Record<string, string>)['X-Voice-Token']
+      receivedForm = init?.body as FormData
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, text: 'bonjour' }),
+        text: async () => '',
+        headers: new Headers(),
+      }
+    }) as unknown as typeof fetch
+
+    const r = await transcribeViaSidecar({
+      token: 'secret-token',
+      audio: SMALL_AUDIO,
+      filename: 'voice.ogg',
+      language: 'fr',
+      fetchImpl: fakeFetch,
+    })
+    expect(r.ok).toBe(true)
+    expect(receivedUrl).toBe(`${DEFAULT_SIDECAR_BASE_URL}/stt`)
+    expect(receivedToken).toBe('secret-token')
+    expect(receivedForm).not.toBeNull()
+    expect(receivedForm!.get('language')).toBe('fr')
+    expect(receivedForm!.get('audio')).not.toBeNull()
+  })
+
+  it('falls back to wall-clock durationMs when the sidecar omits it', async () => {
+    const r = await transcribeViaSidecar({
+      token: 't',
+      audio: SMALL_AUDIO,
+      filename: 'voice.ogg',
+      fetchImpl: makeFetch(200, { ok: true, text: 'hi' }),
+    })
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      expect(r.durationMs).toBeGreaterThanOrEqual(0)
+      expect(r.audioSeconds).toBeNull()
+    }
+  })
+})
+
+describe('transcribeViaSidecar — error paths', () => {
+  it('returns http-401 on a wrong/missing token (sidecar rejects)', async () => {
+    const r = await transcribeViaSidecar({
+      token: 't',
+      audio: SMALL_AUDIO,
+      filename: 'voice.ogg',
+      fetchImpl: makeFetch(401, { ok: false, reason: 'unauthorized' }),
+    })
+    expect(r).toMatchObject({ ok: false, reason: 'http-401' })
+  })
+
+  it('surfaces the sidecar reason on a 2xx { ok: false } body', async () => {
+    const r = await transcribeViaSidecar({
+      token: 't',
+      audio: SMALL_AUDIO,
+      filename: 'voice.ogg',
+      fetchImpl: makeFetch(200, { ok: false, reason: 'gpu-timeout', detail: 'busy' }),
+    })
+    expect(r).toMatchObject({ ok: false, reason: 'gpu-timeout' })
+  })
+
+  it('returns malformed-response when 200 body has no text field', async () => {
+    const r = await transcribeViaSidecar({
+      token: 't',
+      audio: SMALL_AUDIO,
+      filename: 'voice.ogg',
+      fetchImpl: makeFetch(200, { ok: true, unexpected: 'shape' }),
+    })
+    expect(r).toMatchObject({ ok: false, reason: 'malformed-response' })
+  })
+
+  it('returns fetch-failed on a thrown network error', async () => {
+    const fakeFetch: typeof fetch = (async () => {
+      throw new Error('ECONNREFUSED')
+    }) as unknown as typeof fetch
+    const r = await transcribeViaSidecar({
+      token: 't',
+      audio: SMALL_AUDIO,
+      filename: 'voice.ogg',
+      fetchImpl: fakeFetch,
+    })
+    expect(r).toMatchObject({ ok: false, reason: 'fetch-failed' })
+    expect(r.detail).toContain('ECONNREFUSED')
+  })
+
+  it('returns timeout when fetch is aborted', async () => {
+    const fakeFetch: typeof fetch = (async () => {
+      throw new Error('The operation was aborted')
+    }) as unknown as typeof fetch
+    const r = await transcribeViaSidecar({
+      token: 't',
+      audio: SMALL_AUDIO,
+      filename: 'voice.ogg',
+      timeoutMs: 5,
+      fetchImpl: fakeFetch,
+    })
+    expect(r).toMatchObject({ ok: false, reason: 'timeout' })
+  })
+})
+
+// ── materializeSidecarToken — vault resolution (mirrors the key helper) ──
+
+const EMPTY_CONFIG = {} as unknown as SwitchroomConfig
+
+function makeBrokerResolver(
+  resolvedRefs: Record<string, string>,
+): typeof resolveVaultReferencesViaBroker {
+  return (async (config: SwitchroomConfig) => {
+    const ref = config.telegram?.bot_token
+    if (ref && resolvedRefs[ref] !== undefined) {
+      return {
+        ok: true,
+        config: {
+          ...config,
+          telegram: { ...config.telegram, bot_token: resolvedRefs[ref] },
+        },
+      }
+    }
+    return { ok: false, reason: 'not_found' as const }
+  }) as unknown as typeof resolveVaultReferencesViaBroker
+}
+
+describe('materializeSidecarToken — vault resolution', () => {
+  it('defaults to vault:voice/sidecar-token', () => {
+    expect(VOICE_SIDECAR_TOKEN_KEY).toBe('voice/sidecar-token')
+    expect(DEFAULT_VOICE_SIDECAR_TOKEN_REF).toBe('vault:voice/sidecar-token')
+  })
+
+  it('resolves the configured vault ref via the broker', async () => {
+    const tok = await materializeSidecarToken({
+      config: EMPTY_CONFIG,
+      env: {},
+      resolveViaBroker: makeBrokerResolver({
+        'vault:voice/sidecar-token': 'deadbeef' + 'cafe',
+      }),
+    })
+    expect(tok).toBe('deadbeef' + 'cafe')
+  })
+
+  it('returns a literal (non-vault) token directly without the broker', async () => {
+    let brokerCalled = false
+    const tok = await materializeSidecarToken({
+      tokenRef: 'raw' + 'token',
+      config: EMPTY_CONFIG,
+      env: {},
+      resolveViaBroker: (async () => {
+        brokerCalled = true
+        return { ok: false, reason: 'not_found' as const }
+      }) as unknown as typeof resolveVaultReferencesViaBroker,
+    })
+    expect(tok).toBe('raw' + 'token')
+    expect(brokerCalled).toBe(false)
+  })
+
+  it('returns null (graceful fallback, no throw) when unresolvable', async () => {
+    const tok = await materializeSidecarToken(
+      {
+        config: EMPTY_CONFIG,
+        env: {},
+        resolveViaBroker: makeBrokerResolver({}),
+      },
+      () => {},
+    )
+    expect(tok).toBeNull()
+  })
+})

--- a/telegram-plugin/voice-transcribe-sidecar.ts
+++ b/telegram-plugin/voice-transcribe-sidecar.ts
@@ -1,0 +1,176 @@
+/**
+ * Voice-message transcription via the LOCAL GPU STT sidecar (voice PR-B2).
+ *
+ * The cloud twin of this module is `voice-transcribe.ts` (OpenAI Whisper).
+ * This one POSTs the downloaded audio bytes to the in-fleet
+ * `voice-sidecar` service (docker/voice-sidecar/server.py, faster-whisper
+ * on a local GPU) when the host's voice-engine verdict is `local` — no
+ * third-party STT key (vision #3, subscription-honest) and no cloud
+ * dependency (vision #4, always-available).
+ *
+ * Reachability: the gateway runs inside the agent container, which is
+ * `network_mode: host`, so the sidecar's published `0.0.0.0:18900` is
+ * reachable at loopback `127.0.0.1:18900` (compose maps host 18900 → the
+ * sidecar's in-container 8126). See src/agents/compose.ts
+ * (VOICE_SIDECAR_HOST_PORT) for the published-port contract.
+ *
+ * Contract MIRRORS `transcribeViaWhisper`:
+ *   - takes audio bytes + a shared-secret token as args (no env reads,
+ *     no file IO) so it's unit-testable against a mocked fetch;
+ *   - never throws — every failure becomes a structured
+ *     `{ ok: false, reason, detail }`, and the gateway caller falls back
+ *     to the legacy "(voice message)" envelope on any non-ok outcome.
+ *
+ * The sidecar's /stt response shape (server.py):
+ *   200 { ok: true,  text, language?, durationMs, audioSeconds }
+ *   4xx/5xx { ok: false, reason, detail }
+ */
+
+import type {
+  TranscribeOutcome,
+  TranscribeResult,
+} from './voice-transcribe.js'
+
+/** Default loopback base URL for the sidecar (host-network agent). */
+export const DEFAULT_SIDECAR_BASE_URL = 'http://127.0.0.1:18900'
+
+/** The sidecar caps inputs at 25MB before transcode (server.py MAX_BYTES);
+ *  reject before the round-trip to match the cloud path's pre-flight. */
+export const SIDECAR_MAX_BYTES = 25 * 1024 * 1024
+
+export interface SidecarTranscribeArgs {
+  /** Shared secret sent in the X-Voice-Token header (vault:voice/sidecar-token). */
+  token: string
+  audio: Uint8Array
+  /** Filename hint for the multipart body (matches the actual content). */
+  filename: string
+  /** Optional ISO-639-1 language hint to skip detection. */
+  language?: string
+  /** Base URL for the sidecar. Defaults to DEFAULT_SIDECAR_BASE_URL. */
+  baseUrl?: string
+  /** Per-call timeout in ms. Default 90s — local whisper can run longer
+   *  than the cloud API on a cold model / long memo (the sidecar's own
+   *  per-request timeout is 60s by default; we give the HTTP leg slack). */
+  timeoutMs?: number
+  /** Override fetch for tests. */
+  fetchImpl?: typeof fetch
+}
+
+/**
+ * Run a single transcription against the local sidecar. Resolves to a
+ * TranscribeOutcome — the caller branches on `.ok`. Never throws.
+ *
+ * Reason codes mirror the cloud path where they overlap:
+ *   - 'no-token'           — empty shared secret (mirrors 'no-api-key')
+ *   - 'audio-too-short'    — empty audio
+ *   - 'audio-too-large'    — exceeds SIDECAR_MAX_BYTES
+ *   - 'http-<n>'           — non-2xx HTTP status code
+ *   - 'sidecar-error'      — 200/2xx but body said { ok: false }
+ *   - 'fetch-failed'       — network error before any response
+ *   - 'malformed-response' — 2xx but body wasn't the expected JSON
+ *   - 'timeout'            — exceeded the per-call timeout
+ */
+export async function transcribeViaSidecar(
+  args: SidecarTranscribeArgs,
+): Promise<TranscribeOutcome> {
+  if (!args.token || args.token.length === 0) {
+    return { ok: false, reason: 'no-token' }
+  }
+  if (args.audio.length === 0) {
+    return { ok: false, reason: 'audio-too-short' }
+  }
+  if (args.audio.length > SIDECAR_MAX_BYTES) {
+    return {
+      ok: false,
+      reason: 'audio-too-large',
+      detail: `${args.audio.length} bytes (limit ${SIDECAR_MAX_BYTES})`,
+    }
+  }
+
+  const fetchFn = args.fetchImpl ?? fetch
+  const baseUrl = (args.baseUrl ?? DEFAULT_SIDECAR_BASE_URL).replace(/\/$/, '')
+  const timeoutMs = args.timeoutMs ?? 90_000
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+  // Multipart: server.py reads `audio` (bytes) + optional `language`.
+  const form = new FormData()
+  const blob = new Blob([args.audio as unknown as BlobPart])
+  form.append('audio', blob, args.filename)
+  if (args.language) form.append('language', args.language)
+
+  const startedAt = Date.now()
+  let res: Response
+  try {
+    res = await fetchFn(`${baseUrl}/stt`, {
+      method: 'POST',
+      headers: { 'X-Voice-Token': args.token },
+      body: form,
+      signal: controller.signal,
+    })
+  } catch (err) {
+    clearTimeout(timer)
+    const msg = err instanceof Error ? err.message : String(err)
+    if (msg.includes('aborted') || /timeout/i.test(msg)) {
+      return { ok: false, reason: 'timeout', detail: msg }
+    }
+    return { ok: false, reason: 'fetch-failed', detail: msg }
+  }
+  clearTimeout(timer)
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    return { ok: false, reason: `http-${res.status}`, detail: body.slice(0, 200) }
+  }
+
+  let parsed: {
+    ok?: unknown
+    text?: unknown
+    language?: unknown
+    durationMs?: unknown
+    audioSeconds?: unknown
+    reason?: unknown
+    detail?: unknown
+  }
+  try {
+    parsed = (await res.json()) as typeof parsed
+  } catch (err) {
+    return {
+      ok: false,
+      reason: 'malformed-response',
+      detail: err instanceof Error ? err.message : String(err),
+    }
+  }
+
+  // A 2xx with { ok: false } (defence in depth — the sidecar returns
+  // non-2xx on errors, but a proxy could rewrite the status).
+  if (parsed.ok === false) {
+    return {
+      ok: false,
+      reason: typeof parsed.reason === 'string' ? parsed.reason : 'sidecar-error',
+      detail: typeof parsed.detail === 'string' ? parsed.detail.slice(0, 200) : undefined,
+    }
+  }
+
+  if (typeof parsed.text !== 'string') {
+    return {
+      ok: false,
+      reason: 'malformed-response',
+      detail: 'response missing `text` field',
+    }
+  }
+
+  const out: TranscribeResult = {
+    ok: true,
+    text: parsed.text,
+    language: typeof parsed.language === 'string' ? parsed.language : undefined,
+    // Prefer the sidecar's own durationMs; fall back to our wall-clock.
+    durationMs:
+      typeof parsed.durationMs === 'number'
+        ? parsed.durationMs
+        : Date.now() - startedAt,
+    audioSeconds:
+      typeof parsed.audioSeconds === 'number' ? parsed.audioSeconds : null,
+  }
+  return out
+}

--- a/tests/docker/ci-image-matrix.test.ts
+++ b/tests/docker/ci-image-matrix.test.ts
@@ -36,6 +36,15 @@ const DOCKER_MATRIX_OPT_OUT: Record<string, string> = {
   // built/consumed by the UAT CI workflow, not published as a per-version
   // fleet GHCR tag, so it is intentionally outside the docker-images matrix.
   "uat-runner": "CI-only sandboxed UAT host runner (#2236); not a published fleet image",
+  // voice is the GPU STT sidecar (voice PR-B2). It extends a CUDA runtime
+  // base (nvidia/cuda), NOT switchroom-base, so it does not fit the
+  // build-dependents matrix (which threads BASE_IMAGE), and it is emitted
+  // into the fleet compose ONLY on a `local` GPU verdict — most hosts never
+  // pull it. Its CI build/publish needs a dedicated amd64-only,
+  // CUDA-aware job (like build-hindsight's standalone shape) and lands in a
+  // follow-up; opted out here until then so the matrix gate forces that
+  // choice rather than silently shipping an unbuilt image.
+  voice: "GPU STT sidecar (PR-B2); CUDA base, local-verdict-only — dedicated CI build job is a follow-up",
 };
 
 function dockerfileNames(): string[] {

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -3073,3 +3073,59 @@ describe("conditional-mount probe home (in-hostd apply — marko meta_pages regr
     expect(yaml).not.toContain(`${pool}:${pool}:ro`);
   });
 });
+
+// ── voice-sidecar service (PR-B2) ─────────────────────────────────────
+// The local GPU STT sidecar is emitted ONLY on a `local` voice verdict.
+// Both branches are pinned here so a regression that emits the GPU service
+// on a cloud host — or drops it on a local host — fails CI.
+describe("generateCompose — voice-sidecar (PR-B2)", () => {
+  it("emits the voice-sidecar service + volume on a local verdict", () => {
+    const out = generateCompose({
+      config: makeConfig({ coach: {} }),
+      voiceEngine: "local",
+    });
+    expect(out).toContain("voice-sidecar:");
+    expect(out).toContain("container_name: switchroom-voice-sidecar");
+    // GPU reservation.
+    expect(out).toContain("driver: nvidia");
+    expect(out).toContain('capabilities: ["gpu"]');
+    // Published on all interfaces (host-net + strict-isolation reachable).
+    expect(out).toContain('"0.0.0.0:18900:8126"');
+    // Healthcheck on /healthz.
+    expect(out).toContain("/healthz");
+    // Token is a docker interpolation, NOT a literal secret in the YAML.
+    expect(out).toContain("VOICE_SIDECAR_TOKEN: ${VOICE_SIDECAR_TOKEN}");
+    // Model-cache named volume declared.
+    expect(out).toContain("voice-model-cache:");
+  });
+
+  it("emits NEITHER service NOR volume on a cloud verdict", () => {
+    const out = generateCompose({
+      config: makeConfig({ coach: {} }),
+      voiceEngine: "cloud",
+    });
+    expect(out).not.toContain("voice-sidecar:");
+    expect(out).not.toContain("switchroom-voice-sidecar");
+    expect(out).not.toContain("voice-model-cache");
+    expect(out).not.toContain("VOICE_SIDECAR_TOKEN");
+  });
+
+  it("defaults to NO sidecar when the verdict is unset (fail-safe cloud)", () => {
+    // No voiceEngine + no persisted host-capabilities file → defaults to
+    // cloud → never emits a GPU service on an unconfirmed host. Point HOME
+    // at an empty tmp dir so loadHostCapabilities() finds no verdict file
+    // (don't read the operator's real ~/.switchroom on this dev host).
+    const emptyHome = mkdtempSync(join(tmpdir(), "voice-no-verdict-"));
+    const prevHome = process.env.HOME;
+    process.env.HOME = emptyHome;
+    try {
+      const out = generateCompose({ config: makeConfig({ coach: {} }) });
+      expect(out).not.toContain("voice-sidecar:");
+      expect(out).not.toContain("voice-model-cache");
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      rmSync(emptyHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -240,6 +240,9 @@ export default defineConfig({
       // voice-transcribe.test.ts uses bun:test (#578 voice-in spike) —
       // excluded here, run via test:bun.
       "**/telegram-plugin/tests/voice-transcribe.test.ts",
+      // voice-transcribe-sidecar.test.ts uses bun:test (PR-B2 local STT) —
+      // excluded here, run via test:bun.
+      "**/telegram-plugin/tests/voice-transcribe-sidecar.test.ts",
       // telegraph.test.ts uses bun:test (#579 Telegraph Instant View) —
       // excluded here, run via test:bun.
       "**/telegram-plugin/tests/telegraph.test.ts",


### PR DESCRIPTION
## Summary

PR-B2 of the staged voice feature: the **consuming side** of the local GPU STT sidecar plus the apply-time plumbing the PR-B1 compose stanza assumed.

- **Gateway** transcribes inbound Telegram voice notes via the in-fleet `voice-sidecar` (faster-whisper) when the host's PR-B1 verdict is `engine: local`. New `transcribeViaSidecar` (POSTs audio → sidecar `/stt` with the `X-Voice-Token` shared secret, mirroring `transcribeViaWhisper`'s return-contract) + `maybeTranscribeVoiceLocal`. Engine selection reads `loadHostCapabilities()`; the local path needs no `provider === 'openai'` gate (it has no API key). Telegram download factored into a shared `downloadVoiceBytes`. Any failure falls back to the legacy `(voice message)` envelope — voice-in stays non-critical.
- **Token injection** (the open question in the spec): the sidecar shared secret lives in the vault at `voice/sidecar-token`, resolved by **both** ends from there. The gateway resolves it at use-time via the broker (`materializeSidecarToken`, mirroring `materializeVoiceKey`). At `switchroom apply` on a `local` verdict, the token is **seeded** in the vault if absent (random 256-bit, operator-attested put — same recovery path as `provisionLiteLLMKeys`) and **written to the compose-adjacent `.env`** (0600) so docker's native `${VOICE_SIDECAR_TOKEN}` interpolation populates the sidecar's env. The secret never lands in the generated YAML. A `cloud` verdict removes any stale token `.env`.
- **Singleton reconcile + doctor** manage `voice-sidecar` as a verdict-gated conditional singleton (`resolveSingletonServices`): tracked for image-drift on a `local` host, never flagged missing/unhealthy on a `cloud` host.

### Token-injection decision (#2) + rationale
The LiteLLM precedent keeps the secret out of compose by having `start.sh` fetch it from the vault at the **agent** container's boot. That doesn't transfer: the `voice-sidecar` container is a pure-Python faster-whisper server with **no switchroom CLI and no broker socket** — it reads `VOICE_SIDECAR_TOKEN` straight from its env (`server.py:65`). So the cleanest vault-sourced injection that keeps the secret out of the YAML is the **standard docker-compose `.env` interpolation file**, written 0600 at apply time and regenerated each apply. The token's source of truth is still the vault; both ends agree on `voice/sidecar-token`. Documented in `src/cli/voice-sidecar-token.ts`.

## Why
Serves `reference/jobs/talk-to-agents-from-anywhere.md`. Advances vision **#3 (subscription-honest** — local STT means zero third-party STT key) and **#4 (always-available** — no cloud reachability dependency for voice on a GPU host).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run tests/docker/compose-generator.test.ts src/agents/singleton-reconcile.test.ts src/cli/voice-sidecar-token.test.ts` → 211 passed (both compose branches: local emits service+GPU+`0.0.0.0:18900:8126`+healthcheck+`voice-model-cache`; cloud emits neither service nor volume; singleton verdict gating)
- [x] `bun test telegram-plugin/tests/voice-transcribe-sidecar.test.ts voice-transcribe.test.ts` → 32 passed (sidecar transcription mocked-fetch + token resolution mocked-broker)
- [x] `scripts/check-bot-api-wrapping.sh` clean (no allowlist drift)
- [x] `node scripts/check-plugin-references.mjs` clean

## Risk
Low. Strictly additive on the `local` verdict path; the `cloud` (default) path is unchanged — compose, gateway routing, and singleton management all behave exactly as before when no GPU verdict exists. End-to-end against a real GPU sidecar isn't exercised here (no GPU in CI); that's UAT/canary territory. Do NOT auto-merge — orchestrator merges after CI + review.