### PR TITLE
docs(reference): spec the approval/restart continuation contract

### DIFF
--- a/reference/jobs/approve-what-my-agent-can-touch.md
+++ b/reference/jobs/approve-what-my-agent-can-touch.md
@@ -42,6 +42,19 @@ without ever turning the chat into a place a raw credential lives.
   doesn't hand over the next.
 - A granted request **auto-resumes the turn**. The operator taps Allow and
   the agent picks up where it left off, without a nudge.
+- A **denied or expired** request resumes the turn too. The agent hears the
+  outcome, states plainly what it now can't do, and continues or degrades —
+  it is never left parked forever waiting on a card that was already
+  answered.
+- Cards **time out** (60-min default) and the timeout wakes the agent as a
+  *timeout, not a denial*: the agent says the request went unanswered and
+  what it's doing about it, rather than treating silence as a "no". An
+  expired card is **re-offered when the operator returns** (missed-approvals),
+  the same way a permission card is.
+- An approval card **survives a gateway restart**. A tap on a still-valid
+  card after a restart works; a card that expired during the outage is
+  re-offered on the operator's return. The card is durable state, not a
+  live-process artifact that a bounce silently voids.
 - If the operator pastes a secret anyway, the bot deletes the original
   message and confirms. The plaintext leaves the chat, the value lands in
   the vault, the agent never receives it.
@@ -70,6 +83,12 @@ without ever turning the chat into a place a raw credential lives.
   identity, a posture mint of a crown-jewel key.
 - A grant that lands but the turn dies anyway, forcing the operator to
   re-prompt the work they already approved.
+- A denied or timed-out card that strands the agent silently — parked
+  waiting on an outcome that already arrived, with no resume.
+- A card whose tap tells the operator to "ask the agent to re-request"
+  while the agent is parked waiting on that very card and structurally
+  cannot re-request. The stale-card path must resume or re-offer, never
+  hand the operator a dead-end instruction.
 - A false-positive redaction that eats the operator's ordinary question
   just because it said the word "token".
 
@@ -110,6 +129,25 @@ Named by job × surface, pointing at real scenarios in
   resumes on the operator's Allow tap without a re-prompt. *Invariant:*
   `claude-native` — the resume is a synthesized turn injected into the
   interactive session, not a new programmatic model call.
+- **Denied request resumes the turn (DM)** — `vault-deny-resumes-turn-dm`.
+  *Watch:* the operator taps Deny; the parked turn resumes, the agent states
+  what it now can't do and continues or degrades, never left waiting on a
+  card it already got an answer to. *Invariant:* `claude-native` — the
+  resume is a synthesized turn on the deny outcome, not a new programmatic
+  call, and never a silent strand.
+- **Timeout wakes the agent as timeout-not-denial (DM)** —
+  `vault-timeout-wakes-agent-dm`. *Watch:* the card ages past the 60-min
+  default with no tap; the agent is woken with a *timeout, not denial*
+  outcome, says the request went unanswered, and the expired card is
+  re-offered when the operator returns. *Invariant:* `no-self-escalation` —
+  a timeout is never read as a grant, and re-offer keeps the operator in the
+  loop.
+- **Card survives a gateway restart (DM)** —
+  `vault-card-survives-gateway-restart-dm`. *Watch:* a card issued before a
+  gateway restart is still tappable after it; a tap on the still-valid card
+  grants and resumes, and a card that expired during the outage is re-offered
+  on return. *Invariant:* `no-self-escalation` — card state is durable across
+  a bounce, never voided into a silent strand or a self-grant.
 - **One-tap allow off the audit log (DM)** — `vault-audit-allow-dm`.
   *Watch:* operator taps Allow on a recent denial and the agent's next read
   succeeds. *Invariant:* `no-self-escalation` — the denied path offers a
@@ -148,8 +186,11 @@ per-resource, every resume a synthesized turn.
   sourced the same way; per-resource, never blanket.
 - *Tiering:* irreversible / admin-credential actions sit behind the operator
   passphrase, a factor the agent structurally lacks, never a tap alone.
