### PR TITLE
fix(uat): driver decodes Bot API 10.1 rich messages + starts update dispatch

### DIFF
--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -199,16 +199,6 @@ export class Driver {
     const me = await this.client.getMe();
     await this.client.notifyLoggedIn(me.raw);
     await this.client.startUpdatesLoop();
-
-    // TEMP DIAGNOSTIC (remove once dispatch confirmed): distinguish
-    // "no updates arrive at all" from "raw updates arrive but new_message
-    // is never dispatched to onNewMessage". Logs the raw TL `_` type of
-    // every update the manager dispatches, and separately whether the
-    // parsed new/edit-message emitters ever fire. No message bodies or
-    // peer ids are logged (session-secret hygiene) — only update kinds.
-    /* eslint-disable no-console -- harness diagnostic */
-    console.warn(`[uat/driver][diag] connected as self id=${me.id}`);
-    /* eslint-enable no-console */
   }
 
   async disconnect(): Promise<void> {
@@ -374,15 +364,6 @@ export class Driver {
       // observed chatId, the resolved sender, edited flag, and text
       // length (NOT the body — hygiene). Reveals chatId-mismatch vs
       // sender-filter vs empty-text as the reason expectMessage times out.
-      const rawM = msg.raw as { _?: string; media?: { _?: string }; message?: string };
-      // eslint-disable-next-line no-console -- harness diagnostic
-      console.warn(
-        `[uat/driver][diag] observed target=${chatId} chatId=${observed.chatId} ` +
-        `sender=${observed.senderUserId} edited=${observed.edited} ` +
-        `fromBot=${observed.fromBot} textLen=${observed.text.length} ` +
-        `raw_=${rawM._ ?? "?"} media=${rawM.media?._ ?? "none"} ` +
-        `rawMsgLen=${rawM.message?.length ?? -1}`,
-      );
       if (observed.chatId !== chatId) return;
       if (targetThread !== undefined && observed.threadId !== targetThread) return;
       dispatch(observed);

--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -181,11 +181,23 @@ export class Driver {
     await this.client.connect();
     // `connect()` opens the transport but does NOT start the updates
     // dispatch loop — that's `start()`'s job. For a returning session
-    // (no interactive login) we have to call `startUpdatesLoop()`
-    // ourselves, otherwise `onNewMessage` / `onEditMessage` never
-    // fire and `observeMessages` silently waits forever. Symptom:
-    // `expectMessage` timing out even though the bot's reply has
-    // arrived in the chat (visible in Telegram).
+    // (no interactive login) we have to drive that lifecycle ourselves,
+    // otherwise `onNewMessage` / `onEditMessage` never fire and
+    // `observeMessages` silently waits forever. Symptom: `expectMessage`
+    // timing out even though the bot's reply has arrived in the chat
+    // (visible in Telegram).
+    //
+    // Crucially, `startUpdatesLoop()` alone is NOT enough. In mtcute 0.30
+    // the updates manager will not DISPATCH new-message updates unless it
+    // has been told the client is logged in — `start()` does this via
+    // `notifyLoggedIn` in its login callback, but a manually-imported
+    // session skips `start()` entirely. Without it the manager starts the
+    // loop while still considering the user logged-out, the incoming
+    // update is fetched but never routed to `onNewMessage`, and the
+    // observer waits forever. So: resolve self from the imported session
+    // and notify the manager BEFORE starting the loop.
+    const me = await this.client.getMe();
+    await this.client.notifyLoggedIn(me.raw);
     await this.client.startUpdatesLoop();
   }
 

--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -909,20 +909,20 @@ function toObserved(msg: Message, edited: boolean): ObservedMessage {
   // formatting scenario will flag the empty-entities case loudly rather than
   // silently pass). It is no longer expected to trigger on the happy path.
   const rawText = msg.text ?? "";
-  // TEMP DIAGNOSTIC (#2744): dump the COMPLETE raw TL object for any decoded-
-  // empty message so we can see exactly where sendRichMessage puts the visible
-  // text. BigInt-safe replacer. Remove before final commit.
-  if (rawText === "" && msg.raw._ === "message") {
-    // eslint-disable-next-line no-console -- temp harness diagnostic
-    console.warn(
-      "[uat/driver][TEMP-RAWDUMP] empty-text message id=" + msg.id + " raw=" +
-        JSON.stringify(
-          msg.raw,
-          (_k, v) => (typeof v === "bigint" ? v.toString() + "n" : v),
-        ),
-    );
-  }
-  const isRichMedia = rawText === "" &&
+  // Bot API 10.1 rich messages (`sendRichMessage({ markdown })`) arrive on the
+  // wire in a NEW TL field — `message.richMessage` — with the legacy `message`
+  // string left EMPTY and NO `entities`. mtcute 0.30 does not yet map that
+  // field onto `Message.text`/`Message.entities`, so `msg.text` is "" and the
+  // observation looks textless. This is the sibling case to the
+  // `messageMediaUnsupported` sentinel below: the visible text is on the wire,
+  // just in a shape the getter doesn't decode. Flatten the `richMessage`
+  // page-block/RichText tree ourselves into plain text + entities. (Confirmed
+  // via a raw-TL dump on the uat-host runner, #2744.)
+  const richDecoded =
+    rawText === "" && msg.raw._ === "message"
+      ? decodeRichMessage((msg.raw as { richMessage?: unknown }).richMessage)
+      : null;
+  const isRichMedia = rawText === "" && !richDecoded &&
     msg.raw._ === "message" && msg.raw.media?._ === "messageMediaUnsupported";
   // Resolve chat/sender ids from the RAW TL peer, not the `msg.chat` /
   // `msg.sender` getters. Those getters look the peer up in the update's
@@ -946,13 +946,15 @@ function toObserved(msg: Message, edited: boolean): ObservedMessage {
     chatId,
     messageId: msg.id,
     threadId: msg.replyToMessage?.threadId ?? undefined,
-    text: isRichMedia ? "\x01" : rawText,
+    text: isRichMedia ? "\x01" : (richDecoded ? richDecoded.text : rawText),
     senderUserId,
     fromBot: safeIsFromBot(msg),
     date: msg.date,
     edited,
     silent: msg.isSilent,
-    entities: isRichMedia ? [] : toObservedEntities(msg),
+    entities: isRichMedia
+      ? []
+      : (richDecoded ? richDecoded.entities : toObservedEntities(msg)),
     link: safeMessageLink(msg),
   };
 }
@@ -980,6 +982,157 @@ function toObservedEntities(msg: Message): ObservedEntity[] {
       language: params.kind === "pre" ? params.language : undefined,
     };
   });
