### PR TITLE
fix(telegram): promote lone \n in vertical stat cards to hard breaks

### DIFF
--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -686,19 +686,35 @@ function shouldPromoteBreak(prev: string, next: string, placeholder?: string): b
     return true
   }
   // Stat-card / key-value promotion (#2750). A vertical card like
-  // `Calories: 1800 / Protein: 120g / Carbs: 200g` has lines ending in
-  // digits/letters, so the terminator rule above never fires and the whole
-  // card collapses into one wall of text. Promote a lone `\n` when the prev
-  // line reads as a standalone `label: value` stat line — a leading label,
-  // then a colon, then a space, then a value — AND the next line is NOT a
-  // lowercase-started mid-sentence continuation. The next-line guard is what
-  // keeps the deliberately-conservative soft-wrap protection intact: a genuine
-  // wrapped sentence continues in lowercase (`... went on\nto continue`),
-  // whereas a stat/label line is followed by another label or capitalised
-  // prose. A prev with no colon (a plain soft-wrapped sentence) never matches.
-  const isStatLine = /^\s*\S[^\n]*?:[ \t]+\S/.test(prevTrimmed)
-  if (isStatLine && !/^[a-z]/.test(nextTrimmed)) {
-    return true
+  // `Calories: 1800 / Protein: 120g / Carbs: 200g` (or the fleet's HOUSE style
+  // `**Calories:** 1800 / **Protein:** 120g`) has lines ending in digits/
+  // letters, so the terminator rule above never fires and the whole card
+  // collapses into one wall of text. Promote a lone `\n` when the prev line
+  // reads as a standalone `label: value` stat line.
+  //
+  // The discriminator that separates a stat line from a mid-sentence soft wrap
+  // that merely contains a colon (`The deal has one catch: the buyer wants it
+  // and\nToronto lawyers sign off`) is two-fold:
+  //   1. The LABEL (text before the colon) is SHORT — a stat label is a term
+  //      of a few words, a wrapped prose clause is a long run of words. We cap
+  //      the label at 3 words / 24 chars.
+  //   2. The next line is NOT a lowercase-started mid-sentence continuation.
+  //      A genuine wrapped sentence continues in lowercase; a stat/label line
+  //      is followed by another label or capitalised prose.
+  // Markdown emphasis (`*` `_` `` ` ``) is stripped first so bold labels like
+  // `**Calories:**` are recognised. A prev with no colon never matches, so a
+  // plain soft-wrapped sentence is untouched.
+  const statStripped = prevTrimmed.replace(/[*_`]/g, '')
+  const colonIdx = statStripped.indexOf(':')
+  if (colonIdx > 0) {
+    const label = statStripped.slice(0, colonIdx).trim()
+    const value = statStripped.slice(colonIdx + 1)
+    const labelWords = label.length === 0 ? 0 : label.split(/\s+/).length
+    const isStatLine =
+      /^[ \t]+\S/.test(value) && labelWords >= 1 && labelWords <= 3 && label.length <= 24
+    if (isStatLine && !/^[a-z]/.test(nextTrimmed)) {
+      return true
+    }
   }
   return false
 }

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -682,7 +682,25 @@ function shouldPromoteBreak(prev: string, next: string, placeholder?: string): b
   // terminator (e.g. `He said "go."` or `(done.)`).
   const unwrapped = prevTrimmed.replace(/[)"'’”\]]+$/, '')
   const terminator = unwrapped.slice(-1)
-  return terminator === '.' || terminator === '!' || terminator === '?' || terminator === ':'
+  if (terminator === '.' || terminator === '!' || terminator === '?' || terminator === ':') {
+    return true
+  }
+  // Stat-card / key-value promotion (#2750). A vertical card like
+  // `Calories: 1800 / Protein: 120g / Carbs: 200g` has lines ending in
+  // digits/letters, so the terminator rule above never fires and the whole
+  // card collapses into one wall of text. Promote a lone `\n` when the prev
+  // line reads as a standalone `label: value` stat line — a leading label,
+  // then a colon, then a space, then a value — AND the next line is NOT a
+  // lowercase-started mid-sentence continuation. The next-line guard is what
+  // keeps the deliberately-conservative soft-wrap protection intact: a genuine
+  // wrapped sentence continues in lowercase (`... went on\nto continue`),
+  // whereas a stat/label line is followed by another label or capitalised
+  // prose. A prev with no colon (a plain soft-wrapped sentence) never matches.
+  const isStatLine = /^\s*\S[^\n]*?:[ \t]+\S/.test(prevTrimmed)
+  if (isStatLine && !/^[a-z]/.test(nextTrimmed)) {
+    return true
+  }
+  return false
 }
 
 /**

--- a/telegram-plugin/tests/paragraph-normalizer.test.ts
+++ b/telegram-plugin/tests/paragraph-normalizer.test.ts
@@ -48,6 +48,30 @@ describe('normalizeParagraphBreaks', () => {
     expect(normalizeParagraphBreaks(input)).toBe(input)
   })
 
+  test('promotes every interior break in a vertical stat card (#2750)', () => {
+    // The gymbro food-log card: lines end in digits/letters (no terminator),
+    // but each is a standalone `label: value` stat line, so every interior
+    // break must become a GFM hard break instead of collapsing to one wall.
+    const input = 'Calories: 1800\nProtein: 120g\nCarbs: 200g'
+    expect(normalizeParagraphBreaks(input)).toBe(
+      'Calories: 1800  \nProtein: 120g  \nCarbs: 200g',
+    )
+  })
+
+  test('promotes a key-value line followed by prose (#2750)', () => {
+    const input = 'Status: active\nEverything is running smoothly.'
+    expect(normalizeParagraphBreaks(input)).toBe(
+      'Status: active  \nEverything is running smoothly.',
+    )
+  })
+
+  test('regression guard: a mid-sentence colon soft-wrap still does NOT promote (#2750)', () => {
+    // A wrapped sentence that happens to contain a colon must NOT be mistaken
+    // for a stat line: the next line continues the sentence in lowercase.
+    const input = 'He made one point: the plan was sound and\nthe timing was right too'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
   test('does NOT promote when the next line is a list item (tight list stays tight)', () => {
     const input = 'Here are the steps.\n- first\n- second\n- third'
     expect(normalizeParagraphBreaks(input)).toBe(input)

--- a/telegram-plugin/tests/paragraph-normalizer.test.ts
+++ b/telegram-plugin/tests/paragraph-normalizer.test.ts
@@ -65,10 +65,41 @@ describe('normalizeParagraphBreaks', () => {
     )
   })
 
+  test('promotes bold-label stat cards — colon inside AND outside the emphasis (#2750)', () => {
+    // The fleet HOUSE style uses markdown-bold labels. Both `**Calories:** 1800`
+    // (colon inside the bold) and `**Calories**: 1800` (colon outside) must have
+    // every interior break promoted.
+    const inside = '**Calories:** 1800\n**Protein:** 120g\n**Carbs:** 200g'
+    expect(normalizeParagraphBreaks(inside)).toBe(
+      '**Calories:** 1800  \n**Protein:** 120g  \n**Carbs:** 200g',
+    )
+    const outside = '**Calories**: 1800\n**Protein**: 120g'
+    expect(normalizeParagraphBreaks(outside)).toBe('**Calories**: 1800  \n**Protein**: 120g')
+  })
+
   test('regression guard: a mid-sentence colon soft-wrap still does NOT promote (#2750)', () => {
     // A wrapped sentence that happens to contain a colon must NOT be mistaken
     // for a stat line: the next line continues the sentence in lowercase.
     const input = 'He made one point: the plan was sound and\nthe timing was right too'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
+  test('regression guard: a long colon-clause with a CAPITAL continuation does NOT promote (#2750)', () => {
+    // The lowercase-continuation guard alone would miss this: the wrapped clause
+    // continues with a capitalised proper noun. The label before the colon is a
+    // long multi-word run (not a short stat label), so the word/length cap keeps
+    // it from being mistaken for a stat line.
+    const input = 'The deal has one catch: the buyer wants it and\nToronto lawyers must sign off'
+    expect(normalizeParagraphBreaks(input)).toBe(input)
+  })
+
+  test('lowercase-label stat cards are an ACCEPTED false-negative (not promoted) (#2750)', () => {
+    // `calories: 1800\nprotein: 120g` — the lowercase-started next line is
+    // indistinguishable from a mid-sentence soft-wrap continuation, so the
+    // conservative guard leaves it alone. Documented, not fixed: models are
+    // steered toward capitalised / bold labels, and a false-negative (un-promoted
+    // break) is the module's preferred failure mode over a false-positive.
+    const input = 'calories: 1800\nprotein: 120g'
     expect(normalizeParagraphBreaks(input)).toBe(input)
   })
 


### PR DESCRIPTION
## Summary

Vertical stat cards (food-log, morning briefing, daily wrap-up) collapse into one wall of text because `normalizeParagraphBreaks` only promoted a lone `\n` to a GFM hard break when the previous line ended in a sentence terminator (`.` `!` `?` `:`). A card like:

```
Calories: 1800
Protein: 120g
Carbs: 200g
```

has lines ending in digits/letters, so no interior break was promoted and it rendered as `Calories: 1800 Protein: 120g Carbs: 200g`. Reported by the gymbro agent building a food-log card (#2750).

## Why

The terminator-only rule was deliberately conservative to avoid hard-breaking mid-sentence soft wraps. Stat lines are a distinct, recognisable shape that the old rule couldn't see.

## Fix

Broaden `shouldPromoteBreak` (`telegram-plugin/format.ts`): in addition to the terminator rule, promote a lone `\n` when the prev line reads as a standalone `label: value` stat line (`^\s*\S[^\n]*?:[ \t]+\S`) **AND** the next line is not a lowercase-started mid-sentence continuation.

The next-line guard is the discriminator that keeps the conservative soft-wrap protection intact: a genuine wrapped sentence continues in lowercase (`... went on\nto continue`), whereas a stat/label line is followed by another label or capitalised prose. A prev line with no colon never matches the new rule, so the pinned `paragraph-normalizer.test.ts:44` soft-wrap test stays green. Lists/tables/blockquotes/code are still excluded up front via `isMarkerLine`.

## Test plan

- [x] New: 3-line stat card -> every interior break promoted to `  \n`
- [x] New: key-value line followed by prose -> promoted
- [x] New regression guard: mid-sentence colon soft-wrap still NOT promoted
- [x] `vitest run telegram-plugin/tests/paragraph-normalizer.test.ts` -> 69 passed
- [x] `telegram-format` + `formatting-parse-regression` + `card-format` -> 92 passed
- [x] `tsc --noEmit` -> clean

## Risk

Low. Additive discriminator behind a colon+shape gate plus a lowercase-next guard; all existing negative tests (lists, tables, blockquotes, code, soft-wrap) remain green.

Closes #2750

🤖 Generated with [Claude Code](https://claude.com/claude-code)