### PR TITLE
docs: reopen a narrow silent-pin exception for already-rendered status

### DIFF
--- a/reference/invariants.md
+++ b/reference/invariants.md
@@ -171,8 +171,32 @@ agent is doing; framework UI (a reaction, a fallback message) is a safety
 net, never a second state mirror. We crossed this line once (the pinned
 progress card) and retired it (#1122); it is now a line, not a tradeoff.
 
-- **By-construction test:** does this add a card, pinned widget, or status
-  surface that mirrors conversation state in parallel? If yes, change the
-  prompt so the model communicates instead. See the "chat IS the artifact"
-  sub-principle in `principles.md` and `know-my-agent-is-doing`'s design
+**One sanctioned exception — the silent pin of an already-rendered status
+message.** The #1122 removal assumed the status message stays visible in the
+live conversation window. That assumption no longer holds: the speed of modern
+answers, more background workers, and much longer-running turns mean the
+conversation moves on quickly in the feed and the user loses sight of in-flight
+work. Work now routinely outlives the visible feed — fast turns scroll it away,
+concurrent background workers stack up, long-running turns run past the fold. To
+keep in-flight work in view when that happens, the framework MAY pin a status
+message **that is already rendered in the chat** — specifically the existing
+per-turn status message and the existing `🛠 Worker` background-worker message —
+and auto-unpin it when that work completes. The pin MUST be silent
+(`disable_notification: true`). This carries no new content: it re-surfaces a
+message the conversation already owns.
+
+This is the ONE exception, and it is narrow by construction. It does **not**
+reopen bespoke cards. It does NOT permit: a new card/widget/status surface
+rendered solely to be pinned; a notification-generating pin; or any pinned
+surface that renders content not already present in the chat. Pinning a message
+the feed already holds is fine; rendering a second, parallel surface is still the
+retired line.
+
+- **By-construction test:** does this pin a message the conversation *already*
+  rendered (per-turn status / `🛠 Worker`), silently, and auto-unpin it on
+  completion? That is the sanctioned exception. Does it instead add a card,
+  pinned widget, or status surface that mirrors conversation state in *parallel*,
+  or render new content solely to pin it? If yes, that is still the retired line
+  — change the prompt so the model communicates instead. See the "chat IS the
+  artifact" sub-principle in `principles.md` and `know-my-agent-is-doing`'s design
   artifact `rfcs/conversational-pacing.md`.

--- a/reference/jobs/know-what-my-agent-is-doing.md
+++ b/reference/jobs/know-what-my-agent-is-doing.md
@@ -50,12 +50,24 @@ close that gap so the user never has to ask.
   told what happened and what resumes.
 - Scrolling back a week later reads as a real conversation, not a deleted
   widget.
+- When work outlives the visible feed — fast turns scroll it away, background
+  workers stack up, a long turn runs past the fold — the framework silently pins
+  the status message that is *already* in the chat (the per-turn status message,
+  the `🛠 Worker` background-worker message) so in-flight work stays in view, and
+  auto-unpins it when that work completes. The pin is silent (no device buzz) and
+  carries no new content: it re-surfaces a message the conversation already owns.
+  This is the one sanctioned pin (see `invariants.md`
+  § `chat-is-the-single-source-of-truth`).
 
 **Bad looks like: never ship this**
 
 - A separate progress surface running parallel to the chat. This was the
   retired card. It duplicates the conversation or covers for a model that
-  won't talk. Make the model talk.
+  won't talk. Make the model talk. (Silently pinning a status message *already
+  rendered in the feed* is the sanctioned exception above — the line is
+  rendering a new parallel surface, not pinning one the chat already holds.)
+- A bespoke card/widget rendered solely to be pinned, or a pin that buzzes the
+  device. That is the retired card wearing a pin, not the sanctioned exception.
 - Narrating every tool call as its own message. Tool churn isn't something
   the user can act on. Silence during tool-calling is fine; the ambient
   signal carries "alive".

--- a/reference/principles.md
+++ b/reference/principles.md
@@ -211,6 +211,16 @@ When you're tempted to add a new pinned card / status bar / live
 widget, ask: would the model sending a real `reply` cover this? If
 yes, change the prompt instead.
 
+One sanctioned exception carries here from `invariants.md`: the framework
+MAY silently pin a status message **already rendered in the chat** (the
+per-turn status message, the `🛠 Worker` background-worker message) and
+auto-unpin it on completion. The reason the #1122 removal no longer fully
+holds: fast answers, more background workers, and much longer turns mean the
+conversation moves on quickly and in-flight work scrolls out of the visible
+feed. Pinning a message the feed already owns keeps it in view; it renders no
+new content, so it is not a parallel surface. Rendering a fresh card/widget
+solely to pin it, or a notification-generating pin, is still the retired line.
+
 ---
 
 ## Applying the principles


### PR DESCRIPTION
## Summary

Reopens a **narrow, bounded** exception on the `chat-is-the-single-source-of-truth` invariant. It does **not** reverse #1122's removal of the pinned progress card — it carves out exactly one sanctioned pattern and re-states the boundary so it can't be read as reopening bespoke cards.

## What the exception permits

A single, **silent** (`disable_notification: true`) pin of a status message that is **already rendered in the conversation** — specifically:

- the existing per-turn status/activity message, and
- the existing `🛠 Worker` background-worker message

pinned when that work goes in-progress and **auto-unpinned when it completes**.

## What it does NOT permit (the boundary, re-stated in every doc)

- A new bespoke card / widget / status surface rendered *solely* to be pinned.
- A notification-generating pin.
- Any pinned surface that renders content **not already present in the chat** (a parallel state mirror). That is still the retired line.

The distinction is: **pinning a message the feed already holds** (fine) vs. **rendering a second, parallel surface** (still banned).

## Rationale (why the #1122 assumption no longer holds)

The #1122 removal assumed status stays visible in the live conversation window. That assumption no longer holds: the speed of modern answers, more background workers, and much longer-running turns mean the conversation moves on quickly in the feed and the user loses sight of in-flight work. Work now routinely outlives the visible feed — fast turns scroll it away, concurrent background workers stack up, long-running turns run past the fold. Pinning a message the chat already owns re-surfaces it without adding a parallel surface.

## Files changed

- `reference/invariants.md` — under `chat-is-the-single-source-of-truth`: keep the line, add the one sanctioned carve-out + rationale, re-state the boundary, update the by-construction test.
- `reference/principles.md` — mirror the carve-out under the "chat IS the artifact" sub-principle (keeps docs consistent).
- `reference/jobs/know-what-my-agent-is-doing.md` — move "silent pin of an already-rendered status message" into **Good looks like**; keep "a separate parallel progress surface / bespoke card" in the **never ship** list.

Docs-only. This PR authorizes the implementation PR (`fix/autopin-status-card`), which must merge **after** this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)