### PR TITLE
feat(pacing): reliable intent-narration for thinking-visibility (Option 2)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -161,9 +161,22 @@ messaging a capable colleague — not a tool emitting output. Five beats:
    compose the full answer. This holds even for a pure-thinking
    answer: if it will run to a paragraph, ack first. It is the line
    between a colleague and a black box.
-2. **Then go quiet and work.** Heads-down is correct — do NOT narrate
-   every tool call. A typing indicator runs automatically while you
-   work; you do not maintain it.
+2. **Then go quiet and work — but leave a trail of intent.** Heads-down
+   is correct: do NOT narrate every tool call, and a typing indicator
+   runs automatically (you do not maintain it). One thing you SHOULD do,
+   because your private reasoning is never shown to the user: before a
+   burst of tool calls or a long silent stretch, drop ONE short
+   plain-language line of intent in your own working text — *what* you
+   are about to do and *why* ("Now checking the gateway logs to find why
+   the turn stalled"). Write it as ordinary text, NOT a \`reply\` call, so
+   it never becomes a chat message and never pings — the framework
+   mirrors that line into the live preview the user watches while you
+   work. One line per stretch, plain words, never raw tool names
+   ("calling Bash") or debug dumps. It is the difference between the user
+   seeing "checking the logs to find the stall" and seeing a black box.
+   When a step is a \`Bash\` command, always give it a plain-English
+   \`description\` naming the goal — that description, not the raw command,
+   is what the user sees.
 3. **Surface meaningful progress** at genuine inflection points — a
    hard step finished, a blocker, a pivot, dispatching a sub-agent, a
    notably slow wait, a finding worth knowing now. One short \`reply\`,
@@ -4965,6 +4978,22 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
     'once with the answer or a genuine mid-work pivot ("halfway ' +
     'through — found an unexpected issue, want me to continue?"). Not ' +
     '"still working".\n\n' +
+    'NARRATE YOUR INTENT (your reasoning is NOT shown to the user). The ' +
+    'user cannot see your thinking — only your tool activity and your ' +
+    'replies. So before you fire a burst of tools or work silently for a ' +
+    'while, first write ONE short plain-language line of intent as ' +
+    'ordinary working text (NOT a reply tool call): name what you are ' +
+    'about to do and why — "Now checking the gateway logs to find why ' +
+    'the turn stalled". The framework mirrors that line into the live ' +
+    'compose-area preview the user watches; because it is plain text and ' +
+    'not a reply, it is never a chat message and never pings. One intent ' +
+    'line before a silent stretch, in plain words, never raw tool names ' +
+    '("calling Bash", "Read(x)") and never a debug dump. And when you run ' +
+    'a Bash command, always give it a plain-English `description` naming ' +
+    'the goal — that description, not the raw command, is what the user ' +
+    'sees. This intent narration is the ONE thing to keep saying; it is ' +
+    'NOT the placeholder ack banned above (that is a chat reply, which ' +
+    'you still skip).\n\n' +
     'Do NOT send a trailing confirmation after your answer — no "Done.", ' +
     '"Sent.", "Hope that helps." as a separate message once you have ' +
     'already replied. Your answer is the last thing the user should ' +

--- a/telegram-plugin/uat/scenarios/jtbd-narration-intent-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-narration-intent-dm.test.ts
@@ -1,0 +1,134 @@
+/**
+ * JTBD scenario — narration-quality: a plain-language intent line before
+ * a silent tool stretch.
+ *
+ * Serves "know what my agent is actually doing"
+ * (`reference/jobs/know-what-my-agent-is-doing.md`) beat 3, and the
+ * thinking-visibility work (Option 2). With extended-thinking text
+ * server-redacted for the current flagship models (they emit
+ * `thinking` → `tool_use` → `reply` with no interstitial prose, see the
+ * PIVOT in `reference/rfcs/draft-mirror-preview.md`), the model's OWN
+ * plain-language intent narration is the only compliant carrier for
+ * "what am I doing / why" during a silent tool burst. The pacing prompt
+ * (scaffold.ts `TELEGRAM_GUIDANCE` beat 2 + the per-turn `<turn-pacing>`
+ * directive) now instructs the model to drop ONE intent line as ordinary
+ * working text before a tool stretch. This scenario pins the CARRIER: a
+ * leading `text` block surfaces as working narration (not suppressed as a
+ * draft-of-reply, not sent as a chat message) BEFORE the silent tool
+ * stretch, and the Bash `description` is the visible activity label.
+ *
+ * Why a projection-kernel scenario, not a live mtcute harness: the
+ * intent line lives in the ephemeral compose-area draft, and mtcute
+ * "CANNOT observe drafts or reactions" (CLAUDE.md, UAT caveat) — a live
+ * harness structurally cannot see this surface. The same reasoning made
+ * `jtbd-reflective-status-reaction-dm` a controller-level scenario. The
+ * deterministic assertion here (over the exact JSONL the model emits) is
+ * strictly more powerful than a flaky "did the model narrate this run"
+ * live check. The prompt that MAKES the model narrate is pinned by
+ * `tests/scaffold.test.ts` ("intent-narration carrier").
+ */
+
+import { describe, it, expect } from "vitest";
+import { projectTranscriptLine } from "../../session-tail.js";
+import { isDraftOfReply } from "../../narrative-dedup.js";
+import { toolLabel } from "../../tool-labels.js";
+
+/** The plain-language intent the pacing prompt asks for before a burst. */
+const INTENT =
+  "Now checking the gateway logs to find why the turn stalled.";
+
+/** A multi-tool assistant message: intent line, then a SILENT tool burst
+ *  (no reply among the tools). This is the exact shape beat 2 describes —
+ *  one intent line, then heads-down work. */
+function multiToolTurnLine(): string {
+  return JSON.stringify({
+    type: "assistant",
+    message: {
+      content: [
+        { type: "text", text: INTENT },
+        {
+          type: "tool_use",
+          id: "toolu_01",
+          name: "Bash",
+          input: {
+            command: "grep -n stall /var/log/switchroom/gateway.log | tail",
+            description: "Search the gateway log for the stall",
+          },
+        },
+        {
+          type: "tool_use",
+          id: "toolu_02",
+          name: "Read",
+          input: { file_path: "/state/agent/home/gateway.ts" },
+        },
+        {
+          type: "tool_use",
+          id: "toolu_03",
+          name: "Grep",
+          input: { pattern: "activeTurnStartedAt", path: "src/" },
+        },
+      ],
+    },
+  });
+}
+
+describe("uat-jtbd: narration intent before a silent tool stretch", () => {
+  it("a multi-tool turn surfaces at least one plain-language intent line before the burst", () => {
+    const events = projectTranscriptLine(multiToolTurnLine());
+
+    // The intent narration is projected as a `text` event.
+    const textEvents = events.filter((e) => e.kind === "text");
+    expect(textEvents.length).toBeGreaterThanOrEqual(1);
+    const intentEv = textEvents[0];
+    expect(intentEv.kind === "text" && intentEv.text).toBe(INTENT);
+
+    // It is PLAIN LANGUAGE, not a raw tool name / debug dump. (Bad-list:
+    // "calling Bash", "Read(x)", raw commands must never be the carrier.)
+    const t = (intentEv as { text: string }).text;
+    expect(t).not.toMatch(/calling \w+|Read\(|Bash\(|grep -n|\bnull\b/);
+    expect(t.length).toBeLessThan(160); // one line, phone-readable
+
+    // The intent line comes BEFORE the silent stretch: its projected
+    // position precedes every tool_use event in source order.
+    const firstToolIdx = events.findIndex((e) => e.kind === "tool_use");
+    const intentIdx = events.findIndex((e) => e.kind === "text");
+    expect(intentIdx).toBeGreaterThanOrEqual(0);
+    expect(firstToolIdx).toBeGreaterThan(intentIdx);
+
+    // And it really is a SILENT stretch — a burst of >1 tool with no reply
+    // tool interleaved. The narration is the ONLY signal the user gets.
+    const toolCount = events.filter((e) => e.kind === "tool_use").length;
+    expect(toolCount).toBeGreaterThan(1);
+    const replyToolFired = events.some(
+      (e) => e.kind === "tool_use" && /^(reply|stream_reply)$/.test(e.toolName),
+    );
+    expect(replyToolFired).toBe(false);
+  });
+
+  it("the intent line is working-narration (surfaced), not a draft-of-reply (suppressed)", () => {
+    // The reducer-side dedup gate SUPPRESSES a text block only when it is
+    // the model composing its answer just before `reply`. An intent line
+    // that names what it's about to DO shares no prefix with the eventual
+    // answer, so the gate SHOWS it. Pin both sides.
+    const laterAnswer =
+      "The turn stalled because the typing loop was never cleared on error.";
+    expect(isDraftOfReply(INTENT, laterAnswer)).toBe(false);
+
+    // Control: a genuine draft-then-send IS suppressed, so we know the gate
+    // is live and the assertion above isn't vacuously true.
+    const draft = laterAnswer + " (composing…)";
+    expect(isDraftOfReply(draft, laterAnswer)).toBe(true);
+  });
+
+  it("the Bash description — not the raw command — is the visible activity label", () => {
+    // The compose-area draft renders `input.description` for Bash (never
+    // the raw `command`). This is why the prompt tells the model to always
+    // give Bash a plain-English description: it IS the visible carrier.
+    const label = toolLabel("Bash", {
+      command: "grep -n stall /var/log/switchroom/gateway.log | tail",
+      description: "Search the gateway log for the stall",
+    });
+    expect(label).toBe("Search the gateway log for the stall");
+    expect(label).not.toContain("grep");
+  });
+});

--- a/telegram-plugin/uat/scenarios/jtbd-status-phase-transitions-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-status-phase-transitions-dm.test.ts
@@ -1,0 +1,109 @@
+/**
+ * JTBD scenario — the status reaction moves through DISTINCT phases across
+ * a turn: acknowledged → thinking → working/editing → done.
+ *
+ * Serves "know what my agent is actually doing"
+ * (`reference/jobs/know-what-my-agent-is-doing.md`): the "Good looks like"
+ * line — "that signal distinguishes phases at a glance: acknowledged,
+ * thinking or working, actively editing. It stays present from receipt to
+ * turn end and never disappears mid-turn." The reflective controller test
+ * (`jtbd-reflective-status-reaction-dm`) pins the #1713 non-event/
+ * bidirectional rules; THIS scenario pins the complementary contract the
+ * job cares about most: over a realistic full turn the phases actually
+ * FIRE, in order, and are visibly DIFFERENT emoji families (not one
+ * undifferentiated "working" blob — an explicit bad-list item).
+ *
+ * Simulated (not live mtcute): real Bot-API reactions expose only the
+ * CURRENT emoji, never the transition trail, so the controller-level
+ * assertion over the whole sequence is strictly more powerful — the same
+ * reasoning documented in `jtbd-reflective-status-reaction-dm`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { StatusReactionController } from "../../status-reactions.js";
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 8; i++) await Promise.resolve();
+}
+
+// Phase families the JOB cares about (job spec "Good looks like"). Emoji
+// membership is pinned by status-reactions.ts; we assert the family a
+// glance would read, so a palette retune that preserves the phase meaning
+// doesn't false-fail this behavioural scenario.
+const ACK = new Set(["👀", "🤔", "🤓"]); // received / acknowledged
+const THINKING = new Set(["🤔", "🤓"]); // generating
+const WORKING = new Set(["✍", "⚡", "👌", "👨‍💻", "🗜"]); // tools / editing / coding
+const DONE = new Set(["👍", "💯", "🎉"]); // turn over
+
+describe("uat-jtbd: status reaction phase transitions across a turn", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("acknowledged → thinking → working/editing → done all fire, in order, as distinct phases", async () => {
+    const calls: string[] = [];
+    const ctrl = new StatusReactionController(async (e: string) => {
+      calls.push(e);
+    });
+
+    // A realistic turn: inbound arrives, model thinks, then reads/edits
+    // (a silent tool stretch), then the turn ends with an answer.
+    ctrl.setQueued(); // acknowledged
+    await flush();
+
+    ctrl.setThinking(); // thinking
+    vi.advanceTimersByTime(3500);
+    await flush();
+
+    ctrl.setTool("Read"); // working — coding family
+    vi.advanceTimersByTime(3500);
+    await flush();
+
+    ctrl.setTool("Edit"); // still working — actively editing
+    vi.advanceTimersByTime(3500);
+    await flush();
+
+    ctrl.finalize("done"); // turn_end — done
+    await flush();
+
+    // Each phase fired at least once.
+    expect(calls.some((e) => ACK.has(e))).toBe(true);
+    expect(calls.some((e) => THINKING.has(e))).toBe(true);
+    expect(calls.some((e) => WORKING.has(e))).toBe(true);
+    expect(calls.some((e) => DONE.has(e))).toBe(true);
+
+    // They fired IN ORDER: first ack, a working beat before the terminal,
+    // and done strictly last.
+    const firstWorkingIdx = calls.findIndex((e) => WORKING.has(e));
+    const doneIdx = calls.findIndex((e) => DONE.has(e));
+    expect(firstWorkingIdx).toBeGreaterThan(0); // ack precedes working
+    expect(doneIdx).toBe(calls.length - 1); // done is terminal + last
+    expect(firstWorkingIdx).toBeLessThan(doneIdx); // work before done
+
+    // The phases are VISIBLY DIFFERENT — thinking and working are not the
+    // same emoji (the "one undifferentiated working signal" bad-list item).
+    const thinkingEmoji = calls.find((e) => THINKING.has(e))!;
+    const workingEmoji = calls.find((e) => WORKING.has(e))!;
+    expect(thinkingEmoji).not.toBe(workingEmoji);
+
+    // Liveness never disappears mid-turn: 👍 appears exactly once, only at
+    // the end — the signal is present from receipt to terminal state.
+    expect(calls.filter((e) => DONE.has(e)).length).toBe(1);
+  });
+
+  it("a trivial turn still acknowledges before it finishes (never a silent gap)", async () => {
+    // "A trivial ask just gets the answer" — but even then the inbound is
+    // acknowledged (👀) before the turn finalizes; the ack is never skipped.
+    const calls: string[] = [];
+    const ctrl = new StatusReactionController(async (e: string) => {
+      calls.push(e);
+    });
+
+    ctrl.setQueued();
+    await flush();
+    ctrl.finalize("done");
+    await flush();
+
+    expect(ACK.has(calls[0])).toBe(true);
+    expect(DONE.has(calls[calls.length - 1])).toBe(true);
+  });
+});

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync, readlinkSync, lstatSync, readdirSync, cpSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { scaffoldAgent, reconcileAgent, installHindsightPlugin, installSwitchroomSkills } from "../src/agents/scaffold.js";
+import { scaffoldAgent, reconcileAgent, installHindsightPlugin, installSwitchroomSkills, renderFleetInvariants } from "../src/agents/scaffold.js";
 import { renderTemplate, renderProfileClaudeTemplate } from "../src/agents/profiles.js";
 import { cronScriptFilename, cronUnitName } from "../src/agents/cron-unit-name.js";
 import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
@@ -2635,6 +2635,67 @@ describe("scaffoldAgent with global defaults cascade", () => {
     expect(cmd).toMatch(/Skip the hollow openers/);
     expect(cmd).toMatch(/Genuine acknowledgement is fine/);
     expect(cmd).toMatch(/plain punctuation/);
+  });
+
+  it("turn-pacing directive carries the intent-narration carrier (thinking-redacted visibility)", () => {
+    // Option 2 of the thinking-visibility work: with extended-thinking
+    // text server-redacted for the current flagship models, the model's
+    // own plain-language intent narration is the ONLY compliant carrier
+    // for "what am I doing / why". The directive must instruct the model
+    // to drop a one-line intent (as ordinary working text, NOT a reply)
+    // before a silent tool stretch — and to distinguish it from the
+    // banned placeholder ack. It must stay inside the job's bad-list:
+    // no per-tool-call narration, no raw tool names, no debug dumps.
+    const agentConfig = makeAgentConfig({});
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "narration-agent": agentConfig },
+    } as SwitchroomConfig;
+    const result = scaffoldAgent(
+      "narration-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+      switchroomConfig,
+    );
+    const settings = JSON.parse(
+      readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+    );
+    const cmd = (settings.hooks.UserPromptSubmit as Array<{
+      hooks: Array<{ command: string }>;
+    }>)
+      .flatMap((g) => g.hooks)
+      .find((h) => h.command.includes("turn-pacing"))!.command;
+    // The intent-narration carrier is present.
+    expect(cmd).toMatch(/NARRATE YOUR INTENT/);
+    expect(cmd).toMatch(/reasoning is NOT shown/);
+    // It is transcript text mirrored to the preview, NOT a reply.
+    expect(cmd).toMatch(/ordinary working text \(NOT a reply/);
+    expect(cmd).toMatch(/live[\s\S]{0,40}preview/);
+    // It respects the bad-list: no raw tool names, no debug dumps.
+    expect(cmd).toMatch(/never raw tool names/);
+    expect(cmd).toMatch(/never a debug dump/);
+    // Bash gets a plain-English description (the draft-mirror carrier).
+    expect(cmd).toMatch(/plain-English `description`/);
+    // It is explicitly distinguished from the banned placeholder ack.
+    expect(cmd).toMatch(/NOT the placeholder ack/);
+  });
+
+  it("TELEGRAM_GUIDANCE beat 2 carries the intent-narration trail", () => {
+    // The static fleet-invariant block (shipped to every agent via
+    // ~/.switchroom/fleet/switchroom-invariants.md, not just the per-turn
+    // hook) must also teach the intent-narration carrier, so agents that
+    // read the static block still get it. Beat 2 is where "go quiet and
+    // work" lives — the narration trail rides alongside it.
+    const invariants = renderFleetInvariants();
+    expect(invariants).toMatch(/leave a trail of intent/);
+    expect(invariants).toMatch(/private reasoning is never shown/);
+    expect(invariants).toMatch(/NOT a `reply` call/);
+    expect(invariants).toMatch(/plain-English\s+`description`/);
+    // Bad-list guardrails travel with it (no per-tool spam / raw names).
+    expect(invariants).toMatch(/never raw tool names/);
+    expect(invariants).toMatch(/debug dumps/);
   });
 
   it("turn-pacing directive carries the decision-first turn-end shape (#2707)", () => {


### PR DESCRIPTION
## Summary

Extended-thinking text is server-redacted for the current flagship models (they emit `thinking` → `tool_use` → `reply` with no interstitial prose, per the PIVOT in `reference/rfcs/draft-mirror-preview.md`). That leaves the model's own **plain-language intent narration** as the only compliant carrier for "what am I doing / why" during a silent tool burst. This is **Option 2** of the thinking-visibility work: make that narration reliable so the status surfaces (the ephemeral compose-area preview + tool labels) actually convey what the model is working on.

## Why

`reference/jobs/know-what-my-agent-is-doing.md` beat 3: "pivots, blockers, finishing a chunk, dispatching a sub-agent: each is narrated in plain language, as it happens." The pivot found the model emits **no** interstitial prose on a normal tool turn, so the preview went empty. Prompting the narration is the fix — and it must stay inside the job's bad-list (no per-tool-call message spam, no raw tool names, no debug dumps).

## What changed

- **Prompt** (`src/agents/scaffold.ts`): `TELEGRAM_GUIDANCE` beat 2 and the per-turn `<turn-pacing>` directive now teach the intent-narration carrier — drop ONE short plain-language intent line as **ordinary working text (NOT a `reply` call)** before a silent stretch, mirrored into the live preview; always give Bash a plain-English `description` (the visible label). Explicitly distinguished from the banned placeholder ack, so it does not reintroduce the v3/v4 "on it…" chat-clutter regression.
- **Tests**
  - `tests/scaffold.test.ts` — pins the narration contract on both the per-turn directive and the static fleet-invariants block, including bad-list guardrails.
  - `telegram-plugin/uat/scenarios/jtbd-narration-intent-dm.test.ts` — a multi-tool turn surfaces ≥1 plain-language intent line before the silent stretch, shown as working-narration (not suppressed as a draft-of-reply), Bash description as the visible label.
  - `telegram-plugin/uat/scenarios/jtbd-status-phase-transitions-dm.test.ts` — acknowledged → thinking → working/editing → done all fire, in order, as distinct phases across a simulated turn.

Both UAT scenarios are controller/projection-kernel level (not live mtcute): the intent line lives in the ephemeral draft and reactions expose only the current emoji, so a live harness structurally can't see either surface — the same reasoning as the existing `jtbd-reflective-status-reaction-dm` scenario.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] new vitest prompt assertions pass
- [x] new UAT scenarios pass (`vitest.uat.config.ts`)
- [x] bun suites for touched modules (narrative-dedup, status-reactions, session-tail) green
- [x] one pre-existing `$HOME` symlink test fails identically on clean `origin/main` (env-dependent, unrelated)

## Risk

Low. Prompt-only behaviour change plus additive tests. No runtime code paths changed.

Serves: `reference/jobs/know-what-my-agent-is-doing.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)