### PR TITLE
fix(telegram): close worker-feed resurrection race, nested silent-drop, stale finalize

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1527,6 +1527,64 @@ function resolveSubagentOriginChat(
   }
 }
 
+/**
+ * Tracks worker-feed agents whose owner-DM fallback has already been
+ * logged, so `resolveWorkerFeedChat` emits the routing-decision line once
+ * per agent instead of every watcher tick (~1/s). Capped FIFO at 256 — a
+ * late duplicate log is harmless (one extra stderr line), and the cap keeps
+ * the set bounded across a long gateway lifetime even if origin resolution
+ * is persistently broken fleet-wide (history disabled → every nested worker
+ * hits the fallback). A gateway restart clears it.
+ */
+const WORKER_FEED_FALLBACK_LOG_CAP = 256
+const workerFeedOwnerDmFallbackLogged = new Set<string>()
+
+/**
+ * Resolve a worker-feed destination chat with a guaranteed last resort.
+ *
+ * The universal-liveness contract is "any active work has a card, at any
+ * nesting depth, with or without a parent turn open." Origin resolution
+ * (`resolveSubagentOriginChat`) only succeeds when the ancestor turn row is
+ * in `turnsDb` and history is enabled; a depth-2+ worker whose chain can't
+ * be walked (history disabled, row reaped, ancestor never stamped) would
+ * otherwise fall through `fleetChatId || allowFrom[0]` and, if those are
+ * empty too, hit the `chatId.length === 0` skip in `workerActivityFeed.update`
+ * — painting NOTHING, silently. That is the one path most likely to violate
+ * "any and all active work has a card."
+ *
+ * This never returns `''`: the precedence is origin chat → fleet chat →
+ * first allowed chat (the owner DM). The owner DM is the durable floor —
+ * "wrong chat" beats "no card." A one-line routing-decision log flags the
+ * fallback so an operator can see the misroute without it reading as an
+ * error (it isn't one — the card surfaced).
+ */
+function resolveWorkerFeedChat(
+  agentId: string,
+  fleetChatId: string,
+): { chatId: string; threadId?: number } {
+  const origin = resolveSubagentOriginChat(agentId)
+  if (origin != null && origin.chatId.length > 0) return origin
+  if (fleetChatId.length > 0) return { chatId: fleetChatId }
+  const ownerDm = loadAccess().allowFrom[0] ?? ''
+  if (origin == null && fleetChatId.length === 0 && ownerDm.length > 0) {
+    // Routing decision, not a warning: origin resolution failed and no
+    // fleet chat is configured, so the nested worker's card lands in the
+    // owner DM. Logged ONCE per agent so the misroute is auditable
+    // without spamming every tick (the watcher drives onProgress ~1/s).
+    if (!workerFeedOwnerDmFallbackLogged.has(agentId)) {
+      workerFeedOwnerDmFallbackLogged.add(agentId)
+      if (workerFeedOwnerDmFallbackLogged.size > WORKER_FEED_FALLBACK_LOG_CAP) {
+        const oldest = workerFeedOwnerDmFallbackLogged.values().next().value
+        if (oldest != null) workerFeedOwnerDmFallbackLogged.delete(oldest)
+      }
+      process.stderr.write(
+        `telegram gateway: worker-feed origin unresolved agent=${agentId} — routing card to owner DM\n`,
+      )
+    }
+  }
+  return { chatId: ownerDm, threadId: origin?.threadId }
+}
+
 // ─── Periodic history reaper (#1073) ──────────────────────────────────────
 // The init-time prune in history.ts only touched the `messages` table.
 // `subagents` and `turns` in registry.db grew unbounded — every Agent()
@@ -4109,9 +4167,26 @@ async function resolveCompactCard(
       { chat_id: card.chatId, verb: `proactiveCompact.${kind}` },
     );
   } catch (err) {
+    // Best-effort status-card edit — a transport hiccup (429 / "not
+    // modified" / message gone) is not a liveness-logic error and must
+    // not log a "card edit failed" warning (the warning-as-excuse-for-a-
+    // stale-card anti-pattern). Only a genuine unexpected error warrants
+    // a line; transport classes are silent.
+    const desc = err instanceof Error ? err.message : String(err);
+    const low = desc.toLowerCase();
+    if (
+      low.includes('not modified') ||
+      low.includes('not found') ||
+      low.includes("can't be edited") ||
+      low.includes('cannot be edited') ||
+      low.includes('not enough rights') ||
+      low.includes('429') ||
+      low.includes('retry after')
+    ) {
+      return;
+    }
     process.stderr.write(
-      `telegram gateway: proactive-compact ${kind} card edit failed: ` +
-        `${err instanceof Error ? err.message : String(err)}\n`,
+      `telegram gateway: proactive-compact ${kind} card edit failed: ${desc}\n`,
     );
   }
 }
