### PR TITLE
feat(memory): default hindsight LLM ops to OpenRouter via LiteLLM

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -45,7 +45,11 @@ async function resolveLiteLLMForHindsight(
   if (!topLiteLLM?.enabled || !topLiteLLM.base_url) return undefined;
   const result = await getViaBrokerStructured("litellm/hindsight/api-key").catch(() => null);
   if (!result || result.kind !== "ok" || result.entry.kind !== "string") return undefined;
-  return { baseUrl: topLiteLLM.base_url, apiKey: result.entry.value };
+  return {
+    baseUrl: topLiteLLM.base_url,
+    apiKey: result.entry.value,
+    model: config.memory?.config?.llm_model,
+  };
 }
 
 interface RecallLogEntry {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -913,7 +913,11 @@ async function resolveLiteLLMForHindsight(
   if (!topLiteLLM?.enabled || !topLiteLLM.base_url) return undefined;
   const result = await getViaBrokerStructured("litellm/hindsight/api-key").catch(() => null);
   if (!result || result.kind !== "ok" || result.entry.kind !== "string") return undefined;
-  return { baseUrl: topLiteLLM.base_url, apiKey: result.entry.value };
+  return {
+    baseUrl: topLiteLLM.base_url,
+    apiKey: result.entry.value,
+    model: config.memory?.config?.llm_model,
+  };
 }
 
 async function stepMemoryBackend(

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3025,6 +3025,18 @@ export const MemoryBackendConfigSchema = z.object({
         .string()
         .optional()
         .describe("Embedding model (e.g., 'nomic-embed-text')"),
+      llm_model: z
+        .string()
+        .optional()
+        .describe(
+          "LiteLLM model name for Hindsight's LLM ops (retain/reflect/" +
+          "consolidation) when the top-level `litellm.enabled` carve-out is " +
+          "on. Defaults to a cheap OpenRouter model (routed via LiteLLM's " +
+          "model-mapped path, not the Anthropic OAuth pass-through) to keep " +
+          "background memory-op cost off the Claude subscription quota. Set " +
+          "to a `claude-*` model name to route it back through the OAuth " +
+          "pass-through instead. Has no effect when litellm is disabled.",
+        ),
       api_key: z
         .string()
         .optional()

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -139,6 +139,31 @@ export function hindsightImageRef(tag?: string): string {
 export const HINDSIGHT_DEFAULT_MODEL = "claude-sonnet-5";
 
 /**
+ * Default LiteLLM model for Hindsight's LLM ops when the `litellm` routing
+ * carve-out is enabled and no `memory.config.llm_model` override is set.
+ * OpenRouter (not Anthropic OAuth) so background memory-op cost (fact
+ * extraction, recall synthesis, consolidation) doesn't burn the Claude
+ * subscription quota (added 2026-07-07, per Ken). Must be a model_name
+ * registered in litellm's model_list, routed via the model-mapped path (see
+ * {@link isAnthropicPassthroughModel}), NOT the Anthropic pass-through.
+ */
+export const HINDSIGHT_DEFAULT_LITELLM_MODEL =
+  "openrouter/google/gemini-3.1-flash-lite";
+
+/**
+ * Whether `model` should ride LiteLLM's Anthropic pass-through
+ * (`<root>/anthropic`, raw byte-forward, OAuth-authenticated — see the
+ * 2026-07-05 opus-stall fix) rather than the model-mapped route
+ * (`<root>`, translates protocol/auth per model_name). Only real Anthropic
+ * model names/aliases are pass-through-eligible; anything else (OpenRouter,
+ * etc.) needs the model-mapped route since the pass-through only forwards to
+ * the real Anthropic API.
+ */
+function isAnthropicPassthroughModel(model: string): boolean {
+  return model.startsWith("claude-") || model === "sonnet" || model === "fable";
+}
+
+/**
  * Run hindsight's MCP server in stateless HTTP mode.
  *
  * Upstream defaults to stateful (`HINDSIGHT_API_MCP_STATELESS=false`):
@@ -549,6 +574,13 @@ export interface LiteLLMHindsightConfig {
   baseUrl: string;
   /** Per-service virtual key for spend attribution. */
   apiKey: string;
+  /**
+   * LiteLLM model_name for Hindsight's LLM ops. Defaults to
+   * {@link HINDSIGHT_DEFAULT_LITELLM_MODEL} when omitted. A `claude-*`
+   * model/alias rides the Anthropic OAuth pass-through; anything else rides
+   * the model-mapped route (see {@link isAnthropicPassthroughModel}).
+   */
+  model?: string;
 }
 
 /**
@@ -579,21 +611,32 @@ export function startHindsight(
   const apiPort = ports?.apiPort ?? HINDSIGHT_DEFAULT_API_PORT;
   const uiPort = ports?.uiPort ?? HINDSIGHT_DEFAULT_UI_PORT;
 
+  // Resolve the model BEFORE building envArgs: with litellm routing enabled
+  // the default shifts to a cheap OpenRouter model (HINDSIGHT_DEFAULT_LITELLM_MODEL)
+  // instead of Claude, unless the operator set memory.config.llm_model
+  // (threaded through as litellm.model). Direct-OAuth mode (no litellm, or
+  // fail-open) always stays on HINDSIGHT_DEFAULT_MODEL — no proxy exists to
+  // translate a non-Claude model name.
+  const resolvedModel = litellm
+    ? (litellm.model ?? HINDSIGHT_DEFAULT_LITELLM_MODEL)
+    : HINDSIGHT_DEFAULT_MODEL;
+
   // Non-secret env stays on `-e` — provider name + observation cap are
   // configuration, not secrets. Setting `HINDSIGHT_API_LLM_PROVIDER` to
   // `claude-code` selects the subscription-honest path; pinning
-  // `HINDSIGHT_API_LLM_MODEL` keeps memory ops on the same Claude model
-  // the agent fleet uses (see HINDSIGHT_DEFAULT_MODEL above). NOTE: for the
-  // `claude-code` provider, `HINDSIGHT_API_LLM_MODEL` does NOT control the
-  // embedded `claude` CLI — the CLI reads `ANTHROPIC_MODEL`, and without it
-  // falls back to its own default (opus), silently running every memory op
-  // (fact extraction, recall synthesis, consolidation) on the wrong model.
-  // So we ALSO set `ANTHROPIC_MODEL` — that's what actually pins the model.
+  // `HINDSIGHT_API_LLM_MODEL` keeps memory ops on the resolved model (see
+  // HINDSIGHT_DEFAULT_MODEL / HINDSIGHT_DEFAULT_LITELLM_MODEL above). NOTE:
+  // for the `claude-code` provider, `HINDSIGHT_API_LLM_MODEL` does NOT
+  // control the embedded `claude` CLI — the CLI reads `ANTHROPIC_MODEL`, and
+  // without it falls back to its own default (opus), silently running every
+  // memory op (fact extraction, recall synthesis, consolidation) on the
+  // wrong model. So we ALSO set `ANTHROPIC_MODEL` — that's what actually
+  // pins the model.
   const envArgs: string[] = [
     "-e", `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=${HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE}`,
     "-e", "HINDSIGHT_API_LLM_PROVIDER=claude-code",
-    "-e", `HINDSIGHT_API_LLM_MODEL=${HINDSIGHT_DEFAULT_MODEL}`,
-    "-e", `ANTHROPIC_MODEL=${HINDSIGHT_DEFAULT_MODEL}`,
+    "-e", `HINDSIGHT_API_LLM_MODEL=${resolvedModel}`,
+    "-e", `ANTHROPIC_MODEL=${resolvedModel}`,
     "-e", `HINDSIGHT_API_MCP_STATELESS=${HINDSIGHT_DEFAULT_MCP_STATELESS}`,
     // Reranker smart-defaults (v0.13.22) — see constants above for
     // rationale. Each closes a vendor-default gap that hurts our
@@ -620,17 +663,23 @@ export function startHindsight(
     // 127.0.0.1:4010 (LiteLLM) is directly reachable, identical to how
     // agent containers work. Explicit port env vars preserve the same
     // external ports (18888/19999) the operator is used to.
+    const litellmRoot = litellm.baseUrl.replace(/\/+$/, "");
+    // Claude models ride the Anthropic pass-through (<root>/anthropic,
+    // raw byte-forward, OAuth) — the model-mapped route re-chunks the SSE
+    // stream and stalls long Claude responses mid-flight (the 2026-07-05
+    // stall). Any other model (e.g. OpenRouter) MUST use the model-mapped
+    // root instead — the pass-through only forwards to the real Anthropic
+    // API, so a non-Claude model_name there 404s / always fails open.
+    const anthropicBaseUrl = isAnthropicPassthroughModel(resolvedModel)
+      ? `${litellmRoot}/anthropic`
+      : litellmRoot;
     envArgs.push(
       // HINDSIGHT_API_PORT is the only port knob the upstream config.py
       // recognizes; the CP service has no equivalent env var override.
       "-e", `HINDSIGHT_API_PORT=${apiPort}`,
       // LiteLLM routing: inherited by the claude_agent_sdk subprocess so
-      // consolidation/reflect calls hit the proxy for spend tracking. Point
-      // at the Anthropic pass-through (<root>/anthropic), not the model-mapped
-      // route — the latter re-chunks the SSE stream and stalls long Claude
-      // responses mid-flight (the 2026-07-05 stall). hindsight only makes
-      // Claude calls, so it has no /model/info discovery to keep on the root.
-      "-e", `ANTHROPIC_BASE_URL=${litellm.baseUrl.replace(/\/+$/, "")}/anthropic`,
+      // consolidation/reflect calls hit the proxy for spend tracking.
+      "-e", `ANTHROPIC_BASE_URL=${anthropicBaseUrl}`,
       "-e", `ANTHROPIC_CUSTOM_HEADERS=x-litellm-api-key: Bearer ${litellm.apiKey}\nx-litellm-customer-id: hindsight\nx-litellm-tags: service:hindsight`,
     );
   }

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createServer } from "node:net";
+import { isClaudeModel } from "../../telegram-plugin/gateway/model-command.js";
 
 /**
  * Default Hindsight host ports.
@@ -145,23 +146,10 @@ export const HINDSIGHT_DEFAULT_MODEL = "claude-sonnet-5";
  * extraction, recall synthesis, consolidation) doesn't burn the Claude
  * subscription quota (added 2026-07-07, per Ken). Must be a model_name
  * registered in litellm's model_list, routed via the model-mapped path (see
- * {@link isAnthropicPassthroughModel}), NOT the Anthropic pass-through.
+ * {@link isClaudeModel}), NOT the Anthropic pass-through.
  */
 export const HINDSIGHT_DEFAULT_LITELLM_MODEL =
   "openrouter/google/gemini-3.1-flash-lite";
-
-/**
- * Whether `model` should ride LiteLLM's Anthropic pass-through
- * (`<root>/anthropic`, raw byte-forward, OAuth-authenticated — see the
- * 2026-07-05 opus-stall fix) rather than the model-mapped route
- * (`<root>`, translates protocol/auth per model_name). Only real Anthropic
- * model names/aliases are pass-through-eligible; anything else (OpenRouter,
- * etc.) needs the model-mapped route since the pass-through only forwards to
- * the real Anthropic API.
- */
-function isAnthropicPassthroughModel(model: string): boolean {
-  return model.startsWith("claude-") || model === "sonnet" || model === "fable";
-}
 
 /**
  * Run hindsight's MCP server in stateless HTTP mode.
@@ -576,9 +564,9 @@ export interface LiteLLMHindsightConfig {
   apiKey: string;
   /**
    * LiteLLM model_name for Hindsight's LLM ops. Defaults to
-   * {@link HINDSIGHT_DEFAULT_LITELLM_MODEL} when omitted. A `claude-*`
-   * model/alias rides the Anthropic OAuth pass-through; anything else rides
-   * the model-mapped route (see {@link isAnthropicPassthroughModel}).
+   * {@link HINDSIGHT_DEFAULT_LITELLM_MODEL} when omitted. A Claude model/alias
+   * (per {@link isClaudeModel}) rides the Anthropic OAuth pass-through;
+   * anything else rides the model-mapped route.
    */
   model?: string;
 }
@@ -670,7 +658,7 @@ export function startHindsight(
     // stall). Any other model (e.g. OpenRouter) MUST use the model-mapped
     // root instead — the pass-through only forwards to the real Anthropic
     // API, so a non-Claude model_name there 404s / always fails open.
-    const anthropicBaseUrl = isAnthropicPassthroughModel(resolvedModel)
+    const anthropicBaseUrl = isClaudeModel(resolvedModel)
       ? `${litellmRoot}/anthropic`
       : litellmRoot;
     envArgs.push(

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -424,6 +424,25 @@ describe("hindsight LiteLLM model routing (2026-07-07)", () => {
     // Trailing slash on baseUrl must not survive into the resolved URL.
     expect(envVal(args, "ANTHROPIC_BASE_URL")).toBe("http://127.0.0.1:4010");
   });
+
+  // Regression: the routing split must use the same Claude-alias set as the
+  // rest of the product (telegram-plugin/gateway/model-command.ts's
+  // isClaudeModel/MODEL_ALIASES), not a narrower hand-rolled list. A bare
+  // "opus"/"haiku"/"default" override is a legitimate thing an operator would
+  // type (it's what /model accepts everywhere else) — misrouting it to the
+  // model-mapped root would 404 against real Anthropic-shaped names.
+  it.each(["opus", "haiku", "default", "OPUS"])(
+    "treats the Claude alias %s as pass-through-eligible (case-insensitive)",
+    (alias) => {
+      startHindsight(
+        { apiPort: 8888, uiPort: 9999 },
+        { baseUrl: "http://127.0.0.1:4010", apiKey: "sk-test", model: alias },
+      );
+      const args = findRunArgs();
+      expect(envVal(args, "ANTHROPIC_MODEL")).toBe(alias);
+      expect(envVal(args, "ANTHROPIC_BASE_URL")).toBe("http://127.0.0.1:4010/anthropic");
+    },
+  );
 });
 
 describe("generateHindsightComposeSnippet — tmpfs ownership", () => {

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -23,6 +23,7 @@ import {
   HINDSIGHT_IMAGE,
   HINDSIGHT_DEFAULT_SHM_SIZE,
   HINDSIGHT_DEFAULT_MODEL,
+  HINDSIGHT_DEFAULT_LITELLM_MODEL,
   getRunningHindsightPorts,
   HINDSIGHT_DEFAULT_API_PORT,
   HINDSIGHT_DEFAULT_UI_PORT,
@@ -366,6 +367,62 @@ describe("hindsight/scaffold model pin (#2903 fix 5.4)", () => {
     // A fleet model bump must move memory ops too; if these drift, hindsight's
     // retain/reflect/consolidation silently run on a stale model.
     expect(HINDSIGHT_DEFAULT_MODEL).toBe(SWITCHROOM_DEFAULT_MAIN_MODEL);
+  });
+});
+
+describe("hindsight LiteLLM model routing (2026-07-07)", () => {
+  beforeEach(() => {
+    mockedExec.mockReset();
+    mockedExec.mockReturnValue("");
+  });
+
+  function envVal(args: string[], key: string): string | undefined {
+    for (let i = 0; i < args.length - 1; i++) {
+      if (args[i] === "-e" && (args[i + 1] as string).startsWith(`${key}=`)) {
+        return (args[i + 1] as string).slice(key.length + 1);
+      }
+    }
+    return undefined;
+  }
+
+  it("without litellm, stays on HINDSIGHT_DEFAULT_MODEL and sets no ANTHROPIC_BASE_URL", () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 });
+    const args = findRunArgs();
+    expect(envVal(args, "ANTHROPIC_MODEL")).toBe(HINDSIGHT_DEFAULT_MODEL);
+    expect(envVal(args, "HINDSIGHT_API_LLM_MODEL")).toBe(HINDSIGHT_DEFAULT_MODEL);
+    expect(envVal(args, "ANTHROPIC_BASE_URL")).toBeUndefined();
+  });
+
+  it("with litellm and no model override, defaults to HINDSIGHT_DEFAULT_LITELLM_MODEL routed via the model-mapped root (no /anthropic suffix)", () => {
+    startHindsight(
+      { apiPort: 8888, uiPort: 9999 },
+      { baseUrl: "http://127.0.0.1:4010", apiKey: "sk-test" },
+    );
+    const args = findRunArgs();
+    expect(envVal(args, "ANTHROPIC_MODEL")).toBe(HINDSIGHT_DEFAULT_LITELLM_MODEL);
+    expect(envVal(args, "HINDSIGHT_API_LLM_MODEL")).toBe(HINDSIGHT_DEFAULT_LITELLM_MODEL);
+    expect(envVal(args, "ANTHROPIC_BASE_URL")).toBe("http://127.0.0.1:4010");
+  });
+
+  it("with litellm and an explicit claude-* model override, rides the Anthropic pass-through (/anthropic suffix)", () => {
+    startHindsight(
+      { apiPort: 8888, uiPort: 9999 },
+      { baseUrl: "http://127.0.0.1:4010", apiKey: "sk-test", model: "claude-sonnet-5" },
+    );
+    const args = findRunArgs();
+    expect(envVal(args, "ANTHROPIC_MODEL")).toBe("claude-sonnet-5");
+    expect(envVal(args, "ANTHROPIC_BASE_URL")).toBe("http://127.0.0.1:4010/anthropic");
+  });
+
+  it("with litellm and an explicit non-Claude model override, rides the model-mapped root", () => {
+    startHindsight(
+      { apiPort: 8888, uiPort: 9999 },
+      { baseUrl: "http://127.0.0.1:4010/", apiKey: "sk-test", model: "openrouter/minimax/minimax-m3" },
+    );
+    const args = findRunArgs();
+    expect(envVal(args, "ANTHROPIC_MODEL")).toBe("openrouter/minimax/minimax-m3");
+    // Trailing slash on baseUrl must not survive into the resolved URL.
+    expect(envVal(args, "ANTHROPIC_BASE_URL")).toBe("http://127.0.0.1:4010");
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `memory.config.llm_model` config knob so hindsight's LLM ops (retain/reflect/consolidation) can use any LiteLLM-registered model, not just Claude.
- When the `litellm` carve-out is enabled and no override is set, defaults to `openrouter/google/gemini-3.1-flash-lite` (cheap/fast) instead of Claude — moves background memory-op cost off the Claude subscription quota.
- Non-Claude models route via LiteLLM's model-mapped path (`<root>`); `claude-*` models/aliases still ride the Anthropic OAuth pass-through (`<root>/anthropic`) unchanged, preserving the 2026-07-05 opus-stream-stall fix.
- Direct-OAuth mode (litellm disabled or fail-open) is untouched — still pins `HINDSIGHT_DEFAULT_MODEL` (claude-sonnet-5), since there's no proxy to translate a non-Claude model name.

## Why
Fleet litellm-config.yaml already moved some hindsight-adjacent background ops (gpt-oss-20b) off the Anthropic subscription for cost reasons (2026-07-07). This generalizes that pattern into a proper switchroom config knob instead of a one-off env hack, per operator request.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean (all guard scripts pass)
- [x] `tests/setup/hindsight.test.ts` — added 4 new cases covering: no-litellm default, litellm+no-override default (model-mapped root), litellm+claude-* override (pass-through), litellm+non-Claude override (model-mapped root, trailing-slash baseUrl normalization). All 37 tests in the file pass.
- [x] `src/config/schema.test.ts` (126 tests) unaffected/passing
- [x] `tests/memory.test.ts` (19 tests) unaffected/passing
- Job spec: subscription-honest (vision.md pillar 3) — the opt-in LiteLLM carve-out already covers this class of routing (`reference/invariants.md` § Operator-controlled gateway carve-out).

## Risk
Low — additive config field, defaults only apply when `litellm.enabled: true` (opt-in, off by default). Direct-OAuth fail-open path is unchanged.