### PR TITLE
fix(gateway): don't crash gateway on stale/migrated-chat 400 GrammyErrors

### DIFF
--- a/telegram-plugin/gateway/unhandled-rejection-policy.ts
+++ b/telegram-plugin/gateway/unhandled-rejection-policy.ts
@@ -126,7 +126,27 @@ export function classifyRejection(
     // handler shut the process down. reconcileStatusPin now absorbs its own
     // errors (primary fix); this entry is defense-in-depth so ANY leaked
     // pin-rights 400 from any path is log-only, not fatal.
-    desc.includes('not enough rights')
+    desc.includes('not enough rights') ||
+    // 'group chat was upgraded to a supergroup chat' fires when a send
+    // targets a basic-group chat_id that Telegram has since migrated to
+    // a supergroup (new id format -100xxxxxxxxxx). Telegram sometimes
+    // surfaces the replacement id via `error.parameters.migrate_to_chat_id`
+    // but not reliably for every send method, so this handler can't always
+    // auto-repair the stale id — it can only make the failure non-fatal.
+    // This crashed marko's gateway on 2026-07-09 (and recurred from the
+    // same stale-id root cause on 2026-06-07 and 2026-06-09): a send to an
+    // old pre-migration group id crashed the WHOLE gateway process for
+    // every agent/chat, not just the one stale chat. A single unmigrated
+    // chat_id in cached state must never be fatal — log it so the stale id
+    // can be tracked down and fixed, but keep serving every other chat.
+    desc.includes('group chat was upgraded to a supergroup chat') ||
+    // Broader class: any 400 whose description signals the target
+    // chat_id itself is no longer valid (migrated, deactivated, or
+    // otherwise unresolvable). These are all "this one destination is
+    // broken", never "the gateway is broken" — same log-only posture as
+    // 'chat not found' above.
+    desc.includes('chat_id is empty') ||
+    desc.includes('group chat was deactivated')
   ) {
     return 'log_only'
   }

--- a/telegram-plugin/tests/unhandled-rejection-policy.test.ts
+++ b/telegram-plugin/tests/unhandled-rejection-policy.test.ts
@@ -96,6 +96,25 @@ describe('classifyRejection — benign Telegram 400s', () => {
     )
     expect(classifyRejection(err)).toBe('log_only')
   })
+  it('returns "log_only" for "group chat was upgraded to a supergroup chat" (marko 2026-07-09, recurring 2026-06-07/2026-06-09)', () => {
+    // A send targeted a basic-group chat_id that Telegram had since
+    // migrated to a supergroup (new -100xxxxxxxxxx id). This crashed the
+    // ENTIRE gateway process (every agent/chat) over a single stale
+    // cached chat_id — the same root cause recurred three times across a
+    // month because the crash-on-leak behavior masked the underlying
+    // stale-id bug instead of just logging it. A migrated/invalid
+    // destination chat must never take down the whole gateway.
+    const err = grammyError(
+      400,
+      'Bad Request: group chat was upgraded to a supergroup chat',
+    )
+    expect(classifyRejection(err)).toBe('log_only')
+  })
+
+  it('returns "log_only" for "group chat was deactivated"', () => {
+    const err = grammyError(400, 'Bad Request: group chat was deactivated')
+    expect(classifyRejection(err)).toBe('log_only')
+  })
 })
 
 describe('classifyRejection — genuine errors still crash', () => {


### PR DESCRIPTION
## Summary

marko's telegram gateway crashed at `2026-07-09T03:52:56Z` with:

```
telegram gateway: unhandledRejection: GrammyError: Call to 'sendRichMessage' failed! (400: Bad Request: group chat was upgraded to a supergroup chat)
```

This is a **recurring** bug — the same GrammyError also crashed marko's gateway on 2026-06-02, 2026-06-04, 2026-06-07, and 2026-06-09 (5 occurrences total, all matching `grep "upgraded to a supergroup" gateway-supervisor.log`). Each time, the process-level `unhandledRejection` handler treated this 400 as fatal and killed the *entire* gateway process — every agent/chat, not just the one broken send — which orphaned the in-flight turn and left the gateway wedged in a "re-clearing composer + re-delivering" loop on reboot until a manual container restart.

## Fix 1 — gateway resilience (primary)

`telegram-plugin/gateway/unhandled-rejection-policy.ts` already has a narrow allowlist of benign Telegram 400s that are logged rather than fatal (`message is not modified`, `chat not found`, `not enough rights`, etc. — see the file's history for prior crash-loop fixes of the same shape). Added:

- `group chat was upgraded to a supergroup chat` — the exact crash from this incident.
- `group chat was deactivated` — same class (target chat_id is dead/invalid), same non-fatal posture.

A single unreachable/migrated destination chat must never take down the whole gateway process for every other agent and chat. Added test cases to `telegram-plugin/tests/unhandled-rejection-policy.test.ts` covering both.

Grammy's `GrammyError` can carry `error.parameters.migrate_to_chat_id` for this error class, but it wasn't present on this particular send method/path in the logs, so the handler can't reliably auto-repair the id — it can only make the failure non-fatal instead of crash-fatal.

## Fix 2 — the stale chat_id itself (investigated + fixed)

Traced `-5164217975` (the id in the crash) to `/host-home/.switchroom/agents/marko/telegram/access.json`'s `groups{}` map — **not** present in `switchroom.yaml` (already confirmed by the reporter), so it wasn't fleet config drift, it was leftover per-agent runtime state.

Queried Telegram's `getChat` directly with marko's bot token to identify the chat:

```json
{"id":-5164217975,"title":"Panorama Marketing","type":"group", ...}
```

Title "Panorama Marketing" matches the supergroup already correctly registered in `switchroom.yaml` at `chat_id: "-1003831053471"` (comment: "Panorama Marketing supergroup"). Also checked whether `-1003831053471` seen elsewhere in the log (a separate supergroup-routing issue) was the *same* migrated group — confirmed it is not a coincidence, it **is** the same group, just already correctly configured under its new id.

So `access.json` had both the old pre-migration id and the new post-migration id registered as two separate groups — the old one being dead weight that periodically got targeted (e.g. by a cron-driven daily send) and crashed the gateway on every hit. Removed the stale `-5164217975` entry directly from `access.json` (this file isn't tracked in this repo — it's per-agent runtime state on the host, not part of the PR diff). marko's gateway needs a restart to pick up the corrected `access.json` — not done as part of this PR, flagging for the operator/parent agent to action.

## Test plan

- [x] `bun test telegram-plugin/tests/unhandled-rejection-policy.test.ts` — 22 pass, 0 fail (was 20 before this change)
- [x] `npx vitest run telegram-plugin` — 327/330 files pass; the 3 failing files (`status-accent.test.ts`, `stream-reply-handler.test.ts`) are pre-existing markdown-escaping (`*` vs `_`) failures unrelated to this change — confirmed by re-running the same file against `main` (`git stash`) with identical failures before this diff was applied.
- [x] Confirmed via live `getChat` call that `-5164217975` and `-1003831053471` are the same Telegram group ("Panorama Marketing"), pre/post supergroup migration.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>