### PR TITLE
fix(voice): watchdog for wedged GPU calls + sidecar-token tests

### DIFF
--- a/docker/voice-sidecar/server.py
+++ b/docker/voice-sidecar/server.py
@@ -120,6 +120,66 @@ TTS_MAX_CHARS = int(os.environ.get("VOICE_TTS_MAX_CHARS", "1200"))
 TTS_MAX_BODY_BYTES = int(os.environ.get("VOICE_TTS_MAX_BODY_BYTES", str(256 * 1024)))
 TTS_SAMPLE_RATE = 24000  # Kokoro always emits 24kHz mono float PCM.
 
+# ── wedge watchdog (recover from a hung native GPU call) ────────────────
+# A per-request FutureTimeout ABANDONS the future but the worker thread keeps
+# running the native call — and keeps holding _gpu_sem / _tts_sem. With
+# CONCURRENCY=1 a single hung native call permanently holds the only permit,
+# so every later request 503s ("timeout") forever while /healthz still says
+# "ready" — a silent wedge. Python can't cancel the native call, so the only
+# real recovery is to restart the process and let Docker (`restart: always`)
+# bring it back with a fresh GPU context.
+#
+# Mechanism: count CONSECUTIVE per-request timeouts across BOTH lanes. Any
+# successful inference/synthesis resets the count (a lane that still completes
+# work is not wedged). Once the count reaches VOICE_WATCHDOG_MAX_TIMEOUTS we
+# flip a sticky "wedged" flag; /healthz then returns 503, the compose
+# healthcheck goes unhealthy, and Docker restarts the container. We flip
+# /healthz (rather than os._exit immediately) so an in-flight, still-healthy
+# request isn't torn down mid-response — the restart happens on the next
+# healthcheck interval, which is the gentlest correct lever.
+VOICE_WATCHDOG_MAX_TIMEOUTS = max(
+    1, int(os.environ.get("VOICE_WATCHDOG_MAX_TIMEOUTS", "3"))
+)
+_watchdog_lock = threading.Lock()
+_consecutive_timeouts = 0
+_wedged = False
+
+
+def _note_timeout() -> None:
+    """Record a per-request GPU timeout. After VOICE_WATCHDOG_MAX_TIMEOUTS
+    consecutive timeouts (across both lanes) flip the sticky wedged flag so
+    /healthz reports unhealthy and Docker restarts us."""
+    global _consecutive_timeouts, _wedged
+    with _watchdog_lock:
+        _consecutive_timeouts += 1
+        _log(
+            f"watchdog: timeout #{_consecutive_timeouts} "
+            f"(threshold={VOICE_WATCHDOG_MAX_TIMEOUTS})"
+        )
+        if _consecutive_timeouts >= VOICE_WATCHDOG_MAX_TIMEOUTS and not _wedged:
+            _wedged = True
+            _log(
+                "watchdog: WEDGED — a GPU call likely holds a permit that will "
+                "never be released; flipping /healthz to unhealthy so Docker "
+                "restarts the container"
+            )
+
+
+def _note_success() -> None:
+    """Record a completed inference/synthesis — resets the consecutive-timeout
+    counter (a lane that still finishes work is not wedged). Does NOT clear a
+    sticky wedge: once we've decided to restart, we let the restart happen."""
+    global _consecutive_timeouts
+    with _watchdog_lock:
+        if _consecutive_timeouts:
+            _consecutive_timeouts = 0
+
+
+def _is_wedged() -> bool:
+    with _watchdog_lock:
+        return _wedged
+
+
 # ── model state (loaded once, in a background thread at boot) ───────────
 _model = None
 _model_lock = threading.Lock()
@@ -562,7 +622,21 @@ class Handler(BaseHTTPRequestHandler):
             stt_ready = _model is not None
         with _tts_lock:
             tts_ready = _tts is not None
-        if stt_ready and tts_ready:
+        # A sticky wedge (too many consecutive GPU timeouts — see the watchdog
+        # above) reports unhealthy even when both models loaded, so the compose
+        # healthcheck restarts the container to release the stuck permit.
+        if _is_wedged():
+            self._send_json(
+                503,
+                {
+                    "ok": False,
+                    "reason": "wedged",
+                    "stt": stt_ready,
+                    "tts": tts_ready,
+                    "detail": "consecutive GPU timeouts — restarting to recover",
+                },
+            )
+        elif stt_ready and tts_ready:
             self._send_json(
                 200, {"ok": True, "status": "ready", "stt": True, "tts": True}
             )
