### PR TITLE
fix(web): hermes model picker uses family aliases, model.info reads config

### DIFF
--- a/src/web/hermes-adapter.ts
+++ b/src/web/hermes-adapter.ts
@@ -487,18 +487,32 @@ function turnsToMessages(turns: Turn[]): object[] {
   return messages;
 }
 
-/** Claude models available via the switchroom subscription. */
-const SWITCHROOM_MODELS = [
-  "claude-sonnet-5",
-  "claude-opus-4-8",
-  "claude-haiku-4-5-20251001",
-  "claude-fable-5",
-];
+/** Claude models available via the switchroom subscription.
+ *
+ * These are the family ALIASES the claude CLI resolves itself, not pinned
+ * concrete ids. Pinned ids rot: `claude-fable-5` was retired server-side and
+ * 4xx'd the fleet on 2026-06-13 (see telegram-plugin/gateway/model-command.ts
+ * MODEL_ALIASES), while the `fable` alias keeps resolving to the current
+ * flagship. The picker's selection is injected as `/model <value>` (see the
+ * config.set handler), so aliases are the durable selector.
+ */
+export const SWITCHROOM_MODELS = ["fable", "opus", "sonnet", "haiku"];
+
+/** Report the model for an agent session. There is no live per-session model
+ * source in the adapter (a `/model` switch happens inside the claude session
+ * and is not observable here), so the most honest answer is the agent's
+ * configured model from switchroom.yaml (per-agent `model:` over
+ * `defaults.model`), falling back to the `sonnet` family alias (the CLI's
+ * default tier) when nothing is configured. */
+export function configuredModel(config: SwitchroomConfig, agentName?: string): string {
+  const agentModel = agentName ? config.agents?.[agentName]?.model : undefined;
+  return agentModel ?? config.defaults?.model ?? "sonnet";
+}
 
 /** Build a ModelOptionsResponse for the Hermes Desktop model picker. */
