### PR TITLE
test: outcome-based coverage for the approval/restart continuation specs

### DIFF
--- a/telegram-plugin/tests/approval-card-restart-outcome.test.ts
+++ b/telegram-plugin/tests/approval-card-restart-outcome.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Outcome-based composition test for the approval/restart continuation
+ * contract in `reference/jobs/approve-what-my-agent-can-touch.md`:
+ *
+ *   - "An approval card survives a gateway restart. A tap on a still-valid
+ *      card after a restart works; a card that expired during the outage is
+ *      re-offered on the operator's return."
+ *   - "Cards time out (60-min default) and the timeout wakes the agent as a
+ *      timeout, not a denial ... An expired card is re-offered when the
+ *      operator returns."
+ *
+ * The sibling suites pin each module in isolation (pending-card-store.test.ts,
+ * pending-card-expiry.test.ts with mocked deps, approval-timeout-inbound-
+ * builders.test.ts) and pending-card-durability-wiring.test.ts pins the
+ * gateway wiring at the source-text level. This suite wires the REAL modules
+ * together — file-backed durable store + real missed-approvals store + real
+ * expiry sweep + real timeout builders — across a simulated gateway bounce
+ * (store re-instantiation from the same state dir), asserting the promised
+ * OUTCOMES rather than any one module's contract. The user-visible acceptance
+ * twin is `uat/scenarios/vault-card-survives-gateway-restart-dm.test.ts`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  createPendingCardStore,
+  type PersistedApprovalCard,
+  type PersistedVaultAccessCard,
+} from '../gateway/pending-card-store.js'
+import { createMissedApprovalsStore } from '../gateway/missed-approvals-store.js'
+import { expirePendingCard, sweepExpiredEntries } from '../gateway/pending-card-expiry.js'
+import { buildVaultAccessTimeoutInbound } from '../gateway/approval-timeout-inbound-builders.js'
+import type { InboundMessage } from '../gateway/ipc-protocol.js'
+
+const TTL_MS = 60 * 60_000 // the 60-min default the spec names
+const NOW = 1_700_000_000_000
+
+function accessCard(overrides: Partial<PersistedVaultAccessCard> = {}): PersistedVaultAccessCard {
+  return {
+    family: 'vault_request_access',
+    stageId: 'stage-1',
+    agent: 'test-agent',
+    chatId: '12345',
+    cardMessageId: 777,
+    stagedAt: NOW - 60_000, // staged a minute ago — still valid
+    key: 'example/api-key',
+    scope: 'read',
+    ttlSeconds: 30 * 86_400,
+    ...overrides,
+  }
+}
+
+describe('approval/restart continuation — spec outcomes across a gateway bounce', () => {
+  let stateDir: string
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), 'approval-card-restart-outcome-'))
+  })
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true })
+  })
+
+  it('a still-valid card survives the bounce intact, and a post-restart tap resolution works', () => {
+    // Gateway process #1 stages the card.
+    const before = createPendingCardStore(stateDir)
+    const card = accessCard()
+    before.add(card)
+
+    // ── gateway restarts: all in-memory maps are gone ──
+    const after = createPendingCardStore(stateDir)
+    const restored = after.loadAll()
+    expect(restored).toHaveLength(1)
+    expect(restored[0]).toEqual(card) // metadata intact, TTL clock preserved
+
+    // The operator taps the still-live keyboard: resolution removes the
+    // durable record exactly like a pre-restart tap would.
+    after.remove(card.stageId)
+    expect(after.loadAll()).toHaveLength(0)
+  })
+
+  it('a card that expired during the outage wakes the agent ONCE as timeout-not-denial and records the re-offer', () => {
+    // Staged well past the TTL before the bounce.
+    const expired = accessCard({ stageId: 'stage-expired', stagedAt: NOW - TTL_MS - 60_000 })
+    createPendingCardStore(stateDir).add(expired)
+
+    // ── restart: restore into the in-memory map, then the reaper sweeps ──
+    const store = createPendingCardStore(stateDir)
+    const missed = createMissedApprovalsStore(stateDir)
+    const map = new Map<string, PersistedVaultAccessCard>(
+      store.loadAll().map(e => [e.stageId, e as PersistedVaultAccessCard]),
+    )
+    expect(map.size).toBe(1)
+
+    const delivered: InboundMessage[] = []
+    const sweep = () =>
+      sweepExpiredEntries(
+        map,
+        (v, now) => v.stagedAt < now - TTL_MS,
+        (stageId, v) => {
+          expirePendingCard({
+            remove: () => {
+              map.delete(stageId)
+              store.remove(stageId)
+            },
+            editCard: () => {},
+            buildInbound: () =>
+              buildVaultAccessTimeoutInbound({
+                agent: v.agent,
+                chatId: v.chatId,
+                stageId,
+                timeoutMinutes: Math.round(TTL_MS / 60_000),
+                nowMs: NOW,
+                key: v.key,
+                scope: v.scope,
+              }),
+            deliver: m => {
+              delivered.push(m)
+              return true
+            },
+            recordMiss: () =>
+              missed.add({
+                requestId: `approval-card:${stageId}`,
+                toolName: 'vault_request_access',
+                action: `vault access to ${v.key}`,
+                chatId: v.chatId,
+                timedOutAt: NOW,
+              }),
+            log: () => {},
+          })
+        },
+        NOW,
+        () => {},
+      )
+
+    sweep()
+
+    // Exactly one wake, and it is a TIMEOUT, never a denial.
+    expect(delivered).toHaveLength(1)
+    expect(delivered[0].text).toMatch(/TIMEOUT, not a denial/)
+    expect(delivered[0].text).toContain('example/api-key')
+    expect(delivered[0].meta?.source).toBe('vault_grant_timeout')
+
+    // The re-offer is durably recorded for the operator's return.
+    const pending = missed.listPending()
+    expect(pending).toHaveLength(1)
+    expect(pending[0].requestId).toBe('approval-card:stage-expired')
+
+    // Durable record is gone — a later boot can't resurrect the card.
+    expect(store.loadAll()).toHaveLength(0)
+
+    // A second reaper tick (or a second boot sweep) never double-fires.
+    sweep()
+    expect(delivered).toHaveLength(1)
+  })
+
+  it('the post-restart sweep never expires a still-valid card (no false timeout on bounce)', () => {
+    const valid = accessCard({ stageId: 'stage-valid', stagedAt: NOW - 60_000 })
+    createPendingCardStore(stateDir).add(valid)
+
+    const store = createPendingCardStore(stateDir)
+    const map = new Map<string, PersistedApprovalCard>(store.loadAll().map(e => [e.stageId, e]))
+
+    let expiredCount = 0
+    sweepExpiredEntries(
+      map,
+      (v, now) => v.stagedAt < now - TTL_MS,
+      () => {
+        expiredCount += 1
+      },
+      NOW,
+      () => {},
+    )
+
+    expect(expiredCount).toBe(0)
+    expect(map.size).toBe(1) // the card stays live and tappable
+    expect(store.loadAll()).toHaveLength(1)
+  })
+})

