### PR TITLE
feat(hermes): token-compat auth + web rollout docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -744,11 +744,19 @@ section.)
 `feedback_npm_publish_landmines`: past releases shipped without
 `dist/cli/switchroom.js`).
 
+The committed `package.json` version is a stale placeholder (see step 2).
+`npm pack` names the tarball from that stale version, so you get
+`switchroom-0.16.21.tgz` even on a v0.16.22 release. **Bump `package.json`
+temporarily before packing — do NOT commit the bump:**
+
 ```
 node scripts/build.mjs                          # rebuild — reset --hard wipes dist
-npm pack                                        # produces switchroom-X.Y.Z.tgz
+node -e "const p=require('./package.json'); p.version='X.Y.Z'; \
+  require('fs').writeFileSync('./package.json', JSON.stringify(p,null,2)+'\n')"
+npm pack                                        # now produces switchroom-X.Y.Z.tgz
 tar tzf switchroom-X.Y.Z.tgz | grep -E "dist/cli/switchroom.js|vendor/hindsight" | head -5
 npm publish --ignore-scripts switchroom-X.Y.Z.tgz
+# Leave package.json bumped in the worktree (it's throwaway); don't commit it
 ```
 
 `--ignore-scripts` skips `prepublishOnly` so the verified tarball is
@@ -765,6 +773,26 @@ switchroom --version    # confirm X.Y.Z
 --workflow=docker-images --limit 2`, ~5 min). All 5 images (agent,
 broker, auth-broker, kernel, hindsight) must be pull-able under the
 new tag.
+
+**8a. Update the web container** — `switchroom update` and per-agent
+`agent restart` only touch agent/broker/kernel images. The
+`switchroom-web` container is a **separate compose project**
+(`~/.switchroom/web/docker-compose.yml`) and must be updated manually:
+
+```
+docker pull ghcr.io/switchroom/switchroom-web:vX.Y.Z
+sed -i 's|switchroom-web:vOLD|switchroom-web:vX.Y.Z|g' ~/.switchroom/web/docker-compose.yml
+docker compose -p switchroom-web -f ~/.switchroom/web/docker-compose.yml up -d
+docker exec switchroom-web switchroom --version   # confirm X.Y.Z
+```
+
+The auth token for the web API lives at `~/.switchroom/web-token` (plain
+text, auto-generated on first start). Use it to smoke-test endpoints:
+
+```
+TOKEN=$(cat ~/.switchroom/web-token)
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8080/api/sessions | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d['sessions']), 'sessions')"
+```
 
 **9. Canary on test-harness BEFORE fleet rollout** — mandatory gate.
 See **Pre-rollout UAT** below.

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -285,6 +285,13 @@ function extractBearerToken(req: Request): string | null {
     const idx = parts.indexOf("bearer");
     if (idx >= 0 && idx + 1 < parts.length) return parts[idx + 1];
   }
+  // Hermes Desktop sends token as ?token= query param on WS upgrade and
+  // X-Hermes-Session-Token header on REST calls.
+  const url = new URL(req.url);
+  const queryToken = url.searchParams.get("token");
+  if (queryToken) return queryToken;
+  const hermesHeader = req.headers.get("X-Hermes-Session-Token");
+  if (hermesHeader) return hermesHeader;
   return null;
 }
 

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -42,6 +42,7 @@ vi.mock("../src/vault/approvals/client.js", () => ({
 // Mock child_process
 vi.mock("node:child_process", () => ({
   execSync: vi.fn(),
+  execFile: vi.fn(),
   execFileSync: vi.fn(),
   spawnSync: vi.fn(),
   spawn: vi.fn(),


### PR DESCRIPTION
## Summary

- **`fix(web): accept ?token= and X-Hermes-Session-Token for auth`** — Hermes Desktop sends auth as a query-param (`?token=`) and a custom header (`X-Hermes-Session-Token`). Previously only `Authorization: Bearer` was accepted, causing all WS connections to fail with 401. Now accepts all three forms.
- **`docs(claude): web container rollout step + npm pack version bump procedure`** — CLAUDE.md additions: step 8a (update switchroom-web container on release) and the npm pack / temporary version-bump recipe that was missing from the release process.
- **`test(web): mock execFile in node:child_process`** — adds the missing mock to prevent test failures when web.test.ts imports paths that transitively call execFile.

## Why

The auth fix is required for Hermes Desktop v0.17 to connect at all. The CLAUDE.md and test changes are cleanup that came with the work.

## Test plan

- [ ] CI lint + vitest + bun-test pass
- [ ] Hermes Desktop connects and authenticates successfully over WS