### PR TITLE
feat(apply): add --dry-run to switchroom apply

### DIFF
--- a/src/cli/apply.test.ts
+++ b/src/cli/apply.test.ts
@@ -2,13 +2,19 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { Command } from "commander";
 import {
   runApply,
+  runApplyDryRun,
   runApplyPreflight,
+  registerApplyCommand,
+  parseComposeServiceNames,
   isInAgentContainer,
   IN_AGENT_CONTAINER_APPLY_MSG,
 } from "./apply.js";
 import * as scaffoldModule from "../agents/scaffold.js";
+import * as profilesModule from "../agents/profiles.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
 /**
@@ -672,5 +678,113 @@ describe("runApply", () => {
       // Last arg is the recursion guard.
       expect(argv[argv.length - 1]).toBe("--skip-self-elevate");
     });
+  });
+});
+
+describe("apply --dry-run", () => {
+  // Sandbox HOME so the vault-passphrase probe (auto-unlock blob lookup)
+  // and any homedir()-anchored reads don't touch the real ~/.switchroom.
+  let _origHome: string | undefined;
+  let _homeSandbox: string | undefined;
+  beforeEach(async () => {
+    _origHome = process.env.HOME;
+    _homeSandbox = await mkdtemp(join(tmpdir(), "switchroom-dryrun-home-"));
+    process.env.HOME = _homeSandbox;
+  });
+  afterEach(() => {
+    if (_origHome !== undefined) process.env.HOME = _origHome;
+    else delete process.env.HOME;
+  });
+
+  it("registers the --dry-run flag on the apply command", () => {
+    const program = new Command();
+    registerApplyCommand(program);
+    const apply = program.commands.find((c) => c.name() === "apply");
+    expect(apply).toBeDefined();
+    const flags = apply!.options.map((o) => o.long);
+    expect(flags).toContain("--dry-run");
+  });
+
+  it("a clean dry-run reports 'would succeed' and writes NOTHING", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "switchroom-dryrun-clean-"));
+    const outPath = join(dir, "nested", "docker-compose.yml");
+    const sink: string[] = [];
+
+    const res = await runApplyDryRun(
+      makeStubConfig(join(dir, "agents")),
+      { outPath, dryRun: true },
+      { writeOut: (s) => sink.push(s), writeErr: (s) => sink.push(s), ...SKIP_COMPOSE_PREFLIGHT },
+    );
+
+    expect(res.wouldSucceed).toBe(true);
+    expect(res.blocking).toEqual([]);
+    // The compose file must NOT have been written — dry-run is read-only.
+    expect(existsSync(outPath)).toBe(false);
+    // And the whole nested dir the real apply would have mkdir'd stays absent.
+    expect(existsSync(join(dir, "nested"))).toBe(false);
+    // Report mentions success.
+    expect(sink.join("")).toMatch(/would SUCCEED/i);
+  });
+
+  it("computes the would-be compose in memory (imageTag + services)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "switchroom-dryrun-compose-"));
+    const outPath = join(dir, "docker-compose.yml");
+    const sink: string[] = [];
+
+    const res = await runApplyDryRun(
+      makeStubConfig(join(dir, "agents")),
+      { outPath, dryRun: true },
+      { writeOut: (s) => sink.push(s), writeErr: (s) => sink.push(s), ...SKIP_COMPOSE_PREFLIGHT },
+    );
+
+    expect(res.imageTag).toBeTruthy();
+    // No prior compose on disk → every service is "added".
+    expect(res.previousImageTag).toBeNull();
+    expect(res.addedServices.length).toBeGreaterThan(0);
+    expect(existsSync(outPath)).toBe(false);
+  });
+
+  it("exits non-zero (wouldSucceed=false) when a profile fails to resolve", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "switchroom-dryrun-badprofile-"));
+    const outPath = join(dir, "docker-compose.yml");
+    const sink: string[] = [];
+
+    // Reproduce the v0.17.0 incident: the profiles dir doesn't resolve in
+    // this context, so getProfilePath throws "Profile not found".
+    const spy = vi
+      .spyOn(profilesModule, "getProfilePath")
+      .mockImplementation(() => {
+        throw new Error("Profile not found: default (searched /profiles)");
+      });
+    try {
+      const res = await runApplyDryRun(
+        makeStubConfig(join(dir, "agents")),
+        { outPath, dryRun: true },
+        { writeOut: (s) => sink.push(s), writeErr: (s) => sink.push(s), ...SKIP_COMPOSE_PREFLIGHT },
+      );
+      expect(res.wouldSucceed).toBe(false);
+      expect(res.blocking.some((b) => /Profile not found/.test(b))).toBe(true);
+      expect(existsSync(outPath)).toBe(false);
+      expect(sink.join("")).toMatch(/would FAIL/i);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("parseComposeServiceNames extracts top-level service keys only", () => {
+    const compose = [
+      "services:",
+      "  klanker:",
+      "    image: ghcr.io/switchroom/switchroom-agent:v1",
+      "    volumes:",
+      "      - /a:/b",
+      "  vault-broker:",
+      "    image: ghcr.io/switchroom/switchroom-broker:v1",
+      "networks:",
+      "  default:",
+      "volumes:",
+      "  klanker-state:",
+    ].join("\n");
+    expect(parseComposeServiceNames(compose)).toEqual(["klanker", "vault-broker"]);
   });
 });

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -69,7 +69,8 @@ import { refreshAgentConnectionHealth } from "../agents/connection-health.js";
 import type { VaultAclResult } from "./doctor-mcp-secrets.js";
 import { installUpdatePromptHook } from "./update-prompt-hook.js";
 import { allocateAgentUid } from "../agents/compose.js";
-import { writeComposeFile, resolveHostSwitchroomConfigPath, resolveHostHomeForCompose } from "./write-compose.js";
+import { writeComposeFile, computeComposeContent, resolveHostSwitchroomConfigPath, resolveHostHomeForCompose } from "./write-compose.js";
+import { getProfilePath } from "../agents/profiles.js";
 import { detectInstallType } from "./install-detect.js";
 import {
   resolveOperatorUid,
@@ -147,6 +148,22 @@ export interface ApplyOptions {
    * to write start.sh / .mcp.json / settings.json (issue #902).
    */
   composeOnly?: boolean;
