### PR TITLE
feat(memory): per-specialist mental-model curation design + first slice (hindsight Phase 5)

### DIFF
--- a/reference/rfcs/hindsight-phase5-mental-model-curation.md
+++ b/reference/rfcs/hindsight-phase5-mental-model-curation.md
@@ -1,0 +1,119 @@
+---
+artifact: Phase 5 design note — curated per-specialist mental models
+serves: remember-across-sessions
+advances-outcome: standing-team
+relates: rfcs/hindsight-synthesis-layers.md, jobs/run-a-fleet-of-specialists.md
+status: accepted-design + first-slice (2026-07-06)
+---
+
+# Phase 5 — curated per-specialist mental models (design + first slice)
+
+Companion to [`hindsight-synthesis-layers.md`](./hindsight-synthesis-layers.md)
+Phase 5. That RFC named this phase as the least-defined and deliberately
+*not autonomous*. This note pins the design so we don't re-make the
+mistake that got the previous per-agent-model behaviour removed, and
+records the first slice actually shipped.
+
+## The failure we must not repeat (why #2447 removed auto-seeding)
+
+Before #2447, `scaffoldAgent` / `reconcileAgent` called
+`ensureUserProfileMentalModel` on **every apply/restart for every
+agent**, and a Stop hook refreshed it on every stop. That was **blind
+seeding of one fixed model** (`user-profile`, source_query "what do we
+know about the user?") into every bank whether or not the agent had the
+content to back it. Three concrete harms:
+
+1. **Empty/failed models injected every turn.** A freshly-seeded model
+   over a thin bank synthesizes to noise (or fails), and `doctor`
+   flagged them.
+2. **Source-of-truth collision.** The per-agent `user-profile` model
+   duplicated — and could contradict — the dedicated **profile banks**
+   (`users.*.profile_bank`, recalled via `additional_banks` /
+   `sender_banks`) that are the curated answer to "who is the user."
+   A stale per-agent copy produced the "Rex" wrong-dog answer.
+3. **Silent self-enriching structure.** An agent growing its own memory
+   scaffolding unprompted brushes `on-leash` / `no-self-escalation`
+   (RFC tension 3).
+
+#2447's fix was correct: **retire the auto-wiring**, let profile banks
+own identity, keep `ensureUserProfileMentalModel` dormant for the
+operator-triggered dashboard path only.
+
+## The design — declarative, operator-curated, opt-in per model
+
+The RFC's invariant-clean shape for Phase 5 is *"operator-curated, or
+agent-proposes → operator-confirms in chat, never a silent self-write."*
+This note implements the **operator-curated declarative** half — the
+safest first slice — and leaves agent-proposes-→-confirms as a later
+increment.
+
+The design turns "which mental models this specialist carries" into
+**explicit config the operator declares**, then makes scaffold/reconcile
+*ensure* exactly that set. It avoids each #2447 harm by construction:
+
+| #2447 harm | How the declarative design avoids it |
+|---|---|
+| Blind seeding for every agent | **Nothing is created unless declared.** Zero declarations = zero models — byte-for-byte the post-#2447 behaviour. There is no default model. |
+| Empty/noisy model injected | The operator only declares a model when the specialist's bank earns it (a coach's plan state, a lawyer's open matters). It is a deliberate curation act, not an automatic one. |
+| Identity source-of-truth collision | **No fixed identity model is reintroduced.** "Who the user is" stays with profile banks. The schema doc and this note explicitly steer operators away from re-declaring a `user-profile`-shaped model; per-specialist models answer *domain* questions, not *identity* questions. |
+| Silent self-escalation | The declaration lives in `switchroom.yaml`, which **only the operator edits** (agents cannot self-grant — `reference/vision.md` outcome 2). The agent never creates a model on its own initiative. |
+| Fleet-wide over-seeding via defaults | The field is accepted at the **per-agent tier only** — intentionally *not* at `defaults`/profile — so a model can never be pushed across the whole fleet in one line. Each specialist opts in on its own. |
+
+### Refresh is opt-in, off by default
+
+`refresh_after_consolidation` defaults **off**. Per the RFC, a
+refresh-enabled model adds bounded (~2048 tok) but *invisible*
+post-consolidation model-spend and can hit the reflect wall-timeout.
+Static curated models (refresh off) still serve the explicit `reflect`
+path — they let reflect short-circuit the lower tiers — without the
+background cost. Operators turn refresh on per model, deliberately.
+
+### Idempotent ensure, best-effort, non-blocking
+
+Each declared model is ensured create-if-absent by **exact name**
+(substring matching false-positives across sibling models — the bug
+fixed in the list step). The ensure runs inside the existing
+`bankOpsChain` after the bank + missions, is wrapped best-effort with a
+5s per-model timeout, and never blocks or fails scaffold/reconcile if
+Hindsight is slow or down. It runs on **both** scaffold and reconcile
+because a *declared* model is the desired steady state — adding a
+declaration lands it on the next apply/restart. (This is safe precisely
+because the set is operator-authored: unlike #2447, reconcile is not
+recreating something the operator wanted gone.)
+
+## First slice shipped (this PR)
+
+- **Config:** `memory.mental_models[]` — `{ name, source_query,
+  refresh_after_consolidation?, max_tokens? }`, per-agent only, with a
+  duplicate-name guard.
+- **Engine:** generalized `ensureMentalModel(apiUrl, bankId, spec)` (the
+  old `ensureUserProfileMentalModel` is now a thin dormant wrapper over
+  it) + `ensureDeclaredMentalModels(...)` which iterates the declared set
+  and returns per-model outcomes for legible logging.
+- **Wiring:** scaffold + reconcile ensure the declared set (best-effort,
+  non-blocking), logging one `✓`/`⚠` line per model.
+- **Tests:** generalized create payload shape, idempotency, exact-name
+  match, the no-blind-seeding guard (undefined/empty → zero fetches), and
+  the schema surface incl. duplicate/empty/invalid rejection.
+
+## Deliberately out of scope (follow-ups)
+
+- **Agent-proposes → operator-confirms in chat.** The other half of the
+  RFC's invariant-clean shape: an agent surfaces "I'd pin a model for X —
+  approve?" and the operator taps. Higher value, more surface (an
+  approval-card flow), so it is a separate increment on top of this
+  declarative base.
+- **Autonomous creation.** Explicitly never (RFC non-goal + tension 3).
+- **Chat-legible "model refreshed" line.** Belongs with Phase 4's sparse
+  legibility work, not here.
+
+## The open product decision
+
+**Should there be ANY curated default model, or is per-agent-only
+opt-in the final answer?** This slice ships zero defaults on purpose.
+The alternative — a small, safe, *domain-neutral* default (not identity)
+that most specialists benefit from — was rejected here because any
+fleet-wide default re-creates the "seeded whether earned or not" shape
+that #2447 removed. If the fleet later shows a genuinely universal model
+worth defaulting, revisit with the agent-proposes-→-confirms flow rather
+than a silent default. Flagged for the operator, not decided.

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -629,7 +629,7 @@ import { shouldEmitNotionMcp } from "../config/notion-workspace-acl.js";
 import { reconcileAgentDefaultSkills } from "./reconcile-default-skills.js";
 import { applyTelegramProgressGuidance } from "./sub-agent-telegram-prompt.js";
 import type { McpServerConfig } from "../memory/hindsight.js";
