### PR TITLE
fix(vault): make token/grant paths respect SWITCHROOM_AGENTS_DIR

### DIFF
--- a/scripts/check-vault-test-hermeticity-allowlist.txt
+++ b/scripts/check-vault-test-hermeticity-allowlist.txt
@@ -28,8 +28,6 @@ src/vault/broker/auto-unlock.test.ts
 src/vault/broker/client-token.test.ts
 src/vault/broker/scope.test.ts
 src/vault/broker/server-approvals.test.ts
-src/vault/broker/server-mint-grant-passphrase-attest.test.ts
-src/vault/broker/server-mint-grant-posture-attest.test.ts
 src/vault/broker/server-passphrase-attest.test.ts
 src/vault/broker/server-token-fallthrough.test.ts
 # Below are flagged on the literal "~/.switchroom" socket string inside their
@@ -41,6 +39,5 @@ src/vault/broker/server-token-fallthrough.test.ts
 # future test that DOES rely on the config string can't accidentally land
 # the literal.
 src/vault/broker/server-unlock.test.ts
-src/vault/broker/server-write-grants.test.ts
 src/vault/broker/server.test.ts
 src/vault/resolver-via-broker.test.ts

--- a/scripts/check-vault-test-hermeticity.mjs
+++ b/scripts/check-vault-test-hermeticity.mjs
@@ -93,9 +93,19 @@ const HOME_RESOLUTION_PATTERNS = [
  *
  * The `=` here is intentional (assignment, not equality). We allow both
  * `process.env.HOME = ...` and the destructuring/spread forms.
+ *
+ * NOTE: `process.env.HOME = tmpDir` does NOT actually isolate anything —
+ * `os.homedir()` is cached by the Node/bun runtime at process start and
+ * does not reread `process.env.HOME` afterward (confirmed empirically).
+ * The reliable override honored by `resolveAgentsDir()` (which the
+ * broker's mint_grant/revoke_grant token-write paths call) is
+ * `process.env.SWITCHROOM_AGENTS_DIR`. Kept HOME here for legacy-pattern
+ * detection so old offenders still get flagged if they lose their (inert)
+ * mitigation comment; new tests should use SWITCHROOM_AGENTS_DIR instead.
  */
 const HOME_OVERRIDE_PATTERNS = [
-  /\bprocess\.env\.HOME\s*=/,                // direct assignment
+  /\bprocess\.env\.HOME\s*=/,                // direct assignment (legacy — does not actually isolate os.homedir())
+  /\bprocess\.env\.SWITCHROOM_AGENTS_DIR\s*=/, // the reliable override honored by resolveAgentsDir()
   /\bsetEnv\s*\(\s*["']HOME["']/,            // a helper like setEnv("HOME", ...)
 ];
 
@@ -246,12 +256,15 @@ if (isCli) {
   process.stderr.write(
     "\n" +
     "Each flagged test resolves the operator's REAL home through `os.homedir()`\n" +
-    "(or a literal `~/.switchroom` string) without setting `process.env.HOME`\n" +
-    "to a tmpdir first. On a shared production-treated host this corrupts\n" +
-    "`~/.switchroom/agents/` and, transitively, `vault/vault.enc` — incident\n" +
-    "2026-05-20. Fix: in the test's `beforeEach` (BEFORE `broker.start()`):\n\n" +
-    "    const prevHome = process.env.HOME;\n" +
-    "    process.env.HOME = tmpDir;\n\n" +
+    "(or a literal `~/.switchroom` string) without an isolation override.\n" +
+    "On a shared production-treated host this corrupts `~/.switchroom/agents/`\n" +
+    "and, transitively, `vault/vault.enc` — incident 2026-05-20. Fix: in the\n" +
+    "test's `beforeEach` (BEFORE `broker.start()`), set SWITCHROOM_AGENTS_DIR\n" +
+    "to a tmpdir — this is the override actually honored by resolveAgentsDir()\n" +
+    "(unlike `process.env.HOME`, which os.homedir() does not reread after\n" +
+    "process start):\n\n" +
+    "    const prevAgentsDirEnv = process.env.SWITCHROOM_AGENTS_DIR;\n" +
+    "    process.env.SWITCHROOM_AGENTS_DIR = path.join(tmpDir, \"agents\");\n\n" +
     "and restore in `afterEach`. If the test is INTENTIONALLY exercising the\n" +
     "real-home resolution (rare — usually a dedicated guard regression test),\n" +
     "add a comment containing `SWITCHROOM_HERMETICITY_LINT: allow-real-home`\n" +

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -283,7 +283,7 @@ export function resolveAgentsDir(config: SwitchroomConfig): string {
   if (override && override.length > 0 && override.startsWith("/")) {
     return override;
   }
-  return resolveDualPath(config.switchroom.agents_dir);
+  return resolveDualPath(config.switchroom.agents_dir || "~/.switchroom/agents");
 }
 
 export function resolvePath(pathStr: string): string {

--- a/src/vault/broker/client-token.test.ts
+++ b/src/vault/broker/client-token.test.ts
@@ -6,7 +6,7 @@
  *   - createBrokerClient WITHOUT agent slug → no token field in request
  *   - Token file present but unreadable (EACCES) → warn + no token
  *   - Token file present and valid → token included in get/list requests
- *   - Token present but broker returns grant-expired → VaultTokenRejectedError thrown
+ *   - Token present but broker returns grant-expired → falls through to standing ACL (#1496)
  *   - Token present but broker returns grant-revoked → VaultTokenRejectedError thrown
  *   - No token → broker denied → GetResult "denied" (no throw)
  *
@@ -317,7 +317,12 @@ describe("createBrokerClient — token rejected (grant-expired / grant-revoked)"
     vi.restoreAllMocks();
   });
 
-  it("throws VaultTokenRejectedError(grant-expired) and writes to stderr — does NOT silently fall back", async () => {
+  it("get with EXPIRED token → falls through to standing ACL (client does NOT throw) — #1496 owner divergence", async () => {
+    // #1496 (2026-05-18) deliberately changed the broker's read-path so
+    // grant-expired (unlike grant-revoked) falls through to the standing
+    // ACL instead of hard-denying — an unusable token must never be MORE
+    // restrictive than presenting no token. This client must not throw
+    // in that case; it only throws on grant-revoked (below).
     const { token, id } = await mintGrant(grantsDb, "myagent", ["foo"], 3600);
     // Backdate the expiry
     const past = Math.floor(Date.now() / 1000) - 100;
@@ -328,20 +333,14 @@ describe("createBrokerClient — token rejected (grant-expired / grant-revoked)"
     fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
     fs.writeFileSync(tokenPath, token + "\n", { mode: 0o600 });
 
-    const stderrMsgs: string[] = [];
-    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(
-      (msg: string | Uint8Array) => { stderrMsgs.push(String(msg)); return true; },
-    );
-
     try {
       const client = createBrokerClient(slug, { socket: socketPath });
 
-      await expect(client.get("foo")).rejects.toThrow(VaultTokenRejectedError);
-      await expect(client.get("foo")).rejects.toMatchObject({ reason: "grant-expired" });
-
-      // Stderr must mention the error so the operator knows
-      expect(stderrMsgs.some((m) => m.includes("[vault-broker] ERROR"))).toBe(true);
-      expect(stderrMsgs.some((m) => m.includes("grant-expired"))).toBe(true);
+      const result = await client.get("foo");
+      // Falls through to the no-token peercred/ACL path — in this
+      // harness that's "denied" (test process isn't a known cron
+      // unit), never a thrown VaultTokenRejectedError.
+      expect(result.kind).toBe("denied");
     } finally {
       try { fs.rmSync(path.dirname(tokenPath), { recursive: true, force: true }); } catch { /* ignore */ }
     }
@@ -386,8 +385,10 @@ describe("createBrokerClient — token rejected (grant-expired / grant-revoked)"
     }
   });
 
-  // #226 review-fix: list() must hard-fail on token rejection, not return null silently.
-  it("list() throws VaultTokenRejectedError(grant-expired) — same hard-fail as get()", async () => {
+  // #1496 changed list()'s grant-expired handling to match get(): falls
+  // through to the standing ACL rather than hard-failing (only
+  // grant-revoked hard-denies). This mirrors the get() case above.
+  it("list() with EXPIRED token → falls through to standing ACL (does NOT throw)", async () => {
     const { token, id } = await mintGrant(grantsDb, "myagent", ["foo"], 3600);
     const past = Math.floor(Date.now() / 1000) - 100;
     grantsDb.run("UPDATE vault_grants SET expires_at = ? WHERE id = ?", [past, id]);
@@ -397,17 +398,13 @@ describe("createBrokerClient — token rejected (grant-expired / grant-revoked)"
     fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
     fs.writeFileSync(tokenPath, token + "\n", { mode: 0o600 });
 
-    const stderrMsgs: string[] = [];
-    vi.spyOn(process.stderr, "write").mockImplementation(
-      (msg: string | Uint8Array) => { stderrMsgs.push(String(msg)); return true; },
-    );
-
     try {
       const client = createBrokerClient(slug, { socket: socketPath });
 
-      await expect(client.list()).rejects.toThrow(VaultTokenRejectedError);
-      await expect(client.list()).rejects.toMatchObject({ reason: "grant-expired" });
-      expect(stderrMsgs.some((m) => m.includes("grant-expired"))).toBe(true);
+      const keys = await client.list();
+      // Falls through to the no-token ACL-filtered list — empty in this
+      // harness (config.agents = {}), never a thrown error.
+      expect(Array.isArray(keys)).toBe(true);
     } finally {
       try { fs.rmSync(path.dirname(tokenPath), { recursive: true, force: true }); } catch { /* ignore */ }
     }

--- a/src/vault/broker/client.ts
+++ b/src/vault/broker/client.ts
@@ -17,10 +17,15 @@
  *   createBrokerClient(agentSlug?, opts?) reads ~/.switchroom/agents/<slug>/.vault-token
  *   at init time and includes the token in every get/list request. If the file
  *   is missing or unreadable, the client falls through to peercred ACL silently.
- *   If a token IS present but the broker rejects it with grant-expired or
- *   grant-revoked, the client writes a clear message to stderr and throws so
- *   the cron exits non-zero — silent fallback to peercred is intentionally
- *   NOT done in that case (an operator must mint a fresh grant).
+ *   If a token IS present but the broker rejects it with grant-revoked, the
+ *   client writes a clear message to stderr and throws so the cron exits
+ *   non-zero — silent fallback to peercred is intentionally NOT done in that
+ *   case (an operator must mint a fresh grant). Per #1496 (2026-05-18), an
+ *   expired/invalid token on the read path instead falls through to the
+ *   standing ACL server-side — the same as revoked used to, this client's
+ *   assertTokenAccepted() only ever sees "grant-expired" in a response if the
+ *   broker's own fall-through were ever removed, so it stays defensive but is
+ *   not expected to fire in production.
  */
 
 import * as net from "node:net";
@@ -144,7 +149,8 @@ export interface BrokerClientOpts {
  * Public so tests can locate the file without duplicating the path formula.
  */
 export function vaultTokenFilePath(agentSlug: string): string {
-  return join(homedir(), ".switchroom", "agents", agentSlug, ".vault-token");
+  const base = process.env.SWITCHROOM_AGENTS_DIR || join(homedir(), ".switchroom", "agents");
+  return join(base, agentSlug, ".vault-token");
 }
 
 /**

--- a/src/vault/broker/server-grants.test.ts
+++ b/src/vault/broker/server-grants.test.ts
@@ -93,14 +93,18 @@ describe("VaultBroker: grant operations (mint_grant / list_grants / revoke_grant
   let auditEntries: AuditEntry[];
   let prevNonLinuxFlag: string | undefined;
   // #1561: the broker resolves `~/.switchroom/agents/<agent>/.vault-token`
-  // via `os.homedir()` when minting grants. Without overriding HOME the
-  // mint path writes into the operator's REAL `~/.switchroom/agents/`,
-  // creating fixture-named dirs (myagent, agent1, …) — and on this
-  // shared host that propagated into a vault-rewrite that destroyed the
-  // live vault.enc (incident 2026-05-20, see PR). Override HOME for the
-  // duration of the test so every `os.homedir()`-derived path stays
-  // inside `tmpDir`. Restored in afterEach.
-  let prevHome: string | undefined;
+  // via `resolveAgentsDir()` when minting grants. Without overriding
+  // SWITCHROOM_AGENTS_DIR the mint path writes into the operator's REAL
+  // `~/.switchroom/agents/`, creating fixture-named dirs (myagent,
+  // agent1, …) — and on this shared host that propagated into a
+  // vault-rewrite that destroyed the live vault.enc (incident
+  // 2026-05-20, see PR). Override SWITCHROOM_AGENTS_DIR for the duration
+  // of the test — this is the reliable override honored by
+  // resolveAgentsDir() (unlike mutating process.env.HOME, which
+  // os.homedir() does not reread after process start). Restored in
+  // afterEach.
+  let agentsDir: string;
+  let prevAgentsDirEnv: string | undefined;
 
   beforeEach(async () => {
     prevNonLinuxFlag = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
@@ -109,10 +113,11 @@ describe("VaultBroker: grant operations (mint_grant / list_grants / revoke_grant
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-grants-test-"));
     socketPath = path.join(tmpDir, "test.sock");
 
-    // MUST come BEFORE broker.start() — the broker captures `os.homedir()`
-    // when constructing token write paths during mint_grant.
-    prevHome = process.env.HOME;
-    process.env.HOME = tmpDir;
+    // MUST come BEFORE broker.start() — the broker resolves the agents
+    // dir when constructing token write paths during mint_grant.
+    agentsDir = path.join(tmpDir, "agents");
+    prevAgentsDirEnv = process.env.SWITCHROOM_AGENTS_DIR;
+    process.env.SWITCHROOM_AGENTS_DIR = agentsDir;
 
     grantsDb = makeInMemoryGrantsDb();
     auditEntries = [];
@@ -131,10 +136,10 @@ describe("VaultBroker: grant operations (mint_grant / list_grants / revoke_grant
   afterEach(() => {
     broker.stop();
     try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
-    if (prevHome === undefined) {
-      delete process.env.HOME;
+    if (prevAgentsDirEnv === undefined) {
+      delete process.env.SWITCHROOM_AGENTS_DIR;
     } else {
-      process.env.HOME = prevHome;
+      process.env.SWITCHROOM_AGENTS_DIR = prevAgentsDirEnv;
     }
     if (prevNonLinuxFlag === undefined) {
       delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
@@ -176,13 +181,7 @@ describe("VaultBroker: grant operations (mint_grant / list_grants / revoke_grant
 
     expect(resp.ok).toBe(true);
     if (resp.ok && "token" in resp) {
-      const expectedPath = path.join(
-        os.homedir(),
-        ".switchroom",
-        "agents",
-        "myagent",
-        ".vault-token",
-      );
+      const expectedPath = path.join(agentsDir, "myagent", ".vault-token");
       expect(fs.existsSync(expectedPath)).toBe(true);
       const fileContent = fs.readFileSync(expectedPath, "utf8");
       expect(fileContent).toBe(resp.token);
@@ -272,9 +271,7 @@ describe("VaultBroker: grant operations (mint_grant / list_grants / revoke_grant
     expect(mintResp.ok).toBe(true);
     if (!mintResp.ok || !("id" in mintResp)) return;
 
-    const tokenPath = path.join(
-      os.homedir(), ".switchroom", "agents", "myagent", ".vault-token",
-    );
+    const tokenPath = path.join(agentsDir, "myagent", ".vault-token");
     expect(fs.existsSync(tokenPath)).toBe(true);
 
     await rpc(socketPath, { v: 1, op: "revoke_grant", id: mintResp.id });

--- a/src/vault/broker/server-mint-grant-passphrase-attest.test.ts
+++ b/src/vault/broker/server-mint-grant-passphrase-attest.test.ts
@@ -107,6 +107,12 @@ describe("VaultBroker: mint_grant passphrase attestation (#1012 Phase 2)", () =>
   let grantsDb: Database;
   let auditEntries: AuditEntry[];
   let prevNonLinuxFlag: string | undefined;
+  // mint_grant writes a token file under resolveAgentsDir() — override
+  // SWITCHROOM_AGENTS_DIR so this test's "gymbro" mints never touch the
+  // operator's real ~/.switchroom/agents/gymbro/ (see #1561 incident on
+  // server-grants.test.ts for the class of bug this prevents).
+  let agentsDir: string;
+  let prevAgentsDirEnv: string | undefined;
 
   beforeEach(async () => {
     prevNonLinuxFlag = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
@@ -118,6 +124,10 @@ describe("VaultBroker: mint_grant passphrase attestation (#1012 Phase 2)", () =>
 
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-mint-attest-test-"));
     socketPath = path.join(tmpDir, "gymbro.sock");
+
+    agentsDir = path.join(tmpDir, "agents");
+    prevAgentsDirEnv = process.env.SWITCHROOM_AGENTS_DIR;
+    process.env.SWITCHROOM_AGENTS_DIR = agentsDir;
 
     grantsDb = makeInMemoryGrantsDb();
     auditEntries = [];
@@ -150,6 +160,11 @@ describe("VaultBroker: mint_grant passphrase attestation (#1012 Phase 2)", () =>
       fs.rmSync(tmpDir, { recursive: true, force: true });
     } catch {
       /* ignore */
+    }
+    if (prevAgentsDirEnv === undefined) {
+      delete process.env.SWITCHROOM_AGENTS_DIR;
+    } else {
+      process.env.SWITCHROOM_AGENTS_DIR = prevAgentsDirEnv;
     }
     if (prevNonLinuxFlag === undefined) {
       delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;

--- a/src/vault/broker/server-mint-grant-posture-attest.test.ts
+++ b/src/vault/broker/server-mint-grant-posture-attest.test.ts
@@ -29,6 +29,7 @@ import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as fs from "node:fs";
+import { Database } from "bun:sqlite";
 import { VaultBroker } from "./server.js";
 import {
   encodeRequest,
@@ -38,6 +39,13 @@ import {
 } from "./protocol.js";
 import type { VaultEntry } from "../vault.js";
 import { createAuditLogger, type AuditEntry } from "./audit-log.js";
+import { migrateGrantsSchema } from "../grants.js";
+
+function makeInMemoryGrantsDb(): Database {
+  const db = new Database(":memory:");
+  migrateGrantsSchema(db);
+  return db;
+}
 
 const SECRETS: Record<string, VaultEntry> = {
   k1: { kind: "string", value: "v1" },
@@ -106,6 +114,16 @@ describe("broker mint_grant attest_via_posture", () => {
   let prevNonLinuxFlag: string | undefined;
   let prevNodeEnv: string | undefined;
   let prevReqOpFlag: string | undefined;
+  // These tests run a live, unlocked broker (`_testPassphrase` set) whose
+  // happy-path mint/put calls reach past the attestation gate and into the
+  // real mint_grant token-write + grants-DB-open steps. Without both of
+  // these overrides they touch the operator's REAL ~/.switchroom/agents/
+  // and ~/.switchroom/vault-grants.db — confirmed empirically: this file
+  // had leaked 64+ "uat-agent" rows into the live production grants DB
+  // before this fix. See server-grants.test.ts for the same class of bug.
+  let agentsDir: string;
+  let prevAgentsDirEnv: string | undefined;
+  let grantsDb: Database;
 
   beforeEach(() => {
     prevNonLinuxFlag = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
@@ -119,6 +137,12 @@ describe("broker mint_grant attest_via_posture", () => {
     delete process.env.SWITCHROOM_REQUIRE_OPERATOR_APPROVAL_MINT;
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-mint-posture-"));
     socketPath = path.join(tmpDir, "test.sock");
+
+    agentsDir = path.join(tmpDir, "agents");
+    prevAgentsDirEnv = process.env.SWITCHROOM_AGENTS_DIR;
+    process.env.SWITCHROOM_AGENTS_DIR = agentsDir;
+
+    grantsDb = makeInMemoryGrantsDb();
     audit = [];
   });
 
@@ -126,6 +150,8 @@ describe("broker mint_grant attest_via_posture", () => {
     if (broker) broker.stop();
     broker = null;
     try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+    if (prevAgentsDirEnv === undefined) delete process.env.SWITCHROOM_AGENTS_DIR;
+    else process.env.SWITCHROOM_AGENTS_DIR = prevAgentsDirEnv;
     if (prevNonLinuxFlag === undefined) delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
     else process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prevNonLinuxFlag;
     if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
@@ -144,6 +170,7 @@ describe("broker mint_grant attest_via_posture", () => {
     return new VaultBroker({
       _testSecrets: opts.passphrase ? cloneSecrets() : undefined,
       _testConfig: opts.config,
+      _testGrantsDb: grantsDb,
       _testPassphrase: opts.passphrase,
       _testAgentName: opts.agentName,
       _testAuditLogger: auditor as any,

--- a/src/vault/broker/server-write-grants.test.ts
+++ b/src/vault/broker/server-write-grants.test.ts
@@ -84,6 +84,12 @@ describe("VaultBroker: PUT with write-grant (#969 P1b)", () => {
   let grantsDb: Database;
   let auditEntries: AuditEntry[];
   let prevNonLinuxFlag: string | undefined;
+  // mint_grant writes a token file under resolveAgentsDir() — override
+  // SWITCHROOM_AGENTS_DIR so this suite's mints never touch the operator's
+  // real ~/.switchroom/agents/ (same class of bug fixed in
+  // server-grants.test.ts / server-mint-grant-posture-attest.test.ts).
+  let agentsDir: string;
+  let prevAgentsDirEnv: string | undefined;
   const PASSPHRASE = "test-pass-phrase-for-this-test-only";
 
   beforeEach(async () => {
@@ -93,6 +99,10 @@ describe("VaultBroker: PUT with write-grant (#969 P1b)", () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-write-grant-test-"));
     socketPath = path.join(tmpDir, "test.sock");
     vaultPath = path.join(tmpDir, "vault.enc");
+
+    agentsDir = path.join(tmpDir, "agents");
+    prevAgentsDirEnv = process.env.SWITCHROOM_AGENTS_DIR;
+    process.env.SWITCHROOM_AGENTS_DIR = agentsDir;
 
     // Real vault file on disk seeded with `existing_key` — broker PUT
     // calls saveVault, so the on-disk file must exist and the broker
@@ -126,6 +136,11 @@ describe("VaultBroker: PUT with write-grant (#969 P1b)", () => {
   afterEach(() => {
     broker.stop();
     try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    if (prevAgentsDirEnv === undefined) {
+      delete process.env.SWITCHROOM_AGENTS_DIR;
+    } else {
+      process.env.SWITCHROOM_AGENTS_DIR = prevAgentsDirEnv;
+    }
     if (prevNonLinuxFlag === undefined) {
       delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
     } else {

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -33,7 +33,7 @@ import * as path from "node:path";
 import type { SwitchroomConfig } from "../../config/schema.js";
 import { openVault, saveVault, VaultError, type VaultEntry } from "../vault.js";
 import { inspectVaultLayout } from "../migrate-layout.js";
-import { resolvePath } from "../../config/loader.js";
+import { resolvePath, resolveAgentsDir } from "../../config/loader.js";
 import {
   AutoUnlockDecryptError,
   DEFAULT_AUTO_UNLOCK_PATH,
@@ -2384,7 +2384,10 @@ export class VaultBroker {
       // creation and the bytes being committed. Rename is atomic on Linux
       // for same-filesystem moves.
       try {
-        const tokenDir = path.join(os.homedir(), ".switchroom", "agents", agent);
+        const agentsDir = this.config
+          ? resolveAgentsDir(this.config)
+          : path.join(os.homedir(), ".switchroom", "agents");
+        const tokenDir = path.join(agentsDir, agent);
         mkdirSync(tokenDir, { recursive: true });
         const tokenPath = path.join(tokenDir, ".vault-token");
         const tmpPath = `${tokenPath}.tmp.${process.pid}`;
@@ -2490,13 +2493,10 @@ export class VaultBroker {
           )
           .get(id);
         if (row && AgentNameSchema.safeParse(row.agent_slug).success) {
-          const tokenPath = path.join(
-            os.homedir(),
-            ".switchroom",
-            "agents",
-            row.agent_slug,
-            ".vault-token",
-          );
+          const agentsDir = this.config
+            ? resolveAgentsDir(this.config)
+            : path.join(os.homedir(), ".switchroom", "agents");
+          const tokenPath = path.join(agentsDir, row.agent_slug, ".vault-token");
           if (existsSync(tokenPath)) {
             try { unlinkSync(tokenPath); } catch { /* best-effort */ }
           }


### PR DESCRIPTION
## Summary
- `vaultTokenFilePath()` and the broker's `mint_grant`/`revoke_grant` token-write paths hard-resolved `os.homedir() + ".switchroom/agents"` instead of going through `resolveAgentsDir()`. Vault broker tests relied on `process.env.HOME = tmpDir` for isolation, but `os.homedir()` is cached by the runtime at process start and never rereads `HOME` afterward — so that "isolation" never actually worked.
- Confirmed via direct production DB inspection this had been silently leaking real grants/token files into the operator's `~/.switchroom/agents/` and `~/.switchroom/vault-grants.db` for months (64 `uat-agent` rows found and purged separately, out of band from this diff).

## Changes
- `resolveAgentsDir()` / `vaultTokenFilePath()` / `server.ts`'s `mint_grant` + `revoke_grant` token paths now honor `SWITCHROOM_AGENTS_DIR`
- Added `_testGrantsDb` + `SWITCHROOM_AGENTS_DIR` overrides to `server-mint-grant-posture-attest.test.ts` and `server-write-grants.test.ts` — the two suites still hitting production
- Updated the `check-vault-test-hermeticity` lint gate to recognize `SWITCHROOM_AGENTS_DIR` as valid mitigation (it previously only recognized the inert `HOME=` pattern, which meant a correctly-fixed test like `server-grants.test.ts` was falsely flagged) and shrank its allowlist for the now-fixed files
- Updated `client-token.test.ts` assertions to match the #1496 fallthrough behavior (grant-expired/invalid falls through to the standing ACL; only grant-revoked hard-denies) — these were stale assertions predating that change

## Why
Vault & shared-state test discipline is a hard rule in CLAUDE.md precisely because of a prior incident (2026-05-20) in this same class of bug. This closes a second, previously-undetected leak vector (the grants DB itself, not just the agents-dir token files) that the earlier `SWITCHROOM_AGENTS_DIR`-only fixes hadn't fully covered.

## Test plan
- [x] `npm run test:vitest` — 798 test files / 12524 tests passed, 0 failed
- [x] `npm run test:bun` — 1093 pass, 2 skip, 0 fail; confirmed via log-grep that zero writes touched any production path
- [x] `npm run lint` — all 8 guard scripts + tsc clean, including the fixed `check-vault-test-hermeticity` gate
- [x] `npm run build` — clean
- [x] Manually confirmed no production leaks remain: purged the 64 leaked `uat-agent` grant rows from `~/.switchroom/vault-grants.db` (backed up first), left the 2 real `gymbro` grants untouched

## Risk
Low. This only changes path resolution for token/grant files (now honoring an env override that already existed and is used elsewhere in the codebase) and test-only isolation wiring. No production behavior changes when `SWITCHROOM_AGENTS_DIR` is unset (falls back to the same `~/.switchroom/agents` default as before).