### PR TITLE
feat(telegram): render /usage Auth — fleet status as a GFM table

### DIFF
--- a/telegram-plugin/auth-snapshot-format.ts
+++ b/telegram-plugin/auth-snapshot-format.ts
@@ -191,9 +191,68 @@ export function formatAbsolute(
   });
 }
 
-/** Round-trim percentage to 1 dp (more precision is noise on a UX). */
+/**
+ * Render a future absolute time for the table's Status column, showing the
+ * DATE only when it's not "today" in the user's timezone — all in that tz so
+ * DST is handled by the tz database (never a hard-coded offset).
+ *
+ *   - same calendar day as `now` (user tz) → time only: `11:00 PM`
+ *   - a different day, but within the next 6 days → weekday + time: `Wed 1:00 AM`
+ *   - further out → weekday + day + month + time: `Wed 1 Jul 1:00 AM`
+ *
+ * `tz` is an IANA tz-database name (e.g. `Australia/Melbourne`); the caller
+ * sources it from `SWITCHROOM_TIMEZONE` / `TZ`. Returns "—" for null.
+ */
+export function formatStatusTime(
+  target: Date | null,
+  now: Date = new Date(),
+  tz: string = 'UTC',
+): string {
+  if (!target) return '—';
+  // Compare calendar dates in the user's tz using en-CA (YYYY-MM-DD) so the
+  // "is it today?" test is timezone-correct, not UTC-relative.
+  const dayFmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const timeFmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+  const timeStr = timeFmt.format(target);
+  if (dayFmt.format(target) === dayFmt.format(now)) {
+    return timeStr;
+  }
+  // Different day — always include the weekday. Add the day-of-month + month
+  // once the target falls outside the current week (≥ 7 days away), where a
+  // bare weekday would be ambiguous.
+  const withinWeek = target.getTime() - now.getTime() < 7 * 24 * 60 * 60 * 1000;
+  const dateFmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    weekday: 'short',
+    ...(withinWeek ? {} : { day: 'numeric', month: 'short' }),
+  });
+  return `${dateFmt.format(target)} ${timeStr}`;
+}
+
+/**
+ * Render a utilization percentage for display, CLAMPED to [0, 100].
+ *
+ * Anthropic's unified rate-limit headers return a decimal utilization that can
+ * exceed 1.0 (e.g. 1.01 → 101%) when an account is over its window cap. A
+ * displayed value over 100% erodes trust ("how can I be at 101%?"), so the
+ * DISPLAYED number is clamped to 100 here at the format boundary. This does NOT
+ * mutate the source quota data — `classifyHealth` / `blockedReason` still read
+ * the true (possibly >100) value, so the blocked/exhausted state still surfaces
+ * via the Status column and the health emoji. Only the rendered number is
+ * clamped.
+ */
 export function fmtPct(pct: number): string {
-  return `${Math.round(pct)}%`;
+  return `${Math.min(100, Math.round(pct))}%`;
 }
 
 // ── /auth snapshot — Format 2 ────────────────────────────────────────
@@ -233,32 +292,12 @@ function displayLabel(label: string, opts: SnapshotRenderOpts): string {
   return opts.demo ? maskEmail(label) : label;
 }
 
