### PR TITLE
feat(fleet-health): live detection pipeline — model-free sensor, priority ledger, GH-issue lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## v0.16.42 — Fleet Health: operator-facing fleet issue tracker + admin page
+
+Ships the first slice of Fleet Health (RFC `reference/rfcs/fleet-health.md`,
+serving `reference/jobs/fleet-stays-healthy.md`, outcome `always-available`):
+the job-spec-anchored issue tracker's read side. A new admin **Fleet Health**
+page renders the health ledger (`~/.switchroom/fleet-health/ledger.json`) —
+the 22 job records ranked worst-first by `priority_score` — degrading to a
+clearly-marked empty state when no owner agent is assigned. Adds the typed
+read-only ledger reader (`src/web/fleet-health-read.ts`) and the top-level
+`fleet_health.owner_agent` config field (override cascade; the admin agent
+that will run the detection crons). Feature is inert until an owner is
+assigned.
+
+## unreleased — Fleet Health live detection pipeline (model-free sensor, priority ledger, GH-issue lifecycle)
+
+The machinery that populates the ledger the admin page reads (RFC
+`reference/rfcs/fleet-health.md`; serves `fleet-stays-healthy`). A new
+`switchroom fleet-health` CLI verb with three subcommands:
+
+- `scan` — the nightly **model-free (zero-token)** sensor. Iterates every
+  agent under `~/.switchroom/agents/*`, reads each agent's `turns.jsonl` +
+  `logs/<agent>/gateway-supervisor.log`, runs the L0 detectors (ported verbatim
+  from the validated reference detector: `HANG_MS=360000`, `HANG_MAXTOOLS=2`,
+  `synthetic-` exclusion, precise gateway signatures, `turn_id` join key),
+  classifies each finding into the 9-class failure-mode taxonomy, maps it to
+  one of the 22 job specs, scores it `severity × frequency × reach × recency`,
+  and writes the ledger in the exact shape the read side consumes. `--dry-run`
+  / `--json` supported. Defensive: a malformed/missing `turns.jsonl` is skipped
+  with a warning, never crashes the scan.
+- `scan --sync-issues` — the GitHub issue lifecycle (default-off, network-
+  guarded so CI/tests never hit it): opens one issue per distinct problem
+  (`dedup_key`), updates its occurrence list + count on re-scan, and closes it
+  on a verified count-drop. Labels `fleet-health`, `severity:1|2|3`,
+  `job:<slug>`. No-ops with a clear log line if `gh` is unavailable.
+- `deep-dive-targets` — prints the top-N ledger records as a structured brief
+  the owner agent's weekly Opus deep-dive cron consumes (the model spend stays
+  in the agent's own budgeted session; the CLI calls no model — claude-native).
+
+Documents the two owner-agent crons (nightly sensor, weekly deep-dive) and the
+mapping/scoring in the RFC + a new `docs/fleet-health.md`. Per-agent cron config
+and per-agent ledger state are never committed.
+
 ## unreleased — Voice PR-B2: local GPU STT sidecar (gateway consuming side + token injection)
 
 Wires the gateway's voice-in path to the local `voice-sidecar` GPU

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -852,6 +852,10 @@ fleet_health:
   owner_agent: klanker   # admin: true; runs the sensor + deep-dive crons
 ```
 
+The live detection pipeline (the `switchroom fleet-health` CLI, the scoring, the
+GitHub issue lifecycle, and the two owner-agent crons) is documented in
+[`fleet-health.md`](./fleet-health.md).
+
 ## Minimal Example
 
 ```yaml

--- a/docs/fleet-health.md
+++ b/docs/fleet-health.md
@@ -1,7 +1,7 @@
 # Fleet Health — operator guide (live detection pipeline)
 
 Fleet Health is the operator-facing, job-spec-anchored issue tracker: the fleet
-watches itself against the 22 jobs in `reference/jobs/`, ranks its own recurring
+watches itself against the 23 job specs in `reference/jobs/`, ranks its own recurring
 failures by impact, tracks each in a GitHub issue, and closes it on a verified
 count-drop.
 
@@ -94,7 +94,7 @@ implemented in `src/fleet-health/mapping.ts`):
   occurrences stop.
 
 A record's `priority_score` is the max over its open issues (the worst open
-problem drives the ranking). The admin page ranks the 22 records worst-first.
+problem drives the ranking). The admin page ranks the 23 records worst-first.
 
 ## Signal → job-spec mapping
 

