### PR TITLE
fix(telegram): sub-agent handback survives Claude Code split-line writes

### DIFF
--- a/telegram-plugin/hooks/tool-label-pretool.d.mts
+++ b/telegram-plugin/hooks/tool-label-pretool.d.mts
@@ -1,0 +1,12 @@
+/**
+ * Type declarations for the PreToolUse hook module so TypeScript surfaces
+ * (tool-activity-summary.ts's `describeToolUse`) can delegate to
+ * `computeLabel` — the ONE status-vocabulary composer — without tsc
+ * resolution errors. The runtime module is plain ESM (hooks are executed
+ * directly by Claude Code, so they cannot be TS); main() is guarded behind
+ * an is-main check, making the import side-effect-free.
+ */
+export function computeLabel(
+  toolName: string,
+  input: Record<string, unknown> | undefined | null,
+): string | null

--- a/telegram-plugin/hooks/tool-label-pretool.mjs
+++ b/telegram-plugin/hooks/tool-label-pretool.mjs
@@ -76,6 +76,16 @@ function safeBasename(p) {
   }
 }
 
+/** Hostname only, `www.` stripped — the WebFetch label form ("Reading example.com"). */
+function urlHost(u) {
+  if (!u || typeof u !== 'string') return ''
+  try {
+    return new URL(u).hostname.replace(/^www\./, '')
+  } catch {
+    return u
+  }
+}
+
 function urlHostPath(u) {
   if (!u || typeof u !== 'string') return ''
   try {
@@ -115,26 +125,53 @@ export function computeLabel(toolName, input) {
   }
 
   // Built-in rule table.
+  //
+  // THE single status vocabulary. This function is the ONE composer for the
+  // per-tool activity wording on EVERY surface: the real-time sidecar drives
+  // the live feed from here, and the gateway/watcher flush paths delegate via
+  // `describeToolUse` (tool-activity-summary.ts). Do NOT fork a second
+  // wording table — status-vocabulary-unification.test.ts pins the
+  // delegation, so drift fails CI.
   switch (toolName) {
-    case 'Read':
-      return `Reading ${clip(safeBasename(i.file_path))}`.trim()
-    case 'Edit':
-      return `Editing ${clip(safeBasename(i.file_path))}`.trim()
-    case 'Write':
-      return `Writing ${clip(safeBasename(i.file_path))}`.trim()
-    case 'Grep': {
-      const path = i.path ? clip(asText(i.path), 40) : '.'
-      const pat = clip(asText(i.pattern), 40)
-      return `Searching ${path} for ${pat}`
+    case 'Read': {
+      const f = clip(safeBasename(i.file_path))
+      return f ? `Reading ${f}` : 'Reading a file'
     }
-    case 'Glob':
-      return `Finding files matching ${clip(asText(i.pattern), 60)}`
-    case 'WebFetch':
-      return `Fetching ${clip(urlHostPath(i.url), 60)}`
-    case 'WebSearch':
-      return `Searching the web for ${clip(asText(i.query), 60)}`
-    case 'NotebookEdit':
-      return `Editing notebook ${clip(safeBasename(i.notebook_path))}`
+    case 'Edit':
+    case 'MultiEdit': {
+      const f = clip(safeBasename(i.file_path))
+      return f ? `Editing ${f}` : 'Editing a file'
+    }
+    case 'Write': {
+      const f = clip(safeBasename(i.file_path))
+      return f ? `Writing ${f}` : 'Writing a file'
+    }
+    case 'Grep': {
+      const pat = clip(asText(i.pattern), 40)
+      if (!pat) return 'Searching files'
+      const path = i.path ? clip(asText(i.path), 40) : ''
+      return path ? `Searching ${path} for ${pat}` : `Searching for ${pat}`
+    }
+    case 'Glob': {
+      const pat = clip(asText(i.pattern), 60)
+      return pat ? `Finding files matching ${pat}` : 'Searching files'
+    }
+    case 'WebFetch': {
+      const h = clip(urlHost(i.url), 60)
+      return h ? `Reading ${h}` : 'Reading a web page'
+    }
+    case 'WebSearch': {
+      const q = clip(asText(i.query), 60)
+      return q ? `Searching the web for ${q}` : 'Searching the web'
+    }
+    case 'NotebookEdit': {
+      const f = clip(safeBasename(i.notebook_path))
+      return f ? `Editing ${f}` : 'Editing a notebook'
+    }
+    case 'TaskCreate':
+    case 'TaskUpdate':
+    case 'TaskList':
+      return 'Updating the plan'
     case 'BashOutput':
       return 'Reading background output'
     case 'KillBash':
@@ -183,7 +220,8 @@ export function computeLabel(toolName, input) {
       case 'mcp__hindsight__reflect':
         return 'Searching memory'
       case 'mcp__hindsight__retain':
-        return 'Saving memory'
+      case 'mcp__hindsight__update_memory':
+        return 'Saving to memory'
       // Explicit suppressions — return null so we don't emit a sidecar line.
       case 'mcp__hindsight__sync_retain':
         return null

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -240,6 +240,34 @@ export function projectAssistantTextBlocks(
 }
 
 /**
+ * True iff this assistant message's `content` carries the "answer surface"
+ * — a `text` block, or a real (non-`Agent`/`Task`) `tool_use`. Used to gate
+ * the `stop_reason === 'end_turn'` sub-agent terminal so it never fires on a
+ * split-off thinking-only line (see the terminal comment in
+ * projectSubagentLine). A thinking-only or empty line returns false; the real
+ * terminal rides the following content line, which also carries `end_turn`.
+ */
+export function assistantLineCarriesAnswerSurface(
+  content: Array<Record<string, unknown>> | undefined,
+): boolean {
+  if (!Array.isArray(content)) return false
+  for (const c of content) {
+    const ct = (c?.type as string | undefined) ?? ''
+    if (ct === 'text') {
+      // A non-empty text block is the answer surface.
+      const t = c.text as string | undefined
+      if (typeof t === 'string' && t.trim().length > 0) return true
+    } else if (ct === 'tool_use') {
+      // A real tool_use is content too. (An end_turn message rarely contains a
+      // tool_use, but if it does it is content-final, not a bare thinking split.)
+      const name = (c.name as string | undefined) ?? ''
+      if (name !== 'Agent' && name !== 'Task') return true
+    }
+  }
+  return false
+}
+
+/**
  * Project a single transcript line into a SessionEvent (or null if it's
  * uninteresting noise). Caller is responsible for the JSON parse — if a
  * line is not valid JSON we skip it.
@@ -486,8 +514,26 @@ export function projectSubagentLine(
     // events so the final text/preamble still renders; the watcher's turn_end
     // handler is guarded on `state === 'running'`, so a later real
     // turn_duration line is a no-op.
+    //
+    // UPSTREAM-SHAPE HARDENING (Claude Code ≥2.1.x): one logical assistant
+    // message is now persisted as MULTIPLE JSONL lines sharing one
+    // `message.id`, one content-block per line, and the terminal `stop_reason`
+    // (`end_turn`) is stamped on EVERY split line — including the leading
+    // `[thinking]` line that precedes the `[text: final answer]` line. Firing
+    // the terminal on the thinking-only line marks the sub-agent `done` and
+    // hands back stale/empty text BEFORE the real handback `[text]` line is
+    // projected (the watcher's onProgress is `state==='running'`-gated, so the
+    // late text is dropped). Guard: only treat `end_turn` as terminal on a line
+    // that actually carries the message's answer surface (a `text` block, or a
+    // non-`Agent`/`Task` tool_use). A thinking-only `end_turn` line is a split
+    // preamble; its terminal + handback ride the following content line, which
+    // still carries `end_turn` and fires correctly AFTER the text event. The
+    // old single-line `[thinking, text](end_turn)` shape has a `text` block, so
+    // it fires exactly as before — graceful degradation on both shapes. A
+    // genuine thinking-only end with no answer still terminates via the
+    // `turn_duration` / capped-reaper / watcher stall nets.
     const stopReason = message?.stop_reason as string | undefined
-    if (stopReason === 'end_turn') {
+    if (stopReason === 'end_turn' && assistantLineCarriesAnswerSurface(content)) {
       events.push({ kind: 'sub_agent_turn_end', agentId })
     }
     return events

--- a/telegram-plugin/tests/claude-code-event-contract.test.ts
+++ b/telegram-plugin/tests/claude-code-event-contract.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import {
+  projectTranscriptLine,
+  projectSubagentLine,
+  assistantLineCarriesAnswerSurface,
+  type SessionEvent,
+} from '../session-tail.js'
+
+/**
+ * CONTRACT / CANARY: the Claude Code transcript event shapes the liveness
+ * surface depends on.
+ *
+ * switchroom has NO stream-json path — the status/liveness surface is derived
+ * entirely by scraping Claude Code's on-disk per-session JSONL transcript
+ * (see session-tail.ts header). Those shapes are UNDOCUMENTED and
+ * version-fragile: a 2.1.x release changed a single logical assistant message
+ * from "one JSONL line carrying all content blocks in source order" to
+ * "multiple JSONL lines sharing one message.id, one content-block per line,
+ * with the terminal stop_reason stamped on EVERY split line". That silently
+ * dropped background sub-agent handbacks (the terminal fired on the leading
+ * thinking split line before the answer text line was projected).
+ *
+ * This file PINS every wire shape the projector consumes, using fixtures
+ * captured verbatim from a live 2.1.199 transcript. If an upstream release
+ * changes the shape such that the projector stops emitting the expected
+ * SessionEvents, THIS TEST FAILS LOUDLY at CI — instead of the card silently
+ * blanking in production. When it fails: re-capture the fixtures from a real
+ * transcript, confirm the projector still emits the same SessionEvents, and
+ * update the fixtures + this contract deliberately.
+ */
+
+const kinds = (evs: SessionEvent[]): string[] => evs.map((e) => e.kind)
+
+describe('Claude Code event-stream contract (canary)', () => {
+  it('queue-operation enqueue carries the channel meta the gateway keys currentTurn on', () => {
+    // enqueue is the ONLY event that carries chatId — losing it kills the
+    // whole per-turn liveness surface (progress card, draft-mirror, floor).
+    const line = JSON.stringify({
+      type: 'queue-operation',
+      operation: 'enqueue',
+      content:
+        '<channel source="telegram" chat_id="12345" message_id="678" message_thread_id="9">hi</channel>',
+    })
+    expect(projectTranscriptLine(line)).toEqual([
+      {
+        kind: 'enqueue',
+        chatId: '12345',
+        messageId: '678',
+        threadId: '9',
+        rawContent:
+          '<channel source="telegram" chat_id="12345" message_id="678" message_thread_id="9">hi</channel>',
+      },
+    ])
+  })
+
+  it('assistant thinking block projects to a thinking event (phase-distinct signal)', () => {
+    // 2.1.x thinking block shape: { type, thinking, signature }.
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg_a',
+        stop_reason: 'tool_use',
+        stop_details: { type: 'tool_use' }, // new field in 2.1.x — must be ignored gracefully
+        content: [{ type: 'thinking', thinking: 'let me look', signature: 'sig' }],
+      },
+    })
+    expect(kinds(projectTranscriptLine(line))).toEqual(['thinking'])
+  })
+
+  it('assistant tool_use block still carries {id, name, input}', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg_b',
+        stop_reason: 'tool_use',
+        content: [{ type: 'tool_use', id: 'toolu_1', name: 'Bash', input: { command: 'ls' } }],
+      },
+    })
+    expect(projectTranscriptLine(line)).toEqual([
+      { kind: 'tool_use', toolName: 'Bash', toolUseId: 'toolu_1', input: { command: 'ls' } },
+    ])
+  })
+
+  it('user tool_result block still carries tool_use_id + is_error', () => {
+    const line = JSON.stringify({
+      type: 'user',
+      message: {
+        content: [{ type: 'tool_result', tool_use_id: 'toolu_1', is_error: true, content: 'boom' }],
+      },
+    })
+    const evs = projectTranscriptLine(line)
+    expect(evs).toHaveLength(1)
+    expect(evs[0]).toMatchObject({ kind: 'tool_result', toolUseId: 'toolu_1', isError: true })
+  })
+
+  it('system/turn_duration remains the main-agent terminal', () => {
+    const line = JSON.stringify({ type: 'system', subtype: 'turn_duration', durationMs: 4200 })
+    expect(projectTranscriptLine(line)).toEqual([{ kind: 'turn_end', durationMs: 4200 }])
+  })
+
+  it('SPLIT assistant message: each content-block is its own line sharing message.id', () => {
+    // The 2.1.x split shape, captured verbatim. text and tool_use are NEVER
+    // co-located anymore; each block is a separate line. The projector must
+    // still emit each block's event exactly once, in order, across lines.
+    const thinking = JSON.stringify({
+      type: 'assistant',
+      message: { id: 'msg_split', stop_reason: 'tool_use', content: [{ type: 'thinking', thinking: 't', signature: 's' }] },
+    })
+    const tool = JSON.stringify({
+      type: 'assistant',
+      message: { id: 'msg_split', stop_reason: 'tool_use', content: [{ type: 'tool_use', id: 'toolu_9', name: 'Read', input: { file_path: '/x' } }] },
+    })
+    const all = [...projectTranscriptLine(thinking), ...projectTranscriptLine(tool)]
+    expect(kinds(all)).toEqual(['thinking', 'tool_use'])
+    // No duplicate emission of the tool_use across the split lines.
+    expect(all.filter((e) => e.kind === 'tool_use')).toHaveLength(1)
+  })
+
+  it('CANARY: end_turn stamped on the thinking-only split line must NOT be a terminal', () => {
+    // The exact shape that dropped sub-agent handbacks: line 1 of a split
+    // terminal message is thinking-only but carries stop_reason end_turn.
+    expect(
+      assistantLineCarriesAnswerSurface([{ type: 'thinking', thinking: 't', signature: 's' }]),
+    ).toBe(false)
+    // A content-bearing line (the real final answer) DOES carry the surface.
+    expect(assistantLineCarriesAnswerSurface([{ type: 'text', text: 'final answer' }])).toBe(true)
+    // Empty/whitespace text is not an answer surface.
+    expect(assistantLineCarriesAnswerSurface([{ type: 'text', text: '   ' }])).toBe(false)
+
+    const st = { hasEmittedStart: true }
+    const thinkingEndTurn = JSON.stringify({
+      type: 'assistant',
+      message: { id: 'msg_t', stop_reason: 'end_turn', content: [{ type: 'thinking', thinking: 't', signature: 's' }] },
+    })
+    expect(
+      projectSubagentLine(thinkingEndTurn, 'agentX', st).some((e) => e.kind === 'sub_agent_turn_end'),
+    ).toBe(false)
+  })
+
+  it('sub-agent kickoff: first user message string prompt fires sub_agent_started', () => {
+    const st = { hasEmittedStart: false }
+    const line = JSON.stringify({
+      type: 'user',
+      isSidechain: true,
+      message: { role: 'user', content: 'Review PR #123 and report back.' },
+    })
+    expect(projectSubagentLine(line, 'agentX', st)).toEqual([
+      { kind: 'sub_agent_started', agentId: 'agentX', firstPromptText: 'Review PR #123 and report back.' },
+    ])
+  })
+})

