### PR TITLE
chore: quick-wins hardening bundle (log rotation, busy_timeout x3, vault fsync, atomic auto-unlock, doc fixes)

### DIFF
--- a/docs/crash-reports.md
+++ b/docs/crash-reports.md
@@ -1,6 +1,6 @@
 # Crash reports
 
-When the watchdog (`bin/bridge-watchdog.sh`) decides to kill an agent
+When the watchdog (`src/agents/wedge-watchdog.ts`) decides to kill an agent
 because it looks wedged — bridge stale, turn-active marker stuck,
 journal silent past the hard threshold — it first snapshots the
 agent's tmux pane scrollback to a crash-report file. RCA tooling can
@@ -61,19 +61,17 @@ less ~/.switchroom/agents/klanker/crash-reports/2026-05-06T01-59-37Z-turn-hang.t
   watchdog logs the error to its journal trail but proceeds with the
   restart.
 
-## Two implementations, one stream
+## Implementation
 
-Both `bin/bridge-watchdog.sh` (bash, hot path) and
-`src/agents/tmux.ts` (TypeScript, used by lifecycle/crash-detection
-code paths) write to the same directory using the same naming
-scheme and header format. RCA tooling reads from one stream
-regardless of which path produced the file. If you change one
-implementation, change the other.
+Pane capture lives in `src/agents/tmux.ts` (`captureAgentPane`), used
+by the watchdog and lifecycle/crash-detection code paths. (An earlier
+bash mirror, `bin/bridge-watchdog.sh`, has been removed — the
+TypeScript path is now the only implementation.)
 
 ## Disabling
 
 There's no env knob today. To disable, comment out the
-`capture_pane_before_restart` calls in `bridge-watchdog.sh` — the
-function itself is best-effort and never blocks the restart, so
+`captureAgentPane` calls in `src/agents/tmux.ts` — the function
+itself is best-effort and never blocks the restart, so
 leaving it on costs nothing for healthy agents (the file write only
 fires on actual restart events, which are rare on a healthy host).

--- a/docs/posthog.md
+++ b/docs/posthog.md
@@ -125,7 +125,7 @@ is auto-reported. In addition, action-level boundaries call
 Current boundaries:
 
 - `src/cli/setup.ts` — setup wizard catch-all (`action: "setup"`)
