### PR TITLE
fix(liveness): harden #2895 orphan-card reaper + declare honest at-most-once

### DIFF
--- a/reference/rfcs/deterministic-turn-liveness.md
+++ b/reference/rfcs/deterministic-turn-liveness.md
@@ -357,20 +357,35 @@ the file that already owns "what we look for in PRs".
 
 1. ~~**Restart mid-turn.**~~ **Closed** by a follow-up PR
    (`telegram-plugin/gateway/activity-card-store.ts` + gateway wiring in
-   `telegram-plugin/gateway/gateway.ts`). Deterministic guarantee added: no
-   card orphaned by a gateway restart stays visually frozen (or pinned) —
-   it is finalized with one honest edit, and unpinned, on the very next
-   boot. The minimal card handle (chatId, threadId, activityMessageId,
-   startedAt, pinned) is persisted to `TELEGRAM_STATE_DIR/activity-cards-
-   pending.json` the moment a card OPENs and cleared the moment it closes
-   normally — mirroring `status-pin-store.ts`'s durable-snapshot shape
-   byte-for-byte. On boot, after winning the startup mutex (same ordering
-   constraint as `statusPinBootCleanup`), a one-shot, model-free reaper
-   reads any leftover record, deletes it from disk BEFORE attempting its
-   edit/unpin (the idempotency guard — a second boot performs zero edits
-   and zero unpins), and finalizes the orphaned card with a single
-   `editMessageText` (never a new message — no ping) plus an
-   `unpinChatMessage` for cards that were pinned on open. The resumed turn
+   `telegram-plugin/gateway/gateway.ts`). Deterministic guarantee added
+   (**AT-MOST-ONCE**, be precise about it): a card orphaned by a gateway
+   restart is finalized with one honest edit, and unpinned, on the next boot —
+   **best-effort, not guaranteed-delivered**. The reaper deletes each record
+   BEFORE attempting its edit and does NOT retry, so if that single edit fails
+   (flood-wait exhausted, transient 5xx, chat momentarily unreachable) the
+   orphan is **forfeit** and stays frozen. This is a deliberate trade: a
+   retry-until-success design cannot preserve the second-boot-zero-edits
+   idempotency property across a crash between a successful edit and its
+   post-edit delete (that window would re-edit an already-finalized card), and
+   a stale re-finalize on a chat the user has moved on from is worse than one
+   frozen orphan. So the honest promise is "finalized AT MOST ONCE, on the next
+   boot, best-effort", NOT "finalized on the very next boot". The minimal card
+   handle (chatId, threadId, activityMessageId, startedAt, pinned) is persisted
+   to `TELEGRAM_STATE_DIR/activity-cards-pending.json` the moment a card OPENs
+   (with `pinned` mirroring the ACTUAL pin decision — `PIN_STATUS_WHILE_WORKING`
+   — not an unconditional `true`) and cleared, ID-SCOPED (so a fresh live turn
+   that upserts under the same topic key mid-reap keeps its own record — the
+   reap-race guard), the moment it closes normally — mirroring
+   `status-pin-store.ts`'s durable-snapshot shape. On boot, after winning the
+   startup mutex (same ordering constraint as `statusPinBootCleanup`), a
+   one-shot, model-free reaper reads any leftover record, deletes it from disk
+   BEFORE attempting its edit/unpin (the idempotency guard — a second boot
+   performs zero edits and zero unpins), and finalizes the orphaned card with a
+   single `editMessageText` (never a new message — no ping) plus an
+   `unpinChatMessage` for cards that were actually pinned on open (the reaper's
+   unpin is defense-in-depth; `statusPinBootCleanup` owns the primary unpin). A
+   benign-400 (card already deleted) is reported as `vanished`, not counted as a
+   finalize, so the boot log doesn't over-report the guarantee. The resumed turn
    (if any) is NOT made to resume climbing the old card — it opens its own
    fresh card; honest finalization, not resumption, was the goal. Scoped
    out: the standalone worker-activity-feed's `messageId` (a separate,

--- a/telegram-plugin/gateway/activity-card-store.ts
+++ b/telegram-plugin/gateway/activity-card-store.ts
@@ -26,12 +26,23 @@
  * fails open to `[]` — never crashes boot, worst case an orphan isn't cleaned
  * up this boot, no worse than pre-fix behaviour.
  *
