### PR TITLE
fix(litellm): sessions booted during proxy outage self-heal; broker blips can't silently strip routing; cron gets the keep-routing contract

### DIFF
--- a/profiles/_base/cron-session.sh.hbs
+++ b/profiles/_base/cron-session.sh.hbs
@@ -87,36 +87,73 @@ CRON_APPEND_PROMPT="You are the cheap background cron worker for {{name}}. You r
 # claude's project key matches the pre-seeded trust state (.claude-cron).
 cd "{{agentDir}}" || exit 1
 
-# LiteLLM routing for the cron session — mirrors start.sh's boot block.
+# LiteLLM routing for the cron session — ports start.sh's boot contract.
 # IMPORTANT: the vault key is provisioned under the BASE agent name ({{name}}),
 # NOT the cron identity ({{name}}-cron). Use the Handlebars template var so the
-# lookup is a compile-time literal — no fragile runtime suffix-stripping.
-# Attribution headers carry $SWITCHROOM_AGENT_NAME (= {{name}}-cron) so LiteLLM
-# can distinguish cron spend from main-session spend per agent.
-# FAIL-OPEN: missing key OR unreachable proxy → strip routing env, fall back to
-# direct OAuth. An outage must never take the cron session dark.
+# lookup is a compile-time literal — no fragile runtime suffix-stripping. The
+# attribution headers use the SAME compile-time-literal form ({{name}}-cron,
+# identical to $SWITCHROOM_AGENT_NAME here — line 69 exports it) so this block
+# refers to the agent one consistent way instead of mixing a template literal
+# for the key with a runtime env var for the tags. Cron spend is attributed to
+# {{name}}-cron so LiteLLM distinguishes it from main-session spend per agent.
+#
+# Two boot failure modes, handled DIFFERENTLY (ported 2026-07 from start.sh so
+# cron no longer fails OPEN on a transient blip and silently runs UNTRACKED
+# direct OAuth for the fire — the product invariant is all model traffic stays
+# proxy-routed for cost/token tracking):
+#   - MISSING KEY → fail-open: strip routing, fall back to direct OAuth, LOUD
+#     log. Without a key there is no metered route to reach — correct here.
+#   - PROXY UNREACHABLE with key in hand → do NOT strip. Keep routing pointed at
+#     the proxy AND export the auth header so the session authenticates the
+#     moment the proxy recovers (the socat forwarder reconnects per-connection),
+#     LOUD log. Never a silent untracked direct-OAuth fallback.
+# Retry budget is DELIBERATELY short (3 attempts / ~15s) vs start.sh's 120s: a
+# cron fire is latency-sensitive and short-lived, and unreachable now KEEPS
+# routing anyway, so a long boot-probe would only add dead latency for no gain.
 if [ -n "${SWITCHROOM_LITELLM:-}" ] && command -v switchroom >/dev/null 2>&1; then
   sr_ll_key="$(switchroom vault get "litellm/{{name}}/api-key" 2>/dev/null || true)"
   sr_ll_ok=""
+  sr_ll_unreachable=""
   if [ -z "$sr_ll_key" ]; then
-    echo "litellm: no virtual key for cron '{{name}}' — falling back to direct OAuth (no tracking/guardrail)" >&2
-  elif command -v curl >/dev/null 2>&1 && [ -n "$ANTHROPIC_BASE_URL" ] \
-       && ! curl -fsS -m 5 -o /dev/null "${SWITCHROOM_LITELLM_BASE:-${ANTHROPIC_BASE_URL%/anthropic}}/health/liveliness" 2>/dev/null; then
-    echo "litellm: proxy unreachable at ${SWITCHROOM_LITELLM_BASE:-$ANTHROPIC_BASE_URL} — falling back to direct OAuth (no tracking/guardrail this session)" >&2
+    echo "litellm(cron): no virtual key for '{{name}}' — falling back to direct OAuth (untracked, unguarded)" >&2
+  elif command -v curl >/dev/null 2>&1 && [ -n "$ANTHROPIC_BASE_URL" ]; then
+    # Bounded retry probe — short budget for cron latency (3 attempts, ~15s).
+    sr_ll_url="${SWITCHROOM_LITELLM_BASE:-${ANTHROPIC_BASE_URL%/anthropic}}/health/liveliness"
+    sr_ll_try=0
+    sr_ll_up=""
+    while :; do
+      if curl -fsS -m 5 -o /dev/null "$sr_ll_url" 2>/dev/null; then sr_ll_up="1"; break; fi
+      sr_ll_try=$(( sr_ll_try + 1 ))
+      [ "$sr_ll_try" -ge 3 ] && break
+      sleep 5
+    done
+    if [ -z "$sr_ll_up" ]; then
+      # Proxy unreachable but the key is present. Do NOT strip: keep routing so
+      # the cron session self-heals once the proxy is back.
+      sr_ll_unreachable="1"
+      echo "litellm(cron): proxy unreachable at ${SWITCHROOM_LITELLM_BASE:-$ANTHROPIC_BASE_URL} after 3 retries — routing LEFT IN PLACE so it self-heals; NOT falling back to untracked direct Anthropic OAuth." >&2
+    else
+      sr_ll_ok="1"
+    fi
+    unset sr_ll_url sr_ll_try sr_ll_up
   else
     sr_ll_ok="1"
   fi
-  if [ -n "$sr_ll_ok" ]; then
+  if [ -n "$sr_ll_ok" ] || [ -n "$sr_ll_unreachable" ]; then
+    # Key fetched successfully — export the auth header REGARDLESS of the probe
+    # outcome so the virtual key reaches the process env. On unreachable this is
+    # what lets the session authenticate the moment the proxy recovers instead
+    # of 401-ing (the same self-heal fix as start.sh's inner/outer blocks).
     export ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: Bearer $sr_ll_key
-x-litellm-customer-id: $SWITCHROOM_AGENT_NAME
-x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:-default}"
+x-litellm-customer-id: {{name}}-cron
+x-litellm-tags: agent:{{name}}-cron,profile:${SWITCHROOM_AGENT_PROFILE:-default}"
     export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
   else
-    # Fail-open: drop every routing var so the claude CLI talks to Anthropic
-    # directly on its OAuth credential (subscription path), unproxied.
+    # Missing-key fail-open: drop every routing var so the claude CLI talks to
+    # Anthropic directly on its OAuth credential (subscription path), unproxied.
     unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM SWITCHROOM_LITELLM_BASE
   fi
-  unset sr_ll_key sr_ll_ok
+  unset sr_ll_key sr_ll_ok sr_ll_unreachable
 fi
 
 # Create the cron tmux session DETACHED (-d), not in attach mode. This is a

--- a/profiles/_base/cron-session.sh.hbs
+++ b/profiles/_base/cron-session.sh.hbs
@@ -107,9 +107,10 @@ cd "{{agentDir}}" || exit 1
 #     the proxy AND export the auth header so the session authenticates the
 #     moment the proxy recovers (the socat forwarder reconnects per-connection),
 #     LOUD log. Never a silent untracked direct-OAuth fallback.
