### PR TITLE
fix(telegram): make admin-key passphrase prompt unmissable — rich render + ping

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -20160,20 +20160,61 @@ async function handleVaultRequestAccessCallback(ctx: Context, data: string): Pro
       // cards open at once.
       const joiningBatch = items.length > 1
       await ctx.answerCallbackQuery({ text: joiningBatch ? `🔐 Queued — one passphrase covers ${items.length} cards` : '🔐 Send your passphrase…' }).catch(() => {})
+
+      // Strip the buttons on the ORIGINAL card and mark it "waiting" so it
+      // can't be re-tapped, but do NOT overload it as the passphrase prompt.
+      // An in-place edit fires no notification and stays pinned to the card's
+      // old position in the chat, so a busy topic buries it and the operator
+      // never sees the passphrase ask — the exact admin-key miss this fixes
+      // (v0.16.45: the prompt scrolled off, the passphrase never arrived, the
+      // grant was never minted). The prompt goes out as a fresh message below.
       await ctx.api
         .editMessageText(
           pending.chat_id,
           pending.card_message_id,
-          joiningBatch
-            ? `🔐 **Queued behind an earlier card.** Type your passphrase as your next message — it covers **${items.length}** pending approvals in this chat (one entry mints all grants, no re-type per card).`
-            : isAdminOnly
-            ? `🔒 **Admin-only credential.** \`${pending.key}\` requires your vault passphrase to grant — reply with it as your next message and we'll mint the grant for **${escapeHtmlForTg(pending.agent)}**, then delete the passphrase message.\n\n` +
-              `_The passphrase is what proves it's you: an agent can never mint this key on its own._`
-            : `🔐 **Vault is locked.** Reply with your passphrase as your next message — we'll unlock, mint the grant for **${escapeHtmlForTg(pending.agent)}**, and delete the passphrase message in one step.\n\n` +
-              richMessage(`_Mint authority stays operator-only: the broker only accepts the grant when the passphrase matches._`),
+          richMessage(`🔐 _Approved — waiting for your vault passphrase. See the prompt below._`),
           { reply_markup: { inline_keyboard: [] } },
         )
         .catch(() => {})
+
+      // The passphrase prompt as a NEW rich message. Three fixes vs. the old
+      // in-place edit, all of which the reported bug needed:
+      //   1. Real bold/italic — rendered through the sanctioned `richMessage`
+      //      GFM path (`sendRichMessage`), never a raw string. The old admin
+      //      and joining-batch branches passed raw markdown to editMessageText
+      //      (parse_mode=none), so `**`/`_` rendered as literal characters;
+      //      the "locked" branch even concatenated a string with a
+      //      `richMessage()` object (→ `[object Object]`). All three are gone.
+      //   2. It lands at the BOTTOM of the chat, not stapled to an old card
+      //      that later messages bury.
+      //   3. It fires a notification — `disable_notification` is deliberately
+      //      NOT set — so the operator is actually pinged to act.
+      // Attention-grabbing header, short lines, key in code formatting.
+      const promptText = joiningBatch
+        ? `**⚠️🔐 ACTION NEEDED: passphrase required**\n\n` +
+          `Type your vault passphrase as your **next message**.\n` +
+          `One entry covers **${items.length}** pending approvals in this chat, no re-type per card.\n\n` +
+          `_We delete the passphrase message the moment we read it._`
+        : isAdminOnly
+        ? `**⚠️🔐 ACTION NEEDED: passphrase required**\n\n` +
+          `\`${pending.key}\` is an **admin-only credential**.\n` +
+          `Type your vault passphrase as your **next message** to mint the grant for **${escapeHtmlForTg(pending.agent)}**.\n\n` +
+          `_The passphrase is what proves it's you. An agent can never mint this key on its own. We delete the passphrase message the moment we read it._`
+        : `**⚠️🔐 ACTION NEEDED: passphrase required**\n\n` +
+          `Your vault is locked.\n` +
+          `Reply with your passphrase as your **next message** to unlock and mint the grant for **${escapeHtmlForTg(pending.agent)}**.\n\n` +
+          `_Mint authority stays operator-only: the broker only accepts the grant when the passphrase matches. We delete the passphrase message the moment we read it._`
+
+      // #1075: deleted-topic safe — fall back to the main chat. Wrapped
+      // through robustApiCall for flood-wait retries, mirroring the card send.
+      await retryWithThreadFallback<{ message_id: number }>(
+        robustApiCall,
+        (tid) =>
+          lockedBot.api.sendRichMessage(pending.chat_id, richMessage(promptText), {
+            ...(tid != null && Number.isFinite(tid) ? { message_thread_id: tid } : {}),
+          }),
+        { threadId: pending.threadId, chat_id: pending.chat_id, verb: 'vault_request_access.passphrase_prompt' },
+      ).catch(() => {})
       return
     }
 

