### PR TITLE
feat(telegram): fleet-wide consistent outbound formatting

### DIFF
--- a/reference/telegram-formatting-guide.md
+++ b/reference/telegram-formatting-guide.md
@@ -26,49 +26,30 @@ each tool exists.
 ## FLOOR CARD (boot-injected)
 
 You're writing for a phone screen in Telegram. Every reply renders as rich Markdown
-(Bot API 10.1). Format to make the message **scannable and easy to read**, not
-decorated. These are communication tools — use them with judgment. Most short replies
-need none of them.
+(Bot API 10.1). One shared spec, three tiers:
 
-### Mechanical rules (always)
-- Separate paragraphs with a blank line (`\n\n`). A single newline collapses onto the
-  same line and reads as a wall of text.
-- Keep paragraphs short — 1 to 4 lines. Break before the reader has to work for it.
-- Hard cap is 32768 characters. Long before that, ask whether a wall of text is the
-  right answer at all.
+- **Short answers (a line or two): plain prose, no formatting.** "on it, pulling the
+  logs now" is already perfect. No bold, no bullets, no headings.
+- **Default: light structure.** Bold ONLY the one key fact or answer, never more. Use
+  a list only for 3+ genuinely parallel items the reader will scan or compare; two
+  items or a flowing thought stay prose. `code spans` for identifiers: filenames,
+  commands, config keys, error codes (tap-to-copy).
+- **Long answers may add tables / headings / blockquotes, but only when they genuinely
+  aid scanning**: a table for real 2-D data (rows x columns), headings only in a
+  multi-section answer, `>` for quoted text. If the structure doesn't cut the
+  reader's effort, drop it.
 
-### The toolkit, and when to reach for each
-- **Bold** — the one key fact or the answer. Not every noun. If everything is bold,
-  nothing is.
-- *Italic* — light emphasis, asides, labels.
-- `code spans` — every identifier: filenames, commands, config keys, agent / account /
-  slot names, error codes. Tap-to-copy, and visually distinct from prose.
-- Code fences — multi-line output: diffs, logs, command blocks, JSON. Add a language
-  hint (` ```diff `, ` ```json `) when it sharpens the render.
-- Bulleted list — 3+ parallel items the reader will scan or compare. Never for a single
-  thought or a flowing narrative.
-- Numbered list — ordered steps or ranked items.
-- Task lists (`- [x]` / `- [ ]`) — progress on a checklist of steps the reader is
-  tracking. Renders as real checkboxes; reserve for genuine done/not-done state.
-- Tables — 2-D data only (rows × columns): per-account usage, status fields. Render as
-  real tables (up to 20 columns). Overkill for a flat list.
-- Headings (`#`) — only in a long, multi-section answer. Clutter on a short reply.
-- Blockquotes (`>`) — quoted text or indented continuation. Telegram drops leading
-  spaces, so use `>`, never literal indentation.
-- `==highlight==` — a single word or value the reader's eye must land on. Stronger
-  than bold; use at most once per message.
-- Dividers (`---`) — between genuinely separate sections. Heavy; use sparingly.
+The framework normalizes mechanics in code on every outbound message: block spacing
+(one blank line between distinct blocks), em/en dashes, and `•` bullet markers are
+rewritten deterministically at send time. Don't fight it or hand-tune spacing; write
+the content, the gateway makes the typography consistent. Over-bolded messages (most
+of the text bold, or whole paragraphs/lists bolded) have their bold stripped at send
+time, so bold sparingly.
 
-Tables, headings, dividers, task lists, lists, blockquotes and `==highlight==` all
-render as rich blocks (Bot API 10.1) — reach for whichever cuts the reader's scanning
-effort. The ONE exception: sub/superscript (`H~2~O`, `x^2^`) falls back to literal
-text, so don't use it.
-
-### The why
-Structure exists for the reader, not the writer. A two-item bullet list is worse than a
-sentence. A heading on a three-line reply is noise. Reach for structure only when it
-**reduces the reader's effort** — parallel options, scannable data, ordered steps — and
-stay in prose when the thought is connected. When in doubt: shorter and plainer wins.
+Hard cap is 32768 characters. Long before that, ask whether a wall of text is the
+right answer at all. Structure exists for the reader, not the writer: a two-item
+bullet list is worse than a sentence, a heading on a three-line reply is noise. When
+in doubt, shorter and plainer wins.
 
 ---
 

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -383,49 +383,30 @@ a stored value reached a tool argument.`;
 const TELEGRAM_FORMATTING_FLOOR_CARD = `## Formatting for Telegram
 
 You're writing for a phone screen in Telegram. Every reply renders as rich Markdown
-(Bot API 10.1). Format to make the message **scannable and easy to read**, not
-decorated. These are communication tools — use them with judgment. Most short replies
-need none of them.
+(Bot API 10.1). One shared spec, three tiers:
 
