### PR TITLE
cleanup(gateway): drift canary + hard-removal plan for inbound-delivery cutover (Refs #2794)

### DIFF
--- a/reference/rfcs/inbound-delivery-state-machine.md
+++ b/reference/rfcs/inbound-delivery-state-machine.md
@@ -292,6 +292,48 @@ effects array drives the same outcome. Same shadow→live pattern,
 same kill-switch env knob. Out of scope for this section; PR 3b
 prerequisites must land first.
 
+## Hard removal plan — finish the cutover (#2794)
+
+> Added under issue **#2794** (cleanup audit item 2: machine + shadow +
+> imperative dispatch all live at once). This is the standing checklist
+> that keeps the shadow from living indefinitely. Each unchecked box is a
+> remaining PR toward "machine authoritative, shadow + imperative paths
+> deleted." **Do NOT close #2794 until every box is checked.**
+
+State of the triple-maintained paths as of this checklist:
+
+| Concern | Machine (authoritative?) | Shadow / imperative still live? |
+|---|---|---|
+| bridgeUp drain (inbound + perm-verdict redelivery) | **Yes** — dispatched via `dispatchEffects` (PR3a) | Imperative drain only under kill-switch `SWITCHROOM_DELIVERY_MACHINE_CUTOVER=0` (gateway.ts bridgeUp handler) |
+| turn-in-flight GATE (`turnInFlightForGate`) | **Yes** — `isMachineInTurn()` | `claudeBusyKeys` set still fully maintained + reaped in parallel; read on kill-switch path. **Drift canary added (`gate-parity-probe.ts`, #2794).** |
+| `turnEnd` lifecycle | No — shadow-only (`shadowEmit`) | Imperative `purgeReactionTracking` / `endCurrentTurnAtomic` + multi-callsite emits (RFC PR3b step 1 audit) |
+| `inbound` routing (deliver vs buffer) | No — shadow-only | Imperative `if (turnInFlight) buffer else deliver` in `handleInbound` |
+| poke ladder + `firePoke` | No | Imperative silence-poke |
+| perm-verdict deliver/persist (non-bridgeUp) | No | Imperative |
+
+Checklist (each box = one baked PR; keep the kill-switch until PR4):
+
+- [x] **PR3a** — dispatcher + bridgeUp effect execution. *(done)*
+- [x] **Gate cutover** — `turnInFlightForGate` reads the machine. *(done, #2794 adds the drift canary so the parallel `claudeBusyKeys` shadow can't silently diverge in the dangerous `machine_over_holds` direction before it is deleted.)*
+- [ ] **PR3b step 1** — fix the `turnEnd` emit callsites (delete the
+  duplicate bare-purge emits at the 5831/5989/1601 sites; thread `turn`
+  explicitly at 6130/6258; force `outboundEmitted=false` at the
+  silence-poke fallback). Prereq for a safe `turnEnd` cutover.
+- [ ] **PR3b step 2** — flip `shadowEmit({kind:'turnEnd'})` →
+  `dispatchEvent` inside `endCurrentTurnAtomic`; remove the imperative
+  cleanups from `purgeReactionTracking`.
+- [ ] **PR3c** — inbound cutover: `handleInbound` dispatches an inbound
+  Event; the machine's `deliverToBridge`/`bufferInbound` effects replace
+  the imperative in-handler routing.
+- [ ] **PR4** — delete the kill-switch fallback branches, the
+  `claudeBusyKeys` set + its reaper, `gate-parity-probe.ts`, and the
+  redundant silence-poke/purge primitives. Net −200…−500 lines.
+
+Each step must keep the delivery-reliability guarantees from #2787
+(confirm-sweep scoping) and #2801 (enqueue-ack) intact — the machine's
+`drainBuffer` effect already routes through `redeliverBufferedInbound` +
+`onUserInboundDelivered` so the deliver-until-acked sweep survives.
+
 ## What this RFC does NOT cover
 
 - **The boot-time cost** of cold-starting claude + the gateway. The state machine doesn't help; it's pure model-side latency. Tracked separately under "cold-start optimization" (Sprint 4 of the vision-aligned roadmap: defer handoff, async boot card, pre-warm session).

--- a/telegram-plugin/gateway/gate-parity-probe.ts
+++ b/telegram-plugin/gateway/gate-parity-probe.ts
@@ -1,0 +1,102 @@
+/**
+ * Gate-parity drift probe — scaffolding for the inbound-delivery
+ * state-machine cutover (#2794, RFC PR3b→PR4).
+ *
+ * ## Why this exists
+ *
+ * The inbound-delivery pipeline is mid-migration and TRIPLE-maintained:
+ *
+ *   1. the pure state machine (`inbound-delivery-machine.ts`) — the model,
+ *   2. the shadow (`inbound-delivery-machine-shadow.ts`) — module-scope
+ *      machine state advanced by `shadowEmit`, now AUTHORITATIVE for the
+ *      turn-in-flight gate via `isMachineInTurn()`,
+ *   3. the legacy imperative `claudeBusyKeys` set — still fully maintained
+ *      in parallel and read as the kill-switch fallback.
+ *
+ * Per #2794 the standing risk is DRIFT: because the same turn-lifecycle
+ * fact ("is a turn in flight?") is tracked in two live places, a fix in
+ * one can silently diverge from the other. The machine is authoritative
+ * today, but `claudeBusyKeys` is still wired and still read on the
+ * kill-switch path — so the two MUST NOT drift in the dangerous direction.
+ *
+ * ## What "agree" means (and the ONE intended divergence)
+ *
+ * The machine and `claudeBusyKeys` are designed to agree on every
+ * WELL-FORMED schedule (every turnStart has a matching turnEnd). They are
+ * deliberately allowed to diverge in exactly ONE direction on a MALFORMED
+ * schedule — an orphaned turnStart (turn B opens before turn A's turnEnd
+ * ever lands, the gymbro/clerk 5-min dangle of 2026-05-28):
+ *
+ *   - `busykeys_dangle`  — machine reads idle (self-healed via TTL tick or
+ *                          single-activeTurn reopen) while `claudeBusyKeys`
+ *                          still holds an orphan key. This is EXPECTED and
+ *                          GOOD: it is precisely the wedge the machine was
+ *                          made authoritative to kill. Not a drift alarm.
+ *
+ *   - `machine_over_holds` — machine reads in-flight while `claudeBusyKeys`
+ *                            is empty. This is the DANGEROUS direction: the
+ *                            now-authoritative gate would hold closed while
+ *                            the imperative view says idle — a NEW wedge
+ *                            class the cutover must never introduce. This
+ *                            is the drift #2794 warns about; surface it.
+ *
+ * This module is a pure classifier plus a log-only runtime probe. It
+ * performs NO I/O of its own beyond an optional injected log sink and
+ * changes NO delivery behaviour — it only observes. Deleting it once the
+ * `claudeBusyKeys` shadow is removed in PR4 is a no-op for behaviour.
+ */
+
+export type GateParityDivergence = 'none' | 'busykeys_dangle' | 'machine_over_holds'
+
+/**
+ * Classify the relationship between the machine's authoritative
+ * turn-in-flight read and the legacy imperative `claudeBusyKeys` size.
+ * Pure — no side effects.
+ */
+export function gateParityDivergence(
+  machineInTurn: boolean,
+  busyKeysSize: number,
+): GateParityDivergence {
+  const busy = busyKeysSize > 0
+  if (machineInTurn === busy) return 'none'
+  // machine idle, busyKeys non-empty → the orphan dangle the machine heals.
+  if (!machineInTurn && busy) return 'busykeys_dangle'
+  // machine in-flight, busyKeys empty → the dangerous over-hold.
+  return 'machine_over_holds'
+}
+
+/**
+ * True only for divergences that indicate a real cutover regression
+ * (the machine holding a gate the imperative shadow believes is open).
+ * The benign `busykeys_dangle` — the very wedge the machine fixes — is
+ * NOT flagged, so this probe has zero false positives on the known-good
+ * self-heal path.
+ */
+export function isDangerousGateDivergence(d: GateParityDivergence): boolean {
+  return d === 'machine_over_holds'
+}
+
+/**
+ * Log-only runtime drift canary. Call at the authoritative gate read.
+ * Emits a single grep-friendly `gw-trace gate-drift` line ONLY on the
+ * dangerous over-hold direction. Returns the machine value UNCHANGED so
+ * it can wrap the gate read without altering behaviour:
+ *
+ *   return probeGateParity(isMachineInTurn(), claudeBusyKeys.size)
+ *
+ * @param log  optional sink (default stderr) — test hook.
+ */
+export function probeGateParity(
+  machineInTurn: boolean,
+  busyKeysSize: number,
+  log: (line: string) => void = (line) => process.stderr.write(line),
+): boolean {
+  const d = gateParityDivergence(machineInTurn, busyKeysSize)
+  if (isDangerousGateDivergence(d)) {
+    log(
+      `gw-trace gate-drift kind=${d} machineInTurn=${machineInTurn} ` +
+        `busyKeys=${busyKeysSize} note=machine-authoritative-gate-holds-while-imperative-idle\n`,
+    )
+  }
+  return machineInTurn
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -438,6 +438,7 @@ import { chatKey, chatKeyWithSuffix, chatIdOfChatKey } from './chat-key.js'
 import { shadowEmit, isMachineInTurn, isDeliveryCutoverEnabled } from './inbound-delivery-machine-shadow.js'
 import type { ChatKey as _ChatKey } from './inbound-delivery-machine.js'
 import { dispatchEffects, isDispatchEnabled } from './inbound-delivery-machine-dispatch.js'
+import { probeGateParity } from './gate-parity-probe.js'
 import { maybeFireWarmup } from './prefix-warmup.js'
 import {
   buildVaultGrantApprovedInbound,
@@ -2038,7 +2039,14 @@ const POST_ANSWER_LIVENESS_STALE_MS = parsePostAnswerLivenessMs(
  * message self-blocks. See the snapshot at the inbound handler.
  */
 function turnInFlightForGate(): boolean {
-  return isDeliveryCutoverEnabled() ? isMachineInTurn() : claudeBusyKeys.size > 0
+  if (!isDeliveryCutoverEnabled()) return claudeBusyKeys.size > 0
+  // Machine is authoritative. Run the log-only drift canary (#2794): the
+  // imperative `claudeBusyKeys` shadow is still live in parallel, so a
+  // dangerous over-hold divergence (machine holds the gate while the
+  // imperative view is idle) is surfaced without changing behaviour. The
+  // benign orphan-dangle direction — the wedge the machine self-heals — is
+  // NOT flagged. `probeGateParity` returns the machine value unchanged.
+  return probeGateParity(isMachineInTurn(), claudeBusyKeys.size)
 }
 
 /**

--- a/telegram-plugin/tests/gate-parity-probe.test.ts
+++ b/telegram-plugin/tests/gate-parity-probe.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Drift-catching scaffolding for the inbound-delivery state-machine
+ * cutover (#2794). The turn-in-flight gate is now machine-authoritative
+ * (`isMachineInTurn`), but the legacy imperative `claudeBusyKeys` set is
+ * still maintained in parallel. These tests assert the two AGREE on every
+ * well-formed turn schedule, and pin the ONE intended divergence (the
+ * orphan-dangle the machine self-heals) so future edits can't silently
+ * introduce a dangerous `machine_over_holds` drift without turning a test
+ * red.
+ *
+ * This is the "assertion that machine and shadow agree" from the #2794
+ * time-box plan: it turns the standing triple-maintenance drift risk into
+ * a CI gate.
+ */
+
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  shadowEmit,
+  isMachineInTurn,
+  __shadowResetForTests,
+} from '../gateway/inbound-delivery-machine-shadow.js'
+import { TURN_TTL_MS, type ChatKey } from '../gateway/inbound-delivery-machine.js'
+import {
+  gateParityDivergence,
+  isDangerousGateDivergence,
+  probeGateParity,
+} from '../gateway/gate-parity-probe.js'
+
+const KEY_A = '111:_' as ChatKey
+const KEY_B = '222:_' as ChatKey
+
+/**
+ * Reference model of the imperative `claudeBusyKeys` set — a per-delivery
+ * Set stamped on a fresh-turn delivery and deleted on the matching
+ * turnEnd. This mirrors gateway.ts's markBusyKeyLockstep / claudeBusyKeys.delete
+ * lifecycle closely enough to detect real drift in the gate view.
+ */
+class BusyKeysModel {
+  private readonly keys = new Set<string>()
+  stampFreshTurn(key: string) {
+    this.keys.add(key)
+  }
+  endTurn(key: string) {
+    this.keys.delete(key)
+  }
+  get size() {
+    return this.keys.size
+  }
+}
+
+describe('gateParityDivergence classifier', () => {
+  it('agree → none (both idle, both busy)', () => {
+    expect(gateParityDivergence(false, 0)).toBe('none')
+    expect(gateParityDivergence(true, 1)).toBe('none')
+    expect(gateParityDivergence(true, 3)).toBe('none')
+  })
+
+  it('machine idle, busyKeys held → busykeys_dangle (benign self-heal)', () => {
+    expect(gateParityDivergence(false, 1)).toBe('busykeys_dangle')
+    expect(isDangerousGateDivergence('busykeys_dangle')).toBe(false)
+  })
+
+  it('machine in-flight, busyKeys empty → machine_over_holds (dangerous)', () => {
+    expect(gateParityDivergence(true, 0)).toBe('machine_over_holds')
+    expect(isDangerousGateDivergence('machine_over_holds')).toBe(true)
+  })
+
+  it('probeGateParity returns the machine value unchanged (no behaviour change)', () => {
+    const lines: string[] = []
+    const log = (l: string) => lines.push(l)
+    expect(probeGateParity(true, 1, log)).toBe(true)
+    expect(probeGateParity(false, 0, log)).toBe(false)
+    expect(probeGateParity(false, 1, log)).toBe(false)
+    expect(probeGateParity(true, 0, log)).toBe(true)
+    // Only the dangerous over-hold emits a drift line.
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain('gw-trace gate-drift kind=machine_over_holds')
+  })
+})
+
+describe('machine ↔ claudeBusyKeys parity on well-formed schedules', () => {
+  beforeEach(() => __shadowResetForTests())
+
+  it('single turn: agree at every step', () => {
+    const busy = new BusyKeysModel()
+    shadowEmit({ kind: 'bridgeUp', at: 1000 })
+    expect(gateParityDivergence(isMachineInTurn(), busy.size)).toBe('none')
+
+    // Fresh inbound → machine goes in_turn; imperative stamps the key.
+    shadowEmit({ kind: 'inbound', key: KEY_A, msg: { msgId: 1, isSteering: false, payload: null }, at: 2000 })
+    busy.stampFreshTurn(KEY_A)
+    expect(gateParityDivergence(isMachineInTurn(), busy.size)).toBe('none')
+    expect(isMachineInTurn()).toBe(true)
+
+    // turnEnd → both reopen.
+    shadowEmit({ kind: 'turnEnd', key: KEY_A, at: 3000, outboundEmitted: true })
+    busy.endTurn(KEY_A)
+    expect(gateParityDivergence(isMachineInTurn(), busy.size)).toBe('none')
+    expect(isMachineInTurn()).toBe(false)
+  })
+
+  it('sequential turns across two chats: no drift', () => {
+    const busy = new BusyKeysModel()
+    shadowEmit({ kind: 'bridgeUp', at: 1000 })
+
+    const schedule: Array<[ChatKey, number]> = [
+      [KEY_A, 2000],
+      [KEY_B, 4000],
+      [KEY_A, 6000],
+    ]
+    let t = 2000
+    for (const [key, start] of schedule) {
+      shadowEmit({ kind: 'inbound', key, msg: { msgId: t, isSteering: false, payload: null }, at: start })
+      busy.stampFreshTurn(key)
+      expect(gateParityDivergence(isMachineInTurn(), busy.size)).toBe('none')
+      shadowEmit({ kind: 'turnEnd', key, at: start + 500, outboundEmitted: true })
+      busy.endTurn(key)
+      expect(gateParityDivergence(isMachineInTurn(), busy.size)).toBe('none')
+      t = start + 500
+    }
+  })
+
+  it('mid-turn sibling inbound is buffered, not a new turn: parity holds', () => {
+    const busy = new BusyKeysModel()
+    shadowEmit({ kind: 'bridgeUp', at: 1000 })
+
+    shadowEmit({ kind: 'inbound', key: KEY_A, msg: { msgId: 1, isSteering: false, payload: null }, at: 2000 })
+    busy.stampFreshTurn(KEY_A)
+    // Sibling arrives mid-turn: machine buffers (no new activeTurn); the
+    // imperative gate is already busy so it does NOT stamp a fresh key.
+    shadowEmit({ kind: 'inbound', key: KEY_B, msg: { msgId: 2, isSteering: false, payload: null }, at: 2500 })
+    expect(gateParityDivergence(isMachineInTurn(), busy.size)).toBe('none')
+
+    shadowEmit({ kind: 'turnEnd', key: KEY_A, at: 3000, outboundEmitted: true })
+    busy.endTurn(KEY_A)
+    expect(gateParityDivergence(isMachineInTurn(), busy.size)).toBe('none')
+  })
+})
+
+describe('the ONE intended divergence: orphaned turnStart', () => {
+  beforeEach(() => __shadowResetForTests())
+
+  it('machine self-heals the dangle; imperative set holds the orphan (busykeys_dangle, benign)', () => {
+    const busy = new BusyKeysModel()
+    shadowEmit({ kind: 'bridgeUp', at: 1000 })
+
+    // Turn A opens; turn B opens before A's turnEnd ever lands. The
+    // imperative set stamps BOTH; only B's turnEnd arrives, leaving A as
+    // an orphan key — the gymbro/clerk 5-min dangle.
+    shadowEmit({ kind: 'turnStart', key: KEY_A, at: 2000 })
+    busy.stampFreshTurn(KEY_A)
+    shadowEmit({ kind: 'turnStart', key: KEY_B, at: 3000 })
+    busy.stampFreshTurn(KEY_B)
+    shadowEmit({ kind: 'turnEnd', key: KEY_B, at: 4000, outboundEmitted: true })
+    busy.endTurn(KEY_B)
+
+    // Machine still holds activeTurn=A (single-activeTurn); imperative
+    // holds A too → they agree here.
+    expect(gateParityDivergence(isMachineInTurn(), busy.size)).toBe('none')
+
+    // TTL tick past A's start: the machine self-heals to idle, but the
+    // imperative set NEVER gets A's turnEnd → orphan dangles forever.
+    shadowEmit({ kind: 'tick', now: 2000 + TURN_TTL_MS + 1 })
+    expect(isMachineInTurn()).toBe(false)
+    const d = gateParityDivergence(isMachineInTurn(), busy.size)
+    expect(d).toBe('busykeys_dangle')
+    // Benign: this is exactly the wedge the machine was made authoritative
+    // to kill — it must NOT trip the drift alarm.
+    expect(isDangerousGateDivergence(d)).toBe(false)
+  })
+})


### PR DESCRIPTION
Refs #2794. **One step of the multi-PR inbound-delivery state-machine cutover — does NOT close the tracking issue.**

## The three-path map (as of this PR)

The inbound-delivery pipeline is triple-maintained mid-migration:

1. **Machine** — `inbound-delivery-machine.ts`, the pure `(state, event) → (state', effects[])` model.
2. **Shadow** — `inbound-delivery-machine-shadow.ts`, module-scope machine state advanced by `shadowEmit`; already **authoritative** for the turn-in-flight gate via `isMachineInTurn()`.
3. **Imperative** — the legacy `claudeBusyKeys` set + `purgeReactionTracking` / `endCurrentTurnAtomic` + silence-poke, still fully live in parallel.

| Concern | Machine authoritative? | Imperative/shadow still live? |
|---|---|---|
| bridgeUp drain (inbound + perm-verdict) | **Yes** (`dispatchEffects`, PR3a) | Only under kill-switch `SWITCHROOM_DELIVERY_MACHINE_CUTOVER=0` |
| turn-in-flight GATE (`turnInFlightForGate`) | **Yes** (`isMachineInTurn`) | `claudeBusyKeys` set maintained + reaped in parallel; read on kill-switch path |
| `turnEnd` lifecycle | No — shadow-only | Imperative `purgeReactionTracking` / multi-callsite emits |
| `inbound` routing (deliver vs buffer) | No — shadow-only | Imperative `if(turnInFlight) buffer else deliver` in `handleInbound` |
| poke ladder / `firePoke` | No | Imperative silence-poke |
| perm-verdict deliver/persist (non-bridgeUp) | No | Imperative |

## What this PR lands (the smallest safe increment)

The gate is already machine-authoritative, but `claudeBusyKeys` shadows it in parallel — the exact drift surface #2794 flags. A full `turnEnd`/`inbound` cutover is **not cleanly separable** here (RFC PR3b step 1 requires a 6-callsite `outboundEmitted` refactor + a 48h bake before the flip). Per the issue's time-box fallback, this instead makes the drift **catchable** and writes down the removal plan — with **zero observable delivery behaviour change**:

- **`gate-parity-probe.ts`** — a pure classifier (`none` / `busykeys_dangle` / `machine_over_holds`) plus a **log-only** runtime canary wired into `turnInFlightForGate`. It returns the machine value **unchanged** and logs **only** the dangerous over-hold direction (machine holds the gate while the imperative shadow is idle — a new wedge class the cutover must never introduce). The benign orphan-dangle the machine self-heals (the gymbro/clerk 5-min wedge it was made authoritative to kill) is **not** flagged → zero false positives.
- **`gate-parity-probe.test.ts`** — asserts machine and a reference `claudeBusyKeys` model **agree** on every well-formed schedule, and pins the one intended divergence. This is the "assertion that machine and shadow agree" the issue asks for, now a CI gate.
- **RFC "Hard removal plan (#2794)"** — a tracking checklist for PR3b step1/step2, PR3c, PR4 so the shadow doesn't live indefinitely.

## Guarantees preserved

- **No observable delivery behaviour change** — the probe is log-only and returns the machine value unchanged; the classifier is pure.
- **#2787 (confirm-sweep scoping) / #2801 (enqueue-ack) intact** — untouched; the drain path still routes through `redeliverBufferedInbound` + `onUserInboundDelivered`.

## Verdict rule

- **Vision outcome:** always-on / visibility — the wedge class this cutover kills strands inbounds for 5 min.
- **JTBD:** `reference/jobs/know-what-my-agent-is-doing.md`.
- **Invariants:** none crossed (chat-is-single-source-of-truth, on-leash preserved; pure + log-only).

## Tests

`npm run lint` clean (both tsc + all guard checks). `bun test` on the delivery + gate suites: **89 pass / 0 fail** (`gate-parity-probe`, `inbound-delivery-cutover-gate`, `inbound-delivery-machine`, `-machine-dispatch`, `-confirm`, `-gate`).

## Risk assessment — what remains for the full cutover

- **PR3b step 1** (medium): fix duplicate/wrong `turnEnd` emit callsites (5831/5989/1601 duplicate emits; thread `turn` at 6130/6258; force `outboundEmitted=false` at the silence-poke fallback). Prereq for a safe `turnEnd` flip.
- **PR3b step 2** (medium/high): flip `turnEnd` to `dispatchEvent` inside `endCurrentTurnAtomic`; remove imperative `purgeReactionTracking` cleanups. Needs a 48h bake.
- **PR3c** (high): inbound routing cutover in `handleInbound` — the largest surface; same shadow→live + kill-switch pattern.
- **PR4** (low, mechanical): delete the kill-switch branches, `claudeBusyKeys` + reaper, `gate-parity-probe.ts`, and redundant silence-poke/purge primitives (−200…−500 lines).

The drift canary added here de-risks the interim: any `machine_over_holds` divergence between the now-authoritative gate and the still-live `claudeBusyKeys` shadow now surfaces in logs and would fail the parity test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)