### PR TITLE
fix(telegram): step-line timer shows the current step's own elapsed (gated at 10s)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -114,7 +114,7 @@ import { renderVaultRequestAccessCard } from './vault-request-access-card.js'
 import { createPermissionCardStore } from './permission-card-store.js'
 import { pickRecoveredPermissionOrigin } from './permission-card-origin.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
-import { appendActivityLabel, clipNarrative, renderActivityFeedWithNested, type SessionActivityHeader } from '../tool-activity-summary.js'
+import { appendActivityLabel, clipNarrative, renderActivityFeedWithNested, formatStepSuffix, type SessionActivityHeader } from '../tool-activity-summary.js'
 import { REPLY_TOOLS, isDraftOfReply } from '../narrative-dedup.js'
 import { toolLabel } from '../tool-labels.js'
 import { createTypingWrapper } from '../typing-wrap.js'
@@ -1945,13 +1945,8 @@ const POST_ANSWER_LIVENESS_STALE_MS = parsePostAnswerLivenessMs(
   process.env.SWITCHROOM_POST_ANSWER_LIVENESS_STALE_MS,
 ) || 30_000
 
-/** Compact mm/ss-ish elapsed for the live feed suffix: "18s", "1m05s". */
-function formatFeedElapsed(ms: number): string {
-  const s = Math.floor(ms / 1000)
-  if (s < 60) return `${s}s`
-  const m = Math.floor(s / 60)
-  return `${m}m${(s % 60).toString().padStart(2, '0')}s`
-}
+// Live-feed step suffixes render via `formatStepSuffix` (tool-activity-summary):
+// the CURRENT step's own elapsed, shown only past STEP_TIMER_MIN_MS (10 s).
 
 /**
  * Authoritative "is a turn in flight?" for every gate that previously
@@ -12177,7 +12172,10 @@ function openLivenessFeedIfDue(turn: CurrentTurn): void {
   const livenessHeader: SessionActivityHeader = {
     label: 'Agent', elapsedMs: age, toolCount: turn.labeledToolCount, state: 'running',
   }
-  const rendered = renderActivityFeedWithNested(lines, [], false, ` · ${formatFeedElapsed(age)}`, undefined, livenessHeader)
+  // Liveness card is a single "step" whose start is the turn start, so `age`
+  // IS the step's own elapsed. formatStepSuffix keeps the `→` line timer-free
+  // until the step has run ≥ STEP_TIMER_MIN_MS (header total still shows).
+  const rendered = renderActivityFeedWithNested(lines, [], false, formatStepSuffix(age), undefined, livenessHeader)
   if (rendered == null) return
   turn.activityPendingRender = rendered
   const ea = emissionAuthorityFor(turn)
@@ -12297,8 +12295,10 @@ function feedHeartbeatTick(): void {
       label: 'Agent', elapsedMs: age, toolCount: turn.labeledToolCount, state: 'running',
     }
     const lines = turn.mirrorLines.length > 0 ? turn.mirrorLines : ['Working in background…']
+    // `subagentAt` is the worker's last ADVANCE — the current step's start —
+    // so this suffix is already per-step. formatStepSuffix adds the 10 s gate.
     const elapsed = Date.now() - subagentAt
-    const rendered = renderActivityFeedWithNested(lines, [], false, ` · ${formatFeedElapsed(elapsed)}`, undefined, livenessHeader)
+    const rendered = renderActivityFeedWithNested(lines, [], false, formatStepSuffix(elapsed), undefined, livenessHeader)
     if (rendered == null) return
     turn.activityPendingRender = rendered
     const ea = emissionAuthorityFor(turn)
@@ -12339,7 +12339,10 @@ function feedHeartbeatTick(): void {
   if (turn.lastToolLabelAt == null) return // feed not driven by a labelled step
   const elapsed = Date.now() - turn.lastToolLabelAt
   if (elapsed < FEED_HEARTBEAT_MIN_STALE_MS) return // step is fresh; feed advancing normally
-  const rendered = composeTurnActivity(turn, false, ` · ${formatFeedElapsed(elapsed)}`)
+  // `lastToolLabelAt` resets on every new tool label, so `elapsed` is the
+  // CURRENT step's own run time. formatStepSuffix holds the timer back until
+  // the step passes STEP_TIMER_MIN_MS (10 s) — header total is unaffected.
+  const rendered = composeTurnActivity(turn, false, formatStepSuffix(elapsed))
   if (rendered == null) return
   turn.activityPendingRender = rendered
   const ea = emissionAuthorityFor(turn)

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -8,6 +8,8 @@ import {
   renderActivityFeedWithNested,
   renderActivityHeader,
   formatFeedElapsed,
+  formatStepSuffix,
+  STEP_TIMER_MIN_MS,
   type SessionActivityHeader,
 } from "../tool-activity-summary.js";
 import { STATUS_ROLLING_LINES, STATUS_LINE_MAX } from "../status-no-truncate.js";
@@ -779,6 +781,20 @@ describe("formatFeedElapsed — elapsed formatter", () => {
     expect(formatFeedElapsed(60_000)).toBe("1m00s");
     expect(formatFeedElapsed(65_000)).toBe("1m05s");
     expect(formatFeedElapsed(125_000)).toBe("2m05s");
+  });
+});
+
+describe("formatStepSuffix — per-step suffix with 10s gate", () => {
+  it("returns empty string while the step is younger than STEP_TIMER_MIN_MS", () => {
+    expect(formatStepSuffix(0)).toBe("");
+    expect(formatStepSuffix(9_999)).toBe("");
+    expect(formatStepSuffix(STEP_TIMER_MIN_MS - 1)).toBe("");
+  });
+
+  it("renders ` · <elapsed>` once the step reaches the gate", () => {
+    expect(formatStepSuffix(STEP_TIMER_MIN_MS)).toBe(" · 10s");
+    expect(formatStepSuffix(13_000)).toBe(" · 13s");
+    expect(formatStepSuffix(65_000)).toBe(" · 1m05s");
   });
 });
 

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -637,7 +637,7 @@ describe('rolling window — createWorkerActivityFeed narrative accumulation', (
 // ─── Worker heartbeat (option a — suffix-only, never opens a new message) ─────
 
 describe('createWorkerActivityFeed — heartbeat', () => {
-  it('(i) a tick fires a re-render with a climbing · Ns suffix on a stale worker', async () => {
+  it('(i) a tick fires a re-render with a climbing · Ns suffix showing the current step\'s OWN elapsed', async () => {
     const bot = makeFakeBot()
     let clock = 10_000
     const feed = createWorkerActivityFeed({
@@ -649,22 +649,50 @@ describe('createWorkerActivityFeed — heartbeat', () => {
       setInterval: () => 1,
       clearInterval: () => {},
     })
-    // First paint at elapsed 0 (firstPaintMin default 8000 — use 9000).
+    // First paint at elapsed 0 (firstPaintMin default 8000 — use 9000). The
+    // narrative line 'pulling data' lands here, so the current step starts now.
     clock = 19_000
     await feed.update('w1', 'chat', view({ elapsedMs: 9000, latestSummary: 'pulling data' }))
     expect(bot.sent).toHaveLength(1)
-    const dispatchAt = clock - 9000
+    const stepStart = clock // step began when the '→' line first appeared
 
-    // Advance past the staleness window so the heartbeat ticks.
-    clock = 26_000 // lastEditAt(19000) + 7000 ≥ heartbeatTickMs(6000) and ≥ minEditInterval
+    // Advance well past the per-step 10s gate so the heartbeat renders a suffix.
+    clock = 32_000 // step is now 13s old; lastEditAt(19000)+13000 ≥ heartbeatTickMs
     feed.heartbeatTick()
-    await feed.update('w1', 'chat', view({ elapsedMs: 16_000, latestSummary: 'pulling data' })).catch(() => {})
+    await feed.update('w1', 'chat', view({ elapsedMs: 22_000, latestSummary: 'pulling data' })).catch(() => {})
     // Drain the chain.
-    await feed.update('w1', 'chat', view({ elapsedMs: 16_000, latestSummary: 'pulling data' }))
+    await feed.update('w1', 'chat', view({ elapsedMs: 22_000, latestSummary: 'pulling data' }))
     const edit1 = bot.edits.find((e) => /· \d+s\*\*/.test(e.text))
     expect(edit1).toBeDefined()
