### PR TITLE
chore(deps): bump claude-code CLI 2.1.197 -> 2.1.199

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -154,7 +154,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # (`--build-arg CLAUDE_CODE_VERSION=<latest>`) to build a throwaway image on the
 # next version and prove it boots BEFORE the pin is bumped. Keep this default in
 # lockstep with docker/Dockerfile.hindsight's CLAUDE_CODE_VERSION (#1978).
-ARG CLAUDE_CODE_VERSION=2.1.197
+ARG CLAUDE_CODE_VERSION=2.1.199
 # Fail-fast: if the npm install or the resulting binary is broken we
 # want the image build to die here, not produce a base that ships
 # downstream and explodes at agent boot. Previously this had a

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -51,7 +51,7 @@ USER root
 # claude bundle as the agent containers — a version skew here could reintroduce
 # the thinking-block / thinking-effort class of failures on memory reflection
 # (see #1978). The canary overrides it the same way base does.
-ARG CLAUDE_CODE_VERSION=2.1.197
+ARG CLAUDE_CODE_VERSION=2.1.199
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
  && claude --version >&2
 


### PR DESCRIPTION
Bumps the lockstep `CLAUDE_CODE_VERSION` build-arg in `docker/Dockerfile.base` and `docker/Dockerfile.hindsight` from `2.1.197` to `2.1.199`.

**What 2.1.199 brings (vs 2.1.197):**
- 2.1.198: subagents run in the background by default; new `agent_needs_input`/`agent_completed` Notification hook events; Explore agent inherits session model (capped opus); subagents+compaction inherit extended-thinking config
- 2.1.199: subagents cut off by rate-limit/server error return partial work instead of silently failing; API errors reported to parent instead of faking success; SessionStart/Setup/SubagentStart hooks no longer swallow stderr on exit 2; Linux background-agent daemon self-kill fix

SDK pin (`claude-agent-sdk==0.2.87`) is intentionally left unchanged — it's decoupled from the CLI version.

Rides the next release roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)