### PR TITLE
fix(vault-broker): rotate audit log via copy-then-truncate (#2953)

### DIFF
--- a/src/vault/broker/audit-log.test.ts
+++ b/src/vault/broker/audit-log.test.ts
@@ -344,6 +344,80 @@ describe("createAuditLogger rotation", () => {
     writeN(audit, 50);
     expect(fs.existsSync(`${logPath}.1`)).toBe(false);
   });
+
+  // ── copy-then-truncate rotation (#2953) ────────────────────────────────
+  // The active log is bind-mounted into the broker container as a SINGLE
+  // FILE, which makes it a mount point. rename() cannot replace an active
+  // mount point (EBUSY), so rotation must copy-then-truncate: snapshot the
+  // bytes to `.1`, then ftruncate the active file in place. These tests
+  // pin that behaviour — the active inode must survive rotation (proving we
+  // truncate rather than rename/recreate), `.1` must carry the old content,
+  // and the live file must be truncated yet immediately writable again.
+  it("preserves the active file's inode across rotation (truncate-in-place, not rename)", () => {
+    const audit = createAuditLogger({ path: logPath, maxBytes: 200, maxFiles: 3 });
+    // First write creates the file — capture its inode.
+    writeN(audit, 1);
+    const inodeBefore = fs.statSync(logPath).ino;
+    // Push past the threshold to force a rotation.
+    writeN(audit, 20);
+    expect(fs.existsSync(`${logPath}.1`)).toBe(true);
+    const inodeAfter = fs.statSync(logPath).ino;
+    // Same inode ⇒ we truncated the original file rather than replacing it.
+    // This is exactly the property that makes rotation survive a single-file
+    // bind mount (the mount point is preserved).
+    expect(inodeAfter).toBe(inodeBefore);
+  });
+
+  it("snapshots old content to .1 and leaves the active file truncated but writable", () => {
+    const audit = createAuditLogger({ path: logPath, maxBytes: 200, maxFiles: 3 });
+    // Write enough to cross the threshold at least once.
+    writeN(audit, 12);
+    expect(fs.existsSync(`${logPath}.1`)).toBe(true);
+
+    // The rotated snapshot carries the earlier rows.
+    const rotatedRows = readLines(`${logPath}.1`);
+    expect(rotatedRows.length).toBeGreaterThan(0);
+    for (const line of rotatedRows) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+
+    // The active file is smaller than the total history would have been —
+    // it was truncated, not left to grow unbounded (the #2953 symptom).
+    const activeSize = fs.statSync(logPath).size;
+    const rotatedSize = fs.statSync(`${logPath}.1`).size;
+    expect(activeSize).toBeLessThanOrEqual(rotatedSize + 400);
+
+    // The active file is still writable after truncation — a subsequent
+    // append lands cleanly and parses as JSON.
+    audit.write({
+      ts: "2026-04-28T15:00:00.000Z",
+      op: "get",
+      key: "post/rotation",
+      caller: "agent:test",
+      pid: 2,
+      result: "allowed",
+    });
+    const activeRows = readLines(logPath);
+    expect(activeRows.length).toBeGreaterThan(0);
+    const last = JSON.parse(activeRows[activeRows.length - 1]) as AuditEntry;
+    expect(last.key).toBe("post/rotation");
+  });
+
+  it("rotation raw logic: copy-then-truncate over a pre-populated file", () => {
+    // Isolate the copy-then-truncate contract from the size-trigger: write a
+    // fat file, then force a rotation by writing one more row past a tiny
+    // threshold, and assert the snapshot+truncate invariants directly.
+    const audit = createAuditLogger({ path: logPath, maxBytes: 100, maxFiles: 2 });
+    writeN(audit, 1);
+    const firstRow = fs.readFileSync(logPath, "utf8");
+    expect(firstRow.trim().length).toBeGreaterThan(0);
+    // Next write trips the threshold (file already > 100 bytes), rotating.
+    writeN(audit, 1);
+    expect(fs.existsSync(`${logPath}.1`)).toBe(true);
+    // The snapshot begins with the very first row we wrote.
+    const snapshot = fs.readFileSync(`${logPath}.1`, "utf8");
+    expect(snapshot.startsWith(firstRow.split("\n")[0])).toBe(true);
+  });
 });
 
 // ─── defaultAuditLogPath ──────────────────────────────────────────────────────