-/**
- * Header line shape: emoji + group title + count.
- *
- *   🟢 HEALTHY (4)
- *   🟡 ACTIVE — REFRESHING SOON (1)
- *   🔴 BLOCKED (1)
- *   ⚪ UNKNOWN (1)
- */
-function groupHeader(health: AccountHealth, count: number): string {
-  const emoji = HEALTH_EMOJI[health];
-  const title = HEALTH_TITLE[health];
-  return `${emoji} **${title}** (${count})`;
-}
-
+/** Health → State-column emoji for the snapshot table. */
 const HEALTH_EMOJI: Record<AccountHealth, string> = {
   healthy: '🟢',
   throttling: '🟡',
   blocked: '🔴',
   unknown: '⚪',
-};
-
-const HEALTH_TITLE: Record<AccountHealth, string> = {
-  healthy: 'HEALTHY',
-  throttling: 'THROTTLING',
-  blocked: 'BLOCKED',
-  unknown: 'UNKNOWN',
 };
 
 /**
@@ -377,42 +416,102 @@ function formatAgeStamp(atMs: number, now: Date = new Date()): string {
   return ageSec < 60 ? `${ageSec}s ago` : `${Math.round(ageSec / 60)}m ago`;
 }
 
+/**
+ * Health-group rank for the table's secondary sort (after active-first):
+ * problems before good news so the user scans the walled accounts at the top.
+ * blocked → throttling → unknown → healthy.
+ */
+const TABLE_HEALTH_RANK: Record<AccountHealth, number> = {
+  blocked: 0,
+  throttling: 1,
+  unknown: 2,
+  healthy: 3,
+};
+
+/** Escape a cell value for a GFM table cell: pipes break the column grid, and
+ *  newlines break the row. Emails don't normally carry either, but be safe. */
+function tableCell(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
+}
+
+/** The two percent cells (5h / 7d), refill-normalized + clamped, or a
+ *  data-quality marker when the probe is missing/thin. */
+function pctCells(
+  snap: AccountSnapshot,
+  now: Date,
+): { five: string; seven: string } {
+  if (!snap.quota) return { five: '—', seven: '—' };
+  if (isProbeThin(snap.quota)) return { five: '?', seven: '?' };
+  const norm = refillNormalizedUtils(snap.quota, now);
+  return { five: fmtPct(norm.fiveHourUtilizationPct), seven: fmtPct(norm.sevenDayUtilizationPct) };
+}
+
+/**
+ * The Status cell: for a blocked account, when the binding window comes back
+ * (`back <when>`); for a healthy/throttling account, when the soonest window
+ * refills (`refills <when>`). `<when>` is the tz-aware absolute time (date shown
+ * only when not today) plus the concise relative hint in parens.
+ */
+function statusCell(snap: AccountSnapshot, now: Date, tz: string): string {
+  if (!snap.quota) {
+    return snap.quotaError ? `probe failed (${snap.quotaError})` : 'probe failed';
+  }
+  if (isProbeThin(snap.quota)) return 'quota unknown';
+  const q = snap.quota;
+  const health = classifyHealth(snap, now);
+  if (health === 'blocked') {
+    const win = bindingWindow(q);
+    const reset = win === '5h' ? q.fiveHourResetAt : q.sevenDayResetAt;
+    if (!reset) return 'back — (reset unknown)';
+    return `back ${formatStatusTime(reset, now, tz)} (in ${formatRelative(reset, now)})`;
+  }
+  // healthy / throttling — show the soonest refill across both windows.
+  const fiveIn = q.fiveHourResetAt ? q.fiveHourResetAt.getTime() - now.getTime() : Infinity;
+  const sevenIn = q.sevenDayResetAt ? q.sevenDayResetAt.getTime() - now.getTime() : Infinity;
+  const soonest = fiveIn <= sevenIn ? q.fiveHourResetAt : q.sevenDayResetAt;
+  if (!soonest) return 'refills —';
+  return `refills ${formatStatusTime(soonest, now, tz)} (in ${formatRelative(soonest, now)})`;
+}
+
 export function renderAuthSnapshotFormat2(
   snapshots: AccountSnapshot[],
   opts: SnapshotRenderOpts = {},
 ): string {
   const now = opts.now ?? new Date();
+  const tz = opts.tz ?? 'UTC';
   const lines: string[] = [];
   lines.push('🔋 **Auth — fleet status**');
 
-  // Group by health. Render BLOCKED first (it's the urgent action),
-  // then THROTTLING (potential next problem), then HEALTHY (good
-  // news), then UNKNOWN (data quality issue). The active account
-  // floats to the top of its group regardless.
-  const order: AccountHealth[] = ['blocked', 'throttling', 'healthy', 'unknown'];
-  const grouped = new Map<AccountHealth, AccountSnapshot[]>();
-  for (const s of snapshots) {
-    const h = classifyHealth(s, now);
-    if (!grouped.has(h)) grouped.set(h, []);
-    grouped.get(h)!.push(s);
-  }
-  // Within each group, active first.
-  for (const arr of grouped.values()) {
-    arr.sort((a, b) => Number(b.isActive) - Number(a.isActive));
-  }
+  // Single sorted table: the ACTIVE account always sorts to the top row,
+  // regardless of its health group. Remaining rows order by health so
+  // problems are visible — blocked → throttling → unknown → healthy — then
+  // stable/alpha on label for a deterministic order.
+  const ordered = [...snapshots].sort((a, b) => {
+    if (a.isActive !== b.isActive) return a.isActive ? -1 : 1;
+    const r = TABLE_HEALTH_RANK[classifyHealth(a, now)] - TABLE_HEALTH_RANK[classifyHealth(b, now)];
+    if (r !== 0) return r;
+    return a.label.localeCompare(b.label);
+  });
 
-  for (const h of order) {
-    const arr = grouped.get(h);
-    if (!arr || arr.length === 0) continue;
+  if (ordered.length > 0) {
     lines.push('');
-    lines.push(groupHeader(h, arr.length));
-    for (const s of arr) {
-      for (const ln of renderAccountRow(s, opts)) lines.push(ln);
+    lines.push('| State | Account | 5h | 7d | Status |');
+    lines.push('| --- | --- | --- | --- | --- |');
+    for (const s of ordered) {
+      const emoji = HEALTH_EMOJI[classifyHealth(s, now)];
+      // Account cell: FULL email, never truncated; active gets a (active) suffix.
+      // The black-dot active marker is intentionally removed — the suffix reads.
+      const label = displayLabel(s.label, opts);
+      const account = s.isActive ? `${label} (active)` : label;
+      const { five, seven } = pctCells(s, now);
+      const status = statusCell(s, now, tz);
+      lines.push(
+        `| ${emoji} | ${tableCell(account)} | ${five} | ${seven} | ${tableCell(status)} |`,
+      );
     }
   }
 
   lines.push('');
-  lines.push('────────────────────────────');
   lines.push(`_${recommendation(snapshots, now, opts.demo ?? false)}_`);
   // #2495 Change 2 — a failed probe-on-open renders an explicit "cached Nm
   // ago" warning, never a false live stamp. The degraded variant takes

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -20877,7 +20877,7 @@ bot.command('usage', async ctx => {
           }
           return hit?.result ?? { ok: false as const, reason: 'broker returned no result for account' }
         })
-        const { renderAuthSnapshotFormat2, buildSnapshotsFromState } = await import(
+        const { renderAuthSnapshotFormat2, buildSnapshotsFromState, buildSnapshotKeyboard } = await import(
           '../auth-snapshot-format.js'
         )
         const tz = process.env.SWITCHROOM_TIMEZONE ?? process.env.TZ ?? 'UTC'
@@ -20888,7 +20888,22 @@ bot.command('usage', async ctx => {
           demo,
           ...(staleCachedAtMs != null ? { staleCachedAtMs } : { liveProbedAtMs: Date.now() }),
         })
-        await switchroomReply(ctx, text, { html: true })
+        // Preserve the Switch/Refresh/usage/Add inline keyboard on the
+        // rich-message render — the table card carries the same actions the
+        // /auth snapshot does. switchroomReply routes through the rich path
+        // (replyWithRichMessage), which accepts reply_markup. Build a grammy
+        // InlineKeyboard so the markup type matches switchroomReply's contract.
+        const kbRows = buildSnapshotKeyboard(snapshots, { now: new Date() })
+        const keyboard = new InlineKeyboard()
+        kbRows.forEach((row, ri) => {
+          if (ri > 0) keyboard.row()
+          for (const b of row) {
+            if (b.callbackData) keyboard.text(b.text, b.callbackData)
+            else if (b.insertText) keyboard.switchInlineCurrent(b.text, b.insertText)
+            else keyboard.text(b.text, 'auth:noop')
+          }
+        })
+        await switchroomReply(ctx, text, { html: true, reply_markup: keyboard })
         return
       }
     }

--- a/telegram-plugin/tests/auth-command-format2.test.ts
+++ b/telegram-plugin/tests/auth-command-format2.test.ts
@@ -93,8 +93,12 @@ describe('renderShowText — Format 2 vs legacy', () => {
     });
     expect(out).toContain('🔋 **Auth — fleet status**');
     expect(out).toContain('Recommendation:');
-    expect(out).toContain('🔴 **BLOCKED**');
-    expect(out).toContain('🟢 **HEALTHY**');
+    // GFM table card (#2700): State emoji per row, not group headers.
+    expect(out).toContain('| State | Account | 5h | 7d | Status |');
+    expect(out).toContain('| 🔴 |'); // the blocked account's State cell
+    expect(out).toContain('| 🟢 |'); // a healthy account's State cell
+    expect(out).not.toContain('**BLOCKED**');
+    expect(out).not.toContain('**HEALTHY**');
     // Legacy ASCII column headers should be absent
     expect(out).not.toContain('ACCOUNT     STATUS');
   });