-    // The suffix reflects the LIVE elapsed (now - dispatchAt), not the stale view.
-    expect(edit1!.text).toContain(`· ${Math.floor((26_000 - dispatchAt) / 1000)}s`)
+    // The step suffix reflects the STEP's OWN elapsed (now - stepStart), NOT
+    // the worker total — the header already carries the total.
+    expect(edit1!.text).toContain(`· ${Math.floor((32_000 - stepStart) / 1000)}s`)
+  })
+
+  it('(i-a) suppresses the step suffix while the current step is younger than the 10s gate', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      minEditIntervalMs: 2500,
+      heartbeatTickMs: 6000,
+      setInterval: () => 1,
+      clearInterval: () => {},
+    })
+    // Step begins here.
+    clock = 19_000
+    await feed.update('w1', 'chat', view({ elapsedMs: 9000, latestSummary: 'pulling data' }))
+    expect(bot.sent).toHaveLength(1)
+
+    // Heartbeat only 7s into the step — under STEP_TIMER_MIN_MS (10s), so no
+    // `· Ns` suffix on the '→' line yet (the header total still climbs).
+    clock = 26_000
+    feed.heartbeatTick()
+    await feed.update('w1', 'chat', view({ elapsedMs: 16_000, latestSummary: 'pulling data' })).catch(() => {})
+    await feed.update('w1', 'chat', view({ elapsedMs: 16_000, latestSummary: 'pulling data' }))
+    const stepSuffixEdit = bot.edits.find((e) => /· \d+s\*\*/.test(e.text))
+    expect(stepSuffixEdit).toBeUndefined()
   })
 
   it('(i-b) heartbeat repaint keeps the header master elapsed >= the step timer (same clock anchor)', async () => {

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -192,6 +192,25 @@ export function formatFeedElapsed(ms: number): string {
   return `${m}m${(s % 60).toString().padStart(2, '0')}s`
 }
 
+/**
+ * Minimum time the CURRENT step must have been running before its own
+ * `· <elapsed>` suffix appears on the `→` line. Under this, no suffix — a
+ * fresh step reads cleaner without a timer, and the header total already
+ * carries the turn/worker elapsed.
+ */
+export const STEP_TIMER_MIN_MS = 10_000
+
+/**
+ * Live-suffix for the in-progress step line: the STEP's OWN elapsed (time
+ * since that step started — NOT the turn/worker total, which lives in the
+ * header). Empty string until the step has run ≥ STEP_TIMER_MIN_MS, so the
+ * suffix never duplicates the header total on a young step.
+ */
+export function formatStepSuffix(stepElapsedMs: number): string {
+  if (stepElapsedMs < STEP_TIMER_MIN_MS) return ''
+  return ` · ${formatFeedElapsed(stepElapsedMs)}`
+}
+
 // ─── Truncation pipeline (the single correctness-critical primitive) ────────
 //
 // Per RAW line, in this EXACT order:

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -38,7 +38,7 @@ import {
   truncate,
 } from './card-format.js'
 import { STATUS_ROLLING_LINES } from './status-no-truncate.js'
-import { renderStatusCard, formatFeedElapsed } from './tool-activity-summary.js'
+import { renderStatusCard, formatStepSuffix } from './tool-activity-summary.js'
 
 /** Worker-activity feed is ON by default; an operator opts out with
  *  SWITCHROOM_WORKER_ACTIVITY_FEED=0. */
@@ -226,6 +226,13 @@ interface WorkerHandle {
    * `· Ns` suffix climbs even when no fresh view arrives.
    */
   dispatchAtMs: number | null
+  /**
+   * Wall-clock ms the CURRENT step started — stamped whenever a NEW narrative
+   * line lands (the `→` line changes). The heartbeat's step suffix shows the
+   * step's OWN elapsed from this anchor (not the worker total, which the
+   * header already carries), and only once past STEP_TIMER_MIN_MS.
+   */
+  stepStartedAtMs: number | null
 }
 
 const COOLDOWN_JITTER_MS = 500
@@ -321,6 +328,9 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     // same step re-appears once the earlier copy scrolls out of the window.
     if (h.narrative.includes(line)) return
     h.narrative.push(line)
+    // The `→` current-step line just CHANGED — reset the per-step timer so the
+    // heartbeat's `· Ns` suffix measures THIS step, not the whole worker run.
+    h.stepStartedAtMs = nowFn()
     // Rolling window — keep only the last STATUS_ROLLING_LINES in memory. The
     // render shows exactly those lines (clipped per-line by the unified pipeline);
     // fitCardToBudget is the wire-limit backstop.
@@ -470,11 +480,17 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       if (now - h.lastEditAt < minEditInterval) continue
       const stale = now - h.lastEditAt >= heartbeatTickMs
       if (!stale) continue
-      const liveSuffix = ' · ' + formatFeedElapsed(liveElapsed)
+      // Per-step suffix: the CURRENT step's own elapsed (since the `→` line
+      // last changed), never the worker total — the header already shows the
+      // total, and repeating it on the step line was the Ken-observed dupe.
+      // Under STEP_TIMER_MIN_MS formatStepSuffix returns '' (no timer yet);
+      // the header elapsed still climbs via the refreshed view below.
+      const stepElapsed = h.stepStartedAtMs != null ? now - h.stepStartedAtMs : liveElapsed
+      const liveSuffix = formatStepSuffix(stepElapsed)
       // Re-render THROUGH the chain + doUpdate path — never editMessageText directly.
       //
-      // CLOCK-ANCHOR PARITY: refresh the view's elapsedMs to the SAME
-      // `liveElapsed` the step suffix shows. The header renders
+      // CLOCK-ANCHOR PARITY: refresh the view's elapsedMs to the same `now`
+      // anchor the step suffix uses. The header renders
       // `view.elapsedMs`; passing the stale lastView froze the header at the
       // last watcher event while the `· Ns` suffix kept ticking, so the
       // current step's timer could read MORE than the card's master elapsed
@@ -521,6 +537,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
           chain: Promise.resolve(),
           lastView: null,
           dispatchAtMs: null,
+          stepStartedAtMs: null,
         }
         handles.set(agentId, h)
       }


