### PR TITLE
fix(telegram): approval cards survive restarts and timeouts wake the agent

### DIFF
--- a/telegram-plugin/gateway/approval-timeout-inbound-builders.ts
+++ b/telegram-plugin/gateway/approval-timeout-inbound-builders.ts
@@ -1,0 +1,150 @@
+/**
+ * Pure builders for the synthetic inbounds the gateway injects when an
+ * agent-initiated approval card TTL-expires with no operator tap — one per
+ * family: `vault_request_access`, `vault_request_save`, `request_secret`,
+ * `mental_model_propose`.
+ *
+ * Before this, the only way these families woke the parked agent was an
+ * explicit tap. A card that expired unanswered left the agent (which ended its
+ * turn to wait) parked forever. These builders mirror the tap-outcome builders
+ * in `vault-grant-inbound-builders.ts`, but carry TIMEOUT wording:
+ *
+ *   "This is a TIMEOUT, not a denial — you may re-request or degrade
+ *    gracefully."
+ *
+ * matching the permission-card timeout philosophy (#2411 / #2862) so the model
+ * can tell an expiry from a real denial and NOT spam an identical re-request
+ * into an absent operator.
+ *
+ * The `meta.source` string is load-bearing (the bridge keys on it) and each is
+ * distinct from its tap-outcome sibling. Pinned by
+ * `approval-timeout-inbound-builders.test.ts`.
+ */
+
+import type { InboundMessage } from './ipc-protocol.js'
+
+interface TimeoutInboundBase {
+  agent: string
+  /** Chat the card lived in — keeps the resumed turn on the same conversation. */
+  chatId: string
+  /** Forum topic, if the request came from one — so the resumed reply routes back. */
+  threadId?: number
+  stageId: string
+  /** TTL window in whole minutes, for the message copy. */
+  timeoutMinutes: number
+  nowMs?: number
+}
+
+function envelope(opts: {
+  chatId: string
+  threadId?: number
+  ts: number
+  text: string
+  source: string
+  agent: string
+  stageId: string
+  extraMeta?: Record<string, string>
+}): InboundMessage {
+  return {
+    type: 'inbound',
+    chatId: opts.chatId,
+    ...(opts.threadId != null ? { threadId: opts.threadId } : {}),
+    messageId: opts.ts,
+    user: 'vault-broker',
+    userId: 0,
+    ts: opts.ts,
+    text: opts.text,
+    meta: {
+      source: opts.source,
+      agent: opts.agent,
+      ...(opts.threadId != null ? { message_thread_id: String(opts.threadId) } : {}),
+      stage_id: opts.stageId,
+      ...(opts.extraMeta ?? {}),
+    },
+  }
+}
+
+/** `vault_request_access` card expired unanswered. */
+export function buildVaultAccessTimeoutInbound(
+  opts: TimeoutInboundBase & { key: string; scope: 'read' | 'write' },
+): InboundMessage {
+  const ts = opts.nowMs ?? Date.now()
+  return envelope({
+    chatId: opts.chatId,
+    threadId: opts.threadId,
+    ts,
+    source: 'vault_grant_timeout',
+    agent: opts.agent,
+    stageId: opts.stageId,
+    extraMeta: { key: opts.key, scope: opts.scope },
+    text:
+      `⌛ Your vault access request for \`${opts.key}\` (scope=${opts.scope}) ` +
+      `timed out after ${opts.timeoutMinutes} min — the operator did not tap. ` +
+      `This is a TIMEOUT, not a denial. Pick a fallback for the original task ` +
+      `(tell the user, try a different approach, or skip the feature), or ` +
+      `re-request later if it still matters. Do NOT re-request in a loop.`,
+  })
+}
+
+/** `vault_request_save` card expired unanswered. */
+export function buildVaultSaveTimeoutInbound(
+  opts: TimeoutInboundBase & { key: string },
+): InboundMessage {
+  const ts = opts.nowMs ?? Date.now()
+  return envelope({
+    chatId: opts.chatId,
+    threadId: opts.threadId,
+    ts,
+    source: 'vault_save_timeout',
+    agent: opts.agent,
+    stageId: opts.stageId,
+    extraMeta: { key: opts.key },
+    text:
+      `⌛ Your vault_request_save for \`${opts.key}\` timed out after ` +
+      `${opts.timeoutMinutes} min — the operator did not tap, so the secret was ` +
+      `NOT stored and \`vault:${opts.key}\` will not resolve. This is a TIMEOUT, ` +
+      `not a denial. Pick a fallback or re-request the save later. Do NOT loop.`,
+  })
+}
+
+/** `request_secret` card expired unanswered. */
+export function buildSecretRequestTimeoutInbound(
+  opts: TimeoutInboundBase & { key: string },
+): InboundMessage {
+  const ts = opts.nowMs ?? Date.now()
+  return envelope({
+    chatId: opts.chatId,
+    threadId: opts.threadId,
+    ts,
+    source: 'secret_request_timeout',
+    agent: opts.agent,
+    stageId: opts.stageId,
+    extraMeta: { key: opts.key },
+    text:
+      `⌛ Your request_secret for \`${opts.key}\` timed out after ` +
+      `${opts.timeoutMinutes} min — the operator did not provide it. This is a ` +
+      `TIMEOUT, not a denial. Proceed without it, ask the user how they want to ` +
+      `handle the task, or re-request later. Do NOT re-request in a loop.`,
+  })
+}
+
+/** `mental_model_propose` card expired unanswered. */
+export function buildMentalModelProposeTimeoutInbound(
+  opts: TimeoutInboundBase & { name: string },
+): InboundMessage {
+  const ts = opts.nowMs ?? Date.now()
+  return envelope({
+    chatId: opts.chatId,
+    threadId: opts.threadId,
+    ts,
+    source: 'mental_model_propose_timeout',
+    agent: opts.agent,
+    stageId: opts.stageId,
+    extraMeta: { name: opts.name },
+    text:
+      `⌛ Your mental_model_propose for \`${opts.name}\` timed out after ` +
+      `${opts.timeoutMinutes} min — the operator did not tap, so nothing was ` +
+      `declared. This is a TIMEOUT, not a denial. Re-propose later if it still ` +
+      `stands. Do NOT re-propose in a loop.`,
+  })
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -126,6 +126,13 @@ import {
 } from './permission-timeout.js'
 import { renderVaultRequestAccessCard } from './vault-request-access-card.js'
 import { createPermissionCardStore, type PersistedPermCard } from './permission-card-store.js'
+import { createPendingCardStore, type PersistedApprovalCard } from './pending-card-store.js'
+import {
+  buildVaultAccessTimeoutInbound,
+  buildVaultSaveTimeoutInbound,
+  buildSecretRequestTimeoutInbound,
+  buildMentalModelProposeTimeoutInbound,
+} from './approval-timeout-inbound-builders.js'
 import {
   isPermissionRearmEnabled,
   permissionRearmGraceMs,
@@ -724,6 +731,14 @@ process.on('beforeExit', () => {
 // ─── Env + state dir ──────────────────────────────────────────────────────
 const STATE_DIR = process.env.TELEGRAM_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'telegram')
 const permCardStore = createPermissionCardStore(STATE_DIR)
+// Durable store for the four AGENT-INITIATED approval-card families
+// (vault_request_access / vault_request_save / request_secret /
+// mental_model_propose). Persists card METADATA only — never any secret value
+// (see pending-card-store.ts secrets-hygiene note). Restored at boot so a
+// post-restart tap on a still-valid card works like a pre-restart tap, and
+// swept in the pendingStateReaper so an unanswered card wakes the parked agent
+// on TTL instead of leaving it parked forever.
+const pendingCardStore = createPendingCardStore(STATE_DIR)
 // #2862 — missed-approvals re-offer. Persisted list of approvals that
 // TTL-expired while the operator was away; a digest card is posted on the
 // operator's next activity. Kill switch: SWITCHROOM_MISSED_APPROVAL_REOFFER=0.
@@ -5367,16 +5382,22 @@ interface PendingVaultRequestSave {
   why?: string
   /** Unix-ms timestamp; entries are reaped after VAULT_REQUEST_SAVE_TTL_MS. */
   staged_at: number
+  /** Set on entries RESTORED from disk after a gateway restart. The staged
+   *  secret `value` is held in memory only (never persisted — secrets
+   *  hygiene), so a restored entry has an empty value and cannot complete the
+   *  write. A Save tap on such a card degrades gracefully: it tells the agent
+   *  the value was lost to a restart instead of writing an empty secret. */
+  restoredWithoutValue?: boolean
 }
 const pendingVaultRequestSaves = new Map<string, PendingVaultRequestSave>()
 // Gateway-side reap window for a staged vault-save card. Tracks the operator
 // approval-card lifetime (config-driven, 60-min default) so the reap never
 // races ahead of the card the operator is still looking at.
 const VAULT_REQUEST_SAVE_TTL_MS = approvalTtlMs()
-function sweepPendingVaultRequestSaves(): void {
-  const cutoff = Date.now() - VAULT_REQUEST_SAVE_TTL_MS
+function sweepPendingVaultRequestSaves(now = Date.now()): void {
+  const cutoff = now - VAULT_REQUEST_SAVE_TTL_MS
   for (const [k, v] of pendingVaultRequestSaves) {
-    if (v.staged_at < cutoff) pendingVaultRequestSaves.delete(k)
+    if (v.staged_at < cutoff) expireVaultSaveCard(k, v, now)
   }
 }
 
@@ -5420,10 +5441,10 @@ const pendingVaultRequestAccesses = new Map<string, PendingVaultRequestAccess>()
 // Gateway-side reap window for a staged vault-access card. Tracks the operator
 // approval-card lifetime (config-driven, 60-min default) — see approvalTtlMs.
 const VAULT_REQUEST_ACCESS_TTL_MS = approvalTtlMs()
-function sweepPendingVaultRequestAccesses(): void {
-  const cutoff = Date.now() - VAULT_REQUEST_ACCESS_TTL_MS
+function sweepPendingVaultRequestAccesses(now = Date.now()): void {
+  const cutoff = now - VAULT_REQUEST_ACCESS_TTL_MS
   for (const [k, v] of pendingVaultRequestAccesses) {
-    if (v.staged_at < cutoff) pendingVaultRequestAccesses.delete(k)
+    if (v.staged_at < cutoff) expireVaultAccessCard(k, v, now)
   }
 }
 
@@ -5456,22 +5477,10 @@ const MENTAL_MODEL_PROPOSE_TTL_MS = approvalTtlMs()
 // posted card's keyboard away, so a stale card left in the chat can't be tapped
 // into a "Card expired" answer — the operator sees the ⌛ expiry inline instead.
 // Best-effort: card edits are fire-and-forget (the entry is removed regardless).
-function sweepPendingMentalModelProposes(): void {
-  const cutoff = Date.now() - MENTAL_MODEL_PROPOSE_TTL_MS
+function sweepPendingMentalModelProposes(now = Date.now()): void {
+  const cutoff = now - MENTAL_MODEL_PROPOSE_TTL_MS
   for (const [k, v] of pendingMentalModelProposes) {
-    if (v.staged_at < cutoff) {
-      pendingMentalModelProposes.delete(k)
-      if (v.card_message_id != null) {
-        void lockedBot.api
-          .editMessageText(
-            v.chat_id,
-            v.card_message_id,
-            richMessage('⌛ _This mental-model proposal card expired. Ask the agent to re-propose if it still stands._'),
-            { reply_markup: { inline_keyboard: [] } },
-          )
-          .catch(() => {})
-      }
-    }
+    if (v.staged_at < cutoff) expireMentalModelProposeCard(k, v, now)
   }
 }
 
@@ -5709,6 +5718,264 @@ function isAutoFallbackCooldownActive(_agentName: string, now: number): boolean 
   }
 }
 
+// ── Agent-initiated approval-card TTL expiry → wake the parked agent ────────
+//
+// The four agent-initiated approval-card families (vault_request_access /
+// vault_request_save / request_secret / mental_model_propose) each park the
+// requesting agent (it ends its turn to wait for the operator's tap). Before
+// this, an unanswered card that TTL-expired left the agent parked FOREVER: the
+// lazy sweep just deleted the in-memory entry and nothing woke the agent. Each
+// expire* helper mirrors the permission-card timeout path (#2411 / #2862):
+//   1. edit the card to a ⌛ expired state + strip its keyboard,
+//   2. inject a TIMEOUT-outcome synthetic inbound (turn-gated via
+//      deliverResumeSyntheticOrBuffer) so the agent can re-request or degrade,
+//   3. record it in missedApprovalsStore so it's re-offered when the operator
+//      returns,
+//   4. drop the in-memory entry AND its durable store record.
+// Called from BOTH the lazy sweeps (on next stage) and the pendingStateReaper
+// (every 60s — the authoritative timer so an idle gateway still wakes agents).
+
+async function editCardExpired(chatId: string, messageId: number | undefined, body: string): Promise<void> {
+  if (messageId == null) return
+  await lockedBot.api
+    // allow-raw-bot-api: message-id-targeted edit (no thread to lose); best-effort card-expiry strip from the reaper (no grammy ctx). Dropping reply_markup strips the stale keyboard atomically with the text edit.
+    .editMessageText(chatId, messageId, richMessage(body), { reply_markup: { inline_keyboard: [] } })
+    .catch(() => {})
+}
+
+function recordMissedApproval(opts: {
+  stageId: string
+  toolName: string
+  action: string
+  chatId: string
+  threadId?: number
+  now: number
+}): void {
+  if (!MISSED_APPROVAL_REOFFER_ENABLED) return
+  missedApprovalsStore.add({
+    requestId: opts.stageId,
+    toolName: opts.toolName,
+    action: opts.action,
+    chatId: opts.chatId,
+    threadId: opts.threadId ?? null,
+    timedOutAt: opts.now,
+  })
+}
+
+function expireVaultAccessCard(stageId: string, v: PendingVaultRequestAccess, now: number): void {
+  pendingVaultRequestAccesses.delete(stageId)
+  pendingCardStore.remove(stageId)
+  void editCardExpired(
+    v.chat_id,
+    v.card_message_id,
+    `⌛ _This vault access request for \`${escapeHtmlForTg(v.key)}\` timed out before you tapped. Ask **${escapeHtmlForTg(v.agent)}** to re-request if it still stands._`,
+  )
+  const timeoutMinutes = Math.round(VAULT_REQUEST_ACCESS_TTL_MS / 60000)
+  const inbound = buildVaultAccessTimeoutInbound({
+    agent: v.agent,
+    chatId: v.chat_id,
+    ...(v.threadId != null ? { threadId: v.threadId } : {}),
+    stageId,
+    timeoutMinutes,
+    key: v.key,
+    scope: v.scope,
+  })
+  const delivered = deliverResumeSyntheticOrBuffer(v.agent, inbound)
+  recordMissedApproval({
+    stageId,
+    toolName: 'vault_request_access',
+    action: `grant ${v.agent} ${v.scope} access to \`${v.key}\``,
+    chatId: v.chat_id,
+    ...(v.threadId != null ? { threadId: v.threadId } : {}),
+    now,
+  })
+  process.stderr.write(
+    `telegram gateway: vault_request_access TTL expired — wake agent=${v.agent} ` +
+    `key=${v.key} stage=${stageId} delivered=${delivered}\n`,
+  )
+}
+
+function expireVaultSaveCard(stageId: string, v: PendingVaultRequestSave, now: number): void {
+  pendingVaultRequestSaves.delete(stageId)
+  pendingCardStore.remove(stageId)
+  void editCardExpired(
+    v.chat_id,
+    v.card_message_id,
+    `⌛ _This vault-save card for \`${escapeHtmlForTg(v.key)}\` timed out before you tapped. The secret was NOT stored. Ask **${escapeHtmlForTg(v.agent)}** to re-issue if you still want to save._`,
+  )
+  const timeoutMinutes = Math.round(VAULT_REQUEST_SAVE_TTL_MS / 60000)
+  const inbound = buildVaultSaveTimeoutInbound({
+    agent: v.agent,
+    chatId: v.chat_id,
+    ...(v.threadId != null ? { threadId: v.threadId } : {}),
+    stageId,
+    timeoutMinutes,
+    key: v.key,
+  })
+  const delivered = deliverResumeSyntheticOrBuffer(v.agent, inbound)
+  recordMissedApproval({
+    stageId,
+    toolName: 'vault_request_save',
+    action: `save the secret \`${v.key}\` for ${v.agent}`,
+    chatId: v.chat_id,
+    ...(v.threadId != null ? { threadId: v.threadId } : {}),
+    now,
+  })
+  process.stderr.write(
+    `telegram gateway: vault_request_save TTL expired — wake agent=${v.agent} ` +
+    `key=${v.key} stage=${stageId} delivered=${delivered}\n`,
+  )
+}
+
+function expireSecretRequestCard(stageId: string, v: PendingSecretRequest, now: number): void {
+  pendingSecretRequests.delete(stageId)
+  pendingCardStore.remove(stageId)
+  void editCardExpired(
+    v.chat_id,
+    v.card_message_id,
+    `⌛ _This secret-request card for \`${escapeHtmlForTg(v.key)}\` timed out before you provided it. Ask **${escapeHtmlForTg(v.agent)}** to re-request if it still needs the value._`,
+  )
+  const timeoutMinutes = Math.round(PENDING_SECRET_REQUEST_TTL_MS / 60000)
+  const inbound = buildSecretRequestTimeoutInbound({
+    agent: v.agent,
+    chatId: v.chat_id,
+    ...(v.threadId != null ? { threadId: v.threadId } : {}),
+    stageId,
+    timeoutMinutes,
+    key: v.key,
+  })
+  const delivered = deliverResumeSyntheticOrBuffer(v.agent, inbound)
+  recordMissedApproval({
+    stageId,
+    toolName: 'request_secret',
+    action: `provide the secret \`${v.key}\` for ${v.agent}`,
+    chatId: v.chat_id,
+    ...(v.threadId != null ? { threadId: v.threadId } : {}),
+    now,
+  })
+  process.stderr.write(
+    `telegram gateway: request_secret TTL expired — wake agent=${v.agent} ` +
+    `key=${v.key} stage=${stageId} delivered=${delivered}\n`,
+  )
+}
+
+function expireMentalModelProposeCard(stageId: string, v: PendingMentalModelPropose, now: number): void {
+  pendingMentalModelProposes.delete(stageId)
+  pendingCardStore.remove(stageId)
+  void editCardExpired(
+    v.chat_id,
+    v.card_message_id,
+    `⌛ _This mental-model proposal card for \`${escapeHtmlForTg(v.spec.name)}\` timed out before you tapped. Ask **${escapeHtmlForTg(v.agent)}** to re-propose if it still stands._`,
+  )
+  const timeoutMinutes = Math.round(MENTAL_MODEL_PROPOSE_TTL_MS / 60000)
+  const inbound = buildMentalModelProposeTimeoutInbound({
+    agent: v.agent,
+    chatId: v.chat_id,
+    ...(v.threadId != null ? { threadId: v.threadId } : {}),
+    stageId,
+    timeoutMinutes,
+    name: v.spec.name,
+  })
+  const delivered = deliverResumeSyntheticOrBuffer(v.agent, inbound)
+  recordMissedApproval({
+    stageId,
+    toolName: 'mental_model_propose',
+    action: `declare the mental model \`${v.spec.name}\` for ${v.agent}`,
+    chatId: v.chat_id,
+    ...(v.threadId != null ? { threadId: v.threadId } : {}),
+    now,
+  })
+  process.stderr.write(
+    `telegram gateway: mental_model_propose TTL expired — wake agent=${v.agent} ` +
+    `name=${v.spec.name} stage=${stageId} delivered=${delivered}\n`,
+  )
+}
+
+// Run all four agent-initiated approval-card expiry sweeps. Called from the
+// pendingStateReaper (the authoritative 60s timer).
+function sweepExpiredApprovalCards(now: number): void {
+  sweepPendingVaultRequestAccesses(now)
+  sweepPendingVaultRequestSaves(now)
+  sweepPendingMentalModelProposes(now)
+  sweepSecretRequests(now)
+}
+
+// Boot restore: repopulate the four in-memory approval-card maps from the
+// durable store so a post-restart tap on a still-valid card resolves normally
+// (approve → grant + synthetic; deny → denial synthetic) instead of hitting
+// the "Card expired" tombstone. Entries already past their TTL are left for
+// the reaper's next tick, which wakes the parked agent via the timeout path.
+// vault_request_save entries restore WITHOUT their staged value (never
+// persisted) and are flagged `restoredWithoutValue` so a Save tap degrades
+// gracefully rather than writing an empty secret.
+function restorePendingApprovalCards(): number {
+  let restored = 0
+  for (const e of pendingCardStore.loadAll()) {
+    try {
+      if (e.family === 'vault_request_access') {
+        pendingVaultRequestAccesses.set(e.stageId, {
+          agent: e.agent,
+          chat_id: e.chatId,
+          ...(e.cardMessageId != null ? { card_message_id: e.cardMessageId } : {}),
+          ...(e.threadId != null ? { threadId: e.threadId } : {}),
+          key: e.key,
+          scope: e.scope,
+          ...(e.reason != null ? { reason: e.reason } : {}),
+          ttl_seconds: e.ttlSeconds,
+          staged_at: e.stagedAt,
+        })
+        restored++
+      } else if (e.family === 'vault_request_save') {
+        pendingVaultRequestSaves.set(e.stageId, {
+          agent: e.agent,
+          chat_id: e.chatId,
+          ...(e.cardMessageId != null ? { card_message_id: e.cardMessageId } : {}),
+          ...(e.threadId != null ? { threadId: e.threadId } : {}),
+          key: e.key,
+          kind: e.kind,
+          value: '', // never persisted — secrets hygiene
+          ...(e.why != null ? { why: e.why } : {}),
+          staged_at: e.stagedAt,
+          restoredWithoutValue: true,
+        })
+        restored++
+      } else if (e.family === 'request_secret') {
+        pendingSecretRequests.set(e.stageId, {
+          agent: e.agent,
+          chat_id: e.chatId,
+          ...(e.cardMessageId != null ? { card_message_id: e.cardMessageId } : {}),
+          ...(e.threadId != null ? { threadId: e.threadId } : {}),
+          key: e.key,
+          ...(e.reason != null ? { reason: e.reason } : {}),
+          staged_at: e.stagedAt,
+        })
+        restored++
+      } else if (e.family === 'mental_model_propose') {
+        pendingMentalModelProposes.set(e.stageId, {
+          agent: e.agent,
+          chat_id: e.chatId,
+          ...(e.cardMessageId != null ? { card_message_id: e.cardMessageId } : {}),
+          ...(e.threadId != null ? { threadId: e.threadId } : {}),
+          spec: e.spec,
+          ...(e.reason != null ? { reason: e.reason } : {}),
+          staged_at: e.stagedAt,
+        })
+        restored++
+      }
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: pending-card restore skipped a malformed entry: ${(err as Error).message}\n`,
+      )
+    }
+  }
+  if (restored > 0) {
+    process.stderr.write(
+      `telegram gateway: restored ${restored} pending approval card(s) from prior gateway session\n`,
+    )
+  }
+  return restored
+}
+
 // 60-second sweep drops anything past its documented TTL.
 const pendingStateReaper = setInterval(() => {
   const now = Date.now()
@@ -5842,6 +6109,13 @@ const pendingStateReaper = setInterval(() => {
   for (const [k, v] of deferredSecrets) {
     if (now - v.staged_at > DEFERRED_SECRET_TTL_MS) deferredSecrets.delete(k)
   }
+  // Agent-initiated approval cards (vault_request_access / vault_request_save /
+  // request_secret / mental_model_propose): expire past-TTL entries and WAKE
+  // the parked agent (timeout synthetic + missed-approvals re-offer). This is
+  // the authoritative timer — before this the only expiry path was a lazy
+  // sweep on the NEXT stage, so an agent that ended its turn to wait on one of
+  // these cards could sit parked forever if no further request ever staged.
+  sweepExpiredApprovalCards(now)
   // #550: sweep a stale turn-active marker. Defence-in-depth for the
   // case where neither the turn_end arm nor onTurnComplete fired (SDK
   // killed before the JSONL turn_duration record, compaction window,
@@ -11879,6 +12153,21 @@ async function executeVaultRequestSave(args: Record<string, unknown>): Promise<{
     { threadId, chat_id, verb: 'vault_request_save.card' },
   )
   pending.card_message_id = sent.message_id
+  // Persist card METADATA (never the staged `value` — secrets hygiene) so a
+  // gateway restart doesn't strand the parked agent. A restored Save tap can't
+  // complete (value is gone) and degrades to a "value lost to restart" wake-up.
+  pendingCardStore.add({
+    family: 'vault_request_save',
+    stageId,
+    agent: pending.agent,
+    chatId: pending.chat_id,
+    ...(pending.card_message_id != null ? { cardMessageId: pending.card_message_id } : {}),
+    ...(pending.threadId != null ? { threadId: pending.threadId } : {}),
+    key: pending.key,
+    kind: pending.kind,
+    ...(pending.why != null ? { why: pending.why } : {}),
+    stagedAt: pending.staged_at,
+  })
 
   return {
     content: [
@@ -11922,11 +12211,13 @@ const armedSecretCaptures = new Map<string, ArmedSecretCapture>()
 const PENDING_SECRET_REQUEST_TTL_MS = 30 * 60_000 // card lifetime
 const ARMED_SECRET_CAPTURE_TTL_MS = 10 * 60_000   // window to send the value after tapping
 
-function sweepSecretRequests(): void {
-  const now = Date.now()
+function sweepSecretRequests(now = Date.now()): void {
   for (const [k, v] of pendingSecretRequests) {
-    if (now - v.staged_at > PENDING_SECRET_REQUEST_TTL_MS) pendingSecretRequests.delete(k)
+    if (now - v.staged_at > PENDING_SECRET_REQUEST_TTL_MS) expireSecretRequestCard(k, v, now)
   }
+  // armedSecretCaptures is a TRANSIENT post-tap window (never persisted): it's
+  // only set after the operator taps [Provide securely], and the request is
+  // no longer parked-on-a-card. Just drop stale ones — no wake needed.
   for (const [k, v] of armedSecretCaptures) {
     if (now - v.armed_at > ARMED_SECRET_CAPTURE_TTL_MS) armedSecretCaptures.delete(k)
   }
@@ -11976,7 +12267,10 @@ async function executeRequestSecret(args: Record<string, unknown>): Promise<{ co
   // Dedupe: one open request per (chat, key). Drop any prior stage for
   // the same target so the operator never sees stacked cards.
   for (const [sid, p] of pendingSecretRequests) {
-    if (p.chat_id === chat_id && p.key === key) pendingSecretRequests.delete(sid)
+    if (p.chat_id === chat_id && p.key === key) {
+      pendingSecretRequests.delete(sid)
+      pendingCardStore.remove(sid)
+    }
   }
 
   const stageId = randomBytes(4).toString('hex')
@@ -11998,6 +12292,21 @@ async function executeRequestSecret(args: Record<string, unknown>): Promise<{ co
     { threadId, chat_id, verb: 'request_secret.card' },
   )
   pending.card_message_id = sent.message_id
+  // Persist card metadata so a gateway restart doesn't strand the parked
+  // agent. request_secret holds NO value at staging time (the value arrives
+  // after the operator taps [Provide securely]), so nothing sensitive lands
+  // on disk here.
+  pendingCardStore.add({
+    family: 'request_secret',
+    stageId,
+    agent: pending.agent,
+    chatId: pending.chat_id,
+    ...(pending.card_message_id != null ? { cardMessageId: pending.card_message_id } : {}),
+    ...(pending.threadId != null ? { threadId: pending.threadId } : {}),
+    key: pending.key,
+    ...(pending.reason != null ? { reason: pending.reason } : {}),
+    stagedAt: pending.staged_at,
+  })
 
   return {
     content: [
@@ -12046,6 +12355,7 @@ async function captureProvidedSecret(
   armedSecretCaptures.delete(chat_id)
   const pending = pendingSecretRequests.get(armed.stageId)
   pendingSecretRequests.delete(armed.stageId)
+  pendingCardStore.remove(armed.stageId)
 
   // Delete the raw message FIRST — surfaces a warning if it fails.
   if (msgId != null) await deleteSensitiveMessage(chat_id, msgId, 'provided secret value')
@@ -12161,6 +12471,7 @@ async function handleSecretRequestCallback(ctx: Context, data: string): Promise<
 
   if (action === 'decline') {
     pendingSecretRequests.delete(stageId)
+    pendingCardStore.remove(stageId)
     armedSecretCaptures.delete(pending.chat_id)
     await ctx.answerCallbackQuery({ text: 'Declined.' }).catch(() => {})
     if (pending.card_message_id != null) {
@@ -12328,12 +12639,27 @@ async function executeVaultRequestAccess(args: Record<string, unknown>): Promise
     { threadId, chat_id, verb: 'vault_request_access.card' },
   )
   pending.card_message_id = sent.message_id
+  // Persist card metadata (no secret material — this flow stages only the ACL
+  // request) so a gateway restart doesn't strand the parked agent.
+  pendingCardStore.add({
+    family: 'vault_request_access',
+    stageId,
+    agent: pending.agent,
+    chatId: pending.chat_id,
+    ...(pending.card_message_id != null ? { cardMessageId: pending.card_message_id } : {}),
+    ...(pending.threadId != null ? { threadId: pending.threadId } : {}),
+    key: pending.key,
+    scope: pending.scope,
+    ...(pending.reason != null ? { reason: pending.reason } : {}),
+    ttlSeconds: pending.ttl_seconds,
+    stagedAt: pending.staged_at,
+  })
 
   return {
     content: [
       {
         type: 'text',
-        text: `vault_request_access: card sent (stage_id=${stageId}, key=${key}, scope=${scopeRaw}). Wait for the operator to tap Approve or Deny — do not retry the vault read until you see a confirmation message. If the card times out (10 min) you can re-request.`,
+        text: `vault_request_access: card sent (stage_id=${stageId}, key=${key}, scope=${scopeRaw}). Wait for the operator to tap Approve or Deny — do not retry the vault read until you see a confirmation message. If the card times out (${Math.round(VAULT_REQUEST_ACCESS_TTL_MS / 60000)} min) you can re-request.`,
       },
     ],
   }
@@ -12497,6 +12823,19 @@ async function executeMentalModelPropose(args: Record<string, unknown>): Promise
     { threadId, chat_id, verb: 'mental_model_propose.card' },
   )
   pending.card_message_id = sent.message_id
+  // Persist card metadata (the proposed DECLARATION is not secret material) so
+  // a gateway restart doesn't strand the parked agent.
+  pendingCardStore.add({
+    family: 'mental_model_propose',
+    stageId,
+    agent: pending.agent,
+    chatId: pending.chat_id,
+    ...(pending.card_message_id != null ? { cardMessageId: pending.card_message_id } : {}),
+    ...(pending.threadId != null ? { threadId: pending.threadId } : {}),
+    spec: pending.spec,
+    ...(pending.reason != null ? { reason: pending.reason } : {}),
+    stagedAt: pending.staged_at,
+  })
   // Only count a proposal against the rate budget once its card actually
   // posted (validation errors / dupes don't consume the budget).
   mentalModelProposeTimes.push(Date.now())
@@ -21313,6 +21652,7 @@ async function performVaultAccessApproval(
       const visible = await listViaBroker()
       if (visible !== null && visible.includes(pending.key)) {
         pendingVaultRequestAccesses.delete(stageId)
+        pendingCardStore.remove(stageId)
         if (pending.card_message_id != null) {
           await ctx.api
             .editMessageText(
@@ -21411,6 +21751,7 @@ async function performVaultAccessApproval(
     // the agent to re-issue, or the broker error message will tell
     // them the next step.
     pendingVaultRequestAccesses.delete(stageId)
+    pendingCardStore.remove(stageId)
     if (pending.card_message_id != null) {
       await ctx.api
         .editMessageText(
@@ -21442,6 +21783,7 @@ async function performVaultAccessApproval(
   }
 
   pendingVaultRequestAccesses.delete(stageId)
+  pendingCardStore.remove(stageId)
   if (pending.card_message_id != null) {
     const days = Math.round(pending.ttl_seconds / 86400)
     const footer =
@@ -21650,23 +21992,17 @@ async function handleMentalModelProposeCallback(ctx: Context, data: string): Pro
   // this, a card left untapped past its TTL is still resolvable if no fresh
   // proposal has run the sweep — an operator could approve a stale proposal.
   if (Date.now() - pending.staged_at > MENTAL_MODEL_PROPOSE_TTL_MS) {
-    pendingMentalModelProposes.delete(stageId)
-    await ctx.answerCallbackQuery({ text: 'Card expired — ask the agent to re-propose.' }).catch(() => {})
-    if (pending.card_message_id != null) {
-      await ctx.api
-        .editMessageText(
-          pending.chat_id,
-          pending.card_message_id,
-          richMessage('⌛ _This mental-model proposal card expired before you tapped. Ask the agent to re-propose if it still stands._'),
-          { reply_markup: { inline_keyboard: [] } },
-        )
-        .catch(() => {})
-    }
+    // Expired between post and tap: route through the shared expiry path so the
+    // parked agent is WOKEN (timeout synthetic + missed-approvals re-offer) and
+    // the durable store entry is cleared — not just a silent map delete.
+    expireMentalModelProposeCard(stageId, pending, Date.now())
+    await ctx.answerCallbackQuery({ text: 'Card expired — the agent was notified.' }).catch(() => {})
     return
   }
   // Single-shot: remove the pending entry immediately so a double-tap can't
   // resolve twice.
   pendingMentalModelProposes.delete(stageId)
+  pendingCardStore.remove(stageId)
 
   const proposal: MentalModelPendingProposal = {
     agent: pending.agent,
@@ -21808,6 +22144,7 @@ async function handleVaultRequestAccessCallback(ctx: Context, data: string): Pro
 
   if (action === 'deny') {
     pendingVaultRequestAccesses.delete(stageId)
+    pendingCardStore.remove(stageId)
     await ctx.answerCallbackQuery({ text: '🚫 Denied' }).catch(() => {})
     if (pending.card_message_id != null) {
       await ctx.api
@@ -22030,6 +22367,7 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
 
   if (action === 'discard') {
     pendingVaultRequestSaves.delete(stageId)
+    pendingCardStore.remove(stageId)
     await ctx.answerCallbackQuery({ text: '🚫 Discarded' }).catch(() => {})
     if (pending.card_message_id != null) {
       await ctx.api
@@ -22100,6 +22438,43 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
     // stale "spinning" state on the button while we run the write.
     await ctx.answerCallbackQuery({ text: '⏳ Saving…' }).catch(() => {})
 
+    // Restored-after-restart guard: the staged secret VALUE is held in gateway
+    // memory only and is never persisted (secrets hygiene). If this card was
+    // restored from disk after a gateway restart, the value is gone — we CANNOT
+    // complete the write. Degrade gracefully: strip the card, wake the agent
+    // with a save-failed (value-lost) synthetic so it re-requests, and stop.
+    if (pending.restoredWithoutValue || pending.value.length === 0) {
+      pendingVaultRequestSaves.delete(stageId)
+      pendingCardStore.remove(stageId)
+      if (pending.card_message_id != null) {
+        await ctx.api
+          .editMessageText(
+            pending.chat_id,
+            pending.card_message_id,
+            richMessage(`⚠️ _The staged value for \`${escapeHtmlForTg(pending.key)}\` was lost to a gateway restart — nothing was saved. Ask **${escapeHtmlForTg(pending.agent)}** to re-issue \`vault_request_save\` if you still want to store it._`),
+            { reply_markup: { inline_keyboard: [] } },
+          )
+          .catch(() => {})
+      }
+      const lostInbound = buildVaultSaveFailedInbound({
+        ctx: {
+          agent: pending.agent,
+          key: pending.key,
+          chat_id: pending.chat_id,
+          ...(pending.threadId != null ? { threadId: pending.threadId } : {}),
+        },
+        stageId,
+        operatorId: senderId,
+        reason: 'staged value lost to a gateway restart — re-request the save',
+      })
+      const lDelivered = deliverResumeSyntheticOrBuffer(pending.agent, lostInbound)
+      process.stderr.write(
+        `telegram gateway: vault_request_save value lost to restart — wake agent=${pending.agent} ` +
+        `key=${pending.key} stage=${stageId} delivered=${lDelivered}\n`,
+      )
+      return
+    }
+
     // #1115 follow-up: the save-approve flow now mirrors the access-
     // approve flow under telegram-id mode — broker `put` accepts
     // `attest_via_posture: true` (server.ts:1448-1500), so the
@@ -22135,6 +22510,7 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
             .catch(() => {})
         }
         pendingVaultRequestSaves.delete(stageId)
+        pendingCardStore.remove(stageId)
         return
       }
       // defaultVaultWrite spawns `switchroom vault set <key>` with the
@@ -22166,6 +22542,7 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
       // retry by re-invoking the same MCP tool, but the value will be
       // re-staged with a new ID. Drop the current stage.
       pendingVaultRequestSaves.delete(stageId)
+      pendingCardStore.remove(stageId)
       // Wake the waiting agent with the failure (symmetric with the
       // success/discard paths) so it doesn't assume vault:<key> exists.
       const failReason =
@@ -22191,6 +22568,7 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
 
     // Success — mask the value in the card for visual confirmation.
     pendingVaultRequestSaves.delete(stageId)
+    pendingCardStore.remove(stageId)
     if (pending.card_message_id != null) {
       await ctx.api
         .editMessageText(
@@ -26980,6 +27358,18 @@ void (async () => {
               })()
             }, graceMs).unref?.()
           }
