### PR TITLE
fix(ci): review follow-ups from #2807/#2811/#2816/#2818 + hindsight-plugin hardening

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -37,9 +37,13 @@ permissions:
   # :buildcache cache-from). Build-only — nothing is pushed.
   packages: read
 
+# workflow_dispatch runs get their own concurrency group (keyed by
+# run id) so scheduled runs on the same ref can't cancel a manually
+# requested one — dispatch is the manual re-trigger lever, so it must
+# not be cancellable (same pattern as docker-images.yml, #1336).
 concurrency:
-  group: ci-full-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-full-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -41,9 +41,14 @@ on:
 permissions:
   contents: read
 
+# workflow_dispatch runs get their own concurrency group (keyed by
+# run id) so pushes to the same ref can't cancel a manually requested
+# recovery run — dispatch is the recovery lever advertised above, so
+# it must not be cancellable by the very traffic it recovers from
+# (same pattern as docker-images.yml, #1336).
 concurrency:
-  group: docker-e2e-${{ github.ref }}
-  cancel-in-progress: true
+  group: docker-e2e-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   # ─── Path-change filter (skip-as-pass pattern, #1320 followup) ────

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -267,18 +267,34 @@ jobs:
           set -euo pipefail
           IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-base"
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          # Stale-dispatch guard (#2818 follow-up): a workflow_dispatch
+          # on main runs against the tip AT DISPATCH TIME; if main has
+          # advanced since, pushing :latest would REGRESS it behind a
+          # newer push run's :latest. Skip :latest (keep :sha-<7>) when
+          # the checked-out sha is no longer main's tip. Fail-open: if
+          # ls-remote can't answer, keep pushing :latest — the guard is
+          # a safety net, not a new failure mode for the recovery lever.
+          PUSH_LATEST=true
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            MAIN_TIP=$(git ls-remote "https://github.com/${{ github.repository }}" refs/heads/main | cut -f1 || true)
+            if [[ -n "$MAIN_TIP" && "$MAIN_TIP" != "${{ github.sha }}" ]]; then
+              PUSH_LATEST=false
+              echo "::notice title=stale dispatch::checked-out ${{ github.sha }} is no longer main tip ($MAIN_TIP) — skipping :latest, pushing :sha-${SHA_SHORT} only."
+            fi
+          fi
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
             TAG_VERSION="${GITHUB_REF#refs/tags/}"
             TAG_ARGS=(-t "${IMAGE}:${TAG_VERSION}" -t "${IMAGE}:latest")
-          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+          elif [[ "${{ github.ref }}" == "refs/heads/main" && "$PUSH_LATEST" == "true" ]]; then
             # PR C: keep :latest as the canonical install per
             # docs/operators/install.md, BUT also publish :sha-<7> for
             # rollback / promote.yml retagging. (:dev is gated by the
             # smoke-test job and assigned by promote-to-dev — never here.)
             TAG_ARGS=(-t "${IMAGE}:latest" -t "${IMAGE}:sha-${SHA_SHORT}")
           else
-            # dispatch on a non-main, non-tag ref: publish only the
-            # per-commit tag; never move :latest from an odd ref.
+            # dispatch on a non-main/non-tag ref, or a stale main
+            # dispatch: publish only the per-commit tag; never move
+            # :latest from an odd ref or an outdated main sha.
             TAG_ARGS=(-t "${IMAGE}:sha-${SHA_SHORT}")
           fi
           docker buildx imagetools create "${TAG_ARGS[@]}" \
@@ -418,10 +434,19 @@ jobs:
           set -euo pipefail
           IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${{ matrix.image }}"
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          # Stale-dispatch guard — see merge-base for rationale.
+          PUSH_LATEST=true
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            MAIN_TIP=$(git ls-remote "https://github.com/${{ github.repository }}" refs/heads/main | cut -f1 || true)
+            if [[ -n "$MAIN_TIP" && "$MAIN_TIP" != "${{ github.sha }}" ]]; then
+              PUSH_LATEST=false
+              echo "::notice title=stale dispatch::checked-out ${{ github.sha }} is no longer main tip ($MAIN_TIP) — skipping :latest, pushing :sha-${SHA_SHORT} only."
+            fi
+          fi
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
             TAG_VERSION="${GITHUB_REF#refs/tags/}"
             TAG_ARGS=(-t "${IMAGE}:${TAG_VERSION}" -t "${IMAGE}:latest")
-          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+          elif [[ "${{ github.ref }}" == "refs/heads/main" && "$PUSH_LATEST" == "true" ]]; then
             TAG_ARGS=(-t "${IMAGE}:latest" -t "${IMAGE}:sha-${SHA_SHORT}")
           else
             TAG_ARGS=(-t "${IMAGE}:sha-${SHA_SHORT}")
