### PR TITLE
Watch worktree-isolated sub-agent cwds so liveness surfaces

### DIFF
--- a/reference/rfcs/deterministic-turn-liveness.md
+++ b/reference/rfcs/deterministic-turn-liveness.md
@@ -322,14 +322,23 @@ on tick".
    mid-turn permanently freezes the pre-restart card — the new process
    has no handle to resume editing it. The resumed turn opens a fresh
    card; the old one is never finalized.
-2. **Worktree-isolated sub-agents.** The activity watcher's project-slug
-   filter does not match worktree-isolated sub-agents' cwd, so no live
-   worker feed surfaces for them once the parent turn ends.
+2. ~~**Worktree-isolated sub-agents.**~~ **Closed** by a follow-up PR
+   (`telegram-plugin/subagent-watcher.ts` `extraWatchCwdsProvider` +
+   `telegram-plugin/gateway/gateway.ts` wiring against
+   `src/worktree/registry.ts`'s `listRecords()`). Deterministic guarantee
+   added: sub-agent activity in a worktree-isolated cwd this agent itself
+   claimed surfaces in the worker feed / `subagentActivityAt` exactly like
+   a same-cwd sub-agent — the watcher now watches the project-dir slug for
+   every worktree path owned by this agent (`ownerAgent` match against
+   `SWITCHROOM_AGENT_NAME`), re-derived fresh on every rescan tick, in
+   addition to `agentCwd`. Genuinely foreign project dirs (not a slug the
+   agent's own `agentCwd` or a worktree it owns maps to) are still
+   skipped — the #1116 protection is preserved, not widened to a wildcard
+   watch.
 
-Both are pre-existing and orthogonal to the climb, named here so the
-guarantee is not read as broader than delivered. Each needs its own
-follow-up (persist/rehydrate or boot-time reaping of orphaned cards;
-worktree-aware slug matching).
+Gap 1 is pre-existing and orthogonal to the climb, named here so the
+guarantee is not read as broader than delivered. It needs its own
+follow-up (persist/rehydrate or boot-time reaping of orphaned cards).
 - **Fleet restart discipline.** No fleet restart until the operator
   confirms; stagger restarts across agents (a card-edit-path change is
   visible on the very next turn, so a bad edit should not hit the whole

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -559,6 +559,7 @@ import {
   startSubagentWatcher,
   type SubagentWatcherHandle,
 } from '../subagent-watcher.js'
+import { listRecords as listWorktreeRecords } from '../../src/worktree/registry.js'
 import {
   startBootCard,
   resolvePersonaName,
@@ -26295,6 +26296,28 @@ void (async () => {
               // accident no longer pollute the watcher with phantom
               // registrations + ENOENT log spam + false stalls.
               agentCwd: watcherAgentDir,
+              // Gap 2 (deterministic-turn-liveness.md "Known gaps"): a
+              // sub-agent dispatched into a `switchroom worktree claim`
+              // cwd runs under a different project-dir slug than
+              // `agentCwd` above, so the #1116 foreign-slug filter would
+              // otherwise skip it forever — no activity stamp, no `🛠
+              // Worker` feed for the entire run. Re-derive, fresh on every
+              // rescan tick, the set of worktree paths this agent itself
+              // currently owns (registry records are the deterministic
+              // source of truth for "cwds this agent's sub-agents may run
+              // in") and let the watcher also watch those slugs.
+              // Best-effort: a registry read failure (e.g. no worktree dir
+              // on an agent that never claims one) must not affect the
+              // primary agentCwd watch.
+              extraWatchCwdsProvider: () => {
+                try {
+                  return listWorktreeRecords()
+                    .filter((r) => r.ownerAgent === process.env.SWITCHROOM_AGENT_NAME)
+                    .map((r) => r.path)
+                } catch {
+                  return []
+                }
+              },
               // Bug 0 fix: previously omitted, leaving the watcher unable to
               // write liveness/stall/turn_end updates to the registry DB.
               // Liveness writes are now persisted across the gateway lifetime.

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -212,6 +212,24 @@ export interface SubagentWatcherConfig {
    */
   agentCwd?: string
   /**
+   * Additional cwds (beyond `agentCwd`) whose Claude-Code project-dir slug
+   * should also be watched. Gap 2 of `deterministic-turn-liveness.md`: a
+   * sub-agent dispatched with worktree isolation (`switchroom worktree
+   * claim`) runs with a *different* cwd than the parent agent, so its
+   * `agent-*.jsonl` lands under a different `.claude/projects/<slug>/`
+   * tree than `expectedProjectSlug` — the #1116 foreign-slug filter then
+   * silently skips it forever (no activity stamp, no `🛠 Worker` feed).
+   *
+   * Called fresh on every rescan tick (cheap — reads a handful of small
+   * JSON records from the worktree registry) so a worktree claimed or
+   * released mid-run is picked up/dropped without a watcher restart.
+   * Deterministic guarantee this preserves: only cwds this agent's own
+   * sub-agents can legitimately run in are ever added — a worktree record
+   * not owned by this agent is never included, so this does not widen the
+   * #1116 foreign-project protection into a wildcard watch.
+   */
+  extraWatchCwdsProvider?: () => string[]
+  /**
    * How often to re-scan for new subagent dirs (ms). Default 1000.
    */
   rescanMs?: number
@@ -1173,6 +1191,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
   const expectedProjectSlug = config.agentCwd != null
     ? sanitizeCwdToProjectName(config.agentCwd)
     : null
+  const extraWatchCwdsProvider = config.extraWatchCwdsProvider ?? null
   // One-shot logging: warn the first time a foreign slug is observed
   // so silent regressions are visible without re-running with debug.
   const warnedForeignSlugs = new Set<string>()
@@ -1706,11 +1725,32 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       projectDirs = fs.readdirSync(projectsRoot) as string[]
     } catch { return }
 
+    // Gap 2 (deterministic-turn-liveness.md): re-derive the set of
+    // worktree-isolated slugs this agent's own sub-agents may legitimately
+    // run in, fresh on every tick. Best-effort — a registry read hiccup
+    // (e.g. the worktree dir not existing on an agent that never uses
+    // worktrees) must never break the tail loop, so it just yields no
+    // extra slugs for this tick.
+    let allowedSlugs: Set<string> | null = null
+    if (expectedProjectSlug != null) {
+      allowedSlugs = new Set([expectedProjectSlug])
+      if (extraWatchCwdsProvider != null) {
+        try {
+          for (const cwd of extraWatchCwdsProvider()) {
+            allowedSlugs.add(sanitizeCwdToProjectName(cwd))
+          }
+        } catch (err) {
+          log?.(`subagent-watcher: extraWatchCwdsProvider error: ${(err as Error).message}`)
+        }
+      }
+    }
+
     for (const pDir of projectDirs) {
-      // Issue #1116: filter to the agent's own slug. Skip foreign
-      // project dirs so their stale subagent JSONLs (which Claude
-      // Code reaps mid-session) don't pollute the watcher's registry.
-      if (expectedProjectSlug != null && pDir !== expectedProjectSlug) {
+      // Issue #1116: filter to the agent's own slug (plus, per Gap 2, any
+      // worktree-isolated slugs this agent's own sub-agents may run in).
+      // Skip foreign project dirs so their stale subagent JSONLs (which
+      // Claude Code reaps mid-session) don't pollute the watcher's registry.
+      if (allowedSlugs != null && !allowedSlugs.has(pDir)) {
         if (!warnedForeignSlugs.has(pDir)) {
           warnedForeignSlugs.add(pDir)
           log?.(`subagent-watcher: skipping foreign project dir ${pDir} (expected ${expectedProjectSlug})`)

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -1296,6 +1296,145 @@ describe('startSubagentWatcher', () => {
     })
   })
 
+  // ─── deterministic-turn-liveness.md Known-Gap 2 — worktree-isolated sub-agents ──
+
+  describe('worktree-isolated sub-agent visibility (turn-liveness Known Gap 2)', () => {
+    /**
+     * A sub-agent dispatched with `switchroom worktree claim` runs under a
+     * different cwd than the parent agent, so Claude Code mints a
+     * *different* `.claude/projects/<slug>/` tree for it. Pre-fix, the
+     * #1116 foreign-slug filter above skips that slug forever — no
+     * activity stamp, no `🛠 Worker` feed, for the whole worktree worker's
+     * run. `extraWatchCwdsProvider` closes that gap: any cwd it returns is
+     * treated as a first-class watched slug, same as `agentCwd`.
+     */
+
+    let tmpRoot = ''
+    const startedWatchers: Array<{ stop(): void }> = []
+
+    beforeEach(() => {
+      tmpRoot = mkdtempSync(join(tmpdir(), 'switchroom-watcher-worktree-gap2-'))
+    })
+
+    afterEach(() => {
+      while (startedWatchers.length) {
+        try { startedWatchers.pop()?.stop() } catch { /* ignore */ }
+      }
+      try { rmSync(tmpRoot, { recursive: true, force: true }) } catch { /* ignore */ }
+    })
+
+    function startWatcherSync(opts: {
+      agentDir: string
+      agentCwd?: string
+      extraWatchCwdsProvider?: () => string[]
+    }): {
+      logs: string[]
+      poll: () => void
+      watcher: ReturnType<typeof startSubagentWatcher>
+    } {
+      const logs: string[] = []
+      const intervals: Array<{ fn: () => void; ref: number }> = []
+      let nextRef = 1
+      const watcher = startSubagentWatcher({
+        agentDir: opts.agentDir,
+        ...(opts.agentCwd !== undefined ? { agentCwd: opts.agentCwd } : {}),
+        ...(opts.extraWatchCwdsProvider !== undefined
+          ? { extraWatchCwdsProvider: opts.extraWatchCwdsProvider }
+          : {}),
+        stallThresholdMs: 60_000,
+        rescanMs: 500,
+        now: () => Date.now(),
+        setInterval: (fn) => {
+          const ref = nextRef++
+          intervals.push({ fn, ref })
+          return { ref }
+        },
+        clearInterval: () => {},
+        setTimeout: () => ({ ref: 0 }),
+        clearTimeout: () => {},
+        log: (msg) => logs.push(msg),
+      })
+      startedWatchers.push(watcher)
+      return { logs, poll: () => intervals[0]?.fn(), watcher }
+    }
+
+    it('watches a worktree-isolated cwd slug returned by extraWatchCwdsProvider', () => {
+      const agentDir = join(tmpRoot, 'agent')
+      const agentCwd = '/home/test/agent-own'
+      const worktreeCwd = '/home/test/.switchroom/worktrees/wt-abc123'
+      const ownSubagents = join(agentDir, '.claude', 'projects', '-home-test-agent-own', 'sess-A', 'subagents')
+      const worktreeSlug = join(
+        agentDir,
+        '.claude',
+        'projects',
+        '-home-test--switchroom-worktrees-wt-abc123',
+        'sess-B',
+        'subagents',
+      )
+      mkdirSync(ownSubagents, { recursive: true })
+      mkdirSync(worktreeSlug, { recursive: true })
+      writeFileSync(
+        join(ownSubagents, 'agent-ownworker.jsonl'),
+        buildJSONL(subAgentUserMsg('legit work')),
+      )
+      writeFileSync(
+        join(worktreeSlug, 'agent-worktreeworker.jsonl'),
+        buildJSONL(subAgentUserMsg('worktree-isolated work')),
+      )
+
+      // Pre-fix acceptance: without extraWatchCwdsProvider, the worktree
+      // slug is a "foreign" slug per #1116 and is skipped — this is the
+      // regression this test guards against.
+      const preFix = startWatcherSync({ agentDir, agentCwd })
+      preFix.poll()
+      expect(preFix.watcher.getRegistry().has('worktreeworker')).toBe(false)
+      preFix.watcher.stop()
+
+      const h = startWatcherSync({
+        agentDir,
+        agentCwd,
+        extraWatchCwdsProvider: () => [worktreeCwd],
+      })
+      h.poll()
+
+      const reg = h.watcher.getRegistry()
+      expect(reg.has('ownworker')).toBe(true)
+      expect(reg.has('worktreeworker')).toBe(true)
+    })
+
+    it('still skips a genuinely foreign project dir not returned by extraWatchCwdsProvider', () => {
+      const agentDir = join(tmpRoot, 'agent')
+      const agentCwd = '/home/test/agent-own'
+      const worktreeCwd = '/home/test/.switchroom/worktrees/wt-abc123'
+      const ownSubagents = join(agentDir, '.claude', 'projects', '-home-test-agent-own', 'sess-A', 'subagents')
+      const foreignSubagents = join(agentDir, '.claude', 'projects', '-home-test-agent-foreign', 'sess-C', 'subagents')
+      mkdirSync(ownSubagents, { recursive: true })
+      mkdirSync(foreignSubagents, { recursive: true })
+      writeFileSync(
+        join(ownSubagents, 'agent-ownworker.jsonl'),
+        buildJSONL(subAgentUserMsg('legit work')),
+      )
+      writeFileSync(
+        join(foreignSubagents, 'agent-foreignworker.jsonl'),
+        buildJSONL(subAgentUserMsg('a sibling agent, not a registered worktree')),
+      )
+
+      const h = startWatcherSync({
+        agentDir,
+        agentCwd,
+        // Registers a worktree cwd that is NOT the foreign dir above —
+        // proves extraWatchCwdsProvider adds only what it explicitly
+        // names, never a wildcard.
+        extraWatchCwdsProvider: () => [worktreeCwd],
+      })
+      h.poll()
+
+      const reg = h.watcher.getRegistry()
+      expect(reg.has('ownworker')).toBe(true)
+      expect(reg.has('foreignworker')).toBe(false)
+    })
+  })
+
   describe('issue #1116 — terminal cleanup must not re-fire completion (Bug B)', () => {
     /**
      * Pre-#1116: after `TERMINAL_CLEANUP_GRACE_MS` (30s) elapsed,


### PR DESCRIPTION
## Summary

Closes Known Gap 2 in `reference/rfcs/deterministic-turn-liveness.md` and serves `reference/jobs/know-what-my-agent-is-doing.md` ("Sub-agent and background work is visible in the same thread").

A sub-agent dispatched into a `switchroom worktree claim`-allocated cwd runs under a **different** cwd than the parent agent, so Claude Code mints a different `.claude/projects/<sanitized-cwd>/` project-dir slug for it. `subagent-watcher.ts`'s `expectedProjectSlug` filter (#1116) restricts enumeration to the parent's own slug and treats any other slug as foreign — so a worktree worker's `agent-*.jsonl` was silently skipped forever: no `turn.subagentActivityAt` stamp, no `🛠 Worker` feed message, for the entire run. If the parent turn had already ended, the user saw nothing at all while a 20-minute worktree worker ran.

**Fix, small and inside the watcher/feed layer:**
- `subagent-watcher.ts`: new optional `extraWatchCwdsProvider?: () => string[]` config. On every rescan tick, its returned cwds are `sanitizeCwdToProjectName`'d and added to the set of watched project slugs (alongside `agentCwd`), so a worktree claimed or released mid-run is picked up/dropped live, no watcher restart needed.
- `gateway.ts`: wires `extraWatchCwdsProvider` to `src/worktree/registry.ts`'s `listRecords()`, filtered to records this agent itself owns (`ownerAgent === SWITCHROOM_AGENT_NAME`). The worktree registry is the deterministic source of truth for "cwds this agent's sub-agents may legitimately run in" — not a wildcard watch of every project dir under `.claude/projects/`. A registry read failure is best-effort/non-fatal (falls back to zero extra slugs for that tick).
- Genuinely foreign project dirs (belonging to another agent/session, not a registered worktree this agent owns) are still skipped — the #1116 protection is preserved, not widened.
- `reference/rfcs/deterministic-turn-liveness.md`: Known Gap 2 marked closed with the deterministic-guarantee delta stated inline, per the RFC's own Phase 5 erosion-guard rule. Gap 1 (restart mid-turn) stays open.

**Deterministic guarantee added:** sub-agent activity in a worktree-isolated cwd this agent itself claimed surfaces in the worker feed / `subagentActivityAt` exactly like a same-cwd sub-agent.

## Pre-fix failure proof

New test `watches a worktree-isolated cwd slug returned by extraWatchCwdsProvider` in `telegram-plugin/tests/subagent-watcher.test.ts` fails on unmodified `subagent-watcher.ts`/`gateway.ts` (only the test file added, watcher/gateway source stashed back to `origin/main`):

```
error: expect(received).toBe(expected)
Expected: true
Received: false
    at telegram-plugin/tests/subagent-watcher.test.ts:1402:41
(fail) startSubagentWatcher > worktree-isolated sub-agent visibility (turn-liveness Known Gap 2) > watches a worktree-isolated cwd slug returned by extraWatchCwdsProvider
 28 pass
 1 fail
```

With the fix restored: `29 pass, 0 fail`.

A second new test (`still skips a genuinely foreign project dir not returned by extraWatchCwdsProvider`) is the negative case proving this doesn't widen into a wildcard watch.

## Test plan

- [x] `bun test telegram-plugin/tests/subagent-watcher.test.ts` — 29 pass (was 27 pass pre-change; 2 new outcome-based tests added, positive + negative)
- [x] `npm run lint` — clean
- [x] `npm test` (full suite) — 85 pre-existing failures reproduce identically with my changes stashed out against `origin/main` (verified for a sample: `tests/run-hook.test.ts`, `tests/deps.test.ts`) — sandbox environment limitations (docker/spawn/shell-hook access), not caused by this change. None of the failing tests touch `subagent-watcher.ts`, `worker-activity-feed.ts`, `gateway.ts`, or `src/worktree/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)