### PR TITLE
fix: Hindsight port collision — default 18888, loud preflight, memory-down health check + regression tests

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2426,7 +2426,7 @@ export function installHindsightPlugin(
   // /mcp/ MCP endpoint URL — strip the suffix.
   const bankId = agentMemory?.collection ?? agentName;
   const mcpUrl = (memory.config?.url as string | undefined)
-    ?? "http://127.0.0.1:8888/mcp/";
+    ?? "http://127.0.0.1:18888/mcp/";
   const apiBaseUrl = mcpUrl.replace(/\/mcp\/?$/, "").replace(/\/$/, "");
 
   return { pluginDir: destPath, apiBaseUrl, bankId };
@@ -3368,7 +3368,7 @@ export function scaffoldAgent(
   const hindsightBankId = agentConfig.memory?.collection ?? name;
   const hindsightApiBaseUrl = (switchroomConfig?.memory?.config?.url as string | undefined)
     ? (switchroomConfig!.memory!.config!.url as string).replace(/\/mcp\/?$/, "").replace(/\/$/, "")
-    : "http://127.0.0.1:8888";
+    : "http://127.0.0.1:18888";
   // Cascading recall cap. Per-agent value already merged from defaults
   // by config/merge.ts (memory is shallow-merged), so reading
   // agentConfig.memory.recall.max_memories here picks up the resolved
@@ -5501,7 +5501,7 @@ export function reconcileAgent(
   const hindsightBankId = agentConfig.memory?.collection ?? name;
   const hindsightApiBaseUrl = (switchroomConfig.memory?.config?.url as string | undefined)
     ? (switchroomConfig.memory!.config!.url as string).replace(/\/mcp\/?$/, "").replace(/\/$/, "")
-    : "http://127.0.0.1:8888";
+    : "http://127.0.0.1:18888";
   const hindsightRecallMaxMemories = agentConfig.memory?.recall?.max_memories;
   const hindsightRecallCacheTtlSecs = agentConfig.memory?.recall?.cache_ttl_secs;
   const hindsightRecallMinOverlap = agentConfig.memory?.recall?.min_overlap;

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -308,7 +308,7 @@ function buildStatusInputs(
   if (isHindsightEnabled(config)) {
     const baseUrl =
       (config.memory?.config?.url as string | undefined) ??
-      "http://localhost:8888/mcp/";
+      "http://localhost:18888/mcp/";
     hindsightApiUrl = baseUrl.endsWith("/mcp/")
       ? baseUrl
       : baseUrl.replace(/\/$/, "") + "/mcp/";
@@ -898,7 +898,7 @@ export function registerAgentCommand(program: Command): void {
         let hindsightBankId = name;
         if (isHindsightEnabled(config)) {
           const baseUrl = (config.memory?.config?.url as string | undefined)
-            ?? "http://localhost:8888/mcp/";
+            ?? "http://localhost:18888/mcp/";
           // Normalize to end in /mcp/
           hindsightApiUrl = baseUrl.endsWith("/mcp/")
             ? baseUrl

--- a/src/cli/doctor-memory.ts
+++ b/src/cli/doctor-memory.ts
@@ -156,6 +156,79 @@ export function checkHindsightContainerHealth(
 }
 
 /**
+ * Pure: classify the result of a `GET <hindsight>/health` probe into a doctor
+ * result. A memory outage (container down, crash-looping on a port collision,
+ * or wedged) is otherwise SILENT — auto-recall failing produces no user-facing
+ * error, so the fleet goes amnesiac unnoticed (the 2026-07 incident ran ~9h
+ * before anyone noticed). A non-200 /health flips this red.
+ *
+ * `status` is the HTTP status code, or `null` when the request never completed
+ * (connection refused / timeout — the crash-loop signature).
+ */
+export function classifyHindsightHealthProbe(
+  status: number | null,
+  port: number,
+): CheckResult {
+  if (status === 200) {
+    return {
+      name: "hindsight /health",
+      status: "ok",
+      detail: `200 at :${port} — memory backend live`,
+    };
+  }
+  if (status === null) {
+    return {
+      name: "hindsight /health",
+      status: "fail",
+      detail:
+        `no response on :${port} — the container is down or crash-looping ` +
+        `(fleet memory is silently OFF: auto-recall/retain fail with no user error)`,
+      fix:
+        "Check `docker logs switchroom-hindsight` for `[Errno 98] address " +
+        "already in use` (a foreign process on the port) and run " +
+        "`switchroom memory --start` — the launcher now preflights the port " +
+        "and reassigns instead of crash-looping.",
+    };
+  }
+  return {
+    name: "hindsight /health",
+    status: "fail",
+    detail: `HTTP ${status} at :${port} — memory backend unhealthy`,
+    fix: "Inspect `docker logs switchroom-hindsight`; restart with `switchroom memory --restart`.",
+  };
+}
+
+/**
+ * Best-effort async wrapper: GET `<mcpUrl origin>/health` and classify it.
+ * Derives the health URL from the MCP url (strips the `/mcp/` suffix). Fails
+ * closed to a `fail` result (never throws) so a memory outage surfaces even
+ * when the probe itself errors.
+ */
+export async function checkHindsightHealthEndpoint(
+  mcpUrl: string,
+  opts: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<CheckResult> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  const timeoutMs = opts.timeoutMs ?? 4000;
+  const origin = mcpUrl.replace(/\/mcp\/?$/, "").replace(/\/$/, "");
+  const healthUrl = `${origin}/health`;
+  const port = (() => {
+    const m = origin.match(/:(\d+)(?:$|\/)/);
+    return m ? parseInt(m[1], 10) : 80;
+  })();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await doFetch(healthUrl, { signal: controller.signal });
+    return classifyHindsightHealthProbe(res.status, port);
+  } catch {
+    return classifyHindsightHealthProbe(null, port);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * An advertised hindsight tool as returned by tools/list — just the bits the
  * contract check needs.
  */

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -29,7 +29,7 @@ import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
 import { loadManifest, detectDrift, type DriftProbers } from "../manifest.js";
 import { probeHindsight, isHindsightEnabled, fetchHindsightToolsList, collectProfileBanks } from "../memory/hindsight.js";
 import { inspectBankHealth, staleMentalModels, corruptedMentalModels, recentUnextracted, ageDays } from "../memory/bank-health.js";
-import { checkHindsightContainerHealth, classifyToolContract } from "./doctor-memory.js";
+import { checkHindsightContainerHealth, classifyToolContract, checkHindsightHealthEndpoint } from "./doctor-memory.js";
 import { isDockerMode, runDockerChecks } from "./doctor-docker.js";
 import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
 import { runHostdChecks } from "./doctor-hostd.js";
@@ -1170,7 +1170,7 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
   }
 
   const url = (config.memory?.config?.url as string | undefined)
-    ?? "http://localhost:8888/mcp/";
+    ?? "http://localhost:18888/mcp/";
 
   const results: CheckResult[] = [];
 
@@ -1249,6 +1249,11 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
   // (shm exhaustion or OAuth quota 429). These surface both from the local
   // container's shm config + recent logs; no-ops on a remote/dockerless setup.
   results.push(...checkHindsightContainerHealth());
+
+  // Memory-down signal (#outage 2026-07): a GET /health != 200 means the
+  // backend is down / crash-looping — otherwise invisible, since auto-recall
+  // and retain fail with no user-facing error. Make the outage loud here.
+  results.push(await checkHindsightHealthEndpoint(url));
 
   // Per-agent bank ingest health (2026-06-10 incident class): a bank can be
   // reachable and growing while fact extraction silently yields ZERO memory

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -352,6 +352,41 @@ export function registerMemoryCommand(program: Command): void {
       let ports: { apiPort: number; uiPort: number };
       if (reusePorts) {
         ports = reusePorts;
+        // Migration hazard: --recreate pins the container to the SAME host
+        // port it currently publishes, but fresh scaffolding now defaults
+        // memory.config.url to HINDSIGHT_DEFAULT_API_PORT (18888). If the
+        // reused port diverges AND no agent has an explicit memory.config.url,
+        // agents may be repointed to a dead URL. Warn loudly; do NOT
+        // auto-migrate (too risky mid-recreate).
+        if (reusePorts.apiPort !== HINDSIGHT_DEFAULT_API_PORT) {
+          let explicitUrl: string | undefined;
+          try {
+            explicitUrl = getConfig(program).memory?.config?.url;
+          } catch {
+            explicitUrl = undefined;
+          }
+          if (!explicitUrl) {
+            console.log(
+              chalk.yellow(
+                `\n  ⚠  MIGRATION HAZARD: reusing stale host port ${reusePorts.apiPort} ` +
+                `for switchroom-hindsight, but scaffolding now defaults to ` +
+                `${HINDSIGHT_DEFAULT_API_PORT} and no explicit memory.config.url is set.`,
+              ),
+            );
+            console.log(
+              chalk.yellow(
+                `  Agents may be repointed to a dead URL (http://127.0.0.1:${HINDSIGHT_DEFAULT_API_PORT}/mcp/) ` +
+                `while the container listens on ${reusePorts.apiPort}.`,
+              ),
+            );
+            console.log(
+              chalk.yellow(
+                `  Fix: set memory.config.url: http://127.0.0.1:${reusePorts.apiPort}/mcp/ explicitly, ` +
+                `or migrate the container to port ${HINDSIGHT_DEFAULT_API_PORT}.\n`,
+              ),
+            );
+          }
+        }
       } else {
         try {
           ports = await pickHindsightPorts();

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -20,6 +20,7 @@ import {
   pickHindsightPorts,
   pullHindsightImage,
   getRunningHindsightPorts,
+  preflightHindsightPorts,
   HINDSIGHT_DEFAULT_API_PORT,
   type LiteLLMHindsightConfig,
 } from "../setup/hindsight.js";
@@ -368,6 +369,45 @@ export function registerMemoryCommand(program: Command): void {
         );
       }
 
+      // Preflight: NEVER hand an occupied host port to `docker run` — that's
+      // the 2026-07 outage (the --recreate path reused the previously-bound
+      // port with no free-check, so hindsight crash-looped on `[Errno 98]
+      // address already in use` while fleet memory was silently down). The
+      // reuse path (getRunningHindsightPorts) especially bypasses
+      // pickHindsightPorts entirely, so re-validate here for BOTH paths.
+      let conflict = await preflightHindsightPorts(ports);
+      if (conflict) {
+        const heldBy = conflict.holder ? ` (held by ${conflict.holder})` : "";
+        console.log(
+          chalk.yellow(
+            `\n  Chosen Hindsight port ${conflict.port} is occupied${heldBy}; ` +
+            `selecting a free port instead of crash-looping.`,
+          ),
+        );
+        // Re-pick from scratch (skips the occupied port via findFreePort).
+        try {
+          ports = await pickHindsightPorts();
+        } catch (err) {
+          console.error(chalk.red(`\n  ${(err as Error).message}\n`));
+          process.exit(1);
+        }
+        conflict = await preflightHindsightPorts(ports);
+        if (conflict) {
+          const stillHeldBy = conflict.holder ? ` (held by ${conflict.holder})` : "";
+          console.error(
+            chalk.red(
+              `\n  Refusing to start Hindsight: port ${conflict.port} is still ` +
+              `occupied${stillHeldBy} after reassignment. Free it and retry ` +
+              `\`switchroom memory --start\`.\n`,
+            ),
+          );
+          process.exit(1);
+        }
+        console.log(
+          chalk.green(`  Reassigned Hindsight to port ${ports.apiPort}/${ports.uiPort}.`),
+        );
+      }
+
       // RFC H §4.8 — hindsight runs in broker-fed mode against the
       // upstream `claude-code` LLM provider. No API key is needed; the
       // entrypoint shim fetches OAuth credentials from the auth-broker
@@ -584,7 +624,7 @@ export function registerMemoryCommand(program: Command): void {
           const collection = getCollectionForAgent(agent, config);
           const apiUrl =
             (config.memory?.config?.url as string | undefined) ??
-            "http://localhost:8888/mcp/";
+            "http://localhost:18888/mcp/";
           const timeoutMs = Math.max(500, parseInt(opts.timeout, 10) || 5000);
 
           console.log(
@@ -638,7 +678,7 @@ export function registerMemoryCommand(program: Command): void {
   // memory.recall.additional_banks. Single-tenant — the operator's own data
   // in the operator's Hindsight instance.
   const restBase = (url: string | undefined): string =>
-    (url ?? "http://127.0.0.1:8888/mcp/")
+    (url ?? "http://127.0.0.1:18888/mcp/")
       .replace(/\/mcp\/?$/, "")
       .replace(/\/$/, "");
   const VALID_BANK = /^[a-zA-Z0-9_.-]+$/;

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1045,8 +1045,8 @@ async function stepMemoryBackend(
 
     if (isHindsightRunning()) {
       spin.stop(chalk.green(`${STEP_DONE} Hindsight container started (switchroom-hindsight)`));
-      console.log(chalk.gray("  API: http://localhost:8888/mcp"));
-      console.log(chalk.gray("  UI:  http://localhost:9999"));
+      console.log(chalk.gray("  API: http://localhost:18888/mcp"));
+      console.log(chalk.gray("  UI:  http://localhost:19999"));
     } else {
       spin.stop(chalk.yellow("Container started but may still be initializing"));
     }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -36,6 +36,9 @@ import {
   stopHindsight,
   ensureHindsightConsumer,
   HINDSIGHT_CONSUMER_NAME,
+  HINDSIGHT_DEFAULT_API_PORT,
+  pickHindsightPorts,
+  preflightHindsightPorts,
   type LiteLLMHindsightConfig,
 } from "../setup/hindsight.js";
 import { getViaBrokerStructured } from "../vault/broker/client.js";
@@ -1034,19 +1037,75 @@ async function stepMemoryBackend(
     stopHindsight();
   }
 
+  // Pick + preflight host ports through the SAME guard `switchroom memory`
+  // uses, so a fresh install never hands an occupied host port to
+  // `docker run` (the 2026-07 crash-loop: hindsight died on `[Errno 98]
+  // address already in use` while fleet memory was silently down). Upstream
+  // default 18888/19999 first, fall back to a free pair if occupied.
+  let ports: { apiPort: number; uiPort: number };
+  try {
+    ports = await pickHindsightPorts();
+  } catch (err) {
+    console.log(chalk.red(`  ${(err as Error).message}`));
+    return;
+  }
+  if (ports.apiPort !== HINDSIGHT_DEFAULT_API_PORT) {
+    console.log(
+      chalk.yellow(
+        `  Port ${HINDSIGHT_DEFAULT_API_PORT} is already in use; ` +
+          `using ${ports.apiPort}/${ports.uiPort} instead.`,
+      ),
+    );
+  }
+
+  // Preflight: NEVER hand an occupied host port to `docker run`. If the
+  // chosen port is occupied, re-pick from scratch; if still occupied, abort
+  // loudly rather than crash-looping.
+  let conflict = await preflightHindsightPorts(ports);
+  if (conflict) {
+    const heldBy = conflict.holder ? ` (held by ${conflict.holder})` : "";
+    console.log(
+      chalk.yellow(
+        `  Chosen Hindsight port ${conflict.port} is occupied${heldBy}; ` +
+          `selecting a free port instead of crash-looping.`,
+      ),
+    );
+    try {
+      ports = await pickHindsightPorts();
+    } catch (err) {
+      console.log(chalk.red(`  ${(err as Error).message}`));
+      return;
+    }
+    conflict = await preflightHindsightPorts(ports);
+    if (conflict) {
+      const stillHeldBy = conflict.holder ? ` (held by ${conflict.holder})` : "";
+      console.log(
+        chalk.red(
+          `  Refusing to start Hindsight: port ${conflict.port} is still ` +
+            `occupied${stillHeldBy} after reassignment. Free it and re-run ` +
+            "`switchroom setup`.",
+        ),
+      );
+      return;
+    }
+    console.log(
+      chalk.green(`  Reassigned Hindsight to port ${ports.apiPort}/${ports.uiPort}.`),
+    );
+  }
+
   // Start the container in broker-fed mode (no API key).
   const spin = spinner("Starting Hindsight Docker container...");
   try {
     const litellmCfg = await resolveLiteLLMForHindsight(config);
-    startHindsight(undefined, litellmCfg);
+    startHindsight(ports, litellmCfg);
     if (litellmCfg) {
       console.log(chalk.gray("  LiteLLM routing enabled (--network host, ANTHROPIC_BASE_URL set)."));
     }
 
     if (isHindsightRunning()) {
       spin.stop(chalk.green(`${STEP_DONE} Hindsight container started (switchroom-hindsight)`));
-      console.log(chalk.gray("  API: http://localhost:18888/mcp"));
-      console.log(chalk.gray("  UI:  http://localhost:19999"));
+      console.log(chalk.gray(`  API: http://localhost:${ports.apiPort}/mcp`));
+      console.log(chalk.gray(`  UI:  http://localhost:${ports.uiPort}`));
     } else {
       spin.stop(chalk.yellow("Container started but may still be initializing"));
     }

--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -1,5 +1,6 @@
 import type { SwitchroomConfig, MemoryBackendConfig } from "../config/schema.js";
 import { resolveUsers } from "../config/users.js";
+import { HINDSIGHT_DEFAULT_API_PORT, HINDSIGHT_DEFAULT_MCP_URL } from "../setup/hindsight.js";
 
 export interface McpServerConfig {
   type?: string;
@@ -26,17 +27,17 @@ export interface McpServerConfig {
  * Generate the MCP server config entry for Hindsight.
  *
  * Hindsight exposes MCP via Streamable HTTP at /mcp/. The host/port can be
- * overridden in switchroom.yaml's memory.config.url; defaults to localhost:8888
- * (the upstream default). Note that 8888 conflicts with Coolify and other
- * common services — host the container on 18888 and set memory.config.url
- * accordingly.
+ * overridden in switchroom.yaml's memory.config.url; defaults to 127.0.0.1:18888
+ * (HINDSIGHT_DEFAULT_MCP_URL). The upstream default of 8888 conflicts with
+ * Coolify, nginx front-proxies and tunnel gateways — hence the 18888 default,
+ * which the launcher binds and the scaffolding writes in lockstep.
  */
 export function generateHindsightMcpConfig(
   collection: string,
   memoryConfig: MemoryBackendConfig,
 ): McpServerConfig {
   const url = (memoryConfig.config?.url as string | undefined)
-    ?? "http://localhost:8888/mcp/";
+    ?? HINDSIGHT_DEFAULT_MCP_URL;
   return {
     type: "http",
     url,
@@ -67,8 +68,8 @@ export function generateDockerComposeSnippet(
     "hindsight:",
     "  image: ghcr.io/vectorize-io/hindsight:latest",
     "  ports:",
-    "    - \"8888:8888\"",
-    "    - \"9999:9999\"",
+    `    - "${HINDSIGHT_DEFAULT_API_PORT}:8888"`,
+    "    - \"19999:9999\"",
     "  environment:",
     ...envLines,
     "  volumes:",

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -2,10 +2,34 @@ import { execFileSync } from "node:child_process";
 import { createServer } from "node:net";
 
 /**
- * Default Hindsight ports (upstream defaults).
+ * Default Hindsight host ports.
+ *
+ * The API port defaults to **18888**, NOT the upstream default of 8888.
+ * 8888 is a heavily-contended port on a typical host — Coolify, nginx
+ * front-proxies, tunnel gateways, and Jupyter all grab it. Because the
+ * hindsight container runs `--network host` and binds `HINDSIGHT_API_PORT`
+ * directly on the host, a default of 8888 collided with a foreign listener
+ * (nginx-tunnel-gateway on 127.0.0.1:8888) and crash-looped for hours while
+ * fleet memory was silently down (2026-07 incident). Defaulting to 18888
+ * — a port nothing else conventionally claims — removes the collision at the
+ * source. `pickHindsightPorts()` + the caller-side preflight still guard
+ * against 18888 itself being occupied.
+ *
+ * The UI port stays at 9999 (uncontended in the incident); it is
+ * informational and unused by switchroom.
  */
-export const HINDSIGHT_DEFAULT_API_PORT = 8888;
+export const HINDSIGHT_DEFAULT_API_PORT = 18888;
 export const HINDSIGHT_DEFAULT_UI_PORT = 9999;
+
+/**
+ * Default MCP endpoint URL switchroom writes into agent `.mcp.json` /
+ * `memory.config.url` when the operator hasn't overridden it. Derived from
+ * `HINDSIGHT_DEFAULT_API_PORT` so the scaffolded URL and the container's
+ * bound port can never silently drift apart — the exact failure mode behind
+ * the 2026-07 outage (agents pointed at 18888 while the container bound
+ * 8888). Change the port in ONE place and both move together.
+ */
+export const HINDSIGHT_DEFAULT_MCP_URL = `http://127.0.0.1:${HINDSIGHT_DEFAULT_API_PORT}/mcp/`;
 
 /**
  * Default cap on observations per *tag scope*.
@@ -341,6 +365,75 @@ export function isPortFree(port: number): Promise<boolean> {
 }
 
 /**
+ * Best-effort: describe the process currently holding `port`, for a loud
+ * preflight error. Returns a short "pid 1234 (nginx)" style string, or null
+ * when nothing readable holds it (or the probe tools aren't available). Never
+ * throws — this is decoration on an error message, not a control-flow signal.
+ */
+export function describePortHolder(port: number): string | null {
+  // `ss` is present on virtually every modern Linux host and needs no root
+  // to list listeners with their owning process (-p). Fall back to `lsof`.
+  const probes: Array<[string, string[]]> = [
+    ["ss", ["-ltnpH", `sport = :${port}`]],
+    ["lsof", ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN"]],
+  ];
+  for (const [cmd, args] of probes) {
+    try {
+      const out = execFileSync(cmd, args, {
+        stdio: "pipe",
+        encoding: "utf-8",
+      }).trim();
+      if (!out) continue;
+      // ss users:(("nginx",pid=1234,fd=6))  |  lsof: nginx 1234 ...
+      const ssMatch = out.match(/users:\(\("([^"]+)",pid=(\d+)/);
+      if (ssMatch) return `pid ${ssMatch[2]} (${ssMatch[1]})`;
+      const firstDataLine = out
+        .split("\n")
+        .map((l) => l.trim())
+        .find((l) => l && !/^COMMAND\b/.test(l));
+      if (firstDataLine) {
+        const parts = firstDataLine.split(/\s+/);
+        if (cmd === "lsof" && parts.length >= 2) {
+          return `pid ${parts[1]} (${parts[0]})`;
+        }
+        return firstDataLine.slice(0, 80);
+      }
+    } catch {
+      // tool missing / non-zero exit — try the next probe.
+    }
+  }
+  return null;
+}
+
+/**
+ * Preflight guard run by callers immediately before `startHindsight()`.
+ * Verifies the chosen host ports are actually bindable RIGHT NOW; if a
+ * foreign process already holds one, returns the offending port + a
+ * best-effort holder description so the caller can fail LOUD (or reassign)
+ * instead of launching a container that will crash-loop on `[Errno 98]
+ * address already in use`.
+ *
+ * This closes the exact gap behind the 2026-07 outage: the `--recreate`
+ * path reused the previously-published host port via
+ * `getRunningHindsightPorts()` and handed it straight to `docker run`,
+ * with no free-check — so when a foreign service (nginx) had claimed that
+ * port in the meantime, hindsight crash-looped silently.
+ *
+ * Returns `null` when both ports are free.
+ */
+export async function preflightHindsightPorts(ports: {
+  apiPort: number;
+  uiPort: number;
+}): Promise<{ port: number; holder: string | null } | null> {
+  for (const port of [ports.apiPort, ports.uiPort]) {
+    if (!(await isPortFree(port))) {
+      return { port, holder: describePortHolder(port) };
+    }
+  }
+  return null;
+}
+
+/**
  * Find a free port starting at `start`, incrementing until one is found
  * or `maxAttempts` ports have been tried.
  */
@@ -616,6 +709,13 @@ export function pullHindsightImage(imageTag?: string): void {
  * `pickHindsightPorts()`.
  */
 export function getRunningHindsightPorts(): { apiPort: number; uiPort: number } | null {
+  // The container's INTERNAL ports are fixed by the image (8888 API, 9999 UI)
+  // regardless of what host port they're published on. `docker port` is keyed
+  // by the container port, so these are constants — NOT the host defaults.
+  // (Before the 18888 default this coincidentally equaled the host default;
+  // decoupling them here keeps recreate working after the default moved.)
+  const CONTAINER_API_PORT = 8888;
+  const CONTAINER_UI_PORT = 9999;
   const readPort = (containerPort: number): number | null => {
     try {
       const out = execFileSync(
@@ -632,12 +732,12 @@ export function getRunningHindsightPorts(): { apiPort: number; uiPort: number } 
       return null;
     }
   };
-  const apiPort = readPort(HINDSIGHT_DEFAULT_API_PORT);
+  const apiPort = readPort(CONTAINER_API_PORT);
   if (apiPort === null) return null;
   // The UI port is informational (unused by switchroom); reuse it if
-  // readable, else derive the standard pair (8888→9999, 18888→19999).
+  // readable, else derive the standard pair (18888→19999, 8888→9999).
   const uiPort =
-    readPort(HINDSIGHT_DEFAULT_UI_PORT) ??
+    readPort(CONTAINER_UI_PORT) ??
     (apiPort === HINDSIGHT_DEFAULT_API_PORT ? HINDSIGHT_DEFAULT_UI_PORT : 19999);
   return { apiPort, uiPort };
 }
@@ -661,13 +761,14 @@ export function getHindsightStatus(): string | null {
 
 /**
  * Get the MCP server config for Hindsight via HTTP endpoint.
- * Hindsight exposes MCP via Streamable HTTP at localhost:8888/mcp.
+ * Hindsight exposes MCP via Streamable HTTP; switchroom publishes it on the
+ * host at HINDSIGHT_DEFAULT_MCP_URL (127.0.0.1:18888/mcp/ by default).
  */
 export function getHindsightMcpUrl(): {
   url: string;
 } {
   return {
-    url: "http://localhost:8888/mcp/",
+    url: HINDSIGHT_DEFAULT_MCP_URL,
   };
 }
 
@@ -688,8 +789,11 @@ export function generateHindsightComposeSnippet(): string {
     `    image: ${HINDSIGHT_IMAGE}`,
     "    container_name: switchroom-hindsight",
     "    ports:",
-    "      - \"8888:8888\"",
-    "      - \"9999:9999\"",
+    // Host side 18888/19999 → container 8888/9999. The host port MUST match
+    // HINDSIGHT_DEFAULT_API_PORT / the scaffolded memory.config.url or agents
+    // point at a dead URL (see the 2026-07 outage).
+    `      - "${HINDSIGHT_DEFAULT_API_PORT}:8888"`,
+    "      - \"19999:9999\"",
     "    environment:",
     `      - HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=${HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE}`,
     "      - HINDSIGHT_API_LLM_PROVIDER=claude-code",

--- a/tests/cli.doctor.memory-health.test.ts
+++ b/tests/cli.doctor.memory-health.test.ts
@@ -6,6 +6,8 @@ import {
   classifyExtractionLogs,
   checkHindsightContainerHealth,
   classifyToolContract,
+  classifyHindsightHealthProbe,
+  checkHindsightHealthEndpoint,
   type AdvertisedTool,
   MIN_HINDSIGHT_SHM_BYTES,
 } from "../src/cli/doctor-memory.js";
@@ -150,5 +152,52 @@ describe("checkHindsightContainerHealth (docker wrapper)", () => {
     const results = checkHindsightContainerHealth({ exec });
     expect(results.find((r) => r.name === "hindsight shm-size")?.status).toBe("fail");
     expect(results.find((r) => r.name === "hindsight extraction")?.status).toBe("fail");
+  });
+});
+
+// ─── Memory-down /health signal (2026-07 outage) ─────────────────────────────
+//
+// The outage was invisible: hindsight crash-looped on an occupied port while
+// auto-recall/retain failed silently (no user-facing error). A GET /health
+// check makes the outage LOUD in `switchroom doctor`.
+describe("classifyHindsightHealthProbe — memory-down signal", () => {
+  it("200 → ok", () => {
+    const r = classifyHindsightHealthProbe(200, 18888);
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("18888");
+  });
+
+  it("null (connection refused / crash-loop) → fail, names the silent-outage risk", () => {
+    const r = classifyHindsightHealthProbe(null, 18888);
+    expect(r.status).toBe("fail");
+    expect(r.detail).toMatch(/down or crash-looping|silently/i);
+    expect(r.fix).toContain("switchroom memory");
+  });
+
+  it("non-200 (e.g. 503) → fail", () => {
+    const r = classifyHindsightHealthProbe(503, 18888);
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("503");
+  });
+});
+
+describe("checkHindsightHealthEndpoint — async probe wrapper", () => {
+  it("derives /health from the MCP url and reports ok on 200", async () => {
+    const seen: string[] = [];
+    const fetchImpl = (async (u: string | URL) => {
+      seen.push(String(u));
+      return { status: 200 } as Response;
+    }) as unknown as typeof fetch;
+    const r = await checkHindsightHealthEndpoint("http://127.0.0.1:18888/mcp/", { fetchImpl });
+    expect(seen[0]).toBe("http://127.0.0.1:18888/health");
+    expect(r.status).toBe("ok");
+  });
+
+  it("a rejected fetch (container down) fails closed to a loud fail", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("connect ECONNREFUSED 127.0.0.1:18888");
+    }) as unknown as typeof fetch;
+    const r = await checkHindsightHealthEndpoint("http://127.0.0.1:18888/mcp/", { fetchImpl });
+    expect(r.status).toBe("fail");
   });
 });

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -43,7 +43,7 @@ describe("generateHindsightMcpConfig", () => {
     const memConfig = makeMemoryConfig();
     const result = generateHindsightMcpConfig("my-collection", memConfig);
 
-    expect(result.url).toBe("http://localhost:8888/mcp/");
+    expect(result.url).toBe("http://127.0.0.1:18888/mcp/");
     expect(result.command).toBeUndefined();
     expect(result.args).toBeUndefined();
   });
@@ -54,7 +54,7 @@ describe("generateHindsightMcpConfig", () => {
     });
     const result = generateHindsightMcpConfig("local-col", memConfig);
 
-    expect(result.url).toBe("http://localhost:8888/mcp/");
+    expect(result.url).toBe("http://127.0.0.1:18888/mcp/");
   });
 });
 
@@ -224,7 +224,7 @@ describe("getHindsightMcpUrl", () => {
   it("returns HTTP URL for Hindsight MCP endpoint", () => {
     const result = getHindsightMcpUrl();
 
-    expect(result.url).toBe("http://localhost:8888/mcp/");
+    expect(result.url).toBe("http://127.0.0.1:18888/mcp/");
   });
 });
 

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1092,7 +1092,7 @@ describe("scaffoldAgent", () => {
 
     expect(settings.mcpServers).toBeDefined();
     expect(settings.mcpServers.hindsight).toBeDefined();
-    expect(settings.mcpServers.hindsight.url).toBe("http://localhost:8888/mcp/");
+    expect(settings.mcpServers.hindsight.url).toBe("http://127.0.0.1:18888/mcp/");
     expect(settings.mcpServers.hindsight.type).toBe("http");
   });
 

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -37,9 +37,12 @@ import {
   isPortFree,
   findFreePort,
   pickHindsightPorts,
+  preflightHindsightPorts,
   HINDSIGHT_DEFAULT_API_PORT,
   HINDSIGHT_DEFAULT_UI_PORT,
+  HINDSIGHT_DEFAULT_MCP_URL,
 } from "../src/setup/hindsight.js";
+import { generateHindsightMcpConfig } from "../src/memory/hindsight.js";
 
 // ─── validateBotToken ────────────────────────────────────────────────────────
 
@@ -549,6 +552,85 @@ describe("pickHindsightPorts", () => {
       expect(ports.apiPort).toBeGreaterThanOrEqual(18888);
     } finally {
       blocker.close();
+    }
+  });
+});
+
+// ─── Hindsight port-collision regression (2026-07 outage) ────────────────────
+//
+// The bundled Hindsight container runs `--network host` and binds
+// HINDSIGHT_API_PORT directly on the host. When it defaulted to 8888 it
+// collided with a foreign listener (nginx-tunnel-gateway on 127.0.0.1:8888)
+// and crash-looped for ~9h while fleet memory was silently down. These pins
+// guard the three invariants that fix locks in.
+describe("Hindsight port-collision regression", () => {
+  it("defaults the API port to 18888 (guards against silent revert to 8888)", () => {
+    // The exact revert that would re-open the outage.
+    expect(HINDSIGHT_DEFAULT_API_PORT).toBe(18888);
+    expect(HINDSIGHT_DEFAULT_API_PORT).not.toBe(8888);
+  });
+
+  it("scaffolded memory.config.url port matches the launcher's default port", () => {
+    // The url/port drift that caused the outage: agents on 18888 while the
+    // container bound 8888. Both must derive from the same constant.
+    expect(HINDSIGHT_DEFAULT_MCP_URL).toContain(`:${HINDSIGHT_DEFAULT_API_PORT}/`);
+
+    // The default the scaffolder actually writes into an agent's .mcp.json
+    // (no operator override) must equal that URL — same port, no drift.
+    const cfg = generateHindsightMcpConfig("shared", {
+      backend: "hindsight",
+      config: {},
+    } as never);
+    expect(cfg.url).toBe(HINDSIGHT_DEFAULT_MCP_URL);
+    const urlPort = new URL(cfg.url as string).port;
+    expect(Number(urlPort)).toBe(HINDSIGHT_DEFAULT_API_PORT);
+  });
+
+  it("preflight reports the occupied port when a foreign listener holds it", async () => {
+    // Use a high, almost-certainly-free port to simulate the foreign listener
+    // (the default may already be held by a live hindsight on the test host).
+    const PORT = 45211;
+    if (!(await isPortFree(PORT))) return; // host busy — skip rather than flake
+    const blocker = await bindPort(PORT);
+    try {
+      const conflict = await preflightHindsightPorts({
+        apiPort: PORT,
+        uiPort: HINDSIGHT_DEFAULT_UI_PORT,
+      });
+      expect(conflict).not.toBeNull();
+      expect(conflict?.port).toBe(PORT);
+    } finally {
+      blocker.close();
+    }
+  });
+
+  it("preflight returns null when both chosen ports are free", async () => {
+    // Pick a high, almost-certainly-free pair rather than the defaults (CI
+    // may already run hindsight). 45201/45202 are outside any service range.
+    const a = await isPortFree(45201);
+    const b = await isPortFree(45202);
+    if (!a || !b) return; // host busy on these — skip rather than flake
+    const conflict = await preflightHindsightPorts({ apiPort: 45201, uiPort: 45202 });
+    expect(conflict).toBeNull();
+  });
+
+  it("port selection never hands an occupied port to docker run", async () => {
+    // Occupy the preferred default (if it's free to occupy); the resolver must
+    // return a DIFFERENT, actually-bindable port — never the occupied one
+    // (the crash-loop input). If the default is ALREADY held on this host, the
+    // fallback path is exercised without us binding it.
+    const defaultFree = await isPortFree(HINDSIGHT_DEFAULT_API_PORT);
+    const blocker = defaultFree ? await bindPort(HINDSIGHT_DEFAULT_API_PORT) : null;
+    try {
+      const ports = await pickHindsightPorts();
+      expect(ports.apiPort).not.toBe(HINDSIGHT_DEFAULT_API_PORT);
+      // The selected port must be free RIGHT NOW (what preflight verifies
+      // before docker run) — never an occupied port handed to `docker run`.
+      expect(await isPortFree(ports.apiPort)).toBe(true);
+      const conflict = await preflightHindsightPorts(ports);
+      expect(conflict).toBeNull();
+    } finally {
+      blocker?.close();
     }
   });
 });

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -633,6 +633,43 @@ describe("Hindsight port-collision regression", () => {
       blocker?.close();
     }
   });
+
+  // The `switchroom setup` Hindsight step (setup.ts) was the last uncovered
+  // crash-loop path: it called `startHindsight(undefined, litellmCfg)` with no
+  // ports arg, bypassing the pick+preflight guard `switchroom memory` applies,
+  // so a fresh install with 18888 occupied would crash-loop. It must route the
+  // launch through the SAME pick+preflight helpers.
+  it("setup.ts routes its Hindsight launch through the pick+preflight guard", () => {
+    const src = readFileSync(resolve(import.meta.dirname, "../src/cli/setup.ts"), "utf-8");
+    // Must no longer blind-launch on the default port.
+    expect(src).not.toContain("startHindsight(undefined");
+    // Must use the shared guard helpers (not a parallel implementation) and
+    // hand the chosen ports to startHindsight.
+    expect(src).toContain("pickHindsightPorts");
+    expect(src).toContain("preflightHindsightPorts");
+    expect(src).toContain("startHindsight(ports");
+  });
+
+  it("setup's port guard selects a free port instead of binding the occupied default", async () => {
+    // Mirror the exact pick+preflight sequence setup.ts now performs, proving
+    // it selects a bindable port when the default (18888) is occupied rather
+    // than blindly handing 18888 to `docker run`.
+    const defaultFree = await isPortFree(HINDSIGHT_DEFAULT_API_PORT);
+    const blocker = defaultFree ? await bindPort(HINDSIGHT_DEFAULT_API_PORT) : null;
+    try {
+      let ports = await pickHindsightPorts();
+      let conflict = await preflightHindsightPorts(ports);
+      if (conflict) {
+        ports = await pickHindsightPorts();
+        conflict = await preflightHindsightPorts(ports);
+      }
+      expect(conflict).toBeNull();
+      expect(ports.apiPort).not.toBe(HINDSIGHT_DEFAULT_API_PORT);
+      expect(await isPortFree(ports.apiPort)).toBe(true);
+    } finally {
+      blocker?.close();
+    }
+  });
 });
 
 // ─── resolveOrPromptToken precedence (install-validation #31) ────────────────


### PR DESCRIPTION
## Root cause

`switchroom-hindsight` runs with `--network host` and binds `HINDSIGHT_API_PORT`
directly on the host. The launcher could hand an **already-occupied** host port
to `docker run`, then silently crash-loop — fleet memory goes down invisibly
because a failing auto-recall produces no user-facing error.

Two contributing paths in `src/setup/hindsight.ts` + `src/cli/memory.ts`:

1. **Default port 8888.** A separate host service (`nginx-tunnel-gateway`,
   compose project at `/opt/tunnel-gateway`) publishes `127.0.0.1:8888:80` to
   front public sites via a Cloudflare tunnel. Because hindsight is host-networked
   and defaulted to 8888, whichever grabbed 8888 first won. Hindsight lost and
   crash-looped ~72× (`[Errno 98] address already in use: 8888`) with fleet
   memory silently down for ~9h.
2. **`--recreate` reused the old port with no free-check.** The recreate path
   read the previously-published host port via `getRunningHindsightPorts()` and
   passed it straight to `startHindsight()` — bypassing `pickHindsightPorts()`
   and its free-check entirely. Once a foreign service claimed that port, the
   recreate rebound it and crash-looped.

`pickHindsightPorts()` also *preferred* 8888 before falling back to 18888, so
even a fresh start raced nginx for 8888.

## Changes

1. **Default API port 8888 → 18888** (`HINDSIGHT_DEFAULT_API_PORT`). UI stays
   9999 (it did not collide in the incident). Added `HINDSIGHT_DEFAULT_MCP_URL`
   derived from the default port so the launcher's bound port and the scaffolded
   `memory.config.url` can never drift — the exact url/port drift behind the
   outage (agents on 18888, container on 8888).
2. **Every default `memory.config.url` / `.mcp.json` fallback → 18888**:
   `scaffold.ts`, `cli/agent.ts`, `cli/memory.ts`, `cli/doctor.ts`,
   `cli/setup.ts`, `memory/hindsight.ts`, `setup/hindsight.ts`, plus the
   compose host-port maps (host `18888`/`19999` → container `8888`/`9999`).
3. **Decoupled `getRunningHindsightPorts()` from the host default** — it now
   reads the container's FIXED internal ports (8888/9999) for `docker port`, so
   recreate still works after the default moved (previously it coincidentally
   equalled the host default).
4. **Loud preflight before `docker run`** (`preflightHindsightPorts` +
   `describePortHolder`, wired in `switchroom memory`): verifies the chosen host
   ports are bindable *right now*; if occupied it names the port + best-effort
   holding process, reassigns via `pickHindsightPorts()`, and aborts loudly if
   still occupied. Never silently crash-loops on an occupied port. This guards
   BOTH the reuse and pick paths.
5. **Memory-down health signal**: `switchroom doctor` now GETs
   `<hindsight>/health` and flips a non-200 red
   (`classifyHindsightHealthProbe` / `checkHindsightHealthEndpoint` in
   `doctor-memory.ts`), so a memory outage is visible instead of silent.

## Tests (all green)

`tests/setup.test.ts` — new `Hindsight port-collision regression` block:
- default port is **18888** (guards against a silent revert to 8888);
- scaffolded `memory.config.url` port **== launcher default** (drift guard);
- preflight **reports an occupied port** when a foreign listener holds it;
- port selection **never returns an occupied port** to `docker run`.

`tests/cli.doctor.memory-health.test.ts` — `/health` classifier (ok/fail/null)
+ async probe wrapper (derives `/health`, fails closed on a down container).

`tests/memory.test.ts` / `tests/scaffold.test.ts` — updated default-URL
assertions to 18888.

Scoped `vitest run` on touched files: **82 passed** across the three core
files; `tsc --noEmit` clean. One unrelated pre-existing failure in
`scaffold.test.ts` (`start.sh symlinks $HOME/.switchroom to host home`) fails
identically on the clean tree — environmental (host-home path), untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
