### PR TITLE
test(telegram): parse-level formatting regression suite (validates emitted markdown)

### DIFF
--- a/telegram-plugin/tests/formatting-parse-regression.test.ts
+++ b/telegram-plugin/tests/formatting-parse-regression.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Parse-level formatting regression suite.
+ *
+ * GOAL: catch formatting regressions at the *parse* level, not the string
+ * level. For every torture-set fixture we run the raw intent through the SAME
+ * outbound transform pipeline the gateway uses, then assert TWO independent
+ * signals via `rich-markdown-oracle.ts` (an independent CommonMark/GFM
+ * validator — NOT the formatter echoing itself):
+ *
+ *   (a) PARSE-ACCEPT — every emitted chunk is well-formed enough that
+ *       Telegram's rich-message path would not 400 on it (balanced fences,
+ *       terminated code spans, closed links, complete table rows, balanced
+ *       emphasis). This is the signal that would have caught "we shipped
+ *       markdown Telegram rejects."
+ *
+ *   (b) STRUCTURE — the transformed body parses into the entity structure the
+ *       fixture intended (bold/italic/code/pre/link at the right inner text).
+ *
+ * The pipeline mirrors `telegram-plugin/gateway/gateway.ts`:
+ *   repairEscapedWhitespace -> normalizeParagraphBreaks -> addParagraphSpacers
+ *   -> splitMarkdownChunks. (Card-surface fixtures also apply `normalizeDashes`
+ *   first — that is where F1's voice scrub lives.)
+ *
+ * This suite is TEST-ONLY. It changes no production formatting behaviour. If a
+ * fixture ever fails signal (a), it means the formatter emits markdown Telegram
+ * would reject — a real regression, not a test to relax.
+ */
+
+import { describe, test, expect } from 'vitest'
+import {
+  repairEscapedWhitespace,
+  normalizeParagraphBreaks,
+  addParagraphSpacers,
+  splitMarkdownChunks,
+  RICH_MESSAGE_MAX_CHARS,
+} from '../format.js'
+import { normalizeDashes } from '../text-voice-scrub.js'
+import {
+  validateRichMarkdown,
+  isRichMarkdownValid,
+  parseRichEntities,
+  entitiesOfType,
+  scanFences,
+  type RichEntity,
+} from './rich-markdown-oracle.js'
+import { TORTURE_SET, type TortureFixture, type ExpectEntity } from './formatting-torture-set.js'
+
+/**
+ * The outbound transform, mirroring the gateway. `cardSurfaceScrub` prepends
+ * the voice-scrub pass (F1's surface). `cap` overrides the chunk cap so the
+ * F7 hard-slice path is reachable in a test without a 32k fixture.
+ */
+function transform(input: string, opts: { cardSurfaceScrub?: boolean; cap?: number } = {}): {
+  chunks: string[]
+  /** The full transformed body BEFORE chunking — used for structure assertions. */
+  body: string
+} {
+  let text = input
+  if (opts.cardSurfaceScrub) text = normalizeDashes(text)
+  text = normalizeParagraphBreaks(repairEscapedWhitespace(text))
+  const body = addParagraphSpacers(text)
+  const chunks = splitMarkdownChunks(body, opts.cap ?? RICH_MESSAGE_MAX_CHARS)
+  return { chunks, body }
+}
+
+/** Assert an expected entity is present among `got` (membership, not index). */
+function expectEntityPresent(got: ReadonlyArray<RichEntity>, want: ExpectEntity): void {
+  const match = got.find(
+    (e) =>
+      e.type === want.type &&
+      e.text === want.text &&
+      (want.url == null || e.url === want.url) &&
+      (want.lang == null || e.lang === want.lang),
+  )
+  expect(
+    match,
+    `expected a ${want.type} entity with text ${JSON.stringify(want.text)}` +
+      (want.url != null ? ` url ${want.url}` : '') +
+      (want.lang != null ? ` lang ${want.lang}` : '') +
+      `; got: ${JSON.stringify(got)}`,
+  ).toBeDefined()
+}
+
+// ---------------------------------------------------------------------------
+// Oracle self-tests — prove the oracle is a real, non-vacuous validator.
+// If the oracle accepted everything (signal a) or found nothing (signal b),
+// the whole suite would be a rubber stamp. These guard against that.
+// ---------------------------------------------------------------------------
+
+describe('rich-markdown-oracle — self-tests (guards against a vacuous oracle)', () => {
+  test('parse-accept: rejects an UNCLOSED fenced code block', () => {
+    const bad = 'intro\n```bash\necho hi\n' // no closing ```
+    const issues = validateRichMarkdown(bad)
+    expect(issues.some((i) => i.kind === 'unbalanced-fence')).toBe(true)
+  })
+
+  test('parse-accept: rejects an unterminated inline code span', () => {
+    const issues = validateRichMarkdown('here is `unclosed code')
+    expect(issues.some((i) => i.kind === 'unterminated-code-span')).toBe(true)
+  })
+
+  test('parse-accept: rejects an unclosed inline link destination', () => {
+    const issues = validateRichMarkdown('see [label](https://example.com/path')
+    expect(issues.some((i) => i.kind === 'malformed-link')).toBe(true)
+  })
+
+  test('parse-accept: rejects a bisected (half) table row', () => {
+    const issues = validateRichMarkdown('| a | b')
+    expect(issues.some((i) => i.kind === 'incomplete-table-row')).toBe(true)
+  })
+
+  test('parse-accept: rejects an unbalanced ** bold delimiter', () => {
+    const issues = validateRichMarkdown('this is **bold with no close')
+    expect(issues.some((i) => i.kind === 'unbalanced-emphasis')).toBe(true)
+  })
+
+  test('parse-accept: ACCEPTS well-formed markdown with mixed entities', () => {
+    const good =
+      'Intro **bold** and _italic_ and `code`.\n\n```js\nconst x = 1\n```\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n\nSee [x](https://e.com).'
+    expect(validateRichMarkdown(good)).toEqual([])
+  })
+
+  test('structure: extracts bold/italic/code/pre/link at the right text', () => {
+    const md = 'A **b** and _i_ and `c`.\n```py\nprint(1)\n```\n[lab](https://u.co)'
+    const ents = parseRichEntities(md)
+    expect(ents).toContainEqual({ type: 'bold', text: 'b' })
+    expect(ents).toContainEqual({ type: 'italic', text: 'i' })
+    expect(ents).toContainEqual({ type: 'code', text: 'c' })
+    expect(ents).toContainEqual({ type: 'pre', text: 'print(1)', lang: 'py' })
+    expect(ents).toContainEqual({ type: 'link', text: 'lab', url: 'https://u.co' })
+  })
+
+  test('inline code interior is verbatim — reserved chars do not leak as entities', () => {
+    // `*not bold*` inside code must NOT produce a bold/italic entity.
+    const ents = parseRichEntities('literal `*x*` here')
+    expect(ents.filter((e) => e.type === 'bold' || e.type === 'italic')).toEqual([])
+    expect(ents).toContainEqual({ type: 'code', text: '*x*' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The torture set — signal (a) + (b) for every fixture.
+// ---------------------------------------------------------------------------
+
+describe('formatting torture-set — parse-accept + structure', () => {
+  // F7 is the deliberate degraded path: a >cap indivisible fenced block is
+  // hard-sliced, so its individual chunks are intentionally NOT balanced
+  // markdown. Handled separately below.
+  const standard = TORTURE_SET.filter((f) => f.name !== 'F7-over-cap-hard-slice')
+
+  for (const fx of standard) {
+    describe(fx.name, () => {
+      test(`(intent) ${fx.intent}`, () => {
+        // (a) PARSE-ACCEPT — every emitted chunk is well-formed.
+        const { chunks, body } = transform(fx.input, { cardSurfaceScrub: fx.cardSurfaceScrub })
+        for (const c of chunks) {
+          const issues = validateRichMarkdown(c)
+          expect(
+            issues,
+            `chunk failed parse-accept for fixture "${fx.name}":\n${c}\nissues: ${JSON.stringify(issues)}`,
+          ).toEqual([])
+        }
+
+        // (b) STRUCTURE — the transformed body parses into the intended shape.
+        const ents = parseRichEntities(body)
+        for (const want of fx.expect) expectEntityPresent(ents, want)
+      })
+    })
+  }
+
+  // ── F1 extra assertion: the em/en-dash glyph is actually gone. ────────────
+  test('F1: card-surface scrub removes the em/en-dash glyph before the wire', () => {
+    const fx = TORTURE_SET.find((f) => f.name === 'F1-card-surface-dash-scrub')!
+    const { body } = transform(fx.input, { cardSurfaceScrub: true })
+    expect(body).not.toContain('—') // em dash
+    expect(body).not.toContain('–') // en dash
+    // And the scrubbed body is still parse-accept clean.
+    expect(isRichMarkdownValid(body)).toBe(true)
+  })
+
+  // ── F2 extra assertion: the paragraph break survives (not collapsed). ─────
+  test('F2: a loose interior pipe does not swallow the following paragraph break', () => {
+    const fx = TORTURE_SET.find((f) => f.name === 'F2-stray-pipe-keeps-paragraph-spacing')!
+    const { body } = transform(fx.input)
+    // Both paragraphs are present and separated by a blank line (>= one \n\n).
+    expect(body).toContain('plan A | plan B')
+    expect(body).toContain('one pass')
+    expect(body).toMatch(/\n\s*\n/) // a real paragraph gap survived
+    // The loose pipe line must NOT have been turned into / read as a table
+    // row — the oracle would flag a half-row; it must be clean.
+    expect(isRichMarkdownValid(body)).toBe(true)
+  })
+
+  // ── F4 extra assertion: a blank line now separates the fence from prose. ──
+  test('F4: a blank line is inserted between a closed fence and the following prose', () => {
+    const fx = TORTURE_SET.find((f) => f.name === 'F4-blank-line-after-closed-fence')!
+    const { body } = transform(fx.input)
+    // The fence stays balanced (closed) and the trailing prose survives.
+    const { fences } = scanFences(body)
+    expect(fences.length).toBe(1)
+    expect(fences[0].closed).toBe(true)
+    expect(body).toContain('And it ships today.')
+    // The line immediately following the fence close is blank (the F4 fix).
+    const lines = body.split('\n')
+    const closeIdx = lines.findIndex((l, i) => i > 0 && /^```/.test(l.trim()) && lines[i - 1] !== '```')
+    // Find the LAST fence-close line then assert the next non-fence line has a
+    // blank between it and the fence.
+    const fenceCloseLine = lines.map((l) => l.trim()).lastIndexOf('```')
+    expect(fenceCloseLine).toBeGreaterThan(0)
+    expect(lines[fenceCloseLine + 1] ?? '').toBe('')
+    void closeIdx
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F7 — over-cap indivisible block hard-slices (degraded-but-delivered).
+// Signal (a) does NOT apply per-chunk here by design (a hard slice can bisect
+// a fence). What MUST hold: no content is dropped and every chunk fits the cap.
+// ---------------------------------------------------------------------------
+
+describe('F7-over-cap-hard-slice', () => {
+  const fx = TORTURE_SET.find((f) => f.name === 'F7-over-cap-hard-slice')!
+  const CAP = 100
+
+  test('an oversized indivisible fenced block is sliced to <= cap chunks, losing no content', () => {
+    const { chunks } = transform(fx.input, { cap: CAP })
+    expect(chunks.length).toBeGreaterThan(1)
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(CAP)
+    // No content dropped: the slices concatenate back to the original body.
+    // (The transform is a no-op on this fixture apart from chunking — it has no
+    // prose paragraphs to space, so body === input here.)
+    expect(chunks.join('')).toContain('x'.repeat(600))
+  })
+
+  test('the UN-chunked body is itself parse-accept valid (the fence is balanced)', () => {
+    // Sanity: the corruption F7 accepts is ONLY the intra-chunk fence bisection
+    // forced by the cap — the body as a whole is well-formed. This guards
+    // against F7 silently masking a genuine unbalanced-fence bug in the source.
+    const { body } = transform(fx.input, { cap: RICH_MESSAGE_MAX_CHARS })
+    expect(isRichMarkdownValid(body)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Wiring-level: the fake bot API surfaces parsed entities on the rich path so
+// a test can assert structure at the send boundary (deliverable 3). This uses
+// the SAME independent oracle, keeping the check non-circular.
+// ---------------------------------------------------------------------------
+
+describe('wiring: sendRichMessage entity structure at the send boundary', () => {
+  test('a rich send of a torture body lands parse-valid with the intended entities', async () => {
+    const { createFakeBotApi } = await import('./fake-bot-api.js')
+    const bot = createFakeBotApi()
+    const fx = TORTURE_SET.find((f) => f.name === 'links')!
+    const { body } = transform(fx.input)
+
+    await bot.api.sendRichMessage('chat-1', { markdown: body })
+    const sent = bot.messagesIn('chat-1')
+    expect(sent).toHaveLength(1)
+    expect(sent[0].rich).toBe(true)
+
+    // Re-derive entities from what actually landed on the wire (sent[0].text is
+    // the rich markdown body) using the independent oracle.
+    const landed = sent[0].text
+    expect(isRichMarkdownValid(landed)).toBe(true)
+    for (const want of fx.expect) expectEntityPresent(parseRichEntities(landed), want)
+  })
+})
+
+// Keep a reference so unused-import lint never trips on entitiesOfType even if
+// a future edit drops its only direct use.
+void entitiesOfType

--- a/telegram-plugin/tests/formatting-torture-set.ts
+++ b/telegram-plugin/tests/formatting-torture-set.ts
@@ -1,0 +1,218 @@
+/**
+ * formatting-torture-set — curated fixtures for parse-level formatting
+ * regression testing.
+ *
+ * Each fixture is an INTENT (`input`) plus the STRUCTURE we expect the
+ * formatter's output to parse into (checked by `rich-markdown-oracle.ts`).
+ * The `input` is the raw text as a model/card surface would author it — the
+ * regression test runs it through the SAME outbound transform pipeline the
+ * gateway uses (repairEscapedWhitespace -> normalizeParagraphBreaks ->
+ * addParagraphSpacers -> splitMarkdownChunks) and then asserts:
+ *
+ *   (a) every emitted chunk is parse-accept valid (no rich-path 400), and
+ *   (b) the concatenated output parses into `expect` (entity structure).
+ *
+ * The `expect` block describes WHAT should survive, not a byte-for-byte echo
+ * of formatter output — the oracle is independent of the formatter, so this is
+ * a genuine cross-check, not a circular self-comparison.
+ *
+ * F1/F2/F4/F7 fixtures reproduce the specific formatting fixes from PR #2737
+ * (see `telegram-plugin/format.ts` and `text-voice-scrub.ts`).
+ */
+
+import type { EntityType } from './rich-markdown-oracle.js'
+
+export interface ExpectEntity {
+  readonly type: EntityType
+  /** Exact inner text the entity should carry. */
+  readonly text: string
+  /** For links, the destination. */
+  readonly url?: string
+  /** For fenced blocks, the language info string. */
+  readonly lang?: string
+}
+
+export interface TortureFixture {
+  readonly name: string
+  /** One-line description of the intent this fixture pins. */
+  readonly intent: string
+  /** Raw authored input, before the outbound transform pipeline. */
+  readonly input: string
+  /**
+   * Entities we expect to find in the transformed output. The test asserts
+   * every listed entity is PRESENT (membership), not that these are the only
+   * entities — spacer/structure passes may add nothing observable to the
+   * entity set. Empty ⇒ only signal (a) is asserted for this fixture.
+   */
+  readonly expect: ReadonlyArray<ExpectEntity>
+  /**
+   * When set, the raw input is EXPECTED to be scrubbed by the card-surface
+   * voice pass (F1) before it reaches the rich path — the test applies
+   * `normalizeDashes` first and asserts the em/en-dash glyph is gone.
+   */
+  readonly cardSurfaceScrub?: boolean
+}
+
+export const TORTURE_SET: ReadonlyArray<TortureFixture> = [
+  // ── Multi-item bullet list — one fact per bullet ──────────────────────────
+  {
+    name: 'multi-item-bullet-list',
+    intent: 'A plain multi-item bullet list stays parse-valid and keeps its items intact',
+    input: [
+      'Findings:',
+      '- Master Bath 1 is clean',
+      '- Master Bath 2 shows 33% loss',
+      '- Cabinet is clean',
+    ].join('\n'),
+    expect: [],
+  },
+
+  // ── Middot (·) separator INSIDE a bullet — the collapsed-inline case ──────
+  {
+    name: 'middot-separator-inside-bullet',
+    intent: 'A collapsed one-line bullet list using `·` separators splits without corrupting entities',
+    input: '- Master Bath 1, clean · **Master Bath 2**, 33% loss · Cabinet, clean',
+    expect: [{ type: 'bold', text: 'Master Bath 2' }],
+  },
+
+  // ── Em-dash in prose (voice scrub is a DIFFERENT surface — see F1) ────────
+  {
+    name: 'em-dash-in-prose',
+    intent: 'Prose containing an em-dash is parse-valid on the rich path (raw, un-scrubbed)',
+    input: 'The audit is done — every surface checked, nothing left open.',
+    expect: [],
+  },
+
+  // ── Wide / long code block ────────────────────────────────────────────────
+  {
+    name: 'wide-long-code-block',
+    intent: 'A fenced code block with a long line and reserved chars stays balanced and verbatim',
+    input: [
+      'Run this:',
+      '```bash',
+      'grep -rnE "foo\\|bar\\|baz" src/ | awk -F: \'{print $1}\' | sort -u  # a very very very long command line that keeps going and going',
+      'echo "done"',
+      '```',
+    ].join('\n'),
+    expect: [
+      {
+        type: 'pre',
+        lang: 'bash',
+        text: [
+          'grep -rnE "foo\\|bar\\|baz" src/ | awk -F: \'{print $1}\' | sort -u  # a very very very long command line that keeps going and going',
+          'echo "done"',
+        ].join('\n'),
+      },
+    ],
+  },
+
+  // ── A GFM table ───────────────────────────────────────────────────────────
+  {
+    name: 'gfm-table',
+    intent: 'A GFM table stays row-complete (no bisected/half rows) and parse-valid',
+    input: [
+      'Results:',
+      '',
+      '| Surface | Status | Loss |',
+      '| --- | --- | --- |',
+      '| Bath 1 | clean | 0% |',
+      '| Bath 2 | flagged | 33% |',
+    ].join('\n'),
+    expect: [],
+  },
+
+  // ── A nested list ─────────────────────────────────────────────────────────
+  {
+    name: 'nested-list',
+    intent: 'A nested bullet list stays parse-valid with inline emphasis preserved',
+    input: [
+      '- Top level one',
+      '  - Nested **bold** item',
+      '  - Nested plain item',
+      '- Top level two',
+    ].join('\n'),
+    expect: [{ type: 'bold', text: 'bold' }],
+  },
+
+  // ── A long line that wraps ────────────────────────────────────────────────
+  {
+    name: 'long-wrapping-line',
+    intent: 'A single long prose line is parse-valid and preserves inline entities',
+    input:
+      'This is a single very long line of prose that would wrap on a phone screen and keeps going with more and more words to exceed a comfortable width, and it ends with an inline `code token` plus a **bold phrase** to make sure entities survive the length.',
+    expect: [
+      { type: 'code', text: 'code token' },
+      { type: 'bold', text: 'bold phrase' },
+    ],
+  },
+
+  // ── Links ─────────────────────────────────────────────────────────────────
+  {
+    name: 'links',
+    intent: 'Inline links parse into link entities with the right label + destination',
+    input:
+      'See the [switchroom repo](https://github.com/switchroom/switchroom) and the [docs](https://example.com/docs) for details.',
+    expect: [
+      { type: 'link', text: 'switchroom repo', url: 'https://github.com/switchroom/switchroom' },
+      { type: 'link', text: 'docs', url: 'https://example.com/docs' },
+    ],
+  },
+
+  // ── Inline code containing reserved chars ─────────────────────────────────
+  {
+    name: 'inline-code-reserved-chars',
+    intent: 'Inline code holding *, _, [, ], | renders verbatim without breaking entities',
+    input: 'The pattern `a_b*c[d]|e` is matched literally, and `f*g` too.',
+    expect: [
+      { type: 'code', text: 'a_b*c[d]|e' },
+      { type: 'code', text: 'f*g' },
+    ],
+  },
+
+  // ── F1 — dash-scrub on the card surface ───────────────────────────────────
+  // The card/worker-narration surface runs `normalizeDashes` (voice scrub)
+  // before the rich path; an em-dash must not survive to the wire. Assert the
+  // scrub removes the glyph AND the scrubbed text is parse-valid.
+  {
+    name: 'F1-card-surface-dash-scrub',
+    intent: 'F1: em/en-dash is scrubbed off the card surface and the result stays parse-valid',
+    input: 'Cabinet clean — 33% loss noted, second pass pending – rechecking now.',
+    expect: [],
+    cardSurfaceScrub: true,
+  },
+
+  // ── F2 — a stray pipe must NOT eat paragraph spacing ──────────────────────
+  // A prose line containing a loose ` | ` used to be misread as a table row,
+  // suppressing the paragraph break that follows. The two paragraphs must stay
+  // separated and the whole thing must be parse-valid (no half-table-row).
+  {
+    name: 'F2-stray-pipe-keeps-paragraph-spacing',
+    intent: 'F2: a loose interior pipe in prose does not collapse the following paragraph break',
+    input:
+      'You can choose plan A | plan B depending on scale.\n\nEither way the migration completes in one pass.',
+    expect: [],
+  },
+
+  // ── F4 — blank line after a closed code fence ─────────────────────────────
+  // Prose glued directly onto a fence close (single `\n`) can be swallowed.
+  // The block-boundary pass inserts a blank line; the fence must stay balanced
+  // and the trailing prose must survive as parse-valid text.
+  {
+    name: 'F4-blank-line-after-closed-fence',
+    intent: 'F4: a closed fence followed immediately by prose stays balanced and the prose survives',
+    input: ['Here is the fix:', '```', 'const x = 1', '```', 'And it ships today.'].join('\n'),
+    expect: [{ type: 'pre', text: 'const x = 1' }],
+  },
+
+  // ── F7 — over-cap chunk falls back to hard-slice, not dropped ─────────────
+  // An indivisible fenced block larger than the cap must be hard-sliced into
+  // <= cap pieces rather than emitted whole (which Telegram rejects) or dropped.
+  // The test drives this with a small cap so the giant block cannot fit; it
+  // asserts no content is lost and every emitted chunk fits the cap.
+  {
+    name: 'F7-over-cap-hard-slice',
+    intent: 'F7: an oversized indivisible fenced block is hard-sliced to <= cap, losing no content',
+    input: '```\n' + 'x'.repeat(600) + '\n```',
+    expect: [],
+  },
+]

--- a/telegram-plugin/tests/rich-markdown-oracle.ts
+++ b/telegram-plugin/tests/rich-markdown-oracle.ts
@@ -1,0 +1,469 @@
+/**
+ * rich-markdown-oracle — an INDEPENDENT CommonMark/GFM validator + entity
+ * extractor for the Bot API 10.1 rich-message path (`sendRichMessage`,
+ * `editMessageText({ markdown })`).
+ *
+ * ── Why this exists ────────────────────────────────────────────────────────
+ * Every outbound message now ships as raw GFM markdown through the rich path
+ * (see `format.ts` / `rich-send.ts`). A malformed body makes Telegram throw a
+ * 400 ("can't parse entities" / "can't find end of the entity" — see
+ * `isParseEntitiesError` in `rich-send.ts`), which drops or corrupts the
+ * message. Our existing format tests string-compare the text we *emit*; they
+ * do NOT verify that the emitted markdown is well-formed enough that Telegram
+ * won't reject it, nor that it parses into the entity structure we intended.
+ *
+ * This oracle closes that gap with TWO signals:
+ *   (a) PARSE-ACCEPT: `validateRichMarkdown(md)` returns [] when the body is
+ *       well-formed on every axis whose violation actually produces a rich-path
+ *       400 or a corrupt render; otherwise it returns a list of concrete
+ *       problems. A test asserting `[]` fails loudly on output Telegram would
+ *       reject.
+ *   (b) STRUCTURE: `parseRichEntities(md)` extracts the entity spans (bold,
+ *       italic, code, pre/fence, link, strikethrough) so a test can assert the
+ *       body parses into the intended shape.
+ *
+ * ── The non-circularity guarantee (READ THIS) ──────────────────────────────
+ * The oracle is a HAND-WRITTEN tokenizer that follows the CommonMark/GFM
+ * grammar and Telegram's documented entity-closure rules. It shares NO code
+ * with `format.ts` — it does not import, echo, or re-derive the formatter's
+ * output. It is a second, independent implementation, so asserting the
+ * formatter's output against it is a genuine cross-check, not a formatter
+ * comparing itself to itself.
+ *
+ * ── Scope boundary (documented, deliberate) ────────────────────────────────
+ * A byte-exact port of the full CommonMark reference parser is ~3000 lines and
+ * not worth hand-rolling reliably. So:
+ *   - Signal (a) is RIGOROUS for the constructs whose malformedness is what
+ *     actually 400s / corrupts on the rich path: unbalanced fenced-code
+ *     delimiters, unterminated inline code spans, malformed / unclosed link
+ *     syntax, and structurally-incomplete table rows. These are precisely the
+ *     failure modes `format.ts`'s chunker + block-boundary passes are built to
+ *     avoid, so they are the ones a regression test must guard.
+ *   - Signal (b) covers the COMMON entity types (bold `**`/`__`, italic
+ *     `*`/`_`, strikethrough `~~`, inline code, fenced code, links). It uses a
+ *     simplified-but-faithful delimiter model. It deliberately does NOT model
+ *     every CommonMark emphasis edge case (intraword `_`, triple-run
+ *     `***bold italic***` nesting split points) — those are called out inline
+ *     and the fixtures avoid depending on them. When in doubt the extractor is
+ *     CONSERVATIVE: it reports a span only when the open/close is unambiguous.
+ *
+ * CommonMark itself never "fails to parse" (every string is valid CommonMark),
+ * so a naive "does it parse" check would be vacuous. That is exactly why signal
+ * (a) is defined as *structural well-formedness of the emitted constructs*
+ * rather than "did a CommonMark parser throw" — it is the real predictor of a
+ * rich-path 400.
+ */
+
+// ---------------------------------------------------------------------------
+// Entity model
+// ---------------------------------------------------------------------------
+
+export type EntityType =
+  | 'bold'
+  | 'italic'
+  | 'strikethrough'
+  | 'code' // inline code span
+  | 'pre' // fenced code block
+  | 'link'
+
+export interface RichEntity {
+  readonly type: EntityType
+  /** The rendered (delimiter-stripped) inner text of the entity. */
+  readonly text: string
+  /** For a link, the destination URL. */
+  readonly url?: string
+  /** For a fenced block, the info string (language), if any. */
+  readonly lang?: string
+}
+
+export interface ParseIssue {
+  readonly kind:
+    | 'unbalanced-fence'
+    | 'unterminated-code-span'
+    | 'malformed-link'
+    | 'incomplete-table-row'
+    | 'unbalanced-emphasis'
+  readonly detail: string
+  /** 1-based line number where the problem was detected, when known. */
+  readonly line?: number
+}
+
+// ---------------------------------------------------------------------------
+// Fence / code-region masking (independent re-implementation — NOT imported
+// from format.ts, on purpose). We mask fenced blocks and inline code so the
+// emphasis/link scanners never see their interior, matching how a CommonMark
+// parser treats code as verbatim.
+// ---------------------------------------------------------------------------
+
+interface Fence {
+  readonly lang: string
+  readonly body: string
+  readonly startLine: number
+  readonly closed: boolean
+}
+
+/**
+ * Split the document into fenced-code regions and everything else, tracking
+ * whether each fence is CLOSED. A fence opens on a line whose first non-space
+ * run is ``` (or longer) or ~~~; it closes on a later line whose fence marker
+ * is the same char and at least as long, with no trailing info string.
+ *
+ * This is the CommonMark fenced-code rule, scoped to the two markers Telegram
+ * emits (``` predominantly). An unclosed fence is the single most common cause
+ * of a corrupt rich render (it swallows the rest of the message), so we track
+ * `closed` explicitly for signal (a).
+ */
+export function scanFences(md: string): {
+  fences: Fence[]
+  /** Line indices (0-based) that belong to a fence (open, body, close). */
+  fenceLineSet: Set<number>
+} {
+  const lines = md.split('\n')
+  const fences: Fence[] = []
+  const fenceLineSet = new Set<number>()
+  let i = 0
+  const openRe = /^(\s*)(`{3,}|~{3,})\s*([^\n`]*)$/
+  while (i < lines.length) {
+    const m = lines[i].match(openRe)
+    if (m == null) {
+      i++
+      continue
+    }
+    const indent = m[1].length
+    const marker = m[2]
+    const fenceChar = marker[0]
+    const lang = m[3].trim()
+    const startLine = i
+    fenceLineSet.add(i)
+    const bodyLines: string[] = []
+    let j = i + 1
+    let closed = false
+    // Close marker: same char, length >= open marker, only whitespace after.
+    const closeRe = new RegExp(`^\\s*${fenceChar === '`' ? '`' : '~'}{${marker.length},}\\s*$`)
+    for (; j < lines.length; j++) {
+      if (closeRe.test(lines[j])) {
+        fenceLineSet.add(j)
+        closed = true
+        break
+      }
+      bodyLines.push(lines[j].slice(indent))
+      fenceLineSet.add(j)
+    }
+    fences.push({ lang, body: bodyLines.join('\n'), startLine, closed })
+    i = closed ? j + 1 : j
+  }
+  return { fences, fenceLineSet }
+}
+
+/**
+ * Replace fenced regions with blank lines (preserving line count) so the
+ * inline scanners never see fence interiors. Returns the masked doc plus the
+ * fence list.
+ */
+function maskFences(md: string): { masked: string; fences: Fence[]; fenceLineSet: Set<number> } {
+  const { fences, fenceLineSet } = scanFences(md)
+  const lines = md.split('\n')
+  const masked = lines.map((l, idx) => (fenceLineSet.has(idx) ? '' : l)).join('\n')
+  return { masked, fences, fenceLineSet }
+}
+
+/**
+ * Extract inline code spans from a single line (fence interiors already
+ * masked). CommonMark inline code is a run of N backticks, closed by the next
+ * run of exactly N backticks. We support the common single- and double-tick
+ * forms our formatter emits. Returns the spans and the line with each span
+ * blanked (same length) so downstream emphasis scanning skips code content.
+ */
+function extractInlineCode(line: string): { spans: string[]; blanked: string; unterminated: boolean } {
+  const spans: string[] = []
+  let out = ''
+  let i = 0
+  let unterminated = false
+  while (i < line.length) {
+    if (line[i] === '`') {
+      // Measure opening run length.
+      let n = 0
+      while (line[i + n] === '`') n++
+      const openEnd = i + n
+      // Find a closing run of EXACTLY n backticks.
+      let k = openEnd
+      let closeStart = -1
+      while (k < line.length) {
+        if (line[k] === '`') {
+          let m = 0
+          while (line[k + m] === '`') m++
+          if (m === n) {
+            closeStart = k
+            break
+          }
+          k += m
+        } else {
+          k++
+        }
+      }
+      if (closeStart === -1) {
+        // No matching close on this line → unterminated inline code span.
+        unterminated = true
+        out += line.slice(i)
+        break
+      }
+      const inner = line.slice(openEnd, closeStart)
+      spans.push(inner)
+      // Blank out the whole span (ticks + inner) with spaces of equal length.
+      out += ' '.repeat(closeStart + n - i)
+      i = closeStart + n
+    } else {
+      out += line[i]
+      i++
+    }
+  }
+  return { spans, blanked: out, unterminated }
+}
+
+// ---------------------------------------------------------------------------
+// Signal (a): PARSE-ACCEPT validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate that `md` is well-formed enough that Telegram's rich-message path
+ * would NOT 400 on it. Returns an empty array on success, else a list of the
+ * concrete problems found. See the module doc for the exact scope of "well
+ * formed" and why it is the right predictor of a rich-path reject.
+ */
+export function validateRichMarkdown(md: string): ParseIssue[] {
+  const issues: ParseIssue[] = []
+  const { masked, fences } = maskFences(md)
+
+  // --- Unbalanced fence: an unclosed fenced block corrupts the render. -----
+  for (const f of fences) {
+    if (!f.closed) {
+      issues.push({
+        kind: 'unbalanced-fence',
+        detail: `fenced code block opened at line ${f.startLine + 1} is never closed`,
+        line: f.startLine + 1,
+      })
+    }
+  }
+  // Defensive: an ODD number of lone ``` fence lines (that scanFences somehow
+  // did not pair) is also an imbalance. scanFences already pairs greedily, so
+  // this catches only truly stray markers.
+  const strayFenceLines = (md.match(/^\s*(`{3,}|~{3,})\s*$/gm) ?? []).length
+  const openWithInfo = (md.match(/^\s*(`{3,}|~{3,})[^\n`~]+$/gm) ?? []).length
+  if ((strayFenceLines + openWithInfo) % 2 !== 0 && fences.every((f) => f.closed)) {
+    issues.push({
+      kind: 'unbalanced-fence',
+      detail: `odd number of fence delimiter lines (${strayFenceLines + openWithInfo})`,
+    })
+  }
+
+  const maskedLines = masked.split('\n')
+  maskedLines.forEach((rawLine, idx) => {
+    const { blanked, unterminated } = extractInlineCode(rawLine)
+    if (unterminated) {
+      issues.push({
+        kind: 'unterminated-code-span',
+        detail: `inline code span opened but not closed on line ${idx + 1}`,
+        line: idx + 1,
+      })
+    }
+    // --- Malformed link: a `[label](` that never closes its `)` ------------
+    // Only flag an OPENED inline-link that fails to close — a lone `[` used as
+    // literal text (no following `(`) is valid CommonMark and renders fine.
+    checkLinks(blanked, idx + 1, issues)
+  })
+
+  // --- Incomplete table row: a GFM table row must be a complete `| … |`. ---
+  checkTableRows(md, issues)
+
+  // --- Emphasis balance (common-case): odd count of unescaped `**` runs etc.
+  checkEmphasisBalance(masked, issues)
+
+  return issues
+}
+
+/**
+ * Flag an inline-link open `[...](` whose `(...)` destination never closes on
+ * the same line. A closed `[a](b)` is fine; a bare `[a]` with no `(` is fine
+ * (literal text). Nested `()` inside the destination are balanced-counted.
+ */
+function checkLinks(line: string, lineNo: number, issues: ParseIssue[]): void {
+  const re = /\[[^\]]*\]\(/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(line)) != null) {
+    // Start scanning the destination just after `](`.
+    let depth = 1
+    let k = m.index + m[0].length
+    let closed = false
+    for (; k < line.length; k++) {
+      if (line[k] === '(') depth++
+      else if (line[k] === ')') {
+        depth--
+        if (depth === 0) {
+          closed = true
+          break
+        }
+      }
+    }
+    if (!closed) {
+      issues.push({
+        kind: 'malformed-link',
+        detail: `inline link opened at line ${lineNo} col ${m.index + 1} has an unclosed destination`,
+        line: lineNo,
+      })
+    }
+  }
+}
+
+/**
+ * A GFM table is a header row, a delimiter row (`| --- | --- |`), then body
+ * rows. Every row that participates must be a complete pipe row. We flag a
+ * delimiter row that is NOT flanked by a complete header above and at least a
+ * well-formed body/structure — i.e. the specific corruption `format.ts`'s
+ * chunker guards against (a bisected half-row). A row is "complete" when, after
+ * trimming, it starts and ends with `|` OR is a headerless GFM row with a
+ * matching delimiter. We keep this conservative: only flag a row that opens
+ * with `|` but does not close with `|` (a clearly bisected row).
+ */
+function checkTableRows(md: string, issues: ParseIssue[]): void {
+  const { fenceLineSet } = maskFences(md)
+  const lines = md.split('\n')
+  lines.forEach((line, idx) => {
+    if (fenceLineSet.has(idx)) return
+    const t = line.trim()
+    if (t.length === 0) return
+    const looksLikeRow = t.startsWith('|')
+    if (!looksLikeRow) return
+    // A leading-pipe row must also close with a pipe to be a complete row.
+    if (!t.endsWith('|')) {
+      issues.push({
+        kind: 'incomplete-table-row',
+        detail: `table row opens with '|' but does not close with '|' on line ${idx + 1}`,
+        line: idx + 1,
+      })
+    }
+  })
+}
+
+/**
+ * Common-case emphasis balance. Counts unescaped `**` and `__` (bold) runs and
+ * standalone `*`/`_` (italic) and `~~` (strikethrough) on the fence+code-masked
+ * text; an odd count means an unterminated emphasis entity — the thing that
+ * yields "can't find end of the entity" on the rich path.
+ *
+ * NOTE (scope): this is a COUNT check, not a full delimiter-run resolver. It
+ * intentionally does not model CommonMark's left/right-flanking rules, so it
+ * can miss an exotic imbalance or (rarely) over-flag a legitimately
+ * asymmetric-but-valid construct. The torture-set fixtures avoid such exotic
+ * cases so this check stays a reliable regression signal. Escaped markers
+ * (`\*`) and code (already masked) are excluded.
+ */
+function checkEmphasisBalance(masked: string, issues: ParseIssue[]): void {
+  // Strip inline code per-line first (reuse extractInlineCode's blanking).
+  const codeStripped = masked
+    .split('\n')
+    .map((l) => extractInlineCode(l).blanked)
+    .join('\n')
+  // Remove escaped markers so `\*` doesn't count.
+  const noEsc = codeStripped.replace(/\\[*_~`\\]/g, '')
+
+  // Bold `**` and `__`: count runs.
+  const doubleStar = (noEsc.match(/\*\*/g) ?? []).length
+  if (doubleStar % 2 !== 0) {
+    issues.push({ kind: 'unbalanced-emphasis', detail: `odd number of '**' bold delimiters (${doubleStar})` })
+  }
+  const strike = (noEsc.match(/~~/g) ?? []).length
+  if (strike % 2 !== 0) {
+    issues.push({ kind: 'unbalanced-emphasis', detail: `odd number of '~~' strikethrough delimiters (${strike})` })
+  }
+  // Single `*` italic: count SINGLE stars that are not part of a `**` pair.
+  // Remove `**` pairs first, then count leftover lone `*`.
+  const noBold = noEsc.replace(/\*\*/g, '')
+  const loneStar = (noBold.match(/\*/g) ?? []).length
+  if (loneStar % 2 !== 0) {
+    issues.push({ kind: 'unbalanced-emphasis', detail: `odd number of lone '*' italic delimiters (${loneStar})` })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Signal (b): STRUCTURE extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the common entity structure out of a rich-markdown body. Fenced blocks
+ * are extracted first (as `pre`), then inline code, links, bold, italic and
+ * strikethrough from the remaining text. See the module doc for the scope of
+ * "common entities". Order of returned entities is document order per type is
+ * NOT guaranteed across types; assert on membership, not absolute index, in
+ * tests (helpers below make that easy).
+ */
+export function parseRichEntities(md: string): RichEntity[] {
+  const entities: RichEntity[] = []
+  const { masked, fences } = maskFences(md)
+
+  for (const f of fences) {
+    entities.push({ type: 'pre', text: f.body, lang: f.lang.length > 0 ? f.lang : undefined })
+  }
+
+  // Inline code + links + emphasis on the masked (fence-free) text, line-wise.
+  for (const rawLine of masked.split('\n')) {
+    const { spans, blanked } = extractInlineCode(rawLine)
+    for (const s of spans) entities.push({ type: 'code', text: s })
+
+    // Links: [label](url). Extract before emphasis so a bracketed label with
+    // emphasis inside is handled as a link (label text preserved verbatim).
+    let line = blanked
+    const linkRe = /\[([^\]]*)\]\(([^)]*)\)/g
+    let lm: RegExpExecArray | null
+    const linkBlank: string[] = []
+    while ((lm = linkRe.exec(line)) != null) {
+      entities.push({ type: 'link', text: lm[1], url: lm[2] })
+      linkBlank.push(lm[0])
+    }
+    for (const lb of linkBlank) line = line.replace(lb, ' '.repeat(lb.length))
+
+    // Strikethrough ~~...~~
+    line = collect(line, /~~([^~]+)~~/g, (mtext) => entities.push({ type: 'strikethrough', text: mtext }))
+    // Bold **...** (and __...__)
+    line = collect(line, /\*\*([^*]+)\*\*/g, (mtext) => entities.push({ type: 'bold', text: mtext }))
+    line = collect(line, /__([^_]+)__/g, (mtext) => entities.push({ type: 'bold', text: mtext }))
+    // Italic *...* / _..._  (bold already removed above)
+    line = collect(line, /\*([^*]+)\*/g, (mtext) => entities.push({ type: 'italic', text: mtext }))
+    line = collect(line, /(?<![A-Za-z0-9])_([^_]+)_(?![A-Za-z0-9])/g, (mtext) =>
+      entities.push({ type: 'italic', text: mtext }),
+    )
+  }
+
+  return entities
+}
+
+/** Apply `re` globally, invoke `cb` with capture group 1, blank the match. */
+function collect(line: string, re: RegExp, cb: (inner: string) => void): string {
+  let out = line
+  let m: RegExpExecArray | null
+  const toBlank: string[] = []
+  while ((m = re.exec(line)) != null) {
+    cb(m[1])
+    toBlank.push(m[0])
+  }
+  for (const b of toBlank) out = out.replace(b, ' '.repeat(b.length))
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Test-facing convenience helpers
+// ---------------------------------------------------------------------------
+
+/** True when the body is parse-accept clean (signal a). */
+export function isRichMarkdownValid(md: string): boolean {
+  return validateRichMarkdown(md).length === 0
+}
+
+/** All entities of a given type, in document order. */
+export function entitiesOfType(md: string, type: EntityType): RichEntity[] {
+  return parseRichEntities(md).filter((e) => e.type === type)
+}
+
+/** The set of rendered inner texts for a given entity type. */
+export function entityTexts(md: string, type: EntityType): string[] {
+  return entitiesOfType(md, type).map((e) => e.text)
+}


### PR DESCRIPTION
## Summary

Phase-1 parse-level formatting regression suite. Every PR now automatically catches formatting regressions at the **parse** level — verifying the markdown we emit on the rich-message path is well-formed (Telegram won't 400) AND parses into the entity structure we intended — not just string-comparing the text we send.

Three new **test-only** files:
- `telegram-plugin/tests/rich-markdown-oracle.ts` — an independent CommonMark/GFM validator + entity extractor.
- `telegram-plugin/tests/formatting-torture-set.ts` — the curated fixture set.
- `telegram-plugin/tests/formatting-parse-regression.test.ts` — the assertions.

## The two signals

For each fixture, the raw intent is run through the **same** outbound transform pipeline the gateway uses (`repairEscapedWhitespace → normalizeParagraphBreaks → addParagraphSpacers → splitMarkdownChunks`), then:

- **(a) PARSE-ACCEPT** — every emitted chunk is well-formed enough that Telegram's Bot API 10.1 rich path would not 400 on it: balanced fenced-code delimiters, terminated inline code spans, closed inline links, complete (non-bisected) table rows, balanced emphasis.
- **(b) STRUCTURE** — the transformed body parses into the intended entities (bold / italic / code / pre / link) at the right inner text.

## Non-circular by construction

The oracle is a **hand-written** validator/parser that shares no code with `format.ts`. It is a second, independent implementation, so the suite is a genuine cross-check, not the formatter comparing itself to itself. Oracle self-tests prove it is non-vacuous — it rejects unclosed fences, unterminated code spans, unclosed links, half table rows, and unbalanced `**`, and accepts well-formed mixed-entity bodies.

## Framing correction (worth a look on review)

The original task framing assumed **MarkdownV2**. The actual outbound rich path is **CommonMark/GFM** (`sendRichMessage({ markdown })`) — the markdown→HTML engine and the MarkdownV2 escaper were removed in #2669. The oracle therefore validates CommonMark/GFM. Because CommonMark never hard-fails to parse, signal (a) is deliberately scoped to *structural well-formedness of the emitted constructs* (the real predictors of a rich-path 400 / corrupt render), documented in the oracle header.

## What it protects

Fixtures: multi-item bullet lists, the `·`-middot collapsed-inline bullet case, em-dash prose, a wide/long code block, a GFM table, a nested list, a long wrapping line, links, inline code containing reserved chars, plus explicit repros of the PR #2737 fixes:
- **F1** — dash-scrub on the card surface (em/en-dash gone before the wire, result still parse-valid).
- **F2** — a loose interior pipe in prose no longer collapses the following paragraph break (and isn't misread as a table row).
- **F4** — a blank line is inserted between a closed code fence and following prose (fence stays balanced, prose survives).
- **F7** — an over-cap indivisible fenced block hard-slices to ≤ cap chunks, losing no content (the one degraded path where per-chunk parse-accept intentionally does not apply; the un-chunked body is asserted balanced).

## Test plan

- `npm run lint` — clean (tsc --noEmit + all guard scripts).
- New suite + `telegram-format`, `card-format`, `harness-parse-mode-validation` — 105 green under vitest.
- Full vitest run introduces **no new failures**: the pre-existing CLI/scaffold/install/host-control failures in this environment (tmp paths / subprocess / binary-build harness) reproduce identically on clean `origin/main`; this change is purely additive and touches no production or existing-test code.

## Risk

Test-only. No production formatting behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)