--- a/telegram-plugin/tests/approval-card-restart-outcome.test.ts
+++ b/telegram-plugin/tests/approval-card-restart-outcome.test.ts
@@ -16,8 +16,16 @@
  * together — file-backed durable store + real missed-approvals store + real
  * expiry sweep + real timeout builders — across a simulated gateway bounce
  * (store re-instantiation from the same state dir), asserting the promised
- * OUTCOMES rather than any one module's contract. The user-visible acceptance
- * twin is `uat/scenarios/vault-card-survives-gateway-restart-dm.test.ts`.
+ * OUTCOMES rather than any one module's contract.
+ *
+ * SCOPE CAVEAT: the expiry predicate / remove / deliver / recordMiss closures
+ * below are TEST-SUPPLIED stand-ins for gateway.ts's inline closures (which
+ * close over module-level gateway state and can't be imported without a
+ * production refactor). This suite therefore proves the modules COMPOSE
+ * correctly; that gateway.ts actually wires them this way is pinned
+ * separately by pending-card-durability-wiring.test.ts's source greps. The
+ * user-visible acceptance twin is
+ * `uat/scenarios/vault-card-survives-gateway-restart-dm.test.ts`.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
@@ -35,7 +43,11 @@ import { expirePendingCard, sweepExpiredEntries } from '../gateway/pending-card-
 import { buildVaultAccessTimeoutInbound } from '../gateway/approval-timeout-inbound-builders.js'
 import type { InboundMessage } from '../gateway/ipc-protocol.js'
 
-const TTL_MS = 60 * 60_000 // the 60-min default the spec names
+// Test-local stand-in for the 60-min default the spec names. The production
+// TTL comes from approvalTtlMs() in gateway/permission-timeout.ts; this suite
+// does NOT assert that config plumbing — only how the modules behave around
+// whatever TTL the sweep predicate encodes.
+const TTL_MS = 60 * 60_000
 const NOW = 1_700_000_000_000
 
 function accessCard(overrides: Partial<PersistedVaultAccessCard> = {}): PersistedVaultAccessCard {
@@ -63,7 +75,7 @@ describe('approval/restart continuation — spec outcomes across a gateway bounc
     rmSync(stateDir, { recursive: true, force: true })
   })
 