+}
+
+/**
+ * Decode a Bot API 10.1 rich message (`message.richMessage`) into flat
+ * `{ text, entities }`, mirroring what `Message.text` + `Message.entities`
+ * would carry if mtcute mapped the field. Returns `null` when the value isn't
+ * a `richMessage` (so callers fall back to the legacy `message` string).
+ *
+ * On the wire a `richMessage` is Telegram's Instant-View page tree: a list of
+ * `pageBlock`s, each carrying a `RichText` node. We walk the two block kinds
+ * the gateway actually emits — `pageBlockParagraph` (styled inline text) and
+ * `pageBlockPreformatted` (a fenced code block → a `pre` entity spanning the
+ * whole block) — joining blocks with a newline. The RichText tree is a
+ * discriminated union: leaf `textPlain` carries a string; `textConcat` holds a
+ * `texts[]` sequence; the styled wrappers (`textBold`/`textItalic`/`textFixed`/
+ * `textUrl`/…) nest another RichText in `.text`. We flatten depth-first,
+ * tracking UTF-16 code-unit offsets (JS string `.length` is already UTF-16, the
+ * same units Telegram uses on the wire) and emit an `ObservedEntity` for each
+ * styled span so the render-fidelity assertions see the same entity structure
+ * the legacy `entities` path produces.
+ */
+function decodeRichMessage(
+  rich: unknown,
+): { text: string; entities: ObservedEntity[] } | null {
+  const rm = rich as
+    | { _?: string; blocks?: Array<{ _?: string; text?: unknown; language?: string }> }
+    | undefined;
+  if (!rm || rm._ !== "richMessage" || !Array.isArray(rm.blocks)) return null;
+
+  let text = "";
+  const entities: ObservedEntity[] = [];
+
+  const emit = (
+    kind: string,
+    start: number,
+    extra?: { url?: string; language?: string },
+  ): void => {
+    const length = text.length - start;
+    if (length <= 0) return;
+    entities.push({
+      kind,
+      offset: start,
+      length,
+      text: text.slice(start, start + length),
+      url: extra?.url,
+      language: extra?.language,
+    });
+  };
+
+  // Depth-first walk of a RichText node, appending plain text to `text` and
+  // pushing an entity for each styled wrapper (mapping TL kinds to mtcute's).
+  const walk = (node: unknown): void => {
+    const n = node as {
+      _?: string;
+      text?: unknown;
+      texts?: unknown[];
+      url?: string;
+    };
+    if (!n || typeof n._ !== "string") return;
+    switch (n._) {
+      case "textEmpty":
+        return;
+      case "textPlain":
+        if (typeof n.text === "string") text += n.text;
+        return;
+      case "textConcat":
+        for (const t of n.texts ?? []) walk(t);
+        return;
+      case "textBold": {
+        const s = text.length;
+        walk(n.text);
+        emit("bold", s);
+        return;
+      }
+      case "textItalic": {
+        const s = text.length;
+        walk(n.text);
+        emit("italic", s);
+        return;
+      }
+      case "textUnderline": {
+        const s = text.length;
+        walk(n.text);
+        emit("underline", s);
+        return;
+      }
+      case "textStrike": {
+        const s = text.length;
+        walk(n.text);
+        emit("strikethrough", s);
+        return;
+      }
+      case "textFixed": {
+        // Inline fixed-width (`code_token`) → Bot API `code` entity.
+        const s = text.length;
+        walk(n.text);
+        emit("code", s);
+        return;
+      }
+      case "textSpoiler": {
+        const s = text.length;
+        walk(n.text);
+        emit("spoiler", s);
+        return;
+      }
+      case "textUrl": {
+        const s = text.length;
+        walk(n.text);
+        emit("text_link", s, { url: n.url });
+        return;
+      }
+      case "textEmail": {
+        const s = text.length;
+        walk(n.text);
+        emit("email", s);
+        return;
+      }
+      default:
+        // Any other wrapper (marked/sub/superscript/phone/anchor/…) — keep its
+        // visible text but don't classify the span; the render assertions only
+        // key off the kinds the gateway emits.
+        if (n.text !== undefined) walk(n.text);
+        return;
+    }
+  };
+
+  for (const block of rm.blocks) {
+    if (text.length > 0) text += "\n"; // join blocks in send order
+    if (block._ === "pageBlockPreformatted") {
+      // Fenced code block → one `pre` entity spanning the whole block, with
+      // the language string mtcute exposes for `pre` fences.
+      const s = text.length;
+      walk(block.text);
+      const length = text.length - s;
+      if (length > 0) {
+        entities.push({
+          kind: "pre",
+          offset: s,
+          length,
+          text: text.slice(s, s + length),
+          url: undefined,
+          language: block.language || undefined,
+        });
+      }
+    } else {
+      // pageBlockParagraph (and any other text-bearing block) — inline walk.
+      walk(block.text);
+    }
+  }
+
+  return { text, entities };
 }
 
 /**

--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -909,6 +909,19 @@ function toObserved(msg: Message, edited: boolean): ObservedMessage {
   // formatting scenario will flag the empty-entities case loudly rather than
   // silently pass). It is no longer expected to trigger on the happy path.
   const rawText = msg.text ?? "";
+  // TEMP DIAGNOSTIC (#2744): dump the COMPLETE raw TL object for any decoded-
+  // empty message so we can see exactly where sendRichMessage puts the visible
+  // text. BigInt-safe replacer. Remove before final commit.
+  if (rawText === "" && msg.raw._ === "message") {
+    // eslint-disable-next-line no-console -- temp harness diagnostic
+    console.warn(
+      "[uat/driver][TEMP-RAWDUMP] empty-text message id=" + msg.id + " raw=" +
+        JSON.stringify(
+          msg.raw,
+          (_k, v) => (typeof v === "bigint" ? v.toString() + "n" : v),
+        ),
+    );
+  }
   const isRichMedia = rawText === "" &&
     msg.raw._ === "message" && msg.raw.media?._ === "messageMediaUnsupported";
   // Resolve chat/sender ids from the RAW TL peer, not the `msg.chat` /

--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -207,15 +207,7 @@ export class Driver {
     // parsed new/edit-message emitters ever fire. No message bodies or
     // peer ids are logged (session-secret hygiene) — only update kinds.
     /* eslint-disable no-console -- harness diagnostic */
