### PR TITLE
fix(gateway): pin-rights 400 must never crash the gateway

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5721,6 +5721,34 @@ async function reconcileStatusPin(
   chatId: string,
   desired: DesiredPin,
 ): Promise<void> {
+  // Fire-and-forget hard boundary. Most callers invoke this as
+  // `void reconcileStatusPin(...)` (auto status-pin is best-effort — it must
+  // never affect turn flow). reconcilePin already swallows pin/unpin API
+  // errors via onError, but the surrounding persistence + Map bookkeeping
+  // (and any future edge) could still reject the returned promise. A rejected
+  // fire-and-forget promise becomes a process-level `unhandledRejection` which
+  // the gateway's handler crashes on — that is exactly how a benign
+  // "not enough rights to manage pinned messages" 400 in a supergroup took the
+  // whole gateway down (marko, 2026-07-01). Auto status-pin is cosmetic; it
+  // must NEVER be able to crash the gateway. Any throw here is logged and
+  // absorbed. (The `pin_message` MCP tool still surfaces failures to the agent
+  // as a normal tool-error — that path is `executePinMessage`, not this one.)
+  try {
+    await reconcileStatusPinInner(pinKey, chatId, desired)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    process.stderr.write(
+      `telegram gateway: status-pin reconcile absorbed error ` +
+        `(key=${pinKey} chat=${chatId}): ${msg}\n`,
+    )
+  }
+}
+
+async function reconcileStatusPinInner(
+  pinKey: string,
+  chatId: string,
+  desired: DesiredPin,
+): Promise<void> {
   if (!PIN_STATUS_WHILE_WORKING) return
   if (chatId.length === 0) return
   const prev = statusPinState.get(pinKey) ?? null

--- a/telegram-plugin/gateway/unhandled-rejection-policy.ts
+++ b/telegram-plugin/gateway/unhandled-rejection-policy.ts
@@ -115,7 +115,18 @@ export function classifyRejection(
     // same family so a single bad chat id can't restart-loop the
     // process. The visible boot-probe-failed log is the primary
     // diagnostic; this is the can't-restart-loop guarantee.
-    desc.includes('chat not found')
+    desc.includes('chat not found') ||
+    // Pin-rights failure in a supergroup where the bot is not an admin (or
+    // lacks the "pin messages" right). Telegram returns this as a 400, not a
+    // 403: "not enough rights to manage pinned messages in the chat". The
+    // auto status-pin driver is best-effort and cosmetic — a bot that can't
+    // pin should skip the pin, never crash-loop the gateway. This was the
+    // exact 400 that took marko's gateway down (2026-07-01): the fire-and-
+    // forget `void reconcileStatusPin(...)` leaked the rejection and this
+    // handler shut the process down. reconcileStatusPin now absorbs its own
+    // errors (primary fix); this entry is defense-in-depth so ANY leaked
+    // pin-rights 400 from any path is log-only, not fatal.
+    desc.includes('not enough rights')
   ) {
     return 'log_only'
   }

--- a/telegram-plugin/tests/status-pin.test.ts
+++ b/telegram-plugin/tests/status-pin.test.ts
@@ -1,7 +1,19 @@
 import { describe, it, expect } from 'vitest'
+import { GrammyError } from 'grammy'
 import { decidePinAction } from '../status-pin.js'
 import { reconcilePin, type PinBotApi } from '../status-pin-driver.js'
 import type { PinState } from '../status-pin.js'
+
+/** A real GrammyError with the given code + description, mirroring the wire
+ *  shape Telegram returns for the pin-rights failure that crashed marko. */
+function grammyError(error_code: number, description: string): GrammyError {
+  return new GrammyError(
+    `Call to 'pinChatMessage' failed!`,
+    { ok: false, error_code, description },
+    'pinChatMessage',
+    {} as never,
+  )
+}
 
 describe('decidePinAction (pure)', () => {
   it('pins an existing message when work goes in-flight (nothing pinned yet)', () => {
@@ -113,5 +125,78 @@ describe('reconcilePin (driver)', () => {
     await reconcilePin({ api, chatId: '1', prevState: null, desired: { pinned: true, messageId: 7 } })
     await reconcilePin({ api, chatId: '1', prevState: { messageId: 7 }, desired: { pinned: false } })
     expect(Object.keys(api)).toEqual(['pinChatMessage', 'unpinChatMessage'])
+  })
+})
+
+// ── Regression: the marko 2026-07-01 gateway crash ─────────────────────────
+// A pinChatMessage 400 "not enough rights to manage pinned messages" (the bot
+// is not an admin in a supergroup) escaped as an unhandledRejection and shut
+// the whole gateway down. Auto status-pin is best-effort/cosmetic — a
+// pin-rights failure must be absorbed, never fatal, and never reach the
+// process-level unhandledRejection handler.
+describe('reconcilePin — pin-rights 400 must never crash (marko 2026-07-01)', () => {
+  it('absorbs the "not enough rights" 400 via onError and never rejects', async () => {
+    const rightsErr = grammyError(
+      400,
+      'Bad Request: not enough rights to manage pinned messages in the chat',
+    )
+    const captured: { phase: string; code?: number }[] = []
+    const api: PinBotApi = {
+      pinChatMessage: async () => {
+        throw rightsErr
+      },
+      unpinChatMessage: async () => {},
+    }
+
+    // reconcilePin resolves (never rejects) even when the pin API throws a
+    // real GrammyError — this is the contract the fire-and-forget
+    // `void reconcileStatusPin(...)` callsites depend on to not leak a
+    // rejection to the process.
+    const next = await reconcilePin({
+      api,
+      chatId: '-1003831053471',
+      prevState: null,
+      desired: { pinned: true, messageId: 4 },
+      onError: (phase, err) =>
+        captured.push({
+          phase,
+          code: err instanceof GrammyError ? err.error_code : undefined,
+        }),
+    })
+
+    // No claim taken (pin failed), error routed through onError, promise
+    // resolved cleanly.
+    expect(next).toBeNull()
+    expect(captured).toEqual([{ phase: 'pin', code: 400 }])
+  })
+
+  it('a fire-and-forget reconcilePin does NOT emit an unhandledRejection', async () => {
+    const rejections: unknown[] = []
+    const onUnhandled = (err: unknown) => rejections.push(err)
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      const api: PinBotApi = {
+        pinChatMessage: async () => {
+          throw grammyError(
+            400,
+            'Bad Request: not enough rights to manage pinned messages in the chat',
+          )
+        },
+        unpinChatMessage: async () => {},
+      }
+      // Fire-and-forget, exactly as the gateway's auto-pin callsites do.
+      void reconcilePin({
+        api,
+        chatId: '-1003831053471',
+        prevState: null,
+        desired: { pinned: true, messageId: 4 },
+        onError: () => {},
+      })
+      // Let microtasks + a macrotask flush so any leaked rejection would fire.
+      await new Promise((r) => setTimeout(r, 20))
+      expect(rejections).toEqual([])
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
   })
 })

--- a/telegram-plugin/tests/unhandled-rejection-policy.test.ts
+++ b/telegram-plugin/tests/unhandled-rejection-policy.test.ts
@@ -84,6 +84,18 @@ describe('classifyRejection — benign Telegram 400s', () => {
     const err = grammyError(400, 'Bad Request: MESSAGE IS NOT MODIFIED: blah')
     expect(classifyRejection(err)).toBe('log_only')
   })
+
+  it('returns "log_only" for pin-rights 400 "not enough rights to manage pinned messages" (marko 2026-07-01)', () => {
+    // The bot is not an admin in a supergroup, so the auto status-pin
+    // driver's pinChatMessage returns this 400. It was crashing the whole
+    // gateway via a leaked fire-and-forget rejection. Auto-pin is cosmetic —
+    // a missing pin right must never be fatal.
+    const err = grammyError(
+      400,
+      'Bad Request: not enough rights to manage pinned messages in the chat',
+    )
+    expect(classifyRejection(err)).toBe('log_only')
+  })
 })
 
 describe('classifyRejection — genuine errors still crash', () => {


### PR DESCRIPTION
## Summary

A \`pinChatMessage\` **400 \"not enough rights to manage pinned messages in the chat\"** (the bot is not an admin in a supergroup, so it can't pin) escaped as a process-level \`unhandledRejection\` and shut the whole Telegram gateway down mid-turn. The supervisor then restart-looped it.

Observed on live agent \`marko\` (\`gateway-supervisor.log\`, 2026-07-01):

\`\`\`
telegram gateway: status-pin pin failed (key=fg:-1003831053471:4 chat=-1003831053471): Call to 'pinChatMessage' failed! (400: Bad Request: not enough rights to manage pinned messages in the chat)
telegram gateway: unhandledRejection: GrammyError: Call to 'pinChatMessage' failed! (400 ...)
telegram gateway: unhandled rejection (shutdown): GrammyError: ... pinChatMessage ...
[supervise] gateway exited (status=0, ran=3289s) — retrying in 1s
\`\`\`

## Exact escape path (confirmed)

The **auto status-pin** driver — not the \`pin_message\` MCP tool — is the culprit. On the foreground activity-summary path the gateway fires:

\`\`\`ts
void reconcileStatusPin(\`fg:\${statusKey(chat, thread)}\`, chat, { pinned: true, messageId: sent.message_id })
\`\`\`

\`reconcilePin()\` routes the pin API failure through its \`onError\` hook (that's the \"status-pin pin failed\" log line), but the surrounding \`reconcileStatusPin\` promise still leaked a rejection to the process. As a **fire-and-forget** \`void\` call, that leaked rejection became a process-level \`unhandledRejection\`, where \`classifyRejection()\` classified the benign rights-400 as \`shutdown\` — and the gateway exited.

The \`pin_message\` MCP tool path (\`executePinMessage\` → \`onToolCall\` try/catch → \`handleToolCall\` \`.then(onRejected)\`) was already safe — it surfaces to the agent as a tool-error. This bug is specific to the cosmetic auto-pin path.

## Fix (defense in depth)

1. **\`reconcileStatusPin\` is now fail-safe.** Its whole body is wrapped in a try/catch (body moved to \`reconcileStatusPinInner\`) and any error is logged + absorbed. Auto status-pin is cosmetic and always fire-and-forget; it must never be able to reject the process. The \`pin_message\` MCP tool still surfaces failures to the agent unchanged.
2. **The unhandledRejection policy tolerates the benign pin-rights 400.** \`classifyRejection()\` now treats a 400 whose description contains \`not enough rights\` as \`log_only\`, not \`shutdown\` — so any leaked pin-rights 400 from any path is non-fatal. Scoped narrowly: other 400s and all genuine fatals still shut down.

Pin ownership / supergroup keying semantics are unchanged.

## Tests

- \`status-pin.test.ts\` — a real \`GrammyError\` rights-400 from \`pinChatMessage\` is absorbed via \`onError\`, \`reconcilePin\` never rejects, and a fire-and-forget \`reconcilePin\` emits **no** \`unhandledRejection\`.
- \`unhandled-rejection-policy.test.ts\` — the pin-rights 400 classifies as \`log_only\`; genuine 400s / non-Grammy errors / 401 still \`shutdown\` (red→green verified: the new policy test fails without the fix).

Local: \`tsc --noEmit\` clean, \`check-bot-api-wrapping.sh\` clean, all status-pin + policy + retry suites green.

## Job spec / vision

Serves **know-what-my-agent-is-doing** (the status pin) and the **always-on** vision outcome — a benign Telegram 400 can no longer take the gateway down.

🚧 **DRAFT — do not merge.**