-  it('a still-valid card survives the bounce intact, and a post-restart tap resolution works', () => {
+  it('a still-valid card record survives the bounce intact, and removing it clears the durable store', () => {
     // Gateway process #1 stages the card.
     const before = createPendingCardStore(stateDir)
     const card = accessCard()
@@ -73,10 +85,14 @@ describe('approval/restart continuation — spec outcomes across a gateway bounc
     const after = createPendingCardStore(stateDir)
     const restored = after.loadAll()
     expect(restored).toHaveLength(1)
-    expect(restored[0]).toEqual(card) // metadata intact, TTL clock preserved
+    // Metadata roundtrips byte-identical — stagedAt included, so the expiry
+    // deadline the sweep computes from it is unchanged by the bounce.
+    expect(restored[0]).toEqual(card)
 
-    // The operator taps the still-live keyboard: resolution removes the
-    // durable record exactly like a pre-restart tap would.
+    // Post-restart resolution path (what a tap handler does with the store):
+    // remove() drops the durable record so a later boot can't resurrect it.
+    // The tap handler's Telegram/grant side is NOT exercised here — that's
+    // the UAT twin's job.
     after.remove(card.stageId)
     expect(after.loadAll()).toHaveLength(0)
   })
@@ -151,8 +167,29 @@ describe('approval/restart continuation — spec outcomes across a gateway bounc
     // Durable record is gone — a later boot can't resurrect the card.
     expect(store.loadAll()).toHaveLength(0)
 
-    // A second reaper tick (or a second boot sweep) never double-fires.
-    sweep()
+    // A second boot's sweep restores from the (now empty) durable store and
+    // therefore fires nothing — the remove() step cleared BOTH the in-memory
+    // map and the store, so no later process can re-deliver the wake. (The
+    // intra-process single-shot ordering guarantee — remove() before any
+    // fallible side effect — is pinned behaviorally in
+    // pending-card-expiry.test.ts, not here.)
+    const rebootMap = new Map<string, PersistedVaultAccessCard>(
+      createPendingCardStore(stateDir)
+        .loadAll()
+        .map(e => [e.stageId, e as PersistedVaultAccessCard]),
+    )
+    expect(rebootMap.size).toBe(0)
+    let secondBootExpiries = 0
+    sweepExpiredEntries(
+      rebootMap,
+      (v, now) => v.stagedAt < now - TTL_MS,
+      () => {
+        secondBootExpiries += 1
+      },
+      NOW,
+      () => {},
+    )
+    expect(secondBootExpiries).toBe(0)
     expect(delivered).toHaveLength(1)
   })
 

--- a/telegram-plugin/uat/scenarios/jtbd-deliberate-restart-resumes-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-deliberate-restart-resumes-dm.test.ts
@@ -28,6 +28,11 @@ const AGENT = "test-harness";
 const MID_TURN_MS = 10_000;        // let the turn get in-flight before the bounce
 const RESUME_BUDGET_MS = 180_000;  // boot + resume + reply
 const QUIET_WINDOW_MS = 90_000;    // after the resume completes, no second resume may fire
+// Messages landing within this window of the FIRST resume-framed reply are
+// treated as the same resumed turn (e.g. a progress line plus the final
+// answer of one turn) — only a resume-framed message AFTER it counts as a
+// second resume for the at-most-once bound.
+const SAME_TURN_GRACE_MS = 20_000;
 
 const RESUME_FRAMING = /resum|picking .*back|interrupted|cut off|just restarted/i;
 
@@ -73,9 +78,11 @@ const sudoOk = canShellSudo();
           kickRestartDetached(AGENT);
 
           // 1. In-flight work resumes: quota-saving suppression must NOT
-          //    swallow a turn that was mid-flight at the bounce.
+          //    swallow a turn that was mid-flight at the bounce. Edits are
+          //    excluded — a progress-card edit must not satisfy this; only
+          //    a genuinely NEW message from the resumed turn counts.
           const reply = await sc.expectMessage(
-            (m) => RESUME_FRAMING.test(m.text),
+            (m) => !m.edited && RESUME_FRAMING.test(m.text),
             { from: "bot", timeout: RESUME_BUDGET_MS },
           );
           expect(reply.text).toMatch(RESUME_FRAMING);
@@ -83,10 +90,18 @@ const sudoOk = canShellSudo();
 
           // 2. Bounded chain: with the interruption resolved, no SECOND
           //    resume-framed turn may fire (at-most-once per interruption).
+          //    Edits are excluded, and messages within SAME_TURN_GRACE_MS of
+          //    the first reply are deduped as part of the SAME resumed turn
+          //    (two resume-ish lines in one turn are not a second resume).
+          const firstReplyAt = reply.date.getTime();
           let second: unknown = null;
           try {
             second = await sc.expectMessage(
-              (m) => RESUME_FRAMING.test(m.text),
+              (m) =>
+                !m.edited &&
+                m.messageId !== reply.messageId &&
+                m.date.getTime() > firstReplyAt + SAME_TURN_GRACE_MS &&
+                RESUME_FRAMING.test(m.text),
               { from: "bot", timeout: QUIET_WINDOW_MS },
             );
           } catch {

--- a/telegram-plugin/uat/scenarios/jtbd-deliberate-restart-resumes-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-deliberate-restart-resumes-dm.test.ts
@@ -1,0 +1,103 @@
+/**
+ * JTBD scenario named by `reference/jobs/survive-reboots-and-real-life.md`
+ * § Prove it — "Deliberate restart resumes, bounded (DM)".
+ *
+ * Contract under test (#2988): a DELIBERATE restart (operator
+ * `switchroom agent restart`, i.e. a clean SIGTERM shutdown with a
+ * clean-shutdown marker) that lands MID-TURN resumes the interrupted turn
+ * like a crash-class interruption. The quota-saving suppression applies only
+ * when nothing was in flight — it never swallows mid-turn work. And the
+ * resume is bounded: AT MOST ONCE per interruption (the loop-guard caps the
+ * resume chain), so we also assert no second resume-framed turn fires after
+ * the first completes.
+ *
+ * Sibling: `jtbd-interrupted-turn-resumes-dm.test.ts` (same interruption
+ * mechanics; this scenario adds the deliberate-restart class + the
+ * at-most-once bound). Decision-level twin: `decideBootResumeKind` cases in
+ * `tests/resume-inbound-builder.test.ts` (BOUNDED CHAIN) and
+ * `shouldSuppressBootResume` in `tests/gateway-clean-shutdown-marker.test.ts`.
+ *
+ * Self-skips green without NOPASSWD sudo.
+ */
+
+import { describe, it, expect } from "vitest";
+import { execSync, spawn } from "node:child_process";
+import { spinUp } from "../harness.js";
+
+const AGENT = "test-harness";
+const MID_TURN_MS = 10_000;        // let the turn get in-flight before the bounce
+const RESUME_BUDGET_MS = 180_000;  // boot + resume + reply
+const QUIET_WINDOW_MS = 90_000;    // after the resume completes, no second resume may fire
+
+const RESUME_FRAMING = /resum|picking .*back|interrupted|cut off|just restarted/i;
+
+function canShellSudo(): boolean {
+  try {
+    execSync("sudo -n true", { stdio: "ignore", timeout: 2_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function kickRestartDetached(name: string): void {
+  // A deliberate operator restart: clean SIGTERM path, clean-shutdown marker
+  // written — the exact class #2988 makes resume in-flight work through.
+  const child = spawn(
+    "sudo",
+    ["-n", "env", `PATH=${process.env.PATH}`, `HOME=${process.env.HOME}`,
+      "switchroom", "agent", "restart", name, "--force"],
+    { detached: true, stdio: "ignore" },
+  );
+  child.unref();
+}
+
+const sudoOk = canShellSudo();
+
+(sudoOk ? describe : describe.skip)(
+  "uat: deliberate restart mid-turn resumes exactly once (DM, #2988)",
+  () => {
+    it(
+      "an operator restart mid-turn resumes the work once, and never a second time",
+      async () => {
+        const sc = await spinUp({ agent: AGENT, settleMs: 0 });
+        try {
+          // A task long enough to still be in flight at MID_TURN_MS.
+          await sc.sendDM(
+            `Please write a thorough, detailed ~300-word explanation of how a ` +
+            `player piano's pneumatic action reads a music roll, step by step. ` +
+            `Take your time and be complete.`,
+          );
+
+          await new Promise((r) => setTimeout(r, MID_TURN_MS));
+          kickRestartDetached(AGENT);
+
+          // 1. In-flight work resumes: quota-saving suppression must NOT
+          //    swallow a turn that was mid-flight at the bounce.
+          const reply = await sc.expectMessage(
+            (m) => RESUME_FRAMING.test(m.text),
+            { from: "bot", timeout: RESUME_BUDGET_MS },
+          );
+          expect(reply.text).toMatch(RESUME_FRAMING);
+          expect(reply.text.length).toBeGreaterThan(40);
+
+          // 2. Bounded chain: with the interruption resolved, no SECOND
+          //    resume-framed turn may fire (at-most-once per interruption).
+          let second: unknown = null;
+          try {
+            second = await sc.expectMessage(
+              (m) => RESUME_FRAMING.test(m.text),
+              { from: "bot", timeout: QUIET_WINDOW_MS },
+            );
+          } catch {
+            // timeout is the PASS: no repeat resume.
+          }
+          expect(second).toBeNull();
+        } finally {
+          await sc.tearDown();
+        }
+      },
+      RESUME_BUDGET_MS + QUIET_WINDOW_MS + 120_000,
+    );
+  },
+);

--- a/telegram-plugin/uat/scenarios/vault-card-survives-gateway-restart-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/vault-card-survives-gateway-restart-dm.test.ts
@@ -1,0 +1,138 @@
+/**
+ * UAT scenario named by `reference/jobs/approve-what-my-agent-can-touch.md`
+ * § Prove it — "Card survives a gateway restart (DM)".
+ *
+ * Contract under test (#2989 durability fix): an agent-initiated
+ * `vault_request_access` card issued BEFORE a gateway restart is still
+ * tappable AFTER it. The gateway persists card metadata to the durable
+ * pending-card store, restores it on boot, and a tap on the still-valid card
+ * grants and resumes the parked agent exactly like a pre-restart tap —
+ * never the "Card expired — ask the agent to re-request" tombstone while the
+ * agent is parked and structurally cannot re-request.
+ *
+ * Load-bearing assertions:
+ *   1. The post-restart tap does NOT produce the expired-card tombstone edit.
+ *   2. The approve flow completes (passphrase → Granted card edit).
+ *   3. The parked agent resumes on the grant with no driver nudge.
+ *
+ * **Skipped by default.** To unskip:
+ *
+ *   1. Standard UAT preflight (`uat/SETUP.md` §5-6).
+ *   2. NOPASSWD sudo on the runner host (the scenario restarts test-harness).
+ *   3. `TELEGRAM_UAT_VAULT_PASSPHRASE` set in env.
+ *   4. Pre-create a sacrificial vault key:
+ *
+ *      ```bash
+ *      TMPF=$(mktemp) && printf '%s' 'sentinel-2989-value' > "$TMPF" && \
+ *        switchroom vault set uat/card-survives-restart --file "$TMPF" \
+ *          --format string ; shred -u "$TMPF"
+ *      ```
+ *
+ *   5. Remove `describe.skip` below.
+ *
+ * Why skipped: mutates vault state (mints a grant) and bounces the harness
+ * agent. Cleanup is operator-side (`switchroom vault revoke <grant-id>`).
+ *
+ * Module-level twin (every CI run): the restart round-trip in
+ * `tests/approval-card-restart-outcome.test.ts` and the store contract in
+ * `tests/pending-card-store.test.ts`.
+ */
+
+import { describe, expect, it } from "vitest";
+import { execSync, spawn } from "node:child_process";
+import { spinUp } from "../harness.js";
+
+const AGENT = "test-harness";
+const KEY = "uat/card-survives-restart";
+const CARD_BUDGET_MS = 120_000;
+const BOOT_BUDGET_MS = 180_000;
+const RESUME_BUDGET_MS = 180_000;
+
+function canShellSudo(): boolean {
+  try {
+    execSync("sudo -n true", { stdio: "ignore", timeout: 2_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function kickRestartDetached(name: string): void {
+  const child = spawn(
+    "sudo",
+    ["-n", "env", `PATH=${process.env.PATH}`, `HOME=${process.env.HOME}`,
+      "switchroom", "agent", "restart", name, "--force"],
+    { detached: true, stdio: "ignore" },
+  );
+  child.unref();
+}
+
+describe.skip("uat: approval card survives a gateway restart (DM, #2989)", () => {
+  it(
+    "card issued pre-restart is tappable post-restart: grant lands and the agent resumes",
+    async () => {
+      if (!canShellSudo()) {
+        throw new Error("NOPASSWD sudo required — see header to set up.");
+      }
+      const passphrase = process.env.TELEGRAM_UAT_VAULT_PASSPHRASE;
+      if (!passphrase) {
+        throw new Error(
+          "TELEGRAM_UAT_VAULT_PASSPHRASE must be set in env (see uat/SETUP.md).",
+        );
+      }
+      const sc = await spinUp({ agent: AGENT, settleMs: 0 });
+      try {
+        // 1. Park the agent on an approval card.
+        await sc.sendDM(
+          `Please call your vault_request_access MCP tool for the key ` +
+          `\`${KEY}\` (scope read, 30d, reason "UAT #2989 card durability"). ` +
+          `END YOUR TURN cleanly and wait; when the operator approves, resume ` +
+          `by running \`switchroom vault get ${KEY}\` and reporting success.`,
+        );
+        const card = await sc.expectMessage(/wants vault access/, {
+          from: "bot",
+          timeout: CARD_BUDGET_MS,
+        });
+
+        // 2. Bounce the gateway BEFORE anyone taps.
+        kickRestartDetached(AGENT);
+        await new Promise((r) => setTimeout(r, BOOT_BUDGET_MS));
+
+        // 3. Tap Approve on the ORIGINAL, pre-restart card message.
+        const kb = await sc.driver.getKeyboard(sc.botUserId, card.messageId);
+        const approveButton = kb!
+          .flat()
+          .find((b) => b.callbackData !== undefined && /approve/i.test(b.text));
+        expect(approveButton).toBeDefined();
+        await sc.driver.pressButton(
+          sc.botUserId,
+          card.messageId,
+          approveButton!.callbackData!,
+        );
+
+        // 4. The restored card must run the REAL approve flow — the expired
+        //    tombstone ("expired before you tapped") is the pre-#2989 defect.
+        const next = await sc.expectMessage(
+          (m) =>
+            /Reply with your passphrase|Granted|expired before you tapped/i.test(m.text),
+          { from: "bot", timeout: 60_000 },
+        );
+        expect(next.text).not.toMatch(/expired before you tapped/i);
+
+        if (/passphrase/i.test(next.text)) {
+          await sc.sendDM(passphrase);
+        }
+
+        // 5. Grant lands and the parked agent resumes without a nudge.
+        const resumed = await sc.expectMessage(
+          (m) => /(granted|access|vault get|succe)/i.test(m.text) && m.text.length > 40,
+          { from: "bot", timeout: RESUME_BUDGET_MS },
+        );
+        expect(resumed.text.length).toBeGreaterThan(40);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    CARD_BUDGET_MS + BOOT_BUDGET_MS + RESUME_BUDGET_MS + 120_000,
+  );
+});

--- a/telegram-plugin/uat/scenarios/vault-card-survives-gateway-restart-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/vault-card-survives-gateway-restart-dm.test.ts
@@ -124,8 +124,10 @@ describe.skip("uat: approval card survives a gateway restart (DM, #2989)", () =>
         }
 
         // 5. Grant lands and the parked agent resumes without a nudge.
+        //    Edits excluded — the "✅ Granted" edit of the card itself must
+        //    not satisfy this; only a NEW message from the resumed turn does.
         const resumed = await sc.expectMessage(
-          (m) => /(granted|access|vault get|succe)/i.test(m.text) && m.text.length > 40,
+          (m) => !m.edited && /(granted|access|vault get|succe)/i.test(m.text) && m.text.length > 40,
           { from: "bot", timeout: RESUME_BUDGET_MS },
         );
         expect(resumed.text.length).toBeGreaterThan(40);

--- a/telegram-plugin/uat/scenarios/vault-deny-resumes-turn-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/vault-deny-resumes-turn-dm.test.ts
@@ -1,0 +1,81 @@
+/**
+ * UAT scenario named by `reference/jobs/approve-what-my-agent-can-touch.md`
+ * § Prove it — "Denied request resumes the turn (DM)".
+ *
+ * Contract under test: the operator taps Deny on an agent-initiated
+ * `vault_request_access` card; the parked turn RESUMES (the gateway injects
+ * the `vault_grant_denied` synthetic), and the agent states plainly what it
+ * now can't do and continues or degrades — never left waiting on a card it
+ * already got an answer to, and never treating the denial as a reason to
+ * silently strand.
+ *
+ * Load-bearing assertion: after the Deny tap, the DRIVER sees a NEW bot turn
+ * that acknowledges the denial/degraded path WITHOUT the driver sending any
+ * further message. (The unit-level twin pins the synthetic's envelope in
+ * `tests/vault-grant-inbound-builders.test.ts`; this scenario proves the
+ * user-visible outcome over real Telegram.)
+ *
+ * Needs only the standard UAT preflight (`uat/SETUP.md` §5-6) — a Deny mints
+ * nothing and mutates no vault state, so no passphrase or sacrificial key is
+ * required. The requested key deliberately does not exist.
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+const KEY = "uat/deny-resume-nonexistent-key";
+const CARD_BUDGET_MS = 120_000;
+const RESUME_BUDGET_MS = 120_000;
+
+// The deny synthetic steers the model toward naming the blocked capability
+// and a fallback — this framing is the stable signal of a resumed turn.
+const DENY_RESUME_FRAMING =
+  /den(?:ied|ial)|can(?:'|no)t|won'?t be able|without (?:that|the) (?:key|access|credential)|not (?:been )?grant/i;
+
+describe("uat: denied vault request resumes the parked turn (DM)", () => {
+  it(
+    "operator taps Deny → parked turn resumes and the agent names what it can't do, with no nudge",
+    async () => {
+      const sc = await spinUp({ agent: "test-harness" });
+      try {
+        // 1. Park the agent on an approval card.
+        await sc.sendDM(
+          `Please call your vault_request_access MCP tool for the key ` +
+          `\`${KEY}\` (scope read, reason "UAT deny-resumes-turn"). Then END ` +
+          `YOUR TURN cleanly and wait. When you hear the operator's decision, ` +
+          `resume: if denied, tell me plainly that you can't read that key ` +
+          `and what you'd do instead.`,
+        );
+
+        // 2. Wait for the approval card and find the Deny button.
+        const card = await sc.expectMessage(/wants vault access/, {
+          from: "bot",
+          timeout: CARD_BUDGET_MS,
+        });
+        const kb = await sc.driver.getKeyboard(sc.botUserId, card.messageId);
+        const denyButton = kb!
+          .flat()
+          .find((b) => b.callbackData !== undefined && /deny/i.test(b.text));
+        expect(denyButton).toBeDefined();
+
+        // 3. Tap Deny. NO further driver message after this point.
+        await sc.driver.pressButton(
+          sc.botUserId,
+          card.messageId,
+          denyButton!.callbackData!,
+        );
+
+        // 4. The deny synthetic must wake the parked turn: a substantive
+        //    bot reply that acknowledges the denial arrives unprompted.
+        const reply = await sc.expectMessage(
+          (m) => DENY_RESUME_FRAMING.test(m.text) && m.text.length > 40,
+          { from: "bot", timeout: RESUME_BUDGET_MS },
+        );
+        expect(reply.text).toMatch(DENY_RESUME_FRAMING);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    CARD_BUDGET_MS + RESUME_BUDGET_MS + 60_000,
+  );
+});

--- a/telegram-plugin/uat/scenarios/vault-deny-resumes-turn-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/vault-deny-resumes-turn-dm.test.ts
@@ -67,8 +67,11 @@ describe("uat: denied vault request resumes the parked turn (DM)", () => {
 
         // 4. The deny synthetic must wake the parked turn: a substantive
         //    bot reply that acknowledges the denial arrives unprompted.
+        //    Edits are excluded — the gateway's own "🚫 Denied" edit of the
+        //    approval card must not satisfy this; only a genuinely NEW
+        //    message from a resumed turn counts.
         const reply = await sc.expectMessage(
-          (m) => DENY_RESUME_FRAMING.test(m.text) && m.text.length > 40,
+          (m) => !m.edited && DENY_RESUME_FRAMING.test(m.text) && m.text.length > 40,
           { from: "bot", timeout: RESUME_BUDGET_MS },
         );
         expect(reply.text).toMatch(DENY_RESUME_FRAMING);

--- a/telegram-plugin/uat/scenarios/vault-timeout-wakes-agent-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/vault-timeout-wakes-agent-dm.test.ts
@@ -1,0 +1,89 @@
+/**
+ * UAT scenario named by `reference/jobs/approve-what-my-agent-can-touch.md`
+ * § Prove it — "Timeout wakes the agent as timeout-not-denial (DM)".
+ *
+ * Contract under test: an agent-initiated `vault_request_access` card ages
+ * past the approval TTL (60-min default) with NO operator tap. The reaper
+ * expires the card, records the missed-approvals re-offer, and injects the
+ * `vault_grant_timeout` synthetic — waking the parked agent with a *timeout,
+ * not a denial* outcome. The agent then says the request went unanswered
+ * (rather than reading silence as a "no" and rather than staying parked).
+ *
+ * A real 60-min wait is not viable in a scenario, so this test requires the
+ * test-harness gateway to run with a SHORT approval TTL:
+ *
+ *   1. Standard UAT preflight (`uat/SETUP.md` §5-6).
+ *   2. Set `channels.telegram.approval_timeout_minutes: 2` on the
+ *      test-harness agent (threads to `SWITCHROOM_TG_APPROVAL_TIMEOUT_MS`,
+ *      see `approvalTtlMs()` in gateway/permission-timeout.ts) and restart it.
+ *   3. Export `SWITCHROOM_UAT_APPROVAL_TTL_MINUTES=2` in the runner env so
+ *      this scenario unskips and sizes its wait window.
+ *
+ * Self-skips green when `SWITCHROOM_UAT_APPROVAL_TTL_MINUTES` is unset (the
+ * default 60-min TTL cannot be observed within test wall-clock). The
+ * module-level twin covering the same outcome deterministically is
+ * `tests/approval-card-restart-outcome.test.ts` plus
+ * `tests/approval-timeout-inbound-builders.test.ts` (the "TIMEOUT, not a
+ * denial" wording pin).
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+const TTL_MINUTES = Number.parseInt(
+  process.env.SWITCHROOM_UAT_APPROVAL_TTL_MINUTES ?? "",
+  10,
+);
+const ttlTuned = Number.isFinite(TTL_MINUTES) && TTL_MINUTES > 0 && TTL_MINUTES <= 5;
+
+const KEY = "uat/timeout-wake-nonexistent-key";
+const CARD_BUDGET_MS = 120_000;
+// TTL + reaper tick slack + model turn budget.
+const WAKE_BUDGET_MS = (ttlTuned ? TTL_MINUTES : 2) * 60_000 + 240_000;
+
+// The timeout synthetic's load-bearing wording is "TIMEOUT, not a denial" —
+// the model is steered to say the request went unanswered, not refused.
+const TIMEOUT_FRAMING =
+  /unanswer|timed?[ -]?out|no (?:response|answer|decision)|didn'?t (?:hear|get|respond)|went without/i;
+
+(ttlTuned ? describe : describe.skip)(
+  "uat: unanswered approval card times out and wakes the agent as timeout-not-denial (DM)",
+  () => {
+    it(
+      "card ages past the TTL with no tap → agent says the request went unanswered, unprompted",
+      async () => {
+        const sc = await spinUp({ agent: "test-harness" });
+        try {
+          // 1. Park the agent on an approval card that nobody will answer.
+          await sc.sendDM(
+            `Please call your vault_request_access MCP tool for the key ` +
+            `\`${KEY}\` (scope read, reason "UAT timeout-wakes-agent"). Then ` +
+            `END YOUR TURN cleanly and wait for the operator. If the request ` +
+            `times out unanswered, tell me plainly that it went unanswered ` +
+            `(not that it was denied) and what you'll do about it.`,
+          );
+
+          // 2. The card must render — and then we deliberately never tap it.
+          await sc.expectMessage(/wants vault access/, {
+            from: "bot",
+            timeout: CARD_BUDGET_MS,
+          });
+
+          // 3. TTL elapses → reaper fires the vault_grant_timeout synthetic →
+          //    a substantive bot reply arrives with timeout (never denial)
+          //    framing, with no further driver message.
+          const reply = await sc.expectMessage(
+            (m) => TIMEOUT_FRAMING.test(m.text) && m.text.length > 40,
+            { from: "bot", timeout: WAKE_BUDGET_MS },
+          );
+          expect(reply.text).toMatch(TIMEOUT_FRAMING);
+          // A timeout must never be narrated as an operator refusal.
+          expect(reply.text).not.toMatch(/operator denied|was denied|refused my request/i);
+        } finally {
+          await sc.tearDown();
+        }
+      },
+      CARD_BUDGET_MS + WAKE_BUDGET_MS + 60_000,
+    );
+  },
+);

--- a/telegram-plugin/uat/scenarios/vault-timeout-wakes-agent-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/vault-timeout-wakes-agent-dm.test.ts
@@ -71,9 +71,11 @@ const TIMEOUT_FRAMING =
 
           // 3. TTL elapses → reaper fires the vault_grant_timeout synthetic →
           //    a substantive bot reply arrives with timeout (never denial)
-          //    framing, with no further driver message.
+          //    framing, with no further driver message. Edits are excluded —
+          //    the reaper's own "timed out" edit of the approval card must
+          //    not satisfy this; only a NEW message from the woken turn does.
           const reply = await sc.expectMessage(
-            (m) => TIMEOUT_FRAMING.test(m.text) && m.text.length > 40,
+            (m) => !m.edited && TIMEOUT_FRAMING.test(m.text) && m.text.length > 40,
             { from: "bot", timeout: WAKE_BUDGET_MS },
           );
           expect(reply.text).toMatch(TIMEOUT_FRAMING);


### PR DESCRIPTION
## Summary

Coverage audit of the job-spec changes that landed on main in the last ~8h — #2985 (approval/restart continuation contract) and the #2980/#2981 LiteLLM spec reconciliation — mapping every promised outcome to tests and closing the gaps with outcome-based coverage. **Purely additive: 5 new test files, no source changes, no tests updated or removed.**

Job specs cited: `reference/jobs/approve-what-my-agent-can-touch.md`, `reference/jobs/survive-reboots-and-real-life.md`, `reference/jobs/steer-or-queue-mid-flight.md`, `reference/jobs/know-what-my-agent-is-doing.md`.

## Coverage map (spec outcome → test)

| Spec outcome | Existing coverage | Added here |
|---|---|---|
| Granted request auto-resumes the turn | `vault-grant-inbound-builders.test.ts`; UAT `vault-grant-auto-resume-dm` | — |
| **Denied/expired request resumes the turn** | builders only (`buildVaultGrantDeniedInbound`) | UAT `vault-deny-resumes-turn-dm` (spec-named, was missing) |
| **Timeout wakes agent as timeout-not-denial + re-offer** | `approval-timeout-inbound-builders.test.ts`, `pending-card-expiry.test.ts` (mocked deps) | `approval-card-restart-outcome.test.ts` (proves the store/expiry/builder modules COMPOSE correctly with test-supplied closures — it does not import gateway.ts's inline wiring; that wiring is pinned separately by `pending-card-durability-wiring.test.ts`'s source greps; CI); UAT `vault-timeout-wakes-agent-dm` (spec-named, was missing; env-gated on a tuned TTL) |
| **Approval card survives gateway restart** | `pending-card-store.test.ts`, `pending-card-durability-wiring.test.ts` (source-text greps) | `approval-card-restart-outcome.test.ts` (module-composition bounce round-trip — same caveat as above: gateway wiring itself is pinned by the source greps, not here; CI); UAT `vault-card-survives-gateway-restart-dm` (unconditional `describe.skip`, see Known gaps) |
| No dead-end stale-card tap while agent is parked | durability store + expiry wake (#2989) as above | tombstone-absence asserted in the restart UAT |
| **Deliberate restart resumes in-flight turn, at-most-once bounded** | `resume-inbound-builder.test.ts` (`decideBootResumeKind` BOUNDED CHAIN), `gateway-clean-shutdown-marker.test.ts` | UAT `jtbd-deliberate-restart-resumes-dm` (spec-named, was missing; asserts resume once AND no second resume) |
| Killed sub-agents surfaced in resume / worker feed | `resume-inbound-builder.test.ts` (interrupted-subagent block), `registry/subagents.test.ts` | — (well covered) |
| Always-allow persist reliability (#2984) | `always-allow-persist-queue.test.ts` (529 lines incl. concurrency) | — |
| Mid-turn button tap not lost (#2987) | `button-tap-turn-gated.test.ts` | — |
| LiteLLM two-mode boot contract (missing key → fail open; unreachable+key → keep routing) | `scaffold.litellm-failopen.test.ts`, `scaffold.litellm-gateway-outer.test.ts`, `cheap-cron-session-render.test.ts`, `write-compose.litellm-resolve.test.ts`, `provision.test.ts` | — (specs and tests already agree post-#2980/#2981) |
| Wedge-watchdog card-aware (#2978) | `tests/wedge-watchdog.test.ts`, `tests/permission-pending-query.test.ts` | — |

## Tests added / updated / removed

- **Added: 5 files / 7 test cases** — 3 CI-run vitest cases (`telegram-plugin/tests/approval-card-restart-outcome.test.ts`) + 4 UAT scenarios (`vault-deny-resumes-turn-dm`, `vault-timeout-wakes-agent-dm`, `vault-card-survives-gateway-restart-dm`, `jtbd-deliberate-restart-resumes-dm`), following the existing mtcute harness patterns and skip-discipline of their siblings.
- **Updated: 0. Removed: 0** — no stale tests found; the implementation PRs updated their own suites when they changed behavior.

## Spec/behavior misalignment list

**Empty.** Checked candidates, all aligned:
- The "Card expired — ask the agent to re-request" tombstone string still exists in `gateway.ts`, but post-#2989 it can only fire after the TTL wake already resumed the agent (which then CAN re-request) — the spec's bad-list case (parked agent + dead-end instruction) is structurally closed.
- Missed-approvals re-offer is on by default (`SWITCHROOM_MISSED_APPROVAL_REOFFER !== '0'`), matching the spec's re-offer promise.
- Spec-referenced tests `tests/gateway-supervisor-backoff.test.ts` and `tests/lifecycle-restart-reason.test.ts` exist.

## Known gaps (deliberate)

- `vault-card-survives-gateway-restart-dm` is an **unconditional `describe.skip`** — it runs nowhere (no CI job, no runner env unskips it) until someone edits the source to remove the skip, following the setup steps in its header (NOPASSWD sudo, vault passphrase, sacrificial key). It documents and scripts the manual acceptance procedure; the every-CI coverage for this outcome is the module-composition test plus the wiring greps above.
- `vault-timeout-wakes-agent-dm` self-skips unless the harness runs a tuned short approval TTL (`SWITCHROOM_UAT_APPROVAL_TTL_MINUTES`) — a real 60-min wait doesn't fit test wall-clock; the deterministic twin runs every CI pass.
- The live re-offer digest render on operator return is asserted at the store level, not over live Telegram (digest posting is operator-activity-triggered).

## Test plan

- `npm run lint` — clean (tsc + all 8 guards).
- Scoped vitest (7 files, 87 tests) + bun twins — green.
- Full `npm run test:bun` — 1149 pass / 0 fail.
- Full vitest — 61 env-dependent failures, **byte-identical count (61) reproduced on pristine `origin/main` in the same sandbox** (no claude binary, socket/sandbox constraints); CI is the authority for those paths. New file passes under vitest.

Risk: none to runtime — test-only, additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