@@ -12935,7 +13010,22 @@ async function drainActivitySummary(
         turn.activityLastSentRender = target
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
-        if (!msg.includes('message is not modified')) {
+        const low = msg.toLowerCase()
+        // Transport-class failures (429, message gone, "not modified") must
+        // NOT inflate `activityDrainFailures` — that counter flags a turn as
+        // DEGRADED on turn-end, and a transient rate-limit or an
+        // already-deleted message is not a logic defect. Counting them would
+        // false-flag a healthy turn. "not modified" is success; gone/429 are
+        // retried or harmless. Only a genuine send/open failure counts.
+        const isTransport =
+          low.includes('not modified') ||
+          low.includes('not found') ||
+          low.includes("can't be edited") ||
+          low.includes('cannot be edited') ||
+          low.includes('not enough rights') ||
+          low.includes('429') ||
+          low.includes('retry after')
+        if (!isTransport) {
           turn.activityDrainFailures += 1
           // Surface the failing anchor + topic: the resume-400 bug fed a
           // fabricated 13-digit message_id as the reply anchor here, so every
@@ -13285,7 +13375,23 @@ function clearActivitySummary(turn: CurrentTurn, finalHtmlOverride?: string | nu
           { chat_id: chat, ...(thread != null ? { threadId: thread } : {}), verb: 'activity-summary.delete' },
         )
       } catch (err) {
-        process.stderr.write(`telegram gateway: activity-summary delete failed: ${err}\n`)
+        // Best-effort teardown of a status card. A transport-class failure
+        // (message already deleted, chat gone, 429) is not a liveness-logic
+        // error — "message to delete not found" is the desired end state
+        // here, and a 429 on a teardown delete is retried by robustApiCall.
+        // Stay silent on those; warn only on a genuinely unexpected error.
+        const msg = err instanceof Error ? err.message : String(err)
+        const low = msg.toLowerCase()
+        if (
+          low.includes('not modified') ||
+          low.includes('not found') ||
+          low.includes('not enough rights') ||
+          low.includes('429') ||
+          low.includes('retry after')
+        ) {
+          return
+        }
+        process.stderr.write(`telegram gateway: activity-summary delete failed: ${msg}\n`)
       }
       return
     }
@@ -13311,10 +13417,26 @@ function clearActivitySummary(turn: CurrentTurn, finalHtmlOverride?: string | nu
         { chat_id: chat, ...(thread != null ? { threadId: thread } : {}), verb: 'activity-summary.finalize' },
       )
     } catch (err) {
+      // Same transport-class discipline as the delete path: the card
+      // finalize is a best-effort liveness edit. "not modified" = the card
+      // already shows the finalized body (success); "not found" / "not
+      // enough rights" = the message is gone (nothing to finalize); 429 is
+      // retried by robustApiCall. None of those are liveness-logic errors
+      // and none warrant a stderr warning. Warn only on the unexpected.
       const msg = err instanceof Error ? err.message : String(err)
-      if (!msg.includes('message is not modified')) {
-        process.stderr.write(`telegram gateway: activity-summary finalize failed: ${msg}\n`)
+      const low = msg.toLowerCase()
+      if (
+        low.includes('not modified') ||
+        low.includes('not found') ||
+        low.includes("can't be edited") ||
+        low.includes('cannot be edited') ||
+        low.includes('not enough rights') ||
+        low.includes('429') ||
+        low.includes('retry after')
+      ) {
+        return
       }
+      process.stderr.write(`telegram gateway: activity-summary finalize failed: ${msg}\n`)
     }
   })
 }
