### PR TITLE
ci: path-filter docker-images + nightly unfiltered full sweep + shared WS9-F1 filter file

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -1,0 +1,110 @@
+# Shared dorny/paths-filter definitions (external filters file).
+#
+# Consumed via `filters: .github/path-filters.yml` by:
+#   - ci-lint.yml          → key `lint`
+#   - ci-tests-core.yml    → key `core`
+#   - ci-tests-plugin.yml  → key `plugin`
+#   - docker-images.yml    → keys `images`, `hindsight`, `voice`
+#
+# Why this file exists: the sec WS9-F1 (#1402) security-load-bearing
+# path list was copy-pasted across ci-lint / ci-tests-core /
+# ci-tests-plugin and had already started to be a drift hazard — a
+# path added to one workflow's copy but not the others silently
+# re-opens the skip→pass hole WS9-F1 closed. YAML anchors in a single
+# shared file keep the list defined once. dorny/paths-filter flattens
+# nested arrays, so `- *ws9f1-security` inside a filter list works.
+#
+# WS9-F1 rationale (see ci-tests-core.yml pre-#-this-PR history):
+# profiles/ renders every agent's start.sh + the WS8 tool-safety
+# hooks; bin/*-hook.sh + skills/ are baked into the agent image;
+# docker/ + workflows are the supply-chain root. Without these a
+# profiles/bin/skills/docker/.github-only PR skipped→passed required
+# gates with no tests.
+
+ws9f1-security: &ws9f1-security
+  - 'profiles/**'
+  - 'bin/**'
+  - 'skills/**'
+  - 'docker/**'
+  - '.github/workflows/**'
+  # This file gates what runs — a change to it must itself run everything.
+  - '.github/path-filters.yml'
+
+lint:
+  - '**/*.ts'
+  - '**/*.tsx'
+  - 'tsconfig.json'
+  - 'package.json'
+  - 'bun.lock'
+  - 'telegram-plugin/package.json'
+  - 'telegram-plugin/bun.lock'
+  - 'scripts/check-*.mjs'
+  - 'scripts/check-bot-api-wrapping.sh'
+  - '.github/actions/setup-switchroom/**'
+  - '.github/workflows/ci-lint.yml'
+  - *ws9f1-security
+
+core:
+  - 'src/**'
+  - 'tests/**'
+  - 'telegram-plugin/**/*.ts'
+  - 'scripts/build.mjs'
+  - 'vitest.config.ts'
+  - 'tsconfig.json'
+  - 'package.json'
+  - 'bun.lock'
+  - 'telegram-plugin/package.json'
+  - 'telegram-plugin/bun.lock'
+  - '.github/actions/setup-switchroom/**'
+  - '.github/workflows/ci-tests-core.yml'
+  - *ws9f1-security
+
+plugin:
+  - 'telegram-plugin/**'
+  - 'package.json'
+  - 'bun.lock'
+  - 'telegram-plugin/package.json'
+  - 'telegram-plugin/bun.lock'
+  - '.github/actions/setup-switchroom/**'
+  - '.github/workflows/ci-tests-plugin.yml'
+  - *ws9f1-security
+
+# docker-images.yml PR gate. Mirrors docker-e2e.yml's image-input list
+# (the src/** subtrees whose bundles are baked into images) plus the
+# image build inputs themselves. Keep in sync with docker-e2e.yml's
+# cache key + filter when image inputs change.
+images:
+  - 'docker/**'
+  - 'src/vault/**'
+  - 'src/cli/apply.ts'
+  - 'src/agents/compose.ts'
+  - 'src/agent-scheduler/**'
+  - 'src/auth/broker/**'
+  - 'src/host-control/**'
+  - 'telegram-plugin/**'
+  - 'bin/**'
+  - 'profiles/**'
+  - 'vendor/hindsight-memory/**'
+  - 'package.json'
+  - 'bun.lock'
+  - 'scripts/build.mjs'
+  - '.github/workflows/docker-images.yml'
+  - '.github/path-filters.yml'
+
+# hindsight extends upstream vectorize-io/hindsight (not switchroom-base)
+# and rarely changes — path-gated even on main pushes.
+hindsight:
+  - 'docker/Dockerfile.hindsight'
+  - 'docker/hindsight-*'
+  - 'vendor/hindsight-memory/**'
+  - '.github/workflows/docker-images.yml'
+  - '.github/path-filters.yml'
+
+# voice FROMs nvidia/cuda (not switchroom-base), bakes no dist — the
+# CUDA layers make it the heaviest build, and it almost never changes.
+# Path-gated even on main pushes.
+voice:
+  - 'docker/Dockerfile.voice'
+  - 'docker/voice-sidecar/**'
+  - '.github/workflows/docker-images.yml'
+  - '.github/path-filters.yml'

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,0 +1,257 @@
+name: ci-full
+
+# Nightly UNFILTERED sweep — the safety net behind the path-filtered
+# fast path.
+#
+# The PR-facing workflows optimise for velocity: ci-tests-core runs
+# `vitest --changed`, every changes-gated job skips on irrelevant
+# paths, docker-e2e rides an image cache, and docker-images is
+# path-gated on PRs (and hindsight/voice even on main pushes). Each of
+# those optimisations has a theoretical false-negative mode (a stale
+# path filter, an import-graph edge --changed misses, a poisoned image
+# cache, a Dockerfile that only breaks on a cold build). This workflow
+# closes the loop: once a day it runs EVERYTHING from scratch on main
+# with no filters, no --changed, and no warm caches on the e2e path.
+#
+# Jobs are defined directly (not via workflow_call reuse) because the
+# existing workflows' jobs are event-gated (`github.event_name ==
+# 'push' || relevant == 'true'`) — under a `schedule` caller they would
+# all skip; converting them would complicate the required-check
+# workflows for no PR-path benefit. The duplicated steps mirror their
+# sources 1:1 — when editing ci-tests-core / ci-tests-plugin /
+# ci-tests-python / docker-e2e / docker-images, keep the twin job here
+# in sync.
+#
+# Deliberately NOT scheduled: ci-uat / ci-evals — they burn real
+# subscription quota and stay dispatch-only.
+
+on:
+  schedule:
+    # 16:00 UTC = 02:00 AEST — quiet hours for the fleet's operators.
+    - cron: "0 16 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # docker-images-build pulls private GHCR images (BASE_IMAGE +
+  # :buildcache cache-from). Build-only — nothing is pushed.
+  packages: read
+
+concurrency:
+  group: ci-full-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: ${{ github.repository_owner }}
+
+jobs:
+  # ─── Lint (mirrors ci-lint.yml lint-run) ──────────────────────────
+  lint-full:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Set up workspace
+        uses: ./.github/actions/setup-switchroom
+      - name: Run lint
+        run: bun lint
+
+  # ─── Full vitest suite (mirrors ci-tests-core.yml, no --changed) ──
+  build-dist:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Set up workspace
+        uses: ./.github/actions/setup-switchroom
+      - name: Build dist/
+        run: bun scripts/build.mjs
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: dist-built-full
+          path: dist/
+          retention-days: 1
+          if-no-files-found: error
+
+  vitest-full:
+    needs: build-dist
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    env:
+      TELEGRAM_BOT_TOKEN: "123456:stub-for-tests"
+      VITEST_MAX_FORKS: "2"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Set up workspace
+        uses: ./.github/actions/setup-switchroom
+        with:
+          install-jq: "true"
+      - name: Download dist artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: dist-built-full
+          path: dist/
+      - name: Restore exec bits on bundled CLIs
+        # Artifact zip strips POSIX exec bits — see ci-tests-core.yml.
+        run: |
+          chmod +x dist/cli/*.js dist/cli/*.mjs 2>/dev/null || true
+      - name: Vitest shard ${{ matrix.shard }}/4 (full suite)
+        run: bunx vitest run --shard ${{ matrix.shard }}/4
+
+  # ─── Plugin bun tests (mirrors ci-tests-plugin.yml bun-test-run) ──
+  bun-test-full:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    env:
+      TELEGRAM_BOT_TOKEN: "123456:stub-for-tests"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Set up workspace
+        uses: ./.github/actions/setup-switchroom
+      - name: Bun test (telegram-plugin)
+        working-directory: telegram-plugin
+        run: |
+          bun test \
+            admin-commands gateway registry secret-detect tests \
+            channel-envelope-safety.test.ts
+
+  # ─── Python tests (mirrors ci-tests-python.yml unittest) ──────────
+  python-full:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Run unittest discover (hindsight scripts)
+        working-directory: vendor/hindsight-memory/scripts
+        run: python3 -m unittest discover tests/
+      - name: Run voice-sidecar unittests
+        working-directory: docker/voice-sidecar
+        run: python3 -m unittest discover -s . -p 'test_*.py'
+
+  # ─── Docker e2e, forced COLD path (mirrors docker-e2e.yml e2e) ────
+  # Deliberately no actions/cache restore: the nightly job exists to
+  # prove the from-scratch build sequence still works even when every
+  # PR-path run has been riding the warm tarball for weeks.
+  docker-e2e-full:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Set up workspace
+        uses: ./.github/actions/setup-switchroom
+      - name: Build dist/
+        run: bun scripts/build.mjs
+      - name: Set up Docker Buildx
+        # `docker` driver, not docker-container — build-images.sh chains
+        # FROM switchroom/base:phase1b-test via the local daemon (see
+        # docker-e2e.yml).
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+        with:
+          driver: docker
+      - name: Build phase1b-test images (cold)
+        run: bash tests/docker/build-images.sh
+      - name: Tag phase2a-test / phase2b-test aliases
+        run: |
+          docker tag switchroom/broker:phase1b-test switchroom/broker:phase2a-test
+          docker tag switchroom/kernel:phase1b-test switchroom/kernel:phase2b-test
+      - name: Run docker e2e suite (with pre/post snapshot gate)
+        run: bash scripts/ci/docker-snapshot-gate.sh
+      - name: Capture broker / kernel logs on failure
+        if: failure()
+        run: |
+          echo "::group::docker ps -a"
+          docker ps -a || true
+          echo "::endgroup::"
+          for c in $(docker ps -aq --filter label=switchroom.test=phase2c); do
+            echo "::group::logs $c"
+            docker logs "$c" 2>&1 | tail -200 || true
+            echo "::endgroup::"
+          done
+      - name: Label-scoped teardown
+        if: always()
+        run: |
+          for label in switchroom.test=phase1b switchroom.test=phase2a switchroom.test=phase2b switchroom.test=phase2c; do
+            ids=$(docker ps -aq --filter label=$label 2>/dev/null || true)
+            if [ -n "$ids" ]; then
+              docker rm -f $ids 2>/dev/null || true
+            fi
+          done
+
+  # ─── Full image-build validation (mirrors docker-images.yml, BUILD
+  # ONLY — push: false, so :latest / :dev / :sha-* are never touched
+  # and no fresh claude@latest is silently republished) ──────────────
+  # amd64-only like the PR path; dependents resolve BASE_IMAGE from the
+  # published :latest exactly as PR builds do, so every leg is
+  # independent (no base→dependents ordering needed).
+  docker-images-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - { name: base,        file: docker/Dockerfile.base,        dist: true,  base-arg: false }
+          - { name: agent,       file: docker/Dockerfile.agent,       dist: true,  base-arg: true }
+          - { name: broker,      file: docker/Dockerfile.broker,      dist: true,  base-arg: true }
+          - { name: kernel,      file: docker/Dockerfile.kernel,      dist: true,  base-arg: true }
+          - { name: hostd,       file: docker/Dockerfile.hostd,       dist: true,  base-arg: true }
+          - { name: auth-broker, file: docker/Dockerfile.auth-broker, dist: true,  base-arg: true }
+          - { name: web,         file: docker/Dockerfile.web,         dist: true,  base-arg: true }
+          - { name: hindsight,   file: docker/Dockerfile.hindsight,   dist: false, base-arg: false }
+          - { name: voice,       file: docker/Dockerfile.voice,       dist: false, base-arg: false }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up Node (for dist/ bundling)
+        if: matrix.image.dist
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "22"
+
+      - name: Set up Bun (build.mjs invokes bun build)
+        if: matrix.image.dist
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: latest
+
+      - name: Install deps + build dist/
+        if: matrix.image.dist
+        run: |
+          bun install
+          npm run build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      - name: Log in to GHCR (cache-from + BASE_IMAGE pulls only)
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build ${{ matrix.image.name }} (validation only, no push)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        with:
+          context: .
+          file: ${{ matrix.image.file }}
+          platforms: linux/amd64
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/switchroom-${{ matrix.image.name }}:ci-full
+          push: false
+          build-args: ${{ matrix.image.base-arg && format('BASE_IMAGE={0}/{1}/switchroom-base:latest', env.REGISTRY, env.IMAGE_NAMESPACE) || '' }}
+          # Read-only registry cache (never cache-to — #1965 pattern,
+          # and this job must not pollute the release cache).
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-${{ matrix.image.name }}:buildcache

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     outputs:
-      relevant: ${{ steps.filter.outputs.relevant }}
+      relevant: ${{ steps.filter.outputs.lint }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -45,28 +45,11 @@ jobs:
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         with:
-          filters: |
-            relevant:
-              - '**/*.ts'
-              - '**/*.tsx'
-              - 'tsconfig.json'
-              - 'package.json'
-              - 'bun.lock'
-              - 'telegram-plugin/package.json'
-              - 'telegram-plugin/bun.lock'
-              - 'scripts/check-*.mjs'
-              - 'scripts/check-bot-api-wrapping.sh'
-              - '.github/actions/setup-switchroom/**'
-              - '.github/workflows/ci-lint.yml'
-              # sec WS9-F1 (#1402): don't skip→pass the required gate on
-              # a security-load-bearing non-.ts change (agent boot/hook
-              # templates, image-baked hook scripts/skills, Dockerfiles,
-              # CI). See ci-tests-core.yml for the rationale.
-              - 'profiles/**'
-              - 'bin/**'
-              - 'skills/**'
-              - 'docker/**'
-              - '.github/workflows/**'
+          # Shared external filters file — the sec WS9-F1 (#1402)
+          # security-load-bearing path list is defined ONCE there and
+          # anchored into each workflow's filter key. See the header of
+          # .github/path-filters.yml for the rationale.
+          filters: .github/path-filters.yml
 
   lint-run:
     needs: changes

