### PR TITLE
feat(voice): phase-2 pre-TTS naturalization in normalizeForSpeech

### DIFF
--- a/telegram-plugin/tests/voice-normalize-text.test.ts
+++ b/telegram-plugin/tests/voice-normalize-text.test.ts
@@ -95,8 +95,8 @@ describe('normalizeForSpeech — additional structures', () => {
 
   it('expands a minimal, safe set of abbreviations', () => {
     expect(normalizeForSpeech('use it, e.g. here')).toBe('use it, for example, here')
-    expect(normalizeForSpeech('the API, i.e. the interface')).toBe(
-      'the API, that is, the interface',
+    expect(normalizeForSpeech('the tool, i.e. the interface')).toBe(
+      'the tool, that is, the interface',
     )
     expect(normalizeForSpeech('cats, dogs, etc.')).toBe('cats, dogs, and so on')
   })
@@ -107,10 +107,140 @@ describe('normalizeForSpeech — additional structures', () => {
   })
 })
 
+describe('normalizeForSpeech — emoji & pictographs', () => {
+  it('strips emoji and collapses the resulting whitespace', () => {
+    expect(normalizeForSpeech('done 🚀 shipping')).toBe('done shipping')
+    expect(normalizeForSpeech('great 👍🏽 job')).toBe('great job')
+    expect(normalizeForSpeech('🎉')).toBe('')
+  })
+
+  it('drops :shortcode: emoji forms', () => {
+    expect(normalizeForSpeech('nice :rocket: work')).toBe('nice work')
+  })
+
+  it('leaves ordinary colon usage alone', () => {
+    expect(normalizeForSpeech('note: this is fine')).toBe('note: this is fine')
+  })
+})
+
+describe('normalizeForSpeech — numbers, units & symbols', () => {
+  it('speaks percent', () => {
+    expect(normalizeForSpeech('up 20% today')).toBe('up 20 percent today')
+  })
+
+  it('speaks currency amounts', () => {
+    expect(normalizeForSpeech('costs $5')).toBe('costs five dollars')
+    expect(normalizeForSpeech('costs $5.50')).toBe('costs five dollars fifty')
+    expect(normalizeForSpeech('just $1')).toBe('just one dollar')
+  })
+
+  it('speaks standalone & as "and"', () => {
+    expect(normalizeForSpeech('cats & dogs')).toBe('cats and dogs')
+    expect(normalizeForSpeech('R&D team')).toBe('R and D team')
+  })
+
+  it('speaks + between words as "plus" and = as "equals"', () => {
+    expect(normalizeForSpeech('speed + power')).toBe('speed plus power')
+    expect(normalizeForSpeech('x = y')).toBe('x equals y')
+  })
+
+  it('speaks × / x multipliers as "times"', () => {
+    expect(normalizeForSpeech('12× faster')).toBe('twelve times faster')
+    expect(normalizeForSpeech('a 12x speedup')).toBe('a twelve times speedup')
+  })
+
+  it('speaks temperature degrees', () => {
+    expect(normalizeForSpeech('it is 30°C outside')).toBe(
+      'it is 30 degrees outside',
+    )
+    expect(normalizeForSpeech('72°F')).toBe('72 degrees')
+  })
+
+  it('expands number + time/size unit suffixes', () => {
+    expect(normalizeForSpeech('waited 2s')).toBe('waited two seconds')
+    expect(normalizeForSpeech('took 500ms')).toBe('took five hundred milliseconds')
+    expect(normalizeForSpeech('run 5m')).toBe('run five minutes')
+    expect(normalizeForSpeech('run 5min')).toBe('run five minutes')
+    expect(normalizeForSpeech('wait 2h')).toBe('wait two hours')
+    expect(normalizeForSpeech('wait 2hr')).toBe('wait two hours')
+    expect(normalizeForSpeech('in 3d')).toBe('in three days')
+    expect(normalizeForSpeech('10kb file')).toBe('ten kilobytes file')
+    expect(normalizeForSpeech('10KB file')).toBe('ten kilobytes file')
+    expect(normalizeForSpeech('a 5MB image')).toBe('a five megabytes image')
+    expect(normalizeForSpeech('a 2GB dump')).toBe('a two gigabytes dump')
+    expect(normalizeForSpeech('1s ping')).toBe('one second ping')
+  })
+
+  it('expands the "k" thousands shorthand', () => {
+    expect(normalizeForSpeech('100k users')).toBe('one hundred thousand users')
+  })
+
+  it('leaves number-glued-to-word identifiers alone', () => {
+    expect(normalizeForSpeech('my5thing works')).toBe('my5thing works')
+    expect(normalizeForSpeech('class5 room')).toBe('class5 room')
+  })
+})
+
+describe('normalizeForSpeech — abbreviations (phase 2)', () => {
+  it('expands vs / approx / w/', () => {
+    expect(normalizeForSpeech('cats vs dogs')).toBe('cats versus dogs')
+    expect(normalizeForSpeech('cats vs. dogs')).toBe('cats versus dogs')
+    expect(normalizeForSpeech('approx 10 items')).toBe('approximately 10 items')
+    expect(normalizeForSpeech('tea w/ milk')).toBe('tea with milk')
+  })
+})
+
+describe('normalizeForSpeech — acronyms', () => {
+  it('spells curated initialisms letter-by-letter', () => {
+    expect(normalizeForSpeech('the CI passed')).toBe('the C I passed')
+    expect(normalizeForSpeech('open a PR')).toBe('open a P R')
+    expect(normalizeForSpeech('call the API via HTTP')).toBe(
+      'call the A P I via H T T P',
+    )
+    expect(normalizeForSpeech('GPU and CPU load')).toBe('G P U and C P U load')
+    expect(normalizeForSpeech('parse the JSON')).toBe('parse the J S O N')
+  })
+
+  it('leaves word-style acronyms and unknown caps alone', () => {
+    expect(normalizeForSpeech('NASA launch')).toBe('NASA launch')
+    expect(normalizeForSpeech('the FBI report')).toBe('the FBI report')
+  })
+
+  it('does not touch caps inside a larger word', () => {
+    expect(normalizeForSpeech('myAPIkey stays')).toBe('myAPIkey stays')
+  })
+})
+
+describe('normalizeForSpeech — times & dates', () => {
+  it('speaks clock times', () => {
+    expect(normalizeForSpeech('meet at 12:45')).toBe('meet at twelve forty-five')
+    expect(normalizeForSpeech('at 09:05')).toBe('at nine oh five')
+    expect(normalizeForSpeech('at 14:00')).toBe("at fourteen o'clock")
+  })
+
+  it('speaks ISO dates', () => {
+    expect(normalizeForSpeech('on 2026-07-01 we ship')).toBe(
+      'on July first two thousand twenty-six we ship',
+    )
+    expect(normalizeForSpeech('2026-12-25')).toBe(
+      'December twenty-fifth two thousand twenty-six',
+    )
+  })
+})
+
 describe('normalizeForSpeech — conservative, does not mangle real words', () => {
   it('leaves plain prose untouched', () => {
     expect(normalizeForSpeech('The quick brown fox jumps.')).toBe(
       'The quick brown fox jumps.',
+    )
+  })
+
+  it('leaves lowercase day/word tokens and a symbol-free sentence alone', () => {
+    expect(normalizeForSpeech('see you wednesday afternoon')).toBe(
+      'see you wednesday afternoon',
+    )
+    expect(normalizeForSpeech('The report covers three main areas.')).toBe(
+      'The report covers three main areas.',
     )
   })
 

--- a/telegram-plugin/voice-normalize-text.ts
+++ b/telegram-plugin/voice-normalize-text.ts
@@ -30,12 +30,135 @@
  *     choice that never mangles a real word.
  *   - `->` / `=>` / `→` become the spoken word "to".
  *   - A tiny, well-tested set of trivially-safe abbreviations is expanded
- *     ("e.g." → "for example", "i.e." → "that is", "etc." → "and so on").
+ *     ("e.g." → "for example", "i.e." → "that is", "etc." → "and so on",
+ *     "vs" → "versus", "approx" → "approximately", "w/" → "with").
  *     Anything ambiguous is left alone.
+ *
+ * Phase 2 pre-TTS naturalization (all conservative, number/token-guarded):
+ *   - Emoji & pictographs are dropped entirely (TTS would read their long
+ *     CLDR names); `:shortcode:` forms are dropped too. Whitespace collapses.
+ *   - Numbers, units & symbols are spoken: `%` → "percent", `$5.50` → "five
+ *     dollars fifty", `12x`/`12×` → "twelve times", `°C` → "degrees",
+ *     unit suffixes (`500ms`, `2h`, `10KB`, `100k`) expand to words, and the
+ *     `& + =` glue symbols become "and / plus / equals".
+ *   - A curated acronym set (CI, PR, API, URL, GPU, CPU, TTS, STT, HTTP,
+ *     JSON, SQL, UI) is spelled letter-by-letter; word-style acronyms
+ *     (NASA) are left alone.
+ *   - Clear time / date patterns: `12:45` → "twelve forty-five", ISO
+ *     `2026-07-01` → "July first two thousand twenty-six".
+ * Every phase-2 pass is guarded to fire only on a clear number+token so real
+ * identifiers (`my_var`, `class5`, `my5thing`) pass through untouched.
  */
 
 /** Replace a fenced code block with a spoken placeholder. */
 const CODE_BLOCK_PLACEHOLDER = 'code block omitted'
+
+// ---------------------------------------------------------------------------
+// Number → words helpers (small, deterministic, English cardinal only).
+// Used by the numbers/units pass. Supports 0..999_999_999 which is far more
+// than any realistic spoken quantity; larger inputs are left as digits so we
+// never emit a wrong or truncated reading.
+// ---------------------------------------------------------------------------
+const ONES = [
+  'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight',
+  'nine', 'ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen',
+  'sixteen', 'seventeen', 'eighteen', 'nineteen',
+]
+const TENS = [
+  '', '', 'twenty', 'thirty', 'forty', 'fifty', 'sixty', 'seventy', 'eighty',
+  'ninety',
+]
+
+/** Cardinal words for 0..999. */
+function belowThousand(n: number): string {
+  if (n < 20) return ONES[n]
+  if (n < 100) {
+    const t = TENS[Math.floor(n / 10)]
+    const o = n % 10
+    return o ? `${t}-${ONES[o]}` : t
+  }
+  const h = `${ONES[Math.floor(n / 100)]} hundred`
+  const rest = n % 100
+  return rest ? `${h} ${belowThousand(rest)}` : h
+}
+
+/** Cardinal words for a non-negative integer, or null if out of range. */
+function numberToWords(n: number): string | null {
+  if (!Number.isInteger(n) || n < 0 || n > 999_999_999) return null
+  if (n === 0) return 'zero'
+  const parts: string[] = []
+  const millions = Math.floor(n / 1_000_000)
+  const thousands = Math.floor((n % 1_000_000) / 1000)
+  const rest = n % 1000
+  if (millions) parts.push(`${belowThousand(millions)} million`)
+  if (thousands) parts.push(`${belowThousand(thousands)} thousand`)
+  if (rest) parts.push(belowThousand(rest))
+  return parts.join(' ')
+}
+
+/** Ordinal words for 1..31 (used for spoken dates). */
+const ORDINALS: Record<number, string> = {
+  1: 'first', 2: 'second', 3: 'third', 4: 'fourth', 5: 'fifth', 6: 'sixth',
+  7: 'seventh', 8: 'eighth', 9: 'ninth', 10: 'tenth', 11: 'eleventh',
+  12: 'twelfth', 13: 'thirteenth', 14: 'fourteenth', 15: 'fifteenth',
+  16: 'sixteenth', 17: 'seventeenth', 18: 'eighteenth', 19: 'nineteenth',
+  20: 'twentieth', 21: 'twenty-first', 22: 'twenty-second',
+  23: 'twenty-third', 24: 'twenty-fourth', 25: 'twenty-fifth',
+  26: 'twenty-sixth', 27: 'twenty-seventh', 28: 'twenty-eighth',
+  29: 'twenty-ninth', 30: 'thirtieth', 31: 'thirty-first',
+}
+
+const MONTHS = [
+  '', 'January', 'February', 'March', 'April', 'May', 'June', 'July',
+  'August', 'September', 'October', 'November', 'December',
+]
+
+/** Spoken form for a 4-digit year (e.g. 2026 → "two thousand twenty six"). */
+function yearToWords(y: number): string | null {
+  if (y < 1000 || y > 9999) return null
+  // 2000..2099 read as "two thousand …" which is the realistic range for
+  // these timestamps and reads naturally for TTS.
+  if (y >= 2000 && y < 2100) {
+    const lo = y % 100
+    const base = 'two thousand'
+    return lo ? `${base} ${belowThousand(lo)}` : base
+  }
+  // Generic "nineteen eighty-four" style for other centuries.
+  const hi = Math.floor(y / 100)
+  const lo = y % 100
+  const hiW = belowThousand(hi)
+  if (lo === 0) return `${hiW} hundred`
+  return `${hiW} ${belowThousand(lo)}`
+}
+
+/** Spoken minutes for a time-of-day (e.g. 45 → "forty-five", 5 → "oh five"). */
+function minutesToWords(mm: number): string {
+  if (mm === 0) return "o'clock"
+  if (mm < 10) return `oh ${ONES[mm]}`
+  return belowThousand(mm)
+}
+
+/** Number-unit suffixes: token suffix → { singular, plural } spoken unit. */
+const UNIT_MAP: Record<string, { s: string; p: string }> = {
+  ms: { s: 'millisecond', p: 'milliseconds' },
+  s: { s: 'second', p: 'seconds' },
+  sec: { s: 'second', p: 'seconds' },
+  min: { s: 'minute', p: 'minutes' },
+  m: { s: 'minute', p: 'minutes' },
+  h: { s: 'hour', p: 'hours' },
+  hr: { s: 'hour', p: 'hours' },
+  d: { s: 'day', p: 'days' },
+  kb: { s: 'kilobyte', p: 'kilobytes' },
+  mb: { s: 'megabyte', p: 'megabytes' },
+  gb: { s: 'gigabyte', p: 'gigabytes' },
+  tb: { s: 'terabyte', p: 'terabytes' },
+}
+
+/** Curated initialisms spoken letter-by-letter. Uppercase keys only. */
+const ACRONYMS = new Set([
+  'CI', 'PR', 'API', 'URL', 'GPU', 'CPU', 'TTS', 'STT', 'HTTP', 'JSON',
+  'SQL', 'UI',
+])
 
 /**
  * Convert a Markdown/plain reply into clean text for a TTS engine.
@@ -44,6 +167,17 @@ const CODE_BLOCK_PLACEHOLDER = 'code block omitted'
 export function normalizeForSpeech(input: string): string {
   if (!input) return ''
   let s = input.replace(/\r\n?/g, '\n')
+
+  // 0. Emoji & pictographs → dropped entirely, then whitespace collapsed.
+  //    TTS reads an emoji as its long CLDR name ("grinning face"), which is
+  //    noise. We also drop `:shortcode:` forms so nothing is read as
+  //    "colon rocket colon". The shortcode form is matched narrowly
+  //    (:word: with letters/digits/_/- ) so real colon usage survives.
+  s = s.replace(
+    /[\u{1F000}-\u{1FAFF}\u{1F1E6}-\u{1F1FF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE00}-\u{FE0F}\u{200D}\u{2B50}\u{3030}\u{303D}\u{3297}\u{3299}\u{24C2}]/gu,
+    '',
+  )
+  s = s.replace(/:([a-z0-9][a-z0-9_+-]*):/gi, ' ')
 
   // 1. Fenced code blocks first (```lang … ``` or ~~~ … ~~~) — drop the
   //    whole block before any inline processing can see its contents.
@@ -107,11 +241,92 @@ export function normalizeForSpeech(input: string): string {
   s = s.replace(/\be\.g\.,?/gi, 'for example,')
   s = s.replace(/\bi\.e\.,?/gi, 'that is,')
   s = s.replace(/\betc\./gi, 'and so on')
+  s = s.replace(/\bapprox\.?(?=\s|$)/gi, 'approximately')
+  s = s.replace(/\bvs\.?(?=\s|$)/gi, 'versus')
+  s = s.replace(/\bw\/(?=\s)/gi, 'with ')
 
-  // 13. Collapse excessive punctuation the engine would over-emphasise.
+  // 13. Dates & times (clear patterns only, run before the numbers pass so
+  //     the colon in HH:MM and the hyphens in ISO dates are consumed here).
+  //     ISO date YYYY-MM-DD → "Month Dayth Year".
+  s = s.replace(/\b(\d{4})-(\d{2})-(\d{2})\b/g, (m, y, mo, da) => {
+    const year = Number(y)
+    const month = Number(mo)
+    const day = Number(da)
+    if (month < 1 || month > 12 || day < 1 || day > 31) return m
+    const yw = yearToWords(year)
+    const ord = ORDINALS[day]
+    if (!yw || !ord) return m
+    return `${MONTHS[month]} ${ord} ${yw}`
+  })
+  //     Clock time HH:MM (24h ok) → spoken. Guarded by word boundaries so a
+  //     ratio like "3:2" or a bare number isn't caught (needs 2-digit MM).
+  s = s.replace(/\b([01]?\d|2[0-3]):([0-5]\d)\b/g, (m, hh, mm) => {
+    const h = Number(hh)
+    const min = Number(mm)
+    const hw = belowThousand(h)
+    if (min === 0) return `${hw} o'clock`
+    return `${hw} ${minutesToWords(min)}`
+  })
+
+  // 14. Numbers, units & symbols → spoken words. Each sub-pass is guarded so
+  //     it only fires on a clear number+token, never mid-word.
+  //     Currency: $5 / $5.50 → "five dollars" / "five dollars fifty".
+  s = s.replace(/\$(\d{1,9})(?:\.(\d{2}))?\b/g, (m, dollars, cents) => {
+    const dw = numberToWords(Number(dollars))
+    if (!dw) return m
+    const noun = Number(dollars) === 1 && !cents ? 'dollar' : 'dollars'
+    if (cents && cents !== '00') {
+      const cw = numberToWords(Number(cents))
+      return `${dw} ${noun} ${cw}`
+    }
+    return `${dw} ${noun}`
+  })
+  //     Percent sign → " percent".
+  s = s.replace(/(\d)\s*%/g, '$1 percent')
+  //     Temperature °C / °F → "degrees".
+  s = s.replace(/°\s*[CF]\b/g, ' degrees')
+  s = s.replace(/°/g, ' degrees')
+  //     Multiplier NN× / NNx → "NN times" (x only when glued to a number).
+  s = s.replace(/\b(\d{1,9})\s*[×x](?![a-z0-9])/gi, (m, n) => {
+    const w = numberToWords(Number(n))
+    return w ? `${w} times` : m
+  })
+  //     "100k" shorthand → "one hundred thousand" (k as thousands multiplier).
+  s = s.replace(/\b(\d{1,6})k\b/gi, (m, n) => {
+    const w = numberToWords(Number(n) * 1000)
+    return w ? w : m
+  })
+  //     Number + unit suffix → "<number> <unit>" (e.g. 500ms, 2h, 10KB).
+  //     Only when the suffix is a known unit glued directly to the number and
+  //     bounded by a non-letter (so "my5thing" / "class5" are never touched).
+  s = s.replace(
+    /\b(\d{1,9})(ms|sec|min|kb|mb|gb|tb|hr|s|m|h|d)(?![a-z])/gi,
+    (m, num, unitRaw) => {
+      const unit = UNIT_MAP[unitRaw.toLowerCase()]
+      if (!unit) return m
+      const n = Number(num)
+      const w = numberToWords(n)
+      if (!w) return m
+      return `${w} ${n === 1 ? unit.s : unit.p}`
+    },
+  )
+  //     Symbols between tokens: standalone & → and, + → plus, = → equals.
+  s = s.replace(/(\S)\s*\+\s*(\S)/g, '$1 plus $2')
+  s = s.replace(/\s=\s/g, ' equals ')
+  s = s.replace(/(\s)&(\s)/g, '$1and$2')
+  s = s.replace(/(\w)&(\w)/g, '$1 and $2')
+
+  // 15. Acronyms → letter-by-letter for a curated set of initialisms. Only a
+  //     standalone all-caps token that exactly matches the map is expanded;
+  //     word-style acronyms (NASA) and sub-tokens of larger words are left.
+  s = s.replace(/\b[A-Z]{2,5}\b/g, (tok) =>
+    ACRONYMS.has(tok) ? tok.split('').join(' ') : tok,
+  )
+
+  // 16. Collapse excessive punctuation the engine would over-emphasise.
   s = s.replace(/([!?.]){2,}/g, '$1')
 
-  // 14. Whitespace → sentence flow. Blank lines become a sentence break so
+  // 17. Whitespace → sentence flow. Blank lines become a sentence break so
   //     paragraphs don't run together; everything else collapses to a single
   //     space.
   s = s.replace(/[ \t]*\n[ \t]*\n[ \t]*/g, '. ')


### PR DESCRIPTION
Follow-up to #2716. Extends the pure `normalizeForSpeech` pass in `telegram-plugin/voice-normalize-text.ts` with conservative, number/token-guarded naturalization so a TTS engine reads replies as natural prose instead of pronouncing symbols and markup. Still a pure, deterministic string→string function — no model, no network. Nothing under `docker/` touched.

## Buckets & example transforms

**Emoji**
- `done 🚀 shipping` → `done shipping`
- `great 👍🏽 job` → `great job` (skin-tone modifier + ZWJ dropped)
- `nice :rocket: work` → `nice work` (shortcodes dropped; ordinary `note:` colons preserved)

**Numbers, units & symbols**
- `up 20% today` → `up 20 percent today`
- `costs $5` → `costs five dollars`; `costs $5.50` → `costs five dollars fifty`; `just $1` → `just one dollar`
- `cats & dogs` → `cats and dogs`; `R&D team` → `R and D team`
- `speed + power` → `speed plus power`; `x = y` → `x equals y`
- `12× faster` → `twelve times faster`; `a 12x speedup` → `a twelve times speedup`
- `30°C` → `30 degrees`; `72°F` → `72 degrees`
- `2s` → `two seconds`, `500ms` → `five hundred milliseconds`, `5m`/`5min` → `five minutes`, `2h`/`2hr` → `two hours`, `3d` → `three days`, `10kb`/`10KB` → `ten kilobytes`, `5MB` → `five megabytes`, `2GB` → `two gigabytes`, `100k` → `one hundred thousand`

**Abbreviations**
- `cats vs dogs` / `cats vs. dogs` → `cats versus dogs`
- `approx 10 items` → `approximately 10 items`
- `tea w/ milk` → `tea with milk`
- (existing `e.g.`/`i.e.`/`etc.` retained)

**Acronyms** (curated: CI PR API URL GPU CPU TTS STT HTTP JSON SQL UI, spelled letter-by-letter)
- `the CI passed` → `the C I passed`
- `call the API via HTTP` → `call the A P I via H T T P`
- `NASA launch` → `NASA launch` (word-style left alone); `myAPIkey stays` unchanged (not a standalone token)

**Times/dates**
- `12:45` → `twelve forty-five`; `09:05` → `nine oh five`; `14:00` → `fourteen o'clock`
- `2026-07-01` → `July first two thousand twenty-six`

## Conservatism / edge cases deliberately left out
- Identifiers untouched: `my_var`, `class5`, `my5thing`, `wednesday`, and symbol-free sentences pass through unchanged.
- Year spelling is scoped to the 2000–2099 "two thousand …" form (the realistic timestamp range); other centuries fall back to a generic "nineteen eighty-four" style. `numberToWords` caps at 999,999,999 and leaves larger raw numbers as digits rather than risk a wrong reading.
- `x`-multiplier only fires when glued to a number and not followed by a letter/digit, so prose like "box y" is safe.
- Unit suffixes only expand for a known unit glued directly to a number and bounded by a non-letter.
- Ordering: emoji strip runs first; date/time before the numbers pass (so `:`/`-` are consumed as time/date, not symbols); acronyms after URL replacement.

## Tests
Extended `telegram-plugin/tests/voice-normalize-text.test.ts` (bun:test) with explicit cases for every bucket plus conservative non-mangling cases. `bun test` → 38 pass / 0 fail. Typecheck (`tsc --noEmit`) and the repo lint scripts are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)