@@ -27435,8 +27557,8 @@ void (async () => {
                     orphanStatusEnabled,
                   })
                   if (surface === 'worker-feed') {
-                    const origin = resolveSubagentOriginChat(agentId)
-                    const wkChat = origin?.chatId || fleetChatId || (loadAccess().allowFrom[0] ?? '')
+                    const wk = resolveWorkerFeedChat(agentId, fleetChatId)
+                    const wkChat = wk.chatId
                     void workerActivityFeed?.update(
                       agentId,
                       wkChat,
@@ -27448,7 +27570,7 @@ void (async () => {
                         elapsedMs,
                         state: 'running',
                       },
-                      origin?.threadId,
+                      wk.threadId,
                     )?.then(() => reconcileWorkerPin(agentId, wkChat, true))
                     return
                   }
@@ -27573,8 +27695,8 @@ void (async () => {
                 // resolved (the pinned-card fleet that used to carry the chat
                 // is gone — see resolveSubagentOriginChat).
                 if (workerFeedEnabled) {
-                  const origin = resolveSubagentOriginChat(agentId)
-                  const wkChat = origin?.chatId || fleetChatId || (loadAccess().allowFrom[0] ?? '')
+                  const wk = resolveWorkerFeedChat(agentId, fleetChatId)
+                  const wkChat = wk.chatId
                   void workerActivityFeed?.update(
                     agentId,
                     wkChat,
@@ -27589,7 +27711,7 @@ void (async () => {
                       elapsedMs,
                       state: 'running',
                     },
-                    origin?.threadId,
+                    wk.threadId,
                   )?.then(() => reconcileWorkerPin(agentId, wkChat, true))
                   return
                 }

--- a/telegram-plugin/pending-work-progress.ts
+++ b/telegram-plugin/pending-work-progress.ts
@@ -419,9 +419,15 @@ function tick(now: number): void {
       newText,
       literalText: s.anchorLiteralText,
     }
-    // Fire-and-forget so a slow edit doesn't block the tick loop.
-    // Errors are logged but never bubble (a 429 / "message not modified"
-    // / chat-deleted is a soft failure).
+    // Fire-and-forget so a slow edit doesn't block the tick loop. The
+    // production `editMessage` dep is `swallowingApiCall`-wrapped, which
+    // catches every transport outcome (not-modified / not-found / 429 /
+    // network) upstream and never rejects — so in production this `.catch`
+    // is a backstop that rarely fires. It is kept as a contract-level guard
+    // (a throwing dep, or a future non-swallowing wiring, must not log a
+    // scary "edit failed" warning for a best-effort liveness surface nor
+    // keep hammering a dead anchor). Only a genuinely unexpected error
+    // reaches the fallthrough; transport classes are silent.
     void Promise.resolve()
       .then(() => activeDeps!.editMessage(editCtx))
       .then(() => {
@@ -432,10 +438,39 @@ function tick(now: number): void {
         })
       })
       .catch((err) => {
-        process.stderr.write(
-          `pending-work-progress: edit failed key=${key} ` +
-            `msg=${editCtx.messageId}: ${(err as Error).message}\n`,
-        )
+        const desc =
+          err instanceof Error ? err.message : err != null && typeof err === 'object' && 'description' in err
+            ? String((err as { description?: unknown }).description)
+            : String(err)
+        const low = desc.toLowerCase()
+        // "message is not modified" — the anchor already shows this suffix.
+        // The card is correct; count it as an edit and move on silently.
+        if (low.includes('not modified')) {
+          activeDeps!.emitMetric?.({
+            kind: 'pending_progress_edited',
+            chatKey: key,
+            elapsedMs: elapsed,
+          })
+          return
+        }
+        // Message / chat gone, or the 48h edit window closed. The anchor
+        // is dead — stop retrying it (clear state) so the tick isn't
+        // hammering a non-existent message every EDIT_INTERVAL_MS. The
+        // next outbound reply re-establishes a fresh anchor. Silent: no
+        // card to update is not a liveness-logic error.
+        if (
+          low.includes('not found') ||
+          low.includes("can't be edited") ||
+          low.includes('cannot be edited') ||
+          low.includes('not enough rights')
+        ) {
+          clearPending(key, 'stale_turn')
+          return
+        }
+        // 429 / transient network blip — leave state intact; the next tick
+        // retries. No stderr: a transport hiccup on a best-effort card is
+        // not a logic error, and the production wiring already applies
+        // retry_after backoff upstream.
       })
   }
 }

--- a/telegram-plugin/tests/pending-work-progress.test.ts
+++ b/telegram-plugin/tests/pending-work-progress.test.ts
@@ -49,9 +49,11 @@ function setup(): Capture {
 }
 
 async function flush(): Promise<void> {
-  // Allow the fire-and-forget promise chain in tick() to settle.
-  await Promise.resolve()
-  await Promise.resolve()
+  // Allow the fire-and-forget promise chain in tick() to settle. The chain
+  // is `.then(editMessage).then(emitMetric).catch(...)` with an async
+  // editMessage, so it spans several microtask hops — a single macrotask
+  // boundary (setTimeout 0) drains them all deterministically.
+  await new Promise((r) => setTimeout(r, 0))
 }
 
 describe('pending-work-progress', () => {
@@ -557,5 +559,116 @@ describe('pending-work-progress', () => {
     __tickForTests(cap.now)
     await flush()
     expect(cap.edits).toHaveLength(1)
+  })
+
+  // ─── review finding #2: transport-hiccup classification ────────────────────
+  // A best-effort liveness surface must not log a scary "edit failed" warning
+  // for recoverable/permanent transport outcomes, and must stop retrying a
+  // dead anchor. "not modified" counts as success; "gone" clears state; 429 /
+  // transient leave state for the next tick — all silently.
+  it('#2: "message is not modified" counts as a successful edit (no warning, metric emitted)', async () => {
+    const cap = setup()
+    const errs: string[] = []
+    const origStderr = process.stderr.write.bind(process.stderr)
+    process.stderr.write = ((s: string) => { errs.push(s); return true }) as typeof process.stderr.write
+    try {
+      let calls = 0
+      __setDepsForTests({
+        editMessage: async () => {
+          calls++
+          if (calls === 1) throw new Error('Bad Request: message is not modified')
+          cap.edits.push({} as PendingProgressEditCtx)
+        },
+        emitMetric: (e) => cap.metrics.push(e),
+        nowMs: () => cap.now,
+      })
+      startTurn(KEY)
+      noteAsyncDispatch(KEY)
+      noteOutbound(KEY, { messageId: 100, text: 'working' })
+      noteTurnEnd(KEY)
+
+      cap.now = EDIT_INTERVAL_MS
+      __tickForTests(cap.now)
+      // The .catch hop needs an extra microtask drain beyond the 2-await flush.
+      await flush()
+      await Promise.resolve()
+      // The not-modified outcome is success — an `edited` metric was emitted.
+      expect(cap.metrics.some((m) => m.kind === 'pending_progress_edited')).toBe(true)
+      // No scary "edit failed" stderr for a transport-class outcome.
+      expect(errs.some((e) => e.includes('edit failed'))).toBe(false)
+    } finally {
+      process.stderr.write = origStderr
+    }
+  })
+
+  it('#2: a gone anchor (message not found) clears state so the tick stops retrying it, silently', async () => {
+    const cap = setup()
+    const errs: string[] = []
+    const origStderr = process.stderr.write.bind(process.stderr)
+    process.stderr.write = ((s: string) => { errs.push(s); return true }) as typeof process.stderr.write
+    try {
+      let calls = 0
+      __setDepsForTests({
+        editMessage: async () => {
+          calls++
+          throw new Error('Bad Request: message to edit not found')
+        },
+        emitMetric: (e) => cap.metrics.push(e),
+        nowMs: () => cap.now,
+      })
+      startTurn(KEY)
+      noteAsyncDispatch(KEY)
+      noteOutbound(KEY, { messageId: 100, text: 'working' })
+      noteTurnEnd(KEY)
+
+      cap.now = EDIT_INTERVAL_MS
+      __tickForTests(cap.now)
+      await flush()
+      await Promise.resolve()
+      expect(calls).toBe(1)
+      // No warning for a transport-gone outcome.
+      expect(errs.some((e) => e.includes('edit failed'))).toBe(false)
+
+      // Next tick — the anchor was cleared, so no retry against the dead id.
+      cap.now = EDIT_INTERVAL_MS * 3
+      __tickForTests(cap.now)
+      await flush()
+      await Promise.resolve()
+      expect(calls).toBe(1) // no second attempt
+    } finally {
+      process.stderr.write = origStderr
+    }
+  })
+
+  it('#2: a 429 / transient error leaves state intact for the next tick, silently', async () => {
+    const cap = setup()
+    const errs: string[] = []
+    const origStderr = process.stderr.write.bind(process.stderr)
+    process.stderr.write = ((s: string) => { errs.push(s); return true }) as typeof process.stderr.write
+    try {
+      let calls = 0
+      __setDepsForTests({
+        editMessage: async () => {
+          calls++
+          throw { error_code: 429, parameters: { retry_after: 1 }, message: 'Too Many Requests' }
+        },
+        emitMetric: (e) => cap.metrics.push(e),
+        nowMs: () => cap.now,
+      })
+      startTurn(KEY)
+      noteAsyncDispatch(KEY)
+      noteOutbound(KEY, { messageId: 100, text: 'working' })
+      noteTurnEnd(KEY)
+
+      cap.now = EDIT_INTERVAL_MS
+      __tickForTests(cap.now)
+      await flush()
+      await Promise.resolve()
+      // State survives — the anchor is still there to retry next tick.
+      expect(__getStateForTests(KEY)?.anchorMessageId).toBe(100)
+      expect(errs.some((e) => e.includes('edit failed'))).toBe(false)
+    } finally {
+      process.stderr.write = origStderr
+    }
   })
 })

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -945,6 +945,103 @@ describe('createWorkerActivityFeed — heartbeat', () => {
   })
 })
 
