### PR TITLE
fix(hindsight): repair recall integration tests broken by phase-1 prefer_observations

### DIFF
--- a/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
+++ b/vendor/hindsight-memory/scripts/tests/test_recall_integration.py
@@ -74,6 +74,7 @@ class _FakeClient:
         tags=None,
         tags_match=None,
         tag_groups=None,
+        prefer_observations=None,
         timeout=10,
     ):
         self.recall_calls.append(


### PR DESCRIPTION
## Root cause

PR #2931 (hindsight recall precision phase 1) added a `prefer_observations`
parameter to `HindsightClient.recall()` (`lib/client.py:127`) and passed it
from both recall callsites in `recall.py` (lines 1033, 1082). The production
code is internally consistent and correct.

However the test double `_FakeClient.recall()` in
`scripts/tests/test_recall_integration.py` (~line 68) was **not** updated to
accept the new kwarg. Every `client.recall(..., prefer_observations=...)`
call in the integration suite raised
`TypeError: recall() got an unexpected keyword argument 'prefer_observations'`.

That TypeError is caught by the production `except Exception` handlers around
each recall call (which exist so a live recall outage degrades gracefully),
so the failure surfaced indirectly:
- primary-bank call swallowed → `results=[]` → additional context is `None`
  → `TypeError: argument of type 'NoneType' is not iterable`
  (DemoteFromRecallTag* tests).
- kwarg mismatch raises **before** the mock's function body runs, so
  `recall_calls` never gets appended → `recall_calls[1]` → `IndexError`
  (RecallTagFilterIntegration* tests).

Net CI impact in the `unittest discover` job: 17 failures + 7 errors, all in
`test_recall_integration.py`.

## Fix

Add `prefer_observations=None` to `_FakeClient.recall()` so the test double
mirrors the real `lib/client.py` interface. One line. The production sort
(`_sort_by_final_score`) already degrades gracefully on scoreless mocked
results — no production defect there.

## Verification

- `python3 -m unittest discover tests/` (from `vendor/hindsight-memory/scripts`, exact CI command): **245 passed** (was 17 failed / 7 errored).
- `python3 -m pytest tests/` (from `vendor/hindsight-memory`): **221 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)