- * Idempotency: the reaper deletes a record from the on-disk store BEFORE
- * attempting its finalizing edit (not after), so a crash mid-reap, or a
- * second boot re-reading the file, can never double-edit the same message. A
- * failed edit (message already deleted, chat gone, etc.) is swallowed — the
- * record is already gone from disk regardless of whether the edit itself
- * succeeded.
+ * DELIVERED GUARANTEE — AT-MOST-ONCE finalization (be honest about it):
+ * the reaper deletes a record from the on-disk store BEFORE attempting its
+ * finalizing edit (not after) and swallows every Telegram failure with no
+ * retry. That ordering buys strict idempotency — a crash mid-reap, or a second
+ * boot re-reading the file, can never double-edit or double-unpin the same
+ * message — at the cost of durability: if the single edit fails (flood-wait
+ * exhausted, transient 5xx, chat momentarily unreachable), the orphaned card is
+ * FORFEIT and stays frozen, because its record is already gone. So the promise
+ * is NOT "finalized on the very next boot" — it is "finalized AT MOST ONCE, on
+ * the next boot, best-effort". We deliberately chose at-most-once over
+ * at-least-once: a retry-until-success design cannot preserve the
+ * second-boot-zero-edits property across a crash between a successful edit and
+ * its post-edit delete (that window would re-edit an already-finalized card),
+ * and a stale re-finalize on a chat the user has since moved on from is a worse
+ * failure than one frozen orphan. A benign-400 (message already
+ * deleted/vanished, or "not modified") is NOT counted as a finalize — nothing
+ * was delivered — see the `vanished` tally in `runActivityCardBootReaper`.
  */
 
 export interface ActivityCardStoreFsSeam {
@@ -155,16 +166,30 @@ export function writeActivityCardRecord(
  * Remove the card-handle row for `turnKey`, if present. Called the moment a
  * card closes/finalizes normally (clearActivitySummary), and by the boot
  * reaper (BEFORE attempting the finalizing edit — the idempotency guard).
+ *
+ * REAP-RACE guard: when `activityMessageId` is supplied, only a row matching
+ * BOTH `turnKey` AND `activityMessageId` is removed. During a slow multi-record
+ * reap (e.g. a 429 flood-wait between records), a fresh live turn can upsert a
+ * NEW record under the same `turnKey` (its own, different `activityMessageId`).
+ * A turnKey-only clear would then delete the LIVE card's durable protection.
+ * Scoping the clear to the exact message id the reaper (or the closing turn) is
+ * handling leaves the live card's record intact. Omit `activityMessageId` only
+ * when you genuinely mean "clear whatever row exists for this topic".
  */
 export function clearActivityCardRecord(
   path: string,
   fs: ActivityCardStoreFsSeam,
   turnKey: string,
+  activityMessageId?: number,
   log: (line: string) => void = (l) => process.stderr.write(l),
 ): void {
   const current = loadActivityCards(path, fs)
   if (current.length === 0) return
-  const next = current.filter((c) => c.turnKey !== turnKey)
+  const next = current.filter(
+    (c) =>
+      c.turnKey !== turnKey ||
+      (activityMessageId !== undefined && c.activityMessageId !== activityMessageId),
+  )
   if (next.length === current.length) return
   persistActivityCards(path, fs, next, log)
 }
@@ -198,24 +223,37 @@ export function clearActivityCardRecord(
 export async function runActivityCardBootReaper(args: {
   path: string
   fs: ActivityCardStoreFsSeam
+  /** Returns the Telegram result: a truthy value (the edited Message) on a
+   *  real delivered edit, or `null`/`undefined` when the underlying
+   *  `robustApiCall` swallowed a benign 400 (message already deleted /
+   *  vanished / "not modified") — i.e. nothing was actually finalized. */
   finalizeCard: (record: ActivityCardRecord) => Promise<unknown>
   unpinCard: (record: ActivityCardRecord) => Promise<unknown>
   log?: (line: string) => void
-}): Promise<{ finalized: number; unpinned: number; total: number }> {
+}): Promise<{ finalized: number; vanished: number; unpinned: number; total: number }> {
   const log = args.log ?? ((l: string) => process.stderr.write(l))
   const persisted = loadActivityCards(args.path, args.fs)
-  if (persisted.length === 0) return { finalized: 0, unpinned: 0, total: 0 }
+  if (persisted.length === 0) return { finalized: 0, vanished: 0, unpinned: 0, total: 0 }
   let finalized = 0
+  let vanished = 0
   let unpinned = 0
   for (const record of persisted) {
     // Delete BEFORE attempting the edit/unpin — the idempotency guard. If the
     // gateway crashes here, or a second boot re-reads the file, this record
     // no longer exists on disk, so it can never be finalized or unpinned
-    // twice.
-    clearActivityCardRecord(args.path, args.fs, record.turnKey, log)
+    // twice. Scoped to the exact activityMessageId (reap-race guard): a live
+    // turn that upserted a fresh card under the same turnKey mid-reap keeps
+    // its own (different-id) record.
+    clearActivityCardRecord(args.path, args.fs, record.turnKey, record.activityMessageId, log)
     try {
-      await args.finalizeCard(record)
-      finalized++
+      // Count a finalize ONLY when the edit actually landed. robustApiCall
+      // resolves to undefined on a benign-400 (the card was already deleted or
+      // the chat is gone) — that delivered nothing, so it is a `vanished`
+      // orphan, not a `finalized` one. Counting it as finalized (the pre-fix
+      // behaviour) over-reported the guarantee in the boot log.
+      const res = await args.finalizeCard(record)
+      if (res != null) finalized++
+      else vanished++
     } catch (err) {
       log(
         `activity-card-store: boot reaper finalize failed ` +
@@ -236,7 +274,7 @@ export async function runActivityCardBootReaper(args: {
       }
     }
   }
-  return { finalized, unpinned, total: persisted.length }
+  return { finalized, vanished, unpinned, total: persisted.length }
 }
 
 /**

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6140,8 +6140,11 @@ async function statusPinBootCleanup(): Promise<void> {
  * the pure `runActivityCardBootReaper` — binds the live fs seam, a real
  * Telegram edit, and the gateway logger. Finalizes ANY card left open by a
  * prior (crashed/restarted) session with ONE honest edit — never a new
- * message, so no ping — and never re-attempts across boots (the pure routine
- * deletes each record from disk before attempting its edit).
+ * message, so no ping. Guarantee is AT-MOST-ONCE: the pure routine deletes each
+ * record before attempting its edit and does not retry, so a failed edit
+ * forfeits that orphan rather than risk a double-finalize on a later boot (see
+ * the module doc in activity-card-store.ts for the full tradeoff). A benign-400
+ * (card already gone) is reported as `vanished`, not `finalized`.
  *
  * MUST run ONLY after this gateway wins the startup mutex (the store is a
  * shared per-agent file; a losing double-boot would finalize a card the
@@ -6152,14 +6155,19 @@ async function statusPinBootCleanup(): Promise<void> {
  * turn (if any) opens its own fresh card. Honest finalization, not
  * resumption, is the goal (see the module doc in activity-card-store.ts).
  *
- * After the finalizing edit, also unpins the card (every fresh card is
- * silently pinned on open, `reconcileStatusPin('fg:'+key, …)`) — a frozen
- * card that's ALSO still pinned is a worse orphan, glued to the top of the
- * chat forever. Only attempted for a record with `pinned: true`.
+ * After the finalizing edit, also unpins the card, but ONLY for a record whose
+ * persisted `pinned` flag is true — i.e. the card was actually pin-eligible on
+ * open (`PIN_STATUS_WHILE_WORKING`). This unpin is DEFENSE-IN-DEPTH, not the
+ * primary unpin path: `statusPinBootCleanup` already unpins orphaned status
+ * pins from its own durable store on boot. The reaper's unpin is belt-and-
+ * braces for the case where the two stores disagree; the record's `pinned`
+ * flag must therefore reflect the ACTUAL pin outcome (see the open path), not
+ * an unconditional `true`, or the reaper would attempt an unpin on a card that
+ * was never pinned.
  */
 async function activityCardBootReaper(): Promise<void> {
   if (!activityCardPersistEnabled) return
-  const { finalized, unpinned, total } = await runActivityCardBootReaper({
+  const { finalized, vanished, unpinned, total } = await runActivityCardBootReaper({
     path: ACTIVITY_CARD_STORE_PATH,
     fs: activityCardStoreFs,
     finalizeCard: (record) =>
@@ -6189,8 +6197,9 @@ async function activityCardBootReaper(): Promise<void> {
   })
   if (total > 0) {
     process.stderr.write(
-      `telegram gateway: activity-card: finalized ${finalized}/${total}, ` +
-        `unpinned ${unpinned}/${total} orphaned card(s) from a prior session\n`,
+      `telegram gateway: activity-card: finalized ${finalized}/${total} ` +
+        `(vanished ${vanished}/${total}), unpinned ${unpinned}/${total} ` +
+        `orphaned card(s) from a prior session (at-most-once)\n`,
     )
   }
 }
@@ -12648,10 +12657,16 @@ async function drainActivitySummary(
               threadId: thread ?? null,
               activityMessageId: sent.message_id,
               startedAt: turn.startedAt,
-              // The OPEN below unconditionally silently-pins the fresh card
-              // (`reconcileStatusPin('fg:'+key, …)`) — mirror that here so
-              // the boot reaper knows to unpin it too, not just finalize it.
-              pinned: true,
+              // Mirror the ACTUAL pin decision, not an unconditional `true`:
+              // the OPEN below silently-pins the fresh card only when
+              // `PIN_STATUS_WHILE_WORKING` is on (`reconcileStatusPin` no-ops
+              // when it's off, and can also fail on missing supergroup
+              // rights). Persisting `pinned: true` regardless would make the
+              // boot reaper attempt an unpin on a card that was never pinned.
+              // The reaper's unpin is defense-in-depth anyway
+              // (`statusPinBootCleanup` owns the primary unpin), so tracking
+              // the flag honestly is what matters here.
+              pinned: PIN_STATUS_WHILE_WORKING,
             })
           }
           // Status-pin: the per-turn status message just opened — it's the
@@ -13003,6 +13018,10 @@ function clearActivitySummary(turn: CurrentTurn, finalHtmlOverride?: string | nu
         ACTIVITY_CARD_STORE_PATH,
         activityCardStoreFs,
         statusKey(chat, thread),
+        // Scope to this card's exact id (reap-race guard): only drop the row
+        // for the card THIS turn is closing, never a fresher card another
+        // turn may have already upserted under the same topic key.
+        id,
       )
     }
     if (CLEAR_STATUS_ON_COMPLETION) {

--- a/telegram-plugin/tests/activity-card-store.test.ts
+++ b/telegram-plugin/tests/activity-card-store.test.ts
@@ -199,6 +199,9 @@ describe('runActivityCardBootReaper — transport-boundary outcome tests', () =>
           messageId: record.activityMessageId,
           text: restartOrphanCardFinalizeText(record.startedAt),
         })
+        // A truthy result models a REAL delivered edit (grammy returns the
+        // edited Message); a benign-400 would resolve to undefined instead.
+        return { message_id: record.activityMessageId }
       },
       unpinCard: async (record) => {
         unpins.push({ chatId: record.chatId, messageId: record.activityMessageId })
@@ -214,7 +217,7 @@ describe('runActivityCardBootReaper — transport-boundary outcome tests', () =>
     expect(unpins).toHaveLength(1)
     expect(unpins[0]).toEqual({ chatId: '-100123', messageId: 715 })
 
-    expect(res).toEqual({ finalized: 1, unpinned: 1, total: 1 })
+    expect(res).toEqual({ finalized: 1, vanished: 0, unpinned: 1, total: 1 })
     // Record gone — nothing left for a future boot to re-finalize.
     expect(loadActivityCards(PATH, fs)).toEqual([])
   })
@@ -231,6 +234,7 @@ describe('runActivityCardBootReaper — transport-boundary outcome tests', () =>
       fs,
       finalizeCard: async () => {
         edits++
+        return { ok: true }
       },
       unpinCard: async () => {
         unpins++
@@ -245,6 +249,7 @@ describe('runActivityCardBootReaper — transport-boundary outcome tests', () =>
       fs,
       finalizeCard: async () => {
         edits++
+        return { ok: true }
       },
       unpinCard: async () => {
         unpins++
@@ -252,7 +257,7 @@ describe('runActivityCardBootReaper — transport-boundary outcome tests', () =>
     })
     expect(edits).toBe(1) // unchanged
     expect(unpins).toBe(1) // unchanged
-    expect(res2).toEqual({ finalized: 0, unpinned: 0, total: 0 })
+    expect(res2).toEqual({ finalized: 0, vanished: 0, unpinned: 0, total: 0 })
   })
 
   it('a record with pinned:false (or absent) is finalized but never unpinned', async () => {
@@ -262,7 +267,7 @@ describe('runActivityCardBootReaper — transport-boundary outcome tests', () =>
     const res = await runActivityCardBootReaper({
       path: PATH,
       fs,
-      finalizeCard: async () => {},
+      finalizeCard: async () => ({ ok: true }),
       unpinCard: async () => {
         unpins++
       },
@@ -279,12 +284,13 @@ describe('runActivityCardBootReaper — transport-boundary outcome tests', () =>
       fs,
       finalizeCard: async () => {
         calls++
+        return { ok: true }
       },
       unpinCard: async () => {
         calls++
       },
     })
-    expect(res).toEqual({ finalized: 0, unpinned: 0, total: 0 })
+    expect(res).toEqual({ finalized: 0, vanished: 0, unpinned: 0, total: 0 })
     expect(calls).toBe(0)
   })
 
@@ -302,7 +308,7 @@ describe('runActivityCardBootReaper — transport-boundary outcome tests', () =>
         unpinCalled = true
       },
     })
-    expect(res).toEqual({ finalized: 0, unpinned: 1, total: 1 })
+    expect(res).toEqual({ finalized: 0, vanished: 0, unpinned: 1, total: 1 })
     expect(unpinCalled).toBe(true)
     expect(loadActivityCards(PATH, fs)).toEqual([])
   })
@@ -316,12 +322,13 @@ describe('runActivityCardBootReaper — transport-boundary outcome tests', () =>
       fs,
       finalizeCard: async () => {
         editCalls++
+        return { ok: true }
       },
       unpinCard: async () => {
         throw new Error('message to unpin not found')
       },
     })
-    expect(res).toEqual({ finalized: 1, unpinned: 0, total: 1 })
+    expect(res).toEqual({ finalized: 1, vanished: 0, unpinned: 0, total: 1 })
     expect(editCalls).toBe(1)
     expect(loadActivityCards(PATH, fs)).toEqual([])
   })
