### PR TITLE
fix(hindsight): P4 flow hardening — propose-card lifecycle, directive dedup, vendor envelope decoupling

### DIFF
--- a/src/host-control/admit-self-scoped-non-admin-edit.test.ts
+++ b/src/host-control/admit-self-scoped-non-admin-edit.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { admitSelfScopedNonAdminEdit } from "./config-edit-validator.js";
+
+/**
+ * Pins the EITHER/OR admission branch that HostControlServer applies to a
+ * non-admin `config_propose_edit` (Fix 6.1): an edit is admitted if it is
+ * EITHER a self-scoped `tools.allow` widen OR a self-scoped append to the
+ * caller's own `memory.mental_models[]`. Only when BOTH fail is it denied.
+ * Previously only the two component validators were pinned; the OR-combination
+ * (the thing the server actually decides on) had no test.
+ */
+
+const BASE = `agents:
+  coach:
+    persona: fitness
+    tools:
+      allow:
+        - Read
+    memory:
+      collection: coach-bank
+  lawyer:
+    persona: legal
+`;
+
+describe("admitSelfScopedNonAdminEdit", () => {
+  it("ADMITS a self-scoped tools.allow widen (via=tools.allow)", () => {
+    const after = `agents:
+  coach:
+    persona: fitness
+    tools:
+      allow:
+        - Read
+        - Edit(/x)
+    memory:
+      collection: coach-bank
+  lawyer:
+    persona: legal
+`;
+    expect(admitSelfScopedNonAdminEdit(BASE, after, "coach")).toEqual({
+      ok: true,
+      via: "tools.allow",
+    });
+  });
+
+  it("ADMITS a self-scoped mental_models append (via=mental_models) when tools.allow is untouched", () => {
+    const after = `agents:
+  coach:
+    persona: fitness
+    tools:
+      allow:
+        - Read
+    memory:
+      collection: coach-bank
+      mental_models:
+        - name: training-plan-state
+          source_query: What is the plan?
+  lawyer:
+    persona: legal
+`;
+    expect(admitSelfScopedNonAdminEdit(BASE, after, "coach")).toEqual({
+      ok: true,
+      via: "mental_models",
+    });
+  });
+
+  it("DENIES an edit that touches ANOTHER agent — both branches fail", () => {
+    const after = `agents:
+  coach:
+    persona: fitness
+    tools:
+      allow:
+        - Read
+    memory:
+      collection: coach-bank
+  lawyer:
+    persona: legal
+    tools:
+      allow:
+        - Bash
+`;
+    const r = admitSelfScopedNonAdminEdit(BASE, after, "coach");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      // The denial carries BOTH diagnostics: the tools.allow detail (surfaced
+      // as the primary error) and the mental-model detail (for `.why()`).
+      expect(typeof r.detail).toBe("string");
+      expect(typeof r.mentalModelDetail).toBe("string");
+    }
+  });
+
+  it("DENIES an edit that smuggles a foreign field alongside a valid model append", () => {
+    const after = `agents:
+  coach:
+    persona: changed-persona
+    tools:
+      allow:
+        - Read
+    memory:
+      collection: coach-bank
+      mental_models:
+        - name: training-plan-state
+          source_query: What is the plan?
+  lawyer:
+    persona: legal
+`;
+    expect(admitSelfScopedNonAdminEdit(BASE, after, "coach").ok).toBe(false);
+  });
+});

--- a/src/host-control/config-edit-validator.ts
+++ b/src/host-control/config-edit-validator.ts
@@ -738,6 +738,38 @@ export function assertSelfScopedMentalModelEdit(
   return { ok: true };
 }
 
