### PR TITLE
feat(telegram): markdown parser + typed IR (RFC §10 increment 1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,13 @@
         "@secretlint/types": "^12.2.0",
         "@xterm/headless": "^6.0.0",
         "grammy": "^1.44",
+        "mdast-util-from-markdown": "^2.0.2",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
         "posthog-node": "^5.29.2",
+      },
+      "devDependencies": {
+        "@types/mdast": "^4.0.4",
       },
     },
   },
@@ -275,13 +281,21 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/events": ["@types/events@3.0.0", "", {}, "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="],
 
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
     "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@vitest/coverage-v8": ["@vitest/coverage-v8@3.2.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^1.0.2", "ast-v8-to-istanbul": "^0.3.3", "debug": "^4.4.1", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.17", "magicast": "^0.3.5", "std-env": "^3.9.0", "test-exclude": "^7.0.1", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "@vitest/browser": "3.2.4", "vitest": "3.2.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ=="],
 
@@ -357,9 +371,13 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
@@ -387,6 +405,8 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
@@ -395,9 +415,13 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
@@ -436,6 +460,8 @@
     "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
@@ -585,6 +611,8 @@
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
@@ -595,13 +623,93 @@
 
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
@@ -827,6 +935,14 @@
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
@@ -862,6 +978,8 @@
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 

--- a/telegram-plugin/package.json
+++ b/telegram-plugin/package.json
@@ -33,7 +33,13 @@
     "@secretlint/types": "^12.2.0",
     "@xterm/headless": "^6.0.0",
     "grammy": "^1.44",
+    "mdast-util-from-markdown": "^2.0.2",
+    "mdast-util-gfm": "^3.0.0",
+    "micromark-extension-gfm": "^3.0.0",
     "posthog-node": "^5.29.2"
+  },
+  "devDependencies": {
+    "@types/mdast": "^4.0.4"
   },
   "engines": {
     "node": ">=20.11.0"

--- a/telegram-plugin/render/ir.ts
+++ b/telegram-plugin/render/ir.ts
@@ -1,0 +1,173 @@
+// Typed intermediate representation (IR) for the Telegram HTML render engine.
+//
+// This is the parser <-> renderer contract. `parse()` (parse.ts) folds an
+// mdast tree into this shape; a later increment's renderer walks it and emits
+// Telegram Bot API HTML. Increment 1 lands ONLY the parser + this IR — there
+// is no renderer yet.
+//
+// Every node carries `{ start, end }` UTF-16 source offsets copied verbatim
+// from mdast `position.start.offset` / `position.end.offset`. They are UTF-16
+// code-unit indices into the original markdown string, so
+// `source.slice(node.start, node.end)` round-trips to the node's source text.
+//
+// Telegram HTML tag mapping (for the next increment — NOT implemented here):
+//
+//   Inline
+//     plain   -> (raw text, HTML-escaped)
+//     bold    -> <b>…</b>
+//     italic  -> <i>…</i>
+//     strike  -> <s>…</s>
+//     spoiler -> <tg-spoiler>…</tg-spoiler>
+//     code    -> <code>…</code>
+//     link    -> <a href="…">…</a>
+//
+//   Block
+//     paragraph      -> children joined; blocks separated by "\n\n"
+//     heading        -> <b>…</b> (Telegram HTML has no <h1>…<h6>; bold + newlines)
+//     blockquote     -> <blockquote>…</blockquote>
+//                       (expandable === true -> <blockquote expandable>)
+//     code-block     -> <pre><code class="language-…">…</code></pre>
+//     list           -> rendered line-per-item with "•"/"1." bullets
+//                       (Telegram HTML has no <ul>/<ol>)
+//     thematic-break -> a horizontal-rule text line (e.g. "───")
+//     table          -> monospaced <pre> table (Telegram HTML has no <table>)
+
+export interface Pos {
+  /** UTF-16 code-unit offset of the node's first char (mdast position.start.offset). */
+  start: number;
+  /** UTF-16 code-unit offset just past the node's last char (mdast position.end.offset). */
+  end: number;
+}
+
+// ---------------------------------------------------------------------------
+// Inline nodes
+// ---------------------------------------------------------------------------
+
+export interface PlainNode extends Pos {
+  type: "plain";
+  text: string;
+}
+
+export interface BoldNode extends Pos {
+  type: "bold";
+  children: Inline[];
+}
+
+export interface ItalicNode extends Pos {
+  type: "italic";
+  children: Inline[];
+}
+
+export interface StrikeNode extends Pos {
+  type: "strike";
+  children: Inline[];
+}
+
+export interface SpoilerNode extends Pos {
+  type: "spoiler";
+  children: Inline[];
+}
+
+export interface CodeNode extends Pos {
+  type: "code";
+  text: string;
+}
+
+export interface LinkNode extends Pos {
+  type: "link";
+  href: string;
+  children: Inline[];
+}
+
+export type Inline =
+  | PlainNode
+  | BoldNode
+  | ItalicNode
+  | StrikeNode
+  | SpoilerNode
+  | CodeNode
+  | LinkNode;
+
+// ---------------------------------------------------------------------------
+// Block nodes
+// ---------------------------------------------------------------------------
+
+export interface ParagraphNode extends Pos {
+  type: "paragraph";
+  children: Inline[];
+}
+
+export interface HeadingNode extends Pos {
+  type: "heading";
+  /** 1..6 */
+  level: number;
+  children: Inline[];
+}
+
+export interface BlockquoteNode extends Pos {
+  type: "blockquote";
+  children: Block[];
+  /** Telegram <blockquote expandable>. Always false in Increment 1 — see parse.ts. */
+  expandable: boolean;
+}
+
+export interface CodeBlockNode extends Pos {
+  type: "code-block";
+  text: string;
+  language: string | null;
+}
+
+export interface ListNode extends Pos {
+  type: "list";
+  ordered: boolean;
+  // NOTE: the spec names this ordinal `start`, but every node already carries
+  // `start`/`end` UTF-16 offsets (load-bearing for round-trip slicing). To
+  // avoid the collision the ordered-list ordinal is `startNumber` here; its
+  // semantics match the spec's `list.start` exactly (mdast `list.start`).
+  /** First number of an ordered list (mdast `start`); null for unordered. */
+  startNumber: number | null;
+  items: ListItem[];
+}
+
+export interface ThematicBreakNode extends Pos {
+  type: "thematic-break";
+}
+
+export interface TableNode extends Pos {
+  type: "table";
+  header: TableRow;
+  rows: TableRow[];
+  /** Per-column alignment, parallel to the cells. */
+  align: ("left" | "center" | "right" | null)[];
+}
+
+export type Block =
+  | ParagraphNode
+  | HeadingNode
+  | BlockquoteNode
+  | CodeBlockNode
+  | ListNode
+  | ThematicBreakNode
+  | TableNode;
+
+// ---------------------------------------------------------------------------
+// Composite / container shapes
+// ---------------------------------------------------------------------------
+
+export interface ListItem extends Pos {
+  children: Block[];
+  /** GFM task-list state: true (checked), false (unchecked), null (not a task item). */
+  checked: boolean | null;
+}
+
+export interface TableRow extends Pos {
+  cells: TableCell[];
+}
+
+export interface TableCell extends Pos {
+  children: Inline[];
+}
+
+export interface Document {
+  blocks: Block[];
+}

--- a/telegram-plugin/render/parse.ts
+++ b/telegram-plugin/render/parse.ts
@@ -1,0 +1,190 @@
+// Markdown -> typed IR parser for the Telegram HTML render engine.
+//
+// Uses `mdast-util-from-markdown` (micromark under the hood) with the GFM
+// syntax + mdast extensions to obtain an mdast tree, then folds that tree into
+// the IR defined in `ir.ts`. This is Increment 1: parser + IR only. There is
+// no renderer and no chunker yet, and nothing here is wired into the live send
+// path.
+//
+// Design rules honored here:
+//   - Every emitted node copies UTF-16 source offsets straight off mdast
+//     `position.start.offset` / `position.end.offset`, so
+//     `source.slice(node.start, node.end)` round-trips to the source text.
+//   - Never lose text. Any mdast node type outside the supported palette
+//     degrades to a `plain` inline (or a paragraph wrapping one) carrying the
+//     raw source slice, rather than being dropped.
+//
+// Spoiler handling (IR has a `spoiler` node, mdast/GFM has no spoiler concept):
+//   Increment 1 does NOT emit `spoiler` nodes. GFM has no spoiler syntax, and
+//   introducing the switchroom `||…||` convention means teaching micromark a
+//   custom inline extension — out of scope for the parser+IR increment. The IR
+//   type stays in place; a later increment adds a micromark inline extension
+//   (or a post-parse pass over `plain` text) that recognises the spoiler
+//   delimiter and emits `SpoilerNode`. Until then spoiler delimiters fold into
+//   `plain`/`emphasis` text like any other characters.
+//
+// Blockquote expandable handling:
+//   The IR carries `expandable: boolean` for Telegram's `<blockquote
+//   expandable>`. GFM blockquotes have no expandable marker, so Increment 1
+//   always sets `expandable = false`. TODO(next increment): recognise the
+//   `‖…‖` / expandable source convention and set the flag.
+
+import { fromMarkdown } from "mdast-util-from-markdown";
+import { gfm } from "micromark-extension-gfm";
+import { gfmFromMarkdown } from "mdast-util-gfm";
+import type {
+  Node as MdastNode,
+  Parent as MdastParent,
+  RootContent,
+  PhrasingContent,
+  AlignType,
+} from "mdast";
+
+import type {
+  Block,
+  Document,
+  Inline,
+  ListItem,
+  Pos,
+  TableCell,
+  TableRow,
+} from "./ir.js";
+
+/** Copy UTF-16 offsets off an mdast node. Falls back to 0-length when a
+ *  synthesized node lacks a position (from-markdown always sets one, but the
+ *  mdast types make `position` optional). */
+function pos(node: MdastNode): Pos {
+  const p = node.position;
+  return {
+    start: p?.start?.offset ?? 0,
+    end: p?.end?.offset ?? 0,
+  };
+}
+
+/** Raw source text a node spans — used for the never-lose-text fallback. */
+function slice(source: string, node: MdastNode): string {
+  const { start, end } = pos(node);
+  return source.slice(start, end);
+}
+
+/** mdast `AlignType` (null | 'left' | 'right' | 'center') passes through
+ *  unchanged; the IR uses the same union. */
+function foldAlign(a: AlignType | undefined): "left" | "center" | "right" | null {
+  return a ?? null;
+}
+
+function foldInline(node: PhrasingContent, source: string): Inline {
+  switch (node.type) {
+    case "text":
+      return { type: "plain", text: node.value, ...pos(node) };
+    case "strong":
+      return { type: "bold", children: foldInlineChildren(node, source), ...pos(node) };
+    case "emphasis":
+      return { type: "italic", children: foldInlineChildren(node, source), ...pos(node) };
+    case "delete":
+      return { type: "strike", children: foldInlineChildren(node, source), ...pos(node) };
+    case "inlineCode":
+      return { type: "code", text: node.value, ...pos(node) };
+    case "link":
+      return {
+        type: "link",
+        href: node.url,
+        children: foldInlineChildren(node, source),
+        ...pos(node),
+      };
+    // Not in the palette (break, image, html, footnoteReference, …): keep the
+    // raw source text so no content is lost.
+    default:
+      return { type: "plain", text: slice(source, node), ...pos(node) };
+  }
+}
+
+function foldInlineChildren(node: MdastParent, source: string): Inline[] {
+  return node.children.map((c) => foldInline(c as PhrasingContent, source));
+}
+
+function foldTableRow(
+  row: Extract<RootContent, { type: "tableRow" }>,
+  source: string,
+): TableRow {
+  const cells: TableCell[] = row.children.map((cell) => ({
+    children: cell.children.map((c) => foldInline(c as PhrasingContent, source)),
+    ...pos(cell),
+  }));
+  return { cells, ...pos(row) };
+}
+
+function foldBlock(node: RootContent, source: string): Block {
+  switch (node.type) {
+    case "paragraph":
+      return { type: "paragraph", children: foldInlineChildren(node, source), ...pos(node) };
+    case "heading":
+      return {
+        type: "heading",
+        level: node.depth,
+        children: foldInlineChildren(node, source),
+        ...pos(node),
+      };
+    case "blockquote":
+      return {
+        type: "blockquote",
+        children: node.children.map((c) => foldBlock(c, source)),
+        // GFM has no expandable marker — always false in Increment 1.
+        expandable: false,
+        ...pos(node),
+      };
+    case "code":
+      return {
+        type: "code-block",
+        text: node.value,
+        language: node.lang ?? null,
+        ...pos(node),
+      };
+    case "list": {
+      const items: ListItem[] = node.children.map((li) => ({
+        children: li.children.map((c) => foldBlock(c, source)),
+        checked: li.checked ?? null,
+        ...pos(li),
+      }));
+      return {
+        type: "list",
+        ordered: node.ordered ?? false,
+        startNumber: node.ordered ? node.start ?? 1 : null,
+        items,
+        ...pos(node),
+      };
+    }
+    case "thematicBreak":
+      return { type: "thematic-break", ...pos(node) };
+    case "table": {
+      const rows = node.children;
+      const [headerRow, ...bodyRows] = rows;
+      return {
+        type: "table",
+        header: foldTableRow(headerRow, source),
+        rows: bodyRows.map((r) => foldTableRow(r, source)),
+        align: (node.align ?? []).map(foldAlign),
+        ...pos(node),
+      };
+    }
+    // Not in the palette (html, definition, footnoteDefinition, …): degrade to
+    // a paragraph carrying the raw source slice so no content is dropped.
+    default:
+      return {
+        type: "paragraph",
+        children: [{ type: "plain", text: slice(source, node), ...pos(node) }],
+        ...pos(node),
+      };
+  }
+}
+
+/** Parse a markdown string into the typed IR Document. */
+export function parse(markdown: string): Document {
+  const tree = fromMarkdown(markdown, {
+    extensions: [gfm()],
+    mdastExtensions: [gfmFromMarkdown()],
+  });
+  return {
+    blocks: tree.children.map((child) => foldBlock(child, markdown)),
+  };
+}

--- a/telegram-plugin/tests/render/parse-torture.test.ts
+++ b/telegram-plugin/tests/render/parse-torture.test.ts
@@ -1,0 +1,131 @@
+// Cross-check the new markdown->IR parser (render/parse.ts) against the
+// existing adversarial torture-fixture set (formatting-torture-set.ts).
+//
+// This does NOT exercise the renderer or chunker (out of scope for the
+// parser+IR increment) — it feeds each fixture's raw `input` straight into
+// `parse()` and walks the resulting IR tree collecting a flat entity list,
+// then asserts every entity the fixture's `expect` block calls for is
+// present in that list. This is a structural cross-check independent of the
+// existing gateway-pipeline oracle: it proves the new parser captures the
+// same intent the current hand-rolled pipeline is required to preserve.
+import { describe, it, expect } from 'vitest'
+import { parse } from '../../render/parse.js'
+import type { Block, Inline } from '../../render/ir.js'
+import { TORTURE_SET, type ExpectEntity } from '../formatting-torture-set.js'
+import type { EntityType } from '../rich-markdown-oracle.js'
+
+interface FlatEntity {
+  type: EntityType
+  text: string
+  url?: string
+  lang?: string
+}
+
+function textOf(nodes: Inline[]): string {
+  return nodes
+    .map((n) => {
+      switch (n.type) {
+        case 'plain':
+        case 'code':
+          return n.text
+        default:
+          return textOf(n.children)
+      }
+    })
+    .join('')
+}
+
+function walkInline(node: Inline, out: FlatEntity[]) {
+  switch (node.type) {
+    case 'bold':
+      out.push({ type: 'bold', text: textOf(node.children) })
+      node.children.forEach((c) => walkInline(c, out))
+      break
+    case 'italic':
+      out.push({ type: 'italic', text: textOf(node.children) })
+      node.children.forEach((c) => walkInline(c, out))
+      break
+    case 'strike':
+      out.push({ type: 'strikethrough', text: textOf(node.children) })
+      node.children.forEach((c) => walkInline(c, out))
+      break
+    case 'code':
+      out.push({ type: 'code', text: node.text })
+      break
+    case 'link':
+      out.push({ type: 'link', text: textOf(node.children), url: node.href })
+      node.children.forEach((c) => walkInline(c, out))
+      break
+    case 'plain':
+      break
+    case 'spoiler':
+      node.children.forEach((c) => walkInline(c, out))
+      break
+  }
+}
+
+function walkBlock(node: Block, out: FlatEntity[]) {
+  switch (node.type) {
+    case 'paragraph':
+    case 'heading':
+      node.children.forEach((c) => walkInline(c, out))
+      break
+    case 'blockquote':
+      node.children.forEach((c) => walkBlock(c, out))
+      break
+    case 'code-block':
+      out.push({ type: 'pre', text: node.text, lang: node.language ?? undefined })
+      break
+    case 'list':
+      for (const item of node.items) item.children.forEach((c) => walkBlock(c, out))
+      break
+    case 'table':
+      for (const row of [node.header, ...node.rows]) {
+        for (const cell of row.cells) cell.children.forEach((c) => walkInline(c, out))
+      }
+      break
+    case 'thematic-break':
+      break
+  }
+}
+
+function flatten(input: string): FlatEntity[] {
+  const doc = parse(input)
+  const out: FlatEntity[] = []
+  doc.blocks.forEach((b) => walkBlock(b, out))
+  return out
+}
+
+function matches(found: FlatEntity[], want: ExpectEntity): boolean {
+  return found.some(
+    (f) =>
+      f.type === want.type &&
+      f.text === want.text &&
+      (want.url === undefined || f.url === want.url) &&
+      (want.lang === undefined || f.lang === want.lang),
+  )
+}
+
+describe('parse: torture-fixture cross-check', () => {
+  for (const fixture of TORTURE_SET) {
+    if (fixture.expect.length === 0) {
+      // No entity assertions for this fixture — just prove parse() doesn't
+      // throw and returns at least one block (structure-only fixtures).
+      it(`${fixture.name}: parses without throwing`, () => {
+        const doc = parse(fixture.input)
+        expect(doc.blocks.length).toBeGreaterThan(0)
+      })
+      continue
+    }
+
+    it(`${fixture.name}: IR captures every expected entity`, () => {
+      const found = flatten(fixture.input)
+      for (const want of fixture.expect) {
+        expect(
+          matches(found, want),
+          `expected a ${want.type} entity with text ${JSON.stringify(want.text)} in fixture "${fixture.name}"; found: ${JSON.stringify(found)}`,
+        ).toBe(true)
+      }
+    })
+  }
+})

--- a/telegram-plugin/tests/render/parse.test.ts
+++ b/telegram-plugin/tests/render/parse.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "../../render/parse.js";
+import type { Block, Inline } from "../../render/ir.js";
+
+// Assert every node in a subtree round-trips: source.slice(start, end) is the
+// exact source text the node spans. Walks both inline and block children.
+function assertOffsetsRoundTrip(node: any, source: string) {
+  expect(typeof node.start).toBe("number");
+  expect(typeof node.end).toBe("number");
+  // The slice must be non-empty for real nodes and lie within bounds.
+  expect(node.start).toBeGreaterThanOrEqual(0);
+  expect(node.end).toBeLessThanOrEqual(source.length);
+  expect(node.end).toBeGreaterThanOrEqual(node.start);
+  if (Array.isArray(node.children)) {
+    for (const c of node.children) assertOffsetsRoundTrip(c, source);
+  }
+  if (Array.isArray(node.items)) {
+    for (const it of node.items) assertOffsetsRoundTrip(it, source);
+  }
+  if (Array.isArray(node.cells)) {
+    for (const c of node.cells) assertOffsetsRoundTrip(c, source);
+  }
+}
+
+describe("parse: inline palette", () => {
+  const cases: Array<{
+    name: string;
+    md: string;
+    // The inline construct's source text (what slice(start,end) must equal).
+    fragment: string;
+    check: (inline: Inline) => void;
+  }> = [
+    {
+      name: "bold",
+      md: "**hi**",
+      fragment: "**hi**",
+      check: (n) => {
+        expect(n.type).toBe("bold");
+        expect((n as any).children[0]).toMatchObject({ type: "plain", text: "hi" });
+      },
+    },
+    {
+      name: "italic",
+      md: "*hi*",
+      fragment: "*hi*",
+      check: (n) => {
+        expect(n.type).toBe("italic");
+        expect((n as any).children[0]).toMatchObject({ type: "plain", text: "hi" });
+      },
+    },
+    {
+      name: "strike",
+      md: "~~hi~~",
+      fragment: "~~hi~~",
+      check: (n) => {
+        expect(n.type).toBe("strike");
+        expect((n as any).children[0]).toMatchObject({ type: "plain", text: "hi" });
+      },
+    },
+    {
+      name: "inline code",
+      md: "`x = 1`",
+      fragment: "`x = 1`",
+      check: (n) => {
+        expect(n).toMatchObject({ type: "code", text: "x = 1" });
+      },
+    },
+    {
+      name: "link",
+      md: "[label](https://example.com)",
+      fragment: "[label](https://example.com)",
+      check: (n) => {
+        expect(n.type).toBe("link");
+        expect((n as any).href).toBe("https://example.com");
+        expect((n as any).children[0]).toMatchObject({ type: "plain", text: "label" });
+      },
+    },
+  ];
+
+  for (const c of cases) {
+    it(`parses ${c.name} and offsets round-trip`, () => {
+      const doc = parse(c.md);
+      expect(doc.blocks).toHaveLength(1);
+      const para = doc.blocks[0];
+      expect(para.type).toBe("paragraph");
+      const inline = (para as any).children[0] as Inline;
+      c.check(inline);
+      expect(c.md.slice(inline.start, inline.end)).toBe(c.fragment);
+      assertOffsetsRoundTrip(para, c.md);
+    });
+  }
+});
+
+describe("parse: heading levels", () => {
+  for (let level = 1; level <= 6; level++) {
+    it(`parses an h${level} heading`, () => {
+      const md = `${"#".repeat(level)} Title`;
+      const doc = parse(md);
+      expect(doc.blocks).toHaveLength(1);
+      const h = doc.blocks[0] as any;
+      expect(h.type).toBe("heading");
+      expect(h.level).toBe(level);
+      expect(h.children[0]).toMatchObject({ type: "plain", text: "Title" });
+      expect(md.slice(h.start, h.end)).toBe(md);
+    });
+  }
+});
+
+describe("parse: fenced code with language", () => {
+  it("captures text and language", () => {
+    const md = "```ts\nconst x = 1;\n```";
+    const doc = parse(md);
+    const cb = doc.blocks[0] as any;
+    expect(cb.type).toBe("code-block");
+    expect(cb.language).toBe("ts");
+    expect(cb.text).toBe("const x = 1;");
+    expect(md.slice(cb.start, cb.end)).toBe(md);
+  });
+
+  it("null language for a bare fence", () => {
+    const md = "```\nplain\n```";
+    const doc = parse(md);
+    const cb = doc.blocks[0] as any;
+    expect(cb.type).toBe("code-block");
+    expect(cb.language).toBeNull();
+  });
+});
+
+describe("parse: blockquote", () => {
+  it("parses a blockquote with expandable=false", () => {
+    const md = "> quoted text";
+    const doc = parse(md);
+    const bq = doc.blocks[0] as any;
+    expect(bq.type).toBe("blockquote");
+    expect(bq.expandable).toBe(false);
+    expect(bq.children[0].type).toBe("paragraph");
+    expect(md.slice(bq.start, bq.end)).toBe(md);
+  });
+});
+
+describe("parse: lists", () => {
+  it("parses an unordered list (start=null)", () => {
+    const md = "- one\n- two";
+    const doc = parse(md);
+    const list = doc.blocks[0] as any;
+    expect(list.type).toBe("list");
+    expect(list.ordered).toBe(false);
+    expect(list.startNumber).toBeNull();
+    expect(list.items).toHaveLength(2);
+    expect(md.slice(list.start, list.end)).toBe(md);
+    assertOffsetsRoundTrip(list, md);
+  });
+
+  it("parses an ordered list with a start number", () => {
+    const md = "3. three\n4. four";
+    const doc = parse(md);
+    const list = doc.blocks[0] as any;
+    expect(list.type).toBe("list");
+    expect(list.ordered).toBe(true);
+    expect(list.startNumber).toBe(3);
+    expect(list.items).toHaveLength(2);
+  });
+
+  it("parses task-list checked/unchecked state", () => {
+    const md = "- [x] done\n- [ ] todo";
+    const doc = parse(md);
+    const list = doc.blocks[0] as any;
+    expect(list.items[0].checked).toBe(true);
+    expect(list.items[1].checked).toBe(false);
+  });
+
+  it("plain (non-task) list items have checked=null", () => {
+    const md = "- a\n- b";
+    const doc = parse(md);
+    const list = doc.blocks[0] as any;
+    expect(list.items[0].checked).toBeNull();
+    expect(list.items[1].checked).toBeNull();
+  });
+});
+
+describe("parse: GFM table with mixed alignment", () => {
+  it("captures header, rows, and per-column alignment", () => {
+    const md = ["| L | C | R |", "|:--|:-:|--:|", "| 1 | 2 | 3 |"].join("\n");
+    const doc = parse(md);
+    const table = doc.blocks[0] as any;
+    expect(table.type).toBe("table");
+    expect(table.align).toEqual(["left", "center", "right"]);
+    expect(table.header.cells).toHaveLength(3);
+    expect(table.rows).toHaveLength(1);
+    expect(table.rows[0].cells[0].children[0]).toMatchObject({ type: "plain", text: "1" });
+    expect(md.slice(table.start, table.end)).toBe(md);
+    assertOffsetsRoundTrip(table, md);
+  });
+});
+
+describe("parse: thematic break", () => {
+  it("parses a horizontal rule", () => {
+    const md = "---";
+    const doc = parse(md);
+    const tb = doc.blocks[0] as any;
+    expect(tb.type).toBe("thematic-break");
+    expect(md.slice(tb.start, tb.end)).toBe(md);
+  });
+});
+
+describe("parse: nested inline", () => {
+  it("bold containing italic, offsets round-trip at both levels", () => {
+    const md = "**bold *and italic* here**";
+    const doc = parse(md);
+    const bold = (doc.blocks[0] as any).children[0];
+    expect(bold.type).toBe("bold");
+    expect(md.slice(bold.start, bold.end)).toBe("**bold *and italic* here**");
+    const italic = bold.children.find((c: any) => c.type === "italic");
+    expect(italic).toBeDefined();
+    expect(md.slice(italic.start, italic.end)).toBe("*and italic*");
+    assertOffsetsRoundTrip(doc.blocks[0] as Block, md);
+  });
+});
+
+describe("parse: unsupported construct fallback", () => {
+  it("degrades a raw HTML block to plain text without dropping content", () => {
+    // Raw HTML blocks (mdast `html`) are outside the palette; they must
+    // survive as plain source text.
+    const md = "<div class=\"x\">raw</div>";
+    const doc = parse(md);
+    const block = doc.blocks[0] as any;
+    expect(block.type).toBe("paragraph");
+    const plain = block.children[0];
+    expect(plain.type).toBe("plain");
+    expect(plain.text).toBe(md);
+    expect(md.slice(plain.start, plain.end)).toBe(md);
+  });
+});
+
+describe("parse: astral-plane emoji offsets are UTF-16 units", () => {
+  it("uses UTF-16 code-unit offsets, not codepoints or bytes", () => {
+    // U+1F680 ROCKET is one codepoint but TWO UTF-16 code units (a surrogate
+    // pair) and FOUR UTF-8 bytes. The bold node after it must start at the
+    // UTF-16 offset.
+    const emoji = "\u{1F680}"; // 🚀, length 2 in UTF-16
+    expect(emoji.length).toBe(2);
+    const md = `${emoji} **go**`;
+    const doc = parse(md);
+    const para = doc.blocks[0] as any;
+    const bold = para.children.find((c: any) => c.type === "bold");
+    expect(bold).toBeDefined();
+    // "🚀 " is 3 UTF-16 code units (2 + space), so bold starts at offset 3.
+    expect(bold.start).toBe(3);
+    expect(md.slice(bold.start, bold.end)).toBe("**go**");
+    // Sanity: byte-based or codepoint-based offsets would give 2 or a
+    // different index, not 3.
+    expect(md.slice(bold.start, bold.end)).not.toBe("*go**");
+  });
+});


### PR DESCRIPTION
## Summary
Delivers the first line item of docs/telegram-native-formatting-rfc.md §10: "Parser dependency + markdown→typed IR". Scope is intentionally narrow — this lands only the parser + IR module, unused by production code. No renderer, no chunker, no wiring into `sendRichMessage`/`format.ts` — those are later phases.

- **Parser dependency**: `mdast-util-from-markdown` + `micromark-extension-gfm` + `mdast-util-gfm`. Chosen because it parses to a real, well-typed AST (mdast) rather than a bespoke tokenizer, has first-class GFM support (tables, strikethrough, task lists) needed for the RFC §5 feature palette, and is actively maintained (unified/remark ecosystem) — a good fit for "parser-library choice pulls toward the low end" per RFC §10.
- **Typed IR** (`telegram-plugin/render/ir.ts`): inline spans (bold, italic, strike, code, link) and block nodes (paragraph, heading, blockquote, code-block w/ language, list w/ task-item state, table w/ alignment, thematic break) per RFC §4/§5. Every node carries UTF-16 `{start, end}` offsets copied straight from mdast, so `source.slice(start, end)` round-trips exactly — verified against an astral-plane emoji/surrogate-pair fixture per the RFC's explicit warning.
- **Parser** (`telegram-plugin/render/parse.ts`): `parse(markdown): Document` folds the mdast tree into the IR. Any construct outside the supported palette (raw HTML, footnotes, etc.) degrades to a `plain` text node carrying the raw source slice rather than being dropped — never loses content.

## Test plan
- [x] Full inline/block palette coverage (bold/italic/strike/code/link; heading levels 1-6; fenced code w/ language; blockquote; ordered/unordered/task lists; GFM table w/ mixed alignment; thematic break; nested inline spans)
- [x] UTF-16/emoji offset correctness (astral-plane surrogate-pair fixture)
- [x] Unsupported-construct fallback (raw HTML degrades to plain, no content loss)
- [x] Cross-check: every fixture in the existing adversarial torture-fixture set (`tests/formatting-torture-set.ts`) run through the new parser, asserting the IR captures the same entities the current hand-rolled pipeline is required to preserve
- [x] `tsc --noEmit` clean
- [x] `npm run test:vitest` — 12339 passed, 74 pre-existing failures unrelated to this change (hostd self-bump, static-binary bun-build tests — none touch `render/` or `telegram-plugin/tests/render/`)
- [x] Did not touch `sendRichMessage`, `format.ts`'s chunker/escaper, or the live send path; no fleet restart

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>