@@ -337,12 +344,13 @@ describe('runActivityCardBootReaper — transport-boundary outcome tests', () =>
       fs,
       finalizeCard: async (r) => {
         edited.push(r.activityMessageId)
+        return { message_id: r.activityMessageId }
       },
       unpinCard: async (r) => {
         unpinned.push(r.activityMessageId)
       },
     })
-    expect(res).toEqual({ finalized: 2, unpinned: 2, total: 2 })
+    expect(res).toEqual({ finalized: 2, vanished: 0, unpinned: 2, total: 2 })
     expect(edited.sort()).toEqual([1, 2])
     expect(unpinned.sort()).toEqual([1, 2])
     expect(loadActivityCards(PATH, fs)).toEqual([])
@@ -363,6 +371,53 @@ describe('runActivityCardBootReaper — transport-boundary outcome tests', () =>
     // At the moment finalizeCard ran, the record was ALREADY gone from disk —
     // so a crash right here (or a concurrent second boot) can never re-reap it.
     expect(onDiskDuringFinalize).toEqual([])
+  })
+
+  it('a benign-400 (finalizeCard resolves undefined) counts as vanished, not finalized', async () => {
+    const { fs } = memFs()
+    writeActivityCardRecord(PATH, fs, card({ pinned: false }))
+    // robustApiCall swallows "message to edit not found" / "not modified" and
+    // resolves to undefined — nothing was delivered, so it must not be counted
+    // as a finalize (the pre-fix boot log over-reported the guarantee).
+    const res = await runActivityCardBootReaper({
+      path: PATH,
+      fs,
+      finalizeCard: async () => undefined,
+      unpinCard: async () => {},
+    })
+    expect(res).toEqual({ finalized: 0, vanished: 1, unpinned: 0, total: 1 })
+    expect(loadActivityCards(PATH, fs)).toEqual([])
+  })
+
+  it('reap-race guard: an id-scoped clear leaves a live turn\'s fresh upsert (same turnKey) intact', async () => {
+    const { fs } = memFs()
+    // The reaper loads this OLD card (id=715) and finalizes it…
+    writeActivityCardRecord(PATH, fs, card({ turnKey: 'c:_', activityMessageId: 715 }))
+    await runActivityCardBootReaper({
+      path: PATH,
+      fs,
+      finalizeCard: async () => {
+        // …but MID-REAP (e.g. during a 429 flood-wait) a fresh live turn opens a
+        // NEW card under the same topic key (id=999). Its record must survive.
+        writeActivityCardRecord(PATH, fs, card({ turnKey: 'c:_', activityMessageId: 999 }))
+        return { ok: true }
+      },
+      unpinCard: async () => {},
+    })
+    // The id-scoped clear removed only the OLD (715) row; the live 999 row is
+    // still protected. A turnKey-only clear would have wiped it.
+    const remaining = loadActivityCards(PATH, fs)
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0]!.activityMessageId).toBe(999)
+  })
+
+  it('clearActivityCardRecord with a mismatched id is a no-op (does not drop a same-turnKey different-id row)', () => {
+    const { fs } = memFs()
+    writeActivityCardRecord(PATH, fs, card({ turnKey: 'c:_', activityMessageId: 999 }))
+    clearActivityCardRecord(PATH, fs, 'c:_', 715) // wrong id
+    expect(loadActivityCards(PATH, fs)).toHaveLength(1)
+    clearActivityCardRecord(PATH, fs, 'c:_', 999) // matching id
+    expect(loadActivityCards(PATH, fs)).toEqual([])
   })
 })
 

