### PR TITLE
fix(hooks): Stop hook catches trailing reply dropped after an earlier reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+### Stop hook: catch a dropped final reply written after an earlier qualifying reply
+
+The `silent-end-interrupt-stop.mjs` Stop hook's transcript scan
+(`scanTurnForFinalReply` in `silent-end-scan.mjs`) returned `allow` on the
+FIRST qualifying `reply`/`stream_reply` tool call it found while scanning a
+turn forward — effectively "was `reply` called at least once this turn?"
+rather than "did the turn's actual final answer reach the user?". A turn that
+(1) called `reply` early with a short, notification-bearing interim ack (which
+always qualifies as "final" under `isFinalAnswerReply`, regardless of length),
+then (2) kept working and wrote a substantive plain-text verdict afterward
+with no second `reply` call, slipped through the hook undetected — the real
+answer never reached the user and the hook reported `hookErrors: []`,
+`preventedContinuation: false`. The scan now walks the full turn, finds the
+LAST qualifying delivery/silence event, and blocks if any plain assistant
+text was written after it and never (re-)sent through a delivery tool — same
+posture as the existing zero-reply block path, without flagging turns that
+simply end on a delivering `reply` tool_use with nothing after it.
+
 ## v0.18.3 — Watchdog thinking-pause fix, acceptEdits fleet default, Claude CLI 2.1.205, configurable retain cadence
 
 ### Gateway: orphaned-reply watchdog survives model thinking pauses (#2949)

