### PR TITLE
feat(memory): deterministic directive-capture nudge (#2848 Stage B)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -245,6 +245,32 @@ Use this to answer "is 12 the right cap?" — if `CAP` fires on most turns, the 
 
 The log is bounded to the last ~5000 events per agent.
 
+### Making corrections stick — `memory.directive_capture_nudge`
+
+Hindsight **directives** are the primitive that makes a standing rule survive a restart: user-authored, verbatim, and re-injected into every turn. But whether a correction actually *becomes* a directive was, historically, guidance-only — the model is told to call `create_directive` when you give it a durable rule, and inconsistently does. An audit (issue #2848) measured a **~55% miss rate** on clear-cut durable corrections: the same broadcast correction was captured by one agent and silently dropped by two others.
+
+`memory.directive_capture_nudge` (default **on**) closes that gap. On every inbound the auto-recall hook runs a **deterministic regex** over the message; when it looks correction- or standing-rule-shaped — `always`/`never`, `from now on`, `stop doing …`, a stated preference, `call me …`, `that's wrong, it's …` — it appends a terse advisory to the turn's context reminding the model that *if* this is a durable rule (not a one-off), it should persist it with `create_directive` before answering.
+
+Two things it deliberately does **not** do (both are hard invariants):
+
+- **No extra model call.** Detection is pure regex; the *judgment* — is this actually a standing rule? — happens inside the interactive `claude` session, on the operator's subscription. There is no classifier callsite.
+- **No silent write.** The hook only nudges. The model decides and calls `create_directive` itself, visible in chat — the hook never writes a directive you didn't see.
+
+Detection is intentionally inclusive (the nudge is cheap and advisory, so a false positive just costs a few tokens and is ignored), with a guard against the obvious pleasantry shapes (`always happy to help`, `never mind`).
+
+```yaml
+defaults:
+  memory:
+    directive_capture_nudge: false   # disable fleet-wide (not recommended — Stage A proved a real gap)
+
+agents:
+  clerk:
+    memory:
+      directive_capture_nudge: true  # per-agent opt back in
+```
+
+**Cascade: override** (per-agent wins over profile/defaults). Omit the field to inherit the on-by-default. Operationally the knob threads the same way as the other recall tuning: the switchroom default is pinned in the plugin's `settings.json`, and `start.sh` exports `HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE` only when you override it (the env value wins at plugin load). Serves the `remember-across-sessions` job.
+
 ### Server-side caps on the Hindsight container
 
 `switchroom memory --start` launches the bundled Hindsight container with `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=1000` already set. The same default is baked into the `--compose` snippet output.

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -433,6 +433,14 @@ export HINDSIGHT_RECALL_TYPES="{{hindsightRecallTypes}}"
 {{#if hindsightRecallSkipTrivial}}
 export HINDSIGHT_RECALL_SKIP_TRIVIAL={{hindsightRecallSkipTrivial}}
 {{/if}}
+# #2848 Stage B — directive-capture nudge (memory.directive_capture_nudge
+# cascade). On by default (plugin settings.json): recall.py regex-detects
+# correction / standing-rule-shaped inbound and nudges the model to persist
+# it with create_directive if durable. Export only when the operator overrode
+# it; set false to disable the nudge for this agent.
+{{#if hindsightDirectiveCaptureNudge}}
+export HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE={{hindsightDirectiveCaptureNudge}}
+{{/if}}
 # PR6 — supergroup-mode topic tagging. JSON map of {alias: thread_id}
 # parsed by retain.py + recall.py to (a) stamp chat_id/thread_id/topic_alias
 # into retained memory metadata and (b) emit a "Current topic: …" preamble

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2556,6 +2556,15 @@ function renderHindsightSettingsOverrides(
   // opt OUT via memory.recall.skip_trivial=false in switchroom.yaml
   // (exported as HINDSIGHT_RECALL_SKIP_TRIVIAL only when overridden).
   settings.recallSkipTrivial = true;
+  // #2848 Stage B: deterministic directive-capture nudge ON by default.
+  // Stage A audit found a ~55% miss rate on durable corrections (guidance-
+  // only capture is a per-agent lottery), so recall.py regex-detects
+  // correction-shaped inbound and nudges the model to persist it with
+  // create_directive — the model does the judgment in-session (no model
+  // callsite). Operators opt OUT per-agent via memory.directive_capture_nudge
+  // =false (exported as HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE only when overridden;
+  // the env value wins over this settings.json default).
+  settings.directiveCaptureNudge = true;
   // Static shared-bank recall (RFC reference/rfcs/per-speaker-memory-routing.md,
   // ship-B): recall these extra banks on every turn, merged into the agent's
   // own bank results. Sourced from memory.recall.additional_banks (cascaded);
@@ -2626,6 +2635,9 @@ interface BuildWorkspaceContextArgs {
   // each undefined unless the operator overrode the switchroom default.
   hindsightRecallTypes?: string;
   hindsightRecallSkipTrivial?: string;
+  // #2848 Stage B — directive-capture nudge opt-out. Stringified bool,
+  // undefined unless the operator overrode the switchroom default (on).
+  hindsightDirectiveCaptureNudge?: string;
   // PR6 — supergroup-mode topic tagging. JSON map of {alias: thread_id}
   // injected as HINDSIGHT_TOPIC_ALIASES_JSON so retain.py can resolve
   // numeric thread_ids to human alias names in memory metadata.
@@ -2666,6 +2678,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightRecallMinOverlap,
     hindsightRecallTypes,
     hindsightRecallSkipTrivial,
+    hindsightDirectiveCaptureNudge,
     hindsightTopicAliasesJson,
     hindsightSenderBanksJson,
     hindsightTopicFilterMode,
@@ -2745,6 +2758,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightRecallMinOverlap,
     hindsightRecallTypes,
     hindsightRecallSkipTrivial,
+    hindsightDirectiveCaptureNudge,
     // PR6 — only emit the env-export blocks when we actually have a
     // value, so `{{#if hindsightTopicAliasesJsonQ}}` and friends are
     // false-y for fleet-shared / DM agents (the dominant case).
@@ -3358,6 +3372,15 @@ export function scaffoldAgent(
     agentConfig.memory?.recall?.skip_trivial === undefined
       ? undefined
       : String(agentConfig.memory.recall.skip_trivial);
+  // #2848 Stage B — directive-capture nudge cascade. undefined unless the
+  // operator overrode the switchroom default (on). Exported only when set
+  // (see start.sh.hbs), so an unset value leaves the on-by-default
+  // settings.json override in force. Top-level memory.* knob (not under
+  // memory.recall) — it gates a correction-detection nudge, not recall tuning.
+  const hindsightDirectiveCaptureNudge =
+    agentConfig.memory?.directive_capture_nudge === undefined
+      ? undefined
+      : String(agentConfig.memory.directive_capture_nudge);
 
   // PR6 — supergroup-mode topic tagging. Build the {alias: thread_id}
   // JSON for retain.py + recall.py to resolve numeric thread_ids to
@@ -3415,6 +3438,7 @@ export function scaffoldAgent(
     hindsightRecallMinOverlap,
     hindsightRecallTypes,
     hindsightRecallSkipTrivial,
+    hindsightDirectiveCaptureNudge,
     hindsightTopicAliasesJson,
     hindsightSenderBanksJson,
     hindsightTopicFilterMode,
@@ -5447,6 +5471,15 @@ export function reconcileAgent(
     agentConfig.memory?.recall?.skip_trivial === undefined
       ? undefined
       : String(agentConfig.memory.recall.skip_trivial);
+  // #2848 Stage B — directive-capture nudge cascade. undefined unless the
+  // operator overrode the switchroom default (on). Exported only when set
+  // (see start.sh.hbs), so an unset value leaves the on-by-default
+  // settings.json override in force. Top-level memory.* knob (not under
+  // memory.recall) — it gates a correction-detection nudge, not recall tuning.
+  const hindsightDirectiveCaptureNudge =
+    agentConfig.memory?.directive_capture_nudge === undefined
+      ? undefined
+      : String(agentConfig.memory.directive_capture_nudge);
   // PR6 — mirror scaffoldAgent's computation. Both paths feed
   // buildWorkspaceContext, so the template sees identical shape.
   const topicAliases = agentConfig.channels?.telegram?.topic_aliases;
@@ -5528,6 +5561,7 @@ export function reconcileAgent(
       hindsightRecallMinOverlap,
       hindsightRecallTypes,
       hindsightRecallSkipTrivial,
+      hindsightDirectiveCaptureNudge,
       // PR6 — supergroup-mode topic tagging env vars. Same gate as
       // buildWorkspaceContext: only emit the shell-quoted JSON when
       // we actually have a topic_aliases map.
@@ -6231,6 +6265,7 @@ export function reconcileAgent(
       hindsightRecallMinOverlap,
       hindsightRecallTypes,
       hindsightRecallSkipTrivial,
+      hindsightDirectiveCaptureNudge,
       hindsightTopicAliasesJson,
       hindsightSenderBanksJson,
       hindsightTopicFilterMode,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -393,6 +393,22 @@ export const AgentMemorySchema = z
         "Cascade: per-key merge (an agent overrides individual traits and " +
         "inherits the rest, matching `recall`)."
       ),
+    directive_capture_nudge: z
+      .boolean()
+      .optional()
+      .describe(
+        "Deterministic directive-capture nudge (issue #2848 Stage B). When " +
+        "on (switchroom default true — Stage A measured a ~55% miss rate on " +
+        "durable corrections), the auto-recall hook regex-detects correction " +
+        "/ standing-rule-shaped inbound (\"always/never …\", \"from now on …\", " +
+        "\"stop doing …\", a stated preference, \"that's wrong, it's …\") and " +
+        "appends a terse advisory to the turn's context telling the model to " +
+        "persist the rule with mcp__hindsight__create_directive if it IS " +
+        "durable. Detection is pure regex — the model does the judgment " +
+        "in-session and calls create_directive itself (no model callsite, no " +
+        "silent hook-side write). Set false to disable per-agent. " +
+        "Cascade: override (per-agent wins over default)."
+      ),
     recall: z
       .object({
         max_memories: z
@@ -2135,6 +2151,10 @@ const profileFields = {
       // agents) hindsight-native by default, with per-agent `file: true` opt-in.
       file: z.boolean().optional(),
       isolation: z.enum(["default", "strict"]).optional(),
+      // Mirror of AgentMemorySchema.directive_capture_nudge — accepted at the
+      // defaults/profile tier too, so `defaults.memory.directive_capture_nudge:
+      // false` can disable the #2848 nudge fleet-wide (per-agent `true` opt-in).
+      directive_capture_nudge: z.boolean().optional(),
       recall: z
         .object({
           max_memories: z.number().int().min(0).optional(),

--- a/telegram-plugin/uat/scenarios/jtbd-directive-capture-nudge-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-directive-capture-nudge-dm.test.ts
@@ -1,0 +1,185 @@
+/**
+ * JTBD scenario — a correction lands as a directive and survives `/reset`.
+ *
+ * Serves: `reference/jobs/remember-across-sessions.md` — the job's headline
+ * criterion is "a rule set once stays respected / a correction sticks."
+ *
+ * ## Why this exists (issue #2848 Stage B)
+ *
+ * Directive capture was guidance-only: the model is *told* to call
+ * `create_directive` on a durable correction, and a Stage A audit measured a
+ * **~55% miss rate** — the same broadcast correction captured by one agent,
+ * silently dropped by two others. Stage B adds a DETERMINISTIC regex nudge in
+ * the vendored recall hook (`vendor/hindsight-memory/scripts/recall.py`): on a
+ * correction-shaped inbound it appends a terse advisory telling the model to
+ * persist the rule with `create_directive` before answering. Detection is pure
+ * regex — the judgment happens IN the interactive session (claude-native
+ * invariant: no model callsite, no silent hook-side write).
+ *
+ * ## Contract this asserts
+ *
+ * 1. **Capture**: after a correction-shaped DM ("from now on, always end every
+ *    reply with <MARKER>"), an ACTIVE directive referencing the rule exists in
+ *    the agent's hindsight bank (queried via the REST API, the same surface
+ *    Stage A used).
+ * 2. **Survival across `/reset`**: after `/reset` clears the session, a fresh
+ *    neutral follow-up is still answered honoring the rule (the MARKER appears
+ *    in the reply) — proving the directive was re-injected from the bank, not
+ *    merely held in the wiped session context.
+ *
+ * ## Self-skip
+ *
+ * Self-skips GREEN when the mtcute driver isn't wired (no
+ * TELEGRAM_UAT_DRIVER_SESSION etc.), so it never reds an unwired host. The
+ * whole uat/** tree is excluded from gating CI regardless; run live with
+ * `bun run --cwd telegram-plugin test:uat jtbd-directive-capture-nudge-dm`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { randomBytes } from "node:crypto";
+import { spinUp } from "../harness.js";
+import { isActivityFeedMessage, isWorkerFeedMessage } from "../assertions.js";
+import type { ObservedMessage } from "../driver.js";
+
+const AGENT = "test-harness";
+
+// Match the first non-empty bot reply that is neither the worker-activity
+// feed nor the tool-activity feed (same guard as jtbd-memory-survives).
+const isReply = (m: ObservedMessage): boolean =>
+  /\S/.test(m.text) && !isWorkerFeedMessage(m) && !isActivityFeedMessage(m);
+
+const CORRECTION_REPLY_BUDGET_MS = 60_000;
+const DIRECTIVE_SETTLE_MS = 12_000;
+const RESET_SETTLE_MS = 45_000;
+const POSTRESET_REPLY_BUDGET_MS = 120_000;
+
+// Unique per-run marker so directive-content matching and the honored-rule
+// check can't latch onto stale state from a prior run.
+const MARKER = `SR_UAT_DIRECTIVE_${randomBytes(6).toString("hex").toUpperCase()}`;
+
+// Hindsight REST base. Bank id == agent name (Stage A + CLAUDE.md). Override
+// via HINDSIGHT_UAT_API_URL if the host runs it elsewhere.
+const HINDSIGHT_BASE =
+  process.env.HINDSIGHT_UAT_API_URL ??
+  process.env.HINDSIGHT_API_URL ??
+  "http://127.0.0.1:18888";
+
+interface Directive {
+  content?: string;
+  name?: string;
+}
+
+async function fetchActiveDirectives(bank: string): Promise<Directive[]> {
+  const url = `${HINDSIGHT_BASE}/v1/default/banks/${encodeURIComponent(bank)}/directives?active_only=false`;
+  const res = await fetch(url, { signal: AbortSignal.timeout(8_000) });
+  if (!res.ok) {
+    throw new Error(`hindsight directives HTTP ${res.status} for bank ${bank} (${url})`);
+  }
+  const body = (await res.json()) as { items?: Directive[] };
+  return Array.isArray(body.items) ? body.items : [];
+}
+
+const uatWired = Boolean(
+  process.env.TELEGRAM_API_ID &&
+    process.env.TELEGRAM_API_HASH &&
+    process.env.TELEGRAM_UAT_DRIVER_SESSION &&
+    (process.env.TELEGRAM_TEST_BOT_USERNAME || false),
+);
+
+(uatWired ? describe : describe.skip)(
+  "uat: correction lands as a directive and survives /reset (remember-across-sessions JTBD)",
+  () => {
+    it(
+      "a standing-rule correction is persisted as a directive and honored after /reset",
+      async () => {
+        // --- Phase 1: give the agent a durable, correction-shaped rule ---
+        const sc1 = await spinUp({ agent: AGENT });
+        try {
+          await sc1.sendDM(
+            `From now on, always end every reply you send me with this exact ` +
+              `marker on its own final line: ${MARKER}. This is a standing ` +
+              `rule for how you should behave going forward — please persist ` +
+              `it so it sticks across sessions. Confirm you've noted it.`,
+          );
+
+          const reply = await sc1.expectMessage(isReply, {
+            from: "bot",
+            timeout: CORRECTION_REPLY_BUDGET_MS,
+          });
+          expect(reply.text.length).toBeGreaterThan(0);
+
+          // Give the in-turn create_directive call (nudged by the hook) time
+          // to land in the bank before we query it.
+          await new Promise((r) => setTimeout(r, DIRECTIVE_SETTLE_MS));
+
+          // --- Phase 2: CAPTURE — an active directive references the rule ---
+          const directives = await fetchActiveDirectives(AGENT);
+          const matched = directives.some((d) => {
+            const hay = `${d.content ?? ""} ${d.name ?? ""}`;
+            return (
+              hay.includes(MARKER) ||
+              /end (?:every|each|your) repl/i.test(hay) ||
+              /marker/i.test(hay)
+            );
+          });
+          if (!matched) {
+            throw new Error(
+              `[directive-capture] CONTRACT FAILED (capture): no active directive ` +
+                `references the standing rule. The correction was correction-shaped ` +
+                `(the recall hook should have nudged create_directive) but nothing ` +
+                `persisted. Directives seen: ` +
+                `${JSON.stringify(directives.map((d) => d.content ?? d.name).slice(0, 8))}`,
+            );
+          }
+          expect(matched).toBe(true);
+        } finally {
+          await sc1.tearDown();
+        }
+
+        // --- Phase 3: /reset clears the session ---
+        const scReset = await spinUp({ agent: AGENT });
+        try {
+          await scReset.sendDM("/reset");
+        } finally {
+          await scReset.tearDown();
+        }
+        // Let the reset complete + the bridge reattach before probing.
+        await new Promise((r) => setTimeout(r, RESET_SETTLE_MS));
+
+        // --- Phase 4: SURVIVAL — a fresh neutral turn still honors the rule ---
+        const sc2 = await spinUp({ agent: AGENT });
+        try {
+          await sc2.sendDM(
+            `What is 2 + 2? Answer normally — nothing special about this message.`,
+          );
+          const reply = await sc2.expectMessage(isReply, {
+            from: "bot",
+            timeout: POSTRESET_REPLY_BUDGET_MS,
+          });
+          expect(reply.text.length).toBeGreaterThan(0);
+
+          // The rule was NOT in this session's context (it was wiped by
+          // /reset). If the marker appears, the directive was re-injected from
+          // the bank on recall — the correction stuck.
+          const honored = reply.text.includes(MARKER);
+          if (!honored) {
+            throw new Error(
+              `[directive-capture] CONTRACT FAILED (survival): after /reset the ` +
+                `agent did not honor the standing rule — marker ${MARKER} absent ` +
+                `from the reply, so the directive did not survive/re-inject. Reply: ` +
+                `${JSON.stringify(reply.text.slice(0, 400))}`,
+            );
+          }
+          expect(honored).toBe(true);
+        } finally {
+          await sc2.tearDown();
+        }
+      },
+      CORRECTION_REPLY_BUDGET_MS +
+        DIRECTIVE_SETTLE_MS +
+        RESET_SETTLE_MS +
+        POSTRESET_REPLY_BUDGET_MS +
+        30_000,
+    );
+  },
+);

--- a/tests/scaffold.directive-capture-nudge.test.ts
+++ b/tests/scaffold.directive-capture-nudge.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { installHindsightPlugin, scaffoldAgent } from "../src/agents/scaffold.js";
+import { AgentMemorySchema } from "../src/config/schema.js";
+import type { SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+/**
+ * #2848 Stage B — directive-capture nudge threading.
+ *
+ * Stage A audit found a ~55% miss rate on durable corrections. The
+ * deterministic nudge is ON by default for every agent: recall.py
+ * regex-detects correction / standing-rule-shaped inbound and appends a
+ * terse advisory telling the model to persist the rule with
+ * create_directive. The default is pinned into the copied plugin
+ * settings.json by applyHindsightSettingsOverrides; an operator opts OUT
+ * per-agent (or fleet-wide under `defaults`) via
+ * memory.directive_capture_nudge, which scaffold exports into start.sh as
+ * HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE ONLY when set — the env value wins over
+ * the settings.json default at plugin load.
+ */
+describe("directive-capture nudge (#2848 Stage B)", () => {
+  let tmpDir: string;
+  let telegram: TelegramConfig;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `directive-nudge-${Date.now()}-${Math.floor(Math.random() * 1e6)}`);
+    mkdirSync(tmpDir, { recursive: true });
+    telegram = { bot_token: "t", forum_chat_id: "c" };
+  });
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("schema acceptance", () => {
+    it("accepts memory.directive_capture_nudge as a boolean", () => {
+      const ok = AgentMemorySchema.safeParse({
+        collection: "probe",
+        directive_capture_nudge: false,
+      });
+      expect(ok.success).toBe(true);
+      if (ok.success) {
+        expect(ok.data?.directive_capture_nudge).toBe(false);
+      }
+    });
+
+    it("rejects a non-boolean value", () => {
+      const bad = AgentMemorySchema.safeParse({
+        collection: "probe",
+        directive_capture_nudge: "yes",
+      });
+      expect(bad.success).toBe(false);
+    });
+  });
+
+  describe("settings.json default (on)", () => {
+    it("applyHindsightSettingsOverrides pins directiveCaptureNudge true", () => {
+      const config = {
+        agents: {},
+        memory: { backend: "hindsight", config: { url: "http://localhost:18888/mcp/" } },
+        telegram: { bot_token: "t", forum_chat_id: "c" },
+      } as SwitchroomConfig;
+      const res = installHindsightPlugin("probe", tmpDir, config);
+      expect(res).not.toBeNull();
+      const settingsPath = join(tmpDir, ".claude", "plugins", "hindsight-memory", "settings.json");
+      const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+      expect(settings.directiveCaptureNudge).toBe(true);
+    });
+  });
+
+  describe("start.sh opt-out cascade", () => {
+    function startShFor(memory: Record<string, unknown> | undefined): string {
+      const config: SwitchroomConfig = {
+        agents: memory ? ({ probe: { memory } } as never) : {},
+        memory: { backend: "hindsight", config: { url: "http://localhost:18888/mcp/" } },
+        telegram,
+      } as SwitchroomConfig;
+      const res = scaffoldAgent("probe", config.agents.probe ?? {}, tmpDir, telegram, config);
+      return readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+    }
+
+    it("default (no override) emits NO env export — settings.json default stays in force", () => {
+      const startSh = startShFor(undefined);
+      expect(startSh).not.toMatch(/export HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE=/);
+    });
+
+    it("directive_capture_nudge=false exports the false env (not omitted)", () => {
+      // The bool-false case must still emit the export — otherwise the
+      // settings.json default (true) would silently win and the opt-out fail.
+      const startSh = startShFor({ directive_capture_nudge: false });
+      expect(startSh).toMatch(/export HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE=false/);
+    });
+
+    it("directive_capture_nudge=true also exports (explicit re-affirm is harmless)", () => {
+      const startSh = startShFor({ directive_capture_nudge: true });
+      expect(startSh).toMatch(/export HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE=true/);
+    });
+  });
+});

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -37,6 +37,15 @@ DEFAULTS = {
     # scores, so this is the switchroom-side quality filter — see #475.
     "recallMinOverlap": 0.0,
     "recallTypes": ["world", "experience"],
+    # Switchroom #2848 Stage B — deterministic directive-capture nudge.
+    # When on (switchroom default; pinned true in the copied plugin
+    # settings.json by applyHindsightSettingsOverrides), recall.py regex-
+    # detects correction / standing-rule-shaped inbound and appends a terse
+    # advisory to the UserPromptSubmit additionalContext telling the model
+    # to persist the rule with create_directive if it IS durable. Pure
+    # detection — no model callsite. Operators opt out per-agent via
+    # memory.directive_capture_nudge=false → HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE.
+    "directiveCaptureNudge": True,
     "recallContextTurns": 1,
     "recallMaxQueryChars": 800,
     "recallRoles": ["user", "assistant"],
@@ -119,6 +128,11 @@ ENV_OVERRIDES = {
     # from agents.<name>.memory.recall.skip_trivial only on override; the
     # switchroom default is on (recall.py falls back to True).
     "HINDSIGHT_RECALL_SKIP_TRIVIAL": ("recallSkipTrivial", bool),
+    # Switchroom #2848 Stage B: directive-capture nudge on/off. Set by
+    # start.sh from agents.<name>.memory.directive_capture_nudge only when
+    # the operator overrode it; the switchroom default is on (settings.json
+    # pins true; recall.py falls back to True).
+    "HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE": ("directiveCaptureNudge", bool),
     "HINDSIGHT_RECALL_MAX_QUERY_CHARS": ("recallMaxQueryChars", int),
     "HINDSIGHT_RECALL_CONTEXT_TURNS": ("recallContextTurns", int),
     # Upstream 962140eef — recall tag filters. The tags env var accepts JSON

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -597,6 +597,126 @@ def _is_trivial_stateless(ack_form, stripped):
     return False
 
 
+# Switchroom #2848 Stage B — deterministic directive-capture nudge.
+#
+# Stage A audit (issue #2848) measured a ~55% miss rate on durable
+# corrections: the model is instructed (guidance-only, in
+# profiles/default/CLAUDE.md.hbs) to persist standing rules with
+# mcp__hindsight__create_directive, but does so inconsistently — capture
+# is a per-agent lottery (the same broadcast correction was captured by
+# one agent and silently dropped by two others). This adds DETERMINISTIC
+# detection of correction / standing-rule-shaped inbound (pure regex — NO
+# model callsite; the claude-native invariant forbids a classifier call)
+# and appends a terse advisory nudge to the UserPromptSubmit
+# additionalContext. The MODEL makes the judgment IN-SESSION and calls
+# create_directive itself (visible in chat); the hook NEVER writes a
+# directive on its own — a silent hook-side write would break
+# chat-legibility and edge the no-self-escalation invariant.
+#
+# On by default (Stage A proved a real gap → defaults principle);
+# operators opt out per-agent via memory.directive_capture_nudge=false in
+# switchroom.yaml, which start.sh exports as
+# HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE=false (recall.py falls back to the
+# settings.json default, which switchroom pins on).
+#
+# Detection is intentionally inclusive (the nudge is cheap + advisory, so
+# a modest false-positive rate is acceptable — the model just ignores it
+# on a one-off), but a negative guard scrubs the obvious pleasantry
+# shapes ("always happy to help", "never mind") BEFORE the positive
+# match, so those don't fire on a bare "always"/"never".
+_DIRECTIVE_NUDGE_NEGATIVE_RE = re.compile(
+    r"""(?ix)
+    (?:
+        never \s* mind
+      | nevermind
+      | always \s+ (?: happy | glad | welcome | here \s+ to \s+ help | open \s+ to )
+      | never \s+ (?: fails? | hurts? | too \s+ late | a \s+ dull )
+      | as \s+ always
+      | thanks? \s+ as \s+ always
+      | forever \s+ grateful
+    )
+    """
+)
+
+_DIRECTIVE_NUDGE_RE = re.compile(
+    r"""(?ix)
+    (?:
+      # --- explicit standing-rule framings ---
+        \b from \s+ now \s+ on \b
+      | \b going \s+ forward \b
+      | \b in \s+ (?: the \s+ )? future \b
+      | \b (?: as \s+ a \s+ )? general \s+ (?: rule | behaviou?r | policy | principle | agent \s+ behaviou?r ) \b
+      | \b as \s+ a \s+ rule \b
+      | \b i \s+ want \s+ you \s+ to \b
+      | \b you \s+ should \s+ (?: always | never ) \b
+      # --- always / never (pleasantries pre-scrubbed by the negative guard) ---
+      | \b always \b
+      | \b never \b
+      | \b no \s+ longer \b
+      | \b anymore \b
+      # --- prohibitions / behavioural corrections ---
+      | \b stop \s+ (?: doing | saying | using | calling | adding | making | being | sending | putting ) \b
+      | \b (?: do \s* n['’]? t | don['’]? t | do \s+ not ) \s+ (?: ever \s+ )?
+            (?: make | guess | assume | use | say | add | send | call | include | do | put | write | reply | respond | mention ) \b
+      | \b (?: do \s* n['’]? t | don['’]? t | do \s+ not ) \b [^.?!]{0,40} \b again \b
+      | \b (?: should \s* n['’]? t | shouldn['’]? t | should \s+ not ) \b
+      # --- preferences / identity ---
+      | \b (?: i | we ) \s+ (?: prefer | always \s+ want | never \s+ want ) \b
+      | \b i['’]? d \s+ prefer \b
+      | \b call \s+ me \b
+      # --- memory / reinforcement ---
+      | \b remember \s+ (?: to | that | this | always | never ) \b
+      | \b make \s+ sure \s+ (?: you | to | that | not | it ) \b
+      # --- explicit wrongness + restatement ---
+      | \b that['’]? s \s+ (?: wrong | not \s+ right | incorrect | not \s+ what ) \b
+      | \b (?: no ,? \s+ )? it['’]? s \s+ (?: actually | not ) \b
+      | \b (?: that['’]? s | it['’]? s ) \s+ (?: dead | deprecated | retired | closed ) \b
+      | \b we \s+ (?: now \s+ )? (?: use \s+ only | only \s+ use | no \s+ longer \s+ use ) \b
+    )
+    """
+)
+
+# Terse, advisory. The model decides IN-SESSION whether this is a durable
+# rule and, if so, calls create_directive itself (chat-legible). Kept
+# short so it costs a handful of tokens on a false positive.
+_DIRECTIVE_CAPTURE_NUDGE = (
+    "<directive_capture_check>\n"
+    "The latest user message is correction- or standing-rule-shaped "
+    '(e.g. "always/never …", "from now on …", "stop doing …", a stated '
+    'preference, or "that’s wrong, it’s …"). If it states a DURABLE rule '
+    "for how you should behave going forward — not a one-off request for "
+    "this task — persist it NOW with mcp__hindsight__create_directive "
+    "(verbatim, in the user’s own words) BEFORE you answer, so the "
+    "correction survives future sessions. If it’s only a one-off "
+    "instruction, ignore this note and just answer.\n"
+    "</directive_capture_check>"
+)
+
+
+def looks_like_standing_rule(text) -> bool:
+    """Deterministic (regex-only) test for correction / standing-rule shape.
+
+    Pleasantry shapes ("always happy to help", "never mind") are scrubbed
+    BEFORE the positive match so they can't trip the bare always/never
+    signals. Returns False on empty / non-string input. No model call —
+    the model does the actual judgment in-session (issue #2848).
+    """
+    if not isinstance(text, str) or not text.strip():
+        return False
+    scrubbed = _DIRECTIVE_NUDGE_NEGATIVE_RE.sub(" ", text)
+    return bool(_DIRECTIVE_NUDGE_RE.search(scrubbed))
+
+
+def _combine_context(base, nudge) -> str:
+    """Join the recall/directives context with the directive-capture nudge,
+    skipping empties. Either may be None/empty. The nudge is kept OUT of the
+    cached / last-recall context (it's transient per-inbound) and appended
+    only at emit time, so a cache hit re-derives it from the current prompt
+    rather than replaying a stale one."""
+    parts = [p for p in (base, nudge) if p]
+    return "\n\n".join(parts)
+
+
 def main():
     config = load_config()
 
@@ -664,6 +784,22 @@ def main():
     if config.get("recallSkipTrivial", True) and _is_trivial_stateless(_ack_form, _stripped):
         debug_log(config, f"Prompt is trivial/stateless ({_ack_form!r}), skipping recall")
         return
+
+    # Switchroom #2848 Stage B — directive-capture nudge. Deterministic
+    # (regex) detection of correction / standing-rule-shaped inbound; when
+    # it fires we append a terse advisory to the additionalContext telling
+    # the model to persist the rule with create_directive if it IS durable.
+    # Computed on `_stripped` (the channel-envelope-stripped text) so the
+    # `<channel …>` wrapper never trips detection. Runs AFTER the ack/
+    # trivial-skip gates (those return early and genuinely need no nudge)
+    # and leaves the recall/directive path below untouched — it only adds
+    # to whatever additionalContext that path emits. On by default;
+    # HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE=false (or memory.directive_capture_nudge:
+    # false) turns it off. No model callsite (claude-native invariant).
+    nudge_block = None
+    if config.get("directiveCaptureNudge", True) and looks_like_standing_rule(_stripped):
+        nudge_block = _DIRECTIVE_CAPTURE_NUDGE
+        debug_log(config, "Directive-capture nudge: inbound looks like a standing rule")
 
     session_id = hook_input.get("session_id") or ""
 
@@ -771,7 +907,10 @@ def main():
             cached_context = None
         if cached_context is not None:
             debug_log(config, f"Recall cache HIT (key={cache_key[:12]}…) — skipping API call")
-            _emit_cached_context(cached_context)
+            # #2848 — append the nudge to the cached context at emit time
+            # (the cache stores nudge-free context; the nudge is re-derived
+            # from the current prompt, so a hit can't replay a stale one).
+            _emit_cached_context(_combine_context(cached_context, nudge_block))
             _write_recall_log({
                 "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
                 "session_id": (session_id or "")[:32],
@@ -790,6 +929,7 @@ def main():
                 "active_thread_id": active_thread_id,
                 "active_topic_alias": active_topic_alias,
                 "topic_filter_mode": _topic_filter_mode(),
+                "directive_nudge": bool(nudge_block),
             })
             return
         debug_log(config, f"Recall cache MISS (key={cache_key[:12]}…)")
@@ -1025,8 +1165,12 @@ def main():
         update_placeholder(placeholder_chat_id, "💭 thinking")
 
     # If neither block has content, there's nothing to inject — exit
-    # silently to avoid emitting an empty hookSpecificOutput.
+    # silently to avoid emitting an empty hookSpecificOutput. #2848: unless
+    # the directive-capture nudge fired, in which case emit the nudge alone
+    # (a correction with no memories/directives still needs the reminder).
     if not directives_block and not memories_block:
+        if nudge_block:
+            _emit_cached_context(nudge_block)
         return
 
     # Compose final context. Directives block goes ABOVE memories so the
@@ -1092,13 +1236,16 @@ def main():
         "source_topics": source_topic_summary,
         "topic_filter_mode": topic_filter_mode,
         "topic_dropped": topic_dropped,
+        "directive_nudge": bool(nudge_block),
     })
 
-    # Output JSON for Claude Code hook system
+    # Output JSON for Claude Code hook system. #2848: append the
+    # directive-capture nudge (if it fired) at emit time — it's kept out of
+    # the cached / last-recall context above so it can't go stale.
     output = {
         "hookSpecificOutput": {
             "hookEventName": "UserPromptSubmit",
-            "additionalContext": context_message,
+            "additionalContext": _combine_context(context_message, nudge_block),
         }
     }
     json.dump(output, sys.stdout)

--- a/vendor/hindsight-memory/scripts/tests/test_directive_capture_nudge.py
+++ b/vendor/hindsight-memory/scripts/tests/test_directive_capture_nudge.py
@@ -1,0 +1,179 @@
+"""Switchroom #2848 Stage B — unit tests for the directive-capture nudge.
+
+Stage A audit measured a ~55% miss rate on durable corrections: agents are
+told (guidance-only) to persist standing rules with
+`mcp__hindsight__create_directive`, but capture is a per-agent lottery. Stage B
+adds DETERMINISTIC (regex) detection of correction / standing-rule-shaped
+inbound in recall.py's UserPromptSubmit hook and appends a terse advisory nudge
+to the turn's additionalContext — the model does the actual judgment in-session
+(no model callsite; claude-native invariant).
+
+These tests pin:
+  * True positives — the audit's real MISSES + the issue's listed shapes.
+  * True negatives — pleasantries and questions must NOT fire (guard against
+    "always happy to help" / "never mind" tripping the bare always/never).
+  * The nudge is APPENDED to context without disturbing recall output
+    (_combine_context), and the nudge string is the create_directive advisory.
+  * The trivial-stateless recall gate is unaffected — a correction is never
+    trivial-skipped, and greetings still are (no regression on recall.py:582).
+
+Stdlib-only.
+"""
+
+import os
+import sys
+import unittest
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from recall import (  # noqa: E402
+    _DIRECTIVE_CAPTURE_NUDGE,
+    _combine_context,
+    _is_trivial_stateless,
+    looks_like_standing_rule,
+)
+
+
+# Correction / standing-rule-shaped inbound that MUST fire the nudge.
+# The first block is drawn verbatim (paraphrased) from Stage A's clear MISSES
+# — the exact corrections the guidance-only path silently dropped.
+CORRECTIONS = [
+    # --- Stage A clear misses ---
+    "you should always hyperlink linear issues when mentioning",
+    "i also want you to always provide a direct link to open the email",
+    "i want this behaviour of validate, dont assume as a general agent behaviour",
+    "don't make stuff up, investigate and validate",
+    "validate not assume, don't guess",
+    "We shouldn't publish confidential Buildkite data, so don't use names",
+    "The repo mekenthompson/switchroom is closed/dead. We use only switchroom/switchroom now",
+    # --- Stage A true captures (must also detect — the loop should fire on these) ---
+    "i never use them",
+    "We don't use streaming reply anymore",
+    "i always want you to help better format articles for readability",
+    # --- the issue's listed standing-rule shapes ---
+    "from now on, prefer British spelling",
+    "going forward, use GFM syntax",
+    "call me Ken, not Kenneth",
+    "stop doing that",
+    "stop using em-dashes",
+    "don't do that again",
+    "remember to close the loop with a summary",
+    "make sure you cite the file and line",
+    "make sure not to leak the token",
+    "no, it's actually the blue one",
+    "that's wrong",
+    "that's not what I asked for",
+    "I'd prefer you keep replies short",
+    "we prefer concise answers",
+    "in the future, ping me before deploying",
+]
+
+# Pleasantries, one-off questions, acks — must NOT fire (false positives cost
+# tokens + noise; the negative guard scrubs pleasantry shapes first).
+NON_CORRECTIONS = [
+    "always happy to help!",
+    "I'm always glad to assist",
+    "never mind, forget it",
+    "nevermind that",
+    "thanks as always",
+    "as always, appreciate it",
+    "can you check the deploy status",
+    "what time is it",
+    "how do I fix this bug",
+    "tell me about the project",
+    "the CI issue is now closed",  # 'closed' alone, not "it's/that's closed"
+    "please run the tests",
+    "what's the weather like",
+    # The <channel …> envelope wrapper on its own must never trigger.
+    '<channel user="ken" chat_id="123">',
+]
+
+
+class TestDirectiveCaptureDetection(unittest.TestCase):
+    def test_corrections_fire_the_nudge(self):
+        for p in CORRECTIONS:
+            with self.subTest(prompt=p):
+                self.assertTrue(
+                    looks_like_standing_rule(p),
+                    f"expected standing-rule detection for {p!r}",
+                )
+
+    def test_pleasantries_and_questions_do_not_fire(self):
+        for p in NON_CORRECTIONS:
+            with self.subTest(prompt=p):
+                self.assertFalse(
+                    looks_like_standing_rule(p),
+                    f"FALSE POSITIVE: nudge would fire for {p!r}",
+                )
+
+    def test_empty_and_non_string_are_false(self):
+        for bad in ("", "   ", None, 123, [], {}):
+            with self.subTest(value=bad):
+                self.assertFalse(looks_like_standing_rule(bad))
+
+    def test_pleasantry_scrub_does_not_mask_a_real_rule(self):
+        # A message that opens with a pleasantry AND states a real rule must
+        # still fire — the negative guard scrubs only the pleasantry span.
+        self.assertTrue(
+            looks_like_standing_rule(
+                "always happy to help — but from now on use British spelling"
+            )
+        )
+        self.assertTrue(
+            looks_like_standing_rule("never mind that, but always cite the file")
+        )
+
+
+class TestNudgeAppendedWithoutDisturbingRecall(unittest.TestCase):
+    def test_nudge_string_is_the_create_directive_advisory(self):
+        self.assertIn("create_directive", _DIRECTIVE_CAPTURE_NUDGE)
+        self.assertIn("directive_capture_check", _DIRECTIVE_CAPTURE_NUDGE)
+
+    def test_combine_appends_nudge_after_recall_block(self):
+        base = "<hindsight_memories>\n…\n</hindsight_memories>"
+        out = _combine_context(base, _DIRECTIVE_CAPTURE_NUDGE)
+        # Recall block preserved verbatim, nudge appended after it.
+        self.assertTrue(out.startswith(base))
+        self.assertTrue(out.endswith(_DIRECTIVE_CAPTURE_NUDGE))
+        self.assertIn(base + "\n\n", out)
+
+    def test_combine_with_no_nudge_leaves_recall_output_untouched(self):
+        base = "<hindsight_memories>\n…\n</hindsight_memories>"
+        self.assertEqual(_combine_context(base, None), base)
+
+    def test_combine_with_only_nudge_emits_nudge_alone(self):
+        self.assertEqual(
+            _combine_context("", _DIRECTIVE_CAPTURE_NUDGE), _DIRECTIVE_CAPTURE_NUDGE
+        )
+        self.assertEqual(
+            _combine_context(None, _DIRECTIVE_CAPTURE_NUDGE), _DIRECTIVE_CAPTURE_NUDGE
+        )
+
+    def test_combine_empty_is_empty(self):
+        self.assertEqual(_combine_context(None, None), "")
+        self.assertEqual(_combine_context("", ""), "")
+
+
+class TestTrivialSkipUnaffected(unittest.TestCase):
+    """The nudge must not perturb the trivial-stateless recall gate
+    (recall.py:582). Corrections carry standing-rule signals and are never
+    stateless, so they must NOT be trivial-skipped; greetings still are."""
+
+    def test_corrections_are_never_trivial_skipped(self):
+        for p in CORRECTIONS:
+            with self.subTest(prompt=p):
+                self.assertFalse(
+                    _is_trivial_stateless("", p),
+                    f"correction {p!r} was trivial-skipped — recall gate regressed",
+                )
+
+    def test_greetings_still_trivial_skip(self):
+        for p in ("hi", "hello", "what time is it", "good morning"):
+            with self.subTest(prompt=p):
+                self.assertTrue(_is_trivial_stateless("", p))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the directive-capture gap found in **#2848 Stage A** (a **~55% miss rate** on durable corrections — capture is a per-agent lottery). Adds **deterministic detection + an in-context nudge**: the vendored recall hook (UserPromptSubmit) regex-detects correction / standing-rule-shaped inbound and appends a terse advisory to the turn's `additionalContext` telling the model to persist the rule with `create_directive` **if** it is durable. The model does the judgment in-session and calls the tool itself.

This is the issue's **RECOMMENDED v1** (nudge-in-context) — no heavier design.

## Why

Directive capture was guidance-only (`profiles/default/CLAUDE.md.hbs`); the model inconsistently obeyed. Stage A: the same broadcast correction was captured by finn, silently dropped by clerk + reggie; clerk held 0 directives across 449 messages. Directives are the invariant-clean primitive that makes a correction stick (`remember-across-sessions` job headline criterion).

## How it stays invariant-clean

- **No new model callsite.** Detection is pure regex; judgment happens inside the interactive `claude` session (claude-native invariant).
- **No silent hook-side write.** The hook only nudges; the model decides and calls `create_directive` itself, visible in chat (chat-legibility / no-self-escalation).
- The trivial-turn recall gate (`_is_trivial_stateless`) is untouched.

## Where it lives / how it threads

- **Detection**: `vendor/hindsight-memory/scripts/recall.py` — `looks_like_standing_rule()` (a positive alternation regex + a negative guard that scrubs pleasantry shapes like "always happy to help" / "never mind" before matching). Switchroom-divergence comment pattern at the patch site. The nudge is kept **out** of the recall cache / last-recall state and appended only at emit time (`_combine_context`) so a cache hit can't replay a stale nudge; it fires on all three emit paths (cache-hit, no-memories, normal).
- **Config knob**: `memory.directive_capture_nudge` (bool, **default ON** — Stage A proved a real gap → defaults principle), cascade mode **override**. Threads exactly like the sibling recall knobs: default pinned in the plugin `settings.json` via `applyHindsightSettingsOverrides`; `start.sh` exports `HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE` only on operator override (env wins at plugin load). Documented in `docs/configuration.md`.

Serves `reference/jobs/remember-across-sessions.md`.

## Test plan

- [x] **Vendor unittest** `test_directive_capture_nudge.py` — true positives (Stage A's real misses + issue's listed shapes), true negatives (pleasantries/questions/envelope), pleasantry-scrub guard, `_combine_context` append semantics, and a no-regression check that corrections are never trivial-skipped / greetings still are. `python3 -m unittest discover tests/` → **190 pass** (11 new).
- [x] **Vitest** `scaffold.directive-capture-nudge.test.ts` — schema acceptance, settings.json default-on, start.sh opt-out cascade threading (unset→no export, false→`=false`, true→`=true`). **6 pass**; broader scaffold suite **213 pass**; merge/config **150 pass**.
- [x] `./node_modules/.bin/tsc --noEmit` → **exit 0**.
- [x] **UAT** `jtbd-directive-capture-nudge-dm` — a correction lands as a directive (hindsight REST) and survives `/reset` (a fresh neutral turn still honors the rule). Self-skips green when the mtcute driver is unwired. Not run live.

## Follow-up (not in this PR)

The issue's OPTIONAL **Stop-hook post-turn verification** ("correction-shaped inbound + no create_directive call → surface a line") would dovetail with **#2849**'s `detectMemoryLegibilityEvent` observation (its `📌 remembered:` line as the confirmation surface). Deliberately left as a stretch; this PR ships the UserPromptSubmit nudge as v1. (#2849's TS gateway-side observation is a different concern and is not imported here.)

## Risk

Low. Advisory-only; a false positive costs a handful of tokens and the model ignores it. Default-on is the intended behaviour (Stage A gate). Vendor change is additive with the divergence-comment convention; recall/cache/telemetry paths are preserved (nudge appended at emit, telemetry gains a `directive_nudge` bool). Operators can disable per-agent or fleet-wide via `memory.directive_capture_nudge: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)