--- a/telegram-plugin/tests/auth-snapshot-format.test.ts
+++ b/telegram-plugin/tests/auth-snapshot-format.test.ts
@@ -11,6 +11,7 @@ import {
   bindingWindow,
   formatRelative,
   formatAbsolute,
+  formatStatusTime,
   fmtPct,
   recommendation,
   renderAuthSnapshotFormat2,
@@ -133,6 +134,14 @@ describe('fmtPct', () => {
     expect(fmtPct(8.6)).toBe('9%');
     expect(fmtPct(99.6)).toBe('100%');
   });
+  it('CLAMPS the displayed value to 100% — never shows over 100 (trust)', () => {
+    // Anthropic returns a decimal that can exceed 1.0; quota-check multiplies by
+    // 100 → e.g. 1.01 → 101. The displayed number must clamp to 100%.
+    expect(fmtPct(101)).toBe('100%');
+    expect(fmtPct(100.4)).toBe('100%');
+    expect(fmtPct(250)).toBe('100%');
+    expect(fmtPct(1.01 * 100)).toBe('100%');
+  });
 });
 
 // ── formatAbsolute ───────────────────────────────────────────────────
@@ -146,6 +155,52 @@ describe('formatAbsolute', () => {
   });
   it('returns "—" for null', () => {
     expect(formatAbsolute(null, 'UTC')).toBe('—');
+  });
+});
+
+// ── formatStatusTime (date shown only when NOT today, in user tz) ─────
+describe('formatStatusTime', () => {
+  // Fixed injected now + fixed tz → fully deterministic (no wall-clock).
+  // 2026-05-15T05:00:00Z = Fri 15 May 3:00 PM in Australia/Melbourne (AEST,
+  // UTC+10). May is winter there → AEST, not AEDT — the tz database handles it.
+  const MEL = 'Australia/Melbourne';
+  const NOW_MEL = new Date('2026-05-15T05:00:00Z'); // Fri 3:00 PM Melbourne
+
+  it('shows TIME ONLY when the target is the same calendar day (user tz)', () => {
+    // 2026-05-15T13:00:00Z = Fri 11:00 PM Melbourne — same Melbourne day as now.
+    const out = formatStatusTime(new Date('2026-05-15T13:00:00Z'), NOW_MEL, MEL);
+    expect(out).toBe('11:00 PM');
+    // No weekday/date leaks on a same-day target.
+    expect(out).not.toMatch(/Mon|Tue|Wed|Thu|Fri|Sat|Sun/);
+  });
+
+  it('includes the WEEKDAY when the target is a different day (within the week)', () => {
+    // 2026-05-15T15:00:00Z = Sat 16 May 1:00 AM Melbourne — next Melbourne day.
+    const out = formatStatusTime(new Date('2026-05-15T15:00:00Z'), NOW_MEL, MEL);
+    expect(out).toBe('Sat 1:00 AM');
+    expect(out).toMatch(/^Sat\b/);
+  });
+
+  it('includes day-of-month + month when the target is beyond the current week', () => {
+    // ~9 days out: 2026-05-24T01:00:00Z = Sun 24 May 11:00 AM Melbourne.
+    const out = formatStatusTime(new Date('2026-05-24T01:00:00Z'), NOW_MEL, MEL);
+    // Intl en-US renders the weekday+day+month as "Sun, May 24".
+    expect(out).toBe('Sun, May 24 11:00 AM');
+    expect(out).toMatch(/^Sun\b/);
+    expect(out).toContain('May 24');
+  });
+
+  it('is tz-correct — same instant renders differently in UTC vs Melbourne', () => {
+    const instant = new Date('2026-05-15T15:00:00Z');
+    // In UTC that instant is still Fri 15 May 3:00 PM → same day as NOW_MEL's UTC
+    // wall date — but NOW in UTC terms is also 2026-05-15, so time-only.
+    expect(formatStatusTime(instant, NOW_MEL, 'UTC')).toBe('3:00 PM');
+    // In Melbourne it has crossed midnight into Saturday.
+    expect(formatStatusTime(instant, NOW_MEL, MEL)).toBe('Sat 1:00 AM');
+  });
+
+  it('returns "—" for a null target', () => {
+    expect(formatStatusTime(null, NOW_MEL, MEL)).toBe('—');
   });
 });
 