-# Retry budget is DELIBERATELY short (3 attempts / ~15s) vs start.sh's 120s: a
-# cron fire is latency-sensitive and short-lived, and unreachable now KEEPS
-# routing anyway, so a long boot-probe would only add dead latency for no gain.
+# Retry budget is DELIBERATELY short — 3 attempts, worst-case ~25s (3×5s curl
+# timeouts + 2×5s sleeps) — vs start.sh's 120s: a cron fire is
+# latency-sensitive and short-lived, and unreachable now KEEPS routing anyway,
+# so a long boot-probe would only add dead latency for no gain.
 if [ -n "${SWITCHROOM_LITELLM:-}" ] && command -v switchroom >/dev/null 2>&1; then
   sr_ll_key="$(switchroom vault get "litellm/{{name}}/api-key" 2>/dev/null || true)"
   sr_ll_ok=""
@@ -117,7 +118,8 @@ if [ -n "${SWITCHROOM_LITELLM:-}" ] && command -v switchroom >/dev/null 2>&1; th
   if [ -z "$sr_ll_key" ]; then
     echo "litellm(cron): no virtual key for '{{name}}' — falling back to direct OAuth (untracked, unguarded)" >&2
   elif command -v curl >/dev/null 2>&1 && [ -n "$ANTHROPIC_BASE_URL" ]; then
-    # Bounded retry probe — short budget for cron latency (3 attempts, ~15s).
+    # Bounded retry probe — short budget for cron latency (3 attempts,
+    # worst-case ~25s: 3×5s curl timeouts + 2×5s sleeps).
     sr_ll_url="${SWITCHROOM_LITELLM_BASE:-${ANTHROPIC_BASE_URL%/anthropic}}/health/liveliness"
     sr_ll_try=0
     sr_ll_up=""

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -120,17 +120,19 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
     else
       sr_ll_ok="1"
     fi
-    if [ -n "$sr_ll_ok" ]; then
+    if [ -n "$sr_ll_ok" ] || [ -n "$sr_ll_unreachable" ]; then
+      # Key fetched successfully — export the proxy auth header REGARDLESS of the
+      # reachability probe outcome. The header is what carries the virtual key
+      # into the process env; without it the gateway's sr-* discovery
+      # (gateway.ts discoverSrModels) is dead and, once the proxy recovers,
+      # every request 401s until a manual restart. Since routing is LEFT IN
+      # PLACE on unreachable (below/above), the header must be too so the
+      # session actually self-heals when litellm returns. The probe result gates
+      # only log wording + inner-pass _LITELLM_OK, never the header.
       export ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: Bearer $sr_ll_key
 x-litellm-customer-id: $SWITCHROOM_AGENT_NAME
 x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:-default}"
       export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
-    elif [ -n "$sr_ll_unreachable" ]; then
-      # Proxy unreachable at boot: routing intentionally LEFT IN PLACE (loud
-      # warning already emitted) so it survives into the inner pass and
-      # self-heals once litellm returns. NO unset — the permanent strip here
-      # was what made the inner self-heal fix inert on docker.
-      :
     else
       # Missing-key fail-open: gateway talks direct OAuth, unproxied.
       unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM SWITCHROOM_LITELLM_BASE
@@ -1016,8 +1018,15 @@ if [ -n "${SWITCHROOM_LITELLM:-}" ] && command -v switchroom >/dev/null 2>&1; th
   else
     sr_ll_ok="1"
   fi
-  if [ -n "$sr_ll_ok" ]; then
-    _LITELLM_OK="1"
+  if [ -n "$sr_ll_ok" ] || [ -n "$sr_ll_unreachable" ]; then
+    # Key fetched successfully — export the proxy auth header REGARDLESS of the
+    # reachability probe outcome. Routing is LEFT IN PLACE on unreachable so the
+    # session self-heals when litellm returns; the header MUST survive with it,
+    # otherwise every request 401s once the proxy recovers (the "self-heals"
+    # promise below was inert without this) and gateway sr-* discovery stays
+    # dead. The probe outcome gates ONLY the _LITELLM_OK flag (sr-* override
+    # drop) and the log wording above — never the header.
+    #
     # Newline-separated Name: Value pairs (claude CLI ANTHROPIC_CUSTOM_HEADERS format).
     # Tags: agent:<name> for per-agent spend tracking; profile:<profile> for
     # fleet-level cost breakdown by role. Per-turn tags (cron vs telegram) are
@@ -1031,13 +1040,12 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
     # models configured in the proxy appear in the /model picker and can be
     # selected via --model. Without this, the CLI only knows its bundled list.
     export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
-  elif [ -n "$sr_ll_unreachable" ]; then
-    # Proxy unreachable at boot: routing intentionally LEFT IN PLACE (loud
-    # warning already emitted above) so it self-heals when litellm returns.
-    # _LITELLM_OK stays empty so any sr-* session model override is still
-    # dropped below (claude would 4xx an unknown model against a down endpoint).
-    # NO unset here — that permanent strip was the bug this branch fixes.
-    :
+    if [ -n "$sr_ll_ok" ]; then
+      # Probe succeeded: proxy is live, so honor any sr-* session model override
+      # below. On unreachable, _LITELLM_OK stays empty so the override is dropped
+      # (claude would 4xx an unknown model against a down endpoint).
+      _LITELLM_OK="1"
+    fi
   else
     # Missing key fail-open: drop every routing var so the claude CLI talks to
     # Anthropic directly on its OAuth credential (subscription path), unproxied.

--- a/src/cli/write-compose.ts
+++ b/src/cli/write-compose.ts
@@ -25,6 +25,38 @@ import { isDockerRuntime } from "../runtime-mode.js";
 import { resolveOperatorUid } from "./operator-uid.js";
 import { resolveAgentConfig } from "../config/merge.js";
 
+/** Minimal structural view of a broker structured-get result (see
+ *  src/vault/broker/client.ts `getViaBrokerStructured`). We only branch on
+ *  `kind` here, so a `{ kind }`-only shape keeps this decoupled + testable. */
+type BrokerGetResult = { kind: string };
+type BrokerGetFn = (key: string) => Promise<BrokerGetResult>;
+
+/**
+ * Does the on-disk compose already route this agent through the proxy? Parses
+ * the agent's service block (`  agent-<name>:`) for `SWITCHROOM_LITELLM: "1"`.
+ * Targeted string/regex parse (same posture as `AGENT_IMAGE_TAG_RE` above) —
+ * cheaper and less brittle here than a full YAML load of a file we generated.
+ */
+export function agentHadLiteLLMRouting(
+  composeContent: string,
+  agentName: string,
+): boolean {
+  const lines = composeContent.split("\n");
+  const header = `  agent-${agentName}:`;
+  let i = lines.indexOf(header);
+  if (i < 0) return false;
+  for (i = i + 1; i < lines.length; i++) {
+    const line = lines[i];
+    // The block ends at the next service (2-space indent, non-space) or any
+    // top-level key (0-indent). Env vars live at deeper indent, so they never
+    // trip these guards.
+    if (/^ {2}\S/.test(line)) break;
+    if (/^\S/.test(line)) break;
+    if (/^\s+SWITCHROOM_LITELLM:\s*"1"\s*$/.test(line)) return true;
+  }
+  return false;
+}
+
 /**
  * Probe the vault-broker for which opted-in agents already have a LiteLLM
  * virtual key (`litellm/<agent>/api-key`). Used to gate routing-env injection
@@ -35,12 +67,28 @@ import { resolveAgentConfig } from "../config/merge.js";
  * (provisioning runs before this probe on the apply path; the reconcile path
  * sees whatever was already provisioned).
  *
- * Fail-safe: if the broker is unreachable, an agent's key is treated as NOT
- * confirmed (returns it out of the set) so we never emit a key-less proxy
- * route. Best-effort — never throws.
+ * Two failure modes, deliberately NOT treated alike (the product invariant is
+ * that ALL model traffic stays proxy-routed for cost/token tracking; a broker
+ * blip must never silently downgrade a routed agent to untracked direct OAuth):
+ *
+ *   - key genuinely NOT FOUND (broker answered `not_found`/`denied`) → the
+ *     agent legitimately has no key → leave it unconfirmed → routing stripped.
+ *   - broker UNREACHABLE / timed out (or the client import failed) → we do NOT
+ *     know the key status. Silently stripping here is the bug: writeComposeFile
+ *     runs on `agent restart` too, so a container recreated during a broker
+ *     blip would boot on untracked direct OAuth. Instead we PRESERVE the
+ *     agent's prior verdict baked into the on-disk compose (`previousCompose`)
+ *     and emit a loud warning naming the affected agents. If there is no prior
+ *     compose (first-ever apply) the agent stays unconfirmed — it was never
+ *     routed, so that is the safe default.
+ *
+ * Best-effort — never throws. `deps.getKey` is injectable for tests; production
+ * callers pass none and it dynamic-imports the real broker client.
  */
