### PR TITLE
fix(telegram): stop GFM soft-breaks blobbing rich status/command cards

### DIFF
--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -345,6 +345,92 @@ export function normalizeParagraphBreaks(text: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Card line-break hardener — for DETERMINISTIC command/card bodies
+// ---------------------------------------------------------------------------
+
+/**
+ * Harden the lone `\n` line breaks of a DETERMINISTIC card body into GFM hard
+ * breaks (`  \n`, two trailing spaces) so every field lands on its own line
+ * under Telegram's Bot API 10.1 rich-message (GFM) renderer.
+ *
+ * Why this exists (the run-on-blob bug): the rich path (#2669) renders a lone
+ * `\n` between two non-blank lines as a *soft* break — the two lines collapse
+ * onto the same visual line with a space between them. Agent PROSE is repaired
+ * on the reply path by `normalizeParagraphBreaks`, but the ~98 slash-command
+ * card replies dispatched through `switchroomReply(…, { html: true })` are sent
+ * as RAW markdown with no normalization. Their builders stack short labelled
+ * fields (`**5h window** …`, `**Model** …`, `Auth: ✓ Max …`) joined by a single
+ * `\n`, so the whole card renders as one run-on blob.
+ *
+ * A deterministic card is NOT free prose — every newline its builder emits is
+ * an INTENDED line break. So this hardener promotes UNCONDITIONALLY (no
+ * sentence-terminal-punctuation gate, unlike `normalizeParagraphBreaks`) with
+ * one exception: a line that participates in a genuine GFM block construct
+ * (list / table / blockquote / heading / fenced code) keeps its single `\n` so
+ * its native stacking / contiguity survives — a monospace table inside a ```
+ * fence is never touched (it is code-masked AND the fence lines are excluded).
+ * Real `\n\n` paragraph gaps (a builder's block separators) are preserved.
+ *
+ * This is the string-level sibling of `stackCardLines` (card-format.ts), which
+ * does the same promotion from a pre-split `string[]` of guaranteed
+ * single-line, non-block entries. Use `hardenCardBreaks` where the card body is
+ * already an assembled string (e.g. the `switchroomReply` chokepoint) and may
+ * legitimately contain GFM block constructs.
+ *
+ * Runs on code-masked text and is idempotent — a break already hardened to
+ * `  \n` re-hardens to the same `  \n`.
+ */
+export function hardenCardBreaks(text: string): string {
+  if (!text.includes('\n')) return text
+
+  const nonce = Math.random().toString(36).slice(2)
+  const { masked, restore, placeholder } = maskCodeRegions(text, nonce)
+
+  // Collapse 3+ newline runs to a single clean `\n\n` gap (mirrors
+  // normalizeParagraphBreaks step 1) so a stray extra blank line never becomes
+  // an oversized gap. A genuine one-blank-line `\n\n` block gap is preserved.
+  const out = masked.replace(/\n{3,}/g, '\n\n')
+
+  // A line participating in a GFM block construct whose single-`\n` contiguity
+  // must survive (its interior must NOT get a hard break).
+  const isBlockConstructLine = (line: string): boolean =>
+    isListItemLine(line) ||
+    isTableRowLine(line) ||
+    isTableDelimiterLine(line) ||
+    isBlockquoteLine(line) ||
+    isHeadingLine(line) ||
+    isFenceOpenLine(line, placeholder)
+
+  const lines = out.split('\n')
+  const pieces: string[] = []
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i]
+    const isLast = i === lines.length - 1
+    const next = isLast ? '' : lines[i + 1]
+    // Promote only between two non-blank content lines where NEITHER is a GFM
+    // block-construct line (so lists / tables / quotes / headings / fences keep
+    // their native single-`\n` stacking). A blank current/next line is a `\n\n`
+    // paragraph gap — never promote across it.
+    const promote =
+      !isLast &&
+      line.trim() !== '' &&
+      next.trim() !== '' &&
+      !isBlockConstructLine(line) &&
+      !isBlockConstructLine(next)
+    if (promote) {
+      // Strip trailing whitespace so a re-run emits exactly one `  \n` (never
+      // accumulate spaces). Include `\r` for CRLF sources.
+      line = line.replace(/[ \t\r]+$/, '')
+    }
+    pieces.push(line)
+    if (isLast) break
+    pieces.push(promote ? '  \n' : '\n')
+  }
+
+  return restore(pieces.join(''))
+}
+
+// ---------------------------------------------------------------------------
 // Paragraph spacers — restore a VISIBLE blank line between prose paragraphs
 // ---------------------------------------------------------------------------
 

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -132,8 +132,18 @@ export function repairEscapedWhitespace(text: string): string {
 interface MaskedCode {
   masked: string
   restore: (s: string) => string
-  /** The placeholder prefix injected for each masked region (fence or span). */
+  /**
+   * The placeholder prefix injected for FENCED-BLOCK masks only. A masked
+   * fenced block occupies a whole line, so `isFenceOpenLine` / `isMarkerLine`
+   * treat a line that STARTS with this prefix as a block construct. INLINE
+   * code spans get a DISTINCT prefix (see maskCodeRegions) that deliberately
+   * does NOT start with this one — so a line that merely opens with an inline
+   * span (e.g. `\`key\` = \`value\``) reads as ordinary prose and still gets
+   * its line break hardened.
+   */
   placeholder: string
+  /** Remove EVERY mask (fenced + inline) — used to measure visible length. */
+  stripPlaceholders: (s: string) => string
 }
 
 /**
@@ -144,31 +154,40 @@ interface MaskedCode {
  * Fenced blocks are extracted FIRST and only when CLOSED (matching ```), so an
  * unclosed fence is left intact rather than misparsed by the inline pass. Inline
  * spans use `[^\`\n]+` — the same definition the chunker treats as code.
+ *
+ * Fenced and inline masks carry DISTINCT prefixes (`\x00RMF…` vs `\x00RMI…`).
+ * This matters because the fenced prefix is what the block-structure predicates
+ * (`isFenceOpenLine`, `isMarkerLine`) use to recognise a standalone masked code
+ * block. Sharing one prefix (the pre-fix bug) made a line that merely STARTS
+ * with an inline code span look like a fenced block, so its lone `\n` was never
+ * hardened and the card collapsed into one run-on line (real victim:
+ * `/vault get` rendering `\`key\` = \`value\``).
  */
 function maskCodeRegions(text: string, nonce: string): MaskedCode {
-  const CODE_MASK_PH = `\x00RM${nonce}_`
+  const FENCE_MASK_PH = `\x00RMF${nonce}_`
+  const INLINE_MASK_PH = `\x00RMI${nonce}_`
   const codeMasks: string[] = []
 
   const masked = text
     .replace(/```[\s\S]*?```/g, (m) => {
       const idx = codeMasks.length
       codeMasks.push(m)
-      return `${CODE_MASK_PH}${idx}\x00`
+      return `${FENCE_MASK_PH}${idx}\x00`
     })
     .replace(/`[^`\n]+`/g, (m) => {
       const idx = codeMasks.length
       codeMasks.push(m)
-      return `${CODE_MASK_PH}${idx}\x00`
+      return `${INLINE_MASK_PH}${idx}\x00`
     })
 
-  const restoreRe = new RegExp(
-    `${CODE_MASK_PH.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\d+)\x00`,
-    'g',
-  )
+  // Restore / strip match EITHER prefix, keyed on the shared index space.
+  const escNonce = nonce.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const anyMaskRe = new RegExp(`\x00RM[FI]${escNonce}_(\\d+)\x00`, 'g')
   const restore = (s: string): string =>
-    s.replace(restoreRe, (_m, idx) => codeMasks[Number(idx)] ?? _m)
+    s.replace(anyMaskRe, (_m, idx) => codeMasks[Number(idx)] ?? _m)
+  const stripPlaceholders = (s: string): string => s.replace(anyMaskRe, '')
 
-  return { masked, restore, placeholder: CODE_MASK_PH }
+  return { masked, restore, placeholder: FENCE_MASK_PH, stripPlaceholders }
 }
 
 // ---------------------------------------------------------------------------
@@ -709,14 +728,11 @@ export function stripExcessBold(text: string): string {
   if (!text.includes('**')) return text
 
   const nonce = Math.random().toString(36).slice(2)
-  const { masked, restore, placeholder } = maskCodeRegions(text, nonce)
+  const { masked, restore, placeholder, stripPlaceholders } = maskCodeRegions(text, nonce)
 
-  // Non-code character budget: masked text with the placeholders removed.
-  const placeholderRe = new RegExp(
-    `${placeholder.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\d+\x00`,
-    'g',
-  )
-  const visible = masked.replace(placeholderRe, '')
+  // Non-code character budget: masked text with BOTH fenced + inline masks
+  // removed (stripPlaceholders handles the two distinct prefixes).
+  const visible = stripPlaceholders(masked)
   if (visible.length < 100) return restore(masked)
 
   let boldChars = 0

--- a/telegram-plugin/gateway/approvals-commands.ts
+++ b/telegram-plugin/gateway/approvals-commands.ts
@@ -13,7 +13,7 @@
  * add on top of the same client. Tracked in the migration TODO inline.
  */
 
-import { escapeMarkdown, codeSpanSafe } from '../format.js';
+import { escapeMarkdown, codeSpanSafe, hardenCardBreaks } from '../format.js';
 import type { Bot, Context } from "grammy";
 import { richMessage } from "../rich-send.js";
 import {
@@ -84,7 +84,11 @@ export function registerApprovalsCommands(
           );
         })
         .join("\n");
-      await ctx.replyWithRichMessage(richMessage(`**Active approvals**\n\n${summary}\n\n${detail}`));
+      // hardenCardBreaks: the per-agent `summary` rows and per-decision
+      // `detail` rows are single-`\n`-joined field lines that would soft-
+      // collapse into one blob under the GFM rich renderer. Harden them into
+      // GFM hard breaks (block gaps between the three sections preserved).
+      await ctx.replyWithRichMessage(richMessage(hardenCardBreaks(`**Active approvals**\n\n${summary}\n\n${detail}`)));
       return;
     }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -233,7 +233,7 @@ const REPLY_TO_TEXT_MAX = 200
 const SILENT_END_FALLBACK_TEXT =
   '⚠️ The agent finished working but didn’t send a reply — your last ' +
   'message may not have been answered. Please try asking again.'
-import { splitMarkdownChunks, hardSliceToCap, repairEscapedWhitespace, normalizeParagraphBreaks, addParagraphSpacers, normalizePunctuation, stripExcessBold, escapeMarkdown, RICH_MESSAGE_MAX_CHARS } from '../format.js'
+import { splitMarkdownChunks, hardSliceToCap, repairEscapedWhitespace, normalizeParagraphBreaks, addParagraphSpacers, normalizePunctuation, stripExcessBold, escapeMarkdown, hardenCardBreaks, RICH_MESSAGE_MAX_CHARS } from '../format.js'
 import { richMessage } from '../rich-send.js'
 import { scrubVoice } from '../text-voice-scrub.js'
 import {
@@ -10812,7 +10812,10 @@ function renderVaultRequestSaveCard(req: PendingVaultRequestSave, agentSlug: str
   }
   lines.push('')
   lines.push(`_Tap Save to write to the host vault, Rename to change the key name, or Discard to drop it. The value is held in this chat's gateway memory until you decide._`)
-  return lines.join('\n')
+  // hardenCardBreaks: labelled field lines (key: / why:) would soft-collapse
+  // into one blob under the GFM rich renderer; this card is sent direct via
+  // richMessage, bypassing the switchroomReply chokepoint.
+  return hardenCardBreaks(lines.join('\n'))
 }
 
 /**
@@ -11313,7 +11316,11 @@ async function executeVaultRequestAccess(args: Record<string, unknown>): Promise
   pendingVaultRequestAccesses.set(stageId, pending)
   sweepPendingVaultRequestAccesses()
 
-  const text = renderVaultRequestAccessCard(pending)
+  // hardenCardBreaks: the access-request card stacks labelled fields
+  // (key: / scope: / why:) with single `\n`, which soft-collapse into one
+  // blob under the GFM rich renderer — sent direct here, bypassing the
+  // switchroomReply chokepoint.
+  const text = hardenCardBreaks(renderVaultRequestAccessCard(pending))
   const threadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
   // Remember the agent's working topic so the grant-outcome inbound resumes in it.
   if (threadId != null) pending.threadId = threadId
@@ -15717,8 +15724,17 @@ async function switchroomReply(
   }
   // #2669: `options.html` now means "render `text` as GFM markdown via the
   // rich-message path" (legacy field name kept). Plain otherwise.
+  //
+  // Every deterministic slash-command card ships through this html branch as
+  // RAW markdown (no reply-path normalization). Under the Bot API 10.1 GFM
+  // renderer a lone `\n` is a SOFT break, so a card whose builder stacks
+  // labelled fields with single `\n` (e.g. `/usage`, `/model`, `/auth`)
+  // renders as one run-on blob. `hardenCardBreaks` promotes those lone
+  // field breaks to GFM hard breaks (`  \n`) while leaving lists / tables /
+  // fenced code / blockquotes / headings on their native single `\n` — the
+  // same treatment the direct-send cards get from `stackCardLines`.
   if (options.html) {
-    await ctx.replyWithRichMessage(richMessage(text), replyOpts)
+    await ctx.replyWithRichMessage(richMessage(hardenCardBreaks(text)), replyOpts)
   } else {
     await ctx.reply(text, replyOpts)
   }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -11316,11 +11316,9 @@ async function executeVaultRequestAccess(args: Record<string, unknown>): Promise
   pendingVaultRequestAccesses.set(stageId, pending)
   sweepPendingVaultRequestAccesses()
 
-  // hardenCardBreaks: the access-request card stacks labelled fields
-  // (key: / scope: / why:) with single `\n`, which soft-collapse into one
-  // blob under the GFM rich renderer — sent direct here, bypassing the
-  // switchroomReply chokepoint.
-  const text = hardenCardBreaks(renderVaultRequestAccessCard(pending))
+  // renderVaultRequestAccessCard self-hardens its field line breaks (this card
+  // is sent direct, bypassing the switchroomReply chokepoint).
+  const text = renderVaultRequestAccessCard(pending)
   const threadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
   // Remember the agent's working topic so the grant-outcome inbound resumes in it.
   if (threadId != null) pending.threadId = threadId

--- a/telegram-plugin/gateway/ms365-write-approval.test.ts
+++ b/telegram-plugin/gateway/ms365-write-approval.test.ts
@@ -105,6 +105,19 @@ describe("buildMs365CardText", () => {
     expect(text).toContain("bob@example.com");
   });
 
+  it("hard-breaks its field lines so GFM doesn't collapse them into a blob", () => {
+    // The Agent:/Tool:/Item:/Account: field lines must carry GFM hard breaks
+    // (`  \n`), not bare `\n` soft breaks. Assert every adjacent pair of
+    // non-blank content lines is separated by a hard break or a `\n\n` gap.
+    const text = buildMs365CardText(base);
+    expect(text).toContain("  \n");
+    const nl = text.split("\n");
+    for (let i = 0; i < nl.length - 1; i++) {
+      if (nl[i].trim() === "" || nl[i + 1].trim() === "") continue; // block gap
+      expect(nl[i].endsWith("  ")).toBe(true);
+    }
+  });
+
   it("omits ID line for new files", () => {
     const text = buildMs365CardText({ ...base, itemId: "(new)" });
     expect(text).not.toMatch(/^ID:/m);

--- a/telegram-plugin/gateway/ms365-write-approval.ts
+++ b/telegram-plugin/gateway/ms365-write-approval.ts
@@ -31,6 +31,7 @@
 
 import type { IpcClient } from "./ipc-server.js";
 import type { RequestMs365ApprovalMessage } from "./ipc-protocol.js";
+import { hardenCardBreaks } from "../format.js";
 
 // ────────────────────────────────────────────────────────────────────────
 // Wire shape — validates an inbound preview payload
@@ -188,7 +189,10 @@ export function buildMs365CardText(p: Ms365WritePreview): string {
   lines.push(
     "⚠️ Weak attestation (RFC §8 v1): operator should click through to verify the actual change before approving. Structural diff coming v1.5.",
   );
-  return lines.join("\n");
+  // hardenCardBreaks: labelled field lines (Agent:/Tool:/Item:/Account:/Size:…)
+  // would soft-collapse into one blob under the GFM rich renderer; this card is
+  // posted direct (not via the switchroomReply chokepoint).
+  return hardenCardBreaks(lines.join("\n"));
 }
 
 function truncate(s: string, n: number): string {

--- a/telegram-plugin/gateway/vault-request-access-card.ts
+++ b/telegram-plugin/gateway/vault-request-access-card.ts
@@ -20,6 +20,7 @@
 
 import { escapeHtmlForTg } from '../shared/bot-runtime.js'
 import { codeSpanSafe } from './approval-card.js'
+import { hardenCardBreaks } from '../format.js'
 
 /** Minimal shape the card needs — a subset of PendingVaultRequestAccess. */
 export interface VaultRequestAccessCardInput {
@@ -57,5 +58,8 @@ export function renderVaultRequestAccessCard(
   lines.push(
     `_Tap Approve to mint a scoped grant token (same flow as \`switchroom vault grant\`). Tap Deny to refuse — the agent will receive a denial result._`,
   )
-  return lines.join('\n')
+  // hardenCardBreaks: the labelled field lines (key: / scope:…/ why:) would
+  // soft-collapse into one blob under the GFM rich renderer; this card is sent
+  // direct via richMessage, bypassing the switchroomReply chokepoint.
+  return hardenCardBreaks(lines.join('\n'))
 }

--- a/telegram-plugin/tests/format-consistency.test.ts
+++ b/telegram-plugin/tests/format-consistency.test.ts
@@ -16,10 +16,59 @@ import {
   normalizePunctuation,
   stripExcessBold,
   splitMarkdownChunks,
+  hardenCardBreaks,
   PARAGRAPH_SPACER,
 } from '../format.js'
 
 const SP = PARAGRAPH_SPACER // U+00A0
+
+describe('hardenCardBreaks — deterministic card line-break hardener', () => {
+  test('promotes lone field breaks to GFM hard breaks (the blob fix)', () => {
+    const out = hardenCardBreaks('Agent: assistant\nAuth: Max\nStatus: running')
+    expect(out).toBe('Agent: assistant  \nAuth: Max  \nStatus: running')
+  })
+
+  test('preserves `\\n\\n` block gaps (not promoted)', () => {
+    const out = hardenCardBreaks('**Header**\nfield one\n\n**Next**\nfield two')
+    expect(out).toBe('**Header**  \nfield one\n\n**Next**  \nfield two')
+  })
+
+  test('leaves GFM list items on their native single `\\n`', () => {
+    const out = hardenCardBreaks('- one\n- two\n- three')
+    expect(out).toBe('- one\n- two\n- three')
+  })
+
+  test('leaves GFM table rows untouched', () => {
+    const src = '| a | b |\n| - | - |\n| 1 | 2 |'
+    expect(hardenCardBreaks(src)).toBe(src)
+  })
+
+  test('never touches a fenced code block interior', () => {
+    const src = '**Accounts**\n```\nalice  ok\nbob    ok\n```\n**Agents**'
+    // The fenced monospace table keeps its single `\n`s; the header lines that
+    // face the fence are not hard-broken (fence line is a block construct).
+    expect(hardenCardBreaks(src)).toBe(src)
+  })
+
+  test('does not hard-break across a heading or blockquote', () => {
+    expect(hardenCardBreaks('# Title\nbody')).toBe('# Title\nbody')
+    expect(hardenCardBreaks('> quote\nbody')).toBe('> quote\nbody')
+  })
+
+  test('collapses 3+ newline runs to a single `\\n\\n` gap', () => {
+    expect(hardenCardBreaks('a\n\n\n\nb')).toBe('a\n\nb')
+  })
+
+  test('is idempotent', () => {
+    const src = 'Agent: x\nAuth: y\n\n**H**\n🟢 Broker running\n🟢 Kernel up'
+    const once = hardenCardBreaks(src)
+    expect(hardenCardBreaks(once)).toBe(once)
+  })
+
+  test('no-op for single-line text', () => {
+    expect(hardenCardBreaks('just one line')).toBe('just one line')
+  })
+})
 
 describe('addParagraphSpacers — uniform block spacing', () => {
   test('still spaces prose→prose (existing behaviour)', () => {

--- a/telegram-plugin/tests/format-consistency.test.ts
+++ b/telegram-plugin/tests/format-consistency.test.ts
@@ -68,6 +68,36 @@ describe('hardenCardBreaks — deterministic card line-break hardener', () => {
   test('no-op for single-line text', () => {
     expect(hardenCardBreaks('just one line')).toBe('just one line')
   })
+
+  // Regression (reviewer nit): a field line that STARTS with an inline code
+  // span used to be misclassified as a masked fenced-block open (fenced +
+  // inline masks shared one placeholder prefix), so its lone `\n` was never
+  // hardened and the card collapsed. Real victim: `/vault get` rendering
+  // `` `key` = `value` `` on one line.
+  test('hardens a line that STARTS with an inline code span', () => {
+    const out = hardenCardBreaks('`key` = `value`\n`k2` = `v2`')
+    expect(out).toBe('`key` = `value`  \n`k2` = `v2`')
+  })
+
+  test('/vault get shape (`key` =\\n`value`) hard-breaks onto two lines', () => {
+    const out = hardenCardBreaks('`sk-key` =\n`hunter2`')
+    expect(out).toBe('`sk-key` =  \n`hunter2`')
+  })
+
+  test('inline-span-leading fix does NOT disturb a real fenced block', () => {
+    // A genuine ``` fence between two inline-span-leading field lines: the
+    // field lines harden, the fence interior stays byte-for-byte intact.
+    const src = '`a` = 1\n```\nx = 1\ny = 2\n```\n`b` = 2'
+    const out = hardenCardBreaks(src)
+    expect(out).toContain('```\nx = 1\ny = 2\n```') // fence interior untouched
+    expect(out).not.toContain('x = 1  \n') // no hard break injected inside fence
+  })
+
+  test('mid-line inline spans still harden (unchanged behaviour)', () => {
+    expect(hardenCardBreaks('Model: `opus`\nAuth: `Max`')).toBe(
+      'Model: `opus`  \nAuth: `Max`',
+    )
+  })
 })
 
 describe('addParagraphSpacers — uniform block spacing', () => {

--- a/telegram-plugin/tests/vault-request-access-card.test.ts
+++ b/telegram-plugin/tests/vault-request-access-card.test.ts
@@ -91,4 +91,21 @@ describe('renderVaultRequestAccessCard', () => {
     })
     expect(text).toContain('why: _not provided_')
   })
+
+  it('hard-breaks its field lines so GFM does not collapse the card into a blob', () => {
+    const text = renderVaultRequestAccessCard({
+      agent: 'overlord',
+      key: 'openai/OPENAI_API_KEY',
+      scope: 'read',
+      reason: 'call the completions endpoint',
+      ttl_seconds: 7 * 86400,
+    })
+    // The key: / scope: / why: field lines carry GFM hard breaks (`  \n`).
+    expect(text).toContain('  \n')
+    const nl = text.split('\n')
+    for (let i = 0; i < nl.length - 1; i++) {
+      if (nl[i].trim() === '' || nl[i + 1].trim() === '') continue // `\n\n` block gap
+      expect(nl[i].endsWith('  ')).toBe(true)
+    }
+  })
 })

--- a/telegram-plugin/tests/welcome-text.test.ts
+++ b/telegram-plugin/tests/welcome-text.test.ts
@@ -343,6 +343,70 @@ describe("statusPairedText", () => {
   });
 });
 
+// Regression: the Bot API 10.1 rich-message (GFM) renderer collapses a LONE
+// `\n` between two non-blank lines into a SPACE (soft break), so a card built
+// with `lines.join("\n")` renders as one run-on blob. The deterministic card
+// builders MUST route through `stackCardLines`, which promotes every inter-
+// field break to a GFM hard break (`  \n`) and keeps intentional `\n\n` block
+// gaps. These tests pin that so the "/status renders as a giant run-on blob"
+// bug can't silently regress.
+describe("card line-break hardening (GFM soft-break blob fix)", () => {
+  const meta: AgentMetadata = {
+    ...baseMeta,
+    agentName: "assistant",
+    model: "sonnet",
+    status: "running",
+    uptime: "3h",
+    auth: { authenticated: true, subscription_type: "Max", expires_in: "29 days", auth_source: "oauth" },
+    live: [
+      { status: "ok", label: "Broker", detail: "running" },
+      { status: "ok", label: "Kernel", detail: "up" },
+    ],
+    audit: {
+      version: "v0.3.0",
+      tools: "all",
+      skills: "git, vault",
+      limits: "idle 30m",
+      channel: "switchroom",
+      memoryBank: "assistant",
+    },
+  };
+
+  // Every adjacent field-pair inside a block is separated by a GFM hard break,
+  // and NO two adjacent non-blank content lines are joined by a bare `\n`
+  // (which would soft-collapse into a blob). Block separators stay `\n\n`.
+  const assertNoSoftJoin = (out: string) => {
+    const nl = out.split("\n");
+    for (let i = 0; i < nl.length - 1; i++) {
+      const cur = nl[i];
+      const next = nl[i + 1];
+      if (cur.trim() === "" || next.trim() === "") continue; // `\n\n` block gap
+      // A hardened line ends in the two-space GFM hard-break marker.
+      expect(cur.endsWith("  ")).toBe(true);
+    }
+  };
+
+  it("/status: fields are hard-broken, not soft-collapsed into a blob", () => {
+    const out = statusPairedText({ user: "@ken", meta });
+    // Adjacent fields inside the identity block use a GFM hard break.
+    expect(out).toContain("Auth: ✓ Max · expires 29 days  \n");
+    // Health rows stack (hard break before each 🟢 row).
+    expect(out).toContain("  \n🟢 **Kernel**");
+    // Audit rows stack.
+    expect(out).toContain("**Version** v0.3.0  \n");
+    // Blocks stay separated by a real paragraph gap.
+    expect(out).toContain("\n\n**Health**");
+    assertNoSoftJoin(out);
+  });
+
+  it("/start, /help, /commands, /status-pending all hard-break their lines", () => {
+    assertNoSoftJoin(startText("assistant", false));
+    assertNoSoftJoin(helpText("assistant"));
+    assertNoSoftJoin(switchroomHelpText("assistant"));
+    assertNoSoftJoin(statusPendingText("abc-123"));
+  });
+});
+
 // Local alias for the audit shape — duplicates the AgentMetadata.audit
 // type so the test file doesn't have to re-import it just for one
 // hostile-input fixture.

--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -13,7 +13,7 @@
  */
 
 import { maskUsername } from "./demo-mask.js";
-import { escapeMarkdown } from "./card-format.js";
+import { escapeMarkdown, stackCardLines } from "./card-format.js";
 
 export type AuthSummary = {
   authenticated: boolean;
@@ -148,7 +148,7 @@ export function formatAgentLine(meta: AgentMetadata): string {
  */
 export function startText(agentName: string, dmDisabled: boolean): string {
   if (dmDisabled) return "This bot isn't accepting new connections.";
-  return [
+  return stackCardLines([
     `**Switchroom** — Telegram on your Claude Pro or Max subscription.`,
     ``,
     `This bot is the **${escapeHtml(agentName)}** agent. Pair first, then send messages here and they reach the agent; replies and reactions come back.`,
@@ -158,7 +158,7 @@ export function startText(agentName: string, dmDisabled: boolean): string {
     `2. In Claude Code: \`/telegram:access pair <code>\``,
     ``,
     `After pairing, try \`/status\` or \`/commands\`.`,
-  ].join("\n");
+  ]);
 }
 
 /**
@@ -166,7 +166,7 @@ export function startText(agentName: string, dmDisabled: boolean): string {
  * Deliberately short because Telegram truncates /help popovers.
  */
 export function helpText(agentName: string): string {
-  return [
+  return stackCardLines([
     `**Switchroom** — your Pro/Max subscription, wired to Telegram.`,
     ``,
     `This bot is the **${escapeHtml(agentName)}** agent. Text and photos route through to it; replies, reactions and progress cards come back.`,
@@ -177,7 +177,7 @@ export function helpText(agentName: string): string {
     `\`/status\` — agent, model, auth`,
     `\`/vault audit <agent>\` — admin: review agent's vault access + one-tap [🔓 Allow] on recent denials`,
     `\`/commands\` — full command list`,
-  ].join("\n");
+  ]);
 }
 
 /**
@@ -246,14 +246,18 @@ export function statusPairedText(params: {
     if (audit.memoryBank) lines.push(`**Memory** ${escapeHtml(audit.memoryBank)}`);
   }
 
-  return lines.join("\n");
+  return stackCardLines(lines);
 }
 
 /**
  * `/status` when the sender isn't paired yet but has a pending code.
  */
 export function statusPendingText(code: string): string {
-  return `Pending pairing — run in Claude Code:\n\n\`/telegram:access pair ${code}\``;
+  return stackCardLines([
+    `Pending pairing — run in Claude Code:`,
+    ``,
+    `\`/telegram:access pair ${code}\``,
+  ]);
 }
 
 /**
@@ -365,7 +369,7 @@ export const TELEGRAM_BASE_COMMANDS = TELEGRAM_MENU_COMMANDS.slice(0, 3);
 export const TELEGRAM_SWITCHROOM_COMMANDS = TELEGRAM_MENU_COMMANDS.slice(3);
 
 export function switchroomHelpText(agentName: string): string {
-  return [
+  return stackCardLines([
     `**Switchroom bot** — commands for the **${escapeHtml(agentName)}** agent.`,
     ``,
     `**Session & approvals**`,
@@ -415,7 +419,7 @@ export function switchroomHelpText(agentName: string): string {
     `\`/commands\` — this help`,
     ``,
     `_Tip: \`/update\` shows the plan; \`/update apply\` executes it; \`/restart\` bounces a stuck agent; \`/version\` checks what's running._`,
-  ].join("\n");
+  ]);
 }
 
 /**


### PR DESCRIPTION
After the Bot API 10.1 rich-message migration (#2669), Telegram cards render as native GFM, where a lone `\n` between two non-blank lines is a **soft break** — the renderer collapses them onto one visual line. Deterministic cards (`/status`, `/auth`, `/vault`, welcome/help, vault + ms365 approval cards) assembled their labelled fields with `join("\n")`, so every field mashed into a single run-on blob.

## Fix
- New block-aware primitive `hardenCardBreaks()` in `format.ts` — promotes lone field breaks to GFM hard breaks (`  \n`) while leaving lists, tables, blockquotes, headings and fenced code on native `\n` (fence interiors are code-masked).
- Applied at the `switchroomReply(html:true)` chokepoint (covers `/auth`, `/usage`, `/model`, `/effort` + all other command cards in one edit) plus the direct-send cards that bypass it (approvals list, vault access/save, ms365 approval).
- `/status` + `/start` + `/help` + `/commands` + pending-pair routed through the existing `stackCardLines` primitive.
- Distinct mask placeholders for fenced (`RMF`) vs inline (`RMI`) code so an inline-code-leading field line (e.g. `/vault get` rendering `` `key` = `value` ``) hardens correctly instead of being misread as a fence-open.

## Skipped (deliberately, not this bug)
- `diff-preview-card` — diff bodies are `+`/`-`-leading lines that hardening would misparse; correct fix is fencing the diff (separate PR).
- `skill-proposal-card` — still on the legacy HTML `parse_mode` path where `\n` is already a hard break.

## Tests
- New `hardenCardBreaks` unit suite + regression tests (inline-code-leading hardens, fenced blocks stay protected, idempotency) and output assertions on the direct-send builders.
- Full telegram-plugin vitest: `4909 passed / 1 failed` — the one failure is the documented pre-existing `worker-feed-dispatch` flake (passes standalone, unrelated). `tsc --noEmit` clean; `check-bot-api-wrapping` / `check-plugin-references` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)