### PR TITLE
docs(start.sh): correct stale comment after prune-loop readlink guard

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -311,11 +311,10 @@ rm -rf "$HOME/.npm-global/lib/node_modules/@anthropic-ai/claude-code" 2>/dev/nul
 unset _stray_claude
 # Re-seat the canonical symlink so claude v2.1.x+ self-check ("claude command
 # at $HOME/.local/bin/claude missing or broken") stays silent. The prune loop
-# above removes any stale shadow install; this symlink points back to the
-# immutable image binary so the path is present but can never drift (the target
-# is /usr/local/bin/claude, which is baked at image build time). The symlink is
-# removed again by the prune loop on the NEXT boot, then re-created here —
-# idempotent. `mkdir -p` is safe: the dir already exists or is about to be created.
+# above skips this canonical pointer (via the readlink guard) and removes only
+# genuine shadow installs; the ln -sf below creates the symlink on first boot
+# and is a no-op on subsequent boots. `mkdir -p` is safe: the dir already exists
+# or is about to be created.
 mkdir -p "$HOME/.local/bin"
 ln -sf /usr/local/bin/claude "$HOME/.local/bin/claude"
 


### PR DESCRIPTION
## Summary

One-line comment fix in `profiles/_base/start.sh.hbs`, follow-up to #2841.

The re-seat block comment said: _"The symlink is removed again by the prune loop on the NEXT boot, then re-created here — idempotent."_ That was accurate before #2841's `readlink` guard, but after the guard the prune loop **skips** (not removes) the canonical symlink on subsequent boots — so the description was inverted.

Updated to: _"The prune loop above preserves this symlink if it already points at `/usr/local/bin/claude` (the `readlink` guard); `ln -sf` here creates it on first boot and is a no-op on subsequent boots."_

## Test plan

- [ ] CI green (doc-only change, no functional impact)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)