### PR TITLE
perf(ci): native arm64 runners, per-arch manifest merge, tag-only attestation, scoped hindsight chown

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -202,15 +202,21 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - { name: base,        file: docker/Dockerfile.base,        dist: true,  base-arg: false }
-          - { name: agent,       file: docker/Dockerfile.agent,       dist: true,  base-arg: true }
-          - { name: broker,      file: docker/Dockerfile.broker,      dist: true,  base-arg: true }
-          - { name: kernel,      file: docker/Dockerfile.kernel,      dist: true,  base-arg: true }
-          - { name: hostd,       file: docker/Dockerfile.hostd,       dist: true,  base-arg: true }
-          - { name: auth-broker, file: docker/Dockerfile.auth-broker, dist: true,  base-arg: true }
-          - { name: web,         file: docker/Dockerfile.web,         dist: true,  base-arg: true }
-          - { name: hindsight,   file: docker/Dockerfile.hindsight,   dist: false, base-arg: false }
-          - { name: voice,       file: docker/Dockerfile.voice,       dist: false, base-arg: false }
+          # `cache` names each image's registry buildcache tag: since
+          # docker-images.yml split base/dependents into per-arch
+          # native-runner builds, their caches are per-arch
+          # (:buildcache-<arch>); this amd64-only job reads the amd64
+          # one. hindsight/voice stayed single-job and keep the plain
+          # :buildcache tag.
+          - { name: base,        file: docker/Dockerfile.base,        dist: true,  base-arg: false, cache: buildcache-amd64 }
+          - { name: agent,       file: docker/Dockerfile.agent,       dist: true,  base-arg: true,  cache: buildcache-amd64 }
+          - { name: broker,      file: docker/Dockerfile.broker,      dist: true,  base-arg: true,  cache: buildcache-amd64 }
+          - { name: kernel,      file: docker/Dockerfile.kernel,      dist: true,  base-arg: true,  cache: buildcache-amd64 }
+          - { name: hostd,       file: docker/Dockerfile.hostd,       dist: true,  base-arg: true,  cache: buildcache-amd64 }
+          - { name: auth-broker, file: docker/Dockerfile.auth-broker, dist: true,  base-arg: true,  cache: buildcache-amd64 }
+          - { name: web,         file: docker/Dockerfile.web,         dist: true,  base-arg: true,  cache: buildcache-amd64 }
+          - { name: hindsight,   file: docker/Dockerfile.hindsight,   dist: false, base-arg: false, cache: buildcache }
+          - { name: voice,       file: docker/Dockerfile.voice,       dist: false, base-arg: false, cache: buildcache }
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -253,5 +259,8 @@ jobs:
           push: false
           build-args: ${{ matrix.image.base-arg && format('BASE_IMAGE={0}/{1}/switchroom-base:latest', env.REGISTRY, env.IMAGE_NAMESPACE) || '' }}
           # Read-only registry cache (never cache-to — #1965 pattern,
-          # and this job must not pollute the release cache).
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-${{ matrix.image.name }}:buildcache
+          # and this job must not pollute the release cache). Second
+          # line is the legacy pre-per-arch-split tag as a fallback.
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-${{ matrix.image.name }}:${{ matrix.image.cache }}
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-${{ matrix.image.name }}:buildcache

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -9,11 +9,30 @@ name: docker-images
 #   - tag push v*: same matrix, push as `:<tag>` and `:latest`.
 #   - pull_request: build only (no push) to validate Dockerfile changes.
 #
-# Two parallel pipelines:
-#   - build-base + build-dependents: switchroom-{base,agent,broker,kernel,
-#     hostd,auth-broker}. Dependents extend base, so base builds first.
+# Pipelines (perf rework, follows #2807):
+#   - build-base + build-dependents run as a PER-ARCH matrix on NATIVE
+#     runners (amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm) — no
+#     QEMU emulation. Each arch leg pushes a temporary
+#     `:sha-<short>-<arch>` tag; the merge-base / merge-dependents jobs
+#     then stitch the two arch images into the final multi-arch
+#     manifest (`:latest` / `:sha-<short>` / `:vX.Y.Z`) with
+#     `docker buildx imagetools create` — a manifest-only operation, no
+#     rebuild, no re-export. Registry build caches are per-arch
+#     (`:buildcache-<arch>`) so the two legs don't thrash each other.
 #   - build-hindsight: extends upstream `vectorize-io/hindsight:latest`,
 #     no switchroom-base dependency. Runs in parallel with build-base.
+#     DELIBERATELY still single-job multi-arch via QEMU: it's path-gated
+#     on main pushes and rarely builds, so the per-arch split isn't
+#     worth its job-count cost here.
+#   - build-voice: standalone CUDA image, amd64-only by design (see job
+#     comment) — no QEMU, no split.
+#
+# SBOM/provenance policy (WS9-F3, relaxed — operator-approved): full
+# `provenance: mode=max` + `sbom: true` attestation now runs on TAG
+# pushes (release artifacts) only. PR / main-push / dispatch builds set
+# provenance=false and sbom off — attestation generation + export was a
+# large share of every warm build's wall time, and the verification
+# story (`switchroom update` pull-side checks) targets release images.
 #
 # This workflow is staged at docs/proposed/docker-images.yml because the
 # OAuth token used to land code changes here lacks the `workflow` scope
@@ -62,22 +81,30 @@ jobs:
   # Gating policy:
   #   - build-base / build-dependents: PRs gated on `images`; every
   #     non-PR event (main push, tag, dispatch) always builds — we
