### PR TITLE
fix(auth): transient-429 misclassification + M365 get-credentials retry-storm (#2922, #2586)

### DIFF
--- a/src/cli/m365-mcp-launcher.test.ts
+++ b/src/cli/m365-mcp-launcher.test.ts
@@ -614,4 +614,87 @@ describe("runMs365McpLauncher — crash-loop backoff (#2586)", () => {
     rmSync(hbDir, { recursive: true, force: true });
     delete process.env.SWITCHROOM_M365_HEARTBEAT_DIR;
   });
+
+  it("refresh firing during a pending crash-backoff does NOT double-spawn (#2997 review blocker)", async () => {
+    const hbDir = `/tmp/m365-test-dblspawn-${process.pid}-${Date.now()}`;
+    process.env.SWITCHROOM_M365_HEARTBEAT_DIR = hbDir;
+    const children = [makeFakeChild(), makeFakeChild(), makeFakeChild()];
+    let spawnCount = 0;
+    let fetchCount = 0;
+
+    // Timer registry that models real cancellation: a cleared timer must not
+    // fire. This is what lets the test prove the refresh path cancels the
+    // pending backoff timer (fix #1) rather than the harness silently allowing
+    // a second spawn.
+    interface FakeTimer {
+      cb: () => void;
+      cancelled: boolean;
+    }
+    const timers: FakeTimer[] = [];
+    const fire = (t: FakeTimer): void => {
+      if (!t.cancelled) t.cb();
+    };
+
+    const promise = runMs365McpLauncher(
+      {},
+      {
+        fetchCreds: async () => {
+          fetchCount++;
+          return {
+            accessToken: `at-${fetchCount}`,
+            expiresAt: Date.now() + 60 * 60 * 1000,
+          };
+        },
+        spawnSofteria: () =>
+          children[spawnCount++] as unknown as
+            import("node:child_process").ChildProcess,
+        setTimer: ((cb: () => void, _ms: number) => {
+          const t: FakeTimer = { cb, cancelled: false };
+          timers.push(t);
+          return t as unknown as NodeJS.Timeout;
+        }) as typeof setTimeout,
+        clearTimer: ((h: unknown) => {
+          if (h) (h as FakeTimer).cancelled = true;
+        }) as typeof clearTimeout,
+        log: () => {},
+      },
+    );
+
+    await new Promise((r) => setImmediate(r));
+    expect(spawnCount).toBe(1);
+    const refreshTimer = timers[0]; // first schedule = refresh tick
+
+    // softeria crashes → a backoff re-spawn timer is scheduled and the dead
+    // child is nulled out (fix #2).
+    children[0].exitCode = 137;
+    children[0].emit("exit", 137, null);
+    await new Promise((r) => setImmediate(r));
+    const backoffTimer = timers[1];
+    expect(backoffTimer).toBeDefined();
+    expect(backoffTimer.cancelled).toBe(false);
+
+    // The refresh tick now fires WHILE the backoff timer is still pending.
+    // It must cancel that backoff timer (fix #1) and spawn exactly one fresh
+    // child — not race the backoff into a second parallel softeria.
+    fire(refreshTimer);
+    await new Promise((r) => setTimeout(r, 30)); // let async fetch/kill settle
+
+    expect(backoffTimer.cancelled).toBe(true); // fix #1 — backoff cancelled
+    expect(spawnCount).toBe(2); // exactly one respawn (fresh-creds child)
+    expect(fetchCount).toBe(2); // the refresh fetched; backoff would not have
+
+    // Belt-and-suspenders: even if some stale reference tried to fire the
+    // cancelled backoff timer, it is a no-op — still exactly one live child.
+    fire(backoffTimer);
+    await new Promise((r) => setImmediate(r));
+    expect(spawnCount).toBe(2);
+
+    // Cleanup — the one live child exits cleanly, launcher resolves.
+    children[1].exitCode = 0;
+    children[1].emit("exit", 0, null);
+    const code = await promise;
+    expect(code).toBe(0);
+    rmSync(hbDir, { recursive: true, force: true });
+    delete process.env.SWITCHROOM_M365_HEARTBEAT_DIR;
+  });
 });

--- a/src/cli/m365-mcp-launcher.test.ts
+++ b/src/cli/m365-mcp-launcher.test.ts
@@ -19,7 +19,11 @@ import {
   DEFAULT_REFRESH_LEAD_MS,
   heartbeatPath,
   MAX_REFRESH_INTERVAL_MS,
+  computeRestartBackoffMs,
   runMs365McpLauncher,
+  SOFTERIA_RESTART_BASE_MS,
+  SOFTERIA_RESTART_MAX_MS,
+  SOFTERIA_MAX_RESTARTS,
   SOFTERIA_TOKEN_ENV,
   writeRefreshHeartbeat,
 } from "./m365-mcp-launcher.js";
