### PR TITLE
fix(telegram): keep post-answer liveness card climbing during sub-agent delegation

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -13044,11 +13044,19 @@ function feedHeartbeatTick(): void {
     //               durable record once it completes.
     //   - 'emit'  → genuine in-flight post-answer activity; render the card below.
     const subagentAt = turn.subagentActivityAt
+    // Fix 3 (sub-agent-delegation freeze): a foreground `Task`/`Agent` still
+    // tracked in `turn.foregroundSubAgents` is POSITIVE evidence the worker
+    // has not reported finished — see the doc comment on
+    // `PostAnswerLivenessInput.stillDispatched` in turn-liveness-floor.ts for
+    // why this must bypass the staleness cap rather than let a single long
+    // silent step freeze the card mid-delegation.
+    const stillDispatched = turn.foregroundSubAgents.size > 0
     const livenessVerdict = evaluatePostAnswerLiveness({
       subagentActivityAt: subagentAt,
       finalAnswerDeliveredAt: turn.finalAnswerDeliveredAt,
       now: Date.now(),
       staleCapMs: POST_ANSWER_LIVENESS_STALE_MS,
+      stillDispatched,
     })
     if (livenessVerdict !== 'emit' || subagentAt == null) return // idle gap or stale worker → stay silent (the `== null` also narrows subagentAt for the elapsed below)
     // A background worker is genuinely active after the answer. Open or maintain

--- a/telegram-plugin/tests/claude-code-event-contract.test.ts
+++ b/telegram-plugin/tests/claude-code-event-contract.test.ts
@@ -137,6 +137,54 @@ describe('Claude Code event-stream contract (canary)', () => {
     ).toBe(false)
   })
 
