### PR TITLE
fix(gateway): persist 30-min scoped grants across restarts (#2863)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -556,7 +556,9 @@ import {
   recordScopedGrant,
   lookupScopedGrant,
   sweepScopedGrants,
+  countScopedGrants,
 } from '../scoped-approval.js'
+import { createScopedGrantStore } from './scoped-grant-store.js'
 import { grantRestartDecision, type GrantRestartDecision } from './grant-restart.js'
 import { synthesizeAllowRuleDiff, extractAddedAllowRule } from '../permission-diff.js'
 import {
@@ -4623,7 +4625,16 @@ function sweepStaleAlwaysAllowCorrelations(now = Date.now()): void {
 // bridge's untimed sessionAllowRules), fixed-window, fail-closed. Keyed by
 // agent name for per-agent isolation. All policy lives in
 // ../scoped-approval.ts (pure + unit-tested); this gateway only wires it.
-const scopedGrants: ScopedGrantStore = new Map()
+//
+// Persisted across gateway restarts (#2863): a bounce (fleet roll / config
+// apply / failover probe) used to wipe every window, re-carding an action the
+// operator allowed minutes ago. The store mirrors to a tiny STATE_DIR JSON
+// file; reload drops entries already past their ABSOLUTE expiry (a restart
+// never extends a window). Kill switch SWITCHROOM_SCOPED_GRANT_PERSIST=0 boots
+// empty and never writes. Fail-closed lookup semantics are unchanged — a
+// reloaded grant runs the same lookupScopedGrant gate as an in-memory one.
+const scopedGrantStore = createScopedGrantStore(STATE_DIR)
+const scopedGrants: ScopedGrantStore = scopedGrantStore.load(Date.now())
 const selfAgentName = (): string => process.env.SWITCHROOM_AGENT_NAME ?? ''
 
 // `ask_user` MCP tool — open prompts awaiting a user button-tap.
@@ -5261,8 +5272,14 @@ const pendingStateReaper = setInterval(() => {
     if (now > v.expiresAt) vaultPassphraseCache.delete(k)
   }
   // Drop expired "⏱ 30 min" scoped grants. (Lookup already fails closed on
-  // expiry; this just keeps the map from accumulating dead entries.)
+  // expiry; this just keeps the map from accumulating dead entries.) Persist
+  // the removal so a restart between sweeps can't resurrect a swept grant —
+  // only write when the sweep actually changed something (sweeps only remove).
+  const scopedGrantsBefore = countScopedGrants(scopedGrants)
   sweepScopedGrants(scopedGrants, now)
+  if (countScopedGrants(scopedGrants) !== scopedGrantsBefore) {
+    scopedGrantStore.save(scopedGrants)
+  }
   for (const [k, v] of deferredSecrets) {
     if (now - v.staged_at > DEFERRED_SECRET_TTL_MS) deferredSecrets.delete(k)
   }
@@ -23205,6 +23222,9 @@ bot.on('callback_query:data', async ctx => {
   permCardStore.remove(request_id)
   if (timeBox && grantAgent) {
     recordScopedGrant(scopedGrants, grantAgent, timeBox.rule, Date.now(), scopedTtl)
+    // Write-through so the window survives a gateway restart (#2863). Absolute
+    // expiry is baked into the entry, so a reload can't extend it.
+    scopedGrantStore.save(scopedGrants)
     process.stderr.write(
       `telegram gateway: scoped-approval granted via Allow rule="${timeBox.rule}" ` +
       `agent=${grantAgent} ttl_ms=${scopedTtl} (request_id=${request_id})\n`,

--- a/telegram-plugin/gateway/scoped-grant-store.ts
+++ b/telegram-plugin/gateway/scoped-grant-store.ts
@@ -1,0 +1,89 @@
+/**
+ * Persistence for the gateway's 30-min scoped-approval windows
+ * (`scopedGrants: ScopedGrantStore`, see ../scoped-approval.ts).
+ *
+ * Problem: the store is in-memory. Any gateway restart (fleet roll, config
+ * apply, failover probe — marko saw ~14 boots on 2026-07-05) wipes it, so an
+ * action the operator allowed with a 30-min scope minutes ago re-cards
+ * immediately. It reads as "my approval didn't stick."
+ *
+ * Fix: mirror the store to a tiny JSON file in STATE_DIR (same shape as
+ * permission-card-store.ts — synchronous writes, mode 0o600, one small file).
+ * Write-through on every grant and on sweep-expiry removal; reload at boot,
+ * dropping entries already past their ABSOLUTE expiry.
+ *
+ * This only widens WHEN a still-valid window survives a restart — never WHAT
+ * qualifies. Expiry is absolute wall-clock, captured at the original tap, so a
+ * restart can never extend a window. All fail-closed semantics
+ * (destructive-Bash never scoped, expiry lookup fails closed) live in
+ * scoped-approval.ts and are untouched — a reloaded grant runs the identical
+ * `lookupScopedGrant` gate as an in-memory one.
+ *
+ * Kill switch: SWITCHROOM_SCOPED_GRANT_PERSIST=0 → boot with an empty store
+ * and never write (any pre-existing file is ignored).
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  serializeScopedGrants,
+  deserializeScopedGrants,
+  type ScopedGrantStore,
+} from '../scoped-approval.js'
+
+export interface ScopedGrantPersistence {
+  /** True unless the kill switch disabled persistence. */
+  readonly enabled: boolean
+  /** Load surviving grants (absolute expiry > now). Empty when disabled. */
+  load(now: number): ScopedGrantStore
+  /** Write-through the current store. No-op when disabled. */
+  save(store: ScopedGrantStore): void
+}
+
+/** Persistence is on unless SWITCHROOM_SCOPED_GRANT_PERSIST is exactly "0". */
+export function scopedGrantPersistEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env.SWITCHROOM_SCOPED_GRANT_PERSIST !== '0'
+}
+
+export function createScopedGrantStore(
+  stateDir: string,
+  env: Record<string, string | undefined> = process.env,
+): ScopedGrantPersistence {
+  const filePath = join(stateDir, 'scoped-grants.json')
+  const enabled = scopedGrantPersistEnabled(env)
+
+  function read(): unknown[] {
+    try {
+      const raw = readFileSync(filePath, 'utf-8')
+      const parsed = JSON.parse(raw)
+      return Array.isArray(parsed) ? parsed : []
+    } catch {
+      return []
+    }
+  }
+
+  return {
+    enabled,
+
+    load(now) {
+      if (!enabled) return new Map()
+      return deserializeScopedGrants(read(), now)
+    },
+
+    save(store) {
+      if (!enabled) return
+      try {
+        writeFileSync(filePath, JSON.stringify(serializeScopedGrants(store)), {
+          encoding: 'utf-8',
+          mode: 0o600,
+        })
+      } catch (err) {
+        process.stderr.write(
+          `telegram gateway: scoped-grant-store write failed: ${(err as Error).message}\n`,
+        )
+      }
+    },
+  }
+}

--- a/telegram-plugin/scoped-approval.ts
+++ b/telegram-plugin/scoped-approval.ts
@@ -214,6 +214,65 @@ export function sweepScopedGrants(store: ScopedGrantStore, now: number): void {
   }
 }
 
+/** Total number of live-or-not grant entries across all agents. Cheap change
+ *  signal for "did a sweep remove anything?" (sweeps only ever remove). */
+export function countScopedGrants(store: ScopedGrantStore): number {
+  let n = 0;
+  for (const list of store.values()) n += list.length;
+  return n;
+}
+
+/**
+ * A single grant flattened for on-disk persistence. Carries the agent it
+ * belongs to (the store is keyed by agent), the narrow rule/signature, and
+ * the ABSOLUTE wall-clock expiry — never a relative TTL, so a reload can
+ * never extend a window (the restart-doesn't-extend invariant). No grant
+ * time is stored because nothing needs it: expiry is the only gate.
+ */
+export interface SerializedScopedGrant {
+  readonly agent: string;
+  readonly rule: string;
+  readonly expiresAt: number;
+}
+
+/** Flatten the per-agent store to a plain array for JSON persistence. */
+export function serializeScopedGrants(store: ScopedGrantStore): SerializedScopedGrant[] {
+  const out: SerializedScopedGrant[] = [];
+  for (const [agent, list] of store) {
+    for (const g of list) out.push({ agent, rule: g.rule, expiresAt: g.expiresAt });
+  }
+  return out;
+}
+
+/**
+ * Rebuild the store from persisted entries at gateway boot. Entries already
+ * at/past `now` are DROPPED (expiry is absolute — a restart never revives or
+ * extends a window). Malformed rows are skipped defensively (fail-closed:
+ * an unparseable grant simply doesn't exist → the action re-cards). A
+ * duplicate rule for one agent collapses to the latest expiry, mirroring
+ * `recordScopedGrant`'s replace-not-accumulate behaviour.
+ */
+export function deserializeScopedGrants(
+  data: readonly unknown[],
+  now: number,
+): ScopedGrantStore {
+  const store: ScopedGrantStore = new Map();
+  if (!Array.isArray(data)) return store;
+  for (const raw of data) {
+    if (!raw || typeof raw !== "object") continue;
+    const entry = raw as Partial<SerializedScopedGrant>;
+    if (typeof entry.agent !== "string" || entry.agent.length === 0) continue;
+    if (typeof entry.rule !== "string" || entry.rule.length === 0) continue;
+    if (typeof entry.expiresAt !== "number" || !Number.isFinite(entry.expiresAt)) continue;
+    if (entry.expiresAt <= now) continue; // absolute expiry already elapsed → drop
+    const list = store.get(entry.agent) ?? [];
+    const others = list.filter((g) => g.rule !== entry.rule);
+    others.push({ rule: entry.rule, expiresAt: entry.expiresAt });
+    store.set(entry.agent, others);
+  }
+  return store;
+}
+
 /**
  * Heuristic destructive/irreversible-command detector. FAIL-CLOSED: when
  * a command can't be read or looks risky, return `true` so it is never

--- a/telegram-plugin/tests/scoped-grant-persist.test.ts
+++ b/telegram-plugin/tests/scoped-grant-persist.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for the persistence of the 30-min scoped-approval windows across
+ * gateway restarts (#2863). The store (scopedGrants) is in-memory and used
+ * to evaporate on any gateway bounce, re-carding an action the operator
+ * allowed minutes ago. These pin:
+ *
+ *   - round-trip: record → persist → reload → lookup still hits in-window;
+ *   - entries already past their ABSOLUTE expiry are dropped at reload;
+ *   - a restart NEVER extends a window (grant at T, reload at T+29min →
+ *     ~1 min left, not a fresh 30);
+ *   - fail-closed survives a reload (a destructive Bash command still
+ *     re-cards even when a reloaded family grant matches; an expired grant
+ *     never matches);
+ *   - kill switch (SWITCHROOM_SCOPED_GRANT_PERSIST=0): no writes, boot
+ *     ignores any pre-existing file.
+ *
+ * The persistence I/O (createScopedGrantStore) is thin; the invariants live
+ * in the pure serialize/deserialize + lookup, so we drive both together with
+ * an isolated tmpdir (never ~/.switchroom or a shared STATE_DIR).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  SCOPED_APPROVAL_DEFAULT_TTL_MS,
+  recordScopedGrant,
+  lookupScopedGrant,
+  sweepScopedGrants,
+  serializeScopedGrants,
+  deserializeScopedGrants,
+  countScopedGrants,
+  type ScopedGrantStore,
+} from '../scoped-approval.js'
+import { createScopedGrantStore, scopedGrantPersistEnabled } from '../gateway/scoped-grant-store.js'
+
+const T0 = 1_000_000
+const TTL = SCOPED_APPROVAL_DEFAULT_TTL_MS
+const AGENT = 'marko'
+
+const editInput = (path: string) => JSON.stringify({ file_path: path })
+const bashInput = (command: string) => JSON.stringify({ command })
+
+function makeTmpDir() {
+  return mkdtempSync(join(tmpdir(), 'scoped-grant-persist-test-'))
+}
+
+function filePath(dir: string) {
+  return join(dir, 'scoped-grants.json')
+}
+
+describe('scoped-grant persistence', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = makeTmpDir()
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('round-trips: record → persist → reload → lookup hits within the window', () => {
+    const store = createScopedGrantStore(dir, {})
+    expect(store.enabled).toBe(true)
+
+    // Operator taps Allow on a narrow file edit at T0.
+    const live: ScopedGrantStore = new Map()
+    recordScopedGrant(live, AGENT, 'Edit(/state/x.ts)', T0, TTL)
+    store.save(live)
+
+    expect(existsSync(filePath(dir))).toBe(true)
+
+    // Gateway restarts 5 minutes later; reload the store.
+    const reloadAt = T0 + 5 * 60_000
+    const reloaded = store.load(reloadAt)
+
+    // The window is still live → an identical action auto-allows (no re-card).
+    const hit = lookupScopedGrant(reloaded, AGENT, 'Edit', editInput('/state/x.ts'), reloadAt)
+    expect(hit).toBe('Edit(/state/x.ts)')
+  })
+
+  it('drops entries already past their absolute expiry at reload', () => {
+    const store = createScopedGrantStore(dir, {})
+    const live: ScopedGrantStore = new Map()
+    recordScopedGrant(live, AGENT, 'Edit(/state/x.ts)', T0, TTL)
+    store.save(live)
+
+    // Reload well after the 30-min window has elapsed.
+    const reloadAt = T0 + TTL + 60_000
+    const reloaded = store.load(reloadAt)
+
+    expect(countScopedGrants(reloaded)).toBe(0)
+    const hit = lookupScopedGrant(reloaded, AGENT, 'Edit', editInput('/state/x.ts'), reloadAt)
+    expect(hit).toBeNull()
+  })
+
+  it('a restart does NOT extend the window (absolute expiry preserved)', () => {
+    const store = createScopedGrantStore(dir, {})
+    const live: ScopedGrantStore = new Map()
+    recordScopedGrant(live, AGENT, 'Edit(/state/x.ts)', T0, TTL) // expiresAt = T0 + 30min
+    store.save(live)
+
+    // Reload at T0 + 29 min: only ~1 min should remain, not a fresh 30.
+    const reloadAt = T0 + 29 * 60_000
+    const reloaded = store.load(reloadAt)
+
+    // Still live one minute before expiry...
+    expect(lookupScopedGrant(reloaded, AGENT, 'Edit', editInput('/state/x.ts'), reloadAt)).toBe(
+      'Edit(/state/x.ts)',
+    )
+    // ...but dead ~90s later — the original absolute expiry is honoured, the
+    // reload gave it no new lease.
+    const afterOriginalExpiry = T0 + TTL + 1_000
+    expect(
+      lookupScopedGrant(reloaded, AGENT, 'Edit', editInput('/state/x.ts'), afterOriginalExpiry),
+    ).toBeNull()
+  })
+
+  it('fail-closed survives reload: destructive Bash never auto-allows', () => {
+    const store = createScopedGrantStore(dir, {})
+    const live: ScopedGrantStore = new Map()
+    // A benign `git status` earned a Bash(git:*) family window.
+    recordScopedGrant(live, AGENT, 'Bash(git:*)', T0, TTL)
+    store.save(live)
+
+    const reloadAt = T0 + 60_000
+    const reloaded = store.load(reloadAt)
+
+    // Benign member still auto-allows.
+    expect(lookupScopedGrant(reloaded, AGENT, 'Bash', bashInput('git status'), reloadAt)).toBe(
+      'Bash(git:*)',
+    )
+    // Destructive member of the SAME family fails closed after reload.
+    expect(
+      lookupScopedGrant(reloaded, AGENT, 'Bash', bashInput('git push --force'), reloadAt),
+    ).toBeNull()
+    expect(
+      lookupScopedGrant(reloaded, AGENT, 'Bash', bashInput('git reset --hard'), reloadAt),
+    ).toBeNull()
+  })
+
+  it('sweep-expiry removal is written through and a reload cannot resurrect it', () => {
+    const store = createScopedGrantStore(dir, {})
+    const live: ScopedGrantStore = new Map()
+    recordScopedGrant(live, AGENT, 'Edit(/state/x.ts)', T0, TTL)
+    store.save(live)
+
+    // Periodic sweep runs past expiry and removes the entry; write it through.
+    const sweepAt = T0 + TTL + 1_000
+    sweepScopedGrants(live, sweepAt)
+    store.save(live)
+
+    // A restart immediately after must see an empty store.
+    const reloaded = store.load(sweepAt + 1)
+    expect(countScopedGrants(reloaded)).toBe(0)
+  })
+
+  it('kill switch: no writes, and boot ignores a pre-existing file', () => {
+    // Seed a live grant on disk as if a prior (persist-enabled) boot wrote it.
+    const seeded = createScopedGrantStore(dir, {})
+    const live: ScopedGrantStore = new Map()
+    recordScopedGrant(live, AGENT, 'Edit(/state/x.ts)', T0, TTL)
+    seeded.save(live)
+    const onDiskBefore = readFileSync(filePath(dir), 'utf-8')
+
+    // Now boot with the kill switch on.
+    const killed = createScopedGrantStore(dir, { SWITCHROOM_SCOPED_GRANT_PERSIST: '0' })
+    expect(killed.enabled).toBe(false)
+    expect(scopedGrantPersistEnabled({ SWITCHROOM_SCOPED_GRANT_PERSIST: '0' })).toBe(false)
+
+    // Boot ignores the pre-existing file → empty store.
+    const reloaded = killed.load(T0 + 60_000)
+    expect(countScopedGrants(reloaded)).toBe(0)
+
+    // save() is a no-op — the file is not touched.
+    const grantsToPersist: ScopedGrantStore = new Map()
+    recordScopedGrant(grantsToPersist, AGENT, 'Edit(/state/y.ts)', T0, TTL)
+    killed.save(grantsToPersist)
+    expect(readFileSync(filePath(dir), 'utf-8')).toBe(onDiskBefore)
+  })
+
+  it('pure serialize/deserialize drops malformed and expired rows (fail-closed)', () => {
+    const now = T0
+    const raw = [
+      { agent: AGENT, rule: 'Edit(/state/live.ts)', expiresAt: now + TTL }, // keep
+      { agent: AGENT, rule: 'Edit(/state/gone.ts)', expiresAt: now - 1 }, // expired → drop
+      { agent: AGENT, rule: 'Edit(/state/x.ts)' }, // no expiresAt → drop
+      { rule: 'Edit(/state/x.ts)', expiresAt: now + TTL }, // no agent → drop
+      { agent: AGENT, rule: '', expiresAt: now + TTL }, // empty rule → drop
+      'garbage', // not an object → drop
+      null, // → drop
+    ]
+    const store = deserializeScopedGrants(raw, now)
+    expect(countScopedGrants(store)).toBe(1)
+    expect(lookupScopedGrant(store, AGENT, 'Edit', editInput('/state/live.ts'), now)).toBe(
+      'Edit(/state/live.ts)',
+    )
+  })
+
+  it('serialize captures absolute expiry, not a relative TTL', () => {
+    const live: ScopedGrantStore = new Map()
+    recordScopedGrant(live, AGENT, 'Edit(/state/x.ts)', T0, TTL)
+    const flat = serializeScopedGrants(live)
+    expect(flat).toEqual([{ agent: AGENT, rule: 'Edit(/state/x.ts)', expiresAt: T0 + TTL }])
+  })
+
+  it('corrupt on-disk JSON reloads as an empty store (fail-closed, no throw)', () => {
+    writeFileSync(filePath(dir), '{ this is not json', 'utf-8')
+    const store = createScopedGrantStore(dir, {})
+    const reloaded = store.load(T0)
+    expect(countScopedGrants(reloaded)).toBe(0)
+  })
+
+  it('persisted file is written with mode 0o600', () => {
+    const store = createScopedGrantStore(dir, {})
+    const live: ScopedGrantStore = new Map()
+    recordScopedGrant(live, AGENT, 'Edit(/state/x.ts)', T0, TTL)
+    store.save(live)
+    const mode = statSync(filePath(dir)).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+})


### PR DESCRIPTION
## Summary

Persists the gateway's 30-min scoped-approval windows (`scopedGrants`) to a tiny JSON file in `STATE_DIR` so they survive a gateway restart, instead of evaporating in memory on every bounce.

Closes root cause **R4** of umbrella #2859. Implements child issue #2863 (PR C — optional, smallest, independent of PRs A/B #2861/#2862).

## Why

`scopedGrants` was in-memory only. Any gateway bounce — fleet roll, config apply, failover probe (marko saw ~14 boots on 2026-07-05) — wiped every window. An action the operator allowed with a 30-min scope minutes ago re-carded immediately, reading as *"my approval didn't stick."*

## Mechanism

- New `telegram-plugin/gateway/scoped-grant-store.ts` mirrors the store to `STATE_DIR/scoped-grants.json` (same pattern as `permission-card-store.ts`: synchronous writes, mode `0o600`, one tiny file).
- Pure `serializeScopedGrants` / `deserializeScopedGrants` (+ `countScopedGrants`) added to `telegram-plugin/scoped-approval.ts` — unit-tested directly.
- Gateway wiring: load at boot (dropping entries past absolute expiry); write-through on `recordScopedGrant` and on sweep-expiry removal (only when the sweep actually removed something).

## Invariants preserved

- **Absolute expiry** — entries carry the absolute wall-clock `expiresAt` captured at the original tap. A restart can NOT extend a window (grant at T, reload at T+29min → ~1 min left, not a fresh 30).
- **Fail-closed unchanged** — a reloaded grant runs the identical `lookupScopedGrant` gate: destructive Bash never auto-allows even when a reloaded family grant matches; expired grants never match; malformed/corrupt on-disk rows deserialize to nothing → re-card. Persistence widens only *when* a still-valid window survives, never *what* qualifies.
- **`sweepScopedGrants` behaviour unchanged** — still pure; write-through is a separate gateway-side call.
- Bridge-side `sessionAllowRules` left alone (correctly scoped to the claude session by design).

## Kill switch

`SWITCHROOM_SCOPED_GRANT_PERSIST=0` → boot with an empty store, never write, ignore any pre-existing file.

## Test plan

New `telegram-plugin/tests/scoped-grant-persist.test.ts` (10 tests, green under **both** vitest and bun):

- [x] round-trip: record → persist → reload → lookup hits within window
- [x] entries past absolute expiry dropped at reload
- [x] restart does not extend the window (T+29min → ~1 min left)
- [x] fail-closed after reload: destructive Bash re-cards; expired never matches
- [x] sweep-expiry removal written through; reload can't resurrect
- [x] kill switch: no writes, boot ignores existing file
- [x] serialize captures absolute expiry (not relative TTL); malformed/corrupt rows drop; file mode `0o600`

Local: `tsc --noEmit` clean; existing `scoped-approval.test.ts` (32) still green; `check-bot-api-wrapping.sh` clean (no bot-api callsites added). `check-plugin-references.mjs` has a pre-existing host-environment failure (grammy `sendRichMessage`/`replyWithRichMessage` type augmentations) whose error profile is byte-identical to a clean checkout and touches none of my files.

## Risk

Low. Additive persistence around existing pure logic; fail-closed and absolute-expiry invariants covered by tests; kill switch reverts to prior in-memory behaviour. Touches `gateway.ts` (shared with #2861/#2862) — diff kept minimal/localized; conflicts reconciled at merge time.

Umbrella: #2859. Independent of PRs A/B.