-- *Reliability:* an approval that lands resumes the turn; a denied or
-  restart-interrupted grant never strands the agent silently.
+- *Reliability:* an approval that lands resumes the turn; a denied,
+  timed-out, or restart-interrupted grant never strands the agent silently —
+  each wakes it with its outcome (a timeout as *timeout, not denial*). Cards
+  are durable across a gateway restart and re-offered when they expired
+  during an outage.
 
 ## Related
 

--- a/reference/jobs/know-what-my-agent-is-doing.md
+++ b/reference/jobs/know-what-my-agent-is-doing.md
@@ -47,7 +47,9 @@ close that gap so the user never has to ask.
 - Sub-agent and background work is visible in the same thread. No separate
   surface to hunt for. True in a DM and in a forum channel alike.
 - Failures, limits, crashes, and restarts are always spoken. The user is
-  told what happened and what resumes.
+  told what happened and what resumes. A worker orphaned by a restart is
+  narrated in the worker feed — re-dispatched or named as lost — not silently
+  absent from the thread it was running in.
 - Scrolling back a week later reads as a real conversation, not a deleted
   widget.
 - When work outlives the visible feed — fast turns scroll it away, background

--- a/reference/jobs/steer-or-queue-mid-flight.md
+++ b/reference/jobs/steer-or-queue-mid-flight.md
@@ -81,8 +81,10 @@ clearly and says which, or it asks.
   in flight.
 - **Survives a restart mid-flight (DM)** — `jtbd-interrupted-turn-resumes-dm`.
   *Watch:* a task interrupted by a restart resumes and runs to completion, not
-  silently dropped. *Invariant:* a restart never loses an in-flight task or a
-  queued follow-up.
+  silently dropped. *Invariant:* a restart never loses an in-flight task, a
+  queued follow-up, **or in-flight sub-agent work** — dispatched workers that
+  the restart killed are re-dispatched or named as lost on resume, never left
+  silently dead under a parent that carried on.
 
 **Fuzz corpus:** vary follow-up intent (steer × queue × interrupt ×
 ambiguous) × timing (mid-tool-call × at turn boundary × rapid fire) × burst

--- a/reference/jobs/survive-reboots-and-real-life.md
+++ b/reference/jobs/survive-reboots-and-real-life.md
@@ -33,6 +33,15 @@ language, at the point it affects them.
   detail to know whether the in-flight work survived.
 - An interrupted turn either resumes or is explicitly named as lost, never
   dropped on the floor in silence.
+- A **deliberate** restart (an operator restart, a rollout) that interrupts
+  an in-flight turn resumes it exactly as a crash does. The quota-saving
+  suppression that skips a resume applies **only when nothing was in flight**;
+  it never becomes an excuse to swallow work that was mid-turn when the
+  operator bounced the agent.
+- **Sub-agents and workers killed by a restart are surfaced in the resume.**
+  The parent re-dispatches the ones still needed, or names their loss
+  per-worker. A parent turn never "resumes" while the work it dispatched
+  stays silently dead.
 - Context exhaustion reads as a named event the user understands, not a
   mysterious refusal.
 - Transient failures (network, tool, upstream) retry sensibly; the user
@@ -88,10 +97,12 @@ Named by job × surface, pointing at real scenarios.
   a restart is never silent about what happened.
 
 **Fuzz corpus:** vary failure kind (reboot × crash × context-exhaustion ×
-network flap × upgrade-mid-session) × timing (idle vs mid-turn vs during
-boot window) × surface (DM vs forum channel) × scheduled-job-due-during-
-outage. The invariants must hold across the corpus: always comes back,
-never silently, work resumed or named-as-lost.
+network flap × upgrade-mid-session × deliberate-restart × rollout) × timing
+(idle vs mid-turn vs during boot window) × surface (DM vs forum channel) ×
+scheduled-job-due-during-outage × sub-agent-in-flight-at-restart ×
+approval-card-outstanding-at-restart. The invariants must hold across the
+corpus: always comes back, never silently, work resumed or named-as-lost —
+including dispatched sub-agent work and an outstanding approval card.
 
 ## Verdict
 

--- a/reference/jobs/survive-reboots-and-real-life.md
+++ b/reference/jobs/survive-reboots-and-real-life.md
@@ -34,10 +34,13 @@ language, at the point it affects them.
 - An interrupted turn either resumes or is explicitly named as lost, never
   dropped on the floor in silence.
 - A **deliberate** restart (an operator restart, a rollout) that interrupts
