### PR TITLE
test: fix callback-prefix consistency drift from mental-model-propose ('mmp:')

### DIFF
--- a/tests/jtbd-talk-from-anywhere.test.ts
+++ b/tests/jtbd-talk-from-anywhere.test.ts
@@ -335,7 +335,10 @@ describe("Principles/consistency — every operator approval card uses the same 
     // handleAuthDashboardCallback at the dispatcher.
     // `vsp:` added in #2045 (request_secret secure save-card) — handled by
     // handleSecretRequestCallback at the dispatcher.
-    const expectedPrefixes = ["vrs", "vra", "vrd", "vd", "vg", "op", "auth", "vsp"];
+    // `mmp:` added for mental_model_propose (hindsight Phase 5) — the
+    // agent-proposes → human-approves mental-model card; mmp:approve/deny
+    // are handled by handleMentalModelProposeCallback at the dispatcher.
+    const expectedPrefixes = ["vrs", "vra", "vrd", "vd", "vg", "op", "auth", "vsp", "mmp"];
     for (const p of expectedPrefixes) {
       expect(
         gatewaySrc,


### PR DESCRIPTION
## What

`main` (27c1efb5) is red on a single test:

`tests/jtbd-talk-from-anywhere.test.ts` → *"every callback prefix is documented at the dispatcher (single source of truth)"*

```
AssertionError: new callback prefix 'mmp:' — update jtbd-talk-from-anywhere.test.ts expectedPrefixes
```

## Why (verified, not silenced)

This is **test-list drift, not a real gap**. The `mmp:` callback prefix from the `mental_model_propose` feature (hindsight Phase 5) is genuinely wired end-to-end:

- **Tool registered:** `bridge.ts:422` and `gateway.ts:9242/9289` (`mental_model_propose`).
- **Card emits it:** `gateway.ts:11932-11933` — `callback_data: mmp:approve:<stageId>` / `mmp:deny:<stageId>`.
- **Dispatcher routes it:** `gateway.ts:23538` — `if (data.startsWith('mmp:')) { await handleMentalModelProposeCallback(ctx, data); return }`.
- **Resolver exists:** `gateway/mental-model-propose-resolve.ts`.

The button taps go somewhere real. The guard's `expectedPrefixes` list simply wasn't updated when the feature landed. This PR adds `'mmp'` to that list with an explanatory comment. **No behavior change.**

## Verification

- `npx vitest run tests/jtbd-talk-from-anywhere.test.ts` → 11 passed, 5 skipped, 0 failed.
- `npx tsc --noEmit` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)