### PR TITLE
fix(telegram): enforce wire cap on post-escape rich body, never drop oversize sends

### DIFF
--- a/telegram-plugin/render/rich-render.ts
+++ b/telegram-plugin/render/rich-render.ts
@@ -25,7 +25,18 @@
 
 import { parse } from "./parse.js";
 import { renderSafe, type RenderResult } from "./render.js";
-import { RICH_MESSAGE_MAX_CHARS } from "../format.js";
+import { RICH_MESSAGE_MAX_CHARS, splitMarkdownChunks } from "../format.js";
+
+/**
+ * The legacy plain-text `sendMessage` / `editMessageText` wire cap (4096
+ * UTF-16 units). It does NOT apply to the rich path (`sendRichMessage`, up
+ * to `RICH_MESSAGE_MAX_CHARS`), but it DOES apply the moment `renderSafe`
+ * degrades a body to `mode: "plain"` — the send path then routes it through
+ * the plain `sendMessage` endpoint (see stream-controller `doSend`/`doEdit`).
+ * A degraded plain body larger than this is rejected by Telegram with
+ * `message is too long`, so `renderOutboundChunks` caps plain pieces here.
+ */
+export const PLAIN_TEXT_MAX_CHARS = 4096;
 
 /** Parse the `SWITCHROOM_RICH_RENDER` flag value. Default OFF; accepts the
  *  same truthy tokens as the other switchroom env flags. Pure so the default
@@ -69,4 +80,71 @@ export function maybeRenderOutbound(
 ): RenderResult {
   if (!richRenderEnabled(env)) return { text, mode: "markdown", degradations: [] };
   return renderOutbound(text, maxLen);
+}
+
+/**
+ * Flag-gated, CAP-ENFORCING transform for the live send path.
+ *
+ * `maybeRenderOutbound` returns ONE `RenderResult` and can only ever fit a
+ * body into a single wire message. But `renderSafe`'s markdown re-escaping
+ * (GFM-special chars gain a leading `\`) GROWS a chunk: a raw body sized just
+ * under `maxLen` can escape PAST it. `renderSafe` handles that by degrading
+ * the WHOLE document to `mode: "plain"` (raw source, no rich wrapper) — it
+ * never re-splits a multi-block body. The send path then ships that plain
+ * body through the 4096-capped `sendMessage` endpoint, so a ~32k plain body
+ * is rejected by Telegram (`message is too long`) and the answer is dropped.
+ *
+ * This function closes that gap: it returns an ARRAY of pieces, EACH of which
+ * is guaranteed to fit its own wire cap —
+ *   - a `markdown` piece is `<= maxLen` (`renderSafe`'s own guarantee), and
+ *   - a `plain` piece is `<= PLAIN_TEXT_MAX_CHARS` (the plain endpoint's cap).
+ * Pieces are cut only at `splitMarkdownChunks`' safe boundaries, so a fenced
+ * code block or a table row is NEVER bisected. Re-splitting the RAW source and
+ * re-rendering each piece also RECOVERS rich formatting the whole-document
+ * plain degradation would have thrown away: the smaller pieces individually
+ * escape under `maxLen` and come back as `markdown`.
+ *
+ *   - flag OFF (default): `[{ text, mode: "markdown", degradations: [] }]` —
+ *     a single passthrough piece, identical to `maybeRenderOutbound`.
+ *   - flag ON, body fits: `[renderSafe(...)]` — a single piece, identical to
+ *     `maybeRenderOutbound` (byte-for-byte for the common case).
+ *   - flag ON, body oversize: 2+ cap-respecting pieces in send order.
+ */
+export function renderOutboundChunks(
+  text: string,
+  env: NodeJS.ProcessEnv = process.env,
+  maxLen: number = RICH_MESSAGE_MAX_CHARS,
+  plainMax: number = PLAIN_TEXT_MAX_CHARS,
+): RenderResult[] {
+  if (!richRenderEnabled(env)) {
+    return [{ text, mode: "markdown", degradations: [] }];
+  }
+
+  const whole = renderOutbound(text, maxLen);
+  // `markdown` mode from renderSafe is already `<= maxLen`; a `plain` result
+  // that fits the plain cap is a single deliverable piece too. Common case.
+  if (whole.mode === "markdown" && whole.text.length <= maxLen) return [whole];
+  if (whole.mode === "plain" && whole.text.length <= plainMax) return [whole];
+
+  // Oversize: re-split the RAW source at safe boundaries and re-render each
+  // piece. Each sub-piece is `<= maxLen` in raw form, so it usually escapes
+  // back under `maxLen` and renders as rich markdown; a piece whose escaped
+  // form STILL overflows (or an indivisible plain blob) is emitted as plain,
+  // further split to `plainMax` so it fits the plain endpoint.
+  const out: RenderResult[] = [];
+  for (const rawPiece of splitMarkdownChunks(text, maxLen)) {
+    const rendered = renderOutbound(rawPiece, maxLen);
+    if (rendered.mode === "markdown" && rendered.text.length <= maxLen) {
+      out.push(rendered);
+      continue;
+    }
+    // Plain piece — cap at the plain-endpoint limit. `renderSafe` returned the
+    // raw source for a plain result, so split that source (safe boundaries,
+    // never bisecting a fence/table) into `<= plainMax` slices.
+    for (const plainPiece of splitMarkdownChunks(rendered.text, plainMax)) {
+      out.push({ text: plainPiece, mode: "plain", degradations: rendered.degradations });
+    }
+  }
+  // Defensive: a degenerate input that split to nothing still yields one piece.
+  return out.length > 0 ? out : [whole];
 }