-import { createBank, updateBankMissions, DEFAULT_RETAIN_MISSION, resolveBankMissionExtras, isHindsightEnabled } from "../memory/hindsight.js";
+import { createBank, updateBankMissions, ensureDeclaredMentalModels, DEFAULT_RETAIN_MISSION, resolveBankMissionExtras, isHindsightEnabled } from "../memory/hindsight.js";
 import { loadTopicState } from "../telegram/state.js";
 import { resolveDualPath } from "../config/paths.js";
 import { resolvePath } from "../config/loader.js";
@@ -4398,6 +4398,28 @@ export function scaffoldAgent(
         .catch((err) => {
           console.warn(`  ${chalk.yellow("⚠")} Bank mission update error for ${formatAgentBankLabel(name, hindsightBankId)}: ${err}`);
         });
+
+      // Ensure operator-DECLARED per-specialist mental models (Phase 5). Only
+      // models named in memory.mental_models are created — no blind seeding
+      // (that is the #2447 regression this avoids). Best-effort; never blocks.
+      ensureDeclaredMentalModels(
+        apiUrl,
+        hindsightBankId,
+        agentConfig.memory?.mental_models,
+        { timeoutMs: 5000 },
+      )
+        .then((outcomes) => {
+          for (const o of outcomes) {
+            if (o.ok) {
+              console.log(`  ${chalk.green("✓")} Mental model "${o.name}" ready for ${formatAgentBankLabel(name, hindsightBankId)}`);
+            } else {
+              console.warn(`  ${chalk.yellow("⚠")} Failed to ensure mental model "${o.name}" for ${formatAgentBankLabel(name, hindsightBankId)}: ${o.reason}`);
+            }
+          }
+        })
+        .catch((err) => {
+          console.warn(`  ${chalk.yellow("⚠")} Mental model ensure error for ${formatAgentBankLabel(name, hindsightBankId)}: ${err}`);
+        });
     });
   }
 
