### PR TITLE
feat: acceptEdits as fleet default (overridable) + bundle Claude CLI 2.1.205

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -154,7 +154,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # (`--build-arg CLAUDE_CODE_VERSION=<latest>`) to build a throwaway image on the
 # next version and prove it boots BEFORE the pin is bumped. Keep this default in
 # lockstep with docker/Dockerfile.hindsight's CLAUDE_CODE_VERSION (#1978).
-ARG CLAUDE_CODE_VERSION=2.1.199
+ARG CLAUDE_CODE_VERSION=2.1.205
 # Fail-fast: if the npm install or the resulting binary is broken we
 # want the image build to die here, not produce a base that ships
 # downstream and explodes at agent boot. Previously this had a

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -51,7 +51,7 @@ USER root
 # claude bundle as the agent containers — a version skew here could reintroduce
 # the thinking-block / thinking-effort class of failures on memory reflection
 # (see #1978). The canary overrides it the same way base does.
-ARG CLAUDE_CODE_VERSION=2.1.199
+ARG CLAUDE_CODE_VERSION=2.1.205
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
  && claude --version >&2
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,7 @@ Each field type has specific merge behavior when values exist at multiple layers
 |-------|---------|-------------|
 | `model` | override | Claude model (`claude-opus-4-8`, `claude-sonnet-5`, `claude-haiku-4-5`). Haiku is the default for the handoff summarizer; agents typically use opus or sonnet. |
 | `thinking_effort` | override | Adaptive-thinking effort passed as `--effort` (`low`/`medium`/`high`/`xhigh`/`max`). Defaults to `low` when unset. **On Opus 4.x keep this at `low`** — `medium`+ emits thinking blocks that the bundled claude CLI can mis-merge under concurrent sub-agents, causing `400 'thinking blocks cannot be modified'` (issue #1978). `switchroom doctor` warns on the risky combo. Removing the field does *not* help: Opus 4.8 defaults `effort=high` when `--effort` is omitted. |
+| `permission_mode` | override | Permission mode for the agent's Claude session. Drives the `--permission-mode` CLI flag AND the `.claude/settings.json` `permissions.defaultMode`. **The switchroom built-in default is `acceptEdits`** — every agent auto-accepts edits with no yaml needed. Override per-agent here or fleet-wide via `defaults.permission_mode`; per-agent wins. Valid values: `acceptEdits`, `default`, `plan`, `bypassPermissions` (settings.json `defaultMode`), plus `auto`/`dontAsk` (CLI-flag only — these fall back to `acceptEdits` for `defaultMode`). See [Permission mode & auto-accept](#permission-mode--auto-accept). |
 | `extends` | — | Named profile to inherit from |
 | `tools.allow` / `tools.deny` | union | Tool permissions |
 | `soul` | per-field (**seed-time only**) | Agent persona (name, style, boundaries). Cascades per-field, but **only at first scaffold** — it seeds `workspace/SOUL.md`, which is then user-owned (see [Persona & SOUL.md ownership](#persona--soulmd-ownership)). Editing `soul:` later does **not** change an agent whose SOUL.md already exists. |
@@ -76,6 +77,45 @@ Each field type has specific merge behavior when values exist at multiple layers
 | `cli_args` | concatenate | Escape hatch: extra `exec claude` flags |
 | `google_workspace` | deep merge | Google Drive/Docs/Sheets/Calendar integration. `google_client_id` / `google_client_secret` are install-wide (top level only); `tier` + `approvers` cascade per-agent. See § Google Workspace below. |
 | `notion_workspace` | deep merge top-level; per-agent `databases:` list REPLACES (does not concatenate) | Notion integration. Top-level `vault_key` + `databases:` map cascade via deep merge so a profile can add a DB without clobbering top-level entries. The per-agent `databases:` allowlist is **override** — an agent's list replaces the parent's, so a specialist agent inheriting a profile can narrow to fewer DBs. See § Notion Workspace below and [notion-integration.md](notion-integration.md). |
+
+## Permission mode & auto-accept
+
+Switchroom sets `.claude/settings.json` `permissions.defaultMode` to
+**`acceptEdits`** for **every** agent out of the box — auto-accept of file
+edits is the switchroom default on **any** install, with **no yaml needed**.
+This is deliberately decoupled from the `tools.allow: [all]` wildcard (which
+only drives allow-list expansion): a plain agent with a read-only tool set
+still gets `acceptEdits`.
+
+Override it two ways, with the usual switchroom precedence (per-agent wins):
+
+```yaml
+# Fleet-wide default for every agent
+defaults:
+  permission_mode: plan
+
+agents:
+  scout:
+    # Per-agent override — beats the fleet default AND the built-in default,
+    # even for an [all]-wildcard agent.
+    permission_mode: default
+```
+
+Resolution (highest wins):
+
+1. `agents.<name>.permission_mode` — per-agent override
+2. `defaults.permission_mode` — fleet-wide override
+3. `acceptEdits` — the switchroom built-in default
+
+Valid values: `acceptEdits`, `default`, `plan`, `bypassPermissions` map
+directly to the settings.json `defaultMode`. `auto` and `dontAsk` are also
+accepted (they drive the `--permission-mode` CLI flag) but have **no**
+settings.json `defaultMode` equivalent, so for `defaultMode` they fall back to
+`acceptEdits` with a warning — the CLI flag still carries the raw value. An
+unrecognized value is rejected at config-parse time by the schema.
+
+`permission_mode` is independent of `dangerous_mode` (the
+`--dangerously-skip-permissions` path), which is unchanged.
 
 ## Built-in MCP Servers
 

--- a/profiles/_base/settings.json.hbs
+++ b/profiles/_base/settings.json.hbs
@@ -21,8 +21,8 @@
 {
   "permissions": {
     "allow": {{{json permissionAllow}}},
-    "deny": {{{json toolsDeny}}}{{#if defaultModeAcceptEdits}},
-    "defaultMode": "acceptEdits"{{/if}}
+    "deny": {{{json toolsDeny}}},
+    "defaultMode": "{{defaultMode}}"
   }{{#if hindsightEnabled}},
   "autoMemoryEnabled": false{{/if}}{{#if mcpServers}},
   "mcpServers": {{{json mcpServers}}}

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2702,6 +2702,68 @@ function resolveSwitchroomCliPath(): string {
  * closing the gap where `reconcileAgent` used to rebuild a 7-key subset
  * and silently render `""` for anything else.
  */
+/**
+ * The `permissions.defaultMode` values Claude Code accepts in
+ * .claude/settings.json. This is a SUBSET of the schema's `permission_mode`
+ * enum — `auto` and `dontAsk` are valid `--permission-mode` CLI flags but
+ * have no settings.json defaultMode equivalent, so they degrade to the
+ * built-in default in resolvePermissionDefaultMode().
+ */
+const VALID_SETTINGS_DEFAULT_MODES = [
+  "default",
+  "acceptEdits",
+  "plan",
+  "bypassPermissions",
+] as const;
+type SettingsDefaultMode = (typeof VALID_SETTINGS_DEFAULT_MODES)[number];
+
+/** The switchroom-wide built-in default permission mode (no yaml needed). */
+const SWITCHROOM_DEFAULT_PERMISSION_MODE: SettingsDefaultMode = "acceptEdits";
+
+/**
+ * Resolve the settings.json `permissions.defaultMode` for an agent.
+ *
+ * Precedence (highest wins):
+ *   1. agentConfig.permission_mode                 — per-agent override
+ *   2. switchroomConfig.defaults?.permission_mode  — fleet-wide override
+ *   3. "acceptEdits"                               — switchroom built-in default
+ *
+ * This is deliberately INDEPENDENT of the `[all]` tools wildcard: the wildcard
+ * drives allow-list expansion (ALL_BUILTIN_TOOLS) only, never the mode default.
+ * So every agent gets a defaultMode — an [all] agent still defaults to
+ * acceptEdits, and an explicit per-agent `permission_mode: default` wins even
+ * over the wildcard.
+ *
+ * NOTE: resolveAgentConfig / merge.ts already folds `defaults.permission_mode`
+ * into `agentConfig.permission_mode` (per-agent wins, defaults fill blanks),
+ * so (2) is a belt-and-suspenders fallback for any caller that passes an
+ * unmerged config — it never changes the outcome once the cascade has run.
+ */
+function resolvePermissionDefaultMode(
+  agentConfig: AgentConfig,
+  switchroomConfig?: SwitchroomConfig,
+): SettingsDefaultMode {
+  const raw =
+    agentConfig.permission_mode ??
+    switchroomConfig?.defaults?.permission_mode ??
+    SWITCHROOM_DEFAULT_PERMISSION_MODE;
+  if ((VALID_SETTINGS_DEFAULT_MODES as readonly string[]).includes(raw)) {
+    return raw as SettingsDefaultMode;
+  }
+  // `raw` is a schema-valid permission_mode with no settings.json defaultMode
+  // equivalent (auto/dontAsk), or an unexpected value. The `--permission-mode`
+  // CLI flag (start.sh.hbs) still carries the original value; for the
+  // settings.json defaultMode we degrade to the built-in default and warn.
+  console.warn(
+    chalk.yellow(
+      `[switchroom] permission_mode "${raw}" has no settings.json defaultMode ` +
+      `equivalent — using "${SWITCHROOM_DEFAULT_PERMISSION_MODE}" for ` +
+      `permissions.defaultMode (the --permission-mode CLI flag still carries "${raw}").`,
+    ),
+  );
+  return SWITCHROOM_DEFAULT_PERMISSION_MODE;
+}
+
 interface BuildWorkspaceContextArgs {
   name: string;
   agentDir: string;
@@ -2753,11 +2815,11 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     agentDir,
     agentConfig,
     telegramConfig,
+    switchroomConfig,
     switchroomConfigPath,
     topicId,
     tools,
     permissionAllow,
-    hasAllWildcard,
     resolvedBotToken,
     rawBotToken,
     hindsightAutoRecallEnabled,
@@ -2793,7 +2855,11 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
       ...INTERACTIVE_TUI_FLEET_DENY_TOOLS,
     ]),
     permissionAllow,
-    defaultModeAcceptEdits: hasAllWildcard,
+    // settings.json permissions.defaultMode. Decoupled from the `[all]` tools
+    // wildcard (#PR): the built-in switchroom default is acceptEdits for EVERY
+    // agent, overridable per-agent via permission_mode or fleet-wide via
+    // defaults.permission_mode. See resolvePermissionDefaultMode.
+    defaultMode: resolvePermissionDefaultMode(agentConfig, switchroomConfig),
     memory: agentConfig.memory,
     model: agentConfig.model,
     mcpServers: agentConfig.mcp_servers
@@ -5902,11 +5968,14 @@ export function reconcileAgent(
     settings.permissions = settings.permissions ?? {};
     settings.permissions.allow = desiredAllow;
     settings.permissions.deny = desiredDeny;
-    if (hasAllWildcard) {
-      settings.permissions.defaultMode = "acceptEdits";
-    } else {
-      delete settings.permissions.defaultMode;
-    }
+    // defaultMode is now emitted for EVERY agent (decoupled from the `[all]`
+    // wildcard) and MUST stay byte-identical to the scaffold path's
+    // buildWorkspaceContext → settings.json.hbs render. See
+    // resolvePermissionDefaultMode for the precedence rule.
+    settings.permissions.defaultMode = resolvePermissionDefaultMode(
+      agentConfig,
+      switchroomConfig,
+    );
 
     // mcpServers: rebuild from current switchroom.yaml. Preserves user-defined
     // mcp_servers from agentConfig.mcp_servers in addition to the built-ins.

--- a/tests/scaffold.all-wildcard-keeps-explicit.test.ts
+++ b/tests/scaffold.all-wildcard-keeps-explicit.test.ts
@@ -97,7 +97,8 @@ describe("scaffold: tools.allow [all] keeps explicit additions (klanker re-ask f
     expect(allow).toContain("Bash");
     expect(allow).toContain("Edit");
     expect(allow).not.toContain("all");
-    // hasAllWildcard drives defaultMode acceptEdits.
+    // acceptEdits is the switchroom built-in default (now decoupled from the
+    // wildcard) — an [all] agent with no override still gets it.
     expect(settings.permissions.defaultMode).toBe("acceptEdits");
   });
 

--- a/tests/scaffold.permission-default-mode.test.ts
+++ b/tests/scaffold.permission-default-mode.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent, reconcileAgent } from "../src/agents/scaffold.js";
+import type {
+  AgentConfig,
+  AgentDefaults,
+  SwitchroomConfig,
+  TelegramConfig,
+} from "../src/config/schema.js";
+
+// Change B: acceptEdits is the switchroom BUILT-IN default for the
+// settings.json `permissions.defaultMode` of EVERY agent — no yaml needed —
+// overridable per-agent via `permission_mode` OR fleet-wide via
+// `defaults.permission_mode`. Precedence (highest wins):
+//   1. agentConfig.permission_mode
+//   2. defaults.permission_mode
+//   3. "acceptEdits"
+// This is deliberately DECOUPLED from the `tools.allow: [all]` wildcard — the
+// wildcard still drives allow-list expansion, but no longer gates defaultMode.
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+function makeSwitchroomConfig(
+  name: string,
+  agentConfig: AgentConfig,
+  defaults?: AgentDefaults,
+): SwitchroomConfig {
+  return {
+    switchroom: { version: 1, agents_dir: "~/.switchroom/agents" },
+    telegram: telegramConfig,
+    ...(defaults ? { defaults } : {}),
+    agents: { [name]: agentConfig },
+  } as SwitchroomConfig;
+}
+
+function readDefaultMode(agentDir: string): string | undefined {
+  const settings = JSON.parse(
+    readFileSync(join(agentDir, ".claude", "settings.json"), "utf-8"),
+  );
+  return settings.permissions?.defaultMode;
+}
+
+describe("scaffold: permissions.defaultMode precedence", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-defaultmode-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // 1. The core new behavior: a plain agent (no permission_mode, no wildcard,
+  //    no fleet default) now gets acceptEdits. Previously it got NO defaultMode.
+  it("no override + no wildcard + no fleet default → acceptEdits (built-in)", () => {
+    const config = makeAgentConfig({ tools: { allow: ["Read", "Grep"], deny: [] } });
+    const switchroomConfig = makeSwitchroomConfig("plain", config);
+    const result = scaffoldAgent("plain", config, tmpDir, telegramConfig, switchroomConfig);
+    expect(readDefaultMode(result.agentDir)).toBe("acceptEdits");
+  });
+
+  // 2. The [all] wildcard, no override → still acceptEdits (unchanged outcome,
+  //    but now via the wildcard-independent code path).
+  it("[all] wildcard + no override → acceptEdits", () => {
+    const config = makeAgentConfig({ tools: { allow: ["all"], deny: [] } });
+    const switchroomConfig = makeSwitchroomConfig("wild", config);
+    const result = scaffoldAgent("wild", config, tmpDir, telegramConfig, switchroomConfig);
+    expect(readDefaultMode(result.agentDir)).toBe("acceptEdits");
+  });
+
+  // 3. Per-agent override wins EVEN over the wildcard.
+  it("[all] wildcard + permission_mode: default → default (override beats wildcard)", () => {
+    const config = makeAgentConfig({
+      tools: { allow: ["all"], deny: [] },
+      permission_mode: "default",
+    });
+    const switchroomConfig = makeSwitchroomConfig("wild-manual", config);
+    const result = scaffoldAgent("wild-manual", config, tmpDir, telegramConfig, switchroomConfig);
+    expect(readDefaultMode(result.agentDir)).toBe("default");
+  });
+
+  // 4. Fleet-wide default applies when the agent has no per-agent override.
+  it("defaults.permission_mode: plan + no per-agent override → plan", () => {
+    const config = makeAgentConfig({ tools: { allow: ["Read"], deny: [] } });
+    const switchroomConfig = makeSwitchroomConfig("fleet-plan", config, {
+      permission_mode: "plan",
+    } as AgentDefaults);
+    const result = scaffoldAgent("fleet-plan", config, tmpDir, telegramConfig, switchroomConfig);
+    expect(readDefaultMode(result.agentDir)).toBe("plan");
+  });
+
+  // 5. Per-agent override beats the fleet default.
+  it("defaults.permission_mode: plan + agent permission_mode: acceptEdits → acceptEdits", () => {
+    const config = makeAgentConfig({
+      tools: { allow: ["Read"], deny: [] },
+      permission_mode: "acceptEdits",
+    });
+    const switchroomConfig = makeSwitchroomConfig("fleet-vs-agent", config, {
+      permission_mode: "plan",
+    } as AgentDefaults);
+    const result = scaffoldAgent(
+      "fleet-vs-agent",
+      config,
+      tmpDir,
+      telegramConfig,
+      switchroomConfig,
+    );
+    expect(readDefaultMode(result.agentDir)).toBe("acceptEdits");
+  });
+
+  // 6. The reconcile path must produce the SAME defaultMode as the scaffold
+  //    path for the same config — guard against the two code paths diverging.
+  it("reconcile path produces the same defaultMode as scaffold", () => {
+    const cases: Array<{ name: string; config: AgentConfig; defaults?: AgentDefaults }> = [
+      { name: "rc-plain", config: makeAgentConfig({ tools: { allow: ["Read"], deny: [] } }) },
+      { name: "rc-wild", config: makeAgentConfig({ tools: { allow: ["all"], deny: [] } }) },
+      {
+        name: "rc-agent-override",
+        config: makeAgentConfig({ tools: { allow: ["all"], deny: [] }, permission_mode: "plan" }),
+      },
+      {
+        name: "rc-fleet",
+        config: makeAgentConfig({ tools: { allow: ["Read"], deny: [] } }),
+        defaults: { permission_mode: "default" } as AgentDefaults,
+      },
+    ];
+    for (const { name, config, defaults } of cases) {
+      const switchroomConfig = makeSwitchroomConfig(name, config, defaults);
+      const result = scaffoldAgent(name, config, tmpDir, telegramConfig, switchroomConfig);
+      const scaffoldMode = readDefaultMode(result.agentDir);
+      reconcileAgent(name, config, tmpDir, telegramConfig, switchroomConfig);
+      const reconcileMode = readDefaultMode(join(tmpDir, name));
+      expect(reconcileMode, `reconcile diverged from scaffold for ${name}`).toBe(scaffoldMode);
+    }
+  });
+
+  // 7. A schema-valid permission_mode with no settings.json defaultMode
+  //    equivalent (auto/dontAsk) degrades to the built-in default WITH a
+  //    warning — the --permission-mode CLI flag still carries the raw value.
+  it("permission_mode: auto (no defaultMode equivalent) → warn + acceptEdits fallback", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const config = makeAgentConfig({
+        tools: { allow: ["Read"], deny: [] },
+        permission_mode: "auto",
+      });
+      const switchroomConfig = makeSwitchroomConfig("auto-agent", config);
+      const result = scaffoldAgent("auto-agent", config, tmpDir, telegramConfig, switchroomConfig);
+      expect(readDefaultMode(result.agentDir)).toBe("acceptEdits");
+      expect(warnSpy).toHaveBeenCalled();
+      const msg = warnSpy.mock.calls.map((c) => String(c[0])).join("\n");
+      expect(msg).toContain("auto");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -553,7 +553,10 @@ describe("scaffoldAgent", () => {
         "WebSearch",
         "AskUserQuestion",
       ]);
-      expect(settings.permissions.defaultMode).toBeUndefined();
+      // acceptEdits is now the switchroom built-in default for EVERY agent
+      // (decoupled from the `[all]` wildcard) — a plain non-wildcard agent
+      // with no permission_mode / no fleet default gets it too.
+      expect(settings.permissions.defaultMode).toBe("acceptEdits");
     } finally {
       if (prev === undefined) delete process.env.SWITCHROOM_WEBKITE_BINARY;
       else process.env.SWITCHROOM_WEBKITE_BINARY = prev;


### PR DESCRIPTION
## Summary

Two independent changes on one branch, one commit each.

### A — bump bundled Claude Code CLI to 2.1.205 (`6efc28b0`)
Bumps the `CLAUDE_CODE_VERSION` build-arg default from `2.1.199` → `2.1.205` in **both** `docker/Dockerfile.base` and `docker/Dockerfile.hindsight`, kept in lockstep (#1978) so agent containers and the hindsight memory provider ship the identical `claude` bundle. Remaining `2.1.199` references are historical (CHANGELOG, `rollout.ts` example comments, transcript-source notes) and are left as-is.

### B — `acceptEdits` is the built-in default permission mode (`f83d27ba`)
Previously `settings.json` `permissions.defaultMode` was set to `acceptEdits` **only** for agents whose `tools.allow` contained the `[all]` wildcard (on both scaffold and reconcile paths); everyone else got no `defaultMode`.

Now `acceptEdits` is the switchroom built-in default for **every** agent — no yaml needed — and is **decoupled** from the `[all]` wildcard (which still drives allow-list expansion only). New precedence (highest wins):

1. `agents.<name>.permission_mode` — per-agent override
2. `defaults.permission_mode` — fleet-wide override
3. `"acceptEdits"` — built-in default

The per-agent override wins **even for an `[all]` agent**. A single `resolvePermissionDefaultMode()` helper is the source of truth for both the scaffold (`buildWorkspaceContext`) and reconcile paths, so they cannot diverge. `settings.json.hbs` now always emits `defaultMode` from the resolved value rather than the old `{{#if defaultModeAcceptEdits}}` conditional.

`auto`/`dontAsk` are valid `--permission-mode` CLI flags but have no settings.json `defaultMode` equivalent, so they warn + fall back to `acceptEdits` for `defaultMode` while the CLI flag still carries the raw value. Invalid `permission_mode` values are already rejected at config-parse time by the zod schema. `dangerous_mode` is untouched.

## Test coverage (`tests/scaffold.permission-default-mode.test.ts`)
1. no override + no wildcard + no fleet default → `acceptEdits` (the core new behavior)
2. `[all]` wildcard + no override → `acceptEdits`
3. `[all]` wildcard + per-agent override → override wins over the wildcard
4. fleet `defaults.permission_mode: plan`, no per-agent → `plan`
5. fleet `plan` + per-agent `acceptEdits` → `acceptEdits` (per-agent beats fleet)
6. reconcile path produces the SAME `defaultMode` as scaffold for the same config (parity guard)
7. `permission_mode: auto` → warn + `acceptEdits` fallback

Existing "no defaultMode when no wildcard" expectation updated to `acceptEdits`. Docs updated in `docs/configuration.md` (field-reference row + a new "Permission mode & auto-accept" section).

`tsc --noEmit` clean, `npm run lint` clean, scaffold/permission/settings/merge/schema suites green. (Two pre-existing failures in `tests/scaffold.persistent-home.test.ts` are env-dependent — no host `~/.switchroom` symlink in the CI container — and fail identically on clean `origin/main`; unrelated to this change.)

Preps the **v0.18.3** release alongside the already-merged watchdog fix (#2949).

🤖 Generated with [Claude Code](https://claude.com/claude-code)