### PR TITLE
feat(fleet-health): operator-facing fleet issue tracking + admin page

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -824,6 +824,34 @@ surfaces this at config-edit time.
 Setup walkthrough:
 [`docs/notion-integration.md`](notion-integration.md).
 
+## Fleet Health (`fleet_health:`)
+
+Fleet Health is the operator-facing, job-spec-anchored issue tracker: the
+fleet watches itself against the jobs in `reference/jobs/`, ranks its own
+recurring failures by impact, and surfaces them on the admin **Fleet Health**
+page (design: [`reference/rfcs/fleet-health.md`](../reference/rfcs/fleet-health.md),
+serves the job spec `fleet-stays-healthy`).
+
+It is **top-level and operator-owned** — not part of the per-agent
+`defaults → profiles → agents` cascade. The one field assigns WHICH agent
+owns the detection work, so every scan and deep-dive is attributable and
+on-leash.
+
+| Field | Cascade | Description |
+|-------|---------|-------------|
+| `fleet_health.owner_agent` | override (top-level only) | The admin agent that runs the nightly model-free sensor + weekly budgeted deep-dive that populate `~/.switchroom/fleet-health/ledger.json`. Default **unset** → the feature is inert: no crons scheduled, the admin page renders its empty state. The named agent must be `admin: true`. A dedicated owner (not any admin) keeps the fleet-health memory scoped and the token spend accountable. The detection runs **only** as operator-set schedules on this agent — never a self-authored loop. |
+
+The ledger at `~/.switchroom/fleet-health/ledger.json` is per-deployment state
+written by the owner agent; it is **never committed to the repo** (same rule
+as agent scaffolds and the scheduler ledger). The admin page reads it
+read-only and ranks the 22 job records worst-first by `priority_score`
+(`severity × frequency × reach × recency`).
+
+```yaml
+fleet_health:
+  owner_agent: klanker   # admin: true; runs the sensor + deep-dive crons
+```
+
 ## Minimal Example
 
 ```yaml

--- a/reference/jobs/fleet-stays-healthy.md
+++ b/reference/jobs/fleet-stays-healthy.md
@@ -1,0 +1,142 @@
+---
+job: surface the fleet's own recurring failures ranked by impact, so the operator spends attention only on the worst issues instead of auditing everything
+outcome: The fleet detects, ranks, and tracks its own recurring failures against the jobs it is supposed to do. The operator sees the worst-affecting issues first — with frequency, evidence, and a GitHub issue for the work — and never has to hand-audit turns to find what is quietly breaking.
+stakes: A standing fleet of always-on specialists fails silently. An agent writes answers as plain text and never calls the reply tool; the gateway's safety net delivers them 2-4 minutes late for weeks and no one notices. Without a way for the fleet to surface its own recurring failures, the operator either audits every turn by hand (impossible at fleet scale) or learns about the breakage from a principal complaining. Either way trust leaks a turn at a time, and the "always-on" promise quietly rots underneath.
+serves: always-available
+invariants: [chat-is-the-single-source-of-truth, no-self-escalation, on-leash, single-tenant]
+---
+
+# Job Spec: the fleet stays healthy
+
+> The durable, per-job outcome contract. Read by a human (judging a change)
+> and an agent (deciding what to do mid-task). Outcome-oriented, never
+> tech-specific: the detector layers, the ledger shape, the priority
+> formula can all change underneath it while the job stays still.
+
+## The job
+
+The fleet does 22 jobs (`reference/jobs/*.md`). Each is a JTBD an agent
+can quietly fail at — a silent no-op, a late delivery, a duplicate send, a
+missed trigger — in a way that never raises an error and so never reaches
+the operator. The operator wants the fleet to **watch itself against those
+jobs**, rank the recurring failures by how much they actually hurt, and put
+the worst ones in front of the operator with the evidence attached and a
+GitHub issue tracking the fix. The operator's scarce resource is attention;
+this job spends it only on the issues with the largest blast radius.
+
+It ladders to `always-available` (a fleet that stays up and *stays correct*,
+not just alive), and it sits beside `see-my-whole-fleet-from-one-screen`
+(that job is the operator's live glance across the fleet; this one is the
+fleet's standing, ranked record of what is *recurringly broken*). It is held
+inside `chat-is-the-single-source-of-truth` (the admin page is an operator
+surface, not a parallel principal channel), `no-self-escalation` and
+`on-leash` (the detection runs as operator-set schedules on an
+operator-assigned agent, never a self-authored loop), and `single-tenant`
+(it reads this one deployment's own state).
+
+**Distinct from `get-better-the-longer-they-run.md`.** That job is
+*agent-facing*: an agent codifies a lesson into its own skill so it stops
+repeating a correction. This job is *operator-facing*: the fleet surfaces its
+own recurring failures, ranked by impact, into an operator-visible tracker so
+the operator decides what gets fixed. One improves an agent's own behaviour
+silently; the other gives the operator a triage queue over the whole fleet.
+
+## Good / bad
+
+**Good looks like**
+
+- A recurring failure (e.g. an agent never calling the reply tool, so the
+  gateway delivers late) is detected from the fleet's own logs, without a
+  principal reporting it and without the operator auditing turns.
+- The operator opens one page and sees the 22 jobs ranked worst-first by a
+  priority score that reflects real impact (how bad × how often × how many
+  agents × how recently), not raw event counts.
+- Each issue carries its evidence — the exact turns (by turn id) and log
+  pointers — and links to a GitHub issue that tracks both the identification
+  and the resolution.
+- Detection is cheap: a nightly model-free sensor updates every job's counts
+  at zero token cost; expensive deep reasoning runs only on the top one or
+  two issues by score, on a budget.
+- A fix is self-verifying: after it lands, the sensor's count for that issue
+  drops (e.g. 282 → ~2) and the GitHub issue closes on the verified drop.
+
+> [!CAUTION]
+> The detection runs only as operator-set schedules on an operator-assigned
+> owner agent, and its expensive layers are model-free-gated. An agent that
+> stood up its own polling loop to "watch the fleet", or that ran an Opus
+> deep-dive on every job every night, would break `on-leash` (a self-authored
+> loop) and `crons-use-the-model-only-when-it-earns-it` (spending the model
+> where a model-free filter would do). The admin page is an operator surface;
+> it must never become a second principal channel or a parallel status mirror
+> (`chat-is-the-single-source-of-truth`).
+
+**Bad looks like: never ship this**
+
+- A recurring failure only surfaces when a principal complains.
+- The page ranks by raw event count, so a noisy-but-harmless signal buries a
+  rare-but-severe one.
+- An issue with no evidence — a number with no turn ids or log pointers, so
+  the operator still has to go dig.
+- Every job gets an Opus deep-dive every night (token burn) or the sensor
+  itself needs a model to run (should be zero-token).
+- A fixed issue stays "open" forever because nothing verifies the count drop
+  and closes it.
+- The detector opens a fresh duplicate GitHub issue for the same problem
+  every night instead of updating the existing one.
+
+## Prove it
+
+- **Detect × silent-late-delivery** — *(validated end-to-end 2026-07,
+  coverage gap: no runnable UAT yet)*. *Watch:* the model-free sensor flags
+  agents that never call the reply tool (the represent-safety-net signature)
+  and ranks the issue by impact; a deep-dive root-causes it from the
+  transcript. *Invariant:* zero-token sensor, model-free-gated deep-dive.
+- **Rank × severity-over-frequency** — *(coverage gap)*. *Watch:* a
+  rare-but-severe issue outranks a frequent-but-cosmetic one because the
+  priority score weights severity and reach, not just count. *Invariant:*
+  the page reads the ledger; no principal channel.
+- **Close × verified-count-drop** — *(coverage gap)*. *Watch:* after a fix,
+  the sensor's count for the issue drops and its GitHub issue closes on the
+  drop, not on a self-report. *Invariant:* hard-artifact evidence over
+  self-report.
+
+**Fuzz corpus:** vary failure-mode × frequency × agent-count × severity ×
+recency; the ranking puts the highest-impact issue first across the corpus,
+not just the happy path, and the sensor stays model-free across it.
+
+## Verdict
+
+- **Done when:** the fleet detects a recurring per-job failure from its own
+  state at zero token cost, ranks it by real impact on an operator page with
+  evidence attached, tracks identification and resolution in a GitHub issue,
+  runs its expensive reasoning only on the top issues on a budget, and closes
+  the issue on a verified count-drop — all as operator-set schedules on an
+  operator-assigned agent, crossing no invariant.
+
+## Production-readiness
+
+- *Evidence integrity:* a flagged issue must carry hard artifacts (turn ids,
+  log pointers) the operator can independently verify, not a model's
+  self-report. A "detection" that can't be checked against the fleet's own
+  logs is a guess, not a signal.
+- *Cost bounding:* the sensor that touches all 22 jobs every night is
+  model-free (zero tokens); the model spend is gated behind it and budgeted
+  to the top one or two issues by score. The mechanism can run nightly on the
+  whole fleet without the operator paying a reasoning turn per job — the same
+  gate-first discipline as `crons-use-the-model-only-when-it-earns-it`.
+- *Attribution:* the detection work runs on a named, operator-assigned owner
+  agent so every scan and deep-dive is attributable and on-leash, never a
+  self-authored loop on some arbitrary agent.
+- *Self-verification:* a fix is proven by the fleet's own numbers. The issue
+  closes when the sensor's count for it drops, so the tracker can't fill with
+  stale "fixed" issues that never actually recovered.
+- *Surface discipline:* the ranked view lives on the operator admin page, not
+  in a principal's Telegram thread and not as a parallel pinned status mirror.
+  It is operator tooling (like the fleet dashboard), so `telegram-only` and
+  `chat-is-the-single-source-of-truth` hold.
+
+---
+
+> **Implementation:** the how lives in `reference/rfcs/fleet-health.md`
+> (frontmatter `serves:` this job). That artifact churns; this Job Spec
+> outlives it.

--- a/reference/product-spec.md
+++ b/reference/product-spec.md
@@ -150,3 +150,4 @@ Each links its job spec in `jobs/`.
 - [`idempotent-update-and-restart.md`](jobs/idempotent-update-and-restart.md) — update/restart operations completing cleanly and idempotently, target ~100%
 - [`talk-to-agents-from-anywhere.md`](jobs/talk-to-agents-from-anywhere.md) — median ack latency from Telegram message to acknowledgement
 - [`act-in-my-tools-with-an-identity.md`](jobs/act-in-my-tools-with-an-identity.md) — share of external-tool actions attributable to a named agent identity
+- [`fleet-stays-healthy.md`](jobs/fleet-stays-healthy.md) — share of recurring per-job failures the fleet surfaces and tracks itself vs found by a principal complaining

--- a/reference/rfcs/fleet-health.md
+++ b/reference/rfcs/fleet-health.md
@@ -89,7 +89,7 @@ writes it in-container at `/state/fleet-health/ledger.json`, host-mounted to
       "reach": ["clerk", "marko"],           // agents exhibiting it
       "recency": "2026-07-02T21:03:00Z",     // newest occurrence
       "occurrences": [                       // hard-artifact evidence
-        { "agent": "clerk", "turn_id": "8248703757:_#12673",
+        { "agent": "clerk", "turn_id": "12345:_#12673",
           "log_pointer": "logs/clerk/gateway-supervisor.log:represent duplicate-send" }
       ],
       "gh_issue": 1841,
@@ -101,7 +101,7 @@ writes it in-container at `/state/fleet-health/ledger.json`, host-mounted to
 
 The `job_spec` id and the per-issue `turn_id` are the two **join keys**:
 `job_spec` joins a record to `reference/jobs/<slug>.md` and to its GitHub
-label; `turn_id` (origin_turn_id, e.g. `8248703757:_#12673`) joins an
+label; `turn_id` (origin_turn_id, e.g. `12345:_#12673`) joins an
 occurrence across `turns.jsonl`, the gateway log, and the transcript.
 
 ## Priority score

--- a/reference/rfcs/fleet-health.md
+++ b/reference/rfcs/fleet-health.md
@@ -1,0 +1,409 @@
+---
+artifact: Fleet Health — operator-facing, job-spec-anchored fleet issue tracking
+serves: fleet-stays-healthy
+advances-outcome: always-available
+status: Draft
+---
+
+# RFC: Fleet Health — the fleet surfaces its own recurring failures
+
+Status: Draft
+Author: Ken (CPO) via klanker pair-design
+Date: 2026-07-03
+Serves: [`fleet-stays-healthy.md`](../jobs/fleet-stays-healthy.md) → outcome `always-available`
+Kill-clause: `chat-is-the-single-source-of-truth`, `no-self-escalation`, `on-leash`, `single-tenant`
+Builds on: `see-my-whole-fleet-from-one-screen.md` (fleet dashboard), `crons-use-the-model-only-when-it-earns-it.md` (tiered crons), `agent-self-improvement.md` (evidence tiers, failure-mode taxonomy)
+
+> A ship-coupled RFC against the Job Spec. The Job Spec is the durable home
+> of the job; this is one effort against it. Solution shape, not solution.
+
+## TL;DR
+
+1. **The job:** the fleet watches itself against the 22 job specs, ranks its
+   own recurring failures by impact, and puts the worst ones in front of the
+   operator with evidence and a GitHub issue tracking the fix.
+2. **Success:** a recurring failure is detected from the fleet's own logs
+   (not a principal complaint), ranked by `severity × frequency × reach ×
+   recency`, tracked in a GitHub issue, and closed on a verified count-drop.
+3. **Biggest constraint:** the nightly sensor that touches all 22 jobs is
+   **model-free (zero tokens)**; the model spend is gated behind it and
+   budgeted to the top 1-2 issues; everything runs as operator-set schedules
+   on one operator-assigned owner agent.
+
+## The Job
+
+> **When** an agent quietly fails at one of the jobs it is supposed to do
+> (a silent no-op, a late delivery, a duplicate send, a missed trigger),
+> **the operator wants** the fleet to surface that failure ranked by impact
+> with the evidence attached, **so they can** spend their attention on the
+> worst-affecting issues instead of auditing every turn by hand.
+
+Durable home: [Job Spec](../jobs/fleet-stays-healthy.md). Serves
+`always-available`; governed by `chat-is-the-single-source-of-truth`,
+`no-self-escalation`, `on-leash`, `single-tenant`.
+
+## Validation (this is real, not hypothetical)
+
+Validated end-to-end on live fleet data the week of 2026-07:
+
+- The 4-layer funnel below detected that **clerk** and **marko** were writing
+  answers as plain text and never calling the reply tool (clerk 200/201
+  turns, marko 282/282). That tripped the gateway's `represent` safety net —
+  answers delivered 2-4 min late plus a wasted represent turn each time.
+- Root-caused by reading the transcripts (an L2 deep-dive), fixed, and the
+  represent-duplicate-send count dropped toward ~2.
+- **carrie**, a clean control, had only ~2 escalations — the sensor did not
+  false-positive on it.
+
+The failure was invisible to the operator until the sensor found it: no
+error was ever raised, the answers *did* eventually arrive. This is exactly
+the silent-failure class the job exists to catch.
+
+## The health ledger
+
+One persistent record **per job spec** (22 records). It is the standing,
+ranked state the admin page reads and the sensor updates.
+
+**Where it lives:** `~/.switchroom/fleet-health/ledger.json` — per-agent /
+per-deployment state under `~/.switchroom`, **never committed to the repo**
+(same rule as agent scaffolds and the scheduler ledger). The owner agent
+writes it in-container at `/state/fleet-health/ledger.json`, host-mounted to
+`~/.switchroom/fleet-health/`. The web container reads it read-only.
+
+**Record shape** (per job spec):
+
+```jsonc
+{
+  "job_spec": "fleet-stays-healthy",        // the jobs/<slug>.md id — join key
+  "open_issue_count": 3,                     // distinct open problems for this job
+  "last_scanned": "2026-07-03T02:00:00Z",    // last nightly sensor pass
+  "priority_score": 42.7,                    // severity × frequency × reach × recency
+  "gh_issues": [1841, 1842],                 // linked GitHub issue numbers
+  "last_deep_dive": "2026-06-30T02:14:00Z",  // last L2 Opus pass (null if never)
+  "issues": [                                // the distinct problems, with evidence
+    {
+      "dedup_key": "represent-duplicate-send:reply-tool-not-called",
+      "failure_mode": "silent-no-op",        // from the taxonomy below
+      "severity": 3,                         // 1-3
+      "frequency": 282,                      // occurrences in the scan window
+      "reach": ["clerk", "marko"],           // agents exhibiting it
+      "recency": "2026-07-02T21:03:00Z",     // newest occurrence
+      "occurrences": [                       // hard-artifact evidence
+        { "agent": "clerk", "turn_id": "8248703757:_#12673",
+          "log_pointer": "logs/clerk/gateway-supervisor.log:represent duplicate-send" }
+      ],
+      "gh_issue": 1841,
+      "status": "open"                       // open | resolved-pending-verify | closed
+    }
+  ]
+}
+```
+
+The `job_spec` id and the per-issue `turn_id` are the two **join keys**:
+`job_spec` joins a record to `reference/jobs/<slug>.md` and to its GitHub
+label; `turn_id` (origin_turn_id, e.g. `8248703757:_#12673`) joins an
+occurrence across `turns.jsonl`, the gateway log, and the transcript.
+
+## Priority score
+
+`priority_score = severity × frequency × reach × recency`. Ranking by real
+impact, not raw event count — a rare-but-severe issue must outrank a
+frequent-but-cosmetic one.
+
+- **severity** ∈ {1,2,3} — from the failure-mode taxonomy. Silent no-op /
+  constraint-violation = 3 (the fleet did the wrong thing or nothing while
+  reporting success); partial / duplicate / late-delivery = 2; drift /
+  ux-friction = 1. Assigned by the sensor from the signature that matched.
+- **frequency** — count of occurrences of this `dedup_key` in the scan
+  window (default 30 days), normalized as `log10(1 + count)` so 282 vs 20
+  is a meaningful gap but doesn't swamp the other three factors.
+- **reach** — number of distinct agents exhibiting the issue (`|reach|`). A
+  failure across the whole fleet outweighs a one-agent quirk. A single
+  systemic issue (2 agents) already ranks above a noisy one-agent issue.
+- **recency** — decay on the newest occurrence: `1.0` if within 24h,
+  linearly decaying to `0.1` at the window edge. A failure fixed a month ago
+  sinks; a fresh one floats. This is what closes the loop after a fix: as
+  occurrences stop, recency decays the score toward zero.
+
+All four are computed **from the model-free sensor's output** (below) — no
+model judgment enters the score. The web page ranks the 22 records by
+`priority_score` descending.
+
+## The 4-layer detection funnel
+
+Cheap filters gate expensive reasoning. Each layer only escalates what the
+one below flagged.
+
+### L0 — model-free sensor (nightly, zero tokens)
+
+Reads `turns.jsonl` + the gateway log per agent. **No model call, no `claude
+-p`** (claude-native + subscription-honest hold trivially — L0 spends no
+tokens at all). Emits a structured signal digest; only flagged turns
+escalate. This is the canonical sensor — inlined here so the owner agent runs
+it verbatim:
+
+```python
+#!/usr/bin/env python3
+"""Layer-0 spec-conformance detector (read-only, zero-token).
+
+Validated sources only:
+  turns.jsonl   -> per-turn status/tools/duration/turn_id  (structured oracle)
+  gateway log   -> precise failure signatures + delivery artifacts
+
+Emits a structured signal digest; only flagged turns escalate to a paid pass.
+"""
+import json, sys, subprocess
+from collections import Counter, defaultdict
+
+agent = sys.argv[1] if len(sys.argv) > 1 else "overlord"
+HANG_MS = 360_000           # tuned: >6min (data p99=303s) AND low-progress
+HANG_MAXTOOLS = 2           # long+productive = deep work; long+stalled = hang
+TURNS = f"/host-home/.switchroom/agents/{agent}/turns.jsonl"
+GW    = f"/host-home/.switchroom/logs/{agent}/gateway-supervisor.log"
+
+turns = []
+for line in open(TURNS):
+    line = line.strip()
+    if line:
+        try: turns.append(json.loads(line))
+        except: pass
+
+flags = defaultdict(list)   # failure_mode -> [evidence]
+for t in turns:
+    tid = t.get("turn_id", "?"); st = t.get("status"); tl = t.get("tools", 0)
+    dur = t.get("duration_ms", 0)
+    synthetic = "synthetic-" in tid          # gateway-injected, not a real job
+    if st not in ("complete", "no_reply"):
+        flags["killed/incomplete turn"].append(f"{tid} status={st}")
+    # tuned hang: long AND stalled (few tools) — long+productive is deep work
+    if dur > HANG_MS and tl <= HANG_MAXTOOLS:
+        flags["hang (long+stalled)"].append(f"{tid} {dur//1000}s tools={tl}")
+    # silent no-op: completed, zero tools, real (non-synthetic, non-no_reply)
+    if st == "complete" and tl == 0 and not synthetic:
+        flags["silent no-op candidate"].append(f"{tid} tools=0")
+
+def gcount(pat):
+    try:
+        out = subprocess.run(["grep", "-cE", pat, GW], capture_output=True, text=True)
+        return int(out.stdout.strip() or 0)
+    except: return 0
+
+# precise gateway signatures (precision-filtered — getUpdates blips excluded)
+sig = {
+  "duplicate delivery (represent duplicate-send)": "represent duplicate-send",
+  "represent escalation":                          "obligation escalation",
+  "reply delivery failure":                        r"tg-post method=sendRichMessage[^\n]*status=err",
+}
+gw_hits = {name: gcount(pat) for name, pat in sig.items()}
+
+esc = bool(flags.get("killed/incomplete turn") or flags.get("hang (long+stalled)")
+           or flags.get("silent no-op candidate")
+           or gw_hits["duplicate delivery (represent duplicate-send)"]
+           or gw_hits["reply delivery failure"])
+print(json.dumps({
+    "agent": agent, "turns": len(turns),
+    "status_mix": dict(Counter(t.get("status") for t in turns)),
+    "flags": {k: v for k, v in flags.items()}, "gw_hits": gw_hits,
+    "escalate": esc,
+}))
+```
+
+**Tuned constants (load-bearing — do not casually change):** `HANG_MS =
+360000` (>6 min, data p99 = 303 s), `HANG_MAXTOOLS = 2` (long+productive is
+deep work, long+stalled is a hang), exclude `synthetic-` turn ids
+(gateway-injected, not real jobs), and precise gateway signatures
+(`represent duplicate-send`, `tg-post method=sendRichMessage ... status=err`)
+so a `getUpdates` network blip never counts as a delivery failure.
+
+L0 runs nightly across **all** agents and updates the ledger counts for
+**all 22** job records cheaply. It never spends a token.
+
+### L1 — cheap reflect confirm (nightly, only on L0 hits)
+
+For each L0-flagged issue, a cheap `reflect` (Sonnet, run as an ordinary
+synthesized turn on the owner agent — never `claude -p`) confirms the signal
+is a real failure vs a benign explanation, and assigns the failure-mode
+class + severity. Confirmed issues update the ledger and get/refresh a
+GitHub issue. Idle nights (no L0 hit) never reach L1 → zero model cost.
+
+### L2 — Opus deep root-cause (weekly, BUDGETED, top 1-2 only)
+
+Weekly, the owner agent takes the **top one or two** ledger records by
+`priority_score` and runs an Opus deep-dive: read the flagged turns'
+transcripts (joined by `turn_id`), root-cause, and write the finding into the
+GitHub issue. **Budgeted** — never more than 2 deep-dives per week — so the
+expensive layer is bounded regardless of how many issues exist. This is the
+layer that read the clerk/marko transcripts and root-caused the reply-tool
+gap.
+
+### L3 — weekly synthesis
+
+A weekly `reflect` over the ledger + closed issues: what got fixed, what's
+trending, which jobs are chronically fragile. Written into the ledger's
+top-level summary and surfaced on the page header. Cheap (one reflect over a
+small ledger), not per-turn.
+
+**Self-verifying via count-drop.** After a fix, the nightly L0 sensor's count
+for the `dedup_key` falls (e.g. 282 → ~2). When it stays below a
+resolved-threshold for the verify window, the issue flips
+`resolved-pending-verify` → `closed` and its GitHub issue closes — proof from
+the fleet's own numbers, not a self-report.
+
+## GitHub issue lifecycle (the identify + resolve system-of-record)
+
+GitHub issues are where the *work* lives — both identification and
+resolution. The owner agent (via `gh`, authenticated through a vault-held
+token, `no-self-escalation`-clean):
+
+- **Opens** one issue per distinct problem, keyed by `dedup_key` (e.g.
+  `represent-duplicate-send:reply-tool-not-called`). The dedup key prevents a
+  fresh duplicate issue every night — an existing open issue for the key is
+  **updated**, not re-created.
+- **Labels** it `fleet-health`, a severity label (`severity:1|2|3`), and the
+  job-spec label (`job:fleet-stays-healthy`). The labels are what the admin
+  page and any operator `gh` query filter on.
+- **Links occurrences** into the issue body: the turn ids and log pointers
+  from the ledger's `occurrences`, so the operator can jump straight to the
+  evidence.
+- **Closes** on verified count-drop (above). The close is triggered by the
+  sensor's numbers, so the tracker can't fill with stale "fixed" issues.
+
+The ledger stores the issue **numbers**; the admin page optionally reads the
+GitHub API for live open/closed status. GitHub is the durable
+system-of-record for the work; the ledger is the fast, rankable index.
+
+## Owner agent (attribution + on-leash)
+
+A **dedicated, operator-assigned admin agent** runs the sensor + deep-dive
+crons, so every scan and deep-dive is attributable to a named agent (not an
+anonymous host cron, and not some arbitrary agent that happened to have a
+schedule slot).
+
+- **Assignment:** a top-level config field `fleet_health.owner_agent:
+  <name>` (cascade mode **override**; documented in
+  `docs/configuration.md`). Default unset → the feature is inert (no crons
+  scheduled, page renders the empty state). The named agent must be
+  `admin: true`.
+- **Why a dedicated agent, not any admin:** the detection reads every agent's
+  `turns.jsonl` + logs and opens GitHub issues on the fleet's behalf. That is
+  a distinct standing responsibility with its own memory (what's been
+  triaged, what's chronic) and its own attributable audit trail. Folding it
+  into an arbitrary admin agent muddies attribution and mixes the
+  fleet-health memory into an unrelated persona's context. One owner keeps
+  the work legible and the token spend accountable.
+- **On-leash:** the sensor and deep-dive run only as **operator-set
+  schedules** (nightly L0/L1, weekly L2/L3) on that agent — never a
+  self-authored loop. The owner agent proposes nothing autonomously; the
+  operator commits the crons and the owner assignment.
+
+## Admin page data contract
+
+A new **Fleet Health** page on the operator dashboard (`src/web/`). It reads:
+
+- **The ledger** (`~/.switchroom/fleet-health/ledger.json`) — the 22 records,
+  ranked by `priority_score`. This is the primary, always-available source.
+- **Optionally the GitHub API** — live open/closed status per linked issue
+  number, when a token is available; degrades to the ledger's own `status`
+  when not.
+
+It shows:
+
+- The 22 job specs **ranked worst-first** by `priority_score`, each row:
+  score, open-issue count, severity of the worst open issue, frequency/trend,
+  last-scanned, last-deep-dive.
+- **Per-spec drill-down** to its distinct issues: count, frequency/trend,
+  severity, failure-mode class.
+- **Per-issue** links: to occurrences (turn ids + log pointers) and to the
+  GitHub issue.
+
+It is an **operator surface** — same posture as the fleet dashboard
+(`see-my-whole-fleet-from-one-screen`): authenticated, single-tenant, never a
+principal channel, and it renders no parallel status mirror into a Telegram
+thread. `telegram-only` and `chat-is-the-single-source-of-truth` hold.
+
+## Evidence tiers + failure-mode taxonomy (the sensor's classification)
+
+**Evidence tiers** (highest trust first) — an issue's confidence is capped by
+its best evidence:
+
+1. **Hard artifact** — a structured record in `turns.jsonl` or a precise
+   gateway log signature. What L0 emits. Independently verifiable.
+2. **Process trace** — a transcript read (L2 deep-dive) showing the causal
+   path. Verifiable but interpretive.
+3. **Self-report** — a model's assertion with no backing artifact. Lowest
+   trust; never sufficient to open a severity-3 issue on its own.
+
+The count-drop close is a **hard-artifact** verification — never a
+self-report.
+
+**Failure-mode taxonomy** — the classes the sensor + L1 assign, which drive
+severity:
+
+- **silent no-op** — completed, zero tools, real turn (reported success,
+  did nothing). severity 3.
+- **success theater** — reported done but the artifact/effect is absent.
+  severity 3.
+- **partial** — did some of the job, silently dropped the rest. severity 2.
+- **wrong-but-plausible** — produced a confident, incorrect result.
+  severity 3.
+- **missed trigger** — a schedule/reaction/inbound that should have woken the
+  agent didn't. severity 2.
+- **constraint violation** — crossed a stated boundary (e.g. an off-plan
+  callsite, an ungated action). severity 3.
+- **duplicate** — the same effect delivered twice (the represent
+  duplicate-send). severity 2.
+- **drift** — behaviour slowly diverging from spec over time. severity 1.
+- **spec-side failure** — the job spec itself is wrong/stale and the agent is
+  correctly following a bad contract. severity 2; routes to a spec edit, not
+  an agent fix.
+
+## Bets & Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| L2 Opus runs too often → cost tax | Med | High | L0/L1 model-free gate; L2 budgeted to top 1-2/week |
+| Duplicate GitHub issues every night | Med | Med | `dedup_key` — update existing issue, never re-create |
+| Ranking buries a severe-rare issue | Med | High | severity × reach factors, not raw count; fuzz corpus |
+| Stale "fixed" issues pile up | Low | Med | close on verified count-drop, not self-report |
+| Owner agent becomes a self-authored loop | Low | High | operator-set schedules only; owner assignment operator-committed |
+
+## Rollout
+
+**Opt-in, off by default.** No `fleet_health.owner_agent` → inert (no crons,
+empty page). The operator assigns the owner and commits the L0/L1 (nightly)
+and L2/L3 (weekly) schedules. Conservatism comes from the model-free gate and
+the deep-dive budget, not a staged audience.
+
+**This RFC's slice:** the job spec, this design, and a working+tested admin
+**page skeleton** that renders the ledger (typed reader + clearly-marked
+empty state). The owner-agent crons + the GitHub write path are the operator's
+to wire on the assigned agent — specified here, not code in this PR.
+
+## Verdict
+
+Per `reference/vision.md`'s verdict rule, this ships when it:
+
+- **Advances a vision outcome** — `always-available` (a fleet that stays *up
+  and correct*, not just alive).
+- **Satisfies the new job spec** — [`fleet-stays-healthy.md`](../jobs/fleet-stays-healthy.md),
+  proven by its detect/rank/close UATs.
+- **Passes the three principle checks** — *docs:* the page + CLI explain
+  themselves, no `docs/` required; *defaults:* inert until the operator
+  assigns an owner (opt-in complexity); *consistency:* same operator-page
+  shape as the fleet dashboard, same config cascade, same tiered-cron model.
+- **Crosses no invariant** — `chat-is-the-single-source-of-truth` (operator
+  surface, no parallel mirror), `no-self-escalation` (operator-committed owner
+  + schedules), `on-leash` (no self-authored loop), `single-tenant` (reads
+  this one deployment), `claude-native` (L0 model-free; L1-L3 are ordinary
+  synthesized turns, never `claude -p`).
+
+## Related
+
+- [Job Spec](../jobs/fleet-stays-healthy.md)
+- [`see-my-whole-fleet-from-one-screen.md`](../jobs/see-my-whole-fleet-from-one-screen.md) — the sibling operator fleet view
+- [`crons-use-the-model-only-when-it-earns-it.md`](../jobs/crons-use-the-model-only-when-it-earns-it.md) — the tiered-cron discipline the funnel follows
+- [`agent-self-improvement.md`](./agent-self-improvement.md) — the evidence tiers + failure-mode taxonomy origin (agent-facing sibling)
+- [product-spec.md](../product-spec.md) — outcome `always-available`
+- [principles.md](../principles.md), [invariants.md](../invariants.md)
+
+**Last Updated:** 2026-07-03

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3136,6 +3136,34 @@ export const WebServiceConfigSchema = z.object({
 });
 
 /**
+ * Fleet Health — the operator-facing, job-spec-anchored issue tracker
+ * (`reference/rfcs/fleet-health.md`; serves `fleet-stays-healthy`). The
+ * owner agent runs the nightly model-free sensor + weekly budgeted deep-dive
+ * that populate `~/.switchroom/fleet-health/ledger.json`, which the admin
+ * "Fleet Health" page reads. Top-level + operator-owned (never
+ * agent-writable): the operator assigns WHICH agent owns the work so every
+ * scan and deep-dive is attributable and on-leash.
+ */
+export const FleetHealthConfigSchema = z.object({
+  owner_agent: z
+    .string()
+    .regex(/^[a-z0-9][a-z0-9_-]{0,50}$/, {
+      message: "owner_agent must match the standard agent-name pattern",
+    })
+    .optional()
+    .describe(
+      "The admin agent that runs the Fleet Health sensor + deep-dive crons " +
+      "(RFC fleet-health.md). Default unset → the feature is inert: no crons " +
+      "are scheduled and the admin page renders its empty state. The named " +
+      "agent must be admin: true. A dedicated owner (not any admin) keeps " +
+      "the fleet-health work attributable, its memory scoped, and its token " +
+      "spend accountable. The detection runs ONLY as operator-set schedules " +
+      "on this agent — never a self-authored loop (on-leash, " +
+      "no-self-escalation).",
+    ),
+});
+
+/**
  * hostd verb-level knobs (separate from `host_control:` which gates
  * the daemon itself).
  *
@@ -3421,6 +3449,12 @@ export const SwitchroomConfigSchema = z.object({
     "from `host_control:` which governs whether the daemon runs at " +
     "all. Scopes the opt-in flag and rate cap for the " +
     "`config_propose_edit` verb (disabled by default).",
+  ),
+  fleet_health: FleetHealthConfigSchema.default({}).describe(
+    "Fleet Health — job-spec-anchored, operator-facing issue tracker (RFC " +
+    "fleet-health.md, serves fleet-stays-healthy). Assigns the owner agent " +
+    "that runs the nightly model-free sensor + weekly deep-dive. Default " +
+    "unset owner_agent → inert; the admin page renders an empty state.",
   ),
   web_service: WebServiceConfigSchema.default({}).describe(
     "Web-service container (dashboard + GitHub-webhook receiver) config. " +

--- a/src/web/fleet-health-read.ts
+++ b/src/web/fleet-health-read.ts
@@ -24,7 +24,7 @@ import { homedir } from "node:os";
  *  verify. `failure_mode` is from the RFC's taxonomy; `severity` 1-3. */
 export interface FleetHealthOccurrence {
   agent: string;
-  /** origin_turn_id, e.g. `8248703757:_#12673` — the join key across
+  /** origin_turn_id, e.g. `12345:_#12673` — the join key across
    *  turns.jsonl, the gateway log, and the transcript. */
   turn_id: string;
   /** A pointer into the gateway/turns log the operator can grep. */

--- a/src/web/fleet-health-read.ts
+++ b/src/web/fleet-health-read.ts
@@ -147,10 +147,17 @@ export function readFleetHealth(path: string): FleetHealthDashboard {
     };
   }
 
