### PR TITLE
refactor(telegram): extract bot-commands and ops/info CLI from gateway (#2996)

### DIFF
--- a/telegram-plugin/gateway/bot-commands-ops-info.ts
+++ b/telegram-plugin/gateway/bot-commands-ops-info.ts
@@ -1,0 +1,194 @@
+import type { Bot, Context, InlineKeyboard } from 'grammy'
+import { hostdWillBeUsed } from './hostd-dispatch.js'
+import { maskVaultKey } from '../demo-mask.js'
+import { switchroomHelpText as buildSwitchroomHelpText } from '../welcome-text.js'
+
+/**
+ * Read-only ops/info slash commands extracted verbatim from gateway.ts
+ * (#2996 Phase 5 leaf move): `/doctor`, `/grant`, `/dangerous`,
+ * `/permissions`, `/version`, `/whoami`, `/commands`.
+ *
+ * These are pure info/ops surfaces (no send-path or turn-lifecycle
+ * coupling). Every gateway-local helper they close over is passed in via
+ * `deps` (repo factory-deps precedent) so the module never back-references
+ * the gateway singleton or reads `currentTurn`. `bot` is injected so
+ * grammy registration order is preserved at the original call site.
+ */
+export interface OpsInfoCommandDeps {
+  AGENT_ADMIN: boolean
+  isAuthorizedSender: (ctx: Context) => boolean
+  getMyAgentName: () => string
+  switchroomReply: (
+    ctx: Context,
+    text: string,
+    options?: {
+      html?: boolean
+      reply_markup?: InlineKeyboard
+      classification?: 'query' | 'mutation' | 'heavy'
+    },
+  ) => Promise<void>
+  buildDoctorScopeKeyboard: () => InlineKeyboard
+  renderSelfDoctor: (ctx: Context) => Promise<void>
+  preBlock: (text: string) => string
+  formatSwitchroomOutput: (output: string, maxLen?: number) => string
+  getCommandArgs: (ctx: Context) => string
+  assertSafeAgentName: (name: string) => void
+  runSwitchroomCommand: (
+    ctx: Context,
+    args: string[],
+    label: string,
+    classification?: 'query' | 'mutation' | 'heavy',
+  ) => Promise<void>
+  switchroomExecCombined: (args: string[], timeoutMs?: number) => string
+  stripAnsi: (text: string) => string
+  hasDemoFlag: (args: string) => boolean
+  escapeHtmlForTg: (text: string) => string
+}
+
+export function registerOpsInfoCommands(bot: Bot, deps: OpsInfoCommandDeps): void {
+  const {
+    AGENT_ADMIN,
+    isAuthorizedSender,
+    getMyAgentName,
+    switchroomReply,
+    buildDoctorScopeKeyboard,
+    renderSelfDoctor,
+    preBlock,
+    formatSwitchroomOutput,
+    getCommandArgs,
+    assertSafeAgentName,
+    runSwitchroomCommand,
+    switchroomExecCombined,
+    stripAnsi,
+    hasDemoFlag,
+    escapeHtmlForTg,
+  } = deps
+
+  /** Compact HTML card from the `config whoami` JSON view. Names/booleans only.
+   *  `demo` (the `/whoami demo` suffix) masks the vault key NAMES via maskVaultKey
+   *  for screen recordings — agent/MCP/model/skills topology is left untouched
+   *  (out of scope). Off by default. */
+  function formatWhoamiCard(v: {
+    name?: string; persona?: string | null; model?: string | null; tier?: string;
+    tools?: { allow?: string[]; deny?: string[] }; mcpServers?: string[]; skills?: string[];
+    vault?: { key: string; readable: boolean }[];
+    powers?: { admin?: boolean; root?: boolean; configEdit?: boolean; crossAgentHostVerbs?: boolean };
+    scheduleCount?: number; memoryBackend?: string | null;
+  }, demo = false): string {
+    const esc = escapeHtmlForTg
+    const yn = (b?: boolean) => (b ? '✓' : '✗')
+    const lines: string[] = []
+    lines.push(`👤 **${esc(v.name ?? '?')}** · ${esc(v.tier ?? 'standard')}`)
+    if (v.persona) lines.push(esc(v.persona))
+    if (v.model) lines.push(`Model: ${esc(v.model)}`)
+    const allow = v.tools?.allow ?? []
+    lines.push(`Tools: ${allow.length ? esc(allow.slice(0, 8).join(', ')) + (allow.length > 8 ? ` …(+${allow.length - 8})` : '') : '—'}`)
+    if ((v.tools?.deny ?? []).length) lines.push(`Denied: ${esc((v.tools!.deny!).join(', '))}`)
+    if ((v.mcpServers ?? []).length) lines.push(`MCP: ${esc(v.mcpServers!.join(', '))}`)
+    if ((v.skills ?? []).length) lines.push(`Skills: ${esc(v.skills!.join(', '))}`)
+    if ((v.vault ?? []).length) {
+      lines.push(`Vault keys (names only): ${v.vault!.map(k => `${esc(demo ? maskVaultKey(k.key) : k.key)} ${yn(k.readable)}`).join(', ')}`)
+    }
+    const p = v.powers ?? {}
+    lines.push(`Powers: admin ${yn(p.admin)} · root ${yn(p.root)} · config-edit ${yn(p.configEdit)} · cross-agent verbs ${yn(p.crossAgentHostVerbs)}`)
+    lines.push(`Schedule: ${v.scheduleCount ?? 0} cron · Memory: ${esc(v.memoryBackend ?? 'none')}`)
+    return lines.join('\n')
+  }
+
+  bot.command('doctor', async ctx => {
+    if (!isAuthorizedSender(ctx)) return
+    try {
+      // Admin agents with hostd reachable choose scope (one tap, no
+      // approval card — doctor is read-only). Everyone else keeps the
+      // original zero-extra-tap in-container behaviour.
+      if (AGENT_ADMIN && hostdWillBeUsed(getMyAgentName())) {
+        await switchroomReply(ctx, '🩺 **Doctor** — which scope?', {
+          html: true,
+          reply_markup: buildDoctorScopeKeyboard(),
+        })
+        return
+      }
+      await renderSelfDoctor(ctx)
+    } catch (err: unknown) {
+      await switchroomReply(ctx, `**doctor failed:**\n${preBlock(formatSwitchroomOutput((err as any).message ?? 'unknown error'))}`, { html: true })
+    }
+  })
+
+  bot.command('grant', async ctx => {
+    if (!isAuthorizedSender(ctx)) return
+    const parts = getCommandArgs(ctx).split(/\s+/).filter(Boolean)
+    if (parts.length === 0) { await switchroomReply(ctx, 'Usage: /grant <tool>  or  /grant <agent> <tool>'); return }
+    let agentName: string; let tool: string
+    if (parts.length === 1) { agentName = getMyAgentName(); tool = parts[0] }
+    else { agentName = parts[0]; tool = parts.slice(1).join(' ') }
+    try { assertSafeAgentName(agentName) } catch { await switchroomReply(ctx, 'Invalid agent name.'); return }
+    await runSwitchroomCommand(ctx, ['agent', 'grant', agentName, tool], `grant ${agentName} ${tool}`)
+  })
+
+  bot.command('dangerous', async ctx => {
+    if (!isAuthorizedSender(ctx)) return
+    const parts = getCommandArgs(ctx).split(/\s+/).filter(Boolean)
+    let agentName: string; let off = false
+    if (parts.length === 0) { agentName = getMyAgentName() }
+    else if (parts.length === 1 && parts[0] === 'off') { agentName = getMyAgentName(); off = true }
+    else { agentName = parts[0]; if (parts[1] === 'off') off = true }
+    try { assertSafeAgentName(agentName) } catch { await switchroomReply(ctx, 'Invalid agent name.'); return }
+    const args = ['agent', 'dangerous', agentName]; if (off) args.push('--off')
+    await runSwitchroomCommand(ctx, args, `dangerous ${agentName}${off ? ' off' : ''}`)
+  })
+
+  bot.command('permissions', async ctx => {
+    if (!isAuthorizedSender(ctx)) return
+    const agentName = (typeof ctx.match === "string" ? ctx.match : "").trim() || getMyAgentName()
+    try { assertSafeAgentName(agentName) } catch { await switchroomReply(ctx, 'Invalid agent name.'); return }
+    await runSwitchroomCommand(ctx, ['agent', 'permissions', agentName], `permissions ${agentName}`)
+  })
+
+  // Drive-by cleanup (#927): the dead /update handler that lived here
+  // was a pre-#919 stub. Grammy registers in order so the comprehensive
+  // /update handler at line ~6516 (added in #919, hardened in #924,
+  // docker-guarded in #934) fired first and this one never ran.
+  // Removed to avoid future confusion.
+
+  bot.command('version', async ctx => {
+    if (!isAuthorizedSender(ctx)) return
+    try {
+      let output: string
+      try { output = switchroomExecCombined(['version'], 10000) }
+      catch (err: unknown) { output = (err as any).stdout ?? (err as any).message ?? 'version failed' }
+      const trimmed = stripAnsi(output).trim()
+      if (!trimmed) { await switchroomReply(ctx, 'version: no output'); return }
+      await switchroomReply(ctx, preBlock(formatSwitchroomOutput(trimmed)), { html: true })
+    } catch (err: unknown) {
+      await switchroomReply(ctx, `**version failed:**\n${preBlock(formatSwitchroomOutput((err as any).message ?? 'unknown error'))}`, { html: true })
+    }
+  })
+
+
+  // /whoami — the operator's view of THIS agent's sandbox (the same
+  // `config whoami` the agent itself can call as an MCP tool, and the host CLI
+  // exposes). Read-only, isAuthorizedSender-gated like /version — surfaces
+  // tools / MCP / vault key-NAMES (never values) / powers so the operator can
+  // see at a glance what this agent is authorized for.
+  bot.command('whoami', async ctx => {
+    if (!isAuthorizedSender(ctx)) return
+    const demo = hasDemoFlag(getCommandArgs(ctx))
+    try {
+      let raw: string
+      try { raw = switchroomExecCombined(['config', 'whoami'], 10000) }
+      catch (err: unknown) { raw = (err as any).stdout ?? (err as any).message ?? 'whoami failed' }
+      const trimmed = stripAnsi(raw).trim()
+      let card: string
+      try { card = formatWhoamiCard(JSON.parse(trimmed.split('\n').pop() ?? trimmed), demo) }
+      catch { card = preBlock(formatSwitchroomOutput(trimmed || 'whoami: no output')) }
+      await switchroomReply(ctx, card, { html: true })
+    } catch (err: unknown) {
+      await switchroomReply(ctx, `**whoami failed:**\n${preBlock(formatSwitchroomOutput((err as any).message ?? 'unknown error'))}`, { html: true })
+    }
+  })
+
+  bot.command('commands', async ctx => {
+    if (!isAuthorizedSender(ctx)) return
+    await switchroomReply(ctx, buildSwitchroomHelpText(getMyAgentName()), { html: true })
+  })
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -311,8 +311,6 @@ import {
   switchroomHelpText as buildSwitchroomHelpText,
   restartAckText as buildRestartAckText,
   newSessionAckText as buildNewSessionAckText,
-  TELEGRAM_BASE_COMMANDS,
-  TELEGRAM_SWITCHROOM_COMMANDS,
   type AgentMetadata, type AuthSummary, type StatusProbeRow,
 } from '../welcome-text.js'
 import {
@@ -412,6 +410,7 @@ import {
   type EffortCommandDeps,
   type EffortMenuReply,
 } from './effort-command.js'
+import { registerSwitchroomBotCommands } from './register-bot-commands.js'
 import { applyEffort } from '../../src/agents/effort-picker.js'
 import { type BannerState } from '../slot-banner.js'
 import { refreshBanner } from '../slot-banner-driver.js'
@@ -24985,22 +24984,6 @@ bot.command('commands', async ctx => {
   await switchroomReply(ctx, buildSwitchroomHelpText(getMyAgentName()), { html: true })
 })
 
-async function registerSwitchroomBotCommands(): Promise<void> {
-  // Slash-menu is deliberately trimmed from the full command catalogue.
-  // See telegram-plugin/welcome-text.ts TELEGRAM_MENU_COMMANDS for the
-  // rationale (mobile UX focus; ops primitives stay typable but out of
-  // the autocomplete clutter). /commands surfaces the full list.
-  await bot.api.setMyCommands(
-    [...TELEGRAM_BASE_COMMANDS, ...TELEGRAM_SWITCHROOM_COMMANDS],
-    { scope: { type: 'all_private_chats' } },
-  )
-  // Group chats don't support /start pairing, so only the switchroom
-  // commands are registered there.
-  await bot.api.setMyCommands(
-    TELEGRAM_SWITCHROOM_COMMANDS,
-    { scope: { type: 'all_group_chats' } },
-  )
-}
 
 // ─── Inline-button handler (permissions) ──────────────────────────────────
 // Handles `perm:(allow|deny|always|asn|asb|back):<id>` — permission request buttons
@@ -27961,7 +27944,7 @@ void (async () => {
         // lifetime.
         scheduleAlwaysAllowPersistDrain()
 
-        void registerSwitchroomBotCommands().catch(() => {})
+        void registerSwitchroomBotCommands(bot).catch(() => {})
 
         // #613 fix: pre-warm the chatAvailableReactions cache for every
         // chat in access.allowFrom. Without this, the FIRST inbound

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -308,7 +308,6 @@ import {
   statusPairedText as buildStatusPairedText,
   statusPendingText as buildStatusPendingText,
   statusUnpairedText as buildStatusUnpairedText,
-  switchroomHelpText as buildSwitchroomHelpText,
   restartAckText as buildRestartAckText,
   newSessionAckText as buildNewSessionAckText,
   type AgentMetadata, type AuthSummary, type StatusProbeRow,
@@ -411,6 +410,7 @@ import {
   type EffortMenuReply,
 } from './effort-command.js'
 import { registerSwitchroomBotCommands } from './register-bot-commands.js'
+import { registerOpsInfoCommands } from './bot-commands-ops-info.js'
 import { applyEffort } from '../../src/agents/effort-picker.js'
 import { type BannerState } from '../slot-banner.js'
 import { refreshBanner } from '../slot-banner-driver.js'
@@ -667,7 +667,7 @@ import {
   isLiveCorroboration,
 } from '../quota-watch.js'
 import { buildSnapshotsFromState, buildSnapshotsFromCachedState, zipProbeResults } from '../auth-snapshot-format.js'
-import { maskUsername, maskVaultKey } from '../demo-mask.js'
+import { maskUsername } from '../demo-mask.js'
 import {
   writeTurnActiveMarker,
   touchTurnActiveMarker,
@@ -24856,132 +24856,25 @@ async function renderFleetDoctor(ctx: Context): Promise<void> {
   await switchroomReply(ctx, formatDoctorReport(body), { html: true })
 }
 
-bot.command('doctor', async ctx => {
-  if (!isAuthorizedSender(ctx)) return
-  try {
-    // Admin agents with hostd reachable choose scope (one tap, no
-    // approval card — doctor is read-only). Everyone else keeps the
-    // original zero-extra-tap in-container behaviour.
-    if (AGENT_ADMIN && hostdWillBeUsed(getMyAgentName())) {
-      await switchroomReply(ctx, '🩺 **Doctor** — which scope?', {
-        html: true,
-        reply_markup: buildDoctorScopeKeyboard(),
-      })
-      return
-    }
-    await renderSelfDoctor(ctx)
-  } catch (err: unknown) {
-    await switchroomReply(ctx, `**doctor failed:**\n${preBlock(formatSwitchroomOutput((err as any).message ?? 'unknown error'))}`, { html: true })
-  }
-})
-
-bot.command('grant', async ctx => {
-  if (!isAuthorizedSender(ctx)) return
-  const parts = getCommandArgs(ctx).split(/\s+/).filter(Boolean)
-  if (parts.length === 0) { await switchroomReply(ctx, 'Usage: /grant <tool>  or  /grant <agent> <tool>'); return }
-  let agentName: string; let tool: string
-  if (parts.length === 1) { agentName = getMyAgentName(); tool = parts[0] }
-  else { agentName = parts[0]; tool = parts.slice(1).join(' ') }
-  try { assertSafeAgentName(agentName) } catch { await switchroomReply(ctx, 'Invalid agent name.'); return }
-  await runSwitchroomCommand(ctx, ['agent', 'grant', agentName, tool], `grant ${agentName} ${tool}`)
-})
-
-bot.command('dangerous', async ctx => {
-  if (!isAuthorizedSender(ctx)) return
-  const parts = getCommandArgs(ctx).split(/\s+/).filter(Boolean)
-  let agentName: string; let off = false
-  if (parts.length === 0) { agentName = getMyAgentName() }
-  else if (parts.length === 1 && parts[0] === 'off') { agentName = getMyAgentName(); off = true }
-  else { agentName = parts[0]; if (parts[1] === 'off') off = true }
-  try { assertSafeAgentName(agentName) } catch { await switchroomReply(ctx, 'Invalid agent name.'); return }
-  const args = ['agent', 'dangerous', agentName]; if (off) args.push('--off')
-  await runSwitchroomCommand(ctx, args, `dangerous ${agentName}${off ? ' off' : ''}`)
-})
-
-bot.command('permissions', async ctx => {
-  if (!isAuthorizedSender(ctx)) return
-  const agentName = (typeof ctx.match === "string" ? ctx.match : "").trim() || getMyAgentName()
-  try { assertSafeAgentName(agentName) } catch { await switchroomReply(ctx, 'Invalid agent name.'); return }
-  await runSwitchroomCommand(ctx, ['agent', 'permissions', agentName], `permissions ${agentName}`)
-})
-
-// Drive-by cleanup (#927): the dead /update handler that lived here
-// was a pre-#919 stub. Grammy registers in order so the comprehensive
-// /update handler at line ~6516 (added in #919, hardened in #924,
-// docker-guarded in #934) fired first and this one never ran.
-// Removed to avoid future confusion.
-
-bot.command('version', async ctx => {
-  if (!isAuthorizedSender(ctx)) return
-  try {
-    let output: string
-    try { output = switchroomExecCombined(['version'], 10000) }
-    catch (err: unknown) { output = (err as any).stdout ?? (err as any).message ?? 'version failed' }
-    const trimmed = stripAnsi(output).trim()
-    if (!trimmed) { await switchroomReply(ctx, 'version: no output'); return }
-    await switchroomReply(ctx, preBlock(formatSwitchroomOutput(trimmed)), { html: true })
-  } catch (err: unknown) {
-    await switchroomReply(ctx, `**version failed:**\n${preBlock(formatSwitchroomOutput((err as any).message ?? 'unknown error'))}`, { html: true })
-  }
-})
-
-
-// /whoami — the operator's view of THIS agent's sandbox (the same
-// `config whoami` the agent itself can call as an MCP tool, and the host CLI
-// exposes). Read-only, isAuthorizedSender-gated like /version — surfaces
-// tools / MCP / vault key-NAMES (never values) / powers so the operator can
-// see at a glance what this agent is authorized for.
-bot.command('whoami', async ctx => {
-  if (!isAuthorizedSender(ctx)) return
-  const demo = hasDemoFlag(getCommandArgs(ctx))
-  try {
-    let raw: string
-    try { raw = switchroomExecCombined(['config', 'whoami'], 10000) }
-    catch (err: unknown) { raw = (err as any).stdout ?? (err as any).message ?? 'whoami failed' }
-    const trimmed = stripAnsi(raw).trim()
-    let card: string
-    try { card = formatWhoamiCard(JSON.parse(trimmed.split('\n').pop() ?? trimmed), demo) }
-    catch { card = preBlock(formatSwitchroomOutput(trimmed || 'whoami: no output')) }
-    await switchroomReply(ctx, card, { html: true })
-  } catch (err: unknown) {
-    await switchroomReply(ctx, `**whoami failed:**\n${preBlock(formatSwitchroomOutput((err as any).message ?? 'unknown error'))}`, { html: true })
-  }
-})
-
-/** Compact HTML card from the `config whoami` JSON view. Names/booleans only.
- *  `demo` (the `/whoami demo` suffix) masks the vault key NAMES via maskVaultKey
- *  for screen recordings — agent/MCP/model/skills topology is left untouched
- *  (out of scope). Off by default. */
-function formatWhoamiCard(v: {
-  name?: string; persona?: string | null; model?: string | null; tier?: string;
-  tools?: { allow?: string[]; deny?: string[] }; mcpServers?: string[]; skills?: string[];
-  vault?: { key: string; readable: boolean }[];
-  powers?: { admin?: boolean; root?: boolean; configEdit?: boolean; crossAgentHostVerbs?: boolean };
-  scheduleCount?: number; memoryBackend?: string | null;
-}, demo = false): string {
-  const esc = escapeHtmlForTg
-  const yn = (b?: boolean) => (b ? '✓' : '✗')
-  const lines: string[] = []
-  lines.push(`👤 **${esc(v.name ?? '?')}** · ${esc(v.tier ?? 'standard')}`)
-  if (v.persona) lines.push(esc(v.persona))
-  if (v.model) lines.push(`Model: ${esc(v.model)}`)
-  const allow = v.tools?.allow ?? []
-  lines.push(`Tools: ${allow.length ? esc(allow.slice(0, 8).join(', ')) + (allow.length > 8 ? ` …(+${allow.length - 8})` : '') : '—'}`)
-  if ((v.tools?.deny ?? []).length) lines.push(`Denied: ${esc((v.tools!.deny!).join(', '))}`)
-  if ((v.mcpServers ?? []).length) lines.push(`MCP: ${esc(v.mcpServers!.join(', '))}`)
-  if ((v.skills ?? []).length) lines.push(`Skills: ${esc(v.skills!.join(', '))}`)
-  if ((v.vault ?? []).length) {
-    lines.push(`Vault keys (names only): ${v.vault!.map(k => `${esc(demo ? maskVaultKey(k.key) : k.key)} ${yn(k.readable)}`).join(', ')}`)
-  }
-  const p = v.powers ?? {}
-  lines.push(`Powers: admin ${yn(p.admin)} · root ${yn(p.root)} · config-edit ${yn(p.configEdit)} · cross-agent verbs ${yn(p.crossAgentHostVerbs)}`)
-  lines.push(`Schedule: ${v.scheduleCount ?? 0} cron · Memory: ${esc(v.memoryBackend ?? 'none')}`)
-  return lines.join('\n')
-}
-
-bot.command('commands', async ctx => {
-  if (!isAuthorizedSender(ctx)) return
-  await switchroomReply(ctx, buildSwitchroomHelpText(getMyAgentName()), { html: true })
+// Ops/info slash commands (/doctor /grant /dangerous /permissions /version
+// /whoami /commands) extracted verbatim to bot-commands-ops-info.ts (#2996
+// Phase 5). Registered here to preserve grammy's in-order registration.
+registerOpsInfoCommands(bot, {
+  AGENT_ADMIN,
+  isAuthorizedSender,
+  getMyAgentName,
+  switchroomReply,
+  buildDoctorScopeKeyboard,
+  renderSelfDoctor,
+  preBlock,
+  formatSwitchroomOutput,
+  getCommandArgs,
+  assertSafeAgentName,
+  runSwitchroomCommand,
+  switchroomExecCombined,
+  stripAnsi,
+  hasDemoFlag,
+  escapeHtmlForTg,
 })
 
 

--- a/telegram-plugin/gateway/register-bot-commands.ts
+++ b/telegram-plugin/gateway/register-bot-commands.ts
@@ -1,0 +1,30 @@
+import type { Bot } from 'grammy'
+import {
+  TELEGRAM_BASE_COMMANDS,
+  TELEGRAM_SWITCHROOM_COMMANDS,
+} from '../welcome-text.js'
+
+/**
+ * Register the bot's slash-command menu with Telegram (`setMyCommands`).
+ *
+ * Extracted verbatim from gateway.ts (#2996 Phase 5 leaf move). The `bot`
+ * singleton is injected rather than imported so this stays a pure leaf with
+ * no back-reference into the gateway module.
+ *
+ * Slash-menu is deliberately trimmed from the full command catalogue.
+ * See telegram-plugin/welcome-text.ts TELEGRAM_MENU_COMMANDS for the
+ * rationale (mobile UX focus; ops primitives stay typable but out of
+ * the autocomplete clutter). /commands surfaces the full list.
+ */
+export async function registerSwitchroomBotCommands(bot: Bot): Promise<void> {
+  await bot.api.setMyCommands(
+    [...TELEGRAM_BASE_COMMANDS, ...TELEGRAM_SWITCHROOM_COMMANDS],
+    { scope: { type: 'all_private_chats' } },
+  )
+  // Group chats don't support /start pairing, so only the switchroom
+  // commands are registered there.
+  await bot.api.setMyCommands(
+    TELEGRAM_SWITCHROOM_COMMANDS,
+    { scope: { type: 'all_group_chats' } },
+  )
+}


### PR DESCRIPTION
## Summary

Phase 5 ("cheap mechanical leaf moves") of the gateway.ts decomposition (#2996). Verbatim extraction of leaf-ish command regions out of `telegram-plugin/gateway/gateway.ts` into standalone modules, injected-deps style (factory-deps precedent: `buildModelDeps`, `feedOpenGateDeps`, `emission-authority.ts`). No logic changes, no renames beyond module plumbing. Modules read no globals and never touch `currentTurn`.

Job spec: internal refactor advancing the `#2996` reliability-investment track (`reference/jobs/` — no user-facing surface changed; the four info commands behave byte-identically).

## Per-region status

**1. `registerSwitchroomBotCommands` → `register-bot-commands.ts` (commit `4e7d33d4`) — MOVED**
- The `setMyCommands` slash-menu registration. Dep surface: `bot` injected; command constants (`TELEGRAM_BASE_COMMANDS`, `TELEGRAM_SWITCHROOM_COMMANDS`) imported directly from `../welcome-text.js`. Call site updated to `registerSwitchroomBotCommands(bot)`. Removed now-orphaned constant imports from gateway.

**2. Ops/info slash commands → `bot-commands-ops-info.ts` (commit `d6650717`) — MOVED**
- `/doctor /grant /dangerous /permissions /version /whoami /commands` + the `formatWhoamiCard` helper, behind `registerOpsInfoCommands(bot, deps)`.
- Dep surface: 15 injected gateway-local helpers (`AGENT_ADMIN`, `isAuthorizedSender`, `getMyAgentName`, `switchroomReply`, `buildDoctorScopeKeyboard`, `renderSelfDoctor`, `preBlock`, `formatSwitchroomOutput`, `getCommandArgs`, `assertSafeAgentName`, `runSwitchroomCommand`, `switchroomExecCombined`, `stripAnsi`, `hasDemoFlag`, `escapeHtmlForTg`) + `bot`. `hostdWillBeUsed`, `maskVaultKey`, `switchroomHelpText` imported directly. Registration kept at the original call site to preserve grammy in-order matching (the block carries a load-order comment re #927). Removed orphaned `buildSwitchroomHelpText`/`maskVaultKey` imports from gateway.
- These are read-only info surfaces — no send-path / turn-lifecycle coupling, lowest-risk slice of the command region.

**3. Callback-query handlers (`bot.on('callback_query:data')`, ~1287 lines) — DEFERRED**
- Measured free-identifier surface against gateway module scope: **62 module-level deps** (vault/skill/mental-model/operator/auth-dashboard handlers plus pending-approval stores `pendingPermissions`/`permCardStore`/`scopedGrantStore`/`pendingRestarts`/`pendingInboundBuffer`, self-restart glue `triggerSelfRestart`/`shutdown`/`writeRestartMarker`, `dispatchPermissionVerdict`, `resolveThreadId`, `switchroomReply`, etc.). Well past the "30+ deps = defer" line in the task brief. Recommend extracting as a `registerCallbackQueryHandler(bot, deps)` only after the approval-card registry (Phase 3) shrinks its client count — otherwise the deps object duplicates half the gateway.

**4. Broader slash-command / CLI block (`bot.command` ×~35, lines ~19645–24800) — DEFERRED**
- Each registration closes over the same ubiquitous glue (`isAuthorizedSender`, `switchroomReply`, `preBlock`, `switchroomExec*`, `runSwitchroomCommand`) and the heavy flows (auth/vault/connect wizards, `/model` `/effort` with their `buildModelDeps`/`buildEffortDeps` factories, `/restart` `/update` self-restart plumbing entangled with turn lifecycle). The prior extraction PRs already pulled the *logic* into `model-command.ts`/`effort-command.ts`/etc.; what remains in gateway is order-sensitive registration glue whose extraction would cascade the same 30+ ubiquitous deps. Per the brief, not forced. The `/doctor…/commands` tail (region 2) was the genuinely cohesive, low-coupling slice and was taken.

## Test plan

- `check-plugin-references.mjs` (full tsc over plugin source): **zero new errors** about moved symbols. The 18 reported errors are all the known worktree artifacts (`render/parse.ts` mdast ×10, `uat/driver.ts` mtcute ×7, `uat/login.ts` ×1) — pre-existing under symlinked node_modules; CI is the arbiter.
- `check-bot-api-wrapping.sh`: clean (moved `setMyCommands` calls did not trip the file:line allowlist).
- vitest: `dm-command-gate`, `slash-command-smart-split`, `model-command`, `effort-command` — 151/151 pass. No structural guard test pins the moved symbols (verified: no `readFileSync(gateway.ts)` test greps for `setMyCommands`/`formatWhoamiCard`/the moved command strings).

## Risk

Low. Two verbatim leaf moves of read-only surfaces; both regions revertable as isolated commits. No change to send-path, turn-gating, or approval-card state. CI (`lint`/`vitest`/`bun-test`/`images-ok`) is the arbiter.

Refs #2996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
