### PR TITLE
test(uat): real-account renders rich formatting (mtcute 0.30 + entities/permalink) (#2739)

### DIFF
--- a/.github/workflows/ci-uat.yml
+++ b/.github/workflows/ci-uat.yml
@@ -156,6 +156,17 @@ jobs:
         # deterministic, fast.
         working-directory: telegram-plugin
         run: bun run test:uat inbound-no-drop
+      - name: Render fidelity — rich formatting entities + permalink
+        if: steps.secrets.outputs.ok == 'true'
+        # Real-render regression gate (#2739): drives a real agent turn that
+        # replies with rich formatting, then reads back — via the mtcute
+        # driver — the entity structure Telegram ACTUALLY parsed. Proves the
+        # rich message decodes to real text + entities (not the pre-upgrade
+        # \x01 unsupported-media sentinel) and that bold/italic/code/pre/link
+        # survive the render round-trip. The higher-fidelity companion to the
+        # Phase 1 parse-level suite.
+        working-directory: telegram-plugin
+        run: bun run test:uat jtbd-rich-formatting-render-dm
 
   # ─── Sentinel ─────────────────────────────────────────────────────
   # Branch-protection-required context. ALWAYS runs (ubuntu-latest, no

--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
       "dependencies": {
         "@grammyjs/runner": "^2.0.3",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@mtcute/node": "^0.27.0",
+        "@mtcute/node": "^0.30.1",
         "@secretlint/core": "^12.2.0",
         "@secretlint/secretlint-rule-preset-recommend": "^12.2.0",
         "@secretlint/types": "^12.2.0",
@@ -187,21 +187,19 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@mtcute/core": ["@mtcute/core@0.27.9", "", { "dependencies": { "@fuman/io": "0.0.19", "@fuman/net": "0.0.19", "@fuman/utils": "0.0.19", "@mtcute/file-id": "^0.27.8", "@mtcute/tl": "^221.0.0", "@mtcute/tl-runtime": "^0.24.3", "@types/events": "3.0.0", "long": "5.2.3" } }, "sha512-kbi/ml8H7Asnn5u1yQVRVl8CVZd03WU2Z4Sgd5d3RYqaoqRUA9wgUV9aEhq+bEgsvmnEr+PuwZ+/HKriXhtqlA=="],
+    "@mtcute/core": ["@mtcute/core@0.30.1", "", { "dependencies": { "@fuman/io": "0.0.19", "@fuman/net": "0.0.19", "@fuman/utils": "0.0.19", "@mtcute/file-id": "^0.29.0", "@mtcute/tl-runtime": "^0.29.0", "@types/events": "3.0.0", "long": "^5.3.2" } }, "sha512-9mppVRIiC/h8PI8Jo+KhBihk4xR0DwKt16Q9PDUNDcsr4OutmDAK+GCXTzTp2e1MZ/iMMFlJ8PE6mjlQSGSnyg=="],
 
-    "@mtcute/file-id": ["@mtcute/file-id@0.27.8", "", { "dependencies": { "@fuman/utils": "0.0.19", "@mtcute/tl-runtime": "^0.24.3", "long": "5.2.3" } }, "sha512-clwuBxVZKCSv65HMjxCx0zSnaZypAeNFy0pmnA0Uhvb9zvvB8lbd9Ig2BPieUkk/BbI+z8KZa0jvWOVe929Egw=="],
+    "@mtcute/file-id": ["@mtcute/file-id@0.29.0", "", { "dependencies": { "@fuman/utils": "0.0.19", "@mtcute/tl-runtime": "^0.29.0", "long": "^5.3.2" } }, "sha512-kfNFKjdfFoo9YIl823EJ068u0djgK6MsqfIHIcb6iwmKOxnCFTLRvBGnJUaO+SbOejg63Tz5lzQxKnt03kEV6A=="],
 
-    "@mtcute/html-parser": ["@mtcute/html-parser@0.27.9", "", { "dependencies": { "@mtcute/core": "^0.27.9", "htmlparser2": "^10.0.0", "long": "5.2.3" } }, "sha512-ojq7ah4rwkLWmZP0fZx4glnSA7D75fcrMBS1HsEf6/uyrWy/F74aDZWwdLMrL8EjSVS0JdMKbli+kow+49JPJA=="],
+    "@mtcute/html-parser": ["@mtcute/html-parser@0.30.1", "", { "dependencies": { "@mtcute/core": "^0.30.1", "htmlparser2": "^10.0.0", "long": "^5.3.2" } }, "sha512-j/eosnkgDAUSKojIU7ArOvnZuIIpgGlsTDJep1r1WcdTYSzbAzKOi6usMT4JvyS6EKEbu1tu+KpJf14BHlcPbQ=="],
 
-    "@mtcute/markdown-parser": ["@mtcute/markdown-parser@0.27.9", "", { "dependencies": { "@mtcute/core": "^0.27.9", "long": "5.2.3" } }, "sha512-4roQapd+r3aZtP2BWeYbcPt6rhZUBv1Ua0CJfopGY25XlU3lEDYeqGrn0KuWYKr11dztEDo5M01IBmcyRqUlow=="],
+    "@mtcute/markdown-parser": ["@mtcute/markdown-parser@0.30.1", "", { "dependencies": { "@mtcute/core": "^0.30.1", "long": "^5.3.2" } }, "sha512-QYeRMp4tzg0ruBc1dMnooK2M64js0y1r8xi2BlGtFsco/utFHBpEGsas6ckGkQlHfq6Dtdwn5SePe+GYqZP/CA=="],
 
-    "@mtcute/node": ["@mtcute/node@0.27.9", "", { "dependencies": { "@fuman/net": "0.0.19", "@fuman/node": "0.0.19", "@fuman/utils": "0.0.19", "@mtcute/core": "^0.27.9", "@mtcute/html-parser": "^0.27.9", "@mtcute/markdown-parser": "^0.27.9", "@mtcute/wasm": "^0.27.8", "better-sqlite3": "^12.4.1" } }, "sha512-Tflz5LRbTG5DE2rSUIRhLlBfey7ibhSQLTLTJD9nsoNpBeOG4ms/bc6VfBTQMHJytb8VCYQOHrXWZb9eYhWOPg=="],
+    "@mtcute/node": ["@mtcute/node@0.30.1", "", { "dependencies": { "@fuman/net": "0.0.19", "@fuman/node": "0.0.19", "@fuman/utils": "0.0.19", "@mtcute/core": "^0.30.1", "@mtcute/html-parser": "^0.30.1", "@mtcute/markdown-parser": "^0.30.1", "@mtcute/wasm": "^0.29.0", "better-sqlite3": "^12.10.0" } }, "sha512-MqG+St3sTivPzI093bM2OI0YD7KrrKJcAbXwUDGc04L1gKwbZHcc4QZPLlhCFKGxsxAsotSVmuhpPq+AmXIhfQ=="],
 
-    "@mtcute/tl": ["@mtcute/tl@221.0.0", "", { "dependencies": { "long": "5.2.3" } }, "sha512-Wp01L9nznTMLl2s9rbKnzQ8pij72eF4HK2XIziOQoJXiObPKZxQdxvMj+C6l0ArxMFmpT0H0/3EL5RB7O6VPwg=="],
+    "@mtcute/tl-runtime": ["@mtcute/tl-runtime@0.29.0", "", { "dependencies": { "@fuman/utils": "0.0.19", "long": "^5.3.2" } }, "sha512-VhDVYKYeC5TypdgzJ/6CtoZgwlR3h1xKatVTnuVcAe1sXrbIwju0EzZlPbUCjH6vgoOXyrJvkhUXdax/oSSjpg=="],
 
-    "@mtcute/tl-runtime": ["@mtcute/tl-runtime@0.24.3", "", { "dependencies": { "@fuman/utils": "0.0.15", "long": "5.2.3" } }, "sha512-61J3cgYgNOQT532GdIiuezRrSC7v6cc9MfvWv9GO27bRGf7JUKWVbFt4U0KzQ9Tp0J1uMOUfi1EbQKkYKacIKQ=="],
-
-    "@mtcute/wasm": ["@mtcute/wasm@0.27.8", "", {}, "sha512-3z1v1WtkAAW95l5t8LB3Ul+Y8dQNMez5YF16cHE3mAHX5RRrfgE+rgVk+wRQJHa24CugfuEEBSi6QpdZuTRBIw=="],
+    "@mtcute/wasm": ["@mtcute/wasm@0.29.0", "", {}, "sha512-PFZ60ufUIt3BW1FFkCqcaEvEcezaTK+KyMVs3A/aXA19aFhDpu6HCSI8FJ6iOfGsIMGaNGYrwH3CZ7XxLn24XA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -333,7 +331,7 @@
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
-    "better-sqlite3": ["better-sqlite3@12.9.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ=="],
+    "better-sqlite3": ["better-sqlite3@12.11.1", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA=="],
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
@@ -585,7 +583,7 @@
 
     "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
 
-    "long": ["long@5.2.3", "", {}, "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="],
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
@@ -874,8 +872,6 @@
     "@manypkg/get-packages/@changesets/types": ["@changesets/types@4.1.0", "", {}, "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="],
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
-
-    "@mtcute/tl-runtime/@fuman/utils": ["@fuman/utils@0.0.15", "", {}, "sha512-3H3WzkfG7iLKCa/yNV4s80lYD4yr5hgiNzU13ysLY2BcDqFjM08XGYuLd5wFVp4V8+DA/fe8gIDW96To/JwDyA=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 

--- a/telegram-plugin/package.json
+++ b/telegram-plugin/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@grammyjs/runner": "^2.0.3",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@mtcute/node": "^0.27.0",
+    "@mtcute/node": "^0.30.1",
     "@secretlint/core": "^12.2.0",
     "@secretlint/secretlint-rule-preset-recommend": "^12.2.0",
     "@secretlint/types": "^12.2.0",

--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -72,6 +72,45 @@ export interface ObservedMessage {
    * must be silent, only the final answer should ping.
    */
   silent: boolean;
+  /**
+   * The rich-formatting entities Telegram actually attached to the
+   * rendered message (bold / italic / code / pre / text_link / …),
+   * normalized from mtcute's `Message.entities`. This is what the
+   * highest-fidelity UAT layer asserts on: not the markdown we SENT, but
+   * the entity structure Telegram PARSED and will render. Empty array for
+   * a plain-text message with no formatting.
+   *
+   * Empty (never undefined) when the message body could not be decoded to
+   * real text+entities (see `text === "\x01"` sentinel below).
+   */
+  entities: ObservedEntity[];
+  /**
+   * The `t.me/c/<internal_chat>/<msgid>` (or `t.me/<username>/<msgid>`)
+   * permalink to this message, for human eyeball reference in UAT output.
+   * `undefined` for chats that don't support message links (private DMs) —
+   * mtcute's `Message.link` getter throws there, so we swallow and leave it
+   * unset rather than fail the observation.
+   */
+  link?: string;
+}
+
+/**
+ * One rich-formatting entity as Telegram parsed it, flattened from
+ * mtcute's `MessageEntity` into the fields a UAT assertion cares about.
+ * `kind` is mtcute's entity kind (`bold`, `italic`, `code`, `pre`,
+ * `text_link`, `blockquote`, …); `text` is the exact inner substring the
+ * entity spans; `offset`/`length` are UTF-16 code-unit coordinates (the
+ * same units Telegram uses on the wire).
+ */
+export interface ObservedEntity {
+  kind: string;
+  offset: number;
+  length: number;
+  text: string;
+  /** Destination for `text_link` entities; undefined otherwise. */
+  url?: string;
+  /** Language info string for `pre` fenced blocks; undefined otherwise. */
+  language?: string;
 }
 
 export interface ObservedButton {
@@ -838,10 +877,15 @@ export class Driver {
 }
 
 function toObserved(msg: Message, edited: boolean): ObservedMessage {
-  // Bot API 10.1 sendRichMessage stores text in a new MTProto media type.
-  // mtcute 0.27.9 decodes this as messageMediaUnsupported with empty
-  // message.message. Use a sentinel so text-based assertions still fire
-  // until mtcute is updated to support the new TL constructor.
+  // Bot API 10.1 rich messages (`sendMessage` with `{ markdown }`) used to
+  // arrive as `messageMediaUnsupported` with an empty `message.message` on
+  // the pinned mtcute (0.27.x). With mtcute >=0.30 the message decodes to
+  // real text + entities, so we surface those directly. The
+  // `messageMediaUnsupported` sentinel path is KEPT as a defensive fallback:
+  // if a future Bot API / TL-layer change ever regresses the decode, the
+  // `\x01` sentinel still lets text-presence assertions fire (and the
+  // formatting scenario will flag the empty-entities case loudly rather than
+  // silently pass). It is no longer expected to trigger on the happy path.
   const rawText = msg.text ?? "";
   const isRichMedia = rawText === "" &&
     msg.raw._ === "message" && msg.raw.media?._ === "messageMediaUnsupported";
@@ -855,5 +899,47 @@ function toObserved(msg: Message, edited: boolean): ObservedMessage {
     date: msg.date,
     edited,
     silent: msg.isSilent,
+    entities: isRichMedia ? [] : toObservedEntities(msg),
+    link: safeMessageLink(msg),
   };
+}
+
+/**
+ * Flatten mtcute's `Message.entities` into the `ObservedEntity[]` the UAT
+ * assertions consume. Pulls the entity `url` (text_link) and `language`
+ * (pre) out of the discriminated `params` union so scenarios can assert on
+ * link destinations and fenced-block languages, not just the span kind.
+ */
+function toObservedEntities(msg: Message): ObservedEntity[] {
+  // Real mtcute always populates `.entities` (empty array for unformatted
+  // text). Guard against a message shape that lacks it (e.g. a hand-rolled
+  // test double) so the observation degrades to "no entities" rather than
+  // throwing and taking down the whole scenario.
+  const entities = msg.entities ?? [];
+  return entities.map((e): ObservedEntity => {
+    const params = e.params;
+    return {
+      kind: e.kind,
+      offset: e.offset,
+      length: e.length,
+      text: e.text,
+      url: params.kind === "text_link" ? params.url : undefined,
+      language: params.kind === "pre" ? params.language : undefined,
+    };
+  });
+}
+
+/**
+ * `Message.link` throws (`MtArgumentError`) for chats that don't support
+ * message permalinks — notably private DMs, which is exactly where most
+ * UAT scenarios run. Swallow that and leave the field unset rather than
+ * blow up the whole observation; group/channel messages still get a real
+ * `t.me/c/<chat>/<msgid>` link for human eyeball reference.
+ */
+function safeMessageLink(msg: Message): string | undefined {
+  try {
+    return msg.link;
+  } catch {
+    return undefined;
+  }
 }

--- a/telegram-plugin/uat/scenarios/jtbd-rich-formatting-render-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-rich-formatting-render-dm.test.ts
@@ -1,0 +1,189 @@
+/**
+ * JTBD scenario — the real account SEES rendered rich formatting.
+ *
+ * Serves: `reference/jobs/know-what-my-agent-is-doing.md` — the trust
+ * contract that what the agent posts renders correctly on the user's
+ * phone. Phase 1 (PR #2741, `formatting-parse-regression.test.ts`) pins
+ * this at the PARSE level (our emitted markdown parses to the intended
+ * entity structure, checked by an independent oracle). This scenario is
+ * the higher-fidelity RENDER-level layer: it drives a REAL agent turn
+ * through a REAL bot into a REAL chat, then reads back — via the mtcute
+ * MTProto driver — the entity structure Telegram ACTUALLY parsed and will
+ * render. It closes the loop the unit suite can't: it proves Telegram's
+ * own renderer agrees with our oracle, not just that our oracle agrees
+ * with our formatter.
+ *
+ * ## Why this needs the mtcute upgrade (issue #2739)
+ *
+ * On the pinned mtcute (0.27.x) a Bot API 10.1 rich message
+ * (`sendMessage` with `{ markdown }`) decoded as `messageMediaUnsupported`
+ * with empty text — so the driver saw NEITHER text NOR entities and
+ * substituted a `\x01` sentinel. With mtcute >=0.30 the message decodes to
+ * real text + entities, and `toObserved()` now surfaces both
+ * `ObservedMessage.entities` and the `t.me` permalink (`.link`). This test
+ * asserts on that real, decoded structure. If the sentinel ever reappears
+ * (`text === "\x01"`, `entities === []`) the assertions fail LOUDLY rather
+ * than silently pass — it is the regression gate for the decode itself.
+ *
+ * ## What it asserts
+ *
+ * The agent is asked to reply with a small, unambiguous formatting sample
+ * (bold / italic / inline code / a fenced code block / an inline link)
+ * anchored by a stable marker token so the reply is findable in the stream.
+ * We then assert, on the observed bot reply:
+ *
+ *   1. The body decoded to real text (NOT the `\x01` unsupported-media
+ *      sentinel) — the core decode regression gate.
+ *   2. Telegram parsed the expected entity KINDS (membership, not exact
+ *      spans — a model reply is not byte-deterministic, so we mirror
+ *      Phase 1's "these entities are PRESENT" philosophy rather than an
+ *      exact-echo assertion).
+ *   3. The link entity carries the right destination URL.
+ *   4. A `t.me/c/<chat>/<msgid>` (or `t.me/<user>`) permalink is captured
+ *      and logged for human eyeball reference (best-effort — private DMs
+ *      don't support message links, so this is logged, not asserted).
+ *
+ * ## Self-skip
+ *
+ * Like every scenario in this dir, it needs the driver session
+ * (`TELEGRAM_UAT_DRIVER_SESSION`, vault key `telegram-uat-driver-session`,
+ * gated to the CI uat-host runner / test-harness agent). It self-skips
+ * green when those creds are absent so a fork PR / un-wired host never
+ * reds — the `uat/**` tree is excluded from gating CI anyway; the
+ * `uat-gate` sentinel owns the real run.
+ */
+
+import { describe, it, expect } from "vitest";
+import { spinUp } from "../harness.js";
+import type { ObservedMessage } from "../driver.js";
+
+const AGENT = "test-harness";
+
+// The driver session is the load-bearing credential. Absent it, spinUp()
+// throws in resolveConfig — so guard at describe level and self-skip green.
+const HAS_DRIVER_CREDS =
+  (process.env.TELEGRAM_UAT_DRIVER_SESSION ?? "").length > 0 &&
+  (process.env.TELEGRAM_API_HASH ?? "").length > 0 &&
+  Number.isFinite(Number.parseInt(process.env.TELEGRAM_API_ID ?? "", 10)) &&
+  (process.env.TELEGRAM_TEST_BOT_USERNAME ?? "").length > 0;
+
+// A stable marker so the reply is unambiguously findable in the observed
+// stream (the agent is told to include it verbatim). Uppercase + digit so
+// it survives any voice/dash scrub untouched.
+const MARKER = "RICHFMT7";
+
+// The formatting sample the agent is asked to reproduce. Kept small and
+// unambiguous: one entity of each kind we care about, plus a link with a
+// known destination.
+const LINK_URL = "https://github.com/switchroom/switchroom";
+const SAMPLE_LINES = [
+  `Reply with EXACTLY this, including the marker ${MARKER} verbatim, and NOTHING else:`,
+  "",
+  `${MARKER}: here is **a bold phrase**, some *italic words*, an inline \`code_token\`, and a link to [the repo](${LINK_URL}).`,
+  "",
+  "Then, on new lines, a fenced code block:",
+  "```bash",
+  'echo "hello from the torture set"',
+  "```",
+].join("\n");
+
+/** mtcute entity kinds we expect Telegram to have parsed from the sample. */
+const EXPECTED_KINDS = ["bold", "italic", "code", "pre", "text_link"] as const;
+
+function kindsPresent(msg: ObservedMessage): Set<string> {
+  return new Set(msg.entities.map((e) => e.kind));
+}
+
+(HAS_DRIVER_CREDS ? describe : describe.skip)(
+  "uat: real account sees rendered rich formatting (entities + permalink)",
+  () => {
+    it(
+      "bot reply decodes to real text + expected entity kinds; permalink captured",
+      async () => {
+        const sc = await spinUp({ agent: AGENT });
+        try {
+          await sc.sendDM(SAMPLE_LINES);
+
+          // Find the bot reply carrying our marker. The reply may be
+          // streamed/split; we want the chunk that actually holds the
+          // formatting sample (the one with the marker token).
+          const reply = await sc.expectMessage(
+            (m: ObservedMessage) =>
+              m.text.includes(MARKER) || m.text === "\x01",
+            { from: "bot", timeout: 90_000 },
+          );
+
+          // (1) Decode regression gate: the body must be REAL text, not the
+          // unsupported-media sentinel. If this fails, mtcute is not
+          // decoding the rich message — the whole point of the upgrade.
+          expect(
+            reply.text,
+            "bot reply decoded as the \\x01 unsupported-media sentinel — " +
+              "mtcute is NOT decoding the Bot API rich message (issue #2739 regression)",
+          ).not.toBe("\x01");
+          expect(reply.text).toContain(MARKER);
+
+          // (2) Telegram must have parsed at least SOME entities — a reply
+          // that carries the marker but zero entities means formatting was
+          // stripped on the wire (or decode silently dropped entities).
+          const present = kindsPresent(reply);
+          expect(
+            reply.entities.length,
+            `observed reply had zero entities (kinds=${[...present].join(",")}) — ` +
+              "formatting did not survive the render round-trip",
+          ).toBeGreaterThan(0);
+
+          // (3) Entity-kind membership. We assert PRESENCE of each expected
+          // kind, not exact spans (model replies aren't byte-deterministic,
+          // and streaming may split the sample across chunks — this mirrors
+          // Phase 1's membership philosophy). A missing kind is a real
+          // render-fidelity regression for that construct.
+          const missing = EXPECTED_KINDS.filter((k) => !present.has(k));
+          expect(
+            missing,
+            `expected entity kinds missing from the rendered reply: ${missing.join(", ")} ` +
+              `(present: ${[...present].join(", ")})`,
+          ).toEqual([]);
+
+          // (4) The link entity must carry the right destination.
+          const link = reply.entities.find((e) => e.kind === "text_link");
+          expect(link, "no text_link entity found in the reply").toBeDefined();
+          expect(link?.url).toBe(LINK_URL);
+
+          // Permalink capture — best-effort human-eyeball reference. Private
+          // DMs don't support message links (mtcute's .link getter throws
+          // there; toObserved swallows it), so we LOG rather than assert.
+          if (reply.link) {
+            console.info(
+              `[uat] rich-formatting reply permalink: ${reply.link} ` +
+                `(chat=${reply.chatId} msg=${reply.messageId})`,
+            );
+          } else {
+            console.info(
+              `[uat] rich-formatting reply had no permalink ` +
+                `(expected for a private DM) — chat=${reply.chatId} msg=${reply.messageId}`,
+            );
+          }
+
+          // Forensic dump of the exact entity structure Telegram returned —
+          // this is the render-fidelity evidence the parse-level suite can't
+          // produce (it's what Telegram PARSED, not what we EMITTED).
+          console.info(
+            "[uat] rendered entity structure: " +
+              JSON.stringify(
+                reply.entities.map((e) => ({
+                  kind: e.kind,
+                  text: e.text,
+                  ...(e.url ? { url: e.url } : {}),
+                  ...(e.language ? { language: e.language } : {}),
+                })),
+              ),
+          );
+        } finally {
+          await sc.tearDown();
+        }
+      },
+      120_000,
+    );
+  },
+);

--- a/tests/uat-driver.test.ts
+++ b/tests/uat-driver.test.ts
@@ -695,6 +695,98 @@ describe("Driver.getMessage", () => {
   });
 });
 
+describe("toObserved — rich formatting surface (issue #2739)", () => {
+  // Minimal mtcute-Message-shaped double carrying the getters toObserved
+  // reads. `entities` mirrors mtcute's flattened MessageEntity (kind +
+  // offset/length/text + discriminated params).
+  function mockMsg(overrides: Record<string, unknown>): unknown {
+    return {
+      id: 7,
+      text: "",
+      date: new Date("2026-07-02T00:00:00Z"),
+      chat: { id: 111 },
+      sender: { id: 222, type: "user", isBot: true },
+      replyToMessage: undefined,
+      raw: { _: "message", media: undefined },
+      isSilent: false,
+      entities: [],
+      ...overrides,
+    };
+  }
+
+  it("surfaces entities (kind/text/url/language) from a decoded rich message", async () => {
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    mockClient.getMessages.mockResolvedValueOnce([
+      mockMsg({
+        text: "a bold phrase and a code_token and the repo",
+        entities: [
+          { kind: "bold", offset: 2, length: 11, text: "bold phrase", params: { kind: "bold" } },
+          { kind: "code", offset: 25, length: 10, text: "code_token", params: { kind: "code" } },
+          {
+            kind: "text_link",
+            offset: 44,
+            length: 4,
+            text: "repo",
+            params: { kind: "text_link", url: "https://example.com/r" },
+          },
+          {
+            kind: "pre",
+            offset: 0,
+            length: 5,
+            text: "x=1\n",
+            params: { kind: "pre", language: "bash" },
+          },
+        ],
+        link: "https://t.me/c/111/7",
+      } as never),
+    ]);
+    const msg = await driver.getMessage(111, 7);
+    expect(msg?.text).not.toBe("\x01");
+    expect(msg?.entities.map((e) => e.kind)).toEqual([
+      "bold",
+      "code",
+      "text_link",
+      "pre",
+    ]);
+    const link = msg?.entities.find((e) => e.kind === "text_link");
+    expect(link?.url).toBe("https://example.com/r");
+    const pre = msg?.entities.find((e) => e.kind === "pre");
+    expect(pre?.language).toBe("bash");
+    expect(msg?.link).toBe("https://t.me/c/111/7");
+  });
+
+  it("keeps the \\x01 sentinel and empty entities for undecoded rich media", async () => {
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    mockClient.getMessages.mockResolvedValueOnce([
+      mockMsg({
+        text: "",
+        raw: { _: "message", media: { _: "messageMediaUnsupported" } },
+        entities: [],
+      } as never),
+    ]);
+    const msg = await driver.getMessage(111, 7);
+    expect(msg?.text).toBe("\x01");
+    expect(msg?.entities).toEqual([]);
+  });
+
+  it("leaves link undefined when the .link getter throws (private DM)", async () => {
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    const thrower = mockMsg({ text: "hi" }) as Record<string, unknown>;
+    Object.defineProperty(thrower, "link", {
+      get() {
+        throw new Error("chat does not support message links");
+      },
+    });
+    mockClient.getMessages.mockResolvedValueOnce([thrower as never]);
+    const msg = await driver.getMessage(111, 7);
+    expect(msg?.text).toBe("hi");
+    expect(msg?.link).toBeUndefined();
+  });
+});
+
 describe("Driver.sendVoice", () => {
   it("wraps sendMedia with an InputMedia.voice carrying the file path", async () => {
     // fails when: a refactor switches to sending the OGG as a


### PR DESCRIPTION
Closes #2739. Phase 2 of the Telegram formatting-validation plan (Phase 1 = #2741, merged).

## Summary
Makes the real-account (mtcute/MTProto) UAT layer actually validate what Telegram **renders** for rich messages. Before this, that layer was blind: the pinned mtcute (0.27.x) decoded a Bot API 10.1 rich message as `messageMediaUnsupported` (empty text, driver substituted a `\x01` sentinel), and `toObserved()` dropped both `.entities` and the `.link` permalink.

## What changed
1. **Upgrade `@mtcute/node` `^0.27.0` -> `^0.30.1`.** Every driver call site is unchanged across the bump (see risk below).
2. **`ObservedMessage` gains `entities` + `link`**, surfaced in `toObserved()`. Entities flatten mtcute's `Message.entities` (kind/offset/length/text, plus `text_link` url and `pre` language). `.link` is the `t.me` permalink via a getter that throws on private DMs, swallowed and left unset. The `\x01` sentinel is kept as a defensive fallback (entities `[]`) and is now the **decode-regression gate**, not the happy path.
3. **New scenario `jtbd-rich-formatting-render-dm`** sends a bold/italic/code/pre/link sample through a real agent turn and asserts on the entity structure Telegram **actually parsed** (kind membership, mirroring Phase 1), plus captures/logs the permalink. Self-skips green without the driver session; wired into the `ci-uat` `uat-gate-run` job so it runs where the secrets exist.
4. **Unit coverage** for the new `toObserved` surface in `tests/uat-driver.test.ts`.

## Why / JTBD
Serves `reference/jobs/know-what-my-agent-is-doing.md` and the always-on / visibility vision outcomes. Phase 1 pins formatting at the parse level (our oracle agrees with our formatter). This is the higher-fidelity render layer: it proves **Telegram's own renderer** agrees with the oracle.

## mtcute upgrade risk: SAFE
- `tsc --noEmit` green; all driver call-site symbols exist unchanged in 0.30.1 (`@mtcute/node` re-exports `MemoryStorage`/`getMarkedPeerId`/`InputMedia` from core).
- Every `Message` getter the driver reads (`text`, `entities`, `link`, `sender`, `isSilent`, `replyToMessage.threadId`, ...) is present with the same shape.
- `PeerType` and the `messageMedia*` constructor set are identical between TL layer 221 and 223, so `fromBot` classification and the unsupported-media fallback are unaffected.
- All existing `uat-driver` / `uat-login` / `uat-assertions` tests pass on 0.30.1.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `scripts/check-plugin-references.mjs` clean
- [x] `tests/uat-driver.test.ts` — 37 pass (34 existing + 3 new)
- [x] `tests/uat-assertions.test.ts` — 24 pass; `tests/uat-login.test.ts` — 6 pass
- [x] Phase 1 `formatting-parse-regression.test.ts` — 26 pass
- [x] bun `uat/load-env` + `uat/feed-matcher` — 19 pass
- [x] new scenario self-skips green without driver creds
- [ ] **Live render round-trip** — needs the `telegram-uat-driver-session` vault key (gated to the `uat-host` runner / test-harness agent); runs in the `uat-gate-run` CI job, not locally.

## Risk
Test/infra only — no runtime behaviour change to the shipping product. mtcute is imported only under `telegram-plugin/uat/` (+ its tests), which is excluded from gating CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
