### PR TITLE
durability: rebuild stale handoff briefing after a hard crash (#2790)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -657,8 +657,24 @@ mkdir -p "$TELEGRAM_STATE_DIR" 2>/dev/null || true
 # .handoff-briefing.md and merged alongside (or instead of) .handoff.md.
 HANDOFF_FILE="{{agentDir}}/.handoff.md"
 HANDOFF_BRIEFING_FILE="{{agentDir}}/.handoff-briefing.md"
+# Decide whether the on-disk briefing is stale and must be rebuilt (#2790).
+# A clean shutdown leaves a non-empty .handoff.md; a *later* hard crash never
+# fires the Stop hook, so that stale briefing would otherwise be re-injected
+# — hiding the crashed session's turns and reorienting the agent from old
+# context. Rebuild when .handoff.md is empty OR when the newest session JSONL
+# is newer than .handoff.md (i.e. a session ran after the briefing was written).
+_LATEST_JSONL=$(_find_latest_jsonl "$CLAUDE_CONFIG_DIR/projects")
+_HANDOFF_STALE=0
 if [ ! -s "$HANDOFF_FILE" ]; then
-  _LATEST_JSONL=$(_find_latest_jsonl "$CLAUDE_CONFIG_DIR/projects")
+  _HANDOFF_STALE=1
+elif [ -n "$_LATEST_JSONL" ]; then
+  _JSONL_MOD=$(_stat_mtime "$_LATEST_JSONL")
+  _HANDOFF_MOD=$(_stat_mtime "$HANDOFF_FILE")
+  if [ "$_JSONL_MOD" -gt "$_HANDOFF_MOD" ]; then
+    _HANDOFF_STALE=1
+  fi
+fi
+if [ "$_HANDOFF_STALE" = "1" ]; then
   if [ -n "$_LATEST_JSONL" ]; then
     _LAST_MOD=$(_stat_mtime "$_LATEST_JSONL")
     _NOW=$(date +%s)
@@ -704,6 +720,11 @@ $_HANDOFF_CONTENT"
     APPEND_PROMPT="$_HANDOFF_CONTENT"
   fi
 fi
+# Consume the briefing sidecars once injected (#2790). Leaving them on disk
+# lets a later hard crash (which never fires the Stop hook to refresh them)
+# re-serve this now-stale briefing on the next boot. Removing them means the
+# staleness guard above starts from a clean slate every boot.
+rm -f "$HANDOFF_BRIEFING_FILE" "$HANDOFF_FILE" 2>/dev/null || true
 {{else}}
 APPEND_PROMPT={{#if systemPromptAppendShellQuoted}}{{{systemPromptAppendShellQuoted}}}{{else}}""{{/if}}
 {{/if}}

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.16.1";
-export const COMMIT_SHA: string | null = "a42215da";
-export const COMMIT_DATE: string | null = "2026-06-26T15:17:44+10:00";
-export const LATEST_PR: number | null = 2581;
+export const VERSION: string = "0.16.49";
+export const COMMIT_SHA: string | null = "de33dcbf";
+export const COMMIT_DATE: string | null = "2026-07-05T09:57:29+10:00";
+export const LATEST_PR: number | null = 2782;
 export const COMMITS_AHEAD_OF_TAG: number | null = 0;

--- a/tests/handoff-briefing.test.ts
+++ b/tests/handoff-briefing.test.ts
@@ -170,6 +170,27 @@ describe("scaffold: start.sh resume mode behaviours", () => {
     const forceFreshBlock = startSh.slice(forceFreshIdx);
     expect(forceFreshBlock).toContain('CONTINUE_FLAG=""');
   });
+
+  it("rebuilds a stale handoff briefing and consumes the sidecars (#2790)", () => {
+    // A clean shutdown leaves a non-empty .handoff.md; a later hard crash never
+    // refreshes it. The boot gate must therefore rebuild when the newest session
+    // JSONL is newer than .handoff.md — not merely when .handoff.md is empty —
+    // and must consume the sidecars after injection so they can't be re-served.
+    const result = scaffoldAgent(
+      "stale-handoff-test",
+      makeAgentConfig(),
+      tmpDir,
+      telegramConfig,
+    );
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    // Staleness guard: compare JSONL mtime against .handoff.md mtime, not just -s.
+    expect(startSh).toContain("_HANDOFF_STALE=1");
+    expect(startSh).toMatch(/_JSONL_MOD.*-gt.*_HANDOFF_MOD|"\$_JSONL_MOD" -gt "\$_HANDOFF_MOD"/);
+    // The old empty-only gate must be gone.
+    expect(startSh).not.toContain('if [ ! -s "$HANDOFF_FILE" ]; then\n  _LATEST_JSONL=');
+    // Sidecars are consumed after injection so a later crash can't re-serve them.
+    expect(startSh).toContain('rm -f "$HANDOFF_BRIEFING_FILE" "$HANDOFF_FILE"');
+  });
 });
 
 // ── Briefing assembler script ───────────────────────────────────────────────────


### PR DESCRIPTION
## JTBD

Serves **always-on / session-continuity across restarts** (`reference/jobs/`, resume-mode handoff, RFC #1620 / #362). Advances the **always-on** vision outcome: an agent must reorient from its *most recent* state after any restart — including a hard crash — not from a stale snapshot.

## Problem

The boot gate in `profiles/_base/start.sh.hbs` only rebuilt the handoff briefing when `.handoff.md` was empty (`if [ ! -s "$HANDOFF_FILE" ]`). A clean shutdown leaves a **non-empty** `.handoff.md`; a subsequent hard crash never fires the Stop hook to refresh it, so the next boot re-injected the *previous clean session's* tail and hid the crashed session's turns. The resumed agent reoriented from stale context and could lose in-flight work.

## Fix

- **Staleness guard:** treat the briefing as stale (and rebuild via `switchroom handoff` + `handoff-briefing.sh`) when the newest session JSONL is newer than `.handoff.md`, not merely when `.handoff.md` is empty.
- **Consume the sidecars:** `rm -f` `.handoff.md` and `.handoff-briefing.md` after injection so a later crash can't re-serve a now-stale briefing on the next boot.
- Adds a scaffold-render regression test in `tests/handoff-briefing.test.ts`.

`SWITCHROOM_SESSION_MODE` detection is unaffected — it runs before injection/consumption.

## Verification

`npm run lint` clean, `npm test` green (vitest + bun).

Closes #2790

Co-authored-by: Claude <noreply@anthropic.com>