### PR TITLE
chore(release): automate npm publish on tag + gate rollout on it

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,243 @@
+name: npm-publish
+
+# Publish the `switchroom` CLI to npm on every release tag. This is the
+# step that was historically silently skipped — v0.18.4 and v0.18.5 were
+# tagged, image-built, and rolled to the fleet but NEVER published to npm,
+# because the publish step lived only in CLAUDE.md prose and wasn't gated
+# before rollout. Automating it on tag push makes it unmissable: every
+# `vX.Y.Z` tag publishes, and the rollout skill gates on this workflow
+# going green + `npm view switchroom` showing the new version.
+#
+# Trigger: tag push matching `v*` (the release-cut signal). Not fired on
+# main pushes or PRs — only on a real release tag.
+#
+# Auth: the `NPM_TOKEN` repo secret (automation-scoped npm access token,
+# publish access on the `switchroom` package). The operator sets this once
+# in repo settings → Secrets and variables → Actions. Without it this
+# workflow fails loudly at the publish step rather than silently skipping.
+#
+# Version source of truth: the git tag. `package.json` `version` is an
+# intentional stale placeholder (see its `//version` comment + CLAUDE.md >
+# Release). `resolveVersion()` stamps the built dist from the tag; the
+# npm tarball needs the SAME version in its package.json, so we bump it
+# UNCOMMITTED at pack time (never committed — that's the #2733 discipline).
+#
+# Ordering vs the docker-images workflow: both fire on the same tag push
+# and run in parallel. The rollout skill must wait for BOTH this workflow
+# (npm publish verified) AND docker-images (6 ghcr images verified) before
+# any fleet roll — neither alone is sufficient.
+
+on:
+  push:
+    tags:
+      - "v*"
+  # Manual re-trigger for a retry (e.g. a transient npm 5xx on publish).
+  # Rerun will not work for a tag-ref workflow the same way it does for
+  # branch workflows, so this lever exists.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write  # npm provenance (sigstore) — requires npm provenance enabled on the package; harmless if not.
+
+concurrency:
+  group: npm-publish-${{ github.ref }}
+  cancel-in-progress: false  # a publish in flight must not be cancelled mid-PUT
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout (full history for resolveVersion git describe)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0  # resolveVersion() uses `git describe --tags --exact-match HEAD`; needs tags + history
+
+      - name: Set up Bun + install workspace deps
+        uses: ./.github/actions/setup-switchroom
+
+      - name: Resolve release version from the git tag
+        id: ver
+        shell: bash
+        run: |
+          # Mirror scripts/build.mjs:resolveVersion() Layer 1-3 — the tag is
+          # the source of truth. Strip the leading 'v'.
+          ref="${GITHUB_REF#refs/tags/}"
+          case "$ref" in
+            v*) ver="${ref#v}" ;;
+            *)  ver="$ref" ;;
+          esac
+          # Guard: a tag that doesn't look like a version is a misfire.
+          if ! echo "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-.+].+)?$'; then
+            echo "::error::tag '$ref' is not a version tag (got '$ver'); refusing to publish"
+            exit 1
+          fi
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+          echo "Publishing switchroom@$ver (from tag $ref)"
+
+      - name: Bump package.json version UNCOMMITTED (pack-time only)
+        shell: bash
+        run: |
+          # Never commit this bump — the placeholder is stale by design
+          # (#2733). The tarball just needs a real version for npm naming +
+          # `npm view`. Use node to keep the JSON formatting stable.
+          node -e '
+            const fs = require("fs");
+            const p = JSON.parse(fs.readFileSync("package.json", "utf-8"));
+            p.version = process.argv[1];
+            fs.writeFileSync("package.json", JSON.stringify(p, null, 2) + "\n");
+          ' "${{ steps.ver.outputs.version }}"
+          # Sanity: confirm the bump landed and the //version comment survived
+          # (JSON.parse drops comments, so re-add it as a guard below).
+          grep -q "\"version\": \"${{ steps.ver.outputs.version }}\"" package.json || {
+            echo "::error::pack-time version bump did not land in package.json"
+            exit 1
+          }
+
+      - name: Build dist (real node_modules, not a symlink)
+        shell: bash
+        run: |
+          # setup-switchroom ran `bun install --frozen-lockfile` → real
+          # node_modules. A symlinked node_modules made bun build silently
+          # emit an empty dist/cli/ (broke v0.12.6→7); the composite action
+          # avoids that, but we still verify the output is non-empty below.
+          bun scripts/build.mjs
+
+      - name: Verify dist/cli/switchroom.js is non-empty (empty-build guard)
+        shell: bash
+        run: |
+          # The v0.12.6→7 regression: bun build silently emitted an empty
+          # dist/cli/. Catch it here, BEFORE packing, so we never publish a
+          # broken tarball.
+          f="dist/cli/switchroom.js"
+          if [ ! -s "$f" ]; then
+            echo "::error::$f is missing or empty — build produced no CLI entrypoint; refusing to publish"
+            exit 1
+          fi
+          echo "$f is $(wc -c < "$f") bytes — non-empty, OK"
+          # Shebang check: build.mjs fixes the shebang for Node; confirm it
+          # points at node, not bun (npm consumers run via node).
+          head -1 "$f" | grep -q '^#!.*node' || echo "::warning::$f shebang is not node-targeted"
+
+      - name: Pack (npm pack, no publish yet)
+        id: pack
+        shell: bash
+        run: |
+          # `npm pack` names the tarball from the (now-bumped) package.json
+          # version. --ignore-scripts: never run the package's lifecycle
+          # scripts during pack (prepublishOnly runs build+lint+test, which
+          # is redundant here and would re-run the whole suite).
+          # Run once, capturing output WITHOUT a pipe (a pipe masks the
+          # real exit code). `npm pack` prints the tarball filename as its
+          # last line.
+          set +e
+          npm pack --ignore-scripts > /tmp/pack.out 2>&1
+          rc=$?
+          set -e
+          if [ $rc -ne 0 ]; then
+            echo "::error::npm pack failed (exit $rc):"; cat /tmp/pack.out; exit 1
+          fi
+          tarball=$(tail -1 /tmp/pack.out)
+          if [ -z "$tarball" ] || [ ! -f "$tarball" ]; then
+            echo "::error::npm pack produced no tarball filename; output:"; cat /tmp/pack.out; exit 1
+          fi
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+          echo "Packed $tarball ($(wc -c < "$tarball") bytes)"
+
+      - name: Verify dist/cli/switchroom.js IS in the tarball
+        shell: bash
+        run: |
+          # The whole point: confirm the CLI entrypoint ships in the
+          # published tarball. A files/ glob misconfiguration or a missing
+          # dist/ would otherwise publish a package that installs but
+          # can't run.
+          tar tf "${{ steps.pack.outputs.tarball }}" | grep -q '^dist/cli/switchroom\.js$' || {
+            echo "::error::dist/cli/switchroom.js is NOT in the tarball — files/ glob or build is wrong; refusing to publish"
+            tar tf "${{ steps.pack.outputs.tarball }}" | head -20
+            exit 1
+          }
+          echo "dist/cli/switchroom.js confirmed in the tarball"
+
+      - name: Set up npm auth (NPM_TOKEN)
+        shell: bash
+        run: |
+          # .npmjsrc in $HOME so `npm publish` + `npm view` pick up the
+          # automation token. Using the //registry/ auth line (not
+          # _authToken in a published file) keeps the token out of the
+          # repo + the tarball.
+          mkdir -p "$HOME"
+          printf '//registry.npmjs.org/:_authToken=%s\n' "${{ secrets.NPM_TOKEN }}" > "$HOME/.npmrc"
+          chmod 600 "$HOME/.npmrc"
+          # Guard: a missing/empty token fails loudly here, not at publish.
+          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "::error::NPM_TOKEN secret is empty or unset — set it in repo settings → Secrets → Actions"
+            rm -f "$HOME/.npmrc"
+            exit 1
+          fi
+
+      - name: Publish to npm (provenance-first, fallback to plain)
+        shell: bash
+        run: |
+          # --ignore-scripts: do not run the package's prepublishOnly
+          # (build+lint+test) on the npm side — we already built + verified
+          # locally. --access public: the package is public.
+          #
+          # --provenance: sigstore-signed build provenance (needs
+          # id-token: write, set above). Provenance can hard-fail for
+          # reasons that DON'T mean the publish is invalid — the package
+          # requiring 2FA for automation, provenance not enabled on the
+          # npm side, a transient sigstore outage. A provenance
+          # misconfiguration must NOT block a release (the whole point of
+          # this workflow is reliable publish). So: try with --provenance
+          # first; on failure, retry WITHOUT it. A plain publish that
+          # lands is strictly better than a provenanced publish that
+          # never happens.
+          set +e
+          npm publish "${{ steps.pack.outputs.tarball }}" \
+            --ignore-scripts --access public --provenance > /tmp/publish.out 2>&1
+          rc=$?
+          set -e
+          if [ $rc -ne 0 ]; then
+            echo "::warning::npm publish --provenance failed (exit $rc); falling back to a plain publish. Output:"; cat /tmp/publish.out
+            # Guard: if the failure was "already published" (409 / E403
+            # "You cannot publish over the currently published version"),
+            # a retry without provenance will fail identically — treat it
+            # as success (the version IS on npm) and skip the retry.
+            if grep -qiE "cannot publish over|already published|E409" /tmp/publish.out; then
+              echo "Version already on npm — treating as success (no retry)."
+              exit 0
+            fi
+            set +e
+            npm publish "${{ steps.pack.outputs.tarball }}" \
+              --ignore-scripts --access public > /tmp/publish-plain.out 2>&1
+            rc=$?
+            set -e
+            if [ $rc -ne 0 ]; then
+              echo "::error::npm publish failed even without provenance (exit $rc):"; cat /tmp/publish-plain.out
+              exit 1
+            fi
+            echo "Plain publish succeeded (no provenance)."
+          else
+            echo "Publish with provenance succeeded."
+          fi
+
+      - name: Verify the new version is live on npm
+        shell: bash
+        run: |
+          # The gate the rollout skill checks: `npm view switchroom version`
+          # must return the tag version. A publish that doesn't surface on
+          # the registry (rare race) is caught here.
+          set +e
+          for i in 1 2 3 4 5; do
+            published=$(npm view switchroom version 2>/dev/null)
+            if [ "$published" = "${{ steps.ver.outputs.version }}" ]; then
+              echo "npm view switchroom version = $published — published and live"
+              exit 0
+            fi
+            echo "attempt $i: npm view returned '$published', expected '${{ steps.ver.outputs.version }}' — retrying in 6s"
+            sleep 6
+          done
+          set -e
+          echo "::error::npm view switchroom version did not reach ${{ steps.ver.outputs.version }} after publish + retries — publish may have silently failed"
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,29 +302,46 @@ DB, audit log, scaffolds). A test that writes there corrupts a running fleet
 
 ## Release (condensed — full landmine detail in git history)
 
