### PR TITLE
feat(memory): operator-configurable Hindsight auto-retain cadence (default 3/1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## v0.18.3 — Operator-configurable Hindsight auto-retain cadence
+
+The plugin's auto-retain cadence (`retainEveryNTurns` / `retainOverlapTurns`)
+was hardcoded at scaffold to `1` / `2` — retain every single turn with a 3-turn
+overlapping window. That guaranteed a 1–2 turn fact-sharing session survived a
+restart, and was correct while retain/consolidation ran on a cheap remote
+model. Once the fleet moved retain/consolidation to a **local reasoning model**
+(Ollama `gpt-oss-20b`), the every-turn cadence with large overlapping payloads
+made the model run away — single retains observed generating 22k–37k output
+tokens over 100–200s, starving workers.
+
+### Make retain cadence configurable + change defaults to 3 / 1
+
+Adds two optional per-agent+defaults knobs under `memory.retain`:
+
+- `every_n_turns` (int, min 1, **default 3**) → plugin `retainEveryNTurns`
+- `overlap_turns` (int, min 0, **default 1**) → plugin `retainOverlapTurns`
+
+The resolved cascade value (defaults → profile → agent, per-field merge like
+`memory.recall`) is stamped into each agent's plugin `settings.json` on **every**
+scaffold/reconcile, so the yaml value is authoritative and **survives
+`switchroom apply`** regenerating that file — a hand-edit to `settings.json`
+was previously reverted on the next reconcile.
+
+The default change `1`/`2` → `3`/`1` yields ~3× fewer, smaller retains.
+**Tradeoff:** at `every_n_turns: 3`, up to ~3 turns of transcript can be lost on
+a hard crash before the next retain fires, instead of ≤2 at the old every-turn
+cadence. Operators who need the tight crash-durability guarantee set
+`memory.retain.every_n_turns: 1` (per-agent or fleet-wide under `defaults`);
+chatty banks can raise it further.
+
+Schema: `AgentMemorySchema.retain` (`src/config/schema.ts`), deep-merged in
+`src/config/merge.ts` alongside `recall`. Scaffold wiring:
+`resolveHindsightRetainConfig` + `renderHindsightSettingsOverrides` in
+`src/agents/scaffold.ts`. Docs: `docs/configuration.md` ("Tuning auto-retain
+cadence").
+
 ## v0.18.2 — Fix progress-card freeze during foreground sub-agent delegation
 
 The Telegram progress card could freeze mid-turn (observed stuck at 41s and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,6 +111,50 @@ The cap applies to the *combined* result list across the primary bank and any `r
 
 Operationally: the cap is set via the `HINDSIGHT_RECALL_MAX_MEMORIES` env var that `start.sh` exports. The vendored plugin's `recall.py` slices results client-side before formatting (plugin v0.4.0 has no `recallTopK` setting on the Claude Code integration — only Openclaw exposes it).
 
+### Tuning auto-retain cadence — `memory.retain.every_n_turns` / `overlap_turns`
+
+The plugin's Stop hook consolidates recent conversation into the bank on a
+cadence. `memory.retain.every_n_turns` controls how often it fires (in turns);
+`memory.retain.overlap_turns` controls how many extra recent turns are folded
+into each chunked retain window on top of that — so the window is
+`overlap_turns + every_n_turns` recent turns per fire.
+
+```yaml
+defaults:
+  memory:
+    retain:
+      every_n_turns: 3   # switchroom default — retain every 3rd turn
+      overlap_turns: 1   # switchroom default — +1 turn of window overlap
+
+agents:
+  archivist:
+    memory:
+      retain:
+        every_n_turns: 1  # tighter crash durability for a critical bank
+```
+
+**Defaults are `3` / `1`** (the vendor plugin defaults are `10` / `2`). These
+were raised from an earlier hardcoded `1` / `2`: once retain/consolidation
+moved to a **local reasoning model** (Ollama `gpt-oss-20b`), the every-turn
+cadence with large overlapping windows made the model run away — single
+retains generating 22k–37k output tokens over 100–200s and starving workers.
+`3` / `1` yields roughly 3× fewer, smaller retains.
+
+**Crash-durability tradeoff:** at `every_n_turns: 1` every turn was retained on
+its own fire, so a fact shared in a 1–2 turn session always survived a restart.
+At the default `3`, retention fires every 3rd turn, so up to ~3 turns of
+transcript can be lost on a hard crash before the next fire. That is an
+intentional swap of a little crash durability for far cheaper, calmer retains.
+Set `every_n_turns: 1` (per-agent or fleet-wide under `defaults`) to get the
+tight every-turn guarantee back; chatty banks can raise it further.
+
+`min` is `1` for `every_n_turns` and `0` for `overlap_turns`. Cascade:
+per-field merge (an agent may override one knob and inherit the other from
+`defaults`/profile). Both values are stamped into the plugin's `settings.json`
+on **every** scaffold/reconcile, so the yaml value is authoritative and
+**survives `switchroom apply`** regenerating that file (unlike a hand-edit,
+which reconcile would revert).
+
 ### Shared / profile recall banks — `memory.recall.additional_banks`
 
 By default an agent recalls only its own bank. Point `additional_banks` at one or more extra Hindsight banks and the recall hook queries them too on every turn, **merging** their hits into the agent's own results (each extra bank gets an 8s timeout and is non-fatal on failure). Use this for a shared operator/household profile every agent should know — preferences, projects, people — kept consistent fleet-wide.

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2433,6 +2433,12 @@ export function installHindsightPlugin(
   // uses the EXPECTED post-override rendering for that one file.
   const destPath = join(agentDir, ".claude", "plugins", "hindsight-memory");
   const additionalBanks = resolveUsers(switchroomConfig, agentName).additionalBanks;
+  // Resolve the auto-retain cadence knobs from the CASCADED config
+  // (defaults → profile → agent), mirroring how the recall knobs are read
+  // in the env-export path (see resolveHindsightRetainConfig). These drive
+  // the stamped settings.json values below, so a switchroom.yaml
+  // `memory.retain.*` override is authoritative and survives reconcile.
+  const retainConfig = resolveHindsightRetainConfig(switchroomConfig, agentName);
   let expectedSettings: string | null = null;
   try {
     const vendorSettingsPath = join(sourcePath, "settings.json");
@@ -2440,6 +2446,7 @@ export function installHindsightPlugin(
       expectedSettings = renderHindsightSettingsOverrides(
         readFileSync(vendorSettingsPath, "utf-8"),
         additionalBanks,
+        retainConfig,
       );
     }
   } catch {
@@ -2461,22 +2468,28 @@ export function installHindsightPlugin(
   // default settings.json. Vendor stays untouched; overrides are applied
   // after every copy so they survive reconcile/restart.
   //
-  // `retainEveryNTurns: 1` (override from vendor default `10`): the
-  // vendor's default throttles auto-retention to every 10th turn, so a
-  // short session can end before retention ever fires. Switchroom sets it
-  // to 1 so the Stop hook retains every turn (paired with chunked mode,
-  // each retain only slices a small recent window, so per-turn cost stays
-  // low). For
-  // switchroom's "always-on specialist exec-assistant" vision, that
-  // throttle is wrong — users expect "please remember this" or even a
-  // single fact-sharing turn to survive a restart. The jtbd-memory-
-  // survives-restart UAT exposed the gap (2026-05-20): a 2-turn
-  // session NEVER hit the retention threshold, so the token was lost
-  // on restart. Setting retainEveryNTurns=1 makes every Stop hook
-  // trigger retention. Cost: more frequent hindsight API calls
-  // (cheap — async POST to a local container). Memory is the moat
-  // (reference/jobs/remember-across-sessions.md); paying for it on every
-  // turn is correct.
+  // `retainEveryNTurns` / `retainOverlapTurns` (override from vendor
+  // defaults `10` / `2`): the vendor default throttles auto-retention to
+  // every 10th turn, so a short session can end before retention ever
+  // fires. Switchroom stamps the CASCADED config value (defaults →
+  // profile → agent, `memory.retain.every_n_turns` / `.overlap_turns`),
+  // falling back to the switchroom scaffold defaults of 3 / 1 when unset.
+  //
+  // History: this used to be a hardcoded 1 / 2 (retain every single turn,
+  // 3-turn window). That guaranteed a ≤2-turn fact-sharing session
+  // survived a restart (the jtbd-memory-survives-restart UAT, 2026-05-20),
+  // but once retain/consolidation moved to a LOCAL Ollama reasoning model
+  // (gpt-oss-20b), the every-turn cadence with large overlapping windows
+  // made the model run away (single retains generating 22k–37k output
+  // tokens over 100–200s, starving workers). Default 3 / 1 = ~3× fewer,
+  // smaller retains. Tradeoff: at n=3, up to ~3 turns of transcript can be
+  // lost on a hard crash instead of ≤2 — an intentional swap of a little
+  // crash durability for far cheaper, calmer retains. Operators who need
+  // the tight every-turn guarantee back set `memory.retain.every_n_turns: 1`
+  // in switchroom.yaml (per-agent or fleet-wide under `defaults`); chatty
+  // banks can raise it further. Making it a yaml knob also makes the value
+  // update-proof — it survives `switchroom apply`/reconcile, which
+  // regenerates this settings.json and would otherwise revert hand-edits.
   // Resolve the effective extra recall banks for this agent — the static
   // shared-bank foundation for per-user memory (ship-B; RFC
   // reference/rfcs/per-speaker-memory-routing.md). Read from the CASCADED
@@ -2486,7 +2499,7 @@ export function installHindsightPlugin(
   // per-agent value. Now also folds in the `knows`-assigned user/bank profiles
   // (user concept, RFC reference/rfcs/user-concept.md); resolveUsers() handles
   // the cascade + union (defaults ∪ agent, generated ∪ explicit) itself.
-  applyHindsightSettingsOverrides(destPath, additionalBanks);
+  applyHindsightSettingsOverrides(destPath, additionalBanks, retainConfig);
 
   // Resolve the agent's bank/collection name and the Hindsight REST URL.
   // The plugin's hooks expect HINDSIGHT_API_URL (the REST base), not the
@@ -2500,12 +2513,57 @@ export function installHindsightPlugin(
 }
 
 /**
+ * Switchroom scaffold defaults for the hindsight auto-retain cadence,
+ * used when switchroom.yaml leaves `memory.retain.*` unset. Raised from
+ * the historical 1 / 2 after retain/consolidation moved to a local
+ * reasoning model that ran away on every-turn overlapping payloads — see
+ * the rationale comment in installHindsightPlugin().
+ */
+const HINDSIGHT_DEFAULT_RETAIN_EVERY_N_TURNS = 3;
+const HINDSIGHT_DEFAULT_RETAIN_OVERLAP_TURNS = 1;
+
+/** Resolved auto-retain cadence for an agent (post-cascade, defaults applied). */
+interface HindsightRetainConfig {
+  everyNTurns: number;
+  overlapTurns: number;
+}
+
+/**
+ * Resolve the effective auto-retain cadence for an agent from the CASCADED
+ * config (defaults → profile → agent), applying the switchroom scaffold
+ * defaults when `memory.retain.*` is unset. Mirrors how the recall knobs
+ * are resolved in the env-export path (resolveAgentConfig, then read the
+ * merged `memory.recall.*`).
+ */
+function resolveHindsightRetainConfig(
+  switchroomConfig: SwitchroomConfig | undefined,
+  agentName: string,
+): HindsightRetainConfig {
+  const resolved = switchroomConfig
+    ? resolveAgentConfig(
+        switchroomConfig.defaults,
+        switchroomConfig.profiles,
+        // Some scaffold paths install the plugin for an agent that isn't in
+        // the `agents` map yet (fresh scaffold); resolve against an empty
+        // agent so the defaults/profile tiers still apply.
+        switchroomConfig.agents[agentName] ?? ({} as AgentConfig),
+      )
+    : undefined;
+  const retain = resolved?.memory?.retain;
+  return {
+    everyNTurns: retain?.every_n_turns ?? HINDSIGHT_DEFAULT_RETAIN_EVERY_N_TURNS,
+    overlapTurns: retain?.overlap_turns ?? HINDSIGHT_DEFAULT_RETAIN_OVERLAP_TURNS,
+  };
+}
+
+/**
  * Merge switchroom-specific overrides into the vendored hindsight
  * plugin's `settings.json`. Idempotent — runs after every plugin
  * copy on every scaffold/reconcile/restart.
  *
  * Currently overrides:
- *   - `retainEveryNTurns`: 10 → 1 (capture every turn, not every 10th)
+ *   - `retainEveryNTurns`: 10 → configured (default 3; `memory.retain.every_n_turns`)
+ *   - `retainOverlapTurns`: 2 → configured (default 1; `memory.retain.overlap_turns`)
  *   - `retainMode`: full-session → chunked (Phase 6b: window, not whole
  *     transcript, re-consolidated per fire; paired with the vendor
  *     retain.py divergence)
@@ -2520,6 +2578,7 @@ export function installHindsightPlugin(
 function applyHindsightSettingsOverrides(
   pluginDestPath: string,
   additionalBanks: readonly string[],
+  retainConfig: HindsightRetainConfig,
 ): void {
   const settingsPath = join(pluginDestPath, "settings.json");
   if (!existsSync(settingsPath)) return; // vendor structure changed; bail safely
@@ -2529,7 +2588,7 @@ function applyHindsightSettingsOverrides(
   } catch {
     return;
   }
-  const next = renderHindsightSettingsOverrides(raw, additionalBanks);
+  const next = renderHindsightSettingsOverrides(raw, additionalBanks, retainConfig);
   if (next == null) return; // malformed settings; don't make it worse
   writeFileSyncIfChanged(settingsPath, next);
 }
@@ -2545,6 +2604,7 @@ function applyHindsightSettingsOverrides(
 function renderHindsightSettingsOverrides(
   raw: string,
   additionalBanks: readonly string[],
+  retainConfig: HindsightRetainConfig,
 ): string | null {
   let settings: Record<string, unknown>;
   try {
@@ -2552,43 +2612,40 @@ function renderHindsightSettingsOverrides(
   } catch {
     return null; // vendor's settings.json malformed; don't make it worse
   }
-  // Override: every turn retains (no throttle). See the rationale in
-  // installHindsightPlugin() above.
-  settings.retainEveryNTurns = 1;
+  // Override: auto-retain cadence, from the cascaded config (defaults 3 / 1).
+  // See the rationale in installHindsightPlugin() above — the yaml knob
+  // (memory.retain.every_n_turns / .overlap_turns) is authoritative and,
+  // being stamped here on every scaffold/reconcile, survives `switchroom
+  // apply` regenerating this file.
+  settings.retainEveryNTurns = retainConfig.everyNTurns;
   // Phase 6b (RFC reference/rfcs/hindsight-synthesis-layers.md): switch from
-  // the vendor default retainMode="full-session" to "chunked" while keeping
-  // retainEveryNTurns=1. This is the crux of Phase 6b option A — keep the
-  // every-turn crash durability that retainEveryNTurns=1 buys (a ≤2-turn
-  // session still retains its token before a restart; the jtbd-memory-
-  // survives-restart UAT), but STOP re-consolidating the whole accumulated
-  // transcript on every Stop fire. Under full-session × every-turn, each fire
-  // re-sent the entire growing transcript to Hindsight's consolidation engine
-  // — the ~1M-tokens/day/agent invisible spend. In chunked mode retain.py
-  // slices only the recent window (retainOverlapTurns + retainEveryNTurns
-  // turns) per fire.
+  // the vendor default retainMode="full-session" to "chunked". This is the
+  // crux of Phase 6b option A — STOP re-consolidating the whole accumulated
+  // transcript on every Stop fire. Under full-session, each fire re-sent the
+  // entire growing transcript to Hindsight's consolidation engine — the
+  // ~1M-tokens/day/agent invisible spend. In chunked mode retain.py slices
+  // only the recent window (retainOverlapTurns + retainEveryNTurns turns) per
+  // fire.
   //
-  // This override is INERT without the paired vendor patch: upstream retain.py
-  // gated chunked window-slicing on `retainEveryNTurns > 1`, so chunked at
-  // n=1 silently fell back to full-session. The switchroom divergence in
-  // vendor/hindsight-memory/scripts/retain.py (select_retain_window) decouples
-  // the window slice from that throttle, which is what makes chunked+every-turn
-  // actually take effect. See that file's header comment + the CHANGELOG entry.
+  // Crash-durability note: at the historical retainEveryNTurns=1 every turn
+  // retained on its own fire, so no fact could fall outside a window and a
+  // ≤2-turn session always survived a restart (the jtbd-memory-survives-
+  // restart UAT). At the current default of 3, retention fires every 3rd
+  // turn, so up to ~3 turns of transcript can be lost on a hard crash before
+  // the next fire — the intentional tradeoff for smaller, calmer retains that
+  // don't run the local reasoning consolidation model away. Operators who
+  // need the tight guarantee back set memory.retain.every_n_turns: 1.
   //
-  // Durability holds because the window always extends to the END of the
-  // transcript, so the turn that just completed (whose Stop hook is firing)
-  // is always inside the window, and every turn fires at n=1 — so each turn's
-  // content is retained on its own fire. No fact can fall outside every window.
-  //
-  // No operator override surface yet: switchroom.yaml exposes memory.recall.*
-  // (see AgentMemorySchema in src/config/schema.ts) but no memory.retain.mode
-  // key, so this is the scaffold default for every agent. If a retain-mode
-  // cascade is added later, wire it here (mirroring the recall knobs) and let
-  // the env/config value win over this default.
+  // This chunked override is INERT without the paired vendor patch: upstream
+  // retain.py gated chunked window-slicing on `retainEveryNTurns > 1`. The
+  // switchroom divergence in vendor/hindsight-memory/scripts/retain.py
+  // (select_retain_window) decouples the window slice from that throttle,
+  // which is what makes chunked retain actually take effect. See that file's
+  // header comment + the CHANGELOG entry.
   settings.retainMode = "chunked";
-  // retainOverlapTurns stays at the vendor default (2) → window = 3 recent
-  // turns at retainEveryNTurns=1. That's a comfortable safety margin for the
-  // restart guarantee (the firing turn plus the two before it), so no explicit
-  // override is warranted.
+  // retainOverlapTurns from the cascaded config (default 1) → window =
+  // overlap_turns + every_n_turns recent turns per fire (default 1 + 3 = 4).
+  settings.retainOverlapTurns = retainConfig.overlapTurns;
   // v0.13.22 smart defaults: at our recallBudget=low the vendor's 12
   // memories is generous; 8 keeps prompt noise down without hurting
   // the substantive recall@N (top-8 carries the same dominant facts

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -395,6 +395,18 @@ export function mergeAgentConfig(
       if (k === "recall" && base.recall && typeof v === "object" && v !== null && !Array.isArray(v)) {
         combined[k] = { ...base.recall, ...(v as Record<string, unknown>) };
       } else if (
+        k === "retain" &&
+        (base as { retain?: unknown }).retain &&
+        typeof v === "object" && v !== null && !Array.isArray(v)
+      ) {
+        // Same one-level-deep merge as `recall`: an agent may override a
+        // single retain knob (e.g. every_n_turns) and inherit the profile's
+        // overlap_turns, rather than replacing the whole retain object.
+        combined[k] = {
+          ...((base as { retain?: Record<string, unknown> }).retain),
+          ...(v as Record<string, unknown>),
+        };
+      } else if (
         k === "disposition" &&
         (base as { disposition?: unknown }).disposition &&
         typeof v === "object" && v !== null && !Array.isArray(v)

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -579,6 +579,42 @@ export const AgentMemorySchema = z
       })
       .optional()
       .describe("Auto-recall tuning knobs"),
+    retain: z
+      .object({
+        every_n_turns: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe(
+            "How often the Stop hook fires auto-retention, in turns. The " +
+            "vendor plugin default is 10 (a short session can end before " +
+            "retention ever fires); switchroom's scaffold default is 3. " +
+            "Lower = more frequent, smaller retains + tighter crash " +
+            "durability (at 1, every turn is retained before a restart can " +
+            "lose it); higher = fewer, larger retains + less LLM churn. " +
+            "Raised from the historical 1 to 3 because the local reasoning " +
+            "consolidation model (Ollama gpt-oss-20b) ran away on the large " +
+            "overlapping every-turn payloads. Set to 1 for the old " +
+            "every-turn crash-durability guarantee. Min 1. Cascade: " +
+            "per-field merge (agent wins over default).",
+          ),
+        overlap_turns: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "Extra recent turns included in each chunked retain window on " +
+            "top of `every_n_turns`, so window = overlap_turns + " +
+            "every_n_turns recent turns. Vendor default is 2; switchroom's " +
+            "scaffold default is 1 (smaller payloads for the local " +
+            "reasoning consolidation model). Higher = more redundant " +
+            "context re-sent per fire. Min 0. Cascade: per-field merge.",
+          ),
+      })
+      .optional()
+      .describe("Auto-retain (Stop-hook consolidation) cadence knobs"),
   })
   .optional();
 

