### PR TITLE
fix(rollout): hostd-context apply uses --compose-only --non-interactive (unblocks agent-side rolls)

### DIFF
--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -292,7 +292,7 @@ describe("planRollout — hostd context (#2487)", () => {
 describe("executeRollout — hostd context (#2487)", () => {
   const TARGET = "v0.15.18";
 
-  it("apply uses one-shot --pin (pin not yet persisted before canary)", () => {
+  it("apply uses one-shot --pin + --compose-only --non-interactive (pin not yet persisted; scaffold unwritable under hostd)", () => {
     const steps = planRollout(["clerk", "test-harness"], {
       pinToPersist: TARGET,
       hostdContext: true,
@@ -302,7 +302,38 @@ describe("executeRollout — hostd context (#2487)", () => {
     });
     const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
     expect(r.ok).toBe(true);
-    expect(runs[0]).toEqual(["apply", "--pin", TARGET]);
+    // #2745: a version roll only regenerates compose (image tags +
+    // compose-level env + healthcheck). It must NOT run the per-agent
+    // scaffold loop, which fails under hostd (state dirs mode 0700, owned
+    // by per-agent UIDs, unwritable by the unprivileged hostd process) and
+    // hard-aborts the whole roll with rolled:[].
+    expect(runs[0]).toEqual(["apply", "--pin", TARGET, "--compose-only", "--non-interactive"]);
+  });
+
+  it("surfaces a WARNING that per-agent template changes need a host-side apply (compose-only tradeoff)", () => {
+    const steps = planRollout(["clerk", "test-harness"], {
+      pinToPersist: TARGET,
+      hostdContext: true,
+    });
+    const { deps } = harness({
+      versions: { clerk: "0.15.18", "test-harness": "0.15.18" },
+    });
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+    expect(r.ok).toBe(true);
+    expect(r.warnings.some((w) => /compose-only/.test(w) && /host-side/.test(w))).toBe(true);
+  });
+
+  it("host-shell path keeps the bare apply — no --compose-only, no tradeoff warning", () => {
+    const steps = planRollout(["clerk", "test-harness"], { pinToPersist: TARGET });
+    const { deps, runs } = harness({
+      versions: { clerk: "0.15.18", "test-harness": "0.15.18" },
+    });
+    const r = executeRollout(steps, TARGET, deps, {});
+    expect(r.ok).toBe(true);
+    // bare apply reads the already-persisted pin; a privileged host shell
+    // CAN scaffold, so no compose-only downgrade and no tradeoff warning.
+    expect(runs).toContainEqual(["apply"]);
+    expect(r.warnings.some((w) => /compose-only/.test(w))).toBe(false);
   });
 
   it("does NOT persist the pin when the canary FAILS its version assert", () => {

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -528,14 +528,40 @@ export function executeRollout(
         // hostd path: pin not yet persisted (it follows the canary), so
         // pass the one-shot --pin so compose regenerates on the target.
         // host-shell path: pin already persisted → bare apply reads it.
+        //
+        // On the hostd path we ALSO pass `--compose-only --non-interactive`.
+        // A version roll only needs the compose regenerated with the new
+        // image tags plus compose-level env (SWITCHROOM_VOICE_ENGINE) and the
+        // sidecar healthcheck — all emitted by generateCompose(), which
+        // `--compose-only` still runs. What `--compose-only` skips is the
+        // per-agent SCAFFOLD loop (start.sh / .mcp.json / settings.json).
+        // Under docker mode (v0.7+) per-agent state dirs are mode 0700 owned
+        // by per-agent UIDs; hostd runs unprivileged and cannot write into
+        // them, so a FULL apply fails scaffold for every agent, returns
+        // non-zero, and aborts the whole roll having rolled nothing (every
+        // historical hostd rollout in the audit log: failedStep "apply",
+        // rolled []). Skipping scaffold lets the roll actually complete.
         deps.log(`ROLL_STEP apply — regenerating compose for ${target}`);
         emit({ phase: "apply", target });
         const applyArgs = execOpts.hostdContext
-          ? ["apply", "--pin", target]
+          ? ["apply", "--pin", target, "--compose-only", "--non-interactive"]
           : ["apply"];
         const r = deps.run(applyArgs);
         if (r.status !== 0) {
           return { ok: false, rolled, failedStep: "apply", warnings };
+        }
+        if (execOpts.hostdContext) {
+          // TRADEOFF (surfaced, not hidden): --compose-only skipped the
+          // per-agent template refresh. If this release changed the
+          // start.sh / .mcp.json / settings.json templates, agents keep
+          // their stale wrappers until a host-side privileged apply runs.
+          warnings.push(
+            `apply ran --compose-only (hostd is unprivileged and cannot ` +
+              `write per-agent state dirs). Compose + compose-level env/` +
+              `healthcheck are up to date, but per-agent template changes ` +
+              `(start.sh / .mcp.json / settings.json) are NOT applied — run ` +
+              `a host-side \`sudo switchroom apply\` if this release changed them.`,
+          );
         }
         break;
       }


### PR DESCRIPTION
## The bug

`mcp__hostd__rollout` (a version roll fired from hostd/agent context) **always fails at the `apply` step** and rolls nothing. Every historical attempt in the host audit log shows `failedStep: "apply"`, `rolled: []`, with:

> `ERROR: Scaffolded 12/12 agents. 12 failed. Per-agent state dirs are mode 0700 owned by per-agent UIDs — the operator cannot write into them without privilege escalation.`

## Root cause

In the rollout state machine (`src/cli/rollout.ts`, `apply` step), the hostd path ran a **full** `switchroom apply --pin <target>`:

```js
const applyArgs = execOpts.hostdContext ? ["apply", "--pin", target] : ["apply"];
```

A full apply runs the per-agent **scaffold** loop (start.sh / .mcp.json / settings.json). Under docker mode (v0.7+) those state dirs are mode `0700` owned by per-agent UIDs; the unprivileged hostd process cannot write into them, so scaffold fails for every agent, `apply` returns non-zero, and the whole roll aborts having rolled nothing. This is also why compose-level fixes (voice `SWITCHROOM_VOICE_ENGINE`, the sidecar healthcheck) never reached the running fleet — **the roll never completed.**

The `--pin` on this line was added deliberately (#2487) for compose regen against the target image — the scaffold failure is an unintended side effect of using a *full* apply. The apply command's own error message recommends `switchroom apply --non-interactive --compose-only`.

## The fix

hostd-context apply now runs:

```js
["apply", "--pin", target, "--compose-only", "--non-interactive"]
```

`--compose-only` skips **only** the per-agent scaffold loop. It still runs preflight and `generateCompose()`, which emits the pinned image tags, the compose-level `SWITCHROOM_VOICE_ENGINE` env, and the sidecar healthcheck. The existing `restart-agent --pin` step reads the regenerated compose, so the target version still boots. The host-shell path is unchanged (bare `apply`, privileged, can scaffold).

**Tradeoff surfaced, not hidden:** `--compose-only` skips per-agent template refresh, so the rollout now pushes a WARNING into the result telling the operator that per-agent template changes (start.sh / .mcp.json / settings.json) require a host-side `sudo switchroom apply`.

## Compose-level coverage (voice)

Confirmed `generateCompose()` (`src/agents/compose.ts`) is what emits both `SWITCHROOM_VOICE_ENGINE` and the healthcheck — and `--compose-only` still calls it. So an agent-side roll will now actually regenerate compose with the voice env + healthcheck; the previous full-apply abort was the sole reason it never landed.

## Tests

`src/cli/rollout.test.ts`:
- hostd-context apply args now assert `["apply", "--pin", TARGET, "--compose-only", "--non-interactive"]`
- new: tradeoff WARNING is surfaced in `result.warnings`
- new: host-shell path unchanged (bare `apply`, no warning)

Verified red→green: the two new assertions fail on old source, pass on new. Full `rollout.test.ts` (67), `rollout-narrator.test.ts` + `update.test.ts` (73) green; `tsc --noEmit` + all repo lint checks clean.

## JTBD / vision

Serves the always-on fleet + operator-rolls-a-version-from-Telegram jobs; advances the **always-on** and **visibility** vision outcomes. Crosses no invariant (no self-escalation — the fix *reduces* the privilege the roll demands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)