### PR TITLE
fix(uat): repair the liveness test wall's card predicate + scenario logic

### DIFF
--- a/telegram-plugin/uat/assertions.ts
+++ b/telegram-plugin/uat/assertions.ts
@@ -47,15 +47,79 @@ export function isWorkerFeedMessage(m: ObservedMessage): boolean {
 const ACTIVITY_FEED_LINE_RE = /^[→✓]\s/u;
 
 /**
+ * A body line of the activity card: an in-progress `→`, a done `✓`, a nested
+ * child `↳`, or the rolling `✓ +N earlier…` / `↳ +N earlier…` overflow
+ * headers (both covered by the leading glyph). Distinct from
+ * {@link ACTIVITY_FEED_LINE_RE} in that it does NOT require the trailing space
+ * — `↳→ …` nested-in-progress lines render glyph-adjacent.
+ */
+const ACTIVITY_BODY_LINE_RE = /^[→✓↳]/u;
+
+/**
+ * The two-line header `renderActivityHeader`
+ * (telegram-plugin/tool-activity-summary.ts) prepends to the session
+ * activity / liveness card — the shape the pure-arrow
+ * {@link ACTIVITY_FEED_LINE_RE} predicate could never match, which is why the
+ * Phase-1 climb card (`silentTurnClimbRender`) was mis-classified as the
+ * answer and the whole climb test wall passed vacuously
+ * (`deterministic-turn-liveness.md` Phase 4a). Telegram strips the bold/italic
+ * entities, so the OBSERVED lines are:
+ *
+ *   line 1: `<emoji> <label>`            e.g. `🤖 Agent`   (optionally ` · <description>`)
+ *   line 2 running: `<elapsed> · <N> tool(s)`              e.g. `12s · 0 tools`, `2m05s · 3 tools`
+ *   line 2 done:    `<state> · <N> tools · <elapsed>`       e.g. `done · 3 tools · 41s`
+ *
+ * Elapsed is `formatFeedElapsed`: `<N>s` under a minute, else `<M>m<SS>s`.
+ */
+const LIVENESS_HEADER_L1_RE = /^(?:🤖|🛠[️]?|⚙[️]?)\s+\S/u;
+const LIVENESS_ELAPSED = String.raw`(?:\d+m)?\d+s`;
+const LIVENESS_HEADER_L2_RE = new RegExp(
+  `^(?:${LIVENESS_ELAPSED}\\s*·\\s*\\d+\\s+tools?` +
+    `|(?:done|failed)\\s*·\\s*\\d+\\s+tools?\\s*·\\s*${LIVENESS_ELAPSED})$`,
+  "iu",
+);
+
+/**
+ * True when `m` is the session activity / liveness card that carries the
+ * two-line `renderActivityHeader` (emoji + label, then the climbing
+ * `<elapsed> · <N> tools` status), followed only by `→`/`✓`/`↳` body lines.
+ *
+ * This is the card the Phase-1 climb (`feed-heartbeat-climb.ts`) and every
+ * headered activity feed render. The predicate stays strict — it requires
+ * BOTH header lines to match their exact shape — so a real reply that merely
+ * opens with an emoji or contains an arrow is never misclassified (the same
+ * documented reason the pure-arrow predicate demands every line be an activity
+ * line).
+ */
+export function isLivenessCardMessage(m: ObservedMessage): boolean {
+  const lines = m.text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  if (lines.length < 2) return false;
+  if (!LIVENESS_HEADER_L1_RE.test(lines[0])) return false;
+  if (!LIVENESS_HEADER_L2_RE.test(lines[1])) return false;
+  // Any remaining line must be an activity body line — the moment prose
+  // appears below the header, this is no longer the card (guards against a
+  // reply that happens to lead with a header-shaped emoji).
+  return lines.slice(2).every((l) => ACTIVITY_BODY_LINE_RE.test(l));
+}
+
+/**
  * True when `m` is the live tool-activity feed (the one-message list of
  * "what the agent is doing this turn") rather than the agent's reply. A
- * message qualifies only when EVERY non-empty line is an activity line —
- * so a real reply that merely contains an arrow is never misclassified.
+ * message qualifies when EITHER every non-empty line is a pure activity line
+ * (`→`/`✓`, the header-less feed) OR it carries the two-line liveness header
+ * (see {@link isLivenessCardMessage}) — so a real reply that merely contains
+ * an arrow is never misclassified.
  *
  * Recall/reply scenarios must skip this in addition to
  * {@link isWorkerFeedMessage}: on a turn that uses tools, the feed paints
  * `→ Finding the right tool` as its own bot message before the real answer
- * lands, and an `expectMessage(/\S/)` would otherwise latch onto it.
+ * lands, and an `expectMessage(/\S/)` would otherwise latch onto it. Before
+ * this predicate learned the header shape, the Phase-1 climb card (which
+ * ALWAYS carries the header) slipped through as an "answer" and silently
+ * broke the entire liveness-climb test wall.
  */
 export function isActivityFeedMessage(m: ObservedMessage): boolean {
   const lines = m.text
@@ -63,7 +127,8 @@ export function isActivityFeedMessage(m: ObservedMessage): boolean {
     .map((l) => l.trim())
     .filter((l) => l.length > 0);
   if (lines.length === 0) return false;
-  return lines.every((l) => ACTIVITY_FEED_LINE_RE.test(l));
+  if (lines.every((l) => ACTIVITY_FEED_LINE_RE.test(l))) return true;
+  return isLivenessCardMessage(m);
 }
 
 /**
@@ -81,6 +146,25 @@ export function isAnswer(m: ObservedMessage, driverUserId: number): boolean {
     !isActivityFeedMessage(m) &&
     m.text.trim().length > 0
   );
+}
+
+/**
+ * Wording of the framework's own mid-turn / dark-turn fallback sends — the
+ * exact erosion class the liveness test wall exists to catch. A re-added
+ * cadence "still working…" text ping (the #2667 shape the RFC bans) or a
+ * dark-turn fallback would carry one of these phrases. Scenarios use this to
+ * REJECT such a message from the "answer" lane: without it, the first loud
+ * mid-turn framework send is swallowed as the turn's answer and the ping-free
+ * guarantee passes vacuously. Keep in sync with `SILENT_END_FALLBACK_TEXT`
+ * (gateway.ts) and `formatFrameworkFallbackText` (silence-poke.ts).
+ */
+export const FRAMEWORK_FALLBACK_RE =
+  /still working|no update from agent|didn't send a reply|finished working but|waiting for your approval/i;
+
+/** True when `text` reads like a framework mid-turn/dark-turn fallback send
+ *  (see {@link FRAMEWORK_FALLBACK_RE}) rather than a model-authored answer. */
+export function isFrameworkFallbackText(text: string): boolean {
+  return FRAMEWORK_FALLBACK_RE.test(text);
 }
 
 export interface ReplyIsLastOptions {

--- a/telegram-plugin/uat/feed-matcher.test.ts
+++ b/telegram-plugin/uat/feed-matcher.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import {
   isActivityFeedMessage,
+  isFrameworkFallbackText,
+  isLivenessCardMessage,
   isWorkerFeedMessage,
   WORKER_FEED_RE,
 } from "./assertions.js";
@@ -82,5 +84,72 @@ describe("isActivityFeedMessage", () => {
 
   it("does NOT match an empty message", () => {
     expect(isActivityFeedMessage(feed("   "))).toBe(false);
+  });
+
+  // The regression that silently broke the whole liveness-climb test wall
+  // (deterministic-turn-liveness.md Phase 4a): the climb card carries the
+  // two-line `renderActivityHeader`, which the pure-arrow predicate could
+  // never match — so it was classified as the answer and every climb test
+  // exited vacuously. isActivityFeedMessage must now recognise the header.
+  it("matches the Phase-1 climb card (two-line header + Working… body)", () => {
+    expect(
+      isActivityFeedMessage(feed("🤖 Agent\n12s · 0 tools\n→ Working…")),
+    ).toBe(true);
+    expect(
+      isActivityFeedMessage(feed("🤖 Agent\n2m05s · 0 tools\n→ Working…")),
+    ).toBe(true);
+  });
+
+  it("matches a headered narration card (header + narrated → step)", () => {
+    expect(
+      isActivityFeedMessage(feed("🤖 Agent\n18s · 2 tools\n✓ Checking the hostname\n→ Writing the file")),
+    ).toBe(true);
+  });
+});
+
+describe("isLivenessCardMessage", () => {
+  it("matches the climbing Working… card (running header)", () => {
+    expect(isLivenessCardMessage(feed("🤖 Agent\n12s · 0 tools\n→ Working…"))).toBe(true);
+    expect(isLivenessCardMessage(feed("🤖 Agent\n1m41s · 3 tools\n→ Working…"))).toBe(true);
+  });
+
+  it("matches the done header shape", () => {
+    expect(isLivenessCardMessage(feed("🤖 Agent\ndone · 3 tools · 41s\n✓ Ran the check"))).toBe(true);
+  });
+
+  it("matches a header with a description on line 1", () => {
+    expect(isLivenessCardMessage(feed("🤖 Agent · summarising the logs\n8s · 1 tool\n→ Working…"))).toBe(true);
+  });
+
+  it("does NOT match a plain reply", () => {
+    expect(isLivenessCardMessage(feed("done! I created the file and listed it."))).toBe(false);
+  });
+
+  it("does NOT match a reply that opens with an emoji but is prose", () => {
+    expect(
+      isLivenessCardMessage(feed("🤖 Agent here — I finished the task.\nAll four steps done.")),
+    ).toBe(false);
+  });
+
+  it("does NOT match when prose follows the header", () => {
+    expect(
+      isLivenessCardMessage(feed("🤖 Agent\n12s · 0 tools\nHere is your answer.")),
+    ).toBe(false);
+  });
+
+  it("does NOT match a bare single header line", () => {
+    expect(isLivenessCardMessage(feed("🤖 Agent"))).toBe(false);
+  });
+});
+
+describe("isFrameworkFallbackText", () => {
+  it("flags the mid-turn / dark-turn fallback wording", () => {
+    expect(isFrameworkFallbackText("⚠️ still working… (no update from agent in 5 min)")).toBe(true);
+    expect(isFrameworkFallbackText("The agent finished working but didn't send a reply.")).toBe(true);
+    expect(isFrameworkFallbackText("I'm blocked — waiting for your approval to proceed.")).toBe(true);
+  });
+
+  it("does NOT flag an ordinary answer", () => {
+    expect(isFrameworkFallbackText("Done — I created /tmp/foo and wrote a file in it.")).toBe(false);
   });
 });

--- a/telegram-plugin/uat/scenarios/fuzz-liveness-climb-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/fuzz-liveness-climb-dm.test.ts
@@ -19,18 +19,21 @@
  * see the RFC's Known gaps / follow-up list, where this limitation is named
  * explicitly rather than left implicit.
  *
- * Each case fires a turn shape, watches the SAME two invariants the keystone
- * (Phase 1) and the dark-turn guard (Phase 2) promise on the real surface:
+ * Each case fires a turn shape and watches the two Phase-1 (keystone)
+ * invariants on the real surface — this is a climb/dead-air fuzz, NOT a
+ * dark-turn fuzz (the dark-turn at-most-once latch is proven in the
+ * `silent-end-recovery-{dm,channel}` scenarios, not here):
  *
  *   - dead air between VISIBLE updates (card edits, narration, or the final
  *     answer) never exceeds `MAX_DEAD_AIR_MS` — generous slack over the
  *     ~6-12s Phase-1 bound to absorb live Bot API + model latency jitter;
- *   - zero mid-turn device buzz (no non-final message with `silent===false`).
+ *   - zero mid-turn erosion: no non-final message with `silent===false`, and
+ *     no framework fallback TEXT send masquerading as the answer.
  */
 
 import { describe, expect, it } from "vitest";
 import { spinUp } from "../harness.js";
-import { isActivityFeedMessage } from "../assertions.js";
+import { isActivityFeedMessage, isFrameworkFallbackText } from "../assertions.js";
 import type { ObservedMessage } from "../driver.js";
 
 const MAX_DEAD_AIR_MS = 25_000; // generous slack over the ~6-12s Phase-1 bound
@@ -107,6 +110,13 @@ describe("uat-fuzz: liveness dead-air bound across a handful of turn shapes (Pha
               continue;
             }
             if (m.edited) continue;
+            // A framework fallback TEXT send is a mid-turn erosion, not the
+            // answer — never let it be swallowed as the reply (else a re-added
+            // "still working…" ping would pass this fuzz vacuously).
+            if (isFrameworkFallbackText(m.text)) {
+              loudMidTurn = loudMidTurn ?? m;
+              continue;
+            }
             if (!answer && m.text.trim().length > 0) {
               answer = m;
               const gap = now - lastVisibleAt;

--- a/telegram-plugin/uat/scenarios/jtbd-liveness-climb-channel.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-liveness-climb-channel.test.ts
@@ -6,7 +6,12 @@
  * Production-readiness: "every signal is proven in both DM and forum
  * channel"). Phase 1's climb is keyed on the SAME `feedHeartbeatTick` /
  * `runSilentTurnHeartbeatTick` path regardless of chat type — this scenario
- * proves the card edits land in a supergroup too, not just a DM.
+ * proves the card edits land, CLIMB, and stay ping-free in a supergroup too,
+ * not just a DM. It is brought to full parity with the DM twin: it parses the
+ * elapsed suffix, asserts non-decreasing climb, and HARD-FAILS on a frozen
+ * card (zero edits across a clearly-long silent tool) — the exact freeze this
+ * fix exists to detect. (Previously it only warned "INCONCLUSIVE" on a freeze,
+ * so it could never catch the regression it exists for.)
  *
  * Self-skips green when no test supergroup is wired (`SWITCHROOM_UAT_CHAT_ID`
  * unset / unresolvable) — mirrors the existing channel-twin convention (see
@@ -18,14 +23,14 @@
 
 import { describe, expect, it } from "vitest";
 import { spinUp } from "../harness.js";
-import { expectMessage, isActivityFeedMessage } from "../assertions.js";
+import { isActivityFeedMessage, isFrameworkFallbackText } from "../assertions.js";
 import type { ObservedMessage } from "../driver.js";
 
 const AGENT = "test-harness";
 const SUPERGROUP_ID = Number.parseInt(process.env.SWITCHROOM_UAT_CHAT_ID ?? "", 10);
 
 const MIN_CLIMB_EDITS = 4;
-const OVERALL_BUDGET_MS = 150_000;
+const OVERALL_BUDGET_MS = 160_000;
 const SILENT_TOOL_SECONDS = 40;
 
 const SILENT_TOOL_PROMPT =
@@ -35,9 +40,19 @@ const SILENT_TOOL_PROMPT =
   "no intermediate messages. Only after the sleep completes, reply with a " +
   "one-line confirmation that you waited.";
 
+/** Parse the `Working · Ns` (or `· Nm Ss`) elapsed suffix out of a card body.
+ *  Returns null when the shape isn't present. Mirrors the DM twin. */
+function parseElapsedSeconds(text: string): number | null {
+  const m = text.match(/(?:^|\s)·\s*(?:(\d+)\s*m)?\s*(\d+)\s*s\b/i);
+  if (!m) return null;
+  const minutes = m[1] ? Number.parseInt(m[1], 10) : 0;
+  const seconds = Number.parseInt(m[2], 10);
+  return minutes * 60 + seconds;
+}
+
 describe("uat: deterministic turn liveness — silent-tool card climb (channel parity)", () => {
   it(
-    "climbs the activity card in a supergroup the same way it does in a DM",
+    "climbs the activity card in a supergroup ≥4 times with non-decreasing elapsed, no mid-turn ping",
     async () => {
       if (!Number.isFinite(SUPERGROUP_ID)) {
         console.warn("[liveness-climb-channel] SWITCHROOM_UAT_CHAT_ID unset — skipping");
@@ -51,63 +66,123 @@ describe("uat: deterministic turn liveness — silent-tool card climb (channel p
           return;
         }
 
+        const iter = sc.driver
+          .observeMessages(SUPERGROUP_ID)
+          [Symbol.asyncIterator]();
+
         await sc.driver.sendText(SUPERGROUP_ID, SILENT_TOOL_PROMPT);
         const sentAt = Date.now();
+        console.log("[liveness-climb-channel] prompt sent; watching card edits…");
 
-        // First observation of the card — proves it opens in the channel.
-        const firstCard = await expectMessage(
-          sc.driver,
-          SUPERGROUP_ID,
-          (m: ObservedMessage) => isActivityFeedMessage(m),
-          { timeout: 30_000, senderFilter: { notUserId: sc.driverUserId } },
-        );
-        console.log(
-          `[liveness-climb-channel] card opened at +${Date.now() - sentAt}ms (id=${firstCard.messageId}): ` +
-            JSON.stringify(firstCard.text.slice(0, 100)),
-        );
+        let cardMessageId: number | null = null;
+        const elapsedSamples: number[] = [];
+        let cardEditCount = 0;
+        let answer: ObservedMessage | null = null;
+        let otherLoudMessage: ObservedMessage | null = null;
 
-        // Poll the SAME card by id at intervals across the silent window,
-        // checking the body actually changes (climbs) rather than freezing.
-        const samples: string[] = [firstCard.text];
-        const pollDeadline = Date.now() + (SILENT_TOOL_SECONDS + 20) * 1000;
-        let lastText = firstCard.text;
-        let changeCount = 0;
-        while (Date.now() < pollDeadline && changeCount < MIN_CLIMB_EDITS) {
-          await new Promise((r) => setTimeout(r, 6_000));
-          const cur = await sc.driver.getMessage(SUPERGROUP_ID, firstCard.messageId);
-          if (cur == null) continue;
-          if (cur.text !== lastText) {
-            changeCount++;
-            lastText = cur.text;
-            samples.push(cur.text);
-            console.log(
-              `[liveness-climb-channel] card changed (#${changeCount}) at +${Date.now() - sentAt}ms: ` +
-                JSON.stringify(cur.text.slice(0, 100)),
-            );
+        const deadline = Date.now() + 110_000;
+        while (Date.now() < deadline) {
+          if (answer && cardEditCount >= MIN_CLIMB_EDITS) break;
+          const remaining = deadline - Date.now();
+          const next = await Promise.race([
+            iter.next(),
+            new Promise<{ done: true; value: undefined }>((r) =>
+              setTimeout(() => r({ done: true, value: undefined }), Math.max(0, remaining)),
+            ),
+          ]);
+          if (next.done || next.value == null) break;
+          const m = next.value as ObservedMessage;
+          if (m.senderUserId === sc.driverUserId) continue;
+
+          if (isActivityFeedMessage(m)) {
+            if (cardMessageId == null) cardMessageId = m.messageId;
+            if (m.messageId === cardMessageId && m.edited) {
+              cardEditCount++;
+              const secs = parseElapsedSeconds(m.text);
+              if (secs != null) elapsedSamples.push(secs);
+              console.log(
+                `[liveness-climb-channel] card edit #${cardEditCount} at +${Date.now() - sentAt}ms: ` +
+                  JSON.stringify(m.text.slice(0, 100)),
+              );
+            }
+            if (m.edited && m.silent === false) otherLoudMessage = otherLoudMessage ?? m;
+            continue;
           }
+
+          if (m.edited) continue;
+          // A framework fallback TEXT send is a mid-turn erosion, not the
+          // completion proof — reject it from the answer lane (see DM twin).
+          if (isFrameworkFallbackText(m.text)) {
+            otherLoudMessage = otherLoudMessage ?? m;
+            continue;
+          }
+          if (!answer && m.text.trim().length > 0) {
+            answer = m;
+            console.log(`[liveness-climb-channel] answer at +${Date.now() - sentAt}ms.`);
+            continue;
+          }
+          if (m.silent === false) otherLoudMessage = otherLoudMessage ?? m;
+        }
+        await iter.return?.();
+
+        // No mid-turn erosion: the climb is edit-only in a supergroup too.
+        expect(
+          otherLoudMessage,
+          `a mid-turn message eroded the ping-free/edit-only guarantee in the ` +
+            `supergroup (loud ping or framework fallback text): ` +
+            JSON.stringify(otherLoudMessage?.text?.slice(0, 120)),
+        ).toBeNull();
+
+        if (cardEditCount === 0 && cardMessageId == null) {
+          console.warn(
+            "[liveness-climb-channel] INCONCLUSIVE — no activity card observed at all " +
+              "(the model may have narrated, or the turn completed too fast).",
+          );
+          expect(answer, "even in the inconclusive branch the turn must complete").not.toBeNull();
+          return;
         }
 
-        if (changeCount === 0) {
+        if (cardEditCount > 0 && cardEditCount < MIN_CLIMB_EDITS) {
           console.warn(
-            "[liveness-climb-channel] INCONCLUSIVE — card body never changed across the " +
-              "silent window (model may have narrated a tool label, taking the labelled " +
-              "heartbeat path with different cadence). Not a hard failure on its own.",
+            `[liveness-climb-channel] INCONCLUSIVE — card edited ${cardEditCount} time(s), ` +
+              `below the ${MIN_CLIMB_EDITS} target (model may have narrated a tool label ` +
+              "partway through, handing to the labelled-feed heartbeat).",
           );
-        } else if (changeCount < MIN_CLIMB_EDITS) {
-          console.warn(
-            `[liveness-climb-channel] INCONCLUSIVE — only ${changeCount} change(s) observed ` +
-              `(< ${MIN_CLIMB_EDITS} target).`,
-          );
+        } else {
+          expect(
+            cardEditCount,
+            `HARD FAIL — the silent tool ran ~${SILENT_TOOL_SECONDS}s in a supergroup but the ` +
+              `activity card edited only ${cardEditCount} time(s) (< ${MIN_CLIMB_EDITS}). This is ` +
+              "the pre-Phase-1 freeze regression, in the channel surface.",
+          ).toBeGreaterThanOrEqual(MIN_CLIMB_EDITS);
         }
 
-        // Final answer resumes in the same chat — parity + completion proof.
-        const done = await expectMessage(
-          sc.driver,
-          SUPERGROUP_ID,
-          /\S/,
-          { timeout: 60_000, senderFilter: { notUserId: sc.driverUserId } },
-        );
-        expect(done.chatId).toBe(SUPERGROUP_ID);
+        // Climbing property: elapsed samples must be non-decreasing…
+        for (let i = 1; i < elapsedSamples.length; i++) {
+          expect(
+            elapsedSamples[i],
+            `elapsed suffix went backwards/froze across edits: ${JSON.stringify(elapsedSamples)}`,
+          ).toBeGreaterThanOrEqual(elapsedSamples[i - 1]);
+        }
+        // …and must actually climb across the full window (frozen == the freeze
+        // this fix closes; backs the job-spec Prove-it claim).
+        if (elapsedSamples.length >= MIN_CLIMB_EDITS) {
+          expect(
+            elapsedSamples[elapsedSamples.length - 1],
+            `HARD FAIL — the elapsed suffix never advanced across ${elapsedSamples.length} ` +
+              `card edits in the supergroup (frozen at ${JSON.stringify(elapsedSamples)}).`,
+          ).toBeGreaterThan(elapsedSamples[0]);
+        }
+
+        // Completion proof: an ANSWER (not the card itself) resumes in the same
+        // chat. Guarding on `!isActivityFeedMessage` stops the old
+        // `expectMessage(SUPERGROUP_ID, /\S/)` from matching a card edit and
+        // declaring the turn done while the agent was still climbing.
+        expect(
+          answer,
+          "FAIL — no answer (distinct from the activity card) arrived within budget; the turn may be wedged.",
+        ).not.toBeNull();
+        expect(answer?.chatId).toBe(SUPERGROUP_ID);
       } finally {
         await sc.tearDown();
       }

--- a/telegram-plugin/uat/scenarios/jtbd-liveness-climb-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-liveness-climb-dm.test.ts
@@ -45,7 +45,7 @@
 
 import { describe, expect, it } from "vitest";
 import { spinUp } from "../harness.js";
-import { isActivityFeedMessage } from "../assertions.js";
+import { isActivityFeedMessage, isFrameworkFallbackText } from "../assertions.js";
 import type { ObservedMessage } from "../driver.js";
 
 const MIN_CLIMB_EDITS = 4;
@@ -123,6 +123,20 @@ describe("uat: deterministic turn liveness — silent-tool card climb (DM)", () 
           }
 
           if (m.edited) continue;
+          // Attributable-answer gate: a framework mid-turn/dark-turn fallback
+          // TEXT send (the exact #2667 erosion this wall guards against — a
+          // re-added "still working…" ping) must NOT be swallowed as the
+          // turn's answer. Classify it as a mid-turn erosion regardless of its
+          // silent flag, so the first loud mid-turn message trips the
+          // assertion instead of masquerading as the reply.
+          if (isFrameworkFallbackText(m.text)) {
+            otherLoudMessage = otherLoudMessage ?? m;
+            console.log(
+              `[liveness-climb-dm] framework fallback text mid-turn at +${Date.now() - sentAt}ms: ` +
+                JSON.stringify(m.text.slice(0, 120)),
+            );
+            continue;
+          }
           if (!answer && m.text.trim().length > 0) {
             answer = m;
             console.log(`[liveness-climb-dm] answer at +${Date.now() - sentAt}ms.`);
@@ -136,10 +150,14 @@ describe("uat: deterministic turn liveness — silent-tool card climb (DM)", () 
         }
         await iter.return?.();
 
-        // No mid-turn notification ping, on the card OR any other message.
+        // No mid-turn erosion: neither a device-buzzing ping (silent=false on
+        // a non-final message) NOR a framework fallback TEXT send (a
+        // "still working…"-class mid-turn message — the climb is an edit-only
+        // card, never a text send).
         expect(
           otherLoudMessage,
-          `a mid-turn message pinged the user's device (silent=false): ` +
+          `a mid-turn message eroded the ping-free/edit-only guarantee ` +
+            `(loud ping or framework fallback text): ` +
             JSON.stringify(otherLoudMessage?.text?.slice(0, 120)),
         ).toBeNull();
 
@@ -171,12 +189,25 @@ describe("uat: deterministic turn liveness — silent-tool card climb (DM)", () 
         }
 
         // Climbing property: elapsed samples must be non-decreasing (never
-        // freezes/rewinds across edits of the same card).
+        // rewinds across edits of the same card)…
         for (let i = 1; i < elapsedSamples.length; i++) {
           expect(
             elapsedSamples[i],
             `elapsed suffix went backwards/froze across edits: ${JSON.stringify(elapsedSamples)}`,
           ).toBeGreaterThanOrEqual(elapsedSamples[i - 1]);
+        }
+        // …and, when we have the full climb (≥MIN_CLIMB_EDITS parsed samples),
+        // it must actually CLIMB — a frozen/repeated elapsed value across all
+        // edits is the exact pre-Phase-1 freeze and a hard failure (this backs
+        // the job-spec Prove-it claim; non-decreasing alone would pass a
+        // frozen card).
+        if (elapsedSamples.length >= MIN_CLIMB_EDITS) {
+          expect(
+            elapsedSamples[elapsedSamples.length - 1],
+            `HARD FAIL — the elapsed suffix never advanced across ${elapsedSamples.length} ` +
+              `card edits (frozen at ${JSON.stringify(elapsedSamples)}). A repeated elapsed ` +
+              "value across all edits is the pre-Phase-1 freeze this fix closes.",
+          ).toBeGreaterThan(elapsedSamples[0]);
         }
 
         expect(answer, "FAIL — no answer arrived within budget; the turn may be wedged.").not.toBeNull();

--- a/telegram-plugin/uat/scenarios/jtbd-liveness-narration-channel.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-liveness-narration-channel.test.ts
@@ -2,18 +2,21 @@
  * Narrated mid-turn work still shows words on the card — CHANNEL twin of
  * `jtbd-liveness-narration-dm.test.ts` (Phase 4a, `deterministic-turn-liveness.md`).
  *
- * Surface parity bar per the job spec. Self-skips green when no test
- * supergroup is wired.
+ * Surface parity bar per the job spec. Like the DM twin (and unlike the
+ * previous version of this file), it also asserts the no-mid-turn-ping
+ * invariant inline — the RFC and job spec claim the ping-free assertion is
+ * baked into EVERY liveness scenario, DM and channel alike. Self-skips green
+ * when no test supergroup is wired.
  */
 
 import { describe, expect, it } from "vitest";
 import { spinUp } from "../harness.js";
-import { expectMessage, isActivityFeedMessage } from "../assertions.js";
+import { isActivityFeedMessage, isFrameworkFallbackText } from "../assertions.js";
 import type { ObservedMessage } from "../driver.js";
 
 const AGENT = "test-harness";
 const SUPERGROUP_ID = Number.parseInt(process.env.SWITCHROOM_UAT_CHAT_ID ?? "", 10);
-const OVERALL_BUDGET_MS = 140_000;
+const OVERALL_BUDGET_MS = 150_000;
 
 const NARRATED_WORK_PROMPT =
   "Do four short steps, ONE AT A TIME. Before EACH step, write a brief " +
@@ -22,9 +25,27 @@ const NARRATED_WORK_PROMPT =
   "run the step via Bash (`sleep 3` is fine as the step body). After all " +
   "four steps, send a one-line final summary reply.";
 
+/** Body (narration/tool) lines of a card, minus header + climb placeholder.
+ *  Mirrors the DM twin's `narratedBodyLines`. */
+function narratedBodyLines(text: string): string[] {
+  return text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+    .map((l) => l.replace(/^[→✓↳]+\s*/u, "").trim())
+    .filter(
+      (l) =>
+        l.length > 0 &&
+        !/^(?:🤖|🛠[️]?|⚙[️]?)\s/u.test(l) &&
+        !/^(?:(?:\d+m)?\d+s\s*·\s*\d+\s+tools?|(?:done|failed)\s*·)/iu.test(l) &&
+        !/^Working(?:\s*[·…]|$)/i.test(l) &&
+        !/^\+?\d+\s+earlier/i.test(l),
+    );
+}
+
 describe("uat: deterministic turn liveness — narration lands mid-turn (channel parity)", () => {
   it(
-    "the model's own words appear on the activity card mid-turn, in a supergroup",
+    "the model's own words appear on the activity card mid-turn in a supergroup, with no mid-turn ping",
     async () => {
       if (!Number.isFinite(SUPERGROUP_ID)) {
         console.warn("[liveness-narration-channel] SWITCHROOM_UAT_CHAT_ID unset — skipping");
@@ -38,28 +59,75 @@ describe("uat: deterministic turn liveness — narration lands mid-turn (channel
           return;
         }
 
+        const iter = sc.driver
+          .observeMessages(SUPERGROUP_ID)
+          [Symbol.asyncIterator]();
+
         await sc.driver.sendText(SUPERGROUP_ID, NARRATED_WORK_PROMPT);
         const sentAt = Date.now();
 
-        const card = await expectMessage(
-          sc.driver,
-          SUPERGROUP_ID,
-          (m: ObservedMessage) => isActivityFeedMessage(m) && !/^Working(\s*[·…]|$)/i.test(m.text.trim()),
-          { timeout: 60_000, senderFilter: { notUserId: sc.driverUserId } },
-        );
-        console.log(
-          `[liveness-narration-channel] narrated card content at +${Date.now() - sentAt}ms (id=${card.messageId}): ` +
-            JSON.stringify(card.text.slice(0, 140)),
-        );
-        expect(card.chatId).toBe(SUPERGROUP_ID);
+        const narrationSamples: string[] = [];
+        let answer: ObservedMessage | null = null;
+        let otherLoudMessage: ObservedMessage | null = null;
 
-        const answer = await expectMessage(
-          sc.driver,
-          SUPERGROUP_ID,
-          /\S/,
-          { timeout: 60_000, senderFilter: { notUserId: sc.driverUserId } },
-        );
-        expect(answer.chatId).toBe(SUPERGROUP_ID);
+        const deadline = Date.now() + 100_000;
+        while (Date.now() < deadline) {
+          if (answer) break;
+          const remaining = deadline - Date.now();
+          const next = await Promise.race([
+            iter.next(),
+            new Promise<{ done: true; value: undefined }>((r) =>
+              setTimeout(() => r({ done: true, value: undefined }), Math.max(0, remaining)),
+            ),
+          ]);
+          if (next.done || next.value == null) break;
+          const m = next.value as ObservedMessage;
+          if (m.senderUserId === sc.driverUserId) continue;
+
+          if (isActivityFeedMessage(m)) {
+            const narrated = narratedBodyLines(m.text);
+            if (narrated.length > 0) {
+              narrationSamples.push(narrated.join(" | "));
+              console.log(
+                `[liveness-narration-channel] narrated card content at +${Date.now() - sentAt}ms: ` +
+                  JSON.stringify(narrated.join(" | ").slice(0, 140)),
+              );
+            }
+            if (m.edited && m.silent === false) otherLoudMessage = otherLoudMessage ?? m;
+            continue;
+          }
+          if (m.edited) continue;
+          if (isFrameworkFallbackText(m.text)) {
+            otherLoudMessage = otherLoudMessage ?? m;
+            continue;
+          }
+          if (!answer && m.text.trim().length > 0) {
+            answer = m;
+            continue;
+          }
+          if (m.silent === false) otherLoudMessage = otherLoudMessage ?? m;
+        }
+        await iter.return?.();
+
+        // No-mid-turn-ping invariant, inline in the channel twin too.
+        expect(
+          otherLoudMessage,
+          `a mid-turn message eroded the ping-free/edit-only guarantee in the supergroup: ` +
+            JSON.stringify(otherLoudMessage?.text?.slice(0, 120)),
+        ).toBeNull();
+
+        if (narrationSamples.length === 0) {
+          console.warn(
+            "[liveness-narration-channel] INCONCLUSIVE — no narrated content observed on the " +
+              "card (model may have batched steps or the turn was too fast).",
+          );
+        }
+
+        expect(
+          answer,
+          "FAIL — no answer (distinct from the activity card) arrived within budget; the turn may be wedged.",
+        ).not.toBeNull();
+        expect(answer?.chatId).toBe(SUPERGROUP_ID);
       } finally {
         await sc.tearDown();
       }

--- a/telegram-plugin/uat/scenarios/jtbd-liveness-narration-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-liveness-narration-dm.test.ts
@@ -17,8 +17,36 @@
 
 import { describe, expect, it } from "vitest";
 import { spinUp } from "../harness.js";
-import { isActivityFeedMessage } from "../assertions.js";
+import { isActivityFeedMessage, isFrameworkFallbackText } from "../assertions.js";
 import type { ObservedMessage } from "../driver.js";
+
+/**
+ * Extract the narration/tool body lines of an activity card, dropping the
+ * two-line header (`🤖 Agent` / `<elapsed> · <N> tools`) and the bare
+ * `Working…` placeholder the 0-label climb paints. Whatever remains is
+ * model-authored narration or tool labels — the content this scenario proves
+ * still lands on the card mid-turn.
+ */
+function narratedBodyLines(text: string): string[] {
+  return text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+    // strip glyphs so a `→ Working…` placeholder compares as `Working…`
+    .map((l) => l.replace(/^[→✓↳]+\s*/u, "").trim())
+    .filter(
+      (l) =>
+        l.length > 0 &&
+        // header line 1 (emoji + label, optional description)
+        !/^(?:🤖|🛠[️]?|⚙[️]?)\s/u.test(l) &&
+        // header line 2 (elapsed · tools, running or done)
+        !/^(?:(?:\d+m)?\d+s\s*·\s*\d+\s+tools?|(?:done|failed)\s*·)/iu.test(l) &&
+        // the bare climb placeholder is NOT narration
+        !/^Working(?:\s*[·…]|$)/i.test(l) &&
+        // rolling-overflow header is not narration
+        !/^\+?\d+\s+earlier/i.test(l),
+    );
+}
 
 const OVERALL_BUDGET_MS = 130_000;
 
@@ -62,19 +90,27 @@ describe("uat: deterministic turn liveness — narration lands mid-turn (DM)", (
           if (m.senderUserId === sc.driverUserId) continue;
 
           if (isActivityFeedMessage(m)) {
-            // Anything on the card that ISN'T the bare "Working…" placeholder
-            // or a "Working · Ns" climb suffix is model narration.
-            if (!/^Working(\s*[·…]|$)/i.test(m.text.trim())) {
-              narrationSamples.push(m.text);
+            // The card carries the two-line header + (climb placeholder |
+            // narrated body). Any body line that ISN'T the header or the bare
+            // "Working…" placeholder is model narration landing mid-turn.
+            const narrated = narratedBodyLines(m.text);
+            if (narrated.length > 0) {
+              narrationSamples.push(narrated.join(" | "));
               console.log(
                 `[liveness-narration-dm] narrated card content at +${Date.now() - sentAt}ms: ` +
-                  JSON.stringify(m.text.slice(0, 140)),
+                  JSON.stringify(narrated.join(" | ").slice(0, 140)),
               );
             }
             if (m.edited && m.silent === false) otherLoudMessage = otherLoudMessage ?? m;
             continue;
           }
           if (m.edited) continue;
+          // A framework fallback TEXT send is a mid-turn erosion, not the
+          // answer — reject it from the answer lane so it trips the assertion.
+          if (isFrameworkFallbackText(m.text)) {
+            otherLoudMessage = otherLoudMessage ?? m;
+            continue;
+          }
           if (!answer && m.text.trim().length > 0) {
             answer = m;
             continue;
@@ -94,9 +130,13 @@ describe("uat: deterministic turn liveness — narration lands mid-turn (DM)", (
               "card (model may have batched steps or the turn was too fast). Not " +
               "necessarily a regression — but worth a human look if this recurs.",
           );
-        } else {
-          expect(narrationSamples.length).toBeGreaterThan(0);
         }
+        // (No tautological `expect(narrationSamples.length).toBeGreaterThan(0)`
+        //  in the else-branch — it was asserting a condition the branch already
+        //  guarantees. The meaningful signals are the ping-free assertion above
+        //  and the answer-arrived assertion below; narration presence is
+        //  logged, not force-asserted, since a live model may legitimately
+        //  batch its steps.)
 
         expect(answer, "FAIL — no answer arrived within budget; the turn may be wedged.").not.toBeNull();
       } finally {

--- a/telegram-plugin/uat/scenarios/silent-end-recovery-channel.test.ts
+++ b/telegram-plugin/uat/scenarios/silent-end-recovery-channel.test.ts
@@ -7,14 +7,18 @@
  * Phase 2 (already shipped) hardens `recordUndeliveredTurnEnd` /
  * `SILENT_END_FALLBACK_TEXT` as the ONE deterministic guard for a turn that
  * ends having delivered no reply. This scenario proves it fires — at most
- * once — for the same tool-heavy prompt shape, in a supergroup.
+ * once — for the same tool-heavy prompt shape, in a supergroup, AND that no
+ * mid-turn device ping is emitted before the terminal reply/fallback (the
+ * ping-free invariant the RFC/job spec claim is inline in every scenario).
+ * The terminal dark-turn fallback itself is a sanctioned loud unwedge send, so
+ * only pings STRICTLY BEFORE the terminal message count as erosion.
  *
  * Self-skips green when no test supergroup is wired.
  */
 
 import { describe, it, expect } from "vitest";
 import { spinUp } from "../harness.js";
-import { expectMessage } from "../assertions.js";
+import { expectMessage, isActivityFeedMessage } from "../assertions.js";
 import type { ObservedMessage } from "../driver.js";
 
 const AGENT = "test-harness";
@@ -27,7 +31,7 @@ const TOOL_HEAVY_PROMPT =
 
 describe("uat: silent-end recovery (channel parity)", () => {
   it(
-    "user asks in a supergroup → agent always replies exactly once via the fallback ladder if needed",
+    "user asks in a supergroup → agent replies exactly once via the fallback ladder if needed, no mid-turn ping",
     async () => {
       if (!Number.isFinite(SUPERGROUP_ID)) {
         console.warn("[silent-end-recovery-channel] SWITCHROOM_UAT_CHAT_ID unset — skipping");
@@ -41,24 +45,65 @@ describe("uat: silent-end recovery (channel parity)", () => {
           return;
         }
 
+        const iter = sc.driver
+          .observeMessages(SUPERGROUP_ID)
+          [Symbol.asyncIterator]();
+
         await sc.driver.sendText(SUPERGROUP_ID, TOOL_HEAVY_PROMPT);
+        const sentAt = Date.now();
 
         // Same budget rationale as the DM twin: covers normal latency, one
         // Stop-hook re-prompt cycle, and the worst-case 300s framework
-        // fallback.
-        const reply = await expectMessage(
-          sc.driver,
-          SUPERGROUP_ID,
-          /\S/,
-          { timeout: 320_000, senderFilter: { notUserId: sc.driverUserId } },
-        );
-        expect(reply.text.length).toBeGreaterThan(0);
-        expect(reply.chatId).toBe(SUPERGROUP_ID);
+        // fallback. We observe the whole window so we can assert the ping-free
+        // invariant BEFORE the terminal reply, not just wait for the reply.
+        let reply: ObservedMessage | null = null;
+        let midTurnPing: ObservedMessage | null = null;
 
-        if (/no update from agent|didn't send a reply/i.test(reply.text)) {
+        const deadline = Date.now() + 320_000;
+        while (Date.now() < deadline) {
+          if (reply) break;
+          const remaining = deadline - Date.now();
+          const next = await Promise.race([
+            iter.next(),
+            new Promise<{ done: true; value: undefined }>((r) =>
+              setTimeout(() => r({ done: true, value: undefined }), Math.max(0, remaining)),
+            ),
+          ]);
+          if (next.done || next.value == null) break;
+          const m = next.value as ObservedMessage;
+          if (m.senderUserId === sc.driverUserId) continue;
+
+          // Card edits are the sanctioned mid-turn liveness surface (silent by
+          // construction) — skip them from the ping accounting.
+          if (isActivityFeedMessage(m)) {
+            if (m.edited && m.silent === false) midTurnPing = midTurnPing ?? m;
+            continue;
+          }
+          if (m.edited) continue;
+          // First substantive non-card bot message is the terminal reply
+          // (model answer OR the dark-turn fallback — both terminal, both may
+          // legitimately ping).
+          if (m.text.trim().length > 0) {
+            reply = m;
+            continue;
+          }
+        }
+
+        expect(
+          midTurnPing,
+          `a mid-turn message pinged the device BEFORE the terminal reply in the supergroup: ` +
+            JSON.stringify(midTurnPing?.text?.slice(0, 120)),
+        ).toBeNull();
+
+        expect(reply, "FAIL — no reply arrived within budget; the silent-end guard may have regressed.").not.toBeNull();
+        expect(reply!.text.length).toBeGreaterThan(0);
+        expect(reply!.chatId).toBe(SUPERGROUP_ID);
+        console.log(`[silent-end-recovery-channel] reply at +${Date.now() - sentAt}ms.`);
+
+        if (/no update from agent|didn't send a reply/i.test(reply!.text)) {
           console.warn(
             "[silent-end-recovery-channel] reply was the framework/dark-turn fallback — " +
-              `model never replied on its own. Reply text: ${JSON.stringify(reply.text.slice(0, 200))}`,
+              `model never replied on its own. Reply text: ${JSON.stringify(reply!.text.slice(0, 200))}`,
           );
 
           // Exactly-once proof: no SECOND fallback-shaped message should
@@ -80,6 +125,8 @@ describe("uat: silent-end recovery (channel parity)", () => {
               "(the `exhausted` latch should give fire-once)",
           ).toBeNull();
         }
+
+        await iter.return?.();
       } finally {
         await sc.tearDown();
       }

--- a/telegram-plugin/uat/scenarios/silent-end-recovery-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/silent-end-recovery-dm.test.ts
@@ -34,6 +34,7 @@
 
 import { describe, it, expect } from "vitest";
 import { spinUp } from "../harness.js";
+import type { ObservedMessage } from "../driver.js";
 
 // The prompt pushes the model into a tool-heavy state where it has
 // produced "an answer" internally but hasn't yet realised it must
@@ -77,12 +78,33 @@ describe("uat: silent-end recovery", () => {
         // fallback wording ("still working… (no update from agent
         // in N min)") that means the silent-end loop fired AND the
         // model didn't recover. Acceptable outcome — the user got
-        // something — but a design-health alarm. Log it.
-        if (/no update from agent/i.test(reply.text)) {
+        // something — but a design-health alarm. Log it AND assert the
+        // `exhausted` latch gave fire-once (transport-side), matching the
+        // channel twin exactly — the job-spec Prove-it claim is
+        // "asserted transport-side in a DM AND a supergroup alike", so the
+        // DM twin must make the same exactly-once assertion, not just warn.
+        if (/no update from agent|didn't send a reply/i.test(reply.text)) {
           console.warn(
             `[silent-end-recovery] reply was the framework fallback — `
             + `model never replied on its own. Reply text: ${JSON.stringify(reply.text.slice(0, 200))}`,
           );
+
+          // No SECOND fallback-shaped message should follow within a short
+          // window (the `exhausted` latch gives fire-once).
+          let secondFallback: ObservedMessage | null = null;
+          try {
+            secondFallback = await sc.expectMessage(
+              /no update from agent|didn't send a reply/i,
+              { from: "bot", timeout: 15_000 },
+            );
+          } catch {
+            // Timeout is the expected/good outcome — no second fallback fired.
+          }
+          expect(
+            secondFallback,
+            "the dark-turn/framework fallback fired MORE than once for the same turn "
+            + "(the `exhausted` latch should give fire-once)",
+          ).toBeNull();
         }
       } finally {
         await sc.tearDown();


### PR DESCRIPTION
## What & why

The Phase-4a liveness UAT test wall could never fire. `isActivityFeedMessage`
classified a message as the activity card only when **every** non-empty line
matched `/^[→✓]\s/`, but the Phase-1 climb card carries the two-line
`renderActivityHeader` (`🤖 Agent` / `12s · 0 tools`). So the predicate returned
`false` for every climb/liveness card, the card was consumed as the "answer",
`cardEditCount` stayed 0, and all six scenarios exited through their
INCONCLUSIVE/vacuous branches — their hard-fail-on-a-freeze was unreachable.
This is how the bug shipped: authored-but-not-run tests.

## Changes

- **`assertions.ts`** — new strict `isLivenessCardMessage` (both header lines
  must match their exact shape; a real reply that merely contains an arrow or
  leads with an emoji is never misclassified). `isActivityFeedMessage` now
  accepts either the header-less pure-arrow feed OR the headered card. Added
  `isFrameworkFallbackText` to reject a mid-turn "still working…" send from the
  answer lane.
- **climb-dm / climb-channel** — attributable answer (a framework fallback text
  send now trips the ping-free assertion instead of masquerading as the reply);
  assert the elapsed actually **climbs** across the window (frozen/repeated =
  hard failure); channel twin brought to full DM parity (parse elapsed,
  hard-fail on a frozen card, completion proof no longer matches the card).
- **narration-dm / narration-channel** — fixed header-broken narration
  detection; added the inline no-mid-turn-ping assertion to the channel twin;
  dropped the tautological narration-count assertion.
- **silent-end-recovery-dm** — upgraded from warn-only to the same
  transport-side exactly-once (`exhausted` latch) assertion the channel twin
  makes. **silent-end-recovery-channel** — added the no-mid-turn-ping assertion.
- **feed-matcher.test.ts** — CI-verifiable unit coverage for the header-aware
  predicate, `isLivenessCardMessage`, and `isFrameworkFallbackText`.

## Deterministic-guarantee delta (CONTRIBUTING step 8)

**No change to any framework guarantee.** This PR touches only
`telegram-plugin/uat/` (the test wall and its matcher) — no production
liveness surface (`feedHeartbeatTick`, `feed-open-gate.ts`, `silence-poke.ts`,
`turn-liveness-floor.ts`, the card-edit path) is modified. The framework still
delivers, without the model, exactly what it did before: the climbing card edit
on a silent tool and the one-shot dark-turn fallback. What changes is that the
outcome wall can now **observe** those guarantees instead of passing vacuously.

## Test plan

- `bun test telegram-plugin/uat/feed-matcher.test.ts` — 23 pass (predicate +
  fallback detector).
- `tsc --noEmit` — clean.
- **Live UAT (the six scenarios): NOT run — see the "Live UAT status" note in
  the handback.** The three channel twins self-skip without
  `SWITCHROOM_UAT_CHAT_ID` (the `telegram-uat-chat-id` grant was unavailable in
  the authoring environment), and the DM twins send real Telegram messages +
  consume real subscription quota on `test-harness`, which needs an operator
  go-ahead. **Do not merge on authored-but-not-run tests** — that is how the
  original bug shipped. Run `bun test telegram-plugin/uat/scenarios/jtbd-liveness-*.test.ts`
  against the wired `uat-host` before merge and paste the output here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