-function switchroomModelOptions() {
+function switchroomModelOptions(config: SwitchroomConfig, agentName?: string) {
   return {
-    model: "claude-sonnet-5",
+    model: configuredModel(config, agentName),
     provider: "switchroom",
     providers: [
       {
@@ -673,7 +687,9 @@ export async function handleHermesRest(
     return {
       status: 200,
       body: {
-        model: "claude-sonnet-5",
+        // No session context on this endpoint — report the fleet-default
+        // configured model rather than a hardcoded constant.
+        model: configuredModel(config),
         provider: "switchroom",
         capabilities: {},
       },
@@ -771,7 +787,7 @@ export async function handleHermesRest(
 
   // GET /api/model/options — model picker list (ModelOptionsResponse)
   if (method === "GET" && pathname.startsWith("/api/model/options")) {
-    return { status: 200, body: switchroomModelOptions() };
+    return { status: 200, body: switchroomModelOptions(config) };
   }
 
   // POST /api/model/set — model selection (accept silently; agent model is set per-session via config.set RPC)
@@ -1110,12 +1126,16 @@ export async function onHermesMessage(ctx: HermesWsContext, raw: string) {
     }
 
     case "model.options": {
-      sendResponse(ctx, rpcOk(id, switchroomModelOptions()));
+      const sessionId = String(params.session_id ?? ctx.activeSessionId ?? "");
+      const agentName = sessionId ? parseHermesSessionId(sessionId).agentName : undefined;
+      sendResponse(ctx, rpcOk(id, switchroomModelOptions(config, agentName)));
       break;
     }
 
     case "model.info": {
-      sendResponse(ctx, rpcOk(id, { model: "claude-sonnet-5", provider: "switchroom" }));
+      const sessionId = String(params.session_id ?? ctx.activeSessionId ?? "");
+      const agentName = sessionId ? parseHermesSessionId(sessionId).agentName : undefined;
+      sendResponse(ctx, rpcOk(id, { model: configuredModel(config, agentName), provider: "switchroom" }));
       break;
     }
 

--- a/tests/web/hermes-model-picker.test.ts
+++ b/tests/web/hermes-model-picker.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { SWITCHROOM_MODELS, configuredModel } from "../../src/web/hermes-adapter.js";
+import type { SwitchroomConfig } from "../../src/config/schema.js";
+
+/**
+ * Regression coverage for the Hermes model picker (goal #2757, gap 3).
+ *
+ * The picker must offer the family ALIASES the claude CLI resolves itself
+ * (fable/opus/sonnet/haiku) — never pinned concrete ids. The pinned id
+ * `claude-fable-5` was retired server-side and 4xx'd the fleet on 2026-06-13
+ * (see telegram-plugin/gateway/model-command.ts MODEL_ALIASES); injecting a
+ * pinned id via `/model` reproduces that incident from the desktop UI.
+ *
+ * model.info must report the agent's configured model from switchroom.yaml,
+ * not a hardcoded constant.
+ */
+
+describe("SWITCHROOM_MODELS — family aliases only", () => {
+  it("lists exactly the CLI-resolvable family aliases", () => {
+    expect(SWITCHROOM_MODELS).toEqual(["fable", "opus", "sonnet", "haiku"]);
+  });
+
+  it("contains no pinned concrete model ids (the 2026-06-13 fable-5 incident class)", () => {
+    for (const m of SWITCHROOM_MODELS) {
+      expect(m).not.toMatch(/^claude-/);
+      expect(m).not.toMatch(/\d/);
+    }
+  });
+});
+
+describe("configuredModel — model.info source", () => {
+  const cfg = (overrides: Partial<SwitchroomConfig>): SwitchroomConfig =>
+    overrides as SwitchroomConfig;
+
+  it("prefers the per-agent model override", () => {
+    const config = cfg({
+      defaults: { model: "opus" },
+      agents: { overlord: { model: "fable" } },
+    } as Partial<SwitchroomConfig>);
+    expect(configuredModel(config, "overlord")).toBe("fable");
+  });
+
+  it("falls back to defaults.model when the agent has no override", () => {
+    const config = cfg({
+      defaults: { model: "opus" },
+      agents: { overlord: {} },
+    } as Partial<SwitchroomConfig>);
+    expect(configuredModel(config, "overlord")).toBe("opus");
+  });
+
+  it("falls back to the sonnet family alias when nothing is configured", () => {
+    expect(configuredModel(cfg({}))).toBe("sonnet");
+    expect(configuredModel(cfg({}), "unknown-agent")).toBe("sonnet");
+  });
+
+  it("uses defaults.model when no agent name is given (HTTP /api/model/info)", () => {
+    const config = cfg({ defaults: { model: "haiku" } } as Partial<SwitchroomConfig>);
+    expect(configuredModel(config)).toBe("haiku");
+  });
+});


### PR DESCRIPTION
## Summary
- `SWITCHROOM_MODELS` in `src/web/hermes-adapter.ts` offered pinned concrete ids — including `claude-fable-5`, the id that was retired server-side and 4xx'd the fleet on 2026-06-13 (documented in `telegram-plugin/gateway/model-command.ts` MODEL_ALIASES). The picker injects its selection via `/model <value>`, so picking that entry reproduced the incident from the desktop UI. Switched to the family aliases the claude CLI resolves itself: `fable`, `opus`, `sonnet`, `haiku` (Hermes renders the raw model strings; there is no separate label field in ModelOptionsResponse).
- `model.info` (RPC) and `GET /api/model/info` always reported `claude-sonnet-5` regardless of the session. There is no live per-session model source in the adapter (a `/model` switch happens inside the claude session), so they now report the agent's configured model from switchroom.yaml (`agents.<name>.model` over `defaults.model`, `sonnet` alias fallback), derived from the session_id where available. Comment in `configuredModel()` records the limitation.

## Why
Part of #2757 (model selection E2E integrity), gap 3: menu ↔ resolved-model parity. Aliases are the durable selector; pinned ids rot and take the picker down with them.

Serves `reference/jobs/see-my-whole-fleet-from-one-screen.md` (the operator console must drive an agent correctly, including model switches) and `reference/jobs/keep-my-subscription-honest.md` (a 4xx from a retired pinned id breaks the subscription-funded session path).

## Test plan
- [x] New `tests/web/hermes-model-picker.test.ts` pins the alias list (no `claude-*` pinned ids) and the `configuredModel` fallback chain (agent > defaults > sonnet)
- [x] `npm run lint` clean
- [x] `vitest run tests/web/` green (11/11)
- [x] Full local `npm test` run: 11715 passed; the 87 failures are in docker/e2e suites that need the operator host (pre-existing in this sandbox), none in web/hermes paths — gating CI is the source of truth

## Risk
Low. Web-console-only surface; no gateway or agent-runtime paths touched. If an operator has a concrete id in `model:`, model.info reports it verbatim (same string the CLI was booted with).

🤖 Generated with [Claude Code](https://claude.com/claude-code)