+/**
+ * The non-admin `config_propose_edit` admission decision: an edit is admitted
+ * if it is EITHER a self-scoped `tools.allow` widen (the "🔁 Always allow"
+ * persistence path) OR a self-scoped append to the caller's own
+ * `memory.mental_models[]` (the agent-proposes → human-approves curation path).
+ * Only when BOTH fail is the edit denied. This encapsulates the exact either/or
+ * branch enforced in `HostControlServer` so it is unit-testable without standing
+ * up the full server (the historical gap: the branch was only pinned via its two
+ * component validators, never the OR-combination itself).
+ *
+ * On denial, `detail` surfaces the tools.allow failure (the most-common mode)
+ * and `mentalModelDetail` carries the mental-model failure for diagnostics.
+ * Pure: delegates to the two component validators, no I/O.
+ */
+export function admitSelfScopedNonAdminEdit(
+  beforeContent: string,
+  afterContent: string,
+  caller: string,
+):
+  | { ok: true; via: "tools.allow" | "mental_models" }
+  | { ok: false; detail: string; mentalModelDetail: string } {
+  const allowScope = assertSelfScopedAllowEdit(beforeContent, afterContent, caller);
+  if (allowScope.ok) return { ok: true, via: "tools.allow" };
+  const mentalModelScope = assertSelfScopedMentalModelEdit(beforeContent, afterContent, caller);
+  if (mentalModelScope.ok) return { ok: true, via: "mental_models" };
+  return {
+    ok: false,
+    detail: allowScope.detail,
+    mentalModelDetail: mentalModelScope.detail,
+  };
+}
+
 function readCallerMentalModels(cfg: Record<string, unknown>, caller: string): unknown[] {
   const agents = cfg.agents;
   if (!agents || typeof agents !== "object") return [];

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -81,8 +81,7 @@ import { parseUpdateResultLine } from "../cli/update.js";
 import { parseAuditLine, latestRolloutRowForRequest } from "./audit-reader.js";
 import {
   validateConfigEdit,
-  assertSelfScopedAllowEdit,
-  assertSelfScopedMentalModelEdit,
+  admitSelfScopedNonAdminEdit,
 } from "./config-edit-validator.js";
 import { classifyBlastRadius } from "./config-blast-radius.js";
 import type { ApprovalGateway } from "./approval-gateway.js";
@@ -2176,38 +2175,33 @@ export class HostdServer {
       } catch {
         beforeContent = "";
       }
-      const allowScope = assertSelfScopedAllowEdit(
+      // A non-admin edit is admitted if it is EITHER a self-scoped tools.allow
+      // widen (the "🔁 Always allow" path) OR a self-scoped append to the
+      // caller's own memory.mental_models[] (the agent-proposes → human-
+      // approves curation path). Only when BOTH fail is the edit rejected. The
+      // either/or combination lives in admitSelfScopedNonAdminEdit so it is
+      // unit-testable without standing up this server. On denial we surface the
+      // tools.allow detail (the historical, most-common failure mode) and
+      // document the mental-models path in `.why()`.
+      const admission = admitSelfScopedNonAdminEdit(
         beforeContent,
         verdict.postApplyContent,
         caller.name,
       );
-      // A non-admin edit is admitted if it is EITHER a self-scoped tools.allow
-      // widen (the "🔁 Always allow" path) OR a self-scoped append to the
-      // caller's own memory.mental_models[] (the agent-proposes → human-
-      // approves curation path). Only when BOTH fail is the edit rejected. We
-      // surface the tools.allow detail (the historical, most-common failure
-      // mode) and document the mental-models path in `.why()`.
-      if (!allowScope.ok) {
-        const mentalModelScope = assertSelfScopedMentalModelEdit(
-          beforeContent,
-          verdict.postApplyContent,
-          caller.name,
-        );
-        if (!mentalModelScope.ok) {
-          return err("E_NOT_SELF_SCOPED", allowScope.detail)
-            .why(
-              "non-admin agents may only add rules to their own " +
-                "agents.<self>.tools.allow OR append their own " +
-                "agents.<self>.memory.mental_models via config_propose_edit " +
-                `(mental-model check: ${mentalModelScope.detail})`,
-            )
-            .fixBadInput("unified_diff")
-            .op("config_propose_edit")
-            .caller("agent")
-            .agentName(caller.name)
-            .asDenied()
-            .build(req.request_id, Date.now() - started);
-        }
+      if (!admission.ok) {
+        return err("E_NOT_SELF_SCOPED", admission.detail)
+          .why(
+            "non-admin agents may only add rules to their own " +
+              "agents.<self>.tools.allow OR append their own " +
+              "agents.<self>.memory.mental_models via config_propose_edit " +
+              `(mental-model check: ${admission.mentalModelDetail})`,
+          )
+          .fixBadInput("unified_diff")
+          .op("config_propose_edit")
+          .caller("agent")
+          .agentName(caller.name)
+          .asDenied()
+          .build(req.request_id, Date.now() - started);
       }
     }
     // ── Approval card ───────────────────────────────────────────────

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5181,20 +5181,45 @@ interface PendingMentalModelPropose {
 }
 const pendingMentalModelProposes = new Map<string, PendingMentalModelPropose>()
 const MENTAL_MODEL_PROPOSE_TTL_MS = approvalTtlMs()
+// Sweep expired pending proposals. For any entry past its TTL we ALSO edit the
+// posted card's keyboard away, so a stale card left in the chat can't be tapped
+// into a "Card expired" answer — the operator sees the ⌛ expiry inline instead.
+// Best-effort: card edits are fire-and-forget (the entry is removed regardless).
 function sweepPendingMentalModelProposes(): void {
   const cutoff = Date.now() - MENTAL_MODEL_PROPOSE_TTL_MS
   for (const [k, v] of pendingMentalModelProposes) {
-    if (v.staged_at < cutoff) pendingMentalModelProposes.delete(k)
+    if (v.staged_at < cutoff) {
+      pendingMentalModelProposes.delete(k)
+      if (v.card_message_id != null) {
+        void lockedBot.api
+          .editMessageText(
+            v.chat_id,
+            v.card_message_id,
+            richMessage('⌛ _This mental-model proposal card expired. Ask the agent to re-propose if it still stands._'),
+            { reply_markup: { inline_keyboard: [] } },
+          )
+          .catch(() => {})
+      }
+    }
   }
 }
 
-// Per-agent sliding-window rate limit for mental-model proposals: at most
+// Sliding-window rate limit for mental-model proposals: at most
 // MENTAL_MODEL_PROPOSE_MAX_PER_WINDOW cards per MENTAL_MODEL_PROPOSE_WINDOW_MS.
-// A candidate model is a deliberate, rare curation act — an agent that
-// re-proposes in a loop should be throttled so the operator is never spammed.
+// The window is per-gateway-process, and since each agent runs its own gateway
+// process (keyed by $SWITCHROOM_AGENT_NAME), one process == one agent — so this
+// throttle is effectively per-agent. A candidate model is a deliberate, rare
+// curation act — an agent that re-proposes in a loop should be throttled so the
+// operator is never spammed.
 const mentalModelProposeTimes: number[] = []
 const MENTAL_MODEL_PROPOSE_WINDOW_MS = 60 * 60 * 1000
 const MENTAL_MODEL_PROPOSE_MAX_PER_WINDOW = 5
+// Mirror the memory.mental_models[] schema caps (src/config/schema.ts): a
+// source_query capped at 2000 chars and max_tokens capped at 8192. Enforced
+// up-front in executeMentalModelPropose so a proposal that would fail hostd
+// config validation never reaches an approval card.
+const MENTAL_MODEL_SOURCE_QUERY_MAX = 2000
+const MENTAL_MODEL_MAX_TOKENS_CAP = 8192
 function checkMentalModelProposeRate(now = Date.now()): { ok: true } | { ok: false; retryAtMs: number } {
   const cutoff = now - MENTAL_MODEL_PROPOSE_WINDOW_MS
   while (mentalModelProposeTimes.length > 0 && mentalModelProposeTimes[0]! < cutoff) {
@@ -11959,6 +11984,15 @@ async function executeMentalModelPropose(args: Record<string, unknown>): Promise
   }
   const source_query = typeof args.source_query === 'string' ? args.source_query.trim() : ''
   if (!source_query) throw new Error('mental_model_propose: source_query is required')
+  // Enforce the memory.mental_models[] schema cap (src/config/schema.ts) up-front
+  // so the operator never approves a card that then fails hostd config validation.
+  // The 2000-char ceiling also keeps the rendered card under Telegram's 4096-char
+  // message limit.
+  if (source_query.length > MENTAL_MODEL_SOURCE_QUERY_MAX) {
+    throw new Error(
+      `mental_model_propose: source_query is ${source_query.length} chars; the schema caps it at ${MENTAL_MODEL_SOURCE_QUERY_MAX} (a standing reflection query, not a document). Shorten it.`,
+    )
+  }
   // Accept `why` as an alias for `reason` (mirrors the vault tools).
   const reason =
     typeof args.reason === 'string' ? args.reason : typeof args.why === 'string' ? args.why : undefined
@@ -11974,6 +12008,13 @@ async function executeMentalModelPropose(args: Record<string, unknown>): Promise
     const n = Number(args.max_tokens)
     if (!Number.isInteger(n) || n <= 0) {
       throw new Error('mental_model_propose: max_tokens must be a positive integer')
+    }
+    // Enforce the schema ceiling (src/config/schema.ts) here so the card can't be
+    // approved into a config-validation failure downstream.
+    if (n > MENTAL_MODEL_MAX_TOKENS_CAP) {
+      throw new Error(
+        `mental_model_propose: max_tokens ${n} exceeds the schema cap of ${MENTAL_MODEL_MAX_TOKENS_CAP} (a mental model is a standing summary, not a corpus).`,
+      )
     }
     max_tokens = n
   }
@@ -20944,6 +20985,24 @@ async function handleMentalModelProposeCallback(ctx: Context, data: string): Pro
   }
   if (action !== 'approve' && action !== 'deny') {
     await ctx.answerCallbackQuery({ text: 'Bad request' }).catch(() => {})
+    return
+  }
+  // Enforce the TTL at TAP time, not just on the next propose's sweep. Without
+  // this, a card left untapped past its TTL is still resolvable if no fresh
+  // proposal has run the sweep — an operator could approve a stale proposal.
+  if (Date.now() - pending.staged_at > MENTAL_MODEL_PROPOSE_TTL_MS) {
+    pendingMentalModelProposes.delete(stageId)
+    await ctx.answerCallbackQuery({ text: 'Card expired — ask the agent to re-propose.' }).catch(() => {})
+    if (pending.card_message_id != null) {
+      await ctx.api
+        .editMessageText(
+          pending.chat_id,
+          pending.card_message_id,
+          richMessage('⌛ _This mental-model proposal card expired before you tapped. Ask the agent to re-propose if it still stands._'),
+          { reply_markup: { inline_keyboard: [] } },
+        )
+        .catch(() => {})
+    }
     return
   }
   // Single-shot: remove the pending entry immediately so a double-tap can't

--- a/telegram-plugin/tests/mental-model-propose-callback-gate.test.ts
+++ b/telegram-plugin/tests/mental-model-propose-callback-gate.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Contract pins for `handleMentalModelProposeCallback` — the operator-tap
+ * resolver for a mental-model proposal card (hindsight Phase 5, Fix 6.1).
+ *
+ * These are source-inspection pins (the handler needs a live grammY Context +
+ * hostd dispatch to run, so we assert its structure the same way the vault
+ * callback posture tests do). Load-bearing invariants:
+ *
+ *   1. The `allowFrom` authorization gate is the FIRST thing the handler does —
+ *      a tap from anyone not on the operator allow-list is refused before any
+ *      pending lookup, pending delete, or hostd dispatch runs. This is the
+ *      "an agent can never self-approve" boundary.
+ *   2. The TTL is enforced at TAP time, not only on the next propose's sweep —
+ *      a card past MENTAL_MODEL_PROPOSE_TTL_MS is refused and its keyboard is
+ *      edited away, even when no fresh proposal has swept it.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const gatewaySrc = readFileSync(resolve(__dirname, '..', 'gateway', 'gateway.ts'), 'utf-8')
+
+function proposeCallbackBlock(): string {
+  return (
+    gatewaySrc.split('async function handleMentalModelProposeCallback')[1]?.split('\nasync function')[0] ?? ''
+  )
+}
+
+describe('handleMentalModelProposeCallback — authorization gate', () => {
+  it('refuses a tap from a non-operator via the allowFrom allow-list FIRST', () => {
+    const block = proposeCallbackBlock()
+    expect(block).toMatch(/if \(!access\.allowFrom\.includes\(senderId\)\)/)
+    expect(block).toMatch(/Not authorized/)
+    // The allowFrom guard must precede the pending lookup / delete: no state
+    // mutation before authorization.
+    const beforeGuard = block.split('access.allowFrom.includes(senderId)')[0] ?? ''
+    expect(beforeGuard).not.toMatch(/pendingMentalModelProposes\.get/)
+    expect(beforeGuard).not.toMatch(/pendingMentalModelProposes\.delete/)
+  })
+})
+
+describe('handleMentalModelProposeCallback — TTL enforced at tap time', () => {
+  it('checks staged_at against MENTAL_MODEL_PROPOSE_TTL_MS at tap and edits the card away', () => {
+    const block = proposeCallbackBlock()
+    expect(block).toMatch(/Date\.now\(\) - pending\.staged_at > MENTAL_MODEL_PROPOSE_TTL_MS/)
+    // The expired branch deletes the pending entry and clears the keyboard so a
+    // stale card can't be tapped into an approval.
+    const ttlBranch =
+      block.split('Date.now() - pending.staged_at > MENTAL_MODEL_PROPOSE_TTL_MS')[1]?.split('Single-shot')[0] ?? ''
+    expect(ttlBranch).toMatch(/pendingMentalModelProposes\.delete\(stageId\)/)
+    expect(ttlBranch).toMatch(/expired/)
+    expect(ttlBranch).toMatch(/inline_keyboard: \[\]/)
+  })
+})
+
+describe('executeMentalModelPropose — schema caps enforced up-front', () => {
+  it('rejects an over-length source_query and an over-cap max_tokens before posting a card', () => {
+    const fn =
+      gatewaySrc.split('async function executeMentalModelPropose')[1]?.split('\nasync function')[0] ?? ''
+    expect(fn).toMatch(/source_query\.length > MENTAL_MODEL_SOURCE_QUERY_MAX/)
+    expect(fn).toMatch(/n > MENTAL_MODEL_MAX_TOKENS_CAP/)
+    // Caps mirror the schema (src/config/schema.ts): 2000 / 8192.
+    expect(gatewaySrc).toMatch(/MENTAL_MODEL_SOURCE_QUERY_MAX = 2000/)
+    expect(gatewaySrc).toMatch(/MENTAL_MODEL_MAX_TOKENS_CAP = 8192/)
+  })
+})

--- a/vendor/hindsight-memory/scripts/directive_verify.py
+++ b/vendor/hindsight-memory/scripts/directive_verify.py
@@ -58,6 +58,10 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from lib.config import debug_log, load_config  # noqa: E402
+from lib.directives import (  # noqa: E402
+    parse_active_directives_block,
+    rule_already_captured,
+)
 
 # Reuse Stage B's pleasantry scrub so "as always" / "always happy to help"
 # can't trip the high-confidence detector either. Imported lazily-safe: if
@@ -127,6 +131,9 @@ _VERIFY_BLOCK_REASON = (
     "If it is genuinely a durable rule, call "
     "mcp__hindsight__create_directive NOW (verbatim, in the user's own "
     "words), then briefly confirm you have saved it.\n"
+    "UNLESS an equivalent active directive already exists (see the "
+    "<active_directives> block for this turn) — in that case it is already "
+    "saved; do NOT create a duplicate, just finish.\n"
     "If, on reflection, it was only a one-off instruction for this task, do "
     "NOT create a directive — just finish your reply normally.\n"
     "This verification fires once per turn.\n"
@@ -139,44 +146,20 @@ _INJECTED_MARKERS = (
     "<directive_capture_check>",
     "<directive_capture_verify>",
     "<hindsight_memories>",
+    # recall.py injects the bank's active directives as a top-of-prompt block;
+    # it is hook-injected context, not a human turn (#2903 Fix 6.2).
+    "<active_directives>",
     "Relevant memories from past conversations",
 )
 
-# Genuine human inbound channels. A "user" turn whose `<channel source="...">`
-# envelope names anything else is a SYNTHESIZED / cron inbound built by the
-# gateway (see telegram-plugin/gateway/*-inbound-builder.ts + reaction /
-# resume / vault-grant / subagent / obligation builders) — a machine turn, NOT
-# a human correction. The blocking re-prompt must never fire on those: nagging
-# the model to persist a "durable rule" on a cron digest or a resume synthetic
-# is pure noise. Interactive sessions carry NO channel envelope and are treated
-# as human. Kept as a whitelist so any NEW synthetic source is skipped by
-# default rather than accidentally nagged on.
-_HUMAN_INBOUND_SOURCES = frozenset({"telegram"})
-
-# Pulls the source attribute out of the gateway's leading `<channel ...>`
-# envelope. Handles both open (`<channel source="telegram" ...>`) and
-# self-closing (`<channel source="reaction"/>`) forms.
-_CHANNEL_SOURCE_RE = re.compile(r"""<channel\b[^>]*\bsource=["']([^"']+)["']""")
-
-
-def is_synthetic_inbound(text) -> bool:
-    """True when this turn's opening human message is a synthesized/cron
-    inbound rather than a genuine human message.
-
-    Detection is purely on the gateway-prepended ``<channel source="...">``
-    envelope: a ``source`` outside ``_HUMAN_INBOUND_SOURCES`` (``cron``,
-    ``reaction``, ``resume_interrupted``, ``vault_grant_approved``,
-    ``subagent_handback``, ``obligation_represent``, …) marks a non-human turn.
-    No envelope (interactive session) → treated as human. Injected channel tags
-    in a human's own body are neutralised upstream by the channel-envelope
-    sanitiser, so the only real ``<channel source=`` is the gateway's.
-    """
-    if not isinstance(text, str):
-        return False
-    m = _CHANNEL_SOURCE_RE.search(text)
-    if not m:
-        return False
-    return m.group(1).strip().lower() not in _HUMAN_INBOUND_SOURCES
+# SWITCHROOM DIVERGENCE (#2903 Fix 6.3): the `<channel source="...">` envelope
+# grammar and the human-source whitelist used to be hard-coded inline here,
+# silently coupling this vendored Python guard to the switchroom gateway's TS
+# wire format. Extracted to lib/switchroom_envelope.py so a TS-side envelope
+# change has ONE obvious Python counterpart to update (and its own test) rather
+# than breaking this guard undetected. `is_synthetic_inbound` is re-exported for
+# backward compatibility with existing tests/callers.
+from lib.switchroom_envelope import is_synthetic_inbound  # noqa: E402,F401
 
 
 def looks_like_durable_directive(text) -> bool:
@@ -292,6 +275,27 @@ def _errored_tool_use_ids(messages: list) -> set:
     return errored
 
 
+def collect_active_directive_contents(messages: list) -> list:
+    """Gather the CONTENT strings of every active directive injected into this
+    turn's context.
+
+    recall.py injects an ``<active_directives>`` block (the bank's currently
+    active directives) into the UserPromptSubmit context; it shows up in the
+    transcript as an injected user message. We parse those back out so the
+    verifier can tell whether a restated rule is ALREADY stored — in which case
+    the model correctly declines to re-create it and we must NOT block (#2903
+    Fix 6.2). Pure string parsing; no API call.
+    """
+    contents: list = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        text = _message_text(msg.get("content"))
+        if "<active_directives>" in text:
+            contents.extend(parse_active_directives_block(text))
+    return contents
+
+
 def directive_recorded_after(messages: list, start_index: int) -> bool:
     """True if any assistant turn after ``start_index`` called create_directive
     with a SUCCESSFUL result. A call whose tool_result errored does not count
@@ -355,6 +359,12 @@ def evaluate(hook_input: dict, config: dict) -> str | None:
         debug_log(config, "Directive-capture verify: feature disabled, allowing stop")
         return None
 
+    # #2873/#2903 Fix 6.2 — the BLOCK is separately gated: an operator can keep
+    # the advisory Stage B nudge while dropping the more intrusive Stop block.
+    if not config.get("directiveCaptureVerify", True):
+        debug_log(config, "Directive-capture verify: block disabled (nudge-only), allowing stop")
+        return None
+
     # Loop / one-off guard: if we already blocked once this turn, respect the
     # model's second judgment and never re-block.
     if hook_input.get("stop_hook_active"):
@@ -382,6 +392,18 @@ def evaluate(hook_input: dict, config: dict) -> str | None:
 
     if directive_recorded_after(messages, idx):
         debug_log(config, "Directive-capture verify: create_directive already called, allowing stop")
+        return None
+
+    # Dedup (#2903 Fix 6.2): if the restated rule is already covered by an
+    # active directive injected into this turn's <active_directives> block, the
+    # model CORRECTLY declined to re-create a duplicate — blocking here would
+    # nag it to double-store. Allow stop.
+    existing = collect_active_directive_contents(messages)
+    if existing and rule_already_captured(text, existing):
+        debug_log(
+            config,
+            "Directive-capture verify: rule already covered by an active directive, allowing stop",
+        )
         return None
 
     debug_log(

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -54,6 +54,16 @@ DEFAULTS = {
     # out per-agent via memory.directive_capture_nudge=false →
     # HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE (disables BOTH hooks).
     "directiveCaptureNudge": True,
+    # Switchroom #2873/#2903 Fix 6.2 — the BLOCKING half (Stage C
+    # directive_verify.py Stop hook) split out from the advisory nudge. When
+    # True (default) the verifier may block the stop once to re-prompt capture;
+    # when False the Stage B nudge still fires but the Stop hook NEVER blocks
+    # (advisory-only mode). Lets an operator keep the gentle nudge while dropping
+    # the more intrusive block. Gated UNDER directiveCaptureNudge: turning the
+    # nudge off disables both regardless of this knob. Operators opt out
+    # per-agent via memory.directive_capture_verify=false →
+    # HINDSIGHT_DIRECTIVE_CAPTURE_VERIFY.
+    "directiveCaptureVerify": True,
     "recallContextTurns": 1,
     "recallMaxQueryChars": 800,
     "recallRoles": ["user", "assistant"],
@@ -141,6 +151,11 @@ ENV_OVERRIDES = {
     # the operator overrode it; the switchroom default is on (settings.json
     # pins true; recall.py falls back to True).
     "HINDSIGHT_DIRECTIVE_CAPTURE_NUDGE": ("directiveCaptureNudge", bool),
+    # Switchroom #2873/#2903 Fix 6.2: the Stage C block on/off, independent of
+    # the Stage B nudge. Set by start.sh from
+    # agents.<name>.memory.directive_capture_verify only when the operator
+    # overrode it; the switchroom default is on.
+    "HINDSIGHT_DIRECTIVE_CAPTURE_VERIFY": ("directiveCaptureVerify", bool),
     "HINDSIGHT_RECALL_MAX_QUERY_CHARS": ("recallMaxQueryChars", int),
     "HINDSIGHT_RECALL_CONTEXT_TURNS": ("recallContextTurns", int),
     # Upstream 962140eef — recall tag filters. The tags env var accepts JSON

--- a/vendor/hindsight-memory/scripts/lib/directives.py
+++ b/vendor/hindsight-memory/scripts/lib/directives.py
@@ -16,6 +16,7 @@ stderr. We never raise to the caller — directives are nice-to-have on the
 recall path; a directive-fetch failure must not kill the recall block.
 """
 
+import re
 import sys
 from typing import Optional
 
@@ -117,3 +118,90 @@ def format_active_directives_block(directives: list, max_directives: int = MAX_D
 
     lines.append("</active_directives>")
     return "\n".join(lines)
+
+
+# --- Directive dedup (switchroom #2903 Fix 6.2) --------------------------------
+#
+# A user restating a rule that is ALREADY an active directive should not get
+# re-nudged, and the Stage C verifier must not BLOCK the turn where the model
+# correctly declines to re-create the duplicate. The verifier can see the
+# directives that were injected THIS turn (recall.py emits the
+# <active_directives> block into the prompt), so it reads them back out of the
+# transcript and treats a rule already covered there as "already captured".
+#
+# Matching is a deterministic lexical-overlap heuristic (no model call, no API
+# call — the verifier is on the Stop critical path). It is intentionally
+# lenient: a false "already captured" only means we skip a re-prompt (the rule
+# is genuinely already stored in that case), whereas a false "not captured"
+# re-blocks a turn the model correctly finished. So we err toward treating a
+# strong token overlap as a duplicate.
+
+# Parses the numbered "N. [P<pri>] <name>: <content>" body lines out of a
+# rendered <active_directives> block (see format_active_directives_block).
+_ACTIVE_DIRECTIVE_LINE_RE = re.compile(
+    r"^\s*\d+\.\s*\[P-?\d+\]\s*[^:]*:\s*(?P<content>.+?)\s*$"
+)
+
+# Low-signal words stripped before overlap scoring so "always"/"you"/"please"
+# framing doesn't inflate similarity between two unrelated rules.
+_DEDUP_STOPWORDS = frozenset(
+    {
+        "the", "a", "an", "to", "of", "and", "or", "for", "in", "on", "at",
+        "is", "are", "be", "you", "your", "i", "we", "me", "my", "it", "that",
+        "this", "with", "as", "so", "do", "dont", "don", "not", "never",
+        "always", "please", "should", "must", "want", "from", "now", "on",
+        "going", "forward", "forwards", "future", "rule", "remember", "call",
+        "use", "using", "make", "sure", "when", "if", "just", "will", "can",
+    }
+)
+
+
+def _dedup_tokens(text: str) -> set:
+    """Normalize text into a set of significant lower-case word tokens."""
+    if not isinstance(text, str):
+        return set()
+    words = re.findall(r"[a-z0-9]+", text.lower())
+    return {w for w in words if w not in _DEDUP_STOPWORDS and len(w) > 1}
+
+
+def parse_active_directives_block(text: str) -> list:
+    """Extract the directive CONTENT strings from a rendered
+    <active_directives> block (as produced by format_active_directives_block).
+
+    Returns [] when the block is absent or malformed. Pure string parsing.
+    """
+    if not isinstance(text, str) or "<active_directives>" not in text:
+        return []
+    # Isolate the block body between the tags (tolerate missing close tag).
+    body = text.split("<active_directives>", 1)[1]
+    body = body.split("</active_directives>", 1)[0]
+    contents = []
+    for line in body.splitlines():
+        m = _ACTIVE_DIRECTIVE_LINE_RE.match(line)
+        if m:
+            contents.append(m.group("content").strip())
+    return contents
+
+
+def rule_already_captured(
+    rule_text: str, directive_contents: list, threshold: float = 0.6
+) -> bool:
+    """True when ``rule_text`` is lexically well-covered by an EXISTING active
+    directive in ``directive_contents``.
+
+    Coverage = |rule_tokens ∩ directive_tokens| / |rule_tokens| for the
+    best-matching directive. A high coverage ratio means the restated rule adds
+    (almost) no new significant words over one already stored — i.e. a
+    duplicate. Deterministic; no model/API call.
+    """
+    rule_tokens = _dedup_tokens(rule_text)
+    if not rule_tokens:
+        return False
+    for content in directive_contents:
+        d_tokens = _dedup_tokens(content)
+        if not d_tokens:
+            continue
+        covered = len(rule_tokens & d_tokens) / len(rule_tokens)
+        if covered >= threshold:
+            return True
+    return False

--- a/vendor/hindsight-memory/scripts/lib/switchroom_envelope.py
+++ b/vendor/hindsight-memory/scripts/lib/switchroom_envelope.py
@@ -1,0 +1,77 @@
+"""Switchroom gateway inbound-envelope grammar — the ONE place this vendored
+Python knows about switchroom's ``<channel source="...">`` wire format.
+
+SWITCHROOM DIVERGENCE (not upstream Hindsight). This module isolates the
+coupling between the vendored Python hooks and the switchroom telegram-plugin
+gateway's inbound envelope. It exists so a change to the TS-side envelope
+grammar has ONE obvious Python counterpart to update — instead of the grammar
+being buried inline inside directive_verify.py where a silent TS format change
+could break a Python guard undetected (#2903 Fix 6.3).
+
+The gateway prepends a leading ``<channel source="..." ...>`` envelope to every
+SYNTHESIZED / non-human inbound it injects into the model (cron fires, reaction
+dispatches, resume synthetics, vault-grant approvals, sub-agent handbacks,
+obligation representations, …). See, on the TS side:
+
+  * telegram-plugin/gateway/*-inbound-builder.ts (and the reaction / resume /
+    vault-grant / subagent / obligation builders) — they emit
+    ``<channel source="<name>" ...>``.
+  * A genuine human message from the primary channel carries
+    ``source="telegram"``; interactive (non-gateway) sessions carry NO envelope
+    at all.
+
+Contract pinned here (keep in lockstep with the gateway):
+  * ``CHANNEL_SOURCE_RE`` — extracts the ``source`` attribute from the leading
+    envelope. Handles both open (``<channel source="telegram" ...>``) and
+    self-closing (``<channel source="reaction"/>``) forms.
+  * ``HUMAN_INBOUND_SOURCES`` — the whitelist of ``source`` values that denote a
+    GENUINE human turn. A whitelist (not a blacklist) so any NEW synthetic
+    source the gateway adds is treated as machine-authored by default rather
+    than accidentally classified human.
+
+If the gateway ever renames the envelope tag, changes the attribute name, or
+adds a new human-facing channel, update THIS module (and its test,
+tests/test_switchroom_envelope.py). Nothing else in the Python tree should hard
+-code the ``<channel source=`` grammar.
+"""
+
+import re
+
+# Genuine human inbound channels. A "user" turn whose `<channel source="...">`
+# envelope names anything else is a SYNTHESIZED / cron inbound built by the
+# gateway — a machine turn, NOT a human correction.
+HUMAN_INBOUND_SOURCES = frozenset({"telegram"})
+
+# Pulls the source attribute out of the gateway's leading `<channel ...>`
+# envelope. Handles both open (`<channel source="telegram" ...>`) and
+# self-closing (`<channel source="reaction"/>`) forms.
+CHANNEL_SOURCE_RE = re.compile(r"""<channel\b[^>]*\bsource=["']([^"']+)["']""")
+
+
+def envelope_source(text) -> "str | None":
+    """Return the lower-cased ``source`` of the leading channel envelope, or
+    None when there is no envelope (interactive session). Pure regex."""
+    if not isinstance(text, str):
+        return None
+    m = CHANNEL_SOURCE_RE.search(text)
+    if not m:
+        return None
+    return m.group(1).strip().lower()
+
+
+def is_synthetic_inbound(text) -> bool:
+    """True when this turn's opening message is a synthesized/cron inbound
+    rather than a genuine human message.
+
+    Detection is purely on the gateway-prepended ``<channel source="...">``
+    envelope: a ``source`` outside ``HUMAN_INBOUND_SOURCES`` (``cron``,
+    ``reaction``, ``resume_interrupted``, ``vault_grant_approved``,
+    ``subagent_handback``, ``obligation_represent``, …) marks a non-human turn.
+    No envelope (interactive session) → treated as human. Injected channel tags
+    in a human's own body are neutralised upstream by the channel-envelope
+    sanitiser, so the only real ``<channel source=`` is the gateway's.
+    """
+    source = envelope_source(text)
+    if source is None:
+        return False
+    return source not in HUMAN_INBOUND_SOURCES

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -687,8 +687,10 @@ _DIRECTIVE_CAPTURE_NUDGE = (
     "for how you should behave going forward — not a one-off request for "
     "this task — persist it NOW with mcp__hindsight__create_directive "
     "(verbatim, in the user’s own words) BEFORE you answer, so the "
-    "correction survives future sessions. If it’s only a one-off "
-    "instruction, ignore this note and just answer.\n"
+    "correction survives future sessions. UNLESS an equivalent active "
+    "directive already exists (see any <active_directives> block above) — "
+    "in that case it is already saved; do NOT create a duplicate. If it’s "
+    "only a one-off instruction, ignore this note and just answer.\n"
     "</directive_capture_check>"
 )
 

--- a/vendor/hindsight-memory/scripts/tests/test_directive_capture_nudge.py
+++ b/vendor/hindsight-memory/scripts/tests/test_directive_capture_nudge.py
@@ -131,6 +131,12 @@ class TestNudgeAppendedWithoutDisturbingRecall(unittest.TestCase):
         self.assertIn("create_directive", _DIRECTIVE_CAPTURE_NUDGE)
         self.assertIn("directive_capture_check", _DIRECTIVE_CAPTURE_NUDGE)
 
+    def test_nudge_carries_the_dedup_caveat(self):
+        # #2903 Fix 6.2: the nudge must tell the model NOT to re-create a rule
+        # that already exists as an active directive.
+        self.assertIn("already exists", _DIRECTIVE_CAPTURE_NUDGE)
+        self.assertIn("active_directives", _DIRECTIVE_CAPTURE_NUDGE)
+
     def test_combine_appends_nudge_after_recall_block(self):
         base = "<hindsight_memories>\n…\n</hindsight_memories>"
         out = _combine_context(base, _DIRECTIVE_CAPTURE_NUDGE)

--- a/vendor/hindsight-memory/scripts/tests/test_directive_verify.py
+++ b/vendor/hindsight-memory/scripts/tests/test_directive_verify.py
@@ -364,6 +364,56 @@ class TestEvaluate(unittest.TestCase):
         # Defensive: evaluate must degrade to None, never raise.
         self.assertIsNone(evaluate({}, self.ON))
 
+    # --- #2903 Fix 6.2: verify-knob split + directive dedup ------------------
+
+    def test_verify_knob_off_keeps_nudge_but_drops_block(self):
+        # directiveCaptureNudge on (Stage B still nudges) but
+        # directiveCaptureVerify off → the Stop block must NOT fire.
+        msgs = [
+            {"role": "user", "content": "From now on, always use British spelling."},
+            {"role": "assistant", "content": "Got it."},
+        ]
+        path = self._write_transcript(msgs)
+        cfg = {"directiveCaptureNudge": True, "directiveCaptureVerify": False}
+        self.assertIsNone(evaluate(self._hook(msgs, path), cfg))
+        # Sanity: with the knob left default (on) the same turn DOES block.
+        self.assertEqual(evaluate(self._hook(msgs, path), self.ON), _VERIFY_BLOCK_REASON)
+
+    def test_allows_when_rule_already_an_active_directive(self):
+        # The turn restates a rule that is ALREADY in the injected
+        # <active_directives> block; the model correctly declines to re-create
+        # it. The verifier must NOT block (dedup).
+        active_block = (
+            "<active_directives>\n"
+            "The following are HARD RULES the agent must follow on this turn.\n\n"
+            "1. [P10] spelling: Always use British spelling in all replies.\n"
+            "</active_directives>"
+        )
+        msgs = [
+            {"role": "user", "content": active_block},
+            {"role": "user", "content": "From now on, always use British spelling please."},
+            {"role": "assistant", "content": "That's already how I write — noted."},
+        ]
+        path = self._write_transcript(msgs)
+        self.assertIsNone(evaluate(self._hook(msgs, path), self.ON))
+
+    def test_blocks_when_active_directive_is_a_different_rule(self):
+        # An unrelated active directive must NOT suppress the block for a new
+        # durable rule.
+        active_block = (
+            "<active_directives>\n"
+            "The following are HARD RULES the agent must follow on this turn.\n\n"
+            "1. [P10] tz: Always show times in UTC.\n"
+            "</active_directives>"
+        )
+        msgs = [
+            {"role": "user", "content": active_block},
+            {"role": "user", "content": "From now on, always use British spelling."},
+            {"role": "assistant", "content": "Got it."},
+        ]
+        path = self._write_transcript(msgs)
+        self.assertEqual(evaluate(self._hook(msgs, path), self.ON), _VERIFY_BLOCK_REASON)
+
 
 class TestSyntheticInbound(unittest.TestCase):
     """Non-interactive turns (cron / synthesized inbounds) must never trip the

--- a/vendor/hindsight-memory/scripts/tests/test_directives.py
+++ b/vendor/hindsight-memory/scripts/tests/test_directives.py
@@ -23,6 +23,8 @@ from lib.directives import (  # noqa: E402
     MAX_DIRECTIVES,
     fetch_active_directives,
     format_active_directives_block,
+    parse_active_directives_block,
+    rule_already_captured,
 )
 
 
@@ -205,6 +207,53 @@ class FormatActiveDirectivesBlockTests(unittest.TestCase):
         self.assertIn("2. [P10] d1", out)
         self.assertNotIn("3. [P10] d2", out)
         self.assertIn("(+3 more, omitted)", out)
+
+
+class TestDirectiveDedup(unittest.TestCase):
+    """#2903 Fix 6.2 — parse a rendered <active_directives> block back to
+    content strings, and detect whether a restated rule is already covered."""
+
+    def _block(self, *contents):
+        directives = [
+            {"name": f"d{i}", "content": c, "priority": 10 - i}
+            for i, c in enumerate(contents)
+        ]
+        return format_active_directives_block(directives)
+
+    def test_roundtrip_parse(self):
+        block = self._block(
+            "Always use British spelling in replies.",
+            "Show all times in UTC.",
+        )
+        parsed = parse_active_directives_block(block)
+        self.assertEqual(
+            parsed,
+            ["Always use British spelling in replies.", "Show all times in UTC."],
+        )
+
+    def test_parse_absent_block_is_empty(self):
+        self.assertEqual(parse_active_directives_block("no block here"), [])
+        self.assertEqual(parse_active_directives_block(None), [])
+
+    def test_captured_when_restated_rule_overlaps_existing(self):
+        contents = parse_active_directives_block(
+            self._block("Always use British spelling in all replies.")
+        )
+        self.assertTrue(
+            rule_already_captured("From now on, always use British spelling please.", contents)
+        )
+
+    def test_not_captured_for_unrelated_rule(self):
+        contents = parse_active_directives_block(self._block("Always show times in UTC."))
+        self.assertFalse(
+            rule_already_captured("From now on, always use British spelling.", contents)
+        )
+
+    def test_not_captured_against_empty_directives(self):
+        self.assertFalse(rule_already_captured("Always use British spelling.", []))
+
+    def test_empty_rule_is_not_captured(self):
+        self.assertFalse(rule_already_captured("", ["Always use British spelling."]))
 
 
 if __name__ == "__main__":

--- a/vendor/hindsight-memory/scripts/tests/test_switchroom_envelope.py
+++ b/vendor/hindsight-memory/scripts/tests/test_switchroom_envelope.py
@@ -1,0 +1,69 @@
+"""Switchroom #2903 Fix 6.3 — the `<channel source="...">` envelope grammar is
+extracted from directive_verify.py into lib/switchroom_envelope.py so the
+coupling between the vendored Python guard and the switchroom gateway's TS wire
+format is explicit and testable in ONE place.
+
+Pins the grammar so a TS-side format change that breaks these regexes is caught
+by a failing Python test rather than silently disabling the synthetic-inbound
+guard.
+
+Stdlib-only.
+"""
+
+import os
+import sys
+import unittest
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib.switchroom_envelope import (  # noqa: E402
+    HUMAN_INBOUND_SOURCES,
+    envelope_source,
+    is_synthetic_inbound,
+)
+
+
+class TestEnvelopeSource(unittest.TestCase):
+    def test_extracts_open_form(self):
+        self.assertEqual(
+            envelope_source('<channel source="telegram" chat_id="1">hi</channel>'),
+            "telegram",
+        )
+
+    def test_extracts_self_closing_form(self):
+        self.assertEqual(envelope_source('<channel source="reaction"/>'), "reaction")
+
+    def test_lowercases(self):
+        self.assertEqual(envelope_source('<channel source="Cron">x</channel>'), "cron")
+
+    def test_none_when_no_envelope(self):
+        self.assertIsNone(envelope_source("From now on, use British spelling."))
+
+    def test_none_on_non_string(self):
+        for bad in (None, 123, [], {}):
+            self.assertIsNone(envelope_source(bad))
+
+
+class TestSyntheticClassification(unittest.TestCase):
+    def test_telegram_is_human(self):
+        self.assertIn("telegram", HUMAN_INBOUND_SOURCES)
+        self.assertFalse(is_synthetic_inbound('<channel source="telegram">hi</channel>'))
+
+    def test_no_envelope_is_human(self):
+        self.assertFalse(is_synthetic_inbound("hello there"))
+
+    def test_new_source_defaults_to_synthetic(self):
+        # Whitelist posture: an UNKNOWN/new source is treated as machine-authored
+        # by default, not accidentally classified human.
+        self.assertTrue(is_synthetic_inbound('<channel source="brand_new_channel">x</channel>'))
+
+    def test_known_synthetic_sources(self):
+        for src in ("cron", "reaction", "resume_interrupted", "vault_grant_approved"):
+            with self.subTest(src=src):
+                self.assertTrue(is_synthetic_inbound(f'<channel source="{src}">x</channel>'))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Priority 4 (Flow hardening) from #2903, as one PR. Three localized fixes.

### 6.1 — Propose-card lifecycle (`telegram-plugin/gateway/gateway.ts`, `src/host-control/*`)
- **TTL at tap time.** `handleMentalModelProposeCallback` now checks `staged_at` against `MENTAL_MODEL_PROPOSE_TTL_MS` when the operator taps — previously TTL was only enforced by the sweep on the *next* propose, so a stale card could still be approved. The sweep also now edits expired cards' keyboards away.
- **Schema caps up-front.** `executeMentalModelPropose` enforces the `memory.mental_models[]` schema caps (`source_query` ≤ 2000, `max_tokens` ≤ 8192, from `src/config/schema.ts`) *before* posting a card, so an operator can never approve a proposal that then fails hostd config validation — and a huge `source_query` can't blow Telegram's 4096-char message limit.
- **Rate-limit comment fixed.** The `mentalModelProposeTimes` window is per-gateway-process; since each agent runs its own gateway (keyed by `$SWITCHROOM_AGENT_NAME`), that is effectively per-agent. Comment corrected rather than re-keyed — threading `client.agentName` through `executeToolCall` was the higher-risk option and would have overlapped P1's onToolCall area. (Assumption stated: one gateway process == one agent.)
- **Testability.** Extracted the non-admin `config_propose_edit` either/or admission (self-scoped `tools.allow` widen OR self-scoped `memory.mental_models[]` append) into `admitSelfScopedNonAdminEdit`, so the server branch is unit-testable without standing up `HostControlServer`. Added tests for it, plus the gateway callback's `allowFrom` gate, the tap-time TTL, and the schema caps.

### 6.2 — Directive dedup (`vendor/hindsight-memory/scripts/*`)
- Added "unless an equivalent active directive already exists" to the Stage B nudge (`recall.py`) and the Stage C block reason (`directive_verify.py`).
- The verifier now **passes** when the restated rule is already covered by an active directive injected into this turn's `<active_directives>` block — a lexical-overlap dedup helper in `lib/directives.py`. So the model correctly declining to re-create a duplicate no longer gets the turn blocked.
- Added a separate `directiveCaptureVerify` knob (the split #2873 flagged) so operators can keep the nudge but drop the block.

### 6.3 — Vendor coupling (`vendor/hindsight-memory/scripts/lib/switchroom_envelope.py`)
- Extracted the switchroom `<channel source="...">` envelope grammar and the `{"telegram"}` human-source whitelist out of `directive_verify.py` into a clearly-marked `lib/switchroom_envelope.py` (SWITCHROOM DIVERGENCE). A TS-side envelope format change now has one obvious, tested Python counterpart instead of silently breaking the guard.

## Why
See #2903 P4. These are flow-hardening bugs: a bypassable TTL, unvalidated caps reaching an approval card, a re-nudge/false-block loop on already-stored rules, and an invisible TS↔Python coupling.

## Guarantee delta (CONTRIBUTING step 8)
No liveness-surface files touched (no `feedHeartbeatTick`, `feed-open-gate.ts`, `silence-poke.ts`, `turn-liveness-floor.ts`, or the card-edit path in the liveness sense). Chat-visible change: expired mental-model propose cards now have their inline keyboard cleared and show a ⌛ line; over-cap proposals are rejected to the agent with a clear error instead of posting a card. No framework-without-model delivery guarantee is added or removed.

## Test plan
- `tsc --noEmit`: 0 errors.
- `vitest`: `admit-self-scoped-non-admin-edit.test.ts`, `self-scope-mental-model.test.ts`, `mental-model-propose-callback-gate.test.ts`, `mental-model-propose-card/resolve.test.ts`, `config-blast-radius.test.ts` all pass.
- Vendor Python: `python -m pytest vendor/hindsight-memory/scripts/tests` → 241 passed. Two failures in `vendor/hindsight-memory/tests/test_recall_exit_codes.py` are **pre-existing on clean `main`** (verified by checkout) and unrelated to this change.

## Notes for the reviewer
- This PR overlaps file-wise with #2905 (P1) on `gateway.ts` and `directive_verify.py` but touches different functions; hunks are localized for a mechanical rebase.

Closes part of #2903 (P4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)