--- a/docs/fleet-health.md
+++ b/docs/fleet-health.md
@@ -1,0 +1,123 @@
+# Fleet Health — operator guide (live detection pipeline)
+
+Fleet Health is the operator-facing, job-spec-anchored issue tracker: the fleet
+watches itself against the 22 jobs in `reference/jobs/`, ranks its own recurring
+failures by impact, tracks each in a GitHub issue, and closes it on a verified
+count-drop.
+
+Design: [`reference/rfcs/fleet-health.md`](../reference/rfcs/fleet-health.md)
+(serves `reference/jobs/fleet-stays-healthy.md`, outcome `always-available`).
+
+This page is the operator's how-to for the machinery: the `switchroom
+fleet-health` CLI, the ledger, and the two crons the owner agent runs.
+
+## The pieces
+
+- **The model-free sensor** — `switchroom fleet-health scan`. Reads every
+  agent's `turns.jsonl` + `logs/<agent>/gateway-supervisor.log`, runs the L0
+  detectors (zero tokens, no LLM call), classifies each finding into the RFC's
+  9-class failure-mode taxonomy, maps it to a job spec, scores it, and writes
+  `~/.switchroom/fleet-health/ledger.json` — the ranked index the admin **Fleet
+  Health** page reads.
+- **The GitHub issue lifecycle** — `scan --sync-issues` opens/updates/closes one
+  issue per distinct problem (`dedup_key`), labelled `fleet-health`,
+  `severity:1|2|3`, and `job:<slug>`.
+- **The weekly deep-dive brief** — `switchroom fleet-health deep-dive-targets`
+  prints the top-N ledger records as a structured brief for the owner agent's
+  weekly Opus deep-dive.
+
+## Enabling it
+
+1. Assign a dedicated **admin** owner agent (see
+   [`configuration.md`](./configuration.md#fleet-health-fleet_health)):
+
+   ```yaml
+   fleet_health:
+     owner_agent: klanker   # admin: true
+   ```
+
+   Unset → the feature is inert (no crons, admin page renders its empty state).
+
+2. Schedule the two crons **on the owner agent** (operator-committed, or the
+   owner agent self-schedules them via `schedule_add` after merge — never a
+   self-authored loop; on-leash):
+
+   | Cadence | Cron | Command | Tier |
+   |---|---|---|---|
+   | Nightly 02:00 | `0 2 * * *` | `switchroom fleet-health scan --sync-issues` | model-free (zero tokens) |
+   | Weekly Mon 02:30 | `30 2 * * 1` | `fleet-health deep-dive-targets` → Opus deep-dive | budgeted, top 1-2 only |
+
+   The nightly cron is the L0/L1 sensor pass and the GitHub sync. The weekly
+   cron reads the brief, does the transcript-level root-cause on the top 1-2
+   ranked records (joining occurrences by `turn_id`), and writes the finding
+   into the linked GitHub issue. The deep-dive is Opus reasoning run **inside
+   the owner agent's own budgeted session** — the CLI only produces the brief,
+   never calls a model itself (claude-native; no `claude -p`).
+
+### The owner agent's weekly deep-dive cron prompt
+
+Phrased from the owner agent's future-self perspective (what a `schedule_add`
+`prompt` should say):
+
+> Time for the weekly Fleet Health deep-dive. Run `switchroom fleet-health
+> deep-dive-targets --top 2` to get this week's worst 1-2 job records. For each,
+> read the flagged turns' transcripts (join by `turn_id`), root-cause the
+> failure, and update the linked GitHub issue with your finding. Budget: at most
+> 2 deep-dives. Do not open new issues — the nightly sensor owns issue creation.
+
+## The CLI
+
+```
+switchroom fleet-health scan [--dry-run] [--json] [--sync-issues]
+                             [--window-days <n>] [--repo <owner/name>]
+switchroom fleet-health deep-dive-targets [--top <n>] [--json]
+switchroom fleet-health mapping
+```
+
+- `scan` writes the ledger. `--dry-run` prints it and writes nothing (and
+  skips GitHub sync). `--sync-issues` performs the GitHub issue lifecycle;
+  it is **default-off** so CI and ad-hoc runs never hit the network, and it
+  no-ops with a clear log line if `gh` is unavailable/unauthenticated.
+- `deep-dive-targets` prints the top-N open records as the deep-dive brief.
+- `mapping` prints the signal → job-spec mapping table.
+
+## The scoring
+
+`priority_score = severity × frequency × reach × recency` (exactly as
+implemented in `src/fleet-health/mapping.ts`):
+
+- **severity** ∈ {1,2,3} from the failure-mode taxonomy.
+- **frequency** = `log10(1 + count)` over the scan window (default 30 days).
+- **reach** = distinct agents exhibiting the issue (floored at 1).
+- **recency** = 1.0 within 24h, decaying linearly to 0.1 at the window edge,
+  0 if there are no occurrences. This is what sinks a fixed issue's score as
+  occurrences stop.
+
+A record's `priority_score` is the max over its open issues (the worst open
+problem drives the ranking). The admin page ranks the 22 records worst-first.
+
+## Signal → job-spec mapping
+
+The model-free sensor's explicit, documented mapping (source of truth:
+`src/fleet-health/mapping.ts`, `SIGNAL_MAP`):
+
+| L0 signal | Failure mode | Severity | Job spec |
+|---|---|---|---|
+| `silent-no-op-candidate` (complete, 0 tools, real turn) | silent-no-op | 3 | `know-what-my-agent-is-doing` |
+| `duplicate-delivery-represent` (`represent duplicate-send`) | duplicate | 2 | `talk-to-agents-from-anywhere` |
+| `reply-delivery-failure` (`sendRichMessage … status=err`) | success-theater | 3 | `talk-to-agents-from-anywhere` |
+| `hang-long-stalled` (>6 min AND ≤2 tools) | partial | 2 | `steer-or-queue-mid-flight` |
+| `killed-incomplete-turn` (status ∉ complete/no_reply) | missed-trigger | 3 | `steer-or-queue-mid-flight` |
+| `represent-escalation` (`obligation escalation`) | drift | 1 | `feel-like-a-colleague` |
+
+Tuned L0 constants (load-bearing; ported verbatim from the validated reference
+detector): `HANG_MS = 360000`, `HANG_MAXTOOLS = 2`, `synthetic-` turn ids
+excluded, and the precise gateway signatures above so a `getUpdates` network
+blip never counts as a delivery failure.
+
+## The ledger
+
+`~/.switchroom/fleet-health/ledger.json` — per-deployment state, **never
+committed** (same rule as agent scaffolds and the scheduler ledger). Written by
+the owner agent's sensor, read read-only by the web container. Shape: see
+`src/web/fleet-health-read.ts` (the typed reader is the contract).

--- a/reference/rfcs/fleet-health.md
+++ b/reference/rfcs/fleet-health.md
@@ -374,10 +374,68 @@ empty page). The operator assigns the owner and commits the L0/L1 (nightly)
 and L2/L3 (weekly) schedules. Conservatism comes from the model-free gate and
 the deep-dive budget, not a staged audience.
 
-**This RFC's slice:** the job spec, this design, and a working+tested admin
-**page skeleton** that renders the ledger (typed reader + clearly-marked
-empty state). The owner-agent crons + the GitHub write path are the operator's
-to wire on the assigned agent — specified here, not code in this PR.
+**Slice 1 (merged, #2748):** the job spec, this design, and a working+tested
+admin **page skeleton** that renders the ledger (typed reader + clearly-marked
+empty state), plus the `fleet_health.owner_agent` config field.
+
+**Slice 2 (this PR):** the live detection pipeline — the model-free sensor, the
+priority ledger writer, and the GitHub issue lifecycle, all behind the
+`switchroom fleet-health` CLI. See "Implementation" below. The owner-agent crons
+are documented (this section + `docs/fleet-health.md`) and wired by the operator
+or the owner agent via `schedule_add` after merge — never a self-authored loop.
+
+## Implementation (as shipped in slice 2)
+
+**Code:** `src/fleet-health/{detect,mapping,ledger,gh-sync,scan}.ts` +
+`src/cli/fleet-health.ts` (verb `switchroom fleet-health`, subcommands `scan`,
+`deep-dive-targets`, `mapping`). Operator how-to: `docs/fleet-health.md`.
+
+### Signal → job-spec mapping (the model-free classification table)
+
+`src/fleet-health/mapping.ts` `SIGNAL_MAP` is the source of truth. Each L0
+signal is a hard artifact, pinned to the best-fit job spec (derived by reading
+the 22 `reference/jobs/*.md`) and a taxonomy class + severity:
+
+| L0 signal | Failure mode | Severity | Job spec | Rationale |
+|---|---|---|---|---|
+| `silent-no-op-candidate` | silent-no-op | 3 | `know-what-my-agent-is-doing` | completed with 0 tools while reporting success — the operator can't tell it did nothing |
+| `duplicate-delivery-represent` | duplicate | 2 | `talk-to-agents-from-anywhere` | the represent-duplicate-send (the validated clerk/marko case) — delivery to the principal happened twice |
+| `reply-delivery-failure` | success-theater | 3 | `talk-to-agents-from-anywhere` | `sendRichMessage … status=err` — the answer never reached the principal |
+| `hang-long-stalled` | partial | 2 | `steer-or-queue-mid-flight` | a turn stalled mid-flight (>6 min, ≤2 tools) — an in-flight-control failure |
+| `killed-incomplete-turn` | missed-trigger | 3 | `steer-or-queue-mid-flight` | the turn was abandoned incomplete while in progress |
+| `represent-escalation` | drift | 1 | `feel-like-a-colleague` | the gateway had to nudge on the agent's behalf — UX-friction, informational (does not alone open a sev-3 issue) |
+
+The dedup key is `<job_spec>:<signature>` (one GitHub issue per key).
+
+### Priority score (as implemented)
+
+`priority_score = severity × frequency × reach × recency`, computed in
+`mapping.ts`:
+
+- **severity** — from the table above.
+- **frequency** — `log10(1 + count)` over the scan window (default 30 days).
+- **reach** — distinct-agent count, floored at 1.
+- **recency** — `1.0` within 24h, linear decay to `0.1` at the window edge,
+  `0` if there are no occurrences.
+
+A record's score is the **max** over its open issues (the worst open problem
+drives the ranking). The `resolved-pending-verify → closed` count-drop
+transition fires when a previously-noisy `dedup_key` falls to ≤3 occurrences.
+
+### Owner-agent crons (documented, not committed)
+
+Two operator-set (or owner-agent-self-scheduled) crons on the owner agent —
+no per-agent cron config or per-agent state is committed to the repo:
+
+| Cadence | Cron | Command | Tier |
+|---|---|---|---|
+| Nightly 02:00 | `0 2 * * *` | `switchroom fleet-health scan --sync-issues` | model-free (zero tokens) |
+| Weekly Mon 02:30 | `30 2 * * 1` | `fleet-health deep-dive-targets` → Opus deep-dive | budgeted, top 1-2 only |
+
+The weekly deep-dive is Opus reasoning run **inside the owner agent's own
+budgeted session** (claude-native; no `claude -p`). The CLI only produces the
+structured brief; the model spend stays in the agent's cron session. Full cron
+prompt + cadence: `docs/fleet-health.md`.
 
 ## Verdict
 

--- a/reference/rfcs/fleet-health.md
+++ b/reference/rfcs/fleet-health.md
@@ -19,13 +19,13 @@ Builds on: `see-my-whole-fleet-from-one-screen.md` (fleet dashboard), `crons-use
 
 ## TL;DR
 
-1. **The job:** the fleet watches itself against the 22 job specs, ranks its
+1. **The job:** the fleet watches itself against the 23 job specs, ranks its
    own recurring failures by impact, and puts the worst ones in front of the
    operator with evidence and a GitHub issue tracking the fix.
 2. **Success:** a recurring failure is detected from the fleet's own logs
    (not a principal complaint), ranked by `severity × frequency × reach ×
    recency`, tracked in a GitHub issue, and closed on a verified count-drop.
-3. **Biggest constraint:** the nightly sensor that touches all 22 jobs is
+3. **Biggest constraint:** the nightly sensor that touches all 23 jobs is
    **model-free (zero tokens)**; the model spend is gated behind it and
    budgeted to the top 1-2 issues; everything runs as operator-set schedules
    on one operator-assigned owner agent.
@@ -61,7 +61,7 @@ the silent-failure class the job exists to catch.
 
 ## The health ledger
 
-One persistent record **per job spec** (22 records). It is the standing,
+One persistent record **per job spec** (23 records). It is the standing,
 ranked state the admin page reads and the sensor updates.
 
 **Where it lives:** `~/.switchroom/fleet-health/ledger.json` — per-agent /
@@ -126,7 +126,7 @@ frequent-but-cosmetic one.
   occurrences stop, recency decays the score toward zero.
 
 All four are computed **from the model-free sensor's output** (below) — no
-model judgment enters the score. The web page ranks the 22 records by
+model judgment enters the score. The web page ranks the 23 records by
 `priority_score` descending.
 
 ## The 4-layer detection funnel
@@ -216,7 +216,7 @@ deep work, long+stalled is a hang), exclude `synthetic-` turn ids
 so a `getUpdates` network blip never counts as a delivery failure.
 
 L0 runs nightly across **all** agents and updates the ledger counts for
-**all 22** job records cheaply. It never spends a token.
+**all 23** job records cheaply. It never spends a token.
 
 ### L1 — cheap reflect confirm (nightly, only on L0 hits)
 
@@ -300,7 +300,7 @@ schedule slot).
 
 A new **Fleet Health** page on the operator dashboard (`src/web/`). It reads:
 
-- **The ledger** (`~/.switchroom/fleet-health/ledger.json`) — the 22 records,
+- **The ledger** (`~/.switchroom/fleet-health/ledger.json`) — the 23 records,
   ranked by `priority_score`. This is the primary, always-available source.
 - **Optionally the GitHub API** — live open/closed status per linked issue
   number, when a token is available; degrades to the ledger's own `status`
@@ -308,7 +308,7 @@ A new **Fleet Health** page on the operator dashboard (`src/web/`). It reads:
 
 It shows:
 
-- The 22 job specs **ranked worst-first** by `priority_score`, each row:
+- The 23 job specs **ranked worst-first** by `priority_score`, each row:
   score, open-issue count, severity of the worst open issue, frequency/trend,
   last-scanned, last-deep-dive.
 - **Per-spec drill-down** to its distinct issues: count, frequency/trend,
@@ -394,7 +394,7 @@ or the owner agent via `schedule_add` after merge — never a self-authored loop
 
 `src/fleet-health/mapping.ts` `SIGNAL_MAP` is the source of truth. Each L0
 signal is a hard artifact, pinned to the best-fit job spec (derived by reading
-the 22 `reference/jobs/*.md`) and a taxonomy class + severity:
+the 23 `reference/jobs/*.md`) and a taxonomy class + severity:
 
 | L0 signal | Failure mode | Severity | Job spec | Rationale |
 |---|---|---|---|---|
@@ -404,6 +404,11 @@ the 22 `reference/jobs/*.md`) and a taxonomy class + severity:
 | `hang-long-stalled` | partial | 2 | `steer-or-queue-mid-flight` | a turn stalled mid-flight (>6 min, ≤2 tools) — an in-flight-control failure |
 | `killed-incomplete-turn` | missed-trigger | 3 | `steer-or-queue-mid-flight` | the turn was abandoned incomplete while in progress |
 | `represent-escalation` | drift | 1 | `feel-like-a-colleague` | the gateway had to nudge on the agent's behalf — UX-friction, informational (does not alone open a sev-3 issue) |
+
+Note: `represent-escalation` (`/obligation escalation/`) is an added sev-1
+*informational* signal beyond the two precise delivery signatures — it flags
+UX-friction, not a delivery failure, and does not alone open a sev-3 issue, so
+it is not scope creep on the delivery-signature detection.
 
 The dedup key is `<job_spec>:<signature>` (one GitHub issue per key).
 

--- a/src/cli/fleet-health.ts
+++ b/src/cli/fleet-health.ts
@@ -22,7 +22,7 @@ import { SIGNAL_MAP } from "../fleet-health/mapping.js";
  * Subcommands:
  * - `scan` — the nightly model-free (zero-token) sensor. Reads every agent's
  *   `turns.jsonl` + gateway log, runs the L0 detectors, classifies into the
- *   9-class taxonomy, maps to the 22 job specs, scores by
+ *   9-class taxonomy, maps to the 23 job specs, scores by
  *   `severity × frequency × reach × recency`, and writes the ledger the admin
  *   page reads. `--sync-issues` opens/updates/closes the GitHub issues.
  * - `deep-dive-targets` — prints the top-N ledger records as a structured brief

--- a/src/cli/fleet-health.ts
+++ b/src/cli/fleet-health.ts
@@ -1,0 +1,208 @@
+import type { Command } from "commander";
+import chalk from "chalk";
+
+import { getConfig, withConfigError } from "./helpers.js";
+import {
+  runScan,
+  writeLedger,
+  resolveSwitchroomBase,
+} from "../fleet-health/scan.js";
+import { syncLedgerIssues, defaultGhDeps } from "../fleet-health/gh-sync.js";
+import type {
+  FleetHealthLedger,
+  FleetHealthRecord,
+} from "../web/fleet-health-read.js";
+import { SIGNAL_MAP } from "../fleet-health/mapping.js";
+
+/**
+ * `switchroom fleet-health` — the LIVE detection pipeline for the Fleet Health
+ * feature. Design: `reference/rfcs/fleet-health.md`, serving the job
+ * `fleet-stays-healthy` (outcome `always-available`).
+ *
+ * Subcommands:
+ * - `scan` — the nightly model-free (zero-token) sensor. Reads every agent's
+ *   `turns.jsonl` + gateway log, runs the L0 detectors, classifies into the
+ *   9-class taxonomy, maps to the 22 job specs, scores by
+ *   `severity × frequency × reach × recency`, and writes the ledger the admin
+ *   page reads. `--sync-issues` opens/updates/closes the GitHub issues.
+ * - `deep-dive-targets` — prints the top-N ledger records as a structured brief
+ *   the owner agent's weekly cron consumes for the budgeted Opus deep-dive.
+ * - `mapping` — prints the signal→job-spec mapping table (documentation).
+ *
+ * The GitHub sync is default-OFF (network-guarded), so CI/tests never hit it.
+ */
+export function registerFleetHealthCommand(program: Command): void {
+  const cmd = program
+    .command("fleet-health")
+    .description(
+      "Fleet Health live detection pipeline: model-free sensor, priority " +
+        "ledger, and GitHub-issue lifecycle (RFC fleet-health.md).",
+    );
+
+  cmd
+    .command("scan")
+    .description(
+      "Nightly model-free sensor: scan every agent's turns.jsonl + gateway " +
+        "log, rank recurring failures by priority, write the ledger.",
+    )
+    .option("--dry-run", "print the ledger, do not write it", false)
+    .option("--json", "emit machine-readable JSON", false)
+    .option(
+      "--sync-issues",
+      "open/update/close GitHub issues (needs an authed gh; off by default)",
+      false,
+    )
+    .option("--window-days <n>", "scan window in days", "30")
+    .option(
+      "--repo <owner/name>",
+      "GitHub repo for issue sync (default switchroom/switchroom)",
+      "switchroom/switchroom",
+    )
+    .action(
+      withConfigError(async (opts: Record<string, unknown>) => {
+        const cfg = getConfig(program);
+        const ownerAgent = cfg.fleet_health?.owner_agent;
+        const windowDays = Number(opts.windowDays) || 30;
+        const log = (m: string) => console.error(chalk.gray(m));
+
+        const result = runScan({ ownerAgent, windowDays, log });
+        const ledger = result.ledger;
+
+        log(
+          `fleet-health: scanned ${result.agentsScanned} agents` +
+            (result.agentsSkipped.length
+              ? `, skipped ${result.agentsSkipped.length} (${result.agentsSkipped.join(", ")})`
+              : ""),
+        );
+
+        if (opts.syncIssues && !opts.dryRun) {
+          const deps = defaultGhDeps(log);
+          const sync = syncLedgerIssues(ledger, String(opts.repo), deps);
+          if (!sync.skipped) {
+            log(`fleet-health: synced ${sync.synced} issues to ${String(opts.repo)}`);
+          }
+        } else if (opts.syncIssues && opts.dryRun) {
+          log("fleet-health: --dry-run set, skipping GitHub issue sync.");
+        }
+
+        if (opts.json) {
+          process.stdout.write(JSON.stringify(ledger, null, 2) + "\n");
+        } else {
+          printLedgerTable(ledger);
+        }
+
+        if (opts.dryRun) {
+          log("fleet-health: --dry-run — ledger NOT written.");
+          return;
+        }
+        const base = resolveSwitchroomBase();
+        const path = writeLedger(base, ledger);
+        log(chalk.green(`fleet-health: wrote ledger → ${path}`));
+      }),
+    );
+
+  cmd
+    .command("deep-dive-targets")
+    .description(
+      "Print the top-N ledger records (by priority) as a structured brief " +
+        "for the owner agent's weekly Opus deep-dive cron.",
+    )
+    .option("--top <n>", "number of targets", "2")
+    .option("--json", "emit machine-readable JSON", false)
+    .action(
+      withConfigError(async (opts: Record<string, unknown>) => {
+        const base = resolveSwitchroomBase();
+        const { readLedgerIfPresent } = await import("../fleet-health/scan.js");
+        const ledger = readLedgerIfPresent(base);
+        const top = Number(opts.top) || 2;
+        if (!ledger) {
+          console.error(
+            chalk.yellow(
+              "fleet-health: no ledger yet — run `fleet-health scan` first.",
+            ),
+          );
+          return;
+        }
+        const targets = [...ledger.records]
+          .filter((r) => r.open_issue_count > 0)
+          .sort((a, b) => b.priority_score - a.priority_score)
+          .slice(0, top);
+        if (opts.json) {
+          process.stdout.write(JSON.stringify({ targets }, null, 2) + "\n");
+          return;
+        }
+        printDeepDiveBrief(targets);
+      }),
+    );
+
+  cmd
+    .command("mapping")
+    .description("Print the signal→job-spec mapping + severity table.")
+    .action(() => {
+      console.log(chalk.bold("Signal → job-spec mapping (model-free):\n"));
+      for (const [signal, m] of Object.entries(SIGNAL_MAP)) {
+        console.log(
+          `  ${chalk.cyan(signal.padEnd(28))} → ${m.job_spec.padEnd(30)} ` +
+            `[${m.failure_mode}, sev ${m.severity}]`,
+        );
+      }
+    });
+}
+
+function printLedgerTable(ledger: FleetHealthLedger): void {
+  const ranked = [...ledger.records].sort(
+    (a, b) => b.priority_score - a.priority_score,
+  );
+  console.log(chalk.bold("\nFleet Health ledger (worst-first):"));
+  console.log(
+    chalk.gray(
+      `owner=${ledger.owner_agent ?? "(unset)"}  generated_at=${ledger.generated_at}`,
+    ),
+  );
+  for (const r of ranked) {
+    if (r.open_issue_count === 0 && r.priority_score === 0) continue;
+    console.log(
+      `  ${chalk.yellow(r.priority_score.toFixed(2).padStart(8))}  ` +
+        `${r.job_spec.padEnd(34)} open=${r.open_issue_count} ` +
+        `issues=${r.issues.length}`,
+    );
+    for (const iss of r.issues) {
+      console.log(
+        chalk.gray(
+          `        - ${iss.dedup_key}  freq=${iss.frequency} ` +
+            `reach=[${iss.reach.join(",")}] sev=${iss.severity} ${iss.status}`,
+        ),
+      );
+    }
+  }
+}
+
+function printDeepDiveBrief(targets: FleetHealthRecord[]): void {
+  console.log(chalk.bold("Fleet Health — weekly deep-dive targets\n"));
+  if (targets.length === 0) {
+    console.log("  (no open issues — nothing to deep-dive this week)");
+    return;
+  }
+  for (const r of targets) {
+    console.log(chalk.cyan(`## ${r.job_spec}  (score ${r.priority_score.toFixed(2)})`));
+    console.log(`   spec: reference/jobs/${r.job_spec}.md`);
+    console.log(`   open issues: ${r.open_issue_count}`);
+    for (const iss of r.issues) {
+      console.log(`   - ${iss.dedup_key} [${iss.failure_mode}, sev ${iss.severity}]`);
+      console.log(
+        `     freq=${iss.frequency} reach=[${iss.reach.join(",")}] ` +
+          `newest=${iss.recency ?? "—"} gh=${iss.gh_issue ?? "none"}`,
+      );
+      for (const o of iss.occurrences.slice(0, 5)) {
+        console.log(`       • ${o.agent} ${o.turn_id} — ${o.log_pointer ?? ""}`);
+      }
+    }
+    console.log("");
+  }
+  console.log(
+    chalk.gray(
+      "Deep-dive: read the flagged turns' transcripts (join by turn_id), " +
+        "root-cause, and write the finding into the linked GitHub issue.",
+    ),
+  );
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -44,6 +44,7 @@ import { registerHostdMcpCommand } from "./mcp-hostd.js";
 import { registerHostdCommand } from "./hostd.js";
 import { registerWebdCommand } from "./webd.js";
 import { registerHostCommand } from "./host-repair.js";
+import { registerFleetHealthCommand } from "./fleet-health.js";
 import { captureEvent, installGlobalErrorHandlers } from "../analytics/posthog.js";
 
 installGlobalErrorHandlers();
@@ -115,3 +116,4 @@ registerHostdMcpCommand(program);
 registerHostdCommand(program);
 registerWebdCommand(program);
 registerHostCommand(program);
+registerFleetHealthCommand(program);

--- a/src/fleet-health/detect.test.ts
+++ b/src/fleet-health/detect.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import {
+  scanAgent,
+  parseTurns,
+  detectTurnFindings,
+  detectGatewayFindings,
+  HANG_MS,
+} from "./detect.js";
+
+/**
+ * Pins the model-free L0 detector port (from the validated `spec_audit_l0.py`):
+ * the tuned hang threshold, the `synthetic-` exclusion, and the precise gateway
+ * signatures. All fixtures use SYNTHETIC turn ids — never a real Telegram id.
+ */
+
+// Synthetic origin_turn_ids: `<synthetic-chat>:_#<seq>`.
+const CHAT = "77770001";
+
+function turn(seq: number, over: Record<string, unknown>): string {
+  return JSON.stringify({
+    ts: 1_782_600_000 + seq,
+    agent: "alpha",
+    turn_id: `${CHAT}:_#${seq}`,
+    status: "complete",
+    tools: 5,
+    duration_ms: 40_000,
+    ...over,
+  });
+}
+
+describe("parseTurns", () => {
+  it("skips malformed lines without throwing", () => {
+    const text = [turn(1, {}), "{not json", "", turn(2, {})].join("\n");
+    expect(parseTurns(text)).toHaveLength(2);
+  });
+});
+
+describe("detectTurnFindings", () => {
+  it("flags a silent no-op (complete, zero tools, real turn)", () => {
+    const turns = parseTurns(turn(10, { tools: 0 }));
+    const f = detectTurnFindings("alpha", turns);
+    expect(f.map((x) => x.signal)).toContain("silent-no-op-candidate");
+  });
+
+  it("does NOT flag a synthetic zero-tool turn as a silent no-op", () => {
+    const turns = parseTurns(
+      JSON.stringify({
+        turn_id: `${CHAT}:_#synthetic-boot`,
+        status: "complete",
+        tools: 0,
+        duration_ms: 1000,
+      }),
+    );
+    const f = detectTurnFindings("alpha", turns);
+    expect(f.map((x) => x.signal)).not.toContain("silent-no-op-candidate");
+  });
+
+  it("flags a killed/incomplete turn", () => {
+    const turns = parseTurns(turn(11, { status: "killed", tools: 3 }));
+    const f = detectTurnFindings("alpha", turns);
+    expect(f.map((x) => x.signal)).toContain("killed-incomplete-turn");
+  });
+
+  it("does not flag no_reply as incomplete", () => {
+    const turns = parseTurns(turn(12, { status: "no_reply", tools: 1 }));
+    const f = detectTurnFindings("alpha", turns);
+    expect(f.map((x) => x.signal)).not.toContain("killed-incomplete-turn");
+  });
+
+  it("flags a hang only when long AND stalled (few tools)", () => {
+    const stalled = parseTurns(turn(13, { duration_ms: HANG_MS + 1, tools: 1 }));
+    const productive = parseTurns(turn(14, { duration_ms: HANG_MS + 1, tools: 9 }));
+    expect(detectTurnFindings("alpha", stalled).map((x) => x.signal)).toContain(
+      "hang-long-stalled",
+    );
+    expect(
+      detectTurnFindings("alpha", productive).map((x) => x.signal),
+    ).not.toContain("hang-long-stalled");
+  });
+});
+
+describe("detectGatewayFindings", () => {
+  const log = [
+    `2026-07-02T21:03:00Z gateway: represent duplicate-send tid=${CHAT}:_#42`,
+    `2026-07-02T21:04:00Z gateway: tg-post method=getUpdates status=err timeout`,
+    `2026-07-02T21:05:00Z gateway: tg-post method=sendRichMessage tid=${CHAT}:_#43 status=err`,
+    `2026-07-02T21:06:00Z gateway: obligation escalation tid=${CHAT}:_#44`,
+  ].join("\n");
+
+  it("counts represent-duplicate and reply-delivery-failure, ignores getUpdates blip", () => {
+    const { gw_hits } = detectGatewayFindings("alpha", log);
+    expect(gw_hits["duplicate-delivery-represent"]).toBe(1);
+    expect(gw_hits["reply-delivery-failure"]).toBe(1);
+    expect(gw_hits["represent-escalation"]).toBe(1);
+  });
+
+  it("extracts turn_id + ts into the finding", () => {
+    const { findings } = detectGatewayFindings("alpha", log);
+    const dup = findings.find((f) => f.signal === "duplicate-delivery-represent");
+    expect(dup?.turn_id).toBe(`${CHAT}:_#42`);
+    expect(dup?.ts).toBe("2026-07-02T21:03:00Z");
+  });
+});
+
+describe("scanAgent escalation decision", () => {
+  it("escalates on a duplicate-send hit", () => {
+    const res = scanAgent(
+      "alpha",
+      turn(1, {}),
+      "gateway: represent duplicate-send tid=x",
+    );
+    expect(res.escalate).toBe(true);
+  });
+
+  it("does NOT escalate on a represent-escalation alone", () => {
+    const res = scanAgent("alpha", turn(1, {}), "gateway: obligation escalation");
+    expect(res.escalate).toBe(false);
+  });
+
+  it("stays clean on a healthy agent", () => {
+    const res = scanAgent("alpha", turn(1, {}) + "\n" + turn(2, {}), "");
+    expect(res.escalate).toBe(false);
+    expect(res.findings).toHaveLength(0);
+  });
+});

--- a/src/fleet-health/detect.ts
+++ b/src/fleet-health/detect.ts
@@ -1,0 +1,242 @@
+/**
+ * Fleet Health — Layer-0 model-free detector (the nightly sensor).
+ *
+ * Design: `reference/rfcs/fleet-health.md` (serves `fleet-stays-healthy`,
+ * outcome `always-available`). This is the TypeScript port of the validated
+ * reference detector (`spec_audit_l0.py`) — same tuned constants, same precise
+ * gateway signatures, same `synthetic-` exclusion, same `turn_id` join key.
+ *
+ * STRICTLY MODEL-FREE: no LLM call, no `claude -p`, zero tokens. It reads only
+ * hard artifacts — the structured `turns.jsonl` oracle and precise gateway log
+ * signatures — and emits a structured signal digest. Everything here is a pure
+ * function over already-read text so it is trivially unit-testable and never
+ * touches the network.
+ */
+
+/** Tuned hang threshold: >6 min (live data p99 = 303 s). Load-bearing —
+ *  do not casually change (see RFC "Tuned constants"). */
+export const HANG_MS = 360_000;
+/** A long turn with few tool calls is a stall (hang); a long turn with many
+ *  tool calls is deep work. Load-bearing. */
+export const HANG_MAXTOOLS = 2;
+
+/** One row of `turns.jsonl` — the structured per-turn oracle. */
+export interface TurnRecord {
+  ts?: number;
+  agent?: string;
+  duration_ms?: number;
+  tools?: number;
+  status?: string;
+  turn_id?: string;
+}
+
+/** The L0 failure-mode signals emitted from `turns.jsonl`. Kept as stable
+ *  string keys so the signal→spec mapping table can join on them. */
+export type TurnSignal =
+  | "killed-incomplete-turn"
+  | "hang-long-stalled"
+  | "silent-no-op-candidate";
+
+/** The L0 failure-mode signals emitted from precise gateway log signatures. */
+export type GatewaySignal =
+  | "duplicate-delivery-represent"
+  | "represent-escalation"
+  | "reply-delivery-failure";
+
+export type L0Signal = TurnSignal | GatewaySignal;
+
+/** A single flagged occurrence with its hard-artifact evidence. */
+export interface Finding {
+  signal: L0Signal;
+  agent: string;
+  /** origin_turn_id join key (turns.jsonl / gateway log / transcript). For a
+   *  gateway-count signal with no single turn, this is a synthesized pointer. */
+  turn_id: string;
+  /** A grep-able pointer the operator can jump to. */
+  log_pointer: string;
+  /** ISO timestamp of the occurrence (from the turn `ts`, if known). */
+  ts: string | null;
+}
+
+/** The per-agent digest — mirrors the reference detector's JSON output plus
+ *  the structured findings the ledger writer consumes. */
+export interface AgentScanResult {
+  agent: string;
+  turns: number;
+  status_mix: Record<string, number>;
+  findings: Finding[];
+  /** Raw gateway signature hit counts (for the digest / escalate decision). */
+  gw_hits: Record<GatewaySignal, number>;
+  escalate: boolean;
+}
+
+/**
+ * Precise gateway log signatures. Precision-filtered so a `getUpdates` network
+ * blip never counts as a delivery failure — the reply-delivery pattern matches
+ * ONLY a `sendRichMessage` non-ok status. Regex sources match the reference
+ * detector's `grep -E` patterns exactly.
+ */
+export const GATEWAY_SIGNATURES: Record<GatewaySignal, RegExp> = {
+  "duplicate-delivery-represent": /represent duplicate-send/,
+  "represent-escalation": /obligation escalation/,
+  "reply-delivery-failure": /tg-post method=sendRichMessage[^\n]*status=err/,
+};
+
+/** Parse `turns.jsonl` text into records, silently skipping malformed lines
+ *  (a corrupt line must never crash the scan — RFC: defensive). */
+export function parseTurns(text: string): TurnRecord[] {
+  const out: TurnRecord[] = [];
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    try {
+      out.push(JSON.parse(line) as TurnRecord);
+    } catch {
+      // skip malformed line
+    }
+  }
+  return out;
+}
+
+function isoFromTs(ts: number | undefined): string | null {
+  if (typeof ts !== "number" || !Number.isFinite(ts)) return null;
+  // turns.jsonl `ts` is unix seconds.
+  return new Date(ts * 1000).toISOString();
+}
+
+/**
+ * Run the turns.jsonl detectors over one agent's parsed turns. Pure — returns
+ * the flagged findings. Mirrors the reference detector's three turn checks.
+ */
+export function detectTurnFindings(agent: string, turns: TurnRecord[]): Finding[] {
+  const findings: Finding[] = [];
+  for (const t of turns) {
+    const tid = t.turn_id ?? "?";
+    const st = t.status;
+    const tl = typeof t.tools === "number" ? t.tools : 0;
+    const dur = typeof t.duration_ms === "number" ? t.duration_ms : 0;
+    const synthetic = tid.includes("synthetic-"); // gateway-injected, not a real job
+    const ts = isoFromTs(t.ts);
+
+    if (st !== "complete" && st !== "no_reply") {
+      findings.push({
+        signal: "killed-incomplete-turn",
+        agent,
+        turn_id: tid,
+        log_pointer: `turns.jsonl:${tid} status=${st}`,
+        ts,
+      });
+    }
+    // tuned hang: long AND stalled — long+productive is deep work.
+    if (dur > HANG_MS && tl <= HANG_MAXTOOLS) {
+      findings.push({
+        signal: "hang-long-stalled",
+        agent,
+        turn_id: tid,
+        log_pointer: `turns.jsonl:${tid} ${Math.floor(dur / 1000)}s tools=${tl}`,
+        ts,
+      });
+    }
+    // silent no-op: completed, zero tools, real (non-synthetic).
+    if (st === "complete" && tl === 0 && !synthetic) {
+      findings.push({
+        signal: "silent-no-op-candidate",
+        agent,
+        turn_id: tid,
+        log_pointer: `turns.jsonl:${tid} tools=0`,
+        ts,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Run the precise gateway signatures over one agent's gateway log text. Returns
+ * both the per-signature hit counts and one Finding per matched line (so the
+ * ledger gets real log pointers). `logName` is only used to build the pointer.
+ */
+export function detectGatewayFindings(
+  agent: string,
+  logText: string,
+  logName = `logs/${agent}/gateway-supervisor.log`,
+): { findings: Finding[]; gw_hits: Record<GatewaySignal, number> } {
+  const findings: Finding[] = [];
+  const gw_hits: Record<GatewaySignal, number> = {
+    "duplicate-delivery-represent": 0,
+    "represent-escalation": 0,
+    "reply-delivery-failure": 0,
+  };
+  const lines = logText.split("\n");
+  for (const [name, re] of Object.entries(GATEWAY_SIGNATURES) as [
+    GatewaySignal,
+    RegExp,
+  ][]) {
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (!line) continue;
+      if (re.test(line)) {
+        gw_hits[name] += 1;
+        findings.push({
+          signal: name,
+          agent,
+          turn_id: extractTurnId(line) ?? `${agent}:gw#${i + 1}`,
+          log_pointer: `${logName}:${i + 1}`,
+          ts: extractTs(line),
+        });
+      }
+    }
+  }
+  return { findings, gw_hits };
+}
+
+/** Best-effort turn_id extraction from a gateway log line (origin_turn_id
+ *  form `<digits>:_#<digits>`). Returns null if the line carries none. */
+export function extractTurnId(line: string): string | null {
+  const m = line.match(/\d+:_#\d+/);
+  return m ? m[0] : null;
+}
+
+/** Best-effort ISO-timestamp extraction from a gateway log line. Gateway lines
+ *  are prefixed with an ISO-8601 timestamp; return it if present. */
+export function extractTs(line: string): string | null {
+  const m = line.match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?/);
+  return m ? m[0] : null;
+}
+
+/**
+ * Full L0 scan for one agent over the two artifact texts. The gateway signals
+ * that gate escalation match the reference detector exactly: killed/hang/silent
+ * no-op, plus duplicate-delivery and reply-delivery-failure (represent-escalation
+ * is informational and does NOT by itself escalate).
+ */
+export function scanAgent(
+  agent: string,
+  turnsText: string,
+  gatewayText: string,
+): AgentScanResult {
+  const turns = parseTurns(turnsText);
+  const status_mix: Record<string, number> = {};
+  for (const t of turns) {
+    const st = t.status ?? "unknown";
+    status_mix[st] = (status_mix[st] ?? 0) + 1;
+  }
+  const turnFindings = detectTurnFindings(agent, turns);
+  const { findings: gwFindings, gw_hits } = detectGatewayFindings(
+    agent,
+    gatewayText,
+  );
+  const findings = [...turnFindings, ...gwFindings];
+
+  const escalate =
+    turnFindings.some(
+      (f) =>
+        f.signal === "killed-incomplete-turn" ||
+        f.signal === "hang-long-stalled" ||
+        f.signal === "silent-no-op-candidate",
+    ) ||
+    gw_hits["duplicate-delivery-represent"] > 0 ||
+    gw_hits["reply-delivery-failure"] > 0;
+
+  return { agent, turns: turns.length, status_mix, findings, gw_hits, escalate };
+}

--- a/src/fleet-health/gh-sync.test.ts
+++ b/src/fleet-health/gh-sync.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { syncLedgerIssues, type GhSyncDeps } from "./gh-sync.js";
+import { buildLedger } from "./ledger.js";
+import type { Finding } from "./detect.js";
+
+const CHAT = "77770003";
+
+function dup(agent: string, seq: number): Finding {
+  return {
+    signal: "duplicate-delivery-represent",
+    agent,
+    turn_id: `${CHAT}:_#${seq}`,
+    log_pointer: `logs/${agent}/gateway-supervisor.log:${seq}`,
+    ts: "2026-07-02T21:03:00Z",
+  };
+}
+
+function fakeDeps(over: Partial<GhSyncDeps> = {}): {
+  deps: GhSyncDeps;
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  const deps: GhSyncDeps = {
+    log: () => {},
+    run: (args) => {
+      calls.push(args);
+      if (args[0] === "auth") return { ok: true, stdout: "", stderr: "" };
+      if (args[0] === "issue" && args[1] === "create") {
+        return {
+          ok: true,
+          stdout: "https://github.com/switchroom/switchroom/issues/1841",
+          stderr: "",
+        };
+      }
+      return { ok: true, stdout: "", stderr: "" };
+    },
+    ...over,
+  };
+  return { deps, calls };
+}
+
+describe("gh-sync (no network — injected deps)", () => {
+  it("no-ops with a clear signal when gh is unavailable", () => {
+    const led = buildLedger([dup("clerk", 1), dup("clerk", 2), dup("marko", 3)]);
+    const { deps } = fakeDeps({
+      run: (args) =>
+        args[0] === "auth"
+          ? { ok: false, stdout: "", stderr: "not logged in" }
+          : { ok: true, stdout: "", stderr: "" },
+    });
+    const r = syncLedgerIssues(led, "switchroom/switchroom", deps);
+    expect(r.skipped).toBe(true);
+    expect(r.synced).toBe(0);
+  });
+
+  it("opens an issue with fleet-health + severity + job labels and stores the number", () => {
+    const led = buildLedger([dup("clerk", 1), dup("clerk", 2), dup("marko", 3)]);
+    const { deps, calls } = fakeDeps();
+    const r = syncLedgerIssues(led, "switchroom/switchroom", deps);
+    expect(r.skipped).toBe(false);
+    const create = calls.find((c) => c[0] === "issue" && c[1] === "create")!;
+    const labelIdx = create.indexOf("--label");
+    const labels = create[labelIdx + 1];
+    expect(labels).toContain("fleet-health");
+    expect(labels).toContain("severity:2");
+    expect(labels).toContain("job:talk-to-agents-from-anywhere");
+
+    const delivery = led.records.find(
+      (r) => r.job_spec === "talk-to-agents-from-anywhere",
+    )!;
+    expect(delivery.issues[0].gh_issue).toBe(1841);
+    expect(delivery.gh_issues).toContain(1841);
+  });
+});

--- a/src/fleet-health/gh-sync.test.ts
+++ b/src/fleet-health/gh-sync.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { syncLedgerIssues, type GhSyncDeps } from "./gh-sync.js";
 import { buildLedger } from "./ledger.js";
+import { dedupKeyFor } from "./mapping.js";
 import type { Finding } from "./detect.js";
+import type { FleetHealthLedger } from "../web/fleet-health-read.js";
 
 const CHAT = "77770003";
 
@@ -70,5 +72,58 @@ describe("gh-sync (no network — injected deps)", () => {
     )!;
     expect(delivery.issues[0].gh_issue).toBe(1841);
     expect(delivery.gh_issues).toContain(1841);
+  });
+
+  it("closes the GH issue when a fix drops findings to zero (close-on-zero)", () => {
+    // Prior scan: a delivery problem was resolved-pending-verify with a linked
+    // GH issue #1841. The dedup_key must match what buildLedger derives so the
+    // close-on-zero synthesis finds it absent from the current (empty) aggs.
+    const key = dedupKeyFor(dup("clerk", 1));
+    const prior: FleetHealthLedger = {
+      generated_at: "2026-07-02T00:00:00Z",
+      records: [
+        {
+          job_spec: "talk-to-agents-from-anywhere",
+          open_issue_count: 0,
+          last_scanned: "2026-07-02T00:00:00Z",
+          priority_score: 0,
+          gh_issues: [1841],
+          last_deep_dive: null,
+          issues: [
+            {
+              dedup_key: key,
+              failure_mode: "duplicate",
+              severity: 2,
+              frequency: 2,
+              reach: ["clerk"],
+              recency: "2026-07-01T00:00:00Z",
+              occurrences: [],
+              gh_issue: 1841,
+              status: "resolved-pending-verify",
+            },
+          ],
+        },
+      ],
+    };
+
+    // Current scan: NO findings for that key (the fix landed → count zero).
+    const led = buildLedger([], { prior });
+
+    const delivery = led.records.find(
+      (r) => r.job_spec === "talk-to-agents-from-anywhere",
+    )!;
+    const closed = delivery.issues.find((i) => i.dedup_key === key)!;
+    expect(closed.status).toBe("closed");
+    expect(closed.gh_issue).toBe(1841);
+    expect(closed.frequency).toBe(0);
+
+    // gh-sync must see the closed issue and run `gh issue close 1841`.
+    const { deps, calls } = fakeDeps();
+    const r = syncLedgerIssues(led, "switchroom/switchroom", deps);
+    expect(r.skipped).toBe(false);
+    const closeCall = calls.find(
+      (c) => c[0] === "issue" && c[1] === "close" && c[2] === "1841",
+    );
+    expect(closeCall).toBeDefined();
   });
 });

--- a/src/fleet-health/gh-sync.ts
+++ b/src/fleet-health/gh-sync.ts
@@ -1,0 +1,178 @@
+/**
+ * Fleet Health — GitHub issue lifecycle. Design:
+ * `reference/rfcs/fleet-health.md` ("GitHub issue lifecycle").
+ *
+ * GitHub issues are the identify+resolve system-of-record. For each distinct
+ * problem (dedup_key) the sensor: opens an issue if none exists, updates the
+ * occurrence list + count if it does, and closes it on a verified count-drop.
+ * The ledger stores the issue NUMBER back; GitHub is durable, the ledger is the
+ * fast rankable index.
+ *
+ * This shells out to `gh` (authed in the owner-agent container). It is guarded
+ * behind `--sync-issues` at the CLI so tests/CI never hit the network. If `gh`
+ * is unavailable it no-ops with a clear log line — the scan still writes the
+ * ledger.
+ */
+
+import { spawnSync } from "node:child_process";
+import type {
+  FleetHealthLedger,
+  FleetHealthIssue,
+  FleetHealthRecord,
+} from "../web/fleet-health-read.js";
+
+const LABEL = "fleet-health";
+
+export interface GhSyncDeps {
+  /** Runs a `gh` invocation; returns {ok, stdout}. Injectable for tests. */
+  run: (args: string[]) => { ok: boolean; stdout: string; stderr: string };
+  log: (msg: string) => void;
+}
+
+export function defaultGhDeps(log: (m: string) => void): GhSyncDeps {
+  return {
+    log,
+    run: (args) => {
+      const r = spawnSync("gh", args, { encoding: "utf-8" });
+      return {
+        ok: r.status === 0,
+        stdout: (r.stdout ?? "").trim(),
+        stderr: (r.stderr ?? "").trim(),
+      };
+    },
+  };
+}
+
+/** True iff `gh` is present and authenticated. */
+export function ghAvailable(deps: GhSyncDeps): boolean {
+  const r = deps.run(["auth", "status"]);
+  return r.ok;
+}
+
+function severityLabel(sev: number): string {
+  const s = Math.max(1, Math.min(3, Math.round(sev)));
+  return `severity:${s}`;
+}
+
+function issueTitle(iss: FleetHealthIssue, job_spec: string): string {
+  return `[fleet-health] ${job_spec}: ${iss.failure_mode} (${iss.dedup_key})`;
+}
+
+function issueBody(iss: FleetHealthIssue, job_spec: string): string {
+  const lines: string[] = [];
+  lines.push(`**Job spec:** \`${job_spec}\` (\`reference/jobs/${job_spec}.md\`)`);
+  lines.push(`**Failure mode:** ${iss.failure_mode} — severity ${iss.severity}`);
+  lines.push(`**Dedup key:** \`${iss.dedup_key}\``);
+  lines.push(`**Frequency (scan window):** ${iss.frequency}`);
+  lines.push(`**Reach:** ${iss.reach.join(", ") || "—"}`);
+  lines.push(`**Newest occurrence:** ${iss.recency ?? "—"}`);
+  lines.push("");
+  lines.push("**Occurrences (hard-artifact evidence):**");
+  for (const o of iss.occurrences.slice(0, 25)) {
+    lines.push(`- \`${o.agent}\` turn \`${o.turn_id}\` — ${o.log_pointer ?? ""}`);
+  }
+  lines.push("");
+  lines.push(
+    "_Opened + maintained by the Fleet Health sensor " +
+      "(`switchroom fleet-health scan --sync-issues`). Closes automatically on " +
+      "a verified count-drop. See `reference/rfcs/fleet-health.md`._",
+  );
+  return lines.join("\n");
+}
+
+/**
+ * Sync one issue to GitHub. Returns the (possibly new) issue number, or the
+ * existing one. Mutates `iss.gh_issue` and `iss.status`.
+ */
+function syncIssue(
+  deps: GhSyncDeps,
+  repo: string,
+  job_spec: string,
+  iss: FleetHealthIssue,
+): void {
+  const labels = [LABEL, severityLabel(iss.severity), `job:${job_spec}`];
+  const title = issueTitle(iss, job_spec);
+  const body = issueBody(iss, job_spec);
+
+  const shouldClose =
+    iss.status === "closed" || iss.status === "resolved-pending-verify";
+
+  if (iss.gh_issue === undefined) {
+    if (shouldClose) return; // nothing to do — no issue and already resolved.
+    // Open a new issue.
+    const r = deps.run([
+      "issue",
+      "create",
+      "-R",
+      repo,
+      "--title",
+      title,
+      "--body",
+      body,
+      "--label",
+      labels.join(","),
+    ]);
+    if (r.ok) {
+      const m = r.stdout.match(/\/issues\/(\d+)/);
+      if (m) {
+        iss.gh_issue = Number(m[1]);
+        deps.log(`fleet-health: opened GH #${iss.gh_issue} for ${iss.dedup_key}`);
+      }
+    } else {
+      deps.log(`fleet-health: gh issue create failed for ${iss.dedup_key}: ${r.stderr}`);
+    }
+    return;
+  }
+
+  // Existing issue: update the body (refreshes occurrence list + count).
+  const num = String(iss.gh_issue);
+  const upd = deps.run(["issue", "edit", num, "-R", repo, "--body", body]);
+  if (!upd.ok) {
+    deps.log(`fleet-health: gh issue edit #${num} failed: ${upd.stderr}`);
+  }
+
+  if (iss.status === "closed") {
+    const c = deps.run([
+      "issue",
+      "close",
+      num,
+      "-R",
+      repo,
+      "--comment",
+      `Verified count-drop (frequency ${iss.frequency} ≤ resolved threshold). Closed by the Fleet Health sensor.`,
+    ]);
+    if (c.ok) deps.log(`fleet-health: closed GH #${num} (count-drop) for ${iss.dedup_key}`);
+    else deps.log(`fleet-health: gh issue close #${num} failed: ${c.stderr}`);
+  }
+}
+
+/**
+ * Sync every issue in the ledger to GitHub. No-ops (with a clear log line) if
+ * `gh` is unavailable — the scan already wrote the ledger. Mutates the ledger
+ * records in place (fills gh_issue numbers), so the caller re-writes the ledger
+ * afterward to persist them.
+ */
+export function syncLedgerIssues(
+  ledger: FleetHealthLedger,
+  repo: string,
+  deps: GhSyncDeps,
+): { synced: number; skipped: boolean } {
+  if (!ghAvailable(deps)) {
+    deps.log(
+      "fleet-health: gh unavailable or not authenticated — skipping GitHub issue sync (ledger still written).",
+    );
+    return { synced: 0, skipped: true };
+  }
+  let synced = 0;
+  for (const rec of ledger.records as FleetHealthRecord[]) {
+    for (const iss of rec.issues) {
+      syncIssue(deps, repo, rec.job_spec, iss);
+      synced++;
+    }
+    // Refresh the record's rolled-up gh_issues after sync.
+    rec.gh_issues = rec.issues
+      .map((i) => i.gh_issue)
+      .filter((n): n is number => typeof n === "number");
+  }
+  return { synced, skipped: false };
+}

--- a/src/fleet-health/ledger.test.ts
+++ b/src/fleet-health/ledger.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildLedger } from "./ledger.js";
+import { runScan, writeLedger } from "./scan.js";
+import type { Finding } from "./detect.js";
+import { readFleetHealth } from "../web/fleet-health-read.js";
+
+const CHAT = "77770002";
+
+function dupFinding(agent: string, seq: number): Finding {
+  return {
+    signal: "duplicate-delivery-represent",
+    agent,
+    turn_id: `${CHAT}:_#${seq}`,
+    log_pointer: `logs/${agent}/gateway-supervisor.log:${seq}`,
+    ts: "2026-07-02T21:03:00Z",
+  };
+}
+
+describe("buildLedger", () => {
+  const now = new Date("2026-07-03T00:00:00Z");
+
+  it("seeds all 22 records and aggregates by dedup_key across agents", () => {
+    const findings = [
+      dupFinding("clerk", 1),
+      dupFinding("clerk", 2),
+      dupFinding("marko", 3),
+    ];
+    const led = buildLedger(findings, { ownerAgent: "klanker", now });
+    expect(led.records).toHaveLength(23); // 22 job specs (delivery seeded once)
+    const delivery = led.records.find(
+      (r) => r.job_spec === "talk-to-agents-from-anywhere",
+    )!;
+    expect(delivery.issues).toHaveLength(1);
+    expect(delivery.issues[0].frequency).toBe(3);
+    expect(delivery.issues[0].reach).toEqual(["clerk", "marko"]);
+    expect(delivery.open_issue_count).toBe(1);
+    expect(delivery.priority_score).toBeGreaterThan(0);
+  });
+
+  it("carries the GH issue number forward and flips to pending on a count-drop", () => {
+    const prior = buildLedger(
+      Array.from({ length: 20 }, (_, i) => dupFinding("clerk", i)),
+      { now },
+    );
+    // inject a gh_issue number as if a prior sync opened it
+    const pd = prior.records.find(
+      (r) => r.job_spec === "talk-to-agents-from-anywhere",
+    )!;
+    pd.issues[0].gh_issue = 4242;
+
+    // next scan: count dropped to 1 (below RESOLVED_THRESHOLD)
+    const next = buildLedger([dupFinding("clerk", 99)], { now, prior });
+    const nd = next.records.find(
+      (r) => r.job_spec === "talk-to-agents-from-anywhere",
+    )!;
+    expect(nd.issues[0].gh_issue).toBe(4242);
+    expect(nd.issues[0].status).toBe("resolved-pending-verify");
+  });
+});
+
+describe("round-trip: buildLedger → readFleetHealth", () => {
+  it("writes a ledger the reader accepts, ranked non-empty", () => {
+    const dir = mkdtempSync(join(tmpdir(), "fh-ledger-"));
+    try {
+      const base = join(dir, ".switchroom");
+      mkdirSync(base, { recursive: true });
+      const led = buildLedger(
+        [dupFinding("clerk", 1), dupFinding("marko", 2)],
+        { ownerAgent: "klanker", now: new Date("2026-07-03T00:00:00Z") },
+      );
+      const path = writeLedger(base, led);
+      const dash = readFleetHealth(path);
+      expect(dash.empty).toBe(false);
+      expect(dash.owner_agent).toBe("klanker");
+      expect(dash.records[0].priority_score).toBeGreaterThanOrEqual(
+        dash.records[1].priority_score,
+      );
+      expect(dash.records[0].job_spec).toBe("talk-to-agents-from-anywhere");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("runScan (I/O) — defensive over a synthetic fleet tree", () => {
+  it("scans good agents, skips a malformed/missing turns.jsonl without crashing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "fh-scan-"));
+    try {
+      const base = join(dir, ".switchroom");
+      const agents = join(base, "agents");
+      const logs = join(base, "logs");
+      // good agent
+      mkdirSync(join(agents, "clerk"), { recursive: true });
+      mkdirSync(join(logs, "clerk"), { recursive: true });
+      writeFileSync(
+        join(agents, "clerk", "turns.jsonl"),
+        JSON.stringify({
+          turn_id: `${CHAT}:_#1`,
+          status: "complete",
+          tools: 0,
+        }) + "\n",
+      );
+      writeFileSync(
+        join(logs, "clerk", "gateway-supervisor.log"),
+        `2026-07-02T21:03:00Z represent duplicate-send tid=${CHAT}:_#1\n`,
+      );
+      // malformed agent — corrupt turns, no log
+      mkdirSync(join(agents, "broken"), { recursive: true });
+      writeFileSync(join(agents, "broken", "turns.jsonl"), "{{{not json\n");
+      // empty agent — no artifacts at all (skipped)
+      mkdirSync(join(agents, "ghost"), { recursive: true });
+
+      const warnings: string[] = [];
+      const res = runScan({
+        base,
+        ownerAgent: "klanker",
+        log: (m) => warnings.push(m),
+        now: new Date("2026-07-03T00:00:00Z"),
+      });
+      expect(res.agentsSkipped).toContain("ghost");
+      // clerk contributed a silent no-op + a duplicate delivery
+      const delivery = res.ledger.records.find(
+        (r) => r.job_spec === "talk-to-agents-from-anywhere",
+      )!;
+      expect(delivery.issues.length).toBeGreaterThan(0);
+      const silent = res.ledger.records.find(
+        (r) => r.job_spec === "know-what-my-agent-is-doing",
+      )!;
+      expect(silent.issues.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/fleet-health/ledger.test.ts
+++ b/src/fleet-health/ledger.test.ts
@@ -22,14 +22,14 @@ function dupFinding(agent: string, seq: number): Finding {
 describe("buildLedger", () => {
   const now = new Date("2026-07-03T00:00:00Z");
 
-  it("seeds all 22 records and aggregates by dedup_key across agents", () => {
+  it("seeds all 23 records and aggregates by dedup_key across agents", () => {
     const findings = [
       dupFinding("clerk", 1),
       dupFinding("clerk", 2),
       dupFinding("marko", 3),
     ];
     const led = buildLedger(findings, { ownerAgent: "klanker", now });
-    expect(led.records).toHaveLength(23); // 22 job specs (delivery seeded once)
+    expect(led.records).toHaveLength(23); // 23 job specs (delivery seeded once)
     const delivery = led.records.find(
       (r) => r.job_spec === "talk-to-agents-from-anywhere",
     )!;

--- a/src/fleet-health/ledger.ts
+++ b/src/fleet-health/ledger.ts
@@ -29,11 +29,17 @@ import {
 export const RESOLVED_THRESHOLD = 3;
 
 /** A prior ledger's issue state, keyed by dedup_key, so the writer can carry
- *  forward the GH issue number and detect a count-drop for the close path. */
+ *  forward the GH issue number and detect a count-drop for the close path.
+ *  Carries the prior issue's identity fields too, so a dedup_key that vanished
+ *  from the current scan (a real fix drove its count to zero → no agg) can
+ *  still be synthesized as a closed issue and routed to its job spec. */
 export interface PriorIssueState {
   gh_issue?: number;
   frequency: number;
   status: FleetHealthIssue["status"];
+  job_spec: string;
+  failure_mode: FleetHealthIssue["failure_mode"];
+  severity: number;
 }
 
 export function indexPriorIssues(
@@ -47,6 +53,9 @@ export function indexPriorIssues(
         gh_issue: iss.gh_issue,
         frequency: iss.frequency,
         status: iss.status,
+        job_spec: rec.job_spec,
+        failure_mode: iss.failure_mode,
+        severity: iss.severity,
       });
     }
   }
@@ -61,6 +70,9 @@ interface Agg {
   occurrences: FleetHealthOccurrence[];
   reach: Set<string>;
   newest: string | null;
+  /** Authoritative frequency — every finding for this key. Tracked during the
+   *  single aggregation pass to avoid an O(findings × aggs) re-filter later. */
+  count: number;
 }
 
 function newer(a: string | null, b: string | null): string | null {
@@ -79,7 +91,7 @@ export interface BuildLedgerOptions {
 
 /**
  * Build the full ledger from a flat list of findings across the fleet. Seeds
- * all 22 job-spec records (empty ones score 0), aggregates findings into
+ * all 23 job-spec records (empty ones score 0), aggregates findings into
  * distinct issues by dedup_key, computes each issue's priority contribution,
  * and rolls the record's `priority_score` up as the max of its issues' scores
  * (the worst open problem drives the ranking — matches "severity of the worst
@@ -110,9 +122,11 @@ export function buildLedger(
         occurrences: [],
         reach: new Set(),
         newest: null,
+        count: 0,
       };
       aggs.set(key, agg);
     }
+    agg.count += 1;
     agg.reach.add(f.agent);
     agg.newest = newer(agg.newest, f.ts);
     // Cap stored occurrences to keep the ledger bounded; the count is the
@@ -129,11 +143,9 @@ export function buildLedger(
   // Group aggregated issues by job spec.
   const byJob = new Map<string, FleetHealthIssue[]>();
   for (const agg of aggs.values()) {
-    // Authoritative frequency = every finding for this key (occurrences are
-    // capped-at-50 evidence samples; the count is not).
-    const count = findings.filter(
-      (f) => dedupKeyFor(f) === agg.dedup_key,
-    ).length;
+    // Authoritative frequency = every finding for this key (counted during the
+    // single aggregation pass above; occurrences are capped-at-50 samples).
+    const count = agg.count;
     const prior = priorIdx.get(agg.dedup_key);
 
     let status: FleetHealthIssue["status"] = "open";
@@ -160,11 +172,40 @@ export function buildLedger(
     byJob.set(agg.job_spec, list);
   }
 
-  // Seed all 22 records; fill scored issues.
+  // Close-on-zero: a dedup_key that was open (or pending-verify) in the prior
+  // ledger but produced NO findings this scan has no agg above — the fix drove
+  // its count to zero. Synthesize a zero-frequency `closed` issue carrying the
+  // prior GH issue number so gh-sync runs `gh issue close`. This is the common
+  // success path, not an edge case: without it the issue leaks open forever.
+  for (const [dedup_key, prior] of priorIdx) {
+    if (aggs.has(dedup_key)) continue;
+    if (prior.status !== "open" && prior.status !== "resolved-pending-verify") {
+      continue;
+    }
+    const issue: FleetHealthIssue = {
+      dedup_key,
+      failure_mode: prior.failure_mode,
+      severity: prior.severity,
+      frequency: 0,
+      reach: [],
+      recency: null,
+      occurrences: [],
+      ...(prior.gh_issue !== undefined ? { gh_issue: prior.gh_issue } : {}),
+      status: "closed",
+    };
+    const list = byJob.get(prior.job_spec) ?? [];
+    list.push(issue);
+    byJob.set(prior.job_spec, list);
+  }
+
+  // Seed all 23 records; fill scored issues.
   const records: FleetHealthRecord[] = ALL_JOB_SPECS.map((job_spec) => {
-    const issues = (byJob.get(job_spec) ?? []).filter(
-      (i) => i.status !== "closed",
-    );
+    // Retain `closed` issues in the record for THIS cycle so gh-sync
+    // (`syncLedgerIssues`, run by the caller after `buildLedger`) sees them and
+    // runs `gh issue close`. They carry no open weight (excluded from
+    // open_issue_count / priority_score below) and drop out next cycle: prior
+    // status is then `closed`, so the close-on-zero synthesis skips them.
+    const issues = byJob.get(job_spec) ?? [];
     const openIssues = issues.filter((i) => i.status === "open");
     const priority_score = issues.reduce((max, i) => {
       const s = issuePriority(
@@ -178,6 +219,7 @@ export function buildLedger(
       return Math.max(max, s);
     }, 0);
     const gh_issues = issues
+      .filter((i) => i.status !== "closed")
       .map((i) => i.gh_issue)
       .filter((n): n is number => typeof n === "number");
     return {

--- a/src/fleet-health/ledger.ts
+++ b/src/fleet-health/ledger.ts
@@ -1,0 +1,209 @@
+/**
+ * Fleet Health — the ledger writer. Aggregates the model-free detector's
+ * findings (across all agents) into the exact on-disk shape the read-side
+ * (`src/web/fleet-health-read.ts`) consumes: one record per job spec, distinct
+ * issues keyed by dedup_key, priority scored per the RFC.
+ *
+ * Design: `reference/rfcs/fleet-health.md`. Pure aggregation — no I/O, no
+ * model call — so it round-trips cleanly under test (`readFleetHealth` accepts
+ * exactly what `buildLedger` emits).
+ */
+
+import type {
+  FleetHealthLedger,
+  FleetHealthRecord,
+  FleetHealthIssue,
+  FleetHealthOccurrence,
+} from "../web/fleet-health-read.js";
+import type { Finding } from "./detect.js";
+import {
+  ALL_JOB_SPECS,
+  mapSignal,
+  dedupKeyFor,
+  issuePriority,
+} from "./mapping.js";
+
+/** Below this occurrence count, a previously-open issue is considered fixed —
+ *  it flips to `resolved-pending-verify` and its GH issue closes on the next
+ *  verified scan (the RFC count-drop self-verify; e.g. 282 → ~2). */
+export const RESOLVED_THRESHOLD = 3;
+
+/** A prior ledger's issue state, keyed by dedup_key, so the writer can carry
+ *  forward the GH issue number and detect a count-drop for the close path. */
+export interface PriorIssueState {
+  gh_issue?: number;
+  frequency: number;
+  status: FleetHealthIssue["status"];
+}
+
+export function indexPriorIssues(
+  prior: FleetHealthLedger | null,
+): Map<string, PriorIssueState> {
+  const idx = new Map<string, PriorIssueState>();
+  if (!prior?.records) return idx;
+  for (const rec of prior.records) {
+    for (const iss of rec.issues ?? []) {
+      idx.set(iss.dedup_key, {
+        gh_issue: iss.gh_issue,
+        frequency: iss.frequency,
+        status: iss.status,
+      });
+    }
+  }
+  return idx;
+}
+
+interface Agg {
+  dedup_key: string;
+  job_spec: string;
+  failure_mode: FleetHealthIssue["failure_mode"];
+  severity: number;
+  occurrences: FleetHealthOccurrence[];
+  reach: Set<string>;
+  newest: string | null;
+}
+
+function newer(a: string | null, b: string | null): string | null {
+  if (!a) return b;
+  if (!b) return a;
+  return Date.parse(a) >= Date.parse(b) ? a : b;
+}
+
+export interface BuildLedgerOptions {
+  ownerAgent?: string;
+  now?: Date;
+  windowDays?: number;
+  prior?: FleetHealthLedger | null;
+  summary?: string;
+}
+
+/**
+ * Build the full ledger from a flat list of findings across the fleet. Seeds
+ * all 22 job-spec records (empty ones score 0), aggregates findings into
+ * distinct issues by dedup_key, computes each issue's priority contribution,
+ * and rolls the record's `priority_score` up as the max of its issues' scores
+ * (the worst open problem drives the ranking — matches "severity of the worst
+ * open issue" the page shows). Carries forward GH issue numbers from `prior`
+ * and applies the count-drop status transition.
+ */
+export function buildLedger(
+  findings: Finding[],
+  opts: BuildLedgerOptions = {},
+): FleetHealthLedger {
+  const now = opts.now ?? new Date();
+  const windowDays = opts.windowDays ?? 30;
+  const priorIdx = indexPriorIssues(opts.prior ?? null);
+  const nowIso = now.toISOString();
+
+  // Aggregate findings by dedup_key.
+  const aggs = new Map<string, Agg>();
+  for (const f of findings) {
+    const m = mapSignal(f.signal);
+    const key = dedupKeyFor(f);
+    let agg = aggs.get(key);
+    if (!agg) {
+      agg = {
+        dedup_key: key,
+        job_spec: m.job_spec,
+        failure_mode: m.failure_mode,
+        severity: m.severity,
+        occurrences: [],
+        reach: new Set(),
+        newest: null,
+      };
+      aggs.set(key, agg);
+    }
+    agg.reach.add(f.agent);
+    agg.newest = newer(agg.newest, f.ts);
+    // Cap stored occurrences to keep the ledger bounded; the count is the
+    // authoritative frequency (occurrences are evidence samples).
+    if (agg.occurrences.length < 50) {
+      agg.occurrences.push({
+        agent: f.agent,
+        turn_id: f.turn_id,
+        log_pointer: f.log_pointer,
+      });
+    }
+  }
+
+  // Group aggregated issues by job spec.
+  const byJob = new Map<string, FleetHealthIssue[]>();
+  for (const agg of aggs.values()) {
+    // Authoritative frequency = every finding for this key (occurrences are
+    // capped-at-50 evidence samples; the count is not).
+    const count = findings.filter(
+      (f) => dedupKeyFor(f) === agg.dedup_key,
+    ).length;
+    const prior = priorIdx.get(agg.dedup_key);
+
+    let status: FleetHealthIssue["status"] = "open";
+    if (count <= RESOLVED_THRESHOLD && prior && prior.frequency > RESOLVED_THRESHOLD) {
+      // count dropped after a fix → pending verification.
+      status = "resolved-pending-verify";
+    } else if (prior?.status === "resolved-pending-verify" && count <= RESOLVED_THRESHOLD) {
+      status = "closed";
+    }
+
+    const issue: FleetHealthIssue = {
+      dedup_key: agg.dedup_key,
+      failure_mode: agg.failure_mode,
+      severity: agg.severity,
+      frequency: count,
+      reach: [...agg.reach].sort(),
+      recency: agg.newest,
+      occurrences: agg.occurrences,
+      ...(prior?.gh_issue !== undefined ? { gh_issue: prior.gh_issue } : {}),
+      status,
+    };
+    const list = byJob.get(agg.job_spec) ?? [];
+    list.push(issue);
+    byJob.set(agg.job_spec, list);
+  }
+
+  // Seed all 22 records; fill scored issues.
+  const records: FleetHealthRecord[] = ALL_JOB_SPECS.map((job_spec) => {
+    const issues = (byJob.get(job_spec) ?? []).filter(
+      (i) => i.status !== "closed",
+    );
+    const openIssues = issues.filter((i) => i.status === "open");
+    const priority_score = issues.reduce((max, i) => {
+      const s = issuePriority(
+        i.severity,
+        i.frequency,
+        i.reach.length,
+        i.recency,
+        now,
+        windowDays,
+      );
+      return Math.max(max, s);
+    }, 0);
+    const gh_issues = issues
+      .map((i) => i.gh_issue)
+      .filter((n): n is number => typeof n === "number");
+    return {
+      job_spec,
+      open_issue_count: openIssues.length,
+      last_scanned: nowIso,
+      priority_score: Number(priority_score.toFixed(4)),
+      gh_issues,
+      last_deep_dive: findLastDeepDive(opts.prior ?? null, job_spec),
+      issues,
+    };
+  });
+
+  return {
+    ...(opts.ownerAgent ? { owner_agent: opts.ownerAgent } : {}),
+    generated_at: nowIso,
+    ...(opts.summary ? { summary: opts.summary } : {}),
+    records,
+  };
+}
+
+function findLastDeepDive(
+  prior: FleetHealthLedger | null,
+  job_spec: string,
+): string | null {
+  if (!prior?.records) return null;
+  const rec = prior.records.find((r) => r.job_spec === job_spec);
+  return rec?.last_deep_dive ?? null;
+}

--- a/src/fleet-health/mapping.test.ts
+++ b/src/fleet-health/mapping.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  SIGNAL_MAP,
+  ALL_JOB_SPECS,
+  dedupKeyFor,
+  frequencyFactor,
+  recencyFactor,
+  reachFactor,
+  issuePriority,
+} from "./mapping.js";
+import type { Finding } from "./detect.js";
+
+describe("signal → job-spec mapping", () => {
+  it("maps every L0 signal to a real job spec + taxonomy class", () => {
+    for (const [, m] of Object.entries(SIGNAL_MAP)) {
+      expect(ALL_JOB_SPECS).toContain(m.job_spec);
+      expect(m.severity).toBeGreaterThanOrEqual(1);
+      expect(m.severity).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it("routes the represent-duplicate case to delivery, severity 2", () => {
+    const m = SIGNAL_MAP["duplicate-delivery-represent"];
+    expect(m.job_spec).toBe("talk-to-agents-from-anywhere");
+    expect(m.failure_mode).toBe("duplicate");
+    expect(m.severity).toBe(2);
+  });
+
+  it("routes a silent no-op to know-what-my-agent-is-doing, severity 3", () => {
+    const m = SIGNAL_MAP["silent-no-op-candidate"];
+    expect(m.job_spec).toBe("know-what-my-agent-is-doing");
+    expect(m.severity).toBe(3);
+  });
+
+  it("builds a stable dedup key <job_spec>:<signature>", () => {
+    const f: Finding = {
+      signal: "duplicate-delivery-represent",
+      agent: "clerk",
+      turn_id: "x",
+      log_pointer: "y",
+      ts: null,
+    };
+    expect(dedupKeyFor(f)).toBe(
+      "talk-to-agents-from-anywhere:represent-duplicate-send:reply-tool-not-called",
+    );
+  });
+});
+
+describe("priority score math (severity × frequency × reach × recency)", () => {
+  it("frequency uses log10(1+count)", () => {
+    expect(frequencyFactor(0)).toBeCloseTo(0);
+    expect(frequencyFactor(9)).toBeCloseTo(1);
+    expect(frequencyFactor(99)).toBeCloseTo(2);
+  });
+
+  it("reach is the distinct-agent count, floored at 1", () => {
+    expect(reachFactor(0)).toBe(1);
+    expect(reachFactor(2)).toBe(2);
+  });
+
+  it("recency: 1.0 within 24h, ~0.1 at window edge, 0 if never", () => {
+    const now = new Date("2026-07-03T00:00:00Z");
+    expect(recencyFactor(null, now)).toBe(0);
+    expect(recencyFactor("2026-07-02T12:00:00Z", now)).toBe(1.0);
+    // 30 days old = window edge.
+    expect(recencyFactor("2026-06-03T00:00:00Z", now, 30)).toBeCloseTo(0.1, 5);
+  });
+
+  it("a rare-but-severe issue can outrank a frequent-but-cosmetic one", () => {
+    const now = new Date("2026-07-03T00:00:00Z");
+    const fresh = "2026-07-02T23:00:00Z";
+    // severe(3), rare(5), 2 agents, fresh
+    const severe = issuePriority(3, 5, 2, fresh, now);
+    // cosmetic(1), frequent(282), 1 agent, fresh
+    const cosmetic = issuePriority(1, 282, 1, fresh, now);
+    expect(severe).toBeGreaterThan(cosmetic);
+  });
+
+  it("recency decay sinks a fixed issue toward zero as occurrences stop", () => {
+    const now = new Date("2026-07-03T00:00:00Z");
+    const stale = issuePriority(3, 282, 2, "2026-06-04T00:00:00Z", now, 30);
+    const active = issuePriority(3, 282, 2, "2026-07-02T23:00:00Z", now, 30);
+    expect(stale).toBeLessThan(active);
+  });
+});

--- a/src/fleet-health/mapping.ts
+++ b/src/fleet-health/mapping.ts
@@ -1,0 +1,182 @@
+/**
+ * Fleet Health — the signal→job-spec mapping, failure-mode taxonomy, and
+ * priority scoring. Design: `reference/rfcs/fleet-health.md`.
+ *
+ * This is the model-free classification layer: it takes the L0 detector's
+ * signals (hard artifacts) and (a) classifies each into the RFC's 9-class
+ * failure-mode taxonomy, (b) maps it to one of the 22 job specs, and (c)
+ * computes `priority_score = severity × frequency × reach × recency`.
+ *
+ * No model judgment enters any of this — the mapping table is explicit and the
+ * scoring is arithmetic, exactly as the RFC specifies.
+ */
+
+import type { FleetHealthFailureMode } from "../web/fleet-health-read.js";
+import type { L0Signal, Finding } from "./detect.js";
+
+/** How one L0 signal classifies: its failure mode, severity (1-3), the job
+ *  spec it maps to, and the stable dedup-key signature fragment. */
+export interface SignalMapping {
+  failure_mode: FleetHealthFailureMode;
+  severity: number;
+  /** `reference/jobs/<slug>.md` id — the join key + GitHub `job:<slug>` label. */
+  job_spec: string;
+  /** Fragment used to build the dedup key (`<job_spec>:<signature>`). */
+  signature: string;
+}
+
+/**
+ * The explicit signal→job-spec mapping table. Each L0 signal is a hard
+ * artifact; here we pin it to the best-fit job spec (derived by reading the 22
+ * `reference/jobs/*.md`) and the RFC failure-mode taxonomy.
+ *
+ * Rationale (also documented in the RFC):
+ * - `silent-no-op-candidate` → `know-what-my-agent-is-doing`: a turn that
+ *   completed with zero tools while reporting success is the canonical silent
+ *   no-op — the operator cannot tell the agent did nothing. severity 3.
+ * - `duplicate-delivery-represent` / `reply-delivery-failure` →
+ *   `talk-to-agents-from-anywhere`: the answer's delivery to the principal is
+ *   the job; a duplicate send or a failed `sendRichMessage` is a delivery
+ *   defect on that job. (The clerk/marko represent-duplicate case the RFC
+ *   validated on lands here.) duplicate = severity 2, delivery-failure = 3.
+ * - `hang-long-stalled` / `killed-incomplete-turn` →
+ *   `steer-or-queue-mid-flight`: a turn that hangs or is killed mid-flight is
+ *   a responsiveness failure on the in-flight-control job. hang = 2, killed = 3
+ *   (the job was abandoned incomplete while in progress).
+ * - `represent-escalation` → `feel-like-a-colleague`: an obligation escalation
+ *   is a UX-friction signal (the gateway had to nudge on the agent's behalf).
+ *   severity 1 — informational; on its own it does not open a sev-3 issue.
+ */
+export const SIGNAL_MAP: Record<L0Signal, SignalMapping> = {
+  "silent-no-op-candidate": {
+    failure_mode: "silent-no-op",
+    severity: 3,
+    job_spec: "know-what-my-agent-is-doing",
+    signature: "silent-no-op:completed-zero-tools",
+  },
+  "duplicate-delivery-represent": {
+    failure_mode: "duplicate",
+    severity: 2,
+    job_spec: "talk-to-agents-from-anywhere",
+    signature: "represent-duplicate-send:reply-tool-not-called",
+  },
+  "reply-delivery-failure": {
+    failure_mode: "success-theater",
+    severity: 3,
+    job_spec: "talk-to-agents-from-anywhere",
+    signature: "reply-delivery-failure:sendRichMessage-err",
+  },
+  "hang-long-stalled": {
+    failure_mode: "partial",
+    severity: 2,
+    job_spec: "steer-or-queue-mid-flight",
+    signature: "hang:long-stalled-turn",
+  },
+  "killed-incomplete-turn": {
+    failure_mode: "missed-trigger",
+    severity: 3,
+    job_spec: "steer-or-queue-mid-flight",
+    signature: "killed:incomplete-turn",
+  },
+  "represent-escalation": {
+    failure_mode: "drift",
+    severity: 1,
+    job_spec: "feel-like-a-colleague",
+    signature: "represent:obligation-escalation",
+  },
+};
+
+/** The full set of 22 job-spec slugs the ledger carries a record for. Kept
+ *  here so the writer can seed all 22 records (empty ones score 0). */
+export const ALL_JOB_SPECS: readonly string[] = [
+  "act-in-my-tools-with-an-identity",
+  "approve-what-my-agent-can-touch",
+  "crons-use-the-model-only-when-it-earns-it",
+  "deliver-files-i-can-open",
+  "extend-without-forking",
+  "feel-like-a-colleague",
+  "fleet-stays-healthy",
+  "get-better-the-longer-they-run",
+  "get-from-zero-to-a-working-fleet",
+  "give-each-agent-its-own-workspace",
+  "idempotent-update-and-restart",
+  "keep-my-subscription-honest",
+  "know-what-my-agent-is-doing",
+  "operate-the-fleet-from-telegram",
+  "remember-across-sessions",
+  "restart-and-know-what-im-running",
+  "run-a-fleet-of-specialists",
+  "see-my-whole-fleet-from-one-screen",
+  "share-auth-across-the-fleet",
+  "steer-or-queue-mid-flight",
+  "survive-reboots-and-real-life",
+  "talk-to-agents-from-anywhere",
+  "track-plan-quota-live",
+];
+
+export function mapSignal(signal: L0Signal): SignalMapping {
+  return SIGNAL_MAP[signal];
+}
+
+/** The stable dedup key for a finding: `<job_spec>:<signature>`. One GitHub
+ *  issue per key (updated, never re-created). */
+export function dedupKeyFor(finding: Finding): string {
+  const m = mapSignal(finding.signal);
+  return `${m.job_spec}:${m.signature}`;
+}
+
+/**
+ * Frequency factor: `log10(1 + count)` so a 282-count issue meaningfully
+ * outranks a 20-count one without swamping the other three factors (RFC).
+ */
+export function frequencyFactor(count: number): number {
+  return Math.log10(1 + Math.max(0, count));
+}
+
+/**
+ * Recency factor: 1.0 within 24h of `now`, decaying linearly to 0.1 at the
+ * scan-window edge (`windowDays`, default 30). A failure fixed a month ago
+ * sinks; a fresh one floats — this is what closes the loop after a fix (RFC).
+ * `newestIso` null (no occurrences) → 0.
+ */
+export function recencyFactor(
+  newestIso: string | null,
+  now: Date = new Date(),
+  windowDays = 30,
+): number {
+  if (!newestIso) return 0;
+  const newest = Date.parse(newestIso);
+  if (!Number.isFinite(newest)) return 0;
+  const ageMs = now.getTime() - newest;
+  const dayMs = 86_400_000;
+  if (ageMs <= dayMs) return 1.0;
+  const windowMs = windowDays * dayMs;
+  if (ageMs >= windowMs) return 0.1;
+  // linear from 1.0 (at 24h) down to 0.1 (at window edge).
+  const frac = (ageMs - dayMs) / (windowMs - dayMs);
+  return 1.0 - frac * 0.9;
+}
+
+/** Reach factor: number of distinct agents exhibiting the issue (RFC uses
+ *  `|reach|` directly — a fleet-wide failure outweighs a one-agent quirk). */
+export function reachFactor(reachCount: number): number {
+  return Math.max(1, reachCount);
+}
+
+/** The per-issue priority contribution: severity × frequency × reach × recency.
+ *  Exactly the RFC formula. */
+export function issuePriority(
+  severity: number,
+  frequency: number,
+  reachCount: number,
+  newestIso: string | null,
+  now: Date = new Date(),
+  windowDays = 30,
+): number {
+  return (
+    severity *
+    frequencyFactor(frequency) *
+    reachFactor(reachCount) *
+    recencyFactor(newestIso, now, windowDays)
+  );
+}

--- a/src/fleet-health/mapping.ts
+++ b/src/fleet-health/mapping.ts
@@ -4,7 +4,7 @@
  *
  * This is the model-free classification layer: it takes the L0 detector's
  * signals (hard artifacts) and (a) classifies each into the RFC's 9-class
- * failure-mode taxonomy, (b) maps it to one of the 22 job specs, and (c)
+ * failure-mode taxonomy, (b) maps it to one of the 23 job specs, and (c)
  * computes `priority_score = severity × frequency × reach × recency`.
  *
  * No model judgment enters any of this — the mapping table is explicit and the
@@ -86,8 +86,8 @@ export const SIGNAL_MAP: Record<L0Signal, SignalMapping> = {
   },
 };
 
-/** The full set of 22 job-spec slugs the ledger carries a record for. Kept
- *  here so the writer can seed all 22 records (empty ones score 0). */
+/** The full set of 23 job-spec slugs the ledger carries a record for. Kept
+ *  here so the writer can seed all 23 records (empty ones score 0). */
 export const ALL_JOB_SPECS: readonly string[] = [
   "act-in-my-tools-with-an-identity",
   "approve-what-my-agent-can-touch",

--- a/src/fleet-health/scan.ts
+++ b/src/fleet-health/scan.ts
@@ -1,0 +1,155 @@
+/**
+ * Fleet Health — the scan orchestration (I/O boundary). Iterates every agent
+ * under `~/.switchroom/agents/*`, reads each agent's `turns.jsonl` +
+ * `../logs/<agent>/gateway-supervisor.log`, runs the model-free L0 detectors,
+ * aggregates into the priority ledger, and (optionally) writes it +
+ * synchronizes GitHub issues.
+ *
+ * Design: `reference/rfcs/fleet-health.md`. Defensive: an agent with a missing
+ * or malformed `turns.jsonl` is skipped with a warning, never crashes the whole
+ * scan.
+ */
+
+import {
+  readFileSync,
+  readdirSync,
+  existsSync,
+  mkdirSync,
+  writeFileSync,
+} from "node:fs";
+import { resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+
+import type { FleetHealthLedger } from "../web/fleet-health-read.js";
+import { fleetHealthLedgerPath } from "../web/fleet-health-read.js";
+import { scanAgent, type Finding, type AgentScanResult } from "./detect.js";
+import { buildLedger } from "./ledger.js";
+
+/**
+ * Resolve the `.switchroom` base dir, matching the read-side
+ * (`SWITCHROOM_HOME` → `HOME` → os.homedir()). The agents live under
+ * `<base>/.switchroom/agents` and logs under `<base>/.switchroom/logs`.
+ */
+export function resolveSwitchroomBase(
+  home: string = process.env.SWITCHROOM_HOME ?? process.env.HOME ?? homedir(),
+): string {
+  return resolve(home, ".switchroom");
+}
+
+export interface ScanOptions {
+  base?: string;
+  ownerAgent?: string;
+  now?: Date;
+  windowDays?: number;
+  log?: (msg: string) => void;
+}
+
+export interface ScanResult {
+  ledger: FleetHealthLedger;
+  perAgent: AgentScanResult[];
+  agentsScanned: number;
+  agentsSkipped: string[];
+}
+
+/** List agent slugs under `<base>/agents` (directories only). */
+export function listAgents(base: string): string[] {
+  const dir = resolve(base, "agents");
+  if (!existsSync(dir)) return [];
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Run the full fleet scan. Pure of side effects except reading the agent
+ * artifacts — it does NOT write the ledger or touch GitHub (the CLI does that,
+ * gated behind flags).
+ */
+export function runScan(opts: ScanOptions = {}): ScanResult {
+  const base = opts.base ?? resolveSwitchroomBase();
+  const log = opts.log ?? (() => {});
+  const agents = listAgents(base);
+
+  const findings: Finding[] = [];
+  const perAgent: AgentScanResult[] = [];
+  const skipped: string[] = [];
+  let scanned = 0;
+
+  for (const agent of agents) {
+    const turnsPath = resolve(base, "agents", agent, "turns.jsonl");
+    const gwPath = resolve(base, "logs", agent, "gateway-supervisor.log");
+    let turnsText = "";
+    let gwText = "";
+    let sawArtifact = false;
+    try {
+      if (existsSync(turnsPath)) {
+        turnsText = readFileSync(turnsPath, "utf-8");
+        sawArtifact = true;
+      }
+    } catch (e) {
+      log(`fleet-health: WARN skipping ${agent} turns.jsonl unreadable: ${String(e)}`);
+    }
+    try {
+      if (existsSync(gwPath)) {
+        gwText = readFileSync(gwPath, "utf-8");
+        sawArtifact = true;
+      }
+    } catch (e) {
+      log(`fleet-health: WARN ${agent} gateway log unreadable: ${String(e)}`);
+    }
+    if (!sawArtifact) {
+      skipped.push(agent);
+      continue;
+    }
+    try {
+      const res = scanAgent(agent, turnsText, gwText);
+      perAgent.push(res);
+      findings.push(...res.findings);
+      scanned++;
+    } catch (e) {
+      log(`fleet-health: WARN scan failed for ${agent}: ${String(e)}`);
+      skipped.push(agent);
+    }
+  }
+
+  const prior = readLedgerIfPresent(base);
+  const ledger = buildLedger(findings, {
+    ownerAgent: opts.ownerAgent,
+    now: opts.now,
+    windowDays: opts.windowDays,
+    prior,
+  });
+
+  return { ledger, perAgent, agentsScanned: scanned, agentsSkipped: skipped };
+}
+
+/** Read the existing ledger (for GH-number carry-forward + count-drop), or
+ *  null if absent/unreadable. */
+export function readLedgerIfPresent(base: string): FleetHealthLedger | null {
+  const path = ledgerPathForBase(base);
+  try {
+    if (!existsSync(path)) return null;
+    return JSON.parse(readFileSync(path, "utf-8")) as FleetHealthLedger;
+  } catch {
+    return null;
+  }
+}
+
+/** The ledger path for a given base dir (`<base>/fleet-health/ledger.json`).
+ *  Delegates to the read-side resolver so writer + reader can never diverge. */
+export function ledgerPathForBase(base: string): string {
+  return fleetHealthLedgerPath(dirname(base));
+}
+
+/** Write the ledger to disk (creating the dir), pretty-printed. */
+export function writeLedger(base: string, ledger: FleetHealthLedger): string {
+  const path = ledgerPathForBase(base);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(ledger, null, 2) + "\n", "utf-8");
+  return path;
+}

--- a/src/web/fleet-health-read.ts
+++ b/src/web/fleet-health-read.ts
@@ -66,7 +66,7 @@ export interface FleetHealthIssue {
   status: FleetHealthIssueStatus;
 }
 
-/** One persistent record per job spec (22 of them). */
+/** One persistent record per job spec (23 of them). */
 export interface FleetHealthRecord {
   /** The `reference/jobs/<slug>.md` id — join key to the spec + GH label. */
   job_spec: string;

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -1270,7 +1270,7 @@
       }
     }
 
-    // Fleet Health — the 22 job specs ranked worst-first by priority_score
+    // Fleet Health — the 23 job specs ranked worst-first by priority_score
     // (severity × frequency × reach × recency). Each spec drills down to its
     // distinct issues; each issue links to its occurrences (turn_ids + log
     // pointers) and its GitHub issue. Empty state when no owner agent is


### PR DESCRIPTION
## What

The **live detection pipeline** for Fleet Health — the machinery that populates the ledger the admin page (#2748) reads. Serves the job `reference/jobs/fleet-stays-healthy.md` (outcome `always-available`), per `reference/rfcs/fleet-health.md`.

A new `switchroom fleet-health` CLI verb:

- **`scan`** — the nightly **model-free (zero-token)** sensor. Iterates every agent under `~/.switchroom/agents/*`, reads each agent's `turns.jsonl` + `logs/<agent>/gateway-supervisor.log`, runs the L0 detectors (ported verbatim from the validated reference detector), classifies each finding into the 9-class failure-mode taxonomy, maps it to one of the 22 job specs, scores it, and writes `~/.switchroom/fleet-health/ledger.json` in the exact shape `src/web/fleet-health-read.ts` consumes. `--dry-run` / `--json` supported.
- **`scan --sync-issues`** — the GitHub issue lifecycle: opens one issue per distinct problem (`dedup_key`), updates occurrences + count on re-scan, closes on a verified count-drop. Labels `fleet-health`, `severity:1|2|3`, `job:<slug>`. **Default-off / network-guarded** so CI + tests never hit the network; no-ops with a clear log line if `gh` is unavailable.
- **`deep-dive-targets`** — prints the top-N ledger records as a structured brief the owner agent's weekly Opus deep-dive cron consumes. The CLI calls no model — the deep-dive's token spend stays in the agent's own budgeted session (claude-native, no `claude -p`).
- **`mapping`** — prints the signal→job-spec table.

## Why

#2748 shipped the read side (typed reader + admin page) and the `fleet_health.owner_agent` config field, but nothing wrote the ledger. This is that writer.

## The L0 port (load-bearing constants, unchanged)

`HANG_MS=360000` (>6 min, p99=303s), `HANG_MAXTOOLS=2` (long+stalled = hang, long+productive = deep work), `synthetic-` turn-ids excluded, precise gateway signatures (`represent duplicate-send`, `tg-post method=sendRichMessage … status=err`) so a `getUpdates` blip never counts as a delivery failure. `turn_id` is the join key.

## Signal → job-spec mapping

| L0 signal | Failure mode | Sev | Job spec |
|---|---|---|---|
| `silent-no-op-candidate` | silent-no-op | 3 | `know-what-my-agent-is-doing` |
| `duplicate-delivery-represent` | duplicate | 2 | `talk-to-agents-from-anywhere` |
| `reply-delivery-failure` | success-theater | 3 | `talk-to-agents-from-anywhere` |
| `hang-long-stalled` | partial | 2 | `steer-or-queue-mid-flight` |
| `killed-incomplete-turn` | missed-trigger | 3 | `steer-or-queue-mid-flight` |
| `represent-escalation` | drift | 1 | `feel-like-a-colleague` |

## Scoring (as implemented, `src/fleet-health/mapping.ts`)

`priority_score = severity × frequency × reach × recency` — frequency `log10(1+count)`, reach = distinct agents (floored 1), recency 1.0 within 24h decaying to 0.1 at the window edge. Record score = max over its open issues.

## Owner-agent crons (documented, not committed)

Nightly `0 2 * * *` → `fleet-health scan --sync-issues` (model-free); weekly `30 2 * * 1` → `deep-dive-targets` → Opus deep-dive (budgeted, top 1-2). Wired by the operator or owner agent via `schedule_add` **after merge** — never a self-authored loop. No per-agent cron config or ledger state committed.

## Verdict-rule checklist

- **Advances a vision outcome** — `always-available` (up *and correct*).
- **Satisfies the job spec** — `fleet-stays-healthy` (detect/rank/close).
- **Principle checks** — docs: CLI + `docs/fleet-health.md` self-explain; defaults: inert until an owner is assigned + sync default-off; consistency: same operator-page shape + config cascade + tiered-cron model.
- **Invariants** — `chat-is-the-single-source-of-truth`, `no-self-escalation`, `on-leash`, `single-tenant`, `claude-native` (L0 zero-token; deep-dive is an ordinary budgeted turn, never `claude -p`).

## Tests

vitest, all network-free: detector port, signal→spec mapping, priority-score math, ledger round-trip (write → `readFleetHealth` returns ranked non-empty), GH sync via injected deps. `npm run lint` (incl. `check-no-pii-secrets`) and `npm run build` pass; fixtures use synthetic ids only.

Pre-existing env-only failures (`apply`/scaffold filesystem-mode assertions when run as root) are unrelated — no `apply.ts` change in this PR.

**CI must gate merge.** Do not merge until checks are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)