### PR TITLE
fix(gateway): defer delivery-machine inbound emit past the intercept gauntlet

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -15484,30 +15484,32 @@ async function handleInbound(
   // network RTT) but not a user-perceived end-to-end measurement.
   const inboundReceivedAt = Date.now()
 
-  // Phase 2b shadow: inbound arrival. Emit BEFORE the snapshot/gate
-  // logic so the machine sees the event at the same point in time the
-  // imperative code would. The machine internally handles fresh-turn
-  // vs mid-turn — its decision will be visible in the gw-trace shadow
-  // line emitted to stderr.
-  const _shadowKey = statusKey(ctx.chat?.id != null ? String(ctx.chat.id) : '0', ctx.message?.message_thread_id) as _ChatKey
-  // PR3b-cutover: snapshot the machine's in-turn state BEFORE the
-  // inbound event advances it. A fresh-turn inbound transitions the
-  // machine idle→in_turn; reading after the emit would see THIS
-  // message's own just-started turn and self-block it (the same
-  // self-block hazard the claudeBusyKeys snapshot below guards). When
-  // the kill-switch is off this is null and the gate uses the legacy
+  // PR3b-cutover: snapshot the machine's in-turn state AT RECEIPT, before
+  // this handler emits the `inbound` event (that emit is DEFERRED below to
+  // the delivery-commit point — search DEFERRED_INBOUND_EMIT). A fresh-turn
+  // inbound transitions the machine idle→in_turn; reading after the emit
+  // would see THIS message's own just-started turn and self-block it (the
+  // same self-block hazard the claudeBusyKeys snapshot below guards). Null
+  // when the kill-switch is off, in which case the gate uses the legacy
   // claudeBusyKeys read.
+  //
+  // WHY THE INBOUND EMIT IS DEFERRED (overlord /usage wedge, 2026-07-08):
+  // the `inbound` event drives the now-AUTHORITATIVE turn-in-flight gate
+  // (turnInFlightForGate → isMachineInTurn). Emitting it HERE — at handler
+  // entry, before the intercept gauntlet below (permission-reply, /auth
+  // paste-back, interrupt-empty, secret-detect drop, …) — drove the machine
+  // into `bridge_alive_in_turn` for messages that then EARLY-RETURN as an
+  // intercept and never become a turn. No delivery, no claudeBusyKeys mark,
+  // and critically no `turnEnd` ever fires, so the machine held the gate
+  // closed until the 5-min TTL tick force-cleared it — buffering every
+  // subsequent inbound (including /usage) the whole time. That is exactly
+  // the dangerous `machine_over_holds` divergence gate-parity-probe.ts
+  // flags. The imperative claudeBusyKeys tracker got it right (never marked
+  // busy for the intercepted message); the machine was mis-fed. Fix: emit
+  // `inbound` only once the message clears every intercept and reaches the
+  // deliver-or-buffer decision, keeping the machine in lockstep with the
+  // imperative delivery lifecycle it models.
   const machineInTurnAtReceipt = isDeliveryCutoverEnabled() ? isMachineInTurn() : null
-  shadowEmit({
-    kind: 'inbound',
-    key: _shadowKey,
-    msg: {
-      msgId: ctx.message?.message_id ?? 0,
-      isSteering: false, // refined in PR 3 — for now shadow conservatively classifies as non-steering
-      payload: null,
-    },
-    at: Date.now(),
-  })
 
   // #1556 self-blocking fix (v0.12.22): snapshot the live turn-state
   // BEFORE the fresh-turn branch (line ~7357) sets activeTurnStartedAt
@@ -16703,6 +16705,29 @@ async function handleInbound(
     }
     return
   }
