### PR TITLE
fix(agents): retry litellm liveliness probe at boot to close co-boot tracking race

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -69,9 +69,27 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
     sr_ll_ok=""
     if [ -z "$sr_ll_key" ]; then
       echo "litellm(outer): no virtual key for agent '$SWITCHROOM_AGENT_NAME' — gateway will use direct OAuth (no tracking/guardrail)" >&2
-    elif command -v curl >/dev/null 2>&1 && [ -n "$ANTHROPIC_BASE_URL" ] \
-         && ! curl -fsS -m 5 -o /dev/null "${SWITCHROOM_LITELLM_BASE:-${ANTHROPIC_BASE_URL%/anthropic}}/health/liveliness" 2>/dev/null; then
-      echo "litellm(outer): proxy unreachable at ${SWITCHROOM_LITELLM_BASE:-$ANTHROPIC_BASE_URL} — falling back to direct OAuth (no tracking/guardrail this session)" >&2
+    elif command -v curl >/dev/null 2>&1 && [ -n "$ANTHROPIC_BASE_URL" ]; then
+      # Bounded retry probe (co-boot race fix, 2026-07): when the whole stack
+      # co-boots, the litellm proxy's heavy Python app is often not yet healthy
+      # in the first few seconds. A single one-shot probe fails-open and takes
+      # this agent dark (untracked) for the WHOLE session. Poll the liveliness
+      # endpoint every ~3s for up to 120s (hard budget) and only fall open if
+      # it is STILL unreachable after that whole window.
+      sr_ll_url="${SWITCHROOM_LITELLM_BASE:-${ANTHROPIC_BASE_URL%/anthropic}}/health/liveliness"
+      sr_ll_deadline=$(( $(date +%s) + 120 ))
+      sr_ll_up=""
+      while :; do
+        if curl -fsS -m 5 -o /dev/null "$sr_ll_url" 2>/dev/null; then sr_ll_up="1"; break; fi
+        [ "$(date +%s)" -ge "$sr_ll_deadline" ] && break
+        sleep 3
+      done
+      if [ -z "$sr_ll_up" ]; then
+        echo "litellm(outer): proxy unreachable at ${SWITCHROOM_LITELLM_BASE:-$ANTHROPIC_BASE_URL} after 120s of retries — falling back to direct OAuth (no tracking/guardrail this session)" >&2
+      else
+        sr_ll_ok="1"
+      fi
+      unset sr_ll_url sr_ll_deadline sr_ll_up
     else
       sr_ll_ok="1"
     fi
@@ -911,9 +929,27 @@ if [ -n "${SWITCHROOM_LITELLM:-}" ] && command -v switchroom >/dev/null 2>&1; th
   sr_ll_ok=""
   if [ -z "$sr_ll_key" ]; then
     echo "litellm: no virtual key for agent '$SWITCHROOM_AGENT_NAME' — falling back to direct OAuth (no tracking/guardrail)" >&2
-  elif command -v curl >/dev/null 2>&1 && [ -n "$ANTHROPIC_BASE_URL" ] \
-       && ! curl -fsS -m 5 -o /dev/null "${SWITCHROOM_LITELLM_BASE:-${ANTHROPIC_BASE_URL%/anthropic}}/health/liveliness" 2>/dev/null; then
-    echo "litellm: proxy unreachable at ${SWITCHROOM_LITELLM_BASE:-$ANTHROPIC_BASE_URL} — falling back to direct OAuth (no tracking/guardrail this session)" >&2
+  elif command -v curl >/dev/null 2>&1 && [ -n "$ANTHROPIC_BASE_URL" ]; then
+    # Bounded retry probe (co-boot race fix, 2026-07): when the whole stack
+    # co-boots, the litellm proxy's heavy Python app is often not yet healthy
+    # in the first few seconds. A single one-shot probe fails-open and takes
+    # this agent dark (untracked) for the WHOLE session. Poll the liveliness
+    # endpoint every ~3s for up to 120s (hard budget) and only fall open if
+    # it is STILL unreachable after that whole window.
+    sr_ll_url="${SWITCHROOM_LITELLM_BASE:-${ANTHROPIC_BASE_URL%/anthropic}}/health/liveliness"
+    sr_ll_deadline=$(( $(date +%s) + 120 ))
+    sr_ll_up=""
+    while :; do
+      if curl -fsS -m 5 -o /dev/null "$sr_ll_url" 2>/dev/null; then sr_ll_up="1"; break; fi
+      [ "$(date +%s)" -ge "$sr_ll_deadline" ] && break
+      sleep 3
+    done
+    if [ -z "$sr_ll_up" ]; then
+      echo "litellm: proxy unreachable at ${SWITCHROOM_LITELLM_BASE:-$ANTHROPIC_BASE_URL} after 120s of retries — falling back to direct OAuth (no tracking/guardrail this session)" >&2
+    else
+      sr_ll_ok="1"
+    fi
+    unset sr_ll_url sr_ll_deadline sr_ll_up
   else
     sr_ll_ok="1"
   fi


### PR DESCRIPTION
## The boot-ordering race

Agents route Claude traffic through a local litellm proxy (`ANTHROPIC_BASE_URL=http://127.0.0.1:4010/anthropic`) for per-agent token tracking and guardrails. The generated `start.sh` decides whether to use that route **once at boot** with a single `curl -fsS -m 5 .../health/liveliness` probe — in both the gateway "outer" pass and the claude "inner" pass of `profiles/_base/start.sh.hbs`.

When the whole stack co-boots, the agent container comes up milliseconds before litellm's heavy Python app is healthy. The one-shot probe fails, the block permanently `unset ANTHROPIC_BASE_URL ...` and falls back to direct OAuth, and the agent stays invisible to litellm telemetry for its **entire session** — it never re-checks.

**Evidence:** a 58ms co-boot race left `klanker` untracked for 4.5h after a 03:55 co-boot.

## The fix

In both blocks, the single one-shot probe is replaced with a bounded retry loop: poll the same liveliness endpoint every ~3s for up to **120s (hard time budget — cannot hang forever)**, and only take the fail-open (direct OAuth, unset routing env) branch if it is STILL unreachable after that whole window. If the proxy becomes reachable within the budget, `ANTHROPIC_BASE_URL` is kept and the tracked path is taken. The existing loud fail-open warning text is preserved (with an "after 120s of retries" note).

## Blast radius

- Only `profiles/_base/start.sh.hbs` changes.
- The regenerated `start.sh` lands for **all litellm-enabled agents** on their **next restart** (content-aware regeneration rewrites drifted `start.sh`). No behavior change for non-litellm agents.
- Worst case for a genuinely dead proxy: boot is delayed up to 120s before failing open — same end state as before, just no longer racing the healthcheck.

## Tests / validation run

- `vitest run tests/scaffold.litellm-failopen.test.ts tests/scaffold.litellm-gateway-outer.test.ts tests/scaffold.regenerate-start-sh.test.ts` → **10 passed**.
- Scaffolded a real agent and ran `bash -n` on the rendered `start.sh` → **syntax OK**; both probe blocks render with the retry loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)