### PR TITLE
fleet-health: exclude test-harness/synthetic agents from drift counts

### DIFF
--- a/src/cli/fleet-health.ts
+++ b/src/cli/fleet-health.ts
@@ -72,6 +72,9 @@ export function registerFleetHealthCommand(program: Command): void {
           `fleet-health: scanned ${result.agentsScanned} agents` +
             (result.agentsSkipped.length
               ? `, skipped ${result.agentsSkipped.length} (${result.agentsSkipped.join(", ")})`
+              : "") +
+            (result.agentsExcluded.length
+              ? `, excluded ${result.agentsExcluded.length} test agent(s) (${result.agentsExcluded.join(", ")})`
               : ""),
         );
 

--- a/src/fleet-health/scan.ts
+++ b/src/fleet-health/scan.ts
@@ -24,6 +24,7 @@ import type { FleetHealthLedger } from "../web/fleet-health-read.js";
 import { fleetHealthLedgerPath } from "../web/fleet-health-read.js";
 import { scanAgent, type Finding, type AgentScanResult } from "./detect.js";
 import { buildLedger } from "./ledger.js";
+import { isTestAgent } from "./test-agents.js";
 
 /**
  * Resolve the `.switchroom` base dir, matching the read-side
@@ -49,6 +50,10 @@ export interface ScanResult {
   perAgent: AgentScanResult[];
   agentsScanned: number;
   agentsSkipped: string[];
+  /** Test/synthetic agents (e.g. `test-harness`) deliberately excluded from
+   *  the production drift ledger — their findings never enter frequency/reach.
+   *  See `isTestAgent` for the rule. */
+  agentsExcluded: string[];
 }
 
 /** List agent slugs under `<base>/agents` (directories only). */
