### PR TITLE
feat(memory): thread reflect/observations mission + per-bank disposition (hindsight Phase 2)

### DIFF
--- a/reference/rfcs/hindsight-synthesis-layers.md
+++ b/reference/rfcs/hindsight-synthesis-layers.md
@@ -224,7 +224,18 @@ Two things landed adjacent to this RFC that change its framing:
   ~L879), landed 2026-07-05. But **no scaffold override sets any tag filter**
   — the config keys are absent, so the filters collapse to a no-op (empty
   filter = pass-through). This is a ready-made hook for future recall shaping
-  (e.g. scoping additional-bank recall to specific tags), currently dormant.
+  (e.g. scoping additional-bank recall to specific tags), and it is
+  **deliberately kept dormant** (decision, not oversight): tag-scoped recall is
+  orthogonal to Phase 2's mission/disposition specialization and this RFC does
+  not specify a per-bank tag taxonomy, so wiring a first-class
+  `memory.recall.tags` surface now would be speculative generality. The
+  intentional-dormancy is documented at the point of decision in
+  `renderHindsightSettingsOverrides` (`src/agents/scaffold.ts`) with a
+  `TODO(#2816)` naming exactly how to wire it (mirror the `recallTypes`
+  cascade + `HINDSIGHT_RECALL_TAGS` start.sh export) if a future RFC calls for
+  it. The env-var escape hatch (`HINDSIGHT_RECALL_TAGS` /
+  `HINDSIGHT_RECALL_TAGS_MATCH` / `HINDSIGHT_RECALL_TAG_GROUPS` in
+  `lib/config.py`) remains available to advanced operators in the meantime.
 
 ## Proposal — phased, with current status
 
@@ -245,17 +256,22 @@ wall-timeout): that would blow warm TTFO (~1.7s) into seconds and multiply
 per-turn tokens. Reflect stays reserved for explicit "what do you know about
 me" asks.
 