@@ -640,6 +714,9 @@ class Handler(BaseHTTPRequestHandler):
         try:
             result = future.result(timeout=REQUEST_TIMEOUT_S)
         except FutureTimeout:
+            # The worker keeps running (and holding _gpu_sem) — feed the
+            # watchdog so repeated wedges trigger a restart-to-recover.
+            _note_timeout()
             self._send_json(503, {"ok": False, "reason": "timeout"})
             return
         except Exception as exc:  # noqa: BLE001
@@ -648,6 +725,7 @@ class Handler(BaseHTTPRequestHandler):
             )
             return
 
+        _note_success()
         self._send_json(200, {"ok": True, **result})
 
     def _handle_tts(self) -> None:
@@ -725,6 +803,9 @@ class Handler(BaseHTTPRequestHandler):
         try:
             ogg, meta = future.result(timeout=TTS_REQUEST_TIMEOUT_S)
         except FutureTimeout:
+            # The worker keeps running (and holding _tts_sem) — feed the
+            # watchdog so repeated wedges trigger a restart-to-recover.
+            _note_timeout()
             self._send_json(503, {"ok": False, "reason": "timeout"})
             return
         except AssertionError as exc:  # kokoro rejects unknown voice / bad speed
@@ -741,6 +822,7 @@ class Handler(BaseHTTPRequestHandler):
             )
             return
 
+        _note_success()
         # Telegram sendVoice consumes these bytes directly: OGG/Opus, mono.
         self.send_response(200)
         self.send_header("Content-Type", "audio/ogg")

--- a/docker/voice-sidecar/test_server.py
+++ b/docker/voice-sidecar/test_server.py
@@ -47,5 +47,228 @@ class ClampSpeedTests(unittest.TestCase):
         self.assertEqual(server.TTS_SPEED_DEFAULT, 1.0)
 
 
