### PR TITLE
feat(voice): deterministic L1 TTS normalization before /tts (#2760 Phase 1)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -67,6 +67,7 @@ import {
  *  slightly brisker than neutral (Ken's chosen default). */
 const VOICE_OUT_DEFAULT_SPEED = 1.1
 import { normalizeForSpeech } from '../voice-normalize-text.js'
+import { normalizeForTts } from '../tts-normalize.js'
 import { synthesizeViaOpenAi } from '../voice-synthesize.js'
 import {
   createTelegraphAccount,
@@ -8744,12 +8745,17 @@ async function synthesizeVoiceOut(plan: {
   ttsText: string
 }): Promise<Uint8Array | null> {
   try {
+    // #2760 Phase 1: deterministic L1 TTS normalization, applied at the
+    // single choke point where every engine's request body is built.
+    // No-op unless SWITCHROOM_TTS_NORMALIZE=1 (kill switch:
+    // SWITCHROOM_DISABLE_TTS_NORMALIZE).
+    const ttsText = normalizeForTts(plan.ttsText)
     if (plan.engine === 'kokoro') {
       const token = await materializeSidecarToken()
       if (!token) return null // materializeSidecarToken already logged why.
       const result = await synthesizeViaSidecar({
         token,
-        text: plan.ttsText,
+        text: ttsText,
         voice: plan.voice,
         speed: plan.speed,
       })
@@ -8773,7 +8779,7 @@ async function synthesizeVoiceOut(plan: {
     if (!apiKey) return null // materializeVoiceKey already logged why.
     const result = await synthesizeViaOpenAi({
       apiKey,
-      text: plan.ttsText,
+      text: ttsText,
       voice: plan.voice,
     })
     if (!result.ok) {
@@ -22518,7 +22524,11 @@ bot.on('callback_query:data', async ctx => {
     }
     const result = await synthesizeViaSidecar({
       token: sidecarToken,
-      text: entry.text,
+      // #2760 Phase 1: same deterministic normalization as the immediate
+      // voice-out path — the Listen lazy path builds its own /tts body from
+      // the persisted cache, so it must normalize independently (cache
+      // entries may predate the flag flip).
+      text: normalizeForTts(entry.text),
       voice: entry.voice,
       speed: entry.speed,
     })

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8747,8 +8747,7 @@ async function synthesizeVoiceOut(plan: {
   try {
     // #2760 Phase 1: deterministic L1 TTS normalization, applied at the
     // single choke point where every engine's request body is built.
-    // No-op unless SWITCHROOM_TTS_NORMALIZE=1 (kill switch:
-    // SWITCHROOM_DISABLE_TTS_NORMALIZE).
+    // On by default; kill switch: SWITCHROOM_DISABLE_TTS_NORMALIZE=1.
     const ttsText = normalizeForTts(plan.ttsText)
     if (plan.engine === 'kokoro') {
       const token = await materializeSidecarToken()

--- a/telegram-plugin/tests/tts-normalize.test.ts
+++ b/telegram-plugin/tests/tts-normalize.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for tts-normalize.ts — deterministic L1 TTS normalization
+ * (issue #2760, Phase 1). Bun test (this dir uses bun test, not vitest).
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
+import { normalizeForTts, ttsNormalizeEnabled } from '../tts-normalize.js'
+
+const FLAG = 'SWITCHROOM_TTS_NORMALIZE'
+const KILL = 'SWITCHROOM_DISABLE_TTS_NORMALIZE'
+
+let savedFlag: string | undefined
+let savedKill: string | undefined
+
+beforeEach(() => {
+  savedFlag = process.env[FLAG]
+  savedKill = process.env[KILL]
+  process.env[FLAG] = '1'
+  delete process.env[KILL]
+})
+
+afterEach(() => {
+  if (savedFlag === undefined) delete process.env[FLAG]
+  else process.env[FLAG] = savedFlag
+  if (savedKill === undefined) delete process.env[KILL]
+  else process.env[KILL] = savedKill
+})
+
+describe('gating', () => {
+  test('pass-through when flag is off (default)', () => {
+    delete process.env[FLAG]
+    const input = '**bold** $5.20 https://github.com/x 🚀'
+    expect(normalizeForTts(input)).toBe(input)
+    expect(ttsNormalizeEnabled()).toBe(false)
+  })
+
+  test('kill switch wins even when the flag is on', () => {
+    process.env[KILL] = '1'
+    const input = '**bold** and $5.20'
+    expect(normalizeForTts(input)).toBe(input)
+    expect(ttsNormalizeEnabled()).toBe(false)
+  })
+
+  test('enabled when flag=1 and no kill switch', () => {
+    expect(ttsNormalizeEnabled()).toBe(true)
+  })
+
+  test('empty input stays empty', () => {
+    expect(normalizeForTts('')).toBe('')
+  })
+})
+
+describe('markdown', () => {
+  test('bold/italic/strike markers removed', () => {
+    expect(normalizeForTts('**bold** and *italic* and ~~gone~~')).toBe(
+      'bold and italic and gone',
+    )
+  })
+
+  test('headings become plain text', () => {
+    expect(normalizeForTts('## Status report\nAll good')).toBe(
+      'Status report All good',
+    )
+  })
+
+  test('links become link text', () => {
+    expect(normalizeForTts('see [the docs](https://example.com/a/b) now')).toBe(
+      'see the docs now',
+    )
+  })
+
+  test('list markers dropped', () => {
+    expect(normalizeForTts('- first\n- second')).toBe('first second')
+  })
+
+  test('blockquote markers dropped', () => {
+    expect(normalizeForTts('> quoted line')).toBe('quoted line')
+  })
+
+  test('code fences become spoken placeholder', () => {
+    const out = normalizeForTts('before\n```ts\nconst x = 1\n```\nafter')
+    expect(out).toContain('code block omitted')
+    expect(out).not.toContain('const x')
+  })
+
+  test('inline code read as-is without backticks, content untouched', () => {
+    expect(normalizeForTts('run `deploy_5km_run` now')).toBe(
+      'run deploy_5km_run now',
+    )
+  })
+
+  test('tables summarized as table omitted', () => {
+    const out = normalizeForTts('| a | b |\n|---|---|\n| 1 | 2 |\n')
+    expect(out).toContain('table omitted')
+    expect(out).not.toContain('|')
+  })
+})
+
+describe('numbers', () => {
+  test('currency $5.20 → five dollars twenty', () => {
+    expect(normalizeForTts('that costs $5.20 today')).toBe(
+      'that costs five dollars twenty today',
+    )
+  })
+
+  test('whole-dollar and singular', () => {
+    expect(normalizeForTts('$1 fee')).toBe('one dollar fee')
+    expect(normalizeForTts('$300 total')).toBe('three hundred dollars total')
+  })
+
+  test('percent 12% → twelve percent', () => {
+    expect(normalizeForTts('up 12% overnight')).toBe('up twelve percent overnight')
+  })
+
+  test('ordinal 3rd → third', () => {
+    expect(normalizeForTts('the 3rd item and the 21st day')).toBe(
+      'the third item and the twenty-first day',
+    )
+  })
+
+  test('time 14:30 spoken', () => {
+    expect(normalizeForTts('meet at 14:30 sharp')).toBe(
+      'meet at fourteen thirty sharp',
+    )
+  })
+
+  test('ISO date spoken', () => {
+    expect(normalizeForTts('due 2026-07-04 ok')).toBe(
+      'due July fourth two thousand twenty-six ok',
+    )
+  })
+
+  test('phone-like digit run read as digits', () => {
+    expect(normalizeForTts('call 0412 345 678 now')).toBe(
+      'call zero four one two three four five six seven eight now',
+    )
+  })
+
+  test('units expand: 5km, 10GB, 500ms', () => {
+    expect(normalizeForTts('ran 5km')).toBe('ran five kilometres')
+    expect(normalizeForTts('used 10GB')).toBe('used ten gigabytes')
+    expect(normalizeForTts('took 500ms')).toBe('took five hundred milliseconds')
+  })
+
+  test('identifiers with digits are never touched', () => {
+    expect(normalizeForTts('rename class5 and my5thing')).toBe(
+      'rename class5 and my5thing',
+    )
+  })
+})
+
+describe('URLs', () => {
+  test('bare URL → spoken domain', () => {
+    expect(normalizeForTts('see https://github.com/switchroom/switchroom for code')).toBe(
+      'see github dot com link for code',
+    )
+  })
+
+  test('www prefix dropped from spoken domain', () => {
+    expect(normalizeForTts('at https://www.example.org/x')).toBe(
+      'at example dot org link',
+    )
+  })
+
+  test('IP-host URL degrades to a link', () => {
+    expect(normalizeForTts('at http://127.0.0.1:8080/x ok')).toBe('at a link ok')
+  })
+})
+
+describe('emoji', () => {
+  test('common emoji spoken via map', () => {
+    expect(normalizeForTts('great work 👍')).toBe('great work thumbs up')
+  })
+
+  test('other emoji stripped', () => {
+    expect(normalizeForTts('launch 🚀 now 🎉')).toBe('launch now')
+  })
+})
+
+describe('symbols', () => {
+  test('& → and, @ → at, # → hash', () => {
+    expect(normalizeForTts('cats & dogs')).toBe('cats and dogs')
+    expect(normalizeForTts('ping @ken')).toBe('ping at ken')
+    expect(normalizeForTts('see #general')).toBe('see hash general')
+  })
+
+  test('prose slash spoken', () => {
+    expect(normalizeForTts('yes/no answer')).toBe('yes slash no answer')
+  })
+
+  test('~ before a number → about', () => {
+    expect(normalizeForTts('~5 minutes left')).toBe('about 5 minutes left')
+  })
+})
+
+describe('conservatism', () => {
+  test('plain prose passes through unchanged', () => {
+    const input = 'The build finished and everything looks good.'
+    expect(normalizeForTts(input)).toBe(input)
+  })
+
+  test('deterministic: same input, same output', () => {
+    const input = '## Hi\n**bold** $5.20 at 14:30 👍 https://github.com/a'
+    expect(normalizeForTts(input)).toBe(normalizeForTts(input))
+  })
+})

--- a/telegram-plugin/tests/tts-normalize.test.ts
+++ b/telegram-plugin/tests/tts-normalize.test.ts
@@ -5,43 +5,36 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
 import { normalizeForTts, ttsNormalizeEnabled } from '../tts-normalize.js'
 
-const FLAG = 'SWITCHROOM_TTS_NORMALIZE'
 const KILL = 'SWITCHROOM_DISABLE_TTS_NORMALIZE'
 
-let savedFlag: string | undefined
 let savedKill: string | undefined
 
 beforeEach(() => {
-  savedFlag = process.env[FLAG]
   savedKill = process.env[KILL]
-  process.env[FLAG] = '1'
   delete process.env[KILL]
 })
 
 afterEach(() => {
-  if (savedFlag === undefined) delete process.env[FLAG]
-  else process.env[FLAG] = savedFlag
   if (savedKill === undefined) delete process.env[KILL]
   else process.env[KILL] = savedKill
 })
 
 describe('gating', () => {
-  test('pass-through when flag is off (default)', () => {
-    delete process.env[FLAG]
-    const input = '**bold** $5.20 https://github.com/x 🚀'
-    expect(normalizeForTts(input)).toBe(input)
-    expect(ttsNormalizeEnabled()).toBe(false)
-  })
-
-  test('kill switch wins even when the flag is on', () => {
-    process.env[KILL] = '1'
-    const input = '**bold** and $5.20'
-    expect(normalizeForTts(input)).toBe(input)
-    expect(ttsNormalizeEnabled()).toBe(false)
-  })
-
-  test('enabled when flag=1 and no kill switch', () => {
+  test('ON by default — normalizes with no env vars set', () => {
     expect(ttsNormalizeEnabled()).toBe(true)
+    expect(normalizeForTts('**bold** $5.20')).toBe('bold five dollars twenty')
+  })
+
+  test('kill switch → byte-identical pass-through', () => {
+    process.env[KILL] = '1'
+    const input = '**bold** and $5.20 🚀 https://github.com/x'
+    expect(normalizeForTts(input)).toBe(input)
+    expect(ttsNormalizeEnabled()).toBe(false)
+  })
+
+  test('kill switch accepts "true"', () => {
+    process.env[KILL] = 'true'
+    expect(ttsNormalizeEnabled()).toBe(false)
   })
 
   test('empty input stays empty', () => {
@@ -86,6 +79,14 @@ describe('markdown', () => {
     expect(normalizeForTts('run `deploy_5km_run` now')).toBe(
       'run deploy_5km_run now',
     )
+  })
+
+  test('unterminated fence swallows to end-of-input (deliberate)', () => {
+    // An opening ``` with no close drops everything after it — reading
+    // half a code block aloud is worse than omitting it. Pinned as the
+    // intended trade-off.
+    const out = normalizeForTts('before\n```ts\nconst secret = 1\nmore code')
+    expect(out).toBe('before code block omitted.')
   })
 
   test('tables summarized as table omitted', () => {
@@ -133,6 +134,42 @@ describe('numbers', () => {
     expect(normalizeForTts('call 0412 345 678 now')).toBe(
       'call zero four one two three four five six seven eight now',
     )
+  })
+
+  test('international +-prefixed number read as digits', () => {
+    expect(normalizeForTts('call +61 412 345 678')).toBe(
+      'call plus six one four one two three four five six seven eight',
+    )
+  })
+
+  test('ordinary space-separated numbers stay untouched', () => {
+    expect(normalizeForTts('scores were 1024 2048 4096 today')).toBe(
+      'scores were 1024 2048 4096 today',
+    )
+  })
+
+  test('short digit groups without phone prefix stay untouched', () => {
+    // The unit pass may expand a trailing unit, but the digit groups
+    // themselves must never be read digit-by-digit.
+    const out = normalizeForTts('12 34 56 78 items')
+    expect(out).toBe('12 34 56 78 items')
+  })
+
+  test('currency with thousands separator: $1,000 → one thousand dollars', () => {
+    expect(normalizeForTts('paid $1,000 up front')).toBe(
+      'paid one thousand dollars up front',
+    )
+    expect(normalizeForTts('$12,345.67 total')).toBe(
+      'twelve thousand three hundred forty-five dollars sixty-seven total',
+    )
+  })
+
+  test('odd cents ($5.203) left unchanged rather than half-read', () => {
+    expect(normalizeForTts('value $5.203 today')).toBe('value $5.203 today')
+  })
+
+  test('HH:MM:SS left unchanged (no dangling seconds)', () => {
+    expect(normalizeForTts('at 12:34:56 sharp')).toBe('at 12:34:56 sharp')
   })
 
   test('units expand: 5km, 10GB, 500ms', () => {

--- a/telegram-plugin/tts-normalize.ts
+++ b/telegram-plugin/tts-normalize.ts
@@ -17,11 +17,10 @@
  * last line of defence at the actual /tts body build. Rules where both
  * passes apply are no-ops the second time.
  *
- * Gating (issue: "off by default until proven"):
- *   - ENABLED only when `SWITCHROOM_TTS_NORMALIZE=1` (or `true`).
- *   - Additionally, `SWITCHROOM_DISABLE_TTS_NORMALIZE=1` is a kill switch
- *     that wins even when the enable flag is set — same shape as
- *     `SWITCHROOM_DISABLE_VOICE_SCRUB`; rollback is one env var.
+ * Gating: ON BY DEFAULT (operator decision 2026-07-04 — Phase 1 ships
+ * default-on). The only gate is the kill switch:
+ * `SWITCHROOM_DISABLE_TTS_NORMALIZE=1` returns the input byte-identical —
+ * same shape as `SWITCHROOM_DISABLE_VOICE_SCRUB`; rollback is one env var.
  *
  * Rules (en locale, deterministic, conservative — when unsure, pass
  * text through unchanged):
@@ -42,12 +41,10 @@
 const NULL = '\x00'
 const INLINE_PH = `${NULL}TN_INLINE`
 
-/** Enabled = opt-in flag set AND kill switch not set. */
+/** On by default; the kill switch is the only gate. */
 export function ttsNormalizeEnabled(): boolean {
   const kill = process.env.SWITCHROOM_DISABLE_TTS_NORMALIZE
-  if (kill === '1' || kill === 'true') return false
-  const on = process.env.SWITCHROOM_TTS_NORMALIZE
-  return on === '1' || on === 'true'
+  return !(kill === '1' || kill === 'true')
 }
 
 // ---------------------------------------------------------------------------
@@ -262,25 +259,31 @@ export function normalizeForTts(text: string): string {
   })
 
   // -- Phone-like digit runs → digit-by-digit. Fires ONLY on clearly
-  //    phone-shaped tokens (optional +country, groups of digits with
-  //    spaces/hyphens, 7+ digits total) so ordinary numbers are untouched.
+  //    phone-shaped tokens: a leading + (international), or a leading 0
+  //    (national) with separator-delimited 2-4-digit grouping; 7-15
+  //    digits total. Ordinary space-separated numbers ("1024 2048 4096")
+  //    and short groupings without a phone prefix ("12 34 56 78") stay
+  //    untouched.
   s = s.replace(/(?<![\w.])(\+?\d[\d\- ]{6,}\d)(?![\w.])/g, (m: string) => {
-    const digits = m.replace(/[^\d+]/g, '')
-    const digitCount = digits.replace(/\D/g, '').length
-    if (digitCount < 7 || digitCount > 15) return m
-    // A plain large integer (no separators, no +) is more likely a count
-    // than a phone number — leave it for the cardinal pass / as digits.
-    if (!/[+\- ]/.test(m)) return m
+    const digits = m.replace(/\D/g, '')
+    if (digits.length < 7 || digits.length > 15) return m
+    const groups = m.replace(/^\+/, '').split(/[- ]+/)
+    const phoneShaped =
+      m.startsWith('+') ||
+      (m.startsWith('0') &&
+        groups.length >= 2 &&
+        groups.every((g) => /^\d{2,4}$/.test(g)))
+    if (!phoneShaped) return m
     const words: string[] = []
-    for (const ch of digits) {
-      if (ch === '+') words.push('plus')
-      else words.push(ONES[Number(ch)]!)
-    }
+    if (m.startsWith('+')) words.push('plus')
+    for (const ch of digits) words.push(ONES[Number(ch)]!)
     return words.join(' ')
   })
 
-  // -- Times HH:MM (24h) → spoken.
-  s = s.replace(/\b([01]?\d|2[0-3]):([0-5]\d)\b/g, (_m, hh: string, mm: string) => {
+  // -- Times HH:MM (24h) → spoken. The (?!:?\d) guard skips HH:MM:SS
+  //    entirely — a half-spoken time with a dangling ":46" reads worse
+  //    than leaving the digits as-is.
+  s = s.replace(/\b([01]?\d|2[0-3]):([0-5]\d)(?!:?\d)/g, (_m, hh: string, mm: string) => {
     const h = Number(hh)
     const min = Number(mm)
     const hw = belowThousand(h)
@@ -289,18 +292,26 @@ export function normalizeForTts(text: string): string {
     return `${hw} ${belowThousand(min)}`
   })
 
-  // -- Currency: $5 → "five dollars"; $5.20 → "five dollars twenty".
-  s = s.replace(/\$(\d{1,9})(?:\.(\d{2}))?\b/g, (m, dollars: string, cents?: string) => {
-    const dw = numberToWords(Number(dollars))
-    if (!dw) return m
-    const noun = Number(dollars) === 1 && !cents ? 'dollar' : 'dollars'
-    if (cents && cents !== '00') {
-      const cw = numberToWords(Number(cents))
-      if (!cw) return m
-      return `${dw} ${noun} ${cw}`
-    }
-    return `${dw} ${noun}`
-  })
+  // -- Currency: $5 → "five dollars"; $5.20 → "five dollars twenty";
+  //    $1,000 → "one thousand dollars" (thousands separators consumed).
+  //    The trailing lookahead bails on odd-cents ("$5.203") and partial
+  //    thousands ("$1,00") — the whole token is left unchanged rather
+  //    than half-read.
+  s = s.replace(
+    /\$(\d{1,3}(?:,\d{3})+|\d{1,9})(?:\.(\d{2}))?(?![\d,]|\.\d)/g,
+    (m, dollarsRaw: string, cents?: string) => {
+      const dollars = Number(dollarsRaw.replace(/,/g, ''))
+      const dw = numberToWords(dollars)
+      if (!dw) return m
+      const noun = dollars === 1 && !cents ? 'dollar' : 'dollars'
+      if (cents && cents !== '00') {
+        const cw = numberToWords(Number(cents))
+        if (!cw) return m
+        return `${dw} ${noun} ${cw}`
+      }
+      return `${dw} ${noun}`
+    },
+  )
 
   // -- Percentages: 12% → "twelve percent"; 3.5% keeps digits + "percent".
   s = s.replace(/\b(\d{1,9})%/g, (m, n: string) => {

--- a/telegram-plugin/tts-normalize.ts
+++ b/telegram-plugin/tts-normalize.ts
@@ -1,0 +1,366 @@
+/**
+ * tts-normalize.ts — deterministic L1 text-normalization front-end for
+ * the voice sidecar (issue #2760, Phase 1).
+ *
+ * Kokoro ships almost no text normalization, so raw agent text (markdown,
+ * symbols, numbers, currency, emoji, URLs, code) gets read literally and
+ * sounds unnatural. This module is a PURE string→string pass applied in
+ * the gateway voice-out path immediately before the `POST /tts` body is
+ * built, mirroring the `text-voice-scrub.ts` precedent: deterministic
+ * transform, code-region park/restore, kill-switch env var, no network,
+ * no LLM (Phase 2 adds the optional local-LLM layer).
+ *
+ * It runs AFTER `normalizeForSpeech` (which already strips most markdown
+ * on the plan-building path) and is deliberately idempotent/overlapping
+ * with it: the Listen lazy path synthesizes from a persisted cache whose
+ * entries may predate normalizeForSpeech coverage, and this stage is the
+ * last line of defence at the actual /tts body build. Rules where both
+ * passes apply are no-ops the second time.
+ *
+ * Gating (issue: "off by default until proven"):
+ *   - ENABLED only when `SWITCHROOM_TTS_NORMALIZE=1` (or `true`).
+ *   - Additionally, `SWITCHROOM_DISABLE_TTS_NORMALIZE=1` is a kill switch
+ *     that wins even when the enable flag is set — same shape as
+ *     `SWITCHROOM_DISABLE_VOICE_SCRUB`; rollback is one env var.
+ *
+ * Rules (en locale, deterministic, conservative — when unsure, pass
+ * text through unchanged):
+ *   - Markdown: bold/italic/strike markers removed; headings → plain;
+ *     links → link text; bare URLs → spoken domain ("github dot com
+ *     link"); list markers dropped; tables → "table omitted"; code
+ *     fences → "code block omitted"; inline code read as-is without
+ *     backticks (content is parked so number/symbol expansion can never
+ *     mangle an identifier).
+ *   - Emoji: stripped (a small map speaks the common ones).
+ *   - Numbers: currency ($5.20 → "five dollars twenty"), percentages,
+ *     ordinals (3rd → "third"), times (14:30), ISO dates, phone-like
+ *     digit runs read digit-by-digit, units (km, GB, ms, …).
+ *   - Symbols: & → and, @ → at, # → hash, word/word → "word slash word",
+ *     ~5 → "about 5", > blockquote markers dropped.
+ */
+
+const NULL = '\x00'
+const INLINE_PH = `${NULL}TN_INLINE`
+
+/** Enabled = opt-in flag set AND kill switch not set. */
+export function ttsNormalizeEnabled(): boolean {
+  const kill = process.env.SWITCHROOM_DISABLE_TTS_NORMALIZE
+  if (kill === '1' || kill === 'true') return false
+  const on = process.env.SWITCHROOM_TTS_NORMALIZE
+  return on === '1' || on === 'true'
+}
+
+// ---------------------------------------------------------------------------
+// Number → words (English cardinal, 0..999,999,999; larger stays digits so we
+// never emit a wrong reading).
+// ---------------------------------------------------------------------------
+const ONES = [
+  'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight',
+  'nine', 'ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen',
+  'sixteen', 'seventeen', 'eighteen', 'nineteen',
+]
+const TENS = [
+  '', '', 'twenty', 'thirty', 'forty', 'fifty', 'sixty', 'seventy',
+  'eighty', 'ninety',
+]
+
+function belowThousand(n: number): string {
+  if (n < 20) return ONES[n]!
+  if (n < 100) {
+    const t = TENS[Math.floor(n / 10)]!
+    const o = n % 10
+    return o ? `${t}-${ONES[o]}` : t
+  }
+  const h = `${ONES[Math.floor(n / 100)]} hundred`
+  const rest = n % 100
+  return rest ? `${h} ${belowThousand(rest)}` : h
+}
+
+function numberToWords(n: number): string | null {
+  if (!Number.isInteger(n) || n < 0 || n > 999_999_999) return null
+  if (n === 0) return 'zero'
+  const parts: string[] = []
+  const millions = Math.floor(n / 1_000_000)
+  const thousands = Math.floor((n % 1_000_000) / 1000)
+  const rest = n % 1000
+  if (millions) parts.push(`${belowThousand(millions)} million`)
+  if (thousands) parts.push(`${belowThousand(thousands)} thousand`)
+  if (rest) parts.push(belowThousand(rest))
+  return parts.join(' ')
+}
+
+/** Ordinal words for 0..99 ("third", "twenty-first"). null out of range. */
+function ordinalToWords(n: number): string | null {
+  if (!Number.isInteger(n) || n < 0 || n > 99) return null
+  const IRREGULAR: Record<number, string> = {
+    0: 'zeroth', 1: 'first', 2: 'second', 3: 'third', 5: 'fifth',
+    8: 'eighth', 9: 'ninth', 12: 'twelfth',
+  }
+  if (IRREGULAR[n]) return IRREGULAR[n]
+  if (n < 20) return `${ONES[n]}th`
+  const tens = Math.floor(n / 10)
+  const ones = n % 10
+  if (ones === 0) return `${TENS[tens]!.replace(/y$/, 'ie')}th`
+  return `${TENS[tens]}-${ordinalToWords(ones)}`
+}
+
+function yearToWords(y: number): string | null {
+  if (y < 1000 || y > 9999) return null
+  if (y >= 2000 && y < 2100) {
+    const lo = y % 100
+    return lo ? `two thousand ${belowThousand(lo)}` : 'two thousand'
+  }
+  const hi = Math.floor(y / 100)
+  const lo = y % 100
+  return lo === 0 ? `${belowThousand(hi)} hundred` : `${belowThousand(hi)} ${belowThousand(lo)}`
+}
+
+const MONTHS = [
+  '', 'January', 'February', 'March', 'April', 'May', 'June', 'July',
+  'August', 'September', 'October', 'November', 'December',
+]
+
+/** Unit suffixes → spoken units (singular/plural). Lowercased keys. */
+const UNIT_MAP: Record<string, { s: string; p: string }> = {
+  ms: { s: 'millisecond', p: 'milliseconds' },
+  s: { s: 'second', p: 'seconds' },
+  sec: { s: 'second', p: 'seconds' },
+  min: { s: 'minute', p: 'minutes' },
+  h: { s: 'hour', p: 'hours' },
+  hr: { s: 'hour', p: 'hours' },
+  d: { s: 'day', p: 'days' },
+  km: { s: 'kilometre', p: 'kilometres' },
+  m: { s: 'metre', p: 'metres' },
+  cm: { s: 'centimetre', p: 'centimetres' },
+  mm: { s: 'millimetre', p: 'millimetres' },
+  mi: { s: 'mile', p: 'miles' },
+  kg: { s: 'kilogram', p: 'kilograms' },
+  g: { s: 'gram', p: 'grams' },
+  kb: { s: 'kilobyte', p: 'kilobytes' },
+  mb: { s: 'megabyte', p: 'megabytes' },
+  gb: { s: 'gigabyte', p: 'gigabytes' },
+  tb: { s: 'terabyte', p: 'terabytes' },
+  ghz: { s: 'gigahertz', p: 'gigahertz' },
+  mhz: { s: 'megahertz', p: 'megahertz' },
+}
+
+/** Small spoken map for the most common emoji; everything else is dropped. */
+const EMOJI_SPOKEN: Record<string, string> = {
+  '👍': 'thumbs up',
+  '👎': 'thumbs down',
+  '✅': 'done',
+  '❤️': 'love',
+  '⚠️': 'warning',
+}
+
+/** Speak a URL's domain: "https://github.com/x/y" → "github dot com link". */
+function spokenUrl(url: string): string {
+  const m = /^https?:\/\/(?:www\.)?([^/\s:?#]+)/i.exec(url)
+  if (!m) return 'a link'
+  const host = m[1]!
+  // Only verbalize simple dotted hostnames; an IP or userinfo-laden host
+  // reads badly — fall back to "a link".
+  if (!/^[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(host) || /^\d+\.\d+\.\d+\.\d+$/.test(host)) {
+    return 'a link'
+  }
+  return `${host.toLowerCase().split('.').join(' dot ')} link`
+}
+
+function parkInline(text: string): {
+  parked: string
+  parts: Array<{ idx: number; raw: string }>
+} {
+  const parts: Array<{ idx: number; raw: string }> = []
+  const parked = text.replace(/`([^`\n]+)`/g, (_m, content: string) => {
+    const idx = parts.length
+    // Park the CONTENT (backticks already dropped) so the spoken output
+    // reads the identifier as-is and no later pass can rewrite it.
+    parts.push({ idx, raw: content })
+    return `${INLINE_PH}${idx}${NULL}`
+  })
+  return { parked, parts }
+}
+
+function restoreInline(text: string, parts: Array<{ idx: number; raw: string }>): string {
+  let restored = text
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const p = parts[i]!
+    restored = restored.replace(`${INLINE_PH}${p.idx}${NULL}`, () => p.raw)
+  }
+  return restored
+}
+
+/**
+ * Normalize reply text for TTS. Pure + deterministic; returns the input
+ * unchanged when the feature flag is off, the kill switch is on, or the
+ * input is empty.
+ */
+export function normalizeForTts(text: string): string {
+  if (!ttsNormalizeEnabled() || text.length === 0) return text
+
+  let s = text.replace(/\r\n?/g, '\n')
+
+  // -- Code fences → spoken placeholder (before anything can see contents).
+  s = s.replace(/(^|\n)[ \t]*(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n[ \t]*\2[ \t]*(?=\n|$)/g, '$1code block omitted.')
+  s = s.replace(/(^|\n)[ \t]*(`{3,}|~{3,})[^\n]*\n[\s\S]*$/g, '$1code block omitted.')
+
+  // -- Park inline code (content spoken as-is, backticks gone).
+  const { parked, parts } = parkInline(s)
+  s = parked
+  s = s.replace(/`/g, '') // residual unpaired backticks
+
+  // -- Markdown tables → "table omitted." A table block = consecutive lines
+  //    with pipes that include a separator row (|---|---|).
+  s = s.replace(
+    /(?:^|\n)((?:[ \t]*\|[^\n]*\n)?[ \t]*\|?[ \t]*:?-{2,}:?[ \t]*(?:\|[ \t]*:?-{2,}:?[ \t]*)+\|?[ \t]*(?:\n[ \t]*\|[^\n]*)*)/g,
+    '\ntable omitted.',
+  )
+
+  // -- Images / links → text; autolinks + bare URLs → spoken domain.
+  s = s.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+  s = s.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+  s = s.replace(/<(https?:\/\/[^>\s]+)>/gi, (_m, url: string) => spokenUrl(url))
+  s = s.replace(/\bhttps?:\/\/[^\s)]+/gi, (m) => spokenUrl(m))
+
+  // -- Emoji: speak the small common map, drop everything else.
+  for (const [emoji, spoken] of Object.entries(EMOJI_SPOKEN)) {
+    s = s.split(emoji).join(` ${spoken} `)
+  }
+  s = s.replace(
+    /[\u{1F000}-\u{1FAFF}\u{1F1E6}-\u{1F1FF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE00}-\u{FE0F}\u{200D}\u{2B50}]/gu,
+    '',
+  )
+
+  // -- Emphasis markers (paired forms, longest first), strikethrough.
+  s = s.replace(/\*\*\*(.+?)\*\*\*/g, '$1')
+  s = s.replace(/___(.+?)___/g, '$1')
+  s = s.replace(/\*\*(.+?)\*\*/g, '$1')
+  s = s.replace(/__(.+?)__/g, '$1')
+  s = s.replace(/\*(.+?)\*/g, '$1')
+  s = s.replace(/(?<![A-Za-z0-9])_(.+?)_(?![A-Za-z0-9])/g, '$1')
+  s = s.replace(/~~(.+?)~~/g, '$1')
+
+  // -- Block markup per line: headings, blockquote '>' markers, list
+  //    markers, horizontal rules.
+  s = s.replace(/^[ \t]{0,3}#{1,6}[ \t]+/gm, '')
+  s = s.replace(/^[ \t]{0,3}>[ \t]?/gm, '')
+  s = s.replace(/^[ \t]{0,3}[-*+][ \t]+/gm, '')
+  s = s.replace(/^[ \t]{0,3}\d+[.)][ \t]+/gm, '')
+  s = s.replace(/^[ \t]{0,3}([-_*])\1{2,}[ \t]*$/gm, '')
+
+  // -- ISO dates YYYY-MM-DD → "July fourth two thousand twenty-six".
+  //    MUST run before the phone-run pass (an ISO date is 8 digits with
+  //    hyphens and would otherwise be read digit-by-digit).
+  s = s.replace(/\b(\d{4})-(\d{2})-(\d{2})\b/g, (m, y: string, mo: string, da: string) => {
+    const month = Number(mo)
+    const day = Number(da)
+    if (month < 1 || month > 12 || day < 1 || day > 31) return m
+    const yw = yearToWords(Number(y))
+    const dw = ordinalToWords(day)
+    if (!yw || !dw) return m
+    return `${MONTHS[month]} ${dw} ${yw}`
+  })
+
+  // -- Phone-like digit runs → digit-by-digit. Fires ONLY on clearly
+  //    phone-shaped tokens (optional +country, groups of digits with
+  //    spaces/hyphens, 7+ digits total) so ordinary numbers are untouched.
+  s = s.replace(/(?<![\w.])(\+?\d[\d\- ]{6,}\d)(?![\w.])/g, (m: string) => {
+    const digits = m.replace(/[^\d+]/g, '')
+    const digitCount = digits.replace(/\D/g, '').length
+    if (digitCount < 7 || digitCount > 15) return m
+    // A plain large integer (no separators, no +) is more likely a count
+    // than a phone number — leave it for the cardinal pass / as digits.
+    if (!/[+\- ]/.test(m)) return m
+    const words: string[] = []
+    for (const ch of digits) {
+      if (ch === '+') words.push('plus')
+      else words.push(ONES[Number(ch)]!)
+    }
+    return words.join(' ')
+  })
+
+  // -- Times HH:MM (24h) → spoken.
+  s = s.replace(/\b([01]?\d|2[0-3]):([0-5]\d)\b/g, (_m, hh: string, mm: string) => {
+    const h = Number(hh)
+    const min = Number(mm)
+    const hw = belowThousand(h)
+    if (min === 0) return `${hw} o'clock`
+    if (min < 10) return `${hw} oh ${ONES[min]}`
+    return `${hw} ${belowThousand(min)}`
+  })
+
+  // -- Currency: $5 → "five dollars"; $5.20 → "five dollars twenty".
+  s = s.replace(/\$(\d{1,9})(?:\.(\d{2}))?\b/g, (m, dollars: string, cents?: string) => {
+    const dw = numberToWords(Number(dollars))
+    if (!dw) return m
+    const noun = Number(dollars) === 1 && !cents ? 'dollar' : 'dollars'
+    if (cents && cents !== '00') {
+      const cw = numberToWords(Number(cents))
+      if (!cw) return m
+      return `${dw} ${noun} ${cw}`
+    }
+    return `${dw} ${noun}`
+  })
+
+  // -- Percentages: 12% → "twelve percent"; 3.5% keeps digits + "percent".
+  s = s.replace(/\b(\d{1,9})%/g, (m, n: string) => {
+    const w = numberToWords(Number(n))
+    return w ? `${w} percent` : m
+  })
+  s = s.replace(/(\d)\s*%/g, '$1 percent')
+
+  // -- Ordinals: 3rd → "third" (guarded to matching suffix only).
+  s = s.replace(/\b(\d{1,2})(st|nd|rd|th)\b/gi, (m, n: string, suffix: string) => {
+    const num = Number(n)
+    const correct =
+      (num % 10 === 1 && num % 100 !== 11 && suffix.toLowerCase() === 'st') ||
+      (num % 10 === 2 && num % 100 !== 12 && suffix.toLowerCase() === 'nd') ||
+      (num % 10 === 3 && num % 100 !== 13 && suffix.toLowerCase() === 'rd') ||
+      (suffix.toLowerCase() === 'th' &&
+        !((num % 10 === 1 && num % 100 !== 11) || (num % 10 === 2 && num % 100 !== 12) || (num % 10 === 3 && num % 100 !== 13)))
+    if (!correct) return m
+    const w = ordinalToWords(num)
+    return w ?? m
+  })
+
+  // -- Number + unit suffix glued to the number (500ms, 5km, 10GB). Only a
+  //    known unit bounded by a non-letter, so identifiers never match.
+  s = s.replace(
+    /\b(\d{1,9})\s?(ms|sec|min|km|cm|mm|kg|kb|mb|gb|tb|ghz|mhz|hr|mi|s|m|h|d|g)(?![a-z])/gi,
+    (m, num: string, unitRaw: string) => {
+      const unit = UNIT_MAP[unitRaw.toLowerCase()]
+      if (!unit) return m
+      const n = Number(num)
+      const w = numberToWords(n)
+      if (!w) return m
+      return `${w} ${n === 1 ? unit.s : unit.p}`
+    },
+  )
+
+  // -- Symbols in prose.
+  s = s.replace(/(\s)&(\s)/g, '$1and$2')
+  s = s.replace(/(\w)&(\w)/g, '$1 and $2')
+  s = s.replace(/(^|\s)@(\w)/g, '$1at $2')
+  s = s.replace(/(^|\s)#(\w)/g, '$1hash $2')
+  // word/word in prose → "word slash word" (letters only, so paths/dates
+  // with digits are untouched).
+  s = s.replace(/\b([a-zA-Z]{2,})\/([a-zA-Z]{2,})\b/g, '$1 slash $2')
+  // ~ before a number → "about"; other tildes dropped.
+  s = s.replace(/~\s*(\d)/g, 'about $1')
+  s = s.replace(/~/g, '')
+  // Arrows → "to".
+  s = s.replace(/[=-]>/g, ' to ')
+  s = s.replace(/[→⇒]/g, ' to ')
+
+  // -- Restore parked inline-code contents verbatim.
+  s = restoreInline(s, parts)
+
+  // -- Whitespace → sentence flow.
+  s = s.replace(/[ \t]*\n[ \t]*\n[ \t]*/g, '. ')
+  s = s.replace(/\s*\n\s*/g, ' ')
+  s = s.replace(/[ \t]{2,}/g, ' ')
+  s = s.replace(/\.\s*\.(\s|$)/g, '.$1')
+  s = s.replace(/\s+([,.!?;:])/g, '$1')
+
+  return s.trim()
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -160,6 +160,8 @@ export default defineConfig({
       "**/telegram-plugin/tests/history-reaper.test.ts",
       // sandbox-hint-posttool.test.ts uses bun:test — run via test:bun.
       "**/telegram-plugin/tests/sandbox-hint-posttool.test.ts",
+      // tts-normalize.test.ts (#2760 Phase 1) imports bun:test — run via test:bun.
+      "**/telegram-plugin/tests/tts-normalize.test.ts",
       // fleet-fallback-gate.test.ts uses bun:test — run via test:bun.
       "**/telegram-plugin/tests/fleet-fallback-gate.test.ts",
       "**/telegram-plugin/tests/ipc-server-client.test.ts",


### PR DESCRIPTION
## Summary

Phase 1 of #2760: a deterministic (L1) text-normalization front-end in the gateway voice-out path, applied immediately before the `POST /tts` body is built, so Kokoro stops reading markdown, symbols, numbers, currency, emoji, and URLs literally. No LLM, no network, pure TypeScript (the gateway is a Bun process, so the WFST-equivalent rules are implemented directly in TS rather than pulling a Python/nemo dependency).

- **New module `telegram-plugin/tts-normalize.ts`** exporting `normalizeForTts(text)`. Mirrors the `text-voice-scrub.ts` precedent: deterministic transform, code-region park/restore (inline-code content is parked so later passes can never mangle an identifier), kill-switch env var.
- **Rules (en):** markdown strip (bold/italic/strike, headings, links → text, list/quote markers, tables → "table omitted", fences → "code block omitted", inline code read as-is); bare URLs → spoken domain ("github dot com link"); emoji stripped (small spoken map for 👍 ✅ etc.); currency (`$5.20` → "five dollars twenty", `$1,000` → "one thousand dollars"), percentages, ordinals, times (HH:MM; HH:MM:SS deliberately untouched), ISO dates, phone-shaped digit runs (leading `+` or `0`-prefixed 2-4-digit grouping) read digit-by-digit, unit suffixes (km, GB, ms, …); symbol expansion (`&` → and, `@` → at, `#` → hash, prose `/` → slash, `~5` → "about 5"). Conservative by construction: guarded patterns only; odd cents / ambiguous digit runs pass through whole-token unchanged.
- **Gating — ON BY DEFAULT** (operator decision 2026-07-04; supersedes the issue's off-by-default rollout note). The only gate is the kill switch: `SWITCHROOM_DISABLE_TTS_NORMALIZE=1` returns text byte-identical. Same one-env-var rollback shape as `SWITCHROOM_DISABLE_VOICE_SCRUB`.
- **Wiring — both /tts body-build sites in `gateway.ts`:**
  1. `synthesizeVoiceOut` — the choke point for the immediate voice-out path (covers both the kokoro sidecar `POST /tts` and the openai cloud engine).
  2. The 🔊 Listen on-demand callback handler — it synthesizes separately from the persisted `voiceOnDemandCache`, building its own sidecar body from `entry.text`, so it normalizes independently.

## Why

Serves `reference/jobs/talk-to-agents-from-anywhere.md` (always-available: voice replies you can actually listen to on the train are the point of voice-out) with a side of `feel-like-a-colleague` (an agent that says "asterisk asterisk dollar five dot two zero" is a chatbot tell). Verdict rule: (a) advances always-available; (b) job outcome proven by the bun test suite covering every rule class; (c) principles — no docs needed (zero config, works by default; the defaults test is now satisfied in the strong sense), same kill-switch shape as every other gateway safety net (consistency test); (d) no invariant crossed — deterministic local string pass, no model call, subscription-honest untouched.

## Test plan

- [x] `telegram-plugin/tests/tts-normalize.test.ts` (bun test): 38 tests — markdown (headings/bold/links/lists/tables/fences incl. pinned unterminated-fence swallow/inline code), currency (incl. `$1,000` and `$5.203` bail), percent, ordinals, times (incl. HH:MM:SS bail), ISO dates, phone-shape guards (`1024 2048 4096` and `12 34 56 78` pinned untouched), units, URLs (incl. IP degrade), emoji, symbols, default-on pin, kill-switch pin, determinism, identifier safety.
- [x] `npm run lint` green (incl. `check-bun-test-imports.mjs` — the test file is in the vitest exclude list per repo convention).
- [x] `bun test telegram-plugin` (full plugin unit surface, same dirs as CI's bun-test job): 5504 pass / 0 fail.

## Risk

Low-moderate (default-on): scope is confined to the two TTS body-build sites — text replies are untouched; only the synthesized audio input changes. Rollback is one env var (`SWITCHROOM_DISABLE_TTS_NORMALIZE=1`). Rules are individually guarded and bail whole-token when a pattern is ambiguous. Phase 2 (optional CPU Qwen L2) is out of scope here.

Part of #2760 (Phase 1 of 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)