### PR TITLE
fix(hostd): scope config_propose_edit reconcile to requesting agent

### DIFF
--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -2469,10 +2469,20 @@ export class HostdServer {
           started,
         );
       }
-      // Reconcile.
+      // Reconcile — scoped to the requesting agent when possible.
+      // `switchroom apply --only <name>` scaffolds only that agent (8s
+      // vs 2+ min for the full fleet), which keeps the round-trip well
+      // within the gateway's 60s dispatch timeout. Falls back to a
+      // full apply when the caller is the operator socket (rare) or
+      // `runReconcile` is injected by tests.
       const runner =
         this.opts.runReconcile ??
-        (async () => this.runSwitchroom(["apply"]));
+        (async () =>
+          this.runSwitchroom(
+            caller.kind === "agent"
+              ? ["apply", "--only", callerName, "--non-interactive"]
+              : ["apply", "--non-interactive"],
+          ));
       const recRes = await runner({ requestId: approvalId });
       if (recRes.exit_code === 0) {
         // Tell the operator which agents must restart for this edit to go


### PR DESCRIPTION
## Summary

- **Root cause**: `switchroom apply` (full fleet) takes 2+ min on this host — sequential Hindsight bank creation + connection-health probes for all 12 agents. The gateway dispatches `config_propose_edit` with a 60s timeout; the timeout fires before apply finishes, so \"Always allow\" never persists.
- **Fix**: pass `--only <callerName>` so hostd runs `switchroom apply --only <agent> --non-interactive` instead of a full fleet apply. That reduces the round-trip from 2+ min to ~8s (measured on this host), well within the 60s gateway timeout.
- **Scope**: `--only` narrows scaffold + UID-alignment to the requesting agent only; compose is still regenerated covering all agents. Falls back to a full apply for the operator socket (rare) and test-injected `runReconcile` is unchanged.

## Why

The operator taps \"🔁 Always allow\" → gateway calls hostd `config_propose_edit` → hostd runs `switchroom apply` → 2+ min → gateway 60s timeout fires → `durable = false` → config change never written. Pattern visible in gateway logs on Jul 2–3 (multiple times):
```
config_approval_auto_resolved requestId=... agent=marko (operator-tapped always-allow correlation)
hostd dispatch failed (op=config_propose_edit): hostd: request timed out after 60000ms
always-allow hostd FAILED: hostd wire error: hostd: request timed out after 60000ms
finalizeCallback: answerCallbackQuery failed: 400: Bad Request: query is too old
```

## Test plan

- [x] `vitest run tests/host-control/config-propose-edit.test.ts` — 26 pass (tests inject `runReconcile`, not affected)
- [x] `tsc --noEmit` — clean
- [ ] Manual: tap \"Always allow\" on a marko permission card and verify the rule persists after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)