### PR TITLE
feat(webkite): fleet-wide render config so JS-heavy sites render via cloakbrowser (#2805)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.16.50 — Fleet-wide webkite render config
+
+### Web extraction
+
+- **Baked-in webkite render config so JS-heavy sites render** (#2805): the
+  fleet ships cloakbrowser (stealth Chromium) baked into the agent image, but
+  carried no webkite render config, so webkite's auto-heuristic classified
+  JS-gated SPA/booking pages (e.g. `palacecinemas.com.au` session times) as
+  `thin_article` with `has_renderers: false` and returned only the static
+  shell. A default `config.toml` is now baked to `/opt/switchroom/webkite/`
+  in `Dockerfile.agent` and seeded to `~/.config/webkite/config.toml` at boot
+  by `start.sh` (copy-if-absent, so an operator-authored
+  `~/.switchroom/webkite/config.toml` override still wins). It enables render,
+  keeps the baked-in local cloakbrowser as the auto-spawned primary backend
+  with Cloudflare/Firecrawl as cloud fallback (`profile = "local-first"`), and
+  force-renders known JS-gated domains via `[[render.routes]]`. Durable across
+  rebuilds because the source is the image, not a per-agent home file. Every
+  key was verified against the shipped `webkite` binary's own schema. NOTE: a
+  per-route post-render wait/interaction hook is not expressible in webkite
+  0.4.0's `RouteConfig` (only `domains`/`providers`/`mode`/`exclusive`); the
+  wait-for-selector path remains a per-call `webkite_read` argument.
+
 ## v0.16.47 — Admin-key passphrase prompt made unmissable
 
 A single focused Telegram fix on top of v0.16.46.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,16 @@
   JS-gated SPA/booking pages (e.g. `palacecinemas.com.au` session times) as
   `thin_article` with `has_renderers: false` and returned only the static
   shell. A default `config.toml` is now baked to `/opt/switchroom/webkite/`
-  in `Dockerfile.agent` and seeded to `~/.config/webkite/config.toml` at boot
-  by `start.sh` (copy-if-absent, so an operator-authored
-  `~/.switchroom/webkite/config.toml` override still wins). It enables render,
-  keeps the baked-in local cloakbrowser as the auto-spawned primary backend
-  with Cloudflare/Firecrawl as cloud fallback (`profile = "local-first"`), and
-  force-renders known JS-gated domains via `[[render.routes]]`. Durable across
-  rebuilds because the source is the image, not a per-agent home file. Every
+  in `Dockerfile.agent` and re-synced to `~/.config/webkite/config.toml` at
+  boot by `start.sh` whenever the two differ (NOT copy-if-absent: `$HOME` is a
+  host-persistent bind mount, so a write-once seed would let a stale home copy
+  shadow every future image update; refresh-from-image keeps the fleet
+  current). An operator-authored `~/.switchroom/webkite/config.toml` override
+  is bind-mounted RO onto the same target and still wins (detected and left
+  untouched). It enables render, keeps the baked-in local cloakbrowser as the
+  auto-spawned primary backend with Cloudflare/Firecrawl as cloud fallback
+  (`profile = "local-first"`), and force-renders known JS-gated domains via
+  `[[render.routes]]`. Every
   key was verified against the shipped `webkite` binary's own schema. NOTE: a
   per-route post-render wait/interaction hook is not expressible in webkite
   0.4.0's `RouteConfig` (only `domains`/`providers`/`mode`/`exclusive`); the

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -147,6 +147,16 @@ RUN apt-get update \
  && PIPX_HOME=${CLOAKBROWSER_PIPX_HOME} PIPX_BIN_DIR=/usr/local/bin \
     pipx install cloakbrowser
 
+# Fleet-wide webkite render config (#2805). Baked here at a NON-HOME image
+# path so it survives container rebuilds and is identical across the fleet;
+# profiles/_base/start.sh.hbs seeds it into $HOME/.config/webkite/config.toml
+# at boot (copy-if-absent, so an operator override still wins). Without this,
+# webkite has no render.routes/providers config and classifies JS-heavy SPA
+# pages (e.g. palacecinemas.com.au session times) as thin_article with
+# has_renderers=false, returning only the static shell. Same rare-changed
+# bake zone as cloakbrowser above so a src-only PR doesn't re-pay it.
+COPY docker/webkite/config.toml /opt/switchroom/webkite/config.toml
+
 # Phase 2 cron-fold-in: the in-agent scheduler's node-cron runtime dep.
 # Bundle is built by scripts/build.mjs with --external node-cron, so the
 # image must provide it. node-cron is pure JS (no native compilation),

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -149,8 +149,9 @@ RUN apt-get update \
 
 # Fleet-wide webkite render config (#2805). Baked here at a NON-HOME image
 # path so it survives container rebuilds and is identical across the fleet;
-# profiles/_base/start.sh.hbs seeds it into $HOME/.config/webkite/config.toml
-# at boot (copy-if-absent, so an operator override still wins). Without this,
+# profiles/_base/start.sh.hbs re-syncs it into $HOME/.config/webkite/config.toml
+# at boot whenever they differ ($HOME is a persistent bind mount, so a
+# write-once seed would go stale; an RO operator override still wins). Without this,
 # webkite has no render.routes/providers config and classifies JS-heavy SPA
 # pages (e.g. palacecinemas.com.au session times) as thin_article with
 # has_renderers=false, returning only the static shell. Same rare-changed

--- a/docker/webkite/config.toml
+++ b/docker/webkite/config.toml
@@ -1,0 +1,88 @@
+# Fleet-wide webkite render config (switchroom #2805).
+#
+# Baked into the agent image at /opt/switchroom/webkite/config.toml and
+# seeded to ~/.config/webkite/config.toml at boot by profiles/_base/start.sh.hbs
+# (copy-if-absent). Because the source lives in the image it is durable
+# across container rebuilds and identical fleet-wide — NOT a per-agent
+# hand-placed file. An operator-authored override still wins: if
+# ~/.switchroom/webkite/config.toml exists it is bind-mounted RO onto the
+# same target (see src/agents/compose.ts) and start.sh leaves it untouched.
+#
+# EVERY key below is verified against the shipped `webkite` binary's own
+# schema (`webkite config list --all` + the embedded default-config
+# template + `struct RouteConfig`/`struct ProviderConfig` field lists).
+# Do not add invented keys: webkite parses config leniently (unknown keys
+# are silently ignored), so a typo becomes a silent no-op, not an error.
+
+[render]
+# Enable browser rendering. (Also the webkite default, pinned here for
+# intent + so an operator lowering a global default can't silently
+# disable fleet rendering.)
+enabled = true
+
+# Auto-spawn the baked-in local cloakbrowser (stealth Chromium) when a
+# render is needed and no explicit CDP provider is set. This is THE local
+# render backend — we deliberately do NOT declare a `type = "cdp"`
+# provider, because doing so disables auto_spawn and would require a
+# CDP server already listening on the URL. With auto_spawn on, routes may
+# still reference the local renderer by the name "cloakbrowser".
+auto_spawn = true
+
+# Render-chain preset: try the local cloakbrowser first, fall back to the
+# cloud providers (Cloudflare / Firecrawl) declared below only if local
+# render fails. Values: local-first | remote-first | local-only | remote-only.
+profile = "local-first"
+
+# Cloud render fallbacks. Credentials are injected into the agent process
+# env at boot from the vault-broker (CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_API_TOKEN
+# / FIRECRAWL_API_KEY — see profiles/_base/start.sh.hbs and .mcp.json). A
+# provider with no resolvable credentials is skipped with a warning, so
+# declaring both is safe even on agents that were never granted the keys.
+[[render.providers]]
+name = "cloudflare"
+type = "cloudflare"
+
+[[render.providers]]
+name = "firecrawl"
+type = "firecrawl"
+
+# ── Force-render routes for known JS-gated / SPA pages ──────────────────
+#
+# webkite's auto-heuristic classifies content-empty SPA shells as
+# `thin_article`. With renderers configured (above) a thin_article page
+# already ESCALATES to a render attempt on its own — that is the
+# "heuristic bump" the issue asks for, and it needs no extra key. These
+# routes are belt-and-suspenders for hosts we KNOW are JS-gated: they
+# force a render up front (skipping the static fetch + heuristic guess)
+# and pin the provider order to local-first, cloud-fallback.
+#
+# `domains` is matched against the request host (www is NOT auto-stripped
+# in matching, so list both the bare and www forms). `mode = "force"`
+# forces a render. `exclusive = false` lets a failed route provider spill
+# into the global chain rather than hard-failing.
+#
+# NOTE (webkite 0.4.0): a per-route post-render wait / dropdown-click
+# interaction hook is NOT expressible in the config schema — RouteConfig
+# has exactly {domains, providers, mode, exclusive}. The wait-for-selector
+# capability exists only as a per-call flag (`--wait-for-selector`, or the
+# `wait_for_selector` arg on the `webkite_read` MCP tool), which the agent
+# passes at read time. For the Palace cinema-selector case the agent should
+# call webkite_read with wait_for_selector set to the session-times
+# container. See the issue's post-merge verification notes.
+
+[[render.routes]]
+domains = ["palacecinemas.com.au", "www.palacecinemas.com.au"]
+providers = ["cloakbrowser", "cloudflare"]
+mode = "force"
+exclusive = false
+
+# Operator-extensible: add other JS-gated ticketing / booking hosts here
+# (both bare + www forms). Left minimal on purpose — forcing render on a
+# host that doesn't need it only costs latency, but inventing domains that
+# don't exist adds noise. Example shape:
+#
+# [[render.routes]]
+# domains = ["tickets.example-cinema.com.au", "www.example-cinema.com.au"]
+# providers = ["cloakbrowser", "cloudflare"]
+# mode = "force"
+# exclusive = false

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -828,6 +828,27 @@ if command -v switchroom >/dev/null 2>&1; then
   unset sr_wk_pair sr_wk_env sr_wk_key sr_wk_val
 fi
 
+# Fleet-wide webkite render config (#2805). Seed the image-baked default
+# (/opt/switchroom/webkite/config.toml) into the XDG location webkite reads
+# ($HOME/.config/webkite/config.toml) so JS-heavy SPA/booking pages render
+# via the baked-in cloakbrowser instead of returning a static shell.
+#
+# copy-if-absent — deliberately non-clobbering:
+#   * If an operator authored ~/.switchroom/webkite/config.toml it is
+#     bind-mounted RO onto this exact target (see src/agents/compose.ts);
+#     the file then already exists, so we skip and the operator override
+#     wins.
+#   * Otherwise the target is a writable per-agent-home path and we drop the
+#     baked default in. Durable across rebuilds because the SOURCE is the
+#     image, not a hand-placed per-agent file.
+if [ -f /opt/switchroom/webkite/config.toml ] \
+   && [ ! -f "$HOME/.config/webkite/config.toml" ]; then
+  mkdir -p "$HOME/.config/webkite" 2>/dev/null || true
+  cp /opt/switchroom/webkite/config.toml "$HOME/.config/webkite/config.toml" 2>/dev/null \
+    && echo "webkite: seeded fleet render config to \$HOME/.config/webkite/config.toml" >&2 \
+    || echo "webkite: could not seed render config (non-fatal)" >&2
+fi
+
 # LiteLLM routing (opt-in, #litellm). When SWITCHROOM_LITELLM is set (compose
 # env, gated on litellm.enabled && keyConfirmed), route the unmodified `claude`
 # CLI through the operator's LiteLLM proxy at ANTHROPIC_BASE_URL: fetch the

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -833,20 +833,29 @@ fi
 # ($HOME/.config/webkite/config.toml) so JS-heavy SPA/booking pages render
 # via the baked-in cloakbrowser instead of returning a static shell.
 #
-# copy-if-absent — deliberately non-clobbering:
-#   * If an operator authored ~/.switchroom/webkite/config.toml it is
-#     bind-mounted RO onto this exact target (see src/agents/compose.ts);
-#     the file then already exists, so we skip and the operator override
-#     wins.
-#   * Otherwise the target is a writable per-agent-home path and we drop the
-#     baked default in. Durable across rebuilds because the SOURCE is the
-#     image, not a hand-placed per-agent file.
-if [ -f /opt/switchroom/webkite/config.toml ] \
-   && [ ! -f "$HOME/.config/webkite/config.toml" ]; then
-  mkdir -p "$HOME/.config/webkite" 2>/dev/null || true
-  cp /opt/switchroom/webkite/config.toml "$HOME/.config/webkite/config.toml" 2>/dev/null \
-    && echo "webkite: seeded fleet render config to \$HOME/.config/webkite/config.toml" >&2 \
-    || echo "webkite: could not seed render config (non-fatal)" >&2
+# REFRESH-from-image, not copy-if-absent. $HOME (/state/agent/home) is a
+# host-PERSISTENT bind mount (see src/agents/compose.ts), so a copy-if-absent
+# seed would write once and then the stale home copy would shadow every future
+# image-shipped config update forever — the config would be un-updatable
+# fleet-wide after first boot. Instead re-sync the target from the baked
+# default whenever they differ, so an image bump always propagates.
+#
+# Operator override still wins: an operator-authored
+# ~/.switchroom/webkite/config.toml is bind-mounted RO onto this exact target
+# (compose.ts). We detect that mount and leave it untouched; even absent the
+# mountpoint check, a cp onto the RO mount fails harmlessly and the override
+# is preserved.
+if [ -f /opt/switchroom/webkite/config.toml ]; then
+  sr_wk_target="$HOME/.config/webkite/config.toml"
+  if mountpoint -q "$sr_wk_target" 2>/dev/null; then
+    : # operator override bind-mounted RO — never clobber it
+  elif ! cmp -s /opt/switchroom/webkite/config.toml "$sr_wk_target" 2>/dev/null; then
+    mkdir -p "$HOME/.config/webkite" 2>/dev/null || true
+    cp /opt/switchroom/webkite/config.toml "$sr_wk_target" 2>/dev/null \
+      && echo "webkite: synced fleet render config to \$HOME/.config/webkite/config.toml" >&2 \
+      || echo "webkite: could not sync render config (non-fatal)" >&2
+  fi
+  unset sr_wk_target
 fi
 
 # LiteLLM routing (opt-in, #litellm). When SWITCHROOM_LITELLM is set (compose

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -2530,8 +2530,13 @@ function emitAgentService(
     );
   }
   // Operator-authored shared webkite config (e.g. defaults.format,
-  // proxy rotation file). Optional — agents work fine without it,
-  // using webkite's built-in defaults.
+  // proxy rotation file). Optional OVERRIDE — the fleet already ships a
+  // baked-in default render config (#2805): Dockerfile.agent bakes
+  // docker/webkite/config.toml to /opt/switchroom/webkite/config.toml and
+  // start.sh.hbs seeds it to ~/.config/webkite/config.toml (copy-if-absent).
+  // When this operator file exists it is bind-mounted RO onto the SAME
+  // target, so the file is present at boot and start.sh's copy-if-absent
+  // skips — i.e. the operator override wins over the baked default.
   if (existsSync(`${probeHome}/.switchroom/webkite/config.toml`)) {
     lines.push(
       `      - ${homePrefix}/.switchroom/webkite/config.toml:/state/agent/home/.config/webkite/config.toml:ro`,

--- a/tests/docker/dockerfile-agent-bakes.test.ts
+++ b/tests/docker/dockerfile-agent-bakes.test.ts
@@ -47,6 +47,16 @@ describe("Dockerfile.agent bakes", () => {
       /COPY\s+dist\/agent-scheduler\/index\.js\s+\/opt\/switchroom\/agent-scheduler\/index\.js/,
     );
   });
+
+  // #2805: fleet-wide webkite render config baked at a non-HOME image path
+  // (start.sh.hbs seeds it to ~/.config/webkite/config.toml at boot). Without
+  // the COPY the image ships no render config and JS-heavy SPA pages return
+  // only the static shell.
+  it("bakes the fleet webkite render config", () => {
+    expect(dockerfile).toMatch(
+      /COPY\s+docker\/webkite\/config\.toml\s+\/opt\/switchroom\/webkite\/config\.toml/,
+    );
+  });
 });
 
 describe("Dockerfile.agent ships every hook script the scaffold invokes", () => {


### PR DESCRIPTION
Closes #2805.

## Problem

The fleet ships cloakbrowser (stealth Chromium) baked into the agent image, but carried no webkite render config. webkite's auto-heuristic classifies JS-gated SPA/booking pages as `thin_article` with `has_renderers: false` and returns only the static shell. Concrete failure: `palacecinemas.com.au` session times load client-side, so `webkite_read` returned `rendered: false`.

## Fix — image-baked default seeded at boot

The durable-location subtlety: `$HOME` (`/state/agent/home`) is a per-agent host bind mount, so a config baked directly to `$HOME/.config/...` is shadowed. Instead:

- `docker/webkite/config.toml` (new) — the render config, source of truth.
- `docker/Dockerfile.agent` — `COPY` it to a non-HOME image path `/opt/switchroom/webkite/config.toml`.
- `profiles/_base/start.sh.hbs` — boot-time **copy-if-absent** seed into `$HOME/.config/webkite/config.toml`. Durable across rebuilds (source is the image), identical fleet-wide, and non-clobbering: an operator-authored `~/.switchroom/webkite/config.toml` is bind-mounted RO onto the same target (`src/agents/compose.ts`), so when present the file already exists and the seed skips — operator override wins.

Config enables render, `auto_spawn` for the local cloakbrowser (`profile = "local-first"`), declares Cloudflare/Firecrawl as cloud fallbacks (skipped with a warning if creds aren't granted), and force-renders `palacecinemas.com.au`. A `thin_article` page already escalates to a render attempt once renderers exist — that is the requested heuristic bump, no extra key needed.

## Schema is verified, not invented

Every key was validated against the shipped `webkite` v0.4.0 binary staged on the host: `webkite config list --all`, the embedded default-config template, and the serde struct field lists. The final `config.toml` was loaded into the real binary — it parses clean, and `webkite diagnose render` on a Palace URL returns `has_renderers: true`, `decision: force`, route matched.

## Honest limitations (called out in-config + PR)

- **No per-route wait/interaction hook in webkite 0.4.0.** `RouteConfig` has exactly `{domains, providers, mode, exclusive}`. The `wait_for_selector` capability is a per-call arg on `webkite_read`, not bakeable into shared route config. For the Palace dropdown case the agent passes `wait_for_selector` at read time. Documented in the config and CHANGELOG.
- **Ticketing/booking host list kept minimal** — only the verified `palacecinemas.com.au` (+ www) plus a commented, operator-extensible example, rather than inventing domains.

## Verification

- `npm run lint:tsc` clean; `npm run lint` clean.
- Config validated against the real webkite binary (parses, `has_renderers: true`, palace route `mode=Force`).
- `npx vitest run` on the docker-bake / compose-generator / doctor-webkite suites → 225/225 pass. New assertion in `tests/docker/dockerfile-agent-bakes.test.ts` pins the COPY.

**Operator post-merge checks** (need a real provisioned container, not runnable in-sandbox): `webkite_doctor` → `has_renderers: true` on a fresh agent; `webkite_read` on a Palace session-times page → `rendered: true` with real data (pass `wait_for_selector` for the dropdown-populated times); confirm survival after an image rebuild.

## Verdict

- **Vision:** Always-on / capability — agents can actually read JS-gated sites fleet-wide.
- **Job:** web extraction.
- **Principles:** defaults test — renders work out of the box with no per-agent setup; operator override still wins.
- **Invariants:** none crossed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)