### PR TITLE
gateway: finalize restart-orphaned activity cards on boot (deterministic-turn-liveness Known Gap 1)

### DIFF
--- a/reference/rfcs/deterministic-turn-liveness.md
+++ b/reference/rfcs/deterministic-turn-liveness.md
@@ -317,11 +317,29 @@ on tick".
 
 ### Known gaps (out of scope, not closed by this RFC)
 
-1. **Restart mid-turn.** The climb's card handle (`activityMessageId`)
-   and the current-turn state live in gateway memory; a gateway restart
-   mid-turn permanently freezes the pre-restart card — the new process
-   has no handle to resume editing it. The resumed turn opens a fresh
-   card; the old one is never finalized.
+1. ~~**Restart mid-turn.**~~ **Closed** by a follow-up PR
+   (`telegram-plugin/gateway/activity-card-store.ts` + gateway wiring in
+   `telegram-plugin/gateway/gateway.ts`). Deterministic guarantee added: no
+   card orphaned by a gateway restart stays visually frozen (or pinned) —
+   it is finalized with one honest edit, and unpinned, on the very next
+   boot. The minimal card handle (chatId, threadId, activityMessageId,
+   startedAt, pinned) is persisted to `TELEGRAM_STATE_DIR/activity-cards-
+   pending.json` the moment a card OPENs and cleared the moment it closes
+   normally — mirroring `status-pin-store.ts`'s durable-snapshot shape
+   byte-for-byte. On boot, after winning the startup mutex (same ordering
+   constraint as `statusPinBootCleanup`), a one-shot, model-free reaper
+   reads any leftover record, deletes it from disk BEFORE attempting its
+   edit/unpin (the idempotency guard — a second boot performs zero edits
+   and zero unpins), and finalizes the orphaned card with a single
+   `editMessageText` (never a new message — no ping) plus an
+   `unpinChatMessage` for cards that were pinned on open. The resumed turn
+   (if any) is NOT made to resume climbing the old card — it opens its own
+   fresh card; honest finalization, not resumption, was the goal. Scoped
+   out: the standalone worker-activity-feed's `messageId` (a separate,
+   lower-traffic surface — `WorkerActivityFeed` doesn't carry per-turn
+   liveness semantics the same way, and folding it in would double this
+   PR's surface area for a rarer failure mode); left for a follow-up if it
+   proves to matter in practice.
 2. ~~**Worktree-isolated sub-agents.**~~ **Closed** by a follow-up PR
    (`telegram-plugin/subagent-watcher.ts` `extraWatchCwdsProvider` +
    `telegram-plugin/gateway/gateway.ts` wiring against

--- a/telegram-plugin/gateway/activity-card-store.ts
+++ b/telegram-plugin/gateway/activity-card-store.ts
@@ -1,0 +1,255 @@
+/**
+ * activity-card-store.ts — durable handle for the mid-turn activity card, so a
+ * gateway restart mid-turn can finalize the orphaned card instead of leaving it
+ * frozen forever.
+ *
+ * Why this exists (reference/rfcs/deterministic-turn-liveness.md Known Gap 1):
+ * `CurrentTurn.activityMessageId` / `startedAt` and the live `currentTurn`
+ * itself live ONLY in gateway memory. If the gateway restarts while a turn's
+ * activity card is open, the new process has no handle to the old card — it
+ * is never edited again and sits frozen on its last pre-restart text forever.
+ * The resumed turn (if any) opens a FRESH card; the old one is orphaned.
+ *
+ * The fix mirrors `status-pin-store.ts` byte-for-byte in shape: a tiny durable
+ * snapshot on the per-agent state volume (STATE_DIR), written whenever a card
+ * OPENS, cleared the moment it closes/finalizes normally. On boot, AFTER this
+ * gateway wins the startup mutex (same ordering constraint as the status-pin
+ * cleanup — this is a shared per-agent file, so a losing double-boot must
+ * never touch it), a one-shot reaper reads any leftover record and finalizes
+ * the orphaned card with a SINGLE honest edit (never a new message — edits do
+ * not notify, so no ping). We do NOT attempt to resume climbing the old card
+ * across the restart; the resumed turn (if any) owns a fresh card. Honest
+ * finalization — not resumption — is the goal.
+ *
+ * Crash-safety: write-tmp + atomic rename (identical convention to
+ * status-pin-store.ts / obligation-store.ts). A corrupt or unreadable file
+ * fails open to `[]` — never crashes boot, worst case an orphan isn't cleaned
+ * up this boot, no worse than pre-fix behaviour.
+ *
+ * Idempotency: the reaper deletes a record from the on-disk store BEFORE
+ * attempting its finalizing edit (not after), so a crash mid-reap, or a
+ * second boot re-reading the file, can never double-edit the same message. A
+ * failed edit (message already deleted, chat gone, etc.) is swallowed — the
+ * record is already gone from disk regardless of whether the edit itself
+ * succeeded.
+ */
+
+export interface ActivityCardStoreFsSeam {
+  readFileSync: (path: string) => string
+  writeFileSync: (path: string, data: string) => void
+  /** Atomic same-dir replace (POSIX rename) so a crash mid-write can't tear
+   *  the snapshot. */
+  renameSync: (from: string, to: string) => void
+  existsSync: (path: string) => boolean
+}
+
+/** One persisted card handle: enough to identify and finalize the orphaned
+ *  Telegram message on a future boot, without any live turn state. */
+export interface ActivityCardRecord {
+  /** Stable per-topic key (`statusKey(chatId, threadId)` shape) — also the
+   *  upsert key: a fresh OPEN for the same topic replaces any stale row. */
+  turnKey: string
+  chatId: string
+  threadId: number | null
+  activityMessageId: number
+  /** Wall-clock ms the turn started — carried through so the finalize text
+   *  can be honest about elapsed time even after a restart. */
+  startedAt: number
+  /** Whether this card was silently pinned when it opened (the gateway pins
+   *  every fresh activity card via `reconcileStatusPin('fg:'+turnKey, …)`).
+   *  The boot reaper must unpin it too — a frozen card that's ALSO still
+   *  pinned is a worse orphan (it stays glued to the top of the chat
+   *  forever). Optional so a v1-shape record (pre-unpin-tracking) still
+   *  loads and degrades to "don't attempt an unpin", never a crash. */
+  pinned?: boolean
+}
+
+interface SnapshotEnvelope {
+  v: 1
+  cards: ActivityCardRecord[]
+}
+
+function isCardRow(x: unknown): x is ActivityCardRecord {
+  if (x == null || typeof x !== 'object') return false
+  const o = x as Record<string, unknown>
+  return (
+    typeof o.turnKey === 'string' &&
+    o.turnKey.length > 0 &&
+    typeof o.chatId === 'string' &&
+    o.chatId.length > 0 &&
+    (o.threadId === null || typeof o.threadId === 'number') &&
+    typeof o.activityMessageId === 'number' &&
+    typeof o.startedAt === 'number' &&
+    (o.pinned === undefined || typeof o.pinned === 'boolean')
+  )
+}
+
+/**
+ * Load the persisted card-handle set. Returns [] on a missing, unreadable, or
+ * malformed file — fail-open, never throws.
+ */
+export function loadActivityCards(
+  path: string,
+  fs: ActivityCardStoreFsSeam,
+): ActivityCardRecord[] {
+  if (!fs.existsSync(path)) return []
+  let raw = ''
+  try {
+    raw = fs.readFileSync(path)
+  } catch {
+    return []
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  if (parsed == null || typeof parsed !== 'object') return []
+  const env = parsed as Record<string, unknown>
+  if (env.v !== 1 || !Array.isArray(env.cards)) return []
+  return env.cards.filter(isCardRow)
+}
+
+/**
+ * Persist the card-handle set atomically (write sibling tmp → rename). Never
+ * throws — a write failure is logged and the store degrades to in-memory-only
+ * for this process (same contract as `status-pin-store.ts`).
+ */
+export function persistActivityCards(
+  path: string,
+  fs: ActivityCardStoreFsSeam,
+  snapshot: readonly ActivityCardRecord[],
+  log: (line: string) => void = (l) => process.stderr.write(l),
+): void {
+  const env: SnapshotEnvelope = { v: 1, cards: [...snapshot] }
+  const tmp = path + '.tmp'
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(env))
+    fs.renameSync(tmp, path)
+  } catch (err) {
+    log(
+      `activity-card-store: persist FAILED path=${path}: ${(err as Error).message} — ` +
+        `durability degraded to in-memory\n`,
+    )
+  }
+}
+
+/**
+ * Upsert the card-handle row for `turnKey` (replacing any stale row for the
+ * same topic — e.g. a prior turn's card that was never cleared). Called the
+ * moment a card OPENs (activityMessageId transitions null → set).
+ */
+export function writeActivityCardRecord(
+  path: string,
+  fs: ActivityCardStoreFsSeam,
+  record: ActivityCardRecord,
+  log: (line: string) => void = (l) => process.stderr.write(l),
+): void {
+  const current = loadActivityCards(path, fs)
+  const others = current.filter((c) => c.turnKey !== record.turnKey)
+  persistActivityCards(path, fs, [...others, record], log)
+}
+
+/**
+ * Remove the card-handle row for `turnKey`, if present. Called the moment a
+ * card closes/finalizes normally (clearActivitySummary), and by the boot
+ * reaper (BEFORE attempting the finalizing edit — the idempotency guard).
+ */
+export function clearActivityCardRecord(
+  path: string,
+  fs: ActivityCardStoreFsSeam,
+  turnKey: string,
+  log: (line: string) => void = (l) => process.stderr.write(l),
+): void {
+  const current = loadActivityCards(path, fs)
+  if (current.length === 0) return
+  const next = current.filter((c) => c.turnKey !== turnKey)
+  if (next.length === current.length) return
+  persistActivityCards(path, fs, next, log)
+}
+
+/**
+ * Boot-time orphan reaper, extracted as a pure routine over injected seams
+ * (mirrors `runStatusPinBootCleanup`). The gateway's thin wrapper binds the
+ * live fs, a Telegram edit call, and the logger.
+ *
+ * CRITICAL ordering, identical constraint to the status-pin cleanup: the
+ * caller MUST only invoke this AFTER winning the startup mutex. The store is
+ * a shared per-agent file; a losing double-boot running this would finalize
+ * cards the still-alive holder's in-flight turn still legitimately owns.
+ *
+ * Deletes each record from disk BEFORE attempting its edit/unpin (not
+ * after), so a crash mid-reap, or a second boot re-reading the file, can
+ * never re-finalize (and thus never double-edit, never double-unpin) the
+ * same message. `finalizeCard` / `unpinCard` failures (message already
+ * deleted, chat unreachable, permissions changed, already-unpinned, etc.)
+ * are swallowed — non-fatal, logged, and never re-attempted since the
+ * record is already gone.
+ *
+ * Unpin runs AFTER the finalizing edit, only for a record with `pinned:
+ * true` (a v1-shape record with no `pinned` field is left un-unpinned —
+ * conservative degrade, not a crash), and its failure is independent of the
+ * edit's outcome (an edit failure — e.g. message already deleted — must not
+ * skip the unpin attempt, since Telegram allows unpinning a deleted
+ * message's id to no-op harmlessly, and conversely an unpin failure must
+ * never re-attempt the edit).
+ */
+export async function runActivityCardBootReaper(args: {
+  path: string
+  fs: ActivityCardStoreFsSeam
+  finalizeCard: (record: ActivityCardRecord) => Promise<unknown>
+  unpinCard: (record: ActivityCardRecord) => Promise<unknown>
+  log?: (line: string) => void
+}): Promise<{ finalized: number; unpinned: number; total: number }> {
+  const log = args.log ?? ((l: string) => process.stderr.write(l))
+  const persisted = loadActivityCards(args.path, args.fs)
+  if (persisted.length === 0) return { finalized: 0, unpinned: 0, total: 0 }
+  let finalized = 0
+  let unpinned = 0
+  for (const record of persisted) {
+    // Delete BEFORE attempting the edit/unpin — the idempotency guard. If the
+    // gateway crashes here, or a second boot re-reads the file, this record
+    // no longer exists on disk, so it can never be finalized or unpinned
+    // twice.
+    clearActivityCardRecord(args.path, args.fs, record.turnKey, log)
+    try {
+      await args.finalizeCard(record)
+      finalized++
+    } catch (err) {
+      log(
+        `activity-card-store: boot reaper finalize failed ` +
+          `(chat=${record.chatId} msg=${record.activityMessageId}): ` +
+          `${(err as Error).message}\n`,
+      )
+    }
+    if (record.pinned) {
+      try {
+        await args.unpinCard(record)
+        unpinned++
+      } catch (err) {
+        log(
+          `activity-card-store: boot reaper unpin failed ` +
+            `(chat=${record.chatId} msg=${record.activityMessageId}): ` +
+            `${(err as Error).message}\n`,
+        )
+      }
+    }
+  }
+  return { finalized, unpinned, total: persisted.length }
+}
+
+/**
+ * Honest finalize text for an orphaned card — the single edit the boot
+ * reaper applies. Mirrors `silentEndFallbackText`'s honesty-about-elapsed
+ * convention (`telegram-plugin/silent-end.ts`): degenerate/unknown durations
+ * omit the elapsed clause rather than printing a nonsensical "(0s)".
+ */
+export function restartOrphanCardFinalizeText(startedAt: number): string {
+  const elapsedMs = Date.now() - startedAt
+  const elapsed =
+    Number.isFinite(elapsedMs) && elapsedMs > 0
+      ? ` (was running ${Math.round(elapsedMs / 1000)}s)`
+      : ''
+  return `⚠️ Interrupted by a gateway restart${elapsed} — this turn did not finish.`
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -414,6 +414,13 @@ import {
   type StatusPinPersistOp,
   type TrackedStatusPin,
 } from './status-pin-store.js'
+import {
+  writeActivityCardRecord,
+  clearActivityCardRecord,
+  runActivityCardBootReaper,
+  restartOrphanCardFinalizeText,
+  type ActivityCardStoreFsSeam,
+} from './activity-card-store.js'
 import { driveEscalation } from './escalation-drive.js'
 import { shouldSuppressRepresent } from './represent-guard.js'
 import { shouldDeferEscalationForBridge } from './escalation-bridge-gate.js'
@@ -6030,6 +6037,22 @@ const statusPinStoreFs = {
 }
 const statusPinPersistEnabled = !STATIC && PIN_STATUS_WHILE_WORKING
 
+// Durable card-handle snapshot for the mid-turn activity card (Known Gap 1,
+// `reference/rfcs/deterministic-turn-liveness.md`). Persisted on card OPEN,
+// cleared on normal close/finalize; a boot-time reaper (wired alongside
+// `statusPinBootCleanup`, same startup-mutex ordering constraint) finalizes
+// any leftover record with one honest edit so a gateway restart mid-turn can
+// never leave the card frozen forever. STATIC mode skips disk (dry-run, no
+// durable volume) — same gate as the status-pin store.
+const ACTIVITY_CARD_STORE_PATH = join(STATE_DIR, 'activity-cards-pending.json')
+const activityCardStoreFs: ActivityCardStoreFsSeam = {
+  readFileSync: (p: string) => readFileSync(p, 'utf8'),
+  writeFileSync: (p: string, d: string) => writeFileSync(p, d),
+  renameSync: (a: string, b: string) => renameSync(a, b),
+  existsSync: (p: string) => existsSync(p),
+}
+const activityCardPersistEnabled = !STATIC
+
 // Slot-banner pin persistence (#421 crash-recovery). The slot banner is pinned
 // in the owner chat when the agent is on a non-default OAuth slot. Rather than a
 // parallel store + second boot hook, its pin is persisted in the SAME
@@ -6108,6 +6131,66 @@ async function statusPinBootCleanup(): Promise<void> {
     process.stderr.write(
       `telegram gateway: status-pin: cleared ${cleared}/${total} ` +
         `orphaned pin(s) from a prior session\n`,
+    )
+  }
+}
+/**
+ * Boot-time orphan-card reaper (Known Gap 1,
+ * `reference/rfcs/deterministic-turn-liveness.md`). Thin gateway wrapper over
+ * the pure `runActivityCardBootReaper` — binds the live fs seam, a real
+ * Telegram edit, and the gateway logger. Finalizes ANY card left open by a
+ * prior (crashed/restarted) session with ONE honest edit — never a new
+ * message, so no ping — and never re-attempts across boots (the pure routine
+ * deletes each record from disk before attempting its edit).
+ *
+ * MUST run ONLY after this gateway wins the startup mutex (the store is a
+ * shared per-agent file; a losing double-boot would finalize a card the
+ * still-alive holder's in-flight turn still legitimately owns) — identical
+ * ordering constraint to `statusPinBootCleanup`.
+ *
+ * Deliberately does NOT attempt to resume climbing the old card: the resumed
+ * turn (if any) opens its own fresh card. Honest finalization, not
+ * resumption, is the goal (see the module doc in activity-card-store.ts).
+ *
+ * After the finalizing edit, also unpins the card (every fresh card is
+ * silently pinned on open, `reconcileStatusPin('fg:'+key, …)`) — a frozen
+ * card that's ALSO still pinned is a worse orphan, glued to the top of the
+ * chat forever. Only attempted for a record with `pinned: true`.
+ */
+async function activityCardBootReaper(): Promise<void> {
+  if (!activityCardPersistEnabled) return
+  const { finalized, unpinned, total } = await runActivityCardBootReaper({
+    path: ACTIVITY_CARD_STORE_PATH,
+    fs: activityCardStoreFs,
+    finalizeCard: (record) =>
+      robustApiCall(
+        () =>
+          lockedBot.api.editMessageText(
+            record.chatId,
+            record.activityMessageId,
+            richMessage(restartOrphanCardFinalizeText(record.startedAt)),
+            {},
+          ),
+        {
+          chat_id: record.chatId,
+          ...(record.threadId != null ? { threadId: record.threadId } : {}),
+          verb: 'activity-card.boot-reap-finalize',
+        },
+      ),
+    unpinCard: (record) =>
+      robustApiCall(
+        () => lockedBot.api.unpinChatMessage(record.chatId, record.activityMessageId),
+        {
+          chat_id: record.chatId,
+          ...(record.threadId != null ? { threadId: record.threadId } : {}),
+          verb: 'activity-card.boot-reap-unpin',
+        },
+      ),
+  })
+  if (total > 0) {
+    process.stderr.write(
+      `telegram gateway: activity-card: finalized ${finalized}/${total}, ` +
+        `unpinned ${unpinned}/${total} orphaned card(s) from a prior session\n`,
     )
   }
 }