-- `src/cli/init.ts` — init catch-all (`action: "init"`)
+- `src/cli/apply.ts` — apply catch-all (`action: "apply"`; `src/cli/init.ts` was folded into `apply`)
 - `src/web/api.ts` — agent start/stop/restart handlers
 - `telegram-plugin/gateway/gateway.ts` — gateway top-level (`source: "gateway"`,
   installed via `analytics-posthog.installGlobalErrorHandlers()`). Uncaught

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -540,6 +540,23 @@ function emitImageOrBuild(
 }
 
 /**
+ * Emit a `logging:` block capping the Docker json-file log driver.
+ *
+ * `restart: always` services run for weeks; without a cap the json-file
+ * sink (distinct from the in-container `service.log`, cf. #739) grows
+ * unbounded and fills the host disk. A full disk then breaks every write
+ * path fleet-wide — the failure ancestor behind many durability bugs.
+ * 10 MB × 3 files bounds each container to ~30 MB of stdout/stderr.
+ */
+function emitLogging(lines: string[]): void {
+  lines.push(`    logging:`);
+  lines.push(`      driver: json-file`);
+  lines.push(`      options:`);
+  lines.push(`        max-size: "10m"`);
+  lines.push(`        max-file: "3"`);
+}
+
+/**
  * Emit the `voice-sidecar` singleton service (PR-B2) — a local GPU
  * speech-to-text server (faster-whisper) the gateway POSTs voice bytes to
  * when the host's voice verdict is `local`. Caller gates emission on the
@@ -576,6 +593,7 @@ function emitVoiceSidecarService(
   lines.push(`      switchroom.role: "voice-sidecar"`);
   lines.push(`      switchroom.fleet: "${containerNamePrefix}"`);
   lines.push(`    restart: always`);
+  emitLogging(lines);
   // GPU passthrough — requires the nvidia-container-toolkit on the host
   // (the PR-B1 `containerToolkit` probe; a `local` verdict implies it).
   lines.push(`    deploy:`);
@@ -1286,6 +1304,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`      switchroom.role: "broker"`);
   lines.push(`      switchroom.fleet: "${containerNamePrefix}"`);
   lines.push(`    restart: always`);
+  emitLogging(lines);
   // Liveness probe — bind-presence. The broker creates per-agent
   // socket directories at startup and binds `<dir>/sock` for each
   // configured agent. If at least one bind has happened, the daemon
@@ -1516,6 +1535,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`      switchroom.role: "kernel"`);
   lines.push(`      switchroom.fleet: "${containerNamePrefix}"`);
   lines.push(`    restart: always`);
+  emitLogging(lines);
   // Mirror the broker's bind-presence healthcheck — same failure-mode
   // surface (kernel binds per-agent sockets at
   // /run/switchroom/kernel/<agent>/sock; silently exits or hangs the
@@ -1608,6 +1628,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`      switchroom.role: "auth-broker"`);
   lines.push(`      switchroom.fleet: "${containerNamePrefix}"`);
   lines.push(`    restart: always`);
+  emitLogging(lines);
   // Bind-presence healthcheck — same probe pattern as vault-broker /
   // approval-kernel (PR #898). Empty-fleet trade-off applies: a
   // switchroom install with zero agents and zero consumers reports
@@ -1859,6 +1880,7 @@ function emitAgentService(
     lines.push(`    network_mode: host`);
   }
   lines.push(`    restart: always`);
+  emitLogging(lines);
   lines.push(`    init: false`);
   // PTY allocation — claude's interactive mode requires a TTY at stdin
   // (the alt-screen UI, autoaccept-poll keystrokes, and the `--print`

--- a/src/agents/tmux.ts
+++ b/src/agents/tmux.ts
@@ -7,11 +7,11 @@
 // callers (watchdog, lifecycle crash detector) treat capture failure
 // as best-effort and continue with the restart regardless.
 //
-// Naming/retention contract is shared with the bash mirror in
-// `bin/bridge-watchdog.sh` (capture_pane_before_restart). Keep the
-// two paths in sync: same socket convention (`switchroom-<agent>`),
-// same target session (`<agent>`), same output dir, same header
-// format. If you change one, change the other.
+// This is the sole implementation: same socket convention
+// (`switchroom-<agent>`), same target session (`<agent>`), same output
+// dir, same header format. (An earlier bash mirror,
+// `bin/bridge-watchdog.sh`'s `capture_pane_before_restart`, has been
+// removed.)
 
 import { execFileSync } from "node:child_process";
 import { mkdirSync, readdirSync, statSync, unlinkSync, writeFileSync } from "node:fs";

--- a/src/vault/approvals/kernel-server.ts
+++ b/src/vault/approvals/kernel-server.ts
@@ -84,6 +84,10 @@ export function openKernelDb(dbPath: string): Database {
     chmodSync(dbPath, 0o600);
   } catch { /* may already be 0600, or FS ignores modes */ }
   db.run("PRAGMA journal_mode=WAL");
+  // Without a busy_timeout, bun:sqlite defaults to 0ms and a contending
+  // writer fails IMMEDIATELY with SQLITE_BUSY — an approval write can be
+  // silently dropped. Wait-and-retry instead of dropping.
+  db.run("PRAGMA busy_timeout=5000");
   db.run("PRAGMA foreign_keys=ON");
   migrateApprovalSchema(db);
   return db;

