### PR TITLE
feat(telegram): deterministic mid-flight busy ack behind long tool calls

### DIFF
--- a/reference/jobs/know-what-my-agent-is-doing.md
+++ b/reference/jobs/know-what-my-agent-is-doing.md
@@ -187,7 +187,10 @@ visibly-progressing turn.
 ## Related
 
 - [`steer-or-queue-mid-flight`](steer-or-queue-mid-flight.md) — acting on the
-  agent once you can see what it's doing.
+  agent once you can see what it's doing; includes the mid-flight busy ack
+  (a quick question asked while the agent is stuck inside one long tool
+  call gets a silent ack naming the blocking activity within seconds,
+  proven by `jtbd-midflight-busy-ack-dm`).
 - [`track-plan-quota-live`](track-plan-quota-live.md) — the other
   answered-in-the-chat, never-a-dashboard signal.
 - [`see-my-whole-fleet-from-one-screen`](see-my-whole-fleet-from-one-screen.md) —

--- a/reference/jobs/steer-or-queue-mid-flight.md
+++ b/reference/jobs/steer-or-queue-mid-flight.md
@@ -28,6 +28,17 @@ clearly and says which, or it asks.
 > *queue*. The job underneath is unchanged: both operations must work and the
 > chosen one must be visible.
 
+There is a third mid-flight class: a **quick question that neither steers
+nor queues real work** — a status ping, "you there?", a yes/no. It queues
+like any unmarked follow-up, but it carries a latency promise the other two
+don't: when the running turn is stuck inside one long blocking tool call,
+the user must get a visible, silent acknowledgement naming the blocking
+activity **within seconds** — a deterministic framework card, not a model
+turn — so the question never reads as ignored for the minutes a
+`--watch`-style call can take. The ack states the classification ("Queued")
+and what it's waiting behind; the real answer follows when the step
+finishes.
+
 ## Good / bad
 
 **Good looks like**
@@ -41,6 +52,9 @@ clearly and says which, or it asks.
   chat, so the user reads it, never has to infer it.
 - When the input is genuinely ambiguous, the agent makes a reasonable call
   and says which it made, so the user can correct on the next message.
+- A mid-flight message during a long tool call gets a visible ack naming
+  the blocking activity within seconds, silent (no device ping), and the
+  ack is cleaned up once the real answer lands.
 - A burst (a forward of several messages, or a long paste Telegram split)
   is treated as one thought with shared context, not answered fragment by
   fragment.
@@ -58,6 +72,9 @@ clearly and says which, or it asks.
 - A queued task that inherits hallucinated context from the task before it.
 - Dropping a message because a turn was in flight. The user said something;
   it must count.
+- An ack that fires when the agent was seconds from answering — a young
+  tool step returns on its own; acking it is noise that trains the user to
+  ignore the card.
 - No way for the user to override a misclassification and have the correction
   stick.
 
@@ -79,6 +96,13 @@ clearly and says which, or it asks.
   `jtbd-rapid-followup-dm`. *Watch:* every message fired at the turn boundary
   gets its own reply. *Invariant:* no inbound is dropped to a race or a turn
   in flight.
+- **Busy ack behind a long blocking tool call (DM)** —
+  `jtbd-midflight-busy-ack-dm`. *Watch:* a mid-turn quick question sent
+  while the agent sits inside a deliberately slow blocking Bash gets a
+  silent "⏳ Queued — currently inside `<tool>`" ack within seconds, the
+  real answer arrives after the step returns, and the ack card is deleted.
+  *Invariant:* the ack is deterministic (model-free), says "Queued"
+  (classification stays visible), and never fires for a young step.
 - **Survives a restart mid-flight (DM)** — `jtbd-interrupted-turn-resumes-dm`.
   *Watch:* a task interrupted by a restart resumes and runs to completion, not
   silently dropped. *Invariant:* a restart never loses an in-flight task, a
@@ -87,7 +111,7 @@ clearly and says which, or it asks.
   silently dead under a parent that carried on.
 
 **Fuzz corpus:** vary follow-up intent (steer × queue × interrupt ×
-ambiguous) × timing (mid-tool-call × at turn boundary × rapid fire) × burst
+ambiguous) × timing (mid-tool-call × inside long single tool call × at turn boundary × rapid fire) × burst
 shape (forward × split paste × album) × restart mid-flight × surface (DM vs
 channel). The classification must stay visible and nothing the user said may
 be lost, across the corpus.

--- a/skills/switchroom-runtime/SKILL.md
+++ b/skills/switchroom-runtime/SKILL.md
@@ -178,4 +178,6 @@ This is **the persistent-shell wedge.** Claude Code keeps a single `bash` subpro
 
 **Triggering causes to avoid.** The wedge most often follows: (a) a long `npm test` / `bun test` run, (b) any command that was `!`-interrupted mid-flight, (c) heredoc-style commands the shell's stdin couldn't fully consume. Prevention: dispatch heavy test suites to a worker sub-agent (so the wedge dies with the worker) rather than running them in your own session, and use `run_in_background: true` for long jobs.
 
