### PR TITLE
feat(telegram): wire IR renderer into live send path (flag-gated) + parse expandable quotes

### DIFF
--- a/telegram-plugin/render/parse.ts
+++ b/telegram-plugin/render/parse.ts
@@ -24,10 +24,19 @@
 //   `plain`/`emphasis` text like any other characters.
 //
 // Blockquote expandable handling:
-//   The IR carries `expandable: boolean` for Telegram's `<blockquote
-//   expandable>`. GFM blockquotes have no expandable marker, so Increment 1
-//   always sets `expandable = false`. TODO(next increment): recognise the
-//   `‖…‖` / expandable source convention and set the flag.
+//   The IR carries `expandable: boolean` for Telegram's expandable blockquote
+//   (Bot API 10.1). GFM has no expandable marker; the switchroom render path
+//   emits `**> ` on the FIRST line of an expandable quote (`render.ts` /
+//   `reference/telegram-formatting-guide.md`). micromark does NOT understand
+//   `**> ` as a blockquote — the leading `**` makes the line a paragraph with
+//   an unclosed strong-emphasis run — so this module pre-transforms each
+//   `**>` marker into a plain `  >` marker of IDENTICAL length (`**` → two
+//   spaces) before handing the text to mdast. Length preservation keeps every
+//   UTF-16 source offset (and therefore the never-lose-text round-trip
+//   invariant against the ORIGINAL source) exactly intact — only the two
+//   marker characters differ, and they are never part of quoted content. The
+//   set of line-start offsets that carried the marker is threaded into
+//   `foldBlock` so the matching blockquote nodes get `expandable: true`.
 
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { gfm } from "micromark-extension-gfm";
@@ -65,6 +74,52 @@ function pos(node: MdastNode): Pos {
 function slice(source: string, node: MdastNode): string {
   const { start, end } = pos(node);
   return source.slice(start, end);
+}
+
+/** The Bot API 10.1 expandable-blockquote marker: `**>` at the very start of
+ *  a line (column 0). This is exactly what the render path emits
+ *  (`render.ts` writes `**> ` on the first line of an expandable quote; see
+ *  `reference/telegram-formatting-guide.md`). Matching only at column 0 keeps
+ *  the length-preserving rewrite (`**` → two spaces) inside CommonMark's
+ *  3-space blockquote-indent budget — allowing leading indent here would push
+ *  the rewritten `  >` past 3 spaces and turn it into an indented code block. */
+const EXPANDABLE_MARKER_RE = /^\*\*>/;
+
+/** Pre-transform expandable-blockquote markers so mdast can parse them as
+ *  ordinary blockquotes, WITHOUT shifting any source offset. Each line that
+ *  opens with `**>` has its two `*` characters replaced by two spaces
+ *  (`**>` → `  >`), which micromark reads as a normal (optionally
+ *  1–3-space-indented) blockquote line. Returns the rewritten text plus the
+ *  set of line-start offsets that carried the marker — `foldBlock` uses that
+ *  set to flip `expandable: true` on the produced blockquote nodes. */
+function markExpandableQuotes(markdown: string): {
+  text: string;
+  expandableLineStarts: Set<number>;
+} {
+  const expandableLineStarts = new Set<number>();
+  let out = "";
+  let offset = 0;
+  // Split keeping the trailing newline on each line so offsets are exact.
+  for (const line of markdown.split(/(?<=\n)/)) {
+    if (EXPANDABLE_MARKER_RE.test(line)) {
+      expandableLineStarts.add(offset);
+      // Replace the leading two `*` chars with two spaces; the `>` and
+      // everything after it are untouched (`**> x` -> `  > x`), a valid
+      // 2-space-indented blockquote that mdast parses normally.
+      out += "  " + line.slice(2);
+    } else {
+      out += line;
+    }
+    offset += line.length;
+  }
+  return { text: out, expandableLineStarts };
+}
+
+/** Offset of the start of the line containing `offset` in `source`. */
+function lineStart(source: string, offset: number): number {
+  let i = offset;
+  while (i > 0 && source[i - 1] !== "\n") i--;
+  return i;
 }
 
 /** mdast `AlignType` (null | 'left' | 'right' | 'center') passes through
@@ -114,7 +169,11 @@ function foldTableRow(
   return { cells, ...pos(row) };
 }
 
-function foldBlock(node: RootContent, source: string): Block {
+function foldBlock(
+  node: RootContent,
+  source: string,
+  expandableLineStarts: Set<number>,
+): Block {
   switch (node.type) {
     case "paragraph":
       return { type: "paragraph", children: foldInlineChildren(node, source), ...pos(node) };
@@ -125,14 +184,18 @@ function foldBlock(node: RootContent, source: string): Block {
         children: foldInlineChildren(node, source),
         ...pos(node),
       };
-    case "blockquote":
+    case "blockquote": {
+      const p = pos(node);
+      // A blockquote is expandable when its FIRST line carried the `**>`
+      // marker in the original source (recorded by markExpandableQuotes).
+      const expandable = expandableLineStarts.has(lineStart(source, p.start));
       return {
         type: "blockquote",
-        children: node.children.map((c) => foldBlock(c, source)),
-        // GFM has no expandable marker — always false in Increment 1.
-        expandable: false,
-        ...pos(node),
+        children: node.children.map((c) => foldBlock(c, source, expandableLineStarts)),
+        expandable,
+        ...p,
       };
+    }
     case "code":
       return {
         type: "code-block",
@@ -142,7 +205,7 @@ function foldBlock(node: RootContent, source: string): Block {
       };
     case "list": {
       const items: ListItem[] = node.children.map((li) => ({
-        children: li.children.map((c) => foldBlock(c, source)),
+        children: li.children.map((c) => foldBlock(c, source, expandableLineStarts)),
         checked: li.checked ?? null,
         ...pos(li),
       }));
@@ -180,11 +243,19 @@ function foldBlock(node: RootContent, source: string): Block {
 
 /** Parse a markdown string into the typed IR Document. */
 export function parse(markdown: string): Document {
-  const tree = fromMarkdown(markdown, {
+  // Rewrite expandable-blockquote markers (`**>` → `  >`) so micromark parses
+  // them as ordinary blockquotes. The rewrite is length-preserving, so mdast's
+  // offsets are valid against BOTH the rewritten and the original text — we
+  // parse the rewritten text but fold against the ORIGINAL `markdown`, keeping
+  // every source slice byte-identical to the caller's input.
+  const { text: rewritten, expandableLineStarts } = markExpandableQuotes(markdown);
+  const tree = fromMarkdown(rewritten, {
     extensions: [gfm()],
     mdastExtensions: [gfmFromMarkdown()],
   });
   return {
-    blocks: tree.children.map((child) => foldBlock(child, markdown)),
+    blocks: tree.children.map((child) =>
+      foldBlock(child, markdown, expandableLineStarts),
+    ),
   };
 }

--- a/telegram-plugin/render/rich-render.ts
+++ b/telegram-plugin/render/rich-render.ts
@@ -1,0 +1,72 @@
+// Flag-gated wiring for the Bot API 10.1 rich renderer (parse.ts + render.ts)
+// into the live outbound send path.
+//
+// The renderer (`render/render.ts`, PR #2930) and parser (`render/parse.ts`)
+// have full unit coverage but were, until this module, wired into NOTHING —
+// no outbound message ever flowed through them. This module is the single,
+// feature-flagged bridge: the gateway's rich send path (stream-controller.ts)
+// runs the assistant's raw markdown through `parse → renderSafe` before it
+// reaches `sendRichMessage`, but ONLY when the flag is on.
+//
+// Feature flag — `SWITCHROOM_RICH_RENDER`, default OFF:
+//   Mirrors the `SWITCHROOM_VISIBLE_ANSWER_STREAM` convention
+//   (`answer-stream-flag.ts`): an env var read at runtime, default off, opted
+//   in PER AGENT via the `env:` block in `switchroom.yaml` (propagated into
+//   the container `environment:` by `src/agents/compose.ts`). When off,
+//   `maybeRenderOutbound` returns the input untouched, so the live send path
+//   is byte-for-byte unchanged — no agent's behaviour moves until an operator
+//   explicitly flips the flag for a specific agent. Accepts `1/true/on/yes`.
+//
+// Why route through `renderSafe` and not bare `render`:
+//   `renderSafe` guarantees the returned body is never a rich-markdown string
+//   with a mid-construct cut, and degrades a document it can't safely fit to
+//   plain-text mode (structure stripped, content preserved). The send path
+//   honours that `mode` — a `plain` result is sent WITHOUT the rich wrapper.
+
+import { parse } from "./parse.js";
+import { renderSafe, type RenderResult } from "./render.js";
+import { RICH_MESSAGE_MAX_CHARS } from "../format.js";
+
+/** Parse the `SWITCHROOM_RICH_RENDER` flag value. Default OFF; accepts the
+ *  same truthy tokens as the other switchroom env flags. Pure so the default
+ *  + parsing are unit-testable. */
+export function parseRichRenderEnabled(raw: string | undefined): boolean {
+  if (raw == null) return false;
+  const v = raw.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "on" || v === "yes";
+}
+
+/** Is the rich renderer enabled in this process? Reads the env flag live so a
+ *  test can set/unset it per-case; defaults OFF. */
+export function richRenderEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return parseRichRenderEnabled(env.SWITCHROOM_RICH_RENDER);
+}
+
+/** Unconditionally run `text` through `parse → renderSafe` (ignores the flag).
+ *  Exposed for tests and callers that have already gated on the flag. */
+export function renderOutbound(
+  text: string,
+  maxLen: number = RICH_MESSAGE_MAX_CHARS,
+): RenderResult {
+  return renderSafe(parse(text), text, maxLen);
+}
+
+/**
+ * Flag-gated transform for the live send path.
+ *
+ *   - flag OFF (default): returns the input untouched, `mode: "markdown"` —
+ *     identical to the pre-existing behaviour (raw transcript markdown sent
+ *     straight to `sendRichMessage`). No behavioural change for any agent.
+ *   - flag ON: returns `parse → renderSafe` output. `mode: "plain"` signals
+ *     the caller to send WITHOUT the rich wrapper (oversized/unsafe content).
+ */
+export function maybeRenderOutbound(
+  text: string,
+  env: NodeJS.ProcessEnv = process.env,
+  maxLen: number = RICH_MESSAGE_MAX_CHARS,
+): RenderResult {
+  if (!richRenderEnabled(env)) return { text, mode: "markdown" };
+  return renderOutbound(text, maxLen);
+}

--- a/telegram-plugin/stream-controller.ts
+++ b/telegram-plugin/stream-controller.ts
@@ -21,6 +21,7 @@
 
 import { createDraftStream, type DraftStreamHandle } from './draft-stream.js'
 import { richMessage, isParseEntitiesError } from './rich-send.js'
+import { maybeRenderOutbound } from './render/rich-render.js'
 
 /**
  * Minimal bot.api surface the controller needs. Real callers pass grammy's
@@ -224,12 +225,22 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
   // control previews via entity detection), so strip it for the rich path.
   const doSend = (text: string, opts: StreamSendOpts) => {
     if (literalText) return bot.api.sendMessage(chatId, text, opts)
+    // Flag-gated rich render (`SWITCHROOM_RICH_RENDER`, default OFF — returns
+    // the text untouched as markdown when off, so this is a no-op for every
+    // agent until an operator opts in). A `plain` result (oversized/unsafe
+    // content renderSafe declined to emit as rich) sends WITHOUT the wrapper.
+    const rendered = maybeRenderOutbound(text)
+    if (rendered.mode === 'plain') return bot.api.sendMessage(chatId, rendered.text, opts)
     const richOpts = { ...opts }
     delete richOpts.link_preview_options
-    return bot.api.sendRichMessage(chatId, richMessage(text), richOpts)
+    return bot.api.sendRichMessage(chatId, richMessage(rendered.text), richOpts)
   }
-  const doEdit = (id: number, text: string, opts: StreamSendOpts) =>
-    bot.api.editMessageText(chatId, id, literalText ? text : richMessage(text), opts)
+  const doEdit = (id: number, text: string, opts: StreamSendOpts) => {
+    if (literalText) return bot.api.editMessageText(chatId, id, text, opts)
+    const rendered = maybeRenderOutbound(text)
+    if (rendered.mode === 'plain') return bot.api.editMessageText(chatId, id, rendered.text, opts)
+    return bot.api.editMessageText(chatId, id, richMessage(rendered.text), opts)
+  }
 
   return createDraftStream(
     async (text) => {

--- a/telegram-plugin/tests/render/parse.test.ts
+++ b/telegram-plugin/tests/render/parse.test.ts
@@ -252,3 +252,59 @@ describe("parse: astral-plane emoji offsets are UTF-16 units", () => {
     expect(md.slice(bold.start, bold.end)).not.toBe("*go**");
   });
 });
+
+describe("expandable blockquote (Bot API 10.1 `**>` marker)", () => {
+  it("parses a single-line `**>` quote into an expandable blockquote", () => {
+    const md = "**> a collapsible line";
+    const doc = parse(md);
+    const bq = doc.blocks[0] as any;
+    expect(bq.type).toBe("blockquote");
+    expect(bq.expandable).toBe(true);
+  });
+
+  it("marks a multi-line quote expandable when the FIRST line carries `**>`", () => {
+    const md = "**> line one\n> line two\n> line three";
+    const doc = parse(md);
+    const bq = doc.blocks[0] as any;
+    expect(bq.type).toBe("blockquote");
+    expect(bq.expandable).toBe(true);
+    // All three quoted lines fold into ONE blockquote.
+    expect(bq.children.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("leaves a plain `>` quote non-expandable", () => {
+    const doc = parse("> just an ordinary quote");
+    const bq = doc.blocks[0] as any;
+    expect(bq.type).toBe("blockquote");
+    expect(bq.expandable).toBe(false);
+  });
+
+  it("keeps content offsets byte-identical to the ORIGINAL source", () => {
+    const md = "**> quoted body here";
+    const doc = parse(md);
+    const bq = doc.blocks[0] as any;
+    // The marker rewrite (`**>` -> `  >`) is length-preserving, so the inner
+    // text still slices out of the ORIGINAL markdown exactly.
+    const plain = bq.children[0].children[0];
+    expect(md.slice(plain.start, plain.end)).toBe("quoted body here");
+    assertOffsetsRoundTrip(bq, md);
+  });
+
+  it("only recognises the marker at column 0 (leading indent is not expandable)", () => {
+    // The renderer only ever emits `**>` at column 0; a leading-indented
+    // variant is deliberately NOT treated as an expandable quote (matching it
+    // would push the length-preserving rewrite past the 3-space blockquote
+    // budget into indented-code-block territory).
+    const md = "   **> indented";
+    const doc = parse(md);
+    const bq = doc.blocks[0] as any;
+    expect(bq.expandable).not.toBe(true);
+  });
+
+  it("does not treat inline `**` bold followed by `>` mid-line as expandable", () => {
+    // `**bold** > text` is a paragraph, not a quote — the marker must be at
+    // line start.
+    const doc = parse("**bold** > not a quote");
+    expect(doc.blocks[0].type).toBe("paragraph");
+  });
+});

--- a/telegram-plugin/tests/render/rich-render.test.ts
+++ b/telegram-plugin/tests/render/rich-render.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseRichRenderEnabled,
+  richRenderEnabled,
+  renderOutbound,
+  maybeRenderOutbound,
+} from "../../render/rich-render.js";
+
+describe("parseRichRenderEnabled", () => {
+  it("defaults OFF when unset", () => {
+    expect(parseRichRenderEnabled(undefined)).toBe(false);
+  });
+  it("accepts the truthy tokens", () => {
+    for (const v of ["1", "true", "on", "yes", "TRUE", " On "]) {
+      expect(parseRichRenderEnabled(v)).toBe(true);
+    }
+  });
+  it("treats everything else as OFF", () => {
+    for (const v of ["0", "false", "off", "no", "", "maybe"]) {
+      expect(parseRichRenderEnabled(v)).toBe(false);
+    }
+  });
+});
+
+describe("richRenderEnabled", () => {
+  it("reads SWITCHROOM_RICH_RENDER, default OFF", () => {
+    expect(richRenderEnabled({} as NodeJS.ProcessEnv)).toBe(false);
+    expect(
+      richRenderEnabled({ SWITCHROOM_RICH_RENDER: "1" } as NodeJS.ProcessEnv),
+    ).toBe(true);
+  });
+});
+
+describe("maybeRenderOutbound", () => {
+  it("flag OFF is a byte-for-byte passthrough (no behavioural change)", () => {
+    const raw = "**bold** and a\n\n**> collapsible quote\n> second line";
+    const r = maybeRenderOutbound(raw, {} as NodeJS.ProcessEnv);
+    expect(r.mode).toBe("markdown");
+    expect(r.text).toBe(raw);
+  });
+
+  it("flag ON routes through parse -> renderSafe", () => {
+    const r = maybeRenderOutbound("**> collapsible", {
+      SWITCHROOM_RICH_RENDER: "1",
+    } as NodeJS.ProcessEnv);
+    expect(r.mode).toBe("markdown");
+    // The expandable blockquote round-trips back to the `**> ` marker.
+    expect(r.text).toContain("**> ");
+  });
+
+  it("flag ON preserves plain prose through the round-trip", () => {
+    const r = maybeRenderOutbound("just some plain text", {
+      SWITCHROOM_RICH_RENDER: "1",
+    } as NodeJS.ProcessEnv);
+    expect(r.text).toContain("just some plain text");
+  });
+});
+
+describe("renderOutbound (flag-independent)", () => {
+  it("renders an expandable blockquote round-trip end to end", () => {
+    const r = renderOutbound("**> hidden line one\n> hidden line two");
+    expect(r.mode).toBe("markdown");
+    expect(r.text.split("\n")[0]).toMatch(/^\*\*> /);
+  });
+
+  it("falls back to plain mode for oversized atomic content", () => {
+    // A single code block far over the cap cannot be safely emitted as rich.
+    const huge = "```\n" + "x".repeat(40000) + "\n```";
+    const r = renderOutbound(huge, 1000);
+    expect(r.mode).toBe("plain");
+  });
+});

--- a/telegram-plugin/uat/scenarios/jtbd-rich-formatting-render-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-rich-formatting-render-dm.test.ts
@@ -56,8 +56,19 @@
 import { describe, it, expect } from "vitest";
 import { spinUp } from "../harness.js";
 import type { ObservedMessage } from "../driver.js";
+import { richRenderEnabled } from "../../render/rich-render.js";
 
 const AGENT = "test-harness";
+
+// The rich-render wiring (parse -> IR -> renderSafe -> sendRichMessage) is
+// gated behind `SWITCHROOM_RICH_RENDER` (default OFF). The expandable /
+// collapsible round-trip proof below only runs when BOTH the driver creds AND
+// the flag are present — the flag must be set in the gateway process under
+// test for the renderer to actually shape the outbound message, so gating the
+// scenario on the same flag keeps it honest (no false green when the wiring
+// isn't live). When the flag is off, this scenario self-skips green exactly
+// like the credential-less case.
+const RICH_RENDER_ON = richRenderEnabled();
 
 // The driver session is the load-bearing credential. Absent it, spinUp()
 // throws in resolveConfig — so guard at describe level and self-skip green.
@@ -242,6 +253,82 @@ function kindsPresent(msg: ObservedMessage): Set<string> {
                   ...(e.url ? { url: e.url } : {}),
                   ...(e.language ? { language: e.language } : {}),
                 })),
+              ),
+          );
+        } finally {
+          await sc.tearDown();
+        }
+      },
+      120_000,
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Rich-render wiring proof — expandable / collapsible content round-trip.
+//
+// This is the piece the unit suite CANNOT prove: that a REAL markdown reply
+// carrying the Bot API 10.1 expandable-blockquote marker (`**> `) flows
+// through the live send path — parse.ts (marker -> IR `expandable: true`) ->
+// render.ts (IR -> `**> ` markdown) -> renderSafe -> sendRichMessage — and
+// that Telegram actually parses it back to a blockquote entity on the wire.
+//
+// Runs ONLY when the rich-render flag is on in this process (see
+// RICH_RENDER_ON) AND the driver creds are present; self-skips green
+// otherwise, so default CI (flag off) never reds on it.
+// ---------------------------------------------------------------------------
+
+const EXP_MARKER = "COLLAPSE9";
+const EXPANDABLE_SAMPLE = [
+  `Reply with EXACTLY this and NOTHING else, keeping ${EXP_MARKER} verbatim:`,
+  "",
+  `${EXP_MARKER}: here is a collapsible section.`,
+  "",
+  "**> first hidden line of the expandable quote",
+  "> second hidden line",
+  "> third hidden line",
+].join("\n");
+
+(HAS_DRIVER_CREDS && RICH_RENDER_ON ? describe : describe.skip)(
+  "uat: expandable/collapsible content round-trips through the live renderer",
+  () => {
+    it(
+      "a `**>` reply parses -> renders -> sends -> decodes as a blockquote entity",
+      async () => {
+        const sc = await spinUp({ agent: AGENT });
+        try {
+          await sc.sendDM(EXPANDABLE_SAMPLE);
+
+          const reply = await sc.expectMessage(
+            (m: ObservedMessage) =>
+              m.text.includes(EXP_MARKER) || m.text === "\x01",
+            { from: "bot", timeout: 90_000 },
+          );
+
+          // Decode regression gate (same as the primary scenario).
+          expect(
+            reply.text,
+            "expandable reply decoded as the \\x01 unsupported-media sentinel",
+          ).not.toBe("\x01");
+          expect(reply.text).toContain(EXP_MARKER);
+
+          // The collapsible construct must survive as a real blockquote entity
+          // on the wire — proof the parse->render->send path produced valid
+          // Bot API 10.1 markdown, not stray `**>` literal text.
+          const present = kindsPresent(reply);
+          expect(
+            [...present],
+            `expandable quote did not decode as a blockquote entity ` +
+              `(present kinds: ${[...present].join(", ")})`,
+          ).toContain("blockquote");
+
+          // The quoted body text must round-trip (content never lost).
+          expect(reply.text).toContain("first hidden line");
+
+          console.info(
+            "[uat] expandable round-trip entity structure: " +
+              JSON.stringify(
+                reply.entities.map((e) => ({ kind: e.kind, text: e.text })),
               ),
           );
         } finally {


### PR DESCRIPTION
## Summary

The wiring phase after the parser (#2928), RFC (#2929), and renderer (#2930). Two gaps the render-engine review surfaced, closed together:

1. **`parse.ts` never produced an expandable node.** Increment 1 hard-coded `expandable: false` on every blockquote, so the collapsible feature had never been exercised end-to-end from real message text. `parse.ts` now detects the real Bot API 10.1 expandable-blockquote marker (`**>` at column 0, per `reference/telegram-formatting-guide.md`) and emits an IR blockquote with `expandable: true`. It does so via a **length-preserving marker rewrite** (`**>` becomes `  >`) so mdast parses it as an ordinary blockquote while every UTF-16 source offset — and the never-lose-text round-trip against the original source — stays byte-exact.

2. **The renderer (#2930) was wired into nothing.** New `telegram-plugin/render/rich-render.ts` is the single feature-flagged bridge from `parse -> renderSafe` into the live outbound path (`stream-controller.ts`, the `sendRichMessage`/`editMessageText` send closure the reply/stream_reply lane uses). It honors `renderSafe`'s plain-mode fallback (oversized/unsafe content is sent without the rich wrapper).

### Feature flag — `SWITCHROOM_RICH_RENDER`, default OFF

Same convention as `SWITCHROOM_VISIBLE_ANSWER_STREAM` (`answer-stream-flag.ts`): an env var read at runtime, default off, opted in **per agent** via the `env:` block in `switchroom.yaml` (propagated into the container by `src/agents/compose.ts`). **Flag OFF is a byte-for-byte passthrough** — no agent's behaviour changes until an operator explicitly flips it. Flipping the flag on per-agent is a deliberate future product-owner decision, not part of this PR.

## Why

Advances the "know what my agent is doing" render-fidelity trust contract: it gives the collapsible/expandable path its first real end-to-end exercise (parse real markdown -> IR -> render -> send -> Telegram entity), behind an off-by-default gate so nothing ships live yet.

## Test plan

- `vitest telegram-plugin/tests/render` — 77 passed (16 new: expandable-parse + rich-render unit tests, incl. offset round-trip and plain-mode fallback).
- `vitest telegram-plugin/tests/stream-controller.test.ts` — 16 passed (wiring is a no-op with flag off).
- `tsc --noEmit` + `npm run lint` (all 8 guards) — clean.
- New flag-gated UAT scenario in `jtbd-rich-formatting-render-dm.test.ts`: parse real `**>` markdown -> render -> send -> assert Telegram decodes a `blockquote` entity. Self-skips green unless BOTH driver creds AND `SWITCHROOM_RICH_RENDER` are set, so default CI never reds on it.
- Full `npm test`: the only failures are the documented environment-dependent `src/` suites (noexec `/tmp` exit 126, "Vault file not found", in-container deploy guard, static-binary/host-home) — none touch `telegram-plugin/`. CI is the arbiter for those paths.

## Risk

Low. Default-off flag; the live send path is unchanged until an operator opts a specific agent in. No restart/deploy performed.

Job spec: `reference/jobs/know-what-my-agent-is-doing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
