### PR TITLE
fix(gateway): revive dead profile: spend tag + backfill sr-* routing tests

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1967,6 +1967,14 @@ function emitAgentService(
     // this is at worst a no-op — never a regression.
     CLAUDE_CODE_ATTRIBUTION_HEADER: "0",
     SWITCHROOM_AGENT_NAME: a.name,
+    // The agent's profile (its `extends:` value, defaulting to
+    // "default"). Read by the LiteLLM `x-litellm-tags` header emitted
+    // from start.sh.hbs / cron-session.sh.hbs as `profile:<value>` —
+    // without this write the `${SWITCHROOM_AGENT_PROFILE:-default}`
+    // expansion always collapsed to "default" (3 reads, 0 writes), so
+    // the per-profile spend tag was dead. Must match `profile` resolved
+    // in `collectAgentServices` (`agent.extends ?? "default"`).
+    SWITCHROOM_AGENT_PROFILE: a.profile ?? "default",
     // Belt-and-braces in-container marker for the agent-config CLI's
     // isContainerContext() probe (the primary signal is /.dockerenv,
     // but a second independent check is the point of writing `||`).

--- a/telegram-plugin/gateway/chat-id-fallback.ts
+++ b/telegram-plugin/gateway/chat-id-fallback.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared chat_id allowlist fallback for the reply / stream_reply final-answer
+ * paths.
+ *
+ * Non-Claude models (Gemini via LiteLLM `sr-*` routing) sometimes pass a
+ * chat_id that fails the allowlist:
+ *
+ *   - **Bug A (numeric coercion):** the model passes a JSON number, so the
+ *     caller must `String(...)`-coerce before the allowlist compare (the
+ *     allowlist is a string set). Without coercion `42 !== "42"` and every
+ *     reply looks un-allowlisted.
+ *   - **Bug B (executeReply fallback):** the raw value is wrong, so fall back
+ *     to the *active* turn's already-validated `sessionChatId`.
+ *   - **Bug D (lastActiveTurnChatId survives silence poke):** a ≥5-min silence
+ *     poke fires `clearTurnStarted`, so `currentTurn` is null by the time the
+ *     model finally replies. The active-turn tier is gone, but the last-known
+ *     turn's chat still routes the answer correctly.
+ *
+ * These hotfixes shipped test-free; this helper isolates the pure decision so
+ * each bug gets a focused regression test.
+ *
+ * Returns the resolved chat_id (rawChatId unchanged when no valid fallback
+ * exists, so the caller's `assertAllowedChat` throws the human-readable error)
+ * plus the tier used, for logging. Pure — no module state read.
+ */
+export interface ChatIdAllowlist {
+  allowFrom: string[]
+  groups: Record<string, unknown>
+}
+
+export function resolveChatIdFallback(
+  rawChatId: string,
+  access: ChatIdAllowlist,
+  turnSessionChatId: string | undefined,
+  lastKnownChatId: string | undefined,
+  hasLiveTurn: boolean,
+): { chatId: string; tier: 'raw' | 'active' | 'last-known' } {
+  if (access.allowFrom.includes(rawChatId) || rawChatId in access.groups) {
+    return { chatId: rawChatId, tier: 'raw' }
+  }
+  const fallbackChatId = turnSessionChatId ?? lastKnownChatId
+  if (fallbackChatId && (access.allowFrom.includes(fallbackChatId) || fallbackChatId in access.groups)) {
+    return { chatId: fallbackChatId, tier: hasLiveTurn ? 'active' : 'last-known' }
+  }
+  return { chatId: rawChatId, tier: 'raw' }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -399,6 +399,9 @@ import {
 } from './emission-authority.js'
 import { CurrentTurnMap } from './current-turn-map.js'
 import { resolveAnswerThreadId } from './answer-thread-resolve.js'
+import { resolveChatIdFallback } from './chat-id-fallback.js'
+import { decideObligationTurnEnd } from './obligation-turn-end.js'
+import { maybeRotate } from './turns-jsonl-rotate.js'
 import {
   createDeliveryQueue,
   trackDelivery,
@@ -3486,7 +3489,20 @@ function emitTurnRecord(turn: CurrentTurn, endedAt: number): void {
         status: turn.finalAnswerDelivered ? 'complete' : 'no_reply',
         turn_id: turn.turnId,
       }) + '\n'
-    appendFileSync('/state/agent/turns.jsonl', rec)
+    const turnsPath = '/state/agent/turns.jsonl'
+    // Size-cap rotation: keep at most one rotated generation so the file can't
+    // grow unbounded on a long-lived agent. Best-effort (never throws).
+    maybeRotate(turnsPath, {
+      statSize: (p) => {
+        try {
+          return statSync(p).size
+        } catch {
+          return undefined
+        }
+      },
+      rename: (from, to) => renameSync(from, to),
+    })
+    appendFileSync(turnsPath, rec)
   } catch {
     // best-effort — never let metrics emission break turn teardown
   }
@@ -3542,7 +3558,7 @@ function endCurrentTurnAtomic(turn: CurrentTurn): void {
   // At turn_end with replyCalled=true the model explicitly signalled completion
   // AND replied, so the obligation is satisfied regardless of finalAnswerDelivered.
   if (OBLIGATION_LEDGER_ENABLED) {
-    if (turn.finalAnswerDelivered || turn.replyCalled) {
+    if (decideObligationTurnEnd(turn.finalAnswerDelivered, turn.replyCalled) === 'close') {
       obligationLedger.close(turn.turnId)
     } else {
       // Turn ended WITHOUT any reply (no ack, no answer). If this turn was
@@ -8723,18 +8739,20 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   //   null because clearTurnStarted fired ≥5 min of model silence, but the model
   //   finally called reply after the poke).
   const chat_id = (() => {
-    const _a = loadAccess()
-    if (_a.allowFrom.includes(_rawChatId) || _rawChatId in _a.groups) return _rawChatId
-    const fallbackChatId = turn?.sessionChatId ?? lastActiveTurnChatId
-    if (fallbackChatId && (_a.allowFrom.includes(fallbackChatId) || fallbackChatId in _a.groups)) {
-      const tier = turn == null ? 'last-known' : 'active'
+    const resolved = resolveChatIdFallback(
+      _rawChatId,
+      loadAccess(),
+      turn?.sessionChatId,
+      lastActiveTurnChatId,
+      turn != null,
+    )
+    if (resolved.tier !== 'raw') {
       process.stderr.write(
         `telegram gateway: reply: model passed chat_id "${_rawChatId}" (not allowlisted) — ` +
-          `routing to ${tier} turn chat "${fallbackChatId}"\n`,
+          `routing to ${resolved.tier} turn chat "${resolved.chatId}"\n`,
       )
-      return fallbackChatId
     }
-    return _rawChatId // let assertAllowedChat below throw the human-readable error
+    return resolved.chatId // raw tier → let assertAllowedChat throw the human-readable error
   })()
   const rawText = args.text as string | undefined
   if (rawText == null || rawText === '') throw new Error('reply: text is required and cannot be empty')
@@ -9912,6 +9930,31 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
   const turn = currentTurn
   if (!args.chat_id) throw new Error('stream_reply: chat_id is required')
   if (args.text == null || args.text === '') throw new Error('stream_reply: text is required and cannot be empty')
+  // chat_id allowlist fallback — mirrors executeReply (~8725). stream_reply is
+  // the primary final-answer path, so a wrong/late chat_id (int/string mismatch,
+  // or the model echoing the wrong identifier after a silence poke flipped
+  // currentTurn to null) would otherwise fail assertAllowedChat in the stream
+  // controller → an invisible reply. Rewrite args.chat_id in place so every
+  // downstream consumer (origin resolution, dedup key, the send) sees the
+  // corrected value. Tier 1: live turn's sessionChatId. Tier 2: last-known
+  // turn's chat (survives silence poke — Bug D fix; currentTurn is null).
+  {
+    const _rawChatId = String(args.chat_id ?? '')
+    const resolved = resolveChatIdFallback(
+      _rawChatId,
+      loadAccess(),
+      turn?.sessionChatId,
+      lastActiveTurnChatId,
+      turn != null,
+    )
+    if (resolved.tier !== 'raw') {
+      process.stderr.write(
+        `telegram gateway: stream_reply: model passed chat_id "${_rawChatId}" (not allowlisted) — ` +
+          `routing to ${resolved.tier} turn chat "${resolved.chatId}"\n`,
+      )
+      args.chat_id = resolved.chatId
+    }
+  }
   // Thread precedence (matches executeReply; component 3 — turn-origin
   // routing): when the model passes no explicit message_thread_id, inject
   // the ORIGIN turn's thread (matched by origin_turn_id) — authoritative

--- a/telegram-plugin/gateway/obligation-turn-end.ts
+++ b/telegram-plugin/gateway/obligation-turn-end.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure decision for what a turn_end does to the ending turn's delivery
+ * obligation (#2624).
+ *
+ * Two branches, both must be pinned by tests:
+ *
+ *   - **Normal reply** — the turn either delivered a genuine final answer
+ *     (`finalAnswerDelivered`) OR the model explicitly called reply
+ *     (`replyCalled`, true even for a short LiteLLM sr-* `reply("OK",
+ *     {disable_notification:true})` that `isFinalAnswerReply` demoted to
+ *     non-final). Either way the obligation is satisfied → close it at
+ *     turn_end.
+ *
+ *   - **Ack-then-ghost / no-reply** — the turn ended with no reply at all
+ *     (no ack, no answer). The obligation must NOT close at turn_end; it
+ *     stays open and the idle sweep later ends it via the silence_fallback
+ *     path. At turn_end we only stamp the grace clock (`note-ended`).
+ *
+ * Returns the action the caller applies to the ledger. Pure — no ledger
+ * mutation, no module state.
+ */
+export function decideObligationTurnEnd(
+  finalAnswerDelivered: boolean,
+  replyCalled: boolean,
+): 'close' | 'note-ended' {
+  return finalAnswerDelivered || replyCalled ? 'close' : 'note-ended'
+}

--- a/telegram-plugin/gateway/turns-jsonl-rotate.ts
+++ b/telegram-plugin/gateway/turns-jsonl-rotate.ts
@@ -1,0 +1,30 @@
+/**
+ * Minimal size-cap rotation for the turn-record JSONL (`turns.jsonl`).
+ *
+ * emitTurnRecord appends one line per turn forever with no rotation, so the
+ * file grows unbounded on a long-lived agent. This keeps at most one rotated
+ * generation: when the live file exceeds the cap, it is renamed to
+ * `<path>.1` (overwriting any prior generation) and a fresh live file starts.
+ * Bounded disk: ≤ 2× the cap.
+ *
+ * Pure of the append itself — `maybeRotate` only decides + performs the rename.
+ * Best-effort: the fs hooks are injected so it's unit-testable and so a rotate
+ * failure can be swallowed by the caller (never break turn teardown).
+ */
+export const TURNS_JSONL_MAX_BYTES = 5 * 1024 * 1024 // 5 MiB
+
+export interface RotateFs {
+  statSize: (path: string) => number | undefined // undefined ⇒ file absent
+  rename: (from: string, to: string) => void
+}
+
+/**
+ * Rotate `path` → `path.1` if it is at/over `maxBytes`. Returns true if a
+ * rotation happened. Absent file (statSize undefined) ⇒ no rotation.
+ */
+export function maybeRotate(path: string, fs: RotateFs, maxBytes = TURNS_JSONL_MAX_BYTES): boolean {
+  const size = fs.statSize(path)
+  if (size == null || size < maxBytes) return false
+  fs.rename(path, `${path}.1`)
+  return true
+}

--- a/telegram-plugin/tests/chat-id-fallback.test.ts
+++ b/telegram-plugin/tests/chat-id-fallback.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveChatIdFallback, type ChatIdAllowlist } from '../gateway/chat-id-fallback.js'
+
+/**
+ * Regression tests for the sr-* chat_id routing hotfixes that shipped
+ * test-free, plus the stream_reply fallback parity fix.
+ *
+ * The reply / stream_reply final-answer paths call resolveChatIdFallback with a
+ * String()-coerced chat_id. This suite pins the pure decision:
+ *   - Bug A — numeric coercion (String() at the callsite makes 42 match "42")
+ *   - Bug B — executeReply falls back to the active turn's sessionChatId
+ *   - Bug D — lastActiveTurnChatId survives the silence poke (currentTurn null)
+ *   - stream_reply — the SAME fallback (mirrors the executeReply Bug-D test)
+ */
+describe('resolveChatIdFallback', () => {
+  const access = (allowFrom: string[], groups: Record<string, unknown> = {}): ChatIdAllowlist => ({
+    allowFrom,
+    groups,
+  })
+
+  it('allowlisted raw chat_id passes through unchanged (tier=raw)', () => {
+    const r = resolveChatIdFallback('123', access(['123']), '999', '999', true)
+    expect(r).toEqual({ chatId: '123', tier: 'raw' })
+  })
+
+  it('a chat_id present in groups (not allowFrom) passes through (tier=raw)', () => {
+    const r = resolveChatIdFallback('-100777', access([], { '-100777': {} }), '999', '999', true)
+    expect(r).toEqual({ chatId: '-100777', tier: 'raw' })
+  })
+
+  // Bug A — numeric coercion. The model passes a JSON number; the caller
+  // String()-coerces before calling. A stringified numeric id matches the
+  // string allowlist, so it must pass through as tier=raw (no spurious
+  // fallback).
+  it('Bug A: numerically-coerced chat_id ("42") matches the string allowlist', () => {
+    const coerced = String(42 as unknown as number)
+    const r = resolveChatIdFallback(coerced, access(['42']), '999', '999', true)
+    expect(r).toEqual({ chatId: '42', tier: 'raw' })
+  })
+
+  // Bug B — executeReply fallback. Raw chat_id not allowlisted, a live turn is
+  // present → route to the active turn's validated sessionChatId.
+  it('Bug B: non-allowlisted raw + live turn → active turn sessionChatId', () => {
+    const r = resolveChatIdFallback('wrong-id', access(['123']), '123', '123', true)
+    expect(r).toEqual({ chatId: '123', tier: 'active' })
+  })
+
+  // Bug D — lastActiveTurnChatId survives the silence poke. currentTurn is null
+  // (turnSessionChatId undefined, hasLiveTurn false) because clearTurnStarted
+  // fired after ≥5 min silence, but the model finally replied after the poke.
+  // The last-known chat still routes the answer.
+  it('Bug D: no live turn (silence poke) → last-known turn chat', () => {
+    const r = resolveChatIdFallback('wrong-id', access(['123']), undefined, '123', false)
+    expect(r).toEqual({ chatId: '123', tier: 'last-known' })
+  })
+
+  // stream_reply Bug-D mirror: stream_reply is the primary final-answer path
+  // and now applies the SAME fallback. Identical inputs → identical decision.
+  it('stream_reply parity: same fallback after a silence poke (mirrors Bug D)', () => {
+    const r = resolveChatIdFallback('wrong-id', access(['555']), undefined, '555', false)
+    expect(r).toEqual({ chatId: '555', tier: 'last-known' })
+  })
+
+  it('no valid fallback → returns raw so assertAllowedChat throws the human error', () => {
+    const r = resolveChatIdFallback('wrong-id', access(['123']), 'also-wrong', 'still-wrong', true)
+    expect(r).toEqual({ chatId: 'wrong-id', tier: 'raw' })
+  })
+
+  it('active tier wins over last-known when both are set (turn present)', () => {
+    const r = resolveChatIdFallback('wrong-id', access(['active-chat', 'old-chat']), 'active-chat', 'old-chat', true)
+    expect(r).toEqual({ chatId: 'active-chat', tier: 'active' })
+  })
+})

--- a/telegram-plugin/tests/obligation-turn-end.test.ts
+++ b/telegram-plugin/tests/obligation-turn-end.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import { decideObligationTurnEnd } from '../gateway/obligation-turn-end.js'
+import { ObligationLedger } from '../gateway/obligation-ledger.js'
+
+/**
+ * #2624 — obligation close on replyCalled shipped test-free. Pin BOTH branches:
+ *
+ *   - Normal reply → close at turn_end (finalAnswerDelivered OR replyCalled).
+ *   - Ack-then-ghost / no-reply → NOT closed at turn_end; stays open so the
+ *     idle sweep ends it via silence_fallback.
+ */
+describe('decideObligationTurnEnd (#2624)', () => {
+  it('final answer delivered → close', () => {
+    expect(decideObligationTurnEnd(true, false)).toBe('close')
+  })
+
+  it('replyCalled (short sr-* reply demoted to non-final) → close', () => {
+    // The LiteLLM sr-* cascade: reply("OK", {disable_notification:true}) is
+    // below the 200-char backstop + notification-suppressed, so
+    // finalAnswerDelivered is false — but the model explicitly replied.
+    expect(decideObligationTurnEnd(false, true)).toBe('close')
+  })
+
+  it('final answer AND replyCalled → close', () => {
+    expect(decideObligationTurnEnd(true, true)).toBe('close')
+  })
+
+  it('no reply at all (ack-then-ghost / no-reply) → note-ended, NOT close', () => {
+    expect(decideObligationTurnEnd(false, false)).toBe('note-ended')
+  })
+})
+
+describe('#2624 obligation lifecycle — end-to-end over the ledger', () => {
+  const openObligation = (ledger: ObligationLedger, turnId: string) =>
+    ledger.openIfAbsent({
+      originTurnId: turnId,
+      chatId: '123',
+      messageId: 1,
+      text: 'do the thing',
+      openedAt: 1_000,
+    })
+
+  it('normal reply closes the obligation at turn_end', () => {
+    const ledger = new ObligationLedger()
+    openObligation(ledger, 'turn-A')
+    expect(ledger.isOpen('turn-A')).toBe(true)
+
+    // Simulate the gateway turn_end branch for a turn that called reply.
+    if (decideObligationTurnEnd(true, false) === 'close') {
+      ledger.close('turn-A')
+    } else {
+      ledger.noteTurnEnded('turn-A', 2_000)
+    }
+    expect(ledger.isOpen('turn-A')).toBe(false)
+  })
+
+  it('ack-then-ghost turn_end does NOT close — obligation survives for silence_fallback', () => {
+    const ledger = new ObligationLedger()
+    openObligation(ledger, 'turn-B')
+
+    // turn_end with no reply: the ack-then-ghost path.
+    if (decideObligationTurnEnd(false, false) === 'close') {
+      ledger.close('turn-B')
+    } else {
+      ledger.noteTurnEnded('turn-B', 2_000)
+    }
+    // Still open at turn_end — the whole point: it is ended later via
+    // silence_fallback, NOT turn_end.
+    expect(ledger.isOpen('turn-B')).toBe(true)
+
+    // The silence-fallback sweep is what finally closes it.
+    expect(ledger.close('turn-B')).toBe(true)
+    expect(ledger.isOpen('turn-B')).toBe(false)
+  })
+})

--- a/telegram-plugin/tests/turns-jsonl-rotate.test.ts
+++ b/telegram-plugin/tests/turns-jsonl-rotate.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { maybeRotate, TURNS_JSONL_MAX_BYTES, type RotateFs } from '../gateway/turns-jsonl-rotate.js'
+
+describe('maybeRotate — turns.jsonl size cap', () => {
+  const mkFs = (size: number | undefined) => {
+    const rename = vi.fn()
+    const fs: RotateFs = { statSize: () => size, rename }
+    return { fs, rename }
+  }
+
+  it('does not rotate below the cap', () => {
+    const { fs, rename } = mkFs(TURNS_JSONL_MAX_BYTES - 1)
+    expect(maybeRotate('/state/agent/turns.jsonl', fs)).toBe(false)
+    expect(rename).not.toHaveBeenCalled()
+  })
+
+  it('rotates at/over the cap → renames to <path>.1', () => {
+    const { fs, rename } = mkFs(TURNS_JSONL_MAX_BYTES)
+    expect(maybeRotate('/state/agent/turns.jsonl', fs)).toBe(true)
+    expect(rename).toHaveBeenCalledWith('/state/agent/turns.jsonl', '/state/agent/turns.jsonl.1')
+  })
+
+  it('absent file (statSize undefined) → no rotation', () => {
+    const { fs, rename } = mkFs(undefined)
+    expect(maybeRotate('/state/agent/turns.jsonl', fs)).toBe(false)
+    expect(rename).not.toHaveBeenCalled()
+  })
+
+  it('rotation is bounded to one generation (overwrites <path>.1)', () => {
+    // A second rotation renames onto the same .1 target — no unbounded
+    // accumulation of generations.
+    const { fs, rename } = mkFs(TURNS_JSONL_MAX_BYTES * 3)
+    maybeRotate('/a/turns.jsonl', fs)
+    maybeRotate('/a/turns.jsonl', fs)
+    expect(rename).toHaveBeenNthCalledWith(1, '/a/turns.jsonl', '/a/turns.jsonl.1')
+    expect(rename).toHaveBeenNthCalledWith(2, '/a/turns.jsonl', '/a/turns.jsonl.1')
+  })
+})

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -385,6 +385,19 @@ describe("generateCompose", () => {
     expect(out).toMatch(/agent-misc:[\s\S]*?cpus: 1\.0/);
   });
 
+  it("SWITCHROOM_AGENT_PROFILE env = the agent's profile (LiteLLM profile: spend tag)", () => {
+    // Regression: start.sh.hbs / cron-session.sh.hbs emit
+    // `profile:${SWITCHROOM_AGENT_PROFILE:-default}` but the env var was
+    // never written, so the per-profile spend tag was always "default".
+    const out = generateCompose({ config: makeConfig({ worker: { extends: "coding" } }) });
+    expect(out).toMatch(/agent-worker:[\s\S]*?SWITCHROOM_AGENT_PROFILE: "coding"/);
+  });
+
+  it("SWITCHROOM_AGENT_PROFILE defaults to 'default' when no extends set", () => {
+    const out = generateCompose({ config: makeConfig({ misc: {} }) });
+    expect(out).toMatch(/agent-misc:[\s\S]*?SWITCHROOM_AGENT_PROFILE: "default"/);
+  });
+
   it("agent.resources.memory overrides the profile default", () => {
     const out = generateCompose({
       config: makeConfig({ tiny: { extends: "conversational", resources: { memory: "512m" } } }),


### PR DESCRIPTION
## Summary

Five defects on the LiteLLM / MODEL / METRICS surface, one PR.

**1. BLOCKING — the \`profile:\` LiteLLM spend tag was dead.**
\`profiles/_base/start.sh.hbs\` and \`cron-session.sh.hbs\` emit
\`x-litellm-tags: ...,profile:\${SWITCHROOM_AGENT_PROFILE:-default}\`, but
\`SWITCHROOM_AGENT_PROFILE\` was never assigned (3 reads, 0 writes), so every
agent's per-profile spend tag silently collapsed to \`default\`. Now exported
from \`src/agents/compose.ts\` alongside \`SWITCHROOM_AGENT_NAME\`, sourced from
the agent's cascade-resolved profile (\`a.profile ?? "default"\`, matching
\`collectAgentServices\`' \`agent.extends ?? "default"\`).

**2. \`executeStreamReply\` had no chat_id allowlist fallback** (unlike
\`executeReply\`). stream_reply is the primary final-answer path, so a wrong/late
chat_id (int/string mismatch, or the model echoing a wrong id after a silence
poke flipped \`currentTurn\` to null) would fail \`assertAllowedChat\` in the
stream controller → an invisible reply. Applied the SAME two-tier fallback
(active turn \`sessionChatId\` → \`lastActiveTurnChatId\`), extracted into a shared
pure \`resolveChatIdFallback\` helper used by both paths.

**3. Backfilled the sr-* chat_id routing hotfix tests** that shipped test-free:
Bug A (numeric coercion), Bug B (executeReply fallback), Bug D
(\`lastActiveTurnChatId\` survives the silence poke) + a stream_reply parity case.

**4. Obligation close on \`replyCalled\` (#2624)** shipped test-free. Extracted
the decision into \`decideObligationTurnEnd\` and pinned BOTH branches: a normal
reply closes at \`turn_end\`; an ack-then-ghost / no-reply turn stays open and is
ended later via \`silence_fallback\`, NOT \`turn_end\`.

**5. \`turns.jsonl\` appended forever, no rotation.** Added a minimal size-cap
rotation (5 MiB, one rotated \`.1\` generation, ≤ 2× cap on disk) + test.

## Why

The profile tag defect means the operator's LiteLLM usage-metering carve-out
(\`reference/invariants.md\` § "Operator-controlled gateway carve-out") could
never attribute spend per-profile — the headline reason the gated proxy exists.
The others harden the sr-* (LiteLLM-routed) final-answer + obligation paths that
shipped without regression coverage.

Serves the **subscription-honest** vision outcome (accurate per-profile spend
attribution on the operator gateway carve-out) and the **always-on** outcome
(no invisible replies / no obligation double-ask cascade). Crosses no invariant:
the carve-out forwards the Pro/Max OAuth credential unchanged; this only fixes
the static attribution tag.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`vitest run tests/docker/compose-generator.test.ts\` — 193 passed (new profile-env assertions)
- [x] new plugin tests: \`chat-id-fallback\` (8), \`obligation-turn-end\` (6), \`turns-jsonl-rotate\` (4) — all pass under vitest
- [x] neighboring gateway-logic suites green: \`answer-thread-resolve\`, \`obligation-ledger\`, \`obligation-determinism\`
- [x] \`scripts/check-bot-api-wrapping.sh\` clean

## Risk

Low. compose.ts adds one deterministic env key (sorted emission preserved).
The chat_id fallback is behaviorally identical to the existing executeReply
path, now shared. Obligation + rotation changes are pure-helper extractions
with no behavior change to the close/note-ended logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)