### PR TITLE
refactor(telegram): approval-card pending state behind store modules (#2996)

### DIFF
--- a/telegram-plugin/gateway/approval-card-stores.ts
+++ b/telegram-plugin/gateway/approval-card-stores.ts
@@ -1,0 +1,99 @@
+/**
+ * In-memory storage for the four AGENT-INITIATED approval-card families
+ * (vault_request_access / vault_request_save / request_secret /
+ * mental_model_propose), extracted from gateway.ts (Phase 3 step 1 of the
+ * gateway decomposition — see #2996). STORAGE ONLY: the per-card expiry LOGIC
+ * (card edits, timeout synthetics, missed-approval re-offers) still lives in
+ * gateway.ts and is injected here as `expire`. This module owns the Map
+ * lifecycle and CO-LOCATES the TTL sweep next to the storage it sweeps, so the
+ * gateway's authoritative `pendingStateReaper` calls a single `store.sweep(now)`
+ * delegation instead of open-coding a `sweepExpiredEntries(...)` per family.
+ *
+ * Why a Map-compatible surface (get/set/delete/has/iteration) rather than a
+ * bespoke API: every existing gateway call site — the callback-query handlers,
+ * the executor add-sites, and `restorePendingApprovalCards` — used the raw Map
+ * directly. Preserving the exact Map method surface keeps those call sites
+ * BYTE-IDENTICAL (the variable name and every `.get`/`.set`/`.delete`/`for..of`
+ * are unchanged), which is the invariant this phase must not break: the store
+ * moves WHERE the Map is constructed and WHERE its sweep lives, nothing about
+ * how the gateway reads or writes it. Restore semantics are therefore untouched.
+ *
+ * Race contract preserved (pinned by approval-card-stores.test.ts):
+ *   - A verdict (operator tap → `.delete(stageId)`) arriving DURING an expiry
+ *     sweep is single-shot-safe: the pure `expirePendingCard` core removes the
+ *     entry before any fallible side effect, so the same card can never both
+ *     expire and resolve. The store's `sweep` is a thin pass-through to that
+ *     core via `sweepExpiredEntries`, so the ordering guarantee is unchanged.
+ *   - A verdict arriving DURING restore is a plain `.set`/`.delete` on the same
+ *     Map instance the restore populates — no separate storage to desync.
+ *   - The shared reaper cadence is unchanged: `sweep(now)` performs exactly the
+ *     work the old `sweepPendingX(now)` free functions did, in the same order.
+ *
+ * `expire` and `log` are supplied as THUNKS so a store constructed early in
+ * gateway module-eval can reference the hoisted `expire*Card` functions and the
+ * `const cardExpiryLog` arrow (which is in the temporal dead zone at
+ * construction time); both are resolved lazily at sweep time.
+ */
+
+import { sweepExpiredEntries } from './pending-card-expiry.js'
+
+export interface SweepableCardStore<T> {
+  get(stageId: string): T | undefined
+  set(stageId: string, value: T): void
+  delete(stageId: string): boolean
+  has(stageId: string): boolean
+  clear(): void
+  readonly size: number
+  keys(): IterableIterator<string>
+  values(): IterableIterator<T>
+  entries(): IterableIterator<[string, T]>
+  forEach(cb: (value: T, key: string, map: Map<string, T>) => void): void
+  [Symbol.iterator](): IterableIterator<[string, T]>
+  /**
+   * Expire every entry past its TTL. Delegates to the same pure
+   * `sweepExpiredEntries` core the gateway used inline, so per-entry
+   * fault-isolation and single-shot ordering are byte-identical.
+   */
+  sweep(now: number): void
+}
+
+export interface SweepableCardStoreDeps<T> {
+  /** Predicate: is this entry past its TTL at `now`? Closes over the family TTL. */
+  isExpired: (value: T, now: number) => boolean
+  /**
+   * Per-entry expiry action (card strip + timeout synthetic + missed-approval
+   * re-offer). A THUNK so it can reference gateway functions that are hoisted /
+   * defined after this store is constructed. Called once per expired entry.
+   */
+  expire: () => (stageId: string, value: T, now: number) => void
+  /** Error sink thunk (resolves the gateway's `cardExpiryLog` lazily). */
+  log: () => (msg: string) => void
+}
+
+/**
+ * Create a Map-backed, self-sweeping store for one approval-card family.
+ * The backing Map is the sole storage; the returned object forwards the Map
+ * surface the gateway uses plus a co-located `sweep`.
+ */
+export function createSweepableCardStore<T>(
+  deps: SweepableCardStoreDeps<T>,
+): SweepableCardStore<T> {
+  const map = new Map<string, T>()
+  return {
+    get: (stageId) => map.get(stageId),
+    set: (stageId, value) => void map.set(stageId, value),
+    delete: (stageId) => map.delete(stageId),
+    has: (stageId) => map.has(stageId),
+    clear: () => map.clear(),
+    get size() {
+      return map.size
+    },
+    keys: () => map.keys(),
+    values: () => map.values(),
+    entries: () => map.entries(),
+    forEach: (cb) => map.forEach(cb),
+    [Symbol.iterator]: () => map[Symbol.iterator](),
+    sweep: (now) =>
+      sweepExpiredEntries(map, deps.isExpired, deps.expire(), now, deps.log()),
+  }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -135,7 +135,8 @@ import {
   buildSecretRequestTimeoutInbound,
   buildMentalModelProposeTimeoutInbound,
 } from './approval-timeout-inbound-builders.js'
-import { expirePendingCard, sweepExpiredEntries } from './pending-card-expiry.js'
+import { expirePendingCard } from './pending-card-expiry.js'
+import { createSweepableCardStore } from './approval-card-stores.js'
 import {
   isPermissionRearmEnabled,
   permissionRearmGraceMs,
@@ -5729,20 +5730,20 @@ interface PendingVaultRequestSave {
    *  the value was lost to a restart instead of writing an empty secret. */
   restoredWithoutValue?: boolean
 }
-const pendingVaultRequestSaves = new Map<string, PendingVaultRequestSave>()
 // Gateway-side reap window for a staged vault-save card. Tracks the operator
 // approval-card lifetime (config-driven, 60-min default) so the reap never
 // races ahead of the card the operator is still looking at.
 const VAULT_REQUEST_SAVE_TTL_MS = approvalTtlMs()
-function sweepPendingVaultRequestSaves(now = Date.now()): void {
-  sweepExpiredEntries(
-    pendingVaultRequestSaves,
-    (v, n) => v.staged_at < n - VAULT_REQUEST_SAVE_TTL_MS,
-    expireVaultSaveCard,
-    now,
-    cardExpiryLog,
-  )
-}
+// Storage extracted to approval-card-stores.ts (#2996 Phase 3): the store owns
+// the Map + co-locates the TTL sweep (`.sweep(now)`); expiry LOGIC
+// (expireVaultSaveCard) is still gateway-side, injected as a thunk. Call sites
+// (get/set/delete/iteration/restore) are byte-identical — same variable, same
+// Map surface.
+const pendingVaultRequestSaves = createSweepableCardStore<PendingVaultRequestSave>({
+  isExpired: (v, n) => v.staged_at < n - VAULT_REQUEST_SAVE_TTL_MS,
+  expire: () => expireVaultSaveCard,
+  log: () => cardExpiryLog,
+})
 
 /**
  * Issue #1012 — agent-initiated vault ACL request. The agent calls
@@ -5780,19 +5781,16 @@ interface PendingVaultRequestAccess {
   /** Unix-ms timestamp; entries are reaped after VAULT_REQUEST_ACCESS_TTL_MS. */
   staged_at: number
 }
-const pendingVaultRequestAccesses = new Map<string, PendingVaultRequestAccess>()
 // Gateway-side reap window for a staged vault-access card. Tracks the operator
 // approval-card lifetime (config-driven, 60-min default) — see approvalTtlMs.
 const VAULT_REQUEST_ACCESS_TTL_MS = approvalTtlMs()
-function sweepPendingVaultRequestAccesses(now = Date.now()): void {
-  sweepExpiredEntries(
-    pendingVaultRequestAccesses,
-    (v, n) => v.staged_at < n - VAULT_REQUEST_ACCESS_TTL_MS,
-    expireVaultAccessCard,
-    now,
-    cardExpiryLog,
-  )
-}
+// Storage extracted to approval-card-stores.ts (#2996 Phase 3) — see the
+// vault-save store above for the pattern.
+const pendingVaultRequestAccesses = createSweepableCardStore<PendingVaultRequestAccess>({
+  isExpired: (v, n) => v.staged_at < n - VAULT_REQUEST_ACCESS_TTL_MS,
+  expire: () => expireVaultAccessCard,
+  log: () => cardExpiryLog,
+})
 
 /**
  * Staged agent-initiated MENTAL MODEL proposal (hindsight Phase 5). The agent
@@ -5817,21 +5815,18 @@ interface PendingMentalModelPropose {
   reason?: string
   staged_at: number
 }
-const pendingMentalModelProposes = new Map<string, PendingMentalModelPropose>()
 const MENTAL_MODEL_PROPOSE_TTL_MS = approvalTtlMs()
-// Sweep expired pending proposals. For any entry past its TTL we ALSO edit the
-// posted card's keyboard away, so a stale card left in the chat can't be tapped
-// into a "Card expired" answer — the operator sees the ⌛ expiry inline instead.
-// Best-effort: card edits are fire-and-forget (the entry is removed regardless).
-function sweepPendingMentalModelProposes(now = Date.now()): void {
-  sweepExpiredEntries(
-    pendingMentalModelProposes,
-    (v, n) => v.staged_at < n - MENTAL_MODEL_PROPOSE_TTL_MS,
-    expireMentalModelProposeCard,
-    now,
-    cardExpiryLog,
-  )
-}
+// Storage extracted to approval-card-stores.ts (#2996 Phase 3). The store's
+// `.sweep(now)` expires past-TTL proposals; for any expired entry the injected
+// expireMentalModelProposeCard ALSO edits the posted card's keyboard away, so a
+// stale card left in the chat can't be tapped into a "Card expired" answer — the
+// operator sees the ⌛ expiry inline instead. Best-effort: card edits are
+// fire-and-forget (the entry is removed regardless).
+const pendingMentalModelProposes = createSweepableCardStore<PendingMentalModelPropose>({
+  isExpired: (v, n) => v.staged_at < n - MENTAL_MODEL_PROPOSE_TTL_MS,
+  expire: () => expireMentalModelProposeCard,
+  log: () => cardExpiryLog,
+})
 
 // Sliding-window rate limit for mental-model proposals: at most
 // MENTAL_MODEL_PROPOSE_MAX_PER_WINDOW cards per MENTAL_MODEL_PROPOSE_WINDOW_MS.
@@ -6275,9 +6270,9 @@ function expireMentalModelProposeCard(stageId: string, v: PendingMentalModelProp
 // per-entry guarded via sweepExpiredEntries, so one throwing expiry (dead IPC
 // socket, store IO error) can't skip the remaining entries or families.
 function sweepExpiredApprovalCards(now: number): void {
-  sweepPendingVaultRequestAccesses(now)
-  sweepPendingVaultRequestSaves(now)
-  sweepPendingMentalModelProposes(now)
+  pendingVaultRequestAccesses.sweep(now)
+  pendingVaultRequestSaves.sweep(now)
+  pendingMentalModelProposes.sweep(now)
   sweepSecretRequests(now)
 }
 
@@ -12742,23 +12737,23 @@ interface PendingSecretRequest {
    *  in that topic, not General. */
   threadId?: number
 }
-// stageId -> request (lives until tapped or TTL).
-const pendingSecretRequests = new Map<string, PendingSecretRequest>()
 // chat_id -> the armed capture: the operator's NEXT message in this chat is
 // the value for `key`. Set when [Provide securely] is tapped.
 interface ArmedSecretCapture { key: string; agent: string; stageId: string; armed_at: number; threadId?: number }
 const armedSecretCaptures = new Map<string, ArmedSecretCapture>()
 const PENDING_SECRET_REQUEST_TTL_MS = 30 * 60_000 // card lifetime
 const ARMED_SECRET_CAPTURE_TTL_MS = 10 * 60_000   // window to send the value after tapping
+// stageId -> request (lives until tapped or TTL). Storage extracted to
+// approval-card-stores.ts (#2996 Phase 3): the store owns the Map + co-locates
+// the TTL sweep; expireSecretRequestCard (the wake logic) stays gateway-side.
+const pendingSecretRequests = createSweepableCardStore<PendingSecretRequest>({
+  isExpired: (v, n) => n - v.staged_at > PENDING_SECRET_REQUEST_TTL_MS,
+  expire: () => expireSecretRequestCard,
+  log: () => cardExpiryLog,
+})
 
 function sweepSecretRequests(now = Date.now()): void {
-  sweepExpiredEntries(
-    pendingSecretRequests,
-    (v, n) => n - v.staged_at > PENDING_SECRET_REQUEST_TTL_MS,
-    expireSecretRequestCard,
-    now,
-    cardExpiryLog,
-  )
+  pendingSecretRequests.sweep(now)
   // armedSecretCaptures is a TRANSIENT post-tap window (never persisted): it's
   // only set after the operator taps [Provide securely], and the request is
   // no longer parked-on-a-card. Just drop stale ones — no wake needed.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -12669,7 +12669,7 @@ async function executeVaultRequestSave(args: Record<string, unknown>): Promise<{
     staged_at: Date.now(),
   }
   pendingVaultRequestSaves.set(stageId, pending)
-  sweepPendingVaultRequestSaves()
+  pendingVaultRequestSaves.sweep(Date.now())
 
   // Send the approval card. #1075: route through retryWithThreadFallback
   // so a deleted topic still lands the card on the main chat instead of
@@ -13159,7 +13159,7 @@ async function executeVaultRequestAccess(args: Record<string, unknown>): Promise
     staged_at: Date.now(),
   }
   pendingVaultRequestAccesses.set(stageId, pending)