-    this.client.onRawUpdate.add((info: { update?: { _?: string } }) => {
-      console.warn(`[uat/driver][diag] onRawUpdate: ${info?.update?._ ?? "?"}`);
-    });
-    this.client.onNewMessage.add(() => {
-      console.warn(`[uat/driver][diag] onNewMessage FIRED`);
-    });
-    this.client.onEditMessage.add(() => {
-      console.warn(`[uat/driver][diag] onEditMessage FIRED`);
-    });
+    console.warn(`[uat/driver][diag] connected as self id=${me.id}`);
     /* eslint-enable no-console */
   }
 
@@ -377,6 +369,17 @@ export class Driver {
         );
         return;
       }
+      // TEMP DIAGNOSTIC (remove once matching confirmed): why does an
+      // observed message fail to match expectMessage? Log the target vs
+      // observed chatId, the resolved sender, edited flag, and text
+      // length (NOT the body — hygiene). Reveals chatId-mismatch vs
+      // sender-filter vs empty-text as the reason expectMessage times out.
+      // eslint-disable-next-line no-console -- harness diagnostic
+      console.warn(
+        `[uat/driver][diag] observed target=${chatId} chatId=${observed.chatId} ` +
+        `sender=${observed.senderUserId} edited=${observed.edited} ` +
+        `fromBot=${observed.fromBot} textLen=${observed.text.length}`,
+      );
       if (observed.chatId !== chatId) return;
       if (targetThread !== undefined && observed.threadId !== targetThread) return;
       dispatch(observed);

--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -329,18 +329,30 @@ export class Driver {
       else queue.push(m);
     };
 