--- a/src/vault/auto-unlock.ts
+++ b/src/vault/auto-unlock.ts
@@ -47,8 +47,19 @@
  */
 
 import { createHash, createHmac, randomBytes, createCipheriv, createDecipheriv } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { basename, dirname, resolve } from "node:path";
 
 const FORMAT_VERSION = 0x01;
 const SALT_LEN = 16;
@@ -214,11 +225,29 @@ export function decryptAutoUnlock(blob: Buffer, machineId?: string): string {
  */
 export function writeAutoUnlockFile(passphrase: string, filePath: string): void {
   const blob = encryptAutoUnlock(passphrase);
-  mkdirSync(dirname(filePath), { recursive: true, mode: 0o700 });
-  writeFileSync(filePath, blob, { mode: 0o600 });
-  // writeFileSync respects mode only on file creation; chmod for the
-  // existing-file case so re-running enable-auto-unlock tightens perms even
-  // if the user loosened them by hand.
+  const dir = dirname(filePath);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  // Write-temp-then-rename so an interrupted write can never leave a
+  // truncated blob at filePath (readAutoUnlockFile would then fail to
+  // decrypt and the vault couldn't auto-unlock on boot). fsync the tmp
+  // contents before rename so the data is durable, not just the dirent.
+  const tmp = resolve(dir, `.${basename(filePath)}.${process.pid}.${Date.now()}.tmp`);
+  try {
+    const fd = openSync(tmp, "wx", 0o600);
+    try {
+      writeSync(fd, blob);
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+    renameSync(tmp, filePath);
+  } catch (err) {
+    try { if (existsSync(tmp)) unlinkSync(tmp); } catch {}
+    throw err;
+  }
+  // rename respects the tmp file's mode, but chmod for the existing-file
+  // case so re-running enable-auto-unlock tightens perms even if the user
+  // loosened them by hand.
   chmodSync(filePath, 0o600);
 }
 

--- a/src/vault/grants-db.ts
+++ b/src/vault/grants-db.ts
@@ -48,6 +48,10 @@ export function openGrantsDb(dbPath = DEFAULT_GRANTS_DB_PATH): Database {
 
   // Enable WAL mode for better concurrency
   db.run("PRAGMA journal_mode=WAL");
+  // Without a busy_timeout, bun:sqlite defaults to 0ms and a contending
+  // writer fails IMMEDIATELY with SQLITE_BUSY — a grant write can be
+  // silently dropped. Wait-and-retry instead of dropping.
+  db.run("PRAGMA busy_timeout=5000");
   db.run("PRAGMA foreign_keys=ON");
 
   // Idempotent schema migration — vault grants (existing) + approval kernel

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -1,7 +1,7 @@
 import { randomBytes, scryptSync, createCipheriv, createDecipheriv } from "node:crypto";
 import {
   readFileSync,
-  writeFileSync,
+  writeSync,
   existsSync,
   renameSync,
   mkdirSync,
@@ -84,8 +84,25 @@ function atomicWriteFileSync(path: string, data: string, mode: number): void {
   const dir = dirname(resolve(effectivePath));
   const tmp = resolve(dir, `.${basename(effectivePath)}.${process.pid}.${Date.now()}.tmp`);
   try {
-    writeFileSync(tmp, data, { encoding: "utf8", mode });
+    // Write + fsync the tmp file's contents to stable storage BEFORE the
+    // rename. Without the fsync, a host crash can leave the renamed file
+    // present-but-empty (the dirent is durable but the data blocks aren't) —
+    // a torn/zeroed vault survives the crash. Mirrors backup.ts's pattern.
+    const fd = openSync(tmp, "wx", mode);
+    try {
+      writeSync(fd, data);
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
     renameSync(tmp, effectivePath);
+    // Durability: fsync the parent dir so the rename's dirent update is
+    // persisted — otherwise POSIX permits a post-rename crash to lose it.
+    // Best-effort: some filesystems refuse fsync on directories.
+    try {
+      const dirFd = openSync(dir, "r");
+      try { fsyncSync(dirFd); } finally { closeSync(dirFd); }
+    } catch {}
   } catch (err) {
     try { if (existsSync(tmp)) unlinkSync(tmp); } catch {}
     throw err;

--- a/telegram-plugin/history.ts
+++ b/telegram-plugin/history.ts
@@ -140,6 +140,11 @@ export function initHistory(stateDir: string, retentionDays = 30): void {
   // and survives crashes more cleanly than rollback journal.
   db.exec('PRAGMA journal_mode = WAL')
   db.exec('PRAGMA synchronous = NORMAL')
+  // Without a busy_timeout, bun:sqlite defaults to 0ms and a contending
+  // writer fails IMMEDIATELY with SQLITE_BUSY. History rows feed owed-reply
+  // logic (a dropped write can lose an owed reply), so wait-and-retry rather
+  // than drop. Mirrors the registry DB's pattern (turns-schema.ts).
+  db.exec('PRAGMA busy_timeout = 5000')
   db.exec(`
     CREATE TABLE IF NOT EXISTS messages (
       chat_id        TEXT    NOT NULL,


### PR DESCRIPTION
## What

Implements the full quick-wins hardening bundle from #2784 — low-risk, high-value durability fixes surfaced by the four-audit codebase review. Six independent one-to-few-line changes shipped together.

| # | Fix | File |
|---|-----|------|
| 1 | **Docker log rotation** — emit a `logging:` block (`json-file`, `max-size: 10m`, `max-file: 3`) on every generated `restart: always` service | `src/agents/compose.ts` |
| 2 | `PRAGMA busy_timeout=5000` on `history.db` | `telegram-plugin/history.ts` |
| 3 | `PRAGMA busy_timeout=5000` on grants DB + kernel/approvals DB | `src/vault/grants-db.ts`, `src/vault/approvals/kernel-server.ts` |
| 4 | Vault `atomicWriteFileSync` now fsyncs the tmp fd + parent dir before/after rename | `src/vault/vault.ts` |
| 5 | Auto-unlock blob written write-temp-then-rename + fsync | `src/vault/auto-unlock.ts` |
| 6 | Doc fixes — dead references to deleted files (`bin/bridge-watchdog.sh`, `src/cli/init.ts`) | `docs/crash-reports.md`, `docs/posthog.md`, `src/agents/tmux.ts` (comment) |

Item 1 mirrors the existing `emitImageOrBuild` helper via a new `emitLogging` sibling; items 2–3 mirror the registry DB's existing `busy_timeout` pattern (`turns-schema.ts`); items 4–5 reuse the fsync-before-rename pattern already in `backup.ts`.

## Why — JTBD & vision

- **JTBD:** `reference/jobs/survive-reboots-and-real-life.md` — "Agents come back cleanly after crashes, power loss, context exhaustion, and transient failures." Items 1–5 each close a way the machine misbehaving (full disk, concurrent-writer `SQLITE_BUSY`, power loss mid-write) corrupts or drops durable state.
- **Vision outcome:** **always-on** (`reference/vision.md` pillar 4). A disk-fill or a torn vault takes the whole fleet down; these harden the always-on promise.
- **Principle checks:** docs (item 6 keeps the docs honest), defaults (rotation/fsync/busy_timeout are now the safe default with no config), consistency (each fix mirrors an existing in-repo pattern). No invariant crossed.

## Testing

- `npm run lint` (tsc --noEmit + all check-* scripts): **clean**.
- Touched-area tests pass in isolation: `tests/vault.test.ts`, `tests/vault-auto-unlock.test.ts`, `tests/docker/compose-generator.test.ts`, `src/vault/grants.test.ts`.
- Note: the local full-suite run showed failures that are **environmental in this sandbox** — `EROFS` writing to a read-only `~/.switchroom/fleet` mount and 5s timeouts under heavy load — not caused by this diff. Leaving CI to gate.

Closes #2784

Co-authored-by: Claude <noreply@anthropic.com>