### PR TITLE
fix(telegram): composer-tolerant enqueue ack — no duplicate turns (#2786)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -12599,6 +12599,13 @@ function handleSessionEvent(ev: SessionEvent): void {
             deliveryQueue,
             chatKey(ev.chatId, ev.threadId != null ? Number(ev.threadId) : null),
             ev.messageId,
+            // #2786 — pass the raw enqueue envelope so the ack survives the
+            // composer merging/reordering inbound wrappers (the single
+            // re-parsed `ev.messageId` can then belong to a sibling, not our
+            // tracked message). The tolerant match scans all ids in this
+            // content; a synthetic-source turn still lacks the user id, so the
+            // cross-source false-ack guard holds.
+            ev.rawContent,
           )
         }
         // PR3b-cutover: feed the authoritative turn-start to the delivery

--- a/telegram-plugin/gateway/inbound-delivery-confirm.ts
+++ b/telegram-plugin/gateway/inbound-delivery-confirm.ts
@@ -73,6 +73,28 @@ export function trackDelivery<M>(
 }
 
 /**
+ * Extract every `message_id="…"` value carried in a rendered enqueue envelope.
+ *
+ * The `enqueue` session-event's message id (`enqueueMessageId`) is a SINGLE
+ * value re-parsed from the transcript by `parseChannelMeta`, which grabs the
+ * FIRST `message_id` it finds. When claude's composer MERGES several inbound
+ * envelopes into one turn (or reformats the wrapper), that first-parsed id can
+ * be a sibling's — not the tracked message's — even though the tracked
+ * message's envelope is right there in the same content. Strict equality then
+ * mis-concludes "never delivered" and the sweep re-delivers a turn that is
+ * already running (#2786). Scanning ALL ids in the raw content makes the ack
+ * tolerant of that reorder/merge: the tracked id is present iff its envelope
+ * was delivered, regardless of parse order.
+ */
+export function extractEnqueueMessageIds(content: string): string[] {
+  const ids: string[] = []
+  const re = /message_id="([^"]+)"/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(content)) != null) ids.push(m[1]!)
+  return ids
+}
+
+/**
  * Ack a delivery — call from the `enqueue` session-event (claude started a
  * turn). `enqueue` fires for EVERY turn start regardless of source (user
  * inbound, cron, subagent-handback, vault-resume, restart-marker), so acking
@@ -80,21 +102,36 @@ export function trackDelivery<M>(
  * silently drop — a real user message still waiting under the same key. So
  * ack ONLY when the enqueue's source message id matches the tracked one.
  *
- * Matching rule: if we recorded a messageId for the pending entry, require the
- * enqueue's `enqueueMessageId` to equal it. If we never recorded one (legacy /
- * defensive null), fall back to key-only ack. Returns true if an entry was
- * cleared.
+ * Matching rule (composer-tolerant, #2786): if we recorded a messageId for the
+ * pending entry, ack when EITHER
+ *   - the single re-parsed `enqueueMessageId` equals it (the fast path), OR
+ *   - the tracked id appears among the message ids carried in `enqueueContent`
+ *     (the tolerant path — survives the composer merging/reordering envelopes
+ *     so the first-parsed id belongs to a sibling, not the tracked message).
+ * Matching on the exact `message_id="…"` token — not a loose substring —
+ * preserves the cross-source false-ack guard: a synthetic-source turn (cron /
+ * resume / vault) never carries the real user message's id, so it still can't
+ * clear a user message that is genuinely still waiting to land. If we never
+ * recorded a messageId (legacy / defensive null), fall back to key-only ack.
+ * Returns true if an entry was cleared.
  */
 export function ackDelivery<M>(
   q: DeliveryQueue<M>,
   key: string,
   enqueueMessageId: string | null = null,
+  enqueueContent: string | null = null,
 ): boolean {
   const entry = q.pending.get(key)
   if (!entry) return false
-  // A different message started this turn — don't ack ours (it may still be
-  // waiting to land; the sweep will re-deliver it if it stranded).
-  if (entry.messageId != null && entry.messageId !== enqueueMessageId) return false
+  if (entry.messageId != null) {
+    const matches =
+      entry.messageId === enqueueMessageId ||
+      (enqueueContent != null &&
+        extractEnqueueMessageIds(enqueueContent).includes(entry.messageId))
+    // A different message started this turn — don't ack ours (it may still be
+    // waiting to land; the sweep will re-deliver it if it stranded).
+    if (!matches) return false
+  }
   q.pending.delete(key)
   return true
 }

