### PR TITLE
docs(hindsight): correct retain-cadence description (every-turn chunked, not every ~10 turns)

### DIFF
--- a/profiles/coding/CLAUDE.md.hbs
+++ b/profiles/coding/CLAUDE.md.hbs
@@ -41,7 +41,7 @@ You are a senior software engineering agent. You write, review, debug, and archi
 Claude Code's file-based auto-memory is disabled. Use **Hindsight** MCP tools:
 
 - `mcp__hindsight__recall` — search past memories. Auto-fires on every message.
-- `mcp__hindsight__retain` — store important facts. Auto-retains transcript every ~10 turns.
+- `mcp__hindsight__retain` — store important facts. Auto-retains every turn (chunked, a small ~3-turn window each time), so it's prompt and cheap.
 - `mcp__hindsight__reflect` — synthesize across memories for complex queries.
 - `mcp__hindsight__create_mental_model` — maintain semantic summaries (e.g. "codebase architecture").
 

--- a/profiles/default/CLAUDE.md.hbs
+++ b/profiles/default/CLAUDE.md.hbs
@@ -39,7 +39,7 @@ Hindsight is a memory bank with semantic search, knowledge graph, entity resolut
 
 ### Day-to-day tools
 - `mcp__hindsight__recall` — semantic-search the bank for relevant past memories. Auto-fires on every inbound user message via the plugin's UserPromptSubmit hook (you'll see "Relevant memories from past conversations" in your context). Call manually when you need a more specific query than the auto-fired one.
-- `mcp__hindsight__retain` — store a new memory. The plugin automatically retains the conversation transcript every ~10 turns via the Stop hook, so you usually don't need this. Call manually for significant decisions, corrections, or facts you want immediately searchable.
+- `mcp__hindsight__retain` — store a new memory. The plugin auto-retains every turn via the Stop hook, but in chunked mode each retain only processes a small recent window (~3 turns) — so it captures memory promptly and survives restarts without re-sending the whole transcript, and you usually don't need this. Call manually for significant decisions, corrections, or facts you want immediately searchable.
 - `mcp__hindsight__reflect` — Hindsight's LLM-powered "answer this query using the bank's content + directives". Use when the user asks a question that requires synthesis across multiple past memories.
 
 ### Mental Models
@@ -68,7 +68,7 @@ Don't retain:
 - Sensitive content the user explicitly asked you to not remember
 - Things already in a mental model — they'll be re-derived from underlying memories
 
-The plugin's auto-retain (Stop hook) handles transcript-level storage on a 10-turn cadence, so you don't need to manually retain everything. Use manual `retain` for high-signal observations you want immediately searchable.
+The plugin's auto-retain (Stop hook) fires every turn, but in chunked mode each retain only processes a small recent window (~3 turns) — so storage stays prompt and cheap and survives restarts without re-sending the whole transcript, and you don't need to manually retain everything. Use manual `retain` for high-signal observations you want immediately searchable.
 
 ## Sub-Agent Delegation
 

--- a/profiles/executive-assistant/CLAUDE.md.hbs
+++ b/profiles/executive-assistant/CLAUDE.md.hbs
@@ -40,7 +40,7 @@ You help the user stay organized, prepared, and focused on high-leverage work. Y
 Claude Code's file-based auto-memory is disabled. Use **Hindsight** MCP tools:
 
 - `mcp__hindsight__recall` — search past memories. Auto-fires every message.
-- `mcp__hindsight__retain` — store important facts. Auto-retains every ~10 turns.
+- `mcp__hindsight__retain` — store important facts. Auto-retains every turn (chunked, a small ~3-turn window each time), so it's prompt and cheap.
 - `mcp__hindsight__create_mental_model` — maintain models for "contacts", "active projects", "user preferences".
 
 Save proactively: contacts and their roles, scheduling preferences, project status, decisions with rationale, communication templates. Only Hindsight memories survive compaction.

--- a/profiles/health-coach/CLAUDE.md.hbs
+++ b/profiles/health-coach/CLAUDE.md.hbs
@@ -34,7 +34,7 @@ Recommend the user consult a professional for: persistent pain/injury, medical c
 Claude Code's file-based auto-memory is disabled. Use **Hindsight** MCP tools:
 
 - `mcp__hindsight__recall` — search past memories. Auto-fires on every message.
-- `mcp__hindsight__retain` — store important facts. Auto-retains every ~10 turns.
+- `mcp__hindsight__retain` — store important facts. Auto-retains every turn (chunked, a small ~3-turn window each time), so it's prompt and cheap.
 - `mcp__hindsight__create_mental_model` — maintain a "fitness profile" mental model.
 
 Save proactively: workout logs, goals, PRs, preferences, patterns (e.g. "poor sleep on Sundays"), injuries/limitations. Only Hindsight memories survive session compaction.

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2399,7 +2399,11 @@ export function installHindsightPlugin(
   // after every copy so they survive reconcile/restart.
   //
   // `retainEveryNTurns: 1` (override from vendor default `10`): the
-  // vendor's default throttles auto-retention to every 10 turns. For
+  // vendor's default throttles auto-retention to every 10th turn, so a
+  // short session can end before retention ever fires. Switchroom sets it
+  // to 1 so the Stop hook retains every turn (paired with chunked mode,
+  // each retain only slices a small recent window, so per-turn cost stays
+  // low). For
   // switchroom's "always-on specialist exec-assistant" vision, that
   // throttle is wrong — users expect "please remember this" or even a
   // single fact-sharing turn to survive a restart. The jtbd-memory-


### PR DESCRIPTION
## What

The persona docs and one scaffold comment described Hindsight auto-retain as firing "every ~10 turns" / on a "10-turn cadence". That's inaccurate: switchroom ships `retainEveryNTurns: 1` paired with `retainMode: "chunked"`, so the Stop hook retains **every turn**, but each retain only processes a small recent window (~3 turns) — prompt and cheap, and it survives restarts without re-sending the whole transcript.

## Changes (doc/comment text only)

- `profiles/default/CLAUDE.md.hbs` (2 lines) — the `retain` tool blurb and the auto-retain summary paragraph.
- `profiles/executive-assistant/CLAUDE.md.hbs`, `profiles/health-coach/CLAUDE.md.hbs`, `profiles/coding/CLAUDE.md.hbs` — the one-line `retain` blurb each.
- `src/agents/scaffold.ts` (~2401) — stale comment that described the vendor default as switchroom's behavior.

## Not changed

No config values or code logic. `retainEveryNTurns = 1` and `retainMode = "chunked"` are untouched — that cadence is correct by design and asserted by `tests/scaffold.recall-observations.test.ts` (still passing).

## Test plan

- `tsc --noEmit` — clean.
- `vitest run tests/scaffold.recall-observations.test.ts` — 5/5 pass.
- `git diff` confirms doc/comment text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)