### PR TITLE
feat(litellm): Claude via /anthropic pass-through (fix mid-stream stall)

### DIFF
--- a/profiles/_base/cron-session.sh.hbs
+++ b/profiles/_base/cron-session.sh.hbs
@@ -101,8 +101,8 @@ if [ -n "$SWITCHROOM_LITELLM" ] && command -v switchroom >/dev/null 2>&1; then
   if [ -z "$sr_ll_key" ]; then
     echo "litellm: no virtual key for cron '{{name}}' — falling back to direct OAuth (no tracking/guardrail)" >&2
   elif command -v curl >/dev/null 2>&1 && [ -n "$ANTHROPIC_BASE_URL" ] \
-       && ! curl -fsS -m 5 -o /dev/null "${ANTHROPIC_BASE_URL%/}/health/liveliness" 2>/dev/null; then
-    echo "litellm: proxy unreachable at $ANTHROPIC_BASE_URL — falling back to direct OAuth (no tracking/guardrail this session)" >&2
+       && ! curl -fsS -m 5 -o /dev/null "${SWITCHROOM_LITELLM_BASE:-${ANTHROPIC_BASE_URL%/anthropic}}/health/liveliness" 2>/dev/null; then
+    echo "litellm: proxy unreachable at ${SWITCHROOM_LITELLM_BASE:-$ANTHROPIC_BASE_URL} — falling back to direct OAuth (no tracking/guardrail this session)" >&2
   else
     sr_ll_ok="1"
   fi
@@ -114,7 +114,7 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
   else
     # Fail-open: drop every routing var so the claude CLI talks to Anthropic
     # directly on its OAuth credential (subscription path), unproxied.
-    unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM
+    unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM SWITCHROOM_LITELLM_BASE
   fi
   unset sr_ll_key sr_ll_ok
 fi

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -70,8 +70,8 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
     if [ -z "$sr_ll_key" ]; then
       echo "litellm(outer): no virtual key for agent '$SWITCHROOM_AGENT_NAME' — gateway will use direct OAuth (no tracking/guardrail)" >&2
     elif command -v curl >/dev/null 2>&1 && [ -n "$ANTHROPIC_BASE_URL" ] \
-         && ! curl -fsS -m 5 -o /dev/null "${ANTHROPIC_BASE_URL%/}/health/liveliness" 2>/dev/null; then
-      echo "litellm(outer): proxy unreachable at $ANTHROPIC_BASE_URL — falling back to direct OAuth (no tracking/guardrail this session)" >&2
+         && ! curl -fsS -m 5 -o /dev/null "${SWITCHROOM_LITELLM_BASE:-${ANTHROPIC_BASE_URL%/anthropic}}/health/liveliness" 2>/dev/null; then
+      echo "litellm(outer): proxy unreachable at ${SWITCHROOM_LITELLM_BASE:-$ANTHROPIC_BASE_URL} — falling back to direct OAuth (no tracking/guardrail this session)" >&2
     else
       sr_ll_ok="1"
     fi
@@ -81,7 +81,7 @@ x-litellm-customer-id: $SWITCHROOM_AGENT_NAME
 x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:-default}"
       export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
     else
-      unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM
+      unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM SWITCHROOM_LITELLM_BASE
     fi
     unset sr_ll_key sr_ll_ok
   fi
@@ -839,8 +839,8 @@ if [ -n "$SWITCHROOM_LITELLM" ] && command -v switchroom >/dev/null 2>&1; then
   if [ -z "$sr_ll_key" ]; then
     echo "litellm: no virtual key for agent '$SWITCHROOM_AGENT_NAME' — falling back to direct OAuth (no tracking/guardrail)" >&2
   elif command -v curl >/dev/null 2>&1 && [ -n "$ANTHROPIC_BASE_URL" ] \
-       && ! curl -fsS -m 5 -o /dev/null "${ANTHROPIC_BASE_URL%/}/health/liveliness" 2>/dev/null; then
-    echo "litellm: proxy unreachable at $ANTHROPIC_BASE_URL — falling back to direct OAuth (no tracking/guardrail this session)" >&2
+       && ! curl -fsS -m 5 -o /dev/null "${SWITCHROOM_LITELLM_BASE:-${ANTHROPIC_BASE_URL%/anthropic}}/health/liveliness" 2>/dev/null; then
+    echo "litellm: proxy unreachable at ${SWITCHROOM_LITELLM_BASE:-$ANTHROPIC_BASE_URL} — falling back to direct OAuth (no tracking/guardrail this session)" >&2
   else
     sr_ll_ok="1"
   fi
