### PR TITLE
fix(start): keep litellm routing in place when proxy is unreachable at boot

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -75,6 +75,13 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
   #   - proxy down    → log + strip ALL routing env (fail-open)
   #   - ANTHROPIC_CUSTOM_HEADERS already set → skip (idempotent)
   #
+  # NOTE (2026-07-08): the INNER block no longer strips routing on a
+  # proxy-UNREACHABLE boot (it holds the route so it self-heals — see the long
+  # note there). This OUTER gateway-hoist path still fail-opens on unreachable,
+  # matching its own dedicated contract test (scaffold.litellm-gateway-outer).
+  # Aligning it is a deliberate follow-up, tracked in the PR, kept out of this
+  # surgical change to avoid touching the separately-asserted gateway contract.
+  #
   # SWITCHROOM_AGENT_NAME is injected by compose env (compose.ts:1816)
   # so it is available here, before the inner-pass export at line ~320.
   if [ -n "${SWITCHROOM_LITELLM:-}" ] && [ -z "$ANTHROPIC_CUSTOM_HEADERS" ] && command -v switchroom >/dev/null 2>&1; then
@@ -924,12 +931,21 @@ fi
 # content-safety guardrails — it never alters the model or Claude's operation.
 # See reference/invariants.md § "Operator-controlled gateway carve-out".
 #
-# FAIL-OPEN (operator decision 2026-06-28): if the key is missing OR the proxy
-# is unreachable at boot, strip the routing env and fall back to the direct
-# broker-OAuth Anthropic path, logging the reason LOUDLY. Availability wins over
-# tracking/guardrails — a proxy outage must never take an agent dark. The
-# tradeoff is an explicit, logged guardrail lapse for that session, not a silent
-# one. Re-probed on every (re)boot, so recovery is automatic.
+# TWO boot failure modes, handled DIFFERENTLY (2026-07-08 — was a single
+# fail-open path that silently took an agent off-proxy for its whole lifetime):
+#   - MISSING KEY (no per-agent virtual key in the vault): fail-open — strip the
+#     routing env and fall back to the direct broker-OAuth Anthropic path,
+#     logging LOUDLY. Without a key there is nothing to authenticate to the
+#     proxy with, so there is no metered route to self-heal into.
+#   - PROXY UNREACHABLE at boot (key present, liveliness probe fails within the
+#     retry window): do NOT strip. Leave ANTHROPIC_BASE_URL / SWITCHROOM_LITELLM*
+#     pointed at the proxy (the socat forwarder at 127.0.0.1:4010 self-heals
+#     per-connection) and emit a LOUD warning. Claude traffic FAILS+retries until
+#     the proxy returns, then routes through it automatically — the metered path
+#     stays the metered path. We deliberately do NOT silently fall back to
+#     untracked direct Anthropic on a transient blip: an agent that boots during
+#     a brief litellm outage previously never routed through litellm again until
+#     a manual restart. Re-probed on every (re)boot.
 #
 # Static tags (x-litellm-customer-id / x-litellm-tags) give per-AGENT
 # attribution in LiteLLM. Per-SESSION is NOT achievable here: claude sends no
@@ -946,8 +962,13 @@ _LITELLM_OK=""
 if [ -n "${SWITCHROOM_LITELLM:-}" ] && command -v switchroom >/dev/null 2>&1; then
   sr_ll_key="$(switchroom vault get "litellm/$SWITCHROOM_AGENT_NAME/api-key" 2>/dev/null || true)"
   sr_ll_ok=""
+  sr_ll_unreachable=""
   if [ -z "$sr_ll_key" ]; then
-    echo "litellm: no virtual key for agent '$SWITCHROOM_AGENT_NAME' — falling back to direct OAuth (no tracking/guardrail)" >&2
+    echo "==================== litellm FAIL-OPEN ====================" >&2
+    echo "WARNING: no litellm virtual key for agent '$SWITCHROOM_AGENT_NAME'." >&2
+    echo "WARNING: falling back to direct Anthropic OAuth (untracked, unguarded)" >&2
+    echo "WARNING: — cannot authenticate to the proxy without a key." >&2
+    echo "==========================================================" >&2
   elif command -v curl >/dev/null 2>&1 && [ -n "$ANTHROPIC_BASE_URL" ]; then
     # Bounded retry probe (co-boot race fix, 2026-07): when the whole stack
     # co-boots, the litellm proxy's heavy Python app is often not yet healthy
@@ -964,7 +985,16 @@ if [ -n "${SWITCHROOM_LITELLM:-}" ] && command -v switchroom >/dev/null 2>&1; th
       sleep 3
     done
     if [ -z "$sr_ll_up" ]; then
-      echo "litellm: proxy unreachable at ${SWITCHROOM_LITELLM_BASE:-$ANTHROPIC_BASE_URL} after 120s of retries — falling back to direct OAuth (no tracking/guardrail this session)" >&2
+      # Proxy unreachable at boot but the key is present. Do NOT strip routing:
+      # leave it pointed at litellm so the fleet self-heals once the proxy is
+      # back (the socat forwarder at 127.0.0.1:4010 reconnects per-connection).
+      sr_ll_unreachable="1"
+      echo "==================== litellm UNREACHABLE ====================" >&2
+      echo "WARNING: litellm proxy unreachable at ${SWITCHROOM_LITELLM_BASE:-$ANTHROPIC_BASE_URL} after 120s of retries;" >&2
+      echo "WARNING: Claude traffic will FAIL until it recovers — routing LEFT IN PLACE" >&2
+      echo "WARNING: so it self-heals (socat forwarder reconnects per-connection)." >&2
+      echo "WARNING: NOT falling back to untracked direct Anthropic OAuth." >&2
+      echo "============================================================" >&2
     else
       sr_ll_ok="1"
     fi
@@ -987,12 +1017,19 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
     # models configured in the proxy appear in the /model picker and can be
     # selected via --model. Without this, the CLI only knows its bundled list.
     export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
+  elif [ -n "$sr_ll_unreachable" ]; then
+    # Proxy unreachable at boot: routing intentionally LEFT IN PLACE (loud
+    # warning already emitted above) so it self-heals when litellm returns.
+    # _LITELLM_OK stays empty so any sr-* session model override is still
+    # dropped below (claude would 4xx an unknown model against a down endpoint).
+    # NO unset here — that permanent strip was the bug this branch fixes.
+    :
   else
-    # Fail-open: drop every routing var so the claude CLI talks to Anthropic
-    # directly on its OAuth credential (subscription path), unproxied.
+    # Missing key fail-open: drop every routing var so the claude CLI talks to
+    # Anthropic directly on its OAuth credential (subscription path), unproxied.
     unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM SWITCHROOM_LITELLM_BASE
   fi
