### PR TITLE
fix(ci): dispatch image builds get their own concurrency group

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -62,9 +62,16 @@ permissions:
   contents: read
   packages: write
 
+# workflow_dispatch runs get their own concurrency group (keyed by
+# run id) so a busy merge train on main can't cancel a manually
+# requested full build — dispatch is the recovery lever for exactly
+# the case where push runs keep superseding each other before a
+# path-gated image (e.g. hindsight) gets rebuilt (#1336, and observed
+# live on 2026-07-05: three successive merges cancelled both the push
+# run carrying a hindsight pin bump and the recovery dispatch).
 concurrency:
-  group: docker-images-${{ github.ref }}
-  cancel-in-progress: true
+  group: docker-images-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## What
workflow_dispatch runs of docker-images.yml now use a per-run concurrency group and are never cancelled in progress; push runs keep latest-wins cancellation on their ref group.

## Why
Observed live today: three merges in quick succession cancelled (1) the push run carrying the hindsight v0.8.4 pin bump (#2814) and (2) the manual recovery dispatch. Because hindsight is path-gated and retag-unchanged re-stamps :latest on unchanged commits, hindsight:latest/:dev stayed on v0.8.2 with fresh sha tags — exactly the gap workflow_dispatch exists to close (#1336), except the dispatch itself was cancellable.

## Job spec
`reference/jobs/idempotent-update-and-restart.md` — docker-images publishes the exact images `switchroom update` pulls; this keeps the manual recovery lever (the only way to republish `:latest` without another merge) functional under merge traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