--- a/telegram-plugin/stream-controller.ts
+++ b/telegram-plugin/stream-controller.ts
@@ -21,7 +21,7 @@
 
 import { createDraftStream, type DraftStreamHandle } from './draft-stream.js'
 import { richMessage, isParseEntitiesError } from './rich-send.js'
-import { maybeRenderOutbound } from './render/rich-render.js'
+import { renderOutboundChunks } from './render/rich-render.js'
 
 /**
  * Minimal bot.api surface the controller needs. Real callers pass grammy's
@@ -223,81 +223,137 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
   // `format:'text'` stream (plain sendMessage, no rich wrapper).
   // sendRichMessage does NOT accept link_preview_options (rich messages
   // control previews via entity detection), so strip it for the rich path.
-  const doSend = (text: string, opts: StreamSendOpts) => {
-    if (literalText) return bot.api.sendMessage(chatId, text, opts)
-    // Flag-gated rich render (`SWITCHROOM_RICH_RENDER`, default OFF — returns
-    // the text untouched as markdown when off, so this is a no-op for every
-    // agent until an operator opts in). A `plain` result (oversized/unsafe
-    // content renderSafe declined to emit as rich) sends WITHOUT the wrapper.
-    const rendered = maybeRenderOutbound(text)
-    if (rendered.mode === 'plain') return bot.api.sendMessage(chatId, rendered.text, opts)
+  // Render the outbound body into 1+ wire-cap-respecting pieces. The common
+  // case is a SINGLE piece whose output is identical to the pre-existing
+  // `maybeRenderOutbound` path; a body whose markdown-escaping pushed the
+  // rendered form past the cap splits into several pieces, each of which fits
+  // its own wire cap and never bisects a fenced block / table row (see
+  // `renderOutboundChunks`). Flag OFF (default) and a literal `format:'text'`
+  // stream both yield a single passthrough piece — no behavioural change.
+  const renderPieces = (text: string): { text: string; rich: boolean }[] => {
+    if (literalText) return [{ text, rich: false }]
+    // A `plain`-mode piece (oversized/unsafe content renderSafe declined to
+    // emit as rich) sends WITHOUT the rich wrapper.
+    return renderOutboundChunks(text).map((r) => ({ text: r.text, rich: r.mode !== 'plain' }))
+  }
+  // Send ONE rendered piece. Rich pieces go through sendRichMessage (with
+  // link_preview_options stripped — rich messages control previews via entity
+  // detection); plain pieces (and literal streams) through sendMessage.
+  const sendPiece = (piece: { text: string; rich: boolean }, opts: StreamSendOpts) => {
+    if (!piece.rich) return bot.api.sendMessage(chatId, piece.text, opts)
     const richOpts = { ...opts }
     delete richOpts.link_preview_options
-    return bot.api.sendRichMessage(chatId, richMessage(rendered.text), richOpts)
+    return bot.api.sendRichMessage(chatId, richMessage(piece.text), richOpts)
   }
-  const doEdit = (id: number, text: string, opts: StreamSendOpts) => {
-    if (literalText) return bot.api.editMessageText(chatId, id, text, opts)
-    const rendered = maybeRenderOutbound(text)
-    if (rendered.mode === 'plain') return bot.api.editMessageText(chatId, id, rendered.text, opts)
-    return bot.api.editMessageText(chatId, id, richMessage(rendered.text), opts)
+  const editPiece = (id: number, piece: { text: string; rich: boolean }, opts: StreamSendOpts) => {
+    if (!piece.rich) return bot.api.editMessageText(chatId, id, piece.text, opts)
+    return bot.api.editMessageText(chatId, id, richMessage(piece.text), opts)
   }
 
   return createDraftStream(
     async (text) => {
-      try {
-        const sent = await retry(
-          () => doSend(text, sendOpts),
-          { threadId, chat_id: chatId },
-        )
-        onSend?.(sent.message_id, text.length)
-        return sent.message_id
-      } catch (err) {
-        if (!literalText && isParseEntitiesError(err)) {
-          // First send rejected because the markdown couldn't be parsed.
-          // There is no message_id to edit (the send 400'd before any
-          // message was created), so a single fresh send as PLAIN text
-          // (no rich wrapper, so the parser never runs) is the correct
-          // recovery — see issue #657. The raw markdown source is itself
-          // readable, so we send it verbatim.
-          warn?.(
-            `stream-controller: send parse-entities rejected — retrying once as plain text (${err instanceof Error ? err.message : String(err)})`,
-          )
+      // Render → 1+ cap-respecting pieces. The FIRST piece's message_id anchors
+      // the stream (later edits target it); any overflow pieces are sent after
+      // it. For the common single-piece case this is exactly one send.
+      const pieces = renderPieces(text)
+      let anchorId: number | undefined
+      for (let pi = 0; pi < pieces.length; pi++) {
+        const piece = pieces[pi]
+        try {
           const sent = await retry(
-            () => bot.api.sendMessage(chatId, text, sendOpts),
+            () => sendPiece(piece, sendOpts),
             { threadId, chat_id: chatId },
           )
-          onSend?.(sent.message_id, text.length)
-          return sent.message_id
+          if (anchorId == null) anchorId = sent.message_id
+        } catch (err) {
+          if (!literalText && piece.rich && isParseEntitiesError(err)) {
+            // Piece rejected because its markdown couldn't be parsed. There is
+            // no message_id to edit (the send 400'd before any message was
+            // created), so recover with a single fresh PLAIN send of the same
+            // body (no rich wrapper, so the parser never runs) — see issue #657.
+            warn?.(
+              `stream-controller: send parse-entities rejected — retrying once as plain text (${err instanceof Error ? err.message : String(err)})`,
+            )
+            // Resend the RAW source verbatim (readable, and the exact
+            // pre-existing #657 contract) rather than the escaped/rendered
+            // body. For a single-piece stream (the common case) this is the
+            // whole message; for a rare oversize split each piece falls back
+            // to its own body below.
+            const fallbackBody = pieces.length === 1 ? text : piece.text
+            const sent = await retry(
+              () => bot.api.sendMessage(chatId, fallbackBody, sendOpts),
+              { threadId, chat_id: chatId },
+            )
+            if (anchorId == null) anchorId = sent.message_id
+          } else {
+            throw err
+          }
         }
-        throw err
       }
+      onSend?.(anchorId as number, text.length)
+      return anchorId as number
     },
     async (id, text) => {
+      const pieces = renderPieces(text)
+      const head = pieces[0]
+      // Edit the anchor message in place with the FIRST piece.
       try {
         await retry(
-          () => doEdit(id, text, baseOpts),
+          () => editPiece(id, head, baseOpts),
           { threadId, chat_id: chatId },
         )
         onEdit?.(id, text.length)
       } catch (err) {
-        if (!literalText && isParseEntitiesError(err)) {
+        if (!literalText && head.rich && isParseEntitiesError(err)) {
           // Edit rejected because the markdown couldn't be parsed — DO NOT
           // send a fresh message. The whole point of issue #657 is that the
           // previous implementation sent a duplicate message every time a
           // parse rejection fired. Retry the edit on the SAME message_id as
-          // PLAIN text (no rich wrapper, so the parser never runs). The raw
-          // markdown source is itself readable, so we send it verbatim.
+          // PLAIN text (no rich wrapper, so the parser never runs).
           warn?.(
             `stream-controller: edit parse-entities rejected — retrying same id=${id} as plain text (${err instanceof Error ? err.message : String(err)})`,
           )
+          // Re-edit the SAME id with the RAW source verbatim (the exact #657
+          // contract). For a single-piece stream (common case) this is the
+          // whole body; a rare oversize split edits the head piece's body.
+          const fallbackBody = pieces.length === 1 ? text : head.text
           await retry(
-            () => bot.api.editMessageText(chatId, id, text, baseOpts),
+            () => bot.api.editMessageText(chatId, id, fallbackBody, baseOpts),
             { threadId, chat_id: chatId },
           )
           onEdit?.(id, text.length)
-          return
+        } else {
+          throw err
         }
-        throw err
+      }
+      // Oversize tail: the anchor message can hold only the first piece. A body
+      // this large is effectively the terminal stream state, so the remaining
+      // pieces are appended as fresh messages — each obeying its own wire cap —
+      // rather than dropped. This is the fix for the chunk-boundary bug: the old
+      // whole-document plain degradation shipped a ~32k body through the plain
+      // 4096-char `sendMessage` endpoint, which Telegram rejected outright.
+      for (let pi = 1; pi < pieces.length; pi++) {
+        const piece = pieces[pi]
+        try {
+          const sent = await retry(
+            () => sendPiece(piece, sendOpts),
+            { threadId, chat_id: chatId },
+          )
+          onSend?.(sent.message_id, piece.text.length)
+        } catch (err) {
+          if (!literalText && piece.rich && isParseEntitiesError(err)) {
+            warn?.(
+              `stream-controller: overflow-piece parse-entities rejected — sending as plain text (${err instanceof Error ? err.message : String(err)})`,
+            )
+            const sent = await retry(
+              () => bot.api.sendMessage(chatId, piece.text, sendOpts),
+              { threadId, chat_id: chatId },
+            )
+            onSend?.(sent.message_id, piece.text.length)
+          } else {
+            throw err
+          }
+        }
       }
     },
     {

--- a/telegram-plugin/stream-controller.ts
+++ b/telegram-plugin/stream-controller.ts
@@ -250,47 +250,128 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
     return bot.api.editMessageText(chatId, id, richMessage(piece.text), opts)
   }
 
+  // Overflow-tail bookkeeping, shared across the send + edit closures for the
+  // whole stream lifetime. A body large enough to split into several
+  // wire-cap pieces anchors on piece[0] (edited in place by draft-stream) and
+  // parks pieces[1..n] as follow-up messages. The draft-stream edit callback
+  // fires on EVERY throttled flush as a streamed answer grows, so we MUST NOT
+  // re-send those tails each tick (that flooded the chat with duplicates — the
+  // blocker this fix closes). Instead we remember each tail's message_id the
+  // first time it is emitted and edit it in place on later flushes; a tail that
+  // did not exist on a prior flush (the piece count grew) is sent fresh once.
+  // End state after finalize: anchor + one message per tail piece, no dupes.
+  const tailIds: number[] = []
+  const tailLastText: string[] = []
+
+  // Emit or update a single tail piece (0-based index `ti` = piece index - 1).
+  // Sends a fresh message the first time; edits in place (skipping unchanged
+  // text) thereafter. A non-parse failure is logged as a partial-delivery
+  // warning and swallowed so the remaining tail pieces still get a chance to
+  // land — never a silent drop, never an abort of pieces K..N (concern C1).
+  const upsertTail = async (ti: number, piece: { text: string; rich: boolean }): Promise<void> => {
+    const existingId = tailIds[ti]
+    if (existingId != null) {
+      if (tailLastText[ti] === piece.text) return // unchanged — skip the API call
+      try {
+        await retry(() => editPiece(existingId, piece, baseOpts), { threadId, chat_id: chatId })
+        tailLastText[ti] = piece.text
+        onEdit?.(existingId, piece.text.length)
+      } catch (err) {
+        if (!literalText && piece.rich && isParseEntitiesError(err)) {
+          warn?.(
+            `stream-controller: tail-piece #${ti + 1} edit parse-entities rejected — retrying same id=${existingId} as plain text (${err instanceof Error ? err.message : String(err)})`,
+          )
+          await retry(
+            () => bot.api.editMessageText(chatId, existingId, piece.text, baseOpts),
+            { threadId, chat_id: chatId },
+          )
+          tailLastText[ti] = piece.text
+          onEdit?.(existingId, piece.text.length)
+        } else {
+          // Best-effort continue: leave tailLastText[ti] stale so the next
+          // flush retries this piece, and surface the partial delivery loudly.
+          warn?.(
+            `stream-controller: tail-piece #${ti + 1} edit FAILED (id=${existingId}) — partial delivery, this piece may be stale (${err instanceof Error ? err.message : String(err)})`,
+          )
+        }
+      }
+      return
+    }
+    // First emission of this tail piece → a fresh follow-up message.
+    try {
+      const sent = await retry(() => sendPiece(piece, sendOpts), { threadId, chat_id: chatId })
+      tailIds[ti] = sent.message_id
+      tailLastText[ti] = piece.text
+      onSend?.(sent.message_id, piece.text.length)
+    } catch (err) {
+      if (!literalText && piece.rich && isParseEntitiesError(err)) {
+        warn?.(
+          `stream-controller: tail-piece #${ti + 1} send parse-entities rejected — sending as plain text (${err instanceof Error ? err.message : String(err)})`,
+        )
+        const sent = await retry(
+          () => bot.api.sendMessage(chatId, piece.text, sendOpts),
+          { threadId, chat_id: chatId },
+        )
+        tailIds[ti] = sent.message_id
+        tailLastText[ti] = piece.text
+        onSend?.(sent.message_id, piece.text.length)
+      } else {
+        // Best-effort continue: no id recorded, so the next flush re-attempts
+        // this piece rather than silently dropping pieces K..N (concern C1).
+        warn?.(
+          `stream-controller: tail-piece #${ti + 1} send FAILED — partial delivery, this and later pieces may be missing this flush (${err instanceof Error ? err.message : String(err)})`,
+        )
+      }
+    }
+  }
+
   return createDraftStream(
     async (text) => {
       // Render → 1+ cap-respecting pieces. The FIRST piece's message_id anchors
-      // the stream (later edits target it); any overflow pieces are sent after
-      // it. For the common single-piece case this is exactly one send.
+      // the stream (later edits target it); any overflow pieces are parked as
+      // follow-up messages via upsertTail. For the common single-piece case
+      // this is exactly one send.
       const pieces = renderPieces(text)
+      const head = pieces[0]
       let anchorId: number | undefined
-      for (let pi = 0; pi < pieces.length; pi++) {
-        const piece = pieces[pi]
-        try {
+      try {
+        const sent = await retry(
+          () => sendPiece(head, sendOpts),
+          { threadId, chat_id: chatId },
+        )
+        anchorId = sent.message_id
+      } catch (err) {
+        if (!literalText && head.rich && isParseEntitiesError(err)) {
+          // Piece rejected because its markdown couldn't be parsed. There is
+          // no message_id to edit (the send 400'd before any message was
+          // created), so recover with a single fresh PLAIN send of the same
+          // body (no rich wrapper, so the parser never runs) — see issue #657.
+          warn?.(
+            `stream-controller: send parse-entities rejected — retrying once as plain text (${err instanceof Error ? err.message : String(err)})`,
+          )
+          // Resend the RAW source verbatim (readable, and the exact
+          // pre-existing #657 contract) rather than the escaped/rendered
+          // body. For a single-piece stream (the common case) this is the
+          // whole message; for a rare oversize split the head falls back to
+          // its own body and each tail to its own body below.
+          const fallbackBody = pieces.length === 1 ? text : head.text
           const sent = await retry(
-            () => sendPiece(piece, sendOpts),
+            () => bot.api.sendMessage(chatId, fallbackBody, sendOpts),
             { threadId, chat_id: chatId },
           )
-          if (anchorId == null) anchorId = sent.message_id
-        } catch (err) {
-          if (!literalText && piece.rich && isParseEntitiesError(err)) {
-            // Piece rejected because its markdown couldn't be parsed. There is
-            // no message_id to edit (the send 400'd before any message was
-            // created), so recover with a single fresh PLAIN send of the same
-            // body (no rich wrapper, so the parser never runs) — see issue #657.
-            warn?.(
-              `stream-controller: send parse-entities rejected — retrying once as plain text (${err instanceof Error ? err.message : String(err)})`,
-            )
-            // Resend the RAW source verbatim (readable, and the exact
-            // pre-existing #657 contract) rather than the escaped/rendered
-            // body. For a single-piece stream (the common case) this is the
-            // whole message; for a rare oversize split each piece falls back
-            // to its own body below.
-            const fallbackBody = pieces.length === 1 ? text : piece.text
-            const sent = await retry(
-              () => bot.api.sendMessage(chatId, fallbackBody, sendOpts),
-              { threadId, chat_id: chatId },
-            )
-            if (anchorId == null) anchorId = sent.message_id
-          } else {
-            throw err
-          }
+          anchorId = sent.message_id
+        } else {
+          throw err
         }
       }
-      onSend?.(anchorId as number, text.length)
+      // C2: report the ACTUAL emitted anchor-piece length, not the full body
+      // length — the anchor only holds the head piece, and the tails report
+      // their own lengths via upsertTail.
+      onSend?.(anchorId as number, head.text.length)
+      // Park overflow pieces (first-time send records their ids for reuse).
+      for (let pi = 1; pi < pieces.length; pi++) {
+        await upsertTail(pi - 1, pieces[pi])
+      }
       return anchorId as number
     },
     async (id, text) => {
@@ -302,7 +383,8 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
           () => editPiece(id, head, baseOpts),
           { threadId, chat_id: chatId },
         )
-        onEdit?.(id, text.length)
+        // C2: report the actual head-piece length, not the full body length.
+        onEdit?.(id, head.text.length)
       } catch (err) {
         if (!literalText && head.rich && isParseEntitiesError(err)) {
           // Edit rejected because the markdown couldn't be parsed — DO NOT
@@ -321,39 +403,19 @@ export function createStreamController(cfg: StreamControllerConfig): DraftStream
             () => bot.api.editMessageText(chatId, id, fallbackBody, baseOpts),
             { threadId, chat_id: chatId },
           )
-          onEdit?.(id, text.length)
+          onEdit?.(id, head.text.length)
         } else {
           throw err
         }
       }
-      // Oversize tail: the anchor message can hold only the first piece. A body
-      // this large is effectively the terminal stream state, so the remaining
-      // pieces are appended as fresh messages — each obeying its own wire cap —
-      // rather than dropped. This is the fix for the chunk-boundary bug: the old
-      // whole-document plain degradation shipped a ~32k body through the plain
-      // 4096-char `sendMessage` endpoint, which Telegram rejected outright.
+      // Oversize tail: the anchor message holds only the first piece. On EVERY
+      // edit flush we UPDATE the parked tail messages in place (or send a tail
+      // that only just came into existence) — we never re-send tails already
+      // emitted on a prior flush. This is the fix for the duplicate-flood
+      // blocker: the previous code re-sent pieces[1..n] as brand-new messages
+      // on each throttled edit tick.
       for (let pi = 1; pi < pieces.length; pi++) {
-        const piece = pieces[pi]
-        try {
-          const sent = await retry(
-            () => sendPiece(piece, sendOpts),
-            { threadId, chat_id: chatId },
-          )
-          onSend?.(sent.message_id, piece.text.length)
-        } catch (err) {
-          if (!literalText && piece.rich && isParseEntitiesError(err)) {
-            warn?.(
-              `stream-controller: overflow-piece parse-entities rejected — sending as plain text (${err instanceof Error ? err.message : String(err)})`,
-            )
-            const sent = await retry(
-              () => bot.api.sendMessage(chatId, piece.text, sendOpts),
-              { threadId, chat_id: chatId },
-            )
-            onSend?.(sent.message_id, piece.text.length)
-          } else {
-            throw err
-          }
-        }
+        await upsertTail(pi - 1, pieces[pi])
       }
     },
     {

--- a/telegram-plugin/tests/render/render-outbound-chunks.test.ts
+++ b/telegram-plugin/tests/render/render-outbound-chunks.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression tests for the chunk-boundary cap bug (fix/rich-render-chunk-boundary-cap).
+ *
+ * THE BUG: the outbound safe renderer (`renderSafe`) re-escapes GFM-special
+ * characters, which GROWS a body. A raw chunk sized just under the wire cap can
+ * escape PAST it. `renderSafe`'s only oversize recourse is to degrade the WHOLE
+ * document to `mode:"plain"` (raw source, no rich wrapper) — it never re-splits
+ * a multi-block body. The send path then ships that plain body through the
+ * 4096-char plain `sendMessage` endpoint, so a ~32k plain body is rejected by
+ * Telegram (`message is too long`) and the answer is dropped.
+ *
+ * `renderOutboundChunks` closes the gap: every returned piece fits its own wire
+ * cap (rich `<= maxLen`, plain `<= plainMax`) and is cut only at
+ * `splitMarkdownChunks`' safe boundaries (never bisecting a fence / table row).
+ */
+import { describe, it, expect } from "vitest";
+import { renderOutboundChunks, PLAIN_TEXT_MAX_CHARS } from "../../render/rich-render.js";
+import { RICH_MESSAGE_MAX_CHARS } from "../../format.js";
+
+const ON = { SWITCHROOM_RICH_RENDER: "1" } as NodeJS.ProcessEnv;
+const OFF = {} as NodeJS.ProcessEnv;
+
+/** Count fenced-code delimiter lines (```) in a body. A piece that bisects a
+ *  fenced block has an ODD count. */
+function fenceCount(s: string): number {
+  return (s.match(/^```/gm) ?? []).length;
+}
+
+describe("renderOutboundChunks", () => {
+  it("flag OFF is a single passthrough piece (byte-for-byte)", () => {
+    const raw = "**bold** and _italic_ | a | table |";
+    const pieces = renderOutboundChunks(raw, OFF);
+    expect(pieces).toHaveLength(1);
+    expect(pieces[0].text).toBe(raw);
+    expect(pieces[0].mode).toBe("markdown");
+  });
+
+  it("flag ON, body that fits is a single piece (common case)", () => {
+    const pieces = renderOutboundChunks("just some plain prose", ON);
+    expect(pieces).toHaveLength(1);
+    expect(pieces[0].text.length).toBeLessThanOrEqual(RICH_MESSAGE_MAX_CHARS);
+  });
+
+  it("REGRESSION: a near-cap escapable body splits into cap-respecting pieces", () => {
+    // Prose whose escaping (`_ * |` each gain a leading `\`) grows it past the
+    // cap. Use small caps so the test is fast; the invariant is cap-agnostic.
+    const maxLen = 200;
+    const plainMax = 80;
+    const unit = "a_b*c|d ";
+    const raw = unit.repeat(40); // 320 raw chars, ~1.5x after escaping
+    const pieces = renderOutboundChunks(raw, ON, maxLen, plainMax);
+
+    // The whole body did NOT fit as one message — it was re-split.
+    expect(pieces.length).toBeGreaterThan(1);
+    for (const p of pieces) {
+      if (p.mode === "plain") {
+        // A plain piece rides the plain `sendMessage` endpoint — must fit its cap.
+        expect(p.text.length).toBeLessThanOrEqual(plainMax);
+      } else {
+        expect(p.text.length).toBeLessThanOrEqual(maxLen);
+      }
+    }
+  });
+
+  it("REGRESSION: never bisects a fenced code block when splitting", () => {
+    const maxLen = 300;
+    const plainMax = 250; // >= the fence size, so a fence never needs a hard slice.
+    // A fenced block big enough that a naive length cut would land inside it,
+    // wrapped in prose so the whole document overflows and must be re-split.
+    const fence = "```\n" + "code line here\n".repeat(8) + "```";
+    const prose = "word ".repeat(40);
+    const raw = `${prose}\n\n${fence}\n\n${prose}`;
+    const pieces = renderOutboundChunks(raw, ON, maxLen, plainMax);
+
+    expect(pieces.length).toBeGreaterThan(1);
+    for (const p of pieces) {
+      // Every emitted piece has BALANCED fence delimiters — no piece opens a
+      // fence it doesn't close (which would swallow the next piece's text).
+      expect(fenceCount(p.text) % 2).toBe(0);
+      const cap = p.mode === "plain" ? plainMax : maxLen;
+      expect(p.text.length).toBeLessThanOrEqual(cap);
+    }
+  });
+
+  it("REAL-CAP: a ~32k escapable body never yields an over-4096 plain piece", () => {
+    // The production failure: raw just under RICH_MESSAGE_MAX_CHARS, escaping
+    // pushes the rendered form over it. On the buggy path this became ONE
+    // ~32k plain body sent through the 4096 plain endpoint. Here every plain
+    // piece is <= 4096 and every rich piece <= 32768.
+    const unit = "a_b*c|d ";
+    const raw = unit.repeat(Math.floor((RICH_MESSAGE_MAX_CHARS - 20) / unit.length));
+    const pieces = renderOutboundChunks(raw, ON);
+    for (const p of pieces) {
+      const cap = p.mode === "plain" ? PLAIN_TEXT_MAX_CHARS : RICH_MESSAGE_MAX_CHARS;
+      expect(p.text.length).toBeLessThanOrEqual(cap);
+    }
+  }, 30000);
+});

--- a/telegram-plugin/tests/stream-controller-chunk-cap.test.ts
+++ b/telegram-plugin/tests/stream-controller-chunk-cap.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Wire-level regression test for the chunk-boundary cap bug
+ * (fix/rich-render-chunk-boundary-cap).
+ *
+ * With `SWITCHROOM_RICH_RENDER` on, a near-cap body full of escapable chars
+ * (`_ * |`) makes `renderSafe` degrade the whole document to plain (its escaped
+ * rich form exceeds RICH_MESSAGE_MAX_CHARS). BEFORE the fix, the stream
+ * controller shipped that ~32k plain body through the plain `sendMessage`
+ * endpoint in ONE call — Telegram's plain endpoint caps at 4096, so the send
+ * is rejected (`message is too long`) and the streamed answer is dropped.
+ *
+ * AFTER the fix, `renderOutboundChunks` re-splits at safe boundaries so every
+ * emitted send fits its own wire cap: rich pieces <= 32768, plain pieces
+ * <= 4096, and no fenced block is bisected.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { createStreamController } from "../stream-controller.js";
+import { createFakeBotApi } from "./fake-bot-api.js";
+import { RICH_MESSAGE_MAX_CHARS } from "../format.js";
+
+const PLAIN_CAP = 4096; // Telegram's legacy plain-text sendMessage cap (format.ts:29).
+
+function fenceCount(s: string): number {
+  return (s.match(/^```/gm) ?? []).length;
+}
+
+describe("stream-controller enforces the wire cap on the post-escape body", () => {
+  afterEach(() => {
+    delete process.env.SWITCHROOM_RICH_RENDER;
+  });
+
+  it("REGRESSION: near-cap escapable first send never exceeds the plain wire cap", async () => {
+    process.env.SWITCHROOM_RICH_RENDER = "1";
+    const bot = createFakeBotApi({ startMessageId: 1000 });
+    const unit = "a_b*c|d ";
+    const body = unit.repeat(Math.floor((RICH_MESSAGE_MAX_CHARS - 20) / unit.length));
+
+    const stream = createStreamController({
+      bot: bot as unknown as Parameters<typeof createStreamController>[0]["bot"],
+      chatId: "c1",
+      throttleMs: 0,
+    });
+    await stream.update(body);
+    await stream.finalize();
+
+    expect(bot.state.sent.length).toBeGreaterThan(0);
+    for (const s of bot.state.sent) {
+      // Every send fits the rich cap...
+      expect(s.text.length).toBeLessThanOrEqual(RICH_MESSAGE_MAX_CHARS);
+      // ...and a PLAIN send (rich !== true) additionally fits the 4096 plain
+      // endpoint cap — the invariant HEAD violated (one ~32k plain send).
+      if (!s.rich) expect(s.text.length).toBeLessThanOrEqual(PLAIN_CAP);
+      // No send bisects a fenced block.
+      expect(fenceCount(s.text) % 2).toBe(0);
+    }
+  }, 30000);
+
+  it("flag OFF leaves the single-send path untouched", async () => {
+    const bot = createFakeBotApi({ startMessageId: 2000 });
+    const stream = createStreamController({
+      bot: bot as unknown as Parameters<typeof createStreamController>[0]["bot"],
+      chatId: "c1",
+      throttleMs: 0,
+    });
+    await stream.update("**hi** _there_");
+    await stream.finalize();
+    expect(bot.state.sent).toHaveLength(1);
+    expect(bot.state.sent[0].rich).toBe(true);
+    expect(bot.state.sent[0].text).toBe("**hi** _there_");
+  });
+});

