### PR TITLE
fix(hermes): per-session pending prompt-key + history.db poller-read regression

### DIFF
--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -384,14 +384,12 @@ function startHistoryPoll(
 
         for (const row of rows) {
           cursor = row.rowid;
-          // If there's a pending prompt.submit, use that prompt_key so Hermes
-          // resolves the spinner. Otherwise synthesise a new start+complete pair
-          // (Telegram-originated reply the user didn't trigger from Hermes).
-          const promptKey = ctx.pendingPromptKey ?? `tg-${row.rowid}`;
-          if (!ctx.pendingPromptKey) {
+          // Claim the pending prompt.submit key FOR THIS SESSION if present, else
+          // synthesise a fresh start+complete pair for a Telegram-originated reply.
+          const { promptKey, needsStart } = claimPromptKey(ctx, sessionId, row.rowid);
+          if (needsStart) {
             sendEvent(ctx, "message.start", sessionId, { prompt_key: promptKey });
           }
-          ctx.pendingPromptKey = undefined;
           sendEvent(ctx, "message.complete", sessionId, {
             text: row.text,
             prompt_key: promptKey,
@@ -797,11 +795,45 @@ export interface HermesWsContext {
   /** Stop function for the history.db background poller — called on session change or close. */
   stopHistoryPoll?: () => void;
   /**
-   * prompt_key from the most recent prompt.submit that hasn't yet been resolved by
-   * a message.complete. The history poller claims this key for the first new assistant
-   * message so the response resolves the correct pending spinner in Hermes.
+   * Pending prompt_keys, keyed by session_id. Each entry is the prompt_key from
+   * the most recent prompt.submit for that session that hasn't yet been resolved
+   * by a message.complete. The per-session history poller claims only its own
+   * session's key for the first new assistant message, so a submit to a
+   * non-activated session — or two rapid submits to different sessions — can't
+   * cross-claim each other's spinner in Hermes. Lazily initialised.
    */
-  pendingPromptKey?: string;
+  pendingPromptKeys?: Map<string, string>;
+}
+
+/** Get-or-create the per-session pending-prompt-key map on a WS context. */
+export function pendingPromptKeys(ctx: HermesWsContext): Map<string, string> {
+  return (ctx.pendingPromptKeys ??= new Map<string, string>());
+}
+
+/**
+ * Resolve the prompt_key for a freshly-observed assistant reply on `sessionId`.
+ * If that session has a pending prompt.submit, claim (and consume) its key so
+ * Hermes resolves the correct spinner; the caller must NOT emit a message.start
+ * in that case (Hermes already showed one at submit time). Otherwise synthesise
+ * a fresh `tg-<rowid>` key for a Telegram-originated reply and signal that a
+ * message.start is needed.
+ *
+ * Keying by sessionId is the isolation guarantee: a pending submit on session B
+ * never gets claimed by session A's reply, and two rapid submits to different
+ * sessions can't cross-claim. Exported for unit testing.
+ */
+export function claimPromptKey(
+  ctx: HermesWsContext,
+  sessionId: string,
+  rowid: number,
+): { promptKey: string; needsStart: boolean } {
+  const keys = pendingPromptKeys(ctx);
+  const pending = keys.get(sessionId);
+  if (pending !== undefined) {
+    keys.delete(sessionId);
+    return { promptKey: pending, needsStart: false };
+  }
+  return { promptKey: `tg-${rowid}`, needsStart: true };
 }
 
 function sendEvent(ctx: HermesWsContext, type: string, sessionId: string | null, payload: unknown) {
@@ -1013,11 +1045,12 @@ export async function onHermesMessage(ctx: HermesWsContext, raw: string) {
 
       sendEvent(ctx, "message.start", sessionId, { prompt_key: promptKey });
       // Record so the history poller uses this key when the agent's reply lands.
-      ctx.pendingPromptKey = promptKey;
+      // Keyed by sessionId so a submit to another session can't cross-claim it.
+      pendingPromptKeys(ctx).set(sessionId, promptKey);
 
       const result = await injectInbound(agentsDir, submitAgent, chat.chatId, chat.threadId, content, promptKey);
       if (!result.ok) {
-        ctx.pendingPromptKey = undefined;
+        pendingPromptKeys(ctx).delete(sessionId);
         sendEvent(ctx, "error", sessionId, { message: result.error, prompt_key: promptKey });
         sendResponse(ctx, rpcErr(id, -32603, result.error ?? "inject failed"));
         break;

--- a/telegram-plugin/tests/history.test.ts
+++ b/telegram-plugin/tests/history.test.ts
@@ -44,6 +44,39 @@ describe('initHistory', () => {
     initHistory(stateDir, 30)
     expect(() => initHistory(stateDir, 30)).not.toThrow()
   })
+
+  // Regression for HERMES #2689 review defect #1: the web process (a different
+  // uid than the agent) opens history.db READ-ONLY to stream Telegram replies
+  // back to Hermes Desktop. If the db/WAL sidecars were left 0600, that open
+  // fails and the real-time sync poller silently no-ops. Assert both the perm
+  // bits AND that a readonly open + the poller's exact SELECT succeed.
+  it('history.db is world-readable and the Hermes poller can open it read-only', async () => {
+    initHistory(stateDir, 30)
+    recordInbound({ chat_id: '1', thread_id: null, message_id: 1, user: 'a', user_id: '1', ts: 100, text: 'hi' })
+    recordOutbound({ chat_id: '1', thread_id: null, message_ids: [2], texts: ['hello'], ts: 200 })
+
+    const dbPath = join(stateDir, 'history.db')
+    // Force a WAL sidecar to exist so we exercise the -wal/-shm perm path too.
+    for (const suffix of ['', '-shm', '-wal']) {
+      const f = dbPath + suffix
+      if (existsSync(f)) expect(statSync(f).mode & 0o777).toBe(0o644)
+    }
+
+    // Reproduce the poller's open (src/web/hermes-adapter.ts startHistoryPoll):
+    // readonly connection + MAX(rowid) + assistant-row SELECT.
+    const { Database } = await import('bun:sqlite')
+    const rdb = new Database(dbPath, { readonly: true })
+    try {
+      const max = rdb.prepare('SELECT MAX(rowid) AS r FROM messages').get() as { r: number | null }
+      expect(max.r).toBeGreaterThan(0)
+      const rows = rdb
+        .prepare("SELECT rowid, role, text FROM messages WHERE rowid > ? AND role = 'assistant' ORDER BY rowid ASC")
+        .all(0) as Array<{ role: string; text: string }>
+      expect(rows.some((r) => r.text === 'hello')).toBe(true)
+    } finally {
+      rdb.close()
+    }
+  })
 })
 
 describe('recordInbound + query', () => {

--- a/tests/web/hermes-pending-key-isolation.test.ts
+++ b/tests/web/hermes-pending-key-isolation.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  claimPromptKey,
+  pendingPromptKeys,
+  type HermesWsContext,
+} from "../../src/web/hermes-adapter.js";
+
+/**
+ * Regression coverage for the per-session pending-prompt-key isolation fix
+ * (HERMES #2689 review defect #2). Before the fix, `pendingPromptKey` was a
+ * single scalar on the WS context, so a prompt.submit to session B could be
+ * cross-claimed by session A's incoming reply, and two rapid submits could
+ * clobber each other. Keying by session_id removes both hazards.
+ */
+
+function makeCtx(): HermesWsContext {
+  return {
+    // config is unused by the functions under test.
+    config: {} as HermesWsContext["config"],
+    send: () => {},
+  };
+}
+
+describe("claimPromptKey — per-session isolation", () => {
+  it("claims and consumes only the matching session's pending key", () => {
+    const ctx = makeCtx();
+    pendingPromptKeys(ctx).set("agentA", "keyA");
+
+    const res = claimPromptKey(ctx, "agentA", 1);
+    expect(res).toEqual({ promptKey: "keyA", needsStart: false });
+    // Consumed — a second reply on the same session synthesises a fresh key.
+    expect(pendingPromptKeys(ctx).has("agentA")).toBe(false);
+    const res2 = claimPromptKey(ctx, "agentA", 2);
+    expect(res2).toEqual({ promptKey: "tg-2", needsStart: true });
+  });
+
+  it("does NOT cross-claim: a reply on session A leaves session B's key intact", () => {
+    const ctx = makeCtx();
+    pendingPromptKeys(ctx).set("agentB", "keyB");
+
+    // A reply arrives on agentA, which has no pending submit.
+    const resA = claimPromptKey(ctx, "agentA", 10);
+    expect(resA).toEqual({ promptKey: "tg-10", needsStart: true });
+    // agentB's pending key must be untouched.
+    expect(pendingPromptKeys(ctx).get("agentB")).toBe("keyB");
+
+    // agentB's own reply then correctly claims it.
+    const resB = claimPromptKey(ctx, "agentB", 11);
+    expect(resB).toEqual({ promptKey: "keyB", needsStart: false });
+  });
+
+  it("two rapid submits to different sessions each keep their own key", () => {
+    const ctx = makeCtx();
+    const keys = pendingPromptKeys(ctx);
+    keys.set("agentA", "keyA");
+    keys.set("agentB", "keyB");
+
+    // Replies land interleaved; each resolves its own spinner.
+    expect(claimPromptKey(ctx, "agentB", 1).promptKey).toBe("keyB");
+    expect(claimPromptKey(ctx, "agentA", 2).promptKey).toBe("keyA");
+    expect(keys.size).toBe(0);
+  });
+
+  it("a second rapid submit to the SAME session overwrites the pending key (last-writer wins, no stale claim)", () => {
+    const ctx = makeCtx();
+    const keys = pendingPromptKeys(ctx);
+    keys.set("agentA", "first");
+    keys.set("agentA", "second"); // simulate a rapid re-submit before a reply
+
+    const res = claimPromptKey(ctx, "agentA", 1);
+    expect(res.promptKey).toBe("second");
+    expect(keys.has("agentA")).toBe(false);
+  });
+
+  it("pendingPromptKeys lazily initialises and is stable across calls", () => {
+    const ctx = makeCtx();
+    expect(ctx.pendingPromptKeys).toBeUndefined();
+    const m1 = pendingPromptKeys(ctx);
+    const m2 = pendingPromptKeys(ctx);
+    expect(m1).toBe(m2);
+    expect(ctx.pendingPromptKeys).toBe(m1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the HERMES `#2689` adapter defects found in review.

### Defect #2 (SHOULD-FIX) — pending prompt-key cross-claim
`pendingPromptKey` was a single scalar on the per-WS-connection Hermes context (`src/web/hermes-adapter.ts`), but the real-time sync poller (`startHistoryPoll`) runs **per session**, started at `session.activate`. A `prompt.submit` to a non-activated session — or two rapid submits to different sessions — could cross-claim each other's `message.complete` spinner in Hermes Desktop.

**Fix:** key pending prompt-keys by `session_id` via a `Map<string,string>` (`pendingPromptKeys`), and extract the claim logic into an exported `claimPromptKey()`. A reply observed on session A now only ever claims session A's pending submit; session B's key is left intact. `prompt.submit` sets/clears its own session's entry.

### Defect #1 (BLOCKING) — history.db perms
Verified the `0o644` widening for `history.db` (+ `-wal`/`-shm` sidecars) **already landed in `#2689` itself** (`telegram-plugin/history.ts`), mirroring the `registry.db` `#2668` precedent. Without it the web process (a different uid than the agent) can't open the db read-only and the poller silently no-ops. This PR adds an explicit **regression test** that reproduces the poller's exact readonly open + assistant-row SELECT and asserts the perm bits on `db`/`-wal`/`-shm`.

## Tests
- `tests/web/hermes-pending-key-isolation.test.ts` (vitest) — per-session isolation, no cross-claim, interleaved replies, same-session last-writer-wins, lazy-init stability. **5 pass.**
- `telegram-plugin/tests/history.test.ts` (bun) — added poller readonly-open + world-readable regression. **45 pass.**
- `tsc --noEmit` clean.

## Serves
Job: Hermes Desktop as an always-on second surface for the fleet (real-time Telegram↔Hermes response sync, `#2689`). No invariant crossed — read-only, no model call, no self-escalation.

## Risk
Low. Behaviour-preserving refactor of an internal claim path; the scalar→map change is confined to `hermes-adapter.ts` and its two mutation sites. No public RPC shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)