-    const onNew = (msg: Message): void => {
-      const observed = toObserved(msg, false);
+    // Defensive wrapper: a throw inside the listener propagates out of
+    // mtcute's `onNewMessage`/`onEditMessage` emitter (it does not catch
+    // listener errors) and drops the update entirely, so `observeMessages`
+    // would silently never yield it. `toObserved` is already hardened against
+    // the known `PeersIndex` throw, but any future getter that throws must
+    // NOT be allowed to swallow an observation — log and move on instead.
+    const dispatchObserved = (msg: Message, edited: boolean): void => {
+      let observed: ObservedMessage;
+      try {
+        observed = toObserved(msg, edited);
+      } catch (err) {
+        // eslint-disable-next-line no-console -- harness diagnostic
+        console.warn(
+          `[uat/driver] observeMessages: dropping unobservable message ` +
+          `(id=${msg.id}): ${err instanceof Error ? err.message : String(err)}`,
+        );
+        return;
+      }
       if (observed.chatId !== chatId) return;
       if (targetThread !== undefined && observed.threadId !== targetThread) return;
       dispatch(observed);
     };
-    const onEdit = (msg: Message): void => {
-      const observed = toObserved(msg, true);
-      if (observed.chatId !== chatId) return;
-      if (targetThread !== undefined && observed.threadId !== targetThread) return;
-      dispatch(observed);
-    };
+    const onNew = (msg: Message): void => dispatchObserved(msg, false);
+    const onEdit = (msg: Message): void => dispatchObserved(msg, true);
 
     c.onNewMessage.add(onNew);
     c.onEditMessage.add(onEdit);
@@ -889,13 +901,31 @@ function toObserved(msg: Message, edited: boolean): ObservedMessage {
   const rawText = msg.text ?? "";
   const isRichMedia = rawText === "" &&
     msg.raw._ === "message" && msg.raw.media?._ === "messageMediaUnsupported";
+  // Resolve chat/sender ids from the RAW TL peer, not the `msg.chat` /
+  // `msg.sender` getters. Those getters look the peer up in the update's
+  // `PeersIndex` and THROW `MtArgumentError` ("peer not available in this
+  // index") when it's absent — which happens for the driver because it runs
+  // on `MemoryStorage` (empty peer cache each connect), so an incoming bot
+  // reply can arrive before that peer has been cached. An unguarded throw
+  // here propagates out of the mtcute `onNewMessage`/`onEditMessage` emitter
+  // (that emitter does not catch listener errors), so the WHOLE update is
+  // dropped and `observeMessages` never yields it — the exact "bot replied
+  // fast but `expectMessage` timed out" failure. `getMarkedPeerId` reads the
+  // raw TL peer directly and never touches the index, so it can't throw.
+  const chatId = getMarkedPeerId(msg.raw.peerId);
+  const rawFrom = msg.raw._ === "message" || msg.raw._ === "messageService"
+    ? msg.raw.fromId
+    : undefined;
+  const senderUserId = rawFrom
+    ? getMarkedPeerId(rawFrom)
+    : chatId; // no explicit sender ⇒ the DM peer is the sender (bot reply in a DM)
   return {
-    chatId: msg.chat.id,
+    chatId,
     messageId: msg.id,
     threadId: msg.replyToMessage?.threadId ?? undefined,
     text: isRichMedia ? "\x01" : rawText,
-    senderUserId: msg.sender.id,
-    fromBot: msg.sender.type === "user" && msg.sender.isBot === true,
+    senderUserId,
+    fromBot: safeIsFromBot(msg),
     date: msg.date,
     edited,
     silent: msg.isSilent,
@@ -941,5 +971,24 @@ function safeMessageLink(msg: Message): string | undefined {
     return msg.link;
   } catch {
     return undefined;
+  }
+}
+
+/**
+ * Whether the message was sent by a bot. Reads `msg.sender`, which resolves
+ * the peer via the update's `PeersIndex` and THROWS `MtArgumentError` when
+ * that peer isn't cached (the driver's `MemoryStorage` starts empty, so an
+ * incoming reply can arrive before its sender is cached). We only need
+ * `fromBot` for coarse classification, and `expectMessage`'s `from: "bot"`
+ * filter keys off `senderUserId` (resolved from the raw peer above), not this
+ * flag — so a swallowed lookup degrades to `false` rather than dropping the
+ * whole observation. Group/DM messages with a cached sender still classify
+ * correctly.
+ */
+function safeIsFromBot(msg: Message): boolean {
+  try {
+    return msg.sender.type === "user" && msg.sender.isBot === true;
+  } catch {
+    return false;
   }
 }

--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -374,11 +374,14 @@ export class Driver {
       // observed chatId, the resolved sender, edited flag, and text
       // length (NOT the body — hygiene). Reveals chatId-mismatch vs
       // sender-filter vs empty-text as the reason expectMessage times out.
+      const rawM = msg.raw as { _?: string; media?: { _?: string }; message?: string };
       // eslint-disable-next-line no-console -- harness diagnostic
       console.warn(
         `[uat/driver][diag] observed target=${chatId} chatId=${observed.chatId} ` +
         `sender=${observed.senderUserId} edited=${observed.edited} ` +
-        `fromBot=${observed.fromBot} textLen=${observed.text.length}`,
+        `fromBot=${observed.fromBot} textLen=${observed.text.length} ` +
+        `raw_=${rawM._ ?? "?"} media=${rawM.media?._ ?? "none"} ` +
+        `rawMsgLen=${rawM.message?.length ?? -1}`,
       );
       if (observed.chatId !== chatId) return;
       if (targetThread !== undefined && observed.threadId !== targetThread) return;

--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -199,6 +199,24 @@ export class Driver {
     const me = await this.client.getMe();
     await this.client.notifyLoggedIn(me.raw);
     await this.client.startUpdatesLoop();
+
+    // TEMP DIAGNOSTIC (remove once dispatch confirmed): distinguish
+    // "no updates arrive at all" from "raw updates arrive but new_message
+    // is never dispatched to onNewMessage". Logs the raw TL `_` type of
+    // every update the manager dispatches, and separately whether the
+    // parsed new/edit-message emitters ever fire. No message bodies or
+    // peer ids are logged (session-secret hygiene) — only update kinds.
+    /* eslint-disable no-console -- harness diagnostic */
+    this.client.onRawUpdate.add((info: { update?: { _?: string } }) => {
+      console.warn(`[uat/driver][diag] onRawUpdate: ${info?.update?._ ?? "?"}`);
+    });
+    this.client.onNewMessage.add(() => {
+      console.warn(`[uat/driver][diag] onNewMessage FIRED`);
+    });
+    this.client.onEditMessage.add(() => {
+      console.warn(`[uat/driver][diag] onEditMessage FIRED`);
+    });
+    /* eslint-enable no-console */
   }
 
   async disconnect(): Promise<void> {

--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -187,15 +187,13 @@ export class Driver {
     // timing out even though the bot's reply has arrived in the chat
     // (visible in Telegram).
     //
-    // Crucially, `startUpdatesLoop()` alone is NOT enough. In mtcute 0.30
-    // the updates manager will not DISPATCH new-message updates unless it
-    // has been told the client is logged in — `start()` does this via
-    // `notifyLoggedIn` in its login callback, but a manually-imported
-    // session skips `start()` entirely. Without it the manager starts the
-    // loop while still considering the user logged-out, the incoming
-    // update is fetched but never routed to `onNewMessage`, and the
-    // observer waits forever. So: resolve self from the imported session
-    // and notify the manager BEFORE starting the loop.
+    // `notifyLoggedIn` is the lifecycle call `start()` makes from its
+    // login callback but a manually-imported session skips — it tells the
+    // updates manager the client is authorized (and seeds self into the
+    // peer cache). mtcute 0.30's own docs recommend calling it, or
+    // otherwise ensuring the user is logged in, before `startUpdatesLoop`.
+    // Resolve self from the imported session and notify BEFORE starting
+    // the loop, matching what `start()` does internally.
     const me = await this.client.getMe();
     await this.client.notifyLoggedIn(me.raw);
     await this.client.startUpdatesLoop();
@@ -359,11 +357,6 @@ export class Driver {
         );
         return;
       }
-      // TEMP DIAGNOSTIC (remove once matching confirmed): why does an
-      // observed message fail to match expectMessage? Log the target vs
-      // observed chatId, the resolved sender, edited flag, and text
-      // length (NOT the body — hygiene). Reveals chatId-mismatch vs
-      // sender-filter vs empty-text as the reason expectMessage times out.
       if (observed.chatId !== chatId) return;
       if (targetThread !== undefined && observed.threadId !== targetThread) return;
       dispatch(observed);

--- a/tests/uat-driver.test.ts
+++ b/tests/uat-driver.test.ts
@@ -77,6 +77,28 @@ function getMarkedPeerIdImpl(peer: { _: string; userId?: number; chatId?: number
   }
 }
 
+// Build the `raw` slice a Message double needs so `toObserved` can read the
+// chat/sender ids off the RAW TL peer (index-free). Mirrors mtcute's marked-id
+// convention: positive ⇒ user (peerUser), -100…-prefixed ⇒ channel, other
+// negative ⇒ basic chat. `fromId` defaults to the same peer as the chat (a bot
+// reply in a DM has no explicit fromId; the peer IS the sender).
+function rawWithPeer(
+  markedChatId: number,
+  markedFromId?: number,
+): { _: "message"; peerId: unknown; fromId?: unknown; media: undefined } {
+  const toRawPeer = (id: number): unknown => {
+    if (id > 0) return { _: "peerUser", userId: id };
+    if (id <= -1e12) return { _: "peerChannel", channelId: -1e12 - id };
+    return { _: "peerChat", chatId: -id };
+  };
+  return {
+    _: "message",
+    peerId: toRawPeer(markedChatId),
+    fromId: markedFromId !== undefined ? toRawPeer(markedFromId) : undefined,
+    media: undefined,
+  };
+}
+
 vi.mock("@mtcute/node", () => ({
   MemoryStorage: class {},
   TelegramClient: TelegramClientCtor,
@@ -213,6 +235,11 @@ describe("Driver.observeMessages", () => {
       date: new Date(),
       chat: { id: opts.chatId },
       sender: { type: "user", isBot: opts.fromBot === true },
+      // `toObserved` reads the RAW TL peer for chat/sender ids (index-free,
+      // never-throws). A real mtcute Message always carries `raw.peerId`; a
+      // marked chat id maps back to a raw peer (negative-100… ⇒ channel,
+      // negative ⇒ chat, positive ⇒ user).
+      raw: rawWithPeer(opts.chatId),
       replyToMessage: opts.threadId !== undefined
         ? { threadId: opts.threadId }
         : undefined,
@@ -239,6 +266,57 @@ describe("Driver.observeMessages", () => {
     expect(m.text).toBe("match");
     expect(m.threadId).toBe(7);
     expect(m.edited).toBe(false);
+
+    await iter.return?.();
+  });
+
+  it("observes a bot DM reply whose peer is NOT in the update's index (regression: #2742 mtcute 0.30 silent-drop)", async () => {
+    // Root cause: the driver runs on MemoryStorage (empty peer cache each
+    // connect), so a bot's reply can arrive before its peer is cached. When
+    // `toObserved` read `msg.chat.id` / `msg.sender.id`, those getters look
+    // the peer up in the update's PeersIndex and THROW MtArgumentError when
+    // it's absent. That throw propagated out of mtcute's onNewMessage emitter
+    // (which does not catch listener errors), dropping the whole update — so
+    // `observeMessages` never yielded it and `expectMessage(/\S/, {from:"bot"})`
+    // timed out even though the bot had replied fast. The fix reads chat/sender
+    // ids off the RAW TL peer (index-free), so this must now be observed.
+    //
+    // This double reproduces the throw: `chat` and `sender` are getters that
+    // throw the exact mtcute error, while `raw.peerId` / `raw.fromId` carry
+    // the real bot user id (8288144562) — the id the DM chat is keyed on.
+    const BOT = 8288144562;
+    const throwingMsg = {
+      id: 555,
+      text: "4",
+      date: new Date(),
+      replyToMessage: undefined,
+      isSilent: false,
+      entities: [],
+      raw: rawWithPeer(BOT, BOT),
+      get chat(): never {
+        throw new Error("Given peer is not available in this index.");
+      },
+      get sender(): never {
+        throw new Error("Given peer is not available in this index.");
+      },
+    };
+
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    const iter = driver.observeMessages(BOT)[Symbol.asyncIterator]();
+
+    mockClient.onNewMessage.emit(throwingMsg);
+
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+    const m = first.value as ObservedMessage;
+    expect(m.messageId).toBe(555);
+    expect(m.chatId).toBe(BOT);
+    expect(m.senderUserId).toBe(BOT);
+    expect(m.text).toBe("4");
+    // sender getter threw, so fromBot degrades to false — but senderUserId
+    // (what `from: "bot"` filters on) is correct, which is what matters.
+    expect(m.fromBot).toBe(false);
 
     await iter.return?.();
   });
@@ -671,6 +749,7 @@ describe("Driver.getMessage", () => {
         date: new Date("2026-05-11T04:30:00Z"),
         chat: { id: 67890 },
         sender: { id: 67890, type: "user", isBot: true },
+        raw: rawWithPeer(67890),
         replyToMessage: undefined,
       } as never,
     ]);
@@ -707,7 +786,12 @@ describe("toObserved — rich formatting surface (issue #2739)", () => {
       chat: { id: 111 },
       sender: { id: 222, type: "user", isBot: true },
       replyToMessage: undefined,
-      raw: { _: "message", media: undefined },
+      raw: {
+        _: "message",
+        peerId: { _: "peerUser", userId: 111 },
+        fromId: { _: "peerUser", userId: 222 },
+        media: undefined,
+      },
       isSilent: false,
       entities: [],
       ...overrides,
@@ -762,7 +846,12 @@ describe("toObserved — rich formatting surface (issue #2739)", () => {
     mockClient.getMessages.mockResolvedValueOnce([
       mockMsg({
         text: "",
-        raw: { _: "message", media: { _: "messageMediaUnsupported" } },
+        raw: {
+          _: "message",
+          peerId: { _: "peerUser", userId: 111 },
+          fromId: { _: "peerUser", userId: 222 },
+          media: { _: "messageMediaUnsupported" },
+        },
         entities: [],
       } as never),
     ]);

--- a/tests/uat-driver.test.ts
+++ b/tests/uat-driver.test.ts
@@ -283,8 +283,8 @@ describe("Driver.observeMessages", () => {
     //
     // This double reproduces the throw: `chat` and `sender` are getters that
     // throw the exact mtcute error, while `raw.peerId` / `raw.fromId` carry
-    // the real bot user id (8288144562) — the id the DM chat is keyed on.
-    const BOT = 8288144562;
+    // the bot user id — the id the DM chat is keyed on.
+    const BOT = 12345;
     const throwingMsg = {
       id: 555,
       text: "4",

--- a/tests/uat-driver.test.ts
+++ b/tests/uat-driver.test.ts
@@ -37,9 +37,22 @@ class MockEmitter<T> {
   }
 }
 
+// A minimal RawUser stand-in `getMe().raw` returns. `connect()` passes this to
+// `notifyLoggedIn` to mark the imported session authorized before starting the
+// updates loop (mirrors what mtcute's `start()` does internally). The driver
+// only needs `getMe()` to resolve and `notifyLoggedIn()` to accept it — the
+// exact RawUser shape is opaque to the driver, so a tagged object suffices.
+const mockSelfRaw = { _: "user", id: 777, bot: false, self: true };
+
 const mockClient = {
   importSession: vi.fn(async () => undefined),
   connect: vi.fn(async () => undefined),
+  // `connect()` resolves self from the imported session and calls
+  // `notifyLoggedIn(me.raw)` before `startUpdatesLoop()`. Without these two
+  // stubs, `connect()` rejects and every test that connects cascades to fail
+  // (the mtcute 0.30 dispatch fix, #2744).
+  getMe: vi.fn(async () => ({ id: 777, raw: mockSelfRaw })),
+  notifyLoggedIn: vi.fn(async () => undefined),
   startUpdatesLoop: vi.fn(async () => undefined),
   destroy: vi.fn(async () => undefined),
   sendText: vi.fn(async () => ({ id: 999 })),
@@ -838,6 +851,89 @@ describe("toObserved — rich formatting surface (issue #2739)", () => {
     const pre = msg?.entities.find((e) => e.kind === "pre");
     expect(pre?.language).toBe("bash");
     expect(msg?.link).toBe("https://t.me/c/111/7");
+  });
+
+  it("decodes a Bot API 10.1 richMessage (empty .message + page-block tree) into text + entities", async () => {
+    // Direct coverage of `decodeRichMessage` (#2744): sendRichMessage replies
+    // land with the legacy `message` string EMPTY and the visible text in the
+    // new TL field `message.richMessage` (an Instant-View page tree). This is
+    // the exact wire shape captured from the uat-host runner — a paragraph of
+    // styled inline text plus a fenced (preformatted) code block. mtcute 0.30
+    // doesn't map the field, so without the decode `msg.text` is "" and the
+    // observation looks textless. Assert the flattened text + every expected
+    // entity kind (bold/italic/code/text_link/pre) with the right url/language.
+    const driver = new Driver({ apiId: 1, apiHash: "h", session: "S" });
+    await driver.connect();
+    mockClient.getMessages.mockResolvedValueOnce([
+      mockMsg({
+        text: "",
+        entities: [],
+        raw: {
+          _: "message",
+          peerId: { _: "peerUser", userId: 111 },
+          fromId: { _: "peerUser", userId: 222 },
+          media: undefined,
+          message: "",
+          richMessage: {
+            _: "richMessage",
+            rtl: false,
+            part: false,
+            blocks: [
+              {
+                _: "pageBlockParagraph",
+                text: {
+                  _: "textConcat",
+                  texts: [
+                    { _: "textPlain", text: "here is " },
+                    { _: "textBold", text: { _: "textPlain", text: "a bold phrase" } },
+                    { _: "textPlain", text: ", " },
+                    { _: "textItalic", text: { _: "textPlain", text: "italic words" } },
+                    { _: "textPlain", text: ", " },
+                    { _: "textFixed", text: { _: "textPlain", text: "code_token" } },
+                    { _: "textPlain", text: ", and " },
+                    {
+                      _: "textUrl",
+                      text: { _: "textPlain", text: "the repo" },
+                      url: "https://github.com/switchroom/switchroom",
+                      webpageId: 0,
+                    },
+                    { _: "textPlain", text: "." },
+                  ],
+                },
+              },
+              {
+                _: "pageBlockPreformatted",
+                language: "bash",
+                text: { _: "textPlain", text: 'echo "hello from the torture set"' },
+              },
+            ],
+            photos: [],
+            documents: [],
+          },
+        },
+      } as never),
+    ]);
+    const msg = await driver.getMessage(111, 7);
+    expect(msg?.text).not.toBe("\x01");
+    // Blocks joined by a newline; inline text flattened in send order.
+    expect(msg?.text).toBe(
+      "here is a bold phrase, italic words, code_token, and the repo.\n" +
+        'echo "hello from the torture set"',
+    );
+    const kinds = msg?.entities.map((e) => e.kind) ?? [];
+    for (const k of ["bold", "italic", "code", "text_link", "pre"]) {
+      expect(kinds).toContain(k);
+    }
+    // Each entity's `text` is the exact inner substring it spans (UTF-16 offsets).
+    expect(msg?.entities.find((e) => e.kind === "bold")?.text).toBe("a bold phrase");
+    expect(msg?.entities.find((e) => e.kind === "italic")?.text).toBe("italic words");
+    expect(msg?.entities.find((e) => e.kind === "code")?.text).toBe("code_token");
+    const link = msg?.entities.find((e) => e.kind === "text_link");
+    expect(link?.text).toBe("the repo");
+    expect(link?.url).toBe("https://github.com/switchroom/switchroom");
+    const pre = msg?.entities.find((e) => e.kind === "pre");
+    expect(pre?.text).toBe('echo "hello from the torture set"');
+    expect(pre?.language).toBe("bash");
   });
 
   it("keeps the \\x01 sentinel and empty entities for undecoded rich media", async () => {


### PR DESCRIPTION
## Summary

Fixes the UAT real-account driver so it correctly observes the text of the test bot's replies. Two coupled root causes in the driver's observation path, both test-harness-only (no product/gateway change):

1. **Dispatch never started** — a manually `importSession`'d driver skipped the lifecycle `start()` does, so `onNewMessage`/`onEditMessage` never fired and `observeMessages` waited forever (`expectMessage` timeouts even though the reply was visible in Telegram).
2. **Rich replies decoded as empty text** — the gateway sends every reply via Bot API 10.1 `sendRichMessage({ markdown })`. On the MTProto wire that lands in a **new TL field `message.richMessage`** (a Telegram Instant-View page tree) with the legacy `message` string **empty** and no `entities`. mtcute 0.30 doesn't map that field, so `msg.text` was `""` and the driver observed rich replies as textless — `expectMessage` never matched and the render-fidelity scenario could never run.

The `uat-gate` check is now **green**, and the render-fidelity scenario runs live and passes for the first time — the first live proof that bold/italic/code/pre/link survive the render round-trip.

## What the fix does (test-harness only, `telegram-plugin/uat/driver.ts`)

- **Dispatch:** `connect()` resolves self from the imported session and calls `notifyLoggedIn(me.raw)` before `startUpdatesLoop()`, matching what mtcute's `start()` does internally — so update dispatch actually runs for a returning (non-interactive) session.
- **Peer-index hardening:** `toObserved` derives `chatId`/`senderUserId` from the raw TL peer via `getMarkedPeerId` (index-free, never throws), and `fromBot` is behind `safeIsFromBot()`. `observeMessages` wraps `toObserved` in try/catch so no throwing getter can silently swallow an observation.
- **Rich-message decode:** new `decodeRichMessage()` flattens the `message.richMessage` page-block/RichText tree into flat text + `ObservedEntity[]` (bold/italic/code/pre/text_link/…) with UTF-16 offsets — a sibling to the existing `messageMediaUnsupported` `\x01` sentinel guard. When `message` is empty and `richMessage` is present, the observation surfaces the real text and entity structure Telegram parsed.

## Where the text actually lived (raw-TL evidence)

A temporary raw-TL dump on the `uat-host` runner showed the visible text is **not** in `message`, `media`, or `entities`, but in `message.richMessage`:

```json
"message": "",
"richMessage": { "_": "richMessage", "blocks": [
  { "_": "pageBlockParagraph", "text": { "_": "textConcat", "texts": [
    { "_": "textBold", "text": { "_": "textPlain", "text": "Agent" } }, … ] } } ] }
```

## Test plan

- [x] `tsc --noEmit`, `lint`, `vitest` (39 driver tests), `bun-test` all green
- [x] Mock mtcute client stubs `getMe`/`notifyLoggedIn` so `connect()` succeeds
- [x] New unit test covers `decodeRichMessage` directly (empty `.message` + richMessage tree → asserted text + bold/italic/code/text_link/pre entities with url/language)
- [x] **`uat-gate` GREEN** — `jtbd-fast-trivial-dm`, `inbound-no-drop`, and `jtbd-rich-formatting-render-dm` all pass live on `uat-host`. Decoded entity structure from the live run:

```
bold "a bold phrase", italic "italic words", code "code_token",
text_link "the repo" url=https://github.com/switchroom/switchroom,
pre "echo \"hello from the torture set\"" language=bash
```

## JTBD

Serves `reference/jobs/know-what-my-agent-is-doing.md` (the render-fidelity + fast-reply UAT gate that proves the agent's replies actually reach the user rendered correctly). Advances the **visibility** vision outcome. Test-harness only — no invariant surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
