### PR TITLE
fix(hostd): keep broker operator socket across hostd rollouts

### DIFF
--- a/src/cli/operator-uid.ts
+++ b/src/cli/operator-uid.ts
@@ -29,8 +29,21 @@ import { join } from "node:path";
 /**
  * Resolve the real invoking operator's uid even under sudo. `sudo`
  * exports the underlying user's uid as `SUDO_UID` (process.getuid()
- * would return 0). Falls back to getuid() when >0, else undefined
- * (root with no SUDO_UID, or non-POSIX where getuid is unavailable).
+ * would return 0). Falls back to getuid() when >0, then to the
+ * hostd-injected `SWITCHROOM_HOSTD_OPERATOR_UID`, else undefined
+ * (non-POSIX where getuid is unavailable, or root with neither hint).
+ *
+ * The hostd fallback is load-bearing: `switchroom apply` shelled out by
+ * hostd runs as root WITHOUT sudo, so `SUDO_UID` is unset and getuid()
+ * is 0 — resolveOperatorUid() would return undefined and generateCompose
+ * then omits the broker's operator-socket bind (compose.ts gates it on
+ * operatorUid !== undefined). That silently breaks host-shell vault
+ * access AND the litellm key-confirm probe on the *next* apply (which
+ * strips litellm routing fleet-wide). hostd already exports the real
+ * host operator uid as SWITCHROOM_HOSTD_OPERATOR_UID (same host-fact
+ * injection pattern as SWITCHROOM_HOST_HOME) — consume it here so a
+ * hostd-driven rollout emits the operator socket just like a host-shell
+ * `sudo apply` does.
  */
 export function resolveOperatorUid(): number | undefined {
   const sudoUid = process.env.SUDO_UID;
@@ -41,6 +54,11 @@ export function resolveOperatorUid(): number | undefined {
   if (typeof process.getuid === "function") {
     const uid = process.getuid();
     if (uid > 0) return uid;
+  }
+  const hostdUid = process.env.SWITCHROOM_HOSTD_OPERATOR_UID;
+  if (hostdUid !== undefined) {
+    const parsed = parseInt(hostdUid, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
   }
   return undefined;
 }

--- a/tests/operator-uid.test.ts
+++ b/tests/operator-uid.test.ts
@@ -8,9 +8,12 @@ import {
 } from "../src/cli/operator-uid.js";
 
 const savedSudoUid = process.env.SUDO_UID;
+const savedHostdUid = process.env.SWITCHROOM_HOSTD_OPERATOR_UID;
 afterEach(() => {
   if (savedSudoUid === undefined) delete process.env.SUDO_UID;
   else process.env.SUDO_UID = savedSudoUid;
+  if (savedHostdUid === undefined) delete process.env.SWITCHROOM_HOSTD_OPERATOR_UID;
+  else process.env.SWITCHROOM_HOSTD_OPERATOR_UID = savedHostdUid;
   vi.restoreAllMocks();
 });
 
@@ -28,9 +31,35 @@ describe("resolveOperatorUid", () => {
     expect(resolveOperatorUid()).toBe(1000);
   });
 
-  it("returns undefined when running as real root with no SUDO_UID", () => {
+  it("returns undefined when running as real root with no SUDO_UID and no hostd uid", () => {
+    delete process.env.SUDO_UID;
+    delete process.env.SWITCHROOM_HOSTD_OPERATOR_UID;
+    vi.spyOn(process, "getuid").mockReturnValue(0);
+    expect(resolveOperatorUid()).toBeUndefined();
+  });
+
+  it("falls back to SWITCHROOM_HOSTD_OPERATOR_UID under root with no SUDO_UID (hostd-spawned apply)", () => {
+    delete process.env.SUDO_UID;
+    process.env.SWITCHROOM_HOSTD_OPERATOR_UID = "1000";
+    vi.spyOn(process, "getuid").mockReturnValue(0);
+    expect(resolveOperatorUid()).toBe(1000);
+  });
+
+  it("prefers a real getuid()/SUDO_UID over SWITCHROOM_HOSTD_OPERATOR_UID", () => {
+    process.env.SWITCHROOM_HOSTD_OPERATOR_UID = "1000";
+    process.env.SUDO_UID = "1234";
+    expect(resolveOperatorUid()).toBe(1234);
+    delete process.env.SUDO_UID;
+    vi.spyOn(process, "getuid").mockReturnValue(4242);
+    expect(resolveOperatorUid()).toBe(4242);
+  });
+
+  it("ignores an invalid SWITCHROOM_HOSTD_OPERATOR_UID (0 / non-numeric)", () => {
     delete process.env.SUDO_UID;
     vi.spyOn(process, "getuid").mockReturnValue(0);
+    process.env.SWITCHROOM_HOSTD_OPERATOR_UID = "0";
+    expect(resolveOperatorUid()).toBeUndefined();
+    process.env.SWITCHROOM_HOSTD_OPERATOR_UID = "notanumber";
     expect(resolveOperatorUid()).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
`resolveOperatorUid()` read only `SUDO_UID` → `getuid()`. When `switchroom apply` is shelled out **by hostd** it runs as root *without* sudo, so `SUDO_UID` is unset and `getuid()` is `0` → it returned `undefined`. `generateCompose` gates the vault-broker **operator-socket** bind on `operatorUid !== undefined`, so every hostd-driven rollout wrote a compose with **no operator listener**.

This adds `SWITCHROOM_HOSTD_OPERATOR_UID` (already injected into hostd, same host-fact pattern as `SWITCHROOM_HOST_HOME`/`_TZ`) as the final fallback in `resolveOperatorUid()`. sudo/`getuid()` still win when present.

## Why
After a hostd rollout the broker stops binding `~/.switchroom/broker-operator/sock`, which breaks:
1. **Host-shell vault access** (`switchroom vault …` → `broker not running`).
2. **The litellm key-confirm probe** (`resolveLiteLLMConfirmedAgents`, broker-only) on the *next* `apply` → `keyConfirmed=false` for every agent → **litellm routing env silently stripped fleet-wide** (fail-open to direct OAuth).

Observed live: the v0.17.1 rollout dropped the operator socket and turned litellm off for the whole fleet. Root-caused + hot-fixed on the host (broker recreated from a compose that still had the mount; a targeted compose guard re-persists it until this ships).

## Test plan
- [x] `vitest run tests/operator-uid.test.ts` — 11 pass, incl. new cases: hostd fallback under root/no-SUDO_UID; sudo/getuid precedence over hostd uid; invalid (`0`/non-numeric) hostd uid ignored; real-root-with-no-hints still `undefined`.
- [x] `tsc --noEmit` clean.

## Risk
Low. Pure fallback added *after* the existing `SUDO_UID`/`getuid()` checks — no behavior change on host-shell/sudo paths. Only affects the previously-broken root-no-SUDO_UID (hostd) path, which went from `undefined` → the injected operator uid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)