### PR TITLE
fix(gateway): preserve per-chat FIFO under rapid-fire DM (#2917)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -427,7 +427,7 @@ import { shouldSuppressRepresent } from './represent-guard.js'
 import { shouldDeferEscalationForBridge } from './escalation-bridge-gate.js'
 import { createInboundSpool } from './inbound-spool.js'
 import { purgeStaleTurnsForChat } from './turn-state-purge.js'
-import { decideInboundDelivery } from './inbound-delivery-gate.js'
+import { decideInboundDelivery, reserveInboundDelivery } from './inbound-delivery-gate.js'
 import { mayDrainBufferedInbound, shouldArmNoReplyDrain } from './serialize-drain-gate.js'
 import { decideFeedReopen } from './feed-reopen-gate.js'
 import {
@@ -1949,6 +1949,25 @@ const obligationEscalateInFlight = new Set<string>()
 // drain on the bare turn-end signal.
 const SERIALIZE_UNTIL_REPLIED_ENABLED =
   process.env.SWITCHROOM_SERIALIZE_UNTIL_REPLIED !== '0'
+// #2917 — rapid-fire per-chat FIFO. The #1556 delivery gate documents its
+// `turnInFlight` input as a LIVE read ("evaluated at delivery time — not a
+// receipt-time snapshot"), but handleInbound passes a receipt-time snapshot
+// (`turnInFlightAtReceipt`) taken at function entry. Under rapid-fire two
+// same-chat inbounds each snapshot "idle" during the other's async lead-in
+// (attachment download, composer-clear), both pass the gate, and both are
+// delivered — so replies come back reordered (observed 1,2,4,5,3,7,8,6). The
+// fix reads the gate LIVE off `claudeBusyKeys` (which does NOT yet contain
+// THIS inbound's own key — that is only marked at delivery — so it can't
+// self-block) AND reserves the key synchronously BEFORE the composer-clear
+// await, so a concurrent same-chat inbound observes the reservation and
+// buffers behind it, preserving FIFO. Nothing is dropped: a buffered inbound
+// drains on turn-complete / idle exactly as before. Kill switch (=0) restores
+// the receipt-snapshot behaviour. Only the non-cutover path is affected — the
+// delivery-machine cutover keeps its own at-receipt machine snapshot (reading
+// the machine live WOULD self-block, since its inbound event already advanced
+// it for this key).
+const SERIALIZE_INBOUND_DELIVERY_ENABLED =
+  process.env.SWITCHROOM_SERIALIZE_INBOUND_DELIVERY !== '0'
 // Component 2 (bounded no-reply escape hatch). A turn that legitimately
 // ends with NO reply (handback ack, NO_REPLY marker, silent-end) sets
 // finalAnswerDelivered=false and would block the serialize gate forever.
@@ -16569,21 +16588,32 @@ async function handleInbound(
     effectiveText,
   })
 
-  if (
-    decideInboundDelivery({
-      turnInFlight: turnInFlightAtReceipt,
-      isSteering,
-      // Interrupt-marker carve-out (2026-05-24): the `!`-prefixed body
-      // must bypass the "buffer-until-turn-complete" gate because the
-      // SIGINT'd turn often doesn't emit turn_complete, leaving the
-      // body stranded in pendingInboundBuffer indefinitely. The
-      // `interrupt` const is computed at the start of handleInbound
-      // (line ~7606) and remains in scope here. When the user fires
-      // `!`-with-body, this delivers the body as a fresh inbound to
-      // the freshly-killed bridge.
-      isInterrupt: interrupt.isInterrupt,
-    }) === 'buffer-until-idle'
-  ) {
+  // #2917: read the gate LIVE (not the receipt snapshot) on the default path
+  // so a sibling same-chat inbound delivered during THIS handler's async
+  // lead-in is observed here. Reading `claudeBusyKeys` live is self-block-safe:
+  // THIS inbound's own key is only added at delivery (below), never by the
+  // fresh-turn init bundle — so the live read never sees its own key. The
+  // delivery-machine cutover keeps its at-receipt machine snapshot (a live
+  // machine read WOULD self-block, since the inbound event already advanced
+  // the machine for this key). Kill switch (=0) restores the pure snapshot.
+  const gateTurnInFlight =
+    SERIALIZE_INBOUND_DELIVERY_ENABLED && machineInTurnAtReceipt == null
+      ? claudeBusyKeys.size > 0
+      : turnInFlightAtReceipt
+  const deliveryGate = reserveInboundDelivery({
+    turnInFlight: gateTurnInFlight,
+    isSteering,
+    // Interrupt-marker carve-out (2026-05-24): the `!`-prefixed body
+    // must bypass the "buffer-until-turn-complete" gate because the
+    // SIGINT'd turn often doesn't emit turn_complete, leaving the
+    // body stranded in pendingInboundBuffer indefinitely. The
+    // `interrupt` const is computed at the start of handleInbound
+    // (line ~7606) and remains in scope here. When the user fires
+    // `!`-with-body, this delivers the body as a fresh inbound to
+    // the freshly-killed bridge.
+    isInterrupt: interrupt.isInterrupt,
+  })
+  if (deliveryGate.decision === 'buffer-until-idle') {
     pendingInboundBuffer.push(selfAgent, inboundMsg)
     process.stderr.write(
       `telegram gateway: inbound held mid-turn agent=${selfAgent} ` +
@@ -16605,6 +16635,18 @@ async function handleInbound(
       postQueuedStatus(chat_id, messageThreadId, inFlightThread)
     }
     return
+  }
+
+  // #2917: reserve the chat's busy key SYNCHRONOUSLY here — before the
+  // composer-clear await below — so a concurrent same-chat inbound reaching
+  // the LIVE gate above observes this in-flight delivery and buffers behind it
+  // (per-chat FIFO). Without this, both handlers pass the gate during each
+  // other's async lead-in and race to the bridge, reordering the replies.
+  // Only fresh-turn deliveries reserve (steering/interrupt amend a running
+  // turn and must not). Released below if the send misses (bridge offline).
+  let reservedBusyKey: string | null = null
+  if (deliveryGate.reserve && SERIALIZE_INBOUND_DELIVERY_ENABLED && machineInTurnAtReceipt == null) {
+    reservedBusyKey = markClaudeBusyForInbound(inboundMsg)
   }
 
   // Pre-send composer clear (the marko wedge). The inbound is about to be
@@ -16636,7 +16678,10 @@ async function handleInbound(
 
   const delivered = ipcServer.sendToAgent(selfAgent, inboundMsg)
   if (delivered) {
-    const busyKey = markClaudeBusyForInbound(inboundMsg)
+    // Reuse the key reserved synchronously above (#2917) when present, else
+    // mark now — markClaudeBusyForInbound is idempotent (lockstep re-stamp),
+    // so a re-mark is safe and returns the same chat key.
+    const busyKey = reservedBusyKey ?? markClaudeBusyForInbound(inboundMsg)
     // Track until claude acks via `enqueue` (the marko drop-wedge): if no ack
     // lands, the message stranded in the composer and the sweep re-delivers
     // it. Track ONLY messages that produce an `enqueue` to ack against —
@@ -16658,6 +16703,15 @@ async function handleInbound(
     }
   }
   if (!delivered) {
+    // #2917: the synchronous reservation assumed delivery; the send missed
+    // (bridge offline), so release it in lockstep — otherwise the orphaned
+    // busy key would gate every subsequent inbound into the buffer until the
+    // orphan reaper clears it. The message itself is buffered below, so FIFO
+    // is still preserved (it drains in order on the next bridge register).
+    if (reservedBusyKey != null) {
+      claudeBusyKeys.delete(reservedBusyKey)
+      claudeBusyKeySince.delete(reservedBusyKey)
+    }
     // Only persist fresh user turns to the durable spool. Steering / `!`
     // interrupt / empty bodies are mid-turn amendments or no-ops that would
     // arrive orphaned if replayed as a fresh turn after a restart — drop them

--- a/telegram-plugin/gateway/inbound-delivery-gate.ts
+++ b/telegram-plugin/gateway/inbound-delivery-gate.ts
@@ -116,3 +116,29 @@ export function decideInboundDelivery(
   if (input.turnInFlight) return 'buffer-until-idle'
   return 'deliver'
 }
+
+/**
+ * #2917 — atomic check-and-reserve for per-chat outbound FIFO.
+ *
+ * `decideInboundDelivery` decides deliver-vs-buffer, but on the concurrent
+ * `handleInbound` path that decision and the busy-mark that records "a turn is
+ * now in flight for this chat" are separated by an `await` (attachment
+ * download, composer-clear). Two same-chat inbounds can therefore each read
+ * "idle" during the other's async lead-in and both deliver — the replies then
+ * come back reordered. This helper couples the decision with a `reserve` flag:
+ * a FRESH-TURN deliver must reserve the chat's busy key SYNCHRONOUSLY (before
+ * any await) so the next same-chat inbound sees it and buffers behind it.
+ *
+ * `reserve` is true ONLY for a fresh-turn deliver. Steering / interrupt
+ * inbounds deliver mid-turn WITHOUT starting a turn, so they must not reserve
+ * (reserving would wedge the running turn's key). A buffered decision never
+ * reserves.
+ */
+export function reserveInboundDelivery(
+  input: InboundDeliveryGateInput,
+): { decision: InboundDeliveryDecision; reserve: boolean } {
+  const decision = decideInboundDelivery(input)
+  const reserve =
+    decision === 'deliver' && !input.isSteering && input.isInterrupt !== true
+  return { decision, reserve }
+}

--- a/telegram-plugin/tests/rapid-fire-delivery-ordering.test.ts
+++ b/telegram-plugin/tests/rapid-fire-delivery-ordering.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  decideInboundDelivery,
+  reserveInboundDelivery,
+} from '../gateway/inbound-delivery-gate.js'
+
+/**
+ * #2917 — rapid-fire DM: replies emitted late & out of order.
+ *
+ * Root cause: the #1556 delivery gate is documented as a LIVE read
+ * ("evaluated at delivery time — not a receipt-time snapshot"), but on the
+ * concurrent `handleInbound` path the gate decision and the busy-mark that
+ * records "a turn is in flight for this chat" were separated by an `await`
+ * (attachment download, composer-clear). Two same-chat inbounds each read
+ * "idle" during the other's async lead-in, both passed the gate, and both
+ * were delivered to the bridge — so the replies came back reordered.
+ *
+ * The fix couples the deliver decision with a synchronous RESERVE
+ * (`reserveInboundDelivery`): a fresh-turn deliver reserves the chat's busy
+ * key BEFORE any await, so a concurrent same-chat inbound observes the
+ * reservation on the live gate and buffers behind it — restoring per-chat
+ * FIFO without dropping anything (a buffered inbound drains on turn-complete
+ * / idle exactly as before).
+ */
+describe('reserveInboundDelivery — fresh-turn reservation flag', () => {
+  it('reserves a fresh-turn deliver (idle, non-steering, non-interrupt)', () => {
+    const r = reserveInboundDelivery({ turnInFlight: false, isSteering: false, isInterrupt: false })
+    expect(r.decision).toBe('deliver')
+    expect(r.reserve).toBe(true)
+  })
+
+  it('does NOT reserve a buffered (mid-turn) inbound', () => {
+    const r = reserveInboundDelivery({ turnInFlight: true, isSteering: false, isInterrupt: false })
+    expect(r.decision).toBe('buffer-until-idle')
+    expect(r.reserve).toBe(false)
+  })
+
+  it('does NOT reserve a steering deliver (amends the running turn)', () => {
+    const r = reserveInboundDelivery({ turnInFlight: true, isSteering: true, isInterrupt: false })
+    expect(r.decision).toBe('deliver')
+    expect(r.reserve).toBe(false)
+  })
+
+  it('does NOT reserve an interrupt deliver (amends the running turn)', () => {
+    const r = reserveInboundDelivery({ turnInFlight: true, isSteering: false, isInterrupt: true })
+    expect(r.decision).toBe('deliver')
+    expect(r.reserve).toBe(false)
+  })
+
+  it('decision stays byte-identical to decideInboundDelivery across the matrix', () => {
+    for (const turnInFlight of [false, true]) {
+      for (const isSteering of [false, true]) {
+        for (const isInterrupt of [false, true]) {
+          const input = { turnInFlight, isSteering, isInterrupt }
+          expect(reserveInboundDelivery(input).decision).toBe(decideInboundDelivery(input))
+        }
+      }
+    }
+  })
+})
+
+/**
+ * A minimal model of the gateway's concurrent same-chat delivery path. Each
+ * inbound handler:
+ *   1. reads the LIVE gate off the shared busy set,
+ *   2. yields at an `await` (the composer-clear / attachment lead-in),
+ *   3. on a reserving deliver, marks the chat busy and appends to the wire.
+ *
+ * This reproduces the ordering race deterministically: two same-chat handlers
+ * whose async lead-ins overlap. The `syncReserve` flag toggles the fix — when
+ * off (legacy: mark busy only AFTER the await), both handlers deliver and the
+ * wire order is decided by the await race; when on (#2917: reserve BEFORE the
+ * await), the second handler sees the reservation and buffers, preserving FIFO.
+ */
+interface WireResult {
+  delivered: string[]
+  buffered: string[]
+}
+
+async function runTwoConcurrentInbounds(opts: {
+  syncReserve: boolean
+  /** ms the first handler's lead-in await takes vs the second's. First is
+   *  SLOWER so, without the fix, the second overtakes it on the wire. */
+  firstLeadInMs: number
+  secondLeadInMs: number
+}): Promise<WireResult> {
+  const busy = new Set<string>()
+  const key = 'chatDM:_'
+  const delivered: string[] = []
+  const buffered: string[] = []
+
+  const handle = async (id: string, leadInMs: number): Promise<void> => {
+    // Step 1 — live gate read.
+    const gate = reserveInboundDelivery({
+      turnInFlight: busy.size > 0,
+      isSteering: false,
+      isInterrupt: false,
+    })
+    if (gate.decision === 'buffer-until-idle') {
+      buffered.push(id)
+      return
+    }
+    // Step 2 — the fix reserves synchronously BEFORE the await.
+    let reserved = false
+    if (opts.syncReserve && gate.reserve) {
+      busy.add(key)
+      reserved = true
+    }
+    // Step 3 — the async lead-in (composer-clear / attachment download).
+    await new Promise((r) => setTimeout(r, leadInMs))
+    // Step 4 — legacy marks busy only now, after the await.
+    if (!reserved) busy.add(key)
+    delivered.push(id)
+  }
+
+  await Promise.all([
+    handle('msg1', opts.firstLeadInMs),
+    handle('msg2', opts.secondLeadInMs),
+  ])
+  return { delivered, buffered }
+}
+
+describe('rapid-fire same-chat delivery ordering (#2917)', () => {
+  it('LEGACY (mark-after-await): the faster second inbound overtakes the first — reorder', async () => {
+    // msg1's lead-in is slower, so with the busy-mark deferred until after the
+    // await BOTH pass the idle gate and BOTH deliver, with msg2 landing first.
+    const { delivered, buffered } = await runTwoConcurrentInbounds({
+      syncReserve: false,
+      firstLeadInMs: 20,
+      secondLeadInMs: 1,
+    })
+    expect(buffered).toEqual([]) // nothing buffered — the bug
+    expect(delivered).toEqual(['msg2', 'msg1']) // out of order
+  })
+
+  it('FIX (sync reserve): the second inbound sees the reservation and buffers — FIFO preserved', async () => {
+    const { delivered, buffered } = await runTwoConcurrentInbounds({
+      syncReserve: true,
+      firstLeadInMs: 20,
+      secondLeadInMs: 1,
+    })
+    // msg1 reserved synchronously; msg2's live gate sees busy → buffers.
+    expect(delivered).toEqual(['msg1'])
+    expect(buffered).toEqual(['msg2'])
+    // msg2 is not lost — it is held for the turn-complete / idle drain, which
+    // re-delivers it in order after msg1's turn ends.
+  })
+})


### PR DESCRIPTION
Fixes #2917.

## Root cause
The reorder is on the inbound→bridge delivery path, not capacity. The #1556 delivery gate (`inbound-delivery-gate.ts`) documents its `turnInFlight` input as a **live** read — *"evaluated at delivery time — not a receipt-time snapshot"* — but `handleInbound` passes `turnInFlightAtReceipt`, a snapshot taken at function entry (`gateway.ts`). The gate decision and the busy-mark that records *"a turn is now in flight for this chat"* (`markClaudeBusyForInbound`) are separated by an `await` (attachment download, pre-send composer-clear). Under rapid fire two same-chat inbounds each snapshot **"idle"** during the other's async lead-in, both pass the gate, and both are delivered to the bridge — the composer race then decides which turn runs first, so replies come back reordered (observed `1,2,4,5,3,7,8,6`). Non-deterministic (drop indices differ run-to-run), nothing permanently lost.

## Fix (kill switch `SWITCHROOM_SERIALIZE_INBOUND_DELIVERY=0`)
- **Read the gate live** off `claudeBusyKeys` on the non-cutover path. Self-block-safe: THIS inbound's own key is only added at delivery, never by the fresh-turn init bundle, so the live read never sees its own key. (The original #1556 self-block came from reading live `activeTurnStartedAt`, which the fresh-turn branch *does* pre-populate — a different set.) The delivery-machine cutover keeps its at-receipt machine snapshot, since a live machine read would self-block.
- **Reserve the chat's busy key synchronously** before the composer-clear `await` (new `reserveInboundDelivery` helper). The check-and-reserve is atomic (no await between the live read and the mark), so a concurrent same-chat inbound observes the reservation on the live gate and buffers behind it — restoring per-chat FIFO. Only fresh-turn deliveries reserve; steering / interrupt amend a running turn and must not. Released in lockstep if the send misses (bridge offline), so nothing wedges.

Self-healing is untouched: a buffered inbound drains on turn-complete / idle exactly as before, and the deliver-until-acked sweep is unchanged.

## Tests
`telegram-plugin/tests/rapid-fire-delivery-ordering.test.ts` — unit coverage for the reserve flag plus a deterministic two-concurrent-inbound model that reproduces the reorder with the legacy mark-after-await and shows the synchronous reserve restores FIFO (the second inbound buffers instead of overtaking).

- `tsc --noEmit`: clean
- Full `vitest run`: all `telegram-plugin` tests pass. The 15 failing files in the run (host-control, install/static-binary, deps, run-hook, token-helpers, …) are pre-existing host/install/hook environment failures that also fail on clean `main` (verified via stash).

## Verification note
The `inbound-no-drop-rapid-fire-dm` MTCute UAT needs live creds and was **not** run here. Recommend gating this behind that UAT before release; the deterministic unit test is the CI-runnable proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)