--- a/telegram-plugin/tests/activity-card-wiring.test.ts
+++ b/telegram-plugin/tests/activity-card-wiring.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Activity-card durability WIRING (deterministic-turn-liveness.md Known Gap 1 +
+ * the #2895 review fix). The 20 behavioural tests in activity-card-store.test.ts
+ * drive the pure store/reaper in ISOLATION — they prove the routine is correct
+ * but say nothing about whether the GATEWAY actually calls it. That is exactly
+ * the decision-vs-delivery gap the whole RFC exists to close, applied to its own
+ * follow-up: a refactor that drops the `writeActivityCardRecord` call on card
+ * open would keep every store test green while silently un-delivering the
+ * guarantee.
+ *
+ * The gateway IIFE can't be instantiated in-process (same constraint as
+ * silence-liveness-wiring.test.ts / multitopic-routing-wiring.test.ts), so these
+ * are STRUCTURAL assertions that pin the three load-bearing call sites. They
+ * COMPLEMENT (never replace) the behavioural store tests — the RFC's "structural
+ * grep may not be the SOLE coverage" bar is met because the outcome is proven at
+ * the routine level; this only guards the wiring the routine depends on.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const gatewaySrc = readFileSync(resolve(__dirname, '..', 'gateway', 'gateway.ts'), 'utf-8')
+
+function between(src: string, startMarker: string, endMarker: string): string {
+  const after = src.split(startMarker)[1] ?? ''
+  return after.split(endMarker)[0] ?? ''
+}
+
+describe('activity-card durability wiring', () => {
+  it('the card-OPEN path persists the durable handle (writeActivityCardRecord)', () => {
+    // The open branch runs when activityMessageId transitions null → set.
+    const openBranch = between(
+      gatewaySrc,
+      'if (turn.activityMessageId == null) {',
+      'turn.activityLastSentRender = target',
+    )
+    expect(openBranch.length).toBeGreaterThan(100)
+    expect(openBranch).toMatch(/writeActivityCardRecord\(/)
+    // Persist is gated on the feature flag, not unconditional.
+    expect(openBranch).toMatch(/activityCardPersistEnabled/)
+    // Pin honesty: the persisted RECORD mirrors the ACTUAL pin decision, never
+    // a bare `pinned: true` (the #2895 review fix). Scope the negative check to
+    // the writeActivityCardRecord argument block — the reconcileStatusPin call
+    // further down legitimately passes `{ pinned: true }` as the desired state.
+    const recordBlock = between(openBranch, 'writeActivityCardRecord(', 'void reconcileStatusPin(')
+    expect(recordBlock).toMatch(/pinned: PIN_STATUS_WHILE_WORKING/)
+    // Strip comment lines (the code comment legitimately quotes the old
+    // `pinned: true` shape it's warning against) before checking the CODE.
+    const recordCode = recordBlock
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('//'))
+      .join('\n')
+    expect(recordCode).not.toMatch(/pinned: true/)
+  })
+
+  it('the normal-CLOSE path clears the durable handle, id-scoped (reap-race guard)', () => {
+    const closeBody = between(
+      gatewaySrc,
+      'const id = turn.activityMessageId\n    turn.activityMessageId = null',
+      'if (CLEAR_STATUS_ON_COMPLETION)',
+    )
+    expect(closeBody.length).toBeGreaterThan(50)
+    expect(closeBody).toMatch(/clearActivityCardRecord\(/)
+    // Must pass the id so it only drops THIS card's row (not a fresher upsert).
+    expect(closeBody).toMatch(/\n\s*id,\s*\n/)
+  })
+
+  it('the boot reaper runs ONLY after the startup mutex is won (never at import time)', () => {
+    // Both invocation sites (mutex-won + mutex-fallback) sit AFTER
+    // acquireStartupLock, alongside statusPinBootCleanup.
+    const afterLock = between(gatewaySrc, 'await acquireStartupLock({', 'catch (err)')
+    expect(afterLock).toMatch(/void activityCardBootReaper\(\)/)
+    // And it must NOT be invoked at module import time — the same losing-double-
+    // boot hazard the NOTE at statusPinBootCleanup documents.
+    const beforeMain = gatewaySrc.split('await acquireStartupLock({')[0] ?? ''
+    expect(beforeMain).not.toMatch(/^\s*void activityCardBootReaper\(\)/m)
+  })
+
+  it('the reaper wrapper counts a benign-400 as vanished, not finalized (honest boot log)', () => {
+    const wrapper = between(
+      gatewaySrc,
+      'async function activityCardBootReaper()',
+      '\n// NOTE: statusPinBootCleanup()',
+    )
+    expect(wrapper).toMatch(/vanished/)
+    expect(wrapper).toMatch(/at-most-once/)
+  })
+})


### PR DESCRIPTION
## What & why

The #2895 restart-orphaned-card reaper was documented as "finalized on the very
next boot", but it deletes the record **before** editing and swallows all
Telegram failures with **no retry** — the delivered guarantee is
**at-most-once**, not guaranteed-delivered. This PR makes the semantics honest
(RFC option **a**) and closes three concrete gaps found in review.

Why option (a) not (b): a retry-until-success (mark-reaping / delete-after-edit)
design cannot preserve the second-boot-zero-edits idempotency property across a
crash between a *successful* edit and its post-edit delete — that window would
re-edit an already-finalized card. Per the RFC's own criterion, that means
option (a): declare at-most-once honestly + harden the concrete defects.

## Changes

- **Honest guarantee text** — module doc, gateway reaper doc, boot log, and RFC
  Known-Gap-1 declare at-most-once + the forfeit-on-failed-edit tradeoff.
- **Benign-400 counting** — `robustApiCall` resolves to `undefined` on a
  swallowed 400 (card already gone / not modified). The reaper counts that as
  `vanished`, not `finalized`, so the boot log stops over-reporting.
- **Reap-race fix** — `clearActivityCardRecord` is now id-scoped (turnKey AND
  activityMessageId). During a slow multi-record reap a fresh live turn can
  upsert under the same turnKey; a turnKey-only clear would delete the **live**
  card's protection. The reaper and the normal-close path both pass the id.
- **`pinned` honesty** — the open path persists `pinned: PIN_STATUS_WHILE_WORKING`
  (the actual pin decision) instead of unconditional `true`; the justification
  comment notes the reaper unpin is defense-in-depth (`statusPinBootCleanup`
  owns the primary unpin).
- **Wired-path tests** — `activity-card-wiring.test.ts` asserts the gateway
  actually persists on open, id-scoped-clears on close, and runs the reaper only
  after the startup mutex; a refactor dropping the persist call fails the suite.
  Store tests extended for vanished-counting + the reap-race guard.

## Deterministic-guarantee delta (CONTRIBUTING step 8)

Touches the card-edit / boot-reaper path. **Guarantee unchanged in mechanism,
corrected in wording, and made race-safe:** the framework still finalizes a
restart-orphaned card with **one** honest edit (never a new message — no ping),
model-free, on the next boot. The delta is honesty + safety, not scope:
(1) the promise is now stated as **at-most-once best-effort** (a failed edit
forfeits the orphan) rather than the overstated "finalized on the very next
boot"; (2) a live turn's fresh card can no longer have its durable protection
deleted by a concurrent reap (id-scoped clear); (3) the boot log no longer
counts a vanished card as finalized. No new send, no parallel surface, no
mid-turn buzz.

## Test plan

- `vitest run telegram-plugin/tests/activity-card-store.test.ts` — 23 pass
  (incl. new vanished-counting + reap-race guard).
- `vitest run telegram-plugin/tests/activity-card-wiring.test.ts` — 4 pass.
- `bun test telegram-plugin/tests/silence-liveness-wiring.test.ts` — pass.
- `tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