-**Phase 2 — Specialize each bank. — PARTIAL.** Per-agent `retain_mission` /
-`bank_mission` are now first-class config and a generic
-`DEFAULT_RETAIN_MISSION` is seeded at scaffold, so specialists can be shaped
-rather than merely isolated, and three banks (`assistant`, `lawgpt`,
-`ziggy`) carry a specialized `bank_mission` today. **Still open:**
-`reflect_mission`, `observations_mission`, and `disposition` are not wired
-through switchroom config — `disposition` is uniform
-`{empathy:3, literalism:3, skepticism:3}` on every bank. Completing this
-phase means threading the remaining mission/disposition fields from the
-agent's profile (a coach extracts/voices differently than a lawyer).
-Operator-config-driven (no-self-escalation clean).
+**Phase 2 — Specialize each bank. — SHIPPED (#2855).** Per-agent
+`retain_mission` / `bank_mission` were made first-class config with a generic
+`DEFAULT_RETAIN_MISSION` seeded at scaffold; #2855 then threaded the remaining
+knobs — `reflect_mission`, `observations_mission`, and per-bank `disposition`
+— through the full config cascade (`AgentMemorySchema` in
+`src/config/schema.ts`, cascade merge in `src/config/merge.ts` with per-key
+`disposition` inheritance) and into BOTH the scaffold and reconcile bank-update
+paths in `src/agents/scaffold.ts` via `resolveBankMissionExtras` +
+`updateBankMissions` (`src/memory/hindsight.ts`). `disposition` is no longer
+uniform `{empathy:3, literalism:3, skepticism:3}`: built-in
+`PROFILE_MEMORY_DEFAULTS` differentiate the specialists on a zero-YAML install
+(a `health-coach` leans empathy-high, `coding`/`executive-assistant` lean
+skeptical + literal), and operator config overrides per-key. The mechanism is
+general — any bank can set these fields; the RFC's three named banks
+(`assistant`, `lawgpt`, `ziggy`) are just the first adopters, not a hard-coded
+list. Operator-config-driven (no-self-escalation clean).
 
 **Phase 3 — Directives as the "corrections stick" path. — PARTIAL /
 guidance-only.** The intent is to route user-stated preferences/rules into

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2574,6 +2574,29 @@ function renderHindsightSettingsOverrides(
   if (additionalBanks.length > 0) {
     settings.recallAdditionalBanks = [...additionalBanks];
   }
+  // #2816 tag-filter port — INTENTIONALLY DORMANT (do not wire without an RFC).
+  // The vendored recall.py reads `recallTags` / `recallTagsMatch` /
+  // `recallTagGroups` / `recallAdditionalBankFilters` (upstream 962140eef, and
+  // the env overrides HINDSIGHT_RECALL_TAGS / _TAGS_MATCH / _TAG_GROUPS exist in
+  // vendor/hindsight-memory/scripts/lib/config.py). But switchroom deliberately
+  // does NOT set any of them here, and there is no memory.recall.tags config
+  // surface in src/config/schema.ts — so the filters collapse to their no-op
+  // pass-through default (empty filter = match everything).
+  //
+  // This is a decision, not an oversight. reference/rfcs/hindsight-synthesis-
+  // layers.md frames the port as "a ready-made hook for future recall shaping
+  // (e.g. scoping additional-bank recall to specific tags), currently dormant" —
+  // explicitly future work, NOT part of the Phase 2 bank-specialization goals
+  // (which are mission/disposition-driven, already wired via updateBankMissions
+  // + resolveBankMissionExtras). Wiring a first-class tag surface now would mean
+  // inventing a per-bank tag taxonomy the RFC does not specify. The env-var
+  // escape hatch above remains available to advanced operators in the meantime.
+  //
+  // TODO(#2816): if/when an RFC calls for tag-scoped recall, add a
+  // `memory.recall.tags` (+ match/groups) cascade knob mirroring the
+  // `recallTypes` wiring above and export it through profiles/_base/start.sh.hbs
+  // (HINDSIGHT_RECALL_TAGS), letting the env value win over this scaffold
+  // default — then set settings.recallTags here from the resolved config.
   return JSON.stringify(settings, null, 2) + "\n";
 }
 

--- a/tests/scaffold.recall-observations.test.ts
+++ b/tests/scaffold.recall-observations.test.ts
@@ -72,4 +72,22 @@ describe("hindsight recall overrides — observations + trivial-skip", () => {
     expect(s.recallMaxMemories).toBe(8);
     expect(s.recallMinOverlap).toBe(0.1);
   });
+
+  // #2816 tag-filter port — INTENTIONALLY DORMANT (see the decision comment in
+  // renderHindsightSettingsOverrides + reference/rfcs/hindsight-synthesis-
+  // layers.md). The scaffold must NOT set any recall tag filter: doing so would
+  // silently scope every agent's recall to a per-bank tag taxonomy no RFC
+  // specifies. The vendor defaults (empty recallTags → no-op pass-through) must
+  // survive scaffold untouched. If a future RFC wires memory.recall.tags, delete
+  // this guard and replace it with a positive assertion.
+  it("#2816: leaves the recall tag filters at the vendor no-op defaults (dormant)", () => {
+    const s = settingsAfterInstall();
+    // Either absent (inherit vendor default) or explicitly the no-op empty set,
+    // but never a scaffold-imposed non-empty filter.
+    expect(s.recallTags === undefined || (Array.isArray(s.recallTags) && (s.recallTags as unknown[]).length === 0)).toBe(true);
+    expect(s.recallTagGroups === undefined || s.recallTagGroups === null).toBe(true);
+    expect(s.recallAdditionalBankFilters === undefined ||
+      (typeof s.recallAdditionalBankFilters === "object" &&
+        Object.keys(s.recallAdditionalBankFilters as object).length === 0)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Closes out **Phase 2 (bank specialization)** of the Hindsight synthesis-layers RFC (`reference/rfcs/hindsight-synthesis-layers.md`).

**Important context:** the core Phase 2 threading — `reflect_mission`, `observations_mission`, and per-bank `disposition` through the config cascade (`AgentMemorySchema`, `merge.ts` per-key disposition inheritance), scaffold, and reconcile paths (`resolveBankMissionExtras` + `updateBankMissions`) — **already landed on `main` via #2855** before this branch. `disposition` is no longer the uniform hard-coded `{3,3,3}`: built-in `PROFILE_MEMORY_DEFAULTS` differentiate specialists on a zero-YAML install, operator config overrides per-key, and the mechanism is general (any bank can set these fields; the named banks are just first adopters).

This PR therefore resolves the phase's **remaining open item — the dormant #2816 recall tag-filter port** — and syncs the RFC status.

## Decision: #2816 tag-filter stays INTENTIONALLY DORMANT

The vendored `recall.py` reads `recallTags` / `recallTagsMatch` / `recallTagGroups` / `recallAdditionalBankFilters` (upstream `962140eef`), with env overrides in `lib/config.py` — but no scaffold override sets any of them, so they collapse to a no-op pass-through.

Per the RFC, that port is framed as *"a ready-made hook for future recall shaping … currently dormant"* — explicitly future work, **orthogonal** to Phase 2's mission/disposition specialization. Wiring a first-class `memory.recall.tags` surface now would mean inventing a per-bank tag taxonomy the RFC does not specify (speculative generality). So the decision is to **document it, not wire it**:

- `renderHindsightSettingsOverrides` (`src/agents/scaffold.ts`) now carries a decision comment + `TODO(#2816)` spelling out exactly how to wire it later (mirror the `recallTypes` cascade + a `HINDSIGHT_RECALL_TAGS` `start.sh` export, env wins over the scaffold default).
- The env-var escape hatch (`HINDSIGHT_RECALL_TAGS` / `_TAGS_MATCH` / `_TAG_GROUPS`) stays available to advanced operators in the meantime.

## Changes

- **`src/agents/scaffold.ts`** — decision/`TODO(#2816)` comment documenting the intentionally-dormant tag-filter path (no behavior change).
- **`tests/scaffold.recall-observations.test.ts`** — regression test locking the dormancy in: scaffold must leave `recallTags` / `recallTagGroups` / `recallAdditionalBankFilters` at their vendor no-op defaults, so no agent's recall is silently tag-scoped.
- **`reference/rfcs/hindsight-synthesis-layers.md`** — Phase 2 marked **SHIPPED (#2855)** with the actual wiring described; the #2816 note records the intentional-dormancy decision.

## Test

```
vitest run tests/scaffold.recall-observations.test.ts tests/memory.bank-missions.test.ts
  → 2 files, 29 tests passed
vitest run tests/scaffold.recall-additional-banks.test.ts tests/scaffold.recall-optout-cascade.test.ts tests/scaffold.directive-capture-nudge.test.ts
  → 3 files, 16 tests passed
tsc --noEmit  → clean (exit 0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)