### PR TITLE
feat(gateway): re-offer missed approvals after TTL expiry (#2862)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -124,6 +124,13 @@ import {
   computeBootSweepStripTargets,
   distinctRequestIds,
 } from './permission-rearm.js'
+import { createMissedApprovalsStore, type MissedApproval } from './missed-approvals-store.js'
+import {
+  renderMissedApprovalsDigest,
+  missedApprovalsKeyboard,
+  parseMissedApprovalCallback,
+  buildMissedApprovalRetryInbound,
+} from './missed-approvals-card.js'
 import { pickRecoveredPermissionOrigin } from './permission-card-origin.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { appendActivityLabel, clipNarrative, renderActivityFeedWithNested, formatStepSuffix, type SessionActivityHeader } from '../tool-activity-summary.js'
@@ -680,6 +687,12 @@ process.on('beforeExit', () => {
 // ─── Env + state dir ──────────────────────────────────────────────────────
 const STATE_DIR = process.env.TELEGRAM_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'telegram')
 const permCardStore = createPermissionCardStore(STATE_DIR)
+// #2862 — missed-approvals re-offer. Persisted list of approvals that
+// TTL-expired while the operator was away; a digest card is posted on the
+// operator's next activity. Kill switch: SWITCHROOM_MISSED_APPROVAL_REOFFER=0.
+const missedApprovalsStore = createMissedApprovalsStore(STATE_DIR)
+const MISSED_APPROVAL_REOFFER_ENABLED =
+  process.env.SWITCHROOM_MISSED_APPROVAL_REOFFER !== '0'
 const ACCESS_FILE = join(STATE_DIR, 'access.json')
 const APPROVED_DIR = join(STATE_DIR, 'approved')
 const ENV_FILE = join(STATE_DIR, '.env')
@@ -4593,6 +4606,131 @@ function clearPermissionTimeoutSuppression(reason: string): void {
     `telegram gateway: permission no-repeat suppression cleared (${n} sig(s)) — ${reason}\n`,
   )
 }
