### PR TITLE
docs(telegram): reconcile rich-render palette with live-wire ground truth

### DIFF
--- a/reference/rfcs/telegram-native-formatting.md
+++ b/reference/rfcs/telegram-native-formatting.md
@@ -213,6 +213,32 @@ Established with the product owner. Phase 2 ships when:
 
 ---
 
+## 6a. Live-wire construct verification (2026-07, default-on gate)
+
+Before flipping `SWITCHROOM_RICH_RENDER` default-on, every "soft" construct was
+proven directly against the Bot API `sendRichMessage` endpoint — the actual wire
+path — and the returned `rich_message` structure (Telegram's own parse) was
+inspected, not eyeballed. Ground truth:
+
+| Construct | Markdown emitted | Telegram entity returned | Verdict |
+| --- | --- | --- | --- |
+| Bold | `**b**` | `bold` | ✅ ships |
+| Italic | `_i_` | `italic` | ✅ ships |
+| Strikethrough | `~~s~~` | `strikethrough` | ✅ ships |
+| Inline code | `` `c` `` | `code` | ✅ ships |
+| Link | `[t](url)` | `url` (text-link) | ✅ ships |
+| **Spoiler** | `\|\|s\|\|` | `spoiler` | ✅ ships — **live-confirmed** (supersedes the earlier UAT "soft" note, which was an MTProto-decoder limitation in the test harness, not a wire failure) |
+| **Highlight** | `==h==` | `marked` | ✅ ships — live-confirmed |
+| **Underline** | `__u__` | `bold` ❌ | **EXCLUDED** — Telegram's rich-message markdown parser reads `__…__` identically to `**…**`; there is no markdown token for underline on this path. `__u__` degrades to a clean **bold** entity (not broken markup), so no code change is needed, but underline is not a distinctly-supported construct. Documented in `reference/telegram-formatting-guide.md`. |
+| 3-level nested list | tight `-`/indent | nested `list`/`paragraph` blocks, no injected blank lines | ✅ ships (tight-list spacing fixed, PR #2936) |
+| Table | GFM pipe table | `table` with per-column `align` | ✅ ships |
+| Blockquote | `> …` | `blockquote` | ✅ ships |
+
+**Exclusion:** underline. Everything else in the palette renders as its intended
+Telegram entity on the live wire.
+
+---
+
 ## 7. Rollout
 
 - **Ship dark.** Phase 2 lands behind a per-agent flag, default off. Merging the

--- a/reference/telegram-formatting-guide.md
+++ b/reference/telegram-formatting-guide.md
@@ -70,10 +70,10 @@ Bot API 10.1 rich messages.
 | --- | --- | --- |
 | Bold | `**text**` | The one key fact, not decoration. |
 | Italic | `*text*` or `_text_` | Light emphasis, labels, asides. |
-| Underline | `__text__` | Bot API 10.1 GFM extension. Use sparingly — reads like a link. |
+| Underline | — (not supported) | **`__text__` renders as BOLD**, not underline — Telegram's rich-message markdown parser reads a `__…__` run identically to `**…**` (live-verified against the Bot API, 2026-07). There is no markdown token for underline on this path; don't rely on it. |
 | Strikethrough | `~~text~~` | Retractions, "was X now Y". |
-| Spoiler | `\|\|text\|\|` | Hidden until tapped — surprises, long-answer punchlines. |
-| Highlight / marked | `==text==` | The `=` is an `escapeMarkdown` special, so dynamic text won't trigger it by accident. |
+| Spoiler | `\|\|text\|\|` | Hidden until tapped — surprises, long-answer punchlines. Live-verified: surfaces as a `spoiler` entity on the wire (2026-07). |
+| Highlight / marked | `==text==` | Live-verified: surfaces as a `marked` entity on the wire (2026-07). The `=` is an `escapeMarkdown` special, so dynamic text won't trigger it by accident. |
 | Inline code | `` `text` `` | Identifiers, tap-to-copy. Content is literal — no escaping inside. |
 | Subscript | `~text~` (single tilde) | **Falls back to literal text** in rich messages (Bot API 10.1) — the only GFM construct that doesn't render. Avoid. |
 | Superscript | `^text^` | **Falls back to literal text** in rich messages — avoid (use words, e.g. "squared"). |
@@ -109,8 +109,10 @@ Bot API 10.1 rich messages.
 
 > Reach for the exotic spans (spoiler, highlight, math, custom emoji) only when they
 > genuinely serve the reader. The floor card's "why" applies: structure for the reader,
-> not the writer. Note sub/superscript is the one exception — it does NOT render (falls
-> back to literal text), so don't use it.
+> not the writer. Two constructs do NOT render as intended and should be avoided:
+> **sub/superscript** falls back to literal text, and **underline (`__text__`) renders
+> as bold** (Telegram's rich-message markdown has no underline token — live-verified).
+> Spoiler (`||…||`) and highlight (`==…==`) DO render correctly on this path.
 
 ### Escaping rules
 

--- a/telegram-plugin/uat/scenarios/jtbd-rich-formatting-render-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-rich-formatting-render-dm.test.ts
@@ -116,13 +116,18 @@ const SAMPLE_LINES = [
  * trip on the uat-host (PR #2745 first live run: present set was
  * `bold, italic, code, strikethrough, text_link, blockquote, pre`).
  *
- * `spoiler` is deliberately NOT hard-asserted: on the live wire the `||…||`
- * span did NOT surface as a `spoiler`/`textMarked` entity (the model either
- * dropped the syntax or Telegram's chat-message GFM parser doesn't map it the
- * way the IV table-of-contents `textMarked` node does). Rather than red the
- * whole render gate on a construct the round trip doesn't reliably produce, we
- * observe spoiler softly (logged below). The decoder's `textMarked → spoiler`
- * mapping is still pinned deterministically by the hosted unit suite.
+ * `spoiler` is soft-observed HERE only because of THIS harness's decode path:
+ * the `||…||` span did NOT reliably surface as a `spoiler`/`textMarked` entity
+ * through the MTProto send→IV→decode round trip the UAT driver uses. This is a
+ * harness-decoder limitation, NOT a wire failure: a 2026-07 direct probe of the
+ * Bot API `sendRichMessage` endpoint (the actual production send path) confirmed
+ * `||spoiler||` DOES parse to a `spoiler` entity and `==highlight==` to `marked`
+ * on the live wire — see `reference/rfcs/telegram-native-formatting.md` §6a.
+ * Spoiler ships default-on; it stays soft here purely so this MTProto-decode
+ * gate doesn't red on its own decode gap. (Underline `__…__`, by contrast, is a
+ * genuine wire exclusion — it parses as bold; see §6a.) The decoder's
+ * `textMarked → spoiler` mapping is still pinned deterministically by the
+ * hosted unit suite.
  *
  * Lists and dividers carry no first-class Bot API entity (they render as
  * bulleted/numbered/rule TEXT), so they are asserted on `reply.text` below.


### PR DESCRIPTION
Final-rollout gate for `SWITCHROOM_RICH_RENDER`. Before flipping the flag default-on, every "soft"/unproven construct was verified directly against the Bot API `sendRichMessage` endpoint and the returned `rich_message` structure (Telegram's own parse) was inspected — not eyeballed.

## Findings

| Construct | Emitted | Telegram entity | Verdict |
|---|---|---|---|
| Spoiler `\|\|…\|\|` | `\|\|s\|\|` | `spoiler` | ✅ live-confirmed (supersedes UAT "soft" note) |
| Highlight `==…==` | `==h==` | `marked` | ✅ live-confirmed |
| Underline `__…__` | `__u__` | `bold` | ❌ **exclusion** |
| bold / italic / strike / code / link / table / blockquote / 3-level nested list | — | intended entities | ✅ |

**Underline is the one exclusion:** Telegram's rich-message markdown parser reads `__…__` identically to `**…**` — there is no markdown underline token on this path. `__x__` degrades to a clean `bold` entity (valid, not broken markup), so no code change is required, but the docs must stop advertising underline as supported.

## Changes
- `reference/telegram-formatting-guide.md` — underline row now marks it unsupported (renders as bold); spoiler/highlight annotated live-verified.
- `reference/rfcs/telegram-native-formatting.md` — new §6a "Live-wire construct verification" with the full entity-by-entity table + exclusion.
- `telegram-plugin/uat/.../jtbd-rich-formatting-render-dm.test.ts` — corrects the stale spoiler-negative comment (comment only; assertion logic unchanged, so the gate is untouched).

Docs-only + one test comment. No functional code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)