### PR TITLE
fix(voice): resolve voice/sidecar/bot token via single-key vault batch

### DIFF
--- a/src/telegram/materialize-bot-token.test.ts
+++ b/src/telegram/materialize-bot-token.test.ts
@@ -164,6 +164,41 @@ describe("materializeBotToken (issue #758)", () => {
     expect(brokerStub.fn).not.toHaveBeenCalled();
   });
 
+  // ── Regression: single-key isolation (voice token bug class) ──
+  //
+  // resolveVaultReferencesViaBroker fails the WHOLE batch unless EVERY vault:
+  // ref resolves. If the materializer passes the full config, admin-only refs
+  // elsewhere (litellm/master-key, google/client-secret) — correctly DENIED to
+  // a normal agent — would sink the resolution even though the bot_token key is
+  // granted. The fix passes a MINIMAL config carrying only the one ref. This
+  // asserts the broker sees exactly ONE vault ref, regardless of other refs in
+  // the config.
+  it("passes the broker a config containing exactly one vault ref (isolated from admin-only refs)", async () => {
+    let seenRefs: string[] = [];
+    brokerStub.fn.mockImplementationOnce(async (cfg: SwitchroomConfig) => {
+      const refs = new Set<string>();
+      const walk = (v: unknown): void => {
+        if (typeof v === "string" && v.startsWith("vault:")) refs.add(v.slice("vault:".length).split("#")[0]);
+        else if (Array.isArray(v)) v.forEach(walk);
+        else if (v !== null && typeof v === "object") Object.values(v as Record<string, unknown>).forEach(walk);
+      };
+      walk(cfg);
+      seenRefs = [...refs];
+      return { ok: true, config: makeConfig("123456:RESOLVED") };
+    });
+
+    const config = {
+      ...makeConfig("vault:tg/bot"),
+      litellm: { admin_key: "vault:litellm/master-key" },
+      google_workspace: { google_client_secret: "vault:google/client-secret" },
+      agents: { klanker: { some_key: "vault:per-agent/secret" } },
+    } as unknown as SwitchroomConfig;
+
+    const token = await materializeBotToken({ config, env: {} });
+    expect(token).toBe("123456:RESOLVED");
+    expect(seenRefs).toEqual(["tg/bot"]);
+  });
+
   it("BotTokenMaterializeError exports for instanceof checks", () => {
     const e = new BotTokenMaterializeError("x", "locked");
     expect(e).toBeInstanceOf(Error);

--- a/src/telegram/materialize-bot-token.ts
+++ b/src/telegram/materialize-bot-token.ts
@@ -135,14 +135,19 @@ export async function materializeBotToken(opts: MaterializeOpts = {}): Promise<s
   }
 
   // Step 4 — vault reference. Try broker first, then direct decrypt fallback.
+  // Resolve ONLY this one key. We pass a MINIMAL config — just `vault` (so the
+  // broker socket path still resolves) and the ref carried in the bot_token
+  // slot — deliberately WITHOUT spreading `...config`. Spreading the full
+  // config makes collectVaultRefs() see every top-level `vault:` ref (e.g.
+  // litellm.admin_key, google_workspace.google_client_secret), which are
+  // admin-only and DENIED to normal agents; resolveViaBroker then fails the
+  // whole batch (allResolved === false) even though the bot_token itself is
+  // granted. Narrowing to a single ref isolates this resolution from
+  // unrelated denied refs elsewhere in the config.
   const brokerResult = await resolveVaultReferencesViaBroker({
-    ...config,
-    // Narrow the config to just the bot_token reference so the broker only
-    // has to fetch one key (and we don't accidentally surface unrelated
-    // failures from other vault: refs in the config).
-    telegram: { ...config.telegram, bot_token: configured } as SwitchroomConfig["telegram"],
-    agents: {} as SwitchroomConfig["agents"],
-  });
+    vault: config.vault,
+    telegram: { bot_token: configured } as SwitchroomConfig["telegram"],
+  } as SwitchroomConfig);
 
   if (brokerResult.ok) {
     const resolved = brokerResult.config.telegram?.bot_token;

--- a/src/telegram/materialize-sidecar-token.ts
+++ b/src/telegram/materialize-sidecar-token.ts
@@ -98,16 +98,19 @@ export async function materializeSidecarToken(
 
   const resolveViaBroker = opts.resolveViaBroker ?? resolveVaultReferencesViaBroker;
 
-  // Narrow the config so the broker only fetches this one key (reuse the
-  // bot_token slot as the carrier, same trick as materialize-voice-key.ts).
+  // Resolve ONLY this one key. We pass a MINIMAL config — just `vault` (so the
+  // broker socket path still resolves) and the ref carried in the bot_token
+  // slot — deliberately WITHOUT spreading `...config`. Spreading the full
+  // config makes collectVaultRefs() see every top-level `vault:` ref (e.g.
+  // litellm.admin_key, google_workspace.google_client_secret), which are
+  // admin-only and DENIED to normal agents; resolveViaBroker then fails the
+  // whole batch (allResolved === false) even though voice/sidecar-token itself
+  // is granted. Narrowing to a single ref is what actually isolates this
+  // resolution from unrelated denied refs elsewhere in the config.
   const brokerResult = await resolveViaBroker({
-    ...config,
-    telegram: {
-      ...config.telegram,
-      bot_token: ref,
-    } as SwitchroomConfig["telegram"],
-    agents: {} as SwitchroomConfig["agents"],
-  });
+    vault: config.vault,
+    telegram: { bot_token: ref } as SwitchroomConfig["telegram"],
+  } as SwitchroomConfig);
 
   if (brokerResult.ok) {
     const resolved = brokerResult.config.telegram?.bot_token;

--- a/src/telegram/materialize-voice-key.ts
+++ b/src/telegram/materialize-voice-key.ts
@@ -112,16 +112,19 @@ export async function materializeVoiceKey(
 
   const resolveViaBroker = opts.resolveViaBroker ?? resolveVaultReferencesViaBroker;
 
-  // Narrow the config so the broker only fetches this one key and unrelated
-  // vault: refs elsewhere in the config can't fail this resolution.
+  // Resolve ONLY this one key. We pass a MINIMAL config — just `vault` (so the
+  // broker socket path still resolves) and the ref carried in the bot_token
+  // slot — deliberately WITHOUT spreading `...config`. Spreading the full
+  // config makes collectVaultRefs() see every top-level `vault:` ref (e.g.
+  // litellm.admin_key, google_workspace.google_client_secret), which are
+  // admin-only and DENIED to normal agents; resolveViaBroker then fails the
+  // whole batch (allResolved === false) even though the STT key itself is
+  // granted. Narrowing to a single ref is what actually isolates this
+  // resolution from unrelated denied refs elsewhere in the config.
   const brokerResult = await resolveViaBroker({
-    ...config,
-    telegram: {
-      ...config.telegram,
-      bot_token: ref,
-    } as SwitchroomConfig["telegram"],
-    agents: {} as SwitchroomConfig["agents"],
-  });
+    vault: config.vault,
+    telegram: { bot_token: ref } as SwitchroomConfig["telegram"],
+  } as SwitchroomConfig);
 
   if (brokerResult.ok) {
     const resolved = brokerResult.config.telegram?.bot_token;

--- a/telegram-plugin/tests/voice-transcribe-sidecar.test.ts
+++ b/telegram-plugin/tests/voice-transcribe-sidecar.test.ts
@@ -260,4 +260,73 @@ describe('materializeSidecarToken — vault resolution', () => {
     )
     expect(tok).toBeNull()
   })