-### Mechanical rules (always)
-- Separate paragraphs with a blank line (\`\\n\\n\`). A single newline collapses onto the
-  same line and reads as a wall of text.
-- Keep paragraphs short — 1 to 4 lines. Break before the reader has to work for it.
-- Hard cap is 32768 characters. Long before that, ask whether a wall of text is the
-  right answer at all.
+- **Short answers (a line or two): plain prose, no formatting.** "on it, pulling the
+  logs now" is already perfect. No bold, no bullets, no headings.
+- **Default: light structure.** Bold ONLY the one key fact or answer, never more. Use
+  a list only for 3+ genuinely parallel items the reader will scan or compare; two
+  items or a flowing thought stay prose. \`code spans\` for identifiers: filenames,
+  commands, config keys, error codes (tap-to-copy).
+- **Long answers may add tables / headings / blockquotes, but only when they genuinely
+  aid scanning**: a table for real 2-D data (rows x columns), headings only in a
+  multi-section answer, \`>\` for quoted text. If the structure doesn't cut the
+  reader's effort, drop it.
 
-### The toolkit, and when to reach for each
-- **Bold** — the one key fact or the answer. Not every noun. If everything is bold,
-  nothing is.
-- *Italic* — light emphasis, asides, labels.
-- \`code spans\` — every identifier: filenames, commands, config keys, agent / account /
-  slot names, error codes. Tap-to-copy, and visually distinct from prose.
-- Code fences — multi-line output: diffs, logs, command blocks, JSON. Add a language
-  hint (\` \`\`\`diff \`, \` \`\`\`json \`) when it sharpens the render.
-- Bulleted list — 3+ parallel items the reader will scan or compare. Never for a single
-  thought or a flowing narrative.
-- Numbered list — ordered steps or ranked items.
-- Task lists (\`- [x]\` / \`- [ ]\`) — progress on a checklist of steps the reader is
-  tracking. Renders as real checkboxes; reserve for genuine done/not-done state.
-- Tables — 2-D data only (rows × columns): per-account usage, status fields. Render as
-  real tables (up to 20 columns). Overkill for a flat list.
-- Headings (\`#\`) — only in a long, multi-section answer. Clutter on a short reply.
-- Blockquotes (\`>\`) — quoted text or indented continuation. Telegram drops leading
-  spaces, so use \`>\`, never literal indentation.
-- \`==highlight==\` — a single word or value the reader's eye must land on. Stronger
-  than bold; use at most once per message.
-- Dividers (\`---\`) — between genuinely separate sections. Heavy; use sparingly.
+The framework normalizes mechanics in code on every outbound message: block spacing
+(one blank line between distinct blocks), em/en dashes, and \`\u2022\` bullet markers are
+rewritten deterministically at send time. Don't fight it or hand-tune spacing; write
+the content, the gateway makes the typography consistent. Over-bolded messages (most
+of the text bold, or whole paragraphs/lists bolded) have their bold stripped at send
+time, so bold sparingly.
 
-Tables, headings, dividers, task lists, lists, blockquotes and \`==highlight==\` all
-render as rich blocks (Bot API 10.1) — reach for whichever cuts the reader's scanning
-effort. The ONE exception: sub/superscript (\`H~2~O\`, \`x^2^\`) falls back to literal
-text, so don't use it.
-
-### The why
-Structure exists for the reader, not the writer. A two-item bullet list is worse than a
-sentence. A heading on a three-line reply is noise. Reach for structure only when it
-**reduces the reader's effort** — parallel options, scannable data, ordered steps — and
-stay in prose when the thought is connected. When in doubt: shorter and plainer wins.
+Hard cap is 32768 characters. Long before that, ask whether a wall of text is the
+right answer at all. Structure exists for the reader, not the writer: a two-item
+bullet list is worse than a sentence, a heading on a three-line reply is noise. When
+in doubt, shorter and plainer wins.
 
 Every turn that answers a user message ends with a user-visible \`reply\` (or
 \`stream_reply\` done=true) — Telegram is all the user sees; your terminal output

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -373,13 +373,14 @@ export const PARAGRAPH_SPACER = ' '
  * the pre-#2669 HTML behaviour). See PARAGRAPH_SPACER for why a U+00A0 line is
  * the reliable trick.
  *
- * Conservative by construction — a spacer is inserted into a `\n\n` gap ONLY
- * when BOTH the block ENDING above the gap and the block STARTING below it are
- * ordinary prose. A gap adjacent to a structural block (list item, table row,
- * fenced code, blockquote, heading, indented code) is left exactly as it was:
- * those blocks already carry their own vertical rhythm, and a spacer paragraph
- * wedged against a tight list / table would either re-introduce the cramped
- * look from the other side or break the block's contiguity.
+ * Uniform-block-spacing contract: a spacer is inserted into EVERY `\n\n` gap
+ * that separates two DISTINCT blocks — prose→prose, paragraph→list,
+ * list→paragraph, heading→anything, blockquote/table/fence boundaries — so a
+ * mixed message renders with one identical visible blank line between blocks.
+ * The one exception is a gap INSIDE a block of the same structural kind (two
+ * items of a loose list, consecutive table rows/quotes/fences): those stay
+ * tight so the block's contiguity survives. Interiors joined by a single `\n`
+ * are never gaps at all and are untouched by construction.
  *
  * Runs on code-masked text (so a blank line inside a fenced block is never
  * touched) and is idempotent — a gap that already contains a U+00A0 spacer
@@ -410,15 +411,45 @@ export function addParagraphSpacers(text: string): string {
   // Trim ASCII-only (preserve U+00A0) so the spacer line is recognisable.
   const asciiTrim = (line: string): string => line.replace(/^[ \t\r\f\v]+|[ \t\r\f\v]+$/g, '')
 
-  // A line is "prose" for spacing purposes when it is non-blank, not a
-  // structural block marker, not the spacer line itself. Only a gap with prose
-  // on BOTH sides earns a visible spacer.
-  const isProseLine = (line: string): boolean => {
-    if (isBlankLine(line)) return false
-    if (asciiTrim(line) === spacerLine) return false
-    if (isMarkerLine(line, placeholder)) return false
-    // A standalone masked fenced block line is structural.
-    if (isFenceOpenLine(line, placeholder)) return false
+  // Classify the block kind of a facing line so the spacer decision can be
+  // made per BLOCK TRANSITION (#uniform-block-spacing). A spacer is inserted
+  // at every `\n\n` gap between two DIFFERENT block kinds (paragraph→list,
+  // list→paragraph, heading→anything, blockquote/table boundaries) and
+  // between two prose paragraphs — but NEVER inside a single block's interior
+  // (between two items of the same loose list, two rows of a table, two
+  // quote lines, two fenced blocks). One visible blank line between distinct
+  // blocks, identical everywhere; list/table interiors stay tight.
+  type BlockKind = 'spacer' | 'list' | 'table' | 'quote' | 'heading' | 'fence' | 'divider' | 'prose'
+  const blockKind = (line: string): BlockKind => {
+    if (asciiTrim(line) === spacerLine) return 'spacer'
+    if (isFenceOpenLine(line, placeholder)) return 'fence'
+    if (isListItemLine(line)) return 'list'
+    if (isTableRowLine(line) || isTableDelimiterLine(line)) return 'table'
+    if (isBlockquoteLine(line)) return 'quote'
+    if (isHeadingLine(line)) return 'heading'
+    if (/^(-{3,}|\*{3,}|_{3,})\s*$/.test(line.trimStart())) return 'divider'
+    return 'prose'
+  }
+
+  // Same-kind structural pairs whose `\n\n` gap is a block INTERIOR (a loose
+  // list's item gap, consecutive tables/quotes/fences) — no spacer there.
+  const SAME_KIND_TIGHT: ReadonlySet<BlockKind> = new Set([
+    'list',
+    'table',
+    'quote',
+    'fence',
+    'divider',
+  ])
+
+  const shouldSpaceGap = (above: string, below: string): boolean => {
+    const a = blockKind(above)
+    const b = blockKind(below)
+    // A facing spacer line means the gap is already spaced (idempotency —
+    // also guarded by alreadySpaced at the call site).
+    if (a === 'spacer' || b === 'spacer') return false
+    if (a === b && SAME_KIND_TIGHT.has(a)) return false
+    // Everything else is a genuine block transition (incl. prose→prose,
+    // heading→anything, list↔paragraph, table/quote boundaries) — space it.
     return true
   }
 
@@ -451,8 +482,7 @@ export function addParagraphSpacers(text: string): string {
           !alreadySpaced &&
           above != null &&
           below != null &&
-          isProseLine(above) &&
-          isProseLine(below)
+          shouldSpaceGap(above, below)
         ) {
           // Emit: blank, spacer paragraph, blank — a U+00A0 paragraph wedged
           // between two real blank lines so CommonMark renders it as a visible
@@ -492,6 +522,150 @@ function nextNonBlank(
     if (!isBlank(lines[i])) return lines[i]
   }
   return null
+}
+
+// ---------------------------------------------------------------------------
+// Punctuation / bullet normalization — fleet-wide consistent typography
+// ---------------------------------------------------------------------------
+
+/**
+ * Deterministic punctuation + bullet normalization for outbound messages
+ * (fleet-wide consistent Telegram formatting). Runs in the send path AFTER
+ * normalizeParagraphBreaks, on code-masked text (reuses maskCodeRegions), so
+ * code spans and fenced blocks are never touched.
+ *
+ * Transforms:
+ *   1. Space-flanked em/en dash (` — ` / ` – `) → `, ` — except a
+ *      digit-flanked spaced dash (a numeric range `3 – 5`), which becomes a
+ *      plain hyphen range (`3-5`).
+ *   2. Bare em-dash between word characters (`word—word`) → `, `; a
+ *      digit-flanked one (`3—5`) → hyphen.
+ *   3. Bare en-dash between word characters → ASCII hyphen (`2019–2024` →
+ *      `2019-2024`).
+ *   4. Leading unicode bullets (`•` / `·`) as list markers → `- ` so every
+ *      list renders as a real GFM list (indent preserved).
+ *
+ * Idempotent: the output contains no em/en dashes or leading unicode bullets
+ * outside code regions, so a second pass is a no-op.
+ */
+export function normalizePunctuation(text: string): string {
+  if (!/[—–•·]/.test(text)) return text
+
+  const nonce = Math.random().toString(36).slice(2)
+  const { masked, restore } = maskCodeRegions(text, nonce)
+
+  let out = masked
+    // 1. Space-flanked em/en dash. Numeric range keeps a hyphen.
+    .replace(/(\S)[ \t][—–][ \t](\S)/g, (_m, a: string, b: string) =>
+      /\d/.test(a) && /\d/.test(b) ? `${a}-${b}` : `${a}, ${b}`,
+    )
+    // 2. Bare em-dash between word chars. Numeric range keeps a hyphen.
+    .replace(/(\w)—(\w)/g, (_m, a: string, b: string) =>
+      /\d/.test(a) && /\d/.test(b) ? `${a}-${b}` : `${a}, ${b}`,
+    )
+    // 3. Bare en-dash between word chars → hyphen (ranges: 2019–2024).
+    .replace(/(\w)–(\w)/g, '$1-$2')
+
+  // 4. Leading unicode bullet markers → GFM `- ` (per line, indent kept).
+  out = out
+    .split('\n')
+    .map((line) => line.replace(/^([ \t]*)[•·][ \t]+/, '$1- '))
+    .join('\n')
+
+  return restore(out)
+}
+
+// ---------------------------------------------------------------------------
+// Over-bold tripwire — strip bold when a message is clearly over-bolded
+// ---------------------------------------------------------------------------
+
+/** A line's content once a leading list marker (`- ` / `1. `) is removed. */
+function listItemContent(line: string): string {
+  return line.trimStart().replace(/^(?:[-*+]|\d+[.)])\s+/, '')
+}
+
+/** True when a text fragment is one single fully-bolded span (`**…**`). */
+function isFullyBolded(fragment: string): boolean {
+  return /^\*\*[^*]+\*\*[.,:;!?]?$/.test(fragment.trim())
+}
+
+/** Strip `**bold**` markers from a fragment, keeping the text. */
+function unbold(fragment: string): string {
+  return fragment.replace(/\*\*([^*]+)\*\*/g, '$1')
+}
+
+/**
+ * Over-bold tripwire (fleet-wide consistent Telegram formatting). If a
+ * message is clearly over-bolded, strip the `**` markers and keep the text:
+ *
+ *   - GLOBAL: when >30% of the message's non-code characters sit inside
+ *     `**bold**` spans, ALL bold markers are stripped.
+ *   - PER-BLOCK: an entire multi-line paragraph fully bolded, or a list whose
+ *     EVERY item is fully bolded, has that block's bold stripped.
+ *
+ * Deliberately conservative:
+ *   - Messages under 100 non-code characters are exempt (a short reply whose
+ *     one key fact is bolded is exactly the house style).
+ *   - A single-line fully-bolded paragraph of ≤48 chars is treated as a
+ *     pseudo-heading (the "**Section**" label the fleet style encourages) and
+ *     is NOT stripped by the per-block rule (it still counts toward the
+ *     global ratio).
+ *   - A list with any non-fully-bolded item is left alone.
+ *
+ * Code spans/fences are masked (maskCodeRegions) and never counted or
+ * modified. Idempotent: stripped output has no `**` spans left to trip on.
+ */
+export function stripExcessBold(text: string): string {
+  if (!text.includes('**')) return text
+
+  const nonce = Math.random().toString(36).slice(2)
+  const { masked, restore, placeholder } = maskCodeRegions(text, nonce)
+
+  // Non-code character budget: masked text with the placeholders removed.
+  const placeholderRe = new RegExp(
+    `${placeholder.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\d+\x00`,
+    'g',
+  )
+  const visible = masked.replace(placeholderRe, '')
+  if (visible.length < 100) return restore(masked)
+
+  let boldChars = 0
+  for (const m of visible.matchAll(/\*\*([^*]+)\*\*/g)) boldChars += m[1].length
+
+  if (boldChars / visible.length > 0.3) {
+    // Clearly over-bolded — strip every bold span, keep the text.
+    return restore(unbold(masked))
+  }
+
+  // Per-block check on blank-line-delimited blocks of the masked text.
+  const blocks = masked.split(/\n{2,}/)
+  const rebuilt = blocks.map((block) => {
+    const lines = block.split('\n').filter((l) => l.trim() !== '')
+    if (lines.length === 0 || !block.includes('**')) return block
+
+    const listLines = lines.filter((l) => isListItemLine(l))
+    if (listLines.length >= 2 && listLines.length === lines.length) {
+      // A list block: strip only when EVERY item is fully bolded.
+      if (lines.every((l) => isFullyBolded(listItemContent(l)))) return unbold(block)
+      return block
+    }
+
+    // A prose paragraph (no structural marker lines): strip when every line
+    // is one fully-bolded span — except the single-short-line pseudo-heading.
+    const isProseBlock = lines.every((l) => !isMarkerLine(l, placeholder))
+    if (!isProseBlock) return block
+    if (!lines.every((l) => isFullyBolded(l))) return block
+    if (lines.length === 1 && lines[0].trim().length <= 48) return block
+    return unbold(block)
+  })
+
+  // Rejoin with the original gap shapes: split() lost them, so re-split the
+  // masked text capturing the separators and interleave.
+  const seps = masked.match(/\n{2,}/g) ?? []
+  let out = rebuilt[0] ?? ''
+  for (let i = 1; i < rebuilt.length; i++) out += (seps[i - 1] ?? '\n\n') + rebuilt[i]
+
+  return restore(out)
 }
 
 // ---------------------------------------------------------------------------
@@ -583,8 +757,14 @@ function ensureBlockBoundaries(text: string, placeholder?: string): string {
       const startsFence = isFenceOpenLine(line, placeholder) && !isFenceOpenLine(prev, placeholder)
       const startsQuote = isBlockquoteLine(line) && !isBlockquoteLine(prev)
       const startsHeading = isHeadingLine(line) && !isHeadingLine(prev)
+      // List start glued to prose above by a single `\n` (uniform-block-
+      // spacing): a `- ` line already interrupts a paragraph in CommonMark,
+      // so the blank line is render-safe — it only lets the spacer pass see
+      // the transition. Never fires between two list items (prev is a list
+      // item) so list interiors stay tight.
+      const startsList = isListItemLine(line) && !isListItemLine(prev)
 
-      if (startsTableHere || startsFence || startsQuote || startsHeading) {
+      if (startsTableHere || startsFence || startsQuote || startsHeading || startsList) {
         result.push('')
       }
     }

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -555,16 +555,20 @@ export function normalizePunctuation(text: string): string {
   const { masked, restore } = maskCodeRegions(text, nonce)
 
   let out = masked
-    // 1. Space-flanked em/en dash. Numeric range keeps a hyphen.
-    .replace(/(\S)[ \t][—–][ \t](\S)/g, (_m, a: string, b: string) =>
-      /\d/.test(a) && /\d/.test(b) ? `${a}-${b}` : `${a}, ${b}`,
+    // 1. Space-flanked em/en dash. Numeric range keeps a hyphen. The right
+    //    flank is a LOOKAHEAD (captured, not consumed) so consecutive spaced
+    //    dashes ("a — b — c") all normalize in one pass — a consumed \S would
+    //    swallow the char that anchors the next match.
+    .replace(/(\S)[ \t][—–][ \t](?=(\S))/g, (_m, a: string, b: string) =>
+      /\d/.test(a) && /\d/.test(b) ? `${a}-` : `${a}, `,
     )
     // 2. Bare em-dash between word chars. Numeric range keeps a hyphen.
-    .replace(/(\w)—(\w)/g, (_m, a: string, b: string) =>
-      /\d/.test(a) && /\d/.test(b) ? `${a}-${b}` : `${a}, ${b}`,
+    //    Right flank is a lookahead for the same consecutive-match reason.
+    .replace(/(\w)—(?=(\w))/g, (_m, a: string, b: string) =>
+      /\d/.test(a) && /\d/.test(b) ? `${a}-` : `${a}, `,
     )
     // 3. Bare en-dash between word chars → hyphen (ranges: 2019–2024).
-    .replace(/(\w)–(\w)/g, '$1-$2')
+    .replace(/(\w)–(?=\w)/g, '$1-')
 
   // 4. Leading unicode bullet markers → GFM `- ` (per line, indent kept).
   out = out

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8840,15 +8840,19 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // into GFM hard breaks so the rich path doesn't collapse them (lists/tables/
   // code are left untouched — see normalizeParagraphBreaks).
   let text = normalizeParagraphBreaks(repairEscapedWhitespace(rawText))
-  // Fleet-wide consistent formatting: normalize dashes/bullets and trip the
-  // over-bold guard deterministically, on code-masked text, right after
-  // paragraph normalization (same contract on reply / edit / stream paths).
-  text = stripExcessBold(normalizePunctuation(text))
   // Outbound secret scrub (#2044): mask any secret the agent echoed BEFORE
   // the stderr preview below, the dedup key, the send, and the history
   // record. Mutates `text` so every downstream consumer sees the masked
-  // value, exactly like the voice scrub that follows.
+  // value, exactly like the voice scrub that follows. Runs BEFORE the
+  // punctuation/bold normalizers so a secret containing an em-dash or `**`
+  // is matched literally by the redactor before any mutation.
   text = redactOutboundText(text, 'reply')
+  // Fleet-wide consistent formatting: normalize dashes/bullets and trip the
+  // over-bold guard deterministically, on code-masked text (same contract on
+  // reply / edit / stream paths). Runs before scrubVoice below so dashes get
+  // the comma treatment on every path; scrubVoice's dash telemetry
+  // (voice_scrub_applied) drops to ~zero here as a result — deliberate.
+  text = stripExcessBold(normalizePunctuation(text))
   // Voice scrub (#1683): replace em / en dashes with commas / periods.
   // Runs BEFORE outboundDedup so retries see the scrubbed key, and on the
   // raw markdown text (the scrubber does its own code-region parking so
@@ -10107,6 +10111,16 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
   // controller, dedup record, history record) see the scrubbed
   // version. Kill switch: SWITCHROOM_DISABLE_VOICE_SCRUB.
   {
+    // Cross-path consistency (#2755): normalizePunctuation runs BEFORE
+    // scrubVoice here, matching the reply/edit paths, so a spaced em-dash
+    // gets the same comma treatment on every outbound path (scrubVoice
+    // would otherwise see the raw dash first on this path only and apply
+    // its period substitution). handleStreamReply's own deps run
+    // normalizePunctuation again downstream — it is idempotent, so the
+    // second pass is a no-op. Side effect: scrubVoice's dash telemetry
+    // (voice_scrub_applied) drops to ~zero on this path since the dashes
+    // are consumed here first — deliberate.
+    args.text = normalizePunctuation(args.text as string)
     const scrub = scrubVoice(args.text as string)
     if (scrub.replaced > 0) {
       args.text = scrub.scrubbed
@@ -11495,10 +11509,14 @@ async function executeEditMessage(args: Record<string, unknown>): Promise<unknow
   // paragraph breaks for the rich path. A literal-text edit (`format:'text'`)
   // skips paragraph normalization — it must edit byte-for-byte as given.
   let editRawText = repairEscapedWhitespace(args.text as string)
-  if (!editLiteralText) editRawText = addParagraphSpacers(stripExcessBold(normalizePunctuation(normalizeParagraphBreaks(editRawText))))
+  if (!editLiteralText) editRawText = normalizeParagraphBreaks(editRawText)
   // Outbound secret scrub (#2044): an edit must not re-introduce a raw
   // secret into a live bubble or the history row. Mask before scrub/send.
   editRawText = redactOutboundText(editRawText, 'edit_message')
+  // Fleet-wide consistent formatting (same order as the reply path: redact
+  // first so secrets are matched literally, then normalize, then spacers on
+  // the rich path only).
+  if (!editLiteralText) editRawText = addParagraphSpacers(stripExcessBold(normalizePunctuation(editRawText)))
   // Voice scrub (#1683): same em-dash scrub as the reply path. Edits
   // are how silent-anchor and progress-update mutate already-sent
   // bubbles, so without this an edit can re-introduce dashes the

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -225,7 +225,7 @@ const REPLY_TO_TEXT_MAX = 200
 const SILENT_END_FALLBACK_TEXT =
   '⚠️ The agent finished working but didn’t send a reply — your last ' +
   'message may not have been answered. Please try asking again.'
-import { splitMarkdownChunks, hardSliceToCap, repairEscapedWhitespace, normalizeParagraphBreaks, addParagraphSpacers, escapeMarkdown, RICH_MESSAGE_MAX_CHARS } from '../format.js'
+import { splitMarkdownChunks, hardSliceToCap, repairEscapedWhitespace, normalizeParagraphBreaks, addParagraphSpacers, normalizePunctuation, stripExcessBold, escapeMarkdown, RICH_MESSAGE_MAX_CHARS } from '../format.js'
 import { richMessage } from '../rich-send.js'
 import { scrubVoice } from '../text-voice-scrub.js'
 import {
@@ -8840,6 +8840,10 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // into GFM hard breaks so the rich path doesn't collapse them (lists/tables/
   // code are left untouched — see normalizeParagraphBreaks).
   let text = normalizeParagraphBreaks(repairEscapedWhitespace(rawText))
+  // Fleet-wide consistent formatting: normalize dashes/bullets and trip the
+  // over-bold guard deterministically, on code-masked text, right after
+  // paragraph normalization (same contract on reply / edit / stream paths).
+  text = stripExcessBold(normalizePunctuation(text))
   // Outbound secret scrub (#2044): mask any secret the agent echoed BEFORE
   // the stderr preview below, the dedup key, the send, and the history
   // record. Mutates `text` so every downstream consumer sees the masked
@@ -10260,6 +10264,8 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       retry: robustApiCall,
       repairEscapedWhitespace,
       normalizeParagraphBreaks,
+      normalizePunctuation,
+      stripExcessBold,
       addParagraphSpacers,
       assertAllowedChat,
       resolveThreadId,
@@ -11489,7 +11495,7 @@ async function executeEditMessage(args: Record<string, unknown>): Promise<unknow
   // paragraph breaks for the rich path. A literal-text edit (`format:'text'`)
   // skips paragraph normalization — it must edit byte-for-byte as given.
   let editRawText = repairEscapedWhitespace(args.text as string)
-  if (!editLiteralText) editRawText = addParagraphSpacers(normalizeParagraphBreaks(editRawText))
+  if (!editLiteralText) editRawText = addParagraphSpacers(stripExcessBold(normalizePunctuation(normalizeParagraphBreaks(editRawText))))
   // Outbound secret scrub (#2044): an edit must not re-introduce a raw
   // secret into a live bubble or the history row. Mask before scrub/send.
   editRawText = redactOutboundText(editRawText, 'edit_message')

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -159,6 +159,19 @@ export interface StreamReplyDeps {
    */
   normalizeParagraphBreaks?: (text: string) => string
   /**
+   * Punctuation/bullet normalization (fleet-wide consistent formatting):
+   * em/en dashes → comma/hyphen, leading unicode bullets → `- `. Applied on
+   * code-masked text right after normalizeParagraphBreaks. Optional for
+   * backward compat; omitted → no normalization.
+   */
+  normalizePunctuation?: (text: string) => string
+  /**
+   * Over-bold tripwire: strips `**bold**` markers when a message is clearly
+   * over-bolded (>30% bold, or whole paragraphs/lists fully bolded). Applied
+   * after normalizePunctuation. Optional for backward compat.
+   */
+  stripExcessBold?: (text: string) => string
+  /**
    * Insert a visible blank-line spacer into each prose `\n\n` gap so the rich
    * GFM renderer shows a real empty line between paragraphs (the rich engine
    * otherwise renders `\n\n` tight — the post-#2669 paragraph-spacing
@@ -316,9 +329,14 @@ export async function handleStreamReply(
   deps: StreamReplyDeps,
 ): Promise<StreamReplyResult> {
   const chat_id = args.chat_id
-  const rawText = deps.normalizeParagraphBreaks
+  let rawText = deps.normalizeParagraphBreaks
     ? deps.normalizeParagraphBreaks(deps.repairEscapedWhitespace(args.text))
     : deps.repairEscapedWhitespace(args.text)
+  // Fleet-wide consistent formatting: dash/bullet normalization + over-bold
+  // tripwire, same order as the reply/edit paths (after paragraph
+  // normalization, before spacers). Both run on code-masked text internally.
+  if (deps.normalizePunctuation) rawText = deps.normalizePunctuation(rawText)
+  if (deps.stripExcessBold) rawText = deps.stripExcessBold(rawText)
   const done = Boolean(args.done)
   const format = args.format ?? deps.defaultFormat
   if (done) {

--- a/telegram-plugin/tests/format-consistency.test.ts
+++ b/telegram-plugin/tests/format-consistency.test.ts
@@ -135,6 +135,27 @@ describe('normalizePunctuation', () => {
     const once = normalizePunctuation('a — b\n• c\nd—e\n1–2')
     expect(normalizePunctuation(once)).toBe(once)
   })
+
+  test('consecutive spaced dashes all normalize in ONE pass (#2755 finding 2)', () => {
+    expect(normalizePunctuation('a — b — c')).toBe('a, b, c')
+    expect(normalizePunctuation('one — two — three — four')).toBe('one, two, three, four')
+    expect(normalizePunctuation('x—y—z')).toBe('x, y, z')
+    expect(normalizePunctuation('1–2–3')).toBe('1-2-3')
+  })
+
+  test('cross-path ordering: normalizePunctuation before scrubVoice yields the comma treatment', async () => {
+    // The stream path runs normalizePunctuation BEFORE scrubVoice, same as
+    // reply/edit — so a spaced em-dash gets the comma substitution on every
+    // path, and scrubVoice (period substitution) finds no dash left. Pins
+    // the #2755 finding-1 ordering contract.
+    const { scrubVoice } = await import('../text-voice-scrub.js')
+    const input = 'voice came back — three PRs stacked'
+    const normalized = normalizePunctuation(input)
+    const scrub = scrubVoice(normalized)
+    expect(normalized).toBe('voice came back, three PRs stacked')
+    expect(scrub.replaced).toBe(0)
+    expect(scrub.scrubbed).toBe(normalized)
+  })
 })
 
 describe('stripExcessBold', () => {

--- a/telegram-plugin/tests/format-consistency.test.ts
+++ b/telegram-plugin/tests/format-consistency.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for the fleet-wide consistent-formatting bundle:
+ *
+ *   1. addParagraphSpacers extension — a visible U+00A0 spacer line at EVERY
+ *      block transition (paragraph→list, list→paragraph, heading→anything,
+ *      blockquote/table boundaries), never inside a list/table interior.
+ *   2. normalizePunctuation — em/en dashes → comma/hyphen, leading `•`/`·`
+ *      list markers → `- `, on code-masked text, idempotent.
+ *   3. stripExcessBold — over-bold tripwire: >30% bold or fully-bolded
+ *      paragraphs/lists lose their bold markers; short messages exempt.
+ */
+import { describe, test, expect } from 'vitest'
+import {
+  addParagraphSpacers,
+  normalizeParagraphBreaks,
+  normalizePunctuation,
+  stripExcessBold,
+  splitMarkdownChunks,
+  PARAGRAPH_SPACER,
+} from '../format.js'
+
+const SP = PARAGRAPH_SPACER // U+00A0
+
+describe('addParagraphSpacers — uniform block spacing', () => {
+  test('still spaces prose→prose (existing behaviour)', () => {
+    const out = addParagraphSpacers('Alpha.\n\nBravo.')
+    expect(out).toBe(`Alpha.\n\n${SP}\n\nBravo.`)
+  })
+
+  test('spaces paragraph→list transition', () => {
+    const out = addParagraphSpacers('Intro.\n\n- one\n- two')
+    expect(out).toBe(`Intro.\n\n${SP}\n\n- one\n- two`)
+  })
+
+  test('spaces list→paragraph transition', () => {
+    const out = addParagraphSpacers('- one\n- two\n\nOutro.')
+    expect(out).toBe(`- one\n- two\n\n${SP}\n\nOutro.`)
+  })
+
+  test('spaces heading→anything', () => {
+    expect(addParagraphSpacers('# Title\n\nBody.')).toBe(`# Title\n\n${SP}\n\nBody.`)
+    expect(addParagraphSpacers('# Title\n\n- a\n- b')).toBe(`# Title\n\n${SP}\n\n- a\n- b`)
+  })
+
+  test('spaces blockquote and table boundaries', () => {
+    expect(addParagraphSpacers('> quoted\n\nProse.')).toBe(`> quoted\n\n${SP}\n\nProse.`)
+    const table = '| a | b |\n| --- | --- |\n| 1 | 2 |'
+    expect(addParagraphSpacers(`Prose.\n\n${table}`)).toBe(`Prose.\n\n${SP}\n\n${table}`)
+    expect(addParagraphSpacers(`${table}\n\nProse.`)).toBe(`${table}\n\n${SP}\n\nProse.`)
+  })
+
+  test('does NOT space between items of the same loose list', () => {
+    const input = '- one\n\n- two\n\n- three'
+    expect(addParagraphSpacers(input)).toBe(input)
+  })
+
+  test('does NOT space inside a tight list or table interior (single \\n)', () => {
+    const list = 'Intro.\n\n- a\n- b\n- c'
+    expect(addParagraphSpacers(list)).toBe(`Intro.\n\n${SP}\n\n- a\n- b\n- c`)
+    const table = '| a |\n| --- |\n| 1 |\n| 2 |'
+    expect(addParagraphSpacers(table)).toBe(table)
+  })
+
+  test('idempotent across every transition kind', () => {
+    const input = '# H\n\nProse one.\n\n- a\n- b\n\nProse two.\n\n> quote'
+    const once = addParagraphSpacers(input)
+    expect(addParagraphSpacers(once)).toBe(once)
+  })
+
+  test('never touches code fences', () => {
+    const input = '```\nA\n\nB\n```\n\n```\nC\n```'
+    expect(addParagraphSpacers(input)).toBe(input)
+  })
+
+  test('full pipeline: mixed prose+list+heading message gets uniform gaps', () => {
+    const raw = 'Summary line.\n- item one\n- item two\nClosing prose.'
+    const out = addParagraphSpacers(normalizeParagraphBreaks(raw))
+    // Every block transition carries exactly one visible spacer line.
+    expect(out).toBe(
+      `Summary line.\n\n${SP}\n\n- item one\n- item two\n\n${SP}\n\nClosing prose.`,
+    )
+  })
+
+  test('chunk-boundary interaction: a cut in a spacer gap strips the spacer', () => {
+    const a = 'A'.repeat(60)
+    const b = 'B'.repeat(60)
+    const text = `${a}\n\n${SP}\n\n${b}`
+    const chunks = splitMarkdownChunks(text, 80)
+    expect(chunks.length).toBe(2)
+    expect(chunks[0]).toBe(a)
+    expect(chunks[1]).toBe(b)
+  })
+})
+
+describe('normalizePunctuation', () => {
+  test('spaced em-dash → comma', () => {
+    expect(normalizePunctuation('voice came back — three PRs stacked')).toBe(
+      'voice came back, three PRs stacked',
+    )
+  })
+
+  test('spaced en-dash → comma', () => {
+    expect(normalizePunctuation('one thing – another thing')).toBe('one thing, another thing')
+  })
+
+  test('bare em-dash between words → comma', () => {
+    expect(normalizePunctuation('word—word')).toBe('word, word')
+  })
+
+  test('bare en-dash between words → hyphen (ranges survive as ASCII)', () => {
+    expect(normalizePunctuation('2019–2024')).toBe('2019-2024')
+    expect(normalizePunctuation('pre–war')).toBe('pre-war')
+  })
+
+  test('digit-flanked spaced dash → hyphen range, not comma', () => {
+    expect(normalizePunctuation('3 – 5 days')).toBe('3-5 days')
+    expect(normalizePunctuation('10 — 20')).toBe('10-20')
+  })
+
+  test('leading • and · bullets → `- ` (indent preserved)', () => {
+    expect(normalizePunctuation('• one\n• two')).toBe('- one\n- two')
+    expect(normalizePunctuation('  · indented')).toBe('  - indented')
+  })
+
+  test('mid-line bullet glyph untouched', () => {
+    expect(normalizePunctuation('rated 4.5 • 120 reviews')).toBe('rated 4.5 • 120 reviews')
+  })
+
+  test('never touches code spans or fences', () => {
+    const input = 'run `a — b` now\n\n```\nx — y\n• bullet\n```'
+    expect(normalizePunctuation(input)).toBe(input)
+  })
+
+  test('idempotent', () => {
+    const once = normalizePunctuation('a — b\n• c\nd—e\n1–2')
+    expect(normalizePunctuation(once)).toBe(once)
+  })
+})
+
+describe('stripExcessBold', () => {
+  const filler =
+    'This is an ordinary paragraph of connected prose that provides enough plain ' +
+    'characters to clear the one-hundred character exemption comfortably.'
+
+  test('short messages (<100 chars) exempt even when fully bold', () => {
+    const input = '**Everything here is bold.**'
+    expect(stripExcessBold(input)).toBe(input)
+  })
+
+  test('strips all bold when >30% of non-code chars are bold', () => {
+    const bold = '**' + 'B'.repeat(80) + '**'
+    const input = `${bold} plus a little plain text tail here.`
+    const out = stripExcessBold(input)
+    expect(out).not.toContain('**')
+    expect(out).toContain('B'.repeat(80))
+  })
+
+  test('keeps bold when clearly under threshold', () => {
+    const input = `${filler} The key fact is **42**.`
+    expect(stripExcessBold(input)).toBe(input)
+  })
+
+  test('strips a fully-bolded multi-line paragraph, leaves others', () => {
+    const input = `${filler}\n\n**This whole paragraph is bold.**\n**Every single line of it.**`
+    const out = stripExcessBold(input)
+    expect(out).toContain('This whole paragraph is bold.')
+    expect(out).not.toContain('**This whole paragraph is bold.**')
+    expect(out.startsWith(filler)).toBe(true)
+  })
+
+  test('single short fully-bolded line (pseudo-heading) survives', () => {
+    const input = `**Summary**\n\n${filler}`
+    expect(stripExcessBold(input)).toBe(input)
+  })
+
+  test('strips a list whose EVERY item is fully bolded', () => {
+    const input = `${filler}\n\n- **alpha item**\n- **bravo item**\n- **charlie item**`
+    const out = stripExcessBold(input)
+    expect(out).toContain('- alpha item')
+    expect(out).not.toContain('**alpha item**')
+  })
+
+  test('leaves a list where only some items are bolded', () => {
+    const input = `${filler}\n\n- **alpha item**\n- plain bravo\n- plain charlie`
+    expect(stripExcessBold(input)).toBe(input)
+  })
+
+  test('code regions neither counted nor modified', () => {
+    const fence = '```\n**not really bold**\n' + 'x'.repeat(400) + '\n```'
+    const input = `${filler} Key: **fact**.\n\n${fence}`
+    const out = stripExcessBold(input)
+    expect(out).toContain('**not really bold**')
+    expect(out).toContain('**fact**')
+  })
+
+  test('idempotent', () => {
+    const bold = '**' + 'B'.repeat(80) + '**'
+    const input = `${bold} plus a little plain text tail.`
+    const once = stripExcessBold(input)
+    expect(stripExcessBold(once)).toBe(once)
+  })
+})