+// ─── Resurrection guard + deferred finalize (review findings #2 & #3) ─────────
+// #3: a late watcher onProgress tick arriving after `finish()` queued its
+//    chain must NOT resurrect the handle and paint a fresh running message.
+// #2: a terminal edit that hit a 429 cooldown stages on `pendingFinish` and
+//    is re-driven by the heartbeat after cooldown — the card can't get stuck
+//    on its last running render. "not modified" / message-gone are success/drop.
+describe('createWorkerActivityFeed — resurrection guard + deferred finalize', () => {
+  const drain = () => new Promise((r) => setTimeout(r, 0))
+
+  it('#3: a late update tick after finish does not resurrect a running card', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+    await feed.update('w1', 'chat', view({ toolCount: 1, latestSummary: 'step one' }))
+    expect(bot.sent).toHaveLength(1)
+
+    await feed.finish('w1', view({ state: 'done', toolCount: 1, latestSummary: 'done result' }))
+    // finish landed a terminal edit and dropped the handle.
+    expect(bot.edits.some((e) => e.text.includes('_done ·'))).toBe(true)
+    expect(feed.has('w1')).toBe(false)
+
+    // Late watcher tick arrives AFTER finish. Pre-fix this would create a
+    // fresh handle and paint a new running message on a finalized worker.
+    clock = 12_000
+    await feed.update('w1', 'chat', view({ toolCount: 2, latestSummary: 'step two' }))
+    expect(bot.sent).toHaveLength(1) // no new running message
+    expect(feed.has('w1')).toBe(false)
+    expect(feed.size).toBe(0)
+  })
+
+  it('#2: a 429 on the finish edit stages pendingFinish; the heartbeat re-drives it after cooldown', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      minEditIntervalMs: 0,
+      heartbeatTickMs: 6000,
+      setInterval: () => 1,
+      clearInterval: () => {},
+    })
+    await feed.update('w1', 'chat', view({ toolCount: 1, latestSummary: 'running step' }))
+    expect(bot.sent).toHaveLength(1)
+
+    // The terminal edit hits a 429 with a 2s retry_after.
+    bot.failNextEditWith = { error_code: 429, parameters: { retry_after: 2 } }
+    await feed.finish('w1', view({ state: 'done', toolCount: 1, latestSummary: 'final result' }))
+    await drain()
+    // No terminal edit landed yet — the last edit is still the running render.
+    expect(bot.edits.some((e) => e.text.includes('_done ·'))).toBe(false)
+
+    // Inside the cooldown — a heartbeat tick must NOT retry (would re-429).
+    clock = 11_000
+    feed.heartbeatTick()
+    await drain()
+    expect(bot.edits.some((e) => e.text.includes('_done ·'))).toBe(false)
+
+    // Past the cooldown (10_000 + 2000 + 500 jitter = 12_500) — the heartbeat
+    // re-drives the deferred finalize and the terminal edit lands.
+    clock = 13_000
+    feed.heartbeatTick()
+    await drain()
+    expect(bot.edits.some((e) => e.text.includes('_done ·'))).toBe(true)
+    expect(feed.has('w1')).toBe(false) // handle dropped after the terminal edit landed
+  })
+
+  it('#2: "message is not modified" on finish is treated as success (card already correct)', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+    await feed.update('w1', 'chat', view({ toolCount: 1, latestSummary: 'x' }))
+    expect(bot.sent).toHaveLength(1)
+
+    bot.failNextEditWith = new Error('Bad Request: message is not modified')
+    await feed.finish('w1', view({ state: 'done', toolCount: 1, latestSummary: 'x' }))
+    await drain()
+    // The handle is dropped — the not-modified outcome is success, no retry.
+    expect(feed.has('w1')).toBe(false)
+  })
+
+  it('#2: a gone message on finish drops the handle silently (no card to finalize)', async () => {
+    const bot = makeFakeBot()
+    const logs: string[] = []
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0, log: (m) => logs.push(m) })
+    await feed.update('w1', 'chat', view({ toolCount: 1, latestSummary: 'x' }))
+    expect(bot.sent).toHaveLength(1)
+
+    bot.failNextEditWith = new Error('Bad Request: message to edit not found')
+    await feed.finish('w1', view({ state: 'done', toolCount: 1, latestSummary: 'done' }))
+    await drain()
+    expect(feed.has('w1')).toBe(false)
+    // No scary "finish edit failed" warning for a transport-gone outcome.
+    expect(logs.some((l) => l.includes('finish edit failed'))).toBe(false)
+  })
+})
+
 // ─── Extreme-edge: single oversized narrative line (no-truncate ON) ──────────
 // Reproduces the bug where accumulateNarrative's char-budget splice would push
 // the oversized line then immediately splice it out, making the narrative empty

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -221,6 +221,28 @@ interface WorkerHandle {
   /** Last view rendered into the message (drives the heartbeat re-render). */
   lastView: WorkerActivityView | null
   /**
+   * A terminal (`finish`) view whose edit could not land yet — most often
+   * because a 429 cooldown was in effect when `doFinish` ran. The heartbeat
+   * re-drives `doFinish` with this view once the cooldown expires so a
+   * transport hiccup can't leave the card stuck on its last running render
+   * ("worker done, card says running"). Cleared on a successful terminal
+   * edit, on a permanent failure (message gone), or when the handle is
+   * deleted. Null when no finalize is pending.
+   */
+  pendingFinish: WorkerActivityView | null
+  /**
+   * Latched in `doFinish` before the terminal edit. A late watcher
+   * `onProgress` tick that arrives after `finish()` queued its chain (but
+   * before the `.finally(handles.delete)` microtask drains) must NOT
+   * resurrect the handle and paint a fresh `running` message on an
+   * already-finalized worker. The heartbeat's orphan-paint guard
+   * (`if (!handles.has(h.agentId)) continue`) only covers the heartbeat
+   * tick — this flag covers the `update` entry point. Set synchronously
+   * inside `doFinish` (runs on the chain), checked synchronously in
+   * `update` before handle creation.
+   */
+  finished: boolean
+  /**
    * Wall-clock ms the worker was dispatched, derived from `now - view.elapsedMs`
    * on the first update. The heartbeat computes a live elapsed from this so the
    * `· Ns` suffix climbs even when no fresh view arrives.
@@ -244,6 +266,47 @@ function extractRetryAfterSecs(err: unknown): number | null {
   const ra = e.parameters?.retry_after
   if (typeof ra === 'number' && Number.isFinite(ra) && ra > 0) return ra
   return null
+}
+
+/**
+ * Classify a card-edit transport error. Card edits are a best-effort
+ * liveness surface — a recoverable hiccup must never freeze the card, and
+ * a permanent failure must never log a scary warning for something with
+ * nothing to update.
+ *
+ *   'not_modified' — content identical to what's already shown. The card
+ *     already reads correctly; treat as SUCCESS (no retry, no warning).
+ *   'rate_limited' — 429 with retry_after. Back off; the heartbeat re-drives
+ *     the edit after cooldown (running renders + deferred terminal edits).
+ *   'gone'         — message/chat deleted or edit window expired. Nothing to
+ *     update; drop the handle silently (no warning — there is no card).
+ *   'transient'    — anything else (network blip, 5xx). Retry on the next
+ *     heartbeat tick; don't spam stderr.
+ */
+type EditOutcome = 'not_modified' | 'rate_limited' | 'gone' | 'transient'
+function classifyEditError(err: unknown): EditOutcome {
+  const retryAfter = extractRetryAfterSecs(err)
+  if (retryAfter != null) return 'rate_limited'
+  const desc =
+    err instanceof Error ? err.message : err != null && typeof err === 'object' && 'description' in err
+      ? String((err as { description?: unknown }).description)
+      : String(err)
+  const low = desc.toLowerCase()
+  // "message is not modified" / "message was not modified" — Telegram's
+  // identical-content signal. The card already shows the right thing.
+  if (low.includes('not modified')) return 'not_modified'
+  // Message or chat no longer exists, or the edit window (48h) has closed.
+  // "message to edit not found" / "message to delete not found" / "chat not
+  // found" / "message can't be edited". Nothing to update.
+  if (
+    low.includes('not found') ||
+    low.includes("can't be edited") ||
+    low.includes('cannot be edited') ||
+    low.includes('not enough rights')
+  ) {
+    return 'gone'
+  }
+  return 'transient'
 }
 
 /**
@@ -294,6 +357,28 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     })
   const clearIntervalFn = opts.clearInterval ?? ((handle: unknown) => clearInterval(handle as ReturnType<typeof setInterval>))
   const handles = new Map<string, WorkerHandle>()
+  /**
+   * Agent ids that have been finalized (`doFinish` latched). Survives handle
+   * deletion so a LATE watcher `onProgress` tick — which can arrive after
+   * `finish()`'s chain has fully settled and the handle was deleted — cannot
+   * resurrect a fresh handle and paint a running card on a worker that is
+   * already done. The per-handle `finished` flag only covers the narrow
+   * window between latch and delete; this set is the durable gate. A late
+   * tick arrives within seconds of finish (watcher poll cadence), so the set
+   * only needs to cover recent finalizations — capped at FINALIZED_CAP and
+   * trimmed FIFO to stay bounded across a long gateway lifetime.
+   */
+  const finalized = new Set<string>()
+  const FINALIZED_CAP = 256
+  function markFinalized(agentId: string): void {
+    if (finalized.has(agentId)) return
+    finalized.add(agentId)
+    if (finalized.size > FINALIZED_CAP) {
+      // Map-free FIFO trim: Set iterates in insertion order; drop the oldest.
+      const oldest = finalized.values().next().value
+      if (oldest != null) finalized.delete(oldest)
+    }
+  }
   let heartbeatTimer: unknown = null
 
   function sendOptsFor(h: WorkerHandle): Record<string, unknown> {
@@ -384,39 +469,99 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
           `thread=${h.threadId ?? '-'} msgId=${h.messageId} bytes=${body.length}`,
       )
     } catch (err) {
-      noteRateLimited(h, err, 'edit')
-      // Stale message_id (manually deleted / edit window gone). Re-post
-      // on the next tick rather than now, so we don't double-down inside
-      // a cooldown.
-      log(`worker-feed: edit failed, will re-post: ${(err as Error).message}`)
-      h.messageId = null
-      h.lastBody = null
+      const outcome = classifyEditError(err)
+      if (outcome === 'rate_limited') {
+        noteRateLimited(h, err, 'edit')
+        return
+      }
+      if (outcome === 'not_modified') {
+        // Card already shows this body — record it as landed and move on.
+        h.lastBody = body
+        h.lastEditAt = nowFn()
+        return
+      }
+      if (outcome === 'gone') {
+        // Message/chat deleted or edit window closed — there is no card to
+        // update. Drop the handle silently; a fresh first-paint on the next
+        // running tick re-establishes one if the worker is still active. No
+        // warning: "no card" is not a liveness-logic error.
+        h.messageId = null
+        h.lastBody = null
+        return
+      }
+      // 'transient' — network blip / 5xx. Leave the handle intact; the
+      // heartbeat re-attempts on its next tick. Log at debug, not stderr-warn:
+      // a transport hiccup on a best-effort card is not "shit code", it's a
+      // retryable blip the framework rides out deterministically.
+      log(`worker-feed: edit transient error agent=${h.agentId}: ${(err as Error).message}`)
     }
   }
 
   async function doFinish(h: WorkerHandle, view: WorkerActivityView): Promise<void> {
+    // Latch FIRST, before any early return. A `running`-cue tick arriving
+    // after `finish()` queued this chain (but before its `.finally(delete)`
+    // drains) would otherwise resurrect a handle via `update()` and paint a
+    // fresh running message on a finalized worker. Setting this synchronously
+    // on the chain — ahead of the cooldown/no-message guards — makes the
+    // gate in `update()` authoritative regardless of which guard path runs.
+    // The durable `finalized` set survives the subsequent handle deletion so
+    // a tick arriving AFTER the full settle still can't resurrect.
+    h.finished = true
+    markFinalized(h.agentId)
     // No message ever posted → nothing to finalize. The worker's result
     // reaches the user via the handback reply; a bare "done" recap with
     // no preceding activity would be noise.
-    if (h.messageId == null) return
+    if (h.messageId == null) {
+      h.pendingFinish = null
+      return
+    }
     if (nowFn() < h.cooldownUntil) {
-      // Honour the flood-wait; a terminal edit isn't worth a ban. The
-      // message is left at its last running render — stale but harmless.
+      // Honour the flood-wait; a terminal edit isn't worth a ban. But
+      // unlike the prior "stale but harmless" surrender, STAGE the terminal
+      // view so the heartbeat re-drives the finalize edit the instant the
+      // cooldown expires — a transport hiccup can no longer leave a
+      // finished worker's card stuck on its last running render.
+      h.pendingFinish = view
       return
     }
     const body = renderWorkerActivity({ ...view, narrativeLines: h.narrative })
-    if (body === h.lastBody) return
+    if (body === h.lastBody) {
+      h.pendingFinish = null
+      return
+    }
     try {
       await opts.bot.editMessageText(h.chatId, h.messageId, body, sendOptsFor(h))
       h.lastBody = body
       h.lastEditAt = nowFn()
+      h.pendingFinish = null
       log(
         `worker-feed: finish agent=${h.agentId} chat=${h.chatId} ` +
           `thread=${h.threadId ?? '-'} msgId=${h.messageId} state=${view.state} bytes=${body.length}`,
       )
     } catch (err) {
-      noteRateLimited(h, err, 'finish')
-      log(`worker-feed: finish edit failed: ${(err as Error).message}`)
+      const outcome = classifyEditError(err)
+      if (outcome === 'rate_limited') {
+        noteRateLimited(h, err, 'finish')
+        // Re-stage for the heartbeat to re-drive after cooldown.
+        h.pendingFinish = view
+        return
+      }
+      if (outcome === 'not_modified') {
+        // Card already shows the finalized body — terminal edit succeeded.
+        h.lastBody = body
+        h.lastEditAt = nowFn()
+        h.pendingFinish = null
+        return
+      }
+      if (outcome === 'gone') {
+        // Message/chat gone — no card to finalize. Drop silently; the
+        // handback reply carries the result regardless.
+        h.pendingFinish = null
+        return
+      }
+      // 'transient' — re-stage for a heartbeat retry; log at debug.
+      h.pendingFinish = view
+      log(`worker-feed: finish transient error agent=${h.agentId}: ${(err as Error).message}`)
     }
   }
 
