### PR TITLE
feat(telegram): IR -> markdown renderer for the Bot API 10.1 rich path

### DIFF
--- a/telegram-plugin/render/render.ts
+++ b/telegram-plugin/render/render.ts
@@ -1,0 +1,299 @@
+// IR -> Telegram rich-markdown renderer for the Telegram HTML render engine
+// (name kept for continuity with render/ir.ts + render/parse.ts; the actual
+// wire format is GFM markdown, NOT HTML — see the note below).
+//
+// Increment 2 of the render pipeline: takes the typed IR produced by
+// `parse.ts` (per `ir.ts`) and emits a string suitable for the `markdown`
+// field of `InputRichMessageMarkdown` (`telegram-plugin/rich-send.ts`).
+//
+// IMPORTANT — why this emits markdown, not HTML:
+// `ir.ts`'s block-type doc comment (written during Increment 1) sketches an
+// HTML tag mapping "for the next increment." That comment predates the Bot
+// API 10.1 migration (#2669, `telegram-plugin/rich-send.ts`) becoming the
+// live send path: `sendRichMessage` / `editMessageText` are called with
+// `{ markdown: string }` — raw GFM markdown — not with `{ text, parse_mode:
+// "HTML" }`. There is no HTML anywhere on the current outbound path (see
+// `reference/telegram-formatting-guide.md`). This renderer therefore targets
+// the ACTUAL contract: GFM markdown with the Bot API 10.1 extensions
+// documented in the formatting guide (expandable blockquote via `**> `,
+// spoiler via `||…||`, GFM pipe tables, etc). This module is NOT wired into
+// the live send path yet — that is a later increment, per the RFC's phased
+// rollout (rich rendering stays gated off by default until then).
+//
+// Round-trip note: `parse.ts` folds inline text (`PlainNode.text`,
+// `CodeNode.text`, `code-block` `text`, link `href`) into DECODED strings —
+// entity references and escapes are already resolved by mdast. Rendering
+// back to markdown therefore re-escapes GFM-special characters in prose
+// context with `escapeMarkdown` (same helper `format.ts` uses for
+// dynamic-content interpolation) and re-defuses embedded backticks in code
+// spans with `codeSpanSafe`, so the emitted markdown parses back to
+// equivalent entities rather than accidentally re-triggering formatting or
+// breaking out of a code span.
+
+import { escapeMarkdown, codeSpanSafe, RICH_MESSAGE_MAX_CHARS } from "../format.js";
+import type {
+  Block,
+  BlockquoteNode,
+  CodeBlockNode,
+  Document,
+  Inline,
+  ListItem,
+  ListNode,
+  TableNode,
+  TableRow,
+} from "./ir.js";
+
+// ---------------------------------------------------------------------------
+// Inline rendering
+// ---------------------------------------------------------------------------
+
+function renderInline(node: Inline): string {
+  switch (node.type) {
+    case "plain":
+      return escapeMarkdown(node.text);
+    case "bold":
+      return `**${renderInlineChildren(node.children)}**`;
+    case "italic":
+      return `*${renderInlineChildren(node.children)}*`;
+    case "strike":
+      return `~~${renderInlineChildren(node.children)}~~`;
+    case "spoiler":
+      return `||${renderInlineChildren(node.children)}||`;
+    case "code":
+      return `\`${codeSpanSafe(node.text)}\``;
+    case "link":
+      return `[${renderInlineChildren(node.children)}](${node.href})`;
+    default: {
+      // Exhaustiveness guard — the IR union is closed; a new variant must be
+      // handled above rather than silently dropped.
+      const _exhaustive: never = node;
+      return escapeMarkdown((_exhaustive as Inline & { text?: string }).text ?? "");
+    }
+  }
+}
+
+function renderInlineChildren(children: Inline[]): string {
+  return children.map(renderInline).join("");
+}
+
+// ---------------------------------------------------------------------------
+// Block rendering
+// ---------------------------------------------------------------------------
+
+/** Prefix every line of `text` with `prefix` (used for blockquote nesting). */
+function prefixLines(text: string, prefix: string): string {
+  return text
+    .split("\n")
+    .map((line) => (line.length > 0 ? `${prefix}${line}` : prefix.trimEnd()))
+    .join("\n");
+}
+
+function renderBlockquote(node: BlockquoteNode): string {
+  const inner = renderBlocks(node.children);
+  // Bot API 10.1 expandable blockquote: `**> ` on the first quoted line.
+  // Plain blockquote: `> ` on every line.
+  if (node.expandable) {
+    const lines = inner.split("\n");
+    return lines
+      .map((line, i) => {
+        const marker = i === 0 ? "**> " : "> ";
+        return line.length > 0 ? `${marker}${line}` : marker.trimEnd();
+      })
+      .join("\n");
+  }
+  return prefixLines(inner, "> ");
+}
+
+function renderCodeBlock(node: CodeBlockNode): string {
+  const lang = node.language ?? "";
+  // Fenced code content is verbatim per the formatting guide; the only
+  // hazard is an embedded ``` closing the fence early. Widen the fence to a
+  // run of backticks one longer than the longest run already present in the
+  // content, mirroring the guide's `preBlock` defusal strategy.
+  const longestRun = Math.max(
+    0,
+    ...(node.text.match(/`+/g) ?? []).map((run) => run.length),
+  );
+  const fence = "`".repeat(Math.max(3, longestRun + 1));
+  return `${fence}${lang}\n${node.text}\n${fence}`;
+}
+
+function renderListItem(item: ListItem, ordered: boolean, index: number): string {
+  const checkbox =
+    item.checked === null ? "" : item.checked ? "[x] " : "[ ] ";
+  const marker = ordered ? `${index}. ` : "- ";
+  const body = renderBlocks(item.children);
+  const lines = body.split("\n");
+  const first = `${marker}${checkbox}${lines[0] ?? ""}`;
+  const contIndent = " ".repeat(marker.length);
+  const rest = lines
+    .slice(1)
+    .map((line) => (line.length > 0 ? `${contIndent}${line}` : line));
+  return [first, ...rest].join("\n");
+}
+
+function renderList(node: ListNode): string {
+  const start = node.startNumber ?? 1;
+  return node.items
+    .map((item, i) => renderListItem(item, node.ordered, start + i))
+    .join("\n");
+}
+
+/** Render a single cell's inline content for a table (no line breaks — GFM
+ *  table cells can't contain them; pipes are escaped defensively). */
+function renderTableCell(cells: TableRow["cells"][number]): string {
+  return renderInlineChildren(cells.children).replace(/\n+/g, " ");
+}
+
+function alignSeparator(align: TableNode["align"][number]): string {
+  switch (align) {
+    case "left":
+      return ":---";
+    case "right":
+      return "---:";
+    case "center":
+      return ":---:";
+    default:
+      return "---";
+  }
+}
+
+function renderTable(node: TableNode): string {
+  const headerCells = node.header.cells.map(renderTableCell);
+  const colCount = headerCells.length;
+  const align = node.align.length > 0 ? node.align : new Array(colCount).fill(null);
+  const headerLine = `| ${headerCells.join(" | ")} |`;
+  const sepLine = `| ${align
+    .slice(0, colCount)
+    .map(alignSeparator)
+    .join(" | ")} |`;
+  const bodyLines = node.rows.map(
+    (row) => `| ${row.cells.map(renderTableCell).join(" | ")} |`,
+  );
+  return [headerLine, sepLine, ...bodyLines].join("\n");
+}
+
+function renderBlock(node: Block): string {
+  switch (node.type) {
+    case "paragraph":
+      return renderInlineChildren(node.children);
+    case "heading":
+      return `${"#".repeat(node.level)} ${renderInlineChildren(node.children)}`;
+    case "blockquote":
+      return renderBlockquote(node);
+    case "code-block":
+      return renderCodeBlock(node);
+    case "list":
+      return renderList(node);
+    case "thematic-break":
+      return "---";
+    case "table":
+      return renderTable(node);
+    default: {
+      const _exhaustive: never = node;
+      return escapeMarkdown((_exhaustive as Block & { text?: string }).text ?? "");
+    }
+  }
+}
+
+function renderBlocks(blocks: Block[]): string {
+  return blocks.map(renderBlock).join("\n\n");
+}
+
+/** Render a full IR `Document` to Bot API 10.1 rich GFM markdown. */
+export function render(doc: Document): string {
+  return renderBlocks(doc.blocks);
+}
+
+// ---------------------------------------------------------------------------
+// Oversized-content safe fallback
+// ---------------------------------------------------------------------------
+
+export interface RenderResult {
+  /** The rendered text to send. */
+  text: string;
+  /** "markdown": send as rich `{ markdown }`. "plain": send as a literal
+   *  string with no rich wrapper (structure stripped, content preserved). */
+  mode: "markdown" | "plain";
+}
+
+/**
+ * A block is "atomic" for chunking purposes when splitting it mid-construct
+ * would break the wire format — an unterminated fence, a half table row, or
+ * a blockquote whose closing marker got separated from its opener. These are
+ * exactly the constructs `splitMarkdownChunks` (format.ts) already knows how
+ * to avoid bisecting for a MULTI-block body, but a SINGLE such block that by
+ * itself exceeds the cap has nowhere left to cut without breaking mid-tag —
+ * that's the case this module must catch before send.
+ */
+function isAtomicBlock(node: Block): boolean {
+  return (
+    node.type === "code-block" ||
+    node.type === "table" ||
+    node.type === "blockquote"
+  );
+}
+
+/** Render `node`'s raw source text as a plain literal (escaped so none of
+ *  the source's own markdown-special characters accidentally re-trigger
+ *  formatting when sent WITHOUT the rich wrapper — a plain send has no
+ *  parser, but downstream literal display should still show the author's
+ *  intended characters, not stray backslashes, so we use the raw slice
+ *  as-is: a plain send does not interpret markdown at all). */
+function plainSlice(source: string, node: Block): string {
+  return source.slice(node.start, node.end);
+}
+
+/**
+ * Render `doc` to Bot API 10.1 rich markdown, honoring the wire cap
+ * (`RICH_MESSAGE_MAX_CHARS` by default). Behaviour:
+ *
+ *   1. If the full rendered markdown fits under `maxLen`, return it as-is
+ *      (`mode: "markdown"`).
+ *   2. Otherwise, any individual ATOMIC block (table / code-block /
+ *      blockquote — constructs that cannot be safely bisected without
+ *      producing a broken tag/fence/row) whose OWN rendered form alone
+ *      exceeds `maxLen` is replaced by its raw plain-text source slice
+ *      instead of being emitted as rich markdown that a later chunker would
+ *      have to cut mid-construct.
+ *   3. If the document *still* exceeds `maxLen` after that per-block
+ *      substitution (i.e. the oversized content isn't isolated to one
+ *      swappable block, or the whole document is one giant atomic
+ *      construct), the ENTIRE document falls back to plain text — the raw
+ *      source, verbatim, sent with no rich wrapper at all. This never
+ *      truncates: the caller's ordinary length-based chunker
+ *      (`splitMarkdownChunks` and `hardSliceToCap`) is what applies size
+ *      limits to plain text before send; this function's only job is to
+ *      guarantee it is never handed a rich-markdown body with a mid-tag cut.
+ */
+export function renderSafe(
+  doc: Document,
+  source: string,
+  maxLen: number = RICH_MESSAGE_MAX_CHARS,
+): RenderResult {
+  const full = render(doc);
+  if (full.length <= maxLen) {
+    return { text: full, mode: "markdown" };
+  }
+
+  const rendered = doc.blocks.map((block) => ({
+    block,
+    text: renderBlock(block),
+  }));
+
+  const swapped = rendered.map(({ block, text }) => {
+    if (isAtomicBlock(block) && text.length > maxLen) {
+      return escapeMarkdown(plainSlice(source, block));
+    }
+    return text;
+  });
+  const patched = swapped.join("\n\n");
+  if (patched.length <= maxLen) {
+    return { text: patched, mode: "markdown" };
+  }
+
+  // Still oversized (or a giant atomic block never fit even as plain text) —
+  // fall all the way back to plain text for the whole document. Never
+  // truncate here; that is the length-based chunker's job downstream.
+  return { text: source, mode: "plain" };
+}

--- a/telegram-plugin/tests/render/render.test.ts
+++ b/telegram-plugin/tests/render/render.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "../../render/parse.js";
+import { render, renderSafe } from "../../render/render.js";
+import { RICH_MESSAGE_MAX_CHARS } from "../../format.js";
+import type { Document } from "../../render/ir.js";
+
+/** Round-trip helper: parse markdown -> IR -> render -> re-parse, and assert
+ *  the RE-PARSED IR is structurally equivalent to the original (ignoring
+ *  source offsets, which legitimately differ after re-rendering). */
+function assertRoundTripsStructurally(md: string) {
+  const doc = parse(md);
+  const out = render(doc);
+  const reparsed = parse(out);
+  expect(stripPositions(reparsed)).toEqual(stripPositions(doc));
+}
+
+function stripPositions(node: any): any {
+  if (Array.isArray(node)) return node.map(stripPositions);
+  if (node && typeof node === "object") {
+    const { start, end, ...rest } = node;
+    const out: any = {};
+    for (const [k, v] of Object.entries(rest)) out[k] = stripPositions(v);
+    return out;
+  }
+  return node;
+}
+
+describe("render: inline palette", () => {
+  it("bold", () => {
+    expect(render(parse("**hi**"))).toBe("**hi**");
+  });
+  it("italic", () => {
+    expect(render(parse("*hi*"))).toBe("*hi*");
+  });
+  it("strike", () => {
+    expect(render(parse("~~hi~~"))).toBe("~~hi~~");
+  });
+  it("inline code", () => {
+    expect(render(parse("`hi`"))).toBe("`hi`");
+  });
+  it("link", () => {
+    expect(render(parse("[label](https://example.com)"))).toBe(
+      "[label](https://example.com)",
+    );
+  });
+  it("nested inline spans", () => {
+    assertRoundTripsStructurally("**bold *and italic* text**");
+  });
+  it("escapes markdown-special characters in plain text", () => {
+    const out = render(parse("cost is 5 dollars"));
+    expect(out).toBe("cost is 5 dollars");
+  });
+  it("re-escapes literal specials so they don't re-trigger formatting", () => {
+    // A literal asterisk in prose (escaped in the source) must still be a
+    // literal asterisk after a render round trip, not accidentally start
+    // emphasis.
+    const doc = parse("a \\* literal star");
+    const out = render(doc);
+    expect(parse(out).blocks[0]).toMatchObject({ type: "paragraph" });
+    const reparsedText = (parse(out).blocks[0] as any).children
+      .map((c: any) => c.text ?? "")
+      .join("");
+    expect(reparsedText).toContain("*");
+  });
+});
+
+describe("render: block palette", () => {
+  it("heading levels 1-6", () => {
+    for (let level = 1; level <= 6; level++) {
+      const md = `${"#".repeat(level)} Title`;
+      expect(render(parse(md))).toBe(md);
+    }
+  });
+  it("plain blockquote", () => {
+    expect(render(parse("> quoted line"))).toBe("> quoted line");
+  });
+  it("expandable blockquote uses **> on the first line", () => {
+    const doc: Document = {
+      blocks: [
+        {
+          type: "blockquote",
+          expandable: true,
+          start: 0,
+          end: 0,
+          children: [
+            {
+              type: "paragraph",
+              start: 0,
+              end: 0,
+              children: [{ type: "plain", text: "hidden gem", start: 0, end: 0 }],
+            },
+          ],
+        },
+      ],
+    };
+    expect(render(doc)).toBe("**> hidden gem");
+  });
+  it("multi-line expandable blockquote continues with a plain > marker", () => {
+    const doc: Document = {
+      blocks: [
+        {
+          type: "blockquote",
+          expandable: true,
+          start: 0,
+          end: 0,
+          children: [
+            {
+              type: "paragraph",
+              start: 0,
+              end: 0,
+              children: [{ type: "plain", text: "line one", start: 0, end: 0 }],
+            },
+            {
+              type: "paragraph",
+              start: 0,
+              end: 0,
+              children: [{ type: "plain", text: "line two", start: 0, end: 0 }],
+            },
+          ],
+        },
+      ],
+    };
+    const out = render(doc);
+    const lines = out.split("\n");
+    expect(lines[0]).toBe("**> line one");
+    for (const line of lines.slice(1)) {
+      expect(line.startsWith("> ") || line === ">").toBe(true);
+    }
+  });
+  it("fenced code block with language", () => {
+    const md = "```bash\necho hi\n```";
+    expect(render(parse(md))).toBe(md);
+  });
+  it("widens the fence when the content itself contains backticks", () => {
+    const doc: Document = {
+      blocks: [
+        {
+          type: "code-block",
+          text: "```\nnested fence\n```",
+          language: null,
+          start: 0,
+          end: 0,
+        },
+      ],
+    };
+    const out = render(doc);
+    // Must not accidentally close early — the emitted fence must be a longer
+    // backtick run than any run inside the content.
+    const openFenceMatch = out.match(/^`+/);
+    expect(openFenceMatch).not.toBeNull();
+    expect(openFenceMatch![0].length).toBeGreaterThan(3);
+    // Re-parsing the rendered form must recover a single code-block with the
+    // exact original text.
+    const reparsed = parse(out);
+    expect(reparsed.blocks).toHaveLength(1);
+    expect(reparsed.blocks[0]).toMatchObject({
+      type: "code-block",
+      text: "```\nnested fence\n```",
+    });
+  });
+  it("unordered list", () => {
+    assertRoundTripsStructurally("- first\n- second\n- third");
+  });
+  it("ordered list preserves start number", () => {
+    assertRoundTripsStructurally("5. five\n6. six");
+  });
+  it("task list item checked state", () => {
+    assertRoundTripsStructurally("- [x] done\n- [ ] not done");
+  });
+  it("thematic break", () => {
+    expect(render(parse("---"))).toBe("---");
+  });
+  it("GFM table with mixed alignment", () => {
+    const md = [
+      "| Left | Center | Right |",
+      "| :--- | :---: | ---: |",
+      "| a | b | c |",
+      "| d | e | f |",
+    ].join("\n");
+    assertRoundTripsStructurally(md);
+  });
+  it("table cell content survives round trip", () => {
+    const md = ["| Col |", "| --- |", "| **bold** cell |"].join("\n");
+    const out = render(parse(md));
+    expect(out).toContain("**bold** cell");
+  });
+});
+
+describe("render: full document", () => {
+  it("multiple blocks are separated by a blank line", () => {
+    const doc = parse("# Title\n\nSome text.\n\n- one\n- two");
+    const out = render(doc);
+    expect(out).toBe("# Title\n\nSome text.\n\n- one\n- two");
+  });
+
+  it("round trips the parser's own torture-set style sample", () => {
+    const md = [
+      "# Report",
+      "",
+      "A **bold** claim with *italic* support and `a code span`, plus a " +
+        "[link](https://example.com) and ~~a retraction~~.",
+      "",
+      "> a quoted aside",
+      "",
+      "| Metric | Value |",
+      "| --- | ---: |",
+      "| latency | 12ms |",
+      "",
+      "```json\n{\"ok\":true}\n```",
+      "",
+      "1. step one",
+      "2. step two",
+    ].join("\n");
+    assertRoundTripsStructurally(md);
+  });
+});
+
+describe("renderSafe: oversized-content fallback", () => {
+  it("returns markdown mode unchanged when under the cap", () => {
+    const doc = parse("**hi**");
+    const result = renderSafe(doc, "**hi**", RICH_MESSAGE_MAX_CHARS);
+    expect(result.mode).toBe("markdown");
+    expect(result.text).toBe("**hi**");
+  });
+
+  it("swaps only the oversized atomic block to plain source text", () => {
+    // One small paragraph + one giant table (an atomic, non-bisectable
+    // construct). The cap is set low enough that only the table trips it.
+    const smallPara = "Summary line.";
+    const hugeRow = "| " + "x".repeat(200) + " |";
+    const rows = Array.from({ length: 50 }, () => hugeRow).join("\n");
+    const md = `${smallPara}\n\n| Col |\n| --- |\n${rows}`;
+    const doc = parse(md);
+    const maxLen = 500; // full doc exceeds this; the table alone also does
+    const result = renderSafe(doc, md, maxLen);
+
+    // Either the table got swapped to plain (raw slice) while the small
+    // paragraph stayed rich, or (if that still didn't fit) the WHOLE
+    // document fell back to plain — both are acceptable per the "never
+    // truncate mid-tag" contract. What must NEVER happen: a truncated /
+    // broken markdown table (an unterminated row).
+    expect(result.text.length).toBeGreaterThan(0);
+    // No dangling unterminated fence or half-row: every line that starts
+    // with "|" must also end with "|" (a torn row would violate this).
+    for (const line of result.text.split("\n")) {
+      if (line.trimStart().startsWith("|")) {
+        expect(line.trimEnd().endsWith("|")).toBe(true);
+      }
+    }
+  });
+
+  it("falls back to plain text for the whole document when nothing fits", () => {
+    const hugeRow = "| " + "x".repeat(2000) + " |";
+    const rows = Array.from({ length: 100 }, () => hugeRow).join("\n");
+    const md = `| Col |\n| --- |\n${rows}`;
+    const doc = parse(md);
+    const result = renderSafe(doc, md, 50); // impossibly small cap
+    expect(result.mode).toBe("plain");
+    expect(result.text).toBe(md);
+  });
+
+  it("never emits a body with an unbalanced code fence", () => {
+    const bigCode = "```\n" + "line of code\n".repeat(500) + "```";
+    const doc = parse(bigCode);
+    const result = renderSafe(doc, bigCode, 200);
+    const fenceCount = (result.text.match(/```/g) ?? []).length;
+    // A well-formed body has an even number of ``` delimiters (or zero, if
+    // it fell back to plain text where the fence markers are inert text).
+    if (result.mode === "markdown") {
+      expect(fenceCount % 2).toBe(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Delivers Increment 2 of the render pipeline started by #2928 (merged): `render/render.ts` walks the typed IR from `render/ir.ts` and emits Bot API 10.1 rich GFM markdown.

**Correction to Increment 1's stated target.** `ir.ts`'s doc comment sketches an HTML tag mapping "for the next increment," written before the Bot API 10.1 migration (#2669, `telegram-plugin/rich-send.ts`) became the live send path. `sendRichMessage` / `editMessageText` are called with `{ markdown: string }` — raw GFM markdown — never with `{ text, parse_mode: "HTML" }`; there is no HTML anywhere on the current outbound path (`reference/telegram-formatting-guide.md` documents the full markdown vocabulary, including Bot API 10.1 extensions like `**>` expandable blockquotes). This renderer targets the ACTUAL contract: markdown, not HTML.

I could not locate `docs/telegram-native-formatting-rfc.md` (cited by #2928) anywhere in repo history when I started this work. #2929 (in review in parallel) adds a corrected RFC doc — this PR's scope and acceptance criteria come from `reference/telegram-formatting-guide.md` + `rich-send.ts`'s actual contract in the meantime; happy to reconcile naming/scope once #2929 lands.

- `render(doc: Document): string` — full inline + block palette: bold/italic/strike/spoiler/code/link; headings (`#`-`######`); blockquote incl. Bot API 10.1 expandable (`**>` on the first line); fenced code blocks with adaptive fence-width backtick defusal (never closes early on embedded ``` `); ordered/unordered/task lists; thematic break; GFM tables with per-column alignment.
- `renderSafe(doc, source, maxLen = RICH_MESSAGE_MAX_CHARS): RenderResult` — the oversized-content contract: atomic constructs (table / code-block / blockquote — anything that can't be safely bisected without a broken fence/row/tag) that individually exceed the wire cap are swapped for their raw source slice instead of being emitted as rich markdown a downstream chunker would have to cut mid-construct. If the document still doesn't fit after that, the WHOLE document falls back to plain text (verbatim source, no rich wrapper). Never truncates mid-tag — length-based chunking (`splitMarkdownChunks`/`hardSliceToCap`) stays downstream's job.
- **Not wired into `rich-send.ts` or the live send path** — same phased-rollout gating as Increment 1. No production behavior changes.

## Why
Serves the trust contract `reference/jobs/know-what-my-agent-is-doing.md` cites: what the renderer emits must actually be sendable through the real path Telegram renders correctly — this PR corrects course on the wire format (markdown, not HTML) before a later increment wires it into `rich-send.ts`.

## Test plan
- [x] `telegram-plugin/tests/render/render.test.ts` — 26 new tests: full inline/block palette, parse→render→reparse structural round-trip (offset-agnostic equality), expandable-blockquote line-marker behavior, fence-widening backtick defusal + reparse recovery, GFM table alignment + cell-content round-trip, and the `renderSafe` fallback contract (atomic-block swap to plain, whole-doc plain fallback, never an unterminated fence/half table row).
- [x] `tsc --noEmit` clean.
- [x] `npm run test:vitest` (full suite, rebased on current `main`): **12340 passed**, 99 pre-existing failures — all environment artifacts in this sandbox (no `SWITCHROOM_HOST_HOME`/docker/`mount --bind` privileges; `tests/docker/compose-generator.test.ts`, `tests/host-control/*`). Reproduced identically with none of this diff's files present (confirmed via untracked-file check), classifying as pre-existing/environmental per the repo's own discipline. **Zero failures touch `render/` or `telegram-plugin/tests/render/`.**
- [x] Did not touch `rich-send.ts`, `format.ts`'s chunker/escaper, or the live send path; no fleet restart.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>