@@ -861,7 +861,7 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
   else
     # Fail-open: drop every routing var so the claude CLI talks to Anthropic
     # directly on its OAuth credential (subscription path), unproxied.
-    unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM
+    unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM SWITCHROOM_LITELLM_BASE
   fi
   unset sr_ll_key sr_ll_ok
 fi

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -2162,17 +2162,31 @@ function emitAgentService(
   // ANTHROPIC_BASE_URL without a key makes every claude call hit the proxy
   // unauthenticated — a silently-broken agent. So a failed/absent provision
   // ⇒ no routing env ⇒ the agent keeps the normal broker-OAuth Anthropic
-  // path (degraded-but-working) rather than a dead proxy path. When both
-  // gates pass: ANTHROPIC_BASE_URL → proxy, ANTHROPIC_SMALL_FAST_MODEL pins
-  // the fast lane, SWITCHROOM_LITELLM=1 tells start.sh to fetch the key from
-  // the vault and export it as the x-litellm-api-key Bearer (the SECRET is
-  // NEVER emitted here — only the marker). Set BEFORE the userEnv merge so
-  // these system-managed keys are authoritative (the merge only fills env[k]
-  // when undefined). base_url is required for the marker to be useful; only
-  // emit the trio when it resolved.
+  // path (degraded-but-working) rather than a dead proxy path.
+  //
+  // ANTHROPIC_BASE_URL points the `claude` CLI at LiteLLM's **Anthropic
+  // pass-through** endpoint (`<root>/anthropic`), NOT the model-mapped
+  // `/v1/messages` route. The pass-through raw-forwards the request and
+  // streams the upstream SSE bytes natively; the model-mapped route
+  // translate→ChatCompletion→re-emit→re-chunks the stream, which stalls
+  // long opus responses mid-flight ("API Error: Response stalled
+  // mid-stream" — the 2026-07-05 marko incident). claude appends
+  // `/v1/messages`, so `<root>/anthropic` → `<root>/anthropic/v1/messages`,
+  // exactly the pass-through path. OAuth still rides in Authorization
+  // (forwarded upstream unchanged); the virtual key rides in the
+  // x-litellm-api-key header start.sh exports — that split is what keeps
+  // this subscription-native. SWITCHROOM_LITELLM_BASE keeps the ROOT proxy
+  // URL for the two consumers that need the model-mapped/admin surface, NOT
+  // the pass-through: start.sh's `/health/liveliness` probe and the
+  // gateway's `/model/info` non-Claude (sr-*) model discovery. Set BEFORE
+  // the userEnv merge so these system-managed keys are authoritative (the
+  // merge only fills env[k] when undefined). base_url is required for the
+  // markers to be useful; only emit the set when it resolved.
   if (a.litellm.enabled && a.litellm.keyConfirmed && a.litellm.baseUrl) {
+    const root = a.litellm.baseUrl.replace(/\/+$/, "");
     env.SWITCHROOM_LITELLM = "1";
-    env.ANTHROPIC_BASE_URL = a.litellm.baseUrl;
+    env.SWITCHROOM_LITELLM_BASE = root;
+    env.ANTHROPIC_BASE_URL = `${root}/anthropic`;
     env.ANTHROPIC_SMALL_FAST_MODEL = a.litellm.smallFastModel;
   }
   // SWITCHROOM_VOICE_ENGINE: the host's voice-transcription verdict

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -510,8 +510,12 @@ export function startHindsight(
       // recognizes; the CP service has no equivalent env var override.
       "-e", `HINDSIGHT_API_PORT=${apiPort}`,
       // LiteLLM routing: inherited by the claude_agent_sdk subprocess so
-      // consolidation/reflect calls hit the proxy for spend tracking.
-      "-e", `ANTHROPIC_BASE_URL=${litellm.baseUrl}`,
+      // consolidation/reflect calls hit the proxy for spend tracking. Point
+      // at the Anthropic pass-through (<root>/anthropic), not the model-mapped
+      // route — the latter re-chunks the SSE stream and stalls long Claude
+      // responses mid-flight (the 2026-07-05 stall). hindsight only makes
+      // Claude calls, so it has no /model/info discovery to keep on the root.
+      "-e", `ANTHROPIC_BASE_URL=${litellm.baseUrl.replace(/\/+$/, "")}/anthropic`,
       "-e", `ANTHROPIC_CUSTOM_HEADERS=x-litellm-api-key: Bearer ${litellm.apiKey}\nx-litellm-customer-id: hindsight\nx-litellm-tags: service:hindsight`,
     );
   }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -17210,7 +17210,14 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
   return {
     discover: (a) => discoverModels(a),
     discoverSrModels: async () => {
-      const base = process.env.ANTHROPIC_BASE_URL
+      // /model/info lives on the ROOT proxy (model-mapped surface), NOT the
+      // Anthropic pass-through that ANTHROPIC_BASE_URL now points at
+      // (<root>/anthropic). Prefer SWITCHROOM_LITELLM_BASE (the root emitted
+      // by compose.ts); fall back to stripping a trailing /anthropic off
+      // ANTHROPIC_BASE_URL so an agent booted from a pre-passthrough compose
+      // (base_url == root) still resolves correctly.
+      const base = process.env.SWITCHROOM_LITELLM_BASE
+        ?? process.env.ANTHROPIC_BASE_URL?.replace(/\/anthropic\/?$/, '')
       const headers = process.env.ANTHROPIC_CUSTOM_HEADERS
       if (!base || !headers) return []
       const keyMatch = headers.match(/x-litellm-api-key:\s*Bearer\s*(\S+)/)

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -1771,9 +1771,29 @@ describe("agent service env — LiteLLM routing injection (opt-in)", () => {
       litellmConfirmedAgents: new Set(["clerk"]),
     });
     const env = envBlockFor(out, "clerk");
-    expect(env).toMatch(/ANTHROPIC_BASE_URL:\s*"http:\/\/127\.0\.0\.1:4010"/);
+    // claude → Anthropic pass-through (<root>/anthropic), NOT the model-mapped
+    // /v1/messages route (which re-chunks the SSE stream and stalls opus).
+    expect(env).toMatch(/ANTHROPIC_BASE_URL:\s*"http:\/\/127\.0\.0\.1:4010\/anthropic"/);
+    // Root proxy URL kept for start.sh's health probe + gateway /model/info.
+    expect(env).toMatch(/SWITCHROOM_LITELLM_BASE:\s*"http:\/\/127\.0\.0\.1:4010"/);
     expect(env).toMatch(/ANTHROPIC_SMALL_FAST_MODEL:\s*"claude-haiku-4-5-20251001"/);
     expect(env).toMatch(/SWITCHROOM_LITELLM:\s*"1"/);
+  });
+
+  it("points ANTHROPIC_BASE_URL at /anthropic pass-through and normalizes a trailing slash on the root", () => {
+    const out = generateCompose({
+      config: makeConfig({
+        clerk: {
+          litellm: { enabled: true, base_url: "http://127.0.0.1:4010/" },
+        },
+      }),
+      litellmConfirmedAgents: new Set(["clerk"]),
+    });
+    const env = envBlockFor(out, "clerk");
+    // trailing slash collapsed → exactly one /anthropic, no //
+    expect(env).toMatch(/ANTHROPIC_BASE_URL:\s*"http:\/\/127\.0\.0\.1:4010\/anthropic"/);
+    expect(env).toMatch(/SWITCHROOM_LITELLM_BASE:\s*"http:\/\/127\.0\.0\.1:4010"/);
+    expect(env).not.toMatch(/anthropic\/anthropic/);
   });
 
   it("does NOT inject when enabled but the key is NOT confirmed in the vault (blocker-2 gate)", () => {
@@ -1843,7 +1863,8 @@ describe("agent service env — LiteLLM routing injection (opt-in)", () => {
       litellmConfirmedAgents: new Set(["clerk"]),
     });
     const env = envBlockFor(out, "clerk");
-    expect(env).toMatch(/ANTHROPIC_BASE_URL:\s*"http:\/\/127\.0\.0\.1:4010"/);
+    expect(env).toMatch(/ANTHROPIC_BASE_URL:\s*"http:\/\/127\.0\.0\.1:4010\/anthropic"/);
+    expect(env).toMatch(/SWITCHROOM_LITELLM_BASE:\s*"http:\/\/127\.0\.0\.1:4010"/);
     expect(env).toMatch(/SWITCHROOM_LITELLM:\s*"1"/);
     expect(env).toMatch(/ANTHROPIC_SMALL_FAST_MODEL:\s*"claude-haiku-4-5-20251001"/);
   });