--- a/telegram-plugin/tests/vault-request-access-unlock-resume.test.ts
+++ b/telegram-plugin/tests/vault-request-access-unlock-resume.test.ts
@@ -54,6 +54,52 @@ describe('vault_request_access — tap-to-unlock-and-approve UX', () => {
     expect(approveBlock).not.toMatch(/ask the agent to re-issue the request card/)
   })
 
+  it('passphrase prompt goes out as a NEW rich message, not an in-place edit', () => {
+    // fails when: the cache-miss branch reverts to overloading the
+    // ORIGINAL card as the prompt via editMessageText. An in-place
+    // edit fires no notification and stays stapled to the card's old
+    // position, so a busy topic buries it and the operator never sees
+    // the passphrase ask (the reported v0.16.45 admin-key miss). The
+    // prompt must be a fresh `sendRichMessage` below.
+    const approveBlock =
+      gatewaySrc.split('if (action === \'approve\')')[1]?.split('await ctx.answerCallbackQuery({ text: \'Unknown action\'')[0] ?? ''
+    // A distinct passphrase-prompt send exists (verb-tagged).
+    expect(approveBlock).toMatch(/sendRichMessage\(pending\.chat_id, richMessage\(promptText\)/)
+    expect(approveBlock).toMatch(/vault_request_access\.passphrase_prompt/)
+  })
+
+  it('passphrase prompt renders via richMessage — no raw literal-markdown edit', () => {
+    // ROOT CAUSE of the reported bug: the old admin-only and
+    // joining-batch branches passed RAW markdown strings (with literal
+    // `**`/`_`) straight to editMessageText (parse_mode=none), so the
+    // bold/italic rendered as literal characters, and the "locked"
+    // branch concatenated a string with a richMessage() object
+    // (→ "[object Object]"). Every branch must now flow through the
+    // richMessage() GFM render path.
+    const approveBlock =
+      gatewaySrc.split('if (action === \'approve\')')[1]?.split('await ctx.answerCallbackQuery({ text: \'Unknown action\'')[0] ?? ''
+    // The prompt text is assembled once and wrapped in richMessage.
+    expect(approveBlock).toMatch(/const promptText =/)
+    // Regression guard: the old raw-string admin-only edit copy is gone.
+    expect(approveBlock).not.toMatch(/requires your vault passphrase to grant/)
+    // Regression guard: no string-concatenated richMessage() object
+    // (the "[object Object]" bug) remains.
+    expect(approveBlock).not.toMatch(/\+\s*\n\s*richMessage\(/)
+  })
+
+  it('passphrase prompt is attention-grabbing and does NOT suppress notifications', () => {
+    // fails when: the prompt loses its strong header or someone adds
+    // disable_notification to it. The whole point of the fix is that
+    // the operator gets PINGED — a silent prompt is the bug.
+    const approveBlock =
+      gatewaySrc.split('if (action === \'approve\')')[1]?.split('await ctx.answerCallbackQuery({ text: \'Unknown action\'')[0] ?? ''
+    expect(approveBlock).toMatch(/ACTION NEEDED: passphrase required/)
+    // The send options for the prompt must not carry disable_notification.
+    const promptSend =
+      approveBlock.split('const promptText =')[1]?.split('return')[0] ?? ''
+    expect(promptSend).not.toMatch(/disable_notification/)
+  })
+
   it('passphrase intercept deletes the chat message and resumes mint', () => {
     // fails when: the new pending-op handler stops calling
     // deleteSensitiveMessage on the passphrase message OR stops


### PR DESCRIPTION
## Summary

Tapping **Approve** on a vault-grant card for an admin-only key (e.g. `npm_token_*`) sends a follow-up asking for the operator's vault passphrase. On v0.16.45 that prompt was unusable:

- It rendered as **plain text with literal `**` and `_` markers** (sent `parse_mode=none`), so nothing was bold/italic.
- It had **no notification ping** and was **immediately buried** by later bot messages.

The operator missed it entirely, never typed the passphrase, and the grant was never minted.

## Root cause

The prompt was written by **editing the original card in place** with a **raw markdown string** passed straight to `editMessageText`. The repo's outbound formatting contract (`rich-send.ts`, #2755/#2743) is: everything goes through `richMessage()` / `sendRichMessage()`. This one site bypassed it:

- The admin-only and joining-batch branches passed **raw strings** -> `parse_mode=none` -> literal `**`/`_`.
- The "locked vault" branch concatenated a **string with a `richMessage()` object** -> `[object Object]`.
- An **in-place edit** fires no notification and stays at the card's old scroll position -> buried.

## What changed

`telegram-plugin/gateway/gateway.ts` — the cache-miss branch of `handleVaultRequestAccessCallback`:

- The original card is now edited **only** to strip its buttons and show a short `waiting for your vault passphrase` status (so it can't be re-tapped).
- The passphrase prompt goes out as a **NEW rich message** via `retryWithThreadFallback` -> `sendRichMessage(richMessage(...))` (the sanctioned path, deleted-topic safe, flood-wait wrapped):
  - Real bold/italic (no literal markers).
  - Strong header: `⚠️🔐 ACTION NEEDED: passphrase required`, short lines, the key in `code`.
  - Lands at the bottom of the chat and **fires a notification** — `disable_notification` deliberately unset.
- Applies to all three branches (admin-only, locked vault, batched cards); the string-concat `[object Object]` bug is gone too.

**Security semantics unchanged:** the passphrase message is still deleted on receipt (`deleteSensitiveMessage`), never logged, and the agent still can never self-mint (broker passphrase attestation).

Deliberately **not** added: a re-send reminder / pin — there is no existing card re-send machinery to hook into, and the task said not to build a new scheduler. The new-message + ping already fixes the buried/silent miss.

## Why / job spec

Cites `reference/jobs/approve-what-my-agent-can-touch.md`: granting must not be opaque or easy to miss, or "a helpful agent improvises around the gate" and the operator is left out of the loop. Advances the *hold-the-leash* vision outcome; crosses no invariant (`no-self-escalation` intact).

## Test plan

- Extended `telegram-plugin/tests/vault-request-access-unlock-resume.test.ts` with 3 new pins: prompt is a new `sendRichMessage` (not an in-place edit), flows through `richMessage()` (regression guards against the old raw-string copy and the `+ richMessage(` concat), and carries the attention header with **no** `disable_notification`.
- `vitest run` on the three vault suites: **36 passed**.
- `npm run lint`: **clean** (tsc + all 8 guard scripts, incl. `check-bot-api-wrapping`).

Note: the base worktree's symlinked `node_modules` shipped grammy 1.42; `package.json` requires `^1.44` (where `sendRichMessage` lives). Installed correct deps in-worktree to get a clean `tsc`. CI has correct deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)