### PR TITLE
refactor(telegram): invocable executeReply send-loop harness (#2996)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -174,8 +174,6 @@ import {
   createRetryApiCall,
   createSwallowingRetryApiCall,
   retryWithThreadFallback,
-  isHtmlParseRejectError,
-  isMessageTooLongError,
 } from '../retry-api-call.js'
 import { installTgPostLogger, withTgPostTags } from '../shared/bot-runtime.js'
 import { floodStatePath, makeFloodWaitRecorder } from '../flood-circuit-breaker.js'
@@ -288,7 +286,8 @@ import {
   normalizeOutboundBody,
   computeEffectiveText,
   computeReplyChunks,
-  resplitOversizeChunk,
+  sendReplyChunks,
+  type ReplyChunkSendDeps,
 } from './outbound-send-path.js'
 import {
   validateInlineKeyboard,
@@ -11673,158 +11672,83 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     }
   }
 
+  // #2996 step 1 — the chunk-send loop (with its THREAD_NOT_FOUND / oversize
+  // re-split / parse-reject fallback ladder and partial-failure contract) is
+  // relocated verbatim to outbound-send-path.ts's `sendReplyChunks` so it is
+  // unit-testable against a fake bot API (gateway.ts is not importable —
+  // Bun.listen + boot logic run at import). The raw `bot.api.*` calls stay HERE
+  // as thin injected adapters (retry wrapping + allow-raw-bot-api markers
+  // preserved), so the module is bot-agnostic and the check-bot-api-wrapping
+  // allowlist is unchanged. The caller still builds the per-chunk option shape
+  // (byte-identical). `sentIds` is threaded by reference; `threadId` /
+  // `previewMessageId` come back for the file-send + history code below.
+  const chunkSendDeps: ReplyChunkSendDeps = {
+    sendRich: (opts, body, tid) =>
+      robustApiCall(
+        // allow-raw-bot-api: injected chunk-loop adapter — sendRichMessage routed through robustApiCall; THREAD_NOT_FOUND handled by sendReplyChunks' fallback ladder
+        () => lockedBot.api.sendRichMessage(chat_id, body as never, opts as never),
+        { threadId: tid, chat_id },
+      ),
+    sendLiteral: (opts, txt, tid) =>
+      robustApiCall(
+        // allow-raw-bot-api: injected chunk-loop adapter — literal format:'text' send routed through robustApiCall; THREAD_NOT_FOUND handled by sendReplyChunks
+        () => lockedBot.api.sendMessage(chat_id, txt, opts as never),
+        { threadId: tid, chat_id },
+      ),
+    sendLiteralRaw: (opts, txt) =>
+      // allow-raw-bot-api: literal last-resort fallback (plaintext parse-reject / length re-split); wrapping would re-enter the parse/length policy that just rejected the payload
+      lockedBot.api.sendMessage(chat_id, txt, opts as never),
+    sendRichRaw: (opts, body) =>
+      // allow-raw-bot-api: rich length-error re-split last resort; wrapping would re-enter the chunk-loop's own classification on an already-classified length failure
+      lockedBot.api.sendRichMessage(chat_id, body as never, opts as never),
+    editPreview: (mid, body, opts, tid) =>
+      robustApiCall(
+        // allow-raw-bot-api: preview edit-in-place routed through robustApiCall; thread fallback handled by sendReplyChunks
+        () => lockedBot.api.editMessageText(chat_id, mid, body as never, opts as never),
+        { threadId: tid, chat_id },
+      ),
+    richMessage,
+    logOutbound,
+    deleteStalePreview,
+    stderr: (s: string) => { process.stderr.write(s) },
+  }
   try {
-    for (let i = 0; i < chunks.length; i++) {
-      // PR-C2: voice-only mode with a successful synthesis suppresses the
-      // text body — the spoken voice note IS the reply. Bail before the
-      // first chunk send (sentIds stays empty for text); the voice send
-      // below lands the answer. Any other mode (voice+text, or voice-only
-      // that fell back) sends the text chunks as normal.
-      if (suppressText) break
-      const shouldReplyTo =
-        reply_to != null && replyMode !== 'off' && (replyMode === 'all' || i === 0)
-      const isLastChunk = i === chunks.length - 1
-      const sendOpts = {
-        ...(shouldReplyTo
-          ? {
-              reply_parameters: {
-                message_id: reply_to,
-                ...(quoteText != null ? { quote: { text: quoteText, position: 0 } } : {}),
-              },
-            }
-          : {}),
-        ...(threadId != null ? { message_thread_id: threadId } : {}),
-        ...(disableLinkPreview ? { link_preview_options: { is_disabled: true } } : {}),
-        ...(replyMarkup != null && isLastChunk ? { reply_markup: replyMarkup } : {}),
-        ...(protectContent ? { protect_content: true } : {}),
-        ...(disableNotification ? { disable_notification: true } : {}),
-      }
-
-      // The body argument for send/edit: a rich-markdown wrapper on the
-      // default path, or the literal string for `format:'text'` (#2669).
-      const richOrPlain = (s: string) => (literalText ? s : richMessage(s))
-
-      if (i === 0 && previewMessageId != null) {
+    const _sendResult = await sendReplyChunks(chunkSendDeps, {
+      chatId: chat_id,
+      chunks,
+      literalText,
+      suppressText,
+      threadId,
+      previewMessageId,
+      sentIds,
+      buildSendOpts: (i, isLastChunk, tid) => {
+        const shouldReplyTo =
+          reply_to != null && replyMode !== 'off' && (replyMode === 'all' || i === 0)
+        return {
+          ...(shouldReplyTo
+            ? {
+                reply_parameters: {
+                  message_id: reply_to,
+                  ...(quoteText != null ? { quote: { text: quoteText, position: 0 } } : {}),
+                },
+              }
+            : {}),
+          ...(tid != null ? { message_thread_id: tid } : {}),
+          ...(disableLinkPreview ? { link_preview_options: { is_disabled: true } } : {}),
+          ...(replyMarkup != null && isLastChunk ? { reply_markup: replyMarkup } : {}),
+          ...(protectContent ? { protect_content: true } : {}),
+          ...(disableNotification ? { disable_notification: true } : {}),
+        }
+      },
+      buildPreviewEditOpts: (isLastChunk) => {
         const editOpts: Record<string, unknown> = {}
         if (disableLinkPreview) editOpts.link_preview_options = { is_disabled: true }
         if (replyMarkup != null && isLastChunk) editOpts.reply_markup = replyMarkup
-        try {
-          await robustApiCall(
-            () => lockedBot.api.editMessageText(chat_id, previewMessageId!, richOrPlain(chunks[i]), editOpts),
-            { threadId, chat_id },
-          )
-          sentIds.push(previewMessageId!)
-          previewMessageId = null
-          continue
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err)
-          if (/not modified/i.test(msg)) {
-            sentIds.push(previewMessageId!)
-            previewMessageId = null
-            continue
-          }
-          process.stderr.write(`telegram gateway: preview edit-in-place failed (${msg}), sending fresh\n`)
-          await deleteStalePreview(previewMessageId!)
-          previewMessageId = null
-        }
-      }
-
-      // Last-resort: resend this chunk as plain text (no rich wrapper, so
-      // the markdown parser never runs). Keeps thread / reply / markup
-      // params; only the formatting is sacrificed. Used when Telegram
-      // rejects our markdown — better an unformatted answer than a
-      // vanished one. The raw markdown source is itself readable prose, so
-      // we send it verbatim rather than strip anything.
-      const sendChunkPlainText = async (opts: Record<string, unknown>): Promise<void> => {
-        const plain =
-          chunks[i].length > 0
-            ? chunks[i]
-            : '⚠️ (a fragment could not be rendered for Telegram)'
-        // allow-raw-bot-api: plaintext last-resort fallback; wrapping would re-enter the parse policy that just rejected the payload
-        const sent = await lockedBot.api.sendMessage(chat_id, plain, opts as never)
-        sentIds.push(sent.message_id)
-        logOutbound('reply', chat_id, sent.message_id, plain.length, `chunk=${i + 1}/${chunks.length} plaintext-fallback`)
-        process.stderr.write(
-          `telegram gateway: markdown parse-reject — resent chunk ${i + 1}/${chunks.length} as plain text\n`,
-        )
-      }
-
-      // Literal `format:'text'` sends bypass the rich parser entirely
-      // (plain sendMessage, no markdown). The default path ships rich
-      // markdown via sendRichMessage. Both resolve to a Message with a
-      // message_id, which is all the caller reads.
-      const sendChunk = (opts: Record<string, unknown>): Promise<{ message_id: number }> => {
-        if (literalText) {
-          // allow-raw-bot-api: literal format:'text' send; the chunk-loop's own THREAD_NOT_FOUND + parse-reject handling wraps this
-          return lockedBot.api.sendMessage(chat_id, chunks[i], opts as never)
-        }
-        // sendRichMessage does NOT accept link_preview_options (rich messages
-        // control previews via entity detection) — drop it for the rich path.
-        const richOpts = { ...opts }
-        delete (richOpts as { link_preview_options?: unknown }).link_preview_options
-        // allow-raw-bot-api: sendRichMessage is not in the THREAD_NOT_FOUND blast pattern; thread fallback handled in the catch below
-        return lockedBot.api.sendRichMessage(chat_id, richMessage(chunks[i]), richOpts as never)
-      }
-
-      // Length-error recovery: a single pre-computed chunk can still exceed the
-      // wire cap when splitMarkdownChunks hit an indivisible region and emitted
-      // it whole (a giant fenced block, a no-boundary blob). Telegram answers
-      // with RICH_MESSAGE_TEXT_TOO_LONG / MESSAGE_TOO_LONG. Re-split this chunk
-      // at a harder boundary and send each piece, rather than misclassifying it
-      // as a parse-reject (which would resend the same oversized payload as
-      // plain text) or surfacing the raw 400.
-      const sendChunkResplit = async (opts: Record<string, unknown>): Promise<void> => {
-        // Re-split at the same cap; for a truly indivisible block this still
-        // yields one oversized piece, but a hard character-cut on the rendered
-        // markdown at least keeps each delivered piece under the wire cap.
-        const pieces = resplitOversizeChunk(chunks[i])
-        for (let p = 0; p < pieces.length; p++) {
-          let sent: { message_id: number }
-          if (literalText) {
-            // allow-raw-bot-api: length-error re-split last resort (literal text); wrapping would re-enter the chunk-loop's own classification on an already-classified length failure.
-            sent = await lockedBot.api.sendMessage(chat_id, pieces[p], opts as never)
-          } else {
-            const ro = { ...opts }
-            delete (ro as { link_preview_options?: unknown }).link_preview_options
-            // allow-raw-bot-api: length-error re-split last resort (rich); wrapping would re-enter the chunk-loop's own classification on an already-classified length failure.
-            sent = await lockedBot.api.sendRichMessage(chat_id, richMessage(pieces[p]), ro as never)
-          }
-          sentIds.push(sent.message_id)
-          logOutbound('reply', chat_id, sent.message_id, pieces[p].length, `chunk=${i + 1}/${chunks.length} resplit=${p + 1}/${pieces.length}`)
-        }
-        process.stderr.write(
-          `telegram gateway: rich body too long — re-split chunk ${i + 1}/${chunks.length} into ${pieces.length} piece(s)\n`,
-        )
-      }
-
-      try {
-        const sent = await robustApiCall(() => sendChunk(sendOpts), { threadId, chat_id })
-        sentIds.push(sent.message_id)
-        logOutbound('reply', chat_id, sent.message_id, chunks[i].length, `chunk=${i + 1}/${chunks.length}`)
-      } catch (err) {
-        if (err instanceof Error && err.message === 'THREAD_NOT_FOUND') {
-          threadId = undefined
-          const retryOpts = { ...sendOpts }
-          delete (retryOpts as any).message_thread_id
-          try {
-            const sent = await sendChunk(retryOpts)
-            sentIds.push(sent.message_id)
-          } catch (retryErr) {
-            // Thread dropped, AND another failure: length → re-split,
-            // parse-reject → plain text, else propagate.
-            if (isMessageTooLongError(retryErr)) await sendChunkResplit(retryOpts)
-            else if (isHtmlParseRejectError(retryErr)) await sendChunkPlainText(retryOpts)
-            else throw retryErr
-          }
-        } else if (isMessageTooLongError(err)) {
-          await sendChunkResplit(sendOpts)
-        } else if (isHtmlParseRejectError(err)) {
-          await sendChunkPlainText(sendOpts)
-        } else {
-          throw err
-        }
-      }
-    }
+        return editOpts
+      },
+    })
+    threadId = _sendResult.threadId
+    previewMessageId = _sendResult.previewMessageId
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     throw new Error(`reply failed after ${sentIds.length} of ${chunks.length} chunk(s) sent: ${msg}`)