-  an in-flight turn resumes it exactly as a crash does. The quota-saving
-  suppression that skips a resume applies **only when nothing was in flight**;
-  it never becomes an excuse to swallow work that was mid-turn when the
-  operator bounced the agent.
+  an in-flight turn resumes it like an interrupted turn (SIGTERM/crash
+  class). The quota-saving suppression that skips a resume applies **only
+  when nothing was in flight**; it never becomes an excuse to swallow work
+  that was mid-turn when the operator bounced the agent. The resume itself
+  is bounded: a turn is resumed **at most once per interruption**, along a
+  bounded resume chain — a turn that dies again during its own resume is
+  named-as-lost, never resumed forever.
 - **Sub-agents and workers killed by a restart are surfaced in the resume.**
   The parent re-dispatches the ones still needed, or names their loss
   per-worker. A parent turn never "resumes" while the work it dispatched
@@ -83,6 +86,12 @@ Named by job × surface, pointing at real scenarios.
   *Watch:* a turn cut off by a restart is resumed and the resume turn
   completes. *Invariant:* in-flight work is resumed or named-as-lost, never
   dropped in silence.
+- **Deliberate restart resumes, bounded (DM)** —
+  `jtbd-deliberate-restart-resumes-dm`. *Watch:* an operator restart lands
+  mid-turn; the interrupted turn resumes once and runs to completion.
+  *Invariant:* at-most-once resume per interruption, along a bounded resume
+  chain — a deliberate restart never swallows in-flight work, and a resume
+  never loops forever.
 - **Memory survives a restart (DM)** — `jtbd-memory-survives-restart-dm`.
   *Watch:* the agent comes back knowing what it knew before. *Invariant:*
   the agent never resurrects amnesiac without saying so.
@@ -130,3 +139,6 @@ including dispatched sub-agent work and an outstanding approval card.
   the reboots this job handles.
 - [`steer-or-queue-mid-flight`](steer-or-queue-mid-flight.md) — how an
   in-flight task is resumed or named-as-lost after a bounce.
+- [`deterministic-turn-liveness`](../rfcs/deterministic-turn-liveness.md) —
+  the design record carrying the at-most-once, bounded-resume-chain
+  contract this job's resume promises lean on.


### PR DESCRIPTION
The job specs now promise the approval/restart **continuation contract** that a verified audit found under-specified. These are stated as target outcomes; four fixes land in parallel PRs.

**`reference/jobs/approve-what-my-agent-can-touch.md`**
- Deny/timeout wake: a DENIED or EXPIRED request also resumes the turn — the agent hears the outcome, states what it can't do, continues or degrades; never left waiting on an already-answered card.
- Timeout contract: cards time out (60-min default), communicated as *timeout, not denial*, and re-offered on operator return (shipped for permission cards via #2724/#2866/#2867, never spec'd).
- Card durability: an approval card survives a gateway restart; a tap on a still-valid card after a restart works; expired cards are re-offered (missed-approvals).
- New UATs: `vault-deny-resumes-turn-dm`, `vault-timeout-wakes-agent-dm`, `vault-card-survives-gateway-restart-dm`.
- Bad-list: a stale-card tap that says "ask the agent to re-request" while the agent is parked and cannot re-request.

**`reference/jobs/survive-reboots-and-real-life.md`**
- Sub-agent re-dispatch: workers killed by a restart are surfaced in the resume (re-dispatched or named-as-lost per-worker); a parent turn never resumes with dispatched work silently dead.
- Deliberate-restart resume: an operator restart / rollout that interrupts an in-flight turn resumes it like a crash; quota-saving suppression only applies when nothing was in flight.
- Fuzz axis: sub-agent-in-flight × approval-card-outstanding at restart.

**`reference/jobs/steer-or-queue-mid-flight.md`**
- The "Survives a restart mid-flight" invariant now explicitly covers in-flight sub-agent work, not just the parent task.

**`reference/jobs/know-what-my-agent-is-doing.md`** (minor)
- Orphaned-worker state after a restart is narrated in the worker feed, not silently absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)