### PR TITLE
feat(rollout): log-tailed in-chat narration surface (Part 2)

### DIFF
--- a/src/host-control/main.ts
+++ b/src/host-control/main.ts
@@ -28,6 +28,8 @@ import { allocateAgentUid } from "../agents/compose.js";
 import { HostdServer } from "./server.js";
 import { SocketApprovalGateway } from "./approval-gateway.js";
 import { SocketRolloutRelay } from "./rollout-relay.js";
+import { SocketRolloutNarrationRelay } from "./rollout-narration-relay.js";
+import { LogTailRolloutNarrator } from "./rollout-narrator.js";
 import { ReleaseWatcher } from "./release-watcher.js";
 import {
   makeReleaseCheck,
@@ -90,6 +92,20 @@ async function main(): Promise<void> {
     log: (m) => process.stderr.write(`hostd: rollout-relay — ${m}\n`),
   });
 
+  // #2726 Part 2 — the log-tailed in-chat narration surface. hostd tails its
+  // OWN durable rollout rows (it is fed each phase as it parses the child's
+  // stdout) and edits ONE ordinary operator-DM message through the phases —
+  // NOT pinned, NOT a bespoke card. The narrator holds no lifecycle state a
+  // gateway restart could orphan; edits are fire-and-forget, monotonic,
+  // debounced, frozen-on-terminal, and 429-handled gateway-side.
+  const rolloutNarrator = new LogTailRolloutNarrator(
+    new SocketRolloutNarrationRelay({
+      resolveGatewaySocket,
+      log: (m) => process.stderr.write(`hostd: rollout-narration — ${m}\n`),
+    }),
+    { log: (m) => process.stderr.write(`hostd: rollout-narration — ${m}\n`) },
+  );
+
   const server = new HostdServer({
     homeDir: homedir(),
     agentUids,
@@ -115,6 +131,7 @@ async function main(): Promise<void> {
     },
     approvalGateway,
     rolloutRelay,
+    rolloutNarrator,
   });
   await server.start();
 

--- a/src/host-control/rollout-narration-relay.ts
+++ b/src/host-control/rollout-narration-relay.ts
@@ -1,0 +1,177 @@
+/**
+ * #2726 Part 2 — the socket-backed RolloutNarrationRelay.
+ *
+ * Same transport as the approval gateway / the Part 1 terminal relay: hostd
+ * connects, as a client, to the caller agent's gateway IPC socket and writes a
+ * typed JSON line. `post` awaits the gateway's `rollout_status_posted` reply
+ * (bounded, so a silent gateway can't stall the narrator) to learn the
+ * message_id; `edit` is pure fire-and-forget.
+ *
+ * The gateway side owns the actual Telegram send/edit, INCLUDING 429
+ * `retry_after` handling (its `swallowingApiCall`/`robustApiCall` retry
+ * policy). So an edit failure — a rate limit, a deleted message — never
+ * surfaces back to hostd, and never toward the roll.
+ */
+
+import { connect, type Socket } from "node:net";
+import type { RolloutNarrationRelay } from "./rollout-narrator.js";
+
+export interface SocketRolloutNarrationRelayOptions {
+  resolveGatewaySocket: (agentName: string) => string | null;
+  log?: (m: string) => void;
+  /** Max ms to await the post reply before giving up (message_id → null). */
+  postReplyTimeoutMs?: number;
+}
+
+const DEFAULT_POST_REPLY_TIMEOUT_MS = 5000;
+
+export class SocketRolloutNarrationRelay implements RolloutNarrationRelay {
+  constructor(private opts: SocketRolloutNarrationRelayOptions) {}
+
+  post(args: {
+    requestId: string;
+    agentName: string;
+    text: string;
+  }): Promise<number | null> {
+    const log = this.opts.log ?? (() => {});
+    let sockPath: string | null;
+    try {
+      sockPath = this.opts.resolveGatewaySocket(args.agentName);
+    } catch (e) {
+      log(`narration resolveGatewaySocket threw: ${(e as Error).message}`);
+      return Promise.resolve(null);
+    }
+    if (sockPath === null) {
+      log(`narration post: no reachable gateway for ${args.agentName}`);
+      return Promise.resolve(null);
+    }
+    return new Promise<number | null>((resolve) => {
+      let settled = false;
+      const finish = (v: number | null): void => {
+        if (settled) return;
+        settled = true;
+        try {
+          client.destroy();
+        } catch {
+          /* already gone */
+        }
+        resolve(v);
+      };
+      let client: Socket;
+      try {
+        client = connect({ path: sockPath! });
+      } catch (e) {
+        log(`narration post connect threw: ${(e as Error).message}`);
+        resolve(null);
+        return;
+      }
+      client.setTimeout(this.opts.postReplyTimeoutMs ?? DEFAULT_POST_REPLY_TIMEOUT_MS);
+      let buffer = "";
+      client.on("connect", () => {
+        try {
+          client.write(
+            JSON.stringify({
+              type: "rollout_status_post",
+              requestId: args.requestId,
+              agentName: args.agentName,
+              text: args.text,
+            }) + "\n",
+          );
+        } catch (e) {
+          log(`narration post write failed: ${(e as Error).message}`);
+          finish(null);
+        }
+      });
+      client.on("data", (chunk) => {
+        buffer += chunk.toString("utf8");
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          let obj: Record<string, unknown>;
+          try {
+            obj = JSON.parse(line) as Record<string, unknown>;
+          } catch {
+            continue;
+          }
+          if (
+            obj.type === "rollout_status_posted" &&
+            obj.requestId === args.requestId
+          ) {
+            if (obj.ok === true && typeof obj.messageId === "number") {
+              finish(obj.messageId);
+            } else {
+              log(
+                `narration post rejected by gateway (requestId=${args.requestId}): ${typeof obj.reason === "string" ? obj.reason : "no message_id"}`,
+              );
+              finish(null);
+            }
+            return;
+          }
+        }
+      });
+      client.on("timeout", () => {
+        log(`narration post reply timed out (requestId=${args.requestId})`);
+        finish(null);
+      });
+      client.on("error", (e) => {
+        log(`narration post socket error (requestId=${args.requestId}): ${e.message}`);
+        finish(null);
+      });
+      client.on("close", () => finish(null));
+    });
+  }
+
+  edit(args: {
+    requestId: string;
+    agentName: string;
+    messageId: number;
+    text: string;
+  }): void {
+    const log = this.opts.log ?? (() => {});
+    let sockPath: string | null;
+    try {
+      sockPath = this.opts.resolveGatewaySocket(args.agentName);
+    } catch (e) {
+      log(`narration edit resolveGatewaySocket threw: ${(e as Error).message}`);
+      return;
+    }
+    if (sockPath === null) return;
+    try {
+      const client = connect({ path: sockPath });
+      client.setTimeout(5000);
+      const done = (): void => {
+        try {
+          client.destroy();
+        } catch {
+          /* gone */
+        }
+      };
+      client.on("connect", () => {
+        try {
+          client.write(
+            JSON.stringify({
+              type: "rollout_status_edit",
+              requestId: args.requestId,
+              agentName: args.agentName,
+              messageId: args.messageId,
+              text: args.text,
+            }) + "\n",
+          );
+          client.end();
+        } catch (e) {
+          log(`narration edit write failed: ${(e as Error).message}`);
+          done();
+        }
+      });
+      client.on("timeout", done);
+      client.on("error", (e) => {
+        log(`narration edit socket error: ${e.message}`);
+        done();
+      });
+      client.on("close", () => {});
+    } catch (e) {
+      log(`narration edit connect threw: ${(e as Error).message}`);
+    }
+  }
+}