@@ -191,84 +246,120 @@ describe('renderAuthSnapshotFormat2', () => {
     }),
   ];
 
-  it('renders three health-grouped sections (BLOCKED first, then HEALTHY)', () => {
+  // Helper: parse the GFM table rows (the lines between the header separator
+  // and the trailing blank line) into their cell arrays.
+  function tableRows(out: string): string[][] {
+    const lines = out.split('\n');
+    const sep = lines.findIndex((l) => /^\|\s*---/.test(l));
+    if (sep < 0) return [];
+    const rows: string[][] = [];
+    for (let i = sep + 1; i < lines.length; i++) {
+      const l = lines[i];
+      if (!l.startsWith('|')) break;
+      rows.push(l.split('|').slice(1, -1).map((c) => c.trim()));
+    }
+    return rows;
+  }
+
+  it('renders a GFM table with the State/Account/5h/7d/Status header', () => {
     const out = renderAuthSnapshotFormat2(fixtureSnaps, { now: NOW, tz: 'UTC' });
-    // Headers present
     expect(out).toContain('🔋 **Auth — fleet status**');
-    expect(out).toContain('🔴 **BLOCKED** (1)');
-    expect(out).toContain('🟢 **HEALTHY** (2)');
-    // Order: BLOCKED before HEALTHY
-    expect(out.indexOf('🔴')).toBeLessThan(out.indexOf('🟢'));
+    expect(out).toContain('| State | Account | 5h | 7d | Status |');
+    expect(out).toContain('| --- | --- | --- | --- | --- |');
+    // No legacy group headers / health-section titles remain.
+    expect(out).not.toContain('**BLOCKED**');
+    expect(out).not.toContain('**HEALTHY**');
   });
 
-  it('marks the active account with ●', () => {
+  it('sorts the ACTIVE account to the top row regardless of health group', () => {
+    const rows = tableRows(renderAuthSnapshotFormat2(fixtureSnaps, { now: NOW, tz: 'UTC' }));
+    expect(rows.length).toBe(3);
+    // you@example.com is active + healthy; bob is blocked. Active still wins
+    // the top row over the blocked account.
+    expect(rows[0][1]).toContain('you@example.com');
+  });
+
+  it('labels the active account with " (active)" and NO black-dot marker', () => {
     const out = renderAuthSnapshotFormat2(fixtureSnaps, { now: NOW, tz: 'UTC' });
-    expect(out).toMatch(/●\s*`you@example\.com`/);
+    expect(out).toContain('you@example.com (active)');
+    // The ⚫/● active marker is removed entirely.
+    expect(out).not.toContain('⚫');
+    expect(out).not.toContain('●');
   });
 
-  it('shows "back …" for blocked accounts with binding-window word', () => {
-    const out = renderAuthSnapshotFormat2(fixtureSnaps, { now: NOW, tz: 'UTC' });
-    // bob@example is blocked on 7d, recovers Sun
-    expect(out).toMatch(/bob@example\.com[\s\S]*back .* 7-day cap/);
-  });
-
-  it('wraps the cap-line ETA in a `code` span while keeping the surrounding _italic_', () => {
-    const out = renderAuthSnapshotFormat2(fixtureSnaps, { now: NOW, tz: 'UTC' });
-    const capLine = out.split('\n').find((l) => l.includes('quota exhausted'));
-    expect(capLine).toBeDefined();
-    // ETA backtick code-span: "(`in …`, 7-day cap)"
-    expect(capLine).toMatch(/\(`in .+?`, 7-day cap\)/);
-    // The whole sub-line stays italic-wrapped.
-    expect(capLine!.trim().startsWith('_quota exhausted')).toBe(true);
-    expect(capLine!.trim().endsWith('_')).toBe(true);
-  });
-
-  it('drops the ETA code-span on a blocked account with no known reset time', () => {
-    // Blocked on 7d but the binding window has no reset epoch — must NOT
-    // render a `in —` code-span; falls back to plain "reset time unknown".
-    const noReset = [
-      snap({ label: 'norst@example.com', isActive: true, quota: quota({ sevenDayUtilizationPct: 100 }) }),
+  it('shows the FULL email address, never truncated', () => {
+    const longSnaps = [
+      snap({ label: 'a-very-long-account-name@really-long-domain.example.com', isActive: true, quota: quota({ fiveHourUtilizationPct: 5 }) }),
     ];
-    const out = renderAuthSnapshotFormat2(noReset, { now: NOW, tz: 'UTC' });
-    const capLine = out.split('\n').find((l) => l.includes('quota exhausted'));
-    expect(capLine).toBeDefined();
-    expect(capLine).not.toContain('`in —`');
-    expect(capLine).not.toContain('—`');
-    expect(capLine).toContain('reset time unknown');
-    expect(capLine!.trim().startsWith('_quota exhausted')).toBe(true);
-    expect(capLine!.trim().endsWith('_')).toBe(true);
+    const rows = tableRows(renderAuthSnapshotFormat2(longSnaps, { now: NOW, tz: 'UTC' }));
+    expect(rows[0][1]).toContain('a-very-long-account-name@really-long-domain.example.com');
+    expect(rows[0][1]).not.toContain('…');
+    expect(rows[0][1]).not.toContain('...');
   });
 
-  it('wraps both the 5h-refills and 7d-resets ETAs in `code` spans', () => {
-    const out = renderAuthSnapshotFormat2(fixtureSnaps, { now: NOW, tz: 'UTC' });
-    const lines = out.split('\n');
-    const fiveLine = lines.find((l) => l.includes('5h refills') && l.includes('`in '));
-    const sevenLine = lines.find((l) => l.includes('7d resets') && l.includes('`in '));
-    expect(fiveLine).toBeDefined();
-    expect(sevenLine).toBeDefined();
-    // Each ETA value sits in a backtick code-span, inside the italic sub-line.
-    expect(fiveLine).toMatch(/5h refills .+ \(`in .+?`\)/);
-    expect(sevenLine).toMatch(/7d resets .+ \(`in .+?`\)/);
+  it('orders non-active rows blocked-before-healthy', () => {
+    const rows = tableRows(renderAuthSnapshotFormat2(fixtureSnaps, { now: NOW, tz: 'UTC' }));
+    // After the active row (you), the blocked bob must precede the healthy alice.
+    const bob = rows.findIndex((r) => r[1].includes('bob@example.com'));
+    const alice = rows.findIndex((r) => r[1].includes('alice@example.com'));
+    expect(bob).toBeGreaterThan(0);
+    expect(bob).toBeLessThan(alice);
   });
 
-  it('puts the imminent window first on healthy/throttling rows', () => {
-    const out = renderAuthSnapshotFormat2(fixtureSnaps, { now: NOW, tz: 'UTC' });
-    // you: 5h reset is in 7m, 7d reset is in 2d. 5h should come first.
-    // The two reset segments now render on SEPARATE lines (so the 7d
-    // segment doesn't wrap mid-line on a narrow phone) — the imminent 5h
-    // line must precede the 7d line, each on its own line.
-    const lines = out.split('\n');
-    const fiveLine = lines.findIndex((l) => l.includes('5h refills'));
-    const sevenLine = lines.findIndex((l) => l.includes('7d resets'));
-    expect(fiveLine).toBeGreaterThanOrEqual(0);
-    expect(sevenLine).toBeGreaterThanOrEqual(0);
-    // Distinct lines, 5h before 7d.
-    expect(fiveLine).toBeLessThan(sevenLine);
-    expect(lines[fiveLine]).not.toContain('7d resets');
-    expect(lines[sevenLine]).not.toContain('5h refills');
-    // The ETA value is wrapped in a `code` span so the countdown pops.
-    expect(lines[fiveLine]).toMatch(/\(`in .+?`\)/);
-    expect(lines[sevenLine]).toMatch(/\(`in .+?`\)/);
+  it('Status column shows "back <when>" for a blocked account', () => {
+    const rows = tableRows(renderAuthSnapshotFormat2(fixtureSnaps, { now: NOW, tz: 'UTC' }));
+    const bob = rows.find((r) => r[1].includes('bob@example.com'))!;
+    expect(bob[4]).toMatch(/^back .* \(in .+\)$/);
+  });
+
+  it('Status column shows "refills <when>" for a healthy account', () => {
+    const rows = tableRows(renderAuthSnapshotFormat2(fixtureSnaps, { now: NOW, tz: 'UTC' }));
+    const you = rows.find((r) => r[1].includes('you@example.com'))!;
+    expect(you[4]).toMatch(/^refills .* \(in .+\)$/);
+  });
+
+  it('NEVER displays a percentage over 100% even on an over-cap account', () => {
+    // Feed 1.01 (decimal) * 100 = 101 → must clamp to 100% in the cell.
+    const overSnaps = [
+      snap({
+        label: 'over@example.com',
+        isActive: true,
+        quota: quota({ fiveHourUtilizationPct: 101, sevenDayUtilizationPct: 250 }),
+      }),
+    ];
+    const rows = tableRows(renderAuthSnapshotFormat2(overSnaps, { now: NOW, tz: 'UTC' }));
+    expect(rows[0][2]).toBe('100%'); // 5h
+    expect(rows[0][3]).toBe('100%'); // 7d
+    // And the blocked state still surfaces via the emoji (🔴) + Status.
+    expect(rows[0][0]).toBe('🔴');
+    expect(rows[0][4]).toMatch(/^back/);
+  });
+
+  it('renders dates in the Status column only when NOT today (user tz)', () => {
+    // now = Fri 3:00 PM Melbourne. A reset later the SAME Melbourne day shows
+    // time-only; a reset on the next day shows the weekday.
+    const MEL = 'Australia/Melbourne';
+    const NOW_MEL = new Date('2026-05-15T05:00:00Z'); // Fri 3:00 PM Mel
+    const sameDay = [
+      snap({ label: 'today@example.com', isActive: true, quota: quota({
+        fiveHourUtilizationPct: 5,
+        fiveHourResetAt: new Date('2026-05-15T11:00:00Z'), // Fri 9:00 PM Mel (today)
+        sevenDayResetAt: new Date('2026-05-22T11:00:00Z'),
+      }) }),
+    ];
+    const todayRows = tableRows(renderAuthSnapshotFormat2(sameDay, { now: NOW_MEL, tz: MEL }));
+    expect(todayRows[0][4]).toContain('9:00 PM');
+    expect(todayRows[0][4]).not.toMatch(/Mon|Tue|Wed|Thu|Fri|Sat|Sun/);
+
+    const nextDay = [
+      snap({ label: 'tomorrow@example.com', isActive: true, quota: quota({
+        fiveHourUtilizationPct: 5,
+        fiveHourResetAt: new Date('2026-05-15T15:00:00Z'), // Sat 1:00 AM Mel (tomorrow)
+        sevenDayResetAt: new Date('2026-05-22T11:00:00Z'),
+      }) }),
+    ];
+    const tomorrowRows = tableRows(renderAuthSnapshotFormat2(nextDay, { now: NOW_MEL, tz: MEL }));
+    expect(tomorrowRows[0][4]).toContain('Sat 1:00 AM');
   });
 
   it('emits a recommendation footer that names a healthy alternative when active is throttling', () => {
@@ -293,9 +384,10 @@ describe('renderAuthSnapshotFormat2', () => {
       snap({ label: 'broken@x', isActive: true, quota: null, quotaError: 'HTTP 401' }),
     ];
     const out = renderAuthSnapshotFormat2(errSnaps, { now: NOW });
-    expect(out).toContain('quota probe failed');
+    // Probe-failed row: ⚪ State emoji + a "probe failed (...)" Status cell.
+    expect(out).toContain('probe failed');
     expect(out).toContain('HTTP 401');
-    expect(out).toContain('⚪ **UNKNOWN**');
+    expect(out).toContain('⚪');
   });
 
   it('renders refresh stamp when liveProbedAtMs given', () => {
@@ -342,9 +434,8 @@ describe('renderAuthSnapshotFormat2', () => {
       expect(out).not.toContain('alice@example.com');
       expect(out).not.toContain('bob@example.com');
       expect(out).not.toContain('you@example.com');
-      // Masked fakes present (pool order from a clean cache: blocked-first
-      // render order means bob is masked first, then alice/you in healthy).
-      expect(out).toMatch(/`[^@<]+@example\.com`/);
+      // Masked fakes present — plain table cells (no backtick wrap now).
+      expect(out).toMatch(/[^@\s<]+@example\.com/);
     });
 
     it('WITH demo, the recommendation footer masks the active label', () => {
@@ -922,23 +1013,20 @@ describe('#2494 Bug C — blockedReason + thin probe (out_of_credits now informa
 // ── #2494 — row rendering: out_of_credits as informational annotation ─────────
 
 describe('#2494 — renderAuthSnapshotFormat2 row rendering (out_of_credits demoted)', () => {
-  it('out_of_credits at 0% util → healthy row with informational overage annotation, NOT blocked', () => {
-    // THE KEY CHANGE: carol scenario — 0% util, out_of_credits → healthy group
-    // with an informational sub-line "overage off (out_of_credits) — serving from quota"
+  it('out_of_credits at 0% util → healthy (🟢) row, NOT blocked', () => {
+    // THE KEY CHANGE: carol scenario — 0% util, out_of_credits → healthy. In the
+    // table this surfaces as a 🟢 State emoji, not 🔴 — the row is not blocked.
     const out = renderAuthSnapshotFormat2(
       [snap({ label: 'dead@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 0, overageDisabledReason: 'out_of_credits' }) })],
       { now: NOW },
     );
-    // Must be in HEALTHY group, not BLOCKED
-    expect(out).toContain('🟢 **HEALTHY**');
-    expect(out).not.toContain('🔴 **BLOCKED**');
-    // Must have informational annotation. #2669: the reason is markdown-
-    // escaped, so the underscores in "out_of_credits" render as "out\_of\_credits".
-    expect(out).toContain('overage off (out\\_of\\_credits) — serving from quota');
-    // Must NOT have old blocked framing
+    expect(out).toContain('| 🟢 |');
+    expect(out).not.toContain('| 🔴 |');
+    // Must NOT have old blocked framing.
     expect(out).not.toContain('billing disabled');
     expect(out).not.toContain("won't recover until billing is fixed");
     expect(out).not.toContain('quota exhausted');
+    expect(out).not.toContain('back ');
   });
 
   it('out_of_credits account is a valid failover target (appears in buildSnapshotKeyboard switch buttons)', () => {
@@ -952,13 +1040,14 @@ describe('#2494 — renderAuthSnapshotFormat2 row rendering (out_of_credits demo
     expect(allText).toContain('Switch fleet → carol@example.com');
   });
 
-  it('quota-exhausted row shows a recovery countdown, not "billing disabled" or overage annotation', () => {
+  it('quota-exhausted row shows a 🔴 + "back <when>" Status, not "billing disabled"', () => {
     const futureReset = new Date(NOW.getTime() + 45 * 60_000);
     const out = renderAuthSnapshotFormat2(
       [snap({ label: 'ex@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 100, fiveHourResetAt: futureReset }) })],
       { now: NOW },
     );
-    expect(out).toContain('quota exhausted');
+    expect(out).toContain('| 🔴 |');
+    expect(out).toMatch(/back .* \(in 45m\)/);
     expect(out).not.toContain('billing disabled');
     expect(out).not.toContain('overage off');
   });
@@ -978,7 +1067,8 @@ describe('#2494 — renderAuthSnapshotFormat2 row rendering (out_of_credits demo
       [snap({ label: 'org@x', isActive: false, quota: quota({ fiveHourUtilizationPct: 85, overageDisabledReason: 'org_level_disabled' }) })],
       { now: NOW },
     );
-    expect(out).toContain('🟡 **THROTTLING**');
+    // 85% util → throttling, surfaced as the 🟡 State emoji in the table.
+    expect(out).toContain('| 🟡 |');
     expect(out).not.toContain('overage off');
   });
 


### PR DESCRIPTION
## Summary

Reshapes the `/usage` (and the shared `/auth show`) **Auth — fleet status** card from health-grouped text blocks into a single **GFM markdown table** rendered through the rich-message path:

```
| State | Account | 5h | 7d | Status |
```

- **State** — health emoji (🔴 blocked / 🟡 throttling / 🟢 healthy / ⚪ unknown).
- **Account** — the FULL email, never truncated. The active account gets a ` (active)` suffix; the `⚫`/`●` black-dot active marker is **removed** (it didn't read as active).
- **Active-first ordering** — the active account always sorts to the top row regardless of its health group; remaining rows order problems-first (blocked → throttling → unknown → healthy) then alpha. One sorted table, no group headers.
- **5h / 7d** — display values **clamped to 100%** in `fmtPct`. Anthropic returns a decimal that can exceed 1.0 (→ `101%`), which erodes trust. The clamp is **display-only**: the blocked/exhausted state still surfaces via the emoji + Status column, and the source quota data is untouched (`classifyHealth` still reads the true value).
- **Status** — `back <when>` (blocked) / `refills <when>` (healthy). `<when>` is tz-aware via the new `formatStatusTime` helper: the **date is shown only when the reset is NOT today** in the user's timezone, with the concise `(in …)` relative hint preserved.

The `/usage` handler now also attaches the Switch/Refresh/usage/Add inline keyboard (`buildSnapshotKeyboard`), built as a grammy `InlineKeyboard` so it survives the rich-send path.

## Why

JTBD: *"which accounts are maxed, what % of limits, and when does it come back?"* The table reads faster than stacked text blocks, the full email is never lost to truncation, active is unambiguous, and `>100%` no longer appears. Advances the **subscription-honest** + **visibility (leash)** outcomes.

## How the timezone is sourced

`formatStatusTime` takes an IANA tz-database name (e.g. `Australia/Melbourne`) so DST is correct — no hard-coded offset. The gateway already sources it as `process.env.SWITCHROOM_TIMEZONE ?? process.env.TZ ?? 'UTC'` and threads it into the renderer; reused that existing source unchanged.

## Model-free / deterministic

The entire render path (`renderAuthSnapshotFormat2`, `buildSnapshotsFromState`, `formatStatusTime`, `fmtPct`, `statusCell`) is pure code with **no model call**. Quota comes from the broker `probeQuota` HTTP header probe (subscription OAuth, unchanged, pre-existing). The card renders identically with every account quota-blocked and no model callable.

## Test plan

- [x] `bun test telegram-plugin/tests/auth-snapshot-format.test.ts` — 85 pass (golden fixtures rewritten to the table shape).
- [x] New tests: 100% clamp (`1.01 → 100%`), active-row-first ordering, ` (active)` label, full-email-never-truncated, time-only-when-today vs weekday-when-not, tz-correctness (UTC vs Melbourne with a fixed injected `now` + tz).
- [x] `auth-command-format2.test.ts` updated for the table card.
- [x] `npm run lint` clean (tsc + all 8 structural guards, incl. bot-api-wrapping).
- [x] `npm run test:bun` — only 2 pre-existing, unrelated failures in `src/vault/broker/client-token.test.ts` (fail on clean `origin/main` too; vault-broker token, untouched by this PR).
- [x] Affected vitest files (`overage-allowlist-drift`, `broker/server`) green.

## Risk

Low — pure formatting change on one card surface. The `renderAccountRow` / `formatAbsolute` helpers (used by the separate auto-fallback announcement) are unchanged. `fmtPct`'s clamp also applies to the fallback announcement's headroom line, which is desirable (never `>100%`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)