-  const records = Array.isArray(ledger.records) ? ledger.records : [];
-  // Rank worst-first. `??` guards a malformed record missing the score.
+  const rawRecords = Array.isArray(ledger.records) ? ledger.records : [];
+  // Normalize `priority_score` to a finite number so a malformed ledger
+  // (missing / string / NaN / Infinity score) never emits a non-number,
+  // which would crash the render side.
+  const records = rawRecords.map((r) => {
+    const n = Number(r?.priority_score);
+    return { ...r, priority_score: Number.isFinite(n) ? n : 0 };
+  });
+  // Rank worst-first.
   const ranked = [...records].sort(
-    (a, b) => (b.priority_score ?? 0) - (a.priority_score ?? 0),
+    (a, b) => b.priority_score - a.priority_score,
   );
 
   return {

--- a/src/web/fleet-health-read.ts
+++ b/src/web/fleet-health-read.ts
@@ -1,0 +1,176 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+
+/**
+ * Fleet Health — the operator-facing, job-spec-anchored issue tracker.
+ *
+ * Design: `reference/rfcs/fleet-health.md`; serves the job spec
+ * `reference/jobs/fleet-stays-healthy.md` (outcome `always-available`).
+ *
+ * This module is the typed, read-only reader over the health ledger. The
+ * ledger is per-deployment state written by the operator-assigned owner
+ * agent's nightly model-free sensor; it lives OUTSIDE the repo at
+ * `~/.switchroom/fleet-health/ledger.json` (never committed — same rule as
+ * agent scaffolds and the scheduler ledger). The web container mounts it
+ * read-only. Everything here degrades to a clearly-marked empty state when
+ * the ledger is absent (feature inert — no owner agent assigned yet) or
+ * unreadable, so the page always renders and is testable without a live
+ * pipeline.
+ */
+
+/** One distinct problem detected against a job spec, with hard-artifact
+ *  evidence (turn ids + log pointers) the operator can independently
+ *  verify. `failure_mode` is from the RFC's taxonomy; `severity` 1-3. */
+export interface FleetHealthOccurrence {
+  agent: string;
+  /** origin_turn_id, e.g. `8248703757:_#12673` — the join key across
+   *  turns.jsonl, the gateway log, and the transcript. */
+  turn_id: string;
+  /** A pointer into the gateway/turns log the operator can grep. */
+  log_pointer?: string;
+}
+
+export type FleetHealthFailureMode =
+  | "silent-no-op"
+  | "success-theater"
+  | "partial"
+  | "wrong-but-plausible"
+  | "missed-trigger"
+  | "constraint-violation"
+  | "duplicate"
+  | "drift"
+  | "spec-side-failure";
+
+export type FleetHealthIssueStatus =
+  | "open"
+  | "resolved-pending-verify"
+  | "closed";
+
+export interface FleetHealthIssue {
+  /** Stable de-dup key — one GitHub issue per key, updated not re-created. */
+  dedup_key: string;
+  failure_mode: FleetHealthFailureMode;
+  /** 1-3 (3 = did the wrong thing / nothing while reporting success). */
+  severity: number;
+  /** Occurrences of this dedup_key in the scan window. */
+  frequency: number;
+  /** Distinct agents exhibiting the issue. */
+  reach: string[];
+  /** ISO timestamp of the newest occurrence. */
+  recency: string | null;
+  /** Hard-artifact evidence links. */
+  occurrences: FleetHealthOccurrence[];
+  /** Linked GitHub issue number (identify + resolve system-of-record). */
+  gh_issue?: number;
+  status: FleetHealthIssueStatus;
+}
+
+/** One persistent record per job spec (22 of them). */
+export interface FleetHealthRecord {
+  /** The `reference/jobs/<slug>.md` id — join key to the spec + GH label. */
+  job_spec: string;
+  open_issue_count: number;
+  /** ISO timestamp of the last nightly sensor pass. */
+  last_scanned: string | null;
+  /** severity × frequency × reach × recency (see RFC). Higher = worse. */
+  priority_score: number;
+  /** Linked GitHub issue numbers for this job. */
+  gh_issues: number[];
+  /** ISO timestamp of the last L2 Opus deep-dive (null if never). */
+  last_deep_dive: string | null;
+  /** The distinct problems, each with its evidence. */
+  issues: FleetHealthIssue[];
+}
+
+/** On-disk ledger shape (`~/.switchroom/fleet-health/ledger.json`). */
+export interface FleetHealthLedger {
+  /** Owner agent that runs the sensor + deep-dive crons (attribution). */
+  owner_agent?: string;
+  /** ISO timestamp of the most recent sensor pass across the fleet. */
+  generated_at?: string;
+  /** L3 weekly-synthesis summary rendered in the page header. */
+  summary?: string;
+  records: FleetHealthRecord[];
+}
+
+/** The dashboard payload the Fleet Health page consumes. Records are
+ *  ranked worst-first by `priority_score`. `empty` marks the inert state
+ *  (no ledger yet — no owner agent assigned) so the UI can render a clear
+ *  "not wired up" panel rather than a blank table. */
+export interface FleetHealthDashboard {
+  owner_agent: string | null;
+  generated_at: string | null;
+  summary: string | null;
+  records: FleetHealthRecord[];
+  empty: boolean;
+  /** Present only in the empty/degraded state — tells the operator why. */
+  reason?: string;
+}
+
+/**
+ * Resolve the ledger path. `~/.switchroom/fleet-health/ledger.json` by
+ * default; the `home` arg (or `SWITCHROOM_HOME` / `HOME`) is injectable so
+ * tests point at a tmpdir and never touch the operator's live tree.
+ */
+export function fleetHealthLedgerPath(
+  home: string = process.env.SWITCHROOM_HOME ?? process.env.HOME ?? homedir(),
+): string {
+  return resolve(home, ".switchroom", "fleet-health", "ledger.json");
+}
+
+const EMPTY_REASON =
+  "Fleet Health is not wired up yet — no ledger at " +
+  "~/.switchroom/fleet-health/ledger.json. Assign an owner agent " +
+  "(`fleet_health.owner_agent` in switchroom.yaml) and schedule its " +
+  "nightly sensor cron. See reference/rfcs/fleet-health.md.";
+
+/**
+ * Read the ledger from `path` and produce the dashboard payload, records
+ * ranked worst-first by `priority_score`. Missing / unreadable / malformed
+ * ledger → a clearly-marked empty state (never a throw), so the page always
+ * renders. Exported for direct unit coverage (mirrors readContextOccupancy /
+ * agentBridgeAlive: degrade-to-safe, no exceptions escape).
+ */
+export function readFleetHealth(path: string): FleetHealthDashboard {
+  let ledger: FleetHealthLedger;
+  try {
+    ledger = JSON.parse(readFileSync(path, "utf-8")) as FleetHealthLedger;
+  } catch {
+    return {
+      owner_agent: null,
+      generated_at: null,
+      summary: null,
+      records: [],
+      empty: true,
+      reason: EMPTY_REASON,
+    };
+  }
+
+  const records = Array.isArray(ledger.records) ? ledger.records : [];
+  // Rank worst-first. `??` guards a malformed record missing the score.
+  const ranked = [...records].sort(
+    (a, b) => (b.priority_score ?? 0) - (a.priority_score ?? 0),
+  );
+
+  return {
+    owner_agent: ledger.owner_agent ?? null,
+    generated_at: ledger.generated_at ?? null,
+    summary: ledger.summary ?? null,
+    records: ranked,
+    empty: ranked.length === 0,
+    ...(ranked.length === 0 ? { reason: EMPTY_REASON } : {}),
+  };
+}
+
+/**
+ * Dashboard handler — resolves the default ledger path and reads it. `path`
+ * is injectable for tests. Read-only: no model call, no host mutation, no
+ * network (the optional GitHub-status enrichment is layered on the client
+ * side per the RFC, off this always-available local read).
+ */
+export function handleGetFleetHealth(
+  path: string = fleetHealthLedgerPath(),
+): FleetHealthDashboard {
+  return readFleetHealth(path);
+}

--- a/src/web/fleet-health.test.ts
+++ b/src/web/fleet-health.test.ts
@@ -141,6 +141,33 @@ describe("readFleetHealth (job-spec-anchored issue tracker)", () => {
     expect(dash.records).toEqual([]);
   });
 
+  it("normalizes a missing / non-number priority_score to 0", () => {
+    writeLedger({
+      owner_agent: "klanker",
+      records: [
+        // missing priority_score entirely
+        { job_spec: "no-score", open_issue_count: 0, issues: [] },
+        // non-number priority_score (malformed ledger)
+        {
+          job_spec: "bad-score",
+          open_issue_count: 0,
+          priority_score: "oops",
+          issues: [],
+        },
+        { job_spec: "good-score", open_issue_count: 0, priority_score: 5, issues: [] },
+      ],
+    } as unknown as FleetHealthLedger);
+    const dash = readFleetHealth(ledgerPath);
+    expect(dash.empty).toBe(false);
+    // every record now carries a finite number score (never undefined/NaN/string)
+    for (const r of dash.records) {
+      expect(typeof r.priority_score).toBe("number");
+      expect(Number.isFinite(r.priority_score)).toBe(true);
+    }
+    // the real score still ranks first; normalized-to-0 records follow
+    expect(dash.records[0].job_spec).toBe("good-score");
+  });
+
   it("resolves the default ledger path under ~/.switchroom/fleet-health", () => {
     const home = mkdtempSync(join(tmpdir(), "sr-home-"));
     mkdirSync(join(home, ".switchroom", "fleet-health"), { recursive: true });

--- a/src/web/fleet-health.test.ts
+++ b/src/web/fleet-health.test.ts
@@ -78,7 +78,7 @@ describe("readFleetHealth (job-spec-anchored issue tracker)", () => {
             occurrences: [
               {
                 agent: "clerk",
-                turn_id: "8248703757:_#12673",
+                turn_id: "12345:_#12673",
                 log_pointer: "logs/clerk/gateway-supervisor.log:represent duplicate-send",
               },
             ],
@@ -113,7 +113,7 @@ describe("readFleetHealth (job-spec-anchored issue tracker)", () => {
     const dash = readFleetHealth(ledgerPath);
     const rec = dash.records.find((r) => r.job_spec === "fleet-stays-healthy");
     const occ = rec?.issues[0].occurrences[0];
-    expect(occ?.turn_id).toBe("8248703757:_#12673");
+    expect(occ?.turn_id).toBe("12345:_#12673");
     expect(occ?.log_pointer).toContain("represent duplicate-send");
     expect(rec?.issues[0].gh_issue).toBe(1841);
   });

--- a/src/web/fleet-health.test.ts
+++ b/src/web/fleet-health.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readFleetHealth,
+  fleetHealthLedgerPath,
+  type FleetHealthLedger,
+} from "./fleet-health-read.js";
+
+/**
+ * The Fleet Health page reads the owner agent's health ledger
+ * (`~/.switchroom/fleet-health/ledger.json`), ranks the job records
+ * worst-first by priority_score, and degrades to a clearly-marked empty
+ * state when the ledger is absent (no owner agent assigned yet) or
+ * unreadable — so the page always renders and is testable without a live
+ * pipeline. These pin that reader.
+ */
+describe("readFleetHealth (job-spec-anchored issue tracker)", () => {
+  let dir: string;
+  let ledgerPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sr-fleet-health-"));
+    ledgerPath = join(dir, "ledger.json");
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeLedger(ledger: FleetHealthLedger): void {
+    writeFileSync(ledgerPath, JSON.stringify(ledger));
+  }
+
+  const sampleLedger: FleetHealthLedger = {
+    owner_agent: "klanker",
+    generated_at: "2026-07-03T02:00:00Z",
+    summary: "1 severe issue open across 2 agents.",
+    records: [
+      {
+        job_spec: "feel-like-a-colleague",
+        open_issue_count: 1,
+        last_scanned: "2026-07-03T02:00:00Z",
+        priority_score: 12.5,
+        gh_issues: [1840],
+        last_deep_dive: null,
+        issues: [
+          {
+            dedup_key: "drift:padded-replies",
+            failure_mode: "drift",
+            severity: 1,
+            frequency: 20,
+            reach: ["clerk"],
+            recency: "2026-07-01T10:00:00Z",
+            occurrences: [
+              { agent: "clerk", turn_id: "111:_#1", log_pointer: "logs/clerk/gw.log:pad" },
+            ],
+            gh_issue: 1840,
+            status: "open",
+          },
+        ],
+      },
+      {
+        job_spec: "fleet-stays-healthy",
+        open_issue_count: 1,
+        last_scanned: "2026-07-03T02:00:00Z",
+        priority_score: 42.7,
+        gh_issues: [1841],
+        last_deep_dive: "2026-06-30T02:14:00Z",
+        issues: [
+          {
+            dedup_key: "duplicate:represent-duplicate-send",
+            failure_mode: "duplicate",
+            severity: 2,
+            frequency: 282,
+            reach: ["clerk", "marko"],
+            recency: "2026-07-02T21:03:00Z",
+            occurrences: [
+              {
+                agent: "clerk",
+                turn_id: "8248703757:_#12673",
+                log_pointer: "logs/clerk/gateway-supervisor.log:represent duplicate-send",
+              },
+            ],
+            gh_issue: 1841,
+            status: "open",
+          },
+        ],
+      },
+    ],
+  };
+
+  it("ranks records worst-first by priority_score", () => {
+    writeLedger(sampleLedger);
+    const dash = readFleetHealth(ledgerPath);
+    expect(dash.empty).toBe(false);
+    expect(dash.records.map((r) => r.job_spec)).toEqual([
+      "fleet-stays-healthy", // 42.7 — worst first
+      "feel-like-a-colleague", // 12.5
+    ]);
+  });
+
+  it("surfaces owner_agent, generated_at, and the L3 summary", () => {
+    writeLedger(sampleLedger);
+    const dash = readFleetHealth(ledgerPath);
+    expect(dash.owner_agent).toBe("klanker");
+    expect(dash.generated_at).toBe("2026-07-03T02:00:00Z");
+    expect(dash.summary).toContain("severe issue open");
+  });
+
+  it("preserves hard-artifact evidence (turn_id + log pointer) per issue", () => {
+    writeLedger(sampleLedger);
+    const dash = readFleetHealth(ledgerPath);
+    const rec = dash.records.find((r) => r.job_spec === "fleet-stays-healthy");
+    const occ = rec?.issues[0].occurrences[0];
+    expect(occ?.turn_id).toBe("8248703757:_#12673");
+    expect(occ?.log_pointer).toContain("represent duplicate-send");
+    expect(rec?.issues[0].gh_issue).toBe(1841);
+  });
+
+  it("degrades to a clearly-marked empty state when the ledger is missing", () => {
+    // no file written — feature inert (no owner agent assigned yet)
+    const dash = readFleetHealth(ledgerPath);
+    expect(dash.empty).toBe(true);
+    expect(dash.records).toEqual([]);
+    expect(dash.owner_agent).toBeNull();
+    expect(dash.reason).toContain("not wired up");
+  });
+
+  it("degrades to empty (never throws) on malformed JSON", () => {
+    writeFileSync(ledgerPath, "{ not json");
+    const dash = readFleetHealth(ledgerPath);
+    expect(dash.empty).toBe(true);
+    expect(dash.reason).toBeDefined();
+  });
+
+  it("degrades to empty when the records array is absent", () => {
+    writeLedger({ owner_agent: "klanker" } as FleetHealthLedger);
+    const dash = readFleetHealth(ledgerPath);
+    expect(dash.empty).toBe(true);
+    expect(dash.records).toEqual([]);
+  });
+
+  it("resolves the default ledger path under ~/.switchroom/fleet-health", () => {
+    const home = mkdtempSync(join(tmpdir(), "sr-home-"));
+    mkdirSync(join(home, ".switchroom", "fleet-health"), { recursive: true });
+    expect(fleetHealthLedgerPath(home)).toBe(
+      join(home, ".switchroom", "fleet-health", "ledger.json"),
+    );
+    rmSync(home, { recursive: true, force: true });
+  });
+});

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -56,6 +56,7 @@ import {
   type AccountDashboardInfo,
 } from "./api.js";
 import type { CachedResult } from "./cache.js";
+import { handleGetFleetHealth } from "./fleet-health-read.js";
 import { fetchAgentLogsViaHostd } from "./hostd-read-client.js";
 import { handleWebhookIngest } from "./webhook-handler.js";
 import { loadEdgeSecret } from "./webhook-edge.js";
@@ -100,6 +101,7 @@ const SPA_TAB_ROUTES = new Set([
   "connections",
   "schedule",
   "approvals",
+  "fleet-health",
 ]);
 
 /**
@@ -590,6 +592,14 @@ function parseRoute(
     return { handler: "getApprovals", params: {} };
   }
 
+  // GET /api/fleet-health — job-spec-anchored issue tracker (RFC
+  // fleet-health.md). Reads the owner agent's health ledger, ranked
+  // worst-first by priority_score. Read-only; degrades to an empty state
+  // when no owner agent is assigned yet.
+  if (method === "GET" && pathname === "/api/fleet-health") {
+    return { handler: "getFleetHealth", params: {} };
+  }
+
   // GET /api/grants — standing capability grants from the vault-broker
   // grants DB (the operator's REAL grants; the kernel decision ledger
   // above is honestly empty on most installs).
@@ -952,6 +962,12 @@ export function startWebServer(
           case "getApprovals":
             return (async () =>
               jsonResponse(withStamp(await cachedApprovals())))();
+
+          case "getFleetHealth":
+            // Local, always-available read of the health ledger. Not routed
+            // through dashboardCache: it's a single small JSON file read,
+            // not a host round-trip, so a per-tick re-read is cheap.
+            return jsonResponse(handleGetFleetHealth());
 
           case "getGrants":
             return (async () =>

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -570,6 +570,7 @@
     <button id="tab-connections" onclick="switchTab('connections')">Connections</button>
     <button id="tab-schedule" onclick="switchTab('schedule')">Schedule</button>
     <button id="tab-approvals" onclick="switchTab('approvals')">Approvals</button>
+    <button id="tab-fleet-health" onclick="switchTab('fleet-health')">Fleet Health</button>
   </nav>
   <main>
     <div id="error"></div>
@@ -581,6 +582,7 @@
     <div id="connections" style="display:none"></div>
     <div id="schedule" style="display:none"></div>
     <div id="approvals" style="display:none"></div>
+    <div id="fleet-health" style="display:none"></div>
   </main>
 
   <script>
@@ -1257,10 +1259,77 @@
       }
     }
 
+    async function fetchFleetHealth() {
+      try {
+        const res = await fetch(`${API}/api/fleet-health`, { headers: authHeaders() });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        renderFleetHealth(await res.json());
+        clearError();
+      } catch (err) {
+        showError(`Failed to fetch fleet health: ${err.message}`);
+      }
+    }
+
+    // Fleet Health — the 22 job specs ranked worst-first by priority_score
+    // (severity × frequency × reach × recency). Each spec drills down to its
+    // distinct issues; each issue links to its occurrences (turn_ids + log
+    // pointers) and its GitHub issue. Empty state when no owner agent is
+    // assigned yet (feature inert). Design: reference/rfcs/fleet-health.md.
+    function renderFleetHealth(data) {
+      const container = document.getElementById('fleet-health');
+      const dim = (s) => `<span style="color:var(--text-dim)">${escapeHtml(s)}</span>`;
+      const heading = '<h3 style="margin:0 0 0.5rem;font-size:0.95rem">Fleet Health</h3>';
+      if (!data || data.empty) {
+        container.innerHTML = heading +
+          `<div class="loading" style="color:var(--text-dim)">${escapeHtml((data && data.reason) || 'No fleet-health ledger yet.')}</div>`;
+        return;
+      }
+      const meta = [
+        data.owner_agent ? `owner <span class="chip">${escapeHtml(data.owner_agent)}</span>` : dim('no owner agent'),
+        data.generated_at ? `scanned ${escapeHtml(data.generated_at)}` : dim('never scanned'),
+      ].join(' · ');
+      const summary = data.summary
+        ? `<div class="problem" style="margin:.4rem 0">${escapeHtml(data.summary)}</div>` : '';
+      const ghLink = (n) => n != null
+        ? `<a href="https://github.com/switchroom/switchroom/issues/${encodeURIComponent(n)}" target="_blank" rel="noreferrer">#${escapeHtml(String(n))}</a>`
+        : dim('no issue');
+      const issueRows = (issues) => (issues || []).map(i => {
+        const occ = (i.occurrences || []).map(o =>
+          `<span class="chip" title="${escapeHtml(o.log_pointer || '')}">${escapeHtml(o.turn_id)}</span>`).join(' ') || dim('—');
+        return `<tr>
+          <td>${escapeHtml(i.failure_mode || '—')}</td>
+          <td>sev ${escapeHtml(String(i.severity ?? '—'))}</td>
+          <td>${escapeHtml(String(i.frequency ?? 0))}×</td>
+          <td>${escapeHtml((i.reach || []).join(', ') || '—')}</td>
+          <td>${escapeHtml(i.recency || '—')}</td>
+          <td>${occ}</td>
+          <td>${ghLink(i.gh_issue)}</td>
+        </tr>`;
+      }).join('');
+      const specRows = (data.records || []).map(r => `
+        <tr>
+          <td><strong>${escapeHtml(r.job_spec)}</strong></td>
+          <td>${escapeHtml((r.priority_score ?? 0).toFixed ? r.priority_score.toFixed(1) : String(r.priority_score))}</td>
+          <td>${escapeHtml(String(r.open_issue_count ?? 0))}</td>
+          <td>${escapeHtml(r.last_scanned || '—')}</td>
+          <td>${escapeHtml(r.last_deep_dive || '—')}</td>
+        </tr>
+        ${(r.issues && r.issues.length) ? `<tr><td colspan="5" style="padding:0">
+          <table style="width:100%"><thead><tr>
+            <th>mode</th><th>severity</th><th>freq</th><th>reach</th><th>recency</th><th>occurrences</th><th>github</th>
+          </tr></thead><tbody>${issueRows(r.issues)}</tbody></table>
+        </td></tr>` : ''}`).join('');
+      container.innerHTML = heading +
+        `<div style="margin-bottom:.5rem">${meta}</div>` + summary +
+        `<table style="width:100%"><thead><tr>
+          <th>job spec</th><th>priority</th><th>open issues</th><th>last scanned</th><th>last deep-dive</th>
+        </tr></thead><tbody>${specRows}</tbody></table>`;
+    }
+
     // Canonical tab list — kept in sync with the nav buttons above and with
     // SPA_TAB_ROUTES in src/web/server.ts (the server serves the SPA shell for
     // these paths so a reload/deep-link doesn't 404).
-    const TAB_NAMES = ['summary', 'agents', 'accounts', 'system', 'memory', 'connections', 'schedule', 'approvals'];
+    const TAB_NAMES = ['summary', 'agents', 'accounts', 'system', 'memory', 'connections', 'schedule', 'approvals', 'fleet-health'];
 
     // Derive the active tab from the URL path (`/connections` → 'connections',
     // '/' → 'summary'). Unknown paths fall back to summary.
@@ -1291,6 +1360,7 @@
       if (tab === 'connections') fetchConnections();
       if (tab === 'schedule') fetchSchedule();
       if (tab === 'approvals') fetchApprovals();
+      if (tab === 'fleet-health') fetchFleetHealth();
     }
 
     // Back/forward: restore the tab from the history entry (or the path).

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -1309,7 +1309,7 @@
       const specRows = (data.records || []).map(r => `
         <tr>
           <td><strong>${escapeHtml(r.job_spec)}</strong></td>
-          <td>${escapeHtml((r.priority_score ?? 0).toFixed ? r.priority_score.toFixed(1) : String(r.priority_score))}</td>
+          <td>${escapeHtml(typeof r.priority_score === "number" ? r.priority_score.toFixed(1) : '—')}</td>
           <td>${escapeHtml(String(r.open_issue_count ?? 0))}</td>
           <td>${escapeHtml(r.last_scanned || '—')}</td>
           <td>${escapeHtml(r.last_deep_dive || '—')}</td>


### PR DESCRIPTION
## What / why

A standing fleet fails **silently**. An agent writes answers as plain text and never calls the reply tool; the gateway's `represent` safety net delivers them 2-4 min late for weeks and no one notices (validated this week on live data: **clerk 200/201**, **marko 282/282** turns; **carrie** a clean control at ~2). The operator's only options today are to hand-audit every turn (impossible at fleet scale) or wait for a principal to complain.

**Fleet Health** makes the fleet watch itself against the 22 job specs, rank its own recurring failures by real impact, and surface the worst ones to the operator with evidence attached and a GitHub issue tracking the fix.

## The four deliverables

1. **Job spec** — `reference/jobs/fleet-stays-healthy.md` (operator-facing; distinct from the agent-facing `get-better-the-longer-they-run.md`). Registered in the `product-spec.md` job index under `always-available`.
2. **RFC** — `reference/rfcs/fleet-health.md`. Health ledger (one record/spec, 22 total, at `~/.switchroom/fleet-health/ledger.json` — per-deployment state, never committed); `priority_score = severity × frequency × reach × recency`; the 4-layer funnel with the **model-free L0 sensor inlined verbatim** (tuned constants: `HANG_MS=360000`, `HANG_MAXTOOLS=2`, `synthetic-` exclusion, precise gateway signatures); GH-issue lifecycle (dedup-keyed open/update/close-on-verified-count-drop) as the identify+resolve system-of-record; the operator-assigned owner agent (`fleet_health.owner_agent`) for attribution; admin-page data contract; evidence tiers + failure-mode taxonomy.
3. **Admin web page** — a new **Fleet Health** tab in `src/web/`: typed read-only ledger reader (`fleet-health-read.ts`), `/api/fleet-health` route, SPA tab + render (ranked worst-first, per-spec drill-down, per-issue occurrence + GitHub links), and a vitest test (`fleet-health.test.ts`, 7 cases, all green). Degrades to a clearly-marked empty state when no owner agent is assigned yet, so it renders + tests without a live pipeline.
4. **Owner-agent crons** — specified in the RFC (nightly model-free L0/L1, weekly budgeted L2/L3); operator-wired on the assigned agent, not code in this PR (scope kept tight).

Config: `fleet_health.owner_agent` added to `src/config/schema.ts` (top-level override) and documented in `docs/configuration.md`.

## Verdict-rule checklist (reference/vision.md)

- **Advances an outcome** — `always-available` (a fleet that stays *correct*, not just alive).
- **Satisfies the job spec** — `fleet-stays-healthy` (detect / rank / close).
- **Passes the three principle checks** — docs (page + CLI self-explain), defaults (inert until an owner is assigned — opt-in complexity), consistency (same operator-page shape as the fleet dashboard, same config cascade, same tiered-cron model).
- **Crosses no invariant** — `chat-is-the-single-source-of-truth` (operator surface, no parallel mirror), `no-self-escalation` + `on-leash` (operator-committed owner + schedules, no self-authored loop), `single-tenant` (reads this one deployment), `claude-native` (L0 model-free; L1-L3 are ordinary synthesized turns, never `claude -p`). The `check-web-subscription-honest` lint guard passes.

## Test plan

- [x] `npm run lint` (tsc + all guards) — clean, incl. `check-web-subscription-honest`
- [x] `npm run build` — clean
- [x] `src/web/fleet-health.test.ts` — 7/7 pass; full `src/web` + `src/config` slices — 535/535 pass
- [ ] **CI must gate merge** — the 10 required GHA checks are the source of truth; do not merge until green.

Note: some local `tests/` failures (install/scaffold/host-control/vault-broker) are environmental to the sandbox (root uid → pip EACCES, no vault passphrase, host-path spawns) and are unrelated to this change — they pass in CI's proper environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)