### PR TITLE
fix(rollout): cron hot-reload no longer short-circuits --force/--pin recreate (#2779)

### DIFF
--- a/src/cli/agent-reconcile.test.ts
+++ b/src/cli/agent-reconcile.test.ts
@@ -60,7 +60,7 @@ describe("reconcileAndRestartAgent — Phase F cron-only hot reload", () => {
       mkConfig("foo"),
       "/state/agents",
       undefined,
-      { silent: true, force: true },
+      { silent: true },
       deps,
     );
 
@@ -87,12 +87,56 @@ describe("reconcileAndRestartAgent — Phase F cron-only hot reload", () => {
       mkConfig("foo"),
       "/state/agents",
       undefined,
-      { silent: true, force: true },
+      { silent: true },
       deps,
     );
 
     expect(deps.applyCronChangesHot).toHaveBeenCalledWith("foo", changes);
     expect(deps.restartAgent).not.toHaveBeenCalled();
+  });
+
+  it("cron-only changes + force → recreate wins (no hot path, #2779)", async () => {
+    const changes = ["/state/agents/foo/.claude-cron/.mcp.json"];
+    const deps = mkDeps({
+      reconcileAgent: vi.fn(() => ({ agentDir: "/state/agents/foo", changes })) as never,
+    });
+
+    const res = await reconcileAndRestartAgent(
+      "foo",
+      mkConfig("foo"),
+      "/state/agents",
+      undefined,
+      { silent: true, force: true },
+      deps,
+    );
+
+    // force is an explicit demand to recreate on the target image — the
+    // cron-only classification must NOT short-circuit it.
+    expect(deps.applyCronChangesHot).not.toHaveBeenCalled();
+    expect(deps.restartAgent).toHaveBeenCalledTimes(1);
+    expect(res.restarted).toBe(true);
+  });
+
+  it("cron-only changes + releaseOverride (pin) → recreate wins (no hot path, #2779)", async () => {
+    const changes = ["/state/agents/foo/.claude-cron/.mcp.json"];
+    const deps = mkDeps({
+      reconcileAgent: vi.fn(() => ({ agentDir: "/state/agents/foo", changes })) as never,
+    });
+
+    const res = await reconcileAndRestartAgent(
+      "foo",
+      mkConfig("foo"),
+      "/state/agents",
+      undefined,
+      { silent: true, releaseOverride: { pin: "v1.2.3" } },
+      deps,
+    );
+
+    // A one-shot pin (hostd rollout image bump) must reach the container —
+    // the cron-only hot path would leave it on the old image.
+    expect(deps.applyCronChangesHot).not.toHaveBeenCalled();
+    expect(deps.restartAgent).toHaveBeenCalledTimes(1);
+    expect(res.restarted).toBe(true);
   });
 
   it("non-cron change → restartAgent called, applyCronChangesHot NOT called", async () => {
@@ -186,7 +230,7 @@ describe("reconcileAndRestartAgent — compose regen before recreate (pin self-h
     const deps = mkDeps({
       reconcileAgent: vi.fn(() => ({ agentDir: "/state/agents/foo", changes: ["/state/agents/foo/telegram/cron-0.sh"] })) as never,
     });
-    await reconcileAndRestartAgent("foo", mkConfig("foo"), "/state/agents", undefined, { silent: true, force: true }, deps);
+    await reconcileAndRestartAgent("foo", mkConfig("foo"), "/state/agents", undefined, { silent: true }, deps);
     expect(deps.writeComposeFile).not.toHaveBeenCalled();
     expect(deps.restartAgent).not.toHaveBeenCalled();
   });

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -636,7 +636,14 @@ export async function reconcileAndRestartAgent(
   if (allChanges.length > 0) {
     const kinds = allChanges.map((p) => classifyChangeKind(p));
     const allCron = kinds.every((k) => k === "cron");
-    if (allCron) {
+    // The cron-only hot path skips the container recreate — but --force and a
+    // one-shot release override (`--pin <target>` on the hostd rollout path)
+    // are explicit demands to recreate on the TARGET image. If we take the hot
+    // path there, an agent with only cron-tagged drift (e.g.
+    // `.claude-cron/.mcp.json`) stays on the OLD image and the roll's
+    // version-assert stalls. Force/pin must always win over classification.
+    // Fixes #2779.
+    if (allCron && !opts.force && !opts.releaseOverride) {
       const r = deps.applyCronChangesHot(name, allChanges);
       log(
         chalk.cyan(


### PR DESCRIPTION
## Root cause

`reconcileAndRestartAgent` (`src/cli/agent.ts`) took the cron-only **hot path** — regenerate cron units, skip the container recreate — based purely on file-change classification (`allCron`). It ignored `opts.force` and `opts.releaseOverride`.

During a rollout image bump (`agent restart <name> --wait --force --pin <target>`, see `src/cli/rollout.ts:615`), an agent whose only drift was cron-tagged (e.g. `.claude-cron/.mcp.json`) was **never recreated**, stayed on the **old image**, and the roll's version-assert stalled the roll.

## Fix

Guard the hot-path branch so an explicit force or a one-shot pin always wins:

```ts
if (allCron && !opts.force && !opts.releaseOverride) {
```

Force/pin now fall through to the compose regen (which honours `releaseOverride`, emitting the target image tag) and the container recreate.

## Tests

- Existing cron-only hot-path tests updated to drop the incidental `force: true`.
- Added `cron-only changes + force → recreate wins (#2779)` and `cron-only changes + releaseOverride (pin) → recreate wins (#2779)` asserting `applyCronChangesHot` is NOT called and `restartAgent` fires.

`bun run tsc --noEmit` clean; `agent-reconcile.test.ts` 11/11 green.

Closes #2779

🤖 Generated with [Claude Code](https://claude.com/claude-code)