### PR TITLE
chore: release v0.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v0.17.3 — LiteLLM Anthropic pass-through
+
+### Claude routes via the /anthropic pass-through, not the model-mapped path (#2835)
+
+Routing Claude (opus) through LiteLLM's model-mapped `/v1/messages` route
+re-chunks the upstream SSE stream, which stalled long responses mid-flight
+("API Error: Response stalled mid-stream" after minutes — the 2026-07-05
+marko incident). Claude now points at LiteLLM's **Anthropic pass-through**
+(`<root>/anthropic/v1/messages`), which raw-forwards and streams native SSE
+bytes — same shape as direct OAuth, no re-chunk.
+
+- `compose.ts` emits `ANTHROPIC_BASE_URL=<root>/anthropic` for the claude
+  CLI, plus a new `SWITCHROOM_LITELLM_BASE=<root>` for the two consumers
+  that need the root proxy surface, not the pass-through: start.sh's
+  `/health/liveliness` boot probe and the gateway's `/model/info`
+  non-Claude (`sr-*`) model discovery.
+- `start.sh` (outer + inner) + `cron-session.sh` health probes and the
+  gateway's `discoverSrModels` now target the root; hindsight's
+  claude_agent_sdk subprocess also routes via the pass-through.
+- OAuth still rides in `Authorization` (forwarded upstream unchanged); the
+  virtual key rides in `x-litellm-api-key` — the split that keeps this
+  subscription-native. Non-Claude models stay on the model-mapped root path
+  via the virtual key.
+- Pairs with a LiteLLM proxy bump to v1.91.0 ("disable proxy buffering on
+  streaming SSE responses") on the operator's deployment.
+
 ## v0.17.2 — hostd self-service rolls
 
 ### PR A — hostd self-bump on stale-CLI rollout (#2833)


### PR DESCRIPTION
## Summary
Release **v0.17.3** — LiteLLM Anthropic pass-through for Claude (#2835), fixing long-response mid-stream stalls. CHANGELOG-only (version is driven by the git tag).

Bundles everything on `main` since v0.17.2 (which is just #2835; #2832 operator-socket + #2833 hostd self-bump already shipped in v0.17.2).

## Test plan
- [x] `node scripts/build.mjs` exit 0, `dist/cli/switchroom.js` present (3.5MB).
- [x] #2835 already reviewer-approved + CI-green on merge.

## Risk
Low — CHANGELOG only. The shipped code (#2835) was independently reviewed and tested (compose passthrough split, fail-open probe, gateway discovery). Fail-open preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)