### PR TITLE
durability: cron boot-replay accept-vs-consume ledger (#2793 part B)

### DIFF
--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -777,9 +777,15 @@ export async function main(): Promise<void> {
             continue;
           }
           const threadId = resolveEntryThreadId(m.entry, channel);
+          // #2793 part B: stamp the minute-aligned fire this replay is for so
+          // the gateway routes it through the durable inbound spool (accept vs
+          // consume ledgered separately) and `spoolId` derives a stable dedup
+          // key. Closes the boot-replay silent-loss window (accepted but never
+          // consumed → the spool re-delivers on the next gateway boot) and the
+          // double-fire window (re-replay collapses on the stable id).
           const result = dispatchAsInbound(
             m.entry,
-            { chatId: channel.chatId, threadId },
+            { chatId: channel.chatId, threadId, replayFireMs: m.expectedFireMs },
             dispatcher,
           );
           sink.recordFire({

--- a/src/scheduler/dispatch-inbound.test.ts
+++ b/src/scheduler/dispatch-inbound.test.ts
@@ -150,4 +150,31 @@ describe("dispatchAsInbound", () => {
     const wire = JSON.parse(JSON.stringify(dispatcher.calls[0]!.msg));
     expect(validateGatewayMessage(wire)).toBe(true);
   });
+
+  // #2793 part B — a boot-replay stamps meta.replay_fire_ms so the gateway
+  // routes it through the durable inbound spool (accept vs consume ledgered
+  // separately) and spoolId derives a stable dedup key from the replayed
+  // fire. A live tick leaves it unset and keeps the fire-and-forget path.
+  it("emits meta.replay_fire_ms when replayFireMs is set (boot-replay)", () => {
+    const dispatcher = captureDispatcher();
+    const result = dispatchAsInbound(
+      sampleEntry,
+      { chatId: "-100", now: () => 1_700_000_000_000, replayFireMs: 1_699_999_980_000 },
+      dispatcher,
+    );
+    expect(result.message.meta.replay_fire_ms).toBe("1699999980000");
+    // still a valid wire message (meta is Record<string,string>).
+    const wire = JSON.parse(JSON.stringify(dispatcher.calls[0]!.msg));
+    expect(validateGatewayMessage(wire)).toBe(true);
+  });
+
+  it("omits replay_fire_ms for a live tick (byte-identical to today)", () => {
+    const dispatcher = captureDispatcher();
+    const result = dispatchAsInbound(
+      sampleEntry,
+      { chatId: "-100", now: () => 1_700_000_000_000 },
+      dispatcher,
+    );
+    expect(result.message.meta.replay_fire_ms).toBeUndefined();
+  });
 });

--- a/src/scheduler/dispatch.ts
+++ b/src/scheduler/dispatch.ts
@@ -236,6 +236,17 @@ export interface InboundDispatchOptions {
   session?: "cron" | "main";
   /** Tier-1 cron-session model; emitted as `meta.model` for the cron bridge. */
   model?: string;
+  /**
+   * Boot-replay marker (#2793 part B). Set to the minute-aligned epoch ms
+   * of the missed fire being replayed. Emitted as `meta.replay_fire_ms` so
+   * the gateway routes this inject through the durable inbound spool (accept
+   * and consume ledgered separately) instead of the fire-and-forget socket
+   * path, and so `spoolId` derives a STABLE dedup key from the replayed fire
+   * — a re-replay of the same missed fire across a gateway restart collapses
+   * to one delivery. Unset for live cron ticks, which keep the fire-and-forget
+   * path and their per-fire identity.
+   */
+  replayFireMs?: number;
 }
 
 export interface InboundDispatchResult {
@@ -286,6 +297,10 @@ export function dispatchAsInbound(
       // absent → 'main'). meta is Record<string,string> on the wire.
       ...(options.session === "cron" ? { session: "cron" } : {}),
       ...(options.session === "cron" && options.model ? { model: options.model } : {}),
+      // Boot-replay durability marker (#2793 part B) — see InboundDispatchOptions.
+      ...(options.replayFireMs !== undefined
+        ? { replay_fire_ms: String(options.replayFireMs) }
+        : {}),
     },
   };
   const delivered = dispatcher.sendToAgent(entry.agent, message);

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8317,11 +8317,45 @@ const ipcServer: IpcServer = createIpcServer({
     // frequent cron, or a crashed cron session) falls back to the MAIN agent
     // bridge so the fire lands now; it routes cheap again once the session is
     // up. See deliverInjectWithFallback.
+    // #2793 part B — durable cron boot-replay. A fire the scheduler is
+    // REPLAYING across a restart carries `meta.replay_fire_ms`; route it
+    // through the durable inbound spool so accept and consume are ledgered
+    // separately (mirrors the real-inbound path). The scheduler's own
+    // scheduler.jsonl records the fire at socket-accept, which stops
+    // findMissedFires from re-firing it — but a socket accept is NOT proof
+    // the session consumed it. Spooling here means: if the session isn't up
+    // (accepted-but-not-consumed), the entry stays un-acked and the spool's
+    // boot-replay re-delivers it on the next gateway boot (closes the
+    // silent-loss window); and the stable `spoolId` (keyed on the replayed
+    // fire) dedups a re-replay so it lands at most once (closes the
+    // double-fire window). Live cron ticks never set replay_fire_ms, so they
+    // keep the fire-and-forget path unchanged. STATIC mode has no spool —
+    // fall through to the legacy path.
+    const isDurableReplay =
+      inboundSpool != null &&
+      typeof msg.inbound.meta?.replay_fire_ms === 'string' &&
+      msg.inbound.meta.replay_fire_ms.length > 0
+    if (isDurableReplay && inboundSpool != null) {
+      // Durable ACCEPT: put before delivery so a crash between accept and
+      // consume leaves the entry recoverable (boot-replay re-delivers).
+      // Idempotent by stable spoolId — a re-replay of the same missed fire
+      // is a no-op while the prior entry is still un-acked.
+      inboundSpool.put(msg.agentName, msg.inbound as unknown as InboundMessage)
+    }
     const { target, delivered, fellBackToMain } = deliverInjectWithFallback(
       msg.agentName,
       msg.inbound.meta,
       (t) => ipcServer.sendToAgent(t, msg.inbound),
     )
+    if (isDurableReplay && inboundSpool != null && delivered) {
+      // Durable CONSUME: the fire reached a live bridge, so tombstone the
+      // spool entry (same "delivered to a live registered bridge" ack
+      // semantics the inbound spool uses — see its v1 scope note). On a
+      // miss we leave it un-acked: the pendingInboundBuffer.push below
+      // buffers it for the reconnect drain, and the durable spool copy is
+      // re-delivered on the next boot if this process dies first.
+      inboundSpool.ack(msg.inbound as unknown as InboundMessage)
+    }
     if (fellBackToMain) {
       process.stderr.write(
         `telegram gateway: cron fire fell back to main session (no cron bridge) agent=${msg.agentName} prompt_key=${promptKey}\n`,

--- a/telegram-plugin/gateway/inbound-spool.ts
+++ b/telegram-plugin/gateway/inbound-spool.ts
@@ -94,6 +94,28 @@ export function spoolId(msg: InboundMessage): string {
   ) {
     return `s:resume:${msg.meta.resume_turn_key}`
   }
+  // Cron BOOT-REPLAY (#2793 part B): a scheduled fire that the boot
+  // replay re-injects because it was missed across a restart. Keyed on
+  // the minute-aligned fire it is replaying (`replay_fire_ms`) plus the
+  // schedule index, NOT the fresh synthetic `messageId` (=ts, minted per
+  // replay attempt) — so a re-replay of the SAME missed fire across a
+  // subsequent gateway restart collapses to ONE live spool entry instead
+  // of stacking a fresh one each boot. This is what makes routing cron
+  // replays through the durable spool at-least-once WITH dedup, mirroring
+  // the resume/handback stable-id idiom above. Live (non-replay) cron
+  // ticks never set `replay_fire_ms`, so they are unaffected and keep
+  // their per-fire identity.
+  if (
+    msg.meta?.source === 'cron' &&
+    typeof msg.meta?.replay_fire_ms === 'string' &&
+    msg.meta.replay_fire_ms.length > 0
+  ) {
+    const idx =
+      typeof msg.meta?.schedule_index === 'string' && msg.meta.schedule_index.length > 0
+        ? msg.meta.schedule_index
+        : '-'
+    return `s:cron-replay:${msg.chatId}:${idx}:${msg.meta.replay_fire_ms}`
+  }
   if (typeof msg.messageId === 'number' && msg.messageId > 0) {
     return `m:${msg.chatId}:${msg.messageId}`
   }

--- a/telegram-plugin/tests/inbound-spool.test.ts
+++ b/telegram-plugin/tests/inbound-spool.test.ts
@@ -99,6 +99,48 @@ describe('spoolId — stable dedup key', () => {
     )
     expect(a).not.toBe(b)
   })
+  // #2793 part B: a cron BOOT-REPLAY carries meta.replay_fire_ms (the
+  // minute-aligned fire being replayed). spoolId() keys on it + the
+  // schedule index so a re-replay of the SAME missed fire across a gateway
+  // restart — which mints a fresh synthetic messageId=ts each boot —
+  // collapses to one live entry instead of stacking a fresh one each boot.
+  it('cron boot-replay → s:cron-replay:chat:idx:fireMs, stable across ts/messageId', () => {
+    const a = spoolId(
+      msg({
+        messageId: 1700_000_000_000,
+        ts: 1700_000_000_000,
+        meta: { source: 'cron', schedule_index: '3', replay_fire_ms: '1699999980000' },
+      }),
+    )
+    const b = spoolId(
+      msg({
+        messageId: 1700_000_999_999,
+        ts: 1700_000_999_999,
+        meta: { source: 'cron', schedule_index: '3', replay_fire_ms: '1699999980000' },
+      }),
+    )
+    expect(a).toBe('s:cron-replay:c1:3:1699999980000')
+    expect(b).toBe(a) // stable across the fresh per-boot messageId/ts
+  })
+  it('cron boot-replays for distinct missed fires stay distinct', () => {
+    const a = spoolId(
+      msg({ messageId: 0, meta: { source: 'cron', schedule_index: '3', replay_fire_ms: '100' } }),
+    )
+    const b = spoolId(
+      msg({ messageId: 0, meta: { source: 'cron', schedule_index: '3', replay_fire_ms: '200' } }),
+    )
+    const c = spoolId(
+      msg({ messageId: 0, meta: { source: 'cron', schedule_index: '4', replay_fire_ms: '100' } }),
+    )
+    expect(a).not.toBe(b) // different fire minute
+    expect(a).not.toBe(c) // different schedule index
+  })
+  it('a LIVE cron tick (no replay_fire_ms) keeps its per-fire identity', () => {
+    // Live ticks are not routed through the spool, but assert the id path
+    // is unchanged so live fires never collapse into a replay bucket.
+    const live = spoolId(msg({ messageId: 0, meta: { source: 'cron' }, ts: 500 }))
+    expect(live).toBe('s:c1:cron:500')
+  })
   it('subagent_handback without jsonl id falls back to legacy id (back-compat)', () => {
     const a = spoolId(
       msg({ messageId: 555, meta: { source: 'subagent_handback' }, ts: 100 }),
@@ -576,5 +618,68 @@ describe('inbound-spool — #2789 B: spool write failure surfaces a health signa
     expect(s.isDegraded()).toBe(false)
     expect(s.appendFailureCount()).toBe(0)
     expect(events).toEqual([true, false]) // degraded → recovered
+  })
+})
+
+// #2793 part B — cron boot-replay accept-vs-consume durability. A missed
+// scheduled fire re-injected at boot is routed through this spool by the
+// gateway's onInjectInbound handler (put on accept, ack on confirmed
+// delivery). These tests pin the two windows the ledger closes.
+describe('#2793 — cron boot-replay accept vs consume', () => {
+  function replayMsg(fireMs: number, boot: number): InboundMessage {
+    // A fresh synthetic messageId/ts is minted every replay attempt; the
+    // stable identity is (schedule_index, replay_fire_ms).
+    return msg({
+      messageId: boot,
+      ts: boot,
+      user: 'cron',
+      userId: 0,
+      meta: { source: 'cron', schedule_index: '3', replay_fire_ms: String(fireMs) },
+    })
+  }
+
+  it('accepted-but-NOT-consumed replay survives a restart and re-fires', () => {
+    const fs = fakeFs()
+    // Boot 1: the gateway accepts the replay (put) but the session never
+    // came up, so it is never delivered → never acked.
+    createInboundSpool({ path: PATH, fs, log: () => {} }).put('a', replayMsg(1000, 111))
+    // Boot 2: a fresh gateway rehydrates from the durable log. The un-acked
+    // replay is STILL live, so the boot-replay path re-delivers it — the
+    // silent-loss window (accepted, never consumed) is closed.
+    const s2 = createInboundSpool({ path: PATH, fs, log: () => {} })
+    const live = s2.liveEntries()
+    expect(live).toHaveLength(1)
+    expect(live[0]!.msg.meta?.replay_fire_ms).toBe('1000')
+  })
+
+  it('a CONSUMED replay (acked on delivery) does NOT re-fire on restart', () => {
+    const fs = fakeFs()
+    const s1 = createInboundSpool({ path: PATH, fs, log: () => {} })
+    const m = replayMsg(1000, 111)
+    s1.put('a', m)
+    s1.ack(m) // gateway delivered it to a live bridge → tombstone
+    // A fresh gateway sees the tombstone and does not re-deliver — the
+    // double-fire window is closed for a consumed replay.
+    const s2 = createInboundSpool({ path: PATH, fs, log: () => {} })
+    expect(s2.liveEntries()).toHaveLength(0)
+  })
+
+  it('a re-replay of the SAME missed fire dedups (at-least-once with dedup)', () => {
+    const fs = fakeFs()
+    const s = createInboundSpool({ path: PATH, fs, log: () => {} })
+    // First accept.
+    expect(s.put('a', replayMsg(1000, 111))).toBe(true)
+    // The scheduler re-replays the same missed fire on a later boot (fresh
+    // messageId/ts) while the first is still un-acked → collapses to one.
+    expect(s.put('a', replayMsg(1000, 222))).toBe(false)
+    expect(s.liveCount()).toBe(1)
+  })
+
+  it('distinct missed fires are each retained (no cross-fire collapse)', () => {
+    const fs = fakeFs()
+    const s = createInboundSpool({ path: PATH, fs, log: () => {} })
+    expect(s.put('a', replayMsg(1000, 111))).toBe(true)
+    expect(s.put('a', replayMsg(2000, 222))).toBe(true)
+    expect(s.liveCount()).toBe(2)
   })
 })


### PR DESCRIPTION
Fixes #2793

## Context
Issue #2793 had two parts.

- **Part A** (resume double-execution — at-most-once via a `resumed_at`
  ledger) already shipped in **merged PR #2808**. Verified present on
  `main`: `findLatestTurnIfInterrupted` returns null once `resumed_at`
  is stamped, and the gateway stamps it synchronously right after the
  resume inbound is durably spooled.
- **Part B** (cron boot-replay accept-vs-consume) is what this PR fixes.

## Part B — the two windows
Cron boot-replay was ledgered at **socket-accept** in the scheduler
(`scheduler.jsonl` recorded the fire the instant the `inject_inbound`
socket write returned), not at **consumption**:

- **silent-loss:** a replay accepted by the gateway but never consumed
  (bridge not up yet) was recorded delivered and never re-fired — the
  missed scheduled run was dropped.
- **double-fire:** the accept-time ledger couldn't tell "consumed" from
  "accepted", so a re-replay across a gateway restart could re-run it.

## Fix (mirrors the real-inbound path)
A boot-replay now carries `meta.replay_fire_ms`. The gateway's
`onInjectInbound` routes a replay-marked cron fire through the **durable
inbound spool** — `put` on accept, `ack` (tombstone) only on confirmed
delivery to a live bridge. `spoolId` derives a **stable** key from
`(chatId, schedule_index, replay_fire_ms)`, so:

- a re-replay of the same missed fire **dedups** to one live entry
  (closes the double-fire window), and
- an un-acked (accepted-but-not-consumed) entry is **re-delivered on the
  next gateway boot** by the spool's existing boot-replay path (closes
  the silent-loss window).

At-least-once with dedup, matching the inbound-delivery conventions
(#2094 / #2801). Live cron ticks never set `replay_fire_ms` — their
fire-and-forget path and per-fire spool identity are unchanged.

## Changes
- `src/scheduler/dispatch.ts` — `replayFireMs` option → `meta.replay_fire_ms`.
- `src/agent-scheduler/index.ts` — boot-replay stamps `replayFireMs: expectedFireMs`.
- `telegram-plugin/gateway/inbound-spool.ts` — stable `s:cron-replay:<chat>:<idx>:<fireMs>` spoolId.
- `telegram-plugin/gateway/gateway.ts` — `onInjectInbound` puts replay-marked fires on the spool (accept) and acks on delivery (consume).

## Tests
- `inbound-spool.test.ts`: cron-replay spoolId stability across per-boot
  ts/messageId; distinctness across fires/indices; live-tick identity
  unaffected; **accepted-but-not-consumed replay re-fires after restart**;
  **consumed (acked) replay does NOT re-fire**; re-replay dedups; distinct
  fires each retained.
- `dispatch-inbound.test.ts`: emits/omits `replay_fire_ms` correctly.
- Touched suites green (`inbound-spool` 41, `replay` 38, `dispatch-inbound` 9).
- `npm run lint` (tsc + all guard scripts) clean; `npm run build` clean.
- Full `vitest run`: 16 pre-existing environmental file failures
  (scaffold / install-static-binary / host-control / boot / deps —
  fs/mount/bun-compile/docker deps). Confirmed all 16 fail **identically
  on clean `main`** (`origin/main` worktree, same 16 files). Zero new
  failures from this change.

## Caveats for the reviewer
- "Consume" here uses the inbound spool's documented v1 ack semantics —
  "delivered to a live registered bridge", not "claude enqueued it".
  That's the same guarantee the real-inbound spool provides today; a true
  claude→gateway consumption ack remains the spool's documented follow-up.
- The spool `put` uses the main `agentName`, so a boot re-delivery of an
  un-acked cheap-cron replay lands on the main bridge — the already-safe
  cron fallback-to-main behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)