### PR TITLE
feat(rollout): re-pull + recreate hindsight as a rollout step

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -263,8 +263,15 @@ export function registerMemoryCommand(program: Command): void {
       "--recreate",
       "Pull the latest image and recreate the container (reusing its current port). Used by `switchroom update` to keep the hindsight singleton current.",
     )
+    .option(
+      "--tag <version>",
+      "Pin the hindsight image tag to pull + run (e.g. v0.15.18), overriding the " +
+        "default floating `:latest`. Threaded through by `switchroom rollout` so a " +
+        "version-pinned roll recreates hindsight on the SAME tag as the rest of the " +
+        "fleet. Omit for `:latest` (the standalone default).",
+    )
     .option("--provider <provider>", "LLM provider (ollama, openai, anthropic)")
-    .action(async (opts: { stop?: boolean; status?: boolean; recreate?: boolean; provider?: string }) => {
+    .action(async (opts: { stop?: boolean; status?: boolean; recreate?: boolean; tag?: string; provider?: string }) => {
       if (opts.status) {
         if (!isDockerAvailable()) {
           console.log(chalk.red("  Docker is not available."));
@@ -320,9 +327,13 @@ export function registerMemoryCommand(program: Command): void {
       }
 
       if (recreate) {
-        console.log(chalk.gray("  Pulling latest Hindsight image..."));
+        console.log(
+          chalk.gray(
+            `  Pulling ${opts.tag ? `Hindsight image ${opts.tag}` : "latest Hindsight image"}...`,
+          ),
+        );
         try {
-          pullHindsightImage();
+          pullHindsightImage(opts.tag);
         } catch (err) {
           console.error(chalk.red(`\n  Failed to pull Hindsight image: ${(err as Error).message}\n`));
           process.exit(1);
@@ -376,7 +387,7 @@ export function registerMemoryCommand(program: Command): void {
       console.log(chalk.gray("  Starting Hindsight Docker container..."));
       try {
         const litellmCfg = await resolveLiteLLMForHindsight(getConfig(program));
-        startHindsight(ports, litellmCfg);
+        startHindsight(ports, litellmCfg, opts.tag);
         if (litellmCfg) {
           console.log(chalk.gray("  LiteLLM routing enabled for hindsight (--network host)."));
         }

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -117,6 +117,13 @@ describe("formatRolloutPlan", () => {
 function harness(opts: {
   versions: Record<string, string | null>;
   runStatus?: (args: string[]) => number;
+  /**
+   * Inject the standalone-hindsight-container probe so the refresh-hindsight
+   * branch runs without docker. Defaults to false (no container → the step
+   * no-ops), matching a CI host with no hindsight — which is why the
+   * pre-existing web/hostd tests never trip the hindsight run.
+   */
+  hindsightExists?: boolean;
 }): {
   deps: RolloutDeps;
   runs: string[][];
@@ -137,6 +144,7 @@ function harness(opts: {
     log: (line) => logs.push(line),
     emitPhase: (p) => phases.push(p),
     persistPin: (pin) => persisted.push(pin),
+    hindsightExists: () => opts.hindsightExists ?? false,
   };
   return { deps, runs, logs, persisted, phases };
 }
@@ -248,6 +256,63 @@ describe("executeRollout", () => {
     // target carries the v-prefix; in-container version does not.
     const r = executeRollout(steps, "v0.15.18", deps);
     expect(r.ok).toBe(true);
+  });
+});
+
+// ── #2752 refresh-hindsight — pinned tag + fatal recreate ─────────────────
+
+describe("executeRollout — refresh-hindsight (#2752)", () => {
+  const TARGET = "v0.15.18";
+
+  it("no-ops cleanly when no hindsight container exists (never runs memory setup)", () => {
+    const steps = planRollout(["clerk"]);
+    const { deps, runs } = harness({
+      versions: { clerk: "0.15.18" },
+      hindsightExists: false,
+    });
+    const r = executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(true);
+    expect(runs.some((a) => a[0] === "memory")).toBe(false);
+  });
+
+  it("Fix 1: passes --tag <target> so the recreate pulls the PINNED image, not :latest", () => {
+    const steps = planRollout(["clerk"]);
+    const { deps, runs } = harness({
+      versions: { clerk: "0.15.18" },
+      hindsightExists: true,
+    });
+    const r = executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(true);
+    expect(runs).toContainEqual(["memory", "setup", "--recreate", "--tag", TARGET]);
+  });
+
+  it("Fix 2: a recreate FAILURE is FATAL — flips ok:false and stops the roll", () => {
+    const steps = planRollout(["clerk"]);
+    const { deps } = harness({
+      versions: { clerk: "0.15.18" },
+      hindsightExists: true,
+      // Only the hindsight recreate fails; agent restart + apply succeed.
+      runStatus: (args) => (args[0] === "memory" ? 1 : 0),
+    });
+    const r = executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(false);
+    expect(r.failedStep).toBe("refresh-hindsight");
+    // NOT folded into the generic non-fatal web/hostd warning string.
+    expect(r.warnings.some((w) => /hindsight refresh failed \(non-fatal\)/.test(w))).toBe(false);
+    // The agent was already rolled before the fatal memory-backend failure.
+    expect(r.rolled).toEqual(["clerk"]);
+  });
+
+  it("a web/hostd failure stays non-fatal even while hindsight recreate succeeds", () => {
+    const steps = planRollout(["clerk"]);
+    const { deps } = harness({
+      versions: { clerk: "0.15.18" },
+      hindsightExists: true,
+      runStatus: (args) => (args[0] === "webd" || args[0] === "hostd" ? 1 : 0),
+    });
+    const r = executeRollout(steps, TARGET, deps);
+    expect(r.ok).toBe(true);
+    expect(r.warnings.length).toBe(2); // web + hostd only; hindsight succeeded
   });
 });
 

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -70,7 +70,7 @@ describe("orderAgentsCanaryFirst", () => {
 });
 
 describe("planRollout", () => {
-  it("orders apply → restarts (canary-first) → web → hostd → sweep", () => {
+  it("orders apply → restarts (canary-first) → web → hostd → hindsight → sweep", () => {
     const steps = planRollout(["clerk", "test-harness"]);
     expect(steps.map((s) => (s.kind === "restart-agent" ? `r:${s.agent}` : s.kind))).toEqual([
       "apply",
@@ -78,13 +78,21 @@ describe("planRollout", () => {
       "r:clerk",
       "refresh-web",
       "refresh-hostd",
+      "refresh-hindsight",
       "sweep",
     ]);
   });
 
-  it("drops web + hostd when skipWeb is set", () => {
+  it("places refresh-hindsight immediately after refresh-hostd", () => {
+    const kinds = planRollout(["clerk"]).map((s) => s.kind);
+    expect(kinds).toContain("refresh-hindsight");
+    expect(kinds.indexOf("refresh-hindsight")).toBe(kinds.indexOf("refresh-hostd") + 1);
+  });
+
+  it("drops web + hostd + hindsight when skipWeb is set", () => {
     const kinds = planRollout(["clerk"], { skipWeb: true }).map((s) => s.kind);
     expect(kinds).toEqual(["apply", "restart-agent", "sweep"]);
+    expect(kinds).not.toContain("refresh-hindsight");
   });
 
   it("does NOT emit a singleton step (first restart self-heals them, #2170)", () => {

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -16,8 +16,11 @@
  *   3. Refresh `switchroom-web` + `switchroom-hostd` (separate compose
  *      projects that do NOT self-heal on a pin bump) via `webd/hostd
  *      install --tag`, then refresh `switchroom-hindsight` (a standalone
- *      `docker run` on the mutable `:latest` tag — also not compose, also
- *      no self-heal) via `memory setup --recreate` (pull + recreate).
+ *      `docker run` — also not compose, also no self-heal) via `memory
+ *      setup --recreate --tag <target>` (pull the pinned `:vX.Y.Z` +
+ *      recreate). A failed recreate is FATAL — it already stopped/removed
+ *      the old container, so leaving the roll "ok" would report success on
+ *      a fleet whose memory backend is down.
  *   4. Final sweep — print a per-agent version table.
  *
  * Footguns this closes (each a real past incident, see CLAUDE.md / memory):
@@ -27,10 +30,11 @@
  *     self-heal on the first `agent restart` (#2170) — no separate step.
  *   - web + hostd are separate compose projects, stale every release —
  *     step 3.
- *   - hindsight is a standalone `docker run` on the mutable `:latest` tag
- *     (not a compose service), so a roll never re-pulls it and it drifts
- *     stale — observed stuck on claude 2.1.197 while the fleet moved to
- *     2.1.199. The `:latest` re-pull + recreate in step 3 closes it.
+ *   - hindsight is a standalone `docker run` (not a compose service), so a
+ *     roll never re-pulls it and it drifts stale — observed stuck on claude
+ *     2.1.197 while the fleet moved to 2.1.199. Step 3 re-pulls + recreates
+ *     it on the PINNED `:vX.Y.Z` (the roll target), not floating `:latest`,
+ *     so hindsight lands on the same version as the rest of the fleet.
  *   - the `:latest` pull-race / wrong-version-served — the per-agent
  *     `--version` assert in step 2.
  *
@@ -62,7 +66,7 @@ export type RolloutStep =
   | { kind: "sweep" };
 
 export interface RolloutPlanOpts {
-  /** Skip the web + hostd refresh (step 3). */
+  /** Skip the web + hostd + hindsight refresh (step 3). */
   skipWeb?: boolean;
   /**
    * When set (i.e. the operator passed `--pin`), persist `release.pin` to
@@ -204,7 +208,7 @@ export function formatRolloutPlan(
         lines.push(`  ${n}. hostd install --tag ${target} (separate compose project)`);
         break;
       case "refresh-hindsight":
-        lines.push(`  ${n}. refresh hindsight — pull :latest + recreate (standalone docker run, not compose)`);
+        lines.push(`  ${n}. refresh hindsight — pull ${target} + recreate (standalone docker run, not compose)`);
         break;
       case "sweep":
         lines.push(`  ${n}. sweep — print per-agent version table`);
@@ -342,6 +346,13 @@ export interface RolloutDeps {
    * can omit it.
    */
   persistPin?(pin: string): void;
+  /**
+   * Probe whether the standalone `switchroom-hindsight` container exists on
+   * this host (the `refresh-hindsight` step no-ops cleanly when it doesn't).
+   * Defaults (in production) to {@link isHindsightContainerExists}; tests
+   * inject it so the executor's hindsight branch runs without docker.
+   */
+  hindsightExists?(): boolean;
 }
 
 export interface RolloutResult {
@@ -655,13 +666,39 @@ export function executeRollout(
         // memory.config.url never drifts under the fleet. No-op cleanly when
         // hindsight isn't installed on this host (guard below also returns
         // false when docker is unavailable).
-        if (!isHindsightContainerExists()) {
+        const hindsightExists = deps.hindsightExists ?? isHindsightContainerExists;
+        if (!hindsightExists()) {
           deps.log(`ROLL_STEP refresh-hindsight — no hindsight container on this host; skipping`);
           break;
         }
-        deps.log(`ROLL_STEP refresh-hindsight — memory setup --recreate (pull :latest + recreate)`);
-        const r = deps.run(["memory", "setup", "--recreate"]);
-        if (r.status !== 0) warnings.push(`hindsight refresh failed (non-fatal); agents already rolled`);
+        // Thread the pinned rollout target through as `--tag <target>` so the
+        // recreate pulls `…switchroom-hindsight:v<target>` — the SAME pinned
+        // image the rest of the fleet moved to — NOT floating `:latest`
+        // (which drifts hindsight off the roll's version; #2752 fix 1).
+        deps.log(
+          `ROLL_STEP refresh-hindsight — memory setup --recreate --tag ${target} (pull ${target} + recreate)`,
+        );
+        const r = deps.run(["memory", "setup", "--recreate", "--tag", target]);
+        if (r.status !== 0) {
+          // FATAL, not a soft warning (#2752 fix 2): `memory setup --recreate`
+          // already did `docker stop && docker rm` before the failing
+          // `startHindsight`, so a failed recreate leaves the fleet with NO
+          // memory backend. Folding that into the generic non-fatal web/hostd
+          // warning while returning ok:true reported success on a fleet whose
+          // memory is DOWN. Stop the roll (same stop-on-failure semantics as a
+          // failed agent restart) and name the manual recovery.
+          deps.log(
+            `  ✗ hindsight recreate FAILED — the memory backend is DOWN (the ` +
+              `recreate stopped + removed the old container before the failed ` +
+              `start). Run \`switchroom memory setup\` to bring it back. — STOPPING`,
+          );
+          return {
+            ok: false,
+            rolled,
+            failedStep: "refresh-hindsight",
+            warnings,
+          };
+        }
         break;
       }
       case "sweep": {
@@ -728,7 +765,7 @@ export function registerRolloutCommand(program: Command): void {
       "--agents <list>",
       "Comma-separated subset of agents to roll (default: all configured).",
     )
-    .option("--skip-web", "Skip the web + hostd refresh step.")
+    .option("--skip-web", "Skip the web + hostd + hindsight refresh step.")
     .option(
       "--allow-downgrade",
       "Permit rolling to an older semver tag (operator-approved rollback path). " +
@@ -1016,7 +1053,7 @@ export function registerRollbackCommand(program: Command): void {
       "--agents <list>",
       "Comma-separated subset of agents to roll back (default: all configured).",
     )
-    .option("--skip-web", "Skip the web + hostd refresh step.")
+    .option("--skip-web", "Skip the web + hostd + hindsight refresh step.")
     .option("--dry-run", "Print the plan and exit without changing anything.")
     .action(async (opts: { to?: string; agents?: string; skipWeb?: boolean; dryRun?: boolean }) => {
       // Delegate entirely to the rollout action with --allow-downgrade.

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -15,7 +15,9 @@
  *      STOP on the first mismatch (report what rolled, what didn't).
  *   3. Refresh `switchroom-web` + `switchroom-hostd` (separate compose
  *      projects that do NOT self-heal on a pin bump) via `webd/hostd
- *      install --tag`.
+ *      install --tag`, then refresh `switchroom-hindsight` (a standalone
+ *      `docker run` on the mutable `:latest` tag — also not compose, also
+ *      no self-heal) via `memory setup --recreate` (pull + recreate).
  *   4. Final sweep — print a per-agent version table.
  *
  * Footguns this closes (each a real past incident, see CLAUDE.md / memory):
@@ -25,6 +27,10 @@
  *     self-heal on the first `agent restart` (#2170) — no separate step.
  *   - web + hostd are separate compose projects, stale every release —
  *     step 3.
+ *   - hindsight is a standalone `docker run` on the mutable `:latest` tag
+ *     (not a compose service), so a roll never re-pulls it and it drifts
+ *     stale — observed stuck on claude 2.1.197 while the fleet moved to
+ *     2.1.199. The `:latest` re-pull + recreate in step 3 closes it.
  *   - the `:latest` pull-race / wrong-version-served — the per-agent
  *     `--version` assert in step 2.
  *
@@ -43,6 +49,7 @@ import { writeConfigFileSync } from "../util/atomic.js";
 import { compareReleaseTags } from "../config/release-resolve.js";
 import { SWITCHROOM_VERSION } from "./resolve-version.js";
 import { readAndFilter, defaultAuditLogPath } from "../host-control/audit-reader.js";
+import { isHindsightContainerExists } from "../setup/hindsight.js";
 
 /** One ordered step of a rollout plan. Pure data so it unit-tests. */
 export type RolloutStep =
@@ -51,6 +58,7 @@ export type RolloutStep =
   | { kind: "restart-agent"; agent: string }
   | { kind: "refresh-web" }
   | { kind: "refresh-hostd" }
+  | { kind: "refresh-hindsight" }
   | { kind: "sweep" };
 
 export interface RolloutPlanOpts {
@@ -164,6 +172,7 @@ export function planRollout(
   if (!opts.skipWeb) {
     steps.push({ kind: "refresh-web" });
     steps.push({ kind: "refresh-hostd" });
+    steps.push({ kind: "refresh-hindsight" });
   }
   steps.push({ kind: "sweep" });
   return steps;
@@ -193,6 +202,9 @@ export function formatRolloutPlan(
         break;
       case "refresh-hostd":
         lines.push(`  ${n}. hostd install --tag ${target} (separate compose project)`);
+        break;
+      case "refresh-hindsight":
+        lines.push(`  ${n}. refresh hindsight — pull :latest + recreate (standalone docker run, not compose)`);
         break;
       case "sweep":
         lines.push(`  ${n}. sweep — print per-agent version table`);
@@ -630,6 +642,26 @@ export function executeRollout(
         deps.log(`ROLL_STEP refresh-hostd — hostd install --tag ${target}`);
         const r = deps.run(["hostd", "install", "--tag", target]);
         if (r.status !== 0) warnings.push(`hostd refresh failed (non-fatal); agents already rolled`);
+        break;
+      }
+      case "refresh-hindsight": {
+        // hindsight is a STANDALONE `docker run` on the mutable `:latest`
+        // tag — it is NOT a compose service and does NOT self-heal on a pin
+        // bump, so a roll leaves it pinned to whatever `:latest` resolved to
+        // when it was last recreated (observed: hindsight stuck on claude
+        // 2.1.197 while the fleet moved to 2.1.199). `memory setup --recreate`
+        // pulls the latest hindsight image then recreates the container
+        // (pull → stop → start), reusing the running host ports so
+        // memory.config.url never drifts under the fleet. No-op cleanly when
+        // hindsight isn't installed on this host (guard below also returns
+        // false when docker is unavailable).
+        if (!isHindsightContainerExists()) {
+          deps.log(`ROLL_STEP refresh-hindsight — no hindsight container on this host; skipping`);
+          break;
+        }
+        deps.log(`ROLL_STEP refresh-hindsight — memory setup --recreate (pull :latest + recreate)`);
+        const r = deps.run(["memory", "setup", "--recreate"]);
+        if (r.status !== 0) warnings.push(`hindsight refresh failed (non-fatal); agents already rolled`);
         break;
       }
       case "sweep": {

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -51,11 +51,41 @@ export const HINDSIGHT_CONSUMER_NAME = "hindsight";
 export const HINDSIGHT_DEFAULT_UID = 11000;
 
 /**
+ * GHCR repository (no tag) for switchroom's hindsight image. The image is
+ * published per-version as `:vX.Y.Z` on a release tag AND as `:latest` on
+ * every main build (see `.github/workflows/docker-images.yml`). Standalone
+ * paths (`memory setup`) default to `:latest`; a version-pinned rollout
+ * threads the target tag through so the recreate pulls the SAME pinned
+ * image the rest of the fleet moved to (not floating `:latest`).
+ */
+export const HINDSIGHT_IMAGE_REPO = "ghcr.io/switchroom/switchroom-hindsight";
+
+/**
  * Docker image for switchroom's hindsight (extends upstream with the
  * `claude-code` LLM provider's runtime deps). Pulled from GHCR at apply
  * time; built from `docker/Dockerfile.hindsight` when `--build-local`.
+ * The default floating `:latest` tag — used by the standalone `memory
+ * setup` path. A pinned rollout overrides the tag via {@link hindsightImageRef}.
  */
-export const HINDSIGHT_IMAGE = "ghcr.io/switchroom/switchroom-hindsight:latest";
+export const HINDSIGHT_IMAGE = `${HINDSIGHT_IMAGE_REPO}:latest`;
+
+/**
+ * Resolve the hindsight image reference for a given target tag.
+ *
+ * The release workflow publishes the hindsight image with the `v`-prefixed
+ * git tag (`TAG_VERSION="${GITHUB_REF#refs/tags/}"` → `:v0.15.18`), so a
+ * rollout target like `v0.15.18` or `0.15.18` maps to `…hindsight:v0.15.18`.
+ * When `tag` is undefined/empty, returns the floating `:latest` image
+ * ({@link HINDSIGHT_IMAGE}) — preserving the standalone `memory setup`
+ * behavior. Normalizes so a bare `0.15.18` and a `v0.15.18` both resolve to
+ * the `:v0.15.18` tag the workflow actually publishes.
+ */
+export function hindsightImageRef(tag?: string): string {
+  const t = tag?.trim();
+  if (!t) return HINDSIGHT_IMAGE;
+  const v = t.replace(/^v/, "");
+  return `${HINDSIGHT_IMAGE_REPO}:v${v}`;
+}
 
 /**
  * Default Claude model for hindsight's LLM operations (retain / reflect /
@@ -437,6 +467,7 @@ export interface LiteLLMHindsightConfig {
 export function startHindsight(
   ports?: { apiPort: number; uiPort: number },
   litellm?: LiteLLMHindsightConfig,
+  imageTag?: string,
 ): void {
   const apiPort = ports?.apiPort ?? HINDSIGHT_DEFAULT_API_PORT;
   const uiPort = ports?.uiPort ?? HINDSIGHT_DEFAULT_UI_PORT;
@@ -540,7 +571,9 @@ export function startHindsight(
     // entrypoint's `chmod 0700` fails EACCES → restart-loop.
     "--tmpfs", `/run/claude-creds:rw,mode=0700,uid=${HINDSIGHT_DEFAULT_UID},gid=${HINDSIGHT_DEFAULT_UID}`,
     ...envArgs,
-    HINDSIGHT_IMAGE,
+    // Pinned tag when a rollout target is threaded through; floating
+    // `:latest` for the standalone `memory setup` path (imageTag undefined).
+    hindsightImageRef(imageTag),
   );
 
   execFileSync("docker", args, { stdio: "pipe" });
@@ -559,13 +592,15 @@ export function stopHindsight(): void {
 }
 
 /**
- * Pull the latest Hindsight image. `startHindsight` runs `docker run`
- * against whatever image is locally present — it never pulls — so a
- * recreate that wants the newest `:latest` must pull first. Inherits
- * stdio so the operator sees pull progress during `switchroom update`.
+ * Pull the Hindsight image. `startHindsight` runs `docker run` against
+ * whatever image is locally present — it never pulls — so a recreate that
+ * wants the newest bits must pull first. Pulls `:latest` when `imageTag`
+ * is omitted (standalone `memory setup`); pulls the pinned `:vX.Y.Z` when
+ * a rollout threads its target through. Inherits stdio so the operator
+ * sees pull progress during `switchroom update` / `rollout`.
  */
-export function pullHindsightImage(): void {
-  execFileSync("docker", ["pull", HINDSIGHT_IMAGE], { stdio: "inherit" });
+export function pullHindsightImage(imageTag?: string): void {
+  execFileSync("docker", ["pull", hindsightImageRef(imageTag)], { stdio: "inherit" });
 }
 
 /**

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -228,6 +228,28 @@ describe("hindsight broker-fed mode (#1245)", () => {
     expect(args).not.toContain("ghcr.io/vectorize-io/hindsight:latest");
   });
 
+  // #2752 fix 1 — a version-pinned rollout threads its target through as
+  // imageTag so the standalone recreate pulls + runs the SAME pinned image
+  // (`:vX.Y.Z`) the rest of the fleet moved to, not floating `:latest`.
+  it("runs the PINNED :vX.Y.Z image when an imageTag is provided", () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 }, undefined, "v0.15.18");
+    const args = findRunArgs();
+    expect(args).toContain("ghcr.io/switchroom/switchroom-hindsight:v0.15.18");
+    expect(args).not.toContain(HINDSIGHT_IMAGE); // NOT floating :latest
+  });
+
+  it("normalizes a bare (v-less) tag to the :vX.Y.Z form the workflow publishes", () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 }, undefined, "0.15.18");
+    const args = findRunArgs();
+    expect(args).toContain("ghcr.io/switchroom/switchroom-hindsight:v0.15.18");
+  });
+
+  it("falls back to floating :latest when no imageTag is given (standalone memory setup)", () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 });
+    const args = findRunArgs();
+    expect(args).toContain(HINDSIGHT_IMAGE);
+  });
+
   // Regression — without uid/gid on the tmpfs, the mount lands root-owned
   // and the entrypoint shim's `chmod 0700 /run/claude-creds` (running as
   // the image's pinned USER hindsight, UID 11000) fails EACCES → boot


### PR DESCRIPTION
## Summary

`switchroom rollout` refreshes the two non-compose singletons that don't self-heal on a pin bump — `switchroom-web` and `switchroom-hostd` (via `webd/hostd install --tag`) — but **skipped hindsight entirely**. `switchroom-hindsight` is *also* a standalone `docker run` on the mutable `:latest` tag (not a compose service), so a version roll never re-pulls it. Result: hindsight drifts stale across releases — observed **stuck on claude 2.1.197 while the fleet moved to 2.1.199**.

## The fix

- New `RolloutStep` variant `{ kind: "refresh-hindsight" }`, added to `planRollout()` **immediately after `refresh-hostd`**, inside the same `if (!opts.skipWeb)` gate (so `--skip-web` omits it too).
- Added to `formatRolloutPlan()` (`--dry-run` output).
- Executor case: guards on `isHindsightContainerExists()` and **no-ops cleanly** when hindsight isn't installed (the guard also returns false when docker is unavailable). Otherwise runs `memory setup --recreate`, which reuses the existing `pullHindsightImage()` → `stopHindsight()` → `startHindsight()` primitives (pull → stop → start) and preserves the running host ports so `memory.config.url` never drifts under the fleet. Failure is a **non-fatal warning**, mirroring the web/hostd cases (agents are already rolled).
- Top-of-file doc comment updated: hindsight's `:latest` re-pull is now a documented closed footgun in the numbered sequence + footguns list.

No new docker primitive introduced — the recreate reuses the ones `switchroom update --recreate` already uses.

## Job / outcome

Serves **always-on** (`reference/jobs/always-on-after-restart.md`): a rolled fleet keeps a matching, current memory backend instead of a silently stale one.

## Test plan

- [x] `tsc --noEmit` clean.
- [x] `vitest run src/cli/rollout.test.ts` — 68 passed.
- [x] Added assertions: `planRollout` includes `refresh-hindsight` **immediately after** `refresh-hostd`; `--skip-web` omits it; full ordered-plan expectation updated.

## Risk

Low. The step is additive, gated behind the existing `--skip-web` flag, no-ops when hindsight is absent, and is non-fatal on failure. Confined to `src/cli/rollout.ts` (+ its test).