### PR TITLE
feat(telegram): resolve Telegram user ids to human names via users.<key>.person_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,45 @@ SessionStart-hook idle-reaping, and background agents stuck as failed/completed
 after a `SendMessage` resume. The `default`→`Manual` mode rename (2.1.200) is
 backward-compatible; emitted `settings.json` values are unaffected.
 
+### Greet by name — Telegram user id resolution via `users.<key>.person_id`
+
+Inbound Telegram messages only ever carried the sender's raw numeric id/username,
+so an agent couldn't greet a known person by name without hard-coding an id
+somewhere. Adds an optional `person_id` field on `users:` entries
+(`lisa: { telegram_ids: [...], profile_bank: ..., person_id: "Lisa" }`); when
+set, the `<channel>` tag's `user` attribute shows the display name instead of
+the raw id/username (`meta.user_id` is unchanged — still the raw numeric id).
+
+Design constraints, by intent:
+
+- **Not a tool** — never exposed to agents as a callable MCP tool, purely a
+  passive `<channel>` attribute.
+- **Not hot-reloaded** — the gateway's name-resolution table is built once at
+  boot from the config as scaffolded; editing `person_id` requires an agent
+  restart to take effect.
+- **Fail-open, and completely separate from `access.json`** — `access.json` is
+  the fail-**closed** allow-list deciding whether an agent responds at all; this
+  feature never touches it. An id that doesn't resolve just falls back to
+  today's raw-id behavior, never blocking or denying anything.
+- **Chat-scoped** — a resolved name is only shown in a chat/group the person is
+  confirmed to be a member of (via that chat's `access.json` `allowFrom`); an
+  unrestricted/empty `allowFrom` means membership can't be confirmed, so the
+  raw id/username shows instead. A DM always resolves (the chat IS the sender).
+  Prevents a name that's fine to show 1:1 from leaking into every group the
+  agent sits in.
+- **Per-entry, boot-time-only validation** — a malformed `users:` entry (empty
+  `person_id`, no `telegram_ids`, or a `person_id` collision) drops only that
+  one entry (not fleet-wide) and posts a low-severity "config warning" operator
+  alert (reuses the existing fleet-alert channel, tagged so it never pages like
+  a real outage) naming the entry and why. The check itself is dead-man's-switch
+  protected — if it crashes, that's alerted too, with name resolution disabled
+  (fail-open) for that boot rather than failing silently.
+- **Accepted soft mitigation** — there's no automated enforcement that a
+  `person_id` stays safe if a group's membership changes after the entry is
+  written; documented as an operator-discipline convention in
+  `docs/configuration.md`, accepted at today's fleet-wide scale (two
+  configured users) rather than a closed gap.
+
 ### Operator-configurable Hindsight auto-retain cadence (default 3 / 1) (#2950)
 
 The plugin's auto-retain cadence (`retainEveryNTurns` / `retainOverlapTurns`)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,6 +265,30 @@ agents:
 
 > **Note:** this generates the *memory* wiring only. Who may **drive** an agent (`access.allowFrom`) is still paired at agent creation as today — generating access from `users:` is a future phase.
 
+### Greeting by name — `users.<key>.person_id`
+
+By default, an inbound Telegram message only carries the sender's raw numeric id or `@username` — an agent can't greet a known person by name or reason about "who is this" without hard-coding the id somewhere. `person_id` closes that gap:
+
+```yaml
+users:
+  lisa: { telegram_ids: ["8201250670"], profile_bank: lisa-profile, person_id: "Lisa" }
+```
+
+When Lisa messages an agent, the `<channel>` tag's `user` attribute (and the `meta.user` field the model sees) shows `Lisa` instead of the raw id/username. `meta.user_id` is always still the raw numeric id — nothing here changes the id the agent actually authenticates against.
+
+**What `person_id` is not:**
+
+- **Not a stable identity system.** It's a free-text display label, the same discipline as picking a `profile_bank` name — pick something broadly safe to show, not a secret.
+- **Not exposed as a tool.** There is no MCP tool to look up or resolve a `person_id` — it only ever shows up passively in the inbound `<channel>` tag.
+- **Not hot-reloaded.** The gateway builds its name-resolution table exactly once, at boot, from the config as scaffolded. **Editing `person_id` (or `telegram_ids`) requires restarting the agent** (`switchroom agent restart <name>`, or the equivalent `agent_restart` tool) before the change takes effect — the gateway never re-reads it while running.
+- **Not merged with `access.json`.** `access.json` is the fail-**closed** allow-list that decides whether an agent responds to a chat/sender at all — a completely separate concern, never touched by this feature. Name resolution is fail-**open**: an id that doesn't resolve (or a person the gateway can't confirm is a member of *this* chat — see below) just falls back to today's behavior, the raw id/username. It never blocks or denies a message.
+
+**Chat-scoped, not broadcast.** A resolved name is only shown in a chat/group the person is actually confirmed to be a member of (per that chat's `allowFrom`, the same data `access.json` already tracks). In a 1:1 DM the chat *is* the sender, so the name always resolves. In a group, the sender's id or username must be explicitly present in that group's `allowFrom` — an unrestricted or empty `allowFrom` means membership can't be positively confirmed, so the raw id/username is shown instead. This exists because a name that's perfectly safe to show in a private DM could be a bigger disclosure if broadcast into every group the agent happens to sit in.
+
+**Accepted soft mitigation.** There is **no automated enforcement** that a configured `person_id` stays safe to show if a group's membership changes *after* the entry is written (e.g. someone is removed from a group chat but the `switchroom.yaml` entry isn't updated). This is an operator-discipline convention, the same trust model as every other free-text label in `users:` — not a closed gap. Given only two `person_id`s are configured fleet-wide today, this is accepted as a low-severity risk rather than a blocker; revisit if the fleet-wide `users:` list grows meaningfully.
+
+**Malformed entries are dropped individually, not fleet-wide.** A bad `users:` entry — an empty `person_id`, no `telegram_ids`, or a `person_id` already claimed by a different user — drops **only that one entry** at boot; every other configured person still resolves normally. The gateway posts a low-severity "config warning" operator alert (same fleet-alert channel as credential/quota issues, tagged so it never pages like a real outage) naming which entry was dropped and why. If the boot-time check itself fails unexpectedly, that failure is *also* alerted (not silently swallowed) — name resolution is disabled for that boot, but nothing else is affected.
+
 ### Specializing a bank — missions & disposition
 
 A persona without its own memory is cosplay: banks should be *specialized*, not merely isolated. Four `memory.*` fields steer how a bank extracts, recalls, and synthesizes — a coach should read its notes differently than a lawyer.

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -596,7 +596,7 @@ export function maybeWriteCronMcp(
   seedCronConfigDir(agentDir, Object.keys(cronServers));
   return path;
 }
-import { resolveUsers } from "../config/users.js";
+import { resolveUsers, resolvePersonEntries } from "../config/users.js";
 import {
   resolveAgentConfig,
   translateHooksToClaudeShape,
@@ -4363,6 +4363,18 @@ export function scaffoldAgent(
     telegramConfig,
   );
 
+  // --- Telegram people.json (person_id name resolution) ---
+  // Config-derived only (no runtime state to preserve, unlike access.json)
+  // — regenerate on every scaffold/reconcile so a `users:` edit is picked
+  // up. The running gateway itself only reads this file ONCE at boot
+  // (no hot-reload — docs/configuration.md); a config change here needs an
+  // agent restart to take effect.
+  writeFileSyncIfChanged(
+    join(agentDir, "telegram", "people.json"),
+    buildPeopleJson(switchroomConfig),
+    0o600,
+  );
+
   // --- Sub-agent definitions (.claude/agents/<name>.md) ---
   //
   // Render each sub-agent from the merged `subagents:` config into a
@@ -6913,6 +6925,28 @@ export function reconcileConfiguredGroup(
       `(responds to all topics; requireMention=false)`,
     ),
   );