@@ -456,6 +601,36 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       // (which would orphan a card that never finalizes). Restores the
       // structural safety the pre-first-paint `messageId == null` skip gave.
       if (!handles.has(h.agentId)) continue
+
+      // Deferred-finalize re-drive: a terminal edit that hit a 429 cooldown
+      // (or a transient error) was staged on `pendingFinish` by `doFinish`.
+      // Re-drive it once the cooldown has expired so a finished worker's card
+      // can't get stuck on its last running render. This is the deterministic
+      // backstop that replaces the old "stale but harmless" surrender — the
+      // framework owns ALIVE-and-done, wall-clock driven, no model in the loop.
+      // (The handle is still in the map because `finish()`'s `.finally(delete)`
+      // is chained AFTER `doFinish` and won't drain while a re-drive keeps the
+      // chain busy; once the terminal edit lands, `pendingFinish` is cleared
+      // and the `.finally` runs on the next chain settle.)
+      if (h.pendingFinish != null && now >= h.cooldownUntil) {
+        const view = h.pendingFinish
+        h.chain = h.chain
+          .then(() => doFinish(h, view))
+          .catch((err) => {
+            log(`worker-feed: heartbeat finalize re-drive error ${h.agentId}: ${(err as Error).message}`)
+          })
+          .finally(() => {
+            // Mirror `finish()`'s teardown: once the re-driven `doFinish`
+            // clears `pendingFinish` (terminal edit landed OR permanently
+            // failed), drop the handle. If it re-staged (another 429), the
+            // handle survives for the next heartbeat tick to retry.
+            if (handles.get(h.agentId)?.pendingFinish == null) {
+              handles.delete(h.agentId)
+            }
+          })
+        continue
+      }
+
       if (h.lastView == null) continue
       if (h.lastView.state !== 'running') continue
       if (now < h.cooldownUntil) continue
