### PR TITLE
feat(auth): optional consumer pin — unpinned consumers follow fleet active

### DIFF
--- a/src/auth/broker/server-consumer-follow-active.test.ts
+++ b/src/auth/broker/server-consumer-follow-active.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Unpinned consumers follow the fleet active (consumer-unpin change).
+ *
+ * `auth.consumers[].account` is now optional. A consumer WITHOUT a pin
+ * rides `auth.active` exactly like an override-less agent: same swaps
+ * (set-active / auto-promote), same exhaustion failover, and its
+ * mark-exhausted attributes to the active (agent parity). Pinned
+ * consumers keep the pre-change isolation semantics — the pinned paths
+ * are pinned by server.test.ts and stay untouched here.
+ *
+ * Same tmpdir-isolation strategy as server.test.ts (never ~/.switchroom).
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as net from "node:net";
+
+import { AuthBroker } from "./server.js";
+import { decodeResponse, encodeRequest } from "./protocol.js";
+import type { SwitchroomConfig } from "../../config/schema.js";
+import { writeAccountCredentials } from "../account-store.js";
+
+interface Harness {
+  tmp: string;
+  home: string;
+  agentsDir: string;
+  stateDir: string;
+  socketRoot: string;
+}
+
+let harnesses: Harness[] = [];
+
+function makeHarness(): Harness {
+  const tmp = mkdtempSync(join(tmpdir(), "auth-broker-follow-active-"));
+  const home = join(tmp, "home");
+  const agentsDir = join(home, ".switchroom", "agents");
+  const stateDir = join(home, ".switchroom", "state", "auth-broker");
+  const socketRoot = join(tmp, "run", "switchroom", "auth-broker");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(agentsDir, { recursive: true });
+  const h: Harness = { tmp, home, agentsDir, stateDir, socketRoot };
+  harnesses.push(h);
+  return h;
+}
+
+afterEach(() => {
+  for (const h of harnesses) {
+    try { rmSync(h.tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  harnesses = [];
+});
+
+function makeConfig(h: Harness, overrides: Partial<{
+  active: string;
+  fallback_order: string[];
+  admin_agents: string[];
+  agents: Record<string, { auth?: { override?: string }; admin?: boolean }>;
+  consumers: Array<{ name: string; account?: string; uid?: number; mirror_dir?: string }>;
+}> = {}): SwitchroomConfig {
+  const agents = { ...(overrides.agents ?? {}) } as Record<
+    string,
+    { auth?: { override?: string }; admin?: boolean }
+  >;
+  for (const name of overrides.admin_agents ?? []) {
+    agents[name] = { ...(agents[name] ?? {}), admin: true };
+  }
+  return ({
+    switchroom: { version: 1, agents_dir: h.agentsDir },
+    telegram: {},
+    agents,
+    auth: {
+      active: overrides.active,
+      fallback_order: overrides.fallback_order,
+      consumers: overrides.consumers,
+    },
+  } as unknown) as SwitchroomConfig;
+}
+
+async function rpc(socketPath: string, req: object): Promise<unknown> {
+  return await new Promise<unknown>((resolveP, rejectP) => {
+    const c = net.createConnection(socketPath);
+    let buf = "";
+    let settled = false;
+    const settle = (v: unknown, err?: Error): void => {
+      if (settled) return;
+      settled = true;
+      try { c.destroy(); } catch { /* ignore */ }
+      if (err) rejectP(err); else resolveP(v);
+    };
+    c.on("connect", () => {
+      c.write(encodeRequest(req as Parameters<typeof encodeRequest>[0]));
+    });
+    c.on("data", (chunk) => {
+      buf += chunk.toString("utf-8");
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        try { settle(decodeResponse(buf.slice(0, nl))); } catch (err) { settle(null, err as Error); }
+      }
+    });
+    c.on("error", (err) => settle(null, err));
+    setTimeout(() => settle(null, new Error("rpc timeout")), 3000);
+  });
+}
+
+function seedAccount(h: Harness, label: string): void {
+  writeAccountCredentials(
+    label,
+    {
+      claudeAiOauth: {
+        accessToken: `at-${label}`,
+        refreshToken: `rt-${label}`,
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+      },
+    },
+    h.home,
+  );
+}
+
+describe("AuthBroker — unpinned consumer follows the fleet active", () => {
+  it("get-credentials serves the fleet active when the consumer has no pin", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    const broker = new AuthBroker(makeConfig(h, {
+      active: "default",
+      consumers: [{ name: "hindsight" }],
+    }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker.start();
+    const resp = await rpc(join(h.socketRoot, "hindsight", "sock"), {
+      v: 1, id: "1", op: "get-credentials",
+    }) as { ok: boolean; data: { account: string } };
+    expect(resp.ok).toBe(true);
+    expect(resp.data.account).toBe("default");
+    broker.stop();
+  });
+
+  it("set-active moves an unpinned consumer (and pushes its mirror) with the fleet", async () => {
+    const h = makeHarness();
+    seedAccount(h, "old");
+    seedAccount(h, "new");
+    const mirrorDir = join(h.tmp, "consumer-mirror");
+    mkdirSync(mirrorDir, { recursive: true });
+    const broker = new AuthBroker(makeConfig(h, {
+      active: "old",
+      admin_agents: ["adm"],
+      consumers: [{ name: "hindsight", mirror_dir: mirrorDir }],
+    }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker.start();
+    await rpc(join(h.socketRoot, "adm", "sock"), {
+      v: 1, id: "1", op: "set-active", account: "new",
+    });
+    const resp = await rpc(join(h.socketRoot, "hindsight", "sock"), {
+      v: 1, id: "2", op: "get-credentials",
+    }) as { ok: boolean; data: { account: string } };
+    expect(resp.data.account).toBe("new");
+    // Mirror pushed by set-active's fanoutAllConsumers — no pull-tick wait.
+    expect(readFileSync(join(mirrorDir, ".credentials.json"), "utf-8")).toContain("at-new");
+    broker.stop();
+  });
+
+  it("an exhausted active fails an unpinned consumer over like an agent", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    seedAccount(h, "secondary");
+    const broker = new AuthBroker(makeConfig(h, {
+      active: "default",
+      fallback_order: ["default", "secondary"],
+      agents: { marker: {} },
+      consumers: [{ name: "hindsight" }],
+    }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    mkdirSync(join(h.agentsDir, "marker"), { recursive: true });
+    await broker.start();
+    // An agent on the active reports it exhausted (uncorroborated → window
+    // failover semantics; nominal active does not move).
+    await rpc(join(h.socketRoot, "marker", "sock"), {
+      v: 1, id: "1", op: "mark-exhausted", until: Date.now() + 60_000,
+    });
+    const resp = await rpc(join(h.socketRoot, "hindsight", "sock"), {
+      v: 1, id: "2", op: "get-credentials",
+    }) as { ok: boolean; data: { account: string } };
+    expect(resp.data.account).toBe("secondary");
+    broker.stop();
+  });
+
+  it("mark-exhausted from an unpinned consumer attributes to the fleet active (agent parity)", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    seedAccount(h, "secondary");
+    const broker = new AuthBroker(makeConfig(h, {
+      active: "default",
+      fallback_order: ["default", "secondary"],
+      consumers: [{ name: "hindsight" }],
+    }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker.start();
+    const resp = await rpc(join(h.socketRoot, "hindsight", "sock"), {
+      v: 1, id: "1", op: "mark-exhausted", until: Date.now() + 60_000,
+    }) as { ok: boolean; data: { account: string } };
+    expect(resp.ok).toBe(true);
+    expect(resp.data.account).toBe("default");
+    broker.stop();
+  });
+
+  it("list-state reports the bound (active) account for an unpinned consumer", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    const broker = new AuthBroker(makeConfig(h, {
+      active: "default",
+      consumers: [{ name: "hindsight" }],
+    }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker.start();
+    const resp = await rpc(join(h.socketRoot, "hindsight", "sock"), {
+      v: 1, id: "1", op: "list-state",
+    }) as { ok: boolean; data: { consumers: Array<{ name: string; account: string }> } };
+    expect(resp.data.consumers).toEqual([
+      expect.objectContaining({ name: "hindsight", account: "default" }),
+    ]);
+    broker.stop();
+  });
+
+  it("consumer-quota-sensor skips unpinned consumers (no dedicated account to probe)", async () => {
+    const h = makeHarness();
+    seedAccount(h, "default");
+    const probed: string[] = [];
+    const broker = new AuthBroker(makeConfig(h, {
+      active: "default",
+      consumers: [{ name: "hindsight" }],
+    }), {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async ({ accessToken }) => {
+        probed.push(accessToken);
+        return { ok: true, data: {
+          fiveHourUtilizationPct: 1, sevenDayUtilizationPct: 1,
+          fiveHourResetAt: null, sevenDayResetAt: null,
+          representativeClaim: null, overageStatus: null, overageDisabledReason: null,
+        } };
+      },
+    });
+    await broker.start();
+    await broker.consumerQuotaProbeTick();
+    expect(probed).toEqual([]);
+    broker.stop();
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -1715,6 +1715,9 @@ export class AuthBroker {
       process.stdout.write(
         `auth-broker: fleet-quota-probe shows ACTIVE ${label} exhausted — proactive failover\n`,
       );
+      // Audit parity with the consumer sensor: a proactive mark leaves a
+      // durable audit record, not just a stdout line (#2845 review nit).
+      this.audit({ op: "mark-exhausted", identity: { kind: "operator" }, account: label, accountKind: "claude", ok: true });
       await this.markExhaustedAndRoll(label, decision.until ?? undefined, { kind: "operator" });
     }
   }
@@ -1960,7 +1963,13 @@ export class AuthBroker {
    */
   private exhaustionLiveCorroborated(account: string): boolean {
     const snapshot = this.lastQuotaCache[account];
-    if (!snapshot || !snapshotFresh(snapshot, this.now())) return false;
+    // Tighter freshness ceiling than the serving path's 24h default
+    // (#2845 review nit): a durable promote must be backed by a snapshot
+    // younger than one 5h refill period, else a stale walled reading
+    // (fleet probing disabled / degraded) could promote off an account
+    // whose window already refilled. With default probing (minutes-old
+    // snapshots) this never binds.
+    if (!snapshot || !snapshotFresh(snapshot, this.now(), MARK_EXHAUSTED_DEFAULT_MS)) return false;
     if (!snapshotWalled(snapshot)) return false;
     return !overageLiftsWall(snapshot, this.isOverageAllowed(account));
   }

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -1117,7 +1117,12 @@ export class AuthBroker {
     if (identity.kind === "operator") return auth.active ?? null;
     if (identity.kind === "consumer") {
       const c = (auth.consumers ?? []).find((x) => x.name === identity.name);
-      return c?.account ?? null;
+      if (!c) return null;
+      // Unpinned consumer (no `account:` in yaml) rides the fleet active —
+      // same resolution as an override-less agent, so swaps/failover apply
+      // identically. Attribution follows: its mark-exhausted hits the
+      // active, exactly like an agent's.
+      return c.account ?? auth.active ?? null;
     }
     // agent
     const agent = (this.config.agents ?? {})[identity.name];
@@ -1452,7 +1457,10 @@ export class AuthBroker {
     });
     const consumers = (auth.consumers ?? []).map((c) => ({
       name: c.name,
-      account: c.account,
+      // Unpinned consumers report the account they are bound to right now
+      // (the fleet active) so dashboards stay truthful; the wire shape
+      // stays a plain string either way.
+      account: c.account ?? auth.active ?? "",
       last_seen_at: this.consumerLastSeen[c.name] ?? null,
     }));
     // Identity-specific overage signal: is the account THIS caller is bound to
@@ -1724,8 +1732,15 @@ export class AuthBroker {
    * consumer over on a transient probe error). Never throws into the timer.
    */
   async consumerQuotaProbeTick(): Promise<void> {
+    // PINNED accounts only: an unpinned consumer rides the fleet active,
+    // which the fleet-wide probe (fleetQuotaProbeTick) already covers —
+    // including the proactive roll when it walls.
     const accounts = Array.from(
-      new Set((this.config.auth?.consumers ?? []).map((c) => c.account)),
+      new Set(
+        (this.config.auth?.consumers ?? [])
+          .map((c) => c.account)
+          .filter((a): a is string => typeof a === "string" && a.length > 0),
+      ),
     );
     for (const label of accounts) {
       const creds = readAccountCredentials(label, this.home);
@@ -2845,11 +2860,14 @@ export class AuthBroker {
       //       just had its creds refreshed; push the fresh creds immediately.
       // In both cases we write the current serving account (post failover), never
       // the raw pinned one, preserving the attribution invariant.
-      const isPinned = consumer.account === label;
+      // An unpinned consumer's "bound" account is the fleet active.
+      const bound = consumer.account ?? this.config.auth?.active;
+      const isPinned = bound === label;
       const effective = this.servingAccountForConsumer(consumer.name);
       const isEffective = effective === label;
       if (!isPinned && !isEffective) continue;
-      const toMirror = effective ?? consumer.account;
+      const toMirror = effective ?? bound;
+      if (toMirror == null) continue;
       if (this.mirrorAccountToConsumer(toMirror, consumer)) {
         fanned.push(consumer.name);
       }
@@ -2881,7 +2899,8 @@ export class AuthBroker {
   private servingAccountForConsumer(name: string): string | null {
     const c = (this.config.auth?.consumers ?? []).find((x) => x.name === name);
     if (!c) return null;
-    return this.accountWithFailover(c.account);
+    // Unpinned consumer follows the fleet active (agent parity).
+    return this.accountWithFailover(c.account ?? this.config.auth?.active);
   }
 
   /**

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -987,7 +987,7 @@ export function checkHindsightConsumer(
       name: "hindsight consumer",
       status: "warn",
       detail:
-        `auth.consumers[hindsight] -> ${entry.account} (uid ${entry.uid ?? 0}); ` +
+        `auth.consumers[hindsight] -> ${entry.account ?? "(follows active)"} (uid ${entry.uid ?? 0}); ` +
         `couldn't query auth-broker container (not running / docker unavailable)`,
       fix:
         "Check `auth-broker: service health` row above; if the broker is " +
@@ -1000,7 +1000,7 @@ export function checkHindsightConsumer(
       name: "hindsight consumer",
       status: "warn",
       detail:
-        `auth.consumers[hindsight] -> ${entry.account} (uid ${entry.uid ?? 0}); ` +
+        `auth.consumers[hindsight] -> ${entry.account ?? "(follows active)"} (uid ${entry.uid ?? 0}); ` +
         `auth-broker is running but socket not bound at /run/switchroom/auth-broker/${entry.name}/sock`,
       fix:
         "Run `switchroom apply` to refresh compose and rebind per-consumer sockets.",
@@ -1010,7 +1010,7 @@ export function checkHindsightConsumer(
   return {
     name: "hindsight consumer",
     status: "ok",
-    detail: `auth.consumers[hindsight] -> ${entry.account} (uid ${entry.uid ?? 0})`,
+    detail: `auth.consumers[hindsight] -> ${entry.account ?? "(follows active)"} (uid ${entry.uid ?? 0})`,
   };
 }
 

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -983,22 +983,17 @@ async function stepMemoryBackend(
   } catch { /* vault unreachable; skip the courtesy note */ }
 
   // Register the hindsight consumer in switchroom.yaml so the auth-broker
-  // binds a per-consumer UDS for it on next `switchroom apply`.
-  const activeAccount = config.auth?.active;
-  if (!activeAccount) {
-    console.log(
-      chalk.yellow(
-        `  No auth.active account set — skipping consumer registration. ` +
-          `Run \`switchroom auth use <label>\` and re-run setup.`,
-      ),
-    );
-  } else {
+  // binds a per-consumer UDS for it on next `switchroom apply`. Registered
+  // UNPINNED (no `account:`): the consumer follows the fleet `auth.active`
+  // with the same failover agents get. Operators who want quota isolation
+  // can add an explicit `account:` pin afterwards.
+  {
     try {
-      const result = await ensureHindsightConsumer(switchroomConfigPath, activeAccount);
+      const result = await ensureHindsightConsumer(switchroomConfigPath);
       if (result.added) {
         console.log(
           chalk.green(
-            `  ${STEP_DONE} Registered auth.consumers[${HINDSIGHT_CONSUMER_NAME}] = ${activeAccount}`,
+            `  ${STEP_DONE} Registered auth.consumers[${HINDSIGHT_CONSUMER_NAME}] (follows the fleet active account)`,
           ),
         );
       } else {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3354,10 +3354,14 @@ export const SwitchroomConfigSchema = z.object({
             account: z
               .string()
               .min(1)
+              .optional()
               .describe(
-                "Pinned account label for this consumer. `get-credentials` returns " +
-                "this account's credentials; `mark-exhausted` from this consumer " +
-                "only affects this account.",
+                "Optional pinned account label for this consumer. When set, " +
+                "`get-credentials` serves this account (with automatic failover " +
+                "while it is quota-exhausted) and `mark-exhausted` from this " +
+                "consumer attributes to it — use a pin for quota isolation. " +
+                "When omitted, the consumer follows the fleet `auth.active` " +
+                "exactly like an agent: same account swaps, same failover.",
               ),
             uid: z
               .number()

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -744,14 +744,16 @@ export function generateHindsightComposeSnippet(): string {
  * same `name` is already present, leaves it untouched.
  *
  * @param configPath  absolute path to switchroom.yaml
- * @param account     account label to pin the consumer to (typically
- *                    `auth.active` at setup time)
+ * @param account     optional account label to PIN the consumer to. Omit
+ *                    (the default since the consumer-unpin change) to
+ *                    register the consumer follow-active: it rides the
+ *                    fleet `auth.active` with the same failover agents get.
  * @param uid         UID to chown the consumer socket to;
  *                    defaults to HINDSIGHT_DEFAULT_UID
  */
 export async function ensureHindsightConsumer(
   configPath: string,
-  account: string,
+  account?: string,
   uid: number = HINDSIGHT_DEFAULT_UID,
 ): Promise<{ added: boolean; reason: string }> {
   const fs = await import("node:fs");
@@ -797,7 +799,7 @@ export async function ensureHindsightConsumer(
 
   const entry = new YAMLMap();
   entry.set("name", HINDSIGHT_CONSUMER_NAME);
-  entry.set("account", account);
+  if (account !== undefined) entry.set("account", account);
   entry.set("uid", uid);
   consumersNode.add(entry);
 


### PR DESCRIPTION
## Summary

Operator directive (2026-07-05): hindsight must not be pinned — it should fail over the same as everything else.

`auth.consumers[].account` becomes **optional**. An unpinned consumer rides `auth.active` exactly like an override-less agent: same account swaps (`set-active` / #2845 auto-promote), same exhaustion failover, and its `mark-exhausted` attributes to the active (agent parity). Pinned consumers keep the existing quota-isolation semantics byte-for-byte (pinned paths remain covered by the existing server.test.ts suites).

- **Broker:** `callerAccount` / `servingAccountForConsumer` / both consumer fanout paths / `list-state` handle the unpinned shape; the consumer-quota-sensor skips unpinned consumers (the fleet probe + #2845 proactive roll already cover the active account).
- **Setup:** `switchroom setup` registers the hindsight consumer unpinned by default (follows active); explicit `account:` still available for isolation.
- **Doctor:** prints `(follows active)` for a pin-less entry.
- Also folds in the two non-blocking review nits from #2845: proactive marks now write a durable audit record, and the durable-promote corroboration gate tightens its snapshot freshness ceiling from 24h to one 5h refill period.

## Why

The pin's yaml comment history shows four manual repoints in a single month — every account incident required hand-editing hindsight's pin. Follow-active removes the class; the failover machinery (serving-path + #2845 durable promote) does the rest.

## Test plan

- [x] New `server-consumer-follow-active.test.ts` — 6 tests: unpinned serves active; set-active moves it + pushes its mirror; exhausted active fails it over; its mark attributes to active; list-state reports the bound account; sensor skips unpinned.
- [x] Full broker suite 396/396; setup + config suites green; `tsc --noEmit` clean.

## Risk

Low. Schema change is widening-only (existing pinned configs parse unchanged). Config-compat note: a yaml with a pin-less consumer entry requires this broker version — the host yaml unpin happens **after** the fleet deploys this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)