### PR TITLE
fix(apply): direct the agent-container dead-end to the hostd rollout path

### DIFF
--- a/skills/switchroom-cli/SKILL.md
+++ b/skills/switchroom-cli/SKILL.md
@@ -10,7 +10,7 @@ This skill is the reference for running `switchroom` CLI commands against existi
 
 **Four commands to know:**
 - `switchroom update` — full operator path: pulls images + applies config + recreates containers + runs doctor (since v0.7.8 / #918). What you want 95% of the time.
-- `switchroom apply` — config-only reconcile: refresh per-agent scaffolds and (re)write `~/.switchroom/compose/docker-compose.yml` without touching running containers. Use when you want to inspect the generated compose before bringing the fleet up yourself.
+- `switchroom apply` — **host/operator-only**, for structural changes: refresh per-agent scaffolds and (re)write `~/.switchroom/compose/docker-compose.yml`. Its full per-agent scaffold **cannot run from inside an agent container** (no vault at the container HOME, no `docker compose` v2 plugin) — that's correct by construction, not a bug. Version rolls do NOT need it: drive the **hostd rollout** (`mcp__hostd__rollout`), which runs a `--compose-only` apply plus a per-agent restart-reconcile that refreshes each agent's templates automatically. Reserve a host-side `sudo switchroom apply` for compose regeneration / new-agent scaffolding.
 - `switchroom restart [agent]` — bounces a stuck or wedged agent
 - `switchroom version` — shows what's running (versions + health summary)
 
@@ -59,7 +59,7 @@ switchroom update --rebuild      # source-checkout users: also git pull + npm bu
 
 `switchroom update` is the operator path. The CLI self-elevates via sudo internally for the per-agent scaffold dirs that need root — no need for `sudo HOME=… PATH=…` incantations.
 
-If you only need the config-reconcile half without restarting agents, `switchroom apply` writes `~/.switchroom/compose/docker-compose.yml` and refreshes per-agent scaffolds without touching running containers. The operator runs the docker bring-up themselves.
+If you only need the config-reconcile half without restarting agents, `switchroom apply` (run **on the host by the operator**) writes `~/.switchroom/compose/docker-compose.yml` and refreshes per-agent scaffolds without touching running containers. The operator runs the docker bring-up themselves. Note this full apply cannot run from inside an agent container by construction — to roll the fleet to a new version from an agent, use the hostd rollout (`mcp__hostd__rollout`) instead of a full apply.
 
 From inside an agent's Telegram DM, the same flow is available as `/upgradestatus` (read-only) and `/update apply` (admin-gated).
 

--- a/src/cli/apply.test.ts
+++ b/src/cli/apply.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runApply, runApplyPreflight } from "./apply.js";
+import {
+  runApply,
+  runApplyPreflight,
+  isInAgentContainer,
+  IN_AGENT_CONTAINER_APPLY_MSG,
+} from "./apply.js";
 import * as scaffoldModule from "../agents/scaffold.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
