### PR TITLE
fix(hindsight): P1 security — loopback compose ports, gate mental-model writes, confirm-before-legibility

### DIFF
--- a/skills/mental-model-curator/SKILL.md
+++ b/skills/mental-model-curator/SKILL.md
@@ -14,9 +14,11 @@ description: >
   user" — that lives in profile banks, so never propose an identity model here
   (the operator's review of the card, not any code guard, is the only gate — so
   it's on you to honor).
-  Do NOT use when the operator directly asks you to CREATE one specific named
-  model whose shape you know — call create_mental_model directly.
-allowed-tools: mcp__hindsight__list_banks mcp__hindsight__get_bank_stats mcp__hindsight__list_mental_models mcp__hindsight__get_mental_model mcp__hindsight__reflect mcp__hindsight__recall mcp__hindsight__create_mental_model mcp__switchroom-telegram__mental_model_propose
+  Even when the operator directly asks you to CREATE one specific named model
+  whose shape you know, PROPOSE it through the approve/deny card — never call
+  create_mental_model directly (it is not pre-approved; the propose card is the
+  only sanctioned write path, Fix 1.2 / #2903).
+allowed-tools: mcp__hindsight__list_banks mcp__hindsight__get_bank_stats mcp__hindsight__list_mental_models mcp__hindsight__get_mental_model mcp__hindsight__reflect mcp__hindsight__recall mcp__switchroom-telegram__mental_model_propose
 ---
 
 # mental-model-curator — Propose standing knowledge models from your own bank
@@ -33,8 +35,9 @@ job is to make each proposal so obviously right that a glance is enough.
 
 ## Why propose instead of create
 
-You have direct `create_mental_model` access. This skill deliberately routes
-through `mcp__switchroom-telegram__mental_model_propose` instead, because a
+You do NOT have direct `create_mental_model` access — it is deliberately not
+pre-approved (Fix 1.2 / #2903). Every mental-model write routes through
+`mcp__switchroom-telegram__mental_model_propose`, because a
 standing model is a persistent, always-in-context artifact with real cost
 (recall/reflect spend, and — if `refresh_after_consolidation` is on — invisible
 post-consolidation spend). A human should decide which of those the agent runs.

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -947,13 +947,75 @@ const SWITCHROOM_TELEGRAM_MCP_TOOLS = [
 ];
 
 /**
- * Pre-approved MCP tool names for the Hindsight memory server.
- * When the memory backend is hindsight we pre-approve the wildcard so
- * the agent can recall and store memories without prompting.
+ * Mental-model WRITE tools on the Hindsight server that are deliberately
+ * NOT pre-approved. These mutate engine-tier mental models, and the
+ * agent-proposes / human-approves gate (the `mental_model_propose` card,
+ * see reference/rfcs/hindsight-phase5-mental-model-curation.md) is the
+ * only sanctioned path to them. Pre-approving them (e.g. via a
+ * `mcp__hindsight__*` wildcard) silently bypasses that gate — the very
+ * regression this list guards against. Leaving them off the allow-list
+ * means a direct agent call falls through to the normal permission
+ * prompt instead of the propose card, which is acceptable (the curator
+ * skill is instructed to always propose, never call these directly).
  */
-const HINDSIGHT_MCP_TOOLS = [
-  "mcp__hindsight",
-  "mcp__hindsight__*",
+export const HINDSIGHT_MENTAL_MODEL_WRITE_TOOLS = [
+  "mcp__hindsight__create_mental_model",
+  "mcp__hindsight__update_mental_model",
+  "mcp__hindsight__delete_mental_model",
+  "mcp__hindsight__refresh_mental_model",
+];
+
+/**
+ * Pre-approved MCP tool names for the Hindsight memory server.
+ *
+ * This is an ENUMERATED allow-list, deliberately NOT a `mcp__hindsight__*`
+ * wildcard and NOT a bare `mcp__hindsight` server grant (either of which
+ * would pre-approve every tool on the server). It enumerates the
+ * read / retain / reflect / directive tools the agent uses autonomously,
+ * and OMITS the mental-model write tools in
+ * `HINDSIGHT_MENTAL_MODEL_WRITE_TOOLS`, which must go through the
+ * agent-proposes / human-approves propose card instead (Fix 1.2, #2903).
+ *
+ * When adding a hindsight tool to the surface, add it here explicitly —
+ * a wildcard is banned so the next mental-model-write addition can't
+ * silently ride in ungated. The permission surface is pinned by
+ * tests/agents/hindsight-permission-surface.test.ts against
+ * tests/fixtures/hindsight-tools-list.snapshot.json.
+ */
+export const HINDSIGHT_MCP_TOOLS = [
+  // Retain / reflect / recall — the day-to-day store + query surface.
+  "mcp__hindsight__recall",
+  "mcp__hindsight__retain",
+  "mcp__hindsight__sync_retain",
+  "mcp__hindsight__reflect",
+  // Directives — captured autonomously (directive-capture nudge/verifier).
+  "mcp__hindsight__create_directive",
+  "mcp__hindsight__update_bank",
+  "mcp__hindsight__delete_directive",
+  "mcp__hindsight__list_directives",
+  // Banks.
+  "mcp__hindsight__create_bank",
+  "mcp__hindsight__get_bank",
+  "mcp__hindsight__get_bank_stats",
+  "mcp__hindsight__list_banks",
+  "mcp__hindsight__delete_bank",
+  // Memories.
+  "mcp__hindsight__get_memory",
+  "mcp__hindsight__list_memories",
+  "mcp__hindsight__clear_memories",
+  // Documents.
+  "mcp__hindsight__get_document",
+  "mcp__hindsight__list_documents",
+  "mcp__hindsight__delete_document",
+  // Mental models — READ ONLY (writes go through the propose card).
+  "mcp__hindsight__get_mental_model",
+  "mcp__hindsight__list_mental_models",
+  // Tags.
+  "mcp__hindsight__list_tags",
+  // Operations.
+  "mcp__hindsight__get_operation",
+  "mcp__hindsight__list_operations",
+  "mcp__hindsight__cancel_operation",
 ];
 
 /**

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -802,8 +802,11 @@ export function generateHindsightComposeSnippet(): string {
     // Host side 18888/19999 → container 8888/9999. The host port MUST match
     // HINDSIGHT_DEFAULT_API_PORT / the scaffolded memory.config.url or agents
     // point at a dead URL (see the 2026-07 outage).
-    `      - "${HINDSIGHT_DEFAULT_API_PORT}:8888"`,
-    "      - \"19999:9999\"",
+    // Bind to 127.0.0.1 only: the hindsight API is TOKENLESS, so publishing on
+    // 0.0.0.0 would expose the unauthenticated MCP/REST surface to the network.
+    // This mirrors the startHindsight() docker-run path, which binds loopback.
+    `      - "127.0.0.1:${HINDSIGHT_DEFAULT_API_PORT}:8888"`,
+    "      - \"127.0.0.1:19999:9999\"",
     "    environment:",
     `      - HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=${HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE}`,
     "      - HINDSIGHT_API_LLM_PROVIDER=claude-code",

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -97,6 +97,7 @@ import {
   detectMemoryLegibilityEvent,
   isMemoryLegibilityEnabled,
   renderMemoryLegibilityLine,
+  MemoryLegibilityStager,
 } from '../memory-legibility.js'
 import {
   ConsolidationRateLimiter,
@@ -13058,21 +13059,31 @@ function clearActivitySummary(turn: CurrentTurn, finalHtmlOverride?: string | nu
  * gateway. Non-material tool calls return silently — no line on ordinary
  * recall or routine consolidation. Kill-switch: SWITCHROOM_MEMORY_LEGIBILITY=0.
  */
-function surfaceMemoryLegibility(
-  turn: CurrentTurn,
-  toolName: string,
-  input: Record<string, unknown> | undefined,
+/**
+ * Fix 1.3 (#2903): a memory-legibility line must render only AFTER the write
+ * is confirmed. We stage the detected event on `tool_use` (keyed by
+ * `toolUseId`) and flush the 📌/✂️ line on the matching SUCCESSFUL
+ * `tool_result` — a failed write (engine down / isError envelope) drops the
+ * staged line, so chat never claims "remembered" for a write that errored.
+ *
+ * A hindsight `tools/call` returns HTTP 200 + `is_error:true` on failure, and
+ * Claude Code surfaces that on the transcript `tool_result` block, which
+ * `session-tail` projects onto `ev.isError`. That is the confirmed-success
+ * signal we gate on.
+ */
+interface MemoryLegibilityRoute {
+  chatId: string
+  threadId: number | undefined
+  toolName: string
+}
+const memoryLegibilityStager = new MemoryLegibilityStager<MemoryLegibilityRoute>()
+
+function sendMemoryLegibilityLine(
+  event: NonNullable<ReturnType<typeof detectMemoryLegibilityEvent>>,
+  chatId: string,
+  threadId: number | undefined,
 ): void {
-  if (!MEMORY_LEGIBILITY_ENABLED) return
-  const event = detectMemoryLegibilityEvent(toolName, input)
-  if (event == null) return
-  const chatId = turn.sessionChatId
-  const threadId = turn.sessionThreadId
   const line = renderMemoryLegibilityLine(event)
-  process.stderr.write(
-    `telegram gateway: memory-legibility ${event.kind} chat=${chatId} ` +
-      `thread=${threadId ?? '-'} tool=${toolName}\n`,
-  )
   void retryWithThreadFallback(
     robustApiCall,
     (tid) =>
@@ -13090,6 +13101,60 @@ function surfaceMemoryLegibility(
       }\n`,
     )
   })
+}
+
+/** Stage a material memory event observed on `tool_use`. Nothing is sent yet;
+ *  the line is flushed by `confirmMemoryLegibility` on a successful result. */
+function surfaceMemoryLegibility(
+  turn: CurrentTurn,
+  toolName: string,
+  toolUseId: string | null | undefined,
+  input: Record<string, unknown> | undefined,
+): void {
+  if (!MEMORY_LEGIBILITY_ENABLED) return
+  const event = detectMemoryLegibilityEvent(toolName, input)
+  if (event == null) return
+  const chatId = turn.sessionChatId
+  const threadId = turn.sessionThreadId
+  // Without a toolUseId we cannot correlate a result to confirm success. This
+  // effectively never happens (Claude Code always stamps a tool_use id), so
+  // rather than claim an unconfirmed "remembered", we skip and log.
+  if (toolUseId == null || toolUseId.length === 0) {
+    process.stderr.write(
+      `telegram gateway: memory-legibility ${event.kind} SKIPPED (no toolUseId) ` +
+        `chat=${chatId} tool=${toolName}\n`,
+    )
+    return
+  }
+  memoryLegibilityStager.stage(toolUseId, event, { chatId, threadId, toolName })
+  process.stderr.write(
+    `telegram gateway: memory-legibility ${event.kind} STAGED chat=${chatId} ` +
+      `thread=${threadId ?? '-'} tool=${toolName} id=${toolUseId}\n`,
+  )
+}
+
+/** Flush (or drop) a staged memory-legibility line on its matching
+ *  `tool_result`. Sends only on confirmed success; a failed write is dropped
+ *  so chat never claims "remembered" for a write that errored. */
+function confirmMemoryLegibility(
+  toolUseId: string | null | undefined,
+  isError: boolean | undefined,
+): void {
+  const resolved = memoryLegibilityStager.confirm(toolUseId, isError)
+  if (resolved == null) {
+    if (isError === true) {
+      process.stderr.write(
+        `telegram gateway: memory-legibility DROPPED (write errored) id=${toolUseId}\n`,
+      )
+    }
+    return
+  }
+  const { event, meta } = resolved
+  process.stderr.write(
+    `telegram gateway: memory-legibility ${event.kind} CONFIRMED chat=${meta.chatId} ` +
+      `thread=${meta.threadId ?? '-'} tool=${meta.toolName} id=${toolUseId}\n`,
+  )
+  sendMemoryLegibilityLine(event, meta.chatId, meta.threadId)
 }
 
 /**
@@ -13456,7 +13521,7 @@ function handleSessionEvent(ev: SessionEvent): void {
       // on turns with no active status-reaction controller. Deterministic
       // tool-call observation — no model call, no polling; ordinary recall and
       // routine consolidation never reach here (they aren't material tools).
-      surfaceMemoryLegibility(turn, ev.toolName, ev.input)
+      surfaceMemoryLegibility(turn, ev.toolName, ev.toolUseId, ev.input)
       const ctrl = activeStatusReactions.get(statusKey(turn.sessionChatId, turn.sessionThreadId))
       const name = ev.toolName
       // Phase tracking removed in #553 PR 5 — phases only fed the
@@ -13887,6 +13952,9 @@ function handleSessionEvent(ev: SessionEvent): void {
     }
     case 'tool_result': {
       if (ev.toolUseId) typingWrapper.onToolResult(ev.toolUseId)
+      // Fix 1.3 (#2903): flush a staged 📌/✂️ memory-legibility line only on a
+      // CONFIRMED-successful write; a failed write (ev.isError) drops it.
+      confirmMemoryLegibility(ev.toolUseId, ev.isError)
       return
     }
     case 'sub_agent_tool_use': {

--- a/telegram-plugin/memory-legibility.ts
+++ b/telegram-plugin/memory-legibility.ts
@@ -134,6 +134,60 @@ export function detectMemoryLegibilityEvent(
   return { kind: 'forgot', detail }
 }
 
+/**
+ * Confirm-before-legibility stager (Fix 1.3, #2903).
+ *
+ * A material memory op is detected on the `tool_use` event, but the write is
+ * not yet confirmed — the hindsight `tools/call` can still fail (engine down,
+ * `isError` envelope) and return an error `tool_result`. Sending the 📌/✂️ line
+ * on the tool_use would claim "remembered" for a write that then failed.
+ *
+ * This stager holds detected events keyed by `toolUseId`. `confirm` returns the
+ * event to send ONLY on a successful result; a failed result (`isError`) drops
+ * it and returns null. Pure and I/O-free so the send/no-send decision is unit-
+ * testable independent of the gateway's Telegram plumbing.
+ *
+ * `M` is caller-side routing metadata (chat/thread) carried opaquely.
+ */
+export class MemoryLegibilityStager<M> {
+  private pending = new Map<string, { event: MemoryLegibilityEvent; meta: M }>()
+  /** Bound the map so a turn that never emits a matching tool_result (crash
+   *  mid-tool) can't leak entries unboundedly. */
+  constructor(private readonly cap = 256) {}
+
+  /** Stage a detected event awaiting result confirmation. */
+  stage(toolUseId: string, event: MemoryLegibilityEvent, meta: M): void {
+    if (this.pending.size >= this.cap) {
+      const oldest = this.pending.keys().next().value
+      if (oldest != null) this.pending.delete(oldest)
+    }
+    this.pending.set(toolUseId, { event, meta })
+  }
+
+  /**
+   * Resolve a staged event on its matching tool_result. Returns the event +
+   * meta to send on CONFIRMED success; returns null when the write errored,
+   * when nothing was staged for this id, or when the id is empty. Always
+   * consumes the staged entry.
+   */
+  confirm(
+    toolUseId: string | null | undefined,
+    isError: boolean | undefined,
+  ): { event: MemoryLegibilityEvent; meta: M } | null {
+    if (toolUseId == null || toolUseId.length === 0) return null
+    const staged = this.pending.get(toolUseId)
+    if (staged == null) return null
+    this.pending.delete(toolUseId)
+    if (isError === true) return null
+    return staged
+  }
+
+  /** Test/introspection helper: number of currently-staged events. */
+  get size(): number {
+    return this.pending.size
+  }
+}
+
 /** HTML-escape for parse_mode:'HTML' (escape the 3 entity-significant chars). */
 function escapeHtml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')

--- a/telegram-plugin/tests/memory-legibility.test.ts
+++ b/telegram-plugin/tests/memory-legibility.test.ts
@@ -4,6 +4,7 @@ import {
   detectMemoryLegibilityEvent,
   isMemoryLegibilityEnabled,
   renderMemoryLegibilityLine,
+  MemoryLegibilityStager,
   CREATE_DIRECTIVE_TOOL,
   INVALIDATE_MEMORY_TOOL,
   UPDATE_MEMORY_TOOL,
@@ -116,6 +117,53 @@ describe('detectMemoryLegibilityEvent — extracts the human detail', () => {
       kind: 'remembered',
       detail: '',
     })
+  })
+})
+
+describe('MemoryLegibilityStager — confirm-before-legibility (Fix 1.3, #2903)', () => {
+  const evt = { kind: 'remembered' as const, detail: 'Always prefer TypeScript' }
+
+  it('sends the line only on a CONFIRMED-successful tool_result', () => {
+    const s = new MemoryLegibilityStager<{ chatId: string }>()
+    s.stage('toolu_ok', evt, { chatId: '123' })
+    expect(s.size).toBe(1)
+    const resolved = s.confirm('toolu_ok', undefined) // undefined isError = success
+    expect(resolved).not.toBeNull()
+    expect(resolved!.event).toEqual(evt)
+    expect(resolved!.meta).toEqual({ chatId: '123' })
+    expect(s.size).toBe(0) // consumed
+  })
+
+  it('does NOT send on a FAILED write — a failed create_directive shows NO line', () => {
+    const s = new MemoryLegibilityStager<{ chatId: string }>()
+    s.stage('toolu_fail', evt, { chatId: '123' })
+    // is_error:true on the tool_result (engine down / isError envelope)
+    const resolved = s.confirm('toolu_fail', true)
+    expect(resolved).toBeNull()
+    // the staged entry is consumed even on failure — no leak, no later re-send
+    expect(s.size).toBe(0)
+  })
+
+  it('returns null when no event was staged for the id (non-material tool result)', () => {
+    const s = new MemoryLegibilityStager<{ chatId: string }>()
+    expect(s.confirm('unknown-id', undefined)).toBeNull()
+  })
+
+  it('returns null for an empty/missing toolUseId (cannot correlate → no unconfirmed send)', () => {
+    const s = new MemoryLegibilityStager<{ chatId: string }>()
+    expect(s.confirm('', undefined)).toBeNull()
+    expect(s.confirm(null, undefined)).toBeNull()
+    expect(s.confirm(undefined, undefined)).toBeNull()
+  })
+
+  it('evicts the oldest staged entry past the cap so a crashy turn cannot leak', () => {
+    const s = new MemoryLegibilityStager<{ n: number }>(2)
+    s.stage('a', evt, { n: 1 })
+    s.stage('b', evt, { n: 2 })
+    s.stage('c', evt, { n: 3 }) // evicts 'a'
+    expect(s.size).toBe(2)
+    expect(s.confirm('a', undefined)).toBeNull() // evicted
+    expect(s.confirm('c', undefined)).not.toBeNull()
   })
 })
 

--- a/tests/hindsight-permission-surface.test.ts
+++ b/tests/hindsight-permission-surface.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  HINDSIGHT_MCP_TOOLS,
+  HINDSIGHT_MENTAL_MODEL_WRITE_TOOLS,
+} from "../src/agents/scaffold.js";
+
+/**
+ * Pins the pre-approved Hindsight MCP permission surface (Fix 1.2, #2903).
+ *
+ * The scaffold used to pre-approve `mcp__hindsight__*` (a wildcard), which
+ * silently pre-approved the mental-model WRITE tools and thereby bypassed the
+ * agent-proposes / human-approves gate. This test snapshots exactly which
+ * tools are pre-approved so any future change (especially re-introducing a
+ * wildcard, or adding a mental-model write) is a deliberate, reviewed edit.
+ */
+describe("Hindsight pre-approved permission surface (Fix 1.2, #2903)", () => {
+  const snapshot = JSON.parse(
+    readFileSync(
+      join(__dirname, "fixtures", "hindsight-tools-list.snapshot.json"),
+      "utf-8",
+    ),
+  ) as { tools: Record<string, unknown> };
+  const allEngineTools = Object.keys(snapshot.tools).sort();
+
+  it("never pre-approves a wildcard or bare server grant", () => {
+    expect(HINDSIGHT_MCP_TOOLS).not.toContain("mcp__hindsight__*");
+    expect(HINDSIGHT_MCP_TOOLS).not.toContain("mcp__hindsight");
+    for (const t of HINDSIGHT_MCP_TOOLS) {
+      expect(t.startsWith("mcp__hindsight__")).toBe(true);
+      expect(t.endsWith("*")).toBe(false);
+    }
+  });
+
+  it("pre-approves exactly this enumerated set (change = deliberate)", () => {
+    expect([...HINDSIGHT_MCP_TOOLS].sort()).toEqual([
+      "mcp__hindsight__cancel_operation",
+      "mcp__hindsight__clear_memories",
+      "mcp__hindsight__create_bank",
+      "mcp__hindsight__create_directive",
+      "mcp__hindsight__delete_bank",
+      "mcp__hindsight__delete_directive",
+      "mcp__hindsight__delete_document",
+      "mcp__hindsight__get_bank",
+      "mcp__hindsight__get_bank_stats",
+      "mcp__hindsight__get_document",
+      "mcp__hindsight__get_memory",
+      "mcp__hindsight__get_mental_model",
+      "mcp__hindsight__get_operation",
+      "mcp__hindsight__list_banks",
+      "mcp__hindsight__list_directives",
+      "mcp__hindsight__list_documents",
+      "mcp__hindsight__list_memories",
+      "mcp__hindsight__list_mental_models",
+      "mcp__hindsight__list_operations",
+      "mcp__hindsight__list_tags",
+      "mcp__hindsight__recall",
+      "mcp__hindsight__reflect",
+      "mcp__hindsight__retain",
+      "mcp__hindsight__sync_retain",
+      "mcp__hindsight__update_bank",
+    ]);
+  });
+
+  it("NEVER pre-approves a mental-model write tool (they route through the propose card)", () => {
+    for (const w of HINDSIGHT_MENTAL_MODEL_WRITE_TOOLS) {
+      expect(HINDSIGHT_MCP_TOOLS).not.toContain(w);
+    }
+    // The write set matches the mutating mental-model tools in the surface.
+    expect([...HINDSIGHT_MENTAL_MODEL_WRITE_TOOLS].sort()).toEqual([
+      "mcp__hindsight__create_mental_model",
+      "mcp__hindsight__delete_mental_model",
+      "mcp__hindsight__refresh_mental_model",
+      "mcp__hindsight__update_mental_model",
+    ]);
+  });
+
+  it("every pre-approved tool corresponds to a real tool in the engine surface", () => {
+    for (const t of HINDSIGHT_MCP_TOOLS) {
+      const bare = t.replace("mcp__hindsight__", "");
+      expect(
+        allEngineTools,
+        `${bare} not present in the captured 29-tool surface`,
+      ).toContain(bare);
+    }
+  });
+
+  it("read-only mental-model tools ARE pre-approved (get/list), writes are not", () => {
+    expect(HINDSIGHT_MCP_TOOLS).toContain("mcp__hindsight__get_mental_model");
+    expect(HINDSIGHT_MCP_TOOLS).toContain("mcp__hindsight__list_mental_models");
+    expect(HINDSIGHT_MCP_TOOLS).not.toContain(
+      "mcp__hindsight__create_mental_model",
+    );
+  });
+});

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1881,7 +1881,13 @@ describe("reconcileAgent", () => {
     const after = JSON.parse(readFileSync(settingsPath, "utf-8"));
     expect(after.mcpServers.hindsight).toBeDefined();
     expect(after.mcpServers.hindsight.url).toBe("http://localhost:18888/mcp/");
-    expect(after.permissions.allow).toContain("mcp__hindsight__*");
+    // Fix 1.2 (#2903): enumerated allow-list, NOT a wildcard/bare server grant.
+    expect(after.permissions.allow).not.toContain("mcp__hindsight__*");
+    expect(after.permissions.allow).not.toContain("mcp__hindsight");
+    expect(after.permissions.allow).toContain("mcp__hindsight__recall");
+    expect(after.permissions.allow).toContain("mcp__hindsight__retain");
+    // Mental-model writes must NOT be pre-approved — they go through the propose card.
+    expect(after.permissions.allow).not.toContain("mcp__hindsight__create_mental_model");
   });
 
   it("rewrites .mcp.json for switchroom-telegram-plugin agents to include hindsight", () => {
@@ -2156,7 +2162,7 @@ describe("reconcileAgent", () => {
 
     const settingsPath = join(tmpDir, "test-agent", ".claude", "settings.json");
     const beforeReconcile = JSON.parse(readFileSync(settingsPath, "utf-8"));
-    expect(beforeReconcile.permissions.allow).toContain("mcp__hindsight__*");
+    expect(beforeReconcile.permissions.allow).toContain("mcp__hindsight__recall");
 
     // Reconcile against a config with backend=none
     const withoutMemory = buildSwitchroomConfig(agentConfig, {
@@ -2166,7 +2172,7 @@ describe("reconcileAgent", () => {
     reconcileAgent("test-agent", agentConfig, tmpDir, telegramConfig, withoutMemory);
 
     const after = JSON.parse(readFileSync(settingsPath, "utf-8"));
-    expect(after.permissions.allow).not.toContain("mcp__hindsight__*");
+    expect(after.permissions.allow).not.toContain("mcp__hindsight__recall");
     expect(after.mcpServers.hindsight).toBeUndefined();
   });
 });

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -325,6 +325,27 @@ describe("generateHindsightComposeSnippet — tmpfs ownership", () => {
     expect(tmpfsLine).toMatch(/mode=0700\b/);
   });
 
+  it("publishes both ports on 127.0.0.1 only — the tokenless API must never bind 0.0.0.0 (Fix 1.1)", async () => {
+    const { generateHindsightComposeSnippet, HINDSIGHT_DEFAULT_API_PORT } =
+      await import("../../src/setup/hindsight.js");
+    const snippet = generateHindsightComposeSnippet();
+    const portLines = snippet
+      .split("\n")
+      .filter((l) => /^\s+-\s+"[\d.:]+:\d+"\s*$/.test(l));
+    // Both the API and UI published ports must be present and loopback-bound.
+    expect(portLines.length).toBeGreaterThanOrEqual(2);
+    for (const line of portLines) {
+      expect(line, `port binding must be loopback-only: ${line}`).toMatch(
+        /"127\.0\.0\.1:/,
+      );
+    }
+    expect(snippet).toContain(`"127.0.0.1:${HINDSIGHT_DEFAULT_API_PORT}:8888"`);
+    expect(snippet).toContain('"127.0.0.1:19999:9999"');
+    // Guard against a regression that drops the host-IP prefix entirely.
+    expect(snippet).not.toMatch(/-\s+"\d+:8888"/);
+    expect(snippet).not.toMatch(/-\s+"\d+:9999"/);
+  });
+
   it("emits shm_size so the compose path matches the docker-run shm fix (2026-06-06 outage)", async () => {
     const { generateHindsightComposeSnippet, HINDSIGHT_DEFAULT_SHM_SIZE: shm } =
       await import("../../src/setup/hindsight.js");

--- a/vendor/hindsight-memory/scripts/directive_verify.py
+++ b/vendor/hindsight-memory/scripts/directive_verify.py
@@ -242,26 +242,74 @@ def find_last_human_turn(messages: list) -> tuple:
     return None, ""
 
 
-def _directive_call_present(content) -> bool:
-    """True if a message's content contains a create_directive tool_use."""
+def _directive_call_ids(content) -> list:
+    """Return the tool_use ids of any create_directive calls in a message's
+    content (empty list if none)."""
+    ids = []
     if not isinstance(content, list):
-        return False
+        return ids
     for p in content:
         if not isinstance(p, dict) or p.get("type") != "tool_use":
             continue
         name = p.get("name", "")
         if isinstance(name, str) and "create_directive" in name:
-            return True
-    return False
+            # Track the id so we can pair it with its tool_result and reject a
+            # call whose write ERRORED. A call with no id still counts as a
+            # (best-effort) attempt — see _directive_call_present.
+            ids.append(p.get("id"))
+    return ids
+
+
+def _directive_call_present(content) -> bool:
+    """True if a message's content contains a create_directive tool_use."""
+    return len(_directive_call_ids(content)) > 0
+
+
+# SWITCHROOM DIVERGENCE (#2903, Fix 1.3): a create_directive tool_use whose
+# tool_result came back with an error must NOT count as "recorded". A hindsight
+# tools/call returns HTTP 200 + is_error:true on failure (engine down / renamed
+# arg / isError envelope); without this the verifier would see the call, treat
+# the correction as captured, and never fire its one bounded re-prompt — the
+# same false-success class that made chat show "📌 remembered" for a failed
+# write. We scan subsequent user messages for the matching tool_result id and
+# treat is_error:true (or an error-shaped text result) as NOT-recorded.
+def _errored_tool_use_ids(messages: list) -> set:
+    """Collect tool_use ids whose tool_result reported an error."""
+    errored = set()
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for p in content:
+            if not isinstance(p, dict) or p.get("type") != "tool_result":
+                continue
+            if p.get("is_error") is True:
+                tid = p.get("tool_use_id")
+                if tid is not None:
+                    errored.add(tid)
+    return errored
 
 
 def directive_recorded_after(messages: list, start_index: int) -> bool:
-    """True if any assistant turn after ``start_index`` called create_directive."""
+    """True if any assistant turn after ``start_index`` called create_directive
+    with a SUCCESSFUL result. A call whose tool_result errored does not count
+    (SWITCHROOM DIVERGENCE #2903, Fix 1.3) — so the verifier still re-prompts
+    once for a durable rule whose write failed."""
+    errored = _errored_tool_use_ids(messages)
     for msg in messages[start_index + 1:]:
         if not isinstance(msg, dict) or msg.get("role") != "assistant":
             continue
-        if _directive_call_present(msg.get("content")):
-            return True
+        ids = _directive_call_ids(msg.get("content"))
+        if not ids:
+            continue
+        # Recorded only if at least one create_directive call did NOT error.
+        # A call with a None id (older/testing shape carrying no id) has no
+        # pairable result, so treat it as a successful attempt (prior behaviour).
+        for tid in ids:
+            if tid is None or tid not in errored:
+                return True
     return False
 
 

--- a/vendor/hindsight-memory/scripts/tests/test_directive_verify.py
+++ b/vendor/hindsight-memory/scripts/tests/test_directive_verify.py
@@ -224,6 +224,63 @@ class TestDirectiveDetection(unittest.TestCase):
         ]
         self.assertFalse(directive_recorded_after(msgs, 1))
 
+    def _mk_id(self, name, tid):
+        return {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": tid, "name": name, "input": {}}
+            ],
+        }
+
+    def _result(self, tid, is_error):
+        return {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tid,
+                    "is_error": is_error,
+                    "content": "boom" if is_error else "ok",
+                }
+            ],
+        }
+
+    def test_errored_create_directive_is_not_recorded(self):
+        # SWITCHROOM DIVERGENCE #2903 Fix 1.3: a create_directive whose result
+        # errored must NOT count as recorded, so the verifier re-prompts once.
+        msgs = [
+            {"role": "user", "content": "call me Ken"},
+            self._mk_id("mcp__hindsight__create_directive", "toolu_1"),
+            self._result("toolu_1", True),
+        ]
+        self.assertFalse(directive_recorded_after(msgs, 0))
+
+    def test_successful_create_directive_with_result_is_recorded(self):
+        msgs = [
+            {"role": "user", "content": "call me Ken"},
+            self._mk_id("mcp__hindsight__create_directive", "toolu_1"),
+            self._result("toolu_1", False),
+        ]
+        self.assertTrue(directive_recorded_after(msgs, 0))
+
+    def test_one_failed_one_successful_directive_is_recorded(self):
+        msgs = [
+            {"role": "user", "content": "call me Ken"},
+            self._mk_id("mcp__hindsight__create_directive", "toolu_1"),
+            self._result("toolu_1", True),
+            self._mk_id("mcp__hindsight__create_directive", "toolu_2"),
+            self._result("toolu_2", False),
+        ]
+        self.assertTrue(directive_recorded_after(msgs, 0))
+
+    def test_call_without_id_still_counts_as_attempt(self):
+        # Older/testing shape with no tool_use id has no pairable result.
+        msgs = [
+            {"role": "user", "content": "call me Ken"},
+            self._mk("mcp__hindsight__create_directive"),
+        ]
+        self.assertTrue(directive_recorded_after(msgs, 0))
+
 
 class TestEvaluate(unittest.TestCase):
     ON = {"directiveCaptureNudge": True}


### PR DESCRIPTION
Implements the three **Priority 1 (Security & enforcement)** findings from #2903. Core machinery unchanged; these are targeted hardening fixes.

## Fix 1.1 — Compose snippet exposed the tokenless API on all interfaces
`generateHindsightComposeSnippet()` published the API (`18888`) and UI (`19999`) ports with no host-IP prefix, so a compose deployment bound hindsight's **tokenless** MCP/REST API on `0.0.0.0`. The `startHindsight()` docker-run path already binds `127.0.0.1`.

- **What:** prefix both published ports with `127.0.0.1:`.
- **Why:** the API has no auth; publishing on `0.0.0.0` exposes the unauthenticated store/recall/reflect surface to the network.
- **Test:** `tests/setup/hindsight.test.ts` now asserts every published port line is loopback-bound and that no bare `N:8888`/`N:9999` mapping survives.

## Fix 1.2 — Mental-model "human approves" gate was bypassable by design
`HINDSIGHT_MCP_TOOLS = ["mcp__hindsight", "mcp__hindsight__*"]` pre-approved **every** hindsight tool for every hindsight-enabled agent — including the mental-model write tools — so the agent-proposes/human-approves `mental_model_propose` card guarded only config-declared models while engine-tier models were silently writable/deletable.

- **What (Option A):** replace the wildcard + bare server grant with an **enumerated** read/retain/reflect/directive allow-list that OMITS the four mental-model write tools (`create_/update_/delete_/refresh_mental_model`). Those now route through the propose card. `skills/mental-model-curator/SKILL.md` updated to always propose, never call `create_mental_model` directly (removed from `allowed-tools`).
- **Why:** the wildcard made the "human approves" gate cosmetic for engine-tier models.
- **Unaffected paths confirmed:** `src/cli/memory.ts` and `src/web/memory-remediation.ts` hit the hindsight REST API directly and are operator-run — they do not depend on agent MCP permissions (`memory-remediation.ts` uses the `/mental-models/:id/refresh` REST endpoint, not the MCP tool).
- **Test:** new `tests/hindsight-permission-surface.test.ts` snapshots the exact pre-approved set (validated against the 29-tool `hindsight-tools-list.snapshot.json`) and asserts no wildcard/bare-server grant and no mental-model write is ever pre-approved — so the next wildcard change is a conscious decision. `tests/scaffold.test.ts` updated to the enumerated shape.

## Fix 1.3 — "📌 remembered: X" rendered before the write was confirmed
`surfaceMemoryLegibility` sent the 📌/✂️ line on **observing** the `create_directive` tool_use, before the tool result — a failed write (engine down / `isError` envelope) still showed "remembered".

- **What:** stage the detected event on `tool_use` (keyed by `toolUseId`) via a new pure `MemoryLegibilityStager`, and flush the line only on the matching **successful** `tool_result`. The success/error bit was already plumbed through `session-tail` (`ev.isError`); the gateway now gates on it. A failed write drops the staged line — chat never claims "remembered" for a write that errored. The stager is capped (256) so a crashy turn can't leak.
- **Vendor:** `directive_verify.py` now treats a `create_directive` whose `tool_result` errored as **NOT**-recorded (`SWITCHROOM DIVERGENCE #2903` marker), so the verifier's one bounded re-prompt still fires for a durable rule whose write failed. A call with no pairable id keeps prior behaviour.
- **Tests:** `memory-legibility.test.ts` adds the confirm-before-legibility stager cases incl. the failed-write case asserting **no** line is sent; `test_directive_verify.py` adds errored-result / mixed / no-id cases.

### CONTRIBUTING step-8 — deterministic-guarantee delta (chat-visible surface, Fix 1.3)
- **Before:** the 📌 legibility line was emitted on tool-call observation — deterministic w.r.t. the *attempt*, but it could assert "remembered" for a write that then failed (false-positive on the guarantee "a shown 📌 means a stored directive").
- **After:** the 📌 line is emitted **iff** the `create_directive` tool_result is confirmed non-error. New guarantee: **a 📌 line implies a confirmed-successful directive write**; a failed write shows nothing. No new device buzz (`disable_notification: true` retained); no new surface (still one terse real message in the originating topic); kill-switch `SWITCHROOM_MEMORY_LEGIBILITY=0` unchanged. The vendor verifier's guarantee tightens symmetrically: a failed write is no longer counted as captured, so the bounded re-prompt fires.

## Gates
- `tsc --noEmit` (lint:tsc): clean.
- Affected vitest: `hindsight.test.ts` (29 ✓), `hindsight-permission-surface.test.ts` + `memory-legibility.test.ts` (29 ✓), `memory.hindsight-iserror-guard.test.ts` ✓. Pre-existing unrelated failure: `scaffold.test.ts` start.sh `/home/op` symlink assertion (fails on clean `main` too — environment-specific).
- Vendor Python: `test_directive_verify.py` 33 ✓; full scripts suite 226 ✓; full `pytest vendor/hindsight-memory` 432 passed, 2 pre-existing unrelated failures in `test_recall_exit_codes.py` (subprocess-shim record path; fail on clean `main`).

Refs #2903. Does NOT touch #2894 throttle, #2888 model pin, or the Dockerfile patch blocks. UAT live-run of the memory-legibility scenarios (per #2903 verification note) is deferred to a live surface and not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)