+  it('CANARY (Fix 3 precondition): Task tool_use still projects {id, name, input} — the shape the foreground-sub-agent-tracking / post-answer-liveness-freeze fix keys "still dispatched" off of', () => {
+    // The Fix 3 gap-closer (turn-liveness-floor.ts `stillDispatched`) is only
+    // as good as `turn.foregroundSubAgents` staying populated for the
+    // lifetime of a real Task dispatch. That population is driven by THIS
+    // exact tool_use projection (toolName === 'Task') plus the matching
+    // tool_result closing it out — if a future Claude Code release renames
+    // `name`/`input`/`id` or nests them differently, the fix silently goes
+    // inert (stillDispatched always false, freeze regresses) rather than
+    // failing loudly. Pin the shape here so drift fails CI instead.
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg_task',
+        stop_reason: 'tool_use',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_task_1',
+            name: 'Task',
+            input: { description: 'Investigate the freeze bug', subagent_type: 'worker' },
+          },
+        ],
+      },
+    })
+    const evs = projectTranscriptLine(line)
+    expect(evs).toEqual([
+      {
+        kind: 'tool_use',
+        toolName: 'Task',
+        toolUseId: 'toolu_task_1',
+        input: { description: 'Investigate the freeze bug', subagent_type: 'worker' },
+      },
+    ])
+    // The matching tool_result (Task returning) must still carry tool_use_id
+    // so the gateway can close out the foreground-sub-agent tracking entry.
+    const resultLine = JSON.stringify({
+      type: 'user',
+      message: { content: [{ type: 'tool_result', tool_use_id: 'toolu_task_1', is_error: false, content: 'done' }] },
+    })
+    const resultEvs = projectTranscriptLine(resultLine)
+    expect(resultEvs).toHaveLength(1)
+    // `is_error: false` projects to `isError: undefined` (only `true` is
+    // ever stamped — see session-tail.ts's `c.is_error === true ? true :
+    // undefined`), so assert the falsy/absent form, not a literal `false`.
+    expect(resultEvs[0]).toMatchObject({ kind: 'tool_result', toolUseId: 'toolu_task_1' })
+    expect((resultEvs[0] as { isError?: boolean }).isError).toBeFalsy()
+  })
+
   it('sub-agent kickoff: first user message string prompt fires sub_agent_started', () => {
     const st = { hasEmittedStart: false }
     const line = JSON.stringify({

--- a/telegram-plugin/tests/feed-heartbeat-liveness-open.test.ts
+++ b/telegram-plugin/tests/feed-heartbeat-liveness-open.test.ts
@@ -153,6 +153,17 @@ describe('H-2: feedHeartbeatTick post-answer background-agent liveness (Fix 2 / 
     expect(postAnswerBlock).toMatch(/livenessVerdict\s*!==\s*'emit'/)
   })
 
+  it('Fix 3: post-answer branch feeds stillDispatched from turn.foregroundSubAgents so a tracked foreground sub-agent bypasses the staleness cap', () => {
+    const body = feedHeartbeatTickSrc()
+    const afterPostAnswer = body.split('if (turn.finalAnswerDelivered)')[1] ?? ''
+    const postAnswerBlock = afterPostAnswer.split('\n  }\n')[0] ?? ''
+    // A positive foreground-tracking signal must be computed and threaded
+    // into the pure decision — this is what stops the card freezing mid-
+    // delegation while a foreground Task/Agent is still outstanding.
+    expect(postAnswerBlock).toMatch(/stillDispatched\s*=\s*turn\.foregroundSubAgents\.size\s*>\s*0/)
+    expect(postAnswerBlock).toMatch(/stillDispatched,/)
+  })
+
   it('staleness cap (concern 3) is parsed default-ON (30s) from SWITCHROOM_POST_ANSWER_LIVENESS_STALE_MS', () => {
     // The cap const must default to 30_000 when the env is unset (the `|| 30_000`
     // fallback over the positive-or-0 parse) so the post-answer card stops

--- a/telegram-plugin/tests/telegram-activity-visibility-integration.test.ts
+++ b/telegram-plugin/tests/telegram-activity-visibility-integration.test.ts
@@ -40,7 +40,12 @@ import { describe, it, expect } from 'vitest'
 import * as realFs from 'fs'
 import { startSubagentWatcher } from '../subagent-watcher.js'
 import { mayOpenActivityCard } from '../gateway/feed-open-gate.js'
-import { clipNarrative, appendActivityLabel } from '../tool-activity-summary.js'
+import {
+  clipNarrative,
+  appendActivityLabel,
+  renderActivityFeedWithNested,
+  formatStepSuffix,
+} from '../tool-activity-summary.js'
 import { evaluatePostAnswerLiveness } from '../turn-liveness-floor.js'
 import {
   createWorkerActivityFeed,
@@ -249,6 +254,7 @@ describe('Fix 2: post-answer background-agent liveness (watcher → gate → liv
       finalAnswerDeliveredAt: currentTurn!.finalAnswerDeliveredAt,
       now: currentTime + 5, // a heartbeat tick moments after the stamp
       staleCapMs: 30_000,
+      stillDispatched: false,
     })
     expect(verdictInWindow).toBe('emit')
   })
@@ -262,6 +268,7 @@ describe('Fix 2: post-answer background-agent liveness (watcher → gate → liv
       finalAnswerDeliveredAt: 1000,
       now: 50_000,
       staleCapMs: 30_000,
+      stillDispatched: false,
     })
     expect(verdict).toBe('idle')
   })
@@ -273,6 +280,7 @@ describe('Fix 2: post-answer background-agent liveness (watcher → gate → liv
         finalAnswerDeliveredAt: 1000,
         now: 1500,
         staleCapMs: 30_000,
+        stillDispatched: false,
       }),
     ).toBe('idle')
   })
@@ -310,9 +318,14 @@ describe('Fix 2 / concern 2: currentTurn nulls at turn_end → heartbeat path in
 
   // The gateway's feedHeartbeatTick post-answer entry, reduced to its decision:
   // `if (turn == null) return` (no-turn), else the REAL evaluatePostAnswerLiveness.
+  // `stillDispatched` defaults to false (a purely-background worker, no
+  // foreground `turn.foregroundSubAgents` tracking) so these existing tests
+  // keep proving the ORIGINAL staleness-cap behaviour is preserved for that
+  // case; a dedicated Fix-3 describe block below covers `stillDispatched: true`.
   function heartbeatVerdict(
     currentTurn: { finalAnswerDelivered: boolean; finalAnswerDeliveredAt?: number; subagentActivityAt?: number } | null,
     now: number,
+    stillDispatched = false,
   ): 'no-turn' | 'pre-answer' | ReturnType<typeof evaluatePostAnswerLiveness> {
     const turn = currentTurn
     if (turn == null) return 'no-turn' // gateway: `if (turn == null) return`
@@ -322,6 +335,7 @@ describe('Fix 2 / concern 2: currentTurn nulls at turn_end → heartbeat path in
       finalAnswerDeliveredAt: turn.finalAnswerDeliveredAt,
       now,
       staleCapMs: 30_000,
+      stillDispatched,
     })
   }
 
