### PR TITLE
fix(telegram): keep tight nested lists tight in the IR renderer

### DIFF
--- a/telegram-plugin/render/ir.ts
+++ b/telegram-plugin/render/ir.ts
@@ -150,6 +150,12 @@ export interface ListNode extends Pos {
   // semantics match the spec's `list.start` exactly (mdast `list.start`).
   /** First number of an ordered list (mdast `start`); null for unordered. */
   startNumber: number | null;
+  /** Loose vs tight (mdast `list.spread`). A LOOSE list separates its items
+   *  with a blank line in the source; a TIGHT list keeps them on adjacent
+   *  lines. The renderer preserves this: loose lists join items with a blank
+   *  line, tight lists (including nested sub-lists) stay on single newlines so
+   *  no spurious blank line is injected between a tight item and its sub-list. */
+  spread: boolean;
   items: ListItem[];
 }
 
@@ -182,6 +188,12 @@ export interface ListItem extends Pos {
   children: Block[];
   /** GFM task-list state: true (checked), false (unchecked), null (not a task item). */
   checked: boolean | null;
+  /** Loose vs tight at the ITEM level (mdast `listItem.spread`): whether this
+   *  item's own block children are separated by a blank line in the source.
+   *  A tight item (spread=false) — e.g. a paragraph followed by a nested
+   *  sub-list — keeps its children on single newlines, so no blank line is
+   *  injected before the sub-list. */
+  spread: boolean;
 }
 
 export interface TableRow extends Pos {

--- a/telegram-plugin/render/parse.ts
+++ b/telegram-plugin/render/parse.ts
@@ -303,12 +303,18 @@ function foldBlock(
       const items: ListItem[] = node.children.map((li) => ({
         children: li.children.map((c) => foldBlock(c, source, expandableLineStarts)),
         checked: li.checked ?? null,
+        // mdast `listItem.spread`: whether this item's block children are
+        // separated by a blank line. Tight (false) keeps a paragraph and its
+        // nested sub-list adjacent so no blank line is injected on render.
+        spread: li.spread ?? false,
         ...pos(li),
       }));
       return {
         type: "list",
         ordered: node.ordered ?? false,
         startNumber: node.ordered ? node.start ?? 1 : null,
+        // mdast `list.spread`: loose (true) vs tight (false) at the list level.
+        spread: node.spread ?? false,
         items,
         ...pos(node),
       };

--- a/telegram-plugin/render/render.ts
+++ b/telegram-plugin/render/render.ts
@@ -126,7 +126,11 @@ function renderListItem(item: ListItem, ordered: boolean, index: number): string
   const checkbox =
     item.checked === null ? "" : item.checked ? "[x] " : "[ ] ";
   const marker = ordered ? `${index}. ` : "- ";
-  const body = renderBlocks(item.children);
+  // Tight item (spread=false): join the item's block children with a single
+  // newline so a paragraph and its nested sub-list stay adjacent — no spurious
+  // blank line injected before the sub-list. Loose item (spread=true): keep the
+  // blank-line separation the source author intended.
+  const body = renderBlocksJoined(item.children, item.spread ? "\n\n" : "\n");
   const lines = body.split("\n");
   const first = `${marker}${checkbox}${lines[0] ?? ""}`;
   const contIndent = " ".repeat(marker.length);
@@ -138,9 +142,13 @@ function renderListItem(item: ListItem, ordered: boolean, index: number): string
 
 function renderList(node: ListNode): string {
   const start = node.startNumber ?? 1;
+  // Loose list (spread=true): a blank line between top-level items, as the
+  // source author wrote them. Tight list (spread=false, the common case and
+  // all nested sub-lists): siblings on adjacent lines, single newline.
+  const sep = node.spread ? "\n\n" : "\n";
   return node.items
     .map((item, i) => renderListItem(item, node.ordered, start + i))
-    .join("\n");
+    .join(sep);
 }
 
 /** Render a single cell's inline content for a table (no line breaks — GFM
@@ -200,8 +208,16 @@ function renderBlock(node: Block): string {
   }
 }
 
+/** Join a run of blocks with an explicit separator. Blockquote children and
+ *  the top-level document use a blank line (`\n\n`); tight list items pass a
+ *  single newline so a nested sub-list stays adjacent to its item's paragraph
+ *  (see `renderListItem`). */
+function renderBlocksJoined(blocks: Block[], sep: string): string {
+  return blocks.map(renderBlock).join(sep);
+}
+
 function renderBlocks(blocks: Block[]): string {
-  return blocks.map(renderBlock).join("\n\n");
+  return renderBlocksJoined(blocks, "\n\n");
 }
 
 /** Render a full IR `Document` to Bot API 10.1 rich GFM markdown. */

--- a/telegram-plugin/tests/render/render.test.ts
+++ b/telegram-plugin/tests/render/render.test.ts
@@ -190,6 +190,25 @@ describe("render: block palette", () => {
   it("nested list round-trips structurally", () => {
     assertRoundTripsStructurally("- a\n  - nested1\n  - nested2\n- b");
   });
+  it("tight 3-level nested list stays tight — no injected blank lines (regression)", () => {
+    // Regression: `renderListItem` used to join an item's paragraph and its
+    // nested sub-list with a blank line (renderBlocks' `\n\n`), turning a tight
+    // nested list into `- a\n\n  - b\n\n    - c\n- d`. Tight lists must stay
+    // tight: exact-string round trip, no blank line injected anywhere.
+    const md = "- a\n  - b\n    - c\n- d";
+    expect(render(parse(md))).toBe(md);
+  });
+  it("loose list keeps its blank lines between top-level items (tight/loose distinction)", () => {
+    // The fix must NOT hardcode single-newline everywhere: a genuinely loose
+    // list (blank line between items in the source) round-trips WITH the blank
+    // lines preserved.
+    const md = "- a\n\n- b\n\n- c";
+    expect(render(parse(md))).toBe(md);
+  });
+  it("loose item with a trailing paragraph keeps its internal blank line", () => {
+    const md = "- a\n\n  more about a\n\n- b";
+    expect(render(parse(md))).toBe(md);
+  });
   it("thematic break", () => {
     expect(render(parse("---"))).toBe("---");
   });


### PR DESCRIPTION
## What

Follow-up to #2934. The IR renderer injected spurious blank lines into **tight nested lists**: `renderListItem` joined an item's block children with `renderBlocks`' `\n\n`, so

```
- a
  - b
    - c
- d
```

rendered as `- a\n\n  - b\n\n    - c\n- d` — a visible regression on ordinary content (confirmed by direct testing, not theoretical).

## Fix

Thread mdast's tight/loose distinction through the IR rather than hardcoding single newlines (which would break legitimate loose-list spacing):

- Add `spread` to `ListNode` (list-level) and `ListItem` (item-level), copied from mdast `list.spread` / `listItem.spread` in `parse.ts`.
- `renderList` / `renderListItem` join **tight** items with a single `\n` and **loose** items with a blank line.

## Tests

Exact-string round-trip regression tests (99 → 102 render tests, all green):
- 3-level tight nested list stays tight (the exact case that broke).
- Loose flat list keeps its blank lines.
- Loose item with a trailing paragraph keeps its internal blank line.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)