### PR TITLE
fix(hindsight): throttle consolidation + fix max_turns ToolSearch wall

### DIFF
--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -109,6 +109,45 @@ assert NEW_PATH in t and OLD_SS not in t and 'mkdtemp(prefix="hindsight-claude-c
 print("switchroom #2392: claude_code env isolation neutralized (CLAUDE_CONFIG_DIR=/run/claude-creds, SECURESTORAGE override dropped)")
 PYEOF
 
+# max_turns/ToolSearch standard-call fix: the STANDARD (non-tool) LLM-call
+# path in claude_code_llm.py builds `ClaudeAgentOptions` with
+# `allowed_tools=[]` but WITHOUT `tools=[]`. Clearing allowed_tools does NOT
+# unload the built-in Claude Code CLI tools — they stay resident, so on a
+# plain text-generation call Claude burns its single `max_turns=1` turn on a
+# ToolSearch step and then errors with "Reached maximum number of turns (1)".
+# The provider retries, wasting tokens and intermittently failing memory ops
+# (fact extraction / recall). The TOOL-calling path further down the SAME
+# file already carries the correct shape (`tools=[]` + `max_turns=2`, with a
+# comment) — this patch brings the standard path to parity: drop the built-in
+# CLI tools entirely so ToolSearch can't fire, and give one turn of headroom
+# so a stray tool turn can't wall a tool-less generation. Anchored tightly on
+# the `# Single-turn for API-style interactions` comment so we touch ONLY the
+# standard path, never the tool-calling one. Self-verifying: the build FAILS
+# LOUDLY if upstream reformats this call, so we never silently ship the
+# regression.
+RUN python3 - <<'PYEOF'
+import pathlib
+f = pathlib.Path("/app/api/hindsight_api/engine/providers/claude_code_llm.py")
+s = f.read_text()
+OLD = (
+    "            max_turns=1,  # Single-turn for API-style interactions\n"
+    "            allowed_tools=[],  # Disable tools for standard LLM calls\n"
+)
+NEW = (
+    "            tools=[],  # switchroom: disable built-in CLI tools so ToolSearch can't consume the single turn (max_turns wall / wasted-retry fix)\n"
+    "            max_turns=2,  # switchroom: headroom so a stray ToolSearch turn can't wall a tool-less text-gen call\n"
+    "            allowed_tools=[],  # Disable tools for standard LLM calls\n"
+)
+assert s.count(OLD) == 1, "switchroom max_turns/ToolSearch standard-call fix: the standard-call ClaudeAgentOptions anchor (max_turns=1 # Single-turn for API-style interactions + allowed_tools=[]) was not found exactly once — upstream reformatted the standard-call ClaudeAgentOptions; re-author this patch in docker/Dockerfile.hindsight"
+s = s.replace(OLD, NEW, 1)
+f.write_text(s)
+t = f.read_text()
+assert NEW in t, "switchroom max_turns/ToolSearch standard-call fix: verification failed — patched block not present"
+assert "            tools=[],  # switchroom" in t, "switchroom max_turns/ToolSearch standard-call fix: tools=[] not present on the standard path after patch"
+assert "max_turns=1,  # Single-turn" not in t, "switchroom max_turns/ToolSearch standard-call fix: a bare max_turns=1 standard-call still remains after patch"
+print("switchroom max_turns/ToolSearch standard-call fix: standard LLM call now sends tools=[] + max_turns=2 (ToolSearch can no longer wall the turn)")
+PYEOF
+
 # Pin the upstream `hindsight` user to UID 11000 to match
 # `HINDSIGHT_DEFAULT_UID` in src/setup/hindsight.ts (and the
 # `auth.consumers[hindsight].uid` value the operator writes in

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -256,36 +256,40 @@ export const HINDSIGHT_DEFAULT_RECALL_MAX_CONCURRENT = 8;
 export const HINDSIGHT_DEFAULT_REFLECT_WALL_TIMEOUT_S = 600;
 
 /**
- * Consolidation throughput knobs (modest, reversible). Consolidation is
- * LLM-bound via the claude-code provider (observed ~510s/op), so a deep
- * backlog (e.g. after a stall) drains slowly. Two conservative levers:
+ * Consolidation throughput knobs — throttled HARD for shared-quota safety.
+ * Consolidation is LLM-bound via the claude-code provider (observed
+ * ~510s/op), and every concurrent op is a live claude (Sonnet) subprocess
+ * spending the subscription's quota.
  *
- * - LLM_BATCH_SIZE 8→12: more facts per LLM call → fewer round-trips per
- *   round, so less per-call overhead at ~the same total tokens. Kept
- *   modest (not 16+) to avoid diluting per-fact synthesis quality.
- * - CONSOLIDATION_MAX_SLOTS 2→3: one more bank consolidates concurrently,
- *   which matters during multi-bank backlog recovery. Kept to 3 (not
- *   higher) because every slot is a concurrent claude subprocess on the
- *   shared subscription — more would risk contending with the fleet's own
- *   model usage (subscription-honest). Both revert via the env vars.
+ * Since 2026-07-05 hindsight is UNPINNED (auth.consumers[hindsight] has no
+ * `account:`) — it follows the fleet-active account and shares the SAME
+ * live-turn quota the agents use. That makes the hard ceiling on concurrent
+ * model calls (MAX_SLOTS × LLM_PARALLELISM) a direct tax on the fleet: on
+ * 2026-07-06 an 18-way consolidation fan-out (3 × 6) across multiple banks
+ * exhausted the shared account (429 rate-limit wall) and starved live agent
+ * turns. Operator decision: hindsight keeps sharing the fleet's failover,
+ * but consolidation must NEVER be able to exhaust the quota — so the
+ * concurrency ceiling is throttled to 1 × 2 = 2 concurrent model calls
+ * (was 18), and per-round scope is cut so an op can't monopolise a slot for
+ * long.
  *
- * Two more (added after the 2026-06-19 backlog dig): these target a
- * single backed-up bank, where MAX_SLOTS doesn't help (slots parallelise
- * ACROSS banks, but the bottleneck is one bank's per-op rate). The hard
- * ceiling on concurrent model calls is MAX_SLOTS × LLM_PARALLELISM, so we
- * keep it fleet-safe: 3 × 6 = 18 (was 3 × 4 = 12), NOT a reckless
- * doubling that would starve the fleet's interactive model usage.
- * - LLM_PARALLELISM 4→6: more tag-groups consolidated concurrently WITHIN
- *   one op → faster per-op drain on a single bank.
- * - MAX_MEMORIES_PER_ROUND 100→300: a larger scope clears in one op
- *   instead of re-queuing, cutting per-op setup overhead.
- * Pairs with the 8g memory limit below (more in-flight consolidation =
- * more RSS). All operator-overridable via the generated compose / -e.
+ * - MAX_SLOTS 1: at most one bank consolidates at a time (no cross-bank
+ *   fan-out — that fan-out is exactly what walled the account).
+ * - LLM_PARALLELISM 2: at most two tag-groups in flight within that one op.
+ *   1 × 2 = 2 concurrent claude subprocesses, ceiling.
+ * - MAX_MEMORIES_PER_ROUND 100: bounded scope per op → faster slot release,
+ *   more re-queue points where the fleet can reclaim the quota.
+ * - LLM_BATCH_SIZE 12 (unchanged): facts per LLM call — tokens-per-call, not
+ *   concurrency, so it doesn't affect the shared-quota ceiling.
+ * Consolidation now drains slower by design; that is the accepted trade for
+ * never walling the live fleet. All values remain operator-overridable via
+ * the generated compose / -e (raise them only with a dedicated isolated
+ * account pinned back on the consumer).
  */
 export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE = 12;
