### PR TITLE
fix(hindsight): pin ANTHROPIC_MODEL so memory ops run on sonnet, not opus

### DIFF
--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -569,11 +569,17 @@ export function startHindsight(
   // configuration, not secrets. Setting `HINDSIGHT_API_LLM_PROVIDER` to
   // `claude-code` selects the subscription-honest path; pinning
   // `HINDSIGHT_API_LLM_MODEL` keeps memory ops on the same Claude model
-  // the agent fleet uses (see HINDSIGHT_DEFAULT_MODEL above).
+  // the agent fleet uses (see HINDSIGHT_DEFAULT_MODEL above). NOTE: for the
+  // `claude-code` provider, `HINDSIGHT_API_LLM_MODEL` does NOT control the
+  // embedded `claude` CLI — the CLI reads `ANTHROPIC_MODEL`, and without it
+  // falls back to its own default (opus), silently running every memory op
+  // (fact extraction, recall synthesis, consolidation) on the wrong model.
+  // So we ALSO set `ANTHROPIC_MODEL` — that's what actually pins the model.
   const envArgs: string[] = [
     "-e", `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=${HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE}`,
     "-e", "HINDSIGHT_API_LLM_PROVIDER=claude-code",
     "-e", `HINDSIGHT_API_LLM_MODEL=${HINDSIGHT_DEFAULT_MODEL}`,
+    "-e", `ANTHROPIC_MODEL=${HINDSIGHT_DEFAULT_MODEL}`,
     "-e", `HINDSIGHT_API_MCP_STATELESS=${HINDSIGHT_DEFAULT_MCP_STATELESS}`,
     // Reranker smart-defaults (v0.13.22) — see constants above for
     // rationale. Each closes a vendor-default gap that hurts our
@@ -798,6 +804,7 @@ export function generateHindsightComposeSnippet(): string {
     `      - HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=${HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE}`,
     "      - HINDSIGHT_API_LLM_PROVIDER=claude-code",
     `      - HINDSIGHT_API_LLM_MODEL=${HINDSIGHT_DEFAULT_MODEL}`,
+    `      - ANTHROPIC_MODEL=${HINDSIGHT_DEFAULT_MODEL}`,
     `      - HINDSIGHT_API_MCP_STATELESS=${HINDSIGHT_DEFAULT_MCP_STATELESS}`,
     `      - HINDSIGHT_API_RERANKER_LOCAL_BUCKET_BATCHING=${HINDSIGHT_DEFAULT_RERANKER_BUCKET_BATCHING}`,
     `      - HINDSIGHT_API_RERANKER_MAX_CANDIDATES=${HINDSIGHT_DEFAULT_RERANKER_MAX_CANDIDATES}`,

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -252,6 +252,8 @@ describe("generateHindsightComposeSnippet (broker-fed, #1245)", () => {
   it("pins HINDSIGHT_API_LLM_MODEL to the switchroom-default sonnet", () => {
     const snippet = generateHindsightComposeSnippet();
     expect(snippet).toContain("HINDSIGHT_API_LLM_MODEL=claude-sonnet-5");
+    // ANTHROPIC_MODEL is what actually pins the claude-code provider's model.
+    expect(snippet).toContain("ANTHROPIC_MODEL=claude-sonnet-5");
   });
 
   it("sets HINDSIGHT_API_MCP_STATELESS=true (immune to hindsight bounces)", () => {

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -152,6 +152,10 @@ describe("hindsight broker-fed mode (#1245)", () => {
       if (args[i] === "-e") envPairs.push(args[i + 1] as string);
     }
     expect(envPairs).toContain("HINDSIGHT_API_LLM_MODEL=claude-sonnet-5");
+    // For the claude-code provider the embedded `claude` CLI reads
+    // ANTHROPIC_MODEL, not HINDSIGHT_API_LLM_MODEL — without it the CLI
+    // falls back to its own default (opus) and silently burns quota.
+    expect(envPairs).toContain("ANTHROPIC_MODEL=claude-sonnet-5");
   });
 
   it("raises the reflect wall timeout (vendor 300s times out large-bank mental-model refresh)", async () => {


### PR DESCRIPTION
## The bug

`src/setup/hindsight.ts` launches the Hindsight memory container with
`HINDSIGHT_API_LLM_PROVIDER=claude-code` and
`HINDSIGHT_API_LLM_MODEL=${HINDSIGHT_DEFAULT_MODEL}` (`claude-sonnet-5`), but it
never set `ANTHROPIC_MODEL`.

Because the provider is the embedded `claude` CLI, `HINDSIGHT_API_LLM_MODEL`
does **not** control the model the CLI actually calls — the `claude` CLI reads
`ANTHROPIC_MODEL`, and with it unset falls back to its own default (**opus**).
Result: every Hindsight memory op — fact extraction, recall synthesis,
consolidation — silently ran on **opus** instead of the intended sonnet,
burning expensive quota.

Verified live in litellm logs: **100% opus before**, **sonnet-5 after** adding
`ANTHROPIC_MODEL`.

## The fix

Add `ANTHROPIC_MODEL=${HINDSIGHT_DEFAULT_MODEL}` next to the existing
`HINDSIGHT_API_LLM_MODEL` line in both renderings of the same container spec:

- the `docker run` `-e` env args array in `startHindsight()`
- the docker-compose snippet in `generateHindsightComposeSnippet()`

Updated the explanatory comment to note that `ANTHROPIC_MODEL` is what actually
pins the `claude-code` provider's model, and strengthened the two existing
"pins the model" tests to assert `ANTHROPIC_MODEL` in both outputs.

## Why it matters (subscription-honest / memory JTBD)

This keeps memory operations on the intended model — the subscription-honest
vision outcome (`reference/vision.md` pillar 3) — rather than silently
defaulting to a more expensive model behind the operator's back. It directly
serves the memory jobs-to-be-done in `reference/jobs/`: recall, retain, and
consolidation should run on the model the fleet is configured for, predictably.

## Tests

`npm run lint` (tsc) clean; `tests/setup/hindsight.test.ts`,
`tests/memory.test.ts`, `tests/web.test.ts` green under vitest. Test
assertions updated to include `ANTHROPIC_MODEL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)