### PR TITLE
fix(telegram): resume inbound tells the agent which sub-agents the restart killed

### DIFF
--- a/profiles/default/CLAUDE.md.hbs
+++ b/profiles/default/CLAUDE.md.hbs
@@ -105,7 +105,7 @@ By default, every restart starts a **fresh `claude` session** — the in-flight 
   - **`resume_interrupted`** (operator restart / SIGTERM / crash): pick the work back up and carry it to completion. Briefly tell the user you're resuming and roughly how long ago it was interrupted — then just do it. Do NOT ask whether to resume.
   - **`resume_watchdog_timeout`** (hang-watchdog killed it after no progress): do NOT silently resume — it may hang the same way. Tell the user plainly that your last turn was killed after N minutes of no progress, roughly what it was doing, and ask whether to retry or take a different angle. Report only the honest cause; don't invent a deeper root cause.
   The one-shot `SWITCHROOM_PENDING_*` env vars are passive forensic context for the wake-audit / "why did you restart" protocols — not the resume trigger.
-- **`.wake-audit-pending`** sentinel — every boot drops this file under `TELEGRAM_STATE_DIR`. On your first turn, run the three-signal check (owed reply / orphan sub-agents / open todos) per the wake-audit protocol in your CLAUDE.md, then `rm -f` the sentinel.
+- **`.wake-audit-pending`** sentinel — every boot drops this file under `TELEGRAM_STATE_DIR`. On your first turn, run the three-signal check (owed reply / orphan sub-agents / open todos) per the wake-audit protocol in the `switchroom-runtime` skill (`skills/switchroom-runtime/SKILL.md`), then `rm -f` the sentinel.
 
 A config-summary greeting card is sent automatically by the SessionStart hook — you don't need to announce yourself. If your context feels thin (after compaction or any fresh session), proactively recall from Hindsight before proceeding.
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -688,7 +688,8 @@ import {
   buildResumeDeferredReportInbound,
   decideBootResumeKind,
 } from './resume-inbound-builder.js'
-import { applySubagentsSchema, getSubagentByJsonlId, resolveSubagentOriginTurnKey } from '../registry/subagents-schema.js'
+import { applySubagentsSchema, getSubagentByJsonlId, resolveSubagentOriginTurnKey, listNonTerminalSubagentsForTurn } from '../registry/subagents-schema.js'
+import type { InterruptedSubagent } from './resume-inbound-builder.js'
 import { resolveWorkerFeedDispatch, type WorkerFeedDispatch } from './worker-feed-dispatch.js'
 import {
   resolveSubagentStatusSurface,
@@ -1543,8 +1544,32 @@ try {
       maxAgeMs: RESUME_MAX_AGE_MS,
     })
 
