### PR TITLE
fix(telegram): progress-card narration-clobber fix + quota-bar card format

### DIFF
--- a/scripts/print-quota-bar.ts
+++ b/scripts/print-quota-bar.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env bun
+/**
+ * Print the quota-bar block (telegram-plugin/quota-bar-format.ts) for the
+ * current fleet, using the same cached `last_quota` data
+ * `switchroom auth list --json` exposes. No live quota probe — this is the
+ * cheap/cached render path, matching `buildSnapshotsFromCachedState`.
+ *
+ * Usage:
+ *   bun scripts/print-quota-bar.ts
+ *
+ * Minimal by design — this is a manual/dev entrypoint for eyeballing the
+ * block's current output, not a scheduler or a live-refreshing Telegram
+ * sender. Wiring this to an actually-refreshing pinned message is a
+ * follow-up once the format above is confirmed stable in real chats.
+ */
+
+import { execFileSync } from 'node:child_process';
+import type { ListStateData } from '../src/auth/broker/client.js';
+import { renderQuotaBarBlockFromListState } from '../telegram-plugin/quota-bar-format.js';
+
+function loadListState(): ListStateData {
+  const raw = execFileSync('switchroom', ['auth', 'list', '--json'], {
+    encoding: 'utf-8',
+  });
+  return JSON.parse(raw) as ListStateData;
+}
+
+const state = loadListState();
+process.stdout.write(renderQuotaBarBlockFromListState(state) + '\n');

