### PR TITLE
fix(gateway): stop false 'missed this'/'you never answered' during flap + first represent (#2788)

### DIFF
--- a/telegram-plugin/gateway/escalation-bridge-gate.ts
+++ b/telegram-plugin/gateway/escalation-bridge-gate.ts
@@ -1,0 +1,46 @@
+/**
+ * escalation-bridge-gate.ts — the bridge-alive gate for the obligation sweep's
+ * ESCALATE branch, extracted from obligationSweep so the "do NOT direct-send the
+ * 'I may have missed this' nudge while the Telegram bridge is down" decision
+ * (#2788 Gap A) is EXECUTABLE in a pure unit test.
+ *
+ * The bug (#2788 Gap A): the obligation sweep keeps running while the Telegram
+ * bridge is disconnected. Unlike the represent branch (which goes through the
+ * bridge → buffer and is naturally stranded behind a dead bridge), the escalate
+ * branch DIRECT-SENDS via `bot.api.sendMessage`, bypassing the bridge. So during
+ * a transient bridge flap the user could receive a false "I may have missed this"
+ * even though the real reply is simply queued behind the outage and will land the
+ * moment the bridge recovers.
+ *
+ * The fix is a deferral, not a drop: obligations already survive bridge death
+ * (they live in the durable ledger and are re-evaluated every sweep), so gating
+ * the escalate SEND on bridge-alive and returning without closing leaves the
+ * obligation OPEN. The next sweep after the bridge reconnects re-drives it — the
+ * nudge is deferred until it can reflect a real, post-recovery miss. This adds NO
+ * unbounded liveness dependency: the entire gateway's inbound delivery already
+ * rests on the bridge eventually reconnecting / the process restarting.
+ *
+ * PURE — no Telegram, no IPC; the gateway injects `bridgeAlive` (read from
+ * `ipcServer.getClient(agent)?.isAlive()`).
+ */
+
+export interface EscalationBridgeGateDeps {
+  /**
+   * True when this agent's bridge sidecar is currently registered and alive on
+   * the IPC server — i.e. a direct escalate send can actually reflect delivery
+   * reality rather than racing a queued-behind-a-dead-bridge reply.
+   */
+  bridgeAlive: boolean
+}
+
+/**
+ * Decide whether the escalate branch should DEFER (skip this sweep, leave the
+ * obligation OPEN) because the bridge is down.
+ *
+ * Returns true ⇒ defer: do not send the nudge, do not close — the durable
+ * obligation is re-driven on a later sweep once the bridge recovers.
+ * Returns false ⇒ the bridge is alive; proceed with escalation.
+ */
+export function shouldDeferEscalationForBridge(deps: EscalationBridgeGateDeps): boolean {
+  return !deps.bridgeAlive
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -394,6 +394,7 @@ import {
 } from './status-pin-store.js'
 import { driveEscalation } from './escalation-drive.js'
 import { shouldSuppressRepresent } from './represent-guard.js'
+import { shouldDeferEscalationForBridge } from './escalation-bridge-gate.js'
 import { createInboundSpool } from './inbound-spool.js'
 import { purgeStaleTurnsForChat } from './turn-state-purge.js'
 import { decideInboundDelivery } from './inbound-delivery-gate.js'
@@ -7017,6 +7018,22 @@ function obligationSweep(): void {
   // normal close path) — close silently instead of alarming the user with a
   // false "I may have missed this". This is Fix 4: escalate only on knowledge,
   // not doubt. Fall back to false (safe: never suppresses) if history unavailable.
+  //
+  // #2788 Gap A — bridge-flap gate. The escalate branch DIRECT-SENDS (via
+  // bot.api.sendMessage below), bypassing the bridge. So while the bridge is
+  // down the represent branch is naturally stranded (bridge → buffer) but this
+  // branch would still fire a false "I may have missed this", even though the
+  // real reply is merely queued behind a transient outage. Defer: if the bridge
+  // is not alive, leave the obligation OPEN and re-drive on a later sweep once
+  // it recovers. Obligations survive bridge death (durable ledger, re-evaluated
+  // every sweep), so this deferral adds NO unbounded liveness dependency — the
+  // whole gateway already rests on the bridge eventually reconnecting.
+  if (shouldDeferEscalationForBridge({ bridgeAlive: ipcServer.getClient(agent)?.isAlive() === true })) {
+    process.stderr.write(
+      `telegram gateway: obligation escalation deferred — bridge down (nudge waits for reconnect) origin=${o.originTurnId}\n`,
+    )
+    return
+  }
   if (HISTORY_ENABLED && hasOutboundDeliveredSince(o.chatId, o.openedAt, o.threadId)) {
     process.stderr.write(
       `telegram gateway: obligation closed silently — outbound delivered since open origin=${o.originTurnId}\n`,

--- a/telegram-plugin/gateway/represent-guard.ts
+++ b/telegram-plugin/gateway/represent-guard.ts
@@ -14,14 +14,22 @@
  * no Telegram, no SQLite; the gateway injects `hasOutboundDeliveredSince` as a
  * predicate. The single load-bearing subtlety lives here in one testable place:
  *
- *   The cutoff is `lastRepresentedAt` (the time of the PREVIOUS represent), NOT
- *   `openedAt`. On the FIRST represent (`lastRepresentedAt` undefined) the guard
- *   is a no-op, so the genuine "agent wrote a plain-text answer and never called
- *   the reply tool" case still re-presents ONCE. Only the SECOND-and-later
- *   represent is gated — exactly where a reply that landed BETWEEN fires must
- *   suppress the re-ask. A reply that predates the last represent (e.g. the
- *   original plain-text answer) does not count, because it is not evidence the
- *   most recent represent was answered.
+ *   For the SECOND-and-later represent the cutoff is `lastRepresentedAt` (the
+ *   time of the PREVIOUS represent), NOT `openedAt` — exactly where a reply that
+ *   landed BETWEEN fires must suppress the re-ask, while a reply that predates
+ *   the last represent (e.g. the original plain-text answer) does not count,
+ *   because it is not evidence the most recent represent was answered.
+ *
+ *   For the FIRST represent (`lastRepresentedAt` undefined) the cutoff is
+ *   `openedAt` (#2788 Gap B). Previously the first represent was an unconditional
+ *   no-op, leaving a narrow window: if a genuine reply was already delivered
+ *   since the obligation was RAISED but its routing didn't resolve back to the
+ *   origin (so the ledger's normal close path missed it), the first represent
+ *   emitted a false "you never answered". Deduping against outbound history from
+ *   `openedAt` closes that window WITHOUT breaking the genuine "agent wrote a
+ *   plain-text answer and never called the reply tool" case: that case records NO
+ *   outbound row, so `hasOutboundDeliveredSince` reports false and the single
+ *   re-ask still fires.
  */
 
 /** The obligation fields the represent guard inspects. */
@@ -29,6 +37,8 @@ export interface RepresentGuardObligation {
   readonly originTurnId: string
   readonly chatId: string
   readonly threadId?: number
+  /** Wall-clock ms this obligation was RAISED — the FIRST-represent cutoff (#2788). */
+  readonly openedAt?: number
   /** Wall-clock ms this obligation was most recently re-presented, if ever. */
   readonly lastRepresentedAt?: number
 }
@@ -65,8 +75,15 @@ export function shouldSuppressRepresent(
   deps: RepresentGuardDeps,
 ): boolean {
   if (!deps.historyEnabled) return false
-  // First represent: nothing to compare against — let the single re-ask fire so
-  // the genuine plain-text-no-reply case is preserved.
-  if (o.lastRepresentedAt == null) return false
+  // First represent (#2788 Gap B): dedup against outbound history from `openedAt`.
+  // A genuine reply already delivered since the obligation was raised means the
+  // user WAS answered — suppress the false "you never answered". The genuine
+  // plain-text-no-reply case records no outbound row, so the predicate reports
+  // false there and the single re-ask still fires. If `openedAt` is unknown we
+  // cannot dedup safely, so fall back to the prior no-op (never suppress).
+  if (o.lastRepresentedAt == null) {
+    if (o.openedAt == null) return false
+    return deps.hasOutboundDeliveredSince(o.chatId, o.openedAt, o.threadId)
+  }
   return deps.hasOutboundDeliveredSince(o.chatId, o.lastRepresentedAt, o.threadId)
 }

--- a/telegram-plugin/tests/escalation-bridge-gate.test.ts
+++ b/telegram-plugin/tests/escalation-bridge-gate.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { shouldDeferEscalationForBridge } from "../gateway/escalation-bridge-gate.js";
+
+// Executable verification of #2788 Gap A: the obligation sweep's escalate branch
+// DIRECT-SENDS (bypassing the bridge), so during a transient bridge outage it
+// could fire a false "I may have missed this" even though the real reply is just
+// queued behind the flap. The gate defers the nudge while the bridge is down;
+// obligations survive bridge death, so the deferral is safe and self-healing.
+
+describe("shouldDeferEscalationForBridge — #2788 Gap A bridge-flap gate", () => {
+  it("DEFERS escalation while the bridge is down (no false 'I may have missed this')", () => {
+    expect(shouldDeferEscalationForBridge({ bridgeAlive: false })).toBe(true);
+  });
+
+  it("proceeds with escalation when the bridge is alive", () => {
+    expect(shouldDeferEscalationForBridge({ bridgeAlive: true })).toBe(false);
+  });
+
+  it("models the gateway wiring: getClient(agent)?.isAlive() === true drives the gate", () => {
+    // Bridge registered + alive → do not defer.
+    const aliveClient = { isAlive: () => true };
+    expect(
+      shouldDeferEscalationForBridge({ bridgeAlive: aliveClient.isAlive() === true }),
+    ).toBe(false);
+
+    // Bridge registered but a stale/dead socket → defer.
+    const deadClient = { isAlive: () => false };
+    expect(
+      shouldDeferEscalationForBridge({ bridgeAlive: deadClient.isAlive() === true }),
+    ).toBe(true);
+
+    // No client registered at all (getClient returns undefined) → defer.
+    const noClient: { isAlive: () => boolean } | undefined = undefined;
+    expect(
+      shouldDeferEscalationForBridge({ bridgeAlive: noClient?.isAlive() === true }),
+    ).toBe(true);
+  });
+});

--- a/telegram-plugin/tests/represent-guard.test.ts
+++ b/telegram-plugin/tests/represent-guard.test.ts
@@ -37,14 +37,14 @@ describe("shouldSuppressRepresent — #2472 duplicate-represent guard", () => {
   });
 
   it("does NOT suppress the FIRST represent — genuine plain-text-no-reply still represents once", () => {
-    // First represent: lastRepresentedAt is undefined. Even though an assistant
-    // message (the original plain-text answer) exists in history, the single
-    // re-ask must still fire — the agent never called the reply tool.
-    const o = obligation({ lastRepresentedAt: undefined });
+    // First represent: lastRepresentedAt is undefined, no reply tool call was
+    // ever recorded (the genuine plain-text-no-reply case → no outbound row, so
+    // the predicate reports false). The single re-ask must still fire.
+    const o = obligation({ openedAt: 0, lastRepresentedAt: undefined });
     const suppress = shouldSuppressRepresent(o, {
       historyEnabled: true,
-      // history WOULD report an outbound exists, but the first represent ignores it
-      hasOutboundDeliveredSince: () => true,
+      // No outbound row exists for a plain-text answer → predicate is false.
+      hasOutboundDeliveredSince: () => false,
     });
     expect(suppress).toBe(false); // represent fires exactly once
   });
@@ -66,6 +66,42 @@ describe("shouldSuppressRepresent — #2472 duplicate-represent guard", () => {
     const suppress = shouldSuppressRepresent(o, {
       historyEnabled: true,
       hasOutboundDeliveredSince: replyDeliveredAt(500),
+    });
+    expect(suppress).toBe(false);
+  });
+
+  it("#2788 Gap B — SUPPRESSES the FIRST represent when a genuine reply was delivered since openedAt", () => {
+    // The narrow false "you never answered" window: a real reply landed at
+    // t=1500 after the obligation was raised at t=1000, but its routing didn't
+    // resolve back to the origin so the ledger's close path missed it. The FIRST
+    // represent must now dedup against outbound history (cutoff = openedAt) and
+    // suppress, instead of emitting a false "you never answered".
+    const o = obligation({ openedAt: 1000, lastRepresentedAt: undefined });
+    const suppress = shouldSuppressRepresent(o, {
+      historyEnabled: true,
+      hasOutboundDeliveredSince: replyDeliveredAt(1500),
+    });
+    expect(suppress).toBe(true); // first represent deduped → no false "you never answered"
+  });
+
+  it("#2788 Gap B — first represent still fires when the only reply PREDATES openedAt", () => {
+    // A reply at t=500 answered an EARLIER turn, before this obligation was
+    // raised at t=1000. It is not evidence THIS obligation was answered → the
+    // first represent must still fire.
+    const o = obligation({ openedAt: 1000, lastRepresentedAt: undefined });
+    const suppress = shouldSuppressRepresent(o, {
+      historyEnabled: true,
+      hasOutboundDeliveredSince: replyDeliveredAt(500),
+    });
+    expect(suppress).toBe(false);
+  });
+
+  it("#2788 Gap B — first represent falls back to firing when openedAt is unknown", () => {
+    // Without an openedAt cutoff we cannot dedup safely — never suppress on doubt.
+    const o = obligation({ openedAt: undefined, lastRepresentedAt: undefined });
+    const suppress = shouldSuppressRepresent(o, {
+      historyEnabled: true,
+      hasOutboundDeliveredSince: () => true,
     });
     expect(suppress).toBe(false);
   });


### PR DESCRIPTION
## What

Two narrow correctness gaps in the obligation sweep that emit a **false claim to the user**, both fixed with minimal, pure, testable guards.

### Gap A — escalation nudge fires during a bridge flap
The obligation sweep keeps running while the Telegram bridge is down. The represent branch goes through the bridge → buffer (naturally stranded behind a dead bridge), but the **escalate branch direct-sends** via `bot.api.sendMessage`, bypassing the bridge — so during a transient flap the user could get a false "I may have missed this" even though the real reply is merely queued behind the outage.

**Fix:** gate the escalate SEND on bridge-alive (`ipcServer.getClient(agent)?.isAlive()`). If the bridge is down, leave the obligation OPEN and return; the next sweep after reconnect re-drives it. Obligations survive bridge death (durable ledger, re-evaluated every sweep), so the deferral is safe and self-healing — the whole gateway already rests on the bridge eventually reconnecting. Extracted as pure `shouldDeferEscalationForBridge()`.

### Gap B — first represent had no outbound-history dedup
The first represent was an unconditional no-op, leaving a narrow window: a genuine reply already delivered since the obligation was raised (but whose routing didn't resolve back to the origin, so the ledger's normal close path missed it) produced a false "you never answered".

**Fix:** dedup the first represent against outbound history from `openedAt`. The genuine "plain-text answer, never called the reply tool" case records **no** outbound row, so the predicate reports false there and the single re-ask still fires — that behaviour is preserved.

## Files
- `telegram-plugin/gateway/escalation-bridge-gate.ts` (new) — pure `shouldDeferEscalationForBridge()` helper.
- `telegram-plugin/gateway/gateway.ts` — wire the bridge gate into the escalate branch (import + guard).
- `telegram-plugin/gateway/represent-guard.ts` — first-represent now consults outbound history from `openedAt` (added `openedAt` to `RepresentGuardObligation`).
- `telegram-plugin/tests/escalation-bridge-gate.test.ts` (new) — Gap A: bridge-down defers, bridge-alive proceeds, models the `getClient().isAlive()` wiring incl. undefined client.
- `telegram-plugin/tests/represent-guard.test.ts` — Gap B: first represent SUPPRESSES on a prior delivered reply, still fires when the reply predates `openedAt`, still fires for genuine plain-text-no-reply, safe fallback when `openedAt` unknown.

## Verdict rule
- **Vision outcome:** always-on / colleague trust — the agent stops making false "I missed this" claims caused by transient plumbing state.
- **JTBD:** `reference/jobs/feel-like-a-colleague.md` — *verifies before claiming*. Both gaps were the agent confabulating a false claim to the user; the fixes make it check real bridge/outbound state first.
- **Principle checks:** pass (no docs/defaults/consistency surface changed; both guards default to never-suppress on doubt).
- **Invariants:** crosses none. Aligns with `chat-is-the-single-source-of-truth` — the guards consult real outbound history / bridge liveness before asserting anything to the user.

## Tests
`npm run lint` clean (tsc --noEmit + all check scripts). Focused vitest for both gaps green (15 tests across the two files). Both are pure exported units exercising the real decision code paths.

Closes #2788

🤖 Generated with [Claude Code](https://claude.com/claude-code)