### PR TITLE
cleanup: unify path-as-identity peercred primitive (#2795)

### DIFF
--- a/src/auth/broker/peercred.ts
+++ b/src/auth/broker/peercred.ts
@@ -19,22 +19,35 @@
  * on peer UID, because UIDs collide and the bind-path is what we control.
  */
 
+import { matchSocketName } from "../../broker-common/peercred-path.js";
+
 /** Listener-bind regex. Accepts `<name>/sock` shape only — flat `<name>.sock` is rejected. */
 const AUTH_BROKER_SOCKET_PATH_RE =
   /^\/run\/switchroom\/auth-broker\/([a-zA-Z0-9][a-zA-Z0-9_-]*)\/sock$/;
 
+/** Max slug length — defence in depth beyond the regex slug shape. */
+const AUTH_BROKER_MAX_NAME_LEN = 63;
+
 /** Reserved socket-path names that cannot be used as agent or consumer names. */
 export const RESERVED_NAMES = new Set(["operator"]);
 
-/** Bind-path → name. Returns null when the path matches no canonical shape. */
+/**
+ * Bind-path → name (raw, including the reserved `operator` name — the
+ * kind split happens in `classify` against the loaded config). Returns null
+ * when the path matches no canonical shape or the name exceeds the length
+ * guard.
+ *
+ * #2795: the match+length-guard is the shared broker-plane primitive
+ * (`src/broker-common/peercred-path.ts` `matchSocketName`); this call site
+ * supplies only the auth-broker pattern + length cap. Semantics are
+ * identical to the pre-#2795 inline implementation.
+ */
 export function socketPathToName(socketPath: string): string | null {
-  const m = AUTH_BROKER_SOCKET_PATH_RE.exec(socketPath);
-  if (!m) return null;
-  const name = m[1];
-  // Validate name length and that it's a legal slug — defence in depth
-  // against a path slipping past the regex check.
-  if (name.length === 0 || name.length > 63) return null;
-  return name;
+  return matchSocketName(
+    socketPath,
+    [AUTH_BROKER_SOCKET_PATH_RE],
+    AUTH_BROKER_MAX_NAME_LEN,
+  );
 }
 
 /**

--- a/src/broker-common/peercred-path.test.ts
+++ b/src/broker-common/peercred-path.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the shared broker-plane path-as-identity primitive (#2795).
+ *
+ * These assert the SECURITY-load-bearing contract the three brokers now
+ * share: an authorized bind path yields the right identity, and every
+ * unauthorized / malformed / reserved-name path fails closed to null
+ * ("unidentified → DENIED"). The per-broker peercred tests
+ * (vault/auth/host-control) additionally pin that each site's regexes +
+ * reserved sets, fed through this primitive, reproduce their exact
+ * pre-#2795 behaviour.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  matchSocketName,
+  parseSocketIdentity,
+} from "./peercred-path.js";
+
+const SUBDIR = /^\/run\/switchroom\/broker\/([a-zA-Z0-9][a-zA-Z0-9_-]*)\/sock$/;
+const FLAT = /^\/run\/switchroom\/broker\/([a-zA-Z0-9][a-zA-Z0-9_-]*)\.sock$/;
+const reserved = new Set(["operator", "hostd"]);
+
+describe("matchSocketName", () => {
+  it("returns the captured name for an authorized path", () => {
+    expect(matchSocketName("/run/switchroom/broker/alice/sock", [SUBDIR])).toBe(
+      "alice",
+    );
+    expect(matchSocketName("/run/switchroom/broker/bob.sock", [FLAT])).toBe(
+      "bob",
+    );
+  });
+
+  it("returns the reserved name verbatim (no gate at this layer)", () => {
+    expect(matchSocketName("/run/switchroom/broker/operator/sock", [SUBDIR])).toBe(
+      "operator",
+    );
+  });
+
+  it("tries patterns in order, first match wins", () => {
+    expect(matchSocketName("/run/switchroom/broker/carol/sock", [FLAT, SUBDIR])).toBe(
+      "carol",
+    );
+  });
+
+  it("fails closed to null on non-string / empty / no-match", () => {
+    for (const bad of [
+      undefined,
+      null,
+      123,
+      {},
+      "",
+      "/etc/passwd",
+      "/run/switchroom/broker//sock",
+      "/run/switchroom/broker/alice/sock/extra",
+      "/run/switchroom/auth-broker/alice/sock",
+    ]) {
+      expect(matchSocketName(bad, [SUBDIR]), `expected null for ${String(bad)}`)
+        .toBeNull();
+    }
+  });
+
+  it("enforces the optional length guard (defence in depth)", () => {
+    const ok = "a".repeat(63);
+    const tooLong = "a".repeat(64);
+    expect(
+      matchSocketName(`/run/switchroom/broker/${ok}/sock`, [SUBDIR], 63),
+    ).toBe(ok);
+    expect(
+      matchSocketName(`/run/switchroom/broker/${tooLong}/sock`, [SUBDIR], 63),
+    ).toBeNull();
+  });
+});
+
+describe("parseSocketIdentity", () => {
+  const spec = { patterns: [FLAT, SUBDIR], reservedNames: reserved };
+
+  it("accepts an authorized agent peer", () => {
+    expect(parseSocketIdentity("/run/switchroom/broker/alice/sock", spec)).toEqual({
+      kind: "agent",
+      name: "alice",
+    });
+    expect(parseSocketIdentity("/run/switchroom/broker/bob.sock", spec)).toEqual({
+      kind: "agent",
+      name: "bob",
+    });
+  });
+
+  it("maps the operator name to {kind:operator} from either bind shape", () => {
+    expect(
+      parseSocketIdentity("/run/switchroom/broker/operator/sock", spec),
+    ).toEqual({ kind: "operator" });
+    // operator is ALSO in the reserved set — it must still resolve to
+    // operator (matched before the reserved-name rejection), never null.
+    expect(
+      parseSocketIdentity("/run/switchroom/broker/operator.sock", spec),
+    ).toEqual({ kind: "operator" });
+  });
+
+  it("rejects a reserved (non-operator) name as an agent — no bypass", () => {
+    expect(
+      parseSocketIdentity("/run/switchroom/broker/hostd/sock", spec),
+    ).toBeNull();
+    expect(
+      parseSocketIdentity("/run/switchroom/broker/hostd.sock", spec),
+    ).toBeNull();
+  });
+
+  it("rejects unauthorized / malformed paths (fail-closed)", () => {
+    for (const bad of [
+      "",
+      "/etc/passwd",
+      "/run/switchroom/broker/alice", // missing suffix
+      "/run/switchroom/broker/foo;bar/sock", // shell-special
+      "/run/switchroom/hostd/alice/sock", // wrong broker root
+    ]) {
+      expect(parseSocketIdentity(bad, spec), `expected null for "${bad}"`)
+        .toBeNull();
+    }
+  });
+
+  it("honours a custom operator name", () => {
+    const custom = {
+      patterns: [SUBDIR],
+      reservedNames: new Set(["root"]),
+      operatorName: "root",
+    };
+    expect(
+      parseSocketIdentity("/run/switchroom/broker/root/sock", custom),
+    ).toEqual({ kind: "operator" });
+  });
+});

--- a/src/broker-common/peercred-path.ts
+++ b/src/broker-common/peercred-path.ts
@@ -1,0 +1,116 @@
+/**
+ * Shared path-as-identity primitive for the switchroom broker plane (#2795).
+ *
+ * Three brokers derive the *identity* of a caller from the SERVER's own
+ * bind path — never from a wire payload, never from the SO_PEERCRED UID
+ * (UIDs collide; the bind path is what the broker controls):
+ *
+ *   - vault-broker        `/run/switchroom/broker/<agent>.sock` | `<agent>/sock`
+ *   - auth-broker         `/run/switchroom/auth-broker/<name>/sock`
+ *   - host-control (hostd) `/run/switchroom/hostd/<agent>/sock`
+ *                          `*​/.switchroom/hostd/<agent>/sock` (host view)
+ *
+ * Before #2795 each broker carried its own copy of the *same* three-step
+ * gate — (1) regex-match the path to a name, (2) map the reserved
+ * `operator` name to `{kind:"operator"}`, (3) reject any other reserved
+ * name, else `{kind:"agent"}`. Divergence between copies of an
+ * authentication primitive is exactly the class of drift that produces a
+ * silent authz bypass (issue #2795, audit items 4/5). This module is the
+ * single seam for that gate. Each broker keeps ONLY its site-specific
+ * declarative inputs — the anchored path patterns and the reserved-name
+ * set — and delegates the security-load-bearing parse+gate here.
+ *
+ * SECURITY MODEL — fail-closed. `matchSocketName` / `parseSocketIdentity`
+ * return null on ANY of: non-string / empty path, no pattern match, empty
+ * captured name, over-length name, or a reserved (non-operator) name in an
+ * agent slot. Every caller treats null as "unidentified → DENIED". The
+ * operator name is the ONE reserved name that resolves to a non-null,
+ * non-agent identity; it is matched BEFORE the reserved-name rejection so a
+ * reserved set that (correctly) also contains "operator" cannot swallow it.
+ */
+
+/**
+ * Identity of the listener that accepted a connection, derived purely from
+ * the bind path. `{kind:"agent"}` carries the agent slug; `{kind:"operator"}`
+ * is the host-shell operator socket (trust comes from the reserved bind path
+ * plus the mode-0600 + chown-to-operator-UID the broker enforces at bind).
+ */
+export type SocketIdentity =
+  | { kind: "agent"; name: string }
+  | { kind: "operator" };
+
+export interface PathIdentitySpec {
+  /**
+   * Anchored path patterns, tried in order. Each MUST have exactly one
+   * capture group whose match is the raw name. First match wins.
+   */
+  patterns: readonly RegExp[];
+  /**
+   * Names that may NOT be used as an agent name. Should include the
+   * operator name (defence in depth) — `parseSocketIdentity` resolves the
+   * operator name to `{kind:"operator"}` before consulting this set, so
+   * listing it here has no effect on the operator path but keeps the set an
+   * honest "these names are claimed by another identity kind" declaration.
+   */
+  reservedNames: ReadonlySet<string>;
+  /** The reserved name that maps to `{kind:"operator"}`. Default "operator". */
+  operatorName?: string;
+  /**
+   * Optional maximum captured-name length (defence in depth beyond the
+   * regex slug shape). When set, a longer name fails closed to null.
+   */
+  maxNameLen?: number;
+}
+
+/**
+ * Low-level: bind path → raw captured name, or null.
+ *
+ * Returns the name VERBATIM, including reserved names such as "operator" —
+ * it applies NO operator/reserved semantics. Callers that need the raw name
+ * to classify it against external state (auth-broker's config-driven
+ * agent/consumer/operator split) use this directly; callers that want a
+ * ready `SocketIdentity` use {@link parseSocketIdentity}.
+ *
+ * Fail-closed: null on non-string / empty path, no pattern match, empty
+ * capture, or (when `maxNameLen` is set) an over-length name.
+ */
+export function matchSocketName(
+  socketPath: unknown,
+  patterns: readonly RegExp[],
+  maxNameLen?: number,
+): string | null {
+  if (typeof socketPath !== "string" || socketPath.length === 0) return null;
+  let name: string | null = null;
+  for (const re of patterns) {
+    const m = socketPath.match(re);
+    if (m && typeof m[1] === "string") {
+      name = m[1];
+      break;
+    }
+  }
+  if (name === null || name.length === 0) return null;
+  if (maxNameLen !== undefined && name.length > maxNameLen) return null;
+  return name;
+}
+
+/**
+ * Bind path → {@link SocketIdentity} or null.
+ *
+ * The operator name resolves to `{kind:"operator"}` and is checked BEFORE
+ * the reserved-name rejection (so a reserved set that also contains the
+ * operator name can't null it out). Any OTHER reserved name → null. Every
+ * remaining match → `{kind:"agent", name}`.
+ *
+ * Fail-closed by inheritance from {@link matchSocketName}.
+ */
+export function parseSocketIdentity(
+  socketPath: unknown,
+  spec: PathIdentitySpec,
+): SocketIdentity | null {
+  const name = matchSocketName(socketPath, spec.patterns, spec.maxNameLen);
+  if (name === null) return null;
+  const operatorName = spec.operatorName ?? "operator";
+  if (name === operatorName) return { kind: "operator" };
+  if (spec.reservedNames.has(name)) return null;
+  return { kind: "agent", name };
+}

--- a/src/host-control/peercred.ts
+++ b/src/host-control/peercred.ts
@@ -14,6 +14,11 @@
  * an agent cannot forge identity by renaming its in-container view.
  */
 
+import {
+  parseSocketIdentity,
+  type SocketIdentity as BrokerSocketIdentity,
+} from "../broker-common/peercred-path.js";
+
 /** Subdir form on the in-container view: `/run/switchroom/hostd/<agent>/sock`. */
 const SOCKET_PATH_CONTAINER_SUBDIR_RE =
   /^\/run\/switchroom\/hostd\/([a-zA-Z0-9][a-zA-Z0-9_-]*)\/sock$/;
@@ -41,9 +46,7 @@ const SOCKET_PATH_HOST_SUBDIR_RE =
  */
 const RESERVED_AGENT_NAMES = new Set(["operator", "hostd"]);
 
-export type SocketIdentity =
-  | { kind: "agent"; name: string }
-  | { kind: "operator" };
+export type SocketIdentity = BrokerSocketIdentity;
 
 /**
  * Parse a bind-path or connect-path to an identity. Returns null
@@ -57,19 +60,19 @@ export type SocketIdentity =
  * One operator shape (host view only — the operator never connects
  * via a per-agent in-container socket):
  *   - `*\/.switchroom/hostd/operator/sock`
+ *
+ * #2795: the parse+operator+reserved gate is the shared broker-plane
+ * primitive (`src/broker-common/peercred-path.ts`); this call site supplies
+ * only the hostd-specific patterns + reserved set. Semantics are identical
+ * to the pre-#2795 inline implementation.
  */
 export function socketPathToIdentity(
   socketPath: string,
 ): SocketIdentity | null {
-  if (typeof socketPath !== "string" || socketPath.length === 0) return null;
-  const m =
-    socketPath.match(SOCKET_PATH_CONTAINER_SUBDIR_RE) ??
-    socketPath.match(SOCKET_PATH_HOST_SUBDIR_RE);
-  if (!m) return null;
-  const name = m[1];
-  if (name === "operator") return { kind: "operator" };
-  if (RESERVED_AGENT_NAMES.has(name)) return null;
-  return { kind: "agent", name };
+  return parseSocketIdentity(socketPath, {
+    patterns: [SOCKET_PATH_CONTAINER_SUBDIR_RE, SOCKET_PATH_HOST_SUBDIR_RE],
+    reservedNames: RESERVED_AGENT_NAMES,
+  });
 }
 
 /** True iff `name` is reserved by another identity kind and may not

--- a/src/vault/broker/peercred.ts
+++ b/src/vault/broker/peercred.ts
@@ -36,6 +36,10 @@ import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
 import { readFileSync, readlinkSync, fstatSync } from "node:fs";
 import type { Socket } from "node:net";
 import { getPeerCred } from "./peercred-ffi.js";
+import {
+  parseSocketIdentity,
+  type SocketIdentity as BrokerSocketIdentity,
+} from "../../broker-common/peercred-path.js";
 
 /**
  * Socket-path-as-identity (Phase 2a).
@@ -99,9 +103,7 @@ const RESERVED_AGENT_NAMES = new Set(["operator", "hostd"]);
  *                                 mode 0600 + chown to operator UID
  *                                 enforced by the broker at bind time.
  */
-export type SocketIdentity =
-  | { kind: "agent"; name: string }
-  | { kind: "operator" };
+export type SocketIdentity = BrokerSocketIdentity;
 
 /**
  * Path to identity. Returns null when the path matches no canonical shape.
@@ -114,22 +116,23 @@ export type SocketIdentity =
  * One operator shape:
  *   (c) /run/switchroom/broker/operator/sock         (RESERVED — not an agent)
  *
- * "operator" cannot be an agent name (see RESERVED_AGENT_NAMES); a flat
- * file at /run/switchroom/broker/operator.sock is also rejected to keep
- * the reservation airtight regardless of bind shape.
+ * "operator" cannot be an agent name (see RESERVED_AGENT_NAMES); it resolves
+ * to `{kind:"operator"}` from EITHER the subdir or the flat bind shape
+ * (`operator` is matched before the reserved-name gate in the shared
+ * primitive), so the reservation holds regardless of bind shape.
+ *
+ * #2795: the parse+operator+reserved gate is the shared broker-plane
+ * primitive (`src/broker-common/peercred-path.ts`); this call site supplies
+ * only the vault-specific patterns + reserved set. Semantics are identical
+ * to the pre-#2795 inline implementation.
  */
 export function socketPathToIdentity(
   socketPath: string,
 ): SocketIdentity | null {
-  if (typeof socketPath !== "string" || socketPath.length === 0) return null;
-  const m =
-    socketPath.match(SOCKET_PATH_AGENT_RE) ??
-    socketPath.match(SOCKET_PATH_AGENT_SUBDIR_RE);
-  if (!m) return null;
-  const name = m[1];
-  if (name === "operator") return { kind: "operator" };
-  if (RESERVED_AGENT_NAMES.has(name)) return null;
-  return { kind: "agent", name };
+  return parseSocketIdentity(socketPath, {
+    patterns: [SOCKET_PATH_AGENT_RE, SOCKET_PATH_AGENT_SUBDIR_RE],
+    reservedNames: RESERVED_AGENT_NAMES,
+  });
 }
 
 /**


### PR DESCRIPTION
## What & why

**JTBD:** `act-in-my-tools-with-an-identity` — every broker caller shows up under its *own* identity. **Vision outcome:** always-available (extends the fleet's identity plane), guarded by the **no-self-escalation** invariant. The path-as-identity gate is the mechanism that binds a broker caller to an identity; three divergent copies of it is exactly the drift that can silently loosen an authz boundary (audit items 4/5 in #2795).

## The consolidation

The three brokers — vault (`/run/switchroom/broker/…`), auth (`/run/switchroom/auth-broker/…`), host-control (`/run/switchroom/hostd/…`) — each carried their own copy of the same three-step gate:

1. regex-match the **server's own bind path** to a name,
2. map the reserved `operator` name to `{kind:"operator"}`,
3. reject any other reserved name, else `{kind:"agent"}` — fail-closed to `null` ("unidentified → DENIED").

This PR extracts that gate into **one** shared primitive, `src/broker-common/peercred-path.ts`:
- `matchSocketName(path, patterns, maxNameLen?)` — low-level path→raw-name (auth uses this and then classifies the name against loaded config),
- `parseSocketIdentity(path, spec)` — path→`SocketIdentity` with the operator/reserved gate.

Each broker keeps only its **site-specific declarative inputs** (anchored patterns + reserved-name set + auth's length cap) and delegates the security-load-bearing parse+gate. Public exports (`socketPathToIdentity`, `socketPathToAgent`, `isReservedAgentName`, `socketPathToName`, `classify`, `isReservedHostdAgentName`) are unchanged.

## Security consideration — semantics preserved, no check loosened

⚠️ **This wants a security review — it touches the broker authz trust boundary.** Before/after of each call site:

| Site | Patterns | Reserved set | Length cap | operator handling | Result |
|---|---|---|---|---|---|
| **vault** | flat `<a>.sock` + subdir `<a>/sock` | `{operator, hostd}` | none | matched before reserved gate | **identical** |
| **hostd** | container `/run/…/hostd/<a>/sock` + host-view `*​/.switchroom/hostd/<a>/sock` | `{operator, hostd}` | none | matched before reserved gate | **identical** |
| **auth** | subdir `<a>/sock` only | `{operator}` (via `classify`) | 63 | resolved in `classify` against config | **identical** |

Key invariant preserved everywhere: **operator is matched BEFORE the reserved-name rejection**, so a reserved set that (correctly) also lists `operator` can never null it out. Fail-closed on non-string/empty/no-match/over-length/reserved-name is preserved.

**Not triplicated (finding):** the `SO_PEERCRED` getsockopt FFI (`src/vault/broker/peercred-ffi.ts`) already lived in a **single** place — auth and hostd are path-only and never gate on the peer UID (they capture it for audit only). So the SO_PEERCRED primitive was not the duplicated thing; the *path-as-identity* gate was. This PR consolidates the latter.

**Scoped-out (deliberately, per the issue's "reconcile deliberately, not blindly"):** the second half of #2795 — collapsing the four UDS accept/framing loops behind a shared `createBrokerServer` — is **not** in this PR. The four servers differ in frame caps and buffering (vault, auth 64 KiB, hostd 2× `MAX_FRAME_BYTES`, plus the vault approvals kernel-server), and each is a 3k-line file; merging their accept loops blindly is the exact hazard the issue flags. That belongs in its own PR with its own security review, on top of this now-shared identity primitive.

## Tests

New `src/broker-common/peercred-path.test.ts` asserts the shared primitive **accepts authorized peers and rejects unauthorized/malformed/reserved-name ones** (fail-closed), the operator-before-reserved ordering, the length guard, and custom operator names. All existing per-broker peercred tests (`vault`, `auth`, `host-control`) pass **unchanged** — 67/67 across the touched suites.

- `npm run lint` — clean.
- `npm test` — the only failures are pre-existing env-only ones (missing `switchroom` CLI / docker / `claude` binary), identical on clean `origin/main`; zero new failures from this change.

Closes #2795

🤖 Generated with [Claude Code](https://claude.com/claude-code)