-  unset sr_ll_key sr_ll_ok
+  unset sr_ll_key sr_ll_ok sr_ll_unreachable
 fi
 
 # --- Session-only model override (carrier: .session-model-override) ---
@@ -1032,6 +1069,20 @@ if [ -f "{{agentDir}}/.session-model-override" ]; then
           echo "session-model: LiteLLM proxy unreachable at boot — DROPPING sr-* override '$_override', booting on configured default '$_EFFECTIVE_MODEL' instead (would otherwise 4xx against Anthropic)" >&2
           echo "session-model: the requested sr-* model is UNAVAILABLE this session; re-issue /model $_override once LiteLLM is reachable" >&2
           printf 'LiteLLM proxy was unreachable at boot, so the session-only model switch to `%s` was dropped — the agent booted on its configured default `%s` instead. Re-issue /model %s once LiteLLM is reachable.\n' "$_override" "$_EFFECTIVE_MODEL" "$_override" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+        else
+          # sr-* (OpenRouter) models route by MODEL NAME through LiteLLM's normal
+          # endpoint. The default ANTHROPIC_BASE_URL points at the `/anthropic`
+          # PASSTHROUGH (raw byte-forward to api.anthropic.com, chosen to avoid the
+          # Opus SSE re-chunk stall for Claude traffic) — but the passthrough is
+          # model-agnostic and ships EVERY request to Anthropic regardless of
+          # --model, so an sr-* model 4xxs as "model not found". Repoint at the
+          # LiteLLM root so claude's /v1/messages hits LiteLLM's model router →
+          # OpenRouter. Claude (default) sessions are unaffected — they keep the
+          # /anthropic passthrough.
+          if [ -n "$SWITCHROOM_LITELLM_BASE" ]; then
+            export ANTHROPIC_BASE_URL="$SWITCHROOM_LITELLM_BASE"
+            echo "session-model: sr-* override '$_override' — repointed ANTHROPIC_BASE_URL to LiteLLM router '$SWITCHROOM_LITELLM_BASE' (off /anthropic passthrough) so it routes to OpenRouter" >&2
+          fi
         fi
         ;;
     esac

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -70,25 +70,27 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
   # ANTHROPIC_CUSTOM_HEADERS exported BEFORE the gateway fork below, or
   # discoverSrModels() returns [] and /model never shows OpenRouter entries.
   #
-  # Mirrors the INNER block's fail-open logic exactly:
-  #   - missing key   → log + skip export (gateway talks direct OAuth)
-  #   - proxy down    → log + strip ALL routing env (fail-open)
+  # Mirrors the INNER block's split boot contract EXACTLY (see the long note
+  # at the inner block for the full rationale). This OUTER pass runs BEFORE
+  # `exec tmux`, so whatever it does to the routing env is inherited by the
+  # inner pass — which is precisely why the old permanent strip-on-unreachable
+  # was so damaging: it removed SWITCHROOM_LITELLM here, and the inner
+  # self-heal block is gated on SWITCHROOM_LITELLM, so the entire inner fix
+  # was dead on the real docker path. The two boot failure modes:
+  #   - MISSING KEY → log LOUDLY + fail-open (strip routing; gateway direct OAuth)
+  #   - PROXY UNREACHABLE → log LOUDLY + KEEP routing in place (NO strip) so it
+  #     survives into the inner pass and self-heals when litellm returns. Boot
+  #     is non-fatal either way.
   #   - ANTHROPIC_CUSTOM_HEADERS already set → skip (idempotent)
-  #
-  # NOTE (2026-07-08): the INNER block no longer strips routing on a
-  # proxy-UNREACHABLE boot (it holds the route so it self-heals — see the long
-  # note there). This OUTER gateway-hoist path still fail-opens on unreachable,
-  # matching its own dedicated contract test (scaffold.litellm-gateway-outer).
-  # Aligning it is a deliberate follow-up, tracked in the PR, kept out of this
-  # surgical change to avoid touching the separately-asserted gateway contract.
   #
   # SWITCHROOM_AGENT_NAME is injected by compose env (compose.ts:1816)
   # so it is available here, before the inner-pass export at line ~320.
   if [ -n "${SWITCHROOM_LITELLM:-}" ] && [ -z "$ANTHROPIC_CUSTOM_HEADERS" ] && command -v switchroom >/dev/null 2>&1; then
     sr_ll_key="$(switchroom vault get "litellm/$SWITCHROOM_AGENT_NAME/api-key" 2>/dev/null || true)"
     sr_ll_ok=""
+    sr_ll_unreachable=""
     if [ -z "$sr_ll_key" ]; then
-      echo "litellm(outer): no virtual key for agent '$SWITCHROOM_AGENT_NAME' — gateway will use direct OAuth (no tracking/guardrail)" >&2
+      echo "litellm(outer): WARNING — no virtual key for agent '$SWITCHROOM_AGENT_NAME'; gateway falling back to direct Anthropic OAuth (untracked, unguarded)." >&2
     elif command -v curl >/dev/null 2>&1 && [ -n "$ANTHROPIC_BASE_URL" ]; then
       # Bounded retry probe (co-boot race fix, 2026-07): when the whole stack
       # co-boots, the litellm proxy's heavy Python app is often not yet healthy
@@ -105,7 +107,12 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
         sleep 3
       done
       if [ -z "$sr_ll_up" ]; then
-        echo "litellm(outer): proxy unreachable at ${SWITCHROOM_LITELLM_BASE:-$ANTHROPIC_BASE_URL} after 120s of retries — falling back to direct OAuth (no tracking/guardrail this session)" >&2
+        # Proxy unreachable but the key is present. Do NOT strip: leave routing
+        # pointed at litellm so it survives into the inner (tmux) pass and
+        # self-heals once the proxy is back (socat forwarder reconnects
+        # per-connection). Boot continues.
+        sr_ll_unreachable="1"
+        echo "litellm(outer): WARNING — proxy unreachable at ${SWITCHROOM_LITELLM_BASE:-$ANTHROPIC_BASE_URL} after 120s of retries; gateway discovery will FAIL until it recovers — routing LEFT IN PLACE so it self-heals. NOT falling back to untracked direct Anthropic OAuth." >&2
       else
         sr_ll_ok="1"
       fi
@@ -118,10 +125,17 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
 x-litellm-customer-id: $SWITCHROOM_AGENT_NAME
 x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:-default}"
       export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
+    elif [ -n "$sr_ll_unreachable" ]; then
+      # Proxy unreachable at boot: routing intentionally LEFT IN PLACE (loud
+      # warning already emitted) so it survives into the inner pass and
+      # self-heals once litellm returns. NO unset — the permanent strip here
+      # was what made the inner self-heal fix inert on docker.
+      :
     else