@@ -374,6 +388,146 @@ describe('Fix 2 / concern 2: currentTurn nulls at turn_end → heartbeat path in
     // and the card stops climbing `running` forever (the concern-3 bug).
     expect(heartbeatVerdict(currentTurn, 2000 + 30_000)).toBe('stale')
     expect(heartbeatVerdict(currentTurn, 2000 + 90_000)).toBe('stale')
+  })
+})
+
+// ─── Fix 3 — sub-agent-delegation freeze (operator-confirmed: card frozen on
+//     "Running a command" for 41s / 3m12s while a sub-agent ran underneath) ──
+
+describe('Fix 3: a still-tracked foreground sub-agent bypasses the staleness cap (no mid-delegation freeze)', () => {
+  /**
+   * Reproduces the EXACT scenario the operator's 3 screenshots showed: a
+   * foreground `Task`/`Agent` dispatch is still outstanding (one long silent
+   * step — no new watcher narrative tick), so `subagentActivityAt` stops
+   * advancing, yet the worker has NOT reported finished. Before Fix 3 the
+   * staleness cap could not tell this apart from genuine completion and froze
+   * the card after 30s regardless. `stillDispatched: true` — sourced from
+   * `turn.foregroundSubAgents.size > 0` at the real call site — is the
+   * positive signal that closes the gap.
+   */
+
+  // Local copy of the gateway's post-answer decision (same as the "Fix 2 /
+  // concern 2" describe block above — duplicated here rather than hoisted to
+  // module scope so each describe stays self-contained/readable).
+  function heartbeatVerdict(
+    currentTurn: { finalAnswerDelivered: boolean; finalAnswerDeliveredAt?: number; subagentActivityAt?: number } | null,
+    now: number,
+    stillDispatched = false,
+  ): 'no-turn' | 'pre-answer' | ReturnType<typeof evaluatePostAnswerLiveness> {
+    const turn = currentTurn
+    if (turn == null) return 'no-turn'
+    if (!turn.finalAnswerDelivered) return 'pre-answer'
+    return evaluatePostAnswerLiveness({
+      subagentActivityAt: turn.subagentActivityAt,
+      finalAnswerDeliveredAt: turn.finalAnswerDeliveredAt,
+      now,
+      staleCapMs: 30_000,
+      stillDispatched,
+    })
+  }
+
+  it('long silent single step (41s, no new narrative) — bypasses the cap while still dispatched', () => {
+    const turn = {
+      finalAnswerDelivered: true,
+      finalAnswerDeliveredAt: 1000,
+      subagentActivityAt: 2000 as number | undefined,
+    }
+    const currentTurn: typeof turn | null = turn
+    // 41s after the last (and only) narrative advance — well past the 30s cap.
+    // Legacy (stillDispatched: false) behaviour would already be 'stale' here
+    // (proven by the concern-3 test above); with a tracked foreground worker
+    // it must stay 'emit' so the card keeps climbing instead of freezing.
+    expect(heartbeatVerdict(currentTurn, 2000 + 41_000, /* stillDispatched */ true)).toBe('emit')
+  })
+
+  it('long silent single step (3m12s) — still bypasses the cap while still dispatched', () => {
+    const turn = {
+      finalAnswerDelivered: true,
+      finalAnswerDeliveredAt: 1000,
+      subagentActivityAt: 2000 as number | undefined,
+    }
+    const currentTurn: typeof turn | null = turn
+    const threeMinTwelveSecMs = 3 * 60_000 + 12_000
+    expect(heartbeatVerdict(currentTurn, 2000 + threeMinTwelveSecMs, true)).toBe('emit')
+  })
+
+  it('once the foreground sub-agent is no longer tracked (finished), the cap re-applies normally', () => {
+    // The gateway removes the agentId from `turn.foregroundSubAgents` when it
+    // finishes (gateway.ts ~27032/27037) — `stillDispatched` then reads false
+    // again and the ORIGINAL runaway-climb protection re-engages exactly as
+    // before Fix 3. This is the adversarial check that Fix 3 doesn't remove
+    // the cap's protection outright, only bypasses it while genuinely unknown.
+    const turn = {
+      finalAnswerDelivered: true,
+      finalAnswerDeliveredAt: 1000,
+      subagentActivityAt: 2000 as number | undefined,
+    }
+    const currentTurn: typeof turn | null = turn
+    expect(heartbeatVerdict(currentTurn, 2000 + 41_000, false)).toBe('stale')
+  })
+
+  it('idle-gap suppression still wins over stillDispatched (no watcher activity ever ⇒ silent, reply-is-last preserved)', () => {
+    // Adversarial check: a turn that dispatched a foreground sub-agent but has
+    // had NO watcher tick at all since the answer (subagentActivityAt
+    // undefined) must stay 'idle', never 'emit', even if stillDispatched is
+    // true — a still-registered worker with zero ticks yet is not the same as
+    // one whose last tick went stale. This preserves the reply-is-last
+    // invariant for a turn that answered and dispatched but hasn't surfaced
+    // any post-answer step yet.
+    const turn = {
+      finalAnswerDelivered: true,
+      finalAnswerDeliveredAt: 1000,
+      subagentActivityAt: undefined as number | undefined,
+    }
+    const currentTurn: typeof turn | null = turn
+    expect(heartbeatVerdict(currentTurn, 50_000, true)).toBe('idle')
+  })
+
+  it('end-to-end: the RENDERED card text keeps changing across real heartbeat ticks while a foreground sub-agent is silently working (not just the verdict function)', () => {
+    // Full simulated turn: dispatch a foreground Task, one narrative tick
+    // lands, then NOTHING further for over three minutes (one long silent
+    // Bash inside the sub-agent) — the exact operator-reported shape. Drives
+    // the REAL `evaluatePostAnswerLiveness` verdict AND the REAL
+    // `renderActivityFeedWithNested`/`composeTurnActivity`-shaped render at
+    // each tick, asserting the VISIBLE text (not an internal label) actually
+    // climbs instead of freezing.
+    const turn = {
+      finalAnswerDelivered: true,
+      finalAnswerDeliveredAt: 1_000,
+      subagentActivityAt: 2_000 as number | undefined,
+      mirrorLines: ['Delegating to a sub-agent'],
+      foregroundSubAgents: new Map<string, string[]>([['agent-1', ['Running a command']]]),
+    }
+
+    function renderCardAt(now: number): string | null {
+      const verdict = evaluatePostAnswerLiveness({
+        subagentActivityAt: turn.subagentActivityAt,
+        finalAnswerDeliveredAt: turn.finalAnswerDeliveredAt,
+        now,
+        staleCapMs: 30_000,
+        stillDispatched: turn.foregroundSubAgents.size > 0,
+      })
+      if (verdict !== 'emit') return null // the pre-Fix-3 freeze point
+      const childLines = [...turn.foregroundSubAgents.values()].flat()
+      const header = { label: 'Agent', elapsedMs: now - 0, toolCount: 1, state: 'running' as const }
+      return renderActivityFeedWithNested(turn.mirrorLines, childLines, false, formatStepSuffix(now - turn.subagentActivityAt!), undefined, header)
+    }
+
+    const tick1 = renderCardAt(2_000 + 6_000) // 6s after the last tick
+    const tick2 = renderCardAt(2_000 + 41_000) // 41s — the first operator-reported freeze point
+    const tick3 = renderCardAt(2_000 + (3 * 60_000 + 12_000)) // 3m12s — the second
+
+    expect(tick1).not.toBeNull()
+    expect(tick2).not.toBeNull()
+    expect(tick3).not.toBeNull()
+    // The visible text must actually differ tick-over-tick (climbing elapsed),
+    // not be frozen at the same string for minutes.
+    expect(tick2).not.toBe(tick1)
+    expect(tick3).not.toBe(tick2)
+    // And it must contain the growing wall-clock evidence the operator was
+    // missing — a live elapsed suffix on the nested step.
+    expect(tick2).toContain('41s')
+    expect(tick3).toContain('3m12s')
   })
 })
 