@@ -78,9 +83,20 @@ export function runScan(opts: ScanOptions = {}): ScanResult {
   const findings: Finding[] = [];
   const perAgent: AgentScanResult[] = [];
   const skipped: string[] = [];
+  const excluded: string[] = [];
   let scanned = 0;
 
   for (const agent of agents) {
+    // Test/synthetic agents (test-harness et al.) deliberately exercise the
+    // failure paths this scanner watches (represent/obligation escalation,
+    // killed turns, silent no-ops) on every UAT run. Counting them as
+    // production drift inflates frequency/reach and buries the real signal, so
+    // they are excluded from the ledger entirely.
+    if (isTestAgent(agent)) {
+      excluded.push(agent);
+      log(`fleet-health: excluding test/synthetic agent ${agent} from drift counts`);
+      continue;
+    }
     const turnsPath = resolve(base, "agents", agent, "turns.jsonl");
     const gwPath = resolve(base, "logs", agent, "gateway-supervisor.log");
     let turnsText = "";
@@ -125,7 +141,13 @@ export function runScan(opts: ScanOptions = {}): ScanResult {
     prior,
   });
 
-  return { ledger, perAgent, agentsScanned: scanned, agentsSkipped: skipped };
+  return {
+    ledger,
+    perAgent,
+    agentsScanned: scanned,
+    agentsSkipped: skipped,
+    agentsExcluded: excluded,
+  };
 }
 
 /** Read the existing ledger (for GH-number carry-forward + count-drop), or

--- a/src/fleet-health/test-agents.test.ts
+++ b/src/fleet-health/test-agents.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+import { isTestAgent } from "./test-agents.js";
+import { runScan } from "./scan.js";
+
+/**
+ * Metric-truth: `test-harness` (and any test/synthetic/UAT agent) deliberately
+ * exercises the represent/obligation-escalation path on every UAT run, so it
+ * must NOT count as production drift — its occurrences must never enter the
+ * ledger's frequency/reach. Regression guard for the 341/418-inflation bug.
+ */
+describe("isTestAgent", () => {
+  it("flags the sanctioned test-harness canary", () => {
+    expect(isTestAgent("test-harness")).toBe(true);
+    expect(isTestAgent("TEST-HARNESS")).toBe(true);
+  });
+
+  it("flags test/synthetic/uat prefixes", () => {
+    expect(isTestAgent("test-foo")).toBe(true);
+    expect(isTestAgent("synthetic-probe")).toBe(true);
+    expect(isTestAgent("uat-gate")).toBe(true);
+  });
+
+  it("does not flag real production agents", () => {
+    for (const a of ["marko", "clerk", "klanker", "carrie", "gymbro"]) {
+      expect(isTestAgent(a)).toBe(false);
+    }
+  });
+
+  it("does not flag the empty slug", () => {
+    expect(isTestAgent("")).toBe(false);
+    expect(isTestAgent("   ")).toBe(false);
+  });
+});
+
+describe("runScan excludes test agents from the ledger", () => {
+  const bases: string[] = [];
+  afterEach(() => {
+    for (const b of bases.splice(0)) rmSync(b, { recursive: true, force: true });
+  });
+
+  // One gateway log line that trips the represent/obligation-escalation signal.
+  const ESCALATION_LINE =
+    "2026-07-03T02:00:00Z telegram gateway: obligation escalation delivered + closed origin=77770001:_#1";
+
+  function makeAgent(base: string, agent: string, gwLines: string[]): void {
+    mkdirSync(resolve(base, "agents", agent), { recursive: true });
+    writeFileSync(resolve(base, "agents", agent, "turns.jsonl"), "", "utf-8");
+    mkdirSync(resolve(base, "logs", agent), { recursive: true });
+    writeFileSync(
+      resolve(base, "logs", agent, "gateway-supervisor.log"),
+      gwLines.join("\n") + "\n",
+      "utf-8",
+    );
+  }
+
+  function freshBase(): string {
+    const dir = mkdtempSync(resolve(tmpdir(), "fh-scan-"));
+    const base = resolve(dir, ".switchroom");
+    mkdirSync(base, { recursive: true });
+    bases.push(dir);
+    return base;
+  }
+
+  it("keeps a real agent's escalations but drops test-harness's", () => {
+    const base = freshBase();
+    // test-harness produces 5 escalations; a real agent produces 1.
+    makeAgent(base, "test-harness", Array(5).fill(ESCALATION_LINE));
+    makeAgent(base, "marko", [ESCALATION_LINE]);
+
+    const res = runScan({ base });
+
+    expect(res.agentsExcluded).toContain("test-harness");
+    expect(res.agentsScanned).toBe(1); // only marko
+
+    // The represent/obligation-escalation issue must reflect ONLY marko:
+    // frequency 1, reach [marko], not 6 across two agents.
+    const record = res.ledger.records.find(
+      (r) => r.job_spec === "feel-like-a-colleague",
+    );
+    expect(record).toBeDefined();
+    const escalationIssues = (record?.issues ?? []).filter(
+      (i) =>
+        i.dedup_key === "feel-like-a-colleague:represent:obligation-escalation" &&
+        i.frequency > 0,
+    );
+    for (const iss of escalationIssues) {
+      expect(iss.reach).not.toContain("test-harness");
+    }
+    const totalReach = new Set(escalationIssues.flatMap((i) => i.reach));
+    expect(totalReach.has("test-harness")).toBe(false);
+    expect(totalReach.has("marko")).toBe(true);
+    const totalFreq = escalationIssues.reduce((s, i) => s + i.frequency, 0);
+    expect(totalFreq).toBe(1); // marko's single escalation only
+  });
+});

--- a/src/fleet-health/test-agents.ts
+++ b/src/fleet-health/test-agents.ts
@@ -1,0 +1,39 @@
+/**
+ * Fleet Health — test/synthetic agent classification.
+ *
+ * Some agents are NOT production principals: `test-harness` is the sanctioned
+ * UAT canary (see `src/cli/rollout.ts`) that *deliberately* exercises failure
+ * paths — represent/obligation escalation, killed turns, silent no-ops — every
+ * time the end-to-end Telegram UAT runs. Counting its occurrences as real
+ * production drift badly inflates a job spec's `frequency` and `reach` (a
+ * single test agent dominated `feel-like-a-colleague:represent:obligation-
+ * escalation` at 341/418 occurrences), burying the genuine production signal.
+ *
+ * The scanner MUST exclude these agents from the drift frequency/reach counts
+ * so the ledger ranks by real principal-facing impact. This is the single
+ * source of truth for "is this a test/synthetic agent" — keep the rule here so
+ * the scan, the ledger, and any future consumer never drift apart.
+ */
+
+/** Exact-match slugs that are sanctioned test/UAT agents, never production. */
+export const TEST_AGENT_SLUGS: ReadonlySet<string> = new Set(["test-harness"]);
+
+/** Slug prefixes reserved for test/synthetic/UAT agents. An operator naming an
+ *  agent `test-*`, `synthetic-*`, or `uat-*` has flagged it as non-production;
+ *  the fleet-health scanner treats it the same as `test-harness`. */
+export const TEST_AGENT_PREFIXES: readonly string[] = [
+  "test-",
+  "synthetic-",
+  "uat-",
+];
+
+/**
+ * True when `agent` is a test/synthetic/UAT agent whose findings must NOT count
+ * as production drift. Pure + case-insensitive on the slug.
+ */
+export function isTestAgent(agent: string): boolean {
+  const slug = agent.trim().toLowerCase();
+  if (!slug) return false;
+  if (TEST_AGENT_SLUGS.has(slug)) return true;
+  return TEST_AGENT_PREFIXES.some((p) => slug.startsWith(p));
+}


