### PR TITLE
durability: resume at-most-once via resumed_at ledger (#2793 part A)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -616,6 +616,7 @@ import {
   findLatestTurnIfInterrupted,
   findRecentTurnsForChat,
   getTurnByKey,
+  markTurnResumed,
 } from '../registry/turns-schema.js'
 import {
   buildResumeInterruptedInbound,
@@ -6943,6 +6944,25 @@ if (bootResumeInbound != null) {
     inboundSpool.put(bootResumeInbound.agent, bootResumeInbound.msg)
   } else {
     pendingInboundBuffer.push(bootResumeInbound.agent, bootResumeInbound.msg)
+  }
+  // At-most-once resume (#2793 part A): now that the resume inbound is
+  // DURABLY committed (spooled, or buffered in STATIC mode), stamp the
+  // turn's `resumed_at` so a later restart can't re-mint a fresh resume for
+  // the same turn and re-run side effects that already executed. This is
+  // synchronous and runs before any async delivery/ack can interleave, so
+  // the ledger is set before the spool entry can be consumed — closing the
+  // accept-vs-consume double-execution window. Stamping AFTER the durable
+  // put (never before) means a crash in between leaves the turn un-stamped
+  // and the resume is retried, not silently dropped.
+  const resumeTurnKey = bootResumeInbound.msg.meta?.resume_turn_key
+  if (turnsDb != null && typeof resumeTurnKey === 'string' && resumeTurnKey.length > 0) {
+    try {
+      markTurnResumed(turnsDb, resumeTurnKey)
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: markTurnResumed failed turnKey=${resumeTurnKey}: ${(err as Error).message}\n`,
+      )
+    }
   }
 }
 // Boot-replay: re-queue every un-acked spooled inbound into the

--- a/telegram-plugin/registry/turns-schema.ts
+++ b/telegram-plugin/registry/turns-schema.ts
@@ -108,6 +108,18 @@ export interface Turn {
    * cleanly-restarted (`'restart'`) orphans.
    */
   interrupt_reason: string | null
+  /**
+   * Ms epoch at which a boot-resume/report inbound was durably queued for
+   * this interrupted turn (see `markTurnResumed`). It is the at-most-once
+   * ledger for resume: `findLatestTurnIfInterrupted` treats a turn with a
+   * non-null `resumed_at` as already handled and never re-fires it. This
+   * distinguishes "we already committed a resume for this turn (side
+   * effects may have run)" from "work incomplete, never resumed" — closing
+   * the accept-vs-consume double-execution window (#2793 part A) where the
+   * "latest turn not clean" proxy re-minted a fresh resume on every restart.
+   * Null for turns that were never resumed.
+   */
+  resumed_at: number | null
   created_at: number
   updated_at: number
 }
@@ -148,6 +160,7 @@ const SCHEMA_SQL = `
     assistant_reply_preview TEXT,
     tool_call_count         INTEGER,
     interrupt_reason        TEXT,
+    resumed_at              INTEGER,
     created_at              INTEGER NOT NULL,
     updated_at              INTEGER NOT NULL
   );
@@ -169,6 +182,14 @@ const PHASE2_MIGRATIONS = [
   `ALTER TABLE turns ADD COLUMN interrupt_reason TEXT`,
 ]
 
+// Column added for at-most-once resume (#2793 part A). Stamped when the
+// gateway durably queues a boot-resume inbound for an interrupted turn, so a
+// subsequent restart cannot re-mint a fresh resume for the same turn (which
+// would re-run side effects that already executed before the crash).
+const PHASE3_MIGRATIONS = [
+  `ALTER TABLE turns ADD COLUMN resumed_at INTEGER`,
+]
+
 function applySchema(db: SqliteDatabase): void {
   db.exec('PRAGMA journal_mode = WAL')
   db.exec('PRAGMA synchronous = NORMAL')
@@ -185,7 +206,7 @@ function applySchema(db: SqliteDatabase): void {
   // Run migrations. SQLite doesn't support "ADD COLUMN IF NOT EXISTS", so
   // we swallow the "duplicate column" error to stay idempotent on
   // pre-existing registry.db files.
-  for (const sql of [...PHASE1_MIGRATIONS, ...PHASE2_MIGRATIONS]) {
+  for (const sql of [...PHASE1_MIGRATIONS, ...PHASE2_MIGRATIONS, ...PHASE3_MIGRATIONS]) {
     try {
       db.exec(sql)
     } catch (err) {
@@ -261,6 +282,7 @@ interface RawTurnRow {
   assistant_reply_preview: string | null
   tool_call_count: number | null
   interrupt_reason: string | null
+  resumed_at: number | null
   created_at: number
   updated_at: number
 }
@@ -281,6 +303,7 @@ function mapRow(row: RawTurnRow): Turn {
     assistant_reply_preview: row.assistant_reply_preview,
     tool_call_count: row.tool_call_count,
     interrupt_reason: row.interrupt_reason,
+    resumed_at: row.resumed_at,
     created_at: row.created_at,
     updated_at: row.updated_at,
   }
@@ -560,6 +583,38 @@ const INTERRUPTED_VIA: ReadonlySet<TurnEndedVia> = new Set<TurnEndedVia>([
 ])
 
 /**
+ * Stamp `resumed_at` on an interrupted turn at the moment the gateway has
+ * DURABLY committed to resuming it (the boot-resume inbound is on the
+ * inbound spool / in-memory buffer). This is the at-most-once ledger for
+ * resume: once stamped, `findLatestTurnIfInterrupted` no longer returns the
+ * turn, so a subsequent restart cannot mint a SECOND, distinct resume for
+ * the same turn and re-run side effects that already executed before the
+ * crash (#2793 part A).
+ *
+ * Ordering matters: the caller must stamp only AFTER the resume inbound is
+ * durably spooled (synchronously, before any async delivery can ack it), so
+ * a crash between "decide to resume" and "persist the resume" can never mark
+ * a turn resumed that was never actually spooled. The spool's own
+ * at-least-once redelivery (keyed on `resume_turn_key`) still guarantees the
+ * one committed resume is delivered; this ledger only prevents re-minting.
+ *
+ * Idempotent and first-write-wins: an already-stamped turn keeps its
+ * original `resumed_at`. No-ops if `turnKey` is not found.
+ */
+export function markTurnResumed(
+  db: SqliteDatabase,
+  turnKey: string,
+  now: number = Date.now(),
+): void {
+  db.prepare(`
+    UPDATE turns
+    SET resumed_at = ?,
+        updated_at = ?
+    WHERE turn_key = ? AND resumed_at IS NULL
+  `).run(now, now, turnKey)
+}
+
+/**
  * Return the single most-recently-started turn IFF it was interrupted
  * (`ended_at IS NULL`, or `ended_via` in {restart, sigterm, timeout,
  * unknown}). Returns null when the latest turn ended cleanly (`'stop'`)
@@ -576,6 +631,14 @@ const INTERRUPTED_VIA: ReadonlySet<TurnEndedVia> = new Set<TurnEndedVia>([
  * Ordering uses `started_at DESC` (not `updated_at`) so the boot reaper,
  * which mass-stamps orphans with identical timestamps, can't reorder the
  * temporal "last turn" the user actually remembers.
+ *
+ * At-most-once (#2793 part A): a turn that already carries `resumed_at` was
+ * committed to a resume on an earlier boot. Even if it never reached a clean
+ * `'stop'` (its resume ran side effects but the process died before the
+ * follow-up turn wrote `ended_at`, or the resume inbound was accepted but
+ * never consumed), it is NOT re-fired — the "latest turn not clean" proxy
+ * would otherwise re-mint a fresh resume on every restart and double-execute
+ * side effects. Resume is at-most-once per turn.
  */
 export function findLatestTurnIfInterrupted(db: SqliteDatabase): Turn | null {
   const row = db.prepare(`
@@ -585,6 +648,7 @@ export function findLatestTurnIfInterrupted(db: SqliteDatabase): Turn | null {
   `).get() as RawTurnRow | undefined
   if (!row) return null
   const turn = mapRow(row)
+  if (turn.resumed_at != null) return null
   if (turn.ended_at == null) return turn
   if (turn.ended_via != null && INTERRUPTED_VIA.has(turn.ended_via)) return turn
   return null

--- a/telegram-plugin/tests/registry-turns.test.ts
+++ b/telegram-plugin/tests/registry-turns.test.ts
@@ -19,6 +19,8 @@ import {
   findOrphanedTurns,
   markOrphanedWithTimeoutClassification,
   findLatestTurnIfInterrupted,
+  markTurnResumed,
+  getTurnByKey,
 } from '../registry/turns-schema.js'
 
 // Convenience: the boot reaper with no live hang marker — every open turn
@@ -504,6 +506,71 @@ describe('findLatestTurnIfInterrupted', () => {
     recordTurnEnd(db, { turnKey: 'ddd:1', endedVia: 'sigterm' })
     recordTurnEnd(db, { turnKey: 'ddd:2', endedVia: 'stop' })
     expect(findLatestTurnIfInterrupted(db)).toBeNull()
+    db.close()
+  })
+
+  // ── #2793 part A: resume is at-most-once via the `resumed_at` ledger ──
+  // Repro: without the ledger, an interrupted turn whose resume ran its
+  // side effects but never reached a clean 'stop' (process died before the
+  // follow-up turn wrote ended_at, or the resume inbound was accepted but
+  // never consumed) stays "latest + not clean" — so every subsequent boot
+  // re-mints a fresh resume and DOUBLE-EXECUTES. The ledger makes it null
+  // after the first commit.
+  it('re-fires an interrupted turn until it is stamped resumed (double-exec repro)', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'res:1', chatId: 'res' })
+    recordTurnEnd(db, { turnKey: 'res:1', endedVia: 'restart' })
+    // Boot 1: the turn is interrupted and still unresumed → it is returned
+    // (the gateway will mint a resume for it).
+    const first = findLatestTurnIfInterrupted(db)
+    expect(first).not.toBeNull()
+    expect(first!.turn_key).toBe('res:1')
+    expect(first!.resumed_at).toBeNull()
+    // Gateway durably queues the resume, then stamps the ledger.
+    markTurnResumed(db, 'res:1', 1_700_000_000_000)
+    // Boot 2 (crash happened after side effects, turn still 'restart' with
+    // no clean follow-up): the SAME turn must NOT be resumed again.
+    expect(findLatestTurnIfInterrupted(db)).toBeNull()
+    db.close()
+  })
+
+  it('does not re-fire even an OPEN (ended_at IS NULL) turn once resumed', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'res:2', chatId: 'res' })
+    // Still open (never reaped to a terminal ended_via), but already resumed
+    // once — the accept-but-never-consumed window. Must not re-fire.
+    markTurnResumed(db, 'res:2')
+    expect(findLatestTurnIfInterrupted(db)).toBeNull()
+    db.close()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// markTurnResumed — the at-most-once resume ledger (#2793 part A)
+// ---------------------------------------------------------------------------
+
+describe('markTurnResumed', () => {
+  it('stamps resumed_at on the target turn', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'mk:1', chatId: 'mk' })
+    recordTurnEnd(db, { turnKey: 'mk:1', endedVia: 'restart' })
+    markTurnResumed(db, 'mk:1', 1_700_000_000_000)
+    expect(getTurnByKey(db, 'mk:1')!.resumed_at).toBe(1_700_000_000_000)
+    db.close()
+  })
+
+  it('is first-write-wins: a second stamp does not overwrite the first', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'mk:2', chatId: 'mk' })
+    markTurnResumed(db, 'mk:2', 1_700_000_000_000)
+    markTurnResumed(db, 'mk:2', 1_800_000_000_000)
+    expect(getTurnByKey(db, 'mk:2')!.resumed_at).toBe(1_700_000_000_000)
+    db.close()
+  })
+
+  it('no-ops for an unknown turn_key', () => {
+    const db = openTurnsDbInMemory()
+    expect(() => markTurnResumed(db, 'nope:1')).not.toThrow()
     db.close()
   })
 })

