### PR TITLE
fix(model): /model switches always stick and /status reports the truth

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -18740,9 +18740,18 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
     scheduleRestart: async (reason: string) => {
       const name = getMyAgentName()
       // Debounce: mirror the /restart command's 15 s guard to prevent
-      // double-dispatch on a rapid double-tap of /model <claude-alias>.
+      // double-dispatch on a rapid double-tap of /model <claude-alias>. This
+      // path previously `return`ed silently — indistinguishable from a
+      // successful dispatch — so a model switch caught in the window was a
+      // silent no-op while the caller reported success. THROW a tagged error
+      // so scheduleModelRelaunch can react (keep the in-flight restart's carrier,
+      // tell the operator honestly) instead of falsely claiming the switch stuck.
       const existing = readRestartMarker()
-      if (existing && Date.now() - existing.ts < 15_000) return
+      if (existing && Date.now() - existing.ts < 15_000) {
+        const e = new Error('a restart is already in flight — try again in ~15s')
+        ;(e as { code?: string }).code = 'restart_in_flight'
+        throw e
+      }
       if (restartCtx) {
         writeRestartMarker({
           chat_id: restartCtx.chatId,
@@ -18792,9 +18801,25 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
       if (!agentDir) throw new Error('agent dir unresolvable — cannot write session-model carrier')
       // Carrier: single line, token + newline, no quoting (start.sh strips
       // whitespace and shape-gates). One-shot — consumed on the next boot.
+      const prevOverride = activeSessionModelOverride
       writeFileSync(join(agentDir, '.session-model-override'), `${model}\n`, 'utf8')
       activeSessionModelOverride = model
-      await deps.scheduleRestart(reason)
+      try {
+        await deps.scheduleRestart(reason)
+      } catch (err) {
+        const carrierPath = join(agentDir, '.session-model-override')
+        // A restart already in flight OWNS the carrier we just wrote — it will
+        // consume our token at boot, so the switch is queued, not lost: keep the
+        // carrier + override and let the caller tell the operator "~15s". Any
+        // OTHER dispatch failure means no restart is coming, so roll BOTH back —
+        // a lingering carrier/override would lie to /status and mis-launch the
+        // NEXT ordinary restart.
+        if ((err as { code?: string })?.code !== 'restart_in_flight') {
+          try { rmSync(carrierPath, { force: true }) } catch { /* best-effort */ }
+          activeSessionModelOverride = prevOverride
+        }
+        throw err
+      }
     },
   }
   return deps
@@ -18823,6 +18848,15 @@ bot.command('model', async ctx => {
     return
   }
   const reply = await handleModelCommand(parsed, deps)
+  // Record a POSITIVELY-CONFIRMED typed switch so /status reflects what's
+  // actually running — the SAME in-memory override the menu callback path sets
+  // (buildAgentMetadata reads activeSessionModelOverride as sessionModel). Only
+  // set on the confirmed inject path; the sr-*/relaunch paths already set the
+  // override inside scheduleModelRelaunch, and an unverified switch carries no
+  // selectedModel so /status is never lied to.
+  if (reply.selectedModel) {
+    activeSessionModelOverride = reply.selectedModel
+  }
   await switchroomReply(ctx, reply.text, { html: reply.html })
 })
 
@@ -23949,6 +23983,25 @@ bot.on('callback_query:data', async ctx => {
             { reply_markup: { inline_keyboard: [] } },
           )
           .catch(() => {})
+        // Carry the requested Claude model across the restart via the SAME
+        // `.session-model-override` carrier a Claude → sr-* switch uses — otherwise
+        // boot launches the CONFIGURED default and the tapped model is silently
+        // dropped. `selectedModelToken` is a real `claude --model` token (alias or
+        // full claude-* id); a "Default"-row tap yields no token → boot the
+        // configured default (correct). start.sh's LiteLLM-down guard only drops
+        // sr-* overrides, so a Claude token is never dropped.
+        {
+          const agentDir = resolveAgentDirFromEnv()
+          const token = outcome.selectedModelToken
+          if (agentDir && token) {
+            try {
+              writeFileSync(join(agentDir, '.session-model-override'), `${token}\n`, 'utf8')
+              activeSessionModelOverride = token
+            } catch (e) {
+              process.stderr.write(`telegram gateway: sr-to-claude carrier write failed: ${(e as Error)?.message ?? String(e)}\n`)
+            }
+          }
+        }
         // Write the restart marker so the post-restart boot card edits into this chat.
         writeRestartMarker({ chat_id: cbChatId, thread_id: cbThreadId ?? null, ack_message_id: null, ts: Date.now() })
         stampUserRestartReason('user: sr-to-claude model switch (menu)')

--- a/telegram-plugin/gateway/inject-handler.test.ts
+++ b/telegram-plugin/gateway/inject-handler.test.ts
@@ -104,6 +104,25 @@ describe('handleInjectCommand — guards', () => {
     expect(replies[0].text).toContain('Usage')
     expect(replies[0].text).toContain('/cost')
   })
+
+  it('refuses `/inject /model <name>` and points at the real /model driver', async () => {
+    // Bug 7c: /inject /model <arg> bypasses the whole /model driver (no busy
+    // gate, no sr-* carrier/base-URL repoint, no session-override recording).
+    const inject = vi.fn()
+    const { deps, replies } = makeDeps({ getArgs: () => '/model sonnet', inject })
+    await handleInjectCommand(fakeCtx(), deps)
+    expect(inject).not.toHaveBeenCalled()
+    expect(replies).toHaveLength(1)
+    expect(replies[0].text).toContain('/model sonnet')
+    expect(replies[0].text).toContain('own driver')
+  })
+
+  it('still allows bare `/inject /model` (read-only picker) through', async () => {
+    const inject = vi.fn().mockResolvedValue(okResult('/model', 'picker output'))
+    const { deps } = makeDeps({ getArgs: () => '/model', inject })
+    await handleInjectCommand(fakeCtx(), deps)
+    expect(inject).toHaveBeenCalledWith('gymbro', '/model')
+  })
 })
 
 describe('handleInjectCommand — outcome=ok', () => {

--- a/telegram-plugin/gateway/inject-handler.ts
+++ b/telegram-plugin/gateway/inject-handler.ts
@@ -146,6 +146,23 @@ export async function handleInjectCommand(ctx: Context, deps: InjectDeps): Promi
     return
   }
   const slashCommand = arg.startsWith('/') ? arg : `/${arg}`
+
+  // `/inject /model <name>` would type `/model <name>` straight into the pane,
+  // bypassing the entire /model driver — no busy gate, no sr-* carrier/base-URL
+  // repoint, no session-override recording. That path silently fails for sr-*
+  // ids and leaves /status stale for Claude ones. Route the operator to the real
+  // command. Bare `/inject /model` (no arg) still opens claude's read-only picker.
+  const injectTokens = slashCommand.split(/\s+/)
+  if (injectTokens[0]?.toLowerCase() === '/model' && injectTokens.length > 1) {
+    const modelArg = injectTokens.slice(1).join(' ')
+    await deps.reply(
+      ctx,
+      `\`/model\` has its own driver — use \`/model ${deps.escapeHtml(modelArg)}\` directly (not via \`/inject\`) so the switch is gated, recorded, and \`/status\` stays honest.`,
+      { html: true },
+    )
+    return
+  }
+
   const agentName = deps.getAgentName()
 
   let result: InjectResult

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -111,6 +111,15 @@ export function parseModelCommand(text: string): ParsedModelCommand | null {
 export interface ModelCommandDeps {
   /** Inject primitive — wired to injectSlashCommand in the gateway. */
   inject: (agent: string, command: string) => Promise<InjectResult>
+  /**
+   * True while the agent is mid-turn. A typed `/model <name>` switch drives
+   * claude's session (either an inject into the input box, or a carrier-backed
+   * restart) — doing either mid-turn is unsafe: an inject queues `/model` as
+   * user text instead of switching, and a restart would tear down the live
+   * turn. So the set path refuses when this is true and asks the operator to
+   * retry, exactly like the menu callback path (`ModelMenuDeps.isBusy`).
+   */
+  isBusy: () => boolean
   getAgentName: () => string
   /**
    * The agent's configured model from `switchroom agent list` (the
@@ -153,6 +162,16 @@ export interface ModelCommandDeps {
 export interface ModelCommandReply {
   text: string
   html: true
+  /**
+   * On a POSITIVELY-CONFIRMED typed switch, the model now running this session
+   * (parsed from claude's confirmation, falling back to the requested token).
+   * The gateway records this as the session-model override so `/status` reflects
+   * what's actually running — the SAME code path the menu callback uses via
+   * `ModelCallbackOutcome.selectedModel`. Absent on every unverified / non-switch
+   * outcome (silent capture, error, busy refusal) so an unconfirmed switch never
+   * lies to `/status`.
+   */
+  selectedModel?: string
 }
 
 const PERSIST_NOTE =
@@ -205,16 +224,37 @@ export async function handleModelCommand(
   // Expand short aliases: `flash` → `sr-gemini-2.5-flash`, `codex` → `sr-codex-5.5`, etc.
   const model = expandSrAlias(parsed.model)
 
+  // Busy gate: a typed switch either injects into claude's input box or triggers
+  // a carrier-backed restart. Both are unsafe mid-turn — an inject queues the
+  // `/model` text instead of switching, and a restart kills the live turn. Refuse
+  // and ask the operator to retry (parity with the menu callback's isBusy check).
+  if (deps.isBusy()) {
+    return {
+      text: '⏳ The agent is mid-turn — a model switch needs an idle session. Try again in a moment.',
+      html: true,
+    }
+  }
+
   // sr-* → Claude: an in-place `/model` inject would leave LiteLLM routing
   // active in the live session because the sr-* model context was set by
   // the proxy at session start, not by claude's own REPL. A graceful restart
-  // is the only clean path back to the native OAuth route. This matches the
-  // behaviour of the `/restart` command (same mechanism, same marker logic).
+  // is the only clean path back to the native OAuth route. Route it through the
+  // SAME carrier mechanism as a Claude → sr-* switch (scheduleModelRelaunch)
+  // so the requested Claude model is written to `.session-model-override` and
+  // survives the restart — otherwise boot launches the configured default and
+  // the operator's choice is silently dropped. start.sh's LiteLLM-down guard
+  // only special-cases `sr-*` overrides, so a Claude token is never dropped.
   const currentSession = deps.getActiveSessionModel()
   if (currentSession !== null && isSrModel(currentSession) && isClaudeModel(model)) {
     try {
-      await deps.scheduleRestart(`user: /model ${model} (sr-to-claude restart)`)
+      await deps.scheduleModelRelaunch(model, `user: /model ${model} (sr-to-claude restart)`)
     } catch (err) {
+      if (isRestartInFlight(err)) {
+        return {
+          text: `⏳ A restart is already in flight — your switch to \`${deps.escapeHtml(model)}\` will apply as it completes (~15s).`,
+          html: true,
+        }
+      }
       const msg = err instanceof Error ? err.message : String(err)
       return {
         text: `❌ Could not schedule restart: ${deps.escapeHtml(msg)}`,
@@ -239,6 +279,12 @@ export async function handleModelCommand(
     try {
       await deps.scheduleModelRelaunch(model, `user: /model ${model} (session-only relaunch)`)
     } catch (err) {
+      if (isRestartInFlight(err)) {
+        return {
+          text: `⏳ A restart is already in flight — your switch to \`${deps.escapeHtml(model)}\` will apply as it completes (~15s).`,
+          html: true,
+        }
+      }
       const msg = err instanceof Error ? err.message : String(err)
       return {
         text: `❌ Could not schedule model switch: ${deps.escapeHtml(msg)}`,
@@ -267,17 +313,33 @@ export async function handleModelCommand(
   }
 
   if (result.outcome === 'ok') {
-    // claude's `/model <name>` switches the session SILENTLY — it does not
-    // print a confirmation line. So `result.output` on this path is almost
-    // always just whatever pane scrollback sat below the command echo (the
-    // agent's previous prose answer). `isTuiChromeLine` strips borders/glyphs
-    // but NOT ordinary prose, so blindly `preBlock`-ing `result.output` here
-    // dumped that unrelated scrollback back to the user as a code block
-    // (screenshot-confirmed on klanker, v0.16.47). Only relay output when it
-    // actually looks like a model-switch acknowledgement; otherwise suppress
-    // it and send a clean confirmation.
+    // claude's `/model <name>` either prints a "Set model to X" acknowledgement
+    // or switches SILENTLY (no line). `result.output` on the silent path is just
+    // whatever pane scrollback sat below the command echo (the agent's previous
+    // prose answer) — NOT a confirmation. We MUST NOT claim success on that
+    // scrollback, and we must never dump it back as a code block (screenshot-
+    // confirmed leak on klanker, v0.16.47).
+    //
+    // Honest reporting: (1) if claude printed an error ("Model not found" /
+    // "Invalid model"), the switch FAILED — say so. (2) if an anchored
+    // confirmation line is present, the switch is verified — relay it and record
+    // the live model for /status. (3) otherwise we cannot positively verify the
+    // switch (silent success or nothing) — say "sent, but couldn't confirm" and
+    // record NOTHING, so /status is never lied to.
+    const errLine = modelSwitchErrorLine(result.output)
+    if (errLine) {
+      return {
+        text: [
+          `❌ ${verbHtml} — the switch did not take:`,
+          deps.preBlock(errLine),
+          'Check \`/model\` for valid model names.',
+        ].join('\n'),
+        html: true,
+      }
+    }
     const confirmation = modelSwitchConfirmationLine(result.output)
     if (confirmation) {
+      const confirmed = sessionModelFromConfirmation(confirmation) ?? model
       return {
         text: [
           `${verbHtml}`,
@@ -286,11 +348,14 @@ export async function handleModelCommand(
           PERSIST_NOTE,
         ].join('\n'),
         html: true,
+        // Only record when the confirmation carries a real switch (Set/Switched);
+        // a "Kept model as" line means no change — don't overwrite the override.
+        ...(isKeptModelConfirmation(confirmation) ? {} : { selectedModel: confirmed }),
       }
     }
     return {
       text: [
-        `${verbHtml} — switched (session).`,
+        `${verbHtml} — sent, but couldn't confirm the switch — check \`/status\`.`,
         PERSIST_NOTE,
       ].join('\n'),
       html: true,
@@ -676,6 +741,16 @@ export interface ModelCallbackOutcome {
    * Absent on every non-switch outcome.
    */
   selectedModel?: string
+  /**
+   * The canonical `claude --model` token (alias or full `claude-*` id) for a
+   * Claude selection, when derivable — distinct from `selectedModel` (a display
+   * name for /status). The gateway writes this to the `.session-model-override`
+   * carrier on an sr-* → Claude transition so the requested Claude model survives
+   * the restart (otherwise boot launches the configured default). Absent when the
+   * target has no derivable token (e.g. the "Default" row → boot the configured
+   * default).
+   */
+  selectedModelToken?: string
   /** Short toast for answerCallbackQuery. */
   answer: string
   /** Replacement dashboard (message edit). */
@@ -732,15 +807,19 @@ export async function handleModelMenuCallback(
       }
     }
     if (aliasResult.outcome === 'ok') {
+      // Anchored confirmation only — a loose /set model|switched/ match false-
+      // positives on ordinary scrollback prose ("I switched the deploy…").
       const confirmation =
-        aliasResult.output
-          .split('\n')
-          .map((l) => l.trim())
-          .find((l) => /set model|switched/i.test(l)) ?? `Switched to ${alias} (session)`
+        modelSwitchConfirmationLine(aliasResult.output) ?? `Switched to ${alias} (session)`
+      // "Kept model as X" means no change — don't overwrite the override.
+      const kept = isKeptModelConfirmation(confirmation)
       return {
         answer: confirmation,
         reply: await menuWithBannerStatic(deps, `✅ ${deps.escapeHtml(confirmation)}`),
-        selectedModel: sessionModelFromConfirmation(confirmation) ?? alias,
+        ...(kept ? {} : {
+          selectedModel: sessionModelFromConfirmation(confirmation) ?? alias,
+          selectedModelToken: alias,
+        }),
       }
     }
     return {
@@ -759,11 +838,17 @@ export async function handleModelMenuCallback(
     return { answer: 'Tap a model in this section to switch', reply: { text: '', html: true }, toastOnly: true }
   }
 
-  // sr-* model tap: text-inject `/model sr-<name>` rather than cursor-nav.
-  // Text-inject is more reliable when the picker has many models; sr-* names
-  // are safe (no entry in model_group_settings → no OAuth forwarding). See I6.
+  // sr-* model tap. In the live gateway this branch is DEAD — the gateway
+  // intercepts `mdl:sr:` at its callback dispatcher (before calling this
+  // function) and routes it straight to scheduleModelRelaunch (carrier + restart).
+  // The old body here text-injected `/model sr-<name>`, which is doubly broken if
+  // ever reached: claude's picker rejects unknown sr-* ids AND the ANTHROPIC_BASE_URL
+  // is never repointed at the LiteLLM router, so the request 4xxs against Anthropic.
+  // Delegate to the SAME carrier mechanism so a direct caller (tests, a future
+  // refactor that drops the gateway intercept) still does the safe thing.
   if (data.startsWith(MODEL_CALLBACK_SR)) {
     const srName = data.slice(MODEL_CALLBACK_SR.length)
+    const friendlyName = srFriendlyLabel(srName)
     if (!isValidModelArg(srName)) {
       return { answer: 'Invalid model name', reply: await buildModelMenu(deps) }
     }
@@ -774,39 +859,22 @@ export async function handleModelMenuCallback(
         toastOnly: true,
       }
     }
-    let srResult: InjectResult
     try {
-      srResult = await deps.inject(deps.getAgentName(), `/model ${srName}`)
+      await deps.scheduleModelRelaunch(srName, `user: /model ${srName} (session-only relaunch, menu)`)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       return {
         answer: 'Switch failed',
-        reply: await menuWithBanner(deps, `❌ Switch to **${deps.escapeHtml(srName)}** failed: ${deps.escapeHtml(msg)}`),
-      }
-    }
-    if (srResult.outcome === 'ok') {
-      const friendlyName = srFriendlyLabel(srName)
-      const confirmation =
-        srResult.output
-          .split('\n')
-          .map((l) => l.trim())
-          .find((l) => /set model|switched/i.test(l)) ?? `Switched to ${friendlyName} (session)`
-      return {
-        answer: confirmation,
-        // Use the static (no-discover) path — after a text-inject the picker
-        // is in flux and discover() reliably fails, producing a spurious
-        // "(picker unavailable)" line that reads as an error when the switch
-        // actually succeeded.
-        reply: await menuWithBannerStatic(deps, `✅ ${deps.escapeHtml(confirmation)}`),
-        selectedModel: srName,
+        reply: await menuWithBannerStatic(deps, `❌ Switch to **${deps.escapeHtml(friendlyName)}** failed: ${deps.escapeHtml(msg)}`),
       }
     }
     return {
-      answer: 'Switch failed',
-      reply: await menuWithBanner(
+      answer: `Switching to ${friendlyName} — restarting (~30s)`,
+      reply: await menuWithBannerStatic(
         deps,
-        `❌ Switch to **${deps.escapeHtml(srFriendlyLabel(srName))}** failed — agent may be mid-turn`,
+        `🔄 Switching session to **${deps.escapeHtml(friendlyName)}** — restarting (~30s). _Session-only; reverts to the configured default on the next restart._`,
       ),
+      selectedModel: srName,
     }
   }
 
@@ -866,10 +934,26 @@ export async function handleModelMenuCallback(
     }
   }
 
+  // "Kept model as X" means the tapped model was ALREADY the session model —
+  // nothing changed. Do NOT overwrite the override (and never store the display
+  // label). Tapping the "Default (recommended)" row on the already-default model
+  // previously stored "Default (recommended)" verbatim into /status.
+  if (isKeptModelConfirmation(result.confirmation)) {
+    return {
+      answer: deps.escapeHtml(result.confirmation),
+      reply: await menuWithBanner(deps, `✅ ${deps.escapeHtml(result.confirmation)}`),
+    }
+  }
+  // Normalize what we store: prefer the model name claude confirmed, else a
+  // canonical token derived from the row label — never a pure display label like
+  // "Default (recommended)". If neither resolves, record nothing rather than lie.
+  const token = canonicalClaudeToken(target.label)
+  const selectedModel = sessionModelFromConfirmation(result.confirmation) ?? token ?? undefined
   return {
     answer: deps.escapeHtml(result.confirmation),
     reply: await menuWithBanner(deps, `✅ ${deps.escapeHtml(result.confirmation)}`),
-    selectedModel: sessionModelFromConfirmation(result.confirmation) ?? target.label,
+    ...(selectedModel ? { selectedModel } : {}),
+    ...(token ? { selectedModelToken: token } : {}),
   }
 }
 
@@ -902,6 +986,63 @@ export function modelSwitchConfirmationLine(output: string): string | null {
     .map((l) => l.trim())
     .find((l) => MODEL_SWITCH_CONFIRMATION_PREFIX.test(l))
   return line && line.length > 0 ? line : null
+}
+
+/**
+ * claude's failure output for a bad `/model <name>` — the CLI rejects an
+ * unknown id with "Model not found" / "Invalid model" / "Unknown model".
+ * Detecting it lets the typed set path report an HONEST failure instead of
+ * falsely claiming "switched (session)". Anchored to real phrasings, not a
+ * loose word match, so ordinary scrollback prose can't false-positive.
+ */
+const MODEL_SWITCH_ERROR_RE = /\b(?:model not found|invalid model|unknown model|no such model)\b/i
+
+/** The single capture line that reads as a claude model-switch error, or null. */
+export function modelSwitchErrorLine(output: string): string | null {
+  const line = output
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => MODEL_SWITCH_ERROR_RE.test(l))
+  return line && line.length > 0 ? line : null
+}
+
+/**
+ * True when a confirmation line is claude's "Kept model as X" — i.e. the model
+ * was ALREADY the session model and nothing changed. The caller must NOT record
+ * this as a session-override (there is nothing to override), and must not store
+ * a display label in its place. See the menu-select bug where tapping the
+ * "Default (recommended)" row on the already-default model stored the display
+ * label verbatim into /status.
+ */
+export function isKeptModelConfirmation(confirmation: string): boolean {
+  return /^\s*[⏺●•>-]?\s*Kept model as\b/i.test(confirmation.trim())
+}
+
+/**
+ * Normalize a picker ROW LABEL to a canonical `claude --model` token suitable
+ * for the `.session-model-override` carrier (aliases and full `claude-*` ids —
+ * NOT display strings like "Default (recommended)" or "Opus 4.8", which the CLI
+ * flag rejects). Returns null when the label is a pure display label with no
+ * derivable token: for the "Default" row that correctly means "boot the
+ * configured default" (write no carrier).
+ */
+export function canonicalClaudeToken(label: string): string | null {
+  const l = label.trim()
+  if (l.toLowerCase().startsWith('claude-')) return l
+  const first = l.toLowerCase().split(/\s+/)[0]
+  if (first === 'default') return null
+  if ((MODEL_ALIASES as readonly string[]).includes(first)) return first
+  return null
+}
+
+/**
+ * True when an error thrown by scheduleRestart / scheduleModelRelaunch signals
+ * "a restart is already in flight" (the gateway's 15s debounce) rather than a
+ * genuine dispatch failure. Carried as a `code` property so model-command.ts
+ * need not import the gateway's error type.
+ */
+export function isRestartInFlight(err: unknown): boolean {
+  return !!err && typeof err === 'object' && (err as { code?: unknown }).code === 'restart_in_flight'
 }
 
 /**

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -992,10 +992,20 @@ export function modelSwitchConfirmationLine(output: string): string | null {
  * claude's failure output for a bad `/model <name>` — the CLI rejects an
  * unknown id with "Model not found" / "Invalid model" / "Unknown model".
  * Detecting it lets the typed set path report an HONEST failure instead of
- * falsely claiming "switched (session)". Anchored to real phrasings, not a
- * loose word match, so ordinary scrollback prose can't false-positive.
+ * falsely claiming "switched (session)". Anchored to LINE START (behind the
+ * same optional status glyph + optional "Error:" prefix as
+ * MODEL_SWITCH_CONFIRMATION_PREFIX) so ordinary scrollback prose that merely
+ * CONTAINS the phrase mid-sentence (e.g. "deploy failed: model not found in
+ * registry") can never false-positive a successful switch into a reported
+ * failure — the false-FAILURE variant of the scrollback-leak class.
+ *
+ * Empirically verified against claude v2.1.205 (disposable TUI probe,
+ * 2026-07-10): `/model claude-bogus-99` prints
+ * `⎿  Model 'claude-bogus-99' not found` — glyph prefix `⎿`, quoted model
+ * name between "Model" and "not found". Both shapes are covered.
  */
-const MODEL_SWITCH_ERROR_RE = /\b(?:model not found|invalid model|unknown model|no such model)\b/i
+const MODEL_SWITCH_ERROR_RE =
+  /^\s*[⏺●•>⎿-]?\s*(?:Error:\s*)?(?:Model(?:\s+'[^']+')?\s+not found|Invalid model|Unknown model|No such model)\b/i
 
 /** The single capture line that reads as a claude model-switch error, or null. */
 export function modelSwitchErrorLine(output: string): string | null {
@@ -1015,7 +1025,7 @@ export function modelSwitchErrorLine(output: string): string | null {
  * label verbatim into /status.
  */
 export function isKeptModelConfirmation(confirmation: string): boolean {
-  return /^\s*[⏺●•>-]?\s*Kept model as\b/i.test(confirmation.trim())
+  return /^\s*[⏺●•>⎿-]?\s*Kept model as\b/i.test(confirmation.trim())
 }
 
 /**
@@ -1047,25 +1057,35 @@ export function isRestartInFlight(err: unknown): boolean {
 
 /**
  * claude's real model-switch confirmation always begins the line (optionally
- * behind a status glyph like `⏺` + whitespace) with one of these exact
+ * behind a status glyph like `⏺` or `⎿` + whitespace) with one of these exact
  * phrasings. Anchoring to the line start keeps ordinary scrollback prose that
  * merely *contains* words like "switched" or "set model" (e.g. "I switched the
  * deploy to blue-green") from false-positiving as a confirmation worth
  * relaying. Shared by `modelSwitchConfirmationLine` (does this line qualify?)
  * and `sessionModelFromConfirmation` (pull the name out).
+ *
+ * Empirically verified against claude v2.1.205 (disposable TUI probe,
+ * 2026-07-10): the arg form `/model opus` is NOT silent — it prints
+ * `⎿  Set model to Opus 4.8 and saved as your default for new sessions`.
+ * The `⎿` glyph survives the inject capture (isTuiChromeLine doesn't strip
+ * it), so it must be in the glyph class or every typed switch would fall
+ * through to the "couldn't confirm" branch and never record the override.
  */
 const MODEL_SWITCH_CONFIRMATION_PREFIX =
-  /^\s*[⏺●•>-]?\s*(?:Set model to|Switched to|Kept model as)\b/i
+  /^\s*[⏺●•>⎿-]?\s*(?:Set model to|Switched to|Kept model as)\b/i
 
 /**
  * Pull the model NAME out of claude's session-switch confirmation so it can
  * be shown in `/status` as the live session model. claude phrases it as
- * "Set model to <name> for this session only" (or "Switched to <name>").
- * Returns null when the confirmation doesn't carry a recognizable name (the
- * caller falls back to the tapped picker label).
+ * "Set model to <name> for this session only" / "Switched to <name>" /
+ * (v2.1.205 arg form) "Set model to <name> and saved as your default for new
+ * sessions" — the "and saved" tail must terminate the name capture or the
+ * whole sentence would be stored as the model. Returns null when the
+ * confirmation doesn't carry a recognizable name (the caller falls back to
+ * the tapped picker label).
  */
 export function sessionModelFromConfirmation(confirmation: string): string | null {
-  const m = /(?:Set model to|Switched to)\s+(.+?)(?:\s+for (?:this|the) session|\s*\(|\s*$)/i.exec(
+  const m = /(?:Set model to|Switched to)\s+(.+?)(?:\s+for (?:this|the) session|\s+and saved\b|\s*\(|\s*$)/i.exec(
     confirmation.trim(),
   )
   const name = m?.[1]?.trim()

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -50,6 +50,7 @@ function makeDeps(overrides: Partial<ModelCommandDeps> = {}) {
       s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;"),
     preBlock: (s) => `<pre>${s}</pre>`,
     getActiveSessionModel: () => null,
+    isBusy: () => false,
     scheduleRestart: async (reason) => { restartCalls.push(reason); },
     scheduleModelRelaunch: async (model, reason) => { relaunchCalls.push({ model, reason }); },
     ...overrides,
@@ -202,6 +203,9 @@ describe("handleModelCommand — set", () => {
     expect(reply.text).toContain("<pre>⏺ Set model to sonnet</pre>");
     expect(reply.text).toContain("Session-only");
     expect(reply.html).toBe(true);
+    // A verified confirmation records the live model so /status stays honest
+    // (bug 1: the typed path never recorded the switch before).
+    expect(reply.selectedModel).toBe("sonnet");
   });
 
   it("SILENT switch: suppresses raw pane scrollback instead of dumping it as a code block", async () => {
@@ -219,10 +223,13 @@ describe("handleModelCommand — set", () => {
     expect(reply.text).not.toContain("summary you asked for");
     expect(reply.text).not.toContain("rollback plan");
     expect(reply.text).not.toContain("<pre>");
-    // A clean, session-scoped confirmation is sent instead.
+    // No confirmation line was captured, so the switch is UNVERIFIED — report it
+    // honestly (never a false "switched") and record NO session override.
     expect(reply.text).toContain("/model fable");
-    expect(reply.text).toContain("switched (session)");
-    expect(reply.text).toContain("Session-only");
+    expect(reply.text).toContain("couldn't confirm the switch");
+    expect(reply.text).toContain("/status");
+    expect(reply.text).not.toContain("switched (session)");
+    expect(reply.selectedModel).toBeUndefined();
     expect(reply.html).toBe(true);
   });
 
@@ -248,12 +255,15 @@ describe("handleModelCommand — set", () => {
     const { deps } = makeDeps({ inject: async () => okResult(prose) });
     const reply = await handleModelCommand({ kind: "set", model: "fable" }, deps);
     // The anchored regex rejects all three lines, so nothing leaks and there is
-    // no <pre> block. A clean session confirmation is sent instead.
+    // no <pre> block. With no confirmation captured, the switch is UNVERIFIED —
+    // report it honestly, never a false "switched".
     expect(reply.text).not.toContain("<pre>");
     expect(reply.text).not.toContain("switched the deploy");
     expect(reply.text).not.toContain("set model behaviour");
     expect(reply.text).not.toContain("kept model changes");
-    expect(reply.text).toContain("switched (session)");
+    expect(reply.text).toContain("couldn't confirm the switch");
+    expect(reply.text).not.toContain("switched (session)");
+    expect(reply.selectedModel).toBeUndefined();
     expect(reply.html).toBe(true);
   });
 
@@ -327,49 +337,55 @@ describe("isSrModel / isClaudeModel helpers", () => {
 });
 
 describe("handleModelCommand — sr-* → Claude graceful restart", () => {
-  it("schedules restart instead of injecting when session is on sr-* and target is Claude alias", async () => {
-    const { deps, calls, restartCalls } = makeDeps({
+  it("carries the requested Claude model across the restart (relaunch carrier), never injects", async () => {
+    const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
       getActiveSessionModel: () => "sr-gemini-2.5-pro",
     });
     const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
     // Must NOT inject
     expect(calls).toHaveLength(0);
-    // Must schedule a restart
-    expect(restartCalls).toHaveLength(1);
-    expect(restartCalls[0]).toContain("opus");
-    expect(restartCalls[0]).toContain("sr-to-claude");
+    // sr→Claude now rides the SAME carrier mechanism as Claude→sr so the
+    // requested Claude model survives the restart (bug 2). The bespoke
+    // scheduleRestart-without-carrier path is gone.
+    expect(restartCalls).toHaveLength(0);
+    expect(relaunchCalls).toHaveLength(1);
+    expect(relaunchCalls[0].model).toBe("opus");
+    expect(relaunchCalls[0].reason).toContain("sr-to-claude");
     // Reply mentions the sr-* model and ~30s
     expect(reply.text).toContain("sr-gemini-2.5-pro");
     expect(reply.text).toContain("30s");
     expect(reply.html).toBe(true);
   });
 
-  it("schedules restart when session is on sr-* and target is a full claude-* id", async () => {
-    const { deps, calls, restartCalls } = makeDeps({
+  it("carries a full claude-* id across the restart when session is on sr-*", async () => {
+    const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
       getActiveSessionModel: () => "sr-deepseek-r1",
     });
     const reply = await handleModelCommand({ kind: "set", model: "claude-opus-4-8" }, deps);
     expect(calls).toHaveLength(0);
-    expect(restartCalls).toHaveLength(1);
+    expect(restartCalls).toHaveLength(0);
+    expect(relaunchCalls).toHaveLength(1);
+    expect(relaunchCalls[0].model).toBe("claude-opus-4-8");
     expect(reply.text).toContain("sr-deepseek-r1");
     expect(reply.text).toContain("30s");
   });
 
   it("does NOT restart when switching between Claude models (no sr-* session)", async () => {
-    const { deps, calls, restartCalls } = makeDeps({
+    const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
       getActiveSessionModel: () => "Opus 4.8",
     });
     const reply = await handleModelCommand({ kind: "set", model: "sonnet" }, deps);
-    // Normal inject path: still injects, no restart
+    // Normal inject path: still injects, no restart, no relaunch
     expect(calls).toHaveLength(1);
     expect(restartCalls).toHaveLength(0);
+    expect(relaunchCalls).toHaveLength(0);
     expect(reply.text).toContain("Set model to sonnet");
   });
 
-  it("surfaces scheduleRestart failures without propagating the error", async () => {
+  it("surfaces relaunch dispatch failures without propagating the error", async () => {
     const { deps, calls } = makeDeps({
       getActiveSessionModel: () => "sr-deepseek-r1",
-      scheduleRestart: async () => { throw new Error("hostd unreachable"); },
+      scheduleModelRelaunch: async () => { throw new Error("hostd unreachable"); },
     });
     const reply = await handleModelCommand({ kind: "set", model: "sonnet" }, deps);
     expect(calls).toHaveLength(0);
@@ -377,13 +393,68 @@ describe("handleModelCommand — sr-* → Claude graceful restart", () => {
     expect(reply.text).toContain("hostd unreachable");
   });
 
+  it("reports 'restart already in flight' honestly on a debounced dispatch (no silent no-op)", async () => {
+    const { deps } = makeDeps({
+      getActiveSessionModel: () => "sr-deepseek-r1",
+      scheduleModelRelaunch: async () => {
+        const e = new Error("a restart is already in flight — try again in ~15s");
+        (e as { code?: string }).code = "restart_in_flight";
+        throw e;
+      },
+    });
+    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
+    expect(reply.text).toContain("restart is already in flight");
+    expect(reply.text).toContain("15s");
+    // Never a false success.
+    expect(reply.text).not.toContain("Set model to");
+  });
+
   it("null session model (no prior override) still uses normal inject path for Claude target", async () => {
-    const { deps, calls, restartCalls } = makeDeps({
+    const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
       getActiveSessionModel: () => null,
     });
     await handleModelCommand({ kind: "set", model: "opus" }, deps);
     expect(calls).toHaveLength(1);
     expect(restartCalls).toHaveLength(0);
+    expect(relaunchCalls).toHaveLength(0);
+  });
+});
+
+describe("handleModelCommand — busy gate + honest unverified reporting", () => {
+  it("refuses a typed switch while the agent is mid-turn (no inject, no relaunch)", async () => {
+    const { deps, calls, relaunchCalls } = makeDeps({ isBusy: () => true });
+    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
+    expect(calls).toHaveLength(0);
+    expect(relaunchCalls).toHaveLength(0);
+    expect(reply.text).toContain("mid-turn");
+    expect(reply.selectedModel).toBeUndefined();
+  });
+
+  it("refuses an sr-* switch too while mid-turn", async () => {
+    const { deps, relaunchCalls } = makeDeps({ isBusy: () => true });
+    const reply = await handleModelCommand({ kind: "set", model: "sr-glm-5" }, deps);
+    expect(relaunchCalls).toHaveLength(0);
+    expect(reply.text).toContain("mid-turn");
+  });
+
+  it("reports a claude error output as an HONEST failure, not a switch", async () => {
+    const { deps } = makeDeps({
+      inject: async () => okResult("Error: Model not found: bogus-model"),
+    });
+    const reply = await handleModelCommand({ kind: "set", model: "claude-bogus" }, deps);
+    expect(reply.text).toContain("did not take");
+    expect(reply.text).toContain("Model not found");
+    expect(reply.text).not.toContain("Session-only");
+    expect(reply.selectedModel).toBeUndefined();
+  });
+
+  it("does NOT record an override when the confirmation is 'Kept model as' (no change)", async () => {
+    const { deps } = makeDeps({
+      inject: async () => okResult("⏺ Kept model as Opus 4.8 (default)"),
+    });
+    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
+    // The kept line is still relayed as a confirmation, but nothing is recorded.
+    expect(reply.selectedModel).toBeUndefined();
   });
 });
 
@@ -423,14 +494,15 @@ describe("handleModelCommand — Claude → sr-* session relaunch", () => {
     expect(restartCalls).toHaveLength(0);
   });
 
-  it("sr-* → Claude still takes the scheduleRestart path (not scheduleModelRelaunch)", async () => {
+  it("sr-* → Claude rides scheduleModelRelaunch (carrier) so the Claude model survives the restart", async () => {
     const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
       getActiveSessionModel: () => "sr-glm-5",
     });
     await handleModelCommand({ kind: "set", model: "opus" }, deps);
     expect(calls).toHaveLength(0);
-    expect(relaunchCalls).toHaveLength(0);
-    expect(restartCalls).toHaveLength(1);
+    expect(restartCalls).toHaveLength(0);
+    expect(relaunchCalls).toHaveLength(1);
+    expect(relaunchCalls[0].model).toBe("opus");
   });
 
   it("surfaces scheduleModelRelaunch failures without propagating the error", async () => {
@@ -498,14 +570,15 @@ describe("handleModelCommand — arbitrary sr-* passthrough (no whitelist)", () 
     }
   });
 
-  it("switching FROM an arbitrary sr-* back to Claude takes the restart path", async () => {
+  it("switching FROM an arbitrary sr-* back to Claude carries the Claude model via the relaunch carrier", async () => {
     const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
       getActiveSessionModel: () => "sr-gpt-oss-120b",
     });
     await handleModelCommand({ kind: "set", model: "opus" }, deps);
     expect(calls).toHaveLength(0);
-    expect(relaunchCalls).toHaveLength(0);
-    expect(restartCalls).toHaveLength(1);
+    expect(restartCalls).toHaveLength(0);
+    expect(relaunchCalls).toHaveLength(1);
+    expect(relaunchCalls[0].model).toBe("opus");
   });
 });
 
@@ -565,14 +638,15 @@ describe("SR_MODEL_ALIASES / expandSrAlias", () => {
     expect(relaunchCalls[0].model).toBe("sr-gemini-2.5-flash");
   });
 
-  it("handleModelCommand with alias schedules restart when session is on sr-*", async () => {
-    const { deps, calls, restartCalls } = makeDeps({
+  it("handleModelCommand with a Claude alias relaunches (carrier) when session is on sr-*", async () => {
+    const { deps, calls, restartCalls, relaunchCalls } = makeDeps({
       getActiveSessionModel: () => "sr-deepseek-v3",
     });
     await handleModelCommand({ kind: "set", model: "opus" }, deps);
     expect(calls).toHaveLength(0);
-    expect(restartCalls).toHaveLength(1);
-    expect(restartCalls[0]).toContain("opus");
+    expect(restartCalls).toHaveLength(0);
+    expect(relaunchCalls).toHaveLength(1);
+    expect(relaunchCalls[0].model).toBe("opus");
   });
 });
 
@@ -745,6 +819,40 @@ describe("handleModelMenuCallback", () => {
     expect(out.reply.keyboard).toBeDefined();
     // The gateway records this so /status reflects the live session model.
     expect(out.selectedModel).toBe("Haiku 4.5");
+  });
+
+  it("tapping the Default row when already on it (Kept model as) records NO override", async () => {
+    // Bug 6: "Kept model as X" is a no-change; the old code fell back to
+    // target.label and stored "Default (recommended)" verbatim into /status.
+    const { deps } = makeMenuDeps({
+      select: async () => ({ ok: true as const, confirmation: "Kept model as Opus 4.8 (default)" }),
+    });
+    const out = await handleModelMenuCallback(modelSelectCallbackData("Default (recommended)"), deps);
+    expect(out.reply.text).toContain("✅");
+    // Crucially, NOTHING is recorded — no display label leaks into the override.
+    expect(out.selectedModel).toBeUndefined();
+    expect(out.reply.text).not.toContain("Default (recommended)");
+  });
+
+  it("a real switch on the Default row stores a canonical token, never the display label", async () => {
+    // The Default row confirms with a real model name; the /status value is that
+    // name (never "Default (recommended)"), and the carrier token is canonical.
+    const { deps } = makeMenuDeps({
+      select: async () => ({ ok: true as const, confirmation: "Set model to Opus 4.8 for this session only" }),
+    });
+    const out = await handleModelMenuCallback(modelSelectCallbackData("Default (recommended)"), deps);
+    expect(out.selectedModel).toBe("Opus 4.8");
+    // "Default (recommended)" yields no --model token → carrier boots the config default.
+    expect(out.selectedModelToken).toBeUndefined();
+  });
+
+  it("selecting an alias row exposes a canonical --model token for the sr→claude carrier", async () => {
+    const { deps } = makeMenuDeps({
+      select: async () => ({ ok: true as const, confirmation: "Set model to Sonnet for this session" }),
+    });
+    const out = await handleModelMenuCallback(modelSelectCallbackData("Sonnet"), deps);
+    expect(out.selectedModel).toBe("Sonnet");
+    expect(out.selectedModelToken).toBe("sonnet");
   });
 });
 
@@ -945,29 +1053,35 @@ describe("handleModelMenuCallback — sr-* selection", () => {
     });
   }
 
-  it("sr-* tap uses inject path, not cursor nav", async () => {
-    const { deps, calls, injectCalls } = makeMenuDepsWithSr();
+  it("sr-* tap delegates to the carrier relaunch — never a picker-rejecting inject", async () => {
+    // The gateway intercepts mdl:sr: before this function; if a direct caller
+    // reaches it, delegating to scheduleModelRelaunch is the ONLY safe path (an
+    // inject of `/model sr-*` 4xxs — picker rejects the id, base-URL never repointed).
+    const relaunch: Array<{ model: string }> = [];
+    const { deps, calls, injectCalls } = makeMenuDepsWithSr({
+      scheduleModelRelaunch: async (model) => { relaunch.push({ model }); },
+    });
     const out = await handleModelMenuCallback(`${MODEL_CALLBACK_SR}sr-gemini-2.5-pro`, deps);
-    // inject was called with the raw /model command
-    expect(injectCalls).toContainEqual({ agent: "klanker", command: "/model sr-gemini-2.5-pro" });
-    // select (cursor nav) was NOT called
+    // No inject, no cursor nav — a carrier relaunch on the exact sr-* id.
+    expect(injectCalls).toHaveLength(0);
     expect(calls.select).toHaveLength(0);
-    expect(out.answer).toContain("Set model to sonnet");
+    expect(relaunch).toEqual([{ model: "sr-gemini-2.5-pro" }]);
     expect(out.selectedModel).toBe("sr-gemini-2.5-pro");
-    // No keyboard on success: static reply path skips discover() to avoid the
-    // spurious "(picker unavailable)" line that discover() reliably produces
-    // immediately after an inject. Operator taps /model for a fresh menu.
     expect(out.reply.keyboard).toBeUndefined();
-    // Banner present and text doesn't contain picker-unavailable noise
-    expect(out.reply.text).toContain('✅');
+    expect(out.reply.text).toContain('🔄');
     expect(out.reply.text).not.toContain('picker unavailable');
   });
 
-  it("sr-* tap while busy returns toast-only with no inject", async () => {
-    const { deps, injectCalls } = makeMenuDepsWithSr({ isBusy: () => true });
+  it("sr-* tap while busy returns toast-only with no relaunch", async () => {
+    const relaunch: string[] = [];
+    const { deps, injectCalls } = makeMenuDepsWithSr({
+      isBusy: () => true,
+      scheduleModelRelaunch: async (model) => { relaunch.push(model); },
+    });
     const out = await handleModelMenuCallback(`${MODEL_CALLBACK_SR}sr-gemini-2.5-pro`, deps);
     expect(out.toastOnly).toBe(true);
     expect(injectCalls).toHaveLength(0);
+    expect(relaunch).toHaveLength(0);
   });
 
   it("rejects malformed sr-* callback data", async () => {

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -439,13 +439,54 @@ describe("handleModelCommand — busy gate + honest unverified reporting", () =>
 
   it("reports a claude error output as an HONEST failure, not a switch", async () => {
     const { deps } = makeDeps({
-      inject: async () => okResult("Error: Model not found: bogus-model"),
+      inject: async () => okResult("Error: Model not found"),
     });
     const reply = await handleModelCommand({ kind: "set", model: "claude-bogus" }, deps);
     expect(reply.text).toContain("did not take");
     expect(reply.text).toContain("Model not found");
     expect(reply.text).not.toContain("Session-only");
     expect(reply.selectedModel).toBeUndefined();
+  });
+
+  it("detects claude v2.1.205's real error shape: ⎿  Model 'name' not found (TUI-probe verified)", async () => {
+    // Captured verbatim from a disposable claude v2.1.205 TUI, 2026-07-10.
+    const { deps } = makeDeps({
+      inject: async () => okResult("⎿  Model 'claude-bogus-99' not found"),
+    });
+    const reply = await handleModelCommand({ kind: "set", model: "claude-bogus-99" }, deps);
+    expect(reply.text).toContain("did not take");
+    expect(reply.text).toContain("not found");
+    expect(reply.selectedModel).toBeUndefined();
+  });
+
+  it("scrollback prose CONTAINING 'model not found' mid-sentence is NOT a failure (anchored error scan)", async () => {
+    // The error regex is line-start anchored, like the confirmation prefix —
+    // prose that merely mentions the phrase must not flip a successful switch
+    // into a reported failure (the false-FAILURE variant of the scrollback-leak
+    // class this PR eliminates).
+    const { deps } = makeDeps({
+      inject: async () => okResult("deploy failed: model not found in registry"),
+    });
+    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
+    expect(reply.text).not.toContain("did not take");
+    expect(reply.text).not.toContain("model not found");
+    // No confirmation either → honest unverified message, nothing recorded.
+    expect(reply.text).toContain("couldn't confirm the switch");
+    expect(reply.selectedModel).toBeUndefined();
+  });
+
+  it("recognises claude v2.1.205's real arg-form confirmation (⎿ glyph + 'and saved as your default')", async () => {
+    // Captured verbatim from a disposable claude v2.1.205 TUI, 2026-07-10:
+    // the arg form is NOT silent — it prints this line, and the ⎿ glyph
+    // survives the inject capture. The name extraction must stop at "and
+    // saved", not swallow the whole sentence.
+    const { deps } = makeDeps({
+      inject: async () =>
+        okResult("⎿  Set model to Opus 4.8 and saved as your default for new sessions"),
+    });
+    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
+    expect(reply.text).toContain("Set model to Opus 4.8");
+    expect(reply.selectedModel).toBe("Opus 4.8");
   });
 
   it("does NOT record an override when the confirmation is 'Kept model as' (no change)", async () => {
@@ -861,6 +902,11 @@ describe("sessionModelFromConfirmation", () => {
     expect(sessionModelFromConfirmation("Set model to Fable 5 for this session only")).toBe("Fable 5");
     expect(sessionModelFromConfirmation("Set model to Opus 4.8 (1M context) for this session only")).toBe("Opus 4.8");
     expect(sessionModelFromConfirmation("Switched to Haiku 4.5")).toBe("Haiku 4.5");
+  });
+  it("terminates the name at 'and saved' (claude v2.1.205 arg-form phrasing, TUI-probe verified)", () => {
+    expect(
+      sessionModelFromConfirmation("⎿  Set model to Opus 4.8 and saved as your default for new sessions"),
+    ).toBe("Opus 4.8");
   });
   it("returns null when no recognizable name is present", () => {
     expect(sessionModelFromConfirmation("Kept model as Opus 4.8 (default)")).toBeNull();


### PR DESCRIPTION
## Summary

The `/model` command path had seven adversarially-confirmed bugs: a switch could silently vanish while chat reported success, or `/status` could show a model the session was never running. This makes typed and menu switches use one shared override-recording path, carries the requested model across every restart, and makes success reporting honest.

**Job spec:** `reference/jobs/` — on-the-leash control surface (`/model` + `/status` must tell the truth about the live session). Advances the vision "on the leash" + "always available" outcomes.

## Why / the symptom each fix kills

1. **Typed `/model <claude>` never recorded the switch** → `/status` kept showing the old model. Now `handleModelCommand` returns `selectedModel`; the gateway records it into `activeSessionModelOverride` (the same field the menu path sets and `buildAgentMetadata` reads as `sessionModel`).
2. **sr-* → Claude discarded the requested model** → boot relaunched the configured default, not what you picked. Both the typed and menu paths now route through the `.session-model-override` carrier so the chosen Claude model survives the restart. start.sh's LiteLLM-down guard only drops `sr-*` tokens, so a Claude token is never dropped.
3. **Typed set had no busy gate and reported false success** → mid-turn injects queued `/model` as user text; silent captures were reported as "switched (session)". Added `ModelCommandDeps.isBusy` refusal; success is only claimed on an anchored confirmation, a claude error line ("Model not found"/"Invalid model") is reported as failure, and an unverifiable capture says "sent, but couldn't confirm — check /status" and records nothing.
4. **`scheduleRestart`'s 15s debounce silently no-op'd a switch** → the user was told it worked. It now throws a tagged `restart_in_flight` error the caller surfaces honestly.
5. **No rollback on dispatch failure** → a failed restart left a stale carrier + override lying to `/status` (and mis-launching the next ordinary restart). `scheduleModelRelaunch` now rolls both back on a genuine failure (keeps them when a restart is already in flight, since that restart consumes the carrier).
6. **Non-model display label stored as override** → tapping the Default row on the already-default model stored "Default (recommended)" into `/status`. "Kept model as X" is now treated as no-change (no write); stored values normalize to a canonical model token.
7. **Cleanups:** the dead + dangerous `MODEL_CALLBACK_SR` inject branch (guaranteed 4xx if reached) now delegates to the carrier relaunch; loose `/set model|switched/` scans are anchored to the confirmation prefix; `/inject /model <arg>` is refused with a pointer to the real `/model` driver (bare `/inject /model` still opens the read-only picker).

## Test plan

Extended `telegram-plugin/tests/model-command.test.ts` and `telegram-plugin/gateway/inject-handler.test.ts` to pin the new behavior:
- typed switch records the override; unverified switch → honest non-success, no record
- sr → Claude carries the requested Claude model via the relaunch carrier
- busy → refusal (typed + sr-*)
- claude error output → honest failure; debounce → `restart_in_flight` message, no silent lie
- "Kept model as" → no override write; Default-row real switch stores a canonical token, never the display label
- `/inject /model <arg>` refused; bare `/inject /model` still allowed

`telegram-plugin/tests/gateway-session-model-relaunch.test.ts` structural pins unchanged. Existing `tests/scaffold.session-model-override.test.ts` already pins Claude-token carrier consumption in start.sh.

**Results:** `bun test` (model-command, inject-handler, gateway-*, gateway-session-model-relaunch, model-unavailable) + `vitest run` (scaffold, inject-handler) + `npm run lint` (incl. `check-bot-api-wrapping`) all green; `tsc --noEmit` clean.

## Review follow-ups (commit 259db2fc)

1. **Anchored the error scan.** `MODEL_SWITCH_ERROR_RE` was unanchored, so scrollback prose merely containing "model not found" mid-sentence ("deploy failed: model not found in registry") would flip a successful switch into a reported failure. Now line-start anchored behind the same optional glyph class as the confirmation prefix (+ optional `Error:`), with a regression test.

2. **Empirically verified claude's arg-form `/model <name>` output** (disposable claude v2.1.205 TUI in a scratch tmux with an isolated `CLAUDE_CONFIG_DIR`, 2026-07-10). The old comment claiming the arg form switches "silently" is WRONG on the current CLI — it prints a confirmation, but in a shape the anchored regexes didn't match:
   - valid: `⎿  Set model to Opus 4.8 and saved as your default for new sessions`
   - invalid: `⎿  Model 'claude-bogus-99' not found`
   - repeat same-model: same "Set model to …" line (no "Kept model as" on the arg form)

   Without fixes, every typed switch would have fallen through to "couldn't confirm" and never recorded the override — the headline fix would have been inert for the common case. Three regex fixes, each pinned by a verbatim-capture test: the `⎿` glyph joined the glyph class of the confirmation prefix / error scan / `isKeptModelConfirmation` (the glyph survives the inject capture — `isTuiChromeLine` doesn't strip it); the error scan matches the quoted-name shape `Model '<name>' not found`; `sessionModelFromConfirmation` terminates the name at "and saved" so it extracts "Opus 4.8", not the whole sentence.

   The honest "sent, but couldn't confirm the switch — check /status" fallback (recording nothing) is retained for older/newer CLI phrasings that match neither the confirmation nor the error shape.

## Risk

Scoped to the `/model` + `/inject /model` command path. sr-* → Claude switches change dispatch mechanism (scheduleRestart → scheduleModelRelaunch carrier) — the carrier consumption is already covered by start.sh scaffold tests. No schema, compose, or auth surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
