### PR TITLE
feat(memory): consolidation-driven remembered/updated surface (hindsight Phase 4)

### DIFF
--- a/docs/telegram-plugin.md
+++ b/docs/telegram-plugin.md
@@ -81,6 +81,23 @@ Detection is a deterministic tool-call observation (no model call, no polling). 
 
 The surface is **on by default** (kill-switch: `SWITCHROOM_MEMORY_LEGIBILITY=0`). To disable it per-agent, set `SWITCHROOM_MEMORY_LEGIBILITY=0` in the agent's gateway environment.
 
+#### Consolidation-driven "updated what I know" (opt-in)
+
+The store/forget lines above are driven by the **foreground** session's own tool calls. The **background** consolidation engine — which distils new durable observations and supersedes stale ones between turns — is invisible to that path. When hindsight emits a `consolidation.completed` webhook, the gateway can surface a terse companion line for a *genuine* store/correct:
+
+```
+🧠 updated what I know about "your deploy preferences"
+🧠 revised what I know about "the old runbook"
+```
+
+This is **off by default** and opt-in per agent: set `SWITCHROOM_CONSOLIDATION_LEGIBILITY=1` in the gateway environment. It is gated more tightly than the tool-observation path because it is fed by an unbounded background engine:
+
+- **Material-only** — a line surfaces *only* when a consolidation actually stored or corrected a durable memory; the overwhelmingly common no-op consolidation surfaces nothing.
+- **Rate-limited** — at most one line per agent per 10 minutes, and an identical "updated about X" line is suppressed for an hour, so a burst of material consolidations collapses to a single line.
+- **Never a wake** — the webhook is recorded for audit and surfaced as a discrete status message (notifications suppressed); it never injects a model turn.
+
+The webhook flows through the existing peercred-gated ingest socket (`webhook_via_gateway`); the pinned hindsight image does not yet emit `consolidation.completed`, so this consumer is dormant until that upstream event exists — which is why it ships off by default.
+
 ### Message history
 
 A local SQLite database records every inbound and outbound message. After a Claude Code restart, the agent can call `get_recent_messages` to recover context instead of asking "what were we doing?". History survives process restarts and session resets.
@@ -216,3 +233,4 @@ The switchroom fork reads additional env vars from `start.sh`:
 | `SWITCHROOM_CONFIG` | Auto-set by scaffold | Path to switchroom.yaml for config resolution |
 | `SWITCHROOM_WORKER_ACTIVITY_FEED` | Gateway env (kill-switch) | On by default; `0` disables the background worker-activity feed. See "Background worker activity feed" above |
 | `SWITCHROOM_MEMORY_LEGIBILITY` | Gateway env (kill-switch) | On by default; `0` disables the sparse "📌 remembered / ✂️ forgot" memory surface. See "Chat-legible memory" above |
+| `SWITCHROOM_CONSOLIDATION_LEGIBILITY` | Gateway env (opt-in) | Off by default; `1`/`true`/`on`/`yes` enables the rate-limited "🧠 updated what I know about Y" line driven by the `consolidation.completed` webhook. See "Consolidation-driven" above |

--- a/src/web/webhook-gateway-record.test.ts
+++ b/src/web/webhook-gateway-record.test.ts
@@ -392,4 +392,111 @@ describe('recordWebhookEvent', () => {
     const result = recordWebhookEvent(baseRecord(), deps)
     expect(result.status).toBe('error')
   })
