### PR TITLE
fix(gateway): survive model thinking pauses in the orphaned-reply watchdog

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -428,6 +428,21 @@ agents:
         sub_agent_tick_interval_ms: 15000
 ```
 
+### Advanced env: orphaned-reply liveness window
+
+`SWITCHROOM_ORPHANED_REPLY_STREAM_WINDOW_MS` (default `120000` = 2 min) is an
+env-only advanced override on the gateway's orphaned-reply backstop. The
+backstop force-ends a turn that has captured assistant text but never called
+`reply`; its 30 s fuse used to be reset only by `tool_label` / `text` stream
+events, so a long model reasoning pause (which emits neither) could force-end a
+genuinely-live turn mid-work. The gateway now stamps a per-turn liveness marker
+on *any* genuine stream event; if one landed within this window the fuse re-arms
+instead of firing. Raise it to make longer reasoning pauses survivable at the
+cost of slower detection of a genuine hang; lower it to catch a wedged turn
+sooner at the risk of clipping a long think. Most operators never touch this —
+the default is tuned for real production reasoning pauses. Set as a plugin
+environment variable, not a `switchroom.yaml` field.
+
 ## Profiles
 
 Profiles are named partial configs that agents inherit from via `extends: <name>`. They can be defined in two places:

--- a/telegram-plugin/context-exhaustion.ts
+++ b/telegram-plugin/context-exhaustion.ts
@@ -48,3 +48,127 @@ export function shouldArmOrphanedReplyTimeout(params: {
     !params.progressCardActive
   )
 }
+
+/**
+ * Default "recently streaming" window (ms) for the orphaned-reply liveness
+ * stamp. The gateway overrides this from
+ * SWITCHROOM_ORPHANED_REPLY_STREAM_WINDOW_MS; this constant is the fallback and
+ * the value the LivenessTracker tests pin against.
+ */
+export const ORPHANED_REPLY_STREAM_WINDOW_MS = 120_000
+
+/**
+ * Result of a fuse-expiry decision.
+ *
+ *  - `rearm`           — re-arm the fuse (keep the turn alive) instead of
+ *                        firing the synthetic turn_end backstop.
+ *  - `countsAgainstCap`— this rearm (or the fire it turned into at the cap) was
+ *                        a working/recently-streaming rearm, i.e. subject to the
+ *                        ORPHANED_REPLY_MAX_REARMS cap. Human-wait rearms are
+ *                        uncapped and report `false` here.
+ */
+export interface OrphanedReplyExpiryDecision {
+  rearm: boolean
+  countsAgainstCap: boolean
+}
+
+/**
+ * Per-turn liveness tracker for the orphaned-reply backstop.
+ *
+ * WHY THIS EXISTS (the thinking-pause fix):
+ *   The orphaned-reply fuse (ORPHANED_REPLY_TIMEOUT_MS = 30 s) used to be reset
+ *   ONLY by `tool_label` and `text` stream events. During a long model
+ *   reasoning pause the gateway sees NO such events (thinking events carry no
+ *   text), so the fuse ran down and force-ended a genuinely-live turn mid-work
+ *   ("orphaned-reply timeout (30000ms) — forcing backstop" ~1 ms before
+ *   turn_end, with minutes of real work still to come).
+ *
+ * THE FIX:
+ *   Stamp `lastStreamEventAt` on ANY genuine stream event (via onStreamEvent,
+ *   called from the gateway dispatcher entry). If a genuine event arrived
+ *   within `windowMs` (default 120 s) the turn is "recently streaming" and the
+ *   fuse re-arms instead of firing — a reasoning pause is survivable while a
+ *   genuine multi-minute hang (no events at all) still fires.
+ *
+ * This is a small, pure, side-effect-free seam so the decision logic is unit
+ * testable without the full gateway. The gateway holds one instance per
+ * CurrentTurn (so per-turn identity / supersession semantics are unchanged) and
+ * delegates: the dispatcher calls onStreamEvent; the fire callback calls
+ * decideOnExpiry; the defensive turn_end guard reads recentlyStreaming.
+ */
+export class LivenessTracker {
+  /** Wall-clock (ms) of the last genuine stream event for this turn. */
+  lastStreamEventAt: number
+  /**
+   * How many times the fuse re-armed on a working / recently-streaming
+   * expiry. Bounded by ORPHANED_REPLY_MAX_REARMS. Zeroed by onStreamEvent
+   * whenever a genuine stream event lands, so the cap only bites CONSECUTIVE
+   * silent expiries (a genuinely wedged single tool with no stream at all).
+   */
+  orphanedReplyRearmCount = 0
+
+  constructor(startedAt: number) {
+    this.lastStreamEventAt = startedAt
+  }
+
+  /**
+   * Stamp liveness for a genuine stream event and reset the rearm counter.
+   *
+   * F4 predicate: everything EXCEPT the synthetic `turn_end` re-entry
+   * (durationMs === -1, the fire callback's own re-dispatch) counts as a
+   * genuine stream event. Stamping a REAL turn_end (durationMs >= 0) is
+   * harmless — the turn is ending anyway.
+   *
+   * The counter reset lives HERE (driven by the dispatcher), NOT in the fuse
+   * re-arm path — otherwise every rearm would zero its own counter and nullify
+   * the 20-cap.
+   */
+  onStreamEvent(kind: string, durationMs: number | undefined, now: number): void {
+    if (kind === 'turn_end' && durationMs === -1) return
+    this.lastStreamEventAt = now
+    this.orphanedReplyRearmCount = 0
+  }
+
+  /** True iff a genuine stream event landed within `windowMs` of `now`. */
+  recentlyStreaming(now: number, windowMs: number): boolean {
+    return now - this.lastStreamEventAt < windowMs
+  }
+
+  /**
+   * Decide what to do when the orphaned-reply fuse expires.
+   *
+   * Rearm when the turn is working OR recently streaming OR a human is being
+   * waited on. Working / recently-streaming rearms count against `maxRearms`
+   * (so a genuinely wedged single tool that never streams still surfaces after
+   * the cap). Human-wait rearms are uncapped (the human simply hasn't tapped
+   * yet). Once the cap is hit with nothing else keeping the turn alive, fire
+   * (rearm:false) — matching the existing fail-safe.
+   *
+   * Mutates `orphanedReplyRearmCount` on each rearm.
+   */
+  decideOnExpiry(opts: {
+    working: boolean
+    humanWaiting: boolean
+    now: number
+    windowMs: number
+    maxRearms: number
+  }): OrphanedReplyExpiryDecision {
+    // Human-wait rearms are uncapped (unchanged from prior behaviour).
+    if (opts.humanWaiting) {
+      this.orphanedReplyRearmCount++
+      return { rearm: true, countsAgainstCap: false }
+    }
+    const recently = this.recentlyStreaming(opts.now, opts.windowMs)
+    if (opts.working || recently) {
+      if (this.orphanedReplyRearmCount < opts.maxRearms) {
+        this.orphanedReplyRearmCount++
+        return { rearm: true, countsAgainstCap: true }
+      }
+      // Cap reached with only working/recently-streaming keeping it alive:
+      // fire to surface the wedge.
+      return { rearm: false, countsAgainstCap: true }
+    }
+    // Nothing keeping the turn alive → fire (fail-safe).
+    return { rearm: false, countsAgainstCap: false }
+  }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -294,6 +294,7 @@ import {
   shouldArmOrphanedReplyTimeout,
   ORPHANED_REPLY_TIMEOUT_MS,
   ORPHANED_REPLY_MAX_REARMS,
+  LivenessTracker,
 } from '../context-exhaustion.js'
 import {
   decideTurnFlush,
@@ -2371,13 +2372,15 @@ type CurrentTurn = {
   silentAnchorText: string
   capturedText: string[]
   orphanedReplyTimeoutId: ReturnType<typeof setTimeout> | null
-  // How many times the orphaned-reply backstop timer has been re-armed
-  // mid-tool-call instead of firing a synthetic turn_end. Bounded so a
-  // genuinely wedged single long-running tool still surfaces: the cap is
-  // ORPHANED_REPLY_MAX_REARMS (20 × 30 s = 10 min of genuine tool activity).
-  // Reset to 0 on a fresh enqueue; NOT reset on text/tool_label re-arms —
-  // only a new turn resets the budget.
-  orphanedReplyRearmCount: number
+  // Per-turn liveness tracker for the orphaned-reply backstop. Owns
+  // `lastStreamEventAt` (stamped on ANY genuine stream event so a model
+  // reasoning pause keeps the turn "recently streaming" and re-arms the fuse
+  // instead of firing) and the rearm counter (bounded by
+  // ORPHANED_REPLY_MAX_REARMS so a genuinely wedged single tool that never
+  // streams still surfaces after the cap). The counter is zeroed on every
+  // genuine stream event, so the cap only bites CONSECUTIVE silent expiries.
+  // Fresh instance per enqueue (below). See context-exhaustion.ts.
+  liveness: LivenessTracker
   // Component 3 (turn-origin reply routing). A stable per-turn identity,
   // `${registryKey-or-chatKey}#${startedAt}`, assigned when the turn
   // starts and stamped into the inbound meta (`origin_turn_id`) so a reply