+      # Missing-key fail-open: gateway talks direct OAuth, unproxied.
       unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM SWITCHROOM_LITELLM_BASE
     fi
-    unset sr_ll_key sr_ll_ok
+    unset sr_ll_key sr_ll_ok sr_ll_unreachable
   fi
 
   # Tiny in-process supervisor: runs cmd in a respawn loop with
@@ -1058,10 +1072,13 @@ if [ -f "{{agentDir}}/.session-model-override" ]; then
   # metachar inside the double-quoted `claude --model "$_EFFECTIVE_MODEL"` usage below.
   if printf '%s' "$_override" | grep -Eq '^[A-Za-z0-9][]A-Za-z0-9._[/-]{0,99}$'; then
     _EFFECTIVE_MODEL="$_override"
-    # LiteLLM-down guard (operator decision 2026-07): an sr-* override with the
-    # proxy unreachable at boot must NOT 4xx an unknown model against Anthropic.
-    # Drop the override back to the configured default, log LOUDLY, and drop an
-    # alert sentinel the gateway turns into a Telegram message to the operator.
+    # LiteLLM-down guard for an sr-* OVERRIDE only (operator decision 2026-07):
+    # with the proxy unreachable at boot there IS a Claude configured default to
+    # fall back to, so DROP the override rather than boot on an unreachable sr-*
+    # model that would 4xx against Anthropic — log LOUDLY and write an alert
+    # sentinel the gateway turns into a Telegram message. (The passthrough→router
+    # repoint for a LIVE sr-* — override OR configured default — is done once,
+    # post-resolution, below.)
     case "$_override" in
       sr-*)
         if [ -z "$_LITELLM_OK" ]; then
@@ -1069,20 +1086,6 @@ if [ -f "{{agentDir}}/.session-model-override" ]; then
           echo "session-model: LiteLLM proxy unreachable at boot — DROPPING sr-* override '$_override', booting on configured default '$_EFFECTIVE_MODEL' instead (would otherwise 4xx against Anthropic)" >&2
           echo "session-model: the requested sr-* model is UNAVAILABLE this session; re-issue /model $_override once LiteLLM is reachable" >&2
           printf 'LiteLLM proxy was unreachable at boot, so the session-only model switch to `%s` was dropped — the agent booted on its configured default `%s` instead. Re-issue /model %s once LiteLLM is reachable.\n' "$_override" "$_EFFECTIVE_MODEL" "$_override" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
-        else
-          # sr-* (OpenRouter) models route by MODEL NAME through LiteLLM's normal
-          # endpoint. The default ANTHROPIC_BASE_URL points at the `/anthropic`
-          # PASSTHROUGH (raw byte-forward to api.anthropic.com, chosen to avoid the
-          # Opus SSE re-chunk stall for Claude traffic) — but the passthrough is
-          # model-agnostic and ships EVERY request to Anthropic regardless of
-          # --model, so an sr-* model 4xxs as "model not found". Repoint at the
-          # LiteLLM root so claude's /v1/messages hits LiteLLM's model router →
-          # OpenRouter. Claude (default) sessions are unaffected — they keep the
-          # /anthropic passthrough.
-          if [ -n "$SWITCHROOM_LITELLM_BASE" ]; then
-            export ANTHROPIC_BASE_URL="$SWITCHROOM_LITELLM_BASE"
-            echo "session-model: sr-* override '$_override' — repointed ANTHROPIC_BASE_URL to LiteLLM router '$SWITCHROOM_LITELLM_BASE' (off /anthropic passthrough) so it routes to OpenRouter" >&2
-          fi
         fi
         ;;
     esac
@@ -1091,6 +1094,31 @@ if [ -f "{{agentDir}}/.session-model-override" ]; then
   fi
   unset _override
 fi
+
+# sr-* passthrough→router repoint — ONE post-resolution gate covering BOTH the
+# /model override path AND the configured-default path (`model: sr-*` in
+# switchroom.yaml, which has NO override carrier). sr-* (OpenRouter) models route
+# by MODEL NAME through LiteLLM's model-mapped root. The default ANTHROPIC_BASE_URL
+# points at the `/anthropic` PASSTHROUGH (raw byte-forward to api.anthropic.com,
+# chosen to dodge the Opus SSE re-chunk stall for Claude traffic) — but the
+# passthrough is model-agnostic and ships EVERY request to Anthropic regardless of
+# --model, so an sr-* model 4xxs "model not found". Repoint at the LiteLLM router
+# root so claude's /v1/messages hits the model router → OpenRouter. Claude
+# (default/override) sessions are untouched — they keep the passthrough.
+#
+# Guarded on the proxy being reachable at boot ($_LITELLM_OK). If it is NOT, we
+# leave routing exactly as compose/start.sh set it (compose already points a
+# non-Claude default at the router root) and run degraded until litellm returns —
+# there is NO Claude default to fall back to for a persistent sr-* agent, and
+# that (loud-warned, non-fatal) degraded state is the correct behavior.
+case "$_EFFECTIVE_MODEL" in
+  sr-*)
+    if [ -n "$_LITELLM_OK" ] && [ -n "$SWITCHROOM_LITELLM_BASE" ]; then
+      export ANTHROPIC_BASE_URL="$SWITCHROOM_LITELLM_BASE"
+      echo "session-model: effective model '$_EFFECTIVE_MODEL' is sr-* — routing via LiteLLM model router '$SWITCHROOM_LITELLM_BASE' (off /anthropic passthrough) so it reaches OpenRouter" >&2
+    fi
+    ;;
+esac
 # Record the EFFECTIVE launched model so the gateway can re-hydrate its
 # in-memory session-model state after this restart, keeping /status and the
 # welcome card honest. Overwrite (not consumed) — the gateway reads it at boot.

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -82,6 +82,8 @@ export function assertPlausibleHostHome(homePrefix: string): void {
 }
 import { scheduleNeedsCronSession } from "../scheduler/cron-routing.js";
 import { applyDefaultTier } from "../scheduler/tier-selector.js";
+import { resolveMainModel } from "./scaffold.js";
+import { isClaudeModel } from "../../telegram-plugin/gateway/model-command.js";
 import { resolveAgentConfig } from "../config/merge.js";
 import { resolveTimezone } from "../config/timezone.js";
 import { isReservedAgentName } from "../vault/broker/peercred.js";