### PR DESCRIPTION
## What

The progress card was showing the turn/worker **total** elapsed twice — in the header *and* repeated on the `→` current-step line. Ken's screenshot from a worker card: header `7m20s · 25 tools` and bottom line `→ Now the empty-catch swallowing… · 7m20s` (same 7m20s).

Requested behaviour:
- **Header timer** — total turn/worker elapsed — unchanged.
- **Step line timer** — the CURRENT step's OWN elapsed (time since that step started), and only once the step has been running longer than 10s. Under 10s: no timer on the step line.

## How

- New `formatStepSuffix(stepElapsedMs)` in `tool-activity-summary.ts`: renders the step's own elapsed, returns `''` under `STEP_TIMER_MIN_MS` (10s). Single source of truth for the step suffix.
- **Worker feed** (`worker-activity-feed.ts`): stamp `stepStartedAtMs` whenever the `→` narrative line changes; the heartbeat suffix measures from that anchor instead of the worker total.
- **Gateway foreground paths** (`gateway.ts`): liveness card, subagent heartbeat, and session-tail heartbeat all route their per-step suffix through `formatStepSuffix`. The gateway-local `formatFeedElapsed` duplicate is removed (now imported from the shared module).
- Both render paths covered (foreground `renderStatusCard` session-tail + worker activity feed), per the #2782 unification.

## Tests

- Worker feed: per-step suffix shows the step's own elapsed; suffix suppressed while the step is younger than the 10s gate.
- Direct `formatStepSuffix` boundary coverage (gate at exactly 10s, mm:ss formatting).
- `tsc --noEmit` + full `npm run lint` clean.

## Verdict

- **Vision:** Visibility — the step timer now reports accurate per-step timing instead of a duplicated total.
- **Job:** progress-card visibility.
- **Principles:** docs/defaults/consistency all hold (behaviour-consistent across both card render paths).
- **Invariants:** none crossed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)