--- a/telegram-plugin/gateway/outbound-send-path.ts
+++ b/telegram-plugin/gateway/outbound-send-path.ts
@@ -33,6 +33,7 @@ import {
   RICH_MESSAGE_MAX_CHARS,
 } from '../format.js'
 import { scrubVoice } from '../text-voice-scrub.js'
+import { isMessageTooLongError, isHtmlParseRejectError } from '../retry-api-call.js'
 
 /** The redactor the caller injects. In gateway this is `redactOutboundText`,
  *  which wraps `redact()` and logs (never the secret value) when a mask fires.
@@ -151,4 +152,224 @@ export function chunkText(text: string, limit: number, mode: 'length' | 'newline
   }
   if (rest) out.push(rest)
   return out
+}
+
+// ─── Send orchestration (#2996 step 1) ────────────────────────────────────
+//
+// The reply chunk-send loop, relocated VERBATIM from executeReply so it can be
+// driven from a unit test against a fake bot API (see
+// outbound-send-path.test.ts). This is the highest-bug-density mechanic of the
+// send path — the recent oversize / wire-cap / parse-reject / THREAD_NOT_FOUND
+// fallback fixes all landed HERE — and it was previously reachable only through
+// the non-importable gateway monolith (gateway.ts runs boot logic + Bun.listen
+// at import, so `executeReply` cannot be invoked from vitest/bun in-place).
+//
+// The module stays bot-agnostic: every Telegram send is an INJECTED function
+// dep, so the raw `bot.api.*` calls (and their retry wrapping + allow-raw-bot-api
+// markers) remain in gateway.ts, and a test passes fakes. The caller keeps
+// building the per-chunk send/edit option objects (so the option shape stays
+// byte-identical to the inline site and the deps surface stays small — 8), pins
+// the turn, owns dedup/voice/history, and threads the shared `sentIds` array by
+// reference. currentTurn is NEVER read here (#1067/#1664).
+
+/** Injected Telegram send surface + logging for {@link sendReplyChunks}. In
+ *  gateway these are thin adapters over `lockedBot.api.*` (retry-wrapped where
+ *  the inline site wrapped them); in tests they are fakes recording call shape. */
+export interface ReplyChunkSendDeps {
+  /** robustApiCall-wrapped rich send. Adapter: `sendRichMessage(richMessage(s))`.
+   *  `threadId` (the live value) is passed into the robustApiCall meta so a
+   *  thread-not-found 400 is converted to THREAD_NOT_FOUND, exactly as inline. */
+  sendRich: (opts: Record<string, unknown>, richBody: unknown, threadId: number | undefined) => Promise<{ message_id: number }>
+  /** robustApiCall-wrapped literal send. Adapter: `sendMessage(chunk)`. */
+  sendLiteral: (opts: Record<string, unknown>, text: string, threadId: number | undefined) => Promise<{ message_id: number }>
+  /** UNwrapped literal send (last-resort fallbacks that must NOT re-enter the
+   *  retry policy that just rejected the payload). Adapter: raw `sendMessage`. */
+  sendLiteralRaw: (opts: Record<string, unknown>, text: string) => Promise<{ message_id: number }>
+  /** UNwrapped rich send (length-error re-split last resort). Adapter: raw
+   *  `sendRichMessage(richMessage(piece))`. */
+  sendRichRaw: (opts: Record<string, unknown>, richBody: unknown) => Promise<{ message_id: number }>
+  /** robustApiCall-wrapped preview edit-in-place. */
+  editPreview: (messageId: number, body: unknown, opts: Record<string, unknown>, threadId: number | undefined) => Promise<unknown>
+  /** rich-markdown wrapper (`richMessage`). Applied to a chunk/piece string. */
+  richMessage: (s: string) => unknown
+  /** outbound logger (`logOutbound`). */
+  logOutbound: (path: 'reply', chatId: string, messageId: number, chars: number, extra?: string) => void
+  /** delete a stale preview message (`deleteStalePreview`). */
+  deleteStalePreview: (id: number) => Promise<void>
+  /** stderr sink (`process.stderr.write`). */
+  stderr: (s: string) => void
+}
+
+/** Mutable send state + per-chunk option builders for {@link sendReplyChunks}.
+ *  The caller owns option shape (byte-identical to the inline site). */
+export interface ReplyChunkSendState {
+  chatId: string
+  chunks: string[]
+  literalText: boolean
+  /** voice-only mode with a full synthesis skips the text body entirely. */
+  suppressText: boolean
+  /** current thread id; re-split/fallbacks may drop it (THREAD_NOT_FOUND). */
+  threadId: number | undefined
+  /** a stale draft-stream preview to edit-in-place on the first chunk, or null. */
+  previewMessageId: number | null
+  /** shared results array — appended in place (voice/file sends push too). */
+  sentIds: number[]
+  /** build the send-options object for chunk `i` (last-chunk flag + live thread). */
+  buildSendOpts: (i: number, isLastChunk: boolean, threadId: number | undefined) => Record<string, unknown>
+  /** build the preview edit-in-place options for the first chunk. */
+  buildPreviewEditOpts: (isLastChunk: boolean) => Record<string, unknown>
+}
+
+export interface ReplyChunkSendResult {
+  /** thread id after any THREAD_NOT_FOUND fallback (used by later file sends). */
+  threadId: number | undefined
+  /** preview id after consumption (null once edited/deleted). */
+  previewMessageId: number | null
+}
+
+/**
+ * Send the pre-computed reply chunks. Relocated verbatim from executeReply's
+ * chunk loop. Appends message ids to `state.sentIds` in order. On an
+ * unrecoverable send error it throws the raw error — the caller wraps it into
+ * the `reply failed after N of M chunk(s) sent` partial-failure contract and
+ * runs the typing-loop `finally`, exactly as before.
+ */
+export async function sendReplyChunks(
+  deps: ReplyChunkSendDeps,
+  state: ReplyChunkSendState,
+): Promise<ReplyChunkSendResult> {
+  const { chatId, chunks, literalText, suppressText, sentIds } = state
+  let threadId = state.threadId
+  let previewMessageId = state.previewMessageId
+
+  for (let i = 0; i < chunks.length; i++) {
+    // PR-C2: voice-only mode with a successful synthesis suppresses the
+    // text body — the spoken voice note IS the reply. Bail before the
+    // first chunk send (sentIds stays empty for text); the voice send
+    // below lands the answer. Any other mode (voice+text, or voice-only
+    // that fell back) sends the text chunks as normal.
+    if (suppressText) break
+    const isLastChunk = i === chunks.length - 1
+    const sendOpts = state.buildSendOpts(i, isLastChunk, threadId)
+
+    if (i === 0 && previewMessageId != null) {
+      const editOpts = state.buildPreviewEditOpts(isLastChunk)
+      try {
+        await deps.editPreview(previewMessageId!, literalText ? chunks[i] : deps.richMessage(chunks[i]), editOpts, threadId)
+        sentIds.push(previewMessageId!)
+        previewMessageId = null
+        continue
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        if (/not modified/i.test(msg)) {
+          sentIds.push(previewMessageId!)
+          previewMessageId = null
+          continue
+        }
+        deps.stderr(`telegram gateway: preview edit-in-place failed (${msg}), sending fresh\n`)
+        await deps.deleteStalePreview(previewMessageId!)
+        previewMessageId = null
+      }
+    }
+
+    // Last-resort: resend this chunk as plain text (no rich wrapper, so
+    // the markdown parser never runs). Keeps thread / reply / markup
+    // params; only the formatting is sacrificed. Used when Telegram
+    // rejects our markdown — better an unformatted answer than a
+    // vanished one. The raw markdown source is itself readable prose, so
+    // we send it verbatim rather than strip anything.
+    const sendChunkPlainText = async (opts: Record<string, unknown>): Promise<void> => {
+      const plain =
+        chunks[i].length > 0
+          ? chunks[i]
+          : '⚠️ (a fragment could not be rendered for Telegram)'
+      const sent = await deps.sendLiteralRaw(opts, plain)
+      sentIds.push(sent.message_id)
+      deps.logOutbound('reply', chatId, sent.message_id, plain.length, `chunk=${i + 1}/${chunks.length} plaintext-fallback`)
+      deps.stderr(
+        `telegram gateway: markdown parse-reject — resent chunk ${i + 1}/${chunks.length} as plain text\n`,
+      )
+    }
+
+    // Literal `format:'text'` sends bypass the rich parser entirely
+    // (plain sendMessage, no markdown). The default path ships rich
+    // markdown via sendRichMessage. Both resolve to a Message with a
+    // message_id, which is all the caller reads.
+    //
+    // `wrapped` selects the retry-wrapped adapter (first attempt) vs the
+    // UNwrapped adapter (THREAD_NOT_FOUND retry). The inline site wrapped only
+    // the first attempt in robustApiCall; the retry called the raw send
+    // deliberately, so re-attempting after a dropped thread never re-enters the
+    // retry policy. Preserving that split keeps behavior byte-identical.
+    const sendChunk = (opts: Record<string, unknown>, wrapped: boolean): Promise<{ message_id: number }> => {
+      if (literalText) {
+        return wrapped ? deps.sendLiteral(opts, chunks[i], threadId) : deps.sendLiteralRaw(opts, chunks[i])
+      }
+      // sendRichMessage does NOT accept link_preview_options (rich messages
+      // control previews via entity detection) — drop it for the rich path.
+      const richOpts = { ...opts }
+      delete (richOpts as { link_preview_options?: unknown }).link_preview_options
+      const richBody = deps.richMessage(chunks[i])
+      return wrapped ? deps.sendRich(richOpts, richBody, threadId) : deps.sendRichRaw(richOpts, richBody)
+    }
+
+    // Length-error recovery: a single pre-computed chunk can still exceed the
+    // wire cap when splitMarkdownChunks hit an indivisible region and emitted
+    // it whole (a giant fenced block, a no-boundary blob). Telegram answers
+    // with RICH_MESSAGE_TEXT_TOO_LONG / MESSAGE_TOO_LONG. Re-split this chunk
+    // at a harder boundary and send each piece, rather than misclassifying it
+    // as a parse-reject (which would resend the same oversized payload as
+    // plain text) or surfacing the raw 400.
+    const sendChunkResplit = async (opts: Record<string, unknown>): Promise<void> => {
+      // Re-split at the same cap; for a truly indivisible block this still
+      // yields one oversized piece, but a hard character-cut on the rendered
+      // markdown at least keeps each delivered piece under the wire cap.
+      const pieces = resplitOversizeChunk(chunks[i])
+      for (let p = 0; p < pieces.length; p++) {
+        let sent: { message_id: number }
+        if (literalText) {
+          sent = await deps.sendLiteralRaw(opts, pieces[p])
+        } else {
+          const ro = { ...opts }
+          delete (ro as { link_preview_options?: unknown }).link_preview_options
+          sent = await deps.sendRichRaw(ro, deps.richMessage(pieces[p]))
+        }
+        sentIds.push(sent.message_id)
+        deps.logOutbound('reply', chatId, sent.message_id, pieces[p].length, `chunk=${i + 1}/${chunks.length} resplit=${p + 1}/${pieces.length}`)
+      }
+      deps.stderr(
+        `telegram gateway: rich body too long — re-split chunk ${i + 1}/${chunks.length} into ${pieces.length} piece(s)\n`,
+      )
+    }
+
+    try {
+      const sent = await sendChunk(sendOpts, true)
+      sentIds.push(sent.message_id)
+      deps.logOutbound('reply', chatId, sent.message_id, chunks[i].length, `chunk=${i + 1}/${chunks.length}`)
+    } catch (err) {
+      if (err instanceof Error && err.message === 'THREAD_NOT_FOUND') {
+        threadId = undefined
+        const retryOpts = { ...sendOpts }
+        delete (retryOpts as Record<string, unknown>).message_thread_id
+        try {
+          const sent = await sendChunk(retryOpts, false)
+          sentIds.push(sent.message_id)
+        } catch (retryErr) {
+          // Thread dropped, AND another failure: length → re-split,
+          // parse-reject → plain text, else propagate.
+          if (isMessageTooLongError(retryErr)) await sendChunkResplit(retryOpts)
+          else if (isHtmlParseRejectError(retryErr)) await sendChunkPlainText(retryOpts)
+          else throw retryErr
+        }
+      } else if (isMessageTooLongError(err)) {
+        await sendChunkResplit(sendOpts)
+      } else if (isHtmlParseRejectError(err)) {
+        await sendChunkPlainText(sendOpts)
+      } else {
+        throw err
+      }
+    }
+  }
+
+  return { threadId, previewMessageId }
 }