@@ -740,6 +742,19 @@ interface AgentServiceData {
     smallFastModel: string;
   };
   /**
+   * Cascade-resolved configured DEFAULT model for this agent (via
+   * `resolveMainModel`, so `undefined`/"default" → the known-good fleet
+   * default and any explicit id/alias passes through). Load-bearing for
+   * LiteLLM routing: `emitAgentService` gates `ANTHROPIC_BASE_URL` on the
+   * model CLASS — Claude models ride the `<root>/anthropic` raw pass-through
+   * (dodges the Opus SSE re-chunk stall), but a non-Claude default (e.g.
+   * `model: sr-glm-5`) MUST hit the model-mapped router root, because the
+   * pass-through is model-agnostic and always forwards to Anthropic (an sr-*
+   * model 4xxs "model not found" there). Same `isClaudeModel` split
+   * `src/setup/hindsight.ts` already applies for its subprocess.
+   */
+  model: string;
+  /**
    * Resolved IANA timezone for this agent (e.g. "Australia/Melbourne").
    * Walks the four-step cascade in `resolveTimezone`:
    * agent → profile (via merge) → switchroom.timezone → server detection
@@ -846,6 +861,11 @@ export function describeAgents(
             ?.small_fast_model ??
           "claude-haiku-4-5-20251001",
       },
+      // Cascade-resolved configured default model (gates ANTHROPIC_BASE_URL
+      // model-class routing in emitAgentService). resolveMainModel maps
+      // undefined/"default" → the fleet default and passes explicit ids/aliases
+      // (incl. non-Claude sr-*) through unchanged.
+      model: resolveMainModel(resolved.model),
       // Resolve once at describe-time so the same value lands in TZ
       // and SWITCHROOM_TIMEZONE in `emitAgentService`. The resolver
       // is pure modulo the server-detection probes, so two consecutive
@@ -2208,7 +2228,14 @@ function emitAgentService(
     const root = a.litellm.baseUrl.replace(/\/+$/, "");
     env.SWITCHROOM_LITELLM = "1";
     env.SWITCHROOM_LITELLM_BASE = root;
-    env.ANTHROPIC_BASE_URL = `${root}/anthropic`;
+    // Route by model CLASS (mirror src/setup/hindsight.ts): a Claude default
+    // rides the `<root>/anthropic` raw pass-through (dodges the Opus SSE
+    // re-chunk stall), but a non-Claude default (e.g. `model: sr-glm-5`) has
+    // NO `.session-model-override` carrier, so start.sh's sr-* repoint would
+    // never fire — it would 4xx on every call against the model-agnostic
+    // pass-through. Point it straight at the model-mapped router root so a
+    // persistent sr-* default routes to OpenRouter from the first turn.
+    env.ANTHROPIC_BASE_URL = isClaudeModel(a.model) ? `${root}/anthropic` : root;
     env.ANTHROPIC_SMALL_FAST_MODEL = a.litellm.smallFastModel;
   }
   // SWITCHROOM_VOICE_ENGINE: the host's voice-transcription verdict

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -42,6 +42,7 @@ interface MakeConfigAgent {
   admin?: boolean;
   root?: boolean;
   env?: Record<string, string>;
+  model?: string;
   bind_mounts?: Array<{ source: string; target?: string; mode?: "ro" | "rw" }>;
   resources?: { memory?: string; memory_reservation?: string; pids_limit?: number; cpus?: number };
   timezone?: string;
@@ -87,6 +88,7 @@ function makeConfig(
           admin: cfg.admin,
           root: cfg.root,
           env: cfg.env,
+          model: cfg.model,
           bind_mounts: cfg.bind_mounts,
           resources: cfg.resources,
           timezone: cfg.timezone,
@@ -3261,5 +3263,51 @@ describe("generateCompose — voice-sidecar (PR-B2)", () => {
       else process.env.HOME = prevHome;
       rmSync(homeDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("generateCompose — LiteLLM ANTHROPIC_BASE_URL model-class routing", () => {
+  // A Claude default rides the `<root>/anthropic` raw pass-through (dodges the
+  // Opus SSE re-chunk stall). A non-Claude DEFAULT (`model: sr-glm-5`) has no
+  // `.session-model-override` carrier, so it MUST be pointed at the model-mapped
+  // router root at compose time or it 4xxs on every call against the pass-
+  // through. Mirrors the isClaudeModel split src/setup/hindsight.ts applies.
+  const ROOT = "http://litellm.internal:4010";
+
+  function composeFor(model: string | undefined, confirmed = true): string {
+    const config = makeConfig(
+      { router: { model } },
+      { litellm: { enabled: true, base_url: ROOT } },
+    );
+    return generateCompose({
+      config,
+      litellmConfirmedAgents: confirmed ? new Set(["router"]) : undefined,
+    });
+  }
+
+  it("non-Claude configured model → ANTHROPIC_BASE_URL has NO /anthropic suffix (router root)", () => {
+    const out = composeFor("sr-glm-5");
+    expect(out).toContain(`ANTHROPIC_BASE_URL: "${ROOT}"`);
+    expect(out).not.toContain(`ANTHROPIC_BASE_URL: "${ROOT}/anthropic"`);
+    // Router markers still present.
+    expect(out).toContain(`SWITCHROOM_LITELLM_BASE: "${ROOT}"`);
+    expect(out).toContain('SWITCHROOM_LITELLM: "1"');
+  });
+
+  it("Claude configured model → ANTHROPIC_BASE_URL keeps the /anthropic pass-through", () => {
+    const out = composeFor("claude-opus-4-8");
+    expect(out).toContain(`ANTHROPIC_BASE_URL: "${ROOT}/anthropic"`);
+  });
+
+  it("unset model (fleet default is Claude) → keeps the /anthropic pass-through", () => {
+    const out = composeFor(undefined);
+    expect(out).toContain(`ANTHROPIC_BASE_URL: "${ROOT}/anthropic"`);
+  });
+
+  it("no virtual key confirmed → NO routing env injected at all (fail-safe)", () => {
+    const out = composeFor("sr-glm-5", false);
+    // keyConfirmed false ⇒ the whole routing block is skipped, so the proxy URL
+    // never appears for this agent (no unauthenticated proxy calls).
+    expect(out).not.toContain(ROOT);
   });
 });

--- a/tests/scaffold.litellm-failopen.test.ts
+++ b/tests/scaffold.litellm-failopen.test.ts
@@ -6,13 +6,20 @@ import { scaffoldAgent } from "../src/agents/scaffold.js";
 import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
 
 // Ship A (#litellm): the rendered start.sh must implement the operator-decided
-// LiteLLM boot contract:
-//   - FAIL-OPEN: if the per-agent virtual key is missing OR the proxy is
-//     unreachable at boot, strip the routing env and fall back to direct OAuth,
-//     logging the reason. A proxy outage must never take an agent dark.
+// LiteLLM boot contract. Two boot failure modes, handled DIFFERENTLY (revised
+// 2026-07-08 — the old single fail-open path silently took an agent off-proxy
+// for its whole lifetime when it booted during a brief litellm blip):
+//   - MISSING KEY: fail-open — strip the routing env and fall back to direct
+//     OAuth, logging LOUDLY. Without a key there is no metered route to reach.
+//   - PROXY UNREACHABLE at boot (key present): do NOT strip. Leave
+//     ANTHROPIC_BASE_URL / SWITCHROOM_LITELLM* pointed at the proxy (the socat
+//     forwarder at 127.0.0.1:4010 self-heals per-connection) and emit a LOUD
+//     warning. Claude traffic fails+retries until the proxy returns, then routes
+//     through it automatically — no silent untracked direct-Anthropic fallback.
 //   - Per-AGENT tags: x-litellm-customer-id + x-litellm-tags carry the agent
 //     name so LiteLLM can attribute usage per agent.
-// See reference/invariants.md § "Operator-controlled gateway carve-out".
+// See reference/invariants.md § "Operator-controlled gateway carve-out" and
+// docs/model-routing.md § G2.
 
 const telegramConfig: TelegramConfig = {
   bot_token: "123456:ABC-DEF",
@@ -51,7 +58,7 @@ describe("scaffoldAgent: LiteLLM fail-open boot contract (#litellm)", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("renders the fail-open probe + per-agent tags in start.sh", () => {
+  it("renders the split-mode boot contract + per-agent tags in start.sh", () => {
     const name = "ll-agent";
     const config = makeAgentConfig();
     const switchroomConfig = makeSwitchroomConfig(name, config);
@@ -72,18 +79,45 @@ describe("scaffoldAgent: LiteLLM fail-open boot contract (#litellm)", () => {
       "${SWITCHROOM_LITELLM_BASE:-${ANTHROPIC_BASE_URL%/anthropic}}/health/liveliness",
     );
 
-    // FAIL-OPEN: on missing key OR unreachable proxy, strip ALL routing env so
-    // claude talks to Anthropic directly on its OAuth credential. The root URL
+    // MISSING-KEY branch STILL fails open: strip ALL routing env so claude talks
+    // to Anthropic directly on its OAuth credential. The root URL
     // (SWITCHROOM_LITELLM_BASE) must be dropped too — asserted explicitly (not
     // as a prefix) so it can't silently fall out of the unset list.
     expect(startSh).toContain(
       "unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM SWITCHROOM_LITELLM_BASE",
     );
 
-    // The lapse must be logged, not silent (both fallback branches → stderr).
-    expect(startSh).toContain("falling back to direct OAuth");
+    // NEW CONTRACT — PROXY UNREACHABLE at boot must NOT permanently strip the
+    // routing env. The old code ran the same fail-open `unset ...` on an
+    // unreachable proxy, which took an agent that booted during a transient
+    // litellm blip off-proxy for its entire lifetime. This fix is scoped to the
+    // INNER (claude-process) block, which begins at `_LITELLM_OK=""`; the OUTER
+    // gateway-hoist block is left to its own dedicated contract test, so slice
+    // to the inner block before asserting the unreachable-branch behavior.
+    const innerBlock = startSh.slice(startSh.indexOf('_LITELLM_OK=""'));
+    expect(innerBlock.length).toBeGreaterThan(0);
 
-    // Per-AGENT attribution headers, keyed off the agent name.
+    //  1. the unreachable branch is distinguished by its own flag,
+    expect(innerBlock).toContain('sr_ll_unreachable="1"');
+    //  2. the old "unreachable → fall back to direct OAuth" log is GONE from the
+    //     inner block (the unreachable path must not silently drop routing),
+    expect(innerBlock).not.toContain(
+      "falling back to direct OAuth (no tracking/guardrail this session)",
+    );
+    //  3. and it emits a LOUD, unmistakable warning that routing is held in
+    //     place to self-heal rather than silently dropped.
+    expect(innerBlock).toContain("litellm proxy unreachable");
+    expect(innerBlock).toContain("routing LEFT IN PLACE");
+    expect(innerBlock).toContain("NOT falling back to untracked direct Anthropic OAuth");
+
+    // The unreachable branch dispatch must be a no-op (routing kept), guarded by
+    // the flag — never the unset. Assert the elif dispatch exists.
+    expect(innerBlock).toContain('elif [ -n "$sr_ll_unreachable" ]');
+
+    // MISSING-KEY branch is still logged LOUDLY (not silent).
+    expect(innerBlock).toContain("no litellm virtual key for agent");
+
+    // Per-AGENT attribution headers, keyed off the agent name (unchanged path).
     expect(startSh).toContain("x-litellm-api-key: Bearer $sr_ll_key");
     expect(startSh).toContain("x-litellm-customer-id: $SWITCHROOM_AGENT_NAME");
     expect(startSh).toContain("x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME");

--- a/tests/scaffold.litellm-gateway-outer.test.ts
+++ b/tests/scaffold.litellm-gateway-outer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { scaffoldAgent } from "../src/agents/scaffold.js";
@@ -97,24 +98,84 @@ describe("start.sh: LiteLLM ANTHROPIC_CUSTOM_HEADERS hoisted before gateway fork
     expect(headersIdx2, "inner ANTHROPIC_CUSTOM_HEADERS export not found").toBeGreaterThan(forkIdx);
   });
 
-  it("outer block has fail-open behavior matching the inner block", () => {
+  it("outer block splits missing-key (strip) vs unreachable (KEEP routing) like the inner block", () => {
     const startSh = renderStartSh();
-
-    // Both fallback log lines must be present (one per fallback branch).
-    const outerFallbackCount = (
-      startSh.match(/litellm\(outer\): .*falling back to direct OAuth/g) ?? []
-    ).length;
-    // Two fallback branches: missing key and unreachable proxy.
-    expect(outerFallbackCount).toBeGreaterThanOrEqual(1);
-
-    // Fail-open: on unreachable proxy, strip routing env in the outer block too.
-    // The outer `unset` must appear before the gateway fork.
     const forkIdx = startSh.indexOf(GATEWAY_FORK);
+    const outerBlockIdx = startSh.indexOf(LITELLM_GATE);
+    // Slice to the OUTER block only (marker → gateway fork) so these assertions
+    // never accidentally match the inner (claude-process) block.
+    const outerSlice = startSh.slice(outerBlockIdx, forkIdx);
+
+    // The unreachable branch is now distinguished by its own flag — it must NOT
+    // fall through to the fail-open unset.
+    expect(outerSlice).toContain('sr_ll_unreachable="1"');
+    // The unreachable branch keeps routing and loud-warns (routing must survive
+    // into the inner tmux pass — the inner self-heal block is gated on
+    // SWITCHROOM_LITELLM, which the old strip removed HERE).
+    expect(outerSlice).toContain("routing LEFT IN PLACE");
+    expect(outerSlice).toContain("NOT falling back to untracked direct Anthropic OAuth");
+    // The OLD unreachable-strip log is gone from the outer block.
+    expect(outerSlice).not.toContain(
+      "falling back to direct OAuth (no tracking/guardrail this session)",
+    );
+
+    // MISSING-KEY still fails open: the strip remains, guarded by the else
+    // branch, and appears before the gateway fork.
     const outerUnsetIdx = startSh.indexOf(
       "unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM",
     );
-    expect(outerUnsetIdx, "fail-open unset not found").toBeGreaterThan(-1);
+    expect(outerUnsetIdx, "missing-key fail-open unset not found").toBeGreaterThan(-1);
     expect(outerUnsetIdx).toBeLessThan(forkIdx);
+    expect(outerSlice).toContain("no virtual key for agent");
+  });
+
+  it("outer dispatch (executed): UNREACHABLE keeps routing env, MISSING KEY strips it", () => {
+    const startSh = renderStartSh();
+    // Extract JUST the outer dispatch (decision + scratch cleanup): from the
+    // FIRST `if [ -n "$sr_ll_ok" ]` (outer precedes inner) through the first
+    // `unset sr_ll_key sr_ll_ok sr_ll_unreachable`. This runs the real strip-vs-
+    // keep code paths without the 120s probe loop.
+    const dispStart = startSh.indexOf('if [ -n "$sr_ll_ok" ]; then');
+    const dispEndMarker = "unset sr_ll_key sr_ll_ok sr_ll_unreachable";
+    const dispEnd = startSh.indexOf(dispEndMarker, dispStart) + dispEndMarker.length;
+    expect(dispStart).toBeGreaterThan(-1);
+    expect(dispEnd).toBeGreaterThan(dispStart);
+    const dispatch = startSh.slice(dispStart, dispEnd);
+
+    const runDispatch = (preset: { ok: string; unreachable: string }): Record<string, string> => {
+      const script = [
+        "set -e",
+        "export SWITCHROOM_AGENT_NAME=a",
+        "export SWITCHROOM_AGENT_PROFILE=default",
+        'export ANTHROPIC_BASE_URL="http://litellm:4010/anthropic"',
+        "export ANTHROPIC_SMALL_FAST_MODEL=claude-haiku-4-5",
+        "export SWITCHROOM_LITELLM=1",
+        'export SWITCHROOM_LITELLM_BASE="http://litellm:4010"',
+        "sr_ll_key=k",
+        `sr_ll_ok=${JSON.stringify(preset.ok)}`,
+        `sr_ll_unreachable=${JSON.stringify(preset.unreachable)}`,
+        dispatch,
+        'echo "BASEURL=${ANTHROPIC_BASE_URL:-__UNSET__}"',
+        'echo "LITELLM=${SWITCHROOM_LITELLM:-__UNSET__}"',
+        'echo "LLBASE=${SWITCHROOM_LITELLM_BASE:-__UNSET__}"',
+      ].join("\n");
+      const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
+      return Object.fromEntries(
+        [...out.matchAll(/^(BASEURL|LITELLM|LLBASE)=(.*)$/gm)].map((m) => [m[1], m[2].trim()]),
+      );
+    };
+
+    // Proxy unreachable → routing env SURVIVES (must reach the tmux exec env).
+    const unreachable = runDispatch({ ok: "", unreachable: "1" });
+    expect(unreachable.BASEURL).toBe("http://litellm:4010/anthropic");
+    expect(unreachable.LITELLM).toBe("1");
+    expect(unreachable.LLBASE).toBe("http://litellm:4010");
+
+    // Missing key → fail-open strip (all routing vars gone).
+    const missingKey = runDispatch({ ok: "", unreachable: "" });
+    expect(missingKey.BASEURL).toBe("__UNSET__");
+    expect(missingKey.LITELLM).toBe("__UNSET__");
+    expect(missingKey.LLBASE).toBe("__UNSET__");
   });
 
   it("outer block is inside the SWITCHROOM_DOCKER_TMUX_INNER guard (outer-only section)", () => {

--- a/tests/scaffold.session-model-override.test.ts
+++ b/tests/scaffold.session-model-override.test.ts
@@ -207,4 +207,79 @@ describe("scaffoldAgent: session-only model override carrier (start.sh)", () => 
     expect(alert).toContain("sr-glm-5");
     expect(alert).toContain("LiteLLM");
   });
+
+  // --- CONFIGURED-DEFAULT sr-* (persistent, NO override carrier) --------------
+  // An agent whose switchroom.yaml sets `model: sr-glm-5` has no
+  // `.session-model-override` file, so the repoint MUST also cover the
+  // configured-default path (the post-resolution gate), or the agent 4xxs on
+  // every call against the /anthropic passthrough. Scaffold a dedicated agent
+  // with a non-Claude default and drive its block directly.
+  it("configured-default sr-* (no override) + LiteLLM up → repoints to router root", () => {
+    const smTmp = mkdtempSync(join(tmpdir(), "switchroom-session-model-srdef-"));
+    try {
+      const name = "sr-default-agent";
+      const cfg = makeAgentConfig({ model: "sr-glm-5" } as Partial<AgentConfig>);
+      const res = scaffoldAgent(name, cfg, smTmp, telegramConfig, makeSwitchroomConfig(name, cfg));
+      const startSh = readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+      const start = startSh.indexOf("# --- Session-only model override");
+      const anchor = startSh.indexOf('printf \'%s\\n\' "$_EFFECTIVE_MODEL" > ');
+      const end = startSh.indexOf("\n", anchor);
+      const srBlock = startSh.slice(start, end);
+
+      // The configured default is baked into the block as sr-glm-5 (no carrier).
+      expect(srBlock).toContain("_EFFECTIVE_MODEL='sr-glm-5'");
+
+      // LiteLLM reachable → post-resolution gate repoints off /anthropic.
+      const script = [
+        "set -e",
+        `export ANTHROPIC_BASE_URL=${JSON.stringify(PASSTHROUGH)}`,
+        `export SWITCHROOM_LITELLM_BASE=${JSON.stringify(ROUTER_ROOT)}`,
+        "_LITELLM_OK=1",
+        srBlock,
+        'echo "EFFECTIVE=$_EFFECTIVE_MODEL"',
+        'echo "BASEURL=$ANTHROPIC_BASE_URL"',
+      ].join("\n");
+      const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
+      expect(out).toContain("EFFECTIVE=sr-glm-5");
+      expect(out).toContain(`BASEURL=${ROUTER_ROOT}`);
+      expect(out).not.toContain(`BASEURL=${PASSTHROUGH}`);
+    } finally {
+      rmSync(smTmp, { recursive: true, force: true });
+    }
+  });
+
+  it("configured-default sr-* (no override) + LiteLLM DOWN → non-fatal, no crash, no Claude fallback", () => {
+    const smTmp = mkdtempSync(join(tmpdir(), "switchroom-session-model-srdown-"));
+    try {
+      const name = "sr-default-agent";
+      const cfg = makeAgentConfig({ model: "sr-glm-5" } as Partial<AgentConfig>);
+      const res = scaffoldAgent(name, cfg, smTmp, telegramConfig, makeSwitchroomConfig(name, cfg));
+      const startSh = readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+      const start = startSh.indexOf("# --- Session-only model override");
+      const anchor = startSh.indexOf('printf \'%s\\n\' "$_EFFECTIVE_MODEL" > ');
+      const end = startSh.indexOf("\n", anchor);
+      const srBlock = startSh.slice(start, end);
+
+      // Proxy down: compose already pointed a non-Claude default at the router
+      // root, so we simulate that starting env. The block must NOT crash and
+      // must NOT rewrite the effective model to a Claude default — a persistent
+      // sr-* agent runs degraded until litellm returns.
+      const script = [
+        "set -e",
+        `export ANTHROPIC_BASE_URL=${JSON.stringify(ROUTER_ROOT)}`,
+        `export SWITCHROOM_LITELLM_BASE=${JSON.stringify(ROUTER_ROOT)}`,
+        '_LITELLM_OK=""',
+        srBlock,
+        'echo "EFFECTIVE=$_EFFECTIVE_MODEL"',
+        'echo "BASEURL=$ANTHROPIC_BASE_URL"',
+      ].join("\n");
+      const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
+      // Effective model stays sr-glm-5 (no Claude fallback for a persistent default).
+      expect(out).toContain("EFFECTIVE=sr-glm-5");
+      // Routing left in place (still the router root compose set).
+      expect(out).toContain(`BASEURL=${ROUTER_ROOT}`);
+    } finally {
+      rmSync(smTmp, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/scaffold.session-model-override.test.ts
+++ b/tests/scaffold.session-model-override.test.ts
@@ -79,6 +79,34 @@ describe("scaffoldAgent: session-only model override carrier (start.sh)", () => 
     return m ? m[1].trim() : "";
   }
 
+  /**
+   * Run the extracted block with routing env seeded the way the litellm block
+   * above would leave it on a REACHABLE proxy: ANTHROPIC_BASE_URL points at the
+   * `/anthropic` passthrough, SWITCHROOM_LITELLM_BASE at the router root. Returns
+   * both the effective model and the ANTHROPIC_BASE_URL the block leaves set, so
+   * we can assert the sr-* passthrough→router repoint.
+   */
+  const PASSTHROUGH = "http://litellm:4010/anthropic";
+  const ROUTER_ROOT = "http://litellm:4010";
+  function runBlockRouting(litellmOk: string): { effective: string; baseUrl: string } {
+    const script = [
+      "set -e",
+      `export ANTHROPIC_BASE_URL=${JSON.stringify(PASSTHROUGH)}`,
+      `export SWITCHROOM_LITELLM_BASE=${JSON.stringify(ROUTER_ROOT)}`,
+      `_LITELLM_OK=${JSON.stringify(litellmOk)}`,
+      block,
+      'echo "EFFECTIVE=$_EFFECTIVE_MODEL"',
+      'echo "BASEURL=$ANTHROPIC_BASE_URL"',
+    ].join("\n");
+    const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
+    const eff = out.match(/EFFECTIVE=(.*)/);
+    const base = out.match(/BASEURL=(.*)/);
+    return {
+      effective: eff ? eff[1].trim() : "",
+      baseUrl: base ? base[1].trim() : "",
+    };
+  }
+
   it("renders the carrier + companion file wiring in start.sh", () => {
     expect(block).toContain(".session-model-override");
     expect(block).toContain(".active-session-model");
@@ -130,5 +158,53 @@ describe("scaffoldAgent: session-only model override carrier (start.sh)", () => 
     writeFileSync(join(agentDir, ".session-model-override"), "claude-opus-4-8\n");
     expect(runBlock("")).toBe("claude-opus-4-8");
     expect(existsSync(join(agentDir, ".session-model-alert"))).toBe(false);
+  });
+
+  // --- sr-* passthrough→router repoint (fleet-wide /model <sr-*> fix) ---------
+  // The default ANTHROPIC_BASE_URL points at the LiteLLM `/anthropic`
+  // PASSTHROUGH (a raw byte-forward to api.anthropic.com added 2026-07-05 to
+  // dodge the Opus SSE re-chunk stall). That passthrough is model-agnostic:
+  // it ships EVERY request to Anthropic regardless of --model, so an sr-*
+  // OpenRouter model 4xxs "model not found". When an sr-* override is picked up
+  // AND LiteLLM is reachable, start.sh must repoint ANTHROPIC_BASE_URL onto the
+  // LiteLLM router root so /v1/messages routes by model name to OpenRouter.
+  it("sr-* override + LiteLLM up → repoints ANTHROPIC_BASE_URL off /anthropic onto the router root", () => {
+    writeFileSync(join(agentDir, ".session-model-override"), "sr-glm-5\n");
+    const { effective, baseUrl } = runBlockRouting("1");
+    // Launches the requested OpenRouter model.
+    expect(effective).toBe("sr-glm-5");
+    // Repointed to the LiteLLM router root — the `/anthropic` passthrough suffix
+    // is gone, so claude's /v1/messages hits LiteLLM's model router.
+    expect(baseUrl).toBe(ROUTER_ROOT);
+    expect(baseUrl.endsWith("/anthropic")).toBe(false);
+  });
+
+  it("no override (Claude default) → KEEPS the /anthropic passthrough (guards the Opus SSE fix)", () => {
+    // No carrier: default Claude session must retain the passthrough endpoint.
+    const { effective, baseUrl } = runBlockRouting("1");
+    expect(effective).toBe(DEFAULT_MODEL);
+    expect(baseUrl).toBe(PASSTHROUGH);
+    expect(baseUrl.endsWith("/anthropic")).toBe(true);
+  });
+
+  it("claude-* override → KEEPS the /anthropic passthrough (only sr-* repoints)", () => {
+    writeFileSync(join(agentDir, ".session-model-override"), "claude-opus-4-8\n");
+    const { effective, baseUrl } = runBlockRouting("1");
+    expect(effective).toBe("claude-opus-4-8");
+    expect(baseUrl).toBe(PASSTHROUGH);
+    expect(baseUrl.endsWith("/anthropic")).toBe(true);
+  });
+
+  it("sr-* override + LiteLLM DOWN → override dropped to default, passthrough untouched, alert written", () => {
+    writeFileSync(join(agentDir, ".session-model-override"), "sr-glm-5\n");
+    const { effective, baseUrl } = runBlockRouting("");
+    // Dropped back to configured default (existing fail-safe behavior).
+    expect(effective).toBe(DEFAULT_MODEL);
+    // No repoint when the proxy is down — endpoint left as-is.
+    expect(baseUrl).toBe(PASSTHROUGH);
+    // Operator alert sentinel written.
+    const alert = readFileSync(join(agentDir, ".session-model-alert"), "utf-8");
+    expect(alert).toContain("sr-glm-5");
+    expect(alert).toContain("LiteLLM");
   });
 });


