### PR TITLE
fix(gateway): resume in-flight work after deliberate restarts

### DIFF
--- a/docs/session-optimization.md
+++ b/docs/session-optimization.md
@@ -32,6 +32,14 @@ Switchroom agents have three mechanisms that survive restarts and compaction:
 
    A transcript is deleted only when it is **both** over the count bound **and** older than the age bound; the newest two sessions are always retained regardless.
 
+   **In-flight resume across restarts (`session_continuity.boot_resume`).** Independent of `resume_mode` (which governs transcript replay), this controls whether a turn that was genuinely *in flight* when the agent restarted is auto-resumed. It exists because a **deliberate** restart (operator `agent restart`, a rollout, `systemctl restart`) that lands mid-turn used to be silently swallowed — the work was dropped and the user never told. Threaded to the gateway as `SWITCHROOM_BOOT_RESUME`.
+
+   - `in-flight` — **default**. Resume genuinely interrupted work even after a deliberate restart. A sanctioned restart no longer silently drops in-flight work.
+   - `always` — force resume unconditionally (equivalent to the `SWITCHROOM_BOOT_RESUME_ALWAYS=1` escape hatch).
+   - `never` — the quota-saving posture: don't auto-replay work across a clean restart. The user is **still** sent a passive notice of what was in flight — silence is never used.
+
+   Two safety rails always apply, regardless of mode: the **at-most-once ledger** (`resumed_at`) means a given turn resumes at most once, and a **bounded resume-chain loop-guard** means a resume turn that is itself interrupted by another restart is *not* re-resumed (it downgrades to a passive report) — so repeated restarts can never form an endless resume loop. The 60s clean-shutdown marker freshness window is likewise preserved: a slow rollout (>60s) still resumes.
+
 2. **Hindsight memory** — auto-retain fires every 10 turns, saving the full transcript to a semantic bank. Auto-recall fires every turn, bringing back relevant memories. Important facts survive compaction and restart because they're stored externally.
 
 3. **Telegram history** — SQLite buffer of every inbound/outbound message. `get_recent_messages` lets the agent recover recent chat context after a restart, regardless of resume mode.

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -46,6 +46,17 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
   # compose env and the inner-pass export. Pinned by the scaffold-order test.
   export SWITCHROOM_AGENT_NAME="{{name}}"
 
+  # Boot-resume policy (session_continuity.boot_resume; default 'in-flight').
+  # The gateway's boot-resume block reads SWITCHROOM_BOOT_RESUME to decide
+  # whether a genuinely in-flight turn is auto-resumed across a deliberate
+  # restart ('in-flight' — default), always ('always'), or downgraded to a
+  # passive notice ('never'). MUST be exported here, before the gateway fork
+  # below, or the daemon never sees it and every agent defaults silently — same
+  # start.sh env-fork landmine as the channels.telegram knobs. The later
+  # SWITCHROOM_RESUME_MODE block is set AFTER the fork (it drives the inner
+  # `claude` --continue path, not the gateway), so this needs its own hoist.
+  export SWITCHROOM_BOOT_RESUME="{{#if bootResumeMode}}{{{bootResumeMode}}}{{else}}in-flight{{/if}}"
+
   # Gateway-consumed env MUST be exported HERE, before the gateway fork
   # below. The gateway daemon reads channels.telegram.* knobs (and any
   # agent env) from process.env at startup — e.g. SWITCHROOM_TG_STREAM_

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3074,6 +3074,11 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     resumeMode: agentConfig.session_continuity?.resume_mode ?? "handoff",
     resumeMaxBytes:
       agentConfig.session_continuity?.resume_max_bytes ?? 2_000_000,
+    // Boot-resume policy for in-flight-turn recovery across restarts
+    // (session_continuity.boot_resume; default 'in-flight'). Threaded to the
+    // gateway process as SWITCHROOM_BOOT_RESUME (exported before the gateway
+    // fork in start.sh — the gateway reads it at boot-resume time).
+    bootResumeMode: agentConfig.session_continuity?.boot_resume ?? "in-flight",
     // True only when the generated start.sh can actually set CONTINUE_FLAG="--continue"
     // at runtime (i.e. resume_mode is 'auto' or 'continue'). In handoff/none mode the
     // case branches for auto/continue are omitted entirely so the literal string
@@ -5904,6 +5909,10 @@ export function reconcileAgent(
       resumeMode: agentConfig.session_continuity?.resume_mode ?? "handoff",
       resumeMaxBytes:
         agentConfig.session_continuity?.resume_max_bytes ?? 2_000_000,
+      // Boot-resume policy (session_continuity.boot_resume; default
+      // 'in-flight'). Threaded to the gateway as SWITCHROOM_BOOT_RESUME.
+      // Mirror of buildWorkspaceContext — reconcile must keep parity.
+      bootResumeMode: agentConfig.session_continuity?.boot_resume ?? "in-flight",
     };
     const beforeStartSh = existsSync(startShPath)
       ? readFileSync(startShPath, "utf-8")

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -846,6 +846,22 @@ export const SessionContinuitySchema = z
         "can blow out the context window even with prefix caching, and " +
         "--continue replay is known-fragile at scale.",
       ),
+    boot_resume: z
+      .enum(["always", "in-flight", "never"])
+      .optional()
+      .describe(
+        "How the gateway auto-resumes a turn that was IN FLIGHT when the " +
+        "agent restarted. 'in-flight' (default) resumes genuinely " +
+        "interrupted work even after a deliberate/operator restart — a " +
+        "sanctioned restart landing mid-turn no longer silently drops the " +
+        "work. 'always' forces resume unconditionally (same as the " +
+        "SWITCHROOM_BOOT_RESUME_ALWAYS=1 escape hatch). 'never' is the " +
+        "quota-saving posture: don't auto-replay work across a clean " +
+        "restart — but the user is STILL sent a passive notice of what was " +
+        "in flight (silence is never used). Independent of the at-most-once " +
+        "resume ledger and the bounded resume-chain loop-guard, which always " +
+        "apply. Threaded to the gateway as SWITCHROOM_BOOT_RESUME.",
+      ),
     session_retention_max_count: z
       .number()
       .int()