+
+  // ── Consolidation-legibility (hindsight Phase 4) ────────────────────────
+  const consolidationConfig: RecordDeps['loadConfig'] = () =>
+    ({
+      telegram: { forum_chat_id: '-100123' },
+      agents: { reggie: { topic_id: 42, channels: { telegram: {} } } },
+    }) as unknown as ReturnType<NonNullable<RecordDeps['loadConfig']>>
+
+  function consolidationRec(
+    payload: Record<string, unknown> = { stored: 1, subject: 'x' },
+  ): WebhookGatewayRecord {
+    return baseRecord({
+      source: 'hindsight',
+      event_type: 'consolidation.completed',
+      rendered_text: 'consolidation done',
+      delivery_id: undefined,
+      payload,
+    })
+  }
+
+  it('delegates a consolidation.completed event to onConsolidation with the resolved target', () => {
+    const { resolveAgentDir, root } = makeTmpResolveAgentDir()
+    const seen: Array<{ rec: WebhookGatewayRecord; target: { chatId: string; threadId?: number } }> =
+      []
+    const injected: unknown[] = []
+    const deps: RecordDeps = {
+      resolveAgentDir,
+      dedupStore: makeDedupStore(),
+      log: () => {},
+      loadConfig: consolidationConfig,
+      inject: () => {
+        injected.push(true)
+        return true
+      },
+      onConsolidation: (rec, target) => seen.push({ rec, target }),
+    }
+
+    const result = recordWebhookEvent(consolidationRec(), deps)
+
+    expect(result.status).toBe('ok')
+    // Never injected as a model turn — it is a discrete status line.
+    expect(injected).toHaveLength(0)
+    expect(result.dispatched).toBeUndefined()
+    expect(seen).toHaveLength(1)
+    expect(seen[0].target).toEqual({ chatId: '-100123', threadId: 42 })
+    expect(seen[0].rec.payload).toEqual({ stored: 1, subject: 'x' })
+
+    // Still recorded to the audit log regardless of surfacing.
+    const logPath = join(root, 'reggie', 'telegram', 'webhook-events.jsonl')
+    const lines = readFileSync(logPath, 'utf-8').split('\n').filter(Boolean)
+    expect(lines).toHaveLength(1)
+    expect(JSON.parse(lines[0]).event_type).toBe('consolidation.completed')
+  })
+
+  it('skips onConsolidation (but still records) when there is no chat target', () => {
+    const { resolveAgentDir, root } = makeTmpResolveAgentDir()
+    const seen: unknown[] = []
+    const deps: RecordDeps = {
+      resolveAgentDir,
+      dedupStore: makeDedupStore(),
+      log: () => {},
+      loadConfig: () =>
+        ({ agents: { reggie: { channels: { telegram: {} } } } }) as unknown as ReturnType<
+          NonNullable<RecordDeps['loadConfig']>
+        >,
+      onConsolidation: () => seen.push(true),
+    }
+
+    const result = recordWebhookEvent(consolidationRec(), deps)
+    expect(result.status).toBe('ok')
+    expect(seen).toHaveLength(0)
+    const logPath = join(root, 'reggie', 'telegram', 'webhook-events.jsonl')
+    expect(readFileSync(logPath, 'utf-8').split('\n').filter(Boolean)).toHaveLength(1)
+  })
+
+  it('records the consolidation event even when onConsolidation throws', () => {
+    const { resolveAgentDir, root } = makeTmpResolveAgentDir()
+    const deps: RecordDeps = {
+      resolveAgentDir,
+      dedupStore: makeDedupStore(),
+      log: () => {},
+      loadConfig: consolidationConfig,
+      onConsolidation: () => {
+        throw new Error('surface boom')
+      },
+    }
+
+    const result = recordWebhookEvent(consolidationRec(), deps)
+    expect(result.status).toBe('ok')
+    const logPath = join(root, 'reggie', 'telegram', 'webhook-events.jsonl')
+    expect(readFileSync(logPath, 'utf-8').split('\n').filter(Boolean)).toHaveLength(1)
+  })
+
+  it('is a no-op sink when onConsolidation is not provided (event still recorded)', () => {
+    const { resolveAgentDir, root } = makeTmpResolveAgentDir()
+    const deps: RecordDeps = {
+      resolveAgentDir,
+      dedupStore: makeDedupStore(),
+      log: () => {},
+      loadConfig: consolidationConfig,
+    }
+
+    const result = recordWebhookEvent(consolidationRec(), deps)
+    expect(result.status).toBe('ok')
+    const logPath = join(root, 'reggie', 'telegram', 'webhook-events.jsonl')
+    expect(readFileSync(logPath, 'utf-8').split('\n').filter(Boolean)).toHaveLength(1)
+  })
 })

--- a/src/web/webhook-gateway-record.ts
+++ b/src/web/webhook-gateway-record.ts
@@ -93,7 +93,23 @@ export interface RecordDeps {
    * land without a gateway restart (webhook events are infrequent).
    */
   loadConfig?: () => ReturnType<typeof loadSwitchroomConfig>
+  /**
+   * Consolidation-legibility sink (hindsight Phase 4). Called for a
+   * verified `hindsight` / `consolidation.completed` event with the agent's
+   * resolved channel target. The gateway owns the enablement gate, the
+   * materiality check, the rate limit, and the terse-line `sendMessage`;
+   * this handler stays send-free. Absent (or no chat target) → the event is
+   * still recorded above for audit, just not surfaced.
+   */
+  onConsolidation?: (
+    rec: WebhookGatewayRecord,
+    target: { chatId: string; threadId?: number },
+  ) => void
 }
