### PR TITLE
fix(telegram): scrub person_id human names from the broadcast config-warning alert

### DIFF
--- a/telegram-plugin/gateway/resolve-person.ts
+++ b/telegram-plugin/gateway/resolve-person.ts
@@ -63,6 +63,17 @@ export interface PersonDirectory {
 export interface DroppedPersonEntry {
   key: string
   reason: string
+  /**
+   * Name-scrubbed reason CLASS — the same rejection without the embedded
+   * `person_id` human-name value or the colliding telegram id. Used to
+   * build the broadcast `alertDetail` so a config-warning card (which
+   * `emitGatewayOperatorEvent` sends to EVERY `allowFrom` chat, including
+   * group chats where the named person may NOT be a member) never surfaces
+   * a human name that the display path (`resolvePersonName`) deliberately
+   * chat-scopes. The verbose `reason` is still carried for the operator's
+   * own stderr `logLine` (private, not broadcast).
+   */
+  reasonClass: string
 }
 
 export interface BuildPersonDirectoryResult {
@@ -105,15 +116,15 @@ export function buildPersonDirectory(entries: readonly RawPersonEntry[]): BuildP
     const personId = typeof raw.person_id === 'string' ? raw.person_id.trim() : ''
 
     if (key.length === 0) {
-      dropped.push({ key: raw.key || '(unknown)', reason: 'missing users: map key' })
+      dropped.push({ key: raw.key || '(unknown)', reason: 'missing users: map key', reasonClass: 'missing users: map key' })
       continue
     }
     if (personId.length === 0) {
-      dropped.push({ key, reason: 'empty or missing person_id' })
+      dropped.push({ key, reason: 'empty or missing person_id', reasonClass: 'empty or missing person_id' })
       continue
     }
     if (!Array.isArray(raw.telegram_ids) || raw.telegram_ids.length === 0) {
-      dropped.push({ key, reason: 'no telegram_ids to resolve against' })
+      dropped.push({ key, reason: 'no telegram_ids to resolve against', reasonClass: 'no telegram_ids to resolve against' })
       continue
     }
 
@@ -122,7 +133,14 @@ export function buildPersonDirectory(entries: readonly RawPersonEntry[]): BuildP
     if (existingOwner != null && existingOwner !== key) {
       dropped.push({
         key,
+        // Verbose reason (stderr logLine only — private to the operator):
+        // names the person_id value + the owning config key.
         reason: `duplicate person_id "${personId}" already claimed by users.${existingOwner}`,
+        // reasonClass (broadcast alertDetail): scrubs the human-name
+        // person_id value; keeps the entry key + collision class. A
+        // config-warning card fans out to every allowFrom chat, so the
+        // name must not travel further than the display path allows.
+        reasonClass: `duplicate person_id already claimed by users.${existingOwner}`,
       })
       continue
     }
@@ -130,7 +148,7 @@ export function buildPersonDirectory(entries: readonly RawPersonEntry[]): BuildP
 
     const telegramKeys = [...new Set(raw.telegram_ids.map(normalizeTelegramKey).filter((k) => k.length > 0))]
     if (telegramKeys.length === 0) {
-      dropped.push({ key, reason: 'telegram_ids contained no usable id/username' })
+      dropped.push({ key, reason: 'telegram_ids contained no usable id/username', reasonClass: 'telegram_ids contained no usable id/username' })
       personIdOwner.delete(personIdLower)
       continue
     }
@@ -144,6 +162,9 @@ export function buildPersonDirectory(entries: readonly RawPersonEntry[]): BuildP
       dropped.push({
         key,
         reason: `duplicate telegram_id "${collidingTelegramKey}" already claimed by users.${existingTkOwner}`,
+        // Scrub the colliding telegram id/username from the broadcast
+        // reason; keep the owning config key (operator-chosen slug).
+        reasonClass: `duplicate telegram_id already claimed by users.${existingTkOwner}`,
       })
       personIdOwner.delete(personIdLower)
       continue
@@ -189,12 +210,20 @@ export function runPersonDirectoryBootCheck(readEntries: () => RawPersonEntry[])
     const { directory, dropped } = buildPersonDirectory(rawEntries)
 
     if (dropped.length > 0) {
-      const summary = dropped.map((d) => `${d.key} (${d.reason})`).join('; ')
+      // Broadcast-safe summary for `alertDetail` (fans out to EVERY
+      // allowFrom chat via emitGatewayOperatorEvent, including group chats
+      // where the named person may not be a member): built from
+      // `reasonClass`, which scrubs the embedded person_id human-name
+      // value and the colliding telegram id. The verbose `reason`
+      // (names the values) is kept for the operator's own stderr
+      // `logLine` — private, never broadcast.
+      const alertSummary = dropped.map((d) => `${d.key} (${d.reasonClass})`).join('; ')
+      const logSummary = dropped.map((d) => `${d.key} (${d.reason})`).join('; ')
       const plural = dropped.length === 1 ? 'y' : 'ies'
       return {
         directory,
-        alertDetail: `person_id: dropped ${dropped.length} malformed users: entr${plural} at boot — ${summary}`,
-        logLine: `telegram gateway: person_id boot validation dropped ${dropped.length} entr${plural}: ${summary}`,
+        alertDetail: `person_id: dropped ${dropped.length} malformed users: entr${plural} at boot — ${alertSummary}`,
+        logLine: `telegram gateway: person_id boot validation dropped ${dropped.length} entr${plural}: ${logSummary}`,
       }
     }
 
@@ -209,7 +238,10 @@ export function runPersonDirectoryBootCheck(readEntries: () => RawPersonEntry[])
     const msg = err instanceof Error ? err.message : String(err)
     return {
       directory: { byTelegramKey: {} },
-      alertDetail: `person_id boot validation crashed — name resolution disabled this boot (fail-open, raw ids/usernames will show): ${msg}`,
+      // Crash alertDetail scrubs the raw error message too — it can
+      // carry a filesystem path or other host detail that shouldn't fan
+      // out to every allowFrom chat. The full message stays in logLine.
+      alertDetail: `person_id boot validation crashed — name resolution disabled this boot (fail-open, raw ids/usernames will show); see gateway stderr for detail`,
       logLine: `telegram gateway: person_id boot validation CRASHED (name resolution disabled this boot, raw ids will show — fail-open): ${msg}`,
     }
   }

--- a/telegram-plugin/tests/resolve-person.test.ts
+++ b/telegram-plugin/tests/resolve-person.test.ts
@@ -97,6 +97,35 @@ describe('buildPersonDirectory — per-entry validation drops only the bad entry
     expect(result.directory.byTelegramKey['mekenthompson']?.personId).toBe('Ken')
   })
 
