### PR TITLE
fix(telegram): always-allow persist fails ~1 in 3 (issue 2973)

### DIFF
--- a/telegram-plugin/gateway/always-allow-persist-queue.ts
+++ b/telegram-plugin/gateway/always-allow-persist-queue.ts
@@ -31,10 +31,24 @@
  * convention — see {@link MAX_ATTEMPTS}, {@link MAX_AGE_MS}, and
  * {@link MAX_QUEUE_SIZE} below, and the tests that pin them.
  *
- * File format + fault-tolerance mirrors `missed-approvals-store.ts`: a
- * single bounded JSON array, written synchronously, mode 0o600. No file
- * I/O failure here may throw into the caller — writes/reads degrade to
- * a no-op/empty-list rather than crashing the gateway.
+ * File format mirrors `missed-approvals-store.ts`: a single bounded JSON
+ * array, written synchronously, mode 0o600.
+ *
+ * Failure semantics (hardened post-#2973 adversarial review): a failed
+ * READ degrades to an empty list — a corrupt/missing queue file is not
+ * fatal, it just means "nothing queued yet". A failed WRITE is a
+ * different story: silently swallowing it would mean `enqueue()` tells
+ * its caller "queued for retry" when nothing was actually persisted to
+ * disk, and a concurrent `recordAttempt()`/`remove()` would silently
+ * fail to advance the queue's on-disk state. So `write()` PROPAGATES
+ * (throws) on failure, and `enqueue()` / `recordAttempt()` / `remove()`
+ * let that throw reach their own caller rather than pretending the
+ * mutation landed. `drainAlwaysAllowPersistQueue` below catches around
+ * each entry so one entry's write failure can't take down the rest of
+ * the drain pass; callers in the gateway (the interactive "Always
+ * allow" tap path) are responsible for catching enqueue() failures and
+ * reflecting them in the operator-facing message rather than claiming
+ * success.
  */
 
 import { readFileSync, writeFileSync, unlinkSync } from 'node:fs'
@@ -80,7 +94,10 @@ interface FileShape {
 export interface AlwaysAllowPersistQueue {
   /** Enqueue (or refresh) a failed persist for retry. Idempotent on
    * `(agentName, rule)` — an existing entry is updated in place rather
-   * than duplicated. */
+   * than duplicated. Serialized (via an in-process lock) relative to
+   * every other read-modify-write on the queue file, and REJECTS if the
+   * underlying write fails — callers must not treat a settled promise
+   * as "persisted" without checking for rejection. */
   enqueue(entry: {
     agentName: string
     rule: string
@@ -88,27 +105,32 @@ export interface AlwaysAllowPersistQueue {
     chatId?: string
     threadId?: number | null
     error?: string
-  }): void
+  }): Promise<void>
   /** All entries currently due for a retry attempt (nextAttemptAt <= now),
    * oldest first. Does NOT filter by attempts/age — callers should apply
    * {@link isExhausted} to decide terminal-failure vs. retry. */
   listDue(now?: number): AlwaysAllowPersistEntry[]
   /** Every entry in the queue, regardless of due-ness. */
   listAll(): AlwaysAllowPersistEntry[]
-  /** Record the outcome of a retry attempt for `id`.
+  /** Record the outcome of a retry attempt for `id`. Serialized relative
+   * to `enqueue`/`remove`/other `recordAttempt` calls on the same queue
+   * file — never races a concurrent mutation into a lost update.
    *  - `success: true` → dequeue.
    *  - `success: false` → increment attempts, compute the next backoff
    *    (honoring `retryAfterMs` when supplied), and re-persist — UNLESS
    *    the entry is now exhausted (see {@link isExhausted}), in which case
    *    it is dropped and the caller should have already emitted the
    *    terminal-failure notice.
+   * REJECTS if the underlying write fails — the caller must not assume
+   * the state change was durably persisted just because this returned.
    */
   recordAttempt(
     id: string,
     outcome: { success: true } | { success: false; error: string; retryAfterMs?: number },
-  ): void
-  /** Remove an entry outright (e.g. after emitting its terminal notice). */
-  remove(id: string): void
+  ): Promise<void>
+  /** Remove an entry outright (e.g. after emitting its terminal notice).
+   * Serialized like the other mutators; REJECTS if the write fails. */
+  remove(id: string): Promise<void>
   /** Delete the backing file entirely. */
   clear(): void
 }
@@ -142,6 +164,27 @@ export function computeBackoffMs(attempts: number, retryAfterMs?: number): numbe
 export function createAlwaysAllowPersistQueue(stateDir: string): AlwaysAllowPersistQueue {
   const filePath = join(stateDir, 'always-allow-persist-queue.json')
 
+  // ── In-process mutex ──────────────────────────────────────────────────
+  // enqueue / recordAttempt / remove are each a read-modify-write cycle
+  // against the SAME file. Node is single-threaded, but these operations
+  // are exposed as async (their callers `await` a hostd round trip, a
+  // drain pass, etc.), so two calls CAN interleave across a microtask/
+  // macrotask boundary — a naive "read, mutate, write" per call is a
+  // classic lost-update race (#2973 pt.3): call A reads, call B reads the
+  // same pre-A-write snapshot, B writes, A writes — B's update vanishes.
+  // Fix: every read-modify-write against `filePath` is queued through this
+  // single promise chain, so at most one is ever in flight at a time,
+  // regardless of how many callers invoke enqueue/recordAttempt/remove
+  // "concurrently".
+  let lock: Promise<unknown> = Promise.resolve()
+  function withLock<T>(fn: () => T): Promise<T> {
+    const result = lock.then(fn, fn) // run fn even if the previous link rejected
+    // Swallow the rejection on the CHAIN (not on `result`) so one failed
+    // mutation doesn't wedge the lock for everything queued after it.
+    lock = result.catch(() => {})
+    return result
+  }
+
   function read(): FileShape {
     try {
       const raw = readFileSync(filePath, 'utf-8')
@@ -152,54 +195,54 @@ export function createAlwaysAllowPersistQueue(stateDir: string): AlwaysAllowPers
     }
   }
 
+  /** Unlike `read()`, a write failure is NOT swallowed — it propagates so
+   * the caller (enqueue/recordAttempt/remove) finds out its mutation did
+   * not actually land on disk (disk full, permissions, etc.) instead of
+   * silently proceeding as if it had. */
   function write(f: FileShape): void {
-    try {
-      writeFileSync(filePath, JSON.stringify(f), { encoding: 'utf-8', mode: 0o600 })
-    } catch (err) {
-      process.stderr.write(
-        `telegram gateway: always-allow-persist-queue write failed: ${(err as Error).message}\n`,
-      )
-    }
+    writeFileSync(filePath, JSON.stringify(f), { encoding: 'utf-8', mode: 0o600 })
   }
 
   return {
     enqueue(args) {
-      const id = makeEntryId(args.agentName, args.rule)
-      const f = read()
-      const now = Date.now()
-      const idx = f.entries.findIndex(e => e.id === id)
-      if (idx >= 0) {
-        // Already queued (e.g. a second tap failed the same way) — keep
-        // its attempt history/createdAt (age bound is from FIRST failure),
-        // just refresh the description fields and last error.
-        f.entries[idx] = {
-          ...f.entries[idx]!,
-          grantPhrase: args.grantPhrase,
-          chatId: args.chatId,
-          threadId: args.threadId,
-          lastError: args.error,
+      return withLock(() => {
+        const id = makeEntryId(args.agentName, args.rule)
+        const f = read()
+        const now = Date.now()
+        const idx = f.entries.findIndex(e => e.id === id)
+        if (idx >= 0) {
+          // Already queued (e.g. a second tap failed the same way) — keep
+          // its attempt history/createdAt (age bound is from FIRST failure),
+          // just refresh the description fields and last error.
+          f.entries[idx] = {
+            ...f.entries[idx]!,
+            grantPhrase: args.grantPhrase,
+            chatId: args.chatId,
+            threadId: args.threadId,
+            lastError: args.error,
+          }
+        } else {
+          if (f.entries.length >= MAX_QUEUE_SIZE) {
+            // Bounded — drop the oldest to make room rather than growing
+            // without limit under a failure storm.
+            f.entries.sort((a, b) => a.createdAt - b.createdAt)
+            f.entries = f.entries.slice(f.entries.length - MAX_QUEUE_SIZE + 1)
+          }
+          f.entries.push({
+            id,
+            agentName: args.agentName,
+            rule: args.rule,
+            grantPhrase: args.grantPhrase,
+            chatId: args.chatId,
+            threadId: args.threadId,
+            attempts: 1,
+            createdAt: now,
+            nextAttemptAt: now + computeBackoffMs(1),
+            lastError: args.error,
+          })
         }
-      } else {
-        if (f.entries.length >= MAX_QUEUE_SIZE) {
-          // Bounded — drop the oldest to make room rather than growing
-          // without limit under a failure storm.
-          f.entries.sort((a, b) => a.createdAt - b.createdAt)
-          f.entries = f.entries.slice(f.entries.length - MAX_QUEUE_SIZE + 1)
-        }
-        f.entries.push({
-          id,
-          agentName: args.agentName,
-          rule: args.rule,
-          grantPhrase: args.grantPhrase,
-          chatId: args.chatId,
-          threadId: args.threadId,
-          attempts: 1,
-          createdAt: now,
-          nextAttemptAt: now + computeBackoffMs(1),
-          lastError: args.error,
-        })
-      }
-      write(f)
+        write(f)
+      })
     },
 
     listDue(now = Date.now()) {
@@ -213,40 +256,44 @@ export function createAlwaysAllowPersistQueue(stateDir: string): AlwaysAllowPers
     },
 
     recordAttempt(id, outcome) {
-      const f = read()
-      const idx = f.entries.findIndex(e => e.id === id)
-      if (idx === -1) return
-      if (outcome.success) {
-        f.entries.splice(idx, 1)
+      return withLock(() => {
+        const f = read()
+        const idx = f.entries.findIndex(e => e.id === id)
+        if (idx === -1) return
+        if (outcome.success) {
+          f.entries.splice(idx, 1)
+          write(f)
+          return
+        }
+        const entry = f.entries[idx]!
+        const attempts = entry.attempts + 1
+        const updated: AlwaysAllowPersistEntry = {
+          ...entry,
+          attempts,
+          lastError: outcome.error,
+          nextAttemptAt: Date.now() + computeBackoffMs(attempts, outcome.retryAfterMs),
+        }
+        if (isExhausted(updated)) {
+          // Exhausted — drop it. The caller is responsible for having
+          // emitted (or being about to emit) the terminal-failure notice;
+          // this store only owns the bounded-retry bookkeeping.
+          f.entries.splice(idx, 1)
+        } else {
+          f.entries[idx] = updated
+        }
         write(f)
-        return
-      }
-      const entry = f.entries[idx]!
-      const attempts = entry.attempts + 1
-      const updated: AlwaysAllowPersistEntry = {
-        ...entry,
-        attempts,
-        lastError: outcome.error,
-        nextAttemptAt: Date.now() + computeBackoffMs(attempts, outcome.retryAfterMs),
-      }
-      if (isExhausted(updated)) {
-        // Exhausted — drop it. The caller is responsible for having
-        // emitted (or being about to emit) the terminal-failure notice;
-        // this store only owns the bounded-retry bookkeeping.
-        f.entries.splice(idx, 1)
-      } else {
-        f.entries[idx] = updated
-      }
-      write(f)
+      })
     },
 
     remove(id) {
-      const f = read()
-      const filtered = f.entries.filter(e => e.id !== id)
-      if (filtered.length !== f.entries.length) {
-        f.entries = filtered
-        write(f)
-      }
+      return withLock(() => {
+        const f = read()
+        const filtered = f.entries.filter(e => e.id !== id)
+        if (filtered.length !== f.entries.length) {
+          f.entries = filtered
+          write(f)
+        }
+      })
     },
 
     clear() {
@@ -321,13 +368,13 @@ export async function drainAlwaysAllowPersistQueue(
         log(
           `always-allow-persist-queue: rule already persisted, no-op dequeue agent=${entry.agentName} rule=${entry.rule}\n`,
         )
-        queue.recordAttempt(entry.id, { success: true })
+        await recordAttemptSafely(entry, { success: true })
         continue
       }
 
       const diff = deps.synthesizeDiff(entry.agentName, entry.rule, configText)
       if (diff == null) {
-        recordFailure(entry, 'could not re-synthesize diff from fresh config read')
+        await recordFailure(entry, 'could not re-synthesize diff from fresh config read')
         continue
       }
 
@@ -336,17 +383,36 @@ export async function drainAlwaysAllowPersistQueue(
         log(
           `always-allow-persist-queue: retry succeeded agent=${entry.agentName} rule=${entry.rule} attempts=${entry.attempts}\n`,
         )
-        queue.recordAttempt(entry.id, { success: true })
+        await recordAttemptSafely(entry, { success: true })
       } else {
-        recordFailure(entry, result.error, result.retryAfterMs)
+        await recordFailure(entry, result.error, result.retryAfterMs)
       }
     } catch (err) {
       // Never let one entry's unexpected throw take down the drain pass.
-      recordFailure(entry, `unexpected error: ${(err as Error).message}`)
+      await recordFailure(entry, `unexpected error: ${(err as Error).message}`)
     }
   }
 
-  function recordFailure(entry: AlwaysAllowPersistEntry, error: string, retryAfterMs?: number): void {
+  /** `queue.recordAttempt` now REJECTS on a write failure (disk full,
+   * permissions, …) rather than silently pretending the state change
+   * persisted. The drain loop must not let that reject take down the
+   * whole pass (or the other due entries) — log it and move on; the
+   * entry stays in whatever state the last successful write left it in,
+   * and will be picked up again on the next drain pass. */
+  async function recordAttemptSafely(
+    entry: AlwaysAllowPersistEntry,
+    outcome: { success: true } | { success: false; error: string; retryAfterMs?: number },
+  ): Promise<void> {
+    try {
+      await queue.recordAttempt(entry.id, outcome)
+    } catch (err) {
+      log(
+        `always-allow-persist-queue: recordAttempt write failed (state change NOT persisted) agent=${entry.agentName} rule=${entry.rule}: ${(err as Error).message}\n`,
+      )
+    }
+  }
+
+  async function recordFailure(entry: AlwaysAllowPersistEntry, error: string, retryAfterMs?: number): Promise<void> {
     const willBeExhausted = isExhausted({ attempts: entry.attempts + 1, createdAt: entry.createdAt })
     log(
       `always-allow-persist-queue: retry failed agent=${entry.agentName} rule=${entry.rule} attempts=${entry.attempts + 1} exhausted=${willBeExhausted} error=${error}\n`,
@@ -360,6 +426,6 @@ export async function drainAlwaysAllowPersistQueue(
         )
       }
     }
-    queue.recordAttempt(entry.id, { success: false, error, retryAfterMs })
+    await recordAttemptSafely(entry, { success: false, error, retryAfterMs })
   }
 }

--- a/telegram-plugin/gateway/always-allow-persist-queue.ts
+++ b/telegram-plugin/gateway/always-allow-persist-queue.ts
@@ -161,7 +161,14 @@ export function computeBackoffMs(attempts: number, retryAfterMs?: number): numbe
   return exp
 }
 
-export function createAlwaysAllowPersistQueue(stateDir: string): AlwaysAllowPersistQueue {
+export function createAlwaysAllowPersistQueue(
+  stateDir: string,
+  /** Injectable for tests to force a write failure (disk full / permissions /
+   * read-only fs) without real filesystem faults — we run as root in CI/
+   * containers, so chmod-based permission tricks don't reliably fail, and
+   * bun's test runner doesn't support mocking node:fs built-ins. */
+  writeFileSyncFn: typeof writeFileSync = writeFileSync,
+): AlwaysAllowPersistQueue {
   const filePath = join(stateDir, 'always-allow-persist-queue.json')
 
   // ── In-process mutex ──────────────────────────────────────────────────
@@ -200,7 +207,7 @@ export function createAlwaysAllowPersistQueue(stateDir: string): AlwaysAllowPers
    * not actually land on disk (disk full, permissions, etc.) instead of
    * silently proceeding as if it had. */
   function write(f: FileShape): void {
-    writeFileSync(filePath, JSON.stringify(f), { encoding: 'utf-8', mode: 0o600 })
+    writeFileSyncFn(filePath, JSON.stringify(f), { encoding: 'utf-8', mode: 0o600 })
   }
 
   return {

--- a/telegram-plugin/gateway/always-allow-persist-queue.ts
+++ b/telegram-plugin/gateway/always-allow-persist-queue.ts
@@ -1,0 +1,365 @@
+/**
+ * Durable retry queue for the "🔁 Always allow" durable-persist flow
+ * (#1977, hardened in #2973).
+ *
+ * Problem (#2973): a `config_propose_edit` dispatch for an always-allow
+ * rule can fail for RETRYABLE reasons (a transient hostd error, a stale
+ * container-side config view producing `E_PATCH_APPLY_FAILED`, a rate
+ * limit with a structured `retry_after`) — today that failure is simply
+ * reported to the operator ("did NOT save") and the tap is lost; the rule
+ * only lands if the operator notices and re-taps after the next restart.
+ *
+ * Fix: on a retryable dispatch failure, enqueue `{agent, rule, ...}` here
+ * BEFORE giving up. The gateway drains this queue at boot (so a restart
+ * mid-persist doesn't lose the entry) and on a periodic timer. Each drain
+ * pass:
+ *   1. re-checks `isRulePersisted` against a FRESH config read first — if
+ *      the rule already landed (e.g. the original attempt actually
+ *      succeeded server-side but the ack was lost), dequeue as a no-op;
+ *   2. otherwise re-synthesizes the diff from that fresh read (fixes the
+ *      stale-view failure class) and redispatches;
+ *   3. on success, dequeues; on failure, backs off exponentially (honoring
+ *      a structured `retryAfterMs` when the failure supplies one) and
+ *      re-tries later;
+ *   4. once `attempts` reaches {@link MAX_ATTEMPTS} or the entry has aged
+ *      past {@link MAX_AGE_MS}, the entry is dropped and the caller is
+ *      told to post a LOUD terminal-failure notice (a new message, not a
+ *      card edit — card edits don't ping).
+ *
+ * HARD RULE (standing fleet rule, restated in #2973): nothing here may
+ * retry indefinitely. Bounds are enforced structurally, not just by
+ * convention — see {@link MAX_ATTEMPTS}, {@link MAX_AGE_MS}, and
+ * {@link MAX_QUEUE_SIZE} below, and the tests that pin them.
+ *
+ * File format + fault-tolerance mirrors `missed-approvals-store.ts`: a
+ * single bounded JSON array, written synchronously, mode 0o600. No file
+ * I/O failure here may throw into the caller — writes/reads degrade to
+ * a no-op/empty-list rather than crashing the gateway.
+ */
+
+import { readFileSync, writeFileSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+
+/** Hard cap on retry attempts per entry — never retry indefinitely. */
+export const MAX_ATTEMPTS = 5
+
+/** Hard cap on how long an entry may live in the queue before being
+ * dropped as terminally failed, regardless of attempts made. */
+export const MAX_AGE_MS = 24 * 60 * 60 * 1000 // 24h
+
+/** Bound the on-disk file even under a pathological failure storm. */
+export const MAX_QUEUE_SIZE = 50
+
+/** Base backoff for attempt 1; doubles each subsequent attempt (capped). */
+export const BASE_BACKOFF_MS = 60_000 // 1 minute
+
+/** Ceiling on the computed backoff, independent of attempt count. */
+export const MAX_BACKOFF_MS = 30 * 60_000 // 30 minutes
+
+export interface AlwaysAllowPersistEntry {
+  /** Dedup key — one live queue entry per (agent, rule) pair. */
+  id: string
+  agentName: string
+  rule: string
+  /** Human-readable grant description, for the terminal-failure notice. */
+  grantPhrase: string
+  /** Origin chat/thread, so a terminal-failure notice can be targeted
+   * (falls back to the operator broadcast allowlist if absent). */
+  chatId?: string
+  threadId?: number | null
+  attempts: number
+  createdAt: number
+  nextAttemptAt: number
+  lastError?: string
+}
+
+interface FileShape {
+  entries: AlwaysAllowPersistEntry[]
+}
+
+export interface AlwaysAllowPersistQueue {
+  /** Enqueue (or refresh) a failed persist for retry. Idempotent on
+   * `(agentName, rule)` — an existing entry is updated in place rather
+   * than duplicated. */
+  enqueue(entry: {
+    agentName: string
+    rule: string
+    grantPhrase: string
+    chatId?: string
+    threadId?: number | null
+    error?: string
+  }): void
+  /** All entries currently due for a retry attempt (nextAttemptAt <= now),
+   * oldest first. Does NOT filter by attempts/age — callers should apply
+   * {@link isExhausted} to decide terminal-failure vs. retry. */
+  listDue(now?: number): AlwaysAllowPersistEntry[]
+  /** Every entry in the queue, regardless of due-ness. */
+  listAll(): AlwaysAllowPersistEntry[]
+  /** Record the outcome of a retry attempt for `id`.
+   *  - `success: true` → dequeue.
+   *  - `success: false` → increment attempts, compute the next backoff
+   *    (honoring `retryAfterMs` when supplied), and re-persist — UNLESS
+   *    the entry is now exhausted (see {@link isExhausted}), in which case
+   *    it is dropped and the caller should have already emitted the
+   *    terminal-failure notice.
+   */
+  recordAttempt(
+    id: string,
+    outcome: { success: true } | { success: false; error: string; retryAfterMs?: number },
+  ): void
+  /** Remove an entry outright (e.g. after emitting its terminal notice). */
+  remove(id: string): void
+  /** Delete the backing file entirely. */
+  clear(): void
+}
+
+/** Stable id for a (agent, rule) pair — one live retry entry per pair. */
+export function makeEntryId(agentName: string, rule: string): string {
+  return `${agentName}::${rule}`
+}
+
+/** True when `entry` has exhausted its retry budget — attempts maxed OR
+ * aged out — and should be dropped with a terminal-failure notice rather
+ * than retried again. Pure so callers/tests can reason about the bound
+ * without needing the store. */
+export function isExhausted(entry: Pick<AlwaysAllowPersistEntry, 'attempts' | 'createdAt'>, now = Date.now()): boolean {
+  return entry.attempts >= MAX_ATTEMPTS || now - entry.createdAt >= MAX_AGE_MS
+}
+
+/**
+ * Exponential backoff with a hard ceiling, honoring a structured
+ * `retry_after` hint when the failure supplied one (never retries SOONER
+ * than that hint, but still respects {@link MAX_BACKOFF_MS}).
+ */
+export function computeBackoffMs(attempts: number, retryAfterMs?: number): number {
+  const exp = Math.min(BASE_BACKOFF_MS * 2 ** Math.max(0, attempts - 1), MAX_BACKOFF_MS)
+  if (retryAfterMs != null && retryAfterMs > 0) {
+    return Math.min(Math.max(exp, retryAfterMs), MAX_BACKOFF_MS)
+  }
+  return exp
+}
+
+export function createAlwaysAllowPersistQueue(stateDir: string): AlwaysAllowPersistQueue {
+  const filePath = join(stateDir, 'always-allow-persist-queue.json')
+
+  function read(): FileShape {
+    try {
+      const raw = readFileSync(filePath, 'utf-8')
+      const parsed = JSON.parse(raw) as Partial<FileShape>
+      return { entries: Array.isArray(parsed?.entries) ? parsed.entries : [] }
+    } catch {
+      return { entries: [] }
+    }
+  }
+
+  function write(f: FileShape): void {
+    try {
+      writeFileSync(filePath, JSON.stringify(f), { encoding: 'utf-8', mode: 0o600 })
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: always-allow-persist-queue write failed: ${(err as Error).message}\n`,
+      )
+    }
+  }
+
+  return {
+    enqueue(args) {
+      const id = makeEntryId(args.agentName, args.rule)
+      const f = read()
+      const now = Date.now()
+      const idx = f.entries.findIndex(e => e.id === id)
+      if (idx >= 0) {
+        // Already queued (e.g. a second tap failed the same way) — keep
+        // its attempt history/createdAt (age bound is from FIRST failure),
+        // just refresh the description fields and last error.
+        f.entries[idx] = {
+          ...f.entries[idx]!,
+          grantPhrase: args.grantPhrase,
+          chatId: args.chatId,
+          threadId: args.threadId,
+          lastError: args.error,
+        }
+      } else {
+        if (f.entries.length >= MAX_QUEUE_SIZE) {
+          // Bounded — drop the oldest to make room rather than growing
+          // without limit under a failure storm.
+          f.entries.sort((a, b) => a.createdAt - b.createdAt)
+          f.entries = f.entries.slice(f.entries.length - MAX_QUEUE_SIZE + 1)
+        }
+        f.entries.push({
+          id,
+          agentName: args.agentName,
+          rule: args.rule,
+          grantPhrase: args.grantPhrase,
+          chatId: args.chatId,
+          threadId: args.threadId,
+          attempts: 1,
+          createdAt: now,
+          nextAttemptAt: now + computeBackoffMs(1),
+          lastError: args.error,
+        })
+      }
+      write(f)
+    },
+
+    listDue(now = Date.now()) {
+      return read()
+        .entries.filter(e => e.nextAttemptAt <= now)
+        .sort((a, b) => a.nextAttemptAt - b.nextAttemptAt)
+    },
+
+    listAll() {
+      return read().entries
+    },
+
+    recordAttempt(id, outcome) {
+      const f = read()
+      const idx = f.entries.findIndex(e => e.id === id)
+      if (idx === -1) return
+      if (outcome.success) {
+        f.entries.splice(idx, 1)
+        write(f)
+        return
+      }
+      const entry = f.entries[idx]!
+      const attempts = entry.attempts + 1
+      const updated: AlwaysAllowPersistEntry = {
+        ...entry,
+        attempts,
+        lastError: outcome.error,
+        nextAttemptAt: Date.now() + computeBackoffMs(attempts, outcome.retryAfterMs),
+      }
+      if (isExhausted(updated)) {
+        // Exhausted — drop it. The caller is responsible for having
+        // emitted (or being about to emit) the terminal-failure notice;
+        // this store only owns the bounded-retry bookkeeping.
+        f.entries.splice(idx, 1)
+      } else {
+        f.entries[idx] = updated
+      }
+      write(f)
+    },
+
+    remove(id) {
+      const f = read()
+      const filtered = f.entries.filter(e => e.id !== id)
+      if (filtered.length !== f.entries.length) {
+        f.entries = filtered
+        write(f)
+      }
+    },
+
+    clear() {
+      try {
+        unlinkSync(filePath)
+      } catch {
+        // File may not exist — fine.
+      }
+    },
+  }
+}
+
+// ─── Drain ──────────────────────────────────────────────────────────────────
+
+/** Injected dependencies for {@link drainAlwaysAllowPersistQueue} — kept
+ * abstract so the drain loop is unit-testable without gateway/network/hostd
+ * deps. The gateway wires the real implementations at call sites. */
+export interface AlwaysAllowDrainDeps {
+  /** Read the CURRENT (fresh, not cached) config file text. Throwing here
+   * is treated as a retryable failure for the entry being processed. */
+  readConfigText(): string
+  /** Resolve the agent's current, fully-merged `tools.allow` list from the
+   * freshly-read config — used to no-op a retry whose rule already
+   * landed (e.g. the original dispatch actually succeeded). */
+  resolveAllowList(configText: string, agentName: string): string[]
+  isRulePersisted(allowList: string[], rule: string): boolean
+  /** Re-synthesize the diff from the fresh config text. Returns null if
+   * the agent block can no longer be located (treated as retryable —
+   * config may be mid-edit). */
+  synthesizeDiff(agentName: string, rule: string, configText: string): string | null
+  /** Dispatch the (re-synthesized) diff for durable persistence. */
+  dispatchConfigEdit(
+    entry: AlwaysAllowPersistEntry,
+    unifiedDiff: string,
+  ): Promise<{ ok: true } | { ok: false; error: string; retryAfterMs?: number }>
+  /** Called once for an entry that has exhausted its retry budget — the
+   * "loud terminal failure" requirement (#2973 pt.3). Must not throw. */
+  notifyTerminalFailure(entry: AlwaysAllowPersistEntry, reason: string): void
+  /** Optional logger sink (defaults to a no-op) — kept separate from
+   * stderr writes so tests can assert on it without capturing stdio. */
+  log?(line: string): void
+}
+
+/**
+ * Process every currently-due entry once. Safe to call at gateway boot
+ * (drains anything left over from a mid-persist restart) and on a
+ * periodic timer (~10 min in the gateway). Each entry is handled
+ * independently — one entry's dispatch throwing never blocks its
+ * siblings, and this function itself never throws.
+ */
+export async function drainAlwaysAllowPersistQueue(
+  queue: AlwaysAllowPersistQueue,
+  deps: AlwaysAllowDrainDeps,
+): Promise<void> {
+  const log = deps.log ?? (() => {})
+  const due = queue.listDue()
+  for (const entry of due) {
+    try {
+      let configText: string
+      try {
+        configText = deps.readConfigText()
+      } catch (err) {
+        recordFailure(entry, `config read failed: ${(err as Error).message}`)
+        continue
+      }
+
+      // Re-check FIRST: if the rule already landed (original attempt
+      // actually succeeded, or a concurrent tap persisted it), this is a
+      // no-op dequeue — never re-append and risk a duplicate rule.
+      const allowList = deps.resolveAllowList(configText, entry.agentName)
+      if (deps.isRulePersisted(allowList, entry.rule)) {
+        log(
+          `always-allow-persist-queue: rule already persisted, no-op dequeue agent=${entry.agentName} rule=${entry.rule}\n`,
+        )
+        queue.recordAttempt(entry.id, { success: true })
+        continue
+      }
+
+      const diff = deps.synthesizeDiff(entry.agentName, entry.rule, configText)
+      if (diff == null) {
+        recordFailure(entry, 'could not re-synthesize diff from fresh config read')
+        continue
+      }
+
+      const result = await deps.dispatchConfigEdit(entry, diff)
+      if (result.ok) {
+        log(
+          `always-allow-persist-queue: retry succeeded agent=${entry.agentName} rule=${entry.rule} attempts=${entry.attempts}\n`,
+        )
+        queue.recordAttempt(entry.id, { success: true })
+      } else {
+        recordFailure(entry, result.error, result.retryAfterMs)
+      }
+    } catch (err) {
+      // Never let one entry's unexpected throw take down the drain pass.
+      recordFailure(entry, `unexpected error: ${(err as Error).message}`)
+    }
+  }
+
+  function recordFailure(entry: AlwaysAllowPersistEntry, error: string, retryAfterMs?: number): void {
+    const willBeExhausted = isExhausted({ attempts: entry.attempts + 1, createdAt: entry.createdAt })
+    log(
+      `always-allow-persist-queue: retry failed agent=${entry.agentName} rule=${entry.rule} attempts=${entry.attempts + 1} exhausted=${willBeExhausted} error=${error}\n`,
+    )
+    if (willBeExhausted) {
+      try {
+        deps.notifyTerminalFailure(entry, error)
+      } catch (notifyErr) {
+        log(
+          `always-allow-persist-queue: notifyTerminalFailure threw agent=${entry.agentName} rule=${entry.rule}: ${(notifyErr as Error).message}\n`,
+        )
+      }
+    }
+    queue.recordAttempt(entry.id, { success: false, error, retryAfterMs })
+  }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -135,6 +135,11 @@ import {
 } from './permission-rearm.js'
 import { createMissedApprovalsStore, type MissedApproval } from './missed-approvals-store.js'
 import {
+  createAlwaysAllowPersistQueue,
+  drainAlwaysAllowPersistQueue,
+  type AlwaysAllowDrainDeps,
+} from './always-allow-persist-queue.js'
+import {
   renderMissedApprovalsDigest,
   missedApprovalsKeyboard,
   parseMissedApprovalCallback,
@@ -398,7 +403,7 @@ import {
   _resetHostdEnabledCache,
 } from './hostd-dispatch.js'
 import { formatUpdateStatusLine } from './update-status-line.js'
-import type { HostdRequest } from '../../src/host-control/protocol.js'
+import type { HostdRequest, HostdResponse } from '../../src/host-control/protocol.js'
 import type { AgentAudit } from '../welcome-text.js'
 import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
 import { startWebhookIngestServer } from './webhook-ingest-server.js'
@@ -725,6 +730,113 @@ const permCardStore = createPermissionCardStore(STATE_DIR)
 const missedApprovalsStore = createMissedApprovalsStore(STATE_DIR)
 const MISSED_APPROVAL_REOFFER_ENABLED =
   process.env.SWITCHROOM_MISSED_APPROVAL_REOFFER !== '0'
+// #2973 pt.2 — durable retry queue for "🔁 Always allow" persists that
+// fail for a retryable reason (stale config view, rate limit, transient
+// hostd error). Drained at boot (below) and on a periodic timer so a
+// gateway restart mid-persist never loses the retry.
+const alwaysAllowPersistQueue = createAlwaysAllowPersistQueue(STATE_DIR)
+
+/** Read a hostd `error_envelope`'s structured `retry_after` fix (if
+ * present) as a millisecond delay from now. Returns undefined for any
+ * other fix kind / missing envelope / unparsable timestamp — callers
+ * fall back to plain exponential backoff in that case. */
+function extractRetryAfterMs(resp: HostdResponse): number | undefined {
+  const fix = resp.error_envelope?.fix
+  if (fix == null || fix.kind !== 'retry_after') return undefined
+  const at = Date.parse(fix.retry_at)
+  if (Number.isNaN(at)) return undefined
+  return Math.max(0, at - Date.now())
+}
+
+/**
+ * Build a FRESH dependency set for `drainAlwaysAllowPersistQueue` — a new
+ * factory call per drain pass, not a cached singleton, so every attempt
+ * re-reads config from disk (the #2973 stale-container-side-view failure
+ * class is fixed by never reusing a snapshot across retries).
+ */
+function alwaysAllowDrainDeps(): AlwaysAllowDrainDeps {
+  return {
+    readConfigText: () => {
+      const cfgPath = process.env.SWITCHROOM_CONFIG ?? SWITCHROOM_CONFIG ?? findSwitchroomConfigFile()
+      return readFileSync(cfgPath, 'utf8')
+    },
+    resolveAllowList: (_configText, agentName) => {
+      const cfg = loadSwitchroomConfig()
+      const rawAgent = cfg.agents?.[agentName]
+      if (!rawAgent) return []
+      const resolved = resolveAgentConfig(cfg.defaults, cfg.profiles, rawAgent)
+      return (resolved as { tools?: { allow?: string[] } }).tools?.allow ?? []
+    },
+    isRulePersisted,
+    synthesizeDiff: (agentName, rule, configText) =>
+      synthesizeAllowRuleDiff({ agentName, rule, configText }),
+    dispatchConfigEdit: async (entry, unifiedDiff) => {
+      const req: HostdRequest = {
+        v: 1,
+        op: 'config_propose_edit',
+        request_id: hostdRequestId('gw-always-allow-retry'),
+        args: {
+          unified_diff: unifiedDiff,
+          reason: `Operator 'always allow' retry: ${entry.agentName} can ${entry.grantPhrase}`,
+          target_path: '/state/config/switchroom.yaml',
+        },
+      }
+      const resp = await tryHostdDispatch(entry.agentName, req, 720_000)
+      if (resp === 'not-configured') {
+        return { ok: false as const, error: 'hostd not-configured (retry queue requires host_control.enabled)' }
+      }
+      if (resp.result === 'completed') return { ok: true as const }
+      return {
+        ok: false as const,
+        error: resp.error ?? `hostd ${resp.result}`,
+        retryAfterMs: extractRetryAfterMs(resp),
+      }
+    },
+    // #2973 pt.3 — loud terminal failure. A card edit doesn't ping the
+    // operator (the original permission card was already edited to the
+    // "saving durably in background…" interim state); this posts a NEW
+    // message instead, via the same operator-event broadcast every other
+    // fleet alert uses.
+    notifyTerminalFailure: (entry, reason) => {
+      emitGatewayOperatorEvent({
+        kind: 'always-allow-persist-failed',
+        agent: entry.agentName,
+        detail: `"${entry.grantPhrase}" (rule \`${entry.rule}\`) — ${reason}`,
+        suggestedActions: [],
+        firstSeenAt: new Date(),
+      })
+    },
+    log: (line) => process.stderr.write(line),
+  }
+}
+
+/** ~10 min between periodic drain passes — frequent enough that a
+ * retryable failure (rate limit, transient hostd hiccup) resolves within
+ * a reasonable window, infrequent enough to never look like polling. */
+const ALWAYS_ALLOW_DRAIN_INTERVAL_MS = 10 * 60_000
+
+/**
+ * Boot drain (picks up anything a prior gateway process queued right
+ * before a restart — success criterion: "restarting the gateway mid-
+ * persist does not lose the queued entry") + a periodic timer thereafter.
+ * Called once at gateway startup. Every pass is independently
+ * fault-tolerant — `drainAlwaysAllowPersistQueue` never throws.
+ */
+function scheduleAlwaysAllowPersistDrain(): void {
+  void drainAlwaysAllowPersistQueue(alwaysAllowPersistQueue, alwaysAllowDrainDeps()).catch((err) => {
+    process.stderr.write(
+      `telegram gateway: always-allow-persist-queue boot drain failed: ${(err as Error).message}\n`,
+    )
+  })
+  const timer = setInterval(() => {
+    void drainAlwaysAllowPersistQueue(alwaysAllowPersistQueue, alwaysAllowDrainDeps()).catch((err) => {
+      process.stderr.write(
+        `telegram gateway: always-allow-persist-queue periodic drain failed: ${(err as Error).message}\n`,
+      )
+    })
+  }, ALWAYS_ALLOW_DRAIN_INTERVAL_MS)
+  timer.unref?.()
+}
 const ACCESS_FILE = join(STATE_DIR, 'access.json')
 const APPROVED_DIR = join(STATE_DIR, 'approved')
 const ENV_FILE = join(STATE_DIR, '.env')
@@ -24831,6 +24943,23 @@ bot.on('callback_query:data', async ctx => {
           process.stderr.write(
             `telegram gateway: always-allow hostd FAILED: ${failReason} (request_id=${request_id})\n`,
           )
+          // #2973 pt.2 — enqueue for the durable retry queue UNLESS the
+          // failure is non-retryable (config edits locked — retrying
+          // won't help until the operator flips the flag; that case
+          // keeps today's honest "did NOT save" card only). Everything
+          // else (stale config view, transient hostd error, rate limit)
+          // gets picked up by the boot/periodic drain instead of quietly
+          // requiring the operator to notice and re-tap.
+          if (!editLockHint) {
+            alwaysAllowPersistQueue.enqueue({
+              agentName,
+              rule: chosen.rule,
+              grantPhrase,
+              chatId: ctx.chat?.id != null ? String(ctx.chat.id) : undefined,
+              threadId: (ctx.callbackQuery?.message as { message_thread_id?: number } | undefined)?.message_thread_id,
+              error: failReason,
+            })
+          }
         }
       }
 
@@ -26720,6 +26849,12 @@ void (async () => {
             })
           }
         }
+
+        // #2973 pt.2 — drain any always-allow persists left queued by a
+        // prior gateway process (e.g. one that restarted mid-persist),
+        // then keep draining periodically for the rest of this process's
+        // lifetime.
+        scheduleAlwaysAllowPersistDrain()
 
         void registerSwitchroomBotCommands().catch(() => {})
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -24951,14 +24951,27 @@ bot.on('callback_query:data', async ctx => {
           // gets picked up by the boot/periodic drain instead of quietly
           // requiring the operator to notice and re-tap.
           if (!editLockHint) {
-            alwaysAllowPersistQueue.enqueue({
-              agentName,
-              rule: chosen.rule,
-              grantPhrase,
-              chatId: ctx.chat?.id != null ? String(ctx.chat.id) : undefined,
-              threadId: (ctx.callbackQuery?.message as { message_thread_id?: number } | undefined)?.message_thread_id,
-              error: failReason,
-            })
+            try {
+              await alwaysAllowPersistQueue.enqueue({
+                agentName,
+                rule: chosen.rule,
+                grantPhrase,
+                chatId: ctx.chat?.id != null ? String(ctx.chat.id) : undefined,
+                threadId: (ctx.callbackQuery?.message as { message_thread_id?: number } | undefined)?.message_thread_id,
+                error: failReason,
+              })
+            } catch (enqueueErr) {
+              // The retry queue's own write failed (disk full, perms, …) —
+              // don't pretend this landed. Fold it into the operator-facing
+              // failReason so the "did NOT save" card is honest about the
+              // retry mechanism ALSO having failed, not just the original
+              // dispatch (#2973 adversarial review pt.2).
+              const enqueueMsg = (enqueueErr as Error).message
+              process.stderr.write(
+                `telegram gateway: always-allow enqueue for retry FAILED: ${enqueueMsg} (request_id=${request_id})\n`,
+              )
+              failReason = `${failReason} (retry queue also failed to persist: ${enqueueMsg})`
+            }
           }
         }
       }

--- a/telegram-plugin/operator-events.ts
+++ b/telegram-plugin/operator-events.ts
@@ -27,6 +27,7 @@ export type OperatorEventKind =
   | 'unknown-4xx'
   | 'unknown-5xx'
   | 'config-warning'
+  | 'always-allow-persist-failed'
 
 export interface OperatorEvent {
   kind: OperatorEventKind
@@ -387,6 +388,29 @@ export function renderOperatorEvent(ev: OperatorEvent): RenderResult {
           `ℹ️ **Config warning** for **${agent}**.`,
           detail ? `_${detail}_` : '',
           `Non-urgent — config will keep working with today's fallback behavior.`,
+        ]
+          .filter(Boolean)
+          .join('\n'),
+        keyboard: {
+          inline_keyboard: [
+            [{ text: '❌ Dismiss', callback_data: `op:dismiss:${encodeURIComponent(ev.agent)}` }],
+          ],
+        },
+      }
+
+    // #2973 pt.3 — a durable "Always allow" persist exhausted its retry
+    // budget (always-allow-persist-queue.ts) or hit a non-retryable error
+    // (e.g. E_CONFIG_EDIT_DISABLED). MUST be a NEW message, not a card
+    // edit — the original permission card was already edited to the
+    // interim "saving durably in background…" state and card edits don't
+    // ping the operator, so a silent edit here would leave the failure
+    // unnoticed indefinitely.
+    case 'always-allow-persist-failed':
+      return {
+        text: [
+          `⚠️ Your "Always allow" for **${agent}** didn't stick.`,
+          detail ? `_${detail}_` : '',
+          `It will ask again.`,
         ]
           .filter(Boolean)
           .join('\n'),

--- a/telegram-plugin/permission-diff.ts
+++ b/telegram-plugin/permission-diff.ts
@@ -156,6 +156,73 @@ function locateAllowLine(
   return null;
 }
 
+/** Internal: a located multi-line flow list (`allow:` then `[` on a
+ * subsequent line, one entry per line, closing `]` on its own line — the
+ * shape clerk's config uses, `switchroom.yaml:507-514`). */
+interface MultilineFlowList {
+  /** 0-based index of the line containing the opening `[`. */
+  openIdx: number;
+  /** 0-based index of the line containing the matching closing `]`. */
+  closeIdx: number;
+  /** Indentation to use for a newly-inserted entry line. */
+  itemIndent: number;
+  /** 0-based index of the last existing entry line, or -1 if the list is
+   * empty (`[` immediately followed by `]`, possibly across lines). */
+  lastEntryIdx: number;
+}
+
+/**
+ * Scan forward from `scanStart` (the line right after `allow:` when its
+ * inline remainder is empty) for a flow list whose opening `[` is on its
+ * OWN subsequent line (issue #2973 — clerk's exact shape). Tracks bracket
+ * depth char-by-char so a matching `]` is found even several lines down.
+ * Returns null if the first non-blank/comment line doesn't open a flow
+ * list, or the list is unterminated within the block.
+ */
+function locateMultilineFlowList(
+  lines: string[],
+  scanStart: number,
+  blockEnd: number,
+): MultilineFlowList | null {
+  let i = scanStart;
+  while (i < blockEnd && isBlankOrComment(lines[i]!)) i++;
+  if (i >= blockEnd) return null;
+  const firstLine = lines[i]!;
+  if (!firstLine.trim().startsWith("[")) return null;
+  const openIdx = i;
+
+  let depth = 0;
+  let closeIdx = -1;
+  for (let j = openIdx; j < blockEnd && closeIdx === -1; j++) {
+    const line = lines[j]!;
+    for (const ch of line) {
+      if (ch === "[") depth++;
+      else if (ch === "]") {
+        depth--;
+        if (depth === 0) {
+          closeIdx = j;
+          break;
+        }
+      }
+    }
+  }
+  if (closeIdx === -1) return null; // unterminated — caller falls back.
+
+  // Entry lines: strictly between the open and close bracket lines,
+  // one per line (the observed shape). Lines that carry entries AND a
+  // bracket on the same line (e.g. inline `[ all,`) aren't split out
+  // here — they're handled upstream by the single-line flow-list case.
+  let lastEntryIdx = -1;
+  for (let j = openIdx + 1; j < closeIdx; j++) {
+    if (isBlankOrComment(lines[j]!)) continue;
+    lastEntryIdx = j;
+  }
+  const itemIndent =
+    lastEntryIdx !== -1 ? indentOf(lines[lastEntryIdx]!) : indentOf(firstLine) + 2;
+
+  return { openIdx, closeIdx, itemIndent, lastEntryIdx };
+}
+
 /**
  * Build a unified-diff hunk from a contiguous slice of the original
  * file. `lines` is the whole file split on `\n`. The hunk replaces the
@@ -282,6 +349,45 @@ export function synthesizeAllowRuleDiff(
     return wrapDiff(hunk);
   }
 
+  // Case (a2): multi-line flow list — `allow:` has an EMPTY inline
+  // remainder, but the `[` opens on a subsequent line and entries run one
+  // per line down to a closing `]` on its own line (clerk's exact shape,
+  // issue #2973). Must be checked before the block-sequence fallback below
+  // — that fallback would otherwise misread the `[`/entries/`]` lines as
+  // block-sequence context and insert a `- <rule>` line ABOVE the `[`,
+  // corrupting the YAML (`E_YAML_UNSAFE_CONSTRUCT`).
+  if (inlineTrimmed.length === 0) {
+    const flow = locateMultilineFlowList(lines, allow.idx + 1, block.agentBlockEnd);
+    if (flow) {
+      if (flow.lastEntryIdx === -1) {
+        // Empty multi-line list (`[` immediately followed by `]`) — insert
+        // the first entry right after the opening bracket line.
+        const insertAt = flow.openIdx + 1;
+        const added = [`${" ".repeat(flow.itemIndent)}${rule}`];
+        const hunk = buildHunk(lines, insertAt, insertAt, [], added);
+        return wrapDiff(hunk);
+      }
+      // Ensure the current last entry carries a trailing comma (YAML flow
+      // sequences accept it, and it's required here since we're adding a
+      // sibling entry on its own line), then append the new entry —
+      // replacing the single last-entry line with both lines.
+      const lastLine = lines[flow.lastEntryIdx]!;
+      const lastTrimmedEnd = lastLine.replace(/\s+$/, "");
+      const fixedLast = lastTrimmedEnd.endsWith(",")
+        ? lastTrimmedEnd
+        : `${lastTrimmedEnd},`;
+      const itemLine = `${" ".repeat(flow.itemIndent)}${rule}`;
+      const hunk = buildHunk(
+        lines,
+        flow.lastEntryIdx,
+        flow.lastEntryIdx + 1,
+        [lastLine],
+        [fixedLast, itemLine],
+      );
+      return wrapDiff(hunk);
+    }
+  }
+
   // Case (b): block sequence. Find the last `- ` entry at indent
   // allow.indent + 2 and insert a new entry after it.
   const itemIndent = allow.indent + 2;
@@ -348,6 +454,14 @@ export function extractAddedAllowRule(unifiedDiff: string): string | null {
       })
       .filter((x): x is string => x !== null);
     if (items.length === 1) return items[0]!;
+    // Multi-line flow-list first-entry insert (list was empty): a single
+    // bare `+` line with no `- ` prefix — the plain entry text itself,
+    // possibly comma-suffixed.
+    if (items.length === 0 && plus.length === 1) {
+      const bare = plus[0]!.trim();
+      const stripped = bare.endsWith(",") ? bare.slice(0, -1).trim() : bare;
+      return stripped.length > 0 ? stripped : null;
+    }
     return null;
   }
 
@@ -366,6 +480,20 @@ export function extractAddedAllowRule(unifiedDiff: string): string | null {
       if (before[i] !== after[i]) return null;
     }
     return added;
+  }
+
+  // Multi-line flow-list append: one `-` line (the previous last entry)
+  // replaced by TWO `+` lines — that same entry now comma-terminated,
+  // plus the new entry on its own line.
+  if (minus.length === 1 && plus.length === 2) {
+    const orig = minus[0]!.trim();
+    const first = plus[0]!.trim();
+    const second = plus[1]!.trim();
+    const origStripped = orig.endsWith(",") ? orig.slice(0, -1).trim() : orig;
+    const firstStripped = first.endsWith(",") ? first.slice(0, -1).trim() : first;
+    if (firstStripped !== origStripped) return null;
+    const added = second.endsWith(",") ? second.slice(0, -1).trim() : second;
+    return added.length > 0 ? added : null;
   }
 
   return null;

--- a/telegram-plugin/tests/always-allow-persist-queue.test.ts
+++ b/telegram-plugin/tests/always-allow-persist-queue.test.ts
@@ -27,15 +27,12 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
-// Partial mock of node:fs so individual tests can force a `writeFileSync`
-// failure (disk full / permissions / read-only fs) without needing real
-// filesystem faults (we run as root in CI/containers, so chmod-based
-// permission tricks don't reliably fail). `readFileSync`/other exports
-// stay real via `importOriginal`.
-vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs')>()
-  return { ...actual, writeFileSync: vi.fn(actual.writeFileSync) }
-})
+// Tests that need to force a `writeFileSync` failure (disk full /
+// permissions / read-only fs) pass one in via `createAlwaysAllowPersistQueue`'s
+// injectable `writeFileSyncFn` param (see `makeControllableWrite` below)
+// rather than mocking `node:fs` — we run as root in CI/containers, so
+// chmod-based permission tricks don't reliably fail, and bun's test runner
+// doesn't support mocking node:fs built-ins.
 
 import {
   createAlwaysAllowPersistQueue,
@@ -267,32 +264,50 @@ describe('createAlwaysAllowPersistQueue — concurrency (#2973 adversarial revie
   })
 })
 
+/** A `writeFileSync`-shaped fn that runs the real node:fs implementation
+ * unless armed via `failNext()` (throws once, then reverts to real writes)
+ * or `failAlways()` (throws on every call from here on) — lets a test force
+ * writes to fail while everything before/after actually lands on disk. */
+function makeControllableWrite() {
+  let armedMessage: string | null = null
+  let alwaysFail = false
+  const fn = ((...args: Parameters<typeof writeFileSync>) => {
+    if (alwaysFail) throw new Error(armedMessage ?? 'forced write failure')
+    if (armedMessage !== null) {
+      const message = armedMessage
+      armedMessage = null
+      throw new Error(message)
+    }
+    return writeFileSync(...args)
+  }) as typeof writeFileSync
+  return {
+    fn,
+    failNext: (message: string) => { armedMessage = message },
+    failAlways: (message: string) => { armedMessage = message; alwaysFail = true },
+  }
+}
+
 describe('createAlwaysAllowPersistQueue — write failures propagate (#2973 adversarial review pt.2)', () => {
   let dir: string
   beforeEach(() => { dir = makeTmpDir() })
-  afterEach(() => {
-    vi.restoreAllMocks()
-    rmSync(dir, { recursive: true, force: true })
-  })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
 
   it('enqueue() rejects when the underlying writeFileSync throws (disk full / permissions)', async () => {
-    const q = createAlwaysAllowPersistQueue(dir)
-    vi.mocked(writeFileSync).mockImplementationOnce(() => {
-      throw new Error('ENOSPC: no space left on device')
-    })
+    const write = makeControllableWrite()
+    const q = createAlwaysAllowPersistQueue(dir, write.fn)
+    write.failNext('ENOSPC: no space left on device')
     await expect(q.enqueue(baseArgs())).rejects.toThrow(/ENOSPC/)
     // The caller was told it failed — and indeed nothing was persisted.
     expect(q.listAll()).toEqual([])
   })
 
   it('recordAttempt() rejects when the underlying writeFileSync throws, and does not pretend the state change landed', async () => {
-    const q = createAlwaysAllowPersistQueue(dir)
+    const write = makeControllableWrite()
+    const q = createAlwaysAllowPersistQueue(dir, write.fn)
     await q.enqueue(baseArgs())
     const id = q.listAll()[0].id
 
-    vi.mocked(writeFileSync).mockImplementationOnce(() => {
-      throw new Error('EACCES: permission denied')
-    })
+    write.failNext('EACCES: permission denied')
     await expect(q.recordAttempt(id, { success: true })).rejects.toThrow(/EACCES/)
 
     // The entry is still there — the (failed) dequeue never actually
@@ -302,23 +317,21 @@ describe('createAlwaysAllowPersistQueue — write failures propagate (#2973 adve
   })
 
   it('remove() rejects when the underlying writeFileSync throws', async () => {
-    const q = createAlwaysAllowPersistQueue(dir)
+    const write = makeControllableWrite()
+    const q = createAlwaysAllowPersistQueue(dir, write.fn)
     await q.enqueue(baseArgs())
     const id = q.listAll()[0].id
 
-    vi.mocked(writeFileSync).mockImplementationOnce(() => {
-      throw new Error('EROFS: read-only file system')
-    })
+    write.failNext('EROFS: read-only file system')
     await expect(q.remove(id)).rejects.toThrow(/EROFS/)
 
     expect(q.listAll()).toHaveLength(1)
   })
 
   it('a write failure does not wedge the in-process lock — a later successful call still lands', async () => {
-    const q = createAlwaysAllowPersistQueue(dir)
-    vi.mocked(writeFileSync).mockImplementationOnce(() => {
-      throw new Error('ENOSPC: no space left on device')
-    })
+    const write = makeControllableWrite()
+    const q = createAlwaysAllowPersistQueue(dir, write.fn)
+    write.failNext('ENOSPC: no space left on device')
     await expect(q.enqueue(baseArgs({ error: 'first' }))).rejects.toThrow(/ENOSPC/)
 
     // Disk recovered — the NEXT call (real writeFileSync) must succeed,
@@ -490,7 +503,8 @@ describe('drainAlwaysAllowPersistQueue', () => {
   })
 
   it('a drain-time write failure on recordAttempt does not crash the pass and other due entries still get processed', async () => {
-    const q = createAlwaysAllowPersistQueue(dir)
+    const write = makeControllableWrite()
+    const q = createAlwaysAllowPersistQueue(dir, write.fn)
     await q.enqueue(baseArgs({ agentName: 'clerk', rule: 'Skill(calendar)' }))
     await q.enqueue(baseArgs({ agentName: 'clerk', rule: 'Skill(email)' }))
     const dispatchConfigEdit = vi.fn(async () => ({ ok: true as const }))
@@ -499,9 +513,7 @@ describe('drainAlwaysAllowPersistQueue', () => {
     // Both entries' recordAttempt writes fail — the drain pass must
     // swallow that (log it) rather than throwing out of
     // drainAlwaysAllowPersistQueue and abandoning remaining entries.
-    vi.mocked(writeFileSync).mockImplementation(() => {
-      throw new Error('EIO: i/o error')
-    })
+    write.failAlways('EIO: i/o error')
 
     vi.useFakeTimers()
     vi.advanceTimersByTime(BASE_BACKOFF_MS + 1000)

--- a/telegram-plugin/tests/always-allow-persist-queue.test.ts
+++ b/telegram-plugin/tests/always-allow-persist-queue.test.ts
@@ -12,13 +12,31 @@
  *   - a retry that finds the rule already persisted is a no-op dequeue
  *     (no duplicate-rule risk, no redispatch);
  *   - bounds are structural: MAX_ATTEMPTS, MAX_AGE_MS, MAX_QUEUE_SIZE,
- *     MAX_BACKOFF_MS all cap out — nothing retries indefinitely.
+ *     MAX_BACKOFF_MS all cap out — nothing retries indefinitely;
+ *   - concurrent read-modify-write operations against the queue file
+ *     (two overlapping enqueue()s, an enqueue() racing a drain's
+ *     recordAttempt(), etc.) are serialized — no lost update, no
+ *     duplicated/corrupted rule (adversarial review pt.1/pt.3);
+ *   - a write failure (disk full, permissions, …) PROPAGATES to the
+ *     caller of enqueue/recordAttempt/remove rather than being silently
+ *     swallowed (adversarial review pt.2).
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+
+// Partial mock of node:fs so individual tests can force a `writeFileSync`
+// failure (disk full / permissions / read-only fs) without needing real
+// filesystem faults (we run as root in CI/containers, so chmod-based
+// permission tricks don't reliably fail). `readFileSync`/other exports
+// stay real via `importOriginal`.
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return { ...actual, writeFileSync: vi.fn(actual.writeFileSync) }
+})
+
 import {
   createAlwaysAllowPersistQueue,
   drainAlwaysAllowPersistQueue,
@@ -61,80 +79,80 @@ describe('createAlwaysAllowPersistQueue', () => {
     expect(q.listDue()).toEqual([])
   })
 
-  it('enqueue + listAll returns the entry with attempts=1', () => {
+  it('enqueue + listAll returns the entry with attempts=1', async () => {
     const q = createAlwaysAllowPersistQueue(dir)
-    q.enqueue(baseArgs())
+    await q.enqueue(baseArgs())
     const all = q.listAll()
     expect(all).toHaveLength(1)
     expect(all[0].attempts).toBe(1)
     expect(all[0].id).toBe(makeEntryId('clerk', 'Skill(calendar)'))
   })
 
-  it('is idempotent per (agent, rule) — a second failure updates, not duplicates', () => {
+  it('is idempotent per (agent, rule) — a second failure updates, not duplicates', async () => {
     const q = createAlwaysAllowPersistQueue(dir)
-    q.enqueue(baseArgs({ error: 'first' }))
-    q.enqueue(baseArgs({ error: 'second' }))
+    await q.enqueue(baseArgs({ error: 'first' }))
+    await q.enqueue(baseArgs({ error: 'second' }))
     expect(q.listAll()).toHaveLength(1)
     expect(q.listAll()[0].lastError).toBe('second')
   })
 
-  it('listDue only returns entries whose backoff has elapsed', () => {
+  it('listDue only returns entries whose backoff has elapsed', async () => {
     const q = createAlwaysAllowPersistQueue(dir)
-    q.enqueue(baseArgs())
+    await q.enqueue(baseArgs())
     const now = Date.now()
     // Not due yet — backoff for attempt 1 is BASE_BACKOFF_MS.
     expect(q.listDue(now)).toEqual([])
     expect(q.listDue(now + BASE_BACKOFF_MS + 1)).toHaveLength(1)
   })
 
-  it('survives reload (boot drain picks up a queued entry after restart)', () => {
+  it('survives reload (boot drain picks up a queued entry after restart)', async () => {
     const q1 = createAlwaysAllowPersistQueue(dir)
-    q1.enqueue(baseArgs())
+    await q1.enqueue(baseArgs())
     const q2 = createAlwaysAllowPersistQueue(dir)
     expect(q2.listAll()).toHaveLength(1)
   })
 
-  it('recordAttempt(success) dequeues', () => {
+  it('recordAttempt(success) dequeues', async () => {
     const q = createAlwaysAllowPersistQueue(dir)
-    q.enqueue(baseArgs())
+    await q.enqueue(baseArgs())
     const id = q.listAll()[0].id
-    q.recordAttempt(id, { success: true })
+    await q.recordAttempt(id, { success: true })
     expect(q.listAll()).toEqual([])
   })
 
-  it('recordAttempt(failure) increments attempts and pushes nextAttemptAt out', () => {
+  it('recordAttempt(failure) increments attempts and pushes nextAttemptAt out', async () => {
     const q = createAlwaysAllowPersistQueue(dir)
-    q.enqueue(baseArgs())
+    await q.enqueue(baseArgs())
     const id = q.listAll()[0].id
     const before = q.listAll()[0].nextAttemptAt
-    q.recordAttempt(id, { success: false, error: 'boom' })
+    await q.recordAttempt(id, { success: false, error: 'boom' })
     const after = q.listAll()[0]
     expect(after.attempts).toBe(2)
     expect(after.nextAttemptAt).toBeGreaterThan(before)
   })
 
-  it('recordAttempt drops the entry once MAX_ATTEMPTS is reached', () => {
+  it('recordAttempt drops the entry once MAX_ATTEMPTS is reached', async () => {
     // enqueue() itself counts as attempt 1 (the original failed dispatch
     // that triggered the enqueue) — so MAX_ATTEMPTS total tries is reached
     // after (MAX_ATTEMPTS - 1) further recordAttempt(failure) calls.
     const q = createAlwaysAllowPersistQueue(dir)
-    q.enqueue(baseArgs())
+    await q.enqueue(baseArgs())
     const id = q.listAll()[0].id
     for (let i = 0; i < MAX_ATTEMPTS - 2; i++) {
-      q.recordAttempt(id, { success: false, error: 'boom' })
+      await q.recordAttempt(id, { success: false, error: 'boom' })
     }
     // One more failure reaches attempts===MAX_ATTEMPTS and drops it.
     expect(q.listAll()[0].attempts).toBe(MAX_ATTEMPTS - 1)
-    q.recordAttempt(id, { success: false, error: 'boom' })
+    await q.recordAttempt(id, { success: false, error: 'boom' })
     expect(q.listAll()).toEqual([])
   })
 
-  it('honors a structured retryAfterMs floor on backoff', () => {
+  it('honors a structured retryAfterMs floor on backoff', async () => {
     const q = createAlwaysAllowPersistQueue(dir)
-    q.enqueue(baseArgs())
+    await q.enqueue(baseArgs())
     const id = q.listAll()[0].id
     const now = Date.now()
-    q.recordAttempt(id, { success: false, error: 'rate limited', retryAfterMs: 20 * 60_000 })
+    await q.recordAttempt(id, { success: false, error: 'rate limited', retryAfterMs: 20 * 60_000 })
     const entry = q.listAll()[0]
     // 20 minutes is bigger than the exponential value at attempt 2, so the
     // hint should win (but never exceed MAX_BACKOFF_MS).
@@ -142,27 +160,173 @@ describe('createAlwaysAllowPersistQueue', () => {
     expect(entry.nextAttemptAt - now).toBeLessThanOrEqual(MAX_BACKOFF_MS + 1000)
   })
 
-  it('bounds the queue at MAX_QUEUE_SIZE, dropping the oldest', () => {
+  it('bounds the queue at MAX_QUEUE_SIZE, dropping the oldest', async () => {
     const q = createAlwaysAllowPersistQueue(dir)
     for (let i = 0; i < MAX_QUEUE_SIZE + 5; i++) {
-      q.enqueue(baseArgs({ agentName: `agent${i}`, rule: 'Bash' }))
+      await q.enqueue(baseArgs({ agentName: `agent${i}`, rule: 'Bash' }))
     }
     expect(q.listAll().length).toBeLessThanOrEqual(MAX_QUEUE_SIZE)
   })
 
-  it('remove() drops an entry outright', () => {
+  it('remove() drops an entry outright', async () => {
     const q = createAlwaysAllowPersistQueue(dir)
-    q.enqueue(baseArgs())
+    await q.enqueue(baseArgs())
     const id = q.listAll()[0].id
-    q.remove(id)
+    await q.remove(id)
     expect(q.listAll()).toEqual([])
   })
 
-  it('clear() wipes the backing file', () => {
+  it('clear() wipes the backing file', async () => {
     const q = createAlwaysAllowPersistQueue(dir)
-    q.enqueue(baseArgs())
+    await q.enqueue(baseArgs())
     q.clear()
     expect(q.listAll()).toEqual([])
+  })
+})
+
+describe('createAlwaysAllowPersistQueue — concurrency (#2973 adversarial review pt.1/pt.3)', () => {
+  let dir: string
+  beforeEach(() => { dir = makeTmpDir() })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('two concurrent enqueue() calls for the SAME (agent, rule) race but do not duplicate or corrupt the entry', async () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    // Fire both "concurrently" — no await between them — simulating two
+    // overlapping "Always allow" taps racing against each other, the
+    // exact scenario from the original bug report.
+    await Promise.all([
+      q.enqueue(baseArgs({ error: 'attempt-A' })),
+      q.enqueue(baseArgs({ error: 'attempt-B' })),
+    ])
+    const all = q.listAll()
+    // Exactly one entry — never duplicated, never lost.
+    expect(all).toHaveLength(1)
+    expect(all[0].id).toBe(makeEntryId('clerk', 'Skill(calendar)'))
+    // One of the two attempts' error message won — not corrupted/merged
+    // into something neither caller wrote.
+    expect(['attempt-A', 'attempt-B']).toContain(all[0].lastError)
+  })
+
+  it('two concurrent enqueue() calls for DIFFERENT rules both land — no lost update', async () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    await Promise.all([
+      q.enqueue(baseArgs({ rule: 'Skill(calendar)' })),
+      q.enqueue(baseArgs({ rule: 'Skill(email)' })),
+      q.enqueue(baseArgs({ rule: 'Bash(ls:*)' })),
+    ])
+    const all = q.listAll()
+    expect(all).toHaveLength(3)
+    const rules = all.map(e => e.rule).sort()
+    expect(rules).toEqual(['Bash(ls:*)', 'Skill(calendar)', 'Skill(email)'])
+  })
+
+  it('many concurrent enqueue() calls interleaved with recordAttempt on an unrelated id never lose an update', async () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    // Seed one entry to record against concurrently with fresh enqueues —
+    // simulates a drain's recordAttempt() racing new "Always allow" taps.
+    await q.enqueue(baseArgs({ agentName: 'seed', rule: 'Read' }))
+    const seedId = makeEntryId('seed', 'Read')
+
+    const ops: Promise<void>[] = []
+    for (let i = 0; i < 10; i++) {
+      ops.push(q.enqueue(baseArgs({ agentName: `agent${i}`, rule: 'Bash' })))
+    }
+    ops.push(q.recordAttempt(seedId, { success: false, error: 'racing' }))
+
+    await Promise.all(ops)
+
+    const all = q.listAll()
+    // 10 fresh entries + the seed entry (updated, not dropped/duplicated).
+    expect(all).toHaveLength(11)
+    const seed = all.find(e => e.id === seedId)
+    expect(seed).toBeDefined()
+    expect(seed!.attempts).toBe(2)
+    expect(seed!.lastError).toBe('racing')
+    for (let i = 0; i < 10; i++) {
+      expect(all.some(e => e.id === makeEntryId(`agent${i}`, 'Bash'))).toBe(true)
+    }
+  })
+
+  it('a concurrent enqueue() racing recordAttempt(success) on the SAME id does not resurrect a dequeued entry with corrupted state', async () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    await q.enqueue(baseArgs())
+    const id = q.listAll()[0].id
+
+    // One racer dequeues via success, the other refreshes via enqueue
+    // (e.g. a second failed tap landing right as the drain's redispatch
+    // for the SAME rule succeeds). Whichever wins, the on-disk file must
+    // stay well-formed and never contain two entries for the same id.
+    await Promise.all([
+      q.recordAttempt(id, { success: true }),
+      q.enqueue(baseArgs({ error: 'second-tap-failure' })),
+    ])
+
+    const all = q.listAll()
+    const matching = all.filter(e => e.id === id)
+    expect(matching.length).toBeLessThanOrEqual(1)
+  })
+})
+
+describe('createAlwaysAllowPersistQueue — write failures propagate (#2973 adversarial review pt.2)', () => {
+  let dir: string
+  beforeEach(() => { dir = makeTmpDir() })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('enqueue() rejects when the underlying writeFileSync throws (disk full / permissions)', async () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    vi.mocked(writeFileSync).mockImplementationOnce(() => {
+      throw new Error('ENOSPC: no space left on device')
+    })
+    await expect(q.enqueue(baseArgs())).rejects.toThrow(/ENOSPC/)
+    // The caller was told it failed — and indeed nothing was persisted.
+    expect(q.listAll()).toEqual([])
+  })
+
+  it('recordAttempt() rejects when the underlying writeFileSync throws, and does not pretend the state change landed', async () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    await q.enqueue(baseArgs())
+    const id = q.listAll()[0].id
+
+    vi.mocked(writeFileSync).mockImplementationOnce(() => {
+      throw new Error('EACCES: permission denied')
+    })
+    await expect(q.recordAttempt(id, { success: true })).rejects.toThrow(/EACCES/)
+
+    // The entry is still there — the (failed) dequeue never actually
+    // persisted, so a fresh read must still see it, not silently vanish.
+    expect(q.listAll()).toHaveLength(1)
+    expect(q.listAll()[0].id).toBe(id)
+  })
+
+  it('remove() rejects when the underlying writeFileSync throws', async () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    await q.enqueue(baseArgs())
+    const id = q.listAll()[0].id
+
+    vi.mocked(writeFileSync).mockImplementationOnce(() => {
+      throw new Error('EROFS: read-only file system')
+    })
+    await expect(q.remove(id)).rejects.toThrow(/EROFS/)
+
+    expect(q.listAll()).toHaveLength(1)
+  })
+
+  it('a write failure does not wedge the in-process lock — a later successful call still lands', async () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    vi.mocked(writeFileSync).mockImplementationOnce(() => {
+      throw new Error('ENOSPC: no space left on device')
+    })
+    await expect(q.enqueue(baseArgs({ error: 'first' }))).rejects.toThrow(/ENOSPC/)
+
+    // Disk recovered — the NEXT call (real writeFileSync) must succeed,
+    // proving the failed link didn't leave the mutex permanently locked.
+    await q.enqueue(baseArgs({ error: 'second' }))
+    const all = q.listAll()
+    expect(all).toHaveLength(1)
+    expect(all[0].lastError).toBe('second')
   })
 })
 
@@ -205,7 +369,7 @@ describe('drainAlwaysAllowPersistQueue', () => {
 
   it('a retryable failure retries after backoff with a fresh config read and succeeds; entry removed', async () => {
     const q = createAlwaysAllowPersistQueue(dir)
-    q.enqueue(baseArgs())
+    await q.enqueue(baseArgs())
     const readConfigText = vi.fn(() => 'agents:\n  clerk:\n    tools:\n      allow: [Read]\n')
     const dispatchConfigEdit = vi.fn(async () => ({ ok: true as const }))
     const deps = makeDeps({ readConfigText, dispatchConfigEdit })
@@ -231,7 +395,7 @@ describe('drainAlwaysAllowPersistQueue', () => {
 
   it('a retry that finds the rule already persisted is a no-op dequeue (no redispatch)', async () => {
     const q = createAlwaysAllowPersistQueue(dir)
-    q.enqueue(baseArgs({ rule: 'Read' })) // "Read" will already be in the fresh allow list
+    await q.enqueue(baseArgs({ rule: 'Read' })) // "Read" will already be in the fresh allow list
     const dispatchConfigEdit = vi.fn(async () => ({ ok: true as const }))
     const deps = makeDeps({
       resolveAllowList: () => ['Read'],
@@ -253,7 +417,7 @@ describe('drainAlwaysAllowPersistQueue', () => {
     // that triggered the enqueue) — so the drain loop's dispatchConfigEdit
     // fires (MAX_ATTEMPTS - 1) times before the entry is exhausted/dropped.
     const q = createAlwaysAllowPersistQueue(dir)
-    q.enqueue(baseArgs())
+    await q.enqueue(baseArgs())
     const notifyTerminalFailure = vi.fn()
     const dispatchConfigEdit = vi.fn(async () => ({ ok: false as const, error: 'E_PATCH_APPLY_FAILED' }))
     const deps = makeDeps({
@@ -279,7 +443,7 @@ describe('drainAlwaysAllowPersistQueue', () => {
 
   it('never retries indefinitely: attempts and age are both hard bounds (no drain call exceeds MAX_ATTEMPTS-1 dispatches for one entry)', async () => {
     const q = createAlwaysAllowPersistQueue(dir)
-    q.enqueue(baseArgs())
+    await q.enqueue(baseArgs())
     const dispatchConfigEdit = vi.fn(async () => ({ ok: false as const, error: 'boom' }))
     const deps = makeDeps({ resolveAllowList: () => [], dispatchConfigEdit, notifyTerminalFailure: vi.fn() })
 
@@ -297,7 +461,7 @@ describe('drainAlwaysAllowPersistQueue', () => {
 
   it('a config read failure is treated as retryable, not a crash', async () => {
     const q = createAlwaysAllowPersistQueue(dir)
-    q.enqueue(baseArgs())
+    await q.enqueue(baseArgs())
     const deps = makeDeps({
       readConfigText: () => { throw new Error('ENOENT') },
     })
@@ -313,7 +477,7 @@ describe('drainAlwaysAllowPersistQueue', () => {
 
   it('a null re-synthesized diff is treated as retryable, not a crash', async () => {
     const q = createAlwaysAllowPersistQueue(dir)
-    q.enqueue(baseArgs())
+    await q.enqueue(baseArgs())
     const deps = makeDeps({ synthesizeDiff: () => null })
 
     vi.useFakeTimers()
@@ -323,5 +487,31 @@ describe('drainAlwaysAllowPersistQueue', () => {
 
     expect(q.listAll()).toHaveLength(1)
     expect(q.listAll()[0].attempts).toBe(2)
+  })
+
+  it('a drain-time write failure on recordAttempt does not crash the pass and other due entries still get processed', async () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    await q.enqueue(baseArgs({ agentName: 'clerk', rule: 'Skill(calendar)' }))
+    await q.enqueue(baseArgs({ agentName: 'clerk', rule: 'Skill(email)' }))
+    const dispatchConfigEdit = vi.fn(async () => ({ ok: true as const }))
+    const deps = makeDeps({ resolveAllowList: () => [], dispatchConfigEdit })
+
+    // Both entries' recordAttempt writes fail — the drain pass must
+    // swallow that (log it) rather than throwing out of
+    // drainAlwaysAllowPersistQueue and abandoning remaining entries.
+    vi.mocked(writeFileSync).mockImplementation(() => {
+      throw new Error('EIO: i/o error')
+    })
+
+    vi.useFakeTimers()
+    vi.advanceTimersByTime(BASE_BACKOFF_MS + 1000)
+    await expect(drainAlwaysAllowPersistQueue(q, deps)).resolves.toBeUndefined()
+    vi.useRealTimers()
+
+    // Both entries were attempted despite the persistent write failure.
+    expect(dispatchConfigEdit).toHaveBeenCalledTimes(2)
+    // Since the "success" recordAttempt write failed, the entries are
+    // still present on next read (state change did NOT silently land).
+    expect(q.listAll()).toHaveLength(2)
   })
 })

--- a/telegram-plugin/tests/always-allow-persist-queue.test.ts
+++ b/telegram-plugin/tests/always-allow-persist-queue.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Unit tests for telegram-plugin/gateway/always-allow-persist-queue.ts
+ * (#2973 pt.2 — durable retry queue for the "🔁 Always allow" persist).
+ *
+ * Contract under test:
+ *   - enqueue is idempotent per (agent, rule); survives reload (boot drain);
+ *   - listDue only returns entries whose backoff has elapsed;
+ *   - a retryable failure re-checks isRulePersisted FIRST via a fresh
+ *     config read, then re-synthesizes and redispatches — success dequeues;
+ *   - a persist that fails 5 times (or ages out) is dropped AND the
+ *     terminal-failure notice fires exactly once;
+ *   - a retry that finds the rule already persisted is a no-op dequeue
+ *     (no duplicate-rule risk, no redispatch);
+ *   - bounds are structural: MAX_ATTEMPTS, MAX_AGE_MS, MAX_QUEUE_SIZE,
+ *     MAX_BACKOFF_MS all cap out — nothing retries indefinitely.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  createAlwaysAllowPersistQueue,
+  drainAlwaysAllowPersistQueue,
+  computeBackoffMs,
+  isExhausted,
+  makeEntryId,
+  MAX_ATTEMPTS,
+  MAX_AGE_MS,
+  MAX_QUEUE_SIZE,
+  MAX_BACKOFF_MS,
+  BASE_BACKOFF_MS,
+  type AlwaysAllowDrainDeps,
+  type AlwaysAllowPersistEntry,
+} from '../gateway/always-allow-persist-queue.js'
+
+function makeTmpDir() {
+  return mkdtempSync(join(tmpdir(), 'always-allow-persist-queue-test-'))
+}
+
+function baseArgs(over: Partial<Parameters<ReturnType<typeof createAlwaysAllowPersistQueue>['enqueue']>[0]> = {}) {
+  return {
+    agentName: 'clerk',
+    rule: 'Skill(calendar)',
+    grantPhrase: 'use the calendar skill',
+    chatId: '-100123',
+    threadId: 7,
+    error: 'E_PATCH_APPLY_FAILED',
+    ...over,
+  }
+}
+
+describe('createAlwaysAllowPersistQueue', () => {
+  let dir: string
+  beforeEach(() => { dir = makeTmpDir() })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('starts empty', () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    expect(q.listAll()).toEqual([])
+    expect(q.listDue()).toEqual([])
+  })
+
+  it('enqueue + listAll returns the entry with attempts=1', () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    q.enqueue(baseArgs())
+    const all = q.listAll()
+    expect(all).toHaveLength(1)
+    expect(all[0].attempts).toBe(1)
+    expect(all[0].id).toBe(makeEntryId('clerk', 'Skill(calendar)'))
+  })
+
+  it('is idempotent per (agent, rule) — a second failure updates, not duplicates', () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    q.enqueue(baseArgs({ error: 'first' }))
+    q.enqueue(baseArgs({ error: 'second' }))
+    expect(q.listAll()).toHaveLength(1)
+    expect(q.listAll()[0].lastError).toBe('second')
+  })
+
+  it('listDue only returns entries whose backoff has elapsed', () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    q.enqueue(baseArgs())
+    const now = Date.now()
+    // Not due yet — backoff for attempt 1 is BASE_BACKOFF_MS.
+    expect(q.listDue(now)).toEqual([])
+    expect(q.listDue(now + BASE_BACKOFF_MS + 1)).toHaveLength(1)
+  })
+
+  it('survives reload (boot drain picks up a queued entry after restart)', () => {
+    const q1 = createAlwaysAllowPersistQueue(dir)
+    q1.enqueue(baseArgs())
+    const q2 = createAlwaysAllowPersistQueue(dir)
+    expect(q2.listAll()).toHaveLength(1)
+  })
+
+  it('recordAttempt(success) dequeues', () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    q.enqueue(baseArgs())
+    const id = q.listAll()[0].id
+    q.recordAttempt(id, { success: true })
+    expect(q.listAll()).toEqual([])
+  })
+
+  it('recordAttempt(failure) increments attempts and pushes nextAttemptAt out', () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    q.enqueue(baseArgs())
+    const id = q.listAll()[0].id
+    const before = q.listAll()[0].nextAttemptAt
+    q.recordAttempt(id, { success: false, error: 'boom' })
+    const after = q.listAll()[0]
+    expect(after.attempts).toBe(2)
+    expect(after.nextAttemptAt).toBeGreaterThan(before)
+  })
+
+  it('recordAttempt drops the entry once MAX_ATTEMPTS is reached', () => {
+    // enqueue() itself counts as attempt 1 (the original failed dispatch
+    // that triggered the enqueue) — so MAX_ATTEMPTS total tries is reached
+    // after (MAX_ATTEMPTS - 1) further recordAttempt(failure) calls.
+    const q = createAlwaysAllowPersistQueue(dir)
+    q.enqueue(baseArgs())
+    const id = q.listAll()[0].id
+    for (let i = 0; i < MAX_ATTEMPTS - 2; i++) {
+      q.recordAttempt(id, { success: false, error: 'boom' })
+    }
+    // One more failure reaches attempts===MAX_ATTEMPTS and drops it.
+    expect(q.listAll()[0].attempts).toBe(MAX_ATTEMPTS - 1)
+    q.recordAttempt(id, { success: false, error: 'boom' })
+    expect(q.listAll()).toEqual([])
+  })
+
+  it('honors a structured retryAfterMs floor on backoff', () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    q.enqueue(baseArgs())
+    const id = q.listAll()[0].id
+    const now = Date.now()
+    q.recordAttempt(id, { success: false, error: 'rate limited', retryAfterMs: 20 * 60_000 })
+    const entry = q.listAll()[0]
+    // 20 minutes is bigger than the exponential value at attempt 2, so the
+    // hint should win (but never exceed MAX_BACKOFF_MS).
+    expect(entry.nextAttemptAt - now).toBeGreaterThanOrEqual(20 * 60_000 - 1000)
+    expect(entry.nextAttemptAt - now).toBeLessThanOrEqual(MAX_BACKOFF_MS + 1000)
+  })
+
+  it('bounds the queue at MAX_QUEUE_SIZE, dropping the oldest', () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    for (let i = 0; i < MAX_QUEUE_SIZE + 5; i++) {
+      q.enqueue(baseArgs({ agentName: `agent${i}`, rule: 'Bash' }))
+    }
+    expect(q.listAll().length).toBeLessThanOrEqual(MAX_QUEUE_SIZE)
+  })
+
+  it('remove() drops an entry outright', () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    q.enqueue(baseArgs())
+    const id = q.listAll()[0].id
+    q.remove(id)
+    expect(q.listAll()).toEqual([])
+  })
+
+  it('clear() wipes the backing file', () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    q.enqueue(baseArgs())
+    q.clear()
+    expect(q.listAll()).toEqual([])
+  })
+})
+
+describe('computeBackoffMs / isExhausted — structural bounds', () => {
+  it('doubles each attempt, capped at MAX_BACKOFF_MS', () => {
+    expect(computeBackoffMs(1)).toBe(BASE_BACKOFF_MS)
+    expect(computeBackoffMs(2)).toBe(BASE_BACKOFF_MS * 2)
+    expect(computeBackoffMs(3)).toBe(BASE_BACKOFF_MS * 4)
+    // Large attempt counts never exceed the ceiling — no unbounded growth.
+    expect(computeBackoffMs(50)).toBe(MAX_BACKOFF_MS)
+  })
+
+  it('isExhausted trips on attempts>=MAX_ATTEMPTS regardless of age', () => {
+    expect(isExhausted({ attempts: MAX_ATTEMPTS, createdAt: Date.now() })).toBe(true)
+    expect(isExhausted({ attempts: MAX_ATTEMPTS - 1, createdAt: Date.now() })).toBe(false)
+  })
+
+  it('isExhausted trips on age>=MAX_AGE_MS regardless of attempts', () => {
+    expect(isExhausted({ attempts: 1, createdAt: Date.now() - MAX_AGE_MS - 1 })).toBe(true)
+    expect(isExhausted({ attempts: 1, createdAt: Date.now() })).toBe(false)
+  })
+})
+
+describe('drainAlwaysAllowPersistQueue', () => {
+  let dir: string
+  beforeEach(() => { dir = makeTmpDir() })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  function makeDeps(over: Partial<AlwaysAllowDrainDeps> = {}): AlwaysAllowDrainDeps {
+    return {
+      readConfigText: () => 'agents:\n  clerk:\n    tools:\n      allow: [Read]\n',
+      resolveAllowList: () => ['Read'],
+      isRulePersisted: (allow, rule) => allow.includes(rule),
+      synthesizeDiff: () => '--- a/switchroom.yaml\n+++ b/switchroom.yaml\n@@ -1 +1,2 @@\n+fake\n',
+      dispatchConfigEdit: async () => ({ ok: true }),
+      notifyTerminalFailure: vi.fn(),
+      ...over,
+    }
+  }
+
+  it('a retryable failure retries after backoff with a fresh config read and succeeds; entry removed', async () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    q.enqueue(baseArgs())
+    const readConfigText = vi.fn(() => 'agents:\n  clerk:\n    tools:\n      allow: [Read]\n')
+    const dispatchConfigEdit = vi.fn(async () => ({ ok: true as const }))
+    const deps = makeDeps({ readConfigText, dispatchConfigEdit })
+
+    // Not due yet.
+    await drainAlwaysAllowPersistQueue(q, deps)
+    expect(dispatchConfigEdit).not.toHaveBeenCalled()
+    expect(q.listAll()).toHaveLength(1)
+
+    // Force due by rewriting the entry directly via recordAttempt timing —
+    // simplest: enqueue fresh with an already-elapsed backoff by manipulating
+    // system time isn't available here, so instead verify due-gating via a
+    // second queue instance whose entry we mark due by fast-forwarding.
+    vi.useFakeTimers()
+    vi.advanceTimersByTime(BASE_BACKOFF_MS + 1000)
+    await drainAlwaysAllowPersistQueue(q, deps)
+    vi.useRealTimers()
+
+    expect(readConfigText).toHaveBeenCalled()
+    expect(dispatchConfigEdit).toHaveBeenCalledTimes(1)
+    expect(q.listAll()).toEqual([]) // dequeued on success
+  })
+
+  it('a retry that finds the rule already persisted is a no-op dequeue (no redispatch)', async () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    q.enqueue(baseArgs({ rule: 'Read' })) // "Read" will already be in the fresh allow list
+    const dispatchConfigEdit = vi.fn(async () => ({ ok: true as const }))
+    const deps = makeDeps({
+      resolveAllowList: () => ['Read'],
+      isRulePersisted: (allow, rule) => allow.includes(rule),
+      dispatchConfigEdit,
+    })
+
+    vi.useFakeTimers()
+    vi.advanceTimersByTime(BASE_BACKOFF_MS + 1000)
+    await drainAlwaysAllowPersistQueue(q, deps)
+    vi.useRealTimers()
+
+    expect(dispatchConfigEdit).not.toHaveBeenCalled()
+    expect(q.listAll()).toEqual([])
+  })
+
+  it('a persist that fails MAX_ATTEMPTS times sends the terminal-failure notice exactly once and is dropped', async () => {
+    // enqueue() itself counts as attempt 1 (the original failed dispatch
+    // that triggered the enqueue) — so the drain loop's dispatchConfigEdit
+    // fires (MAX_ATTEMPTS - 1) times before the entry is exhausted/dropped.
+    const q = createAlwaysAllowPersistQueue(dir)
+    q.enqueue(baseArgs())
+    const notifyTerminalFailure = vi.fn()
+    const dispatchConfigEdit = vi.fn(async () => ({ ok: false as const, error: 'E_PATCH_APPLY_FAILED' }))
+    const deps = makeDeps({
+      resolveAllowList: () => [], // rule never lands
+      dispatchConfigEdit,
+      notifyTerminalFailure,
+    })
+
+    vi.useFakeTimers()
+    // Drive it through every remaining attempt. Each drain pass needs the
+    // fake clock advanced past the current backoff before the entry
+    // becomes due again.
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+      vi.advanceTimersByTime(MAX_BACKOFF_MS + 1000)
+      await drainAlwaysAllowPersistQueue(q, deps)
+    }
+    vi.useRealTimers()
+
+    expect(notifyTerminalFailure).toHaveBeenCalledTimes(1)
+    expect(q.listAll()).toEqual([]) // dropped after exhaustion
+    expect(dispatchConfigEdit).toHaveBeenCalledTimes(MAX_ATTEMPTS - 1)
+  })
+
+  it('never retries indefinitely: attempts and age are both hard bounds (no drain call exceeds MAX_ATTEMPTS-1 dispatches for one entry)', async () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    q.enqueue(baseArgs())
+    const dispatchConfigEdit = vi.fn(async () => ({ ok: false as const, error: 'boom' }))
+    const deps = makeDeps({ resolveAllowList: () => [], dispatchConfigEdit, notifyTerminalFailure: vi.fn() })
+
+    vi.useFakeTimers()
+    // Drain far more times than MAX_ATTEMPTS would allow — dispatch count
+    // must plateau, never grow further once the entry is exhausted+dropped.
+    for (let i = 0; i < MAX_ATTEMPTS + 10; i++) {
+      vi.advanceTimersByTime(MAX_BACKOFF_MS + 1000)
+      await drainAlwaysAllowPersistQueue(q, deps)
+    }
+    vi.useRealTimers()
+
+    expect(dispatchConfigEdit.mock.calls.length).toBe(MAX_ATTEMPTS - 1)
+  })
+
+  it('a config read failure is treated as retryable, not a crash', async () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    q.enqueue(baseArgs())
+    const deps = makeDeps({
+      readConfigText: () => { throw new Error('ENOENT') },
+    })
+
+    vi.useFakeTimers()
+    vi.advanceTimersByTime(BASE_BACKOFF_MS + 1000)
+    await expect(drainAlwaysAllowPersistQueue(q, deps)).resolves.toBeUndefined()
+    vi.useRealTimers()
+
+    expect(q.listAll()).toHaveLength(1)
+    expect(q.listAll()[0].attempts).toBe(2)
+  })
+
+  it('a null re-synthesized diff is treated as retryable, not a crash', async () => {
+    const q = createAlwaysAllowPersistQueue(dir)
+    q.enqueue(baseArgs())
+    const deps = makeDeps({ synthesizeDiff: () => null })
+
+    vi.useFakeTimers()
+    vi.advanceTimersByTime(BASE_BACKOFF_MS + 1000)
+    await drainAlwaysAllowPersistQueue(q, deps)
+    vi.useRealTimers()
+
+    expect(q.listAll()).toHaveLength(1)
+    expect(q.listAll()[0].attempts).toBe(2)
+  })
+})

--- a/telegram-plugin/tests/operator-events.test.ts
+++ b/telegram-plugin/tests/operator-events.test.ts
@@ -292,6 +292,7 @@ describe('renderOperatorEvent — all kinds produce valid keyboard structure', (
     'unknown-4xx',
     'unknown-5xx',
     'config-warning',
+    'always-allow-persist-failed',
   ]
 
   for (const kind of allKinds) {

--- a/telegram-plugin/tests/permission-diff.test.ts
+++ b/telegram-plugin/tests/permission-diff.test.ts
@@ -178,6 +178,89 @@ describe('synthesizeAllowRuleDiff — structural cases', () => {
     }
   })
 
+  it('(a2) multi-line flow list (clerk\'s exact shape, #2973): appends before the closing ]', () => {
+    // Mirrors switchroom.yaml:507-514 — `allow:` has an empty inline
+    // remainder, `[` opens on the NEXT line, one entry per line, `]`
+    // closes on its own line with no trailing comma on the last entry.
+    const cfg = cfgWith(
+      [
+        '  clerk:',
+        '    topic_name: clerk',
+        '    purpose: clerk',
+        '    tools:',
+        '      allow:',
+        '        [',
+        '          all,',
+        '          mcp__ms-365__*,',
+        '          mcp__ms-365__verify-login,',
+        '          mcp__ms-365__list-mail-messages',
+        '        ]',
+        '    model: opus',
+      ].join('\n'),
+    )
+    const diff = synthesizeAllowRuleDiff({ agentName: 'clerk', rule: 'Skill(calendar)', configText: cfg })
+    expect(diff).not.toBeNull()
+    expect(diff).toContain('--- a/switchroom.yaml')
+    expect(diff).toContain('+++ b/switchroom.yaml')
+    const res = applyViaValidator(cfg, diff!)
+    expect(res).toMatchObject({ ok: true })
+    if (res.ok) {
+      expect(allowListFor(res.postApplyContent, 'clerk')).toEqual([
+        'all',
+        'mcp__ms-365__*',
+        'mcp__ms-365__verify-login',
+        'mcp__ms-365__list-mail-messages',
+        'Skill(calendar)',
+      ])
+    }
+  })
+
+  it('(a2) multi-line flow list: last entry already comma-terminated', () => {
+    const cfg = cfgWith(
+      [
+        '  clerk:',
+        '    topic_name: clerk',
+        '    purpose: clerk',
+        '    tools:',
+        '      allow:',
+        '        [',
+        '          Read,',
+        '          Grep,',
+        '        ]',
+        '    model: opus',
+      ].join('\n'),
+    )
+    const diff = synthesizeAllowRuleDiff({ agentName: 'clerk', rule: 'Bash', configText: cfg })
+    expect(diff).not.toBeNull()
+    const res = applyViaValidator(cfg, diff!)
+    expect(res).toMatchObject({ ok: true })
+    if (res.ok) {
+      expect(allowListFor(res.postApplyContent, 'clerk')).toEqual(['Read', 'Grep', 'Bash'])
+    }
+  })
+
+  it('(a2) multi-line flow list: empty list across lines gets first entry', () => {
+    const cfg = cfgWith(
+      [
+        '  clerk:',
+        '    topic_name: clerk',
+        '    purpose: clerk',
+        '    tools:',
+        '      allow:',
+        '        [',
+        '        ]',
+        '    model: opus',
+      ].join('\n'),
+    )
+    const diff = synthesizeAllowRuleDiff({ agentName: 'clerk', rule: 'Bash', configText: cfg })
+    expect(diff).not.toBeNull()
+    const res = applyViaValidator(cfg, diff!)
+    expect(res).toMatchObject({ ok: true })
+    if (res.ok) {
+      expect(allowListFor(res.postApplyContent, 'clerk')).toEqual(['Bash'])
+    }
+  })
+
   it('multi-agent: only the target agent is touched', () => {
     const cfg = cfgWith(
       [
@@ -248,6 +331,34 @@ describe('extractAddedAllowRule — round-trips the synthesized diff', () => {
         '    purpose: clerk', '    tools:', '      allow: [ all ]', '    model: opus'].join('\n'))
     const diff = synthesizeAllowRuleDiff({ agentName: 'clerk', rule: 'Skill(mail)', configText: cfg })!
     expect(extractAddedAllowRule(diff)).toBe('Skill(mail)')
+  })
+
+  it('multi-line flow-list append (clerk\'s exact shape, #2973)', () => {
+    const cfg = cfgWith(
+      [
+        '  clerk:',
+        '    topic_name: clerk',
+        '    purpose: clerk',
+        '    tools:',
+        '      allow:',
+        '        [',
+        '          all,',
+        '          mcp__ms-365__verify-login',
+        '        ]',
+        '    model: opus',
+      ].join('\n'),
+    )
+    const diff = synthesizeAllowRuleDiff({ agentName: 'clerk', rule: 'Skill(calendar)', configText: cfg })!
+    expect(extractAddedAllowRule(diff)).toBe('Skill(calendar)')
+  })
+
+  it('multi-line flow-list first-entry insert (empty list across lines)', () => {
+    const cfg = cfgWith(
+      ['  clerk:', '    topic_name: clerk', '    purpose: clerk',
+        '    tools:', '      allow:', '        [', '        ]', '    model: opus'].join('\n'),
+    )
+    const diff = synthesizeAllowRuleDiff({ agentName: 'clerk', rule: 'Bash', configText: cfg })!
+    expect(extractAddedAllowRule(diff)).toBe('Bash')
   })
 
   it('absent tools.allow (case c) — extracts the single added rule', () => {


### PR DESCRIPTION
## Summary
- Fixes the multi-line flow-list YAML writer bug that corrupted persisted grants under concurrent "Always allow" taps
- Adds an explicit retry queue (`always-allow-persist-queue.ts`) so a failed persist isn't silently dropped
- Surfaces persist failures to the operator instead of a quiet terminal-side failure
- Drains any queued persists left by a prior gateway process on startup, then periodically for the process lifetime

Closes #2973

## Test plan
- [x] New unit tests for the persist queue (`always-allow-persist-queue.test.ts`) — 114 tests pass across the 3 touched test files
- [x] `tsc --noEmit` + full lint pipeline clean
- [x] Rebased onto latest `origin/main`, no conflicts
- [x] `bun test` full suite run twice to confirm remaining failures (vault-broker/socket timeouts) are host-contention flakiness unrelated to these files, not a regression

Co-Authored-By: Claude <noreply@anthropic.com>