--- a/telegram-plugin/gateway/inbound-delivery-confirm.ts
+++ b/telegram-plugin/gateway/inbound-delivery-confirm.ts
@@ -85,10 +85,18 @@ export function trackDelivery<M>(
  * already running (#2786). Scanning ALL ids in the raw content makes the ack
  * tolerant of that reorder/merge: the tracked id is present iff its envelope
  * was delivered, regardless of parse order.
+ *
+ * The regex is LEFT-ANCHORED on an attribute boundary (start-of-string or a
+ * whitespace/quote before the name) so it matches ONLY the real `message_id`
+ * attribute — never a same-suffix sibling like `target_message_id`,
+ * `reply_to_message_id`, `original_message_id`, or `card_message_id`. This is
+ * what makes the tolerant-path match safe on a never-drop code path: a
+ * substring collision on some other `*_message_id` attribute cannot false-ack
+ * (and thus silently drop) a real user message still waiting to land.
  */
 export function extractEnqueueMessageIds(content: string): string[] {
   const ids: string[] = []
-  const re = /message_id="([^"]+)"/g
+  const re = /(?:^|[\s"'])message_id="([^"]+)"/g
   let m: RegExpExecArray | null
   while ((m = re.exec(content)) != null) ids.push(m[1]!)
   return ids

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -158,9 +158,14 @@ function parseChannelMeta(content: string): {
   messageId: string | null
   threadId: string | null
 } {
-  // Look for `chat_id="..."` etc in the channel XML tag
+  // Look for `chat_id="..."` etc in the channel XML tag. LEFT-ANCHOR on an
+  // attribute boundary (start-of-string or a whitespace/quote before the name)
+  // so `message_id` matches ONLY the real attribute — never a same-suffix
+  // sibling like `target_message_id`, `reply_to_message_id`, or
+  // `original_message_id`. Without the boundary, grab('message_id') would
+  // match the FIRST `*_message_id` substring, mis-attributing the enqueue's id.
   const grab = (key: string): string | null => {
-    const m = content.match(new RegExp(`${key}="([^"]+)"`))
+    const m = content.match(new RegExp(`(?:^|[\\s"'])${key}="([^"]+)"`))
     return m ? m[1] : null
   }
   return {

--- a/telegram-plugin/tests/inbound-delivery-confirm.test.ts
+++ b/telegram-plugin/tests/inbound-delivery-confirm.test.ts
@@ -207,6 +207,46 @@ describe('ackDelivery — composer-tolerant match (#2786 duplicate-turn guard)',
     expect(extractEnqueueMessageIds(merged)).toEqual(['5001', '5002'])
     expect(extractEnqueueMessageIds('no envelope here')).toEqual([])
   })
+
+  // Regression for the unanchored-regex substring collision (silent-drop
+  // hazard on this never-drop path). `target_message_id`, `reply_to_message_id`,
+  // `original_message_id`, `card_message_id` etc. all END in `message_id="…"`.
+  // An unanchored /message_id="([^"]+)"/ grabs those siblings' values as if they
+  // were the real `message_id`, so a synthetic-source turn that merely REFERENCES
+  // message 5002 (e.g. `reply_to_message_id="5002"`) — without actually being
+  // message 5002 — would false-ack and silently drop the still-pending real
+  // inbound 5002. The regex must match ONLY the real `message_id` attribute.
+  it('does NOT extract same-suffix sibling attributes (target_/reply_to_/original_/card_message_id)', () => {
+    const content =
+      'target_message_id="5002" reply_to_message_id="5003" ' +
+      'original_message_id="5004" card_message_id="5005"'
+    expect(extractEnqueueMessageIds(content)).toEqual([])
+  })
+
+  it('extracts the real message_id even when a sibling *_message_id sits alongside it', () => {
+    const content =
+      '<channel source="reaction" chat_id="555" target_message_id="5002" ' +
+      'message_id="9999" user="ken">reacted</channel>'
+    // Only the real attribute (9999) is pulled — never the referenced 5002.
+    expect(extractEnqueueMessageIds(content)).toEqual(['9999'])
+  })
+
+  it('a sibling *_message_id="5002" reference does NOT false-ack a pending entry keyed on 5002 (substring-collision guard)', () => {
+    const q = fresh()
+    trackDelivery(q, 'chat:_', { text: 'real user msg 5002' }, 0, '5002')
+    // A synthetic-source turn (its own id 8000) merely REFERENCES 5002 via
+    // sibling attributes — it is not message 5002 itself.
+    const synthetic =
+      '<channel source="reaction" chat_id="555" message_id="8000" ' +
+      'target_message_id="5002" reply_to_message_id="5002" user="ken">👍</channel>'
+    expect(ackDelivery(q, 'chat:_', '8000', synthetic)).toBe(false)
+    // The real inbound 5002 is still pending — it strands and re-delivers, not dropped.
+    expect(q.pending.size).toBe(1)
+    expect(sweep(q, 15_000, TIMEOUT)).toHaveLength(1)
+    // Its own genuine envelope (real message_id="5002") later acks it cleanly.
+    expect(ackDelivery(q, 'chat:_', '5002', envelope('5002', 'real user msg 5002'))).toBe(true)
+    expect(q.pending.size).toBe(0)
+  })
 })
 
 // Regression for the steer/interrupt re-delivery loop: steering and `!`

--- a/telegram-plugin/tests/inbound-delivery-confirm.test.ts
+++ b/telegram-plugin/tests/inbound-delivery-confirm.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   ackDelivery,
   createDeliveryQueue,
+  extractEnqueueMessageIds,
   forgetDelivery,
   isTrackableResumeSynthetic,
   shouldTrackDelivery,
@@ -148,6 +149,63 @@ describe('ackDelivery — message-id-matched (cross-source false-ack guard)', ()
     trackDelivery(q, 'chat:_', { text: 'x' }, 0) // no messageId
     expect(ackDelivery(q, 'chat:_', '5001')).toBe(true)
     expect(q.pending.size).toBe(0)
+  })
+})
+
+// Regression for #2786 — the enqueue-ack mismatch that re-delivers a RUNNING
+// turn (a duplicate turn / double-actioned user message). Delivery-confirm
+// re-parses the `<channel message_id="…">` envelope back out of the transcript
+// to match the ack. When the composer merges/reorders inbound envelopes, the
+// single re-parsed id can belong to a sibling, so strict equality mis-concludes
+// "never delivered" and the sweep re-delivers a turn already running. Passing
+// the raw enqueue content lets the ack tolerate that by scanning every id.
+describe('ackDelivery — composer-tolerant match (#2786 duplicate-turn guard)', () => {
+  const envelope = (id: string, text: string) =>
+    `<channel source="telegram" chat_id="555" message_id="${id}" user="ken">${text}</channel>`
+
+  it('reproduces the bug: strict re-parsed id mismatch would NOT ack (pre-fix)', () => {
+    const q = fresh()
+    trackDelivery(q, 'chat:_', { text: 'run the deploy' }, 0, '5002')
+    // Composer merged an earlier sibling first, so parseChannelMeta re-parsed
+    // the FIRST id (5001), not our tracked 5002. Without the content, no ack →
+    // the sweep would re-deliver the already-running turn (the duplicate).
+    expect(ackDelivery(q, 'chat:_', '5001')).toBe(false)
+    expect(sweep(q, 15_000, TIMEOUT)).toHaveLength(1) // would double-action
+  })
+
+  it('acks when the tracked id appears anywhere in the merged enqueue content', () => {
+    const q = fresh()
+    trackDelivery(q, 'chat:_', { text: 'run the deploy' }, 0, '5002')
+    const merged = `${envelope('5001', 'hi')}\n${envelope('5002', 'run the deploy')}`
+    // First-parsed id is the sibling's 5001, but our 5002 is present in content.
+    expect(ackDelivery(q, 'chat:_', '5001', merged)).toBe(true)
+    expect(q.pending.size).toBe(0)
+    expect(sweep(q, 15_000, TIMEOUT)).toHaveLength(0) // no duplicate turn
+  })
+
+  it('acks on a reformatted single envelope where content still carries the id', () => {
+    const q = fresh()
+    trackDelivery(q, 'chat:_', { text: 'x' }, 0, '5002')
+    // Re-parse yielded null (wrapper reformatted) but the id survives in content.
+    expect(ackDelivery(q, 'chat:_', null, envelope('5002', 'x'))).toBe(true)
+    expect(q.pending.size).toBe(0)
+  })
+
+  it('preserves the cross-source false-ack guard: a synthetic turn whose content lacks our id does NOT ack', () => {
+    const q = fresh()
+    trackDelivery(q, 'chat:_', { text: 'real user msg' }, 0, '5002')
+    // A cron/resume turn under the same key — its envelope carries a fabricated
+    // id, never the user's 5002. Even with content scanning, it must not ack.
+    const cron = envelope('1716123456789', 'scheduled digest')
+    expect(ackDelivery(q, 'chat:_', '1716123456789', cron)).toBe(false)
+    expect(q.pending.size).toBe(1)
+    expect(sweep(q, 15_000, TIMEOUT)).toHaveLength(1) // user msg re-delivered, not dropped
+  })
+
+  it('extractEnqueueMessageIds pulls every id from a merged envelope', () => {
+    const merged = `${envelope('5001', 'a')}\n${envelope('5002', 'b')}`
+    expect(extractEnqueueMessageIds(merged)).toEqual(['5001', '5002'])
+    expect(extractEnqueueMessageIds('no envelope here')).toEqual([])
   })
 })
 


### PR DESCRIPTION
## Problem

A healthy, running turn could be re-delivered ~15s after it started, double-actioning the user's inbound message (#2786).

Delivery-confirm matches the enqueue ack by re-parsing the `<channel message_id="…">` envelope back out of claude's transcript (`session-tail.ts` `parseChannelMeta` grabs the **first** `message_id`). When the composer merges/reorders inbound envelopes into one turn, that first-parsed id can belong to a **sibling** — not the tracked message. Strict equality in `ackDelivery` then concludes "never delivered" and the sweep re-delivers a turn that is already running. The path fails toward duplication (never loss — verified: delivery-confirm never drops), which makes it the dominant duplicate-turn risk.

## Fix

Make the ack **composer-invariant**. `ackDelivery` now also accepts the raw enqueue content and acks when the tracked id appears among **all** `message_id="…"` tokens in that content, not just the single re-parsed one (`extractEnqueueMessageIds`). Matching on the exact attribute token — not a loose substring — **preserves the cross-source false-ack guard**: a synthetic-source turn (cron / resume / vault) never carries the real user's id, so it still cannot clear a user message genuinely still waiting to land.

The gateway `enqueue` handler passes `ev.rawContent` into the ack.

## Tests

New regression suite in `inbound-delivery-confirm.test.ts`:
- reproduces the merge/reorder mismatch (pre-fix: no ack → sweep re-delivers the running turn),
- proves the tolerant match acks when the tracked id is anywhere in the merged content,
- asserts the cross-source false-ack guard still holds (a cron turn whose content lacks the user id does **not** ack),
- covers `extractEnqueueMessageIds`.

`npm run lint` clean; the delivery-confirm suite passes. (Unrelated infra suites — vault-passphrase, docker-exec, mount/static-binary — fail identically on pristine `origin/main` in this sandbox and are untouched here.)

## Design

- **JTBD:** reliable inbound delivery — every user message is actioned **exactly once** (deliver-until-acked queue, `inbound-delivery-confirm.ts`).
- **Vision outcome:** *always-on* + *visibility* — a duplicate turn double-posts and double-executes side effects, eroding trust in the pinned progress surface.
- **Invariants:** none crossed — pure gateway bookkeeping, claude-native, single-tenant, chat remains the single source of truth.

Closes #2786. Refs #2094.

Co-authored-by: Claude <noreply@anthropic.com>