@@ -523,7 +698,19 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       // No chat to post to (owner DM unconfigured) — don't create a
       // handle that would retry a failing send('') every tick.
       if (chatId.length === 0) return Promise.resolve()
-      let h = handles.get(agentId)
+      // Resurrection guard: a worker that has already been finalized
+      // (`doFinish` latched `finalized`) must not get a fresh running cue.
+      // A late watcher `onProgress` tick can arrive after `finish()`'s chain
+      // has fully settled and the handle was deleted — without this durable
+      // gate the tick would create a brand-new handle and paint a fresh
+      // `running` message on an already-done worker (the card lies). The
+      // heartbeat's orphan-paint guard covers the heartbeat tick only; the
+      // per-handle `finished` flag covers the pre-delete window; this set
+      // covers the post-delete window.
+      if (finalized.has(agentId)) return Promise.resolve()
+      const existing = handles.get(agentId)
+      if (existing?.finished === true) return Promise.resolve()
+      let h = existing
       if (h == null) {
         h = {
           agentId,
@@ -538,6 +725,8 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
           lastView: null,
           dispatchAtMs: null,
           stepStartedAtMs: null,
+          finished: false,
+          pendingFinish: null,
         }
         handles.set(agentId, h)
       }
@@ -556,11 +745,27 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
           log(`worker-feed: finish chain error ${agentId}: ${(err as Error).message}`)
         })
         .finally(() => {
-          handles.delete(agentId)
+          // Only tear down the handle once the terminal edit has actually
+          // landed (or permanently failed). If `doFinish` staged the edit on
+          // `pendingFinish` (a 429 cooldown / transient error was in effect),
+          // the handle must survive so the heartbeat can re-drive the
+          // finalize after cooldown. The heartbeat's re-drive chain ends by
+          // re-entering `doFinish`, which clears `pendingFinish` on success
+          // or permanent-failure — so this `.finally` deletes on the NEXT
+          // chain settle once there is nothing left to finalize. Without this
+          // guard, the `.finally` would delete the handle (and its staged
+          // pendingFinish) immediately after the first staged doFinish,
+          // stranding the card on its last running render.
+          if (handles.get(agentId)?.pendingFinish == null) {
+            handles.delete(agentId)
+          }
         })
       return h.chain
     },
     drop(agentId) {
+      // A dropped worker is also done — mark finalized so a late watcher
+      // tick can't resurrect a running card on it (same gate as `finish`).
+      markFinalized(agentId)
       handles.delete(agentId)
     },
     heartbeatTick,


