### PR TITLE
chore(hindsight): bump upstream image pin v0.8.2 -> v0.8.4

### DIFF
--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -31,16 +31,16 @@
 # from another org; an upstream repoint would otherwise flow into the
 # published hindsight image undetected. Dependabot tracks bumps.
 #
-# Pinned to vectorize-io/hindsight v0.8.2 (digest below; label
-# org.opencontainers.image.version=0.8.2, built 2026-06-12). Bumped from
-# v0.7.1 (sha256:e82b2c05…) to pick up the concurrent-retain FK-violation fix
-# (vectorize-io/hindsight #1795 + #1882, closed 2026-06-01) and the 0.8.x
-# entity-link rework — fixes the `batch_retain` ForeignKeyViolation on
-# `unit_entities` that was silently dropping ~2-3% of memory writes
-# (switchroom #2392). NOTE: upstream publishes only `:latest` (no `:vX.Y.Z`
-# tag in ghcr), so the digest IS the version pin. A bump runs DB migrations
-# on the persisted memory volume — back up `switchroom-hindsight-data` first.
-FROM ghcr.io/vectorize-io/hindsight:latest@sha256:7c069db2d7aeeae82d3d3917292b87b14d6547f979c8b1335a42c94d09d57213
+# Pinned to vectorize-io/hindsight v0.8.4 (digest below; label
+# org.opencontainers.image.version=0.8.4, image revision 92f433c9 = the
+# v0.8.4 tag commit, built 2026-07-01). Bumped from v0.8.2 (sha256:7c069db2…)
+# to pick up 0.8.3 (merges divergent alembic heads, widens bank_id columns)
+# and 0.8.4. Prior history: v0.7.1→v0.8.2 fixed the `batch_retain`
+# ForeignKeyViolation on `unit_entities` (switchroom #2392). NOTE: upstream
+# publishes only `:latest` (no `:vX.Y.Z` tag in ghcr), so the digest IS the
+# version pin. A bump runs DB migrations on the persisted memory volume —
+# back up `switchroom-hindsight-data` first.
+FROM ghcr.io/vectorize-io/hindsight:latest@sha256:2c60f233eaba8f51db31adb920a560735aaf6f314e4b63c36c73159742dfa1a7
 
 USER root
 


### PR DESCRIPTION
## Summary
Bump the digest-pinned upstream Hindsight base image in `docker/Dockerfile.hindsight` from v0.8.2 (`sha256:7c069db2…`) to v0.8.4:

`ghcr.io/vectorize-io/hindsight:latest@sha256:2c60f233eaba8f51db31adb920a560735aaf6f314e4b63c36c73159742dfa1a7`

Digest-only change plus the version comment block; nothing else touched.

## Why
Picks up upstream 0.8.3 (merges divergent alembic heads, widens `bank_id` columns) and 0.8.4. Upstream publishes only `:latest` in GHCR, so the digest is the version pin (sec WS9-F4, #1418).

**Job spec:** `reference/jobs/remember-across-sessions.md` — keeping the memory backend on a current, digest-verified upstream keeps recall/retain healthy without the user re-teaching context.

## Digest evidence
- `ghcr.io/v2/vectorize-io/hindsight/manifests/latest` → index digest `sha256:2c60f233eaba8f51db31adb920a560735aaf6f314e4b63c36c73159742dfa1a7`
- amd64 image config labels: `org.opencontainers.image.version=0.8.4`, `org.opencontainers.image.revision=92f433c90409636804c0797071a4abbe141f76c5`, created 2026-07-01T11:51Z
- Upstream tag `v0.8.4` (released 2026-07-01) dereferences to commit `92f433c9` — matches the image revision label.

## Pins verified, unchanged
- `CLAUDE_CODE_VERSION=2.1.199` stays in lockstep with `docker/Dockerfile.base` (base is not changing here).
- `claude-agent-sdk==0.2.87` still satisfies upstream 0.8.4's `claude-agent-sdk>=0.2.82` (checked `hindsight-api-slim/pyproject.toml` at `92f433c9`).
- The #2392 source-patch anchors (`tempfile.mkdtemp(prefix="hindsight-claude-code-")` and the `CLAUDE_SECURESTORAGE_CONFIG_DIR` dict entry) are still present verbatim in `claude_code_llm.py` at `92f433c9`, so the build-time asserts will pass.

## Deploy note
0.8.3 runs alembic migrations on the persisted memory volume at deploy (divergent-head merge + `bank_id` column widening). **Snapshot the `switchroom-hindsight-data` volume before rolling this out.**

## Ordering vs PR #2811
Open PR #2811 (`perf/docker-build-speedups`) also touches `docker/Dockerfile.hindsight` (UID-migration chown scoping). This PR is deliberately minimal — digest + comment block only — so whichever merges second should rebase trivially. If #2811 lands first, this rebases clean; if this lands first, #2811's chown-layer change is untouched by this diff.

## Test plan / Risk
No local docker available in this environment; relying on docker-images CI to build the image (this PR changes an image input, so CI builds it). Build-time asserts (claude CLI install, SDK import, #2392 patch) fail loudly on regression. Risk: low — single-input bump with verified provenance; rollback is reverting the digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)