### PR TITLE
feat(model): sr-* /model aliases for full OpenRouter model coverage

### DIFF
--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -398,16 +398,31 @@ export const EXTRA_CLAUDE_ALIASES: ReadonlyArray<{ alias: string; label: string 
  * Friendly display names for sr-* synthetic model names. An sr-* model in
  * LiteLLM has no entry in `model_group_settings.*.forward_client_headers_to_llm_api`
  * so the Anthropic OAuth credential is NEVER forwarded — safe to route to
- * OpenRouter. Names here are display-only; the raw `sr-*` id is what gets
- * injected into the agent's session. See reference/rfcs/litellm-max-subscription-invariants.md § I6.
+ * OpenRouter. Names here are display-only (used by srFriendlyLabel for /status
+ * and switch confirmations); the raw `sr-*` id is what gets injected into the
+ * agent's session. This table is a SUPERSET of the menu-reachable set
+ * (SR_MODEL_ALIASES): it also labels models that are only reachable by typing
+ * the full `/model sr-<name>` (manual passthrough), so those still get a
+ * friendly name without appearing as a keyboard button.
+ * See reference/rfcs/litellm-max-subscription-invariants.md § I6.
  */
 export const SR_MODEL_LABELS: Record<string, string> = {
   'sr-gemini-2.5-pro': 'Gemini 2.5 Pro',
   'sr-gemini-2.5-flash': 'Gemini 2.5 Flash',
   'sr-deepseek-r1': 'DeepSeek R1',
   'sr-deepseek-v3': 'DeepSeek V3',
-  'sr-glm-5': 'GLM-5',
+  // sr-glm-5 now targets glm-5.2 in the live litellm config — label bumped to match.
+  'sr-glm-5': 'GLM-5.2',
   'sr-codex-5.5': 'Codex 5.5',
+  // OpenRouter coverage (pairs with the live litellm sr-* model_name additions).
+  'sr-gpt-oss-20b': 'GPT-OSS 20B',
+  'sr-gpt-oss-120b': 'GPT-OSS 120B',
+  'sr-gpt-5.5': 'GPT-5.5',
+  'sr-gpt-5-codex': 'GPT-5 Codex',
+  'sr-gpt-5.2-codex': 'GPT-5.2 Codex',
+  'sr-gemini-flash-lite': 'Gemini 3.1 Flash Lite',
+  'sr-minimax-m3': 'MiniMax M3',
+  'sr-deepseek-v4-flash': 'DeepSeek V4 Flash',
 }
 
 /**
@@ -488,10 +503,15 @@ function headerRow(label: string): ModelMenuKeyboardButton[] {
  * requires ANTHROPIC_CUSTOM_HEADERS (a litellm key) to be set on the gateway
  * process. switchroom never sets that env on the gateway, so in production
  * discoverSrModels() always returns [] and the external group was silently
- * empty. The six SR_MODEL_ALIASES targets are the sr-* names the litellm
- * config actually exposes, so seeding from them makes the group reliable
- * without the missing env — while still merging any live results on hosts
- * that do configure discovery.
+ * empty. The six SR_MODEL_ALIASES targets are the CURATED main sr-* set, so
+ * seeding from them makes the group reliable without the missing env — while
+ * still merging any live results on hosts that do configure discovery.
+ *
+ * Deliberately a SUBSET: the litellm config exposes more sr-* models than this
+ * (the full OpenRouter catalogue). Those extras are display-labelled in
+ * SR_MODEL_LABELS and remain typeable via `/model <full-sr-name>` (manual
+ * passthrough — the set path is a shape gate, no whitelist), but they are kept
+ * OUT of SR_MODEL_ALIASES on purpose so the keyboard stays small and curated.
  *
  * Subscription-honest: ONLY the curated sr-* aliases surface as buttons. Raw
  * gpt-4o / openrouter/* dupes / voyage-* embeddings never do.

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -445,6 +445,70 @@ describe("handleModelCommand — Claude → sr-* session relaunch", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Manual full-sr-* passthrough (Ken 2026-07-08): the /model MENU stays curated
+// to the main SR_MODEL_ALIASES set, but typing `/model <any registered sr-*>`
+// must switch to that exact model — the set path is a SHAPE gate only, with NO
+// whitelist against SR_MODEL_LABELS / SR_MODEL_ALIASES. These guard that any
+// arbitrary sr-* id passes through verbatim and schedules the relaunch on the
+// exact id (not rejected, not remapped, not injected).
+// ---------------------------------------------------------------------------
+describe("handleModelCommand — arbitrary sr-* passthrough (no whitelist)", () => {
+  // sr-* names that are NOT in SR_MODEL_ALIASES (so not menu-reachable) but ARE
+  // registered in the live litellm config — must still switch when typed.
+  const ARBITRARY_SR = [
+    "sr-gpt-oss-120b",
+    "sr-gpt-oss-20b",
+    "sr-minimax-m3",
+    "sr-gemini-flash-lite",
+    "sr-gpt-5.5",
+    "sr-gpt-5-codex",
+    "sr-gpt-5.2-codex",
+    "sr-deepseek-v4-flash",
+  ];
+
+  it("each arbitrary sr-* passes the shape gate and isSrModel", () => {
+    for (const name of ARBITRARY_SR) {
+      expect(isValidModelArg(name), `${name} must pass MODEL_ARG_RE`).toBe(true);
+      expect(isSrModel(name), `${name} must be recognised as sr-*`).toBe(true);
+      expect(isClaudeModel(name)).toBe(false);
+    }
+  });
+
+  it("relaunches on the exact typed id — not rejected, not remapped", async () => {
+    for (const name of ARBITRARY_SR) {
+      const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
+        getActiveSessionModel: () => null,
+      });
+      const reply = await handleModelCommand({ kind: "set", model: name }, deps);
+      // Never injected (claude's picker rejects sr-* ids).
+      expect(calls, `${name} must not inject`).toHaveLength(0);
+      // Never the sr→claude restart path (source session is Claude here).
+      expect(restartCalls, `${name} must not scheduleRestart`).toHaveLength(0);
+      // Scheduled the carrier relaunch on the EXACT id (no alias remap).
+      expect(relaunchCalls).toHaveLength(1);
+      expect(relaunchCalls[0].model, `${name} must relaunch verbatim`).toBe(name);
+      expect(reply.text).toContain(name);
+    }
+  });
+
+  it("parseModelCommand accepts arbitrary sr-* ids as a set command", () => {
+    for (const name of ARBITRARY_SR) {
+      expect(parseModelCommand(`/model ${name}`)).toEqual({ kind: "set", model: name });
+    }
+  });
+
+  it("switching FROM an arbitrary sr-* back to Claude takes the restart path", async () => {
+    const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
+      getActiveSessionModel: () => "sr-gpt-oss-120b",
+    });
+    await handleModelCommand({ kind: "set", model: "opus" }, deps);
+    expect(calls).toHaveLength(0);
+    expect(relaunchCalls).toHaveLength(0);
+    expect(restartCalls).toHaveLength(1);
+  });
+});
+
 describe("inject allowlist contract", () => {
   it("/model stays on the inject allowlist (the set path depends on it)", async () => {
     const { INJECT_COMMANDS } = await import("../../src/agents/inject.js");
@@ -748,6 +812,58 @@ describe("SR_MODEL_LABELS", () => {
   it("has friendly names for the standard sr-* models", () => {
     expect(SR_MODEL_LABELS["sr-gemini-2.5-pro"]).toBe("Gemini 2.5 Pro");
     expect(SR_MODEL_LABELS["sr-deepseek-r1"]).toBe("DeepSeek R1");
+  });
+
+  it("bumps sr-glm-5 label to GLM-5.2 (now targets glm-5.2 in litellm)", () => {
+    expect(SR_MODEL_LABELS["sr-glm-5"]).toBe("GLM-5.2");
+  });
+
+  it("has friendly names for the new OpenRouter sr-* models (display-only)", () => {
+    expect(SR_MODEL_LABELS["sr-gpt-oss-20b"]).toBe("GPT-OSS 20B");
+    expect(SR_MODEL_LABELS["sr-gpt-oss-120b"]).toBe("GPT-OSS 120B");
+    expect(SR_MODEL_LABELS["sr-gpt-5.5"]).toBe("GPT-5.5");
+    expect(SR_MODEL_LABELS["sr-gpt-5-codex"]).toBe("GPT-5 Codex");
+    expect(SR_MODEL_LABELS["sr-gpt-5.2-codex"]).toBe("GPT-5.2 Codex");
+    expect(SR_MODEL_LABELS["sr-gemini-flash-lite"]).toBe("Gemini 3.1 Flash Lite");
+    expect(SR_MODEL_LABELS["sr-minimax-m3"]).toBe("MiniMax M3");
+    expect(SR_MODEL_LABELS["sr-deepseek-v4-flash"]).toBe("DeepSeek V4 Flash");
+  });
+});
+
+describe("menu stays curated — new OpenRouter models are display-only, not in the picker", () => {
+  // The 8 new models are typeable (manual passthrough) but must NOT bloat the
+  // /model keyboard. externalModelNames() seeds the picker from SR_MODEL_ALIASES
+  // values, so these ids must be ABSENT from both the alias table and the picker
+  // list. This locks in Ken's "menu = main models only" decision.
+  const NEW_SR = [
+    "sr-gpt-oss-20b",
+    "sr-gpt-oss-120b",
+    "sr-gpt-5.5",
+    "sr-gpt-5-codex",
+    "sr-gpt-5.2-codex",
+    "sr-gemini-flash-lite",
+    "sr-minimax-m3",
+    "sr-deepseek-v4-flash",
+  ];
+
+  it("SR_MODEL_ALIASES stays the curated 6-entry main set (no new short aliases)", () => {
+    expect(Object.keys(SR_MODEL_ALIASES).sort()).toEqual(
+      ["codex", "deepseek", "flash", "gemini", "glm", "r1"],
+    );
+    // None of the new sr-* ids are an alias target.
+    const targets = new Set(Object.values(SR_MODEL_ALIASES));
+    for (const name of NEW_SR) {
+      expect(targets.has(name), `${name} must NOT be an alias target`).toBe(false);
+    }
+  });
+
+  it("externalModelNames (picker seed) excludes the new models", () => {
+    const picker = externalModelNames([]);
+    for (const name of NEW_SR) {
+      expect(picker.includes(name), `${name} must NOT appear in the picker`).toBe(false);
+    }
+    // The curated main set is still exactly the alias targets.
+    expect(picker.sort()).toEqual([...new Set(Object.values(SR_MODEL_ALIASES))].sort());
   });
 });
 


### PR DESCRIPTION
Pairs with the live litellm `sr-*` model_name additions (the `glm`→`glm-5.2` bump
plus 8 new OpenRouter models) so **`/model <any registered OpenRouter model>`
works** — while the `/model` **menu keyboard stays curated to the main set**.

## Design (per Ken)

- The **menu** must list only the main models (unchanged). `externalModelNames()`
  seeds the picker from **`SR_MODEL_ALIASES`** values, so this PR **does NOT touch
  `SR_MODEL_ALIASES`** — the keyboard stays exactly `{codex, deepseek, flash,
  gemini, glm, r1}`.
- **Manual `/model sr-<full-name>` must pass through** for any registered
  OpenRouter model. It already does: the set path is a **shape gate only**
  (`isValidModelArg` / `MODEL_ARG_RE`, dots + hyphens allowed) with **no
  whitelist** — `expandSrAlias` no-ops an unknown id, `isSrModel` matches the
  `sr-` prefix, and `scheduleModelRelaunch` fires on the exact id. No source
  logic change was required; this PR adds regression tests that lock it in.
- **`SR_MODEL_LABELS`** is display-only (`srFriendlyLabel` for `/status` + switch
  confirmations) and does **not** feed the keyboard, so it's safe to label the
  new models there — they get friendly names without becoming buttons.

## Changes

**`telegram-plugin/gateway/model-command.ts`**
- `SR_MODEL_LABELS`: bump `sr-glm-5` `"GLM-5"` → `"GLM-5.2"`; add display names
  for the 8 new sr-* ids: `sr-gpt-oss-20b` (GPT-OSS 20B), `sr-gpt-oss-120b`
  (GPT-OSS 120B), `sr-gpt-5.5` (GPT-5.5), `sr-gpt-5-codex` (GPT-5 Codex),
  `sr-gpt-5.2-codex` (GPT-5.2 Codex), `sr-gemini-flash-lite` (Gemini 3.1 Flash
  Lite), `sr-minimax-m3` (MiniMax M3), `sr-deepseek-v4-flash` (DeepSeek V4 Flash).
- `SR_MODEL_ALIASES`: **unchanged** — comments updated to explain the menu is a
  deliberate curated subset and the labels table is a superset.

## Tests (`telegram-plugin/tests/model-command.test.ts`)

- **Arbitrary sr-* passthrough** suite: each of the 8 new ids passes the shape
  gate + `isSrModel`, relaunches **verbatim** (not rejected / remapped / injected),
  and parses as a `set` command; switching FROM an arbitrary sr-* session back to
  Claude still takes the restart path.
- **`SR_MODEL_LABELS`**: asserts the 8 new labels + the `GLM-5.2` bump.
- **Menu-curation guard**: `SR_MODEL_ALIASES` stays exactly the 6-entry main set,
  and `externalModelNames()` (the picker seed) **excludes** every new model.

`vitest run telegram-plugin/tests/model-command.test.ts` → **94 passed**. Root
`tsconfig` typechecks with 0 errors.

> This PR only touches the switchroom code tables; the matching live litellm
> `model_name` entries are handled separately by the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
