### PR TITLE
fix(apply): vault-broker unreachable degrades to warning; carry reconcile output in rollback errors (#2781)

### DIFF
--- a/src/cli/apply-litellm-provision.test.ts
+++ b/src/cli/apply-litellm-provision.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for #2781 — `provisionLiteLLMKeys` must degrade a vault-broker
+ * that is UNREACHABLE (an environment limitation: hostd's in-container
+ * `switchroom apply` has no broker socket mounted, by construction) to a
+ * WARNING instead of a per-agent scaffold failure. Pre-fix, every agent got
+ * "x litellm/<agent>: vault-broker unreachable — agent will not get routing
+ * env." recorded in `failures[]`, apply exited 1 (12/12 "failed"), and
+ * hostd's config_propose_edit post-apply reconcile rolled back EVERY edit —
+ * so Telegram "Always allow" persists never saved.
+ *
+ * Genuine provisioning errors (broker reachable, bad admin_key ref / vault
+ * write denial) must STAY failures.
+ *
+ * The broker/provision/yaml modules are lazily imported inside
+ * `provisionLiteLLMKeys`, so `vi.mock` intercepts them cleanly here without
+ * touching the rest of apply.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { provisionLiteLLMKeys, formatScaffoldFailureResolution } from "./apply.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+import type { ScaffoldFailure } from "./apply.js";
+
+const getViaBrokerStructured = vi.fn();
+const putViaBroker = vi.fn();
+vi.mock("../vault/broker/client.js", () => ({
+  getViaBrokerStructured: (...a: unknown[]) => getViaBrokerStructured(...a),
+  putViaBroker: (...a: unknown[]) => putViaBroker(...a),
+}));
+
+const ensureTeam = vi.fn();
+const ensureKey = vi.fn();
+vi.mock("../litellm/provision.js", () => ({
+  ensureTeam: (...a: unknown[]) => ensureTeam(...a),
+  ensureKey: (...a: unknown[]) => ensureKey(...a),
+}));
+
+function makeConfig(): SwitchroomConfig {
+  return {
+    switchroom: { version: 1 },
+    telegram: { bot_token: "123:TEST", forum_chat_id: "-1001" },
+    litellm: {
+      enabled: true,
+      base_url: "http://127.0.0.1:4010",
+      admin_key: "sk-master-test",
+      team: "switchroom",
+    },
+    agents: {
+      clerk: { litellm: { enabled: true } },
+    },
+  } as unknown as SwitchroomConfig;
+}
+
+function makeSinks() {
+  const out: string[] = [];
+  const errs: string[] = [];
+  const failures: ScaffoldFailure[] = [];
+  return {
+    out,
+    errs,
+    failures,
+    ctx: {
+      writeOut: (s: string) => void out.push(s),
+      writeErr: (s: string) => void errs.push(s),
+      failures,
+    },
+  };
+}
+
+describe("provisionLiteLLMKeys — broker-unreachable degrades to warning (#2781)", () => {
+  let prevPass: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prevPass = process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    process.env.SWITCHROOM_VAULT_PASSPHRASE = "test-passphrase";
+  });
+
+  afterEach(() => {
+    if (prevPass === undefined) delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    else process.env.SWITCHROOM_VAULT_PASSPHRASE = prevPass;
+  });
+
+  it("unreachable broker → WARNING, not a scaffold failure (agent keeps prior routing env)", async () => {
+    getViaBrokerStructured.mockResolvedValue({
+      kind: "unreachable",
+      msg: "connect ENOENT /run/switchroom/vault-broker.sock",
+    });
+
+    const { ctx, failures, errs } = makeSinks();
+    await provisionLiteLLMKeys(makeConfig(), ["clerk"], undefined, ctx);
+
+    // The load-bearing assertion: NO failure recorded → apply exits 0.
+    expect(failures).toEqual([]);
+    // The operator still sees a loud-but-yellow warning naming the agent.
+    const err = errs.join("");
+    expect(err).toMatch(/litellm\/clerk: vault-broker unreachable/);
+    expect(err).toMatch(/previous routing env/);
+    // Nothing was provisioned (we never got past the idempotency probe).
+    expect(ensureKey).not.toHaveBeenCalled();
+    expect(putViaBroker).not.toHaveBeenCalled();
+  });
+
+  it("unreachable broker on the NULL-passphrase probe path → warning, not failure", async () => {
+    delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    getViaBrokerStructured.mockResolvedValue({
+      kind: "unreachable",
+      msg: "no broker socket",
+    });
+
+    const { ctx, failures, errs } = makeSinks();
+    // `home` points at a dir with no auto-unlock blob → passphrase null.
+    await provisionLiteLLMKeys(makeConfig(), ["clerk"], undefined, {
+      ...ctx,
+      home: "/nonexistent-home-for-test",
+    });
+
+    expect(failures).toEqual([]);
+    expect(errs.join("")).toMatch(/vault-broker unreachable/);
+    expect(errs.join("")).toMatch(/previous routing env/);
+  });
+
+  it("null passphrase + broker REACHABLE + key not found → still a failure (fail-open guard)", async () => {
+    delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    getViaBrokerStructured.mockResolvedValue({ kind: "not_found" });
+
+    const { ctx, failures } = makeSinks();
+    await provisionLiteLLMKeys(makeConfig(), ["clerk"], undefined, {
+      ...ctx,
+      home: "/nonexistent-home-for-test",
+    });
+
+    expect(failures.some((f) => f.agent === "clerk")).toBe(true);
+    expect(failures.find((f) => f.agent === "clerk")!.message).toMatch(
+      /passphrase/i,
+    );
+  });
+
+  it("broker reachable, admin_key vault ref unresolvable → genuine failure is KEPT", async () => {
+    const config = makeConfig();
+    (config as { litellm: { admin_key: string } }).litellm.admin_key =
+      "vault:litellm/admin-key";
+    // Probe for the agent key: not provisioned. Admin ref resolve: not found.
+    getViaBrokerStructured
+      .mockResolvedValueOnce({ kind: "not_found" }) // litellm/clerk/api-key
+      .mockResolvedValueOnce({ kind: "not_found" }); // litellm/admin-key ref
+
+    const { ctx, failures } = makeSinks();
+    await provisionLiteLLMKeys(config, ["clerk"], undefined, ctx);
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0].agent).toBe("clerk");
+    expect(failures[0].message).toMatch(/admin_key vault ref .* did not resolve/);
+  });
+});
+
+describe("formatScaffoldFailureResolution — permission epilogue gating (#2781)", () => {
+  it("prints the 0700/sudo guidance only for permission (EACCES) failures", () => {
+    const out = formatScaffoldFailureResolution(
+      [{ agent: "alice", message: "EACCES: permission denied, open '.../start.sh'" }],
+      0,
+      1,
+    );
+    expect(out).toMatch(/mode 0700/);
+    expect(out).toMatch(/Re-run interactively/);
+  });
+
+  it("non-permission failures get a generic pointer, NOT the 0700 misdiagnosis", () => {
+    const out = formatScaffoldFailureResolution(
+      [
+        {
+          agent: "clerk",
+          message: "litellm: vault-broker unreachable; cannot provision key.",
+        },
+      ],
+      11,
+      12,
+    );
+    expect(out).toMatch(/Scaffolded 11\/12.*1 failed/s);
+    expect(out).toMatch(/see the per-agent error lines above/);
+    expect(out).not.toMatch(/mode 0700/);
+    expect(out).not.toMatch(/privilege/);
+    expect(out).not.toMatch(/--compose-only/);
+  });
+});

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -312,15 +312,21 @@ export async function provisionLiteLLMKeys(
 
     const alreadyProvisioned: string[] = [];
     const unprovisionedNew: string[] = [];
+    const brokerUnreachable: string[] = [];
     for (const { name } of optedIn) {
       const vaultKey = `litellm/${name}/api-key`;
       const existing = await getViaBrokerStructured(vaultKey);
       if (existing.kind === "ok") {
         alreadyProvisioned.push(name);
+      } else if (existing.kind === "unreachable") {
+        // #2781: broker unreachable is an environment limitation (hostd's
+        // container has no broker socket by construction) — we can't
+        // provision OR confirm, so degrade to a warning rather than fail
+        // apply. The agent keeps its previous routing env either way.
+        brokerUnreachable.push(name);
       } else {
-        // kind === "not_found" (genuinely new) or "unreachable" (can't confirm
-        // it's provisioned) — either way, this agent is not known-good and must
-        // be surfaced, not silently skipped.
+        // kind === "not_found" (genuinely new) or "denied" — this agent is
+        // not known-good and must be surfaced, not silently skipped.
         unprovisionedNew.push(name);
       }
     }
@@ -333,6 +339,16 @@ export async function provisionLiteLLMKeys(
         chalk.gray(
           `  ~ litellm: ${alreadyProvisioned.length} agent(s) already provisioned ` +
           `(${alreadyProvisioned.join(", ")}) — unaffected by missing passphrase.\n`,
+        ),
+      );
+    }
+
+    if (brokerUnreachable.length > 0) {
+      ctx.writeErr(
+        chalk.yellow(
+          `  ! litellm: vault-broker unreachable — could not verify/provision ` +
+          `${brokerUnreachable.length} agent(s) (${brokerUnreachable.join(", ")}); ` +
+          `they keep their previous routing env.\n`,
         ),
       );
     }
