### PR TITLE
feat(voice): wire voice OUTPUT (TTS) end-to-end (PR-C2)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -6365,6 +6365,13 @@ function buildAccessJson(
   if (tg?.voice_in) {
     access.voice_in = tg.voice_in;
   }
+  // PR-C2: project resolved voice_out (TTS) settings so the gateway can
+  // synthesize spoken replies without re-reading switchroom.yaml. Rides
+  // access.json like voice_in; the gateway gates the 'kokoro' engine on the
+  // compose-injected SWITCHROOM_VOICE_ENGINE verdict at send-time.
+  if (tg?.voice_out) {
+    access.voice_out = tg.voice_out;
+  }
   if (tg?.telegraph) {
     access.telegraph = tg.telegraph;
   }

--- a/src/config/merge.test.ts
+++ b/src/config/merge.test.ts
@@ -49,6 +49,52 @@ describe("mergeAgentConfig — release cascade", () => {
   });
 });
 
+describe("mergeAgentConfig — voice_out cascade (PR-C2)", () => {
+  it("cascades defaults.channels.telegram.voice_out to an agent with none", () => {
+    const defaults = {
+      channels: {
+        telegram: {
+          voice_out: { enabled: true, engine: "kokoro", reply_mode: "voice+text" },
+        },
+      },
+    } as unknown as AgentDefaults;
+    const agent = baseAgent();
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.channels?.telegram?.voice_out).toEqual({
+      enabled: true,
+      engine: "kokoro",
+      reply_mode: "voice+text",
+    });
+  });
+
+  it("agent voice_out overrides the fleet default (field-merge wins)", () => {
+    const defaults = {
+      channels: {
+        telegram: {
+          voice_out: { enabled: true, engine: "kokoro", reply_mode: "voice+text" },
+        },
+      },
+    } as unknown as AgentDefaults;
+    const agent = baseAgent({
+      channels: {
+        telegram: { voice_out: { enabled: true, reply_mode: "voice-only" } },
+      },
+    } as unknown as Partial<AgentConfig>);
+    const result = mergeAgentConfig(defaults, agent);
+    // Per-channel one-level merge: agent's voice_out replaces the field.
+    expect(result.channels?.telegram?.voice_out?.reply_mode).toBe("voice-only");
+    expect(result.channels?.telegram?.voice_out?.enabled).toBe(true);
+  });
+
+  it("leaves voice_out undefined when neither layer sets it", () => {
+    const result = mergeAgentConfig(
+      { channels: { telegram: {} } } as unknown as AgentDefaults,
+      baseAgent({ channels: { telegram: {} } } as unknown as Partial<AgentConfig>),
+    );
+    expect(result.channels?.telegram?.voice_out).toBeUndefined();
+  });
+});
+
 describe("mergeAgentConfig — memory.file cascade (fleet-default hindsight-native)", () => {
   it("an agent inherits defaults.memory.file:false when it sets no memory.file", () => {
     const defaults = { memory: { file: false } } as AgentDefaults;

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -44,6 +44,58 @@ describe("TelegramChannelSchema — supergroup smart defaults", () => {
   });
 });
 
+describe("TelegramChannelSchema — voice_out (PR-C2)", () => {
+  it("applies engine/reply_mode defaults when only enabled is set", () => {
+    const r = TelegramChannelSchema.parse({ voice_out: { enabled: true } });
+    expect(r?.voice_out?.enabled).toBe(true);
+    expect(r?.voice_out?.engine).toBe("kokoro");
+    expect(r?.voice_out?.reply_mode).toBe("voice+text");
+    // max_chars has no zod default (the gateway supplies 600 at use-time).
+    expect(r?.voice_out?.max_chars).toBeUndefined();
+  });
+
+  it("preserves explicit engine / voice / reply_mode / max_chars", () => {
+    const r = TelegramChannelSchema.parse({
+      voice_out: {
+        enabled: true,
+        engine: "openai",
+        voice: "alloy",
+        reply_mode: "voice-only",
+        max_chars: 400,
+        api_key: "vault:openai/api-key",
+      },
+    });
+    expect(r?.voice_out?.engine).toBe("openai");
+    expect(r?.voice_out?.voice).toBe("alloy");
+    expect(r?.voice_out?.reply_mode).toBe("voice-only");
+    expect(r?.voice_out?.max_chars).toBe(400);
+    expect(r?.voice_out?.api_key).toBe("vault:openai/api-key");
+  });
+
+  it("rejects an unknown engine", () => {
+    expect(() =>
+      TelegramChannelSchema.parse({ voice_out: { engine: "piper" } }),
+    ).toThrow();
+  });
+
+  it("rejects an unknown reply_mode", () => {
+    expect(() =>
+      TelegramChannelSchema.parse({ voice_out: { reply_mode: "text-only" } }),
+    ).toThrow();
+  });
+
+  it("rejects a non-positive max_chars", () => {
+    expect(() =>
+      TelegramChannelSchema.parse({ voice_out: { max_chars: 0 } }),
+    ).toThrow();
+  });
+
+  it("leaves voice_out undefined when omitted", () => {
+    const r = TelegramChannelSchema.parse({ chat_id: "-100123" });
+    expect(r?.voice_out).toBeUndefined();
+  });
+});
+
 describe("TelegramChannelSchema.linear_agent (#2298)", () => {
   it("parses a valid linear_agent block", () => {
     const r = TelegramChannelSchema.parse({

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -951,9 +951,13 @@ export const TelegramChannelSchema = z
             "exceeds max_chars — the user's answer is never dropped silently.",
           ),
         max_chars: z.number().int().positive().optional().describe(
-          "Reply length (chars) above which voice is skipped and a text-only " +
-          "reply is sent — even in 'voice-only' mode. Default 600. Keeps TTS " +
-          "latency/cost bounded and avoids reading out long structured replies.",
+          "Per-voice-note chunk size (chars). Default 600; clamped to the " +
+          "engine's hard cap (1200). A reply LONGER than this is NOT truncated " +
+          "to text — it's split on sentence/paragraph boundaries and spoken " +
+          "across several sequential voice notes, so the full answer is heard " +
+          "even when the user can't read the screen (driving / cycling). Lower " +
+          "it for snappier individual notes; raise it (up to 1200) for fewer, " +
+          "longer notes.",
         ),
         api_key: z.string().optional().describe(
           "OpenAI TTS API key as a `vault:<key>` reference (only used when " +

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -921,6 +921,59 @@ export const TelegramChannelSchema = z
         "Cascades from defaults.channels.telegram.voice_in. " +
         "(Migrated from per-agent root in #596 — see consistency unification.)"
       ),
+    voice_out: z
+      .object({
+        enabled: z.boolean().optional().describe("Master switch for spoken-reply (TTS) voice notes."),
+        engine: z
+          .enum(["kokoro", "openai"])
+          .default("kokoro")
+          .describe(
+            "Synthesis engine. 'kokoro' = local voice sidecar (POST /tts, " +
+            "subscription-honest, no third-party key); 'openai' = OpenAI TTS " +
+            "cloud (honest-exception, requires an `api_key` vault ref). " +
+            "'kokoro' is only active when the host voice verdict is local " +
+            "(SWITCHROOM_VOICE_ENGINE === 'local'); otherwise voice-out is a " +
+            "no-op and replies stay text-only.",
+          ),
+        voice: z.string().optional().describe(
+          "Engine-specific voice id (e.g. a Kokoro voice name or an OpenAI " +
+          "voice like 'alloy'). Optional — the sidecar/engine has its own " +
+          "default when omitted.",
+        ),
+        reply_mode: z
+          .enum(["voice+text", "voice-only"])
+          .default("voice+text")
+          .describe(
+            "How the spoken reply accompanies the text. 'voice+text' sends " +
+            "both the normal text reply and a voice note; 'voice-only' sends " +
+            "the voice note and suppresses the text body. In either mode the " +
+            "text reply is ALWAYS still sent when synthesis fails or the reply " +
+            "exceeds max_chars — the user's answer is never dropped silently.",
+          ),
+        max_chars: z.number().int().positive().optional().describe(
+          "Reply length (chars) above which voice is skipped and a text-only " +
+          "reply is sent — even in 'voice-only' mode. Default 600. Keeps TTS " +
+          "latency/cost bounded and avoids reading out long structured replies.",
+        ),
+        api_key: z.string().optional().describe(
+          "OpenAI TTS API key as a `vault:<key>` reference (only used when " +
+          "engine='openai'; default 'vault:openai/api-key'). Resolved through " +
+          "the vault broker at use-time and never written to disk or the agent " +
+          "prompt. Ignored for engine='kokoro' (the sidecar needs no key).",
+        ),
+      })
+      .optional()
+      .describe(
+        "Outbound spoken replies via TTS (PR-C2). When enabled, the gateway " +
+        "synthesizes the agent's text reply into an OGG/Opus voice note and " +
+        "sends it alongside (or instead of) the text, per reply_mode. The " +
+        "'kokoro' engine uses the local voice sidecar (POST /tts) and is only " +
+        "active when the host voice verdict is local; the 'openai' engine is " +
+        "an honest-exception cloud path gated on an `api_key` vault ref. Voice " +
+        "is best-effort and fully non-fatal — any TTS error falls back to the " +
+        "text reply. Off by default — opt-in per agent. " +
+        "Cascades from defaults.channels.telegram.voice_out."
+      ),
     telegraph: z
       .object({
         enabled: z.boolean().optional().describe("Master switch for Telegraph Instant View publishing."),

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -49,6 +49,9 @@ import {
 } from '../sticker-aliases.js'
 import { transcribeViaWhisper } from '../voice-transcribe.js'
 import { transcribeViaSidecar } from '../voice-transcribe-sidecar.js'
+import { synthesizeViaSidecar } from '../voice-synthesize-sidecar.js'
+import { synthesizeViaOpenAi } from '../voice-synthesize.js'
+import { stripMarkdown } from '../card-format.js'
 import {
   createTelegraphAccount,
   createTelegraphPage,
@@ -967,6 +970,24 @@ type Access = {
     language?: string
     api_key?: string
   }
+  /** Outbound spoken replies via TTS (PR-C2). When enabled, the agent's
+   *  text reply is synthesized into an OGG/Opus voice note and sent
+   *  alongside (or instead of) the text, per `reply_mode`. The 'kokoro'
+   *  engine uses the local voice sidecar (POST /tts) and is only active
+   *  when the host voice verdict is local (SWITCHROOM_VOICE_ENGINE ===
+   *  'local'); 'openai' is an honest-exception cloud path gated on an
+   *  `api_key` vault ref. Voice is best-effort and fully non-fatal — any
+   *  TTS error falls back to the text reply. Replies longer than
+   *  `max_chars` (default 600) always fall back to text-only. Off by
+   *  default. */
+  voice_out?: {
+    enabled?: boolean
+    engine?: 'kokoro' | 'openai'
+    voice?: string
+    reply_mode?: 'voice+text' | 'voice-only'
+    max_chars?: number
+    api_key?: string
+  }
   /** Telegraph long-reply publishing (#579). When enabled, replies
    *  above `threshold` chars publish to Telegraph and the agent's
    *  reply becomes a single message linking to the Telegraph URL
@@ -1059,6 +1080,7 @@ function readAccessFile(): Access {
       // `access.telegraph`, `access.stickers`) silently see undefined.
       stickers: parsed.stickers,
       voice_in: parsed.voice_in,
+      voice_out: parsed.voice_out,
       telegraph: parsed.telegraph,
     }
   } catch (err) {
@@ -8148,6 +8170,143 @@ function redactOutboundText(text: string, site: string): string {
   return masked
 }
 
+/** Default voice-out length ceiling: replies longer than this are sent
+ *  text-only (even in voice-only mode). Mirrors the schema default. */
+const VOICE_OUT_DEFAULT_MAX_CHARS = 600
+
+type VoiceOutAccess = NonNullable<Access['voice_out']>
+
+/**
+ * Resolve whether outbound TTS is active for this reply, and how
+ * (engine + reply_mode + the plain-text TTS input). PR-C2.
+ *
+ * Mirrors the voice-IN engine-resolution precedence (message:voice
+ * handler): the compose-injected SWITCHROOM_VOICE_ENGINE verdict gates the
+ * local 'kokoro' engine, exactly like the STT sidecar. The 'openai' engine
+ * is an honest-exception cloud path gated on an api_key vault ref — it does
+ * NOT require a local verdict.
+ *
+ * Returns null when voice-out is off / not applicable; otherwise a plan the
+ * caller acts on. `ttsText` is markdown-stripped plain text (Kokoro/OpenAI
+ * read it literally). `withinLimit` is false when the reply exceeds
+ * max_chars — the caller still synthesizes nothing and always sends text.
+ */
+function resolveVoiceOutPlan(
+  voiceOut: VoiceOutAccess | undefined,
+  replyText: string,
+): {
+  engine: 'kokoro' | 'openai'
+  voice?: string
+  apiKeyRef?: string
+  replyMode: 'voice+text' | 'voice-only'
+  ttsText: string
+  withinLimit: boolean
+} | null {
+  if (voiceOut?.enabled !== true) return null
+
+  const engine = voiceOut.engine ?? 'kokoro'
+
+  // Engine gating mirrors the voice-in handler precedence: the
+  // compose-injected env wins, then the persisted host-capabilities file,
+  // then a fail-safe 'cloud'. The in-container ~/.switchroom is a read-only
+  // view that does NOT carry host-capabilities.json, so the env is
+  // load-bearing in-fleet (see message:voice). Kokoro requires 'local';
+  // openai requires a resolvable api_key.
+  if (engine === 'kokoro') {
+    const envVoiceEngine = process.env.SWITCHROOM_VOICE_ENGINE
+    const voiceEngine: VoiceEngine =
+      envVoiceEngine === 'local' || envVoiceEngine === 'cloud'
+        ? envVoiceEngine
+        : loadHostCapabilities()?.voice.engine ?? 'cloud'
+    if (voiceEngine !== 'local') return null
+  }
+
+  // Plain-text TTS input: strip markdown REGARDLESS of mode so the engine
+  // never reads out backticks / asterisks / link syntax. Collapse runs of
+  // whitespace so multi-line prose speaks cleanly.
+  const ttsText = stripMarkdown(replyText).replace(/\s+/g, ' ').trim()
+  if (ttsText.length === 0) return null
+
+  const maxChars = voiceOut.max_chars ?? VOICE_OUT_DEFAULT_MAX_CHARS
+  return {
+    engine,
+    voice: voiceOut.voice,
+    apiKeyRef: voiceOut.api_key,
+    replyMode: voiceOut.reply_mode ?? 'voice+text',
+    ttsText,
+    // Gate on the ORIGINAL reply length (not the stripped length) so the
+    // operator's max_chars maps to what the user typed/read.
+    withinLimit: replyText.length <= maxChars,
+  }
+}
+
+/**
+ * Synthesize `ttsText` into OGG/Opus bytes via the configured engine.
+ * Best-effort: returns null on ANY failure (logged to stderr), never
+ * throws. The caller treats null as "voice unavailable, fall back to
+ * text". PR-C2.
+ */
+async function synthesizeVoiceOut(plan: {
+  engine: 'kokoro' | 'openai'
+  voice?: string
+  apiKeyRef?: string
+  ttsText: string
+}): Promise<Uint8Array | null> {
+  try {
+    if (plan.engine === 'kokoro') {
+      const token = await materializeSidecarToken()
+      if (!token) return null // materializeSidecarToken already logged why.
+      const result = await synthesizeViaSidecar({
+        token,
+        text: plan.ttsText,
+        voice: plan.voice,
+      })
+      if (!result.ok) {
+        process.stderr.write(
+          `telegram gateway: voice-out: local sidecar synthesis failed reason=${result.reason}` +
+            (result.detail ? ` detail=${JSON.stringify(result.detail).slice(0, 100)}` : '') +
+            '\n',
+        )
+        return null
+      }
+      process.stderr.write(
+        `telegram gateway: voice-out: local sidecar synthesized ${result.audio.length} bytes in ${result.durationMs}ms ` +
+          `voice=${result.voice ?? '?'} audio_s=${result.audioSeconds ?? '?'} chars=${plan.ttsText.length}\n`,
+      )
+      return result.audio
+    }
+
+    // engine === 'openai' — honest-exception cloud path.
+    const apiKey = await materializeVoiceKey({ apiKeyRef: plan.apiKeyRef })
+    if (!apiKey) return null // materializeVoiceKey already logged why.
+    const result = await synthesizeViaOpenAi({
+      apiKey,
+      text: plan.ttsText,
+      voice: plan.voice,
+    })
+    if (!result.ok) {
+      process.stderr.write(
+        `telegram gateway: voice-out: openai synthesis failed reason=${result.reason}` +
+          (result.detail ? ` detail=${JSON.stringify(result.detail).slice(0, 100)}` : '') +
+          '\n',
+      )
+      return null
+    }
+    process.stderr.write(
+      `telegram gateway: voice-out: openai synthesized ${result.audio.length} bytes in ${result.durationMs}ms ` +
+        `voice=${result.voice} chars=${plan.ttsText.length}\n`,
+    )
+    return result.audio
+  } catch (err) {
+    // Defence in depth: the synth helpers never throw, but the vault
+    // materialize calls might. Voice is best-effort — swallow + fall back.
+    process.stderr.write(
+      `telegram gateway: voice-out: synthesis threw (non-fatal): ${err instanceof Error ? err.message : String(err)}\n`,
+    )
+    return null
+  }
+}
+
 async function executeReply(args: Record<string, unknown>): Promise<{ content: Array<{ type: string; text: string }> }> {
   // #1664 — pin the turn this reply belongs to at entry. The
   // finalAnswerDelivered write near the end of this function runs after
@@ -8252,6 +8411,11 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   const protectContent = args.protect_content === true
   const quoteText = args.quote_text as string | undefined
   const access = loadAccess()
+  // Outbound TTS plan (PR-C2). Resolved once here (engine gating + mode +
+  // plain-text TTS input); synthesis happens just before the send so a
+  // voice-only reply can suppress the text chunk loop on success. Voice is
+  // fully best-effort — every failure below falls back to the text reply.
+  const voiceOutPlan = resolveVoiceOutPlan(access.voice_out, text)
   const configParseMode = access.parseMode ?? 'html'
   const format = (args.format as string | undefined) ?? configParseMode
   const disableLinkPreview = args.disable_web_page_preview != null
@@ -8492,6 +8656,25 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     ? chunk(effectiveText, limit, access.chunkMode ?? 'length')
     : splitMarkdownChunks(effectiveText, limit)
   const sentIds: number[] = []
+
+  // Outbound TTS synthesis (PR-C2). Done BEFORE the text send so a
+  // voice-only reply can suppress the text chunks on success. Best-effort:
+  // any failure (or a reply over max_chars) leaves `voiceOgg` null and the
+  // text path proceeds unchanged — the user's answer is never dropped.
+  // Long replies always fall back to text-only, even in voice-only mode.
+  let voiceOgg: Uint8Array | null = null
+  if (voiceOutPlan != null && voiceOutPlan.withinLimit) {
+    voiceOgg = await synthesizeVoiceOut(voiceOutPlan)
+  } else if (voiceOutPlan != null && !voiceOutPlan.withinLimit) {
+    process.stderr.write(
+      `telegram gateway: voice-out: reply ${text.length} chars exceeds max_chars — text-only fallback\n`,
+    )
+  }
+  // Suppress the text body ONLY when voice-only AND synthesis actually
+  // produced bytes. If synthesis failed (voiceOgg == null) or the reply was
+  // too long, the text path runs as normal so the answer still lands.
+  const suppressText =
+    voiceOutPlan?.replyMode === 'voice-only' && voiceOgg != null
 
   // #271: validate inline_keyboard and namespace any callback_data with
   // the `agent:` prefix so the gateway's callback_query dispatcher can
@@ -8762,7 +8945,12 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   }
 
   try {
-    for (let i = 0; i < chunks.length; i++) {
+    // PR-C2: voice-only mode with a successful synthesis suppresses the
+    // text body — the spoken voice note IS the reply. The loop is skipped
+    // entirely (sentIds stays empty for text); the voice send below lands
+    // the answer. Any other mode (voice+text, or voice-only that fell back)
+    // sends the text chunks as normal.
+    for (let i = 0; !suppressText && i < chunks.length; i++) {
       const shouldReplyTo =
         reply_to != null && replyMode !== 'off' && (replyMode === 'all' || i === 0)
       const isLastChunk = i === chunks.length - 1
@@ -8916,6 +9104,62 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     throw new Error(`reply failed after ${sentIds.length} of ${chunks.length} chunk(s) sent: ${msg}`)
   } finally {
     stopTypingLoop(chat_id, threadId ?? null)
+  }
+
+  // Outbound voice note (PR-C2). Sent AFTER the text body (voice+text) or
+  // INSTEAD of it (voice-only, where suppressText skipped the chunk loop).
+  // Best-effort and fully non-fatal: the synth already succeeded (voiceOgg
+  // is non-null), but a sendVoice failure must NEVER break the text reply
+  // path — catch + log and move on. In voice-only mode a sendVoice failure
+  // here would leave the user with NOTHING, so re-send the text as a
+  // fallback before continuing.
+  if (voiceOgg != null) {
+    const voiceOpts: Record<string, unknown> = {
+      ...(reply_to != null && replyMode !== 'off'
+        ? { reply_parameters: { message_id: reply_to } }
+        : {}),
+      ...(threadId != null ? { message_thread_id: threadId } : {}),
+      ...(disableNotification ? { disable_notification: true } : {}),
+    }
+    try {
+      const sentVoice = await retryWithThreadFallback<{ message_id: number; message_thread_id?: number }>(
+        robustApiCall,
+        (tid) => {
+          const opts = { ...voiceOpts }
+          if (tid != null) opts.message_thread_id = tid
+          else delete opts.message_thread_id
+          // allow-raw-bot-api: adapter callback INSIDE retryWithThreadFallback→robustApiCall; the THREAD_NOT_FOUND fallback is handled by the wrapper.
+          return lockedBot.api.sendVoice(chat_id, new InputFile(Buffer.from(voiceOgg!)), opts as never)
+        },
+        { threadId, chat_id, verb: 'sendVoice' },
+      )
+      sentIds.push(sentVoice.message_id)
+      logOutbound('reply', chat_id, sentVoice.message_id, voiceOutPlan?.ttsText.length ?? 0, 'voice-note')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      process.stderr.write(`telegram gateway: voice-out: sendVoice failed (non-fatal): ${msg}\n`)
+      // voice-only fell over with no text sent → recover by sending the
+      // text body so the answer still lands (never drop it silently).
+      if (suppressText) {
+        try {
+          const opts: Record<string, unknown> = {
+            ...(reply_to != null && replyMode !== 'off'
+              ? { reply_parameters: { message_id: reply_to } }
+              : {}),
+            ...(threadId != null ? { message_thread_id: threadId } : {}),
+            ...(disableNotification ? { disable_notification: true } : {}),
+          }
+          // allow-raw-bot-api: voice-only recovery fallback — the rich path already ran/was skipped; send the source text plainly so the answer is never lost.
+          const sent = await lockedBot.api.sendMessage(chat_id, effectiveText, opts as never)
+          sentIds.push(sent.message_id)
+          logOutbound('reply', chat_id, sent.message_id, effectiveText.length, 'voice-only-text-recovery')
+        } catch (textErr) {
+          process.stderr.write(
+            `telegram gateway: voice-out: voice-only text recovery ALSO failed: ${textErr instanceof Error ? textErr.message : String(textErr)}\n`,
+          )
+        }
+      }
+    }
   }
 
   // #710: remember per-button agent meta (ack_text / single_use) keyed

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8945,12 +8945,13 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   }
 
   try {
-    // PR-C2: voice-only mode with a successful synthesis suppresses the
-    // text body — the spoken voice note IS the reply. The loop is skipped
-    // entirely (sentIds stays empty for text); the voice send below lands
-    // the answer. Any other mode (voice+text, or voice-only that fell back)
-    // sends the text chunks as normal.
-    for (let i = 0; !suppressText && i < chunks.length; i++) {
+    for (let i = 0; i < chunks.length; i++) {
+      // PR-C2: voice-only mode with a successful synthesis suppresses the
+      // text body — the spoken voice note IS the reply. Bail before the
+      // first chunk send (sentIds stays empty for text); the voice send
+      // below lands the answer. Any other mode (voice+text, or voice-only
+      // that fell back) sends the text chunks as normal.
+      if (suppressText) break
       const shouldReplyTo =
         reply_to != null && replyMode !== 'off' && (replyMode === 'all' || i === 0)
       const isLastChunk = i === chunks.length - 1

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -49,7 +49,7 @@ import {
 } from '../sticker-aliases.js'
 import { transcribeViaWhisper } from '../voice-transcribe.js'
 import { transcribeViaSidecar } from '../voice-transcribe-sidecar.js'
-import { synthesizeViaSidecar } from '../voice-synthesize-sidecar.js'
+import { synthesizeViaSidecar, SIDECAR_TTS_MAX_CHARS, chunkTtsText } from '../voice-synthesize-sidecar.js'
 import { synthesizeViaOpenAi } from '../voice-synthesize.js'
 import { stripMarkdown } from '../card-format.js'
 import {
@@ -8170,15 +8170,22 @@ function redactOutboundText(text: string, site: string): string {
   return masked
 }
 
-/** Default voice-out length ceiling: replies longer than this are sent
- *  text-only (even in voice-only mode). Mirrors the schema default. */
-const VOICE_OUT_DEFAULT_MAX_CHARS = 600
+/** Default per-voice-note chunk size (chars). A long reply is split into
+ *  sequential voice notes of roughly this size on sentence/paragraph
+ *  boundaries — NOT truncated. Mirrors the schema default. The Kokoro
+ *  sidecar's hard per-request cap (VOICE_TTS_MAX_CHARS, 1200) is the upper
+ *  bound; any configured value above it is clamped down. */
+const VOICE_OUT_DEFAULT_CHUNK_CHARS = 600
+
+/** Hard ceiling for a single TTS request, matching the sidecar's
+ *  VOICE_TTS_MAX_CHARS (server.py). Voice-note chunks never exceed this. */
+const VOICE_OUT_HARD_CHUNK_CAP = SIDECAR_TTS_MAX_CHARS
 
 type VoiceOutAccess = NonNullable<Access['voice_out']>
 
 /**
  * Resolve whether outbound TTS is active for this reply, and how
- * (engine + reply_mode + the plain-text TTS input). PR-C2.
+ * (engine + reply_mode + the plain-text TTS chunks). PR-C2.
  *
  * Mirrors the voice-IN engine-resolution precedence (message:voice
  * handler): the compose-injected SWITCHROOM_VOICE_ENGINE verdict gates the
@@ -8187,9 +8194,11 @@ type VoiceOutAccess = NonNullable<Access['voice_out']>
  * NOT require a local verdict.
  *
  * Returns null when voice-out is off / not applicable; otherwise a plan the
- * caller acts on. `ttsText` is markdown-stripped plain text (Kokoro/OpenAI
- * read it literally). `withinLimit` is false when the reply exceeds
- * max_chars — the caller still synthesizes nothing and always sends text.
+ * caller acts on. `ttsChunks` is markdown-stripped plain text split into
+ * sequential voice-note-sized pieces (sentence/paragraph boundaries) — a
+ * LONG reply is spoken across multiple ordered voice notes, never truncated
+ * to text-only (Ken is often on a bike/driving and can't read the screen).
+ * `max_chars` is the per-note chunk size, not a cutoff.
  */
 function resolveVoiceOutPlan(
   voiceOut: VoiceOutAccess | undefined,
@@ -8199,8 +8208,7 @@ function resolveVoiceOutPlan(
   voice?: string
   apiKeyRef?: string
   replyMode: 'voice+text' | 'voice-only'
-  ttsText: string
-  withinLimit: boolean
+  ttsChunks: string[]
 } | null {
   if (voiceOut?.enabled !== true) return null
 
@@ -8227,16 +8235,22 @@ function resolveVoiceOutPlan(
   const ttsText = stripMarkdown(replyText).replace(/\s+/g, ' ').trim()
   if (ttsText.length === 0) return null
 
-  const maxChars = voiceOut.max_chars ?? VOICE_OUT_DEFAULT_MAX_CHARS
+  // Per-voice-note chunk size, clamped to the engine's hard cap. A long
+  // reply becomes several ordered voice notes instead of a text-only
+  // fallback.
+  const chunkChars = Math.min(
+    voiceOut.max_chars ?? VOICE_OUT_DEFAULT_CHUNK_CHARS,
+    VOICE_OUT_HARD_CHUNK_CAP,
+  )
+  const ttsChunks = chunkTtsText(ttsText, chunkChars)
+  if (ttsChunks.length === 0) return null
+
   return {
     engine,
     voice: voiceOut.voice,
     apiKeyRef: voiceOut.api_key,
     replyMode: voiceOut.reply_mode ?? 'voice+text',
-    ttsText,
-    // Gate on the ORIGINAL reply length (not the stripped length) so the
-    // operator's max_chars maps to what the user typed/read.
-    withinLimit: replyText.length <= maxChars,
+    ttsChunks,
   }
 }
 
@@ -8658,23 +8672,39 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   const sentIds: number[] = []
 
   // Outbound TTS synthesis (PR-C2). Done BEFORE the text send so a
-  // voice-only reply can suppress the text chunks on success. Best-effort:
-  // any failure (or a reply over max_chars) leaves `voiceOgg` null and the
-  // text path proceeds unchanged — the user's answer is never dropped.
-  // Long replies always fall back to text-only, even in voice-only mode.
-  let voiceOgg: Uint8Array | null = null
-  if (voiceOutPlan != null && voiceOutPlan.withinLimit) {
-    voiceOgg = await synthesizeVoiceOut(voiceOutPlan)
-  } else if (voiceOutPlan != null && !voiceOutPlan.withinLimit) {
-    process.stderr.write(
-      `telegram gateway: voice-out: reply ${text.length} chars exceeds max_chars — text-only fallback\n`,
-    )
+  // voice-only reply can suppress the text chunks on success. A LONG reply
+  // is synthesized into SEVERAL ordered voice notes (one per chunk) instead
+  // of falling back to text-only — Ken is often on a bike/driving and can't
+  // read the screen, so the full answer must be SPOKEN. Best-effort: each
+  // chunk that fails to synthesize is skipped; if NOTHING synthesizes the
+  // text path proceeds unchanged so the answer is never dropped.
+  const voiceOggs: Uint8Array[] = []
+  if (voiceOutPlan != null) {
+    for (const chunkText of voiceOutPlan.ttsChunks) {
+      const ogg = await synthesizeVoiceOut({
+        engine: voiceOutPlan.engine,
+        voice: voiceOutPlan.voice,
+        apiKeyRef: voiceOutPlan.apiKeyRef,
+        ttsText: chunkText,
+      })
+      // Skip a failed chunk but keep going — a partial spoken answer still
+      // beats silence; full-fail (no oggs at all) falls back to text below.
+      if (ogg != null) voiceOggs.push(ogg)
+    }
+    if (voiceOggs.length < voiceOutPlan.ttsChunks.length) {
+      process.stderr.write(
+        `telegram gateway: voice-out: synthesized ${voiceOggs.length}/${voiceOutPlan.ttsChunks.length} voice-note chunk(s)\n`,
+      )
+    }
   }
-  // Suppress the text body ONLY when voice-only AND synthesis actually
-  // produced bytes. If synthesis failed (voiceOgg == null) or the reply was
-  // too long, the text path runs as normal so the answer still lands.
+  // Suppress the text body ONLY when voice-only AND we synthesized the FULL
+  // set of chunks (every part of the answer is spoken). A partial or total
+  // synthesis failure leaves the text path running so the answer still
+  // lands in full — never drop the user's answer silently.
   const suppressText =
-    voiceOutPlan?.replyMode === 'voice-only' && voiceOgg != null
+    voiceOutPlan?.replyMode === 'voice-only' &&
+    voiceOutPlan.ttsChunks.length > 0 &&
+    voiceOggs.length === voiceOutPlan.ttsChunks.length
 
   // #271: validate inline_keyboard and namespace any callback_data with
   // the `agent:` prefix so the gateway's callback_query dispatcher can
@@ -9107,16 +9137,20 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     stopTypingLoop(chat_id, threadId ?? null)
   }
 
-  // Outbound voice note (PR-C2). Sent AFTER the text body (voice+text) or
-  // INSTEAD of it (voice-only, where suppressText skipped the chunk loop).
-  // Best-effort and fully non-fatal: the synth already succeeded (voiceOgg
-  // is non-null), but a sendVoice failure must NEVER break the text reply
-  // path — catch + log and move on. In voice-only mode a sendVoice failure
-  // here would leave the user with NOTHING, so re-send the text as a
-  // fallback before continuing.
-  if (voiceOgg != null) {
+  // Outbound voice notes (PR-C2). Sent IN ORDER, AFTER the text body
+  // (voice+text) or INSTEAD of it (voice-only, where suppressText skipped
+  // the chunk loop). A long reply produces SEVERAL notes — each spoken in
+  // sequence so the whole answer is heard, never truncated. Best-effort and
+  // fully non-fatal: a sendVoice failure must NEVER break the text reply
+  // path. In voice-only mode a failure would leave the user with an
+  // incomplete spoken answer, so on the FIRST send failure we recover by
+  // sending the full text once and stop sending further notes.
+  for (let v = 0; v < voiceOggs.length; v++) {
+    const oggBytes = voiceOggs[v]!
     const voiceOpts: Record<string, unknown> = {
-      ...(reply_to != null && replyMode !== 'off'
+      // Quote the user's message only on the FIRST voice note (mirrors the
+      // text chunk loop's first-chunk reply behaviour).
+      ...(v === 0 && reply_to != null && replyMode !== 'off'
         ? { reply_parameters: { message_id: reply_to } }
         : {}),
       ...(threadId != null ? { message_thread_id: threadId } : {}),
@@ -9130,17 +9164,26 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
           if (tid != null) opts.message_thread_id = tid
           else delete opts.message_thread_id
           // allow-raw-bot-api: adapter callback INSIDE retryWithThreadFallback→robustApiCall; the THREAD_NOT_FOUND fallback is handled by the wrapper.
-          return lockedBot.api.sendVoice(chat_id, new InputFile(Buffer.from(voiceOgg!)), opts as never)
+          return lockedBot.api.sendVoice(chat_id, new InputFile(Buffer.from(oggBytes)), opts as never)
         },
         { threadId, chat_id, verb: 'sendVoice' },
       )
       sentIds.push(sentVoice.message_id)
-      logOutbound('reply', chat_id, sentVoice.message_id, voiceOutPlan?.ttsText.length ?? 0, 'voice-note')
+      logOutbound(
+        'reply',
+        chat_id,
+        sentVoice.message_id,
+        voiceOutPlan?.ttsChunks[v]?.length ?? 0,
+        `voice-note=${v + 1}/${voiceOggs.length}`,
+      )
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      process.stderr.write(`telegram gateway: voice-out: sendVoice failed (non-fatal): ${msg}\n`)
-      // voice-only fell over with no text sent → recover by sending the
-      // text body so the answer still lands (never drop it silently).
+      process.stderr.write(
+        `telegram gateway: voice-out: sendVoice ${v + 1}/${voiceOggs.length} failed (non-fatal): ${msg}\n`,
+      )
+      // voice-only fell over mid-stream with text suppressed → recover by
+      // sending the FULL text body once so the answer still lands, then
+      // stop sending further notes (the text now carries everything).
       if (suppressText) {
         try {
           const opts: Record<string, unknown> = {
@@ -9159,6 +9202,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
             `telegram gateway: voice-out: voice-only text recovery ALSO failed: ${textErr instanceof Error ? textErr.message : String(textErr)}\n`,
           )
         }
+        break
       }
     }
   }

--- a/telegram-plugin/tests/voice-synthesize-sidecar.test.ts
+++ b/telegram-plugin/tests/voice-synthesize-sidecar.test.ts
@@ -12,6 +12,7 @@
 import { describe, it, expect } from 'bun:test'
 import {
   synthesizeViaSidecar,
+  chunkTtsText,
   SIDECAR_TTS_MAX_CHARS,
   DEFAULT_SIDECAR_BASE_URL,
 } from '../voice-synthesize-sidecar.js'
@@ -193,5 +194,81 @@ describe('synthesizeViaSidecar — error paths', () => {
     }) as unknown as typeof fetch
     const r = await synthesizeViaSidecar({ token: 't', text: 'hi', fetchImpl: aborted })
     expect(r).toMatchObject({ ok: false, reason: 'timeout' })
+  })
+})
+
+describe('chunkTtsText — long-reply voice chunking (PR-C2)', () => {
+  it('returns a single chunk when text fits the cap', () => {
+    expect(chunkTtsText('Short answer.', 600)).toEqual(['Short answer.'])
+  })
+
+  it('returns no chunks for empty text', () => {
+    expect(chunkTtsText('', 600)).toEqual([])
+    expect(chunkTtsText('   ', 600)).toEqual([])
+  })
+
+  it('splits a long reply into multiple chunks, each under the cap', () => {
+    const sentence = 'This is a sentence that is reasonably long. '
+    const text = sentence.repeat(20).trim() // ~880 chars
+    const chunks = chunkTtsText(text, 200)
+    expect(chunks.length).toBeGreaterThan(1)
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(200)
+    // No text is lost: every sentence's words survive across the chunks.
+    const rejoined = chunks.join(' ')
+    expect(rejoined).toContain('reasonably long')
+    expect(rejoined.split('reasonably long').length - 1).toBe(20)
+  })
+
+  it('prefers sentence boundaries — does not cut mid-sentence', () => {
+    const text =
+      'First sentence here. Second sentence here. Third sentence here. Fourth one too.'
+    const chunks = chunkTtsText(text, 45)
+    // Each chunk should end at a sentence terminator (no dangling fragment).
+    for (const c of chunks) expect(/[.!?]$/.test(c)).toBe(true)
+  })
+
+  it('hard-slices a single sentence longer than the cap (no boundary fits)', () => {
+    const longWord = 'a'.repeat(50)
+    const text = `${longWord} ${longWord} ${longWord}` // one boundary-less-ish run
+    const chunks = chunkTtsText(text, 60)
+    expect(chunks.length).toBeGreaterThan(1)
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(60)
+  })
+
+  it('never emits a chunk over the cap even with a giant tokenless blob', () => {
+    const blob = 'x'.repeat(5000)
+    const chunks = chunkTtsText(blob, 1200)
+    expect(chunks.length).toBeGreaterThan(1)
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(1200)
+  })
+})
+
+describe('synthesizeViaSidecar — multi-chunk send path (PR-C2)', () => {
+  it('synthesizes each chunk independently (one POST per chunk)', async () => {
+    const text = 'Sentence one is here. '.repeat(40).trim() // long → many chunks
+    const chunks = chunkTtsText(text, 200)
+    expect(chunks.length).toBeGreaterThan(1)
+
+    let calls = 0
+    const fakeFetch: typeof fetch = (async () => {
+      calls++
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => OGG_BYTES.buffer.slice(0),
+        text: async () => '',
+        headers: new Headers(),
+      }
+    }) as unknown as typeof fetch
+
+    // Mirror the gateway's per-chunk synthesis loop.
+    const oggs: Uint8Array[] = []
+    for (const c of chunks) {
+      const r = await synthesizeViaSidecar({ token: 't', text: c, fetchImpl: fakeFetch })
+      expect(r.ok).toBe(true)
+      if (r.ok) oggs.push(r.audio)
+    }
+    expect(calls).toBe(chunks.length)
+    expect(oggs.length).toBe(chunks.length)
   })
 })

--- a/telegram-plugin/tests/voice-synthesize-sidecar.test.ts
+++ b/telegram-plugin/tests/voice-synthesize-sidecar.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for the LOCAL TTS sidecar synthesis path (voice PR-C2):
+ *   - synthesizeViaSidecar (HTTP POST to /tts, mocked fetch)
+ *
+ * The OUTBOUND mirror of voice-transcribe-sidecar.test.ts: every error
+ * reason is pinned so a refactor can't silently change the contract the
+ * gateway depends on (any non-ok → null → text-only fallback). The /tts
+ * endpoint returns RAW OGG bytes on success (not JSON), so the happy-path
+ * asserts on arrayBuffer + the audio/ogg-style meta headers.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import {
+  synthesizeViaSidecar,
+  SIDECAR_TTS_MAX_CHARS,
+  DEFAULT_SIDECAR_BASE_URL,
+} from '../voice-synthesize-sidecar.js'
+
+const OGG_BYTES = new Uint8Array([0x4f, 0x67, 0x67, 0x53]) // OggS magic
+
+/** Mock a 200 audio/ogg response carrying `bytes`. */
+function makeOggFetch(
+  bytes: Uint8Array,
+  headers: Record<string, string> = {},
+): typeof fetch {
+  return (async () => ({
+    ok: true,
+    status: 200,
+    arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    text: async () => '',
+    headers: new Headers(headers),
+  })) as unknown as typeof fetch
+}
+
+/** Mock a non-2xx JSON error response. */
+function makeErrFetch(status: number, body: unknown): typeof fetch {
+  return (async () => ({
+    ok: false,
+    status,
+    arrayBuffer: async () => new ArrayBuffer(0),
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+    headers: new Headers(),
+  })) as unknown as typeof fetch
+}
+
+describe('synthesizeViaSidecar — pre-flight checks', () => {
+  it('returns no-token when token is empty', async () => {
+    const r = await synthesizeViaSidecar({
+      token: '',
+      text: 'hello',
+      fetchImpl: makeOggFetch(OGG_BYTES),
+    })
+    expect(r).toMatchObject({ ok: false, reason: 'no-token' })
+  })
+
+  it('returns empty-text on whitespace-only text', async () => {
+    const r = await synthesizeViaSidecar({ token: 't', text: '   ' })
+    expect(r).toMatchObject({ ok: false, reason: 'empty-text' })
+  })
+
+  it('returns text-too-long above the cap', async () => {
+    const r = await synthesizeViaSidecar({
+      token: 't',
+      text: 'x'.repeat(SIDECAR_TTS_MAX_CHARS + 1),
+    })
+    expect(r).toMatchObject({ ok: false, reason: 'text-too-long' })
+  })
+})
+
+describe('synthesizeViaSidecar — happy path', () => {
+  it('returns OGG bytes + meta on 200 audio/ogg', async () => {
+    const r = await synthesizeViaSidecar({
+      token: 't',
+      text: 'Hello world',
+      fetchImpl: makeOggFetch(OGG_BYTES, {
+        'X-Voice-Duration-Ms': '1234',
+        'X-Voice-Audio-Seconds': '2.5',
+        'X-Voice-Voice': 'af_heart',
+      }),
+    })
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      expect(Array.from(r.audio)).toEqual(Array.from(OGG_BYTES))
+      expect(r.durationMs).toBe(1234)
+      expect(r.audioSeconds).toBe(2.5)
+      expect(r.voice).toBe('af_heart')
+    }
+  })
+
+  it('POSTs JSON {text,voice,format:ogg} + X-Voice-Token to <base>/tts', async () => {
+    let receivedUrl = ''
+    let receivedToken: string | null = null
+    let receivedBody: string | null = null
+    const fakeFetch: typeof fetch = (async (url: string, init?: RequestInit) => {
+      receivedUrl = url
+      receivedToken = (init?.headers as Record<string, string>)['X-Voice-Token']
+      receivedBody = init?.body as string
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => OGG_BYTES.buffer.slice(0),
+        text: async () => '',
+        headers: new Headers(),
+      }
+    }) as unknown as typeof fetch
+
+    const r = await synthesizeViaSidecar({
+      token: 'secret-token',
+      text: 'bonjour',
+      voice: 'af_sky',
+      fetchImpl: fakeFetch,
+    })
+    expect(r.ok).toBe(true)
+    expect(receivedUrl).toBe(`${DEFAULT_SIDECAR_BASE_URL}/tts`)
+    expect(receivedToken).toBe('secret-token')
+    const parsed = JSON.parse(receivedBody!)
+    expect(parsed.text).toBe('bonjour')
+    expect(parsed.voice).toBe('af_sky')
+    expect(parsed.format).toBe('ogg')
+  })
+
+  it('omits the voice field when none is supplied', async () => {
+    let receivedBody: string | null = null
+    const fakeFetch: typeof fetch = (async (_url: string, init?: RequestInit) => {
+      receivedBody = init?.body as string
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => OGG_BYTES.buffer.slice(0),
+        text: async () => '',
+        headers: new Headers(),
+      }
+    }) as unknown as typeof fetch
+    await synthesizeViaSidecar({ token: 't', text: 'hi', fetchImpl: fakeFetch })
+    const parsed = JSON.parse(receivedBody!)
+    expect('voice' in parsed).toBe(false)
+  })
+
+  it('falls back to wall-clock durationMs when headers are absent', async () => {
+    const r = await synthesizeViaSidecar({
+      token: 't',
+      text: 'hi',
+      fetchImpl: makeOggFetch(OGG_BYTES),
+    })
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      expect(r.durationMs).toBeGreaterThanOrEqual(0)
+      expect(r.audioSeconds).toBeNull()
+      expect(r.voice).toBeNull()
+    }
+  })
+})
+
+describe('synthesizeViaSidecar — error paths', () => {
+  it('echoes the sidecar reason from a non-2xx JSON body', async () => {
+    const r = await synthesizeViaSidecar({
+      token: 't',
+      text: 'hi',
+      fetchImpl: makeErrFetch(413, { ok: false, reason: 'text-too-long', detail: '9999 > 1200' }),
+    })
+    expect(r).toMatchObject({ ok: false, reason: 'text-too-long', detail: '9999 > 1200' })
+  })
+
+  it('falls back to http-<n> when the error body is not JSON', async () => {
+    const r = await synthesizeViaSidecar({
+      token: 't',
+      text: 'hi',
+      fetchImpl: makeErrFetch(503, 'service unavailable'),
+    })
+    expect(r).toMatchObject({ ok: false, reason: 'http-503' })
+  })
+
+  it('returns empty-audio on a 200 with no bytes', async () => {
+    const r = await synthesizeViaSidecar({
+      token: 't',
+      text: 'hi',
+      fetchImpl: makeOggFetch(new Uint8Array(0)),
+    })
+    expect(r).toMatchObject({ ok: false, reason: 'empty-audio' })
+  })
+
+  it('returns fetch-failed on a network error', async () => {
+    const boom: typeof fetch = (async () => {
+      throw new Error('ECONNREFUSED')
+    }) as unknown as typeof fetch
+    const r = await synthesizeViaSidecar({ token: 't', text: 'hi', fetchImpl: boom })
+    expect(r).toMatchObject({ ok: false, reason: 'fetch-failed' })
+  })
+
+  it('returns timeout when the fetch aborts', async () => {
+    const aborted: typeof fetch = (async () => {
+      throw new Error('The operation was aborted')
+    }) as unknown as typeof fetch
+    const r = await synthesizeViaSidecar({ token: 't', text: 'hi', fetchImpl: aborted })
+    expect(r).toMatchObject({ ok: false, reason: 'timeout' })
+  })
+})

--- a/telegram-plugin/voice-synthesize-sidecar.ts
+++ b/telegram-plugin/voice-synthesize-sidecar.ts
@@ -35,6 +35,59 @@ export const DEFAULT_SIDECAR_BASE_URL = 'http://127.0.0.1:18900'
  *  a defence-in-depth ceiling matching the sidecar's hard limit. */
 export const SIDECAR_TTS_MAX_CHARS = 1200
 
+/**
+ * Split already-stripped plain text into sequential TTS chunks, each ≤
+ * `chunkChars`, preferring sentence then word boundaries so a voice note
+ * never cuts mid-sentence. A run with no boundary that fits (e.g. one
+ * enormous URL) is hard-sliced at the cap so a chunk can't exceed the
+ * engine limit. PR-C2 (long-reply voice chunking — the full answer is
+ * spoken across several notes instead of truncated to text-only).
+ */
+export function chunkTtsText(text: string, chunkChars: number): string[] {
+  const cap = Math.max(1, chunkChars)
+  if (text.length <= cap) {
+    const t = text.trim()
+    return t.length > 0 ? [t] : []
+  }
+
+  // Sentence-ish units: keep the terminator with the sentence. Falls back
+  // to the whole string when there's no punctuation to split on.
+  const sentences = text.match(/[^.!?]+[.!?]+(?:\s|$)|[^.!?]+$/g) ?? [text]
+  const chunks: string[] = []
+  let buf = ''
+
+  const flush = (): void => {
+    const t = buf.trim()
+    if (t.length > 0) chunks.push(t)
+    buf = ''
+  }
+  const hardSlice = (s: string): void => {
+    // No boundary fits the cap — split on word boundaries, then hard-cut
+    // any single token still over the cap.
+    let rest = s
+    while (rest.length > cap) {
+      let cut = rest.lastIndexOf(' ', cap)
+      if (cut <= 0) cut = cap
+      chunks.push(rest.slice(0, cut).trim())
+      rest = rest.slice(cut).trimStart()
+    }
+    buf = rest
+  }
+
+  for (const sentence of sentences) {
+    if (sentence.length > cap) {
+      // The sentence itself overflows — flush what we have, then slice it.
+      flush()
+      hardSlice(sentence)
+      continue
+    }
+    if (buf.length + sentence.length > cap) flush()
+    buf += sentence
+  }
+  flush()
+  return chunks
+}
+
 /** A successful synthesis: the OGG/Opus voice-note bytes plus sidecar meta. */
 export interface SynthesizeResult {
   ok: true

--- a/telegram-plugin/voice-synthesize-sidecar.ts
+++ b/telegram-plugin/voice-synthesize-sidecar.ts
@@ -1,0 +1,177 @@
+/**
+ * Spoken-reply synthesis (TTS) via the LOCAL voice sidecar (voice PR-C2).
+ *
+ * The mirror of `voice-transcribe-sidecar.ts` for the OUTBOUND direction.
+ * Where that module POSTs audio bytes to `/stt` and gets text back, this
+ * one POSTs the agent's reply text to `/tts` (docker/voice-sidecar/server.py,
+ * Kokoro on a local GPU/CPU) and gets OGG/Opus bytes back — ready to hand
+ * straight to Telegram `sendVoice`. Used when the host's voice-engine
+ * verdict is `local` (no third-party TTS key, vision #3 + #4).
+ *
+ * Reachability: the gateway runs inside the agent container
+ * (`network_mode: host`), so the sidecar's published `0.0.0.0:18900` is
+ * reachable at loopback `127.0.0.1:18900` (compose maps host 18900 → the
+ * sidecar's in-container 8126). See src/agents/compose.ts
+ * (VOICE_SIDECAR_HOST_PORT) for the published-port contract.
+ *
+ * Contract MIRRORS `transcribeViaSidecar`:
+ *   - takes the text + a shared-secret token as args (no env reads, no
+ *     file IO) so it's unit-testable against a mocked fetch;
+ *   - never throws — every failure becomes a structured
+ *     `{ ok: false, reason, detail }`, and the gateway caller falls back
+ *     to a text-only reply on any non-ok outcome (voice is best-effort).
+ *
+ * The sidecar's /tts response shape (server.py):
+ *   200 audio/ogg  (OGG/Opus, mono — raw bytes, NOT JSON)
+ *   4xx/5xx { ok: false, reason, detail }
+ */
+
+/** Default loopback base URL for the sidecar (host-network agent). */
+export const DEFAULT_SIDECAR_BASE_URL = 'http://127.0.0.1:18900'
+
+/** The sidecar caps text at VOICE_TTS_MAX_CHARS (default 1200, server.py);
+ *  reject obviously-oversized input before the round-trip. The gateway's
+ *  own `voice_out.max_chars` (default 600) is the user-facing gate; this is
+ *  a defence-in-depth ceiling matching the sidecar's hard limit. */
+export const SIDECAR_TTS_MAX_CHARS = 1200
+
+/** A successful synthesis: the OGG/Opus voice-note bytes plus sidecar meta. */
+export interface SynthesizeResult {
+  ok: true
+  /** OGG/Opus (mono) bytes — hand directly to Telegram sendVoice. */
+  audio: Uint8Array
+  /** Wall-clock (or sidecar-reported) synthesis time in ms. */
+  durationMs: number
+  /** Audio length in seconds, if the sidecar reported it. */
+  audioSeconds: number | null
+  /** The voice actually used (echoed by the sidecar). */
+  voice: string | null
+}
+
+export interface SynthesizeFailure {
+  ok: false
+  reason: string
+  detail?: string
+}
+
+export type SynthesizeOutcome = SynthesizeResult | SynthesizeFailure
+
+export interface SidecarSynthesizeArgs {
+  /** Shared secret sent in the X-Voice-Token header (vault:voice/sidecar-token). */
+  token: string
+  /** Plain text to speak. Strip markdown before calling — Kokoro reads it literally. */
+  text: string
+  /** Optional engine-specific voice id; the sidecar has its own default. */
+  voice?: string
+  /** Base URL for the sidecar. Defaults to DEFAULT_SIDECAR_BASE_URL. */
+  baseUrl?: string
+  /** Per-call timeout in ms. Default 60s — Kokoro on CPU can run a few
+   *  seconds for a long memo; the sidecar's own per-request timeout is 60s. */
+  timeoutMs?: number
+  /** Override fetch for tests. */
+  fetchImpl?: typeof fetch
+}
+
+/**
+ * Synthesize a single reply against the local sidecar. Resolves to a
+ * SynthesizeOutcome — the caller branches on `.ok`. Never throws.
+ *
+ * Reason codes mirror the STT path where they overlap:
+ *   - 'no-token'           — empty shared secret
+ *   - 'empty-text'         — empty/whitespace text
+ *   - 'text-too-long'      — exceeds SIDECAR_TTS_MAX_CHARS
+ *   - 'http-<n>'           — non-2xx HTTP status code
+ *   - 'fetch-failed'       — network error before any response
+ *   - 'empty-audio'        — 2xx but no body bytes
+ *   - 'timeout'            — exceeded the per-call timeout
+ */
+export async function synthesizeViaSidecar(
+  args: SidecarSynthesizeArgs,
+): Promise<SynthesizeOutcome> {
+  if (!args.token || args.token.length === 0) {
+    return { ok: false, reason: 'no-token' }
+  }
+  const text = args.text?.trim() ?? ''
+  if (text.length === 0) {
+    return { ok: false, reason: 'empty-text' }
+  }
+  if (text.length > SIDECAR_TTS_MAX_CHARS) {
+    return {
+      ok: false,
+      reason: 'text-too-long',
+      detail: `${text.length} chars (limit ${SIDECAR_TTS_MAX_CHARS})`,
+    }
+  }
+
+  const fetchFn = args.fetchImpl ?? fetch
+  const baseUrl = (args.baseUrl ?? DEFAULT_SIDECAR_BASE_URL).replace(/\/$/, '')
+  const timeoutMs = args.timeoutMs ?? 60_000
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+  // JSON body: server.py reads `text` (str) + optional `voice` + `format`.
+  const body: { text: string; voice?: string; format: 'ogg' } = {
+    text,
+    format: 'ogg',
+  }
+  if (args.voice) body.voice = args.voice
+
+  const startedAt = Date.now()
+  let res: Response
+  try {
+    res = await fetchFn(`${baseUrl}/tts`, {
+      method: 'POST',
+      headers: {
+        'X-Voice-Token': args.token,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    })
+  } catch (err) {
+    clearTimeout(timer)
+    const msg = err instanceof Error ? err.message : String(err)
+    if (msg.includes('aborted') || /timeout/i.test(msg)) {
+      return { ok: false, reason: 'timeout', detail: msg }
+    }
+    return { ok: false, reason: 'fetch-failed', detail: msg }
+  }
+  clearTimeout(timer)
+
+  if (!res.ok) {
+    // Error bodies are JSON ({ ok:false, reason, detail }); echo the reason.
+    const errText = await res.text().catch(() => '')
+    let reason = `http-${res.status}`
+    let detail: string | undefined = errText.slice(0, 200)
+    try {
+      const parsed = JSON.parse(errText) as { reason?: unknown; detail?: unknown }
+      if (typeof parsed.reason === 'string') reason = parsed.reason
+      if (typeof parsed.detail === 'string') detail = parsed.detail.slice(0, 200)
+    } catch {
+      // not JSON — keep the http-<n> reason + raw text detail
+    }
+    return { ok: false, reason, detail }
+  }
+
+  const buf = new Uint8Array(await res.arrayBuffer())
+  if (buf.length === 0) {
+    return { ok: false, reason: 'empty-audio' }
+  }
+
+  // Sidecar echoes synthesis meta as response headers (server.py). A
+  // MISSING header reads as null — guard before Number() (Number(null) is 0,
+  // which would masquerade as a real 0-second clip).
+  const rawDuration = res.headers.get('X-Voice-Duration-Ms')
+  const rawAudioSec = res.headers.get('X-Voice-Audio-Seconds')
+  const hdrDuration = rawDuration != null ? Number(rawDuration) : NaN
+  const hdrAudioSec = rawAudioSec != null ? Number(rawAudioSec) : NaN
+  return {
+    ok: true,
+    audio: buf,
+    durationMs: Number.isFinite(hdrDuration) && hdrDuration > 0
+      ? hdrDuration
+      : Date.now() - startedAt,
+    audioSeconds: Number.isFinite(hdrAudioSec) ? hdrAudioSec : null,
+    voice: res.headers.get('X-Voice-Voice'),
+  }
+}

--- a/telegram-plugin/voice-synthesize.ts
+++ b/telegram-plugin/voice-synthesize.ts
@@ -1,0 +1,128 @@
+/**
+ * Spoken-reply synthesis (TTS) via the OpenAI cloud API (voice PR-C2).
+ *
+ * The cloud twin of `voice-synthesize-sidecar.ts` (local Kokoro sidecar),
+ * and the OUTBOUND mirror of `voice-transcribe.ts` (OpenAI Whisper STT).
+ * Used only when the operator opts an agent into `voice_out.engine: openai`
+ * — an honest-exception third-party path gated on an `api_key` vault ref
+ * (the local sidecar is the subscription-honest default).
+ *
+ * Pure: takes the text + resolved API key as args (no env reads, no file
+ * IO) so it's unit-testable against a mocked fetch. Never throws — every
+ * failure becomes a structured `{ ok: false, reason, detail }` and the
+ * gateway caller falls back to a text-only reply (voice is best-effort).
+ *
+ * Requests OGG/Opus directly (response_format: 'opus') so the bytes hand
+ * straight to Telegram sendVoice with no transcode — same shape the local
+ * sidecar returns.
+ */
+
+const OPENAI_TTS_URL = 'https://api.openai.com/v1/audio/speech'
+
+/** Default model + voice when the operator doesn't pin one. */
+export const DEFAULT_OPENAI_TTS_MODEL = 'gpt-4o-mini-tts'
+export const DEFAULT_OPENAI_TTS_VOICE = 'alloy'
+
+export interface OpenAiSynthesizeResult {
+  ok: true
+  /** OGG/Opus bytes — hand directly to Telegram sendVoice. */
+  audio: Uint8Array
+  /** Wall-clock synthesis time in ms. */
+  durationMs: number
+  /** The voice actually requested. */
+  voice: string
+}
+
+export interface OpenAiSynthesizeError {
+  ok: false
+  reason: string
+  detail?: string
+}
+
+export type OpenAiSynthesizeOutcome = OpenAiSynthesizeResult | OpenAiSynthesizeError
+
+export interface OpenAiSynthesizeArgs {
+  /** Resolved OpenAI API key (already materialized from the vault). */
+  apiKey: string
+  /** Plain text to speak. Strip markdown before calling. */
+  text: string
+  /** Voice id (e.g. 'alloy', 'nova'). Defaults to DEFAULT_OPENAI_TTS_VOICE. */
+  voice?: string
+  /** Model. Defaults to DEFAULT_OPENAI_TTS_MODEL. */
+  model?: string
+  /** Per-call timeout in ms. Default 60s. */
+  timeoutMs?: number
+  /** Override fetch for tests. */
+  fetchImpl?: typeof fetch
+}
+
+/**
+ * Synthesize a single reply via OpenAI TTS. Resolves to an outcome — the
+ * caller branches on `.ok`. Never throws.
+ *
+ * Reason codes:
+ *   - 'no-api-key'  — empty key
+ *   - 'empty-text'  — empty/whitespace text
+ *   - 'http-<n>'    — non-2xx HTTP status code
+ *   - 'fetch-failed'— network error before any response
+ *   - 'empty-audio' — 2xx but no body bytes
+ *   - 'timeout'     — exceeded the per-call timeout
+ */
+export async function synthesizeViaOpenAi(
+  args: OpenAiSynthesizeArgs,
+): Promise<OpenAiSynthesizeOutcome> {
+  if (!args.apiKey || args.apiKey.length === 0) {
+    return { ok: false, reason: 'no-api-key' }
+  }
+  const text = args.text?.trim() ?? ''
+  if (text.length === 0) {
+    return { ok: false, reason: 'empty-text' }
+  }
+
+  const fetchFn = args.fetchImpl ?? fetch
+  const voice = args.voice && args.voice.length > 0 ? args.voice : DEFAULT_OPENAI_TTS_VOICE
+  const model = args.model && args.model.length > 0 ? args.model : DEFAULT_OPENAI_TTS_MODEL
+  const timeoutMs = args.timeoutMs ?? 60_000
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+  const startedAt = Date.now()
+  let res: Response
+  try {
+    res = await fetchFn(OPENAI_TTS_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${args.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      // response_format 'opus' → OGG/Opus, ready for Telegram sendVoice.
+      body: JSON.stringify({ model, voice, input: text, response_format: 'opus' }),
+      signal: controller.signal,
+    })
+  } catch (err) {
+    clearTimeout(timer)
+    const msg = err instanceof Error ? err.message : String(err)
+    if (msg.includes('aborted') || /timeout/i.test(msg)) {
+      return { ok: false, reason: 'timeout', detail: msg }
+    }
+    return { ok: false, reason: 'fetch-failed', detail: msg }
+  }
+  clearTimeout(timer)
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    return { ok: false, reason: `http-${res.status}`, detail: body.slice(0, 200) }
+  }
+
+  const buf = new Uint8Array(await res.arrayBuffer())
+  if (buf.length === 0) {
+    return { ok: false, reason: 'empty-audio' }
+  }
+
+  return {
+    ok: true,
+    audio: buf,
+    durationMs: Date.now() - startedAt,
+    voice,
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -243,6 +243,9 @@ export default defineConfig({
       // voice-transcribe-sidecar.test.ts uses bun:test (PR-B2 local STT) —
       // excluded here, run via test:bun.
       "**/telegram-plugin/tests/voice-transcribe-sidecar.test.ts",
+      // voice-synthesize-sidecar.test.ts uses bun:test (PR-C2 local TTS) —
+      // excluded here, run via test:bun.
+      "**/telegram-plugin/tests/voice-synthesize-sidecar.test.ts",
       // telegraph.test.ts uses bun:test (#579 Telegraph Instant View) —
       // excluded here, run via test:bun.
       "**/telegram-plugin/tests/telegraph.test.ts",


### PR DESCRIPTION
## What

Wires voice **output** (TTS) end-to-end so agents can reply with a spoken voice note, consuming the PR-C1 sidecar `/tts` endpoint (#2712). Mirrors the existing voice-IN wiring at every layer — schema → cascade → access projection → gateway passthrough → sidecar client → `executeReply` send.

## Layers

- **Config schema** — `channels.telegram.voice_out` next to `voice_in`: `enabled`, `engine` (`kokoro` local sidecar = subscription-honest default | `openai` cloud honest-exception), `voice`, `reply_mode` (`voice+text` | `voice-only`), `max_chars` (per-voice-note chunk size, default 600), `api_key` (vault ref, openai only). Cascades from `defaults.channels.telegram.voice_out` via the existing per-channel field-merge; projected into `access.json` by scaffold alongside `voice_in`.
- **Sidecar client** — `telegram-plugin/voice-synthesize-sidecar.ts`: `POST /tts` with `X-Voice-Token`, JSON `{text, voice?, format:'ogg'}` → OGG/Opus `Uint8Array`. Plus `chunkTtsText()` (sentence/paragraph chunker). Mirrors `voice-transcribe-sidecar.ts` (pure, never throws, structured failure reasons). Cloud twin `voice-synthesize.ts` (OpenAI TTS, `response_format: opus`).
- **Gateway** — `voice_out` passthrough on the access type + `loadAccess`. `executeReply` resolves the engine with the **same** `SWITCHROOM_VOICE_ENGINE` precedence as the voice-in handler (kokoro active only on a `local` host verdict; openai active with a resolvable `api_key`), strips markdown to clean plain text, chunks it, synthesizes each chunk, and sends via `bot.api.sendVoice(new InputFile(ogg))` through the standard `retryWithThreadFallback` → `robustApiCall` path.

## Long replies are SPOKEN, never truncated

A long reply is **not** dropped to text past a cutoff — the user is often on a bike / driving and can't read the screen. `max_chars` is the **per-voice-note chunk size** (default 600, clamped to the engine hard cap 1200), not a skip-threshold. A reply longer than the chunk size is split on sentence/paragraph boundaries (`chunkTtsText`) into **several ordered voice notes**, synthesized per-chunk and sent in sequence. A boundary-less blob is hard-sliced so no chunk exceeds the engine cap.

## reply_mode behavior

- `voice+text`: sends the full text reply **and** the ordered voice notes (so the answer is also readable when the user can look).
- `voice-only`: suppresses the text body **only** when the *full* set of chunks synthesized. Any partial/total synthesis failure keeps the text path so the whole answer still lands; a mid-stream `sendVoice` failure recovers by sending the full text once and stops further notes.
- Markdown is stripped to clean plain text for TTS input regardless of mode.

## Best-effort guarantee

Voice is fully **non-fatal**: every TTS/`sendVoice`/vault-materialize error is caught and logged, a failed chunk is skipped, and the text reply path is never broken. The user's answer always lands — as text, voice, or both.

## No new service / port / per-agent env

No new sidecar, port, or per-agent compose env. `voice_out` rides `access.json`; engine availability reuses the existing compose-injected `SWITCHROOM_VOICE_ENGINE` (no in-container verdict-file dependency — avoids the PR-B3 bug).

## Tests

- `voice-synthesize-sidecar.test.ts` — mock fetch: `/tts` URL, `X-Voice-Token`, returns bytes, every error reason; `chunkTtsText` (single/empty/multi-chunk, sentence-boundary, hard-slice, tokenless blob); multi-chunk synth loop (one POST per chunk).
- `schema.test.ts` — `voice_out` engine/reply_mode defaults; enum + positive-int rejection.
- `merge.test.ts` — `voice_out` cascade from defaults; agent override; absent-both.

`tsc --noEmit` clean. Full `npm run lint` clean. Touched-file vitest + bun suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)