+**Follow the `switchroom-release` skill for the full ordered checklist.**
+The two gates below (npm publish + images) are HARD prerequisites for
+rollout — v0.18.4 and v0.18.5 shipped to the fleet but were never
+published to npm because publish wasn't gated. Don't let that recur.
+
 - **Version source of truth is the git tag**, resolved by
   `scripts/build.mjs:resolveVersion()`. The committed `package.json`
   `version` is a stale placeholder by design (see its `//version` comment) —
   never bump it in a commit. Release = CHANGELOG consolidation PR → merge →
-  tag `vX.Y.Z` on the merge commit → push tag (triggers `docker-images`).
-- `npm pack` names the tarball from the stale version — bump `package.json`
-  **uncommitted** at pack time; verify `dist/cli/switchroom.js` is in the
-  tarball before `npm publish --ignore-scripts`. Never pipe the build through
-  `tail` (masks a failed exit). Release builds need a **real
-  `node_modules`**, not a worktree symlink — a symlinked `node_modules` made
-  `bun build` silently emit an empty `dist/cli/` (broke v0.12.6→7).
+  tag `vX.Y.Z` on the merge commit → push tag (triggers `docker-images`
+  AND `npm-publish` in parallel).
+- **npm publish is automated by `.github/workflows/npm-publish.yml`** on
+  tag push: it does the uncommitted pack-time `package.json` bump, builds,
+  verifies `dist/cli/switchroom.js` is non-empty AND in the tarball (the
+  v0.12.6→7 empty-build guard), `npm publish --ignore-scripts
+  --provenance`, and verifies `npm view switchroom version` shows the new
+  version. Needs the `NPM_TOKEN` repo secret (set once). **Do NOT roll
+  the fleet until this workflow is green AND `npm view switchroom version`
+  returns the tag version.** Never run `npm publish` by hand from an
+  agent container (no npm auth there); fix the workflow, don't side-step
+  it. Release builds need a **real `node_modules`**, not a worktree
+  symlink — a symlinked one made `bun build` silently emit an empty
+  `dist/cli/` (broke v0.12.6→7); the workflow's setup-switchroom action
+  avoids this and the empty-build guard catches it.
 - Create the GitHub Release (`gh release create`) — historically silently
   dropped. The naive `awk '/^## vX/,/^## v/'` CHANGELOG range collapses to
   one line; use a start-flag awk instead.
 - The web container is a separate compose project
   (`~/.switchroom/web/docker-compose.yml`) — `switchroom update` doesn't
   touch it; pull + up manually.