+    // Sub-agents that were still in flight (running / stalled — non-terminal)
+    // when the turn was killed. Read HERE, at module top, BEFORE the
+    // subagent-watcher's boot scan + reaper run: the watcher never deletes
+    // these rows (it only flips running→stalled and marks files historical
+    // in-memory), and this accessor already includes 'stalled', so the data
+    // survives either ordering — but reading pre-watcher keeps it simplest.
+    // Threaded into ALL the builders below (resume, watchdog report, and the
+    // deferred report) so the session gets an explicit killed-workers block —
+    // it must not declare the task done on ghost workers, and even a
+    // suppressed/loop-guarded resume must still NAME the deaths.
+    let interruptedSubagents: InterruptedSubagent[] = []
+    try {
+      interruptedSubagents = listNonTerminalSubagentsForTurn(turnsDb, pending.turn_key).map(
+        (s) => ({ agentType: s.agent_type, description: s.description, status: s.status }),
+      )
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: boot-resume subagent lookup failed (${(err as Error).message}) — continuing without worker list\n`,
+      )
+    }
+
     if (bootResumeKind === 'resume') {
-      bootResumeInbound = { agent: selfAgent, msg: buildResumeInterruptedInbound({ turn: pending }) }
+      bootResumeInbound = {
+        agent: selfAgent,
+        msg: buildResumeInterruptedInbound({ turn: pending, subagents: interruptedSubagents }),
+      }
     } else if (bootResumeKind === 'report') {
       // idleMs: this boot's measured marker age if it just classified this
       // turn; otherwise recover it from the persisted interrupt_reason (a
@@ -1559,7 +1584,7 @@ try {
       if (idleMs == null) idleMs = Math.max(0, Date.now() - pending.started_at)
       bootResumeInbound = {
         agent: selfAgent,
-        msg: buildResumeWatchdogReportInbound({ turn: pending, idleMs }),
+        msg: buildResumeWatchdogReportInbound({ turn: pending, idleMs, subagents: interruptedSubagents }),
       }
     } else if (bootResumeKind === 'defer-loop' || bootResumeKind === 'defer-suppressed') {
       // Passive deferred-report: work was in flight but we decline to
@@ -1570,6 +1595,7 @@ try {
         msg: buildResumeDeferredReportInbound({
           turn: pending,
           reason: bootResumeKind === 'defer-loop' ? 'loop-guard' : 'clean-restart-suppressed',
+          subagents: interruptedSubagents,
         }),
       }
     }

--- a/telegram-plugin/gateway/resume-inbound-builder.ts
+++ b/telegram-plugin/gateway/resume-inbound-builder.ts
@@ -49,12 +49,76 @@ export function humanizeElapsed(ms: number): string {
   return `~${days} day${days === 1 ? '' : 's'}`
 }
 
+/**
+ * A sub-agent that was still in flight when the turn was interrupted. The
+ * gateway derives these from the registry (`listNonTerminalSubagentsForTurn`)
+ * — every non-terminal (`running` / `stalled`) worker of the interrupted turn.
+ * Kept to just the display fields so the builder stays pure (no SQLite import).
+ */
+export interface InterruptedSubagent {
+  /** Agent type / label (e.g. 'worker', 'researcher'). */
+  agentType?: string | null
+  /** Human-readable dispatch prompt / task description. */
+  description?: string | null
+  /** Current registry status ('running' | 'stalled'). Informational only. */
+  status?: string | null
+}
+
+/** Max chars of each sub-agent's dispatch prompt included in the inbound. */
+const SUBAGENT_PROMPT_MAX = 200
+/** Max number of sub-agents listed (the rest are summarised as a count). */
+const SUBAGENT_LIST_CAP = 10
+
+function truncatePrompt(s: string, max: number): string {
+  const t = s.trim()
+  if (t.length <= max) return t
+  return t.slice(0, max - 1).trimEnd() + '…'
+}
+
+/**
+ * Render the compact "these workers died with the restart" block appended to
+ * an interrupted-turn inbound. Empty string when there were no in-flight
+ * sub-agents (so the inbound is unchanged in the common case). Bounded: at
+ * most `SUBAGENT_LIST_CAP` entries, each prompt truncated to
+ * `SUBAGENT_PROMPT_MAX` chars, with an overflow count for the remainder.
+ */
+export function renderInterruptedSubagentsBlock(
+  subs: InterruptedSubagent[] | undefined,
+): string {
+  if (!subs || subs.length === 0) return ''
+  const shown = subs.slice(0, SUBAGENT_LIST_CAP)
+  const lines = shown.map((s, i) => {
+    const type = s.agentType?.trim() ? s.agentType.trim() : 'sub-agent'
+    const desc = s.description?.trim()
+      ? truncatePrompt(s.description, SUBAGENT_PROMPT_MAX)
+      : '(no task description recorded)'
+    return `  ${i + 1}. [${type}] ${desc}`
+  })
+  const overflow =
+    subs.length > SUBAGENT_LIST_CAP
+      ? `\n  …and ${subs.length - SUBAGENT_LIST_CAP} more.`
+      : ''
+  const count = subs.length
+  return (
+    `\n\nWhen the restart hit, ${count} sub-agent${count === 1 ? ' was' : 's were'} still ` +
+    `in flight. These sub-agents were killed by the restart and did NOT complete:\n` +
+    lines.join('\n') +
+    overflow +
+    `\nRe-dispatch the ones still needed before declaring the task done — ` +
+    `don't assume their work landed.`
+  )
+}
+
 export interface ResumeInboundContext {
   /** The interrupted turn, straight from the registry. */
   turn: Turn
   /** Wall-clock ms. Drives `ts`, `messageId`, and the elapsed framing.
    *  Defaults to Date.now(). */
   nowMs?: number
+  /** Sub-agents that were still non-terminal when the turn was interrupted.
+   *  Rendered into the inbound so the resumed session knows what to
+   *  re-dispatch. Omitted / empty → the inbound is unchanged. */
+  subagents?: InterruptedSubagent[]
 }
 
 /**
@@ -161,7 +225,8 @@ export function buildResumeInterruptedInbound(ctx: ResumeInboundContext): Inboun
       `plain language) so they're not left wondering — then carry on with the ` +
       `actual task. Do not ask whether to resume; just resume. If even after ` +
       `reading the recent messages you genuinely can't tell what the work was, ` +
-      `say so and ask.`,
+      `say so and ask.` +
+      renderInterruptedSubagentsBlock(ctx.subagents),
     meta,
   }
 }
@@ -220,7 +285,8 @@ export function buildResumeWatchdogReportInbound(
       `after ${idle} of no progress, and roughly what it was doing. Then ask ` +
       `whether they want you to retry it or take a different angle. Report ` +
       `only the honest cause — no observable progress for that long — don't ` +
-      `speculate about a deeper root cause you can't see.`,
+      `speculate about a deeper root cause you can't see.` +
+      renderInterruptedSubagentsBlock(ctx.subagents),
     meta,
   }
 }

--- a/telegram-plugin/gateway/resume-inbound-builder.ts
+++ b/telegram-plugin/gateway/resume-inbound-builder.ts
@@ -424,7 +424,11 @@ export function buildResumeDeferredReportInbound(
       `flight (call get_recent_messages for this chat if you need the full ` +
       `original request — the quoted preview is only the first ~200 ` +
       `characters), then ask whether they want you to pick it back up or drop ` +
-      `it. If you genuinely can't tell what the work was, say so and ask.`,
+      `it. If you genuinely can't tell what the work was, say so and ask.` +
+      // Deferred (non-assertive) form, same as the watchdog path: this is an
+      // ask-first inbound — killed workers are named as facts, but
+      // re-dispatch waits on the user's call.
+      renderInterruptedSubagentsBlock(ctx.subagents, { assertive: false }),
     meta,
   }
 }

--- a/telegram-plugin/gateway/resume-inbound-builder.ts
+++ b/telegram-plugin/gateway/resume-inbound-builder.ts
@@ -72,7 +72,12 @@ const SUBAGENT_LIST_CAP = 10
 function truncatePrompt(s: string, max: number): string {
   const t = s.trim()
   if (t.length <= max) return t
-  return t.slice(0, max - 1).trimEnd() + '…'
+  // Codepoint-safe truncation: slice by code POINTS, not UTF-16 code units —
+  // a naive `.slice()` can split a surrogate pair (emoji, astral-plane CJK)
+  // and leave a lone surrogate that renders as U+FFFD in the inbound.
+  const points = Array.from(t)
+  if (points.length <= max) return t
+  return points.slice(0, max - 1).join('').trimEnd() + '…'
 }
 
 /**
@@ -81,9 +86,21 @@ function truncatePrompt(s: string, max: number): string {
  * sub-agents (so the inbound is unchanged in the common case). Bounded: at
  * most `SUBAGENT_LIST_CAP` entries, each prompt truncated to
  * `SUBAGENT_PROMPT_MAX` chars, with an overflow count for the remainder.
+ *
+ * The closing instruction is mode-aware, mirroring the two builders'
+ * contracts:
+ *   - `assertive: true` (the `resume_interrupted` path, whose inbound already
+ *     says "just resume") → imperative: re-dispatch the ones still needed
+ *     before declaring the task done.
+ *   - `assertive: false` (the `resume_watchdog_timeout` path — an ask-first
+ *     contract: "Do NOT silently resume … ask whether to retry") → deferred:
+ *     IF the user asks to retry, the workers will need re-dispatching. An
+ *     unconditional re-dispatch imperative here would contradict that
+ *     hang-safety gate.
  */
 export function renderInterruptedSubagentsBlock(
   subs: InterruptedSubagent[] | undefined,
+  opts: { assertive: boolean } = { assertive: true },
 ): string {
   if (!subs || subs.length === 0) return ''
   const shown = subs.slice(0, SUBAGENT_LIST_CAP)
@@ -99,13 +116,17 @@ export function renderInterruptedSubagentsBlock(
       ? `\n  …and ${subs.length - SUBAGENT_LIST_CAP} more.`
       : ''
   const count = subs.length
+  const closing = opts.assertive
+    ? `\nRe-dispatch the ones still needed before declaring the task done — ` +
+      `don't assume their work landed.`
+    : `\nIf the user asks you to retry, they'll need re-dispatching — ` +
+      `don't assume their work landed.`
   return (
     `\n\nWhen the restart hit, ${count} sub-agent${count === 1 ? ' was' : 's were'} still ` +
     `in flight. These sub-agents were killed by the restart and did NOT complete:\n` +
     lines.join('\n') +
     overflow +
-    `\nRe-dispatch the ones still needed before declaring the task done — ` +
-    `don't assume their work landed.`
+    closing
   )
 }
 
@@ -286,7 +307,9 @@ export function buildResumeWatchdogReportInbound(
       `whether they want you to retry it or take a different angle. Report ` +
       `only the honest cause — no observable progress for that long — don't ` +
       `speculate about a deeper root cause you can't see.` +
-      renderInterruptedSubagentsBlock(ctx.subagents),
+      // Deferred (non-assertive) form: this is the ask-first path — the killed
+      // workers are listed as facts, but re-dispatch waits on the user's call.
+      renderInterruptedSubagentsBlock(ctx.subagents, { assertive: false }),
     meta,
   }
 }