### PR DESCRIPTION
Hardens the LiteLLM routing path in `profiles/_base/start.sh.hbs` (+ one
`src/agents/compose.ts` gate). FOUR fixes across two commits; all covered by
tests. Aligns with `docs/model-routing.md` (PR #2939): litellm stays the single
metered path, no silent untracked fallback — addresses the **G2** agent
fail-open window.

## Fix 1 — inner boot outage no longer permanently disables litellm routing

The inner (claude-process) boot **liveliness probe** previously ran, on **any**
failure, a permanent strip:

```sh
unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM SWITCHROOM_LITELLM_BASE
```

For a merely **unreachable** proxy that strip is permanent for the process
lifetime — an agent that booted during a brief litellm blip **never routed
through litellm again** until a manual restart, silently falling back to
**untracked direct-Anthropic OAuth**. The two boot failure modes are now split:

- **MISSING KEY** → still fails open (nothing to authenticate to the proxy
  with) — now logged loudly.
- **PROXY UNREACHABLE at boot** (key present) → **no strip**; routing is left
  pointed at litellm with a **loud multi-line warning**, boot continues
  (non-fatal). Claude calls fail+retry until the proxy returns, then route
  automatically — the **socat forwarder at `127.0.0.1:4010` reconnects
  per-connection**. `_LITELLM_OK` stays empty so an `sr-*` session override is
  still dropped while the proxy is down.

## Fix 2 — the boot no-strip must also apply to the OUTER pass (was inert on docker)

`start.sh` runs **twice** on docker: an **OUTER** parent pass, then `exec tmux`
into the **INNER** pass. The OUTER probe block (gateway-hoist) **still** ran the
permanent `unset …` on any failure, **before** `exec tmux`. Because the inner
self-heal block is gated on `SWITCHROOM_LITELLM` — which the outer had just
removed — **Fix 1 was skipped entirely on the real deployment path**. The OUTER
block now carries the identical missing-key-vs-unreachable split: on
**UNREACHABLE** it keeps routing (loud warn, non-fatal) so it survives into the
tmux inner pass and self-heals; on **MISSING KEY** it keeps the fail-open
`unset`. (Found in adversarial review of the first commit; the earlier
"deferred follow-up" comment is gone.)

## Fix 3 — session `/model <sr-*>` switching (override path)

Agents' `ANTHROPIC_BASE_URL` points at the LiteLLM **`/anthropic` passthrough**
(a raw byte-forward to `api.anthropic.com`, added 2026-07-05 to dodge the Opus
SSE re-chunk stall). That passthrough is **model-agnostic**: it ships every
request to Anthropic regardless of `--model`, so `claude --model sr-glm-5` 4xxs
"model not found". On an `sr-*` override **with litellm reachable**, start.sh now
repoints `ANTHROPIC_BASE_URL` onto the LiteLLM **router root** so `/v1/messages`
routes by model name → OpenRouter. Default / `claude-*` sessions keep the
passthrough.

## Fix 4 — persistent non-Claude DEFAULT (`model: sr-glm-5`) never routed

A non-Claude model set as an agent **default** in `switchroom.yaml` has **no**
`.session-model-override` carrier, so the Fix-3 repoint never fired and it 4xx'd
on every call. Fixed in two places:

- **(a) `src/agents/compose.ts`** — `ANTHROPIC_BASE_URL` is now gated on **model
  class** via `isClaudeModel` (the same helper `src/setup/hindsight.ts` already
  uses): a Claude default keeps `${root}/anthropic`; a non-Claude default gets
  the **router root** (no `/anthropic`). The cascade-resolved model is threaded
  onto `AgentServiceData`.
- **(b) `profiles/_base/start.sh.hbs`** — the `sr-*` repoint is **consolidated
  into one post-resolution gate** that covers BOTH the override path AND the
  configured-default path, guarded on `_LITELLM_OK && SWITCHROOM_LITELLM_BASE`.
  For persistent `sr-*` + litellm-unreachable: routing is left in place,
  loud-warned, boot stays **non-fatal** (degraded until litellm returns) — **no
  Claude fallback**, which is correct for a persistent non-Claude agent.

## Tests

- `tests/scaffold.litellm-failopen.test.ts` — inner block: failed boot probe must
  NOT unset routing, must keep `ANTHROPIC_BASE_URL` at the forwarder, loud warning;
  missing-key still fails open.
- `tests/scaffold.litellm-gateway-outer.test.ts` — rewrote the outer contract to
  **no-strip-on-unreachable**; added an **executed** dispatch test proving
  UNREACHABLE keeps the routing env and MISSING KEY strips it (skips the 120s
  probe loop by driving the dispatch directly).
- `tests/docker/compose-generator.test.ts` — non-Claude configured `model:` →
  `ANTHROPIC_BASE_URL` has **no** `/anthropic`; Claude/unset → keeps `/anthropic`;
  no key confirmed → no routing env injected at all.
- `tests/scaffold.session-model-override.test.ts` — the 4 override-path repoint
  cases, plus configured-default `sr-*` (no override) repoint-when-up and
  non-fatal-when-down.

All affected suites green (`scaffold.test.ts` + the four above = **470** +
**16**/adjacent tests passing). Rendered `start.sh` passes `bash -n`. Root
`tsconfig` typechecks with 0 errors.

> Pre-existing/unrelated: repo-wide `npm run build`/`npm run lint` currently
> fails inside `telegram-plugin` (missing `mdast-*` deps for an in-flight
> rich-render feature) and `scaffold.persistent-home.test.ts` has 2
> environment-dependent failures — both reproduce on clean `origin/main` and are
> untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
