### PR TITLE
fix(pacing): decision-first, short, progressive-disclosure turn-ends (#2707)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -229,6 +229,29 @@ into your system prompt every session; this is the conversational summary.
   identifiers. Keep lines short; long unwrapped lines are hard to read on a
   phone.
 
+### Turn-ends — decision first, short by default
+
+The message that ends your turn is the one the user actually reads, on a
+phone. Optimise it for a thumb scroll, not a terminal dump:
+
+- **Lead with the single decision or answer.** First line = the one thing
+  the user has to know. Everything else is supporting detail, and most of it
+  can be cut.
+- **A routine turn-end is a few short lines**, not a multi-section status
+  report. If you are stacking three labelled sections or running past ~6
+  lines for an ordinary turn, you are dumping — trim to the decision.
+- **One idea per message.** When you genuinely touched separate topics, send
+  separate replies rather than piling sections into one bubble. A reply the
+  user has to re-read to find the one fact that matters has already failed.
+- **Progressive disclosure beats pre-emptive dumping.** Don't paste logs,
+  full file contents, or a section per thread by default. Give the headline
+  and offer "want the detail?" — let the user pull depth rather than pushing
+  it.
+- **Reserve the long, multi-section structured message for when the operator
+  explicitly asked to go deep** ("full breakdown", "walk me through it",
+  "show everything"). Then the structure earns its length. Absent that, short
+  wins.
+
 Every turn that answers a user message ends with a user-visible
 \`reply\` (or \`stream_reply\` done=true) — Telegram is all the user
 sees; your terminal output never reaches them.`;
@@ -4798,6 +4821,21 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
     'avoid is the reflexive praise that opens every reply and means ' +
     'nothing. When the user is wrong, say so directly; flattery is not ' +
     'help.\n\n' +
+    'TURN-END SHAPE: the human reads your turn-end on a phone. Build it ' +
+    'for a thumb, not a terminal. LEAD WITH THE ONE DECISION OR ANSWER ' +
+    'in the first line — the single thing the user has to know. A routine ' +
+    'turn-end is a FEW SHORT LINES, not a multi-section report; if you ' +
+    'find yourself writing more than ~6 lines or stacking labelled ' +
+    'sections, you are dumping, not answering. ONE IDEA PER MESSAGE: ' +
+    'split genuinely separate topics into separate replies rather than ' +
+    'piling sections into one bubble. Push detail BELOW the answer or ' +
+    'leave it out — offer "want the detail?" instead of pre-emptively ' +
+    'dumping logs, full file contents, or a section per thread you ' +
+    'touched. RESERVE the long multi-section structured message for when ' +
+    'the operator EXPLICITLY asked to go deep ("full breakdown", "walk me ' +
+    'through it", "show everything"). Default to short; expand on ' +
+    'request. A wall of text the user has to re-read to find the one fact ' +
+    'that matters is the failure this exists to prevent.\n\n' +
     'CRITICAL: "answer" means a call to the reply tool ' +
     '(mcp__switchroom-telegram__reply, or stream_reply with done=true). ' +
     'Your terminal/transcript text is NEVER delivered to Telegram — the ' +

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2637,6 +2637,40 @@ describe("scaffoldAgent with global defaults cascade", () => {
     expect(cmd).toMatch(/plain punctuation/);
   });
 
+  it("turn-pacing directive carries the decision-first turn-end shape (#2707)", () => {
+    // #2707: turn-end replies render as wall-of-text on mobile. The fix
+    // rides the per-turn directive so it reaches EVERY agent fresh each
+    // turn: lead with the one decision, keep routine turn-ends short, one
+    // idea per message, progressive disclosure (offer detail, don't dump),
+    // reserve long structured replies for explicit go-deep asks.
+    const agentConfig = makeAgentConfig({});
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "turnend-agent": agentConfig },
+    } as SwitchroomConfig;
+    const result = scaffoldAgent(
+      "turnend-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+      switchroomConfig,
+    );
+    const settings = JSON.parse(
+      readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+    );
+    const cmd = (settings.hooks.UserPromptSubmit as Array<{
+      hooks: Array<{ command: string }>;
+    }>)
+      .flatMap((g) => g.hooks)
+      .find((h) => h.command.includes("turn-pacing"))!.command;
+    expect(cmd).toMatch(/TURN-END SHAPE/);
+    expect(cmd).toMatch(/LEAD WITH THE ONE DECISION OR ANSWER/);
+    expect(cmd).toMatch(/ONE IDEA PER MESSAGE/);
+    expect(cmd).toMatch(/want the detail/);
+    expect(cmd).toMatch(/EXPLICITLY asked to go deep/);
+  });
+
   it("unions defaults.hooks with per-agent hooks", () => {
     const agentConfig = makeAgentConfig({
       hooks: {


### PR DESCRIPTION
Closes #2707.

## Problem
Agent turn-end Telegram replies routinely render as a dense **wall of text** that isn't built for a human reading on a phone — long, multi-section messages crammed into one bubble. Repeated operator feedback: "end of turn isn't built for humans." The user has to re-read to find the one decision that matters.

## Change
Strengthen the agent steer toward mobile-shaped turn-ends (approach 2 in the issue — the highest-leverage, lowest-risk fix). Two surfaces, both in `src/agents/scaffold.ts`:

1. **Per-turn `<turn-pacing>` directive** (reasserted adjacent to every user message via the `UserPromptSubmit` hook, so it reaches *every* agent fresh each turn): new **TURN-END SHAPE** block —
   - Lead with the one decision/answer in the first line.
   - Routine turn-end is a few short lines, not a multi-section report (~6-line soft ceiling).
   - One idea per message; split genuinely separate topics into separate replies.
   - Progressive disclosure: offer "want the detail?" instead of pre-emptively dumping logs/files/a-section-per-thread.
   - Reserve long structured messages for when the operator *explicitly* asked to go deep.
2. **Static `TELEGRAM_GUIDANCE` formatting section**: complementary "Turn-ends — decision first, short by default" subsection in the same voice, alongside the existing scannability guidance.

Plus a test asserting the turn-end-shape contract rides the per-turn directive (mirrors the existing grounding/voice contract test).

## Vision outcome + JTBD
- **Vision outcome:** Visibility (`reference/vision.md`) — the user can see what matters without effort.
- **JTBD:** `reference/jobs/know-what-my-agent-is-doing.md` (serves `hold-the-leash`). Its "good looks like" calls for "a trivial ask just gets the answer, no progress ceremony" and turn signal that's scannable; its "bad looks like" names the undifferentiated dump. A wall-of-text turn-end is exactly the scannability failure this job targets, at the terminal beat. Implementation home for this job's prompt is the pacing steer this PR edits.

## Principle checks
- **Docs test:** the steer is the documentation; it's concrete and testable (lead-with-decision, ~6-line ceiling, one-idea-per-message, progressive disclosure).
- **Defaults test:** default is now short/decision-first; long structured replies become opt-in on explicit operator request — the right default for a phone.
- **Consistency test:** matches the existing voice and structure of both the per-turn directive and the `TELEGRAM_GUIDANCE` formatting block; no new config field, no cascade change.

## Invariants
No breach. Stays `telegram-only` and `chat-is-the-single-source-of-truth` (it shapes the chat reply, doesn't move signal off-chat or add a parallel surface). Prompt-only steer; no escalation, no new tool.

## Tests / lint / build
- `npm run lint` (tsc --noEmit) ✅
- `npm run build` ✅
- New `#2707` test ✅; grounding/voice contract test ✅. One pre-existing `scaffold.test.ts` symlink-path assertion fails on this container (asserts a `/home/op` host path) — it fails identically on a clean `git stash` of my change, so it's environment-specific and unrelated; CI runs it in the canonical env.

## Deferred follow-ups (deliberate)
- **Approach 1** — a non-blocking length/density lint in the telegram-plugin that warns on an overly long routine turn-end. Skipped to keep this change tight and risk-free; the steer alone is a valid fix.
- **Approach 3** — the "summary + expand button" pattern. Not trivial; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)