### PR TITLE
feat(memory): thread reflect/observations mission + disposition through cascade (#2850)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,6 +181,35 @@ agents:
 
 > **Note:** this generates the *memory* wiring only. Who may **drive** an agent (`access.allowFrom`) is still paired at agent creation as today — generating access from `users:` is a future phase.
 
+### Specializing a bank — missions & disposition
+
+A persona without its own memory is cosplay: banks should be *specialized*, not merely isolated. Four `memory.*` fields steer how a bank extracts, recalls, and synthesizes — a coach should read its notes differently than a lawyer.
+
+| Field | Type | Cascade | Steers |
+| --- | --- | --- | --- |
+| `reflect_mission` | string | override | The bank's "who am I / what matters" framing applied during recall/reflect. Engine-accurate name for what `bank_mission` sets. |
+| `bank_mission` | string | override | **Alias** for `reflect_mission` (retained for back-compat — switchroom's `bank_mission` lands in the engine's `reflect_mission`). If both are set, `reflect_mission` wins. |
+| `retain_mission` | string | override | What the fact-extraction LLM keeps during auto-retain. Defaults to a curated mission on fresh agents. |
+| `observations_mission` | string | override | What the observation-consolidation LLM synthesizes from raw facts (the higher-order "what patterns matter" lens). |
+| `disposition` | object | **per-key merge** | Personality traits (`skepticism` / `literalism` / `empathy`, each `1`–`5`, engine default `3`) shaping recall/reflect/observation framing. |
+
+```yaml
+agents:
+  gymbro:
+    extends: health-coach
+    memory:
+      observations_mission: "Track motivation, adherence, and how setbacks connect to encouragement."
+      disposition:
+        empathy: 5        # overrides just this trait; skepticism/literalism
+                          # inherit the health-coach profile default (2/2)
+```
+
+`disposition` deep-merges one level (like `recall`): overriding a single trait leaves the profile's other traits in place. The other three fields override wholesale.
+
+**Zero-config defaults.** Built-in profiles ship differentiated dispositions so a fresh `switchroom setup` needs no YAML — `health-coach` leans empathy-high (`2/2/5`), `executive-assistant` leans precise (`4/4/3`), `coding` leans skeptical + literal (`4/5/2`). Operator config overrides these per-key.
+
+All four apply at **both** scaffold (fresh agents) and reconcile (`switchroom apply` updates existing banks) — except the `retain_mission` *default*, which is seeded only at scaffold so a customized retain mission is never clobbered.
+
 ### Demoting individual memories from auto-recall
 
 If one specific memory keeps surfacing in the recall block and isn't useful (over-broad world fact, stale context, etc.), tag it with `[demote-from-recall]` — or `demote-from-recall` / `no-recall`, all three work. The memory stays in the bank, `mcp__hindsight__reflect` and manual recall can still find it, but auto-recall skips it.

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -629,7 +629,7 @@ import { shouldEmitNotionMcp } from "../config/notion-workspace-acl.js";
 import { reconcileAgentDefaultSkills } from "./reconcile-default-skills.js";
 import { applyTelegramProgressGuidance } from "./sub-agent-telegram-prompt.js";
 import type { McpServerConfig } from "../memory/hindsight.js";
-import { createBank, updateBankMissions, DEFAULT_RETAIN_MISSION, isHindsightEnabled } from "../memory/hindsight.js";
+import { createBank, updateBankMissions, DEFAULT_RETAIN_MISSION, resolveBankMissionExtras, isHindsightEnabled } from "../memory/hindsight.js";
 import { loadTopicState } from "../telegram/state.js";
 import { resolveDualPath } from "../config/paths.js";
 import { resolvePath } from "../config/loader.js";
@@ -4340,8 +4340,23 @@ export function scaffoldAgent(
       const userRetainMission = agentConfig.memory?.retain_mission;
       const seededRetainMission = userRetainMission ?? DEFAULT_RETAIN_MISSION;
 
-      const missions: { bank_mission?: string; retain_mission?: string } = {
+      // reflect_mission / observations_mission / disposition, layering the
+      // resolved config over the built-in profile defaults (Phase 2). Config
+      // wins; disposition merges per-key.
+      const extras = resolveBankMissionExtras(
+        agentConfig.memory,
+        agentConfig.extends ?? DEFAULT_PROFILE,
+      );
+
+      const missions: {
+        bank_mission?: string;
+        retain_mission?: string;
+        reflect_mission?: string;
+        observations_mission?: string;
+        disposition?: { skepticism?: number; literalism?: number; empathy?: number };
+      } = {
         retain_mission: seededRetainMission,
+        ...extras,
       };
       if (userBankMission) {
         missions.bank_mission = userBankMission;
@@ -6328,15 +6343,32 @@ export function reconcileAgent(
     bankOpsChain.then((bankReady) => {
       if (!bankReady) return;
 
-      if (agentConfig.memory?.bank_mission || agentConfig.memory?.retain_mission) {
-        const missions: { bank_mission?: string; retain_mission?: string } = {};
-        if (agentConfig.memory?.bank_mission) {
-          missions.bank_mission = agentConfig.memory.bank_mission;
-        }
-        if (agentConfig.memory?.retain_mission) {
-          missions.retain_mission = agentConfig.memory.retain_mission;
-        }
+      // Reconcile still does NOT seed the DEFAULT_RETAIN_MISSION (that stays
+      // scaffold-only, so an operator's customized retain mission is never
+      // clobbered). But it DOES push reflect_mission / observations_mission /
+      // disposition — including the built-in profile defaults — so EXISTING
+      // banks pick up Phase 2 changes on `switchroom apply`, not only fresh
+      // ones. Config wins over profile defaults; disposition merges per-key.
+      const extras = resolveBankMissionExtras(
+        agentConfig.memory,
+        agentConfig.extends ?? DEFAULT_PROFILE,
+      );
 
+      const missions: {
+        bank_mission?: string;
+        retain_mission?: string;
+        reflect_mission?: string;
+        observations_mission?: string;
+        disposition?: { skepticism?: number; literalism?: number; empathy?: number };
+      } = { ...extras };
+      if (agentConfig.memory?.bank_mission) {
+        missions.bank_mission = agentConfig.memory.bank_mission;
+      }
+      if (agentConfig.memory?.retain_mission) {
+        missions.retain_mission = agentConfig.memory.retain_mission;
+      }
+
+      if (Object.keys(missions).length > 0) {
         updateBankMissions(apiUrl, hindsightBankId, missions, { timeoutMs: 5000 })
           .then((result) => {
             if (result.ok) {

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -394,6 +394,18 @@ export function mergeAgentConfig(
       if (v === undefined) continue;
       if (k === "recall" && base.recall && typeof v === "object" && v !== null && !Array.isArray(v)) {
         combined[k] = { ...base.recall, ...(v as Record<string, unknown>) };
+      } else if (
+        k === "disposition" &&
+        (base as { disposition?: unknown }).disposition &&
+        typeof v === "object" && v !== null && !Array.isArray(v)
+      ) {
+        // Same one-level-deep merge as `recall`: an agent may override a
+        // single trait (e.g. empathy) and inherit the profile's other two
+        // traits, rather than replacing the whole disposition object.
+        combined[k] = {
+          ...((base as { disposition?: Record<string, unknown> }).disposition),
+          ...(v as Record<string, unknown>),
+        };
       } else {
         combined[k] = v;
       }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -333,11 +333,66 @@ export const AgentMemorySchema = z
     bank_mission: z
       .string()
       .optional()
-      .describe("Bank-level mission statement used during recall to contextualize results"),
+      .describe(
+        "Bank-level mission statement used during recall to contextualize " +
+        "results. NOTE: this is an alias for the Hindsight engine's " +
+        "`reflect_mission` field (verified live: switchroom's bank_mission " +
+        "lands in `config.reflect_mission`). Prefer `reflect_mission` going " +
+        "forward; `bank_mission` is retained for back-compat. If both are " +
+        "set, `reflect_mission` wins. Cascade: override."
+      ),
+    reflect_mission: z
+      .string()
+      .optional()
+      .describe(
+        "Mission/context steering Hindsight Reflect operations (the bank's " +
+        "'who am I / what matters' framing applied during recall). The " +
+        "engine-accurate name for what `bank_mission` sets. Cascade: override."
+      ),
     retain_mission: z
       .string()
       .optional()
-      .describe("Instructions for the fact extraction LLM during retain"),
+      .describe("Instructions for the fact extraction LLM during retain. Cascade: override."),
+    observations_mission: z
+      .string()
+      .optional()
+      .describe(
+        "Steers what the observation-consolidation LLM synthesises from raw " +
+        "facts (the higher-order 'what patterns matter' lens). Cascade: override."
+      ),
+    disposition: z
+      .object({
+        skepticism: z
+          .number()
+          .int()
+          .min(1)
+          .max(5)
+          .optional()
+          .describe("How much the bank doubts unverified claims (1-5; engine default 3)."),
+        literalism: z
+          .number()
+          .int()
+          .min(1)
+          .max(5)
+          .optional()
+          .describe("How literally the bank reads statements vs inferring intent (1-5; engine default 3)."),
+        empathy: z
+          .number()
+          .int()
+          .min(1)
+          .max(5)
+          .optional()
+          .describe("How much the bank weights emotional/relational context (1-5; engine default 3)."),
+      })
+      .optional()
+      .describe(
+        "Personality traits (1-5 each) steering how this bank frames recall, " +
+        "reflect, and observation synthesis — a coach leans empathy-high, a " +
+        "lawyer/analyst leans skepticism/literalism-high. Maps to the engine's " +
+        "flat `disposition_skepticism`/`_literalism`/`_empathy` fields. " +
+        "Cascade: per-key merge (an agent overrides individual traits and " +
+        "inherits the rest, matching `recall`)."
+      ),
     recall: z
       .object({
         max_memories: z

--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -191,6 +191,103 @@ export const DEFAULT_RETAIN_MISSION =
   "conversations. Skip one-off chatter and temporary task noise.";
 
 /**
+ * Hindsight bank disposition traits (1-5 each). Mirrors the engine's flat
+ * `disposition_skepticism` / `disposition_literalism` / `disposition_empathy`
+ * config fields (confirmed against the live `/v1/bank-template-schema`:
+ * integers 1-5, engine default 3 when null). switchroom models them as one
+ * nested object for ergonomic YAML and flattens at the API boundary.
+ */
+export interface BankDisposition {
+  skepticism?: number;
+  literalism?: number;
+  empathy?: number;
+}
+
+/**
+ * Extra bank-mission fields threaded through the config cascade (Phase 2 of
+ * `reference/rfcs/hindsight-synthesis-layers.md` — "a persona without its own
+ * memory is cosplay"; banks should be *specialized*, not merely isolated).
+ *
+ * `reflect_mission` and `observations_mission` are string config fields;
+ * `disposition` flattens to the three `disposition_*` integer fields.
+ */
+export interface BankMissionExtras {
+  reflect_mission?: string;
+  observations_mission?: string;
+  disposition?: BankDisposition;
+}
+
+/**
+ * Code-level memory defaults keyed by built-in **filesystem** profile
+ * (`agents.<name>.extends`). These differentiate the specialists so the
+ * feature works on a fresh `switchroom setup` with zero YAML (defaults
+ * principle) — a coach leans empathy-high, an analyst/EA leans skeptical and
+ * literal. Operator config (already cascaded) overrides these per-key.
+ *
+ * Only `disposition` + `observations_mission` are defaulted here; the
+ * persona statement (`reflect_mission` / `bank_mission`) stays operator-driven
+ * so there is no code-vs-yaml persona conflict. Profiles not listed inherit
+ * the engine default (all traits 3, no observations mission).
+ */
+export const PROFILE_MEMORY_DEFAULTS: Record<string, BankMissionExtras> = {
+  "health-coach": {
+    disposition: { skepticism: 2, literalism: 2, empathy: 5 },
+    observations_mission:
+      "Synthesise the person's wellbeing patterns, motivations, and emotional " +
+      "context — how habits, setbacks, and encouragement connect over time.",
+  },
+  "executive-assistant": {
+    disposition: { skepticism: 4, literalism: 4, empathy: 3 },
+  },
+  coding: {
+    disposition: { skepticism: 4, literalism: 5, empathy: 2 },
+  },
+};
+
+/**
+ * Merge two dispositions per-key (override wins on each trait, inherits the
+ * rest). Returns undefined when neither side sets anything.
+ */
+function mergeDisposition(
+  base: BankDisposition | undefined,
+  over: BankDisposition | undefined,
+): BankDisposition | undefined {
+  if (!base && !over) return undefined;
+  const merged: BankDisposition = { ...(base ?? {}), ...(over ?? {}) };
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+/**
+ * Resolve the effective {@link BankMissionExtras} for an agent by layering
+ * the resolved memory config over the built-in profile defaults
+ * ({@link PROFILE_MEMORY_DEFAULTS}). Config wins; disposition merges per-key.
+ *
+ * Used by BOTH the scaffold and reconcile bank-update paths in
+ * `src/agents/scaffold.ts`, so existing banks pick up profile/config changes
+ * on `switchroom apply` — not only freshly scaffolded ones.
+ */
+export function resolveBankMissionExtras(
+  memory:
+    | { reflect_mission?: string; observations_mission?: string; disposition?: BankDisposition }
+    | undefined,
+  profileName: string,
+): BankMissionExtras {
+  const pd = PROFILE_MEMORY_DEFAULTS[profileName] ?? {};
+  const out: BankMissionExtras = {};
+
+  const reflect = memory?.reflect_mission ?? pd.reflect_mission;
+  if (reflect != null) out.reflect_mission = reflect;
+
+  const observations = memory?.observations_mission ?? pd.observations_mission;
+  if (observations != null) out.observations_mission = observations;
+
+  const disposition = mergeDisposition(pd.disposition, memory?.disposition);
+  if (disposition) out.disposition = disposition;
+
+  return out;
+}
+
+/**
  * Parse a Hindsight MCP response body.
  *
  * Hindsight's MCP server returns text/event-stream responses of the form:
@@ -693,7 +790,13 @@ export async function createBank(
 export async function updateBankMissions(
   apiUrl: string,
   bankId: string,
-  missions: { bank_mission?: string; retain_mission?: string },
+  missions: {
+    bank_mission?: string;
+    retain_mission?: string;
+    reflect_mission?: string;
+    observations_mission?: string;
+    disposition?: BankDisposition;
+  },
   opts?: { fetchImpl?: typeof fetch; timeoutMs?: number }
 ): Promise<{ ok: true } | { ok: false; reason: string }> {
   const fetchImpl = opts?.fetchImpl ?? fetch;
@@ -761,13 +864,34 @@ export async function updateBankMissions(
           // NOT a top-level `retain_mission` — that is a CONFIG field and must
           // go through `config_updates` (verified live: the server SILENTLY
           // DROPPED a top-level retain_mission, so the retain-steering half of
-          // every mission update was a live no-op). Route it correctly.
+          // every mission update was a live no-op). Every other steering field
+          // is a config field too and routes the same way.
+          //
+          // The engine stores the top-level `mission` as `config.reflect_mission`
+          // (verified live: switchroom's bank_mission lands there). So
+          // `reflect_mission` and `bank_mission` target the SAME field — when
+          // the explicit `reflect_mission` is set we route it through
+          // config_updates and drop the top-level `mission` so the two can't
+          // race; a bare `bank_mission` keeps the legacy top-level route.
           arguments: {
             bank_id: bankId,
-            ...(missions.bank_mission != null ? { mission: missions.bank_mission } : {}),
-            ...(missions.retain_mission != null
-              ? { config_updates: { retain_mission: missions.retain_mission } }
+            ...(missions.reflect_mission == null && missions.bank_mission != null
+              ? { mission: missions.bank_mission }
               : {}),
+            ...(() => {
+              const configUpdates: Record<string, unknown> = {};
+              if (missions.retain_mission != null)
+                configUpdates.retain_mission = missions.retain_mission;
+              if (missions.reflect_mission != null)
+                configUpdates.reflect_mission = missions.reflect_mission;
+              if (missions.observations_mission != null)
+                configUpdates.observations_mission = missions.observations_mission;
+              const d = missions.disposition;
+              if (d?.skepticism != null) configUpdates.disposition_skepticism = d.skepticism;
+              if (d?.literalism != null) configUpdates.disposition_literalism = d.literalism;
+              if (d?.empathy != null) configUpdates.disposition_empathy = d.empathy;
+              return Object.keys(configUpdates).length > 0 ? { config_updates: configUpdates } : {};
+            })(),
           },
         },
       }),

--- a/tests/memory.bank-missions.test.ts
+++ b/tests/memory.bank-missions.test.ts
@@ -1,5 +1,26 @@
 import { describe, it, expect, vi } from "vitest";
-import { updateBankMissions, DEFAULT_RETAIN_MISSION } from "../src/memory/hindsight.js";
+import {
+  updateBankMissions,
+  DEFAULT_RETAIN_MISSION,
+  resolveBankMissionExtras,
+  PROFILE_MEMORY_DEFAULTS,
+} from "../src/memory/hindsight.js";
+import { AgentMemorySchema } from "../src/config/schema.js";
+
+/** Drive updateBankMissions with a two-call mock and return the update_bank args. */
+async function captureUpdateBankArgs(
+  missions: Parameters<typeof updateBankMissions>[2],
+): Promise<Record<string, unknown>> {
+  const mockFetch = vi
+    .fn()
+    .mockResolvedValueOnce({ ok: true, headers: new Map() } as any)
+    .mockResolvedValueOnce({ ok: true } as any);
+  const result = await updateBankMissions("http://test.local/mcp/", "test-bank", missions, {
+    fetchImpl: mockFetch as any,
+  });
+  expect(result).toEqual({ ok: true });
+  return JSON.parse(mockFetch.mock.calls[1][1].body).params.arguments;
+}
 
 describe("DEFAULT_RETAIN_MISSION", () => {
   it("matches upstream Hindsight per-user-memory guide wording", () => {
@@ -33,13 +54,14 @@ describe("scaffold seed wiring", () => {
     const scaffoldSource = fs.readFileSync("src/agents/scaffold.ts", "utf-8");
     expect(scaffoldSource).toContain("DEFAULT_RETAIN_MISSION");
     expect(scaffoldSource).toContain("seededRetainMission = userRetainMission ?? DEFAULT_RETAIN_MISSION");
-    // The reconcile-side bank-mission update block must remain
-    // explicit-only (the original `if user yaml has missions` gate).
-    // Asserting both forms exist guards against an accidental copy of
-    // the seed-default behaviour into reconcile.
-    expect(scaffoldSource).toContain(
-      "if (agentConfig.memory?.bank_mission || agentConfig.memory?.retain_mission)",
-    );
+    // The `?? DEFAULT_RETAIN_MISSION` seed-default fallback must appear
+    // EXACTLY ONCE (scaffold only). More than one occurrence means the
+    // seed-default behaviour was copied into reconcile, which would clobber
+    // an operator's customized retain mission on every `switchroom apply`.
+    const seedOccurrences = scaffoldSource.split("?? DEFAULT_RETAIN_MISSION").length - 1;
+    expect(seedOccurrences).toBe(1);
+    // Reconcile still gates its retain push on explicit operator config.
+    expect(scaffoldSource).toContain("if (agentConfig.memory?.retain_mission) {");
   });
 });
 
@@ -191,5 +213,120 @@ describe("updateBankMissions", () => {
 
     expect(result.ok).toBe(false);
     expect(result.reason).toContain("Network error");
+  });
+
+  // --- Phase 2: reflect_mission / observations_mission / disposition ---
+
+  it("routes reflect_mission + observations_mission through config_updates", async () => {
+    const args = await captureUpdateBankArgs({
+      reflect_mission: "You are a legal analyst.",
+      observations_mission: "Synthesise obligations and risks.",
+    });
+    // reflect_mission is explicit → NO top-level `mission` (they target the
+    // same engine field; explicit reflect_mission wins deterministically).
+    expect(args).toEqual({
+      bank_id: "test-bank",
+      config_updates: {
+        reflect_mission: "You are a legal analyst.",
+        observations_mission: "Synthesise obligations and risks.",
+      },
+    });
+    expect("mission" in args).toBe(false);
+  });
+
+  it("flattens disposition to disposition_* integer config fields", async () => {
+    const args = await captureUpdateBankArgs({
+      disposition: { skepticism: 4, literalism: 5, empathy: 2 },
+    });
+    expect(args.config_updates).toEqual({
+      disposition_skepticism: 4,
+      disposition_literalism: 5,
+      disposition_empathy: 2,
+    });
+  });
+
+  it("omits unset disposition traits from config_updates", async () => {
+    const args = await captureUpdateBankArgs({ disposition: { empathy: 5 } });
+    expect(args.config_updates).toEqual({ disposition_empathy: 5 });
+  });
+
+  it("keeps the legacy top-level mission route for a bare bank_mission", async () => {
+    const args = await captureUpdateBankArgs({ bank_mission: "Persona X" });
+    expect(args).toEqual({ bank_id: "test-bank", mission: "Persona X" });
+  });
+
+  it("reflect_mission wins over bank_mission (drops the top-level mission)", async () => {
+    const args = await captureUpdateBankArgs({
+      bank_mission: "legacy persona",
+      reflect_mission: "explicit persona",
+    });
+    expect("mission" in args).toBe(false);
+    expect(args.config_updates).toEqual({ reflect_mission: "explicit persona" });
+  });
+
+  it("omits config_updates entirely when only a bank_mission is set", async () => {
+    const args = await captureUpdateBankArgs({ bank_mission: "just persona" });
+    expect("config_updates" in args).toBe(false);
+  });
+});
+
+describe("resolveBankMissionExtras", () => {
+  it("returns built-in profile defaults when config is empty", () => {
+    expect(resolveBankMissionExtras(undefined, "health-coach")).toEqual({
+      disposition: { skepticism: 2, literalism: 2, empathy: 5 },
+      observations_mission: PROFILE_MEMORY_DEFAULTS["health-coach"].observations_mission,
+    });
+  });
+
+  it("returns nothing for a profile without defaults and no config", () => {
+    expect(resolveBankMissionExtras(undefined, "default")).toEqual({});
+    expect(resolveBankMissionExtras({}, "some-unknown-profile")).toEqual({});
+  });
+
+  it("merges disposition per-key: config trait overrides, others inherit profile", () => {
+    const extras = resolveBankMissionExtras({ disposition: { empathy: 1 } }, "health-coach");
+    expect(extras.disposition).toEqual({ skepticism: 2, literalism: 2, empathy: 1 });
+  });
+
+  it("config observations_mission overrides the profile default wholesale", () => {
+    const extras = resolveBankMissionExtras(
+      { observations_mission: "custom" },
+      "health-coach",
+    );
+    expect(extras.observations_mission).toBe("custom");
+  });
+
+  it("passes reflect_mission straight through (no profile default for it)", () => {
+    const extras = resolveBankMissionExtras({ reflect_mission: "hi" }, "coding");
+    expect(extras.reflect_mission).toBe("hi");
+    // coding still contributes its disposition default
+    expect(extras.disposition).toEqual({ skepticism: 4, literalism: 5, empathy: 2 });
+  });
+});
+
+describe("AgentMemorySchema — Phase 2 fields", () => {
+  it("accepts reflect_mission, observations_mission, and in-range disposition", () => {
+    const parsed = AgentMemorySchema.parse({
+      collection: "b",
+      reflect_mission: "r",
+      observations_mission: "o",
+      disposition: { skepticism: 1, literalism: 3, empathy: 5 },
+    });
+    expect(parsed.disposition).toEqual({ skepticism: 1, literalism: 3, empathy: 5 });
+  });
+
+  it("rejects disposition traits outside 1-5", () => {
+    expect(() =>
+      AgentMemorySchema.parse({ collection: "b", disposition: { empathy: 6 } }),
+    ).toThrow();
+    expect(() =>
+      AgentMemorySchema.parse({ collection: "b", disposition: { skepticism: 0 } }),
+    ).toThrow();
+  });
+
+  it("rejects non-integer disposition traits", () => {
+    expect(() =>
+      AgentMemorySchema.parse({ collection: "b", disposition: { literalism: 2.5 } }),
+    ).toThrow();
   });
 });

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -274,6 +274,33 @@ describe("mergeAgentConfig", () => {
     expect(result.memory?.recall?.cache_ttl_secs).toBe(30); // agent override
   });
 
+  it("deep-merges memory.disposition one level (agent overrides a single trait)", () => {
+    // Same per-key semantics as recall: overriding one disposition trait must
+    // leave the profile/defaults' other traits in place, not replace the whole
+    // object.
+    const defaults: AgentDefaults = {
+      memory: { disposition: { skepticism: 4, literalism: 4, empathy: 3 } },
+    };
+    const agent = baseAgent({
+      memory: { disposition: { empathy: 5 } },
+    });
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.memory?.disposition).toEqual({
+      skepticism: 4, // preserved from defaults
+      literalism: 4, // preserved from defaults
+      empathy: 5, // agent override
+    });
+  });
+
+  it("cascades whole memory.disposition from defaults when agent omits it", () => {
+    const defaults: AgentDefaults = {
+      memory: { disposition: { skepticism: 2, literalism: 2, empathy: 5 } },
+    };
+    const agent = baseAgent({ memory: { collection: "coach" } });
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.memory?.disposition).toEqual({ skepticism: 2, literalism: 2, empathy: 5 });
+  });
+
   it("prepends defaults.schedule to agent.schedule", () => {
     const defaults: AgentDefaults = {
       schedule: [{ cron: "0 8 * * *", prompt: "Morning check-in" }],


### PR DESCRIPTION
Closes #2850. Phase 2 of `reference/rfcs/hindsight-synthesis-layers.md` — "a persona without its own memory is cosplay"; banks should be **specialized**, not merely isolated. Serves `reference/jobs/run-a-fleet-of-specialists.md` (+ `remember-across-sessions`).

## Summary
Wires the remaining bank-steering levers through the config cascade:
- `reflect_mission`, `observations_mission` — string, **override** cascade
- `disposition {skepticism, literalism, empathy}` — 1–5 each, **per-key merge** cascade (like `recall`)

## Why / findings (verified against the live engine, not assumed)
Per the issue's "confirm before pinning" instruction, I queried the live hindsight `/v1/bank-template-schema` and a real bank's `/config`:
1. **`disposition` is three flat integer fields** (`disposition_skepticism/_literalism/_empathy`, each **1–5**, engine default 3) — not a nested object in the engine. switchroom models it as one nested object for ergonomic YAML and **flattens at the `updateBankMissions` API boundary**.
2. **switchroom's existing `bank_mission` IS the engine's `reflect_mission`** — the MCP `update_bank` top-level `mission` param lands in `config.reflect_mission` (confirmed on the live `assistant` bank). So `reflect_mission` is the engine-accurate canonical name; `bank_mission` is retained as a documented **alias** (`reflect_mission` wins if both set, and its explicit config-route replaces the top-level `mission` so they can't race). `observations_mission` + all `disposition_*` are `null` fleet-wide today — genuinely unwired.

## What changed
- `src/config/schema.ts` — 3 new `memory.*` fields + bounds; `bank_mission` doc now notes the alias.
- `src/config/merge.ts` — `disposition` joins `recall` in the one-level deep-merge.
- `src/memory/hindsight.ts` — extended `updateBankMissions` config_updates routing; `PROFILE_MEMORY_DEFAULTS` (built-in profile → disposition/observations defaults) + `resolveBankMissionExtras` helper.
- `src/agents/scaffold.ts` — threads extras through **both** scaffold and reconcile call sites (existing banks update on `apply`; the `retain_mission` *default* stays scaffold-only).
- `docs/configuration.md` — new "Specializing a bank — missions & disposition" section with cascade modes.
- Built-in profile defaults: `health-coach` empathy-high (2/2/5), `executive-assistant` (4/4/3), `coding` (4/5/2) — fresh setup needs zero config.

## Test plan
- [x] `vitest run tests/memory.bank-missions.test.ts tests/merge.test.ts` (119 pass) — config_updates routing + disposition flattening, reflect/bank_mission precedence, `resolveBankMissionExtras` profile-default layering, schema 1–5 validation, disposition per-key cascade
- [x] Regression: scaffold.recall-observations, cli.doctor.memory, memory, hindsight-iserror-guard, hindsight-contract (50 pass)
- [x] `tsc --noEmit` clean

## Principle checks
- **Docs**: new configuration.md section, usable without reading src. **Defaults**: differentiated profile dispositions, zero-config fresh setup. **Consistency**: mirrors `retain_mission`/`recall` cascade shapes + `updateBankMissions` config_updates convention.

## Invariants
Operator-config-driven only — no agent self-modification of its own bank missions (`no-self-escalation`). Did not touch retain cadence / recall types (Phase 6 surfaces).

## Risk
Reconcile now fires `updateBankMissions` for profiled agents even without operator config (to push profile-default disposition to existing banks) — idempotent, best-effort, 5s timeout, never throws. Everything routes through the existing `isError`-guarded envelope.