### PR TITLE
feat(voice): adjustable TTS speed dial for the voice pipeline

### DIFF
--- a/.github/workflows/ci-tests-python.yml
+++ b/.github/workflows/ci-tests-python.yml
@@ -42,6 +42,7 @@ jobs:
           filters: |
             relevant:
               - 'vendor/hindsight-memory/scripts/**'
+              - 'docker/voice-sidecar/**'
               - '.github/workflows/ci-tests-python.yml'
 
   unittest:
@@ -56,3 +57,9 @@ jobs:
       - name: Run unittest discover
         working-directory: vendor/hindsight-memory/scripts
         run: python3 -m unittest discover tests/
+
+      # Voice sidecar's stdlib-only tests (TTS speed clamp). server.py imports
+      # kokoro lazily, so no ONNX runtime / model is needed here.
+      - name: Run voice-sidecar unittests
+        working-directory: docker/voice-sidecar
+        run: python3 -m unittest discover -s . -p 'test_*.py'

--- a/docker/voice-sidecar/server.py
+++ b/docker/voice-sidecar/server.py
@@ -19,7 +19,8 @@ HTTP contract
               header:    X-Voice-Token: <shared secret>
               → 200 { ok: true,  text, language?, durationMs, audioSeconds }
               → 4xx/5xx { ok: false, reason, detail }
-  POST /tts   json: { text: str (ANY length), voice?: str, format?: "ogg" }
+  POST /tts   json: { text: str (ANY length), voice?: str, speed?: float, format?: "ogg" }
+              speed is clamped to 0.5–2.0; absent/invalid → 1.0 (today's default).
               header:    X-Voice-Token: <shared secret>
               → 200 audio/ogg  (ONE continuous OGG/Opus stream, mono — ready
                 for Telegram sendVoice, which REQUIRES OGG/Opus). Text of any
@@ -453,7 +454,25 @@ def _split_text(text: str, max_chars: int) -> list[str]:
     return [p for p in pieces if p]
 
 
-def _run_synthesis(text: str, voice: str) -> tuple[bytes, dict]:
+TTS_SPEED_MIN = 0.5
+TTS_SPEED_MAX = 2.0
+TTS_SPEED_DEFAULT = 1.0
+
+
+def _clamp_speed(value: object) -> float:
+    """Coerce an incoming speed to a float in [TTS_SPEED_MIN, TTS_SPEED_MAX].
+
+    Absent / non-numeric / NaN → TTS_SPEED_DEFAULT (1.0), i.e. today's
+    behavior. Out-of-range numbers are clamped to the nearest bound."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return TTS_SPEED_DEFAULT
+    speed = float(value)
+    if speed != speed:  # NaN
+        return TTS_SPEED_DEFAULT
+    return max(TTS_SPEED_MIN, min(TTS_SPEED_MAX, speed))
+
+
+def _run_synthesis(text: str, voice: str, speed: float = TTS_SPEED_DEFAULT) -> tuple[bytes, dict]:
     """The TTS-serialized synthesis. Acquires the TTS semaphore so only
     TTS_CONCURRENCY synths run at once — a separate lane from STT.
 
@@ -478,7 +497,7 @@ def _run_synthesis(text: str, voice: str) -> tuple[bytes, dict]:
         sample_rate = TTS_SAMPLE_RATE
         for i, piece in enumerate(pieces):
             samples, sample_rate = _tts.create(  # type: ignore[union-attr]
-                piece, voice=voice, speed=1.0, lang=TTS_LANG
+                piece, voice=voice, speed=speed, lang=TTS_LANG
             )
             arr = np.asarray(samples, dtype=np.float32)
             if i > 0:
@@ -496,6 +515,7 @@ def _run_synthesis(text: str, voice: str) -> tuple[bytes, dict]:
             "audioSeconds": audio_seconds,
             "durationMs": elapsed_ms,
             "voice": voice,
+            "speed": speed,
             "pieces": len(pieces),
             "chars": len(text),
         }
@@ -695,9 +715,13 @@ class Handler(BaseHTTPRequestHandler):
             return
         voice = (voice or TTS_VOICE).strip() or TTS_VOICE
 
+        # Optional playback speed. Clamp to [0.5, 2.0]; absent/invalid → 1.0
+        # (exactly today's behavior).
+        speed = _clamp_speed(payload.get("speed"))
+
         # Run synthesis with a hard server-side timeout so a wedged synth
         # can't pin the worker forever (its own TTS pool/lane).