+}
+
+/**
+ * `telegram/people.json` — a plain, config-derived projection of `users:`
+ * entries that carry a `person_id` (docs/configuration.md). Deliberately a
+ * SIBLING file to `access.json`, never merged into it: `access.json` is the
+ * fail-CLOSED access-control allowlist (a different concern, gateway-owned
+ * at runtime, written `writeIfMissing`); this file is fail-OPEN display
+ * data only, purely derived from static config, so it's regenerated every
+ * time `scaffoldAgent` runs (the `switchroom apply` reconcile path calls
+ * `scaffoldAgent` idempotently for every configured agent) via
+ * `writeFileSyncIfChanged` (not `writeIfMissing`) — there's no runtime
+ * state here to preserve.
+ *
+ * All semantic validation (dedup, dropping malformed entries, the
+ * fleet-alert on a dropped entry) happens gateway-side at boot
+ * (`telegram-plugin/gateway/resolve-person.ts`), not here — this is a dumb
+ * projection only.
+ */
+function buildPeopleJson(switchroomConfig: SwitchroomConfig | undefined): string {
+  const entries = switchroomConfig ? resolvePersonEntries(switchroomConfig) : [];
+  return JSON.stringify({ entries }, null, 2) + "\n";
 }
 
 function buildAccessJson(

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3574,6 +3574,23 @@ export const UserSchema = z.object({
       "Hindsight bank holding this user's memory profile (author via " +
       "`switchroom memory profile add <bank> ...`).",
     ),
+  person_id: z
+    .string()
+    .optional()
+    .describe(
+      "Free-text display name projected into the inbound `<channel>` " +
+      "tag's `user` attribute (e.g. \"Lisa\") so an agent can greet by " +
+      "name instead of only seeing the raw Telegram id/username. NOT a " +
+      "stable identity system — just a label. Resolution is boot-time-only " +
+      "(no hot-reload; a config change needs an agent restart) and " +
+      "chat-scoped (a resolved name is only shown in a chat/group the " +
+      "person is actually a member of, per that chat's access.json " +
+      "membership — never broadcast into every chat the agent operates " +
+      "in). Keep this broadly safe to show, the same discipline as " +
+      "picking a `profile_bank` name: there is no automated enforcement " +
+      "that a `person_id` stays safe if a group's membership changes " +
+      "later — see docs/configuration.md.",
+    ),
 });
 export type User = z.infer<typeof UserSchema>;
 

--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -72,3 +72,35 @@ export function resolveUsers(
 
   return { senderBanks, additionalBanks };
 }