--- a/src/host-control/rollout-narrator.test.ts
+++ b/src/host-control/rollout-narrator.test.ts
@@ -1,0 +1,217 @@
+/**
+ * #2726 Part 2 — the log-tailed rollout NARRATOR discipline: fire-and-forget,
+ * monotonic-by-seq, freeze-on-terminal, debounced, one message edited in place.
+ *
+ * Driven with a fake relay (records posts + edits) and fake timers so the
+ * debounce is deterministic. Pure logic — no gateway, no sockets.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  LogTailRolloutNarrator,
+  type RolloutNarrationRelay,
+} from "./rollout-narrator.js";
+import type { StatusEntry } from "./server.js";
+import type { RolloutPhase } from "../cli/rollout.js";
+
+function makeEntry(over: Partial<StatusEntry> = {}): StatusEntry {
+  return {
+    request_id: "ro-1",
+    caller: { kind: "agent", name: "overlord" },
+    op: "rollout",
+    result: "started",
+    exit_code: null,
+    started_at: Date.now(),
+    finished_at: null,
+    stdout_tail: "",
+    stderr_tail: "",
+    pin: "v1.2.3",
+    ...over,
+  };
+}
+
+interface FakeRelay extends RolloutNarrationRelay {
+  posts: { requestId: string; text: string }[];
+  edits: { messageId: number; text: string }[];
+  /** message_id the next post resolves to; null to simulate a failed post. */
+  nextMessageId: number | null;
+  /** Resolve all pending posts (they resolve on a microtask). */
+}
+
+function makeRelay(nextMessageId: number | null = 100): FakeRelay {
+  const posts: { requestId: string; text: string }[] = [];
+  const edits: { messageId: number; text: string }[] = [];
+  const relay: FakeRelay = {
+    posts,
+    edits,
+    nextMessageId,
+    async post(args) {
+      posts.push({ requestId: args.requestId, text: args.text });
+      return relay.nextMessageId;
+    },
+    edit(args) {
+      edits.push({ messageId: args.messageId, text: args.text });
+    },
+  };
+  return relay;
+}
+
+const phase = (p: string, over: Partial<RolloutPhase> = {}): RolloutPhase => ({
+  phase: p as RolloutPhase["phase"],
+  target: "v1.2.3",
+  ...over,
+});
+
+describe("LogTailRolloutNarrator", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("posts ONE message on the first phase, then EDITs it in place", async () => {
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 1000 });
+    const entry = makeEntry();
+
+    n.onPhase(entry, phase("apply"));
+    // Post is dispatched async — let the microtask resolve.
+    await vi.runAllTimersAsync();
+    expect(relay.posts).toHaveLength(1);
+    expect(relay.posts[0]!.text).toContain("applying");
+
+    // A later phase debounces an EDIT (not a second post).
+    n.onPhase(entry, phase("canary-start", { agent: "test-harness", n: 1, m: 3 }));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(relay.posts).toHaveLength(1); // still just one post
+    expect(relay.edits.length).toBeGreaterThanOrEqual(1);
+    expect(relay.edits.at(-1)!.messageId).toBe(100);
+    expect(relay.edits.at(-1)!.text).toContain("canary");
+  });
+
+  it("debounces multiple rapid phases into a single trailing-edge edit", async () => {
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 1000 });
+    const entry = makeEntry();
+
+    n.onPhase(entry, phase("apply"));
+    await vi.runAllTimersAsync(); // first post lands, message_id=100
+
+    // Fire several agent phases within the debounce window.
+    n.onPhase(entry, phase("agent-start", { agent: "a", n: 1, m: 3 }));
+    n.onPhase(entry, phase("agent-done", { agent: "a", n: 1, m: 3 }));
+    n.onPhase(entry, phase("agent-start", { agent: "b", n: 2, m: 3 }));
+    // Before the debounce fires, no new edit yet.
+    expect(relay.edits).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(1000);
+    // Exactly ONE edit coalesced the burst.
+    expect(relay.edits).toHaveLength(1);
+    expect(relay.edits[0]!.text).toContain("agent 2/3");
+  });
+
+  it("is monotonic: a stale (earlier) phase after a later one is dropped", async () => {
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });
+    const entry = makeEntry();
+
+    n.onPhase(entry, phase("apply"));
+    await vi.runAllTimersAsync();
+    // Advance to agent 3/3.
+    n.onPhase(entry, phase("agent-start", { agent: "c", n: 3, m: 3 }));
+    await vi.advanceTimersByTimeAsync(500);
+    const editsAfterProgress = relay.edits.length;
+    const lastText = relay.edits.at(-1)!.text;
+    expect(lastText).toContain("agent 3/3");
+
+    // A stale earlier phase (apply / canary) arrives out of order → dropped.
+    n.onPhase(entry, phase("canary-start", { agent: "x", n: 1, m: 3 }));
+    await vi.advanceTimersByTimeAsync(500);
+    // No regressive edit was applied.
+    expect(relay.edits.length).toBe(editsAfterProgress);
+  });
+
+  it("freezes on terminal: no later phase can un-finalize the message", async () => {
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });
+    const entry = makeEntry();
+
+    n.onPhase(entry, phase("apply"));
+    await vi.runAllTimersAsync();
+
+    // Terminal completes the roll.
+    n.onTerminal(makeEntry({ result: "completed", rolled: ["a", "b", "c"] }));
+    await vi.runAllTimersAsync();
+    const finalEdit = relay.edits.at(-1)!;
+    expect(finalEdit.text).toContain("✅");
+    expect(finalEdit.text).toContain("done");
+    const editCountAtFreeze = relay.edits.length;
+
+    // A late phase arriving after terminal is IGNORED (frozen).
+    n.onPhase(entry, phase("agent-start", { agent: "z", n: 9, m: 9 }));
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(relay.edits.length).toBe(editCountAtFreeze);
+    // The message still shows the terminal outcome, never regressed.
+    expect(relay.edits.at(-1)!.text).toContain("✅");
+  });
+
+  it("renders the ❌ terminal-error outcome with the failed step/agent", async () => {
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });
+    const entry = makeEntry();
+    n.onPhase(entry, phase("canary-start", { agent: "test-harness", n: 1, m: 2 }));
+    await vi.runAllTimersAsync();
+
+    n.onTerminal(
+      makeEntry({
+        result: "error",
+        rolled: [],
+        failed_step: "restart-agent",
+        failed_agent: "test-harness",
+        got: "1.2.2",
+      }),
+    );
+    await vi.runAllTimersAsync();
+    const t = relay.edits.at(-1)!.text;
+    expect(t).toContain("❌");
+    expect(t).toContain("restart-agent");
+    expect(t).toContain("test-harness");
+  });
+
+  it("terminal before any phase still posts the final message", async () => {
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });
+    // No phases — straight to terminal (e.g. apply failed instantly).
+    n.onTerminal(makeEntry({ result: "error", failed_step: "apply", rolled: [] }));
+    await vi.runAllTimersAsync();
+    expect(relay.posts).toHaveLength(1);
+    expect(relay.posts[0]!.text).toContain("❌");
+    expect(relay.posts[0]!.text).toContain("apply");
+  });
+
+  it("a failed post (message_id null) never crashes and skips edits", async () => {
+    const relay = makeRelay(null); // post resolves null
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });
+    const entry = makeEntry();
+    n.onPhase(entry, phase("apply"));
+    await vi.runAllTimersAsync();
+    expect(relay.posts).toHaveLength(1);
+    // A later phase can't edit (no message_id) — it re-attempts a post instead,
+    // never throws.
+    n.onPhase(entry, phase("agent-start", { agent: "a", n: 1, m: 2 }));
+    await vi.advanceTimersByTimeAsync(500);
+    expect(relay.edits).toHaveLength(0);
+  });
+
+  it("does nothing for an operator-initiated roll (no agent gateway target)", async () => {
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });
+    const entry = makeEntry({ caller: { kind: "operator" } });
+    n.onPhase(entry, phase("apply"));
+    await vi.runAllTimersAsync();
+    n.onTerminal(makeEntry({ caller: { kind: "operator" }, result: "completed" }));
+    await vi.runAllTimersAsync();
+    expect(relay.posts).toHaveLength(0);
+    expect(relay.edits).toHaveLength(0);
+  });
+});