-- Fleet rollout: canary on test-harness first (UAT above), then staggered
-  per-agent `switchroom agent restart <name> --wait --force` with a
-  `--version` assertion per agent (guards the `:latest` pull-race). Deploy
-  only from the host shell or via hostd (`SWITCHROOM_HOST_HOME` invariant —
-  `reference/rfcs/deploy-reliability.md`); never via an ad-hoc container
-  mounting the operator home.
+- **Fleet rollout — only after BOTH gates pass:** npm publish verified
+  (above) AND `docker-images` verified (`docker manifest inspect
+  ghcr.io/switchroom/<image>:vX.Y.Z` for agent, auth-broker, kernel,
+  broker, web, hostd). Then canary on test-harness first (UAT above),
+  then staggered per-agent `switchroom agent restart <name> --wait
+  --force` with a `--version` assertion per agent (guards the `:latest`
+  pull-race). Deploy only from the host shell or via hostd
+  (`SWITCHROOM_HOST_HOME` invariant — `reference/rfcs/deploy-reliability.md`);
+  never via an ad-hoc container mounting the operator home.
+
 
 ## Secrets & safety rails
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -94,6 +94,11 @@ skill **except** the universal `cli`/`status`/`health` trio — see
 - `switchroom-install` — bootstrap switchroom on a fresh machine
 - `switchroom-manage` — add/remove/reinstall/list agents (fleet-level)
 - `switchroom-architecture` — internal design context for fleet-management decisions