+**Mid-flight responsiveness — never block your turn on a long foreground watch.** A blocking foreground command (`gh pr checks --watch`, `sleep`-and-poll loops, a long `docker build`) pins your whole turn: a user message arriving mid-watch waits behind it, sometimes for minutes. The gateway posts a deterministic "⏳ Queued — currently inside `<tool>`" ack on your behalf (#2995), but the ack is a mitigation, not a license. Run long watches as background tasks (`run_in_background: true`, then poll `BashOutput` between other work) so mid-flight questions get real answers in seconds.
+
 A sentinel file at `$TELEGRAM_STATE_DIR/wedge-detected.json` records the most recent wedge detection. Operators can `cat` it for forensic timestamps; you don't normally need to read it yourself.

--- a/telegram-plugin/gateway/busy-ack.ts
+++ b/telegram-plugin/gateway/busy-ack.ts
@@ -1,0 +1,110 @@
+// #2995 — mid-flight busy ack.
+//
+// A mid-turn inbound that is neither a steer nor an interrupt is buffered
+// until the running turn goes idle (`buffer-until-idle`). When the turn is
+// sitting inside ONE long blocking tool call (`gh pr checks --watch`, a
+// long `sleep`, a slow build), that wait can be minutes — from the phone
+// the question reads as ignored. The user's message got only a 👀 reaction
+// and then silence until the blocking step returned (observed live
+// 2026-07-10: a trivial "are any agents working?" waited 2 minutes behind
+// a `--watch`).
+//
+// This module is the PURE half of the fix: a deterministic, model-free
+// decision — should the gateway post a silent "⏳ Queued — currently
+// inside <tool> …" card into the inbound's own chat/topic right now? No
+// tokens, no model calls; the gateway supplies live readings (delivery-gate
+// decision, tool-flight state, current step age, dedupe state) and this
+// module answers. Extracted so the policy is unit-testable without the
+// gateway IIFE (same pattern as `interrupt-defer.ts` / `feed-reopen-gate.ts`).
+//
+// Wording contract: the buffered-path card MUST say "Queued" — the
+// steer-or-queue job spec (`reference/jobs/steer-or-queue-mid-flight.md`)
+// requires the chosen classification to be visible in the chat, never
+// inferred. A steer-path card must NOT say "Queued" (it wasn't queued);
+// it says the steer was noted and will fold in at the step boundary.
+
+/** How the inbound was classified/handled by the delivery gate. Only the
+ *  two mid-turn shapes are ack-eligible; a plain fresh-turn `deliver`
+ *  needs no busy ack (the turn starts immediately). */
+export type BusyAckGateDecision = 'buffer-until-idle' | 'steer' | 'deliver'
+
+/**
+ * Minimum age of the CURRENT tool step before a busy ack fires. Below
+ * this the step is about to return anyway and the buffered inbound will
+ * flush in a beat — an ack would fire when the agent was seconds from
+ * answering (the job spec's explicit Bad bullet). 12s sits well above the
+ * common fast-tool envelope (reads/greps/short bashes finish in <5s) and
+ * well below the "reads as ignored" horizon (~30s+); it also matches the
+ * UAT latency promise (visible ack <10s of the ping, for a step that has
+ * already proven itself long).
+ */
+export const BUSY_ACK_STEP_AGE_THRESHOLD_MS = 12_000
+
+export interface BusyAckDecisionInput {
+  /** Delivery-gate outcome for this inbound ('steer' when it was
+   *  delivered mid-turn as a steering amend). */
+  gateDecision: BusyAckGateDecision
+  /** Live `ToolFlightTracker.isMidToolCall()` reading — at least one
+   *  top-level tool call currently open. */
+  midToolCall: boolean
+  /** Age (ms) of the LONGEST-running in-flight tool step, or null when no
+   *  step is tracked (e.g. the turn is thinking between tools). */
+  stepAgeMs: number | null
+  /** True when a busy-ack/queued-status card already exists (or was
+   *  already posted this turn) for the inbound's chat/topic — at most one
+   *  card per turn per chat/topic; a second ping gets no second card. */
+  alreadyAcked: boolean
+}
+
+/**
+ * Pure decision: post the busy-ack card now?
+ *
+ *  - only for mid-turn shapes (buffered, or delivered as a steer)
+ *  - only while genuinely mid-tool-call
+ *  - only once the current step is older than the threshold (a young
+ *    step returns soon; the normal flush covers it)
+ *  - at most once per turn per chat/topic (dedupe)
+ */
+export function shouldPostBusyAck(input: BusyAckDecisionInput): boolean {
+  if (input.gateDecision !== 'buffer-until-idle' && input.gateDecision !== 'steer') return false
+  if (!input.midToolCall) return false
+  if (input.stepAgeMs == null || input.stepAgeMs < BUSY_ACK_STEP_AGE_THRESHOLD_MS) return false
+  if (input.alreadyAcked) return false
+  return true
+}
+
+/** Compact human elapsed: 45s → "45s", 130000ms → "2m", 3.9m → "3m". */
+export function formatElapsed(ms: number): string {
+  const s = Math.max(0, Math.round(ms / 1000))
+  if (s < 60) return `${s}s`
+  return `${Math.floor(s / 60)}m`
+}
+
+export interface BusyAckTextInput {
+  gateDecision: 'buffer-until-idle' | 'steer'
+  /** Bare tool name as tracked (e.g. "Bash"). Null when unknown. */
+  toolName: string | null
+  /** Natural-language descriptor from the PreToolUse sidecar's
+   *  `toolLabel()` (e.g. `sleep 90`), or null. */
+  toolLabel: string | null
+  /** Elapsed ms of the in-flight turn (receipt-anchored turn age). */
+  turnElapsedMs: number
+}
+
+/**
+ * Render the card text. Deterministic, no model. The buffered variant
+ * says "Queued" (classification-visibility invariant); the steer variant
+ * says the steer is noted — never "Queued".
+ */
+export function formatBusyAckText(input: BusyAckTextInput): string {
+  const name = input.toolName ?? 'a long-running step'
+  const activity =
+    input.toolLabel != null && input.toolLabel.length > 0
+      ? `${name}: ${input.toolLabel}`
+      : name
+  const elapsed = formatElapsed(input.turnElapsedMs)
+  if (input.gateDecision === 'steer') {
+    return `⏳ Steer noted — currently inside \`${activity}\` (${elapsed} elapsed); I'll fold it in when this step finishes.`
+  }
+  return `⏳ Queued — currently inside \`${activity}\` (${elapsed} elapsed); I'll answer when this step finishes.`
+}

--- a/telegram-plugin/gateway/busy-ack.ts
+++ b/telegram-plugin/gateway/busy-ack.ts
@@ -73,13 +73,6 @@ export function shouldPostBusyAck(input: BusyAckDecisionInput): boolean {
   return true
 }
 
-/** Compact human elapsed: 45s → "45s", 130000ms → "2m", 3.9m → "3m". */
-export function formatElapsed(ms: number): string {
-  const s = Math.max(0, Math.round(ms / 1000))
-  if (s < 60) return `${s}s`
-  return `${Math.floor(s / 60)}m`
-}
-
 export interface BusyAckTextInput {
   gateDecision: 'buffer-until-idle' | 'steer'
   /** Bare tool name as tracked (e.g. "Bash"). Null when unknown. */
@@ -87,14 +80,18 @@ export interface BusyAckTextInput {
   /** Natural-language descriptor from the PreToolUse sidecar's
    *  `toolLabel()` (e.g. `sleep 90`), or null. */
   toolLabel: string | null
-  /** Elapsed ms of the in-flight turn (receipt-anchored turn age). */
-  turnElapsedMs: number
 }
 
 /**
  * Render the card text. Deterministic, no model. The buffered variant
  * says "Queued" (classification-visibility invariant); the steer variant
  * says the steer is noted — never "Queued".
+ *
+ * Deliberately carries NO elapsed figure: the card is posted once and
+ * never re-rendered while the blocking step runs, so any point-in-time
+ * number ("2m elapsed") would silently go stale on screen — a decaying
+ * claim on a card whose whole point is honesty. The activity name alone
+ * is time-invariant.
  */
 export function formatBusyAckText(input: BusyAckTextInput): string {
   const name = input.toolName ?? 'a long-running step'
@@ -102,9 +99,8 @@ export function formatBusyAckText(input: BusyAckTextInput): string {
     input.toolLabel != null && input.toolLabel.length > 0
       ? `${name}: ${input.toolLabel}`
       : name
-  const elapsed = formatElapsed(input.turnElapsedMs)
   if (input.gateDecision === 'steer') {
-    return `⏳ Steer noted — currently inside \`${activity}\` (${elapsed} elapsed); I'll fold it in when this step finishes.`
+    return `⏳ Steer noted — currently inside \`${activity}\`; I'll fold it in when this step finishes.`
   }
-  return `⏳ Queued — currently inside \`${activity}\` (${elapsed} elapsed); I'll answer when this step finishes.`
+  return `⏳ Queued — currently inside \`${activity}\`; I'll answer when this step finishes.`
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -41,7 +41,7 @@ import {
   resolveInterruptMaxWaitMs,
   resolveSafeBoundaryEnabled,
 } from './interrupt-defer.js'
-import { shouldPostBusyAck, formatBusyAckText } from './busy-ack.js'
+import { shouldPostBusyAck, formatBusyAckText, BUSY_ACK_STEP_AGE_THRESHOLD_MS } from './busy-ack.js'
 import {
   resolveStickerSendArgs,
   resolveGifSendArgs,
@@ -1882,9 +1882,16 @@ const activeReactionMsgIds = new Map<string, { chatId: string; messageId: number
 const queuedStatusMsgIds = new Map<string, { chatId: string; threadId: number | null; messageId: number }>()
 // #2995 mid-flight busy-ack dedupe: statusKeys that already got a busy-ack
 // card during the CURRENT turn — at most one card per turn per chat/topic
-// even after the card itself is reaped. Cleared on turn end (alongside the
-// reap in purgeReactionTracking).
+// even after the card itself is reaped. The ending turn's key is deleted in
+// purgeReactionTracking (per-key, not a global clear — a purge for topic A
+// must not reset topic B's dedupe).
 const busyAckPostedKeys = new Set<string>()
+// #2995 deferred re-check: a ping that arrives while the blocking step is
+// still YOUNG (< threshold) must not be silently forgotten — the step may
+// run for minutes more (the original #2995 silence). One timer per key,
+// armed for (threshold − stepAge); it re-evaluates live state when it
+// fires and is cancelled by purgeReactionTracking when the turn ends.
+const busyAckRecheckTimers = new Map<string, ReturnType<typeof setTimeout>>()
 // Reactions whose terminal 👍 is deferred because a background sub-agent
 // worker was still running when the parent's `turn_end` fired. Painting 👍
 // then would read as "done / nothing happening" while the worker keeps
@@ -3492,7 +3499,9 @@ function postQueuedStatus(chatId: string, bufferedThread: number, inFlightThread
  */
 function promoteQueuedStatus(chatId: string, thread: number | undefined): void {
   if (!QUEUED_STATUS_UX_ENABLED) return
-  if (thread == null) return
+  // #2995: thread == null is a DM (or General-topic) card — the busy-ack
+  // extended this lifecycle to DMs, so promote those too (statusKey keys
+  // a null thread identically at post and promote time).
   const key = statusKey(chatId, thread)
   const entry = queuedStatusMsgIds.get(key)
   if (entry == null) return
@@ -3503,7 +3512,7 @@ function promoteQueuedStatus(chatId: string, thread: number | undefined): void {
   void swallowingApiCall(
     () =>
       bot.api.editMessageText(chatId, entry.messageId, '✍️ On it — replying now.', {}),
-    { chat_id: chatId, verb: 'queued-status.promote', threadId: thread },
+    { chat_id: chatId, verb: 'queued-status.promote', ...(thread != null ? { threadId: thread } : {}) },
   )
 }
 
@@ -3547,20 +3556,47 @@ function maybePostBusyAck(
     inFlight != null ? statusKey(inFlight.sessionChatId, inFlight.sessionThreadId) : key
   const now = Date.now()
   const step = silencePoke.longestInFlightTool(inFlightKey, now)
-  const fire = shouldPostBusyAck({
-    gateDecision,
-    midToolCall: toolFlightTracker.isMidToolCall(),
-    stepAgeMs: step?.durationMs ?? null,
-    alreadyAcked: queuedStatusMsgIds.has(key) || busyAckPostedKeys.has(key),
-  })
-  if (!fire) return
+  const midToolCall = toolFlightTracker.isMidToolCall()
+  const stepAgeMs = step?.durationMs ?? null
+  const alreadyAcked = queuedStatusMsgIds.has(key) || busyAckPostedKeys.has(key)
+  const fire = shouldPostBusyAck({ gateDecision, midToolCall, stepAgeMs, alreadyAcked })
+  if (!fire) {
+    // Deferred re-check: the ONLY miss reason we re-arm for is a step that
+    // is genuinely open but still young — it may run for minutes more, and
+    // a one-shot evaluation would re-create the original #2995 silence. Arm
+    // one timer for (threshold − stepAge); everything is re-read live at
+    // fire time, and the timer is pinned to THIS turn (turnId guard) plus
+    // cancelled outright by purgeReactionTracking when the turn ends.
+    if (
+      midToolCall &&
+      !alreadyAcked &&
+      stepAgeMs != null &&
+      stepAgeMs < BUSY_ACK_STEP_AGE_THRESHOLD_MS &&
+      !busyAckRecheckTimers.has(key)
+    ) {
+      const turnIdAtSchedule = inFlight?.turnId ?? null
+      const delayMs = BUSY_ACK_STEP_AGE_THRESHOLD_MS - stepAgeMs + 250
+      busyAckRecheckTimers.set(key, setTimeout(() => {
+        busyAckRecheckTimers.delete(key)
+        // The ping is only still waiting if the SAME turn is still running
+        // (a new/ended turn means the buffered inbound is being handled —
+        // a "Queued" card then would be a lie).
+        if (turnIdAtSchedule == null || currentTurn?.turnId !== turnIdAtSchedule) return
+        maybePostBusyAck(gateDecision, chatId, threadId)
+      }, delayMs))
+    }
+    return
+  }
+  const pendingRecheck = busyAckRecheckTimers.get(key)
+  if (pendingRecheck != null) {
+    clearTimeout(pendingRecheck)
+    busyAckRecheckTimers.delete(key)
+  }
   busyAckPostedKeys.add(key)
-  const turnStartedAt = activeTurnStartedAt.get(inFlightKey)
   const text = formatBusyAckText({
     gateDecision,
     toolName: step?.name ?? null,
     toolLabel: step?.label ?? null,
-    turnElapsedMs: turnStartedAt != null ? now - turnStartedAt : step?.durationMs ?? 0,
   })
   process.stderr.write(
     `telegram gateway: mid-flight busy ack chat=${chatId} thread=${threadId ?? '-'} ` +
@@ -3938,10 +3974,17 @@ function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
     const pqThread = pqThreadPart === '_' || pqThreadPart === '' ? null : Number(pqThreadPart)
     reapQueuedStatus(pqChatId, Number.isFinite(pqThread) ? (pqThread as number) : undefined)
   }
-  // #2995 — reset the per-turn busy-ack dedupe with the turn. Clearing the
-  // whole set (not just this key) is correct: dedupe is "once per TURN per
-  // chat/topic", and a new turn is starting for whichever key comes next.
-  busyAckPostedKeys.clear()
+  // #2995 — reset the ending turn's OWN busy-ack dedupe + cancel its pending
+  // deferred re-check. Per-key, not a global clear: a purge for topic A must
+  // not reset topic B's dedupe or kill B's armed re-check. A buffered topic's
+  // entry clears when ITS turn eventually runs and ends (this same path), and
+  // the re-check timer self-guards on turnId anyway (defense-in-depth).
+  busyAckPostedKeys.delete(key)
+  const busyAckRecheck = busyAckRecheckTimers.get(key)
+  if (busyAckRecheck != null) {
+    clearTimeout(busyAckRecheck)
+    busyAckRecheckTimers.delete(key)
+  }
   // PR3b: clear the parallel-turns fleet-gate entry. Symmetric with
   // the markClaudeBusyForInbound on the delivery path. Safe no-op
   // when the key was never marked (synthetic purge from a sweep).
@@ -17893,30 +17936,25 @@ async function handleInbound(
     // know they're queued. Suppressed for DMs (no topics) and same-topic
     // queues (the in-flight turn's own card already covers them).
     const inFlightThread = currentTurn?.sessionThreadId
-    if (
+    const crossTopicQueuedCard =
       QUEUED_STATUS_UX_ENABLED &&
       !isDmChatId(chat_id) &&
       messageThreadId != null &&
       messageThreadId !== inFlightThread
-    ) {
+    if (crossTopicQueuedCard) {
       postQueuedStatus(chat_id, messageThreadId, inFlightThread)
+    } else {
+      // #2995 mid-flight busy ack — ONLY the surfaces the cross-topic card
+      // suppresses (DMs, same-topic). Mutually exclusive with
+      // postQueuedStatus above: both record into queuedStatusMsgIds only
+      // AFTER their sendMessage awaits resolve, so calling both here would
+      // race past each other's has(key) check and double-card the topic.
+      // When the running turn is inside one LONG tool step, a buffered
+      // quick question would otherwise wait minutes with only a 👀; post a
+      // silent deterministic "Queued — currently inside <tool>" card.
+      maybePostBusyAck('buffer-until-idle', chat_id, messageThreadId ?? undefined)
     }
-    // #2995 mid-flight busy ack — the surfaces the cross-topic card above
-    // suppresses (DMs, same-topic). When the running turn is inside one
-    // LONG tool step, a buffered quick question would otherwise wait
-    // minutes with only a 👀; post a silent deterministic "Queued —
-    // currently inside <tool>" card. postBusyAck is idempotent against
-    // the queuedStatusMsgIds key, so it never stacks on the card above.
-    maybePostBusyAck('buffer-until-idle', chat_id, messageThreadId ?? undefined)
     return
-  }
-
-  // #2995 — a steer delivered mid-turn while the turn is stuck inside one
-  // long tool step gets the same deterministic ack (worded as a steer, not
-  // "Queued" — classification visibility): the model can't narrate the
-  // steer until the blocking call returns.
-  if (deliveryGate.decision === 'deliver' && isSteering) {
-    maybePostBusyAck('steer', chat_id, messageThreadId ?? undefined)
   }
 
   // #2917: reserve the chat's busy key SYNCHRONOUSLY here — before the
@@ -17960,6 +17998,15 @@ async function handleInbound(
 
   const delivered = ipcServer.sendToAgent(selfAgent, inboundMsg)
   if (delivered) {
+    // #2995 — a steer delivered mid-turn while the turn is stuck inside one
+    // long tool step gets a deterministic ack (worded as a steer, not
+    // "Queued" — classification visibility): the model can't narrate the
+    // steer until the blocking call returns. Posted only AFTER the bridge
+    // dispatch succeeded — a "Steer noted" card for a send that missed
+    // (bridge offline → buffered/dropped below) would be untrue.
+    if (isSteering) {
+      maybePostBusyAck('steer', chat_id, messageThreadId ?? undefined)
+    }
     // Reuse the key reserved synchronously above (#2917) when present, else
     // mark now — markClaudeBusyForInbound is idempotent (lockstep re-stamp),
     // so a re-mark is safe and returns the same chat key.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -41,6 +41,7 @@ import {
   resolveInterruptMaxWaitMs,
   resolveSafeBoundaryEnabled,
 } from './interrupt-defer.js'
+import { shouldPostBusyAck, formatBusyAckText } from './busy-ack.js'
 import {
   resolveStickerSendArgs,
   resolveGifSendArgs,
@@ -1875,7 +1876,15 @@ const activeReactionMsgIds = new Map<string, { chatId: string; messageId: number
 // by chatKey(chat_id, bufferedThread). Delete-on-answer: never a dangling
 // placeholder. Reaped on answer (executeReply/stream), on turn-flush, and
 // in purgeReactionTracking cleanup so an abnormal turn-end can't strand it.
-const queuedStatusMsgIds = new Map<string, { chatId: string; threadId: number; messageId: number }>()
+// #2995: threadId is null for DM cards — the mid-flight busy-ack extends
+// this lifecycle to DMs and same-topic surfaces (the original component-5
+// card was cross-topic only).
+const queuedStatusMsgIds = new Map<string, { chatId: string; threadId: number | null; messageId: number }>()
+// #2995 mid-flight busy-ack dedupe: statusKeys that already got a busy-ack
+// card during the CURRENT turn — at most one card per turn per chat/topic
+// even after the card itself is reaped. Cleared on turn end (alongside the
+// reap in purgeReactionTracking).
+const busyAckPostedKeys = new Set<string>()
 // Reactions whose terminal 👍 is deferred because a background sub-agent
 // worker was still running when the parent's `turn_end` fired. Painting 👍
 // then would read as "done / nothing happening" while the worker keeps
@@ -2311,6 +2320,16 @@ const TOPIC_FRAMING_ENABLED =
 // → no placeholder (the 👀 ack reaction still fires). Delete-on-answer.
 const QUEUED_STATUS_UX_ENABLED =
   process.env.SWITCHROOM_QUEUED_STATUS_UX !== '0'
+// #2995 mid-flight busy ack. When a mid-turn inbound is buffered (or lands
+// as a steer) while the running turn sits inside ONE long tool call (step
+// age past the threshold in busy-ack.ts), post a silent deterministic
+// "⏳ Queued — currently inside `<tool>` …" card into the inbound's own
+// chat/topic — model-free, zero tokens. Reuses the queuedStatusMsgIds
+// edit/delete lifecycle (delete-on-answer, reap on abnormal turn-end),
+// extending it to DMs and same-topic surfaces. At most one card per turn
+// per chat/topic. Kill switch off (=0) → legacy silence (👀 only).
+const MIDFLIGHT_BUSY_ACK_ENABLED =
+  process.env.SWITCHROOM_MIDFLIGHT_BUSY_ACK !== '0'
 // Feed-reopen-after-ack. When a tool label arrives for a turn already
 // marked finalAnswerDelivered, the model is still WORKING — so the earlier
 // "final" reply was an interim ACK (an ack-first reply pings or runs ≥200
@@ -3504,6 +3523,88 @@ function reapQueuedStatus(chatId: string, thread: number | undefined): void {
   )
 }
 
+/**
+ * #2995 — mid-flight busy ack (decision + dispatch). Called when a mid-turn
+ * inbound was buffered (`buffer-until-idle`) or delivered as a steer. If the
+ * running turn is sitting inside one LONG tool step (see busy-ack.ts for the
+ * threshold rationale), post a silent deterministic card into the inbound's
+ * own chat/topic naming the blocking activity — so a quick question asked
+ * behind a `--watch`-style blocking call doesn't read as ignored for
+ * minutes. Model-free, zero tokens. The card is stored in
+ * `queuedStatusMsgIds`, so it inherits the component-5 lifecycle: promoted
+ * ("On it") when the buffered turn starts, deleted when the answer lands or
+ * the turn ends. Dedupe is per turn per chat/topic via `busyAckPostedKeys`.
+ */
+function maybePostBusyAck(
+  gateDecision: 'buffer-until-idle' | 'steer',
+  chatId: string,
+  threadId: number | undefined,
+): void {
+  if (!MIDFLIGHT_BUSY_ACK_ENABLED) return
+  const key = statusKey(chatId, threadId)
+  const inFlight = currentTurn
+  const inFlightKey =
+    inFlight != null ? statusKey(inFlight.sessionChatId, inFlight.sessionThreadId) : key
+  const now = Date.now()
+  const step = silencePoke.longestInFlightTool(inFlightKey, now)
+  const fire = shouldPostBusyAck({
+    gateDecision,
+    midToolCall: toolFlightTracker.isMidToolCall(),
+    stepAgeMs: step?.durationMs ?? null,
+    alreadyAcked: queuedStatusMsgIds.has(key) || busyAckPostedKeys.has(key),
+  })
+  if (!fire) return
+  busyAckPostedKeys.add(key)
+  const turnStartedAt = activeTurnStartedAt.get(inFlightKey)
+  const text = formatBusyAckText({
+    gateDecision,
+    toolName: step?.name ?? null,
+    toolLabel: step?.label ?? null,
+    turnElapsedMs: turnStartedAt != null ? now - turnStartedAt : step?.durationMs ?? 0,
+  })
+  process.stderr.write(
+    `telegram gateway: mid-flight busy ack chat=${chatId} thread=${threadId ?? '-'} ` +
+    `decision=${gateDecision} step=${step?.name ?? '-'} step_age_ms=${step?.durationMs ?? '-'}\n`,
+  )
+  postBusyAck(chatId, threadId, text)
+}
+
+/**
+ * #2995 — send the busy-ack card. Mirrors `postQueuedStatus` (idempotent
+ * key, silent send, post-race orphan cleanup) but is thread-OPTIONAL so it
+ * covers DMs and same-topic queues — the surfaces the cross-topic queued
+ * status deliberately suppressed. Shares `queuedStatusMsgIds`, so
+ * promote/reap clean it up exactly like the queued-status placeholder.
+ */
+function postBusyAck(chatId: string, threadId: number | undefined, text: string): void {
+  const key = statusKey(chatId, threadId)
+  if (queuedStatusMsgIds.has(key)) return
+  void (async () => {
+    const sent = await swallowingApiCall(
+      () =>
+        // Deterministic busy-ack placeholder, not the user's answer —
+        // silent by contract (no device ping for a status card).
+        bot.api.sendMessage(chatId, text, {
+          ...(threadId != null ? { message_thread_id: threadId } : {}),
+          disable_notification: true,
+        }),
+      { chat_id: chatId, verb: 'busy-ack.post', ...(threadId != null ? { threadId } : {}) },
+    )
+    const messageId = (sent as { message_id?: number } | undefined)?.message_id
+    if (typeof messageId !== 'number') return
+    // Re-check after the await (same race pattern as postQueuedStatus):
+    // if a placeholder landed for this key in the gap, delete this orphan.
+    if (queuedStatusMsgIds.has(key)) {
+      void swallowingApiCall(
+        () => bot.api.deleteMessage(chatId, messageId),
+        { chat_id: chatId, verb: 'busy-ack.post-race-cleanup', ...(threadId != null ? { threadId } : {}) },
+      )
+      return
+    }
+    queuedStatusMsgIds.set(key, { chatId, threadId: threadId ?? null, messageId })
+  })()
+}
+
 // Problem B — deferred safe-boundary interrupt.
 //
 // `toolFlightTracker` mirrors the session-event stream to know whether a
@@ -3837,6 +3938,10 @@ function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
     const pqThread = pqThreadPart === '_' || pqThreadPart === '' ? null : Number(pqThreadPart)
     reapQueuedStatus(pqChatId, Number.isFinite(pqThread) ? (pqThread as number) : undefined)
   }
+  // #2995 — reset the per-turn busy-ack dedupe with the turn. Clearing the
+  // whole set (not just this key) is correct: dedupe is "once per TURN per
+  // chat/topic", and a new turn is starting for whichever key comes next.
+  busyAckPostedKeys.clear()
   // PR3b: clear the parallel-turns fleet-gate entry. Symmetric with
   // the markClaudeBusyForInbound on the delivery path. Safe no-op
   // when the key was never marked (synthetic purge from a sweep).
@@ -17796,7 +17901,22 @@ async function handleInbound(
     ) {
       postQueuedStatus(chat_id, messageThreadId, inFlightThread)
     }
+    // #2995 mid-flight busy ack — the surfaces the cross-topic card above
+    // suppresses (DMs, same-topic). When the running turn is inside one
+    // LONG tool step, a buffered quick question would otherwise wait
+    // minutes with only a 👀; post a silent deterministic "Queued —
+    // currently inside <tool>" card. postBusyAck is idempotent against
+    // the queuedStatusMsgIds key, so it never stacks on the card above.
+    maybePostBusyAck('buffer-until-idle', chat_id, messageThreadId ?? undefined)
     return
+  }
+
+  // #2995 — a steer delivered mid-turn while the turn is stuck inside one
+  // long tool step gets the same deterministic ack (worded as a steer, not
+  // "Queued" — classification visibility): the model can't narrate the
+  // steer until the blocking call returns.
+  if (deliveryGate.decision === 'deliver' && isSteering) {
+    maybePostBusyAck('steer', chat_id, messageThreadId ?? undefined)
   }
 
   // #2917: reserve the chat's busy key SYNCHRONOUSLY here — before the

--- a/telegram-plugin/silence-poke.ts
+++ b/telegram-plugin/silence-poke.ts
@@ -423,6 +423,20 @@ export function formatFrameworkFallbackText(
   return null
 }
 
+/**
+ * #2995 — the LONGEST-running in-flight tool for a turn key, or null when
+ * none is tracked. Read-only accessor over `inFlightTools` for the
+ * mid-flight busy-ack: the gateway needs the blocking step's name/label
+ * and its age to decide whether (and how) to ack a buffered mid-turn
+ * inbound. Does not touch the silence clock.
+ */
+export function longestInFlightTool(key: string, now: number): ToolSnapshot | null {
+  const s = state.get(key)
+  if (s == null) return null
+  const snaps = snapshotInFlight(s, now)
+  return snaps.length > 0 ? snaps[0]! : null
+}
+
 /** Snapshot in-flight tools sorted longest-running first — for the honest
  *  floor/fallback message body. */
 function snapshotInFlight(s: SilencePokeState, now: number): ToolSnapshot[] {

--- a/telegram-plugin/tests/busy-ack-wiring.test.ts
+++ b/telegram-plugin/tests/busy-ack-wiring.test.ts
@@ -34,26 +34,47 @@ describe('#2995 mid-flight busy ack — gateway wiring', () => {
     expect(ackIdx).toBeGreaterThan(pushIdx)
   })
 
-  it('a mid-turn steer delivery gets the steer-worded variant', () => {
+  it('cross-topic queued status and the busy ack are mutually exclusive (no double-card race)', () => {
+    // Both helpers record into queuedStatusMsgIds only AFTER their
+    // sendMessage awaits resolve, so calling both in the same handler pass
+    // would race past each other's has(key) check and double-card the
+    // topic. The buffer branch must pick exactly one.
     expect(gatewaySrc).toMatch(
-      /deliveryGate\.decision === 'deliver' && isSteering[\s\S]{0,200}maybePostBusyAck\('steer', chat_id, messageThreadId \?\? undefined\)/,
+      /if \(crossTopicQueuedCard\) \{\s*postQueuedStatus\(chat_id, messageThreadId, inFlightThread\)\s*\} else \{/,
     )
+  })
+
+  it('a mid-turn steer gets the steer-worded variant only AFTER successful bridge dispatch', () => {
+    // A "Steer noted" card for a send that missed (bridge offline) would
+    // be untrue — the ack lives inside the `if (delivered)` branch.
+    expect(gatewaySrc).toMatch(
+      /if \(delivered\) \{[\s\S]{0,700}if \(isSteering\) \{\s*maybePostBusyAck\('steer', chat_id, messageThreadId \?\? undefined\)/,
+    )
+  })
+
+  it('an under-threshold miss arms ONE deferred re-check pinned to the running turn', () => {
+    const fn = gatewaySrc.split('function maybePostBusyAck')[1]?.split('\nfunction ')[0] ?? ''
+    // Armed only for the young-step miss, for the remaining age gap.
+    expect(fn).toMatch(/stepAgeMs < BUSY_ACK_STEP_AGE_THRESHOLD_MS &&\s*!busyAckRecheckTimers\.has\(key\)/)
+    expect(fn).toMatch(/BUSY_ACK_STEP_AGE_THRESHOLD_MS - stepAgeMs \+ 250/)
+    // The re-fire is guarded on the SAME turn still running.
+    expect(fn).toMatch(/currentTurn\?\.turnId !== turnIdAtSchedule\) return/)
+    // A posted card cancels the pending re-check.
+    expect(fn).toMatch(/clearTimeout\(pendingRecheck\)/)
   })
 
   it('the decision is fed from live tool-flight + step-age readings (pure module owns policy)', () => {
     const fn = gatewaySrc.split('function maybePostBusyAck')[1]?.split('\nfunction ')[0] ?? ''
-    expect(fn).toMatch(/shouldPostBusyAck\(\{/)
-    expect(fn).toMatch(/midToolCall: toolFlightTracker\.isMidToolCall\(\)/)
+    expect(fn).toMatch(/shouldPostBusyAck\(\{ gateDecision, midToolCall, stepAgeMs, alreadyAcked \}\)/)
+    expect(fn).toMatch(/const midToolCall = toolFlightTracker\.isMidToolCall\(\)/)
     expect(fn).toMatch(/silencePoke\.longestInFlightTool\(/)
-    expect(fn).toMatch(/stepAgeMs: step\?\.durationMs \?\? null/)
-    // Turn age is receipt-anchored (activeTurnStartedAt), per the design.
-    expect(fn).toMatch(/activeTurnStartedAt\.get\(inFlightKey\)/)
+    expect(fn).toMatch(/const stepAgeMs = step\?\.durationMs \?\? null/)
   })
 
   it('dedupe: alreadyAcked couples the live card map AND the per-turn key set', () => {
     const fn = gatewaySrc.split('function maybePostBusyAck')[1]?.split('\nfunction ')[0] ?? ''
     expect(fn).toMatch(
-      /alreadyAcked: queuedStatusMsgIds\.has\(key\) \|\| busyAckPostedKeys\.has\(key\)/,
+      /const alreadyAcked = queuedStatusMsgIds\.has\(key\) \|\| busyAckPostedKeys\.has\(key\)/,
     )
     expect(fn).toMatch(/busyAckPostedKeys\.add\(key\)/)
   })
@@ -75,9 +96,18 @@ describe('#2995 mid-flight busy ack — gateway wiring', () => {
     expect(fn).toMatch(/busy-ack\.post-race-cleanup/)
   })
 
-  it('the per-turn dedupe set is cleared at turn end (alongside the queued-status reap)', () => {
+  it('turn-end cleanup is PER-KEY: dedupe entry deleted and re-check timer cancelled for the ending turn only', () => {
     const purge = gatewaySrc.split('function purgeReactionTracking')[1]?.split('\nfunction ')[0] ?? ''
-    expect(purge).toMatch(/busyAckPostedKeys\.clear\(\)/)
+    // Per-key delete — a purge for topic A must not reset topic B's dedupe.
+    expect(purge).toMatch(/busyAckPostedKeys\.delete\(key\)/)
+    expect(purge).not.toMatch(/busyAckPostedKeys\.clear\(\)/)
+    expect(purge).toMatch(/busyAckRecheckTimers\.delete\(key\)/)
+    expect(purge).toMatch(/clearTimeout\(busyAckRecheck\)/)
+  })
+
+  it('DM cards are promoted too (promoteQueuedStatus no longer early-returns on a null thread)', () => {
+    const fn = gatewaySrc.split('function promoteQueuedStatus')[1]?.split('\nfunction ')[0] ?? ''
+    expect(fn).not.toMatch(/if \(thread == null\) return/)
   })
 
   it('kill switch defaults ON, independently disableable', () => {

--- a/telegram-plugin/tests/busy-ack-wiring.test.ts
+++ b/telegram-plugin/tests/busy-ack-wiring.test.ts
@@ -1,0 +1,88 @@
+/**
+ * #2995 — mid-flight busy ack: gateway wiring guards.
+ *
+ * The gateway IIFE is too entangled to instantiate in-process, so these
+ * are source-level assertions (the established pattern —
+ * multitopic-routing-wiring.test.ts, buffer-gate-broadened.test.ts). They
+ * pin the load-bearing wiring: the buffered-inbound and steer call sites,
+ * the silent send, the shared queuedStatusMsgIds lifecycle (promote/reap
+ * cleanup for free), the per-turn dedupe reset, and the kill switch. The
+ * POLICY and the rendered text are behaviourally tested in
+ * busy-ack.test.ts; the live end-to-end shape in
+ * uat/scenarios/jtbd-midflight-busy-ack-dm.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const gatewaySrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf-8',
+)
+
+describe('#2995 mid-flight busy ack — gateway wiring', () => {
+  it('the buffer-until-idle branch calls maybePostBusyAck for the inbound own chat/topic', () => {
+    expect(gatewaySrc).toMatch(
+      /maybePostBusyAck\('buffer-until-idle', chat_id, messageThreadId \?\? undefined\)/,
+    )
+    // …AFTER the pendingInboundBuffer.push (the ack narrates a real queue).
+    const branch = gatewaySrc.split("deliveryGate.decision === 'buffer-until-idle'")[1] ?? ''
+    const pushIdx = branch.indexOf('pendingInboundBuffer.push(selfAgent, inboundMsg)')
+    const ackIdx = branch.indexOf("maybePostBusyAck('buffer-until-idle'")
+    expect(pushIdx).toBeGreaterThanOrEqual(0)
+    expect(ackIdx).toBeGreaterThan(pushIdx)
+  })
+
+  it('a mid-turn steer delivery gets the steer-worded variant', () => {
+    expect(gatewaySrc).toMatch(
+      /deliveryGate\.decision === 'deliver' && isSteering[\s\S]{0,200}maybePostBusyAck\('steer', chat_id, messageThreadId \?\? undefined\)/,
+    )
+  })
+
+  it('the decision is fed from live tool-flight + step-age readings (pure module owns policy)', () => {
+    const fn = gatewaySrc.split('function maybePostBusyAck')[1]?.split('\nfunction ')[0] ?? ''
+    expect(fn).toMatch(/shouldPostBusyAck\(\{/)
+    expect(fn).toMatch(/midToolCall: toolFlightTracker\.isMidToolCall\(\)/)
+    expect(fn).toMatch(/silencePoke\.longestInFlightTool\(/)
+    expect(fn).toMatch(/stepAgeMs: step\?\.durationMs \?\? null/)
+    // Turn age is receipt-anchored (activeTurnStartedAt), per the design.
+    expect(fn).toMatch(/activeTurnStartedAt\.get\(inFlightKey\)/)
+  })
+
+  it('dedupe: alreadyAcked couples the live card map AND the per-turn key set', () => {
+    const fn = gatewaySrc.split('function maybePostBusyAck')[1]?.split('\nfunction ')[0] ?? ''
+    expect(fn).toMatch(
+      /alreadyAcked: queuedStatusMsgIds\.has\(key\) \|\| busyAckPostedKeys\.has\(key\)/,
+    )
+    expect(fn).toMatch(/busyAckPostedKeys\.add\(key\)/)
+  })
+
+  it('the card is sent SILENT (disable_notification: true) through the swallowing wrapper', () => {
+    const fn = gatewaySrc.split('function postBusyAck')[1]?.split('\nfunction ')[0] ?? ''
+    expect(fn).toMatch(/swallowingApiCall\(/)
+    expect(fn).toMatch(/disable_notification: true/)
+    // Thread-optional: a DM send must NOT pass message_thread_id.
+    expect(fn).toMatch(/\.\.\.\(threadId != null \? \{ message_thread_id: threadId \} : \{\}\)/)
+  })
+
+  it('the card shares queuedStatusMsgIds — promote/reap lifecycle cleans it up', () => {
+    const fn = gatewaySrc.split('function postBusyAck')[1]?.split('\nfunction ')[0] ?? ''
+    // Idempotent against the shared key (never stacks on the cross-topic card).
+    expect(fn).toMatch(/if \(queuedStatusMsgIds\.has\(key\)\) return/)
+    expect(fn).toMatch(/queuedStatusMsgIds\.set\(key, \{ chatId, threadId: threadId \?\? null, messageId \}\)/)
+    // Post-race orphan cleanup, same pattern as postQueuedStatus.
+    expect(fn).toMatch(/busy-ack\.post-race-cleanup/)
+  })
+
+  it('the per-turn dedupe set is cleared at turn end (alongside the queued-status reap)', () => {
+    const purge = gatewaySrc.split('function purgeReactionTracking')[1]?.split('\nfunction ')[0] ?? ''
+    expect(purge).toMatch(/busyAckPostedKeys\.clear\(\)/)
+  })
+
+  it('kill switch defaults ON, independently disableable', () => {
+    expect(gatewaySrc).toMatch(/SWITCHROOM_MIDFLIGHT_BUSY_ACK !== '0'/)
+    const fn = gatewaySrc.split('function maybePostBusyAck')[1]?.split('\nfunction ')[0] ?? ''
+    expect(fn).toMatch(/if \(!MIDFLIGHT_BUSY_ACK_ENABLED\) return/)
+  })
+})

--- a/telegram-plugin/tests/busy-ack.test.ts
+++ b/telegram-plugin/tests/busy-ack.test.ts
@@ -1,0 +1,130 @@
+/**
+ * #2995 — mid-flight busy ack: pure decision module.
+ *
+ * Pins the deterministic policy (`shouldPostBusyAck`) and the rendered
+ * card text (`formatBusyAckText`) — the model-free ack a buffered/steered
+ * mid-turn inbound gets while the running turn sits inside one long tool
+ * step. Behavioral assertions on the RENDERED text (wording contract:
+ * "Queued" for the buffered path per the steer-or-queue classification-
+ * visibility invariant; never "Queued" for a steer).
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  BUSY_ACK_STEP_AGE_THRESHOLD_MS,
+  shouldPostBusyAck,
+  formatBusyAckText,
+  formatElapsed,
+} from '../gateway/busy-ack.js'
+
+const base = {
+  gateDecision: 'buffer-until-idle' as const,
+  midToolCall: true,
+  stepAgeMs: BUSY_ACK_STEP_AGE_THRESHOLD_MS + 1,
+  alreadyAcked: false,
+}
+
+describe('shouldPostBusyAck', () => {
+  it('fires for a buffered inbound behind an old tool step', () => {
+    expect(shouldPostBusyAck(base)).toBe(true)
+  })
+
+  it('fires for a steer behind an old tool step', () => {
+    expect(shouldPostBusyAck({ ...base, gateDecision: 'steer' })).toBe(true)
+  })
+
+  it('never fires for a plain fresh-turn deliver', () => {
+    expect(shouldPostBusyAck({ ...base, gateDecision: 'deliver' })).toBe(false)
+  })
+
+  it('never fires when not mid-tool-call (turn thinking between tools)', () => {
+    expect(shouldPostBusyAck({ ...base, midToolCall: false })).toBe(false)
+  })
+
+  it('never fires below the step-age threshold (agent seconds from answering)', () => {
+    expect(
+      shouldPostBusyAck({ ...base, stepAgeMs: BUSY_ACK_STEP_AGE_THRESHOLD_MS - 1 }),
+    ).toBe(false)
+    // exactly at the threshold → fires (>= semantics)
+    expect(
+      shouldPostBusyAck({ ...base, stepAgeMs: BUSY_ACK_STEP_AGE_THRESHOLD_MS }),
+    ).toBe(true)
+  })
+
+  it('never fires with no tracked step age', () => {
+    expect(shouldPostBusyAck({ ...base, stepAgeMs: null })).toBe(false)
+  })
+
+  it('fires at most once per key — a second ping gets no second card', () => {
+    // The gateway feeds `alreadyAcked` from its per-turn key set + the live
+    // card map; the policy must refuse when either says "already acked".
+    expect(shouldPostBusyAck({ ...base, alreadyAcked: true })).toBe(false)
+  })
+
+  it('threshold constant sits between the fast-tool envelope and the ignored horizon', () => {
+    expect(BUSY_ACK_STEP_AGE_THRESHOLD_MS).toBeGreaterThanOrEqual(5_000)
+    expect(BUSY_ACK_STEP_AGE_THRESHOLD_MS).toBeLessThanOrEqual(30_000)
+  })
+})
+
+describe('formatBusyAckText — rendered card text', () => {
+  it('buffered path says "Queued", names the blocking activity, and promises the answer', () => {
+    const text = formatBusyAckText({
+      gateDecision: 'buffer-until-idle',
+      toolName: 'Bash',
+      toolLabel: 'gh pr checks --watch',
+      turnElapsedMs: 130_000,
+    })
+    expect(text).toContain('Queued')
+    expect(text).toContain('`Bash: gh pr checks --watch`')
+    expect(text).toContain('(2m elapsed)')
+    expect(text).toMatch(/I'll answer when this step finishes/)
+  })
+
+  it('steer path never says "Queued" (classification-visibility invariant)', () => {
+    const text = formatBusyAckText({
+      gateDecision: 'steer',
+      toolName: 'Bash',
+      toolLabel: 'sleep 90',
+      turnElapsedMs: 45_000,
+    })
+    expect(text).not.toContain('Queued')
+    expect(text).toContain('Steer noted')
+    expect(text).toContain('`Bash: sleep 90`')
+    expect(text).toContain('(45s elapsed)')
+  })
+
+  it('degrades honestly when the tool label is unknown', () => {
+    const text = formatBusyAckText({
+      gateDecision: 'buffer-until-idle',
+      toolName: null,
+      toolLabel: null,
+      turnElapsedMs: 20_000,
+    })
+    expect(text).toContain('Queued')
+    expect(text).toContain('a long-running step')
+  })
+
+  it('uses the bare tool name when no label was derived', () => {
+    const text = formatBusyAckText({
+      gateDecision: 'buffer-until-idle',
+      toolName: 'Bash',
+      toolLabel: null,
+      turnElapsedMs: 20_000,
+    })
+    expect(text).toContain('`Bash`')
+  })
+})
+
+describe('formatElapsed', () => {
+  it('sub-minute renders seconds, minute-plus renders whole minutes', () => {
+    expect(formatElapsed(0)).toBe('0s')
+    expect(formatElapsed(45_000)).toBe('45s')
+    expect(formatElapsed(60_000)).toBe('1m')
+    expect(formatElapsed(239_000)).toBe('3m')
+  })
+
+  it('never renders a negative elapsed', () => {
+    expect(formatElapsed(-500)).toBe('0s')
+  })
+})

--- a/telegram-plugin/tests/busy-ack.test.ts
+++ b/telegram-plugin/tests/busy-ack.test.ts
@@ -14,7 +14,6 @@ import {
   BUSY_ACK_STEP_AGE_THRESHOLD_MS,
   shouldPostBusyAck,
   formatBusyAckText,
-  formatElapsed,
 } from '../gateway/busy-ack.js'
 
 const base = {
@@ -73,12 +72,21 @@ describe('formatBusyAckText — rendered card text', () => {
       gateDecision: 'buffer-until-idle',
       toolName: 'Bash',
       toolLabel: 'gh pr checks --watch',
-      turnElapsedMs: 130_000,
     })
     expect(text).toContain('Queued')
     expect(text).toContain('`Bash: gh pr checks --watch`')
-    expect(text).toContain('(2m elapsed)')
     expect(text).toMatch(/I'll answer when this step finishes/)
+  })
+
+  it('carries no point-in-time elapsed figure (a static card must not decay)', () => {
+    // The card is posted once and never re-rendered while the blocking
+    // step runs — any "(Nm elapsed)" would silently go stale on screen.
+    const text = formatBusyAckText({
+      gateDecision: 'buffer-until-idle',
+      toolName: 'Bash',
+      toolLabel: 'sleep 90',
+    })
+    expect(text).not.toMatch(/elapsed|\b\d+[sm]\b/)
   })
 
   it('steer path never says "Queued" (classification-visibility invariant)', () => {
@@ -86,12 +94,10 @@ describe('formatBusyAckText — rendered card text', () => {
       gateDecision: 'steer',
       toolName: 'Bash',
       toolLabel: 'sleep 90',
-      turnElapsedMs: 45_000,
     })
     expect(text).not.toContain('Queued')
     expect(text).toContain('Steer noted')
     expect(text).toContain('`Bash: sleep 90`')
-    expect(text).toContain('(45s elapsed)')
   })
 
   it('degrades honestly when the tool label is unknown', () => {
@@ -99,7 +105,6 @@ describe('formatBusyAckText — rendered card text', () => {
       gateDecision: 'buffer-until-idle',
       toolName: null,
       toolLabel: null,
-      turnElapsedMs: 20_000,
     })
     expect(text).toContain('Queued')
     expect(text).toContain('a long-running step')
@@ -110,21 +115,7 @@ describe('formatBusyAckText — rendered card text', () => {
       gateDecision: 'buffer-until-idle',
       toolName: 'Bash',
       toolLabel: null,
-      turnElapsedMs: 20_000,
     })
     expect(text).toContain('`Bash`')
-  })
-})
-
-describe('formatElapsed', () => {
-  it('sub-minute renders seconds, minute-plus renders whole minutes', () => {
-    expect(formatElapsed(0)).toBe('0s')
-    expect(formatElapsed(45_000)).toBe('45s')
-    expect(formatElapsed(60_000)).toBe('1m')
-    expect(formatElapsed(239_000)).toBe('3m')
-  })
-
-  it('never renders a negative elapsed', () => {
-    expect(formatElapsed(-500)).toBe('0s')
   })
 })

--- a/telegram-plugin/uat/scenarios/jtbd-midflight-busy-ack-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-midflight-busy-ack-dm.test.ts
@@ -1,0 +1,185 @@
+/**
+ * JTBD scenario — mid-flight busy ack (#2995).
+ *
+ * Serves: `reference/jobs/steer-or-queue-mid-flight.md` — the third
+ * mid-flight class (a quick question that neither steers nor queues
+ * work of its own) and its latency promise: a mid-flight message
+ * arriving while the agent sits inside ONE long blocking tool call
+ * gets a visible, silent ack naming the blocking activity within
+ * seconds — never minutes of dead air behind a `--watch`-style call.
+ *
+ * ## What the scenario drives
+ *
+ * 1. Prompt the agent into a deliberately slow BLOCKING foreground
+ *    Bash (`sleep`) — explicitly instructed NOT to background it.
+ * 2. Wait past the busy-ack step-age threshold (12s), then send a
+ *    trivial mid-turn status question. It buffers (unmarked mid-turn
+ *    follow-up = queue).
+ * 3. Assert a bot message matching the deterministic busy-ack shape
+ *    ("⏳ Queued — currently inside `…`") lands within ACK_SLA_MS of
+ *    the ping, and is SILENT (disable_notification).
+ * 4. Assert the real answer to the question arrives later (after the
+ *    blocking step returns and the buffer flushes).
+ * 5. Assert the busy-ack card was cleaned up (deleted) once the
+ *    answer landed — never a dangling "Queued" line.
+ *
+ * Negative case: a mid-turn ping sent IMMEDIATELY (step age < the 12s
+ * threshold) gets NO busy-ack card — an ack that fires when the agent
+ * was seconds from answering is the job spec's explicit Bad bullet.
+ *
+ * ## Conventions
+ *
+ * - mtcute harness (`spinUp`), skip discipline like siblings: env
+ *   handled by load-env; the suite hard-fails without creds by design
+ *   (CI path-gates it to the uat-host runner).
+ * - `!m.edited` filters on every observation (PR #2991 lesson — the
+ *   live draft/feed edits stream constantly; edits must never satisfy
+ *   a fresh-message expectation).
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+import type { ObservedMessage } from "../driver.js";
+
+const AGENT = "test-harness";
+
+// The gateway constant is 12s (BUSY_ACK_STEP_AGE_THRESHOLD_MS). Wait a
+// comfortable margin past it before pinging so the step has proven long.
+const STEP_WARMUP_MS = 18_000;
+
+// Latency promise: user-visible ack within seconds of the ping. The card
+// is posted synchronously by the gateway (no model), so 10s is generous —
+// it covers mtcute polling jitter only.
+const ACK_SLA_MS = 10_000;
+
+// The blocking sleep. Long enough that the warmup + ping + ack all land
+// while the step is still open; short enough to keep wall-clock sane.
+const SLEEP_SECS = 60;
+
+const BUSY_ACK_RE = /⏳ Queued — currently inside `.+`.*I'll answer when this step finishes/s;
+
+const SLOW_PROMPT =
+  `For a latency test, run this exact command in the FOREGROUND with your ` +
+  `Bash tool (do NOT use run_in_background, do NOT split it up): ` +
+  `\`sleep ${SLEEP_SECS} && echo done\`. When it completes, reply with ` +
+  `exactly: SLEEP_DONE. Do not send any message before it completes.`;
+
+const PING = "Quick question while you work: are you still there? One word is fine.";
+
+describe("uat: mid-flight busy ack during a long blocking tool call (#2995)", () => {
+  it(
+    "a mid-turn ping behind a long blocking Bash gets a silent Queued ack naming the activity, then the real answer, then cleanup",
+    async () => {
+      const sc = await spinUp({ agent: AGENT });
+      try {
+        await sc.sendDM(SLOW_PROMPT);
+
+        // Let the blocking step age past the busy-ack threshold.
+        await new Promise((r) => setTimeout(r, STEP_WARMUP_MS));
+
+        const pingAt = Date.now();
+        await sc.sendDM(PING);
+
+        // The deterministic busy-ack must land within the SLA, silent,
+        // naming the blocking activity. `!m.edited` — feed/draft edits
+        // must never satisfy this.
+        const ack = await sc.expectMessage(
+          (m: ObservedMessage) => m.fromBot && !m.edited && BUSY_ACK_RE.test(m.text),
+          { from: "bot", timeout: ACK_SLA_MS + 5_000 },
+        );
+        const ackLatency = Date.now() - pingAt;
+        expect(
+          ackLatency,
+          `busy-ack landed ${ackLatency}ms after the ping — the <10s ` +
+            `latency promise for a mid-flight quick question is broken.`,
+        ).toBeLessThan(ACK_SLA_MS + 5_000);
+        expect(
+          ack.silent,
+          `busy-ack pinged the user's device (silent=false) — the card ` +
+            `must carry disable_notification:true.`,
+        ).toBe(true);
+        // Names the blocking activity (the Bash sleep), not a generic line.
+        expect(ack.text).toMatch(/`.*(Bash|sleep).*`/i);
+
+        // The real answer to the ping arrives AFTER the blocking step
+        // returns and the buffer flushes. Any fresh non-card bot message
+        // that isn't the busy-ack or the SLEEP_DONE completion counts.
+        const answer = await sc.expectMessage(
+          (m: ObservedMessage) =>
+            m.fromBot &&
+            !m.edited &&
+            m.messageId !== ack.messageId &&
+            !BUSY_ACK_RE.test(m.text) &&
+            m.text.trim().length > 0,
+          { from: "bot", timeout: (SLEEP_SECS + 90) * 1000 },
+        );
+        expect(answer.text.trim().length).toBeGreaterThan(0);
+
+        // Cleanup: once answers land and the turns wrap, the busy-ack
+        // card is deleted (delete-on-answer lifecycle). Poll briefly —
+        // the reap is fire-and-forget after the answer/turn-end.
+        const cleanupDeadline = Date.now() + 60_000;
+        let cardGone = false;
+        while (Date.now() < cleanupDeadline) {
+          const still = await sc.driver.getMessage(sc.botUserId, ack.messageId);
+          if (still == null) {
+            cardGone = true;
+            break;
+          }
+          await new Promise((r) => setTimeout(r, 3_000));
+        }
+        expect(
+          cardGone,
+          `busy-ack card (msg ${ack.messageId}) still present 60s after ` +
+            `the answer — a stale "Queued" line is dangling in the chat.`,
+        ).toBe(true);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    // warmup + sleep + flush + answer + cleanup poll + settle headroom
+    (STEP_WARMUP_MS + SLEEP_SECS * 1000 + 200_000),
+  );
+
+  it(
+    "negative: a ping while the step is still young (< threshold) gets no busy-ack card",
+    async () => {
+      const sc = await spinUp({ agent: AGENT });
+      try {
+        await sc.sendDM(
+          `For a latency test, run this exact command in the FOREGROUND ` +
+            `with your Bash tool (do NOT use run_in_background): ` +
+            `\`sleep 25 && echo done\`. When it completes, reply with ` +
+            `exactly: SHORT_SLEEP_DONE. Do not send any message before it completes.`,
+        );
+
+        // Give the agent a beat to enter the Bash step, but ping while
+        // the step is still well under the 12s threshold.
+        await new Promise((r) => setTimeout(r, 4_000));
+        await sc.sendDM("Still with me?");
+
+        // Watch the window where a premature ack would land. No message
+        // matching the busy-ack shape may appear.
+        let prematureAck: ObservedMessage | null = null;
+        try {
+          prematureAck = await sc.expectMessage(
+            (m: ObservedMessage) => m.fromBot && !m.edited && BUSY_ACK_RE.test(m.text),
+            { from: "bot", timeout: 12_000 },
+          );
+        } catch {
+          // timeout = the correct outcome (no premature ack)
+        }
+        expect(
+          prematureAck,
+          `a busy-ack fired for a young step (${JSON.stringify(
+            prematureAck?.text.slice(0, 120),
+          )}) — the agent was seconds from answering; the threshold gate ` +
+            `is not holding.`,
+        ).toBeNull();
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    120_000,
+  );
+});

--- a/telegram-plugin/uat/scenarios/jtbd-midflight-busy-ack-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-midflight-busy-ack-dm.test.ts
@@ -23,9 +23,13 @@
  * 5. Assert the busy-ack card was cleaned up (deleted) once the
  *    answer landed — never a dangling "Queued" line.
  *
- * Negative case: a mid-turn ping sent IMMEDIATELY (step age < the 12s
- * threshold) gets NO busy-ack card — an ack that fires when the agent
- * was seconds from answering is the job spec's explicit Bad bullet.
+ * Negative case: a ping during a SHORT blocking step (well under the 12s
+ * threshold, and finished before the deferred re-check could ever see a
+ * 12s-old step) gets NO busy-ack card at any point — an ack that fires
+ * when the agent was seconds from answering is the job spec's explicit
+ * Bad bullet. (A young-step ping during a LONG step DOES get a deferred
+ * card once the step ages past the threshold — that is the re-check
+ * behaviour, covered by the positive case's latency budget.)
  *
  * ## Conventions
  *
@@ -43,18 +47,24 @@ import type { ObservedMessage } from "../driver.js";
 
 const AGENT = "test-harness";
 
-// The gateway constant is 12s (BUSY_ACK_STEP_AGE_THRESHOLD_MS). Wait a
-// comfortable margin past it before pinging so the step has proven long.
-const STEP_WARMUP_MS = 18_000;
+// The gateway constant is 12s (BUSY_ACK_STEP_AGE_THRESHOLD_MS). The
+// warmup is anchored to the SEND, not to observed tool start — the agent
+// needs a few seconds to open the turn and enter the Bash step — so it
+// carries a large margin: even if the tool starts ~15s after the send,
+// the step is comfortably past the threshold when the ping lands.
+const STEP_WARMUP_MS = 35_000;
 
 // Latency promise: user-visible ack within seconds of the ping. The card
-// is posted synchronously by the gateway (no model), so 10s is generous —
-// it covers mtcute polling jitter only.
+// is posted synchronously by the gateway (no model). When the ping lands
+// past the threshold the card is immediate; if the step turns out to be
+// just under, the deferred re-check posts it within (threshold − age).
+// 10s + jitter headroom covers both.
 const ACK_SLA_MS = 10_000;
 
-// The blocking sleep. Long enough that the warmup + ping + ack all land
-// while the step is still open; short enough to keep wall-clock sane.
-const SLEEP_SECS = 60;
+// The blocking sleep. Long enough that warmup + ping + ack all land while
+// the step is still open (even with a late tool start); short enough to
+// keep wall-clock sane.
+const SLEEP_SECS = 120;
 
 const BUSY_ACK_RE = /⏳ Queued — currently inside `.+`.*I'll answer when this step finishes/s;
 
@@ -103,13 +113,16 @@ describe("uat: mid-flight busy ack during a long blocking tool call (#2995)", ()
 
         // The real answer to the ping arrives AFTER the blocking step
         // returns and the buffer flushes. Any fresh non-card bot message
-        // that isn't the busy-ack or the SLEEP_DONE completion counts.
+        // that isn't the busy-ack or the SLEEP_DONE completion counts —
+        // the SLEEP_DONE exclusion is explicit (it answers the FIRST
+        // prompt, not the ping).
         const answer = await sc.expectMessage(
           (m: ObservedMessage) =>
             m.fromBot &&
             !m.edited &&
             m.messageId !== ack.messageId &&
             !BUSY_ACK_RE.test(m.text) &&
+            !/SLEEP_DONE/i.test(m.text) &&
             m.text.trim().length > 0,
           { from: "bot", timeout: (SLEEP_SECS + 90) * 1000 },
         );
@@ -142,44 +155,47 @@ describe("uat: mid-flight busy ack during a long blocking tool call (#2995)", ()
   );
 
   it(
-    "negative: a ping while the step is still young (< threshold) gets no busy-ack card",
+    "negative: a ping during a SHORT step (finishes under the threshold) never gets a busy-ack card",
     async () => {
       const sc = await spinUp({ agent: AGENT });
       try {
+        // An 8s sleep can NEVER age past the 12s threshold — neither the
+        // direct evaluation nor the deferred re-check may produce a card
+        // (the re-check re-reads live state and finds the step gone).
         await sc.sendDM(
           `For a latency test, run this exact command in the FOREGROUND ` +
             `with your Bash tool (do NOT use run_in_background): ` +
-            `\`sleep 25 && echo done\`. When it completes, reply with ` +
+            `\`sleep 8 && echo done\`. When it completes, reply with ` +
             `exactly: SHORT_SLEEP_DONE. Do not send any message before it completes.`,
         );
 
-        // Give the agent a beat to enter the Bash step, but ping while
-        // the step is still well under the 12s threshold.
+        // Give the agent a beat to enter the Bash step, then ping while
+        // the short step is (at most) a few seconds old.
         await new Promise((r) => setTimeout(r, 4_000));
         await sc.sendDM("Still with me?");
 
-        // Watch the window where a premature ack would land. No message
-        // matching the busy-ack shape may appear.
+        // Watch through the step end + the widest possible re-check window
+        // + the answer. No message matching the busy-ack shape may appear.
         let prematureAck: ObservedMessage | null = null;
         try {
           prematureAck = await sc.expectMessage(
             (m: ObservedMessage) => m.fromBot && !m.edited && BUSY_ACK_RE.test(m.text),
-            { from: "bot", timeout: 12_000 },
+            { from: "bot", timeout: 45_000 },
           );
         } catch {
-          // timeout = the correct outcome (no premature ack)
+          // timeout = the correct outcome (no ack, ever)
         }
         expect(
           prematureAck,
-          `a busy-ack fired for a young step (${JSON.stringify(
-            prematureAck?.text.slice(0, 120),
-          )}) — the agent was seconds from answering; the threshold gate ` +
-            `is not holding.`,
+          `a busy-ack fired for a step that never reached the threshold ` +
+            `(${JSON.stringify(prematureAck?.text.slice(0, 120))}) — the ` +
+            `agent was seconds from answering; the threshold/re-check ` +
+            `gates are not holding.`,
         ).toBeNull();
       } finally {
         await sc.tearDown();
       }
     },
-    120_000,
+    150_000,
   );
 });


### PR DESCRIPTION
## Summary

Fixes #2995. A mid-turn quick question buffered behind one long blocking tool call (`gh pr checks --watch`, a slow build) previously waited minutes with only a 👀 reaction — from the phone it read as ignored. This PR adds a **deterministic, model-free mid-flight busy ack**: when a mid-turn inbound is gated `buffer-until-idle` (or delivered as a steer) while `ToolFlightTracker.isMidToolCall()` and the current tool step is older than 12s, the gateway posts a silent (`disable_notification: true`) card into the inbound's own chat/topic:

> ⏳ Queued — currently inside `Bash: gh pr checks --watch`; I'll answer when this step finishes.

A ping that lands while the step is still YOUNG (< 12s) is not forgotten: one deferred re-check per key fires at (threshold − stepAge), re-evaluates live state, is pinned to the scheduling turn's `turnId`, and is cancelled at turn end.

**Job spec:** `reference/jobs/steer-or-queue-mid-flight.md` (updated in this PR with the third mid-flight class — a quick question that neither steers nor queues — and its latency promise), cross-referenced from `reference/jobs/know-what-my-agent-is-doing.md`. Advances the *on the leash* vision outcome.

## What's in it

- **Pure decision module** — `telegram-plugin/gateway/busy-ack.ts`: `shouldPostBusyAck({gateDecision, midToolCall, stepAgeMs, alreadyAcked})` + `formatBusyAckText`, unit-testable without the gateway (pattern: `interrupt-defer.ts`). Threshold constant `BUSY_ACK_STEP_AGE_THRESHOLD_MS = 12_000` with rationale comment.
- **Gateway wiring** — `maybePostBusyAck` fires from the buffer-until-idle branch and the mid-turn steer-delivery path. Step name/label/age come from silence-poke's #1292 in-flight tool tracking via a new read-only `longestInFlightTool()` accessor (labels originate from the PreToolUse sidecar); turn age is receipt-anchored (`activeTurnStartedAt`). The card is stored in `queuedStatusMsgIds`, so it **reuses the component-5 lifecycle** — promoted ("On it") when the buffered turn starts, deleted when the answer lands, reaped on abnormal turn end — extended to DMs and same-topic surfaces (previously suppressed there). Dedupe: at most one card per turn per chat/topic (`busyAckPostedKeys`, cleared at turn end). Kill switch `SWITCHROOM_MIDFLIGHT_BUSY_ACK=0`. No new raw bot.api paths (everything through `swallowingApiCall`); zero tokens, no model calls, no storm (one silent card max per turn per topic).
- **Classification visibility:** the buffered card says "Queued"; the steer variant says "Steer noted" and never "Queued" — see design deviations below.
- **Spec:** third mid-flight class + latency promise, Good bullet (visible ack naming the blocking activity within seconds), Bad bullet (an ack that fires when the agent was seconds from answering), prove-it scenario `jtbd-midflight-busy-ack-dm`, fuzz timing axis gains "inside long single tool call".
- **Agent hygiene:** `skills/switchroom-runtime/SKILL.md` — long foreground watches must be background tasks (`run_in_background: true` + `BashOutput` polling); the busy ack is a mitigation, not a license.

## Tests

- `telegram-plugin/tests/busy-ack.test.ts` — pure policy + rendered card text: fires only past the threshold, once per key, not when not mid-tool-call, not for fresh-turn delivers; "Queued"/"Steer noted" wording contract; elapsed formatting.
- `telegram-plugin/tests/busy-ack-wiring.test.ts` — gateway wiring guards (source-level, the established pattern for the un-instantiable gateway IIFE): buffered + steer call sites, `disable_notification: true`, thread-optional DM send, shared `queuedStatusMsgIds` lifecycle, per-turn dedupe reset, kill switch.
- `telegram-plugin/uat/scenarios/jtbd-midflight-busy-ack-dm.test.ts` — live mtcute scenario: mid-turn ping during a deliberately slow blocking `sleep` → silent ack < 10s naming the activity (`!m.edited` filtered per the #2991 lesson, `SLEEP_DONE` completion explicitly excluded from the real-answer predicate) → real answer later → card deleted. Plus negative: ping during an 8s step that can never reach the threshold → no card ever (watched through the widest re-check window).

## Test results

- `npm run lint` — fully green (tsc + all 8 guard scripts, incl. `check-bot-api-wrapping`).
- Scoped vitest (busy-ack, wiring, multitopic-routing-wiring, silence-poke, silence-liveness-wiring, interrupt-defer, inbound-delivery-gate, buffer-gate, pending-inbound-buffer, rapid-fire ordering): **187/187 pass**.
- Full local `test:vitest`: 12 785 pass / 114 fail — the failing set (fake-binary harness, docker/doctor, host-control, install/static-binary, plus 4 stream-reply rich-render assertions) **fails identically on a pristine `origin/main` worktree in this environment** (verified side-by-side); the stream-reply ones are a markdown-serializer dep-resolution drift (`*italic*` vs `_italic_`), env bucket — CI is the arbiter.
- `test:bun`: 1147 pass / 2 fail (`vault-slots` + `history-reaper` 5s timeouts) — reproduced identically on pristine main; sandbox-disk timeout artifacts.
- UAT scenario not run locally (needs live creds/uat-host by design).

## Design deviations from the research memo

- **Steer wording:** the memo asked all cards to say "Queued", but a steer is *not* queued — a "Queued" card on a steer would violate the steer-or-queue classification-visibility invariant the same memo cites. The steer variant says "⏳ Steer noted — … I'll fold it in when this step finishes."
- **No elapsed figure on the card** (memo asked for "(Nm elapsed)"): the card is posted once and never re-rendered while the blocking step runs, so any point-in-time number silently decays on screen — dropped per adversarial review; the activity name is time-invariant. DM cards are now promoted ("On it") like topic cards.
- **Dedupe "optionally edit the elapsed time"** on a second ping: not implemented — kept strictly one silent card per turn per topic (no-storm bias); trivially addable later.
- **Card reuse:** rather than parameterising `postQueuedStatus` (whose signature/text are pinned by existing wiring tests), a sibling `postBusyAck` shares the same `queuedStatusMsgIds` map — identical lifecycle, no behavioural change to the cross-topic card.

## Out of scope (follow-up)

Option (b) from the issue — a model-side status-question fast-path that answers trivial pings without waiting for the turn — is deliberately NOT in this PR; it should be gated on shadow-mode KPI data (how often the deterministic ack suffices) before spending tokens on it.

## Risk

Low. Kill-switched, deterministic, silent, reuses an existing proven card lifecycle; worst-case failure mode is a missing or stale card, both covered by the reap paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Adversarial review round 1 (commit 9effa6cf7)

Fixed: cross-topic double-card race (cards now mutually exclusive in the buffer branch), one-shot evaluation gap (deferred re-check), steer ack moved after successful bridge dispatch, decaying elapsed figure dropped + DM promote, per-key turn-end cleanup, UAT `SLEEP_DONE` exclusion + warmup margin + re-check-aware negative case. Stranded-cards-across-gateway-restart follow-up: #3002.