@@ -6416,6 +6438,29 @@ export function reconcileAgent(
             console.warn(`  ${chalk.yellow("⚠")} Bank mission update error for ${formatAgentBankLabel(name, hindsightBankId)}: ${err}`);
           });
       }
+
+      // Ensure operator-DECLARED per-specialist mental models (Phase 5) on
+      // reconcile too — declared models are the desired steady state, so a
+      // newly-added declaration lands on the next apply/restart. Only named
+      // models are created; nothing is auto-seeded. Best-effort; never blocks.
+      ensureDeclaredMentalModels(
+        apiUrl,
+        hindsightBankId,
+        agentConfig.memory?.mental_models,
+        { timeoutMs: 5000 },
+      )
+        .then((outcomes) => {
+          for (const o of outcomes) {
+            if (o.ok) {
+              console.log(`  ${chalk.green("✓")} Mental model "${o.name}" ready for ${formatAgentBankLabel(name, hindsightBankId)}`);
+            } else {
+              console.warn(`  ${chalk.yellow("⚠")} Failed to ensure mental model "${o.name}" for ${formatAgentBankLabel(name, hindsightBankId)}: ${o.reason}`);
+            }
+          }
+        })
+        .catch((err) => {
+          console.warn(`  ${chalk.yellow("⚠")} Mental model ensure error for ${formatAgentBankLabel(name, hindsightBankId)}: ${err}`);
+        });
     });
   }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -353,6 +353,69 @@ export const AgentMemorySchema = z
       .string()
       .optional()
       .describe("Instructions for the fact extraction LLM during retain. Cascade: override."),
+    mental_models: z
+      .array(
+        z.object({
+          name: z
+            .string()
+            .min(1)
+            .describe(
+              "Stable model name (identity key for idempotent ensure). Two " +
+              "declarations with the same name in one agent are rejected."
+            ),
+          source_query: z
+            .string()
+            .min(1)
+            .describe(
+              "The reflection query the model answers, semantically " +
+              "refreshed from the bank's content."
+            ),
+          refresh_after_consolidation: z
+            .boolean()
+            .optional()
+            .describe(
+              "Refresh this model after each consolidation. Defaults OFF — " +
+              "refresh adds bounded background model-spend + timeout risk " +
+              "(RFC Phase 5), so it is opt-in per model."
+            ),
+          max_tokens: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Cap on the synthesized model's token size."),
+        })
+      )
+      .superRefine((models, ctx) => {
+        const seen = new Set<string>();
+        for (let i = 0; i < models.length; i++) {
+          const key = models[i].name;
+          if (seen.has(key)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: [i, "name"],
+              message:
+                `duplicate mental_models name "${key}" — model names must be ` +
+                `unique within an agent (they are the idempotent-ensure key)`,
+            });
+          }
+          seen.add(key);
+        }
+      })
+      .optional()
+      .describe(
+        "Operator-declared, per-specialist Hindsight mental models (RFC " +
+        "Phase 5). Named, opt-in curated reflections this agent's bank should " +
+        "carry — e.g. a coach's 'training-plan-state' or a lawyer's " +
+        "'open-matters'. Ensured idempotently at scaffold/reconcile: NOTHING " +
+        "is created unless declared here (zero declarations = zero models, " +
+        "matching post-#2447 behaviour), and no fixed identity model is " +
+        "reintroduced — 'who the user is' stays owned by dedicated profile " +
+        "banks (users.*.profile_bank), never a per-agent model. Per-agent " +
+        "ONLY: intentionally not accepted at the defaults/profile tier, so a " +
+        "model can never be fleet-seeded — each specialist opts in on its own " +
+        "(the invariant-clean inverse of the retired blind auto-seeding)."
+      ),
     observations_mission: z
       .string()
       .optional()