@@ -370,8 +374,11 @@ describe("runMs365McpLauncher", () => {
     const hbDir = `/tmp/m365-test-leak-${process.pid}-${Date.now()}`;
     process.env.SWITCHROOM_M365_HEARTBEAT_DIR = hbDir;
     const child1 = makeFakeChild();
+    const child2 = makeFakeChild();
     let fetchCount = 0;
+    let spawnCount = 0;
     let savedRefreshCb: (() => void) | null = null;
+    const backoffCbs: Array<() => void> = [];
 
     const promise = runMs365McpLauncher(
       {},
@@ -384,10 +391,14 @@ describe("runMs365McpLauncher", () => {
           // Second call (refresh tick) fails
           throw new Error("broker transient failure");
         },
-        spawnSofteria: () =>
-          child1 as unknown as import("node:child_process").ChildProcess,
+        spawnSofteria: () => {
+          spawnCount++;
+          return (spawnCount === 1 ? child1 : child2) as unknown as
+            import("node:child_process").ChildProcess;
+        },
         setTimer: ((cb: () => void, _ms: number) => {
           if (!savedRefreshCb) savedRefreshCb = cb;
+          else backoffCbs.push(cb);
           return setTimeout(() => {}, 0);
         }) as typeof setTimeout,
         log: () => {},
@@ -400,14 +411,206 @@ describe("runMs365McpLauncher", () => {
     savedRefreshCb!();
     await new Promise((r) => setTimeout(r, 50));
 
-    // After refresh failure, simulate the child dying on its own
-    // (e.g. network drop). The launcher MUST propagate this as
-    // unexpected — if the flag leaked, the launcher would swallow
-    // the exit silently.
+    // After refresh failure, simulate the child crashing on its own
+    // (e.g. network drop, exit 137). The launcher MUST act on this exit —
+    // if restartingForRefresh had leaked, the exit would be swallowed
+    // silently. With the token still valid, the correct action is a
+    // crash-loop backoff re-spawn (issue #2586), NOT a launcher exit.
     child1.exitCode = 137;
     child1.emit("exit", 137, null);
+    await new Promise((r) => setImmediate(r));
+
+    // A backoff timer was scheduled (the exit was acted on, not swallowed).
+    expect(backoffCbs.length).toBeGreaterThanOrEqual(1);
+    // Fire it — softeria re-spawns in-process with the SAME cached token and
+    // no extra broker fetch.
+    backoffCbs[backoffCbs.length - 1]!();
+    await new Promise((r) => setImmediate(r));
+    expect(spawnCount).toBe(2);
+
+    // Cleanup — child2 exits cleanly so the launcher resolves.
+    child2.exitCode = 0;
+    child2.emit("exit", 0, null);
     const code = await promise;
+    expect(code).toBe(0);
+    rmSync(hbDir, { recursive: true, force: true });
+    delete process.env.SWITCHROOM_M365_HEARTBEAT_DIR;
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// computeRestartBackoffMs — issue #2586
+// ────────────────────────────────────────────────────────────────────────
+
+describe("computeRestartBackoffMs", () => {
+  it("starts at the base delay for attempt 0", () => {
+    expect(computeRestartBackoffMs(0)).toBe(SOFTERIA_RESTART_BASE_MS);
+  });
+
+  it("doubles per attempt (exponential backoff)", () => {
+    expect(computeRestartBackoffMs(1)).toBe(SOFTERIA_RESTART_BASE_MS * 2);
+    expect(computeRestartBackoffMs(2)).toBe(SOFTERIA_RESTART_BASE_MS * 4);
+    expect(computeRestartBackoffMs(3)).toBe(SOFTERIA_RESTART_BASE_MS * 8);
+  });
+
+  it("caps at SOFTERIA_RESTART_MAX_MS", () => {
+    expect(computeRestartBackoffMs(100)).toBe(SOFTERIA_RESTART_MAX_MS);
+  });
+
+  it("treats negative attempts as attempt 0", () => {
+    expect(computeRestartBackoffMs(-5)).toBe(SOFTERIA_RESTART_BASE_MS);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// crash-loop backoff — issue #2586 (get-credentials retry-storm)
+// ────────────────────────────────────────────────────────────────────────
+
+describe("runMs365McpLauncher — crash-loop backoff (#2586)", () => {
+  it("re-spawns softeria on crash WITHOUT a fresh broker fetch while token is valid", async () => {
+    const hbDir = `/tmp/m365-test-storm-${process.pid}-${Date.now()}`;
+    process.env.SWITCHROOM_M365_HEARTBEAT_DIR = hbDir;
+    const children = [makeFakeChild(), makeFakeChild(), makeFakeChild()];
+    let spawnCount = 0;
+    let fetchCount = 0;
+    let savedRefreshCb: (() => void) | null = null;
+    const backoffCbs: Array<() => void> = [];
+
+    const promise = runMs365McpLauncher(
+      {},
+      {
+        fetchCreds: async () => {
+          fetchCount++;
+          return { accessToken: "at-1", expiresAt: Date.now() + 60 * 60 * 1000 };
+        },
+        spawnSofteria: () => {
+          const c = children[spawnCount++];
+          return c as unknown as import("node:child_process").ChildProcess;
+        },
+        setTimer: ((cb: () => void, _ms: number) => {
+          if (!savedRefreshCb) savedRefreshCb = cb;
+          else backoffCbs.push(cb);
+          return setTimeout(() => {}, 0);
+        }) as typeof setTimeout,
+        log: () => {},
+      },
+    );
+
+    await new Promise((r) => setImmediate(r));
+    expect(spawnCount).toBe(1);
+    expect(fetchCount).toBe(1);
+
+    // softeria crashes (exit 137) twice — each time the launcher must
+    // re-spawn with the cached token and MUST NOT call fetchCreds again.
+    for (let i = 0; i < 2; i++) {
+      children[i].exitCode = 137;
+      children[i].emit("exit", 137, null);
+      await new Promise((r) => setImmediate(r));
+      backoffCbs[backoffCbs.length - 1]!();
+      await new Promise((r) => setImmediate(r));
+    }
+
+    expect(spawnCount).toBe(3); // initial + 2 re-spawns
+    expect(fetchCount).toBe(1); // NO extra broker fetch — storm defused
+
+    // Cleanup — clean exit resolves the launcher.
+    children[2].exitCode = 0;
+    children[2].emit("exit", 0, null);
+    const code = await promise;
+    expect(code).toBe(0);
+    rmSync(hbDir, { recursive: true, force: true });
+    delete process.env.SWITCHROOM_M365_HEARTBEAT_DIR;
+  });
+
+  it("propagates exit (no backoff) when the cached token has already expired", async () => {
+    const hbDir = `/tmp/m365-test-exp-${process.pid}-${Date.now()}`;
+    process.env.SWITCHROOM_M365_HEARTBEAT_DIR = hbDir;
+    const child = makeFakeChild();
+    let clock = 1_000_000;
+    const promise = runMs365McpLauncher(
+      {},
+      {
+        // Token valid for only 10ms of virtual time.
+        fetchCreds: async () => ({ accessToken: "at-1", expiresAt: clock + 10 }),
+        spawnSofteria: () =>
+          child as unknown as import("node:child_process").ChildProcess,
+        setTimer: ((_cb: () => void, _ms: number) =>
+          setTimeout(() => {}, 0)) as typeof setTimeout,
+        now: () => clock,
+        log: () => {},
+      },
+    );
+
+    await new Promise((r) => setImmediate(r));
+    // Advance virtual clock past expiry, then crash.
+    clock += 1000;
+    child.exitCode = 137;
+    child.emit("exit", 137, null);
+    const code = await promise;
+    // Token expired → launcher exits (defers to fresh-creds respawn), no
+    // in-process backoff loop.
     expect(code).toBe(137);
+    rmSync(hbDir, { recursive: true, force: true });
+    delete process.env.SWITCHROOM_M365_HEARTBEAT_DIR;
+  });
+
+  it("gives up after SOFTERIA_MAX_RESTARTS consecutive rapid crashes", async () => {
+    const hbDir = `/tmp/m365-test-giveup-${process.pid}-${Date.now()}`;
+    process.env.SWITCHROOM_M365_HEARTBEAT_DIR = hbDir;
+    // Enough children for the initial spawn + MAX_RESTARTS re-spawns.
+    const children = Array.from({ length: SOFTERIA_MAX_RESTARTS + 2 }, () =>
+      makeFakeChild(),
+    );
+    let spawnCount = 0;
+    const clock = 5_000_000;
+    let savedRefreshCb: (() => void) | null = null;
+    const backoffCbs: Array<() => void> = [];
+
+    const promise = runMs365McpLauncher(
+      {},
+      {
+        fetchCreds: async () => ({
+          accessToken: "at-1",
+          expiresAt: clock + 60 * 60 * 1000,
+        }),
+        spawnSofteria: () =>
+          children[spawnCount++] as unknown as
+            import("node:child_process").ChildProcess,
+        setTimer: ((cb: () => void, _ms: number) => {
+          if (!savedRefreshCb) savedRefreshCb = cb;
+          else backoffCbs.push(cb);
+          return setTimeout(() => {}, 0);
+        }) as typeof setTimeout,
+        // Pin the clock so every crash counts as "rapid" (never stable).
+        now: () => clock,
+        log: () => {},
+      },
+    );
+
+    await new Promise((r) => setImmediate(r));
+
+    // Crash repeatedly with no stable window between restarts.
+    let code: number | undefined;
+    let done = false;
+    promise.then((c) => {
+      code = c;
+      done = true;
+    });
+    for (let i = 0; i < SOFTERIA_MAX_RESTARTS + 1 && !done; i++) {
+      children[i].exitCode = 1;
+      children[i].emit("exit", 1, null);
+      await new Promise((r) => setImmediate(r));
+      if (backoffCbs.length > 0 && !done) {
+        backoffCbs[backoffCbs.length - 1]!();
+        await new Promise((r) => setImmediate(r));
+      }
+    }
+
+    await promise;
+    // After the restart budget is exhausted the launcher exits rather than
+    // spinning forever.
+    expect(code).toBe(1);
+    expect(spawnCount).toBeLessThanOrEqual(SOFTERIA_MAX_RESTARTS + 1);
     rmSync(hbDir, { recursive: true, force: true });
     delete process.env.SWITCHROOM_M365_HEARTBEAT_DIR;
   });

--- a/src/cli/m365-mcp-launcher.ts
+++ b/src/cli/m365-mcp-launcher.ts
@@ -296,6 +296,7 @@ export async function runMs365McpLauncher(
   let refreshTimer: NodeJS.Timeout | null = null;
   let restartTimer: NodeJS.Timeout | null = null;
   let restartingForRefresh = false;
+  let shuttingDown = false;
   let resolveLauncher: ((code: number) => void) | null = null;
   // Cached access token + expiry, updated on every successful fetch. Lets the
   // crash-loop backoff re-spawn softeria WITHOUT a fresh broker call (#2586).
@@ -304,6 +305,7 @@ export async function runMs365McpLauncher(
   let lastSpawnMs = 0;
 
   const exitLauncher = (code: number): void => {
+    shuttingDown = true;
     if (refreshTimer) {
       clearTimer(refreshTimer);
       refreshTimer = null;
@@ -341,6 +343,11 @@ export async function runMs365McpLauncher(
       // than exiting, so Claude Code doesn't respawn the launcher and issue a
       // fresh get-credentials broker call on every crash. A clean exit (code 0)
       // is an intentional shutdown and is propagated as before.
+      // If we're already tearing down (SIGTERM/SIGINT or exitLauncher), never
+      // start a fresh softeria — the launcher is on its way out. Relying on
+      // event-loop ordering for this was fragile; the flag is authoritative.
+      if (shuttingDown) return;
+
       const crashed = resolved !== 0;
       const tokenValid = currentCreds != null && currentCreds.expiresAt > now();
       if (crashed && tokenValid) {
@@ -350,11 +357,21 @@ export async function runMs365McpLauncher(
         if (restartAttempts < SOFTERIA_MAX_RESTARTS) {
           const delayMs = computeRestartBackoffMs(restartAttempts);
           restartAttempts += 1;
+          // Null out the dead child BEFORE scheduling the backoff re-spawn.
+          // Otherwise a refresh tick that fires during the backoff window would
+          // call killChild(dead-child) (a no-op) and then spawn its own fresh
+          // child — and when restartTimer later fires it would spawn a SECOND
+          // child, orphaning the first with its exit handler still wired →
+          // multiplying parallel softeria processes (worse than the storm this
+          // fixes). See PR #2997 review. The refresh callback also clears any
+          // pending restartTimer as belt-and-suspenders.
+          currentChild = null;
           log(
             `m365-launcher: softeria exited (code=${resolved} signal=${signal}); re-spawning with cached token in ${Math.round(delayMs / 1000)}s (attempt ${restartAttempts}/${SOFTERIA_MAX_RESTARTS}, no broker call)`,
           );
           restartTimer = setTimer(() => {
             restartTimer = null;
+            if (shuttingDown) return;
             if (currentCreds != null && currentCreds.expiresAt > now()) {
               currentChild = launchChild(currentCreds.accessToken);
             } else {
@@ -395,6 +412,14 @@ export async function runMs365McpLauncher(
     refreshTimer = setTimer(async () => {
       try {
         log("m365-launcher: refreshing token + restarting softeria");
+        // Cancel any pending crash-loop backoff re-spawn. The refresh path is
+        // about to kill + respawn softeria with fresh creds; if a backoff timer
+        // fired afterwards it would spawn a SECOND child, orphaning this one.
+        // See PR #2997 review (double-spawn / process fan-out).
+        if (restartTimer) {
+          clearTimer(restartTimer);
+          restartTimer = null;
+        }
         // Order matters: set the flag BEFORE awaiting fetchCreds. If
         // we awaited first and the child happened to die during the
         // await, the exit handler would treat it as unexpected and

--- a/src/cli/m365-mcp-launcher.ts
+++ b/src/cli/m365-mcp-launcher.ts
@@ -61,6 +61,41 @@ export const DEFAULT_REFRESH_LEAD_MS = 5 * 60 * 1000;
  */
 export const MAX_REFRESH_INTERVAL_MS = 60 * 60 * 1000; // 1h
 
+/**
+ * Crash-loop backoff (issue #2586). When softeria exits unexpectedly the
+ * launcher used to propagate the exit and die, which made Claude Code respawn
+ * the whole MCP server — and each respawn issued a fresh `get-credentials`
+ * broker call. A crash-looping softeria therefore produced a tight
+ * `get-credentials` retry-storm (14.7k fetches/7d, ~96% of all cred fetches).
+ *
+ * Instead, while the cached access token is still valid the launcher now
+ * re-spawns softeria in-process with the SAME token — no broker call — using
+ * exponential backoff between attempts. Only when the token has expired (a
+ * genuine refresh is due) or the restart budget is exhausted does the launcher
+ * exit and defer to Claude Code / the operator.
+ */
+export const SOFTERIA_RESTART_BASE_MS = 1000; // first backoff
+export const SOFTERIA_RESTART_MAX_MS = 30 * 1000; // backoff ceiling
+/**
+ * If softeria stays up at least this long, the crash-loop counter resets — a
+ * one-off death after a healthy run shouldn't inherit prior backoff.
+ */
+export const SOFTERIA_STABLE_MS = 60 * 1000;
+/**
+ * Max consecutive rapid restarts before the launcher gives up and exits (so a
+ * genuinely broken softeria doesn't spin forever with no operator signal).
+ */
+export const SOFTERIA_MAX_RESTARTS = 6;
+
+/**
+ * Exponential backoff for the Nth consecutive crash-loop restart (0-indexed),
+ * capped at `SOFTERIA_RESTART_MAX_MS`. Exported for tests.
+ */
+export function computeRestartBackoffMs(attempt: number): number {
+  const raw = SOFTERIA_RESTART_BASE_MS * 2 ** Math.max(0, attempt);
+  return Math.min(raw, SOFTERIA_RESTART_MAX_MS);
+}
+
 export interface LauncherOptions {
   /** Whether to pass `--org-mode` to softeria (Teams/SharePoint). */
   orgMode?: boolean;
@@ -259,13 +294,23 @@ export async function runMs365McpLauncher(
   let currentChild: ChildProcess | null = null;
   let teardownStdio: (() => void) | null = null;
   let refreshTimer: NodeJS.Timeout | null = null;
+  let restartTimer: NodeJS.Timeout | null = null;
   let restartingForRefresh = false;
   let resolveLauncher: ((code: number) => void) | null = null;
+  // Cached access token + expiry, updated on every successful fetch. Lets the
+  // crash-loop backoff re-spawn softeria WITHOUT a fresh broker call (#2586).
+  let currentCreds: { accessToken: string; expiresAt: number } | null = null;
+  let restartAttempts = 0;
+  let lastSpawnMs = 0;
 
   const exitLauncher = (code: number): void => {
     if (refreshTimer) {
       clearTimer(refreshTimer);
       refreshTimer = null;
+    }
+    if (restartTimer) {
+      clearTimer(restartTimer);
+      restartTimer = null;
     }
     if (resolveLauncher) {
       const r = resolveLauncher;
@@ -277,6 +322,7 @@ export async function runMs365McpLauncher(
   const launchChild = (accessToken: string): ChildProcess => {
     const env = buildSofteriaEnv(accessToken);
     const child = rt.spawnSofteria(env);
+    lastSpawnMs = now();
     teardownStdio = wireStdio(child);
     child.once("exit", (code, signal) => {
       if (teardownStdio) {
@@ -287,8 +333,48 @@ export async function runMs365McpLauncher(
         // Expected — refresh tick killed the child to swap creds.
         return;
       }
-      // Unexpected child exit — propagate up to claude.
       const resolved = code ?? (signal ? 128 : 0);
+
+      // Crash-loop backoff (#2586). A *crash* (non-zero exit / signal) while the
+      // cached token is still valid means softeria fell over for reasons
+      // unrelated to auth — re-spawn it in-process with the SAME token rather
+      // than exiting, so Claude Code doesn't respawn the launcher and issue a
+      // fresh get-credentials broker call on every crash. A clean exit (code 0)
+      // is an intentional shutdown and is propagated as before.
+      const crashed = resolved !== 0;
+      const tokenValid = currentCreds != null && currentCreds.expiresAt > now();
+      if (crashed && tokenValid) {
+        // Reset the counter if softeria stayed up long enough to be "stable".
+        if (now() - lastSpawnMs >= SOFTERIA_STABLE_MS) restartAttempts = 0;
+
+        if (restartAttempts < SOFTERIA_MAX_RESTARTS) {
+          const delayMs = computeRestartBackoffMs(restartAttempts);
+          restartAttempts += 1;
+          log(
+            `m365-launcher: softeria exited (code=${resolved} signal=${signal}); re-spawning with cached token in ${Math.round(delayMs / 1000)}s (attempt ${restartAttempts}/${SOFTERIA_MAX_RESTARTS}, no broker call)`,
+          );
+          restartTimer = setTimer(() => {
+            restartTimer = null;
+            if (currentCreds != null && currentCreds.expiresAt > now()) {
+              currentChild = launchChild(currentCreds.accessToken);
+            } else {
+              // Token expired during backoff — defer to the refresh path /
+              // Claude Code respawn for fresh creds.
+              log("m365-launcher: cached token expired during backoff — exiting for fresh creds");
+              exitLauncher(resolved);
+            }
+          }, delayMs);
+          return;
+        }
+        log(
+          `m365-launcher: softeria crash-looped ${restartAttempts}x within ${Math.round(SOFTERIA_STABLE_MS / 1000)}s — giving up, exiting`,
+        );
+        exitLauncher(resolved);
+        return;
+      }
+
+      // Token expired (a refresh is genuinely due) — propagate up to claude so
+      // it respawns the launcher and pulls fresh credentials.
       log(`m365-launcher: softeria exited unexpectedly code=${resolved} signal=${signal}`);
       exitLauncher(resolved);
     });
@@ -328,6 +414,8 @@ export async function runMs365McpLauncher(
           await killChild(currentChild);
         }
         restartingForRefresh = false;
+        currentCreds = fresh;
+        restartAttempts = 0;
         currentChild = launchChild(fresh.accessToken);
         try {
           process.stdin.resume();
@@ -368,6 +456,7 @@ export async function runMs365McpLauncher(
     log(`m365-launcher: initial broker call failed — ${msg}`);
     return 1;
   }
+  currentCreds = initial;
   currentChild = launchChild(initial.accessToken);
   scheduleRefresh(initial.expiresAt);
 

--- a/telegram-plugin/model-unavailable.ts
+++ b/telegram-plugin/model-unavailable.ts
@@ -69,6 +69,32 @@ export function detectModelUnavailable(
   const sample = stderr.length > 16_384 ? stderr.slice(0, 16_384) : stderr
   const lower = sample.toLowerCase()
 
+  // ── 0. Transient / server-side 429 (NOT account quota) — issue #2922 ────
+  // Anthropic emits a `rate_limit_error` whose message explicitly negates the
+  // account-quota reading: "Server is temporarily limiting requests (not your
+  // usage limit)". A negation-blind substring match on "usage limit" (step 1
+  // below) would misclassify this as `quota_exhausted`, firing a phantom fleet
+  // failover that self-cancels and leaves the turn dead. These are upstream
+  // throttles Claude Code retries internally with backoff — classify them as
+  // `overload` (the calm rate-limit path) BEFORE the quota substrings run, so
+  // the negation is honoured and no failover is announced.
+  const transientUpstreamSignals = [
+    'not your usage limit',
+    'not your account',
+    "not your account's",
+    'temporarily limiting requests',
+    'temporarily rate',
+    'server is temporarily',
+    'would exceed your account’s rate limit',
+    "would exceed your account's rate limit",
+  ]
+  if (transientUpstreamSignals.some(s => lower.includes(s))) {
+    const resetAt = parseResetTime(sample)
+    return resetAt !== undefined
+      ? { kind: 'overload', resetAt, raw: stderr }
+      : { kind: 'overload', raw: stderr }
+  }
+
   // ── 1. Quota / billing exhaustion ──────────────────────────────────────
   const quotaSignals = [
     'out of extra usage',

--- a/telegram-plugin/pty-partial-handler.ts
+++ b/telegram-plugin/pty-partial-handler.ts
@@ -123,6 +123,13 @@ function streamKey(chatId: string, threadId?: number): string {
  *
  * Returns the action taken. All state mutation happens through the
  * supplied `state` object so callers can inspect before/after.
+ *
+ * NOTE on `looksLikeRawApiError` suppression (#2922 Bug 3): this is
+ * *preview-only* scope. PTY partials are the live-streaming terminal tail,
+ * never the authoritative reply (that flows through the operator-event /
+ * reply pipelines). So the worst case of an over-eager match here is a
+ * missing streaming flicker for one snapshot — NOT a dropped user answer.
+ * That asymmetry is why the matcher can stay aggressive on raw error shapes.
  */
 export function handlePtyPartialPure(
   text: string,

--- a/telegram-plugin/pty-partial-handler.ts
+++ b/telegram-plugin/pty-partial-handler.ts
@@ -32,6 +32,7 @@ export type PtyPartialAction =
   | 'dedup-skip' // same text as the previous partial; no-op
   | 'update-existing' // pushed into an already-live stream
   | 'update-new' // created a new stream and pushed into it
+  | 'error-suppressed' // raw API-error TUI line; dropped (issue #2922 Bug 3)
 
 export interface PtyHandlerState {
   /**
@@ -84,6 +85,32 @@ export interface PtyHandlerDeps {
   writeError?: (line: string) => void
 }
 
+/**
+ * Detect a raw API-error line scraped from Claude Code's TUI — issue #2922
+ * Bug 3. When the model 429s / errors, the CLI renders an `API Error: … ·
+ * b'{"type":"error",…}'` line into the terminal; the PTY tail would otherwise
+ * scrape it as the assistant reply and relay the raw bytes verbatim to chat.
+ * These lines are suppressed here so the model-unavailable operator-event
+ * pipeline owns the user-facing rendering (a clean ⚠️ card), not the raw tail.
+ *
+ * Kept deliberately tight (anchored error markers, not any mention of "error")
+ * so genuine assistant text that happens to discuss errors is NOT swallowed.
+ */
+export function looksLikeRawApiError(text: string): boolean {
+  if (typeof text !== 'string' || text.length === 0) return false
+  const lower = text.toLowerCase()
+  return (
+    lower.includes('api error:')
+    || lower.includes('"type":"error"')
+    || lower.includes("'type': 'error'")
+    || lower.includes('rate_limit_error')
+    || lower.includes('overloaded_error')
+    || lower.includes('"is_error":true')
+    // The CLI's Python-style raw-body render: · b'{...}'
+    || / b'\{/.test(text)
+  )
+}
+
 function streamKey(chatId: string, threadId?: number): string {
   // Canonical chat-key derivation lives in gateway/chat-key.ts — keep this
   // expression in lockstep (treats 0/null/undefined the same). See #1564.
@@ -131,6 +158,11 @@ export function handlePtyPartialPure(
   })
 
   if (suppressed) return 'suppressed'
+
+  // Drop raw API-error TUI lines so they never leak to chat as the reply —
+  // the model-unavailable card (operator-event pipeline) renders these
+  // instead. See issue #2922 Bug 3.
+  if (looksLikeRawApiError(text)) return 'error-suppressed'
 
   if (state.lastPtyPreviewByChat.get(sKey) === text) return 'dedup-skip'
 

--- a/telegram-plugin/tests/model-unavailable.test.ts
+++ b/telegram-plugin/tests/model-unavailable.test.ts
@@ -76,6 +76,47 @@ describe('detectModelUnavailable — overload / 429 / 5xx strings', () => {
   })
 })
 
+describe('detectModelUnavailable — transient upstream 429 vs account quota (#2922)', () => {
+  // The load-bearing regression: a server-side transient 429 whose message
+  // explicitly negates the account-quota reading ("not your usage limit")
+  // was misclassified as `quota_exhausted` by the negation-blind "usage limit"
+  // substring, firing a phantom fleet failover + dead turn. It must classify
+  // as `overload` (the calm rate-limit path Claude Code retries internally).
+  it("classifies the live-incident 'not your usage limit' 429 as overload, NOT quota_exhausted", () => {
+    const raw =
+      "API Error: Server is temporarily limiting requests (not your usage limit) · " +
+      'b\'{"type":"error","error":{"type":"rate_limit_error","message":' +
+      '"This request would exceed your account\'s rate limit. Please try again later."}}\''
+    const d = detectModelUnavailable(raw)
+    expect(d?.kind).toBe('overload')
+    expect(d?.kind).not.toBe('quota_exhausted')
+  })
+
+  it("classifies bare 'temporarily limiting requests' as overload", () => {
+    expect(
+      detectModelUnavailable('Server is temporarily limiting requests')?.kind,
+    ).toBe('overload')
+  })
+
+  it("classifies \"would exceed your account's rate limit\" as overload", () => {
+    expect(
+      detectModelUnavailable(
+        "This request would exceed your account's rate limit. Please try again later.",
+      )?.kind,
+    ).toBe('overload')
+  })
+
+  it('still classifies a genuine account usage-limit hit as quota_exhausted', () => {
+    // Guard against over-correction: real quota exhaustion must stay quota.
+    expect(
+      detectModelUnavailable("You've hit your limit · resets 8:50am (Australia/Melbourne)")?.kind,
+    ).toBe('quota_exhausted')
+    expect(detectModelUnavailable('Reached usage limit for the 5h window')?.kind).toBe(
+      'quota_exhausted',
+    )
+  })
+})
+
 describe('detectModelUnavailable — network failures', () => {
   it('classifies ECONNREFUSED', () => {
     expect(detectModelUnavailable('connect ECONNREFUSED 1.2.3.4:443')?.kind).toBe('network')

--- a/telegram-plugin/tests/pty-partial-handler.test.ts
+++ b/telegram-plugin/tests/pty-partial-handler.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   createPtyPartialHandler,
   handlePtyPartialPure,
+  looksLikeRawApiError,
   type PtyHandlerState,
   type PtyHandlerDeps,
 } from '../pty-partial-handler.js'
@@ -63,6 +64,35 @@ describe('handlePtyPartialPure', () => {
     expect(state.activeDraftStreams.size).toBe(0)
     expect(state.lastPtyPreviewByChat.size).toBe(0)
     expect(bot.api.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('suppresses a raw API-error TUI line so it never leaks to chat (#2922 Bug 3)', async () => {
+    const state = makeState({ currentSessionChatId: '1' })
+    const deps = makeDeps(bot)
+    // The exact shape Claude Code's TUI renders on a transient 429.
+    const raw =
+      "API Error: Server is temporarily limiting requests (not your usage limit) · " +
+      "b'{\"type\":\"error\",\"error\":{\"type\":\"rate_limit_error\"}}'"
+    const action = handlePtyPartialPure(raw, state, deps)
+    expect(action).toBe('error-suppressed')
+    await microtaskFlush()
+    // Nothing sent — the operator-event pipeline owns the user-facing card.
+    expect(bot.api.sendMessage).not.toHaveBeenCalled()
+    expect(state.activeDraftStreams.size).toBe(0)
+    // Not recorded as a preview, so it can't poison later dedup either.
+    expect(state.lastPtyPreviewByChat.size).toBe(0)
+  })
+
+  it('does NOT suppress ordinary assistant text that merely mentions errors', async () => {
+    const state = makeState({ currentSessionChatId: '1' })
+    const action = handlePtyPartialPure(
+      "Here's how to handle an error in your retry loop:",
+      state,
+      makeDeps(bot),
+    )
+    expect(action).toBe('update-new')
+    await microtaskFlush()
+    expect(bot.api.sendMessage).toHaveBeenCalledTimes(1)
   })
 
   it('dedups when same text arrives twice in a row', async () => {
@@ -322,5 +352,31 @@ describe('createPtyPartialHandler — session + buffer replay', () => {
 
     expect(bot.api.sendMessage).toHaveBeenCalledTimes(1) // no duplicate
     expect(state.activeDraftStreams.size).toBe(0)
+  })
+})
+
+describe('looksLikeRawApiError (#2922 Bug 3)', () => {
+  it('flags the CLI "API Error: … · b\'{…}\'" line', () => {
+    expect(
+      looksLikeRawApiError(
+        "API Error: Server is temporarily limiting requests · b'{\"type\":\"error\"}'",
+      ),
+    ).toBe(true)
+  })
+
+  it('flags a bare rate_limit_error JSON body', () => {
+    expect(
+      looksLikeRawApiError('{"type":"error","error":{"type":"rate_limit_error"}}'),
+    ).toBe(true)
+  })
+
+  it('flags overloaded_error and is_error markers', () => {
+    expect(looksLikeRawApiError('{"type":"overloaded_error"}')).toBe(true)
+    expect(looksLikeRawApiError('{"is_error":true,"content":"boom"}')).toBe(true)
+  })
+
+  it('does not flag ordinary prose mentioning "error"', () => {
+    expect(looksLikeRawApiError('I hit an error handling that request')).toBe(false)
+    expect(looksLikeRawApiError('')).toBe(false)
   })
 })


### PR DESCRIPTION
Track 5 — auth-broker failover misclassification & retry-storms.

## User outcome
A brief upstream hiccup no longer looks like account exhaustion. Users stop
seeing the scary "quota exhausted → auto-failover" card (that then self-cancels
and leaves the turn dead) and stop seeing raw `b'{...}'` error lines dumped into
chat during a transient blip. And a crash-looping Microsoft MCP server no longer
hammers the auth-broker with thousands of redundant credential fetches.

## Fix 1 — transient 429 misclassified as quota_exhausted (#2922)
A server-side transient `rate_limit_error` ("Server is temporarily limiting
requests (**not your usage limit**)") was classified as `quota_exhausted` by a
negation-blind `"usage limit"` substring match, firing a phantom fleet failover
(announce-then-skip: "probed healthy … Stale event?"), a dead turn, and a raw
error leak.

- `detectModelUnavailable` now matches a transient-upstream signal set
  ("not your usage limit", "temporarily limiting requests", "would exceed your
  account's rate limit", …) **before** the quota substrings, classifying these
  as `overload` — the calm rate-limit path Claude Code retries internally with
  backoff, so **no failover is announced**. Genuine usage-limit hits still
  classify as `quota_exhausted`.
- `pty-partial-handler` now drops raw API-error TUI lines
  (`looksLikeRawApiError`) so they never leak to chat as the assistant reply;
  the operator-event pipeline owns the user-facing card. Ordinary prose that
  merely mentions "error" is untouched.

## Fix 2 — Microsoft 365 get-credentials retry-storm (#2586)
The `m365-mcp-launcher` fetched creds once, then propagated any unexpected
softeria exit to Claude Code, which respawned the MCP server and issued a fresh
`get-credentials` broker call per respawn (14.7k fetches/7d, ~96% of all cred
fetches).

- The launcher now applies an **in-process crash-loop backoff**: on a crash
  (non-zero exit) while the cached token is still valid, it re-spawns softeria
  with the **same token — no broker call** — using exponential backoff
  (1s→30s cap), resetting after a stable run and giving up after
  `SOFTERIA_MAX_RESTARTS`. Clean exits and expired-token cases propagate as
  before.

## Tests
Regression tests added for each fix; verified they **fail before, pass after**.
Targeted suites green: `model-unavailable` (51), `pty-partial-handler` (22),
`m365-mcp-launcher` (27) — 100 passing. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)