-  #     don't gamble on the release path.
+  #     don't gamble on the release path. (The `images` filter is NOT
+  #     complete enough to skip main-push builds: dependents bake
+  #     dist/ bundles derived from all of src/, which the filter only
+  #     partially covers — see retag-unchanged below for the images
+  #     where a filter-driven skip IS sound.)
   #   - build-hindsight / build-voice: also path-gated on MAIN PUSHES
   #     (`hindsight` / `voice` keys) — they extend upstream bases, not
-  #     switchroom-base, and rarely change; an unchanged context was a
-  #     ~100% cache-hit no-op push anyway (promote-to-dev already
-  #     tolerates the missing :sha-<short> tag). Tags + dispatch still
-  #     always build them.
+  #     switchroom-base, and rarely change; their filters enumerate
+  #     their FULL build input set, so an unchanged filter provably
+  #     means an identical image. When skipped on a main push, the
+  #     retag-unchanged job re-points `:sha-<short>` at the existing
+  #     `:latest` manifest instead of re-building/re-exporting. Tags +
+  #     dispatch still always build them.
   #
   # This job itself skips on tag pushes / workflow_dispatch (dorny has
   # no diff base there); downstream `if:`s use `!cancelled()` so a
   # skipped `changes` doesn't auto-skip the builds on those events.
   #
   # NOTE (required checks): Ruleset 16470166 must require the