--- a/.github/workflows/ci-tests-core.yml
+++ b/.github/workflows/ci-tests-core.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     outputs:
-      relevant: ${{ steps.filter.outputs.relevant }}
+      relevant: ${{ steps.filter.outputs.core }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -70,33 +70,11 @@ jobs:
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         with:
-          filters: |
-            relevant:
-              - 'src/**'
-              - 'tests/**'
-              - 'telegram-plugin/**/*.ts'
-              - 'scripts/build.mjs'
-              - 'vitest.config.ts'
-              - 'tsconfig.json'
-              - 'package.json'
-              - 'bun.lock'
-              - 'telegram-plugin/package.json'
-              - 'telegram-plugin/bun.lock'
-              - '.github/actions/setup-switchroom/**'
-              - '.github/workflows/ci-tests-core.yml'
-              # sec WS9-F1 (#1402): security-load-bearing non-src paths.
-              # profiles/ renders every agent's start.sh + the WS8
-              # tool-safety hooks; bin/*-hook.sh + skills/ are baked into
-              # the agent image; docker/ + workflows are the supply-chain
-              # root. Without these a profiles/bin/skills/docker/.github-
-              # only PR skipped→passed this required gate with no tests.
-              # The scaffold/profile-render tests live under src/+tests/
-              # which this `vitest` sentinel runs.
-              - 'profiles/**'
-              - 'bin/**'
-              - 'skills/**'
-              - 'docker/**'
-              - '.github/workflows/**'
+          # Shared external filters file — the sec WS9-F1 (#1402)
+          # security-load-bearing path list is defined ONCE there and
+          # anchored into each workflow's filter key. See the header of
+          # .github/path-filters.yml for the rationale.
+          filters: .github/path-filters.yml
 
   # ─── Build dist/ once, share with all shards ──────────────────────
   build-dist:

--- a/.github/workflows/ci-tests-plugin.yml
+++ b/.github/workflows/ci-tests-plugin.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     outputs:
-      relevant: ${{ steps.filter.outputs.relevant }}
+      relevant: ${{ steps.filter.outputs.plugin }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -46,23 +46,11 @@ jobs:
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         with:
-          filters: |
-            relevant:
-              - 'telegram-plugin/**'
-              - 'package.json'
-              - 'bun.lock'
-              - 'telegram-plugin/package.json'
-              - 'telegram-plugin/bun.lock'
-              - '.github/actions/setup-switchroom/**'
-              - '.github/workflows/ci-tests-plugin.yml'
-              # sec WS9-F1 (#1402): don't skip→pass the required gate on
-              # a security-load-bearing non-telegram-plugin change. See
-              # ci-tests-core.yml for the rationale.
-              - 'profiles/**'
-              - 'bin/**'
-              - 'skills/**'
-              - 'docker/**'
-              - '.github/workflows/**'
+          # Shared external filters file — the sec WS9-F1 (#1402)
+          # security-load-bearing path list is defined ONCE there and
+          # anchored into each workflow's filter key. See the header of
+          # .github/path-filters.yml for the rationale.
+          filters: .github/path-filters.yml
 
   bun-test-run:
     needs: changes

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -54,7 +54,54 @@ env:
   IMAGE_NAMESPACE: ${{ github.repository_owner }}
 
 jobs:
+  # ─── Path-change filter (sentinel pattern, see ci-lint.yml) ───────
+  # PRs that don't touch image inputs skip the whole build matrix —
+  # previously EVERY PR paid ~9 image builds. Filters live in
+  # .github/path-filters.yml (keys: images / hindsight / voice).
+  #
+  # Gating policy:
+  #   - build-base / build-dependents: PRs gated on `images`; every
+  #     non-PR event (main push, tag, dispatch) always builds — we
+  #     don't gamble on the release path.
+  #   - build-hindsight / build-voice: also path-gated on MAIN PUSHES
+  #     (`hindsight` / `voice` keys) — they extend upstream bases, not
+  #     switchroom-base, and rarely change; an unchanged context was a
+  #     ~100% cache-hit no-op push anyway (promote-to-dev already
+  #     tolerates the missing :sha-<short> tag). Tags + dispatch still
+  #     always build them.
+  #
+  # This job itself skips on tag pushes / workflow_dispatch (dorny has
+  # no diff base there); downstream `if:`s use `!cancelled()` so a
+  # skipped `changes` doesn't auto-skip the builds on those events.
+  #
+  # NOTE (required checks): Ruleset 16470166 must require the
+  # `images-ok` sentinel below INSTEAD of build-base/build-hindsight/
+  # build-dependents ×6 — a path-skipped required matrix context would
+  # hard-block irrelevant PRs (#1343 lesson).
+  changes:
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      images: ${{ steps.filter.outputs.images }}
+      hindsight: ${{ steps.filter.outputs.hindsight }}
+      voice: ${{ steps.filter.outputs.voice }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        with:
+          filters: .github/path-filters.yml
+
   build-base:
+    needs: changes
+    # Non-PR events (main push / tag / dispatch): always build.
+    # PRs: only when image inputs changed. `!cancelled()` because
+    # `changes` is skipped on tag/dispatch and a skipped need would
+    # otherwise auto-skip this job.
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.images == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -163,7 +210,12 @@ jobs:
             CACHE_BUST=${{ github.run_attempt }}
 
   build-dependents:
-    needs: build-base
+    needs: [changes, build-base]
+    # Same gate as build-base, plus an explicit success check on the
+    # base build — `!cancelled()` alone would let dependents run past
+    # a FAILED base (unlike the default all-needs-succeeded semantics
+    # it replaces).
+    if: ${{ !cancelled() && needs.build-base.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.images == 'true') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -266,6 +318,14 @@ jobs:
     # base job and runs in parallel. See docker/Dockerfile.hindsight
     # for why we extend instead of running upstream as-is (claude-code
     # provider + claude-agent-sdk + UID pin).
+    #
+    # Path-gated on PRs AND main pushes (see `changes` header): the
+    # hindsight context rarely changes, and an unchanged-context main
+    # push was already a pure cache-hit no-op (nothing pushed, no
+    # :sha-<short> tag — promote-to-dev's absence-skip handles it).
+    # Tags + workflow_dispatch always build.
+    needs: changes
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || needs.changes.outputs.hindsight == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -335,6 +395,12 @@ jobs:
     # hosts are amd64. Building an arm64 leg would emit an image that can't
     # actually run GPU STT, so we don't (this is the one fleet image that
     # is single-arch by design — every other image is amd64+arm64).
+    #
+    # Path-gated on PRs AND main pushes like build-hindsight (see the
+    # `changes` header): the CUDA layers make voice the heaviest build
+    # and its context almost never changes. Tags + dispatch always build.
+    needs: changes
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || needs.changes.outputs.voice == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -448,8 +514,19 @@ jobs:
     # a missing `:sha-<short>` at promote time provably means
     # "build succeeded but context unchanged → buildx cache hit, nothing
     # pushed", never "build failed".
+    # Since the hindsight/voice builds became path-gated on main pushes
+    # too, their `needs` result can legitimately be `skipped` here — a
+    # skip means "context unchanged this commit, nothing pushed", which
+    # the retag step below already treats as a benign absence (existing
+    # :dev retained). So this `if:` requires smoke-test SUCCESS but only
+    # non-failure (success or skipped) from hindsight/voice.
     needs: [smoke-test, build-hindsight, build-voice]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      !cancelled() &&
+      github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+      needs.smoke-test.result == 'success' &&
+      needs.build-hindsight.result != 'failure' && needs.build-hindsight.result != 'cancelled' &&
+      needs.build-voice.result != 'failure' && needs.build-voice.result != 'cancelled'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -504,3 +581,43 @@ jobs:
             printf '%s\n' "$out"
             exit 1
           fi
+
+  # ─── Sentinel ─────────────────────────────────────────────────────
+  # Branch-protection-required context (see ci-lint.yml header for the
+  # pattern). ALWAYS runs and aggregates the path-gated build jobs:
+  # pass when every build succeeded OR was legitimately path-skipped;
+  # fail when any build failed/cancelled, or when the `changes` filter
+  # job itself broke on an event where it gates (can't trust a skip
+  # produced by broken infra). Ruleset 16470166 should require
+  # `images-ok` INSTEAD of build-base / build-hindsight /
+  # build-dependents ×6.
+  images-ok:
+    needs: [changes, build-base, build-dependents, build-hindsight, build-voice]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Verdict
+        run: |
+          c='${{ needs.changes.result }}'
+          # `changes` is intentionally skipped on tag pushes /
+          # workflow_dispatch (no diff base) — skipped is fine; only a
+          # failure/cancel is infra breakage.
+          if [ "$c" = "failure" ] || [ "$c" = "cancelled" ]; then
+            echo "::error::changes=$c — path-filter infra failed; can't trust skip"
+            exit 1
+          fi
+          fail=0
+          for pair in \
+            "build-base=${{ needs.build-base.result }}" \
+            "build-dependents=${{ needs.build-dependents.result }}" \
+            "build-hindsight=${{ needs.build-hindsight.result }}" \
+            "build-voice=${{ needs.build-voice.result }}"; do
+            job="${pair%%=*}"; r="${pair#*=}"
+            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+              echo "::error::${job}=${r} — real build failure, blocking"
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ] || exit 1
+          echo "changes=$c → pass (builds green or path-skipped)"


### PR DESCRIPTION
## What

Three CI changes: path-filter the most expensive PR workflow (`docker-images`), add a nightly unfiltered full sweep as the safety net behind every skip optimisation, and deduplicate the WS9-F1 security path list into a shared filters file.

### A — `docker-images.yml` path-filtered (biggest PR-loop win)

Every PR previously paid ~9 image builds regardless of what it touched. Now:

- New `changes` job (dorny/paths-filter, pinned same SHA as the other workflows) reading keys `images` / `hindsight` / `voice` from `.github/path-filters.yml`.
- `build-base` / `build-dependents`: gated on `images` for PRs; **every non-PR event (main push / tag / dispatch) always builds** — no gamble on the release path.
- `build-hindsight` / `build-voice`: path-gated on PRs **and main pushes**. They extend upstream bases (not `switchroom-base`) and rarely change — an unchanged-context main push was already a 100% cache-hit no-op that pushed nothing; `promote-to-dev`'s existing absence-skip logic handles the missing `:sha-<short>` identically for a path-skip. Tags + dispatch still always build.
- `promote-to-dev` `if:` updated to require smoke-test success but tolerate skipped (not failed/cancelled) hindsight/voice.
- New always-run **`images-ok` sentinel** following the repo pattern (`if: always()`, fails on `failure|cancelled` of any gated build, infra-failure guard on `changes`).

### ⚠️ Required-check retune (one-time, at merge)

Ruleset `16470166` currently requires `build-base`, `build-hindsight`, and `build-dependents ×6`. Once this merges, a docs-only PR will path-skip those and hard-block (#1343 lesson: skipped required ≠ pass). **Swap the 9 build contexts for the single `images-ok` sentinel** via `gh api repos/switchroom/switchroom/rulesets/16470166`. This PR itself is unaffected (it touches workflows, so all builds run).

### B — `ci-full.yml`: nightly unfiltered sweep

`schedule: 0 16 * * *` (02:00 AEST) + `workflow_dispatch`. Skip-vs-safety design: the PR path optimises for velocity (`vitest --changed`, path-gated jobs, warm e2e image cache, path-gated image builds), and each optimisation has a theoretical false-negative mode (stale filter, missed import-graph edge, poisoned cache, cold-build-only Dockerfile breakage). The nightly run closes the loop by running **everything, from scratch, no filters**:

- `lint-full`, full 4-shard vitest (no `--changed`), plugin bun tests, python tests — jobs defined directly (mirroring their source workflows 1:1) rather than `workflow_call`, because the existing jobs are event-gated (`push || relevant`) and would all skip under a `schedule` caller; converting them cheaply wasn't clean.
- `docker-e2e-full`: forced **cold path** — deliberately no `actions/cache` restore, proving the from-scratch image build sequence.
- `docker-images-build`: all 9 images, amd64, **`push: false`** — validation only, so `:latest`/`:dev`/`:sha-*` are never touched and no fresh `claude@latest` gets silently republished at night. Read-only registry cache (never `cache-to`, per #1965 + no release-cache pollution).
- `ci-uat` / `ci-evals` deliberately **not** scheduled — they burn real subscription quota; still dispatch-only.

### C — `.github/path-filters.yml` (shared filters)

The sec WS9-F1 (#1402) security-load-bearing path list was copy-pasted across `ci-lint` / `ci-tests-core` / `ci-tests-plugin` — a drift hazard (a path added to one copy but not the others silently reopens the skip→pass hole). It is now defined once as a YAML anchor in `.github/path-filters.yml` and consumed via dorny's external-filters-file mode (nested-array flattening verified against the pinned commit's `filter.ts`). The file itself is in every filter list, so editing it runs everything.

## Job served

Closest job spec: [`reference/jobs/idempotent-update-and-restart.md`](../blob/main/reference/jobs/idempotent-update-and-restart.md) — `docker-images` publishes the exact images `switchroom update` pulls; this keeps that release path always-built on main/tags while removing its cost from unrelated PRs, and the nightly sweep guarantees a cold rebuild of every image still works even when weeks of PRs rode caches and skips. The faster PR loop also serves the repo's agents-are-the-developers velocity (CLAUDE.md "You are the developer").

## Validation

- `yaml.safe_load` green on all workflows + the filters file.
- `actionlint v1.7.7` clean on all 5 touched workflows.
- dorny/paths-filter anchor/nested-list support verified against the pinned SHA's source.
- No TS touched; `npm run lint` not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)