### PR TITLE
fix(hindsight): P3 runtime correctness — healthcheck claim, host-network port reuse, backlog visibility, port-constant dedup

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -644,6 +644,7 @@ import {
   seedCronConfigDir,
   loadUserConfig,
 } from "../setup/onboarding.js";
+import { HINDSIGHT_DEFAULT_MCP_URL, HINDSIGHT_DEFAULT_API_BASE_URL } from "../setup/hindsight.js";
 import { ensureBareClone } from "../repos/bare-clone.js";
 import {
   ensureAgentWorktree,
@@ -2488,7 +2489,7 @@ export function installHindsightPlugin(
   // /mcp/ MCP endpoint URL — strip the suffix.
   const bankId = agentMemory?.collection ?? agentName;
   const mcpUrl = (memory.config?.url as string | undefined)
-    ?? "http://127.0.0.1:18888/mcp/";
+    ?? HINDSIGHT_DEFAULT_MCP_URL;
   const apiBaseUrl = mcpUrl.replace(/\/mcp\/?$/, "").replace(/\/$/, "");
 
   return { pluginDir: destPath, apiBaseUrl, bankId };
@@ -3430,7 +3431,7 @@ export function scaffoldAgent(
   const hindsightBankId = agentConfig.memory?.collection ?? name;
   const hindsightApiBaseUrl = (switchroomConfig?.memory?.config?.url as string | undefined)
     ? (switchroomConfig!.memory!.config!.url as string).replace(/\/mcp\/?$/, "").replace(/\/$/, "")
-    : "http://127.0.0.1:18888";
+    : HINDSIGHT_DEFAULT_API_BASE_URL;
   // Cascading recall cap. Per-agent value already merged from defaults
   // by config/merge.ts (memory is shallow-merged), so reading
   // agentConfig.memory.recall.max_memories here picks up the resolved
@@ -5563,7 +5564,7 @@ export function reconcileAgent(
   const hindsightBankId = agentConfig.memory?.collection ?? name;
   const hindsightApiBaseUrl = (switchroomConfig.memory?.config?.url as string | undefined)
     ? (switchroomConfig.memory!.config!.url as string).replace(/\/mcp\/?$/, "").replace(/\/$/, "")
-    : "http://127.0.0.1:18888";
+    : HINDSIGHT_DEFAULT_API_BASE_URL;
   const hindsightRecallMaxMemories = agentConfig.memory?.recall?.max_memories;
   const hindsightRecallCacheTtlSecs = agentConfig.memory?.recall?.cache_ttl_secs;
   const hindsightRecallMinOverlap = agentConfig.memory?.recall?.min_overlap;

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -7,6 +7,7 @@ import { getSchedulerState, formatSchedulerState } from "../agents/scheduler-sta
 import YAML from "yaml";
 import { resolveAgentsDir, loadConfig } from "../config/loader.js";
 import { isHindsightEnabled } from "../memory/hindsight.js";
+import { HINDSIGHT_DEFAULT_MCP_URL } from "../setup/hindsight.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 import { scaffoldAgent, reconcileAgent, buildSettingsHooksBlock, detectHooksDrift, SWITCHROOM_DEFAULT_MAIN_MODEL, SWITCHROOM_DEFAULT_THINKING_EFFORT } from "../agents/scaffold.js";
@@ -308,7 +309,7 @@ function buildStatusInputs(
   if (isHindsightEnabled(config)) {
     const baseUrl =
       (config.memory?.config?.url as string | undefined) ??
-      "http://localhost:18888/mcp/";
+      HINDSIGHT_DEFAULT_MCP_URL;
     hindsightApiUrl = baseUrl.endsWith("/mcp/")
       ? baseUrl
       : baseUrl.replace(/\/$/, "") + "/mcp/";
@@ -898,7 +899,7 @@ export function registerAgentCommand(program: Command): void {
         let hindsightBankId = name;
         if (isHindsightEnabled(config)) {
           const baseUrl = (config.memory?.config?.url as string | undefined)
-            ?? "http://localhost:18888/mcp/";
+            ?? HINDSIGHT_DEFAULT_MCP_URL;
           // Normalize to end in /mcp/
           hindsightApiUrl = baseUrl.endsWith("/mcp/")
             ? baseUrl

--- a/src/cli/doctor-memory.ts
+++ b/src/cli/doctor-memory.ts
@@ -59,6 +59,67 @@ export function classifyShmSize(bytes: number): CheckResult {
 }
 
 /**
+ * Backlog thresholds for the consolidation queue. With the #2894 throttle
+ * (MAX_SLOTS=1, ~7 consolidation ops/hour drained against a fleet retaining
+ * every turn) the queue can build silently — the only prior signal was a 2h
+ * queue-lag WARNING written to `docker logs` by `hindsight-maintenance.sh`.
+ * A deep queue means retains are landing but not yet consolidated into recall.
+ * WARN ≈ several hours of backlog; FAIL ≈ ~a day+, likely wedged.
+ */
+export const CONSOLIDATION_BACKLOG_WARN = 25;
+export const CONSOLIDATION_BACKLOG_FAIL = 200;
+
+/**
+ * Pure: classify the consolidation-queue backlog into a doctor result so
+ * `switchroom doctor` surfaces queue depth (and, when available, the oldest
+ * pending op's age) instead of it hiding in docker logs.
+ *
+ * `queueDepth` is the count of pending/processing async operations across all
+ * banks (summed from each bank's `/stats.pending_operations`). `oldestAgeSecs`
+ * is the age of the oldest pending op when known, else `null` — the REST
+ * `/stats` surface exposes depth but not per-op age, so precise age
+ * measurement is deferred to the #2847 follow-up (the maintenance loop already
+ * logs it). Never throws.
+ */
+export function classifyConsolidationBacklog(
+  queueDepth: number,
+  oldestAgeSecs: number | null = null,
+): CheckResult {
+  const ageStr =
+    oldestAgeSecs !== null && oldestAgeSecs > 0
+      ? `, oldest ${Math.round(oldestAgeSecs / 60)}m old`
+      : "";
+  const base = `${queueDepth} pending consolidation op(s)${ageStr}`;
+  if (queueDepth >= CONSOLIDATION_BACKLOG_FAIL) {
+    return {
+      name: "hindsight consolidation backlog",
+      status: "fail",
+      detail:
+        `${base} — queue is deep enough to be wedged; retains are landing but ` +
+        `not consolidating into recall (drains ~7 ops/hr under the #2894 throttle)`,
+      fix:
+        "Check `docker logs switchroom-hindsight` for the queue-lag WARNING and " +
+        "consolidation errors (quota/429/shm); restart with `switchroom memory " +
+        "--restart` if the worker is stuck.",
+    };
+  }
+  if (queueDepth >= CONSOLIDATION_BACKLOG_WARN) {
+    return {
+      name: "hindsight consolidation backlog",
+      status: "warn",
+      detail:
+        `${base} — building faster than it drains (~7 ops/hr under the #2894 ` +
+        `throttle); recall may lag recent turns until it catches up`,
+    };
+  }
+  return {
+    name: "hindsight consolidation backlog",
+    status: "ok",
+    detail: queueDepth > 0 ? base : "queue drained (0 pending)",
+  };
+}
+
+/**
  * Pure: classify recent hindsight logs for fact-extraction health. Catches the
  * two silent-write failure modes by their log signatures.
  */

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -28,8 +28,9 @@ import { getSlotInfos, type SlotInfo } from "../auth/accounts.js";
 import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
 import { loadManifest, detectDrift, type DriftProbers } from "../manifest.js";
 import { probeHindsight, isHindsightEnabled, fetchHindsightToolsList, collectProfileBanks } from "../memory/hindsight.js";
+import { HINDSIGHT_DEFAULT_MCP_URL } from "../setup/hindsight.js";
 import { inspectBankHealth, staleMentalModels, corruptedMentalModels, recentUnextracted, ageDays } from "../memory/bank-health.js";
-import { checkHindsightContainerHealth, classifyToolContract, checkHindsightHealthEndpoint } from "./doctor-memory.js";
+import { checkHindsightContainerHealth, classifyToolContract, checkHindsightHealthEndpoint, classifyConsolidationBacklog } from "./doctor-memory.js";
 import { isDockerMode, runDockerChecks } from "./doctor-docker.js";
 import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
 import { runHostdChecks } from "./doctor-hostd.js";
@@ -1080,6 +1081,22 @@ export async function checkBankIngestHealth(
     ),
   );
 
+  // Fleet-wide consolidation backlog (#2903 fix 5.3): sum the pending-op
+  // count across every reachable bank so `switchroom doctor` shows the queue
+  // depth the #2894 throttle can silently build. Oldest-pending age isn't on
+  // the REST /stats surface (measurement follow-up: #2847), so age is unknown.
+  let totalPending = 0;
+  let anyBankReachable = false;
+  for (const [, , h] of inspected) {
+    if (h.ok) {
+      anyBankReachable = true;
+      totalPending += h.pendingOperations;
+    }
+  }
+  if (anyBankReachable) {
+    results.push(classifyConsolidationBacklog(totalPending));
+  }
+
   for (const [bankId, agents, h] of inspected) {
     const label =
       `bank ${bankId}` +
@@ -1170,7 +1187,7 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
   }
 
   const url = (config.memory?.config?.url as string | undefined)
-    ?? "http://localhost:18888/mcp/";
+    ?? HINDSIGHT_DEFAULT_MCP_URL;
 
   const results: CheckResult[] = [];
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1056,7 +1056,7 @@ function probeAuthBrokerSocket(
 export async function checkBankIngestHealth(
   config: SwitchroomConfig,
   url: string,
-  opts?: { fetchImpl?: typeof fetch; now?: Date },
+  opts?: { fetchImpl?: typeof fetch; now?: Date; includeConsolidationBacklog?: boolean },
 ): Promise<CheckResult[]> {
   const results: CheckResult[] = [];
   const now = opts?.now ?? new Date();
@@ -1085,16 +1085,19 @@ export async function checkBankIngestHealth(
   // count across every reachable bank so `switchroom doctor` shows the queue
   // depth the #2894 throttle can silently build. Oldest-pending age isn't on
   // the REST /stats surface (measurement follow-up: #2847), so age is unknown.
-  let totalPending = 0;
-  let anyBankReachable = false;
-  for (const [, , h] of inspected) {
-    if (h.ok) {
-      anyBankReachable = true;
-      totalPending += h.pendingOperations;
+  // Gated off by default so the per-bank ingest contract stays clean for
+  // callers/tests that only want bank rows; the CLI doctor opts in below.
+  let backlogRow: CheckResult | undefined;
+  if (opts?.includeConsolidationBacklog) {
+    let totalPending = 0;
+    let anyBankReachable = false;
+    for (const [, , h] of inspected) {
+      if (h.ok) {
+        anyBankReachable = true;
+        totalPending += h.pendingOperations;
+      }
     }
-  }
-  if (anyBankReachable) {
-    results.push(classifyConsolidationBacklog(totalPending));
+    if (anyBankReachable) backlogRow = classifyConsolidationBacklog(totalPending);
   }
 
   for (const [bankId, agents, h] of inspected) {
@@ -1173,6 +1176,7 @@ export async function checkBankIngestHealth(
     }
     results.push({ name: label, status: "ok", detail: summary });
   }
+  if (backlogRow) results.push(backlogRow);
   return results;
 }
 
@@ -1277,7 +1281,7 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
   // units per document (consumer quota wall / shm exhaustion) — the agent
   // keeps "remembering" nothing and no surface goes red. Inspect each bank's
   // REST surface for unextracted documents and stale mental models.
-  results.push(...(await checkBankIngestHealth(config, url)));
+  results.push(...(await checkBankIngestHealth(config, url, { includeConsolidationBacklog: true })));
 
   // Per-agent bank health checks
   for (const [agentName, agentConfig] of Object.entries(config.agents)) {

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -22,6 +22,7 @@ import {
   getRunningHindsightPorts,
   preflightHindsightPorts,
   HINDSIGHT_DEFAULT_API_PORT,
+  HINDSIGHT_DEFAULT_MCP_URL,
   type LiteLLMHindsightConfig,
 } from "../setup/hindsight.js";
 import { getViaBrokerStructured } from "../vault/broker/client.js";
@@ -659,7 +660,7 @@ export function registerMemoryCommand(program: Command): void {
           const collection = getCollectionForAgent(agent, config);
           const apiUrl =
             (config.memory?.config?.url as string | undefined) ??
-            "http://localhost:18888/mcp/";
+            HINDSIGHT_DEFAULT_MCP_URL;
           const timeoutMs = Math.max(500, parseInt(opts.timeout, 10) || 5000);
 
           console.log(
@@ -713,7 +714,7 @@ export function registerMemoryCommand(program: Command): void {
   // memory.recall.additional_banks. Single-tenant — the operator's own data
   // in the operator's Hindsight instance.
   const restBase = (url: string | undefined): string =>
-    (url ?? "http://127.0.0.1:18888/mcp/")
+    (url ?? HINDSIGHT_DEFAULT_MCP_URL)
       .replace(/\/mcp\/?$/, "")
       .replace(/\/$/, "");
   const VALID_BANK = /^[a-zA-Z0-9_.-]+$/;

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -32,6 +32,15 @@ export const HINDSIGHT_DEFAULT_UI_PORT = 9999;
 export const HINDSIGHT_DEFAULT_MCP_URL = `http://127.0.0.1:${HINDSIGHT_DEFAULT_API_PORT}/mcp/`;
 
 /**
+ * Default REST base URL (no `/mcp/` suffix) for hindsight's HTTP API — the
+ * form the vendored plugin's hooks expect as `HINDSIGHT_API_URL`. Derived
+ * from {@link HINDSIGHT_DEFAULT_MCP_URL} so the port lives in exactly one
+ * place: every `?? "http://127.0.0.1:18888"` literal fallback that used to be
+ * scattered across scaffold/doctor/agent/memory should reference this instead.
+ */
+export const HINDSIGHT_DEFAULT_API_BASE_URL = HINDSIGHT_DEFAULT_MCP_URL.replace(/\/mcp\/?$/, "");
+
+/**
  * Default cap on observations per *tag scope*.
  *
  * Upstream Hindsight defaults `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE`
@@ -595,8 +604,10 @@ export function startHindsight(
     // Reflect wall timeout — let large-bank mental-model refreshes finish
     // (vendor 300s times out on 12k+ obs banks → stale user-profile models).
     "-e", `HINDSIGHT_API_REFLECT_WALL_TIMEOUT=${HINDSIGHT_DEFAULT_REFLECT_WALL_TIMEOUT_S}`,
-    // Consolidation throughput (modest): fewer LLM round-trips per round +
-    // one more concurrent bank during backlog recovery. See constants above.
+    // Consolidation concurrency: throttled by #2894 to a hard ceiling of
+    // MAX_SLOTS 1 × LLM_PARALLELISM 2 = 2 concurrent model calls (was 18), so
+    // consolidation can never exhaust the shared failover quota. Batch size 12
+    // and per-round scope 100 bound tokens/scope per op. See constants above.
     "-e", `HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE}`,
     "-e", `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`,
     "-e", `HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`,
@@ -637,9 +648,16 @@ export function startHindsight(
     // HINDSIGHT_DEFAULT_SHM_SIZE) or all writes/queries fail with
     // "No space left on device". Keep in sync with the compose snippet.
     `--shm-size=${HINDSIGHT_DEFAULT_SHM_SIZE}`,
-    // Restart a wedged API: docker had no liveness signal for hindsight,
-    // so an unresponsive server (or a never-booting one) stayed "up"
-    // forever. python3 is always present in the image; curl/wget are not.
+    // Liveness signal for a wedged API: docker had no health probe for
+    // hindsight, so an unresponsive server (or a never-booting one) stayed
+    // "up" forever. This marks the container "unhealthy" in `docker inspect`
+    // / `docker ps` so operators and the doctor probe can SEE the wedge.
+    // NOTE: vanilla Docker does NOT auto-restart an unhealthy container —
+    // `--restart always` acts on process EXIT only, never on health status.
+    // So this is visibility, not a self-heal; an unhealthy-but-not-exited
+    // API keeps running until something (operator / an autoheal sidecar)
+    // acts on the status. See PR follow-up for the restart-on-unhealthy
+    // mechanism. python3 is always present in the image; curl/wget are not.
     "--health-cmd", litellm
       ? `python3 -c 'import urllib.request,sys; sys.exit(0 if urllib.request.urlopen("http://localhost:${apiPort}/health",timeout=4).getcode()==200 else 1)'`
       : HINDSIGHT_HEALTHCHECK_CMD,
@@ -743,11 +761,57 @@ export function getRunningHindsightPorts(): { apiPort: number; uiPort: number } 
     }
   };
   const apiPort = readPort(CONTAINER_API_PORT);
+  if (apiPort !== null) {
+    // The UI port is informational (unused by switchroom); reuse it if
+    // readable, else derive the standard pair (18888→19999, 8888→9999).
+    const uiPort =
+      readPort(CONTAINER_UI_PORT) ??
+      (apiPort === HINDSIGHT_DEFAULT_API_PORT ? HINDSIGHT_DEFAULT_UI_PORT : 19999);
+    return { apiPort, uiPort };
+  }
+  // `docker port` returns NOTHING for a `--network host` container (the
+  // deployed litellm shape runs `--network host`, no -p publishing), so a
+  // port-reassigned host-network deployment would otherwise fall back to the
+  // 18888 default and strand `memory.config.url`. Recover the real ports from
+  // the container's env, where `startHindsight` writes `HINDSIGHT_API_PORT`
+  // for exactly this mode.
+  return getHindsightPortsFromEnv();
+}
+
+/**
+ * Fallback for {@link getRunningHindsightPorts}: read the host ports from the
+ * running container's environment (`docker inspect --format '{{.Config.Env}}'`).
+ * Used for `--network host` deployments where `docker port` yields nothing.
+ * Reads `HINDSIGHT_API_PORT`; the UI port is informational, so it's derived
+ * from the API port (18888→19999, else 9999) unless a `HINDSIGHT_UI_PORT`-like
+ * var is present. Returns null when the container isn't inspectable or the API
+ * port env var is absent.
+ */
+function getHindsightPortsFromEnv(): { apiPort: number; uiPort: number } | null {
+  let env: string;
+  try {
+    env = execFileSync(
+      "docker",
+      ["inspect", "--format", "{{.Config.Env}}", "switchroom-hindsight"],
+      { stdio: "pipe", encoding: "utf-8" },
+    );
+  } catch {
+    return null;
+  }
+  // `{{.Config.Env}}` renders the env slice as a space-separated, bracketed
+  // Go list: `[FOO=1 HINDSIGHT_API_PORT=18888 BAR=baz]`. Values never contain
+  // spaces here (they're ports/URLs/keys), so a token split is sufficient.
+  const readVar = (name: string): number | null => {
+    const re = new RegExp(`(?:^|[\\s\\[])${name}=([^\\s\\]]+)`);
+    const m = env.match(re);
+    if (!m) return null;
+    const n = Number(m[1]);
+    return Number.isInteger(n) && n > 0 ? n : null;
+  };
+  const apiPort = readVar("HINDSIGHT_API_PORT");
   if (apiPort === null) return null;
-  // The UI port is informational (unused by switchroom); reuse it if
-  // readable, else derive the standard pair (18888→19999, 8888→9999).
   const uiPort =
-    readPort(CONTAINER_UI_PORT) ??
+    readVar("HINDSIGHT_UI_PORT") ??
     (apiPort === HINDSIGHT_DEFAULT_API_PORT ? HINDSIGHT_DEFAULT_UI_PORT : 19999);
   return { apiPort, uiPort };
 }

--- a/tests/cli.doctor.memory-health.test.ts
+++ b/tests/cli.doctor.memory-health.test.ts
@@ -8,6 +8,9 @@ import {
   classifyToolContract,
   classifyHindsightHealthProbe,
   checkHindsightHealthEndpoint,
+  classifyConsolidationBacklog,
+  CONSOLIDATION_BACKLOG_WARN,
+  CONSOLIDATION_BACKLOG_FAIL,
   type AdvertisedTool,
   MIN_HINDSIGHT_SHM_BYTES,
 } from "../src/cli/doctor-memory.js";
@@ -56,6 +59,41 @@ describe("classifyToolContract — live contract-drift detector", () => {
     for (const tool of Object.keys(EXPECTED_HINDSIGHT_TOOLS)) {
       expect(names.has(tool), `${tool} in EXPECTED_HINDSIGHT_TOOLS but not the snapshot`).toBe(true);
     }
+  });
+});
+
+describe("classifyConsolidationBacklog (#2903 fix 5.3)", () => {
+  it("ok when the queue is drained", () => {
+    const r = classifyConsolidationBacklog(0);
+    expect(r.status).toBe("ok");
+    expect(r.detail).toMatch(/drained/);
+  });
+
+  it("ok (not warn) just below the warn threshold", () => {
+    const r = classifyConsolidationBacklog(CONSOLIDATION_BACKLOG_WARN - 1);
+    expect(r.status).toBe("ok");
+  });
+
+  it("warns once the queue crosses the warn threshold", () => {
+    const r = classifyConsolidationBacklog(CONSOLIDATION_BACKLOG_WARN);
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain(`${CONSOLIDATION_BACKLOG_WARN} pending`);
+  });
+
+  it("fails when the queue is deep enough to be wedged", () => {
+    const r = classifyConsolidationBacklog(CONSOLIDATION_BACKLOG_FAIL);
+    expect(r.status).toBe("fail");
+    expect(r.fix).toBeDefined();
+  });
+
+  it("includes the oldest-op age when it is known", () => {
+    const r = classifyConsolidationBacklog(CONSOLIDATION_BACKLOG_WARN, 7200);
+    expect(r.detail).toMatch(/oldest 120m old/);
+  });
+
+  it("omits the age clause when age is unknown (REST /stats has no per-op age — #2847)", () => {
+    const r = classifyConsolidationBacklog(CONSOLIDATION_BACKLOG_WARN, null);
+    expect(r.detail).not.toMatch(/oldest/);
   });
 });
 

--- a/tests/memory.bank-health.test.ts
+++ b/tests/memory.bank-health.test.ts
@@ -387,6 +387,30 @@ describe("checkBankIngestHealth (doctor)", () => {
     // the agent-less profile bank must NOT render the empty "()" label
     expect(names).not.toContain("bank ken-profile ()");
   });
+
+  it("omits the fleet consolidation-backlog row unless opted in (#2903 fix 5.3)", async () => {
+    const BACKLOGGED = {
+      stats: { total_documents: 5, total_nodes: 50, pending_operations: 250 },
+      documents: { items: [{ id: "d1", created_at: "2026-06-09T00:00:00Z", text_length: 100, memory_unit_count: 2 }] },
+      models: { items: [] },
+    };
+    const cfg = minimalConfig({ marko: {} });
+    const fetchImpl = fakeFetchFor({ marko: BACKLOGGED });
+
+    // Default: per-bank rows only, no backlog aggregate (protects the contract
+    // the other tests in this file assert exact lengths against).
+    const bare = await checkBankIngestHealth(cfg, "http://x/mcp/", { fetchImpl, now: NOW });
+    expect(bare.some((r) => /backlog/i.test(r.name))).toBe(false);
+
+    // Opted in (as the CLI doctor does): the aggregate row is appended last.
+    const withBacklog = await checkBankIngestHealth(cfg, "http://x/mcp/", {
+      fetchImpl,
+      now: NOW,
+      includeConsolidationBacklog: true,
+    });
+    expect(withBacklog.length).toBe(bare.length + 1);
+    expect(/backlog/i.test(withBacklog[withBacklog.length - 1].name)).toBe(true);
+  });
 });
 
 const CORRUPT_MODEL_BANK = {

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -22,7 +22,12 @@ import {
   HINDSIGHT_BROKER_SOCK_VOLUME,
   HINDSIGHT_IMAGE,
   HINDSIGHT_DEFAULT_SHM_SIZE,
+  HINDSIGHT_DEFAULT_MODEL,
+  getRunningHindsightPorts,
+  HINDSIGHT_DEFAULT_API_PORT,
+  HINDSIGHT_DEFAULT_UI_PORT,
 } from "../../src/setup/hindsight.js";
+import { SWITCHROOM_DEFAULT_MAIN_MODEL } from "../../src/agents/scaffold.js";
 
 const mockedExec = execFileSync as unknown as ReturnType<typeof vi.fn>;
 
@@ -62,7 +67,7 @@ describe("hindsight broker-fed mode (#1245)", () => {
     expect(args).not.toContain("--entrypoint");
   });
 
-  it("adds a container healthcheck so docker restarts a wedged API", () => {
+  it("adds a container healthcheck that marks a wedged API unhealthy (visibility, not auto-restart)", () => {
     startHindsight({ apiPort: 8888, uiPort: 9999 });
     const args = findRunArgs();
     expect(args).toContain("--health-cmd");
@@ -186,8 +191,11 @@ describe("hindsight broker-fed mode (#1245)", () => {
     expect(envPairs).toContain(`HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`);
     expect(envPairs).toContain(`HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`);
     // Subscription-honest ceiling: concurrent model calls = slots × parallelism.
-    // Keep it well under a reckless level (was 12; bumped to 18, cap the guard at 24).
-    expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS * h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM).toBeLessThanOrEqual(24);
+    // #2894 throttled this to a hard ceiling of 1 × 2 = 2 after an 18-way
+    // fan-out exhausted the shared failover quota (2026-07-06 token-burn).
+    // The old guard (≤24) let that exact 18-way fan-out pass — this pins the
+    // ceiling at ≤2 so any regression that re-raises slots/parallelism trips it.
+    expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS * h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM).toBeLessThanOrEqual(2);
     const snippet = h.generateHindsightComposeSnippet();
     expect(snippet).toContain(`HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`);
     expect(snippet).toContain(`HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`);
@@ -311,6 +319,56 @@ describe("hindsight broker-fed mode (#1245)", () => {
 // in its OWN compose project rather than via `docker run`) had the same
 // tmpfs ownership bug. Pin the tmpfs flag shape here so the two
 // codepaths can't drift.
+describe("getRunningHindsightPorts — host-network env fallback (#2903 fix 5.2)", () => {
+  beforeEach(() => {
+    mockedExec.mockReset();
+  });
+
+  it("reads HINDSIGHT_API_PORT from `docker inspect` env when `docker port` is empty (--network host)", () => {
+    // A `--network host` container publishes no port mappings, so
+    // `docker port` returns "" — the code must then recover the real host
+    // port from the container's environment.
+    mockedExec.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "port") return ""; // host-network: no mappings
+      if (args[0] === "inspect") {
+        // `{{.Config.Env}}` renders as a bracketed, space-separated Go list.
+        return "[PATH=/usr/bin HINDSIGHT_API_PORT=28888 ANTHROPIC_BASE_URL=http://127.0.0.1:4010/anthropic]\n";
+      }
+      return "";
+    });
+    const ports = getRunningHindsightPorts();
+    expect(ports).toEqual({ apiPort: 28888, uiPort: 19999 });
+  });
+
+  it("still prefers `docker port` output when the container publishes mappings", () => {
+    mockedExec.mockImplementation((_cmd: string, args: string[]) => {
+      // args = ["port", "switchroom-hindsight", "<containerPort>/tcp"]
+      if (args[0] === "port" && args[2] === "8888/tcp") return "127.0.0.1:18888\n";
+      if (args[0] === "port" && args[2] === "9999/tcp") return "127.0.0.1:9999\n";
+      return "";
+    });
+    const ports = getRunningHindsightPorts();
+    expect(ports).toEqual({ apiPort: HINDSIGHT_DEFAULT_API_PORT, uiPort: HINDSIGHT_DEFAULT_UI_PORT });
+  });
+
+  it("returns null when neither `docker port` nor inspect env yield an API port", () => {
+    mockedExec.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "port") return "";
+      if (args[0] === "inspect") return "[PATH=/usr/bin FOO=bar]\n";
+      return "";
+    });
+    expect(getRunningHindsightPorts()).toBeNull();
+  });
+});
+
+describe("hindsight/scaffold model pin (#2903 fix 5.4)", () => {
+  it("HINDSIGHT_DEFAULT_MODEL stays in lockstep with SWITCHROOM_DEFAULT_MAIN_MODEL", () => {
+    // A fleet model bump must move memory ops too; if these drift, hindsight's
+    // retain/reflect/consolidation silently run on a stale model.
+    expect(HINDSIGHT_DEFAULT_MODEL).toBe(SWITCHROOM_DEFAULT_MAIN_MODEL);
+  });
+});
+
 describe("generateHindsightComposeSnippet — tmpfs ownership", () => {
   it("emits uid + gid on the /run/claude-creds tmpfs entry", async () => {
     const { generateHindsightComposeSnippet } = await import("../../src/setup/hindsight.js");


### PR DESCRIPTION
Implements **Priority 3 (Runtime correctness)** from #2903. Scoped to the P3 hunks only; P1 (`fix/hindsight-p1-security`) and P2 (`docs/hindsight-p2-truth`) own their own edits to `src/setup/hindsight.ts`.

## What changed & why

### Fix 5.1 — Healthcheck overclaim (chose: comment/test correction; restart mechanism deferred)
`src/setup/hindsight.ts` and `tests/setup/hindsight.test.ts` claimed the docker healthcheck makes docker "restart a wedged API". Vanilla Docker does **not** restart an unhealthy container — `--restart always` acts on process **exit** only, never on health status. Corrected the docker-run comment and renamed the test to state the healthcheck is *visibility* (marks the container `unhealthy` in `docker inspect`/`docker ps`), not a self-heal, so nobody relies on a heal that doesn't exist.

**Restart-on-unhealthy mechanism: deferred (follow-up).** The natural host for it, `docker/hindsight-maintenance.sh`, runs *inside* the hindsight container (local pg socket, no docker binary/socket), so it cannot `docker restart` itself. A real restart-on-unhealthy needs a host-side autoheal sidecar (or a self-exit-on-wedge probe) — beyond the ~30-min/low-risk bar in the task and it risks the running container. Deferred rather than shipped half-done.

### Fix 5.2 — `--recreate` can't reuse the port on host-network deployments
`getRunningHindsightPorts()` shells `docker port`, which returns nothing for `--network host` containers (the deployed litellm shape). So `switchroom memory setup --recreate` silently fell back to the 18888 default and stranded `memory.config.url`. Added a `docker inspect --format '{{.Config.Env}}'` fallback that recovers `HINDSIGHT_API_PORT` (and UI port) from the container env when `docker port` is empty. New tests with a mocked host-network inspect payload (+ `docker port`-preferred and null cases).

### Fix 5.3 — Backlog visibility for the #2894 throttle
With MAX_SLOTS=1 the consolidation queue drains ~7 ops/hr; the only prior signal was a 2h queue-lag WARNING in `hindsight-maintenance.sh` written to docker logs. Added `classifyConsolidationBacklog()` wired into the doctor memory-health probe, summing each bank's `/stats.pending_operations` so `switchroom doctor` shows queue depth (ok / warn / fail). **Measurement follow-up: #2847** — the REST `/stats` surface exposes depth but not per-op age, so oldest-pending age is reported only when known (null over REST today; the maintenance loop already logs it).

### Fix 5.4 — Port-constant duplication
Replaced the scattered literal `18888` fallbacks in `scaffold.ts` (x3), `doctor.ts`, `agent.ts` (x2) and `memory.ts` (x2) with the shared `HINDSIGHT_DEFAULT_MCP_URL` and a new `HINDSIGHT_DEFAULT_API_BASE_URL` (both derived from `HINDSIGHT_DEFAULT_API_PORT`), so the port genuinely lives in one place. Tied `HINDSIGHT_DEFAULT_MODEL` to `SWITCHROOM_DEFAULT_MAIN_MODEL` via an **equality test** (rather than a shared import, to avoid a scaffold<->setup import cycle) so a fleet model bump can't strand memory ops.

## Out of scope (untouched)
- #2894 throttle values and #2888 model-pin mechanism.
- P1 compose-snippet port lines and docker-run binding; P2 comment-only fixes — left to their PRs to keep rebase mechanical.

## Guarantee-delta (CONTRIBUTING step 8)
No change to any liveness surface (`feedHeartbeatTick`, `feed-open-gate.ts`, `silence-poke.ts`, `turn-liveness-floor.ts`, card-edit path). Chat-visible behavior unchanged; the only new user-visible surface is one extra read-only `switchroom doctor` line (consolidation backlog). No framework delivery guarantee added or removed.

## Test plan
- `tsc --noEmit`: clean
- `vitest run tests/setup/hindsight.test.ts tests/cli.doctor.memory-health.test.ts`: 58 passed
- `vitest run tests/cli.doctor*`: 40 passed

Refs #2903, #2847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)