+
+  // ── Regression: single-key isolation (voice token bug) ──
+  //
+  // resolveVaultReferencesViaBroker fails the WHOLE batch unless EVERY vault:
+  // ref resolves. Admin-only refs (litellm/master-key,
+  // google/client-secret) are correctly DENIED to a normal agent — so if the
+  // materializer passes the full config, those denials sink the resolution
+  // even though voice/sidecar-token itself is granted. The fix passes a
+  // MINIMAL config carrying only the one ref. These tests fail against the
+  // old `...config` spread.
+
+  function collectRefs(v: unknown, out: Set<string>): void {
+    if (typeof v === 'string' && v.startsWith('vault:')) out.add(v.slice('vault:'.length).split('#')[0])
+    else if (Array.isArray(v)) for (const i of v) collectRefs(i, out)
+    else if (v !== null && typeof v === 'object') for (const val of Object.values(v as Record<string, unknown>)) collectRefs(val, out)
+  }
+
+  /** Resolver stub with the real batch semantics: denies unless every collected ref is granted. */
+  function makeBatchResolver(
+    granted: Record<string, string>,
+    onCall?: (refs: Set<string>) => void,
+  ): typeof resolveVaultReferencesViaBroker {
+    return (async (config: SwitchroomConfig) => {
+      const refs = new Set<string>()
+      collectRefs(config, refs)
+      onCall?.(refs)
+      for (const r of refs) {
+        if (granted[`vault:${r}`] === undefined) {
+          return { ok: false, reason: 'denied' as const }
+        }
+      }
+      const resolved = granted[config.telegram?.bot_token ?? '']
+      return {
+        ok: true,
+        config: { ...config, telegram: { ...config.telegram, bot_token: resolved } },
+      }
+    }) as unknown as typeof resolveVaultReferencesViaBroker
+  }
+
+  const CONFIG_WITH_ADMIN_REFS = {
+    telegram: { bot_token: 'vault:tg/bot' },
+    litellm: { admin_key: 'vault:litellm/master-key' },
+    google_workspace: { google_client_secret: 'vault:google/client-secret' },
+    agents: { klanker: { some_key: 'vault:per-agent/secret' } },
+    vault: { path: '~/.switchroom/vault.enc' },
+  } as unknown as SwitchroomConfig
+
+  it('resolves the sidecar token even when the config carries admin-only vault refs the broker DENIES', async () => {
+    const tok = await materializeSidecarToken({
+      config: CONFIG_WITH_ADMIN_REFS,
+      env: {},
+      resolveViaBroker: makeBatchResolver({ 'vault:voice/sidecar-token': 'deadbeefcafe' }),
+    })
+    expect(tok).toBe('deadbeefcafe')
+  })
+
+  it('invokes the resolver with a config containing exactly ONE vault ref (the sidecar token)', async () => {
+    let seen: Set<string> | null = null
+    await materializeSidecarToken({
+      config: CONFIG_WITH_ADMIN_REFS,
+      env: {},
+      resolveViaBroker: makeBatchResolver(
+        { 'vault:voice/sidecar-token': 'deadbeefcafe' },
+        (refs) => { seen = refs },
+      ),
+    })
+    expect(seen).not.toBeNull()
+    expect([...seen!]).toEqual(['voice/sidecar-token'])
+  })
 })