--- a/tests/scaffold.litellm-failopen.test.ts
+++ b/tests/scaffold.litellm-failopen.test.ts
@@ -73,9 +73,11 @@ describe("scaffoldAgent: LiteLLM fail-open boot contract (#litellm)", () => {
     );
 
     // FAIL-OPEN: on missing key OR unreachable proxy, strip ALL routing env so
-    // claude talks to Anthropic directly on its OAuth credential.
+    // claude talks to Anthropic directly on its OAuth credential. The root URL
+    // (SWITCHROOM_LITELLM_BASE) must be dropped too — asserted explicitly (not
+    // as a prefix) so it can't silently fall out of the unset list.
     expect(startSh).toContain(
-      "unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM",
+      "unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM SWITCHROOM_LITELLM_BASE",
     );
 
     // The lapse must be logged, not silent (both fallback branches → stderr).

--- a/tests/scaffold.litellm-failopen.test.ts
+++ b/tests/scaffold.litellm-failopen.test.ts
@@ -63,8 +63,14 @@ describe("scaffoldAgent: LiteLLM fail-open boot contract (#litellm)", () => {
     expect(startSh).toContain('if [ -n "$SWITCHROOM_LITELLM" ]');
 
     // Boot reachability probe against the proxy's unauthenticated liveness
-    // endpoint (so a key-less probe still works).
-    expect(startSh).toContain("/health/liveliness");
+    // endpoint (so a key-less probe still works). It MUST target the ROOT
+    // proxy (SWITCHROOM_LITELLM_BASE), not ANTHROPIC_BASE_URL — the latter now
+    // points at the /anthropic pass-through, and /anthropic/health/liveliness
+    // 404s, which would make the probe fail and silently fail-open the whole
+    // fleet to direct OAuth. Regression guard for the passthrough migration.
+    expect(startSh).toContain(
+      "${SWITCHROOM_LITELLM_BASE:-${ANTHROPIC_BASE_URL%/anthropic}}/health/liveliness",
+    );
 
     // FAIL-OPEN: on missing key OR unreachable proxy, strip ALL routing env so
     // claude talks to Anthropic directly on its OAuth credential.


### PR DESCRIPTION
## Summary
Route Claude through LiteLLM's **Anthropic pass-through** (`<root>/anthropic/v1/messages`) instead of the **model-mapped** `/v1/messages` route. The model-mapped path translate→ChatCompletion→re-emit→**re-chunks the SSE stream**, which stalls long opus responses mid-flight (`API Error: Response stalled mid-stream`, ~5 min). The pass-through raw-forwards and streams native SSE bytes — same shape as direct OAuth, no re-chunk.

## Why
Live incident **2026-07-05**: `marko` (`--model opus`, active supergroup, long turns) wedged with the stall. The whole fleet is opus+litellm and shared the exposure. `marko` was reverted to direct OAuth as a stopgap; this is the real fix so litellm can be re-enabled fleet-wide.

Subscription-honest is preserved: OAuth rides in `Authorization` (forwarded upstream unchanged), the virtual key rides in `x-litellm-api-key` (attribution). Non-Claude (`sr-*`) models stay on the model-mapped root path via the virtual key.

## Changes
- `compose.ts`: emit `ANTHROPIC_BASE_URL=<root>/anthropic` (claude → pass-through) **plus** new `SWITCHROOM_LITELLM_BASE=<root>` (root, for the health probe + `/model/info` discovery + admin). Trailing slash on `base_url` normalized.
- `start.sh.hbs` (outer + inner) & `cron-session.sh.hbs`: `/health/liveliness` probe targets the **root**, not `/anthropic` (which 404s); fail-open unset drops `SWITCHROOM_LITELLM_BASE` too.
- `gateway.ts` `discoverSrModels`: `/model/info` uses the root (`SWITCHROOM_LITELLM_BASE`, with a strip-`/anthropic` fallback for pre-passthrough compose).
- `hindsight.ts`: claude_agent_sdk subprocess base_url → `<root>/anthropic`.

## Test plan
- [x] `tsc --noEmit` clean.
- [x] vitest (220) + bun model-command (78) pass.
- [x] New regression coverage: compose emits the `/anthropic`+root split and normalizes trailing slash (no `//anthropic`); start.sh health probe targets the root (guards the silent fleet-wide fail-open a `/anthropic/health/liveliness` 404 would cause).
- Pre-rollout: canary opus turn (long response) through `/anthropic` on test-harness, confirm no mid-stream stall; verify `/model` still lists `sr-*` models (discovery via root).

## Risk
Medium — touches fleet model routing. Fail-open is preserved (probe failure → direct OAuth). Back-compat: probe + discovery fall back to stripping `/anthropic` if `SWITCHROOM_LITELLM_BASE` is unset (agent booted from an older compose).

## Companion (ops, separate)
Bump the Coolify LiteLLM image `main-stable` → pinned **v1.91.0** — ships *"disable proxy buffering on streaming SSE responses"* + pass-through timeout/header hardening, directly reinforcing this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)