### PR TITLE
fix(telegram): render code-span values literally, not escapeMarkdown

### DIFF
--- a/telegram-plugin/auth-snapshot-format.ts
+++ b/telegram-plugin/auth-snapshot-format.ts
@@ -22,7 +22,7 @@ import type { QuotaResult, QuotaUtilization } from './quota-check.js';
 import { isProbeThin, refillNormalizedUtils } from '../src/auth/quota.js';
 import type { AccountState, LastQuotaSnapshot, ListStateData } from '../src/auth/broker/client.js';
 import { maskEmail } from './demo-mask.js';
-import { escapeMarkdown } from './card-format.js';
+import { escapeMarkdown, codeSpanSafe } from './card-format.js';
 
 // ── shared types ─────────────────────────────────────────────────────
 
@@ -324,7 +324,7 @@ function renderAccountRow(
 
   if (!snap.quota) {
     lines.push(
-      `${marker}\`${escapeMarkdown(label)}\`  _quota probe failed_`,
+      `${marker}\`${codeSpanSafe(label)}\`  _quota probe failed_`,
     );
     if (snap.quotaError) {
       lines.push(`  _${escapeMarkdown(snap.quotaError)}_`);
@@ -337,7 +337,7 @@ function renderAccountRow(
   // it as a data-quality gap, never a confident "0% / 0%".
   if (isProbeThin(q)) {
     lines.push(
-      `${marker}\`${escapeMarkdown(label)}\`  _quota unknown (thin probe)_`,
+      `${marker}\`${codeSpanSafe(label)}\`  _quota unknown (thin probe)_`,
     );
     return lines;
   }
@@ -347,7 +347,7 @@ function renderAccountRow(
   const fiveStr = fmtPct(norm.fiveHourUtilizationPct);
   const sevenStr = fmtPct(norm.sevenDayUtilizationPct);
   lines.push(
-    `${marker}\`${escapeMarkdown(label)}\`  ${fiveStr} / ${sevenStr}`,
+    `${marker}\`${codeSpanSafe(label)}\`  ${fiveStr} / ${sevenStr}`,
   );
 
   const health = classifyHealth(snap, now);
@@ -502,11 +502,19 @@ export function renderAuthSnapshotFormat2(
       // Account cell: FULL email, never truncated; active gets a (active) suffix.
       // The black-dot active marker is intentionally removed — the suffix reads.
       const label = displayLabel(s.label, opts);
-      const account = s.isActive ? `${label} (active)` : label;
+      // #2701 — the account label is an identifier (email / slug) that can
+      // contain markdown-active chars (`_ * ~` etc.). `tableCell` only guards
+      // the table grid (`\ | \n`), NOT inline formatting, so a raw label like
+      // `ken_max` was parsed as emphasis and corrupted the row. Render it in a
+      // code span (backtick content is literal) exactly like renderAccountRow
+      // does, defusing embedded backticks via codeSpanSafe. The wrapping
+      // backticks still need pipe/newline guarding for the grid, hence the
+      // tableCell wrap around the finished span.
+      const accountCell = `\`${codeSpanSafe(s.isActive ? `${label} (active)` : label)}\``;
       const { five, seven } = pctCells(s, now);
       const status = statusCell(s, now, tz);
       lines.push(
-        `| ${emoji} | ${tableCell(account)} | ${five} | ${seven} | ${tableCell(status)} |`,
+        `| ${emoji} | ${tableCell(accountCell)} | ${five} | ${seven} | ${tableCell(status)} |`,
       );
     }
   }
@@ -741,7 +749,7 @@ export function renderFallbackAnnouncement(input: FallbackAnnouncementInput): st
       if (earliest) {
         lines.push('');
         lines.push(
-          `Earliest recovery: \`${escapeMarkdown(earliest.label)}\` ` +
+          `Earliest recovery: \`${codeSpanSafe(earliest.label)}\` ` +
             `${formatAbsolute(earliest.at, tz)} (in ${formatRelative(earliest.at, now)})`,
         );
       }
@@ -769,7 +777,7 @@ export function renderFallbackAnnouncement(input: FallbackAnnouncementInput): st
   );
   lines.push('');
   lines.push(
-    `\`${escapeMarkdown(input.oldLabel)}\` → \`${escapeMarkdown(input.newLabel)}\``,
+    `\`${codeSpanSafe(input.oldLabel)}\` → \`${codeSpanSafe(input.newLabel)}\``,
   );
   lines.push(`Triggered by: agent **${escapeMarkdown(input.triggerAgent)}**`);
   lines.push('');
@@ -778,7 +786,7 @@ export function renderFallbackAnnouncement(input: FallbackAnnouncementInput): st
     const recovery = recoveryAtFor(input.oldQuota);
     if (recovery) {
       lines.push(
-        `\`${escapeMarkdown(input.oldLabel)}\` recovers ` +
+        `\`${codeSpanSafe(input.oldLabel)}\` recovers ` +
           `${formatAbsolute(recovery, tz)} (in ${formatRelative(recovery, now)})`,
       );
     }
@@ -792,7 +800,7 @@ export function renderFallbackAnnouncement(input: FallbackAnnouncementInput): st
       input.newQuota.sevenDayUtilizationPct < THROTTLING_THRESHOLD_PCT;
     const headroomStr = hasHeadroom ? '_(plenty of headroom)_' : '_(near limit — watch this)_';
     lines.push(
-      `\`${escapeMarkdown(input.newLabel)}\` now: ${fiveStr} of 5h · ${sevenStr} of 7d ${headroomStr}`,
+      `\`${codeSpanSafe(input.newLabel)}\` now: ${fiveStr} of 5h · ${sevenStr} of 7d ${headroomStr}`,
     );
   } else {
     lines.push(

--- a/telegram-plugin/card-format.ts
+++ b/telegram-plugin/card-format.ts
@@ -27,13 +27,15 @@
  * which is itself state-free.
  */
 
-import { escapeMarkdown } from './format.js'
+import { escapeMarkdown, codeSpanSafe } from './format.js'
 
 /**
  * Re-export so card surfaces have one import for the markdown escaper they
  * use when interpolating dynamic values into a hand-built markdown card.
+ * `codeSpanSafe` is the code-span (backtick) counterpart: use it for values
+ * interpolated INSIDE `` `…` `` (where backslash escaping is wrong).
  */
-export { escapeMarkdown }
+export { escapeMarkdown, codeSpanSafe }
 
 /**
  * Join a card's pre-rendered, single-line entries so they STACK in the

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -54,6 +54,24 @@ export function escapeMarkdown(text: string): string {
 }
 
 /**
+ * Make a string safe to interpolate INSIDE a `code span`.
+ *
+ * Inside a GFM code span the content is LITERAL — backslash escaping does
+ * NOT apply, so `escapeMarkdown` is exactly wrong there: it emits visible
+ * backslashes (e.g. `openai\_key` for an identifier containing `_`). The
+ * only character that can prematurely CLOSE the span is a backtick, so the
+ * sole transform needed is to defuse embedded backticks. We insert a
+ * zero-width space after each backtick so the raw ``` ` ``` can no longer
+ * terminate the surrounding span while remaining visually identical.
+ *
+ * This is the canonical home for the helper (#2695 regression fix); other
+ * modules re-export from here so there's one implementation.
+ */
+export function codeSpanSafe(s: string): string {
+  return s.replace(/`/g, '`​')
+}
+
+/**
  * Repair LLM-side JSON escape bungles.
  *
  * Some MCP clients (and some LLM tool-call generators) occasionally emit a

--- a/telegram-plugin/gateway/approval-card.ts
+++ b/telegram-plugin/gateway/approval-card.ts
@@ -14,8 +14,12 @@
  *     param  = (for ttl) 1h | 24h | 7d
  */
 
-import { escapeMarkdown } from '../format.js';
+import { escapeMarkdown, codeSpanSafe } from '../format.js';
 import { InlineKeyboard } from "grammy";
+
+// Re-export so existing importers (e.g. vault-request-access-card.ts) keep
+// resolving `codeSpanSafe` from here; the canonical impl lives in format.ts.
+export { codeSpanSafe };
 
 export interface ApprovalCardOptions {
   request_id: string;       // 8-hex from kernel.requestApproval
@@ -124,11 +128,3 @@ export function ttlMsFromToken(token: string): number | null {
   return null;
 }
 
-/**
- * Make a string safe to interpolate INSIDE a `code span` without escaping
- * (content there is literal). The only character that can prematurely close
- * the span is a backtick, so split it with a zero-width space.
- */
-export function codeSpanSafe(s: string): string {
-  return s.replace(/`/g, "`​");
-}

--- a/telegram-plugin/gateway/approvals-commands.ts
+++ b/telegram-plugin/gateway/approvals-commands.ts
@@ -13,7 +13,7 @@
  * add on top of the same client. Tracked in the migration TODO inline.
  */
 
-import { escapeMarkdown } from '../format.js';
+import { escapeMarkdown, codeSpanSafe } from '../format.js';
 import type { Bot, Context } from "grammy";
 import { richMessage } from "../rich-send.js";
 import {
@@ -78,7 +78,7 @@ export function registerApprovalsCommands(
           return (
             `\`${d.id.slice(0, 8)}\` ` +
             `${escapeMarkdown(d.agent_unit)} → ` +
-            `\`${d.scope}\` ` +
+            `\`${codeSpanSafe(d.scope)}\` ` +
             `(${escapeMarkdown(d.action)}, ${ttl}) ` +
             `· /approvals revoke ${escapeMarkdown(d.id)}`
           );

--- a/telegram-plugin/gateway/auth-command.ts
+++ b/telegram-plugin/gateway/auth-command.ts
@@ -28,7 +28,7 @@
  * rather than throwing.
  */
 
-import { escapeMarkdown } from '../format.js'
+import { escapeMarkdown, codeSpanSafe } from '../format.js'
 import type { ListStateData, AccountState } from './auth-line.js'
 import {
   buildSnapshotsFromState,
@@ -159,7 +159,7 @@ export function parseAuthCommand(text: string): ParsedAuthCommand | null {
       if (tail.length > 0) {
         return {
           kind: 'help',
-          reason: `Unknown \`rm\` modifier: \`${escapeMarkdown(tail)}\`. Use \`/auth rm <label> confirm\` to confirm.`,
+          reason: `Unknown \`rm\` modifier: \`${codeSpanSafe(tail)}\`. Use \`/auth rm <label> confirm\` to confirm.`,
         }
       }
       return { kind: 'rm-prompt', label }
@@ -181,7 +181,7 @@ export function parseAuthCommand(text: string): ParsedAuthCommand | null {
       if (sub !== 'override') {
         return {
           kind: 'help',
-          reason: `Unknown \`agent\` subcommand: \`${escapeMarkdown(sub || '(none)')}\`. Try \`/auth agent override <agent> <label|clear>\`.`,
+          reason: `Unknown \`agent\` subcommand: \`${codeSpanSafe(sub || '(none)')}\`. Try \`/auth agent override <agent> <label|clear>\`.`,
         }
       }
       const agent = parts[2]
@@ -202,7 +202,7 @@ export function parseAuthCommand(text: string): ParsedAuthCommand | null {
     case 'help':
       return { kind: 'help' }
     default:
-      return { kind: 'help', reason: `Unknown verb: \`${escapeMarkdown(verb)}\`` }
+      return { kind: 'help', reason: `Unknown verb: \`${codeSpanSafe(verb)}\`` }
   }
 }
 
@@ -433,7 +433,7 @@ export async function handleAuthCommand(
       if (!agent) {
         return {
           text:
-            `**/auth show:** no agent named \`${escapeMarkdown(agentName)}\` in broker view.\n` +
+            `**/auth show:** no agent named \`${codeSpanSafe(agentName)}\` in broker view.\n` +
             `Run \`/auth show\` for the fleet snapshot.`,
           html: true,
         }
@@ -477,7 +477,7 @@ export async function handleAuthCommand(
       const result = await ctx.client.setActive(parsed.label)
       return {
         text:
-          `**Active account →** \`${escapeMarkdown(result.active)}\`\n` +
+          `**Active account →** \`${codeSpanSafe(result.active)}\`\n` +
           `Re-mirrored credentials for ${result.fanned.length} agent${result.fanned.length === 1 ? '' : 's'}.`,
         html: true,
       }
@@ -505,7 +505,7 @@ export async function handleAuthCommand(
       const result = await ctx.client.setActive(nextLabel)
       return {
         text:
-          `**Rotated:** active → \`${escapeMarkdown(result.active)}\`\n` +
+          `**Rotated:** active → \`${codeSpanSafe(result.active)}\`\n` +
           `Re-mirrored credentials for ${result.fanned.length} agent${result.fanned.length === 1 ? '' : 's'}.`,
         html: true,
       }
@@ -534,7 +534,7 @@ export async function handleAuthCommand(
     if (!exists) {
       return {
         text:
-          `**/auth rm:** no account named \`${escapeMarkdown(parsed.label)}\`. ` +
+          `**/auth rm:** no account named \`${codeSpanSafe(parsed.label)}\`. ` +
           `Run \`/auth show\` for the current list.`,
         html: true,
       }
@@ -542,7 +542,7 @@ export async function handleAuthCommand(
     if (state.active === parsed.label) {
       return {
         text:
-          `**/auth rm refused.** \`${escapeMarkdown(parsed.label)}\` is the fleet active. ` +
+          `**/auth rm refused.** \`${codeSpanSafe(parsed.label)}\` is the fleet active. ` +
           `Switch with \`/auth use <other>\` or \`/auth rotate\` first.`,
         html: true,
       }
@@ -561,9 +561,9 @@ export async function handleAuthCommand(
     }
     return {
       text:
-        `**⚠ /auth rm** — about to remove \`${escapeMarkdown(parsed.label)}\` from the broker.\n` +
-        `The fleet active is unchanged. Any agent override pointing at \`${escapeMarkdown(parsed.label)}\` will stop working.\n\n` +
-        `Send \`/auth rm ${escapeMarkdown(parsed.label)} confirm\` within ${Math.round(
+        `**⚠ /auth rm** — about to remove \`${codeSpanSafe(parsed.label)}\` from the broker.\n` +
+        `The fleet active is unchanged. Any agent override pointing at \`${codeSpanSafe(parsed.label)}\` will stop working.\n\n` +
+        `Send \`/auth rm ${codeSpanSafe(parsed.label)} confirm\` within ${Math.round(
           AUTH_RM_CONFIRM_TTL_MS / 1000,
         )}s to proceed.`,
       html: true,
@@ -579,8 +579,8 @@ export async function handleAuthCommand(
       }
       return {
         text:
-          `**/auth rm:** no pending confirm for \`${escapeMarkdown(parsed.label)}\` (expired or not started). ` +
-          `Send \`/auth rm ${escapeMarkdown(parsed.label)}\` first.`,
+          `**/auth rm:** no pending confirm for \`${codeSpanSafe(parsed.label)}\` (expired or not started). ` +
+          `Send \`/auth rm ${codeSpanSafe(parsed.label)}\` first.`,
         html: true,
       }
     }
@@ -590,7 +590,7 @@ export async function handleAuthCommand(
     try {
       const data = await ctx.client.rmAccount(parsed.label)
       return {
-        text: `**Removed** \`${escapeMarkdown(data.label)}\` from the broker.`,
+        text: `**Removed** \`${codeSpanSafe(data.label)}\` from the broker.`,
         html: true,
       }
     } catch (err) {
@@ -610,7 +610,7 @@ export async function handleAuthCommand(
       if (parsed.label && targets.length === 0) {
         return {
           text:
-            `**/auth refresh:** no account named \`${escapeMarkdown(parsed.label)}\`.`,
+            `**/auth refresh:** no account named \`${codeSpanSafe(parsed.label)}\`.`,
           html: true,
         }
       }
@@ -636,7 +636,7 @@ export async function handleAuthCommand(
       }
       const head =
         targets.length === 1
-          ? `**Refreshed** \`${escapeMarkdown(targets[0]!)}\``
+          ? `**Refreshed** \`${codeSpanSafe(targets[0]!)}\``
           : `**Refreshed** ${rows.length - 1}/${targets.length} account${targets.length === 1 ? '' : 's'}`
       const table = rows.length > 1
         ? "\n```\n" + alignTable(rows) + "\n```"
@@ -658,8 +658,8 @@ export async function handleAuthCommand(
       const data = await ctx.client.setOverride(parsed.agent, parsed.label)
       return {
         text:
-          `**Override set.** \`${escapeMarkdown(data.agent)}\` is now pinned to ` +
-          `\`${escapeMarkdown(data.account ?? parsed.label)}\`.`,
+          `**Override set.** \`${codeSpanSafe(data.agent)}\` is now pinned to ` +
+          `\`${codeSpanSafe(data.account ?? parsed.label)}\`.`,
         html: true,
       }
     } catch (err) {
@@ -675,7 +675,7 @@ export async function handleAuthCommand(
       const data = await ctx.client.setOverride(parsed.agent, null)
       return {
         text:
-          `**Override cleared** on \`${escapeMarkdown(data.agent)}\` ` +
+          `**Override cleared** on \`${codeSpanSafe(data.agent)}\` ` +
           `— back to fleet active.`,
         html: true,
       }
@@ -913,7 +913,7 @@ export function renderAgentDetail(
   lines.push(`**${escapeMarkdown(agent.name)}**`)
   const source = agent.override ? 'override' : 'fleet-active'
   lines.push(
-    `Active account: \`${escapeMarkdown(agent.account)}\` (${source})`,
+    `Active account: \`${codeSpanSafe(agent.account)}\` (${source})`,
   )
   const acct = state.accounts.find((a) => a.label === agent.account)
   if (acct) {

--- a/telegram-plugin/quota-watch.ts
+++ b/telegram-plugin/quota-watch.ts
@@ -51,7 +51,7 @@ import {
   fmtPct,
 } from "./auth-snapshot-format.js";
 import type { QuotaUtilization } from "./quota-check.js";
-import { escapeMarkdown } from "./card-format.js";
+import { escapeMarkdown, codeSpanSafe } from "./card-format.js";
 
 const STATE_FILE = "quota-watch.json";
 
@@ -512,7 +512,7 @@ function buildFleetRecoveredMessage(
   accounts: Array<{ label: string; exhausted: boolean }>,
 ): string {
   const healthy = accounts.filter((a) => !a.exhausted).map((a) => a.label);
-  const which = healthy.length > 0 ? ` (\`${escapeMarkdown(healthy[0]!)}\`)` : "";
+  const which = healthy.length > 0 ? ` (\`${codeSpanSafe(healthy[0]!)}\`)` : "";
   return [
     `🟢 **Fleet recovered** — at least one account is healthy again${which}.`,
     ``,
@@ -522,7 +522,7 @@ function buildFleetRecoveredMessage(
 
 // ─── Message builders ─────────────────────────────────────────────────────────
 
-function buildThrottlingMessage(agentName: string, snap: AccountSnapshot): string {
+export function buildThrottlingMessage(agentName: string, snap: AccountSnapshot): string {
   const q = snap.quota!; // classifyHealth returned throttling, so quota is non-null
   const fiveStr = fmtPct(q.fiveHourUtilizationPct);
   const sevenStr = fmtPct(q.sevenDayUtilizationPct);
@@ -536,14 +536,14 @@ function buildThrottlingMessage(agentName: string, snap: AccountSnapshot): strin
 
   const activeNote = snap.isActive
     ? ""
-    : `\nThis is a non-active account. Consider \`/auth use ${escapeMarkdown(snap.label)}\` to switch, or keep it as a fallback reserve.`;
+    : `\nThis is a non-active account. Consider \`/auth use ${codeSpanSafe(snap.label)}\` to switch, or keep it as a fallback reserve.`;
 
   const altNote = snap.isActive
     ? `\nConsider \`/auth use <other-account>\` if you have a healthier account, or wait for the ${winLabel} window to refill${resetStr}.`
     : "";
 
   return [
-    `🟡 **Quota approaching limit** — \`${escapeMarkdown(snap.label)}\``,
+    `🟡 **Quota approaching limit** — \`${codeSpanSafe(snap.label)}\``,
     ``,
     `${fiveStr} of 5h  ·  ${sevenStr} of 7d`,
     `Binding window: ${winLabel}${resetStr}`,
@@ -557,14 +557,14 @@ function buildThrottlingMessage(agentName: string, snap: AccountSnapshot): strin
     .trim();
 }
 
-function buildRecoveryMessage(agentName: string, snap: AccountSnapshot): string {
+export function buildRecoveryMessage(agentName: string, snap: AccountSnapshot): string {
   const q = snap.quota;
   const utilLine = q
     ? `Current: ${fmtPct(q.fiveHourUtilizationPct)} of 5h  ·  ${fmtPct(q.sevenDayUtilizationPct)} of 7d`
     : "Current quota data unavailable.";
 
   return [
-    `🟢 **Quota back in healthy range** — \`${escapeMarkdown(snap.label)}\``,
+    `🟢 **Quota back in healthy range** — \`${codeSpanSafe(snap.label)}\``,
     ``,
     utilLine,
     ``,

--- a/telegram-plugin/tests/auth-command-vernacular.test.ts
+++ b/telegram-plugin/tests/auth-command-vernacular.test.ts
@@ -141,19 +141,21 @@ describe('parseAuthCommand — new verbs', () => {
   })
 
   // Boundary-escaping (#2695 escaper de-dup): the help/reason strings now
-  // escape dynamic user input via the consolidated `escapeMarkdown` import.
-  // A metacharacter-laden verb must come back backslash-escaped, proving the
-  // import swap preserved escaping at this call-site.
-  it('escapes a metacharacter-laden unknown verb in the help reason', () => {
+  // render dynamic user input via `codeSpanSafe` — the reason interpolates the
+  // value INSIDE a `code span`, where backslash escaping is wrong (#2695). A
+  // metacharacter-laden verb must come back LITERAL (no stray backslashes).
+  it('renders a metacharacter-laden unknown verb literally in the code span', () => {
     const p = parseAuthCommand('/auth a_b*c')
     expect(p?.kind).toBe('help')
-    expect((p as { reason?: string }).reason).toContain('a\\_b\\*c')
+    expect((p as { reason?: string }).reason).toContain('`a_b*c`')
+    expect((p as { reason?: string }).reason).not.toContain('a\\_b\\*c')
   })
 
-  it('escapes a metacharacter-laden rm modifier in the help reason', () => {
+  it('renders a metacharacter-laden rm modifier literally in the code span', () => {
     const p = parseAuthCommand('/auth rm spare x_y*z')
     expect(p?.kind).toBe('help')
-    expect((p as { reason?: string }).reason).toContain('x\\_y\\*z')
+    expect((p as { reason?: string }).reason).toContain('`x_y*z`')
+    expect((p as { reason?: string }).reason).not.toContain('x\\_y\\*z')
   })
 
   it('rejects /auth rm with no label', () => {

--- a/telegram-plugin/tests/auth-snapshot-format.test.ts
+++ b/telegram-plugin/tests/auth-snapshot-format.test.ts
@@ -504,11 +504,14 @@ describe('renderFallbackAnnouncement', () => {
     expect(out7).toContain('7-day limit on me@x');
   });
 
-  // Boundary-escaping after the #2695 escaper de-dup: the announcement escapes
-  // dynamic labels + the trigger agent via the consolidated `escapeMarkdown`
-  // import (was a local `escapeHtml` copy). Metacharacter-laden values must come
-  // back backslash-escaped, proving the import swap preserved escaping here.
-  it('escapes metacharacter-laden labels and trigger agent in the swap announcement (#2695)', () => {
+  // Context-correct escaping (#2695 fix): the swap announcement renders each
+  // label in TWO contexts, and each demands a different treatment —
+  //  • **bold** header / trigger-agent → escapeMarkdown (backslash-escaped, so
+  //    an underscore can't open an emphasis run), and
+  //  • `code span` (the old→new line, recovery line) → codeSpanSafe (LITERAL,
+  //    because backslash escaping is inert inside a code span and would show a
+  //    visible `old\_a\*x`).
+  it('escapes labels in the bold header but renders them literally in code spans (#2695)', () => {
     const out = renderFallbackAnnouncement({
       oldLabel: 'old_a*x',
       oldQuota: KEN_5H_BLOWN,
@@ -518,12 +521,14 @@ describe('renderFallbackAnnouncement', () => {
       now: NOW,
       tz: 'UTC',
     });
-    expect(out).toContain('old\\_a\\*x');
-    expect(out).toContain('new\\_b\\*y');
-    expect(out).toContain('agent\\_z\\*q');
-    // And the raw (unescaped) forms must NOT leak through.
-    expect(out).not.toContain('old_a*x');
-    expect(out).not.toContain('agent_z*q');
+    // Emphasis contexts: backslash-escaped.
+    expect(out).toContain('old\\_a\\*x'); // bold header "· … on old_a*x"
+    expect(out).toContain('agent\\_z\\*q'); // "Triggered by: agent **…**"
+    // Code-span contexts: literal, no stray backslash.
+    expect(out).toContain('`old_a*x`');
+    expect(out).toContain('`new_b*y`');
+    expect(out).not.toContain('`old\\_a\\*x`');
+    expect(out).not.toContain('`new\\_b\\*y`');
   });
 
   it('names the triggering agent + recovery countdown for the old account', () => {

--- a/telegram-plugin/tests/codespan-escaping-golden.test.ts
+++ b/telegram-plugin/tests/codespan-escaping-golden.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Golden regression tests for GFM code-span escaping (#2695 / #2701).
+ *
+ * Inside a GFM inline code span (`` `…` ``) content is LITERAL — backslash
+ * escaping does NOT apply. #2695 renamed `escapeHtml`→`escapeMarkdown`
+ * blindly across the auth/quota/usage surfaces, so identifiers containing
+ * `_ * ~ [ ] | =` were rendered with visible backslashes inside code spans
+ * (e.g. `openai\_key` instead of `openai_key`), and the /usage table cell
+ * corrupted the row when a label carried a `_`/`*`.
+ *
+ * These goldens are the ONLY guard for this class of bug: the rendered
+ * rich-message content isn't observable through the mtcute UAT harness
+ * (it can't read message text formatting), so a unit assertion on the
+ * exact string is the regression fence. If any of these re-introduce a
+ * stray backslash before an identifier char inside a code span, they fail.
+ */
+import { describe, it, expect } from 'vitest';
+import { codeSpanSafe, escapeMarkdown } from '../format.js';
+import {
+  renderAuthSnapshotFormat2,
+  renderFallbackAnnouncement,
+  type AccountSnapshot,
+} from '../auth-snapshot-format.js';
+import {
+  buildThrottlingMessage,
+  buildRecoveryMessage,
+} from '../quota-watch.js';
+import type { QuotaUtilization } from '../quota-check.js';
+
+const NOW = new Date('2026-05-15T00:53:00Z');
+
+// Two representative payloads that broke under escapeMarkdown-in-code-span:
+// an email/label with an underscore, and a vault-key-shaped secret ref.
+const LABEL_UNDERSCORE = 'ken_max';
+const SECRET_REF = 'secret:OPENAI_API_KEY';
+
+function quota(part: Partial<QuotaUtilization>): QuotaUtilization {
+  return {
+    fiveHourUtilizationPct: 0,
+    sevenDayUtilizationPct: 0,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+    representativeClaim: null,
+    overageStatus: null,
+    overageDisabledReason: null,
+    ...part,
+  };
+}
+
+function snap(part: Partial<AccountSnapshot>): AccountSnapshot {
+  return {
+    label: 'unset@example.com',
+    isActive: false,
+    quota: null,
+    ...part,
+  };
+}
+
+/**
+ * Assert `value` renders LITERALLY inside a code span somewhere in `rendered`:
+ *  - the exact `` `value` `` span is present, and
+ *  - no backslash-escaped variant of the value leaked (no `\_`, `\*`, etc.).
+ */
+function expectLiteralInCodeSpan(rendered: string, value: string) {
+  expect(rendered).toContain('`' + value + '`');
+  // The buggy output would be `` `secret:OPENAI\_API\_KEY` `` — assert no
+  // backslash immediately precedes any char of the value's active set.
+  const escaped = escapeMarkdown(value);
+  if (escaped !== value) {
+    // escapeMarkdown would have produced a different (backslashed) string;
+    // that exact string must NOT appear.
+    expect(rendered).not.toContain('`' + escaped + '`');
+  }
+  // Belt-and-suspenders: no stray backslash before an identifier char.
+  expect(rendered).not.toMatch(/\\[_*~=\[\]|]/);
+}
+
+describe('codeSpanSafe helper', () => {
+  it('leaves identifier chars untouched (no backslash)', () => {
+    expect(codeSpanSafe(LABEL_UNDERSCORE)).toBe(LABEL_UNDERSCORE);
+    expect(codeSpanSafe(SECRET_REF)).toBe(SECRET_REF);
+    expect(codeSpanSafe('a_b*c~d=e[f]g|h')).toBe('a_b*c~d=e[f]g|h');
+  });
+
+  it('neutralizes an embedded backtick so it cannot close the span', () => {
+    const out = codeSpanSafe('a`b');
+    // A raw backtick would close the surrounding span; the transform must
+    // insert a separator so `` `${out}` `` cannot be split into two spans.
+    expect(out).not.toBe('a`b');
+    expect(out.startsWith('a`')).toBe(true);
+    // The zero-width space sits right after the backtick.
+    expect(out).toContain('`​');
+  });
+
+  it('escapeMarkdown (the WRONG helper for code spans) would backslash these', () => {
+    // Guards the premise: if someone reverts to escapeMarkdown, the output
+    // differs — proving these goldens actually catch the regression.
+    expect(escapeMarkdown(LABEL_UNDERSCORE)).toBe('ken\\_max');
+    expect(escapeMarkdown(SECRET_REF)).toContain('\\_');
+  });
+});
+
+describe('/auth card — code-span labels render literally (#2695)', () => {
+  it('renders an underscore label literally in the /usage table account cell', () => {
+    const rendered = renderAuthSnapshotFormat2(
+      [snap({ label: LABEL_UNDERSCORE, isActive: true, quota: quota({ fiveHourUtilizationPct: 10, sevenDayUtilizationPct: 20 }) })],
+      { now: NOW },
+    );
+    // The account cell wraps the label (plus the (active) suffix) in a code span.
+    expect(rendered).toContain('`' + LABEL_UNDERSCORE + ' (active)`');
+    expect(rendered).not.toContain('ken\\_max');
+    expect(rendered).not.toMatch(/\\[_*~=\[\]|]/);
+  });
+
+  it('renders a secret-ref-shaped label literally in the account cell', () => {
+    const rendered = renderAuthSnapshotFormat2(
+      [snap({ label: SECRET_REF, quota: quota({ fiveHourUtilizationPct: 5, sevenDayUtilizationPct: 5 }) })],
+      { now: NOW },
+    );
+    expect(rendered).toContain('`' + SECRET_REF + '`');
+    expect(rendered).not.toMatch(/\\[_*~=\[\]|]/);
+  });
+
+  it('renders the label literally in the fallback-announcement code spans', () => {
+    const rendered = renderFallbackAnnouncement({
+      oldLabel: LABEL_UNDERSCORE,
+      newLabel: 'new_acct',
+      triggerAgent: 'clerk',
+      oldQuota: null,
+      newQuota: quota({ fiveHourUtilizationPct: 3, sevenDayUtilizationPct: 4 }),
+      now: NOW,
+    });
+    // Code spans are literal (the fix). The **bold** header legitimately
+    // escapes the label — that is emphasis context, out of scope here — so we
+    // only assert the code-span form, not a global no-backslash rule.
+    expect(rendered).toContain('`' + LABEL_UNDERSCORE + '`');
+    expect(rendered).toContain('`new_acct`');
+    expect(rendered).not.toContain('`ken\\_max`');
+  });
+});
+
+describe('quota card — code-span labels render literally (#2695)', () => {
+  it('throttling card renders an underscore label literally', () => {
+    const rendered = buildThrottlingMessage(
+      'clerk',
+      snap({ label: LABEL_UNDERSCORE, isActive: true, quota: quota({ fiveHourUtilizationPct: 85, sevenDayUtilizationPct: 40 }) }),
+    );
+    expectLiteralInCodeSpan(rendered, LABEL_UNDERSCORE);
+  });
+
+  it('throttling card renders a secret-ref label literally (non-active use hint)', () => {
+    const rendered = buildThrottlingMessage(
+      'clerk',
+      snap({ label: SECRET_REF, isActive: false, quota: quota({ fiveHourUtilizationPct: 90, sevenDayUtilizationPct: 30 }) }),
+    );
+    expectLiteralInCodeSpan(rendered, SECRET_REF);
+  });
+
+  it('recovery card renders an underscore label literally', () => {
+    const rendered = buildRecoveryMessage(
+      'clerk',
+      snap({ label: LABEL_UNDERSCORE, isActive: true, quota: quota({ fiveHourUtilizationPct: 10, sevenDayUtilizationPct: 5 }) }),
+    );
+    expectLiteralInCodeSpan(rendered, LABEL_UNDERSCORE);
+  });
+});

--- a/telegram-plugin/tests/quota-watch.test.ts
+++ b/telegram-plugin/tests/quota-watch.test.ts
@@ -249,11 +249,11 @@ describe("evaluateQuotaWatchAccount — message content", () => {
     expect(d.message).toContain("30%");
   });
 
-  it("throttling message markdown-escapes the account label (#2669)", () => {
-    // The label is interpolated inside a code span — the renderer escapes
-    // inline-markdown specials (\ ` * _ ~ = [ ] |), not HTML entities. A label
-    // with an emphasis special (e.g. an underscore) is backslash-escaped; the
-    // literal `<` / `>` pass through (they are not markdown specials).
+  it("throttling message renders the account label literally in a code span (#2695)", () => {
+    // The label is interpolated INSIDE a `code span`, where content is literal
+    // and backslash escaping is WRONG (#2695 regression: escapeMarkdown here
+    // emitted a visible `ev\_il@…`). The correct rendering is via codeSpanSafe,
+    // so an underscore label appears verbatim with no stray backslash.
     const d = evaluateQuotaWatchAccount({
       agentName: "lawgpt",
       snap: makeSnap("ev_il@example.com", makeQuota(85, 40)),
@@ -262,8 +262,8 @@ describe("evaluateQuotaWatchAccount — message content", () => {
     });
     expect(d.kind).toBe("notify");
     if (d.kind !== "notify") return;
-    // The underscore is escaped so it can't open an italic run inside the span.
-    expect(d.message).toContain("ev\\_il@example.com");
+    expect(d.message).toContain("`ev_il@example.com`");
+    expect(d.message).not.toContain("ev\\_il@example.com");
   });
 
   it("throttling message for active account mentions /auth use", () => {


### PR DESCRIPTION
## Summary

`#2695` renamed `escapeHtml`→`escapeMarkdown` blindly across the auth/quota/usage Telegram surfaces. Inside a GFM **inline code span** (`` `…` ``) content is LITERAL — backslash escaping is inert — so `` `${escapeMarkdown(x)}` `` emitted **visible backslashes** for any identifier containing `_ * ~ [ ] | =` (e.g. a user saw `openai\_key`, `ken\_max`). The same commit added the correct helper `codeSpanSafe()` in `gateway/approval-card.ts` and fixed only that file.

This PR routes every value that is *genuinely inside a code span* through `codeSpanSafe`, leaves emphasis/`**bold**` escaping on `escapeMarkdown` (correct there), fixes the `/usage` table row corruption (`#2701`), consolidates the duplicate helper, hardens it against an embedded backtick, and adds golden unit tests.

Serves job: **subscription/quota + auth status surfaces render honestly** (visibility outcome — the status the user reads must be the truth, not littered with escape artifacts). Crosses no invariant.

## Callsites touched (only values genuinely inside a `code span`)

**`telegram-plugin/auth-snapshot-format.ts`** (`escapeMarkdown`→`codeSpanSafe`):
- `renderAccountRow`: account label in `` `…` `` — probe-failed line, thin-probe line, util line.
- `renderFallbackAnnouncement`: earliest-recovery label, `old → new` line (both), old-recovers line, new-account util line.
- **`/usage` table (#2701)**: the account cell now wraps the label in a code span (`` `${codeSpanSafe(label)} (active)` ``) matching the pre-table `renderAccountRow`, then `tableCell`-guards the grid. `tableCell` escapes only `\ | \n`, so a `_`/`*` label previously parsed as emphasis and corrupted the row. `pctCells`/status left unchanged (numeric / prose).
- Emphasis contexts left on `escapeMarkdown`: bold header (`· … on <label>`), `Triggered by: agent **…**`.

**`telegram-plugin/gateway/auth-command.ts`** (`escapeMarkdown`→`codeSpanSafe`): unknown `rm` modifier, unknown `agent` subcommand, unknown verb, `no agent named`, `Active account →`, `Rotated: active →`, `no account named` (rm), `rm refused` label, rm-confirm block (3 spans), no-pending-confirm block (2 spans), `Removed`, refresh `no account named`, `Refreshed <label>`, override-set (2 spans), override-cleared, `renderAgentDetail` active-account line. `**… failed:** ${err}` error lines and `**<name>**` headers left on `escapeMarkdown`. The three `alignTable` values (856/896/952) are inside ``` fenced blocks (separate over-escaping concern) — **left untouched** to keep scope tight.

**`telegram-plugin/quota-watch.ts`** (`escapeMarkdown`→`codeSpanSafe`): fleet-recovered label, throttling `/auth use <label>` hint, throttling header label, recovery header label. (Also exported `buildThrottlingMessage`/`buildRecoveryMessage` for the golden tests.)

**`telegram-plugin/gateway/approvals-commands.ts`**: the scope code span now uses `codeSpanSafe(d.scope)` (was a raw interpolation that a backtick could break out of). Its `escapeMarkdown` uses (agent name bold, plain-text `→`/`revoke` lines) are not in code spans and are left as-is.

**Helper consolidation + hardening:**
- Canonical `codeSpanSafe` now lives in `telegram-plugin/format.ts`, re-exported from `card-format.ts` and `gateway/approval-card.ts` (so `vault-request-access-card.ts` still resolves it). Removed the duplicate definition in `approval-card.ts`.
- Hardened: `codeSpanSafe` neutralizes an embedded backtick (inserts a zero-width space after it) so a raw `` ` `` can't prematurely close the surrounding span.
- (The local, already-correct `codeSpanSafe` in `secret-detect/vault-error.ts` was left as-is — self-contained, out of the listed scope.)

## Tests

New `telegram-plugin/tests/codespan-escaping-golden.test.ts` — golden goldens asserting `ken_max` and `secret:OPENAI_API_KEY` render **literally** (no stray backslash, no breakout) through the `/auth` card, quota throttling/recovery cards, and the `/usage` table. Also pins the backtick-hardening and proves `escapeMarkdown` (the wrong helper) would differ — so the goldens actually catch a revert.

Two pre-existing tests corrected from asserting the buggy backslash output *inside code spans* to the literal form: `auth-command-vernacular.test.ts` (unknown verb / rm modifier reasons) and `quota-watch.test.ts` (#2669 throttling label). `auth-snapshot-format.test.ts`'s swap-announcement test now asserts BOTH behaviors — escaped in the bold header, literal in the code spans.

## Test plan

- [x] `tsc --noEmit` (plugin tsconfig) — clean
- [x] `bun test telegram-plugin/tests/` — **5298 pass, 0 fail** (319 files)
- [ ] CI (`lint`, `bun-test`, `vitest`, builds)

Note: the local `check-plugin-references.mjs` reports 63 tsc errors in this worktree — all pre-existing env artifacts (missing `@mtcute/node` + grammy augmentation types in the symlinked donor `node_modules`); identical count with my changes stashed. CI has a proper install.

## Risk

Low. Pure string-rendering change on status surfaces; no behavior/state change. Emphasis escaping untouched. `parse_mode` in `answer-stream.ts` deliberately NOT touched (separate decision). Fenced-table over-escaping (`alignTable`) is a known separate concern left for a follow-up.