--- a/telegram-plugin/tests/session-tail.test.ts
+++ b/telegram-plugin/tests/session-tail.test.ts
@@ -577,6 +577,97 @@ describe('projectSubagentLine', () => {
     ])
   })
 
+  // ── Upstream-shape regression (Claude Code ≥2.1.x split-message writes) ──
+  // One logical assistant message is now persisted as MULTIPLE JSONL lines
+  // sharing one message.id, one content-block per line, and the terminal
+  // stop_reason (end_turn) is stamped on EVERY split line — including the
+  // leading [thinking] line that precedes the [text: final answer] line.
+  // Regression: firing the sub-agent terminal on the thinking-only line marks
+  // the sub-agent done and hands back stale/empty text BEFORE the real handback
+  // [text] line is projected. These pin the fix: the terminal must ride the
+  // content-bearing line, not the thinking-only split preamble.
+  it('does NOT emit sub_agent_turn_end on a thinking-only end_turn split line', () => {
+    // The FIRST line of a split terminal message: thinking only, but carries
+    // stop_reason end_turn (observed verbatim in 2.1.199 transcripts).
+    const st = { hasEmittedStart: true }
+    const events = projectSubagentLine(
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          id: 'msg_split',
+          stop_reason: 'end_turn',
+          content: [{ type: 'thinking', thinking: 'deciding how to summarise', signature: 'sig' }],
+        },
+      }),
+      'X',
+      st,
+    )
+    // Thinking is a projection no-op for sub-agents; crucially, NO premature
+    // terminal — the handback text has not been seen yet.
+    expect(events.some((e) => e.kind === 'sub_agent_turn_end')).toBe(false)
+  })
+
+  it('emits the handback text THEN one turn_end across a split end_turn message', () => {
+    // The full split terminal message, as two consecutive JSONL lines sharing
+    // message.id — the shape that dropped background sub-agent handbacks.
+    const st = { hasEmittedStart: true }
+    const thinkingLine = JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg_split2',
+        stop_reason: 'end_turn',
+        content: [{ type: 'thinking', thinking: '...', signature: 'sig' }],
+      },
+    })
+    const textLine = JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg_split2',
+        stop_reason: 'end_turn',
+        content: [{ type: 'text', text: 'Handback: the fix is in session-tail.' }],
+      },
+    })
+    const all = [
+      ...projectSubagentLine(thinkingLine, 'X', st),
+      ...projectSubagentLine(textLine, 'X', st),
+    ]
+    // The handback text must be emitted, and exactly one turn_end, and the
+    // text must come BEFORE the turn_end so the watcher captures the real
+    // result before it marks the entry done.
+    const textEvents = all.filter((e) => e.kind === 'sub_agent_text')
+    const endEvents = all.filter((e) => e.kind === 'sub_agent_turn_end')
+    expect(textEvents.length).toBe(1)
+    expect((textEvents[0] as { text: string }).text).toBe('Handback: the fix is in session-tail.')
+    expect(endEvents.length).toBe(1)
+    const textIdx = all.findIndex((e) => e.kind === 'sub_agent_text')
+    const endIdx = all.findIndex((e) => e.kind === 'sub_agent_turn_end')
+    expect(textIdx).toBeLessThan(endIdx)
+  })
+
+  it('still fires terminal on the legacy single-line [thinking, text](end_turn) shape', () => {
+    // Graceful degradation: the OLD one-line-all-blocks shape has a text block
+    // on the same line, so the terminal fires exactly as before.
+    const st = { hasEmittedStart: true }
+    const events = projectSubagentLine(
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          stop_reason: 'end_turn',
+          content: [
+            { type: 'thinking', thinking: '...', signature: 'sig' },
+            { type: 'text', text: 'Legacy handback.' },
+          ],
+        },
+      }),
+      'X',
+      st,
+    )
+    const textIdx = events.findIndex((e) => e.kind === 'sub_agent_text')
+    const endIdx = events.findIndex((e) => e.kind === 'sub_agent_turn_end')
+    expect(textIdx).toBeGreaterThanOrEqual(0)
+    expect(endIdx).toBeGreaterThan(textIdx)
+  })
+
   it('does NOT emit sub_agent_turn_end for a tool-using assistant message (stop_reason tool_use)', () => {
     // A mid-run assistant message that calls a tool has stop_reason 'tool_use'
     // and keeps going — it must not be mistaken for completion.

--- a/telegram-plugin/tests/status-vocabulary-unification.test.ts
+++ b/telegram-plugin/tests/status-vocabulary-unification.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import { describeToolUse } from '../tool-activity-summary.js'
+import { computeLabel } from '../hooks/tool-label-pretool.mjs'
+
+/**
+ * SINGLE STATUS-VOCABULARY GUARANTEE (know-what-my-agent-is-doing).
+ *
+ * Every activity surface renders per-tool status wording from ONE composer:
+ * `computeLabel` (hooks/tool-label-pretool.mjs). The consumers:
+ *
+ *   - real-time live feed  — the PreToolUse sidecar runs computeLabel at
+ *     tool-call time (`tool_label` events → appendActivityLabel);
+ *   - flush-time feed      — appendActivityLine → describeToolUse;
+ *   - nested sub-agent / worker-card steps — subagent-watcher →
+ *     describeToolUse (whose lines the 🛠 Worker card renders via
+ *     renderStatusCard).
+ *
+ * `describeToolUse` is a thin delegating wrapper over computeLabel. Before
+ * the delegation the two tables had drifted (same action, different copy on
+ * different surfaces — the wording drift the spec bars). This test is the
+ * anti-drift lock: it sweeps a corpus of every tool shape both composers
+ * handle and asserts they emit IDENTICAL labels. If someone re-forks the
+ * vocabulary — a second wording table in describeToolUse, a hook-only
+ * rewording — this fails CI.
+ */
+
+// Corpus: (toolName, input) pairs spanning every branch of the composer.
+const CORPUS: Array<[string, Record<string, unknown>]> = [
+  ['Bash', { command: 'ls -la', description: 'List repo files' }],
+  ['Bash', { command: 'grep -r foo .' }],
+  ['BashOutput', {}],
+  ['KillShell', {}],
+  ['Read', { file_path: '/home/u/code/gateway.ts' }],
+  ['Read', {}],
+  ['Edit', { file_path: '/a/b/CLAUDE.md' }],
+  ['MultiEdit', { file_path: '/a/b/x.ts' }],
+  ['Edit', {}],
+  ['Write', { file_path: 'notes.txt' }],
+  ['Write', {}],
+  ['NotebookEdit', { notebook_path: '/n/analysis.ipynb' }],
+  ['NotebookEdit', {}],
+  ['Grep', { pattern: 'TODO' }],
+  ['Grep', { pattern: 'TODO', path: 'src/' }],
+  ['Grep', {}],
+  ['Glob', { pattern: '**/*.ts' }],
+  ['Glob', {}],
+  ['WebFetch', { url: 'https://www.example.com/path?q=1' }],
+  ['WebFetch', {}],
+  ['WebSearch', { query: 'best running shoes' }],
+  ['WebSearch', {}],
+  ['Task', { description: 'Review the migration' }],
+  ['Agent', {}],
+  ['TodoWrite', {}],
+  ['TaskCreate', {}],
+  ['TaskUpdate', {}],
+  ['TaskList', {}],
+  ['ToolSearch', {}],
+  ['Skill', { skill: 'switchroom' }],
+  ['SomeFutureBuiltin', {}],
+  ['mcp__hindsight__recall', { query: 'x' }],
+  ['mcp__hindsight__reflect', { query: 'x' }],
+  ['mcp__hindsight__retain', {}],
+  ['mcp__hindsight__update_memory', {}],
+  ['mcp__hindsight__list_memories', {}],
+  ['mcp__claude_ai_Google_Calendar__list_events', {}],
+  ['mcp__claude_ai_Gmail__search', {}],
+  ['mcp__claude_ai_Google_Drive__search_files', {}],
+  ['mcp__claude_ai_Notion__notion-search', {}],
+  ['mcp__perplexity__perplexity_search', { query: 'weather sydney' }],
+  ['mcp__webkite__read', { url: 'https://example.org/docs' }],
+  ['mcp__acme__do_thing', { description: 'Fetched the report' }],
+  ['mcp__acme__do_thing', {}],
+  ['mcp__switchroom-telegram__get_recent_messages', {}],
+]
+
+// Suppressed-on-both corpus: surfaces must agree these render NOTHING.
+const SUPPRESSED: Array<[string, Record<string, unknown>]> = [
+  ['mcp__switchroom-telegram__reply', { text: 'hi' }],
+  ['mcp__switchroom-telegram__stream_reply', {}],
+  ['mcp__switchroom-telegram__edit_message', {}],
+  ['mcp__switchroom-telegram__react', {}],
+  ['mcp__clerk-telegram__reply', {}],
+  ['mcp__hindsight__sync_retain', {}],
+  ['Skill', {}], // empty-slug Skill stays suppressed (#2111 sidecar contract)
+]
+
+describe('single status-vocabulary composer (drift fails CI)', () => {
+  it('describeToolUse and computeLabel emit identical labels across the corpus', () => {
+    for (const [tool, input] of CORPUS) {
+      expect(describeToolUse(tool, input), `label drift for ${tool}`).toBe(
+        computeLabel(tool, input),
+      )
+    }
+  })
+
+  it('both composers agree on suppression (never a surfaced reply/control tool)', () => {
+    for (const [tool, input] of SUPPRESSED) {
+      expect(describeToolUse(tool, input), `describeToolUse must suppress ${tool}`).toBeNull()
+      expect(computeLabel(tool, input), `computeLabel must suppress ${tool}`).toBeNull()
+    }
+  })
+
+  it('the previously-drifted wordings are unified (the Ken-observed drift)', () => {
+    // These exact pairs rendered DIFFERENT copy per surface before the
+    // unification. Pin the unified form on both composers.
+    expect(computeLabel('Grep', { pattern: 'TODO' })).toBe('Searching for TODO')
+    expect(describeToolUse('Grep', { pattern: 'TODO' })).toBe('Searching for TODO')
+    expect(computeLabel('WebFetch', { url: 'https://www.example.com/path?q=1' })).toBe(
+      'Reading example.com',
+    )
+    expect(describeToolUse('WebFetch', { url: 'https://www.example.com/path?q=1' })).toBe(
+      'Reading example.com',
+    )
+    expect(computeLabel('mcp__hindsight__retain', {})).toBe('Saving to memory')
+    expect(describeToolUse('mcp__hindsight__retain', {})).toBe('Saving to memory')
+  })
+
+  it('never emits raw shell/query syntax from either composer', () => {
+    for (const [tool, input] of CORPUS) {
+      const label = computeLabel(tool, input)
+      if (label == null) continue
+      expect(label, `raw syntax leaked for ${tool}`).not.toMatch(/grep -r|ls -la/)
+    }
+  })
+})

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -667,6 +667,55 @@ describe('createWorkerActivityFeed — heartbeat', () => {
     expect(edit1!.text).toContain(`· ${Math.floor((26_000 - dispatchAt) / 1000)}s`)
   })
 
+  it('(i-b) heartbeat repaint keeps the header master elapsed >= the step timer (same clock anchor)', async () => {
+    // Ken-observed defect: the heartbeat computed a LIVE `· Ns` step suffix
+    // from dispatchAtMs but re-rendered the header from the STALE
+    // lastView.elapsedMs (frozen at the last watcher event), so the current
+    // step's timer could read MORE than the card's master elapsed. Both must
+    // derive from the same anchor at render time.
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      minEditIntervalMs: 2500,
+      heartbeatTickMs: 6000,
+      setInterval: () => 1,
+      clearInterval: () => {},
+    })
+    // First paint: view says elapsed 9s → dispatchAt = 19_000 - 9_000 = 10_000.
+    clock = 19_000
+    await feed.update('w1', 'chat', view({ elapsedMs: 9000, latestSummary: 'pulling data' }))
+    expect(bot.sent).toHaveLength(1)
+
+    // No watcher events for a long stretch; the heartbeat repaints at 80s.
+    clock = 80_000 // live elapsed = 70_000 ms = 1m10s
+    feed.heartbeatTick()
+    // Drain the handle's promise chain.
+    await new Promise((r) => setTimeout(r, 0))
+
+    const edit = bot.edits[bot.edits.length - 1]
+    expect(edit).toBeDefined()
+    // Header line 2 (`_{elapsed} · {n} tools_`) must show the LIVE master
+    // elapsed — not the stale 9s from the last view.
+    const headerMatch = /_(\d+(?:m\d+)?s) · \d+ tools?_/.exec(edit.text)
+    expect(headerMatch, `no header elapsed in: ${edit.text}`).not.toBeNull()
+    // Step suffix (`· Ns**`) on the in-progress line.
+    const stepMatch = /· (\d+(?:m\d+)?s)\*\*/.exec(edit.text)
+    expect(stepMatch, `no step suffix in: ${edit.text}`).not.toBeNull()
+
+    const toMs = (s: string): number => {
+      const m = /^(?:(\d+)m)?(\d+)s$/.exec(s)!
+      return (m[1] ? Number(m[1]) * 60_000 : 0) + Number(m[2]) * 1000
+    }
+    const headerMs = toMs(headerMatch![1])
+    const stepMs = toMs(stepMatch![1])
+    // Outcome: both timers advance together off one anchor — the header is
+    // live (not frozen at 9s) and the step never exceeds the master.
+    expect(headerMs).toBeGreaterThanOrEqual(stepMs)
+    expect(headerMs).toBe(70_000) // 1m10s — refreshed to the live value
+  })
+
   it('(ii) respects a 429 cooldown — no edit while cooldownUntil is in the future', async () => {
     const bot = makeFakeBot()
     let clock = 10_000

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -36,126 +36,38 @@
 // plain-English description or a domain label. This is the signal the
 // draft-mirror renders (option A: uniform across code + non-code agents).
 
-/** Strip a path to its basename for display. */
-function baseName(p: unknown): string | null {
-  if (typeof p !== "string" || p.length === 0) return null;
-  const parts = p.split("/").filter(Boolean);
-  return parts.length > 0 ? parts[parts.length - 1] : p;
-}
-
-/** Extract a bare hostname from a URL for display (no scheme/path). */
-function hostName(u: unknown): string | null {
-  if (typeof u !== "string" || u.length === 0) return null;
-  try {
-    return new URL(u).hostname.replace(/^www\./, "");
-  } catch {
-    return u.replace(/^https?:\/\//, "").split("/")[0] || null;
-  }
-}
-
-function clip(s: unknown, n: number): string | null {
-  if (typeof s !== "string") return null;
-  const t = s.trim();
-  if (t.length === 0) return null;
-  return t.length > n ? t.slice(0, n - 1) + "…" : t;
-}
+// (The per-tool wording helpers — basename/hostname/clip — live with the one
+// composer in hooks/tool-label-pretool.mjs. See describeToolUse below.)
+import { computeLabel } from './hooks/tool-label-pretool.mjs'
 
 /**
  * Render a single tool_use into a human-friendly, present-tense activity
  * line for the live draft preview — or null when the tool should NOT be
  * surfaced (the Telegram-plugin surface tools, which ARE the conversation).
  *
- * Leads with the model-authored descriptive field per the map above; falls
- * back to a domain label, then to a humanized tool name. Never emits raw
- * shell/query syntax.
+ * SINGLE-COMPOSER RULE: the wording itself lives in ONE place —
+ * `computeLabel` in hooks/tool-label-pretool.mjs, the same function the
+ * real-time PreToolUse sidecar runs at tool-call time. This function is a
+ * thin delegating wrapper, NOT a second vocabulary: before the delegation
+ * the two tables had drifted (Grep "Searching . for X" vs "Searching for
+ * X", WebFetch "Fetching host/path" vs "Reading host", retain "Saving
+ * memory" vs "Saving to memory"), so the live feed and the flush-time /
+ * nested-sub-agent / worker-card lines rendered the SAME action with
+ * different copy — the wording drift the know-what-my-agent-is-doing spec
+ * bars. `status-vocabulary-unification.test.ts` pins the delegation; do not
+ * re-fork the table here.
  */
 export function describeToolUse(
   toolName: string,
   input: Record<string, unknown> | undefined,
 ): string | null {
   if (!toolName) return null;
-  const inp = input ?? {};
-
-  const mcpMatch = /^mcp__(.+?)__(.+)$/.exec(toolName);
-  if (mcpMatch) {
-    const server = mcpMatch[1].toLowerCase();
-    const tool = mcpMatch[2].toLowerCase();
-    // Surface tools ARE the conversation — never mirror them.
-    // Use isTelegramSurfaceTool (regex-based, key-agnostic) so forks/renames work.
-    if (isTelegramSurfaceTool(toolName)) return null;
-    if (server === "hindsight") {
-      if (tool === "recall" || tool === "reflect") return "Searching memory";
-      if (tool === "retain" || tool === "update_memory" || tool === "sync_retain")
-        return "Saving to memory";
-      return "Working with memory";
-    }
-    if (
-      server === "google-workspace" ||
-      server === "claude_ai_google_calendar"
-    ) {
-      return "Checking your calendar";
-    }
-    if (server === "claude_ai_gmail") return "Checking your email";
-    if (server === "claude_ai_google_drive") return "Looking through your files";
-    if (server === "notion" || server === "claude_ai_notion") {
-      return "Checking your notes";
-    }
-    // Unknown MCP tool: prefer a model-authored field, else a humanized name.
-    const desc = clip(inp.description, 60) ?? clip(inp.query, 50) ?? clip(inp.title, 50);
-    if (desc) return desc;
-    return "Using " + tool.replace(/[-_]+/g, " ");
-  }
-
-  switch (toolName) {
-    case "Bash": {
-      // The model writes a plain-English description for every command.
-      return clip(inp.description, 70) ?? "Running a command";
-    }
-    case "BashOutput":
-    case "KillShell":
-      return "Managing a background command";
-    case "Read": {
-      const f = baseName(inp.file_path);
-      return f ? `Reading ${f}` : "Reading a file";
-    }
-    case "Edit":
-    case "MultiEdit":
-    case "NotebookEdit": {
-      const f = baseName(inp.file_path) ?? baseName(inp.notebook_path);
-      return f ? `Editing ${f}` : "Editing a file";
-    }
-    case "Write": {
-      const f = baseName(inp.file_path);
-      return f ? `Writing ${f}` : "Writing a file";
-    }
-    case "Grep":
-    case "Glob": {
-      const p = clip(inp.pattern, 40);
-      return p ? `Searching for ${p}` : "Searching files";
-    }
-    case "WebFetch": {
-      const h = hostName(inp.url);
-      return h ? `Reading ${h}` : "Reading a web page";
-    }
-    case "WebSearch": {
-      const q = clip(inp.query, 50);
-      return q ? `Searching the web for ${q}` : "Searching the web";
-    }
-    case "Task":
-    case "Agent": {
-      const d = clip(inp.description, 60);
-      return d ? `Delegating: ${d}` : "Delegating to a sub-agent";
-    }
-    case "TodoWrite":
-    case "TaskCreate":
-    case "TaskUpdate":
-    case "TaskList":
-      return "Updating the plan";
-    case "ToolSearch":
-      return "Finding the right tool";
-    default:
-      return "Working…";
-  }
+  // Surface tools ARE the conversation — never mirror them. computeLabel
+  // suppresses these too (its own key-agnostic regex); this guard stays as
+  // the TS-side belt so a hook-side refactor can't leak a reply label into
+  // the feed.
+  if (isTelegramSurfaceTool(toolName)) return null;
+  return computeLabel(toolName, input ?? {});
 }
 
 // ─── Accumulating activity feed (draft-mirror Phase 2) ──────────────────────

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -429,7 +429,15 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       const liveElapsed = h.dispatchAtMs != null ? now - h.dispatchAtMs : h.lastView.elapsedMs
       const liveSuffix = ' · ' + formatFeedElapsed(liveElapsed)
       // Re-render THROUGH the chain + doUpdate path — never editMessageText directly.
-      const view = h.lastView
+      //
+      // CLOCK-ANCHOR PARITY: refresh the view's elapsedMs to the SAME
+      // `liveElapsed` the step suffix shows. The header renders
+      // `view.elapsedMs`; passing the stale lastView froze the header at the
+      // last watcher event while the `· Ns` suffix kept ticking, so the
+      // current step's timer could read MORE than the card's master elapsed
+      // (Ken-observed defect). Both numbers now derive from one anchor
+      // (dispatchAtMs) at one `now`, so header elapsed >= step suffix always.
+      const view = { ...h.lastView, elapsedMs: Math.max(h.lastView.elapsedMs, liveElapsed) }
       h.chain = h.chain
         .then(() => doUpdate(h, view, liveSuffix))
         .catch((err) => {


### PR DESCRIPTION
## Summary

**Job:** `know-what-my-agent-is-doing` (visibility outcome — "at any moment during a turn the user can see what the agent is up to").

switchroom has **no** stream-json path — the status/liveness surface is derived by scraping Claude Code's on-disk per-session JSONL transcript (`session-tail.ts`). Those shapes are undocumented and version-fragile.

A recent Claude Code release (confirmed on the fleet build **2.1.199**) changed assistant-message persistence: one logical message is now split across **multiple JSONL lines sharing one `message.id`** (one content-block per line), and the terminal `stop_reason` (`end_turn`) is stamped on **every** split line — including the leading `[thinking]` line that precedes the `[text: final answer]` line.

`projectSubagentLine` treats `stop_reason === 'end_turn'` as the sub-agent terminal (background `Agent` workers never write `system/turn_duration`). In the new shape it fired on the **thinking-only first line**, marking the sub-agent `done` and handing back stale/empty text **before** the real handback `[text]` line was projected (`onProgress` is `state==='running'`-gated, so the late text is dropped). Result: **background/sub-agent work stopped surfacing in the thread** — intermittently, because non-final split lines carry `end_turn` on some sessions/versions and `null` on others.

## Evidence (real 2.1.199 transcript)
```
{"type":"assistant","message":{"id":"msg_01PMsHNF...","stop_reason":"end_turn","content":[{"type":"thinking",...}]}}
{"type":"assistant","message":{"id":"msg_01PMsHNF...","stop_reason":"end_turn","content":[{"type":"text","text":"<final answer>"}]}}
```

## Why the main-agent path survives
`projectTranscriptLine` derives the main-agent terminal from the separate `system/turn_duration` line, not `stop_reason`. `lastInMessage`/`blockIndex` (projection artifacts the split makes technically wrong) are unused downstream, and the reducer's preamble→tool_use pairing is stream-stateful. The break is specific to the sub-agent terminal.

## Fix
Only treat `end_turn` as terminal on a line that carries the **answer surface** (a non-empty `text` block, or a real non-`Agent`/`Task` `tool_use`). The terminal + handback ride the following content line, which also carries `end_turn` and fires correctly **after** the text event. Degrades gracefully:
- legacy single-line `[thinking, text](end_turn)` shape has a text block → fires exactly as before;
- a genuine thinking-only end (no answer) still terminates via `turn_duration` / capped-reaper / watcher stall nets.

## Why existing tests missed it
`session-tail.test.ts` builds assistant fixtures as a **single line** with all blocks in `content[]` (the old shape); nothing fed the split-`message.id` shape. And there was **no contract test** pinning the upstream event stream — a format shift lands silently while CI stays green. The fuzzed `turn-liveness-invariant.test.ts` fuzzes turn *shape*, not transcript *wire shape*, so it can't see a projector that mis-derives events from the new format.

## Test plan
- [x] `session-tail.test.ts`: no premature terminal on a thinking-only `end_turn` split line; handback text emitted before exactly one `turn_end` across a split message; legacy single-line shape still fires.
- [x] **`claude-code-event-contract.test.ts` (new canary):** pins every Claude Code transcript wire shape the projector consumes (queue-operation, thinking / tool_use / tool_result / text blocks, `system/turn_duration`, split `message.id`, sub-agent kickoff). An upstream format change now **fails CI loudly** instead of silently blanking the status card.
- [x] All three new assertions **fail on pre-fix code, pass after** (revert-proof).
- [x] Broader suite green: subagent-watcher, handback-gaps, turn-liveness-floor/invariant, silence-poke, session-tail-capped, subagent-handback-decision (156 tests).
- [x] `tsc --noEmit` clean; `check-plugin-references.mjs` clean.

## Risk
Low and localized to `projectSubagentLine`'s terminal gate. Behaviour on the legacy shape is unchanged (pinned by a test). Live DM+channel background-worker UAT (`jtbd-worker-activity-feed-dm`/`-channel`) owns the end-to-end proof; those exercise the real surface but can't inject a specific wire shape, so the split-shape guarantee lives in the projector-level + contract tests here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)