### PR TITLE
fix(npm-publish): un-ignore dist/ at pack time so the tarball ships the CLI

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -120,6 +120,40 @@ jobs:
           # points at node, not bun (npm consumers run via node).
           head -1 "$f" | grep -q '^#!.*node' || echo "::warning::$f shebang is not node-targeted"
 
+      - name: Un-ignore dist/ for npm pack (version-proof the files whitelist)
+        shell: bash
+        run: |
+          # `dist/` is in package.json `files` (the whitelist) AND in
+          # `.gitignore` (build output, never committed). npm's rule: the
+          # `files` whitelist overrides `.gitignore`. BUT this is npm-version-
+          # dependent — on some runner-default npm versions a gitignored dir
+          # in `files` is STILL excluded from the tarball (the v0.18.6 first
+          # publish attempt hit exactly this: dist/ built + verified on disk,
+          # yet `npm pack` emitted a tarball with zero dist/ entries). The
+          # version-proof fix: temporarily strip the `dist/` line from
+          # `.gitignore` so npm never sees dist/ as ignored, regardless of
+          # which npm version the runner ships. This is an UNCOMMITTED
+          # pack-time-only edit (the commit is never made); restore after pack
+          # isn't needed because the workspace is ephemeral. Also keep
+          # `.npmignore` in place (it does NOT list dist/, and its other
+          # exclusions — vendor/, tests/ — are intentional belt-and-braces).
+          if [ -f .gitignore ]; then
+            cp .gitignore .gitignore.release-backup
+            # Remove any line that is exactly `dist/` or `dist` (keep other
+            # dist-prefixed ignore rules like `dist-cli/` intact).
+            sed -E '/^dist\/?$/d' .gitignore.release-backup > .gitignore
+            if grep -Eq '^dist/?$' .gitignore; then
+              echo "::warning::failed to strip dist/ from .gitignore — tarball may miss dist/"
+            else
+              echo "Stripped dist/ from .gitignore for pack (uncommitted, ephemeral workspace)."
+            fi
+          fi
+          # Debug: surface the npm version + ignore-file presence in the log
+          # so any future publish failure is diagnosable without a re-run.
+          echo "npm version: $(npm --version)"
+          echo ".npmignore present: $([ -f .npmignore ] && echo yes || echo no)"
+          echo ".gitignore dist/ line present: $(grep -c '^dist/' .gitignore 2>/dev/null || echo 0)"
+
       - name: Pack (npm pack, no publish yet)
         id: pack
         shell: bash


### PR DESCRIPTION
The v0.18.6 first publish failed the dist-in-tarball guard: build produced dist/cli/switchroom.js but npm pack emitted zero dist/ entries. Root cause: dist/ is in package.json files (whitelist) AND in .gitignore; the files-overrides-gitignore rule is npm-version-dependent and the runner's npm excluded it. Fix: strip dist/ from .gitignore at pack time (uncommitted, ephemeral). The guard did its job — no broken tarball was published. This makes the pack succeed.