### PR TITLE
feat(hostd): self-bump on stale-CLI rollout — one-call agent-driven rolls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## unreleased — hostd self-bump: one-call agent-driven fleet rolls
+
+- **hostd self-bumps on a stale-CLI rollout instead of refusing** (#2645):
+  hostd's CLI is baked into its image, so it is older than EVERY freshly
+  tagged release — which made every agent-invoked `rollout` to a new version
+  fail `preflight-stale-cli`, with a host-shell-only remedy (`switchroom
+  hostd install --tag …`). The root agent could never roll a release by
+  itself; agents worked around it by hand-editing hostd's compose file. Now,
+  when the pin is newer than hostd's own CLI, hostd: verifies the target
+  image is pullable (`docker manifest inspect` — refuses cleanly when the
+  docker-images workflow hasn't finished), tag-bumps its own compose in
+  place (backup kept), writes a resume marker, and hands its own recreate to
+  a detached sibling helper container (`docker run -d --rm`, docker.sock +
+  hostd dir only — a sibling survives the recreate that would SIGKILL any
+  in-container driver, brick scenario #1/#2458). The NEW hostd finds the
+  marker at boot and relaunches the roll under the SAME request_id, so the
+  audit hash-chain, in-chat narration and `get_status` all continue
+  seamlessly. Marker is single-shot (deleted before validation), staleness-
+  capped at 15 min, and shape-validated; a failed helper is caught by a
+  `docker wait` watcher that rolls the compose bump back and writes a loud
+  terminal row. New `self-bump` / `self-bump-done` narration phases. The
+  rollout terminal warnings now name exactly what stays on the prior version
+  (web dashboard, host operator CLI) with the host-side finish commands
+  (#2645 item 3).
+
 ## v0.16.50 — Fleet-wide webkite render config
 
 ### Web extraction

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -250,7 +250,13 @@ export type RolloutPhaseName =
   | "agent-start"
   | "agent-done"
   | "persist-pin"
-  | "hostd-web-deferred";
+  | "hostd-web-deferred"
+  // #2645 — hostd self-bump. Emitted by the DAEMON directly (never via the
+  // child's stdout sentinel): "self-bump" when the old hostd hands its own
+  // recreate to the sibling helper, "self-bump-done" when the new hostd
+  // resumes the roll at boot.
+  | "self-bump"
+  | "self-bump-done";
 
 export interface RolloutPhase {
   phase: RolloutPhaseName;
@@ -317,6 +323,8 @@ export function parseRolloutPhaseLine(line: string): RolloutPhase | null {
     "agent-done",
     "persist-pin",
     "hostd-web-deferred",
+    "self-bump",
+    "self-bump-done",
   ]);
   if (typeof o.phase !== "string" || !PHASES.has(o.phase)) return null;
   if (typeof o.target !== "string") return null;
@@ -845,8 +853,11 @@ export function registerRolloutCommand(program: Command): void {
           `agents on v${cli}, fail the canary, and leave compose downgraded ` +
           `below what's running. ` +
           (hostdCtx
-            ? `Refresh hostd's CLI first — host-side: \`switchroom hostd install ` +
-              `--tag ${target}\` — then re-run the roll.`
+            ? `Normally hostd SELF-BUMPS before this child ever spawns ` +
+              `(#2645) — seeing this refusal means the self-bump was ` +
+              `skipped or resumed while still stale. Refresh hostd's CLI ` +
+              `host-side: \`switchroom hostd install --tag ${target}\` — ` +
+              `then re-run the roll.`
             : `Upgrade this CLI to >= ${target} first (e.g. \`switchroom update ` +
               `--pin ${target}\`, or rebuild your checkout), then re-run.`) +
           ` Nothing was changed.`;
@@ -996,10 +1007,21 @@ export function registerRolloutCommand(program: Command): void {
       // the plan (it would SIGKILL this very process). Surface that as a
       // deferral note so the operator knows to refresh host-side.
       if (hostdCtx) {
+        // #2645 item 3 — name EXACTLY what is still on the prior version so
+        // "rollout done" is never misread as "everything's on the new
+        // version". hostd itself is current on this path when the roll was
+        // preceded by a self-bump (the daemon tag-bumps its own compose
+        // before spawning this child); web + the host-installed operator
+        // CLI never are.
         result.warnings.push(
-          "hostd/web refresh deferred — run host-side (`switchroom webd install` " +
-            "/ `switchroom hostd install`). An agent-invoked rollout cannot " +
-            "recreate its own hostd container without killing itself.",
+          `still on the PRIOR version after this roll: switchroom-web ` +
+            `(host-side: \`switchroom webd install --tag ${target}\`) and the ` +
+            `host operator CLI (\`sudo npm i -g switchroom@${normalizeVersion(target)}\`). ` +
+            `hostd's compose was tag-bumped by the self-bump when one ran; a ` +
+            `full hostd template regen (only needed when a release changes ` +
+            `hostd's mounts/env) is \`switchroom hostd install --tag ${target}\` ` +
+            `host-side. An agent-invoked rollout cannot recreate its own hostd ` +
+            `container mid-roll without killing itself.`,
         );
         // #2726 — narrate the deferral as a phase so the durable log + the
         // narration surface show "hostd/web deferred" between the last agent

--- a/src/host-control/render-rollout-status.ts
+++ b/src/host-control/render-rollout-status.ts
@@ -55,6 +55,10 @@ function phaseLine(s: RolloutRenderState): string {
       return "persisting pin";
     case "hostd-web-deferred":
       return "hostd/web refresh deferred (run host-side)";
+    case "self-bump":
+      return "hostd refreshing itself to the target (brief control blip)…";
+    case "self-bump-done":
+      return "hostd refreshed — resuming the roll";
     default:
       return "starting";
   }

--- a/src/host-control/rollout-narrator.ts
+++ b/src/host-control/rollout-narrator.ts
@@ -159,6 +159,12 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
    */
   private static seqFor(phase: RolloutPhase): number {
     switch (phase.phase) {
+      case "self-bump":
+      case "self-bump-done":
+        // #2645 — hostd self-refresh precedes the roll proper. Co-timed with
+        // apply's window (equal-seq is refine-only, and the daemon feeds
+        // self-bump → self-bump-done → apply strictly in order).
+        return 0;
       case "apply":
         return 0; // always first
       case "canary-start":

--- a/src/host-control/self-bump.test.ts
+++ b/src/host-control/self-bump.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import {
+  needsSelfBump,
+  bumpHostdComposeImageTag,
+  encodePendingRolloutMarker,
+  parsePendingRolloutMarker,
+  isMarkerFresh,
+  selfBumpHelperArgs,
+  SELF_BUMP_HELPER_CONTAINER,
+  SELF_BUMP_MARKER_MAX_AGE_MS,
+  type PendingRolloutMarker,
+} from "./self-bump.js";
+
+describe("needsSelfBump", () => {
+  it("true when the daemon CLI is strictly older than the pin", () => {
+    expect(needsSelfBump("0.16.49", "v0.17.0")).toBe(true);
+    expect(needsSelfBump("v0.16.49", "v0.16.50")).toBe(true);
+  });
+
+  it("false when equal or newer", () => {
+    expect(needsSelfBump("0.17.0", "v0.17.0")).toBe(false);
+    expect(needsSelfBump("0.17.1", "v0.17.0")).toBe(false);
+  });
+
+  it("false (never blocks) on dev/sha/unparseable versions", () => {
+    expect(needsSelfBump(undefined, "v0.17.0")).toBe(false);
+    expect(needsSelfBump("dev", "v0.17.0")).toBe(false);
+    expect(needsSelfBump("0.16.49", "sha-abc1234")).toBe(false);
+  });
+});
+
+describe("bumpHostdComposeImageTag", () => {
+  const yaml = [
+    "services:",
+    "  hostd:",
+    "    image: ghcr.io/switchroom/switchroom-hostd:v0.16.49",
+    "    volumes:",
+    "      - /var/run/docker.sock:/var/run/docker.sock",
+  ].join("\n");
+
+  it("rewrites only the hostd image tag, preserving registry/owner", () => {
+    const r = bumpHostdComposeImageTag(yaml, "v0.17.0");
+    expect(r).not.toBeNull();
+    expect(r!.oldImageRef).toBe(
+      "ghcr.io/switchroom/switchroom-hostd:v0.16.49",
+    );
+    expect(r!.newImageRef).toBe("ghcr.io/switchroom/switchroom-hostd:v0.17.0");
+    expect(r!.yaml).toContain(
+      "image: ghcr.io/switchroom/switchroom-hostd:v0.17.0",
+    );
+    expect(r!.yaml).not.toContain("v0.16.49");
+    // Everything else is untouched.
+    expect(r!.yaml).toContain("/var/run/docker.sock:/var/run/docker.sock");
+  });
+
+  it("works for a fork's registry prefix", () => {
+    const forked = yaml.replace(
+      "ghcr.io/switchroom/switchroom-hostd",
+      "registry.example.com/me/switchroom-hostd",
+    );
+    const r = bumpHostdComposeImageTag(forked, "v1.2.3");
+    expect(r!.newImageRef).toBe(
+      "registry.example.com/me/switchroom-hostd:v1.2.3",
+    );
+  });
+
+  it("returns null when no switchroom-hostd image line exists", () => {
+    expect(
+      bumpHostdComposeImageTag("services:\n  web:\n    image: nginx:1", "v1.0.0"),
+    ).toBeNull();
+  });
+
+  it("does not touch a non-hostd switchroom image", () => {
+    const mixed =
+      "    image: ghcr.io/switchroom/switchroom-agent:v0.16.49\n" + yaml;
+    const r = bumpHostdComposeImageTag(mixed, "v0.17.0");
+    expect(r!.yaml).toContain("switchroom-agent:v0.16.49");
+    expect(r!.yaml).toContain("switchroom-hostd:v0.17.0");
+  });
+});
+
+describe("pending-rollout marker", () => {
+  const marker: PendingRolloutMarker = {
+    v: 1,
+    request_id: "mcp-rollout-123-abc",
+    pin: "v0.17.0",
+    agents: ["test-harness", "klanker"],
+    skip_web: true,
+    caller: { kind: "agent", name: "overlord" },
+    created_at: "2026-07-05T00:00:00.000Z",
+    prior_hostd_version: "0.16.49",
+  };
+
+  it("round-trips through encode/parse", () => {
+    expect(parsePendingRolloutMarker(encodePendingRolloutMarker(marker))).toEqual(
+      marker,
+    );
+  });
+
+  it("round-trips the minimal (no-optionals, operator) shape", () => {
+    const min: PendingRolloutMarker = {
+      v: 1,
+      request_id: "r1",
+      pin: "v1.0.0",
+      caller: { kind: "operator" },
+      created_at: "2026-07-05T00:00:00.000Z",
+      prior_hostd_version: "0.16.49",
+    };
+    expect(parsePendingRolloutMarker(encodePendingRolloutMarker(min))).toEqual(min);
+  });
+
+  it.each([
+    ["not json", "{"],
+    ["wrong version", JSON.stringify({ ...marker, v: 2 })],
+    ["missing request_id", JSON.stringify({ ...marker, request_id: undefined })],
+    ["non-semver pin", JSON.stringify({ ...marker, pin: "sha-abc1234" })],
+    ["bad created_at", JSON.stringify({ ...marker, created_at: "yesterday" })],
+    ["bad caller kind", JSON.stringify({ ...marker, caller: { kind: "root" } })],
+    [
+      "agent caller without name",
+      JSON.stringify({ ...marker, caller: { kind: "agent" } }),
+    ],
+    ["empty agents", JSON.stringify({ ...marker, agents: [] })],
+    [
+      "agent name with shell metachars",
+      JSON.stringify({ ...marker, agents: ["ok", "bad;rm -rf"] }),
+    ],
+    ["non-boolean skip_web", JSON.stringify({ ...marker, skip_web: "yes" })],
+  ])("rejects a malformed marker: %s", (_label, raw) => {
+    expect(parsePendingRolloutMarker(raw)).toBeNull();
+  });
+
+  it("isMarkerFresh honours the cutoff", () => {
+    const created = Date.parse(marker.created_at);
+    expect(isMarkerFresh(marker, created + 1000)).toBe(true);
+    expect(
+      isMarkerFresh(marker, created + SELF_BUMP_MARKER_MAX_AGE_MS - 1),
+    ).toBe(true);
+    expect(isMarkerFresh(marker, created + SELF_BUMP_MARKER_MAX_AGE_MS)).toBe(
+      false,
+    );
+  });
+});
+
+describe("selfBumpHelperArgs", () => {
+  const args = selfBumpHelperArgs({
+    hostdDirHostPath: "/home/op/.switchroom/hostd",
+    image: "ghcr.io/switchroom/switchroom-hostd:v0.17.0",
+  });
+
+  it("is a detached, self-removing, labeled sibling", () => {
+    expect(args.slice(0, 3)).toEqual(["run", "-d", "--rm"]);
+    expect(args).toContain(SELF_BUMP_HELPER_CONTAINER);
+    expect(args).toContain("switchroom.hostd-selfbump=true");
+  });
+
+  it("mounts ONLY the docker socket and the hostd dir, at identical host paths", () => {
+    const mounts = args.flatMap((a, i) => (args[i - 1] === "-v" ? [a] : []));
+    expect(mounts).toEqual([
+      "/var/run/docker.sock:/var/run/docker.sock",
+      "/home/op/.switchroom/hostd:/home/op/.switchroom/hostd",
+    ]);
+  });
+
+  it("pulls then ups the hostd compose project from the target image", () => {
+    const script = args[args.length - 1]!;
+    expect(args).toContain("ghcr.io/switchroom/switchroom-hostd:v0.17.0");
+    expect(script).toContain(
+      "docker compose -p switchroom-hostd -f /home/op/.switchroom/hostd/docker-compose.yml pull",
+    );
+    expect(script).toContain(
+      "docker compose -p switchroom-hostd -f /home/op/.switchroom/hostd/docker-compose.yml up -d",
+    );
+    // pull failure must short-circuit the up (old hostd keeps serving).
+    expect(script).toContain("pull >> ");
+    expect(script.indexOf("pull")).toBeLessThan(script.indexOf("up -d"));
+    expect(script).toContain("&&");
+  });
+});

--- a/src/host-control/self-bump.test.ts
+++ b/src/host-control/self-bump.test.ts
@@ -145,7 +145,8 @@ describe("pending-rollout marker", () => {
 describe("selfBumpHelperArgs", () => {
   const args = selfBumpHelperArgs({
     hostdDirHostPath: "/home/op/.switchroom/hostd",
-    image: "ghcr.io/switchroom/switchroom-hostd:v0.17.0",
+    helperImage: "ghcr.io/switchroom/switchroom-hostd:v0.16.49",
+    targetImage: "ghcr.io/switchroom/switchroom-hostd:v0.17.0",
   });
 
   it("is a detached, self-removing, labeled sibling", () => {
@@ -162,18 +163,41 @@ describe("selfBumpHelperArgs", () => {
     ]);
   });
 
-  it("pulls then ups the hostd compose project from the target image", () => {
+  it("runs the helper on the OLD (local) image, never the target", () => {
+    // The target image would make `docker run -d` pull multi-GB
+    // synchronously and blow the caller's wire timeout; the old image is
+    // pinned local by the running container. The target is only fetched
+    // by the script's own `compose pull`.
+    // argv tail is [..., "--entrypoint", "/bin/sh", <image>, "-c", <script>]
+    expect(args[args.length - 3]).toBe(
+      "ghcr.io/switchroom/switchroom-hostd:v0.16.49",
+    );
+    // The target ref appears only inside the script (log line), never as
+    // the `docker run` image argument.
+    expect(args.slice(0, -1)).not.toContain(
+      "ghcr.io/switchroom/switchroom-hostd:v0.17.0",
+    );
+  });
+
+  it("pulls then ups the hostd compose project", () => {
     const script = args[args.length - 1]!;
-    expect(args).toContain("ghcr.io/switchroom/switchroom-hostd:v0.17.0");
     expect(script).toContain(
-      "docker compose -p switchroom-hostd -f /home/op/.switchroom/hostd/docker-compose.yml pull",
+      'docker compose -p switchroom-hostd -f "/home/op/.switchroom/hostd/docker-compose.yml" pull',
     );
     expect(script).toContain(
-      "docker compose -p switchroom-hostd -f /home/op/.switchroom/hostd/docker-compose.yml up -d",
+      'docker compose -p switchroom-hostd -f "/home/op/.switchroom/hostd/docker-compose.yml" up -d',
     );
     // pull failure must short-circuit the up (old hostd keeps serving).
-    expect(script).toContain("pull >> ");
     expect(script.indexOf("pull")).toBeLessThan(script.indexOf("up -d"));
     expect(script).toContain("&&");
+  });
+
+  it("PROPAGATES the pull/up exit status as the container exit code", () => {
+    // A trailing bare `echo` would mask every failure as exit 0, making
+    // the daemon's docker-wait watcher blind and leaving the
+    // fleet-mutation lock held forever on a failed bump.
+    const script = args[args.length - 1]!;
+    expect(script).toContain("rc=$?");
+    expect(script.trimEnd().endsWith("exit $rc")).toBe(true);
   });
 });

--- a/src/host-control/self-bump.ts
+++ b/src/host-control/self-bump.ts
@@ -1,0 +1,256 @@
+/**
+ * hostd self-bump — the missing lever for a fully agent-driven fleet roll
+ * (#2645 item 1).
+ *
+ * Problem: the rollout verb's stale-CLI preflight (#2542) refuses any roll
+ * whose target pin is NEWER than the CLI driving it. hostd's CLI is baked
+ * into its image, so it is one release behind EVERY new tag by construction
+ * — which made every agent-invoked roll to a fresh release fail with
+ * `preflight-stale-cli`, and the only remedy (`switchroom hostd install
+ * --tag <target>`) was host-shell-only. Agents worked around it by
+ * hand-editing hostd's compose file (the `bak-directroll-*` trail on the
+ * operator host) — exactly the improvisation this module retires.
+ *
+ * Shape of the fix (three phases, two hostd processes):
+ *
+ *   1. OLD hostd receives the rollout request, detects its own CLI is
+ *      older than the pin, and — instead of refusing — tag-bumps its own
+ *      compose file, writes a resume marker, spawns a DETACHED SIBLING
+ *      helper container (`docker run -d`), and answers `started`. The
+ *      helper is a sibling, not a child: `docker compose up -d` on the
+ *      hostd project recreates the hostd container, which would SIGKILL
+ *      any in-container driver (brick scenario #1 / #2458). A sibling
+ *      survives its parent's recreate.
+ *   2. The helper pulls the target hostd image and `compose up -d`s the
+ *      hostd project. Old hostd dies; new hostd (target CLI) boots.
+ *   3. NEW hostd finds the marker at startup, verifies its own version
+ *      now satisfies the pin, and spawns the rollout child under the SAME
+ *      request_id — audit chain, narration surface and get_status all
+ *      continue where they left off.
+ *
+ * Deliberately a TAG-ONLY bump, not a full `hostd install` template
+ * regeneration: regenerating the compose from inside a container gets the
+ * host-side facts wrong (host timezone, operator uid via SUDO_UID, the
+ * skills symlink target — each a real past incident class), while the
+ * on-disk compose is known-good and a version bump only needs the image
+ * ref changed. Template drift (a NEW release requiring a new mount, e.g.
+ * the #2679 machine-id mount) still needs a host-side
+ * `switchroom hostd install` — rare, and surfaced in the roll's warnings.
+ *
+ * Everything here is pure (string/JSON in-out) so it unit-tests without
+ * docker; the daemon wires the side effects.
+ */
+
+import { compareReleaseTags } from "../config/release-resolve.js";
+
+/** Marker filename, written under `<homeDir>/.switchroom/hostd/` — the
+ *  same bind-mounted dir that survives the hostd container recreate. The
+ *  dir is root-owned (agents can only reach their own `<agent>/sock`
+ *  subdir), so the marker cannot be forged by an agent. */
+export const SELF_BUMP_MARKER_FILENAME = "pending-rollout.json";
+
+/** Helper container name. Fixed (not timestamped) so a stale/stuck helper
+ *  from a previous attempt is removable by name before the next spawn. */
+export const SELF_BUMP_HELPER_CONTAINER = "switchroom-hostd-selfbump";
+
+/** Helper output log, next to the compose file (bind-mounted, so it
+ *  survives the recreate and is readable host-side for debugging). */
+export const SELF_BUMP_LOG_FILENAME = "selfbump.log";
+
+/**
+ * A marker older than this at resume time is treated as a failed bump
+ * (terminal error row, no resume). Bounds the window in which a crashed
+ * helper / wedged pull can leave a roll pending; matches the orphan-
+ * reconcile age so the two mechanisms can't race to different verdicts.
+ */
+export const SELF_BUMP_MARKER_MAX_AGE_MS = 15 * 60 * 1000;
+
+/** Resume marker: everything the NEW hostd needs to relaunch the roll the
+ *  OLD hostd accepted. Written by hostd only (root), read once at boot. */
+export interface PendingRolloutMarker {
+  v: 1;
+  request_id: string;
+  /** Version-assertable target, `vX.Y.Z` (validated at the wire + here). */
+  pin: string;
+  agents?: string[];
+  skip_web?: boolean;
+  allow_downgrade?: boolean;
+  caller: { kind: "agent"; name: string } | { kind: "operator" };
+  /** ISO timestamp the OLD hostd wrote the marker. */
+  created_at: string;
+  /** The OLD hostd's own CLI version, for the audit trail. */
+  prior_hostd_version: string;
+}
+
+const SEMVER_PIN_RE = /^v\d+\.\d+\.\d+$/;
+
+/**
+ * True when the daemon's own CLI is strictly older than the target pin —
+ * i.e. the roll would be refused by the CLI-side `preflight-stale-cli`
+ * guard (#2542) and hostd must refresh itself first. Mirrors
+ * `shouldRefuseStaleCli`: conservative, only a clean semver-vs-semver
+ * comparison triggers (dev/sha/unparseable → false → normal path, where
+ * the CLI-side guard remains the backstop).
+ */
+export function needsSelfBump(
+  ownVersion: string | undefined,
+  pin: string,
+): boolean {
+  if (!ownVersion) return false;
+  const cmp = compareReleaseTags(
+    `v${ownVersion.trim().replace(/^v/, "")}`,
+    `v${pin.trim().replace(/^v/, "")}`,
+  );
+  return cmp !== null && cmp < 0;
+}
+
+/**
+ * Tag-bump the hostd compose yaml: rewrite the `image:` line that
+ * references a `switchroom-hostd` image to the target pin, preserving the
+ * registry/owner prefix as-is (forks / GHCR mirrors keep working).
+ *
+ * Returns the rewritten yaml plus the old and new image refs, or null when
+ * no such image line is found (hand-mangled compose — caller refuses and
+ * points at host-side `hostd install`).
+ */
+export function bumpHostdComposeImageTag(
+  yaml: string,
+  pin: string,
+): { yaml: string; oldImageRef: string; newImageRef: string } | null {
+  const re = /^(\s*image:\s*)(\S*switchroom-hostd):(\S+)\s*$/m;
+  const m = yaml.match(re);
+  if (!m) return null;
+  const oldImageRef = `${m[2]}:${m[3]}`;
+  const newImageRef = `${m[2]}:${pin}`;
+  return {
+    yaml: yaml.replace(re, `$1${newImageRef}`),
+    oldImageRef,
+    newImageRef,
+  };
+}
+
+/** Serialize a marker (pretty-printed — it's an operator-debuggable file). */
+export function encodePendingRolloutMarker(m: PendingRolloutMarker): string {
+  return JSON.stringify(m, null, 2) + "\n";
+}
+
+/**
+ * Parse + validate a marker file's contents. Returns null on ANY shape
+ * problem — a malformed/forged/torn marker degrades to "no resume" (the
+ * orphan-reconcile sweep then reports the stranded roll) rather than
+ * letting unvalidated data reach a spawn argv.
+ */
+export function parsePendingRolloutMarker(
+  raw: string,
+): PendingRolloutMarker | null {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof obj !== "object" || obj === null) return null;
+  const o = obj as Record<string, unknown>;
+  if (o.v !== 1) return null;
+  if (typeof o.request_id !== "string" || o.request_id.length === 0) return null;
+  if (typeof o.pin !== "string" || !SEMVER_PIN_RE.test(o.pin)) return null;
+  if (typeof o.created_at !== "string" || !Number.isFinite(Date.parse(o.created_at))) {
+    return null;
+  }
+  if (typeof o.prior_hostd_version !== "string") return null;
+  const caller = o.caller as Record<string, unknown> | null;
+  if (typeof caller !== "object" || caller === null) return null;
+  if (caller.kind === "agent") {
+    if (typeof caller.name !== "string" || caller.name.length === 0) return null;
+  } else if (caller.kind !== "operator") {
+    return null;
+  }
+  if (o.agents !== undefined) {
+    if (
+      !Array.isArray(o.agents) ||
+      o.agents.length === 0 ||
+      !o.agents.every((a) => typeof a === "string" && /^[\w-]+$/.test(a))
+    ) {
+      return null;
+    }
+  }
+  if (o.skip_web !== undefined && typeof o.skip_web !== "boolean") return null;
+  if (o.allow_downgrade !== undefined && typeof o.allow_downgrade !== "boolean") {
+    return null;
+  }
+  return {
+    v: 1,
+    request_id: o.request_id,
+    pin: o.pin,
+    ...(o.agents !== undefined ? { agents: o.agents as string[] } : {}),
+    ...(o.skip_web !== undefined ? { skip_web: o.skip_web as boolean } : {}),
+    ...(o.allow_downgrade !== undefined
+      ? { allow_downgrade: o.allow_downgrade as boolean }
+      : {}),
+    caller:
+      caller.kind === "agent"
+        ? { kind: "agent", name: caller.name as string }
+        : { kind: "operator" },
+    created_at: o.created_at,
+    prior_hostd_version: o.prior_hostd_version,
+  };
+}
+
+/** True when the marker is young enough to resume. */
+export function isMarkerFresh(
+  marker: PendingRolloutMarker,
+  nowMs: number,
+): boolean {
+  const created = Date.parse(marker.created_at);
+  if (!Number.isFinite(created)) return false;
+  return nowMs - created < SELF_BUMP_MARKER_MAX_AGE_MS;
+}
+
+/**
+ * argv for the detached sibling helper (`docker <argv...>`).
+ *
+ * The helper mounts ONLY the docker socket and the hostd compose dir (at
+ * its identical HOST path, so the `-f` path the compose CLI reads matches
+ * the path dockerd resolves bind sources against — no translation layer to
+ * poison, cf. the 2026-06-23 container-HOME deploy incident). It pulls
+ * first (old hostd keeps serving through the download), then `up -d`,
+ * logging to `selfbump.log` in the same dir. `sleep 2` gives the OLD hostd
+ * time to flush the `started` response to the caller before the recreate
+ * SIGTERMs it.
+ *
+ * The helper runs the TARGET hostd image: it is already the image being
+ * pulled, and it carries the docker CLI + compose plugin the script needs.
+ */
+export function selfBumpHelperArgs(opts: {
+  /** HOST path of `~/.switchroom/hostd` (compose file + log live here). */
+  hostdDirHostPath: string;
+  /** Target hostd image ref (registry/owner preserved from the compose). */
+  image: string;
+}): string[] {
+  const composePath = `${opts.hostdDirHostPath}/docker-compose.yml`;
+  const logPath = `${opts.hostdDirHostPath}/${SELF_BUMP_LOG_FILENAME}`;
+  const script =
+    `sleep 2; ` +
+    `echo \"selfbump $(date -u) → ${opts.image}\" >> ${logPath} 2>&1; ` +
+    `docker compose -p switchroom-hostd -f ${composePath} pull >> ${logPath} 2>&1 && ` +
+    `docker compose -p switchroom-hostd -f ${composePath} up -d >> ${logPath} 2>&1; ` +
+    `echo \"selfbump done rc=$?\" >> ${logPath} 2>&1`;
+  return [
+    "run",
+    "-d",
+    "--rm",
+    "--name",
+    SELF_BUMP_HELPER_CONTAINER,
+    "--label",
+    "switchroom.hostd-selfbump=true",
+    "-v",
+    "/var/run/docker.sock:/var/run/docker.sock",
+    "-v",
+    `${opts.hostdDirHostPath}:${opts.hostdDirHostPath}`,
+    "--entrypoint",
+    "/bin/sh",
+    opts.image,
+    "-c",
+    script,
+  ];
+}

--- a/src/host-control/self-bump.ts
+++ b/src/host-control/self-bump.ts
@@ -218,23 +218,39 @@ export function isMarkerFresh(
  * time to flush the `started` response to the caller before the recreate
  * SIGTERMs it.
  *
- * The helper runs the TARGET hostd image: it is already the image being
- * pulled, and it carries the docker CLI + compose plugin the script needs.
+ * The helper runs the CURRENTLY-RUNNING (old) hostd image, NOT the target:
+ * the old image is guaranteed local (the running container pins it), so
+ * `docker run -d` returns in well under a second — running the TARGET
+ * image here would make `run -d` synchronously pull a multi-GB image and
+ * blow the caller's wire timeout before the `started` response ever lands.
+ * The target image is fetched by the script's own `compose pull`, async to
+ * the response. The old image carries the same docker CLI + compose plugin
+ * the script needs.
+ *
+ * The script PROPAGATES the pull/up exit status as the container's exit
+ * code — the daemon's `docker wait` watcher keys on it to detect a failed
+ * bump while the old hostd is still alive (a trailing bare `echo` would
+ * mask every failure as exit 0 and leave the fleet-mutation lock held
+ * forever).
  */
 export function selfBumpHelperArgs(opts: {
   /** HOST path of `~/.switchroom/hostd` (compose file + log live here). */
   hostdDirHostPath: string;
-  /** Target hostd image ref (registry/owner preserved from the compose). */
-  image: string;
+  /** Image to RUN the helper from — the currently-running (old) hostd
+   *  image ref, guaranteed local. */
+  helperImage: string;
+  /** Target image ref, for the log line only (the bumped compose file is
+   *  what actually names it to `compose pull`). */
+  targetImage: string;
 }): string[] {
   const composePath = `${opts.hostdDirHostPath}/docker-compose.yml`;
   const logPath = `${opts.hostdDirHostPath}/${SELF_BUMP_LOG_FILENAME}`;
   const script =
     `sleep 2; ` +
-    `echo \"selfbump $(date -u) → ${opts.image}\" >> ${logPath} 2>&1; ` +
-    `docker compose -p switchroom-hostd -f ${composePath} pull >> ${logPath} 2>&1 && ` +
-    `docker compose -p switchroom-hostd -f ${composePath} up -d >> ${logPath} 2>&1; ` +
-    `echo \"selfbump done rc=$?\" >> ${logPath} 2>&1`;
+    `echo \"selfbump $(date -u) -> ${opts.targetImage}\" >> \"${logPath}\" 2>&1; ` +
+    `docker compose -p switchroom-hostd -f \"${composePath}\" pull >> \"${logPath}\" 2>&1 && ` +
+    `docker compose -p switchroom-hostd -f \"${composePath}\" up -d >> \"${logPath}\" 2>&1; ` +
+    `rc=$?; echo \"selfbump done rc=$rc\" >> \"${logPath}\" 2>&1; exit $rc`;
   return [
     "run",
     "-d",
@@ -249,7 +265,7 @@ export function selfBumpHelperArgs(opts: {
     `${opts.hostdDirHostPath}:${opts.hostdDirHostPath}`,
     "--entrypoint",
     "/bin/sh",
-    opts.image,
+    opts.helperImage,
     "-c",
     script,
   ];

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -38,6 +38,8 @@ import {
   writeSync,
   fsyncSync,
   closeSync,
+  copyFileSync,
+  unlinkSync,
 } from "node:fs";
 import { join, dirname, resolve } from "node:path";
 import { createHash, randomUUID, randomBytes } from "node:crypto";
@@ -62,6 +64,19 @@ import {
   isVersionAssertable,
   type RolloutPhase,
 } from "../cli/rollout.js";
+import { SWITCHROOM_VERSION } from "../cli/resolve-version.js";
+import {
+  needsSelfBump,
+  bumpHostdComposeImageTag,
+  encodePendingRolloutMarker,
+  parsePendingRolloutMarker,
+  isMarkerFresh,
+  selfBumpHelperArgs,
+  SELF_BUMP_MARKER_FILENAME,
+  SELF_BUMP_HELPER_CONTAINER,
+  SELF_BUMP_LOG_FILENAME,
+  type PendingRolloutMarker,
+} from "./self-bump.js";
 import { parseUpdateResultLine } from "../cli/update.js";
 import { parseAuditLine, latestRolloutRowForRequest } from "./audit-reader.js";
 import {
@@ -170,6 +185,20 @@ export interface ServerOptions {
    * transport as the approval card). Fire-and-forget; never blocks/fails the
    * roll. Unset → no terminal ping (durable audit row is still written). */
   rolloutRelay?: RolloutRelay;
+  /**
+   * The daemon's own CLI version, compared against a rollout pin to
+   * decide whether hostd must self-bump before driving the roll (#2645).
+   * Default: the build-stamped SWITCHROOM_VERSION. Test seam.
+   */
+  selfVersion?: string;
+  /**
+   * The operator home as the HOST sees it — used as the bind-source
+   * prefix for the self-bump helper container's mounts (a `/host-home/…`
+   * container path is meaningless to dockerd). Default:
+   * `SWITCHROOM_HOST_HOME` env (set in the hostd compose), falling back
+   * to `homeDir` for the host-direct daemon. Test seam.
+   */
+  hostHomeDir?: string;
   /** Test seam: override the random hex id generator. */
   generateApprovalId?: () => string;
   /** Test seam: override the `switchroom apply` subprocess invocation. */
@@ -572,6 +601,17 @@ export class HostdServer {
     // a root-owned 0700 dir, so no agent could ever reach the daemon.
     await chmod(hostdDir, 0o755).catch(() => undefined);
 
+    // #2645 — self-bump boot resume. MUST run before the sockets bind
+    // (so no incoming request can race the fleet-mutation lock the resume
+    // takes) and before the orphan sweep below (a resumable roll isn't an
+    // orphan — its terminal row is still coming). Best-effort: a resume
+    // failure logs + terminal-rows but never blocks boot.
+    await this.resumePendingSelfBumpRollout().catch((e) => {
+      process.stderr.write(
+        `hostd: self-bump resume failed (non-fatal): ${(e as Error).message}\n`,
+      );
+    });
+
     const agentNames = Object.keys(this.opts.agentUids).sort();
     if (agentNames.length === 0) {
       // No admin agents declared yet. Phase 1 no-op exit — the
@@ -924,7 +964,7 @@ export class HostdServer {
           resp = this.handleApply(req, caller, started);
           break;
         case "rollout":
-          resp = this.handleRollout(req, caller, started);
+          resp = await this.handleRollout(req, caller, started);
           break;
         case "agent_start":
           resp = await this.handleAgentStart(req, started);
@@ -1451,23 +1491,67 @@ export class HostdServer {
    * Returns `started`; default wire timeout (no long override) — same
    * async fire-and-forget pattern as update_apply.
    */
-  private handleRollout(
+  private async handleRollout(
     req: Extract<HostdRequest, { op: "rollout" }>,
     caller: SocketIdentity,
     started: number,
-  ): HostdResponse {
+  ): Promise<HostdResponse> {
     const denied = this.checkFleetMutationLock(req.op, req.request_id, started);
     if (denied) return denied;
+
+    // #2645 item 1 — hostd self-bump. hostd's CLI is baked into its image,
+    // so it is older than EVERY freshly tagged release; without this branch
+    // the roll is refused by the CLI-side `preflight-stale-cli` guard and
+    // the only remedy is a host-shell `hostd install`, defeating the
+    // agent-driven roll entirely. Instead: tag-bump hostd's own compose,
+    // hand off to a detached sibling helper that recreates this container
+    // on the target image, and let the NEW hostd resume this very request
+    // from the marker at boot (see resumePendingSelfBumpRollout).
+    if (
+      needsSelfBump(this.opts.selfVersion ?? SWITCHROOM_VERSION, req.args.pin)
+    ) {
+      return this.beginSelfBump(req, caller, started);
+    }
 
     const assetDenied = this.applyAssetPreflight(req.request_id, started);
     if (assetDenied) return assetDenied;
 
-    const args = ["rollout", "--pin", req.args.pin];
-    if (req.args.agents && req.args.agents.length > 0) {
-      args.push("--agents", req.args.agents.join(","));
+    const entry = this.launchRollout(req.args, req.request_id, caller, started);
+    return {
+      v: 1,
+      request_id: entry.request_id,
+      result: "started",
+      exit_code: null,
+      duration_ms: Date.now() - started,
+    };
+  }
+
+  /**
+   * Shared tail of the rollout launch: build the child argv, capture
+   * prior-pin + install context, record the status entry, take the
+   * fleet-mutation lock and spawn the child. Used by the direct
+   * `handleRollout` path and by the post-self-bump boot resume — the two
+   * MUST stay behaviorally identical so a resumed roll is
+   * indistinguishable from a direct one downstream (audit, narration,
+   * get_status).
+   */
+  private launchRollout(
+    args: {
+      pin: string;
+      agents?: string[];
+      skip_web?: boolean;
+      allow_downgrade?: boolean;
+    },
+    request_id: string,
+    caller: SocketIdentity,
+    started: number,
+  ): StatusEntry {
+    const argv = ["rollout", "--pin", args.pin];
+    if (args.agents && args.agents.length > 0) {
+      argv.push("--agents", args.agents.join(","));
     }
-    if (req.args.skip_web) args.push("--skip-web");
-    if (req.args.allow_downgrade) args.push("--allow-downgrade");
+    if (args.skip_web) argv.push("--skip-web");
+    if (args.allow_downgrade) argv.push("--allow-downgrade");
 
     const installCtx = readCachedInstallType(
       this.opts.bindRoot ?? this.opts.homeDir,
@@ -1492,6 +1576,143 @@ export class HostdServer {
     }
 
     const entry: StatusEntry = {
+      request_id,
+      caller,
+      op: "rollout",
+      result: "started",
+      exit_code: null,
+      started_at: started,
+      finished_at: null,
+      stdout_tail: "",
+      stderr_tail: "",
+      pin: args.pin,
+      install_context: {
+        install_type: installCtx.install_type,
+        detected_at: installCtx.detected_at,
+      },
+      ...(priorPin ? { prior_pin: priorPin } : {}),
+    };
+    this.recordStatus(entry);
+    this.fleetMutationInFlight = {
+      op: "rollout",
+      request_id,
+      started_at: started,
+    };
+    this.spawnRollout(argv, entry);
+    return entry;
+  }
+
+  /** Daemon-view path of the hostd dir (compose file, marker, sockets). */
+  private hostdDirPath(): string {
+    return join(this.opts.homeDir, ".switchroom", "hostd");
+  }
+
+  /** HOST-view path of the hostd dir — what dockerd resolves bind sources
+   *  against. Inside the dockerized daemon `homeDir` is `/host-home`,
+   *  which is meaningless to dockerd; SWITCHROOM_HOST_HOME (baked into the
+   *  hostd compose env) carries the real host home. */
+  private hostdDirHostPath(): string {
+    const hostHome =
+      this.opts.hostHomeDir ??
+      process.env.SWITCHROOM_HOST_HOME?.trim() ??
+      this.opts.homeDir;
+    return join(hostHome, ".switchroom", "hostd");
+  }
+
+  /**
+   * #2645 item 1 — begin a hostd self-bump: tag-bump hostd's own compose
+   * to the roll's target, write the resume marker, and hand the recreate
+   * to a DETACHED SIBLING helper container. Answers `started`; the roll
+   * itself is relaunched by the NEW hostd's boot resume under the same
+   * request_id. Everything before the helper spawn is reversible; a
+   * failed spawn restores the compose + marker so nothing changed.
+   */
+  private async beginSelfBump(
+    req: Extract<HostdRequest, { op: "rollout" }>,
+    caller: SocketIdentity,
+    started: number,
+  ): Promise<HostdResponse> {
+    const ownVersion = this.opts.selfVersion ?? SWITCHROOM_VERSION;
+    const composePath = join(this.hostdDirPath(), "docker-compose.yml");
+    if (!existsSync(composePath)) {
+      return deniedResponse(
+        req.request_id,
+        `rollout: hostd's CLI (v${ownVersion}) is older than the target ` +
+          `${req.args.pin} and needs a self-bump first, but its compose file ` +
+          `is missing at ${composePath}. Run \`switchroom hostd install ` +
+          `--tag ${req.args.pin}\` on the host, then re-run the roll. ` +
+          `Nothing was changed.`,
+        Date.now() - started,
+      );
+    }
+    const before = readFileSync(composePath, "utf8");
+    const bumped = bumpHostdComposeImageTag(before, req.args.pin);
+    if (!bumped) {
+      return deniedResponse(
+        req.request_id,
+        `rollout: hostd needs a self-bump to ${req.args.pin} but no ` +
+          `switchroom-hostd image line was found in ${composePath} ` +
+          `(hand-edited compose?). Run \`switchroom hostd install --tag ` +
+          `${req.args.pin}\` on the host, then re-run the roll. Nothing ` +
+          `was changed.`,
+        Date.now() - started,
+      );
+    }
+
+    // Verify the target image is actually published BEFORE committing to
+    // anything — a roll fired minutes after a tag push can beat the
+    // docker-images workflow. Manifest inspect is a fast metadata round-trip
+    // (no layer download); a failure refuses cleanly with nothing changed.
+    const probe = await this.runDocker([
+      "manifest",
+      "inspect",
+      bumped.newImageRef,
+    ]);
+    if (probe.exit_code !== 0) {
+      return deniedResponse(
+        req.request_id,
+        `rollout: hostd needs a self-bump to ${req.args.pin} but the target ` +
+          `image ${bumped.newImageRef} is not pullable yet (docker manifest ` +
+          `inspect failed: ${tail(probe.stderr).trim() || "unknown error"}). ` +
+          `The docker-images workflow may still be building — retry in a ` +
+          `few minutes. Nothing was changed.`,
+        Date.now() - started,
+      );
+    }
+
+    // A stuck helper from a previous attempt holds the fixed name; remove
+    // it so the fresh spawn can't fail on a name conflict. Per-name rm -f
+    // of a container we own by construction (labeled switchroom.hostd-selfbump).
+    await this.runDocker(["rm", "-f", SELF_BUMP_HELPER_CONTAINER]).catch(
+      () => undefined,
+    );
+
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    const bakPath = `${composePath}.bak-selfbump-${ts}`;
+    const markerPath = join(this.hostdDirPath(), SELF_BUMP_MARKER_FILENAME);
+    const marker: PendingRolloutMarker = {
+      v: 1,
+      request_id: req.request_id,
+      pin: req.args.pin,
+      ...(req.args.agents && req.args.agents.length > 0
+        ? { agents: req.args.agents }
+        : {}),
+      ...(req.args.skip_web ? { skip_web: true } : {}),
+      ...(req.args.allow_downgrade ? { allow_downgrade: true } : {}),
+      caller:
+        caller.kind === "agent"
+          ? { kind: "agent", name: caller.name }
+          : { kind: "operator" },
+      created_at: new Date().toISOString(),
+      prior_hostd_version: ownVersion,
+    };
+    copyFileSync(composePath, bakPath);
+    writeFileSync(composePath, bumped.yaml, "utf8");
+    writeFileSync(markerPath, encodePendingRolloutMarker(marker), {
+      mode: 0o600,
+    });
+
+    const entry: StatusEntry = {
       request_id: req.request_id,
       caller,
       op: req.op,
@@ -1502,11 +1723,6 @@ export class HostdServer {
       stdout_tail: "",
       stderr_tail: "",
       pin: req.args.pin,
-      install_context: {
-        install_type: installCtx.install_type,
-        detected_at: installCtx.detected_at,
-      },
-      ...(priorPin ? { prior_pin: priorPin } : {}),
     };
     this.recordStatus(entry);
     this.fleetMutationInFlight = {
@@ -1514,14 +1730,197 @@ export class HostdServer {
       request_id: req.request_id,
       started_at: started,
     };
-    this.spawnRollout(args, entry);
+    // Durable phase row + narration: the operator sees "hostd refreshing
+    // itself" instead of a silent gap while the container recreates.
+    this.onRolloutPhase(entry, { phase: "self-bump", target: req.args.pin });
+
+    const rollbackBump = (): void => {
+      try {
+        copyFileSync(bakPath, composePath);
+        unlinkSync(markerPath);
+      } catch (e) {
+        process.stderr.write(
+          `hostd: self-bump rollback failed (compose/marker may need manual ` +
+            `restore from ${bakPath}): ${(e as Error).message}\n`,
+        );
+      }
+    };
+
+    const helper = await this.runDocker(
+      selfBumpHelperArgs({
+        hostdDirHostPath: this.hostdDirHostPath(),
+        image: bumped.newImageRef,
+      }),
+    ).catch((e) => ({
+      exit_code: -1,
+      stdout: "",
+      stderr: (e as Error).message,
+    }));
+    if (helper.exit_code !== 0) {
+      rollbackBump();
+      entry.result = "error";
+      entry.finished_at = Date.now();
+      entry.error = `self-bump helper spawn failed: ${tail(helper.stderr).trim()}`;
+      this.fleetMutationInFlight = null;
+      void this.writeTerminalAudit(entry);
+      return {
+        v: 1,
+        request_id: req.request_id,
+        result: "error",
+        exit_code: null,
+        duration_ms: Date.now() - started,
+        error:
+          `rollout: could not spawn the hostd self-bump helper container ` +
+          `(${tail(helper.stderr).trim() || "unknown error"}). The compose ` +
+          `bump was rolled back — nothing is changed. Fallback: ` +
+          `\`switchroom hostd install --tag ${req.args.pin}\` on the host, ` +
+          `then re-run the roll.`,
+      };
+    }
+
+    // Watch the helper from the OLD hostd. On success the helper recreates
+    // this very container, so the watcher usually dies before firing — by
+    // design. It only ever resolves meaningfully on FAILURE (pull error,
+    // compose error): we are still alive, the marker would otherwise sit
+    // until the staleness cutoff, and the caller would poll a perpetual
+    // `started`. Fail loudly instead: restore, clear, terminal row.
+    void this.runDocker(["wait", SELF_BUMP_HELPER_CONTAINER])
+      .then((w) => {
+        const code = Number.parseInt(w.stdout.trim(), 10);
+        if (w.exit_code === 0 && code === 0) return; // recreate imminent
+        rollbackBump();
+        entry.result = "error";
+        entry.finished_at = Date.now();
+        entry.error =
+          `self-bump helper failed (container exit ${Number.isFinite(code) ? code : "unknown"}). ` +
+          `See ${join(this.hostdDirHostPath(), SELF_BUMP_LOG_FILENAME)} on the host. ` +
+          `Compose bump rolled back. Fallback: \`switchroom hostd install ` +
+          `--tag ${req.args.pin}\` host-side, then re-run the roll.`;
+        if (
+          this.fleetMutationInFlight &&
+          this.fleetMutationInFlight.request_id === entry.request_id
+        ) {
+          this.fleetMutationInFlight = null;
+        }
+        void this.writeTerminalAudit(entry);
+        this.pushRolloutTerminal(entry);
+      })
+      .catch(() => undefined);
+
     return {
       v: 1,
       request_id: req.request_id,
       result: "started",
       exit_code: null,
       duration_ms: Date.now() - started,
+      payload: JSON.stringify({
+        phase: "self-bump",
+        pin: req.args.pin,
+        rolled: [],
+        note:
+          `hostd's CLI (v${ownVersion}) is older than ${req.args.pin}, so ` +
+          `hostd is refreshing itself first: its container restarts on the ` +
+          `target image (~30-60s blip on this socket), then the roll resumes ` +
+          `AUTOMATICALLY under this same request_id. Poll get_status with ` +
+          `this request_id after the blip; do NOT re-issue the rollout.`,
+      }),
     };
+  }
+
+  /**
+   * Boot-side of the self-bump (#2645): if the previous hostd process
+   * left a pending-rollout marker, relaunch that roll now — same
+   * request_id, so the audit chain, narration surface and get_status
+   * continue seamlessly. Single-shot: the marker is deleted before any
+   * validation so a crash-looping resume can't re-fire the roll forever.
+   * Runs BEFORE the sockets bind (no request can race the lock) and
+   * BEFORE the orphan sweep (a resumable roll isn't an orphan).
+   */
+  private async resumePendingSelfBumpRollout(): Promise<void> {
+    const markerPath = join(this.hostdDirPath(), SELF_BUMP_MARKER_FILENAME);
+    if (!existsSync(markerPath)) return;
+    let raw: string;
+    try {
+      raw = readFileSync(markerPath, "utf8");
+    } finally {
+      try {
+        unlinkSync(markerPath);
+      } catch {
+        // Unreadable AND undeletable — nothing safe to do; the orphan
+        // sweep will surface the stranded roll.
+      }
+    }
+    const marker = parsePendingRolloutMarker(raw!);
+    if (!marker) {
+      process.stderr.write(
+        `hostd: pending-rollout marker at ${markerPath} was malformed — ` +
+          `dropped without resuming. The originating roll will surface via ` +
+          `the orphan sweep.\n`,
+      );
+      return;
+    }
+    const caller: SocketIdentity =
+      marker.caller.kind === "agent"
+        ? { kind: "agent", name: marker.caller.name }
+        : { kind: "operator" };
+    const failResume = async (why: string): Promise<void> => {
+      const entry: StatusEntry = {
+        request_id: marker.request_id,
+        caller,
+        op: "rollout",
+        result: "error",
+        exit_code: null,
+        started_at: Date.parse(marker.created_at) || Date.now(),
+        finished_at: Date.now(),
+        stdout_tail: "",
+        stderr_tail: "",
+        pin: marker.pin,
+        failed_step: "self-bump",
+        error: why,
+      };
+      this.recordStatus(entry);
+      process.stderr.write(`hostd: self-bump resume failed: ${why}\n`);
+      await this.writeTerminalAudit(entry);
+      this.pushRolloutTerminal(entry);
+    };
+
+    const ownVersion = this.opts.selfVersion ?? SWITCHROOM_VERSION;
+    if (!isMarkerFresh(marker, Date.now())) {
+      await failResume(
+        `pending-rollout marker for ${marker.pin} (request_id ` +
+          `${marker.request_id}) was older than the resume cutoff — the ` +
+          `self-bump helper likely stalled. hostd is now on v${ownVersion}. ` +
+          `Re-issue the rollout to try again.`,
+      );
+      return;
+    }
+    if (needsSelfBump(ownVersion, marker.pin)) {
+      await failResume(
+        `hostd is still on v${ownVersion} after the self-bump to ` +
+          `${marker.pin} (helper failed? see ` +
+          `${join(this.hostdDirHostPath(), SELF_BUMP_LOG_FILENAME)}). ` +
+          `Fallback: \`switchroom hostd install --tag ${marker.pin}\` ` +
+          `host-side, then re-issue the rollout.`,
+      );
+      return;
+    }
+
+    process.stderr.write(
+      `hostd: resuming rollout ${marker.request_id} → ${marker.pin} after ` +
+        `self-bump (v${marker.prior_hostd_version} → v${ownVersion})\n`,
+    );
+    const entry = this.launchRollout(
+      {
+        pin: marker.pin,
+        ...(marker.agents ? { agents: marker.agents } : {}),
+        ...(marker.skip_web ? { skip_web: true } : {}),
+        ...(marker.allow_downgrade ? { allow_downgrade: true } : {}),
+      },
+      marker.request_id,
+      caller,
+      Date.now(),
+    );
+    this.onRolloutPhase(entry, { phase: "self-bump-done", target: marker.pin });
   }
 
   /** Synchronous: `switchroom agent start <name>` — fast (~1-2s for

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -1689,6 +1689,18 @@ export class HostdServer {
 
     const ts = new Date().toISOString().replace(/[:.]/g, "-");
     const bakPath = `${composePath}.bak-selfbump-${ts}`;
+    // Prune old self-bump backups (keep the newest few) — one accrues per
+    // release rolled, and the hostd dir already drowned in compose baks once.
+    try {
+      const baks = readdirSync(this.hostdDirPath())
+        .filter((f) => f.startsWith("docker-compose.yml.bak-selfbump-"))
+        .sort();
+      for (const f of baks.slice(0, Math.max(0, baks.length - 4))) {
+        unlinkSync(join(this.hostdDirPath(), f));
+      }
+    } catch {
+      // best-effort housekeeping
+    }
     const markerPath = join(this.hostdDirPath(), SELF_BUMP_MARKER_FILENAME);
     const marker: PendingRolloutMarker = {
       v: 1,
@@ -1749,7 +1761,14 @@ export class HostdServer {
     const helper = await this.runDocker(
       selfBumpHelperArgs({
         hostdDirHostPath: this.hostdDirHostPath(),
-        image: bumped.newImageRef,
+        // Run the helper on the OLD (currently-running, guaranteed-local)
+        // image so `docker run -d` returns immediately — the target image
+        // is fetched by the helper's own `compose pull`, async to this
+        // request. Running the target here would synchronously pull a
+        // multi-GB image inside this await and blow the caller's wire
+        // timeout before the `started` response lands.
+        helperImage: bumped.oldImageRef,
+        targetImage: bumped.newImageRef,
       }),
     ).catch((e) => ({
       exit_code: -1,
@@ -1787,7 +1806,21 @@ export class HostdServer {
     void this.runDocker(["wait", SELF_BUMP_HELPER_CONTAINER])
       .then((w) => {
         const code = Number.parseInt(w.stdout.trim(), 10);
-        if (w.exit_code === 0 && code === 0) return; // recreate imminent
+        if (w.exit_code !== 0 || !Number.isFinite(code)) {
+          // `docker wait` ITSELF failed (daemon hiccup, or the container
+          // was already auto-removed after a success we raced). Do NOT
+          // roll back on ambiguity: on a successful bump this container
+          // is about to be recreated, and a spurious compose restore
+          // would drift the on-disk tag below the running version. The
+          // marker staleness cutoff + the still-stale resume check are
+          // the backstop for a genuinely failed bump we couldn't observe.
+          process.stderr.write(
+            `hostd: self-bump watcher could not read the helper's exit ` +
+              `code (docker wait rc=${w.exit_code}): ${tail(w.stderr).trim()}\n`,
+          );
+          return;
+        }
+        if (code === 0) return; // bump succeeded — recreate imminent
         rollbackBump();
         entry.result = "error";
         entry.finished_at = Date.now();

--- a/src/mcp/hostd/server.ts
+++ b/src/mcp/hostd/server.ts
@@ -349,9 +349,15 @@ export const TOOLS = [
       "persisted only AFTER the canary confirms (a failed canary never " +
       "strands a bad pin). `pin` MUST be a tagged semver (vX.Y.Z) — sha " +
       "pins are rejected because the version assert needs a semver to " +
-      "compare against. The hostd/web self-refresh is DEFERRED on this path " +
-      "(an agent-invoked rollout cannot recreate its own hostd container " +
-      "without killing itself); run that host-side. By default downgrade pins " +
+      "compare against. When the target pin is NEWER than hostd's own CLI " +
+      "(every freshly tagged release), hostd SELF-BUMPS first (#2645): its " +
+      "container restarts on the target image (~30-60s blip on this MCP " +
+      "socket), then the roll resumes AUTOMATICALLY under the SAME " +
+      "request_id — do NOT re-issue the rollout during the blip; poll " +
+      "get_status with the returned request_id once the socket is back. " +
+      "The web refresh stays DEFERRED on this path; the terminal warnings " +
+      "name exactly what is still on the prior version (web, host operator " +
+      "CLI) and the host-side commands to finish. By default downgrade pins " +
       "are rejected — pass `allow_downgrade: true` for the operator-approved " +
       "rollback path to a known-good earlier tag; all other safety rails " +
       "(canary order, version-assert, stop-on-mismatch) apply unchanged. " +

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -5,12 +5,18 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, chmodSync, rmSync, mkdirSync, statSync, appendFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync, mkdirSync, statSync, appendFileSync, readFileSync, existsSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
 import { HostdServer } from "../../src/host-control/server.js";
 import { hostdRequest } from "../../src/host-control/client.js";
+import {
+  parsePendingRolloutMarker,
+  encodePendingRolloutMarker,
+  SELF_BUMP_MARKER_FILENAME,
+  type PendingRolloutMarker,
+} from "../../src/host-control/self-bump.js";
 
 let tmp: string;
 let server: HostdServer;
@@ -2527,5 +2533,406 @@ describe("hostd server — rollout narrator feed (#2726 Part 2)", () => {
     expect(poll.result).toBe("completed");
 
     rmSync(execTmp, { recursive: true, force: true });
+  });
+});
+
+// ── #2645 — hostd self-bump on stale-CLI rollout ─────────────────────────────
+describe("hostd self-bump (#2645)", () => {
+  const composeSeed = [
+    "services:",
+    "  hostd:",
+    "    image: ghcr.io/switchroom/switchroom-hostd:v0.16.0",
+    "    volumes:",
+    "      - /var/run/docker.sock:/var/run/docker.sock",
+    "",
+  ].join("\n");
+
+  const hostdDir = () => join(tmp, ".switchroom", "hostd");
+  const composePath = () => join(hostdDir(), "docker-compose.yml");
+  const markerPath = () => join(hostdDir(), SELF_BUMP_MARKER_FILENAME);
+
+  /** Recording docker stub: appends argv to `rec`; behavior per-verb via
+   *  the baked-in exit codes. */
+  function writeDockerStub(opts: {
+    rec: string;
+    manifestExit?: number;
+    runExit?: number;
+    waitCode?: number;
+  }): string {
+    const p = join(tmp, `docker-stub-${createHash("sha1").update(opts.rec).digest("hex").slice(0, 8)}.sh`);
+    writeFileSync(
+      p,
+      `#!/bin/sh\n` +
+        `echo "docker: $@" >> "${opts.rec}"\n` +
+        `case "$1" in\n` +
+        `  manifest) exit ${opts.manifestExit ?? 0} ;;\n` +
+        `  rm) exit 0 ;;\n` +
+        `  run) echo cid; exit ${opts.runExit ?? 0} ;;\n` +
+        `  wait) echo ${opts.waitCode ?? 0}; exit 0 ;;\n` +
+        `esac\n` +
+        `exit 0\n`,
+    );
+    chmodSync(p, 0o755);
+    return p;
+  }
+
+  afterEach(() => {
+    // Test 1 deliberately leaves a marker (prod deletes it at resume);
+    // scrub it so the NEXT test's beforeEach server.start() can't resume
+    // a stale roll against the default stub. Same for compose + baks.
+    rmSync(markerPath(), { force: true });
+    rmSync(composePath(), { force: true });
+    for (const f of readdirSync(hostdDir())) {
+      if (f.startsWith("docker-compose.yml.bak-selfbump-")) {
+        rmSync(join(hostdDir(), f), { force: true });
+      }
+    }
+  });
+
+  it("a pin newer than hostd's CLI begins a self-bump: tag-bump + marker + detached helper, answers started", async () => {
+    writeFileSync(composePath(), composeSeed);
+    const dockerRec = join(tmp, "selfbump-docker-1.txt");
+    const cliRec = join(tmp, "selfbump-cli-1.txt");
+    const cliStub = join(tmp, "selfbump-cli-stub-1.sh");
+    writeFileSync(cliStub, `#!/bin/sh\necho "argv: $@" >> "${cliRec}"\nexit 0\n`);
+    chmodSync(cliStub, 0o755);
+
+    await server.stop();
+    server = new HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: cliStub,
+      dockerBin: writeDockerStub({ rec: dockerRec }),
+      auditLogPath: join(tmp, "audit-selfbump-1.log"),
+      allowNonLinux: true,
+      selfVersion: "0.16.0",
+      hostHomeDir: "/host/op",
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "rollout",
+        request_id: "ro-sb-1",
+        args: { pin: "v0.16.5", agents: ["test-harness", "klanker"], skip_web: true },
+      },
+    );
+    expect(resp.result).toBe("started");
+    const payload = JSON.parse(resp.payload!);
+    expect(payload.phase).toBe("self-bump");
+    expect(payload.note).toContain("resumes");
+    expect(payload.note).toContain("do NOT re-issue");
+
+    // Compose tag-bumped in place, backup written.
+    expect(readFileSync(composePath(), "utf8")).toContain(
+      "image: ghcr.io/switchroom/switchroom-hostd:v0.16.5",
+    );
+    expect(
+      readdirSync(hostdDir()).some((f) =>
+        f.startsWith("docker-compose.yml.bak-selfbump-"),
+      ),
+    ).toBe(true);
+
+    // Marker carries everything the new hostd needs to resume.
+    const marker = parsePendingRolloutMarker(readFileSync(markerPath(), "utf8"));
+    expect(marker).toMatchObject({
+      request_id: "ro-sb-1",
+      pin: "v0.16.5",
+      agents: ["test-harness", "klanker"],
+      skip_web: true,
+      caller: { kind: "agent", name: "klanker" },
+      prior_hostd_version: "0.16.0",
+    });
+
+    // Helper spawned detached with the target image + host-path mounts;
+    // target image existence probed first.
+    const dockerCalls = readFileSync(dockerRec, "utf8");
+    expect(dockerCalls).toContain(
+      "manifest inspect ghcr.io/switchroom/switchroom-hostd:v0.16.5",
+    );
+    expect(dockerCalls).toContain("run -d --rm --name switchroom-hostd-selfbump");
+    expect(dockerCalls).toContain(
+      "-v /host/op/.switchroom/hostd:/host/op/.switchroom/hostd",
+    );
+    // The rollout CLI child was NOT spawned — the roll resumes post-recreate.
+    expect(existsSync(cliRec)).toBe(false);
+
+    // Durable self-bump phase row under the SAME request_id.
+    const rows = readFileSync(join(tmp, "audit-selfbump-1.log"), "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    expect(
+      rows.some(
+        (r) =>
+          r.op === "rollout" && r.phase === "self-bump" && r.request_id === "ro-sb-1",
+      ),
+    ).toBe(true);
+
+    // Fleet-mutation lock held through the blip: a second roll is denied.
+    const second = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "rollout", request_id: "ro-sb-1b", args: { pin: "v0.16.5" } },
+    );
+    expect(second.result).toBe("denied");
+    expect(second.error).toContain("fleet-mutation lock");
+  });
+
+  it("refuses cleanly (nothing changed) when the target image is not pullable yet", async () => {
+    writeFileSync(composePath(), composeSeed);
+    const dockerRec = join(tmp, "selfbump-docker-2.txt");
+    await server.stop();
+    server = new HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001 },
+      config: { agents: { klanker: { admin: true } } },
+      switchroomBin: stubBin,
+      dockerBin: writeDockerStub({ rec: dockerRec, manifestExit: 1 }),
+      auditLogPath: join(tmp, "audit-selfbump-2.log"),
+      allowNonLinux: true,
+      selfVersion: "0.16.0",
+      hostHomeDir: "/host/op",
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "rollout", request_id: "ro-sb-2", args: { pin: "v0.16.5" } },
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toContain("not pullable");
+    // Nothing changed: compose still on the old tag, no marker.
+    expect(readFileSync(composePath(), "utf8")).toContain("v0.16.0");
+    expect(existsSync(markerPath())).toBe(false);
+  });
+
+  it("rolls the bump back when the helper container fails to spawn", async () => {
+    writeFileSync(composePath(), composeSeed);
+    const dockerRec = join(tmp, "selfbump-docker-3.txt");
+    await server.stop();
+    server = new HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001 },
+      config: { agents: { klanker: { admin: true } } },
+      switchroomBin: stubBin,
+      dockerBin: writeDockerStub({ rec: dockerRec, runExit: 1 }),
+      auditLogPath: join(tmp, "audit-selfbump-3.log"),
+      allowNonLinux: true,
+      selfVersion: "0.16.0",
+      hostHomeDir: "/host/op",
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "rollout", request_id: "ro-sb-3", args: { pin: "v0.16.5" } },
+    );
+    expect(resp.result).toBe("error");
+    expect(resp.error).toContain("self-bump helper");
+    // Rolled back: compose restored, marker removed.
+    expect(readFileSync(composePath(), "utf8")).toContain("v0.16.0");
+    expect(existsSync(markerPath())).toBe(false);
+    // Terminal error row landed for the request.
+    const rows = readFileSync(join(tmp, "audit-selfbump-3.log"), "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    const terminal = rows.find(
+      (r) => r.request_id === "ro-sb-3" && r.phase === "terminal",
+    );
+    expect(terminal).toBeDefined();
+    expect(terminal!.result).toBe("error");
+    // Lock released — a follow-up roll isn't lock-denied.
+    const retry = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "rollout", request_id: "ro-sb-3b", args: { pin: "v0.16.5" } },
+    );
+    expect(retry.error ?? "").not.toContain("fleet-mutation lock");
+  });
+
+  it("boot resume relaunches the roll under the SAME request_id and deletes the marker", async () => {
+    const cliRec = join(tmp, "selfbump-cli-4.txt");
+    const cliStub = join(tmp, "selfbump-cli-stub-4.sh");
+    writeFileSync(
+      cliStub,
+      `#!/bin/sh\n` +
+        `echo "argv: $@" >> "${cliRec}"\n` +
+        `echo "ctx: $SWITCHROOM_HOSTD_CONTEXT" >> "${cliRec}"\n` +
+        `echo 'SWITCHROOM_ROLLOUT_RESULT:{"ok":true,"rolled":["test-harness","klanker"],"warnings":[]}'\n` +
+        `exit 0\n`,
+    );
+    chmodSync(cliStub, 0o755);
+    const marker: PendingRolloutMarker = {
+      v: 1,
+      request_id: "ro-sb-resume",
+      pin: "v0.16.5",
+      agents: ["test-harness", "klanker"],
+      skip_web: true,
+      caller: { kind: "agent", name: "klanker" },
+      created_at: new Date().toISOString(),
+      prior_hostd_version: "0.16.0",
+    };
+    writeFileSync(markerPath(), encodePendingRolloutMarker(marker));
+
+    await server.stop();
+    server = new HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001 },
+      config: { agents: { klanker: { admin: true } } },
+      switchroomBin: cliStub,
+      auditLogPath: join(tmp, "audit-selfbump-4.log"),
+      allowNonLinux: true,
+      selfVersion: "0.16.5", // now ON the target — resume proceeds
+      hostHomeDir: "/host/op",
+    });
+    await server.start();
+    await new Promise((r) => setTimeout(r, 400));
+
+    // Marker consumed; roll relaunched with the marker's exact args.
+    expect(existsSync(markerPath())).toBe(false);
+    const rec = readFileSync(cliRec, "utf8");
+    expect(rec).toContain(
+      "argv: rollout --pin v0.16.5 --agents test-harness,klanker --skip-web",
+    );
+    expect(rec).toContain("ctx: 1");
+
+    const rows = readFileSync(join(tmp, "audit-selfbump-4.log"), "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    expect(
+      rows.some(
+        (r) =>
+          r.op === "rollout" &&
+          r.phase === "self-bump-done" &&
+          r.request_id === "ro-sb-resume",
+      ),
+    ).toBe(true);
+    const terminal = rows.find(
+      (r) => r.request_id === "ro-sb-resume" && r.phase === "terminal",
+    );
+    expect(terminal).toBeDefined();
+    expect(terminal!.result).toBe("completed");
+    expect(terminal!.rolled).toEqual(["test-harness", "klanker"]);
+    // Caller identity survived the recreate (drives get_status gating + DM push).
+    expect(terminal!.caller).toEqual({ kind: "agent", name: "klanker" });
+  });
+
+  it("boot resume with a STALE marker terminal-errors without spawning", async () => {
+    const cliRec = join(tmp, "selfbump-cli-5.txt");
+    const cliStub = join(tmp, "selfbump-cli-stub-5.sh");
+    writeFileSync(cliStub, `#!/bin/sh\necho "argv: $@" >> "${cliRec}"\nexit 0\n`);
+    chmodSync(cliStub, 0o755);
+    const marker: PendingRolloutMarker = {
+      v: 1,
+      request_id: "ro-sb-stale",
+      pin: "v0.16.5",
+      caller: { kind: "agent", name: "klanker" },
+      created_at: new Date(Date.now() - 20 * 60 * 1000).toISOString(),
+      prior_hostd_version: "0.16.0",
+    };
+    writeFileSync(markerPath(), encodePendingRolloutMarker(marker));
+
+    await server.stop();
+    server = new HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001 },
+      config: { agents: { klanker: { admin: true } } },
+      switchroomBin: cliStub,
+      auditLogPath: join(tmp, "audit-selfbump-5.log"),
+      allowNonLinux: true,
+      selfVersion: "0.16.5",
+      hostHomeDir: "/host/op",
+    });
+    await server.start();
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(existsSync(markerPath())).toBe(false);
+    expect(existsSync(cliRec)).toBe(false); // no roll spawned
+    const rows = readFileSync(join(tmp, "audit-selfbump-5.log"), "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    const terminal = rows.find(
+      (r) => r.request_id === "ro-sb-stale" && r.phase === "terminal",
+    );
+    expect(terminal).toBeDefined();
+    expect(terminal!.result).toBe("error");
+    expect(terminal!.failed_step).toBe("self-bump");
+  });
+
+  it("boot resume terminal-errors when hostd is STILL older than the pin (helper failed)", async () => {
+    const cliRec = join(tmp, "selfbump-cli-6.txt");
+    const cliStub = join(tmp, "selfbump-cli-stub-6.sh");
+    writeFileSync(cliStub, `#!/bin/sh\necho "argv: $@" >> "${cliRec}"\nexit 0\n`);
+    chmodSync(cliStub, 0o755);
+    const marker: PendingRolloutMarker = {
+      v: 1,
+      request_id: "ro-sb-stillstale",
+      pin: "v0.16.5",
+      caller: { kind: "agent", name: "klanker" },
+      created_at: new Date().toISOString(),
+      prior_hostd_version: "0.16.0",
+    };
+    writeFileSync(markerPath(), encodePendingRolloutMarker(marker));
+
+    await server.stop();
+    server = new HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001 },
+      config: { agents: { klanker: { admin: true } } },
+      switchroomBin: cliStub,
+      auditLogPath: join(tmp, "audit-selfbump-6.log"),
+      allowNonLinux: true,
+      selfVersion: "0.16.0", // STILL stale — bump never landed
+      hostHomeDir: "/host/op",
+    });
+    await server.start();
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(existsSync(markerPath())).toBe(false);
+    expect(existsSync(cliRec)).toBe(false);
+    const rows = readFileSync(join(tmp, "audit-selfbump-6.log"), "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    const terminal = rows.find(
+      (r) => r.request_id === "ro-sb-stillstale" && r.phase === "terminal",
+    );
+    expect(terminal).toBeDefined();
+    expect(terminal!.result).toBe("error");
+    expect(String(terminal!.error)).toContain("hostd install");
+  });
+
+  it("a malformed marker is dropped without resuming (and without crashing boot)", async () => {
+    const cliRec = join(tmp, "selfbump-cli-7.txt");
+    const cliStub = join(tmp, "selfbump-cli-stub-7.sh");
+    writeFileSync(cliStub, `#!/bin/sh\necho "argv: $@" >> "${cliRec}"\nexit 0\n`);
+    chmodSync(cliStub, 0o755);
+    writeFileSync(markerPath(), "{not json");
+
+    await server.stop();
+    server = new HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001 },
+      config: { agents: { klanker: { admin: true } } },
+      switchroomBin: cliStub,
+      auditLogPath: join(tmp, "audit-selfbump-7.log"),
+      allowNonLinux: true,
+      selfVersion: "0.16.5",
+      hostHomeDir: "/host/op",
+    });
+    await server.start();
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(existsSync(markerPath())).toBe(false);
+    expect(existsSync(cliRec)).toBe(false);
+    expect(server.getBoundPaths().length).toBe(1); // boot completed normally
   });
 });

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -2648,8 +2648,8 @@ describe("hostd self-bump (#2645)", () => {
       prior_hostd_version: "0.16.0",
     });
 
-    // Helper spawned detached with the target image + host-path mounts;
-    // target image existence probed first.
+    // Helper spawned detached with host-path mounts; target image
+    // existence probed first.
     const dockerCalls = readFileSync(dockerRec, "utf8");
     expect(dockerCalls).toContain(
       "manifest inspect ghcr.io/switchroom/switchroom-hostd:v0.16.5",
@@ -2657,6 +2657,14 @@ describe("hostd self-bump (#2645)", () => {
     expect(dockerCalls).toContain("run -d --rm --name switchroom-hostd-selfbump");
     expect(dockerCalls).toContain(
       "-v /host/op/.switchroom/hostd:/host/op/.switchroom/hostd",
+    );
+    // The helper runs from the OLD (guaranteed-local) image so `run -d`
+    // returns fast; the target is only fetched by its `compose pull`.
+    const runLine = dockerCalls
+      .split("\n")
+      .find((l) => l.includes("run -d --rm"))!;
+    expect(runLine).toContain(
+      "/bin/sh ghcr.io/switchroom/switchroom-hostd:v0.16.0 -c",
     );
     // The rollout CLI child was NOT spawned — the roll resumes post-recreate.
     expect(existsSync(cliRec)).toBe(false);
@@ -2752,6 +2760,60 @@ describe("hostd self-bump (#2645)", () => {
     const retry = await hostdRequest(
       { socketPath: sock },
       { v: 1, op: "rollout", request_id: "ro-sb-3b", args: { pin: "v0.16.5" } },
+    );
+    expect(retry.error ?? "").not.toContain("fleet-mutation lock");
+  });
+
+  it("watcher rolls the bump back when the HELPER (pull/up) fails after spawning", async () => {
+    // The helper spawns fine but its pull/compose script fails — the
+    // container exits nonzero (the script PROPAGATES the failure; a
+    // trailing bare echo would mask it as 0), `docker wait` reports it,
+    // and the still-alive old hostd restores the compose, deletes the
+    // marker, releases the lock and writes a loud terminal row instead of
+    // leaving the caller polling a perpetual `started`.
+    writeFileSync(composePath(), composeSeed);
+    const dockerRec = join(tmp, "selfbump-docker-3w.txt");
+    await server.stop();
+    server = new HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001 },
+      config: { agents: { klanker: { admin: true } } },
+      switchroomBin: stubBin,
+      dockerBin: writeDockerStub({ rec: dockerRec, waitCode: 1 }),
+      auditLogPath: join(tmp, "audit-selfbump-3w.log"),
+      allowNonLinux: true,
+      selfVersion: "0.16.0",
+      hostHomeDir: "/host/op",
+    });
+    await server.start();
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "rollout", request_id: "ro-sb-3w", args: { pin: "v0.16.5" } },
+    );
+    // The spawn itself succeeded, so the caller still gets `started`…
+    expect(resp.result).toBe("started");
+    await new Promise((r) => setTimeout(r, 400));
+
+    // …but the watcher then observed the failure and rolled everything back.
+    expect(readFileSync(composePath(), "utf8")).toContain("v0.16.0");
+    expect(readFileSync(composePath(), "utf8")).not.toContain("v0.16.5");
+    expect(existsSync(markerPath())).toBe(false);
+    const rows = readFileSync(join(tmp, "audit-selfbump-3w.log"), "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    const terminal = rows.find(
+      (r) => r.request_id === "ro-sb-3w" && r.phase === "terminal",
+    );
+    expect(terminal).toBeDefined();
+    expect(terminal!.result).toBe("error");
+    expect(String(terminal!.error)).toContain("helper failed");
+    // Lock released — a follow-up roll isn't lock-denied.
+    const retry = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "rollout", request_id: "ro-sb-3wb", args: { pin: "v0.16.5" } },
     );
     expect(retry.error ?? "").not.toContain("fleet-mutation lock");
   });