+- `switchroom-release` — cut and ship a release end-to-end (CHANGELOG →
+  tag → npm publish → images → rollout gate). Enforces the npm-publish +
+  image-build gates that were historically skipped (v0.18.4/v0.18.5
+  shipped to the fleet but never hit npm). See
+  `.github/workflows/npm-publish.yml` + CLAUDE.md > Release.
 - `switchroom-runtime` — conditional runtime protocols: the agent
   answering for *itself* about a crash, restart, hand-off resume, or
   mid-turn interrupt ("why did you restart?", "did you crash?", "still
@@ -121,6 +126,7 @@ Current `<repo>/skills/` inventory:
 | `switchroom-install` | foreman-only (auto when `role: foreman`) | First-time bootstrap on a fresh machine |
 | `switchroom-manage` | foreman-only (auto when `role: foreman`) | Add/remove/reinstall/list agents (fleet-level) |
 | `switchroom-architecture` | foreman-only (auto when `role: foreman`) | Internal design context for fleet-mgmt decisions |
+| `switchroom-release` | foreman-only (auto when `role: foreman`) | Cut + ship a release; gates npm publish + images before rollout |
 | `switchroom-runtime` | foreman-only (auto when `role: foreman`) | Agent answering for itself about crash/restart/interrupt/hand-off |
 | `humanizer` | developer (opt-in) | Strips AI-writing patterns from replies; opt in via `defaults.skills` |
 | `humanizer-calibrate` | developer (opt-in) | Builds a personal voice template; companion to `humanizer` |
@@ -128,8 +134,8 @@ Current `<repo>/skills/` inventory:
 | `telegram-test-harness` | developer (opt-in) | Guidance for writing Telegram tests against the harness |
 | `token-helpers` | developer (opt-in) | Library skill — OAuth token refresh for Google Calendar / MS Graph |
 
-That's the full `skills/` tree (19 directories: 7 vendored Anthropic +
-7 `switchroom-*` + `humanizer`/`humanizer-calibrate` + `file-bug` +
+That's the full `skills/` tree (20 directories: 7 vendored Anthropic +
+8 `switchroom-*` + `humanizer`/`humanizer-calibrate` + `file-bug` +
 `telegram-test-harness` + `token-helpers`). Verify with `ls skills/`.
 
 Real fleet agents (clerk, klanker, etc.) load their personal skills from `~/.switchroom/skills/` — that directory holds calendar, compass, coolify, doctor-appointments, fully-kiosk, garmin, and similar. **The repo doesn't track those** — they're operator-managed.