--- a/telegram-plugin/tests/stream-controller-chunk-cap.test.ts
+++ b/telegram-plugin/tests/stream-controller-chunk-cap.test.ts
@@ -55,6 +55,57 @@ describe("stream-controller enforces the wire cap on the post-escape body", () =
     }
   }, 30000);
 
+  it("BLOCKER: multi-update oversize stream emits tails ONCE, not per edit tick", async () => {
+    // Reproduces the duplicate-flood blocker: an oversize body splits into N
+    // pieces. The FIRST flush (send path) emits the anchor + (N-1) tail
+    // messages. Every SUBSEQUENT throttled flush routes through the EDIT
+    // callback. The pre-fix code re-sent all (N-1) tails as brand-new messages
+    // on each edit tick, so `sent.length` grew by (N-1) every update. After the
+    // fix, tails are parked once and edited in place — `sent.length` is flat.
+    process.env.SWITCHROOM_RICH_RENDER = "1";
+    const bot = createFakeBotApi({ startMessageId: 3000 });
+    const unit = "a_b*c|d ";
+    // Near-cap body that degrades to plain and splits into several pieces.
+    const base = unit.repeat(Math.floor((RICH_MESSAGE_MAX_CHARS - 20) / unit.length));
+    // Distinct short prefix per flush so the HEAD piece actually changes —
+    // an unchanged head yields a not-modified edit, which short-circuits before
+    // the tail loop and would hide the duplicate-resend bug.
+    const bodyFor = (i: number) => `v${i} ${base}`;
+
+    const stream = createStreamController({
+      bot: bot as unknown as Parameters<typeof createStreamController>[0]["bot"],
+      chatId: "c1",
+      throttleMs: 0,
+    });
+
+    // First flush → send path: anchor + tails, emitted exactly once.
+    await stream.update(bodyFor(1));
+    const afterFirst = bot.state.sent.length;
+    expect(afterFirst).toBeGreaterThan(1); // genuinely multi-piece
+
+    // Drive several more oversize updates — each routes through the EDIT
+    // callback. The count must NOT grow: tails are edited in place, not resent.
+    await stream.update(bodyFor(2));
+    expect(bot.state.sent.length).toBe(afterFirst);
+    await stream.update(bodyFor(3));
+    expect(bot.state.sent.length).toBe(afterFirst);
+    await stream.update(bodyFor(4));
+    expect(bot.state.sent.length).toBe(afterFirst);
+    await stream.finalize();
+
+    // Final: exactly the anchor + tail set, no duplicates across the lifetime.
+    expect(bot.state.sent.length).toBe(afterFirst);
+    const ids = bot.state.sent.map((s) => s.message_id);
+    expect(new Set(ids).size).toBe(ids.length); // no duplicate message ids
+
+    // Every currently-visible message fits its wire cap and (for plain) 4096.
+    for (const s of bot.state.sent) {
+      const cur = bot.textOf(s.message_id) ?? "";
+      expect(cur.length).toBeLessThanOrEqual(RICH_MESSAGE_MAX_CHARS);
+      if (!s.rich) expect(cur.length).toBeLessThanOrEqual(PLAIN_CAP);
+    }
+  }, 30000);
+
   it("flag OFF leaves the single-send path untouched", async () => {
     const bot = createFakeBotApi({ startMessageId: 2000 });
     const stream = createStreamController({


### PR DESCRIPTION
## Problem

When the rich renderer escapes markdown, a long reply could grow past Telegram's size limit. The old path then collapsed the whole message to plain text and sent it via `sendMessage` (real cap 4096, not 32768), and `stream-controller` only caught parse-entity errors, not length errors. Result: an over-long formatted reply silently **dropped the entire answer**.

## Fix

New `renderOutboundChunks` re-splits the raw source at safe boundaries (never bisecting a code fence or table row) and re-renders each piece, so formatting is recovered instead of dumped to plain, and every emitted piece is guaranteed under its wire cap (markdown 32768, plain 4096). `stream-controller` doSend/doEdit are piece-driven: first piece anchors the stream, tail pieces append as fresh cap-respecting messages. Single-piece common path is behaviorally unchanged.

## Tests

Regression tests fail against HEAD (over-cap plain send) and pass with the fix; neighboring stream/render/format suites green (2 pre-existing unrelated failures from `SWITCHROOM_RICH_RENDER=1` in this env).

Stage 1 of the rich-message reliability work. No flag/CHANGELOG changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>