### PR TITLE
refactor(telegram): long-tail pending state behind stores (#2996)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5478,7 +5478,10 @@ interface PendingAskUser {
   timer: ReturnType<typeof setTimeout>
   startedAt: number
 }
-const pendingAskUser = new Map<string, PendingAskUser>()
+// Storage extracted to pending-state-stores.ts (#2996 Phase 3 step 2). Plain
+// store (no TTL sweep): entries are bounded by per-entry timers and cleared on
+// resolution / shutdown / chat-close, not by the reaper.
+const pendingAskUser = createPlainStore<PendingAskUser>()
 
 // Reauth flows. Storage extracted to pending-state-stores.ts (#2996 Phase 3
 // step 2): the store owns the Map + co-locates the delete-past-TTL sweep the

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5502,7 +5502,11 @@ const REAUTH_INTERCEPT_TTL_MS = 10 * 60_000
 // design: when this map is empty (e.g. fresh process) the defaults apply
 // (`'✓ received'` toast + strip keyboard) — the agent only loses any
 // custom ack_text override.
-const agentButtonMeta = new Map<string, Map<string, AgentButtonMeta>>()
+// Storage extracted to pending-state-stores.ts (#2996 Phase 3 step 2). Plain
+// store (no TTL sweep): bounded by the AGENT_BUTTON_META_MAX LRU cap enforced
+// in rememberAgentButtonMeta, not the reaper. keys().next().value gives the
+// oldest insertion for eviction — Map-surface parity preserved.
+const agentButtonMeta = createPlainStore<Map<string, AgentButtonMeta>>()
 const AGENT_BUTTON_META_MAX = 1000
 function rememberAgentButtonMeta(
   chatId: string | number,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5661,7 +5661,12 @@ type PendingVaultOp =
       startedAt: number
     }
 const VAULT_INPUT_TTL_MS = 5 * 60 * 1000
-const pendingVaultOps = new Map<string, PendingVaultOp>()
+// Storage extracted to pending-state-stores.ts (#2996 Phase 3 step 2): the
+// store owns the Map + co-locates the delete-past-TTL sweep the reaper drove
+// inline. TTL + direction stay here (byte-identical: now - startedAt > TTL).
+const pendingVaultOps = createSweepableStore<PendingVaultOp>(
+  (v, now) => now - v.startedAt > VAULT_INPUT_TTL_MS,
+)
 
 // Secret-detection staging: ambiguous hits the user must confirm before we
 // store/delete. Also holds the deferred "we need a passphrase before we can
