### PR TITLE
fix(worktree): make #2893 sub-agent ownership predicate fail closed, not open

### DIFF
--- a/reference/rfcs/deterministic-turn-liveness.md
+++ b/reference/rfcs/deterministic-turn-liveness.md
@@ -390,7 +390,19 @@ the file that already owns "what we look for in PRs".
    addition to `agentCwd`. Genuinely foreign project dirs (not a slug the
    agent's own `agentCwd` or a worktree it owns maps to) are still
    skipped — the #1116 protection is preserved, not widened to a wildcard
-   watch.
+   watch. The ownership predicate is fail-CLOSED, hardened by a review
+   follow-up (`telegram-plugin/worktree-watch-cwds.ts`,
+   `ownedWorktreeCwds`): an unset/empty `SWITCHROOM_AGENT_NAME` contributes
+   NOTHING (a naive `ownerAgent === undefined` would otherwise match every
+   ownerless host-global record — reintroducing #1116), a registry read
+   failure yields `[]` without disturbing the base `agentCwd` watch, and the
+   owned paths are `realpathSync`'d so a symlinked base
+   (`/tmp`→`/private/tmp`) derives the physical slug Claude Code actually
+   mints. Complementarily, `claimWorktree` (`src/worktree/claim.ts`) now
+   defaults `ownerAgent` from `SWITCHROOM_AGENT_NAME` so a plain
+   `worktree claim` (no `-a/--agent`) still produces an OWNED record —
+   without it, an ownerless claim would be filtered out and the sub-agent
+   would stay invisible, the very Gap-2 failure this closes.
 
 Gap 1 is pre-existing and orthogonal to the climb, named here so the
 guarantee is not read as broader than delivered. It needs its own

--- a/src/worktree/claim.ts
+++ b/src/worktree/claim.ts
@@ -171,6 +171,18 @@ export async function claimWorktree(
     mkdirSync(baseDir, { recursive: true });
     worktreePath = join(baseDir, `${id}-${taskSuffix}`);
 
+    // Default ownership from the ambient agent identity when the caller
+    // didn't pass one explicitly. A worktree an agent claims WITHOUT the CLI
+    // `-a/--agent` flag would otherwise produce an ownerless record, which the
+    // gateway's `extraWatchCwdsProvider` filters out — so the sub-agent running
+    // in it stays invisible in the worker feed (Known-Gap-2 regression). An
+    // agent always claims its own worktrees, so `SWITCHROOM_AGENT_NAME` is the
+    // correct owner when no explicit owner is given. Empty string is treated as
+    // unset (never write a falsy owner).
+    const ambientOwner = process.env.SWITCHROOM_AGENT_NAME;
+    const ownerAgent =
+      input.ownerAgent ?? (ambientOwner != null && ambientOwner !== "" ? ambientOwner : undefined);
+
     const now = new Date().toISOString();
     const record = {
       id,
@@ -180,7 +192,7 @@ export async function claimWorktree(
       path: worktreePath,
       createdAt: now,
       heartbeatAt: now,
-      ownerAgent: input.ownerAgent,
+      ownerAgent,
     };
 
     // ATOMIC: write registry record BEFORE git operation.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -567,6 +567,7 @@ import {
   type SubagentWatcherHandle,
 } from '../subagent-watcher.js'
 import { listRecords as listWorktreeRecords } from '../../src/worktree/registry.js'
+import { ownedWorktreeCwds } from '../worktree-watch-cwds.js'
 import {
   startBootCard,
   resolvePersonaName,
@@ -26437,15 +26438,16 @@ void (async () => {
               // Best-effort: a registry read failure (e.g. no worktree dir
               // on an agent that never claims one) must not affect the
               // primary agentCwd watch.
-              extraWatchCwdsProvider: () => {
-                try {
-                  return listWorktreeRecords()
-                    .filter((r) => r.ownerAgent === process.env.SWITCHROOM_AGENT_NAME)
-                    .map((r) => r.path)
-                } catch {
-                  return []
-                }
-              },
+              extraWatchCwdsProvider: () =>
+                // Fail-CLOSED ownership filter (unset identity ⇒ nothing;
+                // ownerless records excluded; registry throw ⇒ []). Extracted
+                // to telegram-plugin/worktree-watch-cwds.ts so the #1116 /
+                // Gap-2 ownership predicate is under direct unit test — see
+                // telegram-plugin/tests/worktree-watch-cwds.test.ts.
+                ownedWorktreeCwds({
+                  self: process.env.SWITCHROOM_AGENT_NAME,
+                  listRecords: listWorktreeRecords,
+                }),
               // Bug 0 fix: previously omitted, leaving the watcher unable to
               // write liveness/stall/turn_end updates to the registry DB.
               // Liveness writes are now persisted across the gateway lifetime.

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -1732,6 +1732,12 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     // worktrees) must never break the tail loop, so it just yields no
     // extra slugs for this tick.
     let allowedSlugs: Set<string> | null = null
+    // Did the extra-cwd provider run cleanly this tick? A transient failure
+    // (registry read hiccup) must NOT permanently mislabel an owned worktree
+    // slug as "foreign": we still skip it this tick (it isn't provably ours
+    // right now), but we do NOT latch the one-shot warning, so the next clean
+    // tick re-includes and re-derives it instead of staying silently excluded.
+    let providerOk = true
     if (expectedProjectSlug != null) {
       allowedSlugs = new Set([expectedProjectSlug])
       if (extraWatchCwdsProvider != null) {
@@ -1740,6 +1746,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
             allowedSlugs.add(sanitizeCwdToProjectName(cwd))
           }
         } catch (err) {
+          providerOk = false
           log?.(`subagent-watcher: extraWatchCwdsProvider error: ${(err as Error).message}`)
         }
       }
@@ -1751,12 +1758,19 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       // Skip foreign project dirs so their stale subagent JSONLs (which
       // Claude Code reaps mid-session) don't pollute the watcher's registry.
       if (allowedSlugs != null && !allowedSlugs.has(pDir)) {
-        if (!warnedForeignSlugs.has(pDir)) {
+        // A slug that is now allowed must clear any stale "foreign" latch, so a
+        // slug that was transiently excluded (or later genuinely goes foreign)
+        // re-warns rather than staying mislabeled forever.
+        if (providerOk && !warnedForeignSlugs.has(pDir)) {
           warnedForeignSlugs.add(pDir)
-          log?.(`subagent-watcher: skipping foreign project dir ${pDir} (expected ${expectedProjectSlug})`)
+          const allowed = [...allowedSlugs].join(', ')
+          log?.(`subagent-watcher: skipping foreign project dir ${pDir} (allowed: ${allowed})`)
         }
         continue
       }
+      // Owned/allowed this tick — drop any prior foreign latch so a future
+      // genuine foreign appearance of the same slug re-warns.
+      warnedForeignSlugs.delete(pDir)
       const projectPath = join(projectsRoot, pDir)
       let sessionDirs: string[]
       try {

--- a/telegram-plugin/tests/worktree-watch-cwds.test.ts
+++ b/telegram-plugin/tests/worktree-watch-cwds.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Ownership predicate for the worktree-isolated cwds the subagent-watcher
+ * additionally watches (deterministic-turn-liveness.md Known Gap 2 / #2893
+ * review fix). Pins the fail-CLOSED behaviour: the review found the closure
+ * both FAILED OPEN (unset identity matched every ownerless record — the #1116
+ * leak reintroduced) and FAILED CLOSED (a plain `worktree claim` produced an
+ * ownerless record filtered out, so the sub-agent stayed invisible — Gap 2).
+ *
+ * Run with:
+ *   bun test telegram-plugin/tests/worktree-watch-cwds.test.ts
+ */
+import { describe, it, expect } from "vitest";
+import {
+  ownedWorktreeCwds,
+  type WorktreeOwnershipRecord,
+} from "../worktree-watch-cwds.js";
+
+const idPath = (p: string) => p; // identity realpath for deterministic tests
+
+describe("ownedWorktreeCwds", () => {
+  const records: WorktreeOwnershipRecord[] = [
+    { path: "/wt/mine-1", ownerAgent: "klanker" },
+    { path: "/wt/mine-2", ownerAgent: "klanker" },
+    { path: "/wt/theirs", ownerAgent: "reggie" },
+    { path: "/wt/ownerless" }, // ownerAgent undefined
+  ];
+
+  it("returns NOTHING when the agent identity is unset (fail-closed, no #1116 leak)", () => {
+    expect(
+      ownedWorktreeCwds({ self: undefined, listRecords: () => records, realpath: idPath }),
+    ).toEqual([]);
+  });
+
+  it("returns NOTHING when the agent identity is empty string", () => {
+    expect(
+      ownedWorktreeCwds({ self: "", listRecords: () => records, realpath: idPath }),
+    ).toEqual([]);
+  });
+
+  it("does NOT match ownerless records even when identity is set", () => {
+    const out = ownedWorktreeCwds({ self: "klanker", listRecords: () => records, realpath: idPath });
+    expect(out).not.toContain("/wt/ownerless");
+    expect(out).not.toContain("/wt/theirs");
+  });
+
+  it("includes exactly the records this agent owns", () => {
+    expect(
+      ownedWorktreeCwds({ self: "klanker", listRecords: () => records, realpath: idPath }),
+    ).toEqual(["/wt/mine-1", "/wt/mine-2"]);
+  });
+
+  it("returns [] when the registry read throws (best-effort; base watch undisturbed)", () => {
+    expect(
+      ownedWorktreeCwds({
+        self: "klanker",
+        listRecords: () => {
+          throw new Error("registry unavailable");
+        },
+        realpath: idPath,
+      }),
+    ).toEqual([]);
+  });
+
+  it("realpaths owned paths (symlinked-base slug fix), falling back on failure", () => {
+    const out = ownedWorktreeCwds({
+      self: "klanker",
+      listRecords: () => [
+        { path: "/tmp/mine", ownerAgent: "klanker" },
+        { path: "/gone/mine", ownerAgent: "klanker" },
+      ],
+      realpath: (p) => {
+        if (p === "/tmp/mine") return "/private/tmp/mine";
+        throw new Error("ENOENT");
+      },
+    });
+    expect(out).toEqual(["/private/tmp/mine", "/gone/mine"]);
+  });
+
+  it("two-tick mutation: a fresh claim/release is picked up without restart", () => {
+    // The provider is re-invoked every rescan tick, so a mutating registry
+    // (claim adds an owned record; release removes it) must be reflected
+    // tick-over-tick with no process restart.
+    let live: WorktreeOwnershipRecord[] = [{ path: "/wt/a", ownerAgent: "klanker" }];
+    const provider = () =>
+      ownedWorktreeCwds({ self: "klanker", listRecords: () => live, realpath: idPath });
+
+    // Tick 1: one owned worktree.
+    expect(provider()).toEqual(["/wt/a"]);
+
+    // Claim a second (as the ambient owner would default via SWITCHROOM_AGENT_NAME).
+    live = [
+      { path: "/wt/a", ownerAgent: "klanker" },
+      { path: "/wt/b", ownerAgent: "klanker" },
+    ];
+    // Tick 2: both picked up, no restart.
+    expect(provider()).toEqual(["/wt/a", "/wt/b"]);
+
+    // Release the first.
+    live = [{ path: "/wt/b", ownerAgent: "klanker" }];
+    // Tick 3: reflects the release.
+    expect(provider()).toEqual(["/wt/b"]);
+  });
+});

--- a/telegram-plugin/worktree-watch-cwds.ts
+++ b/telegram-plugin/worktree-watch-cwds.ts
@@ -1,0 +1,60 @@
+/**
+ * Ownership filter for the worktree-isolated cwds the subagent-watcher should
+ * additionally watch (deterministic-turn-liveness.md Known Gap 2 + the #2893
+ * ownership-predicate review fix).
+ *
+ * A sub-agent dispatched into a `switchroom worktree claim` cwd runs under a
+ * different project-dir slug than the agent's own `agentCwd`, so the #1116
+ * foreign-slug filter would skip it forever unless the watcher also watches
+ * the slugs of worktrees THIS agent owns. This helper derives that set from
+ * the host-global worktree registry, and it is deliberately fail-CLOSED:
+ *
+ *   - Unset/empty identity ⇒ contribute NOTHING. `ownerAgent` is optional in
+ *     the registry, so a naive `r.ownerAgent === process.env.SWITCHROOM_AGENT_NAME`
+ *     with the env var unset becomes `undefined === undefined` and matches
+ *     every OWNERLESS record in the host-global registry — including other
+ *     agents' worktrees. That is precisely the #1116 leak the filter exists to
+ *     prevent, reintroduced by failing OPEN. With no identity we cannot prove
+ *     ownership of anything, so we return `[]`.
+ *   - A registry read failure ⇒ `[]` (best-effort; never disturb the base
+ *     agentCwd watch).
+ *   - Owner match ⇒ include, realpath'd. Claude Code mints the project slug off
+ *     the process's PHYSICAL cwd, so a symlinked base (macOS `/tmp` →
+ *     `/private/tmp`) would otherwise derive a slug that misses the physical
+ *     one; realpath best-effort, falling back to the raw path.
+ */
+import { realpathSync } from "node:fs";
+
+export interface WorktreeOwnershipRecord {
+  path: string;
+  ownerAgent?: string;
+}
+
+export interface OwnedWorktreeCwdsOptions {
+  /** The agent's identity — `process.env.SWITCHROOM_AGENT_NAME`. */
+  self: string | undefined;
+  /** The host-global registry read (`listRecords` from src/worktree/registry). */
+  listRecords: () => WorktreeOwnershipRecord[];
+  /** Injectable for tests; defaults to `fs.realpathSync`. */
+  realpath?: (p: string) => string;
+}
+
+export function ownedWorktreeCwds(opts: OwnedWorktreeCwdsOptions): string[] {
+  const { self } = opts;
+  if (self == null || self === "") return [];
+  const rp = opts.realpath ?? realpathSync;
+  try {
+    return opts
+      .listRecords()
+      .filter((r) => r.ownerAgent === self)
+      .map((r) => {
+        try {
+          return rp(r.path);
+        } catch {
+          return r.path;
+        }
+      });
+  } catch {
+    return [];
+  }
+}

--- a/tests/worktree.claim-integration.test.ts
+++ b/tests/worktree.claim-integration.test.ts
@@ -96,6 +96,48 @@ describe("claim / release / list integration", () => {
     expect(recs).toHaveLength(3);
   });
 
+  it("defaults ownerAgent from SWITCHROOM_AGENT_NAME when the flag is omitted (Gap-2 fix)", async () => {
+    // A plain `switchroom worktree claim <repo>` (no -a/--agent) inside an
+    // agent container must still produce an OWNED record, else the gateway's
+    // ownership filter hides the sub-agent's liveness. #2893 review fix.
+    const origName = process.env.SWITCHROOM_AGENT_NAME;
+    process.env.SWITCHROOM_AGENT_NAME = "klanker";
+    try {
+      await claimWorktree({ repo: repoDir, taskName: "owned-by-default" });
+      const rec = listRecords().find((r) => r.branch.includes("owned-by-default"));
+      expect(rec?.ownerAgent).toBe("klanker");
+    } finally {
+      if (origName === undefined) delete process.env.SWITCHROOM_AGENT_NAME;
+      else process.env.SWITCHROOM_AGENT_NAME = origName;
+    }
+  });
+
+  it("an explicit ownerAgent still wins over the ambient default", async () => {
+    const origName = process.env.SWITCHROOM_AGENT_NAME;
+    process.env.SWITCHROOM_AGENT_NAME = "klanker";
+    try {
+      await claimWorktree({ repo: repoDir, taskName: "explicit-owner", ownerAgent: "reggie" });
+      const rec = listRecords().find((r) => r.branch.includes("explicit-owner"));
+      expect(rec?.ownerAgent).toBe("reggie");
+    } finally {
+      if (origName === undefined) delete process.env.SWITCHROOM_AGENT_NAME;
+      else process.env.SWITCHROOM_AGENT_NAME = origName;
+    }
+  });
+
+  it("leaves ownerAgent unset when neither flag nor env is present", async () => {
+    const origName = process.env.SWITCHROOM_AGENT_NAME;
+    delete process.env.SWITCHROOM_AGENT_NAME;
+    try {
+      await claimWorktree({ repo: repoDir, taskName: "no-owner" });
+      const rec = listRecords().find((r) => r.branch.includes("no-owner"));
+      expect(rec?.ownerAgent).toBeUndefined();
+    } finally {
+      if (origName === undefined) delete process.env.SWITCHROOM_AGENT_NAME;
+      else process.env.SWITCHROOM_AGENT_NAME = origName;
+    }
+  });
+
   it("list_worktrees shows all active claims", async () => {
     await claimWorktree({ repo: repoDir, taskName: "task-a", ownerAgent: "worker1" });
     await claimWorktree({ repo: repoDir, taskName: "task-b", ownerAgent: "worker2" });


### PR DESCRIPTION
## What & why

The #2893 `extraWatchCwdsProvider` closure filtered worktree records with
`r.ownerAgent === process.env.SWITCHROOM_AGENT_NAME`, which broke **both ways**:

- **Fails open:** `ownerAgent` is optional. With `SWITCHROOM_AGENT_NAME` unset
  (tolerated elsewhere in the gateway), `undefined === undefined` matched every
  ownerless record in the host-global registry — including other agents'
  worktrees. This is the #1116 widening the #2893 PR claimed impossible.
- **Fails closed:** `claimWorktree` only set `ownerAgent` when the CLI got
  `-a/--agent`. A worktree an agent claimed without the flag produced an
  ownerless record, was filtered out, and the sub-agent stayed invisible — the
  Known-Gap-2 failure reintroduced.

## Changes

- Extracted the closure to `telegram-plugin/worktree-watch-cwds.ts`
  (`ownedWorktreeCwds`) so it is under direct unit test: unset/empty identity ⇒
  `[]`; ownerless/foreign records excluded; registry throw ⇒ `[]` without
  disturbing the base `agentCwd` watch; owned paths `realpathSync`'d so a
  symlinked base (`/tmp`→`/private/tmp`) derives the physical slug Claude Code
  mints.
- `claimWorktree` now defaults `ownerAgent` from `SWITCHROOM_AGENT_NAME` so
  plain claims are owned (explicit `-a/--agent` still wins).
- `subagent-watcher`: don't permanently latch a "foreign project dir" warning
  when the provider transiently failed (`warnedForeignSlugs` never cleared);
  clear the latch when a slug becomes allowed; log the allowed **set** (expected
  is now a set, not a single slug). [Fix 4]
- RFC Known-Gap-2 text updated to declare the fail-closed hardening.

## Deterministic-guarantee delta (CONTRIBUTING step 8)

This touches the sub-agent-visibility half of the liveness surface (the
`extraWatchCwdsProvider` the subagent-watcher consumes). **Guarantee narrowed
to what it always intended, and made honest:** the framework watches — without
the model — the worker-feed / `subagentActivityAt` liveness of sub-agents in
worktree cwds **this agent provably owns**, and *only* those. Before: an unset
identity silently widened the watch to every ownerless (and other-agent)
worktree (guarantee too broad / a leak). After: unset identity contributes
nothing (fail-closed), and a plain `worktree claim` now yields an owned record
so its sub-agent is actually covered (the guarantee is now delivered for the
common case it was silently dropping). No new send, no new surface, no ping.

## Test plan

- `bun test telegram-plugin/tests/worktree-watch-cwds.test.ts` — 7 pass
  (fail-open/closed + two-tick mutating provider).
- `vitest run tests/worktree.claim-integration.test.ts` — 11 pass (ownership
  defaulting: env default, explicit override, neither-set).
- `bun test telegram-plugin/tests/subagent-watcher-*.test.ts` — 17 pass.
- `tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