--- a/telegram-plugin/tests/resume-inbound-builder.test.ts
+++ b/telegram-plugin/tests/resume-inbound-builder.test.ts
@@ -37,6 +37,7 @@ function makeTurn(overrides: Partial<Turn> = {}): Turn {
     assistant_reply_preview: null,
     tool_call_count: null,
     interrupt_reason: null,
+    resumed_at: null,
     created_at: 1_000_000,
     updated_at: 1_000_000,
     ...overrides,


### PR DESCRIPTION
## What

Closes the **accept-vs-consume double-execution window on boot resume** — part A of #2793.

`findLatestTurnIfInterrupted` used "the latest turn isn't clean" as a proxy for "work incomplete", and the gateway minted a **fresh** resume inbound on **every** restart. So an interrupted turn whose resume already ran its side effects — but never reached a clean `'stop'` (the process died before the follow-up turn wrote `ended_at`, or the resume inbound was *accepted by the bridge but never consumed*) — was resumed again and again, **re-executing side effects**.

## Fix

A durable `resumed_at` ledger on the per-agent turns registry:

- new `resumed_at` column (`PHASE3` `ALTER TABLE`, non-destructive on existing `registry.db` files)
- `markTurnResumed()` stamps it **first-write-wins**
- `findLatestTurnIfInterrupted()` returns `null` once a turn carries `resumed_at` → **resume is at-most-once per turn**

The gateway stamps `resumed_at` **synchronously, immediately after** the resume inbound is durably committed to the inbound spool (or the in-memory buffer in STATIC mode) — before any async delivery/ack can interleave. Stamping *after* the durable put (never before) means a crash in between leaves the turn un-stamped and the resume is retried, not silently dropped. The spool's own at-least-once redelivery (keyed on `resume_turn_key`) still guarantees the single committed resume is delivered; the ledger only prevents re-*minting*.

This distinguishes "we already committed a resume for this turn (side effects may have run)" from "work incomplete, never resumed" — exactly the distinction the issue calls for.

## JTBD / vision

- **Job:** `survive-reboots-and-real-life` — "in-flight work is resumed or named-as-lost, never dropped in silence" (and, per this fix, never *double-executed*).
- **Vision outcome:** always-on — an agent comes back cleanly after a crash without re-running side effects.
- Invariants: sits near `chat-is-the-single-source-of-truth`; the registry stays a durable ledger, no new source of truth.

## Tests

`telegram-plugin/tests/registry-turns.test.ts`:
- **double-exec repro** — an interrupted `'restart'` turn is returned on boot 1, stamped resumed, then **not** re-fired on boot 2 (the exact re-mint that double-executed before this fix).
- an OPEN (`ended_at IS NULL`) turn is not re-fired once resumed (the accept-but-never-consumed window).
- `markTurnResumed` stamps, is first-write-wins, and no-ops on unknown keys.

`npm run lint` green; touched-area `bun test` green (69 pass). Full `test:bun`: 1080 pass / 2 fail — the 2 failures are in `src/vault/broker/client-token.test.ts` and **also fail on clean `origin/main`** (env-only, unrelated to this change).

## Scope note — #2793 part B (cron replay accept-vs-consume)

Part B ("route cron replays through the durable inbound spool so accept and consume are ledgered separately") is **intentionally not in this PR**. The in-agent scheduler (`src/agent-scheduler/`) and the gateway's inbound spool live in **separate processes**: the scheduler's audit JSONL records a fire as done at *socket-accept* (`result.delivered`), while a true consume-ack would require the gateway to signal consumption back across IPC — a cross-process protocol the scheduler cannot ledger alone. That is a genuine design change with real blast radius, so it is left as a documented follow-up rather than guessed at here. This PR fully closes the **resume** half of the double-execution class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)