### PR TITLE
fix(gateway): re-arm approval cards across restarts + bridge request ledger (#2861)

### DIFF
--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -30,6 +30,7 @@ import { createIpcClient, type IpcClientHandle } from './ipc-client.js'
 import { buildEffectiveToolSchemas, LINEAR_ENV } from './tool-filter.js'
 import type { InboundMessage, PermissionEvent, StatusEvent } from '../gateway/ipc-protocol.js'
 import { matchesAllowRule } from '../permission-rule.js'
+import { createOutstandingPermissionLedger } from './permission-ledger.js'
 
 installPluginLogger()
 
@@ -582,6 +583,40 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
 // added by either is honoured by all.
 const sessionAllowRules = new Set<string>()
 
+// #2861: outstanding permission-request ledger. Every permission_request from
+// claude is recorded here and re-sent on each IPC (re)connect, so a request
+// that arrives while the gateway is down (or that the gateway lost across a
+// restart) is redelivered instead of dropped. Deleted in onPermission when a
+// verdict is delivered. Kill switch: SWITCHROOM_PERMISSION_REARM=0 reverts to
+// the legacy drop-when-disconnected behavior.
+const outstandingPermissions = createOutstandingPermissionLedger()
+const permissionRearmEnabled = process.env.SWITCHROOM_PERMISSION_REARM !== '0'
+
+/**
+ * Re-send every outstanding permission_request to the gateway. Called on each
+ * IPC (re)connect via the ipc-client onConnect hook. The gateway dedupes /
+ * re-arms them idempotently (gateway/permission-rearm.ts), so re-sending on
+ * every reconnect is safe. Never answers a card — re-transmits the question.
+ */
+function flushOutstandingPermissionRequests(): void {
+  if (!permissionRearmEnabled) return
+  if (!ipc || !ipc.isConnected()) return
+  const pending = outstandingPermissions.all()
+  if (pending.length === 0) return
+  process.stderr.write(
+    `telegram bridge: re-sending ${pending.length} outstanding permission request(s) on gateway (re)connect\n`,
+  )
+  for (const p of pending) {
+    ipc.sendPermissionRequest({
+      type: 'permission_request',
+      requestId: p.request_id,
+      toolName: p.tool_name,
+      description: p.description,
+      inputPreview: p.input_preview,
+    })
+  }
+}
+
 mcp.setNotificationHandler(
   z.object({
     method: z.literal('notifications/claude/channel/permission_request'),
@@ -615,8 +650,29 @@ mcp.setNotificationHandler(
         return
       }
     }
+    // #2861: record the request in the outstanding ledger BEFORE the connect
+    // check so it survives a disconnected gateway and is re-sent on reconnect.
+    // It's deleted in onPermission when the verdict is delivered.
+    if (permissionRearmEnabled) {
+      outstandingPermissions.add({
+        request_id: params.request_id,
+        tool_name: params.tool_name,
+        description: params.description,
+        input_preview: params.input_preview,
+      })
+    }
     if (!ipc || !ipc.isConnected()) {
-      process.stderr.write('telegram bridge: permission_request received but not connected to gateway\n')
+      // BUFFER, don't drop (#2861 R2). The request is in the ledger; the
+      // onConnect flush re-sends it once the gateway is reachable. Falls back
+      // to the legacy drop only when re-arm is killed.
+      if (permissionRearmEnabled) {
+        process.stderr.write(
+          `telegram bridge: permission_request buffered (gateway offline), will re-send on reconnect ` +
+          `request_id=${params.request_id}\n`,
+        )
+      } else {
+        process.stderr.write('telegram bridge: permission_request received but not connected to gateway\n')
+      }
       return
     }
     ipc.sendPermissionRequest({
@@ -658,6 +714,9 @@ function onPermission(msg: PermissionEvent): void {
   if (msg.rule) {
     sessionAllowRules.add(msg.rule)
   }
+  // #2861: verdict delivered → drop the request from the outstanding ledger so
+  // a later reconnect doesn't re-send an already-resolved approval.
+  outstandingPermissions.delete(msg.requestId)
   mcp.notification({
     method: 'notifications/claude/channel/permission',
     params: {
@@ -836,6 +895,8 @@ async function main(): Promise<void> {
     onInbound,
     onPermission,
     onStatus,
+    // #2861: re-send outstanding permission requests on every (re)connect.
+    onConnect: flushOutstandingPermissionRequests,
     log: (msg) => process.stderr.write(`telegram bridge: ipc: ${msg}\n`),
     // #2307 Tier-1: the cron-session bridge shares the agent's STATE_DIR
     // (access.json / history / gateway.sock) but writes its liveness file to a

--- a/telegram-plugin/bridge/ipc-client.ts
+++ b/telegram-plugin/bridge/ipc-client.ts
@@ -48,6 +48,14 @@ export interface IpcClientOptions {
   onInbound: (msg: InboundMessage) => void;
   onPermission: (msg: PermissionEvent) => void;
   onStatus: (msg: StatusEvent) => void;
+  /**
+   * Called every time the socket (re)connects and has registered — i.e. on
+   * the initial connect AND on each background reconnect. The bridge uses
+   * this to flush its outstanding permission-request ledger so approvals
+   * that arrived while the gateway was down are re-sent (#2861). Best-effort:
+   * a throw here is logged, never propagated into the socket open path.
+   */
+  onConnect?: () => void;
   log?: (msg: string) => void;
   reconnectDelayMs?: number;
   maxReconnectDelayMs?: number;
@@ -93,6 +101,7 @@ export function createIpcClient(options: IpcClientOptions): Promise<IpcClientHan
     onInbound,
     onPermission,
     onStatus,
+    onConnect,
     log = () => {},
     reconnectDelayMs = 2000,
     maxReconnectDelayMs = 30000,
@@ -237,6 +246,16 @@ export function createIpcClient(options: IpcClientOptions): Promise<IpcClientHan
             sendRegister();
             startHeartbeat();
             log(`connected to ${socketPath}`);
+            // Fire the (re)connect hook AFTER register + heartbeat so the
+            // bridge's ledger flush writes onto a live, registered socket.
+            // Best-effort: never let a callback throw abort the open path.
+            if (onConnect) {
+              try {
+                onConnect();
+              } catch (err) {
+                log(`onConnect hook threw: ${err}`);
+              }
+            }
             resolve();
           },
           data(sock, data) {

--- a/telegram-plugin/bridge/permission-ledger.ts
+++ b/telegram-plugin/bridge/permission-ledger.ts
@@ -1,0 +1,61 @@
+/**
+ * Bridge-side outstanding permission-request ledger (#2861 / umbrella #2859).
+ *
+ * Problem it closes (R2): the bridge's `permission_request` handler used to
+ * DROP the request when the gateway IPC was down
+ * (`if (!ipc || !ipc.isConnected()) { log; return }`). claude stays suspended
+ * inside the MCP permission call, no card is ever posted, the turn wedges
+ * forever. There was no record of the ask to re-send once the gateway came
+ * back.
+ *
+ * Fix: every `permission_request` notification from claude is recorded here,
+ * keyed by request_id. When the IPC (re)connects, the bridge re-sends every
+ * outstanding request (the gateway dedupes / re-arms them idempotently — see
+ * `gateway/permission-rearm.ts`). An entry is deleted the moment a verdict is
+ * delivered back to claude (`onPermission`), so a resolved request is never
+ * re-sent.
+ *
+ * This never answers a card — it only re-transmits the QUESTION
+ * (no-self-escalation invariant). Pure in-memory bookkeeping: no model
+ * callsite, no I/O.
+ */
+
+/** The claude-side `permission_request` params the bridge forwards. */
+export interface OutstandingPermissionParams {
+  request_id: string
+  tool_name: string
+  description: string
+  input_preview: string
+}
+
+export interface OutstandingPermissionLedger {
+  /** Record a request. Idempotent on request_id (latest params win). */
+  add(params: OutstandingPermissionParams): void
+  /** Remove a request once its verdict has been delivered. */
+  delete(requestId: string): void
+  has(requestId: string): boolean
+  /** Snapshot of all outstanding requests (insertion order). */
+  all(): OutstandingPermissionParams[]
+  readonly size: number
+}
+
+export function createOutstandingPermissionLedger(): OutstandingPermissionLedger {
+  const map = new Map<string, OutstandingPermissionParams>()
+  return {
+    add(params) {
+      map.set(params.request_id, params)
+    },
+    delete(requestId) {
+      map.delete(requestId)
+    },
+    has(requestId) {
+      return map.has(requestId)
+    },
+    all() {
+      return [...map.values()]
+    },
+    get size() {
+      return map.size
+    },
+  }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4566,11 +4566,6 @@ const STATUS_QUERY_RE = /^\s*status\??\s*$/i
 // ─── Permission handling ──────────────────────────────────────────────────
 const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
 const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; startedAt: number; card_text: string; cards: { chatId: string; messageId: number; threadId?: number | null }[] }>()
-// #2861: request_ids re-claimed by a bridge re-send since boot — either
-// deduped (already live) or re-armed from the persisted card store. The
-// grace-period boot-sweep consults this set: a re-claimed id belongs to a
-// live session and MUST NOT be stripped. Populated in onPermissionRequest.
-const rearmReclaimedRequestIds = new Set<string>()
 // PERMISSION_TTL_MS / ttlForTool / the timed-out card builder now live in
 // ./permission-timeout.ts (pure + unit-testable). hostd gated verbs get a
 // 30-min window; everything else keeps the 10-min default.
@@ -7769,7 +7764,6 @@ const ipcServer: IpcServer = createIpcServer({
         persistedCount: persisted.length,
       })
       if (disposition === 'duplicate') {
-        rearmReclaimedRequestIds.add(requestId)
         process.stderr.write(
           `telegram gateway: permission_request duplicate re-send ignored ` +
           `request=${requestId} (already pending)\n`,
@@ -7777,7 +7771,8 @@ const ipcServer: IpcServer = createIpcServer({
         return
       }
       if (disposition === 'rearm') {
-        rearmReclaimedRequestIds.add(requestId)
+        // Re-arm restores the pending entry; the grace-period boot-sweep
+        // preserves anything live in pendingPermissions, so it won't strip it.
         rearmPermissionFromStore(msg, persisted)
         return
       }
@@ -25129,16 +25124,22 @@ void (async () => {
                 // Reload — some entries may have been resolved (tap/TTL) during
                 // the grace window, which removes them from the store.
                 const remaining = permCardStore.loadAll()
-                const toStrip = computeBootSweepStripTargets(remaining, rearmReclaimedRequestIds)
+                // Preserve anything currently LIVE in pendingPermissions: that
+                // covers both re-armed cards (a bridge re-send restored them)
+                // AND fresh cards born during the grace window (a new approval
+                // posted after boot). Only cards with no live pending entry —
+                // a genuinely dead session that never reconnected — are stripped.
+                const liveRequestIds = new Set(pendingPermissions.keys())
+                const toStrip = computeBootSweepStripTargets(remaining, liveRequestIds)
                 if (toStrip.length === 0) {
                   process.stderr.write(
-                    `telegram gateway: boot-sweep: all pending permission cards re-claimed by bridge re-arm — nothing to strip\n`,
+                    `telegram gateway: boot-sweep: all pending permission cards re-armed or still live — nothing to strip\n`,
                   )
                   return
                 }
                 process.stderr.write(
-                  `telegram gateway: boot-sweep: stripping ${toStrip.length} un-re-claimed permission card(s) ` +
-                  `after ${graceMs}ms grace (of ${remaining.length} still persisted)\n`,
+                  `telegram gateway: boot-sweep: stripping ${toStrip.length} dead-session permission card(s) ` +
+                  `after ${graceMs}ms grace (of ${remaining.length} still persisted, ${liveRequestIds.size} live)\n`,
                 )
                 for (const card of toStrip) await stripStalePermissionCard(card)
                 // Remove ONLY the stripped request_ids — re-armed entries stay

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -116,7 +116,14 @@ import {
   type PermissionCardRef,
 } from './permission-timeout.js'
 import { renderVaultRequestAccessCard } from './vault-request-access-card.js'
-import { createPermissionCardStore } from './permission-card-store.js'
+import { createPermissionCardStore, type PersistedPermCard } from './permission-card-store.js'
+import {
+  isPermissionRearmEnabled,
+  permissionRearmGraceMs,
+  classifyPermissionRequest,
+  computeBootSweepStripTargets,
+  distinctRequestIds,
+} from './permission-rearm.js'
 import { pickRecoveredPermissionOrigin } from './permission-card-origin.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { appendActivityLabel, clipNarrative, renderActivityFeedWithNested, formatStepSuffix, type SessionActivityHeader } from '../tool-activity-summary.js'
@@ -4559,6 +4566,11 @@ const STATUS_QUERY_RE = /^\s*status\??\s*$/i
 // ─── Permission handling ──────────────────────────────────────────────────
 const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
 const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; startedAt: number; card_text: string; cards: { chatId: string; messageId: number; threadId?: number | null }[] }>()
+// #2861: request_ids re-claimed by a bridge re-send since boot — either
+// deduped (already live) or re-armed from the persisted card store. The
+// grace-period boot-sweep consults this set: a re-claimed id belongs to a
+// live session and MUST NOT be stripped. Populated in onPermissionRequest.
+const rearmReclaimedRequestIds = new Set<string>()
 // PERMISSION_TTL_MS / ttlForTool / the timed-out card builder now live in
 // ./permission-timeout.ts (pure + unit-testable). hostd gated verbs get a
 // 30-min window; everything else keeps the 10-min default.
@@ -7294,6 +7306,81 @@ function dispatchPermissionVerdict(ev: PermissionEvent): void {
   }
 }
 
+/**
+ * #2861 re-arm: a `permission_request` re-sent by the bridge after a gateway
+ * restart, for a request_id that's NO LONGER in `pendingPermissions` but is
+ * still in the persisted card store. Restore the in-memory pending entry with
+ * the ORIGINAL `startedAt` (so the existing TTL clock keeps running from the
+ * original ask — an already-expired re-arm drops straight into the TTL
+ * auto-deny sweep, which correctly unwedges claude) and re-attach the inline
+ * keyboard on the EXISTING message(s) via editMessageText — never a new card.
+ *
+ * NEVER answers the card: only the question is restored (no-self-escalation).
+ */
+function rearmPermissionFromStore(
+  msg: PermissionRequestForward,
+  persisted: PersistedPermCard[],
+): void {
+  const { requestId, toolName, description, inputPreview } = msg
+  // Original clock: take the earliest persisted startedAt (all entries for one
+  // request share it, but be defensive).
+  const startedAt = persisted.reduce(
+    (min, c) => (c.startedAt < min ? c.startedAt : min),
+    persisted[0].startedAt,
+  )
+  const cardText = persisted[0].cardText
+  const cards = persisted.map(c => ({ chatId: c.chatId, messageId: c.messageId }))
+  pendingPermissions.set(requestId, {
+    tool_name: toolName,
+    description,
+    input_preview: inputPreview,
+    startedAt,
+    card_text: cardText,
+    cards,
+  })
+  process.stderr.write(
+    `telegram gateway: re-arming permission card(s) for request=${requestId} ` +
+    `tool=${toolName} (${cards.length} card(s), original startedAt preserved)\n`,
+  )
+  // Re-attach the keyboard on each surviving card message. Message-id-targeted
+  // edit — no thread needed, so THREAD_NOT_FOUND is not in the blast radius.
+  const showAlways = resolveScopedAllowChoices(toolName, inputPreview) != null
+  const keyboard = buildPermissionActionRow(requestId, showAlways)
+  for (const c of cards) {
+    void swallowingApiCall(
+      // allow-raw-bot-api: routed through swallowingApiCall (retry policy); message-id-targeted edit (no thread to lose). Re-attaches the Allow/Deny keyboard on the persisted card after a gateway restart.
+      () => bot.api.editMessageText(c.chatId, c.messageId, richMessage(cardText), { reply_markup: keyboard }),
+      { chat_id: c.chatId, verb: 'permission_request.rearm' },
+    )
+  }
+}
+
+/**
+ * Strip a single stale permission card: drop its keyboard and show the
+ * "gateway restarted" notice. Shared by the boot-sweep (immediate legacy path
+ * and the #2861 grace-period path). Best-effort — a deleted/inaccessible card
+ * is swallowed, never fatal.
+ */
+async function stripStalePermissionCard(card: PersistedPermCard): Promise<void> {
+  const toolLabel = card.toolName ?? 'unknown tool'
+  const notice = `🔒 **${toolLabel}**\n\n⚠️ *Gateway restarted — this request is no longer active. Ask your agent to try again if needed.*`
+  try {
+    // allow-raw-bot-api: targeted by message_id; no thread needed; fire-and-forget boot sweep
+    await bot.api.editMessageText(
+      card.chatId,
+      card.messageId,
+      richMessage(notice),
+      { reply_markup: { inline_keyboard: [] } },
+    )
+  } catch (err) {
+    // Card may already be deleted, edited, or in an inaccessible chat — benign
+    process.stderr.write(
+      `telegram gateway: boot-sweep: stale-card strip failed ` +
+      `${card.chatId}:${card.messageId}: ${(err as Error).message}\n`,
+    )
+  }
+}
+
 const ipcServer: IpcServer = createIpcServer({
   socketPath: SOCKET_PATH,
 
@@ -7663,6 +7750,38 @@ const ipcServer: IpcServer = createIpcServer({
 
   onPermissionRequest(_client: IpcClient, msg: PermissionRequestForward) {
     const { requestId, toolName, description, inputPreview } = msg
+    // #2861 idempotent re-send handling. The bridge re-sends every outstanding
+    // permission_request on each IPC (re)connect, so the same request_id can
+    // arrive more than once. Disposition:
+    //   duplicate → already live in pendingPermissions; ignore (no 2nd card).
+    //   rearm     → gone from memory (gateway restarted) but the persisted card
+    //               store still has it; restore + re-attach keyboard in place.
+    //   fresh     → new ask; fall through to the normal card-posting path.
+    // Either re-claim marks the id so the grace-period boot-sweep won't strip
+    // it. Kill switch SWITCHROOM_PERMISSION_REARM=0 skips this entirely (legacy
+    // behavior: a re-send would post a duplicate card, as before this fix).
+    if (isPermissionRearmEnabled()) {
+      const persisted = pendingPermissions.has(requestId)
+        ? []
+        : permCardStore.loadAll().filter(e => e.requestId === requestId)
+      const disposition = classifyPermissionRequest({
+        hasPending: pendingPermissions.has(requestId),
+        persistedCount: persisted.length,
+      })
+      if (disposition === 'duplicate') {
+        rearmReclaimedRequestIds.add(requestId)
+        process.stderr.write(
+          `telegram gateway: permission_request duplicate re-send ignored ` +
+          `request=${requestId} (already pending)\n`,
+        )
+        return
+      }
+      if (disposition === 'rearm') {
+        rearmReclaimedRequestIds.add(requestId)
+        rearmPermissionFromStore(msg, persisted)
+        return
+      }
+    }
     // "⏱ 30 min" short-circuit: if the operator tapped a live scoped grant
     // covering this exact request, auto-allow without posting a card. CRITICAL:
     // dispatch WITHOUT a `rule` so the bridge does NOT cache it untimed
@@ -24973,39 +25092,62 @@ void (async () => {
         // tracks the live turn from there.
         try { removeTurnActiveMarker(STATE_DIR) } catch { /* best-effort */ }
 
-        // Strip stale permission cards from prior gateway session. Any entry
-        // still in the store was never resolved (gateway died before the
-        // operator tapped or the reaper ran). The operator might have seen
-        // those cards and tapped them — if so, they got STALE_TAP_NOTICE
-        // ("already resolved") which is misleading. Edit the messages to
-        // remove the keyboard and show a clear "restarted" notice instead.
-        void (async () => {
-          const stale = permCardStore.loadAll()
-          if (stale.length === 0) return
-          process.stderr.write(
-            `telegram gateway: boot-sweep: stripping ${stale.length} stale permission card(s) from prior gateway session\n`,
-          )
-          for (const card of stale) {
-            const toolLabel = card.toolName ?? 'unknown tool'
-            const notice = `🔒 **${toolLabel}**\n\n⚠️ *Gateway restarted — this request is no longer active. Ask your agent to try again if needed.*`
-            try {
-              // allow-raw-bot-api: targeted by message_id; no thread needed; fire-and-forget boot sweep
-              await bot.api.editMessageText(
-                card.chatId,
-                card.messageId,
-                richMessage(notice),
-                { reply_markup: { inline_keyboard: [] } },
-              )
-            } catch (err) {
-              // Card may already be deleted, edited, or in an inaccessible chat — benign
-              process.stderr.write(
-                `telegram gateway: boot-sweep: stale-card strip failed ` +
-                `${card.chatId}:${card.messageId}: ${(err as Error).message}\n`,
-              )
-            }
+        // Boot-sweep for permission cards from a prior gateway session. Any
+        // entry still in the store was never resolved (gateway died before the
+        // operator tapped or the reaper ran).
+        //
+        // #2861: DON'T strip immediately. A still-live claude session's bridge
+        // re-sends its outstanding permission_requests on IPC reconnect within
+        // a few seconds — re-arming the persisted card instead of losing the
+        // suspended turn. So we wait a grace window (~90 s) and only strip
+        // entries that were NOT re-claimed by a bridge re-send in the meantime.
+        // A genuinely dead session (container recreate → new bridge, empty
+        // ledger) never re-sends, so those still get the "restarted" notice.
+        //
+        // Kill switch SWITCHROOM_PERMISSION_REARM=0 reverts to the legacy
+        // immediate strip-everything sweep.
+        if (!isPermissionRearmEnabled()) {
+          void (async () => {
+            const stale = permCardStore.loadAll()
+            if (stale.length === 0) return
+            process.stderr.write(
+              `telegram gateway: boot-sweep: stripping ${stale.length} stale permission card(s) from prior gateway session\n`,
+            )
+            for (const card of stale) await stripStalePermissionCard(card)
+            permCardStore.clear()
+          })()
+        } else {
+          const bootStale = permCardStore.loadAll()
+          if (bootStale.length > 0) {
+            const graceMs = permissionRearmGraceMs()
+            process.stderr.write(
+              `telegram gateway: boot-sweep: ${bootStale.length} pending permission card(s) from prior ` +
+              `session; deferring strip ${graceMs}ms to allow bridge re-arm (#2861)\n`,
+            )
+            setTimeout(() => {
+              void (async () => {
+                // Reload — some entries may have been resolved (tap/TTL) during
+                // the grace window, which removes them from the store.
+                const remaining = permCardStore.loadAll()
+                const toStrip = computeBootSweepStripTargets(remaining, rearmReclaimedRequestIds)
+                if (toStrip.length === 0) {
+                  process.stderr.write(
+                    `telegram gateway: boot-sweep: all pending permission cards re-claimed by bridge re-arm — nothing to strip\n`,
+                  )
+                  return
+                }
+                process.stderr.write(
+                  `telegram gateway: boot-sweep: stripping ${toStrip.length} un-re-claimed permission card(s) ` +
+                  `after ${graceMs}ms grace (of ${remaining.length} still persisted)\n`,
+                )
+                for (const card of toStrip) await stripStalePermissionCard(card)
+                // Remove ONLY the stripped request_ids — re-armed entries stay
+                // persisted so a subsequent restart re-arms them again.
+                for (const id of distinctRequestIds(toStrip)) permCardStore.remove(id)
+              })()
+            }, graceMs).unref?.()
           }
-          permCardStore.clear()
-        })()
+        }
 
         // Boot-time pin sweep
         try {

--- a/telegram-plugin/gateway/permission-rearm.ts
+++ b/telegram-plugin/gateway/permission-rearm.ts
@@ -26,11 +26,13 @@
  *       - `fresh` — a brand-new ask; post a card as usual.
  *
  *  3. The boot-sweep becomes a grace-period strip. At boot, instead of
- *     stripping persisted cards immediately, wait ~90 s: a live claude
- *     session's bridge re-sends its outstanding requests within that window
- *     (re-claiming them). Only entries NOT re-claimed by the deadline — a
- *     genuinely dead session (container recreate → new bridge, empty ledger,
- *     never re-sends) — get today's "Gateway restarted" strip.
+ *     stripping persisted cards immediately, wait ~90 s, then strip only the
+ *     cards whose request_id is NOT currently live in `pendingPermissions`.
+ *     A live entry means either a bridge re-send re-armed the card, OR a fresh
+ *     approval was posted during the window — both are legitimately-pending
+ *     asks. Only a genuinely dead session's card (container recreate → new
+ *     bridge, empty ledger, never re-sends → no live entry) gets today's
+ *     "Gateway restarted" strip.
  *
  * NEVER auto-allows anything: re-arm restores only the QUESTION, never a
  * verdict (no-self-escalation invariant). No model callsite is involved —
@@ -85,15 +87,24 @@ export function classifyPermissionRequest(opts: {
 
 /**
  * Which persisted cards should the boot-sweep strip at the grace deadline?
- * Everything that was NOT re-claimed by a bridge re-send in the meantime.
- * A re-claimed request_id belongs to a still-live session whose card has
- * already been re-armed — stripping it would kill a legitimately pending ask.
+ * Everything whose request_id is NOT currently live.
+ *
+ * `liveRequestIds` is the set of request_ids present in `pendingPermissions`
+ * at the deadline — which covers BOTH:
+ *   - re-armed cards (a bridge re-send restored the pending entry), and
+ *   - fresh cards born during the grace window (a new approval posted after
+ *     boot sets a pending entry the normal way).
+ * Both are legitimately-pending asks a claude session is still suspended on;
+ * stripping either would re-wedge the turn. Only a genuinely dead session's
+ * card — persisted but with no live pending entry (the bridge never
+ * reconnected to re-arm it) — is stripped. Keying on liveness rather than a
+ * "was re-claimed" flag is what makes fresh-during-grace cards safe.
  */
 export function computeBootSweepStripTargets(
   stale: readonly PersistedPermCard[],
-  reclaimed: ReadonlySet<string>,
+  liveRequestIds: ReadonlySet<string>,
 ): PersistedPermCard[] {
-  return stale.filter(card => !reclaimed.has(card.requestId))
+  return stale.filter(card => !liveRequestIds.has(card.requestId))
 }
 
 /** Distinct request_ids in a persisted-card list (for per-request store removal). */

--- a/telegram-plugin/gateway/permission-rearm.ts
+++ b/telegram-plugin/gateway/permission-rearm.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure decision helpers for permission-card re-arm across gateway restarts
+ * (#2861 / umbrella #2859).
+ *
+ * gateway.ts has top-level side effects and can't be unit-imported, so the
+ * discriminable logic lives here where it can be tested in isolation. The
+ * gateway wires these into `onPermissionRequest` and the boot-sweep.
+ *
+ * The mechanism, end to end:
+ *
+ *  1. The bridge keeps an outstanding-request ledger and re-sends every
+ *     unresolved `permission_request` to the gateway on each IPC (re)connect
+ *     (see `bridge/permission-ledger.ts`). So the gateway MUST treat repeat
+ *     `permission_request`s for the same request_id as idempotent.
+ *
+ *  2. `classifyPermissionRequest` decides what a `permission_request` is:
+ *       - `duplicate` — already live in `pendingPermissions` → ignore (no
+ *         second card). The bridge re-sends on every reconnect.
+ *       - `rearm` — not in memory, but the persisted card store still has
+ *         entries for it → a gateway restart orphaned it. Restore the
+ *         pending entry with the ORIGINAL `startedAt` (the TTL clock keeps
+ *         running from the original ask; an already-expired re-arm falls
+ *         straight into the existing TTL auto-deny sweep, which correctly
+ *         unwedges claude) and re-attach the keyboard on the EXISTING
+ *         message(s) via editMessageText — never a new card.
+ *       - `fresh` — a brand-new ask; post a card as usual.
+ *
+ *  3. The boot-sweep becomes a grace-period strip. At boot, instead of
+ *     stripping persisted cards immediately, wait ~90 s: a live claude
+ *     session's bridge re-sends its outstanding requests within that window
+ *     (re-claiming them). Only entries NOT re-claimed by the deadline — a
+ *     genuinely dead session (container recreate → new bridge, empty ledger,
+ *     never re-sends) — get today's "Gateway restarted" strip.
+ *
+ * NEVER auto-allows anything: re-arm restores only the QUESTION, never a
+ * verdict (no-self-escalation invariant). No model callsite is involved —
+ * verdicts still travel only over the existing IPC/MCP channel.
+ */
+
+import type { PersistedPermCard } from './permission-card-store.js'
+
+/** Default grace window before the boot-sweep strips an un-re-claimed card. */
+export const PERMISSION_REARM_GRACE_MS = 90_000
+
+/**
+ * Kill switch. `SWITCHROOM_PERMISSION_REARM=0` reverts to the legacy
+ * immediate-strip (gateway) / drop-when-disconnected (bridge) behavior.
+ */
+export function isPermissionRearmEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env.SWITCHROOM_PERMISSION_REARM !== '0'
+}
+
+/**
+ * Resolve the boot-sweep grace window (ms). `SWITCHROOM_PERMISSION_REARM_GRACE_MS`
+ * overrides the default (used by tests to collapse the wait). A non-finite or
+ * negative override falls back to the default.
+ */
+export function permissionRearmGraceMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.SWITCHROOM_PERMISSION_REARM_GRACE_MS
+  if (raw == null || raw === '') return PERMISSION_REARM_GRACE_MS
+  const n = Number(raw)
+  return Number.isFinite(n) && n >= 0 ? n : PERMISSION_REARM_GRACE_MS
+}
+
+export type PermissionRequestDisposition = 'duplicate' | 'rearm' | 'fresh'
+
+/**
+ * Classify an incoming `permission_request` (pure).
+ *
+ * @param hasPending    is the request_id already live in `pendingPermissions`?
+ * @param persistedCount how many persisted card entries exist for this request_id?
+ */
+export function classifyPermissionRequest(opts: {
+  hasPending: boolean
+  persistedCount: number
+}): PermissionRequestDisposition {
+  if (opts.hasPending) return 'duplicate'
+  if (opts.persistedCount > 0) return 'rearm'
+  return 'fresh'
+}
+
+/**
+ * Which persisted cards should the boot-sweep strip at the grace deadline?
+ * Everything that was NOT re-claimed by a bridge re-send in the meantime.
+ * A re-claimed request_id belongs to a still-live session whose card has
+ * already been re-armed — stripping it would kill a legitimately pending ask.
+ */
+export function computeBootSweepStripTargets(
+  stale: readonly PersistedPermCard[],
+  reclaimed: ReadonlySet<string>,
+): PersistedPermCard[] {
+  return stale.filter(card => !reclaimed.has(card.requestId))
+}
+
+/** Distinct request_ids in a persisted-card list (for per-request store removal). */
+export function distinctRequestIds(
+  cards: readonly PersistedPermCard[],
+): string[] {
+  return [...new Set(cards.map(c => c.requestId))]
+}

--- a/telegram-plugin/tests/gateway-boot-marker-clear.test.ts
+++ b/telegram-plugin/tests/gateway-boot-marker-clear.test.ts
@@ -43,7 +43,7 @@ describe('gateway boot — clear stale turn-active marker', () => {
     // window to ~5KB so we don't pick up the unrelated
     // `removeTurnActiveMarker` call in the onTurnComplete handler
     // way down at the bottom of the file.
-    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 5000)
+    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 7000)
     const clearMatches = setupWindow.match(/removeTurnActiveMarker\s*\(\s*STATE_DIR\s*\)/g) ?? []
     expect(clearMatches.length).toBe(1)
   })
@@ -53,7 +53,7 @@ describe('gateway boot — clear stale turn-active marker', () => {
     // must not prevent the gateway from coming up. Pin the try-wrapping
     // to make sure a future refactor doesn't drop it.
     const setupBlockStart = GATEWAY_SRC.indexOf('if (!didOneTimeSetup)')
-    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 5000)
+    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 7000)
     expect(setupWindow).toMatch(/try\s*\{\s*removeTurnActiveMarker\(STATE_DIR\)\s*\}\s*catch/)
   })
 
@@ -62,7 +62,7 @@ describe('gateway boot — clear stale turn-active marker', () => {
     // Clearing the marker first means the watchdog sees a clean slate
     // immediately, even if pin sweep takes 30s+ to finish.
     const setupBlockStart = GATEWAY_SRC.indexOf('if (!didOneTimeSetup)')
-    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 5000)
+    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 7000)
     const clearIdx = setupWindow.indexOf('removeTurnActiveMarker(STATE_DIR)')
     const pinSweepIdx = setupWindow.indexOf('Boot-time pin sweep')
     expect(clearIdx).toBeGreaterThan(0)

--- a/telegram-plugin/tests/permission-ledger.test.ts
+++ b/telegram-plugin/tests/permission-ledger.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for the bridge-side outstanding permission-request ledger
+ * (#2861 / #2859).
+ *
+ * The ledger is the primitive that closes R2 (bridge dropped permission
+ * requests while the gateway IPC was down). bridge.ts wires it as:
+ *   - permission_request notification → ledger.add(params) (BEFORE the
+ *     connect check), then send if connected else buffer.
+ *   - onPermission (verdict delivered) → ledger.delete(requestId).
+ *   - onConnect (IPC (re)connect) → re-send ledger.all().
+ *
+ * bridge.ts has top-level side effects and isn't unit-importable, so here we
+ * (a) unit-test the ledger primitive directly and (b) drive a faithful
+ * re-implementation of the three wiring points against a fake IPC to prove the
+ * buffer / re-send / delete behaviours. The source wiring itself is pinned in
+ * permission-rearm-wiring.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createOutstandingPermissionLedger,
+  type OutstandingPermissionParams,
+} from '../bridge/permission-ledger.js'
+
+function params(requestId: string, tool = 'mcp__brevo__post'): OutstandingPermissionParams {
+  return {
+    request_id: requestId,
+    tool_name: tool,
+    description: `${tool} description`,
+    input_preview: '{"foo":"bar"}',
+  }
+}
+
+describe('createOutstandingPermissionLedger', () => {
+  it('starts empty', () => {
+    const led = createOutstandingPermissionLedger()
+    expect(led.size).toBe(0)
+    expect(led.all()).toEqual([])
+  })
+
+  it('add + all + has', () => {
+    const led = createOutstandingPermissionLedger()
+    led.add(params('aaaaa'))
+    led.add(params('bbbbb'))
+    expect(led.size).toBe(2)
+    expect(led.has('aaaaa')).toBe(true)
+    expect(led.has('zzzzz')).toBe(false)
+    expect(led.all().map(p => p.request_id)).toEqual(['aaaaa', 'bbbbb'])
+  })
+
+  it('add is idempotent on request_id (latest params win)', () => {
+    const led = createOutstandingPermissionLedger()
+    led.add(params('aaaaa', 'mcp__brevo__post'))
+    led.add(params('aaaaa', 'mcp__brevo__patch'))
+    expect(led.size).toBe(1)
+    expect(led.all()[0].tool_name).toBe('mcp__brevo__patch')
+  })
+
+  it('delete removes the entry (verdict delivered)', () => {
+    const led = createOutstandingPermissionLedger()
+    led.add(params('aaaaa'))
+    led.delete('aaaaa')
+    expect(led.size).toBe(0)
+    expect(led.has('aaaaa')).toBe(false)
+  })
+
+  it('delete of an unknown id is a no-op', () => {
+    const led = createOutstandingPermissionLedger()
+    led.add(params('aaaaa'))
+    led.delete('nope')
+    expect(led.size).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Faithful re-implementation of the three bridge wiring points. Mirrors
+// bridge.ts exactly so the buffer / re-send / delete contract is exercised
+// without importing the side-effecting module.
+// ---------------------------------------------------------------------------
+
+interface FakeIpc {
+  connected: boolean
+  sent: Array<{ requestId: string }>
+}
+
+function makeHarness(rearmEnabled = true) {
+  const ledger = createOutstandingPermissionLedger()
+  const ipc: FakeIpc = { connected: false, sent: [] }
+
+  // Mirrors the permission_request notification handler.
+  function onPermissionRequest(p: OutstandingPermissionParams): void {
+    if (rearmEnabled) ledger.add(p)
+    if (!ipc.connected) {
+      // BUFFER (not drop) when re-arm enabled.
+      return
+    }
+    ipc.sent.push({ requestId: p.request_id })
+  }
+
+  // Mirrors onPermission (verdict delivered).
+  function onVerdict(requestId: string): void {
+    ledger.delete(requestId)
+  }
+
+  // Mirrors flushOutstandingPermissionRequests on onConnect.
+  function onConnect(): void {
+    ipc.connected = true
+    if (!rearmEnabled) return
+    for (const p of ledger.all()) ipc.sent.push({ requestId: p.request_id })
+  }
+
+  function disconnect(): void {
+    ipc.connected = false
+  }
+
+  return { ledger, ipc, onPermissionRequest, onVerdict, onConnect, disconnect }
+}
+
+describe('bridge permission-request wiring (buffer / re-send / delete)', () => {
+  it('buffers when disconnected — no drop, request retained', () => {
+    const h = makeHarness()
+    h.onPermissionRequest(params('aaaaa'))
+    // Nothing sent (gateway down) but the ledger retained it.
+    expect(h.ipc.sent).toEqual([])
+    expect(h.ledger.has('aaaaa')).toBe(true)
+  })
+
+  it('re-sends every outstanding request on (re)connect', () => {
+    const h = makeHarness()
+    h.onPermissionRequest(params('aaaaa'))
+    h.onPermissionRequest(params('bbbbb'))
+    expect(h.ipc.sent).toEqual([]) // still down
+
+    h.onConnect() // gateway comes up
+    expect(h.ipc.sent.map(s => s.requestId).sort()).toEqual(['aaaaa', 'bbbbb'])
+  })
+
+  it('re-sends again after a disconnect/reconnect cycle (gateway restart)', () => {
+    const h = makeHarness()
+    h.onConnect() // connected
+    h.onPermissionRequest(params('aaaaa')) // sent live
+    expect(h.ipc.sent.map(s => s.requestId)).toEqual(['aaaaa'])
+
+    h.disconnect() // gateway restarts
+    h.onConnect() // reconnect → re-send outstanding
+    expect(h.ipc.sent.map(s => s.requestId)).toEqual(['aaaaa', 'aaaaa'])
+  })
+
+  it('a delivered verdict removes the entry — no re-send after resolution', () => {
+    const h = makeHarness()
+    h.onPermissionRequest(params('aaaaa'))
+    h.onVerdict('aaaaa') // operator tapped, verdict delivered
+    expect(h.ledger.has('aaaaa')).toBe(false)
+
+    h.onConnect() // reconnect
+    expect(h.ipc.sent).toEqual([]) // nothing re-sent
+  })
+
+  it('kill switch: disabled → drop-when-disconnected, no ledger, no re-send', () => {
+    const h = makeHarness(false)
+    h.onPermissionRequest(params('aaaaa')) // disconnected → dropped, not recorded
+    expect(h.ledger.size).toBe(0)
+    h.onConnect()
+    expect(h.ipc.sent).toEqual([]) // nothing to re-send
+  })
+})

--- a/telegram-plugin/tests/permission-no-repeat-wiring.test.ts
+++ b/telegram-plugin/tests/permission-no-repeat-wiring.test.ts
@@ -58,7 +58,7 @@ describe('no-repeat-on-timeout wiring', () => {
   })
 
   it('onPermissionRequest short-circuits a recent-timeout duplicate before posting a card', () => {
-    const fn = slice(GATEWAY, 'onPermissionRequest(', 4000)
+    const fn = slice(GATEWAY, 'onPermissionRequest(', 6000)
     const dupIdx = fn.indexOf('isRecentTimeoutDuplicate(')
     const cardIdx = fn.indexOf('pendingPermissions.set(requestId')
     expect(dupIdx).toBeGreaterThan(-1)

--- a/telegram-plugin/tests/permission-rearm-wiring.test.ts
+++ b/telegram-plugin/tests/permission-rearm-wiring.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Source-text wiring pins for the approval-card re-arm feature (#2861 / #2859).
+ *
+ * gateway.ts and bridge.ts have top-level side effects and aren't
+ * unit-importable; the decision logic is unit-tested in permission-rearm.test.ts
+ * and permission-ledger.test.ts. These pins lock the wiring that connects those
+ * primitives so the two failure modes can't silently regress:
+ *   R1 — gateway restart orphans pending approvals (boot-sweep stripped them).
+ *   R2 — bridge dropped permission requests while the gateway IPC was down.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const read = (p: string) => readFileSync(resolve(__dirname, '..', p), 'utf8')
+const GATEWAY = read('gateway/gateway.ts')
+const BRIDGE = read('bridge/bridge.ts')
+const IPC_CLIENT = read('bridge/ipc-client.ts')
+
+function slice(src: string, header: string, span = 2400): string {
+  const start = src.indexOf(header)
+  expect(start, `expected to find ${header}`).toBeGreaterThan(-1)
+  return src.slice(start, start + span)
+}
+
+// ─── Bridge: outstanding-request ledger (R2) ──────────────────────────────
+
+describe('bridge ledger wiring', () => {
+  it('imports and instantiates the outstanding-permission ledger', () => {
+    expect(BRIDGE).toMatch(/from '\.\/permission-ledger\.js'/)
+    expect(BRIDGE).toMatch(/createOutstandingPermissionLedger\(\)/)
+  })
+
+  it('records every permission_request in the ledger BEFORE the connect check', () => {
+    const handler = slice(BRIDGE, "method: z.literal('notifications/claude/channel/permission_request')", 2600)
+    const addIdx = handler.indexOf('outstandingPermissions.add(')
+    const connIdx = handler.indexOf('!ipc.isConnected()')
+    expect(addIdx, 'ledger.add must be present in the handler').toBeGreaterThan(-1)
+    expect(connIdx, 'connect check must be present').toBeGreaterThan(-1)
+    expect(addIdx, 'ledger.add must precede the connect check so a disconnected request is retained')
+      .toBeLessThan(connIdx)
+  })
+
+  it('the early-return no longer DROPS unconditionally — it buffers on reconnect', () => {
+    const handler = slice(BRIDGE, "method: z.literal('notifications/claude/channel/permission_request')", 2600)
+    // The old drop path was a bare `if (!ipc || !ipc.isConnected()) { log; return }`
+    // with no ledger/buffer. Pin the new buffer semantics instead.
+    expect(handler).toMatch(/buffered.*re-send on reconnect/i)
+    // Structural anti-regression: the legacy standalone drop message must only
+    // appear behind the kill-switch fallback, never as the sole behavior.
+    expect(handler).toMatch(/permissionRearmEnabled/)
+  })
+
+  it('deletes from the ledger when a verdict is delivered (onPermission)', () => {
+    const onPerm = slice(BRIDGE, 'function onPermission(msg: PermissionEvent)', 900)
+    expect(onPerm).toMatch(/outstandingPermissions\.delete\(msg\.requestId\)/)
+  })
+
+  it('flushes outstanding requests on every IPC (re)connect', () => {
+    expect(BRIDGE).toMatch(/function flushOutstandingPermissionRequests/)
+    expect(BRIDGE).toMatch(/onConnect:\s*flushOutstandingPermissionRequests/)
+    const flush = slice(BRIDGE, 'function flushOutstandingPermissionRequests', 900)
+    expect(flush).toMatch(/outstandingPermissions\.all\(\)/)
+    expect(flush).toMatch(/sendPermissionRequest/)
+  })
+
+  it('honours the SWITCHROOM_PERMISSION_REARM kill switch', () => {
+    expect(BRIDGE).toMatch(/SWITCHROOM_PERMISSION_REARM\s*!==\s*'0'/)
+  })
+})
+
+// ─── IPC client: onConnect hook ───────────────────────────────────────────
+
+describe('ipc-client onConnect hook', () => {
+  it('exposes an onConnect option', () => {
+    expect(IPC_CLIENT).toMatch(/onConnect\?:\s*\(\)\s*=>\s*void/)
+  })
+  it('invokes onConnect from the socket open() handler (after register)', () => {
+    const open = slice(IPC_CLIENT, 'open(sock)', 900)
+    const regIdx = open.indexOf('sendRegister()')
+    const connIdx = open.indexOf('onConnect(')
+    expect(connIdx, 'open() must call onConnect').toBeGreaterThan(-1)
+    expect(regIdx).toBeLessThan(connIdx)
+  })
+})
+
+// ─── Gateway: dedupe + re-arm (R1) ────────────────────────────────────────
+
+describe('gateway re-arm wiring', () => {
+  it('imports the pure re-arm helpers', () => {
+    expect(GATEWAY).toMatch(/from '\.\/permission-rearm\.js'/)
+    expect(GATEWAY).toMatch(/classifyPermissionRequest/)
+    expect(GATEWAY).toMatch(/computeBootSweepStripTargets/)
+  })
+
+  it('tracks re-claimed request_ids for the grace-period sweep', () => {
+    expect(GATEWAY).toMatch(/const rearmReclaimedRequestIds = new Set<string>\(\)/)
+  })
+
+  it('onPermissionRequest dedupes / re-arms before posting a card', () => {
+    const fn = slice(GATEWAY, 'onPermissionRequest(_client: IpcClient, msg: PermissionRequestForward)', 5200)
+    expect(fn).toMatch(/isPermissionRearmEnabled\(\)/)
+    expect(fn).toMatch(/classifyPermissionRequest/)
+    // duplicate → return (no second card); rearm → restore from store.
+    expect(fn).toMatch(/disposition === 'duplicate'/)
+    expect(fn).toMatch(/disposition === 'rearm'/)
+    expect(fn).toMatch(/rearmPermissionFromStore\(/)
+    expect(fn).toMatch(/rearmReclaimedRequestIds\.add\(requestId\)/)
+    // The dedup/re-arm block must sit before the card-post (formatPermissionCardBody).
+    const rearmIdx = fn.indexOf('classifyPermissionRequest')
+    const postIdx = fn.indexOf('formatPermissionCardBody')
+    expect(postIdx).toBeGreaterThan(-1)
+    expect(rearmIdx).toBeLessThan(postIdx)
+  })
+
+  it('re-arm preserves the ORIGINAL startedAt (TTL clock, not Date.now())', () => {
+    const fn = slice(GATEWAY, 'function rearmPermissionFromStore', 1800)
+    // startedAt is derived from the persisted entries, never re-stamped.
+    expect(fn).toMatch(/c\.startedAt/)
+    expect(fn).toMatch(/startedAt,/)
+    expect(fn).not.toMatch(/startedAt:\s*Date\.now\(\)/)
+    expect(fn).toMatch(/pendingPermissions\.set\(requestId/)
+  })
+
+  it('re-arm re-attaches the keyboard on the EXISTING message(s) via editMessageText', () => {
+    const fn = slice(GATEWAY, 'function rearmPermissionFromStore', 1800)
+    expect(fn).toMatch(/buildPermissionActionRow\(requestId/)
+    expect(fn).toMatch(/editMessageText\(/)
+    // Re-arm edits existing messages; it must NOT post a brand-new card.
+    expect(fn).not.toMatch(/sendRichMessage/)
+  })
+
+  it('never auto-answers — no dispatchPermissionVerdict inside re-arm (no-self-escalation)', () => {
+    const fn = slice(GATEWAY, 'function rearmPermissionFromStore', 1800)
+    expect(fn).not.toMatch(/dispatchPermissionVerdict/)
+  })
+})
+
+// ─── Gateway: grace-period boot-sweep (R1) ────────────────────────────────
+
+describe('gateway boot-sweep grace period', () => {
+  it('defers the strip when re-arm is enabled, keeps immediate strip as the kill-switch path', () => {
+    const sweep = slice(GATEWAY, 'Boot-sweep for permission cards from a prior gateway session', 3400)
+    expect(sweep).toMatch(/if \(!isPermissionRearmEnabled\(\)\)/)
+    // legacy immediate path still strips everything + clears the store
+    expect(sweep).toMatch(/permCardStore\.clear\(\)/)
+    // grace path: setTimeout + grace-ms knob + reclaimed filter
+    expect(sweep).toMatch(/setTimeout\(/)
+    expect(sweep).toMatch(/permissionRearmGraceMs\(\)/)
+    expect(sweep).toMatch(/computeBootSweepStripTargets\(remaining, rearmReclaimedRequestIds\)/)
+  })
+
+  it('the grace path removes only stripped request_ids, not the whole store', () => {
+    const sweep = slice(GATEWAY, 'Boot-sweep for permission cards from a prior gateway session', 3400)
+    // Per-request removal (preserves re-armed live entries) inside the deferred block.
+    expect(sweep).toMatch(/distinctRequestIds\(toStrip\)/)
+    expect(sweep).toMatch(/permCardStore\.remove\(id\)/)
+  })
+})
+
+// ─── Gateway: re-arm re-holds the #2840 inbound gate ──────────────────────
+
+describe('re-armed pending card re-holds the inbound gate (#2840)', () => {
+  it('turnInFlightForGate counts pending approvals', () => {
+    const gate = slice(GATEWAY, 'function turnInFlightForGate()', 1200)
+    expect(gate).toMatch(/pendingPermissions\.size > 0/)
+  })
+  it('re-arm restores a pendingPermissions entry → gate held automatically', () => {
+    // The gate reads pendingPermissions.size; rearmPermissionFromStore sets an
+    // entry, so a re-armed card holds the gate with no extra wiring.
+    const fn = slice(GATEWAY, 'function rearmPermissionFromStore', 1800)
+    expect(fn).toMatch(/pendingPermissions\.set\(requestId/)
+  })
+})

--- a/telegram-plugin/tests/permission-rearm-wiring.test.ts
+++ b/telegram-plugin/tests/permission-rearm-wiring.test.ts
@@ -96,10 +96,6 @@ describe('gateway re-arm wiring', () => {
     expect(GATEWAY).toMatch(/computeBootSweepStripTargets/)
   })
 
-  it('tracks re-claimed request_ids for the grace-period sweep', () => {
-    expect(GATEWAY).toMatch(/const rearmReclaimedRequestIds = new Set<string>\(\)/)
-  })
-
   it('onPermissionRequest dedupes / re-arms before posting a card', () => {
     const fn = slice(GATEWAY, 'onPermissionRequest(_client: IpcClient, msg: PermissionRequestForward)', 5200)
     expect(fn).toMatch(/isPermissionRearmEnabled\(\)/)
@@ -108,7 +104,6 @@ describe('gateway re-arm wiring', () => {
     expect(fn).toMatch(/disposition === 'duplicate'/)
     expect(fn).toMatch(/disposition === 'rearm'/)
     expect(fn).toMatch(/rearmPermissionFromStore\(/)
-    expect(fn).toMatch(/rearmReclaimedRequestIds\.add\(requestId\)/)
     // The dedup/re-arm block must sit before the card-post (formatPermissionCardBody).
     const rearmIdx = fn.indexOf('classifyPermissionRequest')
     const postIdx = fn.indexOf('formatPermissionCardBody')
@@ -143,18 +138,21 @@ describe('gateway re-arm wiring', () => {
 
 describe('gateway boot-sweep grace period', () => {
   it('defers the strip when re-arm is enabled, keeps immediate strip as the kill-switch path', () => {
-    const sweep = slice(GATEWAY, 'Boot-sweep for permission cards from a prior gateway session', 3400)
+    const sweep = slice(GATEWAY, 'Boot-sweep for permission cards from a prior gateway session', 4200)
     expect(sweep).toMatch(/if \(!isPermissionRearmEnabled\(\)\)/)
     // legacy immediate path still strips everything + clears the store
     expect(sweep).toMatch(/permCardStore\.clear\(\)/)
-    // grace path: setTimeout + grace-ms knob + reclaimed filter
+    // grace path: setTimeout + grace-ms knob + live-pending filter
     expect(sweep).toMatch(/setTimeout\(/)
     expect(sweep).toMatch(/permissionRearmGraceMs\(\)/)
-    expect(sweep).toMatch(/computeBootSweepStripTargets\(remaining, rearmReclaimedRequestIds\)/)
+    // Preserve anything currently live in pendingPermissions — covers both
+    // re-armed AND fresh-during-grace cards (reviewer-caught blocker fix).
+    expect(sweep).toMatch(/new Set\(pendingPermissions\.keys\(\)\)/)
+    expect(sweep).toMatch(/computeBootSweepStripTargets\(remaining, liveRequestIds\)/)
   })
 
   it('the grace path removes only stripped request_ids, not the whole store', () => {
-    const sweep = slice(GATEWAY, 'Boot-sweep for permission cards from a prior gateway session', 3400)
+    const sweep = slice(GATEWAY, 'Boot-sweep for permission cards from a prior gateway session', 4200)
     // Per-request removal (preserves re-armed live entries) inside the deferred block.
     expect(sweep).toMatch(/distinctRequestIds\(toStrip\)/)
     expect(sweep).toMatch(/permCardStore\.remove\(id\)/)

--- a/telegram-plugin/tests/permission-rearm.test.ts
+++ b/telegram-plugin/tests/permission-rearm.test.ts
@@ -52,26 +52,37 @@ describe('classifyPermissionRequest', () => {
 })
 
 describe('computeBootSweepStripTargets', () => {
-  it('strips only entries NOT re-claimed by a bridge re-send', () => {
+  it('strips only entries whose request_id is NOT currently live', () => {
     const stale = [card('aaaaa', 10), card('bbbbb', 11), card('ccccc', 12)]
-    const reclaimed = new Set(['bbbbb'])
-    const targets = computeBootSweepStripTargets(stale, reclaimed)
+    const live = new Set(['bbbbb']) // bbbbb re-armed / still pending
+    const targets = computeBootSweepStripTargets(stale, live)
     expect(targets.map(t => t.requestId)).toEqual(['aaaaa', 'ccccc'])
   })
 
-  it('a re-claimed entry survives the deadline (empty strip)', () => {
+  it('a re-armed (live) entry survives the deadline (empty strip)', () => {
     const stale = [card('aaaaa', 10)]
-    const reclaimed = new Set(['aaaaa'])
-    expect(computeBootSweepStripTargets(stale, reclaimed)).toEqual([])
+    const live = new Set(['aaaaa'])
+    expect(computeBootSweepStripTargets(stale, live)).toEqual([])
   })
 
-  it('an un-re-claimed entry is stripped at the deadline', () => {
+  it('a dead-session entry (no live pending) is stripped at the deadline', () => {
     const stale = [card('aaaaa', 10)]
-    const reclaimed = new Set<string>()
-    expect(computeBootSweepStripTargets(stale, reclaimed).map(t => t.requestId)).toEqual(['aaaaa'])
+    const live = new Set<string>()
+    expect(computeBootSweepStripTargets(stale, live).map(t => t.requestId)).toEqual(['aaaaa'])
   })
 
-  it('keeps ALL fan-out messages for an un-re-claimed request', () => {
+  it('a FRESH card born during the grace window (live but not in the boot set) survives', () => {
+    // Regression for the reviewer-caught blocker: a new approval posted after
+    // boot writes its own persisted row, so it appears in `remaining` at the
+    // deadline. It's live in pendingPermissions, so it must NOT be stripped —
+    // otherwise a legitimately-suspended turn gets re-wedged.
+    const remaining = [card('dead0', 10), card('fresh', 20)]
+    const live = new Set(['fresh']) // 'fresh' posted during grace, still pending
+    const targets = computeBootSweepStripTargets(remaining, live)
+    expect(targets.map(t => t.requestId)).toEqual(['dead0'])
+  })
+
+  it('keeps ALL fan-out messages for a dead-session request', () => {
     // Same request_id, two operator surfaces → two persisted rows.
     const stale = [card('aaaaa', 10), card('aaaaa', 20)]
     const targets = computeBootSweepStripTargets(stale, new Set())

--- a/telegram-plugin/tests/permission-rearm.test.ts
+++ b/telegram-plugin/tests/permission-rearm.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for the pure permission-card re-arm helpers (#2861 / #2859).
+ *
+ * These cover the discriminable decision logic extracted from gateway.ts
+ * (which has top-level side effects and isn't unit-importable):
+ *   - classifyPermissionRequest — duplicate / rearm / fresh
+ *   - computeBootSweepStripTargets — grace-period strip filtering
+ *   - isPermissionRearmEnabled / permissionRearmGraceMs — kill switch + knob
+ *   - distinctRequestIds
+ *
+ * The gateway/bridge WIRING that consumes these is pinned separately in
+ * permission-rearm-wiring.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  classifyPermissionRequest,
+  computeBootSweepStripTargets,
+  isPermissionRearmEnabled,
+  permissionRearmGraceMs,
+  distinctRequestIds,
+  PERMISSION_REARM_GRACE_MS,
+} from '../gateway/permission-rearm.js'
+import type { PersistedPermCard } from '../gateway/permission-card-store.js'
+
+function card(requestId: string, messageId: number): PersistedPermCard {
+  return {
+    requestId,
+    chatId: '-100123',
+    messageId,
+    startedAt: 1_000,
+    toolName: 'mcp__brevo__post',
+    cardText: 'Marko wants to post to Brevo',
+  }
+}
+
+describe('classifyPermissionRequest', () => {
+  it('already-live request → duplicate (ignore, no second card)', () => {
+    expect(classifyPermissionRequest({ hasPending: true, persistedCount: 0 })).toBe('duplicate')
+    // hasPending wins even if the store also has it
+    expect(classifyPermissionRequest({ hasPending: true, persistedCount: 2 })).toBe('duplicate')
+  })
+
+  it('gone from memory but persisted → rearm', () => {
+    expect(classifyPermissionRequest({ hasPending: false, persistedCount: 1 })).toBe('rearm')
+    expect(classifyPermissionRequest({ hasPending: false, persistedCount: 3 })).toBe('rearm')
+  })
+
+  it('unknown request → fresh (post a new card)', () => {
+    expect(classifyPermissionRequest({ hasPending: false, persistedCount: 0 })).toBe('fresh')
+  })
+})
+
+describe('computeBootSweepStripTargets', () => {
+  it('strips only entries NOT re-claimed by a bridge re-send', () => {
+    const stale = [card('aaaaa', 10), card('bbbbb', 11), card('ccccc', 12)]
+    const reclaimed = new Set(['bbbbb'])
+    const targets = computeBootSweepStripTargets(stale, reclaimed)
+    expect(targets.map(t => t.requestId)).toEqual(['aaaaa', 'ccccc'])
+  })
+
+  it('a re-claimed entry survives the deadline (empty strip)', () => {
+    const stale = [card('aaaaa', 10)]
+    const reclaimed = new Set(['aaaaa'])
+    expect(computeBootSweepStripTargets(stale, reclaimed)).toEqual([])
+  })
+
+  it('an un-re-claimed entry is stripped at the deadline', () => {
+    const stale = [card('aaaaa', 10)]
+    const reclaimed = new Set<string>()
+    expect(computeBootSweepStripTargets(stale, reclaimed).map(t => t.requestId)).toEqual(['aaaaa'])
+  })
+
+  it('keeps ALL fan-out messages for an un-re-claimed request', () => {
+    // Same request_id, two operator surfaces → two persisted rows.
+    const stale = [card('aaaaa', 10), card('aaaaa', 20)]
+    const targets = computeBootSweepStripTargets(stale, new Set())
+    expect(targets).toHaveLength(2)
+    expect(targets.map(t => t.messageId).sort()).toEqual([10, 20])
+  })
+})
+
+describe('distinctRequestIds', () => {
+  it('dedupes request_ids across fan-out rows', () => {
+    const cards = [card('aaaaa', 10), card('aaaaa', 20), card('bbbbb', 30)]
+    expect(distinctRequestIds(cards).sort()).toEqual(['aaaaa', 'bbbbb'])
+  })
+})
+
+describe('isPermissionRearmEnabled (kill switch)', () => {
+  it('enabled by default (unset)', () => {
+    expect(isPermissionRearmEnabled({})).toBe(true)
+  })
+  it('enabled for any value other than "0"', () => {
+    expect(isPermissionRearmEnabled({ SWITCHROOM_PERMISSION_REARM: '1' })).toBe(true)
+    expect(isPermissionRearmEnabled({ SWITCHROOM_PERMISSION_REARM: 'on' })).toBe(true)
+  })
+  it('disabled only for the exact "0" kill value', () => {
+    expect(isPermissionRearmEnabled({ SWITCHROOM_PERMISSION_REARM: '0' })).toBe(false)
+  })
+})
+
+describe('permissionRearmGraceMs', () => {
+  it('defaults to PERMISSION_REARM_GRACE_MS when unset', () => {
+    expect(permissionRearmGraceMs({})).toBe(PERMISSION_REARM_GRACE_MS)
+  })
+  it('honours a finite non-negative override (test collapse)', () => {
+    expect(permissionRearmGraceMs({ SWITCHROOM_PERMISSION_REARM_GRACE_MS: '0' })).toBe(0)
+    expect(permissionRearmGraceMs({ SWITCHROOM_PERMISSION_REARM_GRACE_MS: '250' })).toBe(250)
+  })
+  it('falls back to the default on garbage / negative', () => {
+    expect(permissionRearmGraceMs({ SWITCHROOM_PERMISSION_REARM_GRACE_MS: 'nope' })).toBe(PERMISSION_REARM_GRACE_MS)
+    expect(permissionRearmGraceMs({ SWITCHROOM_PERMISSION_REARM_GRACE_MS: '-5' })).toBe(PERMISSION_REARM_GRACE_MS)
+  })
+})


### PR DESCRIPTION
## Summary

Pending tool-permission approvals lived only in the gateway's in-memory `pendingPermissions` map. Two ways they died — both closed here:

- **R1 — gateway restart orphaned every pending approval.** Boot-sweep *stripped* the persisted card ("Gateway restarted…") while the claude session stayed suspended inside the MCP permission call; no verdict was ever dispatched → turn wedged, gated work lost. (marko's gateway booted ~14× on fleet-roll day; every boot killed all pending cards.)
- **R2 — bridge dropped permission requests while the gateway IPC was down.** `if (!ipc.isConnected()) { log; return }` discarded the request → no card ever posted, claude hung indefinitely.

The persistence to fix both already existed (`permission-card-store.ts`). This PR uses it to **re-arm** instead of strip/drop.

**This is PR A of 3 under umbrella #2859, and lands first** (A reduces how often B's re-offer path fires; C is independent).

## Why

The store already persists `requestId, chatId, messageId, startedAt, toolName, cardText` across container recreate — everything needed to restore the *question* after a restart. Stripping it threw that away and wedged the suspended claude turn.

## What changed

**Bridge** (`bridge/bridge.ts`, new `bridge/permission-ledger.ts`, `bridge/ipc-client.ts`):
- Outstanding-request ledger keyed by `request_id`; added on every `permission_request`, deleted in `onPermission` when a verdict is delivered.
- Disconnected requests are **buffered, not dropped**.
- New ipc-client `onConnect` hook re-sends all outstanding requests on every (re)connect.

**Gateway** (`gateway/gateway.ts`, new `gateway/permission-rearm.ts`):
- `onPermissionRequest` dedupes by `request_id`: already-pending → ignore (idempotent under bridge re-sends, no duplicate card); gone-from-memory but persisted → **re-arm** (restore `pendingPermissions` with the **original `startedAt`**, re-attach keyboard on the existing message(s) via `editMessageText` — never a new card).
- Boot-sweep → **grace-period strip** (~90s): only cards NOT re-claimed by a bridge re-send get the "restarted" notice; a genuinely dead session (new bridge, empty ledger) still gets stripped. Per-request store removal preserves re-armed entries.
- Re-arm restores the #2840 inbound gate automatically (`pendingPermissions.size > 0`).

## Invariants / guards

- **Kill switch** `SWITCHROOM_PERMISSION_REARM=0` reverts to legacy immediate-strip / drop-when-disconnected (both sides).
- **No auto-allow** — re-arm restores only the question, never a verdict (no-self-escalation).
- **No new model callsite**, no `claude -p`, no SDK/API — verdicts still travel only over the existing IPC/MCP channel (claude-native).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `check-bot-api-wrapping.sh` clean (new `editMessageText` re-arm calls routed through `swallowingApiCall`)
- [x] Bridge ledger units: buffer-when-disconnected, re-send-on-reconnect (incl. across a disconnect/reconnect cycle), delete-on-verdict, kill switch — under **both** vitest and bun
- [x] Gateway pure re-arm helpers: `classifyPermissionRequest` (duplicate/rearm/fresh), `computeBootSweepStripTargets` (re-claimed survives past deadline, unclaimed stripped), grace-ms knob, kill switch
- [x] Source-text wiring pins: bridge drop-path gone; dedupe/re-arm before card-post; original `startedAt` preserved; keyboard restored in place (no new card); grace sweep with per-request removal; re-armed pending re-holds the inbound gate
- [x] `inbound-delivery-gate` + full telegram-plugin bun suite (5707 pass / 0 fail)
- [ ] **UAT (pending — not run here):** `jtbd-approval-survives-gateway-restart-dm` (+ `-channel` twin) — trigger a card on test-harness, bounce the gateway *process*, assert the same card message is re-armed (keyboard present), tap Allow, assert the gated tool ran.
- [ ] **UAT backfill of #2840 (folded into this PR's UAT):** send a message while a card is pending → buffered, delivered after the tap, **not** a new turn.

> Note: the two required checks' fixed-span source-text pins (`permission-no-repeat-wiring`, `gateway-boot-marker-clear`) were widened in the same PR because the new `onPermissionRequest` / boot-sweep code shifted their slice windows.

## Risk

Low–moderate. Behavior is gated behind the kill switch; the re-arm path only ever restores a card + keyboard (never answers). An already-expired re-arm falls straight into the existing TTL auto-deny sweep, which correctly unwedges claude. The grace-period sweep still strips genuinely dead sessions after ~90s. Requires UAT (above) before fleet rollout.

Refs #2861, umbrella #2859.