@@ -438,13 +454,20 @@ export async function provisionLiteLLMKeys(
         continue;
       }
       if (existing.kind === "unreachable") {
-        failures.push({
-          agent: name,
-          message: `litellm: vault-broker unreachable (${existing.msg ?? "no detail"}); cannot provision key.`,
-        });
+        // #2781: an unreachable broker is an ENVIRONMENT limitation, not a
+        // provisioning error — hostd's in-container `switchroom apply` has no
+        // broker socket mounted BY CONSTRUCTION, so treating this as a
+        // scaffold failure made every hostd reconcile exit 1 (12/12 "failed")
+        // and rolled back every config_propose_edit. Degrade to a WARNING,
+        // mirroring the "Hindsight unreachable — skipping bank creation"
+        // path: the agent keeps whatever routing env its previous provision
+        // gave it, and apply exits 0 if nothing else failed. Genuine
+        // provisioning errors (bad ref / write denial with the broker
+        // reachable) below still land in `failures`.
         ctx.writeErr(
-          chalk.red(
-            `  x litellm/${name}: vault-broker unreachable — agent will not get routing env.\n`,
+          chalk.yellow(
+            `  ! litellm/${name}: vault-broker unreachable (${existing.msg ?? "no detail"}) — ` +
+            `skipping key provisioning; agent keeps its previous routing env.\n`,
           ),
         );
         continue;
@@ -1616,6 +1639,22 @@ export function formatScaffoldFailureResolution(
     `ERROR: Scaffolded ${scaffolded}/${agentsTotal} agents. ${fail} failed.`,
   );
   lines.push("");
+  // #2781: the 0700/privilege-escalation guidance below is only the right
+  // diagnosis when at least one failure actually IS a permission failure.
+  // Printing it for, e.g., litellm/vault failures misdirected operators at
+  // sudo when the problem was elsewhere. Non-permission failures get a
+  // generic pointer at the per-agent error lines instead.
+  const hasPermissionFailure = failures.some((f) =>
+    /EACCES|EPERM|permission denied/i.test(f.message),
+  );
+  if (!hasPermissionFailure) {
+    lines.push(
+      `${fail} agent(s) failed to scaffold — see the per-agent error lines above`,
+    );
+    lines.push("for the specific cause(s).");
+    lines.push("");
+    return lines.join("\n");
+  }
   lines.push(
     "Per-agent state dirs are mode 0700 owned by per-agent UIDs (the v0.7+",
   );

--- a/src/host-control/reconcile-rollback-output.test.ts
+++ b/src/host-control/reconcile-rollback-output.test.ts
@@ -1,0 +1,105 @@
+/**
+ * #2781 — the `E_RECONCILE_FAILED_ROLLED_BACK` response must CARRY the failed
+ * reconcile's stdout/stderr tails, mirroring the success path's
+ * stdout_tail/stderr_tail fields. Pre-fix, `reconcileFailedRolledBack`
+ * discarded the child's output entirely, so a rolled-back config edit
+ * surfaced only "reconcile exit 1" with zero diagnostics — the operator had
+ * nothing to identify the underlying apply failure with.
+ *
+ * `reconcileFailedRolledBack` is a private method that touches no server
+ * state (pure response construction from its arguments), so we exercise it
+ * directly on a bare instance via a cast — same pattern as other
+ * private-method unit tests in this repo.
+ */
+
+import { describe, it, expect } from "vitest";
+import { HostdServer, type ServerOptions } from "./server.js";
+import type { HostdRequest, HostdResponse } from "./protocol.js";
+import type { SocketIdentity } from "./peercred.js";
+
+type ConfigProposeReq = Extract<HostdRequest, { op: "config_propose_edit" }>;
+
+const req: ConfigProposeReq = {
+  v: 1,
+  request_id: "req-2781",
+  op: "config_propose_edit",
+  args: {
+    unified_diff: "@@ -1 +1 @@\n-a\n+b\n",
+    reason: "test",
+    target_path: "/state/config/switchroom.yaml",
+  },
+} as ConfigProposeReq;
+
+const caller: SocketIdentity = { kind: "agent", name: "overlord" } as SocketIdentity;
+
+type RollbackOutput = {
+  primary: { stdout: string; stderr: string };
+  recovery?: { stdout: string; stderr: string; exit_code: number };
+};
+
+function invoke(output?: RollbackOutput): HostdResponse {
+  const server = new HostdServer({} as unknown as ServerOptions);
+  return (
+    server as unknown as {
+      reconcileFailedRolledBack: (
+        detail: string,
+        req: ConfigProposeReq,
+        caller: SocketIdentity,
+        started: number,
+        output?: RollbackOutput,
+      ) => HostdResponse;
+    }
+  ).reconcileFailedRolledBack(
+    "reconcile exit 1; rolled back successfully",
+    req,
+    caller,
+    Date.now(),
+    output,
+  );
+}
+
+describe("reconcileFailedRolledBack — carries reconcile output (#2781)", () => {
+  it("threads the failed reconcile's stdout/stderr into the response tails", () => {
+    const res = invoke({
+      primary: {
+        stdout: "Scaffolded 0/12 agents. 12 failed.",
+        stderr: "x litellm/overlord: vault-broker unreachable",
+      },
+      recovery: { stdout: "", stderr: "", exit_code: 0 },
+    });
+    expect(res.result).toBe("error");
+    expect(res.error).toBe(
+      "E_RECONCILE_FAILED_ROLLED_BACK: reconcile exit 1; rolled back successfully",
+    );
+    expect(res.stdout_tail).toContain("Scaffolded 0/12 agents");
+    expect(res.stderr_tail).toContain("vault-broker unreachable");
+    // Recovery succeeded → its (empty) output is not appended.
+    expect(res.stdout_tail).not.toContain("recovery reconcile");
+  });
+
+  it("appends the recovery reconcile's output when the recovery ALSO failed", () => {
+    const res = invoke({
+      primary: { stdout: "primary out", stderr: "primary err" },
+      recovery: {
+        stdout: "recovery out",
+        stderr: "recovery err",
+        exit_code: 1,
+      },
+    });
+    expect(res.stdout_tail).toContain("primary out");
+    expect(res.stdout_tail).toContain("--- recovery reconcile stdout ---");
+    expect(res.stdout_tail).toContain("recovery out");
+    expect(res.stderr_tail).toContain("primary err");
+    expect(res.stderr_tail).toContain("--- recovery reconcile stderr ---");
+    expect(res.stderr_tail).toContain("recovery err");
+  });
+
+  it("omits the tails when no output was captured (write-failed callsites)", () => {
+    const res = invoke(undefined);
+    expect(res.result).toBe("error");
+    expect(res.stdout_tail).toBeUndefined();
+    expect(res.stderr_tail).toBeUndefined();
+    // Legacy string preserved verbatim for audit-reader decoders.
+    expect(res.error).toMatch(/^E_RECONCILE_FAILED_ROLLED_BACK: /);
+  });
+});

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -2086,15 +2086,19 @@ export class HostdServer {
         recRes2.exit_code === 0
           ? "rolled back successfully"
           : `rolled back but recovery reconcile also failed (exit ${recRes2.exit_code})`;
+      // #2781: carry the failed reconcile's output into the audit row —
+      // pre-fix the rolled-back path discarded stdout/stderr entirely,
+      // so "reconcile exit 1" gave the operator nothing to diagnose with.
       await approval.finalize({
         outcome: "reconcile_failed_rolled_back",
-        detail: recoveryNote,
+        detail: `${recoveryNote}; reconcile stderr: ${tail(recRes.stderr, 512) || "(empty)"}`,
       });
       return this.reconcileFailedRolledBack(
         `reconcile exit ${recRes.exit_code}; ${recoveryNote}`,
         req,
         caller,
         started,
+        { primary: recRes, recovery: recRes2 },
       );
     } finally {
       release();
@@ -2114,6 +2118,15 @@ export class HostdServer {
     req: Extract<HostdRequest, { op: "config_propose_edit" }>,
     caller: SocketIdentity,
     started: number,
+    // #2781: captured output of the failed reconcile (and the recovery
+    // reconcile, when one ran). Pre-fix this path DISCARDED the child's
+    // stdout/stderr while the success path returned stdout_tail/stderr_tail
+    // — so a rolled-back edit surfaced only "reconcile exit 1" with zero
+    // diagnostics. Mirror the success path's tail fields here.
+    output?: {
+      primary: { stdout: string; stderr: string };
+      recovery?: { stdout: string; stderr: string; exit_code: number };
+    },
   ): HostdResponse {
     const legacy = `E_RECONCILE_FAILED_ROLLED_BACK: ${detail}`;
     const built = err(
@@ -2128,7 +2141,20 @@ export class HostdServer {
       .caller(caller.kind === "agent" ? "agent" : "operator")
       .agentName(caller.kind === "agent" ? caller.name : undefined)
       .build(req.request_id, Date.now() - started);
-    return { ...built, error: legacy };
+    const resp: HostdResponse = { ...built, error: legacy };
+    if (output) {
+      const recoveryStdout =
+        output.recovery && output.recovery.exit_code !== 0
+          ? `\n--- recovery reconcile stdout ---\n${output.recovery.stdout}`
+          : "";
+      const recoveryStderr =
+        output.recovery && output.recovery.exit_code !== 0
+          ? `\n--- recovery reconcile stderr ---\n${output.recovery.stderr}`
+          : "";
+      resp.stdout_tail = tail(output.primary.stdout + recoveryStdout);
+      resp.stderr_tail = tail(output.primary.stderr + recoveryStderr);
+    }
+    return resp;
   }
 
   /** Serializes concurrent config_propose_edit apply phases. */

--- a/src/litellm/provision-apply-e2e.test.ts
+++ b/src/litellm/provision-apply-e2e.test.ts
@@ -235,8 +235,9 @@ describe("provisionLiteLLMKeys — real broker e2e (blocker-1 seam)", () => {
   // peer, so `getViaBrokerStructured` returns `denied` for ANY key regardless
   // of presence (peer-identity ACL, not a key lookup) — same limitation the
   // file-header note calls out for operator-mode reads. The null-passphrase
-  // branch deliberately treats a non-`ok` probe (not_found / denied /
-  // unreachable) as "not known-good → surface it", which is the conservative,
+  // branch deliberately treats a not_found / denied probe as "not known-good
+  // → surface it" (an `unreachable` probe degrades to a WARNING since #2781 —
+  // hostd's container has no broker socket by construction), the conservative,
   // LOUD behavior the fix requires. The unit-level split (ok → quiet,
   // else → surfaced) is asserted where the broker read is stubbable; here we
   // pin the load-bearing half: a genuinely-new agent is surfaced, not skipped


### PR DESCRIPTION
## The failure chain

`switchroom apply` inside the hostd container has **no vault-broker socket mounted, by construction**. Yet litellm per-agent key provisioning recorded broker-unreachable as a per-agent scaffold failure, so every in-container apply reported `Scaffolded 0/12 agents. 12 failed.` and exited 1. Consequence: hostd's `config_propose_edit` post-apply reconcile **always failed and rolled back**, so Telegram "Always allow" persists never saved. Worse, the rolled-back error path discarded the reconcile's stdout/stderr, and the apply failure epilogue misdiagnosed everything as the 0700 permission problem.

## Fixes (src/cli/apply.ts, src/host-control/server.ts)

1. **Graceful degrade** — `provisionLiteLLMKeys` now treats a broker-unreachable probe as a WARNING (mirrors the "Hindsight unreachable — skipping bank creation" path): the agent keeps its previous routing env, scaffold counts as success, apply exits 0 if nothing else failed. Applied to both the main provisioning loop and the null-passphrase probe path. Genuine provisioning errors (unresolvable admin_key ref, vault write denial, not_found with no passphrase) remain failures.
2. **Diagnostics** — `reconcileFailedRolledBack` now carries `stdout_tail`/`stderr_tail` of the failed reconcile (plus the recovery reconcile when it also failed) in the response, mirroring the success path, and appends a bounded stderr excerpt to the finalize audit detail.
3. **Epilogue fix** — `formatScaffoldFailureResolution` only prints the 0700/privilege-escalation guidance when at least one failure matches EACCES/EPERM/permission-denied; otherwise a generic "N failed; see the per-agent error lines above" pointer.

## Tests

- `src/cli/apply-litellm-provision.test.ts` (new, vitest): unreachable → warning not failure (both paths); null-passphrase + not_found stays a failure; bad admin_key ref stays a failure; epilogue gating both ways.
- `src/host-control/reconcile-rollback-output.test.ts` (new, vitest): tails threaded, recovery output appended only when recovery failed, tails omitted at write-failed callsites, legacy error string preserved.
- `bun test src/litellm/provision-apply-e2e.test.ts`: 4 pass (real-broker e2e unaffected).
- `tsc --noEmit` clean; `vitest run src/host-control` 52 pass. Pre-existing `apply.test.ts` EROFS failures in this environment reproduce identically on clean main (unrelated).

Closes #2781

🤖 Generated with [Claude Code](https://claude.com/claude-code)