### PR TITLE
fix(profiles): bake reply-tool delivery discipline into base CLAUDE.md template

### DIFF
--- a/profiles/_shared/reply-discipline.md.hbs
+++ b/profiles/_shared/reply-discipline.md.hbs
@@ -1,0 +1,9 @@
+## ⛔ SENDING YOUR ANSWER (read first, applies every turn)
+
+**Plain text you write is INVISIBLE to the user.** The only thing that reaches Telegram is text passed through the `mcp__switchroom-telegram__reply` tool. Writing the answer in your response is NOT sending it — the user sees nothing until you call the reply tool.
+
+- Every turn that answers a user **MUST end with a `reply` tool call** carrying the full answer. No exceptions, no "I'll just write it out."
+- If you did work first (tool calls, lookups), the reply call is still required at the end — don't let the turn end on a tool result or plain prose.
+- If you genuinely have nothing to add, emit exactly `NO_REPLY` and nothing else.
+
+If you skip this, the gateway's safety net eventually forces your answer out 2-4 minutes late and burns extra turns. Don't rely on the net. Send it yourself.

--- a/src/agents/profiles.ts
+++ b/src/agents/profiles.ts
@@ -171,7 +171,7 @@ Handlebars.registerHelper("isNumber", (value: unknown) => {
 // The _shared/ directory is underscore-prefixed (like _base/) and is not
 // listed by listAvailableProfiles() — it's framework-internal.
 const SHARED_FRAGMENTS_DIR = resolve(PROFILES_ROOT, "_shared");
-const SHARED_FRAGMENTS = ["vault-protocol", "agent-self-service", "execution-discipline"] as const;
+const SHARED_FRAGMENTS = ["vault-protocol", "agent-self-service", "execution-discipline", "reply-discipline"] as const;
 for (const name of SHARED_FRAGMENTS) {
   const fragPath = join(SHARED_FRAGMENTS_DIR, `${name}.md.hbs`);
   if (existsSync(fragPath)) {
@@ -246,6 +246,39 @@ export function renderExecutionDisciplineFragment(
   profilesRoot: string = PROFILES_ROOT,
 ): string {
   const fragPath = join(resolve(profilesRoot, "_shared"), "execution-discipline.md.hbs");
+  if (!existsSync(fragPath)) return "";
+  const source = readFileSync(fragPath, "utf-8");
+  const template = Handlebars.compile(source, { noEscape: true });
+  return template(context).trimEnd();
+}
+
+/**
+ * Render the reply-discipline fragment standalone for unconditional
+ * PREPEND (near the top) of every agent's CLAUDE.md. Same
+ * unconditional-carrier pattern as {@link renderVaultProtocolFragment}
+ * and {@link renderExecutionDisciplineFragment}, but this one rides at
+ * the TOP rather than the tail: the "your plain text is invisible —
+ * only the `reply` tool reaches Telegram" contract is turn-critical, so
+ * it must be one of the first things the model reads, and it must reach
+ * EVERY agent on EVERY profile (default / coding / health-coach /
+ * executive-assistant), not just the default profile's CLAUDE.md.
+ *
+ * Root cause it closes: this contract previously lived ONLY in the
+ * telegram MCP runtime instruction blob, which the model deprioritizes —
+ * agents ended turns writing the finished answer as plain assistant text
+ * that never reached Telegram, so the owed-reply safety net force-flushed
+ * it 2-4 min late, burning extra turns. Baking it into the base CLAUDE.md
+ * template makes the discipline durable + fleet-wide.
+ *
+ * Returns the rendered Markdown, or an empty string if the fragment
+ * file is missing (e.g. partial install).
+ */
+export function renderReplyDisciplineFragment(
+  context: Record<string, unknown> = {},
+  /** Override the profiles root; used by tests. */
+  profilesRoot: string = PROFILES_ROOT,
+): string {
+  const fragPath = join(resolve(profilesRoot, "_shared"), "reply-discipline.md.hbs");
   if (!existsSync(fragPath)) return "";
   const source = readFileSync(fragPath, "utf-8");
   const template = Handlebars.compile(source, { noEscape: true });

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -441,6 +441,34 @@ never reaches them.`;
  * Header is a literal string the operator sees first when they open
  * the file — it MUST teach the file's nature without requiring docs.
  */
+/**
+ * Prepend the reply-discipline fragment near the TOP of a rendered
+ * CLAUDE.md — right after the leading `# Agent: <name>` title line, so
+ * the "your plain text is invisible, only the `reply` tool reaches
+ * Telegram" contract is one of the first things the model reads. Unlike
+ * the vault / self-service / execution-discipline fragments (which ride
+ * the tail), this contract is turn-critical and must be prominent.
+ *
+ * Applied identically on BOTH the first-scaffold and reconcile paths so
+ * the two produce byte-identical CLAUDE.md (the reconcile diff-abort
+ * trips otherwise). No-op if the fragment source file is absent.
+ */
+function prependReplyDiscipline(
+  rendered: string,
+  context: Record<string, unknown>,
+): string {
+  const replyDiscipline = renderReplyDisciplineFragment(context);
+  if (!replyDiscipline) return rendered;
+  const newlineIdx = rendered.indexOf("\n");
+  if (newlineIdx === -1) {
+    // Degenerate single-line template — put the title first, then block.
+    return rendered.trimEnd() + "\n\n" + replyDiscipline + "\n";
+  }
+  const title = rendered.slice(0, newlineIdx);
+  const body = rendered.slice(newlineIdx + 1).replace(/^\n+/, "");
+  return title + "\n\n" + replyDiscipline + "\n\n" + body;
+}
+
 export function renderFleetInvariants(): string {
   return [
     "<!--",
@@ -592,6 +620,7 @@ import {
   renderVaultProtocolFragment,
   renderAgentSelfServiceFragment,
   renderExecutionDisciplineFragment,
+  renderReplyDisciplineFragment,
 } from "./profiles.js";
 import {
   getHindsightSettingsEntry,
@@ -3656,6 +3685,11 @@ export function scaffoldAgent(
         () => {
           let rendered = renderTemplate(srcPath, context);
           if (dest === "CLAUDE.md") {
+            // Reply-discipline rides at the TOP (prepended after the
+            // title), unlike the tail fragments below — the "reply tool
+            // or it's invisible" contract must be one of the first things
+            // the model reads. Every profile gets it.
+            rendered = prependReplyDiscipline(rendered, context);
             const vaultProtocol = renderVaultProtocolFragment(context);
             if (vaultProtocol) {
               rendered = rendered.trimEnd() + "\n\n" + vaultProtocol + "\n";
@@ -5456,6 +5490,11 @@ export function reconcileAgent(
       // the other path applied. Both fragments are no-ops if their
       // source file is absent.
       let rendered = renderTemplate(claudeMdSrc, claudeContext);
+      // Reply-discipline rides at the TOP (prepended after the title).
+      // MUST mirror the first-scaffold path (via the shared
+      // prependReplyDiscipline helper) or the diff-abort below trips on
+      // every reconcile.
+      rendered = prependReplyDiscipline(rendered, claudeContext);
       const vaultProtocol = renderVaultProtocolFragment(claudeContext);
       if (vaultProtocol) {
         rendered = rendered.trimEnd() + "\n\n" + vaultProtocol + "\n";


### PR DESCRIPTION
## Summary

Bakes the reply-tool delivery discipline into the **base agent instruction template** so **every** agent gets it, on every profile — via a new `profiles/_shared/reply-discipline.md.hbs` fragment prepended near the top of the rendered `CLAUDE.md` (right after the `# Agent: <name>` title, before "What you are").

The block (verbatim contract):

> **Plain text you write is INVISIBLE to the user.** The only thing that reaches Telegram is text passed through the `mcp__switchroom-telegram__reply` tool… Every turn that answers a user MUST end with a `reply` tool call carrying the full answer… If you genuinely have nothing to add, emit exactly `NO_REPLY`.

## Why — root cause (with evidence)

Agents were ending turns writing the **finished answer as plain assistant text that never reached Telegram**. Observed live: **clerk 200/201 silent turns**, **marko 282/282 silent turns**. Because the answer was never sent through the reply tool, the gateway's **owed-reply safety net force-flushed it 2-4 minutes late**, burning extra turns each time.

Root cause: the "reply tool or it's invisible" contract lived **only in the telegram MCP runtime instruction blob**, which the model deprioritizes — it was **not** in the base `CLAUDE.md` template the model treats as durable standing instruction. This PR moves the contract to a prominent, top-of-file position in the base template so it is one of the first things every agent reads, every turn.

**clerk & marko were hot-patched live; this makes it durable + fleet-wide. Does NOT auto-deploy — existing agents pick it up on next scaffold/apply.**

## Design contract

- **JTBD served:** `reference/jobs/know-what-my-agent-is-doing.md` — "At any moment during a turn, the user can see what the agent is up to and why." An answer that never reaches Telegram is the ultimate failure of that job. (`invariants: [chat-is-the-single-source-of-truth]`.)
- **Vision outcome advanced:** Visibility / "you hold the leash" (hold-the-leash) — and the `chat-is-the-single-source-of-truth` invariant: the chat is the one record, so the answer MUST land in it.

## Implementation

- New shared fragment `profiles/_shared/reply-discipline.md.hbs` (no agent-name handlebars var needed — the block is agent-agnostic).
- `src/agents/profiles.ts`: register the fragment as a partial + add `renderReplyDisciplineFragment()` (mirrors the existing vault-protocol / self-service / execution-discipline carriers).
- `src/agents/scaffold.ts`: new `prependReplyDiscipline()` helper applied identically on **both** the first-scaffold and reconcile composition paths (so the two render byte-identical `CLAUDE.md` and the reconcile diff-abort doesn't trip). Unlike the tail fragments, this one rides at the **top** because the contract is turn-critical.

The fragment reaches every profile because it rides the unconditional-carrier mechanism, not a single profile template — the `coding` / `health-coach` / `executive-assistant` profiles do not inherit `default`'s body, so a `default`-only edit would have missed them.

## Test plan

- [x] `tsc --noEmit` (lint) — pass
- [x] `node scripts/build.mjs` — pass
- [x] `vitest run` on `profiles.test.ts` + scaffold/reconcile identity suites (`scaffold.rerender-claude-md`, `reconcile.persona`, `scaffold.hot-reload-stable`, `reconcile.skip-profile-templates`) — 68 passed. These are the tests that guard scaffold-vs-reconcile byte-identity.
- [x] Render proof: rendered `CLAUDE.md` for all four profiles (default, coding, health-coach, executive-assistant) — block present at line 2 (immediately after the title) in every one.
- Template/prompt-content change: no new dedicated unit test added (the change is a prompt string carried by the existing fragment machinery, which the scaffold/reconcile identity tests already exercise). No Telegram UAT run headless.

## Risk

Low. Prompt-content-only addition riding a proven carrier mechanism. No runtime code path or behaviour changes beyond the rendered `CLAUDE.md` text. Existing agents are unaffected until their next `switchroom apply` / scaffold re-render.
