### PR TITLE
test(telegram): real source-structural guard for turn-flush reply-parity

### DIFF
--- a/telegram-plugin/tests/turn-flush-safety.test.ts
+++ b/telegram-plugin/tests/turn-flush-safety.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
 import {
   decideTurnFlush,
   isSilentFlushMarker,
@@ -238,18 +239,63 @@ describe('#2798 turn-flush block separation — real multi-block transcript shap
 // (stripExcessBold).
 // ---------------------------------------------------------------------------
 describe('#2798 turn-flush punctuation/bold parity with reply', () => {
-  // The shared deterministic format chain both send sites now apply, in order.
-  // replyFormatChain mirrors gateway executeReply (lines ~8924/8937/9175);
-  // turnFlushFormatChain mirrors the turn_end backstop (lines ~13571/added/
-  // 13708). They are deliberately IDENTICAL — that identity IS the parity
-  // contract this test guards; a future edit to only one gateway site would
-  // break byte-parity and red this test.
-  function replyFormatChain(text: string): string {
-    let t = normalizeParagraphBreaks(repairEscapedWhitespace(text))
-    t = stripExcessBold(normalizePunctuation(t))
-    return addParagraphSpacers(t)
-  }
-  function turnFlushFormatChain(text: string): string {
+  // SOURCE-STRUCTURAL guard (house pattern: gateway-outbound-redact.test.ts
+  // reads gateway.ts source and asserts the relative position of calls).
+  //
+  // The reply-parity contract is that the turn_flush backstop applies the SAME
+  // `stripExcessBold(normalizePunctuation(...))` normalization the reply path
+  // applies, in the SAME slot — after redactOutboundText, before scrubVoice.
+  //
+  // A prior version of this suite "guarded" that contract by defining two
+  // BYTE-IDENTICAL local functions (replyFormatChain / turnFlushFormatChain)
+  // and asserting `toBe` between them. That was tautological: the two locals
+  // were equal by construction regardless of what gateway.ts did, so deleting
+  // the normalization line from the turn_flush branch reddened NO test. The
+  // assertions below instead read the gateway source and pin the actual call
+  // ordering, so removing the `stripExcessBold(normalizePunctuation(capturedText))`
+  // line from the turn_flush branch REDS this suite — which is the exact
+  // regression #2798/#2813 shipped to prevent.
+  const gatewaySrc = readFileSync(
+    new URL('../gateway/gateway.ts', import.meta.url),
+    'utf8',
+  )
+
+  it('reply path: normalizes AFTER redact and BEFORE the voice scrub', () => {
+    const start = gatewaySrc.indexOf('async function executeReply(')
+    const redactIdx = gatewaySrc.indexOf(`redactOutboundText(text, 'reply')`, start)
+    const normIdx = gatewaySrc.indexOf('stripExcessBold(normalizePunctuation(text))', start)
+    const scrubIdx = gatewaySrc.indexOf('scrubVoice(text)', start)
+    expect(start).toBeGreaterThan(0)
+    expect(redactIdx).toBeGreaterThan(start)
+    expect(normIdx).toBeGreaterThan(redactIdx) // normalize AFTER the reply redact
+    expect(scrubIdx).toBeGreaterThan(normIdx) // ...and BEFORE the voice scrub
+  })
+
+  it('turn-flush backstop: applies the SAME normalization in the SAME slot (REDS if the line is removed)', () => {
+    const redactIdx = gatewaySrc.indexOf(`redactOutboundText(capturedText, 'turn_flush')`)
+    // The normalization call the reply path uses, verbatim, on the turn_flush
+    // variable. This indexOf is what returns -1 (→ assertion fails) if the
+    // `stripExcessBold(normalizePunctuation(capturedText))` line is deleted
+    // from the turn_flush branch.
+    const normIdx = gatewaySrc.indexOf('stripExcessBold(normalizePunctuation(capturedText))', redactIdx)
+    const scrubIdx = gatewaySrc.indexOf('scrubVoice(capturedText)', redactIdx)
+    expect(redactIdx).toBeGreaterThan(0)
+    expect(normIdx).toBeGreaterThan(redactIdx) // normalize AFTER the turn_flush redact
+    expect(scrubIdx).toBeGreaterThan(normIdx) // ...and BEFORE the voice scrub — mirrors reply
+  })
+
+  it('both send sites share the identical `stripExcessBold(normalizePunctuation(` wrapper', () => {
+    // Parity, structurally: the exact normalization wrapper the reply path uses
+    // is the one the turn_flush branch uses — same call, not a lookalike.
+    expect(gatewaySrc).toContain('stripExcessBold(normalizePunctuation(text))')
+    expect(gatewaySrc).toContain('stripExcessBold(normalizePunctuation(capturedText))')
+  })
+
+  // Behavioural coverage (kept from the original suite): reconstruct the
+  // deterministic format chain both sites apply and assert the REAL
+  // strip/normalize behaviour the added step provides — the over-bold block is
+  // stripped, unicode bullets become GFM list items, dashes are normalized.
+  function formatChain(text: string): string {
     let t = normalizeParagraphBreaks(repairEscapedWhitespace(text))
     t = stripExcessBold(normalizePunctuation(t))
     return addParagraphSpacers(t)
@@ -262,12 +308,8 @@ describe('#2798 turn-flush punctuation/bold parity with reply', () => {
     '• first bullet\n• second bullet\n\n' +
     'A range like 2019 – 2024 and a spaced em-dash a — b for good measure.'
 
-  it('produces byte-identical output to the reply format chain', () => {
-    expect(turnFlushFormatChain(input)).toBe(replyFormatChain(input))
-  })
-
   it('strips the over-bold block and normalizes bullets/dashes exactly as reply does', () => {
-    const out = turnFlushFormatChain(input)
+    const out = formatChain(input)
     // stripExcessBold removed the ** markers from the over-bolded paragraph
     // (the step turn-flush was missing) — the text survives, the markers do not.
     expect(out).not.toContain('**This whole paragraph')


### PR DESCRIPTION
## Summary

The `#2798 turn-flush punctuation/bold parity with reply` suite in `telegram-plugin/tests/turn-flush-safety.test.ts` (added in #2813) shipped a **tautological** guard. It defined two byte-identical local functions:

```ts
function replyFormatChain(text) { /* same 3 lines */ }
function turnFlushFormatChain(text) { /* same 3 lines */ }
it('produces byte-identical output ...', () =>
  expect(turnFlushFormatChain(input)).toBe(replyFormatChain(input)))
```

Those locals were equal **by construction**, independent of `gateway.ts`. So deleting the `stripExcessBold(normalizePunctuation(...))` line from the turn_flush backstop in `telegram-plugin/gateway/gateway.ts` — the exact regression the suite's comment claimed to prevent — would red **no** test. The comment ("a future edit to only one gateway site would break byte-parity and red this test") was false.

The sibling **behavioural** test does exercise real strip/normalize behaviour, so coverage wasn't zero, but the structural parity guard was fake.

## Fix

Replace the tautology with a **source-structural** assertion, modelled on `telegram-plugin/tests/gateway-outbound-redact.test.ts` (which reads `gateway.ts` source text and asserts the relative position of calls). The new suite:

- Reads `gateway.ts` source via `new URL('../gateway/gateway.ts', import.meta.url)`.
- **Reply path:** asserts `stripExcessBold(normalizePunctuation(text))` sits after `redactOutboundText(text, 'reply')` and before `scrubVoice(text)`.
- **Turn-flush backstop:** asserts the *same* `stripExcessBold(normalizePunctuation(capturedText))` call sits after `redactOutboundText(capturedText, 'turn_flush')` and before `scrubVoice(capturedText)` — mirroring reply's order. This is the assertion that reds if the normalization line is removed.
- Asserts both send sites contain the identical `stripExcessBold(normalizePunctuation(` wrapper (structural parity).
- **Keeps** the existing behavioural assertions (over-bold stripping, unicode-bullet and dash normalization).

## Verified it reds on regression

Temporarily deleted `capturedText = stripExcessBold(normalizePunctuation(capturedText))` from the turn_flush branch of `gateway.ts` → **2 assertions failed** (turn-flush ordering guard + shared-wrapper parity). Restored the line → all **45 tests pass**. `tsc --noEmit` clean.

## Test plan

- [x] `./node_modules/.bin/vitest run telegram-plugin/tests/turn-flush-safety.test.ts` — 45 passed
- [x] `./node_modules/.bin/tsc --noEmit` — exit 0
- [x] Confirmed the new guard reds when the turn_flush normalization line is removed

## Risk

Test-only change. No runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)