-  # `images-ok` sentinel below INSTEAD of build-base/build-hindsight/
-  # build-dependents ×6 — a path-skipped required matrix context would
-  # hard-block irrelevant PRs (#1343 lesson).
+  # `images-ok` sentinel below INSTEAD of the individual build jobs —
+  # a path-skipped required matrix context would hard-block irrelevant
+  # PRs (#1343 lesson). Because only the sentinel is required, the
+  # per-arch job renames in this rework don't touch branch protection;
+  # keep the sentinel's `needs` list complete when adding jobs.
   changes:
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
@@ -102,7 +129,15 @@ jobs:
     # `changes` is skipped on tag/dispatch and a skipped need would
     # otherwise auto-skip this job.
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.changes.outputs.images == 'true') }}
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # PR validation: amd64 only — PRs don't merge until amd64 is
+        # green anyway, and the arm64 artifact is only consumed from
+        # main/tag pushes. Non-PR: both arches, each on a NATIVE
+        # runner (no QEMU).
+        arch: ${{ github.event_name == 'pull_request' && fromJSON('["amd64"]') || fromJSON('["amd64","arm64"]') }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -126,14 +161,6 @@ jobs:
         run: |
           bun install
           npm run build
-
-      - name: Set up QEMU (only when arm64 build runs)
-        # QEMU is only needed for cross-arch arm64 emulation on amd64
-        # hosts. PR builds are amd64-only (see `platforms` below), so
-        # skip the QEMU setup — saves ~5s + cuts the resulting image
-        # surface area.
-        if: github.event_name != 'pull_request'
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
@@ -151,32 +178,25 @@ jobs:
         run: |
           IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-base"
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            TAG_VERSION="${GITHUB_REF#refs/tags/}"
-            echo "tags=${IMAGE}:${TAG_VERSION},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
-          elif [[ ( "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "workflow_dispatch" ) && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            # PR C: keep :latest as the canonical install per
-            # docs/operators/install.md, BUT also publish :sha-<7> for
-            # rollback / promote.yml retagging. (The :dev floating tag
-            # is gated by the smoke-test job and assigned by a separate
-            # retag step below — NOT included in this initial push so
-            # that a failed smoke run can't leave a broken :dev behind.)
-            echo "tags=${IMAGE}:latest,${IMAGE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
-          else
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # PR builds: synthesize a non-pushed tag for build-only mode.
             echo "tags=${IMAGE}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            # Every push path (main / tag / dispatch) pushes ONLY the
+            # per-arch scratch tag here; merge-base assigns the real
+            # tags (:latest / :sha-<short> / :vX.Y.Z) from the merged
+            # multi-arch manifest. Nothing user-facing moves until the
+            # merge job runs, so a failed arch leg can't leave a
+            # single-arch :latest behind.
+            echo "tags=${IMAGE}:sha-${SHA_SHORT}-${{ matrix.arch }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build (and push on main/tag) base
+      - name: Build (and push on main/tag) base ${{ matrix.arch }}
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           file: docker/Dockerfile.base
-          # PR validation: amd64 only — arm64 via QEMU is ~3-4 min per
-          # image and PRs don't merge until amd64 is green anyway. Full
-          # multi-arch matrix runs on push to main + tags where the
-          # arm64 artifact is consumed by operators.
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: linux/${{ matrix.arch }}
           tags: ${{ steps.tags.outputs.tags }}
           push: ${{ github.event_name != 'pull_request' }}
           # Cache via GHCR registry, not type=gha (#1965). The GHA
@@ -189,13 +209,21 @@ jobs:
           # and a miss is a non-fatal cold build. cache-to is gated to
           # non-PR events: fork PRs have no GHCR write token, and a
           # failed cache export would break the required build check.
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-base:buildcache
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/switchroom-base:buildcache,mode=max,image-manifest=true,oci-mediatypes=true', github.repository_owner) || '' }}
-          # sec WS9-F3 (#1418): signed build provenance + SBOM so an
-          # operator's `switchroom update` pull can verify the image
-          # was built by THIS pipeline from THIS source (SLSA-style).
-          provenance: mode=max
-          sbom: true
+          #
+          # Per-arch cache tag (:buildcache-<arch>) so the native-runner
+          # legs don't overwrite each other's cache; the legacy mixed
+          # :buildcache is kept as a read-only fallback so the first
+          # run after this split isn't fully cold.
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-base:buildcache-${{ matrix.arch }}
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-base:buildcache
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/switchroom-base:buildcache-{1},mode=max,image-manifest=true,oci-mediatypes=true', github.repository_owner, matrix.arch) || '' }}
+          # sec WS9-F3 (#1418, relaxed per header): signed provenance +
+          # SBOM only on tag pushes — release artifacts are what
+          # `switchroom update` verifies; attestation on every main/PR
+          # build was pure export overhead.
+          provenance: ${{ startsWith(github.ref, 'refs/tags/v') && 'mode=max' || 'false' }}
+          sbom: ${{ startsWith(github.ref, 'refs/tags/v') }}
           # CACHE_BUST is paired with the `ARG CACHE_BUST` in
           # Dockerfile.base immediately before `npm install -g
           # @anthropic-ai/claude-code@latest`. `github.run_attempt`
@@ -209,17 +237,60 @@ jobs:
           build-args: |
             CACHE_BUST=${{ github.run_attempt }}
 
+  # Stitch the per-arch base images into the final multi-arch manifest.
+  # Manifest-only (`imagetools create`): no rebuild, no layer re-export.
+  merge-base:
+    needs: build-base
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.build-base.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge per-arch images into multi-arch tags
+        run: |
+          set -euo pipefail
+          IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-base"
+          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            TAG_VERSION="${GITHUB_REF#refs/tags/}"
+            TAG_ARGS=(-t "${IMAGE}:${TAG_VERSION}" -t "${IMAGE}:latest")
+          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            # PR C: keep :latest as the canonical install per
+            # docs/operators/install.md, BUT also publish :sha-<7> for
+            # rollback / promote.yml retagging. (:dev is gated by the
+            # smoke-test job and assigned by promote-to-dev — never here.)
+            TAG_ARGS=(-t "${IMAGE}:latest" -t "${IMAGE}:sha-${SHA_SHORT}")
+          else
+            # dispatch on a non-main, non-tag ref: publish only the
+            # per-commit tag; never move :latest from an odd ref.
+            TAG_ARGS=(-t "${IMAGE}:sha-${SHA_SHORT}")
+          fi
+          docker buildx imagetools create "${TAG_ARGS[@]}" \
+            "${IMAGE}:sha-${SHA_SHORT}-amd64" \
+            "${IMAGE}:sha-${SHA_SHORT}-arm64"
+
   build-dependents:
+    # Per-arch dependents FROM the per-arch base scratch tag pushed by
+    # build-base — no wait on merge-base (it runs in parallel).
     needs: [changes, build-base]
     # Same gate as build-base, plus an explicit success check on the
     # base build — `!cancelled()` alone would let dependents run past
     # a FAILED base (unlike the default all-needs-succeeded semantics
     # it replaces).
     if: ${{ !cancelled() && needs.build-base.result == 'success' && (github.event_name != 'pull_request' || needs.changes.outputs.images == 'true') }}
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        arch: ${{ github.event_name == 'pull_request' && fromJSON('["amd64"]') || fromJSON('["amd64","arm64"]') }}
         image:
           - { name: agent,        file: docker/Dockerfile.agent }
           - { name: broker,       file: docker/Dockerfile.broker }
@@ -231,6 +302,7 @@ jobs:
           # job (PR #1310) that runs in parallel with build-base
           # because Dockerfile.hindsight extends upstream
           # `vectorize-io/hindsight:latest`, not switchroom-base.
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -254,10 +326,6 @@ jobs:
         run: |
           bun install
           npm run build
-
-      - name: Set up QEMU (only when arm64 build runs)
-        if: github.event_name != 'pull_request'
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
@@ -276,25 +344,24 @@ jobs:
           IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${{ matrix.image.name }}"
           BASE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-base"
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            TAG_VERSION="${GITHUB_REF#refs/tags/}"
-            echo "tags=${IMAGE}:${TAG_VERSION},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
-            echo "base=${BASE}:${TAG_VERSION}" >> "$GITHUB_OUTPUT"
-          elif [[ ( "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "workflow_dispatch" ) && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "tags=${IMAGE}:latest,${IMAGE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
-            echo "base=${BASE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
-          else
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "tags=${IMAGE}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-            # On PRs the base wasn't pushed, so depend on local layer cache.
+            # On PRs the base wasn't pushed, so depend on the published
+            # :latest (multi-arch; buildx resolves the amd64 leg).
             echo "base=${BASE}:latest" >> "$GITHUB_OUTPUT"
+          else
+            # Per-arch scratch tag; merge-dependents assigns the real
+            # tags from the merged manifest (see build-base comment).
+            echo "tags=${IMAGE}:sha-${SHA_SHORT}-${{ matrix.arch }}" >> "$GITHUB_OUTPUT"
+            echo "base=${BASE}:sha-${SHA_SHORT}-${{ matrix.arch }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build (and push on main/tag) ${{ matrix.image.name }}
+      - name: Build (and push on main/tag) ${{ matrix.image.name }} ${{ matrix.arch }}
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           file: ${{ matrix.image.file }}
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: linux/${{ matrix.arch }}
           tags: ${{ steps.tags.outputs.tags }}
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
@@ -305,12 +372,56 @@ jobs:
           # hard-failed the build, blocking releases. Registry cache has no
           # SAS expiry; a miss degrades to a cold build. cache-to gated to
           # non-PR (fork PRs can't write GHCR; export failure would break
-          # the required check). Per-image :buildcache tag, mode=max.
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-${{ matrix.image.name }}:buildcache
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/switchroom-{1}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true', github.repository_owner, matrix.image.name) || '' }}
-          # sec WS9-F3 (#1418): provenance + SBOM on every fleet image.
-          provenance: mode=max
-          sbom: true
+          # the required check). Per-image, per-arch :buildcache-<arch>
+          # tag, mode=max; legacy :buildcache kept as read-only fallback
+          # for the first post-split run.
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-${{ matrix.image.name }}:buildcache-${{ matrix.arch }}
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-${{ matrix.image.name }}:buildcache
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/switchroom-{1}:buildcache-{2},mode=max,image-manifest=true,oci-mediatypes=true', github.repository_owner, matrix.image.name, matrix.arch) || '' }}
+          # sec WS9-F3 (#1418, relaxed per header): attestation on tag
+          # pushes only.
+          provenance: ${{ startsWith(github.ref, 'refs/tags/v') && 'mode=max' || 'false' }}
+          sbom: ${{ startsWith(github.ref, 'refs/tags/v') }}
+
+  # Stitch the per-arch dependent images into their final multi-arch
+  # manifests. Same pattern as merge-base.
+  merge-dependents:
+    needs: build-dependents
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.build-dependents.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [agent, broker, kernel, hostd, auth-broker, web]
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge per-arch images into multi-arch tags
+        run: |
+          set -euo pipefail
+          IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${{ matrix.image }}"
+          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            TAG_VERSION="${GITHUB_REF#refs/tags/}"
+            TAG_ARGS=(-t "${IMAGE}:${TAG_VERSION}" -t "${IMAGE}:latest")
+          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            TAG_ARGS=(-t "${IMAGE}:latest" -t "${IMAGE}:sha-${SHA_SHORT}")
+          else
+            TAG_ARGS=(-t "${IMAGE}:sha-${SHA_SHORT}")
+          fi
+          docker buildx imagetools create "${TAG_ARGS[@]}" \
+            "${IMAGE}:sha-${SHA_SHORT}-amd64" \
+            "${IMAGE}:sha-${SHA_SHORT}-arm64"
 
   build-hindsight:
     # Hindsight extends upstream `ghcr.io/vectorize-io/hindsight:latest`
@@ -320,10 +431,14 @@ jobs:
     # provider + claude-agent-sdk + UID pin).
     #
     # Path-gated on PRs AND main pushes (see `changes` header): the
-    # hindsight context rarely changes, and an unchanged-context main
-    # push was already a pure cache-hit no-op (nothing pushed, no
-    # :sha-<short> tag — promote-to-dev's absence-skip handles it).
-    # Tags + workflow_dispatch always build.
+    # hindsight context rarely changes; when it's unchanged on a main
+    # push this job skips and retag-unchanged re-points :sha-<short>
+    # at the existing :latest manifest. Tags + workflow_dispatch always
+    # build.
+    #
+    # Still single-job multi-arch via QEMU (NOT split per-arch like
+    # base/dependents): this job is skipped on almost every main push,
+    # so doubling its job count buys nothing on the common path.
     needs: changes
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || needs.changes.outputs.hindsight == 'true') }}
     runs-on: ubuntu-latest
@@ -371,9 +486,10 @@ jobs:
           # GHCR registry cache, not type=gha — #1965 (see build-base).
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-hindsight:buildcache
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/switchroom-hindsight:buildcache,mode=max,image-manifest=true,oci-mediatypes=true', github.repository_owner) || '' }}
-          # sec WS9-F3 (#1418): provenance + SBOM on the hindsight image too.
-          provenance: mode=max
-          sbom: true
+          # sec WS9-F3 (#1418, relaxed per header): attestation on tag
+          # pushes only.
+          provenance: ${{ startsWith(github.ref, 'refs/tags/v') && 'mode=max' || 'false' }}
+          sbom: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
   build-voice:
     # Voice STT sidecar (PR-B2 follow-up). Like build-hindsight this is a
@@ -398,7 +514,8 @@ jobs:
     #
     # Path-gated on PRs AND main pushes like build-hindsight (see the
     # `changes` header): the CUDA layers make voice the heaviest build
-    # and its context almost never changes. Tags + dispatch always build.
+    # and its context almost never changes; retag-unchanged covers the
+    # skipped-on-main-push case. Tags + dispatch always build.
     needs: changes
     if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || needs.changes.outputs.voice == 'true') }}
     runs-on: ubuntu-latest
@@ -448,9 +565,76 @@ jobs:
           # the required build check).
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/switchroom-voice:buildcache
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/switchroom-voice:buildcache,mode=max,image-manifest=true,oci-mediatypes=true', github.repository_owner) || '' }}
-          # sec WS9-F3 (#1418): provenance + SBOM on the voice image too.
-          provenance: mode=max
-          sbom: true
+          # sec WS9-F3 (#1418, relaxed per header): attestation on tag
+          # pushes only.
+          provenance: ${{ startsWith(github.ref, 'refs/tags/v') && 'mode=max' || 'false' }}
+          sbom: ${{ startsWith(github.ref, 'refs/tags/v') }}
+
+  # ─── Skip re-export of unchanged images (main pushes) ─────────────
+  # hindsight / voice enumerate their FULL build-input set in
+  # .github/path-filters.yml, so "filter says unchanged" provably means
+  # "the image content is identical to the previous main build". When
+  # their build jobs are path-skipped on a main push, this job re-points
+  # `:sha-<short>` at the existing `:latest` manifest with
+  # `docker buildx imagetools create` (same no-rebuild pattern as
+  # promote-to-dev) — every main commit then has a complete
+  # per-commit tag set with zero build/export cost.
+  #
+  # DELIBERATELY NOT applied to base/dependents: their images bake dist/
+  # bundles derived from effectively all of src/, which the `images`
+  # filter only partially covers — a filter-driven "unchanged" verdict
+  # there would be unsound, and a content-digest scheme short of
+  # actually building is exactly the fragile hashing we avoid. Their
+  # skip-cost is instead attacked by the native-arm64 split + the
+  # attestation relaxation above.
+  retag-unchanged:
+    needs: changes
+    if: >-
+      !cancelled() &&
+      github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+      needs.changes.result == 'success' &&
+      (needs.changes.outputs.hindsight != 'true' || needs.changes.outputs.voice != 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retag :latest as :sha-<7> for path-skipped images
+        env:
+          HINDSIGHT_CHANGED: ${{ needs.changes.outputs.hindsight }}
+          VOICE_CHANGED: ${{ needs.changes.outputs.voice }}
+        run: |
+          set -euo pipefail
+          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          retag() {
+            local name="$1"
+            local IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${name}"
+            # Tolerate a missing :latest (fresh fork / first-ever run):
+            # only a genuine NOT-FOUND is a benign skip; any other
+            # inspect error fails loudly (same discipline as
+            # promote-to-dev — never mask registry/auth trouble).
+            local out
+            if out=$(docker buildx imagetools inspect "${IMAGE}:latest" 2>&1); then
+              docker buildx imagetools create -t "${IMAGE}:sha-${SHA_SHORT}" "${IMAGE}:latest"
+              echo "retagged ${IMAGE}:latest -> ${IMAGE}:sha-${SHA_SHORT} (inputs unchanged this commit)"
+            elif printf '%s' "$out" | grep -qiE 'manifest unknown|not found|404|no such manifest|MANIFEST_UNKNOWN'; then
+              echo "::notice title=retag-unchanged skipped::${IMAGE}:latest absent (never built in this namespace) — nothing to retag."
+            else
+              echo "::error title=retag-unchanged failed::inspecting ${IMAGE}:latest failed with a non-absence error (registry/auth/network?)."
+              printf '%s\n' "$out"
+              exit 1
+            fi
+          }
+          if [ "$HINDSIGHT_CHANGED" != "true" ]; then retag hindsight; fi
+          if [ "$VOICE_CHANGED" != "true" ]; then retag voice; fi
 
   # PR C: smoke test the freshly-pushed :sha-<7> agent image — runs the
   # MCP tools/list harness inside a throwaway container with the
@@ -461,7 +645,9 @@ jobs:
   # smoke run leaves :sha-<7> pushed (for rollback) but does NOT
   # promote to :dev. Job timeout 5 min.
   smoke-test:
-    needs: [build-dependents]
+    # merge-dependents is what creates :sha-<7> now (the per-arch build
+    # jobs only push scratch tags).
+    needs: [merge-dependents]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -512,21 +698,24 @@ jobs:
     # (job green path not taken) could be misread by the retag step as
     # a benign "image unchanged" skip. With build-hindsight in `needs`,
     # a missing `:sha-<short>` at promote time provably means
-    # "build succeeded but context unchanged → buildx cache hit, nothing
-    # pushed", never "build failed".
+    # "build succeeded but context unchanged → nothing pushed", never
+    # "build failed".
     # Since the hindsight/voice builds became path-gated on main pushes
     # too, their `needs` result can legitimately be `skipped` here — a
-    # skip means "context unchanged this commit, nothing pushed", which
-    # the retag step below already treats as a benign absence (existing
-    # :dev retained). So this `if:` requires smoke-test SUCCESS but only
-    # non-failure (success or skipped) from hindsight/voice.
-    needs: [smoke-test, build-hindsight, build-voice]
+    # skip means "context unchanged this commit"; retag-unchanged (also
+    # in `needs`) then re-points :sha-<short> at :latest, so the retag
+    # step below normally finds it. Its absence-tolerance is retained
+    # for the fresh-namespace edge (no :latest to retag from). This
+    # `if:` requires smoke-test SUCCESS but only non-failure
+    # (success or skipped) from hindsight/voice/retag-unchanged.
+    needs: [smoke-test, build-hindsight, build-voice, retag-unchanged]
     if: >-
       !cancelled() &&
       github.event_name == 'push' && github.ref == 'refs/heads/main' &&
       needs.smoke-test.result == 'success' &&
       needs.build-hindsight.result != 'failure' && needs.build-hindsight.result != 'cancelled' &&
-      needs.build-voice.result != 'failure' && needs.build-voice.result != 'cancelled'
+      needs.build-voice.result != 'failure' && needs.build-voice.result != 'cancelled' &&
+      needs.retag-unchanged.result != 'failure' && needs.retag-unchanged.result != 'cancelled'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -549,22 +738,15 @@ jobs:
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
           IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${{ matrix.image }}"
           SRC="${IMAGE}:sha-${SHA_SHORT}"
-          # An image whose build context is unchanged for this commit is
-          # a 100% buildx cache hit and pushes NOTHING — so its per-commit
-          # `:sha-<short>` tag never gets created. This is the norm for
-          # `hindsight` (it extends upstream `vectorize-io/hindsight`, not
-          # `switchroom-base`, so most main commits don't touch its
-          # context). Hard-failing the retag here turned that into a
-          # whole-run red on `docker-images` for every hindsight-untouched
-          # release (e.g. v0.12.15 / dc508a9), even though the fleet is
-          # fine: `:latest` is pushed inline by the build jobs, and the
-          # existing `:dev` already points at the last good build.
-          #
-          # promote-to-dev `needs: [smoke-test, build-hindsight]`, so by
-          # the time this runs EVERY image's build job has SUCCEEDED — a
-          # missing `:sha-<short>` therefore provably means "cache hit,
-          # nothing pushed", never "build failed". In that case the
-          # existing `:dev` is already the last good build → skip.
+          # An image whose build was path-skipped this commit normally
+          # has its `:sha-<short>` created by retag-unchanged above; the
+          # absence branch remains for the fresh-namespace edge (no
+          # :latest existed to retag from). promote-to-dev `needs` every
+          # producing job, so by the time this runs a missing
+          # `:sha-<short>` provably means "nothing was ever pushed for
+          # this image in this namespace", never "build failed" — the
+          # existing `:dev` (if any) is already the last good build →
+          # skip.
           #
           # CRITICAL: only skip on a genuine NOT-FOUND. A transient
           # registry/auth/network error from `imagetools inspect` must
@@ -575,7 +757,7 @@ jobs:
             docker buildx imagetools create -t "${IMAGE}:dev" "$SRC"
             echo "promoted $SRC -> ${IMAGE}:dev"
           elif printf '%s' "$out" | grep -qiE 'manifest unknown|not found|404|no such manifest|MANIFEST_UNKNOWN'; then
-            echo "::notice title=promote-to-dev skipped::$SRC absent (build context unchanged this commit — buildx cache hit, nothing pushed). Existing ${IMAGE}:dev retained; nothing to re-promote."
+            echo "::notice title=promote-to-dev skipped::$SRC absent (nothing pushed for this image). Existing ${IMAGE}:dev retained; nothing to re-promote."
           else
             echo "::error title=promote-to-dev failed::inspecting $SRC failed with a non-absence error (registry/auth/network?) — NOT masking a possibly-real promotion."
             printf '%s\n' "$out"
@@ -586,13 +768,21 @@ jobs:
   # Branch-protection-required context (see ci-lint.yml header for the
   # pattern). ALWAYS runs and aggregates the path-gated build jobs:
   # pass when every build succeeded OR was legitimately path-skipped;
-  # fail when any build failed/cancelled, or when the `changes` filter
-  # job itself broke on an event where it gates (can't trust a skip
-  # produced by broken infra). Ruleset 16470166 should require
-  # `images-ok` INSTEAD of build-base / build-hindsight /
-  # build-dependents ×6.
+  # fail when any build/merge/retag failed/cancelled, or when the
+  # `changes` filter job itself broke on an event where it gates (can't
+  # trust a skip produced by broken infra). Ruleset 16470166 should
+  # require `images-ok` as THE single required context for this
+  # workflow — keep this `needs` list complete when adding jobs.
   images-ok:
-    needs: [changes, build-base, build-dependents, build-hindsight, build-voice]
+    needs:
+      - changes
+      - build-base
+      - merge-base
+      - build-dependents
+      - merge-dependents
+      - build-hindsight
+      - build-voice
+      - retag-unchanged
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -610,9 +800,12 @@ jobs:
           fail=0
           for pair in \
             "build-base=${{ needs.build-base.result }}" \
+            "merge-base=${{ needs.merge-base.result }}" \
             "build-dependents=${{ needs.build-dependents.result }}" \
+            "merge-dependents=${{ needs.merge-dependents.result }}" \
             "build-hindsight=${{ needs.build-hindsight.result }}" \
-            "build-voice=${{ needs.build-voice.result }}"; do
+            "build-voice=${{ needs.build-voice.result }}" \
+            "retag-unchanged=${{ needs.retag-unchanged.result }}"; do
             job="${pair%%=*}"; r="${pair#*=}"
             if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
               echo "::error::${job}=${r} — real build failure, blocking"

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -708,11 +708,19 @@ jobs:
     # for the fresh-namespace edge (no :latest to retag from). This
     # `if:` requires smoke-test SUCCESS but only non-failure
     # (success or skipped) from hindsight/voice/retag-unchanged.
-    needs: [smoke-test, build-hindsight, build-voice, retag-unchanged]
+    # merge-base is a producing job too: it creates base:sha-<short> on
+    # main pushes (build-base only pushes per-arch scratch tags now),
+    # and it never legitimately skips on a main push — so require hard
+    # success. Without it, a transient merge-base failure would let the
+    # base leg's absence-tolerant branch below misread the missing
+    # base:sha-<short> as a benign skip and silently hold base:dev back
+    # while the other :dev tags advance.
+    needs: [smoke-test, merge-base, build-hindsight, build-voice, retag-unchanged]
     if: >-
       !cancelled() &&
       github.event_name == 'push' && github.ref == 'refs/heads/main' &&
       needs.smoke-test.result == 'success' &&
+      needs.merge-base.result == 'success' &&
       needs.build-hindsight.result != 'failure' && needs.build-hindsight.result != 'cancelled' &&
       needs.build-voice.result != 'failure' && needs.build-voice.result != 'cancelled' &&
       needs.retag-unchanged.result != 'failure' && needs.retag-unchanged.result != 'cancelled'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,11 +152,12 @@ fake tokens by runtime concatenation (`"sk-ant-" + "fake"`); pattern:
 ## CI
 
 GitHub Actions is primary and gating. `main` is protected by repository
-Ruleset `16470166` with **11 required checks**: `lint`, `bun-test`, `vitest`,
-`build-base`, `build-hindsight`, and `build-dependents` ×6 (agent, broker,
-kernel, auth-broker, hostd, web). Edits to the required list are Ruleset
-edits (`gh api repos/switchroom/switchroom/rulesets/16470166`), not classic
-branch protection.
+Ruleset `16470166` with **4 required checks**: `lint`, `bun-test`, `vitest`,
+`images-ok` (the docker-images sentinel — the individual build jobs are NOT
+required, so matrix/job renames there don't touch branch protection; keep
+`images-ok`'s `needs` list complete instead). Edits to the required list are
+Ruleset edits (`gh api repos/switchroom/switchroom/rulesets/16470166`), not
+classic branch protection.
 
 - **Sentinel pattern:** `lint` / `bun-test` / `vitest` / `uat-gate` are
   always-running sentinel jobs that aggregate path-gated heavy runs
@@ -171,9 +172,10 @@ branch protection.
 - `gh pr checks <n>` is the source of truth. `mergeStateStatus`: `CLEAN`
   ready, `BLOCKED` pending/failed required check, `DIRTY` merge conflict,
   `UNSTABLE` = optional checks pending (usually fine).
-- Image build cache is **GHCR registry** (`:buildcache` tags), not
-  `type=gha` (#1965 — SAS-token expiry hard-failed heavy builds). `cache-to`
-  is gated off PR events; PRs read cache only.
+- Image build cache is **GHCR registry**, not `type=gha` (#1965 — SAS-token
+  expiry hard-failed heavy builds). base/dependents build per-arch on native
+  runners and use `:buildcache-<arch>` tags; hindsight/voice keep plain
+  `:buildcache`. `cache-to` is gated off PR events; PRs read cache only.
 
 ## UAT — the live end-to-end gate
 

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -117,16 +117,28 @@ PYEOF
 # container didn't match, the entrypoint would EACCES on the
 # socket connect.
 #
-# `usermod -u` rewrites every file under the user's HOME and any
-# explicitly-listed dir we know they own, but the upstream image
-# scatters python venvs across /app and /opt — find any file owned
-# by the old UID and chown it to the new one (idempotent: re-runs
-# of the same build with the same target UID are no-ops).
+# `usermod -u` rewrites every file under the user's HOME; the find
+# below catches everything else the hindsight user owns (idempotent:
+# re-runs of the same build with the same target UID are no-ops).
+#
+# SCOPED, not `find / -xdev` (perf, #2807 follow-up): hindsight-owned
+# files live ONLY under /app and /home/hindsight — verified against
+# upstream docker/standalone/Dockerfile (vectorize-io/hindsight
+# v0.8.2), which does `chown -R hindsight:hindsight /app` and
+# `useradd -m` + `mkdir /home/hindsight/.pg0`; nothing hindsight-owned
+# is created elsewhere. The old whole-filesystem sweep also chowned
+# every UNRELATED file that merely shared the numeric old UID (upstream
+# useradd assigns 1000, which collides with base-image users like
+# `node`), and each chown copy-ups the file into this layer — that
+# roughly doubled the exported image and dominated the CI push time.
+# ASSUMPTION: if a future upstream bump starts placing hindsight-owned
+# files outside /app + /home/hindsight, this list must be extended —
+# symptom would be runtime EACCES under the new path.
 RUN OLD_UID=$(id -u hindsight) && NEW_UID=11000 \
  && if [ "$OLD_UID" != "$NEW_UID" ]; then \
       usermod -u "$NEW_UID" hindsight \
    && groupmod -g "$NEW_UID" hindsight 2>/dev/null || true \
-   && find / -xdev -uid "$OLD_UID" ! -path '/proc/*' -exec chown -h "$NEW_UID":"$NEW_UID" {} + ; \
+   && find /app /home/hindsight -xdev -uid "$OLD_UID" -exec chown -h "$NEW_UID":"$NEW_UID" {} + ; \
     fi \
  && id hindsight >&2
 


### PR DESCRIPTION
## What

Four docker-build speedups. Investigation of run 28725629786 showed warm builds spend nearly all wall time in parent-layer materialization, image export/push, and SBOM generation — not Dockerfile compute (hindsight push job ~208s, voice ~89s, dependents 79-135s). `type=gha` cache was tried and reverted in #1965 and is NOT reintroduced.

### 1 — `docker/Dockerfile.hindsight`: scoped UID-migration chown

The UID pin (1000 → 11000) ran `find / -xdev -uid $OLD_UID -exec chown`, which chowned every file on the filesystem owned by the old numeric UID — including files that were never hindsight's (upstream `useradd` assigns UID 1000, which collides with base-image users like `node`). Every chown copy-ups the file into the layer, roughly doubling the exported image (the 90s+61s export).

Now scoped to `find /app /home/hindsight` — verified against upstream `vectorize-io/hindsight` `docker/standalone/Dockerfile` (v0.8.2): it does `chown -R hindsight:hindsight /app`, `useradd -m`, and `mkdir /home/hindsight/.pg0`; nothing hindsight-owned is created elsewhere. **Assumption stated in a Dockerfile comment:** if a future upstream bump places hindsight-owned files outside those dirs, the list must be extended (symptom: runtime EACCES under the new path). I could not run the docker build locally — CI is the live test.

### 2 — Skip re-export of unchanged images (`retag-unchanged` job)

For **hindsight and voice**, whose `.github/path-filters.yml` keys enumerate their *complete* build-input set, a path-skipped main push now gets `:sha-<short>` re-pointed at the existing `:latest` via `docker buildx imagetools create` (same no-rebuild pattern as `promote-to-dev`) — zero build/export cost, and every main commit now has a complete per-commit tag set. Absence-tolerant with the same "only skip on genuine NOT-FOUND" discipline as promote-to-dev.

**Deliberately NOT applied to base/dependents:** their images bake `dist/` bundles derived from effectively all of `src/`, which the `images` filter only partially covers — a filter-driven "unchanged" verdict would be unsound, and a content-digest scheme short of actually building is exactly the fragile hashing to avoid. Their cost is attacked by items 3 and 4 instead. (Documented in the workflow.)

### 3 — SBOM/provenance on tag pushes only (⚠️ policy change, operator-approved)

`provenance: mode=max` + `sbom: true` previously ran on **every** event. Now conditional: full attestation on tag pushes (release artifacts) only; PR/main-push/dispatch builds use `provenance: false`, sbom off. **This relaxes WS9-F3 (#1418) attestation to release artifacts only — approved by the operator.** The pull-side verification story (`switchroom update`) targets release images.

### 4 — Native arm64 runners + per-arch manifest merge

- `build-base` / `build-dependents` split into a per-arch matrix: amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`. **QEMU dropped** on those paths (arm64 legs of the heavy images were the QEMU-emulated long pole).
- Each arch leg pushes only a scratch tag `:sha-<short>-<arch>`; new `merge-base` / `merge-dependents` jobs stitch them into the final multi-arch manifests (`:latest` / `:sha-<short>` / `:vX.Y.Z`) with `docker buildx imagetools create` — manifest-only, no re-export. Nothing user-facing moves until the merge, so a failed arch leg can't leave a single-arch `:latest` behind.
- Registry cache is **per-arch** (`:buildcache-amd64` / `:buildcache-arm64`) to avoid cross-arch thrash, with the legacy `:buildcache` kept as a read-only fallback so the first post-split run isn't fully cold.
- PRs stay amd64-only build-only (matrix collapses to `["amd64"]` via `fromJSON`); merge jobs skip entirely on PRs.
- **hindsight stays on QEMU** (single multi-arch job): it's path-skipped on almost every main push, so doubling its job count buys nothing on the common path. **voice is amd64-only by design** (CTranslate2 CUDA kernels are x86_64-only) — unchanged.
- `smoke-test` now needs `merge-dependents` (which is what creates `agent:sha-<7>`); `promote-to-dev` needs list extended with `retag-unchanged` (non-failure).
- **`images-ok` sentinel (from #2807)** `needs` list extended to every gated job: `changes, build-base, merge-base, build-dependents, merge-dependents, build-hindsight, build-voice, retag-unchanged`. Ruleset 16470166 requires only `images-ok` (verified live via `gh api`), so the job renames don't touch branch protection.

### Synced files

- `.github/workflows/ci-full.yml`: twin `docker-images-build` job synced — per-image `cache` matrix field (`buildcache-amd64` for base/dependents, `buildcache` for hindsight/voice) + legacy fallback line.
- `CLAUDE.md`: CI section was stale (still described 11 required checks incl. `build-*`); updated to the actual ruleset state (4 required checks, `images-ok` sentinel) and the per-arch cache tags.

## Job served

Closest job spec: [`reference/jobs/idempotent-update-and-restart.md`](../blob/main/reference/jobs/idempotent-update-and-restart.md) — `docker-images` publishes the exact images `switchroom update` pulls; this shrinks the main-push → `:latest`/`:dev` publish latency (native arm64 instead of QEMU, no per-build attestation export, no re-export of provably-unchanged images, halved hindsight image size) without touching what a release tag ships or the smoke-gated `:dev` promotion. Also serves [`reference/jobs/fleet-stays-healthy.md`](../blob/main/reference/jobs/fleet-stays-healthy.md): faster image publish = faster fleet fix rollout.

## Validation

- `yaml.safe_load` + `actionlint` clean on both touched workflows.
- Ruleset 16470166 required-checks verified live: `lint`, `bun-test`, `vitest`, `images-ok` only.
- Docker builds cannot run in my environment — this PR touches `docker-images.yml`, so the PR's own CI builds all images (amd64) and is the live test for items 1 and 4's PR path. The arm64-native legs, merge jobs, retag-unchanged, and promote chain only exercise on the merge-to-main push — watch that run.
- Known trade-offs: scratch `:sha-<short>-<arch>` tags accumulate in GHCR (harmless clutter; a retention sweep can prune them later); first post-merge run is cache-cold-ish for arm64 (legacy `:buildcache` fallback softens amd64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