--- a/telegram-plugin/hooks/silent-end-scan.mjs
+++ b/telegram-plugin/hooks/silent-end-scan.mjs
@@ -127,23 +127,46 @@ function buildTurnKey(chatId, threadId) {
 }
 
 /**
+ * Build the `{ decided: 'block', ... }` result shape, populating
+ * `turnKey`/`chatId`/`threadId` from the enqueue envelope when
+ * available. Shared by both block branches below.
+ *
+ * @param {ReturnType<typeof parseChannelEnvelope>} envelope
+ * @param {string} reason
+ */
+function buildBlockResult(envelope, reason) {
+  const block = { decided: 'block', reason }
+  if (envelope.chatId) {
+    block.chatId = envelope.chatId
+    block.threadId = envelope.threadId
+    block.turnKey = buildTurnKey(envelope.chatId, envelope.threadId)
+  }
+  return block
+}
+
+/**
  * Scan a JSONL transcript and decide whether the current turn ended
  * with a final reply delivered.
  *
  * Returns:
- *   { decided: 'allow', reason }    — qualifying reply OR silent marker found
+ *   { decided: 'allow', reason }    — qualifying reply OR silent marker found,
+ *                                     and nothing undelivered was written
+ *                                     after it
  *   { decided: 'block', reason, turnKey?, chatId?, threadId? }
- *                                   — turn-start found, no qualifying reply,
- *                                     no marker. `turnKey`/`chatId`/`threadId`
- *                                     populated from the enqueue's channel
- *                                     envelope so the hook can write a state
- *                                     file shape that matches what the
- *                                     gateway's `recordSilentTurnEnd` would
- *                                     write — keeping the retry-count
- *                                     preservation gate at
- *                                     `silent-end.ts:114` happy when the
- *                                     gateway's later write reads back the
- *                                     hook's state.
+ *                                   — turn-start found, no qualifying reply
+ *                                     delivered (or a qualifying reply
+ *                                     happened, but the model kept writing
+ *                                     plain-text content afterward that was
+ *                                     never sent through a delivery tool).
+ *                                     `turnKey`/`chatId`/`threadId` populated
+ *                                     from the enqueue's channel envelope so
+ *                                     the hook can write a state file shape
+ *                                     that matches what the gateway's
+ *                                     `recordSilentTurnEnd` would write —
+ *                                     keeping the retry-count preservation
+ *                                     gate at `silent-end.ts:114` happy when
+ *                                     the gateway's later write reads back
+ *                                     the hook's state.
  *   { decided: 'unknown', reason }  — couldn't locate turn-start; caller fail-open
  *
  * Turn-start anchor: the most recent `queue-operation`/`enqueue` line
@@ -153,6 +176,28 @@ function buildTurnKey(chatId, threadId) {
  * the most recent message. (Mild over-allow risk on the multi-enqueue
  * edge case where the model replied combined ahead of the second
  * enqueue's append; accepted residual.)
+ *
+ * IMPORTANT — trailing-content check (fixes the "at least once" bug):
+ * a naive scan that returns 'allow' on the FIRST qualifying reply it
+ * finds is wrong. A turn can legitimately call `reply` early (e.g. a
+ * notification-bearing interim ack — `disable_notification` unset/false
+ * always qualifies as "final" under `isFinalAnswerReply`, regardless of
+ * how short the text is) and then keep working, eventually writing a
+ * SUBSTANTIVE plain-text verdict that never goes through `reply` again.
+ * The early ack satisfied "reply was called somewhere in this turn",
+ * but the user never saw the actual answer. So this scan does NOT
+ * short-circuit on the first match: it walks the ENTIRE turn in
+ * chronological order, remembers the position of the LAST qualifying
+ * delivery event (a final-answer reply/stream_reply call, or an
+ * explicit silent-marker), and then checks whether any plain assistant
+ * text block appears AFTER that position. If one does, that content was
+ * written but never delivered — block, same as the zero-reply case.
+ *
+ * This deliberately does NOT flag a turn that ends on a delivery
+ * tool_use with nothing after it (the normal, healthy shape), nor a
+ * turn where all assistant text precedes the final delivering reply
+ * (the model narrating before it sends) — only text that comes AFTER
+ * the last delivery event counts as a drop.
  *
  * @param {string} jsonl
  * @returns {{ decided: 'allow' | 'block' | 'unknown', reason: string, turnKey?: string, chatId?: string, threadId?: number | null }}
@@ -178,8 +223,13 @@ export function scanTurnForFinalReply(jsonl) {
     return { decided: 'unknown', reason: 'no-turn-start' }
   }
 
-  // 2. Scan forward from the turn start; look for qualifying tool_use
-  //    or silent-marker text.
+  // 2. Flatten every assistant content block (text and tool_use) from
+  //    the turn into a single chronologically-ordered list. Classify
+  //    each block as it's collected: a "delivery" event (qualifying
+  //    final-answer reply/stream_reply, or an explicit silent marker —
+  //    whether emitted as plain text or as a reply-tool payload) or
+  //    plain undelivered text.
+  const blocks = []
   for (let i = startIdx + 1; i < lines.length; i++) {
     const line = lines[i]
     if (!line || line[0] !== '{') continue
@@ -193,16 +243,19 @@ export function scanTurnForFinalReply(jsonl) {
     const content = obj?.message?.content
     if (!Array.isArray(content)) continue
     for (const c of content) {
-      // Plain assistant text carve-out (#2053): a turn that ends with a
-      // trailing bare NO_REPLY / HEARTBEAT_OK line — emitted as plain
-      // transcript text, NOT through the reply tool — is the model
-      // explicitly signalling "intentionally silent". The anchored
-      // SILENT_MARKER_RE below only fires when the ENTIRE reply-tool
-      // text is the bare marker, so a plain-text prose+NO_REPLY turn
-      // matched nothing here → block → nag → sentinel leak. Treat a
-      // trailing-marker text block as a valid silent end.
-      if (c?.type === 'text' && endsWithSilentMarker(String(c.text ?? ''))) {
-        return { decided: 'allow', reason: 'silent-marker-text' }
+      if (c?.type === 'text') {
+        // Plain assistant text carve-out (#2053): a turn that ends with
+        // a trailing bare NO_REPLY / HEARTBEAT_OK line — emitted as
+        // plain transcript text, NOT through the reply tool — is the
+        // model explicitly signalling "intentionally silent". Treat a
+        // trailing-marker text block as a delivery/silence event;
+        // anything else is candidate undelivered content.
+        if (endsWithSilentMarker(String(c.text ?? ''))) {
+          blocks.push({ kind: 'deliver', reason: 'silent-marker-text' })
+        } else if (String(c.text ?? '').trim().length > 0) {
+          blocks.push({ kind: 'text' })
+        }
+        continue
       }
       if (c?.type !== 'tool_use') continue
       if (!REPLY_TOOLS.has(c.name)) continue
@@ -214,33 +267,63 @@ export function scanTurnForFinalReply(jsonl) {
       // prose+trailing-marker shape (#2053). Same posture as the
       // gateway's silent-marker suppression at gateway.ts:6692.
       if (SILENT_MARKER_RE.test(text.trim()) || endsWithSilentMarker(text)) {
-        return { decided: 'allow', reason: 'silent-marker' }
+        blocks.push({ kind: 'deliver', reason: 'silent-marker' })
+        continue
       }
       if (isFinalAnswerReply({
         text,
         disableNotification: input.disable_notification === true,
         done: input.done === true,
       })) {
-        return { decided: 'allow', reason: 'final-reply' }
+        blocks.push({ kind: 'deliver', reason: 'final-reply' })
+        continue
       }
+      // Non-qualifying reply call (interim ack) — delivered to the
+      // user, but not a "final answer". It's neither a delivery event
+      // nor undelivered text, so it doesn't affect the decision either
+      // way; simply not pushed.
     }
   }
 
-  // Cron-fired turns (#2053): a scheduled turn that produced no
-  // qualifying reply is NOT a delivery failure the user is waiting on —
-  // nagging it only pushes the model to escape the loop by shoving a
-  // NO_REPLY sentinel through the reply tool, which leaks to chat. A
-  // cron turn that genuinely needs to speak will have called reply
-  // (caught above); otherwise let it end silently.
-  if (envelope.source === 'cron') {
-    return { decided: 'allow', reason: 'cron-source' }
+  // 3. Find the LAST delivery event's position, then check whether any
+  //    plain-text block appears strictly after it. This is the fix for
+  //    the "at least once" bug: a naive scan that stops at the FIRST
+  //    qualifying reply misses substantive content the model wrote
+  //    afterward and never (re-)sent.
+  let lastAllowBlockIdx = -1
+  let lastAllowReason = null
+  for (let i = 0; i < blocks.length; i++) {
+    if (blocks[i].kind === 'deliver') {
+      lastAllowBlockIdx = i
+      lastAllowReason = blocks[i].reason
+    }
+  }
+  const sawUndeliveredTextAfterAllow = blocks
+    .slice(lastAllowBlockIdx + 1)
+    .some((b) => b.kind === 'text')
+
+  if (lastAllowBlockIdx === -1) {
+    // No qualifying delivery/silence event anywhere in the turn.
+    // Cron-fired turns (#2053): a scheduled turn that produced no
+    // qualifying reply is NOT a delivery failure the user is waiting
+    // on — nagging it only pushes the model to escape the loop by
+    // shoving a NO_REPLY sentinel through the reply tool, which leaks
+    // to chat. A cron turn that genuinely needs to speak will have
+    // called reply (caught above); otherwise let it end silently.
+    if (envelope.source === 'cron') {
+      return { decided: 'allow', reason: 'cron-source' }
+    }
+    return buildBlockResult(envelope, 'no-final-reply')
   }
 
-  const block = { decided: 'block', reason: 'no-final-reply' }
-  if (envelope.chatId) {
-    block.chatId = envelope.chatId
-    block.threadId = envelope.threadId
-    block.turnKey = buildTurnKey(envelope.chatId, envelope.threadId)
+  if (sawUndeliveredTextAfterAllow) {
+    // A qualifying delivery DID happen somewhere in the turn, but the
+    // model kept writing after it and that trailing content was never
+    // sent through a delivery tool. This is the "at least once" bug:
+    // an early ack (or any qualifying reply) must not amnesty
+    // everything written afterward.
+    return buildBlockResult(envelope, 'trailing-text-after-reply')
   }
-  return block
+
+  return { decided: 'allow', reason: lastAllowReason }
 }

--- a/telegram-plugin/hooks/silent-end-scan.mjs
+++ b/telegram-plugin/hooks/silent-end-scan.mjs
@@ -33,6 +33,28 @@
  * delivery obligation.
  */
 
