### PR TITLE
fix(inbound): surface silent message-loss in buffer/spool path (#2789)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6884,11 +6884,18 @@ const pendingInboundBuffer = createPendingInboundBuffer({
     if (last != null && nowMs - last < EVICT_NOTICE_COOLDOWN_MS) return
     evictNoticeByChat.set(key, nowMs)
     const threadOpts = evThread != null ? { message_thread_id: evThread } : {}
+    // Honesty: the evicted message is NOT re-pushed into the buffer
+    // in-session — its only in-session resolution is the escalation sweep
+    // (sweepEscalations, ~15 min), which either delivers it or posts the
+    // "couldn't deliver … please resend" retraction. So this notice must
+    // NOT promise a prompt pickup ("shortly"), or it would contradict a
+    // later escalation. Word it to match that reality: saved, handled when
+    // the current turn frees up, and prompted-to-resend if it can't be.
     void swallowingApiCall(
       () =>
         bot.api.sendMessage(
           chat,
-          "⏳ Messages are arriving faster than I can process them, so some are being deferred — they're saved and will be picked up shortly. If anything seems missed, please resend it.",
+          "⏳ Messages are arriving faster than I can process them. Your messages are saved and will be handled once I finish the current turn — if any can't be picked up, I'll ask you to resend it.",
           { ...threadOpts },
         ),
       { chat_id: chat, verb: 'inbound-buffer-eviction' },

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6847,8 +6847,54 @@ const inboundSpool = STATIC
         existsSync: (p) => existsSync(p),
         statSizeSync: (p) => statSync(p).size,
       },
+      // #2789 B: durability degradation must be visible, not silent. When
+      // spool appends start failing we're back to in-memory-only — a
+      // later crash loses those messages. Latched log so the operator /
+      // health surface sees the transition rather than a silent downgrade.
+      onDegraded: (info) => {
+        process.stderr.write(
+          `telegram gateway: inbound-spool durability ` +
+          `${info.degraded ? 'DEGRADED to in-memory-only' : 'RECOVERED'} ` +
+          `path=${info.path} consecutiveFailures=${info.consecutiveFailures}` +
+          `${info.error != null ? ` error=${info.error}` : ''}\n`,
+        )
+      },
     })
-const pendingInboundBuffer = createPendingInboundBuffer({ spool: inboundSpool })
+
+// #2789 A: the in-memory cap eviction used to silently drop the oldest
+// buffered inbound within a live session (the durable spool copy only
+// replays at boot / escalates after 15 min). Surface it as a coalesced,
+// per-chat "messages deferred" notice so the eviction is visible — the
+// evicted message still lives in the spool, so it is deferred, not lost.
+const EVICT_NOTICE_COOLDOWN_MS = 5 * 60 * 1000
+const evictNoticeByChat = new Map<string, number>()
+const pendingInboundBuffer = createPendingInboundBuffer({
+  spool: inboundSpool,
+  onEvict: (_agent, evicted) => {
+    const chat = evicted.chatId
+    const evThread =
+      typeof evicted.meta?.threadId === 'string' && evicted.meta.threadId
+        ? Number(evicted.meta.threadId)
+        : undefined
+    const key = `${chat}:${evThread ?? '-'}`
+    const last = evictNoticeByChat.get(key)
+    const nowMs = Date.now()
+    // Coalesce: at most one deferral notice per chat per cooldown so a
+    // sustained >32 burst posts one line, not one per evicted message.
+    if (last != null && nowMs - last < EVICT_NOTICE_COOLDOWN_MS) return
+    evictNoticeByChat.set(key, nowMs)
+    const threadOpts = evThread != null ? { message_thread_id: evThread } : {}
+    void swallowingApiCall(
+      () =>
+        bot.api.sendMessage(
+          chat,
+          "⏳ Messages are arriving faster than I can process them, so some are being deferred — they're saved and will be picked up shortly. If anything seems missed, please resend it.",
+          { ...threadOpts },
+        ),
+      { chat_id: chat, verb: 'inbound-buffer-eviction' },
+    )
+  },
+})
 
 // PR2 obligation-ledger idle sweep. Re-present an OPEN obligation only at a
 // CLEAN idle: no turn in flight AND the inbound buffer is empty — so the