--- a/telegram-plugin/turn-liveness-floor.ts
+++ b/telegram-plugin/turn-liveness-floor.ts
@@ -227,13 +227,47 @@ export interface PostAnswerLivenessInput {
   now: number
   /** Staleness cap in ms; `<= 0` disables the cap. */
   staleCapMs: number
+  /**
+   * A POSITIVE, independent signal that a sub-agent dispatch is still known to
+   * be outstanding (e.g. `turn.foregroundSubAgents.size > 0` — a foreground
+   * `Task`/`Agent` this turn dispatched and has not yet reported finished).
+   *
+   * ## The gap this closes
+   *
+   * The staleness cap above was built to stop the card climbing FOREVER once
+   * a worker's `onFinish` froze `subagentActivityAt` and nothing further would
+   * ever arrive — but the ONLY signal it read (`now - subagentActivityAt`) is
+   * identical whether the worker (a) actually finished, or (b) is still
+   * genuinely running a SINGLE long silent step (one long Bash call, a slow
+   * fetch) that simply hasn't produced a NEW distinguishable watcher tick.
+   * Case (b) is exactly the scenario `feed-heartbeat-climb.ts`'s 0-label climb
+   * and `worker-activity-feed.ts`'s own heartbeat both exist to handle
+   * deterministically elsewhere — this post-answer branch alone lacked that
+   * fallback, so it froze the card mid-delegation (the confirmed operator
+   * symptom: "Running a command" stuck for 41s / 3m12s while a sub-agent ran
+   * underneath).
+   *
+   * When `stillDispatched` is `true` we have POSITIVE evidence the worker has
+   * not reported completion, so the staleness cap is bypassed entirely and the
+   * verdict stays `'emit'` — the caller keeps climbing the card deterministically
+   * off wall-clock elapsed exactly like the sibling 0-label/worker-feed paths.
+   * When `false` (no such tracking available — e.g. a purely-background worker
+   * with no foreground registration), the ORIGINAL cap behaviour is preserved
+   * unchanged, so the runaway-climb-after-completion protection this cap was
+   * built for still applies wherever we have no better signal.
+   */
+  stillDispatched: boolean
 }
 
 export function evaluatePostAnswerLiveness(input: PostAnswerLivenessInput): PostAnswerLivenessVerdict {
-  const { subagentActivityAt, finalAnswerDeliveredAt, now, staleCapMs } = input
+  const { subagentActivityAt, finalAnswerDeliveredAt, now, staleCapMs, stillDispatched } = input
   const answeredAt = finalAnswerDeliveredAt ?? 0
   // idle-gap: nothing surfaced after the answer → silent (reply-is-last preserved).
   if (subagentActivityAt == null || subagentActivityAt <= answeredAt) return 'idle'
+  // A positive "still dispatched" signal overrides the staleness cap — we KNOW
+  // the worker hasn't reported done, so a quiet stretch is a long silent step,
+  // not completion. Never freeze the card while that's true.
+  if (stillDispatched) return 'emit'
   // staleness cap: the worker's last advance is older than the cap → stop emitting.
   if (staleCapMs > 0 && now - subagentActivityAt >= staleCapMs) return 'stale'
   return 'emit'


### PR DESCRIPTION
## Summary
- Progress card froze mid-turn (41s / 3m12s observed) while a foreground sub-agent was still working, because `evaluatePostAnswerLiveness` had one signal — elapsed time vs. a hardcoded 30s cap — with no way to tell "sub-agent finished" from "sub-agent silently mid-step."
- Adds a `stillDispatched` input sourced from `turn.foregroundSubAgents.size > 0` (pre-existing lifecycle map) that bypasses the cap only while genuinely still dispatched; cap re-engages normally once the sub-agent completes.
- Background workers (`worker-activity-feed.ts`) were unaffected — separate, already-correct clock-driven heartbeat.

## Test plan
- [x] New end-to-end render test asserts the actual card text at the reported 41s/3m12s marks (not just the verdict function)
- [x] Cap re-engages on sub-agent finish; idle-gap suppression still wins
- [x] `claude-code-event-contract.test.ts` canary hardened to fail loudly on future Claude Code JSONL shape drift
- [x] Targeted files 37/37 passing; full suite has only pre-existing unrelated failures (live-Telegram MTProto integration, sandbox network flakiness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)