--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -438,23 +438,66 @@ export async function probeHindsight(
 }
 
 /**
- * Ensure the user-profile Mental Model exists for a bank.
+ * A single operator-declared mental model for a bank.
  *
- * Creates the Mental Model if it doesn't exist, idempotent on subsequent calls.
- * The MM is pre-computed via reflection and answers "what do we know about the user?"
+ * These are the Phase-5 "curated per-specialist" models: named, opt-in,
+ * operator-authored in `switchroom.yaml` (`memory.mental_models`). Unlike the
+ * retired auto-seeded "user-profile" model (#2447), NOTHING is created unless
+ * the operator explicitly declares it — so zero declarations means zero models,
+ * exactly matching post-#2447 behaviour. This deliberately does NOT reintroduce
+ * a fixed identity model: "who the user is" stays owned by the dedicated profile
+ * banks (`users.*.profile_bank`), never a per-agent mental model.
+ */
+export interface MentalModelSpec {
+  /** Stable model name (the identity key for idempotent ensure). */
+  name: string;
+  /** The reflection query the model answers, refreshed from bank content. */
+  sourceQuery: string;
+  /**
+   * When true, Hindsight refreshes the model after each consolidation. Defaults
+   * OFF (undefined) — refresh adds bounded background model-spend + timeout risk
+   * (see RFC Phase 5), so it is opt-in per model.
+   */
+  refreshAfterConsolidation?: boolean;
+  /** Optional cap on the synthesized model's token size. */
+  maxTokens?: number;
+}
+
+/**
+ * Ensure a single, operator-declared Mental Model exists for a bank.
+ *
+ * Idempotent: creates the model if no model with `spec.name` exists, otherwise
+ * a no-op success. Matches existence by exact item NAME (a substring check
+ * false-positives across sibling models — see the history in the list step).
  *
  * @param apiUrl Hindsight MCP endpoint (e.g. "http://127.0.0.1:18888/mcp/")
  * @param bankId The bank ID to create the MM in
- * @param opts Optional fetch implementation and timeout
+ * @param spec   The declared model (name + source_query + optional knobs)
+ * @param opts   Optional fetch implementation and timeout
  * @returns {ok: true} on success, {ok: false, reason} on error
  */