+
+  // DEFERRED_INBOUND_EMIT — drive the delivery state machine's `inbound`
+  // event HERE, not at handler entry. Every intercept/early-return above
+  // (permission-reply, /auth paste-back, interrupt-empty, secret-detect
+  // drop, drop/pair) has been passed, so any message reaching this point is
+  // a genuine turn the imperative code is about to deliver or buffer. That
+  // keeps the machine's authoritative turn-in-flight state in lockstep with
+  // the imperative delivery it models and can never be advanced into
+  // `bridge_alive_in_turn` by a message that never becomes a turn — the
+  // overlord /usage wedge of 2026-07-08 (see machineInTurnAtReceipt above).
+  // isSteering is now the real classification (computed at ~line 16289), so
+  // the machine correctly distinguishes a mid-turn steer (delivered, no new
+  // turn) from a fresh turn.
+  shadowEmit({
+    kind: 'inbound',
+    key: statusKey(chat_id, messageThreadId) as _ChatKey,
+    msg: {
+      msgId: msgId ?? 0,
+      isSteering,
+      payload: null,
+    },
+    at: Date.now(),
+  })
 
   // PR2 obligation-ledger OPEN — BEFORE the buffer-until-idle / deliver split so
   // a mid-turn cross-topic inbound (the 715 case) is tracked whether it is