--- a/telegram-plugin/registry/subagents-schema.ts
+++ b/telegram-plugin/registry/subagents-schema.ts
@@ -647,6 +647,12 @@ export function listSubagents(
  * excluded. This also makes the read robust to boot ordering: even if the
  * watcher's reaper transitions a row to `stalled` before this runs, the row is
  * still surfaced rather than dropped.
+ *
+ * Known gap: rows with NULL parent_turn_key are silently omitted — the
+ * INSERT-time stamp can be missing (no turn-active marker at dispatch, e.g.
+ * nested workers) and the watcher's async backfill may not have run before the
+ * killing restart. Those workers won't appear in the resume inbound; the
+ * wake-audit orphan-check (switchroom-runtime skill) is the backstop.
  */
 export function listNonTerminalSubagentsForTurn(
   db: SqliteDatabase,

--- a/telegram-plugin/registry/subagents-schema.ts
+++ b/telegram-plugin/registry/subagents-schema.ts
@@ -633,6 +633,37 @@ export function listSubagents(
 }
 
 /**
+ * List the sub-agents of a given parent turn that had NOT reached a terminal
+ * state (`completed` / `failed`) — i.e. `running` or `stalled`. Ordered by
+ * `started_at ASC` (dispatch order) so the resume inbound lists them the way
+ * they were spawned.
+ *
+ * This is the boot-resume accessor: when a turn is interrupted mid-flight, its
+ * in-flight workers were killed with it, so the resumed session needs to know
+ * which ones didn't finish to re-dispatch them. Deliberately includes
+ * `stalled` alongside `running` — a row the reaper flipped to `stalled` (1h
+ * TTL, JSONL linkage missing) still never completed, so it belongs in the
+ * "these died, re-dispatch if still needed" list. Only genuine terminals are
+ * excluded. This also makes the read robust to boot ordering: even if the
+ * watcher's reaper transitions a row to `stalled` before this runs, the row is
+ * still surfaced rather than dropped.
+ */
+export function listNonTerminalSubagentsForTurn(
+  db: SqliteDatabase,
+  parentTurnKey: string,
+): Subagent[] {
+  const rows = db
+    .prepare(`
+      SELECT * FROM subagents
+      WHERE parent_turn_key = ?
+        AND status NOT IN ('completed', 'failed')
+      ORDER BY started_at ASC
+    `)
+    .all(parentTurnKey) as RawSubagentRow[]
+  return rows.map(mapSubagentRow)
+}
+
+/**
  * Retrieve a single subagent row by id. Returns null if not found.
  * Useful in tests and for callers that need to inspect current state.
  */

--- a/telegram-plugin/registry/subagents.test.ts
+++ b/telegram-plugin/registry/subagents.test.ts
@@ -30,6 +30,7 @@ import {
   getSubagent,
   reapStuckRunningRows,
   countRunningBackgroundSubagents,
+  listNonTerminalSubagentsForTurn,
 } from './subagents-schema.js'
 
 // ---------------------------------------------------------------------------
@@ -663,5 +664,45 @@ describe('reapStuckRunningRows', () => {
     const result = reapStuckRunningRows(db, { ttlMs: 100, now: 9999 })
     expect(result.reaped).toBe(5)
     expect(result.ids.sort()).toEqual(['sa-0', 'sa-1', 'sa-2', 'sa-3', 'sa-4'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// listNonTerminalSubagentsForTurn — the boot-resume accessor
+// ---------------------------------------------------------------------------
+
+describe('listNonTerminalSubagentsForTurn', () => {
+  it('returns running + stalled workers of a turn, excluding terminals, ordered by started_at', () => {
+    const db = openFreshSubagentsDbInMemory()
+    const turn = 'chat-1:7'
+    recordSubagentStart(db, { id: 'sa-run', parentTurnKey: turn, agentType: 'worker', description: 'refactor auth', background: true, startedAt: 1000 })
+    recordSubagentStart(db, { id: 'sa-stall', parentTurnKey: turn, agentType: 'researcher', description: 'survey competitors', background: true, startedAt: 2000 })
+    recordSubagentStall(db, { id: 'sa-stall', stalledAt: 3000 })
+    recordSubagentStart(db, { id: 'sa-done', parentTurnKey: turn, agentType: 'worker', description: 'done work', background: true, startedAt: 500 })
+    recordSubagentEnd(db, { id: 'sa-done', endedAt: 4000, status: 'completed' })
+    recordSubagentStart(db, { id: 'sa-fail', parentTurnKey: turn, background: true, startedAt: 600 })
+    recordSubagentEnd(db, { id: 'sa-fail', endedAt: 4100, status: 'failed' })
+
+    const rows = listNonTerminalSubagentsForTurn(db, turn)
+    expect(rows.map((r) => r.id)).toEqual(['sa-run', 'sa-stall']) // started_at ASC, terminals excluded
+    expect(rows[0].agent_type).toBe('worker')
+    expect(rows[0].description).toBe('refactor auth')
+    expect(rows[1].status).toBe('stalled')
+    db.close()
+  })
+
+  it('does not return workers of a different turn', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'sa-a', parentTurnKey: 'chat:1', background: true, startedAt: 1000 })
+    recordSubagentStart(db, { id: 'sa-b', parentTurnKey: 'chat:2', background: true, startedAt: 1000 })
+    const rows = listNonTerminalSubagentsForTurn(db, 'chat:1')
+    expect(rows.map((r) => r.id)).toEqual(['sa-a'])
+    db.close()
+  })
+
+  it('returns empty for a turn with no in-flight workers', () => {
+    const db = openFreshSubagentsDbInMemory()
+    expect(listNonTerminalSubagentsForTurn(db, 'nope:0')).toEqual([])
+    db.close()
   })
 })

--- a/telegram-plugin/tests/resume-inbound-builder.test.ts
+++ b/telegram-plugin/tests/resume-inbound-builder.test.ts
@@ -273,6 +273,44 @@ describe('interrupted sub-agent block', () => {
     expect(msg.text).toContain('Re-dispatch the ones still needed before declaring the task done')
     expect(msg.text).not.toContain('If the user asks you to retry')
   })
+
+  for (const reason of ['loop-guard', 'clean-restart-suppressed'] as const) {
+    it(`the deferred report (${reason}) carries the block in DEFERRED form — suppressed resumes still name worker deaths`, () => {
+      const msg = buildResumeDeferredReportInbound({
+        turn: makeTurn(),
+        reason,
+        subagents: twoRunning,
+      })
+      expect(msg.text).toContain('did NOT complete')
+      expect(msg.text).toContain('refactor the auth module and add tests')
+      expect(msg.text).toContain('survey the pricing pages of 5 competitors')
+      // Deferred wording only — never the resume-path imperative, which would
+      // contradict this inbound's "Do NOT silently resume … ask" contract.
+      expect(msg.text).toContain("If the user asks you to retry, they'll need re-dispatching")
+      expect(msg.text).not.toContain('Re-dispatch the ones still needed')
+      expect(msg.text).not.toContain('before declaring the task done')
+      // Appending the block must not disturb the loop-guard anchor at pos 0.
+      expect(msg.text.startsWith(RESUME_SYNTHETIC_PROMPT_PREFIX)).toBe(true)
+    })
+  }
+
+  it('deferred report without subagents is unchanged (no block)', () => {
+    const withNone = buildResumeDeferredReportInbound({ turn: makeTurn(), reason: 'loop-guard', subagents: [] })
+    const bare = buildResumeDeferredReportInbound({ turn: makeTurn(), reason: 'loop-guard' })
+    expect(withNone.text).toBe(bare.text)
+    expect(withNone.text).not.toContain('did NOT complete')
+  })
+
+  it('appending the block preserves the RESUME_SYNTHETIC_PROMPT_PREFIX anchor on resume + watchdog inbounds too', () => {
+    const resume = buildResumeInterruptedInbound({ turn: makeTurn(), subagents: twoRunning })
+    expect(resume.text.startsWith(RESUME_SYNTHETIC_PROMPT_PREFIX)).toBe(true)
+    const report = buildResumeWatchdogReportInbound({
+      turn: makeTurn({ ended_via: 'timeout' }),
+      idleMs: 300_000,
+      subagents: twoRunning,
+    })
+    expect(report.text.startsWith(RESUME_SYNTHETIC_PROMPT_PREFIX)).toBe(true)
+  })
 })
 
 describe('buildResumeWatchdogReportInbound', () => {

--- a/telegram-plugin/tests/resume-inbound-builder.test.ts
+++ b/telegram-plugin/tests/resume-inbound-builder.test.ts
@@ -23,6 +23,8 @@ import {
   selectResumeBuilder,
   decideBootResumeKind,
   RESUME_SYNTHETIC_PROMPT_PREFIX,
+  renderInterruptedSubagentsBlock,
+  type InterruptedSubagent,
 } from '../gateway/resume-inbound-builder.js'
 import type { Turn, TurnEndedVia } from '../registry/turns-schema.js'
 
@@ -159,6 +161,92 @@ describe('buildResumeInterruptedInbound', () => {
     expect(msg.meta.chat_id).toBe('-1001234567890')
     expect(msg.meta.message_thread_id).toBe('42')
     expect(msg.threadId).toBe(42)
+  })
+})
+
+describe('interrupted sub-agent block', () => {
+  const twoRunning: InterruptedSubagent[] = [
+    { agentType: 'worker', description: 'refactor the auth module and add tests', status: 'running' },
+    { agentType: 'researcher', description: 'survey the pricing pages of 5 competitors', status: 'running' },
+  ]
+
+  it('renderInterruptedSubagentsBlock lists each worker with type + prompt', () => {
+    const block = renderInterruptedSubagentsBlock(twoRunning)
+    expect(block).toContain('2 sub-agents were still')
+    expect(block).toContain('did NOT complete')
+    expect(block).toContain('[worker]')
+    expect(block).toContain('refactor the auth module and add tests')
+    expect(block).toContain('[researcher]')
+    expect(block).toContain('survey the pricing pages of 5 competitors')
+    expect(block).toContain('Re-dispatch the ones still needed')
+  })
+
+  it('returns empty string when there are no in-flight sub-agents', () => {
+    expect(renderInterruptedSubagentsBlock(undefined)).toBe('')
+    expect(renderInterruptedSubagentsBlock([])).toBe('')
+  })
+
+  it('interrupted-turn inbound contains BOTH running sub-agents', () => {
+    const msg = buildResumeInterruptedInbound({ turn: makeTurn(), subagents: twoRunning })
+    expect(msg.text).toContain('refactor the auth module and add tests')
+    expect(msg.text).toContain('survey the pricing pages of 5 competitors')
+    expect(msg.text).toContain('did NOT complete')
+    expect(msg.text).toContain('Re-dispatch the ones still needed')
+  })
+
+  it('interrupted-turn inbound is UNCHANGED when no sub-agents were running', () => {
+    const withNone = buildResumeInterruptedInbound({ turn: makeTurn(), subagents: [] })
+    const bare = buildResumeInterruptedInbound({ turn: makeTurn() })
+    expect(withNone.text).toBe(bare.text)
+    expect(withNone.text).not.toContain('did NOT complete')
+  })
+
+  it('truncates each dispatch prompt to ~200 chars', () => {
+    const long = 'x'.repeat(400)
+    const block = renderInterruptedSubagentsBlock([{ agentType: 'worker', description: long }])
+    // The 400-char prompt must not survive in full; the entry line is capped.
+    expect(block).not.toContain(long)
+    expect(block).toContain('…')
+    // 200-char cap → the truncated slice (199 chars + ellipsis) is present.
+    expect(block).toContain('x'.repeat(199))
+    expect(block).not.toContain('x'.repeat(201))
+  })
+
+  it('caps the list at 10 and summarises the remainder', () => {
+    const many: InterruptedSubagent[] = Array.from({ length: 14 }, (_, i) => ({
+      agentType: 'worker',
+      description: `task number ${i + 1}`,
+    }))
+    const block = renderInterruptedSubagentsBlock(many)
+    expect(block).toContain('14 sub-agents were still')
+    expect(block).toContain('task number 10')
+    expect(block).not.toContain('task number 11')
+    expect(block).toContain('…and 4 more.')
+    // Exactly 10 numbered entries rendered.
+    const numbered = block.match(/^\s+\d+\. \[/gm) ?? []
+    expect(numbered.length).toBe(10)
+  })
+
+  it('falls back to a generic label + placeholder when type/prompt are missing', () => {
+    const block = renderInterruptedSubagentsBlock([{ agentType: null, description: null }])
+    expect(block).toContain('[sub-agent]')
+    expect(block).toContain('(no task description recorded)')
+  })
+
+  it('singularises a single killed sub-agent', () => {
+    const block = renderInterruptedSubagentsBlock([{ agentType: 'worker', description: 'do X' }])
+    expect(block).toContain('1 sub-agent was still')
+    expect(block).not.toContain('1 sub-agents')
+  })
+
+  it('the watchdog report inbound ALSO carries the killed-worker block', () => {
+    const msg = buildResumeWatchdogReportInbound({
+      turn: makeTurn({ ended_via: 'timeout' }),
+      idleMs: 300_000,
+      subagents: twoRunning,
+    })
+    expect(msg.text).toContain('did NOT complete')
+    expect(msg.text).toContain('refactor the auth module and add tests')
   })
 })
 

--- a/telegram-plugin/tests/resume-inbound-builder.test.ts
+++ b/telegram-plugin/tests/resume-inbound-builder.test.ts
@@ -239,7 +239,19 @@ describe('interrupted sub-agent block', () => {
     expect(block).not.toContain('1 sub-agents')
   })
 
-  it('the watchdog report inbound ALSO carries the killed-worker block', () => {
+  it('codepoint-safe truncation never splits a surrogate pair', () => {
+    // 199 ASCII chars, then an astral-plane emoji (2 UTF-16 code units)
+    // straddling the cap. A code-unit slice would cut the pair in half and
+    // leave a lone surrogate; the codepoint-safe slice must not.
+    const desc = 'a'.repeat(199) + '🚀' + 'b'.repeat(50)
+    const block = renderInterruptedSubagentsBlock([{ agentType: 'worker', description: desc }])
+    expect(block).toContain('…')
+    // No lone surrogates anywhere in the rendered block.
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(block)).toBe(false)
+    expect(block).toBe(block.normalize('NFC')) // sanity: still a well-formed string
+  })
+
+  it('the watchdog report inbound carries the block in DEFERRED form (ask-first contract)', () => {
     const msg = buildResumeWatchdogReportInbound({
       turn: makeTurn({ ended_via: 'timeout' }),
       idleMs: 300_000,
@@ -247,6 +259,19 @@ describe('interrupted sub-agent block', () => {
     })
     expect(msg.text).toContain('did NOT complete')
     expect(msg.text).toContain('refactor the auth module and add tests')
+    // Deferred wording: re-dispatch is conditional on the user asking to retry…
+    expect(msg.text).toContain("If the user asks you to retry, they'll need re-dispatching")
+    expect(msg.text).toContain("don't assume their work landed")
+    // …and the resume-path imperative must NOT appear — it would contradict
+    // the watchdog inbound's "Do NOT silently resume … ask" hang-safety gate.
+    expect(msg.text).not.toContain('Re-dispatch the ones still needed')
+    expect(msg.text).not.toContain('before declaring the task done')
+  })
+
+  it('the resume-path inbound keeps the assertive imperative (and not the deferred form)', () => {
+    const msg = buildResumeInterruptedInbound({ turn: makeTurn(), subagents: twoRunning })
+    expect(msg.text).toContain('Re-dispatch the ones still needed before declaring the task done')
+    expect(msg.text).not.toContain('If the user asks you to retry')
   })
 })
 


### PR DESCRIPTION
## Summary

After a mid-task restart the agent knows which workers died and re-dispatches them instead of forgetting.

When a turn is interrupted mid-flight (operator restart / SIGTERM / crash), its in-flight sub-agents are killed with it. The boot resume/report inbound previously carried only a ~200-char prompt preview, so the resumed session had no idea which workers didn't finish — and would declare the task done on ghost workers whose output never landed. This enriches that inbound with a compact per-worker block and an explicit "re-dispatch the ones still needed" instruction.

## Why

- No re-dispatch signal existed. The boot resume inbound (`resume-inbound-builder.ts`) only had the truncated user prompt; killed sub-agents were invisible to the resumed session.
- The wake-audit orphan-check protocol exists in `skills/switchroom-runtime/SKILL.md`, but `profiles/default/CLAUDE.md.hbs` pointed circularly at "your CLAUDE.md" instead of the skill.

## What changed

- **`registry/subagents-schema.ts`** — new `listNonTerminalSubagentsForTurn(db, parentTurnKey)`: running + stalled (non-terminal) workers of a turn, ordered by `started_at`. Includes `stalled` so a reaper-flipped row is still surfaced, making the read robust to boot ordering (the watcher only flips running→stalled and marks files historical in-memory — it never deletes the dispatch prompt/label).
- **`gateway/resume-inbound-builder.ts`** — `renderInterruptedSubagentsBlock()` appends a bounded block: worker type/label + dispatch prompt truncated to 200 chars, capped at 10 with an overflow count, plus the explicit re-dispatch instruction. Empty string when no workers were in flight, so the common case inbound is byte-for-byte unchanged. Wired into **both** the resume and watchdog-report builders via an optional `subagents` field.
- **`gateway/gateway.ts`** — the boot-resume block reads the sub-agents at module top (before the subagent-watcher's boot scan/reaper), passes them to the builders; best-effort with a log-and-continue on lookup failure. (The block that decides *when* resume fires is untouched.)
- **`profiles/default/CLAUDE.md.hbs`** — the `.wake-audit-pending` bullet now points at the `switchroom-runtime` skill's wake-audit protocol (matches `start.sh.hbs`).

## Test plan

- `bun test telegram-plugin/tests/resume-inbound-builder.test.ts telegram-plugin/registry/subagents.test.ts` → 91 pass / 0 fail.
- New builder cases: 2 running workers (both present, truncation applied), none-running (inbound unchanged vs bare), 10-cap + overflow summary, singular/plural, missing type/prompt fallback, watchdog-report also carries the block.
- New accessor cases: running+stalled returned, terminals excluded, turn-scoped, started_at ordering, empty when none.
- `npm run lint` (tsc + 8 guards) green; `tsc --noEmit` clean.

## Risk

Low. The builder change is additive behind an optional field — omitting `subagents` reproduces the exact prior inbound. The DB read is best-effort (failure logs and continues). No change to resume timing/suppression.

## Job spec

Advances the *always available* vision outcome — `reference/jobs/` interrupted-turn resume (the `jtbd-interrupted-turn-resumes-dm` UAT scenario): a restart mid-task must not silently drop in-flight work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)