### PR DESCRIPTION
## Summary

Fixes the structural blocker that made every **agent-invoked rollout to a freshly released version fail by construction**: hostd's CLI is baked into its image, so it's always one release behind a new tag, and the `preflight-stale-cli` guard (#2542) refused the roll with a **host-shell-only** remedy (`switchroom hostd install --tag …`). The root agent (overlord) could never roll a release by itself — the audit log shows the refusals (Jul 4 09:25 overlord, Jul 5 03:52 klanker), and the `docker-compose.yml.bak-directroll-*` trail shows agents hand-editing hostd's compose as a workaround.

Implements the open design in #2645 (item 1 + item 3).

## How it works

When a `rollout` request's pin is newer than hostd's own CLI, instead of refusing hostd now:

1. **Probes** the target hostd image (`docker manifest inspect`) — clean refusal, nothing changed, when the docker-images workflow hasn't published the tag yet.
2. **Tag-bumps its own compose in place** (backup kept). Deliberately NOT a full `hostd install` regen: in-container regen gets host-side facts wrong (host tz, operator uid via SUDO_UID, skills symlink target — each a past incident class). Template regen stays host-side and is named in the warnings.
3. **Writes a single-shot resume marker** and spawns a **detached sibling helper** (`docker run -d --rm`, mounts only docker.sock + the hostd dir at identical host paths) that pulls + `compose up -d`s the hostd project. A sibling survives the recreate that would SIGKILL an in-container driver (brick scenario #1 / #2458 / #2460).
4. **The NEW hostd resumes the roll at boot** under the **same request_id** (before socket bind + before the orphan sweep) — audit hash-chain, in-chat narration (`self-bump` / `self-bump-done` phases) and `get_status` continue seamlessly.

Failure containment: marker is shape-validated, 15-min staleness-capped, deleted before validation (no crashloop refire); a helper that fails while old hostd is still alive is caught by a `docker wait` watcher that rolls the compose bump back and writes a loud terminal row; a resume that's still stale terminal-errors pointing at the host-side fallback. The CLI-side refusal stays as backstop.

Item 3: the hostd-path deferral warning now names exactly what's still on the prior version (web dashboard, host operator CLI) with the host-side finish commands.

## Why

Serves `reference/vision.md` outcome 4 (always available — runs its own lifecycle) and the `/update`-from-Telegram job family; no invariant crossed (no model call, no privilege escalation — rollout stays admin-gated + operator-approval-carded; the marker is written only by hostd itself post-approval, in a root-owned dir agents cannot write).

## Test plan

- [x] `src/host-control/self-bump.test.ts` — 23 pure tests: version guard, compose tag-bump (incl. fork registries, non-hostd images untouched), marker round-trip + 10 malformed-marker rejections, staleness cutoff, helper argv shape (detached/labeled/minimal mounts/pull-before-up).
- [x] `tests/host-control/server.test.ts` — 7 integration tests over a real UDS server with stubbed docker/switchroom binaries: begin-bump happy path (compose bumped, marker content, helper argv, no child spawn, phase row, lock held), unpullable-image clean refusal, helper-spawn-failure rollback + terminal row + lock release, boot resume (same request_id, exact argv, marker consumed, terminal row + caller identity), stale-marker and still-stale-version terminal errors without spawn, malformed-marker drop without crashing boot.
- [x] Full `tests/host-control/server.test.ts` (89) + rollout/narrator/observability/MCP suites (137) green; `tsc --noEmit` clean.

## Risk

Medium — touches the fleet-roll control path, but: the new branch only triggers when it would previously have hard-refused (strictly-older semver), the direct-roll path is a pure refactor (`launchRollout` extraction), and every failure path lands a terminal audit row + restores prior state. Backstop guard unchanged.

Closes #2645.

🤖 Generated with [Claude Code](https://claude.com/claude-code)