@@ -6416,6 +6499,7 @@ function ensureIssuesCard(chatId: string, threadId: number | undefined): void {
     // LOSING double-boot never unpins the live holder's legitimate pins.
     // Fire-and-forget: cleanup is best-effort and must not block boot.
     void statusPinBootCleanup()
+    void activityCardBootReaper()
   } catch (err) {
     process.stderr.write(
       `telegram gateway: boot.lock_acquire_failed err=${(err as Error).message} agent=${SWITCHROOM_AGENT_NAME}\n`,
@@ -6432,6 +6516,7 @@ function ensureIssuesCard(chatId: string, threadId: number | undefined): void {
       // successful writePidFile here means no live holder was detected, so
       // running orphan cleanup is consistent with the pre-mutex behaviour.
       void statusPinBootCleanup()
+      void activityCardBootReaper()
     } catch (writeErr) {
       process.stderr.write(`telegram gateway: writePidFile failed: ${writeErr}\n`)
     }
@@ -12537,6 +12622,25 @@ async function drainActivitySummary(
           )
           turn.activityMessageId = sent.message_id
           turn.activityEverOpened = true
+          // Known Gap 1 (deterministic-turn-liveness.md) — persist the
+          // minimal card handle the moment it opens, so a gateway restart
+          // mid-turn has something to finalize on next boot instead of
+          // leaving this card frozen forever. Fire-and-forget/best-effort:
+          // a failed persist degrades to the pre-fix (in-memory-only)
+          // behaviour, never blocks the card opening.
+          if (activityCardPersistEnabled) {
+            writeActivityCardRecord(ACTIVITY_CARD_STORE_PATH, activityCardStoreFs, {
+              turnKey: statusKey(chat, thread),
+              chatId: chat,
+              threadId: thread ?? null,
+              activityMessageId: sent.message_id,
+              startedAt: turn.startedAt,
+              // The OPEN below unconditionally silently-pins the fresh card
+              // (`reconcileStatusPin('fg:'+key, …)`) — mirror that here so
+              // the boot reaper knows to unpin it too, not just finalize it.
+              pinned: true,
+            })
+          }
           // Status-pin: the per-turn status message just opened — it's the
           // in-flight "what it's doing" surface. Silently pin it so the turn
           // stays in view when the feed scrolls past. Keyed to the same
@@ -12877,6 +12981,17 @@ function clearActivitySummary(turn: CurrentTurn, finalHtmlOverride?: string | nu
     if (turn.activityMessageId == null) return
     const id = turn.activityMessageId
     turn.activityMessageId = null
+    // Known Gap 1 (deterministic-turn-liveness.md) — the card is closing
+    // normally (about to be deleted or finalized below), so drop its durable
+    // handle too: a normal close must never leave a stale record for the
+    // boot reaper to "finalize" a message that's already been handled.
+    if (activityCardPersistEnabled) {
+      clearActivityCardRecord(
+        ACTIVITY_CARD_STORE_PATH,
+        activityCardStoreFs,
+        statusKey(chat, thread),
+      )
+    }
     if (CLEAR_STATUS_ON_COMPLETION) {
       try {
         await robustApiCall(

--- a/telegram-plugin/tests/activity-card-store.test.ts
+++ b/telegram-plugin/tests/activity-card-store.test.ts
@@ -1,0 +1,378 @@
+/**
+ * activity-card-store.test.ts — outcome-based tests for the mid-turn
+ * activity-card restart-survivability fix (Known Gap 1,
+ * `reference/rfcs/deterministic-turn-liveness.md`).
+ *
+ * PRE-FIX PROOF: before this PR, no persistence existed for
+ * `CurrentTurn.activityMessageId` at all — `../gateway/activity-card-store.js`
+ * did not exist, so `import` itself failed at collection time:
+ *
+ *   Error: Cannot find module '../gateway/activity-card-store.js'
+ *   (or its corresponding .ts source) imported from
+ *   telegram-plugin/tests/activity-card-store.test.ts
+ *
+ * i.e. every test below fails on today's (pre-fix) base — there was no seam
+ * to test. Recorded run against `origin/main` (this PR's parent commit)
+ * before the module was added:
+ *
+ *   FAIL  telegram-plugin/tests/activity-card-store.test.ts
+ *   [vitest] Cannot find module '../gateway/activity-card-store.js'
+ *
+ * This file exercises the REAL exported store + boot-reaper functions (not a
+ * structural grep), mirroring `status-pin-store.test.ts`'s in-memory fs seam
+ * convention, plus a transport-boundary reaper test (mirrors
+ * `silent-end-transport.test.ts`'s spy-transport convention) proving the
+ * exact outcome contract: (a) card open persists a record; (b) clean close
+ * clears it; (c) a boot reaper run against a leftover record performs
+ * EXACTLY ONE finalizing edit + one unpin and deletes the record; (d) a
+ * second boot performs ZERO edits and ZERO unpins; (e) a corrupt state file
+ * never crashes boot and is dropped without an edit.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  loadActivityCards,
+  persistActivityCards,
+  writeActivityCardRecord,
+  clearActivityCardRecord,
+  runActivityCardBootReaper,
+  restartOrphanCardFinalizeText,
+  type ActivityCardRecord,
+  type ActivityCardStoreFsSeam,
+} from '../gateway/activity-card-store.js'
+
+/** In-memory fs seam with an atomic rename — same convention as
+ *  status-pin-store.test.ts's memFs, so the tmp→rename crash-safety
+ *  contract is exercised without touching real disk. */
+function memFs(seed: Record<string, string> = {}) {
+  const files = new Map<string, string>(Object.entries(seed))
+  const calls: string[] = []
+  const fs: ActivityCardStoreFsSeam = {
+    readFileSync: (p) => {
+      if (!files.has(p)) throw new Error(`ENOENT ${p}`)
+      return files.get(p)!
+    },
+    writeFileSync: (p, d) => {
+      calls.push(`write:${p}`)
+      files.set(p, d)
+    },
+    renameSync: (a, b) => {
+      calls.push(`rename:${a}->${b}`)
+      if (!files.has(a)) throw new Error(`ENOENT ${a}`)
+      files.set(b, files.get(a)!)
+      files.delete(a)
+    },
+    existsSync: (p) => files.has(p),
+  }
+  return { fs, files, calls }
+}
+
+const PATH = '/state/agent/telegram/activity-cards-pending.json'
+
+function card(over: Partial<ActivityCardRecord> = {}): ActivityCardRecord {
+  return {
+    turnKey: 'c:_',
+    chatId: '-100123',
+    threadId: null,
+    activityMessageId: 715,
+    startedAt: Date.now() - 60_000,
+    pinned: true,
+    ...over,
+  }
+}
+
+describe('activity-card-store — persistence primitives', () => {
+  it('loads [] when no file exists (fresh boot)', () => {
+    const { fs } = memFs()
+    expect(loadActivityCards(PATH, fs)).toEqual([])
+  })
+
+  it('(a) card open → state persisted (round-trips a written record)', () => {
+    const { fs } = memFs()
+    writeActivityCardRecord(PATH, fs, card())
+    const loaded = loadActivityCards(PATH, fs)
+    expect(loaded).toHaveLength(1)
+    expect(loaded[0]).toEqual(card())
+  })
+
+  it('a fresh OPEN for the same topic replaces (upserts) the stale row, not appends', () => {
+    const { fs } = memFs()
+    writeActivityCardRecord(PATH, fs, card({ activityMessageId: 715 }))
+    writeActivityCardRecord(PATH, fs, card({ activityMessageId: 900 }))
+    const loaded = loadActivityCards(PATH, fs)
+    expect(loaded).toHaveLength(1)
+    expect(loaded[0]!.activityMessageId).toBe(900)
+  })
+
+  it('(b) clean close → state cleared', () => {
+    const { fs } = memFs()
+    writeActivityCardRecord(PATH, fs, card())
+    expect(loadActivityCards(PATH, fs)).toHaveLength(1)
+    clearActivityCardRecord(PATH, fs, 'c:_')
+    expect(loadActivityCards(PATH, fs)).toEqual([])
+  })
+
+  it('clearing an absent/mismatched turnKey is a no-op (never throws)', () => {
+    const { fs } = memFs()
+    writeActivityCardRecord(PATH, fs, card({ turnKey: 'c:other' }))
+    clearActivityCardRecord(PATH, fs, 'c:_')
+    expect(loadActivityCards(PATH, fs)).toHaveLength(1)
+  })
+
+  it('writes via tmp + atomic rename (crash-safe)', () => {
+    const { fs, calls } = memFs()
+    persistActivityCards(PATH, fs, [card()])
+    expect(calls).toEqual([`write:${PATH}.tmp`, `rename:${PATH}.tmp->${PATH}`])
+  })
+
+  it('(e) corrupt state file: boot survives, loads as [] (fail-open, never throws)', () => {
+    const { fs } = memFs({ [PATH]: '{not json' })
+    expect(() => loadActivityCards(PATH, fs)).not.toThrow()
+    expect(loadActivityCards(PATH, fs)).toEqual([])
+  })
+
+  it('fail-open: wrong envelope version / malformed shape loads as []', () => {
+    const { fs: f1 } = memFs({ [PATH]: JSON.stringify({ v: 2, cards: [card()] }) })
+    expect(loadActivityCards(PATH, f1)).toEqual([])
+    const { fs: f2 } = memFs({ [PATH]: JSON.stringify({ v: 1, cards: 'nope' }) })
+    expect(loadActivityCards(PATH, f2)).toEqual([])
+  })
+
+  it('drops malformed rows but keeps valid ones', () => {
+    const { fs } = memFs({
+      [PATH]: JSON.stringify({
+        v: 1,
+        cards: [
+          card({ activityMessageId: 715 }),
+          { turnKey: '', chatId: 'c', threadId: null, activityMessageId: 1, startedAt: 1 },
+          { turnKey: 'k', chatId: 'c', threadId: null, startedAt: 1 }, // missing activityMessageId
+        ],
+      }),
+    })
+    const loaded = loadActivityCards(PATH, fs)
+    expect(loaded).toHaveLength(1)
+    expect(loaded[0]!.activityMessageId).toBe(715)
+  })
+
+  it('persist never throws on a failing fs (durability degrades, live path unaffected)', () => {
+    const throwingFs: ActivityCardStoreFsSeam = {
+      readFileSync: () => {
+        throw new Error('boom')
+      },
+      writeFileSync: () => {
+        throw new Error('disk full')
+      },
+      renameSync: () => {
+        throw new Error('nope')
+      },
+      existsSync: () => false,
+    }
+    const logs: string[] = []
+    expect(() => persistActivityCards(PATH, throwingFs, [card()], (l) => logs.push(l))).not.toThrow()
+    expect(logs.join('')).toContain('persist FAILED')
+  })
+})
+
+/**
+ * Boot reaper — transport-boundary outcome tests (mirrors
+ * silent-end-transport.test.ts's spy-transport convention): a spy stands in
+ * for `bot.api.editMessageText` / `bot.api.unpinChatMessage`, asserting an
+ * actual finalizing edit + unpin land, not a stubbed decision callback.
+ */
+describe('runActivityCardBootReaper — transport-boundary outcome tests', () => {
+  it('(c) leftover record → exactly one finalizing edit + one unpin, record deleted', async () => {
+    const { fs } = memFs()
+    const startedAt = Date.now() - 90_000
+    writeActivityCardRecord(PATH, fs, card({ startedAt }))
+
+    const edits: Array<{ chatId: string; messageId: number; text: string }> = []
+    const unpins: Array<{ chatId: string; messageId: number }> = []
+
+    const res = await runActivityCardBootReaper({
+      path: PATH,
+      fs,
+      finalizeCard: async (record) => {
+        edits.push({
+          chatId: record.chatId,
+          messageId: record.activityMessageId,
+          text: restartOrphanCardFinalizeText(record.startedAt),
+        })
+      },
+      unpinCard: async (record) => {
+        unpins.push({ chatId: record.chatId, messageId: record.activityMessageId })
+      },
+    })
+
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.chatId).toBe('-100123')
+    expect(edits[0]!.messageId).toBe(715)
+    expect(edits[0]!.text).toContain('Interrupted by a gateway restart')
+    expect(edits[0]!.text).toContain('was running')
+
+    expect(unpins).toHaveLength(1)
+    expect(unpins[0]).toEqual({ chatId: '-100123', messageId: 715 })
+
+    expect(res).toEqual({ finalized: 1, unpinned: 1, total: 1 })
+    // Record gone — nothing left for a future boot to re-finalize.
+    expect(loadActivityCards(PATH, fs)).toEqual([])
+  })
+
+  it('(d) second boot with an already-empty store → zero edits, zero unpins', async () => {
+    const { fs } = memFs()
+    writeActivityCardRecord(PATH, fs, card())
+
+    let edits = 0
+    let unpins = 0
+    // First boot reaps the one leftover record.
+    await runActivityCardBootReaper({
+      path: PATH,
+      fs,
+      finalizeCard: async () => {
+        edits++
+      },
+      unpinCard: async () => {
+        unpins++
+      },
+    })
+    expect(edits).toBe(1)
+    expect(unpins).toBe(1)
+
+    // Second boot re-reads the (now empty) file — the idempotency guarantee.
+    const res2 = await runActivityCardBootReaper({
+      path: PATH,
+      fs,
+      finalizeCard: async () => {
+        edits++
+      },
+      unpinCard: async () => {
+        unpins++
+      },
+    })
+    expect(edits).toBe(1) // unchanged
+    expect(unpins).toBe(1) // unchanged
+    expect(res2).toEqual({ finalized: 0, unpinned: 0, total: 0 })
+  })
+
+  it('a record with pinned:false (or absent) is finalized but never unpinned', async () => {
+    const { fs } = memFs()
+    writeActivityCardRecord(PATH, fs, card({ pinned: false }))
+    let unpins = 0
+    const res = await runActivityCardBootReaper({
+      path: PATH,
+      fs,
+      finalizeCard: async () => {},
+      unpinCard: async () => {
+        unpins++
+      },
+    })
+    expect(res.finalized).toBe(1)
+    expect(unpins).toBe(0)
+  })
+
+  it('no-op on a fresh boot with no persisted cards (zero edits, zero unpins)', async () => {
+    const { fs } = memFs()
+    let calls = 0
+    const res = await runActivityCardBootReaper({
+      path: PATH,
+      fs,
+      finalizeCard: async () => {
+        calls++
+      },
+      unpinCard: async () => {
+        calls++
+      },
+    })
+    expect(res).toEqual({ finalized: 0, unpinned: 0, total: 0 })
+    expect(calls).toBe(0)
+  })
+
+  it('a failing finalize edit is non-fatal, still attempts the unpin, and the store is still emptied', async () => {
+    const { fs } = memFs()
+    writeActivityCardRecord(PATH, fs, card())
+    let unpinCalled = false
+    const res = await runActivityCardBootReaper({
+      path: PATH,
+      fs,
+      finalizeCard: async () => {
+        throw new Error('message to edit not found')
+      },
+      unpinCard: async () => {
+        unpinCalled = true
+      },
+    })
+    expect(res).toEqual({ finalized: 0, unpinned: 1, total: 1 })
+    expect(unpinCalled).toBe(true)
+    expect(loadActivityCards(PATH, fs)).toEqual([])
+  })
+
+  it('a failing unpin (already unpinned / no rights) is non-fatal and does not re-run the edit', async () => {
+    const { fs } = memFs()
+    writeActivityCardRecord(PATH, fs, card())
+    let editCalls = 0
+    const res = await runActivityCardBootReaper({
+      path: PATH,
+      fs,
+      finalizeCard: async () => {
+        editCalls++
+      },
+      unpinCard: async () => {
+        throw new Error('message to unpin not found')
+      },
+    })
+    expect(res).toEqual({ finalized: 1, unpinned: 0, total: 1 })
+    expect(editCalls).toBe(1)
+    expect(loadActivityCards(PATH, fs)).toEqual([])
+  })
+
+  it('reaps multiple leftover records from distinct topics independently', async () => {
+    const { fs } = memFs()
+    writeActivityCardRecord(PATH, fs, card({ turnKey: 'c:1', chatId: '-100111', activityMessageId: 1 }))
+    writeActivityCardRecord(PATH, fs, card({ turnKey: 'c:2', chatId: '-100222', activityMessageId: 2 }))
+    const edited: number[] = []
+    const unpinned: number[] = []
+    const res = await runActivityCardBootReaper({
+      path: PATH,
+      fs,
+      finalizeCard: async (r) => {
+        edited.push(r.activityMessageId)
+      },
+      unpinCard: async (r) => {
+        unpinned.push(r.activityMessageId)
+      },
+    })
+    expect(res).toEqual({ finalized: 2, unpinned: 2, total: 2 })
+    expect(edited.sort()).toEqual([1, 2])
+    expect(unpinned.sort()).toEqual([1, 2])
+    expect(loadActivityCards(PATH, fs)).toEqual([])
+  })
+
+  it('idempotency guard: the record is removed from disk BEFORE the finalize/unpin calls run (crash-mid-reap safety)', async () => {
+    const { fs } = memFs()
+    writeActivityCardRecord(PATH, fs, card())
+    let onDiskDuringFinalize: ActivityCardRecord[] = []
+    await runActivityCardBootReaper({
+      path: PATH,
+      fs,
+      finalizeCard: async () => {
+        onDiskDuringFinalize = loadActivityCards(PATH, fs)
+      },
+      unpinCard: async () => {},
+    })
+    // At the moment finalizeCard ran, the record was ALREADY gone from disk —
+    // so a crash right here (or a concurrent second boot) can never re-reap it.
+    expect(onDiskDuringFinalize).toEqual([])
+  })
+})
+
+describe('restartOrphanCardFinalizeText', () => {
+  it('is honest about elapsed time', () => {
+    const text = restartOrphanCardFinalizeText(Date.now() - 45_000)
+    expect(text).toContain('Interrupted by a gateway restart')
+    expect(text).toMatch(/was running \d+s/)
+  })
+
+  it('omits a nonsensical elapsed clause for a degenerate startedAt', () => {
+    const text = restartOrphanCardFinalizeText(Date.now() + 10_000) // future — negative elapsed
+    expect(text).toContain('Interrupted by a gateway restart')
+    expect(text).not.toContain('was running')
+  })
+})

--- a/telegram-plugin/tests/activity-card-store.test.ts
+++ b/telegram-plugin/tests/activity-card-store.test.ts
@@ -88,10 +88,13 @@ describe('activity-card-store — persistence primitives', () => {
 
   it('(a) card open → state persisted (round-trips a written record)', () => {
     const { fs } = memFs()
-    writeActivityCardRecord(PATH, fs, card())
+    // Construct ONCE — card() stamps `startedAt: Date.now() - 60_000`, so two
+    // separate calls can straddle a millisecond and flake the deep-equal.
+    const record = card()
+    writeActivityCardRecord(PATH, fs, record)
     const loaded = loadActivityCards(PATH, fs)
     expect(loaded).toHaveLength(1)
-    expect(loaded[0]).toEqual(card())
+    expect(loaded[0]).toEqual(record)
   })
 
   it('a fresh OPEN for the same topic replaces (upserts) the stale row, not appends', () => {


### PR DESCRIPTION
## What

Closes the last real liveness gap named in `reference/rfcs/deterministic-turn-liveness.md` § Known Gaps, item 1 (**restart mid-turn**), serving `reference/jobs/know-what-my-agent-is-doing.md`.

Before this PR, `currentTurn`, `turn.activityMessageId`, and `startedAt` lived only in gateway memory. A gateway restart mid-turn left the pre-restart activity card **permanently frozen** on its last text (and still silently pinned) — the new process had no handle to it, and the resumed turn opened a fresh card, leaving a zombie in the chat.

## Deterministic guarantee delta (Phase-5 erosion-guard declaration)

**Added:** no card orphaned by a gateway restart stays visually frozen or pinned — it is finalized with exactly ONE honest edit (`⚠️ Interrupted by a gateway restart (was running Ns) — this turn did not finish.`) and unpinned, on the next boot. Model-free, zero token cost, pure gateway code at boot. An edit, never a new message — so no device ping (pacing rules intact). No prior guarantee is weakened: the live climb/narration/dark-turn paths are untouched.

## Design

Simplest durable shape, following the repo's existing persistence conventions (`status-pin-store.ts` / `obligation-store.ts` / `silent-end.ts`):

- **`telegram-plugin/gateway/activity-card-store.ts`** (new) — tiny snapshot store on the per-agent state volume: `TELEGRAM_STATE_DIR/activity-cards-pending.json`, envelope-versioned, write-tmp + atomic rename, fail-open `[]` on missing/corrupt file (never crashes boot; a corrupt file is simply overwritten by the next write).
- **Persist on OPEN:** `drainActivitySummary`'s send branch writes the minimal handle `{turnKey, chatId, threadId, activityMessageId, startedAt, pinned: true}` the moment `activityMessageId` is captured (upsert by topic key).
- **Clear on normal close:** `clearActivitySummary` drops the record alongside nulling `activityMessageId`.
- **Boot reaper:** wired immediately after `statusPinBootCleanup`, under the SAME startup-mutex gate (shared per-agent file; a losing double-boot must never touch it). Reads leftover records, and for each: **deletes the record from disk BEFORE attempting the edit** (idempotency guard — a second boot performs zero edits), then edits the orphan card to the honest interrupted state via `robustApiCall(editMessageText)`, then unpins it (every fresh card is silently pinned on open via `reconcileStatusPin('fg:…')`, so a frozen card would otherwise ALSO stay glued to the top of the chat). All Telegram failures (message deleted, chat gone) are swallowed and never re-attempted.
- **Deliberately no resume:** the reaper does not try to keep climbing the old card across the restart — the resumed turn owns a new card. Honest finalization is the goal, per the audit guidance.

## Pre-fix failure proof

The test suite fails on today's `origin/main` — there was no seam to test at all. Recorded run with only the store module removed (i.e., the pre-fix tree):

```
 FAIL  telegram-plugin/tests/activity-card-store.test.ts
Error: Cannot find module '../gateway/activity-card-store.js' imported from
'telegram-plugin/tests/activity-card-store.test.ts'
 Test Files  1 failed (1)
      Tests  no tests
```

(Also recorded in the test file header.)

## Tests (outcome-based, at the transport seam)

`telegram-plugin/tests/activity-card-store.test.ts` — 20 cases against the REAL exported store + reaper (in-memory fs seam per `status-pin-store.test.ts`; spy transport per `silent-end-transport.test.ts`):

- (a) card open → record persisted (round-trip + same-topic upsert)
- (b) clean close → record cleared
- (c) boot reaper with leftover record → **exactly one** finalizing edit + one unpin, record deleted; edit text carries the honest elapsed
- (d) second boot → **zero** edits, zero unpins
- (e) corrupt state file → boot survives, no edit, load fails open to `[]`
- plus: tmp+rename atomicity, malformed-row filtering, failing-fs never throws, failed edit still attempts unpin (and vice versa), multi-topic reap, record-gone-before-edit crash-mid-reap proof, degenerate-elapsed text.

## Scoped out

The standalone worker-activity-feed's `messageId` (`telegram-plugin/worker-activity-feed.ts`) also lives only in memory, but it is a separate surface with its own lifecycle (per-sub-agent handles, `messageIdOf` registry) and a rarer failure mode; folding it in would roughly double this PR's blast radius. Documented in the RFC gap entry as a possible follow-up.

## Verification

- `npm run lint` — clean (tsc strict + all repo check scripts).
- `vitest run telegram-plugin/tests/activity-card-store.test.ts` — 20/20 pass.
- Full `npm test` — compared against clean `origin/main` for the known pre-existing sandbox failures (static-binary, host-control server, env-dependent suites); no new failures attributable to this change.

RFC updated: Known Gaps item 1 marked **closed** with the guarantee text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)