### PR TITLE
fix(telegram): dash-scrub full-stop not comma + collapse whitespace-only blank lines

### DIFF
--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -291,9 +291,9 @@ export function normalizeParagraphBreaks(text: string): string {
     // fires on both `A\n \nB` (one space-only blank line) and `A\n\n \n\nB`
     // (a space-only line inside a multi-blank run) but never rewrites a clean
     // `A\n\nB` (no interior whitespace) — that already-correct gap is left to
-    // the `\n{3,}` pass, which is a no-op on it.
+    // the `\n{3,}` pass below, which collapses any surviving run of 3+
+    // newlines (including pure `A\n\n\n\nB`) down to a single `\n\n`.
     .replace(/\n[ \t\r]+\n(?:[ \t\r]*\n)*/g, '\n\n')
-    .replace(/\n[ \t\r]*(?:\n[ \t\r]*)+\n/g, '\n\n')
     .replace(/\n{3,}/g, '\n\n')
 
   // Step 2: walk lines and promote lone prose breaks. We rebuild the string by

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -266,10 +266,35 @@ export function normalizeParagraphBreaks(text: string): string {
   // never touched. See splitCollapsedInlineBullets for the exact rule.
   const masked = splitCollapsedInlineBullets(maskedRaw)
 
-  // Step 1: collapse 3+ newlines to exactly two. This also normalizes runs that
-  // contain interleaved spaces only between the newlines is NOT done here —
-  // we only touch pure newline runs so we never eat meaningful whitespace.
-  let out = masked.replace(/\n{3,}/g, '\n\n')
+  // Step 1: collapse blank-line runs to exactly ONE clean blank line (`\n\n`),
+  // never leaving a whitespace-only line between two paragraphs.
+  //
+  //   (a) Pure newline runs of 3+ → `\n\n`.
+  //   (b) A blank-line run whose interior lines are ASCII-whitespace-only
+  //       (spaces / tabs / CR) → `\n\n`. A model (or an upstream transform)
+  //       that authors `A\n\n \n\nB` leaves a lone-space line between the
+  //       paragraphs; CommonMark discards it (so it buys no gap) but it reads
+  //       as an oversized / ragged gap in the raw text and in some clients, and
+  //       it was the "stray blank line" seen in real replies. Collapse it.
+  //
+  // Deliberately ASCII-only: a line whose only content is U+00A0 is the
+  // INTENTIONAL, non-collapsible paragraph spacer added later by
+  // addParagraphSpacers (#2692) to force a visible gap on the rich-message
+  // path. This step runs BEFORE that spacer pass and must never eat a U+00A0
+  // line, so the `[ \t\r]` character class here excludes U+00A0 by
+  // construction. Runs on code-masked text, so a blank-ish line inside a
+  // fenced block is parked and never touched.
+  let out = masked
+    // Collapse any run of newlines interleaved with ASCII whitespace-only
+    // interior lines down to a single clean `\n\n`. Requires at least one
+    // whitespace char between the first two newlines OR 3+ newlines, so it
+    // fires on both `A\n \nB` (one space-only blank line) and `A\n\n \n\nB`
+    // (a space-only line inside a multi-blank run) but never rewrites a clean
+    // `A\n\nB` (no interior whitespace) — that already-correct gap is left to
+    // the `\n{3,}` pass, which is a no-op on it.
+    .replace(/\n[ \t\r]+\n(?:[ \t\r]*\n)*/g, '\n\n')
+    .replace(/\n[ \t\r]*(?:\n[ \t\r]*)+\n/g, '\n\n')
+    .replace(/\n{3,}/g, '\n\n')
 
   // Step 2: walk lines and promote lone prose breaks. We rebuild the string by
   // joining lines with the right separator. A separator is "hard" (`  \n`) only

--- a/telegram-plugin/tests/card-format.test.ts
+++ b/telegram-plugin/tests/card-format.test.ts
@@ -60,8 +60,9 @@ describe('stripMarkdown', () => {
   it('F1: normalizes an em-dash on this card/narration prose surface', () => {
     // The reply path scrubs em-dashes but cards/narration/PTY previews did not,
     // so em-dashes leaked there. stripMarkdown now runs the same dash logic.
-    // Lowercase follower → comma (mid-clause); uppercase follower → period.
-    expect(stripMarkdown('build done — shipping now')).toBe('build done, shipping now')
+    // A clause-joining dash becomes a full stop (never a comma — that produces
+    // a comma splice), with the following word recapitalized into a sentence.
+    expect(stripMarkdown('build done — shipping now')).toBe('build done. Shipping now')
     expect(stripMarkdown('build done — Shipping now')).toBe('build done. Shipping now')
   })
 
@@ -93,7 +94,7 @@ describe('cleanWorkerResultParagraph', () => {
 
   it('F1: normalizes em-dashes in worker narration prose', () => {
     const input = '## Result\n\nTests pass — ready to merge'
-    expect(cleanWorkerResultParagraph(input)).toBe('Result Tests pass, ready to merge')
+    expect(cleanWorkerResultParagraph(input)).toBe('Result Tests pass. Ready to merge')
   })
 
   it('F1: an em-dash inside a fenced block is preserved (the block is dropped, never normalized)', () => {
@@ -101,7 +102,7 @@ describe('cleanWorkerResultParagraph', () => {
     // removal — it never reaches (nor is mutated by) the dash normalizer, and
     // the surrounding prose dash IS normalized.
     const input = 'before — after\n```\nlet a = b — c\n```\ntail'
-    expect(cleanWorkerResultParagraph(input)).toBe('before, after tail')
+    expect(cleanWorkerResultParagraph(input)).toBe('before. After tail')
   })
 })
 

--- a/telegram-plugin/tests/paragraph-normalizer.test.ts
+++ b/telegram-plugin/tests/paragraph-normalizer.test.ts
@@ -501,3 +501,86 @@ describe('normalizeParagraphBreaks — inline bullet split integration', () => {
     expect(twice).toBe(once)
   })
 })
+
+/**
+ * Regression guard for the stray whitespace-only blank line between paragraphs
+ * (the "\n\n \n\n" seen in a real reply). A model (or an upstream transform)
+ * that authors a blank line whose only content is ASCII whitespace leaves a
+ * ragged / oversized gap: CommonMark discards it so it buys no visible space,
+ * but it reads as noise in the raw text. Step 1 of normalizeParagraphBreaks now
+ * collapses any run of blank lines — including whitespace-only interior lines —
+ * to exactly one clean `\n\n`, WITHOUT ever eating the deliberate U+00A0
+ * paragraph spacer that addParagraphSpacers (#2692) adds later for a visible
+ * gap on the rich-message path.
+ */
+describe('normalizeParagraphBreaks — whitespace-only blank-line collapse (Bug 2)', () => {
+  const NBSP = ' '
+
+  test('a lone-space blank line between paragraphs collapses to a clean `\\n\\n` (real string)', () => {
+    const input =
+      "Here's what was fixed and how it validates.\n\n \n\n" +
+      'One loose end: a stray thing.'
+    expect(normalizeParagraphBreaks(input)).toBe(
+      "Here's what was fixed and how it validates.\n\n" +
+        'One loose end: a stray thing.',
+    )
+  })
+
+  test('a single whitespace-only blank line (`A\\n \\nB`) collapses to `\\n\\n`', () => {
+    expect(normalizeParagraphBreaks('Alpha para.\n \nBravo para.')).toBe(
+      'Alpha para.\n\nBravo para.',
+    )
+    expect(normalizeParagraphBreaks('Alpha para.\n\t\nBravo para.')).toBe(
+      'Alpha para.\n\nBravo para.',
+    )
+  })
+
+  test('multiple stray whitespace-only lines in one gap collapse to a single `\\n\\n`', () => {
+    expect(normalizeParagraphBreaks('A.\n\n \n\n \n\nB.')).toBe('A.\n\nB.')
+  })
+
+  test('a legitimate single `\\n\\n` paragraph break is preserved exactly', () => {
+    expect(normalizeParagraphBreaks('Alpha para.\n\nBravo para.')).toBe(
+      'Alpha para.\n\nBravo para.',
+    )
+  })
+
+  test('never EMITS a whitespace-only line between two prose paragraphs', () => {
+    const out = normalizeParagraphBreaks('First.\n\n  \n\nSecond.')
+    for (const line of out.split('\n')) {
+      // Every line is either empty or has real (non-ASCII-whitespace) content.
+      expect(line === '' || /\S/.test(line) || line.includes(NBSP)).toBe(true)
+    }
+    expect(out).toBe('First.\n\nSecond.')
+  })
+
+  test('a blank line inside a fenced code block (masked) is NOT collapsed', () => {
+    const input = '```\ncode line 1\n \ncode line 2\n```'
+    // The whitespace-only line lives inside a masked fence and must survive.
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
+  test('trailing hard-break spaces on a CONTENT line are not eaten', () => {
+    // "line.  \n\nNext." — the two trailing spaces are a GFM hard break on a
+    // content line, not a blank line; they must survive.
+    const input = 'Trailing spaces on line.  \n\nNext.'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
+  test('the deliberate U+00A0 spacer from addParagraphSpacers is preserved (no #2692 regression)', () => {
+    const normalized = normalizeParagraphBreaks('Alpha para.\n\nBravo para.')
+    const spaced = addParagraphSpacers(normalized)
+    // addParagraphSpacers wedges a U+00A0-only line to force a visible gap.
+    expect(spaced).toContain('\n\n' + PARAGRAPH_SPACER + '\n\n')
+    expect(spaced.split('\n')).toContain(NBSP)
+    // And re-running the normalizer must NOT eat that intentional spacer.
+    expect(normalizeParagraphBreaks(spaced)).toBe(spaced)
+  })
+
+  test('idempotent: collapsing a stray gap twice is stable', () => {
+    const once = normalizeParagraphBreaks('A.\n\n \n\nB.')
+    const twice = normalizeParagraphBreaks(once)
+    expect(twice).toBe(once)
+    expect(once).toBe('A.\n\nB.')
+  })
+})

--- a/telegram-plugin/tests/text-voice-scrub.test.ts
+++ b/telegram-plugin/tests/text-voice-scrub.test.ts
@@ -10,7 +10,95 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { scrubVoice } from '../text-voice-scrub.js'
+import { scrubVoice, normalizeDashes } from '../text-voice-scrub.js'
+
+/**
+ * Regression guard for the em-dash comma-splice bug seen in a real reply
+ * (the #2737-era voice scrub). The original #1683 rule degraded a
+ * clause-joining em-dash to a comma when the next word was lowercase, which
+ * joined two independent clauses with a comma — a comma splice ("voice came
+ * back, three PRs stacked"). The fix degrades to a full stop and recapitalizes
+ * the following word, so the output is never a splice. These tests use the
+ * verbatim failure strings from the stored bad message.
+ */
+describe('scrubVoice — em-dash between clauses never produces a comma splice', () => {
+  beforeEach(() => {
+    delete process.env.SWITCHROOM_DISABLE_VOICE_SCRUB
+    delete process.env.SWITCHROOM_VOICE_STRIP_OPENERS
+  })
+
+  it('lowercase-continued independent clause becomes two sentences, not a splice (real string 1)', () => {
+    const r = scrubVoice('**Why voice came back** — three PRs stacked')
+    // Was: "**Why voice came back**, three PRs stacked" (comma splice).
+    expect(r.scrubbed).toBe('**Why voice came back**. Three PRs stacked')
+    expect(r.scrubbed).not.toContain('**, three')
+    expect(r.replaced).toBe(1)
+  })
+
+  it('lowercase-continued independent clause becomes two sentences, not a splice (real string 2)', () => {
+    const r = scrubVoice(
+      'never reached the agents — this is what unblocked everything today.',
+    )
+    // Was: "...the agents, this is what unblocked..." (comma splice).
+    expect(r.scrubbed).toBe(
+      'never reached the agents. This is what unblocked everything today.',
+    )
+    expect(r.scrubbed).not.toContain('agents, this')
+    expect(r.replaced).toBe(1)
+  })
+
+  it('the scrubbed output contains no ", <lowercase clause>" splice for any spaced dash', () => {
+    const r = scrubVoice(
+      'first thing — second independent clause and — third one here',
+    )
+    // No comma directly joining the two independent clauses.
+    expect(r.scrubbed).toBe(
+      'first thing. Second independent clause and. Third one here',
+    )
+  })
+
+  it('normalizeDashes (card / worker-narration path) also avoids the splice', () => {
+    // The non-reply surfaces reuse normalizeDashes; same splice-free rule.
+    expect(normalizeDashes('came back — three PRs stacked')).toBe(
+      'came back. Three PRs stacked',
+    )
+  })
+
+  it('a dash before a NON-letter (digit / paren) is not wrongly recapitalized', () => {
+    // capFirst only touches an ASCII lowercase letter; a digit / punctuation
+    // start is left as-is after the full stop.
+    expect(normalizeDashes('the count — 3 items remain')).toBe(
+      'the count. 3 items remain',
+    )
+    expect(normalizeDashes('the note — (see appendix)')).toBe(
+      'the note. (see appendix)',
+    )
+  })
+
+  it('dashes inside code spans, fenced blocks, and URLs are still never touched', () => {
+    const input =
+      'prose — one\n' +
+      'inline `a — b — c` stays\n' +
+      '```\nfenced x — y — z stays\n```\n' +
+      'link https://ex.io/a—b—c stays too — end'
+    const r = scrubVoice(input)
+    expect(r.scrubbed).toContain('`a — b — c`')
+    expect(r.scrubbed).toContain('fenced x — y — z stays')
+    expect(r.scrubbed).toContain('https://ex.io/a—b—c')
+    // Only the two prose dashes were scrubbed (to full stops).
+    expect(r.scrubbed).toContain('prose. One')
+    expect(r.scrubbed).toContain('stays too. End')
+    expect(r.replaced).toBe(2)
+  })
+
+  it('a double-space inside inline code / a URL is left untouched by the scrub', () => {
+    // The scrub must not normalize whitespace inside protected regions.
+    const r = scrubVoice('keep `foo  bar` and http://h/a  b intact — done')
+    expect(r.scrubbed).toContain('`foo  bar`')
+    expect(r.scrubbed).toContain('http://h/a  b')
+    expect(r.scrubbed).toContain('intact. Done')
+  })
+})
 
 describe('scrubVoice — em / en dash replacement', () => {
   beforeEach(() => {
@@ -21,9 +109,13 @@ describe('scrubVoice — em / en dash replacement', () => {
   })
 
   describe('mechanical rewrite of spaced dashes', () => {
-    it('replaces a spaced em-dash before lowercase with a comma', () => {
+    it('replaces a spaced em-dash before lowercase with a full stop (no comma splice)', () => {
+      // #1683 originally emitted a comma here, which produced a comma splice
+      // between two independent clauses ("on it, checking the calendar"). The
+      // splice-free rule degrades the clause-joining dash to a period and
+      // recapitalizes the following word.
       const r = scrubVoice('on it — checking the calendar')
-      expect(r.scrubbed).toBe('on it, checking the calendar')
+      expect(r.scrubbed).toBe('on it. Checking the calendar')
       expect(r.replaced).toBe(1)
     })
 
@@ -34,22 +126,23 @@ describe('scrubVoice — em / en dash replacement', () => {
       expect(r.replaced).toBe(1)
     })
 
-    it('handles multiple em-dashes in one sentence', () => {
+    it('handles multiple em-dashes in one sentence (each becomes a full stop)', () => {
       const r = scrubVoice('one — two — three — done')
-      expect(r.scrubbed).toBe('one, two, three, done')
+      expect(r.scrubbed).toBe('one. Two. Three. Done')
       expect(r.replaced).toBe(3)
     })
 
     it('treats en-dash (–) identically to em-dash', () => {
       const r = scrubVoice('on it – checking the calendar')
-      expect(r.scrubbed).toBe('on it, checking the calendar')
+      expect(r.scrubbed).toBe('on it. Checking the calendar')
       expect(r.replaced).toBe(1)
     })
 
-    it('replaces unspaced word-dash-word as a comma', () => {
-      // Less common but seen in tightly-typed prose.
+    it('replaces unspaced word-dash-word with a full stop (no comma splice)', () => {
+      // Less common but seen in tightly-typed prose. Same splice-free rule as
+      // the spaced form: a period plus a recapitalized following word.
       const r = scrubVoice('flag—on or flag—off')
-      expect(r.scrubbed).toBe('flag, on or flag, off')
+      expect(r.scrubbed).toBe('flag. On or flag. Off')
       expect(r.replaced).toBe(2)
     })
 
@@ -73,33 +166,33 @@ describe('scrubVoice — em / en dash replacement', () => {
       const input = 'here is code:\n```bash\nfoo --bar — baz\n```\nand prose — done'
       const r = scrubVoice(input)
       expect(r.scrubbed).toBe(
-        'here is code:\n```bash\nfoo --bar — baz\n```\nand prose, done',
+        'here is code:\n```bash\nfoo --bar — baz\n```\nand prose. Done',
       )
       expect(r.replaced).toBe(1)
     })
 
     it('preserves dashes inside inline code', () => {
       const r = scrubVoice('the flag `--really — keep` matters — yes')
-      expect(r.scrubbed).toBe('the flag `--really — keep` matters, yes')
+      expect(r.scrubbed).toBe('the flag `--really — keep` matters. Yes')
       expect(r.replaced).toBe(1)
     })
 
     it('preserves dashes inside <code> HTML tags', () => {
       const r = scrubVoice('see <code>x — y</code> and note — ok')
-      expect(r.scrubbed).toBe('see <code>x — y</code> and note, ok')
+      expect(r.scrubbed).toBe('see <code>x — y</code> and note. Ok')
       expect(r.replaced).toBe(1)
     })
 
     it('preserves dashes inside <pre> HTML tags', () => {
       const r = scrubVoice('block:\n<pre>x — y\nz — w</pre>\nend — ok')
-      expect(r.scrubbed).toBe('block:\n<pre>x — y\nz — w</pre>\nend, ok')
+      expect(r.scrubbed).toBe('block:\n<pre>x — y\nz — w</pre>\nend. Ok')
       expect(r.replaced).toBe(1)
     })
 
     it('preserves dashes inside URLs', () => {
       const r = scrubVoice('see https://example.com/a—b for context — ok')
       expect(r.scrubbed).toBe(
-        'see https://example.com/a—b for context, ok',
+        'see https://example.com/a—b for context. Ok',
       )
       expect(r.replaced).toBe(1)
     })
@@ -110,7 +203,7 @@ describe('scrubVoice — em / en dash replacement', () => {
       const fence =
         '```\n# heading — title\nfunction f() {}\n```'
       const r = scrubVoice(fence + '\ntrailing — yes')
-      expect(r.scrubbed).toBe(fence + '\ntrailing, yes')
+      expect(r.scrubbed).toBe(fence + '\ntrailing. Yes')
       expect(r.replaced).toBe(1)
     })
   })
@@ -151,8 +244,8 @@ describe('scrubVoice — em / en dash replacement', () => {
         'Result: empty for Saturday — nothing scheduled. Anything else?'
       const r = scrubVoice(input)
       expect(r.scrubbed).toBe(
-        "I'll check the calendar, should take a few seconds. " +
-        'Result: empty for Saturday, nothing scheduled. Anything else?',
+        "I'll check the calendar. Should take a few seconds. " +
+        'Result: empty for Saturday. Nothing scheduled. Anything else?',
       )
       expect(r.replaced).toBe(2)
     })
@@ -164,9 +257,9 @@ describe('scrubVoice — em / en dash replacement', () => {
         'Ready to commit — go?'
       const r = scrubVoice(input)
       expect(r.scrubbed).toBe(
-        'Running `git status --short`, looks clean. ' +
+        'Running `git status --short`. Looks clean. ' +
         '```\nM file.ts — modified\n```\n' +
-        'Ready to commit, go?',
+        'Ready to commit. Go?',
       )
       expect(r.replaced).toBe(2)
     })
@@ -293,15 +386,16 @@ describe('scrubVoice — opener strip is OFF by default (prompt carries tone)', 
 
   it('STILL normalizes em-dashes by default (punctuation, no content removed)', () => {
     const r = scrubVoice('on it — checking the calendar')
-    expect(r.scrubbed).toBe('on it, checking the calendar')
+    expect(r.scrubbed).toBe('on it. Checking the calendar')
     expect(r.replaced).toBe(1)
     expect(r.openersStripped).toBe(0)
   })
 
   it('an affirmation opener with an em-dash keeps the words, fixes only the dash', () => {
     const r = scrubVoice('Exactly right — the token had expired.')
-    // Opener preserved; the em-dash after it becomes a comma.
-    expect(r.scrubbed).toBe('Exactly right, the token had expired.')
+    // Opener preserved (strip is OFF); the em-dash between two independent
+    // clauses becomes a full stop, not a comma (no splice).
+    expect(r.scrubbed).toBe('Exactly right. The token had expired.')
     expect(r.openersStripped).toBe(0)
     expect(r.replaced).toBe(1)
   })

--- a/telegram-plugin/tests/text-voice-scrub.test.ts
+++ b/telegram-plugin/tests/text-voice-scrub.test.ts
@@ -159,6 +159,32 @@ describe('scrubVoice — em / en dash replacement', () => {
       expect(r.scrubbed).toBe('- note: ship it')
       expect(r.replaced).toBe(1)
     })
+
+    it('does not recapitalize a mixed-case brand token after a dash', () => {
+      // capFirst must leave a lowercase-initial mixed-case token (iOS, eBay,
+      // iPhone, macOS) alone — recapitalizing "iOS" to "IOS" corrupts the
+      // brand. A normal lowercase word still gets recapitalized.
+      const r = scrubVoice('foo—iOS build')
+      expect(r.scrubbed).toBe('foo. iOS build')
+      expect(r.replaced).toBe(1)
+
+      const spaced = scrubVoice('shipped — iPhone ready')
+      expect(spaced.scrubbed).toBe('shipped. iPhone ready')
+
+      const normal = scrubVoice('foo—done here')
+      expect(normal.scrubbed).toBe('foo. Done here')
+    })
+
+    it('preserves numeric ranges as ASCII hyphens, not full stops', () => {
+      // A digit-flanked dash is a range, not a clause break. It falls through
+      // to the catch-all rule and becomes an ASCII hyphen.
+      const unspaced = scrubVoice('10–20')
+      expect(unspaced.scrubbed).toBe('10-20')
+      expect(unspaced.replaced).toBe(1)
+
+      const tight = scrubVoice('scored 3–2')
+      expect(tight.scrubbed).toBe('scored 3-2')
+    })
   })
 
   describe('protected regions are left alone', () => {

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -244,8 +244,8 @@ describe("clipNarrative — narrative-step clip (JSONL-text-narrative primitive)
     // F1: the feed renders through renderStatusCard → stripMarkdown, which now
     // normalizes em/en-dashes on this card surface. A narrative and a label go
     // through the exact same path, so the render is still byte-identical — the
-    // dash is scrubbed to a comma in BOTH.
-    const scrubbed = "Important find: no main branch yet, branching off origin.";
+    // dash is scrubbed to a full stop (new sentence, recapitalized) in BOTH.
+    const scrubbed = "Important find: no main branch yet. Branching off origin.";
     const narrativeRender = appendActivityLabel(narrativeLines, clipNarrative(text));
     const labelRender = appendActivityLabel(labelLines, clipNarrative(text));
     expect(narrativeRender).toBe(labelRender);

--- a/telegram-plugin/text-voice-scrub.ts
+++ b/telegram-plugin/text-voice-scrub.ts
@@ -203,15 +203,27 @@ function restore(
  * Replace em / en dashes with context-appropriate punctuation.
  *
  * Rules, applied in order:
- *   1. ` — ` / ` – ` (flanked by single space) → `, ` if followed by a
- *      lowercase or open-paren character; otherwise `. ` if followed by
- *      an uppercase or end-of-string. Heuristic: lowercase = mid-clause
- *      continuation (comma reads naturally); uppercase = new sentence
- *      (period reads naturally).
+ *   1. ` — ` / ` – ` (flanked by single space) → `. ` + the following
+ *      word recapitalized, in the common case. A spaced em-dash in prose
+ *      almost always joins two INDEPENDENT clauses ("voice came back —
+ *      three PRs stacked"); degrading that to a comma produces a comma
+ *      splice ("voice came back, three PRs stacked"), which reads as
+ *      broken grammar. A period (full stop) is the substitution that
+ *      never corrupts meaning: two independent clauses become two
+ *      sentences. The genuine appositive/parenthetical use of a dash
+ *      ("the lead — a tall man — spoke") is the minority case and still
+ *      reads acceptably as two short sentences, so we default to the
+ *      period rather than risk a splice. A dash already followed by a
+ *      lowercased conjunction/pronoun that only makes sense mid-sentence
+ *      is the rare exception the heuristic can't recover; a clean period
+ *      beats a comma splice there too. Original PR #1683 used a comma for
+ *      lowercase continuations; that was the #2737-era source of splices
+ *      in real replies (fixed here).
  *   2. End-of-line dash (` —\n` / ` –\n`) → `.\n` — treat as full stop.
  *   3. Bare dash with no flanking spaces between word chars
- *      (e.g. "word—word") → `, ` — the missing-space form is rarer but
- *      semantically the same as #1.
+ *      (e.g. "word—word") → `. ` + recapitalized following word — the
+ *      missing-space form is rarer but semantically the same as #1, so it
+ *      gets the same splice-free full-stop treatment.
  *   4. Surviving dash (uncommon, e.g. at sentence start "— note") → `-`
  *      so the message still renders without the AI tell.
  */
@@ -219,14 +231,19 @@ function replaceDashes(text: string): { out: string; replaced: number } {
   let replaced = 0
   let out = text
 
-  // #1: spaced em-dash mid-prose. Decide between ", " and ". " on
-  // the leading character of the following token.
+  // Recapitalize the first ASCII-lowercase letter of `after` so the new
+  // sentence that a full-stop substitution creates reads correctly. A
+  // non-letter start (digit, `(`, quote) is left as-is.
+  const capFirst = (after: string): string =>
+    after.replace(/^([a-z])/, (_m, ch: string) => ch.toUpperCase())
+
+  // #1: spaced em-dash mid-prose. A spaced dash joins two independent
+  // clauses far more often than it sets off an appositive, so degrade it
+  // to a full stop (never a comma — that produces a comma splice) and
+  // recapitalize the following word into a new sentence.
   out = out.replace(/(\S) [—–] (\S)/g, (_m, before: string, after: string) => {
     replaced++
-    // If `after` is uppercase ASCII or one of a known sentence-starter
-    // set, treat as new sentence; otherwise a parenthetical comma.
-    const sentenceStart = /[A-Z]/.test(after)
-    return sentenceStart ? `${before}. ${after}` : `${before}, ${after}`
+    return `${before}. ${capFirst(after)}`
   })
 
   // #2: dash at end of line. Treat as full stop.
@@ -235,11 +252,11 @@ function replaceDashes(text: string): { out: string; replaced: number } {
     return `.${ws}`
   })
 
-  // #3: bare dash between word chars (no flanking spaces). Treat as
-  // missing-space form of #1; comma is the safe fallback.
+  // #3: bare dash between word chars (no flanking spaces). Missing-space
+  // form of #1 — same full-stop treatment so it can't create a splice.
   out = out.replace(/(\w)[—–](\w)/g, (_m, before: string, after: string) => {
     replaced++
-    return `${before}, ${after}`
+    return `${before}. ${capFirst(after)}`
   })
 
   // #4: anything still standing — convert to ASCII hyphen so no

--- a/telegram-plugin/text-voice-scrub.ts
+++ b/telegram-plugin/text-voice-scrub.ts
@@ -233,17 +233,25 @@ function replaceDashes(text: string): { out: string; replaced: number } {
 
   // Recapitalize the first ASCII-lowercase letter of `after` so the new
   // sentence that a full-stop substitution creates reads correctly. A
-  // non-letter start (digit, `(`, quote) is left as-is.
-  const capFirst = (after: string): string =>
-    after.replace(/^([a-z])/, (_m, ch: string) => ch.toUpperCase())
+  // non-letter start (digit, `(`, quote) is left as-is. A lowercase-initial
+  // mixed-case brand token (iOS, eBay, iPhone, macOS — second char is
+  // uppercase) is ALSO left as-is: recapitalizing it to "IOS" corrupts the
+  // brand, and the token's own capitalization already reads as intentional.
+  const capFirst = (after: string): string => {
+    if (/^[a-z][A-Z]/.test(after)) return after
+    return after.replace(/^([a-z])/, (_m, ch: string) => ch.toUpperCase())
+  }
 
   // #1: spaced em-dash mid-prose. A spaced dash joins two independent
   // clauses far more often than it sets off an appositive, so degrade it
   // to a full stop (never a comma — that produces a comma splice) and
-  // recapitalize the following word into a new sentence.
-  out = out.replace(/(\S) [—–] (\S)/g, (_m, before: string, after: string) => {
+  // recapitalize the following word into a new sentence. A digit-flanked
+  // dash is a numeric range (10–20), not a clause break, so it's excluded
+  // here and falls through to rule #4 (→ ASCII hyphen, "10-20").
+  out = out.replace(/(\S) [—–] (\S)(\S?)/g, (m, before: string, after: string, peek: string) => {
+    if (/\d/.test(before) && /\d/.test(after)) return m
     replaced++
-    return `${before}. ${capFirst(after)}`
+    return `${before}. ${capFirst(after + peek)}`
   })
 
   // #2: dash at end of line. Treat as full stop.
@@ -253,10 +261,13 @@ function replaceDashes(text: string): { out: string; replaced: number } {
   })
 
   // #3: bare dash between word chars (no flanking spaces). Missing-space
-  // form of #1 — same full-stop treatment so it can't create a splice.
-  out = out.replace(/(\w)[—–](\w)/g, (_m, before: string, after: string) => {
+  // form of #1 — same full-stop treatment so it can't create a splice. A
+  // digit-flanked dash (3–2) is a numeric range, not a clause break, so it's
+  // excluded and falls through to rule #4 (→ ASCII hyphen, "3-2").
+  out = out.replace(/(\w)[—–](\w)(\w?)/g, (m, before: string, after: string, peek: string) => {
+    if (/\d/.test(before) && /\d/.test(after)) return m
     replaced++
-    return `${before}. ${capFirst(after)}`
+    return `${before}. ${capFirst(after + peek)}`
   })
 
   // #4: anything still standing — convert to ASCII hyphen so no


### PR DESCRIPTION
## What

Two send-path formatting defects seen in real replies:

1. **Comma splices from the dash scrub.** The em/en-dash replacement in `text-voice-scrub.ts` degraded a spaced dash to `", "` for lowercase continuations. A spaced dash almost always joins two *independent* clauses, so `"voice came back — three PRs stacked"` became the run-on `"voice came back, three PRs stacked"`. Now degrades to `". "` + recapitalized following word (never corrupts meaning). Same treatment for bare `word—word`.

2. **Whitespace-only blank lines between paragraphs.** `normalizeParagraphBreaks` in `format.ts` left `A\n\n \n\nB` intact — a lone-space line that reads as a ragged oversized gap. Now collapses any blank-line run whose interior is ASCII-whitespace-only to a single clean `\n\n`, while preserving the intentional U+00A0 spacer from #2692.

## Testing

`bun test` on the three affected suites — **130 pass, 0 fail**. New regression cases use the actual failure strings from live replies.

## Review focus

- En/en-dash between digits (numeric ranges like `10–20`) also matches the `word—word` rule → becomes `10. 20`. This was already broken pre-fix (`10, 20`), so not a new regression, but worth a decision on whether to exclude digit-flanked dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)