### PR TITLE
reference: fix ProductOS link + conform docs to current ProductOS templates

### DIFF
--- a/reference/README.md
+++ b/reference/README.md
@@ -106,6 +106,7 @@ These are considered improvements over the base method, not defects:
 
 - **RFCs are terse design docs, not job-spec hybrids.** Failure-mode thinking (the "Good / bad" section) lives in the job spec. Mechanism lives in the RFC. The two never collapse into one doc.
 - **Two RFC doc-classes, one folder.** A `serves:` key means a ship-coupled RFC delivering a specific job. A `backs:` key means a standing design record defending an invariant. Both live in `rfcs/`; frontmatter tells them apart.
+- **Job specs carry a terse subset of the full template.** They keep the frontmatter plus Good / bad, Prove it, Verdict, Production-readiness, and Related, and omit the full template's today's-alternatives, the-bet, measures-of-success, what-the-job-requires, and abandon-signal sections. The specs are short by design; the product spec's job index and the UAT harness carry that weight.
 - **No STRATEGY, decisions, or job-links artefacts.** A single-operator subscription product has no accounts, renewals, or stakeholder portfolios to join across. Those templates exist in the method for multi-product organisations; they add no signal here.
 
 ## `rfcs/` holds two kinds of doc — that's intended

--- a/reference/README.md
+++ b/reference/README.md
@@ -88,7 +88,7 @@ invariant, a job spec, a design record), never collapsed into one.
 
 ## How this repo instantiates ProductOS
 
