### PR TITLE
feat(voice): eager pre-synthesis + attach-on-tap Listen + 7-day cleanup (#2763)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -62,6 +62,13 @@ import {
   buildListenKeyboard,
   mayInjectListenButton,
 } from '../voice-ondemand.js'
+import {
+  PreSynthQueue,
+  sweepVoiceCacheDir,
+  writeVoiceCacheFile,
+  eagerVoiceEnabled,
+  VOICE_SWEEP_INTERVAL_MS,
+} from '../voice-presynth.js'
 
 /** Fleet default TTS speed when voice_out is enabled but speed is unset —
  *  slightly brisker than neutral (Ken's chosen default). */
@@ -8635,6 +8642,71 @@ const voiceOnDemandCache = new VoiceOnDemandCache({
   persistPath: join(STATE_DIR, 'voice-ondemand.json'),
 })
 
+// ─── Eager voice pre-synthesis (#2763) ─────────────────────────────────────
+// Whenever a reply becomes Listen-eligible (a voiceOnDemandCache entry is
+// persisted alongside the Listen button), ALSO synthesize the audio in the
+// background via the LOCAL sidecar and park it on disk, so the 🔊 Listen tap
+// attaches the pre-made file instantly instead of waiting on the GPU. Local
+// engine only (kokoro — zero token/dollar cost); the openai cloud engine
+// never pre-synthesizes. Strictly off the reply critical path: jobs drain
+// through a bounded FIFO (concurrency 1, drop-oldest past the cap) and every
+// failure is swallowed — the tap just falls back to the lazy synth path.
+// Kill switch: SWITCHROOM_DISABLE_EAGER_VOICE=1 (the sweep still runs so old
+// files age out).
+const VOICE_CACHE_DIR = join(STATE_DIR, 'voice-cache')
+
+const voicePreSynthQueue = new PreSynthQueue({
+  runJob: async (job) => {
+    const sidecarToken = await materializeSidecarToken()
+    if (!sidecarToken) return // sidecar unavailable — lazy path will retry on tap
+    const result = await synthesizeViaSidecar({
+      token: sidecarToken,
+      // Same deterministic normalization the lazy Listen path applies —
+      // job.text is normalizeForSpeech(reply); normalizeForTts is the #2760
+      // L1 pass on top.
+      text: normalizeForTts(job.text),
+      voice: job.voice,
+      speed: job.speed,
+    })
+    if (!result.ok) {
+      process.stderr.write(
+        `telegram gateway: voice-presynth: sidecar synthesis failed token=${job.token} reason=${result.reason}\n`,
+      )
+      return
+    }
+    const filePath = writeVoiceCacheFile(VOICE_CACHE_DIR, job.token, result.audio)
+    voiceOnDemandCache.setFilePath(job.token, filePath)
+    process.stderr.write(
+      `telegram gateway: voice-presynth: cached ${result.audio.length} bytes at ${filePath} ` +
+        `(${result.durationMs}ms, backlog=${voicePreSynthQueue.size})\n`,
+    )
+  },
+})
+
+/** Rolling 7-day TTL + 500MB size-budget sweep over VOICE_CACHE_DIR. Runs at
+ *  boot and hourly; ALWAYS runs (even under the eager-voice kill switch) so
+ *  previously written files age out. Crash-safe: missing dir/files tolerated. */
+function sweepVoiceCache(): void {
+  try {
+    const result = sweepVoiceCacheDir({ dir: VOICE_CACHE_DIR })
+    if (result.deletedTokens.length > 0) {
+      voiceOnDemandCache.prune(result.deletedTokens)
+      process.stderr.write(
+        `telegram gateway: voice-presynth: sweep removed ${result.deletedTokens.length} file(s), ` +
+          `${result.remainingBytes} bytes remain\n`,
+      )
+    }
+  } catch (err) {
+    // Defence in depth — sweepVoiceCacheDir is already per-file crash-safe.
+    process.stderr.write(`telegram gateway: voice-presynth: sweep failed: ${String(err)}\n`)
+  }
+}
+
+if (!STATIC) {
+  sweepVoiceCache() // boot sweep — covers a died timer / long downtime
+  setInterval(sweepVoiceCache, VOICE_SWEEP_INTERVAL_MS).unref()
+}
+
 type VoiceOutAccess = NonNullable<Access['voice_out']>
 
 /**
@@ -9280,6 +9352,22 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
       // replayed. The gate above guarantees this is the ONLY button on the
       // message, so keeping it is safe (no agent buttons to protect).
       replyMarkup = buildListenKeyboard(token)
+      // #2763 eager pre-synthesis: kick a background synth of the same
+      // payload so the Listen tap attaches the pre-made file instantly.
+      // Local-engine only (useOnDemandButton already gates engine==='kokoro'
+      // — the cloud engine never eager-synthesizes). enqueue() is a
+      // synchronous array push; the drain is deferred + async and never
+      // awaited here, so the text sends below are never delayed and a synth
+      // failure can never affect message delivery (the tap just falls back
+      // to the lazy path).
+      if (eagerVoiceEnabled()) {
+        voicePreSynthQueue.enqueue({
+          token,
+          text: voiceOutPlan.ttsChunks[0]!,
+          ...(voiceOutPlan.voice != null ? { voice: voiceOutPlan.voice } : {}),
+          speed: voiceOutPlan.speed,
+        })
+      }
     }
   }
 
@@ -22500,7 +22588,6 @@ bot.on('callback_query:data', async ctx => {
         .catch(() => {})
       return
     }
-    await ctx.answerCallbackQuery({ text: '🔊 Synthesizing…' }).catch(() => {})
     const cbChatId = String(ctx.chat?.id ?? ctx.from.id)
     const cbMessageId = ctx.callbackQuery?.message?.message_id
     const cbThreadId = (() => {
@@ -22511,35 +22598,57 @@ bot.on('callback_query:data', async ctx => {
       }
       return undefined
     })()
-    // Local sidecar (kokoro) synthesis — same helper the immediate voice-out
-    // path uses. On-demand is a local-engine feature; the cache is only
-    // populated when resolveVoiceOutPlan gated the local verdict.
-    const sidecarToken = await materializeSidecarToken()
-    if (!sidecarToken) {
-      await ctx
-        .answerCallbackQuery({ text: 'Voice sidecar unavailable — try again later.' })
-        .catch(() => {})
-      return
+    // #2763 attach-on-tap: prefer the eagerly pre-synthesized file (written
+    // by the pre-synth queue at reply time). If it's on disk, attach it
+    // immediately — no GPU wait. Missing/unreadable file (expired + swept,
+    // crash, pre-feature entry, kill-switched gateway) falls back
+    // transparently to the lazy synth path below.
+    let audio: Uint8Array | null = null
+    if (entry.filePath != null) {
+      try {
+        audio = readFileSync(entry.filePath)
+      } catch {
+        audio = null // swept/missing — lazy fallback
+      }
     }
-    const result = await synthesizeViaSidecar({
-      token: sidecarToken,
-      // #2760 Phase 1: same deterministic normalization as the immediate
-      // voice-out path — the Listen lazy path builds its own /tts body from
-      // the persisted cache, so it must normalize independently (cache
-      // entries may predate the flag flip).
-      text: normalizeForTts(entry.text),
-      voice: entry.voice,
-      speed: entry.speed,
-    })
-    if (!result.ok) {
-      process.stderr.write(
-        `telegram gateway: voice-out on-demand: synthesis failed reason=${result.reason}\n`,
-      )
-      await ctx
-        .answerCallbackQuery({ text: `Voice failed: ${result.reason}` })
-        .catch(() => {})
-      return
+    if (audio != null) {
+      await ctx.answerCallbackQuery({ text: '🔊' }).catch(() => {})
+    } else {
+      await ctx.answerCallbackQuery({ text: '🔊 Synthesizing…' }).catch(() => {})
+      // Local sidecar (kokoro) synthesis — same helper the immediate voice-out
+      // path uses. On-demand is a local-engine feature; the cache is only
+      // populated when resolveVoiceOutPlan gated the local verdict.
+      const sidecarToken = await materializeSidecarToken()
+      if (!sidecarToken) {
+        await ctx
+          .answerCallbackQuery({ text: 'Voice sidecar unavailable — try again later.' })
+          .catch(() => {})
+        return
+      }
+      const result = await synthesizeViaSidecar({
+        token: sidecarToken,
+        // #2760 Phase 1: same deterministic normalization as the immediate
+        // voice-out path — the Listen lazy path builds its own /tts body from
+        // the persisted cache, so it must normalize independently (cache
+        // entries may predate the flag flip).
+        text: normalizeForTts(entry.text),
+        voice: entry.voice,
+        speed: entry.speed,
+      })
+      if (!result.ok) {
+        process.stderr.write(
+          `telegram gateway: voice-out on-demand: synthesis failed reason=${result.reason}\n`,
+        )
+        await ctx
+          .answerCallbackQuery({ text: `Voice failed: ${result.reason}` })
+          .catch(() => {})
+        return
+      }
+      audio = result.audio
     }
+    // Rebind as const so the closure below narrows to non-null (TS doesn't
+    // narrow a captured `let` inside an arrow function).
+    const audioOut: Uint8Array = audio
     try {
       // Native voice note (NOT a document), quote-replying the button's
       // message.
@@ -22548,7 +22657,7 @@ bot.on('callback_query:data', async ctx => {
           bot.api.sendVoice(
             cbChatId,
             // allow-raw-bot-api: single native voice-note send for an on-demand Listen tap.
-            new InputFile(Buffer.from(result.audio)),
+            new InputFile(Buffer.from(audioOut)),
             {
               ...(cbMessageId != null ? { reply_parameters: { message_id: cbMessageId } } : {}),
               ...(cbThreadId != null ? { message_thread_id: cbThreadId } : {}),

--- a/telegram-plugin/tests/voice-presynth.test.ts
+++ b/telegram-plugin/tests/voice-presynth.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Eager voice pre-synthesis + rolling cleanup unit tests (issue #2763).
+ *
+ * gateway.ts is a 25k-line module with import-time side effects, so the
+ * primitives live in ../voice-presynth.ts (imported by the gateway). These
+ * tests exercise the real primitives + reproduce the exact gateway decisions
+ * (queue bounding, TTL/size sweep, attach-vs-fallback, kill switch) without
+ * importing the gateway.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync, utimesSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import {
+  PreSynthQueue,
+  sweepVoiceCacheDir,
+  writeVoiceCacheFile,
+  voiceCacheFilePath,
+  eagerVoiceEnabled,
+  VOICE_FILE_TTL_MS,
+  PRESYNTH_MAX_PENDING,
+  type PreSynthJob,
+  type SweepFs,
+} from '../voice-presynth.js'
+import { VoiceOnDemandCache } from '../voice-ondemand.js'
+
+const KILL = 'SWITCHROOM_DISABLE_EAGER_VOICE'
+let savedKill: string | undefined
+
+beforeEach(() => {
+  savedKill = process.env[KILL]
+  delete process.env[KILL]
+})
+
+afterEach(() => {
+  if (savedKill === undefined) delete process.env[KILL]
+  else process.env[KILL] = savedKill
+})
+
+// ─── Kill switch ────────────────────────────────────────────────────────────
+
+describe('eagerVoiceEnabled (kill switch)', () => {
+  it('is on by default', () => {
+    expect(eagerVoiceEnabled()).toBe(true)
+  })
+
+  it('is off when SWITCHROOM_DISABLE_EAGER_VOICE=1 or =true', () => {
+    process.env[KILL] = '1'
+    expect(eagerVoiceEnabled()).toBe(false)
+    process.env[KILL] = 'true'
+    expect(eagerVoiceEnabled()).toBe(false)
+  })
+
+  it('other values do not disable', () => {
+    process.env[KILL] = '0'
+    expect(eagerVoiceEnabled()).toBe(true)
+    process.env[KILL] = ''
+    expect(eagerVoiceEnabled()).toBe(true)
+  })
+
+  it('gateway put-site decision: kill switch means no job is enqueued', () => {
+    // Reproduces the exact guard the gateway uses around enqueue().
+    process.env[KILL] = '1'
+    const ran: string[] = []
+    const q = new PreSynthQueue({
+      runJob: async (j) => void ran.push(j.token),
+      defer: (fn) => fn(),
+      log: () => {},
+    })
+    if (eagerVoiceEnabled()) q.enqueue({ token: 't1', text: 'hello' })
+    expect(q.size).toBe(0)
+    expect(ran).toEqual([])
+  })
+})
+
+// ─── Queue bounding + serialization ─────────────────────────────────────────
+
+describe('PreSynthQueue', () => {
+  it('drains jobs FIFO with concurrency 1', async () => {
+    const order: string[] = []
+    let inFlight = 0
+    let maxInFlight = 0
+    const deferred: Array<() => void> = []
+    const q = new PreSynthQueue({
+      runJob: async (j) => {
+        inFlight++
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        await Promise.resolve() // yield — lets a concurrent runner interleave if one existed
+        order.push(j.token)
+        inFlight--
+      },
+      defer: (fn) => deferred.push(fn),
+      log: () => {},
+    })
+    q.enqueue({ token: 'a', text: '1' })
+    q.enqueue({ token: 'b', text: '2' })
+    q.enqueue({ token: 'c', text: '3' })
+    expect(deferred.length).toBe(1) // one drain kicked, not one per job
+    deferred[0]!()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(order).toEqual(['a', 'b', 'c'])
+    expect(maxInFlight).toBe(1)
+    expect(q.size).toBe(0)
+    expect(q.busy).toBe(false)
+  })
+
+  it('drops the OLDEST pending job past the backlog cap', () => {
+    const q = new PreSynthQueue({
+      runJob: async () => {},
+      maxPending: 3,
+      defer: () => {}, // never drain — pure backlog test
+      log: () => {},
+    })
+    for (const t of ['a', 'b', 'c', 'd', 'e']) q.enqueue({ token: t, text: t })
+    expect(q.size).toBe(3)
+  })
+
+  it('drop-oldest under a blocked runner keeps only the newest maxPending', async () => {
+    let release: () => void = () => {}
+    const gate = new Promise<void>((r) => (release = r))
+    const ran: string[] = []
+    const q = new PreSynthQueue({
+      runJob: async (j) => {
+        ran.push(j.token)
+        if (j.token === 'first') await gate // block the drain on the first job
+      },
+      maxPending: 2,
+      defer: (fn) => fn(),
+      log: () => {},
+    })
+    q.enqueue({ token: 'first', text: 'x' }) // starts running, blocks
+    await new Promise((r) => setTimeout(r, 0))
+    q.enqueue({ token: 'a', text: '1' })
+    q.enqueue({ token: 'b', text: '2' })
+    q.enqueue({ token: 'c', text: '3' }) // over cap → 'a' dropped
+    expect(q.size).toBe(2)
+    release()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(ran).toEqual(['first', 'b', 'c'])
+  })
+
+  it('default cap matches the design (~50)', () => {
+    expect(PRESYNTH_MAX_PENDING).toBe(50)
+  })
+
+  it('a throwing job never propagates and does not stall the queue', async () => {
+    const ran: string[] = []
+    const logs: string[] = []
+    const q = new PreSynthQueue({
+      runJob: async (j) => {
+        if (j.token === 'boom') throw new Error('synth exploded')
+        ran.push(j.token)
+      },
+      defer: (fn) => fn(),
+      log: (l) => void logs.push(l),
+    })
+    q.enqueue({ token: 'boom', text: 'x' })
+    q.enqueue({ token: 'ok', text: 'y' })
+    await new Promise((r) => setTimeout(r, 0))
+    expect(ran).toEqual(['ok'])
+    expect(logs.some((l) => l.includes('boom'))).toBe(true)
+    expect(q.busy).toBe(false)
+  })
+})
+
+// ─── File persistence helpers ────────────────────────────────────────────────
+
+describe('writeVoiceCacheFile', () => {
+  it('writes atomically under the dir, creating it as needed', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'voice-cache-'))
+    try {
+      const nested = join(dir, 'voice-cache')
+      const audio = new Uint8Array([1, 2, 3, 4])
+      const path = writeVoiceCacheFile(nested, 'tok1', audio)
+      expect(path).toBe(voiceCacheFilePath(nested, 'tok1'))
+      expect(existsSync(path)).toBe(true)
+      expect(Array.from(readFileSync(path))).toEqual([1, 2, 3, 4])
+      expect(existsSync(path + '.tmp')).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+// ─── Sweep: TTL + size budget ────────────────────────────────────────────────
+
+function makeFakeFs(files: Record<string, { mtimeMs: number; size: number }>): {
+  fs: SweepFs
+  deleted: string[]
+} {
+  const deleted: string[] = []
+  const state = { ...files }
+  return {
+    deleted,
+    fs: {
+      readdirSync: () => Object.keys(state),
+      statSync: (path: string) => {
+        const name = path.split('/').pop()!
+        const f = state[name]
+        if (f == null) throw new Error('ENOENT')
+        return { mtimeMs: f.mtimeMs, size: f.size, isFile: () => true }
+      },
+      unlinkSync: (path: string) => {
+        const name = path.split('/').pop()!
+        if (state[name] == null) throw new Error('ENOENT')
+        delete state[name]
+        deleted.push(name)
+      },
+    },
+  }
+}
+
+describe('sweepVoiceCacheDir', () => {
+  const NOW = 1_800_000_000_000
+  const DAY = 24 * 60 * 60 * 1000
+
+  it('deletes files older than 7 days and reports their tokens', () => {
+    const { fs, deleted } = makeFakeFs({
+      'old.ogg': { mtimeMs: NOW - 8 * DAY, size: 100 },
+      'edge.ogg': { mtimeMs: NOW - VOICE_FILE_TTL_MS, size: 100 }, // exactly at cutoff → gone
+      'fresh.ogg': { mtimeMs: NOW - 1 * DAY, size: 100 },
+    })
+    const result = sweepVoiceCacheDir({ dir: '/x', now: () => NOW, fs, log: () => {} })
+    expect(deleted.sort()).toEqual(['edge.ogg', 'old.ogg'])
+    expect(result.deletedTokens.sort()).toEqual(['edge', 'old'])
+    expect(result.remainingBytes).toBe(100)
+  })
+
+  it('size budget: deletes oldest-first down to maxBytes even when fresh', () => {
+    const { fs, deleted } = makeFakeFs({
+      'a.ogg': { mtimeMs: NOW - 3 * DAY, size: 300 },
+      'b.ogg': { mtimeMs: NOW - 2 * DAY, size: 300 },
+      'c.ogg': { mtimeMs: NOW - 1 * DAY, size: 300 },
+    })
+    const result = sweepVoiceCacheDir({
+      dir: '/x',
+      now: () => NOW,
+      fs,
+      maxBytes: 650,
+      log: () => {},
+    })
+    expect(deleted).toEqual(['a.ogg']) // oldest first, stop once under budget
+    expect(result.remainingBytes).toBe(600)
+  })
+
+  it('missing dir is a no-op (crash-safe)', () => {
+    const result = sweepVoiceCacheDir({
+      dir: join(tmpdir(), 'definitely-not-there-' + Date.now()),
+      log: () => {},
+    })
+    expect(result.deletedTokens).toEqual([])
+    expect(result.remainingBytes).toBe(0)
+  })
+
+  it('a file vanishing mid-sweep (stat or unlink ENOENT) never aborts', () => {
+    let statCalls = 0
+    const fs: SweepFs = {
+      readdirSync: () => ['gone.ogg', 'old.ogg'],
+      statSync: (path: string) => {
+        statCalls++
+        if (path.endsWith('gone.ogg')) throw new Error('ENOENT')
+        return { mtimeMs: NOW - 8 * DAY, size: 10, isFile: () => true }
+      },
+      unlinkSync: () => {
+        throw new Error('ENOENT') // concurrent delete — tolerated
+      },
+    }
+    const result = sweepVoiceCacheDir({ dir: '/x', now: () => NOW, fs, log: () => {} })
+    expect(statCalls).toBe(2)
+    expect(result.deletedTokens).toEqual(['old'])
+  })
+
+  it('real-fs end-to-end: TTL sweep removes old, keeps fresh', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'voice-sweep-'))
+    try {
+      const oldPath = join(dir, 'oldtok.ogg')
+      const freshPath = join(dir, 'freshtok.ogg')
+      writeFileSync(oldPath, 'old')
+      writeFileSync(freshPath, 'fresh')
+      const oldTime = (Date.now() - 8 * DAY) / 1000
+      utimesSync(oldPath, oldTime, oldTime)
+      const result = sweepVoiceCacheDir({ dir, log: () => {} })
+      expect(result.deletedTokens).toEqual(['oldtok'])
+      expect(existsSync(oldPath)).toBe(false)
+      expect(existsSync(freshPath)).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+// ─── Attach-vs-fallback decision + cache integration ────────────────────────
+
+describe('attach-on-tap decision (gateway contract)', () => {
+  /** Reproduces the exact gateway tap decision: pre-made file readable →
+   *  attach; otherwise → lazy synth fallback. */
+  function decideTap(entry: { filePath?: string } | null): 'expired' | 'attach' | 'lazy' {
+    if (entry == null) return 'expired'
+    if (entry.filePath != null) {
+      try {
+        readFileSync(entry.filePath)
+        return 'attach'
+      } catch {
+        return 'lazy'
+      }
+    }
+    return 'lazy'
+  }
+
+  it('attaches when the pre-made file exists and the entry is live', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'voice-attach-'))
+    try {
+      const cache = new VoiceOnDemandCache()
+      cache.put('tok', { text: 'hello world', speed: 1.1 })
+      const filePath = writeVoiceCacheFile(dir, 'tok', new Uint8Array([9, 9]))
+      cache.setFilePath('tok', filePath)
+      const entry = cache.get('tok')
+      expect(entry?.filePath).toBe(filePath)
+      expect(decideTap(entry)).toBe('attach')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to lazy when the file was swept from disk', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'voice-attach-'))
+    try {
+      const cache = new VoiceOnDemandCache()
+      cache.put('tok', { text: 'hello', speed: 1.0 })
+      const filePath = writeVoiceCacheFile(dir, 'tok', new Uint8Array([1]))
+      cache.setFilePath('tok', filePath)
+      rmSync(filePath) // sweep/crash took the file
+      expect(decideTap(cache.get('tok'))).toBe('lazy')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('pre-feature entries (no filePath) take the lazy path', () => {
+    const cache = new VoiceOnDemandCache()
+    cache.put('tok', { text: 'hello', speed: 1.0 })
+    const entry = cache.get('tok')
+    expect(entry?.filePath).toBeUndefined()
+    expect(decideTap(entry)).toBe('lazy')
+  })
+
+  it('expired entries degrade to the expired toast (7-day TTL)', () => {
+    let nowMs = 1_000
+    const cache = new VoiceOnDemandCache({ now: () => nowMs })
+    cache.put('tok', { text: 'hello', speed: 1.0 })
+    nowMs += VOICE_FILE_TTL_MS + 1 // > 7 days later
+    expect(cache.get('tok')).toBeNull()
+    expect(decideTap(cache.get('tok'))).toBe('expired')
+  })
+
+  it('setFilePath on an expired/evicted entry is a no-op', () => {
+    let nowMs = 1_000
+    const cache = new VoiceOnDemandCache({ now: () => nowMs })
+    cache.put('tok', { text: 'hello', speed: 1.0 })
+    nowMs += VOICE_FILE_TTL_MS + 1
+    cache.setFilePath('tok', '/some/file.ogg') // must not resurrect
+    expect(cache.get('tok')).toBeNull()
+  })
+
+  it('prune drops entries whose files the sweep deleted', () => {
+    const cache = new VoiceOnDemandCache()
+    cache.put('a', { text: 'x', speed: 1 })
+    cache.put('b', { text: 'y', speed: 1 })
+    cache.prune(['a', 'unknown-token'])
+    expect(cache.get('a')).toBeNull()
+    expect(cache.get('b')).not.toBeNull()
+  })
+
+  it('filePath + createdAt survive the persistence round-trip', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'voice-persist-'))
+    try {
+      const persistPath = join(dir, 'voice-ondemand.json')
+      const c1 = new VoiceOnDemandCache({ persistPath })
+      c1.put('tok', { text: 'hello', speed: 1.2 })
+      c1.setFilePath('tok', '/state/voice-cache/tok.ogg')
+      const c2 = new VoiceOnDemandCache({ persistPath })
+      const entry = c2.get('tok')
+      expect(entry?.filePath).toBe('/state/voice-cache/tok.ogg')
+      // createdAt is persisted on the stored entry (sweep/introspection aid)
+      // even though get() keeps it internal.
+      const raw = JSON.parse(readFileSync(persistPath, 'utf8')) as {
+        entries: Record<string, { createdAt?: number }>
+      }
+      expect(typeof raw.entries['tok']?.createdAt).toBe('number')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+// ─── End-to-end: queue → file → cache → sweep ───────────────────────────────
+
+describe('pre-synth pipeline integration (no gateway import)', () => {
+  it('a job writes the file, records it, and the sweep later prunes both', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'voice-e2e-'))
+    try {
+      const cacheDir = join(dir, 'voice-cache')
+      mkdirSync(cacheDir, { recursive: true })
+      const cache = new VoiceOnDemandCache()
+      cache.put('tok', { text: 'spoken reply', speed: 1.1 })
+      const q = new PreSynthQueue({
+        // Mirrors the gateway runJob: fake sidecar → write → record.
+        runJob: async (job: PreSynthJob) => {
+          const audio = new TextEncoder().encode(`AUDIO:${job.text}`)
+          const filePath = writeVoiceCacheFile(cacheDir, job.token, audio)
+          cache.setFilePath(job.token, filePath)
+        },
+        defer: (fn) => fn(),
+        log: () => {},
+      })
+      q.enqueue({ token: 'tok', text: 'spoken reply', speed: 1.1 })
+      await new Promise((r) => setTimeout(r, 0))
+      const entry = cache.get('tok')
+      expect(entry?.filePath).toBeDefined()
+      expect(readFileSync(entry!.filePath!, 'utf8')).toBe('AUDIO:spoken reply')
+
+      // 8 days later the sweep removes the file and the entry is pruned.
+      const DAY = 24 * 60 * 60 * 1000
+      const result = sweepVoiceCacheDir({
+        dir: cacheDir,
+        now: () => Date.now() + 8 * DAY,
+        log: () => {},
+      })
+      expect(result.deletedTokens).toEqual(['tok'])
+      cache.prune(result.deletedTokens)
+      expect(existsSync(entry!.filePath!)).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/telegram-plugin/voice-ondemand.ts
+++ b/telegram-plugin/voice-ondemand.ts
@@ -26,8 +26,14 @@ import { dirname } from 'path'
 export const VOICE_ONDEMAND_CALLBACK_PREFIX = 'voice:'
 
 /** Cache entry TTL. A button tapped after this degrades to an "expired" toast
- *  rather than pinning reply text in memory forever. */
-export const VOICE_ONDEMAND_TTL_MS = 60 * 60 * 1000 // 1h
+ *  rather than pinning reply text in memory forever.
+ *
+ *  7 days since #2763 (was 1h): eager pre-synthesis keeps the spoken file on
+ *  disk for 7 days, and the acceptance bar is "tapping Listen on any message
+ *  <7 days old plays instantly" — which needs the ENTRY alive that long too
+ *  (the lazy fallback also reads it). Memory stays bounded by
+ *  VOICE_ONDEMAND_MAX_ENTRIES; the entry is a few hundred bytes of text. */
+export const VOICE_ONDEMAND_TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
 
 /** Bounded cache size; oldest entries are evicted past this. */
 export const VOICE_ONDEMAND_MAX_ENTRIES = 500
@@ -39,6 +45,13 @@ export type VoiceOnDemandPayload = {
   voice?: string
   /** Resolved + clamped playback speed. */
   speed: number
+  /** Absolute path of the eagerly pre-synthesized audio file (#2763), set by
+   *  the pre-synth queue after a successful background synth. Absent on
+   *  pre-feature entries, on kill-switched gateways, and until the job runs. */
+  filePath?: string
+  /** Epoch ms the entry was stored (put time) — recorded alongside filePath
+   *  per #2763 so the sweep/introspection can reason about entry age. */
+  createdAt?: number
 }
 
 type StoredEntry = VoiceOnDemandPayload & { expiresAt: number }
@@ -101,7 +114,11 @@ export class VoiceOnDemandCache {
   put(token: string, payload: VoiceOnDemandPayload): void {
     // Re-insert to move an existing key to the newest (most-recent) position.
     this.store.delete(token)
-    this.store.set(token, { ...payload, expiresAt: this.now() + this.ttlMs })
+    this.store.set(token, {
+      createdAt: this.now(),
+      ...payload,
+      expiresAt: this.now() + this.ttlMs,
+    })
     while (this.store.size > this.maxEntries) {
       const oldest = this.store.keys().next().value
       if (oldest === undefined) break
@@ -119,8 +136,37 @@ export class VoiceOnDemandCache {
       this.flush()
       return null
     }
-    const { text, voice, speed } = entry
-    return voice === undefined ? { text, speed } : { text, voice, speed }
+    const { text, voice, speed, filePath } = entry
+    // createdAt stays internal (persisted for sweep/introspection) so the
+    // returned shape only grows when a pre-synth file actually exists —
+    // pre-#2763 callers and tests see the exact old payload.
+    return {
+      text,
+      speed,
+      ...(voice !== undefined ? { voice } : {}),
+      ...(filePath !== undefined ? { filePath } : {}),
+    }
+  }
+
+  /** Record the pre-synthesized audio file path on an existing entry (#2763).
+   *  No-op if the entry has expired or been evicted meanwhile (the file will
+   *  simply age out via the sweep). Does NOT bump LRU position or TTL — the
+   *  entry's lifetime is anchored at put time. */
+  setFilePath(token: string, filePath: string): void {
+    const entry = this.store.get(token)
+    if (entry == null || entry.expiresAt <= this.now()) return
+    entry.filePath = filePath
+    this.flush()
+  }
+
+  /** Drop entries whose pre-synth files the sweep deleted (#2763). Unknown
+   *  tokens are ignored (file may belong to an already-evicted entry). */
+  prune(tokens: Iterable<string>): void {
+    let changed = false
+    for (const token of tokens) {
+      if (this.store.delete(token)) changed = true
+    }
+    if (changed) this.flush()
   }
 
   /** Current entry count (test/introspection aid). */

--- a/telegram-plugin/voice-presynth.ts
+++ b/telegram-plugin/voice-presynth.ts
@@ -1,0 +1,242 @@
+/**
+ * Eager voice pre-synthesis + rolling voice-cache cleanup (issue #2763).
+ *
+ * When an outbound reply becomes Listen-eligible (a voiceOnDemandCache entry
+ * is persisted for its 🔊 Listen button), the gateway ALSO kicks an async
+ * background synthesis of the normalized text via the LOCAL sidecar (kokoro
+ * only — never the cloud engine, which costs money and stays lazy-only). The
+ * resulting OGG lands on disk under TELEGRAM_STATE_DIR/voice-cache/ and its
+ * path is recorded on the cache entry, so a Listen tap attaches the pre-made
+ * file instantly instead of synthesizing on demand.
+ *
+ * This module owns the two dependency-free primitives:
+ *
+ *   - {@link PreSynthQueue} — a bounded FIFO (concurrency 1, drop-oldest past
+ *     the backlog cap) so message bursts can't pile up GPU synth jobs.
+ *   - {@link sweepVoiceCacheDir} — the 7-day TTL + size-budget sweep that
+ *     keeps the voice-cache directory from growing unbounded.
+ *
+ * Kill switch: SWITCHROOM_DISABLE_EAGER_VOICE=1 reverts to lazy-only synth
+ * (no pre-synth jobs, no new files). The sweep still runs under the kill
+ * switch so previously written files age out.
+ *
+ * Strictly off the reply critical path: enqueue is a synchronous array push;
+ * the drain is async and never awaited by the reply flow; every job failure
+ * is swallowed (logged) — a synth failure can never affect message delivery.
+ */
+
+import { readdirSync, statSync, unlinkSync, mkdirSync, writeFileSync, renameSync } from 'fs'
+import { join } from 'path'
+
+/** Voice files older than this are deleted by the rolling sweep. */
+export const VOICE_FILE_TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+/** Size budget for the voice-cache dir; oldest files are deleted first when
+ *  the directory exceeds this (defence in depth if the timer dies and the
+ *  boot sweep is far away). ~500MB per the #2763 design notes. */
+export const VOICE_CACHE_MAX_BYTES = 500 * 1024 * 1024
+
+/** Backlog cap for the pre-synth FIFO. Past this, the OLDEST pending job is
+ *  dropped (newer replies are the ones the user is most likely to tap). */
+export const PRESYNTH_MAX_PENDING = 50
+
+/** Sweep cadence: hourly, plus one sweep at gateway boot. */
+export const VOICE_SWEEP_INTERVAL_MS = 60 * 60 * 1000
+
+/** True unless the operator flipped the kill switch. Same env shape as
+ *  SWITCHROOM_DISABLE_TTS_NORMALIZE / SWITCHROOM_DISABLE_VOICE_SCRUB. */
+export function eagerVoiceEnabled(): boolean {
+  const kill = process.env.SWITCHROOM_DISABLE_EAGER_VOICE
+  return !(kill === '1' || kill === 'true')
+}
+
+export type PreSynthJob = {
+  /** Listen token — doubles as the on-disk filename stem (`<token>.ogg`). */
+  token: string
+  /** Speech-normalized text to synthesize (same payload the lazy path uses). */
+  text: string
+  voice?: string
+  speed?: number
+}
+
+export type PreSynthQueueOptions = {
+  /** Runs ONE job: synthesize + persist + record. Errors are swallowed. */
+  runJob: (job: PreSynthJob) => Promise<void>
+  maxPending?: number
+  /** Injected scheduler (tests). Defaults to setTimeout(fn, 0). */
+  defer?: (fn: () => void) => void
+  log?: (line: string) => void
+}
+
+/**
+ * Bounded FIFO pre-synth queue, concurrency 1. Jobs are drained strictly in
+ * order; past `maxPending` queued jobs the oldest pending job is dropped
+ * (drop-oldest). Enqueue is synchronous and never throws; the drain kicks off
+ * via a deferred callback so the reply flow that enqueued is never blocked.
+ */
+export class PreSynthQueue {
+  private readonly pending: PreSynthJob[] = []
+  private running = false
+  private readonly runJob: (job: PreSynthJob) => Promise<void>
+  private readonly maxPending: number
+  private readonly defer: (fn: () => void) => void
+  private readonly log: (line: string) => void
+
+  constructor(options: PreSynthQueueOptions) {
+    this.runJob = options.runJob
+    this.maxPending = options.maxPending ?? PRESYNTH_MAX_PENDING
+    this.defer = options.defer ?? ((fn) => setTimeout(fn, 0))
+    this.log = options.log ?? ((line) => process.stderr.write(line + '\n'))
+  }
+
+  /** Number of queued (not yet started) jobs — test/introspection aid. */
+  get size(): number {
+    return this.pending.length
+  }
+
+  /** True while a job is in flight. */
+  get busy(): boolean {
+    return this.running
+  }
+
+  /** Enqueue a job. Never throws; never blocks the caller. */
+  enqueue(job: PreSynthJob): void {
+    this.pending.push(job)
+    while (this.pending.length > this.maxPending) {
+      const dropped = this.pending.shift()
+      if (dropped != null) {
+        this.log(
+          `voice-presynth: backlog over ${this.maxPending} — dropped oldest job token=${dropped.token}`,
+        )
+      }
+    }
+    if (!this.running) {
+      this.running = true
+      this.defer(() => void this.drain())
+    }
+  }
+
+  private async drain(): Promise<void> {
+    for (;;) {
+      const job = this.pending.shift()
+      if (job == null) break
+      try {
+        await this.runJob(job)
+      } catch (err) {
+        // Best-effort by contract: a failed pre-synth only means the Listen
+        // tap falls back to the lazy path. Never propagate.
+        this.log(`voice-presynth: job failed token=${job.token}: ${String(err)}`)
+      }
+    }
+    this.running = false
+  }
+}
+
+/** Absolute path of the pre-synthesized file for a Listen token. */
+export function voiceCacheFilePath(dir: string, token: string): string {
+  return join(dir, `${token}.ogg`)
+}
+
+/** Atomically persist synthesized audio for `token` under `dir`; returns the
+ *  final path. Throws on IO failure (caller — the queue runner — swallows). */
+export function writeVoiceCacheFile(dir: string, token: string, audio: Uint8Array): string {
+  mkdirSync(dir, { recursive: true, mode: 0o700 })
+  const final = voiceCacheFilePath(dir, token)
+  const tmp = `${final}.tmp`
+  writeFileSync(tmp, audio)
+  renameSync(tmp, final)
+  return final
+}
+
+/** Minimal fs facade so the sweep is testable without a real 500MB dir. */
+export type SweepFs = {
+  readdirSync: (dir: string) => string[]
+  statSync: (path: string) => { mtimeMs: number; size: number; isFile(): boolean }
+  unlinkSync: (path: string) => void
+}
+
+export type SweepOptions = {
+  dir: string
+  ttlMs?: number
+  maxBytes?: number
+  now?: () => number
+  fs?: SweepFs
+  log?: (line: string) => void
+}
+
+export type SweepResult = {
+  /** Listen tokens whose files were deleted (filename stem, `.ogg` stripped) —
+   *  the caller prunes the matching voiceOnDemandCache entries. */
+  deletedTokens: string[]
+  /** Total bytes remaining in the dir after the sweep. */
+  remainingBytes: number
+}
+
+/**
+ * Rolling voice-cache sweep: delete files older than `ttlMs` (7 days), then —
+ * if the directory still exceeds `maxBytes` — delete oldest-first down to
+ * budget. Crash-safe: a missing dir yields an empty result; a file that
+ * vanishes mid-sweep (concurrent delete) is tolerated; per-file errors never
+ * abort the sweep.
+ */
+export function sweepVoiceCacheDir(options: SweepOptions): SweepResult {
+  const ttlMs = options.ttlMs ?? VOICE_FILE_TTL_MS
+  const maxBytes = options.maxBytes ?? VOICE_CACHE_MAX_BYTES
+  const now = options.now ?? Date.now
+  const fsx: SweepFs = options.fs ?? { readdirSync, statSync, unlinkSync }
+  const log = options.log ?? ((line: string) => process.stderr.write(line + '\n'))
+
+  let names: string[]
+  try {
+    names = fsx.readdirSync(options.dir)
+  } catch {
+    return { deletedTokens: [], remainingBytes: 0 } // no dir yet — nothing to sweep
+  }
+
+  type Entry = { name: string; path: string; mtimeMs: number; size: number }
+  const files: Entry[] = []
+  for (const name of names) {
+    const path = join(options.dir, name)
+    try {
+      const st = fsx.statSync(path)
+      if (!st.isFile()) continue
+      files.push({ name, path, mtimeMs: st.mtimeMs, size: st.size })
+    } catch {
+      // vanished mid-sweep / unreadable — skip, never abort
+    }
+  }
+
+  const deletedTokens: string[] = []
+  const cutoff = now() - ttlMs
+  const remove = (f: Entry, reason: string): boolean => {
+    try {
+      fsx.unlinkSync(f.path)
+    } catch {
+      // Already gone (concurrent delete) — treat as removed either way; a
+      // truly stuck file just gets retried next sweep.
+    }
+    deletedTokens.push(f.name.replace(/\.(ogg|ogg\.tmp)$/, ''))
+    log(`voice-presynth: sweep removed ${f.name} (${reason})`)
+    return true
+  }
+
+  // Pass 1 — TTL: anything older than 7 days goes (including orphaned .tmp).
+  let kept: Entry[] = []
+  for (const f of files) {
+    if (f.mtimeMs <= cutoff) remove(f, 'ttl')
+    else kept.push(f)
+  }
+
+  // Pass 2 — size budget: oldest-first down to maxBytes.
+  let total = kept.reduce((sum, f) => sum + f.size, 0)
+  if (total > maxBytes) {
+    kept.sort((a, b) => a.mtimeMs - b.mtimeMs)
+    while (total > maxBytes && kept.length > 0) {
+      const oldest = kept.shift()!
+      remove(oldest, 'size-budget')
+      total -= oldest.size
+    }
+  }
+
+  return { deletedTokens, remainingBytes: total }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -162,6 +162,8 @@ export default defineConfig({
       "**/telegram-plugin/tests/sandbox-hint-posttool.test.ts",
       // tts-normalize.test.ts (#2760 Phase 1) imports bun:test — run via test:bun.
       "**/telegram-plugin/tests/tts-normalize.test.ts",
+      // voice-presynth.test.ts (#2763) imports bun:test — run via test:bun.
+      "**/telegram-plugin/tests/voice-presynth.test.ts",
       // fleet-fallback-gate.test.ts uses bun:test — run via test:bun.
       "**/telegram-plugin/tests/fleet-fallback-gate.test.ts",
       "**/telegram-plugin/tests/ipc-server-client.test.ts",


### PR DESCRIPTION
## Summary

Implements #2763: invert the 🔊 Listen model for the local voice engine. Voice is now **pre-synthesized eagerly** at reply time (async, off the critical path), the Listen tap **attaches the pre-made file** for instant playback, and a **7-day rolling sweep** keeps the on-disk cache bounded.

Serves `reference/jobs/talk-to-agents-from-anywhere.md` (spoken answers on a phone/bike, now with zero tap-to-audio wait). Builds on #2760 Phase 1 (PR #2762): pre-synth input goes through the same `normalizeForTts` pass as both existing synth sites.

## Design

- **`telegram-plugin/voice-presynth.ts`** (new, dependency-free, gateway-importable): `PreSynthQueue` — bounded FIFO, concurrency 1, drop-oldest past 50 pending, enqueue is a synchronous push and drain is deferred + never awaited; `sweepVoiceCacheDir` — 7-day TTL pass then 500MB oldest-first size-budget pass, crash-safe (missing dir/files tolerated), injectable clock/fs; `writeVoiceCacheFile` — atomic tmp+rename write; `eagerVoiceEnabled` — kill switch.
- **`telegram-plugin/gateway/gateway.ts`**: queue + sweep wiring beside `voiceOnDemandCache` (boot sweep + hourly `setInterval(...).unref()`); enqueue at the Listen-button mint site — **kokoro/local only** by construction (`useOnDemandButton` already gates the engine; the openai cloud path never eager-synthesizes); attach-on-tap in the `voice:` callback handler with transparent lazy-synth fallback (missing/swept/pre-feature/kill-switched entries).
- **`telegram-plugin/voice-ondemand.ts`**: entries gain `filePath`/`createdAt` (+ `setFilePath`, `prune`); persistence round-trips them. Entry TTL raised 1h → **7 days** to meet the acceptance bar ("Listen on any message <7 days old plays instantly") — the lazy fallback also needs the entry text alive that long. Memory stays bounded by the 500-entry LRU cap.
- **Kill switch:** `SWITCHROOM_DISABLE_EAGER_VOICE=1` → lazy-only synth, no new files; the sweep still runs so existing files age out.

## Deviations / decisions

- **Enqueue happens at button-mint time** (just before the Telegram sends) rather than strictly after the last send — the reply flow has several exit paths and threading a post-send hook through all of them would be invasive. The contract still holds: `enqueue()` is a synchronous array push, the drain is deferred (`setTimeout 0`) and fully async, nothing on the reply path awaits it, and every job failure is swallowed — text delivery can never be delayed or affected.
- **`createdAt` is persisted on the stored entry but not returned by `get()`**, keeping the pre-#2763 payload shape exact for existing callers/tests; `filePath` is returned (the tap needs it).
- **Cache TTL 1h → 7d** (above) — flagging explicitly since it predates this issue.

## Test plan

- [x] `telegram-plugin/tests/voice-presynth.test.ts` (bun test, +vitest exclude per the #2762 lesson): queue FIFO/concurrency-1/drop-oldest/error-isolation, TTL + size-budget sweep with injected clock+fs plus a real-fs e2e, attach-vs-fallback decision (pre-made / swept / pre-feature / expired), kill switch, persistence round-trip, full pipeline integration.
- [x] Existing voice suites green (`voice-ondemand`, `voice-out-one-send`, `tts-normalize`).
- [x] `npm run lint` clean (incl. `check-bot-api-wrapping.sh`).
- [x] `npm run test:bun`: 1065 pass / 2 fail — the two `src/vault/broker/client-token.test.ts` failures reproduce on clean `main` (environmental).

## Risk

Low. Eager path is fire-and-forget behind the existing Listen gate; the lazy path is unchanged and remains the fallback for every failure mode. One env var reverts to pre-#2763 behaviour (minus the now-larger entry TTL, which only makes stale buttons resolvable longer).

Closes #2763.

🤖 Generated with [Claude Code](https://claude.com/claude-code)