--- a/src/vault/broker/audit-log.ts
+++ b/src/vault/broker/audit-log.ts
@@ -170,12 +170,29 @@ function resolveRotation(opts: AuditLoggerOptions): {
 
 /**
  * Rotate the audit log: `<path>.(n-1)` → `<path>.n`, dropping the oldest
- * past `maxFiles`, then `<path>` → `<path>.1`. The active path is left
- * absent so the next append re-creates an empty file; the in-process hash
- * chain is intentionally NOT reset, so the first row of the new file links
- * back to the last row of `<path>.1` and cross-file continuity holds.
- * Best-effort: any failure is reported and rotation is skipped (the
+ * past `maxFiles`, then snapshot `<path>` → `<path>.1` and truncate the
+ * active file back to zero bytes IN PLACE.
+ *
+ * Why copy-then-truncate rather than rename (issue #2953): in the deployed
+ * topology the active log is bind-mounted into the broker container as a
+ * SINGLE FILE (not its parent directory), which makes `<path>` a mount
+ * point inside the container's mount namespace. `rename(2)` cannot replace
+ * an active mount point, so `rename(<path>, <path>.1)` fails with EBUSY on
+ * every attempt and the log grows unbounded. Copying the bytes out to
+ * `<path>.1` and then `ftruncate`-ing the original to length 0 keeps the
+ * active inode/mount point in place, so it works regardless of whether the
+ * operator mounts the file or its parent directory.
+ *
+ * The active file is truncated (not deleted/recreated), so its inode, mode,
+ * and — critically — its bind mount survive. The in-process hash chain is
+ * intentionally NOT reset, so the first row appended after truncation links
+ * back to the last row now living in `<path>.1` and cross-file continuity
+ * holds. Best-effort: any failure is reported and rotation is skipped (the
  * current file keeps growing rather than losing data).
+ *
+ * NOTE: the `.1 … .maxFiles` rotated files are ordinary files created by
+ * this function inside the log's directory, so shifting them with `rename`
+ * is safe — only the active `<path>` is (potentially) a mount point.
  */
 function rotateAuditLog(logPath: string, maxFiles: number): void {
   // Delete the oldest retained file if it exists — it would fall off the
@@ -190,7 +207,8 @@ function rotateAuditLog(logPath: string, maxFiles: number): void {
       );
     }
   }
-  // Shift .(n-1) → .n for n = maxFiles down to 2.
+  // Shift .(n-1) → .n for n = maxFiles down to 2. These are ordinary files
+  // (never mount points), so rename is fine.
   for (let n = maxFiles - 1; n >= 1; n--) {
     const from = `${logPath}.${n}`;
     const to = `${logPath}.${n + 1}`;
@@ -204,12 +222,26 @@ function rotateAuditLog(logPath: string, maxFiles: number): void {
       return;
     }
   }
-  // Finally, active → .1.
+  // Finally, snapshot active → .1 by COPYING the bytes, then truncate the
+  // active file in place. Copy first: if the copy fails we leave the active
+  // file untouched (grow rather than lose rows). Only after the snapshot is
+  // safely on disk do we truncate the live file back to zero length.
   try {
-    fs.renameSync(logPath, `${logPath}.1`);
+    fs.copyFileSync(logPath, `${logPath}.1`);
   } catch (err) {
     process.stderr.write(
-      `[vault-audit] ERROR: could not rotate active audit log ${logPath}: ${(err as Error).message}\n`,
+      `[vault-audit] ERROR: could not snapshot active audit log ${logPath} → ${logPath}.1: ${(err as Error).message}\n`,
+    );
+    return;
+  }
+  try {
+    // truncate(2) resets length to 0 while preserving the inode, mode, and
+    // any bind mount at this path — unlike rename, which would fail EBUSY on
+    // a single-file bind mount (issue #2953).
+    fs.truncateSync(logPath, 0);
+  } catch (err) {
+    process.stderr.write(
+      `[vault-audit] ERROR: could not truncate active audit log ${logPath}: ${(err as Error).message}\n`,
     );
   }
 }


### PR DESCRIPTION
## Root cause

`vault-audit.log` is bind-mounted into the `vault-broker` container as a **single file** (not its parent directory), which makes that path a mount point inside the container's mount namespace. `rename(2)` cannot replace an active mount point, so the size-based rotation (`vault-audit.log` → `vault-audit.log.1`) failed with `EBUSY` on **every** attempt:

```
[vault-audit] ERROR: could not rotate active audit log ... : EBUSY: resource busy or locked, rename '.../vault-audit.log' -> '.../vault-audit.log.1'
```

Writes still succeeded, but the log never rotated and grew unbounded (~464 MB on the affected host).

## Fix (Option 2 from the issue)

Change the **active-file** rotation in `rotateAuditLog()` from rename to **copy-then-truncate**:

1. Copy the current log bytes to `<path>.1` (snapshot).
2. `ftruncate` the live file to zero length **in place**.

`truncate(2)` preserves the inode, mode, and — critically — the bind mount at the active path, so rotation now works whether the operator mounts the single file or its parent directory. Copy runs before truncate, so a failed snapshot leaves the live file untouched (grow rather than lose rows).

The `.1 … .maxFiles` shift stays rename-based — those are ordinary files created inside the log's directory, never mount points. The in-process hash chain is preserved across the rotation seam, so cross-file tamper-evidence continuity holds (verified by the existing chain-continuity test).

### On the mount config (Option 1)

`src/agents/compose.ts` intentionally single-file-mounts `vault-audit.log` so admin agents can `:ro`-mount the same host file (see #1024/#1025). Switching to a directory mount would be a broader, riskier change to that contract. The code-level copy-then-truncate fix resolves the bug **regardless** of the mount topology, so the compose config is left unchanged.

## Tests

Added to `src/vault/broker/audit-log.test.ts`:
- active file's inode survives rotation (proves truncate-in-place, not rename/recreate)
- `<path>.1` carries the old content and the live file is truncated but immediately writable again
- copy-then-truncate over a pre-populated file snapshots the earlier rows

## Verification

- `npx vitest run src/vault/broker/audit-log.test.ts` → 21 passed
- `npx vitest run src/vault/` → 341 passed
- `npm run build` → green
- `npm run lint` (tsc + all repo lint checks) → clean

Fixes #2953

🤖 Generated with [Claude Code](https://claude.com/claude-code)