### PR TITLE
fix(telegram): reap stale worker pins, track pin_message tool pins, retry-safe boot sweeps

### DIFF
--- a/reference/jobs/know-what-my-agent-is-doing.md
+++ b/reference/jobs/know-what-my-agent-is-doing.md
@@ -60,6 +60,23 @@ close that gap so the user never has to ask.
   carries no new content: it re-surfaces a message the conversation already owns.
   This is the one sanctioned pin (see `invariants.md`
   § `chat-is-the-single-source-of-truth`).
+- **The restart rule (#3001): a status pin is a claim on unfinished work, and
+  a restart resets it.** Any progress/worker pin (the per-turn status pin, the
+  `🛠 Worker` pin) whose work did not finish is unpinned on the next gateway
+  boot — the boot sweep reads the durable pin store and unpins every
+  work-scoped claim from the dead session, retrying a failed unpin on later
+  boots (capped) rather than forfeiting it. Mid-session the same guarantee
+  holds within the reaper interval: a worker pin whose worker is already
+  terminal in the registry (a missed completion event) or whose claim outlives
+  a generous TTL is unpinned without waiting for a restart. A stale pin glued
+  to the top of the chat for hours is exactly the "can't tell working from
+  stuck" failure this job exists to prevent.
+- **Tool pins are different: no "finished" event, so restart ≠ reset.** A pin
+  the agent placed deliberately via the `pin_message` tool is registered in
+  the same durable store under a `tool:` key with a generous TTL (default 7
+  days). It survives restarts untouched until the TTL lapses, then the boot
+  sweep unpins it — the backstop against deliberate pins accumulating
+  forever, without ever yanking a pin the user still wants.
 
 **Bad looks like: never ship this**
 
@@ -157,6 +174,18 @@ Named by job × surface, pointing at real scenarios in
   *Watch:* the user is told what was interrupted and the work resumes.
   *Invariant:* a restart never swallows an in-flight turn or an inbound
   silently.
+- **Worker-pin lifecycle + restart reset (DM, #3001)** —
+  `jtbd-worker-pin-lifecycle-dm`. *Watch:* the `🛠 Worker` message is silently
+  pinned while a background dispatch runs and unpinned after it completes;
+  with a forced gateway restart mid-dispatch, the orphaned worker pin is
+  unpinned by the next boot's sweep. Observers must filter pin/unpin service
+  events (`observePins`), not message edits — the card EDITS in place while
+  pinned. *Invariant:* the restart rule — no work-scoped pin survives its
+  work's death; a worker pin never outlives its worker by more than the
+  reaper interval (mid-session) or one boot (restart). Decision-layer twins:
+  `telegram-plugin/tests/worker-pin-reaper.test.ts`,
+  `status-pin-store.test.ts` (tool-pin TTL rows + retry-safe boot sweep),
+  `activity-card-store.test.ts` (retry-safe unpin retention).
 - **Status-ask rate (DM)** — `jtbd-status-query-dm`, `fuzz-status-ask-dm`.
   *Watch:* the user rarely needs to ask; when they do, it's answered as a
   real question. *Invariant:* status-ask rate is the lagging KPI for this

--- a/telegram-plugin/gateway/activity-card-store.ts
+++ b/telegram-plugin/gateway/activity-card-store.ts
@@ -308,6 +308,13 @@ export async function runActivityCardBootReaper(args: {
             { ...record, finalizeAttempted: true, unpinAttempts: attempts },
             log,
           )
+        } else {
+          log(
+            `activity-card-store: boot reaper FORFEITING card unpin after ` +
+              `${attempts} failed attempts ` +
+              `(chat=${record.chatId} msg=${record.activityMessageId}) — ` +
+              `will not retry again\n`,
+          )
         }
       }
     }

--- a/telegram-plugin/gateway/activity-card-store.ts
+++ b/telegram-plugin/gateway/activity-card-store.ts
@@ -43,6 +43,11 @@
  * failure than one frozen orphan. A benign-400 (message already
  * deleted/vanished, or "not modified") is NOT counted as a finalize — nothing
  * was delivered — see the `vanished` tally in `runActivityCardBootReaper`.
