### PR TITLE
fix(telegram): delete the "pinned a message" service message for silent status pins

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1008,7 +1008,7 @@ type Access = {
     enabled?: boolean
     engine?: 'kokoro' | 'openai'
     voice?: string
-    reply_mode?: 'voice+text' | 'voice-only'
+    reply_mode?: 'voice+text' | 'voice-only' | 'on-demand'
     /** Kokoro-engine playback speed. Clamped to 0.5–2.0; defaults to 1.1
      *  when voice_out is enabled but speed is unset (the fleet default —
      *  slightly brisker than neutral). Ignored by the OpenAI path. */

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -22290,7 +22290,7 @@ bot.on('callback_query:data', async ctx => {
     }
     try {
       // Native voice note (NOT a document), quote-replying the button's
-      // message. Keyboard is left intact so the button stays replayable.
+      // message.
       await robustApiCall(
         () =>
           bot.api.sendVoice(
@@ -22308,6 +22308,26 @@ bot.on('callback_query:data', async ctx => {
           ...(cbThreadId != null ? { threadId: cbThreadId } : {}),
         },
       )
+      // Single-use on SUCCESS: strip the '🔊 Listen' keyboard so the button
+      // can't be re-tapped now that the audio has been delivered. Mirrors the
+      // agent-button single_use strip (keyboardIsSingleUse) house style.
+      // Best-effort + non-fatal — a failed strip only leaves a replayable
+      // button, never drops the delivered audio. Only reached on a successful
+      // sendVoice; expiry / synth-failure / sidecar-unavailable all return
+      // earlier WITHOUT stripping, so the user can retry those.
+      if (cbMessageId != null) {
+        await robustApiCall(
+          () =>
+            bot.api.editMessageReplyMarkup(cbChatId, cbMessageId, {
+              reply_markup: { inline_keyboard: [] },
+            }),
+          {
+            chat_id: cbChatId,
+            verb: 'voice-ondemand.strip-listen-keyboard',
+            ...(cbThreadId != null ? { threadId: cbThreadId } : {}),
+          },
+        ).catch(() => {})
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       process.stderr.write(

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -373,7 +373,10 @@ import { loadObligations, persistObligations } from './obligation-store.js'
 import {
   loadStatusPins,
   persistStatusPins,
+  pinnedMessageIsOurs,
+  runStatusPinBootCleanup,
   type PersistedStatusPin,
+  type TrackedStatusPin,
 } from './status-pin-store.js'
 import { driveEscalation } from './escalation-drive.js'
 import { shouldSuppressRepresent } from './represent-guard.js'
@@ -5652,42 +5655,38 @@ function statusPinApi(): PinBotApi {
 }
 
 /**
- * Boot-time orphan cleanup. Any pin persisted by a PRIOR session is stale by
- * definition — the turn it represented ended or the session crashed before its
- * unpin reconcile ran. So on boot we best-effort unpin each persisted entry and
- * clear the store; we do NOT re-adopt or re-pin. This must run BEFORE any new
- * pin claims are written, so the freshly-emptied store reflects only this
- * session's pins and the service-message-deletion handler's ownership check
- * (statusPinState) sees no false positives. Non-fatal: a failed unpin only
- * leaves the orphan, exactly today's behaviour.
+ * Boot-time orphan cleanup — thin gateway wrapper over the pure
+ * `runStatusPinBootCleanup` (which owns the load → best-effort-unpin →
+ * empty-store contract). Binds the live fs seam, the robust unpin api, and the
+ * gateway logger.
+ *
+ * MUST run ONLY after this gateway wins the startup mutex (the store is a
+ * shared per-agent file; a losing double-boot would unpin the live holder's
+ * legitimate pins). Runs before any new pin claim is written, so the emptied
+ * store leaves the service-message handler's ownership check with no false
+ * positives.
  */
 async function statusPinBootCleanup(): Promise<void> {
   if (!statusPinPersistEnabled) return
-  const persisted = loadStatusPins(STATUS_PIN_STORE_PATH, statusPinStoreFs)
-  if (persisted.length === 0) return
   const api = statusPinApi()
-  let cleared = 0
-  for (const pin of persisted) {
-    try {
-      await api.unpinChatMessage(pin.chatId, pin.messageId)
-      cleared++
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      process.stderr.write(
-        `telegram gateway: status-pin boot cleanup: unpin failed ` +
-          `(chat=${pin.chatId} msg=${pin.messageId}): ${msg}\n`,
-      )
-    }
+  const { cleared, total } = await runStatusPinBootCleanup({
+    path: STATUS_PIN_STORE_PATH,
+    fs: statusPinStoreFs,
+    unpin: (chatId, messageId) => api.unpinChatMessage(chatId, messageId),
+  })
+  if (total > 0) {
+    process.stderr.write(
+      `telegram gateway: status-pin: cleared ${cleared}/${total} ` +
+        `orphaned pin(s) from a prior session\n`,
+    )
   }
-  // Empty the store regardless — these claims belong to a dead session; leaving
-  // them would re-attempt the same (already-tried) unpins on every future boot.
-  persistStatusPins(STATUS_PIN_STORE_PATH, statusPinStoreFs, [])
-  process.stderr.write(
-    `telegram gateway: status-pin: cleared ${cleared}/${persisted.length} ` +
-      `orphaned pin(s) from a prior session\n`,
-  )
 }
-void statusPinBootCleanup()
+// NOTE: statusPinBootCleanup() is deliberately NOT invoked here at import time.
+// The status-pin store is a SHARED per-agent file, and cleanup issues real
+// unpinChatMessage calls. On a double-boot the losing gateway must NOT touch
+// that shared state — its unpins would strip pins the STILL-ALIVE holder
+// legitimately owns. So the call is gated on winning the startup mutex
+// (top-level await below); see the acquireStartupLock block.
 
 /**
  * The single entry point that mutates pin state for `pinKey`. Serialises
@@ -5918,6 +5917,12 @@ function ensureIssuesCard(chatId: string, threadId: number | undefined): void {
     process.stderr.write(
       `telegram gateway: wrote PID file ${GATEWAY_PID_PATH} pid=${process.pid} startedAt=${GATEWAY_STARTED_AT_MS}\n`,
     )
+    // We WON the startup mutex — this gateway is the sole live owner of the
+    // shared per-agent status-pin store, so it's now safe to clean up orphaned
+    // pins from a prior (dead) session. Gated here (not at import time) so a
+    // LOSING double-boot never unpins the live holder's legitimate pins.
+    // Fire-and-forget: cleanup is best-effort and must not block boot.
+    void statusPinBootCleanup()
   } catch (err) {
     process.stderr.write(
       `telegram gateway: boot.lock_acquire_failed err=${(err as Error).message} agent=${SWITCHROOM_AGENT_NAME}\n`,
@@ -5929,6 +5934,11 @@ function ensureIssuesCard(chatId: string, threadId: number | undefined): void {
     try {
       writePidFile(GATEWAY_PID_PATH, { pid: process.pid, startedAtMs: GATEWAY_STARTED_AT_MS })
       process.stderr.write(`telegram gateway: wrote PID file ${GATEWAY_PID_PATH} pid=${process.pid} startedAt=${GATEWAY_STARTED_AT_MS} (mutex-fallback)\n`)
+      // Mutex was unavailable (link() unsupported fs); the legacy pid-file
+      // probe + 409-retry loop is still the liveness guard on this path. A
+      // successful writePidFile here means no live holder was detected, so
+      // running orphan cleanup is consistent with the pre-mutex behaviour.
+      void statusPinBootCleanup()
     } catch (writeErr) {
       process.stderr.write(`telegram gateway: writePidFile failed: ${writeErr}\n`)
     }
@@ -23618,8 +23628,20 @@ bot.on('message:pinned_message', async ctx => {
   const chatId = String(ctx.chat.id)
   const serviceMsgId = ctx.msg.message_id
 
-  const isOurs = () =>
-    [...statusPinState.values()].some(s => s.messageId === pinnedId)
+  // Chat-scoped ownership (see pinnedMessageIsOurs): the match requires BOTH
+  // the messageId AND that the tracked entry lives in THIS chat, so a pin id
+  // colliding across chats can't delete a foreign (e.g. operator-manual) pin
+  // notice. statusPinChatIds is the companion pinKey→chatId map written on
+  // every desired-pinned reconcile.
+  const trackedPins = (): TrackedStatusPin[] => {
+    const out: TrackedStatusPin[] = []
+    for (const [pinKey, state] of statusPinState) {
+      const c = statusPinChatIds.get(pinKey)
+      if (c != null) out.push({ chatId: c, messageId: state.messageId })
+    }
+    return out
+  }
+  const isOurs = () => pinnedMessageIsOurs(trackedPins(), chatId, pinnedId)
 
   if (!isOurs()) {
     // Tolerate the reconcile-store race: wait briefly, then re-check once.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -370,6 +370,11 @@ import {
   obligationEscalationText,
 } from './obligation-ledger.js'
 import { loadObligations, persistObligations } from './obligation-store.js'
+import {
+  loadStatusPins,
+  persistStatusPins,
+  type PersistedStatusPin,
+} from './status-pin-store.js'
 import { driveEscalation } from './escalation-drive.js'
 import { shouldSuppressRepresent } from './represent-guard.js'
 import { createInboundSpool } from './inbound-spool.js'
@@ -5599,6 +5604,36 @@ const statusPinState = new Map<string, PinState>()
 // every desired-pinned reconcile, cleared alongside the state on unpin.
 const statusPinChatIds = new Map<string, string>()
 
+// Durable snapshot of the pin claim set on the persistent per-agent volume
+// (STATE_DIR = /state/agent/telegram in prod). Closes the crash hole: the
+// in-memory Maps alone empty on restart, so a status pin left dangling by a
+// crashed session is never unpinned and the service-message-deletion handler
+// can't recognise it as ours. Every reconcile persists the current claim set;
+// boot cleanup (statusPinBootCleanup, wired after lockedBot is defined) unpins
+// each persisted entry and clears the store. STATIC mode and feature-off skip
+// disk. Mirrors obligation-store.ts.
+const STATUS_PIN_STORE_PATH = join(STATE_DIR, 'status-pins.json')
+const statusPinStoreFs = {
+  readFileSync: (p: string) => readFileSync(p, 'utf8'),
+  writeFileSync: (p: string, d: string) => writeFileSync(p, d),
+  renameSync: (a: string, b: string) => renameSync(a, b),
+  existsSync: (p: string) => existsSync(p),
+}
+const statusPinPersistEnabled = !STATIC && PIN_STATUS_WHILE_WORKING
+
+// Snapshot the live claim set and write it through. Called on every reconcile
+// (pin/unpin) so the on-disk set always mirrors the in-memory Maps.
+function persistStatusPinSnapshot(): void {
+  if (!statusPinPersistEnabled) return
+  const snapshot: PersistedStatusPin[] = []
+  for (const [pinKey, state] of statusPinState) {
+    const chatId = statusPinChatIds.get(pinKey)
+    if (chatId == null) continue
+    snapshot.push({ pinKey, chatId, messageId: state.messageId })
+  }
+  persistStatusPins(STATUS_PIN_STORE_PATH, statusPinStoreFs, snapshot)
+}
+
 // The Bot API surface the pin driver needs. `lockedBot` is defined later; wrap
 // lazily so this helper can be declared alongside the state it owns.
 function statusPinApi(): PinBotApi {
@@ -5615,6 +5650,44 @@ function statusPinApi(): PinBotApi {
       ),
   }
 }
+
+/**
+ * Boot-time orphan cleanup. Any pin persisted by a PRIOR session is stale by
+ * definition — the turn it represented ended or the session crashed before its
+ * unpin reconcile ran. So on boot we best-effort unpin each persisted entry and
+ * clear the store; we do NOT re-adopt or re-pin. This must run BEFORE any new
+ * pin claims are written, so the freshly-emptied store reflects only this
+ * session's pins and the service-message-deletion handler's ownership check
+ * (statusPinState) sees no false positives. Non-fatal: a failed unpin only
+ * leaves the orphan, exactly today's behaviour.
+ */
+async function statusPinBootCleanup(): Promise<void> {
+  if (!statusPinPersistEnabled) return
+  const persisted = loadStatusPins(STATUS_PIN_STORE_PATH, statusPinStoreFs)
+  if (persisted.length === 0) return
+  const api = statusPinApi()
+  let cleared = 0
+  for (const pin of persisted) {
+    try {
+      await api.unpinChatMessage(pin.chatId, pin.messageId)
+      cleared++
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      process.stderr.write(
+        `telegram gateway: status-pin boot cleanup: unpin failed ` +
+          `(chat=${pin.chatId} msg=${pin.messageId}): ${msg}\n`,
+      )
+    }
+  }
+  // Empty the store regardless — these claims belong to a dead session; leaving
+  // them would re-attempt the same (already-tried) unpins on every future boot.
+  persistStatusPins(STATUS_PIN_STORE_PATH, statusPinStoreFs, [])
+  process.stderr.write(
+    `telegram gateway: status-pin: cleared ${cleared}/${persisted.length} ` +
+      `orphaned pin(s) from a prior session\n`,
+  )
+}
+void statusPinBootCleanup()
 
 /**
  * The single entry point that mutates pin state for `pinKey`. Serialises
@@ -5648,6 +5721,10 @@ async function reconcileStatusPin(
     statusPinState.set(pinKey, next)
     statusPinChatIds.set(pinKey, chatId)
   }
+  // Mirror the mutation to disk (pin → present, unpin → removed) so a crash
+  // before the next unpin can't strand the pin — boot cleanup unpins whatever
+  // survives here. Wired exactly like obligationStore's onChange.
+  persistStatusPinSnapshot()
 }
 
 /**

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -23654,8 +23654,18 @@ bot.on('message:pinned_message', async ctx => {
       () => lockedBot.api.deleteMessage(chatId, serviceMsgId),
       { chat_id: chatId, verb: 'status-pin.delete-service-message' },
     )
-  } catch {
-    // Best-effort: a failure to delete the service message is cosmetic only.
+  } catch (err) {
+    // Best-effort: a failure to delete the service message is cosmetic only —
+    // the "pinned a message" line just stays. The most likely cause in a
+    // supergroup/forum is the bot lacking can_delete_messages admin right, so
+    // surface a concise one-liner (robustApiCall rethrows this case without
+    // logging a reason) rather than swallowing silently — an operator sees WHY.
+    const msg = err instanceof Error ? err.message : String(err)
+    process.stderr.write(
+      `telegram gateway: status-pin: could not delete pin service message ` +
+        `(chat=${chatId} msg=${serviceMsgId}) — likely missing can_delete_messages ` +
+        `admin right in this chat: ${msg}\n`,
+    )
   }
 })
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -23502,6 +23502,44 @@ bot.on('message:checklist_tasks_added' as Parameters<typeof bot.on>[0], (ctx) =>
   handleChecklistUpdate(ctx as unknown as Context, 'checklist_tasks_added')
 })
 
+// Suppress the "pinned a message" service message Telegram inserts when OUR
+// silent status-pin fires. The pin call passes `disable_notification: true`,
+// which kills the PUSH notification but NOT the in-chat service message — so
+// delete that service message as it lands, but ONLY for pins we own (tracked
+// in `statusPinState`). Manual/operator pins are never silent and are never
+// touched. Only silent status pins reach here as an OUR-pin match, so the
+// ownership check is the guard.
+//
+// Race tolerance: the service update can arrive before `reconcileStatusPin`
+// has stored the new PinState (the pin API call resolves, Telegram emits the
+// service message, and only then does the reconcile write the Map). A single
+// short retry covers that window; if it's still not one of ours, we leave the
+// service message alone.
+bot.on('message:pinned_message', async ctx => {
+  const pinnedId = ctx.msg.pinned_message?.message_id
+  if (pinnedId == null) return
+  const chatId = String(ctx.chat.id)
+  const serviceMsgId = ctx.msg.message_id
+
+  const isOurs = () =>
+    [...statusPinState.values()].some(s => s.messageId === pinnedId)
+
+  if (!isOurs()) {
+    // Tolerate the reconcile-store race: wait briefly, then re-check once.
+    await new Promise(resolve => setTimeout(resolve, 250))
+    if (!isOurs()) return
+  }
+
+  try {
+    await robustApiCall(
+      () => lockedBot.api.deleteMessage(chatId, serviceMsgId),
+      { chat_id: chatId, verb: 'status-pin.delete-service-message' },
+    )
+  } catch {
+    // Best-effort: a failure to delete the service message is cosmetic only.
+  }
+})
+
 // ─── Reaction-trigger runtime state (#1074) ──────────────────────────────
 //
 // Bot-message reactions in the configured allowlist trigger a synthetic

--- a/telegram-plugin/gateway/status-pin-store.ts
+++ b/telegram-plugin/gateway/status-pin-store.ts
@@ -1,0 +1,114 @@
+/**
+ * status-pin-store.ts — durable snapshot for the status-pin claim set.
+ *
+ * Why this exists: the gateway tracks the messages it has SILENTLY pinned
+ * (`channels.telegram.pin_status_while_working`) in an in-memory Map
+ * (`statusPinState` keyed by pinKey → PinState, plus a companion chatId map).
+ * A gateway/container restart empties that Map. If a session pins the per-turn
+ * status / `🛠 Worker` message and then crashes BEFORE the unpin reconcile runs,
+ * the message stays pinned in Telegram but the next boot has no record of it —
+ * so it never unpins the orphan, and the service-message-deletion handler can't
+ * recognise the orphan's pin as "ours" either. Result: a stale status pin from
+ * a dead session lingers.
+ *
+ * This makes cleanup self-contained across restart: every pin claim persists
+ * here; on boot the gateway loads the persisted set and unpins each entry
+ * (a status pin from a PRIOR session is stale by definition — the turn it
+ * represented is over or crashed), then clears the store. It does NOT re-adopt
+ * or re-pin — it only cleans up.
+ *
+ * Shape choice — SNAPSHOT, not append-log, mirroring obligation-store.ts. The
+ * claim set is tiny and bounded (one entry per in-flight pinned key, normally
+ * 0–2). Rewriting the whole set on each change is trivially cheap and needs no
+ * compaction. Crash-safety is write-tmp + atomic rename: a crash leaves EITHER
+ * the prior complete snapshot OR the new one, never a torn file. PURE w.r.t.
+ * the injected fs seam ⇒ unit-testable.
+ */
+
+export interface StatusPinStoreFsSeam {
+  readFileSync: (path: string) => string
+  writeFileSync: (path: string, data: string) => void
+  /** Atomic same-dir replace (POSIX rename) so a crash mid-write can't tear
+   *  the snapshot. */
+  renameSync: (from: string, to: string) => void
+  existsSync: (path: string) => boolean
+}
+
+/** One persisted pin claim: the pinKey, the chat it lives in, and the pinned
+ *  message id (so boot cleanup can unpin exactly that message). */
+export interface PersistedStatusPin {
+  pinKey: string
+  chatId: string
+  messageId: number
+}
+
+interface SnapshotEnvelope {
+  v: 1
+  pins: PersistedStatusPin[]
+}
+
+function isPinRow(x: unknown): x is PersistedStatusPin {
+  if (x == null || typeof x !== 'object') return false
+  const o = x as Record<string, unknown>
+  return (
+    typeof o.pinKey === 'string' &&
+    o.pinKey.length > 0 &&
+    typeof o.chatId === 'string' &&
+    o.chatId.length > 0 &&
+    typeof o.messageId === 'number'
+  )
+}
+
+/**
+ * Load the persisted pin set. Returns [] on a missing, unreadable, or malformed
+ * file (fail-open to empty: a corrupt snapshot must never crash boot — worst
+ * case an orphaned pin isn't cleaned up this boot, strictly no worse than the
+ * pre-persistence behaviour).
+ */
+export function loadStatusPins(
+  path: string,
+  fs: StatusPinStoreFsSeam,
+): PersistedStatusPin[] {
+  if (!fs.existsSync(path)) return []
+  let raw = ''
+  try {
+    raw = fs.readFileSync(path)
+  } catch {
+    return []
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  if (parsed == null || typeof parsed !== 'object') return []
+  const env = parsed as Record<string, unknown>
+  if (env.v !== 1 || !Array.isArray(env.pins)) return []
+  return env.pins.filter(isPinRow)
+}
+
+/**
+ * Persist the pin set atomically (write sibling tmp → rename over the real
+ * path). Best-effort relative to fs availability: a write failure is logged but
+ * never thrown — a failing store degrades to in-memory-only (the pre-
+ * persistence behaviour), it must not break live pinning.
+ */
+export function persistStatusPins(
+  path: string,
+  fs: StatusPinStoreFsSeam,
+  snapshot: readonly PersistedStatusPin[],
+  log: (line: string) => void = (l) => process.stderr.write(l),
+): void {
+  const env: SnapshotEnvelope = { v: 1, pins: [...snapshot] }
+  const tmp = path + '.tmp'
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(env))
+    fs.renameSync(tmp, path)
+  } catch (err) {
+    log(
+      `status-pin-store: persist FAILED path=${path}: ${(err as Error).message} — ` +
+        `durability degraded to in-memory\n`,
+    )
+  }
+}

--- a/telegram-plugin/gateway/status-pin-store.ts
+++ b/telegram-plugin/gateway/status-pin-store.ts
@@ -112,3 +112,78 @@ export function persistStatusPins(
     )
   }
 }
+
+/**
+ * A single tracked live pin claim, as the gateway holds it in memory
+ * (statusPinState keyed by pinKey → PinState.messageId, plus the companion
+ * statusPinChatIds pinKey → chatId map). Flattened here so the ownership guard
+ * is a pure, unit-testable function decoupled from the gateway's Maps.
+ */
+export interface TrackedStatusPin {
+  chatId: string
+  messageId: number
+}
+
+/**
+ * CHAT-SCOPED ownership guard for a `pinned_message` service update.
+ *
+ * Telegram message_ids are per-chat small integers, and the gateway tracks
+ * many simultaneous pins across different chats/topics. Matching on messageId
+ * ALONE is a real bug: a pin update in chat B whose pinned id happens to equal
+ * a status-pin id tracked in chat A would pass, and the gateway would delete
+ * chat B's service message — including an operator's MANUAL pin notice. So the
+ * match REQUIRES both the messageId AND that the tracked entry lives in the
+ * SAME chat as the incoming update.
+ */
+export function pinnedMessageIsOurs(
+  tracked: Iterable<TrackedStatusPin>,
+  chatId: string,
+  pinnedMessageId: number,
+): boolean {
+  for (const t of tracked) {
+    if (t.messageId === pinnedMessageId && t.chatId === chatId) return true
+  }
+  return false
+}
+
+/**
+ * Boot-time orphan cleanup, extracted as a pure routine over injected seams so
+ * the ordering + best-effort contract is unit-testable against the REAL code
+ * (the gateway's thin wrapper just binds the live fs / unpin api / logger).
+ *
+ * Any pin persisted by a PRIOR session is stale by definition — its turn ended
+ * or the session crashed before its unpin reconcile ran. We best-effort unpin
+ * each persisted entry (a failure is non-fatal) and then EMPTY the store
+ * regardless, so a permanently-undeliverable unpin can't re-run on every boot.
+ * We do NOT re-adopt or re-pin. Returns the counts for logging/testing.
+ *
+ * CRITICAL: the caller MUST only invoke this AFTER winning the startup mutex.
+ * The store is a shared per-agent file; on a double-boot a losing gateway
+ * running this would unpin the still-alive holder's legitimate pins.
+ */
+export async function runStatusPinBootCleanup(args: {
+  path: string
+  fs: StatusPinStoreFsSeam
+  unpin: (chatId: string, messageId: number) => Promise<unknown>
+  log?: (line: string) => void
+}): Promise<{ cleared: number; total: number }> {
+  const log = args.log ?? ((l: string) => process.stderr.write(l))
+  const persisted = loadStatusPins(args.path, args.fs)
+  if (persisted.length === 0) return { cleared: 0, total: 0 }
+  let cleared = 0
+  for (const pin of persisted) {
+    try {
+      await args.unpin(pin.chatId, pin.messageId)
+      cleared++
+    } catch (err) {
+      log(
+        `status-pin-store: boot cleanup unpin failed ` +
+          `(chat=${pin.chatId} msg=${pin.messageId}): ${(err as Error).message}\n`,
+      )
+    }
+  }
+  // Empty the store regardless — these claims belong to a dead session; leaving
+  // them would re-attempt the same (already-tried) unpins on every future boot.
+  persistStatusPins(args.path, args.fs, [], log)
+  return { cleared, total: persisted.length }
+}

--- a/telegram-plugin/tests/status-pin-service-message-suppression.test.ts
+++ b/telegram-plugin/tests/status-pin-service-message-suppression.test.ts
@@ -15,6 +15,10 @@
 
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
+import {
+  pinnedMessageIsOurs,
+  type TrackedStatusPin,
+} from '../gateway/status-pin-store.js'
 
 const SRC = readFileSync(
   new URL('../gateway/gateway.ts', import.meta.url),
@@ -49,12 +53,18 @@ describe('status-pin service-message suppression', () => {
 
   const body = pinnedMessageHandler()
 
-  it('guards on ownership via statusPinState before deleting', () => {
+  it('guards on ownership via the chat-scoped pinnedMessageIsOurs helper', () => {
     // Must consult our tracked pins — never blindly delete a pin service
-    // message (which would nuke manual/operator pins too).
+    // message (which would nuke manual/operator pins too) — AND it must be
+    // chat-scoped (pinnedMessageIsOurs requires chatId + messageId), never a
+    // messageId-only match.
     expect(body).toContain('statusPinState')
     expect(body).toMatch(/pinned_message\?\.message_id/)
-    expect(body).toMatch(/\.messageId === pinnedId/)
+    expect(body).toContain('pinnedMessageIsOurs(')
+    // The chatId computed from the update must be fed to the guard.
+    expect(body).toMatch(/pinnedMessageIsOurs\(trackedPins\(\), chatId, pinnedId\)/)
+    // And the tracked entries must carry their chat association.
+    expect(body).toContain('statusPinChatIds.get(pinKey)')
   })
 
   it('bails out when the pinned message is not one of ours', () => {
@@ -75,5 +85,40 @@ describe('status-pin service-message suppression', () => {
     // The service update can arrive before reconcileStatusPin stores the
     // PinState; a single delayed re-check covers that window.
     expect(body).toContain('setTimeout')
+  })
+})
+
+/**
+ * BEHAVIORAL coverage of the ownership decision (BUG 1). The handler decides
+ * whether to delete a `pinned_message` service message by calling the real
+ * `pinnedMessageIsOurs(tracked, chatId, pinnedId)`. This models the exact
+ * gateway decision and asserts the delete fires ONLY for a same-chat match —
+ * the structural grep above would pass even with the messageId-only bug live.
+ */
+describe('service-message deletion decision (chat-scoped)', () => {
+  // Two tracked status pins in DIFFERENT chats. Chat A's pin id (715) collides
+  // with an incoming pin update in chat B.
+  const tracked: TrackedStatusPin[] = [
+    { chatId: '-100AAA', messageId: 715 },
+    { chatId: '-100BBB', messageId: 42 },
+  ]
+
+  // Mirror the handler: delete iff pinnedMessageIsOurs(...) is true.
+  const wouldDelete = (chatId: string, pinnedId: number) =>
+    pinnedMessageIsOurs(tracked, chatId, pinnedId)
+
+  it('does NOT delete chat B service message when its pin id collides with chat A', () => {
+    // Chat B, pinned id 715 → belongs to chat A, not B. Must NOT delete
+    // (this is the operator-manual-pin-notice safety case).
+    expect(wouldDelete('-100BBB', 715)).toBe(false)
+  })
+
+  it('DOES delete on a genuine same-chat match', () => {
+    expect(wouldDelete('-100AAA', 715)).toBe(true)
+    expect(wouldDelete('-100BBB', 42)).toBe(true)
+  })
+
+  it('does NOT delete a foreign pin id in a tracked chat', () => {
+    expect(wouldDelete('-100AAA', 9999)).toBe(false)
   })
 })

--- a/telegram-plugin/tests/status-pin-service-message-suppression.test.ts
+++ b/telegram-plugin/tests/status-pin-service-message-suppression.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Structural test for the `bot.on('message:pinned_message')` handler that
+ * suppresses the "pinned a message" service message Telegram inserts when
+ * OUR silent status-pin fires.
+ *
+ * Why structural: like every other gateway handler, this closure is wired
+ * inline against the live `bot` instance and is not exported — a functional
+ * invocation would require booting the full grammy runtime against a mocked
+ * Bot API. The gateway suite settled on file-level grep assertions for
+ * exactly this reason (see `inbound-message-types.test.ts`). The regression
+ * we care about: a future hand dropping the handler, dropping the ownership
+ * guard (which would let us delete manual/operator pins), or swapping the
+ * house deletion wrapper for a raw `bot.api.deleteMessage` (allowlist drift).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(
+  new URL('../gateway/gateway.ts', import.meta.url),
+  'utf8',
+)
+
+/**
+ * Extract the body of the `bot.on('message:pinned_message', …)` handler:
+ * from the `bot.on(` line to the matching outer-scope closing brace.
+ */
+function pinnedMessageHandler(): string {
+  const needle = `bot.on('message:pinned_message'`
+  const start = SRC.indexOf(needle)
+  expect(start, `handler ${needle} not found`).toBeGreaterThan(0)
+  const firstBrace = SRC.indexOf('{', start)
+  let depth = 0
+  for (let i = firstBrace; i < SRC.length; i++) {
+    const c = SRC[i]
+    if (c === '{') depth++
+    else if (c === '}') {
+      depth--
+      if (depth === 0) return SRC.slice(start, i + 1)
+    }
+  }
+  throw new Error('could not find end of pinned_message handler')
+}
+
+describe('status-pin service-message suppression', () => {
+  it("registers a bot.on('message:pinned_message') handler", () => {
+    expect(SRC).toContain(`bot.on('message:pinned_message'`)
+  })
+
+  const body = pinnedMessageHandler()
+
+  it('guards on ownership via statusPinState before deleting', () => {
+    // Must consult our tracked pins — never blindly delete a pin service
+    // message (which would nuke manual/operator pins too).
+    expect(body).toContain('statusPinState')
+    expect(body).toMatch(/pinned_message\?\.message_id/)
+    expect(body).toMatch(/\.messageId === pinnedId/)
+  })
+
+  it('bails out when the pinned message is not one of ours', () => {
+    // A `return` guard for the non-owned case must exist.
+    expect(body).toMatch(/if \(!isOurs\(\)\) return/)
+  })
+
+  it('deletes the service message through the robust wrapper (not a raw api call)', () => {
+    expect(body).toContain('robustApiCall(')
+    expect(body).toContain('deleteMessage')
+    // The message deleted is the service message itself, not the pinned msg.
+    expect(body).toContain('serviceMsgId')
+    // House verb tag so operators can trace it.
+    expect(body).toContain("verb: 'status-pin.delete-service-message'")
+  })
+
+  it('tolerates the reconcile-store race with a short retry', () => {
+    // The service update can arrive before reconcileStatusPin stores the
+    // PinState; a single delayed re-check covers that window.
+    expect(body).toContain('setTimeout')
+  })
+})

--- a/telegram-plugin/tests/status-pin-service-message-suppression.test.ts
+++ b/telegram-plugin/tests/status-pin-service-message-suppression.test.ts
@@ -122,3 +122,89 @@ describe('service-message deletion decision (chat-scoped)', () => {
     expect(wouldDelete('-100AAA', 9999)).toBe(false)
   })
 })
+
+/**
+ * SUPERGROUP / forum-topic coverage. The handler reads only ctx.chat.id +
+ * ctx.msg.message_id and deletes by (chat_id, message_id) — topic-agnostic,
+ * with no private-chat assumption. In a forum supergroup the pinned status
+ * message carries a message_thread_id, but:
+ *   - deletion needs no thread arg (chat_id + message_id is sufficient), and
+ *   - message_id is unique per chat even across topics, so a single chat-scoped
+ *     match is correct regardless of which topic the pin lives in.
+ * These tests model a pinned_message update whose chat is a supergroup (and a
+ * forum variant carrying message_thread_id) and assert the same chat-scoped
+ * decision holds.
+ */
+describe('service-message deletion in supergroups / forum topics', () => {
+  // A status pin tracked in a supergroup chat, plus a collision partner in a
+  // different supergroup.
+  const tracked: TrackedStatusPin[] = [
+    { chatId: '-1001111', messageId: 500 }, // supergroup A
+    { chatId: '-1002222', messageId: 500 }, // supergroup B, SAME id as A
+  ]
+
+  // Model the handler's identity extraction from a grammy-shaped update. The
+  // thread id is present on forum updates but deliberately NOT part of the
+  // ownership/delete identity.
+  type PinnedUpdate = {
+    chat: { id: number; type: 'private' | 'supergroup' }
+    message_id: number
+    message_thread_id?: number
+    pinned_message: { message_id: number }
+  }
+  const wouldDelete = (u: PinnedUpdate) =>
+    pinnedMessageIsOurs(tracked, String(u.chat.id), u.pinned_message.message_id)
+
+  it('deletes on a genuine same-chat match in a plain supergroup', () => {
+    const update: PinnedUpdate = {
+      chat: { id: -1001111, type: 'supergroup' },
+      message_id: 9001, // the service message
+      pinned_message: { message_id: 500 },
+    }
+    expect(wouldDelete(update)).toBe(true)
+  })
+
+  it('deletes on a same-chat match in a FORUM topic (message_thread_id set)', () => {
+    const update: PinnedUpdate = {
+      chat: { id: -1001111, type: 'supergroup' },
+      message_id: 9002,
+      message_thread_id: 77, // forum topic — irrelevant to the delete identity
+      pinned_message: { message_id: 500 },
+    }
+    expect(wouldDelete(update)).toBe(true)
+  })
+
+  it('does NOT delete when the id collides across two supergroups', () => {
+    // Supergroup B receives a pin update for id 500, which also happens to be
+    // supergroup A's tracked status-pin id. Chat-scoped guard keeps them apart.
+    const update: PinnedUpdate = {
+      chat: { id: -1002222, type: 'supergroup' },
+      message_id: 9003,
+      message_thread_id: 12,
+      pinned_message: { message_id: 500 },
+    }
+    // 500 IS tracked for chat -1002222 too in this fixture, so this is a
+    // genuine match — assert the positive, then flip to a true cross-chat miss.
+    expect(wouldDelete(update)).toBe(true)
+
+    // A supergroup NOT in the tracked set, colliding on id 500 → must NOT fire.
+    const foreign: PinnedUpdate = {
+      chat: { id: -1009999, type: 'supergroup' },
+      message_id: 9004,
+      message_thread_id: 5,
+      pinned_message: { message_id: 500 },
+    }
+    expect(wouldDelete(foreign)).toBe(false)
+  })
+
+  it('the handler logs a missing-admin-right hint on delete failure (supergroup)', () => {
+    // Structural: the catch block names the likely supergroup cause so an
+    // operator isn't left with silent nothing.
+    const src = readFileSync(
+      new URL('../gateway/gateway.ts', import.meta.url),
+      'utf8',
+    )
+    expect(src).toContain('could not delete pin service message')
+    expect(src).toContain('missing can_delete_messages')
+  })
+})

--- a/telegram-plugin/tests/status-pin-store.test.ts
+++ b/telegram-plugin/tests/status-pin-store.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import {
+  loadStatusPins,
+  persistStatusPins,
+  type PersistedStatusPin,
+  type StatusPinStoreFsSeam,
+} from "../gateway/status-pin-store.js";
+
+/** In-memory fs seam with an atomic rename, so the store's tmp→rename
+ *  crash-safety contract is exercised without touching the real disk. */
+function memFs(seed: Record<string, string> = {}) {
+  const files = new Map<string, string>(Object.entries(seed));
+  const calls: string[] = [];
+  const fs: StatusPinStoreFsSeam = {
+    readFileSync: (p) => {
+      if (!files.has(p)) throw new Error(`ENOENT ${p}`);
+      return files.get(p)!;
+    },
+    writeFileSync: (p, d) => {
+      calls.push(`write:${p}`);
+      files.set(p, d);
+    },
+    renameSync: (a, b) => {
+      calls.push(`rename:${a}->${b}`);
+      if (!files.has(a)) throw new Error(`ENOENT ${a}`);
+      files.set(b, files.get(a)!);
+      files.delete(a);
+    },
+    existsSync: (p) => files.has(p),
+  };
+  return { fs, files, calls };
+}
+
+const PATH = "/state/agent/telegram/status-pins.json";
+
+function pin(over: Partial<PersistedStatusPin> = {}): PersistedStatusPin {
+  return { pinKey: "fg:c:3", chatId: "-100123", messageId: 715, ...over };
+}
+
+describe("status-pin-store", () => {
+  it("round-trips the pin claim set", () => {
+    const { fs } = memFs();
+    const snap: PersistedStatusPin[] = [
+      pin({ pinKey: "fg:c:3", messageId: 715 }),
+      pin({ pinKey: "wk:agent-x", chatId: "-100999", messageId: 42 }),
+    ];
+    persistStatusPins(PATH, fs, snap);
+    expect(loadStatusPins(PATH, fs)).toEqual(snap);
+  });
+
+  it("writes via tmp + atomic rename (crash-safe)", () => {
+    const { fs, calls } = memFs();
+    persistStatusPins(PATH, fs, [pin()]);
+    expect(calls).toEqual([`write:${PATH}.tmp`, `rename:${PATH}.tmp->${PATH}`]);
+  });
+
+  it("persist-on-pin: a new claim is reflected on disk", () => {
+    const { fs } = memFs();
+    // Simulate reconcile writing state, then snapshotting.
+    persistStatusPins(PATH, fs, [pin({ pinKey: "fg:c:3", messageId: 715 })]);
+    const loaded = loadStatusPins(PATH, fs);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].messageId).toBe(715);
+  });
+
+  it("remove-on-unpin: unpinning empties the persisted set", () => {
+    const { fs } = memFs();
+    persistStatusPins(PATH, fs, [pin()]);
+    expect(loadStatusPins(PATH, fs)).toHaveLength(1);
+    // Reconcile deleted the key → snapshot of the now-empty Map.
+    persistStatusPins(PATH, fs, []);
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+
+  it("loads [] when no file exists (fresh boot)", () => {
+    const { fs } = memFs();
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+
+  it("fail-open: corrupt JSON loads as [] (never crashes boot)", () => {
+    const { fs } = memFs({ [PATH]: "{not json" });
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+
+  it("fail-open: wrong envelope version / shape loads as []", () => {
+    const { fs: f1 } = memFs({ [PATH]: JSON.stringify({ v: 2, pins: [pin()] }) });
+    expect(loadStatusPins(PATH, f1)).toEqual([]);
+    const { fs: f2 } = memFs({ [PATH]: JSON.stringify({ v: 1, pins: "nope" }) });
+    expect(loadStatusPins(PATH, f2)).toEqual([]);
+  });
+
+  it("drops malformed rows but keeps valid ones", () => {
+    const { fs } = memFs({
+      [PATH]: JSON.stringify({
+        v: 1,
+        pins: [
+          pin({ messageId: 715 }),
+          { pinKey: "", chatId: "c", messageId: 1 }, // empty pinKey → dropped
+          { pinKey: "k", chatId: "", messageId: 1 }, // empty chatId → dropped
+          { pinKey: "k", chatId: "c" }, // missing messageId → dropped
+        ],
+      }),
+    });
+    const loaded = loadStatusPins(PATH, fs);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].messageId).toBe(715);
+  });
+
+  it("persist never throws on a failing fs (durability degrades, live path unaffected)", () => {
+    const throwingFs: StatusPinStoreFsSeam = {
+      readFileSync: () => {
+        throw new Error("boom");
+      },
+      writeFileSync: () => {
+        throw new Error("disk full");
+      },
+      renameSync: () => {
+        throw new Error("nope");
+      },
+      existsSync: () => false,
+    };
+    const logs: string[] = [];
+    expect(() =>
+      persistStatusPins(PATH, throwingFs, [pin()], (l) => logs.push(l)),
+    ).not.toThrow();
+    expect(logs.join("")).toContain("persist FAILED");
+  });
+});
+
+/**
+ * Boot-orphan cleanup contract (modelled against the store, since the gateway's
+ * `statusPinBootCleanup` isn't exported — the gateway is a 25k-line module with
+ * import-time side effects). It: (1) loads the persisted set, (2) unpins each
+ * entry best-effort, (3) empties the store. This reproduces that flow over the
+ * store's public surface + a fake unpin so the observable contract is pinned.
+ */
+describe("status-pin boot orphan cleanup", () => {
+  it("unpins every persisted entry and empties the store", async () => {
+    const { fs } = memFs();
+    const orphans: PersistedStatusPin[] = [
+      pin({ pinKey: "fg:c:3", chatId: "-100123", messageId: 715 }),
+      pin({ pinKey: "wk:agent-x", chatId: "-100999", messageId: 42 }),
+    ];
+    persistStatusPins(PATH, fs, orphans);
+
+    const unpinned: Array<[string, number]> = [];
+    const fakeUnpin = async (chatId: string, messageId: number) => {
+      unpinned.push([chatId, messageId]);
+    };
+
+    // Reproduce statusPinBootCleanup's body:
+    const persisted = loadStatusPins(PATH, fs);
+    for (const p of persisted) await fakeUnpin(p.chatId, p.messageId);
+    persistStatusPins(PATH, fs, []);
+
+    expect(unpinned).toEqual([
+      ["-100123", 715],
+      ["-100999", 42],
+    ]);
+    // Store is empty afterwards → no re-attempt on the next boot, and the
+    // service-message handler's ownership Map sees no false positives.
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+
+  it("a failing unpin is non-fatal and the store is still emptied", async () => {
+    const { fs } = memFs();
+    persistStatusPins(PATH, fs, [pin()]);
+
+    const fakeUnpin = async () => {
+      throw new Error("chat gone");
+    };
+
+    const persisted = loadStatusPins(PATH, fs);
+    let threw = false;
+    for (const p of persisted) {
+      try {
+        await fakeUnpin();
+        void p;
+      } catch {
+        /* non-fatal, as in the gateway */
+      }
+    }
+    // Store emptied regardless of unpin outcome.
+    persistStatusPins(PATH, fs, []);
+
+    expect(threw).toBe(false);
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+
+  it("no-op on a fresh boot with no persisted pins", () => {
+    const { fs } = memFs();
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+});

--- a/telegram-plugin/tests/status-pin-store.test.ts
+++ b/telegram-plugin/tests/status-pin-store.test.ts
@@ -2,8 +2,11 @@ import { describe, it, expect } from "vitest";
 import {
   loadStatusPins,
   persistStatusPins,
+  pinnedMessageIsOurs,
+  runStatusPinBootCleanup,
   type PersistedStatusPin,
   type StatusPinStoreFsSeam,
+  type TrackedStatusPin,
 } from "../gateway/status-pin-store.js";
 
 /** In-memory fs seam with an atomic rename, so the store's tmp→rename
@@ -128,13 +131,45 @@ describe("status-pin-store", () => {
 });
 
 /**
- * Boot-orphan cleanup contract (modelled against the store, since the gateway's
- * `statusPinBootCleanup` isn't exported — the gateway is a 25k-line module with
- * import-time side effects). It: (1) loads the persisted set, (2) unpins each
- * entry best-effort, (3) empties the store. This reproduces that flow over the
- * store's public surface + a fake unpin so the observable contract is pinned.
+ * Chat-scoped ownership guard (BUG 1). message_ids are per-chat small integers
+ * and the gateway tracks many pins across chats/topics simultaneously — the
+ * guard MUST match on messageId AND chatId, never messageId alone.
  */
-describe("status-pin boot orphan cleanup", () => {
+describe("pinnedMessageIsOurs — chat-scoped guard", () => {
+  const tracked: TrackedStatusPin[] = [
+    { chatId: "-100AAA", messageId: 715 }, // chat A
+    { chatId: "-100BBB", messageId: 42 }, // chat B, different id
+  ];
+
+  it("matches a genuine same-chat + same-id pin", () => {
+    expect(pinnedMessageIsOurs(tracked, "-100AAA", 715)).toBe(true);
+    expect(pinnedMessageIsOurs(tracked, "-100BBB", 42)).toBe(true);
+  });
+
+  it("does NOT match when the id collides but the chat differs (the bug)", () => {
+    // Chat B receives a pinned_message update whose id (715) collides with
+    // chat A's tracked status pin. A messageId-only guard would wrongly return
+    // true and delete chat B's (possibly operator-manual) service message.
+    expect(pinnedMessageIsOurs(tracked, "-100BBB", 715)).toBe(false);
+    // Symmetric: chat A with chat B's id.
+    expect(pinnedMessageIsOurs(tracked, "-100AAA", 42)).toBe(false);
+  });
+
+  it("does NOT match an untracked id in a tracked chat", () => {
+    expect(pinnedMessageIsOurs(tracked, "-100AAA", 999)).toBe(false);
+  });
+
+  it("does NOT match against an empty tracked set", () => {
+    expect(pinnedMessageIsOurs([], "-100AAA", 715)).toBe(false);
+  });
+});
+
+/**
+ * Boot-orphan cleanup — calls the REAL `runStatusPinBootCleanup` (extracted
+ * pure over injected fs + unpin seams) so ordering / contract regressions are
+ * caught here, not just structurally.
+ */
+describe("runStatusPinBootCleanup", () => {
   it("unpins every persisted entry and empties the store", async () => {
     const { fs } = memFs();
     const orphans: PersistedStatusPin[] = [
@@ -144,51 +179,57 @@ describe("status-pin boot orphan cleanup", () => {
     persistStatusPins(PATH, fs, orphans);
 
     const unpinned: Array<[string, number]> = [];
-    const fakeUnpin = async (chatId: string, messageId: number) => {
-      unpinned.push([chatId, messageId]);
-    };
-
-    // Reproduce statusPinBootCleanup's body:
-    const persisted = loadStatusPins(PATH, fs);
-    for (const p of persisted) await fakeUnpin(p.chatId, p.messageId);
-    persistStatusPins(PATH, fs, []);
+    const res = await runStatusPinBootCleanup({
+      path: PATH,
+      fs,
+      unpin: async (chatId, messageId) => {
+        unpinned.push([chatId, messageId]);
+      },
+      log: () => {},
+    });
 
     expect(unpinned).toEqual([
       ["-100123", 715],
       ["-100999", 42],
     ]);
-    // Store is empty afterwards → no re-attempt on the next boot, and the
-    // service-message handler's ownership Map sees no false positives.
+    expect(res).toEqual({ cleared: 2, total: 2 });
+    // Store empty afterwards → no re-attempt next boot.
     expect(loadStatusPins(PATH, fs)).toEqual([]);
   });
 
   it("a failing unpin is non-fatal and the store is still emptied", async () => {
     const { fs } = memFs();
-    persistStatusPins(PATH, fs, [pin()]);
+    persistStatusPins(PATH, fs, [
+      pin({ pinKey: "fg:c:1", chatId: "-100123", messageId: 5 }),
+      pin({ pinKey: "fg:c:2", chatId: "-100123", messageId: 6 }),
+    ]);
 
-    const fakeUnpin = async () => {
-      throw new Error("chat gone");
-    };
+    const res = await runStatusPinBootCleanup({
+      path: PATH,
+      fs,
+      unpin: async (_c, messageId) => {
+        if (messageId === 5) throw new Error("chat gone");
+      },
+      log: () => {},
+    });
 
-    const persisted = loadStatusPins(PATH, fs);
-    let threw = false;
-    for (const p of persisted) {
-      try {
-        await fakeUnpin();
-        void p;
-      } catch {
-        /* non-fatal, as in the gateway */
-      }
-    }
-    // Store emptied regardless of unpin outcome.
-    persistStatusPins(PATH, fs, []);
-
-    expect(threw).toBe(false);
+    // One failed, one succeeded — still non-fatal, store still emptied.
+    expect(res).toEqual({ cleared: 1, total: 2 });
     expect(loadStatusPins(PATH, fs)).toEqual([]);
   });
 
-  it("no-op on a fresh boot with no persisted pins", () => {
+  it("no-op on a fresh boot with no persisted pins (no unpin calls)", async () => {
     const { fs } = memFs();
-    expect(loadStatusPins(PATH, fs)).toEqual([]);
+    let calls = 0;
+    const res = await runStatusPinBootCleanup({
+      path: PATH,
+      fs,
+      unpin: async () => {
+        calls++;
+      },
+      log: () => {},
+    });
+    expect(res).toEqual({ cleared: 0, total: 0 });
+    expect(calls).toBe(0);
   });
 });

--- a/telegram-plugin/tests/voice-ondemand.test.ts
+++ b/telegram-plugin/tests/voice-ondemand.test.ts
@@ -154,3 +154,49 @@ describe('on-demand: reply-time behaviour (gate + no synthesis)', () => {
     expect(mayInjectListenButton(undefined)).toBe(true)
   })
 })
+
+describe('on-demand: single-use — strip the Listen keyboard on success only', () => {
+  // Reproduce the callback handler's control flow. Each terminal branch in the
+  // gateway either returns EARLY (leaving the button intact so the user can
+  // retry) or falls through to the successful sendVoice + keyboard strip.
+  //
+  //   expired cache entry           → answerCallbackQuery + return (no strip)
+  //   sidecar unavailable           → answerCallbackQuery + return (no strip)
+  //   synth failure (!result.ok)    → answerCallbackQuery + return (no strip)
+  //   sendVoice success             → strip keyboard
+  //
+  // We model that as a pure decision so the observable contract — strip iff the
+  // audio was actually delivered — is pinned without importing the gateway.
+  type Outcome = 'expired' | 'sidecar-unavailable' | 'synth-failed' | 'sent'
+  const shouldStripListenKeyboard = (outcome: Outcome, cbMessageId: number | undefined): boolean =>
+    outcome === 'sent' && cbMessageId != null
+
+  it('strips the keyboard after a successful sendVoice', () => {
+    expect(shouldStripListenKeyboard('sent', 42)).toBe(true)
+  })
+
+  it('does NOT strip when the cache entry expired (user can retry)', () => {
+    expect(shouldStripListenKeyboard('expired', 42)).toBe(false)
+  })
+
+  it('does NOT strip when the voice sidecar is unavailable (user can retry)', () => {
+    expect(shouldStripListenKeyboard('sidecar-unavailable', 42)).toBe(false)
+  })
+
+  it('does NOT strip when synthesis failed (user can retry)', () => {
+    expect(shouldStripListenKeyboard('synth-failed', 42)).toBe(false)
+  })
+
+  it('cannot strip without a callback message id even on success', () => {
+    // The gateway guards the strip on `cbMessageId != null` (no message → no
+    // keyboard to edit).
+    expect(shouldStripListenKeyboard('sent', undefined)).toBe(false)
+  })
+
+  it('strips by clearing the inline keyboard (empty rows)', () => {
+    // The strip payload the handler sends: reply_markup with an empty
+    // inline_keyboard — the same shape the agent-button single_use strip uses.
+    const stripMarkup = { reply_markup: { inline_keyboard: [] as unknown[][] } }
+    expect(stripMarkup.reply_markup.inline_keyboard).toHaveLength(0)
+  })
+})

--- a/telegram-plugin/voice-ondemand.ts
+++ b/telegram-plugin/voice-ondemand.ts
@@ -103,9 +103,10 @@ export function parseVoiceOnDemandToken(data: string): string | null {
   return token.length > 0 ? token : null
 }
 
-/** Build the single-row Listen keyboard for a token. single_use is N/A —
- *  the gate guarantees this is the only button, so the keyboard is never
- *  stripped and the button stays replayable. */
+/** Build the single-row Listen keyboard for a token. Effectively single-use:
+ *  the callback handler strips this keyboard after a SUCCESSFUL synth+send, so
+ *  a delivered voice note can't be re-tapped. On expiry / synth-failure /
+ *  sidecar-unavailable the button is left intact so the user can retry. */
 export function buildListenKeyboard(token: string): {
   inline_keyboard: Array<Array<{ text: string; callback_data: string }>>
 } {
@@ -121,10 +122,13 @@ export function buildListenKeyboard(token: string): {
  * carries no agent-authored buttons.
  *
  * Why: the callback dispatcher's single_use strip (keyboardIsSingleUse)
- * governs the WHOLE message's keyboard. A Listen button is single_use:false
- * (replayable); adding it alongside agent buttons would turn the message into
- * a mixed keyboard and defeat the agent's double-fire protection. So if the
- * agent supplied any button, we skip the Listen button for this message.
+ * governs the WHOLE message's keyboard, keyed off the agent-button metadata.
+ * The Listen button strips its own keyboard independently (on successful
+ * send, in the voice-on-demand callback handler) and carries no agent-button
+ * meta; mixing it alongside agent buttons would put two independent strip
+ * regimes on one message and could defeat the agent's double-fire protection.
+ * So if the agent supplied any button, we skip the Listen button for this
+ * message.
  */
 export function mayInjectListenButton(
   rawKeyboard: unknown[][] | undefined | null,


### PR DESCRIPTION
## Problem

The silent status-pin feature (`channels.telegram.pin_status_while_working`, default ON, added in #2723) pins the per-turn status message while work is in-flight. The pin call in `status-pin-driver.ts` already passes `disable_notification: true`.

That flag suppresses the **push notification** but **not** the in-chat **"pinned a message" service message** that Telegram inserts on every pin. So the "silent" pin was not actually silent in-chat — it littered each topic with a `... pinned a message` service line on every turn.

`allowed_updates` already includes `'message'`, so the pin service update (a `message` update carrying a `pinned_message` field) reaches the bot — but there was no handler for it.

## Fix

Add a `bot.on('message:pinned_message')` handler next to the other `message:*` handlers in `gateway.ts`. It deletes the service message **only when the pinned message is one of our tracked status pins** — looked up in the `statusPinState` map by `.messageId`.

- **Ownership guard:** manual/operator pins are never silent and are never touched. Only status pins are silent, so the ownership check is the sole guard.
- **House deletion wrapper:** deletion goes through `robustApiCall(() => lockedBot.api.deleteMessage(...))` with verb `status-pin.delete-service-message`, matching `executeDeleteMessage`'s style — so the `check-bot-api-wrapping.sh` allowlist stays clean (no raw `bot.api.*` callsite added).
- **Race tolerance:** the service update can arrive before `reconcileStatusPin` stores the new `PinState` (pin API resolves → Telegram emits service message → reconcile writes the Map). A single short delayed re-check covers that window; if still not ours, the service message is left alone.

The pin driver is intentionally **not** touched.

## Tests

- New structural test `telegram-plugin/tests/status-pin-service-message-suppression.test.ts` mirroring the gateway suite's grep-assertion convention (handlers are wired inline against the live `bot`, not exported — see `inbound-message-types.test.ts`): asserts registration, the ownership guard, the robust-wrapper deletion, the correct verb tag, and the race retry.
- `tsc --noEmit` clean; `check-bot-api-wrapping.sh` clean; full `telegram-plugin/tests/` vitest suite green (the one flaky 20k-iteration property-sweep timeout is parallelism resource contention — passes in isolation in 1.2s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)