### PR TITLE
fix(auth): durable fleet failover — persisted active + proactive probe roll

### DIFF
--- a/src/auth/broker/server-active-override.test.ts
+++ b/src/auth/broker/server-active-override.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Persisted fleet-active override + proactive fleet failover
+ * (2026-07-05 incident: every broker recreate reloaded the stale yaml
+ * `auth.active` and re-poisoned the fleet with a quota-walled account;
+ * the wall was only re-handled after an agent crashed into it mid-turn).
+ *
+ * Pins:
+ *   1. `set-active` persists — a new broker over the same state dir boots
+ *      with the swapped active even though yaml still says the old one.
+ *   2. `mark-exhausted` with a successful roll AUTO-PROMOTES the roll
+ *      target to `auth.active` and persists it across a restart.
+ *   3. A hand-edited yaml (changed since the override was written) WINS —
+ *      the override is dropped and its file deleted.
+ *   4. An override pointing at a since-removed account is ignored.
+ *   5. `fleetQuotaProbeTick` proactively fails the fleet over when the
+ *      ACTIVE account's fresh probe shows exhaustion — no agent 429 needed.
+ *
+ * Same tmpdir-isolation strategy as server.test.ts (never ~/.switchroom).
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as net from "node:net";
+
+import { AuthBroker } from "./server.js";
+import { decodeResponse, encodeRequest } from "./protocol.js";
+import type { SwitchroomConfig } from "../../config/schema.js";
+import { writeAccountCredentials } from "../account-store.js";
+import type { QuotaResult } from "../quota.js";
+
+interface Harness {
+  tmp: string;
+  home: string;
+  agentsDir: string;
+  stateDir: string;
+  socketRoot: string;
+}
+
+let harnesses: Harness[] = [];
+
+function makeHarness(): Harness {
+  const tmp = mkdtempSync(join(tmpdir(), "auth-broker-active-override-"));
+  const home = join(tmp, "home");
+  const agentsDir = join(home, ".switchroom", "agents");
+  const stateDir = join(home, ".switchroom", "state", "auth-broker");
+  const socketRoot = join(tmp, "run", "switchroom", "auth-broker");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(agentsDir, { recursive: true });
+  const h: Harness = { tmp, home, agentsDir, stateDir, socketRoot };
+  harnesses.push(h);
+  return h;
+}
+
+afterEach(() => {
+  for (const h of harnesses) {
+    try { rmSync(h.tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  harnesses = [];
+});
+
+function makeConfig(h: Harness, overrides: Partial<{
+  active: string;
+  fallback_order: string[];
+  admin_agents: string[];
+  agents: Record<string, { auth?: { override?: string }; admin?: boolean }>;
+}> = {}): SwitchroomConfig {
+  const agents = { ...(overrides.agents ?? {}) } as Record<
+    string,
+    { auth?: { override?: string }; admin?: boolean }
+  >;
+  for (const name of overrides.admin_agents ?? []) {
+    agents[name] = { ...(agents[name] ?? {}), admin: true };
+  }
+  return ({
+    switchroom: { version: 1, agents_dir: h.agentsDir },
+    telegram: {},
+    agents,
+    auth: {
+      active: overrides.active,
+      fallback_order: overrides.fallback_order,
+    },
+  } as unknown) as SwitchroomConfig;
+}
+
+async function rpc(socketPath: string, req: object): Promise<unknown> {
+  return await new Promise<unknown>((resolveP, rejectP) => {
+    const c = net.createConnection(socketPath);
+    let buf = "";
+    let settled = false;
+    const settle = (v: unknown, err?: Error): void => {
+      if (settled) return;
+      settled = true;
+      try { c.destroy(); } catch { /* ignore */ }
+      if (err) rejectP(err); else resolveP(v);
+    };
+    c.on("connect", () => {
+      c.write(encodeRequest(req as Parameters<typeof encodeRequest>[0]));
+    });
+    c.on("data", (chunk) => {
+      buf += chunk.toString("utf-8");
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        try { settle(decodeResponse(buf.slice(0, nl))); } catch (err) { settle(null, err as Error); }
+      }
+    });
+    c.on("error", (err) => settle(null, err));
+    setTimeout(() => settle(null, new Error("rpc timeout")), 3000);
+  });
+}
+
+function seedAccount(h: Harness, label: string): void {
+  writeAccountCredentials(
+    label,
+    {
+      claudeAiOauth: {
+        accessToken: `at-${label}`,
+        refreshToken: `rt-${label}`,
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+      },
+    },
+    h.home,
+  );
+}
+
+function healthyQuota(): QuotaResult {
+  return { ok: true, data: {
+    fiveHourUtilizationPct: 4,
+    sevenDayUtilizationPct: 12,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+    representativeClaim: null,
+    overageStatus: null,
+    overageDisabledReason: null,
+  } };
+}
+
+function walledQuota(): QuotaResult {
+  return { ok: true, data: {
+    fiveHourUtilizationPct: 3,
+    sevenDayUtilizationPct: 100,
+    fiveHourResetAt: null,
+    sevenDayResetAt: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000),
+    representativeClaim: "seven_day",
+    overageStatus: null,
+    overageDisabledReason: null,
+  } };
+}
+
+async function listState(h: Harness, agent: string): Promise<{ active: string }> {
+  const resp = await rpc(join(h.socketRoot, agent, "sock"), {
+    v: 1, id: "ls", op: "list-state",
+  }) as { ok: boolean; data: { active: string } };
+  expect(resp.ok).toBe(true);
+  return resp.data;
+}
+
+describe("AuthBroker — persisted active override", () => {
+  it("set-active survives a broker restart even though yaml still says the old active", async () => {
+    const h = makeHarness();
+    seedAccount(h, "old");
+    seedAccount(h, "new");
+    const config = makeConfig(h, { active: "old", admin_agents: ["adm"] });
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker.start();
+    const resp = await rpc(join(h.socketRoot, "adm", "sock"), {
+      v: 1, id: "1", op: "set-active", account: "new",
+    }) as { ok: boolean };
+    expect(resp.ok).toBe(true);
+    broker.stop();
+
+    // Recreate: same state dir, yaml (config) still says "old".
+    const broker2 = new AuthBroker(makeConfig(h, { active: "old", admin_agents: ["adm"] }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker2.start();
+    expect((await listState(h, "adm")).active).toBe("new");
+    broker2.stop();
+  });
+
+  it("mark-exhausted roll auto-promotes the target to auth.active and persists it", async () => {
+    const h = makeHarness();
+    seedAccount(h, "primary");
+    seedAccount(h, "backup");
+    const config = makeConfig(h, {
+      active: "primary",
+      fallback_order: ["primary", "backup"],
+      agents: { marker: {} },
+    });
+    mkdirSync(join(h.agentsDir, "marker"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      // primary genuinely walled on live probe (corroborates the durable
+      // promote); backup healthy (the roll target).
+      _testFetchQuota: async ({ accessToken }) =>
+        accessToken.includes("primary") ? walledQuota() : healthyQuota(),
+    });
+    await broker.start();
+    // Prime the live corroboration: a probe-quota caches a FRESH walled
+    // snapshot for primary — the promote gate requires live evidence, so an
+    // uncorroborated (possibly bogus) mark never durably swaps the fleet.
+    await rpc(join(h.socketRoot, "marker", "sock"), {
+      v: 1, id: "0", op: "probe-quota", accounts: ["primary"],
+    });
+    const resp = await rpc(join(h.socketRoot, "marker", "sock"), {
+      v: 1, id: "1", op: "mark-exhausted", until: Date.now() + 60_000,
+    }) as { ok: boolean; data: { rolledTo: string | null } };
+    expect(resp.ok).toBe(true);
+    expect(resp.data.rolledTo).toBe("backup");
+    // Promoted in the running broker…
+    expect((await listState(h, "marker")).active).toBe("backup");
+    broker.stop();
+
+    // …and across a recreate with the stale yaml.
+    const broker2 = new AuthBroker(makeConfig(h, {
+      active: "primary",
+      fallback_order: ["primary", "backup"],
+      agents: { marker: {} },
+    }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker2.start();
+    expect((await listState(h, "marker")).active).toBe("backup");
+    broker2.stop();
+  });
+
+  it("an UNCORROBORATED mark-exhausted rolls the window but does NOT durably promote", async () => {
+    const h = makeHarness();
+    seedAccount(h, "primary");
+    seedAccount(h, "backup");
+    const config = makeConfig(h, {
+      active: "primary",
+      fallback_order: ["primary", "backup"],
+      agents: { marker: {} },
+    });
+    mkdirSync(join(h.agentsDir, "marker"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async () => healthyQuota(),
+    });
+    await broker.start();
+    // No live snapshot for primary exists → the mark is uncorroborated
+    // (possibly bogus — the 2026-06-10 incident shape). The roll still
+    // happens (window failover), but nominal active must NOT move.
+    const resp = await rpc(join(h.socketRoot, "marker", "sock"), {
+      v: 1, id: "1", op: "mark-exhausted", until: Date.now() + 60_000,
+    }) as { ok: boolean; data: { rolledTo: string | null } };
+    expect(resp.ok).toBe(true);
+    expect(resp.data.rolledTo).toBe("backup");
+    expect((await listState(h, "marker")).active).toBe("primary");
+    expect(existsSync(join(h.stateDir, "active-override.json"))).toBe(false);
+    broker.stop();
+  });
+
+  it("a hand-edited yaml active wins over the override, which is dropped", async () => {
+    const h = makeHarness();
+    seedAccount(h, "old");
+    seedAccount(h, "new");
+    seedAccount(h, "hand-edited");
+    const broker = new AuthBroker(makeConfig(h, { active: "old", admin_agents: ["adm"] }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker.start();
+    await rpc(join(h.socketRoot, "adm", "sock"), {
+      v: 1, id: "1", op: "set-active", account: "new",
+    });
+    broker.stop();
+    expect(existsSync(join(h.stateDir, "active-override.json"))).toBe(true);
+
+    // Operator hand-edits yaml active old → hand-edited, then the broker
+    // recreates: yaml wins, override file removed.
+    const broker2 = new AuthBroker(makeConfig(h, { active: "hand-edited", admin_agents: ["adm"] }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker2.start();
+    expect((await listState(h, "adm")).active).toBe("hand-edited");
+    expect(existsSync(join(h.stateDir, "active-override.json"))).toBe(false);
+    broker2.stop();
+  });
+
+  it("an override naming a since-removed account is ignored (yaml active kept)", async () => {
+    const h = makeHarness();
+    seedAccount(h, "old");
+    seedAccount(h, "gone");
+    const broker = new AuthBroker(makeConfig(h, { active: "old", admin_agents: ["adm"] }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker.start();
+    await rpc(join(h.socketRoot, "adm", "sock"), {
+      v: 1, id: "1", op: "set-active", account: "gone",
+    });
+    broker.stop();
+    // The account disappears from disk between restarts.
+    rmSync(join(h.home, ".switchroom", "accounts", "gone"), { recursive: true, force: true });
+
+    const broker2 = new AuthBroker(makeConfig(h, { active: "old", admin_agents: ["adm"] }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker2.start();
+    expect((await listState(h, "adm")).active).toBe("old");
+    broker2.stop();
+  });
+});
+
+describe("AuthBroker — proactive fleet failover (fleet-quota-probe)", () => {
+  it("a walled ACTIVE account is rolled + promoted by the probe tick with no agent trigger", async () => {
+    const h = makeHarness();
+    seedAccount(h, "primary");
+    seedAccount(h, "backup");
+    const config = makeConfig(h, {
+      active: "primary",
+      fallback_order: ["primary", "backup"],
+      agents: { worker: {} },
+    });
+    mkdirSync(join(h.agentsDir, "worker"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async ({ accessToken }) =>
+        accessToken.includes("primary") ? walledQuota() : healthyQuota(),
+    });
+    await broker.start();
+    await broker.fleetQuotaProbeTick();
+    // Fleet promoted off the walled active — durable, no 429 needed.
+    expect((await listState(h, "worker")).active).toBe("backup");
+    // The walled account carries a persisted exhaustion mark.
+    const marker = await rpc(join(h.socketRoot, "worker", "sock"), {
+      v: 1, id: "2", op: "list-state",
+    }) as { ok: boolean; data: { accounts: Array<{ label: string; exhausted: boolean }> } };
+    const primary = marker.data.accounts.find((a) => a.label === "primary");
+    expect(primary?.exhausted).toBe(true);
+    broker.stop();
+  });
+
+  it("a healthy ACTIVE account is left alone by the probe tick", async () => {
+    const h = makeHarness();
+    seedAccount(h, "primary");
+    seedAccount(h, "backup");
+    const broker = new AuthBroker(makeConfig(h, {
+      active: "primary",
+      fallback_order: ["primary", "backup"],
+      agents: { worker: {} },
+    }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async () => healthyQuota(),
+    });
+    await broker.start();
+    await broker.fleetQuotaProbeTick();
+    expect((await listState(h, "worker")).active).toBe("primary");
+    expect(existsSync(join(h.stateDir, "active-override.json"))).toBe(false);
+    broker.stop();
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -54,6 +54,7 @@ import {
   clampMarkExpiry,
   overageLiftsWall,
   snapshotFresh,
+  snapshotWalled,
   WALL_PCT,
 } from "./account-eligibility.js";
 import type { AuthConfig, AuthConsumer, SwitchroomConfig } from "../../config/schema.js";
@@ -155,6 +156,32 @@ interface QuotaEntry {
 }
 interface QuotaState {
   [label: string]: QuotaEntry;
+}
+
+/**
+ * Persisted fleet-active override (`active-override.json`). Written on every
+ * successful `set-active` AND on every `mark-exhausted` roll (auto-promote),
+ * so an account swap survives a broker restart/recreate.
+ *
+ * Why: `set-active` historically mutated only in-memory config —
+ * "persisting back to YAML is the CLI's job" (RFC §4.6). Every non-CLI
+ * swap (Telegram /auth use, the switch buttons, auto-fallback) therefore
+ * silently reverted to the stale yaml `auth.active` on the next broker
+ * recreate — repeatedly re-poisoning the fleet with a quota-walled account
+ * during the 2026-07-05 incident (each recreate re-mirrored the walled
+ * account; agents had to crash into the wall again to re-roll).
+ *
+ * Precedence at boot: the override wins over yaml ONLY while yaml's
+ * `auth.active` still reads the same value it had when the override was
+ * written (`yaml_active_at_write`). A hand-edited yaml is newer operator
+ * intent — it wins and the override file is deleted.
+ */
+interface ActiveOverride {
+  active: string;
+  /** yaml `auth.active` at the moment this override was written (null =
+   *  yaml had no active set). */
+  yaml_active_at_write: string | null;
+  updated_at: number;
 }
 
 /**
@@ -409,6 +436,15 @@ export class AuthBroker {
    *  first heads-up. */
   private capChownWarned = false;
 
+  /**
+   * The `auth.active` value as read from switchroom.yaml (constructor
+   * config / last SIGHUP reload), BEFORE any persisted-override or swap is
+   * applied. Recorded into `active-override.json` at write time so boot
+   * can tell "yaml unchanged since the swap → override wins" apart from
+   * "operator hand-edited yaml since → yaml wins". See applyActiveOverride.
+   */
+  private yamlActive: string | undefined;
+
   private closed = false;
 
   constructor(
@@ -416,6 +452,7 @@ export class AuthBroker {
     private readonly opts: AuthBrokerOptions = {},
   ) {
     this.config = config;
+    this.yamlActive = config.auth?.active;
     this.home = opts.home;
     this.now = opts.now ?? nowMs;
     this.operatorUid = opts.operatorUid;
@@ -618,6 +655,11 @@ export class AuthBroker {
     this.assertConfigConsistent(config);
     const prev = this.config;
     this.config = config;
+    // Re-apply the persisted active override against the fresh yaml read —
+    // without this a SIGHUP would silently revert a persisted swap to the
+    // stale yaml `auth.active` (same class as the boot-revert this fixes).
+    this.yamlActive = config.auth?.active;
+    this.applyActiveOverride();
 
     const wanted = new Set<string>();
     for (const name of Object.keys(config.agents ?? {})) {
@@ -1629,6 +1671,20 @@ export class AuthBroker {
    * Each probe is a 1-token Haiku call (fetchQuota) — negligible spend. Caches
    * the snapshot for `list-state`; a failed probe is a no-op (keeps the prior
    * snapshot). Never throws into the timer. Public for tests.
+   *
+   * Proactive fleet failover (2026-07-05 incident): when the fresh probe of
+   * the ACTIVE account indicates exhaustion (same overage-aware test the
+   * consumer sensor uses), mark it and roll the fleet immediately — without
+   * waiting for an agent to crash into the wall mid-turn. The reactive
+   * 429/TUI-wall path stays as the fast trigger; this closes the idle-fleet
+   * gap (a wall crossed overnight previously sat unhandled until the next
+   * live turn failed) AND the recreate-revert gap (this runs at boot, so a
+   * recreated broker whose stale yaml points at a walled account self-heals
+   * on the first tick instead of re-poisoning the fleet). Self-quiescing:
+   * a successful roll auto-promotes the target to `auth.active`, so the
+   * next tick probes a healthy active and no-ops. During a true all-blocked
+   * window the roll re-runs each tick and succeeds on the first tick after
+   * any fallback's window refills.
    */
   async fleetQuotaProbeTick(): Promise<void> {
     for (const label of listAccounts(this.home)) {
@@ -1643,6 +1699,15 @@ export class AuthBroker {
         continue;
       }
       this.cacheQuotaSnapshot(label, result);
+      // Re-read active each iteration: a promote earlier in this loop moves it.
+      const active = this.config.auth?.active;
+      if (label !== active) continue;
+      const decision = quotaIndicatesExhaustion(result, this.isOverageAllowed(label));
+      if (!decision.exhausted) continue;
+      process.stdout.write(
+        `auth-broker: fleet-quota-probe shows ACTIVE ${label} exhausted — proactive failover\n`,
+      );
+      await this.markExhaustedAndRoll(label, decision.until ?? undefined, { kind: "operator" });
     }
   }
 
@@ -1740,15 +1805,19 @@ export class AuthBroker {
       socket.write(encodeError(id, "ACCOUNT_NOT_FOUND", `account '${account}' not found`));
       return;
     }
-    // Mutate in-memory config; persisting back to YAML is the CLI's job
-    // (CLI calls set-active via the operator socket *after* writing YAML —
-    // see RFC §4.6). The broker accepts the in-memory swap so subsequent
-    // get-credentials calls reflect it immediately.
+    // Mutate in-memory config AND persist the swap to the broker's own
+    // state file. Yaml stays the CLI's job (RFC §4.6: CLI writes YAML then
+    // calls set-active), but non-CLI callers (Telegram /auth use, the
+    // switch buttons) have no yaml writer — pre-fix their swap silently
+    // reverted to the stale yaml `auth.active` on the next broker
+    // recreate (2026-07-05 incident). The override survives restarts and
+    // yields to a newer hand-edited yaml (see applyActiveOverride).
     const cfg: SwitchroomConfig = {
       ...this.config,
       auth: { ...(this.config.auth ?? {}), active: account },
     };
     this.config = cfg;
+    this.persistActiveOverride(account);
     const fanned = this.fanoutToAffectedAgents(account);
     // Push updated creds to any consumer mirror whose effective account is now
     // `account` (e.g. a consumer whose failover just resolved to this account
@@ -1770,6 +1839,24 @@ export class AuthBroker {
       socket.write(encodeError(id, "ACCOUNT_NOT_FOUND", "no active account configured"));
       return;
     }
+    const { rolled, rolledTo } = await this.markExhaustedAndRoll(account, until, identity);
+    this.audit({ op: "mark-exhausted", identity, account, accountKind: "claude", ok: true });
+    socket.write(encodeSuccess(id, { account, rolled, rolledTo }));
+  }
+
+  /**
+   * Mark `account` exhausted, roll the fleet off it, and — when the walled
+   * account was the fleet active — promote the roll target to nominal
+   * `auth.active` (persisted). Shared core of the `mark-exhausted` op (the
+   * reactive 429/TUI-wall path via auto-fallback) and the proactive
+   * fleet-probe path (`fleetQuotaProbeTick`), so the two triggers cannot
+   * diverge in roll/promote semantics.
+   */
+  private async markExhaustedAndRoll(
+    account: string,
+    until: number | undefined,
+    identity: Identity,
+  ): Promise<{ rolled: string[]; rolledTo: string | null }> {
     const now = this.now();
     // Clamp the misfire-prone case: a mark longer than the 5h default (the +7d
     // weekly fallback that landed on the healthy primary on 2026-06-10) is only
@@ -1808,8 +1895,59 @@ export class AuthBroker {
     // auto-fallback) report an accurate "switched to <X>" without a follow-up
     // admin set-active. `null` when every fallback_order entry is genuinely
     // exhausted (honest all-blocked).
-    this.audit({ op: "mark-exhausted", identity, account, accountKind: "claude", ok: true });
-    socket.write(encodeSuccess(id, { account, rolled, rolledTo }));
+    //
+    // Auto-promote (2026-07-05 incident): when the roll found a target AND
+    // the walled account was the fleet active, promote the target to
+    // nominal `auth.active` and persist it. Pre-fix the nominal active
+    // stayed pointed at the walled account for the whole exhaustion
+    // window; every restart/recreate-time mirror path that reads nominal
+    // active (agent recreate scaffolds, boot fanout) re-poisoned the fleet
+    // with walled creds, and each agent had to crash into the wall again
+    // before the serving-path failover re-covered it. Promoting makes the
+    // failover the fleet's real, durable state. Stale-wall storms from
+    // other gateways are guarded upstream: runFleetAutoFallback live-probes
+    // the (now healthy) active and skips before ever calling this op.
+    //
+    // Corroboration gate: a promote is a DURABLE act with no auto-revert,
+    // so it requires a FRESH live snapshot proving the account is genuinely
+    // walled (same discipline clampMarkExpiry applies to long marks, and
+    // the #2478 probe-blind guard applies to the fleet alert). Without it,
+    // a bogus/misfired mark (the 2026-06-10 incident shape) would durably
+    // swap the fleet off a healthy account; ungated marks still get the
+    // temporary window-failover semantics, which self-heal on the next
+    // healthy probe.
+    if (
+      rolledTo &&
+      this.config.auth?.active === account &&
+      this.exhaustionLiveCorroborated(account)
+    ) {
+      this.config = {
+        ...this.config,
+        auth: { ...(this.config.auth ?? {}), active: rolledTo },
+      };
+      this.persistActiveOverride(rolledTo);
+      this.fanoutAllConsumers();
+      this.audit({ op: "auto-promote-active", identity, account: rolledTo, accountKind: "claude", ok: true });
+      process.stdout.write(
+        `auth-broker: auto-promoted auth.active ${account} → ${rolledTo} ` +
+          `(${account} exhausted until ${new Date(exhaustedUntil).toISOString()}) — persisted\n`,
+      );
+    }
+    return { rolled, rolledTo };
+  }
+
+  /**
+   * Is `account`'s exhaustion backed by live evidence — a FRESH cached
+   * snapshot that reads walled (and not overage-lifted)? Gates the durable
+   * auto-promote in `markExhaustedAndRoll`; mirrors the corroboration the
+   * quota-watch fleet alert requires (#2478) and the freshness discipline
+   * of `clampMarkExpiry`.
+   */
+  private exhaustionLiveCorroborated(account: string): boolean {
+    const snapshot = this.lastQuotaCache[account];
+    if (!snapshot || !snapshotFresh(snapshot, this.now())) return false;
+    if (!snapshotWalled(snapshot)) return false;
+    return !overageLiftsWall(snapshot, this.isOverageAllowed(account));
   }
 
   /**
@@ -2982,6 +3120,58 @@ export class AuthBroker {
     // #2495 Change 1 — reload the durable utilization cache so a restart
     // serves last-known (age-stamped) quota, not a blank card.
     this.lastQuotaCache = this.readJson<LastQuotaCache>("last-quota.json") ?? {};
+    this.applyActiveOverride();
+  }
+
+  /**
+   * Apply the persisted fleet-active override (see `ActiveOverride`).
+   * Called on boot (loadStateFromDisk) and after every SIGHUP reload.
+   *
+   * Rules:
+   *   - no file / malformed → nothing.
+   *   - yaml `auth.active` changed since the override was written →
+   *     operator hand-edit is newer intent: drop the override (delete file).
+   *   - override account no longer exists on disk → ignore (keep yaml).
+   *   - otherwise → the override IS the fleet active.
+   */
+  private applyActiveOverride(): void {
+    const ov = this.readJson<ActiveOverride>("active-override.json");
+    if (!ov || typeof ov.active !== "string" || ov.active.length === 0) return;
+    const yamlActive = this.yamlActive ?? null;
+    if ((ov.yaml_active_at_write ?? null) !== yamlActive) {
+      process.stdout.write(
+        `auth-broker: active-override dropped — yaml auth.active changed since the swap ` +
+          `(${ov.yaml_active_at_write ?? "unset"} → ${yamlActive ?? "unset"}); yaml wins\n`,
+      );
+      try { unlinkSync(join(this.stateDir, "active-override.json")); } catch { /* best-effort */ }
+      return;
+    }
+    if (!accountExists(ov.active, this.home)) {
+      process.stdout.write(
+        `auth-broker: active-override ignored — account '${ov.active}' not found on disk\n`,
+      );
+      return;
+    }
+    if (ov.active === this.config.auth?.active) return;
+    this.config = {
+      ...this.config,
+      auth: { ...(this.config.auth ?? {}), active: ov.active },
+    };
+    process.stdout.write(
+      `auth-broker: active-override applied — auth.active ${yamlActive ?? "unset"} → ${ov.active} ` +
+        `(persisted swap survives restarts)\n`,
+    );
+  }
+
+  /** Persist the current fleet-active swap so it survives a broker
+   *  restart/recreate. See `ActiveOverride` for the precedence contract. */
+  private persistActiveOverride(active: string): void {
+    const entry: ActiveOverride = {
+      active,
+      yaml_active_at_write: this.yamlActive ?? null,
+      updated_at: this.now(),
+    };
+    atomicWriteJsonSync(join(this.stateDir, "active-override.json"), entry, 0o600);
   }
 
   private readJson<T>(name: string): T | null {


### PR DESCRIPTION
## Summary

Closes the failover gaps behind the 2026-07-05 walled-fleet incident: the fleet repeatedly reverted onto a 7d-exhausted account because (a) account swaps lived only in broker memory (every recreate reloaded the stale yaml `auth.active`), (b) the nominal active stayed pointed at the walled account by design so recreate-time mirror paths kept re-poisoning agents, and (c) nothing acted proactively — an idle fleet sat on a wall until an agent crashed into it mid-turn (5× `mark-exhausted` in one day, klanker resumed-restarting each time).

Three changes in the broker (one authoritative place):

1. **Persisted active override** — `state/auth-broker/active-override.json`, written on every `set-active` and every corroborated roll. Applied at boot + SIGHUP. A hand-edited yaml `auth.active` (changed since the override was written) **wins** and drops the override — operator intent is never overridden by stale automation.
2. **Auto-promote on roll** — `mark-exhausted` with a successful roll promotes the roll target to nominal `auth.active` (persisted). Gated on **live corroboration** (fresh walled snapshot, overage-aware — same discipline as `clampMarkExpiry` and the #2478 probe-blind guard) so a bogus mark (2026-06-10 shape) can only trigger the temporary window failover, never a durable swap. The three #2218 serving-failover tests pin this: uncorroborated marks keep the old auto-revert semantics exactly.
3. **Proactive fleet failover** — `fleetQuotaProbeTick` (boot + interval) now rolls the fleet when the ACTIVE account's fresh probe shows exhaustion, via the same extracted `markExhaustedAndRoll` core the reactive 429/TUI-wall path uses. Runs at boot, so a recreated broker whose stale yaml points at a walled account self-heals on the first tick.

Serves outcome 4 (always available — the fleet self-heals off a quota wall with nobody watching) and outcome 3 (subscription-honest — rolls only within the operator's own `fallback_order` accounts). No invariant touched: same broker verbs, no new model callsites, path-as-identity unchanged.

## Test plan

- [x] New `server-active-override.test.ts` — 7 tests: set-active persistence across recreate, corroborated promote + persistence, **uncorroborated mark does NOT promote**, hand-edited-yaml-wins (override dropped), missing-account override ignored, proactive tick rolls+promotes a walled active, healthy active untouched.
- [x] Full broker suite: 390/390 (incl. the three #2218 weekly-wall durability tests that pin the corroboration gate's back-compat).
- [x] `vitest run src/auth tests/auth-*` — 477 pass; `tsc --noEmit` clean.

## Risk

Medium-low. The promote changes post-recovery behavior: after a corroborated wall the fleet *stays* on the promoted account when the old one refills (no auto-revert to primary) — matching the operator's recorded healthy-first `fallback_order` preference. Uncorroborated marks keep today's auto-revert window semantics unchanged. Rollout note: takes effect at the next broker image deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)