### PR TITLE
test(memory) + fix(#2976): close the Hindsight coverage gap + kill HTML-entity name corruption

### DIFF
--- a/src/memory/bank-health.test.ts
+++ b/src/memory/bank-health.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Coverage for `bank-health.ts` — the read-side integrity surface that tells an
+ * operator when memory has silently stopped working. Two failure classes it is
+ * built to fingerprint, and which this suite pins:
+ *
+ *   1. Extraction gaps: documents stored but `memory_unit_count === 0` — the
+ *      conversation was retained yet the agent "remembers" nothing from it.
+ *   2. Corrupted mental models: a persisted LLM-failure message (quota wall)
+ *      standing in for real synthesis, injected into every turn until refreshed.
+ *
+ * All parsing runs against an injected `fetchImpl` returning the real REST JSON
+ * shapes; the classifiers run against constructed summaries.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  inspectBankHealth,
+  corruptedMentalModels,
+  staleMentalModels,
+  recentUnextracted,
+  ageDays,
+  hindsightRestBase,
+  type BankMentalModelSummary,
+  type BankDocumentSummary,
+} from "./bank-health.js";
+
+const MCP_URL = "http://127.0.0.1:18888/mcp/";
+
+function jsonFetch(routes: Record<string, unknown>): typeof fetch {
+  return (async (url: string) => {
+    for (const [suffix, body] of Object.entries(routes)) {
+      if (url.includes(suffix)) return new Response(JSON.stringify(body), { status: 200 });
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
+}
+
+describe("hindsightRestBase", () => {
+  it("strips the /mcp/ suffix to derive the REST root", () => {
+    expect(hindsightRestBase("http://127.0.0.1:18888/mcp/")).toBe("http://127.0.0.1:18888");
+    expect(hindsightRestBase("http://h/mcp")).toBe("http://h");
+    expect(hindsightRestBase("http://h/")).toBe("http://h");
+  });
+});
+
+describe("inspectBankHealth", () => {
+  it("flags documents with zero extracted facts as the extraction-gap fingerprint", async () => {
+    const fetchImpl = jsonFetch({
+      "/stats": { total_documents: 3, total_nodes: 12, pending_operations: 0 },
+      "/documents": {
+        items: [
+          { id: "d1", created_at: "2026-07-01T00:00:00Z", text_length: 4000, memory_unit_count: 5 },
+          { id: "d2", created_at: "2026-07-03T00:00:00Z", text_length: 3000, memory_unit_count: 0 },
+          { id: "d3", created_at: "2026-07-02T00:00:00Z", text_length: 2000, memory_unit_count: 0 },
+        ],
+      },
+      "/mental-models": { items: [] },
+    });
+    const h = await inspectBankHealth(MCP_URL, "coach", { fetchImpl });
+    expect(h.ok).toBe(true);
+    expect(h.totalDocuments).toBe(3);
+    expect(h.totalFacts).toBe(12);
+    // Both zero-fact docs surface, sorted oldest-first by createdAt.
+    expect(h.unextractedDocuments.map((d) => d.id)).toEqual(["d3", "d2"]);
+    // Newest doc timestamp is the max across all docs.
+    expect(h.newestDocumentAt).toBe("2026-07-03T00:00:00Z");
+  });
+
+  it("summarises mental-model provenance (based_on counts + model→model edges)", async () => {
+    const fetchImpl = jsonFetch({
+      "/stats": { total_documents: 1, total_nodes: 1, pending_operations: 0 },
+      "/documents": { items: [] },
+      "/mental-models": {
+        items: [
+          {
+            id: "mm-1",
+            name: "training-plan",
+            content: "the plan is...",
+            source_query: "what's the plan?",
+            last_refreshed_at: "2026-07-05T00:00:00Z",
+            trigger: { mode: "incremental" },
+            reflect_response: {
+              based_on: {
+                observation: [{ id: "o1" }, { id: "o2" }],
+                "mental-models": [{ id: "mm-2" }],
+              },
+            },
+          },
+        ],
+      },
+    });
+    const h = await inspectBankHealth(MCP_URL, "coach", { fetchImpl });
+    const mm = h.mentalModels[0]!;
+    expect(mm.basedOnCounts).toEqual({ observation: 2, "mental-models": 1 });
+    expect(mm.totalSourceFacts).toBe(3);
+    expect(mm.derivedFromModelIds).toEqual(["mm-2"]);
+    expect(mm.refreshMode).toBe("incremental");
+    expect(mm.contentHead).toContain("the plan");
+  });
+
+  it("drops mental-model rows missing id/name rather than emitting malformed entries", async () => {
+    const fetchImpl = jsonFetch({
+      "/stats": { total_documents: 0, total_nodes: 0, pending_operations: 0 },
+      "/documents": { items: [] },
+      "/mental-models": { items: [{ id: "ok", name: "fine" }, { name: "no-id" }, { id: "no-name" }] },
+    });
+    const h = await inspectBankHealth(MCP_URL, "coach", { fetchImpl });
+    expect(h.mentalModels.map((m) => m.id)).toEqual(["ok"]);
+  });
+
+  it("returns ok:false with the failing stage's reason when a REST call errors", async () => {
+    const fetchImpl = (async () => new Response("boom", { status: 500 })) as unknown as typeof fetch;
+    const h = await inspectBankHealth(MCP_URL, "coach", { fetchImpl });
+    expect(h.ok).toBe(false);
+    expect(h.reason).toBe("HTTP 500");
+    expect(h.mentalModels).toEqual([]);
+  });
+});
+
+describe("corruptedMentalModels", () => {
+  function mm(over: Partial<BankMentalModelSummary>): BankMentalModelSummary {
+    return {
+      id: "id",
+      name: "n",
+      lastRefreshedAt: "2026-07-01T00:00:00Z",
+      createdAt: "2026-06-01T00:00:00Z",
+      contentLength: 500,
+      contentHead: "healthy synthesized content",
+      sourceQuery: "q",
+      refreshMode: "full",
+      basedOnCounts: {},
+      totalSourceFacts: 0,
+      derivedFromModelIds: [],
+      ...over,
+    };
+  }
+
+  it("flags a tiny model whose content is a quota/limit failure message", () => {
+    const bad = mm({ contentLength: 60, contentHead: "You're out of extra usage · resets 3am (UTC)" });
+    expect(corruptedMentalModels([bad, mm({})]).map((m) => m.id)).toEqual(["id"]);
+  });
+
+  it("flags an empty-content model that HAS refreshed (refresh produced nothing)", () => {
+    const empty = mm({ contentLength: 0, lastRefreshedAt: "2026-07-01T00:00:00Z" });
+    expect(corruptedMentalModels([empty])).toHaveLength(1);
+  });
+
+  it("does NOT flag an empty model that has never refreshed (nothing to synthesise yet)", () => {
+    const fresh = mm({ contentLength: 0, lastRefreshedAt: null });
+    expect(corruptedMentalModels([fresh])).toHaveLength(0);
+  });
+
+  it("does NOT flag a large model that merely mentions a limit phrase (real synthesis)", () => {
+    const big = mm({ contentLength: 800, contentHead: "The user hit your usage limit last week and was frustrated..." });
+    expect(corruptedMentalModels([big])).toHaveLength(0);
+  });
+});
+
+describe("staleMentalModels", () => {
+  const now = new Date("2026-07-10T00:00:00Z");
+  function mm(refreshed: string | null, created: string | null): BankMentalModelSummary {
+    return {
+      id: "id", name: "n", lastRefreshedAt: refreshed, createdAt: created,
+      contentLength: 100, contentHead: "x", sourceQuery: "q", refreshMode: "full",
+      basedOnCounts: {}, totalSourceFacts: 0, derivedFromModelIds: [],
+    };
+  }
+  it("flags a model whose last refresh is older than the threshold", () => {
+    expect(staleMentalModels([mm("2026-07-01T00:00:00Z", null)], 7, now)).toHaveLength(1);
+  });
+  it("does not flag a recently-refreshed model", () => {
+    expect(staleMentalModels([mm("2026-07-09T00:00:00Z", null)], 7, now)).toHaveLength(0);
+  });
+  it("falls back to createdAt when never refreshed", () => {
+    expect(staleMentalModels([mm(null, "2026-06-01T00:00:00Z")], 7, now)).toHaveLength(1);
+  });
+});
+
+describe("recentUnextracted", () => {
+  const now = new Date("2026-07-10T00:00:00Z");
+  function doc(over: Partial<BankDocumentSummary>): BankDocumentSummary {
+    return { id: "d", createdAt: "2026-07-08T00:00:00Z", textLength: 4000, memoryUnitCount: 0, ...over };
+  }
+  it("excludes short documents (a one-line retain can legitimately yield no facts)", () => {
+    expect(recentUnextracted([doc({ textLength: 200 })], 30, now, 1000)).toHaveLength(0);
+  });
+  it("includes a recent, substantial doc that extracted nothing", () => {
+    expect(recentUnextracted([doc({ textLength: 4000 })], 30, now, 1000)).toHaveLength(1);
+  });
+  it("excludes docs older than the window", () => {
+    expect(recentUnextracted([doc({ createdAt: "2026-01-01T00:00:00Z" })], 30, now, 1000)).toHaveLength(0);
+  });
+});
+
+describe("ageDays", () => {
+  it("returns fractional days, floored at zero, null on bad input", () => {
+    const now = new Date("2026-07-10T00:00:00Z");
+    expect(ageDays("2026-07-09T00:00:00Z", now)).toBeCloseTo(1, 5);
+    expect(ageDays(null)).toBeNull();
+    expect(ageDays("not-a-date")).toBeNull();
+    // A future timestamp clamps to 0 rather than going negative.
+    expect(ageDays("2026-07-11T00:00:00Z", now)).toBe(0);
+  });
+});

--- a/src/memory/hindsight-mcp-ops.test.ts
+++ b/src/memory/hindsight-mcp-ops.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Coverage for the Hindsight MCP *write* ops in `hindsight.ts` — the paths
+ * most able to silently corrupt or lose memory state. The failure mode this
+ * suite exists to kill is the one called out across this module's own comments:
+ * a `tools/call` returns HTTP 200 with `result.isError:true` on a renamed /
+ * dropped / phantom arg, so an HTTP-status-only check reports success while the
+ * server persisted NOTHING (silent no-op = silent data loss).
+ *
+ * Every test drives the REAL code path with an injected `fetchImpl` that speaks
+ * the exact SSE (`event: message\ndata: {…}`) envelope Hindsight returns, and
+ * asserts BOTH the wire contract (which tool, which args switchroom actually
+ * sends) and the success/failure classification.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  createBank,
+  updateBankMissions,
+  ensureMentalModel,
+  ensureDeclaredMentalModels,
+  addMemoryTag,
+} from "./hindsight.js";
+
+const API_URL = "http://127.0.0.1:18888/mcp/";
+
+interface CapturedCall {
+  method: string;
+  toolName?: string;
+  arguments?: Record<string, unknown>;
+  bankId: string | null;
+  raw: unknown;
+}
+
+/** A response body in the SSE frame Hindsight actually emits. */
+function sse(payload: unknown): string {
+  return `event: message\ndata: ${JSON.stringify(payload)}\n\n`;
+}
+
+/** Build a tools/call HTTP-200 envelope, optionally an isError one. */
+function toolResult(opts: { isError?: boolean; text?: string } = {}): unknown {
+  return {
+    jsonrpc: "2.0",
+    id: 2,
+    result: {
+      isError: opts.isError ?? false,
+      content: [{ type: "text", text: opts.text ?? "ok" }],
+    },
+  };
+}
+
+/**
+ * A scripted fetch. `router` maps a JSON-RPC method (and, for tools/call, the
+ * tool name) to a Response. All requests are captured for wire-contract
+ * assertions. `initialize` auto-responds 200 with no session id (the stateless
+ * Hindsight default) unless the router overrides it.
+ */
+function scriptedFetch(
+  router: (call: CapturedCall) => Response | undefined,
+  calls: CapturedCall[],
+  opts: { sessionId?: string } = {},
+): typeof fetch {
+  return (async (_url: string, init: RequestInit) => {
+    const body = JSON.parse(String(init.body)) as {
+      method: string;
+      params?: { name?: string; arguments?: Record<string, unknown> };
+    };
+    const headers = init.headers as Record<string, string>;
+    const call: CapturedCall = {
+      method: body.method,
+      toolName: body.params?.name,
+      arguments: body.params?.arguments,
+      bankId: headers?.["X-Bank-Id"] ?? null,
+      raw: body,
+    };
+    calls.push(call);
+
+    const override = router(call);
+    if (override) return override;
+
+    if (body.method === "initialize") {
+      const h = new Headers();
+      if (opts.sessionId) h.set("mcp-session-id", opts.sessionId);
+      return new Response(
+        sse({ jsonrpc: "2.0", id: 1, result: { serverInfo: { name: "hindsight", version: "test" } } }),
+        { status: 200, headers: h },
+      );
+    }
+    // Default: a clean tool success.
+    return new Response(sse(toolResult()), { status: 200 });
+  }) as unknown as typeof fetch;
+}
+
+describe("createBank — MCP envelope classification", () => {
+  it("sends create_bank with bank_id and returns ok on a clean envelope", async () => {
+    const calls: CapturedCall[] = [];
+    const r = await createBank(API_URL, "coach", { fetchImpl: scriptedFetch(() => undefined, calls) });
+    expect(r.ok).toBe(true);
+    const toolCall = calls.find((c) => c.method === "tools/call");
+    expect(toolCall?.toolName).toBe("create_bank");
+    expect(toolCall?.arguments).toMatchObject({ bank_id: "coach" });
+    expect(toolCall?.bankId).toBe("coach");
+  });
+
+  it("threads optional name + mission into the create_bank args when set", async () => {
+    const calls: CapturedCall[] = [];
+    await createBank(API_URL, "coach", {
+      fetchImpl: scriptedFetch(() => undefined, calls),
+      name: "Coach Bank",
+      mission: "help the user train",
+    });
+    const toolCall = calls.find((c) => c.method === "tools/call");
+    expect(toolCall?.arguments).toMatchObject({ bank_id: "coach", name: "Coach Bank", mission: "help the user train" });
+  });
+
+  it("does NOT report success when create_bank returns isError:true (silent no-op guard)", async () => {
+    const calls: CapturedCall[] = [];
+    const fetchImpl = scriptedFetch((c) => {
+      if (c.toolName === "create_bank") {
+        return new Response(sse(toolResult({ isError: true, text: "Missing required argument: bank_id" })), { status: 200 });
+      }
+      return undefined;
+    }, calls);
+    const r = await createBank(API_URL, "coach", { fetchImpl });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toContain("bank_id");
+  });
+
+  it("fails on a non-200 tool response", async () => {
+    const calls: CapturedCall[] = [];
+    const fetchImpl = scriptedFetch((c) => {
+      if (c.method === "tools/call") return new Response("nope", { status: 503 });
+      return undefined;
+    }, calls);
+    const r = await createBank(API_URL, "coach", { fetchImpl });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("Tool call HTTP 503");
+  });
+
+  it("forwards mcp-session-id onto the tool call when the server issues one", async () => {
+    const calls: CapturedCall[] = [];
+    const fetchImpl = scriptedFetch(() => undefined, calls, { sessionId: "sess-123" });
+    // Wrap to capture the session header on the SECOND (tool) request.
+    let toolSessionHeader: string | null = null;
+    const wrapped = (async (url: string, init: RequestInit) => {
+      const resp = await (fetchImpl as unknown as typeof fetch)(url, init);
+      const body = JSON.parse(String(init.body)) as { method: string };
+      if (body.method === "tools/call") {
+        toolSessionHeader = (init.headers as Record<string, string>)["mcp-session-id"] ?? null;
+      }
+      return resp;
+    }) as unknown as typeof fetch;
+    await createBank(API_URL, "coach", { fetchImpl: wrapped });
+    expect(toolSessionHeader).toBe("sess-123");
+  });
+});
+
+describe("updateBankMissions — mission routing (silent-drop guards)", () => {
+  it("routes retain_mission through config_updates, NOT a dropped top-level arg", async () => {
+    const calls: CapturedCall[] = [];
+    const r = await updateBankMissions(
+      API_URL,
+      "coach",
+      { retain_mission: "extract durable facts" },
+      { fetchImpl: scriptedFetch(() => undefined, calls) },
+    );
+    expect(r.ok).toBe(true);
+    const args = calls.find((c) => c.method === "tools/call")?.arguments as Record<string, unknown>;
+    // The server SILENTLY DROPS a top-level retain_mission — it must ride in config_updates.
+    expect(args).not.toHaveProperty("retain_mission");
+    expect(args.config_updates).toMatchObject({ retain_mission: "extract durable facts" });
+  });
+
+  it("sends a bare bank_mission via the legacy top-level `mission` field", async () => {
+    const calls: CapturedCall[] = [];
+    await updateBankMissions(API_URL, "coach", { bank_mission: "be the coach" }, { fetchImpl: scriptedFetch(() => undefined, calls) });
+    const args = calls.find((c) => c.method === "tools/call")?.arguments as Record<string, unknown>;
+    expect(args.mission).toBe("be the coach");
+  });
+
+  it("when reflect_mission is set, routes it via config_updates and DROPS top-level mission (no race)", async () => {
+    const calls: CapturedCall[] = [];
+    await updateBankMissions(
+      API_URL,
+      "coach",
+      { bank_mission: "legacy", reflect_mission: "the real reflect persona" },
+      { fetchImpl: scriptedFetch(() => undefined, calls) },
+    );
+    const args = calls.find((c) => c.method === "tools/call")?.arguments as Record<string, unknown>;
+    expect(args).not.toHaveProperty("mission");
+    expect(args.config_updates).toMatchObject({ reflect_mission: "the real reflect persona" });
+  });
+
+  it("flattens the nested disposition into disposition_* integer config fields", async () => {
+    const calls: CapturedCall[] = [];
+    await updateBankMissions(
+      API_URL,
+      "coach",
+      { disposition: { skepticism: 4, literalism: 5, empathy: 2 } },
+      { fetchImpl: scriptedFetch(() => undefined, calls) },
+    );
+    const args = calls.find((c) => c.method === "tools/call")?.arguments as Record<string, unknown>;
+    expect(args.config_updates).toMatchObject({
+      disposition_skepticism: 4,
+      disposition_literalism: 5,
+      disposition_empathy: 2,
+    });
+  });
+
+  it("does NOT report success when update_bank returns isError:true", async () => {
+    const calls: CapturedCall[] = [];
+    const fetchImpl = scriptedFetch((c) => {
+      if (c.toolName === "update_bank") return new Response(sse(toolResult({ isError: true, text: "Unknown argument" })), { status: 200 });
+      return undefined;
+    }, calls);
+    const r = await updateBankMissions(API_URL, "coach", { retain_mission: "x" }, { fetchImpl });
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("ensureMentalModel — idempotent create keyed on EXACT name", () => {
+  /** Router that lists the given model names and treats create as success. */
+  function routerWithExisting(names: string[]): (c: CapturedCall) => Response | undefined {
+    return (c) => {
+      if (c.toolName === "list_mental_models") {
+        const items = names.map((n) => ({ name: n }));
+        return new Response(
+          sse({ jsonrpc: "2.0", id: 2, result: { content: [{ type: "text", text: JSON.stringify({ items }) }] } }),
+          { status: 200 },
+        );
+      }
+      return undefined;
+    };
+  }
+
+  it("skips create when a model with the EXACT name already exists", async () => {
+    const calls: CapturedCall[] = [];
+    const r = await ensureMentalModel(
+      API_URL,
+      "coach",
+      { name: "training-plan", sourceQuery: "what's the plan?" },
+      { fetchImpl: scriptedFetch(routerWithExisting(["training-plan", "other"]), calls) },
+    );
+    expect(r.ok).toBe(true);
+    expect(calls.some((c) => c.toolName === "create_mental_model")).toBe(false);
+  });
+
+  it("does NOT false-positive on a SUBSTRING match (the #2447-class bug)", async () => {
+    const calls: CapturedCall[] = [];
+    // "training-plan" is a substring of "training-plan-archive" but not an exact name.
+    await ensureMentalModel(
+      API_URL,
+      "coach",
+      { name: "training-plan", sourceQuery: "q" },
+      { fetchImpl: scriptedFetch(routerWithExisting(["training-plan-archive"]), calls) },
+    );
+    const create = calls.find((c) => c.toolName === "create_mental_model");
+    expect(create).toBeDefined();
+    expect(create?.arguments).toMatchObject({ name: "training-plan", source_query: "q" });
+  });
+
+  it("uses source_query (NOT query) as the create arg", async () => {
+    const calls: CapturedCall[] = [];
+    await ensureMentalModel(
+      API_URL,
+      "coach",
+      { name: "m", sourceQuery: "the standing question" },
+      { fetchImpl: scriptedFetch(routerWithExisting([]), calls) },
+    );
+    const create = calls.find((c) => c.toolName === "create_mental_model");
+    expect(create?.arguments).toHaveProperty("source_query", "the standing question");
+    expect(create?.arguments).not.toHaveProperty("query");
+  });
+
+  it("only serialises optional knobs when set", async () => {
+    const calls: CapturedCall[] = [];
+    await ensureMentalModel(
+      API_URL,
+      "coach",
+      { name: "m", sourceQuery: "q", refreshAfterConsolidation: true, maxTokens: 500 },
+      { fetchImpl: scriptedFetch(routerWithExisting([]), calls) },
+    );
+    const create = calls.find((c) => c.toolName === "create_mental_model");
+    expect(create?.arguments).toMatchObject({
+      trigger_refresh_after_consolidation: true,
+      max_tokens: 500,
+    });
+  });
+
+  it("reports failure when create returns isError:true (renamed-arg no-op guard)", async () => {
+    const calls: CapturedCall[] = [];
+    const fetchImpl = scriptedFetch((c) => {
+      if (c.toolName === "list_mental_models") {
+        return new Response(sse({ jsonrpc: "2.0", id: 2, result: { content: [{ text: JSON.stringify({ items: [] }) }] } }), { status: 200 });
+      }
+      if (c.toolName === "create_mental_model") {
+        return new Response(sse(toolResult({ isError: true, text: "Missing required argument: source_query" })), { status: 200 });
+      }
+      return undefined;
+    }, calls);
+    const r = await ensureMentalModel(API_URL, "coach", { name: "m", sourceQuery: "q" }, { fetchImpl });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toContain("source_query");
+  });
+});
+
+describe("ensureDeclaredMentalModels — batch dedupe + per-model outcomes", () => {
+  function okFetch(calls: CapturedCall[]): typeof fetch {
+    return scriptedFetch((c) => {
+      if (c.toolName === "list_mental_models") {
+        return new Response(sse({ jsonrpc: "2.0", id: 2, result: { content: [{ text: JSON.stringify({ items: [] }) }] } }), { status: 200 });
+      }
+      return undefined;
+    }, calls);
+  }
+
+  it("returns [] and makes no calls when nothing is declared", async () => {
+    const calls: CapturedCall[] = [];
+    const out = await ensureDeclaredMentalModels(API_URL, "coach", undefined, { fetchImpl: okFetch(calls) });
+    expect(out).toEqual([]);
+    expect(calls.length).toBe(0);
+  });
+
+  it("de-dupes by name so one bad config can't double-create", async () => {
+    const calls: CapturedCall[] = [];
+    const out = await ensureDeclaredMentalModels(
+      API_URL,
+      "coach",
+      [
+        { name: "dup", source_query: "a" },
+        { name: "dup", source_query: "b" },
+      ],
+      { fetchImpl: okFetch(calls) },
+    );
+    expect(out).toEqual([{ name: "dup", ok: true }]);
+    const creates = calls.filter((c) => c.toolName === "create_mental_model");
+    expect(creates.length).toBe(1);
+  });
+
+  it("records a per-model failure without aborting the batch", async () => {
+    const calls: CapturedCall[] = [];
+    const fetchImpl = scriptedFetch((c) => {
+      if (c.toolName === "list_mental_models") {
+        return new Response(sse({ jsonrpc: "2.0", id: 2, result: { content: [{ text: JSON.stringify({ items: [] }) }] } }), { status: 200 });
+      }
+      if (c.toolName === "create_mental_model" && (c.arguments?.name === "bad")) {
+        return new Response(sse(toolResult({ isError: true, text: "boom" })), { status: 200 });
+      }
+      return undefined;
+    }, calls);
+    const out = await ensureDeclaredMentalModels(
+      API_URL,
+      "coach",
+      [
+        { name: "good", source_query: "a" },
+        { name: "bad", source_query: "b" },
+      ],
+      { fetchImpl },
+    );
+    expect(out).toEqual([
+      { name: "good", ok: true },
+      { name: "bad", ok: false, reason: "boom" },
+    ]);
+  });
+});
+
+describe("addMemoryTag — honest failure on the phantom update_memory tool", () => {
+  it("returns ok:false when the server reports Unknown tool (no silent success)", async () => {
+    const calls: CapturedCall[] = [];
+    const fetchImpl = scriptedFetch((c) => {
+      if (c.toolName === "update_memory") {
+        return new Response(sse(toolResult({ isError: true, text: "Unknown tool: 'update_memory'" })), { status: 200 });
+      }
+      return undefined;
+    }, calls);
+    const r = await addMemoryTag(API_URL, "coach", "mem-1", "[demote-from-recall]", { fetchImpl });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toContain("update_memory");
+    const call = calls.find((c) => c.toolName === "update_memory");
+    expect(call?.arguments).toMatchObject({ bank_id: "coach", memory_id: "mem-1", add_tags: ["[demote-from-recall]"] });
+  });
+});

--- a/telegram-plugin/gateway/mental-model-propose-diff.ts
+++ b/telegram-plugin/gateway/mental-model-propose-diff.ts
@@ -28,23 +28,37 @@ import { parseDocument } from "yaml";
 import { generateUnifiedDiff } from "../../src/web/config-diff.js";
 
 /**
- * Decode the canonical six HTML/XML entities to their literal characters —
- * the write-boundary half of the #2976 fix.
+ * Decode the canonical six HTML/XML entities to their literal characters — the
+ * config-write-boundary layer of the #2976 defense-in-depth.
  *
- * The failure it kills: a model copies HTML-escaped entities out of its own
- * (Telegram-HTML-rendered) context into a mental-model `name` / `source_query`,
- * and nothing decodes them before they persist. The result is a bank with a
- * model literally named `Nutrition Protocol &amp; Deficit Status`, or a
- * reflection query that steers recall on `R&amp;D` instead of `R&D` — a
- * durable, silent corruption of a memory-integrity field. Normalizing here, at
- * the switchroom-owned write boundary that feeds the persisted config, means an
- * escaped name/query can never LAND in `memory.mental_models[]`.
+ * SCOPE / reachability (be honest about which half is load-bearing):
+ *   - `source_query` decode is the REACHABLE half. A model can copy escaped
+ *     entities out of its Telegram-HTML-rendered context into a proposal's
+ *     free-form `source_query`, and undecoded it would steer recall on `R&amp;D`
+ *     instead of `R&D` — a durable, silent corruption of a memory-integrity
+ *     field. Normalizing here means an escaped query can never LAND in
+ *     `memory.mental_models[]`.
+ *   - `name` decode is REDUNDANT belt-and-suspenders. The `mental_model_propose`
+ *     gateway tool already slug-validates `name` against
+ *     /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/ BEFORE this runs, so an entity-bearing
+ *     name is rejected upstream and can't reach here. It's kept only so this
+ *     write boundary is self-contained if that gate ever moves.
+ *   - The observed in-NAME corruption (`Nutrition Protocol &amp; Deficit Status`,
+ *     klanker 2026-07-06) actually arrived via the DIRECT `create_mental_model`
+ *     Hindsight tool (`ensureMentalModel`, undecoded), NOT this propose path.
+ *     That vector is OUT OF SCOPE here — covered by the steering.ts context-
+ *     hygiene + in-service `Dockerfile.hindsight` normalization follow-ups.
  *
  * SINGLE PASS by design (matches issue #2976's success criteria): a
  * double-escaped `R&amp;amp;D` decodes ONE layer to `R&amp;D`, not all the way
  * to `R&D` — we only undo the escaping switchroom itself applied when it
  * rendered the model's prior output, never the user's literal intent. `&amp;`
  * is decoded LAST so `&amp;lt;` collapses to `&lt;` (one layer), not `<`.
+ *
+ * Accepted tradeoff: a `source_query` a human genuinely intended to contain a
+ * literal `&amp;` / `&lt;` / etc. (rare — a reflection question, not markup)
+ * will have that one layer decoded. Steering queries reading as escaped HTML is
+ * the far more common and more harmful case, so we optimize for it.
  */
 export function decodeCanonicalEntities(s: string): string {
   return s
@@ -169,9 +183,11 @@ export function buildMentalModelAppendDiff(args: {
 
   // #2976 write-boundary normalization: decode any HTML/XML entities the model
   // may have copied out of its own escaped context so the LITERAL characters
-  // land in config — never `&amp;` / `&lt;` etc. Applied to both the identity
-  // key (`name`, also the idempotent-ensure key) and the recall-steering
-  // `source_query`. Duplicate-name guard runs on the decoded name below.
+  // land in config — never `&amp;` / `&lt;` etc. The load-bearing target is the
+  // free-form `source_query`; the `name` decode is redundant with the gateway
+  // slug gate (an entity-bearing name is rejected upstream) and kept only so
+  // this boundary is self-contained. Duplicate-name guard runs on the decoded
+  // name above.
   const name = decodedName;
   const source_query = decodeCanonicalEntities(spec.source_query);
 

--- a/telegram-plugin/gateway/mental-model-propose-diff.ts
+++ b/telegram-plugin/gateway/mental-model-propose-diff.ts
@@ -28,6 +28,35 @@ import { parseDocument } from "yaml";
 import { generateUnifiedDiff } from "../../src/web/config-diff.js";
 
 /**
+ * Decode the canonical six HTML/XML entities to their literal characters —
+ * the write-boundary half of the #2976 fix.
+ *
+ * The failure it kills: a model copies HTML-escaped entities out of its own
+ * (Telegram-HTML-rendered) context into a mental-model `name` / `source_query`,
+ * and nothing decodes them before they persist. The result is a bank with a
+ * model literally named `Nutrition Protocol &amp; Deficit Status`, or a
+ * reflection query that steers recall on `R&amp;D` instead of `R&D` — a
+ * durable, silent corruption of a memory-integrity field. Normalizing here, at
+ * the switchroom-owned write boundary that feeds the persisted config, means an
+ * escaped name/query can never LAND in `memory.mental_models[]`.
+ *
+ * SINGLE PASS by design (matches issue #2976's success criteria): a
+ * double-escaped `R&amp;amp;D` decodes ONE layer to `R&amp;D`, not all the way
+ * to `R&D` — we only undo the escaping switchroom itself applied when it
+ * rendered the model's prior output, never the user's literal intent. `&amp;`
+ * is decoded LAST so `&amp;lt;` collapses to `&lt;` (one layer), not `<`.
+ */
+export function decodeCanonicalEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+/**
  * A proposed mental model, in the same snake_case shape the
  * `memory.mental_models[]` schema (#2874) accepts. `name` + `source_query`
  * are required; the knobs are opt-in and only serialised when set (a minimal
@@ -125,20 +154,31 @@ export function buildMentalModelAppendDiff(args: {
   }
 
   // Duplicate-name guard (defense-in-depth; the executor also checks up front
-  // so it never even posts a card for a dupe).
+  // so it never even posts a card for a dupe). Compare on the DECODED name so a
+  // re-propose of an entity-escaped variant collides with the already-stored
+  // literal (#2976) rather than sneaking in a corrupted twin.
+  const decodedName = decodeCanonicalEntities(spec.name);
   const existing = readDeclaredMentalModelNames(configText, agentName);
-  if (existing.includes(spec.name)) {
+  if (existing.includes(decodedName)) {
     return {
       ok: false,
       error: "duplicate",
-      detail: `mental model "${spec.name}" is already declared for ${agentName}`,
+      detail: `mental model "${decodedName}" is already declared for ${agentName}`,
     };
   }
 
+  // #2976 write-boundary normalization: decode any HTML/XML entities the model
+  // may have copied out of its own escaped context so the LITERAL characters
+  // land in config — never `&amp;` / `&lt;` etc. Applied to both the identity
+  // key (`name`, also the idempotent-ensure key) and the recall-steering
+  // `source_query`. Duplicate-name guard runs on the decoded name below.
+  const name = decodedName;
+  const source_query = decodeCanonicalEntities(spec.source_query);
+
   // Assemble the minimal, schema-clean declaration node.
   const item: Record<string, unknown> = {
-    name: spec.name,
-    source_query: spec.source_query,
+    name,
+    source_query,
   };
   if (spec.refresh_after_consolidation !== undefined) {
     item.refresh_after_consolidation = spec.refresh_after_consolidation;

--- a/telegram-plugin/tests/mental-model-name-entity-corruption.test.ts
+++ b/telegram-plugin/tests/mental-model-name-entity-corruption.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Regression coverage for #2976 — HTML-entity corruption in mental-model names.
+ *
+ * A model copies HTML-escaped entities out of its own (Telegram-HTML-rendered)
+ * context into a `create_mental_model` / propose call, and nothing decoded them
+ * before they persisted — so banks ended up with models literally named
+ * `Nutrition Protocol &amp; Deficit Status` and reflection queries steering on
+ * `R&amp;D` instead of `R&D` (observed live, klanker 2026-07-06).
+ *
+ * These tests pin the switchroom-owned WRITE-BOUNDARY normalization: the
+ * proposed name + source_query are decoded to their literal characters BEFORE
+ * they are synthesized into the config diff, so an escaped value can never land
+ * in `memory.mental_models[]`. Each assertion below FAILS against the pre-fix
+ * code (which serialized `spec.name` / `spec.source_query` verbatim) and passes
+ * after.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseDocument } from "yaml";
+import {
+  buildMentalModelAppendDiff,
+  readDeclaredMentalModelNames,
+  decodeCanonicalEntities,
+} from "../gateway/mental-model-propose-diff.js";
+
+const BASE_CONFIG = `agents:
+  klanker:
+    memory:
+      backend: hindsight
+`;
+
+/** Pull the appended model node out of the synthesized `after` config. */
+function appendedModel(after: string, agent = "klanker"): { name?: unknown; source_query?: unknown } {
+  const js = parseDocument(after).toJS() as {
+    agents: Record<string, { memory: { mental_models: Array<Record<string, unknown>> } }>;
+  };
+  const models = js.agents[agent]!.memory.mental_models;
+  return models[models.length - 1]!;
+}
+
+describe("decodeCanonicalEntities — single-pass, canonical six only", () => {
+  it("decodes each canonical entity to its literal character", () => {
+    expect(decodeCanonicalEntities("R&amp;D")).toBe("R&D");
+    expect(decodeCanonicalEntities("a&lt;b&gt;c")).toBe("a<b>c");
+    expect(decodeCanonicalEntities("say &quot;hi&quot;")).toBe('say "hi"');
+    expect(decodeCanonicalEntities("Ken&apos;s")).toBe("Ken's");
+    expect(decodeCanonicalEntities("Ken&#39;s")).toBe("Ken's");
+  });
+
+  it("undoes exactly ONE layer of escaping (double-escaped → single-escaped)", () => {
+    // We only reverse the escaping switchroom applied when rendering the model's
+    // own prior output — never the user's literal intent.
+    expect(decodeCanonicalEntities("R&amp;amp;D")).toBe("R&amp;D");
+    expect(decodeCanonicalEntities("&amp;lt;")).toBe("&lt;");
+  });
+
+  it("leaves entity-free text untouched (idempotent on clean input)", () => {
+    expect(decodeCanonicalEntities("Nutrition Protocol & Deficit")).toBe("Nutrition Protocol & Deficit");
+  });
+});
+
+describe("#2976 — propose write-boundary normalizes the mental-model name", () => {
+  it("stores the LITERAL '&' name, not the escaped '&amp;' the model emitted", () => {
+    const built = buildMentalModelAppendDiff({
+      configText: BASE_CONFIG,
+      agentName: "klanker",
+      spec: { name: "Nutrition Protocol &amp; Deficit Status", source_query: "how is the deficit?" },
+    });
+    expect(built.ok).toBe(true);
+    if (!built.ok) return;
+    expect(appendedModel(built.after).name).toBe("Nutrition Protocol & Deficit Status");
+    // And there is no residual entity anywhere in the persisted config.
+    expect(built.after).not.toContain("&amp;");
+    // Reading the declared names back yields the decoded literal.
+    expect(readDeclaredMentalModelNames(built.after, "klanker")).toContain(
+      "Nutrition Protocol & Deficit Status",
+    );
+  });
+
+  it("normalizes the recall-steering source_query too (not just the name)", () => {
+    const built = buildMentalModelAppendDiff({
+      configText: BASE_CONFIG,
+      agentName: "klanker",
+      spec: { name: "rd-budget", source_query: "what is the user&apos;s R&amp;D budget?" },
+    });
+    expect(built.ok).toBe(true);
+    if (!built.ok) return;
+    expect(appendedModel(built.after).source_query).toBe("what is the user's R&D budget?");
+  });
+
+  it("rejects an entity-escaped re-propose of an already-declared literal name (dup guard on decoded name)", () => {
+    const configWithModel = `agents:
+  klanker:
+    memory:
+      backend: hindsight
+      mental_models:
+        - name: Q3 R&D Plan
+          source_query: what is the plan?
+`;
+    const built = buildMentalModelAppendDiff({
+      configText: configWithModel,
+      agentName: "klanker",
+      // Escaped variant of the same logical name — must collide, not create a twin.
+      spec: { name: "Q3 R&amp;D Plan", source_query: "different query" },
+    });
+    expect(built.ok).toBe(false);
+    if (built.ok) return;
+    expect(built.error).toBe("duplicate");
+  });
+});

--- a/telegram-plugin/tests/mental-model-name-entity-corruption.test.ts
+++ b/telegram-plugin/tests/mental-model-name-entity-corruption.test.ts
@@ -1,18 +1,27 @@
 /**
- * Regression coverage for #2976 — HTML-entity corruption in mental-model names.
+ * Regression coverage for #2976 — HTML-entity corruption in mental-model
+ * fields, config-write-boundary layer.
  *
- * A model copies HTML-escaped entities out of its own (Telegram-HTML-rendered)
- * context into a `create_mental_model` / propose call, and nothing decoded them
- * before they persisted — so banks ended up with models literally named
- * `Nutrition Protocol &amp; Deficit Status` and reflection queries steering on
- * `R&amp;D` instead of `R&D` (observed live, klanker 2026-07-06).
+ * Reachability (stated plainly so these tests don't over-claim):
+ *   - `source_query` decode is the REACHABLE/load-bearing half: a proposal's
+ *     free-form query can carry escaped entities the model copied out of its
+ *     Telegram-HTML context, and undecoded it steers recall on `R&amp;D`
+ *     instead of `R&D`.
+ *   - `name` decode is REDUNDANT with the gateway slug gate
+ *     (/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/ rejects an entity-bearing name before
+ *     `buildMentalModelAppendDiff` ever runs). It's belt-and-suspenders; the
+ *     name-path tests here exercise the boundary directly (bypassing the gate)
+ *     to prove the normalization, NOT to imply the propose path could carry the
+ *     bug.
+ *   - The observed in-NAME corruption (`Nutrition Protocol &amp; Deficit
+ *     Status`, klanker 2026-07-06) actually arrived via the DIRECT
+ *     `create_mental_model` Hindsight tool, which this PR does not touch — that
+ *     vector is out of scope (steering.ts / Dockerfile.hindsight follow-ups).
  *
- * These tests pin the switchroom-owned WRITE-BOUNDARY normalization: the
- * proposed name + source_query are decoded to their literal characters BEFORE
- * they are synthesized into the config diff, so an escaped value can never land
- * in `memory.mental_models[]`. Each assertion below FAILS against the pre-fix
- * code (which serialized `spec.name` / `spec.source_query` verbatim) and passes
- * after.
+ * These tests pin the switchroom-owned WRITE-BOUNDARY normalization: name +
+ * source_query are decoded to their literal characters BEFORE synthesis into
+ * the config diff. Each assertion below FAILS against the pre-fix code (which
+ * serialized `spec.name` / `spec.source_query` verbatim) and passes after.
  */
 
 import { describe, it, expect } from "vitest";


### PR DESCRIPTION
## User outcome

Memory (Hindsight) must never silently corrupt or lose data — a wrong recall with no error signal is the failure mode this closes. `src/memory` was ~2,182 src lines to ~135 test lines (~16:1), far below the ~1:1 bar in `src/vault`/`src/auth`, and mental-model steering fields were persisting HTML-escaped with nothing decoding them. This PR adds meaningful coverage on the highest-risk paths and normalizes entities at the config write boundary.

## Coverage added (35 new tests, all exercising the real code path)

- **`src/memory/hindsight-mcp-ops.test.ts`** (19) — the MCP *write* ops via an injected fetch speaking Hindsight's real SSE envelope: `createBank`, `updateBankMissions`, `ensureMentalModel`, `ensureDeclaredMentalModels`, `addMemoryTag`. Pins the failure mode this module exists to kill: **HTTP 200 + `isError:true` must not report success** (silent no-op = silent data loss). Also pins `retain_mission → config_updates` routing (a top-level `retain_mission` is silently dropped by the server), `reflect_mission` vs `bank_mission` de-race, disposition flattening, exact-name idempotence (no substring false-positive — the #2447 class), the `source_query` (not `query`) create arg, and honest failure on the phantom `update_memory` tool.
- **`src/memory/bank-health.test.ts`** (16) — the read-side integrity surface: extraction-gap fingerprinting (`memory_unit_count === 0`), mental-model provenance, corrupted-model detection (persisted quota-failure content / empty-but-refreshed), staleness, the `recentUnextracted` min-length floor, `ageDays`.

## Integrity fixes / regressions

- **#2976 — HTML-entity corruption in mental-model fields (config-write-boundary layer, FIXED + tested).** New `decodeCanonicalEntities` (canonical six, single-pass) applied in `buildMentalModelAppendDiff` to `source_query` **(the reachable, load-bearing half — a free-form query can carry escaped entities that steer recall on `R&amp;D` instead of `R&D`)** and to `name` **(redundant belt-and-suspenders — the `mental_model_propose` gateway tool already slug-validates `name` against `/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/` upstream, so an entity-bearing name can't reach this path)**. The dup guard compares on the decoded name so an escaped re-propose collides with the stored literal. **6 regression tests fail before the change and pass after** (verified via surgical revert). Accepted tradeoff: a `source_query` a human genuinely intended to contain a literal `&amp;`/`&lt;` will have one layer decoded (rare — a reflection question, not markup).
  - **Out of scope here:** the observed in-*name* corruption (`Nutrition Protocol &amp; Deficit Status`, klanker 2026-07-06) arrived via the DIRECT `create_mental_model` Hindsight tool (`ensureMentalModel`, undecoded), which this PR does not touch. That vector is covered by the steering.ts context-hygiene + in-service `Dockerfile.hindsight` normalization follow-ups noted in the issue.
- **#2904 / ref 51258970 — FK-race memory loss (already fixed on main; characterized).** The switchroom-side fix is the self-verifying `reassert_entities()` build-patch in `docker/Dockerfile.hindsight` (PR #2899), and it already has a comprehensive fail-loud guard test (`tests/docker/dockerfile-hindsight-bakes.test.ts` → "keeps the unit_entities FK-race fix"). No new code needed; confirmed the guard is green.

## Coverage sense

`src/memory` test lines went from ~135 to ~500+ across the two new suites (35 tests), moving the highest-risk write/recall/persist/health paths from effectively untested toward the repo's ~1:1 bar.

## Tests green

`vitest run` on all touched suites: **78 passed** (35 new memory + existing memory/docker/propose suites). `tsc --noEmit` clean, `npm run build` clean, plugin-reference + stale-tool-description lint guards clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)