+
+/**
+ * Raw projection of `users:` entries that carry a `person_id` (see
+ * `UserSchema.person_id` in schema.ts). This is a DUMB projection only — no
+ * dedup, no shape validation beyond what the schema already enforces, no
+ * dropping of malformed entries. That semantic validation happens
+ * gateway-side (`telegram-plugin/gateway/resolve-person.ts`'s
+ * `buildPersonDirectory`) at agent boot, because only the gateway process
+ * can reach the fleet-alert path used to surface a dropped entry.
+ *
+ * Scaffolded into each agent's `telegram/people.json` (a plain
+ * config-derived projection, regenerated on every scaffold/reconcile via
+ * `writeFileSyncIfChanged` — unlike `access.json`, this file is never
+ * mutated by the running gateway, so there's no "boot merge" step to
+ * preserve).
+ */
+export interface RawPersonEntry {
+  /** The `users:` map key (e.g. "lisa") — used only for alert messages. */
+  key: string;
+  person_id: string;
+  telegram_ids: string[];
+}
+
+export function resolvePersonEntries(config: SwitchroomConfig): RawPersonEntry[] {
+  const users = config.users ?? {};
+  const entries: RawPersonEntry[] = [];
+  for (const [key, u] of Object.entries(users)) {
+    if (!u.person_id) continue;
+    entries.push({ key, person_id: u.person_id, telegram_ids: u.telegram_ids });
+  }
+  return entries;
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -187,7 +187,7 @@ import { gatewayStartupRetry } from './startup-network-retry.js'
 import { writeQuarantineMarker } from './quarantine.js'
 import {
   runPersonDirectoryBootCheck,
-  resolvePersonName,
+  safeResolvePersonName,
   type PersonDirectory,
   type RawPersonEntry,
 } from './resolve-person.js'
@@ -16695,12 +16695,16 @@ async function handleInbound(
   // membership can't be positively confirmed from access.json's allowFrom.
   // Never touches access.json itself and never blocks/denies anything.
   const rawUser = from.username ?? String(from.id)
-  const displayUser = resolvePersonName(PERSON_DIRECTORY, {
-    telegramId: String(from.id),
-    username: from.username,
-    isDm: isDmChatId(chat_id),
-    groupAllowFrom: access.groups[chat_id]?.allowFrom,
-  }) ?? rawUser
+  const displayUser = safeResolvePersonName(
+    PERSON_DIRECTORY,
+    {
+      telegramId: String(from.id),
+      username: from.username,
+      isDm: isDmChatId(chat_id),
+      groupAllowFrom: access.groups[chat_id]?.allowFrom,
+    },
+    rawUser,
+  )
   const inboundMsg: InboundMessage = {
     type: 'inbound',
     chatId: chat_id,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -185,6 +185,12 @@ import {
 import { clearStaleTelegramPollingState } from '../startup-reset.js'
 import { gatewayStartupRetry } from './startup-network-retry.js'
 import { writeQuarantineMarker } from './quarantine.js'
+import {
+  runPersonDirectoryBootCheck,
+  resolvePersonName,
+  type PersonDirectory,
+  type RawPersonEntry,
+} from './resolve-person.js'
 // RFC H §7.3: auth-dashboard + auth-slot-parser deleted. Three chat
 // verbs (/auth show | use | rotate) talk to switchroom-auth-broker
 // via the thin client in src/auth/broker/client.ts.
@@ -721,6 +727,12 @@ const ACCESS_FILE = join(STATE_DIR, 'access.json')
 const APPROVED_DIR = join(STATE_DIR, 'approved')
 const ENV_FILE = join(STATE_DIR, '.env')
 const INBOX_DIR = join(STATE_DIR, 'inbox')
+// person_id name resolution (docs/configuration.md). Sibling to
+// access.json but a COMPLETELY SEPARATE, purely config-derived file —
+// scaffold regenerates it on every reconcile via writeFileSyncIfChanged,
+// the gateway never mutates it, and (unlike access.json) it is read
+// exactly ONCE at boot into PERSON_DIRECTORY below — no hot-reload.
+const PEOPLE_FILE = join(STATE_DIR, 'people.json')
 
 /**
  * Trigger a restart of the agent + gateway pair.
@@ -1223,6 +1235,33 @@ const BOOT_ACCESS: Access | null = STATIC
 function loadAccess(): Access {
   return BOOT_ACCESS ?? readAccessFile()
 }
+
+/**
+ * Read `people.json` (the scaffold's plain projection of `users:` entries
+ * that carry a `person_id`). Fail-open: ENOENT or corrupt/malformed JSON
+ * returns an empty array rather than throwing — this feature must never
+ * block startup. Unlike `access.json` this file is never gateway-mutated,
+ * so there's no "move corrupt file aside" concern; the scaffold owns and
+ * regenerates it on every reconcile.
+ */
+function readPeopleFile(): RawPersonEntry[] {
+  try {
+    const raw = readFileSync(PEOPLE_FILE, 'utf8')
+    const parsed = JSON.parse(raw) as { entries?: unknown }
+    if (!Array.isArray(parsed.entries)) return []
+    return parsed.entries as RawPersonEntry[]
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Boot-time-only person-name directory (see resolve-person.ts module doc).
+ * Populated exactly once by the boot-validation block in the startup IIFE
+ * below, then never reassigned or re-read from disk again for the life of
+ * this process — a config change requires an agent restart.
+ */
+let PERSON_DIRECTORY: PersonDirectory = { byTelegramKey: {} }
 
 function assertAllowedChat(chat_id: string | number): void {
   const id = String(chat_id)
@@ -16650,12 +16689,24 @@ async function handleInbound(
     TOPIC_FRAMING_ENABLED && messageThreadId != null
       ? 'This message belongs to the current topic only — answer ONLY this question, in this topic. Do not also answer a pending message from another topic.'
       : undefined
+  // person_id name resolution (docs/configuration.md, resolve-person.ts):
+  // chat-scoped, boot-time-static lookup — falls back to today's raw
+  // id/username behavior (fail-open) whenever unresolved or when group
+  // membership can't be positively confirmed from access.json's allowFrom.
+  // Never touches access.json itself and never blocks/denies anything.
+  const rawUser = from.username ?? String(from.id)
+  const displayUser = resolvePersonName(PERSON_DIRECTORY, {
+    telegramId: String(from.id),
+    username: from.username,
+    isDm: isDmChatId(chat_id),
+    groupAllowFrom: access.groups[chat_id]?.allowFrom,
+  }) ?? rawUser
   const inboundMsg: InboundMessage = {
     type: 'inbound',
     chatId: chat_id,
     ...(messageThreadId != null ? { threadId: messageThreadId } : {}),
     messageId: msgId ?? 0,
-    user: from.username ?? String(from.id),
+    user: displayUser,
     userId: from.id,
     ts: ctx.message?.date ?? Math.floor(Date.now() / 1000),
     text: effectiveText,
@@ -16670,7 +16721,7 @@ async function handleInbound(
     meta: {
       chat_id,
       ...(msgId != null ? { message_id: String(msgId) } : {}),
-      user: from.username ?? String(from.id),
+      user: displayUser,
       user_id: String(from.id),
       ts: new Date((ctx.message?.date ?? 0) * 1000).toISOString(),
       ...(messageThreadId != null ? { message_thread_id: String(messageThreadId) } : {}),
@@ -26380,6 +26431,32 @@ void (async () => {
 
       if (!didOneTimeSetup) {
         didOneTimeSetup = true
+
+        // person_id name resolution (docs/configuration.md, resolve-person.ts):
+        // ONE-TIME boot validation, NOT periodic. `PERSON_DIRECTORY` is
+        // built exactly once, here, from the static in-memory `people.json`
+        // the scaffold projected from `switchroom.yaml`'s `users:` block —
+        // a config change requires an agent restart, this never re-reads.
+        // The orchestration (per-entry validation + dead-man's-switch) is
+        // in the pure, unit-tested `runPersonDirectoryBootCheck` — this
+        // block only performs the resulting I/O (stderr log + the EXISTING
+        // fleet-alert path at low/config severity, kind: 'config-warning',
+        // which must never page like a real outage).
+        {
+          const bootCheck = runPersonDirectoryBootCheck(readPeopleFile)
+          PERSON_DIRECTORY = bootCheck.directory
+          process.stderr.write(bootCheck.logLine + '\n')
+          if (bootCheck.alertDetail != null) {
+            emitGatewayOperatorEvent({
+              kind: 'config-warning',
+              agent: process.env.SWITCHROOM_AGENT_NAME ?? '-',
+              detail: bootCheck.alertDetail,
+              suggestedActions: [],
+              firstSeenAt: new Date(),
+            })
+          }
+        }
+
         void registerSwitchroomBotCommands().catch(() => {})
 
         // #613 fix: pre-warm the chatAvailableReactions cache for every

--- a/telegram-plugin/gateway/resolve-person.ts
+++ b/telegram-plugin/gateway/resolve-person.ts
@@ -88,11 +88,17 @@ function normalizeTelegramKey(raw: string): string {
  *     first-declared entry wins, the later duplicate is dropped whole
  *     (not just the colliding id) so the alert is unambiguous about which
  *     entry lost
+ *   - a `telegram_id`/username already claimed by an earlier (different)
+ *     entry key — same first-declared-wins convention: the later duplicate
+ *     is dropped whole so the alert is unambiguous about which entry lost
+ *     and we never silently last-write-wins a numeric id into the wrong
+ *     person's name
  */
 export function buildPersonDirectory(entries: readonly RawPersonEntry[]): BuildPersonDirectoryResult {
   const byTelegramKey: Record<string, PersonDirectoryEntry> = {}
   const dropped: DroppedPersonEntry[] = []
   const personIdOwner = new Map<string, string>() // person_id (lowercased) -> owning entry key
+  const telegramKeyOwner = new Map<string, string>() // normalized telegram id/username -> owning entry key
 
   for (const raw of entries) {
     const key = typeof raw.key === 'string' ? raw.key.trim() : ''
@@ -129,8 +135,23 @@ export function buildPersonDirectory(entries: readonly RawPersonEntry[]): BuildP
       continue
     }
 
+    const collidingTelegramKey = telegramKeys.find((tk) => {
+      const existingTkOwner = telegramKeyOwner.get(tk)
+      return existingTkOwner != null && existingTkOwner !== key
+    })
+    if (collidingTelegramKey != null) {
+      const existingTkOwner = telegramKeyOwner.get(collidingTelegramKey)
+      dropped.push({
+        key,
+        reason: `duplicate telegram_id "${collidingTelegramKey}" already claimed by users.${existingTkOwner}`,
+      })
+      personIdOwner.delete(personIdLower)
+      continue
+    }
+
     const entry: PersonDirectoryEntry = { key, personId, telegramKeys }
     for (const tk of telegramKeys) {
+      telegramKeyOwner.set(tk, key)
       byTelegramKey[tk] = entry
     }
   }
@@ -227,4 +248,25 @@ export function resolvePersonName(directory: PersonDirectory, opts: ResolvePerso
   const memberConfirmed =
     allowFromNormalized.includes(idKey) || (usernameKey != null && allowFromNormalized.includes(usernameKey))
   return memberConfirmed ? entry.personId : undefined
+}
+
+/**
+ * Fail-open call-site wrapper around `resolvePersonName`, for use at the
+ * `handleInbound` call site (gateway.ts). This feature's whole design
+ * point is "never blocks or denies anything" (module doc above) — a throw
+ * from resolution must fall back to the raw id/username, not abort message
+ * handling. Mirrors the same defensive pattern already used for
+ * `readPeopleFile` (gateway.ts) and `runPersonDirectoryBootCheck` (this
+ * file): catch, fall back, never propagate.
+ */
+export function safeResolvePersonName(
+  directory: PersonDirectory,
+  opts: ResolvePersonOptions,
+  rawFallback: string,
+): string {
+  try {
+    return resolvePersonName(directory, opts) ?? rawFallback
+  } catch {
+    return rawFallback
+  }
 }

--- a/telegram-plugin/gateway/resolve-person.ts
+++ b/telegram-plugin/gateway/resolve-person.ts
@@ -1,0 +1,230 @@
+/**
+ * Boot-time-only, chat-scoped resolution of a raw Telegram id/username into
+ * a human `person_id` (e.g. "Lisa") for display in the `<channel>` tag's
+ * `user` attribute.
+ *
+ * Design (converged after adversarial review — see the PR description for
+ * the tradeoffs, do not re-litigate here):
+ *
+ *   - No MCP tool. Not callable by agents — display-only, gateway-internal.
+ *   - No hot-reload. `PersonDirectory` is built ONCE at gateway boot from
+ *     the static in-memory `people.json` the scaffold projected from
+ *     `switchroom.yaml`'s `users:` block. A config change requires an agent
+ *     restart to take effect — this file never re-reads anything.
+ *   - `access.json` (the fail-CLOSED allow-list) is a completely separate
+ *     concern and is never touched here. This feature is fail-OPEN: an
+ *     unresolved id/username falls back to today's behavior (the caller
+ *     keeps using the raw id/username) — it never blocks or denies
+ *     anything.
+ *   - Chat-scoped: a resolved name is only ever returned for a chat/group
+ *     the person is actually a member of. In a DM the chat IS the sender,
+ *     so resolution always applies. In a group, resolution only applies if
+ *     the sender's id or username is explicitly present in that group's
+ *     `allowFrom` (read from the EXISTING `access.json`/`loadAccess()`
+ *     data — no new membership source). An empty/unset group `allowFrom`
+ *     means membership can't be positively confirmed, so we conservatively
+ *     do NOT resolve (the raw id/username is shown instead) — a name safe
+ *     in a 1:1 DM could be a bigger leak in a shared group.
+ *   - Per-entry validation: a malformed `users:` entry (duplicate
+ *     `person_id` claimed by two different keys, empty/invalid
+ *     `person_id`, no `telegram_ids`) drops ONLY that one entry — it never
+ *     blanks resolution for the whole fleet. `buildPersonDirectory` never
+ *     throws; every failure mode is reported via its `dropped` return
+ *     value instead, so the caller can route it through the existing
+ *     fleet-alert path (`emitGatewayOperatorEvent` in gateway.ts) at
+ *     low/config severity — this must never page like a real outage.
+ *
+ * Fix note (accepted soft mitigation — see docs/configuration.md): there is
+ * no automated enforcement that a configured `person_id` stays safe to show
+ * if a group's membership changes AFTER the entry is written. This is an
+ * operator-discipline convention, not a closed gap. Low severity today —
+ * only two `person_id`s are configured fleet-wide.
+ */
+
+export interface RawPersonEntry {
+  /** The `users:` map key (e.g. "lisa") — carried through for alert text. */
+  key: string
+  person_id: string
+  telegram_ids: string[]
+}
+
+export interface PersonDirectoryEntry {
+  key: string
+  personId: string
+  /** Normalized (lowercased, no leading "@") telegram ids/usernames. */
+  telegramKeys: string[]
+}
+
+export interface PersonDirectory {
+  /** normalized telegram id/username -> directory entry */
+  byTelegramKey: Record<string, PersonDirectoryEntry>
+}
+
+export interface DroppedPersonEntry {
+  key: string
+  reason: string
+}
+
+export interface BuildPersonDirectoryResult {
+  directory: PersonDirectory
+  dropped: DroppedPersonEntry[]
+}
+
+/** Normalize a telegram id or @username for keying: trim, strip a leading
+ * "@", lowercase (Telegram usernames are case-insensitive). */
+function normalizeTelegramKey(raw: string): string {
+  return raw.trim().replace(/^@/, '').toLowerCase()
+}
+
+/**
+ * Validate and dedupe raw `users:` `person_id` entries into a lookup
+ * directory. Never throws — every rejection is reported via `dropped`
+ * instead, per the fail-open / drop-only-that-entry design.
+ *
+ * Drop reasons:
+ *   - missing/blank `key` or `person_id`
+ *   - `telegram_ids` missing or empty (nothing to key the entry by)
+ *   - `person_id` already claimed by an earlier (different) entry key —
+ *     first-declared entry wins, the later duplicate is dropped whole
+ *     (not just the colliding id) so the alert is unambiguous about which
+ *     entry lost
+ */
+export function buildPersonDirectory(entries: readonly RawPersonEntry[]): BuildPersonDirectoryResult {
+  const byTelegramKey: Record<string, PersonDirectoryEntry> = {}
+  const dropped: DroppedPersonEntry[] = []
+  const personIdOwner = new Map<string, string>() // person_id (lowercased) -> owning entry key
+
+  for (const raw of entries) {
+    const key = typeof raw.key === 'string' ? raw.key.trim() : ''
+    const personId = typeof raw.person_id === 'string' ? raw.person_id.trim() : ''
+
+    if (key.length === 0) {
+      dropped.push({ key: raw.key || '(unknown)', reason: 'missing users: map key' })
+      continue
+    }
+    if (personId.length === 0) {
+      dropped.push({ key, reason: 'empty or missing person_id' })
+      continue
+    }
+    if (!Array.isArray(raw.telegram_ids) || raw.telegram_ids.length === 0) {
+      dropped.push({ key, reason: 'no telegram_ids to resolve against' })
+      continue
+    }
+
+    const personIdLower = personId.toLowerCase()
+    const existingOwner = personIdOwner.get(personIdLower)
+    if (existingOwner != null && existingOwner !== key) {
+      dropped.push({
+        key,
+        reason: `duplicate person_id "${personId}" already claimed by users.${existingOwner}`,
+      })
+      continue
+    }
+    personIdOwner.set(personIdLower, key)
+
+    const telegramKeys = [...new Set(raw.telegram_ids.map(normalizeTelegramKey).filter((k) => k.length > 0))]
+    if (telegramKeys.length === 0) {
+      dropped.push({ key, reason: 'telegram_ids contained no usable id/username' })
+      personIdOwner.delete(personIdLower)
+      continue
+    }
+
+    const entry: PersonDirectoryEntry = { key, personId, telegramKeys }
+    for (const tk of telegramKeys) {
+      byTelegramKey[tk] = entry
+    }
+  }
+
+  return { directory: { byTelegramKey }, dropped }
+}
+
+export interface PersonDirectoryBootResult {
+  directory: PersonDirectory
+  /** Non-null when the caller should route an alert through the fleet
+   * alert path (`emitGatewayOperatorEvent`, kind: 'config-warning'). */
+  alertDetail: string | null
+  /** Always present — one human-readable line for stderr. */
+  logLine: string
+}
+
+/**
+ * Orchestrate the ONE-TIME boot-time check (requirement: boot-time-only,
+ * NOT periodic — call this exactly once, at gateway boot, never on a
+ * timer/interval). Extracted as a pure(ish) function — taking the file
+ * read as an injected dependency and RETURNING what to log/alert rather
+ * than performing the I/O itself — so it's unit-testable without booting
+ * the real gateway process.
+ *
+ * Dead-man's-switch: wraps the whole check in try/catch. If anything
+ * throws before completing (including `readEntries` itself), that failure
+ * is ALSO surfaced via `alertDetail` — mirrors a past incident where
+ * `access.json` validation failed silently in the wrong (fail-open)
+ * direction, undetected for hours. `PERSON_DIRECTORY` falls back to an
+ * empty directory on crash (fail-open: raw ids/usernames keep showing).
+ */
+export function runPersonDirectoryBootCheck(readEntries: () => RawPersonEntry[]): PersonDirectoryBootResult {
+  try {
+    const rawEntries = readEntries()
+    const { directory, dropped } = buildPersonDirectory(rawEntries)
+
+    if (dropped.length > 0) {
+      const summary = dropped.map((d) => `${d.key} (${d.reason})`).join('; ')
+      const plural = dropped.length === 1 ? 'y' : 'ies'
+      return {
+        directory,
+        alertDetail: `person_id: dropped ${dropped.length} malformed users: entr${plural} at boot — ${summary}`,
+        logLine: `telegram gateway: person_id boot validation dropped ${dropped.length} entr${plural}: ${summary}`,
+      }
+    }
+
+    return {
+      directory,
+      alertDetail: null,
+      logLine: rawEntries.length > 0
+        ? `telegram gateway: person_id boot validation ok — ${Object.keys(directory.byTelegramKey).length} telegram id/username(s) resolved`
+        : `telegram gateway: person_id boot validation ok — no person_id entries configured`,
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return {
+      directory: { byTelegramKey: {} },
+      alertDetail: `person_id boot validation crashed — name resolution disabled this boot (fail-open, raw ids/usernames will show): ${msg}`,
+      logLine: `telegram gateway: person_id boot validation CRASHED (name resolution disabled this boot, raw ids will show — fail-open): ${msg}`,
+    }
+  }
+}
+
+export interface ResolvePersonOptions {
+  telegramId: string
+  username?: string | undefined
+  isDm: boolean
+  /** That chat's/group's configured allowFrom, if any (from access.json). */
+  groupAllowFrom?: readonly string[] | undefined
+}
+
+/**
+ * Resolve a sender's display name for THIS chat, chat-scoped per the
+ * module doc above. Returns undefined (fall back to raw id/username) when
+ * unresolved OR when membership in a group chat can't be positively
+ * confirmed.
+ */
+export function resolvePersonName(directory: PersonDirectory, opts: ResolvePersonOptions): string | undefined {
+  const idKey = normalizeTelegramKey(opts.telegramId)
+  const usernameKey = opts.username ? normalizeTelegramKey(opts.username) : undefined
+
+  const entry = directory.byTelegramKey[idKey] ?? (usernameKey ? directory.byTelegramKey[usernameKey] : undefined)
+  if (!entry) return undefined
+
+  // DM: the chat IS the sender, so resolution always applies.
+  if (opts.isDm) return entry.personId
+
+  // Group: only resolve if the sender is explicitly present in that
+  // chat's allowFrom (the existing membership source) — conservative
+  // fallback (undefined) otherwise, since we can't positively confirm
+  // membership from an empty/unset list.
+  const allowFrom = opts.groupAllowFrom ?? []
+  const allowFromNormalized = allowFrom.map(normalizeTelegramKey)
+  const memberConfirmed =
+    allowFromNormalized.includes(idKey) || (usernameKey != null && allowFromNormalized.includes(usernameKey))
+  return memberConfirmed ? entry.personId : undefined
+}

--- a/telegram-plugin/operator-events.ts
+++ b/telegram-plugin/operator-events.ts
@@ -26,6 +26,7 @@ export type OperatorEventKind =
   | 'agent-restarted-unexpectedly'
   | 'unknown-4xx'
   | 'unknown-5xx'
+  | 'config-warning'
 
 export interface OperatorEvent {
   kind: OperatorEventKind
@@ -372,6 +373,26 @@ export function renderOperatorEvent(ev: OperatorEvent): RenderResult {
         keyboard: {
           inline_keyboard: [
             [{ text: '⏳ Wait', callback_data: `op:dismiss:${encodeURIComponent(ev.agent)}` }],
+          ],
+        },
+      }
+
+    // Deliberately low-severity framing (ℹ️, Dismiss-only — no Restart /
+    // Reauth / Show-logs actions): config-warning is for boot-time config
+    // problems (e.g. a dropped `person_id` entry) that must be visible to
+    // the operator but MUST NOT read like a real outage or page anyone.
+    case 'config-warning':
+      return {
+        text: [
+          `ℹ️ **Config warning** for **${agent}**.`,
+          detail ? `_${detail}_` : '',
+          `Non-urgent — config will keep working with today's fallback behavior.`,
+        ]
+          .filter(Boolean)
+          .join('\n'),
+        keyboard: {
+          inline_keyboard: [
+            [{ text: '❌ Dismiss', callback_data: `op:dismiss:${encodeURIComponent(ev.agent)}` }],
           ],
         },
       }

--- a/telegram-plugin/tests/gateway-boot-marker-clear.test.ts
+++ b/telegram-plugin/tests/gateway-boot-marker-clear.test.ts
@@ -43,7 +43,7 @@ describe('gateway boot — clear stale turn-active marker', () => {
     // window to ~5KB so we don't pick up the unrelated
     // `removeTurnActiveMarker` call in the onTurnComplete handler
     // way down at the bottom of the file.
-    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 7000)
+    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 9000)
     const clearMatches = setupWindow.match(/removeTurnActiveMarker\s*\(\s*STATE_DIR\s*\)/g) ?? []
     expect(clearMatches.length).toBe(1)
   })
@@ -53,7 +53,7 @@ describe('gateway boot — clear stale turn-active marker', () => {
     // must not prevent the gateway from coming up. Pin the try-wrapping
     // to make sure a future refactor doesn't drop it.
     const setupBlockStart = GATEWAY_SRC.indexOf('if (!didOneTimeSetup)')
-    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 7000)
+    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 9000)
     expect(setupWindow).toMatch(/try\s*\{\s*removeTurnActiveMarker\(STATE_DIR\)\s*\}\s*catch/)
   })
 
@@ -62,7 +62,7 @@ describe('gateway boot — clear stale turn-active marker', () => {
     // Clearing the marker first means the watchdog sees a clean slate
     // immediately, even if pin sweep takes 30s+ to finish.
     const setupBlockStart = GATEWAY_SRC.indexOf('if (!didOneTimeSetup)')
-    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 7000)
+    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 9000)
     const clearIdx = setupWindow.indexOf('removeTurnActiveMarker(STATE_DIR)')
     const pinSweepIdx = setupWindow.indexOf('Boot-time pin sweep')
     expect(clearIdx).toBeGreaterThan(0)

--- a/telegram-plugin/tests/operator-events.test.ts
+++ b/telegram-plugin/tests/operator-events.test.ts
@@ -253,6 +253,21 @@ describe('renderOperatorEvent — unknown-5xx', () => {
   })
 })
 
+describe('renderOperatorEvent — config-warning', () => {
+  it('is framed as non-urgent (dismiss-only, no restart/reauth/logs actions)', () => {
+    const { text, keyboard } = renderOperatorEvent(
+      makeEvent('config-warning', { detail: 'person_id: dropped 1 malformed users: entry at boot — lisa (empty person_id)' }),
+    )
+    expect(text).toContain('Config warning')
+    expect(text).toContain('Non-urgent')
+    const buttons = keyboard.inline_keyboard.flat()
+    expect(buttons.every(b => b.callback_data?.includes('dismiss'))).toBe(true)
+    expect(buttons.some(b => b.callback_data?.includes('restart'))).toBe(false)
+    expect(buttons.some(b => b.callback_data?.includes('reauth'))).toBe(false)
+    expect(buttons.some(b => b.callback_data?.includes('logs'))).toBe(false)
+  })
+})
+
 describe('renderOperatorEvent — markdown escaping (#2669)', () => {
   it('passes < > literally in agent name (markdown, #2669)', () => {
     const { text } = renderOperatorEvent(makeEvent('unknown-4xx', { agent: '<evil>' }))
@@ -276,6 +291,7 @@ describe('renderOperatorEvent — all kinds produce valid keyboard structure', (
     'agent-restarted-unexpectedly',
     'unknown-4xx',
     'unknown-5xx',
+    'config-warning',
   ]
 
   for (const kind of allKinds) {

--- a/telegram-plugin/tests/resolve-person.test.ts
+++ b/telegram-plugin/tests/resolve-person.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildPersonDirectory,
+  resolvePersonName,
+  runPersonDirectoryBootCheck,
+  type RawPersonEntry,
+} from '../gateway/resolve-person.js'
+
+/**
+ * Telegram person_id name resolution (docs/configuration.md).
+ *
+ * Covers the requirements from the converged design:
+ *   - happy-path resolution
+ *   - unresolved-id fallback (fail-open)
+ *   - a malformed single entry is dropped WITHOUT affecting others
+ *   - chat-scoping: a name is shown only in a chat/group the person is a
+ *     member of (per that chat's allowFrom), never broadcast into every
+ *     chat
+ *   - boot-time validation alert firing on bad config
+ *   - validation-step-crash alert firing (dead-man's-switch)
+ */
+
+const LISA: RawPersonEntry = { key: 'lisa', person_id: 'Lisa', telegram_ids: ['8201250670'] }
+const KEN: RawPersonEntry = { key: 'ken', person_id: 'Ken', telegram_ids: ['mekenthompson', '111'] }
+
+describe('buildPersonDirectory — happy path', () => {
+  it('resolves a single well-formed entry', () => {
+    const { directory, dropped } = buildPersonDirectory([LISA])
+    expect(dropped).toEqual([])
+    expect(directory.byTelegramKey['8201250670']?.personId).toBe('Lisa')
+  })
+
+  it('resolves multiple entries, multiple telegram_ids each, case/@-insensitive', () => {
+    const { directory, dropped } = buildPersonDirectory([LISA, KEN])
+    expect(dropped).toEqual([])
+    expect(directory.byTelegramKey['8201250670']?.personId).toBe('Lisa')
+    expect(directory.byTelegramKey['mekenthompson']?.personId).toBe('Ken')
+    expect(directory.byTelegramKey['111']?.personId).toBe('Ken')
+    // username lookups are normalized: leading "@" stripped, lowercased
+    expect(directory.byTelegramKey['@MeKenThompson'.trim().replace(/^@/, '').toLowerCase()]?.personId).toBe('Ken')
+  })
+
+  it('no entries → empty directory (fleet behaves as today)', () => {
+    const { directory, dropped } = buildPersonDirectory([])
+    expect(directory.byTelegramKey).toEqual({})
+    expect(dropped).toEqual([])
+  })
+})
+
+describe('buildPersonDirectory — per-entry validation drops only the bad entry', () => {
+  it('drops an entry with an empty person_id, keeps the other entry intact', () => {
+    const bad: RawPersonEntry = { key: 'ghost', person_id: '', telegram_ids: ['999'] }
+    const { directory, dropped } = buildPersonDirectory([LISA, bad])
+    expect(directory.byTelegramKey['8201250670']?.personId).toBe('Lisa')
+    expect(directory.byTelegramKey['999']).toBeUndefined()
+    expect(dropped).toHaveLength(1)
+    expect(dropped[0]?.key).toBe('ghost')
+    expect(dropped[0]?.reason).toMatch(/person_id/)
+  })
+
+  it('drops an entry with no telegram_ids, keeps the other entry intact', () => {
+    const bad: RawPersonEntry = { key: 'ghost', person_id: 'Ghost', telegram_ids: [] }
+    const { directory, dropped } = buildPersonDirectory([LISA, bad])
+    expect(directory.byTelegramKey['8201250670']?.personId).toBe('Lisa')
+    expect(dropped).toHaveLength(1)
+    expect(dropped[0]?.key).toBe('ghost')
+    expect(dropped[0]?.reason).toMatch(/telegram_ids/)
+  })
+
+  it('drops a duplicate person_id (later entry loses), keeps the first entry intact', () => {
+    const dupe: RawPersonEntry = { key: 'lisa2', person_id: 'Lisa', telegram_ids: ['555'] }
+    const { directory, dropped } = buildPersonDirectory([LISA, dupe])
+    expect(directory.byTelegramKey['8201250670']?.personId).toBe('Lisa')
+    expect(directory.byTelegramKey['555']).toBeUndefined()
+    expect(dropped).toHaveLength(1)
+    expect(dropped[0]?.key).toBe('lisa2')
+    expect(dropped[0]?.reason).toMatch(/duplicate person_id/)
+  })
+
+  it('drops an entry with a missing users: map key', () => {
+    const bad: RawPersonEntry = { key: '', person_id: 'Nobody', telegram_ids: ['1'] }
+    const { directory, dropped } = buildPersonDirectory([LISA, bad])
+    expect(directory.byTelegramKey['8201250670']?.personId).toBe('Lisa')
+    expect(dropped).toHaveLength(1)
+    expect(dropped[0]?.reason).toMatch(/users: map key/)
+  })
+
+  it('multiple malformed entries each get their own drop reason, valid entries unaffected', () => {
+    const bad1: RawPersonEntry = { key: 'a', person_id: '', telegram_ids: ['1'] }
+    const bad2: RawPersonEntry = { key: 'b', person_id: 'B', telegram_ids: [] }
+    const { directory, dropped } = buildPersonDirectory([LISA, bad1, KEN, bad2])
+    expect(dropped).toHaveLength(2)
+    expect(directory.byTelegramKey['8201250670']?.personId).toBe('Lisa')
+    expect(directory.byTelegramKey['mekenthompson']?.personId).toBe('Ken')
+  })
+})
+
+describe('resolvePersonName — unresolved id falls back (fail-open)', () => {
+  it('returns undefined for an id not in the directory', () => {
+    const { directory } = buildPersonDirectory([LISA])
+    const name = resolvePersonName(directory, { telegramId: '000', isDm: true })
+    expect(name).toBeUndefined()
+  })
+
+  it('returns undefined for an empty directory', () => {
+    const { directory } = buildPersonDirectory([])
+    const name = resolvePersonName(directory, { telegramId: '8201250670', isDm: true })
+    expect(name).toBeUndefined()
+  })
+})
+
+describe('resolvePersonName — chat scoping', () => {
+  const { directory } = buildPersonDirectory([LISA])
+
+  it('DM: always resolves (the chat IS the sender)', () => {
+    const name = resolvePersonName(directory, { telegramId: '8201250670', isDm: true })
+    expect(name).toBe('Lisa')
+  })
+
+  it('group: resolves when the sender is present in that chat\'s allowFrom', () => {
+    const name = resolvePersonName(directory, {
+      telegramId: '8201250670',
+      isDm: false,
+      groupAllowFrom: ['8201250670', '111'],
+    })
+    expect(name).toBe('Lisa')
+  })
+
+  it('group: does NOT resolve when allowFrom is empty/unset (can\'t confirm membership)', () => {
+    expect(resolvePersonName(directory, { telegramId: '8201250670', isDm: false })).toBeUndefined()
+    expect(resolvePersonName(directory, { telegramId: '8201250670', isDm: false, groupAllowFrom: [] })).toBeUndefined()
+  })
+
+  it('group: does NOT resolve when the sender is absent from that group\'s allowFrom (a name safe in a DM is not broadcast elsewhere)', () => {
+    const name = resolvePersonName(directory, {
+      telegramId: '8201250670',
+      isDm: false,
+      groupAllowFrom: ['111'], // some other member, not lisa
+    })
+    expect(name).toBeUndefined()
+  })
+
+  it('group: resolves via username when username (not id) is in allowFrom', () => {
+    const { directory: dir2 } = buildPersonDirectory([KEN])
+    const name = resolvePersonName(dir2, {
+      telegramId: '999999',
+      username: 'mekenthompson',
+      isDm: false,
+      groupAllowFrom: ['mekenthompson'],
+    })
+    expect(name).toBe('Ken')
+  })
+})
+
+describe('runPersonDirectoryBootCheck — one-time boot validation + alerting', () => {
+  it('happy path: no alert, directory populated', () => {
+    const result = runPersonDirectoryBootCheck(() => [LISA, KEN])
+    expect(result.alertDetail).toBeNull()
+    expect(result.directory.byTelegramKey['8201250670']?.personId).toBe('Lisa')
+    expect(result.logLine).toMatch(/boot validation ok/)
+  })
+
+  it('no entries configured: no alert (this is not an error)', () => {
+    const result = runPersonDirectoryBootCheck(() => [])
+    expect(result.alertDetail).toBeNull()
+    expect(result.directory.byTelegramKey).toEqual({})
+  })
+
+  it('dropped entry at boot fires an alert (routes through the caller\'s fleet-alert path) and still resolves the good entries', () => {
+    const bad: RawPersonEntry = { key: 'ghost', person_id: '', telegram_ids: ['1'] }
+    const result = runPersonDirectoryBootCheck(() => [LISA, bad])
+    expect(result.alertDetail).not.toBeNull()
+    expect(result.alertDetail).toContain('dropped 1')
+    expect(result.alertDetail).toContain('ghost')
+    expect(result.directory.byTelegramKey['8201250670']?.personId).toBe('Lisa')
+  })
+
+  it('dead-man\'s-switch: readEntries throwing is caught, reported via alertDetail, and PERSON_DIRECTORY falls back to empty (fail-open)', () => {
+    const result = runPersonDirectoryBootCheck(() => {
+      throw new Error('disk read exploded')
+    })
+    expect(result.alertDetail).not.toBeNull()
+    expect(result.alertDetail).toContain('crashed')
+    expect(result.alertDetail).toContain('disk read exploded')
+    expect(result.directory.byTelegramKey).toEqual({})
+    expect(result.logLine).toContain('CRASHED')
+  })
+})

--- a/telegram-plugin/tests/resolve-person.test.ts
+++ b/telegram-plugin/tests/resolve-person.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import {
   buildPersonDirectory,
   resolvePersonName,
   runPersonDirectoryBootCheck,
+  safeResolvePersonName,
+  type PersonDirectory,
   type RawPersonEntry,
 } from '../gateway/resolve-person.js'
 
@@ -77,6 +79,24 @@ describe('buildPersonDirectory — per-entry validation drops only the bad entry
     expect(dropped[0]?.reason).toMatch(/duplicate person_id/)
   })
 
+  it('drops a duplicate telegram_id claimed by a different person_id (later entry loses), keeps the first entry intact — no silent last-write-wins', () => {
+    const dupe: RawPersonEntry = { key: 'imposter', person_id: 'Imposter', telegram_ids: ['8201250670'] }
+    const { directory, dropped } = buildPersonDirectory([LISA, dupe])
+    expect(directory.byTelegramKey['8201250670']?.personId).toBe('Lisa')
+    expect(dropped).toHaveLength(1)
+    expect(dropped[0]?.key).toBe('imposter')
+    expect(dropped[0]?.reason).toMatch(/duplicate telegram_id/)
+  })
+
+  it('telegram_id collision on boot check fires the config-warning alert path, does not blank the whole directory', () => {
+    const dupe: RawPersonEntry = { key: 'imposter', person_id: 'Imposter', telegram_ids: ['8201250670'] }
+    const result = runPersonDirectoryBootCheck(() => [LISA, KEN, dupe])
+    expect(result.alertDetail).not.toBeNull()
+    expect(result.alertDetail).toContain('imposter')
+    expect(result.directory.byTelegramKey['8201250670']?.personId).toBe('Lisa')
+    expect(result.directory.byTelegramKey['mekenthompson']?.personId).toBe('Ken')
+  })
+
   it('drops an entry with a missing users: map key', () => {
     const bad: RawPersonEntry = { key: '', person_id: 'Nobody', telegram_ids: ['1'] }
     const { directory, dropped } = buildPersonDirectory([LISA, bad])
@@ -149,6 +169,54 @@ describe('resolvePersonName — chat scoping', () => {
       groupAllowFrom: ['mekenthompson'],
     })
     expect(name).toBe('Ken')
+  })
+})
+
+describe('safeResolvePersonName — fail-open call-site wrapper used by handleInbound', () => {
+  it('happy path: resolves same as resolvePersonName when nothing throws', () => {
+    const { directory } = buildPersonDirectory([LISA])
+    const name = safeResolvePersonName(directory, { telegramId: '8201250670', isDm: true }, 'raw-fallback')
+    expect(name).toBe('Lisa')
+  })
+
+  it('unresolved id: falls back to the raw id/username, same as today\'s behavior', () => {
+    const { directory } = buildPersonDirectory([LISA])
+    const name = safeResolvePersonName(directory, { telegramId: '000', isDm: true }, 'raw-fallback')
+    expect(name).toBe('raw-fallback')
+  })
+
+  it('resolution throwing (e.g. a malformed opts shape at the call site) is swallowed — falls back to the raw id/username instead of propagating and aborting handleInbound', () => {
+    const { directory } = buildPersonDirectory([LISA])
+    // Force resolvePersonName's internal normalizeTelegramKey to throw by
+    // passing a non-string telegramId past the type system, simulating an
+    // unexpected runtime shape from the Telegram payload.
+    const name = safeResolvePersonName(
+      directory,
+      { telegramId: undefined as unknown as string, isDm: true },
+      'raw-fallback',
+    )
+    expect(name).toBe('raw-fallback')
+  })
+
+  it('a directory whose lookup throws is also swallowed, not propagated', () => {
+    const throwingDirectory: PersonDirectory = {
+      byTelegramKey: new Proxy(
+        {},
+        {
+          get() {
+            throw new Error('boom: directory lookup exploded')
+          },
+        },
+      ),
+    }
+    const spy = vi.fn()
+    try {
+      const name = safeResolvePersonName(throwingDirectory, { telegramId: '8201250670', isDm: true }, 'raw-fallback')
+      expect(name).toBe('raw-fallback')
+    } catch (err) {
+      spy(err)
+    }
+    expect(spy).not.toHaveBeenCalled()
   })
 })
 

--- a/tests/config.resolve-person-entries.test.ts
+++ b/tests/config.resolve-person-entries.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { resolvePersonEntries } from "../src/config/users.js";
+import { SwitchroomConfigSchema } from "../src/config/schema.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+/**
+ * person_id name resolution (docs/configuration.md). `resolvePersonEntries`
+ * is a DUMB raw projection only — no dedup/validation (that's the
+ * gateway-side boot-time job, telegram-plugin/gateway/resolve-person.ts).
+ */
+
+function cfg(partial: Record<string, unknown>): SwitchroomConfig {
+  return {
+    agents: {},
+    memory: { backend: "hindsight", config: { url: "http://localhost:18888/mcp/" } },
+    telegram: { bot_token: "t", forum_chat_id: "c" },
+    ...partial,
+  } as unknown as SwitchroomConfig;
+}
+
+describe("resolvePersonEntries — raw projection of users: person_id entries", () => {
+  it("projects a user with person_id set", () => {
+    const entries = resolvePersonEntries(
+      cfg({
+        users: {
+          lisa: { telegram_ids: ["8201250670"], profile_bank: "lisa-profile", person_id: "Lisa" },
+        },
+      }),
+    );
+    expect(entries).toEqual([{ key: "lisa", person_id: "Lisa", telegram_ids: ["8201250670"] }]);
+  });
+
+  it("skips users without person_id set", () => {
+    const entries = resolvePersonEntries(
+      cfg({
+        users: {
+          ken: { telegram_ids: ["111"], profile_bank: "ken-profile" },
+          lisa: { telegram_ids: ["8201250670"], profile_bank: "lisa-profile", person_id: "Lisa" },
+        },
+      }),
+    );
+    expect(entries).toEqual([{ key: "lisa", person_id: "Lisa", telegram_ids: ["8201250670"] }]);
+  });
+
+  it("no users block → empty array", () => {
+    expect(resolvePersonEntries(cfg({}))).toEqual([]);
+  });
+
+  it("does not dedup or validate — that's the gateway boot-time job", () => {
+    // Two different users declaring the same person_id is NOT rejected
+    // here; buildPersonDirectory (gateway-side) is the one that drops the
+    // duplicate at boot and alerts.
+    const entries = resolvePersonEntries(
+      cfg({
+        users: {
+          a: { telegram_ids: ["1"], profile_bank: "a-profile", person_id: "Same" },
+          b: { telegram_ids: ["2"], profile_bank: "b-profile", person_id: "Same" },
+        },
+      }),
+    );
+    expect(entries).toHaveLength(2);
+  });
+});
+
+describe("schema — users.<key>.person_id", () => {
+  const TELEGRAM = { bot_token: "t", forum_chat_id: "123" };
+
+  it("accepts a user with person_id set", () => {
+    const r = SwitchroomConfigSchema.safeParse({
+      switchroom: { version: 1 },
+      telegram: TELEGRAM,
+      users: { lisa: { telegram_ids: ["x"], profile_bank: "lisa-profile", person_id: "Lisa" } },
+      agents: {},
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("person_id is optional — a user without it still parses", () => {
+    const r = SwitchroomConfigSchema.safeParse({
+      switchroom: { version: 1 },
+      telegram: TELEGRAM,
+      users: { ken: { telegram_ids: ["x"], profile_bank: "ken-profile" } },
+      agents: {},
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a non-string person_id", () => {
+    const r = SwitchroomConfigSchema.safeParse({
+      switchroom: { version: 1 },
+      telegram: TELEGRAM,
+      users: { lisa: { telegram_ids: ["x"], profile_bank: "lisa-profile", person_id: 42 } },
+      agents: {},
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -452,6 +452,58 @@ describe("scaffoldAgent", () => {
     expect(access.groups["-1001234567890"].requireMention).toBe(false);
   });
 
+  it("generates telegram/people.json (empty entries) even with no users: block", () => {
+    const config = makeAgentConfig({});
+    const result = scaffoldAgent("no-people", config, tmpDir, telegramConfig);
+    const people = JSON.parse(
+      readFileSync(join(result.agentDir, "telegram", "people.json"), "utf-8"),
+    );
+    expect(people).toEqual({ entries: [] });
+  });
+
+  it("projects users: person_id entries into telegram/people.json (raw, undeduped)", () => {
+    const config = makeAgentConfig({});
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      users: {
+        lisa: { telegram_ids: ["8201250670"], profile_bank: "lisa-profile", person_id: "Lisa" },
+        ken: { telegram_ids: ["111"], profile_bank: "ken-profile" }, // no person_id — excluded
+      },
+      agents: { "people-agent": config },
+    } as SwitchroomConfig;
+    const result = scaffoldAgent("people-agent", config, tmpDir, telegramConfig, switchroomConfig);
+    const people = JSON.parse(
+      readFileSync(join(result.agentDir, "telegram", "people.json"), "utf-8"),
+    );
+    expect(people.entries).toEqual([{ key: "lisa", person_id: "Lisa", telegram_ids: ["8201250670"] }]);
+  });
+
+  it("people.json is config-derived — re-scaffolding (the `switchroom apply` reconcile path) regenerates it, unlike writeIfMissing access.json", () => {
+    const config = makeAgentConfig({});
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      users: { lisa: { telegram_ids: ["8201250670"], profile_bank: "lisa-profile", person_id: "Lisa" } },
+      agents: { "people-rescaffold": config },
+    } as SwitchroomConfig;
+    scaffoldAgent("people-rescaffold", config, tmpDir, telegramConfig, switchroomConfig);
+
+    // Simulate a users: edit, then re-run `switchroom apply` (which calls
+    // scaffoldAgent again, idempotently, for every configured agent) —
+    // people.json must pick up the change, unlike the writeIfMissing
+    // access.json.
+    const switchroomConfig2: SwitchroomConfig = {
+      ...switchroomConfig,
+      users: { lisa: { telegram_ids: ["8201250670"], profile_bank: "lisa-profile", person_id: "Lisa Renamed" } },
+    } as SwitchroomConfig;
+    scaffoldAgent("people-rescaffold", config, tmpDir, telegramConfig, switchroomConfig2);
+    const people = JSON.parse(
+      readFileSync(join(tmpDir, "people-rescaffold", "telegram", "people.json"), "utf-8"),
+    );
+    expect(people.entries[0].person_id).toBe("Lisa Renamed");
+  });
+
   it("projects channels.telegram.coalesce.window_ms into access.coalescingGapMs", () => {
     const config = makeAgentConfig({
       channels: { telegram: { coalesce: { window_ms: 1200 } } },


### PR DESCRIPTION
## Summary

Adds an optional `person_id` field on `users:` entries so a known person (e.g. the operator's wife "Lisa") shows up by name in the inbound `<channel>` tag's `user` attribute instead of only a raw Telegram numeric id/username. `meta.user_id` is unchanged — always the raw numeric id.

This is the converged design after 4 rounds of adversarial review — see the commit message for the full rationale on each constraint. Key points:

- **No MCP tool** — display-only, never callable by agents.
- **No hot-reload** — the gateway's `PERSON_DIRECTORY` is built exactly once at boot from the static config-derived `telegram/people.json` the scaffold projects; a `users:` edit needs an agent restart.
- **`access.json` untouched** — the fail-CLOSED allowlist stays a completely separate concern. `people.json` is a new sibling file carrying purely fail-OPEN display data; unresolved ids/usernames fall back to today's raw-id behavior and nothing is ever blocked/denied by this feature.
- **Chat-scoped** — a resolved name is only shown in a chat/group the person is confirmed to be a member of (via that chat's `access.json` `allowFrom`). A DM always resolves (the chat IS the sender). An unrestricted/empty group `allowFrom` conservatively does **not** resolve, so a name safe in a private DM never broadcasts into every group the agent sits in.
- **Per-entry validation** — a malformed `users:` entry (empty `person_id`, no `telegram_ids`, or a `person_id` collision) drops only that one entry, never blanks resolution fleet-wide, and posts a low-severity `config-warning` operator alert (new `OperatorEventKind`, reuses the existing fleet-alert channel — `emitGatewayOperatorEvent`/`renderOperatorEvent` — with a Dismiss-only keyboard so it never pages like a real outage).
- **Boot-time-only reconciliation** — the check runs exactly once per gateway boot, not periodic. Extracted as a pure, unit-tested `runPersonDirectoryBootCheck` so the orchestration (including the dead-man's-switch: a crash in the check itself is also alerted, with name resolution disabled fail-open for that boot rather than silently swallowed — mirroring a past `access.json` wrong-direction-fallback incident) is testable without booting the real gateway process.
- **Accepted soft mitigation, documented honestly** — there is no automated enforcement that a configured `person_id` stays safe if a group's membership changes after the entry is written. This is called out explicitly in `docs/configuration.md` as an operator-discipline convention, not a closed gap — low severity today given only two `person_id`s are configured fleet-wide.

**Deliberately out of scope:** the separate, default-off reaction-dispatch synthetic-inbound path (`telegram-plugin/gateway/reaction-dispatch.ts`) is not wired to this feature, to keep the change focused and reviewable.

## Files changed

- `src/config/schema.ts` — `UserSchema.person_id` (optional string)
- `src/config/users.ts` — `resolvePersonEntries()`, a dumb raw projection of `users:` entries carrying `person_id`
- `src/agents/scaffold.ts` — `buildPeopleJson()` + `telegram/people.json` write, via `writeFileSyncIfChanged` (config-derived, regenerated every scaffold — unlike `access.json`'s `writeIfMissing`)
- `telegram-plugin/gateway/resolve-person.ts` (new) — `buildPersonDirectory` (per-entry validation + dedup), `resolvePersonName` (chat-scoped lookup), `runPersonDirectoryBootCheck` (dead-man's-switch orchestration, pure + testable)
- `telegram-plugin/operator-events.ts` — new `'config-warning'` `OperatorEventKind` + non-urgent render case (ℹ️, Dismiss-only)
- `telegram-plugin/gateway/gateway.ts` — `PEOPLE_FILE`/`readPeopleFile`, `PERSON_DIRECTORY`, one-shot boot validation call site (inside the existing `didOneTimeSetup` block), `inboundMsg.user`/`meta.user` wiring in `handleInbound`
- Tests: `telegram-plugin/tests/resolve-person.test.ts`, `tests/config.resolve-person-entries.test.ts`, plus additions to `telegram-plugin/tests/operator-events.test.ts` and `tests/scaffold.test.ts`
- `docs/configuration.md`, `CHANGELOG.md`

## Test plan

- [x] `node node_modules/typescript/bin/tsc --noEmit -p .` — clean, no type errors
- [x] `vitest run` on the new/touched files — 108 tests pass (`resolve-person.test.ts` 19, `config.resolve-person-entries.test.ts` 7, `operator-events.test.ts` 71 incl. new `config-warning` cases, `config.resolve-users.test.ts` 11 regression)
- [x] `vitest run tests/scaffold.test.ts` — 202 tests pass, including 3 new `people.json` scaffold tests
- [x] Full repo `vitest run` — 12480 passed / 114 failed; the 114 failures are pre-existing and unrelated (host-control/docker-exec harness, static-binary build artifact, claude-CLI-binary-presence gate, a timing-sensitive single-flight test) — none touch config/schema/scaffold/gateway/resolve-person/operator-events
- [ ] Manual: configure `person_id` on a fleet user, restart an agent, confirm the `<channel>` tag shows the name in a DM and in a group only when the sender is in that group's `allowFrom`

Leaving this open for review — not merging.

Co-Authored-By: Claude <noreply@anthropic.com>

## Post-review fixes (adversarial re-review)

Two real bugs found and fixed in a follow-up commit:

1. **`telegram_id` collision silently last-write-wins.** `buildPersonDirectory` checked `person_id` collisions but not `telegram_id` collisions — two entries with different `person_id`s but an overlapping/typo'd `telegram_id` just silently overwrote `byTelegramKey[tk]`, with no drop and no alert, risking the wrong person's name being displayed. Now tracked with a `telegramKeyOwner` map, same convention as `personIdOwner`: the later duplicate is dropped whole and routed through the existing low-severity `config-warning` alert path.
2. **`resolvePersonName` call site not fail-open.** The call in `handleInbound` wasn't try/catch wrapped, unlike `readPeopleFile` and `runPersonDirectoryBootCheck` elsewhere in this same feature — a throw there would have aborted the whole inbound flow instead of falling back to the raw id/username. Added `safeResolvePersonName` (try/catch + fallback to the raw id) and switched the call site to it.

Tests added in `telegram-plugin/tests/resolve-person.test.ts`: a `telegram_id`-collision case mirroring the existing `person_id`-collision test (drops only the later entry, alert fires, directory not blanked), plus unit coverage of `safeResolvePersonName` swallowing a thrown exception and falling back to the raw id.

Verified: `tsc --noEmit` clean, `resolve-person.test.ts` (25 tests) + `config.resolve-person-entries.test.ts` (7 tests) + `operator-events.test.ts` (71 tests) all green, `check-bot-api-wrapping` guard clean.