+  // ── #2957 honesty fix: broadcast alertDetail must not surface the
+  //    person_id human-name value (the display path chat-scopes names;
+  //    the config-warning card fans out to EVERY allowFrom chat, incl.
+  //    groups where the named person may not be a member). The verbose
+  //    reason stays in the private logLine. ─────────────────────────
+  it('duplicate person_id: alertDetail scrubs the person_id value (keeps key + class); logLine keeps it', () => {
+    const dupe: RawPersonEntry = { key: 'lisa2', person_id: 'Lisa', telegram_ids: ['555'] }
+    const result = runPersonDirectoryBootCheck(() => [LISA, dupe])
+    expect(result.alertDetail).not.toBeNull()
+    // Broadcast-safe: names the losing config key + the collision class,
+    // but NOT the human-name "Lisa" value nor which name it collided with.
+    expect(result.alertDetail).toContain('lisa2')
+    expect(result.alertDetail).toContain('duplicate person_id already claimed')
+    expect(result.alertDetail).not.toContain('"Lisa"')
+    // Private stderr log keeps the verbose detail.
+    expect(result.logLine).toContain('"Lisa"')
+  })
+
+  it('duplicate telegram_id: alertDetail scrubs the colliding id; logLine keeps it', () => {
+    const dupe: RawPersonEntry = { key: 'imposter', person_id: 'Imposter', telegram_ids: ['8201250670'] }
+    const result = runPersonDirectoryBootCheck(() => [LISA, dupe])
+    expect(result.alertDetail).not.toBeNull()
+    expect(result.alertDetail).toContain('imposter')
+    expect(result.alertDetail).toContain('duplicate telegram_id already claimed')
+    // The colliding telegram id value is scrubbed from the broadcast.
+    expect(result.alertDetail).not.toContain('8201250670')
+    expect(result.logLine).toContain('8201250670')
+  })
+
   it('drops an entry with a missing users: map key', () => {
     const bad: RawPersonEntry = { key: '', person_id: 'Nobody', telegram_ids: ['1'] }
     const { directory, dropped } = buildPersonDirectory([LISA, bad])
@@ -249,8 +278,13 @@ describe('runPersonDirectoryBootCheck — one-time boot validation + alerting', 
     })
     expect(result.alertDetail).not.toBeNull()
     expect(result.alertDetail).toContain('crashed')
-    expect(result.alertDetail).toContain('disk read exploded')
+    // alertDetail is broadcast to every allowFrom chat (incl. groups), so
+    // the raw error message — which may carry a host path or other detail
+    // — is scrubbed from it. The full message stays in the private logLine.
+    expect(result.alertDetail).not.toContain('disk read exploded')
+    expect(result.alertDetail).toContain('see gateway stderr for detail')
     expect(result.directory.byTelegramKey).toEqual({})
     expect(result.logLine).toContain('CRASHED')
+    expect(result.logLine).toContain('disk read exploded')
   })
 })


### PR DESCRIPTION
## Summary
Adversarial-review finding against #2957. PII / no-exfiltrate invariant.

`runPersonDirectoryBootCheck` built its broadcast `alertDetail` from the verbose `dropped[].reason`, which embedded the `person_id` **human-name** value (`"duplicate person_id "Lisa" already claimed by users.lisa"`) and the colliding telegram id. `emitGatewayOperatorEvent` fans that `detail` to EVERY chat in `access.allowFrom`, including group chats where the named person may NOT be a member. The person_id display path (`resolvePersonName`) deliberately chat-scopes names (undefined for group non-members); this boot alert bypassed that scoping.

## Fix
- Each `DroppedPersonEntry` now carries a verbose `reason` (→ private stderr `logLine`) AND a name-scrubbed `reasonClass` (→ broadcast `alertDetail`).
- `reasonClass` keeps the losing config key + collision class, drops the embedded person_id value and colliding telegram id.
- Crash-path `alertDetail` likewise scrubbed of the raw error message (may carry a host path); full message stays in `logLine`.

## Severity context
Only fires on operator misconfig; name is operator-configured; audience is trusted under the single-tenant invariant. Consistency gap with the display path, not a hard wall breach — but the one place a DM-only person_id could reach a group.

## Verified
- `logLine` (stderr-only) still carries the full verbose detail; only the broadcast `alertDetail` is scrubbed (confirmed at the gateway call site: `logLine`→`process.stderr.write`, `alertDetail`→`emitGatewayOperatorEvent`).
- Tests: +2 name-scrubbing, crash test updated. 27 resolve-person tests green. `tsc` + no-PII lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)