### PR TITLE
fix: guard SWITCHROOM_LITELLM against unbound variable under set -u

### DIFF
--- a/profiles/_base/cron-session.sh.hbs
+++ b/profiles/_base/cron-session.sh.hbs
@@ -95,7 +95,7 @@ cd "{{agentDir}}" || exit 1
 # can distinguish cron spend from main-session spend per agent.
 # FAIL-OPEN: missing key OR unreachable proxy → strip routing env, fall back to
 # direct OAuth. An outage must never take the cron session dark.
-if [ -n "$SWITCHROOM_LITELLM" ] && command -v switchroom >/dev/null 2>&1; then
+if [ -n "${SWITCHROOM_LITELLM:-}" ] && command -v switchroom >/dev/null 2>&1; then
   sr_ll_key="$(switchroom vault get "litellm/{{name}}/api-key" 2>/dev/null || true)"
   sr_ll_ok=""
   if [ -z "$sr_ll_key" ]; then

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -64,7 +64,7 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
   #
   # SWITCHROOM_AGENT_NAME is injected by compose env (compose.ts:1816)
   # so it is available here, before the inner-pass export at line ~320.
-  if [ -n "$SWITCHROOM_LITELLM" ] && [ -z "$ANTHROPIC_CUSTOM_HEADERS" ] && command -v switchroom >/dev/null 2>&1; then
+  if [ -n "${SWITCHROOM_LITELLM:-}" ] && [ -z "$ANTHROPIC_CUSTOM_HEADERS" ] && command -v switchroom >/dev/null 2>&1; then
     sr_ll_key="$(switchroom vault get "litellm/$SWITCHROOM_AGENT_NAME/api-key" 2>/dev/null || true)"
     sr_ll_ok=""
     if [ -z "$sr_ll_key" ]; then
@@ -884,7 +884,7 @@ fi
 # per-session cost/issue tracking is handled out-of-band by correlating
 # LiteLLM's request log against switchroom's turn ledger, never by mutating the
 # claude protocol.
-if [ -n "$SWITCHROOM_LITELLM" ] && command -v switchroom >/dev/null 2>&1; then
+if [ -n "${SWITCHROOM_LITELLM:-}" ] && command -v switchroom >/dev/null 2>&1; then
   sr_ll_key="$(switchroom vault get "litellm/$SWITCHROOM_AGENT_NAME/api-key" 2>/dev/null || true)"
   sr_ll_ok=""
   if [ -z "$sr_ll_key" ]; then

--- a/tests/cheap-cron-session-render.test.ts
+++ b/tests/cheap-cron-session-render.test.ts
@@ -153,7 +153,7 @@ describe("cron-session.sh LiteLLM routing — mirrors start.sh boot block", () =
   });
 
   it("is gated on SWITCHROOM_LITELLM — inert when not set", () => {
-    expect(out).toContain('if [ -n "$SWITCHROOM_LITELLM" ]');
+    expect(out).toContain('if [ -n "${SWITCHROOM_LITELLM:-}" ]');
   });
 
   it("exports ANTHROPIC_CUSTOM_HEADERS and CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY on success", () => {

--- a/tests/scaffold.litellm-failopen.test.ts
+++ b/tests/scaffold.litellm-failopen.test.ts
@@ -60,7 +60,7 @@ describe("scaffoldAgent: LiteLLM fail-open boot contract (#litellm)", () => {
     const startSh = readFileSync(join(res.agentDir, "start.sh"), "utf-8");
 
     // Gated on the same SWITCHROOM_LITELLM marker compose injects.
-    expect(startSh).toContain('if [ -n "$SWITCHROOM_LITELLM" ]');
+    expect(startSh).toContain('if [ -n "${SWITCHROOM_LITELLM:-}" ]');
 
     // Boot reachability probe against the proxy's unauthenticated liveness
     // endpoint (so a key-less probe still works).

--- a/tests/scaffold.litellm-gateway-outer.test.ts
+++ b/tests/scaffold.litellm-gateway-outer.test.ts
@@ -79,7 +79,7 @@ describe("start.sh: LiteLLM ANTHROPIC_CUSTOM_HEADERS hoisted before gateway fork
     const startSh = renderStartSh();
 
     // Must check SWITCHROOM_LITELLM (same gate as inner block).
-    expect(startSh).toContain('if [ -n "$SWITCHROOM_LITELLM" ] && [ -z "$ANTHROPIC_CUSTOM_HEADERS" ]');
+    expect(startSh).toContain('if [ -n "${SWITCHROOM_LITELLM:-}" ] && [ -z "$ANTHROPIC_CUSTOM_HEADERS" ]');
   });
 
   it("outer block exports ANTHROPIC_CUSTOM_HEADERS with litellm headers before the gateway fork", () => {


### PR DESCRIPTION
## Summary
- `start.sh` and `cron-session.sh` run under `set -u`, but three call sites checked `$SWITCHROOM_LITELLM` directly instead of `${SWITCHROOM_LITELLM:-}`. For any agent where the var is genuinely unset (litellm disabled), this throws "unbound variable" and kills the script before the fail-open fallback logic runs.
- **Confirmed live in production**: agents carrie/clerk/gymbro/marko were spamming this error on every cron fire.
- Fixed by switching all three sites to `${SWITCHROOM_LITELLM:-}`.
- This is paired with a separate host config change flipping `defaults.litellm.enabled: true` fleet-wide (already applied directly to switchroom.yaml, not part of this repo/PR). The bug was latent before (only agents *without* litellm hit it); after the flip every agent gets `SWITCHROOM_LITELLM` set by default going forward — but this template fix is correct and worth landing regardless of that flip.

## Test plan
- [x] `git diff` confirms exactly the 3 guard sites changed
- [x] Updated 3 existing tests asserting the literal guard string (`tests/scaffold.litellm-failopen.test.ts`, `tests/scaffold.litellm-gateway-outer.test.ts`, `tests/cheap-cron-session-render.test.ts`)
- [x] `vitest run` on affected suites: 46/46 passing
- [ ] shellcheck not available in this environment (templates are `.hbs` mustache anyway, would need pre-processing)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>