### PR TITLE
Harden and test the dark-turn silent-end fallback (RFC Phase 2)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -171,7 +171,7 @@ import { decideSilentReplyAnchor } from '../silent-reply-anchor.js'
 import { classifyInbound } from '../inbound-classifier.js'
 import * as silencePoke from '../silence-poke.js'
 import * as pendingProgress from '../pending-work-progress.js'
-import { writeSilentEndState, clearSilentEndState, recordUndeliveredTurnEnd, type SilentEndDeps } from '../silent-end.js'
+import { writeSilentEndState, clearSilentEndState, recordUndeliveredTurnEnd, silentEndFallbackText, type SilentEndDeps } from '../silent-end.js'
 import { isFinalAnswerReply, isSubstantiveFinalReply, FINAL_ANSWER_MIN_CHARS } from '../final-answer-detect.js'
 import { deriveTurnRole, decideTerminalReason, parsePostAnswerLivenessMs, evaluatePostAnswerLiveness, type LoopRole } from '../turn-liveness-floor.js'
 import { createAnswerStream, type AnswerStreamHandle } from '../answer-stream.js'
@@ -251,26 +251,9 @@ import { validateStringArray } from './access-validator.js'
  */
 const REPLY_TO_TEXT_MAX = 200
 
-/**
- * #1161 — user-facing fallback delivered when a user-message turn ends
- * with zero outbound messages AND the deterministic Stop-hook re-prompt
- * has already been exhausted. Without this the user only sees the
- * progress card vanish; silence must never be the failure mode.
- */
-function silentEndFallbackText(turnDurationMs: number | undefined): string {
-  // reference/rfcs/deterministic-turn-liveness.md Phase 2 hardening: include
-  // the turn's elapsed so the fallback is honest about how long the user
-  // actually waited, instead of a generic apology with no timing.
-  const elapsed =
-    typeof turnDurationMs === 'number' && Number.isFinite(turnDurationMs) && turnDurationMs >= 0
-      ? ` (waited ${Math.round(turnDurationMs / 1000)}s)`
-      : ''
-  return (
-    '⚠️ The agent finished working but didn’t send a reply' +
-    elapsed +
-    ' — your last message may not have been answered. Please try asking again.'
-  )
-}
+// #1161 silent-end fallback text now lives in ../silent-end.ts
+// (`silentEndFallbackText`, imported above) so the transport-boundary
+// tests exercise the real string — see PR #2892.
 import { splitMarkdownChunks, hardSliceToCap, repairEscapedWhitespace, normalizeParagraphBreaks, addParagraphSpacers, normalizePunctuation, stripExcessBold, escapeMarkdown, hardenCardBreaks, RICH_MESSAGE_MAX_CHARS } from '../format.js'
 import { richMessage } from '../rich-send.js'
 import { scrubVoice } from '../text-voice-scrub.js'
