### PR TITLE
fix(model): stop /model <name> leaking pane scrollback into chat

### DIFF
--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -840,9 +840,21 @@ export function modelSwitchConfirmationLine(output: string): string | null {
   const line = output
     .split('\n')
     .map((l) => l.trim())
-    .find((l) => /set model|switched|kept model/i.test(l))
+    .find((l) => MODEL_SWITCH_CONFIRMATION_PREFIX.test(l))
   return line && line.length > 0 ? line : null
 }
+
+/**
+ * claude's real model-switch confirmation always begins the line (optionally
+ * behind a status glyph like `⏺` + whitespace) with one of these exact
+ * phrasings. Anchoring to the line start keeps ordinary scrollback prose that
+ * merely *contains* words like "switched" or "set model" (e.g. "I switched the
+ * deploy to blue-green") from false-positiving as a confirmation worth
+ * relaying. Shared by `modelSwitchConfirmationLine` (does this line qualify?)
+ * and `sessionModelFromConfirmation` (pull the name out).
+ */
+const MODEL_SWITCH_CONFIRMATION_PREFIX =
+  /^\s*[⏺●•>-]?\s*(?:Set model to|Switched to|Kept model as)\b/i
 
 /**
  * Pull the model NAME out of claude's session-switch confirmation so it can

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -227,11 +227,30 @@ export async function handleModelCommand(
   }
 
   if (result.outcome === 'ok') {
+    // claude's `/model <name>` switches the session SILENTLY — it does not
+    // print a confirmation line. So `result.output` on this path is almost
+    // always just whatever pane scrollback sat below the command echo (the
+    // agent's previous prose answer). `isTuiChromeLine` strips borders/glyphs
+    // but NOT ordinary prose, so blindly `preBlock`-ing `result.output` here
+    // dumped that unrelated scrollback back to the user as a code block
+    // (screenshot-confirmed on klanker, v0.16.47). Only relay output when it
+    // actually looks like a model-switch acknowledgement; otherwise suppress
+    // it and send a clean confirmation.
+    const confirmation = modelSwitchConfirmationLine(result.output)
+    if (confirmation) {
+      return {
+        text: [
+          `${verbHtml}`,
+          deps.preBlock(confirmation),
+          ...(result.truncated ? ['_truncated_'] : []),
+          PERSIST_NOTE,
+        ].join('\n'),
+        html: true,
+      }
+    }
     return {
       text: [
-        `${verbHtml}`,
-        deps.preBlock(result.output),
-        ...(result.truncated ? ['_truncated_'] : []),
+        `${verbHtml} — switched (session).`,
         PERSIST_NOTE,
       ].join('\n'),
       html: true,
@@ -806,6 +825,23 @@ export function isSrToClaudeTransition(
   nextModel: string,
 ): boolean {
   return !!prevModel?.startsWith('sr-') && !nextModel.startsWith('sr-')
+}
+
+/**
+ * Return the single line of a pane capture that actually reads as claude's
+ * model-switch acknowledgement ("Set model to X…", "Switched to X", or
+ * "Kept model as X"), or null when no such line is present. Used by the
+ * direct `/model <name>` path to decide whether `result.output` carries a
+ * genuine confirmation worth relaying, versus mere scrollback that must NOT
+ * be echoed back to chat. Mirrors the line-scan already used by the picker
+ * alias/sr-* callback paths.
+ */
+export function modelSwitchConfirmationLine(output: string): string | null {
+  const line = output
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => /set model|switched|kept model/i.test(l))
+  return line && line.length > 0 ? line : null
 }
 
 /**

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -226,6 +226,26 @@ describe("handleModelCommand — set", () => {
     expect(reply.text).not.toContain("earlier prose that must not leak");
   });
 
+  it("does NOT relay scrollback prose that merely contains 'switched'/'set model' as ordinary words", async () => {
+    // No line begins with claude's real confirmation phrasing — these are just
+    // English sentences that happen to use the words. None must be relayed.
+    const prose = [
+      "I switched the deploy to blue-green as we discussed.",
+      "Then I set model behaviour aside and moved on to the tests.",
+      "The team kept model changes out of this release entirely.",
+    ].join("\n");
+    const { deps } = makeDeps({ inject: async () => okResult(prose) });
+    const reply = await handleModelCommand({ kind: "set", model: "fable" }, deps);
+    // The anchored regex rejects all three lines, so nothing leaks and there is
+    // no <pre> block. A clean session confirmation is sent instead.
+    expect(reply.text).not.toContain("<pre>");
+    expect(reply.text).not.toContain("switched the deploy");
+    expect(reply.text).not.toContain("set model behaviour");
+    expect(reply.text).not.toContain("kept model changes");
+    expect(reply.text).toContain("switched (session)");
+    expect(reply.html).toBe(true);
+  });
+
   it("re-gates the model arg at the seam (caller bypassing the parser)", async () => {
     const { deps, calls } = makeDeps();
     const reply = await handleModelCommand({ kind: "set", model: "a b; reboot" }, deps);

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -184,13 +184,46 @@ describe("handleModelCommand — show / help never inject (picker-wedge guard)",
 });
 
 describe("handleModelCommand — set", () => {
-  it("injects exactly `/model <name>` once and relays output + persistence note", async () => {
+  it("injects exactly `/model <name>` once and relays a genuine confirmation + persistence note", async () => {
     const { deps, calls } = makeDeps();
     const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
     expect(calls).toEqual([{ agent: "klanker", command: "/model opus" }]);
     expect(reply.text).toContain("<pre>⏺ Set model to sonnet</pre>");
     expect(reply.text).toContain("Session-only");
     expect(reply.html).toBe(true);
+  });
+
+  it("SILENT switch: suppresses raw pane scrollback instead of dumping it as a code block", async () => {
+    // claude switches models silently, so the pane capture below the command
+    // echo is just the agent's previous prose answer. It must NOT be relayed.
+    const scrollback = [
+      "Here's the summary you asked for earlier:",
+      "- point one about the deploy",
+      "- point two about the rollback plan",
+    ].join("\n");
+    const { deps } = makeDeps({ inject: async () => okResult(scrollback) });
+    const reply = await handleModelCommand({ kind: "set", model: "fable" }, deps);
+    // The leak: none of the scrollback prose reaches the reply, and there is
+    // no <pre> code block echoing the capture.
+    expect(reply.text).not.toContain("summary you asked for");
+    expect(reply.text).not.toContain("rollback plan");
+    expect(reply.text).not.toContain("<pre>");
+    // A clean, session-scoped confirmation is sent instead.
+    expect(reply.text).toContain("/model fable");
+    expect(reply.text).toContain("switched (session)");
+    expect(reply.text).toContain("Session-only");
+    expect(reply.html).toBe(true);
+  });
+
+  it("relays only the confirmation line when the capture also carries scrollback", async () => {
+    const mixed = [
+      "Some earlier prose that must not leak",
+      "⏺ Set model to Fable 5 for this session",
+    ].join("\n");
+    const { deps } = makeDeps({ inject: async () => okResult(mixed) });
+    const reply = await handleModelCommand({ kind: "set", model: "fable" }, deps);
+    expect(reply.text).toContain("<pre>⏺ Set model to Fable 5 for this session</pre>");
+    expect(reply.text).not.toContain("earlier prose that must not leak");
   });
 
   it("re-gates the model arg at the seam (caller bypassing the parser)", async () => {


### PR DESCRIPTION
## Summary

The direct `/model <name>` Telegram switch path leaked tmux pane scrollback into the chat reply. Repro: user types `/model fable`; claude's REPL switches models **silently** (no visible confirmation output); the handler in `telegram-plugin/gateway/model-command.ts` (the `result.outcome === 'ok'` branch) unconditionally did `deps.preBlock(result.output)`, wrapping the raw inject pane-capture in a code block and relaying it. With no real response to capture, the capture diff grabbed whatever conversational scrollback was on screen (the agent's previous prose answer) and dumped it back to the user as a code block. Screenshot-confirmed on klanker (v0.16.47).

The existing chrome stripper `isTuiChromeLine` (`src/agents/inject.ts`) removes borders / `❯` glyphs but **not** ordinary prose scrollback, so it passed straight through.

## Why

A colleague-grade agent never dumps unrelated context back at you. `/model fable` should reply with a clean confirmation, not a fossil of the last answer re-quoted as code.

## What changed (contained to the direct set path)

- New `modelSwitchConfirmationLine(output)` helper: returns the single capture line that actually reads as claude's switch acknowledgement (`Set model to…` / `Switched to` / `Kept model as`), else `null`. This mirrors the line-scan the picker alias/sr-* callback paths already use.
- The direct `/model <name>` `outcome === 'ok'` branch now relays output **only** when it looks like a genuine confirmation (rendered via `preBlock`, as before). On the silent path it **suppresses** the capture entirely and sends a clean session-scoped confirmation (`verbHtml` + the existing `PERSIST_NOTE`).
- **Untouched:** the picker-tap / `selectModel` cursor-nav path, and the global `isTuiChromeLine` stripper.

## Test plan

- `bun test telegram-plugin/tests/model-command.test.ts` — 80 pass. Added two cases: (1) a silent switch whose capture is pure prose scrollback asserts none of the prose and no `<pre>` block reaches the reply, only the clean `switched (session)` confirmation; (2) a mixed capture (prose + a real `Set model to…` line) asserts only the confirmation line is relayed and the prose is dropped.
- `tsc --noEmit` clean.
- No change to `gateway.ts`, so the `check-bot-api-wrapping` allowlist is unaffected.

## Risk

Low, and scoped to one branch of one handler. Behaviour change is strictly a reduction in what gets echoed: genuine confirmations still render identically; only silent-switch scrollback (which was never legitimate output) is now suppressed.

## Design contract

- **Vision outcome:** visibility / chat-is-source-of-truth — the pinned chat must carry only real agent output, not pane fossils.
- **Job spec:** `reference/jobs/feel-like-a-colleague.md` — "verifies before claiming… The user doesn't catch it being a chatbot." Re-quoting a stale answer as a code block on a model switch is exactly the chatbot tell this job forbids.
- **Invariant:** none crossed (claude-native REPL verb path preserved; no API/SDK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)