+// Verified complete (2026-07-09, adversarial-review follow-up): `reply`
+// and `stream_reply` are the ONLY two MCP tools whose payload is the
+// model's free-text final-answer content reaching the user — the exact
+// scope `final-answer-detect.ts`'s own docstring claims ("plain assistant
+// transcript text instead of a `reply` / `stream_reply` tool call").
+// Cross-checked the full tool surface in `telegram-plugin/bridge/bridge.ts`
+// (`TOOL_SCHEMAS`, kept in sync with `gateway/gateway.ts`): `edit_message`
+// explicitly does NOT ping/deliver a fresh answer (its own description says
+// "send a new reply when a long task completes"); `react`, `pin_message`,
+// `delete_message`, `forward_message`, `send_typing`, `download_attachment`,
+// `get_recent_messages` carry no model-authored answer text at all;
+// `send_checklist` / `send_sticker` / `send_gif` / `ask_user` /
+// `update_checklist` deliver structured/templated content, not the turn's
+// prose answer, and are intentionally a different interaction pattern (a
+// question or a fixed artifact, not "the answer"). `stream_reply` sends its
+// FULL cumulative text snapshot on every call (not incremental chunks —
+// see `stream-reply-handler.ts` docstring), and each call is its own
+// `tool_use` block in the transcript in chronological order, so the
+// "last delivery event wins" walk below already treats a stream's final
+// (`done:true`) call as the qualifying one regardless of how many
+// intermediate non-final `stream_reply` calls preceded it. No gap found;
+// re-verify only if a new outbound-delivery tool is added to bridge.ts.
 const REPLY_TOOLS = new Set([
   'mcp__switchroom-telegram__reply',
   'mcp__switchroom-telegram__stream_reply',

--- a/telegram-plugin/tests/silent-end-interrupt-stop-integration.test.ts
+++ b/telegram-plugin/tests/silent-end-interrupt-stop-integration.test.ts
@@ -190,6 +190,59 @@ describe('silent-end-interrupt-stop.mjs — integration', () => {
     expect(state.retryCount).toBe(SILENT_END_MAX_RETRIES)
   })
 
+  it('blocks + writes retryCount=1 when an early qualifying reply is followed by an undelivered verdict (trailing-content bug repro)', () => {
+    // Confirmed-incident shape: (1) a background-task notification
+    // arrives, (2) the agent calls reply ONCE early with a stale,
+    // notification-bearing ack ("running now" — disable_notification
+    // unset, so it satisfies isFinalAnswerReply regardless of length),
+    // (3) the agent then does more work and writes a large substantive
+    // verdict as plain assistant text with NO second reply call. Pre-fix,
+    // the hook's "reply called at least once this turn" check allowed
+    // this to slip through silently — the trailing verdict never reached
+    // the user. Post-fix the hook must block on this shape exactly like
+    // the zero-reply case.
+    const transcript = writeTranscript(tmp, [
+      ENQUEUE,
+      reply('running now'),
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Bash', input: { command: 'ls' } }] } },
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Read', input: { file_path: '/tmp/x' } }] } },
+      {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'Here is the actual verdict: ' + 'X'.repeat(300) }] },
+      },
+    ])
+    const r = runHook({
+      event: { session_id: 's1', transcript_path: transcript },
+      stateDir,
+    })
+    expect(r.status).toBe(0)
+    const out = JSON.parse(r.stdout)
+    expect(out.decision).toBe('block')
+    expect(out.reason).toMatch(/Send your final answer/)
+    const statePath = join(stateDir, 'silent-end-pending.json')
+    expect(existsSync(statePath)).toBe(true)
+    const state = JSON.parse(readFileSync(statePath, 'utf8'))
+    expect(state.retryCount).toBe(1)
+    expect(state.chatId).toBe('111')
+    expect(state.turnKey).toBe('111:_')
+  })
+
+  it('does NOT false-positive on a normal single-reply turn ending on the reply tool_use', () => {
+    const transcript = writeTranscript(tmp, [
+      ENQUEUE,
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'Let me check.' }] } },
+      { type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Bash', input: { command: 'ls' } }] } },
+      reply('Here is your answer.', { disable_notification: false }),
+    ])
+    const r = runHook({
+      event: { session_id: 's1', transcript_path: transcript },
+      stateDir,
+    })
+    expect(r.status).toBe(0)
+    expect(r.stdout.trim()).toBe('')
+    expect(existsSync(join(stateDir, 'silent-end-pending.json'))).toBe(false)
+  })
+
   it('NO_REPLY in transcript → allow stop, no state file written', () => {
     const transcript = writeTranscript(tmp, [
       ENQUEUE,

--- a/telegram-plugin/tests/silent-end-interrupt-stop-scan.test.ts
+++ b/telegram-plugin/tests/silent-end-interrupt-stop-scan.test.ts
@@ -278,6 +278,29 @@ describe('scanTurnForFinalReply — trailing undelivered content after an early 
     expect(r.decided).toBe('allow')
     expect(r.reason).toBe('silent-marker-text')
   })
+
+  it('reverse case: an EARLIER NO_REPLY silence marker followed by later undelivered prose → block', () => {
+    // Mirror image of the "trailing NO_REPLY overrides" allow-case above.
+    // Here the model signals silence FIRST — as plain transcript text,
+    // not through the reply tool — and then keeps going, writing a real
+    // substantive answer afterward that it never sent through `reply` or
+    // `stream_reply`. The NO_REPLY marker is a "deliver" event (silence is
+    // a valid outcome), but it must not amnesty content written AFTER it,
+    // same failure shape as the original "at least once" bug: a naive scan
+    // that stops at the FIRST qualifying delivery/silence event would
+    // return 'allow' here and the trailing answer would be silently
+    // dropped. The fix's "last delivery event, then check for trailing
+    // text" walk must still catch this.
+    const text = jsonl(
+      ENQUEUE,
+      assistantText('Nothing to report right now.\nNO_REPLY'),
+      assistantToolUse('Bash', { command: 'ls' }),
+      assistantText('Wait, actually I found something you need to know: ' + 'Y'.repeat(300)),
+    )
+    const r = scanTurnForFinalReply(text)
+    expect(r.decided).toBe('block')
+    expect(r.reason).toBe('trailing-text-after-reply')
+  })
 })
 
 describe('scanTurnForFinalReply — silent-marker carve-out', () => {

--- a/telegram-plugin/tests/silent-end-interrupt-stop-scan.test.ts
+++ b/telegram-plugin/tests/silent-end-interrupt-stop-scan.test.ts
@@ -184,6 +184,102 @@ describe('scanTurnForFinalReply — final-reply detection', () => {
   })
 })
 
+// ── "at least once" bug regression — trailing content after an early
+//    qualifying reply must still block ────────────────────────────────
+
+describe('scanTurnForFinalReply — trailing undelivered content after an early qualifying reply (bug repro)', () => {
+  it('early notification-bearing ack + later substantive plain text → block (not "reply called once" amnesty)', () => {
+    // Repro of the confirmed incident: the agent (1) got a background-task
+    // notification, (2) called reply ONCE early with a short, stale ack —
+    // notification-bearing (disable_notification unset/false), which
+    // ALWAYS qualifies as "final" under isFinalAnswerReply regardless of
+    // text length — then (3) wrote a large substantive verdict as plain
+    // assistant text with NO second reply call. The pre-fix scan returned
+    // 'allow' on the first qualifying block and never looked further; the
+    // fix must walk the whole turn and catch the undelivered trailing text.
+    const text = jsonl(
+      ENQUEUE,
+      assistantToolUse('mcp__switchroom-telegram__reply', { text: 'running now' }),
+      assistantToolUse('Bash', { command: 'ls' }),
+      assistantToolUse('Read', { file_path: '/tmp/x' }),
+      assistantText('Here is the actual verdict after investigation: ' + 'X'.repeat(300)),
+    )
+    const r = scanTurnForFinalReply(text)
+    expect(r.decided).toBe('block')
+    expect(r.reason).toBe('trailing-text-after-reply')
+    // turnKey/chatId must still be populated so the gateway's retry
+    // bookkeeping works exactly as it does for the zero-reply block path.
+    expect(r.chatId).toBe('111')
+    expect(r.turnKey).toBe('111:_')
+  })
+
+  it('early qualifying reply + trailing short (but non-empty) undelivered text → block (no minimum-length carve-out)', () => {
+    const text = jsonl(
+      ENQUEUE,
+      assistantToolUse('mcp__switchroom-telegram__reply', { text: 'ok', disable_notification: false }),
+      assistantText('actually, one more thing you should know'),
+    )
+    const r = scanTurnForFinalReply(text)
+    expect(r.decided).toBe('block')
+    expect(r.reason).toBe('trailing-text-after-reply')
+  })
+
+  it('final qualifying reply is the LAST content block → allow (healthy shape, no false positive)', () => {
+    const text = jsonl(
+      ENQUEUE,
+      assistantText('Let me check that.'),
+      assistantToolUse('Bash', { command: 'ls' }),
+      assistantToolUse('mcp__switchroom-telegram__reply', {
+        text: 'Here is your answer.',
+        disable_notification: false,
+      }),
+    )
+    const r = scanTurnForFinalReply(text)
+    expect(r.decided).toBe('allow')
+    expect(r.reason).toBe('final-reply')
+  })
+
+  it('turn ends on a tool_result with no trailing text at all → allow (not a normal-turn false positive)', () => {
+    // A turn whose very last assistant content is the delivering
+    // reply tool_use, followed only by a (user-role) tool_result line —
+    // never any further assistant text. Must not be flagged.
+    const text = jsonl(
+      ENQUEUE,
+      assistantToolUse('mcp__switchroom-telegram__reply', {
+        text: 'Done — here is the summary.',
+        disable_notification: false,
+      }),
+      JSON.stringify({ type: 'user', message: { content: [{ type: 'tool_result', content: 'ok' }] } }),
+    )
+    const r = scanTurnForFinalReply(text)
+    expect(r.decided).toBe('allow')
+    expect(r.reason).toBe('final-reply')
+  })
+
+  it('undelivered text sandwiched between two qualifying replies is superseded by the LATER reply → allow', () => {
+    const text = jsonl(
+      ENQUEUE,
+      assistantToolUse('mcp__switchroom-telegram__reply', { text: 'first answer', disable_notification: false }),
+      assistantText('actually let me reconsider that'),
+      assistantToolUse('mcp__switchroom-telegram__reply', { text: 'corrected final answer', disable_notification: false }),
+    )
+    const r = scanTurnForFinalReply(text)
+    expect(r.decided).toBe('allow')
+    expect(r.reason).toBe('final-reply')
+  })
+
+  it('explicit trailing NO_REPLY after an earlier qualifying reply overrides → allow (intentional final silence)', () => {
+    const text = jsonl(
+      ENQUEUE,
+      assistantToolUse('mcp__switchroom-telegram__reply', { text: 'draft answer', disable_notification: false }),
+      assistantText('actually, scrap that, nothing more to add\nNO_REPLY'),
+    )
+    const r = scanTurnForFinalReply(text)
+    expect(r.decided).toBe('allow')
+    expect(r.reason).toBe('silent-marker-text')
+  })
+})
+
 describe('scanTurnForFinalReply — silent-marker carve-out', () => {
   it('NO_REPLY → allow', () => {
     const text = jsonl(


### PR DESCRIPTION
## Summary
- `silent-end-interrupt-stop.mjs`'s transcript scan (`scanTurnForFinalReply` in `silent-end-scan.mjs`) returned `allow` on the FIRST qualifying `reply`/`stream_reply` call found while scanning a turn — i.e. "was `reply` called at least once this turn", not "did the turn's real final answer reach the user".
- Confirmed incident shape: an early notification-bearing ack (`disable_notification` unset/false always qualifies as "final" under `isFinalAnswerReply`, regardless of text length) satisfied the check, then the agent kept working and wrote a substantive plain-text verdict afterward with **no second `reply` call** — that content never reached the user, silently. The hook ran (`hookErrors: []`, `preventedContinuation: false`) and did not flag it.
- Fix: the scan now walks the entire turn in chronological order, finds the position of the **LAST** qualifying delivery/silence event (final-answer reply, or an explicit `NO_REPLY`/`HEARTBEAT_OK` marker), and blocks if any plain assistant text block appears **after** that position and was never (re-)sent through a delivery tool. This mirrors the existing zero-reply block path (same reason surface, same retry-count/turnKey bookkeeping) without flagging the normal, healthy shape of a turn that simply ends on a delivering `reply` tool_use with nothing after it.

## Why
`reference/jobs/talk-to-agents-from-anywhere.md` ("always available" outcome): the whole point of the silent-end Stop hook is that a turn where the agent wrote an answer but never sent it must not silently succeed. The pre-fix "at least once" check let exactly that happen whenever an early interim ack preceded the real (undelivered) answer — the deterministic guardrail from #1775/#2053 had a hole matching the very failure class it was built to close.

## Test plan
- [x] New unit coverage in `telegram-plugin/tests/silent-end-interrupt-stop-scan.test.ts`: exact incident repro (early notification-bearing ack + later undelivered verdict → `block`/`trailing-text-after-reply`), a short-trailing-text variant (no minimum-length carve-out), a healthy single-reply-ends-the-turn case (→ `allow`, no false positive), a turn ending on a tool_result with no trailing text (→ `allow`), superseding-by-a-later-reply, and an explicit trailing `NO_REPLY` override after an earlier reply.
- [x] New integration coverage in `telegram-plugin/tests/silent-end-interrupt-stop-integration.test.ts` spawning the real `.mjs` subprocess for the same incident shape (asserts `decision: 'block'`, retry-count state-file write, `turnKey`) and a normal-single-reply-turn no-false-positive case.
- [x] `node_modules/.bin/vitest run telegram-plugin/tests/silent-end*.test.ts` — 8 files, 136 tests, all green (no regressions in the surrounding silent-end suite).
- [x] `npm run lint` (full `tsc --noEmit` + all 8 guard scripts) — clean.

## Risk
Low — scoped to a single pure function (`scanTurnForFinalReply`) with no other importers besides the hook and its two test files (confirmed via grep). Behavior is strictly a tightening: previously-allowed turns with genuinely nothing written after the delivering reply are unaffected (covered by explicit regression tests); only the specific "delivered-then-kept-writing-undelivered-content" shape newly blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)