### PR TITLE
feat(voice-out): speech-normalize TTS text and send one voice note per response

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -49,9 +49,9 @@ import {
 } from '../sticker-aliases.js'
 import { transcribeViaWhisper } from '../voice-transcribe.js'
 import { transcribeViaSidecar } from '../voice-transcribe-sidecar.js'
-import { synthesizeViaSidecar, SIDECAR_TTS_MAX_CHARS, chunkTtsText } from '../voice-synthesize-sidecar.js'
+import { synthesizeViaSidecar, chunkTtsText } from '../voice-synthesize-sidecar.js'
+import { normalizeForSpeech } from '../voice-normalize-text.js'
 import { synthesizeViaOpenAi } from '../voice-synthesize.js'
-import { stripMarkdown } from '../card-format.js'
 import {
   createTelegraphAccount,
   createTelegraphPage,
@@ -977,14 +977,19 @@ type Access = {
    *  when the host voice verdict is local (SWITCHROOM_VOICE_ENGINE ===
    *  'local'); 'openai' is an honest-exception cloud path gated on an
    *  `api_key` vault ref. Voice is best-effort and fully non-fatal — any
-   *  TTS error falls back to the text reply. Replies longer than
-   *  `max_chars` (default 600) always fall back to text-only. Off by
-   *  default. */
+   *  TTS error falls back to the text reply. ONE voice note per response:
+   *  the reply is speech-normalized (markdown/symbols stripped) and, for the
+   *  kokoro sidecar, sent in a SINGLE /tts call that returns one concatenated
+   *  file. Off by default. */
   voice_out?: {
     enabled?: boolean
     engine?: 'kokoro' | 'openai'
     voice?: string
     reply_mode?: 'voice+text' | 'voice-only'
+    /** OpenAI-engine only: per-voice-note chunk size (default 600) used to
+     *  split a long reply across sequential notes, since OpenAI's TTS input
+     *  has a hard cap. Ignored by the kokoro path, which sends the whole
+     *  reply in one call (the sidecar owns length + concatenation). */
     max_chars?: number
     api_key?: string
   }
@@ -8172,14 +8177,15 @@ function redactOutboundText(text: string, site: string): string {
 
 /** Default per-voice-note chunk size (chars). A long reply is split into
  *  sequential voice notes of roughly this size on sentence/paragraph
- *  boundaries — NOT truncated. Mirrors the schema default. The Kokoro
- *  sidecar's hard per-request cap (VOICE_TTS_MAX_CHARS, 1200) is the upper
- *  bound; any configured value above it is clamped down. */
+ *  boundaries. Only the OpenAI (cloud) engine still uses this — the kokoro
+ *  sidecar now takes the whole reply in one call and returns a single note. */
 const VOICE_OUT_DEFAULT_CHUNK_CHARS = 600
 
-/** Hard ceiling for a single TTS request, matching the sidecar's
- *  VOICE_TTS_MAX_CHARS (server.py). Voice-note chunks never exceed this. */
-const VOICE_OUT_HARD_CHUNK_CAP = SIDECAR_TTS_MAX_CHARS
+/** Hard ceiling for a single OpenAI TTS request. OpenAI's TTS input caps at
+ *  4096 chars, so client-side chunks for that engine never exceed this; the
+ *  reply is spoken across sequential notes when it's longer. (The kokoro path
+ *  no longer chunks — the sidecar owns length and returns one file.) */
+const VOICE_OUT_HARD_CHUNK_CAP = 4096
 
 type VoiceOutAccess = NonNullable<Access['voice_out']>
 
@@ -8194,11 +8200,16 @@ type VoiceOutAccess = NonNullable<Access['voice_out']>
  * NOT require a local verdict.
  *
  * Returns null when voice-out is off / not applicable; otherwise a plan the
- * caller acts on. `ttsChunks` is markdown-stripped plain text split into
- * sequential voice-note-sized pieces (sentence/paragraph boundaries) — a
- * LONG reply is spoken across multiple ordered voice notes, never truncated
- * to text-only (Ken is often on a bike/driving and can't read the screen).
- * `max_chars` is the per-note chunk size, not a cutoff.
+ * caller acts on. `ttsChunks` is speech-normalized plain text (markdown and
+ * TTS-mispronounced symbols removed — see normalizeForSpeech).
+ *
+ * ONE voice note per response: the kokoro (local sidecar) path now sends the
+ * WHOLE normalized reply to `/tts` in a SINGLE call — the sidecar chunks +
+ * concatenates internally on the GPU and returns a single ogg/opus file — so
+ * `ttsChunks` is a single element for kokoro. `max_chars` is no longer a hard
+ * client-side splitter for kokoro; it's retired for that path (the sidecar
+ * owns length). The openai (cloud) engine keeps client-side chunking because
+ * OpenAI's TTS input has its own hard cap; each chunk is one voice note.
  */
 function resolveVoiceOutPlan(
   voiceOut: VoiceOutAccess | undefined,
@@ -8229,20 +8240,31 @@ function resolveVoiceOutPlan(
     if (voiceEngine !== 'local') return null
   }
 
-  // Plain-text TTS input: strip markdown REGARDLESS of mode so the engine
-  // never reads out backticks / asterisks / link syntax. Collapse runs of
-  // whitespace so multi-line prose speaks cleanly.
-  const ttsText = stripMarkdown(replyText).replace(/\s+/g, ' ').trim()
+  // Speech-normalized TTS input: strip markdown AND translate/drop the
+  // symbols TTS mispronounces (~, backticks, arrows, tables, code fences,
+  // link URLs) REGARDLESS of mode so the engine reads clean prose. Applied
+  // for BOTH engines — the older partial stripMarkdown pass leaked `~`,
+  // code fences and arrows.
+  const ttsText = normalizeForSpeech(replyText)
   if (ttsText.length === 0) return null
 
-  // Per-voice-note chunk size, clamped to the engine's hard cap. A long
-  // reply becomes several ordered voice notes instead of a text-only
-  // fallback.
-  const chunkChars = Math.min(
-    voiceOut.max_chars ?? VOICE_OUT_DEFAULT_CHUNK_CHARS,
-    VOICE_OUT_HARD_CHUNK_CAP,
-  )
-  const ttsChunks = chunkTtsText(ttsText, chunkChars)
+  // ONE voice note for kokoro: the sidecar accepts arbitrarily long text and
+  // returns a single concatenated ogg/opus file, so we send the whole reply
+  // in one call — no client-side splitting, no multi-sendVoice. `max_chars`
+  // is retired as a hard splitter here.
+  //
+  // OpenAI still needs client-side chunking (its TTS input has a hard cap),
+  // so for that engine we split at the engine cap; each chunk is one note.
+  let ttsChunks: string[]
+  if (engine === 'kokoro') {
+    ttsChunks = [ttsText]
+  } else {
+    const chunkChars = Math.min(
+      voiceOut.max_chars ?? VOICE_OUT_DEFAULT_CHUNK_CHARS,
+      VOICE_OUT_HARD_CHUNK_CAP,
+    )
+    ttsChunks = chunkTtsText(ttsText, chunkChars)
+  }
   if (ttsChunks.length === 0) return null
 
   return {
@@ -8672,12 +8694,14 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   const sentIds: number[] = []
 
   // Outbound TTS synthesis (PR-C2). Done BEFORE the text send so a
-  // voice-only reply can suppress the text chunks on success. A LONG reply
-  // is synthesized into SEVERAL ordered voice notes (one per chunk) instead
-  // of falling back to text-only — Ken is often on a bike/driving and can't
-  // read the screen, so the full answer must be SPOKEN. Best-effort: each
-  // chunk that fails to synthesize is skipped; if NOTHING synthesizes the
-  // text path proceeds unchanged so the answer is never dropped.
+  // voice-only reply can suppress the text chunks on success. ONE voice note
+  // per response for the kokoro path (ttsChunks is a single element — the
+  // whole normalized reply — synthesized in one /tts call). The OpenAI path
+  // may still produce several ordered notes (one per chunk) because of its
+  // input cap. Ken is often on a bike/driving and can't read the screen, so
+  // the full answer must be SPOKEN. Best-effort: a chunk that fails to
+  // synthesize is skipped; if NOTHING synthesizes the text path proceeds
+  // unchanged so the answer is never dropped.
   const voiceOggs: Uint8Array[] = []
   if (voiceOutPlan != null) {
     for (const chunkText of voiceOutPlan.ttsChunks) {

--- a/telegram-plugin/tests/voice-normalize-text.test.ts
+++ b/telegram-plugin/tests/voice-normalize-text.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for normalizeForSpeech — the speech-normalization pass applied
+ * to a reply BEFORE it is synthesized to a voice note. Covers every case the
+ * operator reported (tilde, asterisks, backticks, headings, links, code
+ * fences) plus the documented behavioural choices.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { normalizeForSpeech } from '../voice-normalize-text.js'
+
+describe('normalizeForSpeech — reported markdown/symbol cases', () => {
+  it('drops stray tildes (never spoken as "tilde")', () => {
+    expect(normalizeForSpeech('It costs ~5 dollars')).toBe('It costs 5 dollars')
+    expect(normalizeForSpeech('done ~ ok')).toBe('done ok')
+  })
+
+  it('strips bold/italic asterisks and underscores, keeping the words', () => {
+    expect(normalizeForSpeech('This is **bold** text')).toBe('This is bold text')
+    expect(normalizeForSpeech('This is *italic* text')).toBe('This is italic text')
+    expect(normalizeForSpeech('This is _emphasis_ text')).toBe('This is emphasis text')
+    expect(normalizeForSpeech('***all*** three')).toBe('all three')
+  })
+
+  it('strips strikethrough ~~text~~ to plain text', () => {
+    expect(normalizeForSpeech('~~gone~~ kept')).toBe('gone kept')
+  })
+
+  it('removes backticks from inline code but keeps the content', () => {
+    expect(normalizeForSpeech('run `npm test` now')).toBe('run npm test now')
+  })
+
+  it('strips headings markers', () => {
+    expect(normalizeForSpeech('# Summary\nAll good')).toBe('Summary All good')
+    expect(normalizeForSpeech('### Deep heading')).toBe('Deep heading')
+  })
+
+  it('speaks link text and drops the URL', () => {
+    expect(normalizeForSpeech('see [the docs](https://example.com/x) here')).toBe(
+      'see the docs here',
+    )
+  })
+
+  it('drops a fenced code block and leaves a spoken placeholder', () => {
+    const input = 'Here is code:\n```js\nconst x = 1\nconsole.log(x)\n```\nDone.'
+    const out = normalizeForSpeech(input)
+    expect(out).toContain('code block omitted')
+    expect(out).not.toContain('const x')
+    expect(out).not.toContain('```')
+    expect(out).toContain('Done.')
+  })
+})
+
+describe('normalizeForSpeech — additional structures', () => {
+  it('converts list bullets and numbers to prose pauses', () => {
+    const out = normalizeForSpeech('Steps:\n- first\n- second\n1. third')
+    expect(out).not.toMatch(/[-*+]\s/)
+    expect(out).not.toMatch(/^\d+\./)
+    expect(out).toContain('first')
+    expect(out).toContain('second')
+    expect(out).toContain('third')
+  })
+
+  it('strips blockquote markers', () => {
+    expect(normalizeForSpeech('> quoted line')).toBe('quoted line')
+  })
+
+  it('turns tables into prose (no pipes or separator rows)', () => {
+    const table = '| A | B |\n| --- | --- |\n| 1 | 2 |'
+    const out = normalizeForSpeech(table)
+    expect(out).not.toContain('|')
+    expect(out).not.toContain('---')
+    expect(out).toContain('A')
+    expect(out).toContain('B')
+  })
+
+  it('converts arrows to the word "to"', () => {
+    expect(normalizeForSpeech('build -> deploy')).toBe('build to deploy')
+    expect(normalizeForSpeech('a => b')).toBe('a to b')
+    expect(normalizeForSpeech('x → y')).toBe('x to y')
+  })
+
+  it('replaces bare and autolink URLs with "a link"', () => {
+    expect(normalizeForSpeech('go to https://example.com now')).toBe('go to a link now')
+    expect(normalizeForSpeech('go to <https://example.com>')).toBe('go to a link')
+  })
+
+  it('drops images to their alt text', () => {
+    expect(normalizeForSpeech('![a cat](x.png) sits')).toBe('a cat sits')
+  })
+
+  it('collapses newlines and whitespace into sentence flow', () => {
+    expect(normalizeForSpeech('Line one.\n\nLine two.')).toBe('Line one. Line two.')
+    expect(normalizeForSpeech('a   b\nc')).toBe('a b c')
+  })
+
+  it('expands a minimal, safe set of abbreviations', () => {
+    expect(normalizeForSpeech('use it, e.g. here')).toBe('use it, for example, here')
+    expect(normalizeForSpeech('the API, i.e. the interface')).toBe(
+      'the API, that is, the interface',
+    )
+    expect(normalizeForSpeech('cats, dogs, etc.')).toBe('cats, dogs, and so on')
+  })
+
+  it('collapses excessive punctuation', () => {
+    expect(normalizeForSpeech('really?!?!')).toBe('really!')
+    expect(normalizeForSpeech('wow!!!')).toBe('wow!')
+  })
+})
+
+describe('normalizeForSpeech — conservative, does not mangle real words', () => {
+  it('leaves plain prose untouched', () => {
+    expect(normalizeForSpeech('The quick brown fox jumps.')).toBe(
+      'The quick brown fox jumps.',
+    )
+  })
+
+  it('preserves an underscore inside an identifier-like word', () => {
+    // A lone mid-word underscore is not emphasis; keep the token intact.
+    expect(normalizeForSpeech('the my_var name')).toBe('the my_var name')
+  })
+
+  it('returns empty for empty/whitespace input', () => {
+    expect(normalizeForSpeech('')).toBe('')
+    expect(normalizeForSpeech('   \n  ')).toBe('')
+  })
+})

--- a/telegram-plugin/tests/voice-out-one-send.test.ts
+++ b/telegram-plugin/tests/voice-out-one-send.test.ts
@@ -1,0 +1,105 @@
+/**
+ * One-voice-note-per-response contract test for the kokoro (local sidecar)
+ * voice-out path.
+ *
+ * The gateway send path (gateway.ts resolveVoiceOutPlan → synth loop →
+ * sendVoice loop) now, for the kokoro engine, sends the WHOLE speech-
+ * normalized reply to /tts in a SINGLE call and issues a SINGLE sendVoice —
+ * the sidecar chunks + concatenates internally and returns one ogg/opus file.
+ *
+ * gateway.ts is a large module with import-time side effects, so rather than
+ * import resolveVoiceOutPlan (private) we reproduce the exact decision it
+ * makes for the kokoro path and assert the observable contract: for a LONG
+ * reply, normalization yields the single text sent to /tts, synthesis issues
+ * exactly ONE /tts fetch, and exactly ONE sendVoice is issued.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { normalizeForSpeech } from '../voice-normalize-text.js'
+import { synthesizeViaSidecar } from '../voice-synthesize-sidecar.js'
+
+const OGG_BYTES = new Uint8Array([0x4f, 0x67, 0x67, 0x53]) // OggS magic
+
+/** Build the kokoro voice-note chunks exactly as resolveVoiceOutPlan does:
+ *  normalize the whole reply, then a SINGLE element (no client-side split). */
+function kokoroTtsChunks(replyText: string): string[] {
+  const ttsText = normalizeForSpeech(replyText)
+  if (ttsText.length === 0) return []
+  return [ttsText] // kokoro: one call, one note
+}
+
+describe('voice-out kokoro path — ONE synth call, ONE sendVoice', () => {
+  it('splits a long markdown reply into exactly one voice-note chunk', () => {
+    const longReply = Array.from(
+      { length: 40 },
+      (_, i) => `## Section ${i}\nSome **bold** prose with \`code\` and a [link](https://x.com/${i}).`,
+    ).join('\n\n')
+    expect(longReply.length).toBeGreaterThan(1200) // would have been multi-chunk before
+
+    const chunks = kokoroTtsChunks(longReply)
+    expect(chunks).toHaveLength(1)
+    // Normalization is applied: no markdown/symbols leak into the spoken text.
+    expect(chunks[0]).not.toContain('##')
+    expect(chunks[0]).not.toContain('`')
+    expect(chunks[0]).not.toContain('**')
+    expect(chunks[0]).not.toContain('https://')
+  })
+
+  it('issues exactly ONE /tts fetch for the whole long reply', async () => {
+    const longReply = 'A '.repeat(2000) // ~4000 chars, well over the old 1200 cap
+    const chunks = kokoroTtsChunks(longReply)
+    expect(chunks).toHaveLength(1)
+
+    let fetchCalls = 0
+    const countingFetch = (async (_url: string, init: RequestInit) => {
+      fetchCalls++
+      // The single call must carry the full normalized text.
+      const body = JSON.parse(init.body as string) as { text: string }
+      expect(body.text.length).toBeGreaterThan(1200)
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () =>
+          OGG_BYTES.buffer.slice(OGG_BYTES.byteOffset, OGG_BYTES.byteOffset + OGG_BYTES.byteLength),
+        text: async () => '',
+        headers: new Headers(),
+      }
+    }) as unknown as typeof fetch
+
+    // Simulate the gateway synth loop over the (single) chunk set.
+    const voiceOggs: Uint8Array[] = []
+    for (const chunkText of chunks) {
+      const r = await synthesizeViaSidecar({ token: 'tok', text: chunkText, fetchImpl: countingFetch })
+      if (r.ok) voiceOggs.push(r.audio)
+    }
+
+    expect(fetchCalls).toBe(1) // ONE synth call
+    expect(voiceOggs).toHaveLength(1) // ONE ogg → ONE sendVoice
+  })
+
+  it('issues exactly ONE sendVoice (simulating the gateway send loop)', async () => {
+    const chunks = kokoroTtsChunks('Hello **world**, this is a `test` reply.\n\nSecond paragraph.')
+    expect(chunks).toHaveLength(1)
+
+    const okFetch = (async () => ({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () =>
+        OGG_BYTES.buffer.slice(OGG_BYTES.byteOffset, OGG_BYTES.byteOffset + OGG_BYTES.byteLength),
+      text: async () => '',
+      headers: new Headers(),
+    })) as unknown as typeof fetch
+
+    const voiceOggs: Uint8Array[] = []
+    for (const chunkText of chunks) {
+      const r = await synthesizeViaSidecar({ token: 'tok', text: chunkText, fetchImpl: okFetch })
+      if (r.ok) voiceOggs.push(r.audio)
+    }
+
+    let sendVoiceCalls = 0
+    for (const _ogg of voiceOggs) {
+      sendVoiceCalls++ // gateway: one sendVoice per ogg
+    }
+    expect(sendVoiceCalls).toBe(1)
+  })
+})

--- a/telegram-plugin/voice-normalize-text.ts
+++ b/telegram-plugin/voice-normalize-text.ts
@@ -1,0 +1,125 @@
+/**
+ * Speech normalization for OUTBOUND voice replies (voice-out).
+ *
+ * The problem: the agent's reply is Markdown-flavoured text. A TTS engine
+ * (Kokoro sidecar or OpenAI) reads it LITERALLY — so `~about 3`, `**bold**`,
+ * `` `code` ``, `# Heading`, `[label](https://…)`, and code fences all get
+ * spoken as "tilde", "asterisk asterisk", "backtick", "hash", or the raw URL
+ * read character-by-character. That is exactly the operator feedback: the
+ * voice is good but it pronounces the markup.
+ *
+ * `normalizeForSpeech` is a PURE string→string pass applied to the reply text
+ * BEFORE it is handed to any TTS engine. It replaces the older, partial
+ * `stripMarkdown` pass on the voice-out path (that one left `~`, code fences,
+ * tables, and arrows leaking through). It is deliberately conservative: the
+ * goal is natural prose, not aggressive rewriting — when in doubt it leaves
+ * real words alone.
+ *
+ * Documented behavioural choices (the "sensible defaults" the task allows):
+ *   - Inline code (`` `x` ``): the backticks are dropped, the CONTENT is
+ *     kept and spoken. Short inline code is usually a word/identifier the
+ *     listener wants to hear.
+ *   - Fenced code blocks (``` … ```): DROPPED entirely and replaced with a
+ *     short spoken placeholder ("(code block omitted)"). Reading a block of
+ *     code aloud is noise; a listener on a bike can't act on it anyway.
+ *   - Links `[text](url)`: spoken as just `text`; the URL is dropped. A bare
+ *     autolink `<https://…>` or a raw URL is replaced with "a link" so the
+ *     engine never spells out a URL character-by-character.
+ *   - `~` is DROPPED (not read as "tilde", not expanded to "about") — it is
+ *     ambiguous (strikethrough marker vs. approx) and dropping is the safest
+ *     choice that never mangles a real word.
+ *   - `->` / `=>` / `→` become the spoken word "to".
+ *   - A tiny, well-tested set of trivially-safe abbreviations is expanded
+ *     ("e.g." → "for example", "i.e." → "that is", "etc." → "and so on").
+ *     Anything ambiguous is left alone.
+ */
+
+/** Replace a fenced code block with a spoken placeholder. */
+const CODE_BLOCK_PLACEHOLDER = 'code block omitted'
+
+/**
+ * Convert a Markdown/plain reply into clean text for a TTS engine.
+ * Pure and deterministic — same input always yields the same output.
+ */
+export function normalizeForSpeech(input: string): string {
+  if (!input) return ''
+  let s = input.replace(/\r\n?/g, '\n')
+
+  // 1. Fenced code blocks first (```lang … ``` or ~~~ … ~~~) — drop the
+  //    whole block before any inline processing can see its contents.
+  s = s.replace(/(^|\n)[ \t]*(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n[ \t]*\2[ \t]*(?=\n|$)/g, `$1${CODE_BLOCK_PLACEHOLDER}.`)
+  // An unterminated fence (opening ``` with no close) — drop to end.
+  s = s.replace(/(^|\n)[ \t]*(`{3,}|~{3,})[^\n]*\n[\s\S]*$/g, `$1${CODE_BLOCK_PLACEHOLDER}.`)
+
+  // 2. Images ![alt](url) → alt text (or drop when alt is empty).
+  s = s.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+
+  // 3. Links [text](url) → text ; drop the URL entirely.
+  s = s.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+
+  // 4. Autolinks <https://…> and bare URLs → "a link" (never spell a URL).
+  s = s.replace(/<https?:\/\/[^>\s]+>/gi, 'a link')
+  s = s.replace(/\bhttps?:\/\/[^\s)]+/gi, 'a link')
+
+  // 5. Inline code `x` → x (keep content, drop backticks). Run before the
+  //    generic backtick sweep so paired spans are handled cleanly.
+  s = s.replace(/`([^`\n]+)`/g, '$1')
+  // Any residual backticks → drop.
+  s = s.replace(/`/g, '')
+
+  // 6. Emphasis markers. Paired forms first (longest marker first), then
+  //    strip residual markup-by-construction doubles. A LONE `*` or `_` in
+  //    the middle of maths/words is left alone (see step 11).
+  s = s.replace(/\*\*\*(.+?)\*\*\*/g, '$1')
+  s = s.replace(/___(.+?)___/g, '$1')
+  s = s.replace(/\*\*(.+?)\*\*/g, '$1')
+  s = s.replace(/__(.+?)__/g, '$1')
+  s = s.replace(/\*(.+?)\*/g, '$1')
+  s = s.replace(/(?<![A-Za-z0-9])_(.+?)_(?![A-Za-z0-9])/g, '$1')
+  // Strikethrough ~~text~~ → text.
+  s = s.replace(/~~(.+?)~~/g, '$1')
+
+  // 7. Leading block markup, per line: headings, blockquotes, list markers.
+  //    List bullets/numbers become a natural sentence pause rather than a
+  //    spoken "dash" / "1 dot".
+  s = s.replace(/^[ \t]{0,3}#{1,6}[ \t]+/gm, '')
+  s = s.replace(/^[ \t]{0,3}>[ \t]?/gm, '')
+  s = s.replace(/^[ \t]{0,3}[-*+][ \t]+/gm, '')
+  s = s.replace(/^[ \t]{0,3}\d+[.)][ \t]+/gm, '')
+
+  // 8. Horizontal rules (---, ___, ***) on their own line → drop.
+  s = s.replace(/^[ \t]{0,3}([-_*])\1{2,}[ \t]*$/gm, '')
+
+  // 9. Table syntax: drop pipes and separator rows so tables read as prose.
+  s = s.replace(/^[ \t]*\|?[ \t]*:?-{2,}:?[ \t]*(\|[ \t]*:?-{2,}:?[ \t]*)+\|?[ \t]*$/gm, '')
+  s = s.replace(/\|/g, ' ')
+
+  // 10. Arrows → the spoken word "to".
+  s = s.replace(/[=-]>/g, ' to ')
+  s = s.replace(/[→⇒]/g, ' to ')
+
+  // 11. Stray tildes (approx / leftover markers) → drop. Ambiguous; dropping
+  //     is the safe choice that never mangles a real word.
+  s = s.replace(/~/g, '')
+
+  // 12. Trivially-safe abbreviation expansions (case-insensitive, only at a
+  //     word boundary followed by space/comma). Kept minimal on purpose.
+  s = s.replace(/\be\.g\.,?/gi, 'for example,')
+  s = s.replace(/\bi\.e\.,?/gi, 'that is,')
+  s = s.replace(/\betc\./gi, 'and so on')
+
+  // 13. Collapse excessive punctuation the engine would over-emphasise.
+  s = s.replace(/([!?.]){2,}/g, '$1')
+
+  // 14. Whitespace → sentence flow. Blank lines become a sentence break so
+  //     paragraphs don't run together; everything else collapses to a single
+  //     space.
+  s = s.replace(/[ \t]*\n[ \t]*\n[ \t]*/g, '. ')
+  s = s.replace(/\s*\n\s*/g, ' ')
+  s = s.replace(/[ \t]{2,}/g, ' ')
+  // Tidy artifacts from the paragraph→". " substitution (". ." → ". ").
+  s = s.replace(/\.\s*\.(\s|$)/g, '.$1')
+  s = s.replace(/\s+([,.!?;:])/g, '$1')
+
+  return s.trim()
+}

--- a/telegram-plugin/voice-synthesize-sidecar.ts
+++ b/telegram-plugin/voice-synthesize-sidecar.ts
@@ -29,11 +29,16 @@
 /** Default loopback base URL for the sidecar (host-network agent). */
 export const DEFAULT_SIDECAR_BASE_URL = 'http://127.0.0.1:18900'
 
-/** The sidecar caps text at VOICE_TTS_MAX_CHARS (default 1200, server.py);
- *  reject obviously-oversized input before the round-trip. The gateway's
- *  own `voice_out.max_chars` (default 600) is the user-facing gate; this is
- *  a defence-in-depth ceiling matching the sidecar's hard limit. */
-export const SIDECAR_TTS_MAX_CHARS = 1200
+/** Defence-in-depth ceiling on a SINGLE /tts request.
+ *
+ *  The sidecar now accepts arbitrarily long text and chunks + concatenates
+ *  internally on the GPU, returning a single ogg/opus file (one voice note
+ *  per response). This client cap is therefore only a sanity ceiling against
+ *  a pathological reply, not a per-note splitter — the gateway sends the
+ *  whole normalized reply in one call. Kept comfortably above any realistic
+ *  chat reply. (Contract with docker/voice-sidecar/server.py: endpoint path,
+ *  X-Voice-Token header, and {text, voice?, format?} JSON shape UNCHANGED.) */
+export const SIDECAR_TTS_MAX_CHARS = 100_000
 
 /**
  * Split already-stripped plain text into sequential TTS chunks, each ≤

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -246,6 +246,11 @@ export default defineConfig({
       // voice-synthesize-sidecar.test.ts uses bun:test (PR-C2 local TTS) —
       // excluded here, run via test:bun.
       "**/telegram-plugin/tests/voice-synthesize-sidecar.test.ts",
+      // voice-normalize-text.test.ts + voice-out-one-send.test.ts use
+      // bun:test (voice-out speech normalization + one-send) — excluded
+      // here, run via test:bun.
+      "**/telegram-plugin/tests/voice-normalize-text.test.ts",
+      "**/telegram-plugin/tests/voice-out-one-send.test.ts",
       // telegraph.test.ts uses bun:test (#579 Telegraph Instant View) —
       // excluded here, run via test:bun.
       "**/telegram-plugin/tests/telegraph.test.ts",


### PR DESCRIPTION
## Summary
Two operator-reported voice-output fixes:

1. **Speech normalization** — new pure `normalizeForSpeech` (`telegram-plugin/voice-normalize-text.ts`) applied to the reply **before** TTS for both engines. It strips/converts markdown and the symbols TTS mispronounces so the engine reads clean prose instead of saying "tilde", "asterisk", "backtick", "hash", or spelling out URLs:
   - bold/italic/strikethrough markers, inline code (backticks dropped, content kept), fenced code blocks (dropped → spoken "code block omitted" placeholder), headings, blockquotes, list bullets/numbers → prose pauses, links → label only (URL dropped), images → alt text.
   - stray `~` dropped, `->`/`=>`/`→` → "to", pipes/table separators dropped, bare/autolink URLs → "a link", excessive punctuation collapsed, whitespace → sentence flow.
   - minimal, well-tested abbreviation expansion (`e.g.`→"for example", `i.e.`→"that is", `etc.`→"and so on"); conservative — real words (e.g. `my_var`) are left intact.

   This replaces the older partial `stripMarkdown` pass on the voice-out path, which leaked `~`, code fences, and arrows.

2. **One voice note per response** — the kokoro (local sidecar) path now sends the whole normalized reply to `/tts` in a **single** call and issues **one** `sendVoice` (the sidecar chunks + concatenates internally and returns one ogg/opus file). `max_chars` is retired as a hard client-side splitter for kokoro. The OpenAI engine keeps client-side chunking (its own input cap, now clamped at 4096 chars/note). Best-effort/non-fatal semantics and `reply_mode` (voice+text / voice-only) are unchanged.

## Contract
The `/tts` contract with `docker/voice-sidecar` (endpoint path, `X-Voice-Token` header, `{text, voice?, format?}` JSON shape) is **unchanged** — only the client-side length ceiling is relaxed so the single long-text call is accepted. No files under `docker/` are touched (that's the parallel PR's job).

## Tests
- `telegram-plugin/tests/voice-normalize-text.test.ts` — covers every reported case (tilde, asterisks, backticks, headings, links, code fences) plus tables, arrows, lists, abbreviations, and conservative non-mangling.
- `telegram-plugin/tests/voice-out-one-send.test.ts` — asserts the kokoro path yields one chunk, issues exactly one `/tts` fetch for a long reply, and one `sendVoice`.

## Verify
- `tsc --noEmit` clean.
- Full `bun lint` chain clean (identical to main).
- `bun test gateway tests` green: 5381 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)