+class SplitTextTests(unittest.TestCase):
+    def test_empty_and_whitespace(self) -> None:
+        self.assertEqual(server._split_text("", 100), [])
+        self.assertEqual(server._split_text("   \n  ", 100), [])
+
+    def test_short_text_single_piece(self) -> None:
+        self.assertEqual(server._split_text("hello world", 100), ["hello world"])
+
+    def test_every_piece_within_cap(self) -> None:
+        text = (
+            "First sentence here. Second sentence follows. Third one too! "
+            "And a fourth? Yes indeed, a fifth as well."
+        )
+        pieces = server._split_text(text, 30)
+        self.assertTrue(pieces)
+        for p in pieces:
+            self.assertLessEqual(len(p), 30, msg=f"piece over cap: {p!r}")
+            self.assertTrue(p.strip(), msg="empty piece emitted")
+
+    def test_splits_on_sentence_boundaries(self) -> None:
+        text = "One. Two. Three. Four."
+        pieces = server._split_text(text, 8)
+        self.assertGreater(len(pieces), 1)
+        # Reassembling the words preserves content (order + tokens).
+        self.assertEqual(
+            " ".join(pieces).split(),
+            text.split(),
+        )
+
+    def test_single_token_longer_than_max_emitted_whole(self) -> None:
+        # A single unbroken token longer than max_chars is emitted whole
+        # rather than sliced mid-character (documented contract).
+        big = "x" * 50
+        pieces = server._split_text(big, 10)
+        self.assertEqual(pieces, [big])
+
+    def test_long_word_run_breaks_on_whitespace(self) -> None:
+        # A long run of words (one "unit", no sentence punctuation) is broken
+        # on whitespace so no piece exceeds the cap, but individual words that
+        # fit are never sliced.
+        words = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"]
+        text = " ".join(words)  # > cap, no sentence boundary
+        pieces = server._split_text(text, 12)
+        for p in pieces:
+            self.assertLessEqual(len(p), 12, msg=f"piece over cap: {p!r}")
+        self.assertEqual(" ".join(pieces).split(), words)
+
+    def test_paragraph_boundary_split(self) -> None:
+        text = "Para one is here.\n\nPara two is also here and longer."
+        pieces = server._split_text(text, 25)
+        for p in pieces:
+            self.assertLessEqual(len(p), 25)
+        self.assertTrue(len(pieces) >= 2)
+
+
+class ParseMultipartTests(unittest.TestCase):
+    @staticmethod
+    def _build(boundary: str, parts: list[tuple[str, bytes]]) -> bytes:
+        delim = ("--" + boundary).encode()
+        chunks = []
+        for disp, data in parts:
+            chunks.append(delim + b"\r\n")
+            chunks.append(
+                f'Content-Disposition: form-data; {disp}\r\n\r\n'.encode()
+            )
+            chunks.append(data + b"\r\n")
+        chunks.append(delim + b"--\r\n")
+        return b"".join(chunks)
+
+    def test_non_multipart_content_type(self) -> None:
+        self.assertEqual(
+            server._parse_multipart(b"whatever", "application/json"),
+            (None, None),
+        )
+
+    def test_missing_boundary(self) -> None:
+        self.assertEqual(
+            server._parse_multipart(b"x", "multipart/form-data"),
+            (None, None),
+        )
+
+    def test_extracts_audio_and_language(self) -> None:
+        boundary = "BOUNDARY123"
+        body = self._build(
+            boundary,
+            [
+                ('name="audio"; filename="a.ogg"', b"\x00\x01\x02rawaudio"),
+                ('name="language"', b"en"),
+            ],
+        )
+        audio, language = server._parse_multipart(
+            body, f"multipart/form-data; boundary={boundary}"
+        )
+        self.assertEqual(audio, b"\x00\x01\x02rawaudio")
+        self.assertEqual(language, "en")
+
+    def test_audio_only_language_none(self) -> None:
+        boundary = "b2"
+        body = self._build(boundary, [('name="audio"', b"bytes")])
+        audio, language = server._parse_multipart(
+            body, f"multipart/form-data; boundary={boundary}"
+        )
+        self.assertEqual(audio, b"bytes")
+        self.assertIsNone(language)
+
+    def test_quoted_boundary(self) -> None:
+        boundary = "quoted-b"
+        body = self._build(boundary, [('name="audio"', b"q")])
+        audio, _ = server._parse_multipart(
+            body, f'multipart/form-data; boundary="{boundary}"'
+        )
+        self.assertEqual(audio, b"q")
+
+
+class _FakeAuthHandler:
+    """A minimal stand-in exercising server.Handler._authed without opening a
+    real socket. Records the JSON status the handler would send on failure."""
+
+    def __init__(self, token_header: str | None) -> None:
+        self._headers = {} if token_header is None else {"X-Voice-Token": token_header}
+        self.sent: tuple[int, dict] | None = None
+
+    # Matches BaseHTTPRequestHandler.headers.get(name, default) shape.
+    class _Headers:
+        def __init__(self, d: dict) -> None:
+            self._d = d
+
+        def get(self, name: str, default: str = "") -> str:
+            return self._d.get(name, default)
+
+    @property
+    def headers(self):  # noqa: ANN201
+        return self._Headers(self._headers)
+
+    def _send_json(self, status: int, body: dict) -> None:
+        self.sent = (status, body)
+
+
+class AuthedTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._orig = server.SHARED_TOKEN
+
+    def tearDown(self) -> None:
+        server.SHARED_TOKEN = self._orig
+
+    def _authed(self, configured: str, presented: str | None) -> bool:
+        server.SHARED_TOKEN = configured
+        h = _FakeAuthHandler(presented)
+        return server.Handler._authed(h)
+
+    def test_empty_configured_token_fails_closed(self) -> None:
+        # No token configured → EVERY call is rejected, even a matching header.
+        self.assertFalse(self._authed("", None))
+        self.assertFalse(self._authed("", ""))
+        self.assertFalse(self._authed("", "anything"))
+
+    def test_correct_token_authorizes(self) -> None:
+        self.assertTrue(self._authed("s3cret", "s3cret"))
+
+    def test_wrong_token_rejected(self) -> None:
+        self.assertFalse(self._authed("s3cret", "nope"))
+
+    def test_missing_header_rejected(self) -> None:
+        self.assertFalse(self._authed("s3cret", None))
+
+    def test_rejection_sends_401(self) -> None:
+        server.SHARED_TOKEN = "s3cret"
+        h = _FakeAuthHandler("wrong")
+        server.Handler._authed(h)
+        self.assertIsNotNone(h.sent)
+        self.assertEqual(h.sent[0], 401)
+
+    def test_uses_constant_time_compare(self) -> None:
+        # Guard against regressing to a plain `==` compare — the source must
+        # route the secret comparison through hmac.compare_digest.
+        import inspect
+
+        src = inspect.getsource(server.Handler._authed)
+        self.assertIn("compare_digest", src)
+
+
+class WatchdogTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Isolate global watchdog state per test.
+        self._orig_max = server.VOICE_WATCHDOG_MAX_TIMEOUTS
+        server.VOICE_WATCHDOG_MAX_TIMEOUTS = 3
+        with server._watchdog_lock:
+            server._consecutive_timeouts = 0
+            server._wedged = False
+
+    def tearDown(self) -> None:
+        server.VOICE_WATCHDOG_MAX_TIMEOUTS = self._orig_max
+        with server._watchdog_lock:
+            server._consecutive_timeouts = 0
+            server._wedged = False
+
+    def test_wedges_after_threshold_consecutive_timeouts(self) -> None:
+        self.assertFalse(server._is_wedged())
+        server._note_timeout()
+        server._note_timeout()
+        self.assertFalse(server._is_wedged())
+        server._note_timeout()  # 3rd hits threshold
+        self.assertTrue(server._is_wedged())
+
+    def test_success_resets_counter(self) -> None:
+        server._note_timeout()
+        server._note_timeout()
+        server._note_success()  # reset
+        server._note_timeout()
+        server._note_timeout()
+        self.assertFalse(server._is_wedged())  # only 2 since reset
+        server._note_timeout()
+        self.assertTrue(server._is_wedged())
+
+    def test_wedge_is_sticky_across_success(self) -> None:
+        for _ in range(3):
+            server._note_timeout()
+        self.assertTrue(server._is_wedged())
+        # A late success does NOT un-wedge — we let the restart happen.
+        server._note_success()
+        self.assertTrue(server._is_wedged())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -588,6 +588,19 @@ function emitVoiceSidecarService(
   // Reachable from both host-net and strict-isolation agents — see the
   // function doc. Publish on all interfaces; the shared-secret header is
   // the access gate, not the bind address.
+  //
+  // SECURITY NOTE: `0.0.0.0` is a DELIBERATE reachability trade-off — a pure
+  // `127.0.0.1` publish is invisible to a strict-isolation peer's bridge
+  // network (which reaches host services via host.docker.internal /
+  // host-gateway, NOT loopback), so the sidecar would be unreachable for those
+  // agents. We therefore bind all interfaces and gate access with the
+  // X-Voice-Token shared secret (constant-time compared, fail-closed when
+  // unset — see server.py `_authed`). /healthz is intentionally
+  // unauthenticated but leaks nothing beyond load state. On a host with a
+  // public interface this port IS LAN/WAN-reachable, so operators SHOULD add a
+  // host firewall rule restricting :18900 to the docker bridge + loopback
+  // (e.g. `iptables -A INPUT -p tcp --dport 18900 ! -s 172.16.0.0/12 -j DROP`,
+  // adjusted to the actual docker subnet). Tracked in the PR description.
   lines.push(`    ports:`);
   lines.push(
     `      - "0.0.0.0:${VOICE_SIDECAR_HOST_PORT}:${VOICE_SIDECAR_CONTAINER_PORT}"`,

--- a/src/telegram/materialize-sidecar-token.test.ts
+++ b/src/telegram/materialize-sidecar-token.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for materializeSidecarToken (voice PR-B2, #2714).
+ *
+ * Strategy mirrors materialize-bot-token.test.ts: stub
+ * `resolveVaultReferencesViaBroker` via vi.mock so we exercise the
+ * materializer's branching WITHOUT a real broker.
+ *
+ * The load-bearing behavior #2714 fixed and this file pins:
+ *   - a LITERAL (non-vault) token ref is returned as-is, no broker call
+ *   - a vault: ref is resolved via the broker (ok path)
+ *   - the broker is handed a MINIMAL config carrying EXACTLY ONE vault ref,
+ *     isolated from admin-only refs elsewhere in the config (the narrowing
+ *     that stops an unrelated denied ref from sinking the whole batch)
+ *   - a resolved value that is STILL a vault: ref (broker echoed the ref
+ *     back unresolved) narrows to null, not the unresolved ref
+ *   - broker not-ok + no passphrase → null (graceful fallback, never throws)
+ *   - broker not-ok + passphrase → direct decrypt fallback
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import type { ResolveViaBrokerResult } from "../vault/resolver.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+const brokerStub = vi.hoisted(() => ({
+  fn: vi.fn<(config: SwitchroomConfig) => Promise<ResolveViaBrokerResult>>(),
+}));
+
+vi.mock("../vault/resolver.js", async (importActual) => {
+  const actual = await importActual<typeof import("../vault/resolver.js")>();
+  return {
+    ...actual,
+    resolveVaultReferencesViaBroker: brokerStub.fn,
+  };
+});
+
+const { materializeSidecarToken, DEFAULT_VOICE_SIDECAR_TOKEN_REF } = await import(
+  "./materialize-sidecar-token.js"
+);
+const { createVault, setStringSecret } = await import("../vault/vault.js");
+
+function makeConfig(): SwitchroomConfig {
+  return {
+    switchroom: { version: 1 },
+    telegram: { bot_token: "plaintext-bot", forum_chat_id: "-1001" },
+    vault: { path: "~/.switchroom/vault.enc" },
+    agents: {},
+  } as unknown as SwitchroomConfig;
+}
+
+/** Build a broker "ok" result whose narrowed telegram.bot_token slot carries
+ * the resolved sidecar token (that's the slot the materializer reads back). */
+function okWith(resolved: string): ResolveViaBrokerResult {
+  return {
+    ok: true,
+    config: {
+      ...makeConfig(),
+      telegram: { bot_token: resolved } as SwitchroomConfig["telegram"],
+    },
+  } as ResolveViaBrokerResult;
+}
+
+describe("materializeSidecarToken (#2714)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "materialize-sidecar-token-"));
+    brokerStub.fn.mockReset();
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it("returns a literal (non-vault) token ref as-is, no broker call", async () => {
+    const token = await materializeSidecarToken(
+      { tokenRef: "literal-secret-xyz", config: makeConfig() },
+      () => {},
+    );
+    expect(token).toBe("literal-secret-xyz");
+    expect(brokerStub.fn).not.toHaveBeenCalled();
+  });
+
+  it("resolves the default vault: ref when broker returns ok", async () => {
+    brokerStub.fn.mockResolvedValueOnce(okWith("RESOLVED-TOKEN"));
+    const token = await materializeSidecarToken({ config: makeConfig() }, () => {});
+    expect(token).toBe("RESOLVED-TOKEN");
+    expect(brokerStub.fn).toHaveBeenCalledTimes(1);
+    expect(DEFAULT_VOICE_SIDECAR_TOKEN_REF).toBe("vault:voice/sidecar-token");
+  });
+
+  it("hands the broker EXACTLY ONE vault ref, isolated from admin-only refs", async () => {
+    let seenRefs: string[] = [];
+    brokerStub.fn.mockImplementationOnce(async (cfg: SwitchroomConfig) => {
+      const refs = new Set<string>();
+      const walk = (v: unknown): void => {
+        if (typeof v === "string" && v.startsWith("vault:"))
+          refs.add(v.slice("vault:".length).split("#")[0]);
+        else if (Array.isArray(v)) v.forEach(walk);
+        else if (v !== null && typeof v === "object")
+          Object.values(v as Record<string, unknown>).forEach(walk);
+      };
+      walk(cfg);
+      seenRefs = [...refs];
+      return okWith("RESOLVED-TOKEN");
+    });
+
+    const config = {
+      ...makeConfig(),
+      litellm: { admin_key: "vault:litellm/master-key" },
+      google_workspace: { google_client_secret: "vault:google/client-secret" },
+      agents: { klanker: { some_key: "vault:per-agent/secret" } },
+    } as unknown as SwitchroomConfig;
+
+    const token = await materializeSidecarToken({ config }, () => {});
+    expect(token).toBe("RESOLVED-TOKEN");
+    expect(seenRefs).toEqual(["voice/sidecar-token"]);
+  });
+
+  it("narrows a still-unresolved vault: ref to null (does not leak the ref)", async () => {
+    // Broker returned ok but echoed the ref back unresolved.
+    brokerStub.fn.mockResolvedValueOnce(okWith("vault:voice/sidecar-token"));
+    const token = await materializeSidecarToken({ config: makeConfig() }, () => {});
+    expect(token).toBeNull();
+  });
+
+  it("returns null when broker not-ok and no passphrase is available (no throw)", async () => {
+    brokerStub.fn.mockResolvedValueOnce({ ok: false, reason: "denied" });
+    const config = {
+      ...makeConfig(),
+      vault: { path: path.join(tmpDir, "nonexistent-vault.enc") },
+    } as unknown as SwitchroomConfig;
+    const token = await materializeSidecarToken({ config, env: {} }, () => {});
+    expect(token).toBeNull();
+  });
+
+  it("falls back to direct decrypt when broker unreachable and passphrase set", async () => {
+    brokerStub.fn.mockResolvedValueOnce({ ok: false, reason: "unreachable" });
+
+    const passphrase = "test-passphrase-abc";
+    const vaultPath = path.join(tmpDir, "vault.enc");
+    createVault(passphrase, vaultPath);
+    setStringSecret(passphrase, vaultPath, "voice/sidecar-token", "DIRECT-DECRYPT-TOKEN");
+
+    const config = {
+      ...makeConfig(),
+      vault: { path: vaultPath },
+    } as unknown as SwitchroomConfig;
+
+    const token = await materializeSidecarToken(
+      { config, env: { SWITCHROOM_VAULT_PASSPHRASE: passphrase } },
+      () => {},
+    );
+    expect(token).toBe("DIRECT-DECRYPT-TOKEN");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes three defects in the voice sidecar (STT/TTS) and adds the missing tests.

### 1. Semaphore-permit leak on a wedged native GPU call (SHOULD-FIX)
`_handle_stt` / `_handle_tts` submit inference to a `ThreadPoolExecutor` and abandon the future on `FutureTimeout`, but the worker thread keeps running and keeps holding `_gpu_sem` / `_tts_sem` (acquired in `_run_inference` / `_run_synthesis`). Python cannot cancel the native call. With `CONCURRENCY=1` one hung call permanently holds the only permit → every later request 503s (`timeout`) forever, yet `/healthz` still reports `ready` — a silent wedge.

**Fix:** restart-to-recover watchdog. A small module (`_note_timeout` / `_note_success` / `_is_wedged`) counts *consecutive* per-request timeouts across both lanes; any successful inference/synthesis resets the counter. After `VOICE_WATCHDOG_MAX_TIMEOUTS` (default 3) it flips a sticky `_wedged` flag; `/healthz` then returns 503 (`reason: wedged`), the compose healthcheck goes unhealthy, and Docker (`restart: always`) restarts the container with a fresh GPU context, releasing the stuck permit. Flipping `/healthz` (rather than `os._exit`) avoids tearing down an in-flight, still-healthy request mid-response.

### 2. Sidecar bind 0.0.0.0:18900 (SHOULD-FIX)
**Decision: kept the `0.0.0.0` bind.** A pure `127.0.0.1` publish is invisible to a strict-isolation peer's bridge network (it reaches host services via `host.docker.internal` / host-gateway, NOT loopback), so loopback-only would break voice for strict-isolation agents. The broad bind is gated by the `X-Voice-Token` shared secret (constant-time compared, fail-closed when unset). Strengthened the code comment to flag the LAN/WAN exposure and recommend a host firewall rule:

```
iptables -A INPUT -p tcp --dport 18900 ! -s 172.16.0.0/12 -j DROP
```
(adjust to the actual docker subnet). `/healthz` stays unauthenticated but leaks nothing beyond load state.

### 3. Missing tests (MISSING TESTS)
- **Python** (`test_server.py`): `_split_text` (incl. single-token > max_chars emitted whole, whitespace/sentence/paragraph boundaries, every-piece-within-cap), `_parse_multipart` (audio+language, audio-only, quoted boundary, non-multipart, missing boundary), `_authed` (constant-time via `compare_digest`, empty-token fail-closed, wrong/missing token, 401), and the new watchdog.
- **TypeScript** (`materialize-sidecar-token.test.ts`): the single-key narrowing logic #2714 fixed (previously only `materialize-bot-token.test.ts` existed) — literal ref passthrough, vault-ref resolve, exactly-one-ref isolation from admin-only refs, still-unresolved-ref → null, graceful null on broker-denied, direct-decrypt fallback.

## Test plan
- [x] `python3 -m unittest discover -s docker/voice-sidecar -p 'test_*.py'` — 27 pass
- [x] `vitest run src/telegram/materialize-sidecar-token.test.ts tests/docker/compose-generator.test.ts` — 197 pass
- [x] `tsc --noEmit` — clean

## Risk
Low. The watchdog is additive (no behavior change on the happy path — success resets the counter). The bind is unchanged. New tests only.

Serves the **always-available** vision outcome: a wedged sidecar previously stayed wedged silently; it now self-heals via Docker restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)