### PR DESCRIPTION
## Summary

Three live bugs in the progress-card / turn-liveness surface, found in an adversarial review of the worker-activity feed + nested-worker routing. Also tightens warning discipline so transport hiccups on the best-effort card surface no longer log scary "edit failed" lines nor inflate the turn-DEGRADED counter.

Adversarial review of the open PR + recent merged PRs surfaced that **#2958** (progress-card narration-clobber fix) already landed on `main` and addressed the narration-not-showing symptom at its real source (`subagent-watcher.ts` — a redundant tool-label `onProgress` clobbering narration in the same tick). This PR does **not** touch that path; it rebases cleanly on top of #2958 and the two are complementary.

### 1. Worker-feed handle resurrected after `finish` (race)
A late watcher `onProgress` tick arriving after `finish()` queued its chain (but before the `.finally(handles.delete)` drained, or after the full settle) created a fresh handle and painted a running card on an already-finalized worker. The heartbeat's orphan-paint guard only covered the heartbeat tick, not the `update` entry point.

**Fix:** latch a `finished` flag in `doFinish` AND a durable `finalized` Set (capped 256, FIFO) that survives handle deletion; gate `update()` on both. `drop()` marks finalized too.

### 2. Transport hiccup left a finished worker's card stuck on its last running render
The terminal `finish` edit surrendered with "stale but harmless" on a 429 cooldown.

