### PR TITLE
fix(telegram): close status-pin persist-after-pin leak window

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -87,6 +87,7 @@ import { DeferredDoneReactions } from '../reaction-defer.js'
 import { createWorkerActivityFeed, isWorkerActivityFeedEnabled } from '../worker-activity-feed.js'
 import { reconcilePin, type PinBotApi } from '../status-pin-driver.js'
 import type { PinState, DesiredPin } from '../status-pin.js'
+import { decidePinAction } from '../status-pin.js'
 import { formatTurnLifecycle, detectStatusSurfaceDegraded } from './status-surface-log.js'
 import { parseSourceMessageId } from './source-message-id.js'
 import {
@@ -372,10 +373,11 @@ import {
 import { loadObligations, persistObligations } from './obligation-store.js'
 import {
   loadStatusPins,
-  persistStatusPins,
   pinnedMessageIsOurs,
+  reconcileAndPersistStatusPin,
   runStatusPinBootCleanup,
   type PersistedStatusPin,
+  type StatusPinPersistOp,
   type TrackedStatusPin,
 } from './status-pin-store.js'
 import { driveEscalation } from './escalation-drive.js'
@@ -5624,17 +5626,22 @@ const statusPinStoreFs = {
 }
 const statusPinPersistEnabled = !STATIC && PIN_STATUS_WHILE_WORKING
 
-// Snapshot the live claim set and write it through. Called on every reconcile
-// (pin/unpin) so the on-disk set always mirrors the in-memory Maps.
-function persistStatusPinSnapshot(): void {
-  if (!statusPinPersistEnabled) return
+// The full live claim set as persisted rows (confirmed pins), from the Maps.
+function snapshotStatusPins(): PersistedStatusPin[] {
   const snapshot: PersistedStatusPin[] = []
   for (const [pinKey, state] of statusPinState) {
     const chatId = statusPinChatIds.get(pinKey)
     if (chatId == null) continue
     snapshot.push({ pinKey, chatId, messageId: state.messageId })
   }
-  persistStatusPins(STATUS_PIN_STORE_PATH, statusPinStoreFs, snapshot)
+  return snapshot
+}
+
+// The live claim set EXCLUDING one key — used by reconcileAndPersistStatusPin so
+// it can rewrite the whole set atomically while it flips that one key's record
+// between pending / confirmed / absent.
+function snapshotStatusPinsExcept(exceptKey: string): PersistedStatusPin[] {
+  return snapshotStatusPins().filter((p) => p.pinKey !== exceptKey)
 }
 
 // The Bot API surface the pin driver needs. `lockedBot` is defined later; wrap
@@ -5701,17 +5708,57 @@ async function reconcileStatusPin(
   if (!PIN_STATUS_WHILE_WORKING) return
   if (chatId.length === 0) return
   const prev = statusPinState.get(pinKey) ?? null
-  const next = await reconcilePin({
-    api: statusPinApi(),
+
+  const runReconcile = () =>
+    reconcilePin({
+      api: statusPinApi(),
+      chatId,
+      prevState: prev,
+      desired,
+      onError: (phase, err) => {
+        const msg = err instanceof Error ? err.message : String(err)
+        process.stderr.write(
+          `telegram gateway: status-pin ${phase} failed (key=${pinKey} chat=${chatId}): ${msg}\n`,
+        )
+      },
+    })
+
+  // Classify the action so we persist INTENT before the pin API call. Only a
+  // fresh `pin` of a message that isn't already our claim opens the leak window
+  // (the API call actually pins something new); everything else (unpin, noop,
+  // re-pin of the same id) clears / leaves the record and is safe to persist
+  // after. See reconcileAndPersistStatusPin for the ordering rationale.
+  const action = decidePinAction(prev, desired)
+  const op: StatusPinPersistOp =
+    action.kind === 'pin'
+      ? { kind: 'pin', messageId: action.messageId }
+      : { kind: 'clear' }
+
+  if (!statusPinPersistEnabled) {
+    // Persistence off (STATIC / feature-off): just reconcile + update Maps.
+    const next = await runReconcile()
+    if (next == null) {
+      statusPinState.delete(pinKey)
+      statusPinChatIds.delete(pinKey)
+    } else {
+      statusPinState.set(pinKey, next)
+      statusPinChatIds.set(pinKey, chatId)
+    }
+    return
+  }
+
+  // Persist-BEFORE-pin ordering lives in reconcileAndPersistStatusPin: for a
+  // pin it writes a `pending` record first, then confirms it after the API call
+  // lands (or drops it on failure). A crash in the window leaves a pending
+  // record boot cleanup will unpin. In-memory Maps are updated from the result.
+  const next = await reconcileAndPersistStatusPin({
+    path: STATUS_PIN_STORE_PATH,
+    fs: statusPinStoreFs,
+    pinKey,
     chatId,
-    prevState: prev,
-    desired,
-    onError: (phase, err) => {
-      const msg = err instanceof Error ? err.message : String(err)
-      process.stderr.write(
-        `telegram gateway: status-pin ${phase} failed (key=${pinKey} chat=${chatId}): ${msg}\n`,
-      )
-    },
+    op,
+    snapshotOthers: () => snapshotStatusPinsExcept(pinKey),
+    applyPin: runReconcile,
   })
   if (next == null) {
     statusPinState.delete(pinKey)
@@ -5720,10 +5767,6 @@ async function reconcileStatusPin(
     statusPinState.set(pinKey, next)
     statusPinChatIds.set(pinKey, chatId)
   }
-  // Mirror the mutation to disk (pin → present, unpin → removed) so a crash
-  // before the next unpin can't strand the pin — boot cleanup unpins whatever
-  // survives here. Wired exactly like obligationStore's onChange.
-  persistStatusPinSnapshot()
 }
 
 /**

--- a/telegram-plugin/gateway/status-pin-store.ts
+++ b/telegram-plugin/gateway/status-pin-store.ts
@@ -35,15 +35,33 @@ export interface StatusPinStoreFsSeam {
 }
 
 /** One persisted pin claim: the pinKey, the chat it lives in, and the pinned
- *  message id (so boot cleanup can unpin exactly that message). */
+ *  message id (so boot cleanup can unpin exactly that message).
+ *
+ *  Concurrency note: there is NO turn/worker-id dimension on the ownership guard
+ *  because the single-gateway startup mutex (acquireStartupLock) guarantees
+ *  exactly one live gateway per agent owns this shared file at a time — so a
+ *  pinKey (`fg:`/`wk:`) is unambiguous within the one owning process, and boot
+ *  cleanup only ever runs after winning that mutex.
+ *
+ *  `pending` marks a record written BEFORE the pin API call landed (persist-
+ *  intent-first). A crash in the window between the pin API call and the
+ *  confirming rewrite leaves a pending record on disk; next-boot cleanup unpins
+ *  pending records too, closing the persist-after-pin leak. Absent/false means
+ *  the pin was confirmed applied. Optional so a v1 snapshot (no field) still
+ *  loads fail-open as a confirmed pin. */
 export interface PersistedStatusPin {
   pinKey: string
   chatId: string
   messageId: number
+  /** True while the pin API call is in-flight / unconfirmed (see above). */
+  pending?: boolean
 }
 
+/** Envelope version. v1 had no `pending` field; a v1 row loads as a confirmed
+ *  pin (pending undefined). v2 adds the optional `pending` flag. Both load
+ *  fail-open — an unknown/newer version yields []. */
 interface SnapshotEnvelope {
-  v: 1
+  v: 1 | 2
   pins: PersistedStatusPin[]
 }
 
@@ -55,7 +73,8 @@ function isPinRow(x: unknown): x is PersistedStatusPin {
     o.pinKey.length > 0 &&
     typeof o.chatId === 'string' &&
     o.chatId.length > 0 &&
-    typeof o.messageId === 'number'
+    typeof o.messageId === 'number' &&
+    (o.pending === undefined || typeof o.pending === 'boolean')
   )
 }
 
@@ -84,7 +103,7 @@ export function loadStatusPins(
   }
   if (parsed == null || typeof parsed !== 'object') return []
   const env = parsed as Record<string, unknown>
-  if (env.v !== 1 || !Array.isArray(env.pins)) return []
+  if ((env.v !== 1 && env.v !== 2) || !Array.isArray(env.pins)) return []
   return env.pins.filter(isPinRow)
 }
 
@@ -100,7 +119,7 @@ export function persistStatusPins(
   snapshot: readonly PersistedStatusPin[],
   log: (line: string) => void = (l) => process.stderr.write(l),
 ): void {
-  const env: SnapshotEnvelope = { v: 1, pins: [...snapshot] }
+  const env: SnapshotEnvelope = { v: 2, pins: [...snapshot] }
   const tmp = path + '.tmp'
   try {
     fs.writeFileSync(tmp, JSON.stringify(env))
@@ -152,10 +171,15 @@ export function pinnedMessageIsOurs(
  * (the gateway's thin wrapper just binds the live fs / unpin api / logger).
  *
  * Any pin persisted by a PRIOR session is stale by definition — its turn ended
- * or the session crashed before its unpin reconcile ran. We best-effort unpin
- * each persisted entry (a failure is non-fatal) and then EMPTY the store
- * regardless, so a permanently-undeliverable unpin can't re-run on every boot.
- * We do NOT re-adopt or re-pin. Returns the counts for logging/testing.
+ * or the session crashed before its unpin reconcile ran. This includes records
+ * left `pending` (the persist-intent-first write from `reconcileAndPersist-
+ * StatusPin`): a crash between the pin API call and its confirming rewrite
+ * leaves a pending record whose pin MAY have landed in Telegram, so we must
+ * treat it exactly like a confirmed one and unpin it. We therefore best-effort
+ * unpin EVERY persisted entry (confirmed and pending alike — a failure is
+ * non-fatal) and then EMPTY the store regardless, so a permanently-
+ * undeliverable unpin can't re-run on every boot. We do NOT re-adopt or re-pin.
+ * Returns the counts for logging/testing.
  *
  * CRITICAL: the caller MUST only invoke this AFTER winning the startup mutex.
  * The store is a shared per-agent file; on a double-boot a losing gateway
@@ -186,4 +210,93 @@ export async function runStatusPinBootCleanup(args: {
   // them would re-attempt the same (already-tried) unpins on every future boot.
   persistStatusPins(args.path, args.fs, [], log)
   return { cleared, total: persisted.length }
+}
+
+/**
+ * The pin action the gateway wants to take for one key, distilled from
+ * `decidePinAction`. `pin` carries the target message id; `clear` covers both
+ * unpin and no-longer-pinned. The gateway's reconcile computes this and hands
+ * it here so the persist-BEFORE-pin ordering lives in one testable place.
+ */
+export type StatusPinPersistOp =
+  | { kind: 'pin'; messageId: number }
+  | { kind: 'clear' }
+
+/**
+ * Persist-ordering wrapper closing the persist-AFTER-pin leak window.
+ *
+ * THE BUG this fixes: previously the gateway pinned the Telegram message FIRST,
+ * then snapshotted the claim set to disk. A SIGKILL landing between the pin API
+ * call succeeding and the snapshot rename left a pin live in Telegram with NO
+ * on-disk record — so next-boot cleanup couldn't see it and the pin lingered
+ * forever.
+ *
+ * THE FIX: for a `pin`, write a `pending` record to disk BEFORE issuing the pin
+ * API call, then rewrite it as confirmed (pending cleared) once the pin lands
+ * — or drop it if the pin failed. Now a crash anywhere in the window leaves a
+ * pending record on disk, and boot cleanup unpins pending records too (see
+ * runStatusPinBootCleanup), so the orphan is recovered next boot.
+ *
+ * `snapshotOthers` returns the OTHER live claims (every key except `pinKey`) so
+ * the whole set is rewritten atomically each step — mirrors how the gateway
+ * snapshots its Map. `applyPin` performs the real Telegram pin/unpin (the
+ * gateway binds `reconcilePin`) and returns the next in-memory state so the
+ * caller can update its Map. Never throws — persistence is best-effort/fail-open
+ * and pin errors are already swallowed by `applyPin` (reconcilePin).
+ */
+export async function reconcileAndPersistStatusPin(args: {
+  path: string
+  fs: StatusPinStoreFsSeam
+  pinKey: string
+  chatId: string
+  op: StatusPinPersistOp
+  /** Live claims for every OTHER key (rewritten alongside on each step). */
+  snapshotOthers: () => PersistedStatusPin[]
+  /** Execute the real pin/unpin; returns the confirmed message id (pin) or
+   *  null (cleared). Must never throw — API errors are swallowed inside. */
+  applyPin: () => Promise<{ messageId: number } | null>
+  log?: (line: string) => void
+}): Promise<{ messageId: number } | null> {
+  const { path, fs, pinKey, chatId, op } = args
+  const log = args.log ?? ((l: string) => process.stderr.write(l))
+
+  if (op.kind === 'pin') {
+    // Persist INTENT first, marked pending — BEFORE the pin API call. If we
+    // crash after the pin lands but before the confirm rewrite, this pending
+    // record is what boot cleanup uses to unpin the orphan.
+    persistStatusPins(
+      path,
+      fs,
+      [
+        ...args.snapshotOthers(),
+        { pinKey, chatId, messageId: op.messageId, pending: true },
+      ],
+      log,
+    )
+    const next = await args.applyPin()
+    if (next == null) {
+      // Pin failed (claim NOT taken by reconcilePin). Clear the pending record
+      // so we don't leave a phantom claim for a pin that never landed.
+      persistStatusPins(path, fs, args.snapshotOthers(), log)
+      return null
+    }
+    // Pin confirmed — rewrite the record without the pending flag.
+    persistStatusPins(
+      path,
+      fs,
+      [
+        ...args.snapshotOthers(),
+        { pinKey, chatId, messageId: next.messageId },
+      ],
+      log,
+    )
+    return next
+  }
+
+  // clear: unpin (best-effort) THEN drop the record. Ordering is safe here —
+  // if we crash after the unpin but before the rewrite, the stale record just
+  // gets unpinned again next boot (idempotent), never a lingering pin.
+  const next = await args.applyPin()
+  persistStatusPins(path, fs, args.snapshotOthers(), log)
+  return next
 }

--- a/telegram-plugin/tests/status-pin-boot-recovery.test.ts
+++ b/telegram-plugin/tests/status-pin-boot-recovery.test.ts
@@ -1,0 +1,294 @@
+/**
+ * status-pin boot-recovery — the HEADLINE crash-recovery path, exercised against
+ * the REAL store + reconcile wrapper the gateway wires up (not just the pure
+ * decision fn). It reproduces the full sequence the gateway performs:
+ *
+ *   reconcile a pin → persist (persist-before-pin) → simulate a crash (SKIP the
+ *   clean SIGTERM sweep `unpinAllStatusPins`) → boot a "new gateway" (fresh
+ *   Maps, same on-disk store) → runStatusPinBootCleanup → assert the orphan pin
+ *   is unpinned AND the store is emptied.
+ *
+ * We cannot import gateway.ts directly (its module top-level runs the whole boot
+ * IIFE incl. the startup mutex + bot.start). Instead we model the gateway's
+ * status-pin subsystem faithfully with the SAME functions gateway.ts calls
+ * (reconcileAndPersistStatusPin, reconcilePin, runStatusPinBootCleanup) over an
+ * in-memory fs + a fake Telegram whose pin set we can inspect — so a regression
+ * in the ordering / cleanup contract reds here.
+ *
+ * Two variants:
+ *   (A) confirmed pin → crash before the clean sweep → recovered next boot.
+ *   (B) pending pin (crash INSIDE the persist-after-pin window, Fix 1) →
+ *       recovered next boot.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  loadStatusPins,
+  persistStatusPins,
+  reconcileAndPersistStatusPin,
+  runStatusPinBootCleanup,
+  type PersistedStatusPin,
+  type StatusPinStoreFsSeam,
+} from "../gateway/status-pin-store.js";
+import { reconcilePin } from "../status-pin-driver.js";
+import type { PinState, DesiredPin } from "../status-pin.js";
+import { decidePinAction } from "../status-pin.js";
+
+const PATH = "/state/agent/telegram/status-pins.json";
+
+function memFs(seed: Record<string, string> = {}) {
+  const files = new Map<string, string>(Object.entries(seed));
+  const fs: StatusPinStoreFsSeam = {
+    readFileSync: (p) => {
+      if (!files.has(p)) throw new Error(`ENOENT ${p}`);
+      return files.get(p)!;
+    },
+    writeFileSync: (p, d) => files.set(p, d),
+    renameSync: (a, b) => {
+      if (!files.has(a)) throw new Error(`ENOENT ${a}`);
+      files.set(b, files.get(a)!);
+      files.delete(a);
+    },
+    existsSync: (p) => files.has(p),
+  };
+  return { fs, files };
+}
+
+/** A fake Telegram that records the current pinned message set per chat, so we
+ *  can assert an orphan is left pinned after a crash and unpinned after boot. */
+function fakeTelegram() {
+  const pinned = new Set<string>(); // `${chatId}:${messageId}`
+  return {
+    pinned,
+    api: {
+      pinChatMessage: async (chat_id: string | number, message_id: number) => {
+        pinned.add(`${chat_id}:${message_id}`);
+      },
+      unpinChatMessage: async (chat_id: string | number, message_id: number) => {
+        pinned.delete(`${chat_id}:${message_id}`);
+      },
+    },
+  };
+}
+
+/**
+ * A faithful stand-in for the gateway's status-pin subsystem — the SAME wiring
+ * as gateway.ts's `reconcileStatusPin` / `unpinAllStatusPins` / boot cleanup,
+ * with injectable fs + api so a single test can span a "crash" and a fresh boot.
+ */
+function makeGateway(fs: StatusPinStoreFsSeam, tg: ReturnType<typeof fakeTelegram>) {
+  const statusPinState = new Map<string, PinState>();
+  const statusPinChatIds = new Map<string, string>();
+
+  const snapshotExcept = (exceptKey: string): PersistedStatusPin[] => {
+    const out: PersistedStatusPin[] = [];
+    for (const [pinKey, st] of statusPinState) {
+      if (pinKey === exceptKey) continue;
+      const chatId = statusPinChatIds.get(pinKey);
+      if (chatId == null) continue;
+      out.push({ pinKey, chatId, messageId: st.messageId });
+    }
+    return out;
+  };
+
+  async function reconcileStatusPin(pinKey: string, chatId: string, desired: DesiredPin) {
+    const prev = statusPinState.get(pinKey) ?? null;
+    const action = decidePinAction(prev, desired);
+    const op =
+      action.kind === "pin"
+        ? ({ kind: "pin", messageId: action.messageId } as const)
+        : ({ kind: "clear" } as const);
+    const next = await reconcileAndPersistStatusPin({
+      path: PATH,
+      fs,
+      pinKey,
+      chatId,
+      op,
+      snapshotOthers: () => snapshotExcept(pinKey),
+      applyPin: () =>
+        reconcilePin({ api: tg.api, chatId, prevState: prev, desired }),
+      log: () => {},
+    });
+    if (next == null) {
+      statusPinState.delete(pinKey);
+      statusPinChatIds.delete(pinKey);
+    } else {
+      statusPinState.set(pinKey, next);
+      statusPinChatIds.set(pinKey, chatId);
+    }
+  }
+
+  async function bootCleanup() {
+    return runStatusPinBootCleanup({
+      path: PATH,
+      fs,
+      unpin: (chatId, messageId) => tg.api.unpinChatMessage(chatId, messageId),
+      log: () => {},
+    });
+  }
+
+  return { statusPinState, reconcileStatusPin, bootCleanup };
+}
+
+describe("status-pin boot recovery (gateway wiring)", () => {
+  it("(A) confirmed pin → crash skips the clean sweep → next boot unpins the orphan + empties the store", async () => {
+    const { fs } = memFs();
+    const tg = fakeTelegram();
+
+    // ── Session 1: reconcile a pin. persist-before-pin runs; pin lands. ──
+    const gw1 = makeGateway(fs, tg);
+    await gw1.reconcileStatusPin("fg:c:3", "-100123", { pinned: true, messageId: 715 });
+
+    // Pin is live in Telegram and recorded on disk (confirmed).
+    expect(tg.pinned.has("-100123:715")).toBe(true);
+    expect(loadStatusPins(PATH, fs)).toEqual([
+      { pinKey: "fg:c:3", chatId: "-100123", messageId: 715 },
+    ]);
+
+    // ── CRASH: we deliberately DO NOT run the clean SIGTERM sweep
+    //    (unpinAllStatusPins). The pin stays live; gw1's Maps vanish. ──
+    expect(tg.pinned.has("-100123:715")).toBe(true);
+
+    // ── Session 2: brand-new gateway, empty Maps, SAME on-disk store. ──
+    const gw2 = makeGateway(fs, tg);
+    const res = await gw2.bootCleanup();
+
+    expect(res).toEqual({ cleared: 1, total: 1 });
+    expect(tg.pinned.has("-100123:715")).toBe(false); // orphan unpinned
+    expect(loadStatusPins(PATH, fs)).toEqual([]); // store emptied
+  });
+
+  it("(B) pending pin (crash inside the persist-after-pin window) → recovered next boot", async () => {
+    const { fs } = memFs();
+    const tg = fakeTelegram();
+
+    // Simulate the exact Fix-1 crash window: the pin API lands, then the
+    // process is SIGKILLed before the confirming rewrite. We model that by
+    // reconcileAndPersistStatusPin whose applyPin pins then throws.
+    await expect(
+      reconcileAndPersistStatusPin({
+        path: PATH,
+        fs,
+        pinKey: "fg:c:3",
+        chatId: "-100123",
+        op: { kind: "pin", messageId: 715 },
+        snapshotOthers: () => [],
+        applyPin: async () => {
+          await tg.api.pinChatMessage("-100123", 715); // pin lands in Telegram
+          throw new Error("SIGKILL before confirm rewrite");
+        },
+        log: () => {},
+      }),
+    ).rejects.toThrow("SIGKILL");
+
+    // Orphan is live in Telegram; a PENDING record is on disk.
+    expect(tg.pinned.has("-100123:715")).toBe(true);
+    expect(loadStatusPins(PATH, fs)).toEqual([
+      { pinKey: "fg:c:3", chatId: "-100123", messageId: 715, pending: true },
+    ]);
+
+    // Fresh boot recovers it from the pending record.
+    const gw2 = makeGateway(fs, tg);
+    const res = await gw2.bootCleanup();
+    expect(res).toEqual({ cleared: 1, total: 1 });
+    expect(tg.pinned.has("-100123:715")).toBe(false);
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+
+  it("clean shutdown (sweep DID run) leaves nothing for boot cleanup to do", async () => {
+    // Contrast: when the SIGTERM sweep runs (unpin each key), the store is
+    // emptied and the pin removed — boot cleanup is a no-op. This guards the
+    // ordering the other way: normal shutdown must NOT rely on boot cleanup.
+    const { fs } = memFs();
+    const tg = fakeTelegram();
+    const gw1 = makeGateway(fs, tg);
+    await gw1.reconcileStatusPin("fg:c:3", "-100123", { pinned: true, messageId: 715 });
+    // Clean sweep: unpin the key.
+    await gw1.reconcileStatusPin("fg:c:3", "-100123", { pinned: false });
+    expect(tg.pinned.size).toBe(0);
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
+
+    const gw2 = makeGateway(fs, tg);
+    expect(await gw2.bootCleanup()).toEqual({ cleared: 0, total: 0 });
+  });
+});
+
+/**
+ * Mutex-gating (P2). The boot cleanup issues real unpins against a SHARED
+ * per-agent store, so a LOSING double-boot must NOT run it — else it would strip
+ * a still-alive sibling gateway's legitimate pins. gateway.ts gates the call
+ * inside the won-lock branch (only the boot that wins acquireStartupLock calls
+ * statusPinBootCleanup; the loser process.exit(1)s first).
+ *
+ * A full held-lock integration test is impractical (gateway.ts's boot IIFE runs
+ * the mutex + bot.start at import). So we assert STRUCTURALLY that the cleanup
+ * call sits inside the won-lock branch and never at the top-level import scope,
+ * and that the loser (blocked) branch exits before it.
+ */
+describe("status-pin boot cleanup is mutex-gated (structural)", () => {
+  const gatewaySrc = readFileSync(
+    fileURLToPath(new URL("../gateway/gateway.ts", import.meta.url)),
+    "utf8",
+  );
+
+  it("does NOT invoke statusPinBootCleanup at module import scope", () => {
+    // The invocation must be gated on winning the mutex, never fired eagerly at
+    // import. A bare top-level `statusPinBootCleanup()` (not inside the lock
+    // block) would let a losing double-boot strip a live sibling's pins.
+    // The definition + the deliberate DO-NOT-invoke note are allowed; assert
+    // there is a note explaining the gating, and that every actual call is
+    // preceded (in source order) by the acquireStartupLock outcome check.
+    expect(gatewaySrc).toContain("acquireStartupLock");
+    // The comment documenting WHY it isn't invoked at import time.
+    expect(gatewaySrc).toMatch(
+      /NOT invoked here at import time|gated on winning the startup mutex/,
+    );
+  });
+
+  it("every statusPinBootCleanup() call site follows the won-lock check", () => {
+    // Find each *invocation* (with parens), excluding the declaration.
+    const lines = gatewaySrc.split("\n");
+    const lockIdx = lines.findIndex((l) => l.includes("acquireStartupLock({"));
+    expect(lockIdx).toBeGreaterThan(-1);
+
+    const declIdx = lines.findIndex((l) =>
+      /async function statusPinBootCleanup/.test(l),
+    );
+    expect(declIdx).toBeGreaterThan(-1);
+
+    const callIdxs = lines
+      .map((l, i) => ({ l, i }))
+      .filter(
+        ({ l, i }) =>
+          i !== declIdx &&
+          /statusPinBootCleanup\(\)/.test(l) &&
+          !l.trimStart().startsWith("//") &&
+          !l.includes("statusPinBootCleanup() is deliberately NOT"),
+      )
+      .map(({ i }) => i);
+
+    // There must be at least one real call, and every real call must come
+    // AFTER the acquireStartupLock outcome is available (i.e. inside the boot
+    // block that only the winner reaches).
+    expect(callIdxs.length).toBeGreaterThan(0);
+    for (const idx of callIdxs) {
+      expect(idx).toBeGreaterThan(lockIdx);
+    }
+  });
+
+  it("the blocked (losing) boot exits before reaching cleanup", () => {
+    // In the mutex block, `outcome.status === 'blocked'` must lead to
+    // process.exit(1) BEFORE any statusPinBootCleanup() call in that block —
+    // so a loser never touches the shared store.
+    const blockedIdx = gatewaySrc.indexOf("outcome.status === 'blocked'");
+    expect(blockedIdx).toBeGreaterThan(-1);
+    const afterBlocked = gatewaySrc.slice(blockedIdx);
+    const exitIdx = afterBlocked.indexOf("process.exit(1)");
+    const cleanupIdx = afterBlocked.indexOf("void statusPinBootCleanup()");
+    expect(exitIdx).toBeGreaterThan(-1);
+    expect(cleanupIdx).toBeGreaterThan(-1);
+    // The exit for the blocked branch appears before the winner's cleanup call.
+    expect(exitIdx).toBeLessThan(cleanupIdx);
+  });
+});

--- a/telegram-plugin/tests/status-pin-store.test.ts
+++ b/telegram-plugin/tests/status-pin-store.test.ts
@@ -3,6 +3,7 @@ import {
   loadStatusPins,
   persistStatusPins,
   pinnedMessageIsOurs,
+  reconcileAndPersistStatusPin,
   runStatusPinBootCleanup,
   type PersistedStatusPin,
   type StatusPinStoreFsSeam,
@@ -86,7 +87,8 @@ describe("status-pin-store", () => {
   });
 
   it("fail-open: wrong envelope version / shape loads as []", () => {
-    const { fs: f1 } = memFs({ [PATH]: JSON.stringify({ v: 2, pins: [pin()] }) });
+    // v3 is an unknown FUTURE version (v1 + v2 are the supported set).
+    const { fs: f1 } = memFs({ [PATH]: JSON.stringify({ v: 3, pins: [pin()] }) });
     expect(loadStatusPins(PATH, f1)).toEqual([]);
     const { fs: f2 } = memFs({ [PATH]: JSON.stringify({ v: 1, pins: "nope" }) });
     expect(loadStatusPins(PATH, f2)).toEqual([]);
@@ -231,5 +233,218 @@ describe("runStatusPinBootCleanup", () => {
     });
     expect(res).toEqual({ cleared: 0, total: 0 });
     expect(calls).toBe(0);
+  });
+
+  it("unpins a PENDING record too (crash in the persist-after-pin window)", async () => {
+    // Fix 1: a pin that landed in Telegram but whose confirming rewrite never
+    // ran leaves a `pending` record. Boot cleanup must treat it like a confirmed
+    // pin and unpin it — otherwise the orphan lingers forever.
+    const { fs } = memFs();
+    persistStatusPins(PATH, fs, [
+      pin({ pinKey: "fg:c:9", chatId: "-100777", messageId: 314, pending: true }),
+    ]);
+    const unpinned: Array<[string, number]> = [];
+    const res = await runStatusPinBootCleanup({
+      path: PATH,
+      fs,
+      unpin: async (chatId, messageId) => {
+        unpinned.push([chatId, messageId]);
+      },
+      log: () => {},
+    });
+    expect(unpinned).toEqual([["-100777", 314]]);
+    expect(res).toEqual({ cleared: 1, total: 1 });
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+});
+
+/**
+ * Envelope versioning — a v1 snapshot (no `pending` field) must still load
+ * fail-open as a confirmed pin, and v2 must round-trip the `pending` flag.
+ */
+describe("status-pin-store — envelope version compat", () => {
+  it("loads a legacy v1 snapshot (no pending field) as confirmed pins", () => {
+    const { fs } = memFs({
+      [PATH]: JSON.stringify({
+        v: 1,
+        pins: [{ pinKey: "fg:c:3", chatId: "-100123", messageId: 715 }],
+      }),
+    });
+    const loaded = loadStatusPins(PATH, fs);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].pending).toBeUndefined();
+    expect(loaded[0].messageId).toBe(715);
+  });
+
+  it("round-trips a v2 pending flag and writes v2 envelopes", () => {
+    const { fs, files } = memFs();
+    persistStatusPins(PATH, fs, [pin({ pending: true })]);
+    expect(JSON.parse(files.get(PATH)!).v).toBe(2);
+    expect(loadStatusPins(PATH, fs)[0].pending).toBe(true);
+  });
+
+  it("rejects an unknown future envelope version (fail-open [])", () => {
+    const { fs } = memFs({ [PATH]: JSON.stringify({ v: 3, pins: [pin()] }) });
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+
+  it("drops a row with a non-boolean pending field", () => {
+    const { fs } = memFs({
+      [PATH]: JSON.stringify({
+        v: 2,
+        pins: [
+          pin({ messageId: 715 }),
+          { pinKey: "k", chatId: "c", messageId: 1, pending: "yes" },
+        ],
+      }),
+    });
+    const loaded = loadStatusPins(PATH, fs);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].messageId).toBe(715);
+  });
+});
+
+/**
+ * reconcileAndPersistStatusPin — the persist-BEFORE-pin ordering that closes the
+ * leak window (Fix 1). These exercise the REAL wrapper the gateway calls, with
+ * an fs seam that can crash at a chosen write so we can prove the leak is
+ * recovered (red→green against the pre-fix persist-after ordering).
+ */
+describe("reconcileAndPersistStatusPin — persist-before-pin ordering", () => {
+  it("writes a PENDING record BEFORE the pin API call", async () => {
+    const { fs } = memFs();
+    const order: string[] = [];
+    // Record what's on disk at the moment the pin API is invoked.
+    let onDiskAtPin: PersistedStatusPin[] = [];
+    const next = await reconcileAndPersistStatusPin({
+      path: PATH,
+      fs,
+      pinKey: "fg:c:3",
+      chatId: "-100123",
+      op: { kind: "pin", messageId: 715 },
+      snapshotOthers: () => [],
+      applyPin: async () => {
+        order.push("pin-api");
+        onDiskAtPin = loadStatusPins(PATH, fs);
+        return { messageId: 715 };
+      },
+      log: () => {},
+    });
+    // At the moment the pin API ran, a pending record was already on disk.
+    expect(onDiskAtPin).toEqual([
+      { pinKey: "fg:c:3", chatId: "-100123", messageId: 715, pending: true },
+    ]);
+    // After success it's confirmed (pending cleared).
+    expect(next).toEqual({ messageId: 715 });
+    expect(loadStatusPins(PATH, fs)).toEqual([
+      { pinKey: "fg:c:3", chatId: "-100123", messageId: 715 },
+    ]);
+  });
+
+  it("RED→GREEN: a crash between pin-lands and confirm leaves a recoverable pending record", async () => {
+    // Simulate SIGKILL: the pin API lands in Telegram, then the process dies
+    // before the confirming rewrite. We model the crash by throwing out of
+    // applyPin AFTER it 'pinned' — the pending record must survive on disk.
+    const { fs } = memFs();
+    let pinnedInTelegram: number | null = null;
+    await expect(
+      reconcileAndPersistStatusPin({
+        path: PATH,
+        fs,
+        pinKey: "fg:c:3",
+        chatId: "-100123",
+        op: { kind: "pin", messageId: 715 },
+        snapshotOthers: () => [],
+        applyPin: async () => {
+          pinnedInTelegram = 715; // the pin landed in Telegram
+          throw new Error("SIGKILL — process died before confirm rewrite");
+        },
+        log: () => {},
+      }),
+    ).rejects.toThrow("SIGKILL");
+
+    // The pin is live in Telegram...
+    expect(pinnedInTelegram).toBe(715);
+    // ...AND a pending record survived on disk (this is what the pre-fix
+    // persist-AFTER-pin ordering FAILED to do — the store would have been empty
+    // and boot cleanup blind to the orphan).
+    const persisted = loadStatusPins(PATH, fs);
+    expect(persisted).toEqual([
+      { pinKey: "fg:c:3", chatId: "-100123", messageId: 715, pending: true },
+    ]);
+
+    // Next boot: cleanup unpins the orphan using the pending record.
+    const unpinned: Array<[string, number]> = [];
+    await runStatusPinBootCleanup({
+      path: PATH,
+      fs,
+      unpin: async (c, m) => {
+        unpinned.push([c, m]);
+      },
+      log: () => {},
+    });
+    expect(unpinned).toEqual([["-100123", 715]]);
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+
+  it("clears the pending record when the pin API fails (no phantom claim)", async () => {
+    const { fs } = memFs();
+    const next = await reconcileAndPersistStatusPin({
+      path: PATH,
+      fs,
+      pinKey: "fg:c:3",
+      chatId: "-100123",
+      op: { kind: "pin", messageId: 715 },
+      snapshotOthers: () => [],
+      // reconcilePin returns null (prevState) when the pin API throws.
+      applyPin: async () => null,
+      log: () => {},
+    });
+    expect(next).toBeNull();
+    // Pending record dropped — nothing to leak, nothing was pinned.
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+
+  it("preserves OTHER live claims while flipping one key pending→confirmed", async () => {
+    const { fs } = memFs();
+    const other: PersistedStatusPin = {
+      pinKey: "wk:agent-x",
+      chatId: "-100999",
+      messageId: 42,
+    };
+    await reconcileAndPersistStatusPin({
+      path: PATH,
+      fs,
+      pinKey: "fg:c:3",
+      chatId: "-100123",
+      op: { kind: "pin", messageId: 715 },
+      snapshotOthers: () => [other],
+      applyPin: async () => ({ messageId: 715 }),
+      log: () => {},
+    });
+    const loaded = loadStatusPins(PATH, fs);
+    expect(loaded).toContainEqual(other);
+    expect(loaded).toContainEqual({
+      pinKey: "fg:c:3",
+      chatId: "-100123",
+      messageId: 715,
+    });
+  });
+
+  it("clear op: unpins then drops the record (post-pin ordering is safe)", async () => {
+    const { fs } = memFs();
+    persistStatusPins(PATH, fs, [pin({ pinKey: "fg:c:3", messageId: 715 })]);
+    const next = await reconcileAndPersistStatusPin({
+      path: PATH,
+      fs,
+      pinKey: "fg:c:3",
+      chatId: "-100123",
+      op: { kind: "clear" },
+      snapshotOthers: () => [],
+      applyPin: async () => null,
+      log: () => {},
+    });
+    expect(next).toBeNull();
+    expect(loadStatusPins(PATH, fs)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Closes the **persist-after-pin leak window** in the status-pin subsystem and adds the missing recovery tests.

Serves the `know-what-my-agent-is-doing` job spec (the one sanctioned silent pin under the `chat-is-the-single-source-of-truth` invariant) — a lingering orphan pin from a dead session is a visibility regression.

## The leak

The gateway pinned the Telegram message **first**, then snapshotted the claim set to disk (`persistStatusPinSnapshot()` ran *after* `reconcilePin`). A `SIGKILL` landing between the pin API call succeeding and the snapshot rename left a pin **live in Telegram with no on-disk record** — so next-boot cleanup (`runStatusPinBootCleanup`) couldn't see it, the ownership guard couldn't recognise it as ours, and the orphan pin lingered permanently.

## The fix

Persist the pin **intent before** the pin API call. New `reconcileAndPersistStatusPin` wrapper:

1. Writes a `pending` record to disk **before** issuing `pinChatMessage`.
2. Rewrites it as **confirmed** (pending cleared) once the pin lands.
3. **Drops** the pending record if the pin failed (no phantom claim).

`runStatusPinBootCleanup` already unpins every persisted entry, and now the doc + tests make explicit that this includes `pending` records — so a crash in the window is recovered on the next boot. The persist path stays fail-open and never throws.

The `PersistedStatusPin` envelope is bumped **v1 → v2** to carry the optional `pending` flag. A v1 snapshot (no field) still loads fail-open as a confirmed pin; an unknown future version yields `[]`.

Supergroup/forum-topic keying and ownership-guard semantics are **unchanged** beyond adding the pending dimension.

## Tests

- **P1 red→green:** `reconcileAndPersistStatusPin` persist-before-pin ordering, including a test proving a crash between pin-lands and confirm leaves a **recoverable pending record** — the pre-fix persist-after ordering left the store empty and boot cleanup blind.
- **P1 integration (headline recovery path):** `status-pin-boot-recovery.test.ts` reproduces the full gateway wiring — reconcile a pin → persist → **skip the clean SIGTERM sweep** (`unpinAllStatusPins`) → boot a fresh gateway (new Maps, same on-disk store) → assert the orphan is unpinned **and** the store emptied. Variant (B) covers the new pending-record case; a clean-shutdown contrast case guards the other direction.
- **P2 mutex-gating (structural):** asserts `statusPinBootCleanup` is never invoked at import scope, every call site sits after the won-lock check, and the blocked (losing) boot `process.exit(1)`s before reaching cleanup — so a double-boot can't strip a live sibling's pins.
- Envelope version-compat (v1 legacy load / v2 round-trip / v3 reject / non-boolean pending drop).

Test plan:
- [x] `tsc --noEmit` clean
- [x] `vitest run` status-pin-store + status-pin-boot-recovery (32 pass)
- [x] `bun test` status-pin suites (54 pass) + gateway-boot suites (61 pass)
- [x] `check-bot-api-wrapping.sh` clean
- [x] `check-bun-test-imports.mjs` clean

## Risk

Low. Persistence remains best-effort/fail-open; STATIC / feature-off paths bypass disk entirely (preserved). The only behavioural change is an extra pending-marked write before a pin, cleared/confirmed immediately after.

**DRAFT — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)