--- a/telegram-plugin/tests/inbound-emit-after-intercepts.test.ts
+++ b/telegram-plugin/tests/inbound-emit-after-intercepts.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Structural pin: the delivery state machine's `inbound` event MUST be
+ * emitted from `handleInbound` only AFTER the intercept/early-return
+ * gauntlet — never eagerly at handler entry.
+ *
+ * The wedge this guards (overlord `/usage` went dead, 2026-07-08). The
+ * inbound emit drives the now-AUTHORITATIVE turn-in-flight gate
+ * (turnInFlightForGate → isMachineInTurn). When it fired at handler entry
+ * — before the permission-reply / `/auth` paste-back / interrupt-empty /
+ * secret-detect-drop intercepts — an intercepted message (e.g. an approval
+ * reply) drove the machine idle→`bridge_alive_in_turn`, then early-returned
+ * as an intercept: no delivery, no claudeBusyKeys mark, and critically no
+ * `turnEnd`. The machine held the gate closed until the 5-min TTL tick
+ * force-cleared it, buffering every inbound (including `/usage`) meanwhile —
+ * the dangerous `machine_over_holds` divergence gate-parity-probe.ts flags.
+ *
+ * The behaviour lives inside the un-exported `handleInbound` closure, so —
+ * mirroring the other gateway-*.test.ts source-pins — we assert on source
+ * structure: the single inbound `shadowEmit` must sit below the intercepts
+ * and carry the real `isSteering` classification. Machine self-heal + gate
+ * accessors are behaviour-tested in inbound-delivery-cutover-gate.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const GATEWAY_SRC = readFileSync(resolve(__dirname, '..', 'gateway', 'gateway.ts'), 'utf8')
+
+/** Byte offset of the sole `shadowEmit({ kind: 'inbound' ... })` call. */
+function inboundEmitOffset(): number {
+  const m = GATEWAY_SRC.match(/shadowEmit\(\{\s*\n\s*kind:\s*'inbound'/)
+  expect(m, 'expected exactly one multi-line inbound shadowEmit').not.toBeNull()
+  const idx = GATEWAY_SRC.indexOf(m![0])
+  // There must be only ONE such emit — a second eager site would reintroduce
+  // the wedge.
+  const second = GATEWAY_SRC.indexOf(m![0], idx + 1)
+  expect(second, 'a second inbound shadowEmit would reintroduce the eager-emit wedge').toBe(-1)
+  return idx
+}
+
+describe('gateway: inbound machine-emit is deferred past the intercepts', () => {
+  it('carries the DEFERRED_INBOUND_EMIT marker so the intent is greppable', () => {
+    expect(GATEWAY_SRC).toContain('DEFERRED_INBOUND_EMIT')
+  })
+
+  it('emits the machine `inbound` event AFTER the permission-reply intercept', () => {
+    const emitIdx = inboundEmitOffset()
+    // The permission-reply intercept is one of the early-return paths that
+    // must NOT drive the machine into a turn.
+    const permIdx = GATEWAY_SRC.indexOf('const permMatch = PERMISSION_REPLY_RE.exec(text)')
+    expect(permIdx).toBeGreaterThan(0)
+    expect(emitIdx).toBeGreaterThan(permIdx)
+  })
+
+  it('emits AFTER the `/auth add` paste-back intercept', () => {
+    const emitIdx = inboundEmitOffset()
+    const authIdx = GATEWAY_SRC.indexOf('pendingAuthAddFlows.get(interceptKey)')
+    expect(authIdx).toBeGreaterThan(0)
+    expect(emitIdx).toBeGreaterThan(authIdx)
+  })
+
+  it('emits AFTER isSteering is classified, and passes the real value (not a hardcoded false)', () => {
+    const emitIdx = inboundEmitOffset()
+    const steerIdx = GATEWAY_SRC.indexOf('isSteering = priorTurnInFlight && isSteerPrefix')
+    expect(steerIdx).toBeGreaterThan(0)
+    expect(emitIdx).toBeGreaterThan(steerIdx)
+    // The emit's msg object must forward the live `isSteering` binding, so a
+    // mid-turn steer is not mis-modelled as a fresh turn.
+    const win = GATEWAY_SRC.slice(emitIdx, emitIdx + 260)
+    expect(win).toMatch(/msg:\s*\{[\s\S]*?\bisSteering,[\s\S]*?\}/)
+  })
+
+  it('emits BEFORE the deliver-or-buffer decision (reserveInboundDelivery)', () => {
+    const emitIdx = inboundEmitOffset()
+    const gateIdx = GATEWAY_SRC.indexOf('const deliveryGate = reserveInboundDelivery({')
+    expect(gateIdx).toBeGreaterThan(0)
+    expect(emitIdx).toBeLessThan(gateIdx)
+  })
+})


### PR DESCRIPTION
## Summary
`handleInbound` fired `shadowEmit({kind:'inbound'})` **eagerly at handler entry**, before the intercept/early-return paths (permission-reply, `/auth` paste-back, interrupt-empty, secret-detect drop, drop/pair). Since the delivery state machine is now **authoritative** for the turn-in-flight gate (`turnInFlightForGate` → `isMachineInTurn`), an intercepted message drove the machine `idle → bridge_alive_in_turn` and then early-returned without ever delivering a turn: no `claudeBusyKeys` mark, and critically **no `turnEnd`**. The machine held the gate closed until the 5-min `TURN_TTL_MS` tick force-cleared it, buffering every subsequent inbound meanwhile.

The fix moves the machine's `inbound` emit to the **delivery-commit point** (after every intercept, before the deliver-or-buffer decision) and passes the real `isSteering` classification. The machine can no longer be advanced into a turn by a message that never becomes one — keeping it in lockstep with the imperative `claudeBusyKeys` tracker it models. The at-receipt snapshot stays at handler entry.

## Why
Live incident: **overlord's `/usage` (and all inbound) went dead for ~5.5 min on 2026-07-08.** The gateway log shows the exact `machine_over_holds` divergence `gate-parity-probe.ts` was built to flag:
```
gw-trace gate-drift kind=machine_over_holds machineInTurn=true busyKeys=0
```
repeating from msg 5906 (an intercepted approval reply) until the TTL tick at 12:26:45 cleared it. This is a **new wedge class the cutover introduced**; the imperative `claudeBusyKeys` tracker was correct throughout (never marked busy for the intercepted message).

## Test plan
- **New** `telegram-plugin/tests/inbound-emit-after-intercepts.test.ts` (5 tests): the sole inbound emit sits below the permission-reply and `/auth` intercepts, above `reserveInboundDelivery`, and forwards the live `isSteering` binding. Fails on the pre-fix layout.
- vitest across the delivery/gate suites (cutover-gate, gate-parity-probe, inbound-delivery-machine + dispatch, inbound-delivery-gate, parallel-turns-deadlock-fix, pending-inbound-buffer, serialize-drain-gate, rapid-fire ordering, delivery-confirm, vault-resume-turn) → **192 passing**.
- `tsc --noEmit` clean; all 8 lint guards pass.

## Risk
Low. Emit relocation only; imperative delivery path unchanged. Kill switch `SWITCHROOM_DELIVERY_MACHINE_CUTOVER=0` still reverts to legacy `claudeBusyKeys`. Interrupt/steer paths verified no-op on machine global state at the new site.

**Job spec:** `reference/jobs/talk-to-agents-from-anywhere.md` — inbound must actually reach the agent and get a reply, not silently buffer for minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)