### PR TITLE
fix(voice): install requests for the STT sidecar model-load path (#2706)

### DIFF
--- a/docker/Dockerfile.voice
+++ b/docker/Dockerfile.voice
@@ -42,8 +42,21 @@ RUN apt-get update \
 
 # faster-whisper pulls in ctranslate2 (with bundled CUDA kernels). Pin so
 # the image is reproducible; Dependabot bumps it.
+#
+# `requests` is an UNDECLARED runtime dependency of faster-whisper 1.0.3:
+# faster_whisper/utils.py does `import requests` at module load (it catches
+# requests.exceptions.ConnectionError in its model-download retry path) but
+# omits it from requires_dist. Older huggingface_hub used to drag requests
+# in transitively, but huggingface_hub>=1.0 migrated off requests (httpx)
+# and no longer does — so on a clean image the model-load path dies with
+# `ModuleNotFoundError: No module named 'requests'` (bug #2706). Pin
+# `requests` explicitly. huggingface_hub is also pinned (0.25.2 still hard-
+# depends on requests) to keep the resolved download API stable; Dependabot
+# bumps all three.
 RUN pip3 install --no-cache-dir \
-        "faster-whisper==1.0.3"
+        "faster-whisper==1.0.3" \
+        "huggingface_hub==0.25.2" \
+        "requests==2.32.3"
 
 COPY docker/voice-sidecar/server.py /opt/voice-sidecar/server.py
 


### PR DESCRIPTION
## Problem

The voice STT sidecar image boots the server then dies at model load:

```
voice-sidecar: model load FAILED: ModuleNotFoundError: No module named 'requests'
```

so it never transcribes.

## Root cause

`faster-whisper==1.0.3` (the only pin in `docker/Dockerfile.voice`) has an **undeclared** runtime dependency on `requests`: `faster_whisper/utils.py` does `import requests` at module load (it catches `requests.exceptions.ConnectionError` in its model-download retry path) but omits `requests` from `requires_dist`.

Older `huggingface_hub` used to drag `requests` in transitively. `huggingface_hub>=1.0` migrated off `requests` (httpx), so on the clean `nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04` base nothing provides `requests` and the import fails.

## Fix

Add `requests` explicitly to the `pip3 install` line, and pin `huggingface_hub==0.25.2` (a line that still hard-depends on `requests`) to keep the resolved download API stable. Dependabot tracks all three.

```
-RUN pip3 install --no-cache-dir \
-        "faster-whisper==1.0.3"
+RUN pip3 install --no-cache-dir \
+        "faster-whisper==1.0.3" \
+        "huggingface_hub==0.25.2" \
+        "requests==2.32.3"
```

## Verification (local)

Built the image and exercised the previously-failing path:

- `docker build -f docker/Dockerfile.voice` → succeeds; resolves `requests-2.32.3`, `huggingface_hub-0.25.2`, `faster-whisper-1.0.3`.
- Import chain inside the image resolves cleanly:
  `python3 -c "import requests; from faster_whisper import WhisperModel; import faster_whisper.utils; from huggingface_hub import hf_hub_download"` → OK, no `ModuleNotFoundError`.
- Full model load on CPU end-to-end: `WhisperModel('tiny', device='cpu', compute_type='int8')` downloads from HF and instantiates → `MODEL LOADED OK on CPU`.

(faster-whisper runs on CPU, so the import/model-load fix is provable without a GPU. The `build-voice` CI job builds the actual CUDA image.)

## JTBD / vision

Serves the local-GPU voice STT feature (PR-B series): vision #3 (subscription-honest — no third-party STT key) and #4 (always-available — no cloud dependency). Pure dependency fix; crosses no invariant.

Fixes #2706

🤖 Generated with [Claude Code](https://claude.com/claude-code)