### PR TITLE
feat(memory): sparse chat-legible memory surface (hindsight Phase 4)

### DIFF
--- a/docs/telegram-plugin.md
+++ b/docs/telegram-plugin.md
@@ -63,6 +63,24 @@ The header carries the **real dispatch task** (the `description` passed to the `
 
 The feed is on by default. To disable it per-agent, set `SWITCHROOM_WORKER_ACTIVITY_FEED=0` in the agent's gateway environment.
 
+### Chat-legible memory (remembered / forgot)
+
+When the agent **materially changes what it remembers** during a turn — stores a new standing directive, or invalidates/demotes an existing memory — the gateway surfaces **one terse line** in the originating chat/topic:
+
+```
+📌 remembered: "Always prefer TypeScript for this user's projects"
+✂️ forgot: superseded deploy runbook
+```
+
+This makes memory honest and legible without being noisy. It is deliberately **sparse and material-only**:
+
+- Fires only on `mcp__hindsight__create_directive` (📌 remembered) and `mcp__hindsight__invalidate_memory` / the `switchroom memory demote` tag path (✂️ forgot).
+- **Never** on ordinary recall, and **never** on routine consolidation — a per-turn "here's what I remember" line would itself be the "regurgitating old facts unprompted" anti-pattern the `remember-across-sessions` job forbids.
+
+Detection is a deterministic tool-call observation (no model call, no polling). The line is a **real message** in the originating topic (never the operator DM), so it's durable and observable.
+
+The surface is **on by default** (kill-switch: `SWITCHROOM_MEMORY_LEGIBILITY=0`). To disable it per-agent, set `SWITCHROOM_MEMORY_LEGIBILITY=0` in the agent's gateway environment.
+
 ### Message history
 
 A local SQLite database records every inbound and outbound message. After a Claude Code restart, the agent can call `get_recent_messages` to recover context instead of asking "what were we doing?". History survives process restarts and session resets.
@@ -197,3 +215,4 @@ The switchroom fork reads additional env vars from `start.sh`:
 | `SWITCHROOM_AGENT_NAME` | Auto-set by scaffold | Agent name for self-restart detection |
 | `SWITCHROOM_CONFIG` | Auto-set by scaffold | Path to switchroom.yaml for config resolution |
 | `SWITCHROOM_WORKER_ACTIVITY_FEED` | Gateway env (kill-switch) | On by default; `0` disables the background worker-activity feed. See "Background worker activity feed" above |
+| `SWITCHROOM_MEMORY_LEGIBILITY` | Gateway env (kill-switch) | On by default; `0` disables the sparse "📌 remembered / ✂️ forgot" memory surface. See "Chat-legible memory" above |

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -93,6 +93,11 @@ import {
 import { StatusReactionController } from '../status-reactions.js'
 import { DeferredDoneReactions } from '../reaction-defer.js'
 import { createWorkerActivityFeed, isWorkerActivityFeedEnabled } from '../worker-activity-feed.js'
+import {
+  detectMemoryLegibilityEvent,
+  isMemoryLegibilityEnabled,
+  renderMemoryLegibilityLine,
+} from '../memory-legibility.js'
 import { reconcilePin, type PinBotApi } from '../status-pin-driver.js'
 import type { PinState, DesiredPin } from '../status-pin.js'
 import { decidePinAction } from '../status-pin.js'
@@ -6222,6 +6227,12 @@ const SILENCE_DEFER_INFLIGHT_TOOLS = process.env.SWITCHROOM_SILENCE_DEFER_INFLIG
 // and null currentTurn mid-work. Default ON; SWITCHROOM_SILENCE_LIVENESS_PRODUCTION=0
 // restores the legacy "only a real reply resets the clock" behaviour.
 const SILENCE_LIVENESS_PRODUCTION = process.env.SWITCHROOM_SILENCE_LIVENESS_PRODUCTION !== '0'
+// Sparse chat-legible memory (#2849, hindsight Phase 4). Surface ONE terse
+// line in the originating chat/topic when the interactive session materially
+// changes what it remembers (create_directive / invalidate / demote) — never
+// on ordinary recall or routine consolidation. Default ON;
+// SWITCHROOM_MEMORY_LEGIBILITY=0 disables it.
+const MEMORY_LEGIBILITY_ENABLED = isMemoryLegibilityEnabled(process.env.SWITCHROOM_MEMORY_LEGIBILITY)
 
 /**
  * Feed-survival predicate — the single source of truth for "is this turn
@@ -12269,6 +12280,52 @@ function clearActivitySummary(turn: CurrentTurn, finalHtmlOverride?: string | nu
   })
 }
 
+/**
+ * #2849 hindsight Phase 4 — sparse chat-legible memory.
+ *
+ * Fire-and-forget: if this main-agent tool call is a material memory
+ * operation (create_directive → 📌 remembered; invalidate/demote → ✂️
+ * forgot), send ONE terse real message into the turn's originating
+ * chat/topic. Routes on `turn.sessionChatId` / `turn.sessionThreadId`
+ * (the originating topic, never the operator DM), through
+ * `retryWithThreadFallback` so a deleted forum topic can't crash the
+ * gateway. Non-material tool calls return silently — no line on ordinary
+ * recall or routine consolidation. Kill-switch: SWITCHROOM_MEMORY_LEGIBILITY=0.
+ */
+function surfaceMemoryLegibility(
+  turn: CurrentTurn,
+  toolName: string,
+  input: Record<string, unknown> | undefined,
+): void {
+  if (!MEMORY_LEGIBILITY_ENABLED) return
+  const event = detectMemoryLegibilityEvent(toolName, input)
+  if (event == null) return
+  const chatId = turn.sessionChatId
+  const threadId = turn.sessionThreadId
+  const line = renderMemoryLegibilityLine(event)
+  process.stderr.write(
+    `telegram gateway: memory-legibility ${event.kind} chat=${chatId} ` +
+      `thread=${threadId ?? '-'} tool=${toolName}\n`,
+  )
+  void retryWithThreadFallback(
+    robustApiCall,
+    (tid) =>
+      bot.api.sendMessage(chatId, line, {
+        parse_mode: 'HTML',
+        // Status surface, not the user's answer — never ping the device.
+        disable_notification: true,
+        ...(tid != null ? { message_thread_id: tid } : {}),
+      }),
+    { threadId, chat_id: chatId, verb: 'memory-legibility.sendMessage' },
+  ).catch((err) => {
+    process.stderr.write(
+      `telegram gateway: memory-legibility send failed: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    )
+  })
+}
+
 function handleSessionEvent(ev: SessionEvent): void {
   switch (ev.kind) {
     case 'enqueue': {
@@ -12567,6 +12624,14 @@ function handleSessionEvent(ev: SessionEvent): void {
       // of dropping. The answer-stream's own dedup handles overlap
       // with the reply tool's payload.
       preambleSuppressor.onTool({ isReplyTool: isTelegramSurfaceTool(ev.toolName) })
+      // #2849 Phase 4 — sparse chat-legible memory. Surface ONE terse line in
+      // the originating chat/topic when this tool call materially changes what
+      // the agent remembers (create_directive / invalidate / demote). Fires
+      // BEFORE the `if (!ctrl) return` status-reaction gate below so it works
+      // on turns with no active status-reaction controller. Deterministic
+      // tool-call observation — no model call, no polling; ordinary recall and
+      // routine consolidation never reach here (they aren't material tools).
+      surfaceMemoryLegibility(turn, ev.toolName, ev.input)
       const ctrl = activeStatusReactions.get(statusKey(turn.sessionChatId, turn.sessionThreadId))
       const name = ev.toolName
       // Phase tracking removed in #553 PR 5 — phases only fed the

--- a/telegram-plugin/memory-legibility.ts
+++ b/telegram-plugin/memory-legibility.ts
@@ -1,0 +1,160 @@
+/**
+ * Sparse, chat-legible memory surface — hindsight Phase 4 (#2849).
+ *
+ * When the interactive `claude` session materially changes what it
+ * remembers during a turn — stores a new standing directive, or
+ * invalidates / demotes an existing memory — this module surfaces ONE
+ * terse line in the ORIGINATING Telegram chat/topic:
+ *
+ *   📌 <i>remembered:</i> "Always prefer TypeScript for this user"
+ *   ✂️ <i>forgot:</i> superseded deploy runbook
+ *
+ * Why so sparse: the `remember-across-sessions` job spec lists
+ * "regurgitating old facts unprompted just to prove it remembered" as a
+ * top anti-pattern. A per-turn line would *become* that anti-pattern, so
+ * this surface fires ONLY on a genuine store/correct — never on ordinary
+ * recall, and never on routine consolidation. Detection is a
+ * deterministic tool-call observation (no model call, no polling): we
+ * watch the main-agent turn stream for the specific hindsight memory
+ * tools that represent a material change.
+ *
+ * Design notes / references:
+ *   - RFC Phase 4: `reference/rfcs/hindsight-synthesis-layers.md`
+ *   - Job spec: `reference/jobs/remember-across-sessions.md`
+ *   - The `consolidation.completed` webhook the RFC names as the poll-free
+ *     driver for the "updated what I know about Y" side does NOT exist in
+ *     the pinned hindsight image (v0.8.2) — it is RFC-only. This v1 ships
+ *     the tool-observation path; the webhook stays a follow-up.
+ *
+ * Reuse: `classifyMemoryToolCall` / `detectMemoryLegibilityEvent` are the
+ * single, reusable "did a directive-create / invalidate happen in this
+ * turn?" primitive. Phase 3 Stage B (#2848) imports these rather than
+ * re-deriving the tool-name matching inline.
+ */
+
+import { stripMarkdown, truncate } from './card-format.js'
+
+/** ON by default; an operator opts out with SWITCHROOM_MEMORY_LEGIBILITY=0.
+ *  Mirrors the SWITCHROOM_WORKER_ACTIVITY_FEED convention (only the literal
+ *  string '0' disables; unset / anything else → enabled). */
+export function isMemoryLegibilityEnabled(envVal: string | undefined): boolean {
+  return envVal !== '0'
+}
+
+/**
+ * The material memory operations we surface. Deliberately narrow — an
+ * ordinary `recall` / `reflect` / benign `update_memory` (a non-demote
+ * edit) is NOT material and returns null from the classifier.
+ */
+export type MemoryToolClass = 'directive-create' | 'memory-invalidate'
+
+/** The two hindsight tools that represent a material store / correct.
+ *  Fully-qualified names as they appear in the turn stream (`ev.toolName`). */
+export const CREATE_DIRECTIVE_TOOL = 'mcp__hindsight__create_directive'
+export const INVALIDATE_MEMORY_TOOL = 'mcp__hindsight__invalidate_memory'
+/** The demote path (`switchroom memory demote`) adds this client-side tag
+ *  via the `update_memory` tool; that specific tagging is the "forgot"
+ *  signal, whereas a plain `update_memory` edit is not material. */
+export const UPDATE_MEMORY_TOOL = 'mcp__hindsight__update_memory'
+export const DEMOTE_FROM_RECALL_MARKER = 'demote-from-recall'
+
+export type MemoryLegibilityKind = 'remembered' | 'forgot'
+
+export interface MemoryLegibilityEvent {
+  kind: MemoryLegibilityKind
+  /** Best-effort human detail (directive body / invalidate reason). May be
+   *  empty when the tool carries no legible detail — the render then falls
+   *  back to a bare "forgot a memory" line. Raw (unescaped, unstripped);
+   *  `renderMemoryLegibilityLine` does the cleanup. */
+  detail: string
+}
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v : ''
+}
+
+/** True when an `update_memory` call's tags carry the demote-from-recall
+ *  marker — the only shape of `update_memory` that is a material correction.
+ *  Bracket- and case-tolerant (`[demote-from-recall]` / `demote-from-recall`). */
+function hasDemoteTag(input: Record<string, unknown> | undefined): boolean {
+  if (input == null) return false
+  const pools: unknown[] = []
+  for (const key of ['add_tags', 'tags']) {
+    const val = input[key]
+    if (Array.isArray(val)) pools.push(...val)
+    else if (typeof val === 'string') pools.push(val)
+  }
+  return pools.some(
+    (t) => typeof t === 'string' && t.toLowerCase().includes(DEMOTE_FROM_RECALL_MARKER),
+  )
+}
+
+/**
+ * Classify a single tool call as a material memory operation, or null if
+ * it isn't one. This is the reusable detection primitive: it answers "did a
+ * directive-create / invalidate happen in this turn?" with no rendering
+ * concern. #2848 Stage B imports this.
+ */
+export function classifyMemoryToolCall(
+  toolName: string,
+  input: Record<string, unknown> | undefined,
+): MemoryToolClass | null {
+  if (toolName === CREATE_DIRECTIVE_TOOL) return 'directive-create'
+  if (toolName === INVALIDATE_MEMORY_TOOL) return 'memory-invalidate'
+  // `update_memory` is material ONLY when it applies the demote-from-recall
+  // tag; any other edit is routine and must not surface a line.
+  if (toolName === UPDATE_MEMORY_TOOL && hasDemoteTag(input)) return 'memory-invalidate'
+  return null
+}
+
+/**
+ * Detect a surfaceable memory-legibility event from one tool call, or null.
+ * Pure — no I/O. Extracts the best-available human detail from the tool
+ * input so the caller can render + route it.
+ */
+export function detectMemoryLegibilityEvent(
+  toolName: string,
+  input: Record<string, unknown> | undefined,
+): MemoryLegibilityEvent | null {
+  const klass = classifyMemoryToolCall(toolName, input)
+  if (klass == null) return null
+  if (klass === 'directive-create') {
+    // The live server requires `content` (directive body); the profile
+    // guidance example writes `create_directive(text)`, so tolerate both,
+    // then fall back to the directive `name`.
+    const detail =
+      asString(input?.content).trim() ||
+      asString(input?.text).trim() ||
+      asString(input?.name).trim()
+    return { kind: 'remembered', detail }
+  }
+  // memory-invalidate: prefer a human `reason`; the opaque memory_id is not
+  // user-legible, so omit it and let the render use the bare fallback.
+  const detail = asString(input?.reason).trim()
+  return { kind: 'forgot', detail }
+}
+
+/** HTML-escape for parse_mode:'HTML' (escape the 3 entity-significant chars). */
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/** Max chars of directive/reason detail shown on the one-liner. */
+const DETAIL_MAX = 160
+
+/**
+ * Render the terse one-line surface (Telegram HTML). Callers send this as a
+ * real `sendMessage` (not a draft/reaction) so it's observable + durable.
+ *
+ *   📌 <i>remembered:</i> "<directive, cleaned + truncated>"
+ *   ✂️ <i>forgot:</i> <reason>            (or "✂️ <i>forgot a memory.</i>")
+ */
+export function renderMemoryLegibilityLine(ev: MemoryLegibilityEvent): string {
+  const clean = truncate(stripMarkdown(ev.detail).replace(/\s+/g, ' ').trim(), DETAIL_MAX)
+  if (ev.kind === 'remembered') {
+    if (clean.length === 0) return `📌 <i>remembered a new directive.</i>`
+    return `📌 <i>remembered:</i> "${escapeHtml(clean)}"`
+  }
+  if (clean.length === 0) return `✂️ <i>forgot a memory.</i>`
+  return `✂️ <i>forgot:</i> ${escapeHtml(clean)}`
+}

--- a/telegram-plugin/tests/memory-legibility.test.ts
+++ b/telegram-plugin/tests/memory-legibility.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyMemoryToolCall,
+  detectMemoryLegibilityEvent,
+  isMemoryLegibilityEnabled,
+  renderMemoryLegibilityLine,
+  CREATE_DIRECTIVE_TOOL,
+  INVALIDATE_MEMORY_TOOL,
+  UPDATE_MEMORY_TOOL,
+} from '../memory-legibility.js'
+
+describe('isMemoryLegibilityEnabled — default-ON kill switch', () => {
+  it('is ON when unset (fresh setup / defaults principle)', () => {
+    expect(isMemoryLegibilityEnabled(undefined)).toBe(true)
+  })
+  it('is ON for any value except the literal "0"', () => {
+    expect(isMemoryLegibilityEnabled('1')).toBe(true)
+    expect(isMemoryLegibilityEnabled('')).toBe(true)
+    expect(isMemoryLegibilityEnabled('true')).toBe(true)
+  })
+  it('is OFF only for "0"', () => {
+    expect(isMemoryLegibilityEnabled('0')).toBe(false)
+  })
+})
+
+describe('classifyMemoryToolCall — the reusable "did a material memory op happen?" primitive (#2848 Stage B imports this)', () => {
+  it('classifies create_directive as directive-create', () => {
+    expect(classifyMemoryToolCall(CREATE_DIRECTIVE_TOOL, { content: 'x', name: 'y' })).toBe(
+      'directive-create',
+    )
+  })
+
+  it('classifies invalidate_memory as memory-invalidate', () => {
+    expect(classifyMemoryToolCall(INVALIDATE_MEMORY_TOOL, { memory_id: 'm1' })).toBe(
+      'memory-invalidate',
+    )
+  })
+
+  it('classifies update_memory as memory-invalidate ONLY when it applies the demote-from-recall tag', () => {
+    expect(
+      classifyMemoryToolCall(UPDATE_MEMORY_TOOL, {
+        memory_id: 'm1',
+        add_tags: ['[demote-from-recall]'],
+      }),
+    ).toBe('memory-invalidate')
+    // bracket-less + case variant still matches
+    expect(
+      classifyMemoryToolCall(UPDATE_MEMORY_TOOL, { add_tags: ['DEMOTE-FROM-RECALL'] }),
+    ).toBe('memory-invalidate')
+  })
+
+  it('does NOT classify a benign update_memory edit (no demote tag) — material-only', () => {
+    expect(
+      classifyMemoryToolCall(UPDATE_MEMORY_TOOL, { memory_id: 'm1', add_tags: ['urgent'] }),
+    ).toBeNull()
+    expect(classifyMemoryToolCall(UPDATE_MEMORY_TOOL, { content: 'edited' })).toBeNull()
+  })
+
+  it('does NOT classify ordinary recall / reflect / retain — no line on routine memory ops', () => {
+    for (const tool of [
+      'mcp__hindsight__recall',
+      'mcp__hindsight__reflect',
+      'mcp__hindsight__retain',
+      'mcp__hindsight__sync_retain',
+      'mcp__hindsight__list_directives',
+      'Bash',
+      'Read',
+    ]) {
+      expect(classifyMemoryToolCall(tool, { query: 'x' })).toBeNull()
+    }
+  })
+})
+
+describe('detectMemoryLegibilityEvent — extracts the human detail', () => {
+  it('reads directive body from the real `content` wire field', () => {
+    expect(
+      detectMemoryLegibilityEvent(CREATE_DIRECTIVE_TOOL, {
+        name: 'ts-pref',
+        content: 'Always prefer TypeScript for this user',
+      }),
+    ).toEqual({ kind: 'remembered', detail: 'Always prefer TypeScript for this user' })
+  })
+
+  it('falls back to `text` then `name` when `content` is absent', () => {
+    expect(detectMemoryLegibilityEvent(CREATE_DIRECTIVE_TOOL, { text: 'Prefer TS' })).toEqual({
+      kind: 'remembered',
+      detail: 'Prefer TS',
+    })
+    expect(detectMemoryLegibilityEvent(CREATE_DIRECTIVE_TOOL, { name: 'Prefer TS' })).toEqual({
+      kind: 'remembered',
+      detail: 'Prefer TS',
+    })
+  })
+
+  it('surfaces an invalidate reason but omits the opaque memory_id', () => {
+    expect(
+      detectMemoryLegibilityEvent(INVALIDATE_MEMORY_TOOL, {
+        memory_id: 'mem_abc123',
+        reason: 'superseded deploy runbook',
+      }),
+    ).toEqual({ kind: 'forgot', detail: 'superseded deploy runbook' })
+    // no reason → empty detail (render uses the bare fallback), never the id
+    expect(detectMemoryLegibilityEvent(INVALIDATE_MEMORY_TOOL, { memory_id: 'mem_abc' })).toEqual({
+      kind: 'forgot',
+      detail: '',
+    })
+  })
+
+  it('returns null for non-material tools', () => {
+    expect(detectMemoryLegibilityEvent('mcp__hindsight__recall', { query: 'x' })).toBeNull()
+    expect(detectMemoryLegibilityEvent(UPDATE_MEMORY_TOOL, { content: 'edit' })).toBeNull()
+  })
+
+  it('tolerates undefined input', () => {
+    expect(detectMemoryLegibilityEvent(CREATE_DIRECTIVE_TOOL, undefined)).toEqual({
+      kind: 'remembered',
+      detail: '',
+    })
+  })
+})
+
+describe('renderMemoryLegibilityLine — terse HTML one-liner', () => {
+  it('renders a remembered directive in quotes', () => {
+    expect(
+      renderMemoryLegibilityLine({ kind: 'remembered', detail: 'Always prefer TypeScript' }),
+    ).toBe('📌 <i>remembered:</i> "Always prefer TypeScript"')
+  })
+
+  it('renders a forgot line with the reason', () => {
+    expect(renderMemoryLegibilityLine({ kind: 'forgot', detail: 'superseded runbook' })).toBe(
+      '✂️ <i>forgot:</i> superseded runbook',
+    )
+  })
+
+  it('uses a bare fallback when there is no legible detail', () => {
+    expect(renderMemoryLegibilityLine({ kind: 'remembered', detail: '' })).toBe(
+      '📌 <i>remembered a new directive.</i>',
+    )
+    expect(renderMemoryLegibilityLine({ kind: 'forgot', detail: '   ' })).toBe(
+      '✂️ <i>forgot a memory.</i>',
+    )
+  })
+
+  it('HTML-escapes the detail so it cannot break parse_mode:HTML', () => {
+    const out = renderMemoryLegibilityLine({
+      kind: 'remembered',
+      detail: 'use <b> & compare a < b',
+    })
+    expect(out).toBe('📌 <i>remembered:</i> "use &lt;b&gt; &amp; compare a &lt; b"')
+    // the only literal < / > left are the wrapper <i> tags
+    expect(out).not.toContain('<b>')
+  })
+
+  it('strips markdown and collapses whitespace before truncating', () => {
+    const out = renderMemoryLegibilityLine({
+      kind: 'remembered',
+      detail: '**Always**   prefer  `TypeScript`',
+    })
+    expect(out).toBe('📌 <i>remembered:</i> "Always prefer TypeScript"')
+  })
+
+  it('truncates very long directive bodies with an ellipsis', () => {
+    const long = 'x'.repeat(400)
+    const out = renderMemoryLegibilityLine({ kind: 'remembered', detail: long })
+    expect(out.length).toBeLessThan(220)
+    expect(out).toContain('…')
+  })
+})

--- a/telegram-plugin/uat/scenarios/jtbd-memory-legibility-channel.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-memory-legibility-channel.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Sparse chat-legible memory in a SUPERGROUP (#2849, hindsight Phase 4) — UAT.
+ *
+ * Channel twin of `jtbd-memory-legibility-dm`. A directive stored while the
+ * conversation is happening in a supergroup must surface its `📌 remembered:`
+ * line IN the supergroup — never the operator DM (the known status-routing
+ * bug class). Proves the memory-legibility status surface has DM/channel
+ * parity: it routes on the ORIGINATING topic (`turn.sessionChatId` /
+ * `sessionThreadId`), not the owner DM.
+ *
+ * Self-skips green when no test supergroup is wired (SWITCHROOM_UAT_CHAT_ID
+ * unset or not resolvable). Uses the General topic (mtcute here has no
+ * forum-topic create API).
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+import { expectMessage } from "../assertions.js";
+
+const AGENT = "test-harness";
+const SUPERGROUP_ID = Number.parseInt(process.env.SWITCHROOM_UAT_CHAT_ID ?? "", 10);
+
+const REMEMBER_PROMPT =
+  `Persist this as a standing directive using the ` +
+  `mcp__hindsight__create_directive tool, with the directive content set ` +
+  `to exactly: "Always greet me as Captain at the start of a reply". ` +
+  `Name the directive "greeting-captain". After creating it, send a brief ` +
+  `one-line confirmation.`;
+
+const REMEMBERED_RE = /📌\s*remembered/i;
+
+describe("uat: sparse chat-legible memory in a supergroup (#2849 channel parity)", () => {
+  it(
+    "surfaces the 📌 remembered line IN the supergroup, not the DM",
+    async () => {
+      if (!Number.isFinite(SUPERGROUP_ID)) {
+        console.warn("[memory-legibility channel UAT] SWITCHROOM_UAT_CHAT_ID unset — skipping");
+        return;
+      }
+      const sc = await spinUp({ agent: AGENT, settleMs: 0 });
+      try {
+        await sc.driver.primeDialogs();
+        if (!(await sc.driver.canResolve(SUPERGROUP_ID))) {
+          console.warn(`[memory-legibility channel UAT] supergroup ${SUPERGROUP_ID} not resolvable — skipping`);
+          return;
+        }
+        await sc.driver.sendText(SUPERGROUP_ID, REMEMBER_PROMPT);
+
+        const line = await expectMessage(sc.driver, SUPERGROUP_ID, REMEMBERED_RE, {
+          timeout: 90_000,
+          senderFilter: { notUserId: sc.driverUserId },
+        });
+        console.log(
+          `[memory-legibility channel UAT] remembered line (id=${line.messageId}, chat=${line.chatId}): ${JSON.stringify(line.text)}`,
+        );
+        expect(line.chatId).toBe(SUPERGROUP_ID); // parity proof: in the channel, not the DM
+        expect(line.fromBot).toBe(true);
+        expect(line.messageId).toBeGreaterThan(0);
+        expect(line.text).toMatch(/Captain/i);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    180_000,
+  );
+});

--- a/telegram-plugin/uat/scenarios/jtbd-memory-legibility-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-memory-legibility-dm.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Sparse chat-legible memory (#2849, hindsight Phase 4) — DM UAT.
+ *
+ * Serves the `remember-across-sessions` job. When the interactive session
+ * stores a new standing directive, ONE terse line must surface in the
+ * originating chat: `📌 remembered: "<directive>"`. It's a REAL message
+ * (sendMessage, not a draft/reaction) so mtcute can observe it. The line
+ * is sparse + material-only — ordinary recall never surfaces one — and is
+ * ON by default (kill-switch SWITCHROOM_MEMORY_LEGIBILITY=0).
+ *
+ * This scenario asks the agent to persist an explicit standing rule via
+ * the create_directive tool, then asserts the 📌 remembered line appears
+ * from the bot in the DM.
+ *
+ * Note: the model must actually call `mcp__hindsight__create_directive`.
+ * The prompt names the tool + the rule verbatim to make the tool call
+ * deterministic. Requires the test-harness agent running an image that
+ * includes #2849.
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+const REMEMBER_PROMPT =
+  `Persist this as a standing directive using the ` +
+  `mcp__hindsight__create_directive tool, with the directive content set ` +
+  `to exactly: "Always greet me as Captain at the start of a reply". ` +
+  `Name the directive "greeting-captain". After creating it, send a brief ` +
+  `one-line confirmation.`;
+
+// The legibility line: `📌 remembered: "<directive body, truncated>"`.
+const REMEMBERED_RE = /📌\s*remembered/i;
+
+describe("uat: sparse chat-legible memory — remembered line (#2849)", () => {
+  it(
+    "surfaces a 📌 remembered line in the DM when a directive is created",
+    async () => {
+      const sc = await spinUp({ agent: "test-harness" });
+      try {
+        await sc.sendDM(REMEMBER_PROMPT);
+
+        // The 📌 remembered line — a real bot message in this DM. May arrive
+        // alongside/near the agent's confirmation reply; generous budget for
+        // the tool round-trip + transcript flush.
+        const line = await sc.expectMessage(REMEMBERED_RE, {
+          from: "bot",
+          timeout: 90_000,
+        });
+        console.log(
+          `[memory-legibility UAT] remembered line (id=${line.messageId}): ${JSON.stringify(line.text)}`,
+        );
+        expect(line.messageId).toBeGreaterThan(0);
+        // The directive body should ride along in the line.
+        expect(line.text).toMatch(/Captain/i);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    180_000,
+  );
+});


### PR DESCRIPTION
Closes #2849 (hindsight Phase 4 — sparse chat-legible memory).

## Summary
Surfaces ONE terse line in the **originating** Telegram chat/topic when the interactive `claude` session materially changes what it remembers during a turn:

- `create_directive` observed → `📌 remembered: "<directive, truncated>"`
- `invalidate_memory` / the `switchroom memory demote` (`update_memory` + demote-from-recall tag) path → `✂️ forgot: …`

Deterministic tool-call observation — **no model call, no polling, no `claude -p`** (stays inside the claude-native invariant).

## Why
The `remember-across-sessions` job wants honest, legible recall, but the `<hindsight_memories>` recall block is hidden `additionalContext` and consolidation is invisible (RFC tensions 1 & 2). This makes *material* memory changes visible **without** becoming the "regurgitating old facts unprompted" anti-pattern the job forbids: it is sparse + material-only — **no line on ordinary recall, no line on routine consolidation**.

Serves **`remember-across-sessions`** (`reference/jobs/remember-across-sessions.md`).

## Design
- New reusable module `telegram-plugin/memory-legibility.ts`. `classifyMemoryToolCall` / `detectMemoryLegibilityEvent` are the single **"did a directive-create / invalidate happen this turn?"** primitive — Phase 3 Stage B (#2848) imports these instead of re-deriving the tool matching inline.
- Wired into `gateway.ts` `case 'tool_use'` (main-agent turn stream), routed on `turn.sessionChatId` / `sessionThreadId` (originating topic, **never** the operator DM) via `retryWithThreadFallback` so a deleted forum topic can't crash the gateway. Real `sendMessage` (not a draft/reaction) so mtcute UAT can observe it.
- `update_memory` is material **only** when it carries the demote-from-recall tag; a benign edit surfaces no line.
- Kill-switch `SWITCHROOM_MEMORY_LEGIBILITY=0` (default ON), mirroring the `SWITCHROOM_WORKER_ACTIVITY_FEED` convention. Documented in `docs/telegram-plugin.md`.

## Webhook note
The `consolidation.completed` webhook the RFC names as the poll-free "updated what I know about Y" driver **does not exist** in the pinned hindsight image (v0.8.2) — it is RFC-only (verified: zero matches in `vendor/hindsight-memory/`). This v1 ships the tool-observation path; the webhook stays a follow-up.

## Test plan
- [x] 19 unit tests (`telegram-plugin/tests/memory-legibility.test.ts`): classification, detection, formatting, HTML-escape, kill-switch. **Pass under both vitest and bun.**
- [x] `tsc --noEmit` clean.
- [x] `check-bot-api-wrapping.sh` clean (send is inside `retryWithThreadFallback`; no allowlist edit needed).
- [x] UAT `-dm` + `-channel` twins (`jtbd-memory-legibility-{dm,channel}`): channel asserts `chatId === supergroup`, self-skips green when `SWITCHROOM_UAT_CHAT_ID` unset. (Authored, not run live.)

## Principle checks
- **Docs test**: line is self-explanatory (📌 remembered / ✂️ forgot); documented in `docs/telegram-plugin.md`.
- **Defaults test**: ON by default, zero config on a fresh setup.
- **Consistency test**: same env-kill-switch convention, same status-surface routing, same real-message rendering as the worker-activity feed.

## Risk
Low. Additive, behind a default-ON kill-switch. Only fires on two narrow, material tool calls; all send failures are swallowed (fire-and-forget through the retry policy). No change to the answer path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)