### PR TITLE
fix(voice): chown STT model-cache dir to runtime uid (completes bring-up after #2708)

### DIFF
--- a/docker/Dockerfile.voice
+++ b/docker/Dockerfile.voice
@@ -60,6 +60,14 @@ RUN pip3 install --no-cache-dir \
 
 COPY docker/voice-sidecar/server.py /opt/voice-sidecar/server.py
 
+# Pre-create the model-cache dir owned by the runtime uid BEFORE the VOLUME
+# instruction. Docker initializes a fresh named volume from the ownership of
+# the image directory at the mount point — if /models is left root:root, the
+# non-root runtime uid (65532) cannot write the first-boot model download and
+# faster-whisper dies with `PermissionError: [Errno 13] ... '/models/...'`
+# (bug #2707). Chowning it here makes the inherited volume ownership writable.
+RUN mkdir -p /models && chown -R 65532:65532 /models
+
 # Weights land in this volume on first boot; never baked into the image.
 VOLUME ["/models"]
 


### PR DESCRIPTION
## Summary

Fixes a second defect in the voice STT sidecar image. After #2708 fixed the
`ModuleNotFoundError: No module named 'requests'`, the rebuilt image reaches
model load but dies with:

```
voice-sidecar: model load FAILED: PermissionError: [Errno 13] Permission denied: '/models/models--Systran--faster-whisper-base'
```

**Root cause:** the sidecar runs as non-root uid `65532` (`USER 65532:65532`),
but `/models` was left `root:root`. Docker initializes a fresh named volume
(`voice-model-cache`, mounted at `/models`) from the ownership of the image
directory at the mount point, so uid 65532 cannot write the first-boot
faster-whisper model download → `PermissionError`.

**Fix:** pre-create `/models` and `chown` it to `65532:65532` **before** the
`VOLUME` instruction, with a comment explaining the named-volume ownership
inheritance. Minimal, consistent with the file's style.

This completes voice STT bring-up after #2708.

## End-to-end verification (local, CPU mode)

Built `docker/Dockerfile.voice` locally, ran it with a **named volume** at
`/models` (mirroring the real compose `-v voice-model-cache:/models`) and a
`VOICE_SIDECAR_TOKEN` set, `device=cpu` / `compute=int8`.

Image `/models` ownership after fix:
```
drwxr-xr-x 2 65532 65532 4096 /models
```

Model loaded with **no PermissionError** and reported healthy:
```
$ curl http://127.0.0.1:18126/healthz
{"ok": true, "status": "ready"}   # HTTP 200
voice-sidecar: model ready
```

Downloaded model dir inside the named volume (the exact path that previously
threw) is owned by the runtime uid:
```
drwxr-xr-x 5 65532 65532 /models/models--Systran--faster-whisper-base
```

Real transcription (audio = espeak-ng "The quick brown fox jumps over the lazy dog", 2.78s WAV):
```
$ curl -H "X-Voice-Token: <token>" -F "audio=@speech.wav" -F "language=en" http://127.0.0.1:18126/stt
{"ok": true, "text": "the quick round fox jump over the lazy dog.", "language": "en", "audioSeconds": 2.7846875, "durationMs": 932}   # HTTP 200
```

Auth gate still enforced (missing token → `HTTP 401`).

(Minor word errors in the transcript are expected from synthetic espeak audio on
the `base` model — the perms + transcription path is what's proven here.)

## JTBD / vision

Serves vision #3 (subscription-honest: local GPU STT, no third-party key) and
#4 (always-available: no cloud dependency) — same outcome as the original
PR-B2 voice work (#2700). Image-only change; no config-cascade or invariant
surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
