### PR TITLE
durability: bound session JSONL + vault audit log growth (#2792)

### DIFF
--- a/docs/session-optimization.md
+++ b/docs/session-optimization.md
@@ -25,6 +25,13 @@ Switchroom agents have three mechanisms that survive restarts and compaction:
    - `continue` — always pass `--continue`. Flaky on large transcripts; only use if you know your sessions stay small.
    - `none` — fresh every time, no briefing.
 
+   **Session-JSONL retention (#2792).** Session transcripts accumulate one JSONL per session under `<agentDir>/.claude/projects/`. The Stop hook prunes old ones after building the briefing (so the handoff source is never touched), bounded by two `session_continuity` fields (same shallow per-key cascade merge as the rest of the block — set fleet-wide under `defaults.session_continuity` or override per agent/profile):
+
+   - `session_retention_max_count` — keep at most this many newest transcripts (default `20`; `0` disables the count bound).
+   - `session_retention_max_age_days` — prune transcripts older than this many days (default `30`; `0` disables the age bound).
+
+   A transcript is deleted only when it is **both** over the count bound **and** older than the age bound; the newest two sessions are always retained regardless.
+
 2. **Hindsight memory** — auto-retain fires every 10 turns, saving the full transcript to a semantic bank. Auto-recall fires every turn, bringing back relevant memories. Important facts survive compaction and restart because they're stored externally.
 
 3. **Telegram history** — SQLite buffer of every inbound/outbound message. `get_recent_messages` lets the agent recover recent chat context after a restart, regardless of resume mode.

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -288,6 +288,17 @@ Fields:
 | `agent_name` | string? | Agent slug derived from the bind socket path — the trusted identity used for the ACL decision (path-as-identity) |
 | `result` | string | `"allowed"`, `"denied:<reason>"`, or `"error:<detail>"` |
 
+### Rotation (bounded growth — #2792)
+
+The audit log is append-only, so on a long-lived host it would grow without bound. It is size-rotated: once the active `vault-audit.log` passes **32 MiB** (default) it is renamed to `vault-audit.log.1` (shifting `.1`→`.2`, …), and **5** rotated files (default) are retained — total on-disk history is bounded at roughly `(maxFiles + 1) × maxBytes`. The per-row tamper-evidence hash chain **continues across the rotation seam** (the in-process chain state is preserved, so the first row of a new file links back to the last row of `.1`); concatenate `…​.5 .4 .3 .2 .1` + the active file, oldest-first, to verify the full chain. Note the oldest rotated file is *deleted* past `maxFiles`, which discards tamper-evidence for the very oldest rows — operators who need an unbounded forensic archive should raise the limits or ship rows off-box.
+
+Overrides (broker-level env vars, read at broker startup):
+
+```sh
+SWITCHROOM_VAULT_AUDIT_MAX_BYTES=67108864   # rotate at 64 MiB; negative disables rotation
+SWITCHROOM_VAULT_AUDIT_MAX_FILES=10         # retain 10 rotated files
+```
+
 ### Grep examples
 
 ```sh

--- a/src/agents/session-retention.test.ts
+++ b/src/agents/session-retention.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for session-JSONL retention (src/agents/session-retention.ts, #2792).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  pruneSessionJsonl,
+  DEFAULT_SESSION_RETENTION_MAX_COUNT,
+} from "./session-retention.js";
+
+let tmpDir: string;
+let claudeConfigDir: string;
+let projectsDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-retention-"));
+  claudeConfigDir = path.join(tmpDir, ".claude");
+  projectsDir = path.join(claudeConfigDir, "projects", "proj-a");
+  fs.mkdirSync(projectsDir, { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+/** Create a JSONL whose mtime is `ageDays` days in the past. */
+function makeSession(name: string, ageDays: number): string {
+  const p = path.join(projectsDir, name);
+  fs.writeFileSync(p, '{"type":"user"}\n');
+  const when = Date.now() - ageDays * 24 * 60 * 60 * 1000;
+  fs.utimesSync(p, new Date(when), new Date(when));
+  return p;
+}
+
+describe("pruneSessionJsonl", () => {
+  it("keeps the newest maxCount sessions and deletes the rest (age disabled)", () => {
+    // 5 sessions aged 0..4 days.
+    for (let i = 0; i < 5; i++) makeSession(`s${i}.jsonl`, i);
+    const res = pruneSessionJsonl(claudeConfigDir, {
+      maxCount: 3,
+      maxAgeDays: 0, // disabled → count alone decides
+    });
+    expect(res.scanned).toBe(5);
+    expect(res.deleted).toBe(2);
+    const remaining = fs.readdirSync(projectsDir).sort();
+    expect(remaining).toEqual(["s0.jsonl", "s1.jsonl", "s2.jsonl"]);
+  });
+
+  it("never deletes the keepPath even if it is old and over-count", () => {
+    for (let i = 0; i < 5; i++) makeSession(`s${i}.jsonl`, i * 10);
+    const keep = path.join(projectsDir, "s4.jsonl"); // oldest
+    const res = pruneSessionJsonl(claudeConfigDir, {
+      maxCount: 2,
+      maxAgeDays: 5,
+      keepPath: keep,
+    });
+    expect(fs.existsSync(keep)).toBe(true);
+    expect(res.deleted).toBeGreaterThan(0);
+  });
+
+  it("only deletes files that are BOTH over-count AND over-age", () => {
+    // 4 recent sessions (all 1 day old) + count bound of 2.
+    for (let i = 0; i < 4; i++) makeSession(`s${i}.jsonl`, 1);
+    const res = pruneSessionJsonl(claudeConfigDir, {
+      maxCount: 2,
+      maxAgeDays: 30, // all files are young → nothing is old enough
+    });
+    expect(res.deleted).toBe(0);
+    expect(fs.readdirSync(projectsDir)).toHaveLength(4);
+  });
+
+  it("always retains at least MIN_KEEP newest even below maxCount", () => {
+    makeSession("new.jsonl", 100);
+    makeSession("old.jsonl", 200);
+    const res = pruneSessionJsonl(claudeConfigDir, {
+      maxCount: 1,
+      maxAgeDays: 1, // both very old
+    });
+    // MIN_KEEP (2) protects both despite maxCount:1.
+    expect(res.deleted).toBe(0);
+  });
+
+  it("is a no-op when both bounds are disabled", () => {
+    for (let i = 0; i < 3; i++) makeSession(`s${i}.jsonl`, i * 100);
+    const res = pruneSessionJsonl(claudeConfigDir, {
+      maxCount: 0,
+      maxAgeDays: 0,
+    });
+    expect(res.deleted).toBe(0);
+    expect(res.scanned).toBe(0);
+  });
+
+  it("returns cleanly when the projects dir does not exist", () => {
+    const res = pruneSessionJsonl(path.join(tmpDir, "nope"), {
+      maxCount: DEFAULT_SESSION_RETENTION_MAX_COUNT,
+    });
+    expect(res).toEqual({ deleted: 0, scanned: 0 });
+  });
+});

--- a/src/agents/session-retention.ts
+++ b/src/agents/session-retention.ts
@@ -1,0 +1,186 @@
+/**
+ * Session JSONL retention (issue #2792 item A).
+ *
+ * Claude Code stores one JSONL transcript per session under
+ * `$CLAUDE_CONFIG_DIR/projects/<sanitized-cwd>/`. Nothing ever prunes
+ * them, so a long-lived always-on agent's `.claude/projects` grows
+ * monotonically — a slow-burn contributor to the fleet-wide disk-full
+ * failure mode. This module bounds that growth by age and count.
+ *
+ * Safety contract — retention must never strip a transcript that is
+ * still needed for correctness:
+ *   - The handoff-briefing consumer (see handoff-summarizer.ts) reads the
+ *     *newest* JSONL to build `.handoff.md`. We NEVER delete the file the
+ *     caller marks as `keepPath`, and we always keep at least the newest
+ *     `minKeep` sessions regardless of age.
+ *   - Deletion is best-effort and never throws: a Stop hook that fails to
+ *     prune must not block agent shutdown. Errors are reported to the
+ *     caller's `onWarn` sink (stderr in production).
+ *
+ * Both thresholds are configurable via the config cascade under
+ * `session_continuity` (shallow per-key merge, agent wins) —
+ * `session_retention_max_count` and `session_retention_max_age_days`.
+ */
+
+import {
+  existsSync,
+  readdirSync,
+  statSync,
+  unlinkSync,
+} from "node:fs";
+import { join } from "node:path";
+
+/** Default: keep the newest 20 session transcripts. */
+export const DEFAULT_SESSION_RETENTION_MAX_COUNT = 20;
+/** Default: delete session transcripts older than 30 days. */
+export const DEFAULT_SESSION_RETENTION_MAX_AGE_DAYS = 30;
+/**
+ * Floor on how many newest sessions are always retained regardless of
+ * age — guarantees the handoff source (and a little history) survives
+ * even a very idle agent whose only transcripts are all "old".
+ */
+const MIN_KEEP = 2;
+
+export interface SessionRetentionOptions {
+  /**
+   * Keep at most this many newest session JSONL files. Older ones beyond
+   * this count are eligible for deletion. `undefined`/`0` disables the
+   * count bound.
+   */
+  maxCount?: number;
+  /**
+   * Delete session JSONL files whose mtime is older than this many days.
+   * `undefined`/`0` disables the age bound.
+   */
+  maxAgeDays?: number;
+  /**
+   * Absolute path to a JSONL that must never be deleted (the file the
+   * handoff briefing was just built from). Optional.
+   */
+  keepPath?: string;
+  /** Warning sink. Defaults to stderr. */
+  onWarn?: (msg: string) => void;
+  /** Injectable clock for tests (ms epoch). Defaults to Date.now. */
+  now?: () => number;
+}
+
+export interface SessionRetentionResult {
+  /** Number of JSONL files deleted. */
+  deleted: number;
+  /** Number of JSONL files scanned. */
+  scanned: number;
+}
+
+interface JsonlFile {
+  path: string;
+  mtime: number;
+}
+
+/**
+ * Collect every session JSONL under `<claudeConfigDir>/projects`,
+ * newest first. Never throws — unreadable dirs/files are skipped.
+ */
+function collectSessionJsonl(claudeConfigDir: string): JsonlFile[] {
+  const projects = join(claudeConfigDir, "projects");
+  if (!existsSync(projects)) return [];
+  const found: JsonlFile[] = [];
+  const walk = (dir: string): void => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const name of entries) {
+      const full = join(dir, name);
+      let st;
+      try {
+        st = statSync(full);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!name.endsWith(".jsonl")) continue;
+      found.push({ path: full, mtime: st.mtimeMs });
+    }
+  };
+  walk(projects);
+  // Newest first.
+  found.sort((a, b) => b.mtime - a.mtime);
+  return found;
+}
+
+/**
+ * Prune old session JSONL transcripts for one agent, bounding growth by
+ * count and age while never deleting the handoff source or the newest
+ * `MIN_KEEP` sessions. Best-effort and non-throwing.
+ */
+export function pruneSessionJsonl(
+  claudeConfigDir: string,
+  opts: SessionRetentionOptions = {},
+): SessionRetentionResult {
+  const onWarn =
+    opts.onWarn ?? ((msg: string) => process.stderr.write(`${msg}\n`));
+  const now = opts.now ?? Date.now;
+
+  const maxCount =
+    opts.maxCount && opts.maxCount > 0 ? opts.maxCount : undefined;
+  const maxAgeDays =
+    opts.maxAgeDays && opts.maxAgeDays > 0 ? opts.maxAgeDays : undefined;
+
+  // Nothing to do if both bounds are disabled.
+  if (maxCount === undefined && maxAgeDays === undefined) {
+    return { deleted: 0, scanned: 0 };
+  }
+
+  const files = collectSessionJsonl(claudeConfigDir);
+  const ageCutoff =
+    maxAgeDays !== undefined
+      ? now() - maxAgeDays * 24 * 60 * 60 * 1000
+      : undefined;
+
+  // Never delete below the MIN_KEEP newest, and honor a larger maxCount.
+  const keepNewest = Math.max(MIN_KEEP, maxCount ?? 0);
+
+  let deleted = 0;
+  for (let i = 0; i < files.length; i++) {
+    const f = files[i];
+    // Index < keepNewest → protected as one of the newest sessions.
+    if (i < keepNewest) continue;
+    // Never delete the explicit keepPath (the handoff source).
+    if (opts.keepPath && f.path === opts.keepPath) continue;
+
+    // A file survives the count bound only if it is ALSO young enough
+    // under the age bound. If the age bound is disabled, everything past
+    // keepNewest is over-count and eligible. If the count bound is
+    // disabled, only age decides.
+    let eligible = false;
+    if (maxCount !== undefined && i >= keepNewest) {
+      // Over the count limit. Still, if an age bound exists and the file
+      // is young, keep it — age is the more conservative signal.
+      if (ageCutoff === undefined || f.mtime < ageCutoff) {
+        eligible = true;
+      }
+    } else if (ageCutoff !== undefined && f.mtime < ageCutoff) {
+      eligible = true;
+    }
+
+    if (!eligible) continue;
+
+    try {
+      unlinkSync(f.path);
+      deleted++;
+    } catch (err) {
+      onWarn(
+        `session-retention: could not delete ${f.path}: ${
+          (err as Error).message
+        }`,
+      );
+    }
+  }
+
+  return { deleted, scanned: files.length };
+}

--- a/src/cli/handoff.ts
+++ b/src/cli/handoff.ts
@@ -7,6 +7,11 @@ import {
   findLatestSessionJsonl,
   DEFAULT_MAX_TURNS,
 } from "../agents/handoff-summarizer.js";
+import {
+  pruneSessionJsonl,
+  DEFAULT_SESSION_RETENTION_MAX_COUNT,
+  DEFAULT_SESSION_RETENTION_MAX_AGE_DAYS,
+} from "../agents/session-retention.js";
 
 /**
  * `switchroom handoff <agent>` — build the agent's session handoff
@@ -46,7 +51,7 @@ export function registerHandoffCommand(program: Command): void {
           // containers the file isn't mounted — fall back to defaults
           // rather than failing the Stop hook (#1745). Anything other
           // than ConfigError still propagates.
-          let agentConfig: { session_continuity?: { enabled?: boolean; max_turns_in_briefing?: number } } | undefined;
+          let agentConfig: { session_continuity?: { enabled?: boolean; max_turns_in_briefing?: number; session_retention_max_count?: number; session_retention_max_age_days?: number } } | undefined;
           let agentDir: string;
           try {
             const config = getConfig(program);
@@ -97,6 +102,24 @@ export function registerHandoffCommand(program: Command): void {
             maxTurns: cappedMaxTurns,
           });
           process.stderr.write(`handoff: ${status}\n`);
+
+          // Session-JSONL retention (#2792). Runs after the briefing is
+          // built so the newest transcript — the handoff source — is
+          // never pruned. Best-effort; never blocks shutdown.
+          const retention = pruneSessionJsonl(claudeConfigDir, {
+            maxCount:
+              continuity?.session_retention_max_count ??
+              DEFAULT_SESSION_RETENTION_MAX_COUNT,
+            maxAgeDays:
+              continuity?.session_retention_max_age_days ??
+              DEFAULT_SESSION_RETENTION_MAX_AGE_DAYS,
+            keepPath: jsonl,
+          });
+          if (retention.deleted > 0) {
+            process.stderr.write(
+              `handoff: pruned ${retention.deleted} old session transcript(s)\n`,
+            );
+          }
         },
       ),
     );

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -667,6 +667,29 @@ export const SessionContinuitySchema = z
         "can blow out the context window even with prefix caching, and " +
         "--continue replay is known-fragile at scale.",
       ),
+    session_retention_max_count: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "Session-JSONL retention (issue #2792): keep at most this many " +
+        "newest session transcripts under .claude/projects; older ones " +
+        "past both this count and the age bound are pruned by the Stop " +
+        "hook. The newest sessions (and the handoff source) are always " +
+        "kept. Default 20; set 0 to disable the count bound.",
+      ),
+    session_retention_max_age_days: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "Session-JSONL retention (issue #2792): prune session transcripts " +
+        "older than this many days (a file is deleted only when it is BOTH " +
+        "over the count bound and older than this). Default 30; set 0 to " +
+        "disable the age bound.",
+      ),
   })
   .optional();
 

--- a/src/vault/broker/audit-log.test.ts
+++ b/src/vault/broker/audit-log.test.ts
@@ -20,6 +20,7 @@ import {
   defaultAuditLogPath,
   type AuditEntry,
 } from "./audit-log.js";
+import { verifyAuditLog } from "../../util/audit-hashchain.js";
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
@@ -282,6 +283,66 @@ describe("callerFromPeer", () => {
     // a literal `caller: ""` entry.
     const caller = callerFromPeer({ pid: 42, systemdUnit: "" });
     expect(caller).toBe("pid:42");
+  });
+});
+
+// ─── size-based rotation (#2792 item B) ───────────────────────────────────────
+
+describe("createAuditLogger rotation", () => {
+  function writeN(logger: ReturnType<typeof createAuditLogger>, n: number): void {
+    for (let i = 0; i < n; i++) {
+      logger.write({
+        ts: "2026-04-28T14:33:00.000Z",
+        op: "get",
+        key: `k/${i}`,
+        caller: "agent:test",
+        pid: 1,
+        result: "allowed",
+      });
+    }
+  }
+
+  it("rotates the active log to .1 once it exceeds maxBytes", () => {
+    // Tiny threshold so a couple of rows trip it.
+    const audit = createAuditLogger({ path: logPath, maxBytes: 200, maxFiles: 3 });
+    writeN(audit, 10);
+    expect(fs.existsSync(`${logPath}.1`)).toBe(true);
+    // Active file exists and is smaller than the full history.
+    expect(fs.existsSync(logPath)).toBe(true);
+  });
+
+  it("retains at most maxFiles rotated files, dropping the oldest", () => {
+    const audit = createAuditLogger({ path: logPath, maxBytes: 120, maxFiles: 2 });
+    writeN(audit, 40);
+    expect(fs.existsSync(`${logPath}.1`)).toBe(true);
+    expect(fs.existsSync(`${logPath}.2`)).toBe(true);
+    // .3 must never exist — the window is bounded at maxFiles.
+    expect(fs.existsSync(`${logPath}.3`)).toBe(false);
+  });
+
+  it("continues the hash chain across a rotation boundary", () => {
+    const audit = createAuditLogger({ path: logPath, maxBytes: 150, maxFiles: 5 });
+    writeN(audit, 20);
+    // Concatenate rotated files (oldest → newest) + active, in order, and
+    // verify the chain is unbroken across the rotation seam.
+    const parts: string[] = [];
+    for (let n = 5; n >= 1; n--) {
+      if (fs.existsSync(`${logPath}.${n}`)) {
+        parts.push(fs.readFileSync(`${logPath}.${n}`, "utf8"));
+      }
+    }
+    parts.push(fs.readFileSync(logPath, "utf8"));
+    const verdict = verifyAuditLog(parts.join(""));
+    // Chain continues across rotation: no tampering, and exactly one
+    // segment (the in-process chain state is preserved across renames).
+    expect(verdict.state).toBe("ok");
+    expect(verdict.segments).toBe(1);
+  });
+
+  it("does not rotate when maxBytes is negative (disabled)", () => {
+    const audit = createAuditLogger({ path: logPath, maxBytes: -1 });
+    writeN(audit, 50);
+    expect(fs.existsSync(`${logPath}.1`)).toBe(false);
   });
 });
 

--- a/src/vault/broker/audit-log.ts
+++ b/src/vault/broker/audit-log.ts
@@ -110,6 +110,108 @@ export interface AuditLoggerOptions {
    * Defaults to ~/.switchroom/vault-audit.log (resolved via os.homedir()).
    */
   path?: string;
+  /**
+   * Size-based rotation threshold in bytes (issue #2792 item B). When the
+   * active log grows past this size, it is rotated to `<path>.1` (shifting
+   * `.1`→`.2`, …) before the next append. `0`/`undefined` uses the default;
+   * a negative value disables rotation entirely. Env override:
+   * `SWITCHROOM_VAULT_AUDIT_MAX_BYTES`.
+   */
+  maxBytes?: number;
+  /**
+   * How many rotated files to retain (`<path>.1` … `<path>.<maxFiles>`).
+   * The oldest is deleted when it would exceed this count. `0`/`undefined`
+   * uses the default. Env override: `SWITCHROOM_VAULT_AUDIT_MAX_FILES`.
+   */
+  maxFiles?: number;
+}
+
+/**
+ * Default rotation threshold: 32 MiB. At ~300 bytes/row this is ~100k
+ * audit rows per file — a generous forensic window that still bounds the
+ * active file. Conservative: rotation preserves rows (nothing is
+ * truncated in place), and the hash chain continues seamlessly across the
+ * rotation boundary (see createAuditLogger).
+ */
+export const DEFAULT_AUDIT_MAX_BYTES = 32 * 1024 * 1024;
+/**
+ * Default number of rotated files retained. Total on-disk audit history is
+ * bounded at roughly `(maxFiles + 1) * maxBytes`. The oldest rotated file
+ * is deleted past this count — that DOES discard tamper-evidence for the
+ * very oldest rows, so operators who need an unbounded forensic archive
+ * should raise this or ship rows off-box.
+ */
+export const DEFAULT_AUDIT_MAX_FILES = 5;
+
+/**
+ * Resolve the effective rotation config from options + env overrides.
+ * Negative maxBytes disables rotation.
+ */
+function resolveRotation(opts: AuditLoggerOptions): {
+  maxBytes: number;
+  maxFiles: number;
+} {
+  const envBytes = Number(process.env.SWITCHROOM_VAULT_AUDIT_MAX_BYTES);
+  const envFiles = Number(process.env.SWITCHROOM_VAULT_AUDIT_MAX_FILES);
+  const maxBytes =
+    opts.maxBytes !== undefined && opts.maxBytes !== 0
+      ? opts.maxBytes
+      : Number.isFinite(envBytes) && envBytes !== 0
+        ? envBytes
+        : DEFAULT_AUDIT_MAX_BYTES;
+  const maxFiles =
+    opts.maxFiles !== undefined && opts.maxFiles > 0
+      ? opts.maxFiles
+      : Number.isFinite(envFiles) && envFiles > 0
+        ? envFiles
+        : DEFAULT_AUDIT_MAX_FILES;
+  return { maxBytes, maxFiles };
+}
+
+/**
+ * Rotate the audit log: `<path>.(n-1)` → `<path>.n`, dropping the oldest
+ * past `maxFiles`, then `<path>` → `<path>.1`. The active path is left
+ * absent so the next append re-creates an empty file; the in-process hash
+ * chain is intentionally NOT reset, so the first row of the new file links
+ * back to the last row of `<path>.1` and cross-file continuity holds.
+ * Best-effort: any failure is reported and rotation is skipped (the
+ * current file keeps growing rather than losing data).
+ */
+function rotateAuditLog(logPath: string, maxFiles: number): void {
+  // Delete the oldest retained file if it exists — it would fall off the
+  // window after the shift.
+  const oldest = `${logPath}.${maxFiles}`;
+  if (fs.existsSync(oldest)) {
+    try {
+      fs.unlinkSync(oldest);
+    } catch (err) {
+      process.stderr.write(
+        `[vault-audit] ERROR: could not drop oldest rotation ${oldest}: ${(err as Error).message}\n`,
+      );
+    }
+  }
+  // Shift .(n-1) → .n for n = maxFiles down to 2.
+  for (let n = maxFiles - 1; n >= 1; n--) {
+    const from = `${logPath}.${n}`;
+    const to = `${logPath}.${n + 1}`;
+    if (!fs.existsSync(from)) continue;
+    try {
+      fs.renameSync(from, to);
+    } catch (err) {
+      process.stderr.write(
+        `[vault-audit] ERROR: could not rotate ${from} → ${to}: ${(err as Error).message}\n`,
+      );
+      return;
+    }
+  }
+  // Finally, active → .1.
+  try {
+    fs.renameSync(logPath, `${logPath}.1`);
+  } catch (err) {
+    process.stderr.write(
+      `[vault-audit] ERROR: could not rotate active audit log ${logPath}: ${(err as Error).message}\n`,
+    );
+  }
 }
 
 /**
@@ -162,8 +264,25 @@ export function createAuditLogger(opts: AuditLoggerOptions = {}): AuditLogger {
   // so a failed append can't desync the chain from disk.
   let chain: ChainState = seedChain(logPath);
 
+  // Rotation config (issue #2792 item B). A negative maxBytes disables
+  // rotation; the chain state is preserved across rotations so cross-file
+  // tamper-evidence continuity holds.
+  const rotation = resolveRotation(opts);
+
   return {
     write(entry: AuditEntry): void {
+      // Size-based rotation check before the append. Best-effort:
+      // stat failures leave the file untouched (grow rather than lose).
+      if (rotation.maxBytes > 0) {
+        try {
+          const size = fs.statSync(logPath).size;
+          if (size >= rotation.maxBytes) {
+            rotateAuditLog(logPath, rotation.maxFiles);
+          }
+        } catch {
+          // No file yet (first write) or stat error — nothing to rotate.
+        }
+      }
       // Build the chained JSON line. Control characters are not a
       // concern for the fields we log (ISO timestamps, key names, unit
       // names, pid numbers); JSON.stringify handles them anyway.


### PR DESCRIPTION
## What & why

Several append-only stores grow monotonically with no pruning — the fleet-wide disk-full failure ancestor (#2792). This bounds the two biggest offenders.

**JTBD:** *always-on / survive-reboots* — an always-on fleet running for weeks must not silently fill its disk. Advances the **Always-on** vision outcome.

## Changes

### A — Session JSONL transcripts (issue item A)
Claude Code writes one JSONL per session under `<agentDir>/.claude/projects/`; nothing pruned them. New `src/agents/session-retention.ts` prunes from the Stop hook (`src/cli/handoff.ts`) **after** the handoff briefing is built, so the newest transcript — the briefing source — is passed as `keepPath` and never deleted.

- Bounded by two `session_continuity` fields: `session_retention_max_count` (default **20**) and `session_retention_max_age_days` (default **30**).
- A file is deleted only when it is **both** over-count **and** over-age; the newest two sessions are always retained (`MIN_KEEP`).
- Best-effort, non-throwing (a Stop hook must never block shutdown).

### B — Vault broker audit log (issue item B)
`~/.switchroom/vault-audit.log` was append-only with no rotation. `createAuditLogger` now size-rotates: at **32 MiB** default the active file → `.1` (shifting `.1`→`.2`, …), retaining **5** rotated files. Total on-disk history ≈ `(maxFiles + 1) × maxBytes`. Env overrides `SWITCHROOM_VAULT_AUDIT_MAX_BYTES` / `SWITCHROOM_VAULT_AUDIT_MAX_FILES` (negative bytes disables).

The #1417 per-row tamper-evidence **hash chain continues across the rotation seam** — the in-process chain state is preserved across renames, so concatenating rotated files oldest-first + active verifies as one unbroken chain (test covers this).

### Deliberately NOT included — vault grants-DB rows
No `DELETE` was added under `src/vault`. Pruning expired grant / approval rows touches the tamper-evidence + approval story and warrants a design coordinated with #1417/#1420. Flagged rather than shipped as an aggressive delete.

## Config cascade

Both new fields live under `session_continuity`, which uses **shallow per-key field merge (agent wins)** — set fleet-wide under `defaults.session_continuity` or override per agent/profile. Documented in `docs/session-optimization.md`; audit rotation documented in `docs/vault.md`.

## Thresholds a human should sanity-check

- Session retention **20 sessions / 30 days** — conservative; only prunes when both exceeded.
- Audit log **32 MiB × 5 files** (~160 MiB ceiling). Deleting the oldest rotated file past `maxFiles` discards tamper-evidence for the very oldest rows — noted in docs; operators needing an unbounded forensic archive should raise limits or ship rows off-box.

## Tests
`npm run lint` clean. New tests: `src/agents/session-retention.test.ts` (6), rotation cases in `src/vault/broker/audit-log.test.ts`. Touched vitest suites (retention, audit-log, config/merge — 452 tests) green.

Closes #2792

Co-authored-by: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)