### PR TITLE
fix(rollout): hostd-driven roll recreates hindsight + calms false bank-create alarm

### DIFF
--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -329,12 +329,13 @@ describe("planRollout — hostd context (#2487)", () => {
     const kinds = steps.map((s) =>
       s.kind === "restart-agent" ? `r:${s.agent}` : s.kind,
     );
-    // apply → canary (test-harness) → persist-pin → rest → sweep.
+    // apply → canary (test-harness) → persist-pin → rest → refresh-hindsight → sweep.
     expect(kinds).toEqual([
       "apply",
       "r:test-harness",
       "persist-pin",
       "r:clerk",
+      "refresh-hindsight",
       "sweep",
     ]);
     // persist-pin comes strictly AFTER the canary restart.
@@ -350,6 +351,20 @@ describe("planRollout — hostd context (#2487)", () => {
     }).map((s) => s.kind);
     expect(kinds).not.toContain("refresh-web");
     expect(kinds).not.toContain("refresh-hostd");
+  });
+
+  it("RECREATES the hindsight singleton (standalone docker run — hostd can recreate it)", () => {
+    const steps = planRollout(["clerk", "marko"], {
+      pinToPersist: TARGET,
+      hostdContext: true,
+    });
+    const kinds = steps.map((s) => s.kind);
+    // hindsight is a standalone `docker run` hostd owns via the docker
+    // socket — it must be rolled so the memory backend isn't left a version
+    // behind (unlike refresh-web/refresh-hostd, separate compose projects).
+    expect(kinds).toContain("refresh-hindsight");
+    // ...and it lands immediately before the final sweep.
+    expect(kinds.indexOf("refresh-hindsight")).toBe(kinds.indexOf("sweep") - 1);
   });
 
   it("host-shell path is unchanged — persist FIRST, web/hostd present", () => {

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -162,6 +162,12 @@ export function planRollout(
       // the persist intent consistent.
       steps.push({ kind: "persist-pin", pin: opts.pinToPersist });
     }
+    // Recreate the hindsight singleton so a hostd/agent-driven roll doesn't
+    // leave the memory backend a version behind (refresh-web/refresh-hostd
+    // stay host-side — separate compose projects; hindsight is a standalone
+    // `docker run` hostd can recreate via the docker socket). The executor's
+    // refresh-hindsight case self-guards via hindsightExists().
+    steps.push({ kind: "refresh-hindsight" });
     steps.push({ kind: "sweep" });
     return steps;
   }

--- a/src/memory/hindsight-createbank-unreachable.test.ts
+++ b/src/memory/hindsight-createbank-unreachable.test.ts
@@ -1,0 +1,75 @@
+/**
+ * createBank connect-failure classification (#2752 follow-up).
+ *
+ * The scaffold's bank-create chain branches on `reason === "Unreachable"`:
+ * that path prints the CALM "Hindsight unreachable — agent still usable"
+ * message and skips creation. Any OTHER reason falls through to the scary
+ * `⚠ Failed to create Hindsight bank …` branch.
+ *
+ * The undici connect-layer failure surfaces as
+ *   `Error: Unable to connect. Is the computer able to access the url?`
+ * with `err.cause?.code === "UND_ERR_CONNECT"` — matching NONE of the
+ * original substrings (ECONNREFUSED / fetch failed / Failed to fetch /
+ * ENOTFOUND). It was therefore mis-classified as a hard create failure and
+ * spammed the scary alarm on every restart. These tests pin that the
+ * broadened classifier now normalizes it to "Unreachable".
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { createBank } from "./hindsight.js";
+
+const API_URL = "http://127.0.0.1:18888/mcp/";
+
+/** A fetch stub that always throws the given error at connect time. */
+function throwingFetch(err: unknown): typeof fetch {
+  return (async () => {
+    throw err;
+  }) as unknown as typeof fetch;
+}
+
+describe("createBank — connect-failure normalizes to Unreachable", () => {
+  it('classifies the undici "Unable to connect" message as Unreachable', async () => {
+    const err = new Error("Unable to connect. Is the computer able to access the url?");
+    const r = await createBank(API_URL, "clerk", {
+      fetchImpl: throwingFetch(err),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("Unreachable");
+  });
+
+  it("classifies an UND_ERR_CONNECT cause code as Unreachable", async () => {
+    const err = new Error("fetch failed - connect error") as Error & {
+      cause?: { code?: string };
+    };
+    // Simulate the undici shape: opaque message, real code on err.cause.
+    const opaque = new Error("something opaque") as Error & {
+      cause?: { code?: string };
+    };
+    opaque.cause = { code: "UND_ERR_CONNECT" };
+    void err; // keep the intent explicit; the opaque-message case is the point.
+    const r = await createBank(API_URL, "clerk", {
+      fetchImpl: throwingFetch(opaque),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("Unreachable");
+  });
+
+  it("still classifies the legacy ECONNREFUSED message as Unreachable", async () => {
+    const err = new Error("connect ECONNREFUSED 127.0.0.1:18888");
+    const r = await createBank(API_URL, "clerk", {
+      fetchImpl: throwingFetch(err),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("Unreachable");
+  });
+
+  it("does NOT swallow an unrelated error into Unreachable (scary branch still reachable)", async () => {
+    const err = new Error("some totally unrelated bug");
+    const r = await createBank(API_URL, "clerk", {
+      fetchImpl: throwingFetch(err),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).not.toBe("Unreachable");
+  });
+});

--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -654,12 +654,23 @@ export async function createBank(
     }
     // ECONNREFUSED / fetch failed → daemon not running. Normalize to
     // "Unreachable" so the CLI can surface a specific operator message.
+    // Also catch the undici connect-layer failure ("Unable to connect. Is
+    // the computer able to access the url?" / UND_ERR_CONNECT), which none
+    // of the substrings above match — it was falling through to the scary
+    // "⚠ Failed to create Hindsight bank" branch on every restart instead
+    // of the calm "unreachable — agent still usable" path.
     const msg = String(err);
+    const causeCode = (err as { cause?: { code?: string } })?.cause?.code;
     if (
       msg.includes("ECONNREFUSED") ||
       msg.includes("fetch failed") ||
       msg.includes("Failed to fetch") ||
-      msg.includes("ENOTFOUND")
+      msg.includes("ENOTFOUND") ||
+      msg.includes("Unable to connect") ||
+      msg.includes("UND_ERR_CONNECT") ||
+      causeCode === "UND_ERR_CONNECT" ||
+      causeCode === "ECONNREFUSED" ||
+      causeCode === "ENOTFOUND"
     ) {
       return { ok: false, reason: "Unreachable" };
     }


### PR DESCRIPTION
## Summary

Two claude-native-safe memory-infra fixes in one PR (no model work touched).

**Change 1 — hostd/agent-driven rollout now recreates the hindsight singleton.**
`planRollout`'s `hostdContext` branch (the `mcp__hostd__rollout` path) returned its step list without a `refresh-hindsight` step, so an agent/hostd-driven roll updated every container **except** hindsight, leaving the memory backend a version behind. Fix: push `{ kind: "refresh-hindsight" }` immediately before the final `sweep` in the `hostdContext` branch. `refresh-web`/`refresh-hostd` deliberately stay host-side (separate compose projects); only hindsight is added, because it is a standalone `docker run` hostd can recreate via the docker socket. The executor's `refresh-hindsight` case is unchanged — it already self-guards via `hindsightExists()`, threads `--tag target`, and treats a failed recreate as fatal.

**Change 2 — stop the false "Failed to create Hindsight bank … Unable to connect" alarm on every restart.**
`createBank`'s catch normalized only `ECONNREFUSED`/`fetch failed`/`Failed to fetch`/`ENOTFOUND` to `reason:"Unreachable"`. The real-world undici connect failure `Error: Unable to connect. Is the computer able to access the url?` (with `err.cause?.code === "UND_ERR_CONNECT"`) matched none, so it fell through to the scary `⚠ Failed to create Hindsight bank` branch in `scaffold.ts` instead of the calm "Hindsight unreachable — agent still usable" path. Fix: broaden the `Unreachable` classifier to also catch the `Unable to connect` phrase and undici connect codes (both in the message and on `err.cause?.code`). One classifier fix covers both `scaffold.ts` call sites (~4281 and ~6282).

## Incident

The v0.16.45 → v0.16.47 roll left hindsight stuck on 0.16.45 while the fleet moved to 0.16.47 (Change 1), and spammed the scary bank-create warnings on every agent restart (Change 2).

## Why (job spec)

Cites `reference/jobs/idempotent-update-and-restart.md` (serves **always-available**): "After running `switchroom update`, the entire stack … memory backend … is at the version switchroom declared and tested as a unit." A roll that leaves hindsight a version behind is exactly the *Integrity* failure that spec bars ("the version the CLI reports is provably the version loaded into every running process; drift is detected, not assumed-away"). The false alarm violates the *docs test* principle — an error that tells the user something is broken when the agent is actually fine.

## Follow-up (out of scope, NOT implemented here)

The deeper structural fix is resolving the correct hindsight URL for a bridge-network caller — topology-dependent, and out of scope for this classifier fix. Filed as a note for a separate PR.

## Test plan

- `src/cli/rollout.test.ts`: added assertions that `planRollout(..., { hostdContext: true })` **includes** `refresh-hindsight` immediately before `sweep`; updated the pre-existing hostdContext ordering expectation to match the corrected behavior. `--skip-web` semantics unchanged.
- `src/memory/hindsight-createbank-unreachable.test.ts` (new focused unit): asserts `"Unable to connect…"`, an `UND_ERR_CONNECT` cause code, and legacy `ECONNREFUSED` all normalize to `reason:"Unreachable"`, while an unrelated error does **not** (the scary branch stays reachable for genuine failures).
- Local: `npm run lint` clean (tsc + 8 guards), `npm run build` clean, scoped vitest for both changed areas green (77 tests). Remaining local full-suite failures are the documented environment-dependent suites only (`tests/host-control/server.test.ts` needs a docker socket, `tests/install/static-binary.test.ts` needs a bun-compile artifact + exec-capable /tmp) — neither imports the changed code; CI is the arbiter for those paths.

## Risk

Low. Change 1 adds one step to a single branch; the executor step it invokes already existed and self-guards (no-op when no hindsight container is present). Change 2 only widens an existing error classifier toward the calmer, correct branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)