### PR TITLE
ci(voice): add CUDA GPU build+push job for the voice STT sidecar

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -315,6 +315,77 @@ jobs:
           provenance: mode=max
           sbom: true
 
+  build-voice:
+    # Voice STT sidecar (PR-B2 follow-up). Like build-hindsight this is a
+    # standalone image: Dockerfile.voice FROMs `nvidia/cuda:…-cudnn-runtime`,
+    # NOT switchroom-base, so it has no base-job dependency and runs in
+    # parallel. It bakes no dist/ (pure-Python faster-whisper server), so
+    # there's no Node/Bun build step here.
+    #
+    # Subscription-honest local GPU STT (vision #3): transcribing inbound
+    # voice notes on the operator's own GPU, no third-party STT key, no
+    # cloud STT dependency (vision #4, always-available). The image only
+    # ships CUDA + cuDNN *runtime* libs + faster-whisper's prebuilt
+    # CTranslate2 kernels; model weights are NOT baked (fetched once into
+    # the voice-model-cache volume on first boot). See docker/Dockerfile.voice.
+    #
+    # amd64 ONLY — and deliberately so. faster-whisper rides CTranslate2's
+    # prebuilt CUDA kernels, which are published for x86_64 GPU hosts; there
+    # is no equivalently-supported aarch64 CUDA wheel, and the fleet's GPU
+    # hosts are amd64. Building an arm64 leg would emit an image that can't
+    # actually run GPU STT, so we don't (this is the one fleet image that
+    # is single-arch by design — every other image is amd64+arm64).
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      - name: Log in to GHCR (push only on main / tags)
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-voice"
+          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            TAG_VERSION="${GITHUB_REF#refs/tags/}"
+            echo "tags=${IMAGE}:${TAG_VERSION},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
+          elif [[ ( "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "workflow_dispatch" ) && "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "tags=${IMAGE}:latest,${IMAGE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tags=${IMAGE}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build (and push on main/tag) voice
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        with:
+          context: .
+          file: docker/Dockerfile.voice
+          # Single-arch: CUDA/CTranslate2 GPU runtime is x86_64-only (see
+          # job-level comment). No QEMU/arm64 leg on any event.
+          platforms: linux/amd64
+          tags: ${{ steps.tags.outputs.tags }}
+          push: ${{ github.event_name != 'pull_request' }}
+          # GHCR registry cache, not type=gha — #1965 (see build-base). The
+          # CUDA base + faster-whisper pip layer are heavy, so the registry
+          # cache materially shortens warm builds. cache-to gated to non-PR
+          # (fork PRs have no GHCR write token; an export failure would break
+          # the required build check).
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-voice:buildcache
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/switchroom-voice:buildcache,mode=max,image-manifest=true,oci-mediatypes=true', github.repository_owner) || '' }}
+          # sec WS9-F3 (#1418): provenance + SBOM on the voice image too.
+          provenance: mode=max
+          sbom: true
+
   # PR C: smoke test the freshly-pushed :sha-<7> agent image — runs the
   # MCP tools/list harness inside a throwaway container with the
   # channels.telegram.enabled:false fixture (no bot-token needed at
@@ -377,13 +448,13 @@ jobs:
     # a missing `:sha-<short>` at promote time provably means
     # "build succeeded but context unchanged → buildx cache hit, nothing
     # pushed", never "build failed".
-    needs: [smoke-test, build-hindsight]
+    needs: [smoke-test, build-hindsight, build-voice]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        image: [base, agent, broker, kernel, hostd, auth-broker, hindsight]
+        image: [base, agent, broker, kernel, hostd, auth-broker, hindsight, voice]
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -25,7 +25,7 @@ name: promote
 #      conflict), the job fails loudly so the promotion is treated as
 #      "did not happen" rather than "happened with a different image."
 #
-# Matrix fans out across all 7 fleet images. `fail-fast: true` so a
+# Matrix fans out across all 8 fleet images. `fail-fast: true` so a
 # single bad image stops the promotion mid-flight rather than leaving a
 # half-promoted channel.
 
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        image: [base, agent, broker, kernel, hostd, auth-broker, hindsight]
+        image: [base, agent, broker, kernel, hostd, auth-broker, hindsight, voice]
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0

--- a/tests/docker/ci-image-matrix.test.ts
+++ b/tests/docker/ci-image-matrix.test.ts
@@ -36,15 +36,11 @@ const DOCKER_MATRIX_OPT_OUT: Record<string, string> = {
   // built/consumed by the UAT CI workflow, not published as a per-version
   // fleet GHCR tag, so it is intentionally outside the docker-images matrix.
   "uat-runner": "CI-only sandboxed UAT host runner (#2236); not a published fleet image",
-  // voice is the GPU STT sidecar (voice PR-B2). It extends a CUDA runtime
-  // base (nvidia/cuda), NOT switchroom-base, so it does not fit the
-  // build-dependents matrix (which threads BASE_IMAGE), and it is emitted
-  // into the fleet compose ONLY on a `local` GPU verdict — most hosts never
-  // pull it. Its CI build/publish needs a dedicated amd64-only,
-  // CUDA-aware job (like build-hindsight's standalone shape) and lands in a
-  // follow-up; opted out here until then so the matrix gate forces that
-  // choice rather than silently shipping an unbuilt image.
-  voice: "GPU STT sidecar (PR-B2); CUDA base, local-verdict-only — dedicated CI build job is a follow-up",
+  // NOTE: `voice` (GPU STT sidecar, PR-B2) was previously opted out here
+  // pending a dedicated CI build job. That follow-up landed: docker-images.yml
+  // now has a standalone `build-voice` job (amd64-only, CUDA-aware, like
+  // build-hindsight's shape), so voice is covered by the matrix and the
+  // opt-out is gone. See the "voice is in the matrix" regression below.
 };
 
 function dockerfileNames(): string[] {
@@ -106,5 +102,13 @@ describe("CI image matrix coverage", () => {
 
   it("hindsight is in the matrix (regression — PR #1266 omitted it)", () => {
     expect(matrixNames().has("hindsight")).toBe(true);
+  });
+
+  it("voice is in the matrix (PR-B2 follow-up: dedicated build-voice job)", () => {
+    expect(matrixNames().has("voice")).toBe(true);
+  });
+
+  it("voice is no longer opted out (its CI build job has landed)", () => {
+    expect("voice" in DOCKER_MATRIX_OPT_OUT).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds the last-mile CI/CD for the voice STT sidecar landed in **PR-B2 (#2700)**: a dedicated `build-voice` job in `docker-images.yml` that builds and publishes `ghcr.io/<owner>/switchroom-voice` from `docker/Dockerfile.voice`.

Without it, the sidecar image is never published, so **voice-in cannot run live on a GPU host** even when the PR-B1 host-capabilities verdict is `local`.

## Why

- **Subscription-honest (vision #3):** STT runs on the operator's own GPU via `faster-whisper`/CTranslate2 — **no third-party STT key**, no cloud STT dependency (vision #4, always-available). Model weights are not baked; they fetch once into the `voice-model-cache` volume on first boot.
- This is the explicit follow-up the codebase was already waiting on: `tests/docker/ci-image-matrix.test.ts` carried a `voice` opt-out whose comment said *"dedicated CI build job is a follow-up"*. This PR is that follow-up, so the opt-out is removed.

## What changed

- **`.github/workflows/docker-images.yml`** — new standalone `build-voice` job.
  - **Standalone (not `build-dependents`):** `Dockerfile.voice` FROMs `nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04`, not `switchroom-base`, so it threads no `BASE_IMAGE` and has no base-job dependency — same shape as `build-hindsight` (runs in parallel). No `dist/` is baked, so there's no Node/Bun build step.
  - **amd64-only, by design:** `faster-whisper` rides CTranslate2's prebuilt CUDA kernels, published for x86_64 GPU hosts; there is no equivalently-supported aarch64 CUDA wheel and the fleet's GPU hosts are amd64. An arm64 leg would emit an image that can't run GPU STT. This is the one fleet image that is single-arch on purpose.
  - Mirrors the existing pattern: PR builds are build-only (no push); `main`/tag builds push `:latest` + `:sha-<7>` / `:<tag>`; GHCR registry buildcache (`#1965`); provenance + SBOM (`#1418`).
  - `promote-to-dev` gains `voice` in its matrix and `build-voice` in `needs` (so a missing `:sha` provably means a buildx cache-hit, never a build failure — same invariant as hindsight).
- **`.github/workflows/promote.yml`** — `voice` added to the channel-promotion matrix (8 images).
- **`tests/docker/ci-image-matrix.test.ts`** — drop the now-stale `voice` opt-out; add regressions asserting `voice` is in the matrix and no longer opted out.

## Test plan

- [x] `vitest run tests/docker/ci-image-matrix.test.ts` — 5 passed locally.
- [x] `tsc --noEmit` — exit 0.
- [x] YAML parse of both workflows — OK.
- [ ] CI: `build-voice` builds the CUDA image (build-only on PR, no push). New job — first run on this PR.

## Risk

- The CUDA base + `faster-whisper` pip layer is a heavy build; first PR build is a cold cache (registry buildcache warms on the first `main` build). No effect on other images' jobs (parallel, independent).
- `build-voice` is a **new** job and is **not** yet in the protected-branch required-checks ruleset (id `16470166`). Making it required is a ruleset edit the orchestrator should apply after merge if the voice image should gate `main`.

## Notes

Per instruction: **not** enabling auto-merge; leaving merge + rollout (and any ruleset/required-check change) to the orchestrator. No fleet agent rebuilt or restarted.