-        future = _tts_pool.submit(_run_synthesis, text, voice)
+        future = _tts_pool.submit(_run_synthesis, text, voice, speed)
         try:
             ogg, meta = future.result(timeout=TTS_REQUEST_TIMEOUT_S)
         except FutureTimeout:

--- a/docker/voice-sidecar/test_server.py
+++ b/docker/voice-sidecar/test_server.py
@@ -1,0 +1,51 @@
+"""Unit tests for the voice sidecar's TTS speed clamp (server._clamp_speed).
+
+The sidecar accepts an optional `speed` in the /tts JSON body, clamps it to
+[0.5, 2.0], and defaults to 1.0 when absent/invalid (exactly today's
+behavior). These tests pin that contract. server.py imports kokoro lazily
+(inside the synth functions), so it imports cleanly without the ONNX runtime
+installed — no model needed to exercise the clamp.
+
+Run: python3 -m unittest discover -s docker/voice-sidecar -p 'test_*.py'
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import server
+
+
+class ClampSpeedTests(unittest.TestCase):
+    def test_default_when_absent_or_invalid(self) -> None:
+        # None / non-numeric / bool / NaN → 1.0 (today's default).
+        for bad in (None, "1.2", "fast", True, False, [], {}, float("nan")):
+            self.assertEqual(
+                server._clamp_speed(bad), 1.0, msg=f"input={bad!r}"
+            )
+
+    def test_in_range_passthrough(self) -> None:
+        for v in (0.5, 0.75, 1.0, 1.1, 1.5, 2.0):
+            self.assertEqual(server._clamp_speed(v), v, msg=f"input={v!r}")
+
+    def test_clamps_below_min(self) -> None:
+        self.assertEqual(server._clamp_speed(0.1), 0.5)
+        self.assertEqual(server._clamp_speed(-3.0), 0.5)
+        self.assertEqual(server._clamp_speed(0), 0.5)
+
+    def test_clamps_above_max(self) -> None:
+        self.assertEqual(server._clamp_speed(2.5), 2.0)
+        self.assertEqual(server._clamp_speed(100), 2.0)
+
+    def test_int_is_accepted(self) -> None:
+        self.assertEqual(server._clamp_speed(1), 1.0)
+        self.assertEqual(server._clamp_speed(2), 2.0)
+
+    def test_bounds_constants(self) -> None:
+        self.assertEqual(server.TTS_SPEED_MIN, 0.5)
+        self.assertEqual(server.TTS_SPEED_MAX, 2.0)
+        self.assertEqual(server.TTS_SPEED_DEFAULT, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -49,7 +49,15 @@ import {
 } from '../sticker-aliases.js'
 import { transcribeViaWhisper } from '../voice-transcribe.js'
 import { transcribeViaSidecar } from '../voice-transcribe-sidecar.js'
-import { synthesizeViaSidecar, chunkTtsText } from '../voice-synthesize-sidecar.js'
+import {
+  synthesizeViaSidecar,
+  chunkTtsText,
+  clampTtsSpeed,
+} from '../voice-synthesize-sidecar.js'
+
+/** Fleet default TTS speed when voice_out is enabled but speed is unset —
+ *  slightly brisker than neutral (Ken's chosen default). */
+const VOICE_OUT_DEFAULT_SPEED = 1.1
 import { normalizeForSpeech } from '../voice-normalize-text.js'
 import { synthesizeViaOpenAi } from '../voice-synthesize.js'
 import {
@@ -986,6 +994,10 @@ type Access = {
     engine?: 'kokoro' | 'openai'
     voice?: string
     reply_mode?: 'voice+text' | 'voice-only'
+    /** Kokoro-engine playback speed. Clamped to 0.5–2.0; defaults to 1.1
+     *  when voice_out is enabled but speed is unset (the fleet default —
+     *  slightly brisker than neutral). Ignored by the OpenAI path. */
+    speed?: number
     /** OpenAI-engine only: per-voice-note chunk size (default 600) used to
      *  split a long reply across sequential notes, since OpenAI's TTS input
      *  has a hard cap. Ignored by the kokoro path, which sends the whole
@@ -8217,6 +8229,7 @@ function resolveVoiceOutPlan(
 ): {
   engine: 'kokoro' | 'openai'
   voice?: string
+  speed: number
   apiKeyRef?: string
   replyMode: 'voice+text' | 'voice-only'
   ttsChunks: string[]
@@ -8267,9 +8280,15 @@ function resolveVoiceOutPlan(
   }
   if (ttsChunks.length === 0) return null
 
+  // Kokoro playback speed: default 1.1 (fleet default) when unset, clamped to
+  // 0.5–2.0. Threaded into the /tts body by synthesizeVoiceOut. The OpenAI
+  // path ignores it.
+  const speed = clampTtsSpeed(voiceOut.speed, VOICE_OUT_DEFAULT_SPEED)
+
   return {
     engine,
     voice: voiceOut.voice,
+    speed,
     apiKeyRef: voiceOut.api_key,
     replyMode: voiceOut.reply_mode ?? 'voice+text',
     ttsChunks,
@@ -8285,6 +8304,7 @@ function resolveVoiceOutPlan(
 async function synthesizeVoiceOut(plan: {
   engine: 'kokoro' | 'openai'
   voice?: string
+  speed?: number
   apiKeyRef?: string
   ttsText: string
 }): Promise<Uint8Array | null> {
@@ -8296,6 +8316,7 @@ async function synthesizeVoiceOut(plan: {
         token,
         text: plan.ttsText,
         voice: plan.voice,
+        speed: plan.speed,
       })
       if (!result.ok) {
         process.stderr.write(
@@ -8708,6 +8729,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
       const ogg = await synthesizeVoiceOut({
         engine: voiceOutPlan.engine,
         voice: voiceOutPlan.voice,
+        speed: voiceOutPlan.speed,
         apiKeyRef: voiceOutPlan.apiKeyRef,
         ttsText: chunkText,
       })

--- a/telegram-plugin/tests/voice-out-one-send.test.ts
+++ b/telegram-plugin/tests/voice-out-one-send.test.ts
@@ -16,7 +16,17 @@
 
 import { describe, it, expect } from 'bun:test'
 import { normalizeForSpeech } from '../voice-normalize-text.js'
-import { synthesizeViaSidecar } from '../voice-synthesize-sidecar.js'
+import { synthesizeViaSidecar, clampTtsSpeed } from '../voice-synthesize-sidecar.js'
+
+/** The fleet default speed the gateway applies when voice_out is enabled but
+ *  speed is unset (mirrors VOICE_OUT_DEFAULT_SPEED in gateway.ts). */
+const VOICE_OUT_DEFAULT_SPEED = 1.1
+
+/** Reproduce resolveVoiceOutPlan's speed resolution: default to 1.1 when
+ *  unset, clamp to 0.5–2.0. */
+function resolveSpeed(speed: number | undefined): number {
+  return clampTtsSpeed(speed, VOICE_OUT_DEFAULT_SPEED)
+}
 
 const OGG_BYTES = new Uint8Array([0x4f, 0x67, 0x67, 0x53]) // OggS magic
 
@@ -101,5 +111,43 @@ describe('voice-out kokoro path — ONE synth call, ONE sendVoice', () => {
       sendVoiceCalls++ // gateway: one sendVoice per ogg
     }
     expect(sendVoiceCalls).toBe(1)
+  })
+})
+
+describe('voice-out kokoro path — speed resolution (gateway default 1.1)', () => {
+  it('defaults to 1.1 when voice_out.speed is unset', () => {
+    expect(resolveSpeed(undefined)).toBe(1.1)
+  })
+
+  it('honours an explicit in-range speed', () => {
+    expect(resolveSpeed(0.9)).toBe(0.9)
+    expect(resolveSpeed(1.5)).toBe(1.5)
+  })
+
+  it('clamps an out-of-range configured speed to 0.5–2.0', () => {
+    expect(resolveSpeed(3.0)).toBe(2.0)
+    expect(resolveSpeed(0.1)).toBe(0.5)
+  })
+
+  it('threads the resolved speed into the single /tts body', async () => {
+    let sentSpeed: number | undefined
+    const capturingFetch = (async (_url: string, init: RequestInit) => {
+      sentSpeed = (JSON.parse(init.body as string) as { speed?: number }).speed
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => OGG_BYTES.buffer.slice(0),
+        text: async () => '',
+        headers: new Headers(),
+      }
+    }) as unknown as typeof fetch
+
+    await synthesizeViaSidecar({
+      token: 't',
+      text: 'hello there',
+      speed: resolveSpeed(undefined), // gateway default path
+      fetchImpl: capturingFetch,
+    })
+    expect(sentSpeed).toBe(1.1)
   })
 })

--- a/telegram-plugin/tests/voice-synthesize-sidecar.test.ts
+++ b/telegram-plugin/tests/voice-synthesize-sidecar.test.ts
@@ -13,6 +13,7 @@ import { describe, it, expect } from 'bun:test'
 import {
   synthesizeViaSidecar,
   chunkTtsText,
+  clampTtsSpeed,
   SIDECAR_TTS_MAX_CHARS,
   DEFAULT_SIDECAR_BASE_URL,
 } from '../voice-synthesize-sidecar.js'
@@ -135,6 +136,83 @@ describe('synthesizeViaSidecar — happy path', () => {
     await synthesizeViaSidecar({ token: 't', text: 'hi', fetchImpl: fakeFetch })
     const parsed = JSON.parse(receivedBody!)
     expect('voice' in parsed).toBe(false)
+  })
+
+  it('omits the speed field when none is supplied (sidecar defaults to 1.0)', async () => {
+    let receivedBody: string | null = null
+    const fakeFetch: typeof fetch = (async (_url: string, init?: RequestInit) => {
+      receivedBody = init?.body as string
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => OGG_BYTES.buffer.slice(0),
+        text: async () => '',
+        headers: new Headers(),
+      }
+    }) as unknown as typeof fetch
+    await synthesizeViaSidecar({ token: 't', text: 'hi', fetchImpl: fakeFetch })
+    const parsed = JSON.parse(receivedBody!)
+    expect('speed' in parsed).toBe(false)
+  })
+
+  it('includes speed in the /tts body when supplied', async () => {
+    let receivedBody: string | null = null
+    const fakeFetch: typeof fetch = (async (_url: string, init?: RequestInit) => {
+      receivedBody = init?.body as string
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => OGG_BYTES.buffer.slice(0),
+        text: async () => '',
+        headers: new Headers(),
+      }
+    }) as unknown as typeof fetch
+    await synthesizeViaSidecar({ token: 't', text: 'hi', speed: 1.1, fetchImpl: fakeFetch })
+    const parsed = JSON.parse(receivedBody!)
+    expect(parsed.speed).toBe(1.1)
+  })
+
+  it('clamps an out-of-range speed before putting it on the wire', async () => {
+    const cap = async (speed: number): Promise<number> => {
+      let receivedBody: string | null = null
+      const fakeFetch: typeof fetch = (async (_url: string, init?: RequestInit) => {
+        receivedBody = init?.body as string
+        return {
+          ok: true,
+          status: 200,
+          arrayBuffer: async () => OGG_BYTES.buffer.slice(0),
+          text: async () => '',
+          headers: new Headers(),
+        }
+      }) as unknown as typeof fetch
+      await synthesizeViaSidecar({ token: 't', text: 'hi', speed, fetchImpl: fakeFetch })
+      return JSON.parse(receivedBody!).speed
+    }
+    expect(await cap(5.0)).toBe(2.0) // above max → 2.0
+    expect(await cap(0.1)).toBe(0.5) // below min → 0.5
+  })
+})
+
+describe('clampTtsSpeed', () => {
+  it('passes in-range values through', () => {
+    for (const v of [0.5, 0.75, 1.0, 1.1, 1.5, 2.0]) {
+      expect(clampTtsSpeed(v)).toBe(v)
+    }
+  })
+
+  it('clamps out-of-range numbers to the nearest bound', () => {
+    expect(clampTtsSpeed(0.1)).toBe(0.5)
+    expect(clampTtsSpeed(-3)).toBe(0.5)
+    expect(clampTtsSpeed(2.5)).toBe(2.0)
+    expect(clampTtsSpeed(100)).toBe(2.0)
+  })
+
+  it('falls back to the default for non-finite / non-numeric input', () => {
+    expect(clampTtsSpeed(undefined)).toBe(1.0)
+    expect(clampTtsSpeed(null)).toBe(1.0)
+    expect(clampTtsSpeed(NaN)).toBe(1.0)
+    expect(clampTtsSpeed('fast')).toBe(1.0)
+    expect(clampTtsSpeed(undefined, 1.1)).toBe(1.1) // custom fallback
   })
 
   it('falls back to wall-clock durationMs when headers are absent', async () => {

--- a/telegram-plugin/voice-synthesize-sidecar.ts
+++ b/telegram-plugin/voice-synthesize-sidecar.ts
@@ -40,6 +40,25 @@ export const DEFAULT_SIDECAR_BASE_URL = 'http://127.0.0.1:18900'
  *  X-Voice-Token header, and {text, voice?, format?} JSON shape UNCHANGED.) */
 export const SIDECAR_TTS_MAX_CHARS = 100_000
 
+/** TTS playback-speed bounds (mirrors the sidecar clamp in server.py). */
+export const SIDECAR_TTS_SPEED_MIN = 0.5
+export const SIDECAR_TTS_SPEED_MAX = 2.0
+
+/**
+ * Coerce an incoming speed to a float in [SIDECAR_TTS_SPEED_MIN,
+ * SIDECAR_TTS_SPEED_MAX]. Non-finite / non-numeric input falls back to
+ * `fallback` (default 1.0). Out-of-range numbers are clamped to the nearest
+ * bound. Mirrors the sidecar's `_clamp_speed` so the wire value is already
+ * valid before it leaves the gateway.
+ */
+export function clampTtsSpeed(value: unknown, fallback = 1.0): number {
+  // Only a real, finite number is a speed. null/undefined/boolean/string all
+  // fall back (Number(null) is 0 and Number('') is 0 — both would otherwise
+  // masquerade as a valid slow speed).
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  return Math.max(SIDECAR_TTS_SPEED_MIN, Math.min(SIDECAR_TTS_SPEED_MAX, value))
+}
+
 /**
  * Split already-stripped plain text into sequential TTS chunks, each ≤
  * `chunkChars`, preferring sentence then word boundaries so a voice note
@@ -121,6 +140,9 @@ export interface SidecarSynthesizeArgs {
   text: string
   /** Optional engine-specific voice id; the sidecar has its own default. */
   voice?: string
+  /** Optional playback speed. Clamped to [0.5, 2.0] before send; when unset
+   *  the sidecar applies its own 1.0 default. */
+  speed?: number
   /** Base URL for the sidecar. Defaults to DEFAULT_SIDECAR_BASE_URL. */
   baseUrl?: string
   /** Per-call timeout in ms. Default 60s — Kokoro on CPU can run a few
@@ -167,12 +189,14 @@ export async function synthesizeViaSidecar(
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
 
-  // JSON body: server.py reads `text` (str) + optional `voice` + `format`.
-  const body: { text: string; voice?: string; format: 'ogg' } = {
+  // JSON body: server.py reads `text` (str) + optional `voice` + `speed` +
+  // `format`.
+  const body: { text: string; voice?: string; speed?: number; format: 'ogg' } = {
     text,
     format: 'ogg',
   }
   if (args.voice) body.voice = args.voice
+  if (args.speed !== undefined) body.speed = clampTtsSpeed(args.speed)
 
   const startedAt = Date.now()
   let res: Response


### PR DESCRIPTION
## What

Adds an optional playback-**speed** dial to the local voice pipeline, end to end, backward-compatible with today's fixed-1.0 behavior.

### Sidecar — `docker/voice-sidecar/server.py`
- `/tts` accepts an optional `speed` field in the JSON body.
- New `_clamp_speed` validates/clamps to **0.5–2.0**; absent/invalid (None, non-numeric, bool, NaN) → **1.0** (exactly today's behavior).
- `speed` is passed into the Kokoro `create(...)` call for **every internal chunk** and echoed in the response meta.
- **Unchanged:** auth, `/healthz`, `/stt`, the response contract, and the any-length single-file concatenation.

### Gateway — `telegram-plugin/`
- `voice_out` gains an optional `speed` (number, 0.5–2.0). Doc comment + type updated.
- When `voice_out` is enabled but `speed` is unset, defaults to **1.1** (Ken's fleet default), clamped to 0.5–2.0, and included in the kokoro `/tts` body.
- `clampTtsSpeed` (mirrors the sidecar clamp) + `speed` threaded through `SidecarSynthesizeArgs` → `/tts` body and `resolveVoiceOutPlan` → synth loop.
- **OpenAI path unaffected.**

## Tests
- `voice-synthesize-sidecar.test.ts` — gateway sends `speed`, omits when unset, clamps out-of-range; `clampTtsSpeed` unit tests.
- `voice-out-one-send.test.ts` — gateway defaults to 1.1 when unset, honours in-range, clamps, threads into the single `/tts` body.
- `docker/voice-sidecar/test_server.py` — stdlib unittest for `_clamp_speed` (default/clamp/bounds), wired into `ci-tests-python`.

lint + typecheck + the voice bun tests + the python sidecar test all pass locally.

## Clamp / defaults
Range **0.5–2.0**. Defaults: **sidecar 1.0**, **gateway 1.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)