### PR TITLE
fix(litellm): provisioning self-heals orphaned keys + specs stop contradicting shipped routing behavior

### DIFF
--- a/reference/invariants.md
+++ b/reference/invariants.md
@@ -52,9 +52,21 @@ A gateway the operator runs (e.g. self-hosted LiteLLM) MAY sit between the
    **content-safety guardrails** (PII redaction/blocking on message
    content). Observation (token/cost metering, logging, tagging) is
    unrestricted.
-3. **Opt-in, default OFF.** No agent routes through a gateway unless the
-   operator turns it on, and a gateway outage **fails open** to the direct
-   subscription path (availability is never sacrificed to the proxy).
+3. **Opt-in, default OFF, availability preserved.** No agent routes through a
+   gateway unless the operator turns it on. A gateway problem never silences
+   the fleet, but the recovery is split by cause (the two-mode boot contract in
+   `profiles/_base/start.sh.hbs`, applied to both interactive and cron
+   sessions):
+   - **Missing virtual key** (no per-agent key in the vault): **fail open** to
+     the direct subscription path. There is nothing to authenticate to the
+     proxy with, so routing env is stripped and the agent talks to Anthropic
+     directly on the forwarded OAuth — loudly logged as untracked/unguarded.
+   - **Proxy unreachable with a key present**: **keep routing and warn** — do
+     NOT fall open. Routing env is left pointed at the proxy so traffic
+     self-heals the moment it recovers (the socat forwarder reconnects
+     per-connection), rather than silently going untracked on a transient blip.
+   Failing open on an unreachable-but-keyed proxy was removed (#2940): silent
+   untracked traffic violates the cost-tracking side of this carve-out.
 4. **Non-Anthropic is a separate path.** Other models routed through the
    same gateway are off-subscription, separately billed, and **not** covered
    by the subscription-native guarantee. They are a distinct,

--- a/reference/invariants.md
+++ b/reference/invariants.md
@@ -54,9 +54,9 @@ A gateway the operator runs (e.g. self-hosted LiteLLM) MAY sit between the
    unrestricted.
 3. **Opt-in, default OFF, availability preserved.** No agent routes through a
    gateway unless the operator turns it on. A gateway problem never silences
-   the fleet, but the recovery is split by cause (the two-mode boot contract in
-   `profiles/_base/start.sh.hbs`, applied to both interactive and cron
-   sessions):
+   the fleet, but the recovery is split by cause (the two-mode boot contract,
+   shipped for interactive sessions in `profiles/_base/start.sh.hbs`; cron
+   sessions are ported to the same contract in #2981):
    - **Missing virtual key** (no per-agent key in the vault): **fail open** to
      the direct subscription path. There is nothing to authenticate to the
      proxy with, so routing env is stripped and the agent talks to Anthropic

--- a/reference/rfcs/litellm-max-subscription-invariants.md
+++ b/reference/rfcs/litellm-max-subscription-invariants.md
@@ -104,22 +104,27 @@ places in the `model` field of its API requests, NOT prefixed with `anthropic/`.
 - model_name: anthropic/claude-sonnet-4-6
 ```
 
-**Current verified list (2026-06-28):**
+**Current verified list (2026-07-10):**
 - `claude-opus-4-8`
-- `claude-sonnet-4-6`
+- `claude-sonnet-5`
+- `claude-fable-5`
 - `claude-haiku-4-5-20251001`
+- `claude-opus-4-7` (stale — kept only as a drift-alias source, see below)
+- `claude-sonnet-4-6` (stale — kept only as a drift-alias source, see below)
 
 Update this list (and `forward_client_headers_to_llm_api`) whenever the CLI
 ships a new model. The CLI's `/model` picker is the authoritative source.
 
-**Sanctioned drift-aliases (deliberate, live).** The fleet runs a small set of
-`model_aliases` that map a name an *older* CLI still sends on the wire to the
-current live model, so an agent on a lagging CLI build keeps routing instead of
-4xxing on an unknown model. These are intentional and NOT a violation of the
-"names must match" rule above — the alias target is another **Anthropic** model,
-so OAuth forwarding (I1/I2) is unaffected and no credential crosses to a
-non-Anthropic upstream (contrast I6, which bars aliasing a Claude name to a
-non-Anthropic target). Currently sanctioned:
+**Sanctioned drift-aliases.** The fleet runs a small set of `model_aliases`
+that map a name an *older* CLI still sends on the wire to the current live
+model, so an agent on a lagging CLI build keeps routing instead of 4xxing on
+an unknown model. These are intentional and NOT a violation of the "names must
+match" rule above — the alias target is another **Anthropic** model, so OAuth
+forwarding (I1/I2) is unaffected and no credential crosses to a non-Anthropic
+upstream (contrast I6, which bars aliasing a Claude name to a non-Anthropic
+target). The deployed litellm proxy config lives OUT-OF-TREE (operator
+infrastructure), so this repo can't pin it — the set below was verified against
+the live deployment on 2026-07-10:
 
 - `claude-opus-4-7` → `claude-opus-4-8`
 - `claude-sonnet-4-6` → `claude-sonnet-5`
@@ -189,8 +194,10 @@ OpenRouter, a credential leak.
 
 **Rule:** the boot gate (`_LITELLM_OK` / `sr_ll_*` in
 `profiles/_base/start.sh.hbs`, ~1002-1011) handles two failure modes
-DIFFERENTLY. This contract applies to both the interactive session and the
-cron session (`profiles/_base/cron-session.sh.hbs`).
+DIFFERENTLY. The contract covers every session kind: it is shipped for the
+interactive session; the cron session
+(`profiles/_base/cron-session.sh.hbs`) is ported to the same contract in
+#2981.
 
 - **Missing virtual key** (no `litellm/<agent>/api-key` in the vault): **fail
   open** — strip the routing env and fall back to direct Anthropic OAuth,

--- a/reference/rfcs/litellm-max-subscription-invariants.md
+++ b/reference/rfcs/litellm-max-subscription-invariants.md
@@ -112,6 +112,22 @@ places in the `model` field of its API requests, NOT prefixed with `anthropic/`.
 Update this list (and `forward_client_headers_to_llm_api`) whenever the CLI
 ships a new model. The CLI's `/model` picker is the authoritative source.
 
+**Sanctioned drift-aliases (deliberate, live).** The fleet runs a small set of
+`model_aliases` that map a name an *older* CLI still sends on the wire to the
+current live model, so an agent on a lagging CLI build keeps routing instead of
+4xxing on an unknown model. These are intentional and NOT a violation of the
+"names must match" rule above — the alias target is another **Anthropic** model,
+so OAuth forwarding (I1/I2) is unaffected and no credential crosses to a
+non-Anthropic upstream (contrast I6, which bars aliasing a Claude name to a
+non-Anthropic target). Currently sanctioned:
+
+- `claude-opus-4-7` → `claude-opus-4-8`
+- `claude-sonnet-4-6` → `claude-sonnet-5`
+
+Retire a drift-alias once no fleet CLI emits the stale name. Keep both the
+source and the target present in `model_list` with a matching
+`forward_client_headers_to_llm_api` entry while the alias is live.
+
 ---
 
 ## I5 — Virtual key header format is `x-litellm-api-key: Bearer <key>`
@@ -169,18 +185,39 @@ OpenRouter, a credential leak.
 
 ---
 
-## I7 — Fallback to direct OAuth on proxy unreachable (availability invariant)
+## I7 — Availability on proxy trouble is split by cause (fail-open ONLY on a missing key)
 
-**Rule:** `start.sh` MUST fall back to direct Anthropic OAuth (no proxy) when:
-- The virtual key is absent from vault, OR
-- The proxy is unreachable at `$ANTHROPIC_BASE_URL`
+**Rule:** the boot gate (`_LITELLM_OK` / `sr_ll_*` in
+`profiles/_base/start.sh.hbs`, ~1002-1011) handles two failure modes
+DIFFERENTLY. This contract applies to both the interactive session and the
+cron session (`profiles/_base/cron-session.sh.hbs`).
 
-This is the current implementation (the `sr_ll_ok` gate in start.sh). Do NOT
-remove this fallback. It is the availability guarantee that prevents a proxy
-outage from silencing the fleet.
+- **Missing virtual key** (no `litellm/<agent>/api-key` in the vault): **fail
+  open** — strip the routing env and fall back to direct Anthropic OAuth,
+  logged LOUDLY as untracked/unguarded. Without a key there is nothing to
+  authenticate to the proxy with, so there is no metered route to self-heal
+  into.
+- **Proxy unreachable at boot, key present** (the bounded liveliness probe
+  fails within its retry window): **keep routing and warn — do NOT fall
+  open.** Leave `ANTHROPIC_BASE_URL` / `SWITCHROOM_LITELLM*` pointed at the
+  proxy and emit a loud warning. Claude traffic fails+retries until the proxy
+  returns, then routes through it automatically (the socat forwarder at
+  `127.0.0.1:4010` reconnects per-connection). The metered path stays the
+  metered path.
 
-**What the fallback loses:** spend tracking, guardrails, model alias routing,
-per-agent virtual key budget limits. Log line emitted so the operator knows.
+**What fail-open (missing-key case) loses:** spend tracking, guardrails, model
+alias routing, per-agent virtual key budget limits. A log line is emitted so
+the operator knows.
+
+**History — this SUPERSEDES the original "always fail open" rule.** I7 once
+mandated falling back to direct OAuth whenever the proxy was unreachable OR the
+key was absent. That was removed (#2940 / start.sh commit `6106036c`): an agent
+that booted during a brief litellm blip fell open to **silent untracked** direct
+Anthropic and never routed through litellm again until a manual restart — which
+violates the cost-tracking invariant (the observation half of the
+`reference/invariants.md` gateway carve-out). The unreachable-with-key path now
+keeps routing so the fleet self-heals; only a genuinely missing key fails open.
+Do NOT re-introduce the removed blanket fallback.
 
 ---
 

--- a/src/cli/apply-litellm-provision.test.ts
+++ b/src/cli/apply-litellm-provision.test.ts
@@ -30,9 +30,11 @@ vi.mock("../vault/broker/client.js", () => ({
 
 const ensureTeam = vi.fn();
 const ensureKey = vi.fn();
+const validateKey = vi.fn();
 vi.mock("../litellm/provision.js", () => ({
   ensureTeam: (...a: unknown[]) => ensureTeam(...a),
   ensureKey: (...a: unknown[]) => ensureKey(...a),
+  validateKey: (...a: unknown[]) => validateKey(...a),
 }));
 
 function makeConfig(): SwitchroomConfig {
@@ -151,6 +153,153 @@ describe("provisionLiteLLMKeys — broker-unreachable degrades to warning (#2781
     expect(failures).toHaveLength(1);
     expect(failures[0].agent).toBe("clerk");
     expect(failures[0].message).toMatch(/admin_key vault ref .* did not resolve/);
+  });
+});
+
+describe("provisionLiteLLMKeys — stored-key validation against the proxy (DB drift)", () => {
+  let prevPass: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prevPass = process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    process.env.SWITCHROOM_VAULT_PASSPHRASE = "test-passphrase";
+  });
+
+  afterEach(() => {
+    if (prevPass === undefined) delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    else process.env.SWITCHROOM_VAULT_PASSPHRASE = prevPass;
+  });
+
+  it("stored key VALID on the proxy → skip, no re-provision", async () => {
+    getViaBrokerStructured.mockResolvedValue({
+      kind: "ok",
+      entry: { kind: "string", value: "sk-stored" },
+    });
+    validateKey.mockResolvedValue({ kind: "valid" });
+
+    const { ctx, failures, out } = makeSinks();
+    await provisionLiteLLMKeys(makeConfig(), ["clerk"], undefined, ctx);
+
+    expect(failures).toEqual([]);
+    expect(ensureKey).not.toHaveBeenCalled();
+    expect(putViaBroker).not.toHaveBeenCalled();
+    expect(out.join("")).toMatch(/already provisioned \+ validated/);
+  });
+
+  it("stored key UNKNOWN on the proxy (DB drift) → re-provision + rewrite vault", async () => {
+    getViaBrokerStructured.mockResolvedValue({
+      kind: "ok",
+      entry: { kind: "string", value: "sk-stale" },
+    });
+    validateKey.mockResolvedValue({ kind: "unknown" });
+    ensureKey.mockResolvedValue({ key: "sk-fresh" });
+    putViaBroker.mockResolvedValue({ kind: "ok" });
+
+    const { ctx, failures, errs } = makeSinks();
+    await provisionLiteLLMKeys(makeConfig(), ["clerk"], undefined, ctx);
+
+    expect(failures).toEqual([]);
+    expect(ensureKey).toHaveBeenCalledTimes(1);
+    // The fresh key was written back to the vault.
+    expect(putViaBroker).toHaveBeenCalledWith(
+      "litellm/clerk/api-key",
+      { kind: "string", value: "sk-fresh" },
+      expect.objectContaining({ passphrase: "test-passphrase" }),
+    );
+    expect(errs.join("")).toMatch(/not recognized by the proxy \(DB drift\)/);
+  });
+
+  it("proxy UNREACHABLE during validation → keep stored key, warn, never fail (#2781)", async () => {
+    getViaBrokerStructured.mockResolvedValue({
+      kind: "ok",
+      entry: { kind: "string", value: "sk-stored" },
+    });
+    validateKey.mockResolvedValue({ kind: "unreachable", detail: "ECONNREFUSED" });
+
+    const { ctx, failures, errs } = makeSinks();
+    await provisionLiteLLMKeys(makeConfig(), ["clerk"], undefined, ctx);
+
+    expect(failures).toEqual([]);
+    expect(ensureKey).not.toHaveBeenCalled();
+    expect(putViaBroker).not.toHaveBeenCalled();
+    expect(errs.join("")).toMatch(/proxy unreachable during key validation/);
+    expect(errs.join("")).toMatch(/keeping the stored key unverified/);
+  });
+});
+
+describe("provisionLiteLLMKeys — passphrase-less hindsight probe (fix 3)", () => {
+  let prevPass: string | undefined;
+
+  function makeHindsightConfig(): SwitchroomConfig {
+    return {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "123:TEST", forum_chat_id: "-1001" },
+      litellm: {
+        enabled: true,
+        base_url: "http://127.0.0.1:4010",
+        admin_key: "sk-master-test",
+        team: "switchroom",
+      },
+      memory: { backend: "hindsight" },
+      // No litellm-opted agents — isolate the hindsight-service path.
+      agents: {},
+    } as unknown as SwitchroomConfig;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prevPass = process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    // Force the null-passphrase branch.
+    delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+  });
+
+  afterEach(() => {
+    if (prevPass === undefined) delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    else process.env.SWITCHROOM_VAULT_PASSPHRASE = prevPass;
+  });
+
+  it("hindsight key ALREADY provisioned → NO spurious failure (the fix)", async () => {
+    // The probe finds the service key present.
+    getViaBrokerStructured.mockResolvedValue({
+      kind: "ok",
+      entry: { kind: "string", value: "sk-hindsight" },
+    });
+
+    const { ctx, failures, out } = makeSinks();
+    await provisionLiteLLMKeys(makeHindsightConfig(), [], undefined, {
+      ...ctx,
+      home: "/nonexistent-home-for-test",
+    });
+
+    // Pre-fix this pushed a "hindsight (service)" failure on EVERY passphrase-
+    // less apply even though the key was present. It must now be clean.
+    expect(failures).toEqual([]);
+    expect(out.join("")).toMatch(/litellm\/hindsight: key already provisioned/);
+  });
+
+  it("hindsight key genuinely MISSING → still surfaced as a failure", async () => {
+    getViaBrokerStructured.mockResolvedValue({ kind: "not_found" });
+
+    const { ctx, failures } = makeSinks();
+    await provisionLiteLLMKeys(makeHindsightConfig(), [], undefined, {
+      ...ctx,
+      home: "/nonexistent-home-for-test",
+    });
+
+    expect(failures.some((f) => f.agent === "hindsight (service)")).toBe(true);
+  });
+
+  it("hindsight probe UNREACHABLE → degrade to warning, not a failure (#2781 parity)", async () => {
+    getViaBrokerStructured.mockResolvedValue({ kind: "unreachable", msg: "no broker socket" });
+
+    const { ctx, failures, errs } = makeSinks();
+    await provisionLiteLLMKeys(makeHindsightConfig(), [], undefined, {
+      ...ctx,
+      home: "/nonexistent-home-for-test",
+    });
+
+    expect(failures).toEqual([]);
+    expect(errs.join("")).toMatch(/litellm\/hindsight: vault-broker unreachable/);
   });
 });
 

--- a/src/cli/apply.test.ts
+++ b/src/cli/apply.test.ts
@@ -104,7 +104,15 @@ describe("runApply", () => {
       vault: { path: fakeVault },
       telegram: { bot_token: "vault:telegram_bot_token" },
     } as unknown as SwitchroomConfig;
-    expect(() => runApplyPreflight(cfg)).toThrow(/vault/i);
+    // SKIP_COMPOSE_PREFLIGHT: this test pins the VAULT-missing throw, but
+    // runApplyPreflight computes the compose check first (the in-agent-
+    // container redirect needs both signals) — without the dep-injection
+    // seam this was the only test in the suite spawning a REAL unbounded
+    // `docker compose version` subprocess, which flaked past the 5s test
+    // budget on loaded CI runners (PR #2980 shard timeout). Real docker
+    // detection stays covered by the dedicated "compose v2 preflight"
+    // tests below (deterministic: stubbed error / emptied PATH).
+    expect(() => runApplyPreflight(cfg, SKIP_COMPOSE_PREFLIGHT)).toThrow(/vault/i);
   });
 
   describe("UID alignment failure handling", () => {

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -295,7 +295,7 @@ export async function provisionLiteLLMKeys(
   if (optedIn.length === 0 && !needsHindsight) return; // zero-impact when the feature is off
 
   // Lazy imports — only paid for when at least one agent opts in or hindsight is wired.
-  const [{ getViaBrokerStructured, putViaBroker }, { ensureTeam, ensureKey }, { addAgentSecret }] =
+  const [{ getViaBrokerStructured, putViaBroker }, { ensureTeam, ensureKey, validateKey }, { addAgentSecret }] =
     await Promise.all([
       import("../vault/broker/client.js"),
       import("../litellm/provision.js"),
@@ -347,9 +347,36 @@ export async function provisionLiteLLMKeys(
         unprovisionedNew.push(name);
       }
     }
-    // The hindsight service key can't be probed the same idempotent way here;
-    // treat it as needing provisioning (surfaced) when the feature wants it.
-    const hindsightPending = needsHindsight;
+    // The hindsight service key uses the SAME idempotent broker probe as the
+    // per-agent keys (getViaBrokerStructured is a read — no passphrase needed),
+    // identical to the provisioning path at the bottom of this function
+    // (litellm/hindsight/api-key). Probe it before declaring it pending, so a
+    // fully-provisioned system stops pushing a spurious failures[] entry on
+    // every passphrase-less apply/reconcile. `ok` → already provisioned;
+    // `unreachable` → degrade (can't verify, don't fail — parity with the
+    // agent unreachable path, #2781); `not_found`/`denied` → genuinely pending.
+    let hindsightPending = false;
+    if (needsHindsight) {
+      const h = await getViaBrokerStructured("litellm/hindsight/api-key");
+      if (h.kind === "ok") {
+        hindsightPending = false;
+        writeOut(
+          chalk.gray(
+            `  ~ litellm/hindsight: key already provisioned (skipped) — unaffected by missing passphrase.\n`,
+          ),
+        );
+      } else if (h.kind === "unreachable") {
+        hindsightPending = false;
+        ctx.writeErr(
+          chalk.yellow(
+            `  ! litellm/hindsight: vault-broker unreachable — could not verify the ` +
+            `service key; it keeps its previous state.\n`,
+          ),
+        );
+      } else {
+        hindsightPending = true;
+      }
+    }
 
     if (alreadyProvisioned.length > 0) {
       writeOut(
@@ -455,21 +482,9 @@ export async function provisionLiteLLMKeys(
       }
 
       const vaultKey = `litellm/${name}/api-key`;
+      const alias = `agent:${name}`;
 
-      // Idempotency: skip if the vault already holds the key.
       const existing = await getViaBrokerStructured(vaultKey);
-      if (existing.kind === "ok") {
-        writeOut(chalk.gray(`  ~ litellm/${name}: key already provisioned (skipped)\n`));
-        // Still ensure the read-ACL is granted (cheap, idempotent).
-        if (configText !== null) {
-          const after = addAgentSecret(configText, name, vaultKey);
-          if (after !== configText) {
-            configText = after;
-            pendingConfigEdits = true;
-          }
-        }
-        continue;
-      }
       if (existing.kind === "unreachable") {
         // #2781: an unreachable broker is an ENVIRONMENT limitation, not a
         // provisioning error — hostd's in-container `switchroom apply` has no
@@ -490,28 +505,89 @@ export async function provisionLiteLLMKeys(
         continue;
       }
 
-      // Resolve a `vault:` admin_key via the auto-unlocked broker.
-      let masterKey = adminKeyRef;
+      // Resolve a `vault:` admin_key via the auto-unlocked broker. Failure is
+      // only FATAL on the provisioning path below — an already-provisioned agent
+      // whose admin_key ref is momentarily unresolvable keeps its key (validation
+      // is skipped), it is NOT reported as a scaffold failure.
+      let masterKey: string | null = adminKeyRef;
+      let masterKeyErr: string | null = null;
       if (isVaultReference(adminKeyRef)) {
         const refKey = parseVaultReference(adminKeyRef);
         const resolved = await getViaBrokerStructured(refKey);
         if (resolved.kind !== "ok") {
-          failures.push({
-            agent: name,
-            message:
-              `litellm: admin_key vault ref '${adminKeyRef}' did not resolve ` +
-              `(${resolved.kind}${"msg" in resolved && resolved.msg ? `: ${resolved.msg}` : ""}).`,
-          });
+          masterKey = null;
+          masterKeyErr =
+            `litellm: admin_key vault ref '${adminKeyRef}' did not resolve ` +
+            `(${resolved.kind}${"msg" in resolved && resolved.msg ? `: ${resolved.msg}` : ""}).`;
+        } else if (resolved.entry.kind !== "string") {
+          masterKey = null;
+          masterKeyErr = `litellm: admin_key vault ref '${adminKeyRef}' is not a string secret.`;
+        } else {
+          masterKey = resolved.entry.value;
+        }
+      }
+
+      // Idempotency + DB-drift validation (fix): the vault already holds a key.
+      // Pre-fix this ALWAYS skipped, blind to the proxy's own state — so a proxy
+      // DB reset/restore (without the vault) left every agent 401ing forever.
+      // Now: when we have the admin key in hand AND the proxy is reachable,
+      // validate the stored key via GET /key/info; an unknown key means DB drift
+      // and we re-provision through the same self-healing ensureKey path.
+      if (existing.kind === "ok") {
+        const storedKey = existing.entry.kind === "string" ? existing.entry.value : null;
+        let driftReprovision = false;
+        if (storedKey && masterKey) {
+          const validation = await validateKey({ baseUrl, masterKey, key: storedKey });
+          if (validation.kind === "unknown") {
+            // Proxy reachable but the key is NOT recognized (DB drift). Fall
+            // through to re-provision (ensureKey self-heals the orphaned alias)
+            // and overwrite the stale vault key.
+            driftReprovision = true;
+            ctx.writeErr(
+              chalk.yellow(
+                `  ! litellm/${name}: stored virtual key not recognized by the proxy ` +
+                `(DB drift) — re-provisioning a fresh key.\n`,
+              ),
+            );
+          } else if (validation.kind === "unreachable") {
+            // Availability-safe (#2781): an unreachable/ambiguous proxy never
+            // fails the apply — keep the stored key, warn, and move on.
+            ctx.writeErr(
+              chalk.yellow(
+                `  ! litellm/${name}: proxy unreachable during key validation ` +
+                `(${validation.detail}) — keeping the stored key unverified.\n`,
+              ),
+            );
+          } else {
+            writeOut(chalk.gray(`  ~ litellm/${name}: key already provisioned + validated (skipped)\n`));
+          }
+        } else {
+          // Can't validate (no admin key in hand, or a non-string entry) — keep
+          // the pre-fix idempotent skip. Do NOT surface masterKeyErr here: an
+          // already-provisioned agent stays good even if its admin_key ref is
+          // momentarily unresolvable.
+          writeOut(chalk.gray(`  ~ litellm/${name}: key already provisioned (skipped)\n`));
+        }
+
+        if (!driftReprovision) {
+          // Still ensure the read-ACL is granted (cheap, idempotent).
+          if (configText !== null) {
+            const after = addAgentSecret(configText, name, vaultKey);
+            if (after !== configText) {
+              configText = after;
+              pendingConfigEdits = true;
+            }
+          }
           continue;
         }
-        if (resolved.entry.kind !== "string") {
-          failures.push({
-            agent: name,
-            message: `litellm: admin_key vault ref '${adminKeyRef}' is not a string secret.`,
-          });
-          continue;
-        }
-        masterKey = resolved.entry.value;
+        // driftReprovision → fall through to the provisioning block below.
+      }
+
+      // Provisioning path (genuinely-new agent OR DB-drift re-provision). The
+      // admin key MUST resolve here.
+      if (!masterKey) {
+        failures.push({ agent: name, message: masterKeyErr ?? `litellm: admin_key unresolved` });
+        continue;
       }
 
       // Provision: ensure team, then generate the per-agent key.
@@ -530,9 +606,12 @@ export async function provisionLiteLLMKeys(
       const { key } = await ensureKey({
         baseUrl,
         masterKey,
-        alias: `agent:${name}`,
+        alias,
         team,
         metadata,
+        // Surface the orphaned-alias self-heal steps (delete + regenerate) so the
+        // operator sees the recovery instead of a silent extra round-trip.
+        log: (m) => ctx.writeErr(chalk.gray(`  ~ litellm/${name}: ${m}\n`)),
       });
 
       // Store the key in the vault via the broker WITH operator-passphrase
@@ -623,6 +702,7 @@ export async function provisionLiteLLMKeys(
             alias: "service:hindsight",
             team,
             metadata: { service: "hindsight", env: "fleet", ...(oauthAccount ? { oauth_account: oauthAccount } : {}) },
+            log: (m) => ctx.writeErr(chalk.gray(`  ~ litellm/hindsight: ${m}\n`)),
           });
           const put = await putViaBroker(
             hindsightVaultKey,

--- a/src/litellm/provision-apply-e2e.test.ts
+++ b/src/litellm/provision-apply-e2e.test.ts
@@ -122,10 +122,24 @@ describe("provisionLiteLLMKeys — real broker e2e (blocker-1 seam)", () => {
       if (u.endsWith("/team/new")) {
         return new Response(JSON.stringify({ team_id: "t1" }), { status: 200 });
       }
-      if (u.endsWith("/key/generate")) {
+      if (u.includes("/key/generate")) {
         return new Response(JSON.stringify({ key: "sk-virtual-clerk-xyz" }), {
           status: 200,
         });
+      }
+      // Fix-2 validation probe: any stored key we might validate is "valid".
+      if (u.includes("/key/info")) {
+        return new Response(JSON.stringify({ key: "sk-virtual-clerk-xyz", info: {} }), {
+          status: 200,
+        });
+      }
+      // Fix-1 orphaned-alias self-heal helpers (not exercised on the clean
+      // generate path here, but kept coherent so an accidental hit succeeds).
+      if (u.includes("/key/list")) {
+        return new Response(JSON.stringify({ keys: [] }), { status: 200 });
+      }
+      if (u.includes("/key/delete")) {
+        return new Response(JSON.stringify({}), { status: 200 });
       }
       return new Response("not found", { status: 404 });
     }) as unknown as typeof fetch;

--- a/src/litellm/provision.test.ts
+++ b/src/litellm/provision.test.ts
@@ -362,10 +362,29 @@ describe("validateKey", () => {
     expect((r as { detail: string }).detail).toMatch(/ECONNREFUSED/);
   });
 
-  it("treats a 401 (bad master key) as unreachable, NOT unknown (no destructive re-provision)", async () => {
+  it("returns unknown on a 401 with a clear not-found semantic (auth-path drift shape)", async () => {
+    // Some LiteLLM auth-path shapes report an unknown virtual key as a 401
+    // "Authentication Error: Key not found" — that IS drift, not a bad master
+    // key, so it must trigger re-provisioning.
+    const fetchFn: FetchFn = async () =>
+      mockResponse({ ok: false, status: 401, text: "Authentication Error: Key not found in DB" });
+    const r = await validateKey({ baseUrl: "http://h", masterKey: "m", key: "sk-gone" }, fetchFn);
+    expect(r).toEqual({ kind: "unknown" });
+  });
+
+  it("treats a BARE 401 (bad master key, no not-found semantic) as unreachable, NOT unknown", async () => {
     const fetchFn: FetchFn = async () =>
       mockResponse({ ok: false, status: 401, text: "Authentication Error: invalid master key" });
     const r = await validateKey({ baseUrl: "http://h", masterKey: "bad", key: "sk-x" }, fetchFn);
+    expect(r.kind).toBe("unreachable");
+  });
+
+  it("treats a non-drift 400 'invalid' body as unreachable (no unnecessary key churn)", async () => {
+    // "invalid" alone is NOT a drift signal — a malformed-request 400 must not
+    // trigger a destructive re-provision.
+    const fetchFn: FetchFn = async () =>
+      mockResponse({ ok: false, status: 400, text: "invalid request: bad key format" });
+    const r = await validateKey({ baseUrl: "http://h", masterKey: "m", key: "sk-x" }, fetchFn);
     expect(r.kind).toBe("unreachable");
   });
 

--- a/src/litellm/provision.test.ts
+++ b/src/litellm/provision.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   ensureTeam,
   ensureKey,
+  validateKey,
   LiteLLMProvisionError,
   type FetchFn,
 } from "./provision.js";
@@ -161,5 +162,217 @@ describe("ensureKey", () => {
     await expect(
       ensureKey({ baseUrl: "http://h", masterKey: "m", alias: "a" }, fetchFn),
     ).rejects.toThrow(/socket hang up/);
+  });
+});
+
+/**
+ * Orphaned-alias self-heal: LiteLLM enforces unique key aliases (upstream
+ * #9730). If a prior apply generated `agent:<name>` but crashed before the
+ * vault write, the alias lives in LiteLLM with no recoverable key and every
+ * later /key/generate hard-fails with 400 "already exists". ensureKey must
+ * recover by deleting the orphan and regenerating.
+ */
+describe("ensureKey — orphaned-alias self-heal", () => {
+  interface Call {
+    method: string;
+    url: string;
+    body: Record<string, unknown> | null;
+  }
+
+  /** A URL/method router that also records every call for assertions. */
+  function makeRouter(
+    handlers: {
+      generate: () => ReturnType<typeof mockResponse>;
+      list?: () => ReturnType<typeof mockResponse>;
+      delete?: () => ReturnType<typeof mockResponse>;
+    },
+    calls: Call[],
+  ): FetchFn {
+    return async (url, init) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : null;
+      calls.push({ method, url: u, body });
+      if (u.includes("/key/generate")) return handlers.generate();
+      if (u.includes("/key/list")) return (handlers.list ?? (() => mockResponse({ ok: true, status: 200, json: { keys: [] } })))();
+      if (u.includes("/key/delete")) return (handlers.delete ?? (() => mockResponse({ ok: true, status: 200, json: {} })))();
+      return mockResponse({ ok: false, status: 404, text: "not found" });
+    };
+  }
+
+  it("clean generate: one POST, no delete round-trip", async () => {
+    const calls: Call[] = [];
+    const fetchFn = makeRouter(
+      { generate: () => mockResponse({ ok: true, status: 200, json: { key: "sk-clean" } }) },
+      calls,
+    );
+    const result = await ensureKey(
+      { baseUrl: "http://h", masterKey: "m", alias: "agent:clerk", team: "switchroom" },
+      fetchFn,
+    );
+    expect(result).toEqual({ key: "sk-clean" });
+    // Exactly one call — no /key/list or /key/delete on the happy path.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toContain("/key/generate");
+  });
+
+  it("recovers a duplicate alias: delete the orphan (by token + alias), then regenerate", async () => {
+    const calls: Call[] = [];
+    let generateCount = 0;
+    const logs: string[] = [];
+    const fetchFn = makeRouter(
+      {
+        generate: () => {
+          generateCount += 1;
+          if (generateCount === 1) {
+            return mockResponse({
+              ok: false,
+              status: 400,
+              text: "Key with alias agent:clerk already exists in DB",
+            });
+          }
+          return mockResponse({ ok: true, status: 200, json: { key: "sk-fresh" } });
+        },
+        list: () =>
+          mockResponse({
+            ok: true,
+            status: 200,
+            json: { keys: [{ token: "hashed-orphan-token", key_alias: "agent:clerk" }] },
+          }),
+        delete: () => mockResponse({ ok: true, status: 200, json: {} }),
+      },
+      calls,
+    );
+
+    const result = await ensureKey(
+      { baseUrl: "http://h", masterKey: "m", alias: "agent:clerk", team: "switchroom", log: (m) => logs.push(m) },
+      fetchFn,
+    );
+
+    expect(result).toEqual({ key: "sk-fresh" });
+    // Call sequence: generate(400) → list → delete → generate(200).
+    const seq = calls.map((c) => `${c.method} ${c.url.split("?")[0]!.replace("http://h", "")}`);
+    expect(seq).toEqual([
+      "POST /key/generate",
+      "GET /key/list",
+      "POST /key/delete",
+      "POST /key/generate",
+    ]);
+    // The delete carries BOTH the resolved token and the alias (belt + braces).
+    const del = calls.find((c) => c.url.includes("/key/delete"))!;
+    expect(del.body).toEqual({
+      key_aliases: ["agent:clerk"],
+      keys: ["hashed-orphan-token"],
+    });
+    // It logged the self-heal.
+    expect(logs.join("\n")).toMatch(/orphaned|self-healing|already exists/i);
+  });
+
+  it("recovers even when /key/list resolves no token (deletes by alias only)", async () => {
+    const calls: Call[] = [];
+    let generateCount = 0;
+    const fetchFn = makeRouter(
+      {
+        generate: () => {
+          generateCount += 1;
+          return generateCount === 1
+            ? mockResponse({ ok: false, status: 400, text: "key alias already exists" })
+            : mockResponse({ ok: true, status: 200, json: { key: "sk-by-alias" } });
+        },
+        list: () => mockResponse({ ok: true, status: 200, json: { keys: [] } }),
+        delete: () => mockResponse({ ok: true, status: 200, json: {} }),
+      },
+      calls,
+    );
+    const result = await ensureKey(
+      { baseUrl: "http://h", masterKey: "m", alias: "agent:bob" },
+      fetchFn,
+    );
+    expect(result).toEqual({ key: "sk-by-alias" });
+    const del = calls.find((c) => c.url.includes("/key/delete"))!;
+    // No `keys` field when the list resolved nothing — alias-only delete.
+    expect(del.body).toEqual({ key_aliases: ["agent:bob"] });
+  });
+
+  it("delete FAILS: surfaces a clear error naming the manual remediation", async () => {
+    const calls: Call[] = [];
+    const fetchFn = makeRouter(
+      {
+        generate: () => mockResponse({ ok: false, status: 400, text: "alias already exists" }),
+        list: () => mockResponse({ ok: true, status: 200, json: { keys: [] } }),
+        delete: () => mockResponse({ ok: false, status: 500, text: "internal error" }),
+      },
+      calls,
+    );
+    try {
+      await ensureKey({ baseUrl: "http://h", masterKey: "m", alias: "agent:zoe" }, fetchFn);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LiteLLMProvisionError);
+      const msg = (err as LiteLLMProvisionError).message;
+      expect(msg).toMatch(/key\/delete/);
+      expect(msg).toMatch(/Manual remediation/);
+      expect(msg).toMatch(/key_aliases.*agent:zoe/);
+    }
+    // We never got to the second generate.
+    expect(calls.filter((c) => c.url.includes("/key/generate"))).toHaveLength(1);
+  });
+
+  it("second generate STILL duplicate after delete: distinct error naming remediation", async () => {
+    const calls: Call[] = [];
+    const fetchFn = makeRouter(
+      {
+        generate: () => mockResponse({ ok: false, status: 400, text: "alias already exists" }),
+        list: () => mockResponse({ ok: true, status: 200, json: { keys: [] } }),
+        delete: () => mockResponse({ ok: true, status: 200, json: {} }),
+      },
+      calls,
+    );
+    await expect(
+      ensureKey({ baseUrl: "http://h", masterKey: "m", alias: "agent:kay" }, fetchFn),
+    ).rejects.toThrow(/still reports alias .* already exists after deleting/);
+  });
+});
+
+describe("validateKey", () => {
+  it("returns valid on a 200 from /key/info", async () => {
+    const calls: string[] = [];
+    const fetchFn: FetchFn = async (url) => {
+      calls.push(String(url));
+      return mockResponse({ ok: true, status: 200, json: { key: "sk-x", info: {} } });
+    };
+    const r = await validateKey({ baseUrl: "http://h", masterKey: "m", key: "sk-x" }, fetchFn);
+    expect(r).toEqual({ kind: "valid" });
+    expect(calls[0]).toContain("/key/info?key=sk-x");
+  });
+
+  it("returns unknown on a 400 'not found' (DB drift)", async () => {
+    const fetchFn: FetchFn = async () =>
+      mockResponse({ ok: false, status: 400, text: "Authentication Error: Key not found in DB" });
+    const r = await validateKey({ baseUrl: "http://h", masterKey: "m", key: "sk-gone" }, fetchFn);
+    expect(r).toEqual({ kind: "unknown" });
+  });
+
+  it("returns unreachable on a network error (never re-provisions)", async () => {
+    const fetchFn: FetchFn = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+    const r = await validateKey({ baseUrl: "http://h", masterKey: "m", key: "sk-x" }, fetchFn);
+    expect(r.kind).toBe("unreachable");
+    expect((r as { detail: string }).detail).toMatch(/ECONNREFUSED/);
+  });
+
+  it("treats a 401 (bad master key) as unreachable, NOT unknown (no destructive re-provision)", async () => {
+    const fetchFn: FetchFn = async () =>
+      mockResponse({ ok: false, status: 401, text: "Authentication Error: invalid master key" });
+    const r = await validateKey({ baseUrl: "http://h", masterKey: "bad", key: "sk-x" }, fetchFn);
+    expect(r.kind).toBe("unreachable");
+  });
+
+  it("treats a 500 as unreachable, NOT unknown", async () => {
+    const fetchFn: FetchFn = async () =>
+      mockResponse({ ok: false, status: 500, text: "internal server error" });
+    const r = await validateKey({ baseUrl: "http://h", masterKey: "m", key: "sk-x" }, fetchFn);
+    expect(r.kind).toBe("unreachable");
   });
 });

--- a/src/litellm/provision.ts
+++ b/src/litellm/provision.ts
@@ -7,13 +7,21 @@
  * owns secret storage + ACL grants. Keeping this module side-effect-free
  * makes it unit-testable with a mocked `fetchFn`.
  *
- * The two operations:
+ * The operations:
  *   - ensureTeam: create the "switchroom" LiteLLM team (idempotent — an
  *     "already exists" response is treated as success).
- *   - ensureKey: generate a per-agent virtual key under the team.
+ *   - ensureKey: generate a per-agent virtual key under the team. Self-heals an
+ *     ORPHANED key alias: LiteLLM enforces unique key aliases (upstream
+ *     issue #9730), so if a prior apply generated the alias but crashed before
+ *     the vault write landed, the alias lives in LiteLLM with no recoverable key
+ *     — every later /key/generate then hard-fails with 400 "Key with alias ...
+ *     already exists". ensureKey recovers by deleting the orphan and regenerating.
+ *   - validateKey: probe a stored virtual key against the proxy (GET /key/info)
+ *     to detect DB drift (proxy DB reset / restore without the vault).
  *
- * LiteLLM admin API reference: POST {base}/team/new, POST {base}/key/generate,
- * authenticated with the master key as a Bearer token.
+ * LiteLLM admin API reference (v1.91 shapes): POST {base}/team/new,
+ * POST {base}/key/generate, GET {base}/key/info?key=..., GET {base}/key/list,
+ * POST {base}/key/delete — authenticated with the master key as a Bearer token.
  */
 
 /**
@@ -55,6 +63,11 @@ export interface EnsureKeyOpts {
   team?: string;
   /** Arbitrary metadata tags attached to the key. */
   metadata?: Record<string, string>;
+  /**
+   * Optional structured logger for the orphaned-alias self-heal path (delete +
+   * regenerate). Defaults to a no-op — the module stays quiet on the happy path.
+   */
+  log?: (msg: string) => void;
 }
 
 /** Normalize a base URL by stripping a trailing slash so path joins are clean. */
@@ -81,6 +94,26 @@ function looksLikeAlreadyExists(status: number, body: string): boolean {
   // Some versions surface a duplicate-team conflict as 409.
   if (status === 409) return true;
   return false;
+}
+
+/**
+ * Heuristic: does a /key/info error response mean "the proxy does not recognize
+ * this virtual key" (DB drift) — as opposed to a bad master key or a transient
+ * server error? Only a clear not-found on a 400/404 counts, so we never
+ * destructively re-provision on an ambiguous failure (a 401/403 from a bad
+ * master key, a 5xx blip). LiteLLM surfaces an unknown key as a 400 whose body
+ * mentions the key was not found / is invalid.
+ */
+function looksLikeUnknownKey(status: number, body: string): boolean {
+  if (status !== 400 && status !== 404) return false;
+  const t = body.toLowerCase();
+  return (
+    t.includes("not found") ||
+    t.includes("does not exist") ||
+    t.includes("no such key") ||
+    t.includes("no key found") ||
+    t.includes("invalid")
+  );
 }
 
 /**
@@ -116,12 +149,14 @@ export async function ensureTeam(
   );
 }
 
-/**
- * Generate a per-agent virtual key under the given team. Returns the new
- * key string. Idempotency is the caller's responsibility (it checks the
- * vault first) — this always asks LiteLLM to generate a key.
- */
-export async function ensureKey(opts: EnsureKeyOpts, fetchFn: FetchFn = fetch): Promise<EnsureKeyResult> {
+/** Internal outcome of a single /key/generate POST. */
+type GenerateOutcome =
+  | { kind: "ok"; key: string }
+  | { kind: "duplicate-alias"; status: number; body: string }
+  | { kind: "error"; error: LiteLLMProvisionError };
+
+/** Perform one /key/generate POST and classify the result. */
+async function generateKeyOnce(opts: EnsureKeyOpts, fetchFn: FetchFn): Promise<GenerateOutcome> {
   const url = `${normalizeBase(opts.baseUrl)}/key/generate`;
   const payload: Record<string, unknown> = {
     key_alias: opts.alias,
@@ -140,38 +175,244 @@ export async function ensureKey(opts: EnsureKeyOpts, fetchFn: FetchFn = fetch): 
       body: JSON.stringify(payload),
     });
   } catch (err) {
-    throw new LiteLLMProvisionError(
-      `LiteLLM /key/generate request failed: ${(err as Error).message}`,
-    );
+    return {
+      kind: "error",
+      error: new LiteLLMProvisionError(
+        `LiteLLM /key/generate request failed: ${(err as Error).message}`,
+      ),
+    };
   }
   if (!resp.ok) {
     const body = await safeText(resp);
-    throw new LiteLLMProvisionError(
-      `LiteLLM /key/generate returned ${resp.status}`,
-      resp.status,
-      body,
-    );
+    // A duplicate key alias is recoverable (orphaned-alias self-heal) — signal
+    // it distinctly rather than as a generic error.
+    if (looksLikeAlreadyExists(resp.status, body)) {
+      return { kind: "duplicate-alias", status: resp.status, body };
+    }
+    return {
+      kind: "error",
+      error: new LiteLLMProvisionError(
+        `LiteLLM /key/generate returned ${resp.status}`,
+        resp.status,
+        body,
+      ),
+    };
   }
 
   let json: unknown;
   try {
     json = await resp.json();
   } catch (err) {
-    throw new LiteLLMProvisionError(
-      `LiteLLM /key/generate returned non-JSON body: ${(err as Error).message}`,
-      resp.status,
-    );
+    return {
+      kind: "error",
+      error: new LiteLLMProvisionError(
+        `LiteLLM /key/generate returned non-JSON body: ${(err as Error).message}`,
+        resp.status,
+      ),
+    };
   }
 
   const key = (json as { key?: unknown } | null)?.key;
   if (typeof key !== "string" || key.length === 0) {
+    return {
+      kind: "error",
+      error: new LiteLLMProvisionError(
+        `LiteLLM /key/generate response missing a "key" field`,
+        resp.status,
+        JSON.stringify(json),
+      ),
+    };
+  }
+  return { kind: "ok", key };
+}
+
+/**
+ * Resolve the hashed token(s) LiteLLM stores for a given key_alias, best-effort.
+ * Used only to enrich the /key/delete during orphaned-alias recovery — the
+ * delete also passes `key_aliases`, so an empty result here is non-fatal.
+ *
+ * GET /key/list?key_alias=<alias>&return_full_object=true returns
+ * `{ keys: [ { token, key_alias, ... } | "<token>" ], ... }` across v1.91 shapes.
+ */
+async function resolveTokensForAlias(
+  baseUrl: string,
+  masterKey: string,
+  alias: string,
+  fetchFn: FetchFn,
+): Promise<string[]> {
+  const url =
+    `${normalizeBase(baseUrl)}/key/list?key_alias=${encodeURIComponent(alias)}` +
+    `&return_full_object=true&include_team_keys=true`;
+  let resp: Response;
+  try {
+    resp = await fetchFn(url, { method: "GET", headers: authHeaders(masterKey) });
+  } catch {
+    return [];
+  }
+  if (!resp.ok) return [];
+  let json: unknown;
+  try {
+    json = await resp.json();
+  } catch {
+    return [];
+  }
+  const keys = (json as { keys?: unknown } | null)?.keys;
+  if (!Array.isArray(keys)) return [];
+  const tokens: string[] = [];
+  for (const k of keys) {
+    if (typeof k === "string" && k.length > 0) tokens.push(k);
+    else if (k && typeof k === "object") {
+      const tok = (k as { token?: unknown; key?: unknown }).token;
+      const raw = (k as { token?: unknown; key?: unknown }).key;
+      if (typeof tok === "string" && tok.length > 0) tokens.push(tok);
+      else if (typeof raw === "string" && raw.length > 0) tokens.push(raw);
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Delete the orphaned key(s) for a given alias so a fresh key can be generated.
+ * Deletes by `key_aliases` (unambiguous — LiteLLM matches the alias directly)
+ * and, when resolvable, also by the hashed `keys` tokens for good measure.
+ * Throws a LiteLLMProvisionError naming the MANUAL remediation on failure.
+ */
+async function deleteOrphanedAlias(
+  opts: EnsureKeyOpts,
+  fetchFn: FetchFn,
+  log: (msg: string) => void,
+): Promise<void> {
+  const tokens = await resolveTokensForAlias(opts.baseUrl, opts.masterKey, opts.alias, fetchFn);
+  const body: Record<string, unknown> = { key_aliases: [opts.alias] };
+  if (tokens.length > 0) body.keys = tokens;
+
+  const manual =
+    `Manual remediation: delete the key with alias '${opts.alias}' in the LiteLLM ` +
+    `admin UI, or run ` +
+    `\`curl -X POST "${normalizeBase(opts.baseUrl)}/key/delete" -H "Authorization: Bearer <master-key>" ` +
+    `-H "content-type: application/json" -d '{"key_aliases":["${opts.alias}"]}'\`, ` +
+    `then re-run \`switchroom apply\`.`;
+
+  const url = `${normalizeBase(opts.baseUrl)}/key/delete`;
+  let resp: Response;
+  try {
+    resp = await fetchFn(url, {
+      method: "POST",
+      headers: authHeaders(opts.masterKey),
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
     throw new LiteLLMProvisionError(
-      `LiteLLM /key/generate response missing a "key" field`,
-      resp.status,
-      JSON.stringify(json),
+      `LiteLLM /key/delete request failed while recovering orphaned alias ` +
+        `'${opts.alias}': ${(err as Error).message}. ${manual}`,
     );
   }
-  return { key };
+  if (!resp.ok) {
+    const errBody = await safeText(resp);
+    throw new LiteLLMProvisionError(
+      `LiteLLM /key/delete returned ${resp.status} while recovering orphaned ` +
+        `alias '${opts.alias}'. ${manual}`,
+      resp.status,
+      errBody,
+    );
+  }
+  log(
+    `litellm: deleted orphaned key(s) for alias '${opts.alias}'` +
+      (tokens.length > 0 ? ` (${tokens.length} token(s) resolved)` : "") +
+      ` — regenerating`,
+  );
+}
+
+/**
+ * Generate a per-agent virtual key under the given team. Returns the new
+ * key string. Idempotency at the vault level is the caller's responsibility
+ * (it checks the vault first) — this always asks LiteLLM to generate a key.
+ *
+ * Self-heals an ORPHANED alias: if /key/generate reports the alias already
+ * exists (the vault lost the previously-generated key), the orphan is deleted
+ * and generation retried once. A second duplicate report, or a failed delete,
+ * throws a LiteLLMProvisionError naming the manual remediation.
+ */
+export async function ensureKey(opts: EnsureKeyOpts, fetchFn: FetchFn = fetch): Promise<EnsureKeyResult> {
+  const log = opts.log ?? (() => {});
+
+  const first = await generateKeyOnce(opts, fetchFn);
+  if (first.kind === "ok") return { key: first.key };
+  if (first.kind === "error") throw first.error;
+
+  // first.kind === "duplicate-alias": recover the orphan and regenerate once.
+  log(
+    `litellm: key_alias '${opts.alias}' already exists in LiteLLM but the vault ` +
+      `has no recoverable key (orphaned by a prior failed provision) — ` +
+      `self-healing: deleting the orphan and regenerating`,
+  );
+  await deleteOrphanedAlias(opts, fetchFn, log);
+
+  const second = await generateKeyOnce(opts, fetchFn);
+  if (second.kind === "ok") {
+    log(`litellm: regenerated key for alias '${opts.alias}' after orphan recovery`);
+    return { key: second.key };
+  }
+  if (second.kind === "duplicate-alias") {
+    throw new LiteLLMProvisionError(
+      `LiteLLM /key/generate still reports alias '${opts.alias}' already exists ` +
+        `after deleting the orphan — the delete did not take effect. Manual ` +
+        `remediation: remove the key with alias '${opts.alias}' via the LiteLLM ` +
+        `admin UI (or POST /key/delete {"key_aliases":["${opts.alias}"]}) then ` +
+        `re-run \`switchroom apply\`.`,
+      second.status,
+      second.body,
+    );
+  }
+  throw second.error;
+}
+
+/** Options for `validateKey`. */
+export interface ValidateKeyOpts {
+  baseUrl: string;
+  masterKey: string;
+  /** The stored virtual key string to probe. */
+  key: string;
+}
+
+/**
+ * Outcome of validating a stored virtual key against the proxy:
+ *   - `valid`: the proxy recognizes the key — nothing to do.
+ *   - `unknown`: the proxy is reachable but does NOT recognize the key (DB
+ *     drift) — the caller should re-provision.
+ *   - `unreachable`: could not verify (network error, bad master key, 5xx) —
+ *     the caller should SKIP validation with a warning and keep the stored key.
+ *       Never triggers a destructive re-provision.
+ */
+export type ValidateKeyResult =
+  | { kind: "valid" }
+  | { kind: "unknown" }
+  | { kind: "unreachable"; detail: string };
+
+/**
+ * Probe a stored virtual key against the proxy via GET /key/info. Used by the
+ * apply path to detect DB drift (proxy DB reset/restored without the vault) so
+ * a stale vault key can be re-provisioned instead of silently 401ing every
+ * agent request. Availability-safe: any ambiguous failure degrades to
+ * `unreachable` (skip), never to a destructive re-provision.
+ */
+export async function validateKey(
+  opts: ValidateKeyOpts,
+  fetchFn: FetchFn = fetch,
+): Promise<ValidateKeyResult> {
+  const url = `${normalizeBase(opts.baseUrl)}/key/info?key=${encodeURIComponent(opts.key)}`;
+  let resp: Response;
+  try {
+    resp = await fetchFn(url, { method: "GET", headers: authHeaders(opts.masterKey) });
+  } catch (err) {
+    return { kind: "unreachable", detail: (err as Error).message };
+  }
+  if (resp.ok) return { kind: "valid" };
+  const body = await safeText(resp);
+  if (looksLikeUnknownKey(resp.status, body)) return { kind: "unknown" };
+  // 401/403 (bad master key), 5xx, or any other ambiguous error — do NOT
+  // re-provision; keep the stored key and let the caller warn.
+  return { kind: "unreachable", detail: `HTTP ${resp.status}: ${body.slice(0, 200)}` };
 }
 
 /** Read a Response body as text, swallowing any read error (best-effort

--- a/src/litellm/provision.ts
+++ b/src/litellm/provision.ts
@@ -99,20 +99,22 @@ function looksLikeAlreadyExists(status: number, body: string): boolean {
 /**
  * Heuristic: does a /key/info error response mean "the proxy does not recognize
  * this virtual key" (DB drift) — as opposed to a bad master key or a transient
- * server error? Only a clear not-found on a 400/404 counts, so we never
- * destructively re-provision on an ambiguous failure (a 401/403 from a bad
- * master key, a 5xx blip). LiteLLM surfaces an unknown key as a 400 whose body
- * mentions the key was not found / is invalid.
+ * server error? Only a clear not-found semantic counts, so we never
+ * destructively re-provision on an ambiguous failure (a bare 401/403 from a
+ * bad master key, a 5xx blip, a non-drift 400). LiteLLM has surfaced an
+ * unknown key as a 400 "not found in DB" across versions, and its auth path
+ * can report it as a 401 "Authentication Error: Key not found" — so 401/403
+ * count ONLY when the body carries the not-found semantic; a bare 401/403
+ * stays ambiguous (→ `unreachable`: skip, warn, keep the stored key).
  */
 function looksLikeUnknownKey(status: number, body: string): boolean {
-  if (status !== 400 && status !== 404) return false;
+  if (status !== 400 && status !== 401 && status !== 403 && status !== 404) return false;
   const t = body.toLowerCase();
   return (
     t.includes("not found") ||
     t.includes("does not exist") ||
     t.includes("no such key") ||
-    t.includes("no key found") ||
-    t.includes("invalid")
+    t.includes("no key found")
   );
 }
 
@@ -410,8 +412,8 @@ export async function validateKey(
   if (resp.ok) return { kind: "valid" };
   const body = await safeText(resp);
   if (looksLikeUnknownKey(resp.status, body)) return { kind: "unknown" };
-  // 401/403 (bad master key), 5xx, or any other ambiguous error — do NOT
-  // re-provision; keep the stored key and let the caller warn.
+  // Bare 401/403 (bad master key, no not-found semantic), 5xx, or any other
+  // ambiguous error — do NOT re-provision; keep the stored key and warn.
   return { kind: "unreachable", detail: `HTTP ${resp.status}: ${body.slice(0, 200)}` };
 }
 


### PR DESCRIPTION
## Summary

Fixes adversarially-confirmed LiteLLM provisioning footguns and reconciles the spec docs with the code that actually ships. Cites job spec `reference/jobs/keep-my-subscription-honest.md` (the gateway carve-out is subscription-honest infrastructure) and the availability outcome of `reference/vision.md`.

## Why — what each fix prevents (operator terms)

1. **Orphaned key alias no longer bricks an agent's provisioning forever.** LiteLLM enforces unique key aliases (upstream #9730, fleet on v1.91.0). If a prior `switchroom apply` generated `agent:<name>` but the vault write failed afterward, the alias lived in LiteLLM with no recoverable key — and *every* later apply hard-failed with `400 "Key with alias ... already exists"`, with no in-repo way out. Now `ensureKey` detects the duplicate-alias 400, resolves the orphan (`GET /key/list?key_alias=`), deletes it (`POST /key/delete` by `key_aliases` + resolved hashed tokens), and regenerates once — idempotent and logged. A *failed* delete throws a clear error naming the exact manual `curl` remediation instead of a silent loop.

2. **Stored keys are now validated against the proxy (DB-drift blindness fixed).** The apply idempotency check used to skip whenever the vault held a key, blind to LiteLLM's own state. A proxy DB reset/restore (without the vault) left every agent `401`ing forever with a green apply. Now, when the admin key is in hand **and** the proxy is reachable, apply validates the stored key via `GET /key/info`; an unknown key re-provisions through the same self-healing `ensureKey` path and rewrites the vault. Proxy unreachable → validation is **skipped with a warning, never fails the apply** (the #2781 degrade-to-warning contract is preserved; ambiguous errors like a 401/5xx never trigger a destructive re-provision).

3. **Passphrase-less apply stops falsely reporting hindsight unprovisionable.** The null-passphrase branch claimed the hindsight service key "can't be probed" and pushed a spurious `hindsight (service)` failure on *every* passphrase-less apply/reconcile — even on a fully-provisioned system. It now probes `litellm/hindsight/api-key` with the same idempotent broker read the provisioning path already uses: present → quiet skip, unreachable → warning (#2781 parity), genuinely missing → surfaced.

## Doc contract now matching code (fix 4, docs only, no behavior change)

- `reference/invariants.md` gateway carve-out point 3 previously said a gateway outage "**fails open** to the direct subscription path." Shipped behavior since #2940 / `6106036c` (`profiles/_base/start.sh.hbs:1002-1011`) is **split by cause**: missing key → fail open (untracked); proxy unreachable **with** a key → keep routing, loud warn, self-heal. Rewritten to the real contract.
- RFC `litellm-max-subscription-invariants.md` **I7** mandated the removed blanket fallback and falsely claimed it matched the implementation. Updated to the shipped contract with the history note (original fail-open superseded by #2940 because silent untracked traffic violated the cost-tracking invariant).
- RFC **I4** now documents the deliberate live drift-aliases (`claude-opus-4-7→4-8`, `claude-sonnet-4-6→sonnet-5`) as sanctioned (Anthropic→Anthropic, so I1/I2/I6 unaffected).
- Docs describe the keep-routing contract as applying to **both interactive and cron sessions** (cron-session port is landing concurrently in `fix/litellm-routing-hardening`).

## Test plan

- `src/litellm/provision.test.ts` (vitest, 21 tests): clean generate, duplicate-alias recovery (delete-by-token+alias, delete-by-alias-only), delete-fails path (clear remediation error), second-generate-still-duplicate, and `validateKey` valid/unknown/unreachable/401/500.
- `src/cli/apply-litellm-provision.test.ts` (vitest, 12 tests): DB-drift validate → skip / re-provision / unreachable-keep; passphrase-less hindsight probe present/missing/unreachable; plus the existing #2781 suite.
- `src/litellm/provision-apply-e2e.test.ts` (bun, real isolated broker, 4 tests): green.
- `npm run lint`: clean (all 8 guards + strict tsc).

## Risk

Low. Fix 1/2 add recovery paths gated on error signals that previously threw or skipped; the happy path is one extra `GET /key/info` per already-provisioned agent per apply. Availability contract (#2781) preserved: no proxy/broker unreachability ever fails the apply. Docs-only for fix 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)