@@ -6390,9 +6395,7 @@ const pendingStateReaper = setInterval(() => {
   for (const [k, v] of pendingAuthRmFlows) {
     if (now >= v.expiresAt) pendingAuthRmFlows.delete(k)
   }
-  for (const [k, v] of pendingVaultOps) {
-    if (now - v.startedAt > VAULT_INPUT_TTL_MS) pendingVaultOps.delete(k)
-  }
+  pendingVaultOps.sweep(now)
   for (const [k, v] of pendingPermissions) {
     // hostd gated fleet-mutation verbs get a longer (30-min) human-scale
     // decision window than the 10-min default (Bug 2 fix #2).

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5480,8 +5480,14 @@ interface PendingAskUser {
 }
 const pendingAskUser = new Map<string, PendingAskUser>()
 
-// Reauth flows
-const pendingReauthFlows = new Map<string, { agent: string; startedAt: number }>()
+// Reauth flows. Storage extracted to pending-state-stores.ts (#2996 Phase 3
+// step 2): the store owns the Map + co-locates the delete-past-TTL sweep the
+// reaper drove inline. Direction preserved: now - startedAt > TTL. The sweep
+// call stays in the SAME reaper position (first, ahead of the OAuth-code
+// cluster) so the awaitingAuthCodeAt contiguity pin is unaffected.
+const pendingReauthFlows = createSweepableStore<{ agent: string; startedAt: number }>(
+  (v, now) => now - v.startedAt > REAUTH_INTERCEPT_TTL_MS,
+)
 const REAUTH_INTERCEPT_TTL_MS = 10 * 60_000
 
 // #710: per-message agent-button metadata (ack_text / single_use). Keyed by
@@ -6372,9 +6378,7 @@ function restorePendingApprovalCards(): number {
 const pendingStateReaper = setInterval(() => {
   const now = Date.now()
   // OAuth-code state grouped first (pinned by secret-detect-oauth-code.test.ts).
-  for (const [k, v] of pendingReauthFlows) {
-    if (now - v.startedAt > REAUTH_INTERCEPT_TTL_MS) pendingReauthFlows.delete(k)
-  }
+  pendingReauthFlows.sweep(now)
   for (const [k, v] of pendingAuthAddFlows) {
     if (now - v.startedAt > REAUTH_INTERCEPT_TTL_MS) {
       cancelAccountAuthSession(v)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -137,6 +137,7 @@ import {
 } from './approval-timeout-inbound-builders.js'
 import { expirePendingCard } from './pending-card-expiry.js'
 import { createSweepableCardStore } from './approval-card-stores.js'
+import { createSweepableStore, createPlainStore } from './pending-state-stores.js'
 import {
   isPermissionRearmEnabled,
   permissionRearmGraceMs,
@@ -5398,14 +5399,15 @@ const PERMISSION_CARD_ORIGIN_MAX_AGE_MS = 30 * 60_000
 // other field finds no entry and falls through to a real operator card.
 // Single-shot (deleted on match) + 30s TTL sweep so a stale correlation
 // can't be replayed.
-const pendingAlwaysAllowCorrelations = new Map<string, { agentName: string; rule: string; unifiedDiff: string; createdAt: number }>()
 const ALWAYS_ALLOW_CORRELATION_TTL_MS = 30_000
+// Storage extracted to pending-state-stores.ts (#2996 Phase 3 step 2): the
+// store owns the Map + co-locates the delete-past-TTL sweep. The TTL and its
+// comparison direction stay here in the injected predicate (byte-identical).
+const pendingAlwaysAllowCorrelations = createSweepableStore<{ agentName: string; rule: string; unifiedDiff: string; createdAt: number }>(
+  (entry, now) => now - entry.createdAt > ALWAYS_ALLOW_CORRELATION_TTL_MS,
+)
 function sweepStaleAlwaysAllowCorrelations(now = Date.now()): void {
-  for (const [key, entry] of pendingAlwaysAllowCorrelations) {
-    if (now - entry.createdAt > ALWAYS_ALLOW_CORRELATION_TTL_MS) {
-      pendingAlwaysAllowCorrelations.delete(key)
-    }
-  }
+  pendingAlwaysAllowCorrelations.sweep(now)
 }
 
 // Sibling of pendingAlwaysAllowCorrelations for the agent-proposes →
@@ -5428,16 +5430,17 @@ function sweepStaleAlwaysAllowCorrelations(now = Date.now()): void {
 // slow-but-valid tap, dropping the auto-approve and surfacing a SECOND card
 // for an edit the operator already approved. Size it to the hostd budget.
 const MENTAL_MODEL_CORRELATION_TTL_MS = 720_000
-const pendingMentalModelCorrelations = new Map<string, { agentName: string; unifiedDiff: string; createdAt: number }>()
+// Storage extracted to pending-state-stores.ts (#2996 Phase 3 step 2). Same
+// pattern as pendingAlwaysAllowCorrelations, but the predicate closes over the
+// larger 720s TTL that must outlive the whole config-edit approval budget.
+const pendingMentalModelCorrelations = createSweepableStore<{ agentName: string; unifiedDiff: string; createdAt: number }>(
+  (entry, now) => now - entry.createdAt > MENTAL_MODEL_CORRELATION_TTL_MS,
+)
 function mentalModelCorrelationKey(agentName: string, unifiedDiff: string): string {
   return `${agentName}::${createHash('sha256').update(unifiedDiff).digest('hex')}`
 }
 function sweepStaleMentalModelCorrelations(now = Date.now()): void {
-  for (const [key, entry] of pendingMentalModelCorrelations) {
-    if (now - entry.createdAt > MENTAL_MODEL_CORRELATION_TTL_MS) {
-      pendingMentalModelCorrelations.delete(key)
-    }
-  }
+  pendingMentalModelCorrelations.sweep(now)
 }
 
 // Scoped-approval store: the 30-min window that backs the "✅ Allow" tap for

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5511,7 +5511,11 @@ function rememberAgentButtonMeta(
 }
 
 // Vault
-const vaultPassphraseCache = new Map<string, { passphrase: string; expiresAt: number }>()
+// Storage extracted to pending-state-stores.ts (#2996 Phase 3 step 2). Absolute
+// expiry: the sweep deletes when now > expiresAt (direction preserved verbatim).
+const vaultPassphraseCache = createSweepableStore<{ passphrase: string; expiresAt: number }>(
+  (v, now) => now > v.expiresAt,
+)
 const VAULT_PASSPHRASE_TTL_MS = 30 * 60 * 1000
 
 /**
@@ -6474,9 +6478,7 @@ const pendingStateReaper = setInterval(() => {
   for (const [sig, at] of permissionTimeoutSignatures) {
     if (now - at > PERMISSION_DUPLICATE_WINDOW_MS) permissionTimeoutSignatures.delete(sig)
   }
-  for (const [k, v] of vaultPassphraseCache) {
-    if (now > v.expiresAt) vaultPassphraseCache.delete(k)
-  }
+  vaultPassphraseCache.sweep(now)
   // Drop expired "⏱ 30 min" scoped grants. (Lookup already fails closed on
   // expiry; this just keeps the map from accumulating dead entries.) Persist
   // the removal so a restart between sweeps can't resurrect a swept grant —

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5703,7 +5703,13 @@ interface DeferredSecret {
    */
   kernel_request_id?: string
 }
-const deferredSecrets = new Map<string, DeferredSecret>()
+// Storage extracted to pending-state-stores.ts (#2996 Phase 3 step 2). The
+// isExpired predicate reads DEFERRED_SECRET_TTL_MS lazily at sweep time (it is
+// declared below this const but only referenced when the reaper sweeps, so the
+// TDZ never bites). Direction preserved: now - staged_at > TTL.
+const deferredSecrets = createSweepableStore<DeferredSecret>(
+  (v, now) => now - v.staged_at > DEFERRED_SECRET_TTL_MS,
+)
 
 /**
  * Agent-initiated save staging (issue #969 P1a). When an agent calls the
@@ -6488,9 +6494,7 @@ const pendingStateReaper = setInterval(() => {
   if (countScopedGrants(scopedGrants) !== scopedGrantsBefore) {
     scopedGrantStore.save(scopedGrants)
   }
-  for (const [k, v] of deferredSecrets) {
-    if (now - v.staged_at > DEFERRED_SECRET_TTL_MS) deferredSecrets.delete(k)
-  }
+  deferredSecrets.sweep(now)
   // Agent-initiated approval cards (vault_request_access / vault_request_save /
   // request_secret / mental_model_propose): expire past-TTL entries and WAKE
   // the parked agent (timeout synthetic + missed-approvals re-offer). This is

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -12675,7 +12675,12 @@ interface PendingSecretRequest {
 // chat_id -> the armed capture: the operator's NEXT message in this chat is
 // the value for `key`. Set when [Provide securely] is tapped.
 interface ArmedSecretCapture { key: string; agent: string; stageId: string; armed_at: number; threadId?: number }
-const armedSecretCaptures = new Map<string, ArmedSecretCapture>()
+// Storage extracted to pending-state-stores.ts (#2996 Phase 3 step 2). Swept by
+// sweepSecretRequests (below) — a plain delete-past-TTL, no wake (transient
+// post-tap window). Direction preserved: now - armed_at > TTL.
+const armedSecretCaptures = createSweepableStore<ArmedSecretCapture>(
+  (v, now) => now - v.armed_at > ARMED_SECRET_CAPTURE_TTL_MS,
+)
 const PENDING_SECRET_REQUEST_TTL_MS = 30 * 60_000 // card lifetime
 const ARMED_SECRET_CAPTURE_TTL_MS = 10 * 60_000   // window to send the value after tapping
 // stageId -> request (lives until tapped or TTL). Storage extracted to
@@ -12692,9 +12697,7 @@ function sweepSecretRequests(now = Date.now()): void {
   // armedSecretCaptures is a TRANSIENT post-tap window (never persisted): it's
   // only set after the operator taps [Provide securely], and the request is
   // no longer parked-on-a-card. Just drop stale ones — no wake needed.
-  for (const [k, v] of armedSecretCaptures) {
-    if (now - v.armed_at > ARMED_SECRET_CAPTURE_TTL_MS) armedSecretCaptures.delete(k)
-  }
+  armedSecretCaptures.sweep(now)
 }
 
 function buildSecretRequestKeyboard(stageId: string): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {

--- a/telegram-plugin/gateway/pending-state-stores.ts
+++ b/telegram-plugin/gateway/pending-state-stores.ts
@@ -1,0 +1,106 @@
+/**
+ * In-memory storage for the LONG-TAIL of gateway.ts pending-state Maps —
+ * the auth/vault-wizard, config-edit correlation, and transient capture Maps
+ * that PR #3008 deferred when it moved the four agent-initiated approval-card
+ * families behind `approval-card-stores.ts`. Phase 3 step 2 of the gateway
+ * decomposition (see #2996): STORAGE ONLY.
+ *
+ * Two shapes, mirroring the two shapes the long-tail Maps actually have:
+ *
+ *  - `createSweepableStore<T>(isExpired)` — a Map-compatible store whose
+ *    `sweep(now)` deletes every entry the caller's `isExpired(value, now)`
+ *    predicate reports as past its TTL. The predicate is supplied by the
+ *    gateway and CLOSES OVER the family's TTL constant, so the TTL and its
+ *    comparison DIRECTION stay verbatim in gateway.ts — different families use
+ *    `now - staged_at > TTL`, `now - startedAt > TTL`, `now - createdAt > TTL`,
+ *    or an absolute `now > expiresAt`, and each is preserved byte-identically.
+ *    `sweep` is a plain delete-past-TTL loop (no wake / side effects); it
+ *    replaces the identical open-coded reaper / standalone-sweep loops. The
+ *    delete-during-iteration is safe (JS Map iterators tolerate deleting the
+ *    current key) — exactly as the original loops relied on.
+ *
+ *  - `createPlainStore<T>()` — a Map-compatible store with NO sweep, for the
+ *    long-tail Maps whose lifetime is bounded by per-entry timers or an
+ *    LRU cap rather than a TTL sweep (`pendingAskUser`, `agentButtonMeta`).
+ *
+ * Why a Map-compatible surface (get/set/delete/has/size/keys/values/entries/
+ * forEach/iteration) rather than a bespoke API: every existing gateway call
+ * site used the raw Map directly. Preserving the exact Map method surface —
+ * and keeping the variable name unchanged — keeps those call sites
+ * BYTE-IDENTICAL. The store moves WHERE the Map is constructed and (for the
+ * sweepable shape) WHERE its sweep lives, nothing about how the gateway reads
+ * or writes it.
+ *
+ * The backing Map is the sole storage and backs every iterator, so mutation-
+ * during-iteration order/semantics are identical to the raw Map the gateway
+ * used before.
+ */
+
+export interface PlainStore<T> {
+  get(key: string): T | undefined
+  set(key: string, value: T): void
+  delete(key: string): boolean
+  has(key: string): boolean
+  clear(): void
+  readonly size: number
+  keys(): IterableIterator<string>
+  values(): IterableIterator<T>
+  entries(): IterableIterator<[string, T]>
+  forEach(cb: (value: T, key: string, map: Map<string, T>) => void): void
+  [Symbol.iterator](): IterableIterator<[string, T]>
+}
+
+export interface SweepableStore<T> extends PlainStore<T> {
+  /**
+   * Delete every entry past its TTL per the injected `isExpired` predicate.
+   * Plain delete-past-TTL, no wake — byte-identical to the open-coded reaper /
+   * standalone sweep loop it replaces.
+   */
+  sweep(now: number): void
+}
+
+// Build the shared Map surface onto `target` (a getter for `size`, so the
+// live Map size is read on every access — an object spread would freeze it).
+function attachMapSurface<T, S extends object>(target: S, map: Map<string, T>): S & PlainStore<T> {
+  return Object.defineProperties(target, {
+    get: { value: (key: string) => map.get(key), enumerable: true },
+    set: { value: (key: string, value: T) => void map.set(key, value), enumerable: true },
+    delete: { value: (key: string) => map.delete(key), enumerable: true },
+    has: { value: (key: string) => map.has(key), enumerable: true },
+    clear: { value: () => map.clear(), enumerable: true },
+    size: { get: () => map.size, enumerable: true },
+    keys: { value: () => map.keys(), enumerable: true },
+    values: { value: () => map.values(), enumerable: true },
+    entries: { value: () => map.entries(), enumerable: true },
+    forEach: {
+      value: (cb: (value: T, key: string, m: Map<string, T>) => void) => map.forEach(cb),
+      enumerable: true,
+    },
+    [Symbol.iterator]: { value: () => map[Symbol.iterator](), enumerable: true },
+  }) as S & PlainStore<T>
+}
+
+/**
+ * Create a Map-backed store with no automatic expiry. For long-tail Maps
+ * whose entries are removed by per-entry timers or an LRU cap, not a TTL sweep.
+ */
+export function createPlainStore<T>(): PlainStore<T> {
+  return attachMapSurface({}, new Map<string, T>())
+}
+
+/**
+ * Create a Map-backed, self-sweeping store for one long-tail pending-state
+ * family. `isExpired` closes over the family's TTL constant and encodes its
+ * exact comparison direction; `sweep(now)` deletes every entry it flags.
+ */
+export function createSweepableStore<T>(
+  isExpired: (value: T, now: number) => boolean,
+): SweepableStore<T> {
+  const map = new Map<string, T>()
+  const sweep = (now: number): void => {
+    for (const [k, v] of map) {
+      if (isExpired(v, now)) map.delete(k)
+    }
+  }
+  return attachMapSurface({ sweep }, map)
+}

--- a/telegram-plugin/tests/pending-state-stores.test.ts
+++ b/telegram-plugin/tests/pending-state-stores.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Contract + race/ordering pins for the long-tail pending-state stores
+ * (gateway/pending-state-stores.ts), extracted in #2996 Phase 3 step 2.
+ *
+ * Written BEFORE the long-tail Maps moved behind the store module. They lock:
+ *
+ *   1. Each family's EXACT `isExpired` comparison direction survives verbatim —
+ *      TTL directions differ across families (`now - staged_at > TTL`,
+ *      `now - startedAt > TTL`, `now - createdAt > TTL`, `now - armed_at > TTL`,
+ *      and the absolute `now > expiresAt`), and a store must delete exactly the
+ *      entries the old open-coded loop deleted, not one tick early or late.
+ *   2. `sweep` is delete-during-iteration safe (JS Map iterators tolerate
+ *      deleting the current key — the raw reaper loops relied on this).
+ *   3. The gateway-visible EAGER-SWEEP-AT-ADD pattern (the sweep called right
+ *      after a `.set` at a staging site, e.g. `sweepSecretRequests()` after the
+ *      `pendingSecretRequests.set` in executeRequestSecret) is single-shot: an
+ *      add followed by an eager sweep expires only entries already past TTL and
+ *      leaves the just-added fresh entry intact.
+ *   4. Map-surface parity for every operation the call sites use, including the
+ *      LRU eviction pattern `agentButtonMeta` uses (`keys().next().value`) and
+ *      the live `size` getter.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createSweepableStore,
+  createPlainStore,
+} from '../gateway/pending-state-stores.js'
+
+// TTL constants mirror the gateway family values so the direction pins are
+// meaningful (values themselves are not the contract — the direction is).
+const VAULT_INPUT_TTL_MS = 5 * 60 * 1000
+const VAULT_PASSPHRASE_TTL_MS = 30 * 60 * 1000
+const DEFERRED_SECRET_TTL_MS = 5 * 60 * 1000
+const ARMED_SECRET_CAPTURE_TTL_MS = 10 * 60_000
+const ALWAYS_ALLOW_CORRELATION_TTL_MS = 30_000
+const MENTAL_MODEL_CORRELATION_TTL_MS = 720_000
+const REAUTH_INTERCEPT_TTL_MS = 10 * 60_000
+
+describe('pending-state-stores: per-family isExpired direction (byte-identical)', () => {
+  it('pendingVaultOps — now - startedAt > VAULT_INPUT_TTL_MS', () => {
+    const store = createSweepableStore<{ startedAt: number }>(
+      (v, now) => now - v.startedAt > VAULT_INPUT_TTL_MS,
+    )
+    const now = 10_000_000
+    store.set('fresh', { startedAt: now - VAULT_INPUT_TTL_MS }) // exactly TTL old: NOT expired (> is strict)
+    store.set('stale', { startedAt: now - VAULT_INPUT_TTL_MS - 1 })
+    store.sweep(now)
+    expect(store.has('fresh')).toBe(true)
+    expect(store.has('stale')).toBe(false)
+  })
+
+  it('vaultPassphraseCache — absolute now > expiresAt', () => {
+    const store = createSweepableStore<{ expiresAt: number }>(
+      (v, now) => now > v.expiresAt,
+    )
+    const now = 10_000_000
+    store.set('atExpiry', { expiresAt: now }) // now > now is false → NOT expired
+    store.set('past', { expiresAt: now - 1 })
+    store.sweep(now)
+    expect(store.has('atExpiry')).toBe(true)
+    expect(store.has('past')).toBe(false)
+    void VAULT_PASSPHRASE_TTL_MS
+  })
+
+  it('deferredSecrets — now - staged_at > DEFERRED_SECRET_TTL_MS', () => {
+    const store = createSweepableStore<{ staged_at: number }>(
+      (v, now) => now - v.staged_at > DEFERRED_SECRET_TTL_MS,
+    )
+    const now = 10_000_000
+    store.set('fresh', { staged_at: now - DEFERRED_SECRET_TTL_MS })
+    store.set('stale', { staged_at: now - DEFERRED_SECRET_TTL_MS - 1 })
+    store.sweep(now)
+    expect(store.has('fresh')).toBe(true)
+    expect(store.has('stale')).toBe(false)
+  })
+
+  it('armedSecretCaptures — now - armed_at > ARMED_SECRET_CAPTURE_TTL_MS', () => {
+    const store = createSweepableStore<{ armed_at: number }>(
+      (v, now) => now - v.armed_at > ARMED_SECRET_CAPTURE_TTL_MS,
+    )
+    const now = 10_000_000
+    store.set('fresh', { armed_at: now - ARMED_SECRET_CAPTURE_TTL_MS })
+    store.set('stale', { armed_at: now - ARMED_SECRET_CAPTURE_TTL_MS - 1 })
+    store.sweep(now)
+    expect(store.has('fresh')).toBe(true)
+    expect(store.has('stale')).toBe(false)
+  })
+
+  it('pendingAlwaysAllowCorrelations — 30s now - createdAt > TTL', () => {
+    const store = createSweepableStore<{ createdAt: number }>(
+      (v, now) => now - v.createdAt > ALWAYS_ALLOW_CORRELATION_TTL_MS,
+    )
+    const now = 10_000_000
+    store.set('fresh', { createdAt: now - ALWAYS_ALLOW_CORRELATION_TTL_MS })
+    store.set('stale', { createdAt: now - ALWAYS_ALLOW_CORRELATION_TTL_MS - 1 })
+    store.sweep(now)
+    expect(store.has('fresh')).toBe(true)
+    expect(store.has('stale')).toBe(false)
+  })
+
+  it('pendingMentalModelCorrelations — 720s now - createdAt > TTL (outlives the 30s window)', () => {
+    const store = createSweepableStore<{ createdAt: number }>(
+      (v, now) => now - v.createdAt > MENTAL_MODEL_CORRELATION_TTL_MS,
+    )
+    const now = 10_000_000
+    // A slow-but-valid tap 10 min in must NOT be swept (the whole point of the
+    // dedicated 720s TTL vs the 30s always-allow window).
+    store.set('slowTap', { createdAt: now - 10 * 60_000 })
+    store.set('stale', { createdAt: now - MENTAL_MODEL_CORRELATION_TTL_MS - 1 })
+    store.sweep(now)
+    expect(store.has('slowTap')).toBe(true)
+    expect(store.has('stale')).toBe(false)
+  })
+
+  it('pendingReauthFlows — now - startedAt > REAUTH_INTERCEPT_TTL_MS', () => {
+    const store = createSweepableStore<{ startedAt: number }>(
+      (v, now) => now - v.startedAt > REAUTH_INTERCEPT_TTL_MS,
+    )
+    const now = 10_000_000
+    store.set('fresh', { startedAt: now - REAUTH_INTERCEPT_TTL_MS })
+    store.set('stale', { startedAt: now - REAUTH_INTERCEPT_TTL_MS - 1 })
+    store.sweep(now)
+    expect(store.has('fresh')).toBe(true)
+    expect(store.has('stale')).toBe(false)
+  })
+})
+
+describe('pending-state-stores: sweep safety', () => {
+  it('deletes every past-TTL entry across a multi-entry map (delete-during-iteration safe)', () => {
+    const store = createSweepableStore<{ staged_at: number }>(
+      (v, now) => now - v.staged_at > 1000,
+    )
+    for (let i = 0; i < 10; i++) store.set(`e${i}`, { staged_at: i % 2 === 0 ? 0 : 9_999_999 })
+    store.sweep(1_000_000) // even entries stale, odd entries fresh
+    for (let i = 0; i < 10; i++) {
+      expect(store.has(`e${i}`)).toBe(i % 2 === 1)
+    }
+  })
+
+  it('is single-shot across two sweep ticks', () => {
+    const store = createSweepableStore<{ staged_at: number }>(
+      (v, now) => now - v.staged_at > 1000,
+    )
+    store.set('one', { staged_at: 0 })
+    store.sweep(1_000_000)
+    expect(store.size).toBe(0)
+    expect(() => store.sweep(1_000_000)).not.toThrow() // second tick — nothing left
+    expect(store.size).toBe(0)
+  })
+})
+
+describe('pending-state-stores: eager-sweep-at-add pattern (gateway-visible)', () => {
+  // Mirrors executeRequestSecret: dedupe-drop prior stage for the same target,
+  // .set the new one, then eagerly sweep. The just-added fresh entry survives;
+  // a stale sibling is reaped in the same eager pass.
+  it('add + eager sweep expires only stale siblings, keeps the fresh add', () => {
+    const TTL = 30 * 60_000
+    const store = createSweepableStore<{ chat_id: string; key: string; staged_at: number }>(
+      (v, now) => now - v.staged_at > TTL,
+    )
+    const now = 100_000_000
+    store.set('old', { chat_id: 'c', key: 'k1', staged_at: now - TTL - 1 }) // stale
+    // Dedupe pass (same target) would delete a live dup; here targets differ.
+    const fresh = { chat_id: 'c', key: 'k2', staged_at: now }
+    store.set('new', fresh)
+    store.sweep(now) // eager sweep at the add site
+    expect(store.has('new')).toBe(true) // fresh add never self-expires
+    expect(store.get('new')).toBe(fresh)
+    expect(store.has('old')).toBe(false) // stale sibling reaped in the eager pass
+  })
+
+  it('dedupe-then-add-then-sweep leaves exactly the new entry', () => {
+    const TTL = 30 * 60_000
+    const store = createSweepableStore<{ chat_id: string; key: string; staged_at: number }>(
+      (v, now) => now - v.staged_at > TTL,
+    )
+    const now = 100_000_000
+    store.set('dup', { chat_id: 'c', key: 'k', staged_at: now - 1000 })
+    // dedupe: drop prior stage for the same (chat, key)
+    for (const [sid, p] of store) {
+      if (p.chat_id === 'c' && p.key === 'k') store.delete(sid)
+    }
+    store.set('fresh', { chat_id: 'c', key: 'k', staged_at: now })
+    store.sweep(now)
+    expect([...store.keys()]).toEqual(['fresh'])
+  })
+})
+
+describe('pending-state-stores: plain store (no sweep)', () => {
+  it('has no sweep method and preserves Map surface', () => {
+    const store = createPlainStore<{ n: number }>()
+    expect((store as { sweep?: unknown }).sweep).toBeUndefined()
+    store.set('a', { n: 1 })
+    store.set('b', { n: 2 })
+    expect(store.size).toBe(2)
+    expect(store.get('a')?.n).toBe(1)
+    expect(store.has('b')).toBe(true)
+    expect(store.delete('a')).toBe(true)
+    expect(store.has('a')).toBe(false)
+  })
+
+  it('agentButtonMeta LRU eviction — keys().next().value is the oldest insertion', () => {
+    const AGENT_BUTTON_META_MAX = 3
+    const store = createPlainStore<Map<string, { ack: string }>>()
+    const remember = (key: string) => {
+      store.set(key, new Map([['cb', { ack: key }]]))
+      while (store.size > AGENT_BUTTON_META_MAX) {
+        const oldest = store.keys().next().value
+        if (oldest === undefined) break
+        store.delete(oldest)
+      }
+    }
+    remember('m1')
+    remember('m2')
+    remember('m3')
+    remember('m4') // evicts m1 (oldest insertion)
+    expect(store.has('m1')).toBe(false)
+    expect([...store.keys()]).toEqual(['m2', 'm3', 'm4'])
+    expect(store.get('m4')?.get('cb')?.ack).toBe('m4')
+  })
+
+  it('pendingAskUser surface — values()/entries()/get/delete used by call sites', () => {
+    const store = createPlainStore<{ chatId: string; messageId: number | null }>()
+    store.set('ask1', { chatId: 'c1', messageId: 10 })
+    store.set('ask2', { chatId: 'c2', messageId: null })
+    expect([...store.values()].map((v) => v.chatId).sort()).toEqual(['c1', 'c2'])
+    const collected: string[] = []
+    for (const [askId] of store.entries()) collected.push(askId)
+    expect(collected.sort()).toEqual(['ask1', 'ask2'])
+    expect(store.get('ask1')?.messageId).toBe(10)
+    store.delete('ask1')
+    expect(store.size).toBe(1)
+  })
+})


### PR DESCRIPTION
Phase 3 step 2 of the `gateway.ts` decomposition tracked in #2996 — the LONG-TAIL of pending-state Maps PR #3008 deferred, moved behind stores following the merged `approval-card-stores.ts` pattern. **Storage before logic**: Maps behind stores, call sites become byte-identical delegations, the delete-past-TTL sweep co-located in the store, TTL constants + comparison directions stay as injected predicates in `gateway.ts`.

## New module

`telegram-plugin/gateway/pending-state-stores.ts` — the long-tail sibling of `approval-card-stores.ts`:
- `createSweepableStore<T>(isExpired)` — Map-compatible store whose `sweep(now)` deletes every entry the injected `isExpired(value, now)` predicate flags. The predicate closes over the family's TTL constant, so the TTL **and its comparison direction** stay verbatim in `gateway.ts`.
- `createPlainStore<T>()` — Map-compatible store, no sweep, for Maps bounded by per-entry timers / an LRU cap rather than a TTL sweep.

Both expose the exact Map surface the call sites use (get/set/delete/has/size/keys/values/entries/forEach/iteration); the `size` getter is a live accessor (not frozen by spread). The backing Map is the sole storage and backs every iterator, so mutation-during-iteration order/semantics are identical.

## Per-Map status

| Map | Status | Store / sweep |
|---|---|---|
| `pendingAlwaysAllowCorrelations` | ✅ moved | sweepable — `now - createdAt > 30s`; `sweepStaleAlwaysAllowCorrelations` → 1-line delegation |
| `pendingMentalModelCorrelations` | ✅ moved | sweepable — `now - createdAt > 720s` (deliberately larger window preserved); delegation |
| `pendingVaultOps` | ✅ moved | sweepable — `now - startedAt > VAULT_INPUT_TTL_MS`; reaper loop → `.sweep` |
| `vaultPassphraseCache` | ✅ moved | sweepable — **absolute** `now > expiresAt` (distinct direction preserved) |
| `deferredSecrets` | ✅ moved | sweepable — `now - staged_at > DEFERRED_SECRET_TTL_MS` (predicate reads TTL lazily; declared after construction, no TDZ) |
| `armedSecretCaptures` | ✅ moved | sweepable — `now - armed_at > ARMED_SECRET_CAPTURE_TTL_MS`; co-sweeps with the already-moved `pendingSecretRequests` inside `sweepSecretRequests` (incl. the eager add-site sweep in `executeRequestSecret`) |
| `pendingReauthFlows` | ✅ moved | sweepable — `now - startedAt > REAUTH_INTERCEPT_TTL_MS`; reaper loop → `.sweep` in the **same position** so the OAuth-code contiguity pin holds |
| `pendingAskUser` | ✅ moved | plain — no TTL sweep (per-entry timers + chat-close/shutdown clears) |
| `agentButtonMeta` | ✅ moved | plain — no TTL sweep (`AGENT_BUTTON_META_MAX` LRU cap; `keys().next().value` eviction preserved) |
| `pendingPermissions` | ⛔ excluded (per plan) | own durability layer (`permission-card-store.ts`); entangled with the reaper auto-deny / missed-approval block |
| `pendingAuthAddFlows` / `pendingMicrosoftConnectFlows` / `pendingAuthRmFlows` | ⏭ deferred | already extracted into their own flow modules (`auth-add-flow.ts` / `microsoft-connect-flow.ts` / `auth-command.ts`) and imported — not gateway-declared module-level Maps; their reaper sweeps carry side effects (`cancelAccountAuthSession`, `cancelled=true`) that a plain delete-store would drop. A dedicated follow-up should give those modules their own side-effecting sweepable store. |

Every gateway-declared long-tail Map from PR #3008's deferred list moved. Variable names are unchanged, so callback-query handlers, executor add-sites, wizard flows, and `restorePendingApprovalCards`-adjacent code are byte-identical.

## Harness-first

`telegram-plugin/tests/pending-state-stores.test.ts` (14 tests), written before the Maps moved, pins:
- **Each family's exact `isExpired` direction** — `now - staged_at > TTL`, `now - startedAt > TTL`, `now - createdAt > TTL`, `now - armed_at > TTL`, and the **absolute** `now > expiresAt`, each with a boundary entry proving strict `>` (at-TTL survives, TTL+1 expires); the 720s mental-model window explicitly not swept at 10 min.
- **Delete-during-iteration sweep safety** across a multi-entry map + single-shot across two ticks.
- **The gateway-visible eager-sweep-at-add pattern** (the `sweepSecretRequests()` after `.set` in `executeRequestSecret`) — an add followed by an eager sweep expires only stale siblings and leaves the fresh add intact; dedupe-then-add-then-sweep leaves exactly the new entry.
- **Map-surface parity** including the `agentButtonMeta` LRU eviction (`keys().next().value` = oldest insertion) and `pendingAskUser`'s `values()/entries()/get/delete`, plus that the plain store exposes **no** `sweep`.

## Tests / checks

- `tsc --noEmit`: **0 errors**.
- Full `telegram-plugin` vitest: **5467 passed, 0 test failures**. The 18 failed *suites* are the known pre-existing worktree load artifact (mdast `mdast-util-from-markdown` / `@mtcute/node` unresolved under the symlinked `node_modules`) — all `render/*` + stream-controller/stream-reply suites that transitively import `render/parse.ts`; none import `gateway.ts` or the new module. Identical set/count to pristine `origin/main`; CI is the arbiter for those paths.
- `check-plugin-references`: 18 errors = **unchanged baseline** (same mdast/mtcute worktree gap), zero new.
- `check-bot-api-wrapping`: clean. `check-no-pii-secrets`: clean (2486 files; no token-shaped literals — TTL fixtures are plain numbers).
- Reaper-ordering pin `secret-detect-oauth-code.test.ts` re-run green after the `pendingReauthFlows` move (24 tests).

## Residual risk

- `createSweepableStore`'s `set` returns `void` (vs `Map.set` returning the map); no call site chains, tsc confirms.
- The `deferredSecrets` / `armedSecretCaptures` predicates reference TTL consts declared *after* the store construction — safe because the predicate only runs at sweep time (runtime), never at module-eval; tsc + the boundary tests confirm.
- The three imported auth-wizard Maps are intentionally NOT forced behind a plain store (their sweeps carry side effects) — deferred with a clear follow-up rather than risking a semantics change.

Refs #2996. **Do not merge** — awaiting fresh-process review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)