### PR TITLE
chore(liveness): retire vestigial 45s text floor, land Phase 4a/5 test wall

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,14 @@ your agents are on the latest code.
    `refactor:`, `test:`) + short imperative description.
 7. PR body: what changed, why, and how to test it. A short test-plan
    checklist is appreciated.
+8. **Liveness-surface PRs declare their guarantee delta.** Any PR touching
+   `feedHeartbeatTick`, `feed-open-gate.ts`, `silence-poke.ts`,
+   `turn-liveness-floor.ts`, or the card-edit path must state, in the PR
+   body, what the framework still guarantees to deliver WITHOUT the model
+   after the change — added or removed. See
+   `reference/rfcs/deterministic-turn-liveness.md` Phase 5: a legitimate
+   anti-nag change (#2667) muted a guarantee as a side effect precisely
+   because no one had to state the delta at review time.
 
 ## What we look for
 

--- a/reference/jobs/know-what-my-agent-is-doing.md
+++ b/reference/jobs/know-what-my-agent-is-doing.md
@@ -121,6 +121,34 @@ Named by job × surface, pointing at real scenarios in
   wired-host twin (follow-on): `jtbd-liveness-floor-dm` / `-channel` with
   `SWITCHROOM_SILENCE_FLOOR_MS` lowered so the beat lands within test
   wall-clock. Design: `reference/rfcs/turn-liveness-primitive.md`.
+- **Deterministic card climb on a silent tool (DM + channel)** —
+  `jtbd-liveness-climb-dm`, `jtbd-liveness-climb-channel`. *Watch:* a 40s
+  silent `Bash` call (no tool label, no narration) edits the SAME activity
+  card ≥4 times with a non-decreasing `Working · Ns` elapsed; a mid-turn ping
+  never fires. *Invariant:* dead air between visible updates never exceeds
+  the Phase-1 bound (~6-12s); a frozen/repeated elapsed value across all
+  edits is a hard failure — the exact pre-fix freeze. Design:
+  `reference/rfcs/deterministic-turn-liveness.md` Phase 1 + Phase 4a.
+- **Narration survives the climb (DM + channel)** — `jtbd-liveness-narration-dm`,
+  `jtbd-liveness-narration-channel`. *Watch:* when the model DOES narrate
+  mid-turn, its own words land on the card (not overwritten by the climb) and
+  a mid-turn ping never fires. *Invariant:* the climb only fills gaps the
+  model leaves; narration is unregressed.
+- **Dark-turn fallback fires exactly once (DM + channel)** —
+  `silent-end-recovery-dm`, `silent-end-recovery-channel`. *Watch:* a turn
+  that ends without a delivered reply gets exactly one fallback message on
+  the real surface (not a stubbed decision). *Invariant:* the `exhausted`
+  latch gives fire-once; asserted transport-side, in a DM and a supergroup
+  alike. Design: `reference/rfcs/deterministic-turn-liveness.md` Phase 2.
+- **Dead-air bound across turn shapes, live-transport scaffold (DM)** —
+  `fuzz-liveness-climb-dm` (`uat-fuzz`, non-required). *Watch:* a handful of
+  hand-picked silent-tool shapes never exceed the dead-air bound and never
+  buzz mid-turn. *Scope note:* the full randomized message-timing × tool-churn
+  × sub-agent-fan-out × surface corpus lives at the decision layer
+  (`turn-liveness-invariant.test.ts`, 2000 shapes, every CI run); a
+  same-breadth LIVE corpus is not yet authored (quota + wall-clock cost) —
+  tracked as a follow-up in `reference/rfcs/deterministic-turn-liveness.md`
+  Known gaps.
 - **Restart mid-conversation (DM + channel)** —
   `jtbd-message-during-restart-dm` / `-channel`,
   `jtbd-always-on-after-restart-dm`, `jtbd-interrupted-turn-resumes-dm`.

--- a/reference/rfcs/deterministic-turn-liveness.md
+++ b/reference/rfcs/deterministic-turn-liveness.md
@@ -2,7 +2,7 @@
 artifact: Deterministic turn liveness — the framework owns "alive", the model owns "what"
 backs: chat-is-the-single-source-of-truth
 serves: jobs/know-what-my-agent-is-doing.md
-status: design v1 — regression fix; re-founds turn-liveness-primitive.md's mid-turn floor as a climbing card edit, not a one-shot text send
+status: Phases 1, 2, 4b, 4d landed (PR 1/2). Phase 3 + Phase 5 landed, Phase 4a authored (this PR). Phase 4c authored as a fixed-shape live scaffold, not the full randomized corpus — see Known gaps.
 ---
 
 # Deterministic turn liveness: the framework owns "alive", the model owns "what"
@@ -221,6 +221,21 @@ mid-turn floor.** Therefore:
 No inert code may imply an absent guarantee. Either the machinery delivers
 or it is removed with a pointer to what does.
 
+**Landed (this PR).** `onMidTurnFloor` (`telegram-plugin/gateway/gateway.ts`)
+now returns early for the busy-but-silent (non-approval) case, with a comment
+pointing at Phase 1. This is provably NOT a behaviour change: before this PR,
+`formatFrameworkFallbackText('working', …, blockedOnApproval=false)`
+(`telegram-plugin/silence-poke.ts`) already returned `null` unconditionally
+for that branch (#2667), so the handler already sent nothing for it — the
+early return makes the no-op explicit in the CALLER instead of implicit in
+the callee's return value. The approval-blocked branch (`blockedOnApproval
+=== true`) is untouched: same threshold gate (`decideMidTurnFloor` /
+`SILENCE_FLOOR_MS`), same text, same silent send. The decision machinery
+(`decideMidTurnFloor`, `tryMidTurnFloor`, `midTurnFloorEnabled`,
+`turn-liveness-floor.ts`) is unchanged and still load-bearing — it is what
+gates the surviving approval-blocked re-ping, so it is NOT vestigial and
+was not removed.
+
 ### Phase 4 — outcome-based test wall
 
 Structural source-greps are retired as *sole* coverage for liveness. The
@@ -230,6 +245,15 @@ wall is behavioural, on the real surface.
 on `uat/scenarios/jtbd-liveness-feed-open-dm.test.ts`), each with a `-dm`
 and a `-channel` twin (surface parity is a production-readiness bar in the
 job spec):
+
+**Landed (this PR — authored, not run from this sandbox; `uat-gate` /
+`uat-fuzz` / the test-harness agent execute them):**
+`jtbd-liveness-climb-{dm,channel}.test.ts` (40s silent tool),
+`jtbd-liveness-narration-{dm,channel}.test.ts` (narrated work),
+`silent-end-recovery-{dm,channel}.test.ts` (dark turn — the `-dm` file
+already existed from Phase 2; this PR adds the `-channel` twin). Each
+asserts no mid-turn ping inline (there is no separate "across all" test —
+the ping-free assertion is baked into every scenario above per the design).
 
 - **40s silent tool** → card **edited ≥4 times**, elapsed **climbing**;
   hard-fail on a freeze (zero edits across the gap).
@@ -268,6 +292,15 @@ on tick".
   after this change. #2667 muted a guarantee as a side effect of a
   legitimate anti-nag change precisely because no one had to state the
   delta.
+
+**Landed (this PR).** `reference/jobs/know-what-my-agent-is-doing.md` §
+Prove-it gained four new bullets: the card-climb DM/channel twins, the
+narration-survives-the-climb DM/channel twins, the dark-turn-fires-once
+DM/channel twins, and the live dead-air fuzz scaffold (with its scope
+honestly noted). The PR-declaration rule is now written down in
+`CONTRIBUTING.md` § Submitting a PR (step 8) — the concrete "wherever the
+repo keeps such contribution rules" surface, since `CONTRIBUTING.md` is
+the file that already owns "what we look for in PRs".
 
 ## Alternatives considered
 
@@ -313,7 +346,12 @@ on tick".
   3. **Phase 3 + Phase 5** as docs/cleanup — remove the vestigial send,
      document the boundary, update the job spec Prove-it and the PR-delta
      policy. Not landed with PRs 1–2; the vestigial 45s path stays
-     in-tree until this PR.
+     in-tree until this PR. **Landed** — see the Phase 3 / Phase 5 sections
+     above for exactly what changed. This same PR additionally authors the
+     Phase 4a DM/channel UAT twins (deferred from PR 1) and a Phase 4c
+     live-transport fuzz scaffold (see Known gaps for its honest scope
+     limit) — these were not blocking Phase 3/5 but were bundled since they
+     complete the outcome-based test wall this RFC promises.
 
 ### Known gaps (out of scope, not closed by this RFC)
 
@@ -339,6 +377,21 @@ on tick".
 Gap 1 is pre-existing and orthogonal to the climb, named here so the
 guarantee is not read as broader than delivered. It needs its own
 follow-up (persist/rehydrate or boot-time reaping of orphaned cards).
+
+3. **Phase 4c live-transport corpus breadth.** The full randomized
+   message-timing × turn-length × tool-churn × sub-agent-fan-out × surface ×
+   role corpus is authored and proven at the DECISION layer only
+   (`telegram-plugin/tests/turn-liveness-invariant.test.ts`, 2000 shapes ×
+   both surfaces, runs on every CI pass — fast, free, no live quota). This
+   PR adds `telegram-plugin/uat/scenarios/fuzz-liveness-climb-dm.test.ts`, a
+   handful (3) of hand-picked, FIXED silent-tool shapes run on the real
+   surface under `uat-fuzz` — genuinely useful (it catches a live-transport
+   regression the decision-layer fuzz cannot, since that fuzz stubs the
+   send), but it is not the same-breadth randomized live corpus the design
+   describes. A true randomized live corpus needs a dedicated long-running
+   canary budget (each live turn burns real subscription quota and
+   30-90s wall-clock; 2000 shapes is not realistic per-PR or even
+   per-release). Tracked here rather than silently claimed as done.
 - **Fleet restart discipline.** No fleet restart until the operator
   confirms; stagger restarts across agents (a card-edit-path change is
   visible on the very next turn, so a bad edit should not hit the whole

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6477,11 +6477,15 @@ function parsePositiveMsEnv(name: string, fallbackMs: number): number {
 }
 const SILENCE_FALLBACK_MS = parsePositiveMsEnv('SWITCHROOM_SILENCE_FALLBACK_MS', 300_000)
 const SILENCE_FALLBACK_HARD_MS = parsePositiveMsEnv('SWITCHROOM_SILENCE_FALLBACK_HARD_MS', 900_000)
-// #2527 — mid-turn liveness floor threshold (default 45s). The early, quiet
-// beat: a `user` turn working silently this long without a substantive answer
-// gets ONE honest "still on it" interim, so the ambient 👀 never masquerades
-// as "done". Strictly below SILENCE_FALLBACK_MS (the loud 300s unwedge).
-// Whole floor is kill-switchable via SWITCHROOM_TG_LIVENESS_FLOOR=0.
+// #2527 — mid-turn liveness floor threshold (default 45s). Still gates the
+// decision (`decideMidTurnFloor`, role + delivery + fire-once + timing) for a
+// `user` turn working silently this long without a substantive answer.
+// Phase 3 (deterministic-turn-liveness.md): the busy-but-silent case no
+// longer sends TEXT at this threshold — the climbing card (Phase 1) covers
+// it. The ONE surviving delivery gated by this threshold is the
+// approval-blocked re-ping (see `onMidTurnFloor` below). Strictly below
+// SILENCE_FALLBACK_MS (the loud 300s unwedge). Whole floor is
+// kill-switchable via SWITCHROOM_TG_LIVENESS_FLOOR=0.
 const SILENCE_FLOOR_MS = parsePositiveMsEnv('SWITCHROOM_SILENCE_FLOOR_MS', 45_000)
 // #2527 — role-aware terminal reaction honesty (the "thumbs-up false done"
 // fix). Default ON; SWITCHROOM_TG_TERMINAL_HONESTY=0 reverts to always-👍.
@@ -6585,10 +6589,19 @@ silencePoke.startTimer({
     if (statusKey(turn.sessionChatId, turn.sessionThreadId) !== key) return null
     return { role: turn.role, finalAnswerDelivered: turn.finalAnswerDelivered }
   },
-  // #2527 — the early, quiet liveness beat. Honest text from the longest
-  // in-flight tool (model-free, claude-native), routed through the SAME send
-  // path as the 300s fallback; pings OFF (this is the gentle beat, not the
-  // loud unwedge) and the turn is NOT torn down — it keeps working.
+  // Phase 3 (reference/rfcs/deterministic-turn-liveness.md): the busy-but-
+  // silent TEXT floor is retired. The climbing card (Phase 1 — the 0-label
+  // branch of `feedHeartbeatTick` / `runSilentTurnHeartbeatTick` above) IS
+  // the mid-turn floor now: it edits the already-open activity card's
+  // elapsed clock every `FEED_HEARTBEAT_MIN_STALE_MS`, model-independent, no
+  // ping. This handler still decides/fires via `decideMidTurnFloor` (the
+  // timing + role + fire-once machinery in `silence-poke.ts` /
+  // `turn-liveness-floor.ts` is unchanged and still load-bearing — see
+  // below), but its ONLY surviving delivery is the approval-blocked re-ping.
+  // Do not re-add a generic "still working…" text send here believing this
+  // path covers the silent-tool case; it does not, and re-adding one would
+  // reintroduce the exact banned cadence ping `conversational-pacing.md`
+  // retired in #2667.
   onMidTurnFloor: async (ctx) => {
     // Late-fire guard, mirroring the fallback: a clean turn-end can race the
     // tick. If the turn is gone, stay silent.
@@ -6596,19 +6609,19 @@ silencePoke.startTimer({
     const blockedOnApproval = activeStatusReactions
       .get(statusKey(ctx.chatId, ctx.threadId))
       ?.isAwaiting() ?? false
+    // The one surviving text case: the turn is parked on an approval card
+    // waiting for YOUR tap. That's not a stall — it names the real blocker —
+    // so it keeps this quiet re-ping (`conversational-pacing.md` § Silence-
+    // poke fallback names this one of the two surviving honest cases). The
+    // busy-but-silent (non-approval) case sends nothing here; the card climb
+    // (Phase 1) is its only signal now.
+    if (!blockedOnApproval) return
     const text = silencePoke.formatFrameworkFallbackText(
       'working',
       ctx.silenceMs,
       ctx.inFlightTools,
       blockedOnApproval,
     )
-    // The stall-notice stop-gap is retired: `formatFrameworkFallbackText`
-    // returns null for the pure-liveness "still working / running <Tool>"
-    // beat (the only string it still emits is the approval-blocked re-ping).
-    // The early quiet floor beat existed ONLY to surface that stall notice, so
-    // with the notice gone there is nothing to send here unless the turn is
-    // parked on an approval card. Skip silently otherwise; the live draft +
-    // the model's own pacing beats carry progress.
     if (text == null) return
     try {
       await robustApiCall(

--- a/telegram-plugin/uat/scenarios/fuzz-liveness-climb-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/fuzz-liveness-climb-dm.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Fuzz: dead-air-between-visible-updates bound across turn shapes (Phase 4c,
+ * `deterministic-turn-liveness.md`). Non-required (`uat-fuzz`,
+ * `workflow_dispatch` + scheduled — see `ci-uat.yml`), scoped to `fuzz-*`.
+ *
+ * SCOPE HONESTY (read before trusting this as "the fuzz invariant" wholesale):
+ * the RFC's Phase 4c corpus is message-timing × turn-length × tool-churn ×
+ * sub-agent-fan-out × surface × role — a genuinely randomized property-fuzz.
+ * That full corpus already exists at the DECISION layer
+ * (`telegram-plugin/tests/turn-liveness-invariant.test.ts`, 2000 random
+ * shapes × both surfaces, fast/local/every-CI-run). What does NOT exist yet
+ * is a live-transport fuzz of the same breadth — each live turn burns real
+ * subscription quota and ~30-90s wall-clock, so a 2000-shape live corpus is
+ * not realistic to author or run from this sandbox (or CI, at any cadence
+ * short of a dedicated long-running canary). This file is the SCAFFOLD:
+ * a handful of FIXED, hand-picked turn shapes run on the real surface,
+ * checked against the SAME dead-air bound the decision-layer fuzz proves in
+ * the abstract. It is not a substitute for a true randomized live corpus —
+ * see the RFC's Known gaps / follow-up list, where this limitation is named
+ * explicitly rather than left implicit.
+ *
+ * Each case fires a turn shape, watches the SAME two invariants the keystone
+ * (Phase 1) and the dark-turn guard (Phase 2) promise on the real surface:
+ *
+ *   - dead air between VISIBLE updates (card edits, narration, or the final
+ *     answer) never exceeds `MAX_DEAD_AIR_MS` — generous slack over the
+ *     ~6-12s Phase-1 bound to absorb live Bot API + model latency jitter;
+ *   - zero mid-turn device buzz (no non-final message with `silent===false`).
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+import { isActivityFeedMessage } from "../assertions.js";
+import type { ObservedMessage } from "../driver.js";
+
+const MAX_DEAD_AIR_MS = 25_000; // generous slack over the ~6-12s Phase-1 bound
+const CASE_BUDGET_MS = 130_000;
+
+interface FuzzCase {
+  name: string;
+  prompt: string;
+  windowMs: number;
+}
+
+const CASES: FuzzCase[] = [
+  {
+    name: "single-silent-tool-short",
+    prompt:
+      "Run exactly one Bash command `sleep 20` with NO narration before or " +
+      "during it, then reply with a one-line confirmation.",
+    windowMs: 30_000,
+  },
+  {
+    name: "single-silent-tool-long",
+    prompt:
+      "Run exactly one Bash command `sleep 50` with NO narration before or " +
+      "during it, then reply with a one-line confirmation.",
+    windowMs: 60_000,
+  },
+  {
+    name: "two-silent-tools-back-to-back",
+    prompt:
+      "Run Bash `sleep 20`, then immediately (no narration in between) run " +
+      "Bash `sleep 20` again, then reply with a one-line confirmation.",
+    windowMs: 50_000,
+  },
+];
+
+describe("uat-fuzz: liveness dead-air bound across a handful of turn shapes (Phase 4c scaffold)", () => {
+  for (const fc of CASES) {
+    it(
+      `[${fc.name}] dead air between visible updates never exceeds ${MAX_DEAD_AIR_MS}ms; no mid-turn ping`,
+      async () => {
+        const sc = await spinUp({ agent: "test-harness" });
+        try {
+          const iter = sc.driver
+            .observeMessages(sc.botUserId)
+            [Symbol.asyncIterator]();
+
+          await sc.sendDM(fc.prompt);
+          const sentAt = Date.now();
+          let lastVisibleAt = sentAt;
+          let maxGap = 0;
+          let answer: ObservedMessage | null = null;
+          let loudMidTurn: ObservedMessage | null = null;
+
+          const deadline = Date.now() + fc.windowMs + 40_000;
+          while (Date.now() < deadline) {
+            if (answer) break;
+            const remaining = deadline - Date.now();
+            const next = await Promise.race([
+              iter.next(),
+              new Promise<{ done: true; value: undefined }>((r) =>
+                setTimeout(() => r({ done: true, value: undefined }), Math.max(0, remaining)),
+              ),
+            ]);
+            if (next.done || next.value == null) break;
+            const m = next.value as ObservedMessage;
+            if (m.senderUserId === sc.driverUserId) continue;
+
+            const now = Date.now();
+            if (isActivityFeedMessage(m)) {
+              const gap = now - lastVisibleAt;
+              maxGap = Math.max(maxGap, gap);
+              lastVisibleAt = now;
+              if (m.edited && m.silent === false) loudMidTurn = loudMidTurn ?? m;
+              continue;
+            }
+            if (m.edited) continue;
+            if (!answer && m.text.trim().length > 0) {
+              answer = m;
+              const gap = now - lastVisibleAt;
+              maxGap = Math.max(maxGap, gap);
+              continue;
+            }
+            if (m.silent === false) loudMidTurn = loudMidTurn ?? m;
+          }
+          await iter.return?.();
+
+          console.log(
+            `[fuzz-liveness-climb][${fc.name}] maxGap=${maxGap}ms answer=${answer != null}`,
+          );
+
+          expect(
+            loudMidTurn,
+            `[${fc.name}] a mid-turn message pinged the device: ` +
+              JSON.stringify(loudMidTurn?.text?.slice(0, 120)),
+          ).toBeNull();
+
+          expect(answer, `[${fc.name}] FAIL — no answer within budget; turn may be wedged.`).not.toBeNull();
+
+          expect(
+            maxGap,
+            `[${fc.name}] dead air of ${maxGap}ms between visible updates exceeds the ` +
+              `${MAX_DEAD_AIR_MS}ms bound — the Phase-1 climb should have kept the card ` +
+              "moving throughout the silent tool stretch.",
+          ).toBeLessThanOrEqual(MAX_DEAD_AIR_MS);
+        } finally {
+          await sc.tearDown();
+        }
+      },
+      CASE_BUDGET_MS,
+    );
+  }
+});

--- a/telegram-plugin/uat/scenarios/jtbd-liveness-climb-channel.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-liveness-climb-channel.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Deterministic-turn-liveness climb — CHANNEL twin of
+ * `jtbd-liveness-climb-dm.test.ts` (Phase 4a, `deterministic-turn-liveness.md`).
+ *
+ * Surface parity is a production-readiness bar for this job (job spec §
+ * Production-readiness: "every signal is proven in both DM and forum
+ * channel"). Phase 1's climb is keyed on the SAME `feedHeartbeatTick` /
+ * `runSilentTurnHeartbeatTick` path regardless of chat type — this scenario
+ * proves the card edits land in a supergroup too, not just a DM.
+ *
+ * Self-skips green when no test supergroup is wired (`SWITCHROOM_UAT_CHAT_ID`
+ * unset / unresolvable) — mirrors the existing channel-twin convention (see
+ * `jtbd-foreground-subagent-activity-channel.test.ts`).
+ *
+ * mtcute has no forum-topic API here, so this uses the General topic — same
+ * limitation as every other channel twin in this suite.
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+import { expectMessage, isActivityFeedMessage } from "../assertions.js";
+import type { ObservedMessage } from "../driver.js";
+
+const AGENT = "test-harness";
+const SUPERGROUP_ID = Number.parseInt(process.env.SWITCHROOM_UAT_CHAT_ID ?? "", 10);
+
+const MIN_CLIMB_EDITS = 4;
+const OVERALL_BUDGET_MS = 150_000;
+const SILENT_TOOL_SECONDS = 40;
+
+const SILENT_TOOL_PROMPT =
+  "Do exactly this and nothing else: run a single Bash command " +
+  `\`sleep ${SILENT_TOOL_SECONDS}\` and wait for it to finish. Do NOT narrate ` +
+  "anything before or during the sleep — no commentary, no other tool calls, " +
+  "no intermediate messages. Only after the sleep completes, reply with a " +
+  "one-line confirmation that you waited.";
+
+describe("uat: deterministic turn liveness — silent-tool card climb (channel parity)", () => {
+  it(
+    "climbs the activity card in a supergroup the same way it does in a DM",
+    async () => {
+      if (!Number.isFinite(SUPERGROUP_ID)) {
+        console.warn("[liveness-climb-channel] SWITCHROOM_UAT_CHAT_ID unset — skipping");
+        return;
+      }
+      const sc = await spinUp({ agent: AGENT, settleMs: 0 });
+      try {
+        await sc.driver.primeDialogs();
+        if (!(await sc.driver.canResolve(SUPERGROUP_ID))) {
+          console.warn(`[liveness-climb-channel] supergroup ${SUPERGROUP_ID} not resolvable — skipping`);
+          return;
+        }
+
+        await sc.driver.sendText(SUPERGROUP_ID, SILENT_TOOL_PROMPT);
+        const sentAt = Date.now();
+
+        // First observation of the card — proves it opens in the channel.
+        const firstCard = await expectMessage(
+          sc.driver,
+          SUPERGROUP_ID,
+          (m: ObservedMessage) => isActivityFeedMessage(m),
+          { timeout: 30_000, senderFilter: { notUserId: sc.driverUserId } },
+        );
+        console.log(
+          `[liveness-climb-channel] card opened at +${Date.now() - sentAt}ms (id=${firstCard.messageId}): ` +
+            JSON.stringify(firstCard.text.slice(0, 100)),
+        );
+
+        // Poll the SAME card by id at intervals across the silent window,
+        // checking the body actually changes (climbs) rather than freezing.
+        const samples: string[] = [firstCard.text];
+        const pollDeadline = Date.now() + (SILENT_TOOL_SECONDS + 20) * 1000;
+        let lastText = firstCard.text;
+        let changeCount = 0;
+        while (Date.now() < pollDeadline && changeCount < MIN_CLIMB_EDITS) {
+          await new Promise((r) => setTimeout(r, 6_000));
+          const cur = await sc.driver.getMessage(SUPERGROUP_ID, firstCard.messageId);
+          if (cur == null) continue;
+          if (cur.text !== lastText) {
+            changeCount++;
+            lastText = cur.text;
+            samples.push(cur.text);
+            console.log(
+              `[liveness-climb-channel] card changed (#${changeCount}) at +${Date.now() - sentAt}ms: ` +
+                JSON.stringify(cur.text.slice(0, 100)),
+            );
+          }
+        }
+
+        if (changeCount === 0) {
+          console.warn(
+            "[liveness-climb-channel] INCONCLUSIVE — card body never changed across the " +
+              "silent window (model may have narrated a tool label, taking the labelled " +
+              "heartbeat path with different cadence). Not a hard failure on its own.",
+          );
+        } else if (changeCount < MIN_CLIMB_EDITS) {
+          console.warn(
+            `[liveness-climb-channel] INCONCLUSIVE — only ${changeCount} change(s) observed ` +
+              `(< ${MIN_CLIMB_EDITS} target).`,
+          );
+        }
+
+        // Final answer resumes in the same chat — parity + completion proof.
+        const done = await expectMessage(
+          sc.driver,
+          SUPERGROUP_ID,
+          /\S/,
+          { timeout: 60_000, senderFilter: { notUserId: sc.driverUserId } },
+        );
+        expect(done.chatId).toBe(SUPERGROUP_ID);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    OVERALL_BUDGET_MS,
+  );
+});

--- a/telegram-plugin/uat/scenarios/jtbd-liveness-climb-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-liveness-climb-dm.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Deterministic-turn-liveness climb — DM (Phase 4a, `deterministic-turn-liveness.md`).
+ *
+ * The RFC's keystone (Phase 1) gives a busy-but-silent foreground turn a
+ * climbing activity card instead of the pre-#2143/#2527/#2667 freeze: once
+ * the card is open and no tool emits a label, `feedHeartbeatTick`'s 0-label
+ * branch re-renders the SAME message with a fresh `Working · Ns` elapsed
+ * every `FEED_HEARTBEAT_MIN_STALE_MS` (~6s), edit-only (no device buzz).
+ *
+ * IMPORTANT product fact this scenario respects: switchroom has NO streaming
+ * REPLY path — the final answer is sent whole (chunked over the char cap if
+ * needed). The card observed here is the activity/liveness card — a distinct,
+ * pre-existing card-edit surface (worker-activity-feed / liveness card), not
+ * a streamed reply. This scenario never asserts a streamed reply edit.
+ *
+ * ## Trigger
+ *
+ * A single `Bash` call that sleeps ~40s with no intermediate narration and no
+ * tool label — the exact "silent tool" shape the Phase-1 climb exists for.
+ *
+ * ## What it asserts (asymmetric — timing on a live model is not fully
+ * forceable)
+ *
+ *   PASS      — the SAME activity-card message is edited (non-initial
+ *               renders, i.e. `edited === true` on repeat observations of the
+ *               same `messageId`) at least `MIN_CLIMB_EDITS` (4) times across
+ *               the ~40s window, and the elapsed suffix parsed out of the
+ *               body is monotonically non-decreasing across those edits
+ *               (the "climbing" property — hard-fails on a frozen/repeated
+ *               elapsed value across all edits, which reproduces the pre-
+ *               Phase-1 freeze).
+ *   PASS      — no bot message OTHER than the one activity-card message id
+ *               appears during the silent window (no mid-turn notification
+ *               ping; the climb is edit-only, per Phase 1 + the job spec's
+ *               "no device buzz" bad-list item).
+ *   INCONCLUSIVE — the model narrated anyway (a tool label / narrative text
+ *               landed), so the 0-label silent-tool path was not exercised.
+ *               Warn + pass — not a regression of this fix.
+ *   FAIL      — no answer at all within budget (wedged), or a mid-turn ping
+ *               is observed (silent === false on a non-final message).
+ *   HARD FAIL — the turn ran clearly longer than the climb bound with fewer
+ *               than `MIN_CLIMB_EDITS` edits on the card and no narration —
+ *               the exact freeze this fix exists to close.
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+import { isActivityFeedMessage } from "../assertions.js";
+import type { ObservedMessage } from "../driver.js";
+
+const MIN_CLIMB_EDITS = 4;
+const OVERALL_BUDGET_MS = 140_000;
+const SILENT_TOOL_SECONDS = 40;
+
+const SILENT_TOOL_PROMPT =
+  "Do exactly this and nothing else: run a single Bash command " +
+  `\`sleep ${SILENT_TOOL_SECONDS}\` and wait for it to finish. Do NOT narrate ` +
+  "anything before or during the sleep — no commentary, no other tool calls, " +
+  "no intermediate messages. Only after the sleep completes, reply with a " +
+  "one-line confirmation that you waited.";
+
+/** Parse the `Working · Ns` (or `· Nm Ss`) elapsed suffix out of a card body.
+ *  Returns null when the shape isn't present (e.g. a labelled feed). */
+function parseElapsedSeconds(text: string): number | null {
+  const m = text.match(/(?:^|\s)·\s*(?:(\d+)\s*m)?\s*(\d+)\s*s\b/i);
+  if (!m) return null;
+  const minutes = m[1] ? Number.parseInt(m[1], 10) : 0;
+  const seconds = Number.parseInt(m[2], 10);
+  return minutes * 60 + seconds;
+}
+
+describe("uat: deterministic turn liveness — silent-tool card climb (DM)", () => {
+  it(
+    "climbs the SAME activity card ≥4 times with non-decreasing elapsed, no mid-turn ping",
+    async () => {
+      const sc = await spinUp({ agent: "test-harness" });
+      try {
+        const iter = sc.driver
+          .observeMessages(sc.botUserId)
+          [Symbol.asyncIterator]();
+
+        await sc.sendDM(SILENT_TOOL_PROMPT);
+        const sentAt = Date.now();
+        console.log("[liveness-climb-dm] prompt sent; watching card edits…");
+
+        let cardMessageId: number | null = null;
+        const elapsedSamples: number[] = [];
+        let cardEditCount = 0;
+        let answer: ObservedMessage | null = null;
+        let otherLoudMessage: ObservedMessage | null = null;
+
+        const deadline = Date.now() + 100_000;
+        while (Date.now() < deadline) {
+          if (answer && cardEditCount >= MIN_CLIMB_EDITS) break;
+          const remaining = deadline - Date.now();
+          const next = await Promise.race([
+            iter.next(),
+            new Promise<{ done: true; value: undefined }>((r) =>
+              setTimeout(() => r({ done: true, value: undefined }), Math.max(0, remaining)),
+            ),
+          ]);
+          if (next.done || next.value == null) break;
+          const m = next.value as ObservedMessage;
+          if (m.senderUserId === sc.driverUserId) continue;
+
+          if (isActivityFeedMessage(m)) {
+            if (cardMessageId == null) cardMessageId = m.messageId;
+            if (m.messageId === cardMessageId && m.edited) {
+              cardEditCount++;
+              const secs = parseElapsedSeconds(m.text);
+              if (secs != null) elapsedSamples.push(secs);
+              console.log(
+                `[liveness-climb-dm] card edit #${cardEditCount} at +${Date.now() - sentAt}ms: ` +
+                  JSON.stringify(m.text.slice(0, 100)),
+              );
+            }
+            // A non-silent card edit would still be a ping; card edits are
+            // asserted separately below via `silent`.
+            if (m.edited && m.silent === false) {
+              otherLoudMessage = otherLoudMessage ?? m;
+            }
+            continue;
+          }
+
+          if (m.edited) continue;
+          if (!answer && m.text.trim().length > 0) {
+            answer = m;
+            console.log(`[liveness-climb-dm] answer at +${Date.now() - sentAt}ms.`);
+            continue;
+          }
+          // Any OTHER non-edit bot message during the window is a candidate
+          // mid-turn ping — track it for the loud-message assertion below.
+          if (m.silent === false) {
+            otherLoudMessage = otherLoudMessage ?? m;
+          }
+        }
+        await iter.return?.();
+
+        // No mid-turn notification ping, on the card OR any other message.
+        expect(
+          otherLoudMessage,
+          `a mid-turn message pinged the user's device (silent=false): ` +
+            JSON.stringify(otherLoudMessage?.text?.slice(0, 120)),
+        ).toBeNull();
+
+        if (cardEditCount === 0 && cardMessageId == null) {
+          console.warn(
+            "[liveness-climb-dm] INCONCLUSIVE — no activity card observed at all " +
+              "(the model may have narrated before/instead of the silent sleep, " +
+              "or the turn completed too fast). Not a regression of this fix.",
+          );
+          expect(answer, "even in the inconclusive branch the turn must complete").not.toBeNull();
+          return;
+        }
+
+        if (cardEditCount > 0 && cardEditCount < MIN_CLIMB_EDITS) {
+          console.warn(
+            `[liveness-climb-dm] INCONCLUSIVE — card edited ${cardEditCount} time(s), ` +
+              `below the ${MIN_CLIMB_EDITS} target (model may have narrated a tool ` +
+              "label partway through, handing off to the labelled-feed heartbeat " +
+              "with a different cadence). Not a hard failure.",
+          );
+        } else {
+          expect(
+            cardEditCount,
+            `HARD FAIL — the silent tool ran ~${SILENT_TOOL_SECONDS}s but the activity ` +
+              `card edited only ${cardEditCount} time(s) (< ${MIN_CLIMB_EDITS}). This is ` +
+              "the pre-Phase-1 freeze regression (#2143/#2527/#2667 archaeology in " +
+              "reference/rfcs/deterministic-turn-liveness.md).",
+          ).toBeGreaterThanOrEqual(MIN_CLIMB_EDITS);
+        }
+
+        // Climbing property: elapsed samples must be non-decreasing (never
+        // freezes/rewinds across edits of the same card).
+        for (let i = 1; i < elapsedSamples.length; i++) {
+          expect(
+            elapsedSamples[i],
+            `elapsed suffix went backwards/froze across edits: ${JSON.stringify(elapsedSamples)}`,
+          ).toBeGreaterThanOrEqual(elapsedSamples[i - 1]);
+        }
+
+        expect(answer, "FAIL — no answer arrived within budget; the turn may be wedged.").not.toBeNull();
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    OVERALL_BUDGET_MS,
+  );
+});

--- a/telegram-plugin/uat/scenarios/jtbd-liveness-narration-channel.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-liveness-narration-channel.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Narrated mid-turn work still shows words on the card — CHANNEL twin of
+ * `jtbd-liveness-narration-dm.test.ts` (Phase 4a, `deterministic-turn-liveness.md`).
+ *
+ * Surface parity bar per the job spec. Self-skips green when no test
+ * supergroup is wired.
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+import { expectMessage, isActivityFeedMessage } from "../assertions.js";
+import type { ObservedMessage } from "../driver.js";
+
+const AGENT = "test-harness";
+const SUPERGROUP_ID = Number.parseInt(process.env.SWITCHROOM_UAT_CHAT_ID ?? "", 10);
+const OVERALL_BUDGET_MS = 140_000;
+
+const NARRATED_WORK_PROMPT =
+  "Do four short steps, ONE AT A TIME. Before EACH step, write a brief " +
+  'one-sentence narration of what you are about to do (e.g. "Checking the ' +
+  'hostname now.") — this is not a reply, just your normal narration — then ' +
+  "run the step via Bash (`sleep 3` is fine as the step body). After all " +
+  "four steps, send a one-line final summary reply.";
+
+describe("uat: deterministic turn liveness — narration lands mid-turn (channel parity)", () => {
+  it(
+    "the model's own words appear on the activity card mid-turn, in a supergroup",
+    async () => {
+      if (!Number.isFinite(SUPERGROUP_ID)) {
+        console.warn("[liveness-narration-channel] SWITCHROOM_UAT_CHAT_ID unset — skipping");
+        return;
+      }
+      const sc = await spinUp({ agent: AGENT, settleMs: 0 });
+      try {
+        await sc.driver.primeDialogs();
+        if (!(await sc.driver.canResolve(SUPERGROUP_ID))) {
+          console.warn(`[liveness-narration-channel] supergroup ${SUPERGROUP_ID} not resolvable — skipping`);
+          return;
+        }
+
+        await sc.driver.sendText(SUPERGROUP_ID, NARRATED_WORK_PROMPT);
+        const sentAt = Date.now();
+
+        const card = await expectMessage(
+          sc.driver,
+          SUPERGROUP_ID,
+          (m: ObservedMessage) => isActivityFeedMessage(m) && !/^Working(\s*[·…]|$)/i.test(m.text.trim()),
+          { timeout: 60_000, senderFilter: { notUserId: sc.driverUserId } },
+        );
+        console.log(
+          `[liveness-narration-channel] narrated card content at +${Date.now() - sentAt}ms (id=${card.messageId}): ` +
+            JSON.stringify(card.text.slice(0, 140)),
+        );
+        expect(card.chatId).toBe(SUPERGROUP_ID);
+
+        const answer = await expectMessage(
+          sc.driver,
+          SUPERGROUP_ID,
+          /\S/,
+          { timeout: 60_000, senderFilter: { notUserId: sc.driverUserId } },
+        );
+        expect(answer.chatId).toBe(SUPERGROUP_ID);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    OVERALL_BUDGET_MS,
+  );
+});

--- a/telegram-plugin/uat/scenarios/jtbd-liveness-narration-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-liveness-narration-dm.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Narrated mid-turn work still shows words on the card (Phase 4a,
+ * `deterministic-turn-liveness.md`) — DM.
+ *
+ * The Phase-1 climb fills the GAPS the model leaves; it must never regress
+ * the pre-existing narration path (session-tail → gateway `case 'text'` →
+ * `stagePendingNarrative` → `showNarrativeStep` → `appendActivityLabel`).
+ * This scenario proves the model's own narrated steps still land on the
+ * card mid-turn, chronologically interleaved with the climb, when the model
+ * DOES talk (the complement of `jtbd-liveness-climb-dm`, which forces the
+ * model silent).
+ *
+ * IMPORTANT: switchroom has no streaming REPLY path. The words asserted here
+ * land on the pre-existing activity/liveness card (a card-edit surface), not
+ * a streamed reply — the final reply is still sent whole.
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+import { isActivityFeedMessage } from "../assertions.js";
+import type { ObservedMessage } from "../driver.js";
+
+const OVERALL_BUDGET_MS = 130_000;
+
+const NARRATED_WORK_PROMPT =
+  "Do four short steps, ONE AT A TIME. Before EACH step, write a brief " +
+  'one-sentence narration of what you are about to do (e.g. "Checking the ' +
+  'hostname now.") — this is not a reply, just your normal narration — then ' +
+  "run the step via Bash (`sleep 3` is fine as the step body). After all " +
+  "four steps, send a one-line final summary reply.";
+
+describe("uat: deterministic turn liveness — narration lands mid-turn (DM)", () => {
+  it(
+    "the model's own words appear on the activity card mid-turn (narration not regressed)",
+    async () => {
+      const sc = await spinUp({ agent: "test-harness" });
+      try {
+        const iter = sc.driver
+          .observeMessages(sc.botUserId)
+          [Symbol.asyncIterator]();
+
+        await sc.sendDM(NARRATED_WORK_PROMPT);
+        const sentAt = Date.now();
+        console.log("[liveness-narration-dm] prompt sent; watching for narrated card content…");
+
+        const narrationSamples: string[] = [];
+        let answer: ObservedMessage | null = null;
+        let otherLoudMessage: ObservedMessage | null = null;
+
+        const deadline = Date.now() + 90_000;
+        while (Date.now() < deadline) {
+          if (answer) break;
+          const remaining = deadline - Date.now();
+          const next = await Promise.race([
+            iter.next(),
+            new Promise<{ done: true; value: undefined }>((r) =>
+              setTimeout(() => r({ done: true, value: undefined }), Math.max(0, remaining)),
+            ),
+          ]);
+          if (next.done || next.value == null) break;
+          const m = next.value as ObservedMessage;
+          if (m.senderUserId === sc.driverUserId) continue;
+
+          if (isActivityFeedMessage(m)) {
+            // Anything on the card that ISN'T the bare "Working…" placeholder
+            // or a "Working · Ns" climb suffix is model narration.
+            if (!/^Working(\s*[·…]|$)/i.test(m.text.trim())) {
+              narrationSamples.push(m.text);
+              console.log(
+                `[liveness-narration-dm] narrated card content at +${Date.now() - sentAt}ms: ` +
+                  JSON.stringify(m.text.slice(0, 140)),
+              );
+            }
+            if (m.edited && m.silent === false) otherLoudMessage = otherLoudMessage ?? m;
+            continue;
+          }
+          if (m.edited) continue;
+          if (!answer && m.text.trim().length > 0) {
+            answer = m;
+            continue;
+          }
+          if (m.silent === false) otherLoudMessage = otherLoudMessage ?? m;
+        }
+        await iter.return?.();
+
+        expect(
+          otherLoudMessage,
+          `a mid-turn message pinged the user's device: ${JSON.stringify(otherLoudMessage?.text?.slice(0, 120))}`,
+        ).toBeNull();
+
+        if (narrationSamples.length === 0) {
+          console.warn(
+            "[liveness-narration-dm] INCONCLUSIVE — no narrated content observed on the " +
+              "card (model may have batched steps or the turn was too fast). Not " +
+              "necessarily a regression — but worth a human look if this recurs.",
+          );
+        } else {
+          expect(narrationSamples.length).toBeGreaterThan(0);
+        }
+
+        expect(answer, "FAIL — no answer arrived within budget; the turn may be wedged.").not.toBeNull();
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    OVERALL_BUDGET_MS,
+  );
+});

--- a/telegram-plugin/uat/scenarios/silent-end-recovery-channel.test.ts
+++ b/telegram-plugin/uat/scenarios/silent-end-recovery-channel.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Silent-end recovery — CHANNEL twin of `silent-end-recovery-dm.test.ts`
+ * (Phase 4a, `deterministic-turn-liveness.md`: the dark-turn guard must
+ * deliver exactly one fallback message on the real surface, in a DM AND a
+ * forum topic alike).
+ *
+ * Phase 2 (already shipped) hardens `recordUndeliveredTurnEnd` /
+ * `SILENT_END_FALLBACK_TEXT` as the ONE deterministic guard for a turn that
+ * ends having delivered no reply. This scenario proves it fires — at most
+ * once — for the same tool-heavy prompt shape, in a supergroup.
+ *
+ * Self-skips green when no test supergroup is wired.
+ */
+
+import { describe, it, expect } from "vitest";
+import { spinUp } from "../harness.js";
+import { expectMessage } from "../assertions.js";
+import type { ObservedMessage } from "../driver.js";
+
+const AGENT = "test-harness";
+const SUPERGROUP_ID = Number.parseInt(process.env.SWITCHROOM_UAT_CHAT_ID ?? "", 10);
+
+const TOOL_HEAVY_PROMPT =
+  "Pick a directory under /tmp that doesn't exist yet. Create it. " +
+  "List its contents (should be empty). Write a small file in it. " +
+  "List again. Then report what you did in a one-line reply.";
+
+describe("uat: silent-end recovery (channel parity)", () => {
+  it(
+    "user asks in a supergroup → agent always replies exactly once via the fallback ladder if needed",
+    async () => {
+      if (!Number.isFinite(SUPERGROUP_ID)) {
+        console.warn("[silent-end-recovery-channel] SWITCHROOM_UAT_CHAT_ID unset — skipping");
+        return;
+      }
+      const sc = await spinUp({ agent: AGENT, settleMs: 0 });
+      try {
+        await sc.driver.primeDialogs();
+        if (!(await sc.driver.canResolve(SUPERGROUP_ID))) {
+          console.warn(`[silent-end-recovery-channel] supergroup ${SUPERGROUP_ID} not resolvable — skipping`);
+          return;
+        }
+
+        await sc.driver.sendText(SUPERGROUP_ID, TOOL_HEAVY_PROMPT);
+
+        // Same budget rationale as the DM twin: covers normal latency, one
+        // Stop-hook re-prompt cycle, and the worst-case 300s framework
+        // fallback.
+        const reply = await expectMessage(
+          sc.driver,
+          SUPERGROUP_ID,
+          /\S/,
+          { timeout: 320_000, senderFilter: { notUserId: sc.driverUserId } },
+        );
+        expect(reply.text.length).toBeGreaterThan(0);
+        expect(reply.chatId).toBe(SUPERGROUP_ID);
+
+        if (/no update from agent|didn't send a reply/i.test(reply.text)) {
+          console.warn(
+            "[silent-end-recovery-channel] reply was the framework/dark-turn fallback — " +
+              `model never replied on its own. Reply text: ${JSON.stringify(reply.text.slice(0, 200))}`,
+          );
+
+          // Exactly-once proof: no SECOND fallback-shaped message should
+          // follow within a short window (the `exhausted` latch).
+          let secondFallback: ObservedMessage | null = null;
+          try {
+            secondFallback = await expectMessage(
+              sc.driver,
+              SUPERGROUP_ID,
+              /no update from agent|didn't send a reply/i,
+              { timeout: 15_000, senderFilter: { notUserId: sc.driverUserId } },
+            );
+          } catch {
+            // Timeout is the expected/good outcome — no second fallback fired.
+          }
+          expect(
+            secondFallback,
+            "the dark-turn/framework fallback fired MORE than once for the same turn " +
+              "(the `exhausted` latch should give fire-once)",
+          ).toBeNull();
+        }
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    360_000,
+  );
+});


### PR DESCRIPTION
## Summary

PR 3 of the deterministic-turn-liveness rollout: Phase 3 + Phase 5 cleanup, plus the Phase 4a/4c test scaffolding deferred from PR 1. Cites `reference/rfcs/deterministic-turn-liveness.md` (Phases 1/2/4b/4d already landed) and `reference/jobs/know-what-my-agent-is-doing.md`.

## Deterministic-guarantee delta (Phase 5 PR-declaration rule)

**Removed: none.** The busy-but-silent `onMidTurnFloor` text send in `telegram-plugin/gateway/gateway.ts` was already inert — `silencePoke.formatFrameworkFallbackText('working', …, blockedOnApproval=false)` has returned `null` unconditionally for that branch since #2667. This PR makes the no-op explicit at the call site (`if (!blockedOnApproval) return`, with a comment pointing at the Phase-1 climbing card) instead of leaving it implicit in the callee's return value. **No behaviour changes** — same skip, same conditions, just an honest early return instead of dead-end null-checking.

**Kept, unchanged:** the approval-blocked re-ping (the turn is parked on an approval card) — same `decideMidTurnFloor`/`SILENCE_FLOOR_MS` gate, same text, same silent send.

**Added:** nothing new is delivered by this PR's code change — Phase 1 (already shipped, PR 1) is what actually delivers the mid-turn liveness guarantee now (the climbing `Working · Ns` card edit). This PR documents that boundary and proves it with new UAT scenarios (Phase 4a) rather than adding new delivery mechanism.

## What changed

- **Phase 3** — `telegram-plugin/gateway/gateway.ts`: `onMidTurnFloor` now returns early for the busy-but-silent case with a comment naming the climb as the real floor; `SILENCE_FLOOR_MS`'s doc comment updated to match. The decision machinery (`decideMidTurnFloor`, `turn-liveness-floor.ts`, `silence-poke.ts`) is untouched — it still gates the surviving approval-blocked re-ping, so it is not vestigial.
- **Phase 5** — `reference/jobs/know-what-my-agent-is-doing.md` § Prove-it gained bullets for the card-climb, narration-survives-the-climb, and dark-turn-fires-once DM+channel scenarios, plus the live dead-air fuzz scaffold (with an honest scope note). `CONTRIBUTING.md` § Submitting a PR gained step 8: any PR touching the liveness surface must declare its deterministic-guarantee delta in the PR body (this PR practices what it adds).
- **Phase 4a (authored, not run from this sandbox)** — `telegram-plugin/uat/scenarios/`:
  - `jtbd-liveness-climb-{dm,channel}.test.ts` — 40s silent tool → same activity card edited ≥4 times, elapsed non-decreasing, no mid-turn ping.
  - `jtbd-liveness-narration-{dm,channel}.test.ts` — narrated work → the model's own words land on the card mid-turn (narration unregressed by the climb).
  - `silent-end-recovery-channel.test.ts` — channel twin of the existing `silent-end-recovery-dm.test.ts` (dark turn, fires exactly once).
- **Phase 4c (scaffolded, scope-limited by design)** — `fuzz-liveness-climb-dm.test.ts`: a handful of fixed silent-tool shapes on the real surface asserting the dead-air bound + no-ping, under `uat-fuzz` (non-required, workflow_dispatch). The FULL randomized message-timing × tool-churn × sub-agent-fan-out corpus already exists at the decision layer (`turn-liveness-invariant.test.ts`, 2000 shapes, every CI run) — a same-breadth LIVE corpus is not realistic per-PR (quota + wall-clock cost) and is named as a follow-up in the RFC's Known gaps rather than faked.
- **RFC** — `reference/rfcs/deterministic-turn-liveness.md`: status line + inline notes mark Phase 3/5 landed, Phase 4a authored, Phase 4c scoped-and-tracked.

## No streaming reply path (per product fact)

None of the new scenarios assume a streamed reply — switchroom sends the final reply whole (chunked over the char cap only). Every assertion targets the pre-existing activity/liveness CARD (a distinct card-edit surface via `editMessageText`), consistent with `isActivityFeedMessage` from `uat/assertions.ts`.

## Test plan

- [x] `npm run lint` — clean (tsc + all 8 guard scripts, including the new UAT scenario files).
- [x] Targeted vitest: `turn-liveness-invariant.test.ts`, `turn-liveness-floor.test.ts`, `feed-heartbeat-liveness-open.test.ts`, `silent-turn-climb-transport.test.ts` — 53/53 pass.
- [x] `npm run test:bun` — 1080 pass / 2 fail (both pre-existing `client-token.test.ts` vault-sandbox failures, confirmed identical on clean `origin/main`).
- [x] Full `npm test` — 90 failed / 12182 passed. Every failure is in `tests/host-control/server.test.ts`, `tests/install/static-binary.test.ts`, `src/auth/broker/claude-compat.test.ts`, or other CLAUDE.md-documented env-dependent buckets (sandbox docker/vault/PATH constraints) — none touch `telegram-plugin/` liveness code, and the count matches the CLAUDE.md-documented "~85 env-dependent" baseline.
- [ ] Live UAT (`jtbd-liveness-climb-*`, `jtbd-liveness-narration-*`, `silent-end-recovery-channel`, `fuzz-liveness-climb-dm`) — authored per Phase 4a/4c but NOT run from this sandbox (needs live MTProto + vault creds); `uat-gate`/`uat-fuzz` and the test-harness agent execute them.

## Risk

Low — Phase 3 is a documented no-op (see delta above); Phase 5 is docs-only; Phase 4a/4c are additive new test files. No production code path gains new behavior.