@@ -8559,7 +8605,7 @@ if (!STATIC) {
     // promise EXPLICITLY (honest failure) instead of letting it sit
     // forever. This is what makes the guarantee deterministic: every
     // queued message ends either delivered or visibly retracted.
-    inboundSpool?.sweepEscalations((e, { postNotice }) => {
+    inboundSpool?.sweepEscalations((e, { postNotice, droppedCount }) => {
       const chat = e.msg.chatId
       const escThread =
         typeof e.msg.meta?.threadId === 'string' && e.msg.meta.threadId
@@ -8578,13 +8624,17 @@ if (!STATIC) {
       // outage that re-ages a synthetic into the bound every 15 min posts ONE
       // notice, not one per cycle (the 2026-06-09 marko "please resend" spam).
       if (!postNotice) return
+      // #2789 C: report the REAL number of dropped messages for this chat
+      // in this sweep rather than under-counting a multi-message drop as a
+      // single one.
+      const n = droppedCount > 0 ? droppedCount : 1
+      const noticeText =
+        n === 1
+          ? "⚠️ I couldn't deliver an earlier message to the agent after repeated retries (it survived restarts but the agent never picked it up). Please resend it."
+          : `⚠️ I couldn't deliver ${n} earlier messages to the agent after repeated retries (they survived restarts but the agent never picked them up). Please resend them.`
       void swallowingApiCall(
         () =>
-          bot.api.sendMessage(
-            chat,
-            "⚠️ I couldn't deliver an earlier message to the agent after repeated retries (it survived restarts but the agent never picked it up). Please resend it.",
-            { ...threadOpts },
-          ),
+          bot.api.sendMessage(chat, noticeText, { ...threadOpts }),
         { chat_id: chat, verb: 'inbound-spool-escalation' },
       )
     })

--- a/telegram-plugin/gateway/inbound-spool.ts
+++ b/telegram-plugin/gateway/inbound-spool.ts
@@ -159,6 +159,21 @@ export interface InboundSpoolOptions {
    *  `escalateAfterMs` here) or back-to-back attempts wouldn't coalesce.
    *  Default 30 min. */
   escalateNoticeCooldownMs?: number
+  /**
+   * #2789 B: fired whenever spool durability changes state — an append
+   * fails (durability has silently degraded to in-memory-only, so a
+   * later crash loses those messages) or recovers. Latches: called once
+   * on the transition into degraded and once on the transition back to
+   * healthy, not on every append. Lets the gateway raise a health
+   * signal instead of quietly continuing as if the durable promise
+   * still held. Best-effort — a throw here never breaks delivery.
+   */
+  onDegraded?: (info: {
+    degraded: boolean
+    consecutiveFailures: number
+    path: string
+    error?: string
+  }) => void
 }
 
 export interface ReplayEntry {
@@ -199,13 +214,25 @@ export interface InboundSpool {
    *  `escalateNoticeCooldownMs` — a burst of undeliverable inbounds (e.g.
    *  a synthetic re-created every 15 min while the agent is down, across
    *  restarts) yields ONE notice, not one per entry. The window is
-   *  persisted, so it holds across a gateway restart. Returns the count
-   *  of entries dropped. Safe to call on a timer. */
+   *  persisted, so it holds across a gateway restart. `droppedCount` is
+   *  the real number of entries dropped for that entry's chat in THIS
+   *  sweep, so the coalesced notice reports the true multi-message loss
+   *  count instead of under-reporting it as one (#2789 C). Returns the
+   *  total count of entries dropped. Safe to call on a timer. */
   sweepEscalations: (
-    onEscalate: (e: ReplayEntry, opts: { postNotice: boolean }) => void,
+    onEscalate: (
+      e: ReplayEntry,
+      opts: { postNotice: boolean; droppedCount: number },
+    ) => void,
   ) => number
   /** Test/observability: count of live (un-acked) ids. */
   liveCount: () => number
+  /** #2789 B: true while spool appends are failing — durability has
+   *  degraded to in-memory-only. A health signal the gateway can surface
+   *  instead of quietly dropping the durability guarantee. */
+  isDegraded: () => boolean
+  /** #2789 B: consecutive append failures since the last success. */
+  appendFailureCount: () => number
 }
 
 export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
@@ -226,6 +253,13 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
   // window survives a gateway restart (the actual 2026-06-09 spam: a
   // synthetic re-aged into the bound every 15 min across many restarts).
   const escAttemptByChat = new Map<string, number>()
+
+  // #2789 B: append-durability health. `consecutiveAppendFailures`
+  // counts failed appends since the last success; `degraded` latches so
+  // the onDegraded callback fires exactly once per state transition
+  // (into degraded / back to healthy) rather than on every append.
+  let consecutiveAppendFailures = 0
+  let degraded = false
 
   function parseLine(line: string): SpoolRecord | null {
     const s = line.trim()
@@ -288,15 +322,52 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
   function appendRecord(rec: SpoolRecord): void {
     try {
       fs.appendFileSync(path, JSON.stringify(rec) + '\n')
+      // #2789 B: a successful append after a failure run means the spool
+      // is durable again — un-latch degraded state and surface recovery
+      // so the health signal clears.
+      if (consecutiveAppendFailures > 0) {
+        log(
+          `inbound-spool: append recovered path=${path} after ` +
+          `${consecutiveAppendFailures} failure(s) — durability restored\n`,
+        )
+        consecutiveAppendFailures = 0
+        if (degraded) {
+          degraded = false
+          try {
+            opts.onDegraded?.({ degraded: false, consecutiveFailures: 0, path })
+          } catch {
+            /* health signal is best-effort; never break delivery */
+          }
+        }
+      }
     } catch (err) {
       // Durability is best-effort relative to fs availability; a spool
-      // write failure must NOT break live delivery. Log loudly — a
-      // persistently failing spool means we're back to in-memory-only
-      // semantics and the operator should know.
+      // write failure must NOT break live delivery. But it must NOT be
+      // SILENT either (#2789 B) — a persistently failing spool means
+      // we're back to in-memory-only semantics and a later crash loses
+      // the message. Log loudly on every failure AND raise a latched
+      // health signal on the transition into degraded so the operator /
+      // health surface knows the durability guarantee is gone.
+      consecutiveAppendFailures++
+      const message = (err as Error).message
       log(
         `inbound-spool: append FAILED path=${path} id=${rec.id} t=${rec.t}: ` +
-        `${(err as Error).message} — durability degraded to in-memory\n`,
+        `${message} — durability degraded to in-memory ` +
+        `(consecutive failures=${consecutiveAppendFailures})\n`,
       )
+      if (!degraded) {
+        degraded = true
+        try {
+          opts.onDegraded?.({
+            degraded: true,
+            consecutiveFailures: consecutiveAppendFailures,
+            path,
+            error: message,
+          })
+        } catch {
+          /* health signal is best-effort; never break delivery */
+        }
+      }
     }
   }
 
@@ -399,10 +470,25 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
     sweepEscalations(onEscalate) {
       const tNow = now()
       const cutoff = tNow - escalateAfterMs
+      // First pass (#2789 C): identify the entries to drop and count them
+      // per chat so the (coalesced) notice reports the REAL number of
+      // dropped messages instead of under-counting a multi-message drop
+      // as a single one. Iteration order is preserved so the tombstone /
+      // esc append order is unchanged.
+      const toDrop: {
+        id: string
+        e: { agent: string; msg: InboundMessage; firstAt: number }
+      }[] = []
+      const perChatCount = new Map<string, number>()
+      for (const [id, e] of live.entries()) {
+        if (e.firstAt > cutoff) continue
+        toDrop.push({ id, e })
+        const key = escChatKey(e.msg)
+        perChatCount.set(key, (perChatCount.get(key) ?? 0) + 1)
+      }
       let dropped = 0
       let posted = 0
-      for (const [id, e] of [...live.entries()]) {
-        if (e.firstAt > cutoff) continue
+      for (const { id, e } of toDrop) {
         live.delete(id)
         appendRecord({ t: 'ack', id }) // tombstone — promise retracted
         // Coalesce the user-facing notice per chat on a SLIDING window:
@@ -420,7 +506,13 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
           typeof threadRaw === 'string' && threadRaw.length > 0 ? threadRaw : undefined
         appendRecord({ t: 'esc', chat: e.msg.chatId, thread, at: tNow })
         try {
-          onEscalate({ agent: e.agent, msg: e.msg }, { postNotice })
+          // #2789 C: hand the caller the real per-chat drop count for
+          // THIS sweep so the notice it posts can say "N messages" rather
+          // than under-reporting a multi-message drop as a single one.
+          onEscalate(
+            { agent: e.agent, msg: e.msg },
+            { postNotice, droppedCount: perChatCount.get(key) ?? 1 },
+          )
         } catch (err) {
           log(`inbound-spool: onEscalate threw id=${id}: ${(err as Error).message}\n`)
         }
@@ -440,6 +532,12 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
     },
     liveCount() {
       return live.size
+    },
+    isDegraded() {
+      return degraded
+    },
+    appendFailureCount() {
+      return consecutiveAppendFailures
     },
   }
 }

--- a/telegram-plugin/gateway/pending-inbound-buffer.ts
+++ b/telegram-plugin/gateway/pending-inbound-buffer.ts
@@ -66,6 +66,19 @@ export interface PendingInboundBufferOptions {
    * than the old silent in-memory drop).
    */
   spool?: InboundSpool
+  /**
+   * Called when the in-memory cap forces an eviction of the OLDEST
+   * entry (#2789 defect A). The evicted message is NOT lost — `push`
+   * still records it durably in the spool (boot-replayed / escalated) —
+   * but within a live session it will not be re-delivered until boot or
+   * escalation, so the eviction must not be SILENT the way it was
+   * before. The caller wires this to a coalesced "N messages deferred"
+   * user-facing notice tied to the spool, turning a silent in-session
+   * drop into a visible deferral (chat-is-the-single-source-of-truth:
+   * surface the loss window, don't hide it). Best-effort: a throw here
+   * never breaks the push hot path.
+   */
+  onEvict?: (agent: string, evicted: InboundMessage) => void
 }
 
 /**
@@ -304,6 +317,19 @@ export function createPendingInboundBuffer(
           `pending-inbound-buffer: agent=${agent} cap=${cap} reached — ` +
           `dropped oldest entry source=${dropped?.meta?.source ?? '-'} ts=${dropped?.ts ?? '-'}\n`,
         )
+        // #2789 A: the cap eviction is no longer a SILENT in-session
+        // drop. `dropped` still lives in the durable spool (it was
+        // spool.put on its own push), so it survives to boot-replay /
+        // escalation — but it won't be re-delivered THIS session. Hand
+        // it to the caller so a coalesced "N messages deferred" notice
+        // can be surfaced. Best-effort: never let the notice break push.
+        if (dropped != null && opts.onEvict != null) {
+          try {
+            opts.onEvict(agent, dropped)
+          } catch {
+            /* user-facing notice is best-effort; never break the hot path */
+          }
+        }
       }
       q.push(msg)
       // Durable record FIRST-class to the in-memory queue: spool BEFORE

--- a/telegram-plugin/tests/inbound-spool.test.ts
+++ b/telegram-plugin/tests/inbound-spool.test.ts
@@ -435,3 +435,146 @@ describe('inbound-spool — robustness', () => {
     ])
   })
 })