+
+// #2862 — missed-approvals re-offer digest. Called from every operator-activity
+// path that clears no-repeat suppression (inbound, /approve|/deny, card verdict):
+// on the FIRST activity after ≥1 approval TTL-expired while the operator was
+// away, post ONE compact digest card per origin surface listing the misses,
+// then promote those pending entries into a delivered-digest record (the posted
+// card is now the durable record in chat). Best-effort + fire-and-forget: never
+// blocks or throws into the hot inbound/callback path. Kill switch (=0) makes
+// this a no-op AND the auto-deny append below a no-op, so the whole feature is off.
+function maybePostMissedApprovalDigest(reason: string): void {
+  if (!MISSED_APPROVAL_REOFFER_ENABLED) return
+  const pending = missedApprovalsStore.listPending()
+  if (pending.length === 0) return
+  // Group by origin surface so each card lands where its cards were posted.
+  const groups = new Map<string, MissedApproval[]>()
+  for (const e of pending) {
+    const key = `${e.chatId}::${e.threadId ?? ''}`
+    const g = groups.get(key)
+    if (g) g.push(e)
+    else groups.set(key, [e])
+  }
+  for (const entries of groups.values()) {
+    const first = entries[0]
+    const chatId = first.chatId
+    const threadId = first.threadId ?? undefined
+    const digestId = randomBytes(4).toString('hex')
+    const text = renderMissedApprovalsDigest(entries, {
+      agentName: process.env.SWITCHROOM_AGENT_NAME ?? null,
+    })
+    void swallowingApiCall(
+      () =>
+        // allow-raw-bot-api: routed through swallowingApiCall retry policy; thread-aware digest card
+        bot.api.sendMessage(chatId, text, {
+          parse_mode: 'HTML',
+          reply_markup: missedApprovalsKeyboard(digestId),
+          ...(threadId != null && threadId !== 1 ? { message_thread_id: threadId } : {}),
+        }),
+      { chat_id: chatId, verb: 'missed-approval-digest', ...(threadId != null ? { threadId } : {}) },
+    )
+    // Promote synchronously (before the async send resolves) so a second
+    // operator-activity event racing in sees an empty pending list and can't
+    // double-post — "one card per accumulated batch" holds.
+    missedApprovalsStore.promoteToDigest({
+      digestId,
+      chatId,
+      threadId: first.threadId ?? null,
+      entries,
+      deliveredAt: Date.now(),
+    })
+  }
+  process.stderr.write(
+    `telegram gateway: missed-approval digest posted (${pending.length} entr(y/ies), ` +
+    `${groups.size} surface(s)) — ${reason}\n`,
+  )
+}
+
+// #2862 — handle a Retry / Dismiss tap on a missed-approvals digest card.
+//   missre:retry:<id>   — inject a synthetic inbound asking the agent to
+//                         re-attempt the actions (claude-native; re-raises a
+//                         fresh approval card). NEVER a verdict / re-execution.
+//   missre:dismiss:<id> — clear the record + edit the card closed.
+async function handleMissedApprovalCallback(ctx: Context, data: string): Promise<void> {
+  const senderId = String(ctx.from?.id ?? '')
+  const access = loadAccess()
+  if (!access.allowFrom.includes(senderId)) {
+    await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+    return
+  }
+  const parsed = parseMissedApprovalCallback(data)
+  if (parsed == null) {
+    await ctx.answerCallbackQuery({ text: 'Bad request' }).catch(() => {})
+    return
+  }
+  const digest = missedApprovalsStore.getDigest(parsed.digestId)
+  if (digest == null) {
+    await ctx.answerCallbackQuery({ text: 'This digest already actioned or expired.' }).catch(() => {})
+    if (ctx.callbackQuery?.message) {
+      await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {})
+    }
+    return
+  }
+
+  if (parsed.action === 'dismiss') {
+    missedApprovalsStore.removeDigest(parsed.digestId)
+    await ctx.answerCallbackQuery({ text: '🚫 Dismissed — cleared.' }).catch(() => {})
+    if (ctx.callbackQuery?.message && 'text' in ctx.callbackQuery.message) {
+      await ctx
+        .editMessageText(
+          `${escapeHtmlForTg(ctx.callbackQuery.message.text ?? '')}\n\n🚫 <i>Dismissed.</i>`,
+          { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
+        )
+        .catch(() => {})
+    }
+    return
+  }
+
+  // Retry — consume the record, then inject a synthetic inbound to the ORIGIN
+  // surface asking the agent to re-attempt. This rides the same synthesized-
+  // inbound path cron uses; the agent naturally re-raises a fresh approval card.
+  missedApprovalsStore.removeDigest(parsed.digestId)
+  const agent = process.env.SWITCHROOM_AGENT_NAME ?? ''
+  const synthetic = buildMissedApprovalRetryInbound({
+    ctx: {
+      agent,
+      chat_id: digest.chatId,
+      ...(digest.threadId != null ? { threadId: digest.threadId } : {}),
+    },
+    actions: digest.entries.map(e => e.action),
+    operatorId: senderId,
+  })
+  const delivered = deliverResumeSyntheticOrBuffer(agent, synthetic)
+  await ctx.answerCallbackQuery({ text: '🔁 Asking the agent to retry…' }).catch(() => {})
+  if (ctx.callbackQuery?.message && 'text' in ctx.callbackQuery.message) {
+    await ctx
+      .editMessageText(
+        `${escapeHtmlForTg(ctx.callbackQuery.message.text ?? '')}\n\n🔁 <i>Retrying — asked the agent.</i>`,
+        { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
+      )
+      .catch(() => {})
+  }
+  process.stderr.write(
+    `telegram gateway: missed-approval retry injection agent=${agent} ` +
+    `digest=${parsed.digestId} actions=${digest.entries.length} delivered=${delivered}\n`,
+  )
+}
 // Permission/approval-card origin recovery (marko Rentals-budget, 2026-06-17).
 // When `currentTurn` was force-closed by the orphaned-reply backstop but the
 // claude session kept running into a permission-gated tool, recover the card's
@@ -5260,6 +5398,23 @@ const pendingStateReaper = setInterval(() => {
           permissionSignature(v.tool_name, v.input_preview),
           now,
         )
+      }
+      // #2862 — record the miss so it can be re-offered when the operator
+      // returns. Anchor to the card's own origin surface (where the operator
+      // would have tapped), so the digest lands in the same topic — not a
+      // fanned-out DM. Skip if the card was never posted anywhere.
+      if (MISSED_APPROVAL_REOFFER_ENABLED) {
+        const origin = v.cards[0]
+        if (origin != null) {
+          missedApprovalsStore.add({
+            requestId: k,
+            toolName: v.tool_name,
+            action: naturalAction(v.tool_name, v.input_preview),
+            chatId: origin.chatId,
+            threadId: origin.threadId ?? null,
+            timedOutAt: now,
+          })
+        }
       }
       process.stderr.write(
         `telegram gateway: permission TTL expired — auto-deny request=${k} ` +
@@ -14519,6 +14674,8 @@ async function handleInbound(
   // present, so reset any no-repeat suppression: the next time the agent asks
   // for something that timed out earlier, they should see a fresh card.
   clearPermissionTimeoutSuppression('operator inbound')
+  // #2862 — operator is back; re-offer any approvals that timed out meanwhile.
+  maybePostMissedApprovalDigest('operator inbound')
 
   // Capture wall-clock receive time for inbound_ack metric (#203).
   // Must be after gate() so early-exit paths (drop/pair) don't skew the delta.
@@ -18271,6 +18428,8 @@ async function handlePermissionSlash(ctx: Context, behavior: 'allow' | 'deny'): 
   }
   // Operator answered via slash ⇒ present; reset no-repeat suppression.
   clearPermissionTimeoutSuppression('operator answered via /approve|/deny')
+  // #2862 — operator is present; re-offer any approvals that timed out meanwhile.
+  maybePostMissedApprovalDigest('operator answered via /approve|/deny')
   // Forward to connected bridges — same IPC the button handler uses.
   dispatchPermissionVerdict({ type: 'permission', requestId: request_id, behavior })
   resumeReactionAfterVerdict()
@@ -22679,6 +22838,15 @@ bot.on('callback_query:data', async ctx => {
     return
   }
 
+  // #2862: missed-approvals re-offer digest.
+  //   missre:retry:<id>   — inject a synthetic inbound asking the agent to
+  //                         re-attempt (re-raises a fresh approval card)
+  //   missre:dismiss:<id> — clear the record + edit the card closed
+  if (data.startsWith('missre:')) {
+    await handleMissedApprovalCallback(ctx, data)
+    return
+  }
+
   // Issue #969 P2b: vault recent-denial one-tap approval.
   //   vrd:<agent>:<key> — mint a 30-day read-grant for the agent + key
   // Posted by /vault audit <agent> in the "Recent denials" section.
@@ -23325,6 +23493,8 @@ bot.on('callback_query:data', async ctx => {
   // Operator tapped a verdict ⇒ they are present; reset no-repeat suppression
   // so a later identical ask is shown fresh rather than silently short-circuited.
   clearPermissionTimeoutSuppression('operator answered a permission card')
+  // #2862 — operator is present; re-offer any approvals that timed out meanwhile.
+  maybePostMissedApprovalDigest('operator answered a permission card')
   const pd = pendingPermissions.get(request_id)
   const resumeAction = pd ? naturalAction(pd.tool_name, pd.input_preview) : ''
   const scopedTtl = scopedApprovalTtlMs()

--- a/telegram-plugin/gateway/missed-approvals-card.ts
+++ b/telegram-plugin/gateway/missed-approvals-card.ts
@@ -1,0 +1,161 @@
+/**
+ * Missed-approvals re-offer digest card (#2862).
+ *
+ * Pure builders — card text, inline keyboard, callback shape, and the
+ * synthetic inbound the gateway injects on Retry — kept out of gateway.ts so
+ * they're pinned by tests independent of the bot plumbing (mirrors
+ * `skill-proposal-card.ts`).
+ *
+ * The digest lists the approvals that TTL-expired while the operator was away
+ * and offers two taps:
+ *   • Ask agent to retry → inject a synthetic inbound asking the live agent to
+ *     re-attempt the actions. This rides the SAME `inject_inbound` /
+ *     synthesized-inbound path cron uses (claude-native): the agent starts a
+ *     fresh turn and naturally re-raises a new approval card. It is a QUESTION
+ *     to the agent — never a re-execution, never a synthesized verdict
+ *     (no-self-escalation intact).
+ *   • Dismiss → clear the list and edit the card closed.
+ *
+ * callback_data shape (fits Telegram's 64-byte limit):
+ *   missre:retry:<digestId>
+ *   missre:dismiss:<digestId>
+ */
+
+import type { InboundMessage } from './ipc-protocol.js'
+import type { MissedApproval } from './missed-approvals-store.js'
+
+export const MISSED_APPROVAL_CALLBACK_PREFIX = 'missre:'
+/** How many entries to list in the card before collapsing to "…and N more". */
+export const MISSED_APPROVAL_RENDER_CAP = 10
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/** Compact HH:MM (UTC) stamp for a miss. */
+function fmtTime(ms: number): string {
+  const d = new Date(ms)
+  const hh = String(d.getUTCHours()).padStart(2, '0')
+  const mm = String(d.getUTCMinutes()).padStart(2, '0')
+  return `${hh}:${mm}`
+}
+
+/**
+ * Render the digest card text (HTML parse mode). Lists up to
+ * `cap` entries, then a "…and N more" overflow line.
+ */
+export function renderMissedApprovalsDigest(
+  entries: MissedApproval[],
+  opts?: { cap?: number; agentName?: string | null },
+): string {
+  const cap = opts?.cap ?? MISSED_APPROVAL_RENDER_CAP
+  const who = opts?.agentName ? escapeHtml(opts.agentName) : 'the agent'
+  const shown = entries.slice(0, cap)
+  const overflow = entries.length - shown.length
+
+  const lines: string[] = []
+  lines.push('⏳ <b>Missed approvals while you were away</b>')
+  lines.push('')
+  lines.push('These approval requests timed out before you could respond:')
+  for (const e of shown) {
+    lines.push(`• ${escapeHtml(e.action)} <i>(${fmtTime(e.timedOutAt)} UTC)</i>`)
+  }
+  if (overflow > 0) {
+    lines.push(`…and ${overflow} more`)
+  }
+  lines.push('')
+  lines.push(
+    `<i>Tap “Ask agent to retry” to have ${who} re-attempt them — you’ll be ` +
+      'asked to approve again as normal. Dismiss to clear.</i>',
+  )
+  return lines.join('\n')
+}
+
+/** Inline keyboard for the digest card. */
+export function missedApprovalsKeyboard(digestId: string): {
+  inline_keyboard: Array<Array<{ text: string; callback_data: string }>>
+} {
+  return {
+    inline_keyboard: [
+      [
+        {
+          text: '🔁 Ask agent to retry',
+          callback_data: `${MISSED_APPROVAL_CALLBACK_PREFIX}retry:${digestId}`,
+        },
+        {
+          text: '🚫 Dismiss',
+          callback_data: `${MISSED_APPROVAL_CALLBACK_PREFIX}dismiss:${digestId}`,
+        },
+      ],
+    ],
+  }
+}
+
+/** Parse a `missre:` callback into { action, digestId }, or null if not ours. */
+export function parseMissedApprovalCallback(
+  data: string,
+): { action: 'retry' | 'dismiss'; digestId: string } | null {
+  if (!data.startsWith(MISSED_APPROVAL_CALLBACK_PREFIX)) return null
+  const rest = data.slice(MISSED_APPROVAL_CALLBACK_PREFIX.length)
+  const idx = rest.indexOf(':')
+  if (idx < 0) return null
+  const action = rest.slice(0, idx)
+  const digestId = rest.slice(idx + 1)
+  if ((action !== 'retry' && action !== 'dismiss') || digestId.length === 0) return null
+  return { action, digestId }
+}
+
+export interface MissedApprovalInboundContext {
+  agent: string
+  chat_id: string
+  threadId?: number
+}
+
+/**
+ * Build the synthetic inbound injected when the operator taps "Ask agent to
+ * retry". It ASKS the agent to re-attempt the listed actions — it never
+ * re-executes them and never carries a verdict (no-self-escalation). The
+ * agent starts a fresh turn and naturally re-raises approval cards.
+ *
+ * `meta.source = "missed_approval_retry"` so the bridge renders it as
+ * `<channel source="missed_approval_retry">`.
+ */
+export function buildMissedApprovalRetryInbound(opts: {
+  ctx: MissedApprovalInboundContext
+  actions: string[]
+  operatorId: string
+  nowMs?: number
+}): InboundMessage {
+  const ts = opts.nowMs ?? Date.now()
+  const list =
+    opts.actions.length === 1
+      ? opts.actions[0]
+      : opts.actions.map(a => `\n• ${a}`).join('')
+  const body =
+    opts.actions.length === 1
+      ? `Please re-attempt it now: ${list}.`
+      : `Please re-attempt them now:${list}`
+  return {
+    type: 'inbound',
+    chatId: opts.ctx.chat_id,
+    ...(opts.ctx.threadId != null ? { threadId: opts.ctx.threadId } : {}),
+    messageId: ts,
+    user: 'missed-approvals',
+    userId: 0,
+    ts,
+    text:
+      `🔁 Operator asked you to retry ${opts.actions.length === 1 ? 'an action' : 'some actions'} ` +
+      `that timed out earlier while they were away. ${body} You'll be asked to ` +
+      `approve again as normal — do not assume the earlier timeout was a denial.`,
+    meta: {
+      source: 'missed_approval_retry',
+      agent: opts.ctx.agent,
+      ...(opts.ctx.threadId != null ? { message_thread_id: String(opts.ctx.threadId) } : {}),
+      operator_id: opts.operatorId,
+      action_count: String(opts.actions.length),
+    },
+  }
+}

--- a/telegram-plugin/gateway/missed-approvals-store.ts
+++ b/telegram-plugin/gateway/missed-approvals-store.ts
@@ -1,0 +1,167 @@
+/**
+ * Persistence store for approvals that TTL-expired while the operator was
+ * away (#2862, "approval cards don't stick — re-offer digest").
+ *
+ * Problem: when a permission card auto-denies on TTL (the #2411 timeout path)
+ * with the operator absent, the gated work is silently dropped and NOTHING
+ * re-offers it when the operator returns. For cron-fired work (marko's brevo
+ * nurture-drip batches) the batch just doesn't go out and the operator finds
+ * out a day later.
+ *
+ * Fix: at TTL auto-deny the gateway appends the missed request to this store
+ * (persisted so a gateway restart — which happens ~14× on a fleet-roll day —
+ * doesn't lose the digest). On the FIRST operator-activity event afterwards,
+ * the gateway posts ONE compact digest card ("While you were away these
+ * approvals timed out: …  [Ask agent to retry] [Dismiss]") to the origin
+ * surface, then promotes the pending entries into a delivered-digest record
+ * (the posted card is now the durable record in chat). Retry synthesizes an
+ * inbound asking the agent to re-attempt the actions; Dismiss clears the
+ * record and edits the card closed.
+ *
+ * File format: a single JSON object `{ pending, delivered }`, written
+ * synchronously to avoid interleaving on concurrent auto-denies, mode 0o600.
+ * Mirrors the `permission-card-store.ts` pattern. Both lists are hard-capped
+ * so the file stays tiny under a runaway loop.
+ */
+
+import { readFileSync, writeFileSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+
+export interface MissedApproval {
+  /** The permission request_id that timed out (dedup key). */
+  requestId: string
+  /** Raw claude tool name, e.g. `mcp__brevo__post`. */
+  toolName: string
+  /** Natural-language action (from `naturalAction()`), e.g. "post to Brevo". */
+  action: string
+  /** Origin surface the card was posted to. */
+  chatId: string
+  threadId?: number | null
+  /** When the TTL auto-deny fired (epoch ms). */
+  timedOutAt: number
+}
+
+export interface DeliveredDigest {
+  /** Short id embedded in the card's callback_data (retry/dismiss routing). */
+  digestId: string
+  /** Origin surface the digest card was posted to. */
+  chatId: string
+  threadId?: number | null
+  /** The missed entries this digest covers (for the Retry synthesis). */
+  entries: MissedApproval[]
+  deliveredAt: number
+}
+
+interface FileShape {
+  pending: MissedApproval[]
+  delivered: DeliveredDigest[]
+}
+
+export interface MissedApprovalsStore {
+  /** Record a newly-missed approval. Idempotent on requestId. */
+  add(entry: MissedApproval): void
+  /** Undelivered misses, oldest first. */
+  listPending(): MissedApproval[]
+  pendingCount(): number
+  /**
+   * Move a set of pending entries into a delivered-digest record. The entries
+   * carried on `digest` are removed from `pending` (matched by requestId).
+   */
+  promoteToDigest(digest: DeliveredDigest): void
+  /** Look up a delivered digest by its id (for a retry/dismiss tap). */
+  getDigest(digestId: string): DeliveredDigest | undefined
+  /** Drop a delivered digest (retry consumed it, or dismiss cleared it). */
+  removeDigest(digestId: string): void
+  /** Delete the backing file entirely. */
+  clear(): void
+}
+
+/** Bound the on-disk file even under a runaway auto-deny loop. */
+export const MAX_PENDING = 50
+export const MAX_DELIVERED = 20
+
+export function createMissedApprovalsStore(stateDir: string): MissedApprovalsStore {
+  const filePath = join(stateDir, 'missed-approvals.json')
+
+  function read(): FileShape {
+    try {
+      const raw = readFileSync(filePath, 'utf-8')
+      const parsed = JSON.parse(raw) as Partial<FileShape>
+      return {
+        pending: Array.isArray(parsed?.pending) ? parsed.pending : [],
+        delivered: Array.isArray(parsed?.delivered) ? parsed.delivered : [],
+      }
+    } catch {
+      return { pending: [], delivered: [] }
+    }
+  }
+
+  function write(f: FileShape): void {
+    try {
+      writeFileSync(filePath, JSON.stringify(f), { encoding: 'utf-8', mode: 0o600 })
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: missed-approvals-store write failed: ${(err as Error).message}\n`,
+      )
+    }
+  }
+
+  return {
+    add(entry) {
+      const f = read()
+      const idx = f.pending.findIndex(e => e.requestId === entry.requestId)
+      if (idx >= 0) {
+        f.pending[idx] = entry
+      } else {
+        f.pending.push(entry)
+      }
+      // Keep only the most-recent MAX_PENDING (drop oldest by insertion order).
+      if (f.pending.length > MAX_PENDING) {
+        f.pending = f.pending.slice(f.pending.length - MAX_PENDING)
+      }
+      write(f)
+    },
+
+    listPending() {
+      return read().pending
+    },
+
+    pendingCount() {
+      return read().pending.length
+    },
+
+    promoteToDigest(digest) {
+      const f = read()
+      const ids = new Set(digest.entries.map(e => e.requestId))
+      f.pending = f.pending.filter(e => !ids.has(e.requestId))
+      // Replace any existing record with the same id, then append.
+      f.delivered = f.delivered.filter(d => d.digestId !== digest.digestId)
+      f.delivered.push(digest)
+      if (f.delivered.length > MAX_DELIVERED) {
+        f.delivered = f.delivered.slice(f.delivered.length - MAX_DELIVERED)
+      }
+      write(f)
+    },
+
+    getDigest(digestId) {
+      return read().delivered.find(d => d.digestId === digestId)
+    },
+
+    removeDigest(digestId) {
+      const f = read()
+      const filtered = f.delivered.filter(d => d.digestId !== digestId)
+      if (filtered.length !== f.delivered.length) {
+        f.delivered = filtered
+        write(f)
+      }
+    },
+
+    clear() {
+      try {
+        unlinkSync(filePath)
+      } catch {
+        // File may not exist — fine.
+      }
+    },
+  }
+}

--- a/telegram-plugin/tests/missed-approvals-card.test.ts
+++ b/telegram-plugin/tests/missed-approvals-card.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for telegram-plugin/gateway/missed-approvals-card.ts (#2862).
+ *
+ * Pure builders — no gateway. Contract under test:
+ *   - parseMissedApprovalCallback round-trips the keyboard's callback_data;
+ *   - renderMissedApprovalsDigest lists entries, escapes HTML, and collapses
+ *     past the cap to "…and N more";
+ *   - buildMissedApprovalRetryInbound pins source='missed_approval_retry',
+ *     frames the retry as a QUESTION (never a verdict), and carries the
+ *     actions in the text.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  MISSED_APPROVAL_CALLBACK_PREFIX,
+  MISSED_APPROVAL_RENDER_CAP,
+  renderMissedApprovalsDigest,
+  missedApprovalsKeyboard,
+  parseMissedApprovalCallback,
+  buildMissedApprovalRetryInbound,
+} from '../gateway/missed-approvals-card.js'
+import type { MissedApproval } from '../gateway/missed-approvals-store.js'
+
+function miss(over: Partial<MissedApproval> = {}): MissedApproval {
+  return {
+    requestId: 'r',
+    toolName: 'mcp__brevo__post',
+    action: 'post to Brevo',
+    chatId: '-100123',
+    threadId: 7,
+    timedOutAt: Date.UTC(2026, 6, 4, 23, 2, 0),
+    ...over,
+  }
+}
+
+describe('missed-approvals callback shape', () => {
+  it('keyboard emits retry + dismiss callbacks that parse back', () => {
+    const kb = missedApprovalsKeyboard('abc123')
+    const [[retry, dismiss]] = kb.inline_keyboard
+    expect(retry.callback_data).toBe(`${MISSED_APPROVAL_CALLBACK_PREFIX}retry:abc123`)
+    expect(dismiss.callback_data).toBe(`${MISSED_APPROVAL_CALLBACK_PREFIX}dismiss:abc123`)
+    expect(parseMissedApprovalCallback(retry.callback_data)).toEqual({ action: 'retry', digestId: 'abc123' })
+    expect(parseMissedApprovalCallback(dismiss.callback_data)).toEqual({ action: 'dismiss', digestId: 'abc123' })
+  })
+
+  it('callback_data stays within Telegram 64-byte limit', () => {
+    const kb = missedApprovalsKeyboard('deadbeef')
+    for (const row of kb.inline_keyboard) {
+      for (const btn of row) {
+        expect(Buffer.byteLength(btn.callback_data, 'utf8')).toBeLessThanOrEqual(64)
+      }
+    }
+  })
+
+  it('rejects foreign / malformed callbacks', () => {
+    expect(parseMissedApprovalCallback('skprop:approve:x')).toBeNull()
+    expect(parseMissedApprovalCallback('missre:bogus:x')).toBeNull()
+    expect(parseMissedApprovalCallback('missre:retry:')).toBeNull()
+    expect(parseMissedApprovalCallback('missre:retry')).toBeNull()
+  })
+})
+
+describe('renderMissedApprovalsDigest', () => {
+  it('lists each entry with its natural action', () => {
+    const text = renderMissedApprovalsDigest([
+      miss({ action: 'post to Brevo' }),
+      miss({ action: 'send an email' }),
+    ])
+    expect(text).toContain('Missed approvals while you were away')
+    expect(text).toContain('post to Brevo')
+    expect(text).toContain('send an email')
+    expect(text).not.toContain('…and')
+  })
+
+  it('collapses past the cap to "…and N more"', () => {
+    const entries = Array.from({ length: MISSED_APPROVAL_RENDER_CAP + 3 }, (_, i) =>
+      miss({ requestId: `r${i}`, action: `action ${i}` }),
+    )
+    const text = renderMissedApprovalsDigest(entries)
+    expect(text).toContain('action 0')
+    expect(text).toContain(`action ${MISSED_APPROVAL_RENDER_CAP - 1}`)
+    // Entry at index == cap must NOT be listed individually.
+    expect(text).not.toContain(`action ${MISSED_APPROVAL_RENDER_CAP}`)
+    expect(text).toContain('…and 3 more')
+  })
+
+  it('escapes HTML in the action text', () => {
+    const text = renderMissedApprovalsDigest([miss({ action: 'run: rm <a> & <b>' })])
+    expect(text).toContain('rm &lt;a&gt; &amp; &lt;b&gt;')
+    expect(text).not.toContain('<a>')
+  })
+
+  it('names the agent when provided', () => {
+    const text = renderMissedApprovalsDigest([miss()], { agentName: 'marko' })
+    expect(text).toContain('marko')
+  })
+})
+
+describe('buildMissedApprovalRetryInbound', () => {
+  it('pins source + origin surface + operator id (single action)', () => {
+    const inbound = buildMissedApprovalRetryInbound({
+      ctx: { agent: 'marko', chat_id: '-100123', threadId: 7 },
+      actions: ['post to Brevo'],
+      operatorId: '8201250670',
+      nowMs: 123,
+    })
+    expect(inbound.type).toBe('inbound')
+    expect(inbound.chatId).toBe('-100123')
+    expect(inbound.threadId).toBe(7)
+    expect(inbound.meta.source).toBe('missed_approval_retry')
+    expect(inbound.meta.agent).toBe('marko')
+    expect(inbound.meta.operator_id).toBe('8201250670')
+    expect(inbound.meta.action_count).toBe('1')
+    expect(inbound.meta.message_thread_id).toBe('7')
+    expect(inbound.text).toContain('post to Brevo')
+  })
+
+  it('frames the retry as a QUESTION, never a verdict (no-self-escalation)', () => {
+    const inbound = buildMissedApprovalRetryInbound({
+      ctx: { agent: 'marko', chat_id: '-100123' },
+      actions: ['post to Brevo'],
+      operatorId: 'x',
+    })
+    // It asks the agent to re-attempt; it must NOT approve/deny on the
+    // operator's behalf.
+    expect(inbound.text.toLowerCase()).toContain('re-attempt')
+    expect(inbound.text.toLowerCase()).toContain('approve again')
+    expect(inbound.text.toLowerCase()).not.toMatch(/\b(approved|allow(ed)? this|permission granted)\b/)
+    // No thread → no thread fields.
+    expect(inbound.threadId).toBeUndefined()
+    expect(inbound.meta.message_thread_id).toBeUndefined()
+  })
+
+  it('lists every action for a multi-miss retry', () => {
+    const inbound = buildMissedApprovalRetryInbound({
+      ctx: { agent: 'marko', chat_id: '-100123' },
+      actions: ['post to Brevo', 'send an email', 'update the CRM'],
+      operatorId: 'x',
+    })
+    expect(inbound.meta.action_count).toBe('3')
+    expect(inbound.text).toContain('post to Brevo')
+    expect(inbound.text).toContain('send an email')
+    expect(inbound.text).toContain('update the CRM')
+  })
+})

--- a/telegram-plugin/tests/missed-approvals-store.test.ts
+++ b/telegram-plugin/tests/missed-approvals-store.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for telegram-plugin/gateway/missed-approvals-store.ts (#2862).
+ *
+ * Persisted list of approvals that TTL-expired while the operator was away.
+ * Contract under test:
+ *   - append at auto-deny; dedup on requestId; survive reload (new instance);
+ *   - cap pending (drop oldest) so the file stays bounded;
+ *   - promoteToDigest moves pending → delivered (so a second read sees empty
+ *     pending → "posts once");
+ *   - getDigest / removeDigest for the retry/dismiss taps.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  createMissedApprovalsStore,
+  MAX_PENDING,
+  type MissedApproval,
+} from '../gateway/missed-approvals-store.js'
+
+function makeTmpDir() {
+  return mkdtempSync(join(tmpdir(), 'missed-approvals-store-test-'))
+}
+
+function entry(over: Partial<MissedApproval> = {}): MissedApproval {
+  return {
+    requestId: 'fztws',
+    toolName: 'mcp__brevo__post',
+    action: 'post to Brevo',
+    chatId: '-100123',
+    threadId: 7,
+    timedOutAt: 1_700_000_000_000,
+    ...over,
+  }
+}
+
+describe('createMissedApprovalsStore', () => {
+  let dir: string
+  beforeEach(() => { dir = makeTmpDir() })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('starts empty', () => {
+    const store = createMissedApprovalsStore(dir)
+    expect(store.listPending()).toEqual([])
+    expect(store.pendingCount()).toBe(0)
+  })
+
+  it('append + listPending returns the entry', () => {
+    const store = createMissedApprovalsStore(dir)
+    store.add(entry())
+    expect(store.listPending()).toHaveLength(1)
+    expect(store.listPending()[0].action).toBe('post to Brevo')
+  })
+
+  it('dedups on requestId (replace, not duplicate)', () => {
+    const store = createMissedApprovalsStore(dir)
+    store.add(entry({ requestId: 'aaa', action: 'first' }))
+    store.add(entry({ requestId: 'aaa', action: 'second' }))
+    expect(store.listPending()).toHaveLength(1)
+    expect(store.listPending()[0].action).toBe('second')
+  })
+
+  it('survives reload (a fresh instance sees persisted entries)', () => {
+    const s1 = createMissedApprovalsStore(dir)
+    s1.add(entry({ requestId: 'a' }))
+    s1.add(entry({ requestId: 'b' }))
+    const s2 = createMissedApprovalsStore(dir)
+    expect(s2.pendingCount()).toBe(2)
+  })
+
+  it('caps pending at MAX_PENDING, dropping the oldest', () => {
+    const store = createMissedApprovalsStore(dir)
+    for (let i = 0; i < MAX_PENDING + 5; i++) {
+      store.add(entry({ requestId: `r${i}`, timedOutAt: 1_700_000_000_000 + i }))
+    }
+    const pending = store.listPending()
+    expect(pending).toHaveLength(MAX_PENDING)
+    // Oldest (r0..r4) dropped; newest (r<MAX+4>) retained.
+    expect(pending.some(e => e.requestId === 'r0')).toBe(false)
+    expect(pending.some(e => e.requestId === `r${MAX_PENDING + 4}`)).toBe(true)
+  })
+
+  it('promoteToDigest moves entries out of pending into a delivered record', () => {
+    const store = createMissedApprovalsStore(dir)
+    store.add(entry({ requestId: 'a', action: 'post to Brevo' }))
+    store.add(entry({ requestId: 'b', action: 'send email' }))
+    const entries = store.listPending()
+    store.promoteToDigest({
+      digestId: 'deadbeef',
+      chatId: '-100123',
+      threadId: 7,
+      entries,
+      deliveredAt: Date.now(),
+    })
+    // Pending is now empty — a second operator-activity event posts nothing.
+    expect(store.listPending()).toEqual([])
+    const digest = store.getDigest('deadbeef')
+    expect(digest?.entries).toHaveLength(2)
+    expect(digest?.entries.map(e => e.action)).toEqual(['post to Brevo', 'send email'])
+  })
+
+  it('removeDigest drops the delivered record (dismiss / retry consumed it)', () => {
+    const store = createMissedApprovalsStore(dir)
+    store.add(entry({ requestId: 'a' }))
+    store.promoteToDigest({
+      digestId: 'cafef00d',
+      chatId: '-100123',
+      threadId: 7,
+      entries: store.listPending(),
+      deliveredAt: Date.now(),
+    })
+    expect(store.getDigest('cafef00d')).toBeDefined()
+    store.removeDigest('cafef00d')
+    expect(store.getDigest('cafef00d')).toBeUndefined()
+  })
+
+  it('promote + remove survive reload', () => {
+    const s1 = createMissedApprovalsStore(dir)
+    s1.add(entry({ requestId: 'a' }))
+    s1.promoteToDigest({
+      digestId: 'd1',
+      chatId: '-100123',
+      threadId: null,
+      entries: s1.listPending(),
+      deliveredAt: Date.now(),
+    })
+    const s2 = createMissedApprovalsStore(dir)
+    expect(s2.getDigest('d1')?.entries).toHaveLength(1)
+    expect(s2.listPending()).toEqual([])
+  })
+
+  it('clear() wipes the backing file', () => {
+    const store = createMissedApprovalsStore(dir)
+    store.add(entry())
+    store.clear()
+    expect(store.listPending()).toEqual([])
+  })
+
+  it('tolerates a corrupt backing file (returns empty)', () => {
+    const store = createMissedApprovalsStore(dir)
+    // Write garbage directly, then ensure reads don't throw.
+    writeFileSync(join(dir, 'missed-approvals.json'), 'not json')
+    expect(store.listPending()).toEqual([])
+  })
+})

--- a/telegram-plugin/tests/missed-approvals-wiring.test.ts
+++ b/telegram-plugin/tests/missed-approvals-wiring.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Source-text pins for the missed-approvals re-offer wiring (#2862).
+ *
+ * gateway.ts has top-level side effects and isn't unit-importable; the store
+ * and card logic are unit-tested in missed-approvals-store.test.ts /
+ * missed-approvals-card.test.ts. These pins lock the gateway wiring so it can't
+ * silently regress:
+ *   - the store is constructed + kill switch defined;
+ *   - the TTL auto-deny appends the miss (anchored to the card origin);
+ *   - all three operator-activity paths trigger the digest;
+ *   - the digest posts ONE card per surface then promotes (clears pending);
+ *   - the callback dispatcher routes `missre:`;
+ *   - retry rides deliverResumeSyntheticOrBuffer; dismiss removes + edits.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const read = (p: string) => readFileSync(resolve(__dirname, '..', p), 'utf8')
+const GATEWAY = read('gateway/gateway.ts')
+
+function slice(src: string, header: string, span = 2000): string {
+  const start = src.indexOf(header)
+  expect(start, `expected to find ${header}`).toBeGreaterThan(-1)
+  return src.slice(start, start + span)
+}
+
+describe('missed-approvals re-offer wiring (#2862)', () => {
+  it('constructs the persisted store and defines the kill switch', () => {
+    expect(GATEWAY).toContain('createMissedApprovalsStore(STATE_DIR)')
+    expect(GATEWAY).toContain('SWITCHROOM_MISSED_APPROVAL_REOFFER')
+    expect(GATEWAY).toMatch(/MISSED_APPROVAL_REOFFER_ENABLED\s*=\s*\n?\s*process\.env\.SWITCHROOM_MISSED_APPROVAL_REOFFER !== '0'/)
+  })
+
+  it('appends the miss at TTL auto-deny, anchored to the card origin, gated by the kill switch', () => {
+    // Within the pending-permission TTL sweep block.
+    const sweep = slice(GATEWAY, 'for (const [k, v] of pendingPermissions)', 3600)
+    expect(sweep).toContain('if (MISSED_APPROVAL_REOFFER_ENABLED) {')
+    expect(sweep).toContain('missedApprovalsStore.add({')
+    expect(sweep).toContain('const origin = v.cards[0]')
+    expect(sweep).toContain('action: naturalAction(v.tool_name, v.input_preview)')
+  })
+
+  it('all three operator-activity paths trigger the digest', () => {
+    const calls = GATEWAY.match(/maybePostMissedApprovalDigest\(/g) ?? []
+    // 1 definition + 3 activity callsites.
+    expect(calls.length).toBeGreaterThanOrEqual(4)
+    expect(GATEWAY).toContain("maybePostMissedApprovalDigest('operator inbound')")
+    expect(GATEWAY).toContain("maybePostMissedApprovalDigest('operator answered via /approve|/deny')")
+    expect(GATEWAY).toContain("maybePostMissedApprovalDigest('operator answered a permission card')")
+  })
+
+  it('the digest posts one card per surface, then promotes (clears pending → posts once)', () => {
+    const fn = slice(GATEWAY, 'function maybePostMissedApprovalDigest(', 2400)
+    expect(fn).toContain('if (!MISSED_APPROVAL_REOFFER_ENABLED) return')
+    expect(fn).toContain('missedApprovalsStore.listPending()')
+    // Groups by origin surface.
+    expect(fn).toMatch(/const groups = new Map/)
+    expect(fn).toContain('missedApprovalsKeyboard(digestId)')
+    expect(fn).toContain('missedApprovalsStore.promoteToDigest({')
+  })
+
+  it('routes the missre: callback family', () => {
+    expect(GATEWAY).toContain("data.startsWith('missre:')")
+    expect(GATEWAY).toContain('handleMissedApprovalCallback(ctx, data)')
+  })
+
+  it('retry injects a synthetic inbound via the shared resume-or-buffer path', () => {
+    const fn = slice(GATEWAY, 'async function handleMissedApprovalCallback(', 2600)
+    // authorization gate first.
+    expect(fn).toContain('access.allowFrom.includes(senderId)')
+    // retry synthesizes + delivers via the cron/synthetic inbound primitive.
+    expect(fn).toContain('buildMissedApprovalRetryInbound({')
+    expect(fn).toContain('deliverResumeSyntheticOrBuffer(agent, synthetic)')
+    // dismiss clears the record + edits the card closed.
+    expect(fn).toContain('missedApprovalsStore.removeDigest(parsed.digestId)')
+    expect(fn).toContain('Dismissed')
+  })
+
+  it('never synthesizes a verdict on retry (no-self-escalation)', () => {
+    const fn = slice(GATEWAY, 'async function handleMissedApprovalCallback(', 2600)
+    // The handler must not dispatch a permission verdict — retry is a question.
+    expect(fn).not.toContain('dispatchPermissionVerdict')
+    expect(fn).not.toContain("behavior: 'allow'")
+  })
+})


### PR DESCRIPTION
## Summary

When an approval card TTL-expires with the operator away, the gateway auto-denies (the #2411 timeout-not-denial path) and records a no-repeat suppression signature — but **nothing re-offered the approval when the operator returned**. Cron-fired gated work was silently dropped.

This adds a persisted **missed-approvals re-offer digest**:

1. **At TTL auto-deny** — append the miss (tool, natural-language action via `naturalAction()`, origin chat/thread, timestamp) to a persisted list in `STATE_DIR` (`missed-approvals-store.ts`, mirroring `permission-card-store.ts`: small JSON, sync writes, `0o600`). A gateway restart no longer loses the digest.
2. **On the first operator-activity event** after ≥1 miss accumulates (the same three paths that clear no-repeat suppression: inbound, `/approve|/deny`, card verdict) — post **one** compact digest card per origin surface, then promote the pending entries into a delivered record so a second activity event can't double-post. Render caps at 10 with a "…and N more" line.
3. **Retry** synthesizes an inbound asking the agent to re-attempt the actions — the same `inject_inbound` / synthesized-inbound path cron uses (`deliverResumeSyntheticOrBuffer`). Claude-native; naturally re-raises a fresh approval card. **Dismiss** clears the record and edits the card closed.

## Why

marko's brevo nurture-drip batches died this way two days running (`permission TTL expired — auto-deny … tool=mcp__brevo__post`, 2026-07-03 & 07-04). For cron-fired work this was the dominant remaining loss mode — the operator found out a day later, if at all.

## Invariants

- **no-self-escalation** — Retry is a *question* to the agent, never a re-execution and never a synthesized verdict. Pinned by a wiring test that asserts the handler never calls `dispatchPermissionVerdict` / synthesizes `behavior: 'allow'`.
- **claude-native** — no new model callsites, no `claude -p`, no SDK. Retry rides the existing synthesized-inbound path.
- **Kill switch** `SWITCHROOM_MISSED_APPROVAL_REOFFER=0` disables both the auto-deny append and the digest post.
- Digest callback is `allowFrom`-gated like every other mutating tap.

## Test plan

- [x] `tsc --noEmit` clean (root).
- [x] Store unit: append / dedup / reload / cap-overflow / promote / remove / corrupt-file tolerance.
- [x] Card unit: render (multi-entry + "N more" overflow + HTML escaping), keyboard callback round-trip + 64-byte limit, retry-inbound builder (source meta + question framing, single & multi action).
- [x] Gateway wiring source-text pins: store init + kill switch, append at TTL sweep, three activity triggers, `missre:` route, retry via synthetic inbound, no verdict synthesized.
- [x] `permission-no-repeat-wiring.test.ts` + `permission-timeout.test.ts` + `permission-card-store.test.ts` still green.
- [x] `check-bot-api-wrapping.sh` clean (digest send carries an inline `allow-raw-bot-api` marker; routed through `swallowingApiCall`).
- [ ] UAT: low `approval_timeout_minutes` on test-harness, trigger a gated action, stay silent past expiry, send any message → assert digest card arrives, tap Retry → assert a fresh approval card is raised. DM + `-channel` twin. (pre-fleet-rollout)

Note: `scripts/check-plugin-references.mjs` reports pre-existing `sendRichMessage`/`richMessage` type errors on this host (identical on pristine `origin/main`; a donor-`node_modules` type-augmentation gap unrelated to this change); no error references the new code. The CI `lint` gate (`tsc --noEmit`) is clean.

## Risk

Low. Additive + kill-switched. Isolated to the TTL-sweep region and the operator-activity hooks. New persisted file is bounded (cap 50 pending / 20 delivered).

Builds on #2411; part of umbrella #2859 (**PR B**). PR A (#2861) lands first but this is textually independent (expected merge conflict near the TTL sweep / `onPermissionRequest`, reconciled at merge time).