--- a/telegram-plugin/quota-bar-format.ts
+++ b/telegram-plugin/quota-bar-format.ts
@@ -1,0 +1,257 @@
+/**
+ * Quota-bar block — a compact per-account ASCII-bar rendering of the 5-hour
+ * and 7-day utilization windows, for a live-refreshing Telegram card.
+ *
+ * JTBD: "at a glance, how much headroom does each account have, and how far
+ * through its reset window are we" — denser than the `/auth` table (Format 2,
+ * `auth-snapshot-format.ts`), meant for a small always-visible strip rather
+ * than a full snapshot.
+ *
+ * Locked output shape (operator-confirmed via live Telegram iteration —
+ * do not reformat without re-confirming):
+ *
+ * ```
+ * - **ken.thompson@outlook.com.au** (active)
+ * - 🟢 5h `[┃░░░░░░░░░] 0% / 4h20m left`
+ * - 🟡 7d `[████┃█░░░░] 47% / 3d1h left`
+ * - **me@kenthompson.com.au** (exhausted)
+ * - 🟢 5h `[┃░░░░░░░░░] 0% / resets now`
+ * - 🔴 7d `[██████┃███] 100% / 2d16h left`
+ * ```
+ *
+ * Rules:
+ *   1. GFM `- ` bullet marker on EVERY line, including the account title
+ *      line — a tight one-item-per-line list, no blank lines between rows
+ *      (a no-bullet hard-break variant was tried live and rejected as
+ *      "worse" — bullets are the final mechanism).
+ *   2. Title line: `- **<email>** (<status>)`, status derived from data
+ *      (`active` | `exhausted` | `idle` — see `accountStatus`).
+ *   3. One row per window (5h, 7d): `- <dot> <window> \`[<bar>] <pct>% /
+ *      <time-left>\``.
+ *   4. Bar is 10 cells of `█` (filled, proportional to utilization) /
+ *      `░` (empty), with a single `┃` "pace" tick marking how far through
+ *      the reset window we currently are. The tick ALWAYS renders at its
+ *      computed position, overriding whatever fill character is there —
+ *      even at 100% utilization — since the pace signal must stay visible
+ *      (operator-confirmed; see `buildBar`).
+ */
+
+import type { QuotaUtilization } from './quota-check.js';
+import { refillNormalizedUtils, isProbeThin } from '../src/auth/quota.js';
+import type { AccountState, ListStateData } from '../src/auth/broker/client.js';
+import { reviveLastQuota, type AccountSnapshot } from './auth-snapshot-format.js';
+import { escapeMarkdown } from './card-format.js';
+
+// ── dot thresholds ───────────────────────────────────────────────────
+
+/**
+ * Per-row status dot, purely a function of THAT window's own utilization
+ * percentage (not the account's overall exhausted flag — an exhausted
+ * account can still show a green 5h row if that window is fresh).
+ *
+ *   - < 50%  → 🟢 healthy
+ *   - 50-89% → 🟡 getting close
+ *   - >= 90% → 🔴 at/near the wall
+ */
+export function pickDot(pct: number): '🟢' | '🟡' | '🔴' {
+  const clamped = Math.max(0, Math.min(100, pct));
+  if (clamped >= 90) return '🔴';
+  if (clamped >= 50) return '🟡';
+  return '🟢';
+}
+
+// ── time-left formatting ─────────────────────────────────────────────
+
+/**
+ * Compact time-left string for the quota-bar row: `4h20m left`,
+ * `3d1h left`, `45m left`, or `resets now` when the reset has already
+ * passed (or is unknown — no reset timestamp to count down to).
+ *
+ * Deliberately more compact than `formatRelative` in
+ * `auth-snapshot-format.ts` (no space between the number and unit) to
+ * keep the fixed-width code-span row from wrapping on a phone screen.
+ */
+export function formatTimeLeft(target: Date | null, now: Date = new Date()): string {
+  if (!target) return 'resets now';
+  const deltaMs = target.getTime() - now.getTime();
+  if (deltaMs <= 0) return 'resets now';
+  const totalMin = Math.round(deltaMs / 60_000);
+  if (totalMin < 60) return `${totalMin}m left`;
+  const totalHours = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  if (totalHours < 24) return `${totalHours}h${m}m left`;
+  const d = Math.floor(totalHours / 24);
+  const h = totalHours % 24;
+  return h > 0 ? `${d}d${h}h left` : `${d}d left`;
+}
+
+// ── pace (elapsed-through-window) fraction ───────────────────────────
+
+const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
+const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * How far through the reset window we currently are, as a 0..1 fraction,
+ * derived from the time LEFT to reset and the window's nominal duration
+ * (we're never told the window's start time, only its end/reset — so this
+ * is an approximation, not an exact elapsed-time read).
+ *
+ *   - no reset timestamp, or reset already passed → 0 (treat as a freshly
+ *     started window rather than claiming we're at the very end of one we
+ *     have no data for)
+ *   - otherwise → `1 - timeLeftMs / windowDurationMs`, clamped to [0, 1]
+ */
+export function elapsedFraction(
+  target: Date | null,
+  windowDurationMs: number,
+  now: Date = new Date(),
+): number {
+  if (!target) return 0;
+  const timeLeftMs = target.getTime() - now.getTime();
+  if (timeLeftMs <= 0) return 0;
+  return Math.max(0, Math.min(1, 1 - timeLeftMs / windowDurationMs));
+}
+
+// ── bar rendering ─────────────────────────────────────────────────────
+
+const BAR_WIDTH = 10;
+
+/**
+ * Build the 10-cell `[█…░…]` bar body (no surrounding brackets — callers
+ * add those) for one window row.
+ *
+ *   - `fillCount = round(pct / 100 * 10)` cells are `█` from the left.
+ *   - a single `┃` pace tick is placed at
+ *     `round(elapsedFrac * (width - 1))`, and ALWAYS overwrites whatever
+ *     cell is there — including a filled `█` cell, even at 100% utilization
+ *     (rule 4 above; the pace signal must always be visible).
+ */
+export function buildBar(pct: number, elapsedFrac: number): string {
+  const clampedPct = Math.max(0, Math.min(100, pct));
+  const fillCount = Math.round((clampedPct / 100) * BAR_WIDTH);
+  const cells: string[] = new Array(BAR_WIDTH).fill('░');
+  for (let i = 0; i < fillCount; i++) cells[i] = '█';
+  const tickIndex = Math.max(
+    0,
+    Math.min(BAR_WIDTH - 1, Math.round(elapsedFrac * (BAR_WIDTH - 1))),
+  );
+  cells[tickIndex] = '┃';
+  return cells.join('');
+}
+
+// ── account status (title-line suffix) ───────────────────────────────
+
+export type QuotaBarAccountStatus = 'active' | 'exhausted' | 'idle';
+
+/**
+ * Title-line status word. `active` wins over `exhausted` (the fleet's
+ * pinned account is reported as active even if the broker also flags it
+ * exhausted — matches the locked example where the operator wants to know
+ * WHICH account is live first, and its health second, from the two window
+ * rows underneath). Otherwise: `exhausted` if the broker's own flag says
+ * so, else `idle` (present, healthy, just not the current pick).
+ */
+export function accountStatus(isActive: boolean, exhausted: boolean): QuotaBarAccountStatus {
+  if (isActive) return 'active';
+  if (exhausted) return 'exhausted';
+  return 'idle';
+}
+
+// ── row / block assembly ─────────────────────────────────────────────
+
+/** One `- <dot> <window> \`[<bar>] <pct>% / <time-left>\`` line. */
+export function formatWindowRow(
+  window: '5h' | '7d',
+  pct: number,
+  resetAt: Date | null,
+  now: Date = new Date(),
+): string {
+  const windowMs = window === '5h' ? FIVE_HOUR_MS : SEVEN_DAY_MS;
+  const dot = pickDot(pct);
+  const bar = buildBar(pct, elapsedFraction(resetAt, windowMs, now));
+  const pctStr = `${Math.round(Math.max(0, Math.min(100, pct)))}%`;
+  const timeLeft = formatTimeLeft(resetAt, now);
+  return `- ${dot} ${window} \`[${bar}] ${pctStr} / ${timeLeft}\``;
+}
+
+/** One account's title line + its two window rows (5h then 7d). */
+export function renderQuotaBarAccount(
+  label: string,
+  isActive: boolean,
+  exhausted: boolean,
+  quota: QuotaUtilization | null,
+  now: Date = new Date(),
+): string[] {
+  const status = accountStatus(isActive, exhausted);
+  // Title line wraps `label` in GFM `**bold**`, NOT a code span — so this
+  // needs `escapeMarkdown` (backslash-escapes *, _, [, ], etc.), not
+  // `codeSpanSafe` (which only defuses backticks and is only correct
+  // inside literal `code spans` — see format.ts). Using codeSpanSafe here
+  // was a bug: a label containing e.g. `**` or `[x](url)` would break the
+  // bold run or inject a markdown link into the card.
+  const lines: string[] = [`- **${escapeMarkdown(label)}** (${status})`];
+  if (!quota || isProbeThin(quota)) {
+    // Data-quality gap: still emit the two rows so the block stays
+    // shape-stable, but at 0%/unknown-reset rather than fabricating numbers.
+    lines.push(formatWindowRow('5h', 0, null, now));
+    lines.push(formatWindowRow('7d', 0, null, now));
+    return lines;
+  }
+  const norm = refillNormalizedUtils(quota, now);
+  lines.push(formatWindowRow('5h', norm.fiveHourUtilizationPct, quota.fiveHourResetAt, now));
+  lines.push(formatWindowRow('7d', norm.sevenDayUtilizationPct, quota.sevenDayResetAt, now));
+  return lines;
+}
+
+export interface QuotaBarRenderOpts {
+  now?: Date;
+}
+
+/**
+ * Render the full multi-account quota-bar block from `AccountSnapshot[]`
+ * (the same shape `auth-snapshot-format.ts` builds — reuse
+ * `buildSnapshotsFromCachedState` / `buildSnapshotsFromState` /
+ * `quotaBarSnapshotsFromListState` to get one).
+ *
+ * Additionally needs each account's `exhausted` flag (not carried on
+ * `AccountSnapshot`), passed as a parallel lookup keyed by label.
+ */
+export function renderQuotaBarBlock(
+  snapshots: AccountSnapshot[],
+  exhaustedByLabel: ReadonlyMap<string, boolean>,
+  opts: QuotaBarRenderOpts = {},
+): string {
+  const now = opts.now ?? new Date();
+  const lines: string[] = [];
+  for (const snap of snapshots) {
+    const exhausted = exhaustedByLabel.get(snap.label) ?? false;
+    lines.push(...renderQuotaBarAccount(snap.label, snap.isActive, exhausted, snap.quota, now));
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Convenience one-shot: build the quota-bar block directly from the shape
+ * `switchroom auth list --json` prints (`ListStateData`), using each
+ * account's cached `last_quota` (no live probe — same cache path
+ * `buildSnapshotsFromCachedState` uses). This is what the CLI script
+ * entrypoint (`scripts/print-quota-bar.ts`) calls.
+ */
+export function renderQuotaBarBlockFromListState(
+  state: ListStateData,
+  opts: QuotaBarRenderOpts = {},
+): string {
+  const now = opts.now ?? new Date();
+  const exhaustedByLabel = new Map<string, boolean>(
+    state.accounts.map((a: AccountState) => [a.label, a.exhausted]),
+  );
+  const snapshots: AccountSnapshot[] = state.accounts.map((acc: AccountState) => ({
+    label: acc.label,
+    isActive: acc.label === state.active,
+    quota: reviveLastQuota(acc.last_quota ?? null),
+    quotaError: acc.last_quota ? undefined : 'no cached quota (no probe since broker start)',
+    expiresAtMs: acc.expiresAt,
+    capturedAtMs: acc.last_quota?.capturedAt,
+  }));
+  return renderQuotaBarBlock(snapshots, exhaustedByLabel, { now });
+}

--- a/telegram-plugin/quota-bar-format.ts
+++ b/telegram-plugin/quota-bar-format.ts
@@ -11,10 +11,10 @@
  * do not reformat without re-confirming):
  *
  * ```
- * - **ken.thompson@outlook.com.au** (active)
+ * - **you@example.com** (active)
  * - 🟢 5h `[┃░░░░░░░░░] 0% / 4h20m left`
  * - 🟡 7d `[████┃█░░░░] 47% / 3d1h left`
- * - **me@kenthompson.com.au** (exhausted)
+ * - **alice@example.com** (exhausted)
  * - 🟢 5h `[┃░░░░░░░░░] 0% / resets now`
  * - 🔴 7d `[██████┃███] 100% / 2d16h left`
  * ```

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -918,8 +918,8 @@ export function readSubTail(
       // (stage-on-text, resolve-on-tool/turn_end) can replay a previously
       // pending block exactly once. `latestSummary` carries the worker's
       // narrative result (entry.lastResultText), never tool labels.
-      const fireNarrativeProgress = (): void => {
-        if (onProgress == null || entry.state !== 'running' || entry.historical) return
+      const fireNarrativeProgress = (): boolean => {
+        if (onProgress == null || entry.state !== 'running' || entry.historical) return false
         try {
           onProgress({
             agentId: entry.agentId,
@@ -933,8 +933,10 @@ export function readSubTail(
             lastTool: entry.lastTool,
             toolCount: entry.toolCount,
           })
+          return true
         } catch (cbErr) {
           log?.(`subagent-watcher: onProgress callback error ${entry.agentId}: ${(cbErr as Error).message}`)
+          return false
         }
       }
       // Resolve a pending sub-agent narrative against a lookahead event.
@@ -952,21 +954,27 @@ export function readSubTail(
       //     compare the trailing block against the worker's last reply text
       //     (`entry.lastReplyText`) and suppress a draft. Background workers
       //     never set lastReplyText, so their trailing narration still SHOWs.
+      // Returns true iff a narrative onProgress cue actually fired this
+      // call — callers use this to skip a redundant/clobbering tool-label
+      // onProgress cue for the SAME tick (see #1042 below: without this,
+      // the tool-description onProgress unconditionally fires right after
+      // and its replace-on-write onProgress always wins, so the narration
+      // shown here is never actually visible on the pinned card).
       const resolvePendingSubNarrative = (
         toolName: string | null,
         toolInput: Record<string, unknown> | undefined,
-      ): void => {
-        if (entry.pendingNarrative == null) return
+      ): boolean => {
+        if (entry.pendingNarrative == null) return false
         const pending = entry.pendingNarrative
         entry.pendingNarrative = null
         if (toolName != null && REPLY_TOOLS.has(toolName)) {
           const replyText = typeof toolInput?.text === 'string' ? (toolInput.text as string) : ''
-          if (isDraftOfReply(pending.text, replyText)) return // draft of the reply → SUPPRESS
+          if (isDraftOfReply(pending.text, replyText)) return false // draft of the reply → SUPPRESS
         } else if (toolName == null && entry.lastReplyText != null && entry.lastReplyText.length > 0) {
           // turn_end path: suppress a trailing draft of the delivered answer.
-          if (isDraftOfReply(pending.text, entry.lastReplyText)) return
+          if (isDraftOfReply(pending.text, entry.lastReplyText)) return false
         }
-        fireNarrativeProgress()
+        return fireNarrativeProgress()
       }
       for (const ev of events) {
         const idleSecBeforeBump = Math.round((now - entry.lastActivityAt) / 1000)
@@ -1012,7 +1020,7 @@ export function readSubTail(
           // this tool is the lookahead that decides it (SHOW unless it drafts
           // a reply tool's text). Runs before the tool's own progress cue so
           // a working preamble surfaces just ahead of its tool step.
-          resolvePendingSubNarrative(ev.toolName, ev.input)
+          const narrativeJustFired = resolvePendingSubNarrative(ev.toolName, ev.input)
           // NIT 3: capture a foreground sub-agent's actual reply text so the
           // turn_end path can suppress a trailing draft of it (see
           // resolvePendingSubNarrative). Only REPLY_TOOLS carry the answer.
@@ -1039,7 +1047,17 @@ export function readSubTail(
           // stays the worker's narrative result (never polluted with tool
           // labels — the handback payload depends on it). Pure jsonl-tail →
           // render, no model call.
-          if (onProgress != null && entry.state === 'running' && !entry.historical) {
+          //
+          // Clobber guard: if a pending narrative just fired an onProgress
+          // cue THIS SAME tick (above), skip this one — replace-on-write
+          // rendering means whichever onProgress call fires last wins, so
+          // firing both back-to-back always threw away the narration in
+          // favour of the generic tool label. Narration already told the
+          // user what's happening for this tick; the label is redundant
+          // here. When nothing preceded this tool call (no pending
+          // narrative), this still fires — that's the named foreground
+          // blindspot fix, unchanged.
+          if (onProgress != null && entry.state === 'running' && !entry.historical && !narrativeJustFired) {
             const toolLine = describeToolUse(ev.toolName, ev.input ?? {})
             if (toolLine != null && toolLine.length > 0) {
               try {

--- a/telegram-plugin/tests/quota-bar-format.test.ts
+++ b/telegram-plugin/tests/quota-bar-format.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for quota-bar-format.ts — bar-building, time-left formatting, and
+ * the full block assembly. Pure functions, frozen-clock fixtures.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  pickDot,
+  formatTimeLeft,
+  elapsedFraction,
+  buildBar,
+  accountStatus,
+  formatWindowRow,
+  renderQuotaBarAccount,
+  renderQuotaBarBlockFromListState,
+} from '../quota-bar-format.js';
+import type { QuotaUtilization } from '../quota-check.js';
+import type { ListStateData } from '../../src/auth/broker/client.js';
+
+const NOW = new Date('2026-07-10T00:00:00.000Z');
+
+function quota(part: Partial<QuotaUtilization>): QuotaUtilization {
+  return {
+    fiveHourUtilizationPct: 0,
+    sevenDayUtilizationPct: 0,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+    representativeClaim: null,
+    overageStatus: null,
+    overageDisabledReason: null,
+    ...part,
+  };
+}
+
+// ── pickDot ──────────────────────────────────────────────────────────
+
+describe('pickDot', () => {
+  it('green under 50%', () => {
+    expect(pickDot(0)).toBe('🟢');
+    expect(pickDot(49)).toBe('🟢');
+  });
+  it('yellow 50-89%', () => {
+    expect(pickDot(50)).toBe('🟡');
+    expect(pickDot(89)).toBe('🟡');
+  });
+  it('red 90%+', () => {
+    expect(pickDot(90)).toBe('🔴');
+    expect(pickDot(100)).toBe('🔴');
+  });
+});
+
+// ── formatTimeLeft ───────────────────────────────────────────────────
+
+describe('formatTimeLeft', () => {
+  it('returns "resets now" when the target is null', () => {
+    expect(formatTimeLeft(null, NOW)).toBe('resets now');
+  });
+  it('returns "resets now" when the target has already passed', () => {
+    expect(formatTimeLeft(new Date(NOW.getTime() - 1000), NOW)).toBe('resets now');
+  });
+  it('returns "resets now" when the target is exactly now', () => {
+    expect(formatTimeLeft(new Date(NOW.getTime()), NOW)).toBe('resets now');
+  });
+  it('formats sub-hour deltas as minutes', () => {
+    expect(formatTimeLeft(new Date(NOW.getTime() + 45 * 60_000), NOW)).toBe('45m left');
+  });
+  it('formats sub-day deltas as compact hours+minutes', () => {
+    expect(formatTimeLeft(new Date(NOW.getTime() + (4 * 60 + 20) * 60_000), NOW)).toBe('4h20m left');
+  });
+  it('formats multi-day deltas as compact days+hours', () => {
+    expect(formatTimeLeft(new Date(NOW.getTime() + (3 * 24 + 1) * 60 * 60_000), NOW)).toBe('3d1h left');
+  });
+  it('drops the hours segment when exactly on a day boundary', () => {
+    expect(formatTimeLeft(new Date(NOW.getTime() + 2 * 24 * 60 * 60_000), NOW)).toBe('2d left');
+  });
+});
+
+// ── elapsedFraction ──────────────────────────────────────────────────
+
+describe('elapsedFraction', () => {
+  const fiveHourMs = 5 * 60 * 60 * 1000;
+  it('is 0 when there is no reset timestamp', () => {
+    expect(elapsedFraction(null, fiveHourMs, NOW)).toBe(0);
+  });
+  it('is 0 when the reset has already passed', () => {
+    expect(elapsedFraction(new Date(NOW.getTime() - 1000), fiveHourMs, NOW)).toBe(0);
+  });
+  it('is close to 1 just before reset', () => {
+    const frac = elapsedFraction(new Date(NOW.getTime() + 60_000), fiveHourMs, NOW);
+    expect(frac).toBeGreaterThan(0.99);
+    expect(frac).toBeLessThanOrEqual(1);
+  });
+  it('is ~0.5 halfway through the window', () => {
+    const frac = elapsedFraction(new Date(NOW.getTime() + fiveHourMs / 2), fiveHourMs, NOW);
+    expect(frac).toBeCloseTo(0.5, 5);
+  });
+});
+
+// ── buildBar ─────────────────────────────────────────────────────────
+
+describe('buildBar', () => {
+  it('is all empty cells with a tick at 0% pct and 0 elapsed fraction', () => {
+    expect(buildBar(0, 0)).toBe('┃░░░░░░░░░');
+  });
+  it('the tick always overrides the fill, even at 100% pct', () => {
+    expect(buildBar(100, 0.5)).toBe('█████┃████');
+  });
+  it('the tick overrides fill at the very last cell (100% pct, 100% elapsed)', () => {
+    expect(buildBar(100, 1)).toBe('█████████┃');
+  });
+  it('is exactly 10 characters for any pct/fraction combination', () => {
+    for (const pct of [0, 1, 33, 47, 89, 99, 100]) {
+      for (const frac of [0, 0.25, 0.5, 0.75, 1]) {
+        expect(buildBar(pct, frac).length).toBe(10);
+      }
+    }
+  });
+  it('places the tick outside the filled region when there is room', () => {
+    // 20% filled (2 cells) + tick at fraction 0.8 → tick lands past the fill.
+    const bar = buildBar(20, 0.8);
+    expect(bar[0]).toBe('█');
+    expect(bar[1]).toBe('█');
+    expect(bar).toContain('┃');
+  });
+});
+
+// ── accountStatus ────────────────────────────────────────────────────
+
+describe('accountStatus', () => {
+  it('active wins even if the broker also flags the account exhausted', () => {
+    expect(accountStatus(true, true)).toBe('active');
+  });
+  it('reports exhausted for a non-active exhausted account', () => {
+    expect(accountStatus(false, true)).toBe('exhausted');
+  });
+  it('reports idle for a non-active, non-exhausted account', () => {
+    expect(accountStatus(false, false)).toBe('idle');
+  });
+});
+
+// ── formatWindowRow / renderQuotaBarAccount ─────────────────────────
+
+describe('formatWindowRow', () => {
+  it('renders the locked row shape', () => {
+    const row = formatWindowRow('5h', 0, null, NOW);
+    expect(row).toBe('- 🟢 5h `[┃░░░░░░░░░] 0% / resets now`');
+  });
+  it('clamps a >100% probe value for display', () => {
+    const row = formatWindowRow('7d', 101, null, NOW);
+    expect(row).toContain('100%');
+  });
+});
+
+describe('renderQuotaBarAccount', () => {
+  it('renders a title line + two window rows', () => {
+    const q = quota({
+      fiveHourUtilizationPct: 0,
+      sevenDayUtilizationPct: 47,
+      sevenDayResetAt: new Date(NOW.getTime() + (3 * 24 + 1) * 60 * 60_000),
+    });
+    const lines = renderQuotaBarAccount('ken@example.com', true, false, q, NOW);
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toBe('- **ken@example.com** (active)');
+    expect(lines[1]).toBe('- 🟢 5h `[┃░░░░░░░░░] 0% / resets now`');
+    expect(lines[2]).toContain('🟢 7d');
+    expect(lines[2]).toContain('47% / 3d1h left');
+  });
+  it('escapes markdown-significant characters in the label (bold run, not a code span)', () => {
+    // Regression: the title line wraps label in **bold**, so a label
+    // containing `**` or `[...]` must be backslash-escaped (escapeMarkdown),
+    // not defused with codeSpanSafe (which only strips backticks and would
+    // leave `*`/`[`/`]` live, breaking the bold run or injecting a link).
+    const lines = renderQuotaBarAccount('a**b[x](evil)_c', false, false, null, NOW);
+    expect(lines[0]).toBe('- **a\\*\\*b\\[x\\](evil)\\_c** (idle)');
+  });
+  it('exhausted account at 0% utilization on both windows still shows exhausted status with healthy dots', () => {
+    const q = quota({ fiveHourUtilizationPct: 0, sevenDayUtilizationPct: 0 });
+    const lines = renderQuotaBarAccount('done@example.com', false, true, q, NOW);
+    expect(lines[0]).toBe('- **done@example.com** (exhausted)');
+    expect(lines[1]).toContain('🟢 5h');
+    expect(lines[2]).toContain('🟢 7d');
+  });
+  it('degrades gracefully to 0%/no-reset rows when quota is missing', () => {
+    const lines = renderQuotaBarAccount('nobody@example.com', false, false, null, NOW);
+    expect(lines).toEqual([
+      '- **nobody@example.com** (idle)',
+      '- 🟢 5h `[┃░░░░░░░░░] 0% / resets now`',
+      '- 🟢 7d `[┃░░░░░░░░░] 0% / resets now`',
+    ]);
+  });
+});
+
+// ── renderQuotaBarBlockFromListState ────────────────────────────────
+
+describe('renderQuotaBarBlockFromListState', () => {
+  it('renders the locked multi-account block shape', () => {
+    const state: ListStateData = {
+      active: 'ken@example.com',
+      fallback_order: ['ken@example.com', 'alt@example.com'],
+      accounts: [
+        {
+          label: 'ken@example.com',
+          exhausted: false,
+          last_quota: {
+            fiveHourUtilizationPct: 0,
+            sevenDayUtilizationPct: 47,
+            fiveHourResetAt: new Date(NOW.getTime() + 60_000).toISOString(),
+            sevenDayResetAt: new Date(NOW.getTime() + (3 * 24 + 1) * 60 * 60_000).toISOString(),
+            representativeClaim: null,
+            overageStatus: null,
+            overageDisabledReason: null,
+            capturedAt: NOW.getTime(),
+          },
+        },
+        {
+          label: 'alt@example.com',
+          exhausted: true,
+          last_quota: {
+            fiveHourUtilizationPct: 0,
+            sevenDayUtilizationPct: 100,
+            fiveHourResetAt: new Date(NOW.getTime() - 60_000).toISOString(),
+            sevenDayResetAt: new Date(NOW.getTime() + 2 * 24 * 60 * 60_000 + 16 * 60 * 60_000).toISOString(),
+            representativeClaim: null,
+            overageStatus: null,
+            overageDisabledReason: null,
+            capturedAt: NOW.getTime(),
+          },
+        },
+      ],
+      agents: [],
+      consumers: [],
+    };
+    const block = renderQuotaBarBlockFromListState(state, { now: NOW });
+    const lines = block.split('\n');
+    expect(lines).toEqual([
+      '- **ken@example.com** (active)',
+      '- 🟢 5h `[░░░░░░░░░┃] 0% / 1m left`',
+      '- 🟢 7d `[█████┃░░░░] 47% / 3d1h left`',
+      '- **alt@example.com** (exhausted)',
+      '- 🟢 5h `[┃░░░░░░░░░] 0% / resets now`',
+      '- 🔴 7d `[██████┃███] 100% / 2d16h left`',
+    ]);
+  });
+});

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -575,6 +575,67 @@ describe('startSubagentWatcher', () => {
       expect(narrativeCues[0]).toContain('find the repo')
     })
 
+    it('narration-clobber regression: a narration cue immediately followed by its resolving tool_use in the same poll does NOT get overwritten by the tool-label cue', () => {
+      // Reproduces the bug: sub_agent_text ("On it...") + sub_agent_tool_use
+      // (Bash) land in the SAME jsonl-tail read, so both the narrative
+      // resolution (fireNarrativeProgress) and the tool-description
+      // onProgress fire within one loop iteration over `events`. Since the
+      // card renders replace-on-write, the tool-label call previously always
+      // clobbered the narration call that fired moments earlier — narration
+      // was staged and "SHOWN" per the dedup gate, but never actually
+      // visible on the pinned card. Assert only ONE onProgress cue fires for
+      // this tick, and it's the narration (progressLine == null), not the
+      // tool label.
+      const allCues: Array<{ progressLine?: string; latestSummary: string }> = []
+      const agentDir = join(tmpRoot, 'agent')
+      const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+      mkdirSync(subagentsDir, { recursive: true })
+      const jsonlPath = join(subagentsDir, 'agent-deadbeef.jsonl')
+      const h = startWatcherSync({
+        agentDir,
+        onProgress: ({ progressLine, latestSummary }) => {
+          allCues.push({ progressLine, latestSummary })
+        },
+      })
+      writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Find the repo')))
+      h.poll()
+      // Narration text + its resolving tool_use appended and tailed together
+      // in a single poll — this is the "same tick" race.
+      appendFileSync(
+        jsonlPath,
+        buildJSONL(subAgentAssistantText('On it. Let me find the repo.'), subAgentToolUse('Bash', 'b1')),
+      )
+      h.poll()
+      expect(allCues.length).toBe(1)
+      expect(allCues[0].progressLine).toBeUndefined()
+      expect(allCues[0].latestSummary).toContain('find the repo')
+    })
+
+    it('unregressed: two sub_agent_tool_use events with no narration between them both still show tool labels (named foreground blindspot)', () => {
+      // Guards against the clobber-guard fix over-suppressing: narrativeJustFired
+      // must be false for a tool_use that has no preceding pending narrative,
+      // so back-to-back tool calls (a researcher reading files with no prose)
+      // must both still surface a progressLine.
+      const toolCues: Array<string | undefined> = []
+      const agentDir = join(tmpRoot, 'agent')
+      const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+      mkdirSync(subagentsDir, { recursive: true })
+      const jsonlPath = join(subagentsDir, 'agent-deadbeef.jsonl')
+      const h = startWatcherSync({
+        agentDir,
+        onProgress: ({ progressLine }) => {
+          if (progressLine != null) toolCues.push(progressLine)
+        },
+      })
+      writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Find the repo')))
+      h.poll()
+      appendFileSync(jsonlPath, buildJSONL(subAgentToolUse('Bash', 'b1')))
+      h.poll()
+      appendFileSync(jsonlPath, buildJSONL(subAgentToolUse('Bash', 'b2')))
+      h.poll()
+      expect(toolCues.length).toBe(2)
+    })
+
     it('narrative gate: trailing narration at turn_end is SHOWN', () => {
       const narrativeCues: string[] = []
       const agentDir = join(tmpRoot, 'agent')


### PR DESCRIPTION
## Summary
- Fixes a bug where sub-agent narration on pinned worker progress cards was computed correctly but silently overwritten by a redundant tool-label `onProgress` call firing in the same tick — cards were showing generic "Reading X" labels instead of the model's actual narration.
- `fireNarrativeProgress`/`resolvePendingSubNarrative` now return whether they fired; the tool-label call is skipped only when narration already rendered this same tick. Tool-only ticks (no narration) are unaffected — verified with a new regression test.
- Adds the locked quota-bar card format (5h/7d usage bars, pace tick always visible even at 100% fill) plus `scripts/print-quota-bar.ts` for manual verification against live broker state.
- Adversarially reviewed: caught and fixed one real bug (label bold-wrapping used `codeSpanSafe` instead of `escapeMarkdown`, leaving `*`/`_`/`[]` unescaped in bold context).

## Test plan
- [x] `bun test` on `quota-bar-format`, `subagent-watcher`, `auth-snapshot-format` — 151/151 pass
- [x] `bun run lint` clean
- [x] Live verification: `bun scripts/print-quota-bar.ts` against real broker state (3 real accounts)
- [x] Regression test confirms same-tick narration+tool_use race no longer clobbers narration
- [x] Regression test confirms two tool_use events with no narration between them still show tool labels (no regression of prior "named foreground blindspot" fix)

🤖 Generated with Claude Code