### PR TITLE
feat(memory): strengthen deterministic correction capture (hindsight Phase 3)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -258,6 +258,8 @@ Two things it deliberately does **not** do (both are hard invariants):
 
 Detection is intentionally inclusive (the nudge is cheap and advisory, so a false positive just costs a few tokens and is ignored), with a guard against the obvious pleasantry shapes (`always happy to help`, `never mind`).
 
+**Post-turn verification (the same knob).** The advisory nudge still relies on the model *choosing* to act on it. To close the residual gap for the clear-cut case, a **Stop-hook verifier** runs after the turn: it re-checks the human turn against a **narrow, high-precision** durable-rule regex — a strict subset of the nudge detector (explicit framings only: `from now on`, `as a rule`, `you should always`, `call me …`, `remember to …`, `don't … again`; bare `always`/`stop …` and world-fact corrections are excluded) — and if the turn stated a durable rule but the model recorded **no** `create_directive` call, it **blocks the stop once** to re-prompt the model to persist it. This keeps the two invariants above: no model call (pure regex), no silent write (the block is a re-prompt; the model still authors the directive itself, visibly). The block fires **at most once per turn** (a `stop_hook_active` loop guard), and its reason explicitly authorizes "if this was really a one-off, don't create a directive — just finish", so a false positive costs one bounded continuation, never a spurious directive. This verifier shares the `memory.directive_capture_nudge` knob — disabling the nudge disables the verifier too.
+
 ```yaml
 defaults:
   memory:

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2240,7 +2240,20 @@ describe("installHindsightPlugin", () => {
     // Hook script copied
     expect(existsSync(join(result!.pluginDir, "scripts", "recall.py"))).toBe(true);
     expect(existsSync(join(result!.pluginDir, "scripts", "retain.py"))).toBe(true);
+    // #2848 Stage C — deterministic correction-capture Stop verify hook.
+    expect(existsSync(join(result!.pluginDir, "scripts", "directive_verify.py"))).toBe(true);
     expect(existsSync(join(result!.pluginDir, "hooks", "hooks.json"))).toBe(true);
+    // The Stop event wires BOTH the directive-capture verify (sync, blocking)
+    // and retain (async). Verify is registered so a durable correction the
+    // model dropped gets a single re-prompt to persist it.
+    const hooksJson = JSON.parse(
+      readFileSync(join(result!.pluginDir, "hooks", "hooks.json"), "utf8"),
+    );
+    const stopCommands = (hooksJson.hooks.Stop as Array<{ hooks: Array<{ command: string }> }>)
+      .flatMap((g) => g.hooks.map((h) => h.command))
+      .join(" ");
+    expect(stopCommands).toContain("directive_verify.py");
+    expect(stopCommands).toContain("retain.py");
   });
 
   it("falls back to agent name when no explicit collection is set", () => {

--- a/vendor/hindsight-memory/hooks/hooks.json
+++ b/vendor/hindsight-memory/hooks/hooks.json
@@ -27,6 +27,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/directive_verify.py\"",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/retain.py\"",
             "timeout": 15,
             "async": true

--- a/vendor/hindsight-memory/scripts/directive_verify.py
+++ b/vendor/hindsight-memory/scripts/directive_verify.py
@@ -142,6 +142,42 @@ _INJECTED_MARKERS = (
     "Relevant memories from past conversations",
 )
 
+# Genuine human inbound channels. A "user" turn whose `<channel source="...">`
+# envelope names anything else is a SYNTHESIZED / cron inbound built by the
+# gateway (see telegram-plugin/gateway/*-inbound-builder.ts + reaction /
+# resume / vault-grant / subagent / obligation builders) — a machine turn, NOT
+# a human correction. The blocking re-prompt must never fire on those: nagging
+# the model to persist a "durable rule" on a cron digest or a resume synthetic
+# is pure noise. Interactive sessions carry NO channel envelope and are treated
+# as human. Kept as a whitelist so any NEW synthetic source is skipped by
+# default rather than accidentally nagged on.
+_HUMAN_INBOUND_SOURCES = frozenset({"telegram"})
+
+# Pulls the source attribute out of the gateway's leading `<channel ...>`
+# envelope. Handles both open (`<channel source="telegram" ...>`) and
+# self-closing (`<channel source="reaction"/>`) forms.
+_CHANNEL_SOURCE_RE = re.compile(r"""<channel\b[^>]*\bsource=["']([^"']+)["']""")
+
+
+def is_synthetic_inbound(text) -> bool:
+    """True when this turn's opening human message is a synthesized/cron
+    inbound rather than a genuine human message.
+
+    Detection is purely on the gateway-prepended ``<channel source="...">``
+    envelope: a ``source`` outside ``_HUMAN_INBOUND_SOURCES`` (``cron``,
+    ``reaction``, ``resume_interrupted``, ``vault_grant_approved``,
+    ``subagent_handback``, ``obligation_represent``, …) marks a non-human turn.
+    No envelope (interactive session) → treated as human. Injected channel tags
+    in a human's own body are neutralised upstream by the channel-envelope
+    sanitiser, so the only real ``<channel source=`` is the gateway's.
+    """
+    if not isinstance(text, str):
+        return False
+    m = _CHANNEL_SOURCE_RE.search(text)
+    if not m:
+        return False
+    return m.group(1).strip().lower() not in _HUMAN_INBOUND_SOURCES
+
 
 def looks_like_durable_directive(text) -> bool:
     """High-precision test for an explicit, durable standing rule.
@@ -283,6 +319,14 @@ def evaluate(hook_input: dict, config: dict) -> str | None:
 
     idx, text = find_last_human_turn(messages)
     if idx is None:
+        return None
+
+    # Non-interactive turn guard: cron / synthesized-inbound turns (resume,
+    # reaction, vault-grant, subagent-handback, obligation-represent, …) are
+    # machine turns, not human corrections. Never block Stop to nag capture on
+    # them — that's spurious. (See is_synthetic_inbound.)
+    if is_synthetic_inbound(text):
+        debug_log(config, "Directive-capture verify: synthetic/cron inbound, allowing stop")
         return None
 
     if not looks_like_durable_directive(text):

--- a/vendor/hindsight-memory/scripts/directive_verify.py
+++ b/vendor/hindsight-memory/scripts/directive_verify.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Post-turn directive-capture verification hook for the Stop event.
+
+Switchroom #2848 Stage C — deterministic correction capture (hindsight
+synthesis-layers RFC, Phase 3 "corrections stick").
+
+Stage B (recall.py) appends an advisory nudge to the UserPromptSubmit
+context when the inbound looks correction-shaped, then trusts the model to
+call ``mcp__hindsight__create_directive`` itself. That closes part of the
+~55% miss rate Stage A measured, but capture still relies on the model
+CHOOSING to act on the nudge — a purely advisory path. When the model
+silently ignores the nudge, a durable correction is lost the same way it was
+before Stage B.
+
+This hook closes the residual gap for the HIGH-CONFIDENCE case. On Stop it:
+
+  1. Re-reads the transcript, isolates the human turn that opened this turn,
+     and tests it against a NARROW, high-precision "durable standing rule"
+     regex (a strict subset of Stage B's inclusive detector — see
+     ``looks_like_durable_directive``). Bare "always"/"never"/"stop …" and
+     other one-off-prone shapes are deliberately EXCLUDED here; only explicit
+     standing-rule framings ("from now on", "as a rule", "you should always",
+     "call me …", "remember to …", "don't … again") qualify.
+  2. Scans the assistant messages of the turn for an actual
+     ``create_directive`` tool call.
+  3. If the turn stated a durable rule but recorded NO directive, it BLOCKS
+     the stop ONCE (Claude Code ``{"decision":"block"}``) with a terse reason
+     telling the model to persist the rule now — or, if on reflection it was
+     genuinely a one-off, to just finish. ``stop_hook_active`` gates the
+     block to fire at most once per turn, so it can never loop and never
+     override the model's second, explicit judgment.
+
+Why this stays invariant-clean (same reasoning as Stage B):
+  * NO model callsite here — detection is pure regex (claude-native).
+  * NO silent hook-side write — the hook never calls the Hindsight API; the
+    MODEL authors the directive verbatim and the call is visible in chat
+    (chat-legibility / no-self-escalation). The block is a re-prompt, not a
+    write.
+  * Guarded against spam — the durable regex is high-precision, the block
+    fires once, and the reason explicitly authorizes "one-off → don't create,
+    just finish". A false positive costs one bounded model continuation.
+
+Gated by the same knob as Stage B: ``directiveCaptureNudge`` (switchroom
+default on; operators opt out per-agent via
+``memory.directive_capture_nudge=false`` →
+``HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE``). Disabling the nudge disables this
+verification too — they are one deterministic-capture feature.
+
+Exit codes:
+  0 — always (graceful degradation; a raise here must never wedge a turn).
+"""
+
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib.config import debug_log, load_config  # noqa: E402
+
+# Reuse Stage B's pleasantry scrub so "as always" / "always happy to help"
+# can't trip the high-confidence detector either. Imported lazily-safe: if
+# recall.py fails to import for any reason we fall back to a no-op scrub so
+# this hook still degrades gracefully rather than wedging Stop.
+try:
+    from recall import _DIRECTIVE_NUDGE_NEGATIVE_RE as _NEGATIVE_RE
+    from recall import looks_like_standing_rule as _looks_like_standing_rule
+except Exception:  # pragma: no cover - defensive import guard
+    _NEGATIVE_RE = re.compile(r"(?!x)x")  # matches nothing → scrub is a no-op
+
+    def _looks_like_standing_rule(_text):  # type: ignore
+        # If recall.py can't be imported, fall back to the high-precision
+        # detector alone rather than wedging the hook. (Never expected in
+        # practice — recall.py ships in the same plugin tree.)
+        return True
+
+
+# High-confidence, high-precision "durable standing rule" detector. Fires only
+# on explicit standing-rule / preference / identity framings that read as
+# durable on their face. Bare "always"/"never"/"stop …"/"don't …" (without a
+# standing frame), and pure world-fact corrections ("we no longer use X" —
+# recall/retain handle those, they aren't behavioural directives), are
+# intentionally omitted: the blocking re-prompt is more intrusive than Stage
+# B's advisory nudge, so its trigger set is narrower and directive-shaped only.
+#
+# looks_like_durable_directive() additionally AND-gates this against
+# recall.py's inclusive looks_like_standing_rule, so the durable trigger set is
+# a GUARANTEED SUBSET of Stage B's nudge trigger set — Stage C can never block
+# on a turn Stage B wouldn't even have nudged on.
+_DURABLE_DIRECTIVE_RE = re.compile(
+    r"""(?ix)
+    (?:
+      # --- explicit temporal / standing-rule framings ---
+        \b from \s+ now \s+ on \b
+      | \b going \s+ forwards? \b
+      | \b in \s+ (?: the \s+ )? future \b
+      | \b as \s+ a \s+ (?: general \s+ )?
+            (?: rule | policy | principle | convention | standard | default | habit ) \b
+      # --- directed standing behaviour ("you should always", "please never") ---
+      | \b you \s+ (?: should | must ) \s+ (?: always | never ) \b
+      | \b i \s+ want \s+ you \s+ to \s+ (?: always | never ) \b
+      | \b please \s+ (?: always | never ) \b
+      # --- durable preferences / identity ---
+      | \b i \s* ['’]? d \s+ (?: really \s+ )? prefer \b
+      | \b (?: i | we ) \s+ prefer \s+ (?: that \s+ )? you \b
+      | \b call \s+ me \b
+      # --- memory / reinforcement ---
+      | \b remember \s+ (?: to | that | always | never ) \b
+      # --- prohibitions with a durable frame ---
+      | \b (?: do \s* n['’]? t | don['’]? t | dont | do \s+ not )
+            \b [^.?!]{0,40} \b again \b
+    )
+    """
+)
+
+# Terse, bounded. Fed back to the model on a single blocked Stop. It must
+# offer an explicit escape hatch (one-off → just finish) so a false positive
+# is cheap and never forces a spurious directive.
+_VERIFY_BLOCK_REASON = (
+    "<directive_capture_verify>\n"
+    "The user's last message stated a DURABLE, standing rule for how you "
+    "should behave going forward (e.g. \"from now on …\", \"as a rule …\", "
+    "\"you should always …\", \"call me …\", \"remember to …\", \"don't … "
+    "again\"), but this turn is ending without recording it — so the "
+    "correction will NOT survive the next session.\n"
+    "If it is genuinely a durable rule, call "
+    "mcp__hindsight__create_directive NOW (verbatim, in the user's own "
+    "words), then briefly confirm you have saved it.\n"
+    "If, on reflection, it was only a one-off instruction for this task, do "
+    "NOT create a directive — just finish your reply normally.\n"
+    "This verification fires once per turn.\n"
+    "</directive_capture_verify>"
+)
+
+# Guard: skip any "user" content that is actually hook-injected context
+# (recall's memories/nudge blocks), not a human message.
+_INJECTED_MARKERS = (
+    "<directive_capture_check>",
+    "<directive_capture_verify>",
+    "<hindsight_memories>",
+    "Relevant memories from past conversations",
+)
+
+
+def looks_like_durable_directive(text) -> bool:
+    """High-precision test for an explicit, durable standing rule.
+
+    Narrower than recall.py's ``looks_like_standing_rule`` — see the module
+    docstring. Pleasantries are scrubbed first (shared Stage B negative
+    guard). Returns False on empty / non-string input. Pure regex; no model
+    call.
+    """
+    if not isinstance(text, str) or not text.strip():
+        return False
+    scrubbed = _NEGATIVE_RE.sub(" ", text)
+    if not _DURABLE_DIRECTIVE_RE.search(scrubbed):
+        return False
+    # Subset gate: only act where Stage B would also have nudged.
+    return bool(_looks_like_standing_rule(text))
+
+
+def _message_text(content) -> str:
+    """Extract the human-authored text from a message's content.
+
+    Handles the plain-string shape and the Claude Code list shape
+    ``[{type:"text", text:...}, {type:"tool_use"/"tool_result", ...}]``.
+    Only ``text`` parts are joined — tool_result / tool_use parts are
+    ignored, so a role="user" tool-result message yields "" (correctly not a
+    human turn).
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for p in content:
+            if isinstance(p, dict) and p.get("type") == "text":
+                t = p.get("text")
+                if isinstance(t, str):
+                    parts.append(t)
+        return "\n".join(parts)
+    return ""
+
+
+def _is_injected(text: str) -> bool:
+    return any(marker in text for marker in _INJECTED_MARKERS)
+
+
+def find_last_human_turn(messages: list) -> tuple:
+    """Return ``(index, text)`` of the most recent genuine human turn.
+
+    Skips role="user" entries that are tool_result-only (no text) or
+    hook-injected context blocks. Returns ``(None, "")`` when there is no
+    human message.
+    """
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        text = _message_text(msg.get("content"))
+        if not text.strip():
+            continue  # tool_result-only user message
+        if _is_injected(text):
+            continue  # recall/nudge injection, not the human
+        return i, text
+    return None, ""
+
+
+def _directive_call_present(content) -> bool:
+    """True if a message's content contains a create_directive tool_use."""
+    if not isinstance(content, list):
+        return False
+    for p in content:
+        if not isinstance(p, dict) or p.get("type") != "tool_use":
+            continue
+        name = p.get("name", "")
+        if isinstance(name, str) and "create_directive" in name:
+            return True
+    return False
+
+
+def directive_recorded_after(messages: list, start_index: int) -> bool:
+    """True if any assistant turn after ``start_index`` called create_directive."""
+    for msg in messages[start_index + 1:]:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        if _directive_call_present(msg.get("content")):
+            return True
+    return False
+
+
+def read_transcript(transcript_path: str) -> list:
+    """Read a JSONL transcript into a list of message dicts (role/content).
+
+    Mirrors retain.py.read_transcript: supports the nested Claude Code shape
+    ``{type, message:{role, content}}`` and the flat testing shape
+    ``{role, content}``.
+    """
+    if not transcript_path or not os.path.isfile(transcript_path):
+        return []
+    messages = []
+    try:
+        with open(transcript_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("type") in ("user", "assistant"):
+                    msg = entry.get("message", {})
+                    if isinstance(msg, dict) and msg.get("role"):
+                        messages.append(msg)
+                elif "role" in entry and "content" in entry:
+                    messages.append(entry)
+    except OSError:
+        pass
+    return messages
+
+
+def evaluate(hook_input: dict, config: dict) -> str | None:
+    """Core decision. Returns a block reason string, or None to allow stop.
+
+    None → the turn is allowed to end (no-op). A non-empty string → block the
+    stop once and feed the string back to the model.
+    """
+    # Same knob as Stage B — disabling the nudge disables this verification.
+    if not config.get("directiveCaptureNudge", True):
+        debug_log(config, "Directive-capture verify: feature disabled, allowing stop")
+        return None
+
+    # Loop / one-off guard: if we already blocked once this turn, respect the
+    # model's second judgment and never re-block.
+    if hook_input.get("stop_hook_active"):
+        debug_log(config, "Directive-capture verify: stop_hook_active, not re-blocking")
+        return None
+
+    messages = read_transcript(hook_input.get("transcript_path", ""))
+    if not messages:
+        return None
+
+    idx, text = find_last_human_turn(messages)
+    if idx is None:
+        return None
+
+    if not looks_like_durable_directive(text):
+        return None
+
+    if directive_recorded_after(messages, idx):
+        debug_log(config, "Directive-capture verify: create_directive already called, allowing stop")
+        return None
+
+    debug_log(
+        config,
+        "Directive-capture verify: durable rule stated, no create_directive call — blocking once",
+    )
+    return _VERIFY_BLOCK_REASON
+
+
+def main():
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        # No input → nothing to verify. Allow stop.
+        return
+    try:
+        config = load_config()
+    except Exception:
+        return
+    try:
+        reason = evaluate(hook_input, config)
+    except Exception as e:  # never wedge a turn on a verify bug
+        debug_log(config, f"Directive-capture verify error (allowing stop): {e}")
+        return
+    if reason:
+        # Claude Code Stop-hook block contract: emit decision=block + reason;
+        # the model continues the turn with `reason` as feedback.
+        print(json.dumps({"decision": "block", "reason": reason}))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:  # absolute backstop — Stop must never hard-fail
+        print(f"[Hindsight] Unexpected error in directive_verify: {e}", file=sys.stderr)
+        try:
+            sys.exit(2 if load_config().get("debug") else 0)
+        except Exception:
+            sys.exit(0)

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -37,14 +37,22 @@ DEFAULTS = {
     # scores, so this is the switchroom-side quality filter — see #475.
     "recallMinOverlap": 0.0,
     "recallTypes": ["world", "experience"],
-    # Switchroom #2848 Stage B — deterministic directive-capture nudge.
+    # Switchroom #2848 Stage B/C — deterministic directive capture.
     # When on (switchroom default; pinned true in the copied plugin
-    # settings.json by applyHindsightSettingsOverrides), recall.py regex-
-    # detects correction / standing-rule-shaped inbound and appends a terse
-    # advisory to the UserPromptSubmit additionalContext telling the model
-    # to persist the rule with create_directive if it IS durable. Pure
-    # detection — no model callsite. Operators opt out per-agent via
-    # memory.directive_capture_nudge=false → HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE.
+    # settings.json by applyHindsightSettingsOverrides), TWO deterministic
+    # hooks share this knob:
+    #   * Stage B (recall.py, UserPromptSubmit): regex-detects correction /
+    #     standing-rule-shaped inbound and appends a terse advisory to the
+    #     turn's additionalContext telling the model to persist the rule with
+    #     create_directive if it IS durable.
+    #   * Stage C (directive_verify.py, Stop): after the turn, re-checks the
+    #     human turn against a HIGH-PRECISION durable-rule regex and, if the
+    #     model recorded no create_directive call, blocks the stop ONCE to
+    #     re-prompt capture (closes the "model ignored the nudge" gap).
+    # Both are pure detection — no model callsite, no silent hook-side write;
+    # the model authors the directive in-session (chat-legible). Operators opt
+    # out per-agent via memory.directive_capture_nudge=false →
+    # HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE (disables BOTH hooks).
     "directiveCaptureNudge": True,
     "recallContextTurns": 1,
     "recallMaxQueryChars": 800,

--- a/vendor/hindsight-memory/scripts/retain.py
+++ b/vendor/hindsight-memory/scripts/retain.py
@@ -147,6 +147,23 @@ def run_retain(hook_input: dict, force: bool = False) -> dict:
 
     debug_log(config, f"Retain hook_input keys: {list(hook_input.keys())} force={force}")
 
+    # Blocked-Stop double-fire guard (switchroom #2848 Phase 3): when
+    # directive_verify.py blocks a Stop, the model continues and the Stop
+    # event fires AGAIN, this time carrying ``stop_hook_active: true``.
+    # Retaining on that second fire would (a) POST a duplicate transcript
+    # document and (b) at retainEveryNTurns>1 call increment_turn_count a
+    # second time for the SAME logical turn — drifting the cadence throttle.
+    # Skip the re-fire entirely BEFORE any store or turn-count increment.
+    # A forced SessionEnd sweep (force=True) is a distinct hook event and
+    # must always flush, so it is exempt.
+    if not force and hook_input.get("stop_hook_active"):
+        debug_log(
+            config,
+            "Stop re-fire (stop_hook_active=true) — skipping retain to avoid "
+            "duplicate document / turn-count drift",
+        )
+        return {"status": "skipped", "reason": "stop_hook_active"}
+
     session_id = hook_input.get("session_id", "unknown")
     transcript_path = hook_input.get("transcript_path", "")
 

--- a/vendor/hindsight-memory/scripts/setup_hooks.py
+++ b/vendor/hindsight-memory/scripts/setup_hooks.py
@@ -48,6 +48,15 @@ def build_hooks(plugin_root: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
+                        "command": f'python3 "{plugin_root}/scripts/directive_verify.py"',
+                        "timeout": 10,
+                    }
+                ]
+            },
+            {
+                "hooks": [
+                    {
+                        "type": "command",
                         "command": f'python3 "{plugin_root}/scripts/retain.py"',
                         "timeout": 15,
                         "async": True,

--- a/vendor/hindsight-memory/scripts/tests/test_directive_verify.py
+++ b/vendor/hindsight-memory/scripts/tests/test_directive_verify.py
@@ -1,0 +1,318 @@
+"""Switchroom #2848 Stage C — unit tests for the Stop-hook directive verify.
+
+Stage B (recall.py) nudges the model to persist a durable rule but still
+relies on the model CHOOSING to call create_directive. Stage C
+(directive_verify.py) closes the residual gap for the high-confidence case:
+on Stop it re-checks the human turn against a NARROW durable-rule regex and,
+if the turn stated a durable rule but recorded no create_directive call,
+blocks the stop ONCE to re-prompt capture.
+
+These tests pin:
+  * The high-precision durable detector — explicit standing-rule framings
+    fire; bare "always"/"stop …"/"don't …" and one-off requests do NOT
+    (the detector is a STRICT SUBSET of Stage B's inclusive one).
+  * Pleasantry scrub is inherited (Stage B negative guard).
+  * Transcript parsing — last human turn is isolated (tool_result-only and
+    injected recall/nudge blocks are skipped), and a create_directive
+    tool_use anywhere after it counts as captured.
+  * evaluate() end-to-end: block iff durable-rule-stated AND no directive
+    call AND feature on AND not stop_hook_active (loop guard).
+  * The block reason is the create_directive re-prompt with a one-off escape.
+
+Stdlib-only.
+"""
+
+import os
+import sys
+import unittest
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from directive_verify import (  # noqa: E402
+    _VERIFY_BLOCK_REASON,
+    directive_recorded_after,
+    evaluate,
+    find_last_human_turn,
+    looks_like_durable_directive,
+)
+from recall import looks_like_standing_rule  # noqa: E402
+
+
+# Explicit durable standing-rule framings that MUST fire the verify block.
+DURABLE_POSITIVES = [
+    "From now on, use British spelling in everything you write.",
+    "Going forward, never open a PR without a test plan.",
+    "In the future, always run the linter before you commit.",
+    "As a rule, keep replies under three sentences.",
+    "As a general policy, don't tag me on weekends.",
+    "You should always cite the file path when you quote code.",
+    "You should never push directly to main.",
+    "You must never ping the whole channel.",
+    "I want you to always double-check the branch name first.",
+    "Please always address me formally.",
+    "Please never use em dashes.",
+    "I'd prefer you keep the summaries terse.",
+    "I prefer that you use tabs, not spaces.",
+    "Call me Ken, not Kenneth.",
+    "Remember to always sign off with my initials.",
+    "Remember that I'm on Sydney time.",
+    "Don't ever guess at config values again.",
+]
+
+# Shapes that MUST NOT fire the verify block. Either genuine one-offs, or the
+# inclusive-but-not-durable shapes Stage B nudges on but Stage C must not
+# block on (bare always/never/stop without a standing frame), or pleasantries.
+DURABLE_NEGATIVES = [
+    # one-off task requests
+    "Can you fix the failing test in auth.py?",
+    "Please deploy the staging branch now.",
+    "What's the status of the build?",
+    "Add a docstring to this function.",
+    "Run the tests and tell me what breaks.",
+    # inclusive-but-not-durable (Stage B may nudge, Stage C must not block):
+    # bare always/never/stop/don't and world-fact corrections carry too much
+    # one-off risk for a blocking re-prompt.
+    "always double-check that number for me here",
+    "stop the server so I can restart it",
+    "stop using that deprecated endpoint for this test",
+    "don't merge that yet, I'm still reviewing",
+    "that's wrong, the port is 8080",
+    "no longer needed for this one file, skip it",
+    "we don't use Jenkins anymore; it's all GitHub Actions now",
+    # pleasantries (shared negative scrub)
+    "always happy to help, thanks!",
+    "never mind, I figured it out.",
+    "as always, appreciate the quick turnaround.",
+    "thanks as always!",
+    # empty / junk
+    "",
+    "   ",
+    "ok",
+]
+
+
+class TestDurableDetector(unittest.TestCase):
+    def test_positives_fire(self):
+        for text in DURABLE_POSITIVES:
+            with self.subTest(text=text):
+                self.assertTrue(
+                    looks_like_durable_directive(text),
+                    f"expected durable-rule detection to FIRE on: {text!r}",
+                )
+
+    def test_negatives_do_not_fire(self):
+        for text in DURABLE_NEGATIVES:
+            with self.subTest(text=text):
+                self.assertFalse(
+                    looks_like_durable_directive(text),
+                    f"expected durable-rule detection NOT to fire on: {text!r}",
+                )
+
+    def test_non_string_input(self):
+        for bad in (None, 123, [], {}, object()):
+            self.assertFalse(looks_like_durable_directive(bad))
+
+    def test_durable_is_subset_of_standing_rule(self):
+        # Every high-confidence durable positive must ALSO be caught by Stage
+        # B's inclusive detector — Stage C never blocks on something Stage B
+        # wouldn't have nudged on.
+        for text in DURABLE_POSITIVES:
+            with self.subTest(text=text):
+                self.assertTrue(
+                    looks_like_standing_rule(text),
+                    f"durable positive not a subset of standing_rule: {text!r}",
+                )
+
+
+class TestTranscriptParsing(unittest.TestCase):
+    def test_find_last_human_turn_plain_string(self):
+        msgs = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "from now on use tabs"},
+        ]
+        idx, text = find_last_human_turn(msgs)
+        self.assertEqual(idx, 2)
+        self.assertEqual(text, "from now on use tabs")
+
+    def test_skips_tool_result_only_user_message(self):
+        msgs = [
+            {"role": "user", "content": "from now on use tabs"},
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "name": "Bash", "input": {}}],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "content": "done"}],
+            },
+        ]
+        idx, text = find_last_human_turn(msgs)
+        self.assertEqual(idx, 0)
+        self.assertEqual(text, "from now on use tabs")
+
+    def test_skips_injected_recall_block(self):
+        msgs = [
+            {"role": "user", "content": "call me Ken"},
+            {
+                "role": "user",
+                "content": "<hindsight_memories>old stuff</hindsight_memories>",
+            },
+        ]
+        idx, text = find_last_human_turn(msgs)
+        self.assertEqual(idx, 0)
+        self.assertEqual(text, "call me Ken")
+
+    def test_extracts_text_from_list_content(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "as a rule, keep it terse"},
+                ],
+            }
+        ]
+        idx, text = find_last_human_turn(msgs)
+        self.assertEqual(idx, 0)
+        self.assertEqual(text, "as a rule, keep it terse")
+
+    def test_no_human_turn(self):
+        msgs = [{"role": "assistant", "content": "hi"}]
+        idx, text = find_last_human_turn(msgs)
+        self.assertIsNone(idx)
+        self.assertEqual(text, "")
+
+
+class TestDirectiveDetection(unittest.TestCase):
+    def _mk(self, name):
+        return {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "name": name, "input": {}}],
+        }
+
+    def test_detects_mcp_create_directive(self):
+        msgs = [
+            {"role": "user", "content": "call me Ken"},
+            self._mk("mcp__hindsight__create_directive"),
+        ]
+        self.assertTrue(directive_recorded_after(msgs, 0))
+
+    def test_detects_bare_create_directive(self):
+        msgs = [
+            {"role": "user", "content": "call me Ken"},
+            self._mk("create_directive"),
+        ]
+        self.assertTrue(directive_recorded_after(msgs, 0))
+
+    def test_ignores_other_tools(self):
+        msgs = [
+            {"role": "user", "content": "call me Ken"},
+            self._mk("mcp__hindsight__recall"),
+            self._mk("Bash"),
+        ]
+        self.assertFalse(directive_recorded_after(msgs, 0))
+
+    def test_only_counts_calls_after_index(self):
+        # A create_directive from an EARLIER turn does not count for this one.
+        msgs = [
+            self._mk("mcp__hindsight__create_directive"),
+            {"role": "user", "content": "call me Ken"},
+            {"role": "assistant", "content": "sure"},
+        ]
+        self.assertFalse(directive_recorded_after(msgs, 1))
+
+
+class TestEvaluate(unittest.TestCase):
+    ON = {"directiveCaptureNudge": True}
+
+    def _hook(self, messages, transcript_path, stop_hook_active=False):
+        return {
+            "transcript_path": transcript_path,
+            "stop_hook_active": stop_hook_active,
+        }
+
+    def _write_transcript(self, messages):
+        import json
+        import tempfile
+
+        fd, path = tempfile.mkstemp(suffix=".jsonl")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            for m in messages:
+                f.write(json.dumps({"type": m["role"], "message": m}) + "\n")
+        self.addCleanup(lambda: os.path.exists(path) and os.remove(path))
+        return path
+
+    def test_blocks_on_durable_rule_without_directive(self):
+        msgs = [
+            {"role": "user", "content": "From now on, always use British spelling."},
+            {"role": "assistant", "content": "Got it, will do."},
+        ]
+        path = self._write_transcript(msgs)
+        reason = evaluate(self._hook(msgs, path), self.ON)
+        self.assertEqual(reason, _VERIFY_BLOCK_REASON)
+
+    def test_allows_when_directive_recorded(self):
+        msgs = [
+            {"role": "user", "content": "From now on, always use British spelling."},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "mcp__hindsight__create_directive",
+                        "input": {"text": "Always use British spelling."},
+                    }
+                ],
+            },
+        ]
+        path = self._write_transcript(msgs)
+        self.assertIsNone(evaluate(self._hook(msgs, path), self.ON))
+
+    def test_allows_on_one_off_request(self):
+        msgs = [
+            {"role": "user", "content": "Please fix the failing test in auth.py."},
+            {"role": "assistant", "content": "Fixed."},
+        ]
+        path = self._write_transcript(msgs)
+        self.assertIsNone(evaluate(self._hook(msgs, path), self.ON))
+
+    def test_allows_when_feature_disabled(self):
+        msgs = [
+            {"role": "user", "content": "From now on, always use British spelling."},
+            {"role": "assistant", "content": "Got it."},
+        ]
+        path = self._write_transcript(msgs)
+        reason = evaluate(self._hook(msgs, path), {"directiveCaptureNudge": False})
+        self.assertIsNone(reason)
+
+    def test_loop_guard_does_not_reblock(self):
+        # Already blocked once this turn → respect model judgment, never loop.
+        msgs = [
+            {"role": "user", "content": "From now on, always use British spelling."},
+            {"role": "assistant", "content": "Got it."},
+        ]
+        path = self._write_transcript(msgs)
+        reason = evaluate(
+            self._hook(msgs, path, stop_hook_active=True), self.ON
+        )
+        self.assertIsNone(reason)
+
+    def test_empty_transcript_allows(self):
+        self.assertIsNone(evaluate(self._hook([], "/nonexistent/path.jsonl"), self.ON))
+
+    def test_never_raises_on_garbage(self):
+        # Defensive: evaluate must degrade to None, never raise.
+        self.assertIsNone(evaluate({}, self.ON))
+
+
+class TestBlockReason(unittest.TestCase):
+    def test_reason_mentions_create_directive_and_escape_hatch(self):
+        self.assertIn("create_directive", _VERIFY_BLOCK_REASON)
+        self.assertIn("one-off", _VERIFY_BLOCK_REASON)
+        self.assertIn("<directive_capture_verify>", _VERIFY_BLOCK_REASON)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/scripts/tests/test_directive_verify.py
+++ b/vendor/hindsight-memory/scripts/tests/test_directive_verify.py
@@ -35,6 +35,7 @@ from directive_verify import (  # noqa: E402
     directive_recorded_after,
     evaluate,
     find_last_human_turn,
+    is_synthetic_inbound,
     looks_like_durable_directive,
 )
 from recall import looks_like_standing_rule  # noqa: E402
@@ -305,6 +306,96 @@ class TestEvaluate(unittest.TestCase):
     def test_never_raises_on_garbage(self):
         # Defensive: evaluate must degrade to None, never raise.
         self.assertIsNone(evaluate({}, self.ON))
+
+
+class TestSyntheticInbound(unittest.TestCase):
+    """Non-interactive turns (cron / synthesized inbounds) must never trip the
+    blocking directive re-prompt — they aren't human corrections.
+    """
+
+    def test_cron_source_is_synthetic(self):
+        self.assertTrue(
+            is_synthetic_inbound('<channel source="cron">Time for the daily digest.</channel>')
+        )
+
+    def test_various_synthetic_sources(self):
+        for src in (
+            "cron",
+            "reaction",
+            "resume_interrupted",
+            "resume_watchdog_timeout",
+            "vault_grant_approved",
+            "subagent_handback",
+            "obligation_represent",
+        ):
+            with self.subTest(src=src):
+                self.assertTrue(
+                    is_synthetic_inbound(f'<channel source="{src}" foo="bar">body</channel>')
+                )
+
+    def test_self_closing_synthetic_source(self):
+        self.assertTrue(is_synthetic_inbound('<channel source="reaction"/>'))
+
+    def test_telegram_source_is_human(self):
+        self.assertFalse(
+            is_synthetic_inbound('<channel source="telegram" chat_id="1" user="ken">hi</channel>')
+        )
+
+    def test_no_envelope_is_human(self):
+        # Interactive session: no channel envelope → treated as human.
+        self.assertFalse(is_synthetic_inbound("From now on, always use British spelling."))
+
+    def test_non_string_is_not_synthetic(self):
+        for bad in (None, 123, [], {}):
+            self.assertFalse(is_synthetic_inbound(bad))
+
+    def test_cron_turn_with_durable_shape_does_not_block(self):
+        # A cron inbound whose text happens to contain a durable-rule phrasing
+        # must STILL be allowed — capture only makes sense on human turns.
+        import json
+        import tempfile
+
+        msgs = [
+            {
+                "role": "user",
+                "content": (
+                    '<channel source="cron">Reminder: from now on, always '
+                    "post the digest at 8am.</channel>"
+                ),
+            },
+            {"role": "assistant", "content": "Posted the digest."},
+        ]
+        fd, path = tempfile.mkstemp(suffix=".jsonl")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            for m in msgs:
+                f.write(json.dumps({"type": m["role"], "message": m}) + "\n")
+        self.addCleanup(lambda: os.path.exists(path) and os.remove(path))
+        hook = {"transcript_path": path, "stop_hook_active": False}
+        self.assertIsNone(evaluate(hook, {"directiveCaptureNudge": True}))
+
+    def test_telegram_turn_with_durable_shape_still_blocks(self):
+        # Control: the SAME durable phrasing on a genuine telegram inbound
+        # must still block (proves the synthetic guard didn't over-reach).
+        import json
+        import tempfile
+
+        msgs = [
+            {
+                "role": "user",
+                "content": (
+                    '<channel source="telegram" chat_id="1" user="ken">From now '
+                    "on, always use British spelling.</channel>"
+                ),
+            },
+            {"role": "assistant", "content": "Got it."},
+        ]
+        fd, path = tempfile.mkstemp(suffix=".jsonl")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            for m in msgs:
+                f.write(json.dumps({"type": m["role"], "message": m}) + "\n")
+        self.addCleanup(lambda: os.path.exists(path) and os.remove(path))
+        hook = {"transcript_path": path, "stop_hook_active": False}
+        self.assertEqual(evaluate(hook, {"directiveCaptureNudge": True}), _VERIFY_BLOCK_REASON)
 
 
 class TestBlockReason(unittest.TestCase):

--- a/vendor/hindsight-memory/scripts/tests/test_retain_window.py
+++ b/vendor/hindsight-memory/scripts/tests/test_retain_window.py
@@ -18,12 +18,13 @@ Stdlib-only; runs under `python3 -m unittest discover tests/`.
 import os
 import sys
 import unittest
+from unittest import mock
 
 SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
-from retain import select_retain_window  # noqa: E402
+from retain import run_retain, select_retain_window  # noqa: E402
 
 
 def _transcript(num_turns: int) -> list:
@@ -255,6 +256,70 @@ class SelectRetainWindowForce(unittest.TestCase):
             all_messages=messages, force=False,
         )
         self.assertEqual(_user_turn_indices(result), [7, 8, 9])  # last 3 turns
+
+
+class RunRetainStopHookActiveGuard(unittest.TestCase):
+    """switchroom #2848 Phase 3 — blocked-Stop double-fire guard.
+
+    When directive_verify.py blocks a Stop, the model continues and the Stop
+    event fires AGAIN with ``stop_hook_active: true``. run_retain must no-op on
+    that re-fire — no store, no increment_turn_count — so the same logical turn
+    can't produce a duplicate transcript document or drift the cadence counter.
+    """
+
+    _CONFIG = {"autoRetain": True, "retainEveryNTurns": 10, "retainMode": "chunked"}
+
+    def test_stop_hook_active_noops_no_store_no_increment(self):
+        hook_input = {
+            "session_id": "s1",
+            "transcript_path": "/some/path.jsonl",
+            "stop_hook_active": True,
+        }
+        with mock.patch("retain.load_config", return_value=self._CONFIG), \
+                mock.patch("retain.increment_turn_count") as inc, \
+                mock.patch("retain.read_transcript") as read_t, \
+                mock.patch("retain.get_api_url") as get_url:
+            result = run_retain(hook_input, force=False)
+        # Early-return skip with the dedicated reason.
+        self.assertEqual(result.get("status"), "skipped")
+        self.assertEqual(result.get("reason"), "stop_hook_active")
+        # No cadence increment, no transcript read, no API resolution/store.
+        inc.assert_not_called()
+        read_t.assert_not_called()
+        get_url.assert_not_called()
+
+    def test_first_stop_not_guarded(self):
+        # The FIRST Stop (no stop_hook_active) must NOT be short-circuited by
+        # this guard — it proceeds into normal retain flow (which we stub out
+        # right after the guard by making the transcript empty).
+        hook_input = {
+            "session_id": "s2",
+            "transcript_path": "/some/path.jsonl",
+            "stop_hook_active": False,
+        }
+        with mock.patch("retain.load_config", return_value=self._CONFIG), \
+                mock.patch("retain.read_transcript", return_value=[]) as read_t:
+            result = run_retain(hook_input, force=False)
+        # Got past the guard into the flow — proven by the transcript read.
+        read_t.assert_called_once()
+        self.assertEqual(result.get("status"), "skipped")
+        self.assertEqual(result.get("reason"), "empty transcript")
+
+    def test_forced_session_end_sweep_exempt_from_guard(self):
+        # A forced (SessionEnd) sweep is a distinct hook event and must always
+        # flush even if stop_hook_active happens to be set — the guard is
+        # gated on `not force`.
+        hook_input = {
+            "session_id": "s3",
+            "transcript_path": "/some/path.jsonl",
+            "stop_hook_active": True,
+        }
+        with mock.patch("retain.load_config", return_value=self._CONFIG), \
+                mock.patch("retain.read_transcript", return_value=[]) as read_t:
+            result = run_retain(hook_input, force=True)
+        # force=True bypasses the stop_hook_active guard → reaches transcript read.
+        read_t.assert_called_once()
+        self.assertEqual(result.get("reason"), "empty transcript")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Extends **#2864 / #2848** (the deterministic directive-capture *nudge*). Stage B regex-detects correction-shaped inbound and appends an advisory to the UserPromptSubmit context, then trusts the model to call `create_directive`. That closes part of Stage A's **~55% miss rate**, but capture is still **advisory** — when the model silently ignores the nudge, a durable correction is lost the same way it was pre-Stage-B.

**Stage C** closes the residual gap for the high-confidence case with a **Stop-hook post-turn verifier** (`vendor/hindsight-memory/scripts/directive_verify.py`). After the turn it isolates the human turn, tests it against a **narrow, high-precision** durable-rule regex, and — if the turn stated a durable rule but the model recorded **no** `create_directive` call — **blocks the stop once** to re-prompt capture.

## Why

RFC `reference/rfcs/hindsight-synthesis-layers.md` Phase 3 wants corrections to *stick*; directives are the invariant-clean primitive for it. The #2864 PR body itself flagged the Stop-hook post-turn verification as the OPTIONAL follow-up — this is that follow-up, shipped conservatively.

Serves `reference/jobs/remember-across-sessions.md` ("rules set once stay respected / correction sticks").

## How it stays invariant-clean (identical to Stage B)

- **No model callsite** — detection is pure regex (claude-native).
- **No silent hook-side write** — the block is a *re-prompt*, not a write. The model authors the directive verbatim; the `create_directive` call is visible in chat (chat-legibility / no-self-escalation).
- **Guarded against spam** — the durable regex is a **strict subset** of Stage B's inclusive detector (AND-gated on `looks_like_standing_rule`), excludes bare `always`/`never`/`stop …` and world-fact corrections, the block fires **at most once per turn** (`stop_hook_active` loop guard), and the reason explicitly authorizes *"if it was only a one-off, don't create a directive — just finish"*. A false positive costs one bounded continuation, never a spurious directive.

## Design decision (flagged for review)

The task's open question was **auto-create vs. always-confirm vs. model-in-loop**. I chose the **safest defensible** version: a **single blocking re-prompt** gated to a high-precision durable subset, leaving the model as the authority on durability (it can decline on the re-prompt for a genuine one-off). This makes capture *reliable* for clear-cut durable rules without ever silently writing a directive or spamming on one-offs.

Two granularity choices worth a reviewer's eye:
1. **Shared knob.** Stage C reuses `memory.directive_capture_nudge` rather than adding a parallel knob, so it threads through zero new TS/scaffold sites (the vendored `hooks.json` is copied wholesale by `installHindsightPlugin`). Trade-off: an operator can't keep the soft nudge but disable the block. A separate `directive_capture_verify` knob is a small follow-up if that granularity is wanted.
2. **Not auto-create.** A stricter reading of "deterministic capture" would have the hook itself POST the directive. Deliberately not done — it crosses the no-silent-write line. The block-once re-prompt is the invariant-clean ceiling.

## Where it lives

- `vendor/hindsight-memory/scripts/directive_verify.py` — the Stop hook (new).
- `vendor/hindsight-memory/hooks/hooks.json` + `scripts/setup_hooks.py` — register it on the `Stop` event (sync, before the async retain).
- `vendor/hindsight-memory/scripts/lib/config.py` — doc comment; reuses `directiveCaptureNudge`.
- `docs/configuration.md` — documents the verifier under the existing knob section.
- `tests/scaffold.test.ts` — asserts the script is copied and wired on Stop.

## Test plan

- [x] **Vendor unittest** `test_directive_verify.py` (21 new) — durable-detector positives/negatives, subset invariant, transcript parsing (tool_result / injected-recall-block skip), `create_directive` detection, `evaluate()` block matrix (feature-off / loop-guard / captured / one-off / empty / garbage), block-reason contract. `python3 -m unittest discover tests/` -> **211 pass** (190 + 21).
- [x] **Manual hook smoke** — durable rule + no directive -> `{"decision":"block",...}`; same + `create_directive` tool_use -> no output, exit 0.
- [x] **Vitest** `tests/scaffold.test.ts` -> **198 pass**. One failure (`start.sh symlinks $HOME/.switchroom …`, #910) **reproduces on pristine `origin/main`** — an env artifact (the test hardcodes `HOME=/home/op`), not this diff.
- [x] `tsc --noEmit` exit 0; lint guards (`check-bun-test-imports`, `check-no-pii-secrets`, `check-vault-test-hermeticity`, `check-plugin-references`) clean.

## Risk

Low. Advisory/re-prompt only; never writes. The one blocking action is bounded to a single fire per turn on a high-precision trigger with an explicit one-off escape. Opt-out via `memory.directive_capture_nudge: false` disables it. Vendor change is additive with the divergence-comment convention; retain's async Stop hook is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
