### PR TITLE
feat(hindsight): per-operation LLM model config (retain/reflect/consolidation)

### DIFF
--- a/docs/operators/hindsight-memory.md
+++ b/docs/operators/hindsight-memory.md
@@ -95,6 +95,47 @@ takes an exclusive lock).
 | `SWITCHROOM_HINDSIGHT_BACKUP_KEEP` | `7` | rotated backups retained |
 | `SWITCHROOM_HINDSIGHT_RETENTION_DAYS` | `30` | completed-op prune age |
 
+## LLM model selection (`hindsight.llm`)
+
+The shared hindsight container runs its LLM operations (retain / reflect /
+consolidation — recall is local-only, no LLM) through whatever model the
+top-level `hindsight.llm` block selects. The flat form sets a **global
+default** for every op:
+
+```yaml
+hindsight:
+  llm:
+    provider: claude-code               # global default provider
+    model: openrouter/z-ai/glm-5.2      # global default model
+```
+
+Each op can be overridden individually with an optional `retain` / `reflect`
+/ `consolidation` sub-block. Any field you omit inherits the global (that is
+the engine's own fallback — switchroom emits only the vars you set, so an
+absent op sends nothing):
+
+```yaml
+hindsight:
+  llm:
+    provider: claude-code
+    model: openrouter/z-ai/glm-5.2      # global default stays as-is
+    retain:
+      model: gpt-oss-20b                # cheap model for ingestion
+    reflect:
+      model: gpt-oss-120b               # stronger model for synthesis
+    # consolidation: omitted → inherits the global model
+```
+
+Per-op fields: `model`, `provider`, `base_url`, `api_key` (all optional,
+`base_url`/`api_key` are passthrough for a per-op provider that needs its own
+endpoint/credential; `api_key` accepts a `vault:` reference). These map to the
+engine's `HINDSIGHT_API_<OP>_LLM_MODEL` / `_PROVIDER` / `_BASE_URL` /
+`_API_KEY` env vars, with the global `HINDSIGHT_API_LLM_*` as the fallback for
+anything unset.
+
+Takes effect on the next `switchroom memory setup` / rollout recreate of the
+hindsight container (env is read at container launch).
+
 ## Health
 
 The container now carries a Docker **healthcheck** (`/health` via

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1711,6 +1711,47 @@ export const LiteLLMConfigSchema = z
  * container also inherits `ANTHROPIC_MODEL=<model>` so the underlying claude
  * subprocess (and any LiteLLM proxy it routes through) targets the same model.
  */
+const HindsightPerOpLlmSchema = z
+  .object({
+    model: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Per-op model (upstream `HINDSIGHT_API_<OP>_LLM_MODEL`). Absent → " +
+        "inherit the global `hindsight.llm.model`.",
+      ),
+    provider: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Per-op provider (upstream `HINDSIGHT_API_<OP>_LLM_PROVIDER`). " +
+        "Absent → inherit the global `hindsight.llm.provider`.",
+      ),
+    base_url: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Per-op base URL (upstream `HINDSIGHT_API_<OP>_LLM_BASE_URL`). " +
+        "Optional passthrough; absent → inherit the global.",
+      ),
+    api_key: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Per-op API key (upstream `HINDSIGHT_API_<OP>_LLM_API_KEY`). Literal " +
+        "or `vault:` reference. Optional passthrough; absent → inherit global.",
+      ),
+  })
+  .describe(
+    "Per-operation LLM override. Every field optional; an unset field (or " +
+    "an omitted op block) inherits the global `hindsight.llm.*`, which is " +
+    "already the engine's fallback — switchroom emits only the vars set.",
+  );
+
 export const HindsightConfigSchema = z.object({
   llm: z
     .object({
@@ -1721,7 +1762,8 @@ export const HindsightConfigSchema = z.object({
         .describe(
           "Hindsight LLM provider (upstream `HINDSIGHT_API_LLM_PROVIDER`). " +
           "Defaults to `claude-code` (subscription-honest, broker-fed OAuth). " +
-          "Any litellm-routable provider the upstream image supports is valid.",
+          "Any litellm-routable provider the upstream image supports is valid. " +
+          "Serves as the GLOBAL default for every op absent a per-op override.",
         ),
       model: z
         .string()
@@ -1732,13 +1774,28 @@ export const HindsightConfigSchema = z.object({
           "to HINDSIGHT_DEFAULT_MODEL. Any model your LiteLLM proxy can route " +
           "is valid, e.g. `openrouter/z-ai/glm-5.2` when routing through the " +
           "fleet proxy. With provider=claude-code this value is ALSO exported " +
-          "as `ANTHROPIC_MODEL` to the claude subprocess.",
+          "as `ANTHROPIC_MODEL` to the claude subprocess. Serves as the GLOBAL " +
+          "default for every op absent a per-op override.",
         ),
+      retain: HindsightPerOpLlmSchema.optional().describe(
+        "Per-op override for the `retain` LLM op (memory ingestion). Emits " +
+        "`HINDSIGHT_API_RETAIN_LLM_*`. Absent → uses the global model/provider.",
+      ),
+      reflect: HindsightPerOpLlmSchema.optional().describe(
+        "Per-op override for the `reflect` LLM op (synthesis / mental-model " +
+        "refresh). Emits `HINDSIGHT_API_REFLECT_LLM_*`. Absent → uses global.",
+      ),
+      consolidation: HindsightPerOpLlmSchema.optional().describe(
+        "Per-op override for the `consolidation` LLM op (background memory " +
+        "merge). Emits `HINDSIGHT_API_CONSOLIDATION_LLM_*`. Absent → global.",
+      ),
     })
     .optional()
     .describe(
-      "LLM knob for the hindsight container. Both fields optional; unset " +
-      "fields fall back to the hard-coded defaults.",
+      "LLM knob for the hindsight container. The flat `provider`/`model` set " +
+      "the global default (backward-compatible); optional `retain`/`reflect`/" +
+      "`consolidation` blocks override individual ops. All fields optional; " +
+      "unset fields fall back to the hard-coded defaults.",
     ),
 });
 

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -587,6 +587,65 @@ export interface HindsightLlmConfig {
   provider?: string;
   /** `HINDSIGHT_API_LLM_MODEL`. Default {@link HINDSIGHT_DEFAULT_MODEL}. */
   model?: string;
+  /** Per-op override for the `retain` LLM op. Falls back to the global. */
+  retain?: HindsightPerOpLlmConfig;
+  /** Per-op override for the `reflect` LLM op. Falls back to the global. */
+  reflect?: HindsightPerOpLlmConfig;
+  /** Per-op override for the `consolidation` LLM op. Falls back to the global. */
+  consolidation?: HindsightPerOpLlmConfig;
+}
+
+/**
+ * Per-operation LLM override (retain / reflect / consolidation). The engine
+ * reads `HINDSIGHT_API_<OP>_LLM_MODEL` (+ `_PROVIDER` / `_BASE_URL` /
+ * `_API_KEY` siblings) and, for any field NOT set, falls back to the global
+ * `HINDSIGHT_API_LLM_*`. So switchroom only emits the vars an operator
+ * actually configured — an absent field means "inherit the global", which is
+ * already the engine's behaviour. All fields optional.
+ */
+export interface HindsightPerOpLlmConfig {
+  /** `HINDSIGHT_API_<OP>_LLM_MODEL`. */
+  model?: string;
+  /** `HINDSIGHT_API_<OP>_LLM_PROVIDER`. */
+  provider?: string;
+  /** `HINDSIGHT_API_<OP>_LLM_BASE_URL`. snake_case to match the zod config shape. */
+  base_url?: string;
+  /** `HINDSIGHT_API_<OP>_LLM_API_KEY`. snake_case to match the zod config shape. */
+  api_key?: string;
+}
+
+/** The three LLM ops that support a per-op model override. */
+const HINDSIGHT_LLM_OPS = ["retain", "reflect", "consolidation"] as const;
+type HindsightLlmOp = (typeof HINDSIGHT_LLM_OPS)[number];
+
+/**
+ * Resolve the per-op LLM env vars from an optional operator override. Returns
+ * a flat `[key, value]` list — ONLY the vars an operator actually set, so an
+ * unconfigured op (or unset field) emits nothing and the engine transparently
+ * falls back to the global `HINDSIGHT_API_LLM_*`. Never emits empty values.
+ *
+ * Shared by the `docker run` path ({@link startHindsight}) and the compose-gen
+ * path ({@link generateHindsightComposeSnippet}) so they never drift.
+ */
+export function resolveHindsightPerOpLlm(
+  llm?: HindsightLlmConfig,
+): Array<[string, string]> {
+  const out: Array<[string, string]> = [];
+  if (!llm) return out;
+  for (const op of HINDSIGHT_LLM_OPS) {
+    const cfg = llm[op as HindsightLlmOp] as HindsightPerOpLlmConfig | undefined;
+    if (!cfg) continue;
+    const prefix = `HINDSIGHT_API_${op.toUpperCase()}_LLM`;
+    const model = cfg.model?.trim();
+    const provider = cfg.provider?.trim();
+    const baseUrl = cfg.base_url?.trim();
+    const apiKey = cfg.api_key?.trim();
+    if (model) out.push([`${prefix}_MODEL`, model]);
+    if (provider) out.push([`${prefix}_PROVIDER`, provider]);
+    if (baseUrl) out.push([`${prefix}_BASE_URL`, baseUrl]);
+    if (apiKey) out.push([`${prefix}_API_KEY`, apiKey]);
+  }
+  return out;
 }
 
 /**
@@ -649,6 +708,11 @@ export function startHindsight(
   // resolveHindsightLlm — since the proxy can translate a non-Claude name.
   const { provider: llmProvider, model: llmModel } = resolveHindsightLlm(llm, litellm);
 
+  // Per-op LLM overrides (retain / reflect / consolidation). Only the vars an
+  // operator actually configured are emitted; an unset op inherits the global
+  // HINDSIGHT_API_LLM_* in the engine, so we emit nothing for it.
+  const perOpLlm = resolveHindsightPerOpLlm(llm);
+
   // Non-secret env stays on `-e` — provider name + observation cap are
   // configuration, not secrets. `HINDSIGHT_API_LLM_PROVIDER=claude-code`
   // selects the subscription-honest path; `HINDSIGHT_API_LLM_MODEL` pins the
@@ -658,6 +722,8 @@ export function startHindsight(
     "-e", `HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=${HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE}`,
     "-e", `HINDSIGHT_API_LLM_PROVIDER=${llmProvider}`,
     "-e", `HINDSIGHT_API_LLM_MODEL=${llmModel}`,
+    // Per-op LLM overrides (only the configured vars — see resolveHindsightPerOpLlm).
+    ...perOpLlm.flatMap(([k, v]) => ["-e", `${k}=${v}`]),
     "-e", `HINDSIGHT_API_MCP_STATELESS=${HINDSIGHT_DEFAULT_MCP_STATELESS}`,
     // Reranker smart-defaults (v0.13.22) — see constants above for
     // rationale. Each closes a vendor-default gap that hurts our
@@ -946,10 +1012,13 @@ export function getHindsightMcpUrl(): {
  */
 export function generateHindsightComposeSnippet(llm?: HindsightLlmConfig): string {
   const { provider: llmProvider, model: llmModel } = resolveHindsightLlm(llm);
+  const perOpLlm = resolveHindsightPerOpLlm(llm);
   const environment = [
     `      - HINDSIGHT_API_MAX_OBSERVATIONS_PER_SCOPE=${HINDSIGHT_DEFAULT_MAX_OBSERVATIONS_PER_SCOPE}`,
     `      - HINDSIGHT_API_LLM_PROVIDER=${llmProvider}`,
     `      - HINDSIGHT_API_LLM_MODEL=${llmModel}`,
+    // Per-op LLM overrides (only the configured vars — see resolveHindsightPerOpLlm).
+    ...perOpLlm.map(([k, v]) => `      - ${k}=${v}`),
     // Mirror of the docker-run path: with the claude-code provider, pin
     // ANTHROPIC_MODEL to the same model for the underlying claude subprocess.
     ...(llmProvider === "claude-code" ? [`      - ANTHROPIC_MODEL=${llmModel}`] : []),

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -215,6 +215,74 @@ describe("hindsight broker-fed mode (#1245)", () => {
     expect(snippet).toContain("ANTHROPIC_MODEL=openrouter/z-ai/glm-5.2");
   });
 
+  it("emits per-op LLM env vars (retain / reflect) alongside the global (#2925 follow-up)", () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 }, undefined, undefined, {
+      provider: "claude-code",
+      model: "openrouter/z-ai/glm-5.2",
+      retain: { model: "gpt-oss-20b" },
+      reflect: { model: "gpt-oss-120b", provider: "openrouter" },
+    });
+    const env = envPairsFromArgs(findRunArgs());
+    // Global still present (backward-compat) …
+    expect(env).toContain("HINDSIGHT_API_LLM_MODEL=openrouter/z-ai/glm-5.2");
+    // … and the per-op overrides ride on top.
+    expect(env).toContain("HINDSIGHT_API_RETAIN_LLM_MODEL=gpt-oss-20b");
+    expect(env).toContain("HINDSIGHT_API_REFLECT_LLM_MODEL=gpt-oss-120b");
+    expect(env).toContain("HINDSIGHT_API_REFLECT_LLM_PROVIDER=openrouter");
+  });
+
+  it("emits per-op provider/base_url/api_key passthrough only for the fields set", () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 }, undefined, undefined, {
+      model: "glm-5.2",
+      consolidation: {
+        model: "gpt-oss-120b",
+        provider: "openrouter",
+        base_url: "http://127.0.0.1:4010",
+        api_key: "sk-consol",
+      },
+    });
+    const env = envPairsFromArgs(findRunArgs());
+    expect(env).toContain("HINDSIGHT_API_CONSOLIDATION_LLM_MODEL=gpt-oss-120b");
+    expect(env).toContain("HINDSIGHT_API_CONSOLIDATION_LLM_PROVIDER=openrouter");
+    expect(env).toContain("HINDSIGHT_API_CONSOLIDATION_LLM_BASE_URL=http://127.0.0.1:4010");
+    expect(env).toContain("HINDSIGHT_API_CONSOLIDATION_LLM_API_KEY=sk-consol");
+  });
+
+  it("does NOT emit a per-op var for an op with no override (engine falls back to global)", () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 }, undefined, undefined, {
+      model: "glm-5.2",
+      retain: { model: "gpt-oss-20b" },
+      // reflect + consolidation absent → no per-op vars for them.
+    });
+    const env = envPairsFromArgs(findRunArgs());
+    expect(env).toContain("HINDSIGHT_API_RETAIN_LLM_MODEL=gpt-oss-20b");
+    expect(env.some((e) => e.startsWith("HINDSIGHT_API_REFLECT_LLM_MODEL="))).toBe(false);
+    expect(env.some((e) => e.startsWith("HINDSIGHT_API_CONSOLIDATION_LLM_MODEL="))).toBe(false);
+    // An empty per-op block emits nothing either.
+    expect(env.some((e) => e.startsWith("HINDSIGHT_API_RETAIN_LLM_PROVIDER="))).toBe(false);
+  });
+
+  it("flat single-model form emits NO per-op vars (backward compat)", () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 }, undefined, undefined, {
+      provider: "claude-code",
+      model: "openrouter/z-ai/glm-5.2",
+    });
+    const env = envPairsFromArgs(findRunArgs());
+    expect(env).toContain("HINDSIGHT_API_LLM_MODEL=openrouter/z-ai/glm-5.2");
+    expect(env.some((e) => /^HINDSIGHT_API_(RETAIN|REFLECT|CONSOLIDATION)_LLM_MODEL=/.test(e))).toBe(false);
+  });
+
+  it("compose snippet emits per-op LLM env vars too", async () => {
+    const { generateHindsightComposeSnippet } = await import("../../src/setup/hindsight.js");
+    const snippet = generateHindsightComposeSnippet({
+      model: "glm-5.2",
+      retain: { model: "gpt-oss-20b" },
+      reflect: { model: "gpt-oss-120b" },
+    });
+    expect(snippet).toContain("HINDSIGHT_API_RETAIN_LLM_MODEL=gpt-oss-20b");
+    expect(snippet).toContain("HINDSIGHT_API_REFLECT_LLM_MODEL=gpt-oss-120b");
+  });
+
   it("pins HINDSIGHT_CP_DATAPLANE_API_URL at the API port in host-network (litellm) mode, not squatted 8888", () => {
     startHindsight({ apiPort: 18888, uiPort: 19999 }, {
       baseUrl: "http://127.0.0.1:4010",


### PR DESCRIPTION
## Summary

Extends the `hindsight.llm` config knob (single global model, merged in #2925) to support **per-operation** LLM model selection for `retain` / `reflect` / `consolidation`. Switchroom-side only.

The hindsight engine already reads `HINDSIGHT_API_<OP>_LLM_MODEL` (+ `_PROVIDER`/`_BASE_URL`/`_API_KEY` siblings) and falls back to the global `HINDSIGHT_API_LLM_*` for anything unset. This PR wires switchroom to emit those per-op vars — **only when an operator actually configures them**, so an absent op sends nothing and the engine transparently inherits the global.

## Config shape

```yaml
hindsight:
  llm:
    provider: claude-code
    model: openrouter/z-ai/glm-5.2   # global default (unchanged)
    retain:
      model: gpt-oss-20b             # cheap model for ingestion
    reflect:
      model: gpt-oss-120b            # stronger model for synthesis
    # consolidation: omitted → inherits the global model
```

Per-op fields (all optional): `model`, `provider`, `base_url`, `api_key`.

## Backward compat + preserved behavior

- The flat `provider`/`model` form still sets the global exactly as before — no per-op vars emitted for the flat form.
- #2924 litellm→OpenRouter model default and #2925 CP dataplane URL fix are untouched (per-op emission is purely additive, layered after the global env).

## Changes

- `src/setup/hindsight.ts` — `HindsightPerOpLlmConfig` interface, `resolveHindsightPerOpLlm()`, per-op emission on both the `docker run` (`startHindsight`) and compose-snippet (`generateHindsightComposeSnippet`) paths.
- `src/config/schema.ts` — per-op sub-blocks on `HindsightConfigSchema`.
- `tests/setup/hindsight.test.ts` — per-op emission, passthrough, absent-op fallback (no var), flat-form backward compat, compose-path emission.
- `docs/operators/hindsight-memory.md` — new "LLM model selection" section.

## Verification

- `tsc --noEmit` — pass
- `vitest run tests/setup/hindsight.test.ts` — 53 passed
- `node scripts/build.mjs` — pass

## Note

This is switchroom-side only. Registering `gpt-oss-120b` (etc.) in the LiteLLM proxy is a separate infra step handled out-of-band — not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)