--- a/src/host-control/rollout-narrator.ts
+++ b/src/host-control/rollout-narrator.ts
@@ -1,0 +1,316 @@
+/**
+ * #2726 Part 2 — the log-tailed rollout NARRATION surface.
+ *
+ * ONE ordinary operator-DM message, edited in place through the phases
+ * (`applying → canary → agent N/M → persisting pin → hostd/web deferred →
+ * ✅ done`, or `❌` with the failed step/agent). NOT pinned, NOT a bespoke card —
+ * in-chat narration, the `chat-is-the-single-source-of-truth` invariant's own
+ * prescribed remedy (a plain message the operator can scroll to).
+ *
+ * WHERE the tail-and-render lives (design point 7): in hostd. hostd owns the
+ * rollout request lifecycle and the durable audit log it writes per phase (the
+ * single source of truth), and it already owns the gateway relay path it uses
+ * for approval cards. So hostd tails ITS OWN rows (it is fed each phase as it
+ * parses the child's stdout — the same event that appends the durable row) and
+ * relays edit ops to the caller agent's live gateway. There is NO in-memory
+ * pin/lifecycle state that a gateway restart could orphan: the narrator holds
+ * only the message_id + last-applied seq for the current request, and recovery
+ * after a gateway restart is a re-post/re-edit driven by the durable rows hostd
+ * keeps reading. We do NOT rely on a "recreate overlord last" assumption (it's
+ * false) — the narrator lives in hostd, not overlord.
+ *
+ * Discipline (locked by the IPC review), all enforced here:
+ *   - fire-and-forget: emits/edits are `void`, never awaited by the roll.
+ *   - idempotent + monotonic by seq: an update with seq <= lastApplied is
+ *     dropped.
+ *   - frozen on terminal: once the final row is applied, no later edit can
+ *     un-finalize the message.
+ *   - debounced (trailing edge) so a 12-agent roll doesn't hammer Telegram's
+ *     single-message edit rate limit; 429 `retry_after` is honored inside the
+ *     renderer and never surfaced back toward the roll.
+ *   - bound to a hostd-attested in-flight request_id: hostd only ever feeds
+ *     phases for a real roll it is driving; a shape-only client IPC message
+ *     can't reach this path.
+ */
+
+import type { RolloutNarrator } from "./server.js";
+import type { StatusEntry } from "./server.js";
+import type { RolloutPhase } from "../cli/rollout.js";
+import {
+  renderRolloutStatus,
+  type RolloutRenderState,
+} from "./render-rollout-status.js";
+
+/**
+ * The transport the narrator drives — a live gateway relay that can POST the
+ * first status message (and learn its message_id) and EDIT it afterwards.
+ * Both are fire-and-forget from the narrator's perspective; the post resolves
+ * with a message_id (or null) so the narrator knows whether it can edit.
+ */
+export interface RolloutNarrationRelay {
+  /**
+   * Post ONE ordinary operator-DM message. Resolves with the Telegram
+   * message_id (so the narrator can edit it) or null when the post failed /
+   * no message_id came back. MUST NOT throw.
+   */
+  post(args: {
+    requestId: string;
+    agentName: string;
+    text: string;
+  }): Promise<number | null>;
+  /**
+   * Edit a previously-posted message in place. Fire-and-forget: MUST NOT throw
+   * and MUST NOT surface an edit failure (incl. 429) back to the caller.
+   */
+  edit(args: {
+    requestId: string;
+    agentName: string;
+    messageId: number;
+    text: string;
+  }): void;
+}
+
+/** Debounce window (trailing edge) for edits — long enough that a fast
+ *  N-agent roll coalesces intermediate phases into one edit, short enough
+ *  that the operator still sees live progress. */
+const DEFAULT_DEBOUNCE_MS = 1500;
+
+/** Per-request narration state. */
+interface NarrationState {
+  agentName: string;
+  /** Highest phase-sequence applied so far (monotonic gate). */
+  lastAppliedSeq: number;
+  /** The message_id once the first post lands; null until then. */
+  messageId: number | null;
+  /** True once the first post has been dispatched (so we don't double-post). */
+  posting: boolean;
+  /** The latest render state (rebuilt as phases arrive). */
+  render: RolloutRenderState;
+  /** Frozen once the terminal row is applied — no later edit may un-finalize. */
+  frozen: boolean;
+  /** Pending debounce timer for a trailing-edge edit. */
+  timer: ReturnType<typeof setTimeout> | null;
+  /** Phases buffered before the first post's message_id arrived. */
+  pendingEditAfterPost: boolean;
+}
+
+/**
+ * Log-tailed narrator. Instantiated once per hostd process; keyed by
+ * request_id so concurrent rolls (there is only ever one, per the
+ * fleet-mutation lock, but be defensive) don't cross-edit.
+ */
+export class LogTailRolloutNarrator implements RolloutNarrator {
+  private states = new Map<string, NarrationState>();
+
+  constructor(
+    private relay: RolloutNarrationRelay,
+    private opts: { debounceMs?: number; log?: (m: string) => void } = {},
+  ) {}
+
+  /**
+   * Monotonic sequence for a phase, so out-of-order / duplicate phases drop.
+   * hostd feeds phases in stdout order; this is defense-in-depth.
+   *
+   * The dominant axis is the roll TIMELINE, and for per-agent phases that is
+   * the agent's roll-order index `n` (1-based). So the sequence is
+   * `timelineBase + n*2 + within`, where `within` distinguishes the -start /
+   * -done pair for the SAME agent. This keeps `agent-start(n=2)` strictly after
+   * `agent-done(n=1)` — the bug a phase-enum-major ordering had (a later
+   * agent's start could sort before an earlier agent's done and get dropped).
+   *
+   * The canary is agent n=1, so canary-start/pass/fail slot naturally into the
+   * n=1 window. persist-pin (hostd path: after the canary) and
+   * hostd-web-deferred (end) get fixed high/low anchors outside the per-agent
+   * band so they never collide with an agent index.
+   */
+  private static seqFor(phase: RolloutPhase): number {
+    switch (phase.phase) {
+      case "apply":
+        return 0; // always first
+      case "canary-start":
+        return 2 * 1 + 0; // n=1 window, start
+      case "canary-pass":
+      case "canary-fail":
+        return 2 * 1 + 1; // n=1 window, done
+      case "persist-pin":
+        // hostd path: right after the canary confirms (between n=1 and n=2).
+        return 2 * 1 + 1; // co-timed with canary-done; monotonic, never regresses
+      case "agent-start":
+        return 2 * (phase.n ?? 1) + 0;
+      case "agent-done":
+        return 2 * (phase.n ?? 1) + 1;
+      case "hostd-web-deferred":
+        return Number.MAX_SAFE_INTEGER - 1; // near the end, before terminal
+      default:
+        return 0;
+    }
+  }
+
+  onPhase(entry: StatusEntry, phase: RolloutPhase): void {
+    try {
+      const st = this.ensureState(entry);
+      if (st.frozen) return; // terminal already applied — never un-finalize.
+
+      // Monotonic gate. seqFor already folds the roll-order index `n` into the
+      // timeline, so a strictly-earlier phase (stale / out-of-order) drops.
+      // `<=` would drop the -done of a phase whose -start shares the window on
+      // the persist-pin/canary co-timing edge, so use strict `<` to let an
+      // equal-seq transition through (it only ever refines the same window).
+      const seq = LogTailRolloutNarrator.seqFor(phase);
+      if (seq < st.lastAppliedSeq) return; // stale — drop.
+      st.lastAppliedSeq = seq;
+
+      // Rebuild the render state from this phase (pull-shaped: each phase is a
+      // projection of the latest durable row hostd just wrote).
+      st.render = {
+        ...st.render,
+        target: phase.target,
+        phase: phase.phase,
+        ...(phase.n !== undefined ? { n: phase.n } : {}),
+        ...(phase.m !== undefined ? { m: phase.m } : {}),
+        ...(phase.agent !== undefined ? { agent: phase.agent } : {}),
+        rolled: entry.rolled,
+      };
+      this.scheduleRenderOrPost(entry.request_id);
+    } catch (e) {
+      this.opts.log?.(`onPhase threw (non-fatal): ${(e as Error).message}`);
+    }
+  }
+
+  onTerminal(entry: StatusEntry): void {
+    try {
+      const st = this.ensureState(entry);
+      // Terminal wins unconditionally and FREEZES the surface.
+      st.render = {
+        target: entry.pin ?? st.render.target,
+        rolled: entry.rolled ?? st.render.rolled,
+        terminal: entry.result === "completed" ? "completed" : "error",
+        ...(entry.failed_step ? { failedStep: entry.failed_step } : {}),
+        ...(entry.failed_agent ? { failedAgent: entry.failed_agent } : {}),
+        ...(entry.got !== undefined ? { got: entry.got } : {}),
+      };
+      st.frozen = true;
+      // Cancel any pending debounced edit — the terminal render supersedes it —
+      // and flush the terminal state immediately (no debounce on the final
+      // message: the operator wants the outcome now).
+      if (st.timer) {
+        clearTimeout(st.timer);
+        st.timer = null;
+      }
+      this.flush(entry.request_id, /* immediate */ true);
+      // Drop state shortly after the terminal flush so the map doesn't grow.
+      setTimeout(() => this.states.delete(entry.request_id), 10_000).unref?.();
+    } catch (e) {
+      this.opts.log?.(`onTerminal threw (non-fatal): ${(e as Error).message}`);
+    }
+  }
+
+  private ensureState(entry: StatusEntry): NarrationState {
+    let st = this.states.get(entry.request_id);
+    if (!st) {
+      const agentName =
+        entry.caller.kind === "agent" ? entry.caller.name : "";
+      st = {
+        agentName,
+        lastAppliedSeq: -1,
+        messageId: null,
+        posting: false,
+        render: { target: entry.pin ?? "" },
+        frozen: false,
+        timer: null,
+        pendingEditAfterPost: false,
+      };
+      this.states.set(entry.request_id, st);
+    }
+    return st;
+  }
+
+  /** Post the first message (once), then debounce edits for subsequent phases. */
+  private scheduleRenderOrPost(requestId: string): void {
+    const st = this.states.get(requestId);
+    if (!st) return;
+    if (st.agentName.length === 0) return; // operator-initiated / unknown — no relay target.
+
+    // First contact: POST the message (async), capture the message_id.
+    if (st.messageId === null && !st.posting) {
+      st.posting = true;
+      const text = renderRolloutStatus(st.render);
+      void this.relay
+        .post({ requestId, agentName: st.agentName, text })
+        .then((mid) => {
+          st.messageId = mid;
+          st.posting = false;
+          // If phases arrived while we were posting, apply the latest now.
+          if (st.pendingEditAfterPost) {
+            st.pendingEditAfterPost = false;
+            this.flush(requestId, /* immediate */ false);
+          }
+        })
+        .catch((e) => {
+          st.posting = false;
+          this.opts.log?.(`rollout narration post failed (non-fatal): ${(e as Error).message}`);
+        });
+      return;
+    }
+
+    // Post in flight — remember to apply the newest render once it lands.
+    if (st.messageId === null && st.posting) {
+      st.pendingEditAfterPost = true;
+      return;
+    }
+
+    // We have a message_id: debounce a trailing-edge edit.
+    this.scheduleDebouncedEdit(requestId);
+  }
+
+  private scheduleDebouncedEdit(requestId: string): void {
+    const st = this.states.get(requestId);
+    if (!st) return;
+    if (st.timer) return; // a trailing-edge edit is already scheduled.
+    const ms = this.opts.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+    st.timer = setTimeout(() => {
+      st.timer = null;
+      this.flush(requestId, /* immediate */ true);
+    }, ms);
+    st.timer.unref?.();
+  }
+
+  /** Render current state and edit the message (or post if none yet). */
+  private flush(requestId: string, immediate: boolean): void {
+    const st = this.states.get(requestId);
+    if (!st) return;
+    if (st.agentName.length === 0) return;
+    if (!immediate) {
+      this.scheduleDebouncedEdit(requestId);
+      return;
+    }
+    const text = renderRolloutStatus(st.render);
+    if (st.messageId === null) {
+      // No message yet (terminal fired before the first phase posted, or the
+      // post is still in flight). Post now if we're not mid-post.
+      if (!st.posting) {
+        st.posting = true;
+        void this.relay
+          .post({ requestId, agentName: st.agentName, text })
+          .then((mid) => {
+            st.messageId = mid;
+            st.posting = false;
+          })
+          .catch((e) => {
+            st.posting = false;
+            this.opts.log?.(`rollout narration terminal-post failed (non-fatal): ${(e as Error).message}`);
+          });
+      } else {
+        st.pendingEditAfterPost = true;
+      }
+      return;
+    }
+    // Edit in place (fire-and-forget; relay swallows failures incl. 429).
+    this.relay.edit({
+      requestId,
+      agentName: st.agentName,
+      messageId: st.messageId,
+      text,
+    });
+  }
+}

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -206,8 +206,11 @@ export interface RolloutNarrator {
  * Per-request status snapshot retained for `get_status` lookups.
  * Capped at the most recent N requests per daemon process; entries
  * older than the cap age get evicted lazily.
+ *
+ * Exported (#2726) so the RolloutNarrator can read the terminal fields when
+ * finalizing the in-chat narration surface.
  */
-interface StatusEntry {
+export interface StatusEntry {
   request_id: string;
   caller: SocketIdentity;
   op: string;
@@ -2586,10 +2589,18 @@ export class HostdServer {
       })
       .finally(() => {
         void this.writeTerminalAudit(entry);
-        // #2726 — terminal effects. All fire-and-forget: a chat push / narrator
-        // finalize must NEVER block the lock release or the roll's completion.
+        // #2726 — terminal effects. All fire-and-forget and defensively
+        // wrapped: a chat push / narrator finalize must NEVER block the lock
+        // release or the roll's completion (a throwing narrator/relay can't
+        // strand the fleet-mutation lock).
         this.pushRolloutTerminal(entry);
-        this.rolloutNarrator?.onTerminal(entry);
+        try {
+          this.rolloutNarrator?.onTerminal(entry);
+        } catch (e) {
+          process.stderr.write(
+            `hostd: rollout narrator onTerminal threw (non-fatal): ${(e as Error).message}\n`,
+          );
+        }
         if (
           this.fleetMutationInFlight &&
           this.fleetMutationInFlight.request_id === entry.request_id
@@ -2950,7 +2961,15 @@ export class HostdServer {
     void this.writePhaseAudit(entry, phase);
     // Part 2 hook — attached only when a narration renderer is wired. Kept as
     // an optional member so Part 1 is mergeable alone (no renderer → no-op).
-    this.rolloutNarrator?.onPhase(entry, phase);
+    // Defensively wrapped: a throwing narrator must not break the stdout tap
+    // (and thus lose subsequent durable phase rows).
+    try {
+      this.rolloutNarrator?.onPhase(entry, phase);
+    } catch (e) {
+      process.stderr.write(
+        `hostd: rollout narrator onPhase threw (non-fatal): ${(e as Error).message}\n`,
+      );
+    }
   }
 
   /**

--- a/telegram-plugin/tests/rollout-status-wiring.test.ts
+++ b/telegram-plugin/tests/rollout-status-wiring.test.ts
@@ -1,0 +1,81 @@
+/**
+ * #2726 — structural wiring guard for the rollout status IPC verbs. The
+ * gateway handlers live in the createIpcServer({...}) IIFE block, which can't
+ * be imported in a unit test (same constraint as the send_outbound /
+ * inject_inbound wiring tests), so the load-bearing invariants are pinned by
+ * reading the source:
+ *   1. ipc-server routes rollout_status_post → onRolloutStatusPost and
+ *      rollout_status_edit → onRolloutStatusEdit, with validator arms.
+ *   2. the POST handler fences agent (agentName === self), posts to the
+ *      OPERATOR chat (allowFrom[0]) as an ORDINARY message (no pin, no
+ *      inline_keyboard card), and replies with the message_id.
+ *   3. the EDIT handler edits in place via the wrapped retry path
+ *      (swallowingApiCall) — fire-and-forget, never a raw bot.api call.
+ *   4. NEITHER handler pins a message — this is in-chat narration, not the
+ *      retired pinned card (chat-is-the-single-source-of-truth).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+const gw = readFileSync(new URL("../gateway/gateway.ts", import.meta.url), "utf8");
+const ipcServer = readFileSync(new URL("../gateway/ipc-server.ts", import.meta.url), "utf8");
+
+describe("rollout_status_* — ipc-server routing", () => {
+  it("validates + dispatches rollout_status_post", () => {
+    expect(ipcServer).toMatch(/case "rollout_status_post": \{/); // validator arm
+    expect(ipcServer).toMatch(/onRolloutStatusPost\(client, msg as RolloutStatusPostMessage\)/);
+  });
+  it("validates + dispatches rollout_status_edit", () => {
+    expect(ipcServer).toMatch(/case "rollout_status_edit": \{/);
+    expect(ipcServer).toMatch(/onRolloutStatusEdit\(client, msg as RolloutStatusEditMessage\)/);
+  });
+});
+
+describe("onRolloutStatusPost — gateway handler invariants", () => {
+  const start = gw.indexOf("async onRolloutStatusPost(client: IpcClient, msg: RolloutStatusPostMessage)");
+  const next = gw.indexOf("onRolloutStatusEdit(", start);
+  const handler = gw.slice(start, next > start ? next : start + 2600);
+
+  it("the handler exists", () => {
+    expect(start).toBeGreaterThan(0);
+  });
+  it("fences the agent (agentName must match this gateway's own)", () => {
+    expect(handler).toMatch(/msg\.agentName !== self/);
+  });
+  it("posts to the OPERATOR chat (allowFrom[0])", () => {
+    expect(handler).toMatch(/loadAccess\(\)\.allowFrom\[0\]/);
+  });
+  it("posts through the wrapped retry path, NOT a raw bot.api", () => {
+    expect(handler).toMatch(/robustApiCall\(/);
+    expect(handler).toMatch(/bot\.api\.sendRichMessage\(operator/);
+  });
+  it("replies with the message_id so hostd can EDIT it later", () => {
+    expect(handler).toMatch(/rollout_status_posted/);
+    expect(handler).toMatch(/messageId/);
+  });
+  it("does NOT pin the message and renders NO inline-keyboard card (narration, not the retired card)", () => {
+    expect(handler).not.toMatch(/pinChatMessage/);
+    expect(handler).not.toMatch(/reply_markup/);
+    expect(handler).not.toMatch(/InlineKeyboard/);
+  });
+});
+
+describe("onRolloutStatusEdit — gateway handler invariants", () => {
+  const start = gw.indexOf("onRolloutStatusEdit(_client: IpcClient, msg: RolloutStatusEditMessage)");
+  const next = gw.indexOf("onInjectInbound(", start);
+  const handler = gw.slice(start, next > start ? next : start + 2000);
+
+  it("the handler exists", () => {
+    expect(start).toBeGreaterThan(0);
+  });
+  it("fences the agent", () => {
+    expect(handler).toMatch(/msg\.agentName !== self/);
+  });
+  it("edits in place via the wrapped retry path (fire-and-forget)", () => {
+    expect(handler).toMatch(/swallowingApiCall\(/);
+    expect(handler).toMatch(/bot\.api\.editMessageText\(operator, msg\.messageId/);
+  });
+  it("does NOT pin (edits an ordinary message)", () => {
+    expect(handler).not.toMatch(/pinChatMessage/);
+  });
+});

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -2416,3 +2416,116 @@ describe("hostd server — rollout phase observability (#2726)", () => {
     rmSync(execTmp, { recursive: true, force: true });
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #2726 Part 2 — the narration renderer is FED each phase + the terminal by
+// hostd (the tail-and-render seam lives in hostd). Wire a fake narrator and
+// assert it receives the phases in order and the terminal, without blocking.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("hostd server — rollout narrator feed (#2726 Part 2)", () => {
+  it("feeds the narrator every phase, in order, then the terminal", async () => {
+    const execTmp = mkdtempSync(join("/var/tmp", "hostd-narrator-"));
+    const stub = join(execTmp, "stub.sh");
+    writeFileSync(
+      stub,
+      `#!/bin/sh\n` +
+        `echo 'SWITCHROOM_ROLLOUT_PHASE:{"phase":"apply","target":"v0.15.18"}'\n` +
+        `echo 'SWITCHROOM_ROLLOUT_PHASE:{"phase":"canary-start","target":"v0.15.18","agent":"klanker","n":1,"m":2}'\n` +
+        `echo 'SWITCHROOM_ROLLOUT_PHASE:{"phase":"canary-pass","target":"v0.15.18","agent":"klanker","n":1,"m":2}'\n` +
+        `echo 'SWITCHROOM_ROLLOUT_PHASE:{"phase":"agent-done","target":"v0.15.18","agent":"bob","n":2,"m":2}'\n` +
+        `echo 'SWITCHROOM_ROLLOUT_RESULT:{"ok":true,"rolled":["klanker","bob"],"warnings":[]}'\n` +
+        `exit 0\n`,
+    );
+    chmodSync(stub, 0o755);
+
+    const assets = join(tmp, `assets-narrator-${Date.now()}`);
+    mkdirSync(join(assets, "profiles", "default"), { recursive: true });
+    mkdirSync(join(assets, "vendor", "hindsight-memory"), { recursive: true });
+
+    const seenPhases: string[] = [];
+    let terminalResult: string | null = null;
+
+    if (server) await server.stop();
+    server = new HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: stub,
+      auditLogPath: join(tmp, "audit-narrator.log"),
+      applyAssetsRoot: assets,
+      allowNonLinux: true,
+      rolloutNarrator: {
+        onPhase: (_e, p) => seenPhases.push(p.phase),
+        onTerminal: (e) => {
+          terminalResult = e.result;
+        },
+      },
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+    await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "rollout", request_id: "ro-narr-1", args: { pin: "v0.15.18" } },
+    );
+    await new Promise((r) => setTimeout(r, 400));
+
+    expect(seenPhases).toEqual(["apply", "canary-start", "canary-pass", "agent-done"]);
+    expect(terminalResult).toBe("completed");
+
+    rmSync(execTmp, { recursive: true, force: true });
+  });
+
+  it("a narrator that throws in onPhase does NOT fail the roll", async () => {
+    const execTmp = mkdtempSync(join("/var/tmp", "hostd-narrator-throw-"));
+    const stub = join(execTmp, "stub.sh");
+    writeFileSync(
+      stub,
+      `#!/bin/sh\n` +
+        `echo 'SWITCHROOM_ROLLOUT_PHASE:{"phase":"apply","target":"v0.15.18"}'\n` +
+        `echo 'SWITCHROOM_ROLLOUT_RESULT:{"ok":true,"rolled":["klanker"],"warnings":[]}'\n` +
+        `exit 0\n`,
+    );
+    chmodSync(stub, 0o755);
+
+    const assets = join(tmp, `assets-narrator-throw-${Date.now()}`);
+    mkdirSync(join(assets, "profiles", "default"), { recursive: true });
+    mkdirSync(join(assets, "vendor", "hindsight-memory"), { recursive: true });
+
+    if (server) await server.stop();
+    server = new HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: stub,
+      auditLogPath: join(tmp, "audit-narrator-throw.log"),
+      applyAssetsRoot: assets,
+      allowNonLinux: true,
+      rolloutNarrator: {
+        onPhase: () => {
+          throw new Error("narrator boom");
+        },
+        onTerminal: () => {
+          throw new Error("narrator terminal boom");
+        },
+      },
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+    await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "rollout", request_id: "ro-narr-throw-1", args: { pin: "v0.15.18" } },
+    );
+    await new Promise((r) => setTimeout(r, 400));
+
+    const poll = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "get_status", request_id: "poll-nt", args: { target_request_id: "ro-narr-throw-1" } },
+    );
+    // The roll completed despite the narrator throwing on every callback.
+    expect(poll.result).toBe("completed");
+
+    rmSync(execTmp, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
Stacks on #2726 (Part 1 — durable rollout observability). **Base = the Part 1 branch**, so review Part 1 first.

## Vision outcome & JTBD

- **Outcome (Visibility):** `hold-the-leash` — the operator watches a fleet operation progress in the chat.
- **JTBD:** `reference/jobs/operate-the-fleet-from-telegram.md` (shipped in Part 1). Consistent with `see-my-whole-fleet-from-one-screen.md` (status in durable artifacts + in-chat narration).

## What Part 2 ships

**One ordinary operator-DM message, edited in place through the phases** — `applying → canary → agent N/M → persisting pin → hostd/web deferred → ✅ done` (or `❌` with the failed step/agent). **NOT pinned, NOT a bespoke card.**

### Where the tail-and-render seam lives (design point 7): in **hostd**

hostd owns the rollout request lifecycle + the durable audit log it writes per phase (the single source of truth) + the gateway relay path it already uses for approval cards. So hostd tails its **own** rows (it is fed each phase as it parses the child's stdout — the same event that appends the durable row) and relays edit ops to the caller agent's live gateway. We do **not** rely on a "recreate overlord last" assumption (it's false) — the narrator lives in hostd, not overlord. There is **no** in-memory pin/lifecycle state a gateway restart could orphan (the killed design's fatal flaw): recovery is a re-post/re-edit driven by the durable rows hostd keeps reading.

### Discipline (all enforced + unit-tested)

- **Fire-and-forget:** emits/edits are `void`, never awaited; a throwing narrator/relay can't block the lock release or fail the roll (defensively wrapped).
- **Idempotent + monotonic by seq:** a stale/out-of-order phase (`seq < lastApplied`) is dropped; the seq is roll-order (`n`)-major so a later agent's start never sorts before an earlier agent's done.
- **Frozen on terminal:** once the final row applies, no later phase un-finalizes the message.
- **Debounced (~1.5s trailing edge)** so a 12-agent roll coalesces phases into one edit and doesn't hit Telegram's single-message edit 429.
- **429 `retry_after`** handled gateway-side (`swallowingApiCall`) — never surfaced back toward the roll.
- **Bound to a hostd-attested in-flight `request_id`:** hostd only feeds phases for a real roll it drives; a shape-only client IPC message can't paint the surface (the reverse channel is unauthenticated — a forged terminal "✅ rolled" is worse than silence).

## Invariants

Crosses **no** invariant. This is **in-chat narration** — the `chat-is-the-single-source-of-truth` invariant's own prescribed remedy: a plain message the operator can scroll to, edited in place, **never pinned**. It is not a parallel pinned mirror (the retired #1122 card).

## Tests

Narrator: post-once-then-edit, debounce-coalescing, monotonic-drop-stale, freeze-on-terminal, ❌-error render, terminal-before-any-phase, failed-post, operator-initiated no-op. hostd feeds the narrator every phase in order + the terminal; a throwing narrator does not fail the roll. Gateway-handler structural wiring (no pin, no card, operator chat, wrapped retry path). `npm run lint` + `npm run build` green; same 3 pre-existing environment-only failures as Part 1 (confirmed on base `900b5451`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)