@@ -155,6 +160,73 @@ describe("runApply", () => {
       const all = sink.join("");
       expect(all).toMatch(/could not chown/);
       expect(all).toMatch(/continuing/i);
+    });
+  });
+
+  describe("in-agent-container preflight redirect", () => {
+    // Snapshot + restore the agent-container env markers so these cases
+    // are deterministic regardless of whether the suite itself happens to
+    // run inside an agent container.
+    let _origName: string | undefined;
+    let _origRoot: string | undefined;
+    beforeEach(() => {
+      _origName = process.env.SWITCHROOM_AGENT_NAME;
+      _origRoot = process.env.SWITCHROOM_AGENT_ROOT;
+      delete process.env.SWITCHROOM_AGENT_NAME;
+      delete process.env.SWITCHROOM_AGENT_ROOT;
+    });
+    afterEach(() => {
+      if (_origName !== undefined) process.env.SWITCHROOM_AGENT_NAME = _origName;
+      else delete process.env.SWITCHROOM_AGENT_NAME;
+      if (_origRoot !== undefined) process.env.SWITCHROOM_AGENT_ROOT = _origRoot;
+      else delete process.env.SWITCHROOM_AGENT_ROOT;
+    });
+
+    it("isInAgentContainer detects the env marker regardless of structural signals", () => {
+      expect(
+        isInAgentContainer(true, true, { SWITCHROOM_AGENT_NAME: "klanker" }),
+      ).toBe(true);
+      expect(
+        isInAgentContainer(true, true, { SWITCHROOM_AGENT_ROOT: "true" }),
+      ).toBe(true);
+    });
+
+    it("isInAgentContainer detects the structural fingerprint (no vault + no compose v2)", () => {
+      expect(isInAgentContainer(false, false, {})).toBe(true);
+      // A genuine host missing only ONE of the two is NOT the fingerprint.
+      expect(isInAgentContainer(false, true, {})).toBe(false);
+      expect(isInAgentContainer(true, false, {})).toBe(false);
+    });
+
+    it("preflight throws the DIRECTED hostd-rollout message when the env marker is set", () => {
+      process.env.SWITCHROOM_AGENT_NAME = "klanker";
+      const fakeVault = join(tmpdir(), `nonexistent-vault-${Date.now()}.enc`);
+      const cfg = {
+        ...makeStubConfig("/tmp/agents"),
+        vault: { path: fakeVault },
+        telegram: { bot_token: "vault:telegram_bot_token" },
+      } as unknown as SwitchroomConfig;
+      // Compose "present" (skip) so only the vault-missing condition trips —
+      // the env marker still routes to the directed message.
+      expect(() => runApplyPreflight(cfg, SKIP_COMPOSE_PREFLIGHT)).toThrow(
+        /mcp__hostd__rollout/,
+      );
+      expect(() => runApplyPreflight(cfg, SKIP_COMPOSE_PREFLIGHT)).toThrow(
+        IN_AGENT_CONTAINER_APPLY_MSG,
+      );
+    });
+
+    it("preflight throws the DIRECTED message on the structural fingerprint (no vault + no compose v2)", () => {
+      const fakeVault = join(tmpdir(), `nonexistent-vault-${Date.now()}.enc`);
+      const cfg = {
+        ...makeStubConfig("/tmp/agents"),
+        vault: { path: fakeVault },
+        telegram: { bot_token: "vault:telegram_bot_token" },
+      } as unknown as SwitchroomConfig;
+      // No env markers (cleared above); force compose v2 "missing".
+      expect(() =>
+        runApplyPreflight(cfg, { detectComposeV2: () => "compose v2 missing" }),
+      ).toThrow(/mcp__hostd__rollout/);
     });
   });
 

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -925,10 +925,70 @@ export function detectComposeV2(): string | null {
 }
 
 /**
+ * The directed error thrown when `switchroom apply`'s full per-agent
+ * scaffold is attempted from *inside* an agent container. This is a dead
+ * end by construction — not a bug to work around:
+ *
+ *   - HOME resolves to the container state dir (`/state/agent/home/
+ *     .switchroom`), which has no vault, so the vault-missing preflight
+ *     trips; and
+ *   - the agent container ships no `docker compose` v2 plugin, so even
+ *     with HOME pointed at the host home the compose-v2 preflight trips.
+ *
+ * A version roll does NOT need an agent to run a full apply: the
+ * hostd-driven rollout already runs apply as `--compose-only` (skipping
+ * the per-agent scaffold loop deliberately, #902) and each agent refreshes
+ * its own per-agent templates from inside its own container on
+ * restart-reconcile. So the roll completes without any full apply. This
+ * message redirects the caller to that path instead of chasing the bare
+ * "vault missing" / "docker compose v2 not found" errors.
+ */
+export const IN_AGENT_CONTAINER_APPLY_MSG =
+  "`switchroom apply`'s full per-agent scaffold cannot run from inside an " +
+  "agent container — this is a host/hostd operation by construction " +
+  "(no vault at the container HOME, and no `docker compose` v2 plugin " +
+  "here).\n" +
+  "To roll the fleet to a new version, drive the hostd rollout " +
+  "(`mcp__hostd__rollout`): it runs a `--compose-only` apply plus a " +
+  "per-agent restart-reconcile, and each agent refreshes its own templates " +
+  "on restart — the roll completes without any agent running a full apply.\n" +
+  "A full host-side `sudo switchroom apply` is only needed for structural " +
+  "changes (compose regeneration / new-agent scaffolding), and is run by " +
+  "the operator on the host, never from inside an agent.";
+
+/**
+ * Detect that we're executing inside a switchroom agent container, where a
+ * full `switchroom apply` is a structural dead end (see
+ * IN_AGENT_CONTAINER_APPLY_MSG). Two independent signals, either is enough:
+ *
+ *   1. The agent-container env markers (`SWITCHROOM_AGENT_NAME` /
+ *      `SWITCHROOM_AGENT_ROOT`), set by the agent wrapper; or
+ *   2. the structural fingerprint — no vault at the resolved HOME AND no
+ *      `docker compose` v2 — which is exactly the shape an agent container
+ *      presents even if the env markers are somehow absent.
+ */
+export function isInAgentContainer(
+  vaultPresent: boolean,
+  composeV2Present: boolean,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (env.SWITCHROOM_AGENT_NAME || env.SWITCHROOM_AGENT_ROOT) {
+    return true;
+  }
+  return !vaultPresent && !composeV2Present;
+}
+
+/**
  * Run the preflight gate. Fail fast (throws) when the config requires
  * vault-resolved secrets but ~/.switchroom/vault.enc is missing, or
  * when `docker compose` v2 is unavailable. Both conditions would have
  * surfaced as cryptic mid-apply / mid-up failures otherwise.
+ *
+ * When those conditions are actually the fingerprint of an agent
+ * container (see isInAgentContainer), throw the DIRECTED
+ * IN_AGENT_CONTAINER_APPLY_MSG instead of the bare vault/compose error, so
+ * an agent chasing a full apply is pointed at the hostd rollout path
+ * rather than a dead end. The genuine host case is unchanged.
  */
 export function runApplyPreflight(
   config: SwitchroomConfig,
@@ -937,14 +997,26 @@ export function runApplyPreflight(
   const vaultPath = resolvePath(
     config.vault?.path ?? "~/.switchroom/vault.enc",
   );
-  if (hasVaultRefs(config) && !existsSync(vaultPath)) {
+  const detect = opts.detectComposeV2 ?? detectComposeV2;
+  const vaultMissing = hasVaultRefs(config) && !existsSync(vaultPath);
+  const composeErr = detect();
+
+  // If this is an agent container, redirect to the hostd rollout path
+  // BEFORE emitting the bare vault/compose errors that mislead the agent
+  // into thinking apply is a step it can complete here.
+  if (
+    (vaultMissing || composeErr) &&
+    isInAgentContainer(!vaultMissing, composeErr === null)
+  ) {
+    throw new Error(IN_AGENT_CONTAINER_APPLY_MSG);
+  }
+
+  if (vaultMissing) {
     throw new Error(
       `Config references vault keys (vault:<name>) but ${vaultPath} is missing. ` +
       `Run \`switchroom setup\` first to initialise the vault.`,
     );
   }
-  const detect = opts.detectComposeV2 ?? detectComposeV2;
-  const composeErr = detect();
   if (composeErr) {
     throw new Error(composeErr);
   }

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -580,16 +580,25 @@ export function executeRollout(
           return { ok: false, rolled, failedStep: "apply", warnings };
         }
         if (execOpts.hostdContext) {
-          // TRADEOFF (surfaced, not hidden): --compose-only skipped the
-          // per-agent template refresh. If this release changed the
-          // start.sh / .mcp.json / settings.json templates, agents keep
-          // their stale wrappers until a host-side privileged apply runs.
+          // SURFACED (not hidden): --compose-only skipped the host-side
+          // per-agent scaffold loop (hostd is unprivileged and cannot write
+          // per-agent state dirs). This is NOT left stale: the per-agent
+          // restart-reconcile that follows for every agent in this roll
+          // refreshes each agent's own templates (start.sh / .mcp.json /
+          // settings.json) from inside its own container on restart. So a
+          // version roll picks up template changes automatically — no
+          // agent-run apply, and no manual host apply, is required here.
+          // A host-side `sudo switchroom apply` is only for STRUCTURAL
+          // changes (new-agent scaffolding / compose regeneration), not for
+          // per-agent template refresh on a roll.
           warnings.push(
             `apply ran --compose-only (hostd is unprivileged and cannot ` +
               `write per-agent state dirs). Compose + compose-level env/` +
-              `healthcheck are up to date, but per-agent template changes ` +
-              `(start.sh / .mcp.json / settings.json) are NOT applied — run ` +
-              `a host-side \`sudo switchroom apply\` if this release changed them.`,
+              `healthcheck are up to date; per-agent template changes ` +
+              `(start.sh / .mcp.json / settings.json) are refreshed ` +
+              `automatically by each agent's restart-reconcile in this roll. ` +
+              `A host-side \`sudo switchroom apply\` is only needed for ` +
+              `structural changes (new agents / compose regeneration).`,
           );
         }
         break;


### PR DESCRIPTION
## Job spec

Serves JTBD [`operate-the-fleet-from-telegram`](reference/jobs/operate-the-fleet-from-telegram.md) — the operator (and an admin agent acting for them) drives a fleet version roll from Telegram and should never be pointed at a step they structurally cannot run.

**Guidance / messaging only — no user-visible behavior change.** It stops an agent/operator chasing a dead end.

## Background

`switchroom apply`'s full per-agent scaffold **cannot run from inside an agent container**, and that's correct by construction, not a bug:

- HOME resolves to the container state dir (`/state/agent/home/.switchroom`), which has no vault → the vault-missing preflight throws; and
- even with `HOME=/host-home` it needs the `docker compose` v2 plugin the agent container lacks → the compose-v2 preflight throws.

The hostd-driven rollout already runs apply as `--compose-only` (skips the per-agent scaffold loop deliberately, #902) and each agent refreshes its own per-agent templates from inside its own container on restart-reconcile. So the version roll completes **without any agent ever running a full apply**. The only problem was that the errors + docs misled an agent into trying — exactly what happened in the **v0.16.47 rollout incident**, where the roll's own compose-only warning pointed an agent at a `sudo switchroom apply` it structurally cannot run.

## Changes

1. **`src/cli/apply.ts` — directed preflight error.** New `isInAgentContainer()` + exported `IN_AGENT_CONTAINER_APPLY_MSG`. The apply preflight detects the in-agent-container context — either the env markers (`SWITCHROOM_AGENT_NAME` / `SWITCHROOM_AGENT_ROOT`) OR the structural fingerprint (no vault at the resolved HOME **and** no `docker compose` v2) — and throws a directed error that names the hostd rollout path (`mcp__hostd__rollout`) instead of the bare "vault missing" / "docker compose v2 not found". The genuine host case is unchanged.

2. **`src/cli/rollout.ts` — reworded the compose-only warning.** It no longer implies an agent/operator must run a host-side `apply` for per-agent template changes: those are refreshed automatically by each agent's restart-reconcile during the roll. A host-side `sudo switchroom apply` is only for **structural** changes (new agents / compose regeneration).

3. **`skills/switchroom-cli/SKILL.md`** — clarified `apply` is host/operator-only for structural changes, cannot run from inside an agent container, and that version rolls go through the hostd rollout.

## Tests

`src/cli/apply.test.ts` gains a describe block asserting the directed error fires for both the env-marker shape and the no-vault + no-compose-v2 fingerprint, and that the message names `mcp__hostd__rollout` — without breaking the existing vault/compose preflight cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)