+ *
+ * The UNPIN half is different (#3001): unpinning is idempotent, so it gets
+ * AT-LEAST-ONCE (capped) semantics — a failed unpin re-persists the record
+ * with `finalizeAttempted: true` + an `unpinAttempts` counter so the next boot
+ * retries ONLY the unpin (never the edit), up to BOOT_UNPIN_MAX_ATTEMPTS.
  */
 
 export interface ActivityCardStoreFsSeam {
@@ -73,7 +78,20 @@ export interface ActivityCardRecord {
    *  forever). Optional so a v1-shape record (pre-unpin-tracking) still
    *  loads and degrades to "don't attempt an unpin", never a crash. */
   pinned?: boolean
+  /** Set when the boot reaper retains a record ONLY to retry its failed
+   *  unpin (#3001). The finalizing edit stays AT-MOST-ONCE: a retained
+   *  record's edit was already attempted, so the next boot skips the edit
+   *  and only retries the (idempotent) unpin. */
+  finalizeAttempted?: boolean
+  /** Boot-reaper unpin retry counter (#3001); the record is forfeited at
+   *  BOOT_UNPIN_MAX_ATTEMPTS. Absent = 0. */
+  unpinAttempts?: number
 }
+
+/** Cap on cross-boot unpin retries — same rationale as the status-pin
+ *  store's BOOT_UNPIN_MAX_ATTEMPTS (bound a permanently-undeliverable
+ *  unpin; unpins themselves are idempotent so retrying is safe). */
+export const BOOT_UNPIN_MAX_ATTEMPTS = 5
 
 interface SnapshotEnvelope {
   v: 1
@@ -91,7 +109,9 @@ function isCardRow(x: unknown): x is ActivityCardRecord {
     (o.threadId === null || typeof o.threadId === 'number') &&
     typeof o.activityMessageId === 'number' &&
     typeof o.startedAt === 'number' &&
-    (o.pinned === undefined || typeof o.pinned === 'boolean')
+    (o.pinned === undefined || typeof o.pinned === 'boolean') &&
+    (o.finalizeAttempted === undefined || typeof o.finalizeAttempted === 'boolean') &&
+    (o.unpinAttempts === undefined || typeof o.unpinAttempts === 'number')
   )
 }
 
@@ -245,32 +265,50 @@ export async function runActivityCardBootReaper(args: {
     // turn that upserted a fresh card under the same turnKey mid-reap keeps
     // its own (different-id) record.
     clearActivityCardRecord(args.path, args.fs, record.turnKey, record.activityMessageId, log)
-    try {
-      // Count a finalize ONLY when the edit actually landed. robustApiCall
-      // resolves to undefined on a benign-400 (the card was already deleted or
-      // the chat is gone) — that delivered nothing, so it is a `vanished`
-      // orphan, not a `finalized` one. Counting it as finalized (the pre-fix
-      // behaviour) over-reported the guarantee in the boot log.
-      const res = await args.finalizeCard(record)
-      if (res != null) finalized++
-      else vanished++
-    } catch (err) {
-      log(
-        `activity-card-store: boot reaper finalize failed ` +
-          `(chat=${record.chatId} msg=${record.activityMessageId}): ` +
-          `${(err as Error).message}\n`,
-      )
+    // The finalizing EDIT stays at-most-once: skip it for a record retained by
+    // a prior boot purely to retry its failed unpin (finalizeAttempted).
+    if (!record.finalizeAttempted) {
+      try {
+        // Count a finalize ONLY when the edit actually landed. robustApiCall
+        // resolves to undefined on a benign-400 (the card was already deleted or
+        // the chat is gone) — that delivered nothing, so it is a `vanished`
+        // orphan, not a `finalized` one. Counting it as finalized (the pre-fix
+        // behaviour) over-reported the guarantee in the boot log.
+        const res = await args.finalizeCard(record)
+        if (res != null) finalized++
+        else vanished++
+      } catch (err) {
+        log(
+          `activity-card-store: boot reaper finalize failed ` +
+            `(chat=${record.chatId} msg=${record.activityMessageId}): ` +
+            `${(err as Error).message}\n`,
+        )
+      }
     }
     if (record.pinned) {
       try {
         await args.unpinCard(record)
         unpinned++
       } catch (err) {
+        // Retry-safe unpin (#3001): unlike the edit (at-most-once by design),
+        // an unpin is idempotent — so a failed one is RE-PERSISTED with an
+        // attempt counter and retried on the next boot, up to the cap, instead
+        // of being forfeited. `finalizeAttempted` guarantees the retained
+        // record can never re-run its edit.
+        const attempts = (record.unpinAttempts ?? 0) + 1
         log(
           `activity-card-store: boot reaper unpin failed ` +
-            `(chat=${record.chatId} msg=${record.activityMessageId}): ` +
-            `${(err as Error).message}\n`,
+            `(chat=${record.chatId} msg=${record.activityMessageId} ` +
+            `attempt=${attempts}): ${(err as Error).message}\n`,
         )
+        if (attempts < BOOT_UNPIN_MAX_ATTEMPTS) {
+          writeActivityCardRecord(
+            args.path,
+            args.fs,
+            { ...record, finalizeAttempted: true, unpinAttempts: attempts },
+            log,
+          )
+        }
       }
     }
   }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -7204,13 +7204,18 @@ async function runMidSessionCardReaper(): Promise<void> {
         }))
       const reaps = decideWorkerPinReaps({
         pins: candidates,
-        isTerminal: (agentId) => {
-          if (turnsDb == null) return false
+        statusOf: (agentId) => {
+          if (turnsDb == null) return 'unknown'
           try {
             const row = getSubagentByJsonlId(turnsDb, agentId)
-            return row != null && (row.status === 'completed' || row.status === 'failed')
+            if (row == null) return 'unknown'
+            if (row.status === 'completed' || row.status === 'failed') return 'terminal'
+            // A live 'running' row exempts the pin from the TTL (no churn on
+            // healthy long workers); 'stalled' degrades to 'unknown' → TTL.
+            if (row.status === 'running') return 'running'
+            return 'unknown'
           } catch {
-            return false // DB hiccup degrades to "keep the pin"
+            return 'unknown' // DB hiccup degrades to "keep until TTL"
           }
         },
         ttlMs: WORKER_PIN_REAPER_TTL_MS,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -460,6 +460,10 @@ import {
   restartOrphanCardFinalizeText,
   type ActivityCardStoreFsSeam,
 } from './activity-card-store.js'
+import {
+  decideWorkerPinReaps,
+  WORKER_PIN_TTL_MS_DEFAULT,
+} from './worker-pin-reaper.js'
 import { driveEscalation } from './escalation-drive.js'
 import { shouldSuppressRepresent } from './represent-guard.js'
 import { shouldDeferEscalationForBridge } from './escalation-bridge-gate.js'
@@ -6831,6 +6835,10 @@ const statusPinState = new Map<string, PinState>()
 // owned pins without threading the chat id through every call site. Written on
 // every desired-pinned reconcile, cleared alongside the state on unpin.
 const statusPinChatIds = new Map<string, string>()
+// Companion registry: pinKey → wall-clock ms the claim was FIRST taken (a
+// re-pin of the same key keeps the original timestamp). Feeds the TTL gate of
+// the mid-session `wk:` pin reaper (#3001); cleared alongside the state.
+const statusPinPinnedAt = new Map<string, number>()
 
 // Durable snapshot of the pin claim set on the persistent per-agent volume
 // (STATE_DIR = /state/agent/telegram in prod). Closes the crash hole: the
@@ -6882,6 +6890,22 @@ const BANNER_PIN_KEY = 'banner:owner'
 // run → no-op). The boot-cleanup gate below is widened to cover this.
 const bannerPinPersistEnabled = !STATIC
 
+// `pin_message` MCP-tool pin registration (#3001). Tool pins ride the same
+// shared status-pins.json store under `tool:<chatId>:<messageId>` keys, but
+// with a TTL row (`expiresAt`): a tool pin is a deliberate agent action with
+// no "work finished" event, so a restart does NOT reset it — boot cleanup
+// keeps unexpired tool rows and only unpins them once the TTL lapses (the
+// backstop against agent-pinned messages accumulating forever). Independent
+// of PIN_STATUS_WHILE_WORKING (it gates the auto status pin, not the tool).
+const toolPinPersistEnabled = !STATIC
+// 7 days: generous — an agent-pinned message the operator still cares about
+// after a week has usually been re-pinned or acted on; anything older is the
+// stale-pin long tail this issue exists to clear. Override for tuning.
+const TOOL_PIN_TTL_MS = (() => {
+  const v = Number(process.env.SWITCHROOM_TOOL_PIN_TTL_MS)
+  return Number.isFinite(v) && v > 0 ? v : 7 * 24 * 60 * 60_000
+})()
+
 // Persist (or drop) the slot-banner's pin row into the shared store. Routes
 // through mutateStatusPinRow: a read-modify-write for ONLY the banner:owner key,
 // serialised on the store's per-path lock, so the live fg:/wk: status-pin rows
@@ -6932,9 +6956,9 @@ async function statusPinBootCleanup(): Promise<void> {
   // map-backed status pins (statusPinPersistEnabled) or the slot banner
   // (bannerPinPersistEnabled). A single cleanup drains ALL orphaned rows —
   // status pins AND banner alike — since they share status-pins.json.
-  if (!statusPinPersistEnabled && !bannerPinPersistEnabled) return
+  if (!statusPinPersistEnabled && !bannerPinPersistEnabled && !toolPinPersistEnabled) return
   const api = statusPinApi()
-  const { cleared, total } = await runStatusPinBootCleanup({
+  const { cleared, retained, kept, total } = await runStatusPinBootCleanup({
     path: STATUS_PIN_STORE_PATH,
     fs: statusPinStoreFs,
     unpin: (chatId, messageId) => api.unpinChatMessage(chatId, messageId),
@@ -6942,7 +6966,8 @@ async function statusPinBootCleanup(): Promise<void> {
   if (total > 0) {
     process.stderr.write(
       `telegram gateway: status-pin: cleared ${cleared}/${total} ` +
-        `orphaned pin(s) from a prior session\n`,
+        `orphaned pin(s) from a prior session ` +
+        `(retained ${retained} for retry, kept ${kept} unexpired tool pin(s))\n`,
     )
   }
 }
@@ -7043,6 +7068,25 @@ const MID_SESSION_CARD_REAPER_INTERVAL_MS = (() => {
   return Number.isFinite(v) && v > 0 ? v : 5 * 60_000 // 5 min
 })()
 
+// ─── Mid-session stale worker-pin reaper (#3001) ─────────────────────────────
+// The `wk:<agentId>` pin is normally dropped by the worker's completion
+// handler, but a missed onFinish (watcher crash / SDK SIGKILL / dropped JSONL
+// tail) used to leave the pin glued to the chat until the NEXT gateway boot.
+// This sweep (piggybacking on the mid-session reaper interval) unpins a
+// claimed worker pin when the registry says its worker is TERMINAL, or when
+// the pin has been held past a TTL. Pure decision in worker-pin-reaper.ts;
+// each reap executes through reconcileStatusPin so the in-memory claim and
+// the durable store row clear together.
+//
+// Kill switch: SWITCHROOM_WORKER_PIN_REAPER=0 disables (clean revert, mirrors
+// SWITCHROOM_MID_SESSION_CARD_REAPER). TTL overridable via env for tuning.
+const WORKER_PIN_REAPER_ENABLED =
+  process.env.SWITCHROOM_WORKER_PIN_REAPER !== '0'
+const WORKER_PIN_REAPER_TTL_MS = (() => {
+  const v = Number(process.env.SWITCHROOM_WORKER_PIN_REAPER_TTL_MS)
+  return Number.isFinite(v) && v > 0 ? v : WORKER_PIN_TTL_MS_DEFAULT // 6 h
+})()
+
 // Snapshot the turn_keys / topic keys owned by a live in-flight turn right now.
 function liveTurnKeySets(): { registryKeys: Set<string>; topicKeys: Set<string> } {
   const registryKeys = new Set<string>()
@@ -7107,15 +7151,27 @@ async function runMidSessionCardReaper(): Promise<void> {
               verb: 'activity-card.mid-session-reap-finalize',
             },
           ),
-        unpinCard: (record) =>
-          robustApiCall(
+        // #3001: route through reconcileStatusPin when the pin is a live
+        // in-memory claim, so the claim AND the durable status-pins.json row
+        // clear together (the raw-API unpin left both behind — the boot sweep
+        // then re-unpinned an already-unpinned message and the service-message
+        // handler kept a phantom claim). Falls back to the raw unpin when no
+        // claim is tracked (e.g. claim already dropped out-of-band).
+        unpinCard: async (record) => {
+          const pinKey = `fg:${record.turnKey}`
+          if (statusPinState.has(pinKey)) {
+            await reconcileStatusPin(pinKey, record.chatId, { pinned: false })
+            return true
+          }
+          return robustApiCall(
             () => lockedBot.api.unpinChatMessage(record.chatId, record.activityMessageId),
             {
               chat_id: record.chatId,
               ...(record.threadId != null ? { threadId: record.threadId } : {}),
               verb: 'activity-card.mid-session-reap-unpin',
             },
-          ),
+          )
+        },
       })
       if (total > 0) {
         process.stderr.write(
@@ -7126,6 +7182,50 @@ async function runMidSessionCardReaper(): Promise<void> {
     } catch (err) {
       process.stderr.write(
         `telegram gateway: mid-session card reaper error: ${(err as Error).message}\n`,
+      )
+    }
+  }
+
+  // 3) Reap stale `wk:` worker pins (#3001): a claimed worker pin whose worker
+  //    is terminal in the registry (missed onFinish) or whose claim outlived
+  //    the TTL. Executes through reconcileStatusPin so the in-memory claim and
+  //    the durable store row clear together.
+  if (WORKER_PIN_REAPER_ENABLED && PIN_STATUS_WHILE_WORKING) {
+    try {
+      const candidates = [...statusPinState.keys()]
+        .filter((k) => k.startsWith('wk:'))
+        .map((k) => ({
+          pinKey: k,
+          chatId: statusPinChatIds.get(k) ?? '',
+          // A missing timestamp (should not happen — set on every claim)
+          // degrades to "claimed just now": terminality can still reap it,
+          // the TTL gate never can. Conservative, never a spurious unpin.
+          pinnedAt: statusPinPinnedAt.get(k) ?? now,
+        }))
+      const reaps = decideWorkerPinReaps({
+        pins: candidates,
+        isTerminal: (agentId) => {
+          if (turnsDb == null) return false
+          try {
+            const row = getSubagentByJsonlId(turnsDb, agentId)
+            return row != null && (row.status === 'completed' || row.status === 'failed')
+          } catch {
+            return false // DB hiccup degrades to "keep the pin"
+          }
+        },
+        ttlMs: WORKER_PIN_REAPER_TTL_MS,
+        now,
+      })
+      for (const reap of reaps) {
+        process.stderr.write(
+          `telegram gateway: worker-pin reaper unpinning ${reap.pinKey} ` +
+            `(chat=${reap.chatId} reason=${reap.reason})\n`,
+        )
+        await reconcileStatusPin(reap.pinKey, reap.chatId, { pinned: false })
+      }
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: worker-pin reaper error: ${(err as Error).message}\n`,
       )
     }
   }
@@ -7216,9 +7316,11 @@ async function reconcileStatusPinInner(
     if (next == null) {
       statusPinState.delete(pinKey)
       statusPinChatIds.delete(pinKey)
+      statusPinPinnedAt.delete(pinKey)
     } else {
       statusPinState.set(pinKey, next)
       statusPinChatIds.set(pinKey, chatId)
+      if (!statusPinPinnedAt.has(pinKey)) statusPinPinnedAt.set(pinKey, Date.now())
     }
     return
   }
@@ -7238,9 +7340,11 @@ async function reconcileStatusPinInner(
   if (next == null) {
     statusPinState.delete(pinKey)
     statusPinChatIds.delete(pinKey)
+    statusPinPinnedAt.delete(pinKey)
   } else {
     statusPinState.set(pinKey, next)
     statusPinChatIds.set(pinKey, chatId)
+    if (!statusPinPinnedAt.has(pinKey)) statusPinPinnedAt.set(pinKey, Date.now())
   }
 }
 
@@ -7283,7 +7387,7 @@ async function unpinAllStatusPins(): Promise<void> {
     if (st == null) continue
     // Recover the chat id from the state map's companion key registry.
     const chatId = statusPinChatIds.get(key)
-    if (chatId == null) { statusPinState.delete(key); continue }
+    if (chatId == null) { statusPinState.delete(key); statusPinPinnedAt.delete(key); continue }
     await reconcileStatusPin(key, chatId, { pinned: false })
   }
 }
@@ -13298,10 +13402,26 @@ async function executePinMessage(args: Record<string, unknown>): Promise<unknown
   // errors are retried. THREAD_NOT_FOUND on a stale topic surfaces to the
   // agent as a tool-error — pinning a vanished message is genuinely a
   // failure the agent should see.
+  const pinMsgId = Number(args.message_id)
   await robustApiCall(
-    () => lockedBot.api.pinChatMessage(pinChatId, Number(args.message_id)),
+    () => lockedBot.api.pinChatMessage(pinChatId, pinMsgId),
     { chat_id: pinChatId, verb: 'pin_message' },
   )
+  // #3001: register the tool pin in the shared status-pin store under a
+  // `tool:` key so it is no longer fire-and-forget. Unlike work-scoped
+  // fg:/wk: rows a tool pin has no "work finished" event, so a restart does
+  // NOT reset it — boot cleanup keeps the row until its TTL, then unpins the
+  // (likely long-forgotten) message. Best-effort fire-and-forget: a store
+  // failure must never fail the tool call the pin already landed for.
+  if (toolPinPersistEnabled) {
+    const toolPinKey = `tool:${pinChatId}:${pinMsgId}`
+    void mutateStatusPinRow(STATUS_PIN_STORE_PATH, statusPinStoreFs, toolPinKey, {
+      pinKey: toolPinKey,
+      chatId: pinChatId,
+      messageId: pinMsgId,
+      expiresAt: Date.now() + TOOL_PIN_TTL_MS,
+    })
+  }
   return { content: [{ type: 'text', text: `pinned message ${args.message_id}` }] }
 }
 

--- a/telegram-plugin/gateway/status-pin-store.ts
+++ b/telegram-plugin/gateway/status-pin-store.ts
@@ -258,6 +258,13 @@ export async function runStatusPinBootCleanup(args: {
         // orphan permanently (retry-safe boot sweep, #3001).
         next.push({ ...pin, attempts })
         retained++
+      } else {
+        log(
+          `status-pin-store: boot cleanup FORFEITING pin after ` +
+            `${attempts} failed unpin attempts ` +
+            `(key=${pin.pinKey} chat=${pin.chatId} msg=${pin.messageId}) — ` +
+            `will not retry again\n`,
+        )
       }
     }
   }

--- a/telegram-plugin/gateway/status-pin-store.ts
+++ b/telegram-plugin/gateway/status-pin-store.ts
@@ -12,10 +12,13 @@
  * a dead session lingers.
  *
  * This makes cleanup self-contained across restart: every pin claim persists
- * here; on boot the gateway loads the persisted set and unpins each entry
- * (a status pin from a PRIOR session is stale by definition — the turn it
- * represented is over or crashed), then clears the store. It does NOT re-adopt
- * or re-pin — it only cleans up.
+ * here; on boot the gateway loads the persisted set and unpins each
+ * work-scoped entry (a status pin from a PRIOR session is stale by definition
+ * — the turn it represented is over or crashed), dropping rows only after a
+ * successful unpin (failed ones are retained with an attempt counter for a
+ * next-boot retry — see runStatusPinBootCleanup). Time-scoped `tool:` rows
+ * (the `pin_message` MCP tool, #3001) survive boots until their `expiresAt`.
+ * It does NOT re-adopt or re-pin — it only cleans up.
  *
  * Shape choice — SNAPSHOT, not append-log, mirroring obligation-store.ts. The
  * claim set is tiny and bounded (one entry per in-flight pinned key, normally
@@ -55,7 +58,26 @@ export interface PersistedStatusPin {
   messageId: number
   /** True while the pin API call is in-flight / unconfirmed (see above). */
   pending?: boolean
+  /** Wall-clock ms after which this pin is stale and boot cleanup unpins it.
+   *  Rows WITHOUT this field are work-scoped (fg:/wk:/banner:) — stale the
+   *  moment their owning session dies, so boot cleanup unpins them
+   *  unconditionally. Rows WITH it (the `tool:` pins written by the
+   *  `pin_message` MCP tool, #3001) represent deliberate agent pins that have
+   *  no "work finished" event: they SURVIVE restarts and are only swept once
+   *  expired. */
+  expiresAt?: number
+  /** Boot-cleanup unpin retry counter (#3001). Incremented each boot the
+   *  unpin fails (flood-wait exhausted / transient 5xx); the row is retained
+   *  for retry until BOOT_UNPIN_MAX_ATTEMPTS, then forfeited. Absent = 0. */
+  attempts?: number
 }
+
+/** How many boots may retry a failing boot-cleanup unpin before the row is
+ *  forfeited. Unpins are idempotent (unpinning an already-unpinned or deleted
+ *  message no-ops), so retrying across boots is safe; the cap only bounds a
+ *  permanently-undeliverable unpin (chat gone, bot removed) so it cannot
+ *  re-fail on every boot forever. */
+export const BOOT_UNPIN_MAX_ATTEMPTS = 5
 
 /** Envelope version. v1 had no `pending` field; a v1 row loads as a confirmed
  *  pin (pending undefined). v2 adds the optional `pending` flag. Both load
@@ -74,7 +96,9 @@ function isPinRow(x: unknown): x is PersistedStatusPin {
     typeof o.chatId === 'string' &&
     o.chatId.length > 0 &&
     typeof o.messageId === 'number' &&
-    (o.pending === undefined || typeof o.pending === 'boolean')
+    (o.pending === undefined || typeof o.pending === 'boolean') &&
+    (o.expiresAt === undefined || typeof o.expiresAt === 'number') &&
+    (o.attempts === undefined || typeof o.attempts === 'number')
   )
 }
 
@@ -170,16 +194,27 @@ export function pinnedMessageIsOurs(
  * the ordering + best-effort contract is unit-testable against the REAL code
  * (the gateway's thin wrapper just binds the live fs / unpin api / logger).
  *
- * Any pin persisted by a PRIOR session is stale by definition — its turn ended
- * or the session crashed before its unpin reconcile ran. This includes records
- * left `pending` (the persist-intent-first write from `reconcileAndPersist-
- * StatusPin`): a crash between the pin API call and its confirming rewrite
- * leaves a pending record whose pin MAY have landed in Telegram, so we must
- * treat it exactly like a confirmed one and unpin it. We therefore best-effort
- * unpin EVERY persisted entry (confirmed and pending alike — a failure is
- * non-fatal) and then EMPTY the store regardless, so a permanently-
- * undeliverable unpin can't re-run on every boot. We do NOT re-adopt or re-pin.
- * Returns the counts for logging/testing.
+ * The restart rule (#3001): a WORK-SCOPED pin persisted by a PRIOR session
+ * (fg:/wk:/banner: — any row without `expiresAt`) is stale by definition — its
+ * work ended or the session crashed before its unpin reconcile ran, so
+ * restart = reset: it is unpinned here. This includes records left `pending`
+ * (the persist-intent-first write from `reconcileAndPersistStatusPin`): a
+ * crash between the pin API call and its confirming rewrite leaves a pending
+ * record whose pin MAY have landed in Telegram, so we must treat it exactly
+ * like a confirmed one and unpin it.
+ *
+ * TIME-SCOPED rows (`tool:` pins from the `pin_message` MCP tool, carrying
+ * `expiresAt`) have no "work finished" event, so a restart does NOT reset
+ * them: an unexpired row is RETAINED untouched across boots and only unpinned
+ * once `now >= expiresAt`.
+ *
+ * RETRY-SAFETY (#3001): a row is dropped only AFTER its unpin resolves. A
+ * failing unpin (flood-wait exhausted / transient 5xx) retains the row with an
+ * incremented `attempts` counter so the NEXT boot retries, up to
+ * BOOT_UNPIN_MAX_ATTEMPTS — then the row is forfeited (a permanently-
+ * undeliverable unpin must not re-fail on every boot forever). Unpins are
+ * idempotent, so the retry can never double-unpin harmfully. We do NOT
+ * re-adopt or re-pin. Returns the counts for logging/testing.
  *
  * CRITICAL: the caller MUST only invoke this AFTER winning the startup mutex.
  * The store is a shared per-agent file; on a double-boot a losing gateway
@@ -189,27 +224,45 @@ export async function runStatusPinBootCleanup(args: {
   path: string
   fs: StatusPinStoreFsSeam
   unpin: (chatId: string, messageId: number) => Promise<unknown>
+  now?: number
   log?: (line: string) => void
-}): Promise<{ cleared: number; total: number }> {
+}): Promise<{ cleared: number; retained: number; kept: number; total: number }> {
   const log = args.log ?? ((l: string) => process.stderr.write(l))
+  const now = args.now ?? Date.now()
   const persisted = loadStatusPins(args.path, args.fs)
-  if (persisted.length === 0) return { cleared: 0, total: 0 }
+  if (persisted.length === 0) return { cleared: 0, retained: 0, kept: 0, total: 0 }
   let cleared = 0
+  let retained = 0
+  let kept = 0
+  const next: PersistedStatusPin[] = []
   for (const pin of persisted) {
+    // Unexpired time-scoped row (tool: pin): deliberately survives the
+    // restart — keep it as-is, no unpin.
+    if (pin.expiresAt != null && pin.expiresAt > now) {
+      next.push(pin)
+      kept++
+      continue
+    }
     try {
       await args.unpin(pin.chatId, pin.messageId)
       cleared++
     } catch (err) {
+      const attempts = (pin.attempts ?? 0) + 1
       log(
         `status-pin-store: boot cleanup unpin failed ` +
-          `(chat=${pin.chatId} msg=${pin.messageId}): ${(err as Error).message}\n`,
+          `(chat=${pin.chatId} msg=${pin.messageId} attempt=${attempts}): ` +
+          `${(err as Error).message}\n`,
       )
+      if (attempts < BOOT_UNPIN_MAX_ATTEMPTS) {
+        // Retain for a retry on the next boot instead of forfeiting the
+        // orphan permanently (retry-safe boot sweep, #3001).
+        next.push({ ...pin, attempts })
+        retained++
+      }
     }
   }
-  // Empty the store regardless — these claims belong to a dead session; leaving
-  // them would re-attempt the same (already-tried) unpins on every future boot.
-  persistStatusPins(args.path, args.fs, [], log)
-  return { cleared, total: persisted.length }
+  persistStatusPins(args.path, args.fs, next, log)
+  return { cleared, retained, kept, total: persisted.length }
 }
 
 /**

--- a/telegram-plugin/gateway/worker-pin-reaper.ts
+++ b/telegram-plugin/gateway/worker-pin-reaper.ts
@@ -1,0 +1,93 @@
+/**
+ * worker-pin-reaper.ts — pure decision for the mid-session `wk:` pin sweep
+ * (#3001).
+ *
+ * Why this exists: the background-worker pin (`wk:<agentId>`, pinned on the
+ * `🛠 Worker` feed message while the worker runs) is normally unpinned by the
+ * worker's completion handler (`reconcileWorkerPin(agentId, null, false)` on
+ * the watcher's onFinish). But that event can be MISSED — watcher crash, SDK
+ * subprocess SIGKILL, a dropped JSONL tail — and then nothing ever unpins the
+ * worker's message until the next gateway boot. Log evidence on one agent:
+ * ~1120 pinChatMessage vs ~1014 unpinChatMessage with zero logged failures —
+ * a long tail of stale pins glued to the top of the chat.
+ *
+ * This module is the pure half (mirrors `runActivityCardMidSessionReaper`'s
+ * decide-over-injected-seams shape): given the currently-claimed `wk:` pins,
+ * a terminality predicate over the sub-agent registry, and a TTL, it returns
+ * the pins that should be unpinned NOW. The gateway executes each reap via
+ * `reconcileStatusPin(key, chat, { pinned: false })` so the in-memory claim
+ * AND the durable store row clear together.
+ *
+ * A pin is reaped when EITHER:
+ *   - `terminal` — the registry says the worker reached a terminal status
+ *     (completed | failed): its work is finished, the pin must go, however
+ *     young it is. (A missed onFinish is exactly this case.)
+ *   - `ttl` — the pin has been held past `ttlMs`. Secondary guard for a
+ *     worker whose registry row never linked / never terminalises (`stalled`
+ *     rows fall back to this gate rather than being treated as terminal — a
+ *     stalled worker may still recover and repin naturally).
+ *
+ * A running worker younger than the TTL is NEVER touched — a healthy
+ * long-running worker keeps its pin for the whole legitimate run.
+ */
+
+/** Default TTL for a held worker pin: 6 hours. Rationale: worker turns are
+ *  expected to run minutes-to-a-couple-of-hours (the watcher's own stall
+ *  detection fires after ~60s of JSONL inactivity, and the longest sanctioned
+ *  background dispatches are bounded by a single Claude session's lifetime).
+ *  6h comfortably exceeds any legitimate worker turn while bounding the
+ *  stale-pin window to the same day instead of "until the next restart". */
+export const WORKER_PIN_TTL_MS_DEFAULT = 6 * 60 * 60_000
+
+export const WORKER_PIN_KEY_PREFIX = 'wk:'
+
+/** One currently-claimed worker pin, flattened from the gateway's Maps. */
+export interface WorkerPinCandidate {
+  /** Full pin key, `wk:<agentId>` shape. */
+  pinKey: string
+  /** Chat the pin lives in (from the gateway's pinKey → chatId registry). */
+  chatId: string
+  /** Wall-clock ms the claim was first taken (gateway's pinnedAt registry). */
+  pinnedAt: number
+}
+
+export interface WorkerPinReap extends WorkerPinCandidate {
+  reason: 'terminal' | 'ttl'
+}
+
+/** Extract the agentId from a `wk:<agentId>` pin key, or null for any other
+ *  key shape (fg:/banner:/tool: keys are never worker-reaped). */
+export function workerAgentIdOfPinKey(pinKey: string): string | null {
+  if (!pinKey.startsWith(WORKER_PIN_KEY_PREFIX)) return null
+  const agentId = pinKey.slice(WORKER_PIN_KEY_PREFIX.length)
+  return agentId.length > 0 ? agentId : null
+}
+
+/**
+ * Decide which claimed worker pins to unpin now. Pure: the registry lookup is
+ * an injected predicate (`isTerminal` must return true ONLY for a row in a
+ * terminal status — completed | failed — and false for running / stalled /
+ * missing / lookup-error; a DB hiccup must degrade to "keep the pin", never
+ * to a spurious unpin).
+ */
+export function decideWorkerPinReaps(args: {
+  pins: Iterable<WorkerPinCandidate>
+  isTerminal: (agentId: string) => boolean
+  ttlMs: number
+  now: number
+}): WorkerPinReap[] {
+  const reaps: WorkerPinReap[] = []
+  for (const pin of args.pins) {
+    const agentId = workerAgentIdOfPinKey(pin.pinKey)
+    if (agentId == null) continue // not a worker pin — never ours to reap
+    if (pin.chatId.length === 0) continue // can't unpin without a chat
+    if (args.isTerminal(agentId)) {
+      reaps.push({ ...pin, reason: 'terminal' })
+      continue
+    }
+    if (args.now - pin.pinnedAt >= args.ttlMs) {
+      reaps.push({ ...pin, reason: 'ttl' })
+    }
+  }
+  return reaps
+}

--- a/telegram-plugin/gateway/worker-pin-reaper.ts
+++ b/telegram-plugin/gateway/worker-pin-reaper.ts
@@ -22,13 +22,16 @@
  *   - `terminal` — the registry says the worker reached a terminal status
  *     (completed | failed): its work is finished, the pin must go, however
  *     young it is. (A missed onFinish is exactly this case.)
- *   - `ttl` — the pin has been held past `ttlMs`. Secondary guard for a
- *     worker whose registry row never linked / never terminalises (`stalled`
- *     rows fall back to this gate rather than being treated as terminal — a
- *     stalled worker may still recover and repin naturally).
+ *   - `ttl` — the pin has been held past `ttlMs` AND the registry cannot
+ *     vouch for the worker (no row / never linked / `stalled` / lookup
+ *     error). A registry-confirmed RUNNING row exempts the pin from the TTL
+ *     entirely: a healthy 7h worker keeps its pin for the whole run instead
+ *     of churning unpin→re-pin every TTL. The stall detector demotes a dead
+ *     worker's row out of 'running' within ~60s, so the TTL still catches
+ *     true zombies.
  *
- * A running worker younger than the TTL is NEVER touched — a healthy
- * long-running worker keeps its pin for the whole legitimate run.
+ * A worker the registry can't vouch for is still never touched before the
+ * TTL — the sweep can only ever shorten a stale pin's life, not a live one's.
  */
 
 /** Default TTL for a held worker pin: 6 hours. Rationale: worker turns are
@@ -63,16 +66,29 @@ export function workerAgentIdOfPinKey(pinKey: string): string | null {
   return agentId.length > 0 ? agentId : null
 }
 
+/** The registry's view of a worker, distilled for the reap decision.
+ *  - 'terminal' — row exists in completed | failed: reap now.
+ *  - 'running'  — row exists and is still 'running': NEVER reap, not even
+ *    past the TTL. A healthy 7h worker must not get unpinned mid-run only
+ *    for the next feed edit to re-pin it (pin/unpin churn every TTL). The
+ *    subagent-watcher's stall detection demotes a dead worker's row out of
+ *    'running' within ~60s of its JSONL going quiet, so a true zombie can
+ *    only hold 'running' briefly — the TTL still catches everything the
+ *    registry has lost track of.
+ *  - 'unknown'  — no row / never linked / 'stalled' / lookup error: the
+ *    TTL gate applies (the registry can't vouch for it). */
+export type WorkerRegistryStatus = 'terminal' | 'running' | 'unknown'
+
 /**
  * Decide which claimed worker pins to unpin now. Pure: the registry lookup is
- * an injected predicate (`isTerminal` must return true ONLY for a row in a
- * terminal status — completed | failed — and false for running / stalled /
- * missing / lookup-error; a DB hiccup must degrade to "keep the pin", never
- * to a spurious unpin).
+ * an injected predicate (`statusOf` must return 'terminal' ONLY for a row in
+ * completed | failed, 'running' only for a live 'running' row, and 'unknown'
+ * for stalled / missing / lookup-error; a DB hiccup must degrade to 'unknown'
+ * — kept until the TTL — never to a spurious 'terminal' unpin).
  */
 export function decideWorkerPinReaps(args: {
   pins: Iterable<WorkerPinCandidate>
-  isTerminal: (agentId: string) => boolean
+  statusOf: (agentId: string) => WorkerRegistryStatus
   ttlMs: number
   now: number
 }): WorkerPinReap[] {
@@ -81,10 +97,15 @@ export function decideWorkerPinReaps(args: {
     const agentId = workerAgentIdOfPinKey(pin.pinKey)
     if (agentId == null) continue // not a worker pin — never ours to reap
     if (pin.chatId.length === 0) continue // can't unpin without a chat
-    if (args.isTerminal(agentId)) {
+    const status = args.statusOf(agentId)
+    if (status === 'terminal') {
       reaps.push({ ...pin, reason: 'terminal' })
       continue
     }
+    // A registry-confirmed RUNNING worker keeps its pin regardless of age —
+    // the TTL only reaps pins the registry can't vouch for (see
+    // WorkerRegistryStatus doc).
+    if (status === 'running') continue
     if (args.now - pin.pinnedAt >= args.ttlMs) {
       reaps.push({ ...pin, reason: 'ttl' })
     }

--- a/telegram-plugin/tests/activity-card-store.test.ts
+++ b/telegram-plugin/tests/activity-card-store.test.ts
@@ -30,6 +30,7 @@
  */
 import { describe, it, expect } from 'vitest'
 import {
+  BOOT_UNPIN_MAX_ATTEMPTS,
   loadActivityCards,
   persistActivityCards,
   writeActivityCardRecord,
@@ -314,9 +315,10 @@ describe('runActivityCardBootReaper — transport-boundary outcome tests', () =>
     expect(loadActivityCards(PATH, fs)).toEqual([])
   })
 
-  it('a failing unpin (already unpinned / no rights) is non-fatal and does not re-run the edit', async () => {
+  it('retry-safe (#3001): a failing unpin is non-fatal, does not re-run the edit, and RETAINS the record for a next-boot unpin retry', async () => {
     const { fs } = memFs()
-    writeActivityCardRecord(PATH, fs, card())
+    const rec = card()
+    writeActivityCardRecord(PATH, fs, rec)
     let editCalls = 0
     const res = await runActivityCardBootReaper({
       path: PATH,
@@ -328,9 +330,52 @@ describe('runActivityCardBootReaper — transport-boundary outcome tests', () =>
       unpinCard: async () => {
         throw new Error('message to unpin not found')
       },
+      log: () => {},
     })
     expect(res).toEqual({ finalized: 1, vanished: 0, unpinned: 0, total: 1 })
     expect(editCalls).toBe(1)
+    // The record is retained (not forfeited) so the next boot retries the
+    // idempotent unpin — flagged so it can never re-run the finalize edit.
+    expect(loadActivityCards(PATH, fs)).toEqual([
+      { ...rec, finalizeAttempted: true, unpinAttempts: 1 },
+    ])
+
+    // Second boot: the retained record retries ONLY the unpin (edit stays
+    // at-most-once); on success the record is finally dropped.
+    let secondBootEdits = 0
+    const res2 = await runActivityCardBootReaper({
+      path: PATH,
+      fs,
+      finalizeCard: async () => {
+        secondBootEdits++
+        return { ok: true }
+      },
+      unpinCard: async () => ({ ok: true }),
+      log: () => {},
+    })
+    expect(secondBootEdits).toBe(0)
+    expect(res2).toEqual({ finalized: 0, vanished: 0, unpinned: 1, total: 1 })
+    expect(loadActivityCards(PATH, fs)).toEqual([])
+  })
+
+  it('retry-safe (#3001): the unpin retry is forfeited at BOOT_UNPIN_MAX_ATTEMPTS', async () => {
+    const { fs } = memFs()
+    writeActivityCardRecord(
+      PATH,
+      fs,
+      card({ finalizeAttempted: true, unpinAttempts: BOOT_UNPIN_MAX_ATTEMPTS - 1 }),
+    )
+    const res = await runActivityCardBootReaper({
+      path: PATH,
+      fs,
+      finalizeCard: async () => ({ ok: true }),
+      unpinCard: async () => {
+        throw new Error('still no rights')
+      },
+      log: () => {},
+    })
+    // Final attempt failed — record forfeited so it cannot re-fail every boot.
+    expect(res).toEqual({ finalized: 0, vanished: 0, unpinned: 0, total: 1 })
     expect(loadActivityCards(PATH, fs)).toEqual([])
   })
 

--- a/telegram-plugin/tests/slot-banner-boot-recovery.test.ts
+++ b/telegram-plugin/tests/slot-banner-boot-recovery.test.ts
@@ -170,7 +170,7 @@ describe("slot-banner boot recovery (gateway wiring)", () => {
     const gw2 = makeGateway(fs, tg);
     const res = await gw2.bootCleanup();
 
-    expect(res).toEqual({ cleared: 1, total: 1 });
+    expect(res).toEqual({ cleared: 1, retained: 0, kept: 0, total: 1 });
     expect(tg.pinned.has(`${OWNER}:${msgId}`)).toBe(false); // orphan unpinned
     expect(loadStatusPins(PATH, fs)).toEqual([]); // store emptied
   });
@@ -220,7 +220,7 @@ describe("slot-banner boot recovery (gateway wiring)", () => {
     // Fresh boot recovers it from the pending record.
     const gw2 = makeGateway(fs, tg);
     const res = await gw2.bootCleanup();
-    expect(res).toEqual({ cleared: 1, total: 1 });
+    expect(res).toEqual({ cleared: 1, retained: 0, kept: 0, total: 1 });
     expect(tg.pinned.has(`${OWNER}:${rec[0].messageId}`)).toBe(false);
     expect(loadStatusPins(PATH, fs)).toEqual([]);
   });
@@ -241,6 +241,6 @@ describe("slot-banner boot recovery (gateway wiring)", () => {
     expect(loadStatusPins(PATH, fs)).toEqual([]);
 
     const gw2 = makeGateway(fs, tg);
-    expect(await gw2.bootCleanup()).toEqual({ cleared: 0, total: 0 });
+    expect(await gw2.bootCleanup()).toEqual({ cleared: 0, retained: 0, kept: 0, total: 0 });
   });
 });

--- a/telegram-plugin/tests/status-pin-boot-recovery.test.ts
+++ b/telegram-plugin/tests/status-pin-boot-recovery.test.ts
@@ -141,7 +141,7 @@ describe("status-pin boot recovery (gateway wiring)", () => {
     const gw2 = makeGateway(fs, tg);
     const res = await gw2.bootCleanup();
 
-    expect(res).toEqual({ cleared: 1, total: 1 });
+    expect(res).toEqual({ cleared: 1, retained: 0, kept: 0, total: 1 });
     expect(tg.pinned.has("-100123:715")).toBe(false); // orphan unpinned
     expect(loadStatusPins(PATH, fs)).toEqual([]); // store emptied
   });
@@ -177,7 +177,7 @@ describe("status-pin boot recovery (gateway wiring)", () => {
     // Fresh boot recovers it from the pending record.
     const gw2 = makeGateway(fs, tg);
     const res = await gw2.bootCleanup();
-    expect(res).toEqual({ cleared: 1, total: 1 });
+    expect(res).toEqual({ cleared: 1, retained: 0, kept: 0, total: 1 });
     expect(tg.pinned.has("-100123:715")).toBe(false);
     expect(loadStatusPins(PATH, fs)).toEqual([]);
   });
@@ -196,7 +196,7 @@ describe("status-pin boot recovery (gateway wiring)", () => {
     expect(loadStatusPins(PATH, fs)).toEqual([]);
 
     const gw2 = makeGateway(fs, tg);
-    expect(await gw2.bootCleanup()).toEqual({ cleared: 0, total: 0 });
+    expect(await gw2.bootCleanup()).toEqual({ cleared: 0, retained: 0, kept: 0, total: 0 });
   });
 });
 

--- a/telegram-plugin/tests/status-pin-store.test.ts
+++ b/telegram-plugin/tests/status-pin-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  BOOT_UNPIN_MAX_ATTEMPTS,
   loadStatusPins,
   mutateStatusPinRow,
   persistStatusPins,
@@ -195,12 +196,12 @@ describe("runStatusPinBootCleanup", () => {
       ["-100123", 715],
       ["-100999", 42],
     ]);
-    expect(res).toEqual({ cleared: 2, total: 2 });
+    expect(res).toEqual({ cleared: 2, retained: 0, kept: 0, total: 2 });
     // Store empty afterwards → no re-attempt next boot.
     expect(loadStatusPins(PATH, fs)).toEqual([]);
   });
 
-  it("a failing unpin is non-fatal and the store is still emptied", async () => {
+  it("retry-safe (#3001): a failing unpin is non-fatal, RETAINS the row with an attempt counter, and drops only the succeeded one", async () => {
     const { fs } = memFs();
     persistStatusPins(PATH, fs, [
       pin({ pinKey: "fg:c:1", chatId: "-100123", messageId: 5 }),
@@ -216,9 +217,64 @@ describe("runStatusPinBootCleanup", () => {
       log: () => {},
     });
 
-    // One failed, one succeeded — still non-fatal, store still emptied.
-    expect(res).toEqual({ cleared: 1, total: 2 });
+    // One failed, one succeeded — the failure is retained for a next-boot
+    // retry instead of forfeiting the orphan (the pre-#3001 behaviour).
+    expect(res).toEqual({ cleared: 1, retained: 1, kept: 0, total: 2 });
+    expect(loadStatusPins(PATH, fs)).toEqual([
+      { pinKey: "fg:c:1", chatId: "-100123", messageId: 5, attempts: 1 },
+    ]);
+  });
+
+  it("retry-safe (#3001): a row is forfeited once its attempts reach BOOT_UNPIN_MAX_ATTEMPTS", async () => {
+    const { fs } = memFs();
+    persistStatusPins(PATH, fs, [
+      pin({
+        pinKey: "fg:c:1",
+        chatId: "-100123",
+        messageId: 5,
+        attempts: BOOT_UNPIN_MAX_ATTEMPTS - 1,
+      }),
+    ]);
+    const res = await runStatusPinBootCleanup({
+      path: PATH,
+      fs,
+      unpin: async () => {
+        throw new Error("chat gone forever");
+      },
+      log: () => {},
+    });
+    // Final attempt failed too — forfeited, not retained: a permanently-
+    // undeliverable unpin must not re-fail on every future boot.
+    expect(res).toEqual({ cleared: 0, retained: 0, kept: 0, total: 1 });
     expect(loadStatusPins(PATH, fs)).toEqual([]);
+  });
+
+  it("tool pins (#3001): an UNEXPIRED `tool:` row survives the boot untouched; an EXPIRED one is unpinned and dropped", async () => {
+    const { fs } = memFs();
+    const now = 1_750_000_000_000;
+    persistStatusPins(PATH, fs, [
+      pin({ pinKey: "tool:-100123:70", chatId: "-100123", messageId: 70, expiresAt: now + 1 }),
+      pin({ pinKey: "tool:-100123:71", chatId: "-100123", messageId: 71, expiresAt: now }),
+      pin({ pinKey: "wk:agent-x", chatId: "-100123", messageId: 72 }),
+    ]);
+    const unpinned: number[] = [];
+    const res = await runStatusPinBootCleanup({
+      path: PATH,
+      fs,
+      unpin: async (_c, messageId) => {
+        unpinned.push(messageId);
+      },
+      now,
+      log: () => {},
+    });
+    // The expired tool pin and the work-scoped wk: pin are unpinned; the
+    // unexpired tool pin is kept for a future boot (restart ≠ reset for a
+    // deliberate agent pin with no "work finished" event).
+    expect(unpinned).toEqual([71, 72]);
+    expect(res).toEqual({ cleared: 2, retained: 0, kept: 1, total: 3 });
+    expect(loadStatusPins(PATH, fs)).toEqual([
+      { pinKey: "tool:-100123:70", chatId: "-100123", messageId: 70, expiresAt: now + 1 },
+    ]);
   });
 
   it("no-op on a fresh boot with no persisted pins (no unpin calls)", async () => {
@@ -232,7 +288,7 @@ describe("runStatusPinBootCleanup", () => {
       },
       log: () => {},
     });
-    expect(res).toEqual({ cleared: 0, total: 0 });
+    expect(res).toEqual({ cleared: 0, retained: 0, kept: 0, total: 0 });
     expect(calls).toBe(0);
   });
 
@@ -254,7 +310,7 @@ describe("runStatusPinBootCleanup", () => {
       log: () => {},
     });
     expect(unpinned).toEqual([["-100777", 314]]);
-    expect(res).toEqual({ cleared: 1, total: 1 });
+    expect(res).toEqual({ cleared: 1, retained: 0, kept: 0, total: 1 });
     expect(loadStatusPins(PATH, fs)).toEqual([]);
   });
 });

--- a/telegram-plugin/tests/worker-pin-reaper.test.ts
+++ b/telegram-plugin/tests/worker-pin-reaper.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import {
+  decideWorkerPinReaps,
+  workerAgentIdOfPinKey,
+  WORKER_PIN_TTL_MS_DEFAULT,
+  type WorkerPinCandidate,
+} from "../gateway/worker-pin-reaper.js";
+
+const NOW = 1_750_000_000_000;
+const TTL = WORKER_PIN_TTL_MS_DEFAULT;
+
+function pin(over: Partial<WorkerPinCandidate> = {}): WorkerPinCandidate {
+  return { pinKey: "wk:agent-1", chatId: "123", pinnedAt: NOW - 60_000, ...over };
+}
+
+describe("workerAgentIdOfPinKey", () => {
+  it("extracts the agentId from a wk: key", () => {
+    expect(workerAgentIdOfPinKey("wk:abc123")).toBe("abc123");
+  });
+  it("returns null for non-worker keys (fg:/banner:/tool:) and empty ids", () => {
+    expect(workerAgentIdOfPinKey("fg:123:5")).toBeNull();
+    expect(workerAgentIdOfPinKey("banner:owner")).toBeNull();
+    expect(workerAgentIdOfPinKey("tool:123:9")).toBeNull();
+    expect(workerAgentIdOfPinKey("wk:")).toBeNull();
+  });
+});
+
+describe("decideWorkerPinReaps (#3001 mid-session wk: sweep)", () => {
+  it("reaps a pin whose worker is terminal, however young the pin is", () => {
+    const reaps = decideWorkerPinReaps({
+      pins: [pin({ pinnedAt: NOW - 1_000 })],
+      isTerminal: () => true,
+      ttlMs: TTL,
+      now: NOW,
+    });
+    expect(reaps).toHaveLength(1);
+    expect(reaps[0].reason).toBe("terminal");
+    expect(reaps[0].pinKey).toBe("wk:agent-1");
+  });
+
+  it("reaps a non-terminal pin once it exceeds the TTL", () => {
+    const reaps = decideWorkerPinReaps({
+      pins: [pin({ pinnedAt: NOW - TTL })],
+      isTerminal: () => false,
+      ttlMs: TTL,
+      now: NOW,
+    });
+    expect(reaps).toHaveLength(1);
+    expect(reaps[0].reason).toBe("ttl");
+  });
+
+  it("NEVER touches a running worker younger than the TTL", () => {
+    const reaps = decideWorkerPinReaps({
+      pins: [pin({ pinnedAt: NOW - TTL + 1 })],
+      isTerminal: () => false,
+      ttlMs: TTL,
+      now: NOW,
+    });
+    expect(reaps).toHaveLength(0);
+  });
+
+  it("ignores non-worker keys entirely (fg:/banner:/tool: are not its job)", () => {
+    const reaps = decideWorkerPinReaps({
+      pins: [
+        pin({ pinKey: "fg:123:5", pinnedAt: NOW - 10 * TTL }),
+        pin({ pinKey: "banner:owner", pinnedAt: NOW - 10 * TTL }),
+        pin({ pinKey: "tool:123:9", pinnedAt: NOW - 10 * TTL }),
+      ],
+      isTerminal: () => true,
+      ttlMs: TTL,
+      now: NOW,
+    });
+    expect(reaps).toHaveLength(0);
+  });
+
+  it("skips a candidate with no chat id (cannot unpin without one)", () => {
+    const reaps = decideWorkerPinReaps({
+      pins: [pin({ chatId: "", pinnedAt: NOW - 10 * TTL })],
+      isTerminal: () => true,
+      ttlMs: TTL,
+      now: NOW,
+    });
+    expect(reaps).toHaveLength(0);
+  });
+
+  it("terminality is consulted per-agent and wins over the TTL gate", () => {
+    const seen: string[] = [];
+    const reaps = decideWorkerPinReaps({
+      pins: [
+        pin({ pinKey: "wk:done", pinnedAt: NOW - 1_000 }),
+        pin({ pinKey: "wk:running", pinnedAt: NOW - 1_000 }),
+        pin({ pinKey: "wk:old-running", pinnedAt: NOW - TTL - 1 }),
+      ],
+      isTerminal: (agentId) => {
+        seen.push(agentId);
+        return agentId === "done";
+      },
+      ttlMs: TTL,
+      now: NOW,
+    });
+    expect(seen).toEqual(["done", "running", "old-running"]);
+    expect(reaps.map((r) => [r.pinKey, r.reason])).toEqual([
+      ["wk:done", "terminal"],
+      ["wk:old-running", "ttl"],
+    ]);
+  });
+
+  it("a throwing-in-caller-terms predicate is the caller's contract: false keeps the pin (registry hiccup never unpins)", () => {
+    // The gateway wraps its DB lookup and degrades to `false`. This pins the
+    // pure module's side of the contract: false + young pin = untouched.
+    const reaps = decideWorkerPinReaps({
+      pins: [pin()],
+      isTerminal: () => false,
+      ttlMs: TTL,
+      now: NOW,
+    });
+    expect(reaps).toHaveLength(0);
+  });
+});

--- a/telegram-plugin/tests/worker-pin-reaper.test.ts
+++ b/telegram-plugin/tests/worker-pin-reaper.test.ts
@@ -29,7 +29,7 @@ describe("decideWorkerPinReaps (#3001 mid-session wk: sweep)", () => {
   it("reaps a pin whose worker is terminal, however young the pin is", () => {
     const reaps = decideWorkerPinReaps({
       pins: [pin({ pinnedAt: NOW - 1_000 })],
-      isTerminal: () => true,
+      statusOf: () => 'terminal' as const,
       ttlMs: TTL,
       now: NOW,
     });
@@ -41,7 +41,7 @@ describe("decideWorkerPinReaps (#3001 mid-session wk: sweep)", () => {
   it("reaps a non-terminal pin once it exceeds the TTL", () => {
     const reaps = decideWorkerPinReaps({
       pins: [pin({ pinnedAt: NOW - TTL })],
-      isTerminal: () => false,
+      statusOf: () => 'unknown' as const,
       ttlMs: TTL,
       now: NOW,
     });
@@ -49,10 +49,10 @@ describe("decideWorkerPinReaps (#3001 mid-session wk: sweep)", () => {
     expect(reaps[0].reason).toBe("ttl");
   });
 
-  it("NEVER touches a running worker younger than the TTL", () => {
+  it("NEVER touches a pin younger than the TTL when the registry cannot vouch (unknown)", () => {
     const reaps = decideWorkerPinReaps({
       pins: [pin({ pinnedAt: NOW - TTL + 1 })],
-      isTerminal: () => false,
+      statusOf: () => 'unknown' as const,
       ttlMs: TTL,
       now: NOW,
     });
@@ -66,7 +66,7 @@ describe("decideWorkerPinReaps (#3001 mid-session wk: sweep)", () => {
         pin({ pinKey: "banner:owner", pinnedAt: NOW - 10 * TTL }),
         pin({ pinKey: "tool:123:9", pinnedAt: NOW - 10 * TTL }),
       ],
-      isTerminal: () => true,
+      statusOf: () => 'terminal' as const,
       ttlMs: TTL,
       now: NOW,
     });
@@ -76,41 +76,54 @@ describe("decideWorkerPinReaps (#3001 mid-session wk: sweep)", () => {
   it("skips a candidate with no chat id (cannot unpin without one)", () => {
     const reaps = decideWorkerPinReaps({
       pins: [pin({ chatId: "", pinnedAt: NOW - 10 * TTL })],
-      isTerminal: () => true,
+      statusOf: () => 'terminal' as const,
       ttlMs: TTL,
       now: NOW,
     });
     expect(reaps).toHaveLength(0);
   });
 
-  it("terminality is consulted per-agent and wins over the TTL gate", () => {
+  it("a registry-confirmed RUNNING worker keeps its pin PAST the TTL (no unpin/re-pin churn on healthy long workers)", () => {
+    const reaps = decideWorkerPinReaps({
+      pins: [pin({ pinnedAt: NOW - 10 * TTL })],
+      statusOf: () => 'running' as const,
+      ttlMs: TTL,
+      now: NOW,
+    });
+    expect(reaps).toHaveLength(0);
+  });
+
+  it("status is consulted per-agent: terminal reaps young, running exempts old, unknown falls to the TTL gate", () => {
     const seen: string[] = [];
     const reaps = decideWorkerPinReaps({
       pins: [
         pin({ pinKey: "wk:done", pinnedAt: NOW - 1_000 }),
-        pin({ pinKey: "wk:running", pinnedAt: NOW - 1_000 }),
-        pin({ pinKey: "wk:old-running", pinnedAt: NOW - TTL - 1 }),
+        pin({ pinKey: "wk:running-old", pinnedAt: NOW - TTL - 1 }),
+        pin({ pinKey: "wk:unknown-young", pinnedAt: NOW - 1_000 }),
+        pin({ pinKey: "wk:unknown-old", pinnedAt: NOW - TTL - 1 }),
       ],
-      isTerminal: (agentId) => {
+      statusOf: (agentId) => {
         seen.push(agentId);
-        return agentId === "done";
+        if (agentId === "done") return "terminal";
+        if (agentId === "running-old") return "running";
+        return "unknown";
       },
       ttlMs: TTL,
       now: NOW,
     });
-    expect(seen).toEqual(["done", "running", "old-running"]);
+    expect(seen).toEqual(["done", "running-old", "unknown-young", "unknown-old"]);
     expect(reaps.map((r) => [r.pinKey, r.reason])).toEqual([
       ["wk:done", "terminal"],
-      ["wk:old-running", "ttl"],
+      ["wk:unknown-old", "ttl"],
     ]);
   });
 
-  it("a throwing-in-caller-terms predicate is the caller's contract: false keeps the pin (registry hiccup never unpins)", () => {
-    // The gateway wraps its DB lookup and degrades to `false`. This pins the
-    // pure module's side of the contract: false + young pin = untouched.
+  it("registry hiccup ('unknown') never unpins a young pin — the caller's contract on statusOf degrade", () => {
+    // The gateway wraps its DB lookup and degrades to 'unknown'. This pins the
+    // pure module's side of the contract: unknown + young pin = untouched.
     const reaps = decideWorkerPinReaps({
       pins: [pin()],
-      isTerminal: () => false,
+      statusOf: () => 'unknown' as const,
       ttlMs: TTL,
       now: NOW,
     });

--- a/telegram-plugin/uat/scenarios/jtbd-worker-pin-lifecycle-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-worker-pin-lifecycle-dm.test.ts
@@ -164,12 +164,25 @@ describe("uat: worker-pin lifecycle + restart rule (#3001, DM)", () => {
         await sc.sendDM(bgDispatchPrompt(30));
         await sc.expectMessage(/.+/, { from: "bot", timeout: 45_000 });
 
-        const pinned = await nextPinEvent(
-          pinIter,
-          (p) => p.pinned,
-          90_000,
-          "worker pin",
-        );
+        // Latch onto the 🛠 Worker feed pin specifically — the parent turn's
+        // own fg: status pin can land first, and a bare `p.pinned` predicate
+        // would seize it and then wait on the wrong messageId's unpin. Keep
+        // consuming pin events until one resolves to a worker-feed message
+        // (AC-1's sanity fetch, applied inside the wait loop).
+        const pinDeadline = Date.now() + 90_000;
+        let pinned: ObservedPin | null = null;
+        while (pinned == null) {
+          const candidate = await nextPinEvent(
+            pinIter,
+            (p) => p.pinned,
+            Math.max(1, pinDeadline - Date.now()),
+            "worker-feed pin",
+          );
+          const msg = await sc.driver
+            .getMessage(sc.botUserId, candidate.messageId)
+            .catch(() => null);
+          if (msg != null && WORKER_FEED_RE.test(msg.text)) pinned = candidate;
+        }
 
         // Force the restart MID-dispatch: the wk: claim is persisted in
         // status-pins.json; the dying session never runs its completion

--- a/telegram-plugin/uat/scenarios/jtbd-worker-pin-lifecycle-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-worker-pin-lifecycle-dm.test.ts
@@ -1,0 +1,195 @@
+/**
+ * JTBD — worker-pin lifecycle + the restart rule (#3001, DM).
+ *
+ * The job spec (`reference/jobs/know-what-my-agent-is-doing.md`) sanctions
+ * exactly one pin: silently pinning the already-rendered status message while
+ * its work is in flight, auto-unpinned when the work completes. #3001's
+ * operator report was the failure mode: worker (`wk:`) pins with no
+ * mid-session reaper and a forfeit-on-failure boot sweep left a long tail of
+ * stale pinned `🛠 Worker` messages. The restart rule this scenario pins:
+ * **agent restart = reset any pinned message whose work didn't finish.**
+ *
+ * Two acceptance criteria, shared setup (a long background dispatch):
+ *
+ *   AC-1 — lifecycle: the `🛠 Worker` feed message is PINNED while the
+ *          background worker runs, and UNPINNED after it completes (the
+ *          normal completion unpin — no restart involved).
+ *   AC-2 — restart rule: with a SECOND dispatch pinned mid-flight, a forced
+ *          gateway restart orphans the pin; the next boot's sweep
+ *          (statusPinBootCleanup, reading status-pins.json) unpins it. The
+ *          restart half self-skips green without NOPASSWD sudo, mirroring
+ *          jtbd-message-during-restart-dm.
+ *
+ * Observation shape: pins/unpins are SERVICE events, not message sends or
+ * edits — the worker card EDITS in place the whole time it is pinned, so a
+ * message-observer predicate would fire on edits and prove nothing. We
+ * assert via `driver.observePins` (raw `updatePinnedMessages`), keyed to the
+ * exact pinned messageId, and explicitly ignore `m.edited` traffic.
+ *
+ * Env note: requires the harness agent's default
+ * `pin_status_while_working` (ON) and the worker activity feed enabled —
+ * same env as bg-sub-agent-dispatch-dm (SETUP.md §6).
+ */
+
+import { describe, it, expect } from "vitest";
+import { execSync, spawn } from "node:child_process";
+import { spinUp } from "../harness.js";
+import type { ObservedPin } from "../driver.js";
+import { WORKER_FEED_RE } from "../assertions.js";
+
+const AGENT = "test-harness";
+
+// Same deterministic Option-1 dispatch prompt shape as
+// bg-sub-agent-dispatch-dm: this scenario verifies the PIN infra, not the
+// model's delegation judgment. ~60s of paced background work — long enough
+// for the feed to paint (8s first-paint floor) and the wk: pin to land.
+function bgDispatchPrompt(steps: number): string {
+  return (
+    `Use the Agent tool with subagent_type "general-purpose" and ` +
+    `run_in_background: true to dispatch a worker with this exact task: ` +
+    `"Do ${steps} steps, ONE AT A TIME, k = 1 through ${steps}. Before each ` +
+    `step write a brief one-sentence narration, then run \`sleep 2\` via the ` +
+    `Bash tool, then run \`echo step-k\` via the Bash tool (substitute the ` +
+    `real number for k). Run every sleep and every echo as its OWN separate ` +
+    `Bash call — never batch or chain them with && — and narrate before ` +
+    `each. Do not stop early; complete all ${steps} steps." After ` +
+    `dispatching, send a brief reply saying you've kicked off the worker.`
+  );
+}
+
+/** Wait for the next pin/unpin event matching `pred`. observePins yields
+ *  service-level pin transitions only — message EDITS never surface here,
+ *  which is exactly why this scenario observes pins, not messages. */
+async function nextPinEvent(
+  iter: AsyncIterator<ObservedPin>,
+  pred: (p: ObservedPin) => boolean,
+  timeoutMs: number,
+  what: string,
+): Promise<ObservedPin> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remaining = deadline - Date.now();
+    const race = await Promise.race([
+      iter.next(),
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), remaining)),
+    ]);
+    if (race === "timeout") break;
+    if (race.done === true) break;
+    if (pred(race.value)) return race.value;
+  }
+  throw new Error(`nextPinEvent: no ${what} within ${timeoutMs}ms`);
+}
+
+function canShellSudo(): boolean {
+  try {
+    execSync("sudo -n true", { stdio: "ignore", timeout: 2_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Kick a marker-safe restart and return immediately (detached) — same shape
+ *  as jtbd-message-during-restart-dm. */
+function kickRestartDetached(name: string): void {
+  const child = spawn(
+    "sudo",
+    ["-n", "env", `PATH=${process.env.PATH}`, `HOME=${process.env.HOME}`,
+      "switchroom", "agent", "restart", name, "--force"],
+    { detached: true, stdio: "ignore" },
+  );
+  child.unref();
+}
+
+const sudoOk = canShellSudo();
+
+describe("uat: worker-pin lifecycle + restart rule (#3001, DM)", () => {
+  it(
+    "AC-1: the worker feed message is pinned while the bg dispatch runs and unpinned after completion",
+    async () => {
+      const sc = await spinUp({ agent: AGENT });
+      const pinIter = sc.driver
+        .observePins(sc.botUserId)
+        [Symbol.asyncIterator]();
+      try {
+        await sc.sendDM(bgDispatchPrompt(10));
+
+        // Parent ack — the dispatch happened.
+        await sc.expectMessage(/.+/, { from: "bot", timeout: 45_000 });
+
+        // The wk: pin lands once the worker feed paints (~8s first-paint) —
+        // a PIN service event, not a send/edit.
+        const pinned = await nextPinEvent(
+          pinIter,
+          (p) => p.pinned,
+          90_000,
+          "worker pin",
+        );
+        expect(pinned.messageId).toBeGreaterThan(0);
+
+        // Sanity: what got pinned is the 🛠 Worker feed message (fetch by id
+        // — the card keeps EDITING in place; we never assert on edits).
+        const msg = await sc.driver.getMessage(sc.botUserId, pinned.messageId);
+        expect(msg, "pinned message vanished").not.toBeNull();
+        expect(msg!.text).toMatch(WORKER_FEED_RE);
+
+        // Completion unpins it. Budget mirrors bg-sub-agent-dispatch-dm's
+        // done-window: worker (~60s) + watcher stall detection (60s) + slack.
+        const unpinned = await nextPinEvent(
+          pinIter,
+          (p) => !p.pinned && p.messageId === pinned.messageId,
+          240_000,
+          `unpin of worker pin msg=${pinned.messageId}`,
+        );
+        expect(unpinned.pinned).toBe(false);
+      } finally {
+        await pinIter.return?.();
+        await sc.tearDown();
+      }
+    },
+    // 45s ack + 90s pin + 240s unpin + spinUp/teardown slack.
+    420_000,
+  );
+
+  (sudoOk ? it : it.skip)(
+    "AC-2 (restart rule): a worker pin orphaned by a forced gateway restart is unpinned by the next boot's sweep",
+    async () => {
+      const sc = await spinUp({ agent: AGENT });
+      const pinIter = sc.driver
+        .observePins(sc.botUserId)
+        [Symbol.asyncIterator]();
+      try {
+        // Longer dispatch (~2min of steps) so the restart reliably lands
+        // while the worker — and its pin — are still in flight.
+        await sc.sendDM(bgDispatchPrompt(30));
+        await sc.expectMessage(/.+/, { from: "bot", timeout: 45_000 });
+
+        const pinned = await nextPinEvent(
+          pinIter,
+          (p) => p.pinned,
+          90_000,
+          "worker pin",
+        );
+
+        // Force the restart MID-dispatch: the wk: claim is persisted in
+        // status-pins.json; the dying session never runs its completion
+        // unpin. The next boot's statusPinBootCleanup must unpin it.
+        kickRestartDetached(AGENT);
+
+        const unpinned = await nextPinEvent(
+          pinIter,
+          (p) => !p.pinned && p.messageId === pinned.messageId,
+          // Restart (docker recreate + gateway boot + startup mutex + boot
+          // sweep) comfortably inside this window.
+          240_000,
+          `boot-sweep unpin of orphaned worker pin msg=${pinned.messageId}`,
+        );
+        expect(unpinned.pinned).toBe(false);
+      } finally {
+        await pinIter.return?.();
+        await sc.tearDown();
+      }
+    },
+    420_000,
+  );
+});


### PR DESCRIPTION
Closes #3001.

Operator rule implemented: **agent restart = reset (unpin) any pinned message whose work didn't finish** — plus a mid-session guarantee so a missed worker completion no longer leaves a pin until the next boot.

## Changes

1. **Mid-session `wk:` pin reaper** — new pure module `telegram-plugin/gateway/worker-pin-reaper.ts` (mirrors `runActivityCardMidSessionReaper`'s decide-over-seams shape), wired as step 3 of the existing 5-min mid-session sweep. A claimed worker pin is unpinned when the sub-agent registry row is terminal (`completed|failed` — the missed-onFinish case) or the claim outlives a **6h TTL** (rationale in the constant's doc: comfortably beyond any legitimate worker turn, bounds the stale window to same-day). Executes via `reconcileStatusPin` so the in-memory claim and the durable `status-pins.json` row clear together. Kill switch `SWITCHROOM_WORKER_PIN_REAPER=0`; TTL override `SWITCHROOM_WORKER_PIN_REAPER_TTL_MS`.
2. **`pin_message` tool pins tracked** — `executePinMessage` now registers `tool:<chatId>:<messageId>` rows in the shared store with `expiresAt` (**7-day TTL**, `SWITCHROOM_TOOL_PIN_TTL_MS` override). Per the spec intent: a tool pin has no "work finished" event, so restart does **not** reset it — boot sweep keeps unexpired tool rows across boots and unpins only once expired. Documented in the job spec.
3. **Card reaper unpin routed through `reconcileStatusPin`** — `runActivityCardMidSessionReaper`'s `unpinCard` uses the reconcile path when the `fg:` claim is live (store row + claim clear together); raw-API unpin kept as fallback for an untracked claim.
4. **Retry-safe boot sweeps** — `runStatusPinBootCleanup` and `runActivityCardBootReaper` now drop a record only **after** a successful unpin; a failure retains it with an attempt counter (cap **5**, `BOOT_UNPIN_MAX_ATTEMPTS`) so the next boot retries instead of forfeiting the orphan. The activity-card finalizing **edit** keeps its deliberate at-most-once contract (`finalizeAttempted` flag on retained records — retries touch only the idempotent unpin).
5. **Spec** — `reference/jobs/know-what-my-agent-is-doing.md`: restart rule + tool-pin lifecycle stated explicitly; prove-it entry added pointing at the new UAT scenario and decision-layer twins.
6. **Tests**
   - `telegram-plugin/tests/worker-pin-reaper.test.ts` — terminal-wins, TTL gate, running-worker safety, non-wk-key exclusion (DI seams, no module mocking).
   - `status-pin-store.test.ts` — tool-pin TTL keep/expire, retry-retention with attempt counter, forfeit at cap; return-shape updates in the two boot-recovery suites.
   - `activity-card-store.test.ts` — retained-record unpin retry (second boot skips the edit), forfeit at cap.
   - UAT `telegram-plugin/uat/scenarios/jtbd-worker-pin-lifecycle-dm.test.ts` — worker pin appears during a long bg dispatch and is unpinned after completion (AC-1) and after a forced gateway restart mid-dispatch (AC-2, sudo-gated self-skip). Observes `observePins` service events keyed to the exact messageId — never message edits.

## Verification

- `npm run lint` — clean (tsc + all 8 guard scripts).
- Scoped vitest: `status-pin-store`, `activity-card-store`, `worker-pin-reaper`, `status-pin`, `status-pin-boot-recovery`, `slot-banner-boot-recovery`, `status-pin-service-message-suppression`, `activity-card-wiring` — **107/107 pass**.
- Scoped bun test (nearby card suites): 80/80 pass.
- Full local vitest not compared (known ~114 pre-existing failures on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-ups (a14d9db7)

- **TTL churn fix (MEDIUM):** `decideWorkerPinReaps` now consults a `statusOf` seam (`terminal | running | unknown`). A registry-confirmed **running** row exempts the pin from the TTL — no more unpin→re-pin churn every 6h on a healthy long worker. The stall detector demotes dead workers out of `running` within ~60s, so the TTL still catches true zombies (`stalled`/missing/lookup-error → `unknown` → TTL).
- **Forfeit logging (LOW):** both boot sweeps log a `FORFEITING … will not retry again` line when a row hits `BOOT_UNPIN_MAX_ATTEMPTS`.
- **UAT AC-2 latch (LOW):** AC-2 now consumes pin events until one resolves to a `🛠 Worker` feed message, so it can't seize the parent turn's `fg:` pin.

## Rollback note (disclosure, no code change)

If the gateway is **rolled back** to pre-#3001 code while `status-pins.json` contains new-format rows, the old `runStatusPinBootCleanup` ignores `expiresAt`/`attempts` (unknown fields pass its row validation) and unpins **every** row once at boot — including live `tool:` pins. No crash, no data corruption; the effect is a one-time reset of deliberate tool pins on rollback. Accepted: rollback safety-of-behaviour, not full behaviour preservation.