+
+/** Wire source + event that drives the consolidation-legibility surface. */
+export const HINDSIGHT_WEBHOOK_SOURCE = 'hindsight'
+export const CONSOLIDATION_COMPLETED_EVENT = 'consolidation.completed'
 
 /**
  * Persist a forwarded webhook event and fire matching dispatch rules.
@@ -152,6 +168,40 @@ export function recordWebhookEvent(
   log(
     `webhook-gateway: agent='${agent}' source='${rec.source}' event='${rec.event_type}' recorded ts=${now}\n`,
   )
+
+  // ── Consolidation-legibility (hindsight Phase 4) ──────────────────────────
+  // A background `consolidation.completed` webhook. The event is already
+  // recorded above for audit; here we delegate to the gateway-supplied sink
+  // to (maybe) surface a terse "🧠 updated what I know about Y" line. It is
+  // NEVER injected as a model turn — this is a discrete status line, not a
+  // wake. Return without falling through to the dispatch-rule matcher.
+  if (
+    rec.source === HINDSIGHT_WEBHOOK_SOURCE &&
+    rec.event_type === CONSOLIDATION_COMPLETED_EVENT
+  ) {
+    try {
+      if (deps.onConsolidation) {
+        const config = (deps.loadConfig ?? loadSwitchroomConfig)()
+        const target = resolveChannelTarget(config, agent)
+        if (target) {
+          deps.onConsolidation(rec, {
+            chatId: target.chatId,
+            ...(target.threadId !== undefined ? { threadId: target.threadId } : {}),
+          })
+        } else {
+          log(
+            `consolidation-legibility: agent='${agent}' skipped — no chat target ` +
+              `(forum_chat_id / chat_id unset)\n`,
+          )
+        }
+      }
+    } catch (err) {
+      log(
+        `consolidation-legibility: agent='${agent}' surface error (event recorded): ${(err as Error).message}\n`,
+      )
+    }
+    return { status: 'ok', ts: now }
+  }
 
   // ── Linear AgentSessionEvent (#2298) ──────────────────────────────────────
   // A first-class Linear agent session (an @mention or a delegation) ALWAYS

--- a/telegram-plugin/consolidation-legibility.ts
+++ b/telegram-plugin/consolidation-legibility.ts
@@ -1,0 +1,279 @@
+/**
+ * Consolidation-driven chat-legible memory surface — hindsight Phase 4,
+ * the "updated what I know about Y" side (RFC
+ * `reference/rfcs/hindsight-synthesis-layers.md`, Phase 4).
+ *
+ * #2858 shipped the STORE/CORRECT side driven by deterministic tool-call
+ * observation of the interactive session (`create_directive` →
+ * "📌 remembered", `invalidate_memory` / demote → "✂️ forgot"). That path
+ * sees only what the *foreground* agent explicitly does with memory tools.
+ *
+ * The RFC also names the poll-free UPDATE side: when the *background*
+ * consolidation engine actually distils new durable observations (or
+ * supersedes stale ones) it emits a `consolidation.completed` webhook, and
+ * that is the honest signal for a terse "🧠 updated what I know about Y"
+ * line. This module is the consumer for that webhook.
+ *
+ * Two hard constraints from the RFC and the `remember-across-sessions` job
+ * shape every choice here:
+ *
+ *   1. **Sparse + material-only.** Consolidation fires on *every* retain
+ *      (`retainEveryNTurns=1`), so the raw webhook stream is per-turn. A
+ *      line per fire would BE the "regurgitating old facts unprompted just
+ *      to prove it remembered" anti-pattern the job forbids. So we surface
+ *      a line ONLY when a consolidation genuinely *stored* or *corrected* a
+ *      durable memory (`detectConsolidationEvent` returns null otherwise),
+ *      AND we rate-limit hard (`ConsolidationRateLimiter`) so bursts of
+ *      material consolidations collapse to at most one line per interval.
+ *
+ *   2. **OFF by default.** Unlike the #2858 tool-observation path (default
+ *      ON — it fires on rare, unambiguous, user-initiated tool calls), this
+ *      path is driven by an unbounded background engine and by a webhook the
+ *      pinned hindsight image does not yet emit. It stays OFF until an
+ *      operator opts in (`SWITCHROOM_CONSOLIDATION_LEGIBILITY=1`), matching
+ *      the RFC's "sparse, not per-turn … clearly gated" language.
+ *
+ * No model call, no polling, no `claude -p` — this is a pure consumer of a
+ * webhook the receiver already verified + forwarded (claude-native clean).
+ */
+
+import { stripMarkdown, truncate } from './card-format.js'
+
+/** The hindsight webhook source + event this module consumes. */
+export const HINDSIGHT_WEBHOOK_SOURCE = 'hindsight'
+export const CONSOLIDATION_COMPLETED_EVENT = 'consolidation.completed'
+
+/**
+ * OPT-IN — the operator must set SWITCHROOM_CONSOLIDATION_LEGIBILITY to a
+ * truthy value ('1' / 'true' / 'on' / 'yes') to enable. Default OFF: the
+ * literal opposite of the #2858 tool-observation path's default-ON switch,
+ * deliberately, because this side is driven by an unbounded background
+ * engine (RFC: "sparse, not per-turn"; "clearly gated").
+ */
+export function isConsolidationLegibilityEnabled(envVal: string | undefined): boolean {
+  if (envVal == null) return false
+  const v = envVal.trim().toLowerCase()
+  return v === '1' || v === 'true' || v === 'on' || v === 'yes'
+}
+
+export type ConsolidationLegibilityKind = 'updated' | 'revised'
+
+export interface ConsolidationLegibilityEvent {
+  /** `updated` — new durable observation(s) distilled; `revised` — an
+   *  existing memory was superseded/invalidated by consolidation. `revised`
+   *  is the higher-signal framing and wins when both happened. */
+  kind: ConsolidationLegibilityKind
+  /** Best-effort human subject ("your deploy preferences"). May be empty —
+   *  the render then falls back to a bare "updated what I know about you".
+   *  Raw (unescaped); `renderConsolidationLine` cleans it. */
+  topic: string
+}
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v : ''
+}
+
+/** Coerce a numeric-ish field (number, or a numeric string) to a count ≥ 0. */
+function asCount(v: unknown): number {
+  if (typeof v === 'number' && Number.isFinite(v)) return v > 0 ? Math.floor(v) : 0
+  if (typeof v === 'string') {
+    const n = Number(v)
+    return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0
+  }
+  // An array field (e.g. `observations: [...]`) counts by length.
+  if (Array.isArray(v)) return v.length
+  return 0
+}
+
+/** First non-empty count across a set of tolerant field aliases. */
+function firstCount(payload: Record<string, unknown>, keys: string[]): number {
+  for (const k of keys) {
+    const c = asCount(payload[k])
+    if (c > 0) return c
+  }
+  return 0
+}
+
+/**
+ * Best-effort human subject of the consolidation. The webhook is RFC-only
+ * (the pinned image does not emit it yet), so tolerate a range of shapes:
+ * an explicit `subject` / `topic`, the first entry of `subjects`/`entities`,
+ * or the `subject`/`statement` of the first observation. Anything opaque
+ * (a bank_id, a uuid) is left to the empty fallback.
+ */
+function extractTopic(payload: Record<string, unknown>): string {
+  const direct = asString(payload.subject).trim() || asString(payload.topic).trim()
+  if (direct) return direct
+
+  for (const key of ['subjects', 'entities', 'topics']) {
+    const arr = payload[key]
+    if (Array.isArray(arr)) {
+      for (const el of arr) {
+        if (typeof el === 'string' && el.trim()) return el.trim()
+        if (el && typeof el === 'object') {
+          const name = asString((el as Record<string, unknown>).name).trim()
+          if (name) return name
+        }
+      }
+    }
+  }
+
+  const obs = payload.observations
+  if (Array.isArray(obs) && obs.length > 0 && obs[0] && typeof obs[0] === 'object') {
+    const o = obs[0] as Record<string, unknown>
+    const sub = asString(o.subject).trim()
+    if (sub) return sub
+    const stmt = asString(o.statement).trim()
+    if (stmt) return stmt
+  }
+  return ''
+}
+
+/**
+ * Decide whether a `consolidation.completed` payload represents a MATERIAL
+ * durable change — a genuine store or correct — or null if it is a routine
+ * no-op consolidation (the common case, which must surface NO line).
+ *
+ * Pure, no I/O. Tolerant of the RFC-only payload's exact field names.
+ */
+export function detectConsolidationEvent(
+  payload: Record<string, unknown> | undefined,
+): ConsolidationLegibilityEvent | null {
+  if (payload == null || typeof payload !== 'object') return null
+
+  const stored = firstCount(payload, [
+    'stored',
+    'created',
+    'added',
+    'new_observations',
+    'observations_created',
+    'observations',
+  ])
+  const corrected = firstCount(payload, [
+    'corrected',
+    'invalidated',
+    'superseded',
+    'removed',
+    'demoted',
+  ])
+
+  // Immaterial: nothing durable stored, nothing corrected. This is the
+  // overwhelming majority of consolidation fires — surface nothing.
+  if (stored === 0 && corrected === 0) return null
+
+  // A correction ("what I believed changed") is higher-signal than another
+  // stored fact, so it wins the framing when both happened.
+  const kind: ConsolidationLegibilityKind = corrected > 0 ? 'revised' : 'updated'
+  return { kind, topic: extractTopic(payload) }
+}
+
+/** HTML-escape for parse_mode:'HTML' (escape the 3 entity-significant chars). */
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/** Max chars of subject shown on the one-liner. */
+const TOPIC_MAX = 120
+
+/**
+ * Render the terse one-line surface (Telegram HTML). Sent as a real
+ * `sendMessage` with notifications suppressed — a status surface, never a
+ * device ping.
+ *
+ *   🧠 <i>updated what I know</i> about "your deploy preferences"
+ *   🧠 <i>revised what I know</i> about "the old runbook"
+ *   🧠 <i>updated what I know about you.</i>        (no legible subject)
+ */
+export function renderConsolidationLine(ev: ConsolidationLegibilityEvent): string {
+  const verb = ev.kind === 'revised' ? 'revised' : 'updated'
+  const clean = truncate(stripMarkdown(ev.topic).replace(/\s+/g, ' ').trim(), TOPIC_MAX)
+  if (clean.length === 0) return `🧠 <i>${verb} what I know about you.</i>`
+  return `🧠 <i>${verb} what I know</i> about "${escapeHtml(clean)}"`
+}
+
+export interface ConsolidationRateLimiterOptions {
+  /** Minimum gap between ANY two surfaced lines for one agent. Collapses a
+   *  burst of material consolidations to at most one line per window.
+   *  Default 10 min. */
+  minIntervalMs?: number
+  /** Suppress an IDENTICAL line (same kind+topic) for this long even if the
+   *  min-interval has passed — stops "updated about X" repeating as the
+   *  engine re-derives the same observation. Default 1 hour. */
+  dedupWindowMs?: number
+  /** Clock override (tests). */
+  now?: () => number
+}
+
+const DEFAULT_MIN_INTERVAL_MS = 10 * 60 * 1000
+const DEFAULT_DEDUP_WINDOW_MS = 60 * 60 * 1000
+/** Cap on retained per-signature timestamps so the map can't grow unbounded
+ *  under a long-lived gateway. */
+const MAX_TRACKED_SIGNATURES = 512
+
+/**
+ * Per-agent rate limiter for the consolidation surface. Two independent
+ * gates, both must pass:
+ *
+ *   - **min-interval** — at most one line per agent per `minIntervalMs`,
+ *     regardless of subject. This is the anti-spam floor.
+ *   - **dedup** — the same (kind+topic) signature is suppressed for
+ *     `dedupWindowMs` even across the interval boundary.
+ *
+ * Stateful + long-lived: the gateway constructs ONE instance and reuses it
+ * across events. Deterministic under an injected clock (tests).
+ */
+export class ConsolidationRateLimiter {
+  private readonly minIntervalMs: number
+  private readonly dedupWindowMs: number
+  private readonly clock: () => number
+  private readonly lastEmit = new Map<string, number>()
+  private readonly recentSig = new Map<string, number>()
+
+  constructor(opts: ConsolidationRateLimiterOptions = {}) {
+    this.minIntervalMs = opts.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS
+    this.dedupWindowMs = opts.dedupWindowMs ?? DEFAULT_DEDUP_WINDOW_MS
+    this.clock = opts.now ?? Date.now
+  }
+
+  /**
+   * True when a line for (`agent`, `signature`) may be surfaced now, and
+   * records the emit. False (and records nothing) when either gate blocks.
+   * `signature` should be stable for identical lines (e.g. `kind:topic`).
+   */
+  allow(agent: string, signature: string, now?: number): boolean {
+    const t = now ?? this.clock()
+
+    const last = this.lastEmit.get(agent)
+    if (last !== undefined && t - last < this.minIntervalMs) return false
+
+    const sigKey = `${agent}\0${signature}`
+    const seen = this.recentSig.get(sigKey)
+    if (seen !== undefined && t - seen < this.dedupWindowMs) return false
+
+    this.lastEmit.set(agent, t)
+    this.recentSig.set(sigKey, t)
+    this.pruneSignatures(t)
+    return true
+  }
+
+  /** Drop signature entries older than the dedup window; hard-cap the map. */
+  private pruneSignatures(now: number): void {
+    for (const [k, ts] of this.recentSig) {
+      if (now - ts >= this.dedupWindowMs) this.recentSig.delete(k)
+    }
+    if (this.recentSig.size > MAX_TRACKED_SIGNATURES) {
+      // Evict oldest until back under the cap (insertion order ≈ age).
+      const excess = this.recentSig.size - MAX_TRACKED_SIGNATURES
+      let i = 0
+      for (const k of this.recentSig.keys()) {
+        if (i++ >= excess) break
+        this.recentSig.delete(k)
+      }
+    }
+  }
+}
+
+/** Stable dedup signature for an event (kind + normalised topic). */
+export function consolidationSignature(ev: ConsolidationLegibilityEvent): string {
+  return `${ev.kind}:${ev.topic.replace(/\s+/g, ' ').trim().toLowerCase()}`
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -12687,7 +12687,14 @@ function surfaceConsolidationLegibility(
   const event = detectConsolidationEvent(rec.payload)
   if (event == null) return // routine no-op consolidation — surface nothing
   const agent = rec.agent
-  if (!consolidationRateLimiter.allow(agent, consolidationSignature(event), rec.ts || Date.now())) {
+  // Rate-limiter clock MUST be wall-clock (Date.now()), never rec.ts: rec.ts
+  // can be derived from the (attacker-influenceable) webhook payload, and a
+  // spoofed far-past / far-future timestamp would poison the per-agent
+  // min-interval gate — either permanently opening it (stale ts always older
+  // than the window) or jamming it shut. The limiter only cares about "how
+  // long since the last surface on THIS gateway", which is a local wall-clock
+  // question.
+  if (!consolidationRateLimiter.allow(agent, consolidationSignature(event), Date.now())) {
     process.stderr.write(
       `telegram gateway: consolidation-legibility ${event.kind} rate-limited ` +
         `agent=${agent} topic='${event.topic}'\n`,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -98,6 +98,14 @@ import {
   isMemoryLegibilityEnabled,
   renderMemoryLegibilityLine,
 } from '../memory-legibility.js'
+import {
+  ConsolidationRateLimiter,
+  consolidationSignature,
+  detectConsolidationEvent,
+  isConsolidationLegibilityEnabled,
+  renderConsolidationLine,
+} from '../consolidation-legibility.js'
+import type { WebhookGatewayRecord } from '../../src/web/webhook-gateway-record.js'
 import { reconcilePin, type PinBotApi } from '../status-pin-driver.js'
 import type { PinState, DesiredPin } from '../status-pin.js'
 import { decidePinAction } from '../status-pin.js'
@@ -6412,6 +6420,19 @@ const SILENCE_LIVENESS_PRODUCTION = process.env.SWITCHROOM_SILENCE_LIVENESS_PROD
 // on ordinary recall or routine consolidation. Default ON;
 // SWITCHROOM_MEMORY_LEGIBILITY=0 disables it.
 const MEMORY_LEGIBILITY_ENABLED = isMemoryLegibilityEnabled(process.env.SWITCHROOM_MEMORY_LEGIBILITY)
+// Consolidation-driven legibility (#2849 follow-up, hindsight Phase 4). The
+// "updated what I know about Y" side, driven by the background
+// `consolidation.completed` webhook rather than a foreground tool call.
+// OPT-IN (default OFF), unlike MEMORY_LEGIBILITY_ENABLED above: this path is
+// fed by an unbounded background engine + a webhook the pinned hindsight image
+// does not yet emit, so the RFC keeps it "sparse … clearly gated".
+const CONSOLIDATION_LEGIBILITY_ENABLED = isConsolidationLegibilityEnabled(
+  process.env.SWITCHROOM_CONSOLIDATION_LEGIBILITY,
+)
+// One long-lived limiter across all consolidation events — collapses a burst
+// of material consolidations to at most one line per interval, and suppresses
+// an identical "updated about X" line inside the dedup window.
+const consolidationRateLimiter = new ConsolidationRateLimiter()
 
 /**
  * Feed-survival predicate — the single source of truth for "is this turn
@@ -8891,6 +8912,7 @@ const ipcServer: IpcServer = createIpcServer({
           {
             inject: webhookInject,
             log: (s) => process.stderr.write(`telegram gateway: ${s}`),
+            onConsolidation: surfaceConsolidationLegibility,
           },
         ),
     })
@@ -12640,6 +12662,58 @@ function surfaceMemoryLegibility(
   ).catch((err) => {
     process.stderr.write(
       `telegram gateway: memory-legibility send failed: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`,
+    )
+  })
+}
+
+/**
+ * #2849 hindsight Phase 4 (follow-up) — consolidation-driven legibility.
+ *
+ * The gateway-side sink for a verified `hindsight` / `consolidation.completed`
+ * webhook. `recordWebhookEvent` has already logged the event for audit and
+ * resolved the agent's channel target; this decides whether it is MATERIAL
+ * (a genuine store/correct — else nothing), rate-limits it hard, and — only
+ * if it clears both gates — sends ONE terse "🧠 updated what I know about Y"
+ * real message with notifications suppressed. Never injects a model turn.
+ * OPT-IN via SWITCHROOM_CONSOLIDATION_LEGIBILITY.
+ */
+function surfaceConsolidationLegibility(
+  rec: WebhookGatewayRecord,
+  target: { chatId: string; threadId?: number },
+): void {
+  if (!CONSOLIDATION_LEGIBILITY_ENABLED) return
+  const event = detectConsolidationEvent(rec.payload)
+  if (event == null) return // routine no-op consolidation — surface nothing
+  const agent = rec.agent
+  if (!consolidationRateLimiter.allow(agent, consolidationSignature(event), rec.ts || Date.now())) {
+    process.stderr.write(
+      `telegram gateway: consolidation-legibility ${event.kind} rate-limited ` +
+        `agent=${agent} topic='${event.topic}'\n`,
+    )
+    return
+  }
+  const chatId = target.chatId
+  const threadId = target.threadId
+  const line = renderConsolidationLine(event)
+  process.stderr.write(
+    `telegram gateway: consolidation-legibility ${event.kind} chat=${chatId} ` +
+      `thread=${threadId ?? '-'} agent=${agent}\n`,
+  )
+  void retryWithThreadFallback(
+    robustApiCall,
+    (tid) =>
+      bot.api.sendMessage(chatId, line, {
+        parse_mode: 'HTML',
+        // Status surface, not the user's answer — never ping the device.
+        disable_notification: true,
+        ...(tid != null ? { message_thread_id: tid } : {}),
+      }),
+    { threadId, chat_id: chatId, verb: 'consolidation-legibility.sendMessage' },
+  ).catch((err) => {
+    process.stderr.write(
+      `telegram gateway: consolidation-legibility send failed: ${
         err instanceof Error ? err.message : String(err)
       }\n`,
     )

--- a/telegram-plugin/tests/consolidation-legibility.test.ts
+++ b/telegram-plugin/tests/consolidation-legibility.test.ts
@@ -175,6 +175,39 @@ describe('ConsolidationRateLimiter — sparse / non-spammy', () => {
     expect(rl.allow('klanker', 'updated:a', 700_000)).toBe(false) // dedup window
     expect(rl.allow('klanker', 'updated:b', 700_000)).toBe(true) // new topic past interval
   })
+
+  // Regression: the gateway caller (surfaceConsolidationLegibility) MUST pass
+  // Date.now() as the clock, never a payload-derived rec.ts. This test proves
+  // WHY: a spoofed/stale timestamp from the webhook payload poisons the
+  // per-agent min-interval gate. A far-FUTURE payload ts leaves the stored
+  // last-surface time in the future, so a genuine later wall-clock surface
+  // reads as "in the past" and the gate stays jammed shut; a far-PAST ts makes
+  // every subsequent surface look older than the window and the gate never
+  // engages (spam). Feeding wall-clock avoids both.
+  it('a payload-derived far-future timestamp would jam the interval gate shut', () => {
+    const rl = new ConsolidationRateLimiter({ minIntervalMs: 600_000, dedupWindowMs: 0 })
+    const wallNow = 1_000_000
+    const spoofedFuture = wallNow + 10 * 365 * 24 * 3_600_000 // ~10y ahead
+    // First surface stamped with the attacker's future ts.
+    expect(rl.allow('klanker', 'updated:a', spoofedFuture)).toBe(true)
+    // A genuine later surface (real wall-clock) is now "before" the stored
+    // last time → interval never elapses → legitimate surface suppressed.
+    expect(rl.allow('klanker', 'updated:b', wallNow + 700_000)).toBe(false)
+  })
+
+  it('a payload-derived timestamp lets a spoofer defeat the interval gate (spam)', () => {
+    // Two events arrive ~1ms apart in REALITY, but each carries a payload ts
+    // inflated to appear far apart. Keyed on payload ts, the gate sees them as
+    // past the interval and lets BOTH through — spam.
+    const rl = new ConsolidationRateLimiter({ minIntervalMs: 600_000, dedupWindowMs: 0 })
+    expect(rl.allow('klanker', 'updated:a', 0)).toBe(true)
+    expect(rl.allow('klanker', 'updated:b', 700_000)).toBe(true) // spoofed far-apart ts → not blocked
+    // Wall-clock (what the fix passes) blocks the same two events 1ms apart.
+    const rl2 = new ConsolidationRateLimiter({ minIntervalMs: 600_000, dedupWindowMs: 0 })
+    const wallNow = 1_000_000_000
+    expect(rl2.allow('klanker', 'updated:a', wallNow)).toBe(true)
+    expect(rl2.allow('klanker', 'updated:b', wallNow + 1)).toBe(false)
+  })
 })
 
 describe('consolidationSignature — stable dedup key', () => {

--- a/telegram-plugin/tests/consolidation-legibility.test.ts
+++ b/telegram-plugin/tests/consolidation-legibility.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isConsolidationLegibilityEnabled,
+  detectConsolidationEvent,
+  renderConsolidationLine,
+  consolidationSignature,
+  ConsolidationRateLimiter,
+  HINDSIGHT_WEBHOOK_SOURCE,
+  CONSOLIDATION_COMPLETED_EVENT,
+} from '../consolidation-legibility.js'
+
+describe('isConsolidationLegibilityEnabled — OPT-IN (default OFF)', () => {
+  it('is OFF when unset (opposite of the default-ON tool-observation path)', () => {
+    expect(isConsolidationLegibilityEnabled(undefined)).toBe(false)
+  })
+  it('is OFF for the empty string and for "0"/"false"/"off"', () => {
+    expect(isConsolidationLegibilityEnabled('')).toBe(false)
+    expect(isConsolidationLegibilityEnabled('0')).toBe(false)
+    expect(isConsolidationLegibilityEnabled('false')).toBe(false)
+    expect(isConsolidationLegibilityEnabled('off')).toBe(false)
+    expect(isConsolidationLegibilityEnabled('no')).toBe(false)
+  })
+  it('is ON only for an explicit truthy opt-in', () => {
+    expect(isConsolidationLegibilityEnabled('1')).toBe(true)
+    expect(isConsolidationLegibilityEnabled('true')).toBe(true)
+    expect(isConsolidationLegibilityEnabled('on')).toBe(true)
+    expect(isConsolidationLegibilityEnabled('yes')).toBe(true)
+    expect(isConsolidationLegibilityEnabled(' TRUE ')).toBe(true)
+  })
+})
+
+describe('wire constants', () => {
+  it('names the hindsight consolidation.completed source/event', () => {
+    expect(HINDSIGHT_WEBHOOK_SOURCE).toBe('hindsight')
+    expect(CONSOLIDATION_COMPLETED_EVENT).toBe('consolidation.completed')
+  })
+})
+
+describe('detectConsolidationEvent — MATERIAL-only (sparse)', () => {
+  it('returns null on a routine no-op consolidation (nothing stored/corrected)', () => {
+    expect(detectConsolidationEvent({ stored: 0, corrected: 0 })).toBeNull()
+    expect(detectConsolidationEvent({})).toBeNull()
+    expect(detectConsolidationEvent(undefined)).toBeNull()
+  })
+
+  it('classifies a pure store as "updated"', () => {
+    const ev = detectConsolidationEvent({ stored: 2, subject: 'your deploy preferences' })
+    expect(ev).toEqual({ kind: 'updated', topic: 'your deploy preferences' })
+  })
+
+  it('classifies any correction as "revised" (higher signal), even alongside stores', () => {
+    expect(detectConsolidationEvent({ corrected: 1, subject: 'old runbook' })).toEqual({
+      kind: 'revised',
+      topic: 'old runbook',
+    })
+    expect(detectConsolidationEvent({ stored: 3, corrected: 1, subject: 'X' })).toEqual({
+      kind: 'revised',
+      topic: 'X',
+    })
+  })
+
+  it('tolerates field aliases (created/added/new_observations; invalidated/superseded)', () => {
+    expect(detectConsolidationEvent({ created: 1, topic: 'a' })?.kind).toBe('updated')
+    expect(detectConsolidationEvent({ new_observations: 5, topic: 'a' })?.kind).toBe('updated')
+    expect(detectConsolidationEvent({ invalidated: 2, topic: 'a' })?.kind).toBe('revised')
+    expect(detectConsolidationEvent({ superseded: 1, topic: 'a' })?.kind).toBe('revised')
+  })
+
+  it('counts an observations array by length as a store', () => {
+    const ev = detectConsolidationEvent({
+      observations: [{ statement: 'User prefers TS', subject: 'coding style' }],
+    })
+    expect(ev).toEqual({ kind: 'updated', topic: 'coding style' })
+  })
+
+  it('accepts numeric-string counts', () => {
+    expect(detectConsolidationEvent({ stored: '2', subject: 'x' })?.kind).toBe('updated')
+  })
+
+  it('derives topic from subjects[]/entities[] arrays when no direct subject', () => {
+    expect(detectConsolidationEvent({ stored: 1, subjects: ['travel plans'] })?.topic).toBe(
+      'travel plans',
+    )
+    expect(
+      detectConsolidationEvent({ stored: 1, entities: [{ name: 'Acme Corp' }] })?.topic,
+    ).toBe('Acme Corp')
+  })
+
+  it('falls back to the first observation statement when no subject', () => {
+    const ev = detectConsolidationEvent({
+      observations: [{ statement: 'The user lives in Sydney' }],
+    })
+    expect(ev?.topic).toBe('The user lives in Sydney')
+  })
+
+  it('leaves topic empty when the payload carries no legible subject', () => {
+    expect(detectConsolidationEvent({ stored: 1, bank_id: 'agent-x' })?.topic).toBe('')
+  })
+})
+
+describe('renderConsolidationLine — terse, HTML, notification-free surface', () => {
+  it('renders the updated line with a subject', () => {
+    expect(renderConsolidationLine({ kind: 'updated', topic: 'your deploy preferences' })).toBe(
+      '🧠 <i>updated what I know</i> about "your deploy preferences"',
+    )
+  })
+  it('renders the revised line with a subject', () => {
+    expect(renderConsolidationLine({ kind: 'revised', topic: 'the old runbook' })).toBe(
+      '🧠 <i>revised what I know</i> about "the old runbook"',
+    )
+  })
+  it('falls back to a bare line when there is no legible subject', () => {
+    expect(renderConsolidationLine({ kind: 'updated', topic: '' })).toBe(
+      '🧠 <i>updated what I know about you.</i>',
+    )
+    expect(renderConsolidationLine({ kind: 'revised', topic: '   ' })).toBe(
+      '🧠 <i>revised what I know about you.</i>',
+    )
+  })
+  it('HTML-escapes the subject (no entity injection)', () => {
+    expect(renderConsolidationLine({ kind: 'updated', topic: 'a <b> & c' })).toBe(
+      '🧠 <i>updated what I know</i> about "a &lt;b&gt; &amp; c"',
+    )
+  })
+  it('truncates a very long subject', () => {
+    const long = 'x'.repeat(500)
+    const out = renderConsolidationLine({ kind: 'updated', topic: long })
+    expect(out.length).toBeLessThan(200)
+    expect(out).toContain('…')
+  })
+})
+
+describe('ConsolidationRateLimiter — sparse / non-spammy', () => {
+  it('allows the first line, then blocks a second within the min-interval', () => {
+    let t = 1_000_000
+    const rl = new ConsolidationRateLimiter({ minIntervalMs: 600_000, now: () => t })
+    expect(rl.allow('klanker', 'updated:a')).toBe(true)
+    t += 60_000 // 1 min later
+    expect(rl.allow('klanker', 'updated:b')).toBe(false) // different topic, still capped
+  })
+
+  it('allows again once the min-interval has elapsed', () => {
+    let t = 1_000_000
+    const rl = new ConsolidationRateLimiter({ minIntervalMs: 600_000, now: () => t })
+    expect(rl.allow('klanker', 'updated:a')).toBe(true)
+    t += 600_001
+    expect(rl.allow('klanker', 'updated:b')).toBe(true)
+  })
+
+  it('suppresses an IDENTICAL signature across the dedup window even after the interval', () => {
+    let t = 1_000_000
+    const rl = new ConsolidationRateLimiter({
+      minIntervalMs: 600_000,
+      dedupWindowMs: 3_600_000,
+      now: () => t,
+    })
+    expect(rl.allow('klanker', 'updated:deploy')).toBe(true)
+    t += 700_000 // past min-interval…
+    expect(rl.allow('klanker', 'updated:deploy')).toBe(false) // …but same topic, still deduped
+    t += 3_600_000 // past dedup window
+    expect(rl.allow('klanker', 'updated:deploy')).toBe(true)
+  })
+
+  it('rate-limits per agent independently', () => {
+    let t = 1_000_000
+    const rl = new ConsolidationRateLimiter({ minIntervalMs: 600_000, now: () => t })
+    expect(rl.allow('klanker', 'updated:a')).toBe(true)
+    expect(rl.allow('reggie', 'updated:a')).toBe(true) // different agent, own budget
+  })
+
+  it('accepts an explicit now override per call', () => {
+    const rl = new ConsolidationRateLimiter({ minIntervalMs: 600_000 })
+    expect(rl.allow('klanker', 'updated:a', 0)).toBe(true)
+    expect(rl.allow('klanker', 'updated:a', 100)).toBe(false)
+    expect(rl.allow('klanker', 'updated:a', 700_000)).toBe(false) // dedup window
+    expect(rl.allow('klanker', 'updated:b', 700_000)).toBe(true) // new topic past interval
+  })
+})
+
+describe('consolidationSignature — stable dedup key', () => {
+  it('normalises whitespace + case so trivially-different topics collapse', () => {
+    expect(consolidationSignature({ kind: 'updated', topic: '  Deploy   Prefs ' })).toBe(
+      'updated:deploy prefs',
+    )
+  })
+  it('separates kind so a store and a correction of the same topic differ', () => {
+    expect(consolidationSignature({ kind: 'updated', topic: 'x' })).not.toBe(
+      consolidationSignature({ kind: 'revised', topic: 'x' }),
+    )
+  })
+})


### PR DESCRIPTION
Extends the Phase 4 chat-legible memory surface (#2858) with its poll-free **UPDATE** side, per `reference/rfcs/hindsight-synthesis-layers.md` Phase 4.

## Summary
#2858 shipped the **foreground** store/forget path — deterministic tool-call observation of the interactive session (`create_directive` → 📌 remembered, `invalidate_memory`/demote → ✂️ forgot), default ON. It sees only what the agent explicitly does with memory tools.

This wires the **background** driver the RFC names and #2858 explicitly deferred: when the consolidation engine actually distils a new durable observation (or supersedes a stale one) it emits a `consolidation.completed` webhook, and the gateway surfaces ONE terse line:

```
🧠 updated what I know about "your deploy preferences"
🧠 revised what I know about "the old runbook"
```

## Design
- **New pure module** `telegram-plugin/consolidation-legibility.ts`:
  - `detectConsolidationEvent` — material store/correct vs routine no-op consolidation (→ `null`, the common case). Tolerant of the RFC-only payload's field aliases; a correction outranks a store for framing.
  - `ConsolidationRateLimiter` — per-agent min-interval (10 min) + identical-line dedup window (1 h), so a burst of material consolidations collapses to at most one line.
  - `renderConsolidationLine`, `consolidationSignature`, opt-in env gate. No I/O.
- `recordWebhookEvent` (`src/web/webhook-gateway-record.ts`) routes a verified `hindsight`/`consolidation.completed` event to a **send-free** `onConsolidation` sink with the agent's resolved channel target. The event is still recorded to `webhook-events.jsonl` for audit; it is **never** injected as a model turn.
- `gateway.ts` `surfaceConsolidationLegibility` owns the enablement gate, materiality check, rate limit, and the terse real `sendMessage` (`disable_notification`, via `retryWithThreadFallback`). One long-lived limiter across events.

## Gating (why OFF by default)
`SWITCHROOM_CONSOLIDATION_LEGIBILITY` is **opt-in** (`1`/`true`/`on`/`yes`), the deliberate opposite of #2858's default-ON kill-switch. This path is fed by an unbounded background engine and by a webhook the **pinned hindsight image (v0.8.4) does not yet emit** — so the consumer is dormant until that upstream event exists. RFC: "sparse, not per-turn … clearly gated". No model call, no polling, no `claude -p`.

## Tests
- 25 unit tests (`telegram-plugin/tests/consolidation-legibility.test.ts`): opt-in gate, materiality, aliases, render/escape/truncate, rate-limiter (interval + dedup + per-agent).
- 4 new `recordWebhookEvent` branch tests: delegation with target, no-target skip (still recorded), throw-safety, no-sink no-op.
- `npm run lint` (tsc + all 8 guards incl. `check-bot-api-wrapping`) green.

## Open decisions
- **`consolidation.completed` payload shape is RFC-only** — the parser tolerates several plausible field names (`stored`/`created`/`observations`, `corrected`/`invalidated`/`superseded`, `subject`/`subjects`/`observations[].subject`). Whoever lands the hindsight-side emitter should pin the exact schema and tighten the parser.
- **Rate-limit constants** (10 min interval / 1 h dedup) are first-guess defaults; not operator-configurable yet.
- No live UAT twin added — the webhook isn't emitted by the current image, so there's nothing to drive end-to-end yet (kept out of scope deliberately).

Serves: `remember-across-sessions` (`reference/jobs/remember-across-sessions.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)