-export const HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS = 3;
-export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM = 6;
-export const HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND = 300;
+export const HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS = 1;
+export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM = 2;
+export const HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND = 100;
 
 /**
  * Container resource caps (memory + pids only; CPU intentionally NOT capped).

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -127,6 +127,55 @@ describe("Dockerfile.hindsight shape", () => {
     );
   });
 
+  it("keeps the #2392 claude_code env-isolation patch (assert-guarded, fail-loud)", () => {
+    // The #2392 build-time patch neutralizes upstream's env isolation
+    // (mkdtemp CONFIG_DIR + SECURESTORAGE="") that breaks file-based
+    // creds. It is self-verifying: it asserts the upstream anchor is
+    // present before patching. Guard the patch block itself so nobody
+    // silently deletes it.
+    expect(dockerfile).toMatch(
+      /assert OLD_PATH in s, "switchroom #2392 patch:/,
+    );
+    expect(dockerfile).toMatch(
+      /path = "\/run\/claude-creds"  # switchroom #2392:/,
+    );
+  });
+
+  it("keeps the max_turns/ToolSearch standard-call fix (assert-guarded, fail-loud)", () => {
+    // The STANDARD LLM-call path in claude_code_llm.py builds
+    // ClaudeAgentOptions with allowed_tools=[] but WITHOUT tools=[], so
+    // the built-in CLI tools stay loaded and ToolSearch burns the single
+    // max_turns=1 turn → "Reached maximum number of turns (1)" → wasted
+    // retries / failed memory ops. This build-time patch brings the
+    // standard path to parity with the tool-calling path (tools=[] +
+    // max_turns=2). It is self-verifying (asserts the anchor exists once
+    // before patching, re-asserts the result). Guard the patch block so
+    // nobody silently deletes it and reintroduces the max_turns wall.
+
+    // The exact-once assert on the pre-patch anchor (fail-loud on drift).
+    expect(dockerfile).toMatch(
+      /assert s\.count\(OLD\) == 1, "switchroom max_turns\/ToolSearch standard-call fix:/,
+    );
+    // The OLD anchor reconstructs the upstream (pre-patch) standard-call shape.
+    expect(dockerfile).toMatch(
+      /max_turns=1,  # Single-turn for API-style interactions/,
+    );
+    // The NEW replacement adds tools=[] + max_turns=2 on the standard path.
+    expect(dockerfile).toMatch(
+      /tools=\[\],  # switchroom: disable built-in CLI tools so ToolSearch/,
+    );
+    expect(dockerfile).toMatch(
+      /max_turns=2,  # switchroom: headroom so a stray ToolSearch turn/,
+    );
+    // Post-replace re-assertions must be present (verification-on-build).
+    expect(dockerfile).toMatch(
+      /assert "            tools=\[\],  # switchroom" in t,/,
+    );
+    expect(dockerfile).toMatch(
+      /assert "max_turns=1,  # Single-turn" not in t,/,
+    );
+  });
+
   it("preserves upstream's start-all.sh as the post-shim CMD", () => {
     // The shim does broker auth, then `exec "$@"` which is whatever
     // CMD docker passes — must be upstream's start-all.sh so the


### PR DESCRIPTION
Protects the shared-account quota after the 2026-07-06 hindsight token-burn incident.

## What
**Throttle consolidation concurrency** (`src/setup/hindsight.ts`)
- `MAX_SLOTS` 3→1, `LLM_PARALLELISM` 6→2 (concurrent-model-call ceiling 18→2)
- `MAX_MEMORIES_PER_ROUND` 300→100 (bounded scope per op, faster slot release)

**Fix the standard-call `max_turns` wall** (`docker/Dockerfile.hindsight`)
The standard (non-tool) LLM-call path in upstream `claude_code_llm.py` sets `allowed_tools=[]` but not `tools=[]`, so the built-in Claude Code CLI tools stay loaded. On a plain text-gen call Claude spends its single `max_turns=1` turn on ToolSearch, errors with "Reached maximum number of turns (1)", and the provider retries — wasting tokens and intermittently failing memory ops. The tool-calling path further down the same file already has the fix (`tools=[]` + `max_turns=2`); this brings the standard path to parity via a self-verifying build-time patch that mirrors the #2392 idiom and **fails the build loudly** if upstream reformats the anchor.

## Test
`tests/docker/dockerfile-hindsight-bakes.test.ts` — guards both patch blocks (the #2392 env-isolation patch and the new max_turns fix) stay present and well-formed.

## Verification
- Runtime hotfix of the same change has been live on `switchroom-hindsight` since the incident: **0 max-turns errors** post-fix (was ~4/min), burn fell from a ~570k/min peak to idle as the backlog drained.
- `tsc --noEmit`: exit 0. `vitest` on the test file: 15/15 pass.

## Rollout
Land, then run `switchroom apply --build-local` from the host to rebuild the hindsight image with the baked code fix and regenerate the container with the throttle env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)