--- a/tests/scaffold.recall-observations.test.ts
+++ b/tests/scaffold.recall-observations.test.ts
@@ -57,18 +57,31 @@ describe("hindsight recall overrides — observations + trivial-skip", () => {
     expect(s.recallSkipTrivial).toBe(true);
   });
 
-  it("Phase 6b: retainMode is chunked (windowed retain), retainEveryNTurns stays 1", () => {
+  it("Phase 6b: retainMode is chunked (windowed retain); retain cadence defaults to 3 / 1", () => {
     const s = settingsAfterInstall();
-    // Chunked + every-turn: keep crash durability (retain every turn), but
-    // slice a recent window per fire instead of re-consolidating the whole
-    // transcript. Depends on the paired vendor retain.py divergence.
+    // Chunked retain: slice a recent window per fire instead of
+    // re-consolidating the whole transcript. Depends on the paired vendor
+    // retain.py divergence. Cadence defaults to the switchroom scaffold
+    // values (every 3rd turn, +1 overlap turn) — raised from the historical
+    // 1 / 2 so the local reasoning consolidation model doesn't run away.
     expect(s.retainMode).toBe("chunked");
+    expect(s.retainEveryNTurns).toBe(3);
+    expect(s.retainOverlapTurns).toBe(1);
+  });
+
+  it("retain cadence is operator-configurable via memory.retain.*", () => {
+    // Fleet-wide override under defaults, plus a per-agent override that wins.
+    config.defaults = { memory: { retain: { every_n_turns: 5, overlap_turns: 2 } } } as SwitchroomConfig["defaults"];
+    config.agents = { probe: { memory: { retain: { every_n_turns: 1 } } } } as unknown as SwitchroomConfig["agents"];
+    const s = settingsAfterInstall();
+    // Per-agent every_n_turns wins; overlap_turns inherits the defaults tier.
     expect(s.retainEveryNTurns).toBe(1);
+    expect(s.retainOverlapTurns).toBe(2);
   });
 
   it("regression: the pre-existing memory overrides still apply", () => {
     const s = settingsAfterInstall();
-    expect(s.retainEveryNTurns).toBe(1);
+    expect(s.retainEveryNTurns).toBe(3);
     expect(s.recallMaxMemories).toBe(8);
     expect(s.recallMinOverlap).toBe(0.1);
   });


### PR DESCRIPTION
## Motivation

The hindsight-memory plugin's auto-retain cadence (`retainEveryNTurns` / `retainOverlapTurns`) was hardcoded at scaffold to `1` / `2` — retain every single turn with a 3-turn overlapping window. That was correct while retain/consolidation ran on a cheap remote model.

The fleet just moved hindsight's retain/consolidation to a **local reasoning model** (Ollama `gpt-oss-20b`). At `retainEveryNTurns=1` / `retainOverlapTurns=2`, auto-retain fires every turn with large overlapping payloads and the reasoning model runs away — observed single retains generating **22k–37k output tokens over 100–200s**, starving workers.

Two problems this PR fixes:
1. **The cadence needs to be tunable per-agent** (chatty banks vs. quiet banks).
2. **It needs to be update-proof.** The value lived only in the generated plugin `settings.json`, which `switchroom apply`/reconcile regenerates — so any hand-edit was silently reverted on the next reconcile.

## What changed

- **New knobs** under `memory.retain` (per-agent + `defaults` tier, per-field merge like `memory.recall`):
  - `every_n_turns` (int, min 1, **default 3**) → plugin `retainEveryNTurns`
  - `overlap_turns` (int, min 0, **default 1**) → plugin `retainOverlapTurns`
- The resolved cascade value (defaults → profile → agent) is stamped into the plugin `settings.json` on **every** scaffold/reconcile, so the yaml value is authoritative and **survives `switchroom apply`**.
- Rationale comments at the scaffold site updated for the new default + crash-durability tradeoff.
- Docs + CHANGELOG.

## Default change `1`/`2` → `3`/`1` and the crash-durability tradeoff

`3` / `1` yields ~3× fewer, smaller retains. **Tradeoff:** at `every_n_turns=1` every turn retained on its own fire, so a fact shared in a 1–2 turn session always survived a restart. At the default `3`, retention fires every 3rd turn, so up to ~3 turns of transcript can be lost on a hard crash before the next fire — an intentional swap of a little crash durability for far cheaper, calmer retains.

**Operators who need the tight guarantee back** set `memory.retain.every_n_turns: 1` (per-agent or fleet-wide under `defaults`); chatty banks can raise it further.

## Schema field names + locations

- `AgentMemorySchema.retain.{every_n_turns, overlap_turns}` — `src/config/schema.ts`
- Deep-merge alongside `recall` — `src/config/merge.ts`
- `resolveHindsightRetainConfig` + threaded through `renderHindsightSettingsOverrides` / `applyHindsightSettingsOverrides` — `src/agents/scaffold.ts`
- Docs: `docs/configuration.md` ("Tuning auto-retain cadence")

## Validation

- `npm run lint:tsc` — clean
- `vitest run` for config + scaffold suites (merge, schema, recall-observations/optout/additional-banks) — **165 passed**
- Updated `tests/scaffold.recall-observations.test.ts` for the new defaults + added coverage that a `memory.retain.*` override (defaults tier + per-agent, per-field merge) lands in settings.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)