### PR TITLE
feat(rollout): durable, Telegram-visible rollout observability (Part 1)

### DIFF
--- a/reference/jobs/operate-the-fleet-from-telegram.md
+++ b/reference/jobs/operate-the-fleet-from-telegram.md
@@ -1,0 +1,146 @@
+---
+job: operate the fleet from Telegram and see what a fleet operation is doing
+outcome: When the operator drives a fleet-wide operation from Telegram (a rollout, an update), they can see it progress and land — phase by phase, in the chat and in a durable record — without host-side grep, and without a live pinned surface running parallel to the conversation.
+stakes: A fleet rollout is the single riskiest thing the operator does, and today it goes dark: the roll writes one terminal row to a host-side log, `get_status` is blind to its phases, and nothing reaches Telegram. When a real roll (v0.16.35) half-failed, the only way to learn the outcome was to SSH in and grep. An operator who can't see a rollout land can't trust it, and can't catch a half-rolled fleet before a principal does. But the fix is one step from re-creating the retired pinned progress card — so the operability this job asks for must live in durable artifacts plus in-chat narration, never a parallel pinned mirror.
+serves: hold-the-leash
+invariants: [chat-is-the-single-source-of-truth, telegram-only, no-self-escalation, single-tenant]
+---
+
+# Job Spec: operate the fleet from Telegram and see what a fleet operation is doing
+
+> A durable Job Spec. The *how* — the per-phase hash-chained audit rows written
+> by hostd, `get_status`'s rollout-row read, the fire-and-forget terminal push,
+> and the log-tailed narration message — lives in the code under
+> `src/cli/rollout.ts`, `src/host-control/` and `telegram-plugin/gateway/`.
+> That implementation churns; this job does not.
+
+## Who this is for, read this first
+
+This is an **operator** job (`vision.md`'s two people). A fleet rollout is an
+operator action taken from an admin agent's Telegram thread. It is NOT a
+principal surface: a principal never rolls the fleet and never needs to watch
+one. That distinction is load-bearing — it is why the narration here stays a
+normal operator-DM message and never grows into a standing status widget.
+
+This job is the **rollout/fleet-op** sibling of two existing jobs, and it must
+stay consistent with both:
+
+- [`see-my-whole-fleet-from-one-screen`](see-my-whole-fleet-from-one-screen.md)
+  locates fleet status in **durable artifacts** (history, audit, sessions),
+  read-only, and explicitly forbids "a live, pinned, parallel progress mirror
+  of a turn". This job obeys the same rule: a rollout's status lives in the
+  durable audit log (the source of truth) and an in-chat narration message —
+  never a parallel pinned surface.
+- [`know-what-my-agent-is-doing`](know-what-my-agent-is-doing.md) answers "what
+  is happening" **in the chat, by the framework/model speaking** — the
+  invariant's own prescribed remedy. This job's narration is exactly that: a
+  plain message the operator can scroll to, edited in place as the roll
+  progresses.
+
+## The job
+
+The operator kicks off a fleet-wide operation (today: `rollout` / `rollback`,
+reachable via `mcp__hostd__rollout` from an admin agent, or `switchroom rollout`
+host-side). It runs staggered across N agents with a canary gate. The operator
+wants to know, without leaving Telegram and without SSH: did apply succeed, did
+the canary pass, which agent are we on (`N/M`), did it land, and if it stopped —
+where and on which agent. And a week later they want the same answer from a
+durable record, not a memory of a chat message that scrolled away.
+
+## Good / bad
+
+**Good looks like**
+
+- Every phase transition of the roll (apply, canary start/pass/fail, per-agent
+  start/done with `N`/`M`, persist-pin, hostd/web deferred, terminal) is
+  written as a **durable, append-only, hash-chained audit row** carrying the
+  `request_id` and the target pin. The durable log is the source of truth.
+- `get_status` for the roll's `request_id` returns its **latest** state — the
+  current phase while in flight, and the terminal outcome (rolled agents,
+  failed step, failed agent, prior pin) when done — reconstructable from the
+  durable log even if the daemon restarted mid-roll.
+- On the terminal row, the operator gets **one ordinary Telegram message** in
+  their DM saying the roll landed (✅) or stopped (❌ with the step/agent). A
+  normal message, not a card, not a pin.
+- The in-chat narration (when present) is **one ordinary message edited in
+  place** through the phases — `applying → canary → agent N/M → … → ✅/❌` — that
+  reads as a normal message the operator can scroll back to.
+- The narration surface **pulls** from the durable rows: after any gateway
+  restart it re-reads the log to recover, holding no in-memory pin/lifecycle
+  state that a restart could orphan.
+- Narration emits/edits are **fire-and-forget, idempotent + monotonic by
+  sequence, frozen on the terminal row, debounced, and 429-aware** — and never
+  block or fail the roll. The roll's correctness never depends on a chat send
+  resolving.
+- The surface is **bound to a hostd-attested in-flight `request_id`**: a
+  shape-only client message can't paint a forged "✅ rolled" surface.
+
+**Bad looks like: never ship this**
+
+- A **pinned progress card** for the rollout, or any bespoke widget/status bar
+  rendered solely to be pinned. That is the retired #1122 card wearing a
+  rollout hat, and it crosses `chat-is-the-single-source-of-truth`. The one
+  sanctioned pin (silently pinning a status message *already* in the chat) is
+  narrow and is NOT this.
+- A rollout that goes dark: one terminal row, `get_status` blind to phases,
+  nothing in Telegram — the pre-#2726 state that made a half-failed roll
+  discoverable only by host-side grep.
+- A chat send / pin / edit that can **block or fail the roll** (e.g. inheriting
+  the approval card's up-to-61-minute wait). Availability of the fleet op is
+  never sacrificed to a chat surface.
+- A narration surface driven by an **unauthenticated** client message — a
+  forged terminal "✅ rolled to vX" is worse than silence.
+- A second approval path, a cross-agent leak (surfacing another agent's
+  rollout to a non-admin agent), or any principal-facing entry point. Rollout
+  stays admin/operator-gated; the narration lands only in the operator's chat.
+
+## Prove it
+
+- **Durable phase trail** — every phase transition appends a hash-chained audit
+  row with `request_id` + pin; the terminal row is distinct and a phase row can
+  never be mistaken for the terminal sentinel. *Invariant:* the durable log is
+  the source of truth; a phase row is lexically disjoint from the terminal one.
+- **Un-blind get_status** — a `get_status` on the roll's `request_id` returns
+  the current phase in flight and the terminal outcome when done, including
+  reconstructed-from-log after a daemon restart. *Invariant:* rollout rows are
+  read, not just `update_apply` rows.
+- **Terminal ping** — the terminal row pushes exactly one ordinary operator-DM
+  message. *Invariant:* it is a normal message (no pin, no card), fire-and-
+  forget, and a failing push never fails the roll.
+- **Narration, not pin** — the in-chat narration is one ordinary message edited
+  in place, pulled from the durable rows, monotonic + frozen-on-terminal +
+  debounced. *Invariant:* no parallel pinned surface; recovery is a log re-read;
+  bound to a hostd-attested request_id.
+
+## Verdict
+
+- **Done when:** the operator can start a fleet rollout from Telegram, watch it
+  progress phase by phase (in-chat narration + `get_status`), and learn its
+  terminal outcome both as a normal Telegram message and from a durable
+  hash-chained audit record — with no host-side grep, and with no surface that
+  runs parallel to (or pinned above) the conversation.
+
+## Production-readiness
+
+- *Compliance:* no Anthropic API/SDK path; the narration is framework messaging,
+  not model work. Cross-checked against `no-self-escalation` (rollout stays
+  admin/operator-gated; the narration adds no approval path).
+- *Availability:* every chat effect is fire-and-forget; the roll's correctness
+  and completion never depend on a chat send. A gateway outage degrades to the
+  durable log, never a stalled roll.
+- *Boundary:* operator-only, in the operator's own chat. It never becomes a
+  principal surface and never becomes a live parallel progress mirror — the two
+  ways this job would fail even if every feature worked (mirrors the CAUTION in
+  `see-my-whole-fleet-from-one-screen.md`).
+
+> [!CAUTION]
+> If the rollout status becomes a pinned parallel surface, this job has failed
+> even if it shows every phase perfectly. Durable artifact + in-chat narration
+> is the whole design; a live pinned mirror is the retired line.
+
+---
+
+> **Implementation:** the per-phase audit rows + `get_status` un-blinding + the
+> terminal push live in `src/cli/rollout.ts` and `src/host-control/`; the
+> log-tailed in-chat narration relays through the gateway IPC path in
+> `telegram-plugin/gateway/`. Those churn; this job outlives them.

--- a/reference/product-spec.md
+++ b/reference/product-spec.md
@@ -138,6 +138,7 @@ Each links its job spec in `jobs/`.
 - [`steer-or-queue-mid-flight.md`](jobs/steer-or-queue-mid-flight.md) — share of in-flight steer/stop requests honoured before the action lands
 - [`approve-what-my-agent-can-touch.md`](jobs/approve-what-my-agent-can-touch.md) — unapproved consequential actions, target zero
 - [`see-my-whole-fleet-from-one-screen.md`](jobs/see-my-whole-fleet-from-one-screen.md) — share of fleet whose live status is visible from one view
+- [`operate-the-fleet-from-telegram.md`](jobs/operate-the-fleet-from-telegram.md) — share of fleet operations (rollout/update) whose progress + outcome are visible in-chat and durably, without host-side grep
 
 ### subscription-honest
 - [`keep-my-subscription-honest.md`](jobs/keep-my-subscription-honest.md) — off-plan callsites, target zero (CI-enforced)

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -21,12 +21,16 @@ import {
   executeRollout,
   encodeRolloutResultLine,
   parseRolloutResultLine,
+  encodeRolloutPhaseLine,
+  parseRolloutPhaseLine,
   shouldRefuseDowngrade,
   shouldRefuseStaleCli,
   resolveRollbackTarget,
   PREFLIGHT_STALE_CLI_STEP,
   ROLLOUT_RESULT_SENTINEL,
+  ROLLOUT_PHASE_SENTINEL,
   type RolloutDeps,
+  type RolloutPhase,
   type RolloutResult,
   type RolloutStep,
 } from "./rollout.js";
@@ -105,10 +109,17 @@ describe("formatRolloutPlan", () => {
 function harness(opts: {
   versions: Record<string, string | null>;
   runStatus?: (args: string[]) => number;
-}): { deps: RolloutDeps; runs: string[][]; logs: string[]; persisted: string[] } {
+}): {
+  deps: RolloutDeps;
+  runs: string[][];
+  logs: string[];
+  persisted: string[];
+  phases: RolloutPhase[];
+} {
   const runs: string[][] = [];
   const logs: string[] = [];
   const persisted: string[] = [];
+  const phases: RolloutPhase[] = [];
   const deps: RolloutDeps = {
     run: (args) => {
       runs.push(args);
@@ -116,9 +127,10 @@ function harness(opts: {
     },
     probeVersion: (agent) => opts.versions[agent] ?? null,
     log: (line) => logs.push(line),
+    emitPhase: (p) => phases.push(p),
     persistPin: (pin) => persisted.push(pin),
   };
-  return { deps, runs, logs, persisted };
+  return { deps, runs, logs, persisted, phases };
 }
 
 describe("executeRollout", () => {
@@ -609,5 +621,146 @@ describe("resolveRollbackTarget (#2492)", () => {
     const logPath = join(tmp, "audit.log");
     writeFileSync(logPath, "");
     expect(resolveRollbackTarget(logPath)).toBeNull();
+  });
+});
+
+// ── #2726 — per-phase emission + phase sentinel (durable observability) ──────
+
+describe("rollout phase sentinel", () => {
+  it("PHASE and RESULT sentinels are lexically disjoint (neither prefixes the other)", () => {
+    // The terminal parser keys on `startsWith(ROLLOUT_RESULT_SENTINEL)`; the
+    // phase parser keys on `startsWith(ROLLOUT_PHASE_SENTINEL)`. If either were
+    // a prefix of the other, a line could cross-match. Assert disjointness.
+    expect(ROLLOUT_PHASE_SENTINEL.startsWith(ROLLOUT_RESULT_SENTINEL)).toBe(false);
+    expect(ROLLOUT_RESULT_SENTINEL.startsWith(ROLLOUT_PHASE_SENTINEL)).toBe(false);
+  });
+
+  it("a phase line does NOT parse as the terminal RESULT sentinel", () => {
+    const phaseLine = encodeRolloutPhaseLine({ phase: "apply", target: "v1.2.3" });
+    // The terminal parser must return null for a phase line — a phase row can
+    // never be mistaken for the terminal sentinel.
+    expect(parseRolloutResultLine(phaseLine)).toBeNull();
+  });
+
+  it("the terminal RESULT line does NOT parse as a phase sentinel", () => {
+    const resultLine = encodeRolloutResultLine({
+      ok: true,
+      rolled: ["clerk"],
+      warnings: [],
+    });
+    expect(parseRolloutPhaseLine(resultLine)).toBeNull();
+  });
+
+  it("round-trips a phase with agent/n/m", () => {
+    const phase: RolloutPhase = {
+      phase: "agent-start",
+      target: "v1.2.3",
+      agent: "clerk",
+      n: 3,
+      m: 8,
+    };
+    const parsed = parseRolloutPhaseLine(encodeRolloutPhaseLine(phase));
+    expect(parsed).toEqual(phase);
+  });
+
+  it("rejects malformed JSON and unknown phase names", () => {
+    expect(parseRolloutPhaseLine(ROLLOUT_PHASE_SENTINEL + "{not json")).toBeNull();
+    expect(
+      parseRolloutPhaseLine(ROLLOUT_PHASE_SENTINEL + JSON.stringify({ phase: "bogus", target: "v1" })),
+    ).toBeNull();
+    // Missing target.
+    expect(
+      parseRolloutPhaseLine(ROLLOUT_PHASE_SENTINEL + JSON.stringify({ phase: "apply" })),
+    ).toBeNull();
+    // A plain (non-sentinel) line is not a phase.
+    expect(parseRolloutPhaseLine("just a log line")).toBeNull();
+  });
+
+  it("tolerates surrounding whitespace on the line", () => {
+    const line = "  " + encodeRolloutPhaseLine({ phase: "persist-pin", target: "v9.9.9" }) + "  ";
+    expect(parseRolloutPhaseLine(line)?.phase).toBe("persist-pin");
+  });
+});
+
+describe("executeRollout — phase emission", () => {
+  const TARGET = "v0.15.18";
+
+  it("emits apply → canary-start/pass → agent-start/done with n/m", () => {
+    const steps = planRollout(["test-harness", "clerk", "marko"]);
+    const { deps, phases } = harness({
+      versions: { "test-harness": "0.15.18", clerk: "0.15.18", marko: "0.15.18" },
+    });
+    executeRollout(steps, TARGET, deps);
+    const names = phases.map((p) => p.phase);
+    expect(names).toContain("apply");
+    // test-harness is the canary (first restart) → canary-start/canary-pass.
+    expect(names).toContain("canary-start");
+    expect(names).toContain("canary-pass");
+    // clerk + marko → agent-start/agent-done.
+    expect(names).toContain("agent-start");
+    expect(names).toContain("agent-done");
+    // Canary is n=1; total m = 3.
+    const canaryStart = phases.find((p) => p.phase === "canary-start");
+    expect(canaryStart).toMatchObject({ agent: "test-harness", n: 1, m: 3, target: TARGET });
+    // A later agent carries its 1-based position.
+    const lastDone = phases.filter((p) => p.phase === "agent-done").at(-1);
+    expect(lastDone).toMatchObject({ agent: "marko", n: 3, m: 3 });
+  });
+
+  it("emits canary-fail (not agent-done) when the canary mismatches and STOPS", () => {
+    const steps = planRollout(["test-harness", "clerk"]);
+    const { deps, phases } = harness({
+      // Canary comes back on the WRONG version → stop.
+      versions: { "test-harness": "0.15.17", clerk: "0.15.18" },
+    });
+    const r = executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(false);
+    const names = phases.map((p) => p.phase);
+    expect(names).toContain("canary-start");
+    expect(names).toContain("canary-fail");
+    expect(names).not.toContain("canary-pass");
+    // Never reached clerk.
+    expect(names).not.toContain("agent-start");
+  });
+
+  it("emits agent-done (per-agent stop) when a NON-canary agent mismatches", () => {
+    const steps = planRollout(["test-harness", "clerk"]);
+    const { deps, phases } = harness({
+      versions: { "test-harness": "0.15.18", clerk: "0.15.17" }, // clerk bad
+    });
+    const r = executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(false);
+    const names = phases.map((p) => p.phase);
+    expect(names).toContain("canary-pass"); // canary was fine
+    // clerk failed → agent-done (its start + the fail-shaped done), never canary-*.
+    const clerkDone = phases.filter((p) => p.phase === "agent-done" && p.agent === "clerk");
+    expect(clerkDone.length).toBe(1);
+  });
+
+  it("emits a persist-pin phase on the hostd path", () => {
+    const steps = planRollout(["test-harness", "clerk"], {
+      hostdContext: true,
+      pinToPersist: TARGET,
+    });
+    const { deps, phases } = harness({
+      versions: { "test-harness": "0.15.18", clerk: "0.15.18" },
+    });
+    executeRollout(steps, TARGET, deps, { hostdContext: true });
+    expect(phases.map((p) => p.phase)).toContain("persist-pin");
+  });
+
+  it("does not throw when emitPhase is omitted (older callers)", () => {
+    const steps = planRollout(["clerk"]);
+    const runs: string[][] = [];
+    const deps: RolloutDeps = {
+      run: (a) => {
+        runs.push(a);
+        return { status: 0 };
+      },
+      probeVersion: () => "0.15.18",
+      log: () => {},
+      // no emitPhase
+    };
+    expect(() => executeRollout(steps, TARGET, deps)).not.toThrow();
   });
 });

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -204,6 +204,110 @@ export function formatRolloutPlan(
   return lines.join("\n");
 }
 
+/**
+ * One rollout phase transition (#2726 durable observability). Emitted by the
+ * spawned subprocess on stdout as a `SWITCHROOM_ROLLOUT_PHASE:` sentinel line;
+ * hostd — the SOLE writer of the hash-chained host-control audit log — parses
+ * each line and persists it as a phase audit row (see the seam note at the top
+ * of this file's phase section). The subprocess NEVER writes the chained log
+ * directly: two writers to one hash chain forks it (audit-hashchain.ts § the
+ * single-writer contract), so the buildable form of "the roll emits a row per
+ * phase" is emit-on-stdout, hostd-appends.
+ *
+ * The `phase` strings are lexically DISJOINT from the terminal-result sentinel
+ * (`SWITCHROOM_ROLLOUT_RESULT:`): a phase line starts with a different prefix,
+ * and no phase string equals "terminal" (hostd owns that row). This keeps the
+ * terminal-sentinel parser (`parseRolloutResultLine`) unable to mistake a phase
+ * line for the result line, and vice versa.
+ */
+export type RolloutPhaseName =
+  | "apply"
+  | "canary-start"
+  | "canary-pass"
+  | "canary-fail"
+  | "agent-start"
+  | "agent-done"
+  | "persist-pin"
+  | "hostd-web-deferred";
+
+export interface RolloutPhase {
+  phase: RolloutPhaseName;
+  /** The rollout target version (carried on every phase for the reader). */
+  target: string;
+  /** Agent name (agent-start / agent-done / canary-* rows). */
+  agent?: string;
+  /** 1-based index of this agent in the roll order (agent-start / -done). */
+  n?: number;
+  /** Total agents being rolled (agent-start / -done). */
+  m?: number;
+}
+
+/**
+ * Sentinel prefix for a per-phase progress line the rollout subprocess writes
+ * to stdout. hostd streams the child's stdout, parses each such line, and
+ * appends a hash-chained phase audit row through its single-writer append path.
+ *
+ * MUST stay lexically disjoint from {@link ROLLOUT_RESULT_SENTINEL} so the
+ * terminal parser and the phase parser can never cross-match. (`…PHASE:` vs
+ * `…RESULT:` — neither is a prefix of the other.)
+ */
+export const ROLLOUT_PHASE_SENTINEL = "SWITCHROOM_ROLLOUT_PHASE:";
+
+/** Serialize a phase for the sentinel line hostd parses. */
+export function encodeRolloutPhaseLine(phase: RolloutPhase): string {
+  return (
+    ROLLOUT_PHASE_SENTINEL +
+    JSON.stringify({
+      phase: phase.phase,
+      target: phase.target,
+      ...(phase.agent !== undefined ? { agent: phase.agent } : {}),
+      ...(phase.n !== undefined ? { n: phase.n } : {}),
+      ...(phase.m !== undefined ? { m: phase.m } : {}),
+    })
+  );
+}
+
+/**
+ * Parse a single line as a rollout PHASE sentinel. Returns null when the line
+ * is not a phase line (including when it is the terminal RESULT sentinel — the
+ * two are anchored disjoint). Defensive against malformed JSON / unknown phase
+ * names so a torn or forged line degrades to "not a phase" rather than throwing.
+ */
+export function parseRolloutPhaseLine(line: string): RolloutPhase | null {
+  const trimmed = line.trim();
+  // Anchor: only a line that STARTS with the phase sentinel is a phase line.
+  // The result sentinel starts with a different prefix, so it can never match.
+  if (!trimmed.startsWith(ROLLOUT_PHASE_SENTINEL)) return null;
+  let obj: unknown;
+  try {
+    obj = JSON.parse(trimmed.slice(ROLLOUT_PHASE_SENTINEL.length));
+  } catch {
+    return null;
+  }
+  if (typeof obj !== "object" || obj === null) return null;
+  const o = obj as Record<string, unknown>;
+  const PHASES: ReadonlySet<string> = new Set([
+    "apply",
+    "canary-start",
+    "canary-pass",
+    "canary-fail",
+    "agent-start",
+    "agent-done",
+    "persist-pin",
+    "hostd-web-deferred",
+  ]);
+  if (typeof o.phase !== "string" || !PHASES.has(o.phase)) return null;
+  if (typeof o.target !== "string") return null;
+  const out: RolloutPhase = {
+    phase: o.phase as RolloutPhaseName,
+    target: o.target,
+  };
+  if (typeof o.agent === "string") out.agent = o.agent;
+  if (typeof o.n === "number") out.n = o.n;
+  if (typeof o.m === "number") out.m = o.m;
+  return out;
+}
+
 /** Injectable side-effects so the executor unit-tests without docker. */
 export interface RolloutDeps {
   /** Run a `switchroom <args>` subcommand; returns the exit status. */
@@ -212,6 +316,13 @@ export interface RolloutDeps {
   probeVersion(agent: string): string | null;
   /** Emit a progress line. */
   log(line: string): void;
+  /**
+   * Emit a structured phase transition. Default (in production) writes an
+   * {@link encodeRolloutPhaseLine} sentinel to stdout for hostd to persist;
+   * tests inject a spy. Optional so callers that don't narrate (and older
+   * tests) can omit it.
+   */
+  emitPhase?(phase: RolloutPhase): void;
   /**
    * Durably persist `release.pin = pin` to switchroom.yaml (comment-
    * preserving, atomic, ownership-restoring). Only invoked for a
@@ -390,6 +501,13 @@ export function executeRollout(
   const targetNorm = normalizeVersion(target);
   const rolled: string[] = [];
   const warnings: string[] = [];
+  const emit = (phase: RolloutPhase): void => deps.emitPhase?.(phase);
+
+  // Roll-order accounting for the agent-start/-done phase rows: `m` is the
+  // total number of agents this plan restarts; `n` is the 1-based position of
+  // the agent being restarted. The canary (first restart-agent step) is n=1.
+  const totalAgents = steps.filter((s) => s.kind === "restart-agent").length;
+  let agentIndex = 0;
 
   for (const step of steps) {
     switch (step.kind) {
@@ -403,6 +521,7 @@ export function executeRollout(
         } else {
           warnings.push(`persist-pin requested but no persist hook wired; pin NOT durable`);
         }
+        emit({ phase: "persist-pin", target });
         break;
       }
       case "apply": {
@@ -410,6 +529,7 @@ export function executeRollout(
         // pass the one-shot --pin so compose regenerates on the target.
         // host-shell path: pin already persisted → bare apply reads it.
         deps.log(`ROLL_STEP apply — regenerating compose for ${target}`);
+        emit({ phase: "apply", target });
         const applyArgs = execOpts.hostdContext
           ? ["apply", "--pin", target]
           : ["apply"];
@@ -421,6 +541,16 @@ export function executeRollout(
       }
       case "restart-agent": {
         deps.log(`ROLL_STEP restart-agent — ${step.agent} (--wait --force)`);
+        agentIndex += 1;
+        const isCanary = agentIndex === 1;
+        // The first agent restarted is the sanctioned canary gate
+        // (stop-on-first-mismatch). Narrate its start/pass/fail distinctly so
+        // the operator sees the canary decision, not just "agent 1/N".
+        emit(
+          isCanary
+            ? { phase: "canary-start", target, agent: step.agent, n: agentIndex, m: totalAgents }
+            : { phase: "agent-start", target, agent: step.agent, n: agentIndex, m: totalAgents },
+        );
         // `agent restart` can exit 0 while still "polling" on boot — do
         // NOT trust its status; the version assert is the real gate.
         //
@@ -439,6 +569,13 @@ export function executeRollout(
         const got = deps.probeVersion(step.agent);
         if (got === null || normalizeVersion(got) !== targetNorm) {
           deps.log(`  ✗ ${step.agent} → ${got ?? "<unreachable>"} (expected ${target}) — STOPPING`);
+          // A failed canary is the gate that stops the whole roll; a
+          // failed non-canary is a per-agent stop. Narrate both distinctly.
+          emit(
+            isCanary
+              ? { phase: "canary-fail", target, agent: step.agent, n: agentIndex, m: totalAgents }
+              : { phase: "agent-done", target, agent: step.agent, n: agentIndex, m: totalAgents },
+          );
           return {
             ok: false,
             rolled,
@@ -450,6 +587,11 @@ export function executeRollout(
         }
         rolled.push(step.agent);
         deps.log(`  ✓ ${step.agent} → ${got}`);
+        emit(
+          isCanary
+            ? { phase: "canary-pass", target, agent: step.agent, n: agentIndex, m: totalAgents }
+            : { phase: "agent-done", target, agent: step.agent, n: agentIndex, m: totalAgents },
+        );
         break;
       }
       case "refresh-web": {
@@ -687,6 +829,14 @@ export function registerRolloutCommand(program: Command): void {
           return (r.stdout ?? "").trim().split("\n").pop()?.trim() ?? null;
         },
         log: (line) => process.stdout.write(line + "\n"),
+        // #2726 — emit each phase transition as a stdout sentinel line hostd
+        // parses into a durable, hash-chained audit row. Harmless on the
+        // host-shell path (no hostd tailing stdout there); load-bearing on the
+        // hostd path where it drives durable observability + the narration
+        // surface. NEVER writes the audit log directly — hostd is the sole
+        // writer, preserving the single-writer hash-chain contract.
+        emitPhase: (phase) =>
+          process.stdout.write(encodeRolloutPhaseLine(phase) + "\n"),
         persistPin: (pin) => {
           const before = readFileSync(configPath, "utf8");
           const after = setReleasePinInConfig(before, pin);
@@ -740,6 +890,14 @@ export function registerRolloutCommand(program: Command): void {
           "hostd/web refresh deferred — run host-side (`switchroom webd install` " +
             "/ `switchroom hostd install`). An agent-invoked rollout cannot " +
             "recreate its own hostd container without killing itself.",
+        );
+        // #2726 — narrate the deferral as a phase so the durable log + the
+        // narration surface show "hostd/web deferred" between the last agent
+        // and the terminal row. Only meaningful on the hostd path (the only
+        // path that defers). Emitted only when the roll got far enough to
+        // matter — i.e. it wasn't refused before executeRollout ran.
+        process.stdout.write(
+          encodeRolloutPhaseLine({ phase: "hostd-web-deferred", target }) + "\n",
         );
       }
 

--- a/src/host-control/audit-reader.ts
+++ b/src/host-control/audit-reader.ts
@@ -50,6 +50,13 @@ export interface AuditEntry {
   failed_step?: string;
   /** Agent that failed the version assert (rollout rows). */
   failed_agent?: string;
+  // ─── Rollout phase rows (#2726) ────────────────────────────────────
+  /** Agent named in a per-phase rollout row (agent-start/-done, canary-*). */
+  agent?: string;
+  /** Roll-order position (1-based) of the agent named in a phase row. */
+  n?: number;
+  /** Total agents this roll restarts (phase rows). */
+  m?: number;
   // ─── Prior-pin capture (#2492) ────────────────────────────────────
   /** Semver that WAS running before this rollout completed. Only present
    *  on completed (ok=true) rollout terminal rows. Enables
@@ -140,6 +147,10 @@ export function parseAuditLine(line: string): AuditEntry | null {
   }
   if (typeof o.failed_step === "string") entry.failed_step = o.failed_step;
   if (typeof o.failed_agent === "string") entry.failed_agent = o.failed_agent;
+  // Rollout phase rows (#2726) — per-phase agent/n/m context.
+  if (typeof o.agent === "string") entry.agent = o.agent;
+  if (typeof o.n === "number") entry.n = o.n;
+  if (typeof o.m === "number") entry.m = o.m;
   // Prior-pin capture (#2492) — present only on completed rollout terminal rows.
   if (typeof o.prior_pin === "string") entry.prior_pin = o.prior_pin;
   return entry;
@@ -182,6 +193,34 @@ export function readAndFilter(
   }
   const filtered = filterEntries(parsed, filters);
   return filtered.slice(-Math.max(1, limit));
+}
+
+/**
+ * #2726 — the LATEST rollout audit row for a given `request_id`, from the
+ * durable log. "Latest" = the last-written row for that request among all
+ * rollout ops (`rollout` + the synthetic `rollout_orphaned`), covering the
+ * per-phase progress rows AND the terminal row. This is what un-blinds
+ * `get_status` when the in-memory status entry is gone (hostd restarted
+ * mid-roll, or the entry aged out) — the durable log is the source of truth.
+ *
+ * Pure: caller passes the whole log contents. Returns null when no rollout row
+ * for that request_id exists. Rows are appended in order, so the last matching
+ * parsed row is the most recent phase/terminal state.
+ */
+export function latestRolloutRowForRequest(
+  raw: string,
+  requestId: string,
+): AuditEntry | null {
+  const ROLLOUT_OPS = new Set(["rollout", "rollout_orphaned"]);
+  let latest: AuditEntry | null = null;
+  for (const line of raw.split("\n")) {
+    const e = parseAuditLine(line);
+    if (e === null) continue;
+    if (e.request_id !== requestId) continue;
+    if (!ROLLOUT_OPS.has(e.op)) continue;
+    latest = e; // keep walking — the last match wins (most-recent).
+  }
+  return latest;
 }
 
 function shortCaller(caller: AuditEntry["caller"]): string {

--- a/src/host-control/main.ts
+++ b/src/host-control/main.ts
@@ -27,6 +27,7 @@ import { loadConfig } from "../config/loader.js";
 import { allocateAgentUid } from "../agents/compose.js";
 import { HostdServer } from "./server.js";
 import { SocketApprovalGateway } from "./approval-gateway.js";
+import { SocketRolloutRelay } from "./rollout-relay.js";
 import { ReleaseWatcher } from "./release-watcher.js";
 import {
   makeReleaseCheck,
@@ -71,12 +72,22 @@ async function main(): Promise<void> {
   const agentsDir =
     process.env.SWITCHROOM_AGENTS_DIR ??
     join(homedir(), ".switchroom", "agents");
+  const resolveGatewaySocket = (agentName: string): string | null => {
+    const sock = resolve(agentsDir, agentName, "telegram", "gateway.sock");
+    return existsSync(sock) ? sock : null;
+  };
   const approvalGateway = new SocketApprovalGateway({
-    resolveGatewaySocket: (agentName) => {
-      const sock = resolve(agentsDir, agentName, "telegram", "gateway.sock");
-      return existsSync(sock) ? sock : null;
-    },
+    resolveGatewaySocket,
     log: (m) => process.stderr.write(`hostd: approval-gateway — ${m}\n`),
+  });
+
+  // #2726 Part 1 — rollout terminal-push relay. Same transport as the approval
+  // gateway (the caller agent's gateway IPC socket), but fire-and-forget: it
+  // posts ONE ordinary operator-DM message on the rollout terminal row and
+  // never awaits a reply, so a slow/absent gateway can't stall the roll.
+  const rolloutRelay = new SocketRolloutRelay({
+    resolveGatewaySocket,
+    log: (m) => process.stderr.write(`hostd: rollout-relay — ${m}\n`),
   });
 
   const server = new HostdServer({
@@ -103,6 +114,7 @@ async function main(): Promise<void> {
         : {}),
     },
     approvalGateway,
+    rolloutRelay,
   });
   await server.start();
 

--- a/src/host-control/render-rollout-status.ts
+++ b/src/host-control/render-rollout-status.ts
@@ -1,0 +1,86 @@
+/**
+ * Pure renderers for the rollout status message (#2726).
+ *
+ * The rollout narration is an ORDINARY operator-DM message the operator can
+ * scroll to — NOT a pinned card, NOT a bespoke widget. It reads like the
+ * framework speaking a plain progress line in the chat, which is exactly the
+ * remedy the `chat-is-the-single-source-of-truth` invariant prescribes (in-chat
+ * narration, never a parallel pinned mirror).
+ *
+ * These functions are pure (input → string) so both the terminal push (Part 1)
+ * and the log-tailed narration surface (Part 2) render identically and can be
+ * unit-tested without a gateway.
+ */
+
+/** The rollout progress state a renderer needs — a projection of the latest
+ *  durable rollout row / status payload. */
+export interface RolloutRenderState {
+  target: string;
+  /** Current phase name from the latest phase row, or "terminal". */
+  phase?: string;
+  /** Agents confirmed on the target, in order. */
+  rolled?: string[];
+  /** Roll-order position (1-based) of the agent in the current phase. */
+  n?: number;
+  /** Total agents this roll restarts. */
+  m?: number;
+  /** Agent named in the current phase. */
+  agent?: string;
+  /** Terminal outcome — set only once the roll finished. */
+  terminal?: "completed" | "error";
+  /** Step that stopped a failed roll. */
+  failedStep?: string;
+  /** Agent that failed the version assert. */
+  failedAgent?: string;
+  /** Version detected on the failed agent (null = unreachable). */
+  got?: string | null;
+}
+
+/** Human-readable one-liner for the current phase. */
+function phaseLine(s: RolloutRenderState): string {
+  switch (s.phase) {
+    case "apply":
+      return "applying — regenerating compose";
+    case "canary-start":
+      return `canary — restarting ${s.agent ?? "canary agent"}`;
+    case "canary-pass":
+      return `canary passed (${s.agent ?? "canary"}) — rolling the rest`;
+    case "canary-fail":
+      return `canary failed (${s.agent ?? "canary"})`;
+    case "agent-start":
+      return `agent ${s.n ?? "?"}/${s.m ?? "?"} — restarting ${s.agent ?? ""}`.trim();
+    case "agent-done":
+      return `agent ${s.n ?? "?"}/${s.m ?? "?"} — ${s.agent ?? ""} done`.trim();
+    case "persist-pin":
+      return "persisting pin";
+    case "hostd-web-deferred":
+      return "hostd/web refresh deferred (run host-side)";
+    default:
+      return "starting";
+  }
+}
+
+/**
+ * Render the full status message body. When `terminal` is set, renders the
+ * final ✅/❌ line; otherwise the in-flight progress line. Always leads with the
+ * target so the message is self-describing when scrolled back to.
+ */
+export function renderRolloutStatus(s: RolloutRenderState): string {
+  const head = `Rollout → ${s.target}`;
+  const rolledCount = s.rolled?.length ?? 0;
+  if (s.terminal === "completed") {
+    return `✅ ${head} — done. Rolled ${rolledCount} agent(s): ${(s.rolled ?? []).join(", ") || "none"}.`;
+  }
+  if (s.terminal === "error") {
+    const where = s.failedStep
+      ? ` at ${s.failedStep}${s.failedAgent ? ` (${s.failedAgent} → ${s.got ?? "unreachable"})` : ""}`
+      : "";
+    return (
+      `❌ ${head} — STOPPED${where}. ` +
+      `Rolled before stop: ${(s.rolled ?? []).join(", ") || "none"}.`
+    );
+  }
+  // In-flight.
+  const progress = rolledCount > 0 ? ` · ${rolledCount} rolled` : "";
+  return `⏳ ${head} — ${phaseLine(s)}${progress}`;
+}

--- a/src/host-control/rollout-observability.test.ts
+++ b/src/host-control/rollout-observability.test.ts
@@ -1,0 +1,162 @@
+/**
+ * #2726 — durable rollout observability: the audit-reader helper that
+ * un-blinds `get_status` (latestRolloutRowForRequest) and the pure status
+ * renderer (renderRolloutStatus). Both are pure functions exercised without a
+ * daemon or a gateway.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  latestRolloutRowForRequest,
+  parseAuditLine,
+} from "./audit-reader.js";
+import { renderRolloutStatus } from "./render-rollout-status.js";
+
+/** Build one JSONL audit row (the shape hostd writes, chain fields elided —
+ *  parseAuditLine ignores `_seq`/`_prev`/`_hash`). */
+function row(o: Record<string, unknown>): string {
+  return (
+    JSON.stringify({
+      ts: "2026-07-01T00:00:00.000Z",
+      caller: { kind: "agent", name: "overlord" },
+      exit_code: null,
+      duration_ms: 10,
+      ...o,
+    }) + "\n"
+  );
+}
+
+describe("latestRolloutRowForRequest", () => {
+  const REQ = "req-abc";
+
+  it("returns null when no rollout row exists for the request", () => {
+    const log =
+      row({ op: "apply", request_id: "other", result: "started" }) +
+      row({ op: "rollout", request_id: "different", phase: "apply", result: "started" });
+    expect(latestRolloutRowForRequest(log, REQ)).toBeNull();
+  });
+
+  it("returns the LATEST rollout row (last-written phase) for the request", () => {
+    const log =
+      row({ op: "rollout", request_id: REQ, phase: "apply", result: "started", pin: "v1.2.3" }) +
+      row({ op: "rollout", request_id: REQ, phase: "canary-start", result: "started", pin: "v1.2.3", agent: "test-harness", n: 1, m: 3 }) +
+      row({ op: "rollout", request_id: REQ, phase: "agent-start", result: "started", pin: "v1.2.3", agent: "clerk", n: 2, m: 3 });
+    const latest = latestRolloutRowForRequest(log, REQ);
+    expect(latest?.phase).toBe("agent-start");
+    expect(latest?.agent).toBe("clerk");
+    expect(latest?.n).toBe(2);
+    expect(latest?.m).toBe(3);
+    expect(latest?.pin).toBe("v1.2.3");
+  });
+
+  it("returns the terminal row once it is written", () => {
+    const log =
+      row({ op: "rollout", request_id: REQ, phase: "agent-start", result: "started", pin: "v1.2.3", agent: "clerk", n: 2, m: 3 }) +
+      row({ op: "rollout", request_id: REQ, phase: "terminal", result: "completed", pin: "v1.2.3", rolled: ["test-harness", "clerk", "marko"], prior_pin: "v1.2.2" });
+    const latest = latestRolloutRowForRequest(log, REQ);
+    expect(latest?.phase).toBe("terminal");
+    expect(latest?.result).toBe("completed");
+    expect(latest?.rolled).toEqual(["test-harness", "clerk", "marko"]);
+    expect(latest?.prior_pin).toBe("v1.2.2");
+  });
+
+  it("includes the synthetic rollout_orphaned op", () => {
+    const log =
+      row({ op: "rollout", request_id: REQ, result: "started" }) +
+      row({ op: "rollout_orphaned", request_id: REQ, phase: "orphan_reconciled", result: "error" });
+    const latest = latestRolloutRowForRequest(log, REQ);
+    expect(latest?.op).toBe("rollout_orphaned");
+    expect(latest?.result).toBe("error");
+  });
+
+  it("ignores non-rollout ops sharing the request_id", () => {
+    const log =
+      row({ op: "rollout", request_id: REQ, phase: "apply", result: "started" }) +
+      // A different op (shouldn't happen with distinct request_ids, but be defensive).
+      row({ op: "agent_restart", request_id: REQ, result: "completed" });
+    const latest = latestRolloutRowForRequest(log, REQ);
+    expect(latest?.op).toBe("rollout");
+    expect(latest?.phase).toBe("apply");
+  });
+
+  it("tolerates torn / malformed lines (parseAuditLine returns null)", () => {
+    const log =
+      "{ not json\n" +
+      row({ op: "rollout", request_id: REQ, phase: "canary-pass", result: "started" }) +
+      "\n"; // trailing blank
+    expect(latestRolloutRowForRequest(log, REQ)?.phase).toBe("canary-pass");
+  });
+});
+
+describe("audit-reader parses rollout phase fields", () => {
+  it("parses agent / n / m off a phase row", () => {
+    const e = parseAuditLine(
+      row({ op: "rollout", request_id: "r", phase: "agent-start", result: "started", agent: "clerk", n: 4, m: 9 }),
+    );
+    expect(e?.agent).toBe("clerk");
+    expect(e?.n).toBe(4);
+    expect(e?.m).toBe(9);
+  });
+});
+
+describe("renderRolloutStatus", () => {
+  it("renders an in-flight applying line", () => {
+    const out = renderRolloutStatus({ target: "v1.2.3", phase: "apply" });
+    expect(out).toContain("v1.2.3");
+    expect(out).toContain("applying");
+    expect(out.startsWith("⏳")).toBe(true);
+  });
+
+  it("renders agent N/M progress", () => {
+    const out = renderRolloutStatus({
+      target: "v1.2.3",
+      phase: "agent-start",
+      agent: "clerk",
+      n: 3,
+      m: 8,
+      rolled: ["test-harness", "marko"],
+    });
+    expect(out).toContain("agent 3/8");
+    expect(out).toContain("clerk");
+    expect(out).toContain("2 rolled");
+  });
+
+  it("renders the ✅ terminal-completed line with the rolled list", () => {
+    const out = renderRolloutStatus({
+      target: "v1.2.3",
+      terminal: "completed",
+      rolled: ["test-harness", "clerk"],
+    });
+    expect(out.startsWith("✅")).toBe(true);
+    expect(out).toContain("done");
+    expect(out).toContain("test-harness, clerk");
+  });
+
+  it("renders the ❌ terminal-error line with the failed step + agent", () => {
+    const out = renderRolloutStatus({
+      target: "v1.2.3",
+      terminal: "error",
+      failedStep: "restart-agent",
+      failedAgent: "clerk",
+      got: "1.2.2",
+      rolled: ["test-harness"],
+    });
+    expect(out.startsWith("❌")).toBe(true);
+    expect(out).toContain("STOPPED");
+    expect(out).toContain("restart-agent");
+    expect(out).toContain("clerk");
+    expect(out).toContain("1.2.2");
+    expect(out).toContain("test-harness");
+  });
+
+  it("renders 'unreachable' when the failed agent version is null", () => {
+    const out = renderRolloutStatus({
+      target: "v1.2.3",
+      terminal: "error",
+      failedStep: "restart-agent",
+      failedAgent: "clerk",
+      got: null,
+    });
+    expect(out).toContain("unreachable");
+  });
+});

--- a/src/host-control/rollout-relay.ts
+++ b/src/host-control/rollout-relay.ts
@@ -1,0 +1,111 @@
+// hostd RolloutRelay (#2726 Part 1) — pushes ONE ordinary operator-DM message
+// to Telegram when a fleet rollout reaches its terminal row.
+//
+// This reuses the SAME transport as the approval card
+// (`src/host-control/approval-gateway.ts`): hostd connects, as a client, to the
+// caller agent's gateway IPC socket (`<agentsDir>/<agent>/telegram/gateway.sock`)
+// and writes one typed JSON line. The gateway posts it to the operator's chat
+// (`allowFrom[0]`) as a NORMAL message — NOT a pinned card, NOT a bespoke
+// widget. That keeps it clear of the `chat-is-the-single-source-of-truth`
+// invariant: it is the model/framework speaking a plain message in the chat,
+// the invariant's own prescribed remedy.
+//
+// Discipline (locked by the design review): fire-and-forget. The approval path
+// blocks up to 61 min awaiting an operator tap; this MUST NOT inherit that. We
+// connect, write, and disconnect — never awaiting a reply, wrapping everything
+// so a slow / absent / erroring gateway can never block or fail the roll.
+
+import { connect, type Socket } from "node:net";
+
+export interface RolloutTerminalNotice {
+  /** hostd request_id of the roll (binds the message to a real request). */
+  requestId: string;
+  /** The admin agent whose gateway relays the message (the rollout caller). */
+  agentName: string;
+  /** Fully-rendered message body (already safe plain/markdown text). */
+  text: string;
+}
+
+export interface RolloutRelay {
+  /**
+   * Post ONE ordinary operator-DM message. Fire-and-forget: returns
+   * immediately, never throws, never blocks the caller. A failure to reach the
+   * gateway is swallowed (logged) — a rolled fleet with a missing chat ping is
+   * strictly better than a roll stalled on a chat send.
+   */
+  postTerminal(notice: RolloutTerminalNotice): void;
+}
+
+export interface SocketRolloutRelayOptions {
+  /** Resolve the caller agent's gateway IPC socket path; null → drop. */
+  resolveGatewaySocket: (agentName: string) => string | null;
+  log?: (msg: string) => void;
+}
+
+/**
+ * Production relay against `<agentDir>/telegram/gateway.sock`. Same socket the
+ * SocketApprovalGateway uses — but this one NEVER waits for a reply.
+ */
+export class SocketRolloutRelay implements RolloutRelay {
+  constructor(private opts: SocketRolloutRelayOptions) {}
+
+  postTerminal(notice: RolloutTerminalNotice): void {
+    const log = this.opts.log ?? (() => {});
+    let sockPath: string | null;
+    try {
+      sockPath = this.opts.resolveGatewaySocket(notice.agentName);
+    } catch (e) {
+      log(`resolveGatewaySocket threw for ${notice.agentName}: ${(e as Error).message}`);
+      return;
+    }
+    if (sockPath === null) {
+      // No reachable gateway. Drop — the durable terminal audit row is still
+      // the record of what happened; the chat ping is best-effort.
+      log(`no reachable gateway socket for ${notice.agentName}; dropping terminal ping`);
+      return;
+    }
+    // Wrap the whole connect+write so nothing here can throw into the caller.
+    try {
+      const client: Socket = connect({ path: sockPath });
+      // Never let a hung connect keep an fd / event loop ref around.
+      client.setTimeout(5000);
+      const done = (): void => {
+        try {
+          client.destroy();
+        } catch {
+          /* already gone */
+        }
+      };
+      client.on("connect", () => {
+        try {
+          client.write(
+            JSON.stringify({
+              type: "rollout_status_post",
+              requestId: notice.requestId,
+              agentName: notice.agentName,
+              text: notice.text,
+            }) + "\n",
+          );
+          // Fire-and-forget: end the write side immediately. We do NOT wait for
+          // a reply — the roll must not depend on the chat send resolving.
+          client.end();
+        } catch (e) {
+          log(`rollout terminal write failed (requestId=${notice.requestId}): ${(e as Error).message}`);
+          done();
+        }
+      });
+      client.on("timeout", () => {
+        log(`rollout terminal connect timed out (requestId=${notice.requestId})`);
+        done();
+      });
+      client.on("error", (e) => {
+        log(`rollout terminal socket error (requestId=${notice.requestId}): ${e.message}`);
+        done();
+      });
+      // Nothing to do on close — the write already left our process.
+      client.on("close", () => {});
+    } catch (e) {
+      log(`rollout terminal connect threw (requestId=${notice.requestId}): ${(e as Error).message}`);
+    }
+  }
+}

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -56,15 +56,22 @@ import { chainRow, seedChain, type ChainState } from "../util/audit-hashchain.js
 import { socketPathToIdentity, type SocketIdentity } from "./peercred.js";
 import { redact } from "../secret-detect/redact.js";
 import { detectInstallType, type InstallType } from "../cli/install-detect.js";
-import { parseRolloutResultLine, isVersionAssertable } from "../cli/rollout.js";
+import {
+  parseRolloutResultLine,
+  parseRolloutPhaseLine,
+  isVersionAssertable,
+  type RolloutPhase,
+} from "../cli/rollout.js";
 import { parseUpdateResultLine } from "../cli/update.js";
-import { parseAuditLine } from "./audit-reader.js";
+import { parseAuditLine, latestRolloutRowForRequest } from "./audit-reader.js";
 import {
   validateConfigEdit,
   assertSelfScopedAllowEdit,
 } from "./config-edit-validator.js";
 import { classifyBlastRadius } from "./config-blast-radius.js";
 import type { ApprovalGateway } from "./approval-gateway.js";
+import type { RolloutRelay } from "./rollout-relay.js";
+import { renderRolloutStatus } from "./render-rollout-status.js";
 import { loadConfig, resolveAgentsDir } from "../config/loader.js";
 import { getAllAgentStatuses } from "../agents/lifecycle.js";
 import {
@@ -149,12 +156,50 @@ export interface ServerOptions {
   configPath?: string;
   /** RFC §3.3 / #1623 — operator-approval surface; unset → `E_NO_APPROVAL_GATEWAY`. */
   approvalGateway?: ApprovalGateway;
+  /**
+   * #2726 Part 2 — optional in-chat rollout narration renderer. When set, each
+   * rollout phase transition is fed to it so it edits ONE ordinary operator-DM
+   * message through the phases (applying → canary → agent N/M → … → ✅/❌). It
+   * PULLS from what it's fed and relays fire-and-forget edits through the
+   * gateway; it never blocks or fails the roll. Unset in Part 1 (durable
+   * observability ships alone). */
+  rolloutNarrator?: RolloutNarrator;
+  /**
+   * #2726 Part 1 — terminal-push relay. When set, hostd pushes ONE ordinary
+   * operator-DM message on the rollout terminal row (via the same gateway IPC
+   * transport as the approval card). Fire-and-forget; never blocks/fails the
+   * roll. Unset → no terminal ping (durable audit row is still written). */
+  rolloutRelay?: RolloutRelay;
   /** Test seam: override the random hex id generator. */
   generateApprovalId?: () => string;
   /** Test seam: override the `switchroom apply` subprocess invocation. */
   runReconcile?: (args: {
     requestId: string;
   }) => Promise<{ exit_code: number; stdout: string; stderr: string }>;
+}
+
+/**
+ * #2726 Part 2 — the in-chat rollout narration renderer, as hostd sees it.
+ * hostd owns the rollout request lifecycle and the gateway relay path (the same
+ * one it uses for approval cards), so it drives the renderer by feeding it each
+ * phase. The renderer is the thing that TAILS/edits; hostd only supplies phases.
+ * Defined here (not in the renderer module) so Part 1 declares the seam and
+ * Part 2 implements it — Part 1 leaves it unset.
+ */
+export interface RolloutNarrator {
+  /**
+   * Called once per rollout phase transition, in `_seq` order (hostd feeds
+   * them as it parses the child's stdout). MUST be non-blocking and swallow all
+   * errors — hostd calls it un-awaited, and an edit failure must never surface
+   * back toward the roll. `entry.request_id` binds the surface to a
+   * hostd-attested in-flight roll.
+   */
+  onPhase(entry: StatusEntry, phase: RolloutPhase): void;
+  /**
+   * Called once when the terminal row is written (success or failure), with the
+   * final entry. Freezes the surface: no later edit may un-finalize it.
+   */
+  onTerminal(entry: StatusEntry): void;
 }
 
 /**
@@ -195,6 +240,17 @@ interface StatusEntry {
   // sentinel line (see parseRolloutResultLine in cli/rollout.ts).
   /** Agents confirmed on the target version, in order. */
   rolled?: string[];
+  // ─── Live rollout phase (#2726) ────────────────────────────────────
+  // Updated on every phase transition parsed off the child's stdout, so an
+  // in-flight `get_status` shows the CURRENT phase ("canary-start",
+  // "agent-start", …) instead of a bare "started". Set only on rollout rows.
+  current_phase?: string;
+  /** Roll-order position of the agent named in the current phase (1-based). */
+  phase_n?: number;
+  /** Total agents this roll restarts. */
+  phase_m?: number;
+  /** Agent named in the current phase (agent-start/-done, canary-*). */
+  phase_agent?: string;
   /** Step that stopped the rollout (e.g. "restart-agent", "apply"). */
   failed_step?: string;
   /** Agent that failed the version assert (when failed_step is restart). */
@@ -483,6 +539,17 @@ export class HostdServer {
         started_at: number;
       }
     | null = null;
+
+  /**
+   * #2726 Part 2 — optional in-chat narration renderer. When wired (via
+   * `ServerOptions.rolloutNarrator`), each rollout phase transition is fed to
+   * it so it edits ONE ordinary operator-DM message through the phases. Left
+   * unset in Part 1 (durable observability ships alone); a null narrator makes
+   * `onRolloutPhase` a pure audit-writer. The renderer PULLS from what it's fed
+   * and holds no lifecycle state that a gateway restart could orphan. */
+  private get rolloutNarrator(): RolloutNarrator | undefined {
+    return this.opts.rolloutNarrator;
+  }
 
   constructor(private opts: ServerOptions) {}
 
@@ -942,6 +1009,18 @@ export class HostdServer {
         // avoid information leakage across agents.
         const entry = this.statusByRequestId.get(req.args.target_request_id);
         if (!entry) {
+          // #2726 — durable-log fallback for a ROLLOUT request whose in-memory
+          // entry is gone (hostd restarted mid-roll, or the 10-min entry aged
+          // out). Rollout is admin/operator-only, so surfacing its LATEST
+          // durable row to an admin agent (or the operator socket) is not a
+          // cross-agent leak. A non-admin agent still gets the opaque
+          // not-found so it can't probe request_ids that aren't theirs.
+          if (
+            callerAdmin &&
+            this.rolloutRowExistsInLog(req.args.target_request_id)
+          ) {
+            return null;
+          }
           // No leak: return "denied: not found" the same as the
           // unauthorized case so callers can't probe for the
           // existence of request_ids that aren't theirs.
@@ -2457,7 +2536,16 @@ export class HostdServer {
    * tail. Releases the fleet-mutation lock on completion (success/fail).
    */
   private spawnRollout(args: string[], entry: StatusEntry): void {
-    this.runSwitchroom(args, { SWITCHROOM_HOSTD_CONTEXT: "1" })
+    // #2726 — tap the child's stdout line-by-line so each rollout PHASE
+    // sentinel becomes a durable, hash-chained audit row AS the roll runs
+    // (the log is the single source of truth; the narration surface in Part 2
+    // PULLS from it). hostd is the SOLE writer of the chained log — the
+    // subprocess only emits sentinels on stdout, never touches the file.
+    const onLine = (line: string): void => {
+      const phase = parseRolloutPhaseLine(line);
+      if (phase) this.onRolloutPhase(entry, phase);
+    };
+    this.runSwitchroom(args, { SWITCHROOM_HOSTD_CONTEXT: "1" }, onLine)
       .then((res) => {
         entry.exit_code = res.exit_code;
         entry.finished_at = Date.now();
@@ -2498,6 +2586,10 @@ export class HostdServer {
       })
       .finally(() => {
         void this.writeTerminalAudit(entry);
+        // #2726 — terminal effects. All fire-and-forget: a chat push / narrator
+        // finalize must NEVER block the lock release or the roll's completion.
+        this.pushRolloutTerminal(entry);
+        this.rolloutNarrator?.onTerminal(entry);
         if (
           this.fleetMutationInFlight &&
           this.fleetMutationInFlight.request_id === entry.request_id
@@ -2507,15 +2599,56 @@ export class HostdServer {
       });
   }
 
+  /**
+   * #2726 Part 1 — push ONE ordinary operator-DM message on the rollout
+   * terminal row via the gateway relay. Fire-and-forget: `postTerminal` never
+   * throws and never awaits a reply, so the roll can't stall on a slow/absent
+   * gateway. No-op when no relay is wired or the caller isn't an agent (the
+   * relay routes through the caller agent's gateway, like the approval card).
+   */
+  private pushRolloutTerminal(entry: StatusEntry): void {
+    if (!this.opts.rolloutRelay) return;
+    if (entry.caller.kind !== "agent") return;
+    try {
+      const text = renderRolloutStatus({
+        target: entry.pin ?? "",
+        rolled: entry.rolled,
+        terminal: entry.result === "completed" ? "completed" : "error",
+        ...(entry.failed_step ? { failedStep: entry.failed_step } : {}),
+        ...(entry.failed_agent ? { failedAgent: entry.failed_agent } : {}),
+        ...(entry.got !== undefined ? { got: entry.got } : {}),
+      });
+      this.opts.rolloutRelay.postTerminal({
+        requestId: entry.request_id,
+        agentName: entry.caller.name,
+        text,
+      });
+    } catch (e) {
+      process.stderr.write(
+        `hostd: rollout terminal push failed (non-fatal): ${(e as Error).message}\n`,
+      );
+    }
+  }
+
   private handleGetStatus(
     req: Extract<HostdRequest, { op: "get_status" }>,
     _caller: SocketIdentity,
     started: number,
   ): HostdResponse {
     const entry = this.statusByRequestId.get(req.args.target_request_id);
-    // checkGate already rejected unknown / cross-agent cases above.
-    // If we got here `entry` must exist.
     if (!entry) {
+      // #2726 — the gate admitted this because a ROLLOUT row for the
+      // request_id exists in the durable log but the in-memory entry is gone
+      // (hostd restarted mid-roll / entry aged out). Rebuild the status
+      // response from the LATEST durable rollout row — the log is the source
+      // of truth. If somehow no row is found now (raced eviction), fall through
+      // to the internal-invariant error.
+      const fromLog = this.rolloutStatusFromLog(
+        req.request_id,
+        req.args.target_request_id,
+        started,
+      );
+      if (fromLog) return fromLog;
       // #1761: internal invariant violation — no fix.kind applies.
       const legacy = `get_status: internal: entry missing despite gate accept`;
       const built = err("E_INTERNAL", "entry missing despite gate accept")
@@ -2524,6 +2657,68 @@ export class HostdServer {
       return { ...built, error: legacy };
     }
     return this.statusEntryToResponse(req.request_id, entry);
+  }
+
+  /** True when the durable audit log holds at least one rollout row for
+   *  `targetRequestId` (#2726 get_status durable fallback). Best-effort:
+   *  a read error is treated as "no row". */
+  private rolloutRowExistsInLog(targetRequestId: string): boolean {
+    const path = this.auditLogPath();
+    if (!existsSync(path)) return false;
+    try {
+      const raw = readFileSync(path, "utf-8");
+      return latestRolloutRowForRequest(raw, targetRequestId) !== null;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Build a `get_status` response for a rollout from its LATEST durable audit
+   * row (#2726). Used only when the in-memory status entry is gone. Surfaces
+   * the same rollout `payload` shape as the live path (phase / n / m / agent /
+   * rolled / failedStep / failedAgent / pin / prior_pin) so a reader gets
+   * identical structure whether the entry is live or reconstructed from disk.
+   * Returns null when no rollout row exists for the request.
+   */
+  private rolloutStatusFromLog(
+    responseRequestId: string,
+    targetRequestId: string,
+    started: number,
+  ): HostdResponse | null {
+    const path = this.auditLogPath();
+    if (!existsSync(path)) return null;
+    let raw: string;
+    try {
+      raw = readFileSync(path, "utf-8");
+    } catch {
+      return null;
+    }
+    const row = latestRolloutRowForRequest(raw, targetRequestId);
+    if (!row) return null;
+    // A terminal row's `result` is completed/error; a phase row's is "started".
+    const isTerminal = row.phase === "terminal";
+    const payload = JSON.stringify({
+      rolled: row.rolled ?? [],
+      // Phase rows carry the transition name in `phase`; the terminal row's
+      // phase is the literal "terminal", which a reader shows as "done".
+      ...(row.phase && !isTerminal ? { phase: row.phase } : {}),
+      ...(row.n !== undefined ? { n: row.n } : {}),
+      ...(row.m !== undefined ? { m: row.m } : {}),
+      ...(row.agent ? { agent: row.agent } : {}),
+      ...(row.failed_step ? { failedStep: row.failed_step } : {}),
+      ...(row.failed_agent ? { failedAgent: row.failed_agent } : {}),
+      ...(row.pin ? { pin: row.pin } : {}),
+      ...(row.prior_pin ? { prior_pin: row.prior_pin } : {}),
+    });
+    return {
+      v: 1,
+      request_id: responseRequestId,
+      result: row.result as Result,
+      exit_code: row.exit_code,
+      duration_ms: Date.now() - started,
+      payload,
+    };
   }
 
   private statusEntryToResponse(
@@ -2538,14 +2733,29 @@ export class HostdServer {
       entry.op === "rollout" &&
       (entry.rolled !== undefined ||
         entry.failed_step !== undefined ||
-        entry.failed_agent !== undefined)
+        entry.failed_agent !== undefined ||
+        // #2726 point 2 — un-blind an IN-FLIGHT rollout too: a live phase (no
+        // rolled[]/failed_step yet) is enough to emit a payload so a
+        // get_status poll mid-roll shows the current phase, not a bare "started".
+        entry.current_phase !== undefined)
         ? JSON.stringify({
             rolled: entry.rolled ?? [],
+            // Current phase + roll-order (#2726) — present while in flight and
+            // on the final row (the terminal phase leaves current_phase set to
+            // the last transition seen). A reader can render "canary-start" /
+            // "agent 3/8" without scraping the durable log.
+            ...(entry.current_phase ? { phase: entry.current_phase } : {}),
+            ...(entry.phase_n !== undefined ? { n: entry.phase_n } : {}),
+            ...(entry.phase_m !== undefined ? { m: entry.phase_m } : {}),
+            ...(entry.phase_agent ? { agent: entry.phase_agent } : {}),
             ...(entry.failed_step ? { failedStep: entry.failed_step } : {}),
             ...(entry.failed_agent ? { failedAgent: entry.failed_agent } : {}),
             // BONUS (#2458 got-field gap): include `got` when present.
             ...(entry.got !== undefined ? { got: entry.got } : {}),
             ...(entry.pin ? { pin: entry.pin } : {}),
+            // Prior-pin (#2492) surfaced structurally too, so a rollback-aware
+            // reader gets it from get_status, not only the durable terminal row.
+            ...(entry.prior_pin ? { prior_pin: entry.prior_pin } : {}),
           })
         : undefined;
     // Update-apply (#2458) payload: deferred steps + channel/pin enrichment.
@@ -2718,13 +2928,91 @@ export class HostdServer {
     });
   }
 
-  /** Spawn the host switchroom CLI and capture stdout/stderr. An
+  /**
+   * #2726 — handle one rollout PHASE transition parsed off the child's
+   * stdout. Two effects, both fire-and-forget so a stall in either can NEVER
+   * block or fail the roll:
+   *   1. Persist a durable, hash-chained phase audit row (the single source of
+   *      truth for rollout progress — `get_status` + the Part 2 narration
+   *      surface both READ from here).
+   *   2. Feed the narration renderer (Part 2), if one is attached, so the
+   *      in-chat message edits through the phases. The renderer PULLS from what
+   *      it's fed; it holds no lifecycle state that a gateway restart could
+   *      orphan (recovery = re-read the log).
+   */
+  private onRolloutPhase(entry: StatusEntry, phase: RolloutPhase): void {
+    // Record the live phase on the in-memory entry so an in-flight get_status
+    // shows the current phase, not a bare "started" (#2726 point 2).
+    entry.current_phase = phase.phase;
+    entry.phase_n = phase.n;
+    entry.phase_m = phase.m;
+    entry.phase_agent = phase.agent;
+    void this.writePhaseAudit(entry, phase);
+    // Part 2 hook — attached only when a narration renderer is wired. Kept as
+    // an optional member so Part 1 is mergeable alone (no renderer → no-op).
+    this.rolloutNarrator?.onPhase(entry, phase);
+  }
+
+  /**
+   * Durable per-phase audit row for an in-flight rollout (#2726). Distinct
+   * from {@link writeTerminalAudit}: `phase` here is the transition name
+   * ("apply", "canary-start", …) rather than the literal "terminal" the
+   * hostd terminal row uses — so a phase row is lexically incapable of being
+   * mistaken for the terminal sentinel by any reader keyed on
+   * `phase === "terminal"`. Carries `request_id` + `pin` on every row per the
+   * observability contract, plus the roll-order `n`/`m` and `agent` when the
+   * phase supplies them. Best-effort: `appendAuditRow` swallows write errors,
+   * so this never throws into the stdout-tap that calls it.
+   */
+  private async writePhaseAudit(
+    entry: StatusEntry,
+    phase: RolloutPhase,
+  ): Promise<void> {
+    await this.appendAuditRow({
+      ts: new Date().toISOString(),
+      op: entry.op,
+      // The transition name — NEVER the string "terminal". Terminal-sentinel
+      // readers key on phase==="terminal"; a phase row can never collide.
+      phase: phase.phase,
+      caller:
+        entry.caller.kind === "agent"
+          ? { kind: "agent", name: entry.caller.name }
+          : { kind: "operator" },
+      request_id: entry.request_id,
+      // In-flight: no exit code / final result yet. `result: "started"` marks
+      // it as an in-progress row, disjoint from the terminal row's
+      // completed/error.
+      result: "started",
+      exit_code: null,
+      duration_ms: Date.now() - entry.started_at,
+      // Observability contract: pin on every rollout row.
+      ...(entry.pin ? { pin: entry.pin } : {}),
+      // Roll-order + agent context when the phase supplies them.
+      ...(phase.agent !== undefined ? { agent: phase.agent } : {}),
+      ...(phase.n !== undefined ? { n: phase.n } : {}),
+      ...(phase.m !== undefined ? { m: phase.m } : {}),
+    });
+  }
+
+  /**
+   * Spawn the host switchroom CLI and capture stdout/stderr. An
    *  optional `extraEnv` is merged onto the inherited env — used by the
    *  rollout path to flip the in-container `SWITCHROOM_HOSTD_CONTEXT`
    *  sentinel (#2487). */
   private runSwitchroom(
     args: string[],
     extraEnv?: Record<string, string>,
+    /**
+     * Optional line-oriented stdout tap (#2726). Invoked once per COMPLETE
+     * stdout line (newline-delimited) as the child emits it — used by
+     * `spawnRollout` to persist each rollout phase sentinel to the durable
+     * audit log AS the roll progresses, not after it exits. The full buffered
+     * stdout is still returned on close (for the terminal sentinel parse), so
+     * this tap is purely additive. Never throws into the child pipe: a callback
+     * that throws is caught and logged so a persistence hiccup can't kill the
+     * roll.
+     */
+    onStdoutLine?: (line: string) => void,
   ): Promise<{ exit_code: number; stdout: string; stderr: string }> {
     return new Promise((resolve, reject) => {
       const bin = this.opts.switchroomBin ?? "switchroom";
@@ -2734,16 +3022,51 @@ export class HostdServer {
       });
       let stdout = "";
       let stderr = "";
+      // Line-buffer for the optional stdout tap. Only maintained when a tap is
+      // wired — the common (untapped) path keeps the cheap buffer-only shape.
+      let lineBuf = "";
+      const drainLines = (flush: boolean): void => {
+        if (!onStdoutLine) return;
+        let nl: number;
+        while ((nl = lineBuf.indexOf("\n")) !== -1) {
+          const line = lineBuf.slice(0, nl);
+          lineBuf = lineBuf.slice(nl + 1);
+          try {
+            onStdoutLine(line);
+          } catch (e) {
+            process.stderr.write(
+              `hostd: rollout stdout-tap threw (non-fatal): ${(e as Error).message}\n`,
+            );
+          }
+        }
+        if (flush && lineBuf.length > 0) {
+          const line = lineBuf;
+          lineBuf = "";
+          try {
+            onStdoutLine(line);
+          } catch (e) {
+            process.stderr.write(
+              `hostd: rollout stdout-tap threw (non-fatal): ${(e as Error).message}\n`,
+            );
+          }
+        }
+      };
       child.stdout.on("data", (d: Buffer) => {
-        stdout += d.toString("utf8");
+        const s = d.toString("utf8");
+        stdout += s;
+        if (onStdoutLine) {
+          lineBuf += s;
+          drainLines(false);
+        }
       });
       child.stderr.on("data", (d: Buffer) => {
         stderr += d.toString("utf8");
       });
       child.on("error", (err) => reject(err));
-      child.on("close", (code) =>
-        resolve({ exit_code: code ?? -1, stdout, stderr }),
-      );
+      child.on("close", (code) => {
+        drainLines(true);
+        resolve({ exit_code: code ?? -1, stdout, stderr });
+      });
     });
   }
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -458,6 +458,8 @@ import type {
   QuotaWallDetectedMessage,
   PostSkillProposalMessage,
   PermissionEvent,
+  RolloutStatusPostMessage,
+  RolloutStatusEditMessage,
 } from './ipc-protocol.js'
 import { DebounceBuffer, HourCap, buildReactionInboundMeta, buildReactionInboundText, evaluateTriggerCandidate, isGroupChat, resolveReactionsConfig, truncatePreview, type PendingReaction, type ReactionBatch, type ReactionsResolvedConfig } from './reaction-trigger.js'
 import { buildReactionDispatchInbound, evaluateReactionDispatch, resolveReactionDispatchConfig, type ReactionDispatchResolvedConfig } from './reaction-dispatch.js'
@@ -7773,6 +7775,81 @@ const ipcServer: IpcServer = createIpcServer({
       log: (m) =>
         process.stderr.write(`telegram gateway: config-finalize — ${m}\n`),
     })
+  },
+
+  // #2726 — hostd-initiated rollout status message. Part 1 uses this only for
+  // the terminal ping; Part 2 uses the same post as the FIRST narration
+  // message, then EDITs it (onRolloutStatusEdit) as later phases arrive. This
+  // is an ORDINARY operator-DM message, NOT a pinned card — the framework
+  // speaking a plain progress line in the chat. We reply with the message_id so
+  // hostd can edit it later; a post failure replies ok:false (hostd then just
+  // won't edit — the durable audit log remains the record).
+  async onRolloutStatusPost(client: IpcClient, msg: RolloutStatusPostMessage) {
+    const self = process.env.SWITCHROOM_AGENT_NAME
+    if (self && msg.agentName !== self) {
+      process.stderr.write(
+        `telegram gateway: rollout_status_post rejected — agent mismatch (${msg.agentName} != ${self})\n`,
+      )
+      try {
+        client.send({ type: 'rollout_status_posted', requestId: msg.requestId, ok: false, reason: 'agent mismatch' })
+      } catch { /* best effort */ }
+      return
+    }
+    const operator = loadAccess().allowFrom[0]
+    if (operator === undefined) {
+      process.stderr.write(`telegram gateway: rollout_status_post — no operator chat (allowFrom empty)\n`)
+      try {
+        client.send({ type: 'rollout_status_posted', requestId: msg.requestId, ok: false, reason: 'no operator chat' })
+      } catch { /* best effort */ }
+      return
+    }
+    try {
+      const sent = await robustApiCall(
+        () =>
+          // allow-raw-bot-api: rich progress line, routed through robustApiCall.
+          bot.api.sendRichMessage(operator, richMessage(msg.text), {}),
+        { chat_id: String(operator), verb: 'rollout-status-post' },
+      )
+      const messageId = (sent as { message_id: number }).message_id
+      process.stderr.write(
+        `telegram gateway: rollout_status_post agent=${msg.agentName} request=${msg.requestId} message_id=${messageId}\n`,
+      )
+      try {
+        client.send({ type: 'rollout_status_posted', requestId: msg.requestId, ok: true, messageId })
+      } catch { /* best effort */ }
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: rollout_status_post send failed: ${(err as Error).message}\n`,
+      )
+      try {
+        client.send({ type: 'rollout_status_posted', requestId: msg.requestId, ok: false, reason: (err as Error).message })
+      } catch { /* best effort */ }
+    }
+  },
+
+  // #2726 Part 2 — edit the previously-posted rollout status message in place as
+  // later phases arrive. Fire-and-forget: an edit failure (incl. Telegram 429)
+  // is swallowed here and NEVER surfaced back toward the roll. hostd owns the
+  // debounce + 429 retry cadence; this handler is a thin edit relay.
+  onRolloutStatusEdit(_client: IpcClient, msg: RolloutStatusEditMessage) {
+    const self = process.env.SWITCHROOM_AGENT_NAME
+    if (self && msg.agentName !== self) {
+      process.stderr.write(
+        `telegram gateway: rollout_status_edit rejected — agent mismatch (${msg.agentName} != ${self})\n`,
+      )
+      return
+    }
+    const operator = loadAccess().allowFrom[0]
+    if (operator === undefined) {
+      process.stderr.write(`telegram gateway: rollout_status_edit — no operator chat (allowFrom empty)\n`)
+      return
+    }
+    void swallowingApiCall(
+      () =>
+        // allow-raw-bot-api: in-place edit of the ordinary status message.
+        bot.api.editMessageText(operator, msg.messageId, richMessage(msg.text), {}),
+      { chat_id: String(operator), verb: 'rollout-status-edit' },
+    )
   },
 
   onInjectInbound(_client: IpcClient, msg: InjectInboundMessage) {

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -142,7 +142,8 @@ export type GatewayToClient =
   | ScheduleRestartResult
   | DriveApprovalPostedEvent
   | Ms365ApprovalPostedEvent
-  | ConfigApprovalResolvedEvent;
+  | ConfigApprovalResolvedEvent
+  | RolloutStatusPostedEvent;
 
 // === Bridge (Client) -> Gateway messages ===
 
@@ -493,6 +494,67 @@ export interface PostSkillProposalMessage {
   draft: Record<string, string>;
 }
 
+/**
+ * #2726 Part 1 — hostd asks the caller agent's gateway to POST one ordinary
+ * operator-DM message narrating a rollout's terminal outcome. This is a NORMAL
+ * message, NOT a pinned card and NOT a bespoke widget — the framework speaking
+ * a plain progress line in the chat, which keeps it clear of
+ * `chat-is-the-single-source-of-truth` (in-chat narration, not a parallel
+ * pinned mirror).
+ *
+ * The gateway posts `text` to the operator chat (`allowFrom[0]`) and — for the
+ * Part 2 narration surface — replies with a `rollout_status_posted` event
+ * carrying the message_id so hostd can EDIT it as later phases arrive. Part 1
+ * uses only the terminal post and ignores the reply (fire-and-forget).
+ *
+ * Trust model: same as request_config_approval — the gateway socket lives in
+ * the agent container; hostd reaches it via the per-agent state-dir bind mount.
+ * `agentName` is validated server-side; the chat target is the gateway's OWN
+ * operator, never a caller-supplied chat.
+ */
+export interface RolloutStatusPostMessage {
+  type: "rollout_status_post";
+  /** hostd request_id of the roll (binds the surface to a real request). */
+  requestId: string;
+  /** The admin agent whose gateway relays the message (the rollout caller). */
+  agentName: string;
+  /** Fully-rendered message body. */
+  text: string;
+}
+
+/**
+ * #2726 Part 2 — hostd asks the gateway to EDIT the rollout status message it
+ * previously posted (identified by `messageId`, returned in the
+ * `rollout_status_posted` reply). Best-effort, fire-and-forget: an edit failure
+ * (incl. Telegram 429) is handled gateway-side and never surfaced back toward
+ * the roll.
+ */
+export interface RolloutStatusEditMessage {
+  type: "rollout_status_edit";
+  requestId: string;
+  agentName: string;
+  /** message_id of the status message to edit (from rollout_status_posted). */
+  messageId: number;
+  /** New fully-rendered body. */
+  text: string;
+}
+
+/**
+ * #2726 — gateway → hostd reply after a `rollout_status_post` was posted, so
+ * hostd learns the message_id to EDIT for subsequent phases. `ok:false` when
+ * the post failed (hostd then simply won't edit — the durable log + terminal
+ * push remain the record).
+ */
+export interface RolloutStatusPostedEvent {
+  type: "rollout_status_posted";
+  requestId: string;
+  ok: boolean;
+  /** Telegram message_id of the posted status message (present when ok). */
+  messageId?: number;
+  /** Diagnostic detail on failure. */
+  reason?: string;
+}
+
 export type ClientToGateway =
   | RegisterMessage
   | ToolCallMessage
@@ -510,4 +572,6 @@ export type ClientToGateway =
   | RequestConfigFinalizeMessage
   | QuotaWallDetectedMessage
   | SendOutboundMessage
-  | PostSkillProposalMessage;
+  | PostSkillProposalMessage
+  | RolloutStatusPostMessage
+  | RolloutStatusEditMessage;

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -15,6 +15,8 @@ import type {
   RequestConfigFinalizeMessage,
   RequestDriveApprovalMessage,
   RequestMs365ApprovalMessage,
+  RolloutStatusPostMessage,
+  RolloutStatusEditMessage,
   ScheduleRestartMessage,
   SessionEventForward,
   ToolCallMessage,
@@ -113,6 +115,25 @@ export interface IpcServerOptions {
     client: IpcClient,
     msg: RequestConfigFinalizeMessage,
   ) => Promise<void>;
+  /**
+   * #2726 Part 1 — hostd asks the gateway to POST one ordinary operator-DM
+   * message narrating a rollout's terminal outcome (Part 1) or its first phase
+   * (Part 2). Handler posts to the agent's own operator chat and — for Part 2 —
+   * replies with a `rollout_status_posted` event carrying the message_id.
+   * Optional: gateways without the hostd integration ignore it.
+   */
+  onRolloutStatusPost?: (
+    client: IpcClient,
+    msg: RolloutStatusPostMessage,
+  ) => Promise<void>;
+  /**
+   * #2726 Part 2 — hostd asks the gateway to EDIT a previously-posted rollout
+   * status message as later phases arrive. Best-effort, no reply. Optional.
+   */
+  onRolloutStatusEdit?: (
+    client: IpcClient,
+    msg: RolloutStatusEditMessage,
+  ) => void;
   log?: (msg: string) => void;
   /**
    * How long (in ms) to wait without a heartbeat before force-closing the
@@ -381,6 +402,33 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
           || (m.ttlMs as number) < 0)) return false;
       return true;
     }
+    case "rollout_status_post": {
+      // #2726 Part 1 — hostd-initiated terminal ping / status post. Wire shape
+      // only; the gateway handler fences the chat to the agent's own operator.
+      if (typeof m.requestId !== "string"
+        || (m.requestId as string).length === 0
+        || (m.requestId as string).length > 64) return false;
+      if (typeof m.agentName !== "string"
+        || !AGENT_NAME_RE.test(m.agentName as string)) return false;
+      if (typeof m.text !== "string"
+        || (m.text as string).length === 0
+        || (m.text as string).length > RICH_MESSAGE_MAX_CHARS) return false;
+      return true;
+    }
+    case "rollout_status_edit": {
+      // #2726 Part 2 — hostd-initiated status-message edit.
+      if (typeof m.requestId !== "string"
+        || (m.requestId as string).length === 0
+        || (m.requestId as string).length > 64) return false;
+      if (typeof m.agentName !== "string"
+        || !AGENT_NAME_RE.test(m.agentName as string)) return false;
+      if (typeof m.messageId !== "number"
+        || !Number.isInteger(m.messageId as number)) return false;
+      if (typeof m.text !== "string"
+        || (m.text as string).length === 0
+        || (m.text as string).length > RICH_MESSAGE_MAX_CHARS) return false;
+      return true;
+    }
     default:
       return false;
   }
@@ -406,6 +454,8 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
     onRequestMs365Approval,
     onRequestConfigApproval,
     onRequestConfigFinalize,
+    onRolloutStatusPost,
+    onRolloutStatusEdit,
     log = () => {},
     heartbeatTimeoutMs = 30_000,
   } = options;
@@ -636,6 +686,42 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
           });
         }
         // No reply expected.
+        break;
+      case "rollout_status_post":
+        if (onRolloutStatusPost) {
+          onRolloutStatusPost(client, msg as RolloutStatusPostMessage).catch(
+            (err) => {
+              log(
+                `rollout_status_post handler threw (client=${client.id}): ${(err as Error).message}`,
+              );
+              // Best-effort failure reply so hostd's Part 2 renderer knows the
+              // post failed (it just won't edit). Part 1 ignores the reply.
+              try {
+                client.send({
+                  type: "rollout_status_posted",
+                  requestId: (msg as RolloutStatusPostMessage).requestId,
+                  ok: false,
+                  reason: `gateway handler error: ${(err as Error).message}`,
+                });
+              } catch {
+                /* best effort */
+              }
+            },
+          );
+        }
+        // No reply required when unwired — hostd falls back to the durable log.
+        break;
+      case "rollout_status_edit":
+        if (onRolloutStatusEdit) {
+          try {
+            onRolloutStatusEdit(client, msg as RolloutStatusEditMessage);
+          } catch (err) {
+            log(
+              `rollout_status_edit handler threw (client=${client.id}): ${(err as Error).message}`,
+            );
+          }
+        }
+        // Fire-and-forget; no reply.
         break;
       case "update_placeholder":
         // Legacy recall.py IPC — placeholder UX was removed in #553 PR 5.

--- a/telegram-plugin/tests/ipc-server-validate-rollout-status.test.ts
+++ b/telegram-plugin/tests/ipc-server-validate-rollout-status.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Validation contract for the #2726 rollout status IPC verbs — hostd asks the
+ * caller agent's gateway to POST (terminal ping / first narration message) or
+ * EDIT (later phases) an ORDINARY operator-DM message. A rogue process on the
+ * same UDS must not inject a malformed payload: requestId + agentName required
+ * and shaped, text required non-empty and bounded, messageId (edit) an integer.
+ *
+ * No Bun-native API → vitest per the mixed-runner gotcha.
+ */
+import { describe, it, expect } from "vitest";
+import { validateClientMessage } from "../gateway/ipc-server.js";
+import { RICH_MESSAGE_MAX_CHARS } from "../format.js";
+
+const post = {
+  type: "rollout_status_post",
+  requestId: "ro-1",
+  agentName: "overlord",
+  text: "⏳ Rollout → v1.2.3 — applying",
+};
+const edit = {
+  type: "rollout_status_edit",
+  requestId: "ro-1",
+  agentName: "overlord",
+  messageId: 42,
+  text: "✅ Rollout → v1.2.3 — done",
+};
+
+describe("validateClientMessage — rollout_status_post", () => {
+  it("accepts a well-formed message", () => {
+    expect(validateClientMessage(post)).toBe(true);
+  });
+
+  it("rejects a missing / empty / over-long requestId", () => {
+    expect(validateClientMessage({ ...post, requestId: undefined })).toBe(false);
+    expect(validateClientMessage({ ...post, requestId: "" })).toBe(false);
+    expect(validateClientMessage({ ...post, requestId: "x".repeat(65) })).toBe(false);
+  });
+
+  it("rejects a missing / malformed agentName", () => {
+    expect(validateClientMessage({ ...post, agentName: undefined })).toBe(false);
+    expect(validateClientMessage({ ...post, agentName: "Bad Name" })).toBe(false);
+  });
+
+  it("rejects empty or over-long text", () => {
+    expect(validateClientMessage({ ...post, text: "" })).toBe(false);
+    expect(
+      validateClientMessage({ ...post, text: "x".repeat(RICH_MESSAGE_MAX_CHARS + 1) }),
+    ).toBe(false);
+  });
+});
+
+describe("validateClientMessage — rollout_status_edit", () => {
+  it("accepts a well-formed message", () => {
+    expect(validateClientMessage(edit)).toBe(true);
+  });
+
+  it("rejects a non-integer messageId", () => {
+    expect(validateClientMessage({ ...edit, messageId: 1.5 })).toBe(false);
+    expect(validateClientMessage({ ...edit, messageId: "42" })).toBe(false);
+    expect(validateClientMessage({ ...edit, messageId: undefined })).toBe(false);
+  });
+
+  it("rejects empty text", () => {
+    expect(validateClientMessage({ ...edit, text: "" })).toBe(false);
+  });
+});

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -2191,3 +2191,228 @@ describe("hostd server — rollout got-field gap fix (BONUS #2458)", () => {
     expect(terminal!.failed_agent).toBe("canary");
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #2726 — durable rollout observability + terminal push + narration seam.
+//
+// The rollout subprocess emits SWITCHROOM_ROLLOUT_PHASE: sentinel lines on
+// stdout; hostd (the SOLE audit writer) streams them and appends a durable,
+// hash-chained phase row per transition. get_status surfaces the live phase,
+// and a fire-and-forget relay pushes ONE ordinary operator-DM message on the
+// terminal row.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("hostd server — rollout phase observability (#2726)", () => {
+  function mkAssets(): string {
+    const assets = join(tmp, `assets-phase-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    mkdirSync(join(assets, "profiles", "default"), { recursive: true });
+    mkdirSync(join(assets, "vendor", "hindsight-memory"), { recursive: true });
+    return assets;
+  }
+
+  it("persists a durable audit row per phase, then a terminal row", async () => {
+    const execTmp = mkdtempSync(join("/var/tmp", "hostd-phase-"));
+    const stub = join(execTmp, "stub.sh");
+    // Emit a realistic phase sequence, then the terminal RESULT sentinel.
+    writeFileSync(
+      stub,
+      `#!/bin/sh\n` +
+        `echo 'SWITCHROOM_ROLLOUT_PHASE:{"phase":"apply","target":"v0.15.18"}'\n` +
+        `echo 'SWITCHROOM_ROLLOUT_PHASE:{"phase":"canary-start","target":"v0.15.18","agent":"klanker","n":1,"m":2}'\n` +
+        `echo 'SWITCHROOM_ROLLOUT_PHASE:{"phase":"canary-pass","target":"v0.15.18","agent":"klanker","n":1,"m":2}'\n` +
+        `echo 'SWITCHROOM_ROLLOUT_PHASE:{"phase":"agent-start","target":"v0.15.18","agent":"bob","n":2,"m":2}'\n` +
+        `echo 'SWITCHROOM_ROLLOUT_PHASE:{"phase":"agent-done","target":"v0.15.18","agent":"bob","n":2,"m":2}'\n` +
+        `echo 'SWITCHROOM_ROLLOUT_RESULT:{"ok":true,"rolled":["klanker","bob"],"warnings":[]}'\n` +
+        `exit 0\n`,
+    );
+    chmodSync(stub, 0o755);
+
+    if (server) await server.stop();
+    server = new HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: stub,
+      auditLogPath: join(tmp, "audit-phase.log"),
+      applyAssetsRoot: mkAssets(),
+      allowNonLinux: true,
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+    await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "rollout", request_id: "ro-phase-1", args: { pin: "v0.15.18" } },
+    );
+    await new Promise((r) => setTimeout(r, 400));
+
+    const rows = readFileSync(join(tmp, "audit-phase.log"), "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as Record<string, unknown>)
+      .filter((r) => r.request_id === "ro-phase-1");
+
+    // A durable phase row exists for each transition.
+    const phases = rows.filter((r) => r.op === "rollout" && r.result === "started" && r.phase !== undefined && r.phase !== "terminal");
+    const phaseNames = phases.map((r) => r.phase);
+    expect(phaseNames).toContain("apply");
+    expect(phaseNames).toContain("canary-start");
+    expect(phaseNames).toContain("canary-pass");
+    expect(phaseNames).toContain("agent-start");
+    expect(phaseNames).toContain("agent-done");
+
+    // Phase rows carry pin + n/m + agent per the observability contract.
+    const canaryStart = phases.find((r) => r.phase === "canary-start")!;
+    expect(canaryStart.pin).toBe("v0.15.18");
+    expect(canaryStart.n).toBe(1);
+    expect(canaryStart.m).toBe(2);
+    expect(canaryStart.agent).toBe("klanker");
+
+    // The terminal row is written AND is distinct from every phase row.
+    const terminal = rows.find((r) => r.phase === "terminal");
+    expect(terminal).toBeDefined();
+    expect(terminal!.result).toBe("completed");
+    // No phase row used the literal "terminal" — a phase can't masquerade as it.
+    expect(phaseNames).not.toContain("terminal");
+
+    rmSync(execTmp, { recursive: true, force: true });
+  });
+
+  it("get_status surfaces the CURRENT phase while the roll is in flight", async () => {
+    const execTmp = mkdtempSync(join("/var/tmp", "hostd-phase-inflight-"));
+    const stub = join(execTmp, "stub.sh");
+    // Emit an early phase, then sleep so the roll is still in flight when we poll.
+    writeFileSync(
+      stub,
+      `#!/bin/sh\n` +
+        `echo 'SWITCHROOM_ROLLOUT_PHASE:{"phase":"canary-start","target":"v0.15.18","agent":"klanker","n":1,"m":3}'\n` +
+        `sleep 1\n` +
+        `echo 'SWITCHROOM_ROLLOUT_RESULT:{"ok":true,"rolled":["klanker"],"warnings":[]}'\n` +
+        `exit 0\n`,
+    );
+    chmodSync(stub, 0o755);
+
+    if (server) await server.stop();
+    server = new HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: stub,
+      auditLogPath: join(tmp, "audit-inflight.log"),
+      applyAssetsRoot: mkAssets(),
+      allowNonLinux: true,
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+    await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "rollout", request_id: "ro-inflight-1", args: { pin: "v0.15.18" } },
+    );
+    // Poll WHILE the stub is sleeping (phase emitted, terminal not yet).
+    await new Promise((r) => setTimeout(r, 300));
+    const poll = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "get_status", request_id: "poll-inflight", args: { target_request_id: "ro-inflight-1" } },
+    );
+    expect(poll.result).toBe("started");
+    expect(poll.payload).toBeDefined();
+    const payload = JSON.parse(poll.payload!) as { phase: string; n: number; m: number; agent: string; pin: string };
+    expect(payload.phase).toBe("canary-start");
+    expect(payload.n).toBe(1);
+    expect(payload.m).toBe(3);
+    expect(payload.agent).toBe("klanker");
+    expect(payload.pin).toBe("v0.15.18");
+
+    await new Promise((r) => setTimeout(r, 1200)); // let it finish
+    rmSync(execTmp, { recursive: true, force: true });
+  });
+
+  it("fires the terminal relay push exactly once, with a rendered message", async () => {
+    const execTmp = mkdtempSync(join("/var/tmp", "hostd-relay-"));
+    const stub = join(execTmp, "stub.sh");
+    writeFileSync(
+      stub,
+      `#!/bin/sh\n` +
+        `echo 'SWITCHROOM_ROLLOUT_RESULT:{"ok":true,"rolled":["klanker","bob"],"warnings":[]}'\n` +
+        `exit 0\n`,
+    );
+    chmodSync(stub, 0o755);
+
+    const pushes: { requestId: string; agentName: string; text: string }[] = [];
+
+    if (server) await server.stop();
+    server = new HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: stub,
+      auditLogPath: join(tmp, "audit-relay.log"),
+      applyAssetsRoot: mkAssets(),
+      allowNonLinux: true,
+      rolloutRelay: {
+        postTerminal: (n) => pushes.push(n),
+      },
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+    await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "rollout", request_id: "ro-relay-1", args: { pin: "v0.15.18" } },
+    );
+    await new Promise((r) => setTimeout(r, 400));
+
+    expect(pushes).toHaveLength(1);
+    expect(pushes[0]!.requestId).toBe("ro-relay-1");
+    expect(pushes[0]!.agentName).toBe("klanker"); // routed through the caller agent
+    expect(pushes[0]!.text).toContain("✅");
+    expect(pushes[0]!.text).toContain("v0.15.18");
+
+    rmSync(execTmp, { recursive: true, force: true });
+  });
+
+  it("a relay that throws does NOT fail the roll (fire-and-forget)", async () => {
+    const execTmp = mkdtempSync(join("/var/tmp", "hostd-relay-throw-"));
+    const stub = join(execTmp, "stub.sh");
+    writeFileSync(
+      stub,
+      `#!/bin/sh\n` +
+        `echo 'SWITCHROOM_ROLLOUT_RESULT:{"ok":true,"rolled":["klanker"],"warnings":[]}'\n` +
+        `exit 0\n`,
+    );
+    chmodSync(stub, 0o755);
+
+    if (server) await server.stop();
+    server = new HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: stub,
+      auditLogPath: join(tmp, "audit-relay-throw.log"),
+      applyAssetsRoot: mkAssets(),
+      allowNonLinux: true,
+      rolloutRelay: {
+        postTerminal: () => {
+          throw new Error("gateway down");
+        },
+      },
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+    await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "rollout", request_id: "ro-relay-throw-1", args: { pin: "v0.15.18" } },
+    );
+    await new Promise((r) => setTimeout(r, 400));
+
+    // The roll still completed (terminal row written), despite the relay throw.
+    const poll = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "get_status", request_id: "poll-throw", args: { target_request_id: "ro-relay-throw-1" } },
+    );
+    expect(poll.result).toBe("completed");
+
+    rmSync(execTmp, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Vision outcome & JTBD

- **Outcome (Visibility):** `hold-the-leash` — the operator can *see* a fleet operation land.
- **JTBD:** `reference/jobs/operate-the-fleet-from-telegram.md` (new; the operator explicitly asked for this doc). Cross-checked against `see-my-whole-fleet-from-one-screen.md` — both locate fleet status in **durable artifacts**; this aligns, it does not contradict.

## The problem

A fleet rollout (`mcp__hostd__rollout`) went dark: it wrote **one** terminal row to `~/.switchroom/host-control-audit.log`, `get_status` was blind to its phases, and nothing reached Telegram. A real v0.16.35 roll half-failed and was only diagnosable by host-side `grep`. That violates the operator-visibility JTBD.

## What Part 1 ships

1. **Per-phase emission.** `src/cli/rollout.ts` emits a `SWITCHROOM_ROLLOUT_PHASE:` sentinel on stdout at every transition (`apply`, `canary-start`/`-pass`/`-fail`, `agent-start`/`-done` with `n`/`m`, `persist-pin`, `hostd-web-deferred`). Every phase carries the target pin.
2. **hostd is the SOLE audit writer.** The spawned subprocess **never** writes the hash-chained log directly — two writers fork the single-writer chain (`audit-hashchain.ts` § the single-writer contract). hostd streams the child's stdout line-by-line and appends each phase as a hash-chained row via its existing `appendAuditRow` (reusing the monotonic `_seq`/`_prev`/`_hash` chain, **not** a second writer). This is the buildable form of "the roll emits a row per phase".
3. **Terminal sentinel stays disjoint.** The `…PHASE:` prefix is lexically disjoint from `…RESULT:`, and no phase name is `"terminal"` — a phase row can never trip the terminal-sentinel parser (unit-tested).
4. **Un-blind `get_status`.** It surfaces the live phase (`current_phase`/`n`/`m`/`agent`) in flight, and reconstructs the latest rollout row from the **durable log** when the in-memory entry is gone (hostd restarted mid-roll), via the new pure `latestRolloutRowForRequest`. The durable log is the source of truth.
5. **Terminal Telegram push.** On the terminal row hostd pushes **one ordinary operator-DM message** through the same gateway IPC transport as the approval card (`SocketRolloutRelay` → caller agent's `gateway.sock` → operator chat `allowFrom[0]`). Fire-and-forget: never awaits a reply; a throw/absent gateway can never block or fail the roll.

## Invariants

Crosses **no** invariant. In particular it stays clear of `chat-is-the-single-source-of-truth`: the terminal push is a **normal message** (no pin, no bespoke card) — in-chat narration, the invariant's own prescribed remedy — and the source of truth is the **durable append-only audit log**, not a parallel surface. A prior pinned-card proposal was killed in review for three CRITICAL reasons (breaches the #2722 exception, reintroduces the orphaned-pin bug, and the relay can't exist); this design avoids all three by construction.

## Tests

Phase-sentinel disjointness + "a phase line cannot parse as the terminal sentinel"; per-phase emission incl. `canary-fail` vs `agent-done`; durable phase rows written as the roll runs; `get_status` shows the live phase in flight; the terminal relay fires exactly once and a throwing relay does not fail the roll; the `get_status` durable-log helper; the pure status renderer; IPC validation for the new `rollout_status_post`/`edit` verbs. `npm run lint` + `npm run build` green; the only failing suites in this container are 3 pre-existing, environment-only failures (bind-mount `EBUSY` repro, operator-socket uid, a fuzzed-schedule) confirmed failing on the base commit `900b5451`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)