--- a/telegram-plugin/tests/paragraph-normalizer.test.ts
+++ b/telegram-plugin/tests/paragraph-normalizer.test.ts
@@ -103,9 +103,14 @@ describe('normalizeParagraphBreaks', () => {
     expect(normalizeParagraphBreaks(input)).toBe(input)
   })
 
-  test('does NOT promote when the next line is a list item (tight list stays tight)', () => {
+  test('list glued to prose gains a block-boundary blank line; interior stays tight', () => {
+    // Uniform-block-spacing: a list start glued to prose by a single `\n`
+    // gets a blank line (so the spacer pass can see the transition); the
+    // list's own single-`\n` interior is never touched.
     const input = 'Here are the steps.\n- first\n- second\n- third'
-    expect(normalizeParagraphBreaks(input)).toBe(input)
+    expect(normalizeParagraphBreaks(input)).toBe(
+      'Here are the steps.\n\n- first\n- second\n- third',
+    )
   })
 
   test('does NOT promote between list items (ordered or unordered)', () => {
@@ -469,31 +474,41 @@ describe('addParagraphSpacers', () => {
     expect(addParagraphSpacers(input)).toBe(input)
   })
 
-  test('does NOT space a gap adjacent to a list (tight list rhythm preserved)', () => {
-    const input = 'Here are the steps.\n\n- first\n- second'
-    expect(addParagraphSpacers(input)).toBe(input)
-    const input2 = '- first\n- second\n\nClosing prose after the list.'
-    expect(addParagraphSpacers(input2)).toBe(input2)
+  test('spaces prose↔list transitions (uniform block spacing), list interior tight', () => {
+    expect(addParagraphSpacers('Here are the steps.\n\n- first\n- second')).toBe(
+      `Here are the steps.${gap}- first\n- second`,
+    )
+    expect(addParagraphSpacers('- first\n- second\n\nClosing prose after the list.')).toBe(
+      `- first\n- second${gap}Closing prose after the list.`,
+    )
   })
 
-  test('does NOT space a gap adjacent to a table', () => {
-    const input = 'Intro.\n\n| a | b |\n| --- | --- |\n| 1 | 2 |'
-    expect(addParagraphSpacers(input)).toBe(input)
+  test('spaces a prose→table boundary; table rows stay contiguous', () => {
+    const table = '| a | b |\n| --- | --- |\n| 1 | 2 |'
+    expect(addParagraphSpacers(`Intro.\n\n${table}`)).toBe(`Intro.${gap}${table}`)
   })
 
-  test('does NOT space a gap adjacent to a fenced code block', () => {
+  test('spaces prose↔fence boundaries; fence interior untouched', () => {
     const input = 'Look here.\n\n```js\nconst a = 1;\n```\n\nDone.'
-    // Neither the prose→fence nor the fence→prose gap gets a spacer.
-    expect(addParagraphSpacers(input)).toBe(input)
+    expect(addParagraphSpacers(input)).toBe(
+      `Look here.${gap}\`\`\`js\nconst a = 1;\n\`\`\`${gap}Done.`,
+    )
   })
 
-  test('does NOT space a gap adjacent to a heading or blockquote', () => {
+  test('spaces heading→anything and blockquote boundaries', () => {
     expect(addParagraphSpacers('Intro prose.\n\n## Section\n\nBody prose.')).toBe(
-      'Intro prose.\n\n## Section\n\nBody prose.',
+      `Intro prose.${gap}## Section${gap}Body prose.`,
     )
     expect(addParagraphSpacers('Said.\n\n> a quote\n\nAfter.')).toBe(
-      'Said.\n\n> a quote\n\nAfter.',
+      `Said.${gap}> a quote${gap}After.`,
     )
+  })
+
+  test('does NOT space between items of the same loose list / same-kind blocks', () => {
+    const looseList = '- first\n\n- second\n\n- third'
+    expect(addParagraphSpacers(looseList)).toBe(looseList)
+    const quotes = '> one\n\n> two'
+    expect(addParagraphSpacers(quotes)).toBe(quotes)
   })
 
   test('never reaches inside a fenced block (interior blank line untouched)', () => {
@@ -501,8 +516,6 @@ describe('addParagraphSpacers', () => {
     const out = addParagraphSpacers(input)
     // The fence interior — including its own blank line — is byte-for-byte intact.
     expect(out).toContain('```\nline 1\n\nline 2\n```')
-    // And no spacer paragraph was injected anywhere (both gaps touch the fence).
-    expect(out).not.toContain(PARAGRAPH_SPACER)
   })
 
   test('a body with no paragraph gap is returned unchanged', () => {
@@ -521,9 +534,9 @@ describe('addParagraphSpacers', () => {
     const out = addParagraphSpacers(normalizeParagraphBreaks(input))
     // The two prose paragraphs gain a visible spacer between them.
     expect(out).toContain(`Summary of the change.${gap}It does two things.`)
-    // The list stays tight (no spacer wedged before it).
-    expect(out).toContain('- adds a normalizer\n- lifts the cap')
-    expect(out).not.toContain(`${PARAGRAPH_SPACER}\n\n- adds`)
+    // The prose→list transition gains a spacer too (uniform block spacing),
+    // but the list INTERIOR stays tight.
+    expect(out).toContain(`It does two things.${gap}- adds a normalizer\n- lifts the cap`)
   })
 })
 


### PR DESCRIPTION
## Summary

Fleet-wide consistent Telegram formatting, enforced deterministically at the gateway on every outbound message (reply / edit_message / stream_reply), plus one concise shared prompt spec.

**Job served:** `reference/jobs/feel-like-a-colleague.md` — the agent communicates the way a trusted colleague would; inconsistent spacing, AI-tell dashes, unicode-bullet lists that don't render, and over-bolded walls are exactly the "chatbot in a Telegram skin" failure the job names. Vision outcome: readability/visibility of the standing team's replies (outcome 1/2 — the user reads these on a phone; the framework, not per-model habit, owns the typography).

## Code changes (`telegram-plugin/format.ts`)

1. **Uniform block spacing** — `addParagraphSpacers` now inserts the visible U+00A0 spacer line at **every** block transition (paragraph↔list, heading→anything, table/blockquote/fence boundaries), not just prose→prose. Interiors stay tight: no spacer between items of the same loose list, rows of a table, or consecutive quote lines. `ensureBlockBoundaries` gained a list-start rule so a list glued to prose by a single `\n` becomes a visible transition.
2. **`normalizePunctuation` (new export)** — on code-masked text (reuses `maskCodeRegions`): ` — `/` – ` → `, ` (digit-flanked → hyphen range), bare `word—word` → `, `, bare en-dash between words → `-`, leading `•`/`·` markers → `- `. Idempotent; code spans/fences untouched.
3. **`stripExcessBold` (new export)** — over-bold tripwire: strips `**` markers when >30% of non-code chars are bold, or when an entire multi-line paragraph / every item of a list is fully bolded. Conservative: <100-char messages exempt; a single short fully-bolded line (pseudo-heading) survives; a list with any plain item is left alone.

Wired in the same send path as `normalizeParagraphBreaks`/`addParagraphSpacers`: `gateway.ts` reply + edit paths, and as optional deps in `stream-reply-handler.ts`.

## Prompt spec

`TELEGRAM_FORMATTING_FLOOR_CARD` ("Formatting for Telegram", `src/agents/scaffold.ts`) rewritten to the one shared spec — (a) short answers = plain prose, no formatting; (b) default = light structure, bold only the one key fact, lists only for 3+ parallel items; (c) long answers may use tables/headings/quotes only when they genuinely aid scanning — with a note that spacing/dashes/bullets are normalized in code so agents shouldn't fight it. `reference/telegram-formatting-guide.md` mirror updated verbatim in the same commit.

## Before / after (mixed prose + list + heading message)

Raw model output:

```
# Status
Summary line — two fixes landed.
• item one
• item two
Closing prose.
```

Rendered before (glued blocks, dead • bullets, em-dash tell):

```
# Status
Summary line — two fixes landed.
• item one
• item two
Closing prose.
```

Rendered after (uniform one-blank-line block rhythm, real GFM list):

```
# Status
␣                       ← visible spacer line
Summary line, two fixes landed.
␣
- item one
- item two
␣
Closing prose.
```

## Test plan

- [x] New `telegram-plugin/tests/format-consistency.test.ts` (29 tests): every transition kind, list/table interiors untouched, code-masking safety, idempotency for all three passes, chunk-boundary spacer stripping.
- [x] Updated `paragraph-normalizer.test.ts` old-contract tests (structural gaps deliberately now get spacers per the approved design).
- [x] `npm run lint` clean (incl. `check-bot-api-wrapping`, `check-plugin-references`).
- [x] Full `vitest run telegram-plugin/tests/` — 4511 pass (one unrelated 20k-seed property test timed out under full-suite load, passes standalone).
- [x] `npm run test:bun` — 1065 pass; the 2 failures (`src/vault/broker/client-token.test.ts`) reproduce on clean `origin/main` (host-environment dependent, unrelated).

## Risk / notes

- **Telemetry note (review finding 1):** scrubVoice's dash telemetry (`voice_scrub_applied`) will drop to ~zero on the reply/edit/stream paths since `normalizePunctuation` now consumes dashes first — deliberate.

- `normalizePunctuation` runs before the voice scrub (#1683), so spaced em-dashes now degrade to **commas** per the approved spec instead of the scrub's full-stop substitution; the scrub remains as backstop for forms this pass doesn't cover.
- Bold-strip is conservative by design; the `<100` char and pseudo-heading exemptions keep house-style short replies untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
