### PR TITLE
fix(update): pin refresh-hindsight recreate to release target (#2851)

### DIFF
--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   planUpdate,
+  resolveHindsightPinTag,
   runUpdate,
   isGitCheckout,
   rebuildRefusalMessage,
@@ -85,6 +86,64 @@ describe("planUpdate", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
+  });
+
+  // #2851: `memory setup` never reads release.pin, so the refresh-hindsight
+  // step must thread the resolved target through as `--tag <version>` (like
+  // `switchroom rollout` does) — otherwise the recreate floats to `:latest`
+  // and the memory singleton drifts a version behind the pinned fleet.
+  describe("refresh-hindsight pins the recreate to the release target (#2851)", () => {
+    const findRefresh = (opts: Parameters<typeof planUpdate>[0]) =>
+      planUpdate({ composePath: "unused-for-run", memoryBackendHindsight: true, ...opts }).find(
+        (s) => s.name === "refresh-hindsight",
+      )!;
+
+    it("threads --tag <version> when this run passes --pin vX.Y.Z", () => {
+      const runner = fakeRunner();
+      findRefresh({ pin: "v0.17.5", runner: runner.fn }).run();
+      expect(runner.calls).toHaveLength(1);
+      expect(runner.calls[0]!.args.slice(-5)).toEqual([
+        "memory",
+        "setup",
+        "--recreate",
+        "--tag",
+        "v0.17.5",
+      ]);
+    });
+
+    it("omits --tag (floating :latest) when there is no pin", () => {
+      const runner = fakeRunner();
+      // hindsightPinTag:"" is the explicit floating override — avoids reading
+      // the developer's real ~/.switchroom config in this unit test.
+      findRefresh({ hindsightPinTag: "", runner: runner.fn }).run();
+      expect(runner.calls).toHaveLength(1);
+      expect(runner.calls[0]!.args.slice(-3)).toEqual(["memory", "setup", "--recreate"]);
+      expect(runner.calls[0]!.args).not.toContain("--tag");
+    });
+
+    it("leaves hindsight floating under a --channel override", () => {
+      const runner = fakeRunner();
+      // channel short-circuits before any config read.
+      findRefresh({ channel: "dev", runner: runner.fn }).run();
+      expect(runner.calls[0]!.args).not.toContain("--tag");
+    });
+
+    it("does not pin a sha-<hash> --pin (no per-sha hindsight image published)", () => {
+      const runner = fakeRunner();
+      findRefresh({ pin: "sha-abc1234", runner: runner.fn }).run();
+      expect(runner.calls[0]!.args).not.toContain("--tag");
+    });
+  });
+
+  describe("resolveHindsightPinTag", () => {
+    it("returns a vX.Y.Z --pin verbatim, undefined for sha / channel / empty override", () => {
+      expect(resolveHindsightPinTag({ pin: "v0.17.5" })).toBe("v0.17.5");
+      expect(resolveHindsightPinTag({ pin: "sha-deadbeef" })).toBeUndefined();
+      expect(resolveHindsightPinTag({ pin: "v0.17.5", channel: "dev" })).toBeUndefined();
+      // Explicit floating override wins over everything (and reads no config).
+      expect(resolveHindsightPinTag({ hindsightPinTag: "", pin: "v0.17.5" })).toBeUndefined();
+      expect(resolveHindsightPinTag({ hindsightPinTag: "v0.16.11" })).toBe("v0.16.11");
+    });
   });
 
   it("inserts regen-compose-for-release-override BEFORE pull-images when --channel is set", () => {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -119,6 +119,11 @@ interface UpdateOptions {
   /** Test seam — override `memory.backend === "hindsight"` detection for
    *  the `refresh-hindsight` step instead of reading from switchroom.yaml. */
   memoryBackendHindsight?: boolean;
+  /** Test seam — override the resolved hindsight image pin tag threaded
+   *  into `memory setup --recreate --tag <tag>` instead of resolving it
+   *  from `--pin` / the persisted `release.pin`. An empty string forces
+   *  the floating `:latest` path (no `--tag`). */
+  hindsightPinTag?: string;
   /** One-shot release-channel override (mirrors `apply --channel`). */
   channel?: "dev" | "rc" | "latest";
   /** One-shot release-pin override (mirrors `apply --pin`). Mutually
@@ -325,6 +330,45 @@ export function parseUpdateResultLine(stdout: string): {
   } catch {
     return null;
   }
+}
+
+/**
+ * Resolve the hindsight image tag to pin the `refresh-hindsight` recreate
+ * to (#2851), mirroring how `switchroom rollout` threads `--tag <target>`.
+ *
+ * `memory setup` never reads the durable `release.pin` (unlike compose /
+ * `webd|hostd install`, whose tags resolve from it), so without an explicit
+ * `--tag` the recreate pulls floating `:latest` and the memory singleton
+ * silently drifts a version behind the pinned fleet — the v0.17.5 roll left
+ * hindsight on `:latest` this way.
+ *
+ * Resolution order: an explicit `hindsightPinTag` override (test seam; empty
+ * string forces the floating path) → nothing when a floating `--channel`
+ * override is in play → this run's `--pin` → the already-persisted
+ * `release.pin`. Only a concrete `vX.Y.Z` is returned, because the release
+ * workflow publishes the hindsight image per version as `:vX.Y.Z`; a
+ * `sha-…` pin (or no pin / unreadable config) yields `undefined` → floating
+ * `:latest`, the standalone default. Resolved lazily at run() time so
+ * build-time step inspection stays free of config I/O.
+ */
+export function resolveHindsightPinTag(opts: UpdateOptions): string | undefined {
+  if (typeof opts.hindsightPinTag === "string") {
+    return opts.hindsightPinTag || undefined;
+  }
+  // A floating channel override has no fixed version — leave hindsight
+  // floating too.
+  if (opts.channel) return undefined;
+  let candidate = opts.pin;
+  if (!candidate) {
+    try {
+      candidate = loadConfig().release?.pin ?? undefined;
+    } catch {
+      // Best-effort: fall back to floating :latest rather than fail the
+      // whole update if config can't be loaded.
+      candidate = undefined;
+    }
+  }
+  return candidate && /^v\d+\.\d+\.\d+$/.test(candidate) ? candidate : undefined;
 }
 
 /**
@@ -550,19 +594,30 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
     },
   });
 
-  // refresh-hindsight: pull the latest hindsight image and recreate the
+  // refresh-hindsight: pull the hindsight image and recreate the
   // container. Same isolation gap as refresh-hostd/refresh-web — the
   // hindsight singleton runs as its own standalone `docker run` container
   // (managed by `memory setup`, NOT in the agent fleet's compose project),
-  // and it uses a floating `:latest` tag that `pull-images` / `--pin`
-  // never touch. So before this step existed, `switchroom update` left
-  // hindsight on whatever stale `:latest` it last started with — even
-  // after the durability fixes (#2412 stable worker_id, #2416 backups /
-  // healthcheck / self-maintenance) were already baked into `:latest`,
-  // the running container kept serving the pre-fix image until an operator
-  // separately ran `memory setup --stop` + `memory setup`. This step folds
-  // that recreate into the update (reusing the container's current port so
-  // memory.config.url never changes under the fleet).
+  // so `pull-images` never touches it. Before this step existed,
+  // `switchroom update` left hindsight on whatever stale image it last
+  // started with — even after the durability fixes (#2412 stable
+  // worker_id, #2416 backups / healthcheck / self-maintenance) were baked
+  // into the image, the running container kept serving the pre-fix bits
+  // until an operator separately ran `memory setup --stop` + `memory
+  // setup`. This step folds that recreate into the update (reusing the
+  // container's current port so memory.config.url never changes under the
+  // fleet).
+  //
+  // Pin the recreate to the fleet's target version (#2851). Unlike
+  // refresh-web/refresh-hostd — whose tags resolve from the durable
+  // `release.pin` via compose / `webd|hostd install` — `memory setup`
+  // never reads `release.pin`, so without an explicit `--tag` it recreates
+  // on floating `:latest` and the memory singleton silently drifts a
+  // version behind the pinned fleet (v0.17.5 roll left hindsight on
+  // `:latest`). Mirror `switchroom rollout`, which threads `--tag
+  // <target>`. The target is resolved lazily inside run() (see
+  // {@link resolveHindsightPinTag}) so build-time step inspection stays
+  // free of config I/O.
   //
   // Skipped when the memory backend isn't hindsight OR --skip-images is set.
   let memoryBackendHindsight: boolean;
@@ -580,14 +635,17 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
   steps.push({
     name: "refresh-hindsight",
     description:
-      "switchroom memory setup --recreate — pull latest hindsight image + recreate the memory singleton (standalone container, reusing its current port)",
+      "switchroom memory setup --recreate — pull the hindsight image (pinned to the release target when set, else :latest) + recreate the memory singleton (reusing its current port)",
     skipReason: !memoryBackendHindsight
       ? "memory.backend is not hindsight — no hindsight singleton to refresh"
       : opts.skipImages
         ? "--skip-images flag set"
         : undefined,
     run: () => {
-      const r = runner(process.execPath, [scriptPath, "memory", "setup", "--recreate"]);
+      const pinTag = resolveHindsightPinTag(opts);
+      const setupArgs = ["memory", "setup", "--recreate"];
+      if (pinTag) setupArgs.push("--tag", pinTag);
+      const r = runner(process.execPath, [scriptPath, ...setupArgs]);
       if (r.status !== 0) throw new Error("switchroom memory setup --recreate failed");
     },
   });


### PR DESCRIPTION
## Summary

`switchroom update`'s `refresh-hindsight` step recreated the hindsight singleton via `memory setup --recreate` with **no `--tag`**, so it always pulled floating `:latest` — even on a version-pinned fleet. This is the hole behind #2851: the v0.17.5 roll left `switchroom-hindsight` on `:latest`.

## Root cause (confirmed)

- On `origin/main`, `rollout.ts` already threads `--tag ${target}` into the recreate (`memory setup --recreate --tag <target>`), and `memory setup` honours `--tag` → `pullHindsightImage`/`startHindsight` → `hindsightImageRef` (`:vX.Y.Z`). That path is pinned.
- The sibling `refresh-web` / `refresh-hostd` steps in `update.ts` need no `--tag` because `--pin` **persists `release.pin`** and their tags resolve from compose / `webd|hostd install`. **But `memory setup` never reads `release.pin`**, so `update.ts`'s untagged `memory setup --recreate` (`update.ts:590`) floats to `:latest`. It is the only unpinned `memory setup --recreate` callsite on main.
- **Live proof:** the running container was recreated at `2026-07-05T12:20:23Z` (the roll window) on `:latest`, and **no `…switchroom-hindsight:v0.17.5` tag was ever pulled** to this host (highest local tag: `v0.17.3`) — so the pinned `--tag` path demonstrably did not run; an unpinned `memory setup --recreate` did.

## Fix

Resolve the target lazily in `run()` via `resolveHindsightPinTag(opts)`: this run's `--pin`, else the persisted `release.pin`; thread it as `memory setup --recreate --tag <version>`. Only a concrete `vX.Y.Z` is pinnable (release workflow publishes hindsight per version as `:vX.Y.Z`). A `sha-…` pin, a floating `--channel`, or no pin → floating `:latest` (the standalone default, unchanged). Lazy resolution keeps build-time step inspection free of config I/O.

## Test plan

- [x] `vitest run src/cli/update.test.ts` — 67 pass, incl. new: `--tag v0.17.5` threaded under `--pin`; omitted when floating / under `--channel` / for a `sha-` pin; `resolveHindsightPinTag` unit coverage.
- [x] `tsc --noEmit` clean.

## Risk

Low. Behaviour is unchanged for unpinned / channel / sha updates (still `:latest`). Only a `vX.Y.Z`-pinned host now pins hindsight to match the fleet — the intended fix.

## Content-safety note (for the live remediation, handled separately)

The running `:latest` (RepoDigest `40b5511c…`) is **byte-identical to GHCR `v0.17.5`** (`buildx imagetools inspect` top-level digest matches). So the label is wrong but the bits are already v0.17.5 — remediation is low-urgency (re-tag/recreate on the pin); the real risk this fix closes is the *next* unpinned recreate pulling a drifted `:latest` (GHCR `:latest` has since advanced to `05ee53e7…`).

## Follow-up (out of scope, flagged for discussion)

A truly manual `switchroom memory setup --recreate` on a pinned host still floats to `:latest` (that's `memory setup`'s documented standalone default). Making `memory setup` itself fall back to `release.pin` when `--tag` is omitted would close that residual and make it consistent with `webd`/`hostd install` — but it changes standalone-command semantics, so I kept it out of this PR.

Closes #2851 (pending live remediation).