### PR TITLE
fix(telegram): /usage + /auth footer no longer claims "Live" on a total probe failure

### DIFF
--- a/telegram-plugin/auth-snapshot-format.ts
+++ b/telegram-plugin/auth-snapshot-format.ts
@@ -274,6 +274,16 @@ export interface SnapshotRenderOpts {
    */
   staleCachedAtMs?: number;
   /**
+   * True when the live probe returned no usable data for ANY account (probe
+   * threw / timed out / returned zero rows) AND nothing was served from
+   * cache either. The footer renders `⚠ probe failed — no live data`
+   * instead of a false bare `_Live_`. Subscription-honesty: a "Live" footer
+   * next to "no data" rows is the exact lie this closes. `staleCachedAtMs`
+   * (cache-served data) takes precedence over this; this takes precedence
+   * over the bare-`Live` fallback.
+   */
+  probeFailed?: boolean;
+  /**
    * Demo mode (the `/usage demo` / `/auth demo` suffix). When true, every
    * account label is run through `maskEmail` before rendering so a screen
    * recording shows stable realistic fakes instead of the operator's real
@@ -521,11 +531,15 @@ export function renderAuthSnapshotFormat2(
   lines.push(`_${recommendation(snapshots, now, opts.demo ?? false)}_`);
   // #2495 Change 2 — a failed probe-on-open renders an explicit "cached Nm
   // ago" warning, never a false live stamp. The degraded variant takes
-  // precedence over the live stamp.
+  // precedence over the live stamp. A TOTAL probe failure (no rows, no
+  // cache) renders an explicit "probe failed" marker — without it the
+  // bare-else rendered `_Live_` next to no-data rows (the honesty gap).
   if (opts.staleCachedAtMs != null) {
     lines.push(`_⚠ cached ${formatAgeStamp(opts.staleCachedAtMs, now)}_`);
   } else if (opts.liveProbedAtMs != null) {
     lines.push(`_Live · refreshed ${formatAgeStamp(opts.liveProbedAtMs, now)}_`);
+  } else if (opts.probeFailed) {
+    lines.push('_⚠ probe failed — no live data_');
   } else {
     lines.push('_Live_');
   }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -23018,7 +23018,15 @@ async function handleAuthDashboardCallback(ctx: Context): Promise<void> {
         tz,
         now: renderNow,
         demo: refreshDemo,
-        ...(staleCachedAtMs != null ? { staleCachedAtMs } : { liveProbedAtMs: renderNow.getTime() }),
+        // Honesty backstop (same as /usage): a TOTAL probe failure (zero
+        // result rows, nothing served from cache) renders an explicit
+        // "probe failed" marker instead of a false "Live" footer next to
+        // no-data rows.
+        ...(staleCachedAtMs != null
+          ? { staleCachedAtMs }
+          : probeResp.results.length > 0
+            ? { liveProbedAtMs: renderNow.getTime() }
+            : { probeFailed: true }),
       })
       const kbRows = buildSnapshotKeyboard(snapshots, { now: renderNow, demo: refreshDemo })
       const inline_keyboard = kbRows.map((row) =>
@@ -23516,9 +23524,17 @@ bot.command('usage', async ctx => {
           // #2495 Change 2 — a TTL-hit / failed-probe fallback is tagged
           // served:"cache"; surface it as `⚠ cached Nm ago` instead of a
           // false live stamp. Otherwise stamp the live refresh time.
+          // Honesty backstop: a TOTAL probe failure (the .catch above
+          // returned `{results: []}` and nothing was served from cache)
+          // must render an explicit "probe failed" marker, NOT a false
+          // "Live" stamp next to "⚠️ no data" rows. Without this the
+          // footer claimed "Live · refreshed 0s ago" while every account
+          // row said "no data — probe failed" (#2959 review finding).
           ...(staleCachedAtMs != null
             ? { staleCachedAtMs }
-            : { liveProbedAtMs: renderNow.getTime() }),
+            : probeResp.results.length > 0
+              ? { liveProbedAtMs: renderNow.getTime() }
+              : { probeFailed: true }),
         })
         // Preserve the Switch/Refresh/usage/Add inline keyboard on the
         // rich-message render — the table card carries the same actions the

--- a/telegram-plugin/quota-bar-format.ts
+++ b/telegram-plugin/quota-bar-format.ts
@@ -241,8 +241,22 @@ export interface UsageCardRenderOpts extends QuotaBarRenderOpts {
    */
   staleCachedAtMs?: number;
   /** Timestamp of the most recent live probe; renders "Live · refreshed Nm
-   *  ago" when no stale-cache marker applies. Omit to render a bare "Live". */
+   *  ago" when no stale-cache marker applies. Omit to render a bare "Live".
+   *  Do NOT set this when the probe failed and no live data was obtained —
+   *  set `probeFailed: true` instead so the footer doesn't claim "Live". */
   liveProbedAtMs?: number;
+  /**
+   * True when the live probe returned no usable data for ANY account (the
+   * probe threw / timed out / returned zero rows, AND nothing was served
+   * from cache either). The footer then renders an explicit `⚠ probe failed
+   * — no live data` instead of a false "Live" stamp. Subscription-honesty:
+   * the /usage card exists to tell the operator the truth about quota state,
+   * so a footer that says "Live" while every row shows "⚠️ no data" is the
+   * exact lie this flag closes. Takes precedence over `liveProbedAtMs`;
+   * `staleCachedAtMs` (cache-served data) still takes precedence over this
+   * because in that case there IS real data, just stale.
+   */
+  probeFailed?: boolean;
 }
 
 /**
@@ -328,11 +342,17 @@ export function renderUsageCard(
   const lines = [bar];
   // Actionable cross-account verdict — restored from renderAuthSnapshotFormat2.
   lines.push(`_${recommendation(snapshots, now, demo)}_`);
-  // Freshness signal: stale-cache warning takes precedence over a live stamp.
+  // Freshness signal: stale-cache warning takes precedence over a live stamp,
+  // which takes precedence over an explicit probe-failed marker (no live data
+  // AND no cache — the card is showing "⚠️ no data" rows, so "Live" would be
+  // a lie). The probeFailed branch is the honesty backstop: without it, a
+  // total probe failure rendered a bare `_Live_` footer next to no-data rows.
   if (opts.staleCachedAtMs != null) {
     lines.push(`_⚠ cached ${formatAgeStamp(opts.staleCachedAtMs, now)}_`);
   } else if (opts.liveProbedAtMs != null) {
     lines.push(`_Live · refreshed ${formatAgeStamp(opts.liveProbedAtMs, now)}_`);
+  } else if (opts.probeFailed) {
+    lines.push('_⚠ probe failed — no live data_');
   } else {
     lines.push('_Live_');
   }

--- a/telegram-plugin/tests/auth-snapshot-format.test.ts
+++ b/telegram-plugin/tests/auth-snapshot-format.test.ts
@@ -431,6 +431,27 @@ describe('renderAuthSnapshotFormat2', () => {
     expect(out).not.toContain('Live · refreshed');
   });
 
+  it('#2959 honesty fix — probeFailed renders an explicit marker instead of a false bare "Live" footer', () => {
+    // Total probe failure: no rows, no cache. The footer must not claim
+    // "Live" next to no-data rows. Pre-fix this rendered a bare `_Live_`.
+    const out = renderAuthSnapshotFormat2(fixtureSnaps.slice(0, 1), {
+      now: NOW,
+      probeFailed: true,
+    });
+    expect(out).toContain('_⚠ probe failed — no live data_');
+    expect(out).not.toContain('_Live_');
+  });
+
+  it('#2959 honesty fix — staleCachedAtMs (real cached data) takes precedence over probeFailed', () => {
+    const out = renderAuthSnapshotFormat2(fixtureSnaps.slice(0, 1), {
+      now: NOW,
+      staleCachedAtMs: NOW.getTime() - 2 * 60_000,
+      probeFailed: true,
+    });
+    expect(out).toContain('⚠ cached 2m ago');
+    expect(out).not.toContain('probe failed');
+  });
+
   // ── demo mode (the `/usage demo` / `/auth demo` suffix) ──────────────
   describe('demo mode masks email labels', () => {
     it('WITHOUT demo, the real account emails still render', () => {

--- a/telegram-plugin/tests/quota-bar-format.test.ts
+++ b/telegram-plugin/tests/quota-bar-format.test.ts
@@ -385,6 +385,28 @@ describe('renderUsageCard', () => {
     expect(out.split('\n').pop()).toBe('_⚠ cached 1m ago_');
   });
 
+  it('probeFailed renders an explicit "probe failed" marker instead of a false "Live" footer (#2959 honesty fix)', () => {
+    // A total probe failure: zero result rows, nothing served from cache.
+    // Every account row renders "⚠️ no data — probe failed"; the footer
+    // must NOT claim "Live". Pre-fix this rendered a bare `_Live_`.
+    const out = renderUsageCard(snapshots, exhausted, { now: NOW, probeFailed: true });
+    expect(out.split('\n').pop()).toBe('_⚠ probe failed — no live data_');
+    expect(out).not.toContain('_Live');
+    expect(out).not.toContain('cached');
+  });
+
+  it('probeFailed does not override real cached data (cache takes precedence)', () => {
+    // If some rows WERE served from cache, there IS real (stale) data —
+    // the cache marker must win over the probe-failed marker.
+    const out = renderUsageCard(snapshots, exhausted, {
+      now: NOW,
+      staleCachedAtMs: NOW.getTime() - 2 * 60_000,
+      probeFailed: true,
+    });
+    expect(out.split('\n').pop()).toBe('_⚠ cached 2m ago_');
+    expect(out).not.toContain('probe failed');
+  });
+
   it('handles an invalid/NaN reset date without emitting "NaN" or corrupting the bar', () => {
     const bad: AccountSnapshot[] = [
       snap({


### PR DESCRIPTION
## Summary
Adversarial-review finding against #2959 (the bar-only /usage quota card). Subscription-honesty invariant.

The `/usage` (and `/auth` ↻ refresh) freshness footer stamped `liveProbedAtMs` whenever `staleCachedAtMs` was unset. But a **total** probe failure (`probeQuota().catch(() => ({ results: [] }))`) leaves `staleCachedAtMs` undefined with zero result rows → the footer rendered `_Live · refreshed 0s ago_` (or bare `_Live_`) while every account row showed `⚠️ no data — probe failed`. A "Live" footer next to no-data rows misrepresents whether the data is live — the exact lie the card exists to prevent.

## Fix
- New `probeFailed` opt on `renderUsageCard` and `renderAuthSnapshotFormat2`.
- Gateway stamps `liveProbedAtMs` only when the probe returned ≥1 result row; on zero rows + no cache it passes `probeFailed: true` → footer renders `_⚠ probe failed — no live data_`.
- Precedence: `staleCachedAtMs` (real cached data) > `probeFailed` > bare `_Live_`.

## Verified
- `/auth show` (`auth-command.ts`) is unaffected — on probe failure it renders the legacy table with no Format2 footer (already honest).
- Tests: +2 `quota-bar-format`, +2 `auth-snapshot-format`. 136 green across both. `tsc` + lint (no-PII, bot-api-wrapping) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)