+
+describe('inbound-spool — #2789 C: multi-message drop notice reports the real count', () => {
+  it('passes the true per-chat dropped count to the coalesced notice', () => {
+    const fs = fakeFs()
+    let t = 0
+    const s = createInboundSpool({
+      path: PATH,
+      fs,
+      now: () => t,
+      escalateAfterMs: 100,
+      escalateNoticeCooldownMs: 10_000,
+    })
+    // Four undeliverable synthetics in ONE chat — the historical bug
+    // coalesced these into a notice that read as a SINGLE drop.
+    s.put('marko', msg({ messageId: 0, ts: 1, meta: { source: 'cron' } }))
+    s.put('marko', msg({ messageId: 0, ts: 2, meta: { source: 'cron' } }))
+    s.put('marko', msg({ messageId: 0, ts: 3, meta: { source: 'cron' } }))
+    s.put('marko', msg({ messageId: 0, ts: 4, meta: { source: 'cron' } }))
+    t = 1000 // all older than the 100ms bound
+    const posted: number[] = []
+    const seen: number[] = []
+    const dropped = s.sweepEscalations((_e, { postNotice, droppedCount }) => {
+      seen.push(droppedCount)
+      if (postNotice) posted.push(droppedCount)
+    })
+    expect(dropped).toBe(4) // all four retracted
+    // Every callback for this chat sees the true sweep count (4), and the
+    // ONE posted notice reports 4 — not 1.
+    expect(seen).toEqual([4, 4, 4, 4])
+    expect(posted).toEqual([4])
+  })
+
+  it('reports per-chat counts independently in a mixed sweep', () => {
+    const fs = fakeFs()
+    let t = 0
+    const s = createInboundSpool({
+      path: PATH,
+      fs,
+      now: () => t,
+      escalateAfterMs: 100,
+      escalateNoticeCooldownMs: 10_000,
+    })
+    // 3 in chat A, 1 in chat B.
+    s.put('m', msg({ chatId: 'A', messageId: 0, ts: 1, meta: { source: 'cron' } }))
+    s.put('m', msg({ chatId: 'A', messageId: 0, ts: 2, meta: { source: 'cron' } }))
+    s.put('m', msg({ chatId: 'A', messageId: 0, ts: 3, meta: { source: 'cron' } }))
+    s.put('m', msg({ chatId: 'B', messageId: 0, ts: 4, meta: { source: 'cron' } }))
+    t = 1000
+    const posted = new Map<string, number>()
+    s.sweepEscalations((e, { postNotice, droppedCount }) => {
+      if (postNotice) posted.set(String(e.msg.chatId), droppedCount)
+    })
+    expect(posted.get('A')).toBe(3)
+    expect(posted.get('B')).toBe(1)
+  })
+
+  it('a single drop still reports a count of 1', () => {
+    const fs = fakeFs()
+    let t = 0
+    const s = createInboundSpool({ path: PATH, fs, now: () => t, escalateAfterMs: 100 })
+    s.put('m', msg({ messageId: 0, ts: 1, meta: { source: 'cron' } }))
+    t = 1000
+    const counts: number[] = []
+    s.sweepEscalations((_e, { droppedCount }) => counts.push(droppedCount))
+    expect(counts).toEqual([1])
+  })
+})
+
+describe('inbound-spool — #2789 B: spool write failure surfaces a health signal', () => {
+  // An fs whose appendFileSync can be toggled to fail, modelling a full /
+  // unwritable persistent volume. The append swallows the error (delivery
+  // must not break) but the degradation must be SURFACED, not silent.
+  function toggleableFs(): InboundSpoolFsSeam & { fail: boolean } {
+    const files = new Map<string, string>()
+    const seam = {
+      fail: false,
+      appendFileSync(p: string, d: string) {
+        if (seam.fail) throw new Error('ENOSPC: no space left on device')
+        files.set(p, (files.get(p) ?? '') + d)
+      },
+      readFileSync: (p: string) => files.get(p) ?? '',
+      writeFileSync: (p: string, d: string) => files.set(p, d),
+      renameSync: (from: string, to: string) => {
+        files.set(to, files.get(from) ?? '')
+        files.delete(from)
+      },
+      existsSync: (p: string) => files.has(p),
+      statSizeSync: (p: string) => Buffer.byteLength(files.get(p) ?? ''),
+    }
+    return seam
+  }
+
+  it('raises a latched onDegraded signal when an append fails, and isDegraded() reflects it', () => {
+    const fs = toggleableFs()
+    const events: { degraded: boolean; consecutiveFailures: number }[] = []
+    const s = createInboundSpool({
+      path: PATH,
+      fs,
+      log: () => {},
+      onDegraded: (info) => events.push({ degraded: info.degraded, consecutiveFailures: info.consecutiveFailures }),
+    })
+    expect(s.isDegraded()).toBe(false)
+    fs.fail = true
+    // put() must NOT throw — live delivery keeps working, durability degrades.
+    expect(() => s.put('a', msg({ messageId: 1, ts: 1 }))).not.toThrow()
+    expect(s.isDegraded()).toBe(true)
+    expect(s.appendFailureCount()).toBe(1)
+    // Latched: exactly one transition event on entering degraded.
+    expect(events).toEqual([{ degraded: true, consecutiveFailures: 1 }])
+  })
+
+  it('does not re-fire the degraded signal on every failing append (latched)', () => {
+    const fs = toggleableFs()
+    const events: boolean[] = []
+    const s = createInboundSpool({
+      path: PATH, fs, log: () => {},
+      onDegraded: (info) => events.push(info.degraded),
+    })
+    fs.fail = true
+    s.put('a', msg({ messageId: 1, ts: 1 }))
+    s.put('a', msg({ messageId: 2, ts: 2 }))
+    s.put('a', msg({ messageId: 3, ts: 3 }))
+    expect(s.appendFailureCount()).toBe(3)
+    expect(events).toEqual([true]) // one transition, not three
+  })
+
+  it('surfaces recovery when appends succeed again (health signal un-latches)', () => {
+    const fs = toggleableFs()
+    const events: boolean[] = []
+    const s = createInboundSpool({
+      path: PATH, fs, log: () => {},
+      onDegraded: (info) => events.push(info.degraded),
+    })
+    fs.fail = true
+    s.put('a', msg({ messageId: 1, ts: 1 }))
+    expect(s.isDegraded()).toBe(true)
+    fs.fail = false
+    s.put('a', msg({ messageId: 2, ts: 2 }))
+    expect(s.isDegraded()).toBe(false)
+    expect(s.appendFailureCount()).toBe(0)
+    expect(events).toEqual([true, false]) // degraded → recovered
+  })
+})