--- a/telegram-plugin/tests/emission-determinism-wiring.test.ts
+++ b/telegram-plugin/tests/emission-determinism-wiring.test.ts
@@ -131,10 +131,17 @@ describe('lever 2 — finalize the card BEFORE a substantive reply send', () => 
     return after.split('\nasync function ')[0]?.split('\nfunction ')[0] ?? after
   }
 
-  it('executeReply finalizes (clearActivitySummary) before the chunk loop, gated on substantive', () => {
+  // #2996 step 1: the chunk send loop was relocated verbatim from executeReply
+  // into outbound-send-path.ts's `sendReplyChunks`, invoked here as
+  // `await sendReplyChunks(chunkSendDeps, …)`. This guard's INTENT — the
+  // lever-2 card finalize runs BEFORE the reply send — is unchanged; the send
+  // marker is now the delegation call rather than the inline `for` loop.
+  const SEND_MARKER = 'sendReplyChunks('
+
+  it('executeReply finalizes (clearActivitySummary) before the reply send, gated on substantive', () => {
     const src = executeReplySrc()
     const clearIdx = src.indexOf('clearActivitySummary(')
-    const loopIdx = src.indexOf('for (let i = 0; i < chunks.length')
+    const loopIdx = src.indexOf(SEND_MARKER)
     expect(clearIdx).toBeGreaterThan(-1)
     expect(loopIdx).toBeGreaterThan(-1)
     expect(clearIdx).toBeLessThan(loopIdx)
@@ -148,8 +155,8 @@ describe('lever 2 — finalize the card BEFORE a substantive reply send', () => 
     // An ack (non-substantive) falls through and never finalizes early, so the
     // reopen path keeps owning the card (the #2141 ack-then-work feed).
     const replySrc = executeReplySrc()
-    // The pre-loop clearActivitySummary must be the substantive-gated one.
-    const preLoop = replySrc.split('for (let i = 0; i < chunks.length')[0] ?? ''
+    // The pre-send clearActivitySummary must be the substantive-gated one.
+    const preLoop = replySrc.split(SEND_MARKER)[0] ?? ''
     const clears = [...preLoop.matchAll(/clearActivitySummary\(/g)]
     expect(clears).toHaveLength(1)
   })

--- a/telegram-plugin/tests/outbound-send-chunks.test.ts
+++ b/telegram-plugin/tests/outbound-send-chunks.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Invocable send-loop harness (#2996 step 1).
+ *
+ * PR 3007 extracted the deterministic text/chunk CORE of the outbound path but
+ * noted the side-effecting send ORCHESTRATION could not be moved (or tested)
+ * without an "invocable-executeReply harness" — because gateway.ts is not
+ * importable in any test runner: it runs boot logic (acquires the PID lock,
+ * `process.exit(1)` when another gateway is live) and calls `Bun.listen` at
+ * import time, so `executeReply` can never be driven from vitest/bun in-place.
+ *
+ * This harness closes that gap for the highest-bug-density mechanic of the send
+ * path — the chunk-send loop with its THREAD_NOT_FOUND / oversize re-split /
+ * parse-reject fallback ladder and partial-failure contract (exactly where the
+ * recent oversize / wire-cap fixes landed). `sendReplyChunks` was relocated
+ * VERBATIM from executeReply and is now driven here against a FAKE bot API,
+ * asserting: multi-chunk send order, partial-failure contract (which chunks
+ * report sent), oversize re-send, HTML parse-reject plaintext fallback,
+ * THREAD_NOT_FOUND thread-drop + retry, keyboard-on-last-chunk passthrough,
+ * preview edit-in-place, and voice-only text suppression.
+ *
+ * The gateway keeps the raw `bot.api.*` calls as thin injected adapters; the
+ * module is bot-agnostic, so a fake is a plain record of function calls. The
+ * cross-surface `outboundDedup` singleton contract is covered by the sibling
+ * `outbound-send-path.test.ts` (a stream-path `record` suppresses a reply-path
+ * `check` on the same instance) — dedup lives in executeReply, not in this
+ * relocated loop, so it is intentionally out of scope here.
+ */
+import { describe, it, expect } from 'vitest'
+import { GrammyError } from 'grammy'
+import {
+  sendReplyChunks,
+  type ReplyChunkSendDeps,
+  type ReplyChunkSendState,
+} from '../gateway/outbound-send-path.js'
+
+// Build a GrammyError with a given 400 description (grammy 1.44 ctor shape).
+function grammy400(description: string, method = 'sendRichMessage'): GrammyError {
+  return new GrammyError(
+    `Call to '${method}' failed! (400: ${description})`,
+    { ok: false, error_code: 400, description },
+    method,
+    {},
+  )
+}
+
+interface RecordedCall {
+  kind: 'sendRich' | 'sendLiteral' | 'sendLiteralRaw' | 'sendRichRaw' | 'editPreview'
+  opts: Record<string, unknown>
+  body: unknown
+  threadId?: number | undefined
+  messageId?: number
+}
+
+/**
+ * Fake bot surface. `sendRich`/`sendLiteral` are the retry-wrapped adapters;
+ * `*Raw` are the unwrapped last-resort adapters; `editPreview` is the
+ * preview edit-in-place. Each records its call; per-kind `failers` inject
+ * one-shot errors (keyed by chunk-body identity or call index) so we can
+ * script the fallback ladder deterministically.
+ */
+function makeFake(opts?: {
+  failNext?: Partial<Record<RecordedCall['kind'], Array<unknown>>>
+  richMessage?: (s: string) => unknown
+}): {
+  deps: ReplyChunkSendDeps
+  calls: RecordedCall[]
+  stderr: string[]
+  logs: Array<{ id: number; chars: number; extra?: string }>
+  deleted: number[]
+} {
+  const calls: RecordedCall[] = []
+  const stderr: string[] = []
+  const logs: Array<{ id: number; chars: number; extra?: string }> = []
+  const deleted: number[] = []
+  let nextId = 1000
+  const queues = opts?.failNext ?? {}
+
+  const maybeFail = (kind: RecordedCall['kind']): void => {
+    const q = queues[kind]
+    if (q && q.length > 0) {
+      const e = q.shift()
+      if (e != null) throw e
+    }
+  }
+  const send = (
+    kind: RecordedCall['kind'],
+    o: Record<string, unknown>,
+    body: unknown,
+    threadId?: number | undefined,
+  ): Promise<{ message_id: number }> => {
+    // Evaluate the failure queue synchronously so a thrown GrammyError
+    // rejects the returned promise exactly as the real adapter would.
+    return (async () => {
+      maybeFail(kind)
+      const id = ++nextId
+      calls.push({ kind, opts: o, body, threadId, messageId: id })
+      return { message_id: id }
+    })()
+  }
+
+  const deps: ReplyChunkSendDeps = {
+    sendRich: (o, body, tid) => send('sendRich', o, body, tid),
+    sendLiteral: (o, txt, tid) => send('sendLiteral', o, txt, tid),
+    sendLiteralRaw: (o, txt) => send('sendLiteralRaw', o, txt),
+    sendRichRaw: (o, body) => send('sendRichRaw', o, body),
+    editPreview: async (mid, body, o, tid) => {
+      maybeFail('editPreview')
+      calls.push({ kind: 'editPreview', opts: o, body, threadId: tid, messageId: mid })
+      return {}
+    },
+    richMessage: opts?.richMessage ?? ((s: string) => ({ rich: s })),
+    logOutbound: (_path, _chat, id, chars, extra) => { logs.push({ id, chars, extra }) },
+    deleteStalePreview: async (id) => { deleted.push(id) },
+    stderr: (s) => { stderr.push(s) },
+  }
+  return { deps, calls, stderr, logs, deleted }
+}
+
+function baseState(over: Partial<ReplyChunkSendState> & { chunks: string[] }): ReplyChunkSendState {
+  return {
+    chatId: '555',
+    literalText: false,
+    suppressText: false,
+    threadId: undefined,
+    previewMessageId: null,
+    sentIds: [],
+    buildSendOpts: (i, isLastChunk, tid) => ({
+      ...(tid != null ? { message_thread_id: tid } : {}),
+      ...(isLastChunk ? { _last: true } : {}),
+      _chunkIndex: i,
+    }),
+    buildPreviewEditOpts: () => ({}),
+    ...over,
+  }
+}
+
+describe('sendReplyChunks — multi-chunk send order', () => {
+  it('sends every chunk in order and appends ids to the shared sentIds array', async () => {
+    const { deps, calls } = makeFake()
+    const state = baseState({ chunks: ['a', 'b', 'c'] })
+    const res = await sendReplyChunks(deps, state)
+    expect(calls.map((c) => c.kind)).toEqual(['sendRich', 'sendRich', 'sendRich'])
+    expect(calls.map((c) => c.body)).toEqual([{ rich: 'a' }, { rich: 'b' }, { rich: 'c' }])
+    // ids appended in order, one per chunk
+    expect(state.sentIds).toHaveLength(3)
+    expect(state.sentIds).toEqual([...state.sentIds].sort((x, y) => x - y))
+    expect(res.threadId).toBeUndefined()
+  })
+
+  it('literal (format:text) chunks route through sendLiteral, never rich', async () => {
+    const { deps, calls } = makeFake()
+    const state = baseState({ chunks: ['x', 'y'], literalText: true })
+    await sendReplyChunks(deps, state)
+    expect(calls.map((c) => c.kind)).toEqual(['sendLiteral', 'sendLiteral'])
+    expect(calls.map((c) => c.body)).toEqual(['x', 'y'])
+  })
+
+  it('voice-only suppressText sends NOTHING (voice note IS the reply)', async () => {
+    const { deps, calls } = makeFake()
+    const state = baseState({ chunks: ['a', 'b'], suppressText: true })
+    await sendReplyChunks(deps, state)
+    expect(calls).toHaveLength(0)
+    expect(state.sentIds).toHaveLength(0)
+  })
+})
+
+describe('sendReplyChunks — keyboard/opts passthrough', () => {
+  it('reply_markup rides ONLY on the last chunk (isLastChunk gate)', async () => {
+    const { deps, calls } = makeFake()
+    const state = baseState({
+      chunks: ['one', 'two', 'three'],
+      buildSendOpts: (i, isLastChunk, tid) => ({
+        ...(tid != null ? { message_thread_id: tid } : {}),
+        ...(isLastChunk ? { reply_markup: { inline_keyboard: [[{ text: 'Go', callback_data: 'x' }]] } } : {}),
+      }),
+    })
+    await sendReplyChunks(deps, state)
+    expect(calls[0].opts.reply_markup).toBeUndefined()
+    expect(calls[1].opts.reply_markup).toBeUndefined()
+    expect(calls[2].opts.reply_markup).toBeDefined()
+  })
+
+  it('rich path strips link_preview_options before sending (rich entity previews)', async () => {
+    const { deps, calls } = makeFake()
+    const state = baseState({
+      chunks: ['only'],
+      buildSendOpts: () => ({ link_preview_options: { is_disabled: true }, keepme: 1 }),
+    })
+    await sendReplyChunks(deps, state)
+    expect(calls[0].opts.link_preview_options).toBeUndefined()
+    expect(calls[0].opts.keepme).toBe(1)
+  })
+})
+
+describe('sendReplyChunks — partial-failure contract', () => {
+  it('an unrecoverable error midway propagates, and sentIds holds ONLY the chunks already sent', async () => {
+    // chunk 0 ok, chunk 1 throws a non-400 (not length, not parse) → rethrow.
+    const boom = new Error('network exploded')
+    const { deps, calls } = makeFake({ failNext: { sendRich: [undefined, boom] } })
+    const state = baseState({ chunks: ['first', 'second', 'third'] })
+    await expect(sendReplyChunks(deps, state)).rejects.toThrow('network exploded')
+    // first chunk reported sent; second/third never appended.
+    expect(state.sentIds).toHaveLength(1)
+    // exactly one send succeeded (chunk 1 threw before being recorded).
+    expect(calls.filter((c) => c.kind === 'sendRich')).toHaveLength(1)
+  })
+})
+
+describe('sendReplyChunks — oversize re-send', () => {
+  it('a RICH_MESSAGE_TEXT_TOO_LONG on the wrapped send re-splits via the raw rich adapter', async () => {
+    // A chunk far past the wire cap so resplitOversizeChunk yields >1 piece.
+    const huge = 'x'.repeat(70_000)
+    const { deps, calls } = makeFake({ failNext: { sendRich: [grammy400('RICH_MESSAGE_TEXT_TOO_LONG')] } })
+    const state = baseState({ chunks: [huge] })
+    await sendReplyChunks(deps, state)
+    const raws = calls.filter((c) => c.kind === 'sendRichRaw')
+    expect(raws.length).toBeGreaterThan(1)
+    // every re-split piece landed a message id
+    expect(state.sentIds.length).toBe(raws.length)
+  })
+})
+
+describe('sendReplyChunks — parse-reject plaintext fallback', () => {
+  it("a can't-parse-entities 400 resends the chunk as plain text via sendLiteralRaw", async () => {
+    const { deps, calls } = makeFake({ failNext: { sendRich: [grammy400("can't parse entities: bad offset")] } })
+    const state = baseState({ chunks: ['**bad markdown'] })
+    await sendReplyChunks(deps, state)
+    expect(calls.map((c) => c.kind)).toEqual(['sendLiteralRaw'])
+    expect(calls[0].body).toBe('**bad markdown')
+    expect(state.sentIds).toHaveLength(1)
+  })
+
+  it('an empty chunk parse-reject falls back to the placeholder glyph', async () => {
+    const { deps, calls } = makeFake({ failNext: { sendRich: [grammy400("can't parse entities")] } })
+    const state = baseState({ chunks: [''] })
+    await sendReplyChunks(deps, state)
+    expect(calls[0].kind).toBe('sendLiteralRaw')
+    expect(String(calls[0].body)).toContain('could not be rendered')
+  })
+})
+
+describe('sendReplyChunks — THREAD_NOT_FOUND fallback', () => {
+  it('drops the thread and retries UNWRAPPED, and returns threadId undefined', async () => {
+    // wrapped send throws THREAD_NOT_FOUND; retry (raw) succeeds.
+    const tnf = new Error('THREAD_NOT_FOUND')
+    const { deps, calls } = makeFake({ failNext: { sendRich: [tnf] } })
+    const state = baseState({ chunks: ['hi'], threadId: 42 })
+    const res = await sendReplyChunks(deps, state)
+    // The first (wrapped) attempt threw before recording; the retry uses
+    // sendChunk(_, false) → the UNWRAPPED raw adapter, deliberately not
+    // re-entering the retry policy after a dropped thread.
+    expect(calls[0].kind).toBe('sendRichRaw')
+    // retry re-built opts WITHOUT the thread id.
+    expect(res.threadId).toBeUndefined()
+    expect(calls[0].opts.message_thread_id).toBeUndefined()
+    expect(state.sentIds).toHaveLength(1)
+  })
+
+  it('THREAD_NOT_FOUND then a length error on retry re-splits', async () => {
+    const tnf = new Error('THREAD_NOT_FOUND')
+    const huge = 'y'.repeat(70_000)
+    const { deps, calls } = makeFake({
+      failNext: { sendRich: [tnf], sendRichRaw: [grammy400('MESSAGE_TOO_LONG')] },
+    })
+    const state = baseState({ chunks: [huge], threadId: 7 })
+    await sendReplyChunks(deps, state)
+    // retry (raw) threw length → resplit sent multiple raw pieces
+    const raws = calls.filter((c) => c.kind === 'sendRichRaw')
+    expect(raws.length).toBeGreaterThan(1)
+  })
+})
+
+describe('sendReplyChunks — preview edit-in-place', () => {
+  it('edits the stale preview on the first chunk, consumes it, then sends the rest fresh', async () => {
+    const { deps, calls } = makeFake()
+    const state = baseState({ chunks: ['a', 'b'], previewMessageId: 900 })
+    const res = await sendReplyChunks(deps, state)
+    expect(calls[0].kind).toBe('editPreview')
+    expect(calls[0].messageId).toBe(900)
+    // preview id consumed → subsequent chunk is a fresh send
+    expect(calls[1].kind).toBe('sendRich')
+    expect(res.previewMessageId).toBeNull()
+    // first sentId is the reused preview id
+    expect(state.sentIds[0]).toBe(900)
+  })
+
+  it('a failed preview edit deletes the stale preview and sends fresh', async () => {
+    const { deps, calls, deleted } = makeFake({ failNext: { editPreview: [new Error('message to edit not found')] } })
+    const state = baseState({ chunks: ['a'], previewMessageId: 901 })
+    const res = await sendReplyChunks(deps, state)
+    expect(deleted).toEqual([901])
+    expect(calls.some((c) => c.kind === 'sendRich')).toBe(true)
+    expect(res.previewMessageId).toBeNull()
+  })
+
+  it('a "not modified" preview edit is treated as success (id reused, no fresh send)', async () => {
+    const { deps, calls, deleted } = makeFake({ failNext: { editPreview: [new Error('Bad Request: message is not modified')] } })
+    const state = baseState({ chunks: ['a'], previewMessageId: 902 })
+    await sendReplyChunks(deps, state)
+    expect(deleted).toEqual([])
+    expect(state.sentIds).toEqual([902])
+    expect(calls.filter((c) => c.kind === 'sendRich')).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Step reached: **step 1 (invocable harness)** — and deliberately stopped there per the task's own guardrail.

Follow-up to PR 3007, which extracted the deterministic text/chunk core of the outbound path and explicitly named an *"invocable-executeReply harness"* as the prerequisite for moving the send orchestration. This PR delivers a testable, invocable slice of that orchestration and documents why the full `sendReply(deps, req)` façade should **not** be taken.

## Key finding — why "export executeReply with injected deps" is impossible

`gateway.ts` is **not importable in any test runner**. At import time it runs boot logic (acquires the PID lock, calls `process.exit(1)` when another gateway is already live) and calls `Bun.listen` (undefined under vitest/node). A probe import fails with `Bun is not defined` inside `createIpcServer`. So the first option PR 3007 listed — "export executeReply itself with an injected deps parameter" — cannot make executeReply invocable in-place. Making *any* of executeReply testable requires relocating logic into an importable module.

## What this PR does

Relocates executeReply's **chunk-send loop** — the highest-bug-density mechanic of the send path (the THREAD_NOT_FOUND / oversize re-split / HTML-parse-reject fallback ladder and the partial-failure contract, exactly where the recent oversize/wire-cap fixes landed) — **verbatim** into `outbound-send-path.ts` as `sendReplyChunks(deps, state)`, and drives it from a fake-bot harness.

### Deps surface: **8** (well within the ~25 guardrail)
`sendRich`, `sendLiteral`, `sendLiteralRaw`, `sendRichRaw`, `editPreview`, `richMessage`, `logOutbound`, `deleteStalePreview`, `stderr`. The module stays **bot-agnostic**: every Telegram send is an injected function, so all raw `bot.api.*` calls (with their retry wrapping + `allow-raw-bot-api` markers) **remain in gateway.ts** as thin adapters — `check-bot-api-wrapping`'s allowlist is unchanged. The caller keeps building the per-chunk option objects (byte-identical option shape), pins the turn, and owns dedup/voice/history. `currentTurn` is never read in the module (#1067/#1664). Preserved fidelity: the first-attempt `robustApiCall`-wrapped send vs the **unwrapped** THREAD_NOT_FOUND retry, and the live `threadId` threaded into the retry-wrap meta (so a thread-not-found 400 still converts to `THREAD_NOT_FOUND`).

## Why step 2 (full `sendReply` façade) was NOT taken

The remaining executeReply orchestration (dedup check/record on the shared `outboundDedup` singleton, over-ping/emission-authority, activity-card finalize, voice synthesis+sends, typing loops, history, silent-anchor edit, files/album send, obligation close, thread routing, Telegraph) reads **40–50** gateway singletons and cannot be pinned byte-identical in one pass. That is past the ~25 threshold the task set as the STOP condition, so per instruction this ships the invocable harness for the send loop alone. A tested-in-place-ish loop behind a small importable seam is the intended "fine outcome."

## Test evidence

- **New harness** `telegram-plugin/tests/outbound-send-chunks.test.ts` — 14 tests, all green: multi-chunk send order, literal vs rich routing, voice-only text suppression, keyboard-on-last-chunk + link_preview strip, partial-failure contract, oversize `RICH_MESSAGE_TEXT_TOO_LONG` re-split, parse-reject plaintext fallback, THREAD_NOT_FOUND drop+unwrapped retry (and TNF-then-length), preview edit-in-place (success / not-modified / failed→delete→fresh).
- Sibling golden `outbound-send-path.test.ts` (40) + `turn-flush-safety` (45) + `length-error-classify` (13) + `gateway-outbound-redact` (7): green.
- **`emission-determinism-wiring.test.ts`**: its lever-2 structural guard keyed on the inline `for (let i = 0; i < chunks.length` marker — re-pointed to the new `sendReplyChunks(` delegation marker (intent, finalize-before-send, unchanged).
- **Full `telegram-plugin/tests`**: 5464 passed. Remaining failures are the **pre-existing mdast worktree artifact** (italic `*`→`_` rendering on the stream path): `status-accent`, `single-mode-stream-reply`, `stream-controller-chunk-cap`, `stream-reply-handler` — proven identical on pristine `origin/main` (baseline: same 4 files fail, plus a `worker-feed-dispatch` flake; my branch had an `emission-determinism-wiring` structural failure that this PR fixes). **Zero new failures** from the diff.
- **`npm run lint`**: clean — `tsc --noEmit` + all 8 guards (`check-bot-api-wrapping` clean, allowlist untouched; `check-no-pii-secrets` clean).

## Residual risk

- The relocated loop is byte-identical but the file-line `check-bot-api-wrapping` allowlist for `gateway.ts` shifts with the deletion (only ADDITIONS fail it — the guard is green).
- The full send-orchestration façade remains inline and is the next step under #2996 Phase 2, but should only be attempted once the 40–50 singleton surface can be pinned (likely after the approval-card / turn-lifecycle extractions shrink gateway's shared state).

Refs #2996. Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)