### PR TITLE
fix(voice): propagate host voice verdict to agents + fix sidecar healthcheck

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -595,8 +595,12 @@ function emitVoiceSidecarService(
   // /healthz returns 200 only once the model is loaded. start_period is
   // generous (model cold-load 30-90s) so reconcile/`up` doesn't flap.
   lines.push(`    healthcheck:`);
+  // Probe via python3, NOT curl: the sidecar image is distroless-ish and
+  // ships no curl, so a curl-based test stays `starting`/`unhealthy`
+  // forever. The sidecar runtime IS python3 (docker/voice-sidecar/server.py),
+  // so urllib from the stdlib is always present.
   lines.push(
-    `      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:${VOICE_SIDECAR_CONTAINER_PORT}/healthz >/dev/null || exit 1"]`,
+    `      test: ["CMD-SHELL", "python3 -c \\"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:${VOICE_SIDECAR_CONTAINER_PORT}/healthz',timeout=3).status==200 else 1)\\""]`,
   );
   lines.push(`      interval: 30s`);
   lines.push(`      timeout: 5s`);
@@ -1718,6 +1722,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
       bundledSkillsPoolDir,
       hostControlEnabled,
       opts.operatorUid,
+      voiceEngine,
     );
   }
 
@@ -1797,6 +1802,7 @@ function emitAgentService(
   bundledSkillsPoolDir: string,
   hostControlEnabled: boolean,
   operatorUid: number | undefined,
+  voiceEngine: VoiceEngine,
 ): void {
   lines.push(`  agent-${a.name}:`);
   emitImageOrBuild(lines, "agent", imageTag, buildMode, buildContext);
@@ -2148,6 +2154,17 @@ function emitAgentService(
     env.ANTHROPIC_BASE_URL = a.litellm.baseUrl;
     env.ANTHROPIC_SMALL_FAST_MODEL = a.litellm.smallFastModel;
   }
+  // SWITCHROOM_VOICE_ENGINE: the host's voice-transcription verdict
+  // (PR-B1 → PR-B2), resolved ONCE per generator call from
+  // host-capabilities.json and threaded down here. The gateway reads it
+  // as the FIRST source when picking the STT engine for a voice note —
+  // without this propagation the in-container gateway never sees the
+  // host verdict file (the constructed in-container `~/.switchroom` view
+  // doesn't carry it) and every agent defaults to `cloud`, so the local
+  // GPU sidecar is never called even on a GPU host. Emitted
+  // unconditionally with the resolved value (`local` or `cloud`) so the
+  // gateway honors it deterministically.
+  env.SWITCHROOM_VOICE_ENGINE = voiceEngine;
   // Merge operator-declared env vars from the agent's `env:` block.
   // System-managed keys (HOME, NPM_*, SWITCHROOM_*) win on collision —
   // an operator can't override the runtime contract from yaml. A

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -145,6 +145,7 @@ import { resolveAuthBrokerSocketPath } from '../../src/auth/broker/client.js'
 import { materializeVoiceKey } from '../../src/telegram/materialize-voice-key.js'
 import { materializeSidecarToken } from '../../src/telegram/materialize-sidecar-token.js'
 import { loadHostCapabilities } from '../../src/setup/host-capabilities.js'
+import type { VoiceEngine } from '../../src/setup/gpu-detect.js'
 import { createFleetFallbackGate } from '../fleet-fallback-gate.js'
 import { createFleetFallbackResumeGate } from '../fleet-fallback-resume.js'
 import { resolveExhaustUntil } from './exhaust-until.js'
@@ -22139,7 +22140,20 @@ bot.on('message:voice', async ctx => {
   // path needs no `provider === 'openai'` gate — it has no API key — so we
   // route to the sidecar whenever voice_in is enabled AND the host verdict
   // is `local`. The cloud path keeps its existing openai gate.
-  const voiceEngine = loadHostCapabilities()?.voice.engine ?? 'cloud'
+  // Source precedence: the compose-injected SWITCHROOM_VOICE_ENGINE env
+  // (set per-agent by compose-gen from the host verdict — PR-B3) wins,
+  // then the persisted host-capabilities file, then a fail-safe `cloud`.
+  // The env is load-bearing in-fleet: the in-container `~/.switchroom`
+  // is a read-only constructed view that does NOT carry the host's
+  // host-capabilities.json, so without the env the file lookup always
+  // misses and every agent silently falls back to `cloud`. Narrow the
+  // env value to the VoiceEngine union so a bogus value can't leak
+  // through — anything but 'local'/'cloud' is ignored and we fall back.
+  const envVoiceEngine = process.env.SWITCHROOM_VOICE_ENGINE
+  const voiceEngine: VoiceEngine =
+    envVoiceEngine === 'local' || envVoiceEngine === 'cloud'
+      ? envVoiceEngine
+      : loadHostCapabilities()?.voice.engine ?? 'cloud'
   const localEnabled = voiceIn?.enabled === true && voiceEngine === 'local'
   const cloudEnabled =
     voiceIn?.enabled === true && voiceEngine !== 'local' && voiceIn?.provider === 'openai'

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -3091,8 +3091,18 @@ describe("generateCompose — voice-sidecar (PR-B2)", () => {
     expect(out).toContain('capabilities: ["gpu"]');
     // Published on all interfaces (host-net + strict-isolation reachable).
     expect(out).toContain('"0.0.0.0:18900:8126"');
-    // Healthcheck on /healthz.
+    // Healthcheck on /healthz, probed via python3 stdlib — NOT curl. The
+    // sidecar image ships no curl, so a curl probe would stay unhealthy
+    // forever (PR-B3).
     expect(out).toContain("/healthz");
+    const sidecarBlock = out.slice(out.indexOf("voice-sidecar:"));
+    const healthLine = sidecarBlock
+      .split("\n")
+      .find((l) => l.includes("test: [") && l.includes("/healthz"));
+    expect(healthLine).toBeDefined();
+    expect(healthLine).not.toContain("curl");
+    expect(healthLine).toContain("python3");
+    expect(healthLine).toContain("urllib.request");
     // Token is a docker interpolation, NOT a literal secret in the YAML.
     expect(out).toContain("VOICE_SIDECAR_TOKEN: ${VOICE_SIDECAR_TOKEN}");
     // Model-cache named volume declared.
@@ -3108,6 +3118,40 @@ describe("generateCompose — voice-sidecar (PR-B2)", () => {
     expect(out).not.toContain("switchroom-voice-sidecar");
     expect(out).not.toContain("voice-model-cache");
     expect(out).not.toContain("VOICE_SIDECAR_TOKEN");
+  });
+
+  // PR-B3: the host voice verdict must reach EVERY agent container as the
+  // SWITCHROOM_VOICE_ENGINE env var. Without it the in-container gateway
+  // never sees the host verdict (the constructed in-container ~/.switchroom
+  // doesn't carry host-capabilities.json) and silently defaults to `cloud`,
+  // so the local GPU sidecar is never called even on a GPU host.
+  function envBlockFor(yml: string, agent: string): string {
+    const re = new RegExp(
+      `  agent-${agent}:[\\s\\S]*?    environment:([\\s\\S]*?)\\n    volumes:`,
+    );
+    return re.exec(yml)?.[1] ?? "";
+  }
+
+  it("propagates SWITCHROOM_VOICE_ENGINE=local to every agent on a local verdict", () => {
+    const out = generateCompose({
+      config: makeConfig({ alice: {}, bob: {} }),
+      voiceEngine: "local",
+    });
+    for (const a of ["alice", "bob"]) {
+      const env = envBlockFor(out, a);
+      expect(env).toContain('SWITCHROOM_VOICE_ENGINE: "local"');
+    }
+  });
+
+  it("propagates SWITCHROOM_VOICE_ENGINE=cloud to every agent on a cloud verdict", () => {
+    const out = generateCompose({
+      config: makeConfig({ alice: {}, bob: {} }),
+      voiceEngine: "cloud",
+    });
+    for (const a of ["alice", "bob"]) {
+      const env = envBlockFor(out, a);
+      expect(env).toContain('SWITCHROOM_VOICE_ENGINE: "cloud"');
+    }
   });
 
   it("defaults to NO sidecar when the verdict is unset (fail-safe cloud)", () => {


### PR DESCRIPTION
## Summary

The local GPU STT sidecar (PR-B2, #2700) is live and proven, but voice transcription never activates fleet-wide because of a propagation gap. This PR closes it (two small changes) and bundles the sidecar healthcheck fix.

## The gap

The telegram gateway decides the voice engine at message-handling time:

```ts
const voiceEngine = loadHostCapabilities()?.voice.engine ?? 'cloud'
```

`loadHostCapabilities()` reads `~/.switchroom/host-capabilities.json` **inside the agent container**. But compose-gen never mounts or copies the host's verdict file into agent containers, and the in-container `~/.switchroom` is a read-only constructed view that doesn't carry it. So every gateway sees no file, defaults to `cloud`, and never calls the local sidecar — even on a confirmed GPU host.

## The fix

1. **Propagate the verdict via env (core fix).** `src/agents/compose.ts` already resolves the host voice engine once per generator call (`voiceEngine: VoiceEngine`). Thread it into `emitAgentService` and emit `SWITCHROOM_VOICE_ENGINE` (`local`/`cloud`) on **every** agent service, unconditionally.

2. **Gateway honors the env first.** `telegram-plugin/gateway/gateway.ts` reads `SWITCHROOM_VOICE_ENGINE` as the FIRST source, falling back to the host-capabilities file then `cloud`. The env value is narrowed to the `VoiceEngine` union (`'local' | 'cloud'`) so a bogus value can't leak through — anything else is ignored and falls through.

3. **Healthcheck fix (bundled).** The voice-sidecar healthcheck used `curl`, but the sidecar image ships no curl, so the container stays `starting`/`unhealthy` forever. Replaced with a python3 stdlib (`urllib`) one-liner — python3 is the sidecar runtime. Port comes from the `VOICE_SIDECAR_CONTAINER_PORT` constant.

## Test plan

- [x] `tsc --noEmit` clean
- [x] New compose-generator tests: every agent service gets `SWITCHROOM_VOICE_ENGINE` with the resolved engine (local + cloud branches); sidecar healthcheck no longer references `curl` and uses `python3`/`urllib`.
- [x] `tests/docker/compose-generator.test.ts` green (one pre-existing host-state failure — `default containerNamePrefix preserves the production fleet label` — fails identically on clean `main` because this dev host has a real `local` host-capabilities verdict; CI runs clean. Unrelated to this PR.)
- [x] `scripts/check-bot-api-wrapping.sh` clean

## Risk

Low. The env is emitted unconditionally with a fail-safe default (`cloud`), the gateway narrows the value defensively, and the healthcheck change only affects a service emitted on `local` hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)