### PR TITLE
fix(telegram): paint background workers on tool activity + suppress false stalls

### DIFF
--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -450,6 +450,28 @@ const DEFAULT_SILENT_SYNTHESIS_STALL_THRESHOLD_MS = 300_000
 const DEFAULT_SILENT_STALL_TERMINAL_MS = 300_000
 
 /**
+ * Tools that legitimately run for minutes with ZERO intervening JSONL
+ * writes: the worker emits ONE `sub_agent_tool_use` line when the command
+ * starts, then nothing until it returns. `Bash` (a build, `npm test`, a long
+ * curl, a git clone) is the canonical case. A worker whose last observed tool
+ * is one of these is NOT stalled just because the JSONL went quiet — the
+ * 60s active-loop threshold misfires on exactly this population, producing the
+ * false "stall detected (idle 60s)" the operator hit while a background worker
+ * was mid-`Bash`. Pass-1 stall detection widens the idle threshold for these
+ * to the same silent-synthesis window used for not-yet-started workers, so a
+ * long command is given room before it counts as stalled. The pass-2 terminal
+ * synthesis is unchanged — it still releases the deferred-completion gate the
+ * fixed window after a stall IS eventually flagged.
+ */
+const LONG_RUNNING_TOOLS: ReadonlySet<string> = new Set(['Bash'])
+
+/** True when the tool named legitimately runs quiet for minutes (see
+ *  LONG_RUNNING_TOOLS). Null/undefined tool name → false. */
+function isLongRunningTool(name: string | null | undefined): boolean {
+  return name != null && LONG_RUNNING_TOOLS.has(name)
+}
+
+/**
  * Freshness window for the boot-scan "in-flight at boot → promote to
  * live" path. A worker file still in `running` state at boot is only
  * promoted (un-suppressed) if its last write (file mtime) is within this
@@ -1446,9 +1468,18 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       // tool_use. Once tools have started, switch to the tighter loop
       // threshold — frequent JSONL writes mean 60s of silence is a
       // strong signal the sub-agent is genuinely stuck.
-      const threshold = entry.toolCount === 0
-        ? silentSynthesisStallThresholdMs
-        : stallThresholdMs
+      // A worker that hasn't fired any tools yet is mid-silent-synthesis; a
+      // worker whose LAST tool is a known long-runner (e.g. `Bash`) is mid-
+      // command — both legitimately go quiet in the JSONL for minutes, so both
+      // use the wider silent-synthesis window instead of the tight 60s active-
+      // loop threshold. Without the long-runner arm a background worker running
+      // a long `Bash`/`npm test` was falsely flagged "stall detected (idle
+      // 60s)" while genuinely alive. Pass-2 terminal synthesis (below) is
+      // unaffected: it still fires the fixed window after a stall IS flagged.
+      const threshold =
+        entry.toolCount === 0 || isLongRunningTool(entry.lastTool?.name)
+          ? silentSynthesisStallThresholdMs
+          : stallThresholdMs
       if (idleMs >= threshold) {
         entry.stallNotified = true
         entry.stalledAt = n

--- a/telegram-plugin/tests/subagent-watcher-env-thresholds.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-env-thresholds.test.ts
@@ -26,9 +26,17 @@ function subAgentUserMsg(promptText: string) {
 function makeHarness(opts: {
   agentId?: string
   configStallThresholdMs?: number
+  configSilentSynthStallThresholdMs?: number
   configSilentStallTerminalMs?: number
+  initialContent?: string
 } = {}) {
-  const { agentId = 'env-thresh-agent', configStallThresholdMs, configSilentStallTerminalMs } = opts
+  const {
+    agentId = 'env-thresh-agent',
+    configStallThresholdMs,
+    configSilentSynthStallThresholdMs,
+    configSilentStallTerminalMs,
+    initialContent,
+  } = opts
 
   let currentTime = 1000
   const stallCalls: Array<{ idleMs: number }> = []
@@ -43,7 +51,7 @@ function makeHarness(opts: {
   const subagentsDir = `${sessionDir}/subagents`
   const jsonlPath = `${subagentsDir}/agent-${agentId}.jsonl`
   const fileContents = new Map<string, Buffer>()
-  fileContents.set(jsonlPath, Buffer.from(buildJSONL(subAgentUserMsg('bg task')), 'utf-8'))
+  fileContents.set(jsonlPath, Buffer.from(initialContent ?? buildJSONL(subAgentUserMsg('bg task')), 'utf-8'))
 
   let lastOpenedPath: string | null = null
   const mockFs = {
@@ -81,7 +89,7 @@ function makeHarness(opts: {
   const watcher = startSubagentWatcher({
     agentDir,
     stallThresholdMs: configStallThresholdMs,
-    silentSynthesisStallThresholdMs: configStallThresholdMs,
+    silentSynthesisStallThresholdMs: configSilentSynthStallThresholdMs ?? configStallThresholdMs,
     silentStallTerminalMs: configSilentStallTerminalMs,
     rescanMs: 500,
     onStall: (_id, idleMs) => stallCalls.push({ idleMs }),
@@ -209,6 +217,41 @@ describe('subagent-watcher env-var threshold overrides', () => {
     h.advance(2_000)
     h.advance(60_000)
     expect(h.stallTerminalCalls).toHaveLength(0)
+  })
+
+  it('a Bash-in-flight worker skips the tight stall threshold but still releases the terminal gate', () => {
+    // End-to-end of the long-runner suppression under compressed env-tuned
+    // windows: a worker mid-`Bash` (a) is NOT flagged at the tight active-loop
+    // threshold, (b) IS eventually flagged at the widened silent-synthesis
+    // window, and (c) the pass-2 terminal synthesis STILL fires the fixed
+    // window after that — the load-bearing completion-gate release is intact.
+    const h = makeHarness({
+      agentId: 'env-thresh-bash',
+      configStallThresholdMs: 1000, // tight active-loop threshold
+      configSilentSynthStallThresholdMs: 10_000, // widened long-runner window
+      configSilentStallTerminalMs: 5000, // compressed terminal window
+      initialContent: buildJSONL(
+        subAgentUserMsg('bg task'),
+        { type: 'assistant', message: { content: [{ type: 'tool_use', id: 'tool-B', name: 'Bash', input: { command: 'npm test' } }] } },
+      ),
+    })
+    h.advance(500) // register + tail → toolCount=1, lastTool=Bash
+    h.unmarkHistorical()
+
+    // 5s idle — well past the 1s active-loop threshold, but a Bash worker uses
+    // the 10s silent-synthesis window, so NO false stall.
+    h.advance(5_000)
+    expect(h.stallCalls).toHaveLength(0)
+
+    // Cross the 10s window → the stall IS flagged (pass-2 becomes reachable).
+    h.advance(6_000)
+    expect(h.stallCalls).toHaveLength(1)
+    expect(h.stallTerminalCalls).toHaveLength(0)
+
+    // 5s post-stall → terminal synthesis releases the deferred-completion gate.
+    h.advance(6_000)
+    expect(h.stallTerminalCalls).toHaveLength(1)
+    expect(h.finishCalls).toHaveLength(1)
   })
 
   it('zero env value falls through to default (zero is not "fire immediately")', () => {

--- a/telegram-plugin/tests/subagent-watcher-stall-notification.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-stall-notification.test.ts
@@ -311,6 +311,76 @@ describe('subagent-watcher onStall callback (Option C, issue #393)', () => {
     expect(stallCalls).toHaveLength(1)
   })
 
+  // Bash-in-flight suppression: a worker whose LAST observed tool is a known
+  // long-runner (`Bash` — a build, `npm test`, a long curl) legitimately goes
+  // quiet in the JSONL for minutes while the command runs. Pre-fix the tight
+  // 60s active-loop threshold misfired on exactly this population, producing
+  // the false "stall detected (idle 60s)" the operator hit while a background
+  // worker was mid-Bash. The watcher now widens the threshold for such workers
+  // to the silent-synthesis window.
+  it('does NOT trip stall at 60s when the last tool is Bash (long-runner suppression)', () => {
+    const agentId = 'stall-bash-01'
+    const { stallCalls, advance, watcher } = makeStallHarness({
+      agentId,
+      stallThresholdMs: 60_000,
+      silentSynthesisStallThresholdMs: 300_000, // 5min
+      rescanMs: 500,
+      initialContent: buildJSONL(
+        subAgentUserMsg('background task'),
+        { type: 'assistant', message: { content: [{ type: 'tool_use', id: 'tool-B', name: 'Bash', input: { command: 'npm test' } }] } },
+      ),
+    })
+    advance(500) // register + tail read → toolCount=1, lastTool=Bash
+    const entry = watcher.getRegistry().get(agentId)
+    if (entry) entry.historical = false
+    expect(entry?.lastTool?.name).toBe('Bash')
+    advance(120_000) // 2min idle — far past 60s but under the silent-synth window
+    expect(stallCalls).toHaveLength(0) // NOT falsely stalled mid-Bash
+  })
+
+  it('DOES trip stall for a Bash worker once past the silent-synthesis window (pass-2 gate still reachable)', () => {
+    const agentId = 'stall-bash-02'
+    const { stallCalls, advance, watcher } = makeStallHarness({
+      agentId,
+      stallThresholdMs: 60_000,
+      silentSynthesisStallThresholdMs: 300_000, // 5min
+      rescanMs: 500,
+      initialContent: buildJSONL(
+        subAgentUserMsg('background task'),
+        { type: 'assistant', message: { content: [{ type: 'tool_use', id: 'tool-B', name: 'Bash', input: { command: 'sleep 999' } }] } },
+      ),
+    })
+    advance(500)
+    const entry = watcher.getRegistry().get(agentId)
+    if (entry) entry.historical = false
+    advance(120_000) // under the window — no stall yet
+    expect(stallCalls).toHaveLength(0)
+    advance(200_000) // total ~5min20s — past the silent-synth window → stall fires
+    expect(stallCalls).toHaveLength(1)
+    expect(stallCalls[0].agentId).toBe(agentId)
+  })
+
+  it('a non-long-runner last tool (Read) still trips at the tight 60s threshold', () => {
+    // Guard the suppression is scoped to long-runners only — a Read that goes
+    // quiet for 60s is genuinely stalled and must still flag.
+    const agentId = 'stall-read-01'
+    const { stallCalls, advance, watcher } = makeStallHarness({
+      agentId,
+      stallThresholdMs: 60_000,
+      silentSynthesisStallThresholdMs: 600_000, // way out — proves the 60s path is taken
+      rescanMs: 500,
+      initialContent: buildJSONL(
+        subAgentUserMsg('background task'),
+        { type: 'assistant', message: { content: [{ type: 'tool_use', id: 'tool-R', name: 'Read', input: { path: '/x' } }] } },
+      ),
+    })
+    advance(500)
+    const entry = watcher.getRegistry().get(agentId)
+    if (entry) entry.historical = false
+    advance(65_000) // 65s quiet after a Read → genuinely stalled
+    expect(stallCalls).toHaveLength(1)
+  })
+
   // Test 10: onStall is NOT called for sub-agents already done/failed
   it('does not call onStall for sub-agents in done/failed state', () => {
     const agentId = 'stall-test-10-done'

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -801,6 +801,87 @@ describe('createWorkerActivityFeed — heartbeat', () => {
     await feed.update('w1', 'chat', view({ elapsedMs: 2000, latestSummary: 'go' })).catch(() => {})
     expect(bot.edits.length).toBe(editsBefore)
   })
+
+  // ─── Prose-silent worker: first paint driven by the heartbeat ──────────────
+  // The user-visible bug: a background worker that dives straight into quiet
+  // work (a long `Bash` / `npm test`) fires ONE `sub_agent_tool_use` tick when
+  // the command starts, then no more JSONL lines for the whole run. If that one
+  // tick lands before `firstPaintMin` the paint is held — and pre-fix the
+  // heartbeat skipped `messageId == null` handles, so nothing ever re-drove the
+  // paint and the worker showed NOTHING for its entire run. The heartbeat now
+  // performs the first paint once the held handle is past `firstPaintMin`.
+  it('(vi) paints a prose-silent worker whose only tick arrived before firstPaintMin, via a later heartbeat', async () => {
+    const bot = makeFakeBot()
+    let clock = 0
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      firstPaintMinMs: 8000,
+      heartbeatTickMs: 6000,
+      minEditIntervalMs: 2500,
+      setInterval: () => 1,
+      clearInterval: () => {},
+    })
+    const drain = () => new Promise((r) => setTimeout(r, 0))
+
+    // A single tool tick at 2s (the Bash invocation) — before firstPaintMin,
+    // so the paint is held. This is the ONLY update the worker ever sends.
+    clock = 2000
+    await feed.update('w1', 'chat', view({ elapsedMs: 2000, toolCount: 1, latestSummary: '' }))
+    expect(bot.sent).toHaveLength(0)
+    expect(feed.messageIdOf('w1')).toBeNull()
+
+    // A heartbeat still before firstPaintMin holds — trivial workers stay silent.
+    clock = 6000
+    feed.heartbeatTick()
+    await drain()
+    expect(bot.sent).toHaveLength(0)
+    expect(feed.messageIdOf('w1')).toBeNull()
+
+    // A heartbeat PAST firstPaintMin performs the first paint — the worker
+    // becomes visible even though it never emitted prose or a second tick.
+    clock = 12_000
+    feed.heartbeatTick()
+    await drain()
+    expect(bot.sent).toHaveLength(1)
+    expect(feed.messageIdOf('w1')).toBe(1000)
+    expect(bot.sent[0].text).toContain('🛠 **Worker**')
+
+    // And it keeps updating: a later heartbeat edits the message with a
+    // climbing `· Ns` suffix so the still-alive worker visibly advances.
+    clock = 20_000
+    feed.heartbeatTick()
+    await drain()
+    expect(bot.edits.length).toBeGreaterThanOrEqual(1)
+    // No narrative step (prose-silent) → the advance shows in the header's
+    // climbing master elapsed rather than a `· Ns` step suffix.
+    expect(bot.edits[bot.edits.length - 1].text).toMatch(/_\d+s · 1 tool_/)
+  })
+
+  it('(vii) still holds a trivial sub-firstPaintMin worker silent (heartbeat never force-paints early)', async () => {
+    const bot = makeFakeBot()
+    let clock = 0
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      firstPaintMinMs: 8000,
+      heartbeatTickMs: 6000,
+      setInterval: () => 1,
+      clearInterval: () => {},
+    })
+    const drain = () => new Promise((r) => setTimeout(r, 0))
+    // Worker ticks once at 1s then finishes at 3s (handback covers it). No
+    // heartbeat before firstPaintMin may paint it.
+    clock = 1000
+    await feed.update('w1', 'chat', view({ elapsedMs: 1000, toolCount: 1, latestSummary: '' }))
+    clock = 3000
+    feed.heartbeatTick()
+    await drain()
+    expect(bot.sent).toHaveLength(0)
+    await feed.finish('w1', view({ state: 'done', toolCount: 1 }))
+    // finish with no posted message → no recap edit (handback covers the result).
+    expect(bot.edits).toHaveLength(0)
+  })
 })
 
 // ─── Extreme-edge: single oversized narrative line (no-truncate ON) ──────────

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -882,6 +882,39 @@ describe('createWorkerActivityFeed — heartbeat', () => {
     // finish with no posted message → no recap edit (handback covers the result).
     expect(bot.edits).toHaveLength(0)
   })
+
+  it('(viii) a finished, still-unpainted worker is NOT orphan-painted by a later heartbeat', async () => {
+    // Regression guard: the heartbeat first-paint branch must never send a
+    // fresh `running` message on an already-finished handle. finish() deletes
+    // the handle; a subsequent heartbeat (even one past firstPaintMin) must
+    // skip it — otherwise a permanently orphaned card that never finalizes.
+    const bot = makeFakeBot()
+    let clock = 0
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      firstPaintMinMs: 8000,
+      heartbeatTickMs: 6000,
+      setInterval: () => 1,
+      clearInterval: () => {},
+    })
+    const drain = () => new Promise((r) => setTimeout(r, 0))
+    // One held tick before firstPaintMin — no paint yet.
+    clock = 2000
+    await feed.update('w1', 'chat', view({ elapsedMs: 2000, toolCount: 1, latestSummary: '' }))
+    expect(bot.sent).toHaveLength(0)
+    expect(feed.messageIdOf('w1')).toBeNull()
+    // Worker finishes while still unpainted (finish drops the handle).
+    await feed.finish('w1', view({ state: 'done', toolCount: 1 }))
+    expect(feed.messageIdOf('w1')).toBeNull()
+    // A heartbeat well past firstPaintMin must NOT paint a new message.
+    clock = 20_000
+    feed.heartbeatTick()
+    await drain()
+    expect(bot.sent).toHaveLength(0)
+    expect(bot.edits).toHaveLength(0)
+    expect(feed.messageIdOf('w1')).toBeNull()
+  })
 })
 
 // ─── Extreme-edge: single oversized narrative line (no-truncate ON) ──────────

--- a/telegram-plugin/tests/worker-visibility-prose-silent-harness.test.ts
+++ b/telegram-plugin/tests/worker-visibility-prose-silent-harness.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Flagship harness for the prose-silent background-worker visibility fix
+ * (PR 2 of 2). This is the automated proxy for the live-gateway test the
+ * operator demanded: it wires the REAL `startSubagentWatcher` to the REAL
+ * `createWorkerActivityFeed` on ONE shared virtual clock, mirroring the
+ * gateway's `onProgress → workerActivityFeed.update` and
+ * `onFinish → workerActivityFeed.finish` wiring, and drives a sub-agent JSONL
+ * that contains ONLY tool_use events (a long `Bash` run) — NO `sub_agent_text`.
+ *
+ * It asserts the four outcomes the fix must deliver:
+ *   (a) the `🛠 Worker` feed PAINTS a message (gets a messageId) within the
+ *       expected window even though the worker never emitted prose,
+ *   (b) the message keeps UPDATING via the heartbeat while the worker is alive,
+ *   (c) NO false stall is flagged during the Bash window (the worker mid-`Bash`
+ *       is not "stalled" just because its JSONL went quiet), and
+ *   (d) the 300s-style silent-stall TERMINAL synthesis still releases the
+ *       deferred-completion gate at the end (onStallTerminal + onFinish fire,
+ *       and the feed finalizes) — the load-bearing completion path is intact.
+ *
+ * The pre-fix behaviour this locks against: a background worker that dives
+ * straight into a long `Bash` fired one tool tick (before firstPaintMin, so the
+ * paint was held), then no further JSONL lines — and the heartbeat skipped
+ * `messageId == null` handles, so the worker showed NOTHING for its entire run
+ * while ALSO being falsely flagged "stall detected (idle 60s)".
+ *
+ * Uses vitest (no bun:sqlite): no registry DB is wired, so the gate-release
+ * proxy is the `onStallTerminal` + `onFinish` callbacks — the exact signals the
+ * gateway's handback delivery and deferred-completion release consume.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { startSubagentWatcher } from '../subagent-watcher.js'
+import {
+  createWorkerActivityFeed,
+  type WorkerActivityView,
+} from '../worker-activity-feed.js'
+import * as fs from 'fs'
+
+function buildJSONL(...lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join('\n') + '\n'
+}
+function subAgentUserMsg(promptText: string) {
+  return { type: 'user', message: { content: [{ type: 'text', text: promptText }] } }
+}
+function bashToolUse(id: string, command: string) {
+  return { type: 'assistant', message: { content: [{ type: 'tool_use', id, name: 'Bash', input: { command } }] } }
+}
+
+interface FakeBot {
+  sent: Array<{ chatId: string; text: string }>
+  edits: Array<{ messageId: number; text: string }>
+  sendMessage: (chatId: string, text: string) => Promise<{ message_id: number }>
+  editMessageText: (chatId: string, messageId: number, text: string) => Promise<unknown>
+}
+function makeFakeBot(): FakeBot {
+  let nextId = 5000
+  const fb: FakeBot = {
+    sent: [],
+    edits: [],
+    sendMessage: async (chatId, text) => {
+      fb.sent.push({ chatId, text })
+      return { message_id: nextId++ }
+    },
+    editMessageText: async (_chatId, messageId, text) => {
+      fb.edits.push({ messageId, text })
+      return {}
+    },
+  }
+  return fb
+}
+
+/** Flush the feed's async chains (microtasks + the awaited fake bot). */
+const flush = async (): Promise<void> => {
+  for (let i = 0; i < 5; i++) await new Promise((r) => setTimeout(r, 0))
+}
+
+function makeHarness() {
+  const agentId = 'prose-silent-bash-01'
+  const chatId = 'chat-42'
+  let currentTime = 1000
+
+  const stallCalls: Array<{ agentId: string; idleMs: number }> = []
+  const stallTerminalCalls: Array<{ agentId: string }> = []
+  const finishCalls: Array<{ agentId: string; outcome: string }> = []
+
+  const agentDir = '/home/user/.switchroom/agents/myagent'
+  const sessionId = 'mock-session'
+  const projectsRoot = `${agentDir}/.claude/projects`
+  const projectDir = `${projectsRoot}/mock-cwd`
+  const sessionDir = `${projectDir}/${sessionId}`
+  const subagentsDir = `${sessionDir}/subagents`
+  const jsonlPath = `${subagentsDir}/agent-${agentId}.jsonl`
+  const fileContents = new Map<string, Buffer>()
+  // Start with ONLY the dispatch user message — no tool, no prose. The Bash
+  // tool_use is appended post-boot so it fires onProgress on a live (non-
+  // historical) entry, exactly like a worker that starts then dives into Bash.
+  fileContents.set(jsonlPath, Buffer.from(buildJSONL(subAgentUserMsg('run the integration suite')), 'utf-8'))
+
+  let lastOpenedPath: string | null = null
+  const mockFs = {
+    existsSync: ((p: fs.PathLike) => {
+      const ps = String(p)
+      if (ps === projectsRoot || ps === projectDir || ps === sessionDir || ps === subagentsDir) return true
+      return fileContents.has(ps)
+    }) as typeof fs.existsSync,
+    readdirSync: ((p: fs.PathLike) => {
+      const ps = String(p)
+      if (ps === projectsRoot) return ['mock-cwd']
+      if (ps === projectDir) return [sessionId]
+      if (ps === sessionDir) return ['subagents']
+      if (ps === subagentsDir) return [`agent-${agentId}.jsonl`]
+      return []
+    }) as unknown as typeof fs.readdirSync,
+    statSync: ((p: fs.PathLike) => ({ size: fileContents.get(String(p))?.length ?? 0 }) as fs.Stats) as typeof fs.statSync,
+    openSync: ((p: fs.PathLike) => { lastOpenedPath = String(p); return 42 }) as unknown as typeof fs.openSync,
+    closeSync: (() => { lastOpenedPath = null }) as typeof fs.closeSync,
+    readSync: ((
+      _fd: number, buf: NodeJS.ArrayBufferView, offset: number, length: number, position: number | null,
+    ): number => {
+      const content = lastOpenedPath != null ? fileContents.get(lastOpenedPath) : undefined
+      if (!content) return 0
+      const pos = position ?? 0
+      const src = content.slice(pos, pos + length)
+      ;(src as Buffer).copy(buf as Buffer, offset)
+      return src.length
+    }) as unknown as typeof fs.readSync,
+    watch: (() => ({ close: vi.fn() }) as unknown as fs.FSWatcher) as unknown as typeof fs.watch,
+  }
+
+  // One shared interval list drives BOTH the watcher (rescan + checkStalls)
+  // and the feed (heartbeat) off the same virtual clock.
+  const intervals: Array<{ fn: () => void; ms: number; ref: number; fireAt: number }> = []
+  let nextRef = 1
+  const sharedSetInterval = (fn: () => void, ms: number): unknown => {
+    const ref = nextRef++
+    intervals.push({ fn, ms, ref, fireAt: currentTime + ms })
+    return { ref }
+  }
+  const sharedClearInterval = (h: unknown): void => {
+    const { ref } = h as { ref: number }
+    const idx = intervals.findIndex((i) => i.ref === ref)
+    if (idx !== -1) intervals.splice(idx, 1)
+  }
+
+  const bot = makeFakeBot()
+  const feed = createWorkerActivityFeed({
+    bot,
+    now: () => currentTime,
+    firstPaintMinMs: 8000,
+    heartbeatTickMs: 6000,
+    minEditIntervalMs: 2500,
+    setInterval: sharedSetInterval,
+    clearInterval: sharedClearInterval,
+  })
+
+  const watcher = startSubagentWatcher({
+    agentDir,
+    stallThresholdMs: 60_000, // tight active-loop threshold
+    silentSynthesisStallThresholdMs: 300_000, // widened window (also long-runner window)
+    silentStallTerminalMs: 300_000, // post-stall terminal-synthesis window (unchanged)
+    rescanMs: 500,
+    now: () => currentTime,
+    setInterval: sharedSetInterval,
+    clearInterval: sharedClearInterval,
+    fs: mockFs,
+    onStall: (id, idleMs) => stallCalls.push({ agentId: id, idleMs }),
+    onStallTerminal: (id) => stallTerminalCalls.push({ agentId: id }),
+    onFinish: ({ agentId: id, outcome, description, resultText, toolCount, durationMs }) => {
+      finishCalls.push({ agentId: id, outcome })
+      // Mirror the gateway's terminal wiring: force the worker feed's recap.
+      void feed.finish(id, {
+        description,
+        lastTool: null,
+        toolCount,
+        latestSummary: resultText,
+        elapsedMs: durationMs,
+        state: outcome === 'failed' ? 'failed' : 'done',
+      })
+    },
+    // Mirror the gateway's onProgress → workerActivityFeed.update wiring for a
+    // background worker (worker-feed owns the progress beat).
+    onProgress: ({ agentId: id, description, latestSummary, elapsedMs, lastTool, toolCount }) => {
+      const view: WorkerActivityView = {
+        description,
+        lastTool,
+        toolCount,
+        latestSummary,
+        elapsedMs,
+        state: 'running',
+      }
+      void feed.update(id, chatId, view)
+    },
+  })
+
+  const advance = (ms: number): void => {
+    currentTime += ms
+    for (;;) {
+      intervals.sort((a, b) => a.fireAt - b.fireAt)
+      const next = intervals[0]
+      if (!next || next.fireAt > currentTime) break
+      next.fireAt += next.ms
+      next.fn()
+    }
+  }
+
+  const appendBash = (): void => {
+    const existing = fileContents.get(jsonlPath) ?? Buffer.from('')
+    const line = JSON.stringify(bashToolUse('tool-bash-1', 'npm run test:integration')) + '\n'
+    fileContents.set(jsonlPath, Buffer.concat([existing, Buffer.from(line, 'utf-8')]))
+  }
+
+  return {
+    agentId, bot, feed, watcher, advance, appendBash, flush,
+    stallCalls, stallTerminalCalls, finishCalls,
+    unmarkHistorical: () => {
+      const e = watcher.getRegistry().get(agentId)
+      if (e) e.historical = false
+    },
+    registry: () => watcher.getRegistry(),
+  }
+}
+
+describe('prose-silent background worker — end-to-end visibility harness (PR 2)', () => {
+  it('paints, keeps updating, does not falsely stall, and still releases the terminal gate', async () => {
+    const h = makeHarness()
+
+    // Boot: register the entry (historical=true at boot). Flip it live to model
+    // an entry discovered post-boot (the only case progress/stall fire).
+    h.advance(500)
+    h.unmarkHistorical()
+
+    // The worker dives into a long Bash. The single tool_use fires onProgress —
+    // BEFORE firstPaintMin — so the feed HOLDS the paint (this is the trap).
+    h.appendBash()
+    h.advance(500) // poll reads the Bash line → onProgress(tool) → feed.update
+    await h.flush()
+    const entry = h.registry().get(h.agentId)
+    expect(entry?.lastTool?.name).toBe('Bash')
+    expect(entry?.toolCount).toBe(1)
+    // Held: elapsed (~1s) < firstPaintMin (8s), no paint yet.
+    expect(h.bot.sent).toHaveLength(0)
+    expect(h.feed.messageIdOf(h.agentId)).toBeNull()
+
+    // (a) PAINT: with NO further JSONL events, the heartbeat performs the first
+    // paint once the held handle is past firstPaintMin. Pre-fix this never
+    // happened (heartbeat skipped messageId==null) → the worker was invisible.
+    h.advance(12_000) // ~12.5s since dispatch — past firstPaintMin, heartbeats fire
+    await h.flush()
+    expect(h.bot.sent).toHaveLength(1)
+    expect(h.feed.messageIdOf(h.agentId)).not.toBeNull()
+    expect(h.bot.sent[0].chatId).toBe('chat-42')
+    expect(h.bot.sent[0].text).toContain('🛠 **Worker**')
+
+    // (b) KEEPS UPDATING: later heartbeats edit the message with a climbing
+    // `· Ns` suffix so the still-alive worker visibly advances.
+    h.advance(30_000)
+    await h.flush()
+    expect(h.bot.edits.length).toBeGreaterThanOrEqual(1)
+    expect(h.bot.edits[h.bot.edits.length - 1].text).toMatch(/· \d+/)
+
+    // (c) NO FALSE STALL during the Bash window: the worker's last tool is a
+    // long-runner, so the tight 60s active-loop threshold does NOT apply. We
+    // are now well past 60s of JSONL silence with zero stall flagged.
+    h.advance(60_000) // total idle ~102s — far past the old 60s misfire point
+    await h.flush()
+    expect(h.stallCalls).toHaveLength(0)
+    // The feed is still live and updating during this window.
+    expect(h.bot.edits.length).toBeGreaterThanOrEqual(2)
+
+    // The stall IS eventually flagged once past the widened silent-synthesis
+    // window (the worker genuinely never wrote another line / turn_end).
+    h.advance(260_000) // total idle > 300s → stall flagged
+    await h.flush()
+    expect(h.stallCalls).toHaveLength(1)
+    expect(h.stallCalls[0].agentId).toBe(h.agentId)
+    expect(h.stallTerminalCalls).toHaveLength(0)
+
+    // (d) TERMINAL GATE RELEASE: 300s past the stall, the silent-stall terminal
+    // synthesis fires — onStallTerminal + onFinish — and the feed finalizes.
+    // This is the untouched, load-bearing completion path.
+    h.advance(310_000)
+    await h.flush()
+    expect(h.stallTerminalCalls).toHaveLength(1)
+    expect(h.finishCalls).toHaveLength(1)
+    expect(h.finishCalls[0].agentId).toBe(h.agentId)
+    // The feed's terminal recap edited the existing worker message to done.
+    const lastEdit = h.bot.edits[h.bot.edits.length - 1]
+    expect(lastEdit.text).toContain('done')
+    // Handle dropped after finish (gateway unpins independently).
+    expect(h.feed.messageIdOf(h.agentId)).toBeNull()
+  })
+})

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -433,6 +433,13 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   function heartbeatTick(): void {
     const now = nowFn()
     for (const h of handles.values()) {
+      // Orphan-paint guard: `finish()` deletes the handle in a `.finally` that
+      // may not have drained if a tick fires in the same synchronous stretch.
+      // Skip any handle no longer in the map so the first-paint branch below
+      // can never send a fresh `running` message on an already-finished worker
+      // (which would orphan a card that never finalizes). Restores the
+      // structural safety the pre-first-paint `messageId == null` skip gave.
+      if (!handles.has(h.agentId)) continue
       if (h.lastView == null) continue
       if (h.lastView.state !== 'running') continue
       if (now < h.cooldownUntil) continue

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -405,13 +405,27 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   }
 
   /**
-   * Heartbeat — option (a), suffix-only, NEVER opens a new message. For each
-   * handle with a posted message, enqueue a re-render through the existing
-   * chain → doUpdate path (never editMessageText directly). Skips:
-   *   - handles with no posted message (messageId == null),
+   * Heartbeat — keeps a running worker's message alive AND performs the
+   * FIRST paint for a prose-silent worker whose only tick arrived before
+   * `firstPaintMin`.
+   *
+   * Why the first-paint branch exists: a background worker that dives
+   * straight into quiet work (e.g. a long `Bash` / `npm test`) emits a
+   * single `sub_agent_tool_use` event when the command is invoked, then no
+   * further JSONL lines for the whole run. That one tick drives `update`
+   * once — but if it lands before `firstPaintMin` the paint is held, and
+   * with no subsequent tick nothing ever re-drives it, so the worker shows
+   * NOTHING for its entire run (the "I can't see the worker" gap). The
+   * heartbeat closes it: once such a handle is past `firstPaintMin`, drive a
+   * paint here through the same chain → doUpdate path. After first paint the
+   * suffix-only maintenance branch keeps it advancing.
+   *
+   * For handles that already have a posted message, this is the original
+   * option-(a), suffix-only re-render (never editMessageText directly). Skips:
    *   - handles inside a 429 cooldown,
-   *   - handles edited within minEditInterval (no stampede),
-   *   - non-running handles (terminal/deleted).
+   *   - handles with no `lastView` (no update ever arrived) or non-running,
+   *   - for the maintenance branch: handles edited within minEditInterval
+   *     (no stampede) or whose current step isn't yet stale.
    * The `· Ns` liveSuffix is applied ONLY when the worker's current step is
    * stale (now - lastEditAt >= heartbeatTickMs) so a normally-ticking worker is
    * untouched and its body stays byte-stable for the dedup.
@@ -419,14 +433,30 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
   function heartbeatTick(): void {
     const now = nowFn()
     for (const h of handles.values()) {
-      if (h.messageId == null) continue
       if (h.lastView == null) continue
       if (h.lastView.state !== 'running') continue
       if (now < h.cooldownUntil) continue
+
+      const liveElapsed = h.dispatchAtMs != null ? now - h.dispatchAtMs : h.lastView.elapsedMs
+
+      // First-paint path: a prose-silent worker's single early tick was held
+      // (elapsed < firstPaintMin) and no further tick re-drove it. Once it is
+      // past firstPaintMin, drive the paint. doUpdate's send branch re-checks
+      // firstPaintMin against the refreshed elapsed, so this is exact.
+      if (h.messageId == null) {
+        if (liveElapsed < firstPaintMin) continue
+        const view = { ...h.lastView, elapsedMs: Math.max(h.lastView.elapsedMs, liveElapsed) }
+        h.chain = h.chain
+          .then(() => doUpdate(h, view))
+          .catch((err) => {
+            log(`worker-feed: heartbeat first-paint chain error ${h.agentId}: ${(err as Error).message}`)
+          })
+        continue
+      }
+
       if (now - h.lastEditAt < minEditInterval) continue
       const stale = now - h.lastEditAt >= heartbeatTickMs
       if (!stale) continue
-      const liveElapsed = h.dispatchAtMs != null ? now - h.dispatchAtMs : h.lastView.elapsedMs
       const liveSuffix = ' · ' + formatFeedElapsed(liveElapsed)
       // Re-render THROUGH the chain + doUpdate path — never editMessageText directly.
       //


### PR DESCRIPTION
## What & why

**Vision outcome:** VISIBILITY (#1 — every step pinned to chat). **JTBD:** `know-what-my-agent-is-doing`.

A background sub-agent that dives straight into quiet work (a long `Bash` / `npm test`) fires a single `sub_agent_tool_use` event when the command starts, then no further JSONL lines for the whole run. That one tick drives the `🛠 Worker` activity feed's `update` once — but if it arrives before `firstPaintMin` (~8s) the paint is held, and the 6s heartbeat only re-rendered handles that ALREADY had a `messageId`. With no second tick to re-drive it, a genuinely-alive worker showed **nothing** for its entire run — the exact "I can't see the worker" gap the operator hit. The same worker was also falsely flagged `stall detected (idle 60s)` because the watcher infers liveness from JSONL line-growth.

## The fixes

1. **Heartbeat first-paint** (`worker-activity-feed.ts`). The heartbeat now performs the FIRST paint for a prose-silent worker whose only tick was held, once it's past `firstPaintMin`, through the same chain → `doUpdate` path — then keeps it updating. Respects `minEditInterval` + the `firstPaintMin` gate; trivial sub-`firstPaintMin` workers still stay silent (their result reaches the user via the handback).
2. **Suppress the false 60s stall while mid-`Bash`** (`subagent-watcher.ts`). Pass-1 stall detection widens the idle threshold to the silent-synthesis window for a worker whose last tool is a known long-runner (`Bash`), mirroring the existing `toolCount == 0` adaptive arm. A worker mid-command is not "stalled" just because its JSONL went quiet.

**The 300s post-stall terminal synthesis is UNCHANGED** — it is the load-bearing completion-gate release, and it still fires the fixed window after a stall IS eventually flagged. The threshold-widening approach (vs. suppressing the notification while still marking `stalledAt`) is deliberately safer: a live worker mid-`Bash` is never marked stalled at all, so it can never be falsely terminated early.

## Invariant note

The `🛠 Worker` message is the sanctioned silently-pinned status surface (the narrow `chat-is-the-single-source-of-truth` exception in `status-pin-driver.ts`). Painting it on tool activity re-surfaces a message the chat already owns — no new parallel status surface is introduced.

## Validation — the harness the operator asked for

`telegram-plugin/tests/worker-visibility-prose-silent-harness.test.ts` wires the **real** `startSubagentWatcher` to the **real** `createWorkerActivityFeed` on **one shared virtual clock** (mirroring the gateway's `onProgress → feed.update` / `onFinish → feed.finish` wiring), feeds a sub-agent JSONL containing **only** a `Bash` tool_use (no `sub_agent_text`), and asserts:

- **(a)** the feed PAINTS a message (gets a `messageId`) within the `firstPaintMin` window, driven purely by the heartbeat;
- **(b)** it keeps UPDATING via later heartbeats (climbing elapsed);
- **(c)** NO false stall is flagged during the Bash window (past the old 60s misfire point);
- **(d)** the silent-stall TERMINAL synthesis still releases the gate at the end (`onStallTerminal` + `onFinish` fire, feed finalizes to done).

Plus unit coverage: prose-silent tool-tick paint + trivial-worker silence (`worker-activity-feed.test.ts`), and Bash-in-flight stall suppression under both default and env-tuned thresholds (`subagent-watcher-stall-notification.test.ts`, `subagent-watcher-env-thresholds.test.ts`).

Local: `npm run lint` clean, `npm run build` clean, full plugin vitest suite green (4823 tests), `src/build-info.ts` reverted.

## Scope

**PR 2 of 2.** PR 1 = #2775 (truthful sub-agent status telemetry). The PR-1 review nit — chat-scoping the process-global worker counts in `status-query-telemetry.ts`'s idle calc — is **deferred as a follow-up**: it lives at the gateway caller (worker feed is keyed by agentId, DB count is process-global), so scoping it meaningfully expands the diff. Noted rather than folded in, to keep this PR tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