### PR DESCRIPTION
## What & why

Fleet Health's nightly sensor was counting the **`test-harness` UAT canary as production drift**. `test-harness` deliberately exercises the exact failure paths the scanner watches (represent/obligation escalation, killed turns, silent no-ops) on every end-to-end Telegram UAT run, so its synthetic failures dominated the ledger.

For the top drift issue `feel-like-a-colleague:represent:obligation-escalation` (frequency 418 across 9 agents), host-log analysis attributes **341 of 418 occurrences (~82%) to `test-harness` alone**. The genuine production signal is only ~77, spread across real agents (marko 28, clerk 23, overlord 8, klanker 7, gymbro 5, finn 3, carrie 2, reggie 1). The metric was badly inflated by a test agent.

## The fix (metric-truth)

- New single source of truth `src/fleet-health/test-agents.ts` → `isTestAgent(slug)`: exact-match `test-harness` plus the `test-*` / `synthetic-*` / `uat-*` slug-prefix conventions.
- `runScan` (`src/fleet-health/scan.ts`) excludes these agents **before** their findings enter the ledger, so they never contribute to `frequency` / `reach` / `severity`. They are surfaced as a new `agentsExcluded` field on the scan result and in the CLI log (`src/cli/fleet-health.ts`), so the exclusion is **visible, not silent**.
- The detector already had a `synthetic-` *turn-id* exclusion; this extends the same principle to the *agent* level.

## Tests

`src/fleet-health/test-agents.test.ts`:
- `isTestAgent` classification (canary, prefixes, real agents, empty slug).
- A `runScan` filesystem integration test: `test-harness` produces 5 escalations and `marko` produces 1 → the `feel-like-a-colleague:represent:obligation-escalation` issue ends up with **frequency 1, reach `[marko]`**, `test-harness` absent.

Full `src/fleet-health/` suite is green (32 tests). Lint + build clean.

## Investigation — the genuine ~77 real-agent escalations

Read the live gateway logs (`logs/<agent>/gateway-supervisor.log`) around the `obligation escalating` lines for the top real agents. Two **distinct** root causes, neither warranting a code hack in this PR:

1. **Ordinary behavioral drift (the majority).** Isolated escalations spread thin across days (clerk: 5 over ~10 days; most of marko's likewise): a turn genuinely ends without the owed `reply` tool call, the represent net re-presents, and after the window the gateway force-delivers a synthesized reply. This is exactly the silent-failure class the sensor exists to catch. The agent-side guidance (the "SENDING YOUR ANSWER" reply-tool contract in agent CLAUDE.md) is already strong — this is prompt/behavioral, so **no code change** (guess-fixing prompt behavior in gateway code would be wrong).

2. **Bridge-reconnect delivery storms (a real code-side pattern, but out of scope here).** marko's 2026-07-02 00:3x–00:4x burst (8+ escalations in minutes) follows a `bridge-reconnect` / `bridge_recover` event: multiple inbound strands land `no enqueue ack`, the gateway loops `inbound strand … — re-clearing composer + re-delivering` every 5–15s and force-escalates a batch of mid-flight obligations at once. This is a genuine gateway inbound-delivery-state-machine issue (cf. `reference/rfcs/inbound-delivery-state-machine.md`, which already calls out an "overlapping-turn silence wedge" firing on reconnect). Fixing it is a substantial, separately-scoped change against that RFC and should **not** be guess-fixed inside this metric-truth PR — flagging it as a recommended follow-up.

## Contract

- **JTBD:** `fleet-stays-healthy` (`reference/rfcs/fleet-health.md`).
- **Vision outcome:** `always-available` — the ledger must rank by real principal-facing impact; a test agent's synthetic failures are not that.
- **Invariants:** none crossed. Sits near the metric-truth of the ranking formula (`severity × frequency × reach × recency`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)