@@ -14494,7 +14477,8 @@ function handleSessionEvent(ev: SessionEvent): void {
         // this path. The turn-flush 'flush' branch also returns earlier
         // (and sets finalAnswerDelivered=true defensively).
         if (turn.finalAnswerDelivered === false) {
-          // #2xxx Phase 2 hardening: wire the represent-guard-style staleness
+          // PR #2892 (deterministic-turn-liveness RFC Phase 2) hardening:
+          // wire the represent-guard-style staleness
           // check (`recordSilentTurnEnd`'s `hasOutboundDeliveredSince` dep) so
           // an exhausted-looking record left over from a PRIOR, already-
           // answered turn on this same chat/thread (statusKey is not a

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -171,7 +171,7 @@ import { decideSilentReplyAnchor } from '../silent-reply-anchor.js'
 import { classifyInbound } from '../inbound-classifier.js'
 import * as silencePoke from '../silence-poke.js'
 import * as pendingProgress from '../pending-work-progress.js'
-import { writeSilentEndState, clearSilentEndState, recordUndeliveredTurnEnd } from '../silent-end.js'
+import { writeSilentEndState, clearSilentEndState, recordUndeliveredTurnEnd, type SilentEndDeps } from '../silent-end.js'
 import { isFinalAnswerReply, isSubstantiveFinalReply, FINAL_ANSWER_MIN_CHARS } from '../final-answer-detect.js'
 import { deriveTurnRole, decideTerminalReason, parsePostAnswerLivenessMs, evaluatePostAnswerLiveness, type LoopRole } from '../turn-liveness-floor.js'
 import { createAnswerStream, type AnswerStreamHandle } from '../answer-stream.js'
@@ -257,9 +257,20 @@ const REPLY_TO_TEXT_MAX = 200
  * has already been exhausted. Without this the user only sees the
  * progress card vanish; silence must never be the failure mode.
  */
-const SILENT_END_FALLBACK_TEXT =
-  '⚠️ The agent finished working but didn’t send a reply — your last ' +
-  'message may not have been answered. Please try asking again.'
+function silentEndFallbackText(turnDurationMs: number | undefined): string {
+  // reference/rfcs/deterministic-turn-liveness.md Phase 2 hardening: include
+  // the turn's elapsed so the fallback is honest about how long the user
+  // actually waited, instead of a generic apology with no timing.
+  const elapsed =
+    typeof turnDurationMs === 'number' && Number.isFinite(turnDurationMs) && turnDurationMs >= 0
+      ? ` (waited ${Math.round(turnDurationMs / 1000)}s)`
+      : ''
+  return (
+    '⚠️ The agent finished working but didn’t send a reply' +
+    elapsed +
+    ' — your last message may not have been answered. Please try asking again.'
+  )
+}
 import { splitMarkdownChunks, hardSliceToCap, repairEscapedWhitespace, normalizeParagraphBreaks, addParagraphSpacers, normalizePunctuation, stripExcessBold, escapeMarkdown, hardenCardBreaks, RICH_MESSAGE_MAX_CHARS } from '../format.js'
 import { richMessage } from '../rich-send.js'
 import { scrubVoice } from '../text-voice-scrub.js'
@@ -14483,11 +14494,27 @@ function handleSessionEvent(ev: SessionEvent): void {
         // this path. The turn-flush 'flush' branch also returns earlier
         // (and sets finalAnswerDelivered=true defensively).
         if (turn.finalAnswerDelivered === false) {
-          const silentEnd = recordUndeliveredTurnEnd({
-            chatId,
-            threadId: threadId ?? null,
-            turnKey: tKey,
-          })
+          // #2xxx Phase 2 hardening: wire the represent-guard-style staleness
+          // check (`recordSilentTurnEnd`'s `hasOutboundDeliveredSince` dep) so
+          // an exhausted-looking record left over from a PRIOR, already-
+          // answered turn on this same chat/thread (statusKey is not a
+          // per-turn nonce) can never be misread as this turn's spent
+          // re-prompt budget. Falls back to the pre-existing turnKey/
+          // retryCount-only check when history is unavailable.
+          const silentEndDeps: SilentEndDeps | undefined = HISTORY_ENABLED
+            ? {
+                hasOutboundDeliveredSince: (cid, sinceMs, tid) =>
+                  hasOutboundDeliveredSince(cid, sinceMs, tid, 1),
+              }
+            : undefined
+          const silentEnd = recordUndeliveredTurnEnd(
+            {
+              chatId,
+              threadId: threadId ?? null,
+              turnKey: tKey,
+            },
+            silentEndDeps,
+          )
           if (silentEnd.exhausted) {
             process.stderr.write(
               `telegram gateway: WARN silent-end fallback — agent stayed ` +
@@ -14499,7 +14526,7 @@ function handleSessionEvent(ev: SessionEvent): void {
               (tid) =>
                 bot.api.sendMessage(
                   chatId,
-                  SILENT_END_FALLBACK_TEXT,
+                  silentEndFallbackText(turnDurationMs),
                   tid != null ? { message_thread_id: tid } : {},
                 ),
               { threadId, chat_id: chatId, verb: 'silent-end-fallback.sendMessage' },

--- a/telegram-plugin/silent-end.ts
+++ b/telegram-plugin/silent-end.ts
@@ -80,6 +80,35 @@ export interface SilentEndDeps {
  */
 export const SILENT_END_MAX_RETRIES = 2
 
+/**
+ * User-facing fallback text delivered when a user-message turn ends with no
+ * final answer AND the deterministic Stop-hook re-prompt has already been
+ * exhausted (#1161). Without this the user only sees the progress card
+ * vanish; silence must never be the failure mode.
+ *
+ * PR #2892 (reference/rfcs/deterministic-turn-liveness.md Phase 2
+ * hardening): include the turn's elapsed so the fallback is honest about
+ * how long the user actually waited, instead of a generic apology with no
+ * timing. A degenerate/unknown duration (missing, non-finite, or <= 0 —
+ * e.g. a turn whose `startedAt` was never stamped) omits the waited clause
+ * rather than printing a nonsensical "(waited 0s)".
+ *
+ * Lives here (not gateway.ts) so the transport-boundary tests exercise the
+ * REAL string (tests/silent-end-transport.test.ts), not a hand-maintained
+ * copy — gateway.ts is not importable in tests.
+ */
+export function silentEndFallbackText(turnDurationMs: number | undefined): string {
+  const elapsed =
+    typeof turnDurationMs === 'number' && Number.isFinite(turnDurationMs) && turnDurationMs > 0
+      ? ` (waited ${Math.round(turnDurationMs / 1000)}s)`
+      : ''
+  return (
+    '⚠️ The agent finished working but didn’t send a reply' +
+    elapsed +
+    ' — your last message may not have been answered. Please try asking again.'
+  )
+}
+
 function resolveStateDir(deps?: SilentEndDeps): string {
   if (deps?.stateDir != null) return deps.stateDir
   const env = process.env.TELEGRAM_STATE_DIR
@@ -291,6 +320,16 @@ export function recordSilentTurnEnd(
           `(retryCount=${prev.retryCount}) but a reply was delivered since ` +
           `${prev.timestamp} — treating as satisfied-but-misdetected, not exhausted\n`,
       )
+      // MUST clear before writing (adversarial review of #2892):
+      // writeSilentEndState re-inherits retryCount whenever the on-disk
+      // turnKey matches — which it ALWAYS does here, since turnKey is the
+      // stable statusKey(chatId, threadId). Writing over the stale record
+      // directly would start the "fresh" ladder at retryCount=MAX: the
+      // Stop hook would see retryCount >= MAX_RETRIES and never re-prompt,
+      // while this call just returned exhausted:false so no fallback fires
+      // either — pure silence, strictly worse than the pre-fix behaviour.
+      // Clearing first makes the new record genuinely start at retryCount=0.
+      clearSilentEndState(args.turnKey, deps)
       writeSilentEndState(args, deps)
       return { exhausted: false }
     }

--- a/telegram-plugin/silent-end.ts
+++ b/telegram-plugin/silent-end.ts
@@ -49,6 +49,17 @@ export interface SilentEndDeps {
   stateDir?: string
   /** stderr writer (defaults to `process.stderr.write`). */
   log?: (line: string) => void
+  /**
+   * Has a genuine assistant reply been delivered to this chat (optionally
+   * scoped to thread) at or after `sinceMs`? Same predicate shape as
+   * `history.hasOutboundDeliveredSince` / the represent-guard's dep
+   * (`gateway/represent-guard.ts`) — injected here so the exhaustion check
+   * below is a pure, testable decision. When omitted (history unavailable,
+   * or callers that don't wire it), the check is skipped and the guard
+   * falls back to the pre-existing turnKey/retryCount bookkeeping only —
+   * never suppress on doubt.
+   */
+  hasOutboundDeliveredSince?: (chatId: string, sinceMs: number, threadId?: number | null) => boolean
 }
 
 /**
@@ -255,6 +266,34 @@ export function recordSilentTurnEnd(
     prev.turnKey === args.turnKey &&
     prev.retryCount >= SILENT_END_MAX_RETRIES
   ) {
+    // Staleness guard (mirrors the represent-guard's #2472 fix,
+    // `gateway/represent-guard.ts:shouldSuppressRepresent`): `turnKey` here
+    // is `statusKey(chatId, threadId)` — stable across every turn on the
+    // same chat/thread, NOT a per-turn nonce (unlike the obligation
+    // ledger's `originTurnId`). The whole mechanism depends on a reply
+    // ALWAYS clearing this state file via `clearSilentEndState` at the
+    // send-site. `clearSilentEndState` is fail-silent by design (state
+    // corruption / a write race must never crash the gateway), so if a
+    // clear is ever missed, a stale `retryCount >= MAX_RETRIES` record
+    // from an OLD, already-answered turn would be misread as "this
+    // brand-new dark turn already exhausted its re-prompt budget" —
+    // firing the user-facing fallback immediately, without the turn ever
+    // going through the Stop-hook re-prompt ladder. Before trusting that
+    // reading, verify against real delivery history: has a genuine reply
+    // landed on this chat/thread since the stale record was last written?
+    // If so, the record is satisfied-but-misdetected — drop it silently
+    // and let this dark turn start its OWN fresh retry cycle instead of
+    // inheriting someone else's spent budget.
+    if (deps?.hasOutboundDeliveredSince?.(args.chatId, prev.timestamp, args.threadId)) {
+      emitLog(
+        deps,
+        `silent-end: stale exhausted record for turnKey=${args.turnKey} ` +
+          `(retryCount=${prev.retryCount}) but a reply was delivered since ` +
+          `${prev.timestamp} — treating as satisfied-but-misdetected, not exhausted\n`,
+      )
+      writeSilentEndState(args, deps)
+      return { exhausted: false }
+    }
     clearSilentEndState(args.turnKey, deps)
     emitLog(
       deps,

--- a/telegram-plugin/tests/silent-end-transport.test.ts
+++ b/telegram-plugin/tests/silent-end-transport.test.ts
@@ -13,12 +13,16 @@
  * This file reproduces the EXACT call sequence at the gateway's turn_end
  * handler (gateway.ts ~14486-14535: `if (turn.finalAnswerDelivered ===
  * false) { const silentEnd = recordUndeliveredTurnEnd(...); if
- * (silentEnd.exhausted) { <send> } }`) against a spy transport, using the
- * REAL exported `recordUndeliveredTurnEnd` / `clearSilentEndState` /
+ * (silentEnd.exhausted) { <send> } }`) against a spy transport standing in
+ * for `bot.api.sendMessage`, using the REAL exported
+ * `recordUndeliveredTurnEnd` / `silentEndFallbackText` /
  * `isFinalAnswerReply` — same pattern `silent-end-integration.test.ts`
  * already established for testing gateway call-sites that aren't
  * themselves exported (gateway.ts is a multi-thousand-line module with
  * process-level side effects on import; see that file's "KNOWN GAP" note).
+ * The spy asserts the SEND CALL is made (outcome, not a stubbed decision
+ * callback); it does not drive grammY itself — that last hop stays covered
+ * by the UAT harness.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdtempSync, rmSync, writeFileSync as writeFileSyncState } from 'node:fs'
@@ -28,6 +32,7 @@ import {
   writeSilentEndState,
   readSilentEndState,
   recordUndeliveredTurnEnd,
+  silentEndFallbackText,
   SILENT_END_MAX_RETRIES,
   type SilentEndDeps,
 } from '../silent-end.js'
@@ -66,20 +71,12 @@ function makeTransport() {
   }
 }
 
-function fallbackText(turnDurationMs: number): string {
-  // Mirrors gateway.ts's silentEndFallbackText(turnDurationMs) exactly —
-  // the elapsed-inclusion hardening from this PR.
-  const elapsed = ` (waited ${Math.round(turnDurationMs / 1000)}s)`
-  return (
-    '⚠️ The agent finished working but didn’t send a reply' +
-    elapsed +
-    ' — your last message may not have been answered. Please try asking again.'
-  )
-}
-
 /**
  * Faithful reproduction of the gateway's turn_end branch
- * (gateway.ts ~14486-14535). Real functions in, spy transport out.
+ * (gateway.ts ~14486-14535). Real functions in, spy transport out —
+ * including the REAL `silentEndFallbackText` (exported from
+ * silent-end.ts so the assertions below validate the shipped copy,
+ * not a hand-maintained duplicate).
  */
 function simulateTurnEnd(
   args: {
@@ -98,7 +95,7 @@ function simulateTurnEnd(
       deps,
     )
     if (silentEnd.exhausted) {
-      transport.send(args.chatId, fallbackText(args.turnDurationMs))
+      transport.send(args.chatId, silentEndFallbackText(args.turnDurationMs))
     }
     return silentEnd
   }
@@ -240,6 +237,15 @@ describe('silent-end dark-turn guard — transport-boundary outcome tests (RFC P
 
     expect(result?.exhausted).toBe(false)
     expect(transport.sent).toHaveLength(0)
+    // CRITICAL (adversarial review of #2892): the "fresh retry cycle" must
+    // actually be fresh. writeSilentEndState re-inherits retryCount when
+    // the on-disk turnKey matches (which it ALWAYS does here — turnKey is
+    // statusKey). If the staleness branch writes without clearing first,
+    // the new record starts at retryCount=MAX: the Stop hook
+    // (silent-end-interrupt-stop.mjs) sees retryCount >= MAX_RETRIES and
+    // never re-prompts, while the gateway just got exhausted:false and
+    // sent no fallback either — pure silence, worse than no fix at all.
+    expect(readSilentEndState()!.retryCount).toBe(0)
   })
 
   it('(d3) staleness hardening does NOT suppress a genuine, fresh exhaustion (no reply since the record)', () => {

--- a/telegram-plugin/tests/silent-end-transport.test.ts
+++ b/telegram-plugin/tests/silent-end-transport.test.ts
@@ -1,0 +1,284 @@
+/**
+ * silent-end-transport.test.ts — PR 2 of
+ * reference/rfcs/deterministic-turn-liveness.md (Phase 2: audit-and-harden
+ * the shipped dark-turn guard, per reference/jobs/know-what-my-agent-is-doing.md).
+ *
+ * Prior coverage (`silent-end.test.ts`, `silent-end-integration.test.ts`)
+ * proves the *decision* — state-file lifecycle, retryCount bookkeeping,
+ * the `{exhausted}` contract. It never asserts a byte reaches the
+ * transport, which is exactly the decision-vs-delivery gap the RFC calls
+ * out for the muted 45s floor (#2667) and asks Phase 2 to wall off for
+ * the dark-turn guard instead of re-creating it.
+ *
+ * This file reproduces the EXACT call sequence at the gateway's turn_end
+ * handler (gateway.ts ~14486-14535: `if (turn.finalAnswerDelivered ===
+ * false) { const silentEnd = recordUndeliveredTurnEnd(...); if
+ * (silentEnd.exhausted) { <send> } }`) against a spy transport, using the
+ * REAL exported `recordUndeliveredTurnEnd` / `clearSilentEndState` /
+ * `isFinalAnswerReply` — same pattern `silent-end-integration.test.ts`
+ * already established for testing gateway call-sites that aren't
+ * themselves exported (gateway.ts is a multi-thousand-line module with
+ * process-level side effects on import; see that file's "KNOWN GAP" note).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync as writeFileSyncState } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  writeSilentEndState,
+  readSilentEndState,
+  recordUndeliveredTurnEnd,
+  SILENT_END_MAX_RETRIES,
+  type SilentEndDeps,
+} from '../silent-end.js'
+import { isFinalAnswerReply } from '../final-answer-detect.js'
+
+let stateDir: string
+const ORIG_ENV = process.env.TELEGRAM_STATE_DIR
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), 'silent-end-transport-test-'))
+  process.env.TELEGRAM_STATE_DIR = stateDir
+})
+
+afterEach(() => {
+  rmSync(stateDir, { recursive: true, force: true })
+  if (ORIG_ENV != null) process.env.TELEGRAM_STATE_DIR = ORIG_ENV
+  else delete process.env.TELEGRAM_STATE_DIR
+})
+
+/** Spy transport — records every "send" with a wall-clock timestamp, the
+ * same shape a `bot.api.sendMessage` spy would capture at the real
+ * transport boundary. */
+interface SentMessage {
+  chatId: string
+  text: string
+  ts: number
+}
+
+function makeTransport() {
+  const sent: SentMessage[] = []
+  return {
+    sent,
+    send: (chatId: string, text: string) => {
+      sent.push({ chatId, text, ts: Date.now() })
+    },
+  }
+}
+
+function fallbackText(turnDurationMs: number): string {
+  // Mirrors gateway.ts's silentEndFallbackText(turnDurationMs) exactly —
+  // the elapsed-inclusion hardening from this PR.
+  const elapsed = ` (waited ${Math.round(turnDurationMs / 1000)}s)`
+  return (
+    '⚠️ The agent finished working but didn’t send a reply' +
+    elapsed +
+    ' — your last message may not have been answered. Please try asking again.'
+  )
+}
+
+/**
+ * Faithful reproduction of the gateway's turn_end branch
+ * (gateway.ts ~14486-14535). Real functions in, spy transport out.
+ */
+function simulateTurnEnd(
+  args: {
+    chatId: string
+    threadId: number | null
+    turnKey: string
+    finalAnswerDelivered: boolean
+    turnDurationMs: number
+  },
+  transport: ReturnType<typeof makeTransport>,
+  deps?: SilentEndDeps,
+): { exhausted: boolean } | null {
+  if (args.finalAnswerDelivered === false) {
+    const silentEnd = recordUndeliveredTurnEnd(
+      { chatId: args.chatId, threadId: args.threadId, turnKey: args.turnKey },
+      deps,
+    )
+    if (silentEnd.exhausted) {
+      transport.send(args.chatId, fallbackText(args.turnDurationMs))
+    }
+    return silentEnd
+  }
+  return null
+}
+
+/** Drives the Stop-hook re-prompt ladder up to (but not past) MAX_RETRIES,
+ * exactly as `silent-end-interrupt-stop.mjs` does on each block. */
+function driveRetryLadderToMax(turnKey: string) {
+  const path = join(stateDir, 'silent-end-pending.json')
+  const s = readSilentEndState()!
+  writeFileSyncState(path, JSON.stringify({ ...s, retryCount: SILENT_END_MAX_RETRIES, turnKey }), 'utf8')
+}
+
+describe('silent-end dark-turn guard — transport-boundary outcome tests (RFC Phase 2)', () => {
+  it('(a) full dark turn: exactly one fallback message lands on the real surface', () => {
+    const transport = makeTransport()
+    const turnKey = 'c:_'
+
+    // First dark turn-end — writes state, does NOT deliver a fallback
+    // (the Stop-hook re-prompt ladder hasn't been exhausted yet).
+    simulateTurnEnd(
+      { chatId: 'c', threadId: null, turnKey, finalAnswerDelivered: false, turnDurationMs: 12_000 },
+      transport,
+    )
+    expect(transport.sent).toHaveLength(0)
+
+    // Stop hook re-prompts twice (SILENT_END_MAX_RETRIES), agent stays
+    // silent both times — ladder exhausted.
+    driveRetryLadderToMax(turnKey)
+
+    // Re-prompted turn ends dark again — budget spent, deliver fallback.
+    simulateTurnEnd(
+      { chatId: 'c', threadId: null, turnKey, finalAnswerDelivered: false, turnDurationMs: 47_000 },
+      transport,
+    )
+
+    expect(transport.sent).toHaveLength(1)
+    expect(transport.sent[0]!.chatId).toBe('c')
+    expect(transport.sent[0]!.text).toContain('waited 47s')
+    expect(transport.sent[0]!.text).toContain('didn’t send a reply')
+    // Once delivered, the state must not linger to double-fire on a
+    // subsequent, unrelated dark turn on the same chat/thread.
+    expect(readSilentEndState()).toBeNull()
+  })
+
+  it('(b) deliberate silent end (NO_REPLY / HEARTBEAT_OK) never fires the guard', () => {
+    // The gateway sets `turn.finalAnswerDelivered = true` for NO_REPLY /
+    // HEARTBEAT_OK silent markers BEFORE reaching this branch
+    // (gateway.ts ~14192, ~13880, ~10762 — the sentinel-suppression
+    // sites) — so the branch is never entered at all for a legitimately
+    // silent turn. Reproduce that gate here.
+    const transport = makeTransport()
+    simulateTurnEnd(
+      { chatId: 'c', threadId: null, turnKey: 'c:_', finalAnswerDelivered: true, turnDurationMs: 5_000 },
+      transport,
+    )
+    expect(transport.sent).toHaveLength(0)
+    expect(readSilentEndState()).toBeNull()
+  })
+
+  it('(c) normal replied turn: zero fallback messages, regardless of prior stale state', () => {
+    const transport = makeTransport()
+    // A prior turn on this chat/thread already reached exhaustion and
+    // was cleared (see test (a)) — simulate a completely normal turn
+    // afterwards; the branch must not even be entered.
+    simulateTurnEnd(
+      { chatId: 'c', threadId: null, turnKey: 'c:_', finalAnswerDelivered: true, turnDurationMs: 3_000 },
+      transport,
+    )
+    expect(transport.sent).toHaveLength(0)
+  })
+
+  it('(d) the guard never double-fires: two calls to the exhausted branch on the same spent record yield exactly one send', () => {
+    const transport = makeTransport()
+    const turnKey = 'c:dup'
+    writeSilentEndState({ chatId: 'c', threadId: null, turnKey })
+    driveRetryLadderToMax(turnKey)
+
+    simulateTurnEnd(
+      { chatId: 'c', threadId: null, turnKey, finalAnswerDelivered: false, turnDurationMs: 10_000 },
+      transport,
+    )
+    expect(transport.sent).toHaveLength(1)
+    // State is cleared by the first exhausted call — a defensive SECOND
+    // call for the exact same still-dark turn (e.g. a duplicate turn_end
+    // event) finds no prior state and starts a FRESH retry cycle rather
+    // than re-firing the fallback a second time.
+    const second = simulateTurnEnd(
+      { chatId: 'c', threadId: null, turnKey, finalAnswerDelivered: false, turnDurationMs: 10_050 },
+      transport,
+    )
+    expect(second?.exhausted).toBe(false)
+    expect(transport.sent).toHaveLength(1)
+  })
+
+  it('(d2) staleness hardening: an exhausted-looking record left by an ALREADY-ANSWERED turn on the same chat/thread must not fire the fallback for a brand-new dark turn', () => {
+    // silent-end's turnKey is `statusKey(chatId, threadId)` — stable
+    // across every turn on a chat/thread, not a per-turn nonce. If a
+    // reply's `clearSilentEndState` call is ever missed (it is
+    // fail-silent by design), a spent retryCount from an OLD,
+    // genuinely-answered turn could otherwise be misread as THIS
+    // brand-new dark turn's already-exhausted budget — firing the
+    // fallback without ever running the Stop-hook re-prompt ladder.
+    //
+    // This is the same class of bug #2472 fixed in the represent guard
+    // (gateway/represent-guard.ts shouldSuppressRepresent): a
+    // satisfied-but-misdetected obligation must be verified against real
+    // delivery history, not trusted from key equality + a counter alone.
+    const transport = makeTransport()
+    const turnKey = 'c:_'
+    const staleTimestamp = 1_000_000
+
+    // Simulate the missed-clear: an old, already-answered turn left the
+    // ladder pinned at MAX_RETRIES and (because the clear was missed) the
+    // file was never removed.
+    writeSilentEndState({ chatId: 'c', threadId: null, turnKey })
+    driveRetryLadderToMax(turnKey)
+    // Force the stale timestamp to predate the "reply" the deps stub
+    // reports below.
+    const path = join(stateDir, 'silent-end-pending.json')
+    const s = readSilentEndState()!
+    writeFileSyncState(path, JSON.stringify({ ...s, timestamp: staleTimestamp }), 'utf8')
+
+    // A reply WAS in fact delivered on this chat (the missed-clear case)
+    // at some point after the stale record's timestamp.
+    const deps: SilentEndDeps = {
+      hasOutboundDeliveredSince: (chatId, sinceMs) =>
+        chatId === 'c' && sinceMs <= staleTimestamp + 500,
+    }
+
+    // A genuinely NEW, unrelated dark turn now ends on the same
+    // chat/thread (same turnKey by construction).
+    const result = simulateTurnEnd(
+      { chatId: 'c', threadId: null, turnKey, finalAnswerDelivered: false, turnDurationMs: 8_000 },
+      transport,
+      deps,
+    )
+
+    expect(result?.exhausted).toBe(false)
+    expect(transport.sent).toHaveLength(0)
+  })
+
+  it('(d3) staleness hardening does NOT suppress a genuine, fresh exhaustion (no reply since the record)', () => {
+    const transport = makeTransport()
+    const turnKey = 'c:_'
+    writeSilentEndState({ chatId: 'c', threadId: null, turnKey })
+    driveRetryLadderToMax(turnKey)
+
+    const deps: SilentEndDeps = {
+      // No reply has landed since the record — the exhaustion is real.
+      hasOutboundDeliveredSince: () => false,
+    }
+
+    const result = simulateTurnEnd(
+      { chatId: 'c', threadId: null, turnKey, finalAnswerDelivered: false, turnDurationMs: 9_000 },
+      transport,
+      deps,
+    )
+
+    expect(result?.exhausted).toBe(true)
+    expect(transport.sent).toHaveLength(1)
+  })
+
+  it('cross-check: isFinalAnswerReply gating means an ack-only turn still reaches the dark-turn branch', () => {
+    // Sanity cross-check against the real predicate used at the reply
+    // send-sites (executeReply/executeStreamReply) — an interim ack does
+    // NOT satisfy finalAnswerDelivered, so the branch is correctly
+    // entered (this is the #1664 case, not a legitimate silent end).
+    const ack = { text: 'On it', disableNotification: true }
+    expect(isFinalAnswerReply(ack)).toBe(false)
+
+    const transport = makeTransport()
+    const turnKey = 'c:ack-only'
+    writeSilentEndState({ chatId: 'c', threadId: null, turnKey })
+    driveRetryLadderToMax(turnKey)
+    simulateTurnEnd(
+      { chatId: 'c', threadId: null, turnKey, finalAnswerDelivered: isFinalAnswerReply(ack), turnDurationMs: 15_000 },
+      transport,
+    )
+    expect(transport.sent).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## What

Implements **Phase 2** of `reference/rfcs/deterministic-turn-liveness.md` (the RFC that re-founds the mid-turn liveness floor as a card climb, PR 1), serving `reference/jobs/know-what-my-agent-is-doing.md`. Phase 2's job is explicitly **audit-and-harden**, not a new mechanism — a fresh guard would double-fire on every genuine dark turn.

The dark-turn guard already ships: on `turn_end` with `finalAnswerDelivered === false`, `recordUndeliveredTurnEnd()` (`telegram-plugin/silent-end.ts` / `telegram-plugin/gateway/gateway.ts`) drives the Stop-hook re-prompt (`silent-end-interrupt-stop.mjs`), and once the re-prompt ladder is exhausted the gateway sends `SILENT_END_FALLBACK_TEXT` with a fire-once `exhausted` latch. This PR:

1. **Proves delivery, not decision.** Adds `telegram-plugin/tests/silent-end-transport.test.ts` — outcome-based tests at the transport boundary (spy `send`, timestamps), reproducing the exact call sequence at the gateway's turn_end branch:
   - (a) a full dark turn → **exactly one** fallback message lands
   - (b) a deliberate silent end (`NO_REPLY`/`HEARTBEAT_OK`) → **zero** fallback messages (the existing code already sets `finalAnswerDelivered = true` for these before the branch is reached — this locks that exclusion in with a test, it isn't a new predicate)
   - (c) a normal replied turn → zero fallback messages
   - (d) the guard never double-fires, including the harder case below

2. **Fixes a real staleness gap in the satisfied-check.** `silent-end`'s `turnKey` is `statusKey(chatId, threadId)` — stable across *every* turn on a chat/thread, not a per-turn nonce (unlike the obligation ledger's `originTurnId`). The whole retry-budget mechanism depends on `clearSilentEndState` firing on every genuine reply; that clear is fail-silent by design. If a clear is ever missed, a stale `retryCount >= MAX_RETRIES` record from an OLD, already-answered turn could be misread as a brand-new dark turn's already-spent budget — firing the user-facing fallback immediately without that turn ever going through the Stop-hook re-prompt ladder. This is the same class of bug `gateway/represent-guard.ts` already fixed for the (separate) `obligation_represent` mechanism (#2472): "satisfied but misdetected" must be verified against real delivery history, not trusted from key equality + a counter alone.

   Fix (minimal, confined to the guard's satisfied-check): `recordSilentTurnEnd` now accepts an optional `hasOutboundDeliveredSince` dep (same shape as the represent-guard's). Before declaring `exhausted:true`, it checks whether a reply landed on the chat/thread since the stale record's timestamp; if so, it treats the record as satisfied-but-misdetected, drops it silently, and lets the current dark turn start its own fresh retry cycle instead of inheriting someone else's spent budget. Wired at the gateway call site via `HISTORY_ENABLED` + `hasOutboundDeliveredSince`. When history is unavailable the check is skipped (never suppress on doubt) — pure fallback to the pre-existing bookkeeping.

   Before: `recordSilentTurnEnd` returned `exhausted:true` purely from `prev.turnKey === args.turnKey && prev.retryCount >= MAX` — no cross-check against actual delivery.
   After: same condition additionally checked against `hasOutboundDeliveredSince(chatId, prev.timestamp, threadId)`; a positive hit suppresses the false exhaustion (test `(d2)` in the new file). A genuine exhaustion (no reply since the record) still fires exactly once (test `(d3)`).

3. **Hardens the fallback text.** Includes the turn's elapsed time (`⚠️ ... didn't send a reply (waited 47s) — ...`) so the message is honest about how long the user actually waited, instead of a generic apology with no timing.

## Deterministic-guarantee delta (RFC Phase 5 policy)

**Before this PR:** the framework guaranteed at-most-one dark-turn fallback message per turn, proven only by state-file unit tests (decision, not delivery) — and the satisfied-check could theoretically be misled by a missed clear on an unrelated earlier turn sharing the same chat/thread key.

**After this PR:** the same at-most-one guarantee is now proven at the transport boundary (spy send, not stubbed callback), and the satisfied-check is verified against real delivery history before ever trusting a "budget already spent" read — closing the one latent staleness gap in the shipped mechanism. No new surface, no new send path, no cadence ping — same one-shot, model-free, terminal-condition fallback `conversational-pacing.md` sanctions.

## Test plan

- `telegram-plugin/tests/silent-end-transport.test.ts` (new, 7 tests) — transport-boundary outcome tests (a)-(d3) above, plus a cross-check against the real `isFinalAnswerReply` predicate.
- `telegram-plugin/tests/silent-end.test.ts` (40 tests, existing) and `telegram-plugin/tests/silent-end-integration.test.ts` (6 tests, existing) — unaffected, still green (the new `hasOutboundDeliveredSince` dep is optional and defaults to the pre-existing behavior).
- `npm run lint` — clean.
- `npx tsc --noEmit` — clean.
- `npx vitest run` (full suite) — same pre-existing failures as clean `main` in this sandbox (`tests/install/static-binary.test.ts`, `tests/host-control/server.test.ts`'s self-bump/lock suite) plus one apparently-flaky concurrency test (`src/auth/broker/server-quota-durable.test.ts` single-flight timing) unrelated to this change's files.
- `npm run test:bun` — 1080 pass, 2 unrelated pre-existing `src/vault/broker/client-token.test.ts` failures (vault token rejection, untouched by this PR).

## Scope

Confined to `telegram-plugin/silent-end.ts` (the guard's satisfied-check), `telegram-plugin/gateway/gateway.ts` (the call site + fallback text), and the new test file. Did not touch the climbing-card heartbeat paths (Phase 1 / PR 1, in flight on another branch) or remove the vestigial 45s floor path (Phase 3 / PR 3).

Co-Authored-By: Claude <noreply@anthropic.com>