--- a/telegram-plugin/tests/pending-inbound-buffer.test.ts
+++ b/telegram-plugin/tests/pending-inbound-buffer.test.ts
@@ -95,6 +95,59 @@ describe('pending-inbound-buffer', () => {
     expect(drained.map((m) => m.meta?.source)).toEqual(['m3', 'm4', 'm5'])
   })
 
+  // #2789 A: a >cap burst mid-turn used to evict the oldest SILENTLY —
+  // the durable spool copy only replays at boot / escalates after 15 min,
+  // so within a live session the evicted message was just gone with no
+  // user-visible signal. onEvict makes the eviction non-silent so the
+  // caller can surface a coalesced "messages deferred" notice.
+  it('#2789 A: fires onEvict with the evicted message on cap eviction (not a silent drop)', () => {
+    const evicted: InboundMessage[] = []
+    const buf = createPendingInboundBuffer({
+      capPerAgent: 3,
+      log: () => {},
+      onEvict: (_agent, m) => evicted.push(m),
+    })
+    // Fill to cap — no eviction yet, no notice.
+    buf.push('a', inbound('m1', 1))
+    buf.push('a', inbound('m2', 2))
+    buf.push('a', inbound('m3', 3))
+    expect(evicted).toHaveLength(0)
+    // The 4th push overflows the cap → oldest (m1) evicted → onEvict fires.
+    buf.push('a', inbound('m4', 4))
+    expect(evicted.map((m) => m.meta?.source)).toEqual(['m1'])
+    // The 5th evicts m2.
+    buf.push('a', inbound('m5', 5))
+    expect(evicted.map((m) => m.meta?.source)).toEqual(['m1', 'm2'])
+  })
+
+  it('#2789 A: a >32 burst produces one onEvict per evicted entry, never a silent drop', () => {
+    const evicted: InboundMessage[] = []
+    const buf = createPendingInboundBuffer({
+      log: () => {}, // default cap = 32
+      onEvict: (_agent, m) => evicted.push(m),
+    })
+    // 40 messages into a 32-cap buffer → exactly 8 evictions, all reported.
+    for (let i = 1; i <= 40; i++) buf.push('a', inbound(`m${i}`, i))
+    expect(buf.depth('a')).toBe(32)
+    expect(evicted).toHaveLength(8)
+    expect(evicted.map((m) => m.meta?.source)).toEqual([
+      'm1', 'm2', 'm3', 'm4', 'm5', 'm6', 'm7', 'm8',
+    ])
+  })
+
+  it('#2789 A: a throwing onEvict never breaks the push hot path', () => {
+    const buf = createPendingInboundBuffer({
+      capPerAgent: 1,
+      log: () => {},
+      onEvict: () => {
+        throw new Error('notice failed')
+      },
+    })
+    buf.push('a', inbound('m1', 1))
+    expect(() => buf.push('a', inbound('m2', 2))).not.toThrow()
+    expect(buf.depth('a')).toBe(1)
+  })
+
   it('push returns false when eviction occurred', () => {
     const buf = createPendingInboundBuffer({ capPerAgent: 2, log: () => {} })
     expect(buf.push('a', inbound('m1'))).toBe(true)


### PR DESCRIPTION
## What & why

Three defects in the inbound buffer/spool path caused **silent message loss** under sustained bursts or spool write-failure. Each is now *surfaced* rather than hidden. Minimal, per-defect changes — no surrounding refactor.

Closes #2789

### A — burst >32 buffered messages mid-turn silently drops the oldest
The in-memory cap evicts the oldest with no user-visible signal. The durable spool copy only replays at boot / tombstones after 15 min, so within a live session the evicted message is just gone.

**Fix (lower-risk coalesced-notice option):** `pending-inbound-buffer.ts` gains an `onEvict(agent, evicted)` seam fired on cap eviction. The gateway wires it to a **coalesced per-chat "messages deferred" notice** (5-min cooldown so a sustained >32 burst posts one line, not one per eviction). The evicted entry still lives in the durable spool (it was `spool.put` on its own push), so it is **deferred, not lost** — boot-replayed / escalated as before, but the in-session eviction is no longer silent.

**Tradeoff taken:** chose the coalesced-notice option over full in-session spool replay. In-session replay would need new drain-trigger plumbing (re-injecting an evicted entry into the live delivery path mid-turn, which the `idleDrainTick` NOTE explicitly warns is unsafe mid-turn). The notice is correct and far lower blast-radius: the message survives durably and the user is told, satisfying "do NOT silently drop."

### B — spool silently degrades to in-memory on write failure
An `appendFileSync` failure was swallowed — durability silently dropped to in-memory-only, and a later crash lost those messages with no warning.

**Fix:** `appendRecord` now tracks consecutive failures and raises a **latched `onDegraded` health signal** on the degraded/recovered transitions, exposed via `isDegraded()` / `appendFailureCount()`. The gateway logs the transition loudly. Delivery is intentionally **never broken** by a spool write failure (per the module's existing contract) — the degradation is simply no longer silent.

### C — spool escalation coalesces multi-message drops into one notice
A multi-message drop reported as a single drop, under-counting the loss.

**Fix:** `sweepEscalations` counts drops **per chat for the sweep** and passes the real `droppedCount` to `onEscalate`; the gateway notice now reads "N earlier messages" instead of "an earlier message".

## Tests (real code paths, exported units)
- **A:** `>32` burst → exactly one `onEvict` per evicted entry (8 evictions on a 40-into-32 burst); cap-3 eviction reports the right entries; a throwing `onEvict` never breaks `push`.
- **B:** append failure → `put()` does not throw, `isDegraded()` true, latched `onDegraded` fires once (not per failing append), recovery un-latches (`degraded → recovered`).
- **C:** four undeliverable entries in one chat → the one posted notice reports `droppedCount: 4`; mixed sweep reports per-chat counts independently (A:3, B:1); single drop still reports 1.

`npm run lint` clean (tsc + all check-*.mjs). Targeted vitest: **83 passed** (`inbound-spool.test.ts`, `pending-inbound-buffer.test.ts`). No `bun:sqlite` in these modules, so vitest is the correct runner.

## Verdict rule
- **Vision outcome:** visibility + always-on (messages under load are visibly deferred / retracted, not silently dropped).
- **JTBD:** `reference/jobs/steer-or-queue-mid-flight.md` — "queue while the agent is mid-flight; the user knows which happened" (serves hold-the-leash).
- **Invariant:** `chat-is-the-single-source-of-truth` — surfacing the loss window in chat *supports* it; nothing crossed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)