-  sweepPendingVaultRequestAccesses()
+  pendingVaultRequestAccesses.sweep(Date.now())
 
   // renderVaultRequestAccessCard self-hardens its field line breaks (this card
   // is sent direct, bypassing the switchroomReply chokepoint).
@@ -13341,7 +13341,7 @@ async function executeMentalModelPropose(args: Record<string, unknown>): Promise
     staged_at: Date.now(),
   }
   pendingMentalModelProposes.set(stageId, pending)
-  sweepPendingMentalModelProposes()
+  pendingMentalModelProposes.sweep(Date.now())
 
   const text = renderMentalModelProposeCard({
     agent: agentSlug,

--- a/telegram-plugin/tests/approval-card-stores.test.ts
+++ b/telegram-plugin/tests/approval-card-stores.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Race/ordering pins for the in-memory approval-card stores
+ * (gateway/approval-card-stores.ts) extracted in #2996 Phase 3 step 1.
+ *
+ * These lock the exact orderings the gateway's reaper + callback handlers +
+ * boot restore depend on, BEFORE the storage moved behind the store module:
+ *
+ *   1. verdict-during-sweep is single-shot — an operator tap (`.delete`) that
+ *      lands while the sweep is iterating fires the expiry synthetic AT MOST
+ *      once for a given card; a second sweep tick never double-wakes it.
+ *   2. verdict-during-restore is desync-free — a `.set` (restore) then a
+ *      `.delete` (tap) operate on one Map instance, so a tap can't resurrect a
+ *      restored entry nor a restore resurrect a tapped one.
+ *   3. sweep cadence/fault-isolation is byte-identical to the old inline
+ *      `sweepExpiredEntries(...)`: only past-TTL entries expire, and one
+ *      throwing expiry never skips the remaining entries.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createSweepableCardStore,
+  type SweepableCardStore,
+} from '../gateway/approval-card-stores.js'
+
+interface Card {
+  staged_at: number
+  agent: string
+}
+
+const TTL = 1000
+
+function makeStore(
+  expire: (stageId: string, v: Card, now: number) => void,
+  log: (msg: string) => void = () => {},
+): SweepableCardStore<Card> {
+  return createSweepableCardStore<Card>({
+    isExpired: (v, now) => now - v.staged_at > TTL,
+    expire: () => expire,
+    log: () => log,
+  })
+}
+
+describe('approval-card-stores: sweep cadence', () => {
+  it('expires only entries past TTL', () => {
+    const expired: string[] = []
+    const store = makeStore((id) => {
+      expired.push(id)
+      store.delete(id) // mirror the gateway's expire.remove()
+    })
+    store.set('fresh', { staged_at: 5000, agent: 'a' })
+    store.set('stale', { staged_at: 1000, agent: 'b' })
+    store.sweep(5000) // fresh: 0ms old, stale: 4000ms old > TTL
+    expect(expired).toEqual(['stale'])
+    expect(store.has('fresh')).toBe(true)
+    expect(store.has('stale')).toBe(false)
+  })
+
+  it('is single-shot across two reaper ticks (verdict-during-sweep safe)', () => {
+    const wakes: string[] = []
+    const store = makeStore((id) => {
+      // The pure expire core removes BEFORE the fallible wake; model that here.
+      store.delete(id)
+      wakes.push(id)
+    })
+    store.set('c1', { staged_at: 0, agent: 'a' })
+    store.sweep(5000)
+    store.sweep(5000) // second tick — entry already gone
+    expect(wakes).toEqual(['c1']) // exactly one wake, never two
+  })
+
+  it('a throwing expiry never skips the remaining entries', () => {
+    const seen: string[] = []
+    const store = makeStore((id) => {
+      seen.push(id)
+      if (id === 'boom') throw new Error('dead socket')
+      store.delete(id)
+    })
+    store.set('boom', { staged_at: 0, agent: 'a' })
+    store.set('ok', { staged_at: 0, agent: 'b' })
+    expect(() => store.sweep(5000)).not.toThrow()
+    expect(seen).toContain('boom')
+    expect(seen).toContain('ok')
+    expect(store.has('ok')).toBe(false) // 'ok' still expired despite 'boom' throwing
+  })
+})
+
+describe('approval-card-stores: verdict-during-restore desync-free', () => {
+  it('a tap after restore removes the restored entry (no resurrection)', () => {
+    const store = makeStore(() => {})
+    store.set('r1', { staged_at: 0, agent: 'a' }) // restore populates
+    expect(store.get('r1')).toBeDefined()
+    const removed = store.delete('r1') // operator tap resolves it
+    expect(removed).toBe(true)
+    expect(store.has('r1')).toBe(false)
+  })
+
+  it('a sweep after a tap on the same instance is a no-op for that card', () => {
+    const wakes: string[] = []
+    const store = makeStore((id) => {
+      store.delete(id)
+      wakes.push(id)
+    })
+    store.set('r2', { staged_at: 0, agent: 'a' })
+    store.delete('r2') // tap resolves before the reaper runs
+    store.sweep(5000)
+    expect(wakes).toEqual([]) // already resolved — no timeout wake
+  })
+})
+
+describe('approval-card-stores: Map surface parity', () => {
+  it('supports get/set/delete/has/size/iteration used by call sites', () => {
+    const store = makeStore(() => {})
+    store.set('a', { staged_at: 1, agent: 'x' })
+    store.set('b', { staged_at: 2, agent: 'y' })
+    expect(store.size).toBe(2)
+    expect(store.get('a')?.agent).toBe('x')
+    const seen: string[] = []
+    for (const [id] of store) seen.push(id)
+    expect(seen.sort()).toEqual(['a', 'b'])
+    expect([...store.values()].map((v) => v.agent).sort()).toEqual(['x', 'y'])
+    expect(store.delete('a')).toBe(true)
+    expect(store.has('a')).toBe(false)
+  })
+})

--- a/telegram-plugin/tests/pending-card-durability-wiring.test.ts
+++ b/telegram-plugin/tests/pending-card-durability-wiring.test.ts
@@ -20,6 +20,11 @@ import { dirname, resolve } from 'node:path'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const read = (p: string) => readFileSync(resolve(__dirname, '..', p), 'utf8')
 const GATEWAY = read('gateway/gateway.ts')
+// #2996 Phase 3: the in-memory approval-card Maps + their TTL sweeps moved
+// behind approval-card-stores.ts. The gateway now delegates each family sweep
+// to `<store>.sweep(now)`; the per-entry sweepExpiredEntries guard lives in the
+// store module.
+const CARD_STORES = read('gateway/approval-card-stores.ts')
 
 function slice(src: string, header: string, span = 3000): string {
   const start = src.indexOf(header)
@@ -141,10 +146,13 @@ describe('TTL expiry wakes the parked agent (Defect B)', () => {
   })
 
   it('sweepExpiredApprovalCards runs all four family sweeps', () => {
+    // #2996 Phase 3: three families now delegate to their store's `.sweep(now)`;
+    // request_secret still routes via sweepSecretRequests (which also sweeps the
+    // transient armedSecretCaptures) and that in turn calls the store sweep.
     const fn = slice(GATEWAY, 'function sweepExpiredApprovalCards', 600)
-    expect(fn).toMatch(/sweepPendingVaultRequestAccesses\(now\)/)
-    expect(fn).toMatch(/sweepPendingVaultRequestSaves\(now\)/)
-    expect(fn).toMatch(/sweepPendingMentalModelProposes\(now\)/)
+    expect(fn).toMatch(/pendingVaultRequestAccesses\.sweep\(now\)/)
+    expect(fn).toMatch(/pendingVaultRequestSaves\.sweep\(now\)/)
+    expect(fn).toMatch(/pendingMentalModelProposes\.sweep\(now\)/)
     expect(fn).toMatch(/sweepSecretRequests\(now\)/)
   })
 
@@ -173,14 +181,20 @@ describe('TTL expiry wakes the parked agent (Defect B)', () => {
   })
 
   it('each family sweep is per-entry guarded via sweepExpiredEntries', () => {
-    for (const fnName of [
-      'function sweepPendingVaultRequestAccesses',
-      'function sweepPendingVaultRequestSaves',
-      'function sweepPendingMentalModelProposes',
-      'function sweepSecretRequests',
+    // #2996 Phase 3: the per-entry guard moved into the store module's `.sweep`,
+    // which is a thin pass-through to the same pure sweepExpiredEntries core.
+    // The three vault/mental families delegate to that store method; the
+    // request_secret family's sweepSecretRequests delegates to it too.
+    expect(CARD_STORES).toMatch(/sweep:\s*\(now\)\s*=>\s*\n?\s*sweepExpiredEntries\(/)
+    const secretSweep = slice(GATEWAY, 'function sweepSecretRequests', 500)
+    expect(secretSweep).toMatch(/pendingSecretRequests\.sweep\(now\)/)
+    for (const store of [
+      'const pendingVaultRequestAccesses = createSweepableCardStore',
+      'const pendingVaultRequestSaves = createSweepableCardStore',
+      'const pendingMentalModelProposes = createSweepableCardStore',
+      'const pendingSecretRequests = createSweepableCardStore',
     ]) {
-      const fn = slice(GATEWAY, fnName, 500)
-      expect(fn, fnName).toMatch(/sweepExpiredEntries\(/)
+      expect(GATEWAY, store).toContain(store)
     }
   })
 


### PR DESCRIPTION
Phase 3 step 1 of the `gateway.ts` decomposition tracked in #2996: the approval-card lifecycle extraction — **storage before logic**. Storage only; the callback-query handler logic is deliberately left for step 2, after these stores are proven.

## What moved

The four **agent-initiated** approval-card families' in-memory Maps now live behind a new Map-compatible store module `telegram-plugin/gateway/approval-card-stores.ts` (`createSweepableCardStore<T>`), with the TTL sweep **co-located** next to the storage it sweeps:

| Map | Moved? | Sweep semantics |
|---|---|---|
| `pendingVaultRequestAccesses` | ✅ moved | `.sweep(now)` → `sweepExpiredEntries` (was `sweepPendingVaultRequestAccesses`, deleted) |
| `pendingVaultRequestSaves` | ✅ moved | `.sweep(now)` (was `sweepPendingVaultRequestSaves`, deleted) |
| `pendingMentalModelProposes` | ✅ moved | `.sweep(now)` (was `sweepPendingMentalModelProposes`, deleted) |
| `pendingSecretRequests` | ✅ moved | `sweepSecretRequests` retained (still sweeps the transient `armedSecretCaptures`) and now delegates the card sweep to `pendingSecretRequests.sweep(now)` |

`sweepExpiredApprovalCards` now delegates: three `<store>.sweep(now)` calls + `sweepSecretRequests(now)`.

The store exposes the exact Map surface every existing call site used (`get`/`set`/`delete`/`has`/`size`/`values`/`entries`/iteration), and the **variable names are unchanged**, so the callback-query handlers, executor add-sites, and `restorePendingApprovalCards` are **byte-identical**. The per-card expiry LOGIC (`expire*Card` — card edits, timeout synthetics, missed-approval re-offers) stays in `gateway.ts` and is injected into the store as a thunk (resolved lazily at sweep time to avoid TDZ against the hoisted expiry fns / `const cardExpiryLog`).

`restorePendingApprovalCards` is untouched — it `.set`s into the same store instances the reaper and taps read.

## Deferred (explicit long tail, follow-up)

Not moved in this PR — outside the agent-initiated approval-card race cluster, or already durable via their own stores:
- `pendingPermissions` (permission-card timeout/lost-tap; already backed by `permission-card-store.ts` for durability — its Map lifecycle is a candidate for a later store but is entangled with the reaper's auto-deny/missed-approval block).
- Correlation Maps `pendingAlwaysAllowCorrelations`, `pendingMentalModelCorrelations` (single-shot config-edit correlators with their own bespoke sweeps).
- `pendingVaultOps`, `pendingAskUser`, `pendingReauthFlows`, `pendingAuthAddFlows`, `pendingMicrosoftConnectFlows`, `pendingAuthRmFlows`, `deferredSecrets`, `vaultPassphraseCache`, `agentButtonMeta`, `armedSecretCaptures` — auth/vault-wizard/transient state swept inline in `pendingStateReaper`, unrelated to the approval-card durability races.

Prioritized per the plan's risk section: the Maps in the known approval-card races and lost-button-tap bugs (the `restorePendingApprovalCards` / `sweepExpiredApprovalCards` cluster) are exactly the four that moved.

## Race tests (harness-first)

New `telegram-plugin/tests/approval-card-stores.test.ts`, written before the Maps moved, pins:
- **verdict-during-sweep is single-shot** — a tap (`.delete`) during an expiry sweep fires the wake at most once; a second reaper tick never double-wakes.
- **verdict-during-restore is desync-free** — `.set` (restore) then `.delete` (tap) on one Map instance; no resurrection either way.
- **sweep cadence / fault isolation** — only past-TTL entries expire; one throwing expiry never skips the remaining entries.
- Map-surface parity for the call-site operations.

## Tests / checks

- `tsc --noEmit`: **0 errors**.
- Full telegram-plugin vitest suite: all real tests green (5172 passed). The ~16 render/* file-load failures are the known pre-existing mdast worktree artifact (CI is the arbiter); the `@mtcute/node` reference-check error is a pre-existing worktree optional-dep gap.
- Updated the two source-text pins in `pending-card-durability-wiring.test.ts` to the new delegation (they codified the deleted `sweepPendingX` names).
- `check-no-pii-secrets.mjs`, `check-bot-api-wrapping.sh`, `check-bun-test-imports.mjs`, `check-stale-tool-descriptions.mjs`: clean.

## Residual risk

- The store's `set` returns `void` (vs `Map.set` returning the map); no call site chains, and tsc confirms. Iteration/`for..of` and `.values()` verified against the actual call sites.
- Callback-handler extraction (step 2) is unbuilt; taps still read the stores through the unchanged handlers.

Refs #2996. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)