### PR TITLE
docs(reference): align to ProductOS method + Ken-voice pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,15 +325,8 @@ telegram-plugin/        The enhanced MCP Telegram plugin (own Bun tests)
   card-format.ts        Shared status-card formatters (progress card
                         rendered via stream-reply-handler.ts + subagent-watcher.ts)
   tool-labels.ts        Tool-use label formatting
-  rich-send.ts          Rich-message send/edit helpers (Bot API 10.1) —
-                        `richMessage(md)` → `{ markdown }`, the ONE render
-                        path through `sendRichMessage`/`editMessageText`
-  format.ts             GFM markdown normalizer + `escapeMarkdown`
+  auth-slot-parser.ts   /auth router (add/use/list/rm)
   auto-fallback.ts      Quota-exhaustion auto-fallback
-  gateway/              Gateway core. `/auth` chat-command routing lives in
-                        gateway/auth-command.ts (parse + handle); the old
-                        auth-slot-parser.ts / auth-dashboard.ts were deleted
-                        (RFC H §7.3)
   tests/                Bun tests
 
 docker/                 Dockerfiles (base, agent, broker, kernel). Built via
@@ -373,12 +366,7 @@ The generated compose file lives at
 bun install              # install deps (project uses bun.lock)
 bun run dev -- <args>    # run the CLI directly from src/ via bin/switchroom.ts
 npm run build            # compile src/ + telegram-plugin/ → dist/
-npm run lint             # tsc --noEmit + 8 structural guard scripts:
-                         #   plugin-references, bot-api-wrapping,
-                         #   bun-test-imports, no-pii-secrets,
-                         #   vault-test-hermeticity, no-broadcast-delivery,
-                         #   stale-tool-descriptions, web-subscription-honest
-                         # (see scripts/check-*.{mjs,sh})
+npm run lint             # tsc --noEmit (type-check only, no emit)
 npm test                 # vitest (src/) + bun test (telegram-plugin/)
 npm run test:vitest      # src/ only
 npm run test:bun         # telegram-plugin/ only
@@ -387,21 +375,6 @@ npm run test:watch       # vitest --watch
 
 The build output (`dist/`) is what `switchroom` resolves when installed
 globally. During local work on src/, prefer `bun run dev` over rebuilding.
-
-## Telegram formatting capability — source of truth
-
-The **Telegram Bot API changelog** is the authority on what renders, not
-our recollection: <https://core.telegram.org/bots/api-changelog>. As of
-**rich messages (Bot API 10.1, June 2026)** every outbound message goes
-through `sendRichMessage` with raw GFM-style Markdown — so **tables,
-headings (`#`), thematic rules (`---`), task lists (`- [x]`), `==highlight==`,
-blockquotes, and ordered/unordered lists all render**. Documented limits:
-**32768 chars, 500 blocks, 16 nesting levels, 20 columns per table**. The
-ONE GFM construct that still falls back to literal text is **sub/superscript**
-(`H~2~O`, `x^2^`) — avoid it. The agent-facing steer is the floor card in
-`src/agents/scaffold.ts` (`TELEGRAM_FORMATTING_FLOOR_CARD`), mirrored in
-`reference/telegram-formatting-guide.md`. When the changelog moves, update
-both.
 
 ## CI
 
@@ -503,6 +476,27 @@ misbehaves, the recovery lever is still `workflow_dispatch` re-trigger
   tests), not human dev hours. "12 dev hours" is the wrong unit;
   "~25 agent minutes" is the right one. Reserve human-time estimates
   only for work that explicitly needs the user's review or input.
+
+## Doc & surface voice
+
+How switchroom talks — in docs, CLI output, errors, status surfaces, the
+setup wizard. This is the house voice; match it.
+
+- **Plain, direct, opinionated.** Reads like one person built it,
+  because one did.
+- **Lead with what the team feels like, not the machinery.** Open on the
+  experience of having the standing team; the plumbing comes after.
+- **Operator and trust details stay honest and present.** Never buried,
+  never dressed up. Say the real cost, the real boundary, the real
+  approval step.
+- **No filler. No hype. No em dashes.** Use a period, colon, comma, or
+  parens instead. (Structural long-dashes in headings, slugs, table
+  cells, and frontmatter status lines are fine.)
+- **Name what it deliberately doesn't do.** No API key, no harness, no
+  heartbeat, no second channel. The restraint is the point.
+- **Carries into every surface.** CLI output, errors, the status the
+  principal sees, the setup wizard — same voice everywhere, not just the
+  docs.
 
 ## Secrets on the dev host — `.env` + the auto-unlocked vault
 
@@ -771,19 +765,11 @@ section.)
 `feedback_npm_publish_landmines`: past releases shipped without
 `dist/cli/switchroom.js`).
 
-The committed `package.json` version is a stale placeholder (see step 2).
-`npm pack` names the tarball from that stale version, so you get
-`switchroom-0.16.21.tgz` even on a v0.16.22 release. **Bump `package.json`
-temporarily before packing — do NOT commit the bump:**
-
 ```
 node scripts/build.mjs                          # rebuild — reset --hard wipes dist
-node -e "const p=require('./package.json'); p.version='X.Y.Z'; \
-  require('fs').writeFileSync('./package.json', JSON.stringify(p,null,2)+'\n')"
-npm pack                                        # now produces switchroom-X.Y.Z.tgz
+npm pack                                        # produces switchroom-X.Y.Z.tgz
 tar tzf switchroom-X.Y.Z.tgz | grep -E "dist/cli/switchroom.js|vendor/hindsight" | head -5
 npm publish --ignore-scripts switchroom-X.Y.Z.tgz
-# Leave package.json bumped in the worktree (it's throwaway); don't commit it
 ```
 
 `--ignore-scripts` skips `prepublishOnly` so the verified tarball is
@@ -800,26 +786,6 @@ switchroom --version    # confirm X.Y.Z
 --workflow=docker-images --limit 2`, ~5 min). All 5 images (agent,
 broker, auth-broker, kernel, hindsight) must be pull-able under the
 new tag.
-
-**8a. Update the web container** — `switchroom update` and per-agent
-`agent restart` only touch agent/broker/kernel images. The
-`switchroom-web` container is a **separate compose project**
-(`~/.switchroom/web/docker-compose.yml`) and must be updated manually:
-
-```
-docker pull ghcr.io/switchroom/switchroom-web:vX.Y.Z
-sed -i 's|switchroom-web:vOLD|switchroom-web:vX.Y.Z|g' ~/.switchroom/web/docker-compose.yml
-docker compose -p switchroom-web -f ~/.switchroom/web/docker-compose.yml up -d
-docker exec switchroom-web switchroom --version   # confirm X.Y.Z
-```
-
-The auth token for the web API lives at `~/.switchroom/web-token` (plain
-text, auto-generated on first start). Use it to smoke-test endpoints:
-
-```
-TOKEN=$(cat ~/.switchroom/web-token)
-curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/sessions | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d['sessions']), 'sessions')"
-```
 
 **9. Canary on test-harness BEFORE fleet rollout** — mandatory gate.
 See **Pre-rollout UAT** below.
@@ -1076,9 +1042,7 @@ invariants, job specs — see "Design contract" above.)
   NOT source the header from `subagent-watcher.ts`. E2E gate:
   `telegram-plugin/uat/scenarios/jtbd-worker-activity-feed-dm.test.ts`.
 - **Auth** → `src/auth/accounts.ts` (slots) + `src/auth/manager.ts`
-  (OAuth). Telegram `/auth` routing: `telegram-plugin/gateway/auth-command.ts`
-  (`parseAuthCommand` + `handleAuthCommand`; the old `auth-slot-parser.ts`
-  was deleted in RFC H §7.3).
+  (OAuth). Telegram `/auth` routing: `telegram-plugin/auth-slot-parser.ts`.
 - **Runtime inspection** → `switchroom debug turn <agent>` (prompt
   layering) and `switchroom workspace render <agent>` (bootstrap block).
 - **Compose generation** → `src/agents/compose.ts:generateCompose()`,

--- a/reference/README.md
+++ b/reference/README.md
@@ -15,9 +15,9 @@ reference/
                                                   details the no-self-escalation invariant)
 ```
 
-The **root holds only the anchors and the product spec** — the top tier.
+The **root holds only the anchors and the product spec**, the top tier.
 **Durable** docs (anchors, product-spec, jobs) state *what the product must be
-and do*; they outlive any implementation. The **`rfcs/`** layer carries *how* —
+and do*; they outlive any implementation. The **`rfcs/`** layer carries *how*:
 ship-coupled proposals (with a `status:`) and standing design records (e.g.
 `access-model.md`, which details the `no-self-escalation` invariant). The split
 is by folder + frontmatter, not by two separate trees.
@@ -34,21 +34,21 @@ is by folder + frontmatter, not by two separate trees.
 | RFCs ([`rfcs/`](rfcs/), `status:` / `artefact:` frontmatter) | *How do we build/ship this change?* — ship-coupled proposals + design records |
 | [`../messaging/copy-kit.md`](../messaging/copy-kit.md) | *How do we say it?* — ready-to-lift public copy (tagline, pillars, boilerplate), each block traced to a product-spec outcome |
 
-The first three are the **anchors**; `product-spec.md` is the product layer
-*beneath* them (it owns the job list); the job specs sit beneath that. The
-RFCs are the ship-coupled delivery layer — each references the job it serves;
-they are **not** a durable contract tier of their own.
+The first three are the **anchors**. `product-spec.md` is the product layer
+*beneath* them (it owns the job list), and the job specs sit beneath that. The
+RFCs are the ship-coupled delivery layer, each referencing the job it serves.
+They are **not** a durable contract tier of their own.
 
 The **verdict rule** (also in `CLAUDE.md` → "Design contract"): a change ships
 only when it (a) advances one of the four outcomes, (b) satisfies its job
-spec — proven by its outcome UAT, (c) passes all three principle checks, and
+spec (proven by its outcome UAT), (c) passes all three principle checks, and
 (d) crosses no invariant.
 
 ## The job index lives in the product spec
 
 [`product-spec.md`](product-spec.md) owns the list of jobs, grouped by the
 outcome each `serves:`. That is the single source of truth for "which jobs
-does switchroom serve" — this README does not duplicate it.
+does switchroom serve". This README does not duplicate it.
 
 ## Use this directory cheaply
 
@@ -64,7 +64,7 @@ head -7 reference/jobs/*.md | grep -E '^(==>|job:|outcome:|stakes:|serves:)'
 Read a job spec in full only when your change touches it. The body is short
 by design: **Good / bad** (the dual-audience decision aid, read by humans
 *and* agents), **Prove it** (UAT wired to real scenarios + a fuzz corpus),
-and **Verdict**. The *how* is not here — it's in the RFC the job points to.
+and **Verdict**. The *how* is not here: it's in the RFC the job points to.
 
 ## Doc-class rule
 
@@ -76,13 +76,13 @@ Decide what a doc is from its frontmatter key alone:
   rewritten.
 - `status:` / `artefact:` / `serves:` / `backs:` (no `job:`) ⇒ an **RFC or
   design record** (in `rfcs/`) that carries the implementation/how. It points
-  *up* — `serves:` at the job it delivers (e.g. [`conversational-pacing.md`](rfcs/conversational-pacing.md)
+  *up*: `serves:` at the job it delivers (e.g. [`conversational-pacing.md`](rfcs/conversational-pacing.md)
   serves `know-what-my-agent-is-doing.md`), or `backs:` the invariant it
   details (e.g. [`access-model.md`](rfcs/access-model.md) backs
   `no-self-escalation`). An RFC carries a status lifecycle (Draft → Approved →
   Shipped/Archived); a design record is kept current rather than archived.
 
-There is no other class. `job:` **always** means a job spec — nothing else
+There is no other class. `job:` **always** means a job spec, nothing else
 uses that key. The line, the outcome, and the how are three separate docs (an
 invariant, a job spec, a design record), never collapsed into one.
 
@@ -115,4 +115,4 @@ These are considered improvements over the base method, not defects:
 records** kept current (e.g. `conversational-pacing.md`,
 `status-card-design.md`). Tell them apart by frontmatter, not by folder. A
 couple are historical and say so in their own status line (e.g.
-`onboarding-gap-analysis.md` — a point-in-time analysis, not a live tracker).
+`onboarding-gap-analysis.md`, a point-in-time analysis, not a live tracker).

--- a/reference/invariants.md
+++ b/reference/invariants.md
@@ -14,7 +14,7 @@ audience: anyone designing, building, reviewing, or releasing switchroom
 > so you trade them off. An **invariant is a line we will not cross by
 > construction**, however useful a feature seems. It is the *"are we even
 > allowed / is this still switchroom"* gate in the verdict rule. A change
-> that breaks one is out of scope, full stop — not a redesign, not a
+> that breaks one is out of scope, full stop. Not a redesign, not a
 > follow-up.
 >
 > Job specs name the invariants they must never cross in their
@@ -38,24 +38,24 @@ work is the interactive session or a synthesized turn injected into it.
 ### Operator-controlled gateway carve-out
 
 A gateway the operator runs (e.g. self-hosted LiteLLM) MAY sit between the
-`claude` CLI and Anthropic — **iff** all four hold:
+`claude` CLI and Anthropic, **iff** all four hold:
 
 1. **OAuth forwarded unchanged.** It passes the operator's Pro/Max OAuth
-   credential through untouched — the subscription stays the funding *and*
+   credential through untouched: the subscription stays the funding *and*
    the identity. The gateway issues **no** `ANTHROPIC_API_KEY`, SDK, or
    raw-API call to Anthropic on the operator's behalf.
 2. **No alteration of Claude's operation.** It must not inject, rewrite, or
    strip anything that changes the model selected, the request parameters,
    or Claude's behaviour. Its only permitted writes to the stream are
    **content-safety guardrails** (PII redaction/blocking on message
-   content). Observation — token/cost metering, logging, tagging — is
+   content). Observation (token/cost metering, logging, tagging) is
    unrestricted.
 3. **Opt-in, default OFF.** No agent routes through a gateway unless the
    operator turns it on, and a gateway outage **fails open** to the direct
    subscription path (availability is never sacrificed to the proxy).
 4. **Non-Anthropic is a separate path.** Other models routed through the
    same gateway are off-subscription, separately billed, and **not** covered
-   by the subscription-native guarantee — they are a distinct,
+   by the subscription-native guarantee. They are a distinct,
    clearly-labelled route.
 
 This is subscription-native by construction: it is still the unmodified CLI
@@ -64,12 +64,12 @@ infrastructure observing and safeguarding the operator's *own* traffic.
 Aligns with the [Anthropic AUP](https://www.anthropic.com/legal/aup) and
 [Claude Code acceptable-use](https://code.claude.com/docs/en/legal-and-compliance).
 The `no protocol interception` clause above bars a *harness over* the CLI
-that fakes or reshapes the model exchange — it does **not** bar an operator
+that fakes or reshapes the model exchange. It does **not** bar an operator
 metering+safety proxy that forwards the exchange faithfully.
 
 ## `no-self-escalation`
 
-Every access decision — a secret, a tool, an MCP server, a host action —
+Every access decision (a secret, a tool, an MCP server, a host action)
 flows from operator-authored config or an operator tap, enforced where the
 agent can't rewrite it. An agent can ask for more; it can never grant itself
 more.
@@ -89,19 +89,19 @@ else.
 
 ## `single-tenant`
 
-Single **tenant** by design — one deployment on one operator's box, with
+Single **tenant** by design: one deployment on one operator's box, with
 their tokens and data. Not a multi-tenant SaaS. The deployment is the trust
 boundary.
 
 Inside that one tenant you may run **multiple trusted users**: the operator
 assigns Telegram user IDs to agents in `switchroom.yaml` (most agents serve
 one user, some serve several). Everyone the operator wires in is
-**implicitly trusted** — this is not an authorization model for mutually
+**implicitly trusted**. This is not an authorization model for mutually
 distrusting parties, and who may drive an agent is exactly that per-agent
 user assignment, nothing finer.
 
 Even within that trust, agents **should isolate memory per user and respect
-user memory privacy** — one user's memories should not bleed into another
+user memory privacy**: one user's memories should not bleed into another
 user's recall context. This is a best-effort *should*, not a hard wall, and
 it serves two ends at once: privacy among trusted users, and **token
 efficiency** (surfacing another user's irrelevant memories just wastes
@@ -110,8 +110,8 @@ isolation is *between the users they configured*, never from the operator.
 
 - **By-construction test:** does this assume more than one **tenant**
   (deployment), or expose one tenant's data to a *different* tenant? If yes,
-  it is out. Multiple trusted **users** inside one tenant — including
-  per-user memory isolation — is in scope, not a violation.
+  it is out. Multiple trusted **users** inside one tenant (including
+  per-user memory isolation) is in scope, not a violation.
 
 ## `telegram-only`
 
@@ -120,7 +120,7 @@ Slack, Discord, or Teams. Auxiliary services (e.g. voice transcription) are
 opt-in helpers, not second channels.
 
 - **By-construction test:** does this add a second human-facing chat
-  channel **for the people the team serves** — a bridge to WhatsApp, Signal,
+  channel **for the people the team serves**, a bridge to WhatsApp, Signal,
   Slack, Discord, Teams, or the like? If yes, it is out. This invariant is
   about the *principal's* channel: there is exactly one, Telegram, done
   properly. It is **not** a ban on operator/admin tooling.
@@ -128,7 +128,7 @@ opt-in helpers, not second channels.
 ### Scope: the admin console is not a channel
 
 An **operator/admin** management console (e.g. a Hermes-Desktop client pointed
-at a Switchroom adapter) is **out of this invariant's scope** — it is admin
+at a Switchroom adapter) is **out of this invariant's scope**: it is admin
 tooling for the person who runs the box, not a chat channel for the people the
 team serves. `telegram-only` stays strictly true: it governs *principal*
 channels, and the admin console is not one.
@@ -144,7 +144,7 @@ channel or a hidden conversation), it must hold all four:
    surface clear of `chat-is-the-single-source-of-truth`.)
 2. **One canonical record.** Every operator turn and the agent's reply
    **mirror into that agent's Telegram thread.** The console is another way
-   *in*, never a separate conversation the Telegram thread can't see — so
+   *in*, never a separate conversation the Telegram thread can't see, so
    there is still exactly one record, and `chat-is-the-single-source-of-truth`
    holds.
 3. **Same path, not a parallel runtime.** The operator turn is injected
@@ -156,7 +156,7 @@ channel or a hidden conversation), it must hold all four:
    sole approval surface (`no-self-escalation`). A console that wires
    approvals is out.
 
-The line that *would* cross `telegram-only` is a **principal-facing** bridge —
+The line that *would* cross `telegram-only` is a **principal-facing** bridge:
 giving the people the team serves a second way to chat (WhatsApp, Signal, a
 public web chat). That is still out. The detail contract for the admin console
 is [`rfcs/fleet-dashboard.md`](rfcs/fleet-dashboard.md).

--- a/reference/jobs/act-in-my-tools-with-an-identity.md
+++ b/reference/jobs/act-in-my-tools-with-an-identity.md
@@ -1,7 +1,7 @@
 ---
 job: have my agent show up and act in the tools where my work already happens, as itself
-outcome: When something happens in a tool the user already works in — a PR opened, a Linear issue assigned, an @-mention — the right agent shows up there, under its own identity, and does the work in that tool, not only in Telegram.
-stakes: An assistant that only lives in a chat box is a side conversation. If the user has to copy work out of Linear or GitHub into Telegram and paste results back, the agent isn't on the team — it's a tool the user operates. But an agent that acts on un-gated external input is a roaming bot wearing the operator's face. Both failures are fatal, one to usefulness and one to the leash.
+outcome: When something happens in a tool the user already works in (a PR opened, a Linear issue assigned, an @-mention) the right agent shows up there, under its own identity, and does the work in that tool, not only in Telegram.
+stakes: An assistant that only lives in a chat box is a side conversation. If the user has to copy work out of Linear or GitHub into Telegram and paste results back, the agent isn't on the team, it's a tool the user operates. But an agent that acts on un-gated external input is a roaming bot wearing the operator's face. Both failures are fatal, one to usefulness and one to the leash.
 serves: always-available
 invariants: [on-leash, no-self-escalation, single-tenant]
 ---
@@ -14,19 +14,19 @@ invariants: [on-leash, no-self-escalation, single-tenant]
 > load-bearing distinction is the **gated-vs-roaming line** in Good / bad
 > below. The *how* (the edge lock, the per-agent HMAC, the gateway-socket
 > forward, the Linear app-actor OAuth) lives in the design docs linked in
-> the footer; that churns, this job does not.
+> the footer. That churns, this job does not.
 
 ## The job
 
 The user's work doesn't happen in a chat box. It happens in the PR thread, the
-Linear ticket, the issue comment — the places where they already collaborate
+Linear ticket, the issue comment, the places where they already collaborate
 with other people. They don't want to relay all of that through Telegram by
 hand: read the ticket, paste it to the agent, copy the agent's answer back into
 the ticket. They want the agent to **show up where the work is, as a named
-participant** — a reviewer on the PR, the assignee on the issue, a teammate you
-can `@`-mention — and act there directly, with its own identity and its own
+participant** (a reviewer on the PR, the assignee on the issue, a teammate you
+can `@`-mention) and act there directly, with its own identity and its own
 granted permissions. Telegram stays the place the user *steers and oversees*
-from; the tools become places the agent can *act in*.
+from. The tools become places the agent can *act in*.
 
 The hard part is that this is the one surface where something other than the
 operator can reach an agent. So the whole job hinges on the trigger being
@@ -41,15 +41,15 @@ sides.
 **Good looks like**
 
 - A PR is opened or an issue is assigned in a tool the user already uses, and
-  the right agent shows up *there* — a comment on the thread, an activity on
-  the issue timeline — without the user relaying anything through Telegram.
+  the right agent shows up *there* (a comment on the thread, an activity on
+  the issue timeline) without the user relaying anything through Telegram.
 - The agent acts under **its own identity** in that tool: a Linear app actor
   with its own avatar, `@`-mentionable and assignable; a reviewer identity on
   the PR. Other collaborators see a named teammate, not an anonymous bot.
 - The agent only wakes on a trigger the **operator configured**: a source the
   operator allowlisted, a dispatch rule the operator wrote, an OAuth grant the
   operator scoped. Nothing else gets it to act.
-- Every inbound event is **proven authentic before it can wake an agent** —
+- Every inbound event is **proven authentic before it can wake an agent**:
   signed by a secret the operator holds, arriving through the operator's
   trusted network edge. An unsigned or off-path request is rejected and the
   agent never sees it.
@@ -59,34 +59,34 @@ sides.
 - The user oversees and steers all of it from Telegram. The tool is where the
   agent *acts*; the chat is where the user stays in the loop and on the leash.
 - When the agent's standing in a tool lapses (a revoked token, an expired
-  grant), the user is told plainly — the agent doesn't silently go dark in a
+  grant), the user is told plainly. The agent doesn't silently go dark in a
   channel the user assumed was live.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
-- The agent acts on an **un-gated external trigger** — a webhook with no
+- The agent acts on an **un-gated external trigger**: a webhook with no
   signature check, a source the operator never allowlisted, an event that
   reached the receiver off the trusted edge. *This is roaming wearing the
   operator's identity, and it breaks `on-leash` by construction.* The line:
-  acting on an **operator-configured, authenticated** trigger is the job;
-  acting on **anything that can reach the endpoint** is the anti-job.
-- A misconfigured gate that **fails open** — ingest accepting events when the
+  acting on an **operator-configured, authenticated** trigger is the job.
+  Acting on **anything that can reach the endpoint** is the anti-job.
+- A misconfigured gate that **fails open**: ingest accepting events when the
   edge secret is missing, or the HMAC unverifiable. A security gate's failure
   mode is *deny*, never *allow*.
 - The agent **self-grants reach**: widening its own OAuth scope, adding a
   webhook source, or wiring a new tool identity without an operator action.
   Scope flows from operator config or an operator tap, full stop.
-- A **heartbeat or self-authored poll** dressed up as "showing up" — the agent
+- A **heartbeat or self-authored poll** dressed up as "showing up": the agent
   waking itself to go look at a tool on a loop it invented. Showing up is
   *event-driven from a gated trigger*, never a loop the agent runs.
 - The agent acting in a tool as a **generic, anonymous bot** with no distinct
-  identity — indistinguishable from the operator, or from another agent
+  identity, indistinguishable from the operator, or from another agent
   sharing one app credential. Each acting identity is its own.
-- Treating the inbound event payload as **instructions** rather than data —
+- Treating the inbound event payload as **instructions** rather than data,
   letting a PR title or issue body steer the agent past its granted scope.
-  Untrusted content is data; the leash is the operator's config.
-- The agent going **silently dead** in a tool — a lapsed token, a disabled
-  webhook — with no word to the user, who keeps assuming it's present.
+  Untrusted content is data. The leash is the operator's config.
+- The agent going **silently dead** in a tool (a lapsed token, a disabled
+  webhook) with no word to the user, who keeps assuming it's present.
 
 ## Prove it
 
@@ -137,7 +137,7 @@ sides.
 (`telegram-plugin/uat/scenarios/`) that drives a real edge-gated webhook into a
 live agent and asserts a visible action *back in the tool* under the agent's
 identity. The layers are proven in isolation; the full path is not.
-*(coverage gap: no runnable scenario yet — needs a `jtbd-act-in-tools-*` driver
+*(coverage gap: no runnable scenario yet, needs a `jtbd-act-in-tools-*` driver
 exercising edge → ingest → wake → Linear-actor activity.)*
 
 **Fuzz corpus:** vary source (github × linear × generic) × auth state (valid
@@ -155,9 +155,9 @@ identity is always surfaced.
 
 - **Done when:** an operator-configured, authenticated event arriving through
   the trusted edge makes the right agent show up *in the tool* under its own
-  identity and act there — while an un-gated, unsigned, off-path, or
+  identity and act there, while an un-gated, unsigned, off-path, or
   un-matched event never moves the agent at all, and the user can see and
-  steer the whole thing from Telegram — proven across the auth/path/identity
+  steer the whole thing from Telegram. Proven across the auth/path/identity
   corpus above (and, once built, the end-to-end driver that closes the gap).
 
 ## Production-readiness

--- a/reference/jobs/approve-what-my-agent-can-touch.md
+++ b/reference/jobs/approve-what-my-agent-can-touch.md
@@ -1,16 +1,16 @@
 ---
 job: approve what my agent can touch, without ever leaking the secret
 outcome: From Telegram, the operator grants or denies an agent's request for a secret, tool, MCP server, or host action with one tap. Access is per-resource, the agent can ask for more but can never self-grant, and the raw credential never appears in the chat.
-stakes: Get this wrong two ways. Make granting hard or opaque and a helpful agent improvises around the gate — tells the user to paste a token into chat, guesses key names, burns taps. Make it loose and "helpful" silently becomes "escalated", with no one in the loop. Either failure leaks a credential or hands an agent access the operator never gave it.
+stakes: Get this wrong two ways. Make granting hard or opaque and a helpful agent improvises around the gate, tells the user to paste a token into chat, guesses key names, burns taps. Make it loose and "helpful" silently becomes "escalated", with no one in the loop. Either failure leaks a credential or hands an agent access the operator never gave it.
 serves: hold-the-leash
 invariants: [no-self-escalation, claude-native]
 ---
 
 # Job Spec: approve what my agent can touch, without ever leaking the secret
 
-> A durable Job Spec. The *how* — the broker, the approval kernel, the
+> A durable Job Spec. The *how* (the broker, the approval kernel, the
 > three auth paths, the per-key ACL, the redaction detector, the
-> posture-mint opt-in — lives in the design artifact
+> posture-mint opt-in) lives in the design artifact
 > `reference/rfcs/access-model.md`. That implementation churns; this job does
 > not. This spec is the **operator-facing** approval/secret-handling
 > outcome; the agent-side authorization mechanism is detailed in
@@ -22,7 +22,7 @@ invariants: [no-self-escalation, claude-native]
 The operator's agent hits the edge of what it was given: it needs a
 credential, a tool, an MCP server, or a host action it doesn't hold. The
 operator wants to make that call from their phone, in the same chat, with
-the full picture — *which* agent wants *what* — and decide in one tap. And
+the full picture (*which* agent wants *what*) and decide in one tap. And
 they want a hard guarantee under it: the agent can ask, but it can never
 grant itself; and whatever secret is involved is never exposed in the
 conversation. The job is to make granting access frictionless and honest
@@ -35,22 +35,22 @@ without ever turning the chat into a place a raw credential lives.
 - The agent that needs more never asks the user to paste a secret into
   chat. It requests; the operator gets a card; the value is provided once,
   securely, and is gone from history.
-- The approval card shows the **exact scope** — this agent, this key, this
-  file, this verb — sourced the same way it's enforced, not a friendly
+- The approval card shows the **exact scope** (this agent, this key, this
+  file, this verb), sourced the same way it's enforced, not a friendly
   label the agent picked.
 - One tap grants or denies. A grant is per-resource: approving one key
   doesn't hand over the next.
 - A granted request **auto-resumes the turn**. The operator taps Allow and
   the agent picks up where it left off, without a nudge.
 - If the operator pastes a secret anyway, the bot deletes the original
-  message and confirms — the plaintext leaves the chat, the value lands in
+  message and confirms. The plaintext leaves the chat, the value lands in
   the vault, the agent never receives it.
 - The agent can see its own sandbox and the denied path offers a clean
   one-tap request, so it stops guessing and never routes around the gate.
 - The irreversible / admin-credential case sits behind the operator
-  passphrase — a secret the agent structurally never holds — not just a tap.
+  passphrase, a secret the agent structurally never holds, not just a tap.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
 - The agent telling the user to paste a token into chat because a slot was
   empty. The improvisation *is* the leak.
@@ -61,7 +61,7 @@ without ever turning the chat into a place a raw credential lives.
 - A blanket grant: one tap silently widening the agent's access beyond the
   one resource on the card.
 - Any path where an agent ends up with access the operator never wrote down
-  or tapped for — a self-edit that survives reconcile, a wire-supplied
+  or tapped for: a self-edit that survives reconcile, a wire-supplied
   identity, a posture mint of a crown-jewel key.
 - A grant that lands but the turn dies anyway, forcing the operator to
   re-prompt the work they already approved.
@@ -87,11 +87,11 @@ Named by job × surface, pointing at real scenarios in
 - **Redaction doesn't false-positive (DM)** —
   `secret-redaction-no-false-positive-dm`. *Watch:* the operator talks
   casually about tokens/secrets and the message is left intact. *Invariant:*
-  the safety net never eats ordinary conversation — a confusing wall is
+  the safety net never eats ordinary conversation. A confusing wall is
   itself a leak risk.
 - **Request → approve → access, end to end (DM)** —
   `vault-request-access-end-to-end-dm`. *Watch:* agent requests access,
-  operator approves, the agent's read then succeeds — and only for the
+  operator approves, the agent's read then succeeds, and only for the
   approved key. *Invariant:* `no-self-escalation` — access flows from the
   operator tap, enforced where the agent can't write it.
 - **Per-resource grant under concurrency (DM)** —
@@ -128,12 +128,12 @@ per-resource, every resume a synthesized turn.
 - **Done when:** the operator can grant or deny exactly what an agent asks
   for with one honest tap, the agent can request but never self-grant, the
   raw secret never appears in chat, and a granted request resumes the turn
-  on its own — proven by the scenarios above.
+  on its own. Proven by the scenarios above.
 
 ## Production-readiness
 
 - *Confidentiality:* a raw credential never persists in chat history, logs,
-  or the agent's view — provided-once, deleted-on-paste, never returned.
+  or the agent's view: provided-once, deleted-on-paste, never returned.
   This is the load-bearing security property; a single leak is a defect, not
   a regression budget.
 - *Authorization integrity:* every grant is enforced where the agent can't
@@ -142,7 +142,7 @@ per-resource, every resume a synthesized turn.
 - *Scope fidelity:* the card's displayed scope equals the granted scope,
   sourced the same way; per-resource, never blanket.
 - *Tiering:* irreversible / admin-credential actions sit behind the operator
-  passphrase — a factor the agent structurally lacks — never a tap alone.
+  passphrase, a factor the agent structurally lacks, never a tap alone.
 - *Reliability:* an approval that lands resumes the turn; a denied or
   restart-interrupted grant never strands the agent silently.
 

--- a/reference/jobs/crons-use-the-model-only-when-it-earns-it.md
+++ b/reference/jobs/crons-use-the-model-only-when-it-earns-it.md
@@ -1,7 +1,7 @@
 ---
-job: scheduled work should cost the minimum that does it — spend the model only when it adds value
+job: scheduled work should cost the minimum that does it, spend the model only when it adds value
 outcome: A cron pays for a model only when the model earns it. Mechanical work (fetch an API, check a value, run a script) runs model-free at zero token cost. A cheap model runs only when light judgment helps. The full agent runs only when its memory and persona genuinely add value. All of it on the subscription, never the API or `claude -p`. The schedule the user set costs what the work needs, not a full reasoning turn per tick.
-stakes: A fleet of always-on specialists runs standing schedules. If every fire is a full-context turn — even a `*/10` "is there anything new?" poll, even a "fetch the feed and post it" chore with no judgment in it — the schedules quietly drain the plan ceiling. The user added a punctual assistant and got an unpredictable token bill. Worse, reaching for `claude -p` to make those cheap fires "efficient" leaves the subscription entirely and breaks Anthropic policy. The job is to make scheduled work cheap *inside* the constraint, so "always-on" never means "always-billing."
+stakes: A fleet of always-on specialists runs standing schedules. If every fire is a full-context turn, even a `*/10` "is there anything new?" poll, even a "fetch the feed and post it" chore with no judgment in it, the schedules quietly drain the plan ceiling. The user added a punctual assistant and got an unpredictable token bill. Worse, reaching for `claude -p` to make those cheap fires "efficient" leaves the subscription entirely and breaks Anthropic policy. The job is to make scheduled work cheap *inside* the constraint, so "always-on" never means "always-billing."
 serves: subscription-honest
 invariants: [claude-native, on-leash]
 ---
@@ -19,20 +19,20 @@ make each scheduled fire cost what its *work* needs and no more: a purely
 mechanical chore (fetch an endpoint, check a value, run a declared script)
 runs model-free at zero token cost; light judgment runs on a cheap model;
 real judgment that needs the agent's memory and persona runs the full
-agent. The system decides which — deterministically, from observable signals
-— so behaviour and cost are predictable and the user never configures a
+agent. The system decides which, deterministically, from observable signals,
+so behaviour and cost are predictable and the user never configures a
 tier. The model is for judgment, synthesis, drafting, decisions; it is never
 woken to make a routine API call. And every model fire is the interactive
-subscription session — never `claude -p`, never the API.
+subscription session, never `claude -p`, never the API.
 
 ## Good / bad
 
 **Good looks like**
 
 - A `*/10` "anything new?" poll and a "fetch and post" chore cost zero
-  tokens — they run model-free; only a real change escalates to the model.
+  tokens. They run model-free, and only a real change escalates to the model.
 - The cheap path is the *default*, picked by the system on a fresh setup
-  with zero config — the user never learns or sets a tier flag.
+  with zero config. The user never learns or sets a tier flag.
 - When light judgment helps (summarise, format, triage), a cheap session
   runs; the full agent fires only when its memory or persona genuinely adds
   value.
@@ -40,25 +40,25 @@ subscription session — never `claude -p`, never the API.
   plan stays the ceiling, predictable, not a meter the user can't forecast.
 - The user can see why a fire ran the way it did ("filed as cheap because
   …") without being asked to approve each tick.
-- A removed or changed schedule stops firing promptly — no zombie fires
+- A removed or changed schedule stops firing promptly: no zombie fires
   burning tokens after the user edited the schedule.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
-- A full reasoning turn for a mechanical chore — "fetch the feed and post
+- A full reasoning turn for a mechanical chore: "fetch the feed and post
   it" waking the full agent because that is the only path.
 - Reaching for `claude -p` (or the SDK / API) to make cheap fires
-  "efficient" — that leaves the subscription and breaks policy. The cheap
+  "efficient": that leaves the subscription and breaks policy. The cheap
   path is the interactive session or no model at all.
 - Cheap-as-opt-in: the expensive tier as default and the cheap one behind a
   flag the user must discover. The good behaviour must be the default.
-- A model deciding its own tier — that reintroduces non-determinism, costs
+- A model deciding its own tier: that reintroduces non-determinism, costs
   tokens, and weakens the leash. The selector is deterministic and
   model-free.
-- Stripping memory where it earns its keep — routing a cron that needs the
+- Stripping memory where it earns its keep: routing a cron that needs the
   agent's persona/history to a bare cheap session and getting a worse
   answer to save tokens.
-- A self-authored loop or a fire with no operator schedule behind it — the
+- A self-authored loop or a fire with no operator schedule behind it: the
   cheaper triggers are still "the schedule you set," never the agent
   roaming.
 - A confirm-every-cron tap in the name of control. Awareness is the leash;
@@ -99,7 +99,7 @@ no-ops, interactive-session-only on any model fire, no zombie fires.
 
 - **Done when:** scheduled work is model-free by default unless it genuinely
   needs judgment, the tier is chosen deterministically by the system, and
-  every model fire is the interactive subscription session — proven by the
+  every model fire is the interactive subscription session, proven by the
   guards above. Billing the plan for reasoning a cron never uses is the bug
   this job exists to kill.
 
@@ -107,5 +107,5 @@ no-ops, interactive-session-only on any model fire, no zombie fires.
 
 - *Compliance:* every cron model fire is the interactive `claude` session;
   zero `claude -p` / SDK / API callsites on the scheduled path.
-- *Determinism:* the tier selector is a pure function of observable signals
-  — same inputs, same tier, fully enumerable, no model in the decision loop.
+- *Determinism:* the tier selector is a pure function of observable signals.
+  Same inputs, same tier, fully enumerable, no model in the decision loop.

--- a/reference/jobs/deliver-files-i-can-open.md
+++ b/reference/jobs/deliver-files-i-can-open.md
@@ -1,6 +1,6 @@
 ---
 job: get work back as a file I can actually open
-outcome: When an agent makes a file, it lands somewhere the user can open it from their phone — a Telegram attachment or a share link to their own Drive — never a path on the container.
+outcome: When an agent makes a file, it lands somewhere the user can open it from their phone, a Telegram attachment or a share link to their own Drive, never a path on the container.
 stakes: A file the user can't reach is work that didn't happen. Hand over a `/state/agent/...` path and the agent looks like it's stalling or lying; the colleague illusion breaks on the last step.
 serves: standing-team
 invariants: [no-self-escalation]
@@ -8,21 +8,21 @@ invariants: [no-self-escalation]
 
 # Job Spec: get work back as a file I can actually open
 
-> A durable Job Spec. The *how* — the `deliver-file` verb, the OneDrive and
+> A durable Job Spec. The *how* (the `deliver-file` verb, the OneDrive and
 > Google Drive uploaders, the `Switchroom/<agent>/` folder convention, the
-> reply-tool 50 MB attach path, and the `DELIVERY_GUIDANCE` prompt block —
+> reply-tool 50 MB attach path, and the `DELIVERY_GUIDANCE` prompt block)
 > churns underneath. The job does not. This is an explicit operator-stated
 > outcome (2026-06-07): agents kept replying with container paths the user
 > couldn't open.
 
 ## The job
 
-The user asks a specialist for something that comes out as a file — a
+The user asks a specialist for something that comes out as a file: a
 report, a CSV export, a generated chart, a converted doc. They're on
 Telegram, on their phone, not on the box the agent runs on. They want the
 artifact in their hands: tap to open, save, forward. A colleague hands you
 the document; they don't email you the absolute path of the document on
-their laptop. The job is to make the last step — *delivery* — feel like
+their laptop. The job is to make the last step, *delivery*, feel like
 that. The agent runs in a container, so its native instinct is to name the
 file where it sits (`/state/agent/...`, `/tmp/...`); that path is dead on
 arrival. Close the gap so the user always gets something they can actually
@@ -35,33 +35,33 @@ reach.
 - The user gets the artifact in a form they can open from their phone: a
   Telegram attachment they tap, or a share link to a file in their own
   Drive. One tap, no copy-paste, no shell.
-- Most files just arrive in the chat — the report, the CSV, the chart land
+- Most files just arrive in the chat: the report, the CSV, the chart land
   as a Telegram attachment in the same thread, no extra step asked of the
   user.
-- Files they'll keep or that are too big for chat go to a stable home —
-  `Switchroom/<agent>/` in their own connected Drive — and the reply carries
+- Files they'll keep or that are too big for chat go to a stable home,
+  `Switchroom/<agent>/` in their own connected Drive, and the reply carries
   the share link, not a path. The same specialist's work collects in the
   same folder over time.
 - When nothing can be delivered (no Drive connected, too big for Telegram),
-  the agent says so plainly and offers the fix — never falls back to a path.
+  the agent says so plainly and offers the fix, never falling back to a path.
 - Delivery uses only the Drive access the operator already granted, and
   writes only to the agent's own delivery folder. It never reaches into the
   user's existing documents and never prompts a per-file approval to land
   its own output.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
 - Replying with a local container path (`/state/agent/report.csv`,
   `/tmp/out.png`) as if that were delivery. The user is not on the box; the
   path leads nowhere.
-- "The file is saved" with no attachment and no link — a claim of work the
+- "The file is saved" with no attachment and no link: a claim of work the
   user can't verify or open.
 - Scattering files loose in the root of the user's Drive, or overwriting
   their existing documents, instead of the agent's own `Switchroom/<agent>/`
   folder.
 - Routing delivery through a credential or scope the operator didn't grant,
   or self-granting Drive write to get the file out.
-- Silently failing to deliver and moving on — the artifact evaporates and
+- Silently failing to deliver and moving on: the artifact evaporates and
   the user never learns it was ready.
 - Making the user run a command, mount a volume, or SSH in to retrieve their
   own result.
@@ -69,7 +69,7 @@ reach.
 ## Prove it
 
 Named by job × surface. Delivery is well covered at the unit layer but has
-**no end-to-end Telegram scenario yet** — flagged honestly below.
+**no end-to-end Telegram scenario yet**, flagged honestly below.
 
 - **Upload to the right folder + share link (unit)** —
   `src/delivery/onedrive.test.ts`, `src/delivery/gdrive.test.ts`. *Watch:*
@@ -97,34 +97,34 @@ Named by job × surface. Delivery is well covered at the unit layer but has
 - **Telegram-attachment delivery (DM + channel)** — *(coverage gap: no
   runnable UAT scenario yet.)* Needs a `jtbd-deliver-file-dm` /
   `-channel` proving an agent that produces a file replies with a tappable
-  attachment (or a Drive link when >50 MB), not a container path — in both a
+  attachment (or a Drive link when >50 MB), not a container path, in both a
   DM and a forum supergroup.
 
 **Fuzz corpus:** vary file size (inline × upload-session × >50 MB) × file
 type (image vs document) × provider (OneDrive, Google Drive, none-connected)
 × share scope (anonymous vs organization vs policy-blocked) × surface (DM vs
 forum channel). The invariants must hold across the corpus: the user always
-gets something openable or a plain can't-deliver message — never a container
-path — and delivery never touches anything outside the agent's own folder.
+gets something openable or a plain can't-deliver message, never a container
+path, and delivery never touches anything outside the agent's own folder.
 
 ## Verdict
 
 - **Done when:** every file an agent produces reaches the user as a Telegram
   attachment or a Drive share link they can open from their phone, never a
-  container path — proven across providers and surfaces, including the
+  container path, proven across providers and surfaces, including the
   no-drive-connected fallback, by the scenarios above (and once the
   end-to-end DM/channel scenario lands, by it).
 
 ## Production-readiness
 
 - *Reliability:* a delivery either yields an openable artifact (attachment or
-  link) or a plain-language can't-deliver message with the fix — never a
+  link) or a plain-language can't-deliver message with the fix, never a
   silent drop and never a dead path.
 - *Least privilege:* delivery writes only `Switchroom/<agent>/` using
   operator-granted Drive scope; it cannot read or overwrite the user's other
   files and cannot self-grant the scope.
 - *Surface parity:* delivery must be proven in both DM and forum channel once
-  the end-to-end scenario exists — channel-routing bugs have hidden in
+  the end-to-end scenario exists. Channel-routing bugs have hidden in
   DM-only coverage before.
 
 ---
@@ -132,4 +132,4 @@ path — and delivery never touches anything outside the agent's own folder.
 > **Implementation:** the `deliver-file` CLI verb (`src/cli/deliver-file.ts`),
 > the Drive/OneDrive providers (`src/delivery/`), and the `DELIVERY_GUIDANCE`
 > prompt block. Those churn; this job outlives them. No standalone design
-> artifact `serves:` this job yet — write one if the delivery design grows.
+> artifact `serves:` this job yet. Write one if the delivery design grows.

--- a/reference/jobs/extend-without-forking.md
+++ b/reference/jobs/extend-without-forking.md
@@ -10,12 +10,12 @@ invariants: [no-self-escalation]
 
 ## The job
 
-The user wants a new capability — a new specialist for a new domain, a new
+The user wants a new capability: a new specialist for a new domain, a new
 skill that teaches an existing agent a new trick, a new tool that connects
 to a system they care about. The product's job is to make that feel like
 configuration, not forking. Convention over configuration is the bar: the
-common 90% — lifecycle, interaction surface, memory, safety, logging,
-restart behaviour — comes for free from the scaffold. What the user writes
+common 90% (lifecycle, interaction surface, memory, safety, logging,
+restart behaviour) comes for free from the scaffold. What the user writes
 is the thing that's actually different about their agent, skill, or tool.
 If they copy a dozen files of boilerplate to add one specialist, the
 product is wrong. The extension story is first-class: documented,
@@ -40,11 +40,11 @@ them.
   automatically; the user doesn't reimplement them.
 - Upgrading the product leaves user-added agents, skills, and tools working.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
 - Boilerplate demanded up front: ten files to get one agent means the
   convention is missing.
-- Extension points that require editing the core — forking with extra
+- Extension points that require editing the core: forking with extra
   steps.
 - A plugin system that's really a promise, with the interesting
   capabilities hard-coded.
@@ -52,7 +52,7 @@ them.
   agents, skills, and tools.
 - Hidden coupling where a new agent silently needs five things configured in
   five other places.
-- A new tool that quietly lands on agents it wasn't meant for — capability
+- A new tool that quietly lands on agents it wasn't meant for, capability
   must follow the operator's config, never spread itself
   (`no-self-escalation`).
 - Breaking changes to the extension shape that silently orphan user
@@ -98,7 +98,7 @@ the upgrade.
 
 - **Done when:** the user adds an agent, skill, or tool by configuring it,
   the scaffold supplies the boilerplate and safety, capability reaches only
-  its intended agents, and upgrades don't orphan extensions — proven by the
+  its intended agents, and upgrades don't orphan extensions, proven by the
   scenarios above.
 
 ## Production-readiness

--- a/reference/jobs/feel-like-a-colleague.md
+++ b/reference/jobs/feel-like-a-colleague.md
@@ -11,7 +11,7 @@ invariants: [no-self-escalation, on-leash]
 ## The job
 
 The user is hiring an agent the way they'd hire an executive assistant or a
-senior developer — not a chatbot, a colleague. The kind who is helpful
+senior developer, not a chatbot, a colleague. The kind who is helpful
 without being a doormat, pushes back when the ask is unclear, reads the file
 before answering a question about it, says what it did and what it's about
 to do, and knows where its authority ends. This posture sits across the
@@ -28,7 +28,7 @@ default; the voice on top varies per persona.
   talking to an AI; the *shape* of the conversation feels human.
 - The agent asks at most one good clarifying question, and skips it when
   intent is clear, stating its assumption inline as it acts.
-- It reads the actual state — file, calendar, what's running — before
+- It reads the actual state (file, calendar, what's running) before
   claiming anything about it, rather than answering from memory.
 - It volunteers the next obvious step inside its patch ("want me to also …?")
   and stops there.
@@ -40,13 +40,13 @@ default; the voice on top varies per persona.
 - A second agent has the same posture in a different voice; the user
   doesn't relearn how to work with each one.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
 - Confident hallucination: answering about mutable state from training-data
   priors instead of reading the source.
 - A question avalanche: three clarifying questions where one would do, then
   a fourth after the user answers.
-- Sycophantic preamble — "Great question!", "I'd be happy to" — and AI
+- Sycophantic preamble ("Great question!", "I'd be happy to") and AI
   tells: em-dashes, rule-of-three closings, "Let me know if you have any
   other questions!".
 - Roaming outside scope: asked to fix one thing, it refactors three.
@@ -56,7 +56,7 @@ default; the voice on top varies per persona.
 - Re-asking what the user already said clearly, instead of stating the
   assumption and acting.
 - Mismatched length: five paragraphs for "what time?".
-- One persona feeling great while the rest feel generic — the posture is
+- One persona feeling great while the rest feel generic: the posture is
   fleet-wide, not a property of the canonical agent.
 
 ## Prove it
@@ -95,8 +95,8 @@ them, not just the scripted prompt.
 
 - **Done when:** across the fleet, the agent asks before guessing, verifies
   before claiming, defers on the leash, matches the user's energy, and
-  sounds like a person — and the user describes it as a colleague, not "the
-  AI bot" — proven by the scenarios above.
+  sounds like a person, and the user describes it as a colleague, not "the
+  AI bot". Proven by the scenarios above.
 
 ## Production-readiness
 

--- a/reference/jobs/get-better-the-longer-they-run.md
+++ b/reference/jobs/get-better-the-longer-they-run.md
@@ -1,7 +1,7 @@
 ---
-job: When my agent learns a better way to work, make the improvement stick reliably without me re-teaching it — and without it sprawling skills, crons, or its own guidance
+job: When my agent learns a better way to work, make the improvement stick reliably without me re-teaching it, and without it sprawling skills, crons, or its own guidance
 outcome: Agents stop repeating corrected mistakes; small fixes to their own skills happen invisibly and reversibly; anything larger arrives as a one-tap suggestion
-stakes: Get it wrong and we lose either way — nothing improves (recurring corrections, trust leaks) or it runs away (token waste, unreviewable skill/cron sprawl, unsafe changes)
+stakes: Get it wrong and we lose either way. Nothing improves (recurring corrections, trust leaks) or it runs away (token waste, unreviewable skill/cron sprawl, unsafe changes)
 serves: standing-team
 invariants: [no-self-escalation, on-leash]
 ---
@@ -34,13 +34,13 @@ reviewed PR). This job adds *when* to do it and *how far* to go alone.
 - A correction given once never has to be given again.
 - A small, safe fix to the agent's own existing skill just happens, silently
   and reversibly.
-- A bigger change — a shared skill, or an edit to the agent's own guidance
-  (`CLAUDE.md`/`SOUL.md`) that touches every turn — arrives as one one-tap
+- A bigger change (a shared skill, or an edit to the agent's own guidance
+  `CLAUDE.md`/`SOUL.md` that touches every turn) arrives as one one-tap
   suggestion.
 - A new cron or new skill is always proposed, never self-served.
 - Idle turns cost ~nothing; the operator never waits on the review.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
 - The same correction needed a second time.
 - Skill or cron sprawl; duplicate skills; an unreviewable pile of proposals.
@@ -69,6 +69,25 @@ just the happy path.
   tested, reversible fix to its own skill (or proposes anything larger) with
   no operator re-teaching, and never auto-creates a cron/new skill or any
   irreversible/cross-agent change.
+
+## Production-readiness
+
+- *Change safety:* the agent edits its own state, so every auto-applied fix
+  is reversible and audited. A self-improvement that can't be rolled back, or
+  that lands without a trail, is a defect, not a feature with a rough edge.
+- *Blast-radius gating:* the size of the change decides who approves it. A
+  small fix to the agent's own skill self-serves; anything that touches every
+  turn (`CLAUDE.md`/`SOUL.md`), crosses agents (a shared skill), or stands up
+  a cron is operator-gated. The agent never widens its own reach under cover
+  of "I learned something". The `no-self-escalation` and `on-leash`
+  invariants hold here, not just on the happy path.
+- *Learning integrity:* a bad lesson must not bind. A correction that turns
+  into a regression is caught and reverted rather than compounding across
+  runs, and the same correction never has to be given twice.
+- *Cost bounding:* the review is gate-first. An idle turn with no learning
+  signal incurs ~no extra tokens or latency, so the mechanism can run on
+  every turn without the operator paying for it on turns that didn't change
+  anything.
 
 ---
 

--- a/reference/jobs/get-from-zero-to-a-working-fleet.md
+++ b/reference/jobs/get-from-zero-to-a-working-fleet.md
@@ -1,15 +1,15 @@
 ---
 job: get from zero to a working fleet in one pass
-outcome: A new operator goes from a fresh box to a paired agent replying in Telegram in one setup pass, with zero config — and when something is wrong it says so, with a next step, instead of reporting success on a broken state.
-stakes: First contact is the whole product. If setup half-succeeds in silence, the operator's first experience is a bot that never answers and a log they don't know to tail — and they leave before the fleet ever knows them.
+outcome: A new operator goes from a fresh box to a paired agent replying in Telegram in one setup pass, with zero config. When something is wrong it says so, with a next step, instead of reporting success on a broken state.
+stakes: First contact is the whole product. If setup half-succeeds in silence, the operator's first experience is a bot that never answers and a log they don't know to tail, and they leave before the fleet ever knows them.
 serves: standing-team
 invariants: []
 ---
 
 # Job Spec: get from zero to a working fleet in one pass
 
-> A durable Job Spec. The *how* — the setup wizard's steps, the pairing
-> handshake, the readiness gate, what `doctor` probes — churns every
+> A durable Job Spec. The *how* (the setup wizard's steps, the pairing
+> handshake, the readiness gate, what `doctor` probes) churns every
 > release. This spec is framed strictly around the **outcome** (one pass,
 > zero config, a real reply in Telegram, loud-not-silent on failure) so it
 > survives the steps changing underneath it. The first-run failure modes
@@ -18,20 +18,20 @@ invariants: []
 
 ## The job
 
-Someone has just heard the pitch — a standing team of specialists they text
+Someone has just heard the pitch: a standing team of specialists they text
 from Telegram, on their own subscription, on their own box. They have a
 fresh Linux box and a Telegram account, and they want one agent talking back
 *today*. They are not signing up to learn switchroom: they want to run one
 setup, answer the prompts it asks, and watch a real reply land in their
-phone. The job is to carry them across that first gap — install to first
-reply — in a single pass, without tribal knowledge, without tailing a log,
+phone. The job is to carry them across that first gap, install to first
+reply, in a single pass, without tribal knowledge, without tailing a log,
 and without the trap that hurts most: a setup that prints "done" while the
 bot is silently dead.
 
-> We used to require a second setup pass — the operator's Telegram id was
+> We used to require a second setup pass: the operator's Telegram id was
 > only knowable after they DM'd the bot `/start`, so pairing meant run
-> setup, DM the bot, rerun setup. The job underneath — *one pass to a paired,
-> replying agent* — is unchanged; the second pass was always a defect, not
+> setup, DM the bot, rerun setup. The job underneath, *one pass to a paired,
+> replying agent*, is unchanged. The second pass was always a defect, not
 > the job.
 
 ## Good / bad
@@ -39,25 +39,25 @@ bot is silently dead.
 **Good looks like**
 
 - One pass. The operator runs setup once, answers what it asks, and ends
-  with a paired agent — never "run it again to capture your id."
+  with a paired agent, never "run it again to capture your id."
 - Zero config to a working fleet. A default agent, a working bot, and a
   conversational first reply come out of the box; customising is opt-in
   later, never a prerequisite.
 - The proof of success is a real reply in Telegram, not a green checkmark in
   the terminal. The operator sees the bot answer.
-- Every prompt explains itself in place — what it needs and why — so the
+- Every prompt explains itself in place (what it needs and why) so the
   operator never has to leave the terminal to know what to type.
 - When a step can't complete, it fails loud and early, naming the broken
   thing and the next command to run. A bad bot token, an unreachable
-  memory backend, a failed MCP — each is spoken, not swallowed.
+  memory backend, a failed MCP: each is spoken, not swallowed.
 - "Ready" means ready to take a message: the process is up, memory is
   reachable, and the gateway is polling. Setup/restart only reports success
   when the agent can actually answer.
 - There is one command to ask "is my agent alive and OK?" and one to ask
-  "what's wrong and how do I fix it?" — the operator never reassembles that
+  "what's wrong and how do I fix it?". The operator never reassembles that
   answer from `ps`, `pstree`, and a log tail.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
 - A cheerful "Restarted" / "Setup complete" while an MCP failed to boot, the
   bank doesn't exist, or the gateway isn't polling. Silent success on a
@@ -71,14 +71,14 @@ bot is silently dead.
   link instead of the broken thing and the next step.
 - Silent-on-read, loud-on-write: a missing bank that looks fine until the
   first memory write blows up much later, far from the cause.
-- Demanding config before the first reply — making the operator fill in
+- Demanding config before the first reply: making the operator fill in
   `switchroom.yaml` to get a bot that answers at all.
 - A first agent that boots burning context on unfilled template placeholders
   instead of just being ready to talk.
 
 ## Prove it
 
-Named by job × surface. The end-to-end surface is thin today — be honest
+Named by job × surface. The end-to-end surface is thin today, so be honest
 about it.
 
 - **DM round-trip, first reply (DM)** — `telegram-plugin/uat/scenarios/smoke-dm-reply.test.ts`,
@@ -86,12 +86,12 @@ about it.
   DM gets a real reply in the phone, fast, not a NO_REPLY or a 300s-fallback
   silence. *Invariant:* the proof of a working agent is a reply the operator
   can see, not a terminal checkmark. *(Covers the "replies in Telegram" tail
-  of the job, but spins up against an already-running `test-harness` — it
+  of the job, but spins up against an already-running `test-harness`, so it
   does not exercise the zero→working setup pass itself.)*
 - **Readiness gate — "ready" means can-answer** — `tests/agent.status.test.ts`
   (`readinessGaps`, `waitForAgentReady`). *Watch:* status reports `fail` when
   the process is down, the gateway isn't polling, memory is unreachable, or
-  the bank is missing — overall state is `fail`, with a distinct detail per
+  the bank is missing. Overall state is `fail`, with a distinct detail per
   cause. *Invariant:* no component reports ready unless it can actually take
   a message; loud-not-silent on a broken boot.
 - **Boot self-test surfaces auth breakage loudly, never blocks boot** —
@@ -103,8 +103,8 @@ about it.
   `tests/agent.status.probe-hindsight.test.ts`. *Watch:* a new agent's bank
   is created idempotently; a reachable-but-bankless backend reports
   `bankExists:false` rather than a false "unreachable" or a deferred
-  write-time FK crash. *Invariant:* silent-on-read / loud-on-write is closed —
-  a missing bank is named at setup, not at the first `retain`.
+  write-time FK crash. *Invariant:* silent-on-read / loud-on-write is closed.
+  A missing bank is named at setup, not at the first `retain`.
 - **Bot token validated at setup, not at first message** — `tests/setup.test.ts`
   (`validateBotToken`, `buildAccessJson`), `tests/doctor.test.ts`
   (`checkTelegram`, `telegramGetMe`). *Watch:* an invalid token throws a
@@ -114,13 +114,13 @@ about it.
 - **Zero-config default agent comes up from a profile** —
   `tests/cli.agent-create-profile.test.ts`, `tests/scaffold.fresh-agent-mcp-trust.test.ts`.
   *Watch:* a default-profile agent scaffolds and reconciles with no
-  hand-written boilerplate. *Invariant:* batteries-included — a working agent
+  hand-written boilerplate. *Invariant:* batteries-included, a working agent
   out of the box, customisation opt-in.
 - **One-pass setup: pairing captures the operator id in-session (DM)** —
   *(coverage gap: no runnable scenario yet)*. *Watch:* the operator runs
   setup once, DMs `/start` when prompted, and the id is captured into
   `access.json` without a second pass. *Invariant:* one pass to a paired
-  agent — the historical two-pass defect never returns. The unit shape is
+  agent, and the historical two-pass defect never returns. The unit shape is
   pinned by `tests/setup.test.ts:buildAccessJson`, but no end-to-end scenario
   drives the live pairing handshake.
 - **Fresh-box install → first reply, end to end (DM)** —
@@ -135,14 +135,14 @@ reachable/bankless/down × MCP boot success/failure × auth
 present/expired/refresh-less × pairing-id-known/unknown-at-start ×
 network-flaky-during-setup. The invariants must hold across the corpus: a
 broken component is always *named with a next step*, and setup/restart
-reports success only on a state that can actually take a message — never a
+reports success only on a state that can actually take a message, never a
 cheerful "done" over a silently-dead agent.
 
 ## Verdict
 
 - **Done when:** a new operator on a fresh box runs setup once, with zero
   hand-written config, and watches their agent reply to a real DM in
-  Telegram — and any broken step along the way fails loud with a next step,
+  Telegram, and any broken step along the way fails loud with a next step,
   never reporting success on a broken state. Proven end to end by a
   fresh-box → first-reply scenario (the named coverage gap above).
 
@@ -153,17 +153,17 @@ cheerful "done" over a silently-dead agent.
 
 - *Reliability:* setup and restart are idempotent and report success only on
   a ready state (process up, memory reachable, gateway polling). A failed
-  component yields a non-zero exit and a named error — never a false green.
+  component yields a non-zero exit and a named error, never a false green.
 - *Observability:* every first-run failure mode is operator-visible from the
   CLI or the agent's own reply, never log-only. There is a single
   `is-it-alive` command and a single `what's-wrong` command.
 - *Defaults:* a fresh setup produces a working, conversational agent with no
-  required config — the "batteries included" principle check is the gate.
+  required config. The "batteries included" principle check is the gate.
 
 ---
 
-> **Implementation:** the how — the setup-wizard steps, the pairing
-> handshake, the readiness gate, the boot self-test, and the per-gap fix plan
-> — lives in `reference/rfcs/onboarding-gap-analysis.md` (it enumerates the real
+> **Implementation:** the how (the setup-wizard steps, the pairing
+> handshake, the readiness gate, the boot self-test, and the per-gap fix plan)
+> lives in `reference/rfcs/onboarding-gap-analysis.md` (it enumerates the real
 > first-run failure modes this job exists to close). That artifact churns;
 > this Job Spec outlives it.

--- a/reference/jobs/give-each-agent-its-own-workspace.md
+++ b/reference/jobs/give-each-agent-its-own-workspace.md
@@ -1,7 +1,7 @@
 ---
 job: give each agent its own working copy of the code, without making the user manage it
 outcome: Multiple specialists work on the same repo on the same machine without stomping each other. Each agent has a stable, isolated working tree it owns. Switchroom creates and tears down those workspaces as part of the agent's lifecycle. The user never thinks about it.
-stakes: A fleet that shares one working tree isn't a fleet — it's a flatshare. One agent runs an install, another's typecheck breaks. One checks out a feature branch, another inherits it mid-turn. Modified files leak between turns of different agents. The "consistent lifecycle" promise fails the first time two agents work in parallel.
+stakes: A fleet that shares one working tree isn't a fleet, it's a flatshare. One agent runs an install, another's typecheck breaks. One checks out a feature branch, another inherits it mid-turn. Modified files leak between turns of different agents. The "consistent lifecycle" promise fails the first time two agents work in parallel.
 serves: standing-team
 invariants: []
 ---
@@ -11,7 +11,7 @@ invariants: []
 ## The job
 
 Switchroom's whole point is multiple specialists running side by side on one
-machine. They share an OS, a vault, a network — but they must not share a
+machine. They share an OS, a vault, a network, but they must not share a
 working tree on a repo they both care about. The moment two agents touch the
 same checkout, the fleet stops behaving like a fleet: one pulls and rebases
 the other's edits away, one switches branches under the other's running
@@ -19,7 +19,7 @@ sub-agent, an install invalidates the other's build mid-flight, and
 uncommitted work from one session looks like the other's untracked junk
 after a restart. The job is to give each agent a stable working tree it
 owns, provisioned and torn down as part of its lifecycle, so the user never
-chooses, names, or manages it — and never debugs a "two agents stomped the
+chooses, names, or manages it, and never debugs a "two agents stomped the
 tree" incident, because the product doesn't allow it.
 
 ## Good / bad
@@ -38,20 +38,20 @@ tree" incident, because the product doesn't allow it.
 - A dirty tree at session start is left alone and surfaced, never reset on
   the agent's behalf.
 - Sub-agent work nests off the parent's tree, the same conceptual operation
-  as a main agent — one scaffold, not two UXes.
+  as a main agent: one scaffold, not two UXes.
 - Prompts and skills refer to a repo by name, never a hardcoded path, so an
   agent works the same on any host.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
 - A shared canonical checkout with locks or branch-naming conventions; two
   agents from one checkout is the exact failure this job exists to fix.
-- A full clone per agent — redundant gigabytes and N× the fetch cost for
+- A full clone per agent: redundant gigabytes and N× the fetch cost for
   isolation a working tree already gives more cheaply.
 - A pool of scratch trees handed to whoever asks first; the agent's tree
   must be stable across sessions so in-flight state survives restart.
 - Inferring an agent's repos from filesystem scans or history instead of its
-  declared manifest — surprise clones.
+  declared manifest: surprise clones.
 - Forcing the agent to learn the tree's path; the path is plumbing, injected
   for it.
 - Silently discarding an agent's uncommitted work; never reset a dirty tree
@@ -64,7 +64,7 @@ tree" incident, because the product doesn't allow it.
 - **Per-agent tree provisioned by lifecycle** —
   `tests/scaffold.repo-provisioning.test.ts`. *Watch:* declaring a repo in
   an agent's manifest provisions its working tree on reconcile, with no user
-  command. *Invariant:* trees are provisioned only for declared repos — no
+  command. *Invariant:* trees are provisioned only for declared repos, with no
   surprise clones.
 - **Isolated tree per agent, registered** — `tests/worktree.registry.test.ts`,
   `tests/worktree.schema.test.ts`, `tests/worktree.claim-integration.test.ts`.
@@ -91,8 +91,8 @@ depth; isolation, stability, and the never-reset-dirty rule hold across all.
 
 - **Done when:** multiple agents work the same repo in parallel without
   stomping each other, each tree is stable across restart with uncommitted
-  work preserved, and the user never runs a git or worktree command —
-  proven by the scenarios above.
+  work preserved, and the user never runs a git or worktree command.
+  Proven by the scenarios above.
 
 ## Production-readiness
 

--- a/reference/jobs/idempotent-update-and-restart.md
+++ b/reference/jobs/idempotent-update-and-restart.md
@@ -1,6 +1,6 @@
 ---
 job: update switchroom and trust that everything is actually running the new version, no manual checks
-outcome: After running `switchroom update`, the entire stack — CLI, agent containers, broker, kernel, scheduler, hostd, MCP servers, bundled skills, memory backend — is at the version switchroom declared and tested as a unit. After any restart, the agent comes back with fresh code, fresh MCP servers, fresh settings, and intact context. The user does not lose their thread.
+outcome: After running `switchroom update`, the entire stack (CLI, agent containers, broker, kernel, scheduler, hostd, MCP servers, bundled skills, memory backend) is at the version switchroom declared and tested as a unit. After any restart, the agent comes back with fresh code, fresh MCP servers, fresh settings, and intact context. The user does not lose their thread.
 stakes: If `update` quietly leaves stale processes running, the user thinks they're talking to a new agent and they're talking to last week's. Bugs come back from the dead. New features advertised in the changelog don't actually load. The user loses faith that the version reported by the CLI matches reality. Updates become a thing to dread.
 serves: always-available
 invariants: []
@@ -10,7 +10,7 @@ invariants: []
 
 ## The job
 
-The user runs one update command — to pick up a bug fix, close a security
+The user runs one update command to pick up a bug fix, close a security
 advisory, or get a new feature. The job is for the next agent reply to be
 backed by the new version of *everything*, without the user having to know
 which processes survive a restart, which dependencies are pinned where, or
@@ -18,7 +18,7 @@ which service quietly held a stale handle. The mental model is:
 **switchroom is a release, not a moving target.** A version pins a tested
 matrix of every moving piece, brought up in lockstep; no piece moves on its
 own. The same contract covers restarts: a restarted unit comes back as a
-fresh process with current settings — and knowing what was happening before
+fresh process with current settings, and knowing what was happening before
 (recent messages, the current goal, today's context), not as an amnesiac
 who needs re-briefing. That continuity is a property of the switchroom
 layer, not a side effect of any underlying session happening to survive.
@@ -32,10 +32,10 @@ layer, not a side effect of any underlying session happening to survive.
   restarting?" exchange.
 - The version the CLI reports matches what's actually loaded into every
   running process, and a health sweep confirms it with a green check.
-- Re-running update any number of times lands in the same valid state — no
+- Re-running update any number of times lands in the same valid state: no
   accumulating side effects, no "now you have to do Y to fix it."
 - After a restart, the agent's first reply shows it knows where the thread
-  was — references the last message, the current task, today's context —
+  was, referencing the last message, the current task, today's context,
   without being prompted.
 - After a restart, every declared MCP server is actually loaded; a
   newly-added tool works on the first try.
@@ -44,9 +44,9 @@ layer, not a side effect of any underlying session happening to survive.
 - Drift between declared and installed versions is surfaced loudly before
   it causes a confusing bug.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
-- The CLI reports a new version but the agent behaves like the old one —
+- The CLI reports a new version but the agent behaves like the old one:
   the reported version has decoupled from what's running.
 - A restart "succeeds" (the container reports running) but the process
   inside never exited; old settings persist until a manual bounce.
@@ -54,7 +54,7 @@ layer, not a side effect of any underlying session happening to survive.
   today, untested against the rest of the stack.
 - The user has to keep a mental model of which dependency moves through
   which channel.
-- A second update or restart exposes new failure modes — proof the first
+- A second update or restart exposes new failure modes: proof the first
   run left an in-between state.
 - After a restart the agent comes back with no awareness of the thread, and
   the user has to re-explain.
@@ -104,14 +104,14 @@ process, intact context, no dropped turn.
 ## Verdict
 
 - **Done when:** after one update or any restart, every running piece is at
-  the declared version and the agent comes back fresh-but-not-amnesiac —
+  the declared version and the agent comes back fresh-but-not-amnesiac,
   proven by the scenarios above, with drift surfaced loudly and idempotent
   across repeated runs.
 
 ## Production-readiness
 
 - *Atomicity:* an update brings the whole declared matrix to its tested
-  combination in lockstep, or stops cleanly with "nothing was applied" —
+  combination in lockstep, or stops cleanly with "nothing was applied",
   never half-applied.
 - *Idempotency:* repeated update/restart runs converge to the same valid
   state with no accumulating side effects.

--- a/reference/jobs/keep-my-subscription-honest.md
+++ b/reference/jobs/keep-my-subscription-honest.md
@@ -17,7 +17,7 @@ invariants: [claude-native]
 The user pays Anthropic for a subscription. They chose that plan knowing
 what it costs and what it covers. The agents are an extension of that
 relationship, not a way around it. The job is to keep the product honest
-about what it uses, who pays, and under what terms — so the user can say in
+about what it uses, who pays, and under what terms, so the user can say in
 one sentence what they're paying for, and have the product's actual
 behaviour match.
 
@@ -40,7 +40,7 @@ behaviour match.
 - There is no second billing surface the user didn't ask for. Hitting a
   plan limit is said honestly; nothing is spent elsewhere.
 - The product is clear about which plans it supports and what it does when
-  a plan can't run a feature — it says so, rather than reaching for the API.
+  a plan can't run a feature: it says so, rather than reaching for the API.
 - Opt-in third-party features (e.g. voice transcription) that need their
   own key are clearly labelled extensions, with the key in the vault, never
   implied to be subscription-native.
@@ -50,18 +50,18 @@ behaviour match.
   product adapts without the user unpicking secrets, and never bills around
   them.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
 - Any *silent* or unintended fallback to a second billing surface when the
   subscription is rate-limited. (The one sanctioned exception is **overage**:
   an account the operator *explicitly* opted into `allow_overage_accounts` may
   continue on the operator's own Anthropic overage credits when Anthropic
-  reports `overageStatus:"allowed"` — default-off, auto-stops at
+  reports `overageStatus:"allowed"`: default-off, auto-stops at
   `out_of_credits`, and still the unmodified interactive `claude` CLI on the
   same OAuth subscription, never API/SDK. What's banned is the *silent,
   un-opted-in* switch, not this opt-in carve-out.)
 - A headless `claude -p`, an Agent SDK call, or a raw Anthropic API call
-  anywhere in a code path — both `-p` and the SDK are *programmatic* usage
+  anywhere in a code path. Both `-p` and the SDK are *programmatic* usage
   off the subscription. Route model work through the interactive session.
 - Asking the user for an Anthropic API key to unlock a core feature. Either
   the subscription supports it or it doesn't.
@@ -87,7 +87,7 @@ behaviour match.
 - **Weekly-cap menu defaults to Escape; only opted-in accounts may take
   overage** — `tests/rate-limit-menu-detect`, `tests/wedge-watchdog`,
   `src/auth/broker/server.test.ts`. *Watch:* on a weekly-quota wall the
-  watchdog sends **only `Escape`** by default — never a keystroke that picks
+  watchdog sends **only `Escape`** by default, never a keystroke that picks
   "usage credits". The sole exception is an account the operator explicitly
   flagged in `allow_overage_accounts`: the **broker** (the single audited
   spend-authority) confirms `overageStatus:"allowed"` (not `out_of_credits`,
@@ -117,14 +117,14 @@ subscription session, and a limit is never routed around with paid credit.
 
 - **Done when:** the user pays for nothing but their subscription, can
   confirm that in under a minute, and the product refuses every shortcut
-  that would split the billing model — proven by the guards above.
+  that would split the billing model, proven by the guards above.
 
 ## Production-readiness
 
 - *Compliance:* zero headless `claude -p` / SDK / raw-API callsites,
   enforced by build-failing CI guards, not convention.
 - *Reliability:* a plan limit (5h or weekly) degrades to honest failure or
-  account failover — never to API, and never to paid credit *except* for an
+  account failover, never to API, and never to paid credit *except* for an
   account the operator explicitly opted into overage (default-off, auto-stops
   at `out_of_credits`, on the operator's own Anthropic credits via the
   unmodified `claude` CLI).

--- a/reference/jobs/know-what-my-agent-is-doing.md
+++ b/reference/jobs/know-what-my-agent-is-doing.md
@@ -50,7 +50,7 @@ close that gap so the user never has to ask.
 - Scrolling back a week later reads as a real conversation, not a deleted
   widget.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
 - A separate progress surface running parallel to the chat. This was the
   retired card. It duplicates the conversation or covers for a model that
@@ -129,7 +129,7 @@ visibly-progressing turn.
 ## Verdict
 
 - **Done when:** the user always knows the agent heard them, can tell
-  working from stuck, and never needs to ask "what are you doing?" — proven
+  working from stuck, and never needs to ask "what are you doing?", proven
   across DM and channel by the scenarios above.
 
 ## Production-readiness

--- a/reference/jobs/remember-across-sessions.md
+++ b/reference/jobs/remember-across-sessions.md
@@ -13,10 +13,10 @@ invariants: [single-tenant]
 The user said something last Tuesday that matters today. They told the agent
 months ago how they like things done. They started a thread that never got
 closed. A goldfish agent forces the user to repeat all of it, so they stop
-trying. The job is to make the agent remember in a way that helps — not in a
+trying. The job is to make the agent remember in a way that helps, not in a
 way that's creepy or noisy. Memory is not a chat log: dumping the last
 thousand messages into the prompt is neither remembering nor useful. Good
-memory is curated, semantic, and retrieved by relevance — the schedule note
+memory is curated, semantic, and retrieved by relevance: the schedule note
 surfaces when planning the week, not when writing code. Memory is also
 honest: when the agent recalls something, the user can see that it did,
 trust why, and correct it if it's wrong. Memory the user can't inspect is
@@ -38,10 +38,10 @@ memory the user won't trust.
   relationship; the agent picks up roughly where it was.
 - The user can ask what the agent believes about them and why, and get an
   honest, legible answer.
-- Each agent's memory is its own — different specialists, topics, and
+- Each agent's memory is its own: different specialists, topics, and
   distinct users are never conflated into one pool.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
 - Raw transcript dumping passed off as memory; that's storage, not
   remembering.
@@ -87,7 +87,7 @@ correction-stickiness, and per-bank isolation hold across all.
 
 - **Done when:** the agent brings back the right context at the right moment
   without being re-told, the user can inspect and correct what it believes,
-  and a restart never resets the relationship — proven by the scenarios
+  and a restart never resets the relationship, proven by the scenarios
   above.
 
 ## Production-readiness

--- a/reference/jobs/restart-and-know-what-im-running.md
+++ b/reference/jobs/restart-and-know-what-im-running.md
@@ -10,14 +10,14 @@ invariants: [chat-is-the-single-source-of-truth]
 
 ## The job
 
-The user comes back to the chat after a restart — a reboot, a crash and
+The user comes back to the chat after a restart: a reboot, a crash and
 respawn, or a config change they reloaded. The agent on the other end might
 not be the same agent it was five minutes ago. The job is to surface that up
 front, every time, so the user starts the next turn with a clear picture of
 what's running: which model, which tools, which skills, which memory backend,
 and whether auth is healthy. Enough to notice a change; little enough that it
 doesn't become wallpaper. The worst outcome is a silent respawn that comes
-back subtly different — the user ends up arguing with a stranger who looks
+back subtly different. The user ends up arguing with a stranger who looks
 like their agent.
 
 ## Good / bad
@@ -32,12 +32,12 @@ like their agent.
   now is said plainly, not discovered mid-task.
 - A restart with no config change still gets a light acknowledgement, so the
   user knows it actually completed.
-- The shape is consistent restart to restart — crash, reboot, reconfigure
-  all land the same way — so the user's eye learns where to look.
+- The shape is consistent restart to restart: crash, reboot, reconfigure
+  all land the same way, so the user's eye learns where to look.
 - Several specialists restarted at once each report their own state in their
   own place, never collapsed into one summary.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
 - A silent respawn: the agent comes back and the user has to guess whether
   it's the same agent with the same config.
@@ -57,9 +57,9 @@ like their agent.
 - **First message after restart (DM)** — `jtbd-always-on-after-restart-dm`.
   *Watch:* the first inbound after a restart is answered promptly, not after
   a multi-minute blank window. *Invariant:* a restart never swallows the
-  return — the user always learns the agent is back, in the chat.
+  return. The user always learns the agent is back, in the chat.
 - **What's live, on demand (DM)** — `jtbd-whoami-dm`. *Watch:* the
-  user can read the live sandbox — tier, model, tools, powers — without SSH
+  user can read the live sandbox (tier, model, tools, powers) without SSH
   or a dashboard. *Invariant:* the surfaced config is resolved from the live
   agent, never an echoed stub.
 - **Config survives the restart (DM)** — `jtbd-memory-survives-restart-dm`.
@@ -79,8 +79,8 @@ config and land in the chat across the corpus, never a stale or cosmetic one.
 
 ## Verdict
 
-- **Done when:** after any restart the user knows what's running — model,
-  tools, skills, memory, auth — from the chat alone, and any change is
+- **Done when:** after any restart the user knows what's running (model,
+  tools, skills, memory, auth) from the chat alone, and any change is
   obvious, proven by the scenarios above.
 
 ## Production-readiness

--- a/reference/jobs/run-a-fleet-of-specialists.md
+++ b/reference/jobs/run-a-fleet-of-specialists.md
@@ -13,13 +13,13 @@ invariants: [no-self-escalation, single-tenant]
 One bot that knows everything is a demo. A fleet of agents, each shaped for
 a specific part of the user's life, is a workforce: a health coach in the
 morning, a coding assistant in the afternoon, an executive assistant for
-the inbox — each with its own voice, its own history, its own sense of
+the inbox, each with its own voice, its own history, its own sense of
 what's in-scope. The user picks the one they need and doesn't re-explain
 themselves. The product's job is to make running many agents genuinely
 easy and to make the fleet behave *as* a fleet: one lifecycle, one
 interaction surface, one safety posture. The thing that varies is the
-specialist, not the plumbing. Specialists are not personas over one model —
-each has its own memory, skills, tools, and topic. The health coach never
+specialist, not the plumbing. Specialists are not personas over one model.
+Each has its own memory, skills, tools, and topic. The health coach never
 sees the code-review history; the coding agent never second-guesses the
 sleep data. Separation is the point.
 
@@ -31,8 +31,8 @@ sleep data. Separation is the point.
   voice and by scope, without a label.
 - Each agent's memory is its own. What the user told one specialist does
   not surface in another.
-- The user never prefixes "as my coding agent" to get the right behaviour —
-  addressing the right agent does that.
+- The user never prefixes "as my coding agent" to get the right behaviour.
+  Addressing the right agent does that.
 - Tools and credentials are scoped per agent; the wrong agent never holds
   the wrong power.
 - A new agent joins as a peer: same lifecycle, same safety rules, same
@@ -42,7 +42,7 @@ sleep data. Separation is the point.
 - A cross-specialist need is routed by the user; agents don't silently
   reach into each other's state.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
 - One agent pretending to be several by switching tone on command. A
   persona without its own memory and scope is cosplay.
@@ -91,7 +91,7 @@ scope stays enforced, and no agent acts on another's state.
 
 - **Done when:** the user runs multiple specialists that are distinct in
   voice, scope, and memory, work in parallel without interfering, and never
-  reach across into each other — proven by the scenarios above.
+  reach across into each other. Proven by the scenarios above.
 
 ## Production-readiness
 

--- a/reference/jobs/see-my-whole-fleet-from-one-screen.md
+++ b/reference/jobs/see-my-whole-fleet-from-one-screen.md
@@ -1,28 +1,29 @@
 ---
 job: see and manage my whole fleet from one operator screen
-outcome: The operator can open one management console and see every agent's live state, health, quota, history, sessions, memory, workspace, and approval/audit trail, run fleet ops (restart, config edits), and drive an agent with a turn from the console — without any secret reaching the client, without approvals ever leaving Telegram, and without the surface becoming the principal's source of truth or a separate conversation record (operator turns mirror into the agent's Telegram thread).
-stakes: An operator running a standing fleet 24/7 needs a place to glance across all of it at once — the chat is per-agent and per-topic, so a fleet-wide problem (a stuck agent, a quota wall, a drifted config, a failing memory backend) is invisible until a principal complains. Without a fleet view the operator debugs blind, one `docker exec` at a time. But a dashboard is also the easiest place to accidentally rebuild the retired progress card, leak a token, or grow a second approval path — so the screen earns its place only by staying an operator tool, never a principal one.
+outcome: The operator can open one management console and see every agent's live state, health, quota, history, sessions, memory, workspace, and approval/audit trail, run fleet ops (restart, config edits), and drive an agent with a turn from the console, without any secret reaching the client, without approvals ever leaving Telegram, and without the surface becoming the principal's source of truth or a separate conversation record (operator turns mirror into the agent's Telegram thread).
+stakes: An operator running a standing fleet 24/7 needs a place to glance across all of it at once. The chat is per-agent and per-topic, so a fleet-wide problem (a stuck agent, a quota wall, a drifted config, a failing memory backend) is invisible until a principal complains. Without a fleet view the operator debugs blind, one `docker exec` at a time. But a dashboard is also the easiest place to accidentally rebuild the retired progress card, leak a token, or grow a second approval path, so the screen earns its place only by staying an operator tool, never a principal one.
 serves: hold-the-leash
 invariants: [chat-is-the-single-source-of-truth, telegram-only, no-self-escalation, single-tenant, claude-native]
 ---
 
 # Job Spec: see and manage my whole fleet from one operator screen
 
-> A durable Job Spec. The *how* — the Hermes-Desktop adapter (REST + JSON-RPC
-> WebSocket) served from `switchroom-web`, the unmodified Hermes Desktop run
-> in remote mode, the `inject_inbound` mirror, the auth gate — lives in the
-> design artifact `reference/rfcs/fleet-dashboard.md` and the code under
-> `src/web/`. That implementation churns; this job does not.
+> A durable Job Spec. The *how* lives in the design artifact
+> `reference/rfcs/fleet-dashboard.md` and the code under `src/web/`: the
+> Hermes-Desktop adapter (REST + JSON-RPC WebSocket) served from
+> `switchroom-web`, the unmodified Hermes Desktop run in remote mode, the
+> `inject_inbound` mirror, the auth gate. That implementation churns; this
+> job does not.
 
-## Who this is for — read this first
+## Who this is for, read this first
 
 Switchroom has **two people** (`vision.md`): the **principal**, who texts an
-agent and never sees a server; and the **operator**, who stands the fleet up
+agent and never sees a server, and the **operator**, who stands the fleet up
 and keeps it running. This job belongs to the **operator only**.
 
 The principal's "what is my agent doing" job is
 [`know-what-my-agent-is-doing`](know-what-my-agent-is-doing.md), and it is
-answered **in the chat**, by the model talking — never by a dashboard. The
+answered **in the chat**, by the model talking, never by a dashboard. The
 quota job is [`track-plan-quota-live`](track-plan-quota-live.md), whose title
 is literally "*without a dashboard*" because the principal should never have
 to stop and open one. This fleet screen does not, and must never, become the
@@ -38,8 +39,8 @@ Telegram topic, which is exactly right for the principal but wrong for the
 operator who needs to know, at a glance: which agents are up, which are
 working, which are wedged, who's near a quota wall, whose memory backend is
 sick, whose config drifted, what's pending approval across the whole fleet,
-and what each has been doing lately. Today that means SSH + `docker exec` +
-grepping logs, one agent at a time. The job is to give the operator one
+and what each has been doing lately. Today that means SSH plus `docker exec`
+plus grepping logs, one agent at a time. The job is to give the operator one
 screen that aggregates all of it, lets them act on the fleet (restart, edit
 config), and never leaks a secret or quietly grows into a second principal
 channel or a second approval path.
@@ -51,20 +52,20 @@ channel or a second approval path.
 - One screen lists every agent with live status (up / working / idle /
   recovering / down), and the operator can drill into any one.
 - Per-agent: auth-slot + quota health (active slot, % used, reset window,
-  expiry) as **metadata only** — never a token, never `credentials.json`.
+  expiry) as **metadata only**, never a token, never `credentials.json`.
 - Per-agent history, sessions (handoff vs continue vs cold, plus
   wake-audit/recovery state), workspace files, and memory are browsable
   read-only for debugging.
 - The approval/grant trail is visible as a **read-only audit feed** across
-  the fleet, plus what's currently pending — so the operator can see the
+  the fleet, plus what's currently pending, so the operator can see the
   leash state at a glance.
-- Fleet ops the operator already does from the CLI — restart, and operator
-  config edits — are available from the screen, routed through the same
+- Fleet ops the operator already does from the CLI (restart, and operator
+  config edits) are available from the screen, routed through the same
   operator-authored, hostd/CLI-enforced paths, never a new privileged
   backdoor.
 - The operator can send a turn to one of their own agents from the console,
   and that turn plus the agent's reply **mirror into the agent's Telegram
-  thread** — the console is another way *in*, never a separate conversation
+  thread**. The console is another way *in*, never a separate conversation
   the Telegram thread can't see. The turn rides the same synthesized-inbound
   path as cron, landing in the one agent session.
 - Off by default, binds loopback by default, refuses to serve
@@ -75,9 +76,9 @@ channel or a second approval path.
   memory) is treated as untrusted and escaped; the file browser is jailed to
   the agent workspace and traversal-safe.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
-- A live, pinned, parallel **progress mirror** of a turn — a web re-creation
+- A live, pinned, parallel **progress mirror** of a turn, a web re-creation
   of the retired #1122 card. The operator may review what an agent *did*
   from durable artifacts (history, audit, sessions); they do not get a live
   blow-by-blow surface that runs beside the conversation and substitutes for
@@ -99,7 +100,7 @@ channel or a second approval path.
 - Any secret reaching the browser, an API response, or a log
   (`credentials.json`, vault values, OAuth/bot tokens).
 - A mutating path that lets the web grant access the operator's config
-  didn't already authorize — a self-escalation backdoor around the cascade.
+  didn't already authorize, a self-escalation backdoor around the cascade.
 - A file browser that can serve arbitrary host paths, or unescaped content
   that lets untrusted message/tool/file text run as script.
 - A service that disappears on `switchroom apply` because it was hand-edited
@@ -142,28 +143,28 @@ principal's chat jobs). Pin:
 - **Done when:** the operator can see and manage the whole fleet from one
   screen, can debug any agent's history/sessions/memory/files/audit
   read-only, sees quota and leash state at a glance, runs the fleet ops they
-  already had on the CLI — and the screen leaks no secret, grows no approval
+  already had on the CLI. And the screen leaks no secret, grows no approval
   or chat path, and never becomes a principal surface or a live parallel
   progress mirror.
 
 ## Production-readiness
 
 - *Compliance:* no Anthropic API/SDK import, no token read/forward/log, no
-  inference proxying — cross-checked against `claude-native` and
+  inference proxying. Cross-checked against `claude-native` and
   `no-self-escalation` (`access-model.md`).
 - *Exposure:* loopback default; non-loopback requires auth; secrets never
   egress; untrusted content escaped; file access jailed.
 - *Boundary:* this surface stays operator-only and read-mostly. The two
-  principal-facing jobs it could cannibalise —
+  principal-facing jobs it could cannibalise,
   [`know-what-my-agent-is-doing`](know-what-my-agent-is-doing.md) and
-  [`track-plan-quota-live`](track-plan-quota-live.md) — remain answered in
+  [`track-plan-quota-live`](track-plan-quota-live.md), remain answered in
   the chat. If the dashboard starts being where a principal goes, this job
   has failed even if every feature works.
 
 ---
 
 > **Implementation:** `reference/rfcs/fleet-dashboard.md` (the design
-> artifact, `serves:` this job) — the Hermes-Desktop adapter served from
+> artifact, `serves:` this job): the Hermes-Desktop adapter served from
 > `src/web/` (`switchroom-web`), with unmodified Hermes Desktop run in remote
 > mode as the client. `reference/invariants.md` records why the admin console
 > is out of `telegram-only`'s scope (it governs principal channels, not admin

--- a/reference/jobs/share-auth-across-the-fleet.md
+++ b/reference/jobs/share-auth-across-the-fleet.md
@@ -1,7 +1,7 @@
 ---
 job: log into Anthropic once per account, not once per agent
 outcome: One `claude setup-token` per Anthropic account covers every agent, sub-agent, hook, summarizer, and cron that account is enabled on. Refresh, quota state, and fallback all live at the account level. The user manages accounts; switchroom routes them to consumers.
-stakes: When auth is per-agent, six agents on one Pro subscription means six OAuth flows, six independent refresh cycles, six places quota state can drift, and six 401-storms when the user adds a seventh agent. The user starts to feel the fleet — and asks why "one subscription" demands six logins.
+stakes: When auth is per-agent, six agents on one Pro subscription means six OAuth flows, six independent refresh cycles, six places quota state can drift, and six 401-storms when the user adds a seventh agent. The user starts to feel the fleet, and asks why "one subscription" demands six logins.
 serves: subscription-honest
 invariants: [claude-native]
 ---
@@ -16,12 +16,12 @@ invariants: [claude-native]
 
 The user pays Anthropic for a subscription. That subscription is the unit
 they care about: it has a bill, a quota, an expiry, and an account identity
-("ken@example.com"). The job is to make that *account* drive the fleet — not
+("ken@example.com"). The job is to make that *account* drive the fleet, not
 to make the user maintain one fictional copy of it per agent. Agents are
 consumers of accounts, not owners of them: one login per account, then "use
 this account on these agents" is configuration.
 
-> We used to give every agent its own private OAuth slot pool — six agents
+> We used to give every agent its own private OAuth slot pool. Six agents
 > on one subscription meant six `claude setup-token` runs, six refresh
 > cycles, and six independent rediscoveries of the same quota wall. We
 > changed the unit to the Anthropic account; the job underneath is
@@ -32,13 +32,13 @@ this account on these agents" is configuration.
 **Good looks like**
 
 - Adding a second, third, or sixth agent to an account the user already set
-  up needs no new OAuth flow — just naming the account and a restart.
+  up needs no new OAuth flow, just naming the account and a restart.
 - The user can answer "which Anthropic accounts am I logged into, and which
   agents use each?" with one command, and it fits on a screen.
 - A sub-agent, Stop hook, handoff summarizer, or cron fires against the same
-  account as its parent — no re-auth, no 401, no env-var hand-offs.
+  account as its parent: no re-auth, no 401, no env-var hand-offs.
 - When an account hits its cap, every agent on that account fails over to
-  the next account within seconds — not one inbound at a time.
+  the next account within seconds, not one inbound at a time.
 - An agent quiet for a week is still authenticated on the next ping; the
   credential was kept fresh whether or not the agent was awake.
 - Removing an account is one explicit action, refused while it is the fleet
@@ -47,9 +47,9 @@ this account on these agents" is configuration.
   recognises (their accounts), and it matches what the agent's own claude
   process reports.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
-- A per-agent OAuth flow for each agent sharing one subscription — the
+- A per-agent OAuth flow for each agent sharing one subscription, the
   per-login storm this job exists to kill.
 - Sharing one credentials file across agents via symlink, hard link, or
   bind mount: an atomic-rename writer orphans the target and other agents
@@ -57,7 +57,7 @@ this account on these agents" is configuration.
 - Per-agent OAuth refresh racing the single-use refresh endpoint, or
   per-agent quota state so each agent rediscovers the wall independently.
 - Falling through one account to another on exhaustion unless the user
-  explicitly listed both as preferences — two accounts must stay visibly
+  explicitly listed both as preferences. Two accounts must stay visibly
   separate.
 - Conflating "set up my Anthropic account" with "wire this agent to an
   existing account" into one verb, dragging the per-agent login back in.
@@ -74,7 +74,7 @@ this account on these agents" is configuration.
 - **One writer, many fresh mirrors** — `tests/auth.credentials-file-success`,
   `tests/auth.stale-token-fix`. *Watch:* a credential write is captured
   correctly and a stale token is never accepted as fresh. *Invariant:*
-  `claude-native` — every consumer reads a current subscription credential,
+  `claude-native`. Every consumer reads a current subscription credential,
   never an expired or API token.
 - **Broker health + per-agent fanout** — `tests/doctor-auth-broker`.
   *Watch:* drift, threshold violations, and active-account are surfaced;
@@ -97,13 +97,13 @@ seconds, no orphaned or stale credentials.
 
 ## Verdict
 
-- **Done when:** one login per account drives the whole fleet — every
+- **Done when:** one login per account drives the whole fleet. Every
   consumer authenticated, quota and failover account-level, no per-agent
-  OAuth storm — proven by the guards above.
+  OAuth storm. Proven by the guards above.
 
 ## Production-readiness
 
-- *Reliability:* the broker's death is degraded, not catastrophic — agents
+- *Reliability:* the broker's death is degraded, not catastrophic. Agents
   run on existing valid tokens until it returns and re-syncs from the
   account store.
 - *Concurrency:* exactly one OAuth refresher per account; no two processes

--- a/reference/jobs/steer-or-queue-mid-flight.md
+++ b/reference/jobs/steer-or-queue-mid-flight.md
@@ -13,11 +13,11 @@ invariants: [chat-is-the-single-source-of-truth]
 The user is half-watching the agent work. Two things can happen: they realise
 it's going the wrong way and want to redirect it, or they have a new,
 unrelated thing they want done. Both are common, both urgent, both must work.
-The job is to make both distinguishable — to the user and to the agent.
+The job is to make both distinguishable, to the user and to the agent.
 Steering is amend-in-place: the current task continues with the new
 information folded in. Queuing is a new task: the current one finishes on its
 own terms, the new one picks up after, with no context bleeding between them.
-Ambiguous input must not silently pick one and hope — the product decides
+Ambiguous input must not silently pick one and hope. The product decides
 clearly and says which, or it asks. The worst outcome is the user thinking
 they steered when they actually queued, or the reverse.
 
@@ -30,25 +30,25 @@ they steered when they actually queued, or the reverse.
 **Good looks like**
 
 - A mid-flight follow-up can course-correct the current task, and the change
-  shows up in the visible progress — not pretended away, not a silent restart
+  shows up in the visible progress, not pretended away, not a silent restart
   from scratch.
 - A mid-flight follow-up can be filed as a new task that waits politely, then
   runs, with the current task untouched and no context bleeding in from it.
-- Whichever the agent picked — steer or queue — is stated by the agent in the
+- Whichever the agent picked, steer or queue, is stated by the agent in the
   chat, so the user reads it, never has to infer it.
 - When the input is genuinely ambiguous, the agent makes a reasonable call
   and says which it made, so the user can correct on the next message.
-- A burst — a forward of several messages, or a long paste Telegram split —
+- A burst (a forward of several messages, or a long paste Telegram split)
   is treated as one thought with shared context, not answered fragment by
   fragment.
 - Nothing the user said is lost: not to a race, not to ambiguity, not to a
   restart.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
 - Silent classification: the agent decides steer-or-queue and never says
   which, leaving the user to guess.
-- One-size-fits-both — always treating follow-ups as the same kind — which
+- One-size-fits-both, always treating follow-ups as the same kind, which
   loses one of the two jobs.
 - A steer applied at an unsafe point (mid-tool-call), or one that silently
   restarts the task when the user wanted an amendment.
@@ -91,7 +91,7 @@ be lost, across the corpus.
 
 - **Done when:** the user can steer or queue mid-flight, the agent treats
   each correctly, the user always reads which one happened, and nothing they
-  said is lost — proven by the scenarios above.
+  said is lost. Proven by the scenarios above.
 
 ## Production-readiness
 

--- a/reference/jobs/survive-reboots-and-real-life.md
+++ b/reference/jobs/survive-reboots-and-real-life.md
@@ -14,7 +14,7 @@ Agents are long-running processes that live on real machines. Machines
 reboot, power drops, networks flap, disks fill, sessions run out of
 context. The user hires this job so they don't have to babysit the fleet
 to keep it alive. Surviving means two things: the agent comes back on its
-own after a reboot, crash, or upgrade — and it is honest about what
+own after a reboot, crash, or upgrade, and it is honest about what
 happened. If a turn was interrupted, memory was lost, context was
 compacted, or a tool call failed mid-way, the user hears about it in plain
 language, at the point it affects them. Silent recovery is worse than a
@@ -29,7 +29,7 @@ bug, not the resilience.
   has to kick anything.
 - After a crash, the agent is respawned and the user is told, with enough
   detail to know whether the in-flight work survived.
-- An interrupted turn either resumes or is explicitly named as lost — never
+- An interrupted turn either resumes or is explicitly named as lost, never
   dropped on the floor in silence.
 - Context exhaustion reads as a named event the user understands, not a
   mysterious refusal.
@@ -41,12 +41,12 @@ bug, not the resilience.
 - The user can ask "is everything healthy?" and get a real answer, not a
   green tick over a dead process.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
 - Silent death: a process that's gone but still appears addressable.
 - Silent resurrection: an agent that came back in a different state than it
   went down in, without saying so.
-- Endless retry loops with no surfacing — the user thinks it's working and
+- Endless retry loops with no surfacing. The user thinks it's working and
   it's actually stuck.
 - Dropping in-flight work when a process dies, with no mention of what was
   lost.
@@ -95,7 +95,7 @@ never silently, work resumed or named-as-lost.
 
 - **Done when:** after any reboot, crash, or transient failure, the agent
   comes back on its own and the user is told in plain language what
-  happened to their in-flight work — proven by the scenarios above, never
+  happened to their in-flight work. Proven by the scenarios above, never
   recovered in silence.
 
 ## Production-readiness

--- a/reference/jobs/talk-to-agents-from-anywhere.md
+++ b/reference/jobs/talk-to-agents-from-anywhere.md
@@ -15,11 +15,11 @@ user wants to pick something up while walking to the shops, finish thinking
 about it on the train, hand off to the agent, and get a result while
 they're making dinner. The job is to make that loop feel native on a phone,
 with one hand. The chat surface is first-class, not a bolted-on
-notification channel: everything the user needs to steer, inspect, correct,
+notification channel. Everything the user needs to steer, inspect, correct,
 or pause their agents must be reachable from where they already are. If a
 capability only exists on the desktop, the user is tethered and the product
-stops being theirs. This is not porting a CLI to mobile — it's accepting
-the phone as the primary surface and designing back from there; the desktop
+stops being theirs. This is not porting a CLI to mobile. It's accepting
+the phone as the primary surface and designing back from there. The desktop
 benefits from that discipline rather than being diminished by it.
 
 ## Good / bad
@@ -30,18 +30,18 @@ benefits from that discipline rather than being diminished by it.
   moment where they wish they were at the laptop.
 - Inbound messages feel acknowledged instantly, not "processing" for ten
   seconds before anything appears.
-- Formatting reads naturally on a phone — no wide code blocks that need
+- Formatting reads naturally on a phone. No wide code blocks that need
   horizontal scroll, no structure that collapses on a narrow screen.
 - Attachments the user sends (a photo, a file) are treated as real input,
   not stripped or ignored.
-- Notifications tell the user something they actually need to know — they
+- Notifications tell the user something they actually need to know. They
   don't fire on every edit, and they don't go silent when it mattered.
 - The user can hand off a task, lock the phone, come back an hour later, and
   pick up where the agent left off without re-explaining.
 - Multiple agents in the same app feel like one fleet, not a drawer of
   disconnected bots the user has to remember how to address.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
 - A mobile experience that's really a web view of the desktop UI. If the
   user has to pinch to zoom, it wasn't designed for a phone.
@@ -56,7 +56,7 @@ benefits from that discipline rather than being diminished by it.
 - Requiring the user to be in a specific view, or tap through a settings
   panel, to steer a task that's already running.
 - A second human-facing chat channel bolted on beside the one. One channel,
-  done properly — not a multi-channel bridge.
+  done properly, not a multi-channel bridge.
 
 ## Prove it
 
@@ -74,7 +74,7 @@ Named by job × surface, pointing at real scenarios.
 - **One-handed correction mid-flight (DM)** — `jtbd-rapid-followup-dm`,
   `jtbd-interrupt-marker-dm`. *Watch:* a short reply course-corrects a
   running turn. *Invariant:* steering an in-flight turn needs no view
-  switch or settings panel — just a message.
+  switch or settings panel, just a message.
 - **Attachments are real input (DM)** — `voice-inbound-dm`,
   `location-inbound-dm`, `jtbd-album-coalescing-dm`. *Watch:* a photo,
   voice note, or location the user sends is acted on, not discarded.
@@ -92,7 +92,7 @@ Named by job × surface, pointing at real scenarios.
 - **One fleet, addressable across surfaces (DM + channel)** —
   `jtbd-supergroup-reply-channel`, `fuzz-multitopic-routing-channel`.
   *Watch:* multiple agents are addressed naturally in DM and forum channel
-  alike. *Invariant:* the fleet stays one coherent surface — the single
+  alike. *Invariant:* the fleet stays one coherent surface, the single
   Telegram channel, never a second one.
 
 **Fuzz corpus:** vary input type (text × photo × voice × location × album)
@@ -105,6 +105,26 @@ walk-away, one channel only.
 ## Verdict
 
 - **Done when:** the user can run, steer, and finish real work entirely
-  from a phone — instant ack, attachments honoured, no notification storm,
-  no silent walk-away, never a punt to the desktop — proven across DM and
+  from a phone. Instant ack, attachments honoured, no notification storm,
+  no silent walk-away, never a punt to the desktop. Proven across DM and
   channel by the scenarios above.
+
+## Production-readiness
+
+- *Availability:* the chat surface is the product, so it has to be reachable
+  whenever the user is. A dead-zone or reconnect never costs the user their
+  place; the agent picks up the conversation after the gap rather than
+  starting over.
+- *Delivery integrity:* no turn is silently dropped. Every inbound is
+  acknowledged, every user-sent attachment (photo, voice, location, album)
+  is received as real input or fails loudly, and an outbound that matters
+  reaches the user's device rather than dying in a buffer.
+- *Latency:* an inbound is acknowledged within ~1s, before any answer.
+  On mobile a silent gap reads as "dead," so perceived responsiveness is a
+  hard property, not a nicety.
+- *Reliability:* a long turn never ends in silence. The user can hand off,
+  lock the phone, and return to a finished result or an honest status,
+  never to a turn that quietly stalled while they were away.
+- *Notification discipline:* alerts fire on what the user needs to know and
+  stay quiet on intermediate steps, so the channel never trains the user to
+  mute it and miss the one message that mattered.

--- a/reference/jobs/track-plan-quota-live.md
+++ b/reference/jobs/track-plan-quota-live.md
@@ -11,17 +11,17 @@ invariants: [claude-native]
 ## The job
 
 The user is on a subscription with rolling-window quotas. They don't want to
-think about those limits — they want to know when they should. The job is to
+think about those limits, they want to know when they should. The job is to
 make usage visible without making it the main show, and to raise a flag
 before the user hits a wall. "At a glance" is the point: no command, no
 browser, no status report. The signal sits where the user already is, at a
-weight matching its importance — ambient when there's headroom, a nudge when
+weight matching its importance: ambient when there's headroom, a nudge when
 a cap is approaching, a clear message with recovery timing when it's crossed.
 Accuracy matters as much as visibility: a number that lags reality by an hour
 makes the user plan around a phantom.
 
 Because every model call is the interactive `claude` session and there is no
-programmatic surface, there is exactly *one* pool to track — the interactive
+programmatic surface, there is exactly *one* pool to track: the interactive
 subscription window. Quota stays a single-signal problem.
 
 ## Good / bad
@@ -29,18 +29,18 @@ subscription window. Quota stays a single-signal problem.
 **Good looks like**
 
 - The user can answer "am I close to my limit?" without stopping what they're
-  doing — the signal is ambient, where they already are.
+  doing. The signal is ambient, where they already are.
 - Approaching a cap produces a visible change at a point where the user can
   still act on it.
 - Hitting a cap produces an honest message: blocked, why, and when it clears.
 - Usage shown matches reality closely enough that the user trusts it for
   planning.
 - Different plans and limits are handled correctly with zero configuration.
-- The signal scales with the stakes — background when there's headroom,
-  louder when there isn't — and the user sees recovery when the window rolls,
+- The signal scales with the stakes, background when there's headroom,
+  louder when there isn't, and the user sees recovery when the window rolls,
   without refreshing.
 
-**Bad looks like — never ship this**
+**Bad looks like: never ship this**
 
 - Quota visible only in a separate dashboard or behind a command. If the user
   has to go looking, they won't, and they'll hit the wall.
@@ -50,7 +50,7 @@ subscription window. Quota stays a single-signal problem.
 - Conflating different windows or plan limits into one blurred number.
 - "You've used 87%" with no sense of whether that's routine or concerning.
 - Telling the user they're blocked without telling them when they won't be.
-- Recovering quota by routing off the subscription (API/PAYG/credits) — the
+- Recovering quota by routing off the subscription (API/PAYG/credits). The
   ceiling is the plan the user chose, never a second meter.
 
 ## Prove it
@@ -58,11 +58,11 @@ subscription window. Quota stays a single-signal problem.
 - **Weekly-cap wall is caught, on-subscription (agent)** —
   `tests/rate-limit-menu-detect.test.ts`. *Watch:* a hit weekly limit is
   detected and parked, surfacing the reset timing. *Invariant:* by default
-  recovery is never "switch to usage credits" — the off-subscription path is
+  recovery is never "switch to usage credits". The off-subscription path is
   never taken (the load-bearing `claude-native` assertion). The one carve-out
   is an account the operator explicitly opted into overage
   (`allow_overage_accounts`): the broker confirms `overageStatus:"allowed"`
-  and only then is "usage credits" selected — on the operator's own Anthropic
+  and only then is "usage credits" selected, on the operator's own Anthropic
   credits, default-off, auto-stopping at `out_of_credits`, and still the
   unmodified interactive `claude` CLI (never API/SDK). Unflagged accounts are
   Escape-only, unchanged.
@@ -76,7 +76,7 @@ subscription window. Quota stays a single-signal problem.
   the shown number tracks reality and never flatters a walled account.
 - **Quota visible in the chat (DM/channel)** — *(coverage gap: no runnable
   scenario yet)*. *Watch:* the user sees usage ambient while normal, a nudge
-  near a cap, and an honest block-with-recovery at the cap — all in the chat,
+  near a cap, and an honest block-with-recovery at the cap, all in the chat,
   never a dashboard. *Invariant:* the signal scales with the stakes and is
   always where the user already is.
 
@@ -90,13 +90,13 @@ must stay honest, on-subscription, and legible across the corpus.
 - **Done when:** the user can read where they stand against their plan at a
   glance, is warned before a cap while they can still act, gets an honest
   block-with-recovery at the cap, and is never pushed off the subscription to
-  recover — proven by the scenarios above.
+  recover. Proven by the scenarios above.
 
 ## Production-readiness
 
 - *Accuracy:* shown usage agrees closely with authoritative data; staleness
   is surfaced (snapshot age), never hidden.
-- *Compliance:* a quota wall is parked on-subscription — the off-subscription
+- *Compliance:* a quota wall is parked on-subscription. The off-subscription
   recovery path is never selected, by construction, **except** for an account
   the operator explicitly opted into overage (`allow_overage_accounts`), where
   the broker authorizes spending the operator's own Anthropic overage credits

--- a/reference/principles.md
+++ b/reference/principles.md
@@ -13,6 +13,17 @@ whether a feature serves the vision.
 If you can't answer **yes** to all three checks at the bottom of this
 doc, the work isn't done. Redesign, don't ship and patch later.
 
+These three principles cover one half of "built well": the UX and
+coherence bar (docs / defaults / consistency). The other half, the
+non-functional trust and safety bar, is **not** a principle you trade
+off on a gradient. It's enforced as hard lines in
+[`invariants.md`](invariants.md): claude-native, no-self-escalation,
+on-leash, single-tenant, telegram-only,
+chat-is-the-single-source-of-truth. Security, the on-leash stakes, and
+the subscription-honest stakes live there as binary pass/fail gates. A
+feature can ace all three principle checks and still be out of scope
+because it crosses an invariant. Check both.
+
 ---
 
 ## 1. "If they need the docs, we've failed"
@@ -36,7 +47,7 @@ job.
 ### Examples
 
 - ✅ **Good:** `switchroom auth add default --via-claude` prints the
-  OAuth URL inline, says *"open this in any browser — complete the sign-in
+  OAuth URL inline, says *"open this in any browser, complete the sign-in
   and the token saves automatically,"* and watches for completion.
   For refreshing an existing session: `switchroom auth reauth coach`.
 - ❌ **Bad:** `switchroom auth add` exits with `EAUTH_FAILED`
@@ -69,11 +80,11 @@ job.
 
 Ship the pre-built Lego set, not the bag of bricks.
 
-`switchroom setup` should produce a **working fleet** on the first run
-— a default agent, a working bot, the agent responding
+`switchroom setup` should produce a **working fleet** on the first run:
+a default agent, a working bot, the agent responding
 conversationally on the first message. The defaults cover 80% of
-cases. Power users will customise;
-make them **opt into complexity, never opt out of it**. Configuration
+cases. Power users will customise.
+Make them **opt into complexity, never opt out of it**. Configuration
 is work. Give them the working thing first. Let them tinker later.
 
 ### Check questions
@@ -109,7 +120,7 @@ is work. Give them the working thing first. Let them tinker later.
 
 - ✅ **Good:** The upgrade flow is one command: `switchroom update` pulls
   new images, reconciles the compose file, rolls the fleet, and runs
-  doctor — idempotent and the same on every host.
+  doctor: idempotent and the same on every host.
 - ❌ **Bad:** "Run `bun run build`, then bounce each container by hand,
   then re-render the compose file, then…"
 
@@ -128,7 +139,7 @@ The whole product should feel like one person designed it.
 No seams between layers. Consistent CLI shape, consistent Telegram UX,
 shared config cascade, unified vault and OAuth model. When you learn
 how one part works, you've learned how the rest works. This is about
-**cognitive load**, not visual design — every new interaction model
+**cognitive load**, not visual design. Every new interaction model
 asks users to re-learn the product.
 
 ### Check questions
@@ -140,14 +151,14 @@ asks users to re-learn the product.
 
 ### Examples
 
-- ✅ **Good:** Every top-level CLI verb is `switchroom <noun> <verb>`
-  — `agent start`, `vault set`, `topics sync`, `auth add`. One
+- ✅ **Good:** Every top-level CLI verb is `switchroom <noun> <verb>`:
+  `agent start`, `vault set`, `topics sync`, `auth add`. One
   shape. One file per noun in `src/cli/`.
 - ❌ **Bad:** `switchroom agent start` next to `switchroom
   restart-agent` next to `switchroom start_telegram`.
 
-- ✅ **Good:** Every long-running operation — interactive reply,
-  scheduled task, sub-agent delegation — uses the same conversational
+- ✅ **Good:** Every long-running operation (interactive reply,
+  scheduled task, sub-agent delegation) uses the same conversational
   pacing rhythm. Soft-commit, mid-turn updates at meaningful
   punctuation, final answer pings once. Sub-agent work is narrated in
   the same thread as the parent.
@@ -161,14 +172,14 @@ asks users to re-learn the product.
   the same way across `defaults`, profiles, and agents. See
   `src/config/merge.ts` and `docs/configuration.md`.
 - ❌ **Bad:** Some fields cascade, some override, some concat, with no
-  documented mode — users have to read the merge logic to predict
+  documented mode, so users have to read the merge logic to predict
   behaviour.
 
 - ✅ **Good:** Secrets are referenced uniformly as `vault:<key>`
   anywhere in `switchroom.yaml`. The vault CLI, the cascade resolver,
   and the bootstrap layer all know that prefix.
 - ❌ **Bad:** Tokens via `vault:`, API keys via `${env.FOO}`, group
-  IDs via plain literals — three idioms for "this came from somewhere
+  IDs via plain literals: three idioms for "this came from somewhere
   else."
 
 - ✅ **Good:** `switchroom agent restart` always reconciles first
@@ -178,7 +189,7 @@ asks users to re-learn the product.
 - ❌ **Bad:** `restart` only restarts the process, `reconcile` only
   rewrites config, and you have to know which one to run when.
 
-- ✅ **Good:** Same Telegram UX surface for every agent — same `/auth`
+- ✅ **Good:** Same Telegram UX surface for every agent: same `/auth`
   router, same reaction lifecycle, same conversational pacing, same
   silence-poke safety net, regardless of profile.
 - ❌ **Bad:** Custom one-off Telegram behaviours per profile that look
@@ -193,7 +204,7 @@ retired in #1122). Build the model to communicate; let the framework
 be the safety net, not the headline. Single source of truth for "what
 is the agent doing": the chat itself, paced by the model. The
 framework's job is to escalate the *reaction* (ambient) and fire a
-backstop message at 5min silence (safety net) — not to mirror state
+backstop message at 5min silence (safety net), not to mirror state
 in parallel.
 
 When you're tempted to add a new pinned card / status bar / live
@@ -220,8 +231,17 @@ Before you open a PR, ask:
 If you can't answer **yes** to all three, you're not done. Redesign,
 don't ship and patch later.
 
-These principles don't replace the existing JTBDs in `reference/` —
-they *judge* them. A feature can satisfy a JTBD outcome and still fail
+And the three principle checks aren't the whole gate. The
+non-functional trust bar (security, the on-leash stakes, the
+subscription-honest stakes) is owned as binary lines in
+[`invariants.md`](invariants.md), not as anything you weigh here:
+claude-native, no-self-escalation, on-leash, single-tenant,
+telegram-only, chat-is-the-single-source-of-truth. Before you open the
+PR, confirm the change crosses none of them. A "yes" on all three
+principle checks plus a crossed invariant is still out of scope.
+
+These principles don't replace the existing JTBDs in `reference/`.
+They *judge* them. A feature can satisfy a JTBD outcome and still fail
 all three principle checks. When that happens, the JTBD outcome is the
-goal; the principles are how we get there without making the product
+goal, and the principles are how we get there without making the product
 feel like a kit.

--- a/reference/product-spec.md
+++ b/reference/product-spec.md
@@ -22,6 +22,33 @@ A switchboard for your Pro or Max: a standing team of always-on specialists
 you text from Telegram, each running the unmodified `claude` CLI on your own
 subscription, on your box, on your leash.
 
+## North Star
+
+> One number the whole product is judged on. If it moves, we're winning. If it
+> stalls, nothing else matters. The four outcome Signals below are its drivers.
+> They decompose it, they don't compete with it.
+
+- **Metric:** Trusted Unsupervised Turn Rate (TUTR).
+- **Definition:** Of every consequential turn the fleet handles in a rolling
+  30-day window, the share that land clean on all four counts:
+  - **Unsupervised.** It finished without you babysitting it. No re-onboarding,
+    it acted on what it already knows about you.
+  - **Trusted.** It took no consequential action you didn't approve, and made
+    no off-plan model call.
+  - **Observable.** You could see what it was doing in plain words. If you had
+    to ask it for status, that turn failed.
+  - **Steerable.** You could steer it or stop it mid-flight and it listened.
+
+  A turn fails TUTR if it trips any one of the four. "Consequential" means a
+  turn that does or changes something, not a pleasantry.
+- **Now → Target:** baseline TBD (instrument first), then north of 95% once
+  there's a baseline to set the date against.
+- **Why this one:** The vision is a standing team that knows you, acts on your
+  leash, costs only the plan you pay for, and is there when you reach for it. We
+  win when work gets done that you trust, without re-explaining it or watching
+  over it. TUTR is that sentence made countable. It only climbs when all four
+  outcome Signals hold at once.
+
 ## Outcomes
 
 Every job the product serves ladders up to exactly one of these. A change
@@ -92,30 +119,30 @@ The jobs this product serves, grouped by the outcome they ladder up to.
 Each links its job spec in `jobs/`.
 
 ### standing-team
-- [`run-a-fleet-of-specialists.md`](jobs/run-a-fleet-of-specialists.md)
-- [`feel-like-a-colleague.md`](jobs/feel-like-a-colleague.md)
-- [`give-each-agent-its-own-workspace.md`](jobs/give-each-agent-its-own-workspace.md)
-- [`remember-across-sessions.md`](jobs/remember-across-sessions.md)
-- [`extend-without-forking.md`](jobs/extend-without-forking.md)
-- [`get-better-the-longer-they-run.md`](jobs/get-better-the-longer-they-run.md)
-- [`get-from-zero-to-a-working-fleet.md`](jobs/get-from-zero-to-a-working-fleet.md)
-- [`deliver-files-i-can-open.md`](jobs/deliver-files-i-can-open.md)
+- [`run-a-fleet-of-specialists.md`](jobs/run-a-fleet-of-specialists.md) — count of active specialists kept on the fleet 90+ days
+- [`feel-like-a-colleague.md`](jobs/feel-like-a-colleague.md) — share of turns answered in-persona without a re-introduction
+- [`give-each-agent-its-own-workspace.md`](jobs/give-each-agent-its-own-workspace.md) — cross-agent context/credential bleed incidents, target zero
+- [`remember-across-sessions.md`](jobs/remember-across-sessions.md) — share of turns acting on stored context vs re-asking (re-onboarding rate)
+- [`extend-without-forking.md`](jobs/extend-without-forking.md) — share of new specialists added via config only, no product fork
+- [`get-better-the-longer-they-run.md`](jobs/get-better-the-longer-they-run.md) — repeat-correction rate on the same task, trending down
+- [`get-from-zero-to-a-working-fleet.md`](jobs/get-from-zero-to-a-working-fleet.md) — time from clean box to first useful turn
+- [`deliver-files-i-can-open.md`](jobs/deliver-files-i-can-open.md) — share of file deliverables the principal opens without rework
 
 ### hold-the-leash
-- [`know-what-my-agent-is-doing.md`](jobs/know-what-my-agent-is-doing.md)
-- [`restart-and-know-what-im-running.md`](jobs/restart-and-know-what-im-running.md)
-- [`track-plan-quota-live.md`](jobs/track-plan-quota-live.md)
-- [`steer-or-queue-mid-flight.md`](jobs/steer-or-queue-mid-flight.md)
-- [`approve-what-my-agent-can-touch.md`](jobs/approve-what-my-agent-can-touch.md)
-- [`see-my-whole-fleet-from-one-screen.md`](jobs/see-my-whole-fleet-from-one-screen.md)
+- [`know-what-my-agent-is-doing.md`](jobs/know-what-my-agent-is-doing.md) — share of turns whose state reads in plain words without a log dive
+- [`restart-and-know-what-im-running.md`](jobs/restart-and-know-what-im-running.md) — share of restarts that surface an accurate running-state summary
+- [`track-plan-quota-live.md`](jobs/track-plan-quota-live.md) — quota-surprise events (hit a limit unforecast), target zero
+- [`steer-or-queue-mid-flight.md`](jobs/steer-or-queue-mid-flight.md) — share of in-flight steer/stop requests honoured before the action lands
+- [`approve-what-my-agent-can-touch.md`](jobs/approve-what-my-agent-can-touch.md) — unapproved consequential actions, target zero
+- [`see-my-whole-fleet-from-one-screen.md`](jobs/see-my-whole-fleet-from-one-screen.md) — share of fleet whose live status is visible from one view
 
 ### subscription-honest
-- [`keep-my-subscription-honest.md`](jobs/keep-my-subscription-honest.md)
-- [`share-auth-across-the-fleet.md`](jobs/share-auth-across-the-fleet.md)
-- [`crons-use-the-model-only-when-it-earns-it.md`](jobs/crons-use-the-model-only-when-it-earns-it.md)
+- [`keep-my-subscription-honest.md`](jobs/keep-my-subscription-honest.md) — off-plan callsites, target zero (CI-enforced)
+- [`share-auth-across-the-fleet.md`](jobs/share-auth-across-the-fleet.md) — auth-exhaustion turns recovered by failover, target ~100%
+- [`crons-use-the-model-only-when-it-earns-it.md`](jobs/crons-use-the-model-only-when-it-earns-it.md) — share of cron fires routed to the cheapest tier that does the job
 
 ### always-available
-- [`survive-reboots-and-real-life.md`](jobs/survive-reboots-and-real-life.md)
-- [`idempotent-update-and-restart.md`](jobs/idempotent-update-and-restart.md)
-- [`talk-to-agents-from-anywhere.md`](jobs/talk-to-agents-from-anywhere.md)
-- [`act-in-my-tools-with-an-identity.md`](jobs/act-in-my-tools-with-an-identity.md)
+- [`survive-reboots-and-real-life.md`](jobs/survive-reboots-and-real-life.md) — turns silently dropped across reboots/network drops, target zero
+- [`idempotent-update-and-restart.md`](jobs/idempotent-update-and-restart.md) — update/restart operations completing cleanly and idempotently, target ~100%
+- [`talk-to-agents-from-anywhere.md`](jobs/talk-to-agents-from-anywhere.md) — median ack latency from Telegram message to acknowledgement
+- [`act-in-my-tools-with-an-identity.md`](jobs/act-in-my-tools-with-an-identity.md) — share of external-tool actions attributable to a named agent identity

--- a/reference/rfcs/access-model.md
+++ b/reference/rfcs/access-model.md
@@ -1,5 +1,5 @@
 ---
-artefact: switchroom access model
+artifact: switchroom access model
 backs: no-self-escalation
 relates: jobs/approve-what-my-agent-can-touch.md
 ---
@@ -8,9 +8,9 @@ relates: jobs/approve-what-my-agent-can-touch.md
 
 This is the design record detailing **how** the
 [`no-self-escalation`](../invariants.md#no-self-escalation) invariant is
-enforced — the security contract for authorization in switchroom. It is
+enforced. It is the security contract for authorization in switchroom. It is
 deliberately small. Read it before changing anything that grants,
-checks, or prompts for access — secrets, tools, MCP servers, vault
+checks, or prompts for access: secrets, tools, MCP servers, vault
 grants, or host/fleet verbs. The operator-facing approval/secret-handling
 outcome is the job [`approve-what-my-agent-can-touch`](../jobs/approve-what-my-agent-can-touch.md);
 this doc is the agent-side mechanism beneath it.
@@ -20,7 +20,7 @@ this doc is the agent-side mechanism beneath it.
 Switchroom is a **local install on a single-tenant Linux server**: one
 operator, their own box, agents that are **eager to help, not
 adversarial** (the [`single-tenant`](../invariants.md#single-tenant)
-invariant). That reality is what lets the model be simple — so don't
+invariant). That reality is what lets the model be simple, so don't
 import a multi-tenant or hostile-network threat model and over-build for
 it.
 
@@ -30,7 +30,7 @@ it.
   *"the vault ACL is misconfiguration protection, not a security
   boundary"*). The real boundary is filesystem perms + the vault
   passphrase. Hardening against a process that already shares the
-  agent's uid is effort spent on a threat this product doesn't have —
+  agent's uid is effort spent on a threat this product doesn't have,
   and it's where the over-built proposals went (see *Closed
   directions*).
 - The threat we **do** secure is escalation by a helpful agent: it
@@ -39,11 +39,11 @@ it.
 ## The invariant this enforces
 
 The line is owned by the [`no-self-escalation`](../invariants.md#no-self-escalation)
-invariant — *an agent can request more access, but can never author its
+invariant: *an agent can request more access, but can never author its
 own authorization; every grant is written by the operator, in a place
 the agent cannot write.* This doc is the **how** beneath that line. If a
 change lets an agent widen its own access without the operator, the
-change is wrong — redesign it, don't gate it after the fact.
+change is wrong. Redesign it, don't gate it after the fact.
 
 ## The one boundary — and it's free
 
@@ -58,7 +58,7 @@ an agent must never escalate to lives behind a _different_ uid.**
   bind-mounted **read-only**. The agent's own scaffold files
   (`settings.json`, `.mcp.json`) are writable by it, but they are
   **regenerated from `switchroom.yaml` on every reconcile/restart**, so a
-  self-edit doesn't survive — and the one sanctioned self-edit path
+  self-edit doesn't survive. The one sanctioned self-edit path
   (`config_propose_edit`) is **server-validated additive-to-self behind
   an operator tap**. The agent reads its sandbox; it cannot durably
   rewrite it.
@@ -71,11 +71,11 @@ the operator (`vault.broker.approvalAuth: passphrase`, the default), so
 the agent self-mints nothing. The agent↔gateway channel only becomes
 forgeable if the operator **opts in** to single-factor posture mint for a
 named agent (`approvalAuth: telegram-id` **and** adding the agent to
-`vault.broker.postureMintAgents` — both default-off). Even then it's
+`vault.broker.postureMintAgents`, both default-off). Even then it's
 bounded: `adminOnlyKeys` claws the sensitive keys back to
 **passphrase-only**, which a same-uid agent still can't satisfy. So the
-same-uid surface is an operator opt-in gated by a factor the agent lacks
-— not an open door — which is why the model needs no cryptographic
+same-uid surface is an operator opt-in gated by a factor the agent lacks,
+not an open door. That's why the model needs no cryptographic
 proofing of the agent↔gateway channel.
 
 ## Three tiers, three minimal mechanisms
@@ -89,7 +89,7 @@ requires.
 | **Ad-hoc** | something not in the sandbox | One **honest** approval card → the operator's Telegram tap. `callback_query.from.id` is Telegram-authenticated; an agent cannot fake it. |
 | **Crown jewels** | irreversible actions, admin credentials | Operator **passphrase** — a secret the agent structurally never holds. The only tier above a tap. |
 
-The passphrase — not process-isolation tricks — is the unforgeable line,
+The passphrase, not process-isolation tricks, is the unforgeable line,
 because it's a capability the agent **lacks**, not a barrier we hope it
 won't cross. Mark genuinely-sensitive vault keys passphrase-required
 (`vault.broker.adminOnlyKeys`) so an eager agent can't posture-mint them.
@@ -97,12 +97,12 @@ won't cross. Mark genuinely-sensitive vault keys passphrase-required
 ## Honest cards
 
 An approval an agent can socially-engineer is no approval. A card must
-show the **exact scope being granted** — the vault key, the fileId, the
-verb — not a friendly label the agent chose. Keep the
+show the **exact scope being granted**: the vault key, the fileId, the
+verb, not a friendly label the agent chose. Keep the
 wrapper-attested-truth vs `💬` agent-framing split (the Drive
 diff-preview is the reference implementation) on every approval surface.
 
-- ✅ **Good:** "⚠ clerk wants to write to `Q3 Plan` (`1aBc…xyz`)" — the
+- ✅ **Good:** "⚠ clerk wants to write to `Q3 Plan` (`1aBc…xyz`)". The
   operator approves the exact file that becomes the scope.
 - ❌ **Bad:** a card whose displayed label and granted scope come from
   different sources, so the agent can show one thing and obtain another.
@@ -110,14 +110,14 @@ diff-preview is the reference implementation) on every approval surface.
 ## Dead-ends breed workarounds
 
 Half of access security here is **legibility**, because an eager agent
-that hits a confusing wall improvises — and improvisation is where the
+that hits a confusing wall improvises, and improvisation is where the
 leaks happen (an agent told the user to paste a raw token into chat
 because the vault slot was empty; agents guess vault key names and burn
 operator taps). So:
 
-- An agent should be able to **see its own sandbox** — what it's
-  authorized for — so it stops guessing and overreaching.
-- When it hits the edge, the sanctioned path ("you don't have X — here's
+- An agent should be able to **see its own sandbox**, what it's
+  authorized for, so it stops guessing and overreaching.
+- When it hits the edge, the sanctioned path ("you don't have X, here's
   the one-tap request") must be **frictionless and obvious**, so it
   never routes around the gate.
 
@@ -151,15 +151,15 @@ kernel, and the honest-card + passphrase items above.
 - Could an agent end up with access the operator never wrote down or
   tapped for? (If yes, redesign.)
 - Is the grant enforced where the agent **can't write it** (different
-  uid, or operator-owned read-only config) — not in something the agent
+  uid, or operator-owned read-only config), not in something the agent
   controls?
 - Does the approval card show the **real scope**, sourced the same way
   it's enforced?
 - For the irreversible / crown-jewel case, is it behind the
   **passphrase**, not just a tap?
 - When access is denied, does the agent get a clean one-tap path to
-  request it — so it won't improvise around the gate?
+  request it, so it won't improvise around the gate?
 
 If you're reaching for a new daemon, a second bot, or per-action crypto
-to answer these, stop: on single-tenant the uid boundary + read-only
+to answer these, stop. On single-tenant the uid boundary + read-only
 operator config + the passphrase already answer them.

--- a/reference/rfcs/admin-agent-config-edit.md
+++ b/reference/rfcs/admin-agent-config-edit.md
@@ -1,6 +1,7 @@
 ---
-artefact: admin-agent config edit via approval-gated hostd verb
-serves: jobs/approve-what-my-agent-can-touch.md
+artifact: admin-agent config edit via approval-gated hostd verb
+serves: approve-what-my-agent-can-touch
+advances-outcome: hold-the-leash
 status: Draft v1
 ---
 
@@ -21,7 +22,7 @@ primary chat showing the rendered diff, the requesting agent, and the
 rationale. On Approve, the host writes the file atomically, snapshots
 the prior version to `~/.switchroom/config-backups/`, and runs
 `switchroom apply`; on Deny (or timeout) the proposal is a no-op.
-Every proposal — approved, denied, errored — is appended to the
+Every proposal, approved, denied, or errored, is appended to the
 existing hostd audit log.
 
 This collapses today's "agent pastes yaml block, asks human to copy-
@@ -46,7 +47,7 @@ Admin agents (today: `klanker`) regularly need to edit
 - "Flip `defaults.model` to opus-4-7-2."
 
 The agent's container mounts `/state/config/switchroom.yaml` read-
-only — by design; admin agents are prompt-injectable and must not be
+only, by design. Admin agents are prompt-injectable and must not be
 trusted with autonomous writes. So today the flow is:
 
 1. Agent drafts the yaml block in Telegram.
@@ -62,7 +63,7 @@ before drafting.
 ### 2.2 Why not just give the agent write access
 
 The whole point of the read-only mount is that admin agents are the
-biggest prompt-injection blast radius in the fleet — they can already
+biggest prompt-injection blast radius in the fleet. They can already
 restart peers, exec read-only commands inside peers, and trigger
 fleet upgrades. Adding silent yaml writes would mean a single
 poisoned tool-output (a doctored PR description, a malicious file in
@@ -73,7 +74,7 @@ verb is gated this way; config edits should be no different.
 ### 2.3 Why not granular per-section verbs
 
 We could ship `schedule_add`, `schedule_remove`, `skill_install`,
-`webhook_dispatch_add`, `defaults_set`, etc. — one verb per common
+`webhook_dispatch_add`, `defaults_set`, etc., one verb per common
 edit. Each would have a tight, typed surface area. Two reasons not
 to:
 
@@ -130,14 +131,14 @@ In order, all server-side, all before the operator hears a peep:
 1. **Patch shape.** Must be a unified diff with ≥3 lines context.
    The `---` and `+++` header paths must each match exactly one of
    `a/switchroom.yaml`, `b/switchroom.yaml`, or the bare filename
-   `switchroom.yaml` (git's three accepted forms). Any other path —
+   `switchroom.yaml` (git's three accepted forms). Any other path,
    including `../`, absolute paths, multi-file diffs, or symlink
-   targets — is rejected at this step as `validation-rejected`
+   targets, is rejected at this step as `validation-rejected`
    before `git apply` is invoked. Closes the
    `+++ b/../../etc/passwd` attack vector. Reject context-less
-   patches too — they're ambiguous and they defeat the operator's
+   patches too. They're ambiguous and they defeat the operator's
    ability to spot-check the diff visually. Patches MUST be LF-only
-   (no CRLF), no BOM, and capped at 1 MB raw bytes — this step is
+   (no CRLF), no BOM, and capped at 1 MB raw bytes. This step is
    the single source of truth for the 1 MB cap, §3.3's attachment
    discussion references it but does not re-decide it.
 2. **Apply check.** `git apply --check --whitespace=nowarn --recount`
@@ -152,7 +153,7 @@ In order, all server-side, all before the operator hears a peep:
    { schema: FAILSAFE_SCHEMA })` for js-yaml, or `safe_load` for
    PyYAML-shaped libs). Reject `!!`-tags (`!!js/function`,
    `!!python/object`, …) and reject merge-key anchors / aliases
-   (`&foo` / `*foo` / `<<:`) at parse time — these are code-
+   (`&foo` / `*foo` / `<<:`) at parse time. These are code-
    execution / hidden-mutation primitives the zod schema runs *after*
    and cannot defend against. If the zod parse fails, reject with the
    formatted error; the operator is not woken.
@@ -168,7 +169,7 @@ Only proposals that pass all four go to the operator.
 
 Posted to the operator's primary chat via the existing approval-card
 infra in `telegram-plugin/gateway/approval-card.ts` /
-`drive-write-approval.ts` — both are existing precedents for non-
+`drive-write-approval.ts`, both existing precedents for non-
 vault mutating actions gated by a card. Card payload:
 
 - **Header**: `<agent_name> wants to edit switchroom.yaml`
@@ -179,7 +180,7 @@ vault mutating actions gated by a card. Card payload:
   "+N more lines" footer and attach the full diff as a `.diff` file
   via Telegram's attachment surface. Hard cap the attachment at 1 MB
   (well under Telegram's 50 MB document ceiling); a patch larger than
-  that is `validation-rejected` at §3.2 step 1 — config patches of
+  that is `validation-rejected` at §3.2 step 1. Config patches of
   that size belong in a hand-edited release, not a chat approval.
 - **Buttons**: `[Approve]` / `[Deny]`.
 - **Safety delay**: for diffs over 20 lines, the Approve button
@@ -189,7 +190,7 @@ vault mutating actions gated by a card. Card payload:
   to swap in the live `[✅ Approve]` button bound to the diff_id.
   Aimed at diff fatigue (see §5).
 
-The card lives in the **operator's** chat — `operator_chat_id` from
+The card lives in the **operator's** chat: `operator_chat_id` from
 the gateway config, NOT the requesting agent's chat. The operator
 may be a different human from the agent's day-to-day user; the
 person who owns the host is the person who approves config writes.
@@ -202,7 +203,7 @@ would catch it, but failing fast at 10m is friendlier than
 mysterious post-approval `does-not-apply` errors.)
 
 `diff_id` is a 128-bit cryptographically random token (not derived
-from `patch_sha256` — identical patches collide, and content-
+from `patch_sha256`: identical patches collide, and content-
 derived ids leak deduplication signal). Each id is single-use;
 recorded as consumed in the same sqlite row that backs the rate
 limiter (§5), so the approve-callback handler atomically transitions
@@ -233,7 +234,7 @@ until the first either commits or rolls back.
    change. Closes the TOCTOU between §3.2 step 2 and the rename
    below.
 2. **Snapshot.** `cp switchroom.yaml
-   ~/.switchroom/config-backups/switchroom.yaml.bak-<ts>` — the
+   ~/.switchroom/config-backups/switchroom.yaml.bak-<ts>`: the
    snapshot is of the *just-re-checked* live file, so the rollback
    target in step 4 cannot clobber an interleaved operator edit.
    Rotate to keep the 10 most recent.
@@ -241,7 +242,7 @@ until the first either commits or rolls back.
    original; `fsync`; `rename(2)` over the original. Atomic on the
    same filesystem.
 4. **Reconcile.** Invoke `switchroom apply` (the existing host-side
-   reconcile entrypoint — see `src/agents/reconcile-dry-run.ts` and
+   reconcile entrypoint, see `src/agents/reconcile-dry-run.ts` and
    the apply path it shadows). Stdout/stderr are appended to
    `~/.switchroom/hostd-audit.jsonl` as a single
    `{op: "config_propose_edit", phase: "reconcile-output", ...}`
@@ -268,7 +269,7 @@ recoverable shapes:
 
 - **Orphan `.tmp`.** Crash between step 3 (`fsync` of `switchroom.
   yaml.tmp`) and step 4 (`rename`). On boot, hostd unlinks any
-  `switchroom.yaml.tmp` adjacent to `switchroom.yaml` — the file is
+  `switchroom.yaml.tmp` adjacent to `switchroom.yaml`. The file is
   by definition uncommitted.
 - **Orphan reconcile.** Crash between step 4 (rename complete) and
   step 5 (reconcile exit). The yaml is the new version but
@@ -302,7 +303,7 @@ Every proposal terminus appends one line to
   patch_sha256, backup_path?, reconcile_exit_code? }
 ```
 
-The full diff is NOT in the audit row — only its sha256 — to keep
+The full diff is NOT in the audit row, only its sha256, to keep
 the audit log scannable. The diff itself is preserved in
 `~/.switchroom/config-backups/proposals/<diff_id>.diff` for the
 30-day retention window the rest of hostd audit uses.
@@ -330,11 +331,11 @@ know where it goes.
   (just strings in yaml), not on the encrypted vault store. Concrete
   rules: adding a new `vault:foo/bar` reference is allowed; removing
   one is allowed; *replacing* `vault:foo/bar` with `vault:baz/qux` is
-  allowed (it's still a reference swap, not a value change — the
+  allowed (it's still a reference swap, not a value change: the
   vault store is untouched, and the operator sees both keys on the
   diff card). What the verb cannot do is set a non-`vault:` literal
   where one previously existed (e.g. replacing `vault:foo/bar` with
-  an inline plaintext secret) — that's caught by the schema-
+  an inline plaintext secret). That's caught by the schema-
   validation step in §3.2 if the field is typed as a vault ref, and
   by the operator's eyes on the diff regardless.
 - **Editing `~/.switchroom/skills/**` content.** That dir is
@@ -354,7 +355,7 @@ know where it goes.
   injected can now ask for any yaml change, not just restarts.
   Mitigation: the operator MUST read the diff. The card surfaces
   requester + rationale prominently so "klanker wants to edit gymbro's
-  `secrets:` block — why?" is visually obvious. Diffs over 20 lines
+  `secrets:` block, why?" is visually obvious. Diffs over 20 lines
   get a 5-second tap delay (see §3.3). Per-agent rate limit of 3
   cards/hour (configurable, defaults flag).
 - **Diff fatigue.** Operator approves without reading. Mitigations
@@ -365,7 +366,7 @@ know where it goes.
   hour** (default; overridable via
   `hostd.config_edit_rate_per_hour`). Implemented as a sqlite
   token-bucket in `~/.switchroom/hostd-state.db` (atomic decrement
-  inside a single transaction — naive in-memory counters race when
+  inside a single transaction; naive in-memory counters race when
   two proposals from the same agent arrive concurrently). Tripping
   the limit returns `{ outcome: "rate-limited", approved: false,
   applied: false }` immediately, audits the attempt as a terminal
@@ -391,7 +392,7 @@ know where it goes.
   fallback. Doesn't address the agent-driven workflow.
 - **Granular per-section verbs.** See §2.3.
 - **No-approval autonomous writes for admin agents.** Violates the
-  prompt-injection threat model — see §2.2. Non-starter.
+  prompt-injection threat model. See §2.2. Non-starter.
 - **Approval card to the requesting agent's chat, not the operator's.**
   Rejected: the agent's chat may be shared with a non-operator user
   (a family member, a collaborator). Config writes need the host

--- a/reference/rfcs/agent-managed-skills-phase0-findings.md
+++ b/reference/rfcs/agent-managed-skills-phase0-findings.md
@@ -1,6 +1,7 @@
 ---
-artefact: agent-managed skills phase 0 findings
-serves: jobs/extend-without-forking.md
+artifact: agent-managed skills phase 0 findings
+serves: extend-without-forking
+advances-outcome: standing-team
 status: design decisions, ready to drive PR-3 implementation
 ---
 
@@ -23,7 +24,7 @@ recorded here.
 
 **Evidence**:
 
-Claude Code v2.x's skill discovery is **depth-1** — the glob is
+Claude Code v2.x's skill discovery is **depth-1**: the glob is
 `<root>/<skill-name>/SKILL.md`. Nested subdirs are NOT scanned. This
 was verified two ways:
 
@@ -34,13 +35,13 @@ was verified two ways:
   `plugin:skill-name`).
 
 - Direct extraction from the Claude Code v2.1.150 binary at
-  `~/.local/share/claude/versions/2.1.150` — string
+  `~/.local/share/claude/versions/2.1.150`. String
   extract confirms the discovery glob is depth-1, hard-coded to
   `.claude/skills/` and `~/.claude/skills/`. No "personal" subdir
   keyword anywhere in the binary.
 
 **Implication**: the originally-proposed `.claude/skills/personal/<name>/`
-subdir layout (RFC v2's design) is **silently broken** — claude-code
+subdir layout (RFC v2's design) is **silently broken**: claude-code
 would never discover those skills. The `personal-` name-prefix layout
 works today with zero shim.
 
@@ -66,13 +67,13 @@ durable bonus of operational legibility (everything lives under
 
 - Claude-code's depth-1 discovery glob targets `.claude/skills/`.
   Anything under `.claude/skills-trash/` is outside the discovery
-  root — guaranteed not scanned.
+  root, guaranteed not scanned.
 - Putting trash inside `.claude/skills/.trash/` would *probably* work
   (the dotfile prefix + missing SKILL.md should silently skip), but
   the convention is implicit and fragile to future upstream changes.
   A sibling dir is explicit and absolute.
 - Switchroom's own validator code (`skill-common.ts`) has no
-  awareness of either trash location — no false-positive risk either
+  awareness of either trash location, so no false-positive risk either
   way. The sibling-dir choice is purely about clarity and
   futureproofing.
 
@@ -89,17 +90,17 @@ namespace, less clean).
 **Evidence**:
 
 The `skill-creator` skill (Anthropic-vendored, lives at
-`skills/skill-creator/`) is an *authoring workflow* — it teaches the
+`skills/skill-creator/`) is an *authoring workflow*. It teaches the
 agent end-to-end (draft → test → eval → improve → optimize
 description → package). It runs `claude -p` as a subprocess in
 three places (`scripts/improve_description.py:26,174` and
-`scripts/run_eval.py:71-78`) to power its eval framework — these are
+`scripts/run_eval.py:71-78`) to power its eval framework. These are
 bundled-skill operator-sourced invocations, not content-delivery
 calls.
 
 The skill's *output* (the skill the agent authors using it) lands at
 `$CLAUDE_CONFIG_DIR/skills/<name>/` via direct Write/Edit tool calls
-inside the agent — same path PR-3 will route through
+inside the agent, the same path PR-3 will route through
 `skill_init_personal`. So the **path collides** but the **mechanism
 differs**:
 
@@ -173,7 +174,7 @@ Comprehensive grep across `src/` confirmed:
   `.claude/skills/`.
 - The `agent-config skill install --source bundled:<name>` overlay
   path (`~/.switchroom/agents/<name>/skills.d/<slug>.yaml`) is a
-  completely different filesystem location — no conflict with
+  completely different filesystem location, no conflict with
   in-skills-dir personal skills.
 
 **Greppable receipts** (every regex match assessed):
@@ -215,7 +216,7 @@ apply sweeps), neither of which an in-agent attacker can disable.
 **Recovery window guarantee**: 24h from the `skill_remove_personal`
 call until the next sweep finalises. If the agent never invokes
 another MCP op AND the container never restarts in 24h, the trash
-entry lives indefinitely — degraded behavior, not a security
+entry lives indefinitely: degraded behavior, not a security
 problem (the operator just sees more disk usage). Acceptable.
 
 ---
@@ -247,14 +248,14 @@ unless required.
 
 ## Open questions for PR-3 (out of Phase 0 scope)
 
-- Permissions on `.claude/skills-trash/<name>-<ts>/` — mode 0700 owned
+- Permissions on `.claude/skills-trash/<name>-<ts>/`: mode 0700 owned
   by agent UID (same as parent `.claude/skills/`)? Confirm during
   implementation; should be the obvious default.
 - Race condition on lazy sweep vs concurrent `skill_remove_personal`
-  — likely handled by file-by-file unlink with `ENOENT` tolerance,
+  is likely handled by file-by-file unlink with `ENOENT` tolerance,
   but verify during implementation.
 - Whether the scaffold boot-time sweep is part of `switchroom apply`
-  or `switchroom agent restart` — both are needed for full coverage,
+  or `switchroom agent restart`: both are needed for full coverage,
   but `apply` is the more frequently-invoked operator verb.
 
 These are Phase-1-implementation-detail; they don't gate the design

--- a/reference/rfcs/agent-managed-skills.md
+++ b/reference/rfcs/agent-managed-skills.md
@@ -1,22 +1,23 @@
 ---
-artefact: agent-managed skills — fleet capability lifecycle
-serves: jobs/extend-without-forking.md
+artifact: agent-managed skills — fleet capability lifecycle
+serves: extend-without-forking
+advances-outcome: standing-team
 status: Historical — shipped (Phase 1 + 3); Phase 2a superseded
 ---
 
 # RFC: Agent-managed skills — fleet capability lifecycle
 
-Status: **Historical** — Phase 1 (personal-skill autonomy) shipped in
+Status: **Historical**. Phase 1 (personal-skill autonomy) shipped in
 PR #1825, Phase 3 (`skill_search` MCP) in PR #1826; agent-default
 follow-up in PR #1828; 60-day observability in PR #1829. Phase 2
 remains deferred. Original framing below preserved as institutional
 memory.
 
-Original status: Draft v3 — **rescoped to Option B + tactical CLI
+Original status: Draft v3, **rescoped to Option B + tactical CLI
 escape hatch** after four independent Opus reviewer passes (2026-05-25)
 Date: 2026-05-25
 Reviewer pass v1 → v2: 1 reviewer (general-purpose, 8 items incorporated)
-Reviewer pass v2 → v3: 4 reviewers (Opus, parallel, distinct angles —
+Reviewer pass v2 → v3: 4 reviewers (Opus, parallel, distinct angles:
 security threat model / implementation feasibility / operator UX /
 independent design alignment)
 
@@ -58,7 +59,7 @@ fleet co-manages":
    without prejudicing the larger design.
 
 2. **PR-2 (Phase 0 spike, 2-3h):** Documentation-only PR resolving the
-   load-bearing unknowns surfaced by reviewers — claude-code subdir
+   load-bearing unknowns surfaced by reviewers: claude-code subdir
    discovery semantics, `.trash/` exclusion, `skill-creator` overlap,
    upstream Anthropic personal-skills feature signals, path-conflict
    risk. Outcome: written design decision for Phase 1's on-disk
@@ -70,7 +71,7 @@ fleet co-manages":
    / `skill_remove_personal` / `skill_list_personal`. Multi-file
    bundle validator (new code per feasibility review). `O_NOFOLLOW |
    O_EXCL` writes (per security T3). Trash-dir soft-undo with
-   sweep mechanism per PR-2's decision (NOT host-side cron — switchroom
+   sweep mechanism per PR-2's decision (NOT host-side cron; switchroom
    has none post-Phase-4; likely a lazy-on-write sweep + an
    agent-scheduler-registered immutable schedule entry the agent
    can't disable). Pre-publish `claude -p` content scan in skill
@@ -82,7 +83,7 @@ fleet co-manages":
    returning SKILL.md frontmatter, no approval required.
 
 **What does NOT ship in v3:** the `skill_propose_publish` /
-`skill_propose_edit` hostd verbs (the heavy machinery — approval card
+`skill_propose_edit` hostd verbs (the heavy machinery: approval card
 UX, audit-log integration, multi-file apply primitive, `proposed_opt_ins`
 chaining, the 8 reviewer must-fixes). Tracked in
 [GH issue: deferred Phase 2 design].
@@ -92,7 +93,7 @@ independently recommended Option B. The triggering pain (two paste-
 and-relay loops during a debug session) is N=1 evidence; a 2-hour CLI
 verb solves it today. The shared-pool publish/edit machinery is
 ~17h of work resting on assumptions about an approval-card UX whose
-needs we don't yet know — personal-skill usage in PR-3 generates the
+needs we don't yet know. Personal-skill usage in PR-3 generates the
 signal that should drive that design.
 
 ## 2. Operator workflows v3 serves
@@ -145,12 +146,12 @@ there's no path to make it shared.
 After v3: still doesn't exist *automatically*. Operator can use PR-1
 to manually publish a personal skill they want to share (read it out
 of the agent's personal-skill dir, run `switchroom skill apply`).
-The full `skill_propose_publish` approval-card flow is deferred —
+The full `skill_propose_publish` approval-card flow is deferred:
 the design needs personal-skill telemetry from PR-3 first.
 
 ### Workflow 4 — "Retire skills nothing uses anymore." *(anticipated, deferred)*
 
-Not yet a felt operator pain — the fleet hasn't run long enough for
+Not yet a felt operator pain. The fleet hasn't run long enough for
 skill-rot to materialise. PR-4's `skill_search` makes the audit
 possible (list pool entries + opt-ins); the *retirement primitive*
 itself is deferred. If skill-rot is never observed in practice, the
@@ -168,15 +169,15 @@ workflow.
 
 ## 3. Outcome being optimized for
 
-Quoting `reference/vision.md` pillar 4 (*always available*) — *"there
+Quoting `reference/vision.md` pillar 4 (*always available*): *"there
 in Telegram the second you reach for it; survives reboots, runs its
 schedules."* A fleet whose toolkit can't evolve without the operator
 at a terminal does not fully meet this pillar. Tonight's debug session
 proved it: two consecutive skill patches each took a 9-step
-choreographed pasting loop. That's not always-available — that's the
+choreographed pasting loop. That's not always-available. That's the
 operator being on-call for skill maintenance.
 
-Quoting pillar 1 (*standing team of specialists*) — skills are the
+Quoting pillar 1 (*standing team of specialists*): skills are the
 toolkit each specialist carries. Letting the specialists maintain
 their own toolkit is the difference between handing someone a wrench
 and equipping them to set up the workshop.
@@ -187,9 +188,9 @@ The principle test:
   After this RFC, the agent itself authors via skill-creator (already
   bundled), no doc-reading by the operator required.
 - **Defaults test** — "does it work on a fresh `switchroom setup`?"
-  Yes — the personal-skill dir is part of scaffold, no extra config.
+  Yes. The personal-skill dir is part of scaffold, no extra config.
 - **Consistency test** — same CLI shape, cascade, vault syntax,
-  progress card as adjacent features? Yes — `skill_propose_*` mirrors
+  progress card as adjacent features? Yes. `skill_propose_*` mirrors
   `config_propose_edit` exactly; same approval-card shape; same audit
   log entries.
 
@@ -213,7 +214,7 @@ skill location anywhere today.
 
 `<agentDir>/.claude/skills/<name>` is a symlink into the pool,
 created by `scaffold.ts:syncGlobalSkills` (`src/agents/scaffold.ts:
-720-814`). Idempotent — broken symlinks are refreshed; correct ones
+720-814`). Idempotent: broken symlinks are refreshed, correct ones
 skipped; foreign files left alone.
 
 ### 4.3 Agents CAN opt themselves IN to bundled skills
@@ -226,10 +227,10 @@ The agent writes an overlay file at
 the symlink lands.
 
 **Important**: this means **half of the JTBDs above are already
-50% solved** — agents can opt in to bundled skills today, without
+50% solved**: agents can opt in to bundled skills today, without
 operator approval, and the precedent for per-agent overlay-driven
 skill management exists. What's missing is everything *upstream* of
-that — actually authoring a new skill, editing pool content,
+that: actually authoring a new skill, editing pool content,
 publishing personal → shared.
 
 ### 4.4 SKILL.md validator already exists
@@ -298,7 +299,7 @@ tier: shared           # personal | shared | bundled
 **Back-compat verified during review**: the existing validator at
 `skill-common.ts:151-226` only enforces `name` + `description`;
 unknown frontmatter keys are silently kept. So the extension is
-purely additive — no existing skill breaks, and old switchroom CLIs
+purely additive: no existing skill breaks, and old switchroom CLIs
 reading a new skill just ignore the new fields.
 
 ### 5.4 No search / discovery surface
@@ -306,12 +307,12 @@ reading a new skill just ignore the new fields.
 No `skill_search` MCP op exists. Need a read-only enumerator that
 returns: pool entries, JTBD summary, current opt-ins per skill,
 date authored, recent edits. Cheaply built on top of `readdir` +
-SKILL.md frontmatter parse — no new state.
+SKILL.md frontmatter parse. No new state.
 
 ## 6. Proposed model
 
 Same shape as `config_propose_edit` (RFC `admin-agent-config-edit.md`)
-— a tightly-scoped hostd write primitive gated by the operator's
+a tightly-scoped hostd write primitive gated by the operator's
 existing approval-card UI. Reuses every load-bearing component.
 
 ### 6.1 Two new hostd verbs
@@ -387,12 +388,12 @@ Server-side flow on both:
 The existing `installSwitchroomSkills` machinery (`scaffold.ts:838-
 944`) gates a small set of skills to `foreman`-role agents. The new
 `skill_propose_publish` does *not* automatically respect role gating
-— `proposed_opt_ins` is the proposer's recommendation, not a
+`proposed_opt_ins` is the proposer's recommendation, not a
 hard contract. On approve, the card shows any opt-in agents whose
 role is incompatible with the skill's declared tools (when SKILL.md
 declares `tools:`) so the operator can drop them before confirming.
 Worst case the skill lands and is wired up via symlink for an
-incompatible-role agent — claude-code's per-skill role enforcement
+incompatible-role agent; claude-code's per-skill role enforcement
 (if any) becomes the runtime check, same as today's pool. The RFC
 does NOT introduce role-aware refusal at write-time.
 
@@ -407,7 +408,7 @@ distinction earns its keep.
 ### 6.2 New agent-config MCP op for personal-skill scope
 
 **`skill_init_personal`** — agent creates a personal skill in its
-own workspace. No approval needed — agent's own files.
+own workspace. No approval needed, agent's own files.
 
 ```typescript
 {
@@ -464,13 +465,13 @@ extending the schema is purely additive.
 
 **Strictness stays permanent-passthrough.** An earlier draft of this
 RFC proposed flipping the validator to reject unknown keys once the
-new fields shipped — that's a rollout footgun: every operator-pool
+new fields shipped. That's a rollout footgun: every operator-pool
 skill carrying a typo'd or experimental field would break at next
 reconcile. Permanent passthrough means the new fields are
 *signals* the approval card can render when present, never gates
 that fail validation when absent. If per-skill strictness ever
 becomes useful, opt in via `strict_frontmatter: true` in the skill
-itself — never a global flip.
+itself, never a global flip.
 
 ### 6.5 Vault-key auto-grant on opt-in (stretch)
 
@@ -478,7 +479,7 @@ If a skill declares `vault_keys: [garmin/credentials]` and an agent
 opts in via `skill install bundled:garmin`, the skill's declared
 vault keys could be **proposed for grant** to that agent (separate
 approval card, mirroring the existing vault grant flow). Keeps the
-"skill is a self-contained capability" invariant — installing the
+"skill is a self-contained capability" invariant: installing the
 skill installs everything it needs.
 
 Out of scope for v1 (covered by the existing
@@ -507,7 +508,7 @@ Mapping to this RFC:
 **Soft-undo for `skill_remove_personal`** (cheap insurance, real
 recovery value): the op moves the skill dir to
 `<agentDir>/.claude/skills/.trash/<name>-<unix-ts>/` rather than
-unlinking. A sweep mechanism (per PR-2's design decision — switchroom
+unlinking. A sweep mechanism (per PR-2's design decision: switchroom
 has no host-side cron post-Phase-4, so likely a lazy-on-write sweep
 plus an immutable scaffold-baked agent-scheduler entry) deletes
 trash entries older than 24h.
@@ -516,7 +517,7 @@ cycle; benefit: the failure mode "agent removed a skill mid-use,
 context broken on next turn" gets a 24h window to undo. Same
 philosophy as the operator's standing `trash > rm` preference (per
 global CLAUDE.md). No equivalent needed for `skill_propose_remove`
-on the shared pool — operator-gated removal is already a deliberate
+on the shared pool; operator-gated removal is already a deliberate
 human-checked decision.
 
 **Deliberately out of v1**: auto-approve heuristics for small
@@ -589,7 +590,7 @@ Workflow 2 today without committing to the heavy machinery.
   pattern (mirrors `overlay-writer.ts:writeOverlayEntry` shape,
   generalised to a multi-file write).
 - Runs `bash -n` on every `scripts/*.sh` and `python -m py_compile`
-  on every `scripts/*.py` before the write — same pre-publish
+  on every `scripts/*.py` before the write: same pre-publish
   validation Phase 2 would have done.
 - Runs `switchroom apply` on success to re-sync agents.
 - `--dry-run` validates + diffs against current pool content, prints
@@ -649,7 +650,7 @@ After PR-2 resolves the layout. Implementation:
   payload contents. (Closes security review T3.)
 - **Trash-dir soft-undo** (per §7): `skill_remove_personal` moves to
   trash-dir; sweep mechanism per PR-2 (#1818) decision. **Not a
-  host-side cron** — switchroom retired host-side cron in Phase 4
+  host-side cron**: switchroom retired host-side cron in Phase 4
   (`src/agents/lifecycle.ts:841`). The most likely answer from PR-2's
   spike is a *lazy sweep* (on next `skill_remove_personal` / agent
   boot, sweep trash entries older than 24h) plus an immutable
@@ -658,7 +659,7 @@ After PR-2 resolves the layout. Implementation:
 - **Pre-publish content scan**: every `scripts/*.{sh,py}` file in the
   payload is grepped server-side for `\bclaude\s+-p\b`; reject the
   write if found. Closes the CI-guard gap that was flagged by both
-  security and feasibility reviewers — the existing
+  security and feasibility reviewers; the existing
   `tests/bridge-flap-regression-guard.test.ts` only scans TS source.
 - **Behavioral validation**: `bash -n` on shell scripts,
   `python -m py_compile` on python scripts. Surface structured
@@ -701,15 +702,15 @@ that suite before it can ship safely:
 
 1. Per-opt-in vault-grant delta on approval card (security T6)
 2. Multi-file diff attachment flow (UX) + content-quoting for `scripts/*`
-3. Personal-skill writer symlink safety (security T3) — covered in PR-3
+3. Personal-skill writer symlink safety (security T3), covered in PR-3
 4. Rationale typographic quarantine + 200-char cap (UX + security T5)
 5. Semantic lint pass for diff content (security T2)
 6. Per-agent rate-limit on propose verbs (security T8)
-7. `.trash/` claude-code-scan exclusion (security T4) — covered by PR-2
+7. `.trash/` claude-code-scan exclusion (security T4), covered by PR-2
 8. Strict line-equality patcher for diffs (security)
 
 Plus the new finding from feasibility review: the "mirrors
-`config_propose_edit`" claim is structurally wrong — the existing
+`config_propose_edit`" claim is structurally wrong: the existing
 framework is single-file-YAML-only. A real Phase 2 would need a new
 multi-file apply primitive, new approval-card multi-file payload
 shape, new audit-log entries. Net new code, not reuse.
@@ -735,7 +736,7 @@ naming collisions) or wait for upstream support.
 **Action**: gating spike (Phase 0 in §8). Resolution captured in
 writing before Phase 1 implementation begins. If subdir-blocked,
 fall back to the name-prefix convention
-(`<agentDir>/.claude/skills/personal-<name>/`) — same primitives,
+(`<agentDir>/.claude/skills/personal-<name>/`), same primitives,
 slightly different directory layout. Phase 1's MCP op shapes don't
 change; the on-disk layout does.
 
@@ -768,7 +769,7 @@ new hostd verbs.
 Today: `secrets:` on a *cron schedule entry* declares vault-key
 needs (`schema.ts:79-91`). Tomorrow: `vault_keys:` in *SKILL.md
 frontmatter* declares the same for the skill as a whole. Two
-mechanisms saying the same thing about different scopes —
+mechanisms saying the same thing about different scopes:
 acceptable, or should the schedule-entry one fold into the skill
 one (skills declare needs; schedule entries reference skills)?
 
@@ -831,19 +832,19 @@ Default: pool-resolution-order is enough. Lookup goes:
   get JTBD summaries before authoring (no duplicate-skill creation).
 - **AC-4**: Audit log shows every skill mutation tagged with proposer
   agent + outcome + sha256.
-- **AC-5**: SKILL.md frontmatter extension is back-compat — existing
+- **AC-5**: SKILL.md frontmatter extension is back-compat: existing
   skills without `jtbd:`/`vault_keys:` keep validating and working.
 - **AC-6**: Bundled skills remain source-PR only (no in-fleet edit
   path); this verb-set never writes under `skills/_bundled/`.
 - **AC-7**: Pre-publish behavioral validation runs server-side before
-  the approval card renders — `bash -n` on every `scripts/*.sh`,
+  the approval card renders: `bash -n` on every `scripts/*.sh`,
   `python -m py_compile` on every `scripts/*.py`. A skill containing
   a script with syntax errors cannot reach the approval card; the
   proposer agent gets a structured error pointing at the failing
   file:line. The static SKILL.md validator (`name`, `description`,
   size, path allowlist) keeps running first; behavioral validation
   is an additional gate on top.
-- **AC-8**: `skill_remove_personal` is recoverable — a removed skill
+- **AC-8**: `skill_remove_personal` is recoverable: a removed skill
   lands in `.trash/` for 24h before the sweep mechanism finalises
   the delete. An agent (or operator) can `mv` it back inside the
   window with no other state change.

--- a/reference/rfcs/agent-self-improvement.md
+++ b/reference/rfcs/agent-self-improvement.md
@@ -1,6 +1,7 @@
 ---
-artefact: agents that improve themselves, on the leash
-serves: jobs/get-better-the-longer-they-run.md
+artifact: agents that improve themselves, on the leash
+serves: get-better-the-longer-they-run
+advances-outcome: standing-team
 status: Draft
 ---
 
@@ -96,10 +97,10 @@ not one:
    never again" path.
 2. **Recurring-work review — proactive, periodic, cadenced.** On a low cadence
    (not per-turn) a separate pass runs `reflect` over the agent's own Hindsight
-   experience memories — "what multi-step thing have I repeated by hand that no
+   experience memories: "what multi-step thing have I repeated by hand that no
    skill/cron covers?" A genuine, deduplicated hit (≈3–5×, checked against
    existing skills/crons, prefer-extend-over-create) becomes a **T3 proposal**
-   for a new skill or cron — never an auto-create. This is the "finds a path it
+   for a new skill or cron, never an auto-create. This is the "finds a path it
    will reuse" path.
 
 Same router and same guardrails downstream; different triggers and cadences
@@ -114,7 +115,7 @@ every turn.
     skills dir (per `skill-authoring-native`); validator hook + git =
     audit/rollback.
   - **T2 Propose, one-tap** — medium / shared-skill changes, **and any edit to
-    the agent's own guidance (`CLAUDE.md` / `SOUL.md`)** — because guidance
+    the agent's own guidance (`CLAUDE.md` / `SOUL.md`)** because guidance
     affects *every* turn, even a small guidance edit is proposed, never silent.
     Surfaced as a pending suggestion (Telegram one-tap; backing store = Linear
     issue or a small per-agent queue file).
@@ -139,7 +140,7 @@ backing.
 
 No new eval engine. Each skill carries `evals/evals.json` (a few test-case
 prompts). A **grader subagent** (`agents/grader.md`, runnable on a cheap
-model — this is the "small model call") checks assertions → pass/fail +
+model, this is the "small model call") checks assertions → pass/fail +
 evidence; `scripts/aggregate_benchmark.py` gives pass-rate + variance (mean ±
 stddev) vs baseline. **An edit lands only if its evals pass and don't
 regress baseline.** New skills ship a starter `evals.json` at creation.
@@ -170,7 +171,7 @@ Net: git + PR + the validator hook that already exists.
   case by the PR-as-gate decision already in `skill-authoring-native`.
 - Hermes (`github.com/NousResearch/hermes-agent` + `…-self-evolution`):
   forked post-turn `background_review` (restricted toolset, cadence-gated)
-  and GEPA trace-driven eval — the patterns behind the forked review and the
+  and GEPA trace-driven eval: the patterns behind the forked review and the
   per-skill eval gate.
 
 ## Bets & Risks
@@ -207,7 +208,7 @@ propose-only). Guidance, cron, and new-skill changes are never auto-applied.
       first slice.
 - [ ] Starting defaults: correction-gate threshold (2 vs 3), diff-size cap,
       max pending/auto-applies per day, **recurring-work review cadence** (every
-      ~N turns vs weekly) and its repeat bar (3 vs 5) — tuned by measuring on
+      ~N turns vs weekly) and its repeat bar (3 vs 5), tuned by measuring on
       `clerk` first.
 - [x] T2/T3 pending surface: **per-agent JSON-lines queue file** for the first
       slice (decided 2026-06-20); Telegram one-tap surfacing layered on next.

--- a/reference/rfcs/approval-kernel.md
+++ b/reference/rfcs/approval-kernel.md
@@ -1,22 +1,22 @@
 ---
-artefact: unified human-approval kernel
+artifact: unified human-approval kernel
 backs: no-self-escalation
 status: Draft v4 — partially shipped; hard-boundary direction descoped for single-tenant
 ---
 
 # RFC B: Unified human-approval kernel
 
-Status: Draft v4 — **partially shipped; hard-boundary direction descoped for single-tenant (2026-06-02)**
+Status: Draft v4. **Partially shipped; hard-boundary direction descoped for single-tenant (2026-06-02)**
 Author: klanker (sub-agent draft)
 Date: 2026-05-06
 
 > **Scope note (2026-06-02).** The kernel, nonce/scope binding, per-agent
 > socket ACL, and `apv:` callback flow are shipped. The "hard boundary"
-> direction this RFC anticipates — making the agent↔gateway channel
+> direction this RFC anticipates, making the agent↔gateway channel
 > unforgeable against a **same-uid** actor (a host-side operator verifier
 > setting `origin='operator'`, flipping
 > `SWITCHROOM_REQUIRE_OPERATOR_APPROVAL_MINT=1`, and the second-bot idea
-> floated alongside it) — is **descoped for the single-tenant deployment**
+> floated alongside it), is **descoped for the single-tenant deployment**
 > switchroom targets. Same-uid is out of scope by construction
 > (`docs/vault.md`), so that machinery defends a threat this product
 > doesn't have, at real cost. The authorization contract that supersedes
@@ -24,13 +24,13 @@ Date: 2026-05-06
 > the mint flag stays **off** by default. Reopen only if the deployment
 > model changes (untrusted agents / multi-operator / hostile network).
 
-Prerequisite: **RFC A — Bot token to vault** (`reference/rfcs/bot-token-to-vault.md`). Keeping the token in the vault rather than plaintext `.env` is still worthwhile hygiene (one revocation surface, no casual read); it is **not** relied on as a security boundary against a same-uid agent per the access model.
+Prerequisite: **RFC A, Bot token to vault** (`reference/rfcs/bot-token-to-vault.md`). Keeping the token in the vault rather than plaintext `.env` is still worthwhile hygiene (one revocation surface, no casual read); it is **not** relied on as a security boundary against a same-uid agent per the access model.
 
 ## 1. Summary
 
-Switchroom asks the user to approve sensitive actions through several independent code paths today: deferred-secret cards (`vd:`), vault grants, and the various per-MCP prompts that are about to multiply as Drive, Notion, Slack, and Gmail wrappers come online. This RFC proposes a single approval kernel — folded into the existing vault broker — that **secrets and MCP tool calls** plug into. One process, one socket, one SQLite file, one audit table, one Telegram card primitive, one set of `/approvals` commands.
+Switchroom asks the user to approve sensitive actions through several independent code paths today: deferred-secret cards (`vd:`), vault grants, and the various per-MCP prompts that are about to multiply as Drive, Notion, Slack, and Gmail wrappers come online. This RFC proposes a single approval kernel, folded into the existing vault broker, that **secrets and MCP tool calls** plug into. One process, one socket, one SQLite file, one audit table, one Telegram card primitive, one set of `/approvals` commands.
 
-**Scope is deliberately narrow.** The kernel covers secrets, vault grants, and MCP tool calls (Drive, Notion, Slack, Gmail, etc.). Tool/skill permissions stay on the existing `permission-rule.ts` + `settings.json` path — see §14.
+**Scope is deliberately narrow.** The kernel covers secrets, vault grants, and MCP tool calls (Drive, Notion, Slack, Gmail, etc.). Tool/skill permissions stay on the existing `permission-rule.ts` + `settings.json` path; see §14.
 
 ## 2. Motivation
 
@@ -126,7 +126,7 @@ CREATE TABLE approval_audit (
 
 UUID is the durable primary key. The 8-hex callback token (matching existing `generateAskId` at `telegram-plugin/ask-user.ts:133`) maps to the UUID for the prompt's lifetime only.
 
-The audit table splits agent-intent from kernel-verb into two columns: `action` records what the agent wanted to do (read/write/etc., same vocabulary as `approval_decisions.action`) and `event` records what the kernel did about it. Audit-by-scope queries need both. `event` is a superset of the original RFC vocabulary — it adds `consume`, `expire`, and `drift_revoke` for operational events the kernel records (nonce redemption, prompt timeout, drift-triggered auto-revocation per §5.1).
+The audit table splits agent-intent from kernel-verb into two columns: `action` records what the agent wanted to do (read/write/etc., same vocabulary as `approval_decisions.action`) and `event` records what the kernel did about it. Audit-by-scope queries need both. `event` is a superset of the original RFC vocabulary: it adds `consume`, `expire`, and `drift_revoke` for operational events the kernel records (nonce redemption, prompt timeout, drift-triggered auto-revocation per §5.1).
 
 The "same-uid attacker writes a forged grant row directly to SQLite" attack is acknowledged per §3 and not defended against in code; it's defended against by the trust model documented in `docs/vault.md`.
 
@@ -153,7 +153,7 @@ interface ScopeMatcher {
 }
 ```
 
-ScopeMatcher is **new code** — not a reuse of `checkEntryScope` in `src/vault/broker/acl.ts` (that one matches agent slugs against entry allow/deny lists; different problem). The agent-identity ACL gating IS reused; scope-string-vs-scope-string matching is built fresh.
+ScopeMatcher is **new code**, not a reuse of `checkEntryScope` in `src/vault/broker/acl.ts` (that one matches agent slugs against entry allow/deny lists; different problem). The agent-identity ACL gating IS reused; scope-string-vs-scope-string matching is built fresh.
 
 Namespaces in v1:
 
@@ -171,7 +171,7 @@ apv:<8-hex request id>:<action>[:<param>]
 ```
 
 - 8-hex request id matches `generateAskId` convention.
-- Single-use enforced by an atomic `UPDATE approval_nonces SET consumed_at = ? WHERE request_id = ? AND consumed_at IS NULL` with a rowcount check. Only on rowcount=1 does the kernel proceed to insert/update the corresponding `approval_decisions` row. A re-tap of an already-consumed callback returns a brief "this prompt expired" toast via `answerCallbackQuery`. *(PR-6: the Telegram `apv:` card path realizes this "only on rowcount=1 do we proceed to the decision row" as a single atomic `approval_consume_record` op — `consumeNonce` + `recordDecision` in one `db.transaction()` — rather than two RPC round-trips, so a broker death between consume and record can no longer burn the nonce without a decision. See `src/vault/approvals/MIGRATION.md`.)*
+- Single-use enforced by an atomic `UPDATE approval_nonces SET consumed_at = ? WHERE request_id = ? AND consumed_at IS NULL` with a rowcount check. Only on rowcount=1 does the kernel proceed to insert/update the corresponding `approval_decisions` row. A re-tap of an already-consumed callback returns a brief "this prompt expired" toast via `answerCallbackQuery`. *(PR-6: the Telegram `apv:` card path realizes this "only on rowcount=1 do we proceed to the decision row" as a single atomic `approval_consume_record` op (`consumeNonce` + `recordDecision` in one `db.transaction()`) rather than two RPC round-trips, so a broker death between consume and record can no longer burn the nonce without a decision. See `src/vault/approvals/MIGRATION.md`.)*
 - Examples: `apv:a3f1b9c2:allow`, `apv:a3f1b9c2:ttl:1h`, `apv:a3f1b9c2:deny`.
 
 Full scope and humanized title are stored server-side keyed by request id.
@@ -190,7 +190,7 @@ The card surfaces only the common subset. Full mode set is editable via `/approv
 
 ## 8. Telegram approval card UX
 
-One shape, every surface. Built on the existing `aq:` (ask_user) primitive at `telegram-plugin/gateway/gateway.ts:8321` — that path already handles topic routing, quote-reply targeting, reaction lifecycle, and `allowFrom` enforcement. The kernel registers a new `apv:` callback handler and reuses the rest.
+One shape, every surface. Built on the existing `aq:` (ask_user) primitive at `telegram-plugin/gateway/gateway.ts:8321`; that path already handles topic routing, quote-reply targeting, reaction lifecycle, and `allowFrom` enforcement. The kernel registers a new `apv:` callback handler and reuses the rest.
 
 ### 8.1 Card states
 
@@ -213,7 +213,7 @@ One shape, every surface. Built on the existing `aq:` (ask_user) primitive at `t
 
 **Denied:** `🚫 Denied`
 
-**Expired (5-minute timeout):** `⌛ Expired — agent will re-request.` A tap on an already-expired callback returns `answerCallbackQuery({ text: 'this prompt expired' })`.
+**Expired (5-minute timeout):** `⌛ Expired, agent will re-request.` A tap on an already-expired callback returns `answerCallbackQuery({ text: 'this prompt expired' })`.
 
 **Revoked-after-grant:** on the next use attempt the agent gets a denial; the kernel posts a fresh notification card identifying which standing grant fired the denial and offering one-tap reinstate.
 
@@ -244,7 +244,7 @@ The kernel calls `humanize()` before rendering but never blocks on it.
 
 ### 9.1 Staleness model with weekly digest coalescing
 
-Rather than per-row prompts (which scale badly — 40 stale rows = 40 prompts), staleness coalesces into a single weekly digest with the same threshold-trigger logic:
+Rather than per-row prompts (which scale badly: 40 stale rows = 40 prompts), staleness coalesces into a single weekly digest with the same threshold-trigger logic:
 
 - **New-grants digest** (threshold-triggered): when `count(allow_always WHERE never_seen_in_digest) >= 3`, send a digest of the new standing grants. At most one digest per 24h.
 - **Stale-grants digest** (weekly): grants that haven't fired in 30d coalesce into one digest with one inline `Revoke` button per row. **No more than one staleness digest per week** regardless of how many rows go stale.
@@ -262,7 +262,7 @@ Multi-step with real failure modes; spec the ordering.
 4. **SIGHUP gateway** — gateway re-reads token from vault.
 5. **Mark `revoke-all` complete** — audit row.
 
-`switchroom token rotate` is the recovery command — idempotent re-run of steps 1, 3, 4. Documented in killswitch help text.
+`switchroom token rotate` is the recovery command, an idempotent re-run of steps 1, 3, 4. Documented in killswitch help text.
 
 ## 10. Wait protocol — short-poll
 
@@ -273,7 +273,7 @@ The vault broker is request/response. Approvals can wait up to 5 minutes for a t
 1. Agent calls `requestApproval(...)` → `{ status: 'pending', request_id }` immediately.
 2. Agent calls `lookupDecision({ request_id })` every 2 seconds. Broker responds immediately with `{ status: 'pending' | 'granted' | 'denied' | 'expired', mode?, ttl? }`.
 3. On `granted`/`denied`/`expired`, agent stops polling.
-4. On gateway restart between polls, agent simply retries — `lookupDecision` is stateless from the agent's perspective.
+4. On gateway restart between polls, agent simply retries; `lookupDecision` is stateless from the agent's perspective.
 
 **Caps:**
 
@@ -285,8 +285,8 @@ The vault broker is request/response. Approvals can wait up to 5 minutes for a t
 - **Cross-agent grant scope is unit-scoped.** `allow_always` for `secret:OPENAI_API_KEY` granted to klanker does NOT auto-grant to gymbro. Each `agent_unit` is a separate principal, matching existing vault grants. User-scoped grants out of scope for v1.
 - **Callback delivery is best-effort.** If the gateway is down when the user taps, the tap is lost. 5-minute timeout, `timeout` audit row, agent re-issues if still wanted.
 - **OAuth tokens (Google refresh tokens) live in vault.** Kernel asks vault for the token by slot name; vault enforces its own grant on that slot; kernel never persists raw tokens.
-- **Adding a user re-confirms standing grants.** Multiple trusted users per agent is supported (`single-tenant` invariant), but standing *grants* stay conservative: drift-revocation (§5.1) makes a roster change safe-by-default — the moment `allowFrom` changes (including growing past one entry), every standing grant becomes dormant pending re-confirmation. Per-user grant *scoping* is out of scope for v1 (grants are unit-scoped, matching the invariant's "nothing finer than the per-agent user assignment").
-- **Tap-budget target and instrumentation.** Day 1 of Drive enablement: 10–30 taps expected (cold cache, no folder grants). Steady state: <5 taps/day. `/approvals stats` surfaces 7-day tap counts. Soft-alert (DM) at >10 taps/day sustained for 3 days. If exceeded, **batch coalescing** kicks in: the kernel buffers prompts for 5 seconds; if 3+ pending share a scope-prefix (e.g. `doc:gdrive:folder/Work/*`), it collapses into a single "klanker is requesting access to 4 docs in /Work — allow folder?" card.
+- **Adding a user re-confirms standing grants.** Multiple trusted users per agent is supported (`single-tenant` invariant), but standing *grants* stay conservative: drift-revocation (§5.1) makes a roster change safe-by-default: the moment `allowFrom` changes (including growing past one entry), every standing grant becomes dormant pending re-confirmation. Per-user grant *scoping* is out of scope for v1 (grants are unit-scoped, matching the invariant's "nothing finer than the per-agent user assignment").
+- **Tap-budget target and instrumentation.** Day 1 of Drive enablement: 10–30 taps expected (cold cache, no folder grants). Steady state: <5 taps/day. `/approvals stats` surfaces 7-day tap counts. Soft-alert (DM) at >10 taps/day sustained for 3 days. If exceeded, **batch coalescing** kicks in: the kernel buffers prompts for 5 seconds; if 3+ pending share a scope-prefix (e.g. `doc:gdrive:folder/Work/*`), it collapses into a single "klanker is requesting access to 4 docs in /Work, allow folder?" card.
 
 ## 12. Migration plan
 
@@ -296,7 +296,7 @@ The vault broker is request/response. Approvals can wait up to 5 minutes for a t
 
 **Phase 2 — secrets as first consumer.** Migrate the deferred-secret card path (`gateway.ts:5555`) to call the kernel. Lower-traffic, validates the abstraction. Preserve the inline-passphrase capture UX. ~0.5 day.
 
-**Phase 3 — first MCP consumer (Google Drive).** Covered separately in **RFC D — Google Drive MCP integration** (originally drafted as "RFC C", renumbered after `host-control-daemon.md` took the C slot).
+**Phase 3 — first MCP consumer (Google Drive).** Covered separately in **RFC D, Google Drive MCP integration** (originally drafted as "RFC C", renumbered after `host-control-daemon.md` took the C slot).
 
 ## 13. Estimated effort
 
@@ -306,7 +306,7 @@ Combined with RFC A (~0.5d) and RFC D (~1d): **~3.5 days total** across the thre
 
 ## 14. Out of scope
 
-- **Tool/skill permission migration: deferred indefinitely.** Tools and skills stay on the existing `permission-rule.ts` + `settings.json` path, untouched. Migrating Claude's tool-permission prompts into the kernel would conflict with switchroom's "unmodified Claude" principle (`README.md:16`) — it requires intercepting and rewriting `settings.json` from kernel state, which the kernel does NOT do. The kernel is not authoritative for tool perms.
+- **Tool/skill permission migration: deferred indefinitely.** Tools and skills stay on the existing `permission-rule.ts` + `settings.json` path, untouched. Migrating Claude's tool-permission prompts into the kernel would conflict with switchroom's "unmodified Claude" principle (`README.md:16`): it requires intercepting and rewriting `settings.json` from kernel state, which the kernel does NOT do. The kernel is not authoritative for tool perms.
 - Group / multi-user bot support.
 - Per-action MFA prompts beyond approval — Telegram 2FA is sufficient at this trust level.
 - Web dashboard approval UX (CLI + Telegram only for v1).

--- a/reference/rfcs/ask-peer.md
+++ b/reference/rfcs/ask-peer.md
@@ -1,6 +1,7 @@
 ---
-artefact: ask_peer — operator-allowlisted visible cross-agent handoff
-serves: jobs/run-a-fleet-of-specialists.md
+artifact: ask_peer — operator-allowlisted visible cross-agent handoff
+serves: run-a-fleet-of-specialists
+advances-outcome: standing-team
 status: Draft v1
 ---
 
@@ -13,7 +14,7 @@ Date: 2026-06-14
 ## 1. Summary
 
 Add a way for one agent to **ask another agent a question and get the
-answer back** — without merging their memory and without either agent
+answer back**, without merging their memory and without either agent
 silently reaching into the other. A leader/EA agent (canonically
 `clerk`) calls a new MCP tool `ask_peer(agent, question)`; the question
 is delivered into the target agent's live session as a synthetic turn;
@@ -23,7 +24,7 @@ visible to the operator** the whole time.
 
 `ask_peer` is gated by an **operator-written per-pair allowlist**
 (`agents.<caller>.peers.ask_allow: [<targets>]`). An agent can never add
-itself to another's allowlist — the gate lives in config the agent
+itself to another's allowlist: the gate lives in config the agent
 cannot write (`reference/rfcs/access-model.md`: *"an agent can request more
 access, but it can never author its own authorization. Every grant is
 written by the operator, in a place the agent cannot write"*).
@@ -45,7 +46,7 @@ Anti-patterns / UAT): *"Need a thing that crosses two specialists. The
 user should be able to route it without the agents silently reaching
 into each other."* `ask_peer` turns "the user routes it" into "the user
 *pre-authorised* a route the leader can take, and still sees every
-crossing" — which is the same leash, less manual relaying.
+crossing", which is the same leash, less manual relaying.
 
 ## 3. Non-goals
 
@@ -60,7 +61,7 @@ crossing" — which is the same leash, less manual relaying.
   target's tools.
 - **Not** privilege transfer. The target runs with **its own** tools,
   vault grants, and scope. `ask_peer` never lets the caller borrow the
-  target's credentials — if gymbro can't read a key, neither can a
+  target's credentials. If gymbro can't read a key, neither can a
   question routed through it.
 
 ## 4. Design
@@ -80,14 +81,14 @@ ask_peer(agent: string, question: string, wait_seconds?: number) -> { reply: str
   executed as a command.
 - The call is **async with a bounded wait**: it returns when the target's
   reply lands or `wait_seconds` (default ~120s, capped) elapses
-  (`no_reply` — the caller can try again or tell the operator).
+  (`no_reply`; the caller can try again or tell the operator).
 
 ### 4.2 Routing (reuses existing rails)
 
 The plumbing is mostly already there:
 
 - **Out:** the gateway already routes a synthetic inbound to any agent by
-  name — `ipcServer.sendToAgent(agentName, inbound)` +
+  name: `ipcServer.sendToAgent(agentName, inbound)` +
   `dispatchAsInbound` (the cron / webhook / Linear path,
   `src/scheduler/dispatch.ts`). The `ask_peer` question is delivered the
   same way, tagged `meta.source = "peer_ask"`,
@@ -109,7 +110,7 @@ Both legs are operator-visible, not just logged:
 - The **question** posts into the **target's** topic ("🔁 clerk asks: …")
   so the operator sees clerk reached into gymbro.
 - The **reply** is what clerk synthesises back to the operator in clerk's
-  own turn ("I checked with gymbro — …"), per the
+  own turn ("I checked with gymbro, …"), per the
   `conversational-pacing.md` "hand back delegations with synthesis" beat.
 
 So a cross-agent crossing is never invisible: the operator can read it in
@@ -125,7 +126,7 @@ agents:
       ask_allow: [gymbro, ziggy]   # operator-written; clerk cannot add to this
 ```
 
-- Default: **empty** (no agent can `ask_peer` anyone — batteries-included
+- Default: **empty** (no agent can `ask_peer` anyone, batteries-included
   safe default, `reference/principles.md` defaults test).
 - The target may *also* opt out of being asked
   (`agents.<target>.peers.askable: false`) so a sensitive specialist is
@@ -140,7 +141,7 @@ agents:
    "What's Ken's current weekly mileage and any flags for a taper?")`.
 3. gymbro's topic shows "🔁 clerk asks: …"; gymbro answers from **its own**
    Garmin/coaching context.
-4. The reply routes back; clerk replies to Ken: "Checked with gymbro —
+4. The reply routes back; clerk replies to Ken: "Checked with gymbro,
    you're at ~45km/wk, HRV's been low this week, so here's a conservative
    taper…"
 
@@ -166,20 +167,20 @@ target's bank (`X-Bank-Id: <target>`, write tools denied).
 
 Rejected as the primary mechanism because:
 
-- It is the **named anti-pattern** — `run-a-fleet-of-specialists.md`:
+- It is the **named anti-pattern**, `run-a-fleet-of-specialists.md`:
   *"Shared memory across all agents. Every specialist should have its own
   view of the user."* and `remember-across-sessions.md` bans *"conflating
   … different specialists into one undifferentiated memory pool."*
-- **All-or-nothing per bank** — it can't distinguish a safe summary from a
+- **All-or-nothing per bank.** It can't distinguish a safe summary from a
   confidential detail, so the most-useful targets (lawgpt = estate case,
   finn = banking, gymbro = health) are exactly the ones it would leak.
-- **Silent** — the caller ingests another agent's memory with no operator
+- **Silent.** The caller ingests another agent's memory with no operator
   visibility (fails the leash).
-- **Lower value** — returns stale extracted facts, can't act, and can't
+- **Lower value.** Returns stale extracted facts, can't act, and can't
   give the live answer `ask_peer` does.
 
-A narrower variant — a curated **shared "team board"** bank that agents
-*publish* select facts to (the source mediates), read by the leader — is
+A narrower variant, a curated **shared "team board"** bank that agents
+*publish* select facts to (the source mediates), read by the leader, is
 contract-acceptable and complementary. It serves *passive awareness of
 standing facts* where `ask_peer` serves *live answers + delegation*. It
 is out of scope here but noted as a possible companion (the unused
@@ -187,18 +188,18 @@ is out of scope here but noted as a possible companion (the unused
 
 ## 8. Principle checks (`reference/principles.md`)
 
-- **Docs test:** the chat teaches it — "I checked with gymbro" is
+- **Docs test:** the chat teaches it. "I checked with gymbro" is
   self-explanatory; no docs needed to understand a crossing happened.
 - **Defaults test:** empty allowlist out of the box; the capability is
   dormant until the operator lists a pair. No dangerous default.
 - **Consistency test:** reuses `peers_list` (same server), the
   `inject_inbound` transport, the approval/visibility surface, and the
-  "hand back with synthesis" pacing beat — same shapes as adjacent
+  "hand back with synthesis" pacing beat, same shapes as adjacent
   features.
 
 ## 9. Phasing
 
-- **Phase 0 (shipped, this workstream):** `clerk` soul `Boundaries` —
+- **Phase 0 (shipped, this workstream):** `clerk` soul `Boundaries`,
   router-advisor behaviour using the existing `peers_list`. clerk names
   who owns a domain and offers to route, and is told never to reach into
   another agent's memory/vault/state. Zero new capability; immediate
@@ -222,7 +223,7 @@ is out of scope here but noted as a possible companion (the unused
    per-turn ask count enough, or do we need a fleet-wide rate limit?
 4. **Target persona for the answer.** Should the target know it's
    answering a peer (so it can be terse/structured) vs. answering the
-   operator? Probably yes — `meta.ask_from` lets its prompt adapt.
+   operator? Probably yes; `meta.ask_from` lets its prompt adapt.
 
 ## 11. Effort estimate (agent-minutes)
 

--- a/reference/rfcs/auth-broker.md
+++ b/reference/rfcs/auth-broker.md
@@ -1,6 +1,7 @@
 ---
-artefact: switchroom-auth-broker — single-writer OAuth credential plane
-serves: jobs/share-auth-across-the-fleet.md
+artifact: switchroom-auth-broker — single-writer OAuth credential plane
+serves: share-auth-across-the-fleet
+advances-outcome: subscription-honest
 status: Draft v1
 ---
 
@@ -47,7 +48,7 @@ Side effects of landing this RFC:
   ships a clean break; existing dev/test fleets re-mirror cleanly
   on first `switchroom apply` post-merge.
 
-This unblocks `feat/hindsight-claude-code` (parked branch — see
+This unblocks `feat/hindsight-claude-code` (parked branch, see
 memory entry), which needs the broker's `get-credentials` UDS verb
 to feed `claude` running in a hindsight container without
 bind-mounting an agent dir.
@@ -63,13 +64,13 @@ that have shown up in production over the last week:
    /.claude/.credentials.json` (owned by the per-agent UID, mode 0700)
    from the host user (UID 1000) and silently fail with a ⚠ that the
    exit code claims is success. Operator recovers by running
-   `sudo HOME=… /full/path/bun /full/path/dist/cli/switchroom.js …`
-   — an incantation no doc mentions.
+   `sudo HOME=… /full/path/bun /full/path/dist/cli/switchroom.js …`,
+   an incantation no doc mentions.
 
 2. **Last-write-wins fanout in `auth refresh-accounts`.** The function
    iterates `for (const label of listAccounts()) { fanoutAccountToAgents(label, allEnabled) }`,
    so each agent's `credentials.json` ends up holding whichever
-   account iterated last — regardless of `auth.accounts[0]`. Running
+   account iterated last, regardless of `auth.accounts[0]`. Running
    the tick once silently nukes the entire fleet's credentials onto
    one (effectively random) account.
 
@@ -130,7 +131,7 @@ refresher per account. This RFC is the *how* to that *what*.
   algorithm (§6) that handles that fleet's specific shape and is
   retained as deletable code for ~one release. The "no migration"
   stance here means: no compatibility shims, no two-shapes-
-  coexisting, no `switchroom auth migrate` verb — *not* "no
+  coexisting, no `switchroom auth migrate` verb, *not* "no
   in-place upgrade." Pick the right framing when reading §6.
 
 ## 4. Design
@@ -147,19 +148,19 @@ A new compose service `switchroom-auth-broker`, lives alongside
 - Runs as root (needs CAP_CHOWN to chown per-agent sockets and
   mirror files to the agent UID).
 - `cap_drop: [ALL]`, then `cap_add: [CHOWN, FOWNER, DAC_READ_SEARCH]`
-  — the smallest cap set that lets it bind sockets and write mirror
-  files into per-agent state dirs.
+  (the smallest cap set that lets it bind sockets and write mirror
+  files into per-agent state dirs).
 - `restart: unless-stopped`.
 - Healthcheck: bind-presence probe on `/run/switchroom/auth-broker/`
   (same pattern as vault-broker PR #898).
 
 Volumes:
-- `~/.switchroom/accounts/` mounted rw — broker is canonical
+- `~/.switchroom/accounts/` mounted rw: broker is canonical
   writer of `<label>/credentials.json` (it's where refreshes land).
-- `~/.switchroom/agents/` mounted rw — broker writes per-agent
+- `~/.switchroom/agents/` mounted rw: broker writes per-agent
   mirror files into `<agentDir>/.claude/.credentials.json`. This is
   intentionally a broad mount (the broker only needs each
-  `<agentDir>/.claude/`) — it matches vault-broker's existing
+  `<agentDir>/.claude/`); it matches vault-broker's existing
   mount scope, so per-agent introspection commands can reuse the
   same code path. Principle-of-consistency trade. If a future
   PR tightens vault-broker's mount scope, this one follows.
@@ -167,7 +168,7 @@ Volumes:
   `/run/switchroom/auth-broker/<name>/` inside the broker AND at
   `/run/switchroom/auth-broker/` inside agent-`<name>`. Same per-agent
   socket model as vault-broker / approval-kernel.
-- `~/.switchroom/state/auth-broker/` mounted rw — broker's own
+- `~/.switchroom/state/auth-broker/` mounted rw: broker's own
   state (quota tracker, audit log, refresh lease records,
   sha-index).
 
@@ -198,7 +199,7 @@ name from the bind path via `socketPathToAgent()`, never from a
 wire payload. The agent's UID can connect (mode 0660); the broker
 can read peer credentials via SO_PEERCRED for audit attribution
 but does not gate authorization on them (UIDs collide; bind paths
-don't). Same threat model as vault-broker — see
+don't). Same threat model as vault-broker, see
 `docs/vault-broker.md` § "Path-as-identity".
 
 ### 4.3 Wire protocol
@@ -239,18 +240,18 @@ or for a consumer the `auth.consumers[].account` binding), and
 gates verbs against that:
 
 - `get-credentials` always returns the caller's active account's
-  credentials. No argument override — a caller cannot ask for an
+  credentials. No argument override; a caller cannot ask for an
   account it isn't on.
 - `mark-exhausted` always operates on the caller's active account.
   Argument is `until` only; no `account` argument. This closes the
   abuse path where any agent could spuriously deauth the fleet by
   marking accounts it wasn't using. Spurious-from-real-user case
   (an agent that's actually on account X spamming `mark-exhausted`
-  on X) is still possible but bounded — that agent's own account
+  on X) is still possible but bounded: that agent's own account
   is the one it kills, which is self-limiting.
 - All `admin only` verbs require one of:
   - Peer UID == 0 (root, i.e. CLI re-execed under sudo via the
-    operator path) — host operator.
+    operator path), the host operator.
   - Peer agent listed in `auth.admin_agents: [...]` in
     `switchroom.yaml` (admin-agent capability, intentionally
     introduced *with* the broker).
@@ -275,7 +276,7 @@ The 55-minute gap is what guarantees no concurrent tmp+rename race
 between broker and claude on the same `credentials.json`. Two
 deliverables in this PR enforce the invariant:
 
-1. **`docs/auth.md` § "Refresh windows"** — new operator doc that
+1. **`docs/auth.md` § "Refresh windows"**: new operator doc that
    pins the broker / claude thresholds with the claude version
    range we tested against. The doc is part of this PR, not a
    follow-up.
@@ -314,18 +315,18 @@ same implementation.
 **`~/.switchroom/accounts/<label>/credentials.json` ownership.** The
 file is created by the operator's CLI invocation of `auth add`
 (host-user UID) and *then* written atomically by the broker (root)
-on each subsequent refresh — so its on-disk owner flips to root
+on each subsequent refresh, so its on-disk owner flips to root
 after the first refresh. The broker chowns to root on first write.
 Any host-user CLI code path that previously read this file directly
 (e.g., to seed an agent) now goes through `get-credentials` over
-the broker UDS — no direct file reads from the CLI. This is the
+the broker UDS, no direct file reads from the CLI. This is the
 sole-writer invariant: it costs one indirection in the CLI but
 keeps the file's owner stable.
 
 **Drift detection.** The broker computes and stores the sha256 of
 every `~/.switchroom/accounts/<label>/credentials.json` it writes,
 in `state/auth-broker/sha-index.json`. On boot, it verifies the
-on-disk sha matches its index; mismatch is a hard error — broker
+on-disk sha matches its index; mismatch is a hard error: broker
 logs a `DRIFT_DETECTED <label>` line and exits non-zero. Operator
 recovers via `switchroom auth add <label> --replace`, which the
 broker accepts as authoritative and re-indexes. This commits the
@@ -388,7 +389,7 @@ common case; per-agent override is an explicit edge case.
 
 `auth.consumers[]` entries each declare a non-agent peer that can
 hold a broker socket. v1 schema is
-`{ name: string, account: string, uid?: number }` — `name`
+`{ name: string, account: string, uid?: number }`: `name`
 becomes the socket-path identity (binds at
 `/run/switchroom/auth-broker/<name>/sock`), `account` is the
 consumer's pinned active account, `uid` (optional) is the UID the
@@ -401,7 +402,7 @@ the CLI's `switchroom.yaml` schema validator (`src/config/schema.ts`)
 refuses to write a config where any name appears in both
 `admin_agents` and `consumers[].name`; the broker re-checks on
 boot and refuses to start with a `CONFIG_INVALID` error if the
-invariant is violated (defence in depth — operator could edit
+invariant is violated (defence in depth; operator could edit
 the YAML by hand).
 
 ### 4.6 CLI surface diff
@@ -467,7 +468,7 @@ in to Anthropic" + "name your first agent"), zero per-agent
 Per-account, the broker owns:
 
 1. **Refresh loop.** A scheduled task per account, fires when
-   `expiresAt - now < REFRESH_THRESHOLD_MS` (60 minutes — the
+   `expiresAt - now < REFRESH_THRESHOLD_MS` (60 minutes, the
    existing constant in `src/auth/account-refresh.ts:60`, imported
    into the broker, *not* changed by this RFC). The broker also
    compares the on-disk `expiresAt` against its own last-write to
@@ -514,21 +515,21 @@ outside the agent fleet. The pattern:
    `/run/switchroom/auth-broker/hindsight/sock`, chowned to the
    hindsight container's UID (declared via `consumers[].uid` if
    non-default).
-2. Hindsight compose (separate project — `docker-compose -p
+2. Hindsight compose (separate project, `docker-compose -p
    hindsight`) bind-mounts the named volume `auth-broker-hindsight-sock`
    at `/run/switchroom/auth-broker/`.
 3. Container calls `get-credentials` on the socket → returns
    the credentials for *its declared account* (cannot ask for
-   a different one — peer-identity gating).
+   a different one, peer-identity gating).
 4. Container writes `credentials` to a tmpfs path
    `/run/claude-creds/credentials.json`, sets
    `CLAUDE_CONFIG_DIR=/run/claude-creds`, runs `claude -p '…'`.
-5. On 429, container calls `mark-exhausted` — broker affects only
+5. On 429, container calls `mark-exhausted`; broker affects only
    the consumer's bound account (path-identity → consumer →
    bound account; the `account` arg is not honoured). Switchroom
    agents on the same account fail over too (quota state is
    shared at the account level).
-6. Refresh attribution is the broker's job — broker owns the
+6. Refresh attribution is the broker's job; broker owns the
    refresh lease. The refresh-threshold invariant (broker at
    60min, claude at <5min) means the in-container claude never
    fires its own refresh against the same credentials.json file.
@@ -539,13 +540,13 @@ outside the agent fleet. The pattern:
 with path-identity (same primitive as agents), but they cannot be
 admins (rejected at schema validation if added to `admin_agents`).
 A consumer's reachable verbs are `get-credentials`, `list-state`,
-and `mark-exhausted` — all scoped to its declared account by
+and `mark-exhausted`, all scoped to its declared account by
 broker-side derivation. `set-active`, `add-account`, etc. are
-forbidden — admin operations only come from operator-CLI (UID 0
+forbidden; admin operations only come from operator-CLI (UID 0
 peer) or admin-agent peers.
 
 Cross-host / network-reachable broker (a remote hindsight on a
-different host) is **out of scope** for v1 — that's a TLS-fronted
+different host) is **out of scope** for v1: that's a TLS-fronted
 variant with its own trust model. v1 is UDS-only.
 
 ## 5. Compose / installer changes
@@ -574,9 +575,9 @@ the agent in `created` state until the broker recovers. If the
 broker *dies after agents are running*, agents continue on their
 existing mirrored credentials (Decision 9 of the JTBD doc). The
 only window of risk is "broker has never been up + healthcheck
-hasn't passed" — `depends_on` handles that.
+hasn't passed"; `depends_on` handles that.
 
-Tests update at `tests/docker/compose-generator.test.ts` — pin
+Tests update at `tests/docker/compose-generator.test.ts`, pin
 every emitted field, same pattern as existing broker / kernel
 emission tests.
 
@@ -638,7 +639,7 @@ algorithm:
 
 The pre-upgrade backup at `switchroom.yaml.pre-auth-broker` is
 the audit trail. The migration is **destructive of per-agent
-fallback ordering** when the fleet was divergent — that data does
+fallback ordering** when the fleet was divergent: that data does
 not survive because the new schema can't express it. This is the
 deliberate cost of the simpler model; the loud warning is the
 mitigation. Tested against three fixture shapes (uniform-single,
@@ -653,18 +654,18 @@ The implementation is ~120 lines and lives in
 ### 7.1 Deleted source files
 
 - `src/auth/account-promote.ts` (subsumed by broker `set-active`).
-- `src/auth/token-refresh.ts` (per-agent refresh loop — replaced
+- `src/auth/token-refresh.ts` (per-agent refresh loop, replaced
   by broker's per-account loop).
 - `src/auth/account-quota-store.ts` (broker owns the canonical
   quota store at `state/auth-broker/quota.json`).
 - `src/cli/auth-accounts-yaml.ts` (per-agent `auth.accounts:` list
-  manipulation — no longer a list).
-- `telegram-plugin/auth-dashboard.ts` (1,104 lines — the in-place
+  manipulation, no longer a list).
+- `telegram-plugin/auth-dashboard.ts` (1,104 lines, the in-place
   promote UI built on top of the old per-agent slot model. Replaced
   by simpler in-chat `/auth use <label>` and `/auth show` commands;
   see §7.3).
 - `telegram-plugin/auth-slot-parser.ts` (parses `/auth <verb>` chat
-  syntax for the dashboard model — replaced by a tighter parser
+  syntax for the dashboard model, replaced by a tighter parser
   for the three new chat commands inline in `gateway.ts`).
 - `src/cli/auth.ts:registerHealCommand` and `auth heal` verb (no
   slot pool to heal).
@@ -730,8 +731,8 @@ The implementation is ~120 lines and lives in
 
 ### 7.3 Telegram surface
 
-`auth-dashboard.ts` is replaced — not by a deletion-with-no-
-replacement — by three thin chat commands the gateway adds:
+`auth-dashboard.ts` is replaced, not by a deletion-with-no-
+replacement, but by three thin chat commands the gateway adds:
 
 - `/auth show` → calls broker `list-state` via gateway IPC,
   renders the same two-table format as the CLI's `auth show`.
@@ -744,7 +745,7 @@ replacement — by three thin chat commands the gateway adds:
 
 The complexity of the old dashboard (drift-warnings, slot-state
 fixups, per-agent promote with mid-flight YAML editing) is gone
-because the *fleet-wide* model has nothing to fix up — there's one
+because the *fleet-wide* model has nothing to fix up: there's one
 account active and one knob to change it.
 
 **Transitive imports.** The deletion of `auth-dashboard.ts` and
@@ -770,7 +771,7 @@ explicit replacement, not just a "remove the import" pass:
   inline `parseAuthCommand()` (~60 LOC) handling the three verbs;
   the rest of the symbols just stop being imported.
 
-Each rewire is straightforward but visible — the implementer must
+Each rewire is straightforward but visible. The implementer must
 *replace* the surface, not just delete the imports and call it
 done.
 
@@ -790,7 +791,7 @@ deleted in this RFC:
 
 ### 7.5 Net diff
 
-Net negative — roughly **~2,400 LOC removed in src/ and telegram-plugin/
+Net negative, roughly **~2,400 LOC removed in src/ and telegram-plugin/
 plus ~2,000 LOC of paired tests removed; ~1,500 LOC added** for the
 broker, client, protocol, migrate-schema, and the new test surface.
 
@@ -817,7 +818,7 @@ broker, client, protocol, migrate-schema, and the new test surface.
   in isolation (label `switchroom.test=auth-broker-rfc`), connect
   from a host-side client, exercise all v1 verbs end-to-end against
   fixture credentials. `--rm`, per-name teardown in `finally`,
-  `safeLabelTeardown` in `afterAll` — same discipline as the existing
+  `safeLabelTeardown` in `afterAll`, same discipline as the existing
   docker tests.
 - `tests/docker/auth-broker-fanout.test.ts` — three-agent compose,
   `auth use <label>`, verify each agent's mirror file contains the
@@ -827,7 +828,7 @@ broker, client, protocol, migrate-schema, and the new test surface.
 **JTBD UAT** (run by hand, documented in the PR description):
 
 The eight UAT prompts in `reference/jobs/share-auth-across-the-fleet.md`
-§ "UAT prompts" — every one of them executed and notes appended to
+§ "UAT prompts": every one of them executed and notes appended to
 the PR.
 
 ## 9. Alternatives considered
@@ -835,7 +836,7 @@ the PR.
 - **Sudo self-elevation parity for current auth verbs.** Half-day
   unblock, leaves the refresh race, the OAuth fanout bug, the
   no-visibility gap, the env-injection double-mechanism. Throwaway
-  work — would be deleted by this RFC. Rejected.
+  work that would be deleted by this RFC. Rejected.
 - **Group permissions on per-agent `.claude/` dirs.** Cleaner than
   sudo, would let an "admin agent" write across the fleet. But
   doesn't fix the refresh race or the quota-fanout coordination,
@@ -845,12 +846,12 @@ the PR.
   notion as a peer-identity check).
 - **Stage broker work**: ship broker-with-current-schema first, do
   the schema flip in a follow-up. Rejected because we have no users
-  in the wild — the staging cost (legacy schema shapes in the
+  in the wild: the staging cost (legacy schema shapes in the
   broker, doc churn, two CLI surfaces transiently coexisting) buys
   nothing and ships twice the surface.
 - **Run the broker as a host-side systemd service, not a
   container.** Rejected per project memory entry "Docker-first
-  deployment philosophy" — new long-running components are
+  deployment philosophy": new long-running components are
   containers; survives switchroom-project recreate by being a
   sibling container, not a different process model.
 
@@ -864,7 +865,7 @@ the PR.
    spawn or its own next disk-read. Acceptable; matches the
    broker's "I-write-the-file, claude-rereads-eventually" contract.
 
-3. **Telegram-side ships in v1 — three commands** (`/auth show`,
+3. **Telegram-side ships in v1, three commands** (`/auth show`,
    `/auth use`, `/auth rotate`). The old `auth-dashboard.ts` is
    deleted in the same PR, replaced by these three chat commands
    (§7.3). The UX is simpler than the dashboard *because* the
@@ -890,7 +891,7 @@ None blocking. Two minor items tracked as PR-time decisions:
 - Should the broker expose its quota-cap data (`5h / 7d` windows
   per account, already gathered by `quota-check.ts`) via
   `list-state`, or keep that in the chat-surface layer? Lean: yes
-  expose via `list-state.accounts[].quota_5h_pct` etc — JTBD
+  expose via `list-state.accounts[].quota_5h_pct` etc; JTBD
   *track-plan-quota-live* benefits directly.
 
 ## 12. Verdict / next steps
@@ -916,7 +917,7 @@ The RFC ships when:
   prompts" pass on a 3-agent / 2-account dev fleet.
 - The unit + integration test plan from §8 is implemented and
   green.
-- Net diff is meaningfully negative (~2k LOC deleted net) — the
+- Net diff is meaningfully negative (~2k LOC deleted net): the
   cleanup is the win, not just the new daemon.
 
 After merge: `feat/hindsight-claude-code` rebases on this and uses

--- a/reference/rfcs/bot-token-to-vault.md
+++ b/reference/rfcs/bot-token-to-vault.md
@@ -1,16 +1,17 @@
 ---
-artefact: complete the bot-token-to-vault migration
-serves: jobs/approve-what-my-agent-can-touch.md
+artifact: complete the bot-token-to-vault migration
+serves: approve-what-my-agent-can-touch
+advances-outcome: hold-the-leash
 status: Draft v2 — hygiene, not a boundary
 ---
 
 # RFC A: Complete the bot-token-to-vault migration
 
-Status: Draft v2 — **hygiene, not a boundary (2026-06-02)**
+Status: Draft v2. **Hygiene, not a boundary (2026-06-02)**
 Author: klanker (sub-agent draft)
 Date: 2026-05-06
 
-> **Scope note (2026-06-02).** Worth doing as **hygiene** — one revocation
+> **Scope note (2026-06-02).** Worth doing as **hygiene**: one revocation
 > surface, no plaintext token `cat`-able on disk. But per
 > [`reference/rfcs/access-model.md`](access-model.md) it is
 > **not** a security boundary: a same-uid agent is out of scope by
@@ -28,7 +29,7 @@ This RFC is **not** a proposal to build that machinery. It's the operational tas
 
 The bot token sits on disk in plaintext (`TELEGRAM_BOT_TOKEN=...` in agent env files; see `src/setup/onboarding.ts:163` `writeAgentEnv`). Any process running as `kenthompson` can read it. That includes every agent. An agent that reads the token can post messages and approval cards as the bot, intercept callbacks, and impersonate the gateway to the user.
 
-The fix in code is already done — what's left is the operational cutover. The kernel work in RFC B leans on this being completed: if an agent can lift the bot token, the kernel's audit trail is undermined because the agent can post fake "Allow this scary thing?" cards.
+The fix in code is already done; what's left is the operational cutover. The kernel work in RFC B leans on this being completed: if an agent can lift the bot token, the kernel's audit trail is undermined because the agent can post fake "Allow this scary thing?" cards.
 
 ## 3. Threat model framing — what the vault actually buys us
 
@@ -38,7 +39,7 @@ What the migration **does** buy us:
 
 - **No more plaintext-on-disk.** The token is no longer sitting in a file `cat`able by anything that wanders past it (a stray `find` script, a backup tool, a misbehaving agent that was never meant to talk to Telegram at all).
 - **A single revocation surface.** Once the token lives in a vault slot, rotation goes through `switchroom token rotate` and one place updates; today the token is duplicated across whatever env files reference it.
-- **Equal trust level with other vault secrets.** The bot token sits at the same trust level as any other vault entry — no better, no worse. It is not "only the gateway can read it"; it is "the broker hands it out under the same ACL machinery as everything else, which is misconfiguration protection." This honest framing replaces an earlier draft's overclaim.
+- **Equal trust level with other vault secrets.** The bot token sits at the same trust level as any other vault entry, no better, no worse. It is not "only the gateway can read it"; it is "the broker hands it out under the same ACL machinery as everything else, which is misconfiguration protection." This honest framing replaces an earlier draft's overclaim.
 
 The bot token is not made magically safer than e.g. an OpenAI API key in the same vault. It is made *no worse* than any other secret the user has decided to consolidate there.
 
@@ -80,11 +81,11 @@ The current plaintext token has been on disk and possibly in shell history; trea
 
 ### 5.5 Shred the old plaintext
 
-**Only after the smoke message has landed**, `shred -u` (or `trash` then secure-delete) the env-file backups taken in 5.1. If `shred` fails (e.g. on a CoW filesystem like btrfs), log loudly — the rotated old token is already dead at Telegram's edge per 5.2.1 so the failure is recoverable, but it should not pass silently.
+**Only after the smoke message has landed**, `shred -u` (or `trash` then secure-delete) the env-file backups taken in 5.1. If `shred` fails (e.g. on a CoW filesystem like btrfs), log loudly. The rotated old token is already dead at Telegram's edge per 5.2.1 so the failure is recoverable, but it should not pass silently.
 
 ## 6. Rollback
 
-- **Vault write fails (5.2.2)** → token has been rotated; the old one is dead. Recovery is to retry the write or run `switchroom token rotate` to mint another and store. There is no rollback to "the original plaintext token" because step 5.2.1 already invalidated it. This is intentional — half-rotated state is worse than committing forward.
+- **Vault write fails (5.2.2)** → token has been rotated; the old one is dead. Recovery is to retry the write or run `switchroom token rotate` to mint another and store. There is no rollback to "the original plaintext token" because step 5.2.1 already invalidated it. This is intentional: half-rotated state is worse than committing forward.
 - **Vault read after write fails (5.2.3)** → same as above; the rotation is durable at Telegram, the only path is forward (fix vault, retry write).
 - **Smoke message fails (5.4)** → the gateway is reading from vault but cannot post; debug as a normal gateway boot failure (broker unreachable, peercred mismatch, etc.) rather than reverting config.
 - **Config syntax error (5.3)** → revert the `switchroom.yaml` edit; the token is already in vault and rotated, so re-applying once the syntax is fixed is the path forward.
@@ -110,6 +111,6 @@ Each migration is its own small ticket; no further design work is needed because
 
 ## 9. Out of scope
 
-- Building vault-backed bot-token plumbing — already shipped.
-- Forcing the migration on other deployments via tooling — this RFC is about Ken's deployment specifically; the pattern is documented for reuse but not automated.
-- The approval kernel itself — see RFC B, which depends on this migration being complete.
+- Building vault-backed bot-token plumbing: already shipped.
+- Forcing the migration on other deployments via tooling: this RFC is about Ken's deployment specifically; the pattern is documented for reuse but not automated.
+- The approval kernel itself: see RFC B, which depends on this migration being complete.

--- a/reference/rfcs/bridge-presence.md
+++ b/reference/rfcs/bridge-presence.md
@@ -1,12 +1,13 @@
 ---
-artefact: bridge presence — guaranteeing always-on inbound delivery
-serves: jobs/survive-reboots-and-real-life.md
+artifact: bridge presence — guaranteeing always-on inbound delivery
+serves: survive-reboots-and-real-life
+advances-outcome: always-available
 status: draft v1
 ---
 
 # RFC: Bridge presence — guaranteeing always-on inbound delivery
 
-> Status: **draft v1** — design contract for the real fix to the
+> Status: **draft v1**. Design contract for the real fix to the
 > bridge-flap / bridge-wedge class. Supersedes the two rejected fix
 > attempts catalogued in issue #1613. Implementation is gated on the
 > "Open questions" section being closed.
@@ -15,7 +16,7 @@ status: draft v1
 
 The Telegram bridge is the relay between `claude` (running the agent)
 and the long-lived gateway sidecar. Inbound Telegram messages reach
-claude only through a **registered** bridge; when none is registered
+claude only through a **registered** bridge. When none is registered
 the gateway buffers them.
 
 Two production-visible failure modes share one root:
@@ -26,16 +27,16 @@ Two production-visible failure modes share one root:
 2. **The wedge** — `global=bridge_dead` with buffered inbounds
    stranded for minutes; a turn's completion lost.
 
-Issue #1613 root-caused both and — critically — proved that **the
+Issue #1613 root-caused both and, critically, proved that **the
 flap is load-bearing *during active-state channel cycling***: while
 claude is cycling bridges (~every 7s during a turn), the flap's
 constant reconnect/re-register storm is currently the only thing
 keeping a bridge continuously registered. This is a *scoped* claim,
-not an unconditional one — see research finding #6: an *idle* agent
+not an unconditional one: see research finding #6, an *idle* agent
 holds one stable bridge with no flap at all. The flap is therefore
 not needed in general; it is only inadvertently covering the
 **active-state handover gap**. The real fix does not need a wholesale
-"replacement for the flap" — it needs to **bound that handover gap**.
+"replacement for the flap". It needs to **bound that handover gap**.
 Two structurally different fixes were built, canary-tested, and
 rejected (both removed the flap and, on a saturated host, surfaced
 the wedge):
@@ -48,10 +49,10 @@ the wedge):
   the wedge returned.
 
 Both confirm the scoped claim above: removing the flap is safe only
-if the **active-state handover gap is bounded** — otherwise an inbound
+if the **active-state handover gap is bounded**; otherwise an inbound
 that lands in the gap is delayed (until the next bridge registers, or
-until the agent settles to its idle bridge). Bounding that gap — by
-measuring it, by tolerating it, or by eliminating it structurally —
+until the agent settles to its idle bridge). Bounding that gap, by
+measuring it, by tolerating it, or by eliminating it structurally,
 is what this RFC designs.
 
 ## Background — the architecture
@@ -68,7 +69,7 @@ is what this RFC designs.
   `claude --dangerously-load-development-channels`) is an MCP server.
   **Claude spawns it as a subprocess and owns its entire lifecycle.**
 - Claude's experimental channel layer **cycles** the MCP connection
-  roughly every 7s — closing the old bridge's MCP session and
+  roughly every 7s, closing the old bridge's MCP session and
   spawning a fresh bridge process. The old process is given no
   detectable close signal (no stdin EOF, no MCP `onclose`; verified
   against bridge stderr captured in claude's MCP debug logs).
@@ -77,7 +78,7 @@ is what this RFC designs.
 
 **The gateway cannot create, keep alive, or directly control a bridge
 process.** Claude owns bridge lifecycle completely. Every viable
-design must work within this constraint — the gateway can only react
+design must work within this constraint: the gateway can only react
 to bridges that connect to its IPC socket.
 
 ## What we know (research)
@@ -89,7 +90,7 @@ instrumented canaries:
    process; the prior is orphaned without a clean signal.
 2. **A bridge process connects to the gateway exactly once** and does
    not self-reconnect within its own lifetime (confirmed by
-   nonce-tagged lifecycle instrumentation — each bridge's ipc-client
+   nonce-tagged lifecycle instrumentation: each bridge's ipc-client
    logs exactly one `doConnect`/`open`).
 3. **The flap is two+ bridge processes ping-ponging:** the gateway's
    #1585 zombie-close force-closes a prior bridge's socket → that
@@ -99,30 +100,30 @@ instrumented canaries:
 4. **The reconnect storm keeps `agentIndex` continuously populated.**
    This is the accidental bridge-presence guarantee. Remove it and,
    when claude's handover leaves a gap, `agentIndex` empties and stays
-   empty — the wedge.
+   empty: the wedge.
 5. **The gateway already buffers and drains correctly.** Inbounds
    that arrive while `bridge_dead` are held in `pendingInboundBuffer`
    and flushed by the `drainBuffer` effect on the next `bridgeUp`.
-   Buffered inbounds are **not lost** — they are delayed until a
+   Buffered inbounds are **not lost**; they are delayed until a
    bridge returns. The open question is whether a bridge always
    returns (see below).
 6. **Idle agents hold exactly one stable bridge.** A 4.5-minute
    observation of an idle clean-v0.13.2 agent (16 samples, 17s apart)
    showed `bridgeProcs=1, global=bridge_alive_idle` on *every* sample
-   — zero churn, no flap, no cycling. **The ~7s channel cycling is an
+   (zero churn, no flap, no cycling). **The ~7s channel cycling is an
    ACTIVE-state behaviour, not an idle one.** When the agent has
    nothing to do it keeps one steady bridge.
 7. **The flap and the wedge are active-state phenomena.** They occur
    only during turns / channel activity, when claude cycles bridges.
    An agent that finishes its work returns to the stable single-bridge
-   idle state — which means a backlog buffered during active churn
+   idle state, which means a backlog buffered during active churn
    *will* drain once the agent settles (`bridgeUp` on the stable
    bridge fires `drainBuffer`).
 8. **Wedge severity scales with host load.** The canary wedges that
    rejected both prior fixes ran on a host saturated by an all-night
    build+canary session. On a loaded host, claude's bridge spawn is
    slow, so the handover gap stretches from ~1-2s to tens of seconds.
-   The prior rejections are therefore **confounded** — they measured
+   The prior rejections are therefore **confounded**: they measured
    "remove the flap on a saturated host", not "remove the flap". This
    materially changes the verdict on Option 2 (below).
 
@@ -130,7 +131,7 @@ instrumented canaries:
 
 ### Option 1 — Decouple bridge lifetime from claude's MCP connection (recommended)
 
-**Make the bridge a long-lived, `start.sh`-managed process** — a
+**Make the bridge a long-lived, `start.sh`-managed process**, a
 sibling of the gateway, not a claude subprocess. Claude's channel
 connects to the already-running bridge; claude cycling its MCP
 connection no longer kills the bridge process.
@@ -145,11 +146,11 @@ connection no longer kills the bridge process.
 
 - The bridge keeps **one** persistent IPC connection to the gateway
   for the container's lifetime. `agentIndex` is populated once and
-  never churns. No flap, no wedge, no handover gap — structurally.
+  never churns. No flap, no wedge, no handover gap, structurally.
 - When claude's MCP side is down (between cycles), the bridge holds
   inbounds and flushes them when claude's MCP session reconnects.
   The bridge already knows when claude connects (a new MCP session is
-  an explicit event) — the flush trigger is clean and detectable,
+  an explicit event), so the flush trigger is clean and detectable,
   unlike the close signal.
 
 **The hard dependency:** claude must be able to connect its channel
@@ -174,12 +175,12 @@ handover gap on every active-state cycle and rely on the fact that
   new registration fires `bridgeUp` → `drainBuffer`. The buffer
   therefore drains roughly once per cycle even mid-burst.
 - When activity ends, the agent returns to the stable single-bridge
-  idle state (research finding #6) — a final guaranteed `drainBuffer`.
+  idle state (research finding #6): a final guaranteed `drainBuffer`.
 - The gateway buffer already holds inbounds indefinitely and is
   lossless across the gap; an inbound is *delayed*, never *lost*.
 
 **Re-assessment (post research findings #6-8):** Option 2 was
-*rejected* in #1613 — but on a host saturated by the build session,
+*rejected* in #1613, but on a host saturated by the build session,
 where claude's bridge spawn was pathologically slow and the handover
 gap stretched to tens of seconds. That was not a fair test. On a
 healthy host the gap should be ~1-2s, which is well inside tolerance.
@@ -190,7 +191,7 @@ If a clean-host re-test shows bounded (~1-2s) gaps, Option 2 is the
 *pragmatic* fix: it is small (already implemented on the branch),
 needs no claude-channel-transport change, and ships fast. Its
 residual cost is bounded added latency for an inbound that lands
-exactly inside a handover gap during a sustained active burst —
+exactly inside a handover gap during a sustained active burst:
 acceptable, and strictly better than the flap.
 
 ### Option 3 — Status quo: accept the flap (#1613 Option C)
@@ -198,7 +199,7 @@ acceptable, and strictly better than the flap.
 The flap is survivable: self-heals in 20-30s, occasionally costs one
 turn's `turn_end`. It is the only **currently-safe** state and is
 where the fleet sits today (v0.13.2). The cost is real but bounded.
-This RFC exists to retire Option 3, not endorse it — but it remains
+This RFC exists to retire Option 3, not endorse it, but it remains
 the fallback if Options 1 and 2 both prove infeasible.
 
 ### Option 4 — "Sticky bridge": gateway nominates one reconnecting bridge (rejected)
@@ -212,10 +213,10 @@ bridge keeps `agentIndex` populated.
 
 - The gateway's "nomination" has no force. Claude owns every bridge
   process and kills the sticky one on its normal cycle exactly like
-  any other — a gateway flag does not stop that.
+  any other; a gateway flag does not stop that.
 - Once the sticky bridge is killed, *something* must become the new
   sticky bridge, and there is a gap between "old sticky killed" and
-  "new one nominated + reconnecting" — the same handover gap, not
+  "new one nominated + reconnecting": the same handover gap, not
   removed.
 - "One bridge reconnects-on-drop" is just a single-participant flap.
   It collapses into Option 1 if "sticky" is made to mean "a
@@ -227,7 +228,7 @@ Recorded here so the design history is complete; not pursued.
 ## Recommendation
 
 The research (findings #6-8) shifts the verdict. **Option 2 is the
-recommended first move** — not because it is more elegant than
+recommended first move**, not because it is more elegant than
 Option 1, but because it is already built, needs no upstream
 dependency, and its only prior rejection is confounded by host
 saturation. Validate it cleanly; if it holds, ship it. Option 1
@@ -254,7 +255,7 @@ Option 2's clean re-test still shows unacceptable gaps.
 
 **Why not jump straight to Option 1:** it is a real rearchitecture
 (bridge process model, a new MCP transport or an upstream change, a
-buffer relocated into the bridge) — weeks of work with an unresolved
+buffer relocated into the bridge): weeks of work with an unresolved
 upstream dependency. Option 2 is a ~30-line diff that already exists.
 If the clean re-test vindicates it, shipping Option 2 retires the
 flap *now* and Option 1 becomes a deliberate, unhurried follow-up
@@ -262,7 +263,7 @@ rather than an emergency.
 
 ## Open questions
 
-The handover-gap measurement is not listed here — it is not an open
+The handover-gap measurement is not listed here. It is not an open
 *question*, it is a *test task* (step 1 of the plan). The genuine
 unknowns:
 
@@ -271,11 +272,11 @@ unknowns:
    attach-don't-spawn mode), rather than spawning a stdio subprocess?
    This determines whether Option 1 is buildable in switchroom or
    needs an upstream change.
-2. **Bridge re-spawn reliability after active churn ends — the
+2. **Bridge re-spawn reliability after active churn ends, the
    gating unknown for Option 2.** Option 2's safety rests entirely on
    the agent always returning to a registered bridge once a burst
    ends. Research finding #6 observed exactly this once (a 4.5-minute
-   idle hold) — but *not* across the specific race that matters: the
+   idle hold), but *not* across the specific race that matters: the
    moment a turn ends while claude is mid-cycle. Does claude reliably
    re-spawn and keep a bridge after every turn-end, including
    turn-end-during-cycle? If there is any path where claude ends a
@@ -298,7 +299,7 @@ A correct fix:
 - (b) keeps a bridge continuously registered (or re-registered within
   a few seconds) so no inbound is delayed more than ~5s by bridge
   absence, **and**
-- (c) preserves inbound ordering — a backlog drained after a gap is
+- (c) preserves inbound ordering: a backlog drained after a gap is
   delivered in arrival order (OQ4), **and**
 - (d) passes `bridge-flap-resilience-dm.test.ts` repeatably on an
   unloaded host (4 rapid DMs, all replied, low `bridge disconnected`

--- a/reference/rfcs/cheap-cron-sessions.md
+++ b/reference/rfcs/cheap-cron-sessions.md
@@ -1,6 +1,7 @@
 ---
-artefact: cheap cron — deterministic polls + per-agent Sonnet cron session
-serves: jobs/crons-use-the-model-only-when-it-earns-it.md
+artifact: cheap cron — deterministic polls + per-agent Sonnet cron session
+serves: crons-use-the-model-only-when-it-earns-it
+advances-outcome: subscription-honest
 status: Draft, post-review (rev 2)
 ---
 
@@ -9,7 +10,7 @@ status: Draft, post-review (rev 2)
 **Status:** Draft, post-review (rev 2)
 **Author:** (agent-authored, operator-directed)
 **Targets:** `upstream/main` @ v0.14.91
-**Compliance pillar touched:** 3 (Claude-native, subscription-honest) — preserved by construction; see §7.
+**Compliance pillar touched:** 3 (Claude-native, subscription-honest), preserved by construction; see §7.
 
 ---
 
@@ -33,7 +34,7 @@ below.
 
 ## Build status (this branch)
 
-Behind `SWITCHROOM_CHEAP_CRON` (default **off**) — every layer below is dormant
+Behind `SWITCHROOM_CHEAP_CRON` (default **off**): every layer below is dormant
 until the flag is set, so this branch is a no-op in production until the canary.
 
 | Layer | Status | Tests |
@@ -49,13 +50,13 @@ until the flag is set, so this branch is a no-op in production until the canary.
 
 **Why the split:** L1–L3 are the algorithmic + security core (the SSRF BLOCK
 resolution, the routing proof, the cost-saving poll engine) and the full gateway
-plumbing for the cron session — self-contained and exhaustively tested. The
+plumbing for the cron session, self-contained and exhaustively tested. The
 staged items are **deploy-sensitive integration**: the live wiring touches the
-**vault broker** (strict test-isolation discipline — see CLAUDE.md + the
+**vault broker** (strict test-isolation discipline, see CLAUDE.md + the
 2026-05-22 clobber incident) and L4 launches a second `claude` process, both of
 which must be proven on the **test-harness canary**, not landed unproven in a
 long build session. With `escalate-to-main` (a poll entry with no `model`/
-`context` → Tier 2), **Tier-0 delivers its full cost saving without L4** — so the
+`context` → Tier 2), **Tier-0 delivers its full cost saving without L4**, so the
 live wiring + canary is the next, focused PR.
 
 ---
@@ -66,7 +67,7 @@ Cron fires are expensive for one structural reason: **every fire injects a
 synthesized turn into the agent's live interactive session**, so it pays the
 full standing-context cache-read tax (system prompt + ~31k-token MCP schema
 surface + the whole running conversation) *and* runs at the agent's configured
-model — even when the fire is a `*/10` poll that finds nothing to do.
+model, even when the fire is a `*/10` poll that finds nothing to do.
 
 Three tiers, cheapest-first:
 
@@ -145,12 +146,12 @@ Neither needs a model on the no-op path. **240 fires/day, ~all wasted.**
 agent-authored script (§6.2). Two built-in types cover the fleet:
 
 - `poll: http-diff` — `{ url, method, headers?, secrets:[...], diff_jsonpath,
-  state_key }`. Scheduler does a guarded `fetch()` (§6.1 — egress allowlist,
+  state_key }`. Scheduler does a guarded `fetch()` (§6.1: egress allowlist,
   no-redirect, host-pinned secret binding), extracts `diff_jsonpath`, compares to
   the last value under `state_key`. **New → escalate; unchanged → `HEARTBEAT_OK`.**
 - `poll: telegram-reactions` — `{ chat_id, emoji, lookback }`. Needs a **new
   gateway internal IPC verb** `query_recent_reactions` (today `get_recent_messages`
-  exists only as an MCP tool via the bridge — `bridge.ts:281` — there is no
+  exists only as an MCP tool via the bridge (`bridge.ts:281`); there is no
   model-free internal path; this verb is net-new, see §3.3 / Q4). **Match →
   escalate; none → `HEARTBEAT_OK`.**
 
@@ -170,14 +171,14 @@ dispatch-ack). State advance and escalation intent are one durable write.
 **First-run semantics (Q3, now resolved).** No baseline ⟹ **record baseline, do
 NOT escalate** (else every existing Brevo contact emails on day one). poll-state
 lives on the `/state/agent/` volume; reconcile writes scaffold/config only and
-**must not** touch runtime state — pinned by a new test
+**must not** touch runtime state, pinned by a new test
 `tests/agent-scheduler/tier0-poll-first-run.test.ts`.
 
 **Errors don't escalate.** Brevo 500 / vault denial / bad jsonpath → record a
 poll-error row + **one-shot** operator notice (not every fire) naming the
 next-step command; reuse the existing bounded retry ladder (`index.ts:156-230`).
 
-**Min-interval applies to polls too** (§6.3) — model-free ≠ free (each poll hits
+**Min-interval applies to polls too** (§6.3): model-free ≠ free (each poll hits
 an external API / the broker; a tight poll is a cheap DoS).
 
 ### 2.2 Tier 1 — per-agent cheap cron session
@@ -186,27 +187,27 @@ A second **interactive** `claude --model {cronModel}` (default
 `claude-sonnet-4-6`) in the agent container, addressed by gateway session label
 `cron`. Minimal-context by construction: own `CLAUDE_CONFIG_DIR=.claude-cron`
 (separate transcript), a **trimmed `.mcp.json`** (only `switchroom-telegram` +
-the task's tool — not the full hindsight/perplexity/webkite surface, cutting the
+the task's tool, not the full hindsight/perplexity/webkite surface, cutting the
 ~31k schema tax), `/clear` between fires.
 
-**Runtime shape — recommendation changed by review to B3 (lazy).** Three shapes:
+**Runtime shape, recommendation changed by review to B3 (lazy).** Three shapes:
 
 - **B1 — persistent at boot.** Warm, simplest supervision, but **doubles idle
   memory 24/7** to serve fires that Tier 0 makes rare. Needs a per-profile mem
   bump on tight (1.5g) profiles.
 - **B2 — ephemeral per-fire.** Zero idle cost, minimal context by construction,
-  no mem bump — but per-fire cold start + per-fire bridge-registration
+  no mem bump, but per-fire cold start + per-fire bridge-registration
   orchestration (the harder build).
 - **B3 — lazy with idle-timeout (RECOMMENDED).** Forked on the *first* Tier-1
   fire, kept warm, **torn down after N minutes idle** (default 30). Zero idle
   cost in steady state (Tier 0 absorbs the frequent polls), warm within a burst,
   no per-fire cold start inside a burst, no permanent mem-bump. Best fit for the
   "rare bursty Tier-1 fire behind a frequent Tier-0 poll" profile this design
-  creates. **The canary measures the Tier-0 no-op fraction first** (§5) — if it
+  creates. **The canary measures the Tier-0 no-op fraction first** (§5): if it
   is >90% as expected, B3 is clearly right; the data also sizes any mem headroom.
 
 All three are **interactive `claude` (no `-p`)** (§7). **B2/B3 must not be built
-headless** — a CI guard asserts every cron-session spawn is interactive +
+headless**: a CI guard asserts every cron-session spawn is interactive +
 `--strict-mcp-config` (extend `tests/bridge-flap-regression-guard.test.ts`).
 
 ### 2.3 Tier 2 — main session passthrough
@@ -220,7 +221,7 @@ about (§3.1).
 A second session emitting Telegram status into the same chat+topic as the main
 session collides: two sessions editing one progress card; a main-session reply
 closing a cron's obligation; competing worker-feed `editMessageText`. **v1
-stance: the cron session is status-silent** — it renders **no** progress card and
+stance: the cron session is status-silent**: it renders **no** progress card and
 **no** worker-activity feed; its only Telegram output is the final reply. And
 **obligations are session-scoped**: add `sessionLabel` to the `Obligation`
 interface (`obligation-ledger.ts:29-58`) + the close-matcher
@@ -257,12 +258,12 @@ and `collectScheduleEntries`; `dispatchAsInbound` emits `meta.model` + `meta.ses
 cross-entry/cross-layer inheritance** of the new fields; the array stays
 concat/append-only (`merge.ts:559-561`). Documented in `docs/configuration.md`.
 
-**Migration — guarantee no existing cron changes tier silently:**
+**Migration, guarantee no existing cron changes tier silently:**
 
 - `model: opus` or **unset** → `context: agent` (Tier 2 = today's behaviour).
 - **`model` = a known-cheap id (sonnet/haiku family) only** → `context: fresh`.
 - **Custom / unrecognised model id → `context: agent`** (conservative; never
-  assume a custom id is cheap) **+ a one-time warn**: "cron X has custom model Y —
+  assume a custom id is cheap) **+ a one-time warn**: "cron X has custom model Y,
   running on the main session; set `model: sonnet` + `context: fresh` to use a
   cheap cron session."
 
@@ -275,23 +276,23 @@ This closes the review's silent-tier-flip gap for every current fleet config.
 
 - **New agent-authored crons default cheap** (`sonnet`/`fresh`). The
   `schedule_add` response states it plainly so it is never silent: *"this cron
-  will run on Sonnet in a fresh cron session, not <agent>'s own model/persona —
+  will run on Sonnet in a fresh cron session, not <agent>'s own model/persona;
   pass context: agent to use the agent."*
 - **Escalation is operator-gated, and the gate is the *commit*, not an env
   check.** `context: agent`, `model: opus`, or any new `poll.secrets`/`poll.url`
   from an agent **stage** under `.pending/` (new `PendingReasonCode`s) and go live
   **only** when the operator commits (`schedule pending commit`, routed via hostd
-  Allow/Deny — memory `feedback_dashboard_loopback_header_forge`). An agent
+  Allow/Deny, memory `feedback_dashboard_loopback_header_forge`). An agent
   scrubbing `SWITCHROOM_AGENT_NAME` (the pre-existing, acknowledged host-CLI
   identity weakness, `agent-config-write.ts:119-127`) still **cannot** commit its
-  own pending entry — the operator commits. The security boundary is the
+  own pending entry; the operator commits. The security boundary is the
   operator-only commit, by design, not the forgeable agent-side identity.
 - **Cost label at staging (v1, lightweight).** The pending meta carries a coarse
   `fires_per_day × tier_weight` estimate (sonnet=1, opus=5) so the operator's tap
   sees the spend before approving. Full predictive UX deferred to v2; v1 ships the
   one-number bound rather than zero visibility.
 
-### 3.3 Gateway: session-labelled routing — the real refactor (review-corrected)
+### 3.3 Gateway: session-labelled routing, the real refactor (review-corrected)
 
 This is **more than one primitive.** Three structures are single-keyed by agent
 and a second bridge would clobber the first today:
@@ -328,13 +329,13 @@ the obligation `sessionLabel` add in §2.4.
 - **Env-order landmine:** the fork's env must be exported in the preamble before
   it (`start.sh.hbs:47`, memory `project_configurable_status_clear_v0_14_55`).
 
-## 5. Observability (review-found gap — now v1)
+## 5. Observability (review-found gap, now v1)
 
 The value prop is cost; the operator must *see* it.
 
 - `DispatchResult` (`dispatch.ts`) gains `tier: 'poll'|'cheap'|'main'` +
   `model_used`; written to `scheduler.jsonl` and the gateway fire log.
-- A report surface — extend the existing `switchroom schedule`/`auth schedule`
+- A report surface: extend the existing `switchroom schedule`/`auth schedule`
   family with `switchroom schedule report <agent> [--since]`: counts of
   poll / cheap / main fires + an estimated cost-weighted-token breakdown
   (`poll×0 + cheap×sonnet + main×opus`). This is how the canary's success is
@@ -344,7 +345,7 @@ The value prop is cost; the operator must *see* it.
 
 ### 6.1 `http-diff` egress hardening (resolves the BLOCK)
 
-A poll = URL + headers + vault secrets executed by the scheduler — an exfil/SSRF
+A poll = URL + headers + vault secrets executed by the scheduler, an exfil/SSRF
 primitive unless fenced. Mandatory before any Tier-0 poll ships:
 
 1. **Egress allowlist, operator-owned.** A poll `url`'s host must match an
@@ -353,7 +354,7 @@ primitive unless fenced. Mandatory before any Tier-0 poll ships:
    non-`https`, `file://`, `unix://`. Resolve-then-pin the IP to defeat DNS-rebind.
 2. **Host-pinned secret bindings.** A `poll.secrets` name may only be sent to the
    host it is **bound** to in operator config (`brevo_api_key → api.brevo.com`). A
-   poll requesting a secret for an unbound host is rejected at staging — the
+   poll requesting a secret for an unbound host is rejected at staging: the
    operator can't be socially-engineered into approving an exfil because the
    binding, not the agent, decides where a secret may go.
 3. **No redirects, hard timeout (5s), response size cap.** Secrets never appear in
@@ -375,10 +376,10 @@ Model-free polls are cheaper to abuse → enforce `MIN_CRON_INTERVAL`
 smallest gap for CSV/range expressions (today `0,30 * * * *` slips through);
 reject unparseable expressions for cheap-cron rather than passing them.
 
-## 7. Compliance (pillar 3) — preserved by construction
+## 7. Compliance (pillar 3): preserved by construction
 
 - **Tier 0** touches no model → outside the inference surface (a guarded poll).
-- **Tier 1 & 2** are **interactive `claude`** injected via `inject_inbound` — the
+- **Tier 1 & 2** are **interactive `claude`** injected via `inject_inbound`, the
   sanctioned synthesized-turn pattern. The cron session launches `exec claude
   --model sonnet …` (no `-p`), the exact shape of `start.sh.hbs:673`, with
   `--strict-mcp-config`. **Neither uses `claude -p`**; a CI guard enforces it for
@@ -392,7 +393,7 @@ reject unparseable expressions for cheap-cron rather than passing them.
 - **Q1 — v1 poll scope.** `http-diff` only (canary = marko, 96/day) vs **both**
   poll types (canary = marko + clerk, 240/day). Review note: clerk's reactions
   poll is ~60% of the savings, but `telegram-reactions` needs the net-new internal
-  gateway verb (§2.1/§3.3) — more build for a fuller canary.
+  gateway verb (§2.1/§3.3), more build for a fuller canary.
 - **Q2 — cron quota partitioning.** Tier-1 fires share the operator's OAuth weekly
   window. Accept (simple) vs ring-fence a dedicated `fallback_order` account for
   cron (protects live turns from a cron burst, memory

--- a/reference/rfcs/cold-start-ttfo.md
+++ b/reference/rfcs/cold-start-ttfo.md
@@ -1,16 +1,17 @@
 ---
-artefact: cold-start TTFO — minimising time to first outbound after restart
-serves: jobs/survive-reboots-and-real-life.md
+artifact: cold-start TTFO — minimising time to first outbound after restart
+serves: survive-reboots-and-real-life
+advances-outcome: always-available
 status: draft v1
 ---
 
 # RFC — Cold-start TTFO
 
-> Status: draft v1 — scoping cold-start latency optimization. Companion to `reference/vision.md` (always-on specialist exec-assistants) and the wedge-cluster JTBD ("agent feels continuous across restarts").
+> Status: draft v1. Scoping cold-start latency optimization. Companion to `reference/vision.md` (always-on specialist exec-assistants) and the wedge-cluster JTBD ("agent feels continuous across restarts").
 
 ## Why this RFC
 
-The vision is **always-on specialist exec-assistants** — agents that feel continuous, present, immediate. The wedge cluster of 2026-05-18→20 closed the 5-minute *correctness* failure mode (stranded inbound, silence-poke fallback firing). It did not close the *experience* failure mode: every agent restart imposes a multi-second blank window between the user's first message after restart and the model's first reply (Time To First Outbound — TTFO).
+The vision is **always-on specialist exec-assistants**: agents that feel continuous, present, immediate. The wedge cluster of 2026-05-18→20 closed the 5-minute *correctness* failure mode (stranded inbound, silence-poke fallback firing). It did not close the *experience* failure mode: every agent restart imposes a multi-second blank window between the user's first message after restart and the model's first reply (Time To First Outbound, TTFO).
 
 ### What we measured (2026-05-21 baseline)
 
@@ -37,7 +38,7 @@ The "always-on" experience erodes most visibly during restart windows. Operators
 The cold-start TTFO has two layers:
 
 1. **Pre-claude shell work in `start.sh`** (~2s). Three serialized `timeout` calls before `exec claude`: handoff summarizer, briefing assembler, workspace render. Switchroom-controllable.
-2. **Claude-side cold prefix-cache** (~3-10s). Anthropic's prompt cache is warm only after the first turn. On a fresh session with a 14-18KB system-prompt prefix, the first turn pays full processing cost. Not directly switchroom-controllable — but indirectly addressable by changing what gets sent, when, and how.
+2. **Claude-side cold prefix-cache** (~3-10s). Anthropic's prompt cache is warm only after the first turn. On a fresh session with a 14-18KB system-prompt prefix, the first turn pays full processing cost. Not directly switchroom-controllable, but indirectly addressable by changing what gets sent, when, and how.
 
 ## Architectural options
 
@@ -45,16 +46,16 @@ Four options ranked by blast radius. Each addresses layer 2 (the dominant cost);
 
 ### Option A — Prefix-cache warmup turn (lowest blast radius)
 
-On bridge-up after restart, the gateway synthesizes a warmup `InboundMessage` (`text: "__WARMUP_PING__"`, `meta.source: "warmup"`) and delivers it to the just-registered bridge. Claude processes the warmup — paying the full cold-cache cost — and responds with `NO_REPLY` (existing sentinel; gateway already suppresses output). When the real user message arrives next, the prefix cache is warm.
+On bridge-up after restart, the gateway synthesizes a warmup `InboundMessage` (`text: "__WARMUP_PING__"`, `meta.source: "warmup"`) and delivers it to the just-registered bridge. Claude processes the warmup, paying the full cold-cache cost, and responds with `NO_REPLY` (existing sentinel; gateway already suppresses output). When the real user message arrives next, the prefix cache is warm.
 
 **Pros**
 - Single point of change (gateway `onClientRegistered`).
 - Reuses existing `NO_REPLY` suppression (gateway.ts:5900).
-- **Reuses cron's `meta.source` envelope** (`src/scheduler/dispatch.ts:174-199`). Tag the synthesized inbound with `meta.source: "warmup"` and the bridge / hindsight already know how to render and exclude non-user sources — same contract cron rides today. No new envelope field, no new bridge protocol.
+- **Reuses cron's `meta.source` envelope** (`src/scheduler/dispatch.ts:174-199`). Tag the synthesized inbound with `meta.source: "warmup"` and the bridge / hindsight already know how to render and exclude non-user sources, the same contract cron rides today. No new envelope field, no new bridge protocol.
 - Quota cost: ~1 OAuth turn per restart. Negligible (typical fleet sees < 10 restarts/day).
 - Naturally debounceable.
 
-**Cons** — confirmed by walking the codebase:
+**Cons**, confirmed by walking the codebase:
 - **Progress card UX cost**: the warmup inbound triggers `handleInbound`'s 👀 reaction emission + stream-reply-handler's progress card. The 👀 reaction lands on a synthetic message and the card briefly appears in the agent's primary chat. NO_REPLY suppression unpins the card on turn end but the flash is visible.
 - The cron-source path already handles parts of this (cron turns are rendered with `<channel source="cron">` framing). Reusing `meta.source="warmup"` collapses much of the UX-suppression work into "extend cron's handling for warmup" rather than new plumbing.
 - Hindsight memory may capture the warmup turn; tag for memory-exclusion via the same source-discriminator path cron uses.
@@ -72,7 +73,7 @@ Today every gateway restart (`/restart`, `/update apply`, container recreate) re
 **Cons**
 - Container architecture change. Today `start.sh` forks gateway + autoaccept + agent-scheduler as siblings then `exec`s into tmux/claude. Decoupling means either (a) two containers per agent (claude + gateway-sidecar), or (b) one container with a stricter PID 1 supervisor.
 - MCP reconnect semantics. Claude Code's MCP client expects stable stdio; rebinding a stdio socket on the fly isn't a documented feature.
-- Survival across `/update apply` is hard because the agent image itself changes — claude inside the old image would still need to be restarted to pick up new bundles. Decoupling buys us the gateway-only restart cases, not image-bump cases.
+- Survival across `/update apply` is hard because the agent image itself changes; claude inside the old image would still need to be restarted to pick up new bundles. Decoupling buys us the gateway-only restart cases, not image-bump cases.
 
 **Net**: 4-6 PR architectural change. Estimated TTFO win: near-100% elimination of gateway-only-restart cold-starts (probably 60-80% of operator-initiated restarts). Image bumps still pay full cost.
 
@@ -90,7 +91,7 @@ Move all stable workspace content (AGENTS.md, SOUL.md, USER.md, IDENTITY.md, TOO
 - The handoff briefing (LLM-generated session summary from the Stop hook) still needs to land. Today it's appended after the workspace block in `--append-system-prompt`. If we drop that path, briefing needs a new injection point (UserPromptSubmit hook is the natural one).
 - Behavior measurement requires holding all 9 agents constant and watching for regressions in agent quality. Not pure win.
 
-**Net**: 2-PR change. TTFO win uncertain — depends on whether Claude Code caches CLAUDE.md better than we cache `--append-system-prompt`. Worth measuring first.
+**Net**: 2-PR change. TTFO win uncertain; depends on whether Claude Code caches CLAUDE.md better than we cache `--append-system-prompt`. Worth measuring first.
 
 ### Option D — Warm pool of pre-spawned claude processes
 
@@ -102,14 +103,14 @@ Maintain N hot-standby claude processes per agent slot. On restart, swap to a wa
 **Cons**
 - RAM: each claude instance is ~500MB+ resident. Doubling instances doubles fleet RAM.
 - Session slot consumption: Anthropic per-account session slots are finite. A pool that exceeds the OAuth quota fails immediately.
-- Pool warming requires its own cold-start somewhere — we're moving cost, not eliminating it. The pool member's prefix-cache is cold until used.
+- Pool warming requires its own cold-start somewhere; we're moving cost, not eliminating it. The pool member's prefix-cache is cold until used.
 - Complex lifecycle: when does a pool member retire? Recycle on schedule? On staleness?
 
 **Net**: 5+ PR architectural change with ongoing infra cost. Likely not worth it for switchroom's scale.
 
 ## Recommendations
 
-1. **Ship the measurement infrastructure**. Without per-line timestamps on `gateway-supervisor.log` (or equivalent OTel/PostHog spans), every optimization claim is unverifiable. Recommend either (a) in-gateway stderr monkey-patch that prepends `[YYYY-MM-DDTHH:MM:SS.mmm]` to every write, OR (b) an external host-side capture script that adds timestamps as it tails the per-agent log. Option (a) is more robust; (b) is faster to ship. **This can ship in parallel to an Option-A spike — it doesn't gate other work.**
+1. **Ship the measurement infrastructure**. Without per-line timestamps on `gateway-supervisor.log` (or equivalent OTel/PostHog spans), every optimization claim is unverifiable. Recommend either (a) in-gateway stderr monkey-patch that prepends `[YYYY-MM-DDTHH:MM:SS.mmm]` to every write, OR (b) an external host-side capture script that adds timestamps as it tails the per-agent log. Option (a) is more robust; (b) is faster to ship. **This can ship in parallel to an Option-A spike; it doesn't gate other work.**
 
 2. **Pursue Option A (warmup turn) as the architectural fix**. By reusing cron's `meta.source` envelope (per the Pros above), this is closer to a 1-PR change than originally scoped. The OAuth quota cost is trivial. Lowest blast radius among the four options.
 
@@ -123,7 +124,7 @@ Maintain N hot-standby claude processes per agent slot. On restart, swap to a wa
 
 These can ship without an RFC if measurement supports them:
 
-- **`hotReloadStable: true` as default**. Moves the ~12KB workspace content out of `--append-system-prompt` and into a per-turn UserPromptSubmit hook. Shrinks cold prefix. Schema's own description (`src/config/schema.ts:485`) warns of "5-10% per-turn latency/spend" — that's a steady-state cost, not a correctness risk. Ship measured-on-canary (test-harness for 24h with `runtime-metrics.jsonl` comparison) — blind fleet-wide is harsher than the risk warrants given the kill-switch is a 1-line config flip and 9 production agents would surface a regression within hours.
+- **`hotReloadStable: true` as default**. Moves the ~12KB workspace content out of `--append-system-prompt` and into a per-turn UserPromptSubmit hook. Shrinks cold prefix. Schema's own description (`src/config/schema.ts:485`) warns of "5-10% per-turn latency/spend"; that's a steady-state cost, not a correctness risk. Ship measured-on-canary (test-harness for 24h with `runtime-metrics.jsonl` comparison). Blind fleet-wide is harsher than the risk warrants given the kill-switch is a 1-line config flip and 9 production agents would surface a regression within hours.
 - **Parallelize `start.sh` handoff/briefing** with `&` and a final `wait`. Saves wall-clock if both calls fire (rare in production). ~0.5s expected win.
 - **Pre-warm `workspace render --stable` output** at scaffold time. Cache the rendered bytes to a file; `start.sh` just `cat`s. -0.9s wall-clock.
 
@@ -132,13 +133,13 @@ These can ship without an RFC if measurement supports them:
 1. Anthropic prefix-cache TTL. If it's < 60s, a warmup turn at restart-time may already be cold by the time the user messages. Need to measure or contact Anthropic for the documented value.
 2. Whether `meta.source: "warmup"` should be a first-class envelope field or piggyback on existing `meta: Record<string, string>`. Affects scheduler / autoaccept / mcp-bridge protocol contracts.
 3. Whether the warmup turn should be tagged for Hindsight exclusion (recommend yes) or written into the transcript as a system event (a la cron).
-4. Multi-bridge-reconnect debounce window — gymbro churns ~6 reconnects per UAT cycle. Without debounce, every cycle would warm. With aggressive debounce (e.g., 5 min), a real restart's warmup gets correctly emitted. Recommend cooldown anchored on the most-recent OAuth API call timestamp, not on the warmup itself.
-5. **Where does warmup dedup live?** Cron's fold-in (Phase 4, #890-#893) discovered that `meta.source`-tagged synthetic inbound interacts subtly with the per-agent scheduler's at-least-once boot replay (`SWITCHROOM_AGENT_SCHEDULER_REPLAY_MIN`). The dedup primitive there lives in `src/scheduler/dispatch.ts`'s scheduler-jsonl audit, not in the gateway. Should warmup dedup ride on the same audit log, or invent a separate cooldown store? Recommend riding the audit log — same observability, same disk format, one fewer concept to maintain.
+4. Multi-bridge-reconnect debounce window: gymbro churns ~6 reconnects per UAT cycle. Without debounce, every cycle would warm. With aggressive debounce (e.g., 5 min), a real restart's warmup gets correctly emitted. Recommend cooldown anchored on the most-recent OAuth API call timestamp, not on the warmup itself.
+5. **Where does warmup dedup live?** Cron's fold-in (Phase 4, #890-#893) discovered that `meta.source`-tagged synthetic inbound interacts subtly with the per-agent scheduler's at-least-once boot replay (`SWITCHROOM_AGENT_SCHEDULER_REPLAY_MIN`). The dedup primitive there lives in `src/scheduler/dispatch.ts`'s scheduler-jsonl audit, not in the gateway. Should warmup dedup ride on the same audit log, or invent a separate cooldown store? Recommend riding the audit log: same observability, same disk format, one fewer concept to maintain.
 
 ## Success criteria (post-implementation, future PR)
 
 - First-turn-after-restart TTFO falls from current 5-13s to **under 3s** for at least 80% of operator-initiated restarts.
-- No regression on warm-cache trivial UAT (currently 1.77s) — warmup must not slow steady-state.
+- No regression on warm-cache trivial UAT (currently 1.77s): warmup must not slow steady-state.
 - Quota burn under 1 extra turn per agent per day on the production fleet.
 - Progress-card UX: no visible flash in user chats during warmup (this is the plumbing cost).
 

--- a/reference/rfcs/context-headroom-surface.md
+++ b/reference/rfcs/context-headroom-surface.md
@@ -1,6 +1,7 @@
 ---
-artefact: context-headroom visibility surface
-serves: jobs/restart-and-know-what-im-running.md
+artifact: context-headroom visibility surface
+serves: restart-and-know-what-im-running
+advances-outcome: hold-the-leash
 relates: vision.md (pillar 2 on-leash / pillar 3 predictable)
 ---
 
@@ -8,13 +9,13 @@ relates: vision.md (pillar 2 on-leash / pillar 3 predictable)
 
 Make each agent's working-context occupancy and headroom-to-compaction
 visible in `switchroom status`, `switchroom doctor`, and the web
-dashboard — turning the predictability won by `ENABLE_TOOL_SEARCH=true`
+dashboard, turning the predictability won by `ENABLE_TOOL_SEARCH=true`
 (v0.15.40, ~40% baseline cut) into something the operator can see and
 trust.
 
 ## Why
 
-After v0.15.40 a fresh agent sits at ~47k of a 300k cap — predictable,
+After v0.15.40 a fresh agent sits at ~47k of a 300k cap: predictable,
 but **invisible**. The operator can't see how close an agent is to a
 `/compact`, or catch a context-bloated agent before it stalls mid-task.
 
@@ -22,12 +23,12 @@ but **invisible**. The operator can't see how close an agent is to a
   control, not a tool-call log to babysit."* At-a-glance context headroom
   is exactly that awareness.
 - **Pillar 3 (subscription-honest & predictable).** Makes "the plan is
-  the ceiling" *legible* — you see the ceiling and each agent's distance
+  the ceiling" *legible*: you see the ceiling and each agent's distance
   from it, instead of inferring it.
 - **Pillar 4 (always available).** A near-cap agent is about to compact
   (a visible stall); surfacing the band lets the operator act first.
 
-Serves `jobs/restart-and-know-what-im-running.md` — the "know what's
+Serves `jobs/restart-and-know-what-im-running.md`, the "know what's
 running" awareness job. Crosses no invariant: pure observability.
 
 ## What it surfaces (per agent)
@@ -49,7 +50,7 @@ Example: `marko  context 250k/300k (83% · tight)` · `clerk 47k/300k (16%)`.
 
 The gateway already computes occupancy at the turn-end idle gate for
 proactive-compaction. P1 writes that value (and the resolved cap) to a
-snapshot at `<agentDir>/context-occupancy.json` on every idle pass —
+snapshot at `<agentDir>/context-occupancy.json` on every idle pass,
 crucially **even when no cap is configured** (proactive-compact returns
 early without a cap; the snapshot must not). Host surfaces read the
 snapshot (via `docker exec … cat`, the same way `status` already runs
@@ -71,14 +72,14 @@ gateway already has.
 ## Principle checks
 
 - **Docs test:** `context 47k/300k (16%)` is self-explanatory. ✅
-- **Defaults test:** works on a fresh install — occupancy already exists;
+- **Defaults test:** works on a fresh install: occupancy already exists;
   cap falls back to native (shown as occupancy only). ✅
 - **Consistency test:** same row/section shape as the existing health
   surfaces + the connection-health probe. ✅
 
 ## Non-goals / risk
 
-- Does **not** change compaction behavior — pure observability.
+- Does **not** change compaction behavior; pure observability.
 - No new model calls; reads cached occupancy (no per-turn cost).
 - Read-only; crosses no invariant (claude-native / on-leash /
   single-tenant untouched). Snapshot is best-effort: a missing/stale file

--- a/reference/rfcs/conversational-pacing.md
+++ b/reference/rfcs/conversational-pacing.md
@@ -8,15 +8,15 @@ status: design v2 — the five-beat human-feel model (supersedes v1's card-era p
 
 Switchroom's turn UX is built around one premise: **messaging an agent
 should feel like messaging a capable human.** The chat itself is the
-artifact — framework UI elements (cards, pinned widgets, status bars)
+artifact. Framework UI elements (cards, pinned widgets, status bars)
 only paper over the model failing to communicate. Build the model to
 communicate like a person; let the framework carry ambient liveness
 and the safety net, not the headline.
 
 This is **design v2.** v1 (#1122) retired the pinned progress card and
-declared "the chat is the artifact" — correct — but kept a *card-era*
+declared "the chat is the artifact" (correct) but kept a *card-era*
 pacing instinct ("don't fill silence", "the reaction signals alive",
-"silence is valid"). That was right *while the card existed* — the
+"silence is valid"). That was right *while the card existed*. The
 card carried progress, so a status `reply` was redundant. With no
 card, the same instinct is just a black box. v2 re-founds pacing on
 the five beats below and removes the contradiction.
@@ -33,18 +33,18 @@ These are priorities. Ambient is always on. Conversational does the
 heavy lifting. Safety net only fires when a turn is genuinely stuck.
 
 > **What the safety net used to be (and why it shrank).** Earlier
-> versions of this layer ran a model-targeted *nudge ladder* — an ack
+> versions of this layer ran a model-targeted *nudge ladder*: an ack
 > poke at 10s, a soft poke at 75s, a firm poke at 180s, each appended
-> as a `<system-reminder>` to the next tool result — plus a 60s
+> as a `<system-reminder>` to the next tool result, plus a 60s
 > user-visible *awareness ping*. They were retired (the nudge-ladder
 > retirement PR) for two reasons. (1) **They didn't work by their own
 > KPI:** the `silence_poke_succeeded / silence_poke_fired` rate sat at
-> 0–7% across the fleet against a >80% target — a `<system-reminder>`
+> 0–7% across the fleet against a >80% target. A `<system-reminder>`
 > on a tool result can't reliably make the model stop and talk. (2)
 > **The job moved.** The live-updating reply/draft (the thinking-lane
 > draft that edits in place, see beat-1/beat-3 below and the
 > `sendMessageDraft` transport) now carries the acknowledgement and
-> progress beats natively — the user watches the message compose itself
+> progress beats natively. The user watches the message compose itself
 > rather than waiting for a framework nudge to provoke one. A timer-
 > fired "still working" nudge on top of that is the exact cadence-based
 > update the Anti-patterns section bans. What remains is the one thing
@@ -54,37 +54,37 @@ heavy lifting. Safety net only fires when a turn is genuinely stuck.
 ## The five beats (the prompt teaches this)
 
 Messaging an agent should feel like messaging a capable colleague. The
-model — not a framework widget — carries this, via its own `reply`
+model carries this, not a framework widget, via its own `reply`
 calls, in five beats:
 
 1. **Acknowledge first.** Unless the whole reply is a single short
    sentence to send immediately (*"what's 2+2"*), the first action on
-   any turn is a short `reply` in persona voice — *"on it — checking
-   now"* — before the work starts. The gate is answer length, **not**
+   any turn is a short `reply` in persona voice (*"on it, checking
+   now"*) before the work starts. The gate is answer length, **not**
    whether tools are involved: a turn that is pure reasoning but will
    run to a paragraph still acks first. Skipped only for the immediate
    one-sentence answer.
 2. **Go quiet and work.** Heads-down is correct. No narration of
-   individual tool calls. Ambient liveness — the status reaction and
-   the typing indicator — covers "still alive"; the model does not.
-3. **Surface meaningful progress** at genuine inflection points — a
+   individual tool calls. Ambient liveness (the status reaction and
+   the typing indicator) covers "still alive"; the model does not.
+3. **Surface meaningful progress** at genuine inflection points: a
    hard step done, a blocker, a pivot, a sub-agent dispatched, a
    notably slow wait, a finding worth knowing now. A fresh `reply`,
    `disable_notification: true`. **Human-style prose, never raw tool
-   narration** — *"the migration's running — slow one"*, not *"calling
+   narration.** *"the migration's running, slow one"*, not *"calling
    Bash"* or *"Read(config.ts)"*.
 4. **Hand back delegations with synthesis.** When a sub-agent reports
-   back, the main agent re-enters in its own voice — what the
-   sub-agent found, and the next step — *"reviewer flagged the auth
+   back, the main agent re-enters in its own voice: what the
+   sub-agent found, and the next step. *"reviewer flagged the auth
    gap; fixing it now"*. The sub-agent's raw report is never the
    user-facing reply. A foreground sub-agent's result lands in the
    parent's own turn (a PostToolUse hook nudges the synthesis); a
    *background* worker finishes after the turn ends, so the gateway
    wakes the agent with a `<channel source="subagent_handback">` turn
-   carrying the result. Either way the model owns the prose — the
+   carrying the result. Either way the model owns the prose; the
    framework only delivers the cue.
 5. **Deliver the answer** as a fresh `reply` (omit
-   `disable_notification` — pings the device once).
+   `disable_notification`, pings the device once).
 
 The single guardrail is **anti-spam, not pro-silence**: no reply per
 tool call, no cadence timer, no repeating yourself. Responsive and
@@ -94,7 +94,7 @@ of* a real milestone (beats 3–4) is the black box this prevents.
 
 ## Silence-poke fallback
 
-The framework backstops the model with **one timer** — no ladder. State
+The framework backstops the model with **one timer**, no ladder. State
 per-turn: `{ turnStartedAt, lastOutboundAt, lastThinkingAt,
 fallbackFired, inFlightTools }`. Polled every 5s.
 
@@ -102,23 +102,23 @@ fallbackFired, inFlightTools }`. Polled every 5s.
 |---|---|---|
 | 300s | Framework fallback: gateway **unwedges the turn** (clears `activeTurnStartedAt`, nulls `currentTurn`, drains buffered inbound). The generic *"still working… (no update from agent in N min)"* / *"still thinking…"* stall message is **no longer sent** — it was a stop-gap from before the live-updating draft carried the progress beats natively, and is the exact cadence-based "still working" update the Anti-patterns section bans (retired in the stall-stop-gap PR). The fallback now sends a user-visible message in only two honest cases: an in-flight `update_apply` carries hostd's real phase/elapsed, or the turn is parked on an approval card (the loud *"waiting for your approval — tap Approve or Deny…"* re-ping). The `silence_poke_fire` event is still logged regardless, so observability + the wedge accounting are unchanged. | `silencePoke.startTimer.onFrameworkFallback` callback |
 
-The fallback fires purely on the silence clock — `now -
-(lastOutboundAt ?? turnStartedAt) >= 300s` — and once per turn
+The fallback fires purely on the silence clock (`now -
+(lastOutboundAt ?? turnStartedAt) >= 300s`) and once per turn
 (`fallbackFired`). It is **not a nudge**: it does not append a
 `<system-reminder>` hoping the model will speak; it speaks *for* the
-framework (only when there's something honest to say — see the two
+framework (only when there's something honest to say, see the two
 cases above) and breaks the wedge. That unwedge is the one job the
 live-updating draft genuinely can't do (a turn that produced no
 output at all has no draft to watch), which is why this single beat
 survived the nudge-ladder retirement (see the blockquote under "Three
-layers"). Any outbound — including the draft's first edit — resets the
+layers"). Any outbound, including the draft's first edit, resets the
 clock, so a turn that's visibly composing never trips it.
 
 **Thinking detection:** session stream `kind: 'thinking'` events
 update `lastThinkingAt`. If the framework fallback fires within 30s
 of a thinking event, wording switches to *"still thinking…"*.
 
-**Tool-aware enrichment (#1292) — retired with the stall notice.** The
+**Tool-aware enrichment (#1292), retired with the stall notice.** The
 gateway still tracks in-flight tools in `inFlightTools`
 (`noteToolStart` / `noteToolEnd` / `noteToolLabel` off the session
 stream) for metrics, but the *"running Grep \"foo\" for 4m"* enrichment
@@ -130,7 +130,7 @@ Tool churn never moved the 300s timing and still doesn't.
 `silence-poke.ts:formatFrameworkFallbackText`, which now returns `null`
 for every stall variant (the stop-gap is retired) and a string only for
 the approval-blocked re-ping. The parenthetical *"(N min)"* on that
-re-ping is honest — N is derived from `ctx.silenceMs`, not hard-coded.
+re-ping is honest. N is derived from `ctx.silenceMs`, not hard-coded.
 
 **Kill switch:** `SWITCHROOM_DISABLE_SILENCE_POKE=1` disables the
 whole subsystem. The conversational-pacing prompt still applies; only
@@ -150,7 +150,7 @@ the runtime-metrics events documented in `docs/posthog.md`:
 
 A `Switchroom Runtime` PostHog dashboard tracks these four. Wire-up
 documented in `docs/posthog.md`. (The retired
-`silence_poke_succeeded / silence_poke_fired` ratio is gone — the
+`silence_poke_succeeded / silence_poke_fired` ratio is gone. The
 nudge ladder it measured no longer exists; the surviving fallback is
 metered only by its *fire* rate, which is meant to stay near zero.)
 
@@ -160,7 +160,7 @@ metered only by its *fire* rate, which is meant to stay near zero.)
   pull, but always devolves into either redundant noise or implicit
   safety-net. Use the chat.
 - Narrating every tool call as a `reply`, **or** narrating with raw
-  tool names. Beat 3 is human-style prose at real inflection points —
+  tool names. Beat 3 is human-style prose at real inflection points,
   not a message per call, and never *"calling Grep"* / *"Read(x)"*.
   Ambient liveness handles "alive"; the chat is for *information*.
 - Mid-turn updates that ping. `disable_notification: true` is free; use it.
@@ -175,7 +175,7 @@ metered only by its *fire* rate, which is meant to stay near zero.)
 
 - The status-reaction lifecycle could simplify from 4 intermediate
   states (`thinking/tool/code/done`) to 2 (`alive / done`) since the
-  intermediate phases are now less load-bearing — but the cost of
+  intermediate phases are now less load-bearing, but the cost of
   keeping the full lifecycle is essentially zero. Defer.
 - A `/lasttrace` Telegram command for power users who want the
   technical receipt (tool calls, durations) on demand. Hindsight

--- a/reference/rfcs/deploy-reliability.md
+++ b/reference/rfcs/deploy-reliability.md
@@ -1,5 +1,5 @@
 ---
-artefact: fleet deploy reliability
+artifact: fleet deploy reliability
 backs: always-available
 relates: reference/rfcs/host-control-daemon.md
 ---
@@ -19,7 +19,7 @@ source.
 **Root cause (2026-06-23 outage, 5 h fleet-down):** a v0.15.56 upgrade
 ran inside a helper container (`HOME=/state/agent/home`,
 `SWITCHROOM_HOST_HOME` unset). The compose generator fell back to
-`homedir()` — the *container* HOME — and baked that path as the leading
+`homedir()`, the *container* HOME, and baked that path as the leading
 segment of every host bind-mount source. Docker's behaviour when a `:ro`
 bind source doesn't exist: **silently auto-creates it as a root-owned
 directory**. Consequences:
@@ -42,7 +42,7 @@ sailed through it.
 **The general class:** any deploy context that resolves the host home
 from the container's ambient `HOME` (or any other in-container
 filesystem root) and bakes it into compose bind-mount sources. Docker
-never hard-fails on a missing `:ro` source — it auto-creates, and
+never hard-fails on a missing `:ro` source. It auto-creates, and
 the auto-created artifact is always a root-owned directory, never the
 file or populated directory the container expected.
 
@@ -67,15 +67,15 @@ writable or leaves `SWITCHROOM_HOST_HOME` unset.
 
 `src/agents/compose.ts:assertPlausibleHostHome` is called at compose
 **generation time** with the `homePrefix` that will be baked into every
-bind-mount source. It maintains `CONTAINER_ROOT_PREFIXES` — a list of
+bind-mount source. It maintains `CONTAINER_ROOT_PREFIXES`, a list of
 in-container filesystem roots (`/state`, `/run`, `/proc`, `/sys`,
-`/dev`, `/tmp`, `/host-home`) — and throws on any prefix that is or
+`/dev`, `/tmp`, `/host-home`), and throws on any prefix that is or
 starts with one of those, AND on any non-absolute path. The only
 pass-through besides a real host path is the legacy `${HOME}` literal
 (resolved by Docker at `up` time on the host, never by the generator).
 
 This generalises the old `/host-home`-only guard to the whole class.
-It fires before any file is written — the fleet is never poisoned.
+It fires before any file is written, so the fleet is never poisoned.
 
 ### 2. Fail-closed resolver — `resolveHostHomeForCompose`
 
@@ -86,12 +86,12 @@ strictly fail-closed:
 1. `SWITCHROOM_HOST_HOME` set and non-empty → validate via
    `assertPlausibleHostHome`, use it. (The blessed path.)
 2. Running inside a container + `SWITCHROOM_HOST_HOME` unset → **THROW**.
-   Never falls back to `homedir()` (the container HOME — the poison).
+   Never falls back to `homedir()` (the container HOME, the poison).
 3. Running on the host shell + `SWITCHROOM_HOST_HOME` unset → `homedir()`.
    Safe because `homedir()` on the host shell IS the real operator home.
 
 The same resolver governs the mount-source seeder in `apply.ts` that
-creates any missing host-side bind-source directories — so that path
+creates any missing host-side bind-source directories, so that path
 can't silently create them under a container root either.
 
 ### 3. Sudo self-elevation env preservation
@@ -101,7 +101,7 @@ truth for env vars passed across the `sudo` boundary. It explicitly
 includes `SWITCHROOM_HOST_HOME` (and `SWITCHROOM_HOSTD_CONTEXT`).
 Without this, the blessed value set by the caller would be stripped by
 sudo's secure environment and the resolver would fall through to
-`homedir()` — which, under sudo, is `/root`, not the operator home.
+`homedir()`, which under sudo is `/root`, not the operator home.
 
 ### 4. Pre-flight bind-source validator — `preflight-mounts.ts`
 
@@ -110,7 +110,7 @@ compose file's host bind sources and `stat`s each one before `docker
 compose up` is called. A source that is:
 
 - **missing** → abort (would be auto-created by Docker)
-- **wrong type** (a file where a dir is expected, or vice versa — the
+- **wrong type** (a file where a dir is expected, or vice versa, the
   exact signature of a prior auto-dir poisoning) → abort
 
 This is the last-resort catch: even if the generation guard and
@@ -148,7 +148,7 @@ docker run --rm \
 ```
 
 bypasses all of them: the container has no `SWITCHROOM_HOST_HOME`,
-`isContainerContext()` returns true, and the CLI throws — but only if
+`isContainerContext()` returns true, and the CLI throws, but only if
 the script is using a version of switchroom that has this fix. A
 pre-fix image would silently poison the host.
 

--- a/reference/rfcs/doc-connection-completion.md
+++ b/reference/rfcs/doc-connection-completion.md
@@ -1,12 +1,13 @@
 ---
-artefact: make Google Drive a real collaboration surface
-serves: jobs/act-in-my-tools-with-an-identity.md
+artifact: make Google Drive a real collaboration surface
+serves: act-in-my-tools-with-an-identity
+advances-outcome: always-available
 status: Draft v3 — implementation pivot in §4.2
 ---
 
 # RFC E: Make Google Drive a real collaboration surface
 
-Status: Draft v3 (v3.1 amendment 2026-05-15 — implementation pivot in §4.2)
+Status: Draft v3 (v3.1 amendment 2026-05-15, implementation pivot in §4.2)
 Author: Ken (with Claude pair-design)
 Date: 2026-05-14
 
@@ -19,10 +20,10 @@ Date: 2026-05-14
   ship as designed. See §4.2's pivot banner for the full delta.
 
 **v3 changes** (addressing PR #1227 review):
-- §3 dropped `extend-without-forking` JTBD claim (overstated — that JTBD is about adding new agents/skills/tools, not config-surface affordances inside an existing integration).
+- §3 dropped `extend-without-forking` JTBD claim (overstated: that JTBD is about adding new agents/skills/tools, not config-surface affordances inside an existing integration).
 - §4.5 added a third anchor primitive: text-snippet anchor (`after_line_containing: "..."` resolved by wrapper). Covers the 80% of real-world meeting-notes / draft-prose docs that have no headings without forcing a "agent must add headings first" hard contract.
 - §4.2 hardened the diff-preview against intent-lies (not just size-lies): wrapper-attested anchor name appears on the primary card, agent-supplied summary appears below it. User has wrapper truth to sanity-check the agent's framing against.
-- §6.3 added explicit acknowledgment that approval cards are the existing exception to the "chat IS the artifact" sub-principle, per RFC B §8.1 — preempt the next reviewer re-litigating it.
+- §6.3 added explicit acknowledgment that approval cards are the existing exception to the "chat IS the artifact" sub-principle, per RFC B §8.1, to preempt the next reviewer re-litigating it.
 - §9 added two risks: anchor-fragmentation (covered in §4.5 expansion) + summary-lies-about-intent variant.
 
 Prerequisites — both shipped:
@@ -39,7 +40,7 @@ once the Drive collab loop is real.
 
 A user can give an agent a Google Doc, ask it to draft into the doc,
 review the agent's changes inline in Drive, and resume the
-conversation in Telegram — all without leaving the
+conversation in Telegram, all without leaving the
 phone-or-laptop-they-already-have-open. The agent is a collaborator
 on the user's docs, not a one-shot reader-and-summarizer.
 
@@ -101,7 +102,7 @@ Maps to three of the four outcomes in `reference/vision.md`:
   un-trashes mid-week doesn't leave the agent stuck.
 
 Visibility (#1) is served by the existing approval card UX from RFC
-D plus the new diff-preview surface in §4.2 — the user always sees
+D plus the new diff-preview surface in §4.2. The user always sees
 what the agent is about to do *before* it touches their doc.
 
 ## 3. JTBD alignment
@@ -109,19 +110,19 @@ what the agent is about to do *before* it touches their doc.
 - **`share-auth-across-the-fleet.md`** — Drive OAuth = once per
   Google account. Adding a second agent that needs the same Drive
   doesn't re-prompt; the cascade resolves the shared vault slot.
-  (Note: this JTBD is the load-bearing one for **RFC G** — RFC E
+  (Note: this JTBD is the load-bearing one for **RFC G**. RFC E
   inherits its OAuth posture but doesn't drive that JTBD by itself.)
 - **`talk-to-agents-from-anywhere.md`** — Folder browsing, write
   approvals with diff preview, deep-link to Drive, reconnect-on-
-  token-revocation — every step is reachable from a phone. The
+  token-revocation, every step is reachable from a phone. The
   headless OAuth tier from RFC D §3.2 covers initial connect;
   nothing else needs a desktop browser.
 - **`know-what-my-agent-is-doing.md`** — The diff-preview-before-
   write pattern is the JTBD's "see every step" applied to mutations.
   The user never finds out the agent edited a doc by re-opening it
   later. The wrapper-attested anchor name on the diff-preview card
-  (§4.2) is the load-bearing detail that makes this JTBD honest —
-  without it, "see every step" reduces to "see whatever the agent
+  (§4.2) is the load-bearing detail that makes this JTBD honest.
+  Without it, "see every step" reduces to "see whatever the agent
   chose to summarize."
 
 ## 4. Scope — five pieces, all Drive
@@ -134,7 +135,7 @@ worse than either default and explicitly punted.
 
 **Design:**
 
-- New CLI verb: `switchroom drive folders <agent>` — does *not*
+- New CLI verb: `switchroom drive folders <agent>`. Does *not*
   render in the terminal. Posts a card in the agent's Telegram
   topic.
 - Card surface: paginated folder list, top-level first, breadcrumb
@@ -144,7 +145,7 @@ worse than either default and explicitly punted.
   standard granted-card confirmation (with `· /approvals revoke
   <id>` inline per RFC B §9).
 - The same picker is reachable from inside an in-flight per-doc
-  approval card via a new `[ 📁 Allow folder instead ]` button —
+  approval card via a new `[ 📁 Allow folder instead ]` button,
   the primary mitigation for the prompt-flood path RFC D §5 warns
   about.
 - Listing source: `files.list` with
@@ -163,7 +164,7 @@ trees (>100 top-level folders) are common. Ship paginated on day 1.
 > **Implementation pivot — Path A Cut 2 (2026-05-15).** §4.2 as
 > originally specified assumed switchroom would ship its own MCP
 > wrapper exposing `gdrive_suggest_edit` / `gdrive_apply_edit` /
-> `gdrive_create_doc` / `gdrive_append_to_doc` — purpose-built so the
+> `gdrive_create_doc` / `gdrive_append_to_doc`, purpose-built so the
 > wrapper could default writes to Drive's Suggesting mode and pre-
 > resolve every anchor before posting the diff-preview card.
 >
@@ -176,9 +177,9 @@ trees (>100 top-level folders) are common. Ship paginated on day 1.
 > `create_table_with_data`, `update_doc_headers_footers`,
 > `update_paragraph_style`, `manage_doc_tab`) and **no Suggesting
 > mode** at all. Building our own wrapper to add Suggesting was
-> scoped out — the upstream MCP is already shipped, our agents
+> scoped out. The upstream MCP is already shipped, our agents
 > already use it, and forking it would mean carrying the diff
-> indefinitely.
+> forever.
 >
 > The chosen mechanism is a **Claude Code PreToolUse hook**
 > registered against `^mcp__google-workspace__` write tools. The
@@ -186,8 +187,8 @@ trees (>100 top-level folders) are common. Ship paginated on day 1.
 > `documents.get`), builds the wrapper-attested diff preview,
 > requests an approval through the kernel + gateway, polls until
 > the user taps Allow/Cancel, and returns `{decision:"block"}` if
-> denied. Same trust boundary as the §4.2 design — the wrapper still
-> attests the anchor + metrics — but no Suggesting affordance.
+> denied. Same trust boundary as the §4.2 design (the wrapper still
+> attests the anchor + metrics), but no Suggesting affordance.
 >
 > **What this preserves from §4.2:**
 > - Wrapper-attested anchor name on the diff-preview card (`📍`
@@ -200,13 +201,13 @@ trees (>100 top-level folders) are common. Ship paginated on day 1.
 >
 > **What this does NOT preserve:**
 > - Suggesting as the default. Every gated write is a direct write
->   when applied — agents have no way to propose a non-destructive
+>   when applied. Agents have no way to propose a non-destructive
 >   suggestion. (User can still revert via Drive's version history.)
 > - Two-button "Apply as suggestion" + "Apply directly" affordance.
 >   The card shows Allow / Cancel only.
 > - `doc:gdrive:suggest:*` scope namespace. Only `doc:gdrive:write:*`
 >   is wired up. Agents already holding a `read` grant can attempt
->   writes — each one prompts.
+>   writes, each one prompts.
 > - `gdrive_apply_edit` / `gdrive_create_doc` / `gdrive_append_to_doc`
 >   as named tools. Agents use the upstream tool names directly.
 >
@@ -215,7 +216,7 @@ trees (>100 top-level folders) are common. Ship paginated on day 1.
 > write methods (load-bearing diff to maintain; rejected for now);
 > (b) shipping a thin switchroom wrapper MCP that re-exports the
 > upstream tools with Suggesting-by-default behavior (still
-> requires the underlying Docs API to expose Suggesting — it does
+> requires the underlying Docs API to expose Suggesting, which it does
 > via `suggestionsViewMode` on read, but for write, the API only
 > creates `Suggestions` if the requesting Drive account is not the
 > doc owner; agent-owned docs would still apply directly).
@@ -224,7 +225,7 @@ trees (>100 top-level folders) are common. Ship paginated on day 1.
 > into #1316), **#1316** (Docs API client + write-preview spec
 > builder), **#1318** (gateway IPC verb posting the diff-preview
 > card), **#1319** (PreToolUse hook + scaffold registration).
-> Card UX (no separate suggest/write modes — Allow/Cancel only) is
+> Card UX (no separate suggest/write modes, Allow/Cancel only) is
 > a v0.10.x decision, not the long-term RFC E §4.2 contract.
 
 **Today:** read-only by design. RFC D §12 stipulates writes need
@@ -233,7 +234,7 @@ a write.
 
 **Why "Suggesting" is the default, not direct write:** Drive has a
 first-class Suggesting mode (the same one human collaborators use).
-Suggestions are non-destructive — the user reviews and accepts them
+Suggestions are non-destructive: the user reviews and accepts them
 in Drive's UI just like a peer's edit. **Defaulting to Suggesting
 mode is the difference between "agent writes to my doc" (scary) and
 "agent proposes edits I review" (collaboration).** Direct writes
@@ -272,7 +273,7 @@ edits, etc.).
   - **Wrapper-attested anchor name** sits on its own line above the
     diff metrics, prefixed `📍`. The wrapper has just resolved the
     anchor (per §4.5) so it knows the actual heading / line-snippet
-    / position the edit will land at — and surfaces it independently
+    / position the edit will land at, and surfaces it independently
     of whatever the agent says in its summary. This is the
     load-bearing detail that makes the JTBD `know-what-my-agent-is-
     doing` honest for mutations: even if the agent's summary says
@@ -283,13 +284,13 @@ edits, etc.).
     wrapper computes these from the proposed edit relative to the
     current doc state. Agent cannot lie about size.
   - **Agent-supplied summary** (`💬 "..."`) is the agent's
-    explanation of *why*, not *what* — the wrapper-attested anchor
+    explanation of *why*, not *what*. The wrapper-attested anchor
     and metrics already cover *what*. Audit row stores both for
     post-hoc review of agent intent vs. wrapper truth.
-  - Primary action is **Apply as suggestion** — single tap, lands
+  - Primary action is **Apply as suggestion**: single tap, lands
     as a Drive Suggestion the user reviews in Drive's UI.
   - **Apply directly** is a secondary, badged with `⚠`. Standing
-    direct-write grants are opt-in via expand only — never on the
+    direct-write grants are opt-in via expand only, never on the
     primary card row.
   - **Open in Drive** is always present. See §4.3.
 - Audit row records `action: suggest` or `action: write` so
@@ -304,7 +305,7 @@ edits, etc.).
 
 **Today:** every reference to a doc in chat is a title; the user
 has to find the doc themselves to look at it. Breaks the collab
-loop — the user can't tap from "agent edited X" to "let me see X."
+loop. The user can't tap from "agent edited X" to "let me see X."
 
 **Design:**
 
@@ -319,7 +320,7 @@ loop — the user can't tap from "agent edited X" to "let me see X."
   `?disco=<thread_id>` on the URL when Drive's API exposes a
   discussion thread for the proposed edit, so the link lands the
   user directly on the suggestion they're reviewing.
-- No new permission needed — these are the same shareable URLs the
+- No new permission needed. These are the same shareable URLs the
   user would copy from Drive's "Share" dialog.
 
 ### 4.4 Reconciler missing→present recovery (deferred from RFC D §12) — Phase 1
@@ -333,16 +334,16 @@ week even after the user fixes it.
 **Why it's promoted from "Phase 4 cleanup" to Phase 1:** in a
 collab loop the missing→present transition is *common*. The user
 trashes their draft, asks the agent to start over, un-trashes the
-original to compare — they expect both versions to be live for the
+original to compare. They expect both versions to be live for the
 agent.
 
-**Design:** trivial extension of `src/drive/reconciler.ts` —
+**Design:** trivial extension of `src/drive/reconciler.ts`:
 
 - When a missing-state grant transitions back to Present on its
   next scheduled check, write a `recover` row to `approval_audit`
   and surface a `[ ↻ Re-enabled ]` line in the next staleness
   digest + a one-line nudge in the agent's chat:
-  *"↻ 'Q3 Strategy Notes' is back — let me know if you want me to
+  *"↻ 'Q3 Strategy Notes' is back, let me know if you want me to
   pick up where I left off."*
 - No retro-active state-management. No automatic re-trigger of the
   scheduled task. Just don't *hide* the recovery from the user.
@@ -366,7 +367,7 @@ shifts.
    ambiguous), the first match wins; agent can disambiguate by
    adding `level` or `nth_match`.
 
-2. **Text-snippet anchor** (covers unheaded docs — meeting notes,
+2. **Text-snippet anchor** (covers unheaded docs: meeting notes,
    draft prose, the long tail):
    ```
    anchor: { after_line_containing: "we agreed to ship by Q3" }
@@ -377,7 +378,7 @@ shifts.
    matching the snippet (case-insensitive substring by default;
    regex if the value is a `RegExp`-shaped object). If multiple
    matches, the agent gets `MULTIPLE_MATCHES` with the first 3
-   surrounding-context excerpts and must pick one — no "first
+   surrounding-context excerpts and must pick one. No "first
    wins" silent guess for snippets, because the user can't
    visually verify which match the agent meant.
 
@@ -401,7 +402,7 @@ shifts.
   **resolved anchor name** that gets surfaced on the diff-preview
   card per §4.2 (e.g. `'Goals' (heading)` or `line 47: "we agreed
   to ship by Q3"` or `at end of doc`). This is the
-  wrapper-attested anchor the user sees — the agent cannot
+  wrapper-attested anchor the user sees. The agent cannot
   override it.
 
 ## 5. Out of scope (this spec)
@@ -436,7 +437,7 @@ Per `reference/principles.md`, applied to this spec:
 - ✅ `switchroom drive folders klanker` posts a card with inline
   guidance. No prerequisite reading.
 - ✅ Approval card copy explains the suggestion vs direct-write
-  trade-off in one line — no glossary needed.
+  trade-off in one line, no glossary needed.
 - ✅ `[ 📖 Open in Drive ]` is self-explanatory. Tap → doc opens.
 - ✅ Anchor-resolution errors give the user a next step
   (*"Want me to suggest a heading-by-heading rewrite?"*).
@@ -459,7 +460,7 @@ Per `reference/principles.md`, applied to this spec:
 - ✅ Same `vault:gdrive:*` slot pattern (no new vault concepts).
 - ✅ Same approval card states (pristine / expanded / granted /
   denied / expired) — RFC B §8.1.
-- ✅ Same `/approvals list|revoke|add|stats` surface — adding
+- ✅ Same `/approvals list|revoke|add|stats` surface: adding
   `suggest` and `write` action types adds rows, not commands.
 - ✅ Same headed-doc model the user already lives in for any Drive
   doc; agent anchors mean what they look like they mean.
@@ -475,7 +476,7 @@ doesn't have to re-litigate:
 > Approval cards are the existing exception per RFC B §8.1. The
 > rule is "build the model to communicate; let the framework be
 > the safety net, not the headline." Approvals are the framework
-> safety net for **mutations under operator authorization** —
+> safety net for **mutations under operator authorization**:
 > they're the one place where the chat alone can't carry the
 > semantic weight (a tap is structurally different from a
 > message). The diff-preview card in §4.2 is the same primitive
@@ -485,7 +486,7 @@ doesn't have to re-litigate:
 > existing card, not a separate widget. If the user taps "Apply
 > directly" repeatedly the model can still narrate ("you've
 > approved 6 direct writes today, want me to suggest instead?")
-> in chat — the card never replaces the chat as the source of
+> in chat. The card never replaces the chat as the source of
 > truth.
 
 ## 7. Migration / rollout
@@ -502,8 +503,8 @@ Substructure for sequencing within the phase:
 3. **1c — Suggesting writes + diff preview (§4.2).** The headline
    feature. Lands on top of the anchor primitive and the
    Open-in-Drive button.
-4. **1d — Reconciler recovery (§4.4).** Lowest-effort, ships last
-   — useful but not blocking the headline collab loop.
+4. **1d — Reconciler recovery (§4.4).** Lowest-effort, ships last,
+   useful but not blocking the headline collab loop.
 
 Phase 2+ (Notion as second surface, framework extraction, broader
 doc surfaces) lives in a follow-up RFC and is explicitly out of
@@ -531,13 +532,13 @@ shippable as four PRs (1a, 1b, 1c, 1d) for incremental review.
 ## 9. Risks and open questions
 
 - **Drive's Suggestions API has gaps.** Some operations (creating
-  a doc, pure append) have no Suggesting equivalent — those stay
+  a doc, pure append) have no Suggesting equivalent. Those stay
   on the direct `write` scope. Document this clearly in the agent-
   facing tool descriptions so the agent picks the right tool.
 - **Anchor type selection by the agent.** Three anchor types in
   §4.5 (heading / snippet / position) means the agent has to pick
   the right one. Wrong pick = `*_NOT_FOUND` error and a wasted
-  tool call, not user-visible damage — but it does add a class of
+  tool call, not user-visible damage, but it does add a class of
   agent confusion. Mitigation: prompt-pack guidance + tool
   descriptions explicitly call out the priority order (try
   heading first, fall back to snippet, position only for
@@ -555,8 +556,8 @@ shippable as four PRs (1a, 1b, 1c, 1d) for incremental review.
   collab loop; not a blocker.
 - **Diff preview — size lies and intent lies, separately
   defended.** Two distinct attacks on the diff-preview card:
-  (a) *size lie* — agent claims `+5 lines` for a 47-line change;
-  (b) *intent lie* — agent's summary says "Added Hiring section"
+  (a) *size lie*: agent claims `+5 lines` for a 47-line change;
+  (b) *intent lie*: agent's summary says "Added Hiring section"
   but the edit lands in Goals. Mitigation: §4.2 surfaces both
   the wrapper-attested anchor name (`📍 after heading 'Goals'`)
   and the wrapper-attested line counts (`+47 / -0 lines`)
@@ -571,11 +572,11 @@ shippable as four PRs (1a, 1b, 1c, 1d) for incremental review.
 - **Open-in-Drive auth assumption.** The deep-link assumes the
   user is logged into Google in their browser/app on the device
   they tap from. If they're not, Drive's own login flow handles it
-  — not our problem, but the link doesn't pre-validate.
+  (not our problem), but the link doesn't pre-validate.
 - **Discoverability of Suggesting vs Write.** A user who taps
   `Apply directly` once might not realise Suggesting was the safer
   default. After 3 direct-applies in a 24h window, surface a
-  one-time tip: *"You're approving direct writes a lot — want to
+  one-time tip: *"You're approving direct writes a lot, want to
   set 'always suggest' as the default for this doc?"*
 
 ## 10. Tracking

--- a/reference/rfcs/docker-multi-container.md
+++ b/reference/rfcs/docker-multi-container.md
@@ -1,6 +1,7 @@
 ---
-artefact: One container per agent + docker compose (shipped RFC)
-serves: jobs/give-each-agent-its-own-workspace.md
+artifact: One container per agent + docker compose (shipped RFC)
+serves: give-each-agent-its-own-workspace
+advances-outcome: standing-team
 title: One container per agent + docker compose
 status: Shipped
 shippedIn: v0.7
@@ -22,7 +23,7 @@ then `switchroom setup`, then `switchroom apply && docker compose pull
 && docker compose up -d --remove-orphans`. Seven published GHCR images
 (`switchroom-base`, `switchroom-agent`, `switchroom-broker`,
 `switchroom-kernel`, `switchroom-auth-broker`, `switchroom-hostd`,
-`switchroom-hindsight`) — no `docker build` on the operator's host. The
+`switchroom-hindsight`), no `docker build` on the operator's host. The
 singleton `switchroom-scheduler` container described later in this RFC
 was retired in PR #893 (Phase 4 cron-fold-in); cron now runs in-container
 in every agent as a sibling of the gateway. See `docs/scheduling.md`.
@@ -51,7 +52,7 @@ current state of the codebase. For the current operator surface see
 
 ## Summary
 
-Switchroom today is a Linux-only host install. Multi-OS reach is the point of #793 and Docker is the obvious substrate. This RFC picks Option 3 from the comparison: **one container per agent, plus a small set of shared-service containers (vault broker, approval kernel, telegram bridge), all wired together by a generated `docker-compose.yml`**. The user-visible end state is `switchroom setup` produces a compose file, `docker compose up -d` brings the fleet alive, and the README install path is one block of shell on Linux and Mac. Windows-WSL2, Synology, Unraid, and RasPi work in principle on the same compose file, but they aren't formally validated for v1.0 — best-effort, community-tested, no support promise. The host-native install stays supported on Linux alongside Docker. Both deliver the same product promise.
+Switchroom today is a Linux-only host install. Multi-OS reach is the point of #793 and Docker is the obvious substrate. This RFC picks Option 3 from the comparison: **one container per agent, plus a small set of shared-service containers (vault broker, approval kernel, telegram bridge), all wired together by a generated `docker-compose.yml`**. The user-visible end state is `switchroom setup` produces a compose file, `docker compose up -d` brings the fleet alive, and the README install path is one block of shell on Linux and Mac. Windows-WSL2, Synology, Unraid, and RasPi work in principle on the same compose file, but they aren't formally validated for v1.0: best-effort, community-tested, no support promise. The host-native install stays supported on Linux alongside Docker. Both deliver the same product promise.
 
 ## Motivation
 
@@ -59,11 +60,11 @@ The host-native model has carried us a long way. It also carries weight we keep 
 
 ### Klanker takes the fleet down with it
 
-A claude REPL is not a small process. RSS sits 150-300MB idle and spikes hard during long tool loops. Klanker (Opus 4.7, agentic, often dispatching parallel sub-agents) is the canonical OOM offender. When the host kernel reaps it, anything else co-resident with it on the same box is in the blast radius — either because the OOM killer wandered into a neighbour, or because the swap thrash before the kill stalled every other agent's response. We don't have observed cross-agent OOM kills in the audit log yet, but we have observed multi-second response stalls during klanker's heavy sub-agent fan-outs. Per-agent cgroup limits are the right answer. Today they aren't first-class — we'd have to hand-roll `MemoryMax=` into each unit and pick a number per agent. With one container per agent, `mem_limit` is one line in compose and the kernel does the enforcement.
+A claude REPL is not a small process. RSS sits 150-300MB idle and spikes hard during long tool loops. Klanker (Opus 4.7, agentic, often dispatching parallel sub-agents) is the canonical OOM offender. When the host kernel reaps it, anything else co-resident with it on the same box is in the blast radius, either because the OOM killer wandered into a neighbour, or because the swap thrash before the kill stalled every other agent's response. We don't have observed cross-agent OOM kills in the audit log yet, but we have observed multi-second response stalls during klanker's heavy sub-agent fan-outs. Per-agent cgroup limits are the right answer. Today they aren't first-class. We'd have to hand-roll `MemoryMax=` into each unit and pick a number per agent. With one container per agent, `mem_limit` is one line in compose and the kernel does the enforcement.
 
 ### Multi-OS install is the wedge and we're losing it
 
-`install.sh` is 133 lines of Linux. Mac users have to bring Lima or UTM. Windows users have to bring WSL2 first and then fight systemd-in-WSL. Both work, neither is one-click. The product principle "if they need the docs, we've failed" (`reference/principles.md` §1) is not currently met for non-Linux users — they need the docs before they can even start. Docker fixes that. `docker compose up -d` is the same line on every host that runs Docker, which is every host worth shipping to.
+`install.sh` is 133 lines of Linux. Mac users have to bring Lima or UTM. Windows users have to bring WSL2 first and then fight systemd-in-WSL. Both work, neither is one-click. The product principle "if they need the docs, we've failed" (`reference/principles.md` §1) is not currently met for non-Linux users. They need the docs before they can even start. Docker fixes that. `docker compose up -d` is the same line on every host that runs Docker, which is every host worth shipping to.
 
 ### `bin/bridge-watchdog.sh` is 967 lines of bash and the grace windows are cranked to "effectively never"
 
@@ -71,23 +72,23 @@ The watchdog's job is to detect a wedged agent and bounce it. The current implem
 
 ### Per-agent resource isolation is missing
 
-`MemoryMax`, `CPUQuota`, `IOWeight` are systemd-unit-level knobs. We don't set them today. We could. We won't, because tuning them by hand per agent on a host with a shared kernel is the wrong abstraction — the right abstraction is "this agent gets this slice of the box." Compose makes that one line per service and Docker enforces it.
+`MemoryMax`, `CPUQuota`, `IOWeight` are systemd-unit-level knobs. We don't set them today. We could. We won't, because tuning them by hand per agent on a host with a shared kernel is the wrong abstraction. The right abstraction is "this agent gets this slice of the box." Compose makes that one line per service and Docker enforces it.
 
 ### What's actually changing for users
 
 PR #796 already landed the positioning shift this RFC implements: switchroom's product promise is the JTBD outcomes, not the substrate. Long-running service per agent, survives reboots, auto-recovery with audit trail, per-agent isolated logs, OAuth under your existing subscription, stock `claude` CLI. None of those say "systemd" and none of them say "Docker." The substrate is an internal engineering detail.
 
-The user-visible change is reach, tiered. Today switchroom installs cleanly on Linux only. After this RFC, the supported install targets for v1.0 are **Linux and Mac** — same product promise on both. Windows-WSL2, Synology, Unraid, and RasPi run on the same architecture and compose file and are expected to work; they just aren't formally validated or release-gated. Operators on those platforms can install and most things will work; what they don't get is a "we tested this and signed it off" stamp. The architecture supports them; the test/release matrix is the thing that's tiered. Whether the agent runs under a systemd unit or a Docker container is the CLI's problem, not the user's.
+The user-visible change is reach, tiered. Today switchroom installs cleanly on Linux only. After this RFC, the supported install targets for v1.0 are **Linux and Mac**, same product promise on both. Windows-WSL2, Synology, Unraid, and RasPi run on the same architecture and compose file and are expected to work; they just aren't formally validated or release-gated. Operators on those platforms can install and most things will work; what they don't get is a "we tested this and signed it off" stamp. The architecture supports them; the test/release matrix is the thing that's tiered. Whether the agent runs under a systemd unit or a Docker container is the CLI's problem, not the user's.
 
 **"Community-tested / best-effort" defined operationally.** Issues filed against best-effort platforms get the `platform:best-effort` label and are accepted but not release-blocking; bug reports are welcome, fixes via PR are welcome, but maintainers make no commitment to reproduce on those platforms or to gate releases on their state. Linux (and Mac under the default ship plan) get the inverse: maintainer-reproduced, release-gated, regressions block ship.
 
-**JTBD narrowing acknowledged.** v1.0 narrows the "runs on the box you already have" claim to Linux + Mac boxes. Synology / Unraid / RasPi / Windows-WSL2 become bonus surface, not headline coverage — the install path is documented for them but they are not part of the v1.0 promise. The substrate-agnostic vision copy already reads correctly under this narrowing; release-notes are the right surface for naming the tier explicitly.
+**JTBD narrowing acknowledged.** v1.0 narrows the "runs on the box you already have" claim to Linux + Mac boxes. Synology / Unraid / RasPi / Windows-WSL2 become bonus surface, not headline coverage. The install path is documented for them but they are not part of the v1.0 promise. The substrate-agnostic vision copy already reads correctly under this narrowing; release-notes are the right surface for naming the tier explicitly.
 
-The OpenClaw wedge — stock `claude` CLI under your Pro/Max subscription, not a custom runtime against your API key — is unchanged. The container runs the unmodified `claude` CLI against the user's OAuth, exactly as the systemd unit does today. The substrate swap is invisible to that wedge.
+The OpenClaw wedge (stock `claude` CLI under your Pro/Max subscription, not a custom runtime against your API key) is unchanged. The container runs the unmodified `claude` CLI against the user's OAuth, exactly as the systemd unit does today. The substrate swap is invisible to that wedge.
 
 ## Goals
 
-- One install command on Linux and Mac as the supported v1.0 targets. Same command works on Windows-WSL2 and ARM homelab boxes (Synology, Unraid, RasPi 4/5) on a best-effort basis — expected to work, not formally validated.
+- One install command on Linux and Mac as the supported v1.0 targets. Same command works on Windows-WSL2 and ARM homelab boxes (Synology, Unraid, RasPi 4/5) on a best-effort basis: expected to work, not formally validated.
 - Per-agent resource isolation — memory and CPU caps as first-class config, enforced by the kernel, not advisory.
 - Watchdog rewritten in TypeScript against Docker's event stream. Smaller, testable, restorable to "actually catches wedges" thresholds.
 - Product-promise-preserving: stock `claude` CLI inside the container, official OAuth, no API-key interception, vault and approval kernel work identically inside and out. Same JTBD outcomes as host-native, same wedge against OpenClaw.
@@ -140,7 +141,7 @@ The OpenClaw wedge — stock `claude` CLI under your Pro/Max subscription, not a
 
 ### Per-agent container internals
 
-PID 1 is `tini`. tini reaps zombies, forwards signals, and exits clean. The process tree under it is single-spine — there is no separate "supervisor process" doing 4-way fan-out. The actual shape, mirroring today's host-native unit (`bin/start.sh.hbs:373` and the systemd unit's `ExecStart`):
+PID 1 is `tini`. tini reaps zombies, forwards signals, and exits clean. The process tree under it is single-spine. There is no separate "supervisor process" doing 4-way fan-out. The actual shape, mirroring today's host-native unit (`bin/start.sh.hbs:373` and the systemd unit's `ExecStart`):
 
 ```
 tini (PID 1)
@@ -156,13 +157,13 @@ tini (PID 1)
                 └── MCP child: ... (per-agent .mcp.json)
 ```
 
-`start.sh` forks the gateway daemon and autoaccept-poll as supervised background processes (`_switchroom_supervise ... &`), then `exec`s into a tmux session. The telegram gateway is a **supervised sidecar sibling** launched before tmux — it is not an MCP child of claude. The in-claude MCP entry (`telegram-plugin/server.ts`) is the stdio bridge that talks to the already-running gateway process over a unix socket; the gateway itself runs outside claude's process tree. tini handles PID 1 signal forwarding and zombie reaping.
+`start.sh` forks the gateway daemon and autoaccept-poll as supervised background processes (`_switchroom_supervise ... &`), then `exec`s into a tmux session. The telegram gateway is a **supervised sidecar sibling** launched before tmux. It is not an MCP child of claude. The in-claude MCP entry (`telegram-plugin/server.ts`) is the stdio bridge that talks to the already-running gateway process over a unix socket; the gateway itself runs outside claude's process tree. tini handles PID 1 signal forwarding and zombie reaping.
 
 Inside the container `CLAUDE_CONFIG_DIR=/state/.claude` (per-agent bind-mount, see Volume layout). The `!` interrupt path stays local: `tmux send-keys C-c` is a local IPC call inside the container. No container boundary is crossed for the interrupt.
 
 ### Container identity model — per-agent socket directories
 
-This subsection is the load-bearing security redesign. Today's broker authenticates connecting clients by reading `/proc/<pid>/cgroup` to extract a systemd unit name like `switchroom-klanker-cron-3.service`, then cross-checking via `systemctl --user show <unit>` to defend against same-UID cgroup spoofing (`src/vault/broker/peercred.ts:196-302`). The broker's ACL (`src/vault/broker/acl.ts:159-209`) **only serves callers whose `peer.systemdUnit` parses as a switchroom cron unit**; anything else is rejected with "caller is not a switchroom cron unit". Both the cgroup parse and the `systemctl --user show` cross-check are structurally absent inside a container — there is no host systemd to consult, and the cgroup path inside the container's namespace says nothing about which agent the connection came from.
+This subsection is the load-bearing security redesign. Today's broker authenticates connecting clients by reading `/proc/<pid>/cgroup` to extract a systemd unit name like `switchroom-klanker-cron-3.service`, then cross-checking via `systemctl --user show <unit>` to defend against same-UID cgroup spoofing (`src/vault/broker/peercred.ts:196-302`). The broker's ACL (`src/vault/broker/acl.ts:159-209`) **only serves callers whose `peer.systemdUnit` parses as a switchroom cron unit**; anything else is rejected with "caller is not a switchroom cron unit". Both the cgroup parse and the `systemctl --user show` cross-check are structurally absent inside a container. There is no host systemd to consult, and the cgroup path inside the container's namespace says nothing about which agent the connection came from.
 
 We need a different way to bind a connection to an agent identity. **Picked: per-agent unix socket directories, with OS file permissions as the gatekeeper.** Rationale: it requires no token storage, no token rotation, no replay-window reasoning, no new crypto. The kernel-vouched property the broker's threat model relies on (only the right principal can connect) is preserved by filesystem permissions, which is a substitution the broker already trusts for its on-disk audit log and SQLite. HMAC tokens were the obvious alternative; rejected because they widen the secret surface (one more thing to provision, leak, rotate, audit) when filesystem permissions already give us the same property.
 
@@ -196,26 +197,26 @@ vault-broker:
     - broker-finn-sock:/run/switchroom/broker/finn
 ```
 
-On startup the broker `mkdir`s `/run/switchroom/broker/<agent>/`, `chown`s it to that agent's UID, `chmod`s `0700`, and `bind()`s a socket at `<agent>/sock`. An agent container only mounts its own subdirectory — agent-klanker has no path, no descriptor, no namespace through which it can reach `/run/switchroom/broker/coach/sock`. Compose is the gatekeeper; the compose generator enforces the invariant (one agent's broker volume mounts into exactly one agent's container) and a unit test asserts it on every regenerated file.
+On startup the broker `mkdir`s `/run/switchroom/broker/<agent>/`, `chown`s it to that agent's UID, `chmod`s `0700`, and `bind()`s a socket at `<agent>/sock`. An agent container only mounts its own subdirectory: agent-klanker has no path, no descriptor, no namespace through which it can reach `/run/switchroom/broker/coach/sock`. Compose is the gatekeeper; the compose generator enforces the invariant (one agent's broker volume mounts into exactly one agent's container) and a unit test asserts it on every regenerated file.
 
 Identity resolution inside the broker:
 
-- Replace `peer.systemdUnit` with `peer.agentName`, derived at `accept()` time from the **socket the connection arrived on**. The broker calls `getsockname(connFd)` to read the listening socket's path (`/run/switchroom/broker/<agent>/sock`), and parses `<agent>` out of the path. This is broker-controlled input — the agent has no way to influence it.
-- ACL becomes: "this connection came in on the klanker socket, therefore caller is `klanker`; check `config.agents.klanker.schedule[*].secrets` for the requested key." `parseCronUnit` and the `(agentName, index)` pair go away — under containers, every grant is agent-scoped, not schedule-entry-scoped (the scheduler is now a separate container; see Scheduler architecture below).
-- `peer.uid` is still consulted as a defence-in-depth check (does it match the expected UID for that agent's socket directory?), but the primary identity binding is path-derived, not credential-derived. SO_PEERCRED becomes confirmatory, not authoritative — which is exactly what we want, because it removes the userns / virtiofs peercred-regression risk that dominated the prior draft's Phase 0 matrix.
-- The "non-cron callers are not served" rule (`acl.ts:204-208`) is dropped under containers — every connection on a per-agent socket *is* an agent caller by construction. Interactive `vault get` continues to use the `--no-broker` direct-read path.
+- Replace `peer.systemdUnit` with `peer.agentName`, derived at `accept()` time from the **socket the connection arrived on**. The broker calls `getsockname(connFd)` to read the listening socket's path (`/run/switchroom/broker/<agent>/sock`), and parses `<agent>` out of the path. This is broker-controlled input; the agent has no way to influence it.
+- ACL becomes: "this connection came in on the klanker socket, therefore caller is `klanker`; check `config.agents.klanker.schedule[*].secrets` for the requested key." `parseCronUnit` and the `(agentName, index)` pair go away: under containers, every grant is agent-scoped, not schedule-entry-scoped (the scheduler is now a separate container; see Scheduler architecture below).
+- `peer.uid` is still consulted as a defence-in-depth check (does it match the expected UID for that agent's socket directory?), but the primary identity binding is path-derived, not credential-derived. SO_PEERCRED becomes confirmatory, not authoritative, which is exactly what we want, because it removes the userns / virtiofs peercred-regression risk that dominated the prior draft's Phase 0 matrix.
+- The "non-cron callers are not served" rule (`acl.ts:204-208`) is dropped under containers: every connection on a per-agent socket *is* an agent caller by construction. Interactive `vault get` continues to use the `--no-broker` direct-read path.
 
 What the agent sees: `SWITCHROOM_BROKER_SOCKET=/run/switchroom/broker/sock` (the in-container path; agent doesn't know its own UID is special). One env var. One socket. No tokens. No client-side crypto.
 
-What the broker code change costs: about 80 lines net. `peercred.ts` keeps the SO_PEERCRED reader for defence-in-depth and grows a `socketPathToAgent()` helper. `acl.ts` grows a `checkAclByAgent(agentName, key)` path that runs alongside the existing cron-unit path; on host-native both still work, on Docker only the new path runs. The cron-unit path stays untouched — host-native scheduling is unchanged.
+What the broker code change costs: about 80 lines net. `peercred.ts` keeps the SO_PEERCRED reader for defence-in-depth and grows a `socketPathToAgent()` helper. `acl.ts` grows a `checkAclByAgent(agentName, key)` path that runs alongside the existing cron-unit path; on host-native both still work, on Docker only the new path runs. The cron-unit path stays untouched; host-native scheduling is unchanged.
 
-**Phase 0 acceptance for this section (replacing the previous peercred matrix):** end-to-end ACL resolution through `acl.ts`-equivalent — both deny and allow paths — on every target environment. Specifically: (a) klanker's container connects to its socket and successfully resolves a key in its allow-list; (b) klanker's container connects to its socket and is denied a key NOT in its allow-list; (c) klanker's container, with the compose file hand-edited to also mount coach's socket volume, successfully connects to coach's socket — and the doctor check catches the cross-mount before this is reachable. `getsockopt(SO_PEERCRED)` return values are recorded for forensics but are no longer pass/fail for the matrix.
+**Phase 0 acceptance for this section (replacing the previous peercred matrix):** end-to-end ACL resolution through `acl.ts`-equivalent (both deny and allow paths) on every target environment. Specifically: (a) klanker's container connects to its socket and successfully resolves a key in its allow-list; (b) klanker's container connects to its socket and is denied a key NOT in its allow-list; (c) klanker's container, with the compose file hand-edited to also mount coach's socket volume, successfully connects to coach's socket, and the doctor check catches the cross-mount before this is reachable. `getsockopt(SO_PEERCRED)` return values are recorded for forensics but are no longer pass/fail for the matrix.
 
 ### Approval kernel container (singleton)
 
 `src/vault/approvals/kernel.ts` (564 lines), today an in-process module the broker server talks to. In Docker: separate container, same identity model as the broker. Per-agent socket directories under `/run/switchroom/kernel/<agent>/sock` with the same UID/permission discipline; `kernel.ts` derives the requesting agent from the listening socket path at `accept()` time. There is no token, no shared secret, no cross-agent reachability.
 
-The kernel's SQLite (`kernel.db`) lives on a persistent named volume (`approvals-data`), bind-mounted only into the kernel container. Agent containers reach approvals only through the kernel socket — they have no path to `kernel.db` itself.
+The kernel's SQLite (`kernel.db`) lives on a persistent named volume (`approvals-data`), bind-mounted only into the kernel container. Agent containers reach approvals only through the kernel socket; they have no path to `kernel.db` itself.
 
 ### Image layering
 
@@ -252,17 +253,17 @@ Per-agent customisation (skills, profile, telegram tokens) lives in bind-mounted
                                      per-agent CLAUDE_CONFIG_DIR isolation
 ```
 
-Volumes that are shared between containers (broker socket, kernel IPC) are Docker-managed named volumes, not host bind mounts — that avoids the macOS bind-mount perf trap for everything except the things that genuinely need to be on the host filesystem (logs, audit trail, agent config the operator edits).
+Volumes that are shared between containers (broker socket, kernel IPC) are Docker-managed named volumes, not host bind mounts. That avoids the macOS bind-mount perf trap for everything except the things that genuinely need to be on the host filesystem (logs, audit trail, agent config the operator edits).
 
 ### Host UID alignment for bind-mounts
 
-Agent containers run as a per-agent UID in the 10001..10999 range — see Container identity model. Bind-mounted host paths (`~/.switchroom/agents/<agent>/`, `~/.claude/projects/<agent>/`, `~/.switchroom/logs/<agent>/`) need to be readable and writable by the matching in-container UID, otherwise `start.sh` fails on first write.
+Agent containers run as a per-agent UID in the 10001..10999 range (see Container identity model). Bind-mounted host paths (`~/.switchroom/agents/<agent>/`, `~/.claude/projects/<agent>/`, `~/.switchroom/logs/<agent>/`) need to be readable and writable by the matching in-container UID, otherwise `start.sh` fails on first write.
 
 Convention:
 
-- **`SWITCHROOM_HOST_UID`** env var, sourced from `~/.switchroom/.env` written by `switchroom setup`. Linux default: the operator's own UID (the output of `id -u` at setup time, typically `1000`). Mac/Windows: explicit, no default — `switchroom setup` prompts and writes whatever the operator confirms.
+- **`SWITCHROOM_HOST_UID`** env var, sourced from `~/.switchroom/.env` written by `switchroom setup`. Linux default: the operator's own UID (the output of `id -u` at setup time, typically `1000`). Mac/Windows: explicit, no default. `switchroom setup` prompts and writes whatever the operator confirms.
 - The compose generator sets `user: "${SWITCHROOM_HOST_UID}:${SWITCHROOM_HOST_GID}"` on every agent container that mounts host paths, **plus** an in-container supplementary group binding for the per-agent identity used inside `/run/switchroom/broker/<agent>/`. The two-UID story is: outside-mounted host files are owned as the host operator; inside-only sockets are owned as the per-agent UID. Compose's `user:` directive sets the primary UID; supplementary groups are added at start.sh entry.
-- **Docker Desktop caveat (Mac/Windows):** the LinuxKit VM's virtiofs translates host UIDs so that *every* host file appears owned by container UID 1000 inside the VM, regardless of the host operator's actual UID. Per-agent isolation between bind-mounted host paths therefore cannot rely on UID separation on Mac/Win — it can only rely on the **compose generator never mounting agent-A's host path into agent-B's container**. This invariant is enforced by `src/agents/compose.ts` (a single agent's `~/.switchroom/agents/<name>` and `~/.claude/projects/<name>` paths only ever appear under that agent's service block) and audited by a doctor check `switchroom doctor --check cross-agent-mounts` that grep-asserts the rendered compose has no host path appearing under more than one service.
+- **Docker Desktop caveat (Mac/Windows):** the LinuxKit VM's virtiofs translates host UIDs so that *every* host file appears owned by container UID 1000 inside the VM, regardless of the host operator's actual UID. Per-agent isolation between bind-mounted host paths therefore cannot rely on UID separation on Mac/Win. It can only rely on the **compose generator never mounting agent-A's host path into agent-B's container**. This invariant is enforced by `src/agents/compose.ts` (a single agent's `~/.switchroom/agents/<name>` and `~/.claude/projects/<name>` paths only ever appear under that agent's service block) and audited by a doctor check `switchroom doctor --check cross-agent-mounts` that grep-asserts the rendered compose has no host path appearing under more than one service.
 - The doctor check runs on every `switchroom apply`, and as a CI gate on the compose generator's snapshot tests. Operator hand-edits that violate it fail the next doctor invocation with a hard error and a pointer to the offending lines.
 
 ### Compose skeleton
@@ -339,7 +340,7 @@ volumes:
 
 `switchroom apply` regenerates this whole file from `switchroom.yaml`, the same way it regenerates systemd units today. Hand edits get clobbered. There's a `# generated by` warning at the top.
 
-**Why `stop_grace_period: 45s`.** Docker's default SIGTERM-to-SIGKILL window is 10s. The telegram gateway's drain path (`telegram-plugin/gateway/gateway.ts` shutdown handler) needs ~35s in the worst case to flush in-flight stream-replies, finalise the progress card, persist the FIFO queue tail, and let claude write its session JSONL. Without `stop_grace_period`, every `docker compose restart` becomes a SIGKILL crash mid-flush, which is precisely the failure mode the watchdog exists to detect — and would make routine restarts indistinguishable from real wedges in the audit log. 45s gives a 10s safety margin over observed peak.
+**Why `stop_grace_period: 45s`.** Docker's default SIGTERM-to-SIGKILL window is 10s. The telegram gateway's drain path (`telegram-plugin/gateway/gateway.ts` shutdown handler) needs ~35s in the worst case to flush in-flight stream-replies, finalise the progress card, persist the FIFO queue tail, and let claude write its session JSONL. Without `stop_grace_period`, every `docker compose restart` becomes a SIGKILL crash mid-flush, which is precisely the failure mode the watchdog exists to detect, and would make routine restarts indistinguishable from real wedges in the audit log. 45s gives a 10s safety margin over observed peak.
 
 ### Scheduler architecture
 
@@ -353,7 +354,7 @@ volumes:
 > are gone. See `docs/scheduling.md` for the post-cutover model. The
 > body below is preserved as the historical design record.
 
-Compose has no native scheduler. Today, scheduled tasks declared in `switchroom.yaml` (`src/config/schema.ts:757`, the `schedule:` cascade) become per-agent systemd `.timer` units generated by `src/agents/systemd.ts:794-864` via `cronToOnCalendar`. Under Docker, those timer units don't exist — and the cron-unit identity model the broker's old ACL relied on doesn't either (see Container identity model).
+Compose has no native scheduler. Today, scheduled tasks declared in `switchroom.yaml` (`src/config/schema.ts:757`, the `schedule:` cascade) become per-agent systemd `.timer` units generated by `src/agents/systemd.ts:794-864` via `cronToOnCalendar`. Under Docker, those timer units don't exist, and the cron-unit identity model the broker's old ACL relied on doesn't either (see Container identity model).
 
 **Picked: singleton scheduler container reading the cascade and dispatching via `docker exec`.** Rationale: per-agent ofelia sidecars would multiply container count by 1.x and require their own bind-mounts to read cascade state; host-side cron (cron on the host calling `docker compose exec`) breaks the "same install path on Mac/Win/Linux" wedge because Mac and Windows-WSL2 don't have host cron stories that match. A singleton scheduler container is one new image, reads the same `switchroom.yaml` the rest of the fleet reads, owns its own audit trail, and has exactly one place to put the "did this fire" SQLite. It's also the shape that maps cleanly back to today's "every cron is a switchroom-managed entity," which keeps the operator mental model unchanged.
 
@@ -390,9 +391,9 @@ switchroom-cron:
 Implementation:
 
 - `src/scheduler/` (new, target ~500 lines + tests). Reads the cascade via the existing `src/config/loader.ts`, walks `agents.<name>.schedule[]`, registers each entry with `node-cron` against the same cron expression `cronToOnCalendar` parses today (so Phase 2 reuses the same cron-spec test fixtures).
-- On fire, dispatches the prompt via `docker exec -i agent-<name> claude -p "<prompt>"` with the per-task env (vault refs already injected via `SWITCHROOM_BROKER_SOCKET` from the agent container's compose entry — the scheduler doesn't materialise secrets, the agent does). The scheduler is **not** a vault-broker client — it never sees the secret values, only fires the task.
+- On fire, dispatches the prompt via `docker exec -i agent-<name> claude -p "<prompt>"` with the per-task env (vault refs already injected via `SWITCHROOM_BROKER_SOCKET` from the agent container's compose entry; the scheduler doesn't materialise secrets, the agent does). The scheduler is **not** a vault-broker client; it never sees the secret values, only fires the task.
 - Writes a row per fire to `scheduler.db` (timestamp, agent, schedule index, prompt hash, exit code). `journalctl -t switchroom-cron` (Linux) / `docker compose logs switchroom-cron` (Mac/Win) for live observation.
-- Authenticates to the vault broker (if it ever needs to — reserved): same per-agent socket model, but the scheduler container is special — it has its own `/run/switchroom/scheduler/sock` mount. For now, the scheduler does not call the broker; agents resolve their own secrets at task-start time, which is the same flow as host-native today.
+- Authenticates to the vault broker (if it ever needs to, reserved): same per-agent socket model, but the scheduler container is special: it has its own `/run/switchroom/scheduler/sock` mount. For now, the scheduler does not call the broker; agents resolve their own secrets at task-start time, which is the same flow as host-native today.
 - Identity model reflection: under containers, the broker's ACL no longer scopes by `(agentName, scheduleIndex)` because the scheduler-container-firing-an-agent-container path doesn't preserve `scheduleIndex` through `docker exec`. ACL becomes per-agent, with allowed keys flattening to the union of all `schedule[*].secrets` for that agent in the cascade. Documented loss of granularity; acceptable because (a) the audit log captures the firing schedule entry by index in `scheduler.db`, (b) host-native mode keeps the per-index ACL for operators who need it, (c) per-agent secret partitioning is the security boundary that matters in practice.
 
 This is an architecture change, not a Phase 1 detail. The architecture diagram at the top of the doc gains one box. Effort lands in Phase 1 (compose generator emits the scheduler service) and Phase 2 (broker ACL gains the per-agent path).
@@ -443,7 +444,7 @@ Files: `Dockerfile.base`, throwaway compose, `docs/phase0-identity-matrix.md` (d
 3. **Container identity model end-to-end.** Per-agent socket directory layout works in practice: broker chowns `/run/switchroom/broker/<agent>/` to per-agent UIDs, agent container only mounts its own subdirectory, ACL resolves correctly via path-derived agent identity. Test matrix below.
 4. tmux send-keys C-c from the gateway (claude's MCP child) inside the container reaches claude in the same container's tmux pane. `!` interrupt loop end-to-end.
 
-**Identity-model test matrix (deliverable, not optional).** Tiered. The two Linux rows are mandatory PASS to unblock Phase 1. Mac is mandatory before v1.0 ships but runs as a parallel-track spike when hardware lands (next-week ETA), so it does not gate Phase 1 entry. Windows/WSL2 and the homelab platforms (Synology, Unraid, RasPi) are optional/best-effort — capture results if convenient, don't block on them.
+**Identity-model test matrix (deliverable, not optional).** Tiered. The two Linux rows are mandatory PASS to unblock Phase 1. Mac is mandatory before v1.0 ships but runs as a parallel-track spike when hardware lands (next-week ETA), so it does not gate Phase 1 entry. Windows/WSL2 and the homelab platforms (Synology, Unraid, RasPi) are optional/best-effort: capture results if convenient, don't block on them.
 
 | Environment | Tier | Allow path resolves? | Deny path rejects? | Cross-mount detection? | SO_PEERCRED uid (forensics) |
 |---|---|---|---|---|---|
@@ -460,12 +461,12 @@ Files: `Dockerfile.base`, throwaway compose, `docs/phase0-identity-matrix.md` (d
 - **Cross-mount detection:** compose hand-edited to additionally mount `broker-coach-sock` into agent-klanker. `switchroom doctor --check cross-agent-mounts` flags the mount with a hard error pointing at the offending compose lines, before the fleet comes up.
 - **SO_PEERCRED forensics column** (informational only, not pass/fail): record the uid returned for sanity. Under the new model it's defence-in-depth, not authoritative.
 
-Acceptance criteria: **both Linux rows pass all three pass/fail columns** — that's the gate to start Phase 1. Mac runs as a parallel-track spike when hardware arrives (next-week ETA); it must pass all three columns before v1.0 ships, but does not gate Phase 1 entry. Optional rows are recorded if exercised, ignored if not. SO_PEERCRED column captured for the trouble-shooting record but does not gate anything.
+Acceptance criteria: **both Linux rows pass all three pass/fail columns**. That's the gate to start Phase 1. Mac runs as a parallel-track spike when hardware arrives (next-week ETA); it must pass all three columns before v1.0 ships, but does not gate Phase 1 entry. Optional rows are recorded if exercised, ignored if not. SO_PEERCRED column captured for the trouble-shooting record but does not gate anything.
 
 Abort criteria:
-- **Linux rootful OR Linux rootless fails** and the workaround is `--privileged` or host-level UID remap — pause the RFC. The whole plan rests on these two passing.
-- **Mac fails** when validated — does NOT pause Linux build-out. Redesign virtiofs UID handling on the parallel track. Linux v1.0 can ship without Mac if the redesign slips past the v1.0 date (see Decision criteria); Mac then becomes a v1.1 deliverable.
-- Per-agent socket directories cannot be made to work on Linux — pivot to HMAC tokens with a full lifecycle spec (issuance, storage at `/run/secrets/<agent>-broker-token`, revocation on broker restart, scoped ACL) and re-run Phase 0 against the token design. The HMAC fallback is documented in Risks but should not be needed; the per-agent socket design has no known blockers on Linux.
+- **Linux rootful OR Linux rootless fails** and the workaround is `--privileged` or host-level UID remap: pause the RFC. The whole plan rests on these two passing.
+- **Mac fails** when validated: does NOT pause Linux build-out. Redesign virtiofs UID handling on the parallel track. Linux v1.0 can ship without Mac if the redesign slips past the v1.0 date (see Decision criteria); Mac then becomes a v1.1 deliverable.
+- Per-agent socket directories cannot be made to work on Linux: pivot to HMAC tokens with a full lifecycle spec (issuance, storage at `/run/secrets/<agent>-broker-token`, revocation on broker restart, scoped ACL) and re-run Phase 0 against the token design. The HMAC fallback is documented in Risks but should not be needed; the per-agent socket design has no known blockers on Linux.
 - Optional-tier failures are notes, not aborts.
 
 ### Phase 1 — Dockerfiles + compose generator + scheduler, agent-minutes ≈ 600
@@ -478,7 +479,7 @@ Success: `switchroom apply` writes a compose file that `docker compose config` v
 
 Abort: if compose generation can't cleanly express the cascade and we end up with post-render shell munging, stop and rethink.
 
-**Test fleet teardown contract.** Phase 1 (and every later phase that spins up a fleet for tests) must follow these rules — the test host is shared with Coolify and hindsight in many environments; treat it as production unless you provisioned it yourself for this run.
+**Test fleet teardown contract.** Phase 1 (and every later phase that spins up a fleet for tests) must follow these rules. The test host is shared with Coolify and hindsight in many environments; treat it as production unless you provisioned it yourself for this run.
 
 - Every test container MUST carry the label `switchroom.test=<phase>` (e.g. `phase1c`) AND a per-run UUID label (e.g. `switchroom.test.run=<uuid>`).
 - Use `--rm` on every `docker run`.
@@ -489,25 +490,25 @@ Abort: if compose generation can't cleanly express the cascade and we end up wit
   ```
 
 - Banned: bulk teardown over `docker ps -a` (`docker ps -a | xargs docker rm`, bare `docker rm $(docker ps -aq)`). Banned: any `prune` command in test scripts (`docker system prune`, `docker container prune`, `docker volume prune`).
-- Per-container removal by explicit name is fine. Project-scoped compose teardown (`docker compose -p <project> down -v --remove-orphans`) is also fine — scope is the compose project, won't touch anything outside it.
+- Per-container removal by explicit name is fine. Project-scoped compose teardown (`docker compose -p <project> down -v --remove-orphans`) is also fine: scope is the compose project, won't touch anything outside it.
 
 ### Phase 2 — broker + kernel IPC port, agent-minutes ≈ 280
 
-Files: `src/vault/broker/peercred.ts` (add `socketPathToAgent` + container code branch), `src/vault/broker/acl.ts` (add `checkAclByAgent`), `src/vault/approvals/client.ts` socket-path resolver, kernel-side mirrors. Goal: vault refs + approval grants work identically inside-Docker and host-native, exercised by the existing test suite. Path here depends on the identity model that landed in Phase 0 — this phase is the production implementation of whatever Phase 0 proved.
+Files: `src/vault/broker/peercred.ts` (add `socketPathToAgent` + container code branch), `src/vault/broker/acl.ts` (add `checkAclByAgent`), `src/vault/approvals/client.ts` socket-path resolver, kernel-side mirrors. Goal: vault refs + approval grants work identically inside-Docker and host-native, exercised by the existing test suite. Path here depends on the identity model that landed in Phase 0; this phase is the production implementation of whatever Phase 0 proved.
 
 Success: every existing vault + approval test passes against a live broker container via testcontainers.
 
-**Schema-stability invariant.** Phase 2 **must not change the vault broker SQLite layout** (grants table, audit-log table, indices, triggers — all frozen). The migration tool relies on `switchroom migrate to-host` reading the same DB the host-native broker reads. Any schema change here breaks the rollback path and turns migration into a one-way door. If a schema change is genuinely required, it gets its own RFC and ships ahead of Docker migration with paired up/down migrations and a parallel-read test. Same invariant applies to the approval kernel's SQLite (`kernel.db`).
+**Schema-stability invariant.** Phase 2 **must not change the vault broker SQLite layout** (grants table, audit-log table, indices, triggers, all frozen). The migration tool relies on `switchroom migrate to-host` reading the same DB the host-native broker reads. Any schema change here breaks the rollback path and turns migration into a one-way door. If a schema change is genuinely required, it gets its own RFC and ships ahead of Docker migration with paired up/down migrations and a parallel-read test. Same invariant applies to the approval kernel's SQLite (`kernel.db`).
 
 Abort: if peercred-in-Docker requires user namespace remapping that breaks rootless setups, fall back to a token-based broker auth path. Document the security tradeoff (see Phase 0 ACL-narrowing review).
 
 ### Phase 3 — watchdog port, agent-minutes ≈ 750
 
-> **Status (post-v0.6):** DEFERRED / REMOVED in PR #825 — see Status block at top.
+> **Status (post-v0.6):** DEFERRED / REMOVED in PR #825 (see Status block at top).
 
 Files: `src/watchdog/` from scratch, fixture suite under `src/watchdog/__fixtures__/`. Source: Docker events stream (`docker events --filter type=container`) for restart triggers, `docker logs --since` + `docker stats` for liveness probes, `docker inspect` for config sanity.
 
-**Log-driver decision (committed, Linux hosts only): `--log-driver=journald` for every container.** On Linux hosts (the production target — bare-metal, RasPi, Linux servers), all container stdout/stderr forwards to the host journal under a `CONTAINER_NAME=` selector. This preserves the bash watchdog's existing `journalctl` queries verbatim during the parallel dry-run window and keeps `journalctl -t switchroom-watchdog` working for operators after cutover. Compose snippet:
+**Log-driver decision (committed, Linux hosts only): `--log-driver=journald` for every container.** On Linux hosts (the production target: bare-metal, RasPi, Linux servers), all container stdout/stderr forwards to the host journal under a `CONTAINER_NAME=` selector. This preserves the bash watchdog's existing `journalctl` queries verbatim during the parallel dry-run window and keeps `journalctl -t switchroom-watchdog` working for operators after cutover. Compose snippet:
 
 ```yaml
 x-logging: &default-logging
@@ -518,10 +519,10 @@ x-logging: &default-logging
 
 Applied to every service on Linux. Without this, `journalctl` has no signal under Docker (default `json-file` driver writes to `/var/lib/docker/containers/...`) and the parallel-run validation strategy is vacuous on Linux.
 
-**Mac and Windows caveat.** Docker Desktop runs the engine inside a LinuxKit/virtiofs VM. The host (macOS or Windows) has no journald, and the in-VM journal isn't exposed to host tooling — so `journalctl -t switchroom-watchdog` is a non-starter on those platforms regardless of compose log-driver settings. The compose generator should still emit the `journald` directive (Docker Desktop's engine accepts it transparently), but operator muscle memory for `journalctl` on Mac/Win does not carry over, and the parallel dry-run premise (bash watchdog vs TS watchdog, both sourcing journald-forwarded logs) **does not apply on Mac/Win**. On those platforms, the validation reduces to fixture-only.
+**Mac and Windows caveat.** Docker Desktop runs the engine inside a LinuxKit/virtiofs VM. The host (macOS or Windows) has no journald, and the in-VM journal isn't exposed to host tooling, so `journalctl -t switchroom-watchdog` is a non-starter on those platforms regardless of compose log-driver settings. The compose generator should still emit the `journald` directive (Docker Desktop's engine accepts it transparently), but operator muscle memory for `journalctl` on Mac/Win does not carry over, and the parallel dry-run premise (bash watchdog vs TS watchdog, both sourcing journald-forwarded logs) **does not apply on Mac/Win**. On those platforms, the validation reduces to fixture-only.
 
 Validation strategy:
-- **Parallel dry-run, two weeks — Linux hosts only.** Bash watchdog continues to source from `journalctl -t switchroom-watchdog`. TS watchdog sources from `docker events`. Both run in dry-run mode (log intended action, don't execute). Compare action streams nightly; any divergence files an issue and blocks cutover. This check is gated on Linux — Mac/Win don't participate.
+- **Parallel dry-run, two weeks — Linux hosts only.** Bash watchdog continues to source from `journalctl -t switchroom-watchdog`. TS watchdog sources from `docker events`. Both run in dry-run mode (log intended action, don't execute). Compare action streams nightly; any divergence files an issue and blocks cutover. This check is gated on Linux; Mac/Win don't participate.
 - **Fixture suite — every platform.** Every documented restart reason gets a recorded `(docker events stream + docker logs tail + docker stats sample)` triple plus an expected action. Fixtures live in tree, run on every PR across Linux/Mac/Win CI matrices. **Target: 30+ fixtures**, derived from an honest inventory of the bash watchdog's behaviour:
 
   Trigger surface (6 distinct restart reasons): `service-failed`, `service-inactive`, `bridge-disconnect`, `bridge-socket-flap`, `journal-silence`, `turn-hang`. Each has a "fires" path and a "deferred" path.
@@ -534,25 +535,25 @@ Success: parallel dry-run shows zero divergence for 14 consecutive days **on Lin
 
 **Log hygiene audit — gating acceptance for the journald commit.** Before Phase 3 ships and locks in `--log-driver=journald`, audit every container's stdout/stderr for secret content with a recorded run sheet:
 
-- **Broker:** confirm no vault-key values, no agent OAuth tokens, no full grant rows leak to stdout — only redacted audit-line equivalents (key name + reason + agent + decision). Inspect `src/vault/broker/server.ts` log-call sites; any `logger.info(grant)` style call that includes the resolved value gets redacted before this phase closes.
-- **Kernel:** approval prompts and approval bodies must NOT hit stdout — they're potentially sensitive (the prompts users see in approval-required dialogs). Stdout gets the kernel decision (allow/deny) plus the request hash, nothing more.
+- **Broker:** confirm no vault-key values, no agent OAuth tokens, no full grant rows leak to stdout, only redacted audit-line equivalents (key name + reason + agent + decision). Inspect `src/vault/broker/server.ts` log-call sites; any `logger.info(grant)` style call that includes the resolved value gets redacted before this phase closes.
+- **Kernel:** approval prompts and approval bodies must NOT hit stdout. They're potentially sensitive (the prompts users see in approval-required dialogs). Stdout gets the kernel decision (allow/deny) plus the request hash, nothing more.
 - **Agent:** claude-side stdout already excludes user message bodies by default, but verify that the gateway's debug logs (when `DEBUG=switchroom:*` is set) don't print full user message contents. The `--log-driver=journald` invariant assumes "no secrets to stdout under any debug flag operators would routinely set."
-- **MCP servers:** out of our control — third-party MCP servers may print arbitrary content. Documented mitigation: operators with sensitive-MCP setups can per-service override `logging.driver: local` (file-based, not journald-forwarded) for the affected agent. The compose generator exposes `logging_driver_override:` in the agent stanza for this. Doctor warns when an MCP-emitting agent is on the default `journald` driver and points at the override.
+- **MCP servers:** out of our control. Third-party MCP servers may print arbitrary content. Documented mitigation: operators with sensitive-MCP setups can per-service override `logging.driver: local` (file-based, not journald-forwarded) for the affected agent. The compose generator exposes `logging_driver_override:` in the agent stanza for this. Doctor warns when an MCP-emitting agent is on the default `journald` driver and points at the override.
 
 Document the **"no secrets to stdout"** invariant in `reference/operators-guide.md`. Failing the audit blocks the journald commit; we either fix the offending log site or add `logging_driver_override` to default for that container class.
 
-Abort: if porting introduces regressions we can't catch in tests because they're timing-dependent, keep the bash watchdog running against the Docker engine via journald-sourced events on Linux. Ugly but workable, and the journald commitment guarantees that fallback path exists on Linux. Mac/Win have no equivalent fallback — for those, fixture coverage is the only safety net, which is one more reason the fixture suite must be exhaustive.
+Abort: if porting introduces regressions we can't catch in tests because they're timing-dependent, keep the bash watchdog running against the Docker engine via journald-sourced events on Linux. Ugly but workable, and the journald commitment guarantees that fallback path exists on Linux. Mac/Win have no equivalent fallback. For those, fixture coverage is the only safety net, which is one more reason the fixture suite must be exhaustive.
 
 ### Phase 4 — CLI shim + log abstraction + update flow, agent-minutes ≈ 360
 
-> **Status (post-v0.6):** DEFERRED / REMOVED in PR #825 — see Status block at top.
+> **Status (post-v0.6):** DEFERRED / REMOVED in PR #825 (see Status block at top).
 
-Files: `src/cli/*.ts` for every command that today shells to systemctl, `src/logs/` (new — stdout-tailing shim for non-Linux). Detect runtime mode at startup. Map verbs:
+Files: `src/cli/*.ts` for every command that today shells to systemctl, `src/logs/` (new, a stdout-tailing shim for non-Linux). Detect runtime mode at startup. Map verbs:
 
 - `switchroom agent restart klanker` → `docker compose restart agent-klanker`
 - `switchroom agent logs klanker` → on Linux, `journalctl --user CONTAINER_NAME=switchroom-klanker -f`; on Mac/Win, reads from the rotated bind-mount path (see below).
 - `switchroom update` → rolling restart, see below.
-- `switchroom hindsight shell` (new) → `docker exec -it agent-<name> sqlite3 /state/agent/.switchroom/hindsight/bank.db`. Preserves the today-UX of `sqlite3 ~/.switchroom/hindsight/bank.db` for operators who poke the bank directly. Without this, `principles.md §1` ("if they need the docs we've failed") fails — because anyone who already has muscle memory for the host-native path now needs to learn `docker exec` invocations. Sibling verb `switchroom bank sqlite` aliases to the same thing for discoverability. The wrapper resolves the right container by agent name, picks the right path inside the container, and falls through transparently to a host `sqlite3` invocation when running in host-native mode.
+- `switchroom hindsight shell` (new) → `docker exec -it agent-<name> sqlite3 /state/agent/.switchroom/hindsight/bank.db`. Preserves the today-UX of `sqlite3 ~/.switchroom/hindsight/bank.db` for operators who poke the bank directly. Without this, `principles.md §1` ("if they need the docs we've failed") fails, because anyone who already has muscle memory for the host-native path now needs to learn `docker exec` invocations. Sibling verb `switchroom bank sqlite` aliases to the same thing for discoverability. The wrapper resolves the right container by agent name, picks the right path inside the container, and falls through transparently to a host `sqlite3` invocation when running in host-native mode.
 
 **Update flow — rolling restart commitment.** `switchroom update` does not bounce the whole fleet at once. Sequence:
 
@@ -567,11 +568,11 @@ docker compose up -d --no-deps vault-broker approval-kernel switchroom-cron  # s
 
 The serial loop means at most one agent is down at any moment; the rest of the fleet keeps responding to Telegram throughout. The 30s sleep is configurable per-fleet via `~/.switchroom/.env`; doctor warns if it's set below 15s (gateway re-handshake margin).
 
-**Phase 4 acceptance test for update:** 5-agent fleet running, send a message to each agent every 5s during the update, verify (a) no agent is unresponsive for more than `SWITCHROOM_UPDATE_GRACE` seconds, (b) at no point are 2+ agents simultaneously down, (c) shared services are restarted exactly once at the tail, (d) all 5 agents respond on the new image within `5 × (grace + restart_time)` seconds total. Distinct from the Phase 1 `add agent` acceptance — that one tested non-disturbance during scale-up; this one tests bounded disruption during update.
+**Phase 4 acceptance test for update:** 5-agent fleet running, send a message to each agent every 5s during the update, verify (a) no agent is unresponsive for more than `SWITCHROOM_UPDATE_GRACE` seconds, (b) at no point are 2+ agents simultaneously down, (c) shared services are restarted exactly once at the tail, (d) all 5 agents respond on the new image within `5 × (grace + restart_time)` seconds total. Distinct from the Phase 1 `add agent` acceptance: that one tested non-disturbance during scale-up; this one tests bounded disruption during update.
 
 **Cross-platform log abstraction (`src/logs/`).** Wake-audit and operator log-grep currently rely on `journalctl -t switchroom-watchdog` and `journalctl --user CONTAINER_NAME=...`. Mac/Win Docker Desktop has no host journald (the journal lives in the LinuxKit VM and isn't exposed to host tooling). Spec:
 
-- Each agent container gets a stdout-tailing sidecar baked into `start.sh` — a `node` shim that reads claude/gateway stdout and appends rotated jsonl to `/var/log/switchroom/agent.jsonl` (bind-mounted to `~/.switchroom/logs/<agent>/agent.jsonl` on the host). Rotation: 50 MB × 10 files. Same writer used on Linux too — operators get a consistent jsonl format alongside journald.
+- Each agent container gets a stdout-tailing sidecar baked into `start.sh`, a `node` shim that reads claude/gateway stdout and appends rotated jsonl to `/var/log/switchroom/agent.jsonl` (bind-mounted to `~/.switchroom/logs/<agent>/agent.jsonl` on the host). Rotation: 50 MB × 10 files. Same writer used on Linux too, so operators get a consistent jsonl format alongside journald.
 - Wake-audit's `journalctl -t switchroom-watchdog` calls become reads against `~/.switchroom/logs/watchdog/audit.jsonl` on non-Linux. The `src/watchdog/` audit writer (Phase 3) emits to both journald (Linux) and the bind-mounted jsonl (every platform).
 - `switchroom agent logs` and `switchroom agent logs --since <duration>` route to journalctl on Linux, jsonl tail on Mac/Win. Same UX, two backends.
 - Documented in `reference/operators-guide.md`: "logs live at `~/.switchroom/logs/<agent>/agent.jsonl` on every platform; on Linux, the same content is also in journald."
@@ -582,11 +583,11 @@ Abort: if a verb has no Docker equivalent, write the missing command. Don't pape
 
 ### Phase 5 — migration tooling + e2e, agent-minutes ≈ 400
 
-> **Status (post-v0.6):** DEFERRED / REMOVED in PR #825 — see Status block at top.
+> **Status (post-v0.6):** DEFERRED / REMOVED in PR #825 (see Status block at top).
 
 Files: `src/cli/migrate-to-docker.ts`, `src/cli/migrate-to-host.ts`, e2e suite. Migration tool reads the existing `~/.switchroom/`, generates compose, validates, performs UID alignment, prompts user to switch.
 
-README install path messaging: **Docker is the default install path for Mac and Linux.** The bare-metal/host-native install path stays fully supported on Linux for operators who prefer it or already have it — no behavioural difference, same product promise. Other platforms (Windows-WSL2, Synology, Unraid, RasPi) work via the same Docker compose file but are best-effort: expected to work, not formally tested or release-gated. Migration tooling and CLI verbs work on those platforms when Docker Desktop or Docker Engine is functional, they're just not part of the validated release matrix. The CLI auto-detects which mode it's in by looking for `~/.switchroom/compose/docker-compose.yml`.
+README install path messaging: **Docker is the default install path for Mac and Linux.** The bare-metal/host-native install path stays fully supported on Linux for operators who prefer it or already have it, no behavioural difference, same product promise. Other platforms (Windows-WSL2, Synology, Unraid, RasPi) work via the same Docker compose file but are best-effort: expected to work, not formally tested or release-gated. Migration tooling and CLI verbs work on those platforms when Docker Desktop or Docker Engine is functional, they're just not part of the validated release matrix. The CLI auto-detects which mode it's in by looking for `~/.switchroom/compose/docker-compose.yml`.
 
 **UID alignment in migration.** Host-native files are owned by the operator's host UID (typically `1000`). Under Docker, agents may run as a different UID (e.g. a value in the 10001..10999 range per the identity model on Linux, or as `${SWITCHROOM_HOST_UID}` for bind-mounted host paths on Mac/Win where virtiofs translates everything to `1000` regardless). Migration must `chown -R` session JSONLs, hindsight banks, and per-agent state to match the destination UID:
 
@@ -607,7 +608,7 @@ Failure to complete the round-trip = Phase 5 incomplete.
 Success: clean migration from host-native to Docker on a real fleet, AND clean rollback. e2e cold-install matrix is tiered:
 
 - **Mandatory (release gate):** Linux (Docker Engine, bare metal) and Mac (Docker Desktop). Both to "first agent reply in Telegram" in under 5 minutes.
-- **Best-effort, not blocking:** Windows-WSL2 (Docker Desktop), Synology DSM, Unraid, RasPi 4 (arm64). These platforms aren't unsupported — they're "expected to work, not formally tested." Migration tooling, the compose file, and the CLI verbs all work on those platforms when Docker is functional; we just don't run them through the release-gate e2e suite. Community-validated bug reports get triaged like any other issue, but they don't block ship.
+- **Best-effort, not blocking:** Windows-WSL2 (Docker Desktop), Synology DSM, Unraid, RasPi 4 (arm64). These platforms aren't unsupported; they're "expected to work, not formally tested." Migration tooling, the compose file, and the CLI verbs all work on those platforms when Docker is functional; we just don't run them through the release-gate e2e suite. Community-validated bug reports get triaged like any other issue, but they don't block ship.
 
 Round-trip migration test passes on Linux (the only platform where host-native ever ran).
 
@@ -617,28 +618,28 @@ Abort: if Mac Docker Desktop file performance makes the bind-mounted Hindsight S
 
 ### Vault broker IPC across container boundaries
 
-Resolved by the per-agent socket directory design (see §"Container identity model"). The broker no longer relies on SO_PEERCRED for primary identity — agent identity is derived from the listening socket path, which is broker-controlled and compose-enforced. Peercred remains as a defence-in-depth UID match.
+Resolved by the per-agent socket directory design (see §"Container identity model"). The broker no longer relies on SO_PEERCRED for primary identity. Agent identity is derived from the listening socket path, which is broker-controlled and compose-enforced. Peercred remains as a defence-in-depth UID match.
 
 What's left as a risk:
 
 - **Compose-generator correctness.** The whole model collapses if the generator ever mounts agent-A's broker socket volume into agent-B. Mitigation: unit test on `src/agents/compose.ts` asserts the per-agent-volume-mounts-into-one-service invariant for every generated compose. Doctor check `--check cross-agent-mounts` greps the live compose. CI gate. Operator hand-edits that violate it fail doctor.
-- **HMAC fallback (only if Phase 0 surfaces something we didn't predict).** If per-agent socket directories prove unworkable on one of the four target environments, fall back to HMAC tokens with a full lifecycle: broker generates a token bundle on startup (rotating per-agent tokens, written to `/run/secrets/<agent>-broker-token` mode 0400 owned by that agent's UID), agents read at connect time, broker revokes all tokens on its own restart (forcing agents to re-fetch on first 401). Token replay across broker restarts: by construction impossible — broker startup invalidates the prior bundle. No design work needed up-front, but the spec is here so Phase 0 has a known fallback to argue against if the primary design fails.
-- **Broker container unhealthy.** Every agent's vault resolution fails fast with a typed error ("vault broker unavailable, retry in N seconds"). Health check + `restart: unless-stopped` keeps the broker bouncing. Agents don't crash — they degrade to "vault refs return errors" until the broker is back. Acceptable degradation; vault-using calls were already going to fail.
+- **HMAC fallback (only if Phase 0 surfaces something we didn't predict).** If per-agent socket directories prove unworkable on one of the four target environments, fall back to HMAC tokens with a full lifecycle: broker generates a token bundle on startup (rotating per-agent tokens, written to `/run/secrets/<agent>-broker-token` mode 0400 owned by that agent's UID), agents read at connect time, broker revokes all tokens on its own restart (forcing agents to re-fetch on first 401). Token replay across broker restarts: by construction impossible, broker startup invalidates the prior bundle. No design work needed up-front, but the spec is here so Phase 0 has a known fallback to argue against if the primary design fails.
+- **Broker container unhealthy.** Every agent's vault resolution fails fast with a typed error ("vault broker unavailable, retry in N seconds"). Health check + `restart: unless-stopped` keeps the broker bouncing. Agents don't crash; they degrade to "vault refs return errors" until the broker is back. Acceptable degradation; vault-using calls were already going to fail.
 
 ### tmux interrupt path
 
-The `!` interrupt arrives at the gateway process. Gateway and claude REPL are **in the same container**, same tmux socket at `/tmp/tmux-1000/<agent>`. `tmux send-keys C-c` is a local IPC call. No container boundary crossed. This is the whole reason we picked one-container-per-agent over single-container-many-agents — it keeps the interrupt path identical to today's host-native model.
+The `!` interrupt arrives at the gateway process. Gateway and claude REPL are **in the same container**, same tmux socket at `/tmp/tmux-1000/<agent>`. `tmux send-keys C-c` is a local IPC call. No container boundary crossed. This is the whole reason we picked one-container-per-agent over single-container-many-agents: it keeps the interrupt path identical to today's host-native model.
 
 Validate in Phase 0. If this doesn't work, the design is wrong and we restart.
 
 ### Watchdog rewrite — porting bash logic to TS without losing fidelity
 
-> **Status (post-v0.6):** DEFERRED / REMOVED in PR #825 — see Status block at top.
+> **Status (post-v0.6):** DEFERRED / REMOVED in PR #825 (see Status block at top).
 
 `bin/bridge-watchdog.sh` has 967 lines of accumulated edge-case handling. Rewriting it from scratch is a translation problem, and translations introduce bugs.
 
 Mitigations (committed in Phase 3):
-- **Log driver: `--log-driver=journald` on every container, on Linux hosts.** This is the load-bearing decision for the Linux validation path. With journald forwarding in place, the bash watchdog's existing `journalctl` queries continue to return signal, which is what makes the parallel dry-run a real comparison rather than a tautology on Linux. On Mac/Win (Docker Desktop, no host journald), the parallel-run claim does not apply — see Phase 3 for the platform split.
+- **Log driver: `--log-driver=journald` on every container, on Linux hosts.** This is the load-bearing decision for the Linux validation path. With journald forwarding in place, the bash watchdog's existing `journalctl` queries continue to return signal, which is what makes the parallel dry-run a real comparison rather than a tautology on Linux. On Mac/Win (Docker Desktop, no host journald), the parallel-run claim does not apply (see Phase 3 for the platform split).
 - **Parallel dry-run for 14 days, Linux hosts only.** Both watchdogs run, neither acts (log-only). Action-stream divergence is investigated and resolved before either is allowed to act.
 - **Fixture suite, every platform.** Recorded event streams + log tails + expected actions for every restart reason. Runs on every PR across the Linux/Mac/Win CI matrix. This is the only safety net on Mac/Win, so coverage must be exhaustive.
 - Audit trail (`journalctl -t switchroom-watchdog`) shape preserved bit-for-bit on Linux so existing operator `grep`s keep working there. Mac/Win operators use `switchroom agent logs` (Phase 4) which abstracts the platform difference.
@@ -664,17 +665,17 @@ Defaults proposal, derived from observed RSS on the current production fleet plu
 | lightweight (gymbro, reggie, ziggy) | 290–330 MB | `1g` | 0.5 |
 | coding/worker/researcher | 400–700 MB under load | `2g` | 2.0 |
 
-Klanker's 6 GB is **not** a typo — the previous draft's 4 GB was based on idle measurement and would have OOM-killed the container during routine sub-agent fan-outs (observed peak ~3.8 GB plus dispatch overhead lands well above 4 GB). Conversational's 1.5 GB likewise gives ~3x headroom over typical, accommodating the spikes during long stream-replies and progress-card edits.
+Klanker's 6 GB is **not** a typo. The previous draft's 4 GB was based on idle measurement and would have OOM-killed the container during routine sub-agent fan-outs (observed peak ~3.8 GB plus dispatch overhead lands well above 4 GB). Conversational's 1.5 GB likewise gives ~3x headroom over typical, accommodating the spikes during long stream-replies and progress-card edits.
 
-Numbers go in `profiles/<profile>/profile.yaml`, override at the agent level. `switchroom doctor` warns if a 24h watchdog window shows OOM kills — that's the signal to bump the limit. Operators on tight-memory hosts (RasPi 4 with 4 GB total) can lower limits explicitly; the doctor also warns if `sum(mem_limit) > 0.8 * host_total`.
+Numbers go in `profiles/<profile>/profile.yaml`, override at the agent level. `switchroom doctor` warns if a 24h watchdog window shows OOM kills. That's the signal to bump the limit. Operators on tight-memory hosts (RasPi 4 with 4 GB total) can lower limits explicitly; the doctor also warns if `sum(mem_limit) > 0.8 * host_total`.
 
 ### Docker Desktop on Mac and Windows
 
 Three real, documented problems:
 
 1. **Bind-mount file performance.** `~/.claude/projects/<agent>/sessions/*.jsonl` gets appended on every turn, and Hindsight's SQLite does heavy reads/writes. On Mac Docker Desktop with `osxfs`/`virtiofs`, bind-mount throughput is famously poor. Mitigation: hot data (claude session JSONLs, Hindsight bank, SQLite) lives on Docker-managed named volumes. User-edited files (compose.yml, agent config, logs) stay on bind mounts. This needs measurement in Phase 5.
-2. **Networking.** Telegram long-polling against `api.telegram.org` from inside a container is plain outbound HTTPS — works on every Docker engine including Desktop. No special routing. The OAuth loopback redirect (`localhost:port`) needs `--network host` (Linux) or a published port (Mac/Windows). Document both.
-3. **cgroup v1 vs v2.** Docker Desktop for Mac is v2. Linux hosts are mixed. Memory limit semantics differ slightly (swap accounting). The TS watchdog reads `docker stats` which abstracts this, so we don't care at the watchdog layer. We do care at the kernel layer for OOM triggers — test on both.
+2. **Networking.** Telegram long-polling against `api.telegram.org` from inside a container is plain outbound HTTPS. Works on every Docker engine including Desktop. No special routing. The OAuth loopback redirect (`localhost:port`) needs `--network host` (Linux) or a published port (Mac/Windows). Document both.
+3. **cgroup v1 vs v2.** Docker Desktop for Mac is v2. Linux hosts are mixed. Memory limit semantics differ slightly (swap accounting). The TS watchdog reads `docker stats` which abstracts this, so we don't care at the watchdog layer. We do care at the kernel layer for OOM triggers, so test on both.
 
 ### Rootless Docker
 
@@ -683,10 +684,10 @@ Vault broker socket cross-container: works as long as both containers are in the
 ### Logs survive container restart
 
 Two paths for any given log:
-- High-frequency, ephemeral: `docker logs <container>` — survives container restart, lost on `docker rm`. Fine for stdout/stderr noise.
+- High-frequency, ephemeral: `docker logs <container>`. Survives container restart, lost on `docker rm`. Fine for stdout/stderr noise.
 - Audit-grade: bind-mount `~/.switchroom/logs/<agent>/` into the container, agent writes structured logs there. Survives anything short of host disk loss.
 
-`clean-shutdown.json`, watchdog audit trail, card-event-log — all bind-mounted. Same audit guarantees as today.
+`clean-shutdown.json`, watchdog audit trail, card-event-log: all bind-mounted. Same audit guarantees as today.
 
 ### Approval kernel state
 
@@ -712,11 +713,11 @@ Today: `switchroom update` does a `git pull` against the in-tree checkout, runs 
 
 ### Networking inside Docker
 
-Outbound to api.telegram.org: bridge network, NAT'd through the host. Long polling works. Latency adds <5ms vs host-native. Inbound: we don't need any. Telegram is poll-only by default. If a future feature uses webhooks, it'd need a published port — that's a per-deployment operator choice, not a default.
+Outbound to api.telegram.org: bridge network, NAT'd through the host. Long polling works. Latency adds <5ms vs host-native. Inbound: we don't need any. Telegram is poll-only by default. If a future feature uses webhooks, it'd need a published port. That's a per-deployment operator choice, not a default.
 
 ### Performance — bind-mount IO on Docker Desktop
 
-Hindsight's SQLite is the heaviest IO surface. On Mac Docker Desktop, bind-mounted SQLite has been measured at 3-10x slower than native, varying by virtiofs version. Mitigation: hindsight bank goes on a Docker-managed named volume (`hindsight-data`), bind-mounted only for user backups via `docker run --rm -v hindsight-data:/src busybox tar czf -`. This is the single biggest open question in Phase 5 — needs real measurement before we commit.
+Hindsight's SQLite is the heaviest IO surface. On Mac Docker Desktop, bind-mounted SQLite has been measured at 3-10x slower than native, varying by virtiofs version. Mitigation: hindsight bank goes on a Docker-managed named volume (`hindsight-data`), bind-mounted only for user backups via `docker run --rm -v hindsight-data:/src busybox tar czf -`. This is the single biggest open question in Phase 5; needs real measurement before we commit.
 
 ### Single point of failure — vault broker container
 
@@ -735,7 +736,7 @@ Wiring under Docker:
 - The hook script is rendered into the agent's bind-mounted config directory (`~/.switchroom/agents/<name>/hooks/pretool-label.sh`), which mounts to `/state/agent/hooks/` inside the container. The generated `settings.json` references the in-container path: `"PreToolUse": "/state/agent/hooks/pretool-label.sh"`.
 - The hook runs inside the container under the same UID as `claude` (UID 1000), with `PATH` set in `start.sh` to include `/usr/local/bin` and `/state/agent/bin`. If the hook needs `gh`, `git`, or other CLI tools, those ship in `Dockerfile.agent`.
 - The hook's environment receives `SWITCHROOM_RUNTIME=docker` so existing host-native logic that branches on path layout can disambiguate.
-- Fallback: if `/state/agent/hooks/pretool-label.sh` is missing or non-executable at hook-fire time, the harness logs a one-line warning to the agent's stdout (captured by journald per the Phase 3 log-driver decision) and proceeds without labelling. We do not block tool calls on hook failure — that's the same fail-open behaviour as host-native today.
+- Fallback: if `/state/agent/hooks/pretool-label.sh` is missing or non-executable at hook-fire time, the harness logs a one-line warning to the agent's stdout (captured by journald per the Phase 3 log-driver decision) and proceeds without labelling. We do not block tool calls on hook failure; that's the same fail-open behaviour as host-native today.
 
 Phase 1 acceptance: PreToolUse labels appear on agent activity in a containerised fleet identically to host-native.
 
@@ -746,11 +747,11 @@ Phase 1 acceptance: PreToolUse labels appear on agent activity in a containerise
 In Docker, the file crosses the container boundary. The threat surface widens in one specific way: **any container that mounts that volume can read the refresh token.** Compose is the gatekeeper. The discipline:
 
 - **Each agent's `~/.claude/projects/<name>` is mounted into that agent's container only.** Never shared between agents. Never mounted into broker, kernel, or watchdog containers.
-- The compose generator (`src/agents/compose.ts`) enforces this — the bind-mount line for `~/.claude/projects/<name>` only appears under `agent-<name>:`. A test asserts this invariant on every regenerated compose.
+- The compose generator (`src/agents/compose.ts`) enforces this: the bind-mount line for `~/.claude/projects/<name>` only appears under `agent-<name>:`. A test asserts this invariant on every regenerated compose.
 - Inside the container, the directory is owned by UID 1000 with `0700` perms, same as host.
 - Operators who hand-edit the generated compose to share `~/.claude/projects` across containers are explicitly warned in the file header. Doctor flags it.
 
-A compromised container reading its own agent's token is no worse than a compromised host process reading the host file — the threat model is unchanged for that case. A compromised broker or kernel container reading agent tokens **would** be a regression; the per-agent-only mount discipline prevents it.
+A compromised container reading its own agent's token is no worse than a compromised host process reading the host file. The threat model is unchanged for that case. A compromised broker or kernel container reading agent tokens **would** be a regression; the per-agent-only mount discipline prevents it.
 
 ## Migration story (v0.6)
 
@@ -771,7 +772,7 @@ Build a Debian image with systemd as PID 1, run the existing systemd units insid
 
 ### Option 2 — Single Node supervisor, all agents in one container
 
-Replace systemd with a TS supervisor process that spawns and manages every agent's claude REPL as a child process inside one container. **Rejected.** Fails the "always-on, auto-recovery" outcome: OOM in one agent kills the whole container, taking the rest of the fleet with it. Per-agent resource isolation impossible without cgroup gymnastics. Single-process model also forces every agent's tmux session into one tmux server, which complicates the `!` interrupt path and weakens the "see every step" promise. The "compose multiplies image overhead" worry from #793 is actually small (one image, multiple containers — pages of memory shared).
+Replace systemd with a TS supervisor process that spawns and manages every agent's claude REPL as a child process inside one container. **Rejected.** Fails the "always-on, auto-recovery" outcome: OOM in one agent kills the whole container, taking the rest of the fleet with it. Per-agent resource isolation impossible without cgroup gymnastics. Single-process model also forces every agent's tmux session into one tmux server, which complicates the `!` interrupt path and weakens the "see every step" promise. The "compose multiplies image overhead" worry from #793 is actually small (one image, multiple containers, pages of memory shared).
 
 ### Option 3 — One container per agent + compose (this RFC)
 
@@ -786,8 +787,8 @@ A long-lived control-plane container that drives ephemeral per-task runner conta
 These need spike-validation in Phase 0, not paper analysis.
 
 1. Peercred semantics under rootless Docker on Mac Docker Desktop's specific virtiofs setup. I believe it works. I haven't proved it.
-2. Hindsight SQLite IO on Mac Docker Desktop bind mount vs named volume — quantified throughput numbers, not vibes.
-3. tmux send-keys behaviour when the gateway and the claude process are in the same container but the tmux server was started by `start.sh` under tini's supervision. Should be fine — tmux is a normal client/server unix-socket dance — but spike to confirm.
+2. Hindsight SQLite IO on Mac Docker Desktop bind mount vs named volume: quantified throughput numbers, not vibes.
+3. tmux send-keys behaviour when the gateway and the claude process are in the same container but the tmux server was started by `start.sh` under tini's supervision. Should be fine (tmux is a normal client/server unix-socket dance), but spike to confirm.
 4. claude CLI OAuth on Windows Docker Desktop with WSL2 backend. Loopback ports and WSL2 networking have edge cases.
 
 (The `switchroom add agent` reconcile-then-up race that previously sat here is now a Phase 1 acceptance test, not a deferred question.)
@@ -802,13 +803,13 @@ Abandon this plan and pivot if any of these hit:
 
 Tradeoff calls (decide, don't pivot):
 
-- **Mac validation slips past the v1.0 ship date.** Hardware delays, virtiofs redesign drags, peercred fails on Mac and the workaround needs more time — any of these. Decision: either (a) **slip Mac to v1.1** and ship Linux-only as v1.0 (Mac install path documented as "coming, beta"), or (b) **hold v1.0** until Mac passes. Default lean is (a) — Linux is the substrate the existing fleet runs on and Mac users are not currently served by switchroom anyway, so shipping Linux-on-Docker without Mac is still a strict improvement over today. Pick at the time based on how close Mac is. **If decision (a) fires, the supported-target language elsewhere in this RFC (Summary line, Goals, Motivation paragraph, the install-path README block) re-resolves to Linux-only for v1.0; the Mac language ships in v1.1 release notes when validation completes.** This RFC's "Linux + Mac" framing is the intent under the default ship plan — it is not a promise that survives a Mac slip.
-- Multi-arch image build instability on arm64 in CI for >2 weeks. RasPi/homelab is best-effort, not release-gating, so this doesn't pause the plan — it just means the arm64 image stays "build it yourself" until CI stabilises. Document, move on.
+- **Mac validation slips past the v1.0 ship date.** Hardware delays, virtiofs redesign drags, peercred fails on Mac and the workaround needs more time, any of these. Decision: either (a) **slip Mac to v1.1** and ship Linux-only as v1.0 (Mac install path documented as "coming, beta"), or (b) **hold v1.0** until Mac passes. Default lean is (a): Linux is the substrate the existing fleet runs on and Mac users are not currently served by switchroom anyway, so shipping Linux-on-Docker without Mac is still a strict improvement over today. Pick at the time based on how close Mac is. **If decision (a) fires, the supported-target language elsewhere in this RFC (Summary line, Goals, Motivation paragraph, the install-path README block) re-resolves to Linux-only for v1.0; the Mac language ships in v1.1 release notes when validation completes.** This RFC's "Linux + Mac" framing is the intent under the default ship plan. It is not a promise that survives a Mac slip.
+- Multi-arch image build instability on arm64 in CI for >2 weeks. RasPi/homelab is best-effort, not release-gating, so this doesn't pause the plan. It just means the arm64 image stays "build it yourself" until CI stabilises. Document, move on.
 
 If none of the abandon criteria hit, the plan ships.
 
 ## Vision and product copy
 
-Already done. PR #796 rewrote `reference/vision.md`, `reference/principles.md`, the README, and `docs/vs-openclaw.md` to be substrate-agnostic — the product promise is the JTBD outcomes (long-running service, survives reboots, auto-recovery, OAuth under your subscription, stock `claude` CLI), with no commitment to systemd or Docker either way. This RFC implements the substrate change behind that copy.
+Already done. PR #796 rewrote `reference/vision.md`, `reference/principles.md`, the README, and `docs/vs-openclaw.md` to be substrate-agnostic: the product promise is the JTBD outcomes (long-running service, survives reboots, auto-recovery, OAuth under your subscription, stock `claude` CLI), with no commitment to systemd or Docker either way. This RFC implements the substrate change behind that copy.
 
-Light touch needed: the substrate-agnostic copy already squares with the tiered-platform reality. The JTBD framing "runs on the box you already have" remains accurate — Linux and Mac are the supported install targets for v1.0; Windows, Synology, Unraid, and RasPi work in principle and may work for you, but aren't formally validated. Don't rewrite vision.md to enumerate the tiers — the substrate-agnostic framing is correct and shouldn't list operating systems by name. The release notes for v1.0 are where the supported-vs-best-effort split gets stated explicitly. No further RFC-driven edits to vision/principles/README.
+Light touch needed: the substrate-agnostic copy already squares with the tiered-platform reality. The JTBD framing "runs on the box you already have" remains accurate: Linux and Mac are the supported install targets for v1.0; Windows, Synology, Unraid, and RasPi work in principle and may work for you, but aren't formally validated. Don't rewrite vision.md to enumerate the tiers; the substrate-agnostic framing is correct and shouldn't list operating systems by name. The release notes for v1.0 are where the supported-vs-best-effort split gets stated explicitly. No further RFC-driven edits to vision/principles/README.

--- a/reference/rfcs/draft-mirror-preview.md
+++ b/reference/rfcs/draft-mirror-preview.md
@@ -1,6 +1,7 @@
 ---
-artefact: draft-stream mirror preview + real-time activity feed
-serves: jobs/know-what-my-agent-is-doing.md
+artifact: draft-stream mirror preview + real-time activity feed
+serves: know-what-my-agent-is-doing
+advances-outcome: hold-the-leash
 status: Implemented — flag retired
 ---
 
@@ -12,7 +13,7 @@ status: Implemented — flag retired
 **Touches:** `telegram-plugin/gateway/gateway.ts`, `telegram-plugin/answer-stream.ts`, `telegram-plugin/tool-activity-summary.ts`, `telegram-plugin/session-tail.ts`
 
 > **Update (2026-05-29):** shipped as the real-time activity feed (#1982,
-> driven by the PreToolUse `tool_label` sidecar — see the PIVOT below).
+> driven by the PreToolUse `tool_label` sidecar, see the PIVOT below).
 > The feed is now the **unconditional default**: the
 > `SWITCHROOM_DRAFT_MIRROR` env flag and its kill-switch (Phasing /
 > Kill-switch sections below) have been **removed**, and the legacy
@@ -25,7 +26,7 @@ status: Implemented — flag retired
 
 ## Problem
 
-During a turn, the user wants to see what the agent is doing — in the
+During a turn, the user wants to see what the agent is doing, in the
 agent's own voice, as it happens. Today there are **two fragmented,
 loosely-coordinated preview surfaces**:
 
@@ -36,7 +37,7 @@ loosely-coordinated preview surfaces**:
    framework-authored tool counting, cleared on first reply.
 
 These can both be live at once (separate message IDs), and the
-activity-summary is framework-authored progress chrome — the model's
+activity-summary is framework-authored progress chrome: the model's
 machinery, not its voice. Extended-thinking turns also read as dead
 air at the *message* level (only the 🤔 reaction reflects them).
 
@@ -45,12 +46,12 @@ air at the *message* level (only the 🤔 reaction reflects them).
 The original design below proposed streaming the model's interstitial
 `assistant.text` prose into the draft. **The flag-on canary on
 test-harness falsified that premise.** On a normal tool turn the model
-emits *no* interstitial prose — it goes `thinking` (redacted, no text)
+emits *no* interstitial prose. It goes `thinking` (redacted, no text)
 → `tool_use` → `reply`. Routing `assistant.text` to the draft just
 produced an empty preview.
 
-The real human-friendly signal — verified against a live session JSONL
-(1360 Bash calls etc.) — lives in **`tool_use.input`, authored by the
+The real human-friendly signal, verified against a live session JSONL
+(1360 Bash calls etc.), lives in **`tool_use.input`, authored by the
 model**:
 
 | Tool | Field | Example |
@@ -67,11 +68,11 @@ This is exactly why Claude Code's own UI reads friendly: the Bash tool
 filename. There is never a raw `grep`/`jq`/`ls` to surface.
 
 **Revised design intent:** render each `tool_use` as a human-friendly,
-present-tense line via `describeToolUse` (`tool-activity-summary.ts`) —
-model-authored description, then a domain label, then a humanized name;
-never raw shell/query syntax — and stream the latest line into the
+present-tense line via `describeToolUse` (`tool-activity-summary.ts`),
+model-authored description, then a domain label, then a humanized name,
+never raw shell/query syntax. Stream the latest line into the
 **ephemeral compose-area draft**, clearing on `reply`. **Option A:
-uniform across code + non-code agents** — a health coach sees
+uniform across code + non-code agents.** A health coach sees
 "Searching memory" / "Checking your calendar"; a code agent sees
 "Editing gateway.ts" / the model's Bash description. The `reply` tool
 stays the canonical, formatted, pinged, persistent answer.
@@ -85,8 +86,8 @@ that lane.
 
 ## Original design intent (superseded by the PIVOT above)
 
-Mirror the **model's narration** — its summaries / descriptions /
-thinking-style commentary — into the **ephemeral compose-area draft**,
+Mirror the **model's narration** (its summaries / descriptions /
+thinking-style commentary) into the **ephemeral compose-area draft**,
 like Claude Code's running narration. **Not** tool-call labels. The
 draft clears when the final `reply` lands. The `reply` tool stays the
 canonical, formatted, pinged, persistent answer.
@@ -97,7 +98,7 @@ This is the next step on the same trajectory, not a walk-back. The
 arc:
 
 1. **Card era** — a persistent pinned status surface. Retired in
-   #1122: it failed three ways — redundant (user saw the answer before
+   #1122: it failed three ways. Redundant (user saw the answer before
    the card refreshed), confusing (card landed *after* the final
    answer due to send ordering), empty (it was the safety net for a
    model that wouldn't talk).
@@ -108,29 +109,29 @@ arc:
 3. **Live-narration-preview era (this RFC)** — the model's voice,
    streamed *as it forms*, in an ephemeral surface that leaves no
    residue. This couldn't exist safely until the reply-guarantee
-   (turn-pacing v4 + silent-end) was solid; now it can.
+   (turn-pacing v4 + silent-end) was solid. Now it can.
 
 The #1122 lesson is *carried forward*, not contradicted. An
 **ephemeral draft of the model's own prose** structurally avoids the
 three failure modes that killed the card:
 
-- Can't be redundant — it clears the instant `reply` lands.
-- Largely escapes the ordering trap — but not perfectly. The card's
+- Can't be redundant. It clears the instant `reply` lands.
+- Largely escapes the ordering trap, but not perfectly. The card's
   failure was a *persistent visible message* landing after the answer.
   The draft-clear is best-effort fire-and-forget
   (`answer-stream.ts:~282,598`), so a late draft-edit *can* land after
   the reply cleared it. The residue is a **stale ephemeral draft**
-  (auto-expires in 30s), not a stale visible chat message — strictly
+  (auto-expires in 30s), not a stale visible chat message, strictly
   less harmful than the card's failure, but the race exists. Mitigate
   by sequencing the clear after the reply send and accepting the 30s
   expiry as the floor.
-- Can't be empty — if the model emits no prose, no draft is shown
+- Can't be empty. If the model emits no prose, no draft is shown
   (the card was *forced* to render something).
 
 And it stays inside the contract: per
 `feedback_chat_is_artifact_ux_not_implementation`, streaming the
-model's *own words* (framework-transported, ephemeral) is sanctioned;
-only framework-authored chrome that *lingers* was ever the
+model's *own words* (framework-transported, ephemeral) is sanctioned.
+Only framework-authored chrome that *lingers* was ever the
 anti-pattern. The draft mirror is the former, never the latter.
 
 ## The three layers (target state)
@@ -146,14 +147,14 @@ anti-pattern. The draft mirror is the former, never the latter.
 1. **Route interstitial `assistant.text` to the draft, not a visible
    message.** The answer-stream's transport moves to `sendMessageDraft`
    for the live preview. v0.13.44 routed it to a *visible real message*
-   as a safety move — because at the time the ephemeral draft could
+   as a safety move, because at the time the ephemeral draft could
    strand an answer the model never committed. That safety is now
    provided structurally by the reply-guarantee + the backstop in (4),
    so the preview can return to its natural ephemeral home while the
    answer's durability is owned by `reply`. Safe *only* with (4).
 
 2. **Remove the tool-call mirror.** The activity-summary lane
-   ("Ran 5 commands") is dropped from the preview — the operator does
+   ("Ran 5 commands") is dropped from the preview. The operator does
    not want tool-call machinery mirrored. `tool-activity-summary.ts`
    and `drainActivitySummary`/`clearActivitySummary` are retired (or
    gated off by default). Tool activity still shows ambiently via the
@@ -165,7 +166,7 @@ anti-pattern. The draft mirror is the former, never the latter.
    `{ kind: 'thinking' }` and never extracts the block's text
    (`session-tail.ts:219`), and extended-thinking content is typically
    unavailable in the on-disk JSONL anyway. So we surface the *state*,
-   not the text — enough to keep extended-thinking turns from reading
+   not the text, enough to keep extended-thinking turns from reading
    as dead air at the message level, in the model's-state voice rather
    than a tool log. (If we later want real thinking text, that's a
    session-tail parser change AND depends on the content actually being
@@ -187,7 +188,7 @@ anti-pattern. The draft mirror is the former, never the latter.
    real message). If for any reason we prefer materialize() to own
    this, that is NEW code (make materialize fire when
    `streamMsgId == null`), not "keep existing." **This backstop is what
-   prevents re-opening the v0.13.44 19%-framework-fallback hole — and
+   prevents re-opening the v0.13.44 19%-framework-fallback hole, and
    it covers answer *delivery* only, not liveness *perception* (see
    Risks).** Non-negotiable.
 
@@ -215,7 +216,7 @@ The preview MAY reuse the pure render helpers (`markdownToHtml`,
   per CLAUDE.md). The on-disk JSONL is whole-message; ~1 edit/sec is
   the ceiling. Out of scope.
 - **Mirroring tool calls / results.** Explicitly excluded by the
-  operator — the model's voice, not its machinery.
+  operator. The model's voice, not its machinery.
 
 ## Phasing
 
@@ -232,7 +233,7 @@ The preview MAY reuse the pure render helpers (`markdownToHtml`,
   Risks) — operator confirms the draft is actually visible on their
   client(s), not just that delivery held.
 - **Phase 4** — retire the activity-summary tool-count lane, **only
-  after Phase 3 default-on has stuck**. Reason (design review): if
+  after Phase 3 default-on has stuck**. The reason (design review): if
   activity-summary is deleted while the mirror is still flag-gated and
   Phase 3's gate fails, the `SWITCHROOM_DRAFT_MIRROR=0` kill-switch
   could not restore it. Retire last, when there's nothing to fall back
@@ -263,13 +264,13 @@ tool-count lane is gone for good by then).
 - **Re-opening the 19% hole (delivery)** — mitigated by the turn-flush
   backstop (4) + turn-pacing v4. The framework-fallback metric gate in
   Phase 3 is the hard check. NOTE: this guarantees the *answer is
-  delivered*, not that the *liveness is perceived* — see next.
+  delivered*, not that the *liveness is perceived*. See next.
 - **Liveness invisibility (perception) — the real open risk.** v0.13.44
   moved narration to a *visible message* precisely because the
   compose-area draft wasn't surfacing on the operator's client; that
   invisibility was the perceived dead-air behind the 19%
   framework-fallback. This RFC moves narration *back* to the draft.
-  The delivery backstop does NOT cover this — if the draft is invisible
+  The delivery backstop does NOT cover this. If the draft is invisible
   on a given client, the user sees nothing until the `reply` lands,
   i.e. the same gap v0.13.44 closed, minus the lost-answer part. This
   is acceptable ONLY if (a) the reply reliably lands fast (turn-pacing
@@ -278,7 +279,7 @@ tool-count lane is gone for good by then).
   explicit perception check** (operator confirms the draft renders on
   their client[s]) separate from the delivery metric. If the draft is
   invisible in practice, this whole direction is wrong and we stay on
-  visible-answer-stream — surface that early, don't push to default-on.
+  visible-answer-stream. Surface that early, don't push to default-on.
 - **Operator-divergence during rollout** — same `apply`-regenerates-
-  settings concern as any scaffold change; ship via the normal
+  settings concern as any scaffold change. Ship via the normal
   release + fleet roll, not hot-patch, for the default flip.

--- a/reference/rfcs/eliminate-claude-p.md
+++ b/reference/rfcs/eliminate-claude-p.md
@@ -1,6 +1,7 @@
 ---
-artefact: eliminate claude -p (programmatic usage) from switchroom
-serves: jobs/keep-my-subscription-honest.md
+artifact: eliminate claude -p (programmatic usage) from switchroom
+serves: keep-my-subscription-honest
+advances-outcome: subscription-honest
 status: accepted — shipped in #1625 and #1626
 ---
 
@@ -21,14 +22,14 @@ stay reserved for *interactive* Claude Code / Cowork / chat.
 
 Switchroom's design contract (`reference/vision.md`, pillar 3) is
 **subscription-honest** — Pro/Max is the ceiling. A 9-agent always-on
-fleet cannot live inside a $200/month credit. Therefore every model
+fleet cannot live inside a $200/month credit. So every model
 call switchroom makes must be **interactive Claude Code**. Any
 `claude -p` is now a programmatic surface: a recurring cost leak and a
 classification liability.
 
 **The prize is not just cost.** Remove every `claude -p` and 100% of
-switchroom's model usage becomes the interactive `claude` session —
-cron, webhooks, everything enters as synthesized turns *into* that
+switchroom's model usage becomes the interactive `claude` session.
+Cron, webhooks, everything enters as synthesized turns *into* that
 session. There is no programmatic surface left to classify. That is
 the strongest possible position for the June 15 interactive-vs-
 programmatic line: nothing to argue about.
@@ -42,9 +43,9 @@ Exactly **two** real `claude -p` spawn sites remain:
 | `src/agents/handoff-summarizer.ts:308` | every turn (handoff Stop hook) | Haiku 4.5 |
 | `src/web/webhook-dispatch.ts:468` (`spawnAgentOneShot`) | per inbound web webhook | configurable |
 
-The main agent session is interactive `claude` — unaffected. Cron was
+The main agent session is interactive `claude`, unaffected. Cron was
 already migrated off `claude -p` in Phase 4 (fires fold into the live
-session via `inject_inbound`) — out of scope.
+session via `inject_inbound`), out of scope.
 
 ## Goal
 
@@ -130,7 +131,7 @@ The output is consumed **only at the next session start**. Per-turn
 generation of a rarely-consumed artifact is the core waste.
 
 ### What the feature provides
-Restart continuity — the "restart-and-know" JTBD (#27). After an agent
+Restart continuity, the "restart-and-know" JTBD (#27). After an agent
 process restarts, the new session is seeded with the briefing so it
 knows what it was doing, **including in-flight task state that may not
 yet be written to `MEMORY.md`**.
@@ -139,7 +140,7 @@ yet be written to `MEMORY.md`**.
 - **B1 — Native `--continue`, delete the summarizer.** Launch the
   post-restart session with claude's native `--continue` (resume the
   prior session). Large sessions are handled by claude's built-in
-  context compaction — *inside* the interactive (subscription) session.
+  context compaction, *inside* the interactive (subscription) session.
   `resume_mode` already has a `continue` value; make it the default
   and delete the handoff path. Zero `claude -p`, least code.
 - **B2 — Self-orient from a transcript tail.** Delete the summarizer;
@@ -159,7 +160,7 @@ with a bounded raw transcript tail and orients itself in-session. No
 `claude -p`; the summarization cost moves into the subscription-funded
 interactive session, and the context handed forward is bounded and
 controlled rather than whatever `--continue` happens to carry. B1
-(native `--continue`) was considered and set aside: a raw resume
+(native `--continue`) was considered and set aside. A raw resume
 carries more stale tool/turn state than a deliberate tail, and the
 restart-and-know JTBD wants a clean, bounded handoff.
 

--- a/reference/rfcs/fleet-dashboard.md
+++ b/reference/rfcs/fleet-dashboard.md
@@ -1,6 +1,7 @@
 ---
-artefact: Fleet dashboard — Hermes-Desktop adapter for the operator console
-serves: jobs/see-my-whole-fleet-from-one-screen.md
+artifact: Fleet dashboard — Hermes-Desktop adapter for the operator console
+serves: see-my-whole-fleet-from-one-screen
+advances-outcome: hold-the-leash
 status: rfc — draft. Pivoted from "build our own SPA" to "expose the
   Hermes-Desktop contract from a Switchroom adapter and run the unmodified
   desktop in remote mode." Carries the alignment review of the original
@@ -19,8 +20,8 @@ The operator wants a Hermes-class management surface. Rather than build our
 own SPA, **Switchroom exposes the Hermes-Desktop integration contract** and
 the operator runs the **unmodified, MIT-licensed Hermes Desktop** (NousResearch
 `hermes-agent/apps/desktop`) in its **remote-gateway mode**, pointed at a
-Switchroom adapter. The adapter speaks the desktop's two transports — REST
-`/api/*` and **JSON-RPC-2.0-over-WebSocket** `/api/ws` — backed by
+Switchroom adapter. The adapter speaks the desktop's two transports (REST
+`/api/*` and **JSON-RPC-2.0-over-WebSocket** `/api/ws`) backed by
 Switchroom's own artifacts and IPC.
 
 The connection is **observe + operator-chat, approvals stay on Telegram**:
@@ -30,19 +31,19 @@ The connection is **observe + operator-chat, approvals stay on Telegram**:
 - **Operator chat.** Implement `prompt.submit` by routing the operator's turn
   through Switchroom's existing **synthesized-inbound path** (`inject_inbound`
   / cron pattern). The operator's turn **and the agent's reply mirror into
-  that agent's Telegram thread** — one canonical record.
+  that agent's Telegram thread**, one canonical record.
 - **Approvals stay on Telegram.** We simply **do not implement** the approval
   methods/events; per the desktop's graceful-degradation behaviour that panel
   just stays empty. The Telegram tap remains the sole approval surface.
 
 **`telegram-only` is not crossed.** That invariant governs the *principal's*
-channel — it bars a second chat channel for the people the team serves
+channel. It bars a second chat channel for the people the team serves
 (WhatsApp, Signal, Slack). The dashboard is an **admin component** of
 switchroom, not a principal channel, so it is out of that invariant's scope.
 This change clarifies that scope in `invariants.md` and pins the conditions
 that keep the admin console from quietly becoming a second channel (operator
 audience, mirrored to the one Telegram thread, approvals on Telegram). No
-desktop fork is maintained — we track upstream by implementing its contract.
+desktop fork is maintained. We track upstream by implementing its contract.
 
 ## Decisions (owner-ratified)
 
@@ -76,7 +77,7 @@ renderer and supports a documented **remote-gateway** mode
 
 Canonical data types live in `apps/desktop/src/types/hermes.ts`. Auth is
 **token mode** by default (`X-Hermes-Session-Token` header on REST, `?token=`
-on WS) — which maps cleanly onto Switchroom's existing `switchroom-web` token
+on WS), which maps cleanly onto Switchroom's existing `switchroom-web` token
 + Tailscale setup. Per the research, **features we don't implement degrade
 that panel only; they don't block chat.**
 
@@ -99,12 +100,12 @@ that panel only; they don't block chat.**
 **NOT implemented (panels degrade empty, by design):**
 `approval.request` / `approval.respond`, `sudo.*`, `secret.*` (approvals stay
 Telegram); plus `pet.*`, `billing.*`, `moa.*`, `voice.*`, computer-use,
-messaging-platforms (Hermes's own chat gateway — irrelevant to us).
+messaging-platforms (Hermes's own chat gateway, irrelevant to us).
 
 **REST subset to implement:** `/api/sessions*`, `/api/status`,
 `/api/logs`, `/api/analytics/usage`, `/api/config` (read; secrets redacted).
 Model/provider/env endpoints return Switchroom's claude-native truth
-(single provider, OAuth-slot health as metadata) — never a token.
+(single provider, OAuth-slot health as metadata). Never a token.
 
 ### The mirror (the load-bearing bit)
 
@@ -193,7 +194,7 @@ embedded-terminal path; Hermes's own messaging-platform gateway; deprecating
   emitted event frames match the `{type,session_id,payload}` shape.
 - **Mirror test:** an operator `prompt.submit` produces a real turn in the
   target agent's Telegram thread (the turn and reply are observable there),
-  not just on the WS — the load-bearing admin-console condition.
+  not just on the WS. This is the load-bearing admin-console condition.
 - **No-approval test:** the adapter exposes no approve/deny method; an
   `approval.respond` call is rejected/absent.
 - Secret-redaction: no REST/WS payload ever carries token-shaped material.
@@ -201,10 +202,10 @@ embedded-terminal path; Hermes's own messaging-platform gateway; deprecating
 ## Deployment
 
 The adapter ships in the `switchroom-web` service (its own compose project,
-pinned GHCR image — `project_web_dashboard_local_hotfix_deploy`), reached via
+pinned GHCR image `project_web_dashboard_local_hotfix_deploy`), reached via
 `tailscale serve` → `127.0.0.1:8080`. The operator points Hermes Desktop's
 remote-gateway config at that URL with the service token. Keep the service
-rendered from config so it survives `switchroom apply` — never hand-edited
+rendered from config so it survives `switchroom apply`, never hand-edited
 into the generated compose file.
 
 ## Open questions

--- a/reference/rfcs/gdrive-mcp.md
+++ b/reference/rfcs/gdrive-mcp.md
@@ -1,16 +1,17 @@
 ---
-artefact: Google Drive MCP integration
-serves: jobs/act-in-my-tools-with-an-identity.md
+artifact: Google Drive MCP integration
+serves: act-in-my-tools-with-an-identity
+advances-outcome: always-available
 status: Implemented in v0.6.0
 ---
 
 # RFC D: Google Drive MCP integration
 
-Status: **Implemented in v0.6.0** (2026-05-06). Originally drafted as "RFC C" — renumbered to D after `host-control-daemon.md` claimed the C slot in v0.7.x. This document is retained as the design record; the implementation is the source of truth.
+Status: **Implemented in v0.6.0** (2026-05-06). Originally drafted as "RFC C", renumbered to D after `host-control-daemon.md` claimed the C slot in v0.7.x. This document is retained as the design record; the implementation is the source of truth.
 Author: klanker (sub-agent draft)
 Date: 2026-05-06
 
-Prerequisite: **RFC B — Approval kernel** (`reference/rfcs/approval-kernel.md`) — landed in v0.6.0 (#762). The Drive MCP is the first real consumer.
+Prerequisite: **RFC B — Approval kernel** (`reference/rfcs/approval-kernel.md`), landed in v0.6.0 (#762). The Drive MCP is the first real consumer.
 
 ## Implementation pointers
 
@@ -26,22 +27,22 @@ Add a Google Drive MCP server so agents can read and (with explicit approval) wr
 
 ## 2. MCP server choice
 
-**Pinned:** [`taylorwilsdon/google_workspace_mcp`](https://github.com/taylorwilsdon/google_workspace_mcp), MIT-licensed, pinned to an explicit upstream **commit SHA** (a tag's deref'd commit, not a floating ref, so upstream history rewrites can't change what we run). The RFC originally targeted `v0.5.x`, but no such tag exists upstream. The live pin is single-sourced in code as `GOOGLE_WORKSPACE_MCP_PINNED_SHA` (`src/memory/scaffold-integration.ts`) — that constant, with its doc comment, is the source of truth (currently the `v1.20.4` commit); do not duplicate the literal here, it only rots. Bump deliberately per the procedure in that comment + the `tests/docker/drive-mcp-pin-smoke.test.ts` guard.
+**Pinned:** [`taylorwilsdon/google_workspace_mcp`](https://github.com/taylorwilsdon/google_workspace_mcp), MIT-licensed, pinned to an explicit upstream **commit SHA** (a tag's deref'd commit, not a floating ref, so upstream history rewrites can't change what we run). The RFC originally targeted `v0.5.x`, but no such tag exists upstream. The live pin is single-sourced in code as `GOOGLE_WORKSPACE_MCP_PINNED_SHA` (`src/memory/scaffold-integration.ts`). That constant, with its doc comment, is the source of truth (currently the `v1.20.4` commit); do not duplicate the literal here, it only rots. Bump deliberately per the procedure in that comment + the `tests/docker/drive-mcp-pin-smoke.test.ts` guard.
 
 - **Runtime:** Python 3.11+, run via `uvx` so no system-wide install is required. Switchroom's existing MCP-subprocess machinery already supports `uvx`-launched servers.
 - **License:** MIT.
 - **Coverage:** Drive + Docs + Sheets + Calendar + Gmail in one binary. We use only the Drive + Docs surface in v1; the others are dormant and gated by their own future RFCs (Notion/Slack/Gmail RFCs may use this same server for Gmail rather than spinning up another).
 - **Why this one over alternatives:**
-  - `modelcontextprotocol/servers` reference Drive server (Node) is single-account-only, no refresh-token persistence — re-auth every restart, breaks headless installs.
+  - `modelcontextprotocol/servers` reference Drive server (Node) is single-account-only, no refresh-token persistence, so it re-auths every restart and breaks headless installs.
   - `isaacphi/mcp-gdrive` is read-only and per-doc-id only; no folder traversal, which makes RFC B's folder-coalescing pointless.
-  - Service-account-based servers (e.g. `googleworkspace/mcp-server`) bypass per-user OAuth, which collapses approval semantics — every access shows up as the service account, not the user.
+  - Service-account-based servers (e.g. `googleworkspace/mcp-server`) bypass per-user OAuth, which collapses approval semantics: every access shows up as the service account, not the user.
   - `taylorwilsdon/google_workspace_mcp` is actively maintained, supports per-user OAuth with refresh-token storage, exposes folder traversal, and is the only one of the four with a non-trivial test suite.
 
 We run the MCP server as a switchroom-managed subprocess of each agent that has Drive enabled, the same way other MCP servers are managed today. Configuration goes through the existing MCP config surface; no new config plane.
 
 ## 3. OAuth flow for headless hosts
 
-**The MCP server's stock OAuth flow assumes a desktop browser is reachable on the host running the bot. That is wrong for switchroom** — the host is typically a Linux box reached over SSH. The connect command must support both shapes:
+**The MCP server's stock OAuth flow assumes a desktop browser is reachable on the host running the bot. That is wrong for switchroom**: the host is typically a Linux box reached over SSH. The connect command must support both shapes:
 
 ### 3.1 Desktop-browser flow (when available)
 
@@ -78,22 +79,22 @@ The CLI auto-selects: try device-code, fall back to OOB-paste, fall back to desk
 ### 4.1 Storage
 
 - The refresh token lands in a vault slot at `gdrive:<agent_unit>:refresh_token`. ACL grants the agent's unit only.
-- Access tokens are short-lived (Google's default ~1h) and **never persisted** — the MCP wrapper holds them in process memory only and refreshes on demand using the vault-stored refresh token.
+- Access tokens are short-lived (Google's default ~1h) and **never persisted**. The MCP wrapper holds them in process memory only and refreshes on demand using the vault-stored refresh token.
 - The MCP wrapper, on startup, reads the refresh token via the broker, exchanges for an access token, and proceeds. If the broker is unreachable at startup, the wrapper exits with a clear "vault unreachable" error rather than caching a token to disk.
 
 ### 4.2 Rotation
 
 Google rotates refresh tokens silently in two cases: (a) when the user changes their Google password, (b) when the user revokes the app's access in their Google Account dashboard. There is no callback for either. The wrapper must handle a rotated/invalidated refresh token gracefully:
 
-- On a `invalid_grant` response from Google's token endpoint, the wrapper marks the slot as **invalid** (writes a sidecar `gdrive:<agent_unit>:refresh_token:status` slot containing `invalid_grant` + timestamp) and posts a kernel approval card titled "Drive disconnected — reconnect klanker?" with `[Reconnect]` `[Disconnect permanently]` buttons.
+- On a `invalid_grant` response from Google's token endpoint, the wrapper marks the slot as **invalid** (writes a sidecar `gdrive:<agent_unit>:refresh_token:status` slot containing `invalid_grant` + timestamp) and posts a kernel approval card titled "Drive disconnected, reconnect klanker?" with `[Reconnect]` `[Disconnect permanently]` buttons.
 - `[Reconnect]` runs `switchroom drive connect <agent>` again, which overwrites the slot.
-- The vault slot itself is overwrite-on-write (no version history) — there's no value in keeping invalid refresh tokens around, and Google may have already invalidated the one we held.
+- The vault slot itself is overwrite-on-write (no version history). There's no value in keeping invalid refresh tokens around, and Google may have already invalidated the one we held.
 
 ### 4.3 Revocation
 
 `switchroom drive disconnect <agent>` calls Google's `https://oauth2.googleapis.com/revoke` endpoint AND deletes the slot AND writes a `mcp:gdrive` audit row to `approval_audit` (RFC B §5).
 
-The kernel's `/revoke-all` killswitch (RFC B §9.2) iterates Drive-connected agents and calls the same revocation path before the kernel-level mass revoke. If Google's revoke endpoint fails for a given agent, the slot is still deleted locally and the failure is surfaced in the killswitch's status report — the user can manually revoke at `myaccount.google.com/permissions`.
+The kernel's `/revoke-all` killswitch (RFC B §9.2) iterates Drive-connected agents and calls the same revocation path before the kernel-level mass revoke. If Google's revoke endpoint fails for a given agent, the slot is still deleted locally and the failure is surfaced in the killswitch's status report. The user can manually revoke at `myaccount.google.com/permissions`.
 
 Vault path summary:
 - `gdrive:<agent_unit>:refresh_token` — the durable token.
@@ -103,7 +104,7 @@ Vault path summary:
 
 Per the reviewer's prompt-flood concern: per-doc default produces 20+ prompts on day 1 (initial folder browse + readme reads + the agent finding the right doc). That's a UX failure that trains the user to tap-through rather than read.
 
-**v1 default flips to "Allow my Drive (read-only)" — single grant, no per-doc prompts.** Per-doc remains an explicit option for security-conscious users. Onboarding copy makes the trade-off explicit so the user is choosing, not defaulting blindly:
+**v1 default flips to "Allow my Drive (read-only)": single grant, no per-doc prompts.** Per-doc remains an explicit option for security-conscious users. Onboarding copy makes the trade-off explicit so the user is choosing, not defaulting blindly:
 
 ```
 🆕 Google Drive enabled for klanker.
@@ -122,7 +123,7 @@ want a tap-by-tap audit trail.
 - "Per-doc approval" writes nothing; every doc access goes through `requestApproval`. This is the path the reviewer flagged as prompt-flood-prone, and the copy now warns explicitly before the user picks it.
 - "Cancel" exits without writing config; the operator can re-run `switchroom drive connect <agent>` later.
 
-A "Choose folders now" option was considered and dropped — without a real folder picker (deferred per §6) it would force the user to type folder IDs, which is worse than either default.
+A "Choose folders now" option was considered and dropped. Without a real folder picker (deferred per §6) it would force the user to type folder IDs, which is worse than either default.
 
 ## 6. Folder picker — deferred
 
@@ -130,7 +131,7 @@ A real Telegram-side folder picker (browse Drive, tap a folder, grant `doc:gdriv
 
 ## 7. Scope-prefix batch coalescing
 
-Per RFC B §11, the kernel buffers prompts for 5 seconds; if 3+ pending share a scope-prefix, it collapses into a single card. Drive is the first surface where this matters in practice — and it is the primary mitigation for users who chose per-doc in §5.
+Per RFC B §11, the kernel buffers prompts for 5 seconds; if 3+ pending share a scope-prefix, it collapses into a single card. Drive is the first surface where this matters in practice, and it is the primary mitigation for users who chose per-doc in §5.
 
 Common pattern: an agent opens a folder, then reads 6 docs in it back-to-back. With per-doc approval, that's 6 prompts. With coalescing:
 
@@ -156,8 +157,8 @@ A naive `present? yes/no` reconciler is wrong for Drive. A doc the agent expecte
 | **Conflict** | `files.get` returns 200 but the doc's `modifiedTime` is newer than the agent's last-seen `modifiedTime` AND content hash differs, OR the doc's `mimeType` changed (e.g. converted from Doc to PDF), OR `permissions` changed in a way that excludes the agent's owner. | Surface a "doc changed since last access" notice with the diff summary; require re-confirmation before write operations; reads proceed but flag the staleness in the response. |
 
 The reconciler runs:
-- On every doc access (cheap — same `files.get` round-trip the read needs anyway).
-- Lazily across the grant set when the user opens `/approvals list <agent>` — surfaces stale folder-grants where the underlying folder was deleted or renamed.
+- On every doc access (cheap, the same `files.get` round-trip the read needs anyway).
+- Lazily across the grant set when the user opens `/approvals list <agent>`, which surfaces stale folder-grants where the underlying folder was deleted or renamed.
 
 Conflict-state grants are not auto-revoked but are flagged with a `⚠️` badge in `/approvals list`. Missing-state grants beyond 30 days fold into the staleness digest (RFC B §9.1).
 
@@ -174,7 +175,7 @@ Conflict-state grants are not auto-revoked but are flagged with a `⚠️` badge
 3. Kernel posts the §5 onboarding card.
 4. Normal usage begins.
 
-The first week is the high-traffic window — under the new default ("Allow my Drive") expected steady-state taps drop to write-related only, which should be near-zero in v1 since writes default to per-action. Users who choose per-doc see the 10–30 taps/day burst RFC B §11 forecasts; the coalescing in §7 softens it but does not eliminate it.
+The first week is the high-traffic window. Under the new default ("Allow my Drive") expected steady-state taps drop to write-related only, which should be near-zero in v1 since writes default to per-action. Users who choose per-doc see the 10–30 taps/day burst RFC B §11 forecasts; the coalescing in §7 softens it but does not eliminate it.
 
 ## 11. Effort
 

--- a/reference/rfcs/google-workspace-generalization.md
+++ b/reference/rfcs/google-workspace-generalization.md
@@ -1,6 +1,7 @@
 ---
-artefact: Google Workspace as a first-class agent capability
-serves: jobs/act-in-my-tools-with-an-identity.md
+artifact: Google Workspace as a first-class agent capability
+serves: act-in-my-tools-with-an-identity
+advances-outcome: always-available
 status: Draft v3
 ---
 
@@ -18,7 +19,7 @@ RFC H rather than the deleted `auth account ...` shape:
 
 - **CLI shape collapses to `enable | disable | list`** (Phase 3a's
   shipped surface). Drop `share`, drop `connect <agent>` wizard alias
-  — RFC H deleted the equivalent Anthropic verbs (no `auth share`,
+  since RFC H deleted the equivalent Anthropic verbs (no `auth share`,
   no `auth login`). Account *creation* moves to `auth google account
   add <email>`, which becomes a thin client over the auth-broker
   (Phase 3b). See §4.5.
@@ -32,7 +33,7 @@ RFC H rather than the deleted `auth account ...` shape:
   for *non-agent peers needing an Anthropic-account socket*
   (hindsight is the in-tree consumer), NOT for non-Anthropic OAuth
   providers. Phase 3b.1 introduces a provider abstraction RFC H
-  deliberately deferred — this is a real architectural addition,
+  deliberately deferred. This is a real architectural addition,
   not a config-flag wiring exercise. The motivation stands:
   rebuilding a parallel refresher in `src/drive/` would duplicate
   flock leases, sha-index drift detection, and audit log machinery
@@ -101,7 +102,7 @@ $ switchroom auth google share you@example.com --from-agent klanker --to-agent e
    ✅ executive now has access via you@example.com (copied from klanker).
 ```
 
-(The shape mirrors `switchroom auth account add | enable | share | list | account remove` for Anthropic accounts. Google is the second vendor under `auth`; future vendors — Notion, Slack — follow the same `auth <vendor> ...` pattern.)
+(The shape mirrors `switchroom auth account add | enable | share | list | account remove` for Anthropic accounts. Google is the second vendor under `auth`; future vendors (Notion, Slack) follow the same `auth <vendor> ...` pattern.)
 
 End-to-end flow from a Telegram thread (uses RFC E §4.3 deep links + RFC D headless OAuth):
 
@@ -120,7 +121,7 @@ What's different from today (RFC D shipped state):
   alongside Drive + Docs.
 - Operator picks the tier (`core` / `extended` / `complete`) per agent
   rather than getting a hardcoded Drive surface.
-- Agent identity stays separate at the approval layer — `klanker`
+- Agent identity stays separate at the approval layer: `klanker`
   reading `/Q3 Strategy` is a different approval row than `gymbro`
   reading the same doc, even though they share the OAuth token.
 
@@ -139,7 +140,7 @@ Maps to three of the four outcomes in `reference/vision.md`:
   storage means a single broker keeps one token fresh, not N.
 
 Visibility (#1) is served by the existing approval kernel (RFC B) +
-RFC E's diff-preview surface — no new work for that outcome here.
+RFC E's diff-preview surface. No new work for that outcome here.
 
 ## 3. JTBD alignment
 
@@ -207,10 +208,10 @@ Maps directly to the upstream MCP's `--tool-tier` flag.
   agent newly connected.
 - `extended` (~40 tools): adds Slides, Forms, Tasks, Chat.
 - `complete` (~60+ tools): adds Gmail (which has its own approval-
-  shape considerations — see §5 out of scope).
+  shape considerations, see §5 out of scope).
 
 Tier is per-agent, not per-account. Two agents on the same account
-can have different tiers — each runs its own MCP wrapper subprocess
+can have different tiers. Each runs its own MCP wrapper subprocess
 inside its own container, configured with its tier. The OAuth token
 is shared; the **MCP server process is not** (preserving RFC D's
 per-agent subprocess model and its security properties).
@@ -244,7 +245,7 @@ manifest; unknown tool names fail fast with the suggestion list.
 - **auth-broker** (RFC H) — sole OAuth refresher and credentials
   writer. As shipped by RFC H, supports Anthropic only.
   Phase 3b.1 of *this* RFC adds the provider abstraction the
-  broker needs to host Google as a second provider — RFC H
+  broker needs to host Google as a second provider. RFC H
   deliberately scoped the broker to Anthropic-only ("speaks OAuth
   and only OAuth" per RFC H §3); the multi-provider extension
   is RFC G's contribution, not RFC H's. Once 3b.1 lands the
@@ -276,7 +277,7 @@ The vault-broker's `checkAclByAgent()` routes `google:<acct>:*` keys
 through `google_accounts.<acct>.enabled_for[]` instead of the
 per-cron `schedule.secrets[]` allowlist. Fail-closed on unknown
 account, empty `enabled_for`, or agent-not-in-list. This is the
-load-bearing security boundary — without the ACL, any agent could
+load-bearing security boundary: without the ACL, any agent could
 read any Google account's token from vault.
 
 **Drift handling — loud removal, not polite mirror** (v3 change per
@@ -308,7 +309,7 @@ retrieved post-RFC-H. Wrapper startup:
    to the upstream MCP, no token persistence inside the wrapper.
 
 Refresh ticks happen entirely inside auth-broker per RFC H §4.7's
-flock-protected lease primitive — wrapper never re-fetches refresh
+flock-protected lease primitive. Wrapper never re-fetches refresh
 tokens from vault, never owns the refresh loop. Identical pattern
 to Anthropic; no Google-specific refresh code in `src/drive/`.
 
@@ -318,10 +319,10 @@ to Anthropic; no Google-specific refresh code in `src/drive/`.
 `auth ...` (the post-RFC-H Anthropic surface). Google is the second
 auth vendor; future vendors (Notion, Slack) follow the same `auth
 <vendor> ...` pattern. `switchroom workspace` already exists as a
-top-level verb (manages AGENTS.md/MEMORY.md scaffold files) — using
+top-level verb (manages AGENTS.md/MEMORY.md scaffold files), so using
 it for Google would silently break operators.
 
-**Important divergence from Anthropic post-RFC-H** — Google and
+**Important divergence from Anthropic post-RFC-H.** Google and
 Anthropic have *different* problems, so the verb shapes are allowed
 to differ:
 
@@ -374,7 +375,7 @@ switchroom auth google account list                    # bare accounts (no agent
 (device-code → OOB-paste → desktop-loopback). On a host with no
 `$DISPLAY`, the device-code flow is used by default; explicit
 `--headless` forces it. The OAuth flow itself moves into
-`src/auth/broker/google-provider.ts` (Phase 3b — see §7) — the CLI
+`src/auth/broker/google-provider.ts` (Phase 3b, see §7). The CLI
 verb is a thin client.
 
 **`account remove` refuses** while any agent is still enabled on
@@ -388,7 +389,7 @@ audit row, not three.
 **`disable` prunes when `enabled_for` empties** (v3 change per RFC
 H §10): no "dormant ACL" intermediate state. If the operator wants
 the account to stay configured but have no agents, they can leave
-`enabled_for: []` in YAML by hand — the CLI doesn't write that
+`enabled_for: []` in YAML by hand. The CLI doesn't write that
 shape.
 
 ### 4.6 Setup wizard inline prompt
@@ -408,7 +409,7 @@ Connect now? [Y/n] _
 ```
 
 Default Y. Phase 4 (already merged) prints the next-step command
-and continues — does NOT run OAuth inline (would break the linear
+and continues. Does NOT run OAuth inline (would break the linear
 wizard, same reason RFC H §4.6 doesn't auto-add an account).
 
 **Phase 4 (today)** surfaces the legacy command for back-compat:
@@ -428,7 +429,7 @@ deliberately separate verbs; the wizard surfaces both lines but
 runs neither inline.
 
 Survives the docs test (no docs reading needed) and the defaults
-test (no config-by-default for users who aren't using Workspace —
+test (no config-by-default for users who aren't using Workspace,
 opt-in but advertised).
 
 ### 4.7 `examples/personal-google-workspace-mcp/` for operator-host use
@@ -444,10 +445,10 @@ examples/
     .env.example       # OAuth client ID + signing-key placeholder
 ```
 
-**Distinct from the agent-side feature** above — the README opens
+**Distinct from the agent-side feature** above: the README opens
 with: *"This is for **operators** who want their **own** Claude Code
 on the host to have Workspace tools (alongside or instead of giving
-agents access). It does not affect switchroom agents — they get
+agents access). It does not affect switchroom agents; they get
 Workspace via `switchroom auth google account add` + `enable` (RFC G §4.5)."*
 
 Today `examples/` contains only top-level YAMLs (`minimal.yaml`,
@@ -461,7 +462,7 @@ Slack, etc.) follow the same shape under `examples/personal-*-mcp/`.
   account at a time. If an agent needs both `you@example.com` and
   `work@bigcorp.com`, that's a future spec. Ad-hoc workaround:
   spin up a second agent on the second account. **This is
-  acknowledged as the most likely follow-up RFC** — operators who
+  acknowledged as the most likely follow-up RFC.** Operators who
   run a personal+work life from one assistant agent will hit it
   fast. The fix probably looks like a list-valued `accounts:` config
   block + a runtime account-picker on tool invocation. Out of scope
@@ -500,18 +501,18 @@ Per `reference/principles.md`:
   same way for the first-run path.
 - ✅ Setup wizard prompt explains *what* and *why* in two
   sentences ("read and (with approval) write to your Drive, Docs,
-  Sheets, Calendar — tools appear as approval-gated requests").
-- ✅ `workspace list` is self-documenting — accounts × agents
+  Sheets, Calendar; tools appear as approval-gated requests").
+- ✅ `workspace list` is self-documenting: accounts × agents
   matrix tells the user the state.
 - ✅ Drift error (agent removed from ACL) tells the user the next
   command.
 
 ### 6.2 Defaults test — *"Does it work on a fresh `switchroom setup`?"*
 
-- ✅ Tier defaults to `core` — the validated 16-tool surface.
+- ✅ Tier defaults to `core`, the validated 16-tool surface.
 - ✅ Setup wizard offers Workspace by default (Y), so a fresh
   install gets it without config-file editing.
-- ✅ Per-account storage is the default once enabled — no operator
+- ✅ Per-account storage is the default once enabled: no operator
   has to opt into "share auth across the fleet"; that's just how it
   works.
 - ✅ Per-agent approval default is per-action (RFC B / RFC E
@@ -524,21 +525,21 @@ Per `reference/principles.md`:
   `auth`; sibling to RFC H's `auth add|use|rotate|rm` for
   Anthropic. Different verb shapes are honest because the
   problems differ (Anthropic = quota routing, Google = per-
-  account access ACL — see §4.5 divergence note).
+  account access ACL, see §4.5 divergence note).
 - ✅ `vault:google:<acct>:*` matches the `vault:<surface>:*` slot
   pattern.
-- ✅ Auth-broker is the single OAuth refresher per host (RFC H §4.7)
-  — Google plugs in via the provider abstraction (Phase 3b), not
+- ✅ Auth-broker is the single OAuth refresher per host (RFC H §4.7).
+  Google plugs in via the provider abstraction (Phase 3b), not
   a parallel refresher.
 - ✅ `apv:` callback shape unchanged; new tools added to existing
   approval kernel.
-- ✅ `/approvals list|revoke|add|stats` surface unchanged — adding
+- ✅ `/approvals list|revoke|add|stats` surface unchanged: adding
   Calendar/Sheets/Slides scopes adds rows, not commands.
 - ✅ Cascade rules for `google_workspace:` block follow standard
   per-key merge (`src/config/merge.ts`), documented same way as
   every other config field.
 - ✅ Setup wizard prompt is in the same style as the bot-token and
-  first-agent prompts — opinionated default, easy decline.
+  first-agent prompts: opinionated default, easy decline.
 - ✅ "Loud removal beats polite mirror" applied to ACL pruning per
   RFC H §10's decision against dormant intermediate states.
 
@@ -551,19 +552,19 @@ merged first.
 
 ### Already shipped
 
-1. **Phase 1 — Config block + tier knob (no breaking changes)** —
+1. **Phase 1 — Config block + tier knob (no breaking changes)**:
    merged #1244. `google_workspace:` block + `drive:` alias + tier
    enum. Backwards-compatible.
-2. **Phase 2 — Per-account vault slot + per-agent ACL primitive** —
+2. **Phase 2 — Per-account vault slot + per-agent ACL primitive**:
    merged #1246. New helpers in `src/drive/vault-slots.ts`, ACL
    routing in `src/vault/broker/acl.ts`, top-level `google_accounts:`
-   schema. **Currently inert** — no code consumes it yet (Phase 3b
+   schema. **Currently inert**: no code consumes it yet (Phase 3b
    wires the wrapper read).
-3. **Phase 3a — `auth google enable | disable | list` CLI verbs** —
+3. **Phase 3a — `auth google enable | disable | list` CLI verbs**:
    merged #1247. Operators can populate `google_accounts.enabled_for[]`.
-4. **Phase 4 — Setup wizard Step 11** — merged #1248. Prompt only;
+4. **Phase 4 — Setup wizard Step 11**: merged #1248. Prompt only;
    surfaces the connect command.
-5. **Phase 5 — `examples/personal-google-workspace-mcp/`** —
+5. **Phase 5 — `examples/personal-google-workspace-mcp/`**:
    merged #1245. Operator-host docker-compose pattern, fully usable.
 
 ### Phase 3b — auth-broker integration (post-RFC-H, post-#1254)
@@ -581,7 +582,7 @@ Scope:
   mapping, error mapping (provider-specific OAuth error codes →
   broker's `invalid_grant` / `network` / `quota_exceeded`).
 - Provider plugin loading at broker startup (mirrors how the
-  vault-broker loads ACL config) — providers ship as files under
+  vault-broker loads ACL config): providers ship as files under
   `src/auth/broker/<vendor>-provider.ts`.
 - Per-provider refresh tick — RFC H's existing flock-protected
   lease primitive needs to key on `(provider, account)`, not just
@@ -639,7 +640,7 @@ Identity is path-as-identity (agent name from socket path); broker
 validates `agent ∈ google_accounts.<acct>.enabled_for[]`.
 
 After 3b.4 lands, the agent containers ARE actually using
-per-account shared tokens with per-agent ACL — the load-bearing
+per-account shared tokens with per-agent ACL, the load-bearing
 RFC G goal.
 
 #### 3b.5 — Apply-time legacy-slot migration (~60 min)
@@ -656,14 +657,14 @@ slot + populates `google_accounts.<account>.enabled_for[]`, deletes
 the legacy slot.
 
 Mirrors RFC H §6 ("rewrite once, refuse second run") rather than
-the v2 "warn and continue" design — RFC H showed loud-fail is the
+the v2 "warn and continue" design. RFC H showed loud-fail is the
 honest default for installed-base migrations.
 
 #### 3b.6 — Setup wizard pivot to two-step `account add` + `enable` (~10 min)
 
 The shipped Phase 4 (`src/cli/setup.ts:1112-1200`) explicitly
 anticipates `auth google connect <agent>` as a future surfaced
-command — but v3 §4.5 deletes that verb. Phase 3b.6 rewrites the
+command, but v3 §4.5 deletes that verb. Phase 3b.6 rewrites the
 `connectCmd` constant + the surrounding comment block in
 `stepGoogleWorkspace` to surface the two-step shape per §4.6:
 
@@ -711,7 +712,7 @@ Per CLAUDE.md, in **agent minutes**.
 
 **~5.75-6.5h agent time** for Phase 3b. Total RFC G end-to-end:
 ~9.5-10.25h. (v3-initial estimate of ~4.25h was too aggressive
-per reviewer — provider abstraction is real architectural work,
+per reviewer: provider abstraction is real architectural work,
 not a config-flag wiring exercise.)
 
 ## 9. Risks and open questions
@@ -720,8 +721,8 @@ not a config-flag wiring exercise.)
   If `klanker` is enabled at `tier: core` (Drive+Docs+Sheets+Cal)
   and the operator later runs `account remove` + `account add` to
   re-consent for `gymbro` at `tier: extended` (adds Slides), the
-  shared refresh token now grants Slides scope to **klanker too**
-  — even though klanker's operator never approved that. The kernel
+  shared refresh token now grants Slides scope to **klanker too**,
+  even though klanker's operator never approved that. The kernel
   still gates writes per-agent (Slides write requires a fresh
   approval card), but reads of newly-scoped surfaces are not
   gated. Mitigation: re-consent triggered by tier-bump posts a
@@ -731,7 +732,7 @@ not a config-flag wiring exercise.)
   unwanted.
 
 - **Approval kernel drift on agent removal.** `disable <account>
-  <agents...>` orphans the agents' standing approvals — they get
+  <agents...>` orphans the agents' standing approvals; they get
   `not_authorized` from the broker on next use. Mitigation: the
   approval-kernel surfaces a single chat nudge identifying the
   removed-agent + grant + the `auth google enable` command to
@@ -743,17 +744,17 @@ not a config-flag wiring exercise.)
   connect` for multiple agents on the same Google account ends up
   with N copies of the same refresh token in N per-agent slots.
   The migration tool needs to ask the operator "which Google
-  account does each per-agent slot belong to?" — there's no
+  account does each per-agent slot belong to?". There's no
   programmatic way to know (the slot key is per-agent, not
   per-account). Mitigation: migration tool prompts interactively
   AND surfaces the legacy slot's cached scope set + last-refresh
-  timestamp in the prompt — these are the only on-disk hints
+  timestamp in the prompt. These are the only on-disk hints
   for identifying which Google account is which. Falls back to
   "skip and re-OAuth" if operator can't remember.
 
 - **Inheritance of RFC H known-blocker class.** PR #1254 (RFC H)
   was reviewed with three blockers, including: *"`auth use` does
-  not persist `auth.active` to YAML — the broker mutates
+  not persist `auth.active` to YAML, the broker mutates
   in-memory only, so on any restart it re-reads YAML and the
   swap reverts."* Phase 3b.3 (`auth google account add / remove`)
   writes `google_accounts:` to YAML and expects the broker to
@@ -766,12 +767,12 @@ not a config-flag wiring exercise.)
   mirror the same pattern in `auth google account add / remove`.
 
 - **Tier change after connect.** Going from `core` to `extended`
-  doesn't expand granted OAuth scopes — Google's consent already
+  doesn't expand granted OAuth scopes. Google's consent already
   completed. The new tier's tools that need broader scopes will
   fail at runtime. Mitigation: `apply` checks each agent's tier
   against the cached `google:<acct>:scopes` slot; warns operator
   inline if the upgrade requires re-consent: *"klanker's tier
-  bumped to extended — needs Slides scope. Run `auth google
+  bumped to extended, needs Slides scope. Run `auth google
   account remove you@example.com` + `account add` to re-consent,
   or exclude Slides tools."*
 
@@ -779,7 +780,7 @@ not a config-flag wiring exercise.)
   but recommended" prompts during setup, the user starts skipping
   by reflex. Workspace prompt sits after bot-token + first-agent
   + (potentially) Hindsight memory; that's already three Y/n
-  prompts. Mitigation: order matters — Workspace prompt comes
+  prompts. Mitigation: order matters. Workspace prompt comes
   *last* in the optional-features sequence, after the user has
   seen the agent respond once. Fewer dropouts at the end.
 
@@ -787,7 +788,7 @@ not a config-flag wiring exercise.)
   operator manually edits `~/.switchroom/google_accounts.yaml`
   (or wherever ACL lives) outside the CLI, the broker's view and
   the CLI's view of "who's enabled" can diverge. Mitigation: ACL
-  state is a derived view, not source-of-truth — `auth google
+  state is a derived view, not source-of-truth: `auth google
   list` reads the broker, `enable/disable` writes through the
   broker.
   No manual edit path documented; the file (if any) is internal.

--- a/reference/rfcs/hindsight-synthesis-layers.md
+++ b/reference/rfcs/hindsight-synthesis-layers.md
@@ -1,6 +1,7 @@
 ---
-artefact: Hindsight primitive fit — use the synthesis layers the memory job demands
-serves: jobs/remember-across-sessions.md
+artifact: Hindsight primitive fit — use the synthesis layers the memory job demands
+serves: remember-across-sessions
+advances-outcome: standing-team
 relates: jobs/run-a-fleet-of-specialists.md, jobs/feel-like-a-colleague.md
 status: proposal (2026-06-18, rev. speed/token budget) — analysis + phased plan, not yet scheduled
 ---
@@ -8,8 +9,8 @@ status: proposal (2026-06-18, rev. speed/token budget) — analysis + phased pla
 # Hindsight synthesis layers — what we run vs. what the job asks for
 
 Switchroom runs the Hindsight memory engine but consumes only its
-weakest layer. Hindsight ships four tiers of memory — raw facts,
-**observations**, **directives**, **mental models** — and an agentic
+weakest layer. Hindsight ships four tiers of memory (raw facts,
+**observations**, **directives**, **mental models**) and an agentic
 **reflect** path built to prefer the top tiers. Switchroom uses it as a
 *raw-fact store*: retain everything → recall raw `world`/`experience`
 facts → inject them invisibly. That is close to the exact shape the
@@ -18,7 +19,7 @@ names as **bad** ("raw transcript dumping passed off as memory",
 "grab-bag", "every memory equally weighted"). The synthesis tiers are
 the job's **good** ("curated, semantic, retrieved by relevance",
 "honest legible answer about what it believes and why"), and they're
-already being generated on the subscription — just not consumed.
+already being generated on the subscription, just not consumed.
 
 This is a design record + phased proposal. It does not change a job
 spec or an invariant; it argues for using capability we already pay
@@ -33,13 +34,13 @@ for, within the lines.
   requests `types=["world","experience"]` only (vendored plugin default;
   `vendor/hindsight-memory/scripts/lib/config.py`), so the synthesized
   layer is excluded from what reaches the agent. We pay the
-  consolidation cost and drop the output.
+  consolidation cost and throw away the output.
 - **One mental model per agent.** Every agent bank has exactly the
   host-seeded `user-profile` model (`src/memory/hindsight.ts`
   `ensureUserProfileMentalModel`). Nothing creates more; the engine
   never auto-creates them (only `create_mental_model` does, an explicit
   call). The richer banks (clerk/`assistant`: 4 models; `lawgpt`: 7)
-  were curated by hand, not grown.
+  were curated by hand. They didn't grow on their own.
 - **Reflect prefers the tiers we don't feed it.** The reflect agent's
   forced tool order is `search_mental_models` → `search_observations`
   → `recall` (raw) (with `expand` available but not forced); on a
@@ -83,13 +84,13 @@ extraction, synthesis, and voice per bank.
 ## Where Hindsight would *not* help — invariant tensions
 
 The synthesis tiers help, but some of Hindsight's always-on behavior
-rubs against switchroom's lines. Name these honestly; the proposal is
+rubs against switchroom's lines. Name these honestly. The proposal is
 shaped to stay clean of them.
 
 1. **Silent background consolidation vs
    [`chat-is-the-single-source-of-truth`](../invariants.md) + `on-leash`.**
    The engine runs LLM consolidation/observation/graph-building the
-   operator never triggered and never sees — "memory silently updating
+   operator never triggered and never sees. "Memory silently updating
    on patterns the user can't see" is the anti-pattern the job names.
    Bounded and inspectable in output, but it is background model-spend
    on the subscription the operator didn't initiate (also brushes
@@ -101,11 +102,11 @@ shaped to stay clean of them.
 3. **Auto-creating mental models vs `on-leash` / `no-self-escalation`.**
    An agent enriching its own memory structure unprompted is borderline
    self-escalation. The invariant-clean shape is **operator-curated, or
-   agent-proposes → operator-confirms, surfaced in chat** — never a
+   agent-proposes → operator-confirms, surfaced in chat**, never a
    silent self-write.
 4. **No time-based decay is actually aligned.** Hindsight never forgets
    (recency is a soft ±10% weight); the job calls silent forgetting bad
-   and wants *explicit* demote/correct — which exists (the
+   and wants *explicit* demote/correct, which exists (the
    `[demote-from-recall]` tag + `invalidate_memory`). Keep it.
 
 `single-tenant` and `claude-native` are satisfied by construction
@@ -121,21 +122,21 @@ and crosses no invariant.
 Add `observation` to the auto-recall `types`. Turns 45k of paid-for,
 deduped, provenance-carrying observations from dead weight into the
 "curated, by-relevance" recall the job demands. Pure consumption change
-(retrieval + local rerank, no model call) — it adds one
+(retrieval + local rerank, no model call). It adds one
 per-fact-type retrieval arm, but the cross-encoder rerank stays bounded
-by the 300-candidate cap, so the added latency is *bounded*, not zero;
-and observations are *denser* (one synthesized statement replaces N raw
+by the 300-candidate cap, so the added latency is *bounded*, not zero.
+And observations are *denser* (one synthesized statement replaces N raw
 facts) so coverage improves inside the same 1024-token cap. **Do not**
 route the hot recall path through `reflect` (an agentic loop, ~5–10
-iterations / 10 ceiling, 300s wall-timeout) — that would blow warm TTFO
-(~1.7s) into seconds and multiply per-turn tokens; reflect stays reserved
+iterations / 10 ceiling, 300s wall-timeout): that would blow warm TTFO
+(~1.7s) into seconds and multiply per-turn tokens. Reflect stays reserved
 for explicit "what do you know about me" asks (where it belongs and is
-kept — Phase 5 builds on it).
+kept, Phase 5 builds on it).
 
 **Phase 2 — Specialize each bank.** Set a per-agent `retain_mission` /
 `reflect_mission` / `disposition` from the agent's profile (a coach
 extracts/voices differently than a lawyer). Makes specialists'
-memory *specialized*, not merely *isolated* — directly serves
+memory *specialized*, not merely *isolated*, and directly serves
 fleet-of-specialists. Operator-config-driven (no-self-escalation clean).
 
 **Phase 3 — Directives as the "corrections stick" path.** Route
@@ -146,7 +147,7 @@ respected / correction sticks" criteria.
 
 **Phase 4 — Make memory chat-legible (sparse, not per-turn).** Surface a
 terse "remembered: X" / "updated what I know about Y" line so recall and
-consolidation stop being invisible — closing tension (1) and (2). **This
+consolidation stop being invisible, closing tension (1) and (2). **This
 must be sparse and material-only**, never default-on-every-turn:
 the job lists "regurgitating old facts unprompted just to prove it
 remembered" as a top anti-pattern, so a per-turn legibility line would
@@ -158,10 +159,10 @@ side without polling.
 Operator-curated, or agent-proposes → operator-confirms in chat, for
 specialists that earn a pinned model (the gap behind "Hindsight doesn't
 create models as needed"). Deliberately *not* autonomous creation
-(tension 3). Curate **selectively** — a model set to
+(tension 3). Curate **selectively**: a model set to
 `refresh_after_consolidation` (which defaults *off*) adds
 post-consolidation refresh spend (bounded ~2048 tokens, and a reflect
-refresh can hit the 300s wall-timeout — observed historically on this
+refresh can hit the 300s wall-timeout, observed historically on this
 fleet), so more refresh-enabled models is more invisible background cost.
 Their upside is real on the *explicit* reflect path (fresh models let
 reflect short-circuit the lower tiers → faster), but they do not speed
@@ -170,32 +171,32 @@ the hot recall path.
 **Phase 6 — Two near-free hot-path levers (UX + speed + tokens).** Not
 synthesis-tier work, but the largest responsiveness/cost wins and they
 cross no invariant:
-- **Gate recall on need.** Recall fires on *every* substantive turn — a
+- **Gate recall on need.** Recall fires on *every* substantive turn. A
   trivial "what time is it" still pays a ~1–2s recall arm (budget `low`)
   + up to 1024 injected tokens it never uses. The hook already skips
   ultra-short and ack-phrase turns; this *extends* that skip to
   plausibly-stateless/trivial asks, speeding the warm-TTFO path the
   `jtbd-fast-trivial-dm` gate measures *and* saving tokens. **Caveat
-  (symmetry with 6b):** the failure mode is a false negative — gating a
+  (symmetry with 6b):** the failure mode is a false negative. Gating a
   turn that *did* need memory undercuts the job's continuity criteria,
   so this lever is likewise gated on proving no recall-quality
   regression, not shipped blind.
 - **Right-size retain cadence.** `retainEveryNTurns=1` means every turn
-  triggers background consolidation (sonnet) — the single largest
+  triggers background consolidation (sonnet), the single largest
   *invisible* subscription draw (live: on the order of ~1M consolidation
   tokens/day/agent, ~100% of an agent's LLM spend), and the engine room
   of tension (1). Firing retain every 2–3 turns instead cuts that
-  roughly in proportion — an order-of-magnitude estimate, not derived
+  roughly in proportion. This is an order-of-magnitude estimate, not derived
   math: switchroom runs `full-session` retain mode (not chunked), so
   each fire re-consolidates the accumulated transcript and the per-fire
   cost grows with session length, making the real savings curve
   non-linear. **Caveat:** the every-turn setting is deliberate (the
   restart-memory-loss UAT), so this is a real tradeoff to measure, not a
-  free win — gated on proving no memory-loss regression.
+  free win, and is gated on proving no memory-loss regression.
 
 ## Speed & token budget
 
-The fit argument above is about *correctness*; this section weighs
+The fit argument above is about *correctness*. This section weighs
 *cost*. Two latency/token surfaces matter, and they pull in opposite
 directions:
 
@@ -205,13 +206,13 @@ directions:
   timeout inside the 12s hook ceiling, injecting up to 1024 tokens of
   context. It is on the critical path for warm TTFO (~1.7s baseline,
   gated by `jtbd-fast-trivial-dm`), so anything added here is felt
-  directly — but it spends *no* model tokens. (`low` is operator-raisable
+  directly, but it spends *no* model tokens. (`low` is operator-raisable
   to `mid` ~5s, which adds an LLM rerank pass; switchroom does not.)
 - **Background (invisible).** Every retain triggers consolidation
   (sonnet, on the subscription) the operator never sees;
   `retainEveryNTurns=1` makes that per-turn. This is the largest
-  *uncounted* subscription draw — live, it is essentially **100% of an
-  agent's model spend** (order ~1M consolidation tokens/day/agent) — and
+  *uncounted* subscription draw. Live, it is essentially **100% of an
+  agent's model spend** (order ~1M consolidation tokens/day/agent), and
   the engine room of invariant tension (1). Mental-model refreshes (when
   refresh-enabled) add to it.
 
@@ -230,12 +231,12 @@ Per-phase scorecard against the three axes:
 Net read: **Phase 1(a), 2, 3, 6a** are positive-or-neutral on all three
 axes (1(a) and 6a are close to free wins). **Phase 4** is UX-positive
 only if kept sparse. **Phase 5** trades background tokens for
-explicit-reflect speed — curate selectively. **Phase 6b** is the biggest
+explicit-reflect speed, so curate selectively. **Phase 6b** is the biggest
 token lever but a measured tradeoff, not a free win.
 
 ## Verdict check (the four-part rule)
 
-- **Advances an outcome?** Yes — `standing-team`, via the core memory
+- **Advances an outcome?** Yes, `standing-team`, via the core memory
   job and the specialist job.
 - **Satisfies the job spec?** Moves recall from the job's *bad* column
   (grab-bag/raw) toward its *good* column (curated/legible/by-relevance).
@@ -243,7 +244,7 @@ token lever but a measured tradeoff, not a free win.
   config defaults, no operator assembly. Docs: behavior improves without
   new user-facing concepts. Consistency: same vault/config cascade.
   Speed/tokens: net-positive or measured (see *Speed & token budget*).
-- **Crosses an invariant?** No — each phase is shaped to avoid the
+- **Crosses an invariant?** No. Each phase is shaped to avoid the
   tensions named above (no autonomous self-writes; legibility added, not
   removed).
 

--- a/reference/rfcs/host-control-daemon.md
+++ b/reference/rfcs/host-control-daemon.md
@@ -27,7 +27,7 @@ on the unhappy path.
 
 This closes the long-tracked "true self-modification" gap from #1164:
 an in-container agent can stage a code change in its own worktree
-(`repos:` pattern), open a PR, get review, and then — after merge —
+(`repos:` pattern), open a PR, get review, and then (after merge)
 ask the daemon to deploy the change to the running fleet. Today step 4
 forces the operator out of Telegram and onto the host shell.
 
@@ -48,7 +48,7 @@ synchronous shell-outs** the gateway issues per session, all targeting
    `spawnSwitchroomDetached`, restart marker + sweep. The gateway
    runs *inside* the agent container in v0.7+, so the legacy
    cgroup-escape branch in `spawnSwitchroomDetached` (a v0.6 holdover)
-   never executes — the detached child is just `spawn(..., {detached:
+   never executes. The detached child is just `spawn(..., {detached:
    true}).unref()` and the agent container's restart policy
    (`--restart unless-stopped` on the compose service) cleans up if
    the parent dies. Workable today but couples agent-restart UX to
@@ -74,7 +74,7 @@ Two adjacent forces:
 
 - **The "self-restart from inside" pattern is fragile.** The gateway
   asking docker (via `switchroom agent restart`) to restart its own
-  container is a circular dependency — the parent issuing the
+  container is a circular dependency. The parent issuing the
   restart is killed by the restart it requested. Today's
   `spawnSwitchroomDetached` + restart-marker dance navigates around
   this, but it ties self-restart UX to the gateway's process tree.
@@ -149,13 +149,13 @@ distribution alongside the existing `switchroom-broker`,
 
 **Deployment shape: host-side docker container, outside the
 switchroom compose project.** Matches the v0.7+ docker-first
-ethos — every other component (broker, kernel, agent) is a docker
+ethos. Every other component (broker, kernel, agent) is a docker
 container; the daemon follows suit. The container runs with
 `network_mode: host` (so its UDS paths land on the operator's
 filesystem at `~/.switchroom/hostd/`), `--restart unless-stopped`,
 and the docker socket bind-mounted in. Operators bring it up
 either via a one-line `docker run` or a sibling
-`~/.switchroom/hostd/docker-compose.yml` file — **a separate
+`~/.switchroom/hostd/docker-compose.yml` file, **a separate
 compose project** from `switchroom` itself.
 
 **Why a separate compose project, not a sibling service in the
@@ -181,7 +181,7 @@ The daemon container declares those caps explicitly (see the
 **Same release surface as everything else.** The daemon ships
 from `ghcr.io/switchroom/switchroom-hostd:<tag>`, pulled on
 `switchroom update` like the other images. Operators don't manage
-yet-another-supervisor system — they `docker pull`, `docker run`,
+yet-another-supervisor system. They `docker pull`, `docker run`,
 `docker logs`, `docker stop`. No systemd dependency. No Linux-
 specific deployment paths. Works on macOS dev hosts the same way
 it works on production Linux. `switchroom hostd install` (Phase
@@ -228,7 +228,7 @@ Notes on the compose shape:
   absolute path.
 
 The daemon shells out to a `switchroom` CLI invocation inside its
-own container — the image bakes in the same bundle as the agent
+own container. The image bakes in the same bundle as the agent
 images (`/opt/switchroom/switchroom.js`). Mounting the docker
 socket lets the in-container CLI's `apply` / `update` paths reach
 the host's docker daemon. `--restart unless-stopped` means a daemon
@@ -311,7 +311,7 @@ error: "verb not in v1 allowlist"`. New verbs land via RFC + table
 addition.
 
 **Optional `reason` on gated verbs.** Every operator-gated verb accepts an
-optional `reason` (≤512 chars). It is NOT forwarded to the spawned CLI — it
+optional `reason` (≤512 chars). It is NOT forwarded to the spawned CLI. It
 exists solely to populate the Telegram approval card's `why:` line so the
 operator can decide in context. The card reads the caller-supplied `reason`
 arg only, never the tool's static schema description (#2469). Agents are
@@ -323,7 +323,7 @@ survives Claude Code's ~200-char `input_preview` truncation.
 (load-bearing): the long-running verbs (`update_apply` at 20–60s,
 `apply` at 5–20s) return `result: "started"` within ~50ms, then run
 detached. Without a query mechanism, the gateway can't tell whether a
-verb succeeded, failed fast, or is still running — a regression
+verb succeeded, failed fast, or is still running. That's a regression
 versus today's `notifyDetachedFailure` (`gateway.ts:7776`) which
 catches non-zero exits within ~5s. `get_status` closes the gap:
 gateway polls every ~2s for `started`-result verbs, drives the
@@ -353,7 +353,7 @@ Three layers, layered fail-closed:
      daemon's needs.
 
 For `agent_restart` self-targeting (`args.name === caller.identity.name`),
-the gate downgrades to `any` — matches the gateway's current behavior
+the gate downgrades to `any`, matching the gateway's current behavior
 (`/restart` self-targeting works without admin).
 
 The daemon never has the vault passphrase. Attestation reuses the
@@ -368,12 +368,12 @@ admin-client connection to the broker (mounted at
 path at `server.ts:1668-1695`. No new broker RPCs are added; no
 passphrase fingerprint is introduced (an earlier draft sketched a
 `status`-op fingerprint, but it would have widened the broker's
-same-UID attack surface to offline guessing — struck in favour of
+same-UID attack surface to offline guessing, struck in favour of
 plaintext-forward).
 
 **Trust-loop sanity.** A compromised in-container actor that can
 already drive the broker via the agent's vault-request flow can
-already attest if `/vault unlock` was recent — that's the existing
+already attest if `/vault unlock` was recent. That's the existing
 envelope, not new surface. The daemon does not enlarge it: it just
 exposes a *different* operation set behind the same gate. Recovery
 posture (`switchroom vault lock` from the host) is unchanged.
@@ -408,7 +408,7 @@ Tail consumable by `switchroom audit hostd` (new verb) and by the
 admin agents' `/audit hostd` Telegram command (mirrors `/vault audit`).
 
 Log rotation inherits `vault-audit.log`'s policy verbatim
-(`logrotate.d/switchroom-vault-audit` per `docs/vault-broker.md` —
+(`logrotate.d/switchroom-vault-audit` per `docs/vault-broker.md`:
 size-trigger rotation, retain N generations). The setup helper
 installs an analogous `logrotate.d/switchroom-host-control-audit`
 fragment.
@@ -447,13 +447,13 @@ sibling project (the daemon itself).
   `~/.switchroom/hostd/<name>/` (host) → `/run/switchroom/hostd/<name>/`
   (agent container). Gated on `host_control.enabled` AND the host
   directory existing (same `existsSync` guard pattern as the
-  vault-audit.log mount — docker compose `up` hard-fails on a
+  vault-audit.log mount; docker compose `up` hard-fails on a
   missing bind source).
 - Both ends of the bind are on the host filesystem; no named volume
   is needed (the daemon container also bind-mounts the same host
   path, so they share the file directly).
 - No compose service for the daemon itself in the switchroom
-  project — see §5.1 for why (would get recreated on
+  project. See §5.1 for why (would get recreated on
   `update_apply`).
 
 **New sibling project (`~/.switchroom/hostd/docker-compose.yml`):**
@@ -463,7 +463,7 @@ sibling project (the daemon itself).
   recreate cycle can never touch it.
 - The daemon's container declares `cap_add: [CHOWN, FOWNER,
   DAC_OVERRIDE]` so it can bind and chown the per-agent sockets
-  across UIDs — mirrors the broker's caps declared at
+  across UIDs, mirroring the broker's caps declared at
   `src/agents/compose.ts:549-552`.
 - Healthcheck: same socket-presence shape the broker and kernel
   use today.
@@ -480,7 +480,7 @@ sibling project (the daemon itself).
 **`switchroom setup`** grows a one-shot step that drops the sibling
 compose file at `~/.switchroom/hostd/docker-compose.yml` and prints
 the `docker compose -p switchroom-hostd up -d` command. Idempotent;
-safe to re-run. Works identically on Linux and macOS — no
+safe to re-run. Works identically on Linux and macOS. No
 host-specific install path.
 
 ## 7. Migration / cutover
@@ -495,7 +495,7 @@ Phased, behind `host_control.enabled` config flag (default
      the call returns a clean operator-visible error
      ("`switchroom-hostd` unreachable; check `docker compose -p
      switchroom-hostd ps`"). This preserves the §5.5 audit
-     guarantee — every privileged call lands in the daemon's audit
+     guarantee: every privileged call lands in the daemon's audit
      log or fails loudly, never quietly routes around it.
    - **`enabled: false`** (default) → gateway uses the existing
      `spawnSwitchroomDetached` path unchanged. The two code paths
@@ -505,8 +505,8 @@ Phased, behind `host_control.enabled` config flag (default
      posture.
 
    Reviewer-flagged (load-bearing): an earlier draft proposed
-   "prefer daemon, fall back to spawn on socket-miss." Struck —
-   silent fallback means a flaky daemon would route privileged
+   "prefer daemon, fall back to spawn on socket-miss." Struck.
+   Silent fallback means a flaky daemon would route privileged
    calls through the un-audited path that §5.5 promises is gone,
    and the audit log would have invisible gaps. Hard fail is the
    right shape.
@@ -548,8 +548,8 @@ phase 3 makes downgrade harder.
 
 1. **Daemon binary distribution.** Bundled into the existing
    switchroom CLI (one binary, multiple entrypoints) or a separate
-   `switchroom-hostd` binary? Leaning bundled — same release
-   surface, same version pin, same telemetry — but the survey
+   `switchroom-hostd` binary? Leaning bundled (same release
+   surface, same version pin, same telemetry), but the survey
    shows the broker and kernel are separate entrypoints. Match
    that pattern or break it?
 
@@ -558,16 +558,16 @@ phase 3 makes downgrade harder.
    the wire protocol grow streamed-progress frames (one per stage:
    `pulling`, `recreating`, `health-checking`, `done`) so the
    gateway can edit the progress card in real time? Probably yes,
-   but adds protocol complexity — defer to v2 unless the UX is
+   but adds protocol complexity. Defer to v2 unless the UX is
    visibly bad in v1 testing.
 
 3. **Idempotency window.** Tied to the gateway's existing
-   restart-marker debounce at `gateway.ts:7836` / `:7976` — currently
+   restart-marker debounce at `gateway.ts:7836` / `:7976`, currently
    15s. The daemon's `idempotency_key` cache uses the **same** 15s
    value so a double-tap that gets debounced at the gateway layer
    doesn't slip through to the daemon and vice versa. If the gateway
    debounce gets tuned, the daemon constant follows. (Earlier draft
-   said 60s — struck; layer-divergence was the reviewer's
+   said 60s, struck; layer-divergence was the reviewer's
    correction.)
 
 4. **Operator-attest cache.** The broker caches the operator
@@ -583,7 +583,7 @@ phase 3 makes downgrade harder.
 
 ## 10. Verdict / next steps
 
-Already landed in #1175 (Phase 1 — library + opt-in flag + per-agent
+Already landed in #1175 (Phase 1: library + opt-in flag + per-agent
 compose bind mounts):
 
 1. ✅ `src/host-control/{protocol,peercred,server,client,main}.ts`
@@ -616,7 +616,7 @@ compose bind mounts):
      always allowed; cross-agent requires admin. Synchronous.
      NOT gated by the fleet-mutation lock (per-service docker
      compose ops can safely race across agents).
-   `reconcile` was dropped from the original list — there's no
+   `reconcile` was dropped from the original list. There's no
    underlying `switchroom reconcile` CLI verb; `apply` covers the
    same intent.
 3. **Phase 2 gateway swap** (separate PR, deferred). Replace the
@@ -636,7 +636,7 @@ compose bind mounts):
    `spawnSwitchroomDetached`. Both are dead-code-inside-docker
    today (the docker branch is taken first and `systemd-run` is
    absent in containers), but they're still callable on v0.6
-   installs — removal lands when those are no longer supported.
+   installs; removal lands when those are no longer supported.
 
 Effort estimate: **~120 agent minutes** for Phase 1.5 (Dockerfile +
 image build + compose template + install verb + tests). **~180–240
@@ -680,11 +680,11 @@ opens a streaming `tail_status` (Phase 4) for live output.
 arbitrary code from the agent's worktree. Two posture constraints:
 
 1. **Path canonicalization.** `worktree` must canonicalize under
-   `~/.switchroom/agents/<agent>/home/**` — same containment check
+   `~/.switchroom/agents/<agent>/home/**`, the same containment check
    the bind_mounts primitive (#1166) uses. Refuse anything outside.
 2. **Command allowlist.** Either a fixed string like `npm test` or
    `bun run test`, or an explicit array; no shell expansion. The
-   agent can't ask hostd to run arbitrary commands — only registered
+   agent can't ask hostd to run arbitrary commands, only registered
    test entrypoints. Future verbs (`run_build`, `run_lint`) would
    sit alongside with the same shape.
 

--- a/reference/rfcs/inbound-delivery-state-machine.md
+++ b/reference/rfcs/inbound-delivery-state-machine.md
@@ -1,6 +1,7 @@
 ---
-artefact: InboundDeliveryStateMachine
-serves: jobs/survive-reboots-and-real-life.md
+artifact: InboundDeliveryStateMachine
+serves: survive-reboots-and-real-life
+advances-outcome: always-available
 status: draft v1
 ---
 
@@ -15,11 +16,11 @@ Between 2026-05-18 and 2026-05-20 the gateway shipped **9 PRs** (#1536 #1537 #15
 The v0.12.22 boot-wedge (#1573) is the latest instance:
 
 - `handleInbound` ran the fresh-turn init bundle which set `activeTurnStartedAt[key]`
-- The #1556 delivery gate (next 190 lines) read `activeTurnStartedAt.size > 0` LIVE — saw the entry the same handler had just written for THIS inbound's turn
+- The #1556 delivery gate (next 190 lines) read `activeTurnStartedAt.size > 0` LIVE, saw the entry the same handler had just written for THIS inbound's turn
 - Buffered the turn-starting message; bridge never received it; claude never replied; `activeTurnStartedAt[key]` stayed set; silence-poke fallback fired 300s later
 - Symptom: every first user message after every container restart was stuck 5 minutes
 
-The fix was a 2-line snapshot of the live size at receipt-time. **It works** (validated by mtcute UAT, 19.4s → 1.77s for warm trivial). But it's a symptom fix — the underlying problem is **the gateway's delivery state is implicit and scattered**:
+The fix was a 2-line snapshot of the live size at receipt-time. **It works** (validated by mtcute UAT, 19.4s → 1.77s for warm trivial). But it's a symptom fix. The underlying problem is **the gateway's delivery state is implicit and scattered**:
 
 - `currentTurn` (singleton, module-level)
 - `activeTurnStartedAt` (`Map<ChatKey, number>`)
@@ -32,13 +33,13 @@ The fix was a 2-line snapshot of the live size at receipt-time. **It works** (va
 - One sibling-key sweep (#1564)
 - One restart-marker dance (#1546)
 
-Each piece is correct in isolation. The interactions produce the wedges. There is **no model** anywhere in the codebase that says "given these inputs, what should the gateway do" — only an accumulated pile of imperative code paths that have to be kept consistent by hand. Every new PR risks introducing a new misalignment.
+Each piece is correct in isolation. The interactions produce the wedges. There is **no model** anywhere in the codebase that says "given these inputs, what should the gateway do," only an accumulated pile of imperative code paths that have to be kept consistent by hand. Every new PR risks introducing a new misalignment.
 
 A **post-v0.12.22 mid-turn silence wedge** was discovered during the 2026-05-20 rollout: overlapping turns (turn 966 created 27.5s after turn 965 was still in flight) cause the silence-poke clock to reset to 0 on each `startTurn(key)`, with no carry-forward of the prior turn's outbound signal. User status-query messages don't reset the clock (they're inbound). At 300s the fallback fires spuriously even though the model replied 290s ago. **Same shape of bug**: a per-turn lifecycle resets state that should have been per-key-persistent.
 
 ## The proposal
 
-Extract the implicit state into a single pure module: `telegram-plugin/gateway/inbound-delivery-machine.ts`. The module **decides**; the gateway **executes effects**. No I/O, no timers, no mutation — every transition is `(state, event) → (state', effects[])`.
+Extract the implicit state into a single pure module: `telegram-plugin/gateway/inbound-delivery-machine.ts`. The module **decides**; the gateway **executes effects**. No I/O, no timers, no mutation. Every transition is `(state, event) → (state', effects[])`.
 
 The module is then property-tested against four invariants. Any state schedule that violates an invariant is a counterexample. The wedge cluster bugs are not patched one-by-one; they become **unrepresentable**.
 
@@ -82,7 +83,7 @@ type Event =
   | { kind: 'tick'; now: number }
 ```
 
-`modelOutbound` is the canonical signal for "the model produced output for this key" — replaces the scattered `signalTracker.noteOutbound` / `silencePoke.noteOutbound` calls.
+`modelOutbound` is the canonical signal for "the model produced output for this key." It replaces the scattered `signalTracker.noteOutbound` / `silencePoke.noteOutbound` calls.
 
 ### Effects
 
@@ -105,10 +106,10 @@ Effects are **returned, not performed**. The gateway dispatcher receives `(state
 
 ### Transition rules (concrete)
 
-These are exhaustive — every `(state, event)` pair has a defined transition. (Full table in the implementation PR; key cases here.)
+These are exhaustive: every `(state, event)` pair has a defined transition. (Full table in the implementation PR; key cases here.)
 
 **`bridge_alive_idle` + `inbound(key, msgId, at, isSteering=false)`:**
-- Look up `perKey[key].turnStartedAt`. If non-null: state stays `bridge_alive_idle` (wait — but turnStartedAt non-null means a turn IS in flight, so this case can't happen — that's invariant #2's content).
+- Look up `perKey[key].turnStartedAt`. If non-null: state stays `bridge_alive_idle` (wait, but turnStartedAt non-null means a turn IS in flight, so this case can't happen, that's invariant #2's content).
 - Otherwise: state → `bridge_alive_in_turn(key)`. Effects: `setTurnStarted(key, at)`, `deliverToBridge(msg)`, `logTrace(stage=fresh_turn_deliver)`.
 
 **`bridge_alive_in_turn(activeKey)` + `inbound(key, msgId, at, isSteering=false)`:**
@@ -118,7 +119,7 @@ These are exhaustive — every `(state, event)` pair has a defined transition. (
 - State → `bridge_alive_idle`. Effects: `clearTurnStarted(key)`, `drainBuffer(agentName)`, `noteOutbound(key, at)` (if outboundEmitted), `logTrace(stage=turn_complete)`.
 
 **`bridge_alive_*` + `bridgeDown(at)`:**
-- State → `bridge_dead`. Effects: `clearTurnStarted(activeKey if in_turn)` (no — actually KEEP per-key state, the bridge flap shouldn't clobber turn state; let the next bridgeUp + turnEnd handle it), `logTrace(stage=bridge_flap)`.
+- State → `bridge_dead`. Effects: `clearTurnStarted(activeKey if in_turn)` (no, actually KEEP per-key state, the bridge flap shouldn't clobber turn state; let the next bridgeUp + turnEnd handle it), `logTrace(stage=bridge_flap)`.
 
 **`bridge_dead` + `inbound(...)`:**
 - Effects: `bufferInbound(msg)`, `persistInbound(msg)`, `logTrace(stage=bridge_dead_buffer)`. State unchanged.
@@ -131,7 +132,7 @@ These are exhaustive — every `(state, event)` pair has a defined transition. (
   - **Check `lastOutboundAt` first** (this is the v0.12.22-mid-turn-silence fix). If `lastOutboundAt != null && now - lastOutboundAt < OUTBOUND_RECENT_MS` (60s), the model recently broke silence; suppress the fallback fire. Otherwise emit `firePoke(key, 'fallback')` + `clearTurnStarted(key)` + transition to `bridge_alive_idle` if this was the activeTurn.
 
 **Any state + `modelOutbound(key, at)`:**
-- Effects: `noteOutbound(key, at)` — updates `perKey[key].lastOutboundAt = at`. Does NOT change global state.
+- Effects: `noteOutbound(key, at)`, which updates `perKey[key].lastOutboundAt = at`. Does NOT change global state.
 
 ### Property-test invariants (the load-bearing contract)
 
@@ -139,7 +140,7 @@ These four invariants are property-tested with arbitrary event schedules. Any vi
 
 **Invariant #1 — Every inbound is exactly delivered OR persisted.**
 
-For every `inbound(msg)` event in the schedule, the effects emitted in response contain either `deliverToBridge(msg)` OR (`bufferInbound(msg)` AND `persistInbound(msg)`) — never both, never neither. Catches the wedge-cluster class where a buffered inbound was lost (no persist) or double-delivered (deliver + buffer).
+For every `inbound(msg)` event in the schedule, the effects emitted in response contain either `deliverToBridge(msg)` OR (`bufferInbound(msg)` AND `persistInbound(msg)`), never both, never neither. Catches the wedge-cluster class where a buffered inbound was lost (no persist) or double-delivered (deliver + buffer).
 
 **Invariant #2 — Turn lifecycle: setTurnStarted always paired with clearTurnStarted before next end-of-life event.**
 
@@ -147,7 +148,7 @@ For every `setTurnStarted(key, t)` effect: the next `turnEnd(key)` event, OR `ti
 
 **Invariant #3 — Per-chat sibling-key cleanup on turnEnd.**
 
-For any chatId, after the last `turnEnd(key)` whose key has that chatId, no entry for that chatId remains in `perKey` within one event-loop tick. Lifts PR #1564's `purgeStaleTurnsForChat` to a machine invariant. The test generates arbitrary `(chatId, threadId | null | undefined | 0)` sequences and asserts no sibling entries survive — this is the invariant that catches the #1564 sibling-key class as a property-test counterexample.
+For any chatId, after the last `turnEnd(key)` whose key has that chatId, no entry for that chatId remains in `perKey` within one event-loop tick. Lifts PR #1564's `purgeStaleTurnsForChat` to a machine invariant. The test generates arbitrary `(chatId, threadId | null | undefined | 0)` sequences and asserts no sibling entries survive. This is the invariant that catches the #1564 sibling-key class as a property-test counterexample.
 
 **Invariant #4 — Permission verdicts: delivered iff bridge alive, else persisted and re-delivered on next bridgeUp.**
 
@@ -171,7 +172,7 @@ Gate: all 5 invariants pass on 10,000 random schedules.
 
 `gateway.ts:handleInbound` constructs an Event for each input and dispatches through the state machine. The dispatcher receives the Effects array and executes them in order. Each effect maps 1:1 to an existing code path (e.g., `deliverToBridge` → `ipcServer.sendToAgent`; `bufferInbound` → `pendingInboundBuffer.push`).
 
-Gate: every existing UAT scenario still passes, including the post-restart mtcute UAT (jtbd-always-on-after-restart), the fast-trivial UAT, and every fuzz scenario. The state machine SHOULD produce the same observable behavior as the current ad-hoc code — if it doesn't, either the machine has a bug or the current code has one we're now seeing.
+Gate: every existing UAT scenario still passes, including the post-restart mtcute UAT (jtbd-always-on-after-restart), the fast-trivial UAT, and every fuzz scenario. The state machine SHOULD produce the same observable behavior as the current ad-hoc code. If it doesn't, either the machine has a bug or the current code has one we're now seeing.
 
 ### PR 3 — Delete the redundant primitives (cleanup)
 
@@ -188,7 +189,7 @@ Net: a few hundred lines removed, plus the bugs they were patching.
 The original "PR 3 = cleanup" framing turned out to be too coarse. PR
 3 (#1591) shipped the dispatcher and bit-identical effect execution
 for the **happy paths**, but the legacy `purgeReactionTracking` callsites
-were left in place — the shadow `turnEnd` event still fires from inside
+were left in place. The shadow `turnEnd` event still fires from inside
 that function, and several callsites can't see the authoritative
 `turn` object (so `outboundEmitted` falls back to module-scope
 `currentTurn` which may already be nulled).
@@ -212,7 +213,7 @@ The cleanup PR is therefore being split:
 `purgeReactionTracking(key, endingTurn?)` reads `outboundEmitted` from
 `endingTurn.replyCalled` if the caller threaded the turn, else falls
 back to `currentTurn?.replyCalled`. The canonical, threaded path is
-`endCurrentTurnAtomic(turn)` (gateway.ts:1381) — it nulls
+`endCurrentTurnAtomic(turn)` (gateway.ts:1381). It nulls
 `currentTurn`, then passes `turn` explicitly. Legacy bare-purge
 callsites can produce **wrong** `outboundEmitted` data in the shadow
 trace, which makes the shadow→live cutover (step 2) unsafe.
@@ -232,7 +233,7 @@ worktree, baseline commit a6e48b88):
 
 **Risk profile by site:**
 - 1601 / 5831 / 5989 are all **duplicate-`turnEnd`-emit bugs in the
-  same class** — shadow data correctness issues that surface as
+  same class**: shadow data correctness issues that surface as
   `turnEnd` events fired more than once per logical turn. Fixing them
   is mostly delete-the-bare-call, not refactor. Highest value, lowest
   risk.
@@ -293,13 +294,13 @@ prerequisites must land first.
 
 ## What this RFC does NOT cover
 
-- **The boot-time cost** of cold-starting claude + the gateway. The state machine doesn't help; it's pure model-side latency. Tracked separately under "cold-start optimization" (Sprint 4 of the vision-aligned roadmap — defer handoff, async boot card, pre-warm session).
+- **The boot-time cost** of cold-starting claude + the gateway. The state machine doesn't help; it's pure model-side latency. Tracked separately under "cold-start optimization" (Sprint 4 of the vision-aligned roadmap: defer handoff, async boot card, pre-warm session).
 - **Webhook vs polling.** Polling lag (0-3s typical) is upstream of the state machine. Separate decision.
-- **PostHog observability dashboards** for the runtime-metrics emitted by the new machine (`logTrace` effect). The state machine emits the trace events; the dashboards consume them — separate workstream.
+- **PostHog observability dashboards** for the runtime-metrics emitted by the new machine (`logTrace` effect). The state machine emits the trace events; the dashboards consume them. Separate workstream.
 
 ## Risks + mitigations
 
-- **PR 2 cutover risk**: behavior-equivalence is asserted by every existing UAT, but the property test ONLY asserts invariants — it doesn't prove equivalence to the prior ad-hoc code. If there was an UNDOCUMENTED behavior the prior code had that the new machine doesn't, it'd break silently. *Mitigation*: run PR 2 against the full fuzz scenario suite (already CI-gated) + a 48-hour test-harness bake before merging.
+- **PR 2 cutover risk**: behavior-equivalence is asserted by every existing UAT, but the property test ONLY asserts invariants. It doesn't prove equivalence to the prior ad-hoc code. If there was an UNDOCUMENTED behavior the prior code had that the new machine doesn't, it'd break silently. *Mitigation*: run PR 2 against the full fuzz scenario suite (already CI-gated) + a 48-hour test-harness bake before merging.
 - **State machine becomes the new monolith**: easy to keep growing. *Mitigation*: the invariants are the contract. New features must show how they satisfy or extend the invariants, not just add to the transition function.
 - **Polling vs event-driven**: the `tick(now)` event has to be driven by something. Currently the gateway has a setInterval idle-drain timer (#1549). The state machine can use the same trigger or be event-driven externally. *Mitigation*: explicit `tick` effect lets the dispatcher decide; no opinion baked into the machine.
 
@@ -312,9 +313,9 @@ prerequisites must land first.
 ## Success criteria
 
 - The post-v0.12.22 overlapping-turn silence wedge (currently firing 2x/hour on test-harness) becomes unrepresentable per Invariant #5.
-- The wedge cluster class — any variant — fails the property test before reaching the fleet.
+- The wedge cluster class, any variant, fails the property test before reaching the fleet.
 - Net code: -200 to -500 lines after PR 3.
-- Cold-start TTFO unchanged (this work is about correctness, not speed — cold-start optimization is a separate workstream).
+- Cold-start TTFO unchanged (this work is about correctness, not speed; cold-start optimization is a separate workstream).
 - mtcute UATs `jtbd-always-on-after-restart` and `jtbd-fast-trivial` continue passing.
 
 ---

--- a/reference/rfcs/litellm-max-subscription-invariants.md
+++ b/reference/rfcs/litellm-max-subscription-invariants.md
@@ -1,7 +1,6 @@
 ---
-serves: subscription-honest
-backs: subscription-honest
-artefact: litellm-max-subscription-invariants
+backs: claude-native
+artifact: litellm-max-subscription-invariants
 ---
 
 # LiteLLM Max Subscription Invariants
@@ -9,7 +8,7 @@ artefact: litellm-max-subscription-invariants
 **Context:** Switchroom routes the unmodified `claude` CLI through a self-hosted
 LiteLLM proxy (`ANTHROPIC_BASE_URL=http://127.0.0.1:4010`). The subscription
 invariant (pillar 3 of `reference/vision.md`) says Anthropic models MUST be paid
-via the operator's Claude Max OAuth credential — never via an `ANTHROPIC_API_KEY`.
+via the operator's Claude Max OAuth credential, never via an `ANTHROPIC_API_KEY`.
 LiteLLM is scaffolding around the CLI, not a billing bypass.
 
 Source: https://docs.litellm.ai/docs/tutorials/claude_code_max_subscription
@@ -20,7 +19,7 @@ Source: https://docs.litellm.ai/docs/tutorials/claude_code_max_subscription
 
 **Rule:** OAuth header forwarding MUST be set per-model in `model_group_settings`,
 not in `litellm_settings`. The `litellm_settings.forward_client_headers_to_llm_api`
-field is `Optional[bool]` — a list value (e.g. a list of model names) is coerced
+field is `Optional[bool]`. A list value (e.g. a list of model names) is coerced
 to `true` (truthy), making forwarding global. That leaks the OAuth token to
 OpenRouter, OpenAI, VoyageAI, etc.
 
@@ -93,7 +92,7 @@ token is meaningless and will result in a 401.
 
 **Rule:** `model_name` in `model_list` and entries in
 `forward_client_headers_to_llm_api` must be the literal string Claude Code
-places in the `model` field of its API requests — NOT prefixed with `anthropic/`.
+places in the `model` field of its API requests, NOT prefixed with `anthropic/`.
 
 ```yaml
 # CORRECT — Claude Code sends "claude-sonnet-4-6"
@@ -153,7 +152,7 @@ the proxy config. The critical question is whether the forwarding check runs
 against the *requested* model name (before alias resolution) or the *resolved*
 upstream target (after alias). If before, a `claude-sonnet-4-6` request aliased
 to `openrouter/google/gemini-2.5-pro` would forward the OAuth token to
-OpenRouter — a credential leak.
+OpenRouter, a credential leak.
 
 **Required pre-check before enabling Ship D model aliases in production:**
 1. Set a test alias `claude-haiku-4-5-20251001 → openrouter/google/gemini-2.5-flash`
@@ -163,7 +162,7 @@ OpenRouter — a credential leak.
    confirm the outbound call to OpenRouter does NOT carry the `Authorization`
    header with the Anthropic OAuth token.
 4. If it does forward, mitigation is to remove the aliased model from
-   `forward_client_headers_to_llm_api` dynamically — or do not use model
+   `forward_client_headers_to_llm_api` dynamically, or do not use model
    aliases for Anthropic model names; use a separate non-Claude `model_name`
    as the alias target instead (e.g. `sr-gemini` → `openrouter/google/gemini-2.5-pro`)
    so there is no entry in the forwarding list to match.
@@ -177,7 +176,7 @@ OpenRouter — a credential leak.
 - The proxy is unreachable at `$ANTHROPIC_BASE_URL`
 
 This is the current implementation (the `sr_ll_ok` gate in start.sh). Do NOT
-remove this fallback — it is the availability guarantee that prevents a proxy
+remove this fallback. It is the availability guarantee that prevents a proxy
 outage from silencing the fleet.
 
 **What the fallback loses:** spend tracking, guardrails, model alias routing,

--- a/reference/rfcs/microsoft-workspace.md
+++ b/reference/rfcs/microsoft-workspace.md
@@ -1,6 +1,7 @@
 ---
-artefact: Microsoft 365 integration (OneDrive + Office files + Mail + Calendar)
-serves: jobs/act-in-my-tools-with-an-identity.md
+artifact: Microsoft 365 integration (OneDrive + Office files + Mail + Calendar)
+serves: act-in-my-tools-with-an-identity
+advances-outcome: always-available
 status: Draft
 ---
 
@@ -24,7 +25,7 @@ agents.
   `MS365_MCP_OAUTH_TOKEN` env var.
 - **Office authoring**: handled by the already-bundled Anthropic
   skills at `skills/docx`, `skills/xlsx`, `skills/pptx`. No in-house
-  Word/PPT MCP shim needed — the skills know the file formats
+  Word/PPT MCP shim needed. The skills know the file formats
   properly; softeria just shuttles bytes via OneDrive.
 - **OAuth shape**: Entra "personal accounts + any work/school
   directory" multi-tenant app at the `/common` endpoint. One operator
@@ -93,7 +94,7 @@ in `skills/docx`, `skills/xlsx`, `skills/pptx`). The agent flow:
 1. Agent calls softeria's `download-bytes` to fetch a `.docx` from
    OneDrive to its workspace
 2. Agent invokes the `docx` skill (or `xlsx`/`pptx`) to author the edit
-   — proper file-format manipulation, tracked changes, etc.
+   (proper file-format manipulation, tracked changes, etc.)
 3. Agent calls softeria's `upload-file-content` (or
    `create-upload-session` for files >4 MB) to put the result back to
    OneDrive
@@ -116,7 +117,7 @@ unlock Teams/SharePoint/admin tools. Cascade via
 
 ### 4.1 App registration (operator one-time)
 
-**Register a new Entra app for switchroom — don't reuse an existing
+**Register a new Entra app for switchroom. Don't reuse an existing
 one.** If the operator already has a Microsoft-integrated app
 (personal calendar app, side project, anything), there are two
 load-bearing reasons to register a new one rather than expand the
@@ -140,18 +141,18 @@ Weaker reasons people cite (and that won't actually bite):
 incremental consent works, scope expansion is supported, redirect
 URIs can be multi-platform on one app. So if the existing app
 *already* has `AzureADandPersonalMicrosoftAccount` audience +
-public-client flows enabled, sharing isn't catastrophic — just
+public-client flows enabled, sharing isn't catastrophic, just
 cluttered. New app is still the cleaner default.
 
-Operator runs `switchroom auth microsoft connect` — a wizard that:
+Operator runs `switchroom auth microsoft connect`, a wizard that:
 
 1. Walks the operator through registering a new app in the **Entra
    admin center** (entra.microsoft.com → App registrations → New
    registration).
 2. Required settings:
    - **Supported account types**: "Accounts in any organizational
-     directory (any Microsoft Entra ID tenant — multitenant) **and**
-     personal Microsoft accounts (e.g. Skype, Xbox)" — manifest value
+     directory (any Microsoft Entra ID tenant, multitenant) **and**
+     personal Microsoft accounts (e.g. Skype, Xbox)", manifest value
      `AzureADandPersonalMicrosoftAccount`.
    - **Redirect URI**: platform "Mobile and desktop applications" →
      `http://localhost`. (Microsoft ignores port for loopback URIs.)
@@ -174,7 +175,7 @@ microsoft_workspace:
 ### 4.2 Per-account auth (per Microsoft account)
 
 Operator runs `switchroom auth microsoft account add [--label
-personal|work|<name>]`. Two flows depending on host capability —
+personal|work|<name>]`. Two flows depending on host capability,
 same tiering as Google's RFC D §3.2:
 
 **Tier 1 — desktop loopback** (default when `$DISPLAY` is set or
@@ -182,7 +183,7 @@ same tiering as Google's RFC D §3.2:
 
 1. Spawns a local HTTP server on an ephemeral port bound to `127.0.0.1`.
 2. Constructs auth URL via MSAL-Node `getAuthCodeUrl({ scopes, state,
-   codeChallenge })` — auth code + PKCE.
+   codeChallenge })`: auth code + PKCE.
 3. Opens browser to that URL.
 4. Catches callback at `/auth/callback?code=...&state=...`, validates
    state, hands code to MSAL `acquireTokenByCode()`.
@@ -193,9 +194,9 @@ same tiering as Google's RFC D §3.2:
 1. Calls MSAL-Node `acquireTokenByDeviceCode({ scopes, deviceCodeCallback })`.
 2. Wizard prints: "Open https://microsoft.com/devicelogin and enter
    code: ABCD-1234 (expires in 15min)". Operator opens that URL on any
-   device — phone, laptop, work computer — and pastes the code.
+   device (phone, laptop, work computer) and pastes the code.
 3. Wizard polls Microsoft's `/token` endpoint until the user completes
-   auth on the other device, then receives tokens.
+   auth on the other device, then receives the tokens.
 
 Switchroom is regularly installed on headless VPSs (see
 `reference_install_validation_loop`); device-code is the right
@@ -204,7 +205,7 @@ default for those hosts.
 **Stale-doc trap worth pre-empting**: Microsoft's older device-code
 page (`learn.microsoft.com/en-us/entra/identity-platform/scenario-desktop-acquire-token-device-code-flow`)
 contains the line *"AADSTS90133: Device Code flow is not supported
-under /common or /consumers endpoint"*. This is **outdated** — MSAL.NET
+under /common or /consumers endpoint"*. This is **outdated**: MSAL.NET
 4.5+ release notes and the MSAL .NET device-code wiki confirm device-
 code works on `/common` + `/consumers` for personal MSA, and every
 community MS-MCP server I surveyed uses this path successfully. The
@@ -245,9 +246,9 @@ Both flows converge after token acquisition:
 
 ### 4.3 Scope set v1
 
-Two scope sets — chosen at consent time based on account type and
+Two scope sets, chosen at consent time based on account type and
 `org_mode`. **Not "tiering"** (which would be per-agent and create
-upgrade friction) — this is per-account-at-consent, set once.
+upgrade friction): this is per-account-at-consent, set once.
 
 **Default v1 (personal MSA + work without `org_mode`):**
 
@@ -274,16 +275,16 @@ Sites.ReadWrite.All
 Rationale for the split:
 
 - `Sites.ReadWrite.All` grants read/write to **every SharePoint site
-  the user can access** — in a large enterprise that's potentially
+  the user can access**: in a large enterprise that's potentially
   thousands of sites holding HR/finance/legal docs. The defaults
   test (`reference/principles.md` §2) says the working default for
   a personal-use solo founder is not "agent has write access to my
   employer's entire SharePoint." Opt-in via `org_mode`.
 - `Files.ReadWrite.All` is bounded to the user's OneDrive (personal
-  or business) — narrow blast radius for the personal case, the right
+  or business), a narrow blast radius for the personal case, the right
   default. **Scope-narrowing option worth considering in PR 2 spike**:
   `Files.ReadWrite` (no `.All`) is also MSA-supported and covers
-  "the signed-in user's files" — which on a personal account IS the
+  "the signed-in user's files," which on a personal account IS the
   user's OneDrive. Dropping the `.All` suffix could lower blast
   radius further with no functional loss for personal-MSA. Verify
   via UAT that softeria's tools don't require the `.All` variant.
@@ -304,7 +305,7 @@ knob, single mental model.
   but worth doctor-probing).
 - Unverified-app warning: until switchroom is publisher-verified
   (requires MPN account, $-cost), MSA users see a "Permissions
-  requested — App info" page with an "unverified" badge. The wizard
+  requested, App info" page with an "unverified" badge. The wizard
   doc explicitly tells the operator: this is expected, accept it,
   this is your own app.
 
@@ -324,14 +325,14 @@ Mode 0600 on both files. Atomic writes (write-temp-then-rename).
 Owner is the auth-broker UID.
 
 **Only the broker holds the MSAL `PublicClientApplication` instance.**
-Agents never instantiate MSAL directly — they IPC to the broker for
+Agents never instantiate MSAL directly. They IPC to the broker for
 access tokens (mirrors Google's per-call `get_credentials` pattern).
 This is load-bearing for cache integrity: two MSAL instances writing
 the same `cache.json` would race on refresh-token rotation under
 concurrent agent activity, and atomic-write only protects against
 torn writes, not last-writer-wins clobber of a newer RT.
 
-**No machine-encryption v1** (matches current Google posture — RFC G
+**No machine-encryption v1** (matches current Google posture, RFC G
 §4.4 deferred broker-side vault encryption). Cache is filesystem-
 permissioned. Defer to RFC G's eventual broker-encryption proposal
 covering both providers uniformly.
@@ -340,7 +341,7 @@ covering both providers uniformly.
 
 Microsoft refresh tokens **rotate every refresh** (every successful
 `acquireTokenSilent` returns a new RT, invalidates the old). MSAL-Node
-handles this transparently inside its cache — the broker's
+handles this transparently inside its cache. The broker's
 `afterCacheAccess` callback writes the updated cache to disk after
 each rotation.
 
@@ -350,13 +351,13 @@ recover without operator re-auth.
 
 ### 5.3 Refresh distribution to softeria (BYOT)
 
-softeria has no in-server refresh — `MS365_MCP_OAUTH_TOKEN` is read
+softeria has no in-server refresh. `MS365_MCP_OAUTH_TOKEN` is read
 once at process spawn and softeria forwards it on every Graph call
 until it 401s. Claude Code does **not** auto-respawn MCP servers on
 tool errors; MCP children persist for the agent session lifetime
 (hours, sometimes days). A 60-min token against a session that long
 is total outage every hour. The original draft of this RFC tried to
-defer the refresher to v2 — that's wrong, the math is deterministic
+defer the refresher to v2. That's wrong, the math is deterministic
 and the v1 UX would be unusable.
 
 **v1 ships a sidecar refresher.** The launcher (`m365-mcp-launcher`)
@@ -371,7 +372,7 @@ spawns two processes per agent:
    - Writes the new AT to a tmpfile + atomically renames it to a
      well-known path (e.g. `/tmp/m365-token-<agent>.json`)
    - Sends softeria child SIGHUP (which softeria docs as a
-     refresh-trigger — verify in PR 1 spike; if not honored,
+     refresh-trigger; verify in PR 1 spike; if not honored,
      restart-child semantics instead)
    - Loops
 
@@ -391,7 +392,7 @@ scope set via `MS_TODO_ACCESS_TOKEN` + `MS_TODO_REFRESH_TOKEN` env
 vars; the rotate-and-persist loop at `src/token-manager.ts:100-162`
 is a clean reference for the upstream contribution. (Not drop-in
 usable as-is because scope is hardcoded to To-Do and the client
-shape requires a secret — but the auth-code path against
+shape requires a secret, but the auth-code path against
 `/{tenant}/oauth2/v2.0/token` is the pattern softeria's contribution
 should follow.) Validates that "refresh-token-in single-user" is
 implementable; we're not inventing it, we're generalizing it.
@@ -460,8 +461,8 @@ agents:
 
 Both keys are required. Mismatch (ACL says yes, no `account:` selected)
 is silent until first MS tool call, where broker returns
-`ACCOUNT_NOT_FOUND`. **`doctor` probe catches it at config time** —
-adds `microsoft:agent-ACL-and-selector-aligned` check.
+`ACCOUNT_NOT_FOUND`. **`doctor` probe catches it at config time**: it
+adds the `microsoft:agent-ACL-and-selector-aligned` check.
 
 ### 6.3 Cascade
 
@@ -482,17 +483,17 @@ shape as `google_workspace:`):
 Google has `core / extended / complete` tiers. We chose **not to
 mirror** because:
 
-- Tiers exist because **scopes are fixed at consent** — upgrading
+- Tiers exist because **scopes are fixed at consent**: upgrading
   means re-running the loopback flow. For personal use this friction
   is real but rare.
 - Mapping to the four vision outcomes:
   - **Standing team that knows you**: right granularity is "is MS
-    enabled for this agent at all", not "which slice" — handled by
+    enabled for this agent at all", not "which slice", handled by
     `enabled_for[]`
   - **Hold the leash**: in personal use the leash you want is the
     per-write approval card (§8), not the scope set. There's no
     adversary inside your own team.
-  - **Always available**: tiers actively harm — "sorry, this agent
+  - **Always available**: tiers actively harm. "Sorry, this agent
     doesn't have OneDrive write, please re-consent" mid-task is
     exactly the friction Outcome 4 forbids.
 - The **defaults test** in `reference/principles.md`: a working
@@ -537,9 +538,9 @@ yesterday's meeting"]
 [clerk reports back: "Updated Q3-Strategy.docx with the meeting notes."]
 ```
 
-**No new authoring code is needed in switchroom** — the skills already
+**No new authoring code is needed in switchroom.** The skills already
 ship in the skills pool, the agent invokes them via Claude Code's
-native skill-invocation flow, OneDrive is just a delivery mechanism.
+native skill-invocation flow, and OneDrive is just a delivery mechanism.
 
 ## 8. Approval-kernel write cards
 
@@ -549,7 +550,7 @@ Mirror RFC E's PreToolUse-hook pattern (Path A Cut 2):
   (similar to the existing Google write-approval hook).
 - Triggers on softeria's write tool names:
   - `upload-file-content`, `create-upload-session` (OneDrive writes)
-  - `send-mail` (deferred — `Mail.Send` not in v1 scope)
+  - `send-mail` (deferred; `Mail.Send` not in v1 scope)
   - `create-event`, `update-event`, `delete-event` (calendar writes)
   - `update-message`, `delete-message` (mail edits)
 - Card metadata:
@@ -573,11 +574,11 @@ Mirror RFC E's PreToolUse-hook pattern (Path A Cut 2):
 link + agent rationale). The operator must trust the agent's
 rationale + click through to OneDrive to see the actual diff. v1.5
 ships structural diff via skills `--diff` mode and brings attestation
-to parity with Google's RFC E. Don't market v1 as full parity — it
+to parity with Google's RFC E. Don't market v1 as full parity. It
 isn't. UAT measures whether the weak-metadata UX is good enough in
 practice for personal-use; if it isn't, v1.5 follows immediately.
 
-**Reads are standing grants** (no per-call approval) — same as Google.
+**Reads are standing grants** (no per-call approval), same as Google.
 The grant is implicit in `enabled_for[]`.
 
 ## 9. Doctor probes
@@ -608,7 +609,7 @@ Add to `switchroom doctor`:
 ## 10. Implementation plan
 
 **5 PRs total**, sized to keep each reviewable. The original 3-PR
-draft was 30-50% under realistic size — Google's `drive-mcp-launcher.ts`
+draft was 30-50% under realistic size. Google's `drive-mcp-launcher.ts`
 is 919 LOC alone, `auth-google.ts` is 1,282 LOC. Sizing here is
 calibrated against shipped equivalents.
 
@@ -658,7 +659,7 @@ calibrated against shipped equivalents.
 - `profiles/_shared/hooks/microsoft-write-approval.mjs.hbs` — hook
   template intercepting softeria write tools
 - Hook → kernel IPC verb (extends existing approval card builders)
-- Weak metadata only v1 (byte delta + size + link + rationale —
+- Weak metadata only v1 (byte delta + size + link + rationale;
   §8 explicitly scopes this)
 - Tests: hook intercept; card metadata extraction; deny → block
   short-circuit
@@ -700,7 +701,7 @@ shipped LOC counts):
 - **Reviewer rounds** — assume ~30 min each PR
 
 Total: **~300 agent minutes** end-to-end (~5 hours). Roughly double
-the original 140-min estimate — sized honestly so review and UAT
+the original 140-min estimate, sized honestly so review and UAT
 have room.
 
 ## 12. Out of scope (v1)
@@ -794,7 +795,7 @@ Material consulted during this RFC:
 - MSAL-Node docs: `caching.md`, `msal-node-migration`,
   `scenario-desktop-acquire-token-interactive`
 - MS Learn: `reply-url`, `id-tokens`, `publisher-verification-overview`
-- Family-calendar app (calendar-app/) — Microsoft auth precedent
+- Family-calendar app (calendar-app/): Microsoft auth precedent
   (raw-fetch, common-tenant, encrypted token storage in Postgres)
 - Existing switchroom RFCs: gdrive-mcp.md, google-workspace-
   generalization.md, doc-connection-completion.md, auth-broker.md

--- a/reference/rfcs/notion-integration.md
+++ b/reference/rfcs/notion-integration.md
@@ -1,6 +1,7 @@
 ---
-artefact: Notion integration
-serves: jobs/act-in-my-tools-with-an-identity.md
+artifact: Notion integration
+serves: act-in-my-tools-with-an-identity
+advances-outcome: always-available
 status: Draft
 ---
 
@@ -28,14 +29,14 @@ level.
 - **Token storage**: vault key `notion/integration-token`. The
   vault-broker mints short-lived per-agent grants the same way it does
   for any other vault secret. There is **no auth-broker MSAL
-  equivalent** — Notion tokens don't rotate.
+  equivalent**: Notion tokens don't rotate.
 - **Per-agent grant**: two-key model that *parallels* m365/gdrive but
   isn't identical because Notion has no per-account concept (one
   integration = one workspace). The two keys are: (1) operator-set
   ACL on the vault grant (which agents can fetch the token),
   (2) per-agent `notion_workspace.databases[]` YAML allowlist.
 - **Top-level config key**: `notion_workspace:` (mirrors
-  `google_workspace:` and `microsoft_workspace:` — consistency over
+  `google_workspace:` and `microsoft_workspace:`, consistency over
   novelty; no nested `integrations.*` namespace v1).
 - **Friendly names**: operator-level config maps `essays → <uuid>`
   once; per-agent grants reference the friendly name. Agents never
@@ -50,7 +51,7 @@ level.
   their API-call cost. See §7.
 
 This RFC explicitly *diverges* from the original task brief on two
-points (§13.1) — it drops the per-agent `scopes: [read, write]`
+points (§13.1): it drops the per-agent `scopes: [read, write]`
 field in favour of consistency with m365's "no scope tiering v1"
 call (§6.4), and re-frames the per-agent grant under
 `notion_workspace` rather than `integrations.notion`. Rate limiting
@@ -105,7 +106,7 @@ The launcher (`src/cli/notion-mcp-launcher.ts`) is responsible for:
 4. Heartbeat file at `/tmp/notion-launcher-<agent>.heartbeat.json` for
    the doctor probe (mirrors m365's pattern, PR #1888).
 
-Unlike m365, the launcher does **not** run a refresh loop — there is
+Unlike m365, the launcher does **not** run a refresh loop. There is
 no token expiry. The launcher process is single-purpose: vault fetch
 → env inject → exec MCP.
 
@@ -117,11 +118,11 @@ The operator creates an internal integration in Notion's settings:
 
 1. Settings → **Connections** → **Develop or manage integrations** →
    **New integration**.
-2. Name: `switchroom` (or whatever the operator wants — visible only
+2. Name: `switchroom` (or whatever the operator wants, visible only
    to the workspace owner).
 3. Type: **Internal**. Associated workspace: the operator's primary
    workspace.
-4. Capabilities — recommended starting set:
+4. Capabilities, recommended starting set:
    - Read content
    - Update content
    - Insert content
@@ -136,28 +137,28 @@ The operator creates an internal integration in Notion's settings:
 After registration, the operator goes back to each Notion page /
 database they want any switchroom agent to touch and **shares it with
 the `switchroom` integration** (top-right ⋯ → Connections → add
-`switchroom`). This is Notion's *upstream* ACL — the integration
+`switchroom`). This is Notion's *upstream* ACL: the integration
 literally cannot see pages that weren't shared with it, regardless of
 what switchroom config says.
 
-**Bootstrap order — this matters**:
+**Bootstrap order, this matters**:
 
 1. Create integration (step 1–4 above).
 2. Vault put the token (step 6).
 3. Share DBs/pages with the integration in Notion's UI.
 4. Run `switchroom notion list-dbs` to print a ready-to-paste
    YAML block of `friendly-name → uuid` mappings (PR 4). This needs
-   steps 2 + 3 done first — the CLI fetches the integration's
+   steps 2 + 3 done first: the CLI fetches the integration's
    visible-DB list from Notion's API.
 5. Paste that block into `switchroom.yaml` under `notion_workspace:
    databases:`, edit friendly names as desired.
 6. Add `notion_workspace: {}` (or a `databases: [...]` filter) to
    each agent that should get Notion access.
-7. `switchroom apply` — config validation cross-checks DB
+7. `switchroom apply`: config validation cross-checks DB
    references, vault ACL alignment (§6.3), and writes the scaffold.
 
-If the operator skips step 4 they'll be left typing UUIDs by hand —
-the CLI verb in PR 4 exists specifically to make this painless.
+If the operator skips step 4 they'll be left typing UUIDs by hand.
+The CLI verb in PR 4 exists specifically to make this painless.
 
 ### 4.2 Switchroom-side ACL (defence in depth)
 
@@ -170,10 +171,10 @@ call if the resolved DB UUID isn't in the agent's allowlist.
 
 Both boundaries matter:
 - The upstream share-list is **what the operator manages via Notion's
-  UI** — natural place for "this DB is brand new, hasn't been wired
+  UI**, natural place for "this DB is brand new, hasn't been wired
   to anything yet".
 - The switchroom allowlist is **what the operator manages via
-  `switchroom.yaml`** — natural place for "this agent's role is
+  `switchroom.yaml`**, natural place for "this agent's role is
   narrower than the integration".
 
 ### 4.3 No OAuth, no refresh
@@ -181,7 +182,7 @@ Both boundaries matter:
 Notion supports an OAuth-public-integration flow for vendors building
 multi-tenant apps. Switchroom is single-operator-per-deployment; the
 internal-integration model is materially simpler and the right
-default. Public OAuth is out of scope for v1 — flagged in §12.
+default. Public OAuth is out of scope for v1, flagged in §12.
 
 ## 5. Token storage, rotation, revocation
 
@@ -190,7 +191,7 @@ default. Public OAuth is out of scope for v1 — flagged in §12.
 - Vault key: `notion/integration-token` (plural-namespace contract:
   `<provider>/<artifact>`).
 - ACL: operator sets `--allow <agents>` (comma-separated) at `vault set` time.
-  The broker enforces this on every grant request — agents not in the
+  The broker enforces this on every grant request; agents not in the
   ACL get `E_BROKER_GRANT_DENIED`.
 - The launcher fetches via `vault_request_access` → ephemeral token →
   child env var. The token never lands on disk inside the agent
@@ -204,7 +205,7 @@ own):
 1. Notion Settings → Integrations → `switchroom` → **Refresh secret**.
 2. Copy new secret.
 3. `switchroom vault set notion/integration-token` (overwrite).
-   Re-state `--allow` to preserve the existing allowlist — `vault set`
+   Re-state `--allow` to preserve the existing allowlist, since `vault set`
    replaces the entire scope.
 4. Agents pick up the new token on their next vault grant — for the
    notion launcher specifically that means **launcher restart**.
@@ -251,7 +252,7 @@ notion_workspace:
 
 The top-level key is `notion_workspace:`, parallel to
 `google_workspace:` and `microsoft_workspace:`. No nested
-`integrations.*` namespace — consistency test wins over taxonomic
+`integrations.*` namespace, consistency test wins over taxonomic
 neatness.
 
 Validation (in `src/config/schema.ts`):
@@ -308,7 +309,7 @@ The allowlist gates Notion tool calls in three buckets:
    to remove the field entirely; explicit empty list = "no DBs at
    all" which is the same as not having Notion).
 3. Agent has `notion_workspace:` but the vault has no
-   `notion/integration-token` key — fail at `apply`, not at runtime.
+   `notion/integration-token` key, failing at `apply`, not at runtime.
 4. Agent has `notion_workspace:` but is **not in the vault ACL** for
    `notion/integration-token`. Surface the precise remediation:
    `switchroom vault set notion/integration-token --allow <full-list>` re-stating the allowlist including the missing agent. This
@@ -379,7 +380,7 @@ noisy operator-facing errors.
 **Ship the token bucket in v1**, in the launcher process:
 
 - **Where**: `src/cli/notion-mcp-launcher.ts`, inline. Not a separate
-  daemon, no shared store — one operator-bounded integration token
+  daemon, no shared store: one operator-bounded integration token
   ⇒ one launcher's bucket suffices *across agents* if the launcher
   is shared. But the launcher is per-agent (stdio bridge), so the
   bucket has to be global to the operator. Implementation: a tiny
@@ -401,8 +402,8 @@ noisy operator-facing errors.
   non-switchroom consumer.
 
 **v2 trigger** (after v1 ships): if even the global bucket isn't
-enough — e.g. operators with 5+ agents all heavily Notion-dependent
-— consider per-agent quotas inside the global bucket. Not blocking
+enough (e.g. operators with 5+ agents all heavily Notion-dependent),
+consider per-agent quotas inside the global bucket. Not blocking
 v1.
 
 **Doctor probe**: report bucket-saturation events from the last 24 h
@@ -471,7 +472,7 @@ launcher).
 
 - Cache shape: `Map<pageId|blockId, { dbId: string, expiresAt: number }>`.
 - Bounded: max 5000 entries, LRU eviction. Tunable via
-  `NOTION_LAUNCHER_CACHE_SIZE` env (not surfaced in YAML — internal).
+  `NOTION_LAUNCHER_CACHE_SIZE` env (not surfaced in YAML, internal).
 - TTL: 10 minutes. After expiry the resolver re-walks. Cheap enough
   given the bucket.
 - Cache is per-launcher-process (per-agent) — not shared across
@@ -522,7 +523,7 @@ Mitigation, **mandatory in v1**:
 
 Reads still go through Layer 1 (allowlist) but skip Layer 2
 (approval card). Consistent with gdrive/m365: read-only calls are
-below the approval bar. The allowlist still applies — a read
+below the approval bar. The allowlist still applies, and a read
 against a DB outside the allowlist is still rejected.
 
 ## 9. Doctor probes
@@ -555,7 +556,7 @@ shape):
    limit budget on every routine doctor run.
 
 Doctor must **skip** (not fail) when no agent has `notion_workspace:`
-configured — same posture as the existing gdrive/m365 probes.
+configured, same posture as the existing gdrive/m365 probes.
 
 ## 10. Implementation plan
 
@@ -584,7 +585,7 @@ its own reviewer pass; only the final PR enables auto-merge.
 
 - `src/cli/notion-mcp-launcher.ts`: vault-fetch → env-inject → spawn
   bridge. Heartbeat file. Crash-loop on vault failure (exit 1, no
-  retry — let docker restart-policy handle it). Wraps HTTP layer
+  retry, let docker restart-policy handle it). Wraps HTTP layer
   with rate-bucket client.
 - `src/vault/broker/notion-rate-bucket.ts`: token-bucket primitive
   (3 tokens, refill 3/sec, configurable via
@@ -606,7 +607,7 @@ its own reviewer pass; only the final PR enables auto-merge.
 ### PR 3 — Allowlist enforcement + approval hook + post-filter (~700 LOC)
 
 - `telegram-plugin/gateway/notion-write-approval.ts`: PreToolUse hook
-  with two layers — allowlist gate (all tools) + approval card
+  with two layers: allowlist gate (all tools) + approval card
   (writes). Uses the broker's rate-bucket for its own resolver calls.
 - `src/notion/db-resolver.ts`: per-tool DB resolution (§8.2). Tool-
   shape dispatch table; recursion-bounded ≤4 hops for block-parent
@@ -651,7 +652,7 @@ its own reviewer pass; only the final PR enables auto-merge.
   currently on clerk is **retired** in favour of this bundled skill
   (§13.2 covers the migration).
 - `telegram-plugin/uat/scenarios/jtbd-notion-readwrite-dm.test.ts`:
-  end-to-end UAT — operator DMs clerk asking to add an item to a
+  end-to-end UAT: operator DMs clerk asking to add an item to a
   DB, approval card appears, accept, DM confirmation lands.
 - `telegram-plugin/uat/scenarios/jtbd-notion-allowlist-deny-dm.test.ts`:
   carrie tries to write to a DB outside her allowlist, gets a clean
@@ -669,7 +670,7 @@ its own reviewer pass; only the final PR enables auto-merge.
 - Per-page (not per-DB) allowlist (when a page-level use case lands).
 - Public-integration OAuth flow (for multi-operator deployments).
 - Notion comment / mention threading into telegram (could be a
-  different RFC — same `inbox-zero` JTBD).
+  different RFC, same `inbox-zero` JTBD).
 
 ## 11. Effort estimate
 
@@ -692,7 +693,7 @@ Plus ~20–30 minutes total across the series for reviewer iteration.
 
 This is still materially cheaper than m365's 5-PR series (which
 clocked several hours because OAuth/MSAL is heavyweight). The
-integration-token model is still the dominant savings — but the
+integration-token model is still the dominant savings, but the
 per-DB allowlist + search post-filter are real engineering, not the
 free win the first draft suggested.
 
@@ -762,7 +763,7 @@ while agents are running?
 
 The MCP server returns 401 on the next call. The launcher process
 keeps running; only the *next* tool call fails. The agent surfaces
-the 401 to the operator naturally. No automatic recovery — operator
+the 401 to the operator naturally. No automatic recovery: the operator
 re-creates the integration, rotates the vault key, restarts the
 launchers. Documented as a v1 limitation.
 

--- a/reference/rfcs/onboarding-gap-analysis.md
+++ b/reference/rfcs/onboarding-gap-analysis.md
@@ -1,6 +1,7 @@
 ---
-artefact: Switchroom onboarding gap analysis (point-in-time, historical)
-serves: jobs/get-from-zero-to-a-working-fleet.md
+artifact: Switchroom onboarding gap analysis (point-in-time, historical)
+serves: get-from-zero-to-a-working-fleet
+advances-outcome: standing-team
 status: historical (last updated 2026-04-25) — not a live tracker
 ---
 
@@ -14,7 +15,7 @@ track closure and is stale. Several of the gaps below have since
 shipped fixes. It is deliberately **not** re-adjudicated gap-by-gap
 here (per-gap status would itself go stale and risks introducing
 errors). Read it as a snapshot of the onboarding pain that motivated a
-batch of fixes — not as the current state of any individual gap. For
+batch of fixes, not as the current state of any individual gap. For
 present-day onboarding behaviour, follow the docs and the CLI, not
 this list.
 
@@ -34,7 +35,7 @@ repeats the same song.
 
 Scaffolding a new agent does not create its Hindsight bank. The first
 `retain` against a missing bank blows up with a foreign-key constraint
-failure — because `get_bank_stats` returns an empty-looking response for a
+failure, because `get_bank_stats` returns an empty-looking response for a
 missing bank rather than erroring, the worker driving the ingest didn't
 realise the bank wasn't there until the first write failed. Silent-on-read,
 loud-on-write is the worst ordering for this kind of bug. The fix is two
@@ -46,7 +47,7 @@ instead of bubbling up a raw FK error.
 
 `switchroom agent restart lawgpt` returned `"Restarted lawgpt"` in under a
 second. The service log, a few seconds later, said `"1 MCP server failed ·
-/mcp"`. The CLI has no notion of readiness — it spawns the process and
+/mcp"`. The CLI has no notion of readiness. It spawns the process and
 returns. From the operator's seat this looks identical to a clean boot.
 Anything that relies on the broken MCP silently no-ops until someone
 notices. Restart needs a readiness gate with a timeout and a clear error if
@@ -75,7 +76,7 @@ list, none of them declarative per-agent:
 - **Dynamic UserPromptSubmit hook.** Injects `MEMORY.md` (plus today/yesterday
   daily notes) into context every turn. Hardcoded list.
 - **Agent self-read.** `AGENTS.md` instructs the agent to read additional
-  files (e.g. `BRIEF.md`) on session start. Nothing loads them — the agent
+  files (e.g. `BRIEF.md`) on session start. Nothing loads them. The agent
   pulls them because its own instructions say to.
 
 During `lawgpt` setup, I renamed `BRIEF.md` → `BOOTSTRAP.md` on the theory
@@ -83,7 +84,7 @@ that the rename would pull it into the system prompt. It did, but the
 agent's `AGENTS.md` already pointed at `BRIEF.md` to self-load, so the
 rename broke the self-read path. Had to rename back.
 
-The real problem isn't documentation — it's that there's no single place
+The real problem isn't documentation. It's that there's no single place
 where an agent declares "here are my context files and when they load."
 Short term, a conventions doc stops operators tripping on the incident I
 tripped on. Medium term, the three loaders should converge onto one
@@ -106,7 +107,7 @@ improvisation each time.
 only becomes knowable after the user DMs the bot `/start`. So the user has
 to: run setup, DM the bot, rerun setup to get their id captured into
 `access.json`. Two passes where one would do. The bot is already polling
-between the passes — we could just wait for the `/start` interactively
+between the passes. We could just wait for the `/start` interactively
 during setup and write `access.json` in the same session.
 
 ### 7. Empty template files pollute every turn's context
@@ -115,8 +116,8 @@ New agents ship with template `MEMORY.md`, `USER.md`, `TOOLS.md` etc.
 containing placeholder strings like `_set this_` and "Edit this file to
 describe …". Those files load into the system prompt (stable) or every
 turn (`MEMORY.md` via the dynamic hook) regardless of whether anyone
-filled them in. The result is that a fresh agent burns context — and
-occasionally model attention — on instructions to fill in blanks that
+filled them in. The result is that a fresh agent burns context, and
+occasionally model attention, on instructions to fill in blanks that
 nobody is going to fill in during the conversation. Either the loader
 should skip files whose only content is template placeholder, or the
 scaffold should ship them empty with a commented header and let them
@@ -128,14 +129,14 @@ Related to gap 4 but worth calling out: `switchroom workspace render
 --stable` has a literal list of filenames baked into the binary. Adding
 a new context file to an agent requires editing switchroom source, not
 the agent's config. That's what drove the `BRIEF.md` → `BOOTSTRAP.md`
-rename in the first place — there was no way to add `BRIEF.md` to the
+rename in the first place. There was no way to add `BRIEF.md` to the
 stable list without shipping a switchroom release. Folds into the
 convergence work proposed in gap 4.
 
 ## Phased fix plan
 
 Effort estimates are Ken-hours, not calendar time. Success criteria are
-the bar for "done" — not aspirational, the actual gate.
+the bar for "done", not aspirational, the actual gate.
 
 ### Phase A — quick wins, ship first
 
@@ -179,8 +180,8 @@ the bar for "done" — not aspirational, the actual gate.
 
 - **Effort:** ~2 hours
 - **Scope:** one page (`docs/workspace-files.md`) covering the three
-  loading mechanisms — stable system-prompt render, dynamic UserPromptSubmit
-  hook, agent self-read — what files go where, naming conventions, and
+  loading mechanisms (stable system-prompt render, dynamic UserPromptSubmit
+  hook, agent self-read): what files go where, naming conventions, and
   how an agent actually boots. Linked from `README.md` and the profile
   docs.
 - **Success criteria:** a new contributor can set up a new agent's
@@ -214,7 +215,7 @@ the bar for "done" — not aspirational, the actual gate.
 #### B3. `switchroom agent doctor <name>`
 
 - **Effort:** ~1 day
-- **Scope:** deeper than `status` — checks Hindsight bank exists and has
+- **Scope:** deeper than `status`. Checks Hindsight bank exists and has
   non-zero memories if the agent is supposed to be seeded, directives are
   loaded, stable workspace files are non-empty and aren't still the
   unedited template with `_set this_` placeholders, every file referenced
@@ -228,7 +229,7 @@ the bar for "done" — not aspirational, the actual gate.
 #### C1. Corpus bootstrap with an LLM worker template
 
 - **Effort:** ~week
-- **Scope:** the real work in onboarding a corpus isn't file copying —
+- **Scope:** the real work in onboarding a corpus isn't file copying,
   it's synthesis. Reading hundreds of files to produce a `BRIEF.md`,
   extracting directives, seeding mental models, and writing recall
   validation queries. That's LLM work, not a shell script. The scope
@@ -236,7 +237,7 @@ the bar for "done" — not aspirational, the actual gate.
   agent declaring corpus paths, directive seeds, brief-template sources,
   and recall-test queries; (b) a packaged prompt-template that
   `switchroom agent bootstrap <name>` feeds to a worker sub-agent to
-  execute the synthesis against the declared inputs. Idempotent —
+  execute the synthesis against the declared inputs. Idempotent:
   re-running skips work already done. Today's lawgpt Phase 1 onboarding
   becomes a one-liner.
 - **Success criteria:** `lawgpt`-scale corpus onboarding is reproducible

--- a/reference/rfcs/per-speaker-memory-routing.md
+++ b/reference/rfcs/per-speaker-memory-routing.md
@@ -1,8 +1,8 @@
 ---
-artefact: Per-speaker memory routing — recall the right user's bank by Telegram sender
-serves: jobs/remember-across-sessions.md
+artifact: Per-speaker memory routing — recall the right user's bank by Telegram sender
+serves: remember-across-sessions
+advances-outcome: standing-team
 relates: jobs/run-a-fleet-of-specialists.md, jobs/feel-like-a-colleague.md
-backs: single-tenant
 status: proposal (2026-06-19) — design + effort, gate cleared, not yet scheduled
 ---
 
@@ -17,7 +17,7 @@ it costs.
 
 Serves [`remember-across-sessions`](../jobs/remember-across-sessions.md):
 the agent brings back *the right* facts in the moment. With multiple users
-on one agent, "the right facts" is speaker-dependent — Lisa's preferences
+on one agent, "the right facts" is speaker-dependent. Lisa's preferences
 are noise in a turn with Ken, and vice-versa. Two payoffs at once:
 
 1. **Privacy / relevance** — one user's memories don't bleed into another
@@ -35,7 +35,7 @@ user memory privacy."*
 Routing data by human identity *looks* like multi-tenancy, so it has to
 pass the by-construction test. It does, because:
 
-- It stays **one tenant** — every bank is the operator's data, in the
+- It stays **one tenant**. Every bank is the operator's data, in the
   operator's hindsight instance, fully visible to the operator. A per-user
   bank is a *recall scope*, not a private silo the operator can't see.
 - It is **additive recall scoping, never authorization.** Who may drive an
@@ -44,7 +44,7 @@ pass the by-construction test. It does, because:
   the agent.
 
 If a future change tries to make per-user routing an *isolation-from-the-operator*
-or an *access-control* boundary, that change — not this one — trips the
+or an *access-control* boundary, that change (not this one) trips the
 invariant.
 
 ## How it works — the plumbing already exists
@@ -58,7 +58,7 @@ Every Telegram inbound is wrapped in a `<channel source="telegram"
 chat_id="…" user="…" …>` envelope before it reaches the `claude` session.
 The gateway emits the sender per-message:
 
-(Citations are symbol-based — line numbers in these files drift.)
+(Citations are symbol-based; line numbers in these files drift.)
 
 - `handleInbound` (`telegram-plugin/gateway/gateway.ts`) captures `ctx.from`.
 - It assembles the `InboundMessage` carrying `userId: from.id` plus
@@ -73,7 +73,7 @@ The gateway emits the sender per-message:
 
 So the speaker is **physically in the prompt text** the recall hook reads
 from stdin (`vendor/hindsight-memory/scripts/recall.py`). The hook already
-parses sibling attributes out of that same envelope head —
+parses sibling attributes out of that same envelope head:
 `extract_chat_id_from_prompt` / `extract_topic_from_prompt` in
 `vendor/hindsight-memory/scripts/lib/gateway_ipc.py`.
 
@@ -85,7 +85,7 @@ merges the results (the additional-banks loop in `recall.py`). It's
 production-hardened: the cache key includes the extra banks, each extra bank
 has an 8 s timeout with headroom inside the 12 s hook ceiling, and a failed
 extra-bank recall is non-fatal. `derive_bank_id` (`scripts/lib/bank.py`)
-even has a `user` granularity segment already — it just sources the user
+even has a `user` granularity segment already. It just sources the user
 from a *static boot-time* env (`HINDSIGHT_USER_ID`), not the per-message
 sender. That static-vs-per-message gap is the entire feature.
 
@@ -102,12 +102,12 @@ topic.
 ## The change
 
 1. **Vendor hook** (`vendor/hindsight-memory/`, as marked
-   `# Switchroom-local:` additions — the existing convention):
+   `# Switchroom-local:` additions, the existing convention):
    - Add `extract_user_from_prompt(prompt)` to `gateway_ipc.py` (a ~3-line
      sibling of the chat-id/topic extractors).
    - In `recall.py`, after deriving `bank_id`, look the sender up in a
      switchroom-provided map and **append the resolved bank to
-     `additional_banks`** (additive — the agent's own bank is still
+     `additional_banks`** (additive, the agent's own bank is still
      recalled).
    - Add the sender to `_cache_key` so two speakers in one session with the
      same prompt don't collide on the recall cache.
@@ -152,7 +152,7 @@ Recommended sequence:
   (only the hook sees the per-message sender), so it's a vendor patch with
   an upstream-sync note, landed as marked `# Switchroom-local:` additions.
 - **Username vs numeric id.** `user=` is `from.username ?? String(from.id)`
-  — username-less senders key by numeric id. The map must accept both;
+  so username-less senders key by numeric id. The map must accept both;
   normalize switchroom-side or document the key format.
 
 ## Effort

--- a/reference/rfcs/secret-request-vault-save.md
+++ b/reference/rfcs/secret-request-vault-save.md
@@ -1,6 +1,7 @@
 ---
-artefact: agent-requested secrets — secure save-card to vault (no chat paste)
-serves: jobs/approve-what-my-agent-can-touch.md
+artifact: agent-requested secrets — secure save-card to vault (no chat paste)
+serves: approve-what-my-agent-can-touch
+advances-outcome: hold-the-leash
 status: Draft
 ---
 
@@ -15,7 +16,7 @@ status: Draft
 
 When an agent needs a secret that isn't in the vault, it must **never ask
 the user to paste the raw value into a chat message**. Today nothing stops
-that — it's exactly what triggered the 2026-06-01 incident: Clerk asked the
+that. It's exactly what triggered the 2026-06-01 incident: Clerk asked the
 operator to paste a Coolify API token because the `vault:` entry was empty,
 the operator pasted it as freeform text, and (because the Sanctum shape was
 uncovered) it persisted in plaintext.
@@ -24,7 +25,7 @@ This RFC adds the missing primitive: an agent-facing **`request_secret`**
 tool that triggers a **secure save-card → vault** flow. The operator taps
 the card and sends the value once; the gateway deletes it instantly and
 writes it straight to the vault. The raw value is never recorded to
-history, never logged, and **never returned to the agent** — the agent only
+history, never logged, and **never returned to the agent**. The agent only
 ever sees `vault:<key>`.
 
 This is composition of primitives that already exist for the
@@ -46,7 +47,7 @@ storage path.
 
 1. Agent: "Please paste your Coolify API token here and I'll use it."
 2. Operator pastes `17|<40-char>` as a normal message.
-3. Inbound gate runs `detectSecrets` (ingest, fail-closed) — but only
+3. Inbound gate runs `detectSecrets` (ingest, fail-closed), but only
    catches it if a pattern matches. Pre-#2043 the Sanctum shape was
    uncovered → the raw token was recorded to `history.db` and forwarded to
    the agent over IPC.
@@ -75,9 +76,9 @@ request_secret(key: string, reason: string, chat_id?: string)
 ### 4.2 The save-card
 The gateway posts to the operator chat:
 
-> 🔒 *<agent>* needs a secret: `<key>` — <reason>.
+> 🔒 *<agent>* needs a secret: `<key>`, <reason>.
 > Tap **Provide securely**, then send the value. I'll delete your message
-> instantly and store it in the vault — it's never shown in chat or to the
+> instantly and store it in the vault. It's never shown in chat or to the
 > agent.
 > `[ Provide securely ]  [ Not now ]`
 
@@ -90,14 +91,14 @@ secret keyboard (`buildDeferredSecretKeyboard` / `mintDeferredSecretKernelReques
   `AUTH_CODE_CONTEXT_TTL_MS`). Edit the card → "Send the value for `<key>`
   now (auto-deletes)."
 - The **next inbound message** in that chat is intercepted **early in
-  `handleInbound`** — before `recordInbound`, before the IPC broadcast,
-  before even the normal secret-detect logging — and treated as the value:
+  `handleInbound`**, before `recordInbound`, before the IPC broadcast,
+  before even the normal secret-detect logging, and treated as the value:
   1. `deleteSensitiveMessage(chat_id, msgId, 'requested secret value')`.
   2. Write to the vault under `key` via the **existing deferred-secret
      path**: if a passphrase is cached, store directly; if not, stage with
      `suggested_slug = key` and present the existing one-tap
      unlock-and-save card (`buildDeferredSecretKeyboard`). This is the same
-     code path a detected paste already uses — we just pre-set the slug
+     code path a detected paste already uses. We just pre-set the slug
      instead of deriving it.
   3. Confirm: "✅ saved as `vault:<key>` (masked: `<maskToken>`)." Clear the
      marker.
@@ -112,7 +113,7 @@ Update the fleet behavior text (the `TELEGRAM_GUIDANCE` const →
 `renderFleetInvariants` → `switchroom-invariants.md`, per
 `reference_live_telegram_guidance_carrier`): **"Never ask the user to paste
 a secret, API key, token, or password into chat. If you need a credential
-that isn't in the vault, call `request_secret(key, reason)` — the operator
+that isn't in the vault, call `request_secret(key, reason)`. The operator
 provides it through a secure card and you reference it as `vault:<key>`."**
 This is what actually prevents the incident class; the tool + card are the
 mechanism it points at.
@@ -129,14 +130,14 @@ The gateway already ships two agent-initiated vault tools (issue #969 P1a / #101
   to an existing key (`vra:` callbacks).
 
 `request_secret` is the **missing third case**: the agent needs a value it
-does **not** have. It is `vault_request_save` *minus the `value` arg* — the
+does **not** have. It is `vault_request_save` *minus the `value` arg*: the
 value arrives from the operator via secure capture instead of from the
 agent. It reuses the same staging map shape, card/keyboard rendering, slug
 validation (`VAULT_KEY_REGEX`), and the on-tap vault write
 (`defaultVaultWritePosture` / `defaultVaultWrite`). New callback prefix
 `vsp:` (vault-secret-provide), mirroring `vrs:`.
 
-**This resolves §6.1:** the access grant is NOT new work — after the value
+**This resolves §6.1:** the access grant is NOT new work. After the value
 is saved, the requesting agent gets read access through the *existing*
 `vault_request_access` flow (or the operator's `mcp_servers[].secrets[]`).
 `request_secret` can optionally chain into it, but it doesn't reimplement
@@ -167,12 +168,12 @@ map, one callback branch, and one early interception branch in
    `switchroom.yaml`? Requesting ≠ access: the value lands in the vault
    under broker ACL regardless; the question is whether we offer a one-tap
    "also let <agent> read this" on the same card. (Recommendation: offer it
-   on the card, since the operator is already in the approve flow — but it's
+   on the card, since the operator is already in the approve flow, but it's
    a security-posture call.)
 2. **Tool name + card copy** — `request_secret` vs `need_secret` vs
    `ask_for_credential`; exact card wording. Product/voice call.
 3. **Should we also intercept a detected raw-secret paste** (the #2043
-   flow) and *steer* it: "looks like you pasted a secret — want me to save
+   flow) and *steer* it: "looks like you pasted a secret, want me to save
    it to the vault instead?" Already partly true (detected pastes are
    deleted + offered for vaulting); this would add explicit steering copy.
    In scope here or a separate ticket?
@@ -190,7 +191,7 @@ map, one callback branch, and one early interception branch in
   broadcast in `handleInbound` (mirror `gateway-secret-detect.test.ts`).
 - Guarantee: a captured value never appears in `history.db` (extend
   `history.test.ts`) and never in the IPC payload.
-- UAT (operator, mtcute): end-to-end — agent calls `request_secret`, card
+- UAT (operator, mtcute): end-to-end, agent calls `request_secret`, card
   appears, operator provides, value deletes + vaults, agent reads
   `vault:<key>`.
 

--- a/reference/rfcs/shared-user-profile.md
+++ b/reference/rfcs/shared-user-profile.md
@@ -1,6 +1,7 @@
 ---
-artefact: Shared user-identity profile across the fleet — evaluation + recommendation
-serves: jobs/remember-across-sessions.md
+artifact: Shared user-identity profile across the fleet — evaluation + recommendation
+serves: remember-across-sessions
+advances-outcome: standing-team
 relates: jobs/run-a-fleet-of-specialists.md, invariants.md
 status: Draft (2026-06-19) — EVALUATION; recommends the light path, defers the heavy one
 ---
@@ -10,26 +11,26 @@ status: Draft (2026-06-19) — EVALUATION; recommends the light path, defers the
 ## The ask
 
 > Many agents' `user-profile` mental models aren't populated. Define a
-> switchroom concept of a *user* — tied to a Telegram account as identity
-> (e.g. Ken, Lisa for this install) — and let the operator declare things
+> switchroom concept of a *user*, tied to a Telegram account as identity
+> (e.g. Ken, Lisa for this install), and let the operator declare things
 > about that user that are shared across all agents, so every agent knows
 > the same baseline consistently.
 
 This doc evaluates whether that's a good idea and, if so, in what shape.
-It is deliberately not a one-sided spec: the conclusion is that the
+It is deliberately not a one-sided spec. The conclusion: the
 **goal is right and on-vision**, but the **mechanism the ask reaches for
 (a shared memory bank + identity-keyed recall) is more machinery than
-the core need requires** — a far lighter path already exists and should
+the core need requires**. A far lighter path already exists and should
 ship first.
 
 ## Why the goal is right
 
-It serves the vision's first outcome directly — *"a standing team that
+It serves the vision's first outcome directly: *"a standing team that
 knows you."* The relationship is supposed to compound; an agent that
 makes you re-explain who you are each time is the goldfish the
 [`remember-across-sessions`](../jobs/remember-across-sessions.md) job
-exists to kill. Stable facts about the operator — timezone, family,
-working style, hard preferences — *should* be consistent across every
+exists to kill. Stable facts about the operator (timezone, family,
+working style, hard preferences) *should* be consistent across every
 specialist. Today they aren't: the seeded `user-profile` mental model is
 synthesised **bottom-up** from each agent's own conversations, so a
 low-traffic agent has a sparse or empty profile. Seeding it **top-down**
@@ -42,23 +43,23 @@ on-vision.
 makes memory **isolation** a hard requirement and names *"memory pooled
 across the fleet so what you told one specialist leaks into another"* as
 a top **bad**. `access-model` / `single-tenant` add that one operator
-owns the box. So any "shared" memory has to thread two needles:
+owns the box. So any "shared" memory has to thread two needles.
 
 1. **Identity layer, not conversation layer.** A shared *who-you-are*
    baseline is fine; a shared *what-you-said-to-the-coding-agent* pool is
    exactly the cosplay the job forbids. The split only holds if the
    shared layer is **operator-authored stable facts** and never a sink
    that auto-retains conversational memory. That discipline is the whole
-   ballgame — a shared bank that quietly accumulates is the failure mode.
+   ballgame. A shared bank that quietly accumulates is the failure mode.
 2. **Known people, not co-operators.** Declaring *Lisa* as a person the
    agents know about is compatible with `single-tenant`. Letting Lisa
-   *command or grant* is not — that's a multi-principal access change, a
+   *command or grant* is not. That's a multi-principal access change, a
    much larger and separate decision. This RFC scopes "user" to
    **identity + profile**, explicitly not control.
 
 ## Two designs
 
-### B — Light: operator-authored profile, injected fleet-wide (recommended first)
+### B (light): operator-authored profile, injected fleet-wide (recommended first)
 
 switchroom **already** injects operator-authored, release-controlled
 context into every agent: `renderFleetInvariants()` writes
@@ -67,14 +68,14 @@ Code's `--add-dir` (`src/agents/scaffold.ts:353`). And directives
 already reach **every turn** (surfaced client-side in the recall hook,
 `vendor/hindsight-memory/scripts/lib/directives.py`).
 
-So the lightest version of the ask is: **an operator-authored
-user-profile block, injected into every agent's always-on context** —
+So the lightest version of the ask is **an operator-authored
+user-profile block, injected into every agent's always-on context**:
 either a `user:` section in switchroom.yaml rendered into a fleet-level
 profile file, or expressed as directives. No new memory infrastructure,
 no new bank, no identity-keyed recall.
 
 - **Invariants:** clean. It's static operator-authored text, not a
-  pooled conversational bank — the isolation line is never approached.
+  pooled conversational bank, so the isolation line is never approached.
   Chat-legible (the operator wrote it; the agent can recite it).
 - **Cost:** a few hundred tokens of always-present context per turn.
   Negligible, and it's identity facts the agent would otherwise
@@ -82,18 +83,18 @@ no new bank, no identity-keyed recall.
 - **Delivers:** every agent consistently knows the declared baseline,
   immediately, even on a brand-new or zero-traffic agent. This is most
   of the stated value.
-- **Limits — and these are precisely what design A buys back:** static
-  (every fact every turn — fine for a small stable profile, wasteful if
+- **Limits, and these are precisely what design A buys back:** static
+  (every fact every turn, fine for a small stable profile, wasteful if
   it grows large → A's *semantic recall*); single-profile (no per-speaker
   switching → A's *identity keying*); doesn't grow or self-correct (→ A's
   *living bank*). All three are speculative-today (see the verdict), which
   is why they're the deferred remainder, not the core.
 
-### A — Heavy: shared hindsight bank + `recallAdditionalBanks` + identity keying
+### A (heavy): shared hindsight bank + `recallAdditionalBanks` + identity keying
 
 The recall hook already supports `recallAdditionalBanks`
 (`vendor/hindsight-memory/scripts/recall.py:641`) and the code even
-names this use case — `recall.py:744`: *"Also recall from any additional
+names this use case at `recall.py:744`: *"Also recall from any additional
 banks (e.g. shared user profile bank)."* The heavy design:
 seed a shared per-user bank (`user-profile:ken`) top-down, wire every
 agent's `recallAdditionalBanks` to include it, and **select the bank by
@@ -105,22 +106,22 @@ surfaces.
   corrected** over time, and genuine **per-speaker** switching (Ken's
   profile when Ken talks, Lisa's when Lisa talks).
 - **What it costs:** `recallAdditionalBanks` isn't wired through
-  switchroom config today (`src/cli/memory.ts:33` is the only mention) —
-  it needs config-cascade plumbing, bank seeding/maintenance, and
+  switchroom config today (`src/cli/memory.ts:33` is the only mention).
+  It needs config-cascade plumbing, bank seeding/maintenance, and
   inbound-`user_id`→bank selection. It adds a **second recall query every
-  turn** (latency + tokens — the exact axis the Phase 1/6a work just
+  turn** (latency + tokens, the exact axis the Phase 1/6a work just
   optimised). And it re-opens the **isolation tension**: a shared bank is
   pooled memory, kept safe only by the discipline of never auto-retaining
   into it.
 - **Single-tenant:** per-speaker keying only earns its complexity if Lisa
   *actually talks to the agents* and you want *her* profile to surface
   when *she* does. If the need is just "agents know my wife is Lisa,"
-  that's one fact in **my** profile (design B) — no Lisa-identity bank
+  that's one fact in **my** profile (design B). No Lisa-identity bank
   required.
 
-## Verdict — is this a good idea?
+## Verdict: is this a good idea?
 
-**The goal: yes. The heavy mechanism: not yet — and probably not for a
+**The goal: yes. The heavy mechanism: not yet, and probably not for a
 while.**
 
 - **Ship B.** It delivers the core outcome ("every agent consistently
@@ -132,12 +133,12 @@ while.**
   design is justified only if (a) the profile grows large enough that
   injecting it whole every turn is wasteful, or (b) a *second human*
   genuinely converses with the fleet and you want per-speaker profiles.
-  Both are speculative today. Until one is real, A is complexity +
-  recall cost + a re-opened isolation tension bought for value B already
-  provides.
+  Both are speculative today. Until one is real, A is complexity plus
+  recall cost plus a re-opened isolation tension bought for value B
+  already provides.
 - **Treat multi-user as its own decision.** "Known people" (profile only)
   is a small extension of B. "People who can drive agents" is a
-  multi-principal change to the access model and `single-tenant` — out of
+  multi-principal change to the access model and `single-tenant`. Out of
   scope here, and not to be smuggled in via a memory feature.
 
 So: a good idea, reframed. Build the operator-authored shared profile
@@ -146,11 +147,11 @@ need names itself.
 
 ## Verdict check (the four-part rule)
 
-- **Advances an outcome?** Yes — `standing-team` / knows-you, via the
+- **Advances an outcome?** Yes, `standing-team` / knows-you, via the
   core memory job.
 - **Satisfies the job spec?** B makes every agent know the operator
   consistently (remember-across-sessions) without pooling conversational
-  memory (run-a-fleet-of-specialists) — both honoured. A risks the
+  memory (run-a-fleet-of-specialists). Both honoured. A risks the
   second.
 - **Principle checks?** B: defaults (operator declares once, works
   fleet-wide), docs (no new user concept beyond a yaml block),
@@ -158,12 +159,12 @@ need names itself.
   new memory surface + config + identity routing.
 - **Crosses an invariant?** B: no. A: only if the shared bank ever
   auto-retains (isolation) or "user" creeps from identity into control
-  (single-tenant) — both avoidable by construction, but they are live
+  (single-tenant). Both avoidable by construction, but they are live
   risks A must design against and B sidesteps.
 
 ## Recommended next step
 
-If accepted: implement **B** as a thin slice — a `user:` block in
+If accepted: implement **B** as a thin slice, a `user:` block in
 switchroom.yaml (free-form facts + a few optional structured fields)
 rendered into the fleet-injected operator-profile context, default on.
 Measure whether the unpopulated-profile complaint actually goes away.

--- a/reference/rfcs/skill-authoring-native.md
+++ b/reference/rfcs/skill-authoring-native.md
@@ -1,6 +1,7 @@
 ---
-artefact: native-by-default skill authoring
-serves: jobs/extend-without-forking.md
+artifact: native-by-default skill authoring
+serves: extend-without-forking
+advances-outcome: standing-team
 status: Implemented (Phase 1 + 3); Phase 2a superseded
 ---
 
@@ -10,7 +11,7 @@ status: Implemented (Phase 1 + 3); Phase 2a superseded
 > agent-scope authoring + the non-blocking validator hook) and Phase 3
 > (deleting the deprecated create/edit/read/delete shim) shipped and
 > stand. **Phase 2a's runtime `skill_publish`/`skill_unpublish` path
-> was removed** — fleet-wide sharing is a reviewed pull request
+> was removed.** Fleet-wide sharing is a reviewed pull request
 > (bundled-default opt-out / `skills:` cascade), not a runtime broker
 > write, because PR review is the stronger and simpler gate for code
 > every agent runs. The `--adopt` idea (§3.5/§7) was dropped for the
@@ -18,17 +19,17 @@ status: Implemented (Phase 1 + 3); Phase 2a superseded
 > as the design record of how we got here.
 
 Status: Implemented (Phase 1 + 3); Phase 2a/`--adopt` superseded by
-review-via-PR — see banner above
+review-via-PR, see banner above
 Author: Ken (via Claude pair-design)
 Date: 2026-05-18
 Relates: #1490 (PR A), #1491 (PR B), #1492/#1494 (the `--version`
-collision that motivated this), #1163 (skill install/remove —
+collision that motivated this), #1163 (skill install/remove,
 orthogonal, see §3.4)
 
 > **v2 changelog (independent review + code-validation pass):**
 > §2.2 persistence citation corrected to the same-path mount and
 > *why* it (not the `/state/*` mount) is load-bearing; §3.3 stops
-> claiming cron-deny is "kept" — it is **inert in production today**
+> claiming cron-deny is "kept": it is **inert in production today**
 > and is now an explicit non-goal with a stated accepted residual;
 > §3.5 promotes `skill_publish` marker-write atomicity into a stated
 > contract with the crash-after-copy self-lockout named; §3.3/§3.5
@@ -43,16 +44,16 @@ orthogonal, see §3.4)
 Make **agent-scope** skill authoring 100% Claude-native: an agent
 creates and edits its own skills with the bundled `skill-creator`
 skill and ordinary `Write`/`Edit` into
-`$CLAUDE_CONFIG_DIR/skills/<slug>/` — a directory that is already
+`$CLAUDE_CONFIG_DIR/skills/<slug>/`, a directory that is already
 persistent, reconcile-safe, and auto-discovered. Delete the
 agent-scope `skill_create/edit/read/delete` MCP tools, their
 `switchroom skill create|edit|read|delete` CLI verbs, the
 JSON-over-stdout shim (`spawnSyncWithStdin`), and the
 optimistic-concurrency version-token machinery.
 
-Keep the privileged broker **only** where it is irreducible —
-**global / cross-agent** writes the agent UID physically cannot make —
-and collapse that surface from four verbs to **one**: `skill_publish`
+Keep the privileged broker **only** where it is irreducible, the
+**global / cross-agent** writes the agent UID physically cannot make.
+Collapse that surface from four verbs to **one**: `skill_publish`
 (plus `skill_unpublish`). An admin agent authors and tests a skill
 natively in agent scope, then promotes a known-good copy with one
 explicit, audited, admin-gated action.
@@ -69,7 +70,7 @@ operator/admin does one thing, not three.
 #1492: `switchroom skill edit --version <token>` collided with the
 root program's commander `.version()` flag. Commander's version
 printer intercepted `--version`, printed `0.11.1` to stdout, exited
-0 — the edit never ran, nothing landed on disk, and the MCP server's
+0. The edit never ran, nothing landed on disk, and the MCP server's
 `JSON.parse("0.11.1")` threw "Unable to parse JSON string". `skill_read`
 /`skill_create` (no `--version` flag) worked, and #1491's only E2E
 covered `create`, so CI stayed green over the gap.
@@ -77,7 +78,7 @@ covered `create`, so CI stayed green over the gap.
 That bug class **only exists because there is a CLI + JSON-over-stdout
 shim in front of what is, for agent scope, a plain file write into the
 agent's own writable directory.** Argv parsing, stdout discipline,
-JSON round-tripping, version tokens, `--scope` plumbing — every one of
+JSON round-tripping, version tokens, `--scope` plumbing: every one of
 those is surface area that does not exist in the native model.
 
 > **Note — #1492 is already patched in-band.** #1494 renamed the
@@ -85,7 +86,7 @@ those is surface area that does not exist in the native model.
 > agent-facing MCP `version` arg unchanged) and added an E2E
 > regression. That is the *tactical* stop-gap so the surface works
 > until Phase 3 deletes it; this RFC is the *structural* fix. The two
-> don't conflict — Phase 3 removes the flag (and the whole shim)
+> don't conflict. Phase 3 removes the flag (and the whole shim)
 > entirely, retiring the patched code along with the bug class.
 
 ### 2.2 Agent scope needs none of it
@@ -94,7 +95,7 @@ Verified wiring (file:line):
 
 - **Persistent.** The load-bearing mount is the **same-path** bind
   `~/.switchroom/agents/<name>:~/.switchroom/agents/<name>`
-  (`src/agents/compose.ts:1661`) — *not* the `:/state/agent` mount at
+  (`src/agents/compose.ts:1661`), *not* the `:/state/agent` mount at
   `:1658`. This matters: `start.sh.hbs:173` sets
   `CLAUDE_CONFIG_DIR={{agentDir}}/.claude` where `{{agentDir}}` is the
   *host* path `~/.switchroom/agents/<name>` (`scaffold.ts` resolves it
@@ -107,13 +108,13 @@ Verified wiring (file:line):
   (`src/agents/scaffold.ts:793-795`, `:831-834`).
 - **Auto-discovered.** Claude scans `$CLAUDE_CONFIG_DIR/skills/`;
   `CLAUDE_CONFIG_DIR=<agentDir>/.claude`
-  (`profiles/_base/start.sh.hbs:173`) — exactly where agent-scope
+  (`profiles/_base/start.sh.hbs:173`), exactly where agent-scope
   skills resolve (`src/cli/skill-common.ts:189`, the
   `join(base, ".claude", "skills")`).
 - **Writable.** It is the agent's own scaffold dir, owned by the
   per-agent container UID.
 
-So for agent scope the four-tool shim adds **no capability** — only
+So for agent scope the four-tool shim adds **no capability**, only
 audit/caps/concurrency/identity-pin *policy*, none of which require a
 CLI for the agent's own persistent, reconcile-safe directory. Audit
 and caps are better expressed as a non-blocking validator hook on the
@@ -124,11 +125,11 @@ native write path (§3.3).
 `skills/skill-creator/SKILL.md` is already a bundled default
 (`src/agents/reconcile-default-skills.ts`), but it is destination-
 agnostic: it talks about producing a skill *directory* / `.skill`
-package and even warns "direct writes may fail due to permissions —
+package and even warns "direct writes may fail due to permissions,
 stage in `/tmp/` first" (SKILL.md:461). Nothing tells the agent that
 `$CLAUDE_CONFIG_DIR/skills/<slug>/` is the canonical, writable,
-live-next-turn home. Closing *that* gap — a few lines of skill-creator
-guidance plus a documented path — is the actual work for agent scope.
+live-next-turn home. Closing *that* gap, a few lines of skill-creator
+guidance plus a documented path, is the actual work for agent scope.
 Not four MCP tools.
 
 ### 2.4 It fails the product principles (see §6)
@@ -189,7 +190,7 @@ admin agent ─> skill-creator (native, AGENT scope) ─> iterate/test ─┐
 
 `skill_publish` is the **only** broker-backed write. It is a
 deliberate, atomic *replace-by-publish* of a complete skill directory
-— no per-file edits, no version tokens, no `--from-stdin`. The agent
+with no per-file edits, no version tokens, no `--from-stdin`. The agent
 already iterated in its own scope; publish promotes the result.
 
 ### 3.3 Delete / keep / new
@@ -217,7 +218,7 @@ already iterated in its own scope; publish promotes the result.
 
 `skill_install` / `skill_remove` (#1163 Phase 2) are **orthogonal**:
 they adopt/drop a *pool* skill into an agent's declared `skills:`
-list — a config edit materialised by reconcile, not authoring. They
+list, a config edit materialised by reconcile, not authoring. They
 stay as-is. (They are a candidate for a later "this is just a
 `skills:` cascade edit" simplification, but not in this RFC.)
 
@@ -232,7 +233,7 @@ already-iterated skill dir into a temp dir under the pool root,
 The marker is stamped **before** the rename so the published dir is
 never observable without its marker; the step-(4) fsync (marker +
 temp-dir dirent) before the rename is the Phase-2 implementation
-detail that makes "stamped before observable" durable across a crash. Rationale — the failure mode this
+detail that makes "stamped before observable" durable across a crash. Rationale, the failure mode this
 prevents: if publish copied the dir but crashed before stamping the
 marker, the next `skill_publish`/`skill_unpublish` would see an
 unmarked dir, classify it operator-owned (`E_SKILL_OPERATOR_OWNED`),
@@ -249,8 +250,8 @@ in its change set, and agent containers have no docker socket. So
 `--adopt` deliberately does **not** synthesise a new in-broker skill-
 reconcile. It only edits the named `skills:` cascade layer (the same
 declarative edit `skill_install` makes to its overlay). Symlink
-materialisation happens on the **next ordinary reconcile** —
-`switchroom apply` / a hostd-mediated `agent restart` — exactly the
+materialisation happens on the **next ordinary reconcile**
+(`switchroom apply` / a hostd-mediated `agent restart`), exactly the
 declare-then-reconcile gate this RFC already defends as the
 opt-in safety boundary (§5, alternative 3). This is *more* consistent
 (Principle 3), not a limitation: `--adopt` removes the "remember to
@@ -267,13 +268,13 @@ subject to no hard gate regardless of turn source. This is a
 **deliberate accepted residual**, documented here in the same spirit
 as switchroom's other stated residuals (e.g. the `strict`-off CI
 posture in `CLAUDE.md`): the blast radius is the **authoring agent's
-own UID-owned, per-agent directory** — it cannot reach a peer or the
+own UID-owned, per-agent directory**. It cannot reach a peer or the
 global pool without the privileged, admin-gated, marker-guarded
 `skill_publish`. A prompt-injected turn could rewrite that agent's own
 skills, which is strictly bounded by the agent's existing trust
 domain. If a real turn-source guard is later wanted, wiring a
 production `SWITCHROOM_TURN_SOURCE` (or a hook-readable cron signal)
-is a *separate* prerequisite deliverable — this RFC does not
+is a *separate* prerequisite deliverable. This RFC does not
 pretend the current code provides it.
 
 ## 4. Migration / phasing
@@ -283,11 +284,11 @@ Three PRs, each through the standard reviewer → auto-merge flow.
 - **Phase 1 — native agent scope (low risk, immediate UX win).**
   Document the canonical writable destination in
   `skill-creator/SKILL.md` (and that the skill is live on the *next*
-  turn, not mid-turn — §7 Q3); replace its actively-wrong "direct
-  writes may fail due to permissions — stage in `/tmp/` first"
+  turn, not mid-turn, see §7 Q3); replace its actively-wrong "direct
+  writes may fail due to permissions, stage in `/tmp/` first"
   guidance (`SKILL.md:460-461`), which is false for the agent-scope
   case. Add the non-blocking validator hook. Mark the four
-  agent-scope tools **deprecated** — and the deprecation string in
+  agent-scope tools **deprecated**, and the deprecation string in
   each MCP tool description MUST point explicitly at the native path
   (*"deprecated: author into `$CLAUDE_CONFIG_DIR/skills/<slug>/`
   directly with Write/Edit; this tool is removed in Phase 3"*) so the
@@ -295,7 +296,7 @@ Three PRs, each through the standard reviewer → auto-merge flow.
   conflicting instructions during the Phase 1→3 overlap. Note the
   overlap hazard: the legacy `skill_create` path errors
   `E_SKILL_ALREADY_EXISTS` (exit 13) on a slug a native write already
-  created — the deprecation text must say "if this errors, the skill
+  created. The deprecation text must say "if this errors, the skill
   already exists; just edit the files directly." No deletions yet.
   Ships the entire agent-scope benefit with zero capability loss.
 - **Phase 2 — collapse global.** Ship `skill_publish`/`skill_unpublish`
@@ -360,7 +361,7 @@ privileged verb shaped like `switchroom <noun> <verb>`. ✅
 Verdict per the contract's rule: advances the **multi-agent fleet**
 and **subscription-honest / no custom runtime** outcomes, satisfies
 the extend-without-forking JTBD, and passes all three principle checks
-*after* the redesign — which is exactly why it is a redesign and not a
+*after* the redesign, which is exactly why it is a redesign and not a
 patch.
 
 ## 7. Decisions & open questions
@@ -385,15 +386,15 @@ patch.
 
 **Genuinely open (non-blocking for Phase 1):**
 
-1. **Validator hook: warn vs. block?** Lean **warn** — native Claude
+1. **Validator hook: warn vs. block?** Lean **warn**. Native Claude
    doesn't block skill writes, and Principle 3's "let the model
    communicate" sub-principle argues against a hard gate. Hard-cap
    only the one thing with real blast radius (total skill bytes), as a
    hook-level reject with a clear message. *Note the interaction:*
    with cron-deny inert (§3.3) and the hook non-blocking, agent-scope
-   authoring has no hard turn-source gate — that is the deliberate
+   authoring has no hard turn-source gate. That is the deliberate
    accepted residual stated in §3.5, not an oversight.
-2. **`skill_publish` dry-run/diff.** Probably yes — mirror
+2. **`skill_publish` dry-run/diff.** Probably yes, mirror
    `switchroom update --check`: `skill_publish --check` prints what
    would change in the pool (new/overwrite, marker state) without
    writing. Consistency with the existing `--check` idiom.
@@ -407,7 +408,7 @@ patch.
 ## 8. Verdict / next steps
 
 Recommend proceeding with **Phase 1 now** (native agent scope: doc +
-hook + deprecation flag) — it is low-risk, additive, reversible, and
+hook + deprecation flag): it is low-risk, additive, reversible, and
 delivers the whole agent-scope UX win immediately. Phases 2–3 follow
 as separate PRs once the `skill_publish` contract in §3.5 and open
 questions 2–3 are nailed down.

--- a/reference/rfcs/status-card-design.md
+++ b/reference/rfcs/status-card-design.md
@@ -1,11 +1,12 @@
 ---
-artefact: Telegram progress card
-serves: jobs/know-what-my-agent-is-doing.md
+artifact: Telegram progress card
+serves: know-what-my-agent-is-doing
+advances-outcome: hold-the-leash
 status: archived — superseded
 supersededBy: conversational-pacing.md
 ---
 
-# Status card design — archived
+# Status card design (archived)
 
 The pinned two-zone progress card was retired in #1122 (PR3,
 2026-05-12) in favour of conversational pacing + a silence-poke

--- a/reference/rfcs/sub-agent-visibility.md
+++ b/reference/rfcs/sub-agent-visibility.md
@@ -1,20 +1,21 @@
 ---
-artefact: Sub-agent visibility — TDD verification + design RFC
-serves: jobs/know-what-my-agent-is-doing.md
+artifact: Sub-agent visibility — TDD verification + design RFC
+serves: know-what-my-agent-is-doing
+advances-outcome: hold-the-leash
 status: shipped (closed) — TDD verification landed; 2 narrow follow-ups tracked
 supersedes: nothing (extends status-card-design.md with TDD verification)
 relates: "#709 #776 #782 #788 #64 #757"
 ---
 
-# Sub-agent visibility — TDD verification + design RFC
+# Sub-agent visibility: TDD verification + design RFC
 
-## Status — SHIPPED / CLOSED
+## Status: SHIPPED / CLOSED
 
-The frontmatter previously read `rfc — draft, awaiting sign-off`; that
+The frontmatter previously read `rfc — draft, awaiting sign-off`. That
 is stale. The verification work this RFC proposed **landed**: the UAT
 scenarios were written and run, and Bugs 1–5 in the changelog table
 below merged (#1057, #1059, #1060, #1063, #1066). Treat this RFC as
-**closed** — its purpose (prove the background-dispatch path with a
+**closed**. Its purpose (prove the background-dispatch path with a
 regression-locked test) is done. Bug 6 and Bug 7 are moot. The
 progress-card-driver was deleted in PR #1122 PR3 before these could be
 fixed. The cross-turn visibility problem they addressed is now handled
@@ -27,7 +28,7 @@ by pending-work-progress.ts (#1445) and subagent-handback (#1720).
 > and `reference/rfcs/status-card-design.md` is archived. The acceptance
 > criteria and bug diagnoses here are still valid as the historical
 > record of how sub-agent visibility was verified, but the current
-> card-pacing contract lives in `conversational-pacing.md` — read that
+> card-pacing contract lives in `conversational-pacing.md`. Read that
 > for present-day behaviour.
 
 ## TL;DR
@@ -46,7 +47,7 @@ This RFC proposes:
 
 From `reference/jobs/know-what-my-agent-is-doing.md`:
 
-> Sub-agent work is visible in the same place as parent work — including
+> Sub-agent work is visible in the same place as parent work, including
 > background sub-agents that outlive the turn that spawned them. The user
 > never has to hunt for it, and never loses sight of a background member
 > just because the parent turn replied (the #64 fix).
@@ -88,27 +89,27 @@ What's NOT wired (the missing piece this RFC closes):
   - stuck detection (UAT prompt #10)
   - done-semantics with bg still running (UAT prompt #11)
 
-Without those scenarios, the design's correctness is theoretical. The 2026-05-07 incident is evidence that *something* in the chain still doesn't deliver — but without a repro, we'd be guessing which gap.
+Without those scenarios, the design's correctness is theoretical. The 2026-05-07 incident is evidence that *something* in the chain still doesn't deliver, but without a repro we'd be guessing which gap.
 
 ## Acceptance criteria (from `status-card-design.md` + JTBD)
 
-Numbered ACs — each maps 1:1 to a UAT scenario in §Scenarios:
+Numbered ACs, each maps 1:1 to a UAT scenario in §Scenarios:
 
 - **AC-1** — *Background-dispatch-and-continue.* Operator sends a DM that causes the agent to dispatch a background sub-agent. Parent replies; parent `turn_end` fires. The pinned progress card MUST stay pinned for at least 30 s past parent reply, with the fleet zone showing the running bg sub-agent (id6 chip + activity).
 
 - **AC-2** — *Done semantics.* While the bg sub-agent runs (status = `background`), the header MUST render as 🌀 Background, never ✅ Done. After the bg sub-agent terminates (`sub_agent_turn_end`), the header MUST flip to ✅ Done.
 
-- **AC-3** — *Live activity.* While the bg sub-agent is running, the card edits MUST land at ≥ 1 edit per 30 s wall-clock as the worker fires tools — i.e. the elapsed counter visibly advances and the fleet row's `last activity` age stays fresh.
+- **AC-3** — *Live activity.* While the bg sub-agent is running, the card edits MUST land at ≥ 1 edit per 30 s wall-clock as the worker fires tools, i.e. the elapsed counter visibly advances and the fleet row's `last activity` age stays fresh.
 
-- **AC-4** — *Stuck escalation.* [Moot — the progress card that would have rendered these glyphs was deleted in PR #1122 PR3. Stall detection still fires in `subagent-watcher.ts` but has no user-visible rendering surface. See issue #1445 for the cross-turn replacement.]
+- **AC-4** — *Stuck escalation.* [Moot: the progress card that would have rendered these glyphs was deleted in PR #1122 PR3. Stall detection still fires in `subagent-watcher.ts` but has no user-visible rendering surface. See issue #1445 for the cross-turn replacement.]
 
-- **AC-5** — *Heavy fleet HTML safety.* [Moot — the fleet zone renderer (`two-zone-card.ts`) was deleted in PR #1122 PR3. No fleet HTML is currently sent to Telegram.]
+- **AC-5** — *Heavy fleet HTML safety.* [Moot: the fleet zone renderer (`two-zone-card.ts`) was deleted in PR #1122 PR3. No fleet HTML is currently sent to Telegram.]
 
 - **AC-6** — *Originating-turn pinning.* If a new parent turn starts while a bg sub-agent from the prior turn is still running, the prior turn's card stays pinned and live-updating. The new turn gets its own card. Cards do not get cross-wired.
 
 ## TDD plan
 
-### Phase 1 — write failing scenarios
+### Phase 1: write failing scenarios
 
 Create `telegram-plugin/uat/scenarios/bg-sub-agent-dispatch-dm.test.ts` (AC-1 + AC-2 + AC-3 in one scenario, since they share setup).
 
@@ -176,7 +177,7 @@ describe("uat: background sub-agent stays visible on parent card", () => {
 });
 ```
 
-### Phase 2 — run + diagnose
+### Phase 2: run + diagnose
 
 For each AC that fails, file a sub-issue with the exact failure mode. The scenario's failure message identifies which AC tripped, which means each diagnosis is bounded:
 
@@ -186,14 +187,14 @@ For each AC that fails, file a sub-issue with the exact failure mode. The scenar
 - `t2.text === t1.text` → card not being re-edited → look at heartbeat + subagent-watcher
 - Final `waitForCardPhase("done")` timeout → defer-gate never released → look at terminal-state propagation
 
-### Phase 3 — heavy-fleet + stuck scenarios
+### Phase 3: heavy-fleet + stuck scenarios
 
 Once AC-1/2/3 are green, add:
 
-- `bg-heavy-fleet-dm.test.ts` (AC-5) — prompt spawns 6+ parallel sub-agents, scrape rendered HTML, assert balanced tags + size cap + "N more" footer.
-- `bg-stuck-detection-dm.test.ts` (AC-4) — prompt spawns a sub-agent that does one tool call then sleeps > 60 s. Assert row glyph flips to ⚠ within 90 s.
+- `bg-heavy-fleet-dm.test.ts` (AC-5): prompt spawns 6+ parallel sub-agents, scrape rendered HTML, assert balanced tags + size cap + "N more" footer.
+- `bg-stuck-detection-dm.test.ts` (AC-4): prompt spawns a sub-agent that does one tool call then sleeps > 60 s. Assert row glyph flips to ⚠ within 90 s.
 
-### Phase 4 — close stale issues
+### Phase 4: close stale issues
 
 When each AC has a green scenario locked in:
 - #709, #776, #782, #788 close as "verified by `bg-sub-agent-dispatch-dm.test.ts` covering AC-1/2/3" + the linked test.
@@ -210,7 +211,7 @@ The scenarios need a DM prompt that reliably gets `test-harness` to call the `Ag
    Reply briefly that you've dispatched the worker.
    ```
    Pros: deterministic, sub-agent emits 3 visible tool calls over ~10 s.
-   Cons: prompt is meta — agent is being told to use a specific tool.
+   Cons: prompt is meta, the agent is being told to use a specific tool.
 
 2. **Naturalistic task that should obviously delegate.**
    ```
@@ -234,16 +235,16 @@ The cleaner shape is the new phase. `detectPhase` in `assertions.ts` would gain 
 
 ## Risks + open questions
 
-- **Test-harness model nondeterminism.** Even option 1 of the dispatch prompt depends on the LLM following instructions. Mitigation: the prompt is direct enough that model failure (no dispatch at all) shows up as `expectMessage(/dispatch.../) timeout` — clearly distinguishable from infra failure (`expectPinnedCard` timeout, fleet not updating, etc).
+- **Test-harness model nondeterminism.** Even option 1 of the dispatch prompt depends on the LLM following instructions. Mitigation: the prompt is direct enough that model failure (no dispatch at all) shows up as `expectMessage(/dispatch.../) timeout`, clearly distinguishable from infra failure (`expectPinnedCard` timeout, fleet not updating, etc).
 - **Concurrent sub-agent JSONL paths.** When Claude Code spawns a background `Agent`, *where* does its JSONL land? Need to verify `subagent-watcher` polls the right directory. This is a known-but-unverified contract; the scenario surfaces it as a side-effect.
 - **Heartbeat cadence vs UAT poll cadence.** `expectPinnedCard` polls pin updates at the driver's MTProto cadence; the heartbeat flushes at e.g. 5 s. A 15 s gap between snapshots is generous enough not to flake.
 - **No isolation between scenarios** until #866 Phase 2b. The bg-scenario could leak state into the next run. Mitigation: existing `spinUp` settle (8 s) + unpin path from #1031 handles this.
 
 ## What this RFC does NOT decide
 
-- Whether to extract bg-sub-agent rendering into a separate card (the alternative shape mentioned in #788's "per-agent cards" branches). The status-card v2 spec deliberately rejects that — same card, fleet zone — and there's no evidence yet that the shared-card design is the problem.
+- Whether to extract bg-sub-agent rendering into a separate card (the alternative shape mentioned in #788's "per-agent cards" branches). The status-card v2 spec deliberately rejects that (same card, fleet zone), and there's no evidence yet that the shared-card design is the problem.
 - Whether to add a Telegram-side "tap to see worker output" affordance. Nice-to-have; not in scope until AC-1..6 are green.
-- Whether to surface bg sub-agent activity in chat (e.g. as periodic "still working: X done so far" messages). The JTBD explicitly anti-patterns "narrating every tool call as a new chat message" — card-zone surface is correct.
+- Whether to surface bg sub-agent activity in chat (e.g. as periodic "still working: X done so far" messages). The JTBD explicitly anti-patterns "narrating every tool call as a new chat message". Card-zone surface is correct.
 
 ## Sequencing
 
@@ -263,7 +264,7 @@ Without the UAT scenarios as regression gates, the next refactor to `progress-ca
 
 ## Progress log
 
-### 2026-05-12 — Phase 3 wave: Bugs 1–5 shipped, Bugs 6–7 surfaced
+### 2026-05-12, Phase 3 wave: Bugs 1–5 shipped, Bugs 6–7 surfaced
 
 The TDD scenario from Phase 2 (`bg-sub-agent-dispatch-dm.test.ts`) ran end-to-end and exposed a cascade of issues:
 
@@ -289,9 +290,9 @@ subagent-watcher: backfill linked a2883d0da9533c3a6 → toolu_013CyQq3Dk6L3EWeop
 subagent-watcher: stall detected for a2883d0da9533c3a6 (idle 60s): sub-agent
 ```
 
-The watcher saw the bg worker's JSONL, backfilled the DB-row link (Bug 2's fix working), and then *stalled* it at 60 s of idle — NEVER fired `sub_agent_turn_end`. Subsequent log searches confirm no `sub_agent_turn_end` event was ever emitted for this agentId, despite the parent agent reporting "Worker finished" upstream.
+The watcher saw the bg worker's JSONL, backfilled the DB-row link (Bug 2's fix working), and then *stalled* it at 60 s of idle. It NEVER fired `sub_agent_turn_end`. Subsequent log searches confirm no `sub_agent_turn_end` event was ever emitted for this agentId, despite the parent agent reporting "Worker finished" upstream.
 
-The hypothesis: Claude Code's bg `Agent` dispatches write a JSONL that doesn't end with a `sub_agent_turn_end` line — the worker's last line is just the final `sub_agent_tool_result` (or analogous), then the file stops growing. The watcher's terminal-detection logic in `telegram-plugin/subagent-watcher.ts:498` only flips state to `'done'` when it sees an explicit `sub_agent_turn_end` event in the JSONL. With no such line, the worker is forever "running" from the gateway's view; only the 30-min `maxIdleMs` heartbeat ceiling eventually force-closes the card.
+The hypothesis: Claude Code's bg `Agent` dispatches write a JSONL that doesn't end with a `sub_agent_turn_end` line. The worker's last line is just the final `sub_agent_tool_result` (or analogous), then the file stops growing. The watcher's terminal-detection logic in `telegram-plugin/subagent-watcher.ts:498` only flips state to `'done'` when it sees an explicit `sub_agent_turn_end` event in the JSONL. With no such line, the worker is forever "running" from the gateway's view; only the 30-min `maxIdleMs` heartbeat ceiling eventually force-closes the card.
 
 Phase 6 fix candidates:
 
@@ -299,20 +300,20 @@ Note: the stall-terminal synthesis (Bug 6 option 1) was wired into `gateway.ts` 
 
 1. **Watcher infers `sub_agent_turn_end` from stall + JSONL-not-growing.** Simplest. After the stall escalation already fires at 60 s, add a follow-up timer (e.g. 30 s post-stall) that synthesises a `sub_agent_turn_end` event for the gateway. Risk: false-positive completion if Claude Code's bg dispatch was genuinely paused and not done.
 2. **Watcher reads the bg dispatch's terminal record from a sibling file** (e.g. `<agentId>.result.json` if Claude Code writes one). Need to verify the on-disk shape Claude Code uses for bg completion.
-3. **Have the parent agent's PostToolUse hook synthesise a `sub_agent_turn_end` event** when an `Agent` tool_use with `run_in_background:true` returns. Different shape; the `tool_result` *is* the dispatch confirmation, and the worker keeps running, so this is wrong — the parent doesn't know when the worker actually finished. Skip.
+3. **Have the parent agent's PostToolUse hook synthesise a `sub_agent_turn_end` event** when an `Agent` tool_use with `run_in_background:true` returns. Different shape; the `tool_result` *is* the dispatch confirmation, and the worker keeps running, so this is wrong. The parent doesn't know when the worker actually finished. Skip.
 
 Recommended: option 1 with a longer post-stall window (e.g. 5 min) so genuinely-paused workers aren't misreported. Tracker issue should reference this RFC section.
 
 ### Bug 7 diagnosis
 
-The driver-side `cs.backgroundParentToolUseIds.add(event.toolUseId)` at `progress-card-driver.ts:1833` fires during the `tool_use` event for `Agent(run_in_background:true)`. The check at `:1849` in the `sub_agent_started` case then reads `cs.backgroundParentToolUseIds.has(parentToolUseId)` — and returns FALSE despite the reducer having correctly correlated `parentToolUseId` via Bug 1+5's fixes.
+The driver-side `cs.backgroundParentToolUseIds.add(event.toolUseId)` at `progress-card-driver.ts:1833` fires during the `tool_use` event for `Agent(run_in_background:true)`. The check at `:1849` in the `sub_agent_started` case then reads `cs.backgroundParentToolUseIds.has(parentToolUseId)`, and returns FALSE despite the reducer having correctly correlated `parentToolUseId` via Bug 1+5's fixes.
 
-Reading the code paths carefully, the Set should retain entries — there's no `.clear()` or `.delete()`. Both events should route to the same `chatState` via `currentTurnKey`. But the empirical result is that the Set lookup misses. The leading hypotheses:
+Reading the code paths carefully, the Set should retain entries. There's no `.clear()` or `.delete()`. Both events should route to the same `chatState` via `currentTurnKey`. But the empirical result is that the Set lookup misses. The leading hypotheses:
 
 - The chatState containing the populated Set is being replaced by a fresh one between the tool_use and the late `sub_agent_started` events. Possibly via cross-turn carry-over (`#334`) or zombie-close + new enqueue.
-- `event.input.run_in_background` is a different shape (string vs boolean) than the strict `=== true` check expects — the reducer's matching check fires (log shows `bg=true`) but the driver's identical check might trip on a re-serialized event variant.
+- `event.input.run_in_background` is a different shape (string vs boolean) than the strict `=== true` check expects. The reducer's matching check fires (log shows `bg=true`) but the driver's identical check might trip on a re-serialized event variant.
 
-Phase 7 fix path: add temporary stderr diagnostic to `updateFleetForEvent` (the patch was prepared mid-session but the live hot-swap was blocked by the auto-mode classifier — operator can deploy it manually). Once the diagnostic prints what the Set contains at `sub_agent_started` time, the right fix should be obvious. Diagnostic patch lives at `git show diag/bg-fleet-flag` (branch was deleted post-session but the commit content is the literal stderr writes around `progress-card-driver.ts:1833` and `:1849`).
+Phase 7 fix path: add temporary stderr diagnostic to `updateFleetForEvent` (the patch was prepared mid-session but the live hot-swap was blocked by the auto-mode classifier; operator can deploy it manually). Once the diagnostic prints what the Set contains at `sub_agent_started` time, the right fix should be obvious. Diagnostic patch lives at `git show diag/bg-fleet-flag` (branch was deleted post-session but the commit content is the literal stderr writes around `progress-card-driver.ts:1833` and `:1849`).
 
 Alternative quick fix: derive `isBackgroundDispatch` from the *reducer's* state (e.g. read `pendingAgentSpawn.runInBackground` before the `sub_agent_started` reduce consumes it). That decouples the driver-side Set from the fleet flag entirely.
 
@@ -320,9 +321,9 @@ Alternative quick fix: derive `isBackgroundDispatch` from the *reducer's* state 
 
 Note: the progress-card-driver was deleted in PR #1122 PR3. The steps below are preserved as historical context but the Bug 6 / Bug 7 fix paths are moot. Cross-turn visibility is now handled by `pending-work-progress.ts` (#1445) and subagent-handback (#1720).
 
-1. ~~Reproduce: `bun test telegram-plugin/uat/scenarios/bg-sub-agent-dispatch-dm.test.ts` (after `sed -i 's/describe.skip(/describe(/' …` on the file). Verifies 5/6 still passing.~~ (Moot — scenario tests deleted card infrastructure, will fail immediately.)
-2. ~~Bug 6: read a recent bg worker's terminal JSONL; confirm no `sub_agent_turn_end` line is written. Implement option 1 (post-stall terminal synthesis).~~ (Moot — see Bug 6 note above.)
-3. ~~Bug 7: deploy the diagnostic stderr patch, capture one bg-dispatch run, read the trace. Pick fix based on what the Set actually contains. Most likely: derive bg-flag from `pendingAgentSpawn.runInBackground` so the driver doesn't need its own Set at all.~~ (Moot — `progress-card-driver` deleted.)
+1. ~~Reproduce: `bun test telegram-plugin/uat/scenarios/bg-sub-agent-dispatch-dm.test.ts` (after `sed -i 's/describe.skip(/describe(/' …` on the file). Verifies 5/6 still passing.~~ (Moot: scenario tests deleted card infrastructure, will fail immediately.)
+2. ~~Bug 6: read a recent bg worker's terminal JSONL; confirm no `sub_agent_turn_end` line is written. Implement option 1 (post-stall terminal synthesis).~~ (Moot: see Bug 6 note above.)
+3. ~~Bug 7: deploy the diagnostic stderr patch, capture one bg-dispatch run, read the trace. Pick fix based on what the Set actually contains. Most likely: derive bg-flag from `pendingAgentSpawn.runInBackground` so the driver doesn't need its own Set at all.~~ (Moot: `progress-card-driver` deleted.)
 4. ~~When AC-2-positive goes green: drop the `.skip` in the UAT scenario, close #709 / #776 / #782 / #788 with a link to the now-passing test.~~ (Moot.)
 
 TDD inverts that: red test → minimum diff to green → test locks the contract. The 2026-05-07 incident is the test we never wrote.

--- a/reference/rfcs/supergroup-easy-defaults.md
+++ b/reference/rfcs/supergroup-easy-defaults.md
@@ -1,6 +1,7 @@
 ---
-artefact: supergroup easy-mode defaults (zero-config "agent owns a working room")
-serves: jobs/talk-to-agents-from-anywhere.md
+artifact: supergroup easy-mode defaults (zero-config "agent owns a working room")
+serves: talk-to-agents-from-anywhere
+advances-outcome: always-available
 status: Phase 1 implemented
 ---
 
@@ -16,9 +17,9 @@ status: Phase 1 implemented
 ## 1. Summary
 
 Make the supergroup-owned topology **zero-config easy mode**: an operator
-points an agent at a Telegram supergroup and it Just Works — responds to
+points an agent at a Telegram supergroup and it Just Works: responds to
 every message, in every topic (including ones created later), with DMs
-still served — without hand-editing `access.json` or picking a default
+still served, without hand-editing `access.json` or picking a default
 topic.
 
 This came out of enabling marko in the "Panorama Marketing" group, which
@@ -46,7 +47,7 @@ blast radius.
 
 - **P1 "If they need the docs, we've failed":** Today the bot joins a group
   and **silently drops** every message (`group_unknown`) until the operator
-  reads docs + edits JSON — this is *verbatim* the ❌ example in
+  reads docs + edits JSON. This is *verbatim* the ❌ example in
   `principles.md`. Phase 1 fixes the silent-config-gap half (config drives
   registration). Phase 2 adds the in-Telegram "enable this group?" nudge so
   the silent-drop is gone end-to-end. **Pass (P1) after phase 2; phase 1 is
@@ -61,11 +62,11 @@ blast radius.
 
 ## 4. Design
 
-### Phase 1 (this PR) — the zero-config core
+### Phase 1 (this PR): the zero-config core
 1. **Config-driven group registration.** `reconcileConfiguredGroup`
    (scaffold) idempotently merges the agent's configured supergroup
    (`channels.telegram.chat_id`, which overrides the fleet
-   `telegram.forum_chat_id`) into `access.json` on every reconcile —
+   `telegram.forum_chat_id`) into `access.json` on every reconcile,
    strictly additive: only adds the group if absent, preserves
    `allowFrom` / pairings / other groups / operator policy overrides.
    This closes the `writeIfMissing` gap that made a post-scaffold
@@ -88,7 +89,7 @@ agents:
 
 ### Phase 2 (follow-up PRs)
 3. **CLI on-ramp:** `switchroom agent add --topology supergroup --chat-id <id>`
-   and `agent set-topology <name> supergroup` (convert an existing agent) —
+   and `agent set-topology <name> supergroup` (convert an existing agent):
    writes the stanza + reconciles, so no YAML editing at all.
 4. **Kill the silent drop (P1 completion):** when a bot is in a group it
    isn't enabled for, post a one-tap "enable this group for <agent>?"

--- a/reference/rfcs/supergroup-mode.md
+++ b/reference/rfcs/supergroup-mode.md
@@ -1,6 +1,7 @@
 ---
-artefact: per-agent Telegram supergroup mode
-serves: jobs/talk-to-agents-from-anywhere.md
+artifact: per-agent Telegram supergroup mode
+serves: talk-to-agents-from-anywhere
+advances-outcome: always-available
 status: Draft for ratification
 ---
 
@@ -19,11 +20,11 @@ forum topics, runs **multiple conversations in parallel across topics without
 cross-topic blocking**, and routes scheduled / automated outbounds into named
 topic lanes.
 
-## Why — and what the actual pain is
+## Why, and what the actual pain is
 
 The headline user pain is **parallel conversations**: talk to an agent in topic
 A while a long-running turn in topic B continues. Today the gateway gates
-inbound delivery on `activeTurnStartedAt.size > 0` — a **fleet-wide**
+inbound delivery on `activeTurnStartedAt.size > 0`, a **fleet-wide**
 check. If any topic has an active turn, every other topic's inbound is
 buffered until it ends. Two topics deadlock each other.
 
@@ -32,7 +33,7 @@ compact cards) interleaves with conversation in one topic. Carving lanes
 fixes the cosmetic complaint and, more importantly, makes the cron-can-target-
 a-topic case (morning digest → `#planning`) ergonomic.
 
-## What's already here — current topology
+## What's already here: current topology
 
 The original spec assumes klanker lives in a flat DM. It doesn't. The
 existing topology is:
@@ -41,7 +42,7 @@ existing topology is:
 - Each agent has `topic_name` + auto-assigned `topic_id`: its own topic in
   that shared supergroup. `topic-manager.ts` + `switchroom topics
   sync/list/cleanup` create and reconcile these.
-- `dm_only: true` (per-agent): escape hatch — own bot token, private chat.
+- `dm_only: true` (per-agent): escape hatch, own bot token, private chat.
 - `TELEGRAM_TOPIC_ID` env var filters inbound to a single topic per gateway
   instance (one gateway per agent).
 
@@ -52,7 +53,7 @@ per-its-own-supergroup is explicitly deferred.
 
 ## Schema delta
 
-No `mode:` enum. Mode is implied by config shape — additive, backward-compat.
+No `mode:` enum. Mode is implied by config shape, additive, backward-compat.
 
 ```yaml
 # Fleet-wide default supergroup (unchanged)
@@ -99,7 +100,7 @@ schedule:
 - The cascade (defaults → profile → agent) merges `topic_aliases` per-key;
   agent overrides win, defaults + profile fill in unset keys.
 
-## The structural refactor — what blocks parallel turns
+## The structural refactor: what blocks parallel turns
 
 Spec PR2 ("correctness fixes, ~2d") underestimates the surface. Trace below
 distinguishes **CRITICAL** (parallel turns impossible without it) from **HIGH**
@@ -118,9 +119,9 @@ distinguishes **CRITICAL** (parallel turns impossible without it) from **HIGH**
 | 9 | `lastPtyPreviewByChat`, `chatAvailableReactions` | `gateway.ts:1108,1156` | Shared dedup cache across topics; rare misfires. Composite-key. | LOW |
 | 10 | `chatKey()` primitive exists but `stream-reply-handler.ts:308` reinvents it inline | `chat-key.ts:44` | Adopt + delete the duplicate; consider tightening the brand. | LOW |
 
-Already-safe (composite-keyed today): `activeDraftStreams`, `activeStatusReactions`, `progressUpdateLastSent`, `pending-work-progress`, vault/permission state. Good — these are the pattern to extend.
+Already-safe (composite-keyed today): `activeDraftStreams`, `activeStatusReactions`, `progressUpdateLastSent`, `pending-work-progress`, vault/permission state. Good, these are the pattern to extend.
 
-## Outbound routing — by event class
+## Outbound routing: by event class
 
 The router decides which `message_thread_id` an autonomous (non-reply) outbound
 lands on. Per-agent topic_aliases give operator-friendly names; falls back to
@@ -149,7 +150,7 @@ notification, `admin` for action-required).
 | **Approval-button callbacks** (`apv:…`, `/approve` `/deny` `/pending`) | reply where the card was (callback-driven, no change) | — |
 
 Background/turn-initiated split requires the bridge to mark each outbound
-event with its origin class (a single enum field). Already partly there —
+event with its origin class (a single enum field). Already partly there:
 `pendingVaultRequestAccesses` knows whether it was opened from a turn handler
 or from a fire-and-forget scheduled task; just needs threading through to
 the card-sender.
@@ -157,24 +158,24 @@ the card-sender.
 Emitter callsites: `gateway/boot-card.ts` (3 sites), vault grant cards,
 hostd approval cards (already builds via approval-kernel), cron synthetic-
 inbound builder (`src/scheduler/dispatch.ts`), compact card
-(`gateway.ts:1639`). All already plumb `message_thread_id` conditionally —
+(`gateway.ts:1639`). All already plumb `message_thread_id` conditionally;
 the change is sourcing the value from `resolveOutboundTopic(agent, event,
 ctx)` instead of `null`.
 
-## General-topic Telegram quirk — wrapper
+## General-topic Telegram quirk: the wrapper
 
 Definitively answered (sources in research notes): General topic has `id=1`
 at MTProto, but the Bot API `sendMessage` **rejects** `message_thread_id: 1`
 with HTTP 400 "message thread not found." Inbound carries 1; outbound must
 omit. The strip-1 wrapper goes at the existing chokepoint
-(`chatLock.wrapBot` proxy in `chat-lock.ts:40-62`) — single layer, no
+(`chatLock.wrapBot` proxy in `chat-lock.ts:40-62`): single layer, no
 callsite changes. Apply to both `sendMessage` AND `sendChatAction` (spec said
-sendChatAction is exempt; that appears to be folklore — confirm with a 5-min
+sendChatAction is exempt; that appears to be folklore, confirm with a 5-min
 live test in UAT before locking). `editMessageText` doesn't take
-`message_thread_id` at all (inferred from `message_id`) — progress-card
+`message_thread_id` at all (inferred from `message_id`), so progress-card
 editing is unaffected.
 
-## Memory — topic-aware metadata, single bank (CPO call, ratified)
+## Memory: topic-aware metadata, single bank (CPO call, ratified)
 
 Hindsight memory stays **per-agent, one bank** (preserves the
 "one agent, one persona, one memory bank" principle from `reference/vision.md`).
@@ -186,7 +187,7 @@ the active topic into the recall preamble so the model can self-filter.
 - Pass them as fields in the `retain()` metadata bag:
   `metadata: { ..., chat_id, thread_id, topic_alias }` (topic_alias = the
   human-readable name from `topic_aliases`, if any).
-- No schema migration needed — Hindsight already accepts arbitrary metadata.
+- No schema migration needed; Hindsight already accepts arbitrary metadata.
 
 **Recall path** (`recall.py`):
 - Extract `chat_id` + `thread_id` from the prompt envelope (one regex
@@ -212,10 +213,10 @@ the bank principle, and creates a bank explosion (N topics × M agents).
 
 **Out of scope for v1:** UI for inspecting per-topic memory counts.
 `switchroom memory recall-log <agent>` will already show the topic in
-each recalled memory's metadata once tags are added — that's the inspection
+each recalled memory's metadata once tags are added. That's the inspection
 surface for now.
 
-## Two regressions to pull forward (CPO call, ratified — ship as standalone fleet PRs)
+## Two regressions to pull forward (CPO call, ratified; ship as standalone fleet PRs)
 
 Surfaced in research; both affect the **existing** shared-supergroup
 fleet, just less visibly. Ship as standalone PRs before / parallel to the
@@ -245,11 +246,11 @@ soak. Recommend skipping that and using a simpler model:
    Backward-compat: existing fleet agents keep working unchanged (no
    `channels.telegram.chat_id` set → fleet mode).
 2. Create klanker's new supergroup; populate topic_aliases.
-3. **Edit klanker's config in place** — flip from `topic_id` in the fleet
+3. **Edit klanker's config in place**: flip from `topic_id` in the fleet
    supergroup to `channels.telegram.chat_id` + `default_topic_id`. Run
    `switchroom apply` + `switchroom agent restart klanker --wait`.
-4. Hindsight memory bank is agent-scoped, not chat-scoped — survives. Vault
-   grants keyed by agent+key, not chat — survive. DM history is in
+4. Hindsight memory bank is agent-scoped, not chat-scoped, so it survives. Vault
+   grants keyed by agent+key, not chat, so they survive. DM history is in
    per-(chat,thread) SQLite; nothing is deleted on flip.
 5. **Rollback**: edit the config back, restart. The DM/fleet topic is
    never deleted; messages are preserved both sides.
@@ -307,13 +308,13 @@ sequence the supergroup work.
 | 7 | `switchroom telegram topics <chat_id>` discovery command (read SQLite buffer for distinct thread_ids) | ~0.5 day | Ergonomics; ship last |
 
 **Ship order:** PR0a + PR0b first (fleet wins, no dependency). PR1 + PR2 next
-(unblock the supergroup work + close more fleet bugs). PR3 is the gated work
-— UAT-heavy. PR4 + PR5 + PR6 + PR7 are surface polish; can ship in any order
+(unblock the supergroup work + close more fleet bugs). PR3 is the gated work,
+it is UAT-heavy. PR4 + PR5 + PR6 + PR7 are surface polish; can ship in any order
 after PR3.
 
 ## Out of scope (v1)
 
-- Multi-agent-per-supergroup (deferred — needs orchestrator routing layer)
+- Multi-agent-per-supergroup (deferred, needs orchestrator routing layer)
 - Per-topic system prompts / personas (violates "one agent, one persona")
 - Per-topic memory bank sharding (violates "one agent, one bank")
 - `forum_topic_created` / `_closed` / `_reopened` service-message handling
@@ -322,7 +323,7 @@ after PR3.
 
 ## Open questions still needing live verification
 
-- `sendChatAction` with `thread_id=1` for General — folklore says it works,
+- `sendChatAction` with `thread_id=1` for General: folklore says it works,
   research suggests strip-1 needed; **5-min UAT test before locking the
   wrapper**.
 - Behavior when the operator deletes a topic referenced in `topic_aliases`
@@ -342,7 +343,7 @@ Spec claims checked file-by-file at HEAD. Corrected:
 - `activeTurnStartedAt is global int` → it's a `Map<string, number>`
   composite-keyed; the bug is `.size > 0` being fleet-wide.
 - ScheduleEntrySchema topic field → confirmed absent today, needs adding.
-- `bot.api` wrapper exists (`chatLock.wrapBot`) — strip-1 layer slots in
+- `bot.api` wrapper exists (`chatLock.wrapBot`); strip-1 layer slots in
   there, not at 205 callsites.
-- AgentSchema has no `chat_id` today — `dm_only` is the existing per-agent
+- AgentSchema has no `chat_id` today; `dm_only` is the existing per-agent
   override; new `channels.telegram.chat_id` is the cleanest add.

--- a/reference/rfcs/turn-liveness-primitive.md
+++ b/reference/rfcs/turn-liveness-primitive.md
@@ -1,26 +1,25 @@
 ---
-artefact: Turn-liveness primitive — one role-keyed liveness/completion floor across every loop role
-serves: jobs/know-what-my-agent-is-doing.md
+artifact: Turn-liveness primitive — one role-keyed liveness/completion floor across every loop role
 backs: chat-is-the-single-source-of-truth
 status: design v1 — refines conversational-pacing.md's "Safety net" layer (does not replace the five-beat model)
 ---
 
-# Turn-liveness primitive — design contract
+# Turn-liveness primitive: design contract
 
 > Refines, does not replace, `reference/rfcs/conversational-pacing.md`.
 > The three-layer model (Ambient reaction / Conversational five-beat /
 > Safety net) stands. This RFC re-founds the **Safety-net layer** as a
 > single primitive keyed on **loop role** and hung off **CLI-native loop
 > boundaries**, so coverage is *by construction* instead of *by
-> enumeration* — and adds the missing **mid-turn text floor** the
+> enumeration*, and adds the missing **mid-turn text floor** the
 > 300s-only safety net never had.
 
 Closes the recurring failure in issue **#2527**: a user messages an
 agent, sees an ambient ack (👀 / typing), the agent works for minutes or
-ends the turn, and **no text ever arrives** — the ack reads as *done*.
+ends the turn, and **no text ever arrives**. The ack reads as *done*.
 Reproduced in both a DM and a forum supergroup, v0.15.56.
 
-## Why this kept happening — coverage by enumeration
+## Why this kept happening: coverage by enumeration
 
 The machinery already exists and is *mostly correct*. It keeps failing
 because liveness/completion is **enumerated per turn-type and per
@@ -30,7 +29,7 @@ surface** rather than derived from the loop. Verified evidence:
    *defers* its 300s fallback while `isLegitimatelyWorking(key)` is true
    (`silence-poke.ts:457`), on the rationale (`:434-438`) that *"the live
    activity feed renders that work."* But the activity feed only exists for
-   **background sub-agents** — a **foreground** turn doing 6 minutes of
+   **background sub-agents**. A **foreground** turn doing 6 minutes of
    silent `Bash`/`Read`/restart calls has no feed, so the user sees only
    the 👀. This is the documented #2527 evidence (the operator sent
    "Status?" twice into the silence).
@@ -42,20 +41,20 @@ surface** rather than derived from the loop. Verified evidence:
    (`buildSettingsHooksBlock`, `scaffold.ts:4246`, emits only `Stop`).
    Sub-agents, nested sub-agents, background/research workers (all
    `SubagentStop`) and crashes/limits (`StopFailure`) get **no** terminal
-   guarantee. *This is the literal whack-a-mole the operator described —
+   guarantee. *This is the literal whack-a-mole the operator described:
    "foreground works, then sub-agents don't, then research workers, then
    nested."*
 
 3. **The "done" emoji is painted unconditionally.** `gateway.ts:11459`
    `finalizeStatusReaction(chatId, threadId, 'done')` paints 👍 at every
    turn_end, *then* `:11510` handles the undelivered case. A user turn that
-   ended undelivered still shows 👍 — the operator's "thumbs up so it feels
+   ended undelivered still shows 👍, the operator's "thumbs up so it feels
    like you are done" report.
 
 4. **Surface forks.** `maybeEarlyAckReaction` hard-gates
    `chatType !== 'private'` (`gateway.ts:11966`): the instant ack is
    DM-only; supergroups get a different path. The fix for one surface never
-   covers the other — #2527 reproduced in both.
+   covers the other. #2527 reproduced in both.
 
 5. **The role question is answered by three different predicates.**
    "Is this turn intentionally/ system-silent?" is keyed on `chatId == null`
@@ -72,12 +71,12 @@ surface** rather than derived from the loop. Verified evidence:
 2. **One discriminator: the loop role.** Every turn is exactly one of
    `user` | `sub-agent` | `system` (cron/scheduled/wake). The role is
    stamped **once at enqueue** and read everywhere. No `chatType` branch, no
-   re-derivation. New *agent types* are not new roles — a research worker
+   re-derivation. New *agent types* are not new roles: a research worker
    and a nested sub-agent are both `sub-agent`.
 3. **Coverage by construction off CLI-native boundaries.** The primitive
    hangs off boundaries the `claude` CLI emits for *every* turn regardless
    of shape, so a turn type nobody has built yet is covered the day it
-   ships. The boundaries (from the hooks reference — cadences are *once per
+   ships. The boundaries (from the hooks reference, cadences are *once per
    session*, *once per turn*, and *every tool call in the loop*):
 
    | Need | CLI-native boundary | Fires for |
@@ -91,7 +90,7 @@ surface** rather than derived from the loop. Verified evidence:
 4. **Two-part invariant.** A turn that received a user inbound and set an
    ambient ack must (i) **surface mid-turn liveness** if it works silently
    past a short threshold, and (ii) **terminate with a visible artifact or
-   an explicit silent-marker** — never just an emoji.
+   an explicit silent-marker**, never just an emoji.
 5. **Emoji is liveness only, never a stand-in for an answer.** A user turn
    with real content always owes *text*. The only carve-out: a purely social
    turn ("thanks") may resolve on a terminal emoji alone.
@@ -100,12 +99,12 @@ surface** rather than derived from the loop. Verified evidence:
    redact → voice-scrub → markdown→HTML → chunk(4000) → outbound-dedup →
    `retryWithThreadFallback` pipeline as a model reply. A framework message
    can never be malformed, mis-escaped, double-sent, or mis-threaded.
-7. **Surface parity by construction.** The substantive guarantees — the
-   mid-turn floor and the role-aware terminal reaction — are keyed on
+7. **Surface parity by construction.** The substantive guarantees (the
+   mid-turn floor and the role-aware terminal reaction) are keyed on
    `statusKey(chatId, threadId)` + loop role (already thread-shaped, identical
    for a DM `threadId=null` and a forum topic), never on chat type. The fired
    floor beat routes to the originating thread. (The sub-second early-ack 👀
-   stays DM-only by design — see the consolidation table — because group
+   stays DM-only by design (see the consolidation table) because group
    pre-acking can react to a message the full gate would drop; the parity that
    matters rides the floor + terminal, proven by the fuzzed invariant's
    DM-vs-topic equivalence and the `-dm`/`-channel` UAT twins.)
@@ -118,7 +117,7 @@ surface** rather than derived from the loop. Verified evidence:
 | `sub-agent` | `SubagentStart`/sidechain | no (parent carries the user-facing beat) | completion **surfaces to the parent/feed** (✅/⚠️); never owes a direct Telegram reply |
 | `system` | enqueue `source` (cron/wake/handback) | no | **may stay silent**; speaks only if it called `reply`; opts out with `NO_REPLY` — never a scattered carve-out |
 
-## Mid-turn text floor — the primary #2527 fix
+## Mid-turn text floor: the primary #2527 fix
 
 A new pure decision unit (`turn-liveness-floor.ts`, mirroring
 `turn-flush-safety.ts`'s pure-function shape) drives one **code-owned,
@@ -128,7 +127,7 @@ edit-in-place** interim message when, for a `user` turn:
 - **zero substantive outbound** has landed in the thread so far
   (`finalAnswerDelivered` is the existing signal), AND
 - the turn is **legitimately working** (an in-flight tool / dispatched
-  sub-agent) — so we fire *because* it's busy-silent, not despite it. (This
+  sub-agent), so we fire *because* it's busy-silent, not despite it. (This
   is the exact inversion of the bug at `silence-poke.ts:457`, where busy =
   suppress.)
 
@@ -136,26 +135,26 @@ Properties:
 
 - **Honest, model-free, claude-native.** The text is built from the
   *longest in-flight tool label* / sub-agent task description the gateway
-  already snapshots (`silence-poke.ts:468-477`) — e.g. *"Still on it —
+  already snapshots (`silence-poke.ts:468-477`), e.g. *"Still on it,
   restarting the container (1m so far)."* No model call (no `claude -p`),
   no generic "working…".
 - **One beat, then back off.** Fires once, edits in place on later updates,
   **never re-notifies** (`disable_notification: true`). The existing 300s
   hard fallback remains the genuine-wedge unwedge above it.
 - **"Status?" short-circuit.** A user inbound *during* a silent working
-  stretch fires the floor immediately (the user is explicitly asking — the
+  stretch fires the floor immediately (the user is explicitly asking, the
   #2527 "Status?"×2 scenario).
 - **Kill-switch** `SWITCHROOM_TG_LIVENESS_FLOOR=0`; whole primitive behind
   the same flag, default-on with revert.
 
-## Terminal reaction honesty — the "thumbs-up" fix
+## Terminal reaction honesty: the "thumbs-up" fix
 
 `gateway.ts:11459` is gated on the **role + delivery**: a `user` turn ending
 with `finalAnswerDelivered === false` finalizes to a **non-`done`** terminal
 (it is a failure state, with the silent-end fallback text carrying the
 apology), so 👍 never reads over an undelivered answer. `system`/`sub-agent`
-turns and `NO_REPLY`/`HEARTBEAT_OK` turns finalize 👍 exactly as today —
-their silence is legitimate.
+turns and `NO_REPLY`/`HEARTBEAT_OK` turns finalize 👍 exactly as today.
+Their silence is legitimate.
 
 ## Consolidation plan
 
@@ -184,7 +183,7 @@ framework emits, and the **absorbed telemetry**.
 > the operator actually asked for:** user-facing liveness hangs off the
 > *main turn's* silence, and the main turn stays "legitimately working"
 > while **any** sub-agent (foreground / background / nested / research)
-> runs. So the user gets liveness for sub-agent shapes nobody enumerated —
+> runs. So the user gets liveness for sub-agent shapes nobody enumerated,
 > without any per-sub-agent wiring. New shapes are covered for free.
 
 **Staged (own canary, not blind in an autonomous pass):**
@@ -209,15 +208,15 @@ framework emits, and the **absorbed telemetry**.
   kill-switch.
 - *`isLegitimatelyWorking` is global, not per-key* (`gateway.ts:5267`). A
   multi-topic agent could defer/fire across topics. Accepted residual today;
-  flagged because the floor makes it user-visible — the floor keys its
+  flagged because the floor makes it user-visible: the floor keys its
   *emit* on the per-turn `statusKey`, only the work-signal is global.
 - *Framework-authored floor/fallback text* must carry `parse_mode`
-  consistently and not be voice-scrub/em-dash-mangled — it rides the one
+  consistently and not be voice-scrub/em-dash-mangled. It rides the one
   send path and is covered by the format tests.
-- *Reaction must always reach a terminal* on every turn_end branch — the
+- *Reaction must always reach a terminal* on every turn_end branch: the
   role-aware gate preserves "some terminal state on every exit."
 
-## Proof — fuzz the invariant, don't enumerate scenarios
+## Proof: fuzz the invariant, don't enumerate scenarios
 
 The anti-whack-a-mole proof is a **property/invariant test** over the
 turn-shape space, not a growing scenario list:
@@ -236,7 +235,7 @@ and at terminal.
 ## Verdict
 
 Done when the user always knows the agent heard them, can tell working from
-stuck, and never sees an ambient ack masquerade as a completed answer — in a
-DM and a supergroup topic alike — proven by a turn-shape-fuzzed invariant
+stuck, and never sees an ambient ack masquerade as a completed answer, in a
+DM and a supergroup topic alike, proven by a turn-shape-fuzzed invariant
 across all three loop roles, with the safety net hung off CLI-native loop
 boundaries so the next un-built agent type is covered for free.

--- a/reference/rfcs/user-concept.md
+++ b/reference/rfcs/user-concept.md
@@ -1,6 +1,5 @@
 ---
-artefact: First-class users — identity → profile → agent assignment
-serves: jobs/remember-across-sessions.md
+artifact: First-class users — identity → profile → agent assignment
 relates: jobs/feel-like-a-colleague.md, rfcs/per-speaker-memory-routing.md, rfcs/access-model.md
 backs: single-tenant
 status: proposal (2026-06-19) — design, not yet scheduled
@@ -8,7 +7,7 @@ status: proposal (2026-06-19) — design, not yet scheduled
 
 # First-class users
 
-A **user** is a trusted person the operator's fleet serves — identified by
+A **user** is a trusted person the operator's fleet serves, identified by
 their Telegram account, carrying their own memory profile. This RFC makes
 "user" a first-class config entity so the operator defines a person *once*
 and assigns them to agents, instead of hand-maintaining parallel
@@ -20,7 +19,7 @@ the [`single-tenant`](../invariants.md#single-tenant) invariant already
 states that multiple **trusted users within one tenant** are supported, and
 that agents should isolate memory per user. This RFC is how that's expressed.
 
-## Why — the problem
+## Why: the problem
 
 After per-speaker routing shipped, wiring a multi-user fleet means repeating
 the same person across three unrelated places, per agent:
@@ -29,7 +28,7 @@ the same person across three unrelated places, per agent:
 - `memory.recall.sender_banks` — whose profile to recall when they speak.
 - `memory.recall.additional_banks` — whose profile the agent always knows.
 
-These all key on the same thing — a person's Telegram identity — but the
+These all key on the same thing, a person's Telegram identity, but the
 operator keeps them in sync by hand, per agent. There is no entity that says
 "this is Lisa: here are her ids, here is her memory." That entity is the
 missing abstraction, and it's also the natural anchor for everything
@@ -62,11 +61,11 @@ users:
     profile_bank: lisa-profile
 ```
 
-A user has Telegram identities (one or more — username and/or numeric id,
+A user has Telegram identities (one or more, username and/or numeric id,
 since the gateway emits `from.username ?? String(from.id)`) and a
 `profile_bank` (their memory, authored via `switchroom memory profile`).
 
-### Agent assignment — `serves` and `knows`
+### Agent assignment: `serves` and `knows`
 
 ```yaml
 agents:
@@ -81,7 +80,7 @@ agents:
   it, and when one of them is speaking their profile is recalled.
 - **`knows: [<user-or-bank>…]`** — profiles the agent should always have as
   *subjects*, even if that person never talks to it. Accepts a user name
-  (resolves to their `profile_bank`) **or** a raw bank name — so non-users
+  (resolves to their `profile_bank`) **or** a raw bank name, so non-users
   like the kids (a `kids` profile bank with no Telegram identity) can be
   known without being modelled as users.
 
@@ -93,7 +92,7 @@ agents:
 | `serves[] → profile_bank` | `memory.recall.sender_banks` | speaker routing: the talking user's profile is prioritized |
 | `knows[] → bank` | `memory.recall.additional_banks` | subject knowledge: always-available, recall-ranked |
 
-The recall hook is unchanged — it already reads `sender_banks` and
+The recall hook is unchanged. It already reads `sender_banks` and
 `additional_banks` (shipped in #2441/#2442). This RFC is a **config + scaffold
 resolution layer only; no vendor-hook change.**
 
@@ -101,7 +100,7 @@ resolution layer only; no vendor-hook change.**
 
 The table above *is* the wiring you'd otherwise hand-maintain: `ziggy`=Lisa,
 `marko`/`lawgpt`=both, the rest Ken, and `clerk` additionally *knows* the
-family — so "what does Lisa want for dinner?" resolves there even though Ken
+family, so "what does Lisa want for dinner?" resolves there even though Ken
 is the one asking.
 
 ## Invariant & access-model compliance
@@ -115,7 +114,7 @@ is the one asking.
   remains **operator-authored**: it's derived from a `users:` block the
   operator writes, never from anything an agent or a sender can set at
   runtime. The sender→profile routing is **additive recall scoping, never an
-  authorization decision** — `serves` widening `allowFrom` is the operator
+  authorization decision**. `serves` widening `allowFrom` is the operator
   granting access by editing config, identical in trust to editing
   `allowFrom` directly today. An agent cannot add a user, widen its own
   `serves`, or self-grant.
@@ -123,25 +122,25 @@ is the one asking.
 ## Backward compatibility & precedence
 
 `access.allowFrom`, `memory.recall.sender_banks`, and
-`memory.recall.additional_banks` remain valid as direct, low-level config —
-`users:` is the higher layer that *generates* them. Precedence (decided —
+`memory.recall.additional_banks` remain valid as direct, low-level config.
+`users:` is the higher layer that *generates* them. Precedence (decided,
 see Open Question 1): `resolveUsers()` computes the generated values and
 **unions** any explicit per-agent `allowFrom` / `sender_banks` /
-`additional_banks` on top — additive, so an explicit value *extends* the
+`additional_banks` on top, additive, so an explicit value *extends* the
 generated set rather than replacing it.
 
 Crucially, this union is done **inside `resolveUsers()`**, not by leaning on
 the default config cascade. The `memory.recall` cascade
 (`src/config/merge.ts`) merges one level per-key and **replaces** an
 array/map value wholesale (an override's `additional_banks` array or
-`sender_banks` map replaces the base, it does not extend it) — so relying on
+`sender_banks` map replaces the base, it does not extend it), so relying on
 it would silently drop the generated wiring. `resolveUsers()` therefore
 produces the final unioned maps itself, before scaffold emits them. A fleet
 with no `users:` block generates empty maps and behaves exactly as today.
 
 ## Effort
 
-~PR1/PR2-sized — config + scaffold, no vendor change:
+~PR1/PR2-sized: config + scaffold, no vendor change:
 
 - Schema: top-level `users` block + agent `serves`/`knows` (with a
   validation that referenced users exist; `knows` accepts user-or-bank).
@@ -173,12 +172,12 @@ with no `users:` block generates empty maps and behaves exactly as today.
    compatibility above). One source of truth: removing a served user's access
    is a `serves` edit, not a subtractive override. Open sub-question: do we
    ever need a *subtractive* per-agent exclusion ("serves Lisa fleet-wide but
-   not on this agent")? Deferred — add an explicit `excludes:` only if a real
+   not on this agent")? Deferred; add an explicit `excludes:` only if a real
    need appears.
 2. **Served vs known overlap** — a `serves` user is speaker-routed; should
    they *also* be always-known (subject) on that agent? Recommend **no** by
    default (speaker routing already loads them when they talk; add them to
-   `knows` if you want them surfaced when *another* user asks about them) —
+   `knows` if you want them surfaced when *another* user asks about them);
    keeps the always-on recall arms minimal.
 3. **Kids / non-driver people** — modelled as `knows:` bank names (no user
    entity) for v1. Promote to users only if/when they get a Telegram account.

--- a/reference/rfcs/vault-approval-hard-boundary.md
+++ b/reference/rfcs/vault-approval-hard-boundary.md
@@ -1,5 +1,5 @@
 ---
-artefact: hard-boundary operator approvals (no agent self-elevation)
+artifact: hard-boundary operator approvals (no agent self-elevation)
 backs: no-self-escalation
 status: Draft for operator review
 ---
@@ -8,7 +8,7 @@ status: Draft for operator review
 
 - Status: **Draft for operator review**
 - Author: drafted 2026-06-02
-- Tracks: vision.md outcome 2 ("you hold the leash — it can't self-elevate
+- Tracks: vision.md outcome 2 ("you hold the leash, it can't self-elevate
   or route around you"); supersedes the audit-only framing of #833 / the
   approval-kernel `src/vault/approvals/MIGRATION.md` Phase 2 for the
   *enforcement* question.
@@ -32,15 +32,15 @@ mints via `mint_grant` on the broker's **per-agent socket**. The
 posture-attested path requires only: agent on `postureMintAgents`, telegram-id
 mode, agent-self-match. **No key-ACL, no proof an operator tapped.**
 
-Completing the approval-kernel "enforcing flip" (#833) — making the broker
-require a consumed kernel `approval_decision` — does **not** fix it. The
+Completing the approval-kernel "enforcing flip" (#833), making the broker
+require a consumed kernel `approval_decision`, does **not** fix it. The
 kernel's `approval_consume` / `approval_record` are themselves on the
 **per-agent socket** and verify only *"the nonce belongs to the calling
 agent"* (`src/vault/approvals/kernel-server.ts:414-483`). The code says so:
 
 > "Without this a compromised agent could self-consume + self-record an
 > allow_always decision … no operator ever approved (approval-integrity
-> bypass)." — kernel-server.ts:472
+> bypass)." (kernel-server.ts:472)
 
 That listener-ACL blocks **cross-agent** forgery only. An agent forging a
 decision for **its own** request still works: `claude` calls
@@ -57,7 +57,7 @@ have simply never been reconciled in code.
 ## 3. The crux
 
 The only authorization `claude` cannot manufacture is the operator's **real
-Telegram tap** — a `callback_query` Telegram delivers, signed by Telegram's
+Telegram tap**: a `callback_query` Telegram delivers, signed by Telegram's
 own infrastructure, to whoever holds the bot token's update stream. To make
 approvals hard, **that tap must be received and verified by a component
 outside the agent container**, and the broker must gate the mint on a
@@ -67,7 +67,7 @@ decision recorded only through that component.
 UID** in its own compose project, brokers privileged ops, and binds an
 **operator-only socket** (`~/.switchroom/hostd/operator/sock`, mode 0600)
 that no agent container can reach. But note the trap: hostd *also* binds
-per-agent sockets that `claude` shares — so "route through hostd" is only
+per-agent sockets that `claude` shares, so "route through hostd" is only
 hard if the **operator-tap verification itself** happens host-side, not via
 a per-agent dispatch hostd would have to trust.
 
@@ -76,7 +76,7 @@ a per-agent dispatch hostd would have to trust.
 ### 4.1 Recommended: host-side approval verification
 
 Introduce a host-side **approval verifier** (in the hostd process / compose
-project, operator UID — *not* in any agent container) that:
+project, operator UID, *not* in any agent container) that:
 
 1. **Holds the credential that receives approval taps.** Two sub-options:
    - **(A) Dedicated approval bot.** A second Telegram bot token, host-only,
@@ -86,12 +86,12 @@ project, operator UID — *not* in any agent container) that:
      chat; only the sensitive-approval card lives on the approval bot.
    - **(B) Host-side callback relay for the existing bot.** Move
      `callback_query` reception for `apv:`/`vg:` cards to the host verifier
-     (the gateway stops being the sole poller for those updates). Heavier —
-     splits one bot's update stream — and Telegram delivers a bot's updates
+     (the gateway stops being the sole poller for those updates). Heavier,
+     splits one bot's update stream, and Telegram delivers a bot's updates
      to a single poller/webhook, so this effectively means the *host* polls
      and forwards non-approval updates inward. Higher blast radius.
 
-   **Recommend (A)** — a dedicated, host-only approval bot keeps the
+   **Recommend (A)**: a dedicated, host-only approval bot keeps the
    unforgeable path small and additive, and never changes the agent bots.
 
 2. **Verifies the tap** (`from.id ∈ approvers`) host-side, where `claude`
@@ -99,10 +99,10 @@ project, operator UID — *not* in any agent container) that:
 
 3. **Records the kernel decision on the kernel's OPERATOR socket**
    (host-only). The kernel already distinguishes `isOperator` connections
-   (kernel-server.ts:188, 333) — extend the operator socket to accept
+   (kernel-server.ts:188, 333): extend the operator socket to accept
    `approval_record`/`approval_consume` for the verified decision (today the
-   operator socket is read-mostly; see `feedback_kernel_operator_socket_deny_by_default`
-   — this RFC deliberately revisits that for the host-verified path only).
+   operator socket is read-mostly; see `feedback_kernel_operator_socket_deny_by_default`,
+   which this RFC deliberately revisits for the host-verified path only).
 
 ### 4.2 Broker enforcement
 
@@ -117,7 +117,7 @@ passphrase-attested and operator-socket CLI paths are unchanged.
 
 ### 4.3 Why this is hard, not soft
 
-`claude` can still self-`consume`+`record` an `origin='agent'` decision — but
+`claude` can still self-`consume`+`record` an `origin='agent'` decision, but
 the broker won't mint on it. It cannot produce an `origin='operator'`
 decision because it cannot reach the operator socket and cannot make the
 host verifier act without a real Telegram tap it cannot generate.
@@ -156,7 +156,7 @@ generalize the `origin='operator'` gate to the apv: enforcing flip.
 1. **Approval-bot (4.1-A) vs host-side relay (4.1-B)?** A is smaller/additive
    and recommended; B avoids a second bot but splits the update stream.
 2. **Ship the Phase-1 interim key-ACL constraint now** (defense-in-depth,
-   honest framing) while Phase 2 is built — or wait for the hard boundary?
+   honest framing) while Phase 2 is built, or wait for the hard boundary?
 3. **Scope of Phase 2** — vault grants only first (recommended), or bundle
    the apv: MCP-approval generalization?
 
@@ -175,20 +175,20 @@ the gateway share **one uid in one container** (`compose.ts` allocates a single
 uid per agent; `start.sh.hbs` forks the gateway and `exec claude` as that uid).
 The broker authorizes by **socket bind-path**, not connecting uid, and the
 per-agent socket is chowned to that one uid. So B requires **either a separate
-per-agent gateway container OR running agent containers as root** (uid-drop) —
+per-agent gateway container OR running agent containers as root** (uid-drop),
 both re-architect the load-bearing co-located runtime (tmux / autoaccept /
 bridge; CLAUDE.md: "the tmux layer is load-bearing").
 
-**Invasiveness ranking of the hard options:** dedicated approval bot (lightest —
-additive, host-side, no runtime change) < host-relay (moderate — Telegram I/O
-host-side) < **uid-split gateway (heaviest — separate container / root)**. The
+**Invasiveness ranking of the hard options:** dedicated approval bot (lightest:
+additive, host-side, no runtime change) < host-relay (moderate: Telegram I/O
+host-side) < **uid-split gateway (heaviest: separate container / root)**. The
 "use existing auth, no bot" framing sounds lightest but, made unbypassable,
 lands on the most invasive change.
 
 **What ships / stands:**
 - **PR ① (#2070, merged):** `approval_decisions.origin` + flag-gated broker mint
   gate, **inert** (`SWITCHROOM_REQUIRE_OPERATOR_APPROVAL_MINT` default off).
-  Kept — it is the ready enforcement seam if the trust model changes or the
+  Kept. It is the ready enforcement seam if the trust model changes or the
   gateway is split out for other reasons (B then comes nearly free).
 - **No** host verifier, approval bot, or gateway uid-split built.
 - **Optional belt-and-suspenders (deferred):** the broker key-ACL constraint on

--- a/reference/rfcs/vault-broker-resilience.md
+++ b/reference/rfcs/vault-broker-resilience.md
@@ -1,6 +1,7 @@
 ---
-artefact: vault-broker resilience and default auto-unlock
-serves: jobs/survive-reboots-and-real-life.md
+artifact: vault-broker resilience and default auto-unlock
+serves: survive-reboots-and-real-life
+advances-outcome: always-available
 status: Draft v1
 ---
 
@@ -16,7 +17,7 @@ The vault-broker is the single decryptor that serves secrets (bot
 tokens, OAuth creds) to agent gateways over per-agent UDS sockets.
 The 2026-05-17 install-validation re-run surfaced a class of failure
 that breaks the product's defining **always-on** outcome
-(`reference/vision.md:88` — "Each agent is a long-running service.
+(`reference/vision.md:88`, "Each agent is a long-running service.
 They survive reboots, network drops…"):
 
 > A routine `switchroom apply` (e.g. adding an agent) recreates the
@@ -24,7 +25,7 @@ They survive reboots, network drops…"):
 > **locked**. Every agent gateway whose `bot_token` is a `vault:`
 > ref then crash-loops, the supervisor **permanently gives up after
 > 10 restarts in 60 s**, and that bot goes dark until a human
-> intervenes — with **no working operator unlock path in the docker
+> intervenes, with **no working operator unlock path in the docker
 > model**, while `docker compose ps` still reports the broker
 > "healthy" and `switchroom vault broker status` reports a *phantom
 > host daemon* as `unlocked:true`.
@@ -37,7 +38,7 @@ surface that tells the truth.
 
 ## 2. Problem (code-grounded)
 
-### 2.1 The docker-native auto-unlock mechanism already works — it is just never populated
+### 2.1 The docker-native auto-unlock mechanism already works, it is just never populated
 
 The broker derives a machine-bound AES key from host-mounted
 `/etc/machine-id` (HKDF-SHA256, `src/vault/auto-unlock.ts:60-190`)
@@ -46,7 +47,7 @@ and at boot calls `_tryAutoUnlockFromMachineBoundFile`
 `SWITCHROOM_VAULT_BROKER_AUTO_UNLOCK_PATH` (compose sets it to
 `/state/vault-auto-unlock`, `src/agents/compose.ts:858`). The
 "systemd-creds" wording in `vault broker enable-auto-unlock --help`
-is **vestigial/incorrect** — the implementation uses machine-id
+is **vestigial/incorrect**. The implementation uses machine-id
 crypto (`src/cli/vault-broker.ts:404-415` → `encryptCredential` →
 `writeAutoUnlockFile`), not systemd-creds (that path is a v0.6
 fallback never hit in docker, `server.ts:2531-2550`).
@@ -82,17 +83,17 @@ the skipped optional step.
 with a hard cap: **10 restarts in 60 s → log "giving up" → `return
 1`** (`:68-70`); the sidecar dies and the agent runs with no
 Telegram connectivity until the *container* is recreated. There is
-**no backoff and no retry-forever path** — a 1 s fixed sleep
+**no backoff and no retry-forever path**, just a 1 s fixed sleep
 (`:72`), then permanent death. A transient dependency outage (broker
 recreate, host reboot ordering, momentary lock) is therefore
 *terminal*. The only non-give-up branch is `EX_CONFIG=78`
-(`:58-60`), used for genuine 401/token-config errors (#1076) — that
+(`:58-60`), used for genuine 401/token-config errors (#1076). That
 quarantine is correct and must be preserved; the bug is that
 *transient* unavailability is treated the same as permanent
 misconfig.
 
 Agents that resolved their token *before* a broker recreate keep
-working on a held long-poll — which **masks** the failure until the
+working on a held long-poll, which **masks** the failure until the
 next restart. Nothing should depend on a held long-poll surviving.
 
 ### 2.3 #32: two competing brokers; the CLI reports a phantom
@@ -114,19 +115,19 @@ Net: on the VM, `switchroom vault broker status` reported
 started/unlocked) while the *container* broker logged "staying
 locked." **The CLI actively misreports the broker the agents
 actually use.** The fix is not "make host unlock also reach the
-container" (perpetuates two paths) — it is to collapse to one.
+container" (perpetuates two paths). It is to collapse to one.
 
 ### 2.4 Dishonest observability
 
 The broker healthcheck (`src/agents/compose.ts:800`) is
-bind-presence only (`ls /run/switchroom/broker/*/sock`) — a
+bind-presence only (`ls /run/switchroom/broker/*/sock`), a
 deliberate "we don't speak the app protocol here" choice
 (`:782-799`).
 Consequence: a **locked** broker reads **healthy**. `BrokerStatus`
-already carries `unlocked` (`src/vault/broker/protocol.ts:340-346`)
-— the readiness signal exists, the healthcheck just ignores it.
+already carries `unlocked` (`src/vault/broker/protocol.ts:340-346`).
+The readiness signal exists, the healthcheck just ignores it.
 Plus stale strings: the gateway error says `Run: switchroom vault
-unlock` (`src/telegram/materialize-bot-token.ts:161`) — that
+unlock` (`src/telegram/materialize-bot-token.ts:161`), and that
 command does not exist (real: `switchroom vault broker unlock`); and
 `vault broker unlock` printed "Timeout waiting for broker" on the VM
 *while it actually succeeded*.
@@ -143,13 +144,13 @@ command does not exist (real: `switchroom vault broker unlock`); and
 
 **Non-goals**
 - Changing the at-rest crypto (machine-id HKDF is sound; unchanged).
-- Removing interactive-passphrase unlock — it remains, as the
+- Removing interactive-passphrase unlock. It remains, as the
   opt-in higher-assurance mode.
 - Multi-host / HA broker. Single-tenant always-on box is the model.
 
 ## 4. Design
 
-### Phase 1 — Auto-unlock is the unattended default (root-cause fix)
+### Phase 1: Auto-unlock is the unattended default (root-cause fix)
 
 - `encryptCredential` / `vault broker enable-auto-unlock` gain a
   non-interactive path: when stdin is not a TTY, consume
@@ -171,11 +172,11 @@ command does not exist (real: `switchroom vault broker unlock`); and
   missing/empty/malformed, surface a single actionable error
   (don't silently leave a fleet that will brick on next recreate).
 
-### Phase 2 — Supervisor resilience (the always-on backbone)
+### Phase 2: Supervisor resilience (the always-on backbone)
 
 `profiles/_base/start.sh.hbs` supervisor: classify exits.
 - `EX_CONFIG=78` (401/token misconfig): keep the immediate
-  quarantine + marker (unchanged — genuinely permanent).
+  quarantine + marker (unchanged, genuinely permanent).
 - All other non-zero exits (incl. the "vault locked" class):
   **exponential backoff (cap ~60 s) and retry indefinitely**, with
   the attempt count + next-delay surfaced to the supervisor log and
@@ -184,10 +185,10 @@ command does not exist (real: `switchroom vault broker unlock`); and
 - The gateway's "vault locked" exit becomes explicitly a *transient*
   class (it self-resolves when the broker unlocks), so an agent
   whose broker comes back (auto-unlock or operator action) recovers
-  on its own within one backoff cycle — no container recreate, no
+  on its own within one backoff cycle. No container recreate, no
   human.
 
-### Phase 3 — Collapse the broker duality (#32)
+### Phase 3: Collapse the broker duality (#32)
 
 - `switchroom vault broker {status,unlock,lock,start,stop}`
   runtime-detect docker mode (same detection used elsewhere:
@@ -205,7 +206,7 @@ command does not exist (real: `switchroom vault broker unlock`); and
   window; a single resolver decides target by runtime so the
   operator types the *same command* regardless.
 
-### Phase 4 — Honest observability
+### Phase 4: Honest observability
 
 - Broker healthcheck: probe the real readiness signal (`unlocked &&
   serving`) rather than socket bind-presence. Either an
@@ -238,12 +239,12 @@ Phase order is by leverage and independence:
    deprecation); do last, on its own, with the host-mode
    compatibility window explicit.
 
-Risks: (a) auto-unlock default is a security posture change —
+Risks: (a) auto-unlock default is a security posture change,
 mitigated by gating on explicit unattended signal + documenting the
 machine-bound threat model; (b) supervisor backoff must not mask a
-real permanent misconfig — mitigated by preserving the EX_CONFIG
+real permanent misconfig, mitigated by preserving the EX_CONFIG
 quarantine and surfacing attempt counts; (c) #32 collapse must not
-strand v0.6 installs — mitigated by runtime-detected routing with
+strand v0.6 installs, mitigated by runtime-detected routing with
 the legacy path intact for the deprecation window.
 
 ## 6. Definition of done
@@ -251,7 +252,7 @@ the legacy path intact for the deprecation window.
 Re-run the install-validation two-bot matrix on a fresh
 `--non-interactive` VM: add an agent via `switchroom apply` (which
 recreates the broker), do **nothing else**, and within one backoff
-cycle every bot — including the new one — is replying in Telegram.
+cycle every bot, including the new one, is replying in Telegram.
 `docker compose ps` shows the broker unhealthy iff it is actually
 locked. `switchroom vault broker status` reports the broker the
 agents use. No human typed a passphrase.

--- a/reference/rfcs/webhook-cloudflare-edge-lock.md
+++ b/reference/rfcs/webhook-cloudflare-edge-lock.md
@@ -1,5 +1,5 @@
 ---
-artefact: Cloudflare-only edge lock for webhook ingest
+artifact: Cloudflare-only edge lock for webhook ingest
 backs: no-self-escalation
 status: Draft v1
 ---
@@ -21,16 +21,16 @@ by any other path don't carry it and are rejected `403`.
 
 This is Phase 2 of the Docker-native webhook work (Phase 1:
 `webhook-via-gateway-socket.md`). It is **defence in depth**, stacking
-on the two controls already in place — not replacing either:
+on the two controls already in place, not replacing either:
 
 1. **GitHub-IP WAF allowlist** at the Cloudflare edge (network origin).
 2. **Per-agent HMAC** (`X-Hub-Signature-256`) at the receiver (body
-   provenance — proves a secret-holder produced the body).
+   provenance: proves a secret-holder produced the body).
 
 The gap this closes: the HMAC proves *who signed the body*, not *which
 network path the request took*. If anyone learns the tunnel origin, or a
 co-located service is coerced into an SSRF against `localhost:8080`, the
-HMAC is the only thing standing — and for a public-repo webhook the
+HMAC is the only thing standing, and for a public-repo webhook the
 "secret" is only as private as GitHub's storage. The edge header proves
 "this request entered through our Cloudflare edge", which nothing else
 on the request can.
@@ -41,7 +41,7 @@ The receiver (`switchroom-web`) listens on `127.0.0.1:8080` and is
 fronted by a cloudflared tunnel. Cloudflare's WAF only admits GitHub's
 published IP ranges. But the receiver itself cannot tell a request that
 came *through* Cloudflare from one that arrived at the tunnel origin
-some other way — both look like loopback once cloudflared forwards them.
+some other way. Both look like loopback once cloudflared forwards them.
 A header that only Cloudflare can inject (because only Cloudflare's
 Transform Rule holds the secret) lets the receiver assert the network
 path.
@@ -54,7 +54,7 @@ The owner's ask, verbatim: *"Can we make it only work for cloudflare??"*
 
 A single endpoint-global value at `~/.switchroom/webhook-edge-secret`
 (mode `0600`, one line, trailing whitespace trimmed on read). It guards
-the whole receiver, not a single agent — the per-agent grain is already
+the whole receiver, not a single agent. The per-agent grain is already
 the HMAC. The same value is configured as the injected header value in
 the Cloudflare Transform Rule.
 
@@ -93,7 +93,7 @@ loads the edge secret only when required, passing `requireEdge` +
 
 If `requireEdge` is true but `edgeSecret` is `null` (file missing /
 empty / unreadable), **every** request is rejected `403`. A
-misconfigured lock must never silently fall open — the failure mode of a
+misconfigured lock must never silently fall open. The failure mode of a
 security control is "deny", not "allow".
 
 ### 3.4 Cloudflare Transform Rule
@@ -106,7 +106,7 @@ Modification rule:
 - **Set static header**: `X-Switchroom-Edge` = `<the secret>`.
 
 Cloudflare strips/overwrites any client-supplied `X-Switchroom-Edge` so
-a forged value from outside cannot survive the edge — the rule *sets*
+a forged value from outside cannot survive the edge. The rule *sets*
 (not appends) the header. The secret lives only in the Transform Rule
 config and the local file; it never appears in repo, compose, or agent
 state.
@@ -127,7 +127,7 @@ state.
 1. Write `~/.switchroom/webhook-edge-secret` (random value, `0600`).
 2. Add the Cloudflare Transform Rule with the same value.
 3. Flip `reggie`'s `webhook_require_edge: true`; `apply` (no agent
-   restart needed — receiver-side flag), restart the receiver.
+   restart needed, receiver-side flag), restart the receiver.
 4. Verify: a signed POST *through* `hooks.switchroom.ai` → `202`; a
    signed POST direct to `127.0.0.1:8080` (no edge header) → `403`.
 5. Green → leave on reggie; widen per-agent as desired.

--- a/reference/rfcs/webhook-via-gateway-socket.md
+++ b/reference/rfcs/webhook-via-gateway-socket.md
@@ -1,5 +1,5 @@
 ---
-artefact: webhook ingest writes via the agent gateway socket
+artifact: webhook ingest writes via the agent gateway socket
 backs: no-self-escalation
 status: Draft v1
 ---
@@ -21,8 +21,8 @@ record to the agent's gateway via a new `webhook_ingest` IPC verb;
 the gateway, running as the agent's UID, performs the append.
 
 This restores the single-writer invariant the rest of the agent's
-`telegram/` directory already follows (every other file there —
-`history.db`, `registry.db`, `gateway.log`, `issues.jsonl` — is
+`telegram/` directory already follows (every other file there,
+`history.db`, `registry.db`, `gateway.log`, `issues.jsonl`, is
 written by the gateway and only the gateway). Webhook events became
 the lone exception when ingest moved host-side in #586, and that
 exception just bit us in production.
@@ -36,7 +36,7 @@ returning HTTP 500 for ~12 days, with the receiver silently dropping
 events. Root cause: `~/.switchroom/agents/reggie/telegram/webhook-
 events.jsonl` is mode `0o600`, owner UID `10014` (reggie's container
 UID, set when the file was first created by something running as that
-UID — likely the gateway or a host process during a different
+UID, likely the gateway or a host process during a different
 deployment topology). The host's web server now runs as a different
 UID. `appendFileSync` → EACCES → caught → `jsonReply(500, "write
 failed")` → GitHub treats the hook as broken and eventually disables
@@ -53,8 +53,8 @@ The proximate fix ("`rm webhook-events.jsonl`") works because the
 receiver recreates the file under its current UID. But that fix
 papers over the actual defect: **two processes with different UIDs
 share a private state file**. Any future change to either process's
-UID — a packaging change, a systemd unit edit, a docker user-
-namespace tweak, a `docker compose` re-up under a different account —
+UID (a packaging change, a systemd unit edit, a docker user-
+namespace tweak, a `docker compose` re-up under a different account)
 silently re-breaks ingest. The webhook surface is the *only*
 untrusted-inbound surface in switchroom; silently dropping events is
 the worst failure mode.
@@ -72,7 +72,7 @@ Adjacent defensive fixes considered and rejected:
   silently fails until the operator re-runs `usermod -aG`.
 - **Run the web server as root** (or as a shared "switchroom" user
   that's a member of every agent's group). Expands the privilege
-  envelope of the only untrusted-inbound process in the system —
+  envelope of the only untrusted-inbound process in the system,
   exactly backwards.
 - **Move webhook state to a web-server-owned directory** (e.g.
   `~/.switchroom/webhooks/<agent>/events.jsonl`). Drops cross-UID
@@ -133,7 +133,7 @@ IPC. Add a `webhook_ingest` handler that:
 2. Appends `JSON.stringify(record) + "\n"` to
    `telegram/webhook-events.jsonl`. Same content as today, same
    path, but now the writer is the gateway (UID match guaranteed).
-3. Triggers any matching `webhook_dispatch` rule — today this
+3. Triggers any matching `webhook_dispatch` rule. Today this
    logic lives in the web server (`src/web/webhook-dispatch.ts`)
    and spawns `claude -p` as a sibling of the web-server process.
    In the new model the gateway is the parent of the long-running
@@ -146,7 +146,7 @@ IPC. Add a `webhook_ingest` handler that:
    wait for it to finish. Web-server-side cooldown + dedup (kept
    in place per §4) prevents dispatch storms.
 4. Returns `{ ok: true, ts }` to the web server after the append
-   syscall returns (NOT after `fsync` — see §5). The web server
+   syscall returns (NOT after `fsync`, see §5). The web server
    then returns HTTP 202 to GitHub. Records are durable to the
    OS page cache, not to disk; that matches the prior on-host
    `appendFileSync` semantics exactly (no regression, no false
@@ -157,7 +157,7 @@ IPC. Add a `webhook_ingest` handler that:
 `src/web/webhook-handler.ts` keeps its job through the verify /
 dedup / rate-limit / render steps. The terminal `appendFileSync`
 block becomes a Unix-socket POST. Socket path is the well-known
-`~/.switchroom/agents/<agent>/telegram/gateway.sock` — same path
+`~/.switchroom/agents/<agent>/telegram/gateway.sock`, the same path
 the gateway binds, same path `mkdirSync(telegramDir, ...)` in the
 current handler already implies it knows. New failure modes:
 
@@ -181,7 +181,7 @@ gateway downtime warrants them:
    a web-server-owned `~/.switchroom/webhook-spool/<agent>/...`
    directory; gateway drains on next startup. Adds a second
    writer and a second state dir, but only as a degradation
-   path — not a steady-state second writer.
+   path, not a steady-state second writer.
 2. `switchroom doctor` proactively pings agent sockets and warns
    the operator when one is down for >N minutes.
 Neither is in scope here; called out so future readers don't
@@ -206,7 +206,7 @@ Three PRs:
    legacy `appendFileSync` path and the flag. Add a
    `switchroom doctor` check that flags any
    `webhook-events.jsonl` whose owner UID doesn't match the
-   gateway's expected UID — points to either a stale file
+   gateway's expected UID. Points to either a stale file
    (delete & let recreate) or a misconfigured deploy.
 
 A `switchroom doctor --fix` mode could repair stale files in
@@ -239,7 +239,7 @@ PR 3; out of scope for this RFC.
   `src/vault/broker/scope.test.ts`.
 - **One new hard-fail mode: gateway down.** Mapped to HTTP 503,
   which trades silent 500-then-disable for noisy retry-then-give-
-  up. Net improvement, but see §3.3 "Durability caveat" — long
+  up. Net improvement, but see §3.3 "Durability caveat": long
   agent outages can still lose events if the deferred spool
   mitigation isn't built.
 - **Webhook dispatch fans out from inside the gateway.** A
@@ -261,7 +261,7 @@ state dir). Each rejected with rationale.
   peercred allowlist. Re-read on SIGHUP so a web-server restart
   under a different user (e.g. systemd unit edit) is picked up
   without a gateway restart. **Not** derived from
-  `~/.switchroom/` ownership — that's a coincidence of typical
+  `~/.switchroom/` ownership; that's a coincidence of typical
   single-user installs and would silently fail closed for
   deployments where the web server runs as e.g. `www-data`,
   which is the exact failure mode this RFC is trying to remove.

--- a/reference/vision.md
+++ b/reference/vision.md
@@ -30,7 +30,7 @@ stays on your leash.
 
 The use case came from OpenClaw. Always-on assistants in a chat app,
 each with a personality and a job. Good idea. Three things stopped it
-being the one I needed, and nothing else fixed them:
+being the one I needed, and nothing else fixed them.
 
 - **On the subscription, properly.** The Claude plan I already pay for,
   the same OAuth as the desktop. Compliant. Predictable cost. Not an
@@ -58,7 +58,7 @@ functions to deliver them, and the jobs that ladder up to each live in
    the operator explicitly opts a specific account into overage (their own
    Anthropic-funded credits; default-off, auto-stops when the credit runs out).
    The claude-native invariant is unaffected: overage is still the unmodified
-   interactive `claude` CLI on the same OAuth subscription — never API/SDK.
+   interactive `claude` CLI on the same OAuth subscription, never API/SDK.
    An operator MAY also opt an agent into routing through their own metering
    gateway (self-hosted LiteLLM) for usage tracking + content-safety
    guardrails: still the unmodified CLI on the same OAuth, forwarded
@@ -66,8 +66,8 @@ functions to deliver them, and the jobs that ladder up to each live in
    [`invariants.md`](invariants.md).
 4. **Always available, in Telegram, done properly** — there when you want it.
 
-The hard constraints under these — claude-native, no-self-escalation,
-on-leash, single-tenant, telegram-only — are the lines we won't cross by
+The hard constraints under these (claude-native, no-self-escalation,
+on-leash, single-tenant, telegram-only) are the lines we won't cross by
 construction: [`invariants.md`](invariants.md).
 
 ---
@@ -102,20 +102,6 @@ hidden.
 
 ---
 
-## Voice and tone
-
-Plain, direct, opinionated. Reads like one person built it, because
-one did. Lead with what it feels like to have the team, not the
-machinery. Operator and trust details stay honest and present, never
-buried, never dressed up. No filler. No hype. No em dashes. Say what
-it deliberately doesn't do, no API key, no harness, no heartbeat, no
-second channel. The restraint is the point.
-
-Carries into every surface: CLI output, errors, the status the
-principal sees, the setup wizard.
-
----
-
 ## How vision becomes verdict
 
 The *why*. Three anchors and a product layer turn it into a verdict on a
@@ -130,6 +116,6 @@ specific PR or design:
   frontmatter) each `serves:` one outcome.
 
 A change lands when it (a) advances one of the four outcomes, (b) satisfies
-its job spec — proven by its outcome UAT, (c) passes all three principle
+its job spec (proven by its outcome UAT), (c) passes all three principle
 checks, and (d) crosses no invariant. Anything else is out of scope, however
 clever.


### PR DESCRIPTION
Reconciles the switchroom reference corpus with the ProductOS method and rewrites it in Ken's voice across all 64 docs (anchors, 21 jobs, 43 RFCs, product-spec).

## What's in here

**Content / method alignment**
- **product-spec:** North Star (Trusted Unsupervised Turn Rate), framed around *unsupervised / trusted / observable / steerable*; 21 per-job Signal metrics finalized.
- **jobs:** Production-readiness sections added where non-functional stakes were already implicit.
- **anchors/principles/invariants:** method patterns folded back (non-scope table, invariant carve-outs, trust-and-safety bar as hard binary lines).
- **RFC frontmatter:** dual-class RFCs resolved to one primary class; `serves:` slugs normalized; `advances-outcome` filled deterministically from the canonical job→outcome mapping.

**Voice pass**
- Prose em-dashes flattened to commas / periods / parentheses. Structural dashes kept (bullet-term leads, `*Invariant:* slug` leads, phase labels, issue tags, table cells, ranges).
- AI tells stripped; comma-chained run-ons broken into short sentences.

## Notes
- Docs-only: every change is under `reference/` plus the repo `CLAUDE.md`.
- `CLAUDE.md` deliberately left out of the voice pass (engineering/ops contract, structural-dash-heavy) — content updates only.
- The ProductOS side of this work is already shipped to `mekenthompson/ProductOS` and live on the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)