+  /**
+   * Validate-only: run the full compose-regeneration + validation
+   * pipeline IN MEMORY (resolve every agent's profile, probe the
+   * vault-broker for key-provisioning gaps, compute the would-be
+   * compose) and print a report — WITHOUT writing the compose file,
+   * persisting anything, or touching any container. Handled by the
+   * dedicated {@link runApplyDryRun} path, not by `runApply`.
+   *
+   * Exists because `rollout --dry-run` only prints the step plan; it
+   * never exercises the config-regeneration that actually fails (the
+   * v0.17.0 rollout incident: profile-not-found, vault-broker
+   * unreachable, and passphrase-needed-for-new-keys all surfaced only
+   * once the real apply mutated state). `apply --dry-run` is the
+   * pre-flight that catches those BEFORE anything is mutated.
+   */
+  dryRun?: boolean;
 }
 
 export interface ApplyDeps {
@@ -1611,6 +1628,301 @@ export async function runApply(
 }
 
 /**
+ * Read-only probe of the LiteLLM per-agent (and hindsight-service)
+ * virtual-key provisioning state. Mirrors the split that
+ * `provisionLiteLLMKeys` computes, but performs NO writes — used by the
+ * `apply --dry-run` path to report vault-provisioning gaps before a real
+ * apply mutates anything.
+ *
+ * `passphraseAvailable` reports whether the operator vault passphrase can
+ * be recovered non-interactively (env or machine-id auto-unlock blob) — a
+ * NEW key can only be provisioned when it is. `unprovisionedNew` are
+ * opted-in agents with no key in the vault yet; `brokerUnreachable` are
+ * agents we couldn't verify because the broker socket wasn't reachable
+ * (an environment limitation, not a hard failure).
+ */
+export async function probeVaultProvisioning(
+  config: SwitchroomConfig,
+  agentNames: string[],
+  home: string,
+): Promise<{
+  optedInCount: number;
+  passphraseAvailable: boolean;
+  alreadyProvisioned: string[];
+  unprovisionedNew: string[];
+  brokerUnreachable: string[];
+  needsHindsight: boolean;
+}> {
+  const optedIn: string[] = [];
+  for (const name of agentNames) {
+    const agentConfig = config.agents[name];
+    if (!agentConfig) continue;
+    const resolved = resolveAgentConfig(config.defaults, config.profiles, agentConfig);
+    if (effectiveLiteLLMEnabled(config, resolved.litellm)) optedIn.push(name);
+  }
+  const needsHindsight =
+    (config as { litellm?: { enabled?: boolean } }).litellm?.enabled === true &&
+    (config as { memory?: { backend?: string } }).memory?.backend === "hindsight";
+
+  const passphraseAvailable = (await resolveOperatorVaultPassphrase(home)) !== null;
+
+  const alreadyProvisioned: string[] = [];
+  const unprovisionedNew: string[] = [];
+  const brokerUnreachable: string[] = [];
+
+  if (optedIn.length > 0) {
+    const { getViaBrokerStructured } = await import("../vault/broker/client.js");
+    for (const name of optedIn) {
+      const existing = await getViaBrokerStructured(`litellm/${name}/api-key`);
+      if (existing.kind === "ok") alreadyProvisioned.push(name);
+      else if (existing.kind === "unreachable") brokerUnreachable.push(name);
+      else unprovisionedNew.push(name); // not_found / denied
+    }
+  }
+
+  return {
+    optedInCount: optedIn.length,
+    passphraseAvailable,
+    alreadyProvisioned,
+    unprovisionedNew,
+    brokerUnreachable,
+    needsHindsight,
+  };
+}
+
+/** Parse the top-level service names out of a generated compose YAML. */
+export function parseComposeServiceNames(compose: string): string[] {
+  const lines = compose.split("\n");
+  const names: string[] = [];
+  let inServices = false;
+  for (const line of lines) {
+    if (/^services:\s*$/.test(line)) {
+      inServices = true;
+      continue;
+    }
+    // A new top-level key (column 0, non-space) ends the services block.
+    if (inServices && /^\S/.test(line)) break;
+    if (!inServices) continue;
+    // Service entries are keyed at exactly two-space indent: `  <name>:`.
+    const m = /^ {2}([A-Za-z0-9_.-]+):\s*$/.exec(line);
+    if (m) names.push(m[1]);
+  }
+  return names;
+}
+
+export interface ApplyDryRunResult {
+  /** Conditions that would make a real apply exit non-zero. */
+  blocking: string[];
+  /** Non-fatal advisories (a real apply would still succeed). */
+  warnings: string[];
+  /** Informational lines (would-change summary, would-provision, etc.). */
+  info: string[];
+  /** Agent image tag a real apply would bake into the compose. */
+  imageTag: string | null;
+  /** Agent image tag currently on disk, or null. */
+  previousImageTag: string | null;
+  /** True when the would-be compose differs from what's on disk. */
+  composeChanged: boolean;
+  /** Service names present in the new compose but not the old. */
+  addedServices: string[];
+  /** Service names present in the old compose but not the new. */
+  removedServices: string[];
+  /** True when a real apply would succeed (no blocking conditions). */
+  wouldSucceed: boolean;
+}
+
+/**
+ * `apply --dry-run` — run the full compose-regeneration + validation
+ * pipeline IN MEMORY and report what a real apply would do, WITHOUT
+ * writing the compose file, persisting anything, or touching a container.
+ *
+ * Catches the failure modes that the v0.17.0 rollout surfaced only AFTER
+ * the real apply had already started mutating state:
+ *   - profile-resolution failures (`Profile not found: default …`);
+ *   - vault-broker unreachable (can't verify/provision keys);
+ *   - vault passphrase unavailable for NEW keys that need provisioning.
+ *
+ * Returns a structured result; the CLI handler exits non-zero when
+ * `wouldSucceed` is false. Deliberately does NOT call `runApply`,
+ * `writeComposeFile`, `scaffoldAgent`, `alignAgentUid`, or any broker
+ * reload — every step here is read-only.
+ */
+export async function runApplyDryRun(
+  config: SwitchroomConfig,
+  options: ApplyOptions,
+  deps: ApplyDeps = {},
+  switchroomConfigPath?: string,
+): Promise<ApplyDryRunResult> {
+  const writeOut = deps.writeOut ?? ((s) => process.stdout.write(s));
+  const writeErr = deps.writeErr ?? ((s) => process.stderr.write(s));
+
+  const blocking: string[] = [];
+  const warnings: string[] = [];
+  const info: string[] = [];
+
+  writeOut(
+    chalk.bold("\nDry-run: validating switchroom config (no changes will be written)...\n"),
+  );
+
+  // ── 1. Preflight (vault present, docker compose v2, agent-container guard)
+  try {
+    runApplyPreflight(config, { detectComposeV2: deps.detectComposeV2 });
+  } catch (err) {
+    blocking.push(`preflight: ${(err as Error).message}`);
+  }
+
+  const allAgentNames = Object.keys(config.agents ?? {});
+  const agentNames =
+    options.only !== undefined ? [options.only] : allAgentNames;
+  if (options.only !== undefined && !allAgentNames.includes(options.only)) {
+    blocking.push(
+      `apply --only=${options.only}: no such agent in switchroom.yaml ` +
+      `(defined: ${allAgentNames.join(", ") || "none"}).`,
+    );
+  }
+
+  // ── 2. Profile resolution — the #1 thing rollout --dry-run missed.
+  for (const name of agentNames) {
+    const agentConfig = config.agents[name];
+    if (!agentConfig) continue;
+    const profileName = agentConfig.extends ?? "default";
+    try {
+      getProfilePath(profileName);
+      // Also exercise the cascade merge so a malformed profile block fails here.
+      resolveAgentConfig(config.defaults, config.profiles, agentConfig);
+    } catch (err) {
+      blocking.push(
+        `profile '${profileName}' for agent '${name}': ${(err as Error).message}`,
+      );
+    }
+  }
+
+  // ── 3. Vault provisioning gaps (broker reachability + new-key passphrase).
+  try {
+    const probe = await probeVaultProvisioning(config, agentNames, homedir());
+    if (probe.alreadyProvisioned.length > 0) {
+      info.push(
+        `litellm: ${probe.alreadyProvisioned.length} agent(s) already provisioned ` +
+        `(${probe.alreadyProvisioned.join(", ")}).`,
+      );
+    }
+    if (probe.brokerUnreachable.length > 0) {
+      // #2781: unreachable broker is an environment limitation, not a hard
+      // failure — a real apply degrades to a warning and keeps previous env.
+      warnings.push(
+        `litellm: vault-broker unreachable — could not verify/provision ` +
+        `${probe.brokerUnreachable.length} agent(s) ` +
+        `(${probe.brokerUnreachable.join(", ")}); they keep their previous routing env.`,
+      );
+    }
+    const pending = [
+      ...probe.unprovisionedNew,
+      ...(probe.needsHindsight ? ["hindsight (service)"] : []),
+    ];
+    if (pending.length > 0) {
+      if (probe.passphraseAvailable) {
+        info.push(
+          `litellm: would provision ${pending.length} new virtual key(s) ` +
+          `(${pending.join(", ")}) — vault passphrase is available.`,
+        );
+      } else {
+        // Mirrors provisionLiteLLMKeys pushing these to failures[] → exit 1.
+        blocking.push(
+          `litellm: ${pending.length} agent(s)/service(s) need a NEW vault key ` +
+          `(${pending.join(", ")}) but the vault passphrase is unavailable ` +
+          `(no SWITCHROOM_VAULT_PASSPHRASE env and machine-id auto-unlock blob ` +
+          `missing/undecryptable) — a real apply could not provision them.`,
+        );
+      }
+    }
+  } catch (err) {
+    warnings.push(`litellm: provisioning probe failed — ${(err as Error).message}`);
+  }
+
+  // ── 4. Compute the would-be compose IN MEMORY (no write).
+  let imageTag: string | null = null;
+  let previousImageTag: string | null = null;
+  let composeChanged = false;
+  let addedServices: string[] = [];
+  let removedServices: string[] = [];
+  try {
+    const computed = await computeComposeContent({
+      config,
+      composePath: options.outPath ?? DEFAULT_COMPOSE_PATH,
+      switchroomConfigPath,
+      releaseOverride: options.releaseOverride,
+      buildMode: options.buildLocal ? "local" : "pull",
+      buildContext: options.buildContext,
+    });
+    imageTag = computed.imageTag;
+    previousImageTag = computed.previousImageTag;
+    composeChanged = computed.previous !== computed.content;
+    const newServices = parseComposeServiceNames(computed.content);
+    const oldServices = computed.previous
+      ? parseComposeServiceNames(computed.previous)
+      : [];
+    addedServices = newServices.filter((s) => !oldServices.includes(s));
+    removedServices = oldServices.filter((s) => !newServices.includes(s));
+
+    if (previousImageTag === null) {
+      info.push(`compose: no existing compose on disk — a real apply would create it.`);
+    } else if (previousImageTag !== imageTag) {
+      info.push(
+        `compose: agent image would change ${previousImageTag} → ${imageTag}.`,
+      );
+    } else {
+      info.push(`compose: agent image unchanged (${imageTag}).`);
+    }
+    if (addedServices.length > 0) {
+      info.push(`compose: services added: ${addedServices.join(", ")}.`);
+    }
+    if (removedServices.length > 0) {
+      info.push(`compose: services removed: ${removedServices.join(", ")}.`);
+    }
+    if (previousImageTag !== null && !composeChanged) {
+      info.push(`compose: no change (would be byte-identical to the current file).`);
+    }
+  } catch (err) {
+    blocking.push(`compose generation: ${(err as Error).message}`);
+  }
+
+  // ── 5. Report ─────────────────────────────────────────────────────
+  for (const line of info) writeOut(chalk.gray(`  ~ ${line}\n`));
+  for (const line of warnings) writeErr(chalk.yellow(`  ! ${line}\n`));
+  for (const line of blocking) writeErr(chalk.red(`  x ${line}\n`));
+
+  const wouldSucceed = blocking.length === 0;
+  writeOut("\n");
+  if (wouldSucceed) {
+    writeOut(
+      chalk.green.bold(
+        `Dry-run: a real apply would SUCCEED. ` +
+        `${allAgentNames.length} agent(s) validated; nothing was written.\n`,
+      ),
+    );
+  } else {
+    writeErr(
+      chalk.red.bold(
+        `Dry-run: a real apply would FAIL — ${blocking.length} blocking ` +
+        `condition(s) above. Nothing was written.\n`,
+      ),
+    );
+  }
+
+  return {
+    blocking,
+    warnings,
+    info,
+    imageTag,
+    previousImageTag,
+    composeChanged,
+    addedServices,
+    removedServices,
+    wouldSucceed,
+  };
+}
+
+/**
  * Resolution block printed when one or more agents fail to scaffold.
  * Tells the operator their two real options (sudo or `--compose-only`)
  * so the next step is obvious. Returns the formatted string so the
@@ -1913,6 +2225,10 @@ export function registerApplyCommand(program: Command): void {
       "Skip the per-agent scaffold loop entirely; only (re)generate the compose file. Use in CI / scripts that can't chown into per-agent state dirs (mode 0700, owned by per-agent UIDs in v0.7+ docker mode). The full apply still runs preflight + emits compose; only the start.sh / .mcp.json / settings.json refresh is skipped.",
     )
     .option(
+      "--dry-run",
+      "Validate only: run the full compose-regeneration + validation pipeline IN MEMORY (resolve every agent's profile, probe the vault-broker for key-provisioning gaps, compute the would-be compose) and print a report — without writing the compose file, persisting anything, or touching a container. Exits non-zero if a real apply would fail (e.g. a profile can't resolve). Use as a pre-flight before a `rollout`/`update` (which only print the step plan, not the config-regeneration that actually fails).",
+    )
+    .option(
       "--no-doctor",
       "Skip the post-apply doctor sweep that surfaces stale start.sh / unhealthy agents (#929). Default: doctor runs after a successful scaffold so the operator sees whether the v0.7+ post-Phase-4 supervisor block is now in place. `switchroom update` passes this internally to avoid running doctor twice (it has its own doctor step).",
     )
@@ -1951,6 +2267,7 @@ export function registerApplyCommand(program: Command): void {
         allowUnaligned?: boolean;
         only?: string;
         composeOnly?: boolean;
+        dryRun?: boolean;
         printSudoCmd?: boolean;
         skipSelfElevate?: boolean;
         channel?: "dev" | "rc" | "latest";
@@ -1988,6 +2305,42 @@ export function registerApplyCommand(program: Command): void {
             const argv = ["sudo", ...buildSelfElevateArgv()];
             process.stdout.write(argv.join(" ") + "\n");
             process.exit(0);
+          }
+
+          // ─── Dry-run (validate-only) ────────────────────────────
+          //
+          // Runs the full compose-regeneration + validation pipeline in
+          // memory and reports what a real apply would do, WITHOUT
+          // writing the compose, persisting anything, self-elevating, or
+          // touching a container. Handled here — before the sudo
+          // pre-check — because it is entirely read-only and must never
+          // escalate. Exits non-zero when a real apply would fail.
+          if (opts.dryRun) {
+            const dry = await runApplyDryRun(
+              config,
+              {
+                buildLocal: !!opts.buildLocal,
+                buildContext:
+                  typeof opts.buildLocal === "string" ? opts.buildLocal : process.cwd(),
+                outPath: opts.out,
+                only: opts.only,
+                releaseOverride: opts.channel
+                  ? { channel: opts.channel }
+                  : opts.pin
+                    ? { pin: opts.pin }
+                    : undefined,
+                dryRun: true,
+              },
+              {},
+              switchroomConfigPath,
+            );
+            await captureEvent("apply_dry_run", {
+              agents_total: Object.keys(config.agents ?? {}).length,
+              would_succeed: dry.wouldSucceed,
+              blocking: dry.blocking.length,
+              warnings: dry.warnings.length,
+            });
+            process.exit(dry.wouldSucceed ? 0 : 1);
           }
           if (
             !opts.skipSelfElevate

--- a/src/cli/write-compose.ts
+++ b/src/cli/write-compose.ts
@@ -185,8 +185,29 @@ export function resolveHostHomeForCompose(): string {
   return homedir();
 }
 
-/** Generate the compose content and write it (mode 0600). Always writes — same as apply. */
-export async function writeComposeFile(opts: WriteComposeOpts): Promise<WriteComposeResult> {
+export interface ComputeComposeResult {
+  /** The generated compose YAML content (not yet written to disk). */
+  content: string;
+  /** The agent image tag baked into `content`. */
+  imageTag: string;
+  /** Content currently on disk at `composePath`, or null if none. */
+  previous: string | null;
+  /** The agent image tag previously on disk (for drift logging), or null. */
+  previousImageTag: string | null;
+}
+
+/**
+ * Generate the compose content IN MEMORY and read the current on-disk
+ * compose for comparison — WITHOUT writing anything. Shared by
+ * {@link writeComposeFile} (which then persists) and the `apply --dry-run`
+ * path (which only reports the would-be diff). Extracting this keeps the
+ * two paths byte-identical: a dry-run computes exactly the content a real
+ * apply would write.
+ */
+export async function computeComposeContent(
+  opts: Omit<WriteComposeOpts, "buildMode" | "buildContext"> &
+    Pick<WriteComposeOpts, "buildMode" | "buildContext">,
+): Promise<ComputeComposeResult> {
   const release = resolveRelease({ override: opts.releaseOverride, root: opts.config.release });
   const imageTag = resolveImageTag(release);
   const operatorUid = resolveOperatorUid();
@@ -236,6 +257,14 @@ export async function writeComposeFile(opts: WriteComposeOpts): Promise<WriteCom
     previous = null;
   }
   const previousImageTag = previous ? (AGENT_IMAGE_TAG_RE.exec(previous)?.[1] ?? null) : null;
+
+  return { content, imageTag, previous, previousImageTag };
+}
+
+/** Generate the compose content and write it (mode 0600). Always writes — same as apply. */
+export async function writeComposeFile(opts: WriteComposeOpts): Promise<WriteComposeResult> {
+  const { content, imageTag, previous, previousImageTag } = await computeComposeContent(opts);
+  const operatorUid = resolveOperatorUid();
 
   await mkdir(dirname(opts.composePath), { recursive: true });
   // Last-known-good backup + atomic write. If a deploy regenerates a bad


### PR DESCRIPTION
## What

Adds a real `--dry-run` flag to `switchroom apply`. It runs the full
compose-regeneration + validation pipeline **in memory** and prints a
report of what a real apply would do — **without** writing the compose
file, persisting anything, or touching any container. Exits non-zero
when a real apply would fail; zero when it would succeed.

## Why — the v0.17.0 rollout incident

We tried to roll the fleet to v0.17.0. `switchroom rollout --pin v0.17.0
--dry-run` only prints the step plan; it does **not** exercise the
config-regeneration that actually fails. When the real `apply` ran, it
surfaced problems a dry-run should have caught **before** mutating
anything:

- `Profile not found: default (searched /profiles)` for every agent
  (profiles dir not resolved in that context)
- `vault-broker unreachable — could not verify/provision N agents`
  (kept previous routing env)
- `vault passphrase unavailable — hindsight (service) needs a NEW key
  and was NOT provisioned`

`switchroom apply` had **no** `--dry-run` option at all (`apply
--dry-run` errored with `unknown option '--dry-run'`). This closes that
gap so a rollout can be validated non-destructively first.

## What it reports

- **Profile resolution** for every agent (the #1 thing `rollout
  --dry-run` missed) — a profile that can't resolve is a **blocking**
  condition.
- **Vault provisioning gaps**: broker reachability (unreachable ⇒
  warning, agent keeps previous env, matching the real apply's #2781
  degrade) and new-key provisioning where the vault passphrase is
  unavailable (⇒ **blocking**, mirroring `provisionLiteLLMKeys` pushing
  those to `failures[]`).
- **Would-be compose**: agent image-tag change (`prev → new`) and the
  service add/remove diff, computed from the byte-identical content a
  real apply would write.

Exit code mirrors a real apply: an unreachable broker is a warning
(exit 0); a profile that can't resolve or a new key needing an
unavailable passphrase is blocking (exit 1).

## Implementation

- Extract `computeComposeContent()` from `writeComposeFile()` so the
  dry-run computes exactly what a real apply would write, without
  writing. `writeComposeFile()` now delegates to it — the non-dry-run
  path is behaviour-neutral.
- `runApplyDryRun()`, `probeVaultProvisioning()` (read-only), and
  `parseComposeServiceNames()` added to `src/cli/apply.ts`. The
  `--dry-run` flag is handled **before** the self-elevation pre-check,
  so it never escalates via sudo and never writes.

## Tests

Added to `src/cli/apply.test.ts`:
- the `--dry-run` flag is registered on the `apply` command;
- a clean dry-run reports "would succeed" and writes **nothing** (asserts
  the compose file and its parent dir are never created);
- an in-memory compose compute exposes image-tag + service diff;
- a seeded profile-resolution failure (reproducing the incident's
  `Profile not found: default`) exits non-zero and writes nothing;
- `parseComposeServiceNames` extracts top-level service keys only.

## JTBD / verdict

Serves the **always-on / safe-rollout** job: an operator rolling the
fleet can validate the config-regeneration non-destructively before any
mutation. Advances the **visibility** vision outcome (surfaces what a
roll would break, up front). No invariant crossed — the dry-run path is
entirely read-only.

Refs the v0.17.0 rollout dry-run gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