@@ -6740,6 +6743,11 @@ function parsePositiveMsEnv(name: string, fallbackMs: number): number {
   const n = Number(raw)
   return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallbackMs
 }
+// Orphaned-reply "recently streaming" window (thinking-pause fix). If a genuine
+// stream event landed within this window, the fuse re-arms instead of firing —
+// so a long model reasoning pause (which emits no text/tool events) is
+// survivable while a genuine multi-minute hang still surfaces. Default 120 s.
+const ORPHANED_REPLY_STREAM_WINDOW_MS = parsePositiveMsEnv('SWITCHROOM_ORPHANED_REPLY_STREAM_WINDOW_MS', 120_000)
 const SILENCE_FALLBACK_MS = parsePositiveMsEnv('SWITCHROOM_SILENCE_FALLBACK_MS', 300_000)
 const SILENCE_FALLBACK_HARD_MS = parsePositiveMsEnv('SWITCHROOM_SILENCE_FALLBACK_HARD_MS', 900_000)
 // #2527 — mid-turn liveness floor threshold (default 45s). Still gates the
@@ -12555,20 +12563,32 @@ function resetOrphanedReplyTimeout(): void {
           }
           return false
         })()
-        if (working || humanWaiting) {
-          const underCap = t.orphanedReplyRearmCount < ORPHANED_REPLY_MAX_REARMS
-          if (humanWaiting || underCap) {
-            t.orphanedReplyRearmCount++
-            process.stderr.write(
-              `telegram gateway: orphaned-reply fuse expired — re-arming` +
-              ` (rearm ${t.orphanedReplyRearmCount}/${ORPHANED_REPLY_MAX_REARMS},` +
-              ` in_flight=${toolFlightTracker.inFlightCount()},` +
-              ` human_wait=${humanWaiting},` +
-              ` bg_work=${pendingProgress.hasPendingAsyncDispatch(turnKey)})\n`,
-            )
-            resetOrphanedReplyTimeout()
-            return
-          }
+        // Route the rearm decision through the per-turn LivenessTracker. It
+        // rearms when working OR recently-streaming (thinking-pause survival)
+        // OR human-waiting; working/recently-streaming rearms count against
+        // ORPHANED_REPLY_MAX_REARMS while human-wait rearms stay uncapped.
+        const now = Date.now()
+        const recentlyStreaming = t.liveness.recentlyStreaming(now, ORPHANED_REPLY_STREAM_WINDOW_MS)
+        const decision = t.liveness.decideOnExpiry({
+          working,
+          humanWaiting,
+          now,
+          windowMs: ORPHANED_REPLY_STREAM_WINDOW_MS,
+          maxRearms: ORPHANED_REPLY_MAX_REARMS,
+        })
+        if (decision.rearm) {
+          process.stderr.write(
+            `telegram gateway: orphaned-reply fuse expired — re-arming` +
+            ` (rearm ${t.liveness.orphanedReplyRearmCount}/${ORPHANED_REPLY_MAX_REARMS},` +
+            ` in_flight=${toolFlightTracker.inFlightCount()},` +
+            ` human_wait=${humanWaiting},` +
+            ` recently_streaming=${recentlyStreaming},` +
+            ` bg_work=${pendingProgress.hasPendingAsyncDispatch(turnKey)})\n`,
+          )
+          resetOrphanedReplyTimeout()
+          return
+        }
+        if (decision.countsAgainstCap) {
           process.stderr.write(
             `telegram gateway: orphaned-reply rearm cap reached (${ORPHANED_REPLY_MAX_REARMS}) — forcing backstop despite working state\n`,
           )
@@ -13430,6 +13450,22 @@ function surfaceConsolidationLegibility(
 }
 
 function handleSessionEvent(ev: SessionEvent): void {
+  // Per-turn liveness stamp (orphaned-reply thinking-pause fix). Stamp
+  // lastStreamEventAt AND reset the rearm counter on ANY genuine stream event,
+  // under ONE shared predicate: a live turn is present and this is not the
+  // synthetic durationMs===-1 turn_end (the fire callback's own re-dispatch).
+  // The counter reset MUST live here at the dispatcher — NOT inside
+  // resetOrphanedReplyTimeout() (which is called from the fire callback one
+  // line after the counter increments) and NOT tied to a single case (e.g.
+  // tool_result does not call resetOrphanedReplyTimeout). onStreamEvent applies
+  // the `!(turn_end && -1)` half of the predicate internally.
+  {
+    const liveTurn = currentTurn
+    if (liveTurn != null) {
+      const durationMs = ev.kind === 'turn_end' ? ev.durationMs : undefined
+      liveTurn.liveness.onStreamEvent(ev.kind, durationMs, Date.now())
+    }
+  }
   switch (ev.kind) {
     case 'enqueue': {
       // Drain any orphaned typing-wrap entries left over from a crashed
@@ -13465,6 +13501,14 @@ function handleSessionEvent(ev: SessionEvent): void {
           prior.answerStream.forceNewMessage()
           prior.answerStream.stop()
           prior.answerStream = null
+        }
+        // Bounded-leak hardening (A5): clear the prior turn's orphaned-reply
+        // fuse before it is superseded. The fire callback re-reads currentTurn
+        // and no-ops on a stale turn, but proactively clearing the timer avoids
+        // a bounded pile-up of dangling timers across rapid steer/queue turns.
+        if (prior?.orphanedReplyTimeoutId != null) {
+          clearTimeout(prior.orphanedReplyTimeoutId)
+          prior.orphanedReplyTimeoutId = null
         }
         // #1067: swap the entire turn atom in one assignment. Every
         // handler captures `const turn = currentTurn` at entry, so a
@@ -13525,7 +13569,9 @@ function handleSessionEvent(ev: SessionEvent): void {
           silentAnchorText: '',
           capturedText: [],
           orphanedReplyTimeoutId: null,
-          orphanedReplyRearmCount: 0,
+          // Fresh liveness tracker: lastStreamEventAt seeded to the turn start
+          // so a turn that never streams still trips the fuse after windowMs.
+          liveness: new LivenessTracker(startedAt),
           turnId,
           registryKey: null,
           noReplyDrainTimer: null,
@@ -14195,10 +14241,25 @@ function handleSessionEvent(ev: SessionEvent): void {
       if (ev.durationMs === -1) {
         const turn = currentTurn
         const key = turn != null ? statusKey(turn.sessionChatId, turn.sessionThreadId) : ''
-        if (isLegitimatelyWorking(key)) {
+        // Widened to also suppress while the turn is RECENTLY STREAMING — a
+        // model reasoning pause emits no tool/text events (so
+        // isLegitimatelyWorking is false) but a genuine stream landed within
+        // the window, so the turn is alive and must not be torn down.
+        // ACCEPTED TRADE-OFF (F3): the context-exhaustion recovery latency via
+        // THIS backstop path grows from ~30 s to ~120-150 s, because the
+        // "Prompt is too long" marker is itself a genuine `text` event that
+        // stamps recentlyStreaming. This is acceptable — the primary
+        // context-exhaustion teardown is the immediate `endCurrentTurnAtomic`
+        // in `case 'text'` (isContextExhaustionText) above; this backstop only
+        // matters if that path is missed, and it still COMPLETES once the
+        // window lapses. Recovery is delayed, never suppressed forever.
+        const recentlyStreaming =
+          turn != null && turn.liveness.recentlyStreaming(Date.now(), ORPHANED_REPLY_STREAM_WINDOW_MS)
+        if (isLegitimatelyWorking(key) || recentlyStreaming) {
           process.stderr.write(
             `telegram gateway: synthetic turn_end suppressed — legitimately working` +
             ` (in_flight=${toolFlightTracker.inFlightCount()},` +
+            ` recently_streaming=${recentlyStreaming},` +
             ` bg_work=${turn != null ? pendingProgress.hasPendingAsyncDispatch(key) : false})\n`,
           )
           return

--- a/telegram-plugin/tests/feed-survival.test.ts
+++ b/telegram-plugin/tests/feed-survival.test.ts
@@ -47,6 +47,8 @@ import { ToolFlightTracker } from '../gateway/interrupt-defer.js'
 import {
   ORPHANED_REPLY_TIMEOUT_MS,
   ORPHANED_REPLY_MAX_REARMS,
+  ORPHANED_REPLY_STREAM_WINDOW_MS,
+  LivenessTracker,
 } from '../context-exhaustion.js'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -522,5 +524,42 @@ describe('silence-poke — hard ceiling bounds the defer', () => {
     __tickForTests(700_000) // additional tick after ceiling
     expect(f.fallbacks).toHaveLength(1) // only fires once
     expect(__getStateForTests('chat:0')!.fallbackFired).toBe(true)
+  })
+})
+
+// ─── Thinking-pause liveness via the REAL LivenessTracker (orphaned-reply fix) ─
+
+describe('silence-poke — thinking-pause liveness via the real LivenessTracker', () => {
+  // Drives the REAL LivenessTracker as the isLegitimatelyWorking source: a
+  // genuine stream event within ORPHANED_REPLY_STREAM_WINDOW_MS keeps the feed
+  // alive (a model reasoning pause is survivable); a gap longer than the window
+  // with no work tears the feed down.
+  it('a stream event within the window keeps the feed alive (thinking-pause survivable)', () => {
+    let clockNow = 0
+    const tracker = new LivenessTracker(0)
+    const f = setupSilenceDeps({
+      thresholds: { fallback: 300_000, fallbackHardCeiling: 900_000 },
+      isLegitimatelyWorking: () => tracker.recentlyStreaming(clockNow, ORPHANED_REPLY_STREAM_WINDOW_MS),
+    })
+    startTurn('chat:0', 0)
+    // A genuine stream event lands mid-turn (e.g. the model resumes after a
+    // reasoning pause) — only 50s before the 300s fallback tick.
+    tracker.onStreamEvent('text', undefined, 250_000)
+    clockNow = 300_000
+    __tickForTests(300_000) // 50s since last stream < 120s window → deferred
+    expect(f.fallbacks).toHaveLength(0)
+  })
+
+  it('no stream event for longer than the window tears the feed down', () => {
+    let clockNow = 0
+    const tracker = new LivenessTracker(0) // seed at t=0, nothing after
+    const f = setupSilenceDeps({
+      thresholds: { fallback: 300_000, fallbackHardCeiling: 900_000 },
+      isLegitimatelyWorking: () => tracker.recentlyStreaming(clockNow, ORPHANED_REPLY_STREAM_WINDOW_MS),
+    })
+    startTurn('chat:0', 0)
+    clockNow = 300_000
+    __tickForTests(300_000) // 300s since last stream >> 120s window → fires
+    expect(f.fallbacks).toHaveLength(1)
   })
 })

--- a/telegram-plugin/tests/liveness-tracker.test.ts
+++ b/telegram-plugin/tests/liveness-tracker.test.ts
@@ -1,0 +1,228 @@
+/**
+ * liveness-tracker.test.ts — drives the REAL LivenessTracker (the testability
+ * seam of the orphaned-reply thinking-pause fix).
+ *
+ * Root cause being fixed: the orphaned-reply fuse (ORPHANED_REPLY_TIMEOUT_MS =
+ * 30 s) was reset ONLY by `tool_label` / `text` events. During a long model
+ * reasoning pause the gateway sees NO such events (thinking carries no text),
+ * so the fuse ran down and force-ended a genuinely-live turn mid-work.
+ *
+ * The fix stamps `lastStreamEventAt` on ANY genuine stream event; if a genuine
+ * event landed within `windowMs` (default 120 s) the turn is "recently
+ * streaming" and the fuse re-arms instead of firing. A genuine multi-minute
+ * hang (no events at all) still fires.
+ *
+ * These tests use the REAL class — no replica helpers.
+ *
+ * NOTE on onStreamEvent's signature: it is `(kind, durationMs, now)`. The
+ * tracker is time-only — it never reads text content (the "Prompt is too long"
+ * marker matters to the gateway's context-exhaustion detection, not to the
+ * tracker). Where the fix spec wrote `onStreamEvent('text','Prompt is too
+ * long',0)` we pass `undefined` as durationMs (it is not a turn_end).
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  LivenessTracker,
+  ORPHANED_REPLY_STREAM_WINDOW_MS,
+  ORPHANED_REPLY_TIMEOUT_MS,
+  ORPHANED_REPLY_MAX_REARMS,
+} from '../context-exhaustion.js'
+
+const W = ORPHANED_REPLY_STREAM_WINDOW_MS // 120_000
+const MAX = ORPHANED_REPLY_MAX_REARMS // 20
+const FUSE = ORPHANED_REPLY_TIMEOUT_MS // 30_000
+
+function expiry(
+  t: LivenessTracker,
+  now: number,
+  opts?: { working?: boolean; humanWaiting?: boolean },
+) {
+  return t.decideOnExpiry({
+    working: opts?.working ?? false,
+    humanWaiting: opts?.humanWaiting ?? false,
+    now,
+    windowMs: W,
+    maxRearms: MAX,
+  })
+}
+
+describe('LivenessTracker — pinned constants', () => {
+  it('window is 120 s and fuse tick is 30 s', () => {
+    expect(W).toBe(120_000)
+    expect(FUSE).toBe(30_000)
+    expect(MAX).toBe(20)
+  })
+})
+
+describe('T1 — thinking-pause survival', () => {
+  it('text→tool_use→tool_result then a 45s stream gap keeps re-arming (gap < window)', () => {
+    const t = new LivenessTracker(0)
+    t.onStreamEvent('text', undefined, 0)
+    t.onStreamEvent('tool_use', undefined, 1_000)
+    t.onStreamEvent('tool_result', undefined, 2_000)
+
+    // +30s past the last event (t=32s): recently streaming → re-arm.
+    const d1 = expiry(t, 32_000)
+    expect(d1).toEqual({ rearm: true, countsAgainstCap: true })
+    expect(t.orphanedReplyRearmCount).toBe(1)
+
+    // +45s past the last event (t=47s): still within the 120s window → re-arm.
+    const d2 = expiry(t, 47_000)
+    expect(d2).toEqual({ rearm: true, countsAgainstCap: true })
+    expect(t.orphanedReplyRearmCount).toBe(2)
+  })
+
+  it('the next genuine stream event ZEROES the rearm counter and re-stamps liveness', () => {
+    const t = new LivenessTracker(0)
+    t.onStreamEvent('tool_result', undefined, 2_000)
+    expiry(t, 32_000)
+    expiry(t, 47_000)
+    expect(t.orphanedReplyRearmCount).toBe(2)
+
+    t.onStreamEvent('tool_label', undefined, 48_000)
+    expect(t.orphanedReplyRearmCount).toBe(0)
+    expect(t.lastStreamEventAt).toBe(48_000)
+  })
+
+  it('a synthetic turn_end (durationMs === -1) does NOT stamp or reset (F4 boundary)', () => {
+    const t = new LivenessTracker(0)
+    t.onStreamEvent('tool_label', undefined, 48_000)
+    expiry(t, 60_000) // counter → 1
+    expect(t.orphanedReplyRearmCount).toBe(1)
+
+    t.onStreamEvent('turn_end', -1, 70_000)
+    expect(t.lastStreamEventAt).toBe(48_000) // unchanged — synthetic excluded
+    expect(t.orphanedReplyRearmCount).toBe(1) // not reset
+
+    // A REAL turn_end (durationMs >= 0) DOES stamp — harmless, the turn is
+    // ending anyway (spec #3).
+    t.onStreamEvent('turn_end', 0, 71_000)
+    expect(t.lastStreamEventAt).toBe(71_000)
+    expect(t.orphanedReplyRearmCount).toBe(0)
+  })
+})
+
+describe('T2 — production repro (48s tool_result, 78s expiry)', () => {
+  it('text@0, tool_use@1s, tool_result@48s → expiry@78s re-arms (78-48=30 < 120)', () => {
+    const t = new LivenessTracker(0)
+    t.onStreamEvent('text', undefined, 0)
+    t.onStreamEvent('tool_use', undefined, 1_000)
+    t.onStreamEvent('tool_result', undefined, 48_000)
+
+    const d = expiry(t, 78_000)
+    expect(d.rearm).toBe(true)
+    expect(t.orphanedReplyRearmCount).toBe(1)
+
+    // tool_label@80s zeroes the counter (progress observed).
+    t.onStreamEvent('tool_label', undefined, 80_000)
+    expect(t.orphanedReplyRearmCount).toBe(0)
+  })
+})
+
+describe('T3 — long active turn (A2: counter reset is load-bearing)', () => {
+  it('tool_label every 60s + expiry every 60s+30s NEVER fires across 15 min; counter never exceeds 1', () => {
+    const t = new LivenessTracker(0)
+    for (let k = 0; k < 15; k++) {
+      t.onStreamEvent('tool_label', undefined, k * 60_000) // progress → reset
+      const d = expiry(t, k * 60_000 + 30_000, { working: true })
+      expect(d.rearm).toBe(true) // never fires
+      expect(t.orphanedReplyRearmCount).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it('WITHOUT the progress reset the SAME cadence hits cap=20 near t=600s (proves reset load-bearing)', () => {
+    const t = new LivenessTracker(0)
+    let firedAt = -1
+    for (let k = 1; k <= 25; k++) {
+      const now = k * 30_000
+      // working:true so it would re-arm indefinitely IF the counter didn't
+      // accumulate — but with no onStreamEvent reset it climbs to the cap.
+      const d = expiry(t, now, { working: true })
+      if (!d.rearm) {
+        firedAt = now
+        break
+      }
+    }
+    // 20th re-arm lands at t=600s; the 21st expiry (t=630s) fires at the cap.
+    expect(t.orphanedReplyRearmCount).toBe(MAX)
+    expect(firedAt).toBeGreaterThanOrEqual(600_000)
+  })
+})
+
+describe('T4 — genuine hang caught (no events at all)', () => {
+  it('tool_result@0 then silence: re-arms via recentlyStreaming @30/60/90s, FIRES @120s (window lapsed)', () => {
+    const t = new LivenessTracker(0)
+    t.onStreamEvent('tool_result', undefined, 0)
+
+    for (const now of [30_000, 60_000, 90_000]) {
+      const d = expiry(t, now) // working:false — kept alive only by recentlyStreaming
+      expect(d.rearm).toBe(true)
+    }
+
+    // t=120s: now - lastStreamEventAt = 120_000 >= window → not recently
+    // streaming, working false → fail-safe FIRE.
+    const d = expiry(t, 120_000)
+    expect(d).toEqual({ rearm: false, countsAgainstCap: false })
+  })
+})
+
+describe('T5 — context-exhaustion recovery COMPLETES (not suppressed forever)', () => {
+  it('a "Prompt is too long" text event stamps liveness; defensive-guard predicate is true@30s, false@>=120s', () => {
+    const t = new LivenessTracker(0)
+    // The marker is a genuine `text` event (content is not a tracker concern).
+    t.onStreamEvent('text', undefined, 0)
+
+    // Context exhaustion means no tool is in flight: working === false. The
+    // defensive-guard suppression predicate is `working || recentlyStreaming`.
+    const working = false
+
+    // @30s: recentlyStreaming true → synthetic turn_end is suppressed. This
+    // DOCUMENTS the accepted ~30s→~120s recovery-latency growth (F3).
+    expect(working || t.recentlyStreaming(30_000, W)).toBe(true)
+
+    // @120s: window lapsed → NOT suppressed → teardown COMPLETES.
+    expect(working || t.recentlyStreaming(120_000, W)).toBe(false)
+
+    // @150s: still not suppressed — recovery is delayed, never forever.
+    expect(working || t.recentlyStreaming(150_000, W)).toBe(false)
+  })
+})
+
+describe('T7 — cap semantics', () => {
+  it('interleaved expiry/genuine-event: count 1 → 0 → 1 → 2', () => {
+    const t = new LivenessTracker(0)
+
+    expect(expiry(t, 10_000).rearm).toBe(true)
+    expect(t.orphanedReplyRearmCount).toBe(1)
+
+    t.onStreamEvent('tool_label', undefined, 11_000) // genuine event resets
+    expect(t.orphanedReplyRearmCount).toBe(0)
+
+    expiry(t, 20_000)
+    expect(t.orphanedReplyRearmCount).toBe(1)
+
+    expiry(t, 30_000) // consecutive silence (last event 11_000, gap 19s < 120s)
+    expect(t.orphanedReplyRearmCount).toBe(2)
+  })
+
+  it('21 consecutive recently-streaming expiries (no reset): 21st fires at the cap', () => {
+    const t = new LivenessTracker(0)
+    let last: { rearm: boolean; countsAgainstCap: boolean } | undefined
+    for (let k = 1; k <= 21; k++) {
+      // now = k*1000 keeps the gap from the seed (0) under the 120s window,
+      // so recentlyStreaming stays true throughout — the ONLY bound is the cap.
+      last = expiry(t, k * 1_000)
+    }
+    expect(last).toEqual({ rearm: false, countsAgainstCap: true })
+    expect(t.orphanedReplyRearmCount).toBe(MAX)
+
+    // humanWaiting past the cap → uncapped re-arm.
+    const dHuman = expiry(t, 22_000, { humanWaiting: true })
+    expect(dHuman).toEqual({ rearm: true, countsAgainstCap: false })
+
+    // recentlyStreaming false + working false + humanWaiting false → fail-safe FIRE.
+    const dFire = expiry(t, 200_000)
+    expect(dFire).toEqual({ rearm: false, countsAgainstCap: false })
+  })
+})

--- a/telegram-plugin/tests/narrative-render.test.ts
+++ b/telegram-plugin/tests/narrative-render.test.ts
@@ -1,0 +1,125 @@
+/**
+ * narrative-render.test.ts — T6: end-to-end narration through the REAL pure
+ * render helpers, tied to the REAL LivenessTracker (thinking-pause fix).
+ *
+ * Proves the narration surface still behaves after the orphaned-reply fix:
+ *   (a) a long narration is clipped and rendered as ONE feed line;
+ *   (b) a narration that is a draft of the delivered reply is SUPPRESSED,
+ *       while a differing narration is SHOWN;
+ *   (c) a narration after a >30s stream gap keeps the turn alive (the tracker
+ *       stamps liveness) AND renders; thinking / tool_result carry no narration
+ *       text so they add NO feed line (thinking only drives the 🤔 reaction).
+ *
+ * All assertions drive the REAL helpers — no replicas.
+ *
+ * DEVIATION NOTE: the fix spec's T6(a) wrote "≤120-char line". The real clip
+ * bound is `STATUS_LINE_MAX` (200) in status-no-truncate.ts, so this test pins
+ * the real constant instead of the stale 120.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  clipNarrative,
+  appendActivityLabel,
+  renderActivityFeedWithNested,
+} from '../tool-activity-summary.js'
+import { isDraftOfReply, REPLY_TOOLS } from '../narrative-dedup.js'
+import { STATUS_LINE_MAX } from '../status-no-truncate.js'
+import { LivenessTracker, ORPHANED_REPLY_STREAM_WINDOW_MS } from '../context-exhaustion.js'
+
+const W = ORPHANED_REPLY_STREAM_WINDOW_MS
+
+describe('T6(a) — long narration is clipped to one feed line', () => {
+  it('clipNarrative → appendActivityLabel → renderActivityFeedWithNested yields one clipped line', () => {
+    const long = 'x'.repeat(STATUS_LINE_MAX + 50) // 250 chars, no newlines
+    const clipped = clipNarrative(long)
+    expect(clipped.length).toBe(STATUS_LINE_MAX)
+
+    const lines: string[] = []
+    appendActivityLabel(lines, clipped)
+    expect(lines).toHaveLength(1)
+
+    const rendered = renderActivityFeedWithNested(lines, [])
+    expect(rendered).not.toBeNull()
+    expect(rendered).toContain(clipped)
+  })
+
+  it('clipNarrative keeps only the first line, trimmed', () => {
+    const multi = '  first line of narration  \nsecond line should be dropped'
+    expect(clipNarrative(multi)).toBe('first line of narration')
+  })
+})
+
+describe('T6(b) — a narration that drafts the reply is suppressed', () => {
+  // Model the reducer decision: only render narration that is NOT a draft of
+  // the delivered reply (narrative-dedup gate).
+  function renderNarrationUnlessDraft(narration: string, replyText: string): string | null {
+    if (isDraftOfReply(narration, replyText)) return null // suppressed
+    const lines: string[] = []
+    appendActivityLabel(lines, clipNarrative(narration))
+    return renderActivityFeedWithNested(lines, [])
+  }
+
+  it('REPLY_TOOLS is the reply set (sanity — draft dedup only runs for reply tools)', () => {
+    expect(REPLY_TOOLS.has('reply')).toBe(true)
+    expect(REPLY_TOOLS.has('stream_reply')).toBe(true)
+  })
+
+  it('suppresses a trailing narration that is a draft of the delivered reply', () => {
+    const reply = 'The build passed and I deployed the fix to staging.'
+    const draft = 'The build passed and I deployed the fix to staging' // ~identical
+    expect(isDraftOfReply(draft, reply)).toBe(true)
+    expect(renderNarrationUnlessDraft(draft, reply)).toBeNull()
+  })
+
+  it('shows a genuinely different narration line', () => {
+    const reply = 'The build passed and I deployed the fix to staging.'
+    const working = 'Running the integration test suite'
+    expect(isDraftOfReply(working, reply)).toBe(false)
+    const rendered = renderNarrationUnlessDraft(working, reply)
+    expect(rendered).not.toBeNull()
+    expect(rendered).toContain('Running the integration test suite')
+  })
+})
+
+describe('T6(c) — narration after a stream gap: alive + rendered; thinking/tool_result add no line', () => {
+  it('a narration text event after a >30s gap stamps liveness (turn alive) and renders', () => {
+    const t = new LivenessTracker(0)
+    t.onStreamEvent('text', undefined, 0)
+    // >30s gap with no events — turn would previously have been at risk.
+    const gapNow = 35_000
+    // Narration lands: stamps liveness, keeping the turn alive.
+    t.onStreamEvent('text', undefined, gapNow)
+    expect(t.lastStreamEventAt).toBe(gapNow)
+    expect(t.recentlyStreaming(gapNow, W)).toBe(true)
+
+    const lines: string[] = []
+    appendActivityLabel(lines, clipNarrative('Compiling the gateway bundle'))
+    const rendered = renderActivityFeedWithNested(lines, [])
+    expect(rendered).toContain('Compiling the gateway bundle')
+  })
+
+  it('thinking and tool_result stamp liveness but carry NO narration text → no feed line', () => {
+    const t = new LivenessTracker(0)
+    const lines: string[] = []
+    // A rendered narration line already present.
+    appendActivityLabel(lines, clipNarrative('Editing gateway.ts'))
+    expect(lines).toHaveLength(1)
+
+    // thinking: keeps the turn alive (liveness stamp) but produces no text.
+    t.onStreamEvent('thinking', undefined, 5_000)
+    expect(t.lastStreamEventAt).toBe(5_000)
+    // A thinking/tool_result event has no label → appendActivityLabel adds nothing.
+    expect(appendActivityLabel(lines, undefined)).toBeNull()
+    expect(lines).toHaveLength(1)
+
+    // tool_result: same — stamps liveness, no narration line.
+    t.onStreamEvent('tool_result', undefined, 6_000)
+    expect(t.lastStreamEventAt).toBe(6_000)
+    expect(appendActivityLabel(lines, '')).toBeNull()
+    expect(lines).toHaveLength(1)
+
+    const rendered = renderActivityFeedWithNested(lines, [])
+    expect(rendered).toContain('Editing gateway.ts')
+  })
+})

--- a/telegram-plugin/tests/orphaned-reply-rearm.test.ts
+++ b/telegram-plugin/tests/orphaned-reply-rearm.test.ts
@@ -1,21 +1,22 @@
 /**
- * Unit tests for the activity-feed-teardown fix (orphaned-reply backstop).
+ * Unit tests for the orphaned-reply backstop, repointed at the REAL
+ * LivenessTracker (the thinking-pause fix seam) — no replica decision helpers.
  *
  * Root cause: the orphaned-reply backstop fired a synthetic turn_end
- * (`durationMs: -1`) after 30 s of silence, even mid-tool-call. That nulled
+ * (`durationMs: -1`) after 30 s of silence, even mid-work. That nulled
  * `currentTurn` and dropped every subsequent `tool_label`, darkening the live
  * activity feed for the rest of the turn.
  *
- * Fix: three layers described in the PR.
- *   PRIMARY   — fuse fires mid-tool → re-arm instead (bounded by ORPHANED_REPLY_MAX_REARMS).
- *   SECONDARY — tool_label re-arms the fuse so active label streams keep it fresh.
- *   DEFENSIVE — turn_end entry rejects the synthetic event if tools are in flight.
- *
- * These tests cover the pure / unit-testable surfaces:
- *   - shouldArmOrphanedReplyTimeout (existing, now with midToolCall param)
- *   - ORPHANED_REPLY_MAX_REARMS constant math
- *   - The re-arm guard logic (pure decision extracted from the closure)
- *   - The defensive turn_end discriminator (durationMs === -1 + in-flight check)
+ * Fix layers (all now expressed through `LivenessTracker`):
+ *   PRIMARY   — the fuse fires mid-work → re-arm instead. `decideOnExpiry`
+ *               re-arms while working OR recently-streaming OR human-waiting,
+ *               bounded by ORPHANED_REPLY_MAX_REARMS for the working /
+ *               recently-streaming cases (human-wait is uncapped).
+ *   SECONDARY — a genuine stream event (`onStreamEvent`) re-stamps liveness and
+ *               zeroes the rearm counter, so an actively-progressing turn never
+ *               hits the cap.
+ *   DEFENSIVE — the gateway rejects a synthetic turn_end while the turn is
+ *               legitimately working OR recently streaming (`recentlyStreaming`).
  */
 
 import { describe, it, expect } from 'vitest'
@@ -23,37 +24,24 @@ import {
   shouldArmOrphanedReplyTimeout,
   ORPHANED_REPLY_TIMEOUT_MS,
   ORPHANED_REPLY_MAX_REARMS,
+  ORPHANED_REPLY_STREAM_WINDOW_MS,
+  LivenessTracker,
 } from '../context-exhaustion.js'
 import { ToolFlightTracker } from '../gateway/interrupt-defer.js'
 
-// ---------------------------------------------------------------------------
-// Helpers — pure decision functions mirroring the gateway closure logic.
-// These extract the discriminable parts of the fix so they are unit-testable
-// without instantiating the full gateway.
-// ---------------------------------------------------------------------------
+const W = ORPHANED_REPLY_STREAM_WINDOW_MS
+const MAX = ORPHANED_REPLY_MAX_REARMS
 
 /**
- * Mirrors the PRIMARY fix decision inside the setTimeout callback:
- * should the backstop re-arm (true) or fire turn_end (false)?
+ * A tracker whose last stream event is far enough in the past that
+ * `recentlyStreaming` is false at `now`, so the ONLY thing keeping the turn
+ * alive in a `decideOnExpiry` call is the `working` / `humanWaiting` inputs.
+ * Lets us test the "no liveness except the tool" decisions in isolation.
  */
-function shouldRearmInsteadOfFire(opts: {
-  midToolCall: boolean
-  rearmCount: number
-  maxRearms: number
-}): boolean {
-  return opts.midToolCall && opts.rearmCount < opts.maxRearms
+function staleTracker(): LivenessTracker {
+  return new LivenessTracker(0)
 }
-
-/**
- * Mirrors the DEFENSIVE fix at turn_end entry:
- * should a synthetic turn_end (durationMs === -1) be suppressed?
- */
-function shouldSuppressSyntheticTurnEnd(opts: {
-  durationMs: number
-  midToolCall: boolean
-}): boolean {
-  return opts.durationMs === -1 && opts.midToolCall
-}
+const STALE_NOW = W + 10_000 // gap > window → recentlyStreaming false
 
 // ---------------------------------------------------------------------------
 // Tests: ORPHANED_REPLY_MAX_REARMS constant
@@ -66,7 +54,6 @@ describe('ORPHANED_REPLY_MAX_REARMS', () => {
 
   it('combined with ORPHANED_REPLY_TIMEOUT_MS covers at least 10 min of tool activity', () => {
     const coverageMs = ORPHANED_REPLY_MAX_REARMS * ORPHANED_REPLY_TIMEOUT_MS
-    // 20 × 30 000 ms = 600 000 ms = 10 min
     expect(coverageMs).toBeGreaterThanOrEqual(10 * 60 * 1000)
   })
 
@@ -76,165 +63,138 @@ describe('ORPHANED_REPLY_MAX_REARMS', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Tests: PRIMARY fix — re-arm guard
+// Tests: PRIMARY fix — re-arm via decideOnExpiry (REAL tracker)
 // ---------------------------------------------------------------------------
 
-describe('PRIMARY fix: re-arm guard (shouldRearmInsteadOfFire)', () => {
-  it('re-arms when a tool is in flight and rearm count is under the cap', () => {
-    expect(shouldRearmInsteadOfFire({ midToolCall: true, rearmCount: 0, maxRearms: 20 })).toBe(true)
-    expect(shouldRearmInsteadOfFire({ midToolCall: true, rearmCount: 19, maxRearms: 20 })).toBe(true)
+describe('PRIMARY fix: re-arm guard (LivenessTracker.decideOnExpiry)', () => {
+  it('re-arms while working and under the cap (recentlyStreaming false)', () => {
+    const t = staleTracker()
+    const d = t.decideOnExpiry({ working: true, humanWaiting: false, now: STALE_NOW, windowMs: W, maxRearms: MAX })
+    expect(d).toEqual({ rearm: true, countsAgainstCap: true })
   })
 
-  it('fires once rearm count reaches the cap, even mid-tool-call', () => {
-    expect(shouldRearmInsteadOfFire({ midToolCall: true, rearmCount: 20, maxRearms: 20 })).toBe(false)
-    expect(shouldRearmInsteadOfFire({ midToolCall: true, rearmCount: 21, maxRearms: 20 })).toBe(false)
-  })
-
-  it('fires immediately when no tool is in flight, regardless of rearm count', () => {
-    expect(shouldRearmInsteadOfFire({ midToolCall: false, rearmCount: 0, maxRearms: 20 })).toBe(false)
-    expect(shouldRearmInsteadOfFire({ midToolCall: false, rearmCount: 5, maxRearms: 20 })).toBe(false)
-  })
-
-  it('rearm count transitions: 0 → cap-1 → cap fires', () => {
-    const max = ORPHANED_REPLY_MAX_REARMS
-    for (let i = 0; i < max; i++) {
-      expect(shouldRearmInsteadOfFire({ midToolCall: true, rearmCount: i, maxRearms: max })).toBe(true)
+  it('fires once the working rearm count reaches the cap (recentlyStreaming false)', () => {
+    const t = staleTracker()
+    let last: { rearm: boolean } | undefined
+    for (let k = 0; k <= MAX; k++) {
+      last = t.decideOnExpiry({ working: true, humanWaiting: false, now: STALE_NOW, windowMs: W, maxRearms: MAX })
     }
-    // At exactly the cap: fire
-    expect(shouldRearmInsteadOfFire({ midToolCall: true, rearmCount: max, maxRearms: max })).toBe(false)
+    // MAX re-arms proceeded (counter 1..MAX); the (MAX+1)th fires.
+    expect(last!.rearm).toBe(false)
+    expect(t.orphanedReplyRearmCount).toBe(MAX)
+  })
+
+  it('fires immediately when nothing keeps the turn alive (idle, not recently streaming)', () => {
+    const t = staleTracker()
+    const d = t.decideOnExpiry({ working: false, humanWaiting: false, now: STALE_NOW, windowMs: W, maxRearms: MAX })
+    expect(d).toEqual({ rearm: false, countsAgainstCap: false })
+  })
+
+  it('re-arms while recently streaming even when NOT working (thinking-pause survival)', () => {
+    const t = new LivenessTracker(0)
+    t.onStreamEvent('text', undefined, 0)
+    const d = t.decideOnExpiry({ working: false, humanWaiting: false, now: 30_000, windowMs: W, maxRearms: MAX })
+    expect(d).toEqual({ rearm: true, countsAgainstCap: true })
   })
 })
 
 // ---------------------------------------------------------------------------
-// Tests: DEFENSIVE fix — synthetic turn_end suppressor
+// Tests: DEFENSIVE fix — recentlyStreaming keeps the synthetic turn_end at bay
 // ---------------------------------------------------------------------------
 
-describe('DEFENSIVE fix: synthetic turn_end suppressor', () => {
-  it('suppresses a synthetic turn_end (durationMs === -1) when tools are in flight', () => {
-    expect(shouldSuppressSyntheticTurnEnd({ durationMs: -1, midToolCall: true })).toBe(true)
+describe('DEFENSIVE fix: recentlyStreaming suppression window', () => {
+  it('is true within the window of the last genuine stream event', () => {
+    const t = new LivenessTracker(0)
+    t.onStreamEvent('tool_use', undefined, 5_000)
+    expect(t.recentlyStreaming(5_000, W)).toBe(true)
+    expect(t.recentlyStreaming(5_000 + W - 1, W)).toBe(true)
   })
 
-  it('does NOT suppress a synthetic turn_end when no tools are in flight', () => {
-    // No tools → the backstop should fire normally (turn is genuinely orphaned)
-    expect(shouldSuppressSyntheticTurnEnd({ durationMs: -1, midToolCall: false })).toBe(false)
+  it('is false once the window lapses (genuine hang, teardown proceeds)', () => {
+    const t = new LivenessTracker(0)
+    t.onStreamEvent('tool_use', undefined, 5_000)
+    expect(t.recentlyStreaming(5_000 + W, W)).toBe(false)
   })
 
-  it('does NOT suppress an authoritative turn_end (durationMs >= 0)', () => {
-    expect(shouldSuppressSyntheticTurnEnd({ durationMs: 0, midToolCall: true })).toBe(false)
-    expect(shouldSuppressSyntheticTurnEnd({ durationMs: 1, midToolCall: true })).toBe(false)
-    expect(shouldSuppressSyntheticTurnEnd({ durationMs: 12345, midToolCall: true })).toBe(false)
-    expect(shouldSuppressSyntheticTurnEnd({ durationMs: 0, midToolCall: false })).toBe(false)
-  })
-
-  it('only durationMs === -1 is the synthetic discriminator', () => {
-    // Values near -1 must not accidentally trigger suppression
-    expect(shouldSuppressSyntheticTurnEnd({ durationMs: -2, midToolCall: true })).toBe(false)
-    expect(shouldSuppressSyntheticTurnEnd({ durationMs: -0.5, midToolCall: true })).toBe(false)
+  it('a synthetic turn_end (-1) does not extend the window', () => {
+    const t = new LivenessTracker(0)
+    t.onStreamEvent('tool_use', undefined, 5_000)
+    t.onStreamEvent('turn_end', -1, 5_500) // ignored
+    expect(t.lastStreamEventAt).toBe(5_000)
+    expect(t.recentlyStreaming(5_000 + W, W)).toBe(false)
   })
 })
 
 // ---------------------------------------------------------------------------
-// Tests: ToolFlightTracker integration with the guard logic
+// Tests: ToolFlightTracker → working input → decideOnExpiry
 // ---------------------------------------------------------------------------
 
-describe('ToolFlightTracker + guard integration', () => {
-  it('re-arm fires when a Bash tool is in flight', () => {
-    const tracker = new ToolFlightTracker()
-    tracker.onEvent({ kind: 'tool_use', toolUseId: 'bash_1' })
-
-    expect(shouldRearmInsteadOfFire({
-      midToolCall: tracker.isMidToolCall(),
-      rearmCount: 0,
-      maxRearms: ORPHANED_REPLY_MAX_REARMS,
-    })).toBe(true)
+describe('ToolFlightTracker drives the `working` input', () => {
+  it('re-arm fires when a Bash tool is in flight (working=true)', () => {
+    const flight = new ToolFlightTracker()
+    flight.onEvent({ kind: 'tool_use', toolUseId: 'bash_1' })
+    const t = staleTracker()
+    const d = t.decideOnExpiry({
+      working: flight.isMidToolCall(),
+      humanWaiting: false,
+      now: STALE_NOW,
+      windowMs: W,
+      maxRearms: MAX,
+    })
+    expect(d.rearm).toBe(true)
   })
 
-  it('fires normally after tool_result completes the tool', () => {
-    const tracker = new ToolFlightTracker()
-    tracker.onEvent({ kind: 'tool_use', toolUseId: 'bash_1' })
-    tracker.onEvent({ kind: 'tool_result', toolUseId: 'bash_1' })
-
-    expect(shouldRearmInsteadOfFire({
-      midToolCall: tracker.isMidToolCall(),
-      rearmCount: 0,
-      maxRearms: ORPHANED_REPLY_MAX_REARMS,
-    })).toBe(false)
-  })
-
-  it('defensive guard suppresses synthetic turn_end mid-Bash', () => {
-    const tracker = new ToolFlightTracker()
-    tracker.onEvent({ kind: 'tool_use', toolUseId: 'bash_2' })
-
-    expect(shouldSuppressSyntheticTurnEnd({
-      durationMs: -1,
-      midToolCall: tracker.isMidToolCall(),
-    })).toBe(true)
-  })
-
-  it('defensive guard allows synthetic turn_end after all tools complete', () => {
-    const tracker = new ToolFlightTracker()
-    tracker.onEvent({ kind: 'tool_use', toolUseId: 'bash_2' })
-    tracker.onEvent({ kind: 'tool_result', toolUseId: 'bash_2' })
-
-    expect(shouldSuppressSyntheticTurnEnd({
-      durationMs: -1,
-      midToolCall: tracker.isMidToolCall(),
-    })).toBe(false)
+  it('fires normally after tool_result completes the tool (working=false, not recently streaming)', () => {
+    const flight = new ToolFlightTracker()
+    flight.onEvent({ kind: 'tool_use', toolUseId: 'bash_1' })
+    flight.onEvent({ kind: 'tool_result', toolUseId: 'bash_1' })
+    const t = staleTracker()
+    const d = t.decideOnExpiry({
+      working: flight.isMidToolCall(),
+      humanWaiting: false,
+      now: STALE_NOW,
+      windowMs: W,
+      maxRearms: MAX,
+    })
+    expect(d.rearm).toBe(false)
   })
 
   it('parallel tools: re-arm persists while ANY tool is in flight', () => {
-    const tracker = new ToolFlightTracker()
-    tracker.onEvent({ kind: 'tool_use', toolUseId: 'read_1' })
-    tracker.onEvent({ kind: 'tool_use', toolUseId: 'read_2' })
-    tracker.onEvent({ kind: 'tool_use', toolUseId: 'edit_1' })
+    const flight = new ToolFlightTracker()
+    flight.onEvent({ kind: 'tool_use', toolUseId: 'read_1' })
+    flight.onEvent({ kind: 'tool_use', toolUseId: 'read_2' })
+    flight.onEvent({ kind: 'tool_use', toolUseId: 'edit_1' })
+    const t = staleTracker()
+    expect(
+      t.decideOnExpiry({ working: flight.isMidToolCall(), humanWaiting: false, now: STALE_NOW, windowMs: W, maxRearms: MAX }).rearm,
+    ).toBe(true)
 
-    // Still re-arming: 3 tools open
-    expect(shouldRearmInsteadOfFire({
-      midToolCall: tracker.isMidToolCall(),
-      rearmCount: 0,
-      maxRearms: ORPHANED_REPLY_MAX_REARMS,
-    })).toBe(true)
+    flight.onEvent({ kind: 'tool_result', toolUseId: 'read_1' })
+    flight.onEvent({ kind: 'tool_result', toolUseId: 'read_2' })
+    expect(
+      t.decideOnExpiry({ working: flight.isMidToolCall(), humanWaiting: false, now: STALE_NOW, windowMs: W, maxRearms: MAX }).rearm,
+    ).toBe(true) // edit_1 still open
 
-    // Two complete
-    tracker.onEvent({ kind: 'tool_result', toolUseId: 'read_1' })
-    tracker.onEvent({ kind: 'tool_result', toolUseId: 'read_2' })
-
-    // Still re-arming: edit_1 open
-    expect(shouldRearmInsteadOfFire({
-      midToolCall: tracker.isMidToolCall(),
-      rearmCount: 1,
-      maxRearms: ORPHANED_REPLY_MAX_REARMS,
-    })).toBe(true)
-
-    // All complete
-    tracker.onEvent({ kind: 'tool_result', toolUseId: 'edit_1' })
-
-    expect(shouldRearmInsteadOfFire({
-      midToolCall: tracker.isMidToolCall(),
-      rearmCount: 2,
-      maxRearms: ORPHANED_REPLY_MAX_REARMS,
-    })).toBe(false)
+    flight.onEvent({ kind: 'tool_result', toolUseId: 'edit_1' })
+    const t2 = staleTracker() // fresh so the earlier rearms don't confound the cap
+    expect(
+      t2.decideOnExpiry({ working: flight.isMidToolCall(), humanWaiting: false, now: STALE_NOW, windowMs: W, maxRearms: MAX }).rearm,
+    ).toBe(false) // all complete, not recently streaming → fire
   })
 
   it('cap fires even mid-tool after 20 re-arms (wedged tool surfaces)', () => {
-    const tracker = new ToolFlightTracker()
-    tracker.onEvent({ kind: 'tool_use', toolUseId: 'hung_bash' })
-
-    // First 20 re-arms proceed
-    for (let i = 0; i < ORPHANED_REPLY_MAX_REARMS; i++) {
-      expect(shouldRearmInsteadOfFire({
-        midToolCall: tracker.isMidToolCall(),
-        rearmCount: i,
-        maxRearms: ORPHANED_REPLY_MAX_REARMS,
-      })).toBe(true)
+    const flight = new ToolFlightTracker()
+    flight.onEvent({ kind: 'tool_use', toolUseId: 'hung_bash' })
+    const t = staleTracker()
+    for (let i = 0; i < MAX; i++) {
+      expect(
+        t.decideOnExpiry({ working: flight.isMidToolCall(), humanWaiting: false, now: STALE_NOW, windowMs: W, maxRearms: MAX }).rearm,
+      ).toBe(true)
     }
-
-    // 21st: cap exceeded — fire despite in-flight
-    expect(shouldRearmInsteadOfFire({
-      midToolCall: tracker.isMidToolCall(),
-      rearmCount: ORPHANED_REPLY_MAX_REARMS,
-      maxRearms: ORPHANED_REPLY_MAX_REARMS,
-    })).toBe(false)
+    // Cap exceeded — fire despite in-flight.
+    expect(
+      t.decideOnExpiry({ working: flight.isMidToolCall(), humanWaiting: false, now: STALE_NOW, windowMs: W, maxRearms: MAX }).rearm,
+    ).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Problem

The orphaned-reply watchdog (`ORPHANED_REPLY_TIMEOUT_MS = 30_000`) was force-ending **live** agent turns during model thinking pauses. The fuse only reset on `tool_label` / `text` events; thinking blocks emit no gateway events, so a reasoning pause looked identical to a wedged turn. `isLegitimatelyWorking` only inspected tool-state, so invisible thinking got cut off.

Real production failures: turns force-ended at **48s** (1 tool) and **135s** (9 tools) with minutes of genuine work still to come, logging `orphaned-reply timeout (30000ms) — forcing backstop` 1ms before `turn_end`.

## Fix

Per-turn liveness stamp. Any genuine stream event stamps `lastStreamEventAt`; if an event arrived within a window (default 120s, env `SWITCHROOM_ORPHANED_REPLY_STREAM_WINDOW_MS`), the turn is "recently streaming" and the fuse **re-arms** instead of firing. Thinking pauses now survive; genuine hangs are still caught.

A pure `LivenessTracker` is extracted into `context-exhaustion.ts` (`onStreamEvent` / `recentlyStreaming` / `decideOnExpiry`) so tests drive the real decision code rather than replicas.

### Load-bearing correctness properties (verified by an independent review against the real diff)

- **Counter-reset placement** — the rearm-counter reset lives at the dispatcher (`onStreamEvent`), not in the fuse re-arm path, so a rearm can't zero its own counter and nullify the cap.
- **20-rearm cap kept** — a genuinely-wedged turn still climbs to the cap and fires (~10min). The uncap-and-defer-to-900s-ceiling amendment was rejected: the 900s ceiling never fires for a turn emitting activity cards (each render resets its clock).
- **Synthetic turn_end excluded** — only the backstop's own synthetic re-entry (`durationMs === -1`) is excluded from stamping, so it can't self-perpetuate and silently disable context-exhaustion recovery. Recovery still completes.
- **Fail-safe** — once the cap is hit with no genuine progress and no human waiting, it fires (today's behavior).
- **Supersession** — prior turn's fuse is cleared on supersession.

## Trade-off (intended)

Context-exhaustion recovery latency goes from ~30s to ~120-150s (the "Prompt is too long" marker is a genuine `text` event that stamps liveness). Rare event, still fully recovers; a test asserts completion. A runaway thinking-only turn is now bounded by the outer 900s ceiling rather than the 30s fuse.

## Tests

- New `tests/liveness-tracker.test.ts` — drives the real tracker (thinking-pause survival, the two production repros, 15-min active turn, genuine-hang caught, context-exhaustion completion, cap semantics).
- `tests/orphaned-reply-rearm.test.ts` — replica helpers deleted, repointed at the real `decideOnExpiry` / `recentlyStreaming`.
- New `tests/narrative-render.test.ts` — narration renders end-to-end via the real render helpers.
- `tests/feed-survival.test.ts` — thinking-pause pair through the real silence-poke module + real tracker.

**73 target tests pass, `tsc --noEmit` clean, all lint guards clean** (incl. `check-bot-api-wrapping`). Full-suite reds are pre-existing (rich-markdown backlog, confirmed failing identically on `main`) or environment-dependent CI suites — none from this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