-export async function ensureUserProfileMentalModel(
+export async function ensureMentalModel(
   apiUrl: string,
   bankId: string,
+  spec: MentalModelSpec,
   opts?: { fetchImpl?: typeof fetch; timeoutMs?: number }
 ): Promise<{ ok: true } | { ok: false; reason: string }> {
   const fetchImpl = opts?.fetchImpl ?? fetch;
   const timeoutMs = opts?.timeoutMs ?? 5000;
+
+  // Only send optional args when set — keeps the create payload minimal and
+  // schema-clean (props verified against tests/fixtures/hindsight-tools-list).
+  const createArguments: Record<string, unknown> = {
+    name: spec.name,
+    source_query: spec.sourceQuery,
+  };
+  if (spec.refreshAfterConsolidation !== undefined) {
+    createArguments.trigger_refresh_after_consolidation =
+      spec.refreshAfterConsolidation;
+  }
+  if (spec.maxTokens !== undefined) {
+    createArguments.max_tokens = spec.maxTokens;
+  }
 
   try {
     const controller = new AbortController();
@@ -539,7 +582,7 @@ export async function ensureUserProfileMentalModel(
         if (models && typeof models === "string") {
           const parsed = JSON.parse(models) as { items?: Array<{ name?: string }> };
           const items = Array.isArray(parsed?.items) ? parsed.items : [];
-          if (items.some((m) => m?.name === "user-profile")) {
+          if (items.some((m) => m?.name === spec.name)) {
             return { ok: true }; // Already exists (by exact name)
           }
         }
@@ -566,25 +609,18 @@ export async function ensureUserProfileMentalModel(
         method: "tools/call",
         params: {
           name: "create_mental_model",
-          arguments: {
-            name: "user-profile",
-            // The server's create_mental_model argument is `source_query`, not
-            // `query` (an upstream rename). Passing `query` returns HTTP 200
-            // with isError:true "Missing required argument: source_query" — and
-            // because the old code only checked `createResponse.ok` (HTTP
-            // status), it reported {ok:true} while creating NOTHING. That broke
-            // the user-profile mental model fleet-wide (the "knows you" feature):
-            // banks had zero mental models despite "ready". Fixed: correct arg +
-            // the isError check below.
-            source_query:
-              "What are the key facts, preferences, context, and communication style about the user I talk to? Summarize what matters for making the agent feel like it knows them.",
-            // NOTE: do NOT send `types` — create_mental_model's schema does not
-            // accept it (props: name, source_query, mental_model_id, tags,
-            // max_tokens, trigger_refresh_after_consolidation, bank_id), so the
-            // server SILENTLY DROPS it (isError stays false). The mental model
-            // draws across fact types from its source_query regardless. Adding a
-            // schema-unknown arg back here reds memory.hindsight-contract.fixture.
-          },
+          // The server's create_mental_model argument is `source_query`, not
+          // `query` (an upstream rename). Passing `query` returns HTTP 200 with
+          // isError:true "Missing required argument: source_query" — and if a
+          // caller only checked `createResponse.ok` (HTTP status), it would
+          // report {ok:true} while creating NOTHING (the isError check below
+          // guards that). Optional knobs (trigger_refresh_after_consolidation,
+          // max_tokens) are added by the caller in `createArguments` only when
+          // set. Do NOT add `types` — it is not in create_mental_model's schema
+          // (props: name, source_query, mental_model_id, tags, max_tokens,
+          // trigger_refresh_after_consolidation, bank_id); the server silently
+          // drops it and it reds memory.hindsight-contract.fixture.
+          arguments: createArguments,
         },
       }),
       signal: controller.signal,
@@ -620,6 +656,111 @@ export async function ensureUserProfileMentalModel(
     }
     return { ok: false, reason: String(err) };
   }
+}
+
+/**
+ * The source_query for the (retired-from-auto-wiring) user-profile model.
+ * Kept as a named constant so the dormant dashboard "Build profile" path and
+ * its tests share one definition. NOT auto-created by scaffold/reconcile any
+ * more (#2447) — dedicated profile banks own user identity.
+ */
+export const USER_PROFILE_SOURCE_QUERY =
+  "What are the key facts, preferences, context, and communication style about the user I talk to? Summarize what matters for making the agent feel like it knows them.";
+
+/**
+ * Ensure the user-profile Mental Model exists for a bank.
+ *
+ * DORMANT auto-wiring: scaffold/reconcile no longer call this (#2447 retired
+ * per-agent user-profile models in favour of dedicated profile banks). Kept for
+ * the operator-triggered dashboard "Build profile" path. Thin wrapper over the
+ * generalized {@link ensureMentalModel}.
+ */
+export async function ensureUserProfileMentalModel(
+  apiUrl: string,
+  bankId: string,
+  opts?: { fetchImpl?: typeof fetch; timeoutMs?: number }
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  return ensureMentalModel(
+    apiUrl,
+    bankId,
+    { name: "user-profile", sourceQuery: USER_PROFILE_SOURCE_QUERY },
+    opts
+  );
+}
+
+/**
+ * The raw shape of a `memory.mental_models[]` entry as it lands from
+ * switchroom.yaml (snake_case, post-cascade). Mapped to {@link MentalModelSpec}
+ * by {@link ensureDeclaredMentalModels}.
+ */
+export interface DeclaredMentalModelConfig {
+  name: string;
+  source_query: string;
+  refresh_after_consolidation?: boolean;
+  max_tokens?: number;
+}
+
+/**
+ * The result of ensuring one declared model, for legible scaffold/reconcile
+ * logging.
+ */
+export interface EnsureMentalModelOutcome {
+  name: string;
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Ensure every operator-DECLARED mental model exists for a bank (Phase 5).
+ *
+ * This is the invariant-clean replacement for the retired auto-seeding (#2447):
+ * it creates ONLY the models the operator named in `memory.mental_models`, so
+ * an agent with no declarations gets no models (identical to post-#2447
+ * behaviour). No fixed "user-profile" identity model is implied — that domain
+ * stays with the dedicated profile banks. Each model is ensured idempotently
+ * (create-if-absent by exact name); best-effort and never throws, so a slow or
+ * down Hindsight never blocks scaffold/reconcile.
+ *
+ * @param apiUrl  Hindsight MCP endpoint
+ * @param bankId  The agent's bank id
+ * @param models  The declared models (may be undefined / empty → no-op)
+ * @param opts    Optional fetch impl + per-model timeout
+ * @returns per-model outcomes (empty array when nothing was declared)
+ */
+export async function ensureDeclaredMentalModels(
+  apiUrl: string,
+  bankId: string,
+  models: DeclaredMentalModelConfig[] | undefined,
+  opts?: { fetchImpl?: typeof fetch; timeoutMs?: number }
+): Promise<EnsureMentalModelOutcome[]> {
+  if (!models || models.length === 0) return [];
+
+  const outcomes: EnsureMentalModelOutcome[] = [];
+  const seen = new Set<string>();
+  for (const m of models) {
+    // Defensive de-dupe (schema also rejects dupes) so one bad config can't
+    // double-create; first declaration wins.
+    if (seen.has(m.name)) continue;
+    seen.add(m.name);
+
+    const spec: MentalModelSpec = {
+      name: m.name,
+      sourceQuery: m.source_query,
+      refreshAfterConsolidation: m.refresh_after_consolidation,
+      maxTokens: m.max_tokens,
+    };
+    try {
+      const result = await ensureMentalModel(apiUrl, bankId, spec, opts);
+      outcomes.push(
+        result.ok
+          ? { name: m.name, ok: true }
+          : { name: m.name, ok: false, reason: result.reason }
+      );
+    } catch (err) {
+      outcomes.push({ name: m.name, ok: false, reason: String(err) });
+    }
+  }
+  return outcomes;
 }
 
 /**

--- a/tests/memory.mental-models.test.ts
+++ b/tests/memory.mental-models.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  ensureMentalModel,
+  ensureDeclaredMentalModels,
+  USER_PROFILE_SOURCE_QUERY,
+} from "../src/memory/hindsight.js";
+
+/**
+ * Phase 5 — operator-declared per-specialist mental models.
+ *
+ * The invariant these tests pin: NOTHING is created unless the operator
+ * declared it (no blind seeding — that is the #2447 regression), and the
+ * generalized ensure sends the schema-correct create payload.
+ */
+
+function initResponse() {
+  return {
+    ok: true,
+    headers: new Map([["mcp-session-id", "s"]]),
+    text: async () => "",
+  } as any;
+}
+function listResponse(names: string[]) {
+  const items = names.map((n) => ({ name: n }));
+  const inner = JSON.stringify({ items });
+  return {
+    ok: true,
+    text: async () =>
+      `data: {"result":{"content":[{"text":${JSON.stringify(inner)}}]}}\n`,
+  } as any;
+}
+function createOk() {
+  return { ok: true, text: async () => 'data: {"result":{"isError":false}}\n' } as any;
+}
+
+describe("ensureMentalModel — generalized create", () => {
+  it("creates a named model with the given source_query and no extra args when knobs unset", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(initResponse())
+      .mockResolvedValueOnce(listResponse([])) // empty → create
+      .mockResolvedValueOnce(createOk());
+
+    const result = await ensureMentalModel(
+      "http://test.local/mcp/",
+      "coach-bank",
+      { name: "training-plan-state", sourceQuery: "What is the athlete's current plan?" },
+      { fetchImpl: mockFetch as any },
+    );
+
+    expect(result).toEqual({ ok: true });
+    const createBody = JSON.parse(mockFetch.mock.calls[2][1].body);
+    expect(createBody.params.name).toBe("create_mental_model");
+    expect(createBody.params.arguments.name).toBe("training-plan-state");
+    expect(createBody.params.arguments.source_query).toBe(
+      "What is the athlete's current plan?",
+    );
+    // No optional knobs → payload stays minimal and schema-clean.
+    expect(createBody.params.arguments.trigger_refresh_after_consolidation).toBeUndefined();
+    expect(createBody.params.arguments.max_tokens).toBeUndefined();
+    // `query` (the wrong upstream name) and schema-unknown `types` must be absent.
+    expect(createBody.params.arguments.query).toBeUndefined();
+    expect(createBody.params.arguments.types).toBeUndefined();
+  });
+
+  it("forwards refresh_after_consolidation + max_tokens only when set", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(initResponse())
+      .mockResolvedValueOnce(listResponse([]))
+      .mockResolvedValueOnce(createOk());
+
+    await ensureMentalModel(
+      "http://test.local/mcp/",
+      "law-bank",
+      {
+        name: "open-matters",
+        sourceQuery: "Which matters are open?",
+        refreshAfterConsolidation: true,
+        maxTokens: 2048,
+      },
+      { fetchImpl: mockFetch as any },
+    );
+
+    const createBody = JSON.parse(mockFetch.mock.calls[2][1].body);
+    expect(createBody.params.arguments.trigger_refresh_after_consolidation).toBe(true);
+    expect(createBody.params.arguments.max_tokens).toBe(2048);
+  });
+
+  it("is idempotent — no create when a model with the same exact name exists", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(initResponse())
+      .mockResolvedValueOnce(listResponse(["open-matters"])); // present → skip create
+
+    const result = await ensureMentalModel(
+      "http://test.local/mcp/",
+      "law-bank",
+      { name: "open-matters", sourceQuery: "Which matters are open?" },
+      { fetchImpl: mockFetch as any },
+    );
+
+    expect(result).toEqual({ ok: true });
+    // Only init + list — create was NOT called.
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("matches existence by EXACT name — a substring sibling does not false-positive", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(initResponse())
+      .mockResolvedValueOnce(listResponse(["open-matters-archive"])) // substring-ish sibling
+      .mockResolvedValueOnce(createOk());
+
+    const result = await ensureMentalModel(
+      "http://test.local/mcp/",
+      "law-bank",
+      { name: "open-matters", sourceQuery: "Which matters are open?" },
+      { fetchImpl: mockFetch as any },
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledTimes(3); // create DID fire
+  });
+
+  it("USER_PROFILE_SOURCE_QUERY is exported and unchanged (dormant dashboard path)", () => {
+    expect(USER_PROFILE_SOURCE_QUERY).toContain("key facts, preferences");
+  });
+});
+
+describe("ensureDeclaredMentalModels — no blind seeding (the #2447 guard)", () => {
+  it("does NOTHING when no models are declared (undefined)", async () => {
+    const mockFetch = vi.fn();
+    const outcomes = await ensureDeclaredMentalModels(
+      "http://test.local/mcp/",
+      "bank",
+      undefined,
+      { fetchImpl: mockFetch as any },
+    );
+    expect(outcomes).toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("does NOTHING when the declared list is empty", async () => {
+    const mockFetch = vi.fn();
+    const outcomes = await ensureDeclaredMentalModels(
+      "http://test.local/mcp/",
+      "bank",
+      [],
+      { fetchImpl: mockFetch as any },
+    );
+    expect(outcomes).toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("ensures each declared model and reports per-model outcomes", async () => {
+    // Two models, both absent → each does init+list+create (6 calls total).
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(initResponse())
+      .mockResolvedValueOnce(listResponse([]))
+      .mockResolvedValueOnce(createOk())
+      .mockResolvedValueOnce(initResponse())
+      .mockResolvedValueOnce(listResponse([]))
+      .mockResolvedValueOnce(createOk());
+
+    const outcomes = await ensureDeclaredMentalModels(
+      "http://test.local/mcp/",
+      "coach-bank",
+      [
+        { name: "training-plan-state", source_query: "plan?" },
+        { name: "injury-history", source_query: "injuries?", max_tokens: 1024 },
+      ],
+      { fetchImpl: mockFetch as any },
+    );
+
+    expect(outcomes).toEqual([
+      { name: "training-plan-state", ok: true },
+      { name: "injury-history", ok: true },
+    ]);
+    expect(mockFetch).toHaveBeenCalledTimes(6);
+  });
+
+  it("surfaces a per-model failure honestly (ok:false with reason) without throwing", async () => {
+    const errorBody =
+      'data: {"result":{"isError":true,"content":[{"text":"boom"}]}}\n';
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(initResponse())
+      .mockResolvedValueOnce(listResponse([]))
+      .mockResolvedValueOnce({ ok: true, text: async () => errorBody } as any);
+
+    const outcomes = await ensureDeclaredMentalModels(
+      "http://test.local/mcp/",
+      "bank",
+      [{ name: "flaky", source_query: "q?" }],
+      { fetchImpl: mockFetch as any },
+    );
+
+    expect(outcomes).toEqual([{ name: "flaky", ok: false, reason: "boom" }]);
+  });
+});

--- a/tests/schema.mental-models.test.ts
+++ b/tests/schema.mental-models.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { AgentMemorySchema } from "../src/config/schema.js";
+
+/**
+ * Phase 5 config surface — `memory.mental_models[]`.
+ */
+describe("AgentMemorySchema.mental_models", () => {
+  it("accepts a valid per-specialist declaration", () => {
+    const parsed = AgentMemorySchema.parse({
+      collection: "b",
+      mental_models: [
+        { name: "training-plan-state", source_query: "What is the plan?" },
+        {
+          name: "injury-history",
+          source_query: "What injuries?",
+          refresh_after_consolidation: true,
+          max_tokens: 2048,
+        },
+      ],
+    });
+    expect(parsed.mental_models).toHaveLength(2);
+    expect(parsed.mental_models?.[1].refresh_after_consolidation).toBe(true);
+    expect(parsed.mental_models?.[1].max_tokens).toBe(2048);
+  });
+
+  it("is optional — omitting it is valid (zero-declaration = post-#2447 behaviour)", () => {
+    const parsed = AgentMemorySchema.parse({ collection: "b" });
+    expect(parsed.mental_models).toBeUndefined();
+  });
+
+  it("rejects duplicate model names within one agent", () => {
+    const result = AgentMemorySchema.safeParse({
+      collection: "b",
+      mental_models: [
+        { name: "dupe", source_query: "a?" },
+        { name: "dupe", source_query: "b?" },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("duplicate mental_models name");
+    }
+  });
+
+  it("rejects an empty name or empty source_query", () => {
+    expect(
+      AgentMemorySchema.safeParse({
+        collection: "b",
+        mental_models: [{ name: "", source_query: "q?" }],
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentMemorySchema.safeParse({
+        collection: "b",
+        mental_models: [{ name: "x", source_query: "" }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a non-positive / non-integer max_tokens", () => {
+    expect(
+      AgentMemorySchema.safeParse({
+      collection: "b",
+        mental_models: [{ name: "x", source_query: "q?", max_tokens: 0 }],
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentMemorySchema.safeParse({
+      collection: "b",
+        mental_models: [{ name: "x", source_query: "q?", max_tokens: 1.5 }],
+      }).success,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 5 of the Hindsight synthesis-layers RFC — *curated per-specialist mental models* — was the least-defined phase and was arguably **regressed** by #2447. That PR retired per-agent `user-profile` mental models because they were **blind-seeded into every bank** on every apply/restart and **collided with the dedicated profile banks** (`users.*.profile_bank`) that are the real source of truth for "who the user is" — the "Rex" wrong-dog bug. So today there is *no* automated per-specialist mental-model curation at all.

This PR **leads with design**, then ships the safest first slice that avoids the exact failure #2447 removed.

## Path chosen — operator-declared, per-specialist models (declarative, not autonomous)

The RFC's invariant-clean shape for Phase 5 is *"operator-curated, or agent-proposes → operator-confirms, never a silent self-write."* This lands the **operator-curated declarative** half. It avoids each #2447 harm by construction:

- **No blind seeding.** Nothing is created unless the operator declares it in `memory.mental_models`. Zero declarations = byte-for-byte the post-#2447 behaviour. There is no default model.
- **No identity collision.** No fixed `user-profile`-shaped model is reintroduced; profile banks still own identity. Per-specialist models answer *domain* questions (a coach's `training-plan-state`, a lawyer's `open-matters`), not *who the user is*.
- **No self-escalation.** Declarations live in `switchroom.yaml`, operator-edited only; the agent never self-creates a model.
- **No fleet-wide over-seeding.** The field is accepted at the **per-agent tier only** (intentionally *not* `defaults`/profile), so a model can never be pushed across the whole fleet in one line.
- **Refresh is opt-in, off by default** (`refresh_after_consolidation`) — static curated models still speed the explicit `reflect` path without the invisible background spend/timeout risk the RFC flags.

Full reasoning: **`reference/rfcs/hindsight-phase5-mental-model-curation.md`** (new design note).

## What it implements

- **Config** (`src/config/schema.ts`): `memory.mental_models[]` — `{ name, source_query, refresh_after_consolidation?, max_tokens? }`, per-agent only, with a duplicate-name `superRefine` guard.
- **Engine** (`src/memory/hindsight.ts`): generalized `ensureMentalModel(apiUrl, bankId, spec)` (the old `ensureUserProfileMentalModel` is now a thin **dormant** wrapper over it — the dashboard "Build profile" path still works); `ensureDeclaredMentalModels(...)` iterates the declared set and returns per-model outcomes for legible logging. Exact-name idempotency preserved.
- **Wiring** (`src/agents/scaffold.ts`): scaffold **and** reconcile ensure the declared set, best-effort with a 5s per-model timeout, non-blocking, one log line per model.

## Test plan

New suites (`tests/memory.mental-models.test.ts`, `tests/schema.mental-models.test.ts`): generalized create-payload shape, optional-knob forwarding, exact-name idempotency, substring-sibling non-false-positive, the **no-blind-seeding guard** (undefined/empty → zero fetches), honest per-model failure surfacing, and schema accept/reject (duplicate names, empty name/query, invalid `max_tokens`). All green; pre-existing memory/scaffold/config suites stay green. `tsc --noEmit` + `npm run lint` clean.

(Some unrelated suites fail in a fresh worktree that hasn't run `bun run build` — `dist/...`-exists guards, boot-self-test, python-venv `deps`, HOME-symlink — verified identical on pristine `main` with these changes stashed, so they are pre-existing/environmental, not from this PR.)

## Open product decision (for the operator)

**Should there ever be a curated *default* model, or is per-agent-only opt-in the final answer?** This slice ships zero defaults on purpose — any fleet-wide default re-creates the "seeded whether earned or not" shape #2447 removed. If a genuinely universal model later proves worth defaulting, the right vehicle is the **agent-proposes → operator-confirms** flow (a follow-up), not a silent default. Flagged, not decided.

## Not done (deliberate follow-ups)

- Agent-proposes-→-operator-confirms-in-chat (the other half of the RFC shape; needs an approval-card flow).
- Autonomous creation — **never** (RFC non-goal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