-async function resolveLiteLLMConfirmedAgents(
+export async function resolveLiteLLMConfirmedAgents(
   config: SwitchroomConfig,
+  previousCompose: string | null,
+  deps?: { getKey?: BrokerGetFn },
 ): Promise<Set<string>> {
   const confirmed = new Set<string>();
   // Determine opted-in agents (effective enabled = agent ?? top-level ?? false).
@@ -56,18 +104,71 @@ async function resolveLiteLLMConfirmedAgents(
   }
   if (optedIn.length === 0) return confirmed;
 
-  try {
-    const { getViaBrokerStructured } = await import("../vault/broker/client.js");
-    for (const name of optedIn) {
-      try {
-        const r = await getViaBrokerStructured(`litellm/${name}/api-key`);
-        if (r.kind === "ok") confirmed.add(name);
-      } catch {
-        // treat as not-confirmed (fail-safe)
+  // Resolve the broker getter (injected for tests, else the real client). A
+  // failed import means the broker layer is unavailable ⇒ EVERY opted-in agent
+  // is "unreachable" (never silently strip the whole fleet — the outer-catch bug).
+  let getKey: BrokerGetFn | null = deps?.getKey ?? null;
+  if (!getKey) {
+    try {
+      ({ getViaBrokerStructured: getKey } = await import("../vault/broker/client.js"));
+    } catch {
+      getKey = null;
+    }
+  }
+
+  const unreachableAgents: string[] = [];
+  for (const name of optedIn) {
+    if (!getKey) {
+      unreachableAgents.push(name);
+      continue;
+    }
+    try {
+      const r = await getKey(`litellm/${name}/api-key`);
+      if (r.kind === "ok") {
+        confirmed.add(name);
+      } else if (r.kind === "unreachable") {
+        unreachableAgents.push(name);
+      }
+      // not_found / denied ⇒ broker answered "no key" ⇒ legitimate strip
+      // (leave out of the confirmed set).
+    } catch {
+      // An unexpected throw from the client is broker-layer trouble, not a
+      // "no key" answer — treat it as unreachable (preserve, don't strip).
+      unreachableAgents.push(name);
+    }
+  }
+
+  if (unreachableAgents.length > 0) {
+    const preserved: string[] = [];
+    const couldNotPreserve: string[] = [];
+    for (const name of unreachableAgents) {
+      if (previousCompose && agentHadLiteLLMRouting(previousCompose, name)) {
+        confirmed.add(name);
+        preserved.push(name);
+      } else {
+        couldNotPreserve.push(name);
       }
     }
-  } catch {
-    // broker client import / connection failure ⇒ nothing confirmed
+    // LOUD warning — naming every affected agent — so a broker blip during an
+    // apply/restart is visible in the operator's console, not silent.
+    console.warn(
+      `switchroom: vault-broker unreachable while resolving LiteLLM key status for ` +
+      `${unreachableAgents.length} opted-in agent(s): ${unreachableAgents.join(", ")}. ` +
+      `Refusing to silently strip proxy routing (that would boot them on untracked ` +
+      `direct OAuth). Re-run \`switchroom apply\` once the broker is back to reconcile.`,
+    );
+    if (preserved.length > 0) {
+      console.warn(
+        `switchroom: PRESERVED existing proxy routing from the on-disk compose for: ` +
+        `${preserved.join(", ")}.`,
+      );
+    }
+    if (couldNotPreserve.length > 0) {
+      console.warn(
+        `switchroom: no prior routing verdict on disk for: ${couldNotPreserve.join(", ")} ` +
+        `— leaving them unrouted (they were not previously routed).`,
+      );
+    }
   }
   return confirmed;
 }
@@ -222,9 +323,19 @@ export async function computeComposeContent(
     ? resolveHostSwitchroomConfigPath(opts.switchroomConfigPath)
     : undefined;
 
+  // Read the compose currently on disk BEFORE resolving key status: the
+  // LiteLLM resolver needs it to preserve an agent's prior routing verdict
+  // when the broker is unreachable (never silently strip on a broker blip).
+  let previous: string | null = null;
+  try {
+    previous = await readFile(opts.composePath, "utf8");
+  } catch {
+    previous = null;
+  }
+
   // Which opted-in agents have a LiteLLM key in the vault — gates routing-env
   // injection so a key-less agent never boots a dead proxy route (#litellm).
-  const litellmConfirmedAgents = await resolveLiteLLMConfirmedAgents(opts.config);
+  const litellmConfirmedAgents = await resolveLiteLLMConfirmedAgents(opts.config, previous);
 
   const content = generateCompose({
     config: opts.config,
@@ -250,12 +361,6 @@ export async function computeComposeContent(
     operatorUid,
   });
 
-  let previous: string | null = null;
-  try {
-    previous = await readFile(opts.composePath, "utf8");
-  } catch {
-    previous = null;
-  }
   const previousImageTag = previous ? (AGENT_IMAGE_TAG_RE.exec(previous)?.[1] ?? null) : null;
 
   return { content, imageTag, previous, previousImageTag };

--- a/src/cli/write-compose.ts
+++ b/src/cli/write-compose.ts
@@ -26,9 +26,14 @@ import { resolveOperatorUid } from "./operator-uid.js";
 import { resolveAgentConfig } from "../config/merge.js";
 
 /** Minimal structural view of a broker structured-get result (see
- *  src/vault/broker/client.ts `getViaBrokerStructured`). We only branch on
- *  `kind` here, so a `{ kind }`-only shape keeps this decoupled + testable. */
-type BrokerGetResult = { kind: string };
+ *  src/vault/broker/client.ts `getViaBrokerStructured`). We branch on `kind`
+ *  plus — for kind "denied" — the underlying broker error `code`: the client
+ *  rolls LOCKED, DENIED, BAD_REQUEST and INTERNAL all up into "denied", and
+ *  only the code distinguishes a transient broker condition (vault LOCKED
+ *  during the routine apply/relock window; INTERNAL error) from a genuine
+ *  grant/ACL DENIED. Treating them alike would silently strip a routed agent
+ *  on every relock — the exact bug class this resolver exists to prevent. */
+type BrokerGetResult = { kind: string; code?: string };
 type BrokerGetFn = (key: string) => Promise<BrokerGetResult>;
 
 /**
@@ -71,16 +76,20 @@ export function agentHadLiteLLMRouting(
  * that ALL model traffic stays proxy-routed for cost/token tracking; a broker
  * blip must never silently downgrade a routed agent to untracked direct OAuth):
  *
- *   - key genuinely NOT FOUND (broker answered `not_found`/`denied`) → the
- *     agent legitimately has no key → leave it unconfirmed → routing stripped.
- *   - broker UNREACHABLE / timed out (or the client import failed) → we do NOT
- *     know the key status. Silently stripping here is the bug: writeComposeFile
- *     runs on `agent restart` too, so a container recreated during a broker
- *     blip would boot on untracked direct OAuth. Instead we PRESERVE the
- *     agent's prior verdict baked into the on-disk compose (`previousCompose`)
- *     and emit a loud warning naming the affected agents. If there is no prior
- *     compose (first-ever apply) the agent stays unconfirmed — it was never
- *     routed, so that is the safe default.
+ *   - broker ANSWERED with a definitive "no key for you": `not_found`
+ *     (UNKNOWN_KEY — the key isn't there) or a genuine grant/ACL `DENIED` →
+ *     the agent legitimately has no usable key → leave it unconfirmed →
+ *     routing stripped.
+ *   - broker CANNOT answer right now: UNREACHABLE / timed out, client import
+ *     failed, vault LOCKED (routine during the apply/relock window), or an
+ *     INTERNAL broker error → we do NOT know the key status. Silently
+ *     stripping here is the bug: writeComposeFile runs on `agent restart` too,
+ *     so a container recreated during a broker blip would boot on untracked
+ *     direct OAuth. Instead we PRESERVE the agent's prior verdict baked into
+ *     the on-disk compose (`previousCompose`) and emit a loud warning naming
+ *     the affected agents. If there is no prior compose (first-ever apply) the
+ *     agent stays unconfirmed — it was never routed, so that is the safe
+ *     default.
  *
  * Best-effort — never throws. `deps.getKey` is injectable for tests; production
  * callers pass none and it dynamic-imports the real broker client.
@@ -128,9 +137,17 @@ export async function resolveLiteLLMConfirmedAgents(
         confirmed.add(name);
       } else if (r.kind === "unreachable") {
         unreachableAgents.push(name);
+      } else if (r.kind === "denied" && r.code !== "DENIED") {
+        // The client collapses LOCKED / DENIED / BAD_REQUEST / INTERNAL into
+        // kind "denied". Only a genuine grant/ACL DENIED is a definitive "no
+        // key for you". LOCKED (the vault relocks routinely during apply) and
+        // INTERNAL are transient broker states — and BAD_REQUEST / an absent
+        // code means WE (or a protocol skew) are at fault, not the key. All of
+        // those mean "status unknown" ⇒ preserve, never silently strip.
+        unreachableAgents.push(name);
       }
-      // not_found / denied ⇒ broker answered "no key" ⇒ legitimate strip
-      // (leave out of the confirmed set).
+      // not_found (UNKNOWN_KEY) / denied with code DENIED ⇒ broker answered
+      // definitively "no usable key" ⇒ legitimate strip (leave unconfirmed).
     } catch {
       // An unexpected throw from the client is broker-layer trouble, not a
       // "no key" answer — treat it as unreachable (preserve, don't strip).
@@ -150,9 +167,15 @@ export async function resolveLiteLLMConfirmedAgents(
       }
     }
     // LOUD warning — naming every affected agent — so a broker blip during an
-    // apply/restart is visible in the operator's console, not silent.
+    // apply/restart is visible in the operator's console, not silent. This
+    // INTENTIONALLY repeats on every writeComposeFile invocation while the
+    // broker stays unavailable (apply and each agent restart): each run is a
+    // separate operator-visible operation whose routing verdict was degraded,
+    // and deduping across process invocations would need on-disk state for no
+    // real gain.
     console.warn(
-      `switchroom: vault-broker unreachable while resolving LiteLLM key status for ` +
+      `switchroom: vault-broker unreachable or unable to answer (locked/internal) ` +
+      `while resolving LiteLLM key status for ` +
       `${unreachableAgents.length} opted-in agent(s): ${unreachableAgents.join(", ")}. ` +
       `Refusing to silently strip proxy routing (that would boot them on untracked ` +
       `direct OAuth). Re-run \`switchroom apply\` once the broker is back to reconcile.`,

--- a/tests/cheap-cron-session-render.test.ts
+++ b/tests/cheap-cron-session-render.test.ts
@@ -197,7 +197,7 @@ describe("cron-session.sh LiteLLM routing — mirrors start.sh boot block", () =
   });
 
   it("dispatch (executed): UNREACHABLE keeps routing + HEADER, MISSING KEY strips it", () => {
-    // Slice JUST the decision dispatch (skips the 15s probe loop): from the
+    // Slice JUST the decision dispatch (skips the ~25s probe loop): from the
     // shared decision `if` through the scratch-var cleanup, driven by preset
     // flags — the real strip-vs-keep code paths without any sleeping.
     const dispStart = out.indexOf(

--- a/tests/cheap-cron-session-render.test.ts
+++ b/tests/cheap-cron-session-render.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { renderTemplate } from "../src/agents/profiles.js";
 import { scheduleNeedsCronSession } from "../src/scheduler/cron-routing.js";
@@ -156,18 +157,101 @@ describe("cron-session.sh LiteLLM routing — mirrors start.sh boot block", () =
     expect(out).toContain('if [ -n "${SWITCHROOM_LITELLM:-}" ]');
   });
 
-  it("exports ANTHROPIC_CUSTOM_HEADERS and CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY on success", () => {
+  it("exports ANTHROPIC_CUSTOM_HEADERS and CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY when key present", () => {
     expect(out).toContain("x-litellm-api-key: Bearer $sr_ll_key");
-    expect(out).toContain("x-litellm-customer-id: $SWITCHROOM_AGENT_NAME");
-    expect(out).toContain("x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME");
+    // Attribution now uses the compile-time-literal cron identity (marko-cron)
+    // consistently — no longer a runtime $SWITCHROOM_AGENT_NAME (drift fix). The
+    // value is identical (line 69 sets SWITCHROOM_AGENT_NAME=$CRON_NAME).
+    expect(out).toContain("x-litellm-customer-id: marko-cron");
+    expect(out).toContain("x-litellm-tags: agent:marko-cron");
+    expect(out).not.toContain("x-litellm-customer-id: $SWITCHROOM_AGENT_NAME");
     expect(out).toContain("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1");
   });
 
-  it("fail-open: unsets ALL routing vars so claude falls back to direct OAuth", () => {
+  it("MISSING KEY fails open: unsets ALL routing vars → direct OAuth, loud log", () => {
     expect(out).toContain(
       "unset ANTHROPIC_BASE_URL ANTHROPIC_SMALL_FAST_MODEL SWITCHROOM_LITELLM",
     );
+    // The missing-key branch still fails open (correct — no metered route).
+    expect(out).toContain("no virtual key for 'marko'");
     expect(out).toContain("falling back to direct OAuth");
+  });
+
+  it("PROXY UNREACHABLE with key does NOT fail open — keeps routing + self-heals (ported from start.sh)", () => {
+    // The pre-#2940 cron logic unset routing on unreachable → untracked direct
+    // OAuth for the fire. The new contract keeps routing in place, loud-warns,
+    // and exports the header so it self-heals when the proxy returns.
+    expect(out).toContain('sr_ll_unreachable="1"');
+    expect(out).toContain("routing LEFT IN PLACE");
+    expect(out).toContain("NOT falling back to untracked direct Anthropic OAuth");
+    // The header-export arm fires for BOTH ok and unreachable (key in hand).
+    expect(out).toContain('if [ -n "$sr_ll_ok" ] || [ -n "$sr_ll_unreachable" ]; then');
+    // The old fail-open-on-unreachable log wording is gone.
+    expect(out).not.toContain("no tracking/guardrail this session");
+  });
+
+  it("bounded SHORT retry budget (3 attempts) — not start.sh's 120s deadline", () => {
+    // Cron latency budget: a few quick retries, then keep routing anyway.
+    expect(out).toContain('[ "$sr_ll_try" -ge 3 ]');
+    expect(out).not.toContain("+ 120 ))"); // no 120s boot-probe deadline here
+  });
+
+  it("dispatch (executed): UNREACHABLE keeps routing + HEADER, MISSING KEY strips it", () => {
+    // Slice JUST the decision dispatch (skips the 15s probe loop): from the
+    // shared decision `if` through the scratch-var cleanup, driven by preset
+    // flags — the real strip-vs-keep code paths without any sleeping.
+    const dispStart = out.indexOf(
+      'if [ -n "$sr_ll_ok" ] || [ -n "$sr_ll_unreachable" ]; then',
+    );
+    const endMarker = "unset sr_ll_key sr_ll_ok sr_ll_unreachable";
+    const dispEnd = out.indexOf(endMarker, dispStart) + endMarker.length;
+    expect(dispStart).toBeGreaterThan(-1);
+    expect(dispEnd).toBeGreaterThan(dispStart);
+    const dispatch = out.slice(dispStart, dispEnd);
+
+    const runDispatch = (preset: { ok: string; unreachable: string }): Record<string, string> => {
+      const script = [
+        "set -e",
+        "unset ANTHROPIC_CUSTOM_HEADERS",
+        "export SWITCHROOM_AGENT_NAME=marko-cron",
+        "export SWITCHROOM_AGENT_PROFILE=default",
+        'export ANTHROPIC_BASE_URL="http://litellm:4010/anthropic"',
+        "export ANTHROPIC_SMALL_FAST_MODEL=claude-haiku-4-5",
+        "export SWITCHROOM_LITELLM=1",
+        'export SWITCHROOM_LITELLM_BASE="http://litellm:4010"',
+        "sr_ll_key=k",
+        `sr_ll_ok=${JSON.stringify(preset.ok)}`,
+        `sr_ll_unreachable=${JSON.stringify(preset.unreachable)}`,
+        dispatch,
+        'echo "BASEURL=${ANTHROPIC_BASE_URL:-__UNSET__}"',
+        'echo "LITELLM=${SWITCHROOM_LITELLM:-__UNSET__}"',
+        'if [ -n "${ANTHROPIC_CUSTOM_HEADERS:-}" ]; then echo "HEADERS=SET"; else echo "HEADERS=__UNSET__"; fi',
+        'case "${ANTHROPIC_CUSTOM_HEADERS:-}" in *"Bearer k"*) echo "KEYINHEADER=YES";; *) echo "KEYINHEADER=NO";; esac',
+        'case "${ANTHROPIC_CUSTOM_HEADERS:-}" in *"customer-id: marko-cron"*) echo "CRONID=YES";; *) echo "CRONID=NO";; esac',
+      ].join("\n");
+      const cmdOut = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
+      return Object.fromEntries(
+        [...cmdOut.matchAll(/^(BASEURL|LITELLM|HEADERS|KEYINHEADER|CRONID)=(.*)$/gm)].map((m) => [
+          m[1],
+          m[2].trim(),
+        ]),
+      );
+    };
+
+    // Proxy unreachable → routing SURVIVES and the auth header is exported with
+    // the key + cron identity, so the fire self-heals instead of running dark.
+    const unreachable = runDispatch({ ok: "", unreachable: "1" });
+    expect(unreachable.BASEURL).toBe("http://litellm:4010/anthropic");
+    expect(unreachable.LITELLM).toBe("1");
+    expect(unreachable.HEADERS).toBe("SET");
+    expect(unreachable.KEYINHEADER).toBe("YES");
+    expect(unreachable.CRONID).toBe("YES");
+
+    // Missing key → fail-open strip (routing gone; no header).
+    const missingKey = runDispatch({ ok: "", unreachable: "" });
+    expect(missingKey.BASEURL).toBe("__UNSET__");
+    expect(missingKey.LITELLM).toBe("__UNSET__");
+    expect(missingKey.HEADERS).toBe("__UNSET__");
   });
 
   it("LiteLLM block appears BEFORE the tmux new-session call", () => {

--- a/tests/scaffold.litellm-failopen.test.ts
+++ b/tests/scaffold.litellm-failopen.test.ts
@@ -110,9 +110,27 @@ describe("scaffoldAgent: LiteLLM fail-open boot contract (#litellm)", () => {
     expect(innerBlock).toContain("routing LEFT IN PLACE");
     expect(innerBlock).toContain("NOT falling back to untracked direct Anthropic OAuth");
 
-    // The unreachable branch dispatch must be a no-op (routing kept), guarded by
-    // the flag — never the unset. Assert the elif dispatch exists.
-    expect(innerBlock).toContain('elif [ -n "$sr_ll_unreachable" ]');
+    // NEW CONTRACT (boot-while-proxy-down self-heal): the header-export arm now
+    // fires for BOTH the reachable AND the unreachable branch (key in hand), so
+    // the virtual key reaches the process env and requests authenticate the
+    // moment the proxy recovers instead of 401-ing until a manual restart. The
+    // decision `if` therefore ORs the two flags…
+    expect(innerBlock).toContain(
+      'if [ -n "$sr_ll_ok" ] || [ -n "$sr_ll_unreachable" ]; then',
+    );
+    // …the OLD `elif`-no-op branch (headers NOT exported on unreachable — the
+    // bug) is gone…
+    expect(innerBlock).not.toContain('elif [ -n "$sr_ll_unreachable" ]');
+    // …and the probe outcome now gates ONLY the _LITELLM_OK flag (sr-* override
+    // drop), via a nested probe-only `if` inside the shared arm.
+    expect(innerBlock).toContain('if [ -n "$sr_ll_ok" ]; then');
+    expect(innerBlock).toContain('_LITELLM_OK="1"');
+    // Header + gateway-discovery exports live in the SHARED arm (before the
+    // nested probe-only gate) so they fire on the unreachable branch too.
+    expect(
+      innerBlock.indexOf("export ANTHROPIC_CUSTOM_HEADERS="),
+      "header export must precede the probe-only _LITELLM_OK gate",
+    ).toBeLessThan(innerBlock.indexOf('_LITELLM_OK="1"'));
 
     // MISSING-KEY branch is still logged LOUDLY (not silent).
     expect(innerBlock).toContain("no litellm virtual key for agent");

--- a/tests/scaffold.litellm-gateway-outer.test.ts
+++ b/tests/scaffold.litellm-gateway-outer.test.ts
@@ -129,13 +129,15 @@ describe("start.sh: LiteLLM ANTHROPIC_CUSTOM_HEADERS hoisted before gateway fork
     expect(outerSlice).toContain("no virtual key for agent");
   });
 
-  it("outer dispatch (executed): UNREACHABLE keeps routing env, MISSING KEY strips it", () => {
+  it("outer dispatch (executed): UNREACHABLE keeps routing env + HEADERS, MISSING KEY strips it", () => {
     const startSh = renderStartSh();
     // Extract JUST the outer dispatch (decision + scratch cleanup): from the
-    // FIRST `if [ -n "$sr_ll_ok" ]` (outer precedes inner) through the first
+    // FIRST decision `if` (outer precedes inner) through the first
     // `unset sr_ll_key sr_ll_ok sr_ll_unreachable`. This runs the real strip-vs-
     // keep code paths without the 120s probe loop.
-    const dispStart = startSh.indexOf('if [ -n "$sr_ll_ok" ]; then');
+    const dispStart = startSh.indexOf(
+      'if [ -n "$sr_ll_ok" ] || [ -n "$sr_ll_unreachable" ]; then',
+    );
     const dispEndMarker = "unset sr_ll_key sr_ll_ok sr_ll_unreachable";
     const dispEnd = startSh.indexOf(dispEndMarker, dispStart) + dispEndMarker.length;
     expect(dispStart).toBeGreaterThan(-1);
@@ -145,6 +147,10 @@ describe("start.sh: LiteLLM ANTHROPIC_CUSTOM_HEADERS hoisted before gateway fork
     const runDispatch = (preset: { ok: string; unreachable: string }): Record<string, string> => {
       const script = [
         "set -e",
+        // The outer block's own guard requires ANTHROPIC_CUSTOM_HEADERS empty on
+        // entry; clear any value inherited from the test runner's env so the
+        // dispatch runs from the same precondition it sees at real boot.
+        "unset ANTHROPIC_CUSTOM_HEADERS",
         "export SWITCHROOM_AGENT_NAME=a",
         "export SWITCHROOM_AGENT_PROFILE=default",
         'export ANTHROPIC_BASE_URL="http://litellm:4010/anthropic"',
@@ -158,24 +164,47 @@ describe("start.sh: LiteLLM ANTHROPIC_CUSTOM_HEADERS hoisted before gateway fork
         'echo "BASEURL=${ANTHROPIC_BASE_URL:-__UNSET__}"',
         'echo "LITELLM=${SWITCHROOM_LITELLM:-__UNSET__}"',
         'echo "LLBASE=${SWITCHROOM_LITELLM_BASE:-__UNSET__}"',
+        // Collapse the (multi-line) header to a single sentinel so the regex
+        // below can capture "set vs unset" without newline handling.
+        'if [ -n "${ANTHROPIC_CUSTOM_HEADERS:-}" ]; then echo "HEADERS=SET"; else echo "HEADERS=__UNSET__"; fi',
+        // Prove the virtual key actually rode into the header (this is what
+        // authenticates to the proxy once it recovers — the whole self-heal).
+        'case "${ANTHROPIC_CUSTOM_HEADERS:-}" in *"Bearer k"*) echo "KEYINHEADER=YES";; *) echo "KEYINHEADER=NO";; esac',
       ].join("\n");
       const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
       return Object.fromEntries(
-        [...out.matchAll(/^(BASEURL|LITELLM|LLBASE)=(.*)$/gm)].map((m) => [m[1], m[2].trim()]),
+        [...out.matchAll(/^(BASEURL|LITELLM|LLBASE|HEADERS|KEYINHEADER)=(.*)$/gm)].map((m) => [
+          m[1],
+          m[2].trim(),
+        ]),
       );
     };
 
-    // Proxy unreachable → routing env SURVIVES (must reach the tmux exec env).
+    // Proxy unreachable → routing env SURVIVES (must reach the tmux exec env)
+    // AND the auth header is exported with the key in hand, so the session
+    // self-heals (authenticates) the moment the proxy recovers instead of
+    // 401-ing until a manual restart. This header assertion is the regression
+    // guard for the boot-while-proxy-down-never-recovers bug.
     const unreachable = runDispatch({ ok: "", unreachable: "1" });
     expect(unreachable.BASEURL).toBe("http://litellm:4010/anthropic");
     expect(unreachable.LITELLM).toBe("1");
     expect(unreachable.LLBASE).toBe("http://litellm:4010");
+    expect(unreachable.HEADERS).toBe("SET");
+    expect(unreachable.KEYINHEADER).toBe("YES");
 
-    // Missing key → fail-open strip (all routing vars gone).
+    // Proxy reachable → routing + header both present (the happy path).
+    const ok = runDispatch({ ok: "1", unreachable: "" });
+    expect(ok.BASEURL).toBe("http://litellm:4010/anthropic");
+    expect(ok.LITELLM).toBe("1");
+    expect(ok.HEADERS).toBe("SET");
+    expect(ok.KEYINHEADER).toBe("YES");
+
+    // Missing key → fail-open strip (all routing vars gone; no header exported).
     const missingKey = runDispatch({ ok: "", unreachable: "" });
     expect(missingKey.BASEURL).toBe("__UNSET__");
     expect(missingKey.LITELLM).toBe("__UNSET__");
     expect(missingKey.LLBASE).toBe("__UNSET__");
+    expect(missingKey.HEADERS).toBe("__UNSET__");
   });
 
   it("outer block is inside the SWITCHROOM_DOCKER_TMUX_INNER guard (outer-only section)", () => {

--- a/tests/write-compose.litellm-resolve.test.ts
+++ b/tests/write-compose.litellm-resolve.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  resolveLiteLLMConfirmedAgents,
+  agentHadLiteLLMRouting,
+} from "../src/cli/write-compose.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+/**
+ * Fix #2 regression guard: a vault-broker outage must NOT silently strip fleet
+ * routing.
+ *
+ * `resolveLiteLLMConfirmedAgents` gates the LiteLLM routing-env injection in the
+ * generated compose. `writeComposeFile` runs on `agent restart` too, so if a
+ * broker blip (unreachable/timeout) marked every opted-in agent not-confirmed,
+ * a container recreated mid-blip would boot on UNTRACKED direct OAuth —
+ * violating the product invariant that all model traffic stays proxy-routed.
+ *
+ * Contract under test:
+ *   - broker answers `not_found`  → legitimately no key → strip (unconfirmed).
+ *   - broker answers `unreachable`→ status unknown → PRESERVE the agent's prior
+ *     verdict from the on-disk compose (never silently strip), loud-warn.
+ *   - broker client entirely unavailable (getKey null via import failure) is
+ *     modelled here by an injected getter that returns `unreachable` for all.
+ */
+
+const telegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+} as const;
+
+function makeConfig(agentNames: string[]): SwitchroomConfig {
+  const agents: Record<string, unknown> = {};
+  for (const name of agentNames) {
+    agents[name] = {
+      extends: "default",
+      topic_name: "T",
+      schedule: [],
+      litellm: { enabled: true },
+    };
+  }
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+    },
+    telegram: telegramConfig,
+    litellm: { enabled: true },
+    agents,
+  } as unknown as SwitchroomConfig;
+}
+
+/** A minimal generated-compose fragment routing exactly `routedNames`. */
+function composeWith(routedNames: string[], allNames: string[]): string {
+  const blocks = allNames.map((name) => {
+    const env = [`      SWITCHROOM_AGENT_NAME: "${name}"`];
+    if (routedNames.includes(name)) {
+      env.push(`      SWITCHROOM_LITELLM: "1"`);
+      env.push(`      SWITCHROOM_LITELLM_BASE: "http://litellm:4010"`);
+      env.push(`      ANTHROPIC_BASE_URL: "http://litellm:4010/anthropic"`);
+    }
+    return [
+      `  agent-${name}:`,
+      `    image: ghcr.io/switchroom/switchroom-agent:v1`,
+      `    environment:`,
+      ...env,
+      `    volumes:`,
+      `      - broker-${name}-sock:/run/switchroom/broker`,
+    ].join("\n");
+  });
+  return ["services:", ...blocks, "volumes:", "  broker-x-sock:"].join("\n");
+}
+
+describe("agentHadLiteLLMRouting", () => {
+  it("detects a routed agent and ignores an unrouted sibling", () => {
+    const compose = composeWith(["alpha"], ["alpha", "beta"]);
+    expect(agentHadLiteLLMRouting(compose, "alpha")).toBe(true);
+    expect(agentHadLiteLLMRouting(compose, "beta")).toBe(false);
+  });
+
+  it("returns false for an agent absent from the compose", () => {
+    const compose = composeWith(["alpha"], ["alpha"]);
+    expect(agentHadLiteLLMRouting(compose, "ghost")).toBe(false);
+  });
+
+  it("does not leak a sibling's SWITCHROOM_LITELLM into an unrouted block", () => {
+    // beta unrouted, alpha routed and lexically adjacent — the block scan must
+    // stop at beta's service header, not read alpha's env.
+    const compose = composeWith(["alpha"], ["beta", "alpha"]);
+    expect(agentHadLiteLLMRouting(compose, "beta")).toBe(false);
+  });
+});
+
+describe("resolveLiteLLMConfirmedAgents — broker outage vs key-not-found", () => {
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  afterEach(() => warnSpy.mockClear());
+
+  it("confirms agents whose key the broker returns as ok", async () => {
+    const config = makeConfig(["alpha", "beta"]);
+    const confirmed = await resolveLiteLLMConfirmedAgents(config, null, {
+      getKey: async () => ({ kind: "ok" }),
+    });
+    expect([...confirmed].sort()).toEqual(["alpha", "beta"]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("STRIPS an agent the broker reports as not_found (legitimate)", async () => {
+    const config = makeConfig(["alpha"]);
+    // Prior compose HAD routing — but not_found is a real "no key" answer, so
+    // the strip is correct and the prior verdict must NOT rescue it.
+    const prior = composeWith(["alpha"], ["alpha"]);
+    const confirmed = await resolveLiteLLMConfirmedAgents(config, prior, {
+      getKey: async () => ({ kind: "not_found" }),
+    });
+    expect(confirmed.has("alpha")).toBe(false);
+    // No broker-outage warning on a clean not_found.
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("PRESERVES routing for an unreachable agent that was routed on disk", async () => {
+    const config = makeConfig(["alpha"]);
+    const prior = composeWith(["alpha"], ["alpha"]);
+    const confirmed = await resolveLiteLLMConfirmedAgents(config, prior, {
+      getKey: async () => ({ kind: "unreachable" }),
+    });
+    // The broker blip must NOT strip routing — the agent keeps its verdict.
+    expect(confirmed.has("alpha")).toBe(true);
+    // …and it warns loudly, naming the affected agent.
+    expect(warnSpy).toHaveBeenCalled();
+    const warned = warnSpy.mock.calls.flat().join("\n");
+    expect(warned).toContain("vault-broker unreachable");
+    expect(warned).toContain("alpha");
+    expect(warned).toContain("PRESERVED");
+  });
+
+  it("does NOT invent routing for an unreachable agent absent from prior compose", async () => {
+    const config = makeConfig(["alpha"]);
+    // First-ever apply: no prior compose → nothing to preserve → stay unrouted.
+    const confirmed = await resolveLiteLLMConfirmedAgents(config, null, {
+      getKey: async () => ({ kind: "unreachable" }),
+    });
+    expect(confirmed.has("alpha")).toBe(false);
+    const warned = warnSpy.mock.calls.flat().join("\n");
+    expect(warned).toContain("vault-broker unreachable");
+    expect(warned).toContain("leaving them unrouted");
+  });
+
+  it("splits a mixed fleet: ok confirmed, not_found stripped, unreachable preserved", async () => {
+    const config = makeConfig(["ok1", "gone", "blip"]);
+    const prior = composeWith(["ok1", "gone", "blip"], ["ok1", "gone", "blip"]);
+    const confirmed = await resolveLiteLLMConfirmedAgents(config, prior, {
+      getKey: async (key) => {
+        if (key.includes("ok1")) return { kind: "ok" };
+        if (key.includes("gone")) return { kind: "not_found" };
+        return { kind: "unreachable" };
+      },
+    });
+    expect(confirmed.has("ok1")).toBe(true);
+    expect(confirmed.has("gone")).toBe(false); // legitimately stripped
+    expect(confirmed.has("blip")).toBe(true); // preserved across the blip
+    const warned = warnSpy.mock.calls.flat().join("\n");
+    expect(warned).toContain("blip");
+    expect(warned).not.toContain("gone,"); // not lumped into the unreachable list
+  });
+
+  it("treats an injected getter that throws as unreachable (preserve, not strip)", async () => {
+    const config = makeConfig(["alpha"]);
+    const prior = composeWith(["alpha"], ["alpha"]);
+    const confirmed = await resolveLiteLLMConfirmedAgents(config, prior, {
+      getKey: async () => {
+        throw new Error("socket ECONNREFUSED");
+      },
+    });
+    expect(confirmed.has("alpha")).toBe(true);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("returns empty (no probe) when no agent opted in", async () => {
+    const config = makeConfig([]);
+    const getKey = vi.fn(async () => ({ kind: "ok" }));
+    const confirmed = await resolveLiteLLMConfirmedAgents(config, null, { getKey });
+    expect(confirmed.size).toBe(0);
+    expect(getKey).not.toHaveBeenCalled();
+  });
+});

--- a/tests/write-compose.litellm-resolve.test.ts
+++ b/tests/write-compose.litellm-resolve.test.ts
@@ -117,6 +117,49 @@ describe("resolveLiteLLMConfirmedAgents — broker outage vs key-not-found", () 
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
+  it("STRIPS an agent on a genuine grant/ACL DENIED (broker answered definitively)", async () => {
+    const config = makeConfig(["alpha"]);
+    const prior = composeWith(["alpha"], ["alpha"]);
+    const confirmed = await resolveLiteLLMConfirmedAgents(config, prior, {
+      getKey: async () => ({ kind: "denied", code: "DENIED" }),
+    });
+    // A real ACL denial means "no usable key" — the strip is legitimate and
+    // the prior verdict must NOT rescue it.
+    expect(confirmed.has("alpha")).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("PRESERVES routing on LOCKED — the client rolls it into kind 'denied' (the relock window)", async () => {
+    // The broker returns LOCKED whenever the vault is locked, which happens
+    // routinely during the apply/relock window — and the client collapses it
+    // into kind "denied". Treating that as a definitive no-key answer would be
+    // a silent strip of a routed agent on every relock. The code must be
+    // classified: LOCKED ⇒ status unknown ⇒ preserve + warn.
+    const config = makeConfig(["alpha"]);
+    const prior = composeWith(["alpha"], ["alpha"]);
+    const confirmed = await resolveLiteLLMConfirmedAgents(config, prior, {
+      getKey: async () => ({ kind: "denied", code: "LOCKED" }),
+    });
+    expect(confirmed.has("alpha")).toBe(true);
+    expect(warnSpy).toHaveBeenCalled();
+    const warned = warnSpy.mock.calls.flat().join("\n");
+    expect(warned).toContain("alpha");
+    expect(warned).toContain("PRESERVED");
+  });
+
+  it("PRESERVES routing on INTERNAL — transient broker error, not a no-key answer", async () => {
+    const config = makeConfig(["alpha"]);
+    const prior = composeWith(["alpha"], ["alpha"]);
+    const confirmed = await resolveLiteLLMConfirmedAgents(config, prior, {
+      getKey: async () => ({ kind: "denied", code: "INTERNAL" }),
+    });
+    expect(confirmed.has("alpha")).toBe(true);
+    expect(warnSpy).toHaveBeenCalled();
+    const warned = warnSpy.mock.calls.flat().join("\n");
+    expect(warned).toContain("alpha");
+    expect(warned).toContain("PRESERVED");
+  });
+
   it("PRESERVES routing for an unreachable agent that was routed on disk", async () => {
     const config = makeConfig(["alpha"]);
     const prior = composeWith(["alpha"], ["alpha"]);


### PR DESCRIPTION
## Summary

Three adversarially-confirmed reliability bugs in the LiteLLM proxy carve-out, all violating the same product invariant: **ALL model traffic must stay routed through the LiteLLM proxy for cost/token tracking and policy; a proxy outage must degrade loudly and self-heal, never silently fall back to untracked direct OAuth.** (`reference/invariants.md` § "Operator-controlled gateway carve-out"; job: keep the fleet subscription-honest + always-available.)

### 1. Boot-while-proxy-down never recovers — `profiles/_base/start.sh.hbs` (outer + inner blocks)
- **Symptom it kills:** an agent that booted while the proxy was down kept `ANTHROPIC_BASE_URL` pointed at the proxy (correct, per #2940) but `ANTHROPIC_CUSTOM_HEADERS` was exported *only* in the reachable (`sr_ll_ok`) arm. The PROXY-UNREACHABLE arm was a no-op even though the virtual key had been fetched, so the key never reached the process env: once the proxy recovered, every request 401'd until a manual restart — flatly contradicting the branch's own "self-heals" comment. The gateway's `sr-*` model discovery (`discoverSrModels`, which requires the header) also stayed dead.
- **Invariant it restores:** proxy-routed traffic that actually self-heals. The header (and `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY`) is now exported whenever the key fetch succeeded, regardless of probe outcome. The reachability probe now gates **only** the `_LITELLM_OK` flag (the `sr-*` session-override drop) and the log wording.

### 2. Silent fleet routing strip on vault-broker outage — `src/cli/write-compose.ts`
- **Symptom it kills:** `resolveLiteLLMConfirmedAgents` treated *any* broker failure (unreachable, timeout, import failure) identically to key-not-found and dropped every opted-in agent from the confirmed set, so `compose.ts` omitted `SWITCHROOM_LITELLM`/`ANTHROPIC_BASE_URL`. Because `writeComposeFile` runs on `agent restart` as well as `apply`, any container recreated during a broker blip silently booted on untracked direct OAuth.
- **Invariant it restores:** a broker blip can no longer downgrade a routed agent. **Chosen approach: preserve the on-disk verdict** (documented choice) rather than fail the whole operation — it fits the existing code (this path already reads the previous compose for image-tag drift) and mirrors start.sh's "keep routing, self-heal" philosophy, whereas hard-failing would block every restart during a transient blip. We now distinguish `not_found`/`denied` (legitimate strip) from `unreachable`; on unreachable we re-parse the agent's prior `SWITCHROOM_LITELLM: "1"` verdict from the current generated compose (`agentHadLiteLLMRouting`) and keep it. Every branch emits a **loud `console.warn` naming the affected agents**. First-ever apply (no prior compose) stays unrouted — the safe default for a never-provisioned agent.

### 3. Cron sessions still failed open (pre-#2940 logic) — `profiles/_base/cron-session.sh.hbs`
- **Symptom it kills:** a one-shot 5s probe that, on unreachable, unset `ANTHROPIC_BASE_URL`/`SWITCHROOM_LITELLM` → untracked direct OAuth for that cron fire.
- **Invariant it restores:** cron obeys the same contract as start.sh. Missing key → strip (fail-open still correct there); proxy unreachable with key in hand → keep routing + export the header + loud log so the fire self-heals. **Retry budget is a deliberately short 3 attempts / ~15s** (documented) vs start.sh's 120s, because a cron fire is latency-sensitive and short-lived and unreachable now keeps routing regardless. Also resolved the cosmetic identity drift by unifying on the compile-time-literal form: vault key stays `{{name}}` (base name, documented), attribution headers use the `{{name}}-cron` literal (identical value to the old runtime `$SWITCHROOM_AGENT_NAME`).

**Non-goals (untouched, per separate PRs):** the missing-key fail-open policy in start.sh, provisioning, and `reference/` docs.

## Test plan
- `tests/scaffold.litellm-gateway-outer.test.ts` — new executed-dispatch assertion that the auth header (with the key) **survives the UNREACHABLE branch**, plus the reachable + missing-key paths.
- `tests/scaffold.litellm-failopen.test.ts` — updated to the shared-arm contract (header exported for both `sr_ll_ok` and `sr_ll_unreachable`; probe gates only `_LITELLM_OK`).
- `tests/cheap-cron-session-render.test.ts` — unreachable-keeps-routing + short-retry-budget + executed dispatch proving header/routing survive on unreachable and strip on missing key; identity-drift assertion.
- `tests/write-compose.litellm-resolve.test.ts` (new) — `agentHadLiteLLMRouting` parsing + `not_found`→strip vs `unreachable`→preserve vs `ok`→confirm, mixed-fleet split, throw-treated-as-unreachable, and loud-warning content.
- Scoped `vitest` for all touched files: **49 passed**. `npm run lint`: **clean** (tsc + all 8 guards).
- Classification note: `tests/host-home-resolver.test.ts` fails **only** in this in-container dev sandbox (its own comment documents it assumes a non-Docker host; `/.dockerenv` + `SWITCHROOM_CONTAINER=1` flip `isContainerContext()` true). It exercises `resolveHostHomeForCompose`, which this PR does not touch — environment-only artifact, CI runs on non-container runners.

## Risk
Shell-template + compose-gen changes only; no runtime code path outside boot/compose generation. Routing is preserved-or-kept in every ambiguous case (never newly stripped), so the change is strictly safer than the status quo. Running agents pick up the start.sh/cron changes only on restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)