--- a/telegram-plugin/gateway/clean-shutdown-marker.ts
+++ b/telegram-plugin/gateway/clean-shutdown-marker.ts
@@ -183,43 +183,91 @@ export function resolveShutdownMarker(
 }
 
 /**
+ * Boot-resume policy, from `session_continuity.boot_resume`
+ * (SWITCHROOM_BOOT_RESUME env). Governs whether a clean/deliberate
+ * shutdown suppresses auto-resume of a genuinely in-flight turn:
+ *
+ *   - 'always'   — always resume interrupted work, even after a clean
+ *                  shutdown (equivalent to SWITCHROOM_BOOT_RESUME_ALWAYS=1).
+ *   - 'in-flight' — (DEFAULT) resume work that was genuinely in flight at
+ *                  shutdown, even after a deliberate/operator restart. This
+ *                  is the whole point: a sanctioned restart that lands mid-
+ *                  turn must not silently drop the work. The boot-resume
+ *                  block only runs when a pending interrupted turn exists —
+ *                  i.e. when there IS in-flight work — so in this mode the
+ *                  clean-shutdown gate never swallows real work.
+ *   - 'never'    — the #2585 quota-saving posture: suppress AUTO-resume on a
+ *                  fresh clean shutdown. NOTE the caller still delivers a
+ *                  passive REPORT inbound in this case (silence is never
+ *                  acceptable when work was in flight); this flag only
+ *                  downgrades an active resume to a passive notice.
+ */
+export type BootResumeMode = 'always' | 'in-flight' | 'never';
+
+/** The product default (2026-07): resume genuinely in-flight work even
+ *  after a deliberate restart. Restores the pre-#2585 recovery of real
+ *  work while keeping #2585's "don't replay abandoned work" intent for the
+ *  no-in-flight-turn case (which is a no-op — the boot block never runs
+ *  without a pending turn). */
+export const DEFAULT_BOOT_RESUME_MODE: BootResumeMode = 'in-flight';
+
+/**
+ * Parse the SWITCHROOM_BOOT_RESUME env value into a BootResumeMode. Unknown
+ * / empty / undefined falls back to the default ('in-flight'). Case- and
+ * separator-insensitive ("in_flight", "inflight", "IN-FLIGHT" all map to
+ * 'in-flight') so a config typo degrades to the safe default rather than a
+ * silent misparse.
+ */
+export function parseBootResumeMode(raw: string | undefined | null): BootResumeMode {
+  if (typeof raw !== 'string') return DEFAULT_BOOT_RESUME_MODE;
+  const norm = raw.trim().toLowerCase().replace(/[_\s]+/g, '-');
+  if (norm === 'always') return 'always';
+  if (norm === 'never') return 'never';
+  if (norm === 'in-flight' || norm === 'inflight') return 'in-flight';
+  return DEFAULT_BOOT_RESUME_MODE;
+}
+
+/**
  * Pure decision: should the boot-resume path SUPPRESS the active
  * resume_interrupted inbound because the prior shutdown was clean?
  *
- * A clean marker present and fresh (<= maxAgeMs, default 60s) means the
- * prior shutdown was operator/roll/CLI-initiated — NOT a crash. In that
- * case auto-resuming interrupted work is wasteful: the agent was asked to
- * stop, it stopped cleanly, and the "interrupted" turn was implicitly
- * abandoned by that decision. Burning a full model turn to replay it on
- * every operator restart wastes subscription quota for no user benefit.
+ * This block is only ever consulted when a pending INTERRUPTED turn
+ * exists — i.e. there IS genuinely in-flight work to recover. The product
+ * decision (2026-07, superseding #2585) is that a deliberate restart must
+ * NOT silently drop that work, so the DEFAULT mode ('in-flight') never
+ * suppresses. #2585's quota-saving posture survives only as the opt-in
+ * 'never' mode — and even then the caller downgrades to a passive REPORT
+ * rather than going silent.
  *
- * Returns true ONLY when:
+ * Returns true (suppress the ACTIVE resume) ONLY when:
+ *   - mode === 'never', AND
  *   - a clean marker is present, AND
  *   - the marker is younger than maxAgeMs (default 60s), AND
- *   - the SWITCHROOM_BOOT_RESUME_ALWAYS escape hatch is not set.
+ *   - neither forceAlways nor mode 'always' is set.
  *
- * Returns false when:
- *   - no marker (crash / OOM / unexpected kill — resume normally), OR
- *   - marker is stale (>= maxAgeMs — something stalled; treat as crash), OR
- *   - forceAlways is true (the escape hatch is active).
+ * Returns false (resume normally) when:
+ *   - mode is 'always' or 'in-flight' (the default), OR
+ *   - forceAlways is true (SWITCHROOM_BOOT_RESUME_ALWAYS=1 escape hatch), OR
+ *   - no marker (crash / OOM / unexpected kill), OR
+ *   - marker is stale (>= maxAgeMs — clean shutdown that stalled mid-drain;
+ *     preserves the ">60s slow-rollout already resumes" behaviour).
  *
- * The forceAlways parameter maps to the env var
- * SWITCHROOM_BOOT_RESUME_ALWAYS=1, which restores the pre-gate behaviour
- * unconditionally. Pass it in as a parsed boolean so this function stays
- * pure and testable without touching process.env.
- *
- * Keeping this pure makes the decision unit-testable in bun test without
- * spinning up the gateway.
+ * forceAlways maps to SWITCHROOM_BOOT_RESUME_ALWAYS=1 and is preserved for
+ * back-compat: it forces resume regardless of mode. Passed in as a parsed
+ * boolean + mode so this function stays pure and testable.
  */
 export function shouldSuppressBootResume(
   marker: CleanShutdownMarker | null,
   now: number,
-  { maxAgeMs = DEFAULT_MAX_AGE_MS, forceAlways = false }: {
+  { maxAgeMs = DEFAULT_MAX_AGE_MS, forceAlways = false, mode = DEFAULT_BOOT_RESUME_MODE }: {
     maxAgeMs?: number;
     forceAlways?: boolean;
+    mode?: BootResumeMode;
   } = {},
 ): boolean {
   if (forceAlways) return false;
+  if (mode === 'always' || mode === 'in-flight') return false;
+  // mode === 'never': the legacy #2585 clean-shutdown gate.
   if (marker === null) return false;
   const age = now - marker.ts;
   if (age < 0) return false; // clock skew defence — treat as stale

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -568,6 +568,7 @@ import {
   clearCleanShutdownMarker,
   shouldSuppressRecoveryBanner,
   shouldSuppressBootResume,
+  parseBootResumeMode,
   resolveShutdownMarker,
   DEFAULT_MAX_AGE_MS as CLEAN_SHUTDOWN_MAX_AGE_MS,
 } from './clean-shutdown-marker.js'
@@ -684,7 +685,8 @@ import {
 import {
   buildResumeInterruptedInbound,
   buildResumeWatchdogReportInbound,
-  selectResumeBuilder,
+  buildResumeDeferredReportInbound,
+  decideBootResumeKind,
 } from './resume-inbound-builder.js'
 import { applySubagentsSchema, getSubagentByJsonlId, resolveSubagentOriginTurnKey } from '../registry/subagents-schema.js'
 import { resolveWorkerFeedDispatch, type WorkerFeedDispatch } from './worker-feed-dispatch.js'
@@ -1497,70 +1499,98 @@ try {
   const pending = findLatestTurnIfInterrupted(turnsDb)
   const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? ''
   if (pending != null && selfAgent) {
-    // Clean-shutdown gate: suppress auto-resume when the prior shutdown was
-    // operator/roll/CLI-initiated (clean). A clean-shutdown marker present and
-    // fresh means the agent was asked to stop; the "interrupted" turn was
-    // abandoned by that decision. Replaying it on every planned restart wastes
-    // subscription quota for no user benefit. Only unclean exits (crash/OOM/
-    // unexpected kill) should auto-resume.
+    // Boot-resume policy (2026-07, superseding #2585). The block only runs
+    // when `pending` exists — i.e. there IS genuinely in-flight work. The
+    // product decision is that a DELIBERATE restart must not silently drop
+    // that work: `session_continuity.boot_resume` (SWITCHROOM_BOOT_RESUME,
+    // default 'in-flight') resumes it even after a clean shutdown. #2585's
+    // quota-saving posture survives only as the opt-in 'never' mode — and
+    // even then we deliver a passive REPORT, never silence, because the user
+    // must always be told when in-flight work stopped.
     //
     // NOTE: GATEWAY_CLEAN_SHUTDOWN_MARKER_PATH is defined lower in this file
     // (module-init order); we compute the path inline here using the same
     // formula so we can read it at boot-resume time.
-    // SWITCHROOM_BOOT_RESUME_ALWAYS=1 is an escape hatch that restores
-    // unconditional resume if needed.
+    // SWITCHROOM_BOOT_RESUME_ALWAYS=1 remains a back-compat escape hatch that
+    // forces unconditional resume regardless of mode.
     const bootResumeMarkerPath =
       process.env.SWITCHROOM_GATEWAY_CLEAN_SHUTDOWN_MARKER ?? join(STATE_DIR, 'clean-shutdown.json')
     const bootResumeCleanMarker = readCleanShutdownMarker(bootResumeMarkerPath)
     const bootResumeForceAlways = process.env.SWITCHROOM_BOOT_RESUME_ALWAYS === '1'
+    const bootResumeMode = parseBootResumeMode(process.env.SWITCHROOM_BOOT_RESUME)
     const bootResumeSuppressed = shouldSuppressBootResume(bootResumeCleanMarker, Date.now(), {
       forceAlways: bootResumeForceAlways,
+      mode: bootResumeMode,
     })
-    if (bootResumeSuppressed) {
+
+    // 3h staleness failsafe (operator spec, 2026-06-03): never AUTO-resume
+    // interrupted work older than RESUME_MAX_AGE_MS — selectResumeBuilder
+    // downgrades a stale 'resume' to the passive 'report'. Env override
+    // SWITCHROOM_RESUME_MAX_AGE_MS (ms); set very high to disable.
+    const RESUME_MAX_AGE_MS = (() => {
+      const v = Number(process.env.SWITCHROOM_RESUME_MAX_AGE_MS)
+      return Number.isFinite(v) && v > 0 ? v : 10_800_000 // 3h
+    })()
+
+    // Decide the inbound kind (pure — see decideBootResumeKind). Precedence:
+    //   1. loop-guard  → 'defer-loop'       (never a second resume of a resume)
+    //   2. suppressed  → 'defer-suppressed' (boot_resume: never; notice, not silence)
+    //   3. otherwise   → selectResumeBuilder (resume | report | none)
+    const bootResumeKind = decideBootResumeKind({
+      pending,
+      suppressed: bootResumeSuppressed,
+      ageMs: Math.max(0, Date.now() - pending.started_at),
+      maxAgeMs: RESUME_MAX_AGE_MS,
+    })
+
+    if (bootResumeKind === 'resume') {
+      bootResumeInbound = { agent: selfAgent, msg: buildResumeInterruptedInbound({ turn: pending }) }
+    } else if (bootResumeKind === 'report') {
+      // idleMs: this boot's measured marker age if it just classified this
+      // turn; otherwise recover it from the persisted interrupt_reason (a
+      // later boot, marker already swept); else fall back to total runtime.
+      let idleMs = pending.turn_key === timeoutTurnKey && markerAgeMs != null ? markerAgeMs : null
+      if (idleMs == null && pending.interrupt_reason) {
+        try {
+          const parsed = JSON.parse(pending.interrupt_reason) as { idleMs?: unknown }
+          if (typeof parsed.idleMs === 'number' && Number.isFinite(parsed.idleMs)) idleMs = parsed.idleMs
+        } catch { /* malformed snapshot — fall through */ }
+      }
+      if (idleMs == null) idleMs = Math.max(0, Date.now() - pending.started_at)
+      bootResumeInbound = {
+        agent: selfAgent,
+        msg: buildResumeWatchdogReportInbound({ turn: pending, idleMs }),
+      }
+    } else if (bootResumeKind === 'defer-loop' || bootResumeKind === 'defer-suppressed') {
+      // Passive deferred-report: work was in flight but we decline to
+      // auto-resume (loop-guard, or boot_resume:never). Silence is never
+      // acceptable here — tell the user what was in flight and ask.
+      bootResumeInbound = {
+        agent: selfAgent,
+        msg: buildResumeDeferredReportInbound({
+          turn: pending,
+          reason: bootResumeKind === 'defer-loop' ? 'loop-guard' : 'clean-restart-suppressed',
+        }),
+      }
+    }
+
+    if (bootResumeKind === 'defer-suppressed') {
       process.stderr.write(
         `telegram gateway: boot-resume suppressed (clean shutdown` +
         `${bootResumeCleanMarker?.reason ? ` reason=${JSON.stringify(bootResumeCleanMarker.reason)}` : ''}` +
-        `) — unclean exits still resume turnKey=${pending.turn_key}\n`,
+        `, mode=${bootResumeMode}) — passive report delivered for turnKey=${pending.turn_key}\n`,
       )
-    } else {
-      // 3h staleness failsafe (operator spec, 2026-06-03): never AUTO-resume
-      // interrupted work older than RESUME_MAX_AGE_MS — selectResumeBuilder
-      // downgrades a stale 'resume' to the passive 'report' so the user is told
-      // ("I was working on X ~Nh ago") but nothing replays unprompted. Env
-      // override SWITCHROOM_RESUME_MAX_AGE_MS (ms); set very high to disable.
-      const RESUME_MAX_AGE_MS = (() => {
-        const v = Number(process.env.SWITCHROOM_RESUME_MAX_AGE_MS)
-        return Number.isFinite(v) && v > 0 ? v : 10_800_000 // 3h
-      })()
-      const kind = selectResumeBuilder(pending.ended_via, {
-        ageMs: Math.max(0, Date.now() - pending.started_at),
-        maxAgeMs: RESUME_MAX_AGE_MS,
-      })
-      if (kind === 'resume') {
-        bootResumeInbound = { agent: selfAgent, msg: buildResumeInterruptedInbound({ turn: pending }) }
-      } else if (kind === 'report') {
-        // idleMs: this boot's measured marker age if it just classified this
-        // turn; otherwise recover it from the persisted interrupt_reason (a
-        // later boot, marker already swept); else fall back to total runtime.
-        let idleMs = pending.turn_key === timeoutTurnKey && markerAgeMs != null ? markerAgeMs : null
-        if (idleMs == null && pending.interrupt_reason) {
-          try {
-            const parsed = JSON.parse(pending.interrupt_reason) as { idleMs?: unknown }
-            if (typeof parsed.idleMs === 'number' && Number.isFinite(parsed.idleMs)) idleMs = parsed.idleMs
-          } catch { /* malformed snapshot — fall through */ }
-        }
-        if (idleMs == null) idleMs = Math.max(0, Date.now() - pending.started_at)
-        bootResumeInbound = {
-          agent: selfAgent,
-          msg: buildResumeWatchdogReportInbound({ turn: pending, idleMs }),
-        }
-      }
-      if (bootResumeInbound != null) {
-        process.stderr.write(
-          `telegram gateway: boot-resume queued kind=${kind} turnKey=${pending.turn_key} ` +
-          `endedVia=${pending.ended_via ?? 'open'} chat=${pending.chat_id}\n`,
-        )
-      }
+    } else if (bootResumeKind === 'defer-loop') {
+      process.stderr.write(
+        `telegram gateway: boot-resume loop-guard tripped (interrupted turn was itself a resume) ` +
+        `— passive report delivered instead of re-resuming turnKey=${pending.turn_key}\n`,
+      )
+    }
+    if (bootResumeInbound != null) {
+      process.stderr.write(
+        `telegram gateway: boot-resume queued kind=${bootResumeKind} mode=${bootResumeMode} ` +
+        `turnKey=${pending.turn_key} endedVia=${pending.ended_via ?? 'open'} chat=${pending.chat_id}\n`,
+      )
     }
   }
 

--- a/telegram-plugin/gateway/inbound-spool.ts
+++ b/telegram-plugin/gateway/inbound-spool.ts
@@ -88,7 +88,8 @@ export function spoolId(msg: InboundMessage): string {
   // given turn can only be one or the other.
   if (
     (msg.meta?.source === 'resume_interrupted' ||
-      msg.meta?.source === 'resume_watchdog_timeout') &&
+      msg.meta?.source === 'resume_watchdog_timeout' ||
+      msg.meta?.source === 'resume_deferred') &&
     typeof msg.meta?.resume_turn_key === 'string' &&
     msg.meta.resume_turn_key.length > 0
   ) {

--- a/telegram-plugin/gateway/resume-inbound-builder.ts
+++ b/telegram-plugin/gateway/resume-inbound-builder.ts
@@ -57,6 +57,36 @@ export interface ResumeInboundContext {
   nowMs?: number
 }
 
+/**
+ * Machine-stable leading token shared by EVERY synthetic boot inbound this
+ * module mints (resume, watchdog-report, deferred-report). It is the anchor
+ * the loop-guard keys on: a turn whose `user_prompt_preview` starts with
+ * this string was itself started by a synthetic boot inbound, so building
+ * ANOTHER resume for it would replay already-resumed work and could chain
+ * unboundedly across repeated restarts.
+ *
+ * `extractUserPromptPreview` strips the `<channel …>` wrapper before storing
+ * the preview, so the stored text begins with this prose prefix (not the
+ * `meta.source` attribute, which the preview drops). Every builder below
+ * MUST keep this as the first characters of its `text`; `resume-inbound-
+ * builder.test.ts` pins that contract so a prose edit can't silently break
+ * the loop-guard.
+ */
+export const RESUME_SYNTHETIC_PROMPT_PREFIX = 'You just restarted.'
+
+/**
+ * Loop-guard predicate: was this interrupted turn ITSELF started by one of
+ * this module's synthetic boot inbounds? Detected via the stored
+ * `user_prompt_preview` prefix. Used at boot to cap the auto-resume chain at
+ * depth 1 — a resume turn that is itself interrupted is NOT re-resumed
+ * (which would double-execute the resumed side effects and could loop
+ * forever); the caller downgrades to a passive deferred-report instead.
+ */
+export function isResumeSyntheticTurn(turn: Turn): boolean {
+  const p = turn.user_prompt_preview
+  return typeof p === 'string' && p.startsWith(RESUME_SYNTHETIC_PROMPT_PREFIX)
+}
+
 function threadIdNum(turn: Turn): number | undefined {
   if (turn.thread_id == null) return undefined
   const n = Number(turn.thread_id)
@@ -191,6 +221,121 @@ export function buildResumeWatchdogReportInbound(
       `whether they want you to retry it or take a different angle. Report ` +
       `only the honest cause — no observable progress for that long — don't ` +
       `speculate about a deeper root cause you can't see.`,
+    meta,
+  }
+}
+
+/** Why an auto-resume was declined in favour of a passive notice. */
+export type ResumeDeferReason = 'clean-restart-suppressed' | 'loop-guard'
+
+/**
+ * The inbound the boot-resume block should mint for an interrupted turn:
+ *   - 'resume'           → active resume (buildResumeInterruptedInbound)
+ *   - 'report'           → watchdog report (buildResumeWatchdogReportInbound)
+ *   - 'defer-loop'       → loop-guard passive notice (deferred-report)
+ *   - 'defer-suppressed' → boot_resume:never passive notice (deferred-report)
+ *   - null               → nothing (turn finished cleanly)
+ */
+export type BootResumeKind = 'resume' | 'report' | 'defer-loop' | 'defer-suppressed' | null
+
+/**
+ * Pure boot-resume decision, extracted from the gateway so the precedence
+ * (esp. the bounded resume-chain loop-guard) is unit-testable without
+ * booting a gateway. Precedence, highest first:
+ *
+ *   1. loop-guard — the interrupted turn was ITSELF a synthetic resume/report
+ *      turn (`isResumeSyntheticTurn`). NEVER mint another resume for it: that
+ *      would replay already-partly-executed work and could chain
+ *      restart→resume→restart forever. The at-most-once `resumed_at` ledger
+ *      bounds each individual turn, but each resume spawns a NEW turn, so
+ *      without this the CHAIN is unbounded. Cap it at one auto-resume by
+ *      downgrading to a passive deferred-report ('defer-loop').
+ *   2. suppressed — `boot_resume: never` on a fresh clean restart. Downgrade
+ *      to a passive deferred-report ('defer-suppressed') — a notice, never
+ *      silence.
+ *   3. otherwise — the normal age/ended_via policy (`selectResumeBuilder`).
+ */
+export function decideBootResumeKind(args: {
+  pending: Turn
+  suppressed: boolean
+  ageMs: number
+  maxAgeMs: number
+}): BootResumeKind {
+  if (isResumeSyntheticTurn(args.pending)) return 'defer-loop'
+  if (args.suppressed) return 'defer-suppressed'
+  return selectResumeBuilder(args.pending.ended_via, {
+    ageMs: args.ageMs,
+    maxAgeMs: args.maxAgeMs,
+  })
+}
+
+/**
+ * Build the `resume_deferred` inbound — a passive notice delivered when the
+ * framework declines to AUTO-resume interrupted work but must NOT stay
+ * silent (silence when work was in flight is never acceptable). Two reasons:
+ *
+ *   - 'clean-restart-suppressed' — `session_continuity.boot_resume: never`
+ *     is set and the prior shutdown was a fresh, deliberate restart. Per
+ *     that opt-in posture we don't replay the work unprompted, but we still
+ *     tell the user what was in flight so they can ask us to continue.
+ *
+ *   - 'loop-guard' — the interrupted turn was ITSELF a synthetic resume/
+ *     report turn (see `isResumeSyntheticTurn`). Auto-resuming a resume that
+ *     was interrupted again risks an unbounded restart→resume→restart chain
+ *     and double-executed side effects, so we cap the chain: report instead
+ *     of resuming, and let the user decide whether to keep going.
+ *
+ * Like the watchdog report, this is a REPORT (source `resume_deferred`), not
+ * a resume: the agent must not silently pick the work back up. The text
+ * starts with RESUME_SYNTHETIC_PROMPT_PREFIX so a further restart during
+ * THIS turn is itself detected as a synthetic turn and stays capped.
+ */
+export function buildResumeDeferredReportInbound(
+  ctx: ResumeInboundContext & { reason: ResumeDeferReason },
+): InboundMessage {
+  const ts = ctx.nowMs ?? Date.now()
+  const elapsed = humanizeElapsed(ts - ctx.turn.started_at)
+  const threadId = threadIdNum(ctx.turn)
+  const meta: Record<string, string> = {
+    source: 'resume_deferred',
+    // Origin chat/topic as channel attributes so the report turn gets a
+    // currentTurn (progress card + silence-poke) and the notice lands in the
+    // topic the work lived in. Same rationale as the other builders.
+    chat_id: ctx.turn.chat_id,
+    ...(threadId != null ? { message_thread_id: String(threadId) } : {}),
+    resume_turn_key: ctx.turn.turn_key,
+    interrupted_via: ctx.turn.ended_via ?? 'restart',
+    defer_reason: ctx.reason,
+    started_at: String(ctx.turn.started_at),
+  }
+  if (ctx.turn.user_prompt_preview) meta.original_prompt = ctx.turn.user_prompt_preview
+  const cause =
+    ctx.reason === 'loop-guard'
+      ? `Your previous turn was ALREADY a resume of earlier interrupted work, ` +
+        `and it was interrupted again by another restart ${elapsed} ago. To ` +
+        `avoid an endless restart→resume loop (and re-running work that may ` +
+        `have already partly executed), the framework has stopped ` +
+        `auto-resuming this chain.`
+      : `Your previous turn was interrupted ${elapsed} ago by a deliberate ` +
+        `restart, before it finished. This agent is configured NOT to ` +
+        `auto-resume work across deliberate restarts (boot_resume: never), so ` +
+        `it was not replayed automatically.`
+  return {
+    type: 'inbound',
+    chatId: ctx.turn.chat_id,
+    ...(threadId != null ? { threadId } : {}),
+    messageId: ts,
+    user: 'switchroom',
+    userId: 0,
+    ts,
+    text:
+      `${RESUME_SYNTHETIC_PROMPT_PREFIX} ${cause}` +
+      promptClause(ctx.turn) +
+      ` Do NOT silently resume it. Instead, briefly tell the user what was in ` +
+      `flight (call get_recent_messages for this chat if you need the full ` +
+      `original request — the quoted preview is only the first ~200 ` +
+      `characters), then ask whether they want you to pick it back up or drop ` +
+      `it. If you genuinely can't tell what the work was, say so and ask.`,
     meta,
   }
 }

--- a/telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts
+++ b/telegram-plugin/tests/gateway-clean-shutdown-marker.test.ts
@@ -36,6 +36,7 @@ import {
   clearCleanShutdownMarker,
   shouldSuppressRecoveryBanner,
   shouldSuppressBootResume,
+  parseBootResumeMode,
   resolveShutdownMarker,
   DEFAULT_MAX_AGE_MS,
   EXTERNAL_RESTART_FALLBACK_REASON,
@@ -350,77 +351,117 @@ describe("resolveShutdownMarker (SIGTERM-handler sequencing)", () => {
 // ---------------------------------------------------------------------------
 
 describe("shouldSuppressBootResume", () => {
-  // Core contract: clean shutdown (fresh marker) → suppress; crash (no marker
-  // or stale) → do not suppress; forceAlways override → never suppress.
+  // Product decision 2026-07 (supersedes #2585): the DEFAULT mode is
+  // 'in-flight' — a genuinely in-flight turn resumes even after a clean /
+  // deliberate restart, so a fresh clean marker NO LONGER suppresses by
+  // default. Suppression survives only as the opt-in 'never' mode.
 
-  it("returns false when no marker is present (crash/OOM — resume as before)", () => {
-    expect(shouldSuppressBootResume(null, Date.now())).toBe(false);
-  });
-
-  it("returns true for a fresh clean-shutdown marker (operator/roll restart — suppress)", () => {
+  it("DEFAULT (in-flight): fresh clean marker does NOT suppress — in-flight work resumes", () => {
+    // This is the core regression fix: a deliberate restart landing mid-turn
+    // must not silently drop the work.
     const now = 1_700_000_000_000;
     const marker: CleanShutdownMarker = { ts: now - 5_000, signal: "SIGTERM" };
-    expect(shouldSuppressBootResume(marker, now)).toBe(true);
+    expect(shouldSuppressBootResume(marker, now)).toBe(false);
+    // Explicit 'in-flight' behaves identically to the default.
+    expect(shouldSuppressBootResume(marker, now, { mode: "in-flight" })).toBe(false);
   });
 
-  it("returns true at age=0 (marker written right before boot)", () => {
+  it("mode 'never': returns false when no marker is present (crash/OOM — resume)", () => {
+    expect(shouldSuppressBootResume(null, Date.now(), { mode: "never" })).toBe(false);
+  });
+
+  it("mode 'never': returns true for a fresh clean-shutdown marker (suppress)", () => {
+    const now = 1_700_000_000_000;
+    const marker: CleanShutdownMarker = { ts: now - 5_000, signal: "SIGTERM" };
+    expect(shouldSuppressBootResume(marker, now, { mode: "never" })).toBe(true);
+  });
+
+  it("mode 'never': returns true at age=0 (marker written right before boot)", () => {
     const now = 1_700_000_000_000;
     const marker: CleanShutdownMarker = { ts: now, signal: "SIGTERM" };
-    expect(shouldSuppressBootResume(marker, now)).toBe(true);
+    expect(shouldSuppressBootResume(marker, now, { mode: "never" })).toBe(true);
   });
 
-  it("returns false when marker age equals maxAgeMs (boundary is exclusive)", () => {
+  it("mode 'never': false when marker age equals maxAgeMs (boundary is exclusive)", () => {
     const now = 1_700_000_000_000;
     const marker: CleanShutdownMarker = { ts: now - DEFAULT_MAX_AGE_MS, signal: "SIGTERM" };
-    expect(shouldSuppressBootResume(marker, now)).toBe(false);
+    expect(shouldSuppressBootResume(marker, now, { mode: "never" })).toBe(false);
   });
 
-  it("returns false for a stale marker (drain took >60s — treat as crash)", () => {
+  it("mode 'never': false for a stale marker (drain took >60s — slow rollout resumes)", () => {
+    // Preserves the ">60s already resumes" behaviour even under 'never'.
     const now = 1_700_000_000_000;
     const marker: CleanShutdownMarker = { ts: now - 90_000, signal: "SIGTERM" };
-    expect(shouldSuppressBootResume(marker, now)).toBe(false);
+    expect(shouldSuppressBootResume(marker, now, { mode: "never" })).toBe(false);
   });
 
-  it("treats clock skew (future ts) as stale to avoid false suppression", () => {
+  it("mode 'never': treats clock skew (future ts) as stale to avoid false suppression", () => {
     const now = 1_700_000_000_000;
     const marker: CleanShutdownMarker = { ts: now + 10_000, signal: "SIGTERM" };
-    expect(shouldSuppressBootResume(marker, now)).toBe(false);
+    expect(shouldSuppressBootResume(marker, now, { mode: "never" })).toBe(false);
   });
 
-  it("respects a custom maxAgeMs", () => {
+  it("mode 'never': respects a custom maxAgeMs", () => {
     const now = 1_700_000_000_000;
     const marker: CleanShutdownMarker = { ts: now - 30_000, signal: "SIGTERM" };
-    expect(shouldSuppressBootResume(marker, now, { maxAgeMs: 60_000 })).toBe(true);
-    expect(shouldSuppressBootResume(marker, now, { maxAgeMs: 10_000 })).toBe(false);
+    expect(shouldSuppressBootResume(marker, now, { mode: "never", maxAgeMs: 60_000 })).toBe(true);
+    expect(shouldSuppressBootResume(marker, now, { mode: "never", maxAgeMs: 10_000 })).toBe(false);
   });
 
-  it("forceAlways=true disables suppression even for a fresh clean marker (escape hatch)", () => {
+  it("forceAlways=true disables suppression even under 'never' + fresh marker (escape hatch)", () => {
     // SWITCHROOM_BOOT_RESUME_ALWAYS=1 must restore unconditional resume.
     const now = 1_700_000_000_000;
     const marker: CleanShutdownMarker = { ts: now - 1_000, signal: "SIGTERM" };
-    expect(shouldSuppressBootResume(marker, now, { forceAlways: true })).toBe(false);
+    expect(shouldSuppressBootResume(marker, now, { mode: "never", forceAlways: true })).toBe(false);
   });
 
-  it("forceAlways=false has no effect (default behaviour is the gate)", () => {
+  it("mode 'always': never suppresses, even with a fresh clean marker", () => {
     const now = 1_700_000_000_000;
     const marker: CleanShutdownMarker = { ts: now - 1_000, signal: "SIGTERM" };
-    expect(shouldSuppressBootResume(marker, now, { forceAlways: false })).toBe(true);
+    expect(shouldSuppressBootResume(marker, now, { mode: "always" })).toBe(false);
   });
 
-  it("works for SIGTERM and SIGINT (signal value is opaque)", () => {
+  it("mode 'never': works for SIGTERM and SIGINT (signal value is opaque)", () => {
     const now = 1_700_000_000_000;
-    expect(shouldSuppressBootResume({ ts: now, signal: "SIGTERM" }, now)).toBe(true);
-    expect(shouldSuppressBootResume({ ts: now, signal: "SIGINT" }, now)).toBe(true);
+    expect(shouldSuppressBootResume({ ts: now, signal: "SIGTERM" }, now, { mode: "never" })).toBe(true);
+    expect(shouldSuppressBootResume({ ts: now, signal: "SIGINT" }, now, { mode: "never" })).toBe(true);
   });
 
-  it("works with a marker that carries a reason field (rollout attribution is preserved)", () => {
+  it("mode 'never': works with a marker that carries a reason field", () => {
     const now = 1_700_000_000_000;
     const marker: CleanShutdownMarker = {
       ts: now - 2_000,
       signal: "SIGTERM",
       reason: "operator: switchroom update",
     };
-    expect(shouldSuppressBootResume(marker, now)).toBe(true);
+    expect(shouldSuppressBootResume(marker, now, { mode: "never" })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Boot-resume mode parsing
+// ---------------------------------------------------------------------------
+
+describe("parseBootResumeMode", () => {
+  it("defaults to 'in-flight' for undefined/null/empty/unknown", () => {
+    expect(parseBootResumeMode(undefined)).toBe("in-flight");
+    expect(parseBootResumeMode(null)).toBe("in-flight");
+    expect(parseBootResumeMode("")).toBe("in-flight");
+    expect(parseBootResumeMode("bogus")).toBe("in-flight");
+  });
+
+  it("parses the three canonical values", () => {
+    expect(parseBootResumeMode("always")).toBe("always");
+    expect(parseBootResumeMode("in-flight")).toBe("in-flight");
+    expect(parseBootResumeMode("never")).toBe("never");
+  });
+
+  it("is case- and separator-insensitive", () => {
+    expect(parseBootResumeMode("ALWAYS")).toBe("always");
+    expect(parseBootResumeMode("In-Flight")).toBe("in-flight");
+    expect(parseBootResumeMode("in_flight")).toBe("in-flight");
+    expect(parseBootResumeMode("inflight")).toBe("in-flight");
+    expect(parseBootResumeMode("  never  ")).toBe("never");
   });
 });
 
@@ -446,9 +487,14 @@ describe("gateway.ts boot-resume clean-shutdown gate (source-level)", () => {
     expect(gatewaySource).toContain("readCleanShutdownMarker(bootResumeMarkerPath)");
   });
 
-  it("calls shouldSuppressBootResume with the marker, now, and forceAlways", () => {
+  it("calls shouldSuppressBootResume with the marker, now, forceAlways, and mode", () => {
     expect(gatewaySource).toContain("shouldSuppressBootResume(bootResumeCleanMarker, Date.now()");
     expect(gatewaySource).toContain("forceAlways: bootResumeForceAlways");
+    expect(gatewaySource).toContain("mode: bootResumeMode");
+  });
+
+  it("parses the boot-resume mode from SWITCHROOM_BOOT_RESUME", () => {
+    expect(gatewaySource).toContain("parseBootResumeMode(process.env.SWITCHROOM_BOOT_RESUME)");
   });
 
   it("provides the SWITCHROOM_BOOT_RESUME_ALWAYS escape hatch", () => {
@@ -458,6 +504,18 @@ describe("gateway.ts boot-resume clean-shutdown gate (source-level)", () => {
 
   it("logs a diagnostic when boot-resume is suppressed", () => {
     expect(gatewaySource).toContain("boot-resume suppressed (clean shutdown");
+  });
+
+  it("still delivers a passive report (never silence) when resume is suppressed", () => {
+    // Requirement: silence is never acceptable when work was in flight.
+    // The suppressed path builds a deferred-report inbound, not nothing.
+    expect(gatewaySource).toContain("defer-suppressed");
+    expect(gatewaySource).toContain("buildResumeDeferredReportInbound");
+  });
+
+  it("caps the resume chain with a loop-guard (no unbounded resume-of-resume)", () => {
+    expect(gatewaySource).toContain("decideBootResumeKind");
+    expect(gatewaySource).toContain("defer-loop");
   });
 });
 

--- a/telegram-plugin/tests/resume-inbound-builder.test.ts
+++ b/telegram-plugin/tests/resume-inbound-builder.test.ts
@@ -18,7 +18,11 @@ import {
   humanizeElapsed,
   buildResumeInterruptedInbound,
   buildResumeWatchdogReportInbound,
+  buildResumeDeferredReportInbound,
+  isResumeSyntheticTurn,
   selectResumeBuilder,
+  decideBootResumeKind,
+  RESUME_SYNTHETIC_PROMPT_PREFIX,
 } from '../gateway/resume-inbound-builder.js'
 import type { Turn, TurnEndedVia } from '../registry/turns-schema.js'
 
@@ -241,5 +245,136 @@ describe('selectResumeBuilder', () => {
   it('legacy behaviour preserved when age/maxAge omitted (blanket resume)', () => {
     expect(selectResumeBuilder('restart')).toBe('resume')
     expect(selectResumeBuilder('restart', { ageMs: MAX + 1 })).toBe('resume') // needs BOTH to cap
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Loop-guard: RESUME_SYNTHETIC_PROMPT_PREFIX / isResumeSyntheticTurn
+// ---------------------------------------------------------------------------
+
+describe('resume synthetic-turn detection (loop-guard anchor)', () => {
+  it('EVERY synthetic boot inbound text starts with the machine-stable prefix', () => {
+    // The loop-guard keys on this prefix landing in user_prompt_preview, so if
+    // a prose edit drops it the chain-cap silently breaks. Pin it here.
+    const turn = makeTurn({ user_prompt_preview: 'do the thing' })
+    expect(buildResumeInterruptedInbound({ turn }).text.startsWith(RESUME_SYNTHETIC_PROMPT_PREFIX)).toBe(true)
+    expect(
+      buildResumeWatchdogReportInbound({ turn: makeTurn({ ended_via: 'timeout' }), idleMs: 1000 }).text.startsWith(
+        RESUME_SYNTHETIC_PROMPT_PREFIX,
+      ),
+    ).toBe(true)
+    expect(
+      buildResumeDeferredReportInbound({ turn, reason: 'loop-guard' }).text.startsWith(
+        RESUME_SYNTHETIC_PROMPT_PREFIX,
+      ),
+    ).toBe(true)
+    expect(
+      buildResumeDeferredReportInbound({ turn, reason: 'clean-restart-suppressed' }).text.startsWith(
+        RESUME_SYNTHETIC_PROMPT_PREFIX,
+      ),
+    ).toBe(true)
+  })
+
+  it('isResumeSyntheticTurn is true for a turn whose preview is a synthetic prompt', () => {
+    const synthetic = buildResumeInterruptedInbound({ turn: makeTurn() })
+    // A resume turn stores the first ~200 chars of the synthetic text as its
+    // preview (channel wrapper stripped) — simulate that.
+    const resumeTurn = makeTurn({ user_prompt_preview: synthetic.text.slice(0, 200) })
+    expect(isResumeSyntheticTurn(resumeTurn)).toBe(true)
+  })
+
+  it('isResumeSyntheticTurn is false for real user work and for null preview', () => {
+    expect(isResumeSyntheticTurn(makeTurn({ user_prompt_preview: 'refactor the auth module' }))).toBe(false)
+    expect(isResumeSyntheticTurn(makeTurn({ user_prompt_preview: null }))).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildResumeDeferredReportInbound
+// ---------------------------------------------------------------------------
+
+describe('buildResumeDeferredReportInbound', () => {
+  it('emits source=resume_deferred and carries the dedup anchor + reason', () => {
+    const turn = makeTurn({ turn_key: 'zz:3' })
+    const msg = buildResumeDeferredReportInbound({ turn, reason: 'loop-guard' })
+    expect(msg.meta.source).toBe('resume_deferred')
+    expect(msg.meta.resume_turn_key).toBe('zz:3')
+    expect(msg.meta.defer_reason).toBe('loop-guard')
+  })
+
+  it('loop-guard framing tells the model the chain was capped, not to resume', () => {
+    const msg = buildResumeDeferredReportInbound({ turn: makeTurn(), reason: 'loop-guard' })
+    expect(msg.text.toLowerCase()).toContain('resume of earlier interrupted work')
+    expect(msg.text).toContain('Do NOT silently resume')
+  })
+
+  it('clean-restart-suppressed framing cites boot_resume: never', () => {
+    const msg = buildResumeDeferredReportInbound({ turn: makeTurn(), reason: 'clean-restart-suppressed' })
+    expect(msg.text).toContain('boot_resume: never')
+    expect(msg.text).toContain('Do NOT silently resume')
+  })
+
+  it('routes to the origin thread when the turn carried one', () => {
+    const turn = makeTurn({ chat_id: '-100999', thread_id: '77' })
+    const msg = buildResumeDeferredReportInbound({ turn, reason: 'loop-guard' })
+    expect(msg.chatId).toBe('-100999')
+    expect(msg.threadId).toBe(77)
+    expect(msg.meta.message_thread_id).toBe('77')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// decideBootResumeKind — boot-resume precedence + bounded resume chain
+// ---------------------------------------------------------------------------
+
+describe('decideBootResumeKind', () => {
+  const MAX = 10_800_000 // 3h
+
+  it('resumes genuinely in-flight work after a deliberate restart (not suppressed)', () => {
+    // The core product fix: clean restart mid-turn → resume, not silence.
+    const pending = makeTurn({ ended_via: 'restart', user_prompt_preview: 'ship the release' })
+    expect(decideBootResumeKind({ pending, suppressed: false, ageMs: 1000, maxAgeMs: MAX })).toBe('resume')
+  })
+
+  it("boot_resume:never (suppressed) → 'defer-suppressed' passive report, never silence", () => {
+    const pending = makeTurn({ ended_via: 'restart', user_prompt_preview: 'ship the release' })
+    expect(decideBootResumeKind({ pending, suppressed: true, ageMs: 1000, maxAgeMs: MAX })).toBe('defer-suppressed')
+  })
+
+  it('watchdog timeout still reports even when not suppressed', () => {
+    const pending = makeTurn({ ended_via: 'timeout', user_prompt_preview: 'ship the release' })
+    expect(decideBootResumeKind({ pending, suppressed: false, ageMs: 1000, maxAgeMs: MAX })).toBe('report')
+  })
+
+  it('BOUNDED CHAIN: a restart DURING a resume turn does NOT re-resume — loop-guard fires', () => {
+    // Simulate the chain the coordinator flagged:
+    //   A: real work, interrupted → resume R1 (turn B created from R1's text)
+    //   restart lands during B → pending is B, whose preview IS the synthetic
+    //   resume prompt. We must NOT mint a second resume (endless loop risk).
+    const r1 = buildResumeInterruptedInbound({ turn: makeTurn({ user_prompt_preview: 'real work' }) })
+    const turnB = makeTurn({ ended_via: 'restart', user_prompt_preview: r1.text.slice(0, 200) })
+    // Even though NOT suppressed (would normally resume), the loop-guard wins:
+    expect(decideBootResumeKind({ pending: turnB, suppressed: false, ageMs: 1000, maxAgeMs: MAX })).toBe('defer-loop')
+  })
+
+  it('BOUNDED CHAIN: a restart during a deferred-report turn stays capped (still defer-loop, never resume)', () => {
+    // Depth does not grow: a report-of-report is still a passive report, never
+    // a resume — so no unbounded restart→resume→restart chain can form.
+    const deferred = buildResumeDeferredReportInbound({ turn: makeTurn(), reason: 'loop-guard' })
+    const turnC = makeTurn({ ended_via: 'restart', user_prompt_preview: deferred.text.slice(0, 200) })
+    const kind = decideBootResumeKind({ pending: turnC, suppressed: false, ageMs: 1000, maxAgeMs: MAX })
+    expect(kind).toBe('defer-loop')
+    expect(kind).not.toBe('resume')
+  })
+
+  it('loop-guard takes precedence over suppression too (synthetic turn never resumes or double-reports as resume)', () => {
+    const r1 = buildResumeInterruptedInbound({ turn: makeTurn() })
+    const turnB = makeTurn({ ended_via: 'restart', user_prompt_preview: r1.text.slice(0, 200) })
+    expect(decideBootResumeKind({ pending: turnB, suppressed: true, ageMs: 1000, maxAgeMs: MAX })).toBe('defer-loop')
+  })
+
+  it('stale in-flight work downgrades to report when older than maxAgeMs', () => {
+    const pending = makeTurn({ ended_via: 'restart', user_prompt_preview: 'stale work' })
+    expect(decideBootResumeKind({ pending, suppressed: false, ageMs: MAX + 1, maxAgeMs: MAX })).toBe('report')
   })
 })

--- a/tests/scaffold.gateway-env-order.test.ts
+++ b/tests/scaffold.gateway-env-order.test.ts
@@ -94,6 +94,22 @@ describe("start.sh: gateway-consumed env exported before the gateway fork", () =
     expect(nameIdx).toBeLessThan(forkIdx);
   });
 
+  it("hoists SWITCHROOM_BOOT_RESUME AHEAD of the gateway fork so the boot-resume policy reaches the daemon", () => {
+    const startSh = renderStartSh();
+    const forkIdx = startSh.indexOf(GATEWAY_FORK);
+    expect(forkIdx).toBeGreaterThan(-1);
+
+    const bootResumeIdx = startSh.indexOf("export SWITCHROOM_BOOT_RESUME=");
+    expect(bootResumeIdx).toBeGreaterThan(-1);
+    // The gateway reads SWITCHROOM_BOOT_RESUME at boot-resume time; if it were
+    // exported only after the fork (like SWITCHROOM_RESUME_MODE, which drives
+    // the inner claude --continue path), the daemon would never see it and
+    // every agent would silently default.
+    expect(bootResumeIdx).toBeLessThan(forkIdx);
+    // Default value when session_continuity.boot_resume is unset.
+    expect(startSh).toContain('export SWITCHROOM_BOOT_RESUME="in-flight"');
+  });
+
   it("still re-exports the same vars in the inner pass (after the fork) for claude", () => {
     const startSh = renderStartSh();
     const forkIdx = startSh.indexOf(GATEWAY_FORK);


### PR DESCRIPTION
## What & why

Deliberate restarts (operator `agent restart`, rollouts, `systemctl restart`, hostd `agent_restart`) that landed **mid-turn** were **silently dropping the in-flight work**. PR #2585's clean-shutdown gate suppressed BOTH the resume AND the passive report whenever a fresh clean-shutdown marker was present — but the boot-resume block only ever runs when a *pending interrupted turn* exists, so in practice it was swallowing real in-flight work, not the "deliberately abandoned turn" case #2585 was aimed at (which is a no-op — nothing to resume).

**User-facing outcome: deliberate restarts no longer silently drop in-flight work.** A sanctioned restart that interrupts a turn now resumes that turn (or, in the opt-in quota-saving mode, tells the user what was in flight). Silence is never used when work was in flight.

## Changes

- **New config surface `session_continuity.boot_resume`** — `always` | `in-flight` (new default) | `never`. Plumbed through the cascade + scaffold and exported to the gateway as `SWITCHROOM_BOOT_RESUME`, hoisted **before the gateway fork** in `start.sh` (the later `SWITCHROOM_RESUME_MODE` block is post-fork and drives the inner `claude --continue` path, not the daemon — so this needed its own hoist, same env-fork landmine as the `channels.telegram` knobs).
- `shouldSuppressBootResume` now takes `mode`. Default `in-flight` never suppresses genuinely in-flight work. `never` preserves #2585's posture but the caller **still delivers a passive report** (new `resume_deferred` inbound) rather than going silent. `SWITCHROOM_BOOT_RESUME_ALWAYS=1` back-compat escape hatch kept (forces resume regardless of mode).
- **Bounded resume-chain loop-guard** (per operator course-correction): a resume turn that is itself interrupted by another restart is **not** re-resumed — that could double-execute already-partly-run side effects and chain `restart→resume→restart` forever. The at-most-once `resumed_at` ledger bounds each individual turn, but each resume spawns a *new* turn, so the chain was unbounded. `isResumeSyntheticTurn` (preview-prefix anchor) detects a synthetic turn and downgrades to a passive deferred-report, capping the chain at one auto-resume.
- Boot-resume kind decision extracted to a pure, testable `decideBootResumeKind`.

## Safety rails preserved (req #5)

- At-most-once `resumed_at` ledger untouched — a turn resumes at most once.
- 60s clean-shutdown marker freshness window preserved — a slow rollout (>60s) still resumes under `never`.

## Liveness delta

This **adds** a delivered-without-the-model guarantee: whenever a turn was in flight at a restart, the framework now always delivers *something* (an active resume, or a passive report) — it can no longer stay silent. It does not remove any existing guarantee.

## Test plan

- [x] `bun test` — `resume-inbound-builder`, `gateway-clean-shutdown-marker`, `inbound-spool`, `registry-turns`, `turns-writer` (191 pass)
- [x] `vitest run` — `scaffold.gateway-env-order`, `config`, `scaffold` (216 pass)
- [x] Loop-guard chain test: restart during a resume turn → at most one more resume, then a report, never a loop
- [x] `tsc --noEmit` clean (root + plugin), all 8 lint guards clean
- [x] `node scripts/build.mjs` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)