### PR TITLE
feat(telegram): live model on progress cards — main agent, sub-agents, workers

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -144,6 +144,7 @@ import { pickRecoveredPermissionOrigin } from './permission-card-origin.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { appendActivityLabel, clipNarrative, renderActivityFeedWithNested, formatStepSuffix, type SessionActivityHeader } from '../tool-activity-summary.js'
 import { formatModelLabel } from '../model-label.js'
+import { createSessionModelSource } from './session-model-source.js'
 import { runSilentTurnHeartbeatTick } from '../feed-heartbeat-climb.js'
 import { REPLY_TOOLS, isDraftOfReply } from '../narrative-dedup.js'
 import { toolLabel } from '../tool-labels.js'
@@ -2635,23 +2636,16 @@ type CurrentTurn = {
 // is never written and this is exactly the old singleton.
 let currentTurn: CurrentTurn | null = null
 const currentTurnMap = new CurrentTurnMap<CurrentTurn>()
-// Last-seen MAIN-transcript model per session chat, sourced from the
-// `message.model` on each assistant line (session-tail `model` event). This is
-// the ground truth for "what model is the main agent actually running" — it
-// survives between turns (unlike `currentTurn`, nulled at turn end), so a
-// /status query landing in the idle gap still reflects the real model instead
-// of the launch-time / in-memory override. buildAgentMetadata prefers this over
-// the override when present. Bounded implicitly by the single-tenant chat set.
-const lastTranscriptModelByChat = new Map<string, string>()
-// Chat-agnostic most-recent main-transcript model — the fallback /status uses
-// (buildAgentMetadata has no chat context, and single-tenant agents have one
-// main session). Updated alongside the per-chat map.
-let lastMainTranscriptModel: string | null = null
-function rememberTranscriptModel(chatId: string | null | undefined, model: string): void {
-  lastMainTranscriptModel = model
-  if (chatId == null || chatId.length === 0) return
-  lastTranscriptModelByChat.set(chatId, model)
-}
+// Freshness-aware /status session-model source. Two writers: the session-tail
+// `model` event (each assistant line's `message.model` — ground truth for the
+// last API call, survives between turns) and the #2982 /model override (set
+// the instant a switch is confirmed — the ONLY truthful source in the
+// idle-after-switch window, before the next assistant line lands). Every write
+// is seq-stamped and `resolve()` prefers the NEWER observation, so neither
+// source can go stale behind the other (session-model-source.ts, pinned by
+// tests/session-model-source.test.ts). buildAgentMetadata reads resolve();
+// the /model command paths write via setOverride.
+const sessionModelSource = createSessionModelSource()
 // Captures the most-recently-started turn's sessionChatId. Unlike currentTurn,
 // this is NOT cleared by the silence poke (firePoke/clearTurnStarted). It lets
 // the Bug B fallback in executeReply route to the correct chat even when the
@@ -13932,13 +13926,14 @@ function handleSessionEvent(ev: SessionEvent): void {
       // value reaching here is a real resolved model id. Record it on the turn
       // (update-on-change) so the activity/liveness card header and /status
       // render the model actually serving this turn's API calls — transcript-
-      // sourced, never config. Also mirror it onto the sessionModel override
-      // store so a /status query between turns still reflects the last model.
+      // sourced, never config. Also note it on the freshness-aware session-model
+      // source so a /status query between turns still reflects the last model
+      // (and a fresh assistant line reclaims the source from a /model override).
       const turn = currentTurn
       if (turn != null) {
         turn.currentModel = ev.model
-        rememberTranscriptModel(turn.sessionChatId, ev.model)
       }
+      sessionModelSource.noteTranscriptModel(ev.model)
       return
     }
     case 'thinking': {
@@ -18507,13 +18502,12 @@ function buildAgentAudit(agentName: string): AgentAudit | undefined {
 // broker's fleet-wide `ListStateData` payload via
 // `buildAuthSummaryFromBroker`, with billingType pulled from the
 // agent's `.claude.json` (the broker doesn't track plan tier).
-/**
- * Live session-model override set by the `/model` picker (session-only). Held
- * in gateway memory so it clears on restart, the same point at which claude's
- * session reverts to the configured model — keeping `/status` honest without
- * a persisted store. Null when no session switch is active.
- */
-let activeSessionModelOverride: string | null = null
+// The live session-model override set by the `/model` picker (session-only)
+// lives on `sessionModelSource` (setOverride/getOverride, declared beside the
+// currentTurn globals). Held in gateway memory so it clears on restart, the
+// same point at which claude's session reverts to the configured model —
+// keeping `/status` honest without a persisted store. `resolve()` arbitrates
+// freshness against the transcript-observed model (#2982 idle-switch window).
 
 async function buildAgentMetadata(agentName: string): Promise<AgentMetadata> {
   type AgentListResp = {
@@ -18543,16 +18537,18 @@ async function buildAgentMetadata(agentName: string): Promise<AgentMetadata> {
   return {
     agentName,
     model: a?.model ?? null,
-    // Prefer the LIVE model actually serving turns, read from the main
-    // transcript's `message.model` (the ground truth for what the session is
-    // running right now) and rendered in the same short friendly form the
-    // cards use. Fall back to the in-memory /model override (kept truthful +
-    // friendly by #2982) when no transcript model has been observed yet — a
-    // fresh boot before the first assistant line, or an sr-* relaunch window.
-    // Never sourced from config. Surgical per PR #2982 overlap.
-    sessionModel:
-      (lastMainTranscriptModel != null ? formatModelLabel(lastMainTranscriptModel) : null) ??
-      activeSessionModelOverride,
+    // The FRESHEST session-model observation wins (session-model-source.ts):
+    // the transcript's `message.model` (ground truth for the last API call)
+    // vs the #2982 /model override (the only truthful source in the idle-
+    // after-switch window, before the next assistant line). Both rendered
+    // through formatModelLabel for a consistent short form; an override value
+    // that isn't model-shaped (an already-friendly "Opus 4.8" label) passes
+    // through verbatim. Never sourced from config.
+    sessionModel: (() => {
+      const resolved = sessionModelSource.resolve()
+      if (resolved == null) return null
+      return formatModelLabel(resolved.model) ?? resolved.model
+    })(),
     extendsProfile: (a?.extends ?? a?.template) ?? null,
     topicName: a?.topic_name ?? null,
     topicEmoji: a?.topic_emoji ?? null,
@@ -18783,7 +18779,7 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
     },
     escapeHtml: escapeHtmlForTg,
     preBlock,
-    getActiveSessionModel: () => activeSessionModelOverride,
+    getActiveSessionModel: () => sessionModelSource.getOverride(),
     /**
      * Graceful restart for sr-* → Claude model switch. Same mechanism as
      * the /restart command: writes a restart marker (so the post-restart
@@ -18854,9 +18850,9 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
       if (!agentDir) throw new Error('agent dir unresolvable — cannot write session-model carrier')
       // Carrier: single line, token + newline, no quoting (start.sh strips
       // whitespace and shape-gates). One-shot — consumed on the next boot.
-      const prevOverride = activeSessionModelOverride
+      const prevOverride = sessionModelSource.getOverride()
       writeFileSync(join(agentDir, '.session-model-override'), `${model}\n`, 'utf8')
-      activeSessionModelOverride = model
+      sessionModelSource.setOverride(model)
       try {
         await deps.scheduleRestart(reason)
       } catch (err) {
@@ -18869,7 +18865,7 @@ function buildModelDeps(restartCtx?: ModelDepsRestartContext): ModelMenuDeps & M
         // NEXT ordinary restart.
         if ((err as { code?: string })?.code !== 'restart_in_flight') {
           try { rmSync(carrierPath, { force: true }) } catch { /* best-effort */ }
-          activeSessionModelOverride = prevOverride
+          sessionModelSource.setOverride(prevOverride)
         }
         throw err
       }
@@ -18903,12 +18899,12 @@ bot.command('model', async ctx => {
   const reply = await handleModelCommand(parsed, deps)
   // Record a POSITIVELY-CONFIRMED typed switch so /status reflects what's
   // actually running — the SAME in-memory override the menu callback path sets
-  // (buildAgentMetadata reads activeSessionModelOverride as sessionModel). Only
+  // (buildAgentMetadata resolves it via sessionModelSource). Only
   // set on the confirmed inject path; the sr-*/relaunch paths already set the
   // override inside scheduleModelRelaunch, and an unverified switch carries no
   // selectedModel so /status is never lied to.
   if (reply.selectedModel) {
-    activeSessionModelOverride = reply.selectedModel
+    sessionModelSource.setOverride(reply.selectedModel)
   }
   await switchroomReply(ctx, reply.text, { html: reply.html })
 })
@@ -24008,13 +24004,13 @@ bot.on('callback_query:data', async ctx => {
     }
     const didInterimSrEdit = false
     try {
-      const prevSessionModel = activeSessionModelOverride
+      const prevSessionModel = sessionModelSource.getOverride()
       const outcome = await handleModelMenuCallback(data, modelDeps)
       // Record a successful session switch so /status reflects what's
       // actually running. In-memory only → clears when the gateway (and thus
       // claude's session) restarts, exactly matching the session-only scope.
       if (outcome.selectedModel) {
-        activeSessionModelOverride = outcome.selectedModel
+        sessionModelSource.setOverride(outcome.selectedModel)
       }
       // toastOnly: leave the menu untouched — but only if we haven't already
       // cleared its buttons with the interim sr-* edit. If we have, fall
@@ -24049,7 +24045,7 @@ bot.on('callback_query:data', async ctx => {
           if (agentDir && token) {
             try {
               writeFileSync(join(agentDir, '.session-model-override'), `${token}\n`, 'utf8')
-              activeSessionModelOverride = token
+              sessionModelSource.setOverride(token)
             } catch (e) {
               process.stderr.write(`telegram gateway: sr-to-claude carrier write failed: ${(e as Error)?.message ?? String(e)}\n`)
             }
@@ -27067,8 +27063,9 @@ void (async () => {
                   // a phantom session override.
                   return resolveMainModel(raw ?? undefined)
                 })()
-                activeSessionModelOverride =
-                  launched.length > 0 && launched !== configured ? launched : null
+                sessionModelSource.setOverride(
+                  launched.length > 0 && launched !== configured ? launched : null,
+                )
               } catch { /* leave override as-is on a bad read */ }
             }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -143,6 +143,7 @@ import {
 import { pickRecoveredPermissionOrigin } from './permission-card-origin.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { appendActivityLabel, clipNarrative, renderActivityFeedWithNested, formatStepSuffix, type SessionActivityHeader } from '../tool-activity-summary.js'
+import { formatModelLabel } from '../model-label.js'
 import { runSilentTurnHeartbeatTick } from '../feed-heartbeat-climb.js'
 import { REPLY_TOOLS, isDraftOfReply } from '../narrative-dedup.js'
 import { toolLabel } from '../tool-labels.js'
@@ -2502,6 +2503,13 @@ type CurrentTurn = {
   // resume protocol uses this to decide "did the previous turn actually
   // finish a reply, or was it interrupted before commit?".
   lastAssistantDone: boolean
+  // Live model in use for THIS turn, sourced from the main transcript's
+  // `message.model` (the exact resolved model per API call) via the session-tail
+  // `model` event — never from config or launch-time state. Updated on change;
+  // undefined until the turn's first assistant line lands. Rendered onto the
+  // activity/liveness card header's metrics line (e.g. "2m · 14 tools · opus 4.8")
+  // and preferred by /status's buildAgentMetadata over the in-memory override.
+  currentModel?: string
   // Phase 1 of #332: count of tool_use events in the current turn, for
   // the tool_call_count column in the turns registry.
   toolCallCount: number
@@ -2627,6 +2635,23 @@ type CurrentTurn = {
 // is never written and this is exactly the old singleton.
 let currentTurn: CurrentTurn | null = null
 const currentTurnMap = new CurrentTurnMap<CurrentTurn>()
+// Last-seen MAIN-transcript model per session chat, sourced from the
+// `message.model` on each assistant line (session-tail `model` event). This is
+// the ground truth for "what model is the main agent actually running" — it
+// survives between turns (unlike `currentTurn`, nulled at turn end), so a
+// /status query landing in the idle gap still reflects the real model instead
+// of the launch-time / in-memory override. buildAgentMetadata prefers this over
+// the override when present. Bounded implicitly by the single-tenant chat set.
+const lastTranscriptModelByChat = new Map<string, string>()
+// Chat-agnostic most-recent main-transcript model — the fallback /status uses
+// (buildAgentMetadata has no chat context, and single-tenant agents have one
+// main session). Updated alongside the per-chat map.
+let lastMainTranscriptModel: string | null = null
+function rememberTranscriptModel(chatId: string | null | undefined, model: string): void {
+  lastMainTranscriptModel = model
+  if (chatId == null || chatId.length === 0) return
+  lastTranscriptModelByChat.set(chatId, model)
+}
 // Captures the most-recently-started turn's sessionChatId. Unlike currentTurn,
 // this is NOT cleared by the silence poke (firePoke/clearTurnStarted). It lets
 // the Bug B fallback in executeReply route to the correct chat even when the
@@ -12771,6 +12796,7 @@ function composeTurnActivity(turn: CurrentTurn, final = false, liveSuffix = ''):
     elapsedMs: turn.startedAt > 0 ? Date.now() - turn.startedAt : 0,
     toolCount: turn.labeledToolCount,
     state: final ? 'done' : 'running',
+    model: turn.currentModel,
   }
   return renderActivityFeedWithNested(turn.mirrorLines, childLines, final, liveSuffix, stepCount, header)
 }
@@ -13088,6 +13114,7 @@ function openLivenessFeedIfDue(turn: CurrentTurn): void {
   const lines = turn.mirrorLines.length > 0 ? turn.mirrorLines : ['Working…']
   const livenessHeader: SessionActivityHeader = {
     label: 'Agent', elapsedMs: age, toolCount: turn.labeledToolCount, state: 'running',
+    model: turn.currentModel,
   }
   // Liveness card is a single "step" whose start is the turn start, so `age`
   // IS the step's own elapsed. formatStepSuffix keeps the `→` line timer-free
@@ -13218,6 +13245,7 @@ function feedHeartbeatTick(): void {
     const age = Date.now() - turn.startedAt
     const livenessHeader: SessionActivityHeader = {
       label: 'Agent', elapsedMs: age, toolCount: turn.labeledToolCount, state: 'running',
+      model: turn.currentModel,
     }
     const lines = turn.mirrorLines.length > 0 ? turn.mirrorLines : ['Working in background…']
     // `subagentAt` is the worker's last ADVANCE — the current step's start —
@@ -13407,6 +13435,7 @@ function clearActivitySummary(turn: CurrentTurn, finalHtmlOverride?: string | nu
       const livenessElapsed = turn.startedAt > 0 ? Date.now() - turn.startedAt : 0
       const livenessHeader: SessionActivityHeader = {
         label: 'Agent', elapsedMs: livenessElapsed, toolCount: turn.labeledToolCount, state: 'done',
+        model: turn.currentModel,
       }
       finalHtml = renderActivityFeedWithNested(['Working…'], [], true, '', undefined, livenessHeader)
     }
@@ -13897,6 +13926,21 @@ function handleSessionEvent(ev: SessionEvent): void {
       return
     }
     case 'dequeue': return
+    case 'model': {
+      // Live model capture for the main turn. The session-tail projection
+      // already filtered sentinels (`<synthetic>` compaction lines), so any
+      // value reaching here is a real resolved model id. Record it on the turn
+      // (update-on-change) so the activity/liveness card header and /status
+      // render the model actually serving this turn's API calls — transcript-
+      // sourced, never config. Also mirror it onto the sessionModel override
+      // store so a /status query between turns still reflects the last model.
+      const turn = currentTurn
+      if (turn != null) {
+        turn.currentModel = ev.model
+        rememberTranscriptModel(turn.sessionChatId, ev.model)
+      }
+      return
+    }
     case 'thinking': {
       // #1067: snapshot the turn atom at handler entry. Even though this
       // handler is sync, the principle is uniform across all event arms
@@ -18499,7 +18543,16 @@ async function buildAgentMetadata(agentName: string): Promise<AgentMetadata> {
   return {
     agentName,
     model: a?.model ?? null,
-    sessionModel: activeSessionModelOverride,
+    // Prefer the LIVE model actually serving turns, read from the main
+    // transcript's `message.model` (the ground truth for what the session is
+    // running right now) and rendered in the same short friendly form the
+    // cards use. Fall back to the in-memory /model override (kept truthful +
+    // friendly by #2982) when no transcript model has been observed yet — a
+    // fresh boot before the first assistant line, or an sr-* relaunch window.
+    // Never sourced from config. Surgical per PR #2982 overlap.
+    sessionModel:
+      (lastMainTranscriptModel != null ? formatModelLabel(lastMainTranscriptModel) : null) ??
+      activeSessionModelOverride,
     extendsProfile: (a?.extends ?? a?.template) ?? null,
     topicName: a?.topic_name ?? null,
     topicEmoji: a?.topic_emoji ?? null,
@@ -27402,6 +27455,10 @@ void (async () => {
                       latestSummary: resultText,
                       elapsedMs: durationMs,
                       state: outcome === 'failed' ? 'failed' : 'done',
+                      // Persisted (registry) model — the last one the watcher
+                      // recorded from the worker's transcript — so the terminal
+                      // card keeps the model tag even with no live entry.
+                      model: dispatch.feedModel ?? undefined,
                     })
                     reconcileWorkerPin(agentId, null, false)
                   }
@@ -27479,6 +27536,7 @@ void (async () => {
                       latestSummary: resultText,
                       elapsedMs: durationMs,
                       state: outcome === 'failed' ? 'failed' : 'done',
+                      model: dispatch.feedModel ?? undefined,
                     })
                     // Status-pin: worker done — drop its pin.
                     reconcileWorkerPin(agentId, null, false)
@@ -27498,6 +27556,7 @@ void (async () => {
                     latestSummary: resultText,
                     elapsedMs: durationMs,
                     state: outcome === 'failed' ? 'failed' : 'done',
+                    model: dispatch.feedModel ?? undefined,
                   })
                   // Status-pin: worker done — drop its pin.
                   reconcileWorkerPin(agentId, null, false)
@@ -27584,7 +27643,7 @@ void (async () => {
               // suppresses stale-after-restart delivery (a 4-h-old
               // "still working (5m)" would be a lie). Sweep on handback
               // lives in the `onFinish` block just above.
-              onProgress: ({ agentId, description, latestSummary, elapsedMs, prevBucketIdx, setBucketIdx, lastTool, toolCount, progressLine }) => {
+              onProgress: ({ agentId, description, latestSummary, elapsedMs, prevBucketIdx, setBucketIdx, lastTool, toolCount, progressLine, model }) => {
                 let fleetChatId = ''
                 try {
                   const fleets = progressDriver?.peekAllFleets() ?? []
@@ -27618,6 +27677,13 @@ void (async () => {
                 // never grew past "starting…" (the frozen-card symptom). The
                 // foreground nest path below already used this precedence.
                 const stepLine = (progressLine != null && progressLine.length > 0) ? progressLine : latestSummary
+                // Live model for the worker card: prefer the transcript-sourced
+                // model on the entry (threaded via onProgress) and fall back to
+                // the dispatch-time model persisted on the registry row
+                // (tool_input.model) until the worker's first assistant line
+                // lands. Undefined when neither is known — the card omits it,
+                // never guessing from config.
+                const feedModel = model ?? dispatch.feedModel ?? undefined
                 if (!isBackground) {
                   // Model A — a foreground sub-agent runs inside the parent's
                   // turn, so its live narrative nests under the parent's
@@ -27657,6 +27723,7 @@ void (async () => {
                         latestSummary: stepLine,
                         elapsedMs,
                         state: 'running',
+                        model: feedModel,
                       },
                       wk.threadId,
                     )?.then(() => reconcileWorkerPin(agentId, wkChat, true))
@@ -27798,6 +27865,7 @@ void (async () => {
                       latestSummary: stepLine,
                       elapsedMs,
                       state: 'running',
+                      model: feedModel,
                     },
                     wk.threadId,
                   )?.then(() => reconcileWorkerPin(agentId, wkChat, true))

--- a/telegram-plugin/gateway/session-model-source.ts
+++ b/telegram-plugin/gateway/session-model-source.ts
@@ -1,0 +1,73 @@
+/**
+ * Freshness-aware source of truth for the /status session model.
+ *
+ * Two independent signals report what model the live session is running:
+ *
+ *   - the TRANSCRIPT: `message.model` on each assistant line (session-tail's
+ *     `model` event) — ground truth for the model that served the LAST API
+ *     call, but only advances when a new assistant line lands;
+ *   - the OVERRIDE: the in-memory `/model` switch record (#2982) — set the
+ *     moment a switch is positively confirmed, ahead of any assistant line.
+ *
+ * Neither is unconditionally right. Preferring the transcript regresses the
+ * idle-after-switch window (#2982's core fix): a native `/model` inject while
+ * idle sets the override to the NEW model, but the transcript still holds the
+ * OLD one until the next assistant line — /status would lie. Preferring the
+ * override goes stale the other way (a relaunch carrier that never applied).
+ *
+ * The invariant is "prefer the NEWER observation": every write from either
+ * source is stamped with a shared monotonic sequence, and `resolve()` returns
+ * whichever was observed last. A fresh assistant line always reclaims the
+ * transcript as the source; a confirmed switch always beats an older
+ * transcript line. Pinned by tests/session-model-source.test.ts.
+ */
+
+export interface SessionModelResolution {
+  /** The raw value from the winning source. Transcript entries are resolved
+   *  model ids (`claude-opus-4-8`); override entries may be friendly labels
+   *  ("Opus 4.8") or sr-* ids depending on the /model path that set them. */
+  model: string
+  source: 'transcript' | 'override'
+}
+
+export interface SessionModelSource {
+  /** Record a transcript observation (an assistant line's `message.model`,
+   *  already sentinel-filtered by the session-tail projection). */
+  noteTranscriptModel(model: string): void
+  /** Record an override set (a positively-confirmed /model switch), or clear
+   *  it with null. Setting stamps a fresh sequence, so the override wins over
+   *  every EARLIER transcript observation until a new assistant line lands. */
+  setOverride(model: string | null): void
+  /** Current override value (the #2982 in-memory record), independent of
+   *  freshness — for callers that need the override itself (e.g. the model
+   *  menu's "session" marker), not the /status resolution. */
+  getOverride(): string | null
+  /** The freshest observation across both sources, or null when neither has
+   *  reported yet. */
+  resolve(): SessionModelResolution | null
+}
+
+export function createSessionModelSource(): SessionModelSource {
+  let seq = 0
+  let transcript: { model: string; seq: number } | null = null
+  let override: { model: string; seq: number } | null = null
+  return {
+    noteTranscriptModel(model: string): void {
+      transcript = { model, seq: ++seq }
+    },
+    setOverride(model: string | null): void {
+      override = model == null ? null : { model, seq: ++seq }
+    },
+    getOverride(): string | null {
+      return override?.model ?? null
+    },
+    resolve(): SessionModelResolution | null {
+      if (transcript == null && override == null) return null
+      if (override == null) return { model: transcript!.model, source: 'transcript' }
+      if (transcript == null || transcript.seq < override.seq) {
+        return { model: override.model, source: 'override' }
+      }
+      return { model: transcript.model, source: 'transcript' }
+    },
+  }
+}

--- a/telegram-plugin/gateway/worker-feed-dispatch.ts
+++ b/telegram-plugin/gateway/worker-feed-dispatch.ts
@@ -25,6 +25,15 @@ export interface WorkerFeedDispatch {
    * result returns to its dispatching worker as the Task tool result).
    */
   isNested: boolean
+  /**
+   * Dispatch-time / last-persisted model for the worker, from the registry
+   * row's `model` column (seeded by the pretool hook from `tool_input.model`,
+   * later updated by the watcher from the worker's transcript). The FIRST-PAINT
+   * fallback the worker card renders before the live watcher entry has observed
+   * a transcript model. Null when the row is missing or never carried a model —
+   * the card then omits the model rather than guessing from config.
+   */
+  feedModel: string | null
 }
 
 /**
@@ -65,5 +74,6 @@ export function resolveWorkerFeedDispatch(
     feedDescription: (sub?.description ?? '') || watcherDescription,
     hasRow: sub != null,
     isNested: sub?.parent_agent_id != null,
+    feedModel: sub?.model ?? null,
   }
 }

--- a/telegram-plugin/hooks/subagent-tracker-pretool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-pretool.mjs
@@ -243,7 +243,7 @@ function writeRow(dbPath, { id, parentSessionId, parentTurnKey, agentType, descr
     return
   }
 
-  // sqlite3 CLI fallback — two non-blocking spawns sequenced via callbacks.
+  // sqlite3 CLI fallback — non-blocking spawns sequenced via callbacks.
   // This legacy path (neither node:sqlite nor bun:sqlite available) can't
   // cheaply verify the marker's turn_key against the turns table, so drop
   // parent_turn_key and let the gateway's window backfill attribute it.
@@ -252,7 +252,15 @@ function writeRow(dbPath, { id, parentSessionId, parentTurnKey, agentType, descr
   params[2] = null
   spawnSql(dbPath, SCHEMA_SQL.replace(/\n\s+/g, ' '), (err) => {
     if (err) { done(err); return }
-    spawnSql(dbPath, fillPlaceholders(INSERT_SQL.trim(), params), done)
+    // Best-effort model-column migration for a legacy DB: the INSERT below
+    // references the model column, which a pre-model table lacks (CREATE TABLE
+    // IF NOT EXISTS is a no-op there, so the schema exec doesn't add it). The
+    // ALTER fails with "duplicate column name" when the column already exists —
+    // that error is EXPECTED and deliberately ignored; on any failure we still
+    // proceed to the INSERT, which surfaces a real problem via `done`.
+    spawnSql(dbPath, 'ALTER TABLE subagents ADD COLUMN model TEXT', () => {
+      spawnSql(dbPath, fillPlaceholders(INSERT_SQL.trim(), params), done)
+    })
   })
 }
 

--- a/telegram-plugin/hooks/subagent-tracker-pretool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-pretool.mjs
@@ -55,7 +55,8 @@ const SCHEMA_SQL = `
     status            TEXT    NOT NULL,
     result_summary    TEXT,
     jsonl_agent_id    TEXT,
-    parent_agent_id   TEXT
+    parent_agent_id   TEXT,
+    model             TEXT
   );
   CREATE INDEX IF NOT EXISTS subagents_turn      ON subagents(parent_turn_key);
   CREATE INDEX IF NOT EXISTS subagents_status    ON subagents(status);
@@ -157,14 +158,14 @@ function spawnSql(dbPath, sql, cb) {
 // DB write
 // ---------------------------------------------------------------------------
 
-function writeRow(dbPath, { id, parentSessionId, parentTurnKey, agentType, description, background, now }, done) {
+function writeRow(dbPath, { id, parentSessionId, parentTurnKey, agentType, description, background, model, now }, done) {
   const INSERT_SQL = `
     INSERT OR IGNORE INTO subagents
       (id, parent_session_id, parent_turn_key, agent_type, description,
-       background, started_at, last_activity_at, status)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'running')
+       background, started_at, last_activity_at, status, model)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'running', ?)
   `
-  const params = [id, parentSessionId, parentTurnKey, agentType, description, background, now, now]
+  const params = [id, parentSessionId, parentTurnKey, agentType, description, background, now, now, model ?? null]
 
   // Resolve a synchronous SQLite binding. Try in order:
   //   1. node:sqlite (Node 22+, production path) — exposes DatabaseSync
@@ -206,6 +207,13 @@ function writeRow(dbPath, { id, parentSessionId, parentTurnKey, agentType, descr
           .get()
         if (hasParentAgentCol == null) {
           db.exec('ALTER TABLE subagents ADD COLUMN parent_agent_id TEXT')
+        }
+        // Migrate older DBs that pre-date the live-model column.
+        const hasModelCol = db
+          .prepare("SELECT name FROM pragma_table_info('subagents') WHERE name = 'model'")
+          .get()
+        if (hasModelCol == null) {
+          db.exec('ALTER TABLE subagents ADD COLUMN model TEXT')
         }
         // Verify the marker-derived parent_turn_key (snapParams[2]) actually has
         // a row in the turns table before trusting it. The gateway writes the
@@ -363,6 +371,13 @@ function main() {
       agentType: input.subagent_type ?? null,
       description: input.description ?? null,
       background: input.run_in_background === true ? 1 : 0,
+      // First-paint model for the worker card: the Agent tool payload carries
+      // the model the sub-agent will run under (`tool_input.model`), available
+      // BEFORE the sub-agent writes its first assistant line. Persisted so the
+      // card can render the model from dispatch; the watcher later overwrites it
+      // from the worker's own transcript (transcript wins). Only a non-empty
+      // string is stored — never guess from config.
+      model: typeof input.model === 'string' && input.model.length > 0 ? input.model : null,
       now: Date.now(),
     },
     (err) => {

--- a/telegram-plugin/model-label.ts
+++ b/telegram-plugin/model-label.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared friendly-model formatter for progress / activity surfaces.
+ *
+ * Every progress card renders the model actually in use, sourced LIVE from the
+ * session transcripts (`message.model` on each `type:"assistant"` line — the
+ * exact resolved model for that API call). This module owns the two pure
+ * decisions both the capture side (session-tail projection) and the render side
+ * (activity/worker cards) depend on:
+ *
+ *   - `isModelSentinel(v)` — is this a value we must NOT treat as a real model?
+ *     Compaction / synthetic transcript lines carry `model:"<synthetic>"`, and
+ *     test fixtures may carry junk. Anything starting with `<`, empty, or not
+ *     shaped like a model id is a sentinel: the capture side SKIPS it and keeps
+ *     the previous value; it is never rendered.
+ *   - `formatModelLabel(v)` — the short friendly form shown on a card's metrics
+ *     line (e.g. `claude-opus-4-8` → `opus 4.8`). Returns null for sentinels so
+ *     the caller simply omits the model field (never guesses from config).
+ *
+ * Friendly-form rules (verified against live fleet transcript values):
+ *   - `claude-opus-4-8`            → `opus 4.8`
+ *   - `claude-sonnet-5`           → `sonnet 5`
+ *   - `claude-haiku-4-5-20251001` → `haiku 4.5`   (trailing YYYYMMDD dropped)
+ *   - `sr-glm-5`, `sr-gpt-5.5`    → verbatim (LiteLLM routing ids stay literal)
+ *   - anything else               → verbatim (unknown but model-shaped)
+ */
+
+/** Trailing 8-digit date stamp (YYYYMMDD) on a claude model id — dropped. */
+const DATE_SUFFIX = /^\d{8}$/
+
+/**
+ * True when `model` must NOT be treated as a real resolved model. Compaction /
+ * synthetic lines write `model:"<synthetic>"`; fixtures may carry junk. Callers
+ * that see a sentinel keep the previously-seen model (or omit the field).
+ */
+export function isModelSentinel(model: unknown): boolean {
+  if (typeof model !== 'string') return true
+  const m = model.trim()
+  if (m.length === 0) return true
+  // Synthetic / placeholder sentinels: `<synthetic>`, `<compact>`, etc.
+  if (m.startsWith('<')) return true
+  // Model ids are simple tokens (letters, digits, dot, dash, underscore,
+  // slash). Anything with whitespace or leading punctuation is junk.
+  if (!/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(m)) return true
+  return false
+}
+
+/**
+ * Short friendly label for a resolved model id, or null when `model` is absent
+ * or a sentinel (caller omits the field — never guesses). See module header for
+ * the rules.
+ */
+export function formatModelLabel(model: string | null | undefined): string | null {
+  if (model == null) return null
+  const m = model.trim()
+  if (isModelSentinel(m)) return null
+  // LiteLLM / self-routed ids stay verbatim — the sr- prefix is meaningful.
+  if (m.startsWith('sr-')) return m
+  if (m.startsWith('claude-')) {
+    const rest = m.slice('claude-'.length)
+    const parts = rest.split('-').filter((p) => p.length > 0)
+    if (parts.length === 0) return m
+    const family = parts[0]
+    const version = parts.slice(1).filter((p) => !DATE_SUFFIX.test(p))
+    if (version.length === 0) return family
+    return `${family} ${version.join('.')}`
+  }
+  // Unknown but model-shaped (a future family, a bare alias) — show verbatim.
+  return m
+}

--- a/telegram-plugin/registry/subagents-schema.ts
+++ b/telegram-plugin/registry/subagents-schema.ts
@@ -116,6 +116,16 @@ export interface Subagent {
    * chain instead.
    */
   parent_agent_id: string | null
+  /**
+   * Live model the sub-agent is running, as a raw resolved model id (e.g.
+   * `claude-opus-4-8`, `sr-glm-5`). Seeded at dispatch from the Agent tool's
+   * `tool_input.model` (first-paint fallback, written by the pretool hook), then
+   * updated on change by the watcher from the worker's own transcript
+   * `message.model` (transcript wins). Persisted so boot-replay / handback cards
+   * can render the model even with no live watcher entry. NULL when never
+   * observed — the card omits the model rather than guessing from config.
+   */
+  model: string | null
 }
 
 export interface RecordSubagentStartArgs {
@@ -207,7 +217,8 @@ const SUBAGENTS_SCHEMA_SQL = `
     status            TEXT    NOT NULL,
     result_summary    TEXT,
     jsonl_agent_id    TEXT,
-    parent_agent_id   TEXT
+    parent_agent_id   TEXT,
+    model             TEXT
   );
   CREATE INDEX IF NOT EXISTS subagents_turn      ON subagents(parent_turn_key);
   CREATE INDEX IF NOT EXISTS subagents_status    ON subagents(status);
@@ -239,6 +250,12 @@ export function applySubagentsSchema(db: SqliteDatabase): void {
   const hasParentAgentId = cols.some((c) => c.name === 'parent_agent_id')
   if (!hasParentAgentId) {
     db.exec('ALTER TABLE subagents ADD COLUMN parent_agent_id TEXT')
+  }
+  // Idempotent migration for DBs created before the live-model column existed
+  // (progress-card live model — see the Subagent.model doc).
+  const hasModel = cols.some((c) => c.name === 'model')
+  if (!hasModel) {
+    db.exec('ALTER TABLE subagents ADD COLUMN model TEXT')
   }
   // Always (re-)apply the index. `IF NOT EXISTS` makes this a no-op when it
   // already exists. Splitting it from SUBAGENTS_SCHEMA_SQL is what fixes the
@@ -316,6 +333,7 @@ interface RawSubagentRow {
   result_summary: string | null
   jsonl_agent_id: string | null
   parent_agent_id?: string | null
+  model?: string | null
 }
 
 function mapSubagentRow(row: RawSubagentRow): Subagent {
@@ -333,6 +351,7 @@ function mapSubagentRow(row: RawSubagentRow): Subagent {
     result_summary: row.result_summary,
     jsonl_agent_id: row.jsonl_agent_id,
     parent_agent_id: row.parent_agent_id ?? null,
+    model: row.model ?? null,
   }
 }
 
@@ -564,6 +583,29 @@ export function bumpSubagentActivity(db: SqliteDatabase, args: BumpSubagentActiv
     SET last_activity_at = ?
     WHERE id = ?
   `).run(args.ts, args.id)
+}
+
+export interface RecordSubagentModelArgs {
+  id: string
+  /** Raw resolved model id (e.g. `claude-opus-4-8`). Callers pass only
+   *  non-sentinel, non-empty values — the watcher filters at the projection. */
+  model: string
+}
+
+/**
+ * Persist the live model on a subagent row (update-on-change, like
+ * last_activity_at). Written by the watcher whenever it observes a NEW model on
+ * the worker's transcript, so a later boot-replay / handback card renders the
+ * model even with no live in-memory entry. Unconditional UPDATE by `id`; no-ops
+ * gracefully if the row is not found. Idempotent — the caller only calls it on
+ * an actual change, but a repeat write is harmless.
+ */
+export function recordSubagentModel(db: SqliteDatabase, args: RecordSubagentModelArgs): void {
+  db.prepare(`
+    UPDATE subagents
+    SET model = ?
+    WHERE id = ?
+  `).run(args.model, args.id)
 }
 
 /**

--- a/telegram-plugin/registry/subagents.test.ts
+++ b/telegram-plugin/registry/subagents.test.ts
@@ -26,6 +26,7 @@ import {
   recordSubagentStall,
   recordSubagentResume,
   bumpSubagentActivity,
+  recordSubagentModel,
   getSubagent,
   reapStuckRunningRows,
   countRunningBackgroundSubagents,
@@ -66,6 +67,54 @@ describe('migration on fresh DB', () => {
   it('schema is idempotent — applying twice does not throw', () => {
     const db = openFreshSubagentsDbInMemory()
     expect(() => applySubagentsSchema(db)).not.toThrow()
+    db.close()
+  })
+
+  it('creates the model column on a fresh DB', () => {
+    const db = openFreshSubagentsDbInMemory()
+    const cols = db.prepare("SELECT name FROM pragma_table_info('subagents')").all() as { name: string }[]
+    expect(cols.map((c) => c.name)).toContain('model')
+    db.close()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Live-model column — migration + record helper
+// ---------------------------------------------------------------------------
+
+describe('live-model column', () => {
+  it('migrates a pre-model subagents table by adding the model column (idempotent)', () => {
+    const db = openFreshSubagentsDbInMemory()
+    // Simulate a legacy table with no model column.
+    db.exec('ALTER TABLE subagents DROP COLUMN model')
+    let cols = db.prepare("SELECT name FROM pragma_table_info('subagents')").all() as { name: string }[]
+    expect(cols.map((c) => c.name)).not.toContain('model')
+    // Re-applying the schema must add it back, and be safe to repeat.
+    applySubagentsSchema(db)
+    applySubagentsSchema(db)
+    cols = db.prepare("SELECT name FROM pragma_table_info('subagents')").all() as { name: string }[]
+    expect(cols.map((c) => c.name)).toContain('model')
+    db.close()
+  })
+
+  it('recordSubagentStart leaves model null; recordSubagentModel persists on change', () => {
+    const db = openFreshSubagentsDbInMemory()
+    const now = Date.now()
+    recordSubagentStart(db, { id: 'toolu_m1', background: true, startedAt: now, jsonlAgentId: 'a1' })
+    expect(getSubagent(db, 'toolu_m1')?.model).toBeNull()
+
+    recordSubagentModel(db, { id: 'toolu_m1', model: 'claude-opus-4-8' })
+    expect(getSubagent(db, 'toolu_m1')?.model).toBe('claude-opus-4-8')
+
+    // Update-on-change: a later model overwrites.
+    recordSubagentModel(db, { id: 'toolu_m1', model: 'sr-glm-5' })
+    expect(getSubagent(db, 'toolu_m1')?.model).toBe('sr-glm-5')
+    db.close()
+  })
+
+  it('recordSubagentModel no-ops gracefully on a missing id', () => {
+    const db = openFreshSubagentsDbInMemory()
+    expect(() => recordSubagentModel(db, { id: 'nope', model: 'claude-opus-4-8' })).not.toThrow()
     db.close()
   })
 })

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -42,6 +42,7 @@ function isMultiAgentEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
 }
 import { classifyClaudeError, type OperatorEventKind } from './operator-events.js'
 import { createToolLabelSidecar, type ToolLabelSidecar } from './tool-label-sidecar.js'
+import { isModelSentinel } from './model-label.js'
 
 /** Match Claude Code's cli.js VX() function. */
 export function sanitizeCwdToProjectName(cwd: string): string {
@@ -92,6 +93,13 @@ export type SessionEvent =
   | { kind: 'enqueue'; chatId: string | null; messageId: string | null; threadId: string | null; rawContent: string; isSync?: boolean }
   | { kind: 'dequeue' }
   | { kind: 'thinking' }
+  // Live model in use for the MAIN session, extracted from `message.model` on
+  // each `type:"assistant"` transcript line (the exact model that served that
+  // API call). Emitted FIRST among a line's events so a card rendered on the
+  // same batch already reflects the current model. Sentinels (`<synthetic>` on
+  // compaction lines, fixture junk) are filtered at projection — see
+  // isModelSentinel — so this only ever carries a real resolved model id.
+  | { kind: 'model'; model: string }
   | { kind: 'tool_use'; toolName: string; toolUseId?: string | null; input?: Record<string, unknown>; precomputedLabel?: string }
   // Real-time tool label from the PreToolUse-hook sidecar — fires when the
   // hook writes the label (synchronous at tool-call time), independent of
@@ -115,6 +123,11 @@ export type SessionEvent =
   // filename stem (e.g. "aac6f1…"). Routed through the same ingest path
   // as parent events; the reducer fans them out to per-sub-agent state.
   | { kind: 'sub_agent_started'; agentId: string; firstPromptText: string; subagentType?: string }
+  // Live model in use for a SUB-AGENT, extracted from `message.model` on each
+  // of its `type:"assistant"` transcript lines. Same contract as the main
+  // `model` kind (sentinel-filtered, emitted first) but agent-scoped so the
+  // watcher can track it per WorkerEntry and thread it onto the worker card.
+  | { kind: 'sub_agent_model'; agentId: string; model: string }
   | { kind: 'sub_agent_tool_use'; agentId: string; toolUseId: string | null; toolName: string; input?: Record<string, unknown>; precomputedLabel?: string }
   // Same shared contract as the main-agent `text` kind — see its doc above
   // (including the `lastInMessage` projection-artifact note). The wire-kind
@@ -320,6 +333,15 @@ export function projectTranscriptLine(line: string): SessionEvent[] {
     const content = message?.content as Array<Record<string, unknown>> | undefined
     if (!Array.isArray(content)) return []
     const events: SessionEvent[] = []
+    // Live model capture: `message.model` is the exact resolved model that
+    // served THIS assistant API call. Emit it FIRST (before the content events)
+    // so a card rendered on the same read batch already carries the current
+    // model. Sentinels (`<synthetic>` on compaction lines, fixture junk) are
+    // skipped — the reducer keeps the last real value.
+    const mainModel = message?.model
+    if (typeof mainModel === 'string' && !isModelSentinel(mainModel)) {
+      events.push({ kind: 'model', model: mainModel })
+    }
     // Text→narrative projection comes from the ONE shared kernel
     // (projectAssistantTextBlocks): it owns the empty-drop + blockIndex +
     // lastInMessage contract. We emit its events at their source positions
@@ -468,6 +490,12 @@ export function projectSubagentLine(
     const content = message?.content as Array<Record<string, unknown>> | undefined
     if (!Array.isArray(content)) return []
     const events: SessionEvent[] = []
+    // Live model capture (sub-agent tier): same contract as the main-agent
+    // branch — emit the sub-agent's resolved model first, sentinel-filtered.
+    const subModel = message?.model
+    if (typeof subModel === 'string' && !isModelSentinel(subModel)) {
+      events.push({ kind: 'sub_agent_model', agentId, model: subModel })
+    }
     // Text→narrative projection comes from the SAME shared kernel as the
     // main agent (projectAssistantTextBlocks): one source for the empty-drop
     // + blockIndex + lastInMessage contract. The `make` adapter only changes

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -48,7 +48,7 @@ import { sanitiseToolArg } from './fleet-state.js'
 import { clipNarrative, describeToolUse } from './tool-activity-summary.js'
 import { REPLY_TOOLS, isDraftOfReply } from './narrative-dedup.js'
 import { truncate } from './card-format.js'
-import { bumpSubagentActivity, recordSubagentStall, recordSubagentResume, recordSubagentEnd, reapStuckRunningRows, countRunningBackgroundSubagents, recordNestedSubagentDispatch } from './registry/subagents-schema.js'
+import { bumpSubagentActivity, recordSubagentStall, recordSubagentResume, recordSubagentEnd, reapStuckRunningRows, countRunningBackgroundSubagents, recordNestedSubagentDispatch, recordSubagentModel } from './registry/subagents-schema.js'
 import { touchTurnActiveMarker } from './gateway/turn-active-marker.js'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -220,6 +220,17 @@ export interface WorkerEntry {
    * the row has been observed at least once.
    */
   background?: boolean
+  /**
+   * Live model this worker is running, as a raw resolved model id (e.g.
+   * `claude-opus-4-8`). Set from the worker's OWN transcript `message.model`
+   * (`sub_agent_model` event) — the authoritative live source — and persisted to
+   * the registry row on change (recordSubagentModel) so boot-replay / handback
+   * cards can render it without a live entry. Threaded onto the onProgress
+   * payload so the worker card's metrics line shows the model. Undefined until
+   * the worker's first assistant line lands; before that the card falls back to
+   * the dispatch-time `tool_input.model` persisted on the registry row.
+   */
+  currentModel?: string
 }
 
 export interface SubagentWatcherConfig {
@@ -462,6 +473,12 @@ export interface SubagentWatcherConfig {
      *  feed. Undefined on `sub_agent_text` ticks — the gateway falls back
      *  to `latestSummary` (the narrative line), preserving prior behavior. */
     progressLine?: string
+    /** Live model this worker is running (raw resolved id, e.g.
+     *  `claude-opus-4-8`), from `WorkerEntry.currentModel`. Threaded onto the
+     *  worker/nested card's metrics line. Undefined before the worker's first
+     *  assistant line — the gateway then falls back to the registry's
+     *  dispatch-time model. */
+    model?: string
   }) => void
   /** `Date.now` override for tests. */
   now?: () => number
@@ -874,6 +891,8 @@ export function readSubTail(
     /** Friendly display line for THIS tick (set on tool ticks; see the
      *  SubagentWatcherConfig.onProgress doc). */
     progressLine?: string
+    /** Live model this worker is running (see SubagentWatcherConfig.onProgress). */
+    model?: string
   }) => void,
 ): void {
   try {
@@ -1003,6 +1022,7 @@ export function readSubTail(
             },
             lastTool: entry.lastTool,
             toolCount: entry.toolCount,
+            model: entry.currentModel,
           })
           return true
         } catch (cbErr) {
@@ -1086,6 +1106,31 @@ export function readSubTail(
           }
           log?.(`subagent-watcher: stall cleared for ${entry.agentId} (activity resumed after ${idleSecBeforeBump}s — re-arming detection)`)
         }
+        if (ev.kind === 'sub_agent_model') {
+          // Live model capture for this worker. The projection already filtered
+          // sentinels, so `ev.model` is a real resolved id. Record it on the
+          // entry (transcript wins over the dispatch-time tool_input.model) and
+          // persist to the registry row on CHANGE — update-on-change like
+          // last_activity_at — so a boot-replay / handback card can render the
+          // model without a live entry. No card render here: the model rides the
+          // next onProgress tick's payload (below).
+          if (entry.currentModel !== ev.model) {
+            entry.currentModel = ev.model
+            if (db != null) {
+              try {
+                const rowRef = db
+                  .prepare('SELECT id FROM subagents WHERE jsonl_agent_id = ?')
+                  .get(entry.agentId) as { id: string } | null
+                if (rowRef != null) {
+                  recordSubagentModel(db, { id: rowRef.id, model: ev.model })
+                }
+              } catch (dbErr) {
+                log?.(`subagent-watcher: model DB write error ${entry.agentId}: ${(dbErr as Error).message}`)
+              }
+            }
+          }
+          continue
+        }
         if (ev.kind === 'sub_agent_tool_use') {
           // Narrative-dedup gate step 2: a sub_agent_text block was pending;
           // this tool is the lookahead that decides it (SHOW unless it drafts
@@ -1144,6 +1189,7 @@ export function readSubTail(
                   lastTool: entry.lastTool,
                   toolCount: entry.toolCount,
                   progressLine: toolLine,
+                  model: entry.currentModel,
                 })
               } catch (cbErr) {
                 log?.(`subagent-watcher: onProgress (tool) callback error ${entry.agentId}: ${(cbErr as Error).message}`)

--- a/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
+++ b/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
@@ -26,10 +26,12 @@ describe('gateway: scheduleModelRelaunch dep', () => {
     expect(win).toMatch(/writeFileSync\(\s*join\(agentDir, '\.session-model-override'\),\s*`\$\{model\}\\n`/)
   })
 
-  it('sets the in-memory activeSessionModelOverride before dispatching the restart', () => {
+  it('sets the in-memory session-model override before dispatching the restart', () => {
     const idx = GATEWAY_SRC.indexOf('scheduleModelRelaunch: async')
     const win = GATEWAY_SRC.slice(idx, idx + 900)
-    const setIdx = win.indexOf('activeSessionModelOverride = model')
+    // The override now lives on the freshness-aware sessionModelSource
+    // (session-model-source.ts) rather than a bare module-level variable.
+    const setIdx = win.indexOf('sessionModelSource.setOverride(model)')
     const restartIdx = win.indexOf('deps.scheduleRestart(reason)')
     expect(setIdx).toBeGreaterThan(0)
     expect(restartIdx).toBeGreaterThan(setIdx)

--- a/telegram-plugin/tests/model-label.test.ts
+++ b/telegram-plugin/tests/model-label.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { formatModelLabel, isModelSentinel } from '../model-label.js'
+
+describe('isModelSentinel', () => {
+  it('flags synthetic / placeholder values starting with "<"', () => {
+    expect(isModelSentinel('<synthetic>')).toBe(true)
+    expect(isModelSentinel('<compact>')).toBe(true)
+  })
+
+  it('flags empty / whitespace / non-string values', () => {
+    expect(isModelSentinel('')).toBe(true)
+    expect(isModelSentinel('   ')).toBe(true)
+    expect(isModelSentinel(undefined)).toBe(true)
+    expect(isModelSentinel(null)).toBe(true)
+    expect(isModelSentinel(42)).toBe(true)
+  })
+
+  it('flags junk that is not shaped like a model id', () => {
+    expect(isModelSentinel('not a model')).toBe(true) // whitespace
+    expect(isModelSentinel('!!!')).toBe(true) // leading punctuation
+  })
+
+  it('accepts real resolved model ids', () => {
+    expect(isModelSentinel('claude-opus-4-8')).toBe(false)
+    expect(isModelSentinel('claude-haiku-4-5-20251001')).toBe(false)
+    expect(isModelSentinel('sr-glm-5')).toBe(false)
+    expect(isModelSentinel('sr-gpt-5.5')).toBe(false)
+  })
+})
+
+describe('formatModelLabel', () => {
+  it('renders the friendly short form for claude models', () => {
+    expect(formatModelLabel('claude-opus-4-8')).toBe('opus 4.8')
+    expect(formatModelLabel('claude-sonnet-5')).toBe('sonnet 5')
+  })
+
+  it('drops a trailing YYYYMMDD date stamp', () => {
+    expect(formatModelLabel('claude-haiku-4-5-20251001')).toBe('haiku 4.5')
+    expect(formatModelLabel('claude-opus-4-8-20260115')).toBe('opus 4.8')
+  })
+
+  it('shows sr-* ids verbatim', () => {
+    expect(formatModelLabel('sr-glm-5')).toBe('sr-glm-5')
+    expect(formatModelLabel('sr-gpt-5.5')).toBe('sr-gpt-5.5')
+    expect(formatModelLabel('sr-gemini-2.5-pro')).toBe('sr-gemini-2.5-pro')
+  })
+
+  it('returns null for sentinels and absent values (caller omits the field)', () => {
+    expect(formatModelLabel('<synthetic>')).toBeNull()
+    expect(formatModelLabel('')).toBeNull()
+    expect(formatModelLabel(null)).toBeNull()
+    expect(formatModelLabel(undefined)).toBeNull()
+    expect(formatModelLabel('has spaces')).toBeNull()
+  })
+
+  it('shows unknown but model-shaped ids verbatim', () => {
+    expect(formatModelLabel('gpt-5')).toBe('gpt-5')
+    expect(formatModelLabel('opus')).toBe('opus')
+  })
+
+  it('handles a claude id with only a family segment', () => {
+    expect(formatModelLabel('claude-opus')).toBe('opus')
+  })
+})

--- a/telegram-plugin/tests/session-model-source.test.ts
+++ b/telegram-plugin/tests/session-model-source.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Pins the /status session-model freshness contract (#2982 + live-model PR):
+ * the FRESHEST observation wins between the transcript's `message.model` and
+ * the /model override, arbitrated by a shared monotonic sequence. This is the
+ * "model display must never be stale" invariant:
+ *
+ *   - override set AFTER the last transcript observation (idle-time /model
+ *     switch, no assistant line yet) → /status shows the override;
+ *   - a new assistant line after that → the transcript wins again.
+ */
+import { describe, it, expect } from 'vitest'
+import { createSessionModelSource } from '../gateway/session-model-source.js'
+
+describe('createSessionModelSource — freshest observation wins', () => {
+  it('returns null when neither source has reported', () => {
+    const s = createSessionModelSource()
+    expect(s.resolve()).toBeNull()
+    expect(s.getOverride()).toBeNull()
+  })
+
+  it('transcript-only → transcript', () => {
+    const s = createSessionModelSource()
+    s.noteTranscriptModel('claude-opus-4-8')
+    expect(s.resolve()).toEqual({ model: 'claude-opus-4-8', source: 'transcript' })
+  })
+
+  it('override-only → override (fresh boot before the first assistant line)', () => {
+    const s = createSessionModelSource()
+    s.setOverride('sr-glm-5')
+    expect(s.resolve()).toEqual({ model: 'sr-glm-5', source: 'override' })
+  })
+
+  it('idle-after-switch window: an override set AFTER the last transcript line wins', () => {
+    // The #2982 regression this pins: /model switch while idle — the
+    // transcript still holds the OLD model, the override holds the NEW one.
+    const s = createSessionModelSource()
+    s.noteTranscriptModel('claude-opus-4-8') // old model's last assistant line
+    s.setOverride('Sonnet 5') // confirmed switch, no assistant line yet
+    expect(s.resolve()).toEqual({ model: 'Sonnet 5', source: 'override' })
+  })
+
+  it('a NEW assistant line after the switch reclaims the transcript as the source', () => {
+    const s = createSessionModelSource()
+    s.noteTranscriptModel('claude-opus-4-8')
+    s.setOverride('Sonnet 5')
+    s.noteTranscriptModel('claude-sonnet-5') // first line under the new model
+    expect(s.resolve()).toEqual({ model: 'claude-sonnet-5', source: 'transcript' })
+  })
+
+  it('clearing the override (null) falls back to the transcript', () => {
+    const s = createSessionModelSource()
+    s.noteTranscriptModel('claude-opus-4-8')
+    s.setOverride('sr-glm-5')
+    s.setOverride(null)
+    expect(s.getOverride()).toBeNull()
+    expect(s.resolve()).toEqual({ model: 'claude-opus-4-8', source: 'transcript' })
+  })
+
+  it('getOverride reports the override independent of freshness', () => {
+    const s = createSessionModelSource()
+    s.setOverride('sr-glm-5')
+    s.noteTranscriptModel('claude-opus-4-8') // transcript is now fresher
+    expect(s.resolve()?.source).toBe('transcript')
+    // ...but the override record itself is still readable (menu "session" marker).
+    expect(s.getOverride()).toBe('sr-glm-5')
+  })
+})

--- a/telegram-plugin/tests/session-tail.test.ts
+++ b/telegram-plugin/tests/session-tail.test.ts
@@ -345,6 +345,42 @@ describe('projectTranscriptLine', () => {
       messageId: '103',
     })
   })
+
+  // ─── Live model capture (message.model) ──────────────────────────────
+  it('emits a model event (first) from message.model on an assistant line', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        model: 'claude-opus-4-8',
+        content: [{ type: 'tool_use', name: 'Bash', id: 'toolu_01', input: {} }],
+      },
+    })
+    // Model event is emitted BEFORE the content events so a same-batch render
+    // already reflects the current model.
+    expect(projectTranscriptLine(line)).toEqual([
+      { kind: 'model', model: 'claude-opus-4-8' },
+      { kind: 'tool_use', toolName: 'Bash', toolUseId: 'toolu_01', input: {} },
+    ])
+  })
+
+  it('skips a synthetic model sentinel (keeps no model event)', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        model: '<synthetic>',
+        content: [{ type: 'thinking', thinking: '...' }],
+      },
+    })
+    expect(projectTranscriptLine(line)).toEqual([{ kind: 'thinking' }])
+  })
+
+  it('omits the model event when message.model is absent', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: { content: [{ type: 'thinking', thinking: '...' }] },
+    })
+    expect(projectTranscriptLine(line)).toEqual([{ kind: 'thinking' }])
+  })
 })
 
 // ─── Bug 1 regression: per-file cursor state survives re-attachment ────
@@ -488,6 +524,34 @@ describe('projectSubagentLine', () => {
     expect(events2).toEqual([
       { kind: 'sub_agent_tool_result', agentId: 'aaa', toolUseId: 'toolu_x', isError: undefined },
     ])
+  })
+
+  it('emits sub_agent_model (first) from message.model on a sub-agent assistant line', () => {
+    const st = { hasEmittedStart: true }
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        model: 'sr-glm-5',
+        content: [{ type: 'tool_use', id: 'toolu_a', name: 'Read', input: { file_path: '/a' } }],
+      },
+    })
+    const events = projectSubagentLine(line, 'X', st)
+    expect(events[0]).toEqual({ kind: 'sub_agent_model', agentId: 'X', model: 'sr-glm-5' })
+    expect(events[1].kind).toBe('sub_agent_tool_use')
+  })
+
+  it('skips a synthetic sub-agent model sentinel', () => {
+    const st = { hasEmittedStart: true }
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        model: '<synthetic>',
+        content: [{ type: 'tool_use', id: 'toolu_a', name: 'Read', input: { file_path: '/a' } }],
+      },
+    })
+    const events = projectSubagentLine(line, 'X', st)
+    expect(events.some((e) => e.kind === 'sub_agent_model')).toBe(false)
+    expect(events[0].kind).toBe('sub_agent_tool_use')
   })
 
   it('emits sub_agent_tool_use for regular tools; nested Agent fires ONLY nested_spawn', () => {

--- a/telegram-plugin/tests/subagent-tracker-hooks.test.ts
+++ b/telegram-plugin/tests/subagent-tracker-hooks.test.ts
@@ -108,6 +108,45 @@ describe('subagent-tracker-pretool', () => {
     expect(row!.last_activity_at).toBe(row!.started_at)
   })
 
+  it('persists tool_input.model as the first-paint model on the row', () => {
+    const event = {
+      session_id: 'sess-model',
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_model001',
+      tool_input: {
+        subagent_type: 'worker',
+        description: 'Build with a pinned model',
+        run_in_background: true,
+        model: 'claude-opus-4-8',
+      },
+    }
+    const result = runHook(PRETOOL_SCRIPT, event)
+    expect(result.status).toBe(0)
+
+    const db = openDb()
+    const row = db.prepare('SELECT model FROM subagents WHERE id = ?').get('toolu_model001') as
+      | { model: string | null }
+      | undefined
+    expect(row?.model).toBe('claude-opus-4-8')
+  })
+
+  it('leaves model null when the Agent dispatch carries no model', () => {
+    const event = {
+      session_id: 'sess-nomodel',
+      tool_name: 'Agent',
+      tool_use_id: 'toolu_nomodel001',
+      tool_input: { subagent_type: 'worker', description: 'no model', run_in_background: false },
+    }
+    const result = runHook(PRETOOL_SCRIPT, event)
+    expect(result.status).toBe(0)
+
+    const db = openDb()
+    const row = db.prepare('SELECT model FROM subagents WHERE id = ?').get('toolu_nomodel001') as
+      | { model: string | null }
+      | undefined
+    expect(row?.model ?? null).toBeNull()
+  })
+
   it('does not write a row when tool_name is not Agent', () => {
     const event = {
       session_id: 'sess-abc123',

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -519,6 +519,60 @@ describe('startSubagentWatcher', () => {
       expect(toolTick?.latestSummary).toBe('')
     })
 
+    it('captures message.model into entry.currentModel and threads it onto onProgress', () => {
+      const progress: Array<{ model?: string }> = []
+      const agentDir = join(tmpRoot, 'agent')
+      const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+      mkdirSync(subagentsDir, { recursive: true })
+      const jsonlPath = join(subagentsDir, 'agent-deadbeef.jsonl')
+
+      const h = startWatcherSync({
+        agentDir,
+        onProgress: ({ model }) => { progress.push({ model }) },
+      })
+      writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Research the competitors')))
+      h.poll()
+
+      // Assistant line carrying a resolved model + a tool_use (drives an
+      // onProgress tick). The model event is projected first, so the entry's
+      // currentModel is set before the tool tick fires.
+      appendFileSync(jsonlPath, buildJSONL({
+        type: 'assistant',
+        message: {
+          model: 'claude-opus-4-8',
+          content: [{ type: 'tool_use', name: 'Read', id: 'r1', input: { file_path: '/x/CLAUDE.md' } }],
+        },
+      }))
+      h.poll()
+
+      expect(h.watcher.getRegistry().get('deadbeef')?.currentModel).toBe('claude-opus-4-8')
+      const modelled = progress.find((p) => p.model != null)
+      expect(modelled?.model).toBe('claude-opus-4-8')
+    })
+
+    it('ignores a synthetic model sentinel, keeping the last real model', () => {
+      const agentDir = join(tmpRoot, 'agent')
+      const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+      mkdirSync(subagentsDir, { recursive: true })
+      const jsonlPath = join(subagentsDir, 'agent-deadbeef.jsonl')
+
+      const h = startWatcherSync({ agentDir })
+      writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Research')))
+      h.poll()
+      appendFileSync(jsonlPath, buildJSONL({
+        type: 'assistant',
+        message: { model: 'claude-opus-4-8', content: [{ type: 'tool_use', name: 'Read', id: 'r1', input: {} }] },
+      }))
+      h.poll()
+      // A compaction/synthetic line — must NOT clobber the last real model.
+      appendFileSync(jsonlPath, buildJSONL({
+        type: 'assistant',
+        message: { model: '<synthetic>', content: [{ type: 'tool_use', name: 'Bash', id: 'b1', input: {} }] },
+      }))
+      h.poll()
+      expect(h.watcher.getRegistry().get('deadbeef')?.currentModel).toBe('claude-opus-4-8')
+    })
+
     it('narrative gate: a draft-then-reply sub_agent_text is SUPPRESSED (no progress cue)', () => {
       // The worker composes its answer as a text block, then calls
       // stream_reply with near-identical text. The narrative cue must be

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -723,6 +723,28 @@ describe("renderActivityHeader — two-line header builder", () => {
     const [h1] = renderActivityHeader("🤖", "Agent", "run a_b & c*d", 5_000, 1, "running");
     expect(h1).toContain("run a\\_b & c\\*d");
   });
+
+  it("appends the friendly live model to the running metrics line", () => {
+    const [, h2] = renderActivityHeader("🤖", "Agent", "", 120_000, 14, "running", "claude-opus-4-8");
+    expect(h2).toBe("_2m00s · 14 tools · opus 4.8_");
+  });
+
+  it("appends the friendly live model to the done metrics line", () => {
+    const [, h2] = renderActivityHeader("🤖", "Agent", "", 65_000, 3, "done", "claude-sonnet-5");
+    expect(h2).toBe("_done · 3 tools · 1m05s · sonnet 5_");
+  });
+
+  it("shows an sr-* model id verbatim on the metrics line", () => {
+    const [, h2] = renderActivityHeader("🛠", "Worker", "run tests", 10_000, 2, "running", "sr-glm-5");
+    expect(h2).toBe("_10s · 2 tools · sr-glm-5_");
+  });
+
+  it("omits the model tag for a sentinel / absent value", () => {
+    const [, h2none] = renderActivityHeader("🤖", "Agent", "", 15_000, 7, "running");
+    expect(h2none).toBe("_15s · 7 tools_");
+    const [, h2synth] = renderActivityHeader("🤖", "Agent", "", 15_000, 7, "running", "<synthetic>");
+    expect(h2synth).toBe("_15s · 7 tools_");
+  });
 });
 
 describe("agent flat path routes through the shared step-feed primitive", () => {
@@ -813,6 +835,21 @@ describe("renderActivityFeed — header param (main-session card fix)", () => {
     // Step feed follows the header.
     expect(out).toContain("~~_✓ Reading CLAUDE.md_~~");
     expect(out).toContain("**→ Searching memory**");
+  });
+
+  it("threads the header model through the flat and nested feed paths", () => {
+    const header: SessionActivityHeader = {
+      label: "Agent",
+      elapsedMs: 120_000,
+      toolCount: 14,
+      state: "running",
+      model: "claude-opus-4-8",
+    };
+    const flat = renderActivityFeed(["Searching memory"], false, "", undefined, header)!;
+    expect(flat).toContain("_2m00s · 14 tools · opus 4.8_");
+    // Nested path (with a child line) carries the same model tag.
+    const nested = renderActivityFeedWithNested(["Reading"], ["nested step"], false, "", undefined, header)!;
+    expect(nested).toContain("· opus 4.8_");
   });
 
   it("prepends the done header when final=true", () => {

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -86,6 +86,17 @@ describe('renderWorkerActivity', () => {
     expect(out).not.toContain('<code>')
   })
 
+  it('renders the friendly live model on the worker metrics line', () => {
+    const out = renderWorkerActivity(view({ model: 'claude-sonnet-5' }))
+    expect(out).toContain('_10s · 3 tools · sonnet 5_')
+  })
+
+  it('omits the model tag when the worker model is unknown', () => {
+    const out = renderWorkerActivity(view())
+    expect(out).toContain('_10s · 3 tools_')
+    expect(out).not.toContain('· sonnet')
+  })
+
   it('shows a "starting…" line when no step has run yet', () => {
     const out = renderWorkerActivity(view({ lastTool: null, latestSummary: '' }))
     expect(out).toContain('🛠 **Worker**')

--- a/telegram-plugin/tests/worker-feed-dispatch.test.ts
+++ b/telegram-plugin/tests/worker-feed-dispatch.test.ts
@@ -17,6 +17,7 @@ function makeSub(over: Partial<Subagent>): Subagent {
     result_summary: null,
     jsonl_agent_id: 'a37ad7639ae61476c',
     parent_agent_id: null,
+    model: null,
     ...over,
   }
 }
@@ -60,6 +61,16 @@ describe('resolveWorkerFeedDispatch (#2002 regression pin)', () => {
     // The gateway gates the feed on isBackground; a registry miss must not
     // flip a foreground turn into a background one.
     expect(resolveWorkerFeedDispatch(null, '').isBackground).toBe(false)
+  })
+
+  it('surfaces the persisted registry model as feedModel (first-paint fallback)', () => {
+    const sub = makeSub({ background: true, model: 'claude-opus-4-8' })
+    expect(resolveWorkerFeedDispatch(sub, 'sub-agent').feedModel).toBe('claude-opus-4-8')
+  })
+
+  it('feedModel is null when the row is missing or carries no model', () => {
+    expect(resolveWorkerFeedDispatch(null, 'sub-agent').feedModel).toBeNull()
+    expect(resolveWorkerFeedDispatch(makeSub({ model: null }), 'sub-agent').feedModel).toBeNull()
   })
 })
 

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -91,6 +91,7 @@ import {
 } from './status-no-truncate.js'
 import { escapeMarkdown, stripMarkdown, truncate, stackCardLines } from './card-format.js'
 import { isTelegramSurfaceTool } from './tool-names.js'
+import { formatModelLabel } from './model-label.js'
 
 /**
  * Optional header for the main-session activity card, matching the worker
@@ -106,6 +107,14 @@ export interface SessionActivityHeader {
   elapsedMs: number
   toolCount: number
   state: 'running' | 'done'
+  /**
+   * Live model in use, as a raw resolved model id (e.g. `claude-opus-4-8`,
+   * `sr-glm-5`) sourced from the transcript. Rendered as a short friendly form
+   * appended to the metrics line (`… · opus 4.8`). Omitted when unknown — the
+   * card never guesses from config. Formatting + sentinel-filtering live in
+   * `formatModelLabel` (model-label.ts).
+   */
+  model?: string
 }
 
 /**
@@ -173,14 +182,19 @@ export function renderActivityHeader(
   elapsedMs: number,
   toolCount: number,
   state: 'running' | 'done' | 'failed',
+  model?: string,
 ): [string, string] {
   const toolWord = toolCount === 1 ? 'tool' : 'tools'
   const elapsed = formatFeedElapsed(elapsedMs)
   const descPart = description.length > 0 ? ` · _${escapeMarkdown(description)}_` : ''
   const line1 = `${emoji} **${escapeMarkdown(label)}**${descPart}`
+  // Subtle live-model tag: joins the existing dot-separated metrics (never a new
+  // line). formatModelLabel returns null for absent/sentinel values → no suffix.
+  const modelLabel = formatModelLabel(model)
+  const modelPart = modelLabel != null ? ` · ${escapeMarkdown(modelLabel)}` : ''
   const line2 = state === 'running'
-    ? `_${elapsed} · ${toolCount} ${toolWord}_`
-    : `_${state} · ${toolCount} ${toolWord} · ${elapsed}_`
+    ? `_${elapsed} · ${toolCount} ${toolWord}${modelPart}_`
+    : `_${state} · ${toolCount} ${toolWord} · ${elapsed}${modelPart}_`
   return [line1, line2]
 }
 
@@ -270,6 +284,9 @@ export interface StatusCardHeader {
   elapsedMs: number
   toolCount: number
   state: 'running' | 'done' | 'failed'
+  /** Live model id (raw, e.g. `claude-opus-4-8`) — rendered as a short friendly
+   *  tag on the metrics line via `formatModelLabel`. Omitted when unknown. */
+  model?: string
 }
 
 /** Inputs to the unified status-card renderer. */
@@ -321,6 +338,7 @@ export function renderStatusCard(opts: StatusCardOpts): string | null {
         // when the result block is empty. The agent surface never passes
         // 'failed', so only the worker card is affected.
         header.state,
+        header.model,
       )
     : []
 
@@ -476,6 +494,7 @@ export function renderActivityFeed(
           elapsedMs: header.elapsedMs,
           toolCount: header.toolCount,
           state: header.state,
+          model: header.model,
         }
       : undefined,
     steps: lines,
@@ -527,6 +546,7 @@ export function renderActivityFeedWithNested(
           elapsedMs: header.elapsedMs,
           toolCount: header.toolCount,
           state: header.state,
+          model: header.model,
         }
       : undefined,
     steps: lines,

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -70,6 +70,14 @@ export interface WorkerActivityView {
   /** Wall-clock since dispatch, ms. */
   elapsedMs: number
   state: WorkerActivityState
+  /**
+   * Live model the worker is running, as a raw resolved model id sourced from
+   * its transcript (`message.model`) or, before its first assistant line, the
+   * dispatch-time `tool_input.model` persisted on the registry row. Rendered as
+   * a short friendly tag on the worker card's metrics line. Omitted when
+   * unknown — never guessed from config.
+   */
+  model?: string
 }
 
 export interface BotApiForWorkerFeed {
@@ -133,6 +141,7 @@ export function renderWorkerActivity(v: WorkerActivityView, liveSuffix = ''): st
     elapsedMs: v.elapsedMs,
     toolCount: v.toolCount,
     state: v.state,
+    model: v.model,
   }
 
   // Terminal: latestSummary carries the worker's final result text (gateway


### PR DESCRIPTION
## Summary

Every progress / activity surface now shows the model **actually in use**, sourced live from the session transcripts — never from config, never from launch-time state. The main-agent activity card, the liveness card, background-worker feed cards, nested sub-agent blocks, and workflow agent cards each render the model serving that agent's API calls, as a subtle tag on the existing dot-separated metrics line:

```
🤖 Agent
2m · 14 tools · opus 4.8
```

Per-agent, per-sub-agent: a worker running on a different model than the main agent shows its own model on its own card.

## Why / design

- **Transcript-sourced, never config.** Every `type:"assistant"` line in a Claude Code transcript (main session and each `subagents/agent-*.jsonl`, including workflow `wf_*/agent-*.jsonl`) carries `message.model` — the exact resolved model for that API call. The two session-tail projection branches now extract it and emit a dedicated `model` / `sub_agent_model` event (first among a line's events, so a same-batch render already reflects it).
- **Sentinel filtering.** Compaction / synthetic lines carry `model:"<synthetic>"`, and fixtures can carry junk. A shared `isModelSentinel` treats anything starting with `<`, empty, or non-model-shaped as a sentinel: it's skipped and the previous value is kept. Real ids (`claude-opus-4-8`, `sr-glm-5`) pass.
- **First-paint fallback.** Before a sub-agent writes its first assistant line, the worker card falls back to the dispatch-time `tool_input.model` — captured by the pretool hook and persisted on a new `model` registry column (migration follows the existing `jsonl_agent_id` / `parent_agent_id` pattern). Once the transcript value lands, the transcript wins. If neither is known, the tag is omitted — never guessed from config.
- **Registry persistence.** The watcher persists the current model on the subagents row (update-on-change, like `last_activity_at`) so boot-replay / handback cards render it without a live entry.
- **/status accuracy.** `buildAgentMetadata` prefers the last-seen main-transcript model (rendered in the same friendly short form) over the in-memory `/model` override, falling back to the override on a fresh boot / sr-* relaunch window. Kept surgical to coexist with #2982 (rebased on it; no conflict).

One small shared formatter (`model-label.ts`) renders the friendly form (`claude-opus-4-8 → opus 4.8`, `claude-haiku-4-5-20251001 → haiku 4.5`, `sr-*` verbatim) and owns the sentinel gate, with dedicated unit tests.

## Test plan

- `model-label.ts` — formatter + sentinel-filtering unit tests
- `session-tail` — `model` / `sub_agent_model` projection (main + sub-agent), sentinel skip, absent-model omission
- registry `subagents` — model column on fresh DB, idempotent migration, `recordSubagentModel` update-on-change
- pretool hook — persists `tool_input.model`, leaves null when absent
- watcher — `currentModel` capture into the entry + onProgress threading, synthetic-sentinel ignore
- render — header metrics-line model tag (running / done / sr-*/ omitted), flat + nested feed threading, worker card model tag
- `bun test` for the bun suites, `vitest` for the rest, `npm run lint` all green (incl. `check-bot-api-wrapping`)

## Risk

Additive: the model field is optional on every header / view / event and every registry column migration is idempotent. Cards with no observed model render byte-identically to before. Rebased onto #2982; the /status edit is a one-line preference change that leaves #2982's `/model` override path intact as the fallback.

Job spec: `reference/jobs/` — the on-the-leash progress-visibility surface (activity/worker cards). This advances the "on the leash" vision outcome: the operator can see, live, exactly which model each agent and sub-agent is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)