### PR TITLE
fix(hooks): substance floor on trailing-text-after-reply so a pleasantry doesn't re-prompt

### DIFF
--- a/telegram-plugin/hooks/silent-end-scan.mjs
+++ b/telegram-plugin/hooks/silent-end-scan.mjs
@@ -221,6 +221,16 @@ function buildBlockResult(envelope, reason) {
  * (the model narrating before it sends) — only text that comes AFTER
  * the last delivery event counts as a drop.
  *
+ * Substance floor (#2956 review): the trailing-text check only BLOCKS
+ * when the trailing text is SUBSTANTIVE — at least FINAL_ANSWER_MIN_CHARS
+ * (the same bar `isFinalAnswerReply` uses to recognise a real answer). A
+ * SHORT trailing pleasantry / closer after a delivered reply ("Let me
+ * know if you need anything else.") is not a dropped answer and must not
+ * trigger a re-prompt (no-spam / single-answer invariant). A long
+ * trailing verdict the model forgot to send still blocks. The floor keeps
+ * the "at least once" guarantee for real dropped answers while stopping a
+ * false-positive that burned retry budget on healthy turns.
+ *
  * @param {string} jsonl
  * @returns {{ decided: 'allow' | 'block' | 'unknown', reason: string, turnKey?: string, chatId?: string, threadId?: number | null }}
  */
@@ -275,7 +285,16 @@ export function scanTurnForFinalReply(jsonl) {
         if (endsWithSilentMarker(String(c.text ?? ''))) {
           blocks.push({ kind: 'deliver', reason: 'silent-marker-text' })
         } else if (String(c.text ?? '').trim().length > 0) {
-          blocks.push({ kind: 'text' })
+          // Carry the trimmed char count so the trailing-content check
+          // (step 3) can apply a substance floor: a SHORT trailing text
+          // after a delivered reply (a pleasantry / closer like "Let me
+          // know if you need anything else.") is NOT a dropped answer and
+          // must not trigger a re-prompt (no-spam invariant). Only
+          // SUBSTANTIVE trailing text — at least FINAL_ANSWER_MIN_CHARS,
+          // the same bar `isFinalAnswerReply` uses to recognise a real
+          // answer — counts as "undelivered content the user was waiting
+          // on". #2956 review finding.
+          blocks.push({ kind: 'text', chars: String(c.text ?? '').trim().length })
         }
         continue
       }
@@ -322,7 +341,7 @@ export function scanTurnForFinalReply(jsonl) {
   }
   const sawUndeliveredTextAfterAllow = blocks
     .slice(lastAllowBlockIdx + 1)
-    .some((b) => b.kind === 'text')
+    .some((b) => b.kind === 'text' && (b.chars ?? 0) >= FINAL_ANSWER_MIN_CHARS)
 
   if (lastAllowBlockIdx === -1) {
     // No qualifying delivery/silence event anywhere in the turn.

--- a/telegram-plugin/tests/silent-end-interrupt-stop-scan.test.ts
+++ b/telegram-plugin/tests/silent-end-interrupt-stop-scan.test.ts
@@ -213,11 +213,30 @@ describe('scanTurnForFinalReply — trailing undelivered content after an early 
     expect(r.turnKey).toBe('111:_')
   })
 
-  it('early qualifying reply + trailing short (but non-empty) undelivered text → block (no minimum-length carve-out)', () => {
+  it('early qualifying reply + trailing SHORT pleasantry → allow (#2956 review: substance floor, no-spam)', () => {
+    // A short trailing text after a delivered reply (a closer like "let me
+    // know if you need anything else.") is NOT a dropped answer — it's a
+    // pleasantry the persona prompts discourage but which must not burn
+    // retry budget or force a redundant second reply. Only SUBSTANTIVE
+    // trailing text (≥ FINAL_ANSWER_MIN_CHARS) blocks. Pre-fix this
+    // false-positive blocked and re-prompted a healthy turn.
     const text = jsonl(
       ENQUEUE,
       assistantToolUse('mcp__switchroom-telegram__reply', { text: 'ok', disable_notification: false }),
       assistantText('actually, one more thing you should know'),
+    )
+    const r = scanTurnForFinalReply(text)
+    expect(r.decided).toBe('allow')
+  })
+
+it('early qualifying reply + trailing SUBSTANTIVE undelivered text (≥ floor) → block (at-least-once holds)', () => {
+    // The substance floor must NOT weaken the at-least-once guarantee for
+    // a real dropped answer: a long trailing verdict the model forgot to
+    // send still blocks. The trailing text here clears FINAL_ANSWER_MIN_CHARS.
+    const text = jsonl(
+      ENQUEUE,
+      assistantToolUse('mcp__switchroom-telegram__reply', { text: 'ok', disable_notification: false }),
+      assistantText('Here is the actual verdict after investigation: ' + 'X'.repeat(200)),
     )
     const r = scanTurnForFinalReply(text)
     expect(r.decided).toBe('block')


### PR DESCRIPTION
## Summary
Adversarial-review finding against #2956. No-spam / single-answer invariant.

The Stop hook's trailing-content check blocked when ANY plain assistant text appeared after the last delivery event — no length floor. A healthy turn that sent a real answer then a short trailing pleasantry ("Let me know if you need anything else.") was classified `trailing-text-after-reply` → block → re-prompt up to MAX_RETRIES=2. The user already had the answer; the hook burned retry budget and risked a redundant second reply.

## Fix
Carry the trimmed char count on each `text` block; only count it as undelivered content when it's SUBSTANTIVE — ≥ `FINAL_ANSWER_MIN_CHARS` (200), the same bar `isFinalAnswerReply` uses to recognise a real answer. Short trailing pleasantry → allow; long trailing verdict the model forgot to send → still blocks. At-least-once holds for real dropped answers; the false positive on closers is gone.

## Verified
The existing "no minimum-length carve-out" test is inverted to the new correct behavior + a new substantive-trailing-still-blocks test. 109 silent-end tests green. `tsc` clean, mjs parses, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)