@@ -473,13 +498,29 @@ jobs:
         run: |
           IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-hindsight"
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          # Stale-dispatch guard — see merge-base for rationale.
+          PUSH_LATEST=true
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            MAIN_TIP=$(git ls-remote "https://github.com/${{ github.repository }}" refs/heads/main | cut -f1 || true)
+            if [[ -n "$MAIN_TIP" && "$MAIN_TIP" != "${{ github.sha }}" ]]; then
+              PUSH_LATEST=false
+              echo "::notice title=stale dispatch::checked-out ${{ github.sha }} is no longer main tip ($MAIN_TIP) — skipping :latest, pushing :sha-${SHA_SHORT} only."
+            fi
+          fi
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
             TAG_VERSION="${GITHUB_REF#refs/tags/}"
             echo "tags=${IMAGE}:${TAG_VERSION},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
-          elif [[ ( "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "workflow_dispatch" ) && "${{ github.ref }}" == "refs/heads/main" ]]; then
+          elif [[ "${{ github.ref }}" == "refs/heads/main" && "$PUSH_LATEST" == "true" ]]; then
             echo "tags=${IMAGE}:latest,${IMAGE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
-          else
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "tags=${IMAGE}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            # dispatch on a non-main/non-tag ref, or a stale main
+            # dispatch: sha tag only. Previously a non-main dispatch
+            # fell into the pr-<number> branch with an EMPTY number,
+            # producing an invalid `:pr-` reference and failing the
+            # push (#2816 review follow-up).
+            echo "tags=${IMAGE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build (and push on main/tag) hindsight
@@ -546,13 +587,26 @@ jobs:
         run: |
           IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-voice"
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          # Stale-dispatch guard — see merge-base for rationale.
+          PUSH_LATEST=true
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            MAIN_TIP=$(git ls-remote "https://github.com/${{ github.repository }}" refs/heads/main | cut -f1 || true)
+            if [[ -n "$MAIN_TIP" && "$MAIN_TIP" != "${{ github.sha }}" ]]; then
+              PUSH_LATEST=false
+              echo "::notice title=stale dispatch::checked-out ${{ github.sha }} is no longer main tip ($MAIN_TIP) — skipping :latest, pushing :sha-${SHA_SHORT} only."
+            fi
+          fi
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
             TAG_VERSION="${GITHUB_REF#refs/tags/}"
             echo "tags=${IMAGE}:${TAG_VERSION},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
-          elif [[ ( "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "workflow_dispatch" ) && "${{ github.ref }}" == "refs/heads/main" ]]; then
+          elif [[ "${{ github.ref }}" == "refs/heads/main" && "$PUSH_LATEST" == "true" ]]; then
             echo "tags=${IMAGE}:latest,${IMAGE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
-          else
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "tags=${IMAGE}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            # dispatch on a non-main/non-tag ref, or a stale main
+            # dispatch: sha tag only (see build-hindsight's twin branch).
+            echo "tags=${IMAGE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build (and push on main/tag) voice
@@ -735,7 +789,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [base, agent, broker, kernel, hostd, auth-broker, hindsight, voice]
+        # Keep in sync with the merge-dependents matrix + base +
+        # hindsight/voice: every image that publishes :sha-<7> on main
+        # must be promoted here, or its :dev tag silently stops
+        # advancing (web was missing until #2818's follow-up).
+        image: [base, agent, broker, kernel, hostd, auth-broker, web, hindsight, voice]
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0

--- a/vendor/hindsight-memory/CHANGELOG.md
+++ b/vendor/hindsight-memory/CHANGELOG.md
@@ -16,6 +16,10 @@
   rewrite: filters compose with sender-bank routing (per-bank overrides
   apply to sender banks too) and are part of the recall cache key
   (`_tag_filter_sig`) so a filter change can't serve stale cached results.
+  Note: because the key now joins an extra part (empty string when filters
+  are unused), every cache key rotates ONCE across this upgrade boundary —
+  the first recall per session after upgrading is a cache miss. Within a
+  version, keys are unchanged as long as filters stay unused.
 - `55ef70679` — optional `requestTimeoutSeconds` /
   `HINDSIGHT_REQUEST_TIMEOUT_SECONDS` global request-timeout override in
   `HindsightClient` (adapted to our `_request`). Wired into retain.py only;

--- a/vendor/hindsight-memory/scripts/lib/client.py
+++ b/vendor/hindsight-memory/scripts/lib/client.py
@@ -59,8 +59,14 @@ class HindsightClient:
 
         Upstream 55ef70679. NOTE: recall.py deliberately does not pass the
         override — its 8s timeout is a hook-budget invariant.
+
+        The override is clamped to >= 1: a zero/negative env value would
+        otherwise reach urlopen as a nonsensical timeout (0 fails every
+        request immediately), turning a config typo into a dead client.
         """
-        return self.request_timeout_override if self.request_timeout_override is not None else timeout
+        if self.request_timeout_override is None:
+            return timeout
+        return max(1, self.request_timeout_override)
 
     def _headers(self) -> dict:
         headers = {

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -151,16 +151,21 @@ def _cast_env(value: str, typ):
         if typ is float:
             return float(value)
         if typ is list:
-            # JSON list first (upstream 962140eef), else fall through to the
-            # comma-separated fallback in the except branch below.
+            # JSON list first (upstream 962140eef). A value that parses as
+            # JSON but is NOT a list (e.g. `42`, `"x"`, `{}`) is a config
+            # mistake, not a comma-separated string — return None so the
+            # default is kept (matches upstream; fail-open). Only values
+            # that don't parse as JSON at all take the comma-split path.
             try:
                 parsed = json.loads(value)
-                if isinstance(parsed, list):
-                    return parsed
             except ValueError:
-                pass
-            # Comma-separated → list of trimmed, non-empty strings.
-            return [t.strip() for t in value.split(",") if t.strip()]
+                if value.lstrip().startswith(("[", "{")):
+                    # Looks like intended JSON but doesn't parse —
+                    # malformed config, not a comma list. Keep default.
+                    return None
+                # Comma-separated → list of trimmed, non-empty strings.
+                return [t.strip() for t in value.split(",") if t.strip()]
+            return parsed if isinstance(parsed, list) else None
         if typ is dict:
             # JSON only (dict or list accepted — tag_groups may be a list).
             parsed = json.loads(value)

--- a/vendor/hindsight-memory/scripts/tests/test_config_client_casts.py
+++ b/vendor/hindsight-memory/scripts/tests/test_config_client_casts.py
@@ -1,0 +1,111 @@
+"""Unit tests for config env casting (`lib.config._cast_env`) and the
+client's request-timeout override clamp (`HindsightClient._resolve_timeout`).
+
+Follow-ups from the #2816 review punch list:
+  - list cast: a value that parses as JSON but is NOT a list (e.g. `42`)
+    must return None (keep default, fail-open) instead of falling through
+    to comma-split and producing a junk one-element list. Malformed
+    intended-JSON (`[1,2`) also keeps the default; plain comma strings
+    still split.
+  - timeout override: zero/negative env values are clamped to >= 1 instead
+    of passing straight through to urlopen.
+
+Stdlib-only.
+"""
+
+import os
+import sys
+import unittest
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib.config import _cast_env  # noqa: E402
+from lib.client import HindsightClient  # noqa: E402
+
+
+class CastEnvListTests(unittest.TestCase):
+    def test_valid_json_list(self):
+        self.assertEqual(_cast_env('["a", "b"]', list), ["a", "b"])
+
+    def test_empty_json_list(self):
+        self.assertEqual(_cast_env("[]", list), [])
+
+    def test_comma_string_splits(self):
+        self.assertEqual(_cast_env("a, b ,c", list), ["a", "b", "c"])
+
+    def test_comma_string_drops_empty_tokens(self):
+        self.assertEqual(_cast_env("a,,b,", list), ["a", "b"])
+
+    def test_single_bare_string(self):
+        # Not valid JSON, no commas → one-element list.
+        self.assertEqual(_cast_env("solo", list), ["solo"])
+
+    def test_json_non_list_scalar_returns_none(self):
+        # Parses as JSON int — not a list, not a comma string. Default kept.
+        self.assertIsNone(_cast_env("42", list))
+
+    def test_json_non_list_object_returns_none(self):
+        self.assertIsNone(_cast_env('{"a": 1}', list))
+
+    def test_json_string_returns_none(self):
+        # A JSON-quoted string is valid JSON but not a list.
+        self.assertIsNone(_cast_env('"tag"', list))
+
+    def test_malformed_json_array_returns_none(self):
+        # Looks like intended JSON but doesn't parse → default kept,
+        # NOT comma-split into junk like ['["a"', '"b"'].
+        self.assertIsNone(_cast_env('["a", "b"', list))
+
+    def test_malformed_json_object_returns_none(self):
+        self.assertIsNone(_cast_env('{"a": ', list))
+
+
+class CastEnvOtherTypesTests(unittest.TestCase):
+    """Guard the neighbours the list change must not disturb."""
+
+    def test_int_valid(self):
+        self.assertEqual(_cast_env("30", int), 30)
+
+    def test_int_invalid_returns_none(self):
+        self.assertIsNone(_cast_env("thirty", int))
+
+    def test_bool_true_variants(self):
+        for v in ("true", "1", "yes", "TRUE"):
+            self.assertTrue(_cast_env(v, bool), v)
+
+    def test_bool_false(self):
+        self.assertFalse(_cast_env("false", bool))
+
+    def test_dict_valid(self):
+        self.assertEqual(_cast_env('{"a": 1}', dict), {"a": 1})
+
+    def test_dict_non_container_returns_none(self):
+        self.assertIsNone(_cast_env("42", dict))
+
+
+class ResolveTimeoutTests(unittest.TestCase):
+    URL = "http://127.0.0.1:9999"
+
+    def _client(self, override):
+        return HindsightClient(self.URL, request_timeout_override=override)
+
+    def test_no_override_uses_caller_timeout(self):
+        self.assertEqual(self._client(None)._resolve_timeout(30), 30)
+
+    def test_valid_override_wins(self):
+        self.assertEqual(self._client(15)._resolve_timeout(30), 15)
+
+    def test_zero_override_clamped_to_one(self):
+        self.assertEqual(self._client(0)._resolve_timeout(30), 1)
+
+    def test_negative_override_clamped_to_one(self):
+        self.assertEqual(self._client(-5)._resolve_timeout(30), 1)
+
+    def test_one_passes_through(self):
+        self.assertEqual(self._client(1)._resolve_timeout(30), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Accumulated review follow-ups from the merged PRs #2807 / #2811 / #2816 / #2818, batched into one PR.

Serves job spec `reference/jobs/idempotent-update-and-restart.md` (the CI image-publish path feeds `switchroom update`); the plugin fixes serve `reference/jobs/remember-across-sessions.md`.

## CI workflows

**A. Dispatch recovery-lever concurrency (docker-e2e.yml, ci-full.yml)** — same bug fixed in docker-images.yml by #2818: `workflow_dispatch` runs shared the ref-keyed concurrency group and were cancellable by pushes, despite dispatch being the advertised stale-run recovery lever. Now: per-run group for dispatch, `cancel-in-progress` only for non-dispatch.

**B1. promote-to-dev matrix missing `web`** — merge-dependents publishes `web:sha-<7>`/`:latest`, but `web` was absent from the promote matrix so `web:dev` never advanced (preexisting). Added, with a keep-in-sync comment.

**B2. hindsight/voice tag composition on non-main dispatch** — a `workflow_dispatch` on a non-main, non-tag ref fell into the `pr-${{ github.event.pull_request.number }}` else-branch with an empty number, producing an invalid `:pr-` reference and failing the push. Now any non-main/non-tag ref (and stale main dispatch, below) yields the `:sha-<7>` tag.

**B3. `:latest` stale-dispatch regression guard** (documented in the #2818 review) — on `workflow_dispatch`, the four jobs that push `:latest` (merge-base, merge-dependents, build-hindsight, build-voice) now check `git ls-remote` against `github.sha`; if main has advanced since dispatch, `:latest` is skipped (sha tags kept) with a `::notice`. Fail-open when ls-remote can't answer, so the recovery lever never gains a new failure mode.

Guard logic exercised locally via an extracted shell snippet — all six scenarios correct:

```
push main                       -> latest,sha-<7>
dispatch main, tip match        -> latest,sha-<7>
dispatch main, STALE            -> sha-<7> only
dispatch main, tip unknown      -> latest,sha-<7> (fail-open)
dispatch non-main ref           -> sha-<7> only
tag push                        -> v1.2.3,latest
```

`actionlint` clean and `yaml.safe_load` OK on all three touched workflows.

## vendor/hindsight-memory (#2816 punch list)

**C1.** `lib/client.py` `_resolve_timeout`: override clamped to `>= 1` — a zero/negative `HINDSIGHT_REQUEST_TIMEOUT_SECONDS` no longer reaches `urlopen` (where 0 fails every request).

**C2.** `lib/config.py` `_cast_env` list cast: values that parse as JSON but aren't a list (`42`, `"x"`, `{}`) now return `None` → default kept (matches upstream, fail-open), instead of comma-splitting into a junk one-element list. Malformed intended-JSON (`[1,2`) also keeps the default; plain comma strings still split.

**C3.** CHANGELOG cache-key wording corrected: keys rotate ONCE across the upgrade boundary (an extra empty part is joined into `_cache_key`), unchanged only within-version when filters are unused.

## Tests

New stdlib-only `scripts/tests/test_config_client_casts.py` (20 tests: list cast matrix incl. JSON-non-list → default and malformed JSON → default; int/bool/dict neighbours; timeout clamp for 0/negative/None/1/valid). Full plugin suite run exactly as CI does (`python3 -m unittest discover tests/` from `vendor/hindsight-memory/scripts`): **164 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)