### PR TITLE
cleanup(telegram): finish inbound-delivery machine cutover (#2794)

### DIFF
--- a/telegram-plugin/gateway/inbound-delivery-machine-dispatch.ts
+++ b/telegram-plugin/gateway/inbound-delivery-machine-dispatch.ts
@@ -221,9 +221,16 @@ function dispatchOne(effect: Effect, ctx: DispatchCtx): void {
         )
         ok = false
       }
-      if (ok && ctx.onUserInboundDelivered && msg.meta?.source !== undefined) {
+      if (ok && ctx.onUserInboundDelivered) {
         // Enrol in the deliver-until-acked sweep — a socket write is not
         // proof claude consumed it (see onUserInboundDelivered doc).
+        // Pass UNCONDITIONALLY, mirroring the drainBuffer path above:
+        // the callback self-gates via shouldTrackDelivery (inbound-
+        // delivery-confirm.ts), which REJECTS sourced messages and
+        // tracks real user inbounds (meta.source undefined) — exactly
+        // the messages the sweep protects. Do NOT pre-filter on
+        // meta.source here; an inverted guard would skip user inbounds
+        // and enrol only messages the inner gate discards.
         try {
           ctx.onUserInboundDelivered(msg)
         } catch {
@@ -252,6 +259,20 @@ function dispatchOne(effect: Effect, ctx: DispatchCtx): void {
     }
 
     case 'deliverPermVerdict': {
+      // Branch order differs from the imperative twin
+      // (gateway.ts dispatchPermissionVerdict), which always goes via
+      // `ipcServer.sendToAgent` — it runs outside any bridgeUp context,
+      // so it has no just-registered client handle. Here `ctx.client`
+      // is preferred WHEN PRESENT for the same reason as drainBuffer /
+      // redeliverPersistedPermVerdicts above: on the bridgeUp path the
+      // registry lookup may not yet observe the just-registered client,
+      // and a direct send to the connecting socket is the reliable
+      // route. PR3c's live call site for machine-driven permVerdict
+      // events (non-bridgeUp) must construct the ctx WITHOUT `client`,
+      // which makes this branch behave exactly like the twin
+      // (sendToAgent). Note the twin additionally buffers on a failed
+      // send; the machine models that as a separate persistPermVerdict
+      // effect (bridge_dead state), so no fallback push here.
       const ev = effect.verdict.payload as PermissionEvent
       let ok = false
       try {

--- a/telegram-plugin/gateway/inbound-delivery-machine-dispatch.ts
+++ b/telegram-plugin/gateway/inbound-delivery-machine-dispatch.ts
@@ -7,17 +7,40 @@
  * (b) execute the returned effects against real I/O. This module owns
  * step (b) for the cutover.
  *
- * Scope of THIS PR — bridgeUp only:
- *   - drainBuffer                       → executed
- *   - redeliverPersistedPermVerdicts    → executed
+ * Effects wired to real executors (all effect kinds now handled):
+ *   - drainBuffer                       → redeliverBufferedInbound
+ *   - redeliverPersistedPermVerdicts    → pendingPermissionBuffer.drain → send
+ *   - deliverToBridge                   → client.send / ipcServer.sendToAgent
+ *   - bufferInbound                     → pendingInboundBuffer.push
+ *   - persistInbound                    → inboundSpool.put
+ *   - deliverPermVerdict                → client.send / ipcServer.sendToAgent
+ *   - persistPermVerdict                → pendingPermissionBuffer.push
+ *   - setTurnStarted / clearTurnStarted → onSetTurnStarted / onClearTurnStarted
+ *   - noteOutbound                      → onNoteOutbound
+ *   - firePoke                          → onFirePoke
  *   - logTrace                          → executed
  *
- * Other effects (deliverToBridge, bufferInbound, persistInbound,
- * setTurnStarted, clearTurnStarted, noteOutbound, firePoke,
- * deliverPermVerdict, persistPermVerdict) still flow through their
- * existing imperative paths in `gateway.ts`. The dispatcher logs them
- * as `not-yet-cutover` so a future PR can wire them without grep-and-
- * pray. NEVER silently no-op: the trace is the gate.
+ * IMPORTANT — this module executing an effect is NOT the same as the
+ * gateway being cut over for that effect. The gateway currently only
+ * calls `dispatchEffects()` with the **bridgeUp** effect set
+ * (`drainBuffer` / `redeliverPersistedPermVerdicts` / `logTrace`).
+ * The inbound-routing effects (deliverToBridge / bufferInbound /
+ * persistInbound) and the turn-lifecycle / poke / perm-verdict effects
+ * are wired here so PR3c (inbound cutover) can flip `handleInbound` to
+ * dispatch through the machine WITHOUT further wiring — but the live
+ * imperative paths in `gateway.ts` still own those flows today (see the
+ * "Hard removal plan" checklist in the RFC: PR3b/PR3c/PR4 remain open).
+ * Wiring an effect whose live driver is still imperative causes NO
+ * double-execution because the gateway never passes that effect kind to
+ * this dispatcher yet. The effect-level unit + equivalence tests gate
+ * the wiring so PR3c is a one-line call-site flip, not a rewrite.
+ *
+ * The gateway-internal turn/poke effects (setTurnStarted,
+ * clearTurnStarted, noteOutbound, firePoke) map to gateway-scope state
+ * (`claudeBusyKeys`, the silence-poke ladder) that this decoupled module
+ * cannot reach directly, so they are dispatched through OPTIONAL
+ * callbacks on the ctx. When a callback is absent the effect logs an
+ * `unwired` trace rather than silently no-opping — the trace is the gate.
  *
  * Kill switch: `SWITCHROOM_DELIVERY_MACHINE_CUTOVER=0` disables
  * dispatcher execution and the gateway falls back to imperative-only.
@@ -26,10 +49,11 @@
 
 import type {
   Effect,
+  ChatKey,
   InboundMessage as MachineInboundMessage,
 } from './inbound-delivery-machine.js'
 import type { IpcServer, IpcClient } from './ipc-server.js'
-import type { InboundMessage } from './ipc-protocol.js'
+import type { InboundMessage, PermissionEvent } from './ipc-protocol.js'
 import type { PendingInboundBuffer } from './pending-inbound-buffer.js'
 import { redeliverBufferedInbound } from './pending-inbound-buffer.js'
 import type { InboundSpool } from './inbound-spool.js'
@@ -54,6 +78,15 @@ export interface DispatchCtx {
    * (clerk lost-message incident, 2026-06-03.)
    */
   readonly onUserInboundDelivered?: (merged: InboundMessage) => void
+  // ── Gateway-internal turn/poke effect callbacks ──────────────────
+  // These effects map to gateway-scope state (`claudeBusyKeys`, the
+  // silence-poke ladder) that this decoupled module cannot reach. The
+  // gateway supplies them when it flips inbound routing through the
+  // machine (PR3c). Absent → the effect logs an `unwired` trace.
+  readonly onSetTurnStarted?: (key: ChatKey, at: number) => void
+  readonly onClearTurnStarted?: (key: ChatKey) => void
+  readonly onNoteOutbound?: (key: ChatKey, at: number) => void
+  readonly onFirePoke?: (key: ChatKey, level: 'soft' | 'firm' | 'fallback') => void
 }
 
 const enabled = process.env.SWITCHROOM_DELIVERY_MACHINE_CUTOVER !== '0'
@@ -168,20 +201,105 @@ function dispatchOne(effect: Effect, ctx: DispatchCtx): void {
       return
     }
 
-    // The cases below are KNOWN effect kinds that this PR does NOT
-    // cut over. The imperative paths still run for them; the
-    // dispatcher logs the event so future cutover PRs can grep for
-    // exactly the call sites to migrate.
-    case 'deliverToBridge':
-    case 'bufferInbound':
-    case 'persistInbound':
-    case 'setTurnStarted':
-    case 'clearTurnStarted':
-    case 'noteOutbound':
-    case 'firePoke':
-    case 'deliverPermVerdict':
+    case 'deliverToBridge': {
+      // Route a single inbound to the live bridge. The machine's
+      // InboundMessage.payload carries the real ipc-protocol
+      // InboundMessage; the machine treats it as opaque.
+      const msg = effect.msg.payload as InboundMessage
+      let ok = false
+      try {
+        if (ctx.client) {
+          ctx.client.send(msg)
+          ok = true
+        } else {
+          ok = ctx.ipcServer.sendToAgent(ctx.selfAgent, msg)
+        }
+      } catch (err) {
+        log(
+          `telegram gateway: dispatch deliverToBridge send threw agent=${ctx.selfAgent} ` +
+            `key=${effect.key}: ${(err as Error).message}\n`,
+        )
+        ok = false
+      }
+      if (ok && ctx.onUserInboundDelivered && msg.meta?.source !== undefined) {
+        // Enrol in the deliver-until-acked sweep — a socket write is not
+        // proof claude consumed it (see onUserInboundDelivered doc).
+        try {
+          ctx.onUserInboundDelivered(msg)
+        } catch {
+          /* enrolment is best-effort; never breaks delivery */
+        }
+      }
+      log(`gw-trace dispatch deliverToBridge key=${effect.key} ok=${ok}\n`)
+      return
+    }
+
+    case 'bufferInbound': {
+      const msg = effect.msg.payload as InboundMessage
+      const buffered = ctx.pendingInboundBuffer.push(ctx.selfAgent, msg)
+      log(`gw-trace dispatch bufferInbound key=${effect.key} buffered=${buffered}\n`)
+      return
+    }
+
+    case 'persistInbound': {
+      // Durable spool. `pendingInboundBuffer.push` already spools when a
+      // spool is attached to the buffer, so a persistInbound paired with
+      // a bufferInbound is idempotent (put() is idempotent by spoolId).
+      const msg = effect.msg.payload as InboundMessage
+      const put = ctx.inboundSpool ? ctx.inboundSpool.put(ctx.selfAgent, msg) : false
+      log(`gw-trace dispatch persistInbound key=${effect.key} put=${put}\n`)
+      return
+    }
+
+    case 'deliverPermVerdict': {
+      const ev = effect.verdict.payload as PermissionEvent
+      let ok = false
+      try {
+        if (ctx.client) {
+          ctx.client.send(ev as never)
+          ok = true
+        } else {
+          ok = ctx.ipcServer.sendToAgent(ctx.selfAgent, ev as never)
+        }
+      } catch (err) {
+        log(
+          `telegram gateway: dispatch deliverPermVerdict send threw agent=${ctx.selfAgent} ` +
+            `request=${effect.verdict.requestId}: ${(err as Error).message}\n`,
+        )
+        ok = false
+      }
+      log(`gw-trace dispatch deliverPermVerdict request=${effect.verdict.requestId} ok=${ok}\n`)
+      return
+    }
+
     case 'persistPermVerdict': {
-      log(`gw-trace dispatch not-yet-cutover effect=${effect.kind}\n`)
+      const ev = effect.verdict.payload as PermissionEvent
+      const pushed = ctx.pendingPermissionBuffer.push(ctx.selfAgent, ev)
+      log(`gw-trace dispatch persistPermVerdict request=${effect.verdict.requestId} pushed=${pushed}\n`)
+      return
+    }
+
+    case 'setTurnStarted': {
+      if (ctx.onSetTurnStarted) ctx.onSetTurnStarted(effect.key, effect.at)
+      else log(`gw-trace dispatch unwired effect=setTurnStarted key=${effect.key}\n`)
+      return
+    }
+
+    case 'clearTurnStarted': {
+      if (ctx.onClearTurnStarted) ctx.onClearTurnStarted(effect.key)
+      else log(`gw-trace dispatch unwired effect=clearTurnStarted key=${effect.key}\n`)
+      return
+    }
+
+    case 'noteOutbound': {
+      if (ctx.onNoteOutbound) ctx.onNoteOutbound(effect.key, effect.at)
+      else log(`gw-trace dispatch unwired effect=noteOutbound key=${effect.key}\n`)
+      return
+    }
+
+    case 'firePoke': {
+      if (ctx.onFirePoke) ctx.onFirePoke(effect.key, effect.level)
+      else log(`gw-trace dispatch unwired effect=firePoke key=${effect.key} level=${effect.level}\n`)
       return
     }
   }

--- a/telegram-plugin/tests/inbound-delivery-dispatch-equivalence.test.ts
+++ b/telegram-plugin/tests/inbound-delivery-dispatch-equivalence.test.ts
@@ -1,18 +1,13 @@
 /**
- * Dispatch-equivalence harness for the inbound-delivery state-machine
- * cutover (#2794 / #2996 Phase 1).
+ * Machine→dispatcher coverage + self-consistency harness for the
+ * inbound-delivery state-machine cutover (#2794 / #2996 Phase 1).
  *
- * The RFC's cutover protocol requires that BEFORE the imperative twins
- * (`markClaudeBusyForInbound`, `reapOrphanBusyKeysNow`, the legacy
- * `turnInFlightForGate` claudeBusyKeys branch) are deleted, we prove the
- * machine + dispatcher reproduce the same observable I/O the imperative
- * paths perform — in the same order.
+ * SCOPE — what this file proves, and what it deliberately does NOT:
  *
- * This harness does exactly that end-to-end WITHOUT touching production
- * behavior: it drives realistic event schedules (the same shapes the
- * gateway's `shadowEmit` call sites feed the machine — bridge flap,
- * fresh turn, mid-turn buffering, steering, turn-end drain, permission
- * verdicts across a bridge outage, stale-turn fallback) through the PURE
+ * It drives realistic event schedules (the same shapes the gateway's
+ * `shadowEmit` call sites feed the machine — bridge flap, fresh turn,
+ * mid-turn buffering, steering, turn-end drain, permission verdicts
+ * across a bridge outage, stale-turn fallback) through the PURE
  * `transition()` function, collects the returned effect sequence, then
  * replays that sequence through the REAL `dispatchEffects()` against a
  * recording fake-deps object. It asserts:
@@ -23,11 +18,17 @@
  *   3. Invariant #1 at the dispatch layer: an inbound is delivered XOR
  *      (buffered AND persisted) — never both, never neither.
  *
- * If a future edit to the machine adds an effect kind the dispatcher
- * doesn't execute, the "no unhandled effect" recorder assertion fails
- * loudly — the gate that lets PR3c flip the live call site to
- * `dispatchEffects` as a one-liner, and lets PR4 delete the twins
- * knowing the machine path is equivalent.
+ * It does NOT invoke the imperative twins (`markClaudeBusyForInbound`,
+ * the legacy `turnInFlightForGate` claudeBusyKeys branch,
+ * `dispatchPermissionVerdict`, the silence-poke ladder), so it is NOT a
+ * proof that machine path and imperative path produce identical I/O.
+ * Twin-equivalence evidence for PR4 (twin deletion) must come from the
+ * live shadow trace + gate-parity-probe bake per the RFC's cutover
+ * protocol — do NOT cite this file as that proof.
+ *
+ * What it DOES gate: if a future edit adds an effect kind the
+ * dispatcher doesn't execute, the "no unhandled effect" assertion fails
+ * loudly — keeping PR3c's live call-site flip a one-liner.
  */
 
 import { describe, expect, it } from 'vitest'
@@ -86,7 +87,7 @@ function makeRecorder(): Recorder {
     pendingPermissionBuffer: perm,
     client: client as never,
     log: () => {},
-    onUserInboundDelivered: () => {},
+    onUserInboundDelivered: (m) => ops.push(`enrol:${(m as { id?: string }).id}`),
     onSetTurnStarted: (key, at) => ops.push(`setTurn:${key}:${at}`),
     onClearTurnStarted: (key) => ops.push(`clearTurn:${key}`),
     onNoteOutbound: (key) => ops.push(`noteOutbound:${key}`),
@@ -135,6 +136,15 @@ const inMsg = (id: number, steer = false): MachineInbound => ({
   isSteering: steer,
   payload: { type: 'inbound', id: `m${id}`, chat_id: '1', text: `t${id}`, meta: { source: 'telegram' } },
 })
+// Real user inbound — NO meta.source. This is the primary live case:
+// shouldTrackDelivery (inbound-delivery-confirm.ts) only tracks
+// no-source messages, so fixtures that all carry a source would mask a
+// broken enrolment guard (the exact HIGH found in review of PR #3006).
+const userMsg = (id: number): MachineInbound => ({
+  msgId: id,
+  isSteering: false,
+  payload: { type: 'inbound', id: `m${id}`, chat_id: '1', text: `t${id}`, meta: {} },
+})
 const verdict = (r: string) => ({
   requestId: r,
   behavior: 'allow' as const,
@@ -175,6 +185,10 @@ const SCHEDULES: Record<string, Event[]> = {
     { kind: 'bridgeUp', at: 0 },
     { kind: 'inbound', key: K('1'), msg: inMsg(1), at: 10 },
     { kind: 'tick', now: 10 + 300_001 }, // past TURN_TTL, no outbound → firePoke
+  ],
+  fresh_turn_user_no_source: [
+    { kind: 'bridgeUp', at: 0 },
+    { kind: 'inbound', key: K('1'), msg: userMsg(1), at: 10 }, // real user inbound, no meta.source
   ],
   overlapping_turn_no_spurious_fallback: [
     { kind: 'bridgeUp', at: 0 },
@@ -283,6 +297,17 @@ describe('dispatch-equivalence: machine effects → dispatcher I/O', () => {
     dispatchEffects(effects, ctx)
     expect(ops).toContain('poke:1:_:fallback')
     expect(ops).toContain('clearTurn:1:_')
+  })
+
+  it('fresh_turn_user_no_source: a real user inbound (no meta.source) is delivered AND enrolled in the deliver-until-acked sweep', () => {
+    const { effects } = runMachine(SCHEDULES.fresh_turn_user_no_source)
+    const { ctx, ops } = makeRecorder()
+    dispatchEffects(effects, ctx)
+    expect(ops).toContain('send:inbound:m1')
+    // The enrolment callback MUST fire for no-source user inbounds —
+    // shouldTrackDelivery inside the gateway callback is the gate, not
+    // a dispatcher-side meta.source pre-filter (review HIGH, PR #3006).
+    expect(ops).toContain('enrol:m1')
   })
 
   it('overlapping_turn_no_spurious_fallback: recent outbound suppresses the poke', () => {

--- a/telegram-plugin/tests/inbound-delivery-dispatch-equivalence.test.ts
+++ b/telegram-plugin/tests/inbound-delivery-dispatch-equivalence.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Dispatch-equivalence harness for the inbound-delivery state-machine
+ * cutover (#2794 / #2996 Phase 1).
+ *
+ * The RFC's cutover protocol requires that BEFORE the imperative twins
+ * (`markClaudeBusyForInbound`, `reapOrphanBusyKeysNow`, the legacy
+ * `turnInFlightForGate` claudeBusyKeys branch) are deleted, we prove the
+ * machine + dispatcher reproduce the same observable I/O the imperative
+ * paths perform — in the same order.
+ *
+ * This harness does exactly that end-to-end WITHOUT touching production
+ * behavior: it drives realistic event schedules (the same shapes the
+ * gateway's `shadowEmit` call sites feed the machine — bridge flap,
+ * fresh turn, mid-turn buffering, steering, turn-end drain, permission
+ * verdicts across a bridge outage, stale-turn fallback) through the PURE
+ * `transition()` function, collects the returned effect sequence, then
+ * replays that sequence through the REAL `dispatchEffects()` against a
+ * recording fake-deps object. It asserts:
+ *
+ *   1. Every effect kind the machine can emit is handled by the
+ *      dispatcher (no silent no-op, no `unwired`/`not-yet-cutover` gap).
+ *   2. The observable side-effects fire in the machine's returned order.
+ *   3. Invariant #1 at the dispatch layer: an inbound is delivered XOR
+ *      (buffered AND persisted) — never both, never neither.
+ *
+ * If a future edit to the machine adds an effect kind the dispatcher
+ * doesn't execute, the "no unhandled effect" recorder assertion fails
+ * loudly — the gate that lets PR3c flip the live call site to
+ * `dispatchEffects` as a one-liner, and lets PR4 delete the twins
+ * knowing the machine path is equivalent.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  transition,
+  initialState,
+  type Effect,
+  type Event,
+  type State,
+  type ChatKey,
+  type InboundMessage as MachineInbound,
+} from '../gateway/inbound-delivery-machine'
+import {
+  dispatchEffects,
+  type DispatchCtx,
+} from '../gateway/inbound-delivery-machine-dispatch'
+import { createPendingInboundBuffer } from '../gateway/pending-inbound-buffer'
+import { createPendingPermissionBuffer } from '../gateway/pending-permission-decisions'
+
+// ── Recording fake deps ──────────────────────────────────────────────
+// Records every observable dispatcher action in call order so the test
+// can assert the effect→I/O mapping and its ordering.
+
+interface Recorder {
+  ctx: DispatchCtx
+  ops: string[]
+}
+
+function makeRecorder(): Recorder {
+  const ops: string[] = []
+  const inbound = createPendingInboundBuffer()
+  const perm = createPendingPermissionBuffer()
+  const client = {
+    id: 'c1',
+    agentName: 'test-agent',
+    send: (m: unknown) => {
+      const msg = m as { type?: string; id?: string; requestId?: string }
+      if (msg.type === 'permission_decision') ops.push(`send:perm:${msg.requestId}`)
+      else ops.push(`send:inbound:${msg.id}`)
+    },
+  }
+  const spoolPuts: string[] = []
+  const ctx: DispatchCtx = {
+    selfAgent: 'test-agent',
+    ipcServer: { sendToAgent: () => true } as never,
+    pendingInboundBuffer: inbound,
+    inboundSpool: {
+      put: (_agent: string, m: { id?: string }) => {
+        spoolPuts.push(m.id ?? '?')
+        ops.push(`persist:${m.id}`)
+        return true
+      },
+      ack: () => {},
+      liveEntries: () => [],
+    } as never,
+    pendingPermissionBuffer: perm,
+    client: client as never,
+    log: () => {},
+    onUserInboundDelivered: () => {},
+    onSetTurnStarted: (key, at) => ops.push(`setTurn:${key}:${at}`),
+    onClearTurnStarted: (key) => ops.push(`clearTurn:${key}`),
+    onNoteOutbound: (key) => ops.push(`noteOutbound:${key}`),
+    onFirePoke: (key, level) => ops.push(`poke:${key}:${level}`),
+  }
+  // bufferInbound goes through the real buffer; record via a wrapper.
+  const origPush = inbound.push.bind(inbound)
+  ;(inbound as { push: typeof inbound.push }).push = (agent, m) => {
+    ops.push(`buffer:${(m as { id?: string }).id}`)
+    return origPush(agent, m)
+  }
+  return { ctx, ops }
+}
+
+// A logging deps object that records the raw effect kinds a dispatch
+// pass would execute, so we can assert "no unhandled effect kind".
+function makeEffectKindProbe(): { ctx: DispatchCtx; seen: string[] } {
+  const seen: string[] = []
+  const ctx: DispatchCtx = {
+    selfAgent: 'test-agent',
+    ipcServer: { sendToAgent: () => true } as never,
+    pendingInboundBuffer: createPendingInboundBuffer(),
+    inboundSpool: { put: () => true, ack: () => {}, liveEntries: () => [] } as never,
+    pendingPermissionBuffer: createPendingPermissionBuffer(),
+    client: { id: 'c1', agentName: 'test-agent', send: () => {} } as never,
+    log: (line: string) => {
+      // The dispatcher must NEVER leave an effect unhandled. Two gap
+      // markers exist in the code; both are failures for a live cutover.
+      if (line.includes('not-yet-cutover') || line.includes('unwired')) {
+        seen.push(`GAP:${line.trim()}`)
+      }
+    },
+    onSetTurnStarted: () => {},
+    onClearTurnStarted: () => {},
+    onNoteOutbound: () => {},
+    onFirePoke: () => {},
+  }
+  return { ctx, seen }
+}
+
+// ── Event-schedule fixtures (mirror gateway shadowEmit call sites) ────
+
+const K = (chat: string, thread?: string): ChatKey => `${chat}:${thread ?? '_'}` as ChatKey
+const inMsg = (id: number, steer = false): MachineInbound => ({
+  msgId: id,
+  isSteering: steer,
+  payload: { type: 'inbound', id: `m${id}`, chat_id: '1', text: `t${id}`, meta: { source: 'telegram' } },
+})
+const verdict = (r: string) => ({
+  requestId: r,
+  behavior: 'allow' as const,
+  payload: { type: 'permission_decision', requestId: r, behavior: 'allow', updatedInput: {}, timestamp: 0 },
+})
+
+/** Named schedules that exercise every transition branch. */
+const SCHEDULES: Record<string, Event[]> = {
+  fresh_turn_then_end: [
+    { kind: 'bridgeUp', at: 0 },
+    { kind: 'inbound', key: K('1'), msg: inMsg(1), at: 10 },
+    { kind: 'turnEnd', key: K('1'), at: 20, outboundEmitted: true },
+  ],
+  mid_turn_buffer: [
+    { kind: 'bridgeUp', at: 0 },
+    { kind: 'inbound', key: K('1'), msg: inMsg(1), at: 10 },
+    { kind: 'inbound', key: K('1'), msg: inMsg(2), at: 15 }, // buffered
+    { kind: 'turnEnd', key: K('1'), at: 20, outboundEmitted: true },
+  ],
+  steering_mid_turn: [
+    { kind: 'bridgeUp', at: 0 },
+    { kind: 'inbound', key: K('1'), msg: inMsg(1), at: 10 },
+    { kind: 'inbound', key: K('1'), msg: inMsg(2, true), at: 15 }, // steer → deliver
+  ],
+  bridge_dead_buffer_then_recover: [
+    { kind: 'inbound', key: K('1'), msg: inMsg(1), at: 10 }, // bridge dead → buffer+persist
+    { kind: 'bridgeUp', at: 20 }, // drain
+  ],
+  perm_verdict_alive: [
+    { kind: 'bridgeUp', at: 0 },
+    { kind: 'permVerdict', verdict: verdict('rA'), at: 5 },
+  ],
+  perm_verdict_dead_then_recover: [
+    { kind: 'permVerdict', verdict: verdict('rB'), at: 5 }, // dead → persist
+    { kind: 'bridgeUp', at: 10 }, // redeliver
+  ],
+  stale_turn_fallback: [
+    { kind: 'bridgeUp', at: 0 },
+    { kind: 'inbound', key: K('1'), msg: inMsg(1), at: 10 },
+    { kind: 'tick', now: 10 + 300_001 }, // past TURN_TTL, no outbound → firePoke
+  ],
+  overlapping_turn_no_spurious_fallback: [
+    { kind: 'bridgeUp', at: 0 },
+    { kind: 'inbound', key: K('1'), msg: inMsg(1), at: 10 },
+    { kind: 'modelOutbound', key: K('1'), at: 10 + 300_000 }, // recent outbound
+    { kind: 'tick', now: 10 + 300_001 }, // suppressed by invariant #5
+  ],
+}
+
+// Run a schedule through the machine, returning the concatenated effect
+// stream in machine order.
+function runMachine(events: Event[]): { effects: Effect[]; finalState: State } {
+  let state = initialState()
+  const effects: Effect[] = []
+  for (const ev of events) {
+    const r = transition(state, ev)
+    state = r.state
+    effects.push(...r.effects)
+  }
+  return { effects, finalState: state }
+}
+
+describe('dispatch-equivalence: machine effects → dispatcher I/O', () => {
+  for (const [name, events] of Object.entries(SCHEDULES)) {
+    it(`'${name}': every emitted effect is handled by the dispatcher (no gap)`, () => {
+      const { effects } = runMachine(events)
+      const { ctx, seen } = makeEffectKindProbe()
+      dispatchEffects(effects, ctx)
+      expect(seen).toEqual([]) // no not-yet-cutover / unwired markers
+    })
+  }
+
+  it('fresh_turn_then_end replays in machine order: setTurn → send → noteOutbound/clearTurn', () => {
+    const { effects } = runMachine(SCHEDULES.fresh_turn_then_end)
+    const { ctx, ops } = makeRecorder()
+    dispatchEffects(effects, ctx)
+    // setTurnStarted precedes the deliver (downstream observer must see
+    // the turn marker up first), and turn-end clears + notes outbound.
+    expect(ops[0]).toBe('setTurn:1:_:10')
+    expect(ops[1]).toBe('send:inbound:m1')
+    expect(ops).toContain('clearTurn:1:_')
+    expect(ops).toContain('noteOutbound:1:_')
+    expect(ops.indexOf('setTurn:1:_:10')).toBeLessThan(ops.indexOf('send:inbound:m1'))
+  })
+
+  it('mid_turn_buffer: the second inbound is buffered+persisted, never delivered', () => {
+    const { effects } = runMachine(SCHEDULES.mid_turn_buffer)
+    const { ctx, ops } = makeRecorder()
+    dispatchEffects(effects, ctx)
+    // m1 delivered (fresh turn), m2 buffered+persisted (mid-turn).
+    expect(ops).toContain('send:inbound:m1')
+    expect(ops).toContain('buffer:m2')
+    expect(ops).toContain('persist:m2')
+    // Invariant #1 at the dispatch layer: buffer implies persist, same msg.
+    expect(ops.filter((o) => o === 'buffer:m2')).toHaveLength(1)
+    expect(ops.filter((o) => o === 'persist:m2')).toHaveLength(1)
+    // m2 is NOT delivered at receipt-time; if it is redelivered at all
+    // it happens via the turn-end drainBuffer, i.e. strictly AFTER the
+    // turn was cleared — never as an in-turn delivery.
+    const m2SendIdx = ops.indexOf('send:inbound:m2')
+    if (m2SendIdx !== -1) {
+      expect(m2SendIdx).toBeGreaterThan(ops.indexOf('clearTurn:1:_'))
+    }
+    expect(ops.indexOf('buffer:m2')).toBeLessThan(ops.indexOf('clearTurn:1:_'))
+  })
+
+  it('steering_mid_turn: a steer message is delivered mid-turn, not buffered', () => {
+    const { effects } = runMachine(SCHEDULES.steering_mid_turn)
+    const { ctx, ops } = makeRecorder()
+    dispatchEffects(effects, ctx)
+    expect(ops).toContain('send:inbound:m1')
+    expect(ops).toContain('send:inbound:m2')
+    expect(ops).not.toContain('buffer:m2')
+  })
+
+  it('bridge_dead_buffer_then_recover: buffer+persist while dead, drain on recover', () => {
+    const { effects } = runMachine(SCHEDULES.bridge_dead_buffer_then_recover)
+    const { ctx, ops } = makeRecorder()
+    dispatchEffects(effects, ctx)
+    // Buffered+persisted while dead; the drainBuffer effect at bridgeUp
+    // redelivers from the buffer → the recorded buffer push then a send.
+    expect(ops).toContain('buffer:m1')
+    expect(ops).toContain('persist:m1')
+    expect(ops).toContain('send:inbound:m1') // redelivered by drainBuffer
+  })
+
+  it('perm_verdict_alive: verdict delivered straight to the bridge', () => {
+    const { effects } = runMachine(SCHEDULES.perm_verdict_alive)
+    const { ctx, ops } = makeRecorder()
+    dispatchEffects(effects, ctx)
+    expect(ops).toContain('send:perm:rA')
+  })
+
+  it('perm_verdict_dead_then_recover: persisted while dead, redelivered on bridgeUp', () => {
+    const { effects } = runMachine(SCHEDULES.perm_verdict_dead_then_recover)
+    const { ctx, ops } = makeRecorder()
+    dispatchEffects(effects, ctx)
+    // Persisted while dead (no direct send at persist time), then the
+    // redeliverPersistedPermVerdicts effect at bridgeUp sends it.
+    expect(ops).toContain('send:perm:rB')
+  })
+
+  it('stale_turn_fallback: fires the fallback poke + clears the turn', () => {
+    const { effects } = runMachine(SCHEDULES.stale_turn_fallback)
+    const { ctx, ops } = makeRecorder()
+    dispatchEffects(effects, ctx)
+    expect(ops).toContain('poke:1:_:fallback')
+    expect(ops).toContain('clearTurn:1:_')
+  })
+
+  it('overlapping_turn_no_spurious_fallback: recent outbound suppresses the poke', () => {
+    const { effects } = runMachine(SCHEDULES.overlapping_turn_no_spurious_fallback)
+    const { ctx, ops } = makeRecorder()
+    dispatchEffects(effects, ctx)
+    // Invariant #5: the model broke silence within OUTBOUND_RECENT_MS,
+    // so NO fallback poke fires.
+    expect(ops.some((o) => o.startsWith('poke:'))).toBe(false)
+  })
+})
+
+describe('dispatch-equivalence: effect-kind coverage', () => {
+  it('the union of all schedule effects covers every machine effect kind that maps to I/O', () => {
+    const allKinds = new Set<string>()
+    for (const events of Object.values(SCHEDULES)) {
+      for (const e of runMachine(events).effects) allKinds.add(e.kind)
+    }
+    // Every kind produced by the fixtures must be one the dispatcher
+    // executes. logTrace is pure telemetry; the rest are I/O.
+    const expected = [
+      'deliverToBridge',
+      'bufferInbound',
+      'persistInbound',
+      'drainBuffer',
+      'setTurnStarted',
+      'clearTurnStarted',
+      'noteOutbound',
+      'firePoke',
+      'deliverPermVerdict',
+      'persistPermVerdict',
+      'redeliverPersistedPermVerdicts',
+    ]
+    for (const kind of expected) {
+      expect(allKinds.has(kind)).toBe(true)
+    }
+  })
+})

--- a/telegram-plugin/tests/inbound-delivery-machine-dispatch.test.ts
+++ b/telegram-plugin/tests/inbound-delivery-machine-dispatch.test.ts
@@ -22,6 +22,7 @@ import {
 import type { DispatchCtx } from '../gateway/inbound-delivery-machine-dispatch'
 import { createPendingInboundBuffer } from '../gateway/pending-inbound-buffer'
 import { createPendingPermissionBuffer } from '../gateway/pending-permission-decisions'
+import { createInboundSpool } from '../gateway/inbound-spool'
 
 function makeCtx(overrides?: Partial<DispatchCtx>): {
   ctx: DispatchCtx
@@ -207,6 +208,20 @@ describe('dispatchEffects — inbound-routing effects (PR3c wiring)', () => {
     expect(onUserInboundDelivered).toHaveBeenCalledWith(ipcMsg)
   })
 
+  it('deliverToBridge DOES pass the enrolment callback for a real user inbound (NO meta.source)', () => {
+    // The primary live case: real user messages carry NO meta.source,
+    // and they are exactly the messages shouldTrackDelivery tracks. A
+    // dispatcher-side pre-filter on meta.source would skip them (the
+    // review HIGH on PR #3006) — the callback must fire unconditionally
+    // and self-gate inside the gateway.
+    const noSourceMsg = { type: 'inbound' as const, id: 'u1', chat_id: '1', text: 'hi', meta: {} }
+    const onUserInboundDelivered = vi.fn()
+    const { ctx, clientSend } = makeCtx({ onUserInboundDelivered })
+    __dispatchOneForTests({ kind: 'deliverToBridge', key: k, msg: { msgId: 2, isSteering: false, payload: noSourceMsg } }, ctx)
+    expect(clientSend).toHaveBeenCalledWith(noSourceMsg)
+    expect(onUserInboundDelivered).toHaveBeenCalledWith(noSourceMsg)
+  })
+
   it('bufferInbound pushes onto the pending inbound buffer', () => {
     const { ctx, inbound, clientSend } = makeCtx()
     __dispatchOneForTests({ kind: 'bufferInbound', key: k, msg: { msgId: 1, isSteering: false, payload: ipcMsg } }, ctx)
@@ -226,6 +241,45 @@ describe('dispatchEffects — inbound-routing effects (PR3c wiring)', () => {
     expect(() =>
       __dispatchOneForTests({ kind: 'persistInbound', key: k, msg: { msgId: 1, isSteering: false, payload: ipcMsg } }, ctx),
     ).not.toThrow()
+  })
+
+  it('bufferInbound + persistInbound with a spool attached to the buffer does NOT double-spool (idempotent by spoolId)', () => {
+    // The machine emits bufferInbound AND persistInbound as a pair for a
+    // mid-turn / bridge-dead inbound. When the ctx's buffer is
+    // constructed with the SAME durable spool (the production wiring),
+    // buffer.push already spools — so the paired persistInbound's
+    // spool.put must dedupe by spoolId, leaving exactly ONE live entry.
+    const spoolPath = '/state/agent/telegram/inbound-spool.jsonl'
+    const files = new Map<string, string>()
+    const fs = {
+      appendFileSync: (p: string, d: string) => files.set(p, (files.get(p) ?? '') + d),
+      readFileSync: (p: string) => files.get(p) ?? '',
+      writeFileSync: (p: string, d: string) => files.set(p, d),
+      renameSync: (from: string, to: string) => {
+        files.set(to, files.get(from) ?? '')
+        files.delete(from)
+      },
+      existsSync: (p: string) => files.has(p),
+      statSizeSync: (p: string) => Buffer.byteLength(files.get(p) ?? ''),
+    }
+    const spool = createInboundSpool({ path: spoolPath, fs, log: () => {} })
+    const buffer = createPendingInboundBuffer({ spool, log: () => {} })
+    const { ctx } = makeCtx({ pendingInboundBuffer: buffer, inboundSpool: spool })
+    // Spool-identifiable message shape (spoolId reads chatId/messageId).
+    const durableMsg = {
+      type: 'inbound' as const,
+      chatId: 'c1',
+      messageId: 77,
+      user: 'u',
+      userId: 1,
+      ts: 1000,
+      text: 'hold me',
+      meta: {},
+    }
+    __dispatchOneForTests({ kind: 'bufferInbound', key: k, msg: { msgId: 77, isSteering: false, payload: durableMsg } }, ctx)
+    __dispatchOneForTests({ kind: 'persistInbound', key: k, msg: { msgId: 77, isSteering: false, payload: durableMsg } }, ctx)
+    expect(buffer.depth('test-agent')).toBe(1)
+    expect(spool.liveCount()).toBe(1) // no double-spool
   })
 })
 

--- a/telegram-plugin/tests/inbound-delivery-machine-dispatch.test.ts
+++ b/telegram-plugin/tests/inbound-delivery-machine-dispatch.test.ts
@@ -22,7 +22,6 @@ import {
 import type { DispatchCtx } from '../gateway/inbound-delivery-machine-dispatch'
 import { createPendingInboundBuffer } from '../gateway/pending-inbound-buffer'
 import { createPendingPermissionBuffer } from '../gateway/pending-permission-decisions'
-import type { Effect } from '../gateway/inbound-delivery-machine'
 
 function makeCtx(overrides?: Partial<DispatchCtx>): {
   ctx: DispatchCtx
@@ -184,57 +183,93 @@ describe('dispatchEffects — kill switch', () => {
   })
 })
 
-describe('dispatchOne — not-yet-cutover effects log without throwing', () => {
-  const notYet: Effect['kind'][] = [
-    'deliverToBridge',
-    'bufferInbound',
-    'persistInbound',
-    'setTurnStarted',
-    'clearTurnStarted',
-    'noteOutbound',
-    'firePoke',
-    'deliverPermVerdict',
-    'persistPermVerdict',
-  ]
+describe('dispatchEffects — inbound-routing effects (PR3c wiring)', () => {
+  const k = 'c1:_' as never
+  const ipcMsg = { type: 'inbound' as const, id: 'm1', chat_id: '1', text: 'hi', meta: { source: 'telegram' } }
 
-  for (const kind of notYet) {
-    it(`'${kind}' logs not-yet-cutover and does NOT touch primitives`, () => {
-      const { ctx, sendToAgent, clientSend, logs } = makeCtx()
-      // Construct a minimal valid effect for each kind. Most carry a
-      // payload that the dispatcher ignores in this PR.
-      const effect = synthesizeNotYetCutoverEffect(kind)
-      expect(() => __dispatchOneForTests(effect, ctx)).not.toThrow()
-      expect(sendToAgent).not.toHaveBeenCalled()
-      expect(clientSend).not.toHaveBeenCalled()
-      expect(logs.some((l) => l.includes(`not-yet-cutover effect=${kind}`))).toBe(true)
-    })
-  }
+  it('deliverToBridge sends the payload to the client', () => {
+    const { ctx, clientSend } = makeCtx()
+    __dispatchOneForTests({ kind: 'deliverToBridge', key: k, msg: { msgId: 1, isSteering: false, payload: ipcMsg } }, ctx)
+    expect(clientSend).toHaveBeenCalledTimes(1)
+    expect(clientSend).toHaveBeenCalledWith(ipcMsg)
+  })
+
+  it('deliverToBridge falls back to ipcServer.sendToAgent with no client', () => {
+    const { ctx, sendToAgent } = makeCtx({ client: undefined })
+    __dispatchOneForTests({ kind: 'deliverToBridge', key: k, msg: { msgId: 1, isSteering: false, payload: ipcMsg } }, ctx)
+    expect(sendToAgent).toHaveBeenCalledWith('test-agent', ipcMsg)
+  })
+
+  it('deliverToBridge enrols in the deliver-until-acked sweep', () => {
+    const onUserInboundDelivered = vi.fn()
+    const { ctx } = makeCtx({ onUserInboundDelivered })
+    __dispatchOneForTests({ kind: 'deliverToBridge', key: k, msg: { msgId: 1, isSteering: false, payload: ipcMsg } }, ctx)
+    expect(onUserInboundDelivered).toHaveBeenCalledWith(ipcMsg)
+  })
+
+  it('bufferInbound pushes onto the pending inbound buffer', () => {
+    const { ctx, inbound, clientSend } = makeCtx()
+    __dispatchOneForTests({ kind: 'bufferInbound', key: k, msg: { msgId: 1, isSteering: false, payload: ipcMsg } }, ctx)
+    expect(inbound.depth('test-agent')).toBe(1)
+    expect(clientSend).not.toHaveBeenCalled()
+  })
+
+  it('persistInbound puts to the spool when one is attached', () => {
+    const put = vi.fn(() => true)
+    const { ctx } = makeCtx({ inboundSpool: { put } as never })
+    __dispatchOneForTests({ kind: 'persistInbound', key: k, msg: { msgId: 1, isSteering: false, payload: ipcMsg } }, ctx)
+    expect(put).toHaveBeenCalledWith('test-agent', ipcMsg)
+  })
+
+  it('persistInbound is a safe no-op when no spool is attached', () => {
+    const { ctx } = makeCtx({ inboundSpool: null })
+    expect(() =>
+      __dispatchOneForTests({ kind: 'persistInbound', key: k, msg: { msgId: 1, isSteering: false, payload: ipcMsg } }, ctx),
+    ).not.toThrow()
+  })
 })
 
-function synthesizeNotYetCutoverEffect(kind: Effect['kind']): Effect {
+describe('dispatchEffects — perm-verdict effects', () => {
+  const permEv = { type: 'permission_decision' as const, requestId: 'r1', behavior: 'allow' as const, updatedInput: {}, timestamp: 0 }
+
+  it('deliverPermVerdict sends the payload to the client', () => {
+    const { ctx, clientSend } = makeCtx()
+    __dispatchOneForTests({ kind: 'deliverPermVerdict', verdict: { requestId: 'r1', behavior: 'allow', payload: permEv } }, ctx)
+    expect(clientSend).toHaveBeenCalledWith(permEv)
+  })
+
+  it('persistPermVerdict pushes onto the pending permission buffer', () => {
+    const { ctx, perm, clientSend } = makeCtx()
+    __dispatchOneForTests({ kind: 'persistPermVerdict', verdict: { requestId: 'r1', behavior: 'allow', payload: permEv } }, ctx)
+    expect(clientSend).not.toHaveBeenCalled()
+    expect(perm.drain('test-agent')).toEqual([permEv])
+  })
+})
+
+describe('dispatchEffects — turn/poke callbacks', () => {
   const k = 'c1:_' as never
-  const msg = { msgId: 1, isSteering: false, payload: null } as never
-  const verdict = { requestId: 'r', behavior: 'allow' as const, payload: null } as never
-  switch (kind) {
-    case 'deliverToBridge':
-      return { kind, key: k, msg }
-    case 'bufferInbound':
-      return { kind, key: k, msg }
-    case 'persistInbound':
-      return { kind, key: k, msg }
-    case 'setTurnStarted':
-      return { kind, key: k, at: 0 }
-    case 'clearTurnStarted':
-      return { kind, key: k }
-    case 'noteOutbound':
-      return { kind, key: k, at: 0 }
-    case 'firePoke':
-      return { kind, key: k, level: 'fallback' }
-    case 'deliverPermVerdict':
-      return { kind, verdict }
-    case 'persistPermVerdict':
-      return { kind, verdict }
-    default:
-      throw new Error(`unreachable: ${kind}`)
-  }
-}
+
+  it('setTurnStarted / clearTurnStarted / noteOutbound / firePoke fire their callbacks', () => {
+    const onSetTurnStarted = vi.fn()
+    const onClearTurnStarted = vi.fn()
+    const onNoteOutbound = vi.fn()
+    const onFirePoke = vi.fn()
+    const { ctx } = makeCtx({ onSetTurnStarted, onClearTurnStarted, onNoteOutbound, onFirePoke })
+    __dispatchOneForTests({ kind: 'setTurnStarted', key: k, at: 7 }, ctx)
+    __dispatchOneForTests({ kind: 'clearTurnStarted', key: k }, ctx)
+    __dispatchOneForTests({ kind: 'noteOutbound', key: k, at: 9 }, ctx)
+    __dispatchOneForTests({ kind: 'firePoke', key: k, level: 'fallback' }, ctx)
+    expect(onSetTurnStarted).toHaveBeenCalledWith(k, 7)
+    expect(onClearTurnStarted).toHaveBeenCalledWith(k)
+    expect(onNoteOutbound).toHaveBeenCalledWith(k, 9)
+    expect(onFirePoke).toHaveBeenCalledWith(k, 'fallback')
+  })
+
+  it('logs an `unwired` trace (never silently no-ops) when a callback is absent', () => {
+    const { ctx, logs } = makeCtx()
+    __dispatchOneForTests({ kind: 'setTurnStarted', key: k, at: 0 }, ctx)
+    __dispatchOneForTests({ kind: 'firePoke', key: k, level: 'soft' }, ctx)
+    expect(logs.some((l) => l.includes('unwired effect=setTurnStarted'))).toBe(true)
+    expect(logs.some((l) => l.includes('unwired effect=firePoke'))).toBe(true)
+  })
+})


### PR DESCRIPTION
## What this is

Phase 1 of the `gateway.ts` decomposition (#2996 §3A) = advancing #2794's finish-the-cutover checklist. It does the **harness-first** groundwork the RFC's cutover protocol mandates and wires the remaining state-machine effects to real executors, **without** deleting the imperative twins (which the RFC gates behind a live bake — see Residual below).

## What cut over / landed

**1. Machine→dispatcher coverage + self-consistency harness (new, landed FIRST)** — `telegram-plugin/tests/inbound-delivery-dispatch-equivalence.test.ts`. Drives realistic event schedules (bridge flap, fresh turn, mid-turn buffering, steering, turn-end drain, perm verdicts across a bridge outage, stale-turn fallback + invariant-#5 suppression, and a no-`meta.source` real-user-inbound case) through the pure `transition()`, then replays the returned effect sequence through the real `dispatchEffects()` against a recording fake-deps object. Asserts: every emitted effect kind is handled (no `not-yet-cutover`/`unwired` gap), observable I/O fires in machine order, and invariant #1 (deliver XOR buffer+persist) holds at the dispatch layer.

**Scope honesty (per adversarial review):** this harness does NOT invoke the imperative twins, so it is coverage/self-consistency evidence, **not** a machine-vs-imperative equivalence proof. Twin-equivalence for PR4 (twin deletion) must come from the live shadow trace + `gate-parity-probe` bake per the RFC — PR4 must not cite this file as that proof.

**2. Remaining effects wired to real executors** — `inbound-delivery-machine-dispatch.ts`. Previously only the bridgeUp effects (`drainBuffer` / `redeliverPersistedPermVerdicts` / `logTrace`) executed; all others logged `not-yet-cutover`. Now every effect kind executes:
- `deliverToBridge` → `client.send` / `ipcServer.sendToAgent`, with **unconditional** deliver-until-acked enrolment (the gateway callback self-gates via `shouldTrackDelivery`)
- `bufferInbound` → `pendingInboundBuffer.push`
- `persistInbound` → `inboundSpool.put` (idempotent by spoolId — now test-proven, no double-spool when the buffer shares the spool)
- `deliverPermVerdict` → bridge send (client-first only on the bridgeUp path; documented — PR3c's non-bridgeUp ctx must omit `client`, making it behave exactly like the imperative twin's `sendToAgent`); `persistPermVerdict` → `pendingPermissionBuffer.push`
- `setTurnStarted`/`clearTurnStarted`/`noteOutbound`/`firePoke` → optional gateway-supplied callbacks (gateway-scope `claudeBusyKeys`/silence-poke state). Absent callback logs an `unwired` trace — **never a silent no-op**.

## Adversarial-review findings addressed (commit 739b2456)

- **HIGH** — deliver-until-acked enrolment guard was inverted (`msg.meta?.source !== undefined` enrolled only sourced messages, which `shouldTrackDelivery` discards, and skipped real user inbounds). Fixed: callback passed unconditionally, mirroring the drainBuffer path; inner gate is authoritative.
- **MEDIUM** — equivalence-test header + this PR body no longer overclaim twin-equivalence (see scope honesty above).
- **MEDIUM** — all inbound fixtures carried `meta.source`, masking the HIGH. Added no-source fixtures in both test files, including a unit test asserting `deliverToBridge` DOES pass the enrolment callback for a no-source inbound.
- **LOW** — documented the `deliverPermVerdict` client-first branch order vs the imperative twin (`dispatchPermissionVerdict` → `sendToAgent`) and what PR3c must supply; noted the twin's failed-send buffering maps to the machine's separate `persistPermVerdict` effect.
- **LOW** — added a real-spool test proving `bufferInbound`+`persistInbound` with a shared spool leaves exactly one live entry (no double-spool).

## What got deleted

Nothing from the production imperative paths (see Residual). Deleted only the obsolete `not-yet-cutover` unit-test block in `inbound-delivery-machine-dispatch.test.ts`, replaced with real-execution assertions.

## Kill-switch semantics (unchanged)

`SWITCHROOM_DELIVERY_MACHINE_CUTOVER=0` still reverts the dispatcher to a no-op and the gateway to imperative-only. `gateway.ts` still calls `dispatchEffects()` **only** with the bridgeUp effect set, so the newly-wired effect kinds are never reached at runtime yet — no double-execution against the still-live imperative twins, zero production behavior change.

## Residual / deliberately deferred (per the RFC's own protocol)

The RFC `reference/rfcs/inbound-delivery-state-machine.md` "Hard removal plan" checklist gates twin deletion behind **PR3b (turnEnd cutover) + PR3c (inbound routing cutover) baking 48h on live fleet traffic**. Those flips (`handleInbound` dispatching an inbound Event; `endCurrentTurnAtomic` dispatching turnEnd) are behavior cutovers that need shadow-trace validation over a bake window that cannot be performed inside one un-baked PR. Deleting `markClaudeBusyForInbound`, `reapOrphanBusyKeysNow`, the legacy `turnInFlightForGate` claudeBusyKeys branch, `gate-parity-probe.ts`, and the shadow-comparison path **now** would break both the kill-switch fallback and the still-imperative live delivery path.

Remaining checklist (mechanical call-site flips backed by the wired dispatcher):
- [ ] PR3b step 2 — `endCurrentTurnAtomic` dispatches `turnEnd` (wiring ready)
- [ ] PR3c — `handleInbound` dispatches inbound Event (deliver/buffer wiring ready)
- [ ] PR4 — after live shadow-trace + gate-parity bake, delete twins + `gate-parity-probe.ts` + shadow path

## Test evidence

- Changed-area suites green (110 tests): `inbound-delivery-dispatch-equivalence` (19), `inbound-delivery-machine-dispatch` (21), `inbound-delivery-machine` property tests (7), `inbound-delivery-cutover-gate` (6), `inbound-delivery-gate` (10), `inbound-delivery-confirm` (40), `rapid-fire-delivery-ordering`.
- Full `telegram-plugin/tests` run: **5128 tests passed**. (17 `render/*` test *files* fail to load with `Cannot find package 'mdast-util-from-markdown'` — a bun-hoisted-`node_modules` resolution artifact of the local worktree symlink, unrelated to this diff, which touches none of the render path. CI is the arbiter for those.)
- `tsc --noEmit` clean.
- `gateway.ts` untouched, so the file:line-keyed `check-bot-api-wrapping` allowlist does not shift.

Refs #2794 #2996

🤖 Generated with [Claude Code](https://claude.com/claude-code)