### PR TITLE
fix(gateway): hold inbound gate while approval card is outstanding

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -309,6 +309,15 @@ for _stray_claude in \
 done
 rm -rf "$HOME/.npm-global/lib/node_modules/@anthropic-ai/claude-code" 2>/dev/null || true
 unset _stray_claude
+# Re-seat the canonical symlink so claude v2.1.x+ self-check ("claude command
+# at $HOME/.local/bin/claude missing or broken") stays silent. The prune loop
+# above removes any stale shadow install; this symlink points back to the
+# immutable image binary so the path is present but can never drift (the target
+# is /usr/local/bin/claude, which is baked at image build time). The symlink is
+# removed again by the prune loop on the NEXT boot, then re-created here —
+# idempotent. `mkdir -p` is safe: the dir already exists or is about to be created.
+mkdir -p "$HOME/.local/bin"
+ln -sf /usr/local/bin/claude "$HOME/.local/bin/claude"
 
 # ── Root-tier agent: provision the docker CLI ────────────────────────
 # The root debugging agent (`root: true`) has /var/run/docker.sock

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2039,14 +2039,25 @@ const POST_ANSWER_LIVENESS_STALE_MS = parsePostAnswerLivenessMs(
  * message self-blocks. See the snapshot at the inbound handler.
  */
 function turnInFlightForGate(): boolean {
-  if (!isDeliveryCutoverEnabled()) return claudeBusyKeys.size > 0
+  // Include pendingPermissions in the "turn busy" signal (#2841): after the
+  // first interim reply, `releaseTurnBufferGate` clears claudeBusyKeys/machine
+  // even though a permission card is still outstanding and claude is still
+  // blocked mid-turn waiting for the tap verdict. A new inbound that arrives
+  // in this window would see turnInFlightAtReceipt=false and deliver directly,
+  // landing while claude's bridge is suspended in the permission-notification
+  // handler — displacing the approval and orphaning the pending brevo/MCP call.
+  // Keeping the gate closed for as long as there is an outstanding approval
+  // card prevents that race. The gate reopens when the card is tapped or times
+  // out (pendingPermissions.delete in finalizeCallback / TTL sweep).
+  const hasPendingApproval = pendingPermissions.size > 0
+  if (!isDeliveryCutoverEnabled()) return claudeBusyKeys.size > 0 || hasPendingApproval
   // Machine is authoritative. Run the log-only drift canary (#2794): the
   // imperative `claudeBusyKeys` shadow is still live in parallel, so a
   // dangerous over-hold divergence (machine holds the gate while the
   // imperative view is idle) is surfaced without changing behaviour. The
   // benign orphan-dangle direction — the wedge the machine self-heals — is
   // NOT flagged. `probeGateParity` returns the machine value unchanged.
-  return probeGateParity(isMachineInTurn(), claudeBusyKeys.size)
+  return probeGateParity(isMachineInTurn(), claudeBusyKeys.size) || hasPendingApproval
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Approval race condition fixed**: `turnInFlightForGate()` now also returns `true` when `pendingPermissions.size > 0`, preventing new Telegram inbounds from being delivered while a permission card is still outstanding and claude is suspended mid-turn waiting for the tap verdict.
- **`start.sh` claude path warning fixed**: After the prune loop that removes stale user-local claude installs, `start.sh.hbs` now re-seats a `$HOME/.local/bin/claude` symlink pointing at the immutable image binary. This silences the v2.1.x+ \"missing or broken\" startup warning without re-introducing drift risk.

## Why

**Root cause (identified by deep trace):** `releaseTurnBufferGate` clears `claudeBusyKeys` on the agent's *first reply*, even when the turn is still blocked on a pending permission card. A new Telegram inbound arriving in that window sees `turnInFlightAtReceipt = false` and is delivered directly — landing while the bridge is suspended in the permission-notification handler, displacing the approval context and orphaning the pending MCP call.

This explains the live incident: marko's brevo POST approval cards timed out or were silently dropped because the operator's follow-up message ("what's happening?") triggered a new turn before the card was tapped.

**Fix contract:** The gate remains closed for the duration of the outstanding card (from `pendingPermissions.set` in `onPermissionRequest` through `pendingPermissions.delete` in `finalizeCallback` / TTL sweep). The inbound delivery gate at line 6184 already guards the delivery-confirm sweep on `pendingPermissions.size > 0` — this fix brings `decideInboundDelivery` in line with that existing precaution.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run telegram-plugin/tests/inbound-delivery-gate.test.ts` — all 10 tests pass
- [ ] UAT: send a message to an agent while a permission card is pending — verify message is buffered and delivered after the tap, not as a new turn
- [ ] Marko brevo Day 3 re-send: verify approval card is respected end-to-end

## Risk

Low. The change extends the existing "pending approval" precaution from the delivery-confirm sweep to the inbound delivery gate. Approval cards already have a 10-minute TTL auto-deny, so the gate cannot be held indefinitely by a missed card — worst case, inbounds buffer for ≤10 minutes if the operator does not tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)