+        }
+
+        // Restore the four agent-initiated approval-card families from the
+        // durable store so a post-restart tap on a still-valid card resolves
+        // normally instead of hitting the "Card expired" tombstone (and an
+        // already-expired entry gets woken by the reaper's next tick).
+        try {
+          restorePendingApprovalCards()
+        } catch (err) {
+          process.stderr.write(
+            `telegram gateway: pending approval-card restore failed: ${(err as Error).message}\n`,
+          )
         }
 
         // Boot-time pin sweep

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -133,6 +133,7 @@ import {
   buildSecretRequestTimeoutInbound,
   buildMentalModelProposeTimeoutInbound,
 } from './approval-timeout-inbound-builders.js'
+import { expirePendingCard, sweepExpiredEntries } from './pending-card-expiry.js'
 import {
   isPermissionRearmEnabled,
   permissionRearmGraceMs,
@@ -5395,10 +5396,13 @@ const pendingVaultRequestSaves = new Map<string, PendingVaultRequestSave>()
 // races ahead of the card the operator is still looking at.
 const VAULT_REQUEST_SAVE_TTL_MS = approvalTtlMs()
 function sweepPendingVaultRequestSaves(now = Date.now()): void {
-  const cutoff = now - VAULT_REQUEST_SAVE_TTL_MS
-  for (const [k, v] of pendingVaultRequestSaves) {
-    if (v.staged_at < cutoff) expireVaultSaveCard(k, v, now)
-  }
+  sweepExpiredEntries(
+    pendingVaultRequestSaves,
+    (v, n) => v.staged_at < n - VAULT_REQUEST_SAVE_TTL_MS,
+    expireVaultSaveCard,
+    now,
+    cardExpiryLog,
+  )
 }
 
 /**
@@ -5442,10 +5446,13 @@ const pendingVaultRequestAccesses = new Map<string, PendingVaultRequestAccess>()
 // approval-card lifetime (config-driven, 60-min default) — see approvalTtlMs.
 const VAULT_REQUEST_ACCESS_TTL_MS = approvalTtlMs()
 function sweepPendingVaultRequestAccesses(now = Date.now()): void {
-  const cutoff = now - VAULT_REQUEST_ACCESS_TTL_MS
-  for (const [k, v] of pendingVaultRequestAccesses) {
-    if (v.staged_at < cutoff) expireVaultAccessCard(k, v, now)
-  }
+  sweepExpiredEntries(
+    pendingVaultRequestAccesses,
+    (v, n) => v.staged_at < n - VAULT_REQUEST_ACCESS_TTL_MS,
+    expireVaultAccessCard,
+    now,
+    cardExpiryLog,
+  )
 }
 
 /**
@@ -5478,10 +5485,13 @@ const MENTAL_MODEL_PROPOSE_TTL_MS = approvalTtlMs()
 // into a "Card expired" answer — the operator sees the ⌛ expiry inline instead.
 // Best-effort: card edits are fire-and-forget (the entry is removed regardless).
 function sweepPendingMentalModelProposes(now = Date.now()): void {
-  const cutoff = now - MENTAL_MODEL_PROPOSE_TTL_MS
-  for (const [k, v] of pendingMentalModelProposes) {
-    if (v.staged_at < cutoff) expireMentalModelProposeCard(k, v, now)
-  }
+  sweepExpiredEntries(
+    pendingMentalModelProposes,
+    (v, n) => v.staged_at < n - MENTAL_MODEL_PROPOSE_TTL_MS,
+    expireMentalModelProposeCard,
+    now,
+    cardExpiryLog,
+  )
 }
 
 // Sliding-window rate limit for mental-model proposals: at most
@@ -5725,13 +5735,19 @@ function isAutoFallbackCooldownActive(_agentName: string, now: number): boolean 
 // requesting agent (it ends its turn to wait for the operator's tap). Before
 // this, an unanswered card that TTL-expired left the agent parked FOREVER: the
 // lazy sweep just deleted the in-memory entry and nothing woke the agent. Each
-// expire* helper mirrors the permission-card timeout path (#2411 / #2862):
-//   1. edit the card to a ⌛ expired state + strip its keyboard,
-//   2. inject a TIMEOUT-outcome synthetic inbound (turn-gated via
-//      deliverResumeSyntheticOrBuffer) so the agent can re-request or degrade,
-//   3. record it in missedApprovalsStore so it's re-offered when the operator
-//      returns,
-//   4. drop the in-memory entry AND its durable store record.
+// expire* helper mirrors the permission-card timeout path (#2411 / #2862) by
+// routing through the pure `expirePendingCard` core (pending-card-expiry.ts),
+// whose ordering + fault-isolation contract is behaviorally pinned by
+// pending-card-expiry.test.ts:
+//   1. drop the in-memory entry AND its durable store record FIRST (single-
+//      shot — a second tick can never double-fire the wake),
+//   2. edit the card to a ⌛ expired state + strip its keyboard (best-effort),
+//   3. record it in missedApprovalsStore BEFORE delivering, so a throwing
+//      deliver can't lose the re-offer for the operator's return,
+//   4. inject a TIMEOUT-outcome synthetic inbound (turn-gated via
+//      deliverResumeSyntheticOrBuffer, guarded — a half-dead IPC socket that
+//      throws on write is contained, never escaping the reaper's setInterval
+//      callback into an uncaughtException gateway shutdown).
 // Called from BOTH the lazy sweeps (on next stage) and the pendingStateReaper
 // (every 60s — the authoritative timer so an idle gateway still wakes agents).
 
@@ -5762,32 +5778,41 @@ function recordMissedApproval(opts: {
   })
 }
 
+const cardExpiryLog = (msg: string): void => {
+  process.stderr.write(`telegram gateway: ${msg}\n`)
+}
+
 function expireVaultAccessCard(stageId: string, v: PendingVaultRequestAccess, now: number): void {
-  pendingVaultRequestAccesses.delete(stageId)
-  pendingCardStore.remove(stageId)
-  void editCardExpired(
-    v.chat_id,
-    v.card_message_id,
-    `⌛ _This vault access request for \`${escapeHtmlForTg(v.key)}\` timed out before you tapped. Ask **${escapeHtmlForTg(v.agent)}** to re-request if it still stands._`,
-  )
   const timeoutMinutes = Math.round(VAULT_REQUEST_ACCESS_TTL_MS / 60000)
-  const inbound = buildVaultAccessTimeoutInbound({
-    agent: v.agent,
-    chatId: v.chat_id,
-    ...(v.threadId != null ? { threadId: v.threadId } : {}),
-    stageId,
-    timeoutMinutes,
-    key: v.key,
-    scope: v.scope,
-  })
-  const delivered = deliverResumeSyntheticOrBuffer(v.agent, inbound)
-  recordMissedApproval({
-    stageId,
-    toolName: 'vault_request_access',
-    action: `grant ${v.agent} ${v.scope} access to \`${v.key}\``,
-    chatId: v.chat_id,
-    ...(v.threadId != null ? { threadId: v.threadId } : {}),
-    now,
+  const { delivered } = expirePendingCard({
+    remove: () => {
+      pendingVaultRequestAccesses.delete(stageId)
+      pendingCardStore.remove(stageId)
+    },
+    editCard: () => void editCardExpired(
+      v.chat_id,
+      v.card_message_id,
+      `⌛ _This vault access request for \`${escapeHtmlForTg(v.key)}\` timed out before you tapped. Ask **${escapeHtmlForTg(v.agent)}** to re-request if it still stands._`,
+    ),
+    buildInbound: () => buildVaultAccessTimeoutInbound({
+      agent: v.agent,
+      chatId: v.chat_id,
+      ...(v.threadId != null ? { threadId: v.threadId } : {}),
+      stageId,
+      timeoutMinutes,
+      key: v.key,
+      scope: v.scope,
+    }),
+    deliver: (inbound) => deliverResumeSyntheticOrBuffer(v.agent, inbound),
+    recordMiss: () => recordMissedApproval({
+      stageId,
+      toolName: 'vault_request_access',
+      action: `grant ${v.agent} ${v.scope} access to \`${v.key}\``,
+      chatId: v.chat_id,
+      ...(v.threadId != null ? { threadId: v.threadId } : {}),
+      now,
+    }),
+    log: cardExpiryLog,
   })
   process.stderr.write(
     `telegram gateway: vault_request_access TTL expired — wake agent=${v.agent} ` +
@@ -5796,30 +5821,35 @@ function expireVaultAccessCard(stageId: string, v: PendingVaultRequestAccess, no
 }
 
 function expireVaultSaveCard(stageId: string, v: PendingVaultRequestSave, now: number): void {
-  pendingVaultRequestSaves.delete(stageId)
-  pendingCardStore.remove(stageId)
-  void editCardExpired(
-    v.chat_id,
-    v.card_message_id,
-    `⌛ _This vault-save card for \`${escapeHtmlForTg(v.key)}\` timed out before you tapped. The secret was NOT stored. Ask **${escapeHtmlForTg(v.agent)}** to re-issue if you still want to save._`,
-  )
   const timeoutMinutes = Math.round(VAULT_REQUEST_SAVE_TTL_MS / 60000)
-  const inbound = buildVaultSaveTimeoutInbound({
-    agent: v.agent,
-    chatId: v.chat_id,
-    ...(v.threadId != null ? { threadId: v.threadId } : {}),
-    stageId,
-    timeoutMinutes,
-    key: v.key,
-  })
-  const delivered = deliverResumeSyntheticOrBuffer(v.agent, inbound)
-  recordMissedApproval({
-    stageId,
-    toolName: 'vault_request_save',
-    action: `save the secret \`${v.key}\` for ${v.agent}`,
-    chatId: v.chat_id,
-    ...(v.threadId != null ? { threadId: v.threadId } : {}),
-    now,
+  const { delivered } = expirePendingCard({
+    remove: () => {
+      pendingVaultRequestSaves.delete(stageId)
+      pendingCardStore.remove(stageId)
+    },
+    editCard: () => void editCardExpired(
+      v.chat_id,
+      v.card_message_id,
+      `⌛ _This vault-save card for \`${escapeHtmlForTg(v.key)}\` timed out before you tapped. The secret was NOT stored. Ask **${escapeHtmlForTg(v.agent)}** to re-issue if you still want to save._`,
+    ),
+    buildInbound: () => buildVaultSaveTimeoutInbound({
+      agent: v.agent,
+      chatId: v.chat_id,
+      ...(v.threadId != null ? { threadId: v.threadId } : {}),
+      stageId,
+      timeoutMinutes,
+      key: v.key,
+    }),
+    deliver: (inbound) => deliverResumeSyntheticOrBuffer(v.agent, inbound),
+    recordMiss: () => recordMissedApproval({
+      stageId,
+      toolName: 'vault_request_save',
+      action: `save the secret \`${v.key}\` for ${v.agent}`,
+      chatId: v.chat_id,
+      ...(v.threadId != null ? { threadId: v.threadId } : {}),
+      now,
+    }),
+    log: cardExpiryLog,
   })
   process.stderr.write(
     `telegram gateway: vault_request_save TTL expired — wake agent=${v.agent} ` +
@@ -5828,30 +5858,35 @@ function expireVaultSaveCard(stageId: string, v: PendingVaultRequestSave, now: n
 }
 
 function expireSecretRequestCard(stageId: string, v: PendingSecretRequest, now: number): void {
-  pendingSecretRequests.delete(stageId)
-  pendingCardStore.remove(stageId)
-  void editCardExpired(
-    v.chat_id,
-    v.card_message_id,
-    `⌛ _This secret-request card for \`${escapeHtmlForTg(v.key)}\` timed out before you provided it. Ask **${escapeHtmlForTg(v.agent)}** to re-request if it still needs the value._`,
-  )
   const timeoutMinutes = Math.round(PENDING_SECRET_REQUEST_TTL_MS / 60000)
-  const inbound = buildSecretRequestTimeoutInbound({
-    agent: v.agent,
-    chatId: v.chat_id,
-    ...(v.threadId != null ? { threadId: v.threadId } : {}),
-    stageId,
-    timeoutMinutes,
-    key: v.key,
-  })
-  const delivered = deliverResumeSyntheticOrBuffer(v.agent, inbound)
-  recordMissedApproval({
-    stageId,
-    toolName: 'request_secret',
-    action: `provide the secret \`${v.key}\` for ${v.agent}`,
-    chatId: v.chat_id,
-    ...(v.threadId != null ? { threadId: v.threadId } : {}),
-    now,
+  const { delivered } = expirePendingCard({
+    remove: () => {
+      pendingSecretRequests.delete(stageId)
+      pendingCardStore.remove(stageId)
+    },
+    editCard: () => void editCardExpired(
+      v.chat_id,
+      v.card_message_id,
+      `⌛ _This secret-request card for \`${escapeHtmlForTg(v.key)}\` timed out before you provided it. Ask **${escapeHtmlForTg(v.agent)}** to re-request if it still needs the value._`,
+    ),
+    buildInbound: () => buildSecretRequestTimeoutInbound({
+      agent: v.agent,
+      chatId: v.chat_id,
+      ...(v.threadId != null ? { threadId: v.threadId } : {}),
+      stageId,
+      timeoutMinutes,
+      key: v.key,
+    }),
+    deliver: (inbound) => deliverResumeSyntheticOrBuffer(v.agent, inbound),
+    recordMiss: () => recordMissedApproval({
+      stageId,
+      toolName: 'request_secret',
+      action: `provide the secret \`${v.key}\` for ${v.agent}`,
+      chatId: v.chat_id,
+      ...(v.threadId != null ? { threadId: v.threadId } : {}),
+      now,
+    }),
+    log: cardExpiryLog,
   })
   process.stderr.write(
     `telegram gateway: request_secret TTL expired — wake agent=${v.agent} ` +
@@ -5860,30 +5895,35 @@ function expireSecretRequestCard(stageId: string, v: PendingSecretRequest, now: 
 }
 
 function expireMentalModelProposeCard(stageId: string, v: PendingMentalModelPropose, now: number): void {
-  pendingMentalModelProposes.delete(stageId)
-  pendingCardStore.remove(stageId)
-  void editCardExpired(
-    v.chat_id,
-    v.card_message_id,
-    `⌛ _This mental-model proposal card for \`${escapeHtmlForTg(v.spec.name)}\` timed out before you tapped. Ask **${escapeHtmlForTg(v.agent)}** to re-propose if it still stands._`,
-  )
   const timeoutMinutes = Math.round(MENTAL_MODEL_PROPOSE_TTL_MS / 60000)
-  const inbound = buildMentalModelProposeTimeoutInbound({
-    agent: v.agent,
-    chatId: v.chat_id,
-    ...(v.threadId != null ? { threadId: v.threadId } : {}),
-    stageId,
-    timeoutMinutes,
-    name: v.spec.name,
-  })
-  const delivered = deliverResumeSyntheticOrBuffer(v.agent, inbound)
-  recordMissedApproval({
-    stageId,
-    toolName: 'mental_model_propose',
-    action: `declare the mental model \`${v.spec.name}\` for ${v.agent}`,
-    chatId: v.chat_id,
-    ...(v.threadId != null ? { threadId: v.threadId } : {}),
-    now,
+  const { delivered } = expirePendingCard({
+    remove: () => {
+      pendingMentalModelProposes.delete(stageId)
+      pendingCardStore.remove(stageId)
+    },
+    editCard: () => void editCardExpired(
+      v.chat_id,
+      v.card_message_id,
+      `⌛ _This mental-model proposal card for \`${escapeHtmlForTg(v.spec.name)}\` timed out before you tapped. Ask **${escapeHtmlForTg(v.agent)}** to re-propose if it still stands._`,
+    ),
+    buildInbound: () => buildMentalModelProposeTimeoutInbound({
+      agent: v.agent,
+      chatId: v.chat_id,
+      ...(v.threadId != null ? { threadId: v.threadId } : {}),
+      stageId,
+      timeoutMinutes,
+      name: v.spec.name,
+    }),
+    deliver: (inbound) => deliverResumeSyntheticOrBuffer(v.agent, inbound),
+    recordMiss: () => recordMissedApproval({
+      stageId,
+      toolName: 'mental_model_propose',
+      action: `declare the mental model \`${v.spec.name}\` for ${v.agent}`,
+      chatId: v.chat_id,
+      ...(v.threadId != null ? { threadId: v.threadId } : {}),
+      now,
+    }),
+    log: cardExpiryLog,
   })
   process.stderr.write(
     `telegram gateway: mental_model_propose TTL expired — wake agent=${v.agent} ` +
@@ -5892,7 +5932,9 @@ function expireMentalModelProposeCard(stageId: string, v: PendingMentalModelProp
 }
 
 // Run all four agent-initiated approval-card expiry sweeps. Called from the
-// pendingStateReaper (the authoritative 60s timer).
+// pendingStateReaper (the authoritative 60s timer). Each family sweep is
+// per-entry guarded via sweepExpiredEntries, so one throwing expiry (dead IPC
+// socket, store IO error) can't skip the remaining entries or families.
 function sweepExpiredApprovalCards(now: number): void {
   sweepPendingVaultRequestAccesses(now)
   sweepPendingVaultRequestSaves(now)
@@ -6115,7 +6157,17 @@ const pendingStateReaper = setInterval(() => {
   // the authoritative timer — before this the only expiry path was a lazy
   // sweep on the NEXT stage, so an agent that ended its turn to wait on one of
   // these cards could sit parked forever if no further request ever staged.
-  sweepExpiredApprovalCards(now)
+  // try/catch matches the sibling sweepStaleTurnActiveMarker guard: an escaped
+  // throw inside this setInterval callback would reach uncaughtException and
+  // take the WHOLE gateway down (per-entry faults are already contained inside
+  // sweepExpiredEntries/expirePendingCard; this is the outer belt).
+  try {
+    sweepExpiredApprovalCards(now)
+  } catch (err) {
+    process.stderr.write(
+      `telegram gateway: approval-card expiry sweep failed: ${(err as Error).message}\n`,
+    )
+  }
   // #550: sweep a stale turn-active marker. Defence-in-depth for the
   // case where neither the turn_end arm nor onTurnComplete fired (SDK
   // killed before the JSONL turn_duration record, compaction window,
@@ -12212,9 +12264,13 @@ const PENDING_SECRET_REQUEST_TTL_MS = 30 * 60_000 // card lifetime
 const ARMED_SECRET_CAPTURE_TTL_MS = 10 * 60_000   // window to send the value after tapping
 
 function sweepSecretRequests(now = Date.now()): void {
-  for (const [k, v] of pendingSecretRequests) {
-    if (now - v.staged_at > PENDING_SECRET_REQUEST_TTL_MS) expireSecretRequestCard(k, v, now)
-  }
+  sweepExpiredEntries(
+    pendingSecretRequests,
+    (v, n) => n - v.staged_at > PENDING_SECRET_REQUEST_TTL_MS,
+    expireSecretRequestCard,
+    now,
+    cardExpiryLog,
+  )
   // armedSecretCaptures is a TRANSIENT post-tap window (never persisted): it's
   // only set after the operator taps [Provide securely], and the request is
   // no longer parked-on-a-card. Just drop stale ones — no wake needed.

--- a/telegram-plugin/gateway/pending-card-expiry.ts
+++ b/telegram-plugin/gateway/pending-card-expiry.ts
@@ -1,0 +1,98 @@
+/**
+ * Pure, injectable core for expiring an agent-initiated approval card
+ * (vault_request_access / vault_request_save / request_secret /
+ * mental_model_propose) whose TTL elapsed with no operator tap.
+ *
+ * Extracted from gateway.ts so the ORDERING and FAULT-ISOLATION contract is
+ * unit-testable behaviorally (pending-card-expiry.test.ts), not just pinned by
+ * source-text regex:
+ *
+ *   1. remove() FIRST — the in-memory map entry + durable store record are
+ *      dropped before anything else, so the expiry is single-shot: a second
+ *      reaper tick (or a concurrent lazy sweep) can never double-fire the
+ *      synthetic wake for the same card.
+ *   2. editCard() — best-effort ⌛ card strip; a Telegram failure never blocks
+ *      the wake.
+ *   3. recordMiss() — the missed-approvals re-offer entry is written BEFORE
+ *      the deliver attempt, so a throwing IPC socket can't lose the re-offer:
+ *      even if the wake never lands, the operator's return re-surfaces it.
+ *   4. deliver() — the timeout synthetic, wrapped in try/catch. A half-dead
+ *      client socket that throws on write is contained here: the error is
+ *      logged, `delivered: false` is returned, and the caller's sweep loop
+ *      continues to the remaining entries/families.
+ *
+ * Every step is individually guarded — one failing dependency never skips the
+ * later steps or escapes to the caller (the reaper's setInterval callback,
+ * where an escaped throw would take the whole gateway down via
+ * uncaughtException).
+ */
+
+import type { InboundMessage } from './ipc-protocol.js'
+
+export interface ExpireCardDeps {
+  /** Drop the in-memory map entry AND the durable store record. Runs first. */
+  remove: () => void
+  /** Best-effort ⌛ card edit (strip keyboard). Failures are swallowed. */
+  editCard: () => void
+  /** Build the timeout synthetic inbound for this card's family. */
+  buildInbound: () => InboundMessage
+  /** Inject the synthetic (turn-safe gate). May throw on a dead socket. */
+  deliver: (inbound: InboundMessage) => boolean
+  /** Record the missed-approvals re-offer entry. Runs BEFORE deliver. */
+  recordMiss: () => void
+  /** Error sink (stderr in production). */
+  log: (msg: string) => void
+}
+
+export interface ExpireCardResult {
+  delivered: boolean
+}
+
+export function expirePendingCard(deps: ExpireCardDeps): ExpireCardResult {
+  // 1. Single-shot: entry gone before any fallible side effect.
+  deps.remove()
+  // 2. Card strip is cosmetic — never let it block the wake.
+  try {
+    deps.editCard()
+  } catch (err) {
+    deps.log(`card-expiry: card edit failed: ${(err as Error).message}`)
+  }
+  // 3. Re-offer entry BEFORE the deliver attempt so a throwing deliver can't
+  //    lose it (the operator's return still re-surfaces the missed card).
+  try {
+    deps.recordMiss()
+  } catch (err) {
+    deps.log(`card-expiry: missed-approval record failed: ${(err as Error).message}`)
+  }
+  // 4. The wake itself — contained so one dead socket doesn't skip the
+  //    remaining entries in the caller's sweep loop.
+  let delivered = false
+  try {
+    delivered = deps.deliver(deps.buildInbound())
+  } catch (err) {
+    deps.log(`card-expiry: timeout synthetic delivery failed: ${(err as Error).message}`)
+  }
+  return { delivered }
+}
+
+/**
+ * Sweep one pending-card map: expire every entry past its TTL via `expire`,
+ * guarding each entry so one throwing expiry can't skip the rest of the map
+ * (or, at the caller, the remaining families).
+ */
+export function sweepExpiredEntries<T>(
+  map: Map<string, T>,
+  isExpired: (value: T, now: number) => boolean,
+  expire: (stageId: string, value: T, now: number) => void,
+  now: number,
+  log: (msg: string) => void,
+): void {
+  for (const [k, v] of map) {
+    if (!isExpired(v, now)) continue
+    try {
+      expire(k, v, now)
+    } catch (err) {
+      log(`card-expiry: expire threw for stage=${k}: ${(err as Error).message}`)
+    }
+  }
+}

--- a/telegram-plugin/gateway/pending-card-store.ts
+++ b/telegram-plugin/gateway/pending-card-store.ts
@@ -1,0 +1,167 @@
+/**
+ * Persistence store for in-flight AGENT-INITIATED approval cards that park
+ * the requesting agent until the operator taps: `vault_request_access`,
+ * `vault_request_save`, `request_secret`, and `mental_model_propose`.
+ *
+ * Problem (mirror of the permission-card `permission-card-store.ts` bug): the
+ * gateway holds each staged request in an in-memory Map only
+ * (`pendingVaultRequestAccesses`, `pendingVaultRequestSaves`,
+ * `pendingSecretRequests`, `pendingMentalModelProposes`). When the gateway
+ * restarts (crash OR container restart), every entry is lost. The card in
+ * Telegram keeps its live inline keyboard, so when the operator taps it later
+ * they hit the "Card expired — ask the agent to re-request" tombstone: no
+ * grant, no injected inbound, and the agent that ended its turn to WAIT on the
+ * card stays parked forever.
+ *
+ * Fix: persist the METADATA for every posted card to a JSON file in STATE_DIR.
+ * On each resolution (tap / TTL-expire) remove the entry. On gateway boot,
+ * restore surviving entries into the in-memory maps so a post-restart tap on a
+ * still-valid (unexpired) card works exactly like a pre-restart tap.
+ *
+ * SECRETS HYGIENE — LOAD-BEARING: this file is written to disk unencrypted.
+ * It MUST NOT carry any secret VALUE. `vault_request_save` stages a secret
+ * value in gateway memory; only its key/metadata is persisted here (never the
+ * value), so a restored save card is re-associated with a tap but cannot
+ * complete the write — the caller degrades gracefully (tells the agent the
+ * value was lost to a restart). `request_secret` never holds a value at
+ * staging time (the value arrives after the tap), so its metadata is safe to
+ * persist. The `check-no-pii-secrets` guard and the accompanying test pin the
+ * "no value field" invariant.
+ *
+ * File format: JSON array of PersistedApprovalCard objects. Written
+ * synchronously (mode 0o600) to avoid interleaving on concurrent card posts;
+ * production rate is a handful of cards, so the file stays tiny.
+ */
+
+import { readFileSync, writeFileSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+
+/** The four agent-initiated approval-card families we persist. */
+export type ApprovalCardFamily =
+  | 'vault_request_access'
+  | 'vault_request_save'
+  | 'request_secret'
+  | 'mental_model_propose'
+
+interface BasePersistedCard {
+  family: ApprovalCardFamily
+  /** The staging id embedded in the card's callback_data (dedup + re-associate). */
+  stageId: string
+  /** Agent that requested (process.env.SWITCHROOM_AGENT_NAME). */
+  agent: string
+  /** Chat the card was rendered into; edited on tap / expiry. */
+  chatId: string
+  /** Card message id (filled after the card is sent). */
+  cardMessageId?: number
+  /** Forum topic the agent was working in, if any. */
+  threadId?: number
+  /** Unix-ms staging timestamp — the TTL clock. Preserved across restart. */
+  stagedAt: number
+}
+
+export interface PersistedVaultAccessCard extends BasePersistedCard {
+  family: 'vault_request_access'
+  key: string
+  scope: 'read' | 'write'
+  reason?: string
+  ttlSeconds: number
+}
+
+export interface PersistedVaultSaveCard extends BasePersistedCard {
+  family: 'vault_request_save'
+  key: string
+  kind: 'string' | 'binary'
+  why?: string
+  // NOTE: NO `value` — the staged secret never touches disk.
+}
+
+export interface PersistedSecretRequestCard extends BasePersistedCard {
+  family: 'request_secret'
+  key: string
+  reason?: string
+}
+
+export interface PersistedMentalModelCard extends BasePersistedCard {
+  family: 'mental_model_propose'
+  spec: {
+    name: string
+    source_query: string
+    refresh_after_consolidation?: boolean
+    max_tokens?: number
+  }
+  reason?: string
+}
+
+export type PersistedApprovalCard =
+  | PersistedVaultAccessCard
+  | PersistedVaultSaveCard
+  | PersistedSecretRequestCard
+  | PersistedMentalModelCard
+
+export interface PendingCardStore {
+  /** Record a newly-posted card. Idempotent on stageId (replaces in place). */
+  add(entry: PersistedApprovalCard): void
+  /** Remove the entry for this stageId (resolved — tap or TTL). */
+  remove(stageId: string): void
+  /** All persisted entries (for boot-time restore). */
+  loadAll(): PersistedApprovalCard[]
+  /** Delete the backing file entirely. */
+  clear(): void
+}
+
+export function createPendingCardStore(stateDir: string): PendingCardStore {
+  const filePath = join(stateDir, 'pending-approval-cards.json')
+
+  function read(): PersistedApprovalCard[] {
+    try {
+      const raw = readFileSync(filePath, 'utf-8')
+      const parsed = JSON.parse(raw)
+      return Array.isArray(parsed) ? (parsed as PersistedApprovalCard[]) : []
+    } catch {
+      return []
+    }
+  }
+
+  function write(entries: PersistedApprovalCard[]): void {
+    try {
+      writeFileSync(filePath, JSON.stringify(entries), { encoding: 'utf-8', mode: 0o600 })
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: pending-card-store write failed: ${(err as Error).message}\n`,
+      )
+    }
+  }
+
+  return {
+    add(entry) {
+      const entries = read()
+      const idx = entries.findIndex(e => e.stageId === entry.stageId)
+      if (idx >= 0) {
+        entries[idx] = entry
+      } else {
+        entries.push(entry)
+      }
+      write(entries)
+    },
+
+    remove(stageId) {
+      const entries = read()
+      const filtered = entries.filter(e => e.stageId !== stageId)
+      if (filtered.length !== entries.length) {
+        write(filtered)
+      }
+    },
+
+    loadAll() {
+      return read()
+    },
+
+    clear() {
+      try {
+        unlinkSync(filePath)
+      } catch {
+        // File may not exist — that's fine.
+      }
+    },
+  }
+}

--- a/telegram-plugin/gateway/pending-card-store.ts
+++ b/telegram-plugin/gateway/pending-card-store.ts
@@ -25,15 +25,17 @@
  * complete the write — the caller degrades gracefully (tells the agent the
  * value was lost to a restart). `request_secret` never holds a value at
  * staging time (the value arrives after the tap), so its metadata is safe to
- * persist. The `check-no-pii-secrets` guard and the accompanying test pin the
- * "no value field" invariant.
+ * persist. The "no value field" invariant is enforced by the record types
+ * below (PersistedVaultSaveCard has no `value` member, so a callsite can't
+ * compile one in) and pinned by the on-disk sentinel test in
+ * pending-card-store.test.ts.
  *
  * File format: JSON array of PersistedApprovalCard objects. Written
  * synchronously (mode 0o600) to avoid interleaving on concurrent card posts;
  * production rate is a handful of cards, so the file stays tiny.
  */
 
-import { readFileSync, writeFileSync, unlinkSync } from 'node:fs'
+import { readFileSync, writeFileSync, unlinkSync, chmodSync } from 'node:fs'
 import { join } from 'node:path'
 
 /** The four agent-initiated approval-card families we persist. */
@@ -125,6 +127,10 @@ export function createPendingCardStore(stateDir: string): PendingCardStore {
   function write(entries: PersistedApprovalCard[]): void {
     try {
       writeFileSync(filePath, JSON.stringify(entries), { encoding: 'utf-8', mode: 0o600 })
+      // `mode` only applies when writeFileSync CREATES the file; an existing
+      // file keeps its prior perms. Re-assert 0600 on every write so the file
+      // can never stay laxer than intended.
+      chmodSync(filePath, 0o600)
     } catch (err) {
       process.stderr.write(
         `telegram gateway: pending-card-store write failed: ${(err as Error).message}\n`,

--- a/telegram-plugin/tests/approval-timeout-inbound-builders.test.ts
+++ b/telegram-plugin/tests/approval-timeout-inbound-builders.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Pin the synthetic-inbound shapes the gateway injects when an agent-initiated
+ * approval card TTL-expires unanswered (the "wake the parked agent on timeout"
+ * half of the durability fix). A regression that drops/changes `meta.source`
+ * silently breaks the wake-up: the bridge wouldn't recognize the source and the
+ * model wouldn't know its card timed out.
+ *
+ * The load-bearing wording invariant: each message says TIMEOUT, not a denial,
+ * matching the permission-card philosophy so the model degrades gracefully
+ * instead of spam-re-requesting into an absent operator.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  buildVaultAccessTimeoutInbound,
+  buildVaultSaveTimeoutInbound,
+  buildSecretRequestTimeoutInbound,
+  buildMentalModelProposeTimeoutInbound,
+} from '../gateway/approval-timeout-inbound-builders.js'
+
+const FIXED_NOW = 1_700_000_000_000
+const BASE = { agent: 'gymbro', chatId: '12345', stageId: 's1', timeoutMinutes: 60, nowMs: FIXED_NOW }
+
+describe('timeout inbound builders — envelope', () => {
+  const cases = [
+    buildVaultAccessTimeoutInbound({ ...BASE, key: 'fatsecret/creds', scope: 'read' }),
+    buildVaultSaveTimeoutInbound({ ...BASE, key: 'brevo/api-key' }),
+    buildSecretRequestTimeoutInbound({ ...BASE, key: 'openai/token' }),
+    buildMentalModelProposeTimeoutInbound({ ...BASE, name: 'training-plan-state' }),
+  ]
+
+  it('all share the canonical vault-broker envelope', () => {
+    for (const m of cases) {
+      expect(m.type).toBe('inbound')
+      expect(m.chatId).toBe('12345')
+      expect(m.user).toBe('vault-broker')
+      expect(m.userId).toBe(0)
+      expect(m.ts).toBe(FIXED_NOW)
+      expect(m.messageId).toBe(FIXED_NOW)
+      expect(m.meta?.agent).toBe('gymbro')
+      expect(m.meta?.stage_id).toBe('s1')
+    }
+  })
+
+  it('every message says TIMEOUT, not a denial (degrade-gracefully wording)', () => {
+    for (const m of cases) {
+      expect(m.text).toMatch(/TIMEOUT, not a denial/)
+      expect(m.text).toMatch(/60 min/)
+      expect(m.text).toMatch(/Do NOT (re-request|loop|re-propose)/i)
+    }
+  })
+})
+
+describe('timeout inbound builders — distinct sources', () => {
+  it('pins each meta.source string (load-bearing for the bridge)', () => {
+    expect(buildVaultAccessTimeoutInbound({ ...BASE, key: 'k', scope: 'read' }).meta?.source).toBe('vault_grant_timeout')
+    expect(buildVaultSaveTimeoutInbound({ ...BASE, key: 'k' }).meta?.source).toBe('vault_save_timeout')
+    expect(buildSecretRequestTimeoutInbound({ ...BASE, key: 'k' }).meta?.source).toBe('secret_request_timeout')
+    expect(buildMentalModelProposeTimeoutInbound({ ...BASE, name: 'n' }).meta?.source).toBe('mental_model_propose_timeout')
+  })
+
+  it('sources are all disjoint', () => {
+    const sources = [
+      buildVaultAccessTimeoutInbound({ ...BASE, key: 'k', scope: 'read' }).meta?.source,
+      buildVaultSaveTimeoutInbound({ ...BASE, key: 'k' }).meta?.source,
+      buildSecretRequestTimeoutInbound({ ...BASE, key: 'k' }).meta?.source,
+      buildMentalModelProposeTimeoutInbound({ ...BASE, name: 'n' }).meta?.source,
+    ]
+    expect(new Set(sources).size).toBe(4)
+  })
+})
+
+describe('timeout inbound builders — topic routing', () => {
+  const THREAD = 4242
+  it('threadId set → top-level threadId + meta.message_thread_id (stringified)', () => {
+    const m = buildVaultAccessTimeoutInbound({ ...BASE, threadId: THREAD, key: 'k', scope: 'write' })
+    expect(m.threadId).toBe(THREAD)
+    expect(m.meta?.message_thread_id).toBe(String(THREAD))
+    expect(m.meta?.scope).toBe('write')
+  })
+  it('threadId absent → both omitted (DM stays thread-less)', () => {
+    const m = buildVaultSaveTimeoutInbound({ ...BASE, key: 'k' })
+    expect(m.threadId).toBeUndefined()
+    expect(m.meta?.message_thread_id).toBeUndefined()
+  })
+  it('defaults nowMs to Date.now() when omitted', () => {
+    const before = Date.now()
+    const m = buildSecretRequestTimeoutInbound({ agent: 'a', chatId: '1', stageId: 's', timeoutMinutes: 30, key: 'k' })
+    const after = Date.now()
+    expect(m.ts).toBeGreaterThanOrEqual(before)
+    expect(m.ts).toBeLessThanOrEqual(after)
+    expect(m.messageId).toBe(m.ts)
+  })
+})

--- a/telegram-plugin/tests/mental-model-propose-callback-gate.test.ts
+++ b/telegram-plugin/tests/mental-model-propose-callback-gate.test.ts
@@ -41,16 +41,19 @@ describe('handleMentalModelProposeCallback — authorization gate', () => {
 })
 
 describe('handleMentalModelProposeCallback — TTL enforced at tap time', () => {
-  it('checks staged_at against MENTAL_MODEL_PROPOSE_TTL_MS at tap and edits the card away', () => {
+  it('checks staged_at against MENTAL_MODEL_PROPOSE_TTL_MS at tap and routes through the shared expiry path', () => {
     const block = proposeCallbackBlock()
     expect(block).toMatch(/Date\.now\(\) - pending\.staged_at > MENTAL_MODEL_PROPOSE_TTL_MS/)
-    // The expired branch deletes the pending entry and clears the keyboard so a
-    // stale card can't be tapped into an approval.
+    // The expired branch routes through expireMentalModelProposeCard, which
+    // deletes the pending entry, clears the durable store, edits the card away
+    // (keyboard stripped), AND wakes the parked agent with a timeout synthetic —
+    // so a stale card can't be tapped into an approval and the agent isn't left
+    // parked. (The helper's delete/clear/wake behavior is pinned in
+    // pending-card-durability-wiring.test.ts.)
     const ttlBranch =
       block.split('Date.now() - pending.staged_at > MENTAL_MODEL_PROPOSE_TTL_MS')[1]?.split('Single-shot')[0] ?? ''
-    expect(ttlBranch).toMatch(/pendingMentalModelProposes\.delete\(stageId\)/)
+    expect(ttlBranch).toMatch(/expireMentalModelProposeCard\(stageId, pending, Date\.now\(\)\)/)
     expect(ttlBranch).toMatch(/expired/)
-    expect(ttlBranch).toMatch(/inline_keyboard: \[\]/)
   })
 })
 

--- a/telegram-plugin/tests/pending-card-durability-wiring.test.ts
+++ b/telegram-plugin/tests/pending-card-durability-wiring.test.ts
@@ -132,9 +132,12 @@ describe('resolution clears the durable store (Defect A)', () => {
 // ─── Defect B: TTL expiry wakes the parked agent ──────────────────────────
 
 describe('TTL expiry wakes the parked agent (Defect B)', () => {
-  it('the periodic reaper runs the approval-card expiry sweep', () => {
+  it('the periodic reaper runs the approval-card expiry sweep inside try/catch', () => {
     const reaper = slice(GATEWAY, 'const pendingStateReaper = setInterval', 12000)
-    expect(reaper).toMatch(/sweepExpiredApprovalCards\(now\)/)
+    // The sweep call must be guarded like the sibling sweepStaleTurnActiveMarker:
+    // an escaped throw inside this setInterval callback reaches uncaughtException
+    // and takes the whole gateway down.
+    expect(reaper).toMatch(/try\s*\{\s*sweepExpiredApprovalCards\(now\)\s*\}\s*catch/)
   })
 
   it('sweepExpiredApprovalCards runs all four family sweeps', () => {
@@ -145,14 +148,19 @@ describe('TTL expiry wakes the parked agent (Defect B)', () => {
     expect(fn).toMatch(/sweepSecretRequests\(now\)/)
   })
 
-  it('each expire* helper injects a TIMEOUT synthetic + records a missed approval', () => {
+  it('each expire* helper routes through the guarded expirePendingCard core', () => {
     for (const [fnName, builder] of [
       ['function expireVaultAccessCard', 'buildVaultAccessTimeoutInbound'],
       ['function expireVaultSaveCard', 'buildVaultSaveTimeoutInbound'],
       ['function expireSecretRequestCard', 'buildSecretRequestTimeoutInbound'],
       ['function expireMentalModelProposeCard', 'buildMentalModelProposeTimeoutInbound'],
     ] as const) {
-      const fn = slice(GATEWAY, fnName, 1600)
+      const fn = slice(GATEWAY, fnName, 2400)
+      // The pure core owns ordering + fault isolation (delete-before-deliver,
+      // recordMiss-before-deliver, guarded deliver) — pinned BEHAVIORALLY in
+      // pending-card-expiry.test.ts. Here we pin that the gateway routes each
+      // family through it with the right dependencies.
+      expect(fn, fnName).toMatch(/expirePendingCard\(\{/)
       expect(fn, fnName).toMatch(new RegExp(builder))
       // turn-safe injection gate
       expect(fn, fnName).toMatch(/deliverResumeSyntheticOrBuffer\(/)
@@ -161,6 +169,18 @@ describe('TTL expiry wakes the parked agent (Defect B)', () => {
       // card edited to expired + store cleared
       expect(fn, fnName).toMatch(/editCardExpired\(/)
       expect(fn, fnName).toMatch(/pendingCardStore\.remove\(stageId\)/)
+    }
+  })
+
+  it('each family sweep is per-entry guarded via sweepExpiredEntries', () => {
+    for (const fnName of [
+      'function sweepPendingVaultRequestAccesses',
+      'function sweepPendingVaultRequestSaves',
+      'function sweepPendingMentalModelProposes',
+      'function sweepSecretRequests',
+    ]) {
+      const fn = slice(GATEWAY, fnName, 500)
+      expect(fn, fnName).toMatch(/sweepExpiredEntries\(/)
     }
   })
 

--- a/telegram-plugin/tests/pending-card-durability-wiring.test.ts
+++ b/telegram-plugin/tests/pending-card-durability-wiring.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Source-text wiring pins for the agent-initiated approval-card durability fix.
+ *
+ * gateway.ts has top-level side effects and isn't unit-importable; the pure
+ * primitives are unit-tested in pending-card-store.test.ts and
+ * approval-timeout-inbound-builders.test.ts. These pins lock the wiring that
+ * connects them so the two failure modes can't silently regress:
+ *
+ *   Defect A — pending card state was in-memory only; a gateway restart lost it
+ *     and a later tap hit the "Card expired" tombstone (agent parked forever).
+ *   Defect B — no wake on TTL expiry; an unanswered card left the agent parked
+ *     forever (the sweeps were lazy and never woke the agent).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const read = (p: string) => readFileSync(resolve(__dirname, '..', p), 'utf8')
+const GATEWAY = read('gateway/gateway.ts')
+
+function slice(src: string, header: string, span = 3000): string {
+  const start = src.indexOf(header)
+  expect(start, `expected to find ${header}`).toBeGreaterThan(-1)
+  return src.slice(start, start + span)
+}
+
+// ─── Store instantiation ──────────────────────────────────────────────────
+
+describe('pending-card-store wiring', () => {
+  it('imports and instantiates the durable pending-card store', () => {
+    expect(GATEWAY).toMatch(/from '\.\/pending-card-store\.js'/)
+    expect(GATEWAY).toMatch(/const pendingCardStore = createPendingCardStore\(STATE_DIR\)/)
+  })
+
+  it('imports the four timeout inbound builders', () => {
+    expect(GATEWAY).toMatch(/from '\.\/approval-timeout-inbound-builders\.js'/)
+    for (const b of [
+      'buildVaultAccessTimeoutInbound',
+      'buildVaultSaveTimeoutInbound',
+      'buildSecretRequestTimeoutInbound',
+      'buildMentalModelProposeTimeoutInbound',
+    ]) {
+      expect(GATEWAY).toContain(b)
+    }
+  })
+})
+
+// ─── Defect A part 1: persistence at staging ──────────────────────────────
+
+describe('staging persists card metadata (Defect A)', () => {
+  it('vault_request_access stages into the durable store', () => {
+    const fn = slice(GATEWAY, 'async function executeVaultRequestAccess', 6000)
+    expect(fn).toMatch(/pendingCardStore\.add\(\{[\s\S]*family: 'vault_request_access'/)
+  })
+
+  it('request_secret stages into the durable store', () => {
+    const fn = slice(GATEWAY, 'async function executeRequestSecret', 3000)
+    expect(fn).toMatch(/pendingCardStore\.add\(\{[\s\S]*family: 'request_secret'/)
+  })
+
+  it('mental_model_propose stages into the durable store', () => {
+    const fn = slice(GATEWAY, 'async function executeMentalModelPropose', 6000)
+    expect(fn).toMatch(/pendingCardStore\.add\(\{[\s\S]*family: 'mental_model_propose'/)
+  })
+
+  it('vault_request_save stages metadata but NEVER the secret value (hygiene)', () => {
+    const fn = slice(GATEWAY, 'async function executeVaultRequestSave', 6000)
+    const addBlock = slice(fn, "pendingCardStore.add({", 700)
+    expect(addBlock).toMatch(/family: 'vault_request_save'/)
+    // The staged secret `value` must NOT be copied into the persisted record.
+    expect(addBlock).not.toMatch(/value:/)
+  })
+})
+
+// ─── Defect A part 2: boot restore ────────────────────────────────────────
+
+describe('boot restore (Defect A)', () => {
+  it('defines restorePendingApprovalCards and calls it at boot', () => {
+    expect(GATEWAY).toMatch(/function restorePendingApprovalCards\(\)/)
+    expect(GATEWAY).toMatch(/restorePendingApprovalCards\(\)/g)
+  })
+
+  it('restored vault_request_save has no value + is flagged restoredWithoutValue', () => {
+    const fn = slice(GATEWAY, 'function restorePendingApprovalCards', 4000)
+    expect(fn).toMatch(/value: '',/)
+    expect(fn).toMatch(/restoredWithoutValue: true/)
+  })
+
+  it('a Save tap on a restored (valueless) card degrades gracefully instead of writing empty', () => {
+    const fn = slice(GATEWAY, 'async function handleVaultRequestSaveCallback', 9000)
+    expect(fn).toMatch(/pending\.restoredWithoutValue \|\| pending\.value\.length === 0/)
+    expect(fn).toMatch(/lost to a gateway restart/)
+    expect(fn).toMatch(/buildVaultSaveFailedInbound/)
+  })
+})
+
+// ─── Defect A part 3: removal on resolution ───────────────────────────────
+
+describe('resolution clears the durable store (Defect A)', () => {
+  it('vault access approve/deny remove from the store', () => {
+    // deny path
+    const deny = slice(GATEWAY, 'async function handleVaultRequestAccessCallback', 4000)
+    expect(deny).toMatch(/pendingCardStore\.remove\(stageId\)/)
+    // approve path (performVaultAccessApproval) removes on every terminal branch
+    const approve = slice(GATEWAY, 'async function performVaultAccessApproval', 9000)
+    expect(approve).toMatch(/pendingCardStore\.remove\(stageId\)/)
+  })
+
+  it('vault save resolution paths remove from the store', () => {
+    const fn = slice(GATEWAY, 'async function handleVaultRequestSaveCallback', 12000)
+    // discard / write-fail / success / passphrase-missing all clear the store.
+    const count = (fn.match(/pendingCardStore\.remove\(stageId\)/g) ?? []).length
+    expect(count).toBeGreaterThanOrEqual(3)
+  })
+
+  it('secret request provide/decline remove from the store', () => {
+    // capture (provide → value arrives) removes via armed.stageId
+    expect(GATEWAY).toMatch(/pendingCardStore\.remove\(armed\.stageId\)/)
+    const decline = slice(GATEWAY, 'async function handleSecretRequestCallback', 3000)
+    expect(decline).toMatch(/pendingCardStore\.remove\(stageId\)/)
+  })
+
+  it('mental model resolve removes from the store', () => {
+    const fn = slice(GATEWAY, 'async function handleMentalModelProposeCallback', 4000)
+    expect(fn).toMatch(/pendingCardStore\.remove\(stageId\)/)
+  })
+})
+
+// ─── Defect B: TTL expiry wakes the parked agent ──────────────────────────
+
+describe('TTL expiry wakes the parked agent (Defect B)', () => {
+  it('the periodic reaper runs the approval-card expiry sweep', () => {
+    const reaper = slice(GATEWAY, 'const pendingStateReaper = setInterval', 12000)
+    expect(reaper).toMatch(/sweepExpiredApprovalCards\(now\)/)
+  })
+
+  it('sweepExpiredApprovalCards runs all four family sweeps', () => {
+    const fn = slice(GATEWAY, 'function sweepExpiredApprovalCards', 600)
+    expect(fn).toMatch(/sweepPendingVaultRequestAccesses\(now\)/)
+    expect(fn).toMatch(/sweepPendingVaultRequestSaves\(now\)/)
+    expect(fn).toMatch(/sweepPendingMentalModelProposes\(now\)/)
+    expect(fn).toMatch(/sweepSecretRequests\(now\)/)
+  })
+
+  it('each expire* helper injects a TIMEOUT synthetic + records a missed approval', () => {
+    for (const [fnName, builder] of [
+      ['function expireVaultAccessCard', 'buildVaultAccessTimeoutInbound'],
+      ['function expireVaultSaveCard', 'buildVaultSaveTimeoutInbound'],
+      ['function expireSecretRequestCard', 'buildSecretRequestTimeoutInbound'],
+      ['function expireMentalModelProposeCard', 'buildMentalModelProposeTimeoutInbound'],
+    ] as const) {
+      const fn = slice(GATEWAY, fnName, 1600)
+      expect(fn, fnName).toMatch(new RegExp(builder))
+      // turn-safe injection gate
+      expect(fn, fnName).toMatch(/deliverResumeSyntheticOrBuffer\(/)
+      // re-offered when the operator returns
+      expect(fn, fnName).toMatch(/recordMissedApproval\(/)
+      // card edited to expired + store cleared
+      expect(fn, fnName).toMatch(/editCardExpired\(/)
+      expect(fn, fnName).toMatch(/pendingCardStore\.remove\(stageId\)/)
+    }
+  })
+
+  it('recordMissedApproval writes to the missed-approvals store (re-offer path)', () => {
+    const fn = slice(GATEWAY, 'function recordMissedApproval', 700)
+    expect(fn).toMatch(/missedApprovalsStore\.add\(/)
+    expect(fn).toMatch(/MISSED_APPROVAL_REOFFER_ENABLED/)
+  })
+})
+
+// ─── Copy-bug fix: derive the timeout window from the real TTL ─────────────
+
+describe('vault_request_access copy derives the window from the real TTL', () => {
+  it('no hard-coded "10 min" claim; uses VAULT_REQUEST_ACCESS_TTL_MS', () => {
+    const fn = slice(GATEWAY, 'async function executeVaultRequestAccess', 12000)
+    expect(fn).not.toMatch(/times out \(10 min\)/)
+    expect(fn).toMatch(/Math\.round\(VAULT_REQUEST_ACCESS_TTL_MS \/ 60000\)/)
+  })
+})

--- a/telegram-plugin/tests/pending-card-expiry.test.ts
+++ b/telegram-plugin/tests/pending-card-expiry.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Behavioral pins for the pure approval-card expiry core
+ * (gateway/pending-card-expiry.ts) — the ordering + fault-isolation contract
+ * the gateway's reaper relies on:
+ *
+ *   - single-shot: two reaper ticks fire exactly ONE synthetic per expired card
+ *     (delete-before-deliver, pinned behaviorally, not by regex),
+ *   - a throwing deliver (half-dead IPC socket) never loses the
+ *     missed-approvals re-offer and never escapes to the caller,
+ *   - one throwing expiry never skips the remaining entries in a sweep.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import type { InboundMessage } from '../gateway/ipc-protocol.js'
+import {
+  expirePendingCard,
+  sweepExpiredEntries,
+  type ExpireCardDeps,
+} from '../gateway/pending-card-expiry.js'
+
+const INBOUND: InboundMessage = {
+  type: 'inbound',
+  chatId: '1',
+  messageId: 1,
+  user: 'vault-broker',
+  userId: 0,
+  ts: 1,
+  text: 'timeout',
+}
+
+function makeDeps(overrides: Partial<ExpireCardDeps> = {}): ExpireCardDeps & {
+  calls: string[]
+} {
+  const calls: string[] = []
+  return {
+    calls,
+    remove: () => calls.push('remove'),
+    editCard: () => calls.push('editCard'),
+    buildInbound: () => {
+      calls.push('buildInbound')
+      return INBOUND
+    },
+    deliver: () => {
+      calls.push('deliver')
+      return true
+    },
+    recordMiss: () => calls.push('recordMiss'),
+    log: () => {},
+    ...overrides,
+  }
+}
+
+describe('expirePendingCard — ordering contract', () => {
+  it('runs remove FIRST, then editCard, then recordMiss BEFORE deliver', () => {
+    const deps = makeDeps()
+    const { delivered } = expirePendingCard(deps)
+    expect(delivered).toBe(true)
+    expect(deps.calls).toEqual(['remove', 'editCard', 'recordMiss', 'buildInbound', 'deliver'])
+  })
+
+  it('a throwing deliver returns delivered=false, never throws, and the re-offer is already recorded', () => {
+    const log = vi.fn()
+    const deps = makeDeps({
+      deliver: () => {
+        throw new Error('EPIPE: half-dead socket')
+      },
+      log,
+    })
+    const { delivered } = expirePendingCard(deps)
+    expect(delivered).toBe(false)
+    // recordMiss ran BEFORE the deliver attempt — the missed-approvals entry
+    // survives the failed wake (the operator's return re-offers it).
+    expect(deps.calls).toContain('recordMiss')
+    expect(deps.calls.indexOf('recordMiss')).toBeLessThan(deps.calls.indexOf('buildInbound'))
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('delivery failed'))
+  })
+
+  it('a throwing editCard still records the miss and delivers the wake', () => {
+    const deps = makeDeps({
+      editCard: () => {
+        throw new Error('telegram edit failed')
+      },
+    })
+    const { delivered } = expirePendingCard(deps)
+    expect(delivered).toBe(true)
+    expect(deps.calls).toEqual(['remove', 'recordMiss', 'buildInbound', 'deliver'])
+  })
+
+  it('a throwing recordMiss still delivers the wake', () => {
+    const deps = makeDeps({
+      recordMiss: () => {
+        throw new Error('store write failed')
+      },
+    })
+    const { delivered } = expirePendingCard(deps)
+    expect(delivered).toBe(true)
+    expect(deps.calls).toContain('deliver')
+  })
+})
+
+describe('sweepExpiredEntries — single-shot across ticks', () => {
+  interface Entry {
+    staged_at: number
+  }
+  const TTL = 60_000
+
+  function makeSweepWorld() {
+    const map = new Map<string, Entry>()
+    const synthetics: string[] = []
+    const expire = (stageId: string, _v: Entry, _now: number) => {
+      // Mirrors the gateway wiring: expirePendingCard with remove-from-map
+      // FIRST and the synthetic recorded on deliver.
+      expirePendingCard({
+        remove: () => map.delete(stageId),
+        editCard: () => {},
+        buildInbound: () => INBOUND,
+        deliver: () => {
+          synthetics.push(stageId)
+          return true
+        },
+        recordMiss: () => {},
+        log: () => {},
+      })
+    }
+    const tick = (now: number) =>
+      sweepExpiredEntries(map, (v, n) => v.staged_at < n - TTL, expire, now, () => {})
+    return { map, synthetics, tick }
+  }
+
+  it('two reaper ticks fire exactly ONE synthetic per expired card', () => {
+    const { map, synthetics, tick } = makeSweepWorld()
+    map.set('s1', { staged_at: 0 })
+    map.set('s2', { staged_at: 0 })
+    map.set('fresh', { staged_at: 150_000 }) // still inside TTL at both ticks
+
+    tick(120_000) // both s1+s2 expired; fresh is not
+    tick(180_000) // second tick — expired entries are GONE from the map
+
+    expect(synthetics.sort()).toEqual(['s1', 's2'])
+    expect(map.has('fresh')).toBe(true)
+    expect(map.size).toBe(1)
+  })
+
+  it('delete-before-deliver: the map entry is gone by the time the synthetic fires', () => {
+    const map = new Map<string, Entry>()
+    map.set('s1', { staged_at: 0 })
+    let presentAtDeliver: boolean | null = null
+    sweepExpiredEntries(
+      map,
+      (v, n) => v.staged_at < n - TTL,
+      (stageId) => {
+        expirePendingCard({
+          remove: () => map.delete(stageId),
+          editCard: () => {},
+          buildInbound: () => INBOUND,
+          deliver: () => {
+            presentAtDeliver = map.has(stageId)
+            return true
+          },
+          recordMiss: () => {},
+          log: () => {},
+        })
+      },
+      120_000,
+      () => {},
+    )
+    expect(presentAtDeliver).toBe(false)
+  })
+
+  it('one throwing expiry does not skip the remaining entries', () => {
+    const map = new Map<string, Entry>()
+    map.set('boom', { staged_at: 0 })
+    map.set('ok', { staged_at: 0 })
+    const expired: string[] = []
+    const log = vi.fn()
+    sweepExpiredEntries(
+      map,
+      (v, n) => v.staged_at < n - TTL,
+      (stageId) => {
+        if (stageId === 'boom') throw new Error('dead socket at the worst layer')
+        map.delete(stageId)
+        expired.push(stageId)
+      },
+      120_000,
+      log,
+    )
+    expect(expired).toEqual(['ok'])
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('boom'))
+  })
+})

--- a/telegram-plugin/tests/pending-card-store.test.ts
+++ b/telegram-plugin/tests/pending-card-store.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Durable store for the four AGENT-INITIATED approval-card families
+ * (vault_request_access / vault_request_save / request_secret /
+ * mental_model_propose). Mirrors permission-card-store.test.ts.
+ *
+ * The load-bearing extra invariant here (beyond plain persistence): NO SECRET
+ * VALUE ever lands on disk. The file is written unencrypted; a vault_request_save
+ * stages the secret value in gateway memory only, and this store must persist
+ * just its key/metadata. The "no value field" test is the regression guard for
+ * that hygiene rule.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  createPendingCardStore,
+  type PersistedApprovalCard,
+} from '../gateway/pending-card-store.js'
+
+function makeTmpDir() {
+  return mkdtempSync(join(tmpdir(), 'pending-card-store-test-'))
+}
+
+const ACCESS: PersistedApprovalCard = {
+  family: 'vault_request_access',
+  stageId: 'a1b2c3d4',
+  agent: 'gymbro',
+  chatId: '10001',
+  cardMessageId: 555,
+  key: 'fatsecret/credentials',
+  scope: 'read',
+  reason: 'needs the API for the daily log',
+  ttlSeconds: 30 * 86400,
+  stagedAt: 1_700_000_000_000,
+}
+
+const SAVE: PersistedApprovalCard = {
+  family: 'vault_request_save',
+  stageId: 'e5f6a7b8',
+  agent: 'marko',
+  chatId: '10002',
+  cardMessageId: 556,
+  key: 'brevo/api-key',
+  kind: 'string',
+  why: 'store the campaign key',
+  stagedAt: 1_700_000_000_000,
+}
+
+const SECRET: PersistedApprovalCard = {
+  family: 'request_secret',
+  stageId: 'c9d0e1f2',
+  agent: 'gymbro',
+  chatId: '10003',
+  cardMessageId: 557,
+  key: 'openai/token',
+  reason: 'the model call needs it',
+  stagedAt: 1_700_000_000_000,
+}
+
+const MMP: PersistedApprovalCard = {
+  family: 'mental_model_propose',
+  stageId: 'aabbccdd',
+  agent: 'gymbro',
+  chatId: '10004',
+  cardMessageId: 558,
+  spec: { name: 'training-plan-state', source_query: 'the user current training plan' },
+  stagedAt: 1_700_000_000_000,
+}
+
+describe('createPendingCardStore', () => {
+  let dir: string
+  beforeEach(() => { dir = makeTmpDir() })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('starts empty', () => {
+    expect(createPendingCardStore(dir).loadAll()).toEqual([])
+  })
+
+  it('add + loadAll round-trips each family', () => {
+    const store = createPendingCardStore(dir)
+    store.add(ACCESS)
+    store.add(SAVE)
+    store.add(SECRET)
+    store.add(MMP)
+    const all = store.loadAll()
+    expect(all.length).toBe(4)
+    expect(new Set(all.map(e => e.family))).toEqual(
+      new Set(['vault_request_access', 'vault_request_save', 'request_secret', 'mental_model_propose']),
+    )
+  })
+
+  it('add is idempotent on stageId (replaces in place)', () => {
+    const store = createPendingCardStore(dir)
+    store.add(SAVE)
+    store.add({ ...SAVE, cardMessageId: 999 })
+    const all = store.loadAll()
+    expect(all.length).toBe(1)
+    expect((all[0] as { cardMessageId?: number }).cardMessageId).toBe(999)
+  })
+
+  it('remove drops only the matching stageId', () => {
+    const store = createPendingCardStore(dir)
+    store.add(ACCESS)
+    store.add(SAVE)
+    store.remove(ACCESS.stageId)
+    const all = store.loadAll()
+    expect(all.length).toBe(1)
+    expect(all[0].stageId).toBe(SAVE.stageId)
+  })
+
+  it('remove is idempotent when the entry is absent', () => {
+    const store = createPendingCardStore(dir)
+    expect(() => store.remove('nope')).not.toThrow()
+  })
+
+  it('clear empties the store', () => {
+    const store = createPendingCardStore(dir)
+    store.add(ACCESS)
+    store.clear()
+    expect(store.loadAll()).toEqual([])
+  })
+
+  it('survives re-instantiation (data persists across gateway restart)', () => {
+    createPendingCardStore(dir).add(ACCESS)
+    const all = createPendingCardStore(dir).loadAll()
+    expect(all.length).toBe(1)
+    expect(all[0].stageId).toBe(ACCESS.stageId)
+    // The restored access card carries everything a post-restart tap needs to
+    // mint the grant: agent, key, scope, ttl, chat, card message id.
+    const restored = all[0] as Extract<PersistedApprovalCard, { family: 'vault_request_access' }>
+    expect(restored.agent).toBe('gymbro')
+    expect(restored.key).toBe('fatsecret/credentials')
+    expect(restored.scope).toBe('read')
+    expect(restored.ttlSeconds).toBe(30 * 86400)
+    expect(restored.cardMessageId).toBe(555)
+  })
+
+  // ── Secrets hygiene — the whole reason this store persists metadata only ──
+  it('a vault_request_save record has NO `value` field (type + runtime)', () => {
+    // Type-level: PersistedVaultSaveCard has no `value` member, so this object
+    // literal wouldn't compile with one. Runtime-level: assert it's absent.
+    expect('value' in SAVE).toBe(false)
+  })
+
+  it('the on-disk JSON contains NO secret value for a saved card', () => {
+    const store = createPendingCardStore(dir)
+    // Simulate the gateway callsite: it builds the persisted record from the
+    // pending entry WITHOUT copying `value`. Even if a caller mistakenly spread
+    // a value in, the type wouldn't allow it — but assert the file is clean.
+    store.add(SAVE)
+    const raw = readFileSync(join(dir, 'pending-approval-cards.json'), 'utf-8')
+    const SECRET_SENTINEL = 'super-secret-brevo-value'
+    expect(raw).not.toContain(SECRET_SENTINEL)
+    expect(raw).not.toContain('"value"')
+    // The key/metadata we DO need is present.
+    expect(raw).toContain('brevo/api-key')
+    expect(raw).toContain('vault_request_save')
+  })
+
+  it('the file is written with 0600 perms (no world-readable secrets-adjacent state)', () => {
+    const store = createPendingCardStore(dir)
+    store.add(ACCESS)
+    // mode is enforced at write; a re-read via the store proves the file is
+    // parseable. (Perms are asserted structurally by the write options.)
+    expect(createPendingCardStore(dir).loadAll().length).toBe(1)
+  })
+})

--- a/telegram-plugin/tests/pending-card-store.test.ts
+++ b/telegram-plugin/tests/pending-card-store.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import {
@@ -159,11 +159,15 @@ describe('createPendingCardStore', () => {
     expect(raw).toContain('vault_request_save')
   })
 
-  it('the file is written with 0600 perms (no world-readable secrets-adjacent state)', () => {
+  it('the file ends up 0600 even when it pre-existed with lax perms', () => {
+    // writeFileSync's `mode` only applies on CREATE — a pre-existing
+    // world-readable file would keep its perms without the explicit chmod
+    // the store does on every write.
+    const filePath = join(dir, 'pending-approval-cards.json')
+    writeFileSync(filePath, '[]', { mode: 0o644 })
     const store = createPendingCardStore(dir)
     store.add(ACCESS)
-    // mode is enforced at write; a re-read via the store proves the file is
-    // parseable. (Perms are asserted structurally by the write options.)
+    expect(statSync(filePath).mode & 0o777).toBe(0o600)
     expect(createPendingCardStore(dir).loadAll().length).toBe(1)
   })
 })


### PR DESCRIPTION
## User outcome

**Agents are never permanently parked on an approval card — cards survive restarts and timeouts wake the agent.**

The four agent-initiated approval-card families (`vault_request_access`, `vault_request_save`, `request_secret`, `mental_model_propose`) each end the agent's turn to wait for an operator tap. Two confirmed defects could leave that agent parked forever.

## Defect A — pending card state was in-memory only

A gateway restart (crash or container restart) lost every staged entry. The card in Telegram kept its live keyboard, so a later tap hit the "Card expired — ask the agent to re-request" tombstone: no grant, no injected inbound, agent stuck.

Fix — a durable `pending-card-store.ts` (JSON in `STATE_DIR`, mirrors the existing `permission-card-store.ts` + `rearmPermissionFromStore` pattern):
- persists card **metadata** at staging (`pendingCardStore.add`),
- removes it on every resolution path (tap / TTL),
- restores it at boot (`restorePendingApprovalCards`) so a post-restart tap on a still-valid card resolves exactly like a pre-restart tap (approve → grant + synthetic; deny → denial synthetic).

**Secrets hygiene (load-bearing):** the `vault_request_save` staged **value** is NEVER written to disk. A restored save card is flagged `restoredWithoutValue`; a Save tap on it degrades gracefully — wakes the agent with a "value lost to a gateway restart" synthetic instead of writing an empty secret. `request_secret` holds no value at staging time (it arrives after the tap), so its metadata is safe.

## Defect B — no wake on TTL expiry

The sweeps were lazy (only ran when the *next* request staged). An unanswered card left the agent parked with nothing injected.

Fix — the periodic `pendingStateReaper` now runs all four family sweeps every 60s (`sweepExpiredApprovalCards`). On expiry each card:
- is edited to a ⌛ expired state (keyboard stripped),
- injects a **TIMEOUT, not a denial** synthetic via the turn-safe `deliverResumeSyntheticOrBuffer` gate (four new builders in `approval-timeout-inbound-builders.ts`, each with a distinct `meta.source` and degrade-gracefully wording), and
- is recorded in `missedApprovalsStore` so it's re-offered when the operator returns — matching the permission-card behavior.

## Copy-bug fix

`vault_request_access` claimed a "10 min" timeout window but the TTL is `approvalTtlMs()` (60-min default). The copy now derives from the actual TTL.

## Scope note

Avoided the agent-button callback handler (~L24500+) and boot-resume block (~L1400) regions per the parallel-worker coordination note.

## Test plan

- `pending-card-store.test.ts` — persistence round-trip per family, idempotent add/remove, survives re-instantiation (restart), and the **no-secret-value-on-disk** hygiene invariant.
- `approval-timeout-inbound-builders.test.ts` — TIMEOUT-not-a-denial wording, distinct `meta.source` strings, envelope + topic routing.
- `pending-card-durability-wiring.test.ts` — gateway source-text pins: staging persists, boot restores (save is valueless + flagged), resolution removes, reaper wakes + re-offers, copy derives from TTL.
- Updated `mental-model-propose-callback-gate.test.ts` for the shared expiry path.
- New suites: 35 pass. Adjacent suites (vault/secret/reaper/rearm/missed-approvals): green. `check-plugin-references` (strict tsc over plugin), `check-bot-api-wrapping`, and the other lint guards: clean.

Job spec: `reference/jobs/` — this advances the "always available" outcome (an agent blocked on a lost approval card is unavailable) and the on-leash approval contract (operator taps are the safety boundary; a restart or timeout must not silently drop them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)