-Switchroom is the canonical worked example of the [ProductOS method](../../ProductOS/).
+Switchroom is the canonical worked example of the [ProductOS method](https://github.com/mekenthompson/ProductOS).
 The map from each reference doc to its method anchor or template:
 
 | Reference doc | ProductOS anchor / template |

--- a/reference/jobs/act-in-my-tools-with-an-identity.md
+++ b/reference/jobs/act-in-my-tools-with-an-identity.md
@@ -190,6 +190,15 @@ identity is always surfaced.
   mint a new identity or widen a grant. `single-tenant` — one operator's
   tokens and identities, never shared across tenants.
 
+## Related
+
+- [`approve-what-my-agent-can-touch`](approve-what-my-agent-can-touch.md) --
+  how the operator grants the identity and scope this job acts under.
+- [`share-auth-across-the-fleet`](share-auth-across-the-fleet.md) -- the
+  credential plane behind the per-agent acting identities.
+- [`know-what-my-agent-is-doing`](know-what-my-agent-is-doing.md) -- seeing
+  and steering the tool-side action from Telegram.
+
 ---
 
 > **Implementation:** the *how* lives in `docs/webhook-ingest.md` and

--- a/reference/jobs/approve-what-my-agent-can-touch.md
+++ b/reference/jobs/approve-what-my-agent-can-touch.md
@@ -151,6 +151,15 @@ per-resource, every resume a synthesized turn.
 - *Reliability:* an approval that lands resumes the turn; a denied or
   restart-interrupted grant never strands the agent silently.
 
+## Related
+
+- [`share-auth-across-the-fleet`](share-auth-across-the-fleet.md) -- the
+  credential plane the grants draw on; this job gates what that pool hands out.
+- [`act-in-my-tools-with-an-identity`](act-in-my-tools-with-an-identity.md) --
+  what the agent does with a granted identity once the operator has approved it.
+- [`operate-the-fleet-from-telegram`](operate-the-fleet-from-telegram.md) --
+  the other one-tap, in-chat operator control surface.
+
 ---
 
 > **Implementation:** the *how* lives in `reference/rfcs/access-model.md` (the

--- a/reference/jobs/crons-use-the-model-only-when-it-earns-it.md
+++ b/reference/jobs/crons-use-the-model-only-when-it-earns-it.md
@@ -114,3 +114,13 @@ no-ops, interactive-session-only on any model fire, no zombie fires.
   zero `claude -p` / SDK / API callsites on the scheduled path.
 - *Determinism:* the tier selector is a pure function of observable signals.
   Same inputs, same tier, fully enumerable, no model in the decision loop.
+
+## Related
+
+- [`keep-my-subscription-honest`](keep-my-subscription-honest.md) -- the
+  outcome-level bill-honesty contract this job's tiering enforces on the
+  scheduled path.
+- [`survive-reboots-and-real-life`](survive-reboots-and-real-life.md) --
+  scheduled fires must also survive restarts without duplicating or dropping.
+- [`fleet-stays-healthy`](fleet-stays-healthy.md) -- the same gate-first,
+  model-only-when-it-earns-it discipline applied to fleet health scans.

--- a/reference/jobs/deliver-files-i-can-open.md
+++ b/reference/jobs/deliver-files-i-can-open.md
@@ -132,6 +132,15 @@ path, and delivery never touches anything outside the agent's own folder.
   the end-to-end scenario exists. Channel-routing bugs have hidden in
   DM-only coverage before.
 
+## Related
+
+- [`talk-to-agents-from-anywhere`](talk-to-agents-from-anywhere.md) -- the
+  phone-first chat surface a deliverable has to be openable from.
+- [`approve-what-my-agent-can-touch`](approve-what-my-agent-can-touch.md) --
+  the operator grant behind the Drive scope delivery writes with.
+- [`feel-like-a-colleague`](feel-like-a-colleague.md) -- a colleague hands
+  you the document, not a path on their machine.
+
 ---
 
 > **Implementation:** the `deliver-file` CLI verb (`src/cli/deliver-file.ts`),

--- a/reference/jobs/fleet-stays-healthy.md
+++ b/reference/jobs/fleet-stays-healthy.md
@@ -135,6 +135,15 @@ not just the happy path, and the sensor stays model-free across it.
   It is operator tooling (like the fleet dashboard), so `telegram-only` and
   `chat-is-the-single-source-of-truth` hold.
 
+## Related
+
+- [`see-my-whole-fleet-from-one-screen`](see-my-whole-fleet-from-one-screen.md) --
+  the operator surface the ranked health view lives beside.
+- [`crons-use-the-model-only-when-it-earns-it`](crons-use-the-model-only-when-it-earns-it.md) --
+  the gate-first cost discipline the nightly sensor inherits.
+- [`know-what-my-agent-is-doing`](know-what-my-agent-is-doing.md) -- per-turn
+  visibility; this job is its fleet-wide, over-time counterpart.
+
 ---
 
 > **Implementation:** the how lives in `reference/rfcs/fleet-health.md`

--- a/reference/jobs/get-better-the-longer-they-run.md
+++ b/reference/jobs/get-better-the-longer-they-run.md
@@ -95,6 +95,15 @@ just the happy path.
   every turn without the operator paying for it on turns that didn't change
   anything.
 
+## Related
+
+- [`remember-across-sessions`](remember-across-sessions.md) -- the memory
+  substrate a lesson has to land in to bind.
+- [`feel-like-a-colleague`](feel-like-a-colleague.md) -- the standing-team
+  outcome that improvement over time serves.
+- [`extend-without-forking`](extend-without-forking.md) -- self-served skill
+  fixes ride the same config-not-fork extension surface.
+
 ---
 
 > **Implementation:** the how lives in `reference/rfcs/agent-self-improvement.md`

--- a/reference/jobs/get-from-zero-to-a-working-fleet.md
+++ b/reference/jobs/get-from-zero-to-a-working-fleet.md
@@ -166,6 +166,15 @@ cheerful "done" over a silently-dead agent.
 - *Defaults:* a fresh setup produces a working, conversational agent with no
   required config. The "batteries included" principle check is the gate.
 
+## Related
+
+- [`run-a-fleet-of-specialists`](run-a-fleet-of-specialists.md) -- the fleet
+  this job bootstraps from a clean box.
+- [`extend-without-forking`](extend-without-forking.md) -- growing the fleet
+  after first contact, config only.
+- [`restart-and-know-what-im-running`](restart-and-know-what-im-running.md) --
+  the same loud-not-silent readiness bar, applied to every later restart.
+
 ---
 
 > **Implementation:** the how (the setup-wizard steps, the pairing

--- a/reference/jobs/operate-the-fleet-from-telegram.md
+++ b/reference/jobs/operate-the-fleet-from-telegram.md
@@ -139,6 +139,15 @@ durable record, not a memory of a chat message that scrolled away.
   ways this job would fail even if every feature worked (mirrors the CAUTION in
   `see-my-whole-fleet-from-one-screen.md`).
 
+## Related
+
+- [`see-my-whole-fleet-from-one-screen`](see-my-whole-fleet-from-one-screen.md) --
+  the read-mostly operator console; this job is the act-on-it counterpart.
+- [`idempotent-update-and-restart`](idempotent-update-and-restart.md) -- the
+  update/restart operations whose progress this job narrates.
+- [`know-what-my-agent-is-doing`](know-what-my-agent-is-doing.md) -- the same
+  answered-in-the-chat, never-a-parallel-surface discipline, per turn.
+
 > [!CAUTION]
 > If the rollout status becomes a pinned parallel surface, this job has failed
 > even if it shows every phase perfectly. Durable artifact + in-chat narration

--- a/reference/jobs/see-my-whole-fleet-from-one-screen.md
+++ b/reference/jobs/see-my-whole-fleet-from-one-screen.md
@@ -160,6 +160,15 @@ principal's chat jobs). Pin:
   [`track-plan-quota-live`](track-plan-quota-live.md), remain answered in
   the chat.
 
+## Related
+
+- [`know-what-my-agent-is-doing`](know-what-my-agent-is-doing.md) -- the
+  principal-facing per-turn signal this screen must never cannibalise.
+- [`operate-the-fleet-from-telegram`](operate-the-fleet-from-telegram.md) --
+  acting on the fleet once you can see it.
+- [`fleet-stays-healthy`](fleet-stays-healthy.md) -- the ranked health view
+  that shares this operator-only surface.
+
 > [!CAUTION]
 > If the dashboard starts being where a principal goes, this job has failed
 > even if every feature works.

--- a/reference/rfcs/conversational-pacing.md
+++ b/reference/rfcs/conversational-pacing.md
@@ -1,6 +1,6 @@
 ---
 artefact: Telegram conversational pacing + silence-poke safety net
-serves: jobs/know-what-my-agent-is-doing.md
+serves: know-what-my-agent-is-doing
 status: design v2 — the five-beat human-feel model (supersedes v1's card-era pacing)
 ---
 

--- a/reference/rfcs/host-control-daemon.md
+++ b/reference/rfcs/host-control-daemon.md
@@ -1,6 +1,6 @@
 ---
 artefact: host-control daemon (switchroom-hostd)
-serves: jobs/idempotent-update-and-restart.md
+serves: idempotent-update-and-restart
 status: Draft v3 (docker-first correction)
 ---
 


### PR DESCRIPTION
Originally a one-line link fix; now also brings `reference/` into conformance with the current ProductOS templates after the ProductOS front-door revamp.

- Fix the `../../ProductOS/` relative link in `reference/README.md` (404s on GitHub) to the repo URL.
- Document the terse job-spec shape as a deliberate divergence in the README divergence list.
- Add the missing `## Related` section to the 9 job specs that lacked it; all 23 now carry the full terse subset.
- Fix two RFCs using path-style `serves:` values to the template's bare-slug scheme.

Checked and left alone: product spec, anchors, and RFC shape all conform or are documented divergence. One flag for a follow-up: `rfcs/deploy-reliability.md` has `backs: always-available` (an outcome slug, not an invariant); a strict fix needs a new named invariant, which is an anchor change for human ratification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)