--- a/telegram-plugin/tests/voice-transcribe.test.ts
+++ b/telegram-plugin/tests/voice-transcribe.test.ts
@@ -280,6 +280,83 @@ describe('materializeVoiceKey — vault resolution', () => {
     )
     expect(key).toBeNull()
   })
+
+  // ── Regression: single-key isolation (voice token bug) ──
+  //
+  // The batch resolver (resolveVaultReferencesViaBroker) fails the WHOLE
+  // resolution unless EVERY vault: ref it finds resolves. Admin-only refs
+  // like litellm.admin_key / google_workspace.google_client_secret are
+  // (correctly) DENIED to a normal agent, so if the materializer passes the
+  // full config those denials sink the resolution even though openai/api-key
+  // itself is granted. The fix passes a MINIMAL config carrying only the one
+  // ref. These tests would fail against the old `...config` spread.
+
+  /** Regex of every vault: ref the resolver sees; denies if it sees any admin-only key. */
+  function collectRefs(v: unknown, out: Set<string>): void {
+    if (typeof v === 'string' && v.startsWith('vault:')) out.add(v.slice('vault:'.length).split('#')[0])
+    else if (Array.isArray(v)) for (const i of v) collectRefs(i, out)
+    else if (v !== null && typeof v === 'object') for (const val of Object.values(v as Record<string, unknown>)) collectRefs(val, out)
+  }
+
+  /**
+   * A resolver stub with the SAME batch semantics as the real one: it fails
+   * (denied) unless every ref it collects is in `granted`. Mirrors how a real
+   * broker denies admin-only keys to a normal agent.
+   */
+  function makeBatchResolver(
+    granted: Record<string, string>,
+    onCall?: (refs: Set<string>) => void,
+  ): typeof resolveVaultReferencesViaBroker {
+    return (async (config: SwitchroomConfig) => {
+      const refs = new Set<string>()
+      collectRefs(config, refs)
+      onCall?.(refs)
+      for (const r of refs) {
+        if (granted[`vault:${r}`] === undefined) {
+          return { ok: false, reason: 'denied' as const }
+        }
+      }
+      const resolvedToken = granted[config.telegram?.bot_token ?? '']
+      return {
+        ok: true,
+        config: { ...config, telegram: { ...config.telegram, bot_token: resolvedToken } },
+      }
+    }) as unknown as typeof resolveVaultReferencesViaBroker
+  }
+
+  const CONFIG_WITH_ADMIN_REFS = {
+    telegram: { bot_token: 'vault:tg/bot' },
+    litellm: { admin_key: 'vault:litellm/master-key' },
+    google_workspace: { google_client_secret: 'vault:google/client-secret' },
+    agents: { klanker: { some_key: 'vault:per-agent/secret' } },
+    vault: { path: '~/.switchroom/vault.enc' },
+  } as unknown as SwitchroomConfig
+
+  it('resolves the STT key even when the config carries admin-only vault refs the broker DENIES', async () => {
+    const key = await materializeVoiceKey({
+      apiKeyRef: 'vault:openai/api-key',
+      config: CONFIG_WITH_ADMIN_REFS,
+      env: {},
+      // ONLY openai/api-key is granted; litellm/google/per-agent all DENY.
+      resolveViaBroker: makeBatchResolver({ 'vault:openai/api-key': 'sk-granted-key' }),
+    })
+    expect(key).toBe('sk-granted-key')
+  })
+
+  it('invokes the resolver with a config containing exactly ONE vault ref (the STT key)', async () => {
+    let seen: Set<string> | null = null
+    await materializeVoiceKey({
+      apiKeyRef: 'vault:openai/api-key',
+      config: CONFIG_WITH_ADMIN_REFS,
+      env: {},
+      resolveViaBroker: makeBatchResolver(
+        { 'vault:openai/api-key': 'sk-granted-key' },
+        (refs) => { seen = refs },
+      ),
+    })
+    expect(seen).not.toBeNull()
+    expect([...seen!]).toEqual(['openai/api-key'])
+  })
 })
 
 describe('voice-in — no plaintext key file is read', () => {


### PR DESCRIPTION
## Root cause

The gateway resolves the voice sidecar token (and the STT key, and the bot token) through `resolveVaultReferencesViaBroker`, which runs `collectVaultRefs()` over the ENTIRE passed config and returns `{ok:false, reason:"denied"}` unless **every** `vault:` ref resolves (`allResolved = resolvedCount === refs.size`, `src/vault/resolver.ts` ~L358).

All three materializers passed the full config via `...config`, wiping only `agents: {}`. That wipe removes per-agent refs but the spread still carries **top-level** admin-only refs:

- `litellm.admin_key` → `vault:litellm/master-key`
- `google_workspace.google_client_secret` → `vault:google/client-secret`

Both are correctly DENIED to a normal (non-admin) agent, so the batch always fails on them and the token never resolves — even though `voice/sidecar-token` itself is granted. Proven from an agent container: `vault get voice/sidecar-token` → OK, `vault get litellm/master-key` / `vault get google/client-secret` → DENIED. The comment in `materialize-voice-key.ts` claimed it narrowed the config "so unrelated vault: refs elsewhere can't fail this resolution" — but the code never achieved that.

## Fix

Pass a **minimal** config to the broker — just `vault` (so broker socket resolution still works) and the single ref carried in the `telegram.bot_token` slot — dropping the `...config` spread so `collectVaultRefs` finds exactly one key:

```ts
await resolveViaBroker({
  vault: config.vault,
  telegram: { bot_token: ref },
} as SwitchroomConfig)
```

`config.vault` holds the broker socket / vault-file path, not a secret ref, so it adds no vault key. An unrelated denied ref elsewhere in the config can no longer fail the resolution.

Applied to all three materializers for consistency:
- `src/telegram/materialize-sidecar-token.ts`
- `src/telegram/materialize-voice-key.ts`
- `src/telegram/materialize-bot-token.ts` (currently dodges the bug via a per-agent `.env` side-channel, but its broker fallback path was latently broken)

The return-shape handling (`brokerResult.config.telegram?.bot_token`), the literal-token short-circuit, and the direct-decrypt fallback are all preserved. The batch semantics of `resolveVaultReferencesViaBroker` are **unchanged** — other callers rely on them.

## Regression test (the one the existing tests missed)

Added to `voice-transcribe.test.ts`, `voice-transcribe-sidecar.test.ts`, and `materialize-bot-token.test.ts`. Each gives the materializer a config that carries admin-only vault refs which the (stubbed) broker resolver DENIES with real batch semantics, and asserts:
1. the token still resolves (single-key isolation works), and
2. the resolver is invoked with a config containing **exactly one** vault ref.

Confirmed these fail against the old `...config` spread and pass with the fix.

## Verification

- `tsc --noEmit` clean
- `npm run lint` chain clean (no grammY type errors — none on main either)
- `bun test` voice suites: 36 pass / 0 fail
- `vitest run materialize-bot-token.test.ts`: 10 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)