**Fix:** stage the terminal view on `pendingFinish` and have the heartbeat re-drive `doFinish` once the cooldown expires — wall-clock driven, no model. `finish()`'s teardown is deferred until `pendingFinish` clears so a staged finalize isn't stranded. New `classifyEditError` classifies `not_modified` (success) / `rate_limited` (back off + re-stage) / `gone` (drop silently) / `transient` (re-stage).

> Note: production `editMessageText` is `robustApiCall`-wrapped, which swallows `not_modified`/`not_found` and retries 429 upstream — so the `not_modified`/`gone` branches are a contract-level backstop; the **live** fix is the deferred-finalize re-drive for an exhausted 429.

### 3. Nested-worker card silently dropped when origin resolution failed
A depth-2+ worker whose `parent_agent_id` chain couldn't be walked (history disabled, row reaped, ancestor never stamped) fell through `fleetChatId || allowFrom[0]` and, if both empty, hit the `chatId.length === 0` skip in `workerActivityFeed.update` — painting nothing, silently.

**Fix:** new `resolveWorkerFeedChat` with precedence origin → fleet → owner DM, never returning `''`. Both worker-feed call sites use it. A once-per-agent routing-decision log line flags the fallback (capped 256 FIFO so it can't grow unbounded if origin resolution is persistently broken fleet-wide).

### Warning discipline ("warning as excuse for a stale card")
Card-edit catch sites that go through `robustApiCall`/`swallowingApiCall` only ever see genuine non-transport errors (transport is swallowed upstream), so:
- `activity-summary` delete/finalize/drain warnings now exclude transport-class from stderr.
- The `drain` failure counter (`activityDrainFailures`, which flags a turn as DEGRADED on turn-end) now excludes transport-class — a 429 or gone message must not false-flag a healthy turn.
- The proactive-compact card edit warning is softened likewise.
- `pending-work-progress.ts` `.catch` is a contract-level backstop (its production dep is `swallowingApiCall`-wrapped and never rejects); it classifies transport outcomes silently rather than logging "edit failed".

### No change to narration/tool-label precedence
#2958 fixed the narration-clobber at its source (same-tick redundant `onProgress`). This PR does not touch that path; inverting precedence at `gateway.ts:27309` would regress #2777's tools-only-worker fix. The two PRs are complementary.

## Test plan
- +4 `worker-activity-feed` tests: resurrection guard, 429-deferred-finalize re-drive, `not_modified`, `gone`.
- +3 `pending-work-progress` tests: `not_modified`, `gone`, 429/transient.
- 162 vitest + 59 bun green across worker-feed, pending-work, visibility-integration, feed-survival, activity-card-store, liveness, nested-worker harnesses.
- `tsc` clean, `lint` (no-PII, stale-tool-descriptions, bot-api-wrapping) clean.
- #2958's own `subagent-watcher.test.ts` (31 tests) still green on the rebased tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)