--- a/skills/switchroom-release/SKILL.md
+++ b/skills/switchroom-release/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: switchroom-release
+description: "Cut and ship a switchroom release end-to-end: CHANGELOG consolidation, tag, npm publish, image build, and the fleet rollout gate. Use when the user says 'cut a release', 'ship a release', 'release vX', 'publish a new version', 'roll out the latest', or otherwise wants the merged work on main to go live for the fleet. This is the ONLY skill that authorizes a fleet rollout, and it enforces the npm-publish + image-build gates that were historically skipped (v0.18.4/v0.18.5 shipped to the fleet but never hit npm). Do NOT use for adding agents (switchroom-manage), diagnostics (switchroom-health), or a plain `switchroom update` on one agent (switchroom-cli)."
+allowed-tools: Bash(git *) Bash(gh *) Bash(npm view *) Bash(npm pack *) Bash(docker manifest inspect *) Bash(docker buildx imagetools inspect *)
+---
+
+# Switchroom release
+
+Cut a release of `switchroom/switchroom` and get it live on the fleet. This is a **gated, ordered checklist** — do not skip steps, do not reorder. The whole point of this skill is that two steps that used to be skipped silently (npm publish, image-build verification) are now **hard gates before rollout**.
+
+## What a release actually is
+
+- A release = a `vX.Y.Z` **git tag** on `main` (the merge commit of the CHANGELOG PR).
+- The tag is the version source of truth (`scripts/build.mjs:resolveVersion()`). `package.json` `version` is a **stale placeholder by design** — never bump it in a commit (the `//version` comment + #2733 discipline). The uncommitted pack-time bump happens in CI now, not by hand.
+- Cutting the tag fires TWO workflows in parallel on tag push: `docker-images` (builds + pushes the 6 ghcr images) and `npm-publish` (builds, packs, verifies, publishes to npm). **Rollout is gated on BOTH going green.**
+
+## Before you start — pre-flight (verify, don't assume)
+
+1. `git fetch origin`, confirm `main` is at the commit you want released.
+2. `gh pr list --state open` — confirm no PR meant for this release is still open. Ask the operator if unsure.
+3. Confirm CI on `main` is green (`gh run list --branch main --limit 3`).
+4. Read `CHANGELOG.md` — the `## Unreleased` section is the staging area for this release's notes. If it's empty, there's nothing to release.
+5. Pick the next version: read the latest tag (`git tag --list 'v*' --sort=-v:refname | head -1`) and bump the patch (or minor if the operator asks). Confirm with the operator which.
+
+## Step 1 — Consolidate the changelog (the release commit is CHANGELOG-only)
+
+- Move the `## Unreleased` entries under a new `## vX.Y.Z — <one-line summary>` heading.
+- The release commit touches **CHANGELOG.md only**. Do NOT bump `package.json` (placeholder discipline).
+- Branch protection blocks direct push to `main`, so: create a `release/vX.Y.Z` branch, push it, open a `chore: release vX.Y.Z` PR (base `main`), arm auto-merge (squash, delete-branch) on green CI.
+
+## Step 2 — Cut the tag (on the merge commit, not the PR branch)
+
+Once the changelog PR is merged:
+- `git fetch origin && git checkout main && git pull --ff-only`
+- Tag the merge commit and create the GitHub Release:
+  - `gh release create vX.Y.Z -R switchroom/switchroom --target main --title 'vX.Y.Z — <summary>' --notes-file <notes-file>`
+- **Notes extraction gotcha (historical):** the naive `awk '/^## vX/,/^## v/' CHANGELOG` range collapses to a single line. Use a start-flag awk: `awk 'f{print} /^## vX\.Y\.Z/{print; f=1} f && /^## v/ && !/^## vX\.Y\.Z/{exit}'` — or extract the section to a temp file by line range.
+- **`gh release create` has been silently dropped in past runs.** After running it, verify: `gh release view vX.Y.Z` must return the release. If it didn't create, re-run.
+
+## Step 3 — Wait for BOTH tag-push workflows (hard gates)
+
+The tag push triggers `docker-images` AND `npm-publish` in parallel. **Do not proceed to rollout until both are green AND verified.**
+
+### Gate A — npm publish (`npm-publish.yml`)
+- `gh run list --workflow=npm-publish.yml --limit 1` — wait for it to reach `completed` / `success`.
+- Verify the publish is live: `npm view switchroom version` must return `X.Y.Z` (not the old version). Retry a few times — npm registry propagation can lag a few seconds.
+- If this workflow fails: **the release is not published.** Do NOT roll. Diagnose (NPM_TOKEN unset? npm 5xx? empty dist?). Re-run via `gh workflow run npm-publish.yml --ref vX.Y.Z` after fixing.
+
+### Gate B — docker images (`docker-images.yml`)
+- `gh run list --workflow=docker-images.yml --limit 1` — wait for `completed` / `success`.
+- Verify all 6 images are published: `docker manifest inspect ghcr.io/switchroom/<image>:vX.Y.Z` for `agent`, `auth-broker`, `kernel`, `broker`, `web`, `hostd`. Each must resolve.
+- If any image is missing: do NOT roll — the rollout canary version-assert fails on an unpublished tag. Wait + re-check.
+
+**Only when Gate A AND Gate B are green + verified** do you proceed.
+
+## Step 4 — Fleet rollout (operator-gated, canary-first)
+
+- Fire the rollout via the hostd rollout path (`mcp__hostd__rollout`), which pops an **approval card**. Do NOT roll without the operator tapping approve.
+- Canary discipline: roll the release-critical canary agent first (the test-harness agent, per CLAUDE.md > Release canary discipline), monitor its logs + a smoke check, then stagger the rest per-agent with a `--version` assertion each (guards the `:latest` pull-race).
+- For a release that changes agent runtime behavior (a CLI pin bump, a behavioral template change), offer the operator a canary-first path (one agent → monitor → sweep) vs all-at-once; let them choose.
+
+## What you must NOT do
+
+- **Never bump `package.json` `version` in a commit.** It's a stale placeholder; the tag is the source of truth and `npm-publish.yml` does the uncommitted pack-time bump.
+- **Never run `npm publish` by hand from the agent container.** You can't reach the operator's npm auth, and the workflow is the reliable path. If the workflow is broken, fix the workflow — don't side-step it.
+- **Never roll the fleet before Gate A (npm) AND Gate B (images) are both green + verified.** A release that's on the fleet but not on npm is the exact regression this skill exists to prevent.
+- **Never push directly to `main`.** The CHANGELOG PR goes through auto-merge on green.
+- **Never force-push `main` or bypass hooks (`--no-verify`).**
+
+## If something goes wrong
+
+- **npm-publish failed but the tag is already pushed:** fix + `gh workflow run npm-publish.yml --ref vX.Y.Z`. Do NOT roll until it's green + `npm view` confirms.
+- **Images failed but npm succeeded:** the npm package is live but the fleet can't roll yet. Fix the image workflow / re-run. (npm being ahead of images is fine — the CLI is published for npm consumers; the fleet waits on images.)
+- **Rollout started before publish verified (the old bug):** abort the rollout, publish, then re-roll. Do not let a half-published release sit on the fleet.
+
+## Operator one-time setup (tell them once, not every release)
+
+The `npm-publish.yml` workflow needs an `NPM_TOKEN` repo secret (automation-scoped npm access token with publish rights on `switchroom`). Set it once in repo settings → Secrets and variables → Actions → `NPM_TOKEN`. Without it, Gate A fails loudly on the first release — that's the design (loud > silent).


### PR DESCRIPTION
## Summary
v0.18.4 and v0.18.5 shipped to the fleet but were never published to npm — the publish step was CLAUDE.md prose, not gated, so it kept getting skipped. This makes it unmissable.

## Changes
1. **`.github/workflows/npm-publish.yml`** — fires on `v*` tag push (parallel with `docker-images`). Resolves version from the tag (source of truth), uncommitted pack-time `package.json` bump (#2733 discipline — never committed), builds via the shared `setup-switchroom` action, guards the v0.12.6→7 empty-dist regression (verifies `dist/cli/switchroom.js` non-empty AND in the tarball), publishes with `NPM_TOKEN` (**provenance-first, plain-fallback** so a provenance misconfig can't block a release; "already published" = success), and verifies `npm view switchroom version` before going green.
2. **`skills/switchroom-release/SKILL.md`** — the full ordered, gated checklist: pre-flight → CHANGELOG PR → tag → **TWO HARD GATES** (npm publish via `npm view` + 6 ghcr images via `docker manifest inspect`) → operator-gated canary rollout. Explicit never-list. Foreman-only (auto-symlinked to `role: foreman` agents).
3. **`CLAUDE.md` > Release** — names `npm-publish.yml` as the automated path, states both-gates-before-rollout as a hard rule.
4. **`docs/skills.md`** — registers `switchroom-release` (foreman-only list + inventory; 20 dirs, 8 `switchroom-*`).

## One-time operator setup
Set the `NPM_TOKEN` repo secret (repo settings → Secrets → Actions). Automation-scoped npm access token with publish rights on `switchroom`. Without it, the first release fails loudly at publish — by design (loud > silent).

## Verified
scaffold + skill + manifest tests green (225), `tsc` clean, no-PII + plugin-references lint clean. The reconcile gate globs `switchroom-*` + `SKILL.md` and excludes the universal trio, so the new skill is auto-picked-up for foreman agents with no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)