### PR TITLE
fix(telegram): ack-queue-apply-confirm for mid-turn /model + /effort; persist model across graceful deploy (#3017)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -408,6 +408,8 @@ import {
   intentForRestartReason,
   readSessionModelFile,
   RELAUNCH_MODEL_INTENT_FILE,
+  GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX,
+  clearStaleGatewayShutdownIntent,
 } from './session-model-file.js'
 import { discoverModels, selectModel } from '../../src/agents/model-picker.js'
 import { resolveMainModel } from '../../src/agents/scaffold.js'
@@ -421,7 +423,9 @@ import {
   type EffortMenuReply,
 } from './effort-command.js'
 import {
-  createPendingSessionCommandSlot,
+  createPendingSessionCommandSlots,
+  drainCapDecision as pendingCmdDrainCapDecision,
+  shutdownResolutionEdits as pendingCmdShutdownResolutionEdits,
   ackText as pendingCmdAckText,
   supersededText as pendingCmdSupersededText,
   restartSupersededText as pendingCmdRestartSupersededText,
@@ -974,6 +978,24 @@ function triggerSelfRestart(
   } catch (err) {
     process.stderr.write(`telegram gateway: restart spawn failed for ${targetAgent}: ${err}\n`)
     return false
+  }
+}
+
+// #3018 finding 4: a gateway-only bounce (supervisor relaunch, bare gateway
+// unit restart) leaves the shutdown handler's deploy-survival keep-intent
+// stamp on disk UNCONSUMED — start.sh only runs on a container-level boot.
+// If this gateway boot still sees a gateway-shutdown-stamped intent, the
+// preceding bounce was gateway-only: clear it so a genuine crash inside the
+// 10-min freshness window can't be converted into a "keep" (crash-reverts
+// policy intact). A real container stop/deploy consumes the file in start.sh
+// before any gateway boots, so a legitimate deploy stamp is never touched;
+// triggerSelfRestart / user-slash stamps use un-prefixed reasons.
+{
+  const bootSmDir = resolveAgentDirFromEnv()
+  if (bootSmDir != null && clearStaleGatewayShutdownIntent(bootSmDir)) {
+    process.stderr.write(
+      'telegram gateway: cleared stale gateway-shutdown relaunch-model intent (previous bounce was gateway-only — container never restarted)\n',
+    )
   }
 }
 
@@ -2631,14 +2653,16 @@ async function deliverButtonTapInbound(
 const pendingRestarts = new Map<string, number>()  // agentName -> timestamp when restart was requested
 
 // Deterministic ack-queue-apply-confirm for /model + /effort issued mid-turn
-// (#3017). Single-valued, last-write-wins. Enqueued at the busy gates (typed
+// (#3017). One slot per kind (model|effort): same-kind last-write-wins,
+// cross-kind coexist (#3018 finding 2). Enqueued at the busy gates (typed
 // and menu), drained at the SAME model-idle gate as pendingRestarts (turn
 // complete + the reaper cap), which then EDITS the ack card into the
 // confirmation. See pending-session-command.ts for the contract.
-const pendingSessionCommand = createPendingSessionCommandSlot()
+const pendingSessionCommand = createPendingSessionCommandSlots()
 // Bounded drain-cap for a queued /model|/effort command whose session never
 // cleanly idles — mirrors PENDING_RESTART_DRAIN_CAP_MS. After this, force the
-// apply-or-report so the ack card never dangles unresolved.
+// apply-or-report so the ack card never dangles unresolved — but ONLY while
+// no turn is in flight (#3018 finding 1; see drainCapDecision).
 const PENDING_CMD_DRAIN_CAP_MS = 60_000
 
 // ─── Proactive context compaction (session.max_context_tokens) ──────────
@@ -6418,15 +6442,31 @@ const pendingStateReaper = setInterval(() => {
       triggerSelfRestart(agentName, 'restart-drain-cap-forced', 100)
     }
   }
-  // Drain cap for a queued /model|/effort command (#3017): if the session
+  // Drain cap for queued /model|/effort commands (#3017): if the session
   // never cleanly idled, force the apply-or-report so the ack card never
   // dangles unresolved. drainPendingSessionCommand no-ops on an idle-gate race
   // (its own re-entrancy guard) and reports honestly when a restart is pending.
-  const queued = pendingSessionCommand.get()
-  if (queued != null && now - queued.requestedAt > PENDING_CMD_DRAIN_CAP_MS) {
-    const waitedSec = Math.round((now - queued.requestedAt) / 1000)
+  // #3018 finding 1: NEVER force while a turn is genuinely in flight — a
+  // forced mid-turn drain hits the typed model handler's busy gate (edits the
+  // ack card into the old "try again" refusal, choice destroyed) and /effort
+  // has no busy gate at all (would type into the live claude input). The cap
+  // only rescues the missed-idle-gate case; mid-turn we keep waiting and the
+  // idle gate drains at turn end.
+  const queuedCmds = pendingSessionCommand.list()
+  const cmdDecision = pendingCmdDrainCapDecision(
+    queuedCmds,
+    now,
+    PENDING_CMD_DRAIN_CAP_MS,
+    turnInFlightForGate(),
+  )
+  if (cmdDecision === 'defer-turn-in-flight') {
     process.stderr.write(
-      `telegram gateway: [pending-cmd-drain] forcing kind=${queued.kind} target=${queued.targetLabel} waited=${waitedSec}s threshold=${Math.round(PENDING_CMD_DRAIN_CAP_MS / 1000)}s\n`,
+      `telegram gateway: [pending-cmd-drain] deferred reason=turn-in-flight queued=${queuedCmds.map(c => c.kind).join(',')}\n`,
+    )
+  } else if (cmdDecision === 'force') {
+    const oldest = Math.min(...queuedCmds.map(c => c.requestedAt))
+    process.stderr.write(
+      `telegram gateway: [pending-cmd-drain] forcing queued=${queuedCmds.map(c => `${c.kind}:${c.targetLabel}`).join(',')} waited=${Math.round((now - oldest) / 1000)}s threshold=${Math.round(PENDING_CMD_DRAIN_CAP_MS / 1000)}s\n`,
     )
     void drainPendingSessionCommand()
   }
@@ -20072,9 +20112,10 @@ async function editPendingCommandCard(chatId: string, messageId: number, text: s
 }
 
 /**
- * Enqueue a mid-turn session command (last-write-wins). If it displaces an
- * earlier queued command, edit that stale ack card into a "superseded" note so
- * the operator's replaced choice is never silently lost.
+ * Enqueue a mid-turn session command (same-kind last-write-wins; a /model and
+ * a /effort coexist). If it displaces an earlier same-kind command, edit that
+ * stale ack card into a "superseded" note so the operator's replaced choice is
+ * never silently lost.
  */
 function enqueueSessionCommand(cmd: PendingSessionCommand): void {
   const displaced = pendingSessionCommand.set(cmd)
@@ -20085,6 +20126,12 @@ function enqueueSessionCommand(cmd: PendingSessionCommand): void {
       pendingCmdSupersededText(displaced, cmd, escapeHtmlForTg),
     )
   }
+  // #3018 finding 5 — enqueue/turn-end race: if the idle gate fired between
+  // the busy check and this enqueue, no further turn-end will drain the slot
+  // and the command would sit until the reaper cap. If the session is idle
+  // NOW, kick the drain immediately (re-entrancy-guarded, no-op if a racing
+  // drain already ran).
+  if (!turnInFlightForGate()) void drainPendingSessionCommand()
 }
 
 /** Apply a queued typed/menu-alias model command at idle; return the reply body. */
@@ -20128,43 +20175,44 @@ async function applyQueuedEffortCommand(cmd: PendingSessionCommand): Promise<str
 let pendingCmdDraining = false
 
 /**
- * Drain the queued session command when the agent goes idle: apply it, then
- * edit the ack card into the confirmation (or a failure banner). Called from
- * the model-idle gate (turn complete) and the reaper drain-cap. No-op when the
- * slot is empty. If a restart is also pending the session is going away — a
- * Claude-model / effort session change would not survive, so report that
- * honestly rather than falsely confirming.
+ * Drain the queued session command(s) when the agent goes idle: apply each,
+ * then edit its ack card into the confirmation (or a failure banner). Called
+ * from the model-idle gate (turn complete), the post-enqueue idle kick, and
+ * the reaper drain-cap. No-op when the slots are empty. If a restart is (or
+ * becomes — a model apply can itself enqueue one) pending, the session is
+ * going away — a Claude-model / effort session change would not survive, so
+ * report that honestly rather than falsely confirming.
  */
 async function drainPendingSessionCommand(): Promise<void> {
   if (pendingCmdDraining) return
   if (pendingSessionCommand.size === 0) return
   pendingCmdDraining = true
-  const cmd = pendingSessionCommand.take()
   try {
-    if (cmd == null) return
-    if (pendingRestarts.size > 0) {
-      await editPendingCommandCard(
-        cmd.ackChatId,
-        cmd.ackMessageId,
-        pendingCmdRestartSupersededText(cmd, escapeHtmlForTg),
-      )
-      return
+    for (const cmd of pendingSessionCommand.takeAll()) {
+      if (pendingRestarts.size > 0) {
+        await editPendingCommandCard(
+          cmd.ackChatId,
+          cmd.ackMessageId,
+          pendingCmdRestartSupersededText(cmd, escapeHtmlForTg),
+        )
+        continue
+      }
+      let body: string
+      try {
+        body =
+          cmd.kind === 'model'
+            ? await applyQueuedModelCommand(cmd)
+            : await applyQueuedEffortCommand(cmd)
+      } catch (err) {
+        await editPendingCommandCard(
+          cmd.ackChatId,
+          cmd.ackMessageId,
+          `❌ Couldn’t apply the queued ${cmd.kind} switch to \`${escapeHtmlForTg(cmd.targetLabel)}\`: ${escapeHtmlForTg((err as Error)?.message ?? String(err))}`,
+        )
+        continue
+      }
+      await editPendingCommandCard(cmd.ackChatId, cmd.ackMessageId, body)
     }
-    let body: string
-    try {
-      body =
-        cmd.kind === 'model'
-          ? await applyQueuedModelCommand(cmd)
-          : await applyQueuedEffortCommand(cmd)
-    } catch (err) {
-      await editPendingCommandCard(
-        cmd.ackChatId,
-        cmd.ackMessageId,
-        `❌ Couldn’t apply the queued ${cmd.kind} switch to \`${escapeHtmlForTg(cmd.targetLabel)}\`: ${escapeHtmlForTg((err as Error)?.message ?? String(err))}`,
-      )
-      return
-    }
-    await editPendingCommandCard(cmd.ackChatId, cmd.ackMessageId, body)
   } finally {
     pendingCmdDraining = false
   }
@@ -25518,7 +25566,12 @@ async function shutdown(signal: string): Promise<void> {
         const hasOverride = readSessionModelFile(smDir) != null
         const intentAlreadyStamped = existsSync(join(smDir, RELAUNCH_MODEL_INTENT_FILE))
         if (hasOverride && !intentAlreadyStamped) {
-          writeRelaunchModelIntent(smDir, 'keep', `graceful ${signal} shutdown (deploy/rolling restart) — preserving user-chosen session model`)
+          // The GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX makes this stamp
+          // recognisable at the next GATEWAY boot: a gateway-only bounce never
+          // runs start.sh, so a leftover stamp with this prefix is cleared at
+          // boot (clearStaleGatewayShutdownIntent) instead of lingering to
+          // convert a later genuine crash into a "keep" (#3018 finding 4).
+          writeRelaunchModelIntent(smDir, 'keep', `${GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX} graceful ${signal} shutdown (deploy/rolling restart) — preserving user-chosen session model`)
           process.stderr.write(`telegram gateway: shutdown.session_model_keep_stamped signal=${signal}\n`)
         }
       }
@@ -25527,6 +25580,27 @@ async function shutdown(signal: string): Promise<void> {
     }
   } else {
     process.stderr.write(`telegram gateway: shutdown.clean_marker_skipped signal=${signal} (crash path — banner will fire on next boot)\n`)
+  }
+
+  // #3018 finding 3: resolve any queued /model|/effort ack cards. The gateway
+  // (and with it the queue) is going away — without this the ack card dangles
+  // at "the moment this turn finishes" forever and the operator's choice is
+  // silently lost. Edit each into the restart-superseded text ("re-issue once
+  // the agent is back"). Best-effort and time-bounded so a wedged Telegram
+  // API can't block shutdown.
+  const orphanedCmdEdits = pendingCmdShutdownResolutionEdits(pendingSessionCommand, escapeHtmlForTg)
+  if (orphanedCmdEdits.length > 0) {
+    process.stderr.write(
+      `telegram gateway: shutdown.pending_cmd_resolved count=${orphanedCmdEdits.length}\n`,
+    )
+    await Promise.race([
+      Promise.allSettled(
+        orphanedCmdEdits.map(e => editPendingCommandCard(e.chatId, e.messageId, e.text)),
+      ),
+      new Promise<void>(resolve => {
+        setTimeout(resolve, SHUTDOWN_PROGRESS_FLUSH_BUDGET_MS).unref()
+      }),
+    ])
   }
 
   // Stage 3c: stamp any in-flight turn as endedVia='sigterm' (or 'restart'

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -387,6 +387,7 @@ import {
   MODEL_CALLBACK_PREFIX,
   MODEL_CALLBACK_HEADER,
   MODEL_CALLBACK_SR,
+  MODEL_CALLBACK_ALIAS,
   MODEL_CALLBACK_PAGE_EXTERNAL,
   MODEL_CALLBACK_PAGE_MAIN,
   srFriendlyLabel,
@@ -405,6 +406,8 @@ import {
   writeRelaunchModelIntent,
   clearRelaunchModelIntent,
   intentForRestartReason,
+  readSessionModelFile,
+  RELAUNCH_MODEL_INTENT_FILE,
 } from './session-model-file.js'
 import { discoverModels, selectModel } from '../../src/agents/model-picker.js'
 import { resolveMainModel } from '../../src/agents/scaffold.js'
@@ -417,6 +420,14 @@ import {
   type EffortCommandDeps,
   type EffortMenuReply,
 } from './effort-command.js'
+import {
+  createPendingSessionCommandSlot,
+  ackText as pendingCmdAckText,
+  supersededText as pendingCmdSupersededText,
+  restartSupersededText as pendingCmdRestartSupersededText,
+  type PendingSessionCommand,
+} from './pending-session-command.js'
+import type { EffortLevel } from './effort-command.js'
 import { registerSwitchroomBotCommands } from './register-bot-commands.js'
 import { registerOpsInfoCommands } from './bot-commands-ops-info.js'
 import { applyEffort } from '../../src/agents/effort-picker.js'
@@ -2619,6 +2630,17 @@ async function deliverButtonTapInbound(
 
 const pendingRestarts = new Map<string, number>()  // agentName -> timestamp when restart was requested
 
+// Deterministic ack-queue-apply-confirm for /model + /effort issued mid-turn
+// (#3017). Single-valued, last-write-wins. Enqueued at the busy gates (typed
+// and menu), drained at the SAME model-idle gate as pendingRestarts (turn
+// complete + the reaper cap), which then EDITS the ack card into the
+// confirmation. See pending-session-command.ts for the contract.
+const pendingSessionCommand = createPendingSessionCommandSlot()
+// Bounded drain-cap for a queued /model|/effort command whose session never
+// cleanly idles — mirrors PENDING_RESTART_DRAIN_CAP_MS. After this, force the
+// apply-or-report so the ack card never dangles unresolved.
+const PENDING_CMD_DRAIN_CAP_MS = 60_000
+
 // ─── Proactive context compaction (session.max_context_tokens) ──────────
 //
 // Opt-in: when the resolved agent config sets session.max_context_tokens,
@@ -4103,6 +4125,13 @@ function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
   // serialize gate): a pending self-restart or proactive compaction must
   // fire when claude is idle regardless of whether the last turn replied.
   if (!turnInFlightForGate()) {
+    // Apply any /model|/effort command queued mid-turn (#3017) BEFORE the
+    // restart drain reads the pending-restart map — drainPendingSessionCommand
+    // itself checks pendingRestarts and, when a restart is also pending,
+    // reports "restarting" on the ack card instead of a false confirmation.
+    // The sr-*→Claude menu apply may ITSELF enqueue a restart, which the
+    // restart drain below then picks up. Async + best-effort (own try/catch).
+    void drainPendingSessionCommand()
     if (pendingRestarts.size > 0) {
       for (const [agentName, _timestamp] of pendingRestarts.entries()) {
         triggerSelfRestart(agentName, 'turn-complete-pending-restart');
@@ -6388,6 +6417,18 @@ const pendingStateReaper = setInterval(() => {
       pendingRestarts.delete(agentName)
       triggerSelfRestart(agentName, 'restart-drain-cap-forced', 100)
     }
+  }
+  // Drain cap for a queued /model|/effort command (#3017): if the session
+  // never cleanly idled, force the apply-or-report so the ack card never
+  // dangles unresolved. drainPendingSessionCommand no-ops on an idle-gate race
+  // (its own re-entrancy guard) and reports honestly when a restart is pending.
+  const queued = pendingSessionCommand.get()
+  if (queued != null && now - queued.requestedAt > PENDING_CMD_DRAIN_CAP_MS) {
+    const waitedSec = Math.round((now - queued.requestedAt) / 1000)
+    process.stderr.write(
+      `telegram gateway: [pending-cmd-drain] forcing kind=${queued.kind} target=${queued.targetLabel} waited=${waitedSec}s threshold=${Math.round(PENDING_CMD_DRAIN_CAP_MS / 1000)}s\n`,
+    )
+    void drainPendingSessionCommand()
   }
 }, 60_000)
 pendingStateReaper.unref()
@@ -19866,6 +19907,269 @@ function modelMenuReplyMarkup(reply: ModelMenuReply): InlineKeyboard | undefined
   return kb
 }
 
+/**
+ * Record a POSITIVELY-CONFIRMED typed `/model` switch: set the in-memory
+ * override so `/status` reflects the live model and persist the sticky
+ * `.session-model` carrier. Shared by the live `bot.command('model')` handler
+ * and the deferred (queued mid-turn) apply so both record identically. Returns
+ * a persist-warning suffix to append to the reply body (empty when clean).
+ *
+ * The `/status` honesty invariant lives here: only `reply.selectedModel`
+ * (present only on a confirmed switch) records; an unverified inject records
+ * nothing. `/model default` clears the carrier idempotently.
+ */
+function recordTypedModelSwitch(
+  reply: { text: string; selectedModel?: string },
+  requestedModelArg: string | null,
+  deps: ModelCommandDeps,
+): string {
+  const requested = requestedModelArg != null ? expandSrAlias(requestedModelArg) : null
+  if (requested?.toLowerCase() === 'default') {
+    const smDir = resolveAgentDirFromEnv()
+    if (smDir) clearSessionModelFile(smDir)
+    if (reply.selectedModel) sessionModelSource.setOverride(null)
+    return ''
+  }
+  if (!reply.selectedModel) return ''
+  sessionModelSource.setOverride(reply.selectedModel)
+  const smDir = resolveAgentDirFromEnv()
+  if (smDir && requested && isValidModelArg(requested) && !isSrModel(requested)) {
+    try {
+      writeSessionModelFile(
+        smDir,
+        requested,
+        readConfiguredDefaultModel(smDir) ??
+          resolveMainModel(deps.getConfiguredModel() ?? undefined),
+      )
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: session-model persist failed (typed /model): ${(err as Error)?.message ?? String(err)}\n`,
+      )
+      return '\n⚠️ Couldn’t persist the sticky override — the switch is live now but won’t survive a relaunch.'
+    }
+  }
+  return ''
+}
+
+/**
+ * Record a model-MENU callback outcome (persist/clear sticky override) and
+ * drive an sr-*→Claude graceful restart when the tap crosses that boundary.
+ * Extracted from the live `mdl:*` dispatcher so the deferred (queued mid-turn)
+ * apply records + restarts identically. Does NOT edit any Telegram message —
+ * callers own the card edit. Returns a restart notice when a session restart
+ * was scheduled (the card should then drop its keyboard).
+ */
+function recordModelMenuSideEffects(
+  outcome: Awaited<ReturnType<typeof handleModelMenuCallback>>,
+  modelDeps: ModelCommandDeps,
+  cbChatId: string,
+  cbThreadId: number | undefined,
+  prevSessionModel: string | null,
+): { restartNotice?: string } {
+  // Record a successful session switch so /status reflects what's actually
+  // running, and persist the STICKY override
+  // (reference/rfcs/session-model-stickiness.md): the canonical token (never
+  // the display label) goes to the durable `.session-model`; a confirmed
+  // "Default (recommended)" selection clears it instead.
+  if (outcome.selectedModel) {
+    sessionModelSource.setOverride(outcome.selectedModel)
+    const smDir = resolveAgentDirFromEnv()
+    if (smDir && outcome.selectedModelToken) {
+      try {
+        writeSessionModelFile(
+          smDir,
+          outcome.selectedModelToken,
+          readConfiguredDefaultModel(smDir) ??
+            resolveMainModel(modelDeps.getConfiguredModel() ?? undefined),
+        )
+      } catch (err) {
+        outcome.reply.text +=
+          '\n⚠️ Couldn’t persist the sticky override — the switch is live now but won’t survive a relaunch.'
+        process.stderr.write(
+          `telegram gateway: session-model persist failed (menu): ${(err as Error)?.message ?? String(err)}\n`,
+        )
+      }
+    }
+  }
+  if (outcome.clearedDefault) {
+    const smDir = resolveAgentDirFromEnv()
+    if (smDir) clearSessionModelFile(smDir)
+  }
+
+  // sr-* → Claude transition: the picker-select only changes the session model
+  // label, but the sr-* LiteLLM routing context persists until the session is
+  // torn down — a graceful restart (same mechanism as /restart) is required.
+  if (outcome.selectedModel && isSrToClaudeTransition(prevSessionModel, outcome.selectedModel)) {
+    const agentName = getMyAgentName()
+    // Carry the requested Claude model across the restart via the SAME durable
+    // `.session-model` override a Claude → sr-* switch uses — otherwise boot
+    // launches the CONFIGURED default and the tapped model is silently dropped.
+    const agentDir = resolveAgentDirFromEnv()
+    const token = outcome.selectedModelToken
+    if (agentDir && token) {
+      try {
+        writeSessionModelFile(
+          agentDir,
+          token,
+          readConfiguredDefaultModel(agentDir) ??
+            resolveMainModel(modelDeps.getConfiguredModel() ?? undefined),
+        )
+        sessionModelSource.setOverride(token)
+      } catch (e) {
+        process.stderr.write(`telegram gateway: sr-to-claude session-model write failed: ${(e as Error)?.message ?? String(e)}\n`)
+      }
+    } else if (agentDir) {
+      // Default-row tap while on sr-*: the restart must land on the configured
+      // default — a stale sticky override would resurrect the old model.
+      clearSessionModelFile(agentDir)
+    }
+    // Write the restart marker so the post-restart boot card edits into this chat.
+    writeRestartMarker({ chat_id: cbChatId, thread_id: cbThreadId ?? null, ack_message_id: null, ts: Date.now() })
+    stampUserRestartReason('user: sr-to-claude model switch (menu)')
+    if (turnInFlightForGate()) {
+      // Defer restart until the in-flight turn completes (same gate as /restart).
+      pendingRestarts.set(agentName, Date.now())
+    } else {
+      void sweepBeforeSelfRestart().finally(() =>
+        triggerSelfRestart(agentName, 'sr-to-claude-model-switch', 1500),
+      )
+    }
+    return {
+      restartNotice: `🔄 Switching from **${escapeHtmlForTg(prevSessionModel!)}** back to Claude — restarting session cleanly. Claude will be ready in ~30s.`,
+    }
+  }
+  return {}
+}
+
+// ─── Mid-turn ack-queue-apply-confirm for /model + /effort (#3017) ──────────
+//
+// See pending-session-command.ts for the contract. The busy gates ENQUEUE
+// here + ACK; drainPendingSessionCommand() APPLIES the moment the agent idles
+// (from the same model-idle gate that drains pendingRestarts, plus the reaper
+// cap) and EDITS the ack card into the confirmation.
+
+/**
+ * Edit a queued command's ack card (chatId+messageId) into a new body,
+ * dropping any inline keyboard. Best-effort — a deleted card just logs.
+ * Mirrors redeliverBufferedInbound's edit-on-deliver via the shared retry
+ * policy so flood-wait / not-found are handled by the standard wrapper.
+ */
+async function editPendingCommandCard(chatId: string, messageId: number, text: string): Promise<void> {
+  try {
+    await robustApiCall(
+      () =>
+        // allow-raw-bot-api: deferred command-card edit routed through robustApiCall (not in the THREAD_NOT_FOUND blast pattern)
+        lockedBot.api.editMessageText(chatId, messageId, richMessage(hardenCardBreaks(text)), {
+          reply_markup: { inline_keyboard: [] },
+        }),
+      { chat_id: chatId, verb: 'pending-cmd-card' },
+    )
+  } catch (err) {
+    process.stderr.write(
+      `telegram gateway: pending-command card edit failed chat=${chatId} msg=${messageId}: ${(err as Error)?.message ?? String(err)}\n`,
+    )
+  }
+}
+
+/**
+ * Enqueue a mid-turn session command (last-write-wins). If it displaces an
+ * earlier queued command, edit that stale ack card into a "superseded" note so
+ * the operator's replaced choice is never silently lost.
+ */
+function enqueueSessionCommand(cmd: PendingSessionCommand): void {
+  const displaced = pendingSessionCommand.set(cmd)
+  if (displaced) {
+    void editPendingCommandCard(
+      displaced.ackChatId,
+      displaced.ackMessageId,
+      pendingCmdSupersededText(displaced, cmd, escapeHtmlForTg),
+    )
+  }
+}
+
+/** Apply a queued typed/menu-alias model command at idle; return the reply body. */
+async function applyQueuedModelCommand(cmd: PendingSessionCommand): Promise<string> {
+  const deps = buildModelDeps({ chatId: cmd.chatId, threadId: cmd.threadId })
+  if (cmd.origin === 'menu') {
+    // Menu SELECT (mdl:s:<tag>) — replay the callback handler (discovery is
+    // idle-safe now) and record via the shared side-effects helper.
+    const prevSessionModel = sessionModelSource.getOverride()
+    const outcome = await handleModelMenuCallback(cmd.arg, deps)
+    const { restartNotice } = recordModelMenuSideEffects(
+      outcome,
+      deps,
+      cmd.chatId,
+      cmd.threadId,
+      prevSessionModel,
+    )
+    return restartNotice ?? outcome.reply.text
+  }
+  // Typed (and alias/sr menu taps converted to typed at enqueue): run the real
+  // handler + shared recording.
+  const reply = await handleModelCommand({ kind: 'set', model: cmd.arg }, deps)
+  const warning = recordTypedModelSwitch(reply, cmd.arg, deps)
+  return reply.text + warning
+}
+
+/** Apply a queued typed/menu effort command at idle; return the reply body. */
+async function applyQueuedEffortCommand(cmd: PendingSessionCommand): Promise<string> {
+  const deps = buildEffortDeps()
+  if (cmd.origin === 'menu') {
+    const outcome = await handleEffortMenuCallback(cmd.arg, deps)
+    return outcome.reply.text
+  }
+  const reply = await handleEffortCommand({ kind: 'set', level: cmd.arg as EffortLevel }, deps)
+  return reply.text
+}
+
+// Synchronous re-entrancy guard — the idle gate can fire several times per
+// turn-end; the async apply must not double-dispatch before the first settles
+// (mirrors compactDispatching).
+let pendingCmdDraining = false
+
+/**
+ * Drain the queued session command when the agent goes idle: apply it, then
+ * edit the ack card into the confirmation (or a failure banner). Called from
+ * the model-idle gate (turn complete) and the reaper drain-cap. No-op when the
+ * slot is empty. If a restart is also pending the session is going away — a
+ * Claude-model / effort session change would not survive, so report that
+ * honestly rather than falsely confirming.
+ */
+async function drainPendingSessionCommand(): Promise<void> {
+  if (pendingCmdDraining) return
+  if (pendingSessionCommand.size === 0) return
+  pendingCmdDraining = true
+  const cmd = pendingSessionCommand.take()
+  try {
+    if (cmd == null) return
+    if (pendingRestarts.size > 0) {
+      await editPendingCommandCard(
+        cmd.ackChatId,
+        cmd.ackMessageId,
+        pendingCmdRestartSupersededText(cmd, escapeHtmlForTg),
+      )
+      return
+    }
+    let body: string
+    try {
+      body =
+        cmd.kind === 'model'
+          ? await applyQueuedModelCommand(cmd)
+          : await applyQueuedEffortCommand(cmd)
+    } catch (err) {
+      await editPendingCommandCard(
+        cmd.ackChatId,
+        cmd.ackMessageId,
+        `❌ Couldn’t apply the queued ${cmd.kind} switch to \`${escapeHtmlForTg(cmd.targetLabel)}\`: ${escapeHtmlForTg((err as Error)?.message ?? String(err))}`,
+      )
+      return
+    }
+    await editPendingCommandCard(cmd.ackChatId, cmd.ackMessageId, body)
+  } finally {
+    pendingCmdDraining = false
+  }
+}
+
 bot.command('model', async ctx => {
   if (!isAuthorizedSender(ctx)) return
   const text = ctx.message?.text ?? ctx.channelPost?.text ?? ''
@@ -19878,50 +20182,38 @@ bot.command('model', async ctx => {
     await switchroomReply(ctx, menu.text, { html: true, reply_markup: modelMenuReplyMarkup(menu) })
     return
   }
+  // Mid-turn: instead of dead-ending ("Try again in a moment"), ACK + QUEUE +
+  // apply-on-idle + confirm (#3017). The typed set path either injects into
+  // claude's input box or triggers a carrier restart — both unsafe mid-turn.
+  if (parsed.kind === 'set' && deps.isBusy()) {
+    const target = expandSrAlias(parsed.model)
+    const sent = await ctx.replyWithRichMessage(
+      richMessage(hardenCardBreaks(pendingCmdAckText('model', target, escapeHtmlForTg))),
+      threadId != null ? { message_thread_id: threadId } : {},
+    )
+    enqueueSessionCommand({
+      kind: 'model',
+      origin: 'typed',
+      arg: target,
+      targetLabel: target,
+      chatId,
+      threadId,
+      ackChatId: chatId,
+      ackMessageId: (sent as { message_id: number }).message_id,
+      requestedAt: Date.now(),
+    })
+    return
+  }
   const reply = await handleModelCommand(parsed, deps)
   // Record a POSITIVELY-CONFIRMED typed switch so /status reflects what's
-  // actually running — the SAME in-memory override the menu callback path sets
-  // (buildAgentMetadata resolves it via sessionModelSource). Only
-  // set on the confirmed inject path; the sr-*/relaunch paths already set the
-  // override inside scheduleModelRelaunch, and an unverified switch carries no
-  // selectedModel so /status is never lied to.
-  const requested = parsed.kind === 'set' ? expandSrAlias(parsed.model) : null
-  let persistWarning = ''
-  if (requested?.toLowerCase() === 'default') {
-    // `/model default` clears the sticky file even WITHOUT a positive
-    // confirmation: claude's arg-form switch can be silent, and a surviving
-    // sticky file would resurrect the old model on the next keep-relaunch.
-    // Clearing is idempotent; the in-memory override change stays gated on a
-    // confirmed switch so an unverified inject never lies to /status.
-    const smDir = resolveAgentDirFromEnv()
-    if (smDir) clearSessionModelFile(smDir)
-    if (reply.selectedModel) sessionModelSource.setOverride(null)
-  } else if (reply.selectedModel) {
-    sessionModelSource.setOverride(reply.selectedModel)
-    // Durable stickiness: persist the REQUESTED canonical token — never
-    // the confirmation's display label ("Opus 4.8"), which `claude
-    // --model` would reject on the next boot. sr-* switches never reach
-    // here (they go through scheduleModelRelaunch, which persists).
-    const smDir = resolveAgentDirFromEnv()
-    if (smDir && requested && isValidModelArg(requested) && !isSrModel(requested)) {
-      try {
-        writeSessionModelFile(
-          smDir,
-          requested,
-          readConfiguredDefaultModel(smDir) ??
-            resolveMainModel(deps.getConfiguredModel() ?? undefined),
-        )
-      } catch (err) {
-        // The reply body already promises stickiness — never let the promise
-        // and the disk disagree silently.
-        persistWarning =
-          '\n⚠️ Couldn’t persist the sticky override — the switch is live now but won’t survive a relaunch.'
-        process.stderr.write(
-          `telegram gateway: session-model persist failed (typed /model): ${(err as Error)?.message ?? String(err)}\n`,
-        )
-      }
-    }
-  }
+  // actually running (shared with the deferred/menu paths). The sr-*/relaunch
+  // paths already set the override inside scheduleModelRelaunch; an unverified
+  // switch carries no selectedModel so /status is never lied to.
+  const persistWarning = recordTypedModelSwitch(
+    reply,
+    parsed.kind === 'set' ? parsed.model : null,
+    deps,
+  )
   await switchroomReply(ctx, reply.text + persistWarning, { html: reply.html })
 })
 
@@ -19965,6 +20257,30 @@ bot.command('effort', async ctx => {
   if (parsed.kind === 'show') {
     const menu = buildEffortMenu(deps)
     await switchroomReply(ctx, menu.text, { html: true, reply_markup: effortMenuReplyMarkup(menu) })
+    return
+  }
+  // Mid-turn: ACK + QUEUE + apply-on-idle + confirm (#3017) — parity with
+  // /model. `applyEffort` mid-turn silently maybe-failed ("couldn't confirm it
+  // applied") before this gate existed. `currentTurn !== null` is the same
+  // busy signal the model path reads via deps.isBusy().
+  if (parsed.kind === 'set' && currentTurn !== null) {
+    const chatId = String(ctx.chat!.id)
+    const threadId = resolveThreadId(chatId, ctx.message?.message_thread_id)
+    const sent = await ctx.replyWithRichMessage(
+      richMessage(hardenCardBreaks(pendingCmdAckText('effort', parsed.level, escapeHtmlForTg))),
+      threadId != null ? { message_thread_id: threadId } : {},
+    )
+    enqueueSessionCommand({
+      kind: 'effort',
+      origin: 'typed',
+      arg: parsed.level,
+      targetLabel: parsed.level,
+      chatId,
+      threadId,
+      ackChatId: chatId,
+      ackMessageId: (sent as { message_id: number }).message_id,
+      requestedAt: Date.now(),
+    })
     return
   }
   const reply = await handleEffortCommand(parsed, deps)
@@ -22704,9 +23020,37 @@ bot.on('callback_query:data', async ctx => {
       await ctx.answerCallbackQuery({ text: 'Not authorized.' })
       return
     }
-    // No picker-driving (the inline `/effort <level>` form sets it
-    // directly via the inject primitive), so no mid-turn guard is needed
-    // here — just ack and apply.
+    // Mid-turn: ACK + QUEUE + apply-on-idle + confirm (#3017). `applyEffort`
+    // types `/effort <level>` into claude's input box + drives the confirm
+    // modal — mid-turn that queues the text as user input instead of switching
+    // (the silent maybe-fail this fix closes). Parity with the model-menu gate.
+    const effLevel = data.startsWith('eff:s:') ? data.slice('eff:s:'.length) : null
+    const effCardMsgId = ctx.callbackQuery?.message?.message_id
+    if (effLevel != null && currentTurn !== null && effCardMsgId != null) {
+      await ctx
+        .answerCallbackQuery({ text: '📥 Queued — applies when the turn ends' })
+        .catch(() => {})
+      const effChatId = String(ctx.chat?.id ?? '')
+      const effThreadId = resolveThreadId(effChatId, ctx.callbackQuery?.message?.message_thread_id)
+      await ctx
+        .editMessageText(richMessage(hardenCardBreaks(pendingCmdAckText('effort', effLevel, escapeHtmlForTg))), {
+          reply_markup: { inline_keyboard: [] },
+        })
+        .catch(() => {})
+      enqueueSessionCommand({
+        kind: 'effort',
+        origin: 'menu',
+        arg: data,
+        targetLabel: effLevel,
+        chatId: effChatId,
+        threadId: effThreadId,
+        ackChatId: effChatId,
+        ackMessageId: effCardMsgId,
+        requestedAt: Date.now(),
+      })
+      return
+    }
+    // Idle: apply directly. No picker-driving concern — just ack and apply.
     await ctx.answerCallbackQuery({ text: 'Setting effort…' }).catch(() => {})
     try {
       const outcome = await handleEffortMenuCallback(data, buildEffortDeps())
@@ -22745,12 +23089,51 @@ bot.on('callback_query:data', async ctx => {
     const cbChatId = String(ctx.chat?.id ?? '')
     const cbThreadId = resolveThreadId(cbChatId, ctx.callbackQuery?.message?.message_thread_id)
     const modelDeps = buildModelDeps({ chatId: cbChatId, threadId: cbThreadId })
-    // Mid-turn refusal is INSTANT (a sync isBusy() check, no picker drive),
-    // so handle it before the "Working…" ack: toast WHY and leave the menu
-    // message untouched (buttons intact) so the operator taps again when
-    // idle. Editing the menu into a button-less "try again" line was the
-    // "nothing happened" report — the menu looked dead.
+    // Mid-turn (#3017): a model-SWITCH tap no longer dead-ends. ACK + QUEUE +
+    // apply-on-idle + confirm — the tap edits the menu card into the ack, which
+    // the idle drain then edits into the confirmation. Non-switch taps (Refresh
+    // / page-nav / header) still just toast — they drive the picker (discovery)
+    // which is unsafe mid-turn and carry no operator choice to preserve.
     if (modelDeps.isBusy()) {
+      // Classify: sr-*/alias taps carry a real model token → queue as a typed
+      // apply (reuses the typed drain + recording). A select tag (mdl:s:<tag>)
+      // needs idle discovery to resolve → queue as a menu apply (replayed).
+      const cardMsgId = ctx.callbackQuery?.message?.message_id
+      let queueArg: string | null = null
+      let queueOrigin: 'typed' | 'menu' = 'menu'
+      let queueLabel = 'the selected model'
+      if (data.startsWith(MODEL_CALLBACK_SR)) {
+        const srName = data.slice(MODEL_CALLBACK_SR.length)
+        if (isValidModelArg(srName)) { queueArg = srName; queueOrigin = 'typed'; queueLabel = srFriendlyLabel(srName) }
+      } else if (data.startsWith(MODEL_CALLBACK_ALIAS)) {
+        const alias = data.slice(MODEL_CALLBACK_ALIAS.length)
+        if (isValidModelArg(alias)) { queueArg = alias; queueOrigin = 'typed'; queueLabel = alias }
+      } else if (data.startsWith('mdl:s:')) {
+        queueArg = data; queueOrigin = 'menu'
+      }
+      if (queueArg != null && cardMsgId != null) {
+        await ctx
+          .answerCallbackQuery({ text: '📥 Queued — applies when the turn ends' })
+          .catch(() => {})
+        await ctx
+          .editMessageText(richMessage(hardenCardBreaks(pendingCmdAckText('model', queueLabel, escapeHtmlForTg))), {
+            reply_markup: { inline_keyboard: [] },
+          })
+          .catch(() => {})
+        enqueueSessionCommand({
+          kind: 'model',
+          origin: queueOrigin,
+          arg: queueArg,
+          targetLabel: queueLabel,
+          chatId: cbChatId,
+          threadId: cbThreadId,
+          ackChatId: cbChatId,
+          ackMessageId: cardMsgId,
+          requestedAt: Date.now(),
+        })
+        return
+      }
+      // Non-switch tap (or unresolvable) — keep the menu intact, just toast.
       await ctx
         .answerCallbackQuery({ text: '⏳ Agent is mid-turn — tap again when it’s idle', show_alert: false })
         .catch(() => {})
@@ -22814,105 +23197,32 @@ bot.on('callback_query:data', async ctx => {
       }
       return
     }
-    const didInterimSrEdit = false
     try {
       const prevSessionModel = sessionModelSource.getOverride()
       const outcome = await handleModelMenuCallback(data, modelDeps)
-      // Record a successful session switch so /status reflects what's
-      // actually running, and persist the STICKY override
-      // (reference/rfcs/session-model-stickiness.md): the canonical token
-      // (never the display label) goes to the durable `.session-model`; a
-      // confirmed "Default (recommended)" selection clears it instead.
-      if (outcome.selectedModel) {
-        sessionModelSource.setOverride(outcome.selectedModel)
-        const smDir = resolveAgentDirFromEnv()
-        if (smDir && outcome.selectedModelToken) {
-          try {
-            writeSessionModelFile(
-              smDir,
-              outcome.selectedModelToken,
-              readConfiguredDefaultModel(smDir) ??
-                resolveMainModel(modelDeps.getConfiguredModel() ?? undefined),
-            )
-          } catch (err) {
-            // The banner already promises stickiness — surface the failure on
-            // the same card instead of only stderr.
-            outcome.reply.text +=
-              '\n⚠️ Couldn’t persist the sticky override — the switch is live now but won’t survive a relaunch.'
-            process.stderr.write(
-              `telegram gateway: session-model persist failed (menu): ${(err as Error)?.message ?? String(err)}\n`,
-            )
-          }
-        }
-      }
-      if (outcome.clearedDefault) {
-        const smDir = resolveAgentDirFromEnv()
-        if (smDir) clearSessionModelFile(smDir)
-      }
-      // toastOnly: leave the menu untouched — but only if we haven't already
-      // cleared its buttons with the interim sr-* edit. If we have, fall
-      // through to the final edit so the message is recovered (busyReply or
-      // the full menu) rather than left permanently button-less.
-      if (outcome.toastOnly && !didInterimSrEdit) return
-
-      // sr-* → Claude transition via the model menu: trigger a graceful restart.
-      // Switching FROM an sr-* (LiteLLM/OpenRouter) model BACK to a Claude model
-      // via the picker requires a session restart — the picker-select only changes
-      // the session model label, but the sr-* LiteLLM routing context persists
-      // until the session is torn down. Same mechanism as the /restart command.
-      if (outcome.selectedModel && isSrToClaudeTransition(prevSessionModel, outcome.selectedModel)) {
-        const agentName = getMyAgentName()
-        // Replace the menu with a restart notice (no buttons — session is ending).
+      // toastOnly: leave the menu untouched — a mid-turn refusal keeps its
+      // buttons so the operator can tap again. (In the enqueue world this
+      // branch is unreachable — the dispatcher enqueues switches mid-turn
+      // before ever calling the handler — but retained for callers that skip
+      // the dispatcher gate.)
+      if (outcome.toastOnly) return
+      // Record the switch (persist/clear sticky override) + drive an sr-*→Claude
+      // graceful restart when needed. Shared with the deferred (queued) apply so
+      // both surfaces record identically. Returns a restart notice when a
+      // session restart was scheduled.
+      const { restartNotice } = recordModelMenuSideEffects(
+        outcome,
+        modelDeps,
+        cbChatId,
+        cbThreadId,
+        prevSessionModel,
+      )
+      if (restartNotice) {
         await ctx
-          .editMessageText(
-            richMessage(`🔄 Switching from **${escapeHtmlForTg(prevSessionModel!)}** back to Claude — restarting session cleanly. Claude will be ready in ~30s.`),
-            { reply_markup: { inline_keyboard: [] } },
-          )
+          .editMessageText(richMessage(restartNotice), { reply_markup: { inline_keyboard: [] } })
           .catch(() => {})
-        // Carry the requested Claude model across the restart via the SAME
-        // durable `.session-model` override a Claude → sr-* switch uses —
-        // otherwise boot launches the CONFIGURED default and the tapped model
-        // is silently dropped. `selectedModelToken` is a real `claude --model`
-        // token (alias or full claude-* id); a "Default"-row tap yields no
-        // token → clear the override and boot the configured default
-        // (correct). start.sh's LiteLLM-down guard only skips sr-* overrides,
-        // so a Claude token is never dropped.
-        {
-          const agentDir = resolveAgentDirFromEnv()
-          const token = outcome.selectedModelToken
-          if (agentDir && token) {
-            try {
-              writeSessionModelFile(
-                agentDir,
-                token,
-                readConfiguredDefaultModel(agentDir) ??
-                  resolveMainModel(modelDeps.getConfiguredModel() ?? undefined),
-              )
-              sessionModelSource.setOverride(token)
-            } catch (e) {
-              process.stderr.write(`telegram gateway: sr-to-claude session-model write failed: ${(e as Error)?.message ?? String(e)}\n`)
-            }
-          } else if (agentDir) {
-            // Default-row tap while on sr-*: the restart must land on the
-            // configured default — a stale sticky override would resurrect
-            // the old model on the next keep-relaunch.
-            clearSessionModelFile(agentDir)
-          }
-        }
-        // Write the restart marker so the post-restart boot card edits into this chat.
-        writeRestartMarker({ chat_id: cbChatId, thread_id: cbThreadId ?? null, ack_message_id: null, ts: Date.now() })
-        stampUserRestartReason('user: sr-to-claude model switch (menu)')
-        if (turnInFlightForGate()) {
-          // Defer restart until the in-flight turn completes (same gate as /restart).
-          pendingRestarts.set(agentName, Date.now())
-        } else {
-          void sweepBeforeSelfRestart().finally(() =>
-            triggerSelfRestart(agentName, 'sr-to-claude-model-switch', 1500),
-          )
-        }
         return
       }
-
       await ctx
         .editMessageText(richMessage(outcome.reply.text), {
           reply_markup: modelMenuReplyMarkup(outcome.reply) ?? { inline_keyboard: [] },
@@ -25190,6 +25500,30 @@ async function shutdown(signal: string): Promise<void> {
       process.stderr.write(`telegram gateway: shutdown.clean_marker_written signal=${signal} reason=${JSON.stringify(next.reason ?? '')} preserved=${prior?.reason === next.reason && prior != null} path=${GATEWAY_CLEAN_SHUTDOWN_MARKER_PATH}\n`)
     } catch (err) {
       process.stderr.write(`telegram gateway: shutdown.clean_marker_write_failed err=${(err as Error).message}\n`)
+    }
+    // #3017 — persist a Telegram-set model across a GRACEFUL deploy/restart.
+    // Boot default is REVERT, and an EXTERNAL deploy (SIGTERM to PID 1 from
+    // `switchroom apply` / `docker compose up`) never routes through
+    // triggerSelfRestart, so it stamps no `.relaunch-model-intent` and start.sh
+    // drops the user's `/model` choice (the overlord `fable`→`opus` revert on
+    // the v0.18.9 roll). A graceful OS-signal shutdown IS a clean, planned
+    // bounce — stamp keep-intent for an active `.session-model` override so the
+    // chosen model survives and start.sh re-confirms it via `.session-model-alert`
+    // on boot. Respect an intent an initiator already stamped (a /restart stamps
+    // 'revert' before SIGTERM): only stamp when none exists. A crash routes
+    // through the non-OS-signal branch and still reverts (safe side preserved).
+    try {
+      const smDir = resolveAgentDirFromEnv()
+      if (smDir != null) {
+        const hasOverride = readSessionModelFile(smDir) != null
+        const intentAlreadyStamped = existsSync(join(smDir, RELAUNCH_MODEL_INTENT_FILE))
+        if (hasOverride && !intentAlreadyStamped) {
+          writeRelaunchModelIntent(smDir, 'keep', `graceful ${signal} shutdown (deploy/rolling restart) — preserving user-chosen session model`)
+          process.stderr.write(`telegram gateway: shutdown.session_model_keep_stamped signal=${signal}\n`)
+        }
+      }
+    } catch (err) {
+      process.stderr.write(`telegram gateway: shutdown.session_model_keep_stamp_failed err=${(err as Error).message}\n`)
     }
   } else {
     process.stderr.write(`telegram gateway: shutdown.clean_marker_skipped signal=${signal} (crash path — banner will fire on next boot)\n`)

--- a/telegram-plugin/gateway/pending-session-command.ts
+++ b/telegram-plugin/gateway/pending-session-command.ts
@@ -1,0 +1,157 @@
+/**
+ * Deterministic ack-queue-apply-confirm for the session-mutating Telegram
+ * commands (`/model`, `/effort`).
+ *
+ * The bug this closes (#TODO): a `/model` or `/effort` command issued while
+ * the agent is MID-TURN used to dead-end. The typed `/model <name>` path
+ * refused with "⏳ … Try again in a moment." and dropped the request; the
+ * menu taps toasted the same refusal; `/effort` had no busy gate at all and
+ * silently maybe-failed ("sent, but couldn't confirm it applied"). In every
+ * case the operator's choice was lost — they had to notice and re-issue it.
+ *
+ * The contract now, consistent across BOTH commands and BOTH their typed and
+ * menu surfaces:
+ *
+ *   1. immediately APPLICABLE (session idle) → apply + confirm, unchanged.
+ *   2. session MID-TURN → immediately ACK ("📥 … the moment this turn
+ *      finishes"), deterministically QUEUE the request, then APPLY the moment
+ *      the agent goes idle and EDIT the ack card into the confirmation.
+ *
+ * This is a SINGLE-VALUED per-agent slot, last-write-wins: a rapid `/model
+ * fable` then `/model opus` queues only the latest (the earlier ack card is
+ * edited to "superseded"). It reuses the same idle-gate discipline as
+ * `pendingRestarts` / proactive `/compact` — drained at the model-idle gate
+ * (`activeTurnStartedAt.size === 0`) with a bounded reaper fallback so a
+ * session that never cleanly idles still applies-or-reports.
+ *
+ * The apply itself (running the real handler, recording the session-model
+ * override, editing the ack card) lives in the gateway — this module is the
+ * pure slot + the ack/confirm/superseded text so it is unit-testable without
+ * booting the bot. Mirrors the split shape of model-command.ts /
+ * effort-command.ts.
+ */
+
+export type PendingCommandKind = 'model' | 'effort'
+export type PendingCommandOrigin = 'typed' | 'menu'
+
+export interface PendingSessionCommand {
+  kind: PendingCommandKind
+  /**
+   * How the request arrived — `typed` for `/model <name>` / `/effort <level>`,
+   * `menu` for an inline-keyboard tap. Determines which handler the drain
+   * replays (the typed handler vs the menu-callback handler).
+   */
+  origin: PendingCommandOrigin
+  /**
+   * The apply payload the drain replays verbatim:
+   *   - typed model  → the (alias-expanded) model token, e.g. `fable`, `sr-glm-5`
+   *   - typed effort → the effort level, e.g. `high`
+   *   - menu         → the raw callback data (`mdl:s:<tag>` / `mdl:alias:<a>` /
+   *                    `mdl:sr:<name>` / `eff:s:<level>`), replayed through the
+   *                    menu-callback handler which re-discovers at idle.
+   */
+  arg: string
+  /**
+   * Human-facing label for the ack / superseded text (e.g. `fable`, `high`,
+   * `Gemini 2.5 Pro`). Display-only — never fed to `claude --model`.
+   */
+  targetLabel: string
+  /** The chat the command came from (for building model deps on the deferred apply). */
+  chatId: string
+  /** The forum topic, if any. */
+  threadId?: number
+  /** The chat the ack card was posted to (usually === chatId). */
+  ackChatId: string
+  /** The ack card's message id — the drain EDITS this into the confirmation. */
+  ackMessageId: number
+  requestedAt: number
+}
+
+export interface PendingSessionCommandSlot {
+  /** The queued command, or null when the slot is empty. */
+  get(): PendingSessionCommand | null
+  /**
+   * Enqueue last-write-wins. Returns the command it DISPLACED (if any) so the
+   * caller can edit that stale ack card into a "superseded" note.
+   */
+  set(cmd: PendingSessionCommand): PendingSessionCommand | null
+  /** Atomically remove and return the queued command (the drain's read). */
+  take(): PendingSessionCommand | null
+  /** Drop the queued command without applying it. */
+  clear(): void
+  /** 0 or 1 — mirrors the `pendingRestarts.size` gate shape. */
+  readonly size: number
+}
+
+/** Create an empty single-valued slot. */
+export function createPendingSessionCommandSlot(): PendingSessionCommandSlot {
+  let slot: PendingSessionCommand | null = null
+  return {
+    get: () => slot,
+    set(cmd: PendingSessionCommand): PendingSessionCommand | null {
+      const displaced = slot
+      slot = cmd
+      return displaced
+    },
+    take(): PendingSessionCommand | null {
+      const cur = slot
+      slot = null
+      return cur
+    },
+    clear(): void {
+      slot = null
+    },
+    get size(): number {
+      return slot == null ? 0 : 1
+    },
+  }
+}
+
+const KIND_NOUN: Record<PendingCommandKind, string> = {
+  model: 'model',
+  effort: 'effort',
+}
+
+const KIND_VERB: Record<PendingCommandKind, string> = {
+  model: 'switch to',
+  effort: 'set effort to',
+}
+
+/**
+ * The immediate ACK shown when a command is queued behind a live turn. Names
+ * the target so the operator sees their choice was captured, not dropped.
+ * `escapeHtml` guards the (already shape-gated) label for the HTML send path.
+ */
+export function ackText(
+  kind: PendingCommandKind,
+  targetLabel: string,
+  escapeHtml: (s: string) => string,
+): string {
+  return `📥 Agent is mid-turn — I'll ${KIND_VERB[kind]} \`${escapeHtml(targetLabel)}\` the moment this turn finishes.`
+}
+
+/**
+ * Edited onto a stale ack card when a NEWER command of the same slot displaces
+ * it (last-write-wins). Tells the operator their earlier choice was replaced,
+ * not silently lost.
+ */
+export function supersededText(
+  displaced: PendingSessionCommand,
+  next: PendingSessionCommand,
+  escapeHtml: (s: string) => string,
+): string {
+  return `↩️ Superseded — queued \`${escapeHtml(next.targetLabel)}\` instead (your earlier \`${escapeHtml(displaced.targetLabel)}\` ${KIND_NOUN[displaced.kind]} request was replaced before it applied).`
+}
+
+/**
+ * Edited onto the ack card when the queued command could not apply because the
+ * session is restarting (a Claude-model / effort session change does not
+ * survive the bounce). The operator is told to re-issue after boot rather than
+ * being left believing it landed.
+ */
+export function restartSupersededText(
+  cmd: PendingSessionCommand,
+  escapeHtml: (s: string) => string,
+): string {
+  return `↩️ The session is restarting before your \`${escapeHtml(cmd.targetLabel)}\` ${KIND_NOUN[cmd.kind]} change could apply — re-issue \`/${cmd.kind} ${escapeHtml(cmd.targetLabel)}\` once the agent is back.`
+}

--- a/telegram-plugin/gateway/pending-session-command.ts
+++ b/telegram-plugin/gateway/pending-session-command.ts
@@ -17,12 +17,17 @@
  *      finishes"), deterministically QUEUE the request, then APPLY the moment
  *      the agent goes idle and EDIT the ack card into the confirmation.
  *
- * This is a SINGLE-VALUED per-agent slot, last-write-wins: a rapid `/model
- * fable` then `/model opus` queues only the latest (the earlier ack card is
- * edited to "superseded"). It reuses the same idle-gate discipline as
- * `pendingRestarts` / proactive `/compact` — drained at the model-idle gate
- * (`activeTurnStartedAt.size === 0`) with a bounded reaper fallback so a
- * session that never cleanly idles still applies-or-reports.
+ * This is a PER-KIND slot store (one slot for `model`, one for `effort`):
+ * same-kind last-write-wins — a rapid `/model fable` then `/model opus`
+ * queues only the latest (the earlier ack card is edited to "superseded") —
+ * while cross-kind requests coexist (a queued `/effort` never displaces a
+ * queued `/model`; both apply at idle). It reuses the same idle-gate
+ * discipline as `pendingRestarts` / proactive `/compact` — drained at the
+ * model-idle gate (`activeTurnStartedAt.size === 0`) with a bounded reaper
+ * fallback so a session that never cleanly idles still applies-or-reports.
+ * The reaper cap DEFERS while a turn is genuinely in flight (see
+ * `drainCapDecision`): forcing mid-turn would hit the typed handler's busy
+ * refusal (dropping the choice) or type into the live claude input.
  *
  * The apply itself (running the real handler, recording the session-model
  * override, editing the ack card) lives in the gateway — this module is the
@@ -67,44 +72,113 @@ export interface PendingSessionCommand {
   requestedAt: number
 }
 
-export interface PendingSessionCommandSlot {
-  /** The queued command, or null when the slot is empty. */
-  get(): PendingSessionCommand | null
+export interface PendingSessionCommandSlots {
+  /** The queued command of that kind, or null when its slot is empty. */
+  get(kind: PendingCommandKind): PendingSessionCommand | null
   /**
-   * Enqueue last-write-wins. Returns the command it DISPLACED (if any) so the
-   * caller can edit that stale ack card into a "superseded" note.
+   * Enqueue. SAME-KIND last-write-wins: returns the same-kind command it
+   * DISPLACED (if any) so the caller can edit that stale ack card into a
+   * "superseded" note. CROSS-KIND commands coexist — a `/effort` never
+   * displaces a queued `/model` and vice versa.
    */
   set(cmd: PendingSessionCommand): PendingSessionCommand | null
-  /** Atomically remove and return the queued command (the drain's read). */
-  take(): PendingSessionCommand | null
-  /** Drop the queued command without applying it. */
+  /** Atomically remove and return the queued command of that kind. */
+  take(kind: PendingCommandKind): PendingSessionCommand | null
+  /**
+   * Atomically remove and return ALL queued commands in enqueue order (a
+   * same-kind re-enqueue moves to the back). The drain's and shutdown's read.
+   */
+  takeAll(): PendingSessionCommand[]
+  /** Snapshot of every queued command WITHOUT removing (the reaper's overdue check). */
+  list(): PendingSessionCommand[]
+  /** Drop every queued command without applying it. */
   clear(): void
-  /** 0 or 1 — mirrors the `pendingRestarts.size` gate shape. */
+  /** 0..2 — mirrors the `pendingRestarts.size` gate shape. */
   readonly size: number
 }
 
-/** Create an empty single-valued slot. */
-export function createPendingSessionCommandSlot(): PendingSessionCommandSlot {
-  let slot: PendingSessionCommand | null = null
+/** Create an empty per-kind slot store. */
+export function createPendingSessionCommandSlots(): PendingSessionCommandSlots {
+  const slots = new Map<PendingCommandKind, PendingSessionCommand>()
   return {
-    get: () => slot,
+    get: (kind: PendingCommandKind) => slots.get(kind) ?? null,
     set(cmd: PendingSessionCommand): PendingSessionCommand | null {
-      const displaced = slot
-      slot = cmd
+      const displaced = slots.get(cmd.kind) ?? null
+      // Delete-then-set so a same-kind re-enqueue moves to the BACK of the
+      // enqueue order — takeAll applies in latest-request order.
+      slots.delete(cmd.kind)
+      slots.set(cmd.kind, cmd)
       return displaced
     },
-    take(): PendingSessionCommand | null {
-      const cur = slot
-      slot = null
+    take(kind: PendingCommandKind): PendingSessionCommand | null {
+      const cur = slots.get(kind) ?? null
+      slots.delete(kind)
       return cur
     },
+    takeAll(): PendingSessionCommand[] {
+      const all = [...slots.values()]
+      slots.clear()
+      return all
+    },
+    list: () => [...slots.values()],
     clear(): void {
-      slot = null
+      slots.clear()
     },
     get size(): number {
-      return slot == null ? 0 : 1
+      return slots.size
     },
   }
+}
+
+/**
+ * What the reaper's bounded drain-cap should do this tick.
+ *
+ *   - 'wait'                 — nothing queued long enough; keep waiting.
+ *   - 'defer-turn-in-flight' — something IS overdue, but a turn is genuinely
+ *     in flight. Forcing a drain now would destroy the queued command: the
+ *     typed model path hits handleModelCommand's busy gate (the old "try
+ *     again" refusal, choice dropped) and /effort would type into the live
+ *     claude input. The cap only rescues the MISSED-IDLE-GATE case, so keep
+ *     waiting — the idle gate drains at turn end.
+ *   - 'force'                — overdue AND idle: the idle gate was missed;
+ *     force the apply-or-report so the ack card never dangles unresolved.
+ */
+export type DrainCapDecision = 'wait' | 'defer-turn-in-flight' | 'force'
+
+export function drainCapDecision(
+  queued: readonly PendingSessionCommand[],
+  now: number,
+  capMs: number,
+  turnInFlight: boolean,
+): DrainCapDecision {
+  const overdue = queued.some(c => now - c.requestedAt > capMs)
+  if (!overdue) return 'wait'
+  return turnInFlight ? 'defer-turn-in-flight' : 'force'
+}
+
+/** One best-effort ack-card edit the caller should perform. */
+export interface PendingCommandCardEdit {
+  chatId: string
+  messageId: number
+  text: string
+}
+
+/**
+ * Gateway-shutdown resolution for queued commands: EMPTY the slots and return
+ * the ack-card edits that tell the operator their queued choice cannot apply
+ * (the session is going away with the gateway) and must be re-issued after
+ * boot. Without this, a SIGTERM leaves the ack card dangling at "the moment
+ * this turn finishes" forever and the choice is silently lost.
+ */
+export function shutdownResolutionEdits(
+  slots: PendingSessionCommandSlots,
+  escapeHtml: (s: string) => string,
+): PendingCommandCardEdit[] {
+  return slots.takeAll().map(cmd => ({
+    chatId: cmd.ackChatId,
+    messageId: cmd.ackMessageId,
+    text: restartSupersededText(cmd, escapeHtml),
+  }))
 }
 
 const KIND_NOUN: Record<PendingCommandKind, string> = {

--- a/telegram-plugin/gateway/session-model-file.ts
+++ b/telegram-plugin/gateway/session-model-file.ts
@@ -174,6 +174,61 @@ export function writeRelaunchModelIntent(
   }
 }
 
+/**
+ * Reason prefix the gateway's SIGTERM/SIGINT shutdown handler stamps on its
+ * deploy-survival keep-intent (#3017/#3018). Distinguishable on purpose:
+ * a gateway-only bounce (supervisor relaunch, bare gateway-unit restart)
+ * leaves that stamp UNCONSUMED on disk — start.sh only runs on a container
+ * boot — and the next gateway boot uses this prefix to recognise and clear
+ * the stale stamp (see clearStaleGatewayShutdownIntent).
+ */
+export const GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX = 'gateway-shutdown:'
+
+export interface RelaunchModelIntentRecord {
+  intent: RelaunchModelIntent
+  reason: string
+  ts: number
+}
+
+/** Parsed `.relaunch-model-intent`, or null when absent / corrupt / malformed. */
+export function readRelaunchModelIntent(agentDir: string): RelaunchModelIntentRecord | null {
+  try {
+    const raw = readFileSync(join(agentDir, RELAUNCH_MODEL_INTENT_FILE), 'utf8')
+    const parsed = JSON.parse(raw) as Partial<RelaunchModelIntentRecord>
+    if (
+      (parsed.intent !== 'keep' && parsed.intent !== 'revert') ||
+      typeof parsed.reason !== 'string' ||
+      typeof parsed.ts !== 'number'
+    ) {
+      return null
+    }
+    return { intent: parsed.intent, reason: parsed.reason, ts: parsed.ts }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Boot-time cleanup for the gateway-only-bounce hole (#3018 finding 4).
+ *
+ * A container-level stop/deploy consumes `.relaunch-model-intent` in start.sh
+ * BEFORE any gateway boots. So if a freshly-booting GATEWAY still sees an
+ * intent that a gateway shutdown handler stamped (reason carries
+ * GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX), the preceding bounce was
+ * gateway-only — the container never restarted and the stamp is stale.
+ * Left in place, it could convert a genuine crash within the 10-min
+ * freshness window into a "keep", breaking the crash-reverts policy.
+ * Clear it. Never touches a triggerSelfRestart / user-slash stamp (those
+ * use their own un-prefixed reasons and precede a container bounce).
+ * Returns true when a stale stamp was cleared.
+ */
+export function clearStaleGatewayShutdownIntent(agentDir: string): boolean {
+  const rec = readRelaunchModelIntent(agentDir)
+  if (rec == null || !rec.reason.startsWith(GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX)) return false
+  clearRelaunchModelIntent(agentDir)
+  return true
+}
+
 /** Remove a stamped intent (rollback of a failed dispatch). Best-effort. */
 export function clearRelaunchModelIntent(agentDir: string): void {
   try {

--- a/telegram-plugin/tests/gateway-pending-command-wiring.test.ts
+++ b/telegram-plugin/tests/gateway-pending-command-wiring.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Structural pins for the #3018 fixes to the mid-turn ack-queue-apply-confirm
+ * wiring in gateway.ts (/model + /effort, #3017).
+ *
+ * The behaviour lives in un-exported inline closures (the pendingStateReaper
+ * interval, enqueueSessionCommand, drainPendingSessionCommand, and the
+ * shutdown() handler), so — mirroring gateway-session-model-relaunch.test.ts —
+ * we assert on the source structure. The pure contract (per-kind slots,
+ * drainCapDecision, shutdownResolutionEdits) is unit-tested in
+ * pending-session-command.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const GATEWAY_SRC = readFileSync(resolve(__dirname, '..', 'gateway', 'gateway.ts'), 'utf8')
+
+describe('gateway: reaper drain-cap defers while a turn is in flight (#3018 finding 1)', () => {
+  it('feeds turnInFlightForGate() into drainCapDecision and only forces on the force branch', () => {
+    const idx = GATEWAY_SRC.indexOf('pendingCmdDrainCapDecision(')
+    expect(idx).toBeGreaterThan(0)
+    const win = GATEWAY_SRC.slice(idx, idx + 1200)
+    // The decision reads the live turn gate…
+    expect(win).toContain('turnInFlightForGate()')
+    // …has an explicit defer branch that does NOT drain…
+    const deferIdx = win.indexOf("'defer-turn-in-flight'")
+    expect(deferIdx).toBeGreaterThan(0)
+    const forceIdx = win.indexOf("cmdDecision === 'force'")
+    expect(forceIdx).toBeGreaterThan(deferIdx)
+    // …and the ONLY drain call in the reaper block sits after the force check.
+    const drainIdx = win.indexOf('void drainPendingSessionCommand()')
+    expect(drainIdx).toBeGreaterThan(forceIdx)
+    expect(win.slice(0, forceIdx)).not.toContain('drainPendingSessionCommand()')
+  })
+})
+
+describe('gateway: post-enqueue idle kick (#3018 finding 5)', () => {
+  it('enqueueSessionCommand drains immediately when the session went idle between the busy check and the enqueue', () => {
+    const fnIdx = GATEWAY_SRC.indexOf('function enqueueSessionCommand(')
+    expect(fnIdx).toBeGreaterThan(0)
+    const win = GATEWAY_SRC.slice(fnIdx, fnIdx + 1500)
+    expect(win).toContain('if (!turnInFlightForGate()) void drainPendingSessionCommand()')
+  })
+})
+
+describe('gateway: shutdown resolves queued ack cards (#3018 finding 3)', () => {
+  it('shutdown() empties the slots via shutdownResolutionEdits and edits each card, before the force-exit timer', () => {
+    const fnIdx = GATEWAY_SRC.indexOf('async function shutdown(signal: string)')
+    expect(fnIdx).toBeGreaterThan(0)
+    const win = GATEWAY_SRC.slice(fnIdx, GATEWAY_SRC.indexOf('forceExitTimer', fnIdx))
+    const resolveIdx = win.indexOf('pendingCmdShutdownResolutionEdits(pendingSessionCommand')
+    expect(resolveIdx).toBeGreaterThan(0)
+    expect(win.indexOf('editPendingCommandCard(', resolveIdx)).toBeGreaterThan(resolveIdx)
+    // Bounded: raced against a timeout so a wedged Telegram API can't block shutdown.
+    expect(win.slice(resolveIdx)).toContain('Promise.race')
+  })
+})
+
+describe('gateway: keep-intent stamp narrowing (#3018 finding 4)', () => {
+  it('the shutdown keep-intent stamp carries the gateway-shutdown reason prefix', () => {
+    expect(GATEWAY_SRC).toContain(
+      "writeRelaunchModelIntent(smDir, 'keep', `${GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX} graceful ${signal} shutdown",
+    )
+  })
+
+  it('boot clears a stale gateway-shutdown-stamped intent (gateway-only bounce never runs start.sh)', () => {
+    const idx = GATEWAY_SRC.indexOf('clearStaleGatewayShutdownIntent(bootSmDir)')
+    expect(idx).toBeGreaterThan(0)
+    // The cleanup runs at module top-level (gateway boot), BEFORE the shutdown
+    // handler could stamp a fresh one for THIS process's own exit.
+    expect(idx).toBeLessThan(GATEWAY_SRC.indexOf('async function shutdown(signal: string)'))
+  })
+})

--- a/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
+++ b/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
@@ -137,22 +137,28 @@ describe('gateway: intent writers on the restart verbs', () => {
 
 describe('gateway: model-menu callback persists the sticky override', () => {
   it('a confirmed selection persists the canonical token (selectedModelToken), never the display label', () => {
-    const idx = GATEWAY_SRC.indexOf('const outcome = await handleModelMenuCallback(data, modelDeps)')
+    // Recording extracted into recordModelMenuSideEffects (#3017) — shared by the
+    // live dispatcher and the deferred (queued mid-turn) apply so both record
+    // identically.
+    const idx = GATEWAY_SRC.indexOf('function recordModelMenuSideEffects')
     expect(idx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(idx, idx + 1600)
+    const win = GATEWAY_SRC.slice(idx, idx + 2400)
     expect(win).toContain('outcome.selectedModelToken')
     expect(win).toMatch(/writeSessionModelFile\(\s*smDir,\s*outcome\.selectedModelToken/)
   })
 
   it('a confirmed "Default" selection CLEARS the sticky file', () => {
-    const idx = GATEWAY_SRC.indexOf('const outcome = await handleModelMenuCallback(data, modelDeps)')
-    const win = GATEWAY_SRC.slice(idx, idx + 1800)
+    const idx = GATEWAY_SRC.indexOf('function recordModelMenuSideEffects')
+    const win = GATEWAY_SRC.slice(idx, idx + 2400)
     expect(win).toContain('outcome.clearedDefault')
     expect(win).toContain('clearSessionModelFile(smDir)')
   })
 
   it('the sr-* callback branch calls scheduleModelRelaunch, not inject', () => {
-    const idx = GATEWAY_SRC.indexOf('if (data.startsWith(MODEL_CALLBACK_SR))')
+    // Anchor on the sr-* TARGET dispatcher branch specifically (a mid-turn
+    // busy-gate #3017 also matches `if (data.startsWith(MODEL_CALLBACK_SR))`, so
+    // anchor on the relaunch call that is unique to the idle apply branch).
+    const idx = GATEWAY_SRC.indexOf('const srLabel = escapeHtmlForTg(srFriendlyLabel(srName))')
     expect(idx).toBeGreaterThan(0)
     const win = GATEWAY_SRC.slice(idx, idx + 1400)
     expect(win).toContain('modelDeps.scheduleModelRelaunch(srName')
@@ -172,7 +178,9 @@ describe('gateway: model-menu callback persists the sticky override', () => {
 
 describe('gateway: typed /model persists the REQUESTED canonical token', () => {
   it('persists expandSrAlias(parsed.model), and `/model default` clears file + in-memory override', () => {
-    const idx = GATEWAY_SRC.indexOf("const requested = parsed.kind === 'set' ? expandSrAlias(parsed.model) : null")
+    // Recording extracted into recordTypedModelSwitch (#3017) — shared by the
+    // live `bot.command('model')` handler and the deferred (queued mid-turn) apply.
+    const idx = GATEWAY_SRC.indexOf('function recordTypedModelSwitch')
     expect(idx).toBeGreaterThan(0)
     const win = GATEWAY_SRC.slice(idx, idx + 2400)
     expect(win).toContain("requested?.toLowerCase() === 'default'")
@@ -184,7 +192,7 @@ describe('gateway: typed /model persists the REQUESTED canonical token', () => {
   })
 
   it('`/model default` file-clear is NOT gated on a positive confirmation (silent-switch path must not resurrect)', () => {
-    const idx = GATEWAY_SRC.indexOf("const requested = parsed.kind === 'set' ? expandSrAlias(parsed.model) : null")
+    const idx = GATEWAY_SRC.indexOf('function recordTypedModelSwitch')
     const win = GATEWAY_SRC.slice(idx, idx + 2400)
     // The default branch clears the file unconditionally, and only the
     // in-memory override change is confirmation-gated inside it.

--- a/telegram-plugin/tests/pending-session-command.test.ts
+++ b/telegram-plugin/tests/pending-session-command.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Contract pins for the mid-turn ack-queue-apply-confirm slot (#3017) that
+ * backs `/model` + `/effort` when the agent is busy.
+ *
+ * The gateway wiring (busy-gate enqueue, idle-gate drain, reaper drain-cap) is
+ * exercised end-to-end by the UAT harness; these lock the PURE contract the
+ * gateway relies on:
+ *
+ *   - single-valued slot, last-write-wins (a rapid re-issue queues only the
+ *     latest and REPORTS the displaced one so it's never silently lost)
+ *   - take() is the atomic drain read (empties the slot)
+ *   - size mirrors the `pendingRestarts.size` gate shape (0 or 1)
+ *   - the ack / superseded / restart-superseded text names the target so the
+ *     operator always sees their choice was captured, replaced, or deferred —
+ *     never dropped.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createPendingSessionCommandSlot,
+  ackText,
+  supersededText,
+  restartSupersededText,
+  type PendingSessionCommand,
+} from '../gateway/pending-session-command.js'
+
+const ident = (s: string) => s
+
+function cmd(overrides: Partial<PendingSessionCommand> = {}): PendingSessionCommand {
+  return {
+    kind: 'model',
+    origin: 'typed',
+    arg: 'fable',
+    targetLabel: 'fable',
+    chatId: '100',
+    threadId: undefined,
+    ackChatId: '100',
+    ackMessageId: 42,
+    requestedAt: 1_000,
+    ...overrides,
+  }
+}
+
+describe('pending-session-command slot', () => {
+  it('starts empty (size 0, get null, take null)', () => {
+    const slot = createPendingSessionCommandSlot()
+    expect(slot.size).toBe(0)
+    expect(slot.get()).toBeNull()
+    expect(slot.take()).toBeNull()
+  })
+
+  it('set on an empty slot displaces nothing and becomes gettable', () => {
+    const slot = createPendingSessionCommandSlot()
+    const a = cmd({ arg: 'opus', targetLabel: 'opus' })
+    expect(slot.set(a)).toBeNull()
+    expect(slot.size).toBe(1)
+    expect(slot.get()).toBe(a)
+  })
+
+  it('last-write-wins: a second set returns the displaced command', () => {
+    const slot = createPendingSessionCommandSlot()
+    const first = cmd({ arg: 'fable', targetLabel: 'fable', ackMessageId: 1 })
+    const second = cmd({ arg: 'opus', targetLabel: 'opus', ackMessageId: 2 })
+    expect(slot.set(first)).toBeNull()
+    const displaced = slot.set(second)
+    expect(displaced).toBe(first) // caller edits THIS ack card to "superseded"
+    expect(slot.get()).toBe(second) // only the latest is queued
+    expect(slot.size).toBe(1)
+  })
+
+  it('take() atomically empties the slot (the drain read)', () => {
+    const slot = createPendingSessionCommandSlot()
+    const a = cmd()
+    slot.set(a)
+    expect(slot.take()).toBe(a)
+    expect(slot.size).toBe(0)
+    expect(slot.get()).toBeNull()
+    expect(slot.take()).toBeNull() // second drain is a no-op
+  })
+
+  it('clear() drops the queued command without returning it', () => {
+    const slot = createPendingSessionCommandSlot()
+    slot.set(cmd())
+    slot.clear()
+    expect(slot.size).toBe(0)
+    expect(slot.get()).toBeNull()
+  })
+})
+
+describe('ackText', () => {
+  it('names the model target with a mid-turn framing', () => {
+    const t = ackText('model', 'fable', ident)
+    expect(t).toContain('mid-turn')
+    expect(t).toContain('`fable`')
+    expect(t).toContain('switch to')
+  })
+
+  it('uses the effort verb for effort commands', () => {
+    const t = ackText('effort', 'high', ident)
+    expect(t).toContain('set effort to')
+    expect(t).toContain('`high`')
+  })
+
+  it('routes the label through escapeHtml', () => {
+    const seen: string[] = []
+    ackText('model', 'sr-glm-5', (s) => { seen.push(s); return s })
+    expect(seen).toContain('sr-glm-5')
+  })
+})
+
+describe('supersededText', () => {
+  it('names BOTH the replaced and the new target', () => {
+    const displaced = cmd({ kind: 'model', targetLabel: 'fable' })
+    const next = cmd({ kind: 'model', targetLabel: 'opus' })
+    const t = supersededText(displaced, next, ident)
+    expect(t).toContain('`opus`')
+    expect(t).toContain('`fable`')
+    expect(t).toContain('replaced')
+  })
+})
+
+describe('restartSupersededText', () => {
+  it('tells the operator to re-issue after the restart', () => {
+    const t = restartSupersededText(cmd({ kind: 'effort', targetLabel: 'max' }), ident)
+    expect(t).toContain('restarting')
+    expect(t).toContain('/effort max')
+    expect(t).toContain('`max`')
+  })
+})

--- a/telegram-plugin/tests/pending-session-command.test.ts
+++ b/telegram-plugin/tests/pending-session-command.test.ts
@@ -1,15 +1,21 @@
 /**
- * Contract pins for the mid-turn ack-queue-apply-confirm slot (#3017) that
- * backs `/model` + `/effort` when the agent is busy.
+ * Contract pins for the mid-turn ack-queue-apply-confirm slots (#3017/#3018)
+ * that back `/model` + `/effort` when the agent is busy.
  *
- * The gateway wiring (busy-gate enqueue, idle-gate drain, reaper drain-cap) is
- * exercised end-to-end by the UAT harness; these lock the PURE contract the
- * gateway relies on:
+ * The gateway wiring (busy-gate enqueue, idle-gate drain, reaper drain-cap,
+ * shutdown resolution) is exercised end-to-end by the UAT harness and pinned
+ * structurally in gateway-pending-command-wiring.test.ts; these lock the PURE
+ * contract the gateway relies on:
  *
- *   - single-valued slot, last-write-wins (a rapid re-issue queues only the
- *     latest and REPORTS the displaced one so it's never silently lost)
- *   - take() is the atomic drain read (empties the slot)
- *   - size mirrors the `pendingRestarts.size` gate shape (0 or 1)
+ *   - one slot PER KIND (model, effort): same-kind last-write-wins (a rapid
+ *     re-issue queues only the latest and REPORTS the displaced one so it's
+ *     never silently lost); cross-kind requests COEXIST (#3018 finding 2)
+ *   - take(kind)/takeAll() are the atomic drain reads (empty the slots)
+ *   - size mirrors the `pendingRestarts.size` gate shape (0..2)
+ *   - the reaper's drainCapDecision DEFERS while a turn is in flight — the
+ *     60s cap must never force a mid-turn drain (#3018 finding 1)
+ *   - shutdownResolutionEdits empties the slots and yields the ack-card edits
+ *     telling the operator to re-issue after boot (#3018 finding 3)
  *   - the ack / superseded / restart-superseded text names the target so the
  *     operator always sees their choice was captured, replaced, or deferred —
  *     never dropped.
@@ -17,7 +23,9 @@
 
 import { describe, it, expect } from 'vitest'
 import {
-  createPendingSessionCommandSlot,
+  createPendingSessionCommandSlots,
+  drainCapDecision,
+  shutdownResolutionEdits,
   ackText,
   supersededText,
   restartSupersededText,
@@ -41,49 +49,142 @@ function cmd(overrides: Partial<PendingSessionCommand> = {}): PendingSessionComm
   }
 }
 
-describe('pending-session-command slot', () => {
-  it('starts empty (size 0, get null, take null)', () => {
-    const slot = createPendingSessionCommandSlot()
-    expect(slot.size).toBe(0)
-    expect(slot.get()).toBeNull()
-    expect(slot.take()).toBeNull()
+describe('pending-session-command slots', () => {
+  it('start empty (size 0, get null, take null, takeAll empty)', () => {
+    const slots = createPendingSessionCommandSlots()
+    expect(slots.size).toBe(0)
+    expect(slots.get('model')).toBeNull()
+    expect(slots.get('effort')).toBeNull()
+    expect(slots.take('model')).toBeNull()
+    expect(slots.takeAll()).toEqual([])
+    expect(slots.list()).toEqual([])
   })
 
   it('set on an empty slot displaces nothing and becomes gettable', () => {
-    const slot = createPendingSessionCommandSlot()
+    const slots = createPendingSessionCommandSlots()
     const a = cmd({ arg: 'opus', targetLabel: 'opus' })
-    expect(slot.set(a)).toBeNull()
-    expect(slot.size).toBe(1)
-    expect(slot.get()).toBe(a)
+    expect(slots.set(a)).toBeNull()
+    expect(slots.size).toBe(1)
+    expect(slots.get('model')).toBe(a)
   })
 
-  it('last-write-wins: a second set returns the displaced command', () => {
-    const slot = createPendingSessionCommandSlot()
+  it('SAME-KIND last-write-wins: a second set returns the displaced command', () => {
+    const slots = createPendingSessionCommandSlots()
     const first = cmd({ arg: 'fable', targetLabel: 'fable', ackMessageId: 1 })
     const second = cmd({ arg: 'opus', targetLabel: 'opus', ackMessageId: 2 })
-    expect(slot.set(first)).toBeNull()
-    const displaced = slot.set(second)
+    expect(slots.set(first)).toBeNull()
+    const displaced = slots.set(second)
     expect(displaced).toBe(first) // caller edits THIS ack card to "superseded"
-    expect(slot.get()).toBe(second) // only the latest is queued
-    expect(slot.size).toBe(1)
+    expect(slots.get('model')).toBe(second) // only the latest is queued
+    expect(slots.size).toBe(1)
   })
 
-  it('take() atomically empties the slot (the drain read)', () => {
-    const slot = createPendingSessionCommandSlot()
-    const a = cmd()
-    slot.set(a)
-    expect(slot.take()).toBe(a)
-    expect(slot.size).toBe(0)
-    expect(slot.get()).toBeNull()
-    expect(slot.take()).toBeNull() // second drain is a no-op
+  it('CROSS-KIND commands coexist: /effort never displaces a queued /model (#3018 finding 2)', () => {
+    const slots = createPendingSessionCommandSlots()
+    const model = cmd({ kind: 'model', arg: 'fable', targetLabel: 'fable', ackMessageId: 1 })
+    const effort = cmd({ kind: 'effort', arg: 'high', targetLabel: 'high', ackMessageId: 2 })
+    expect(slots.set(model)).toBeNull()
+    expect(slots.set(effort)).toBeNull() // NOT a displacement
+    expect(slots.size).toBe(2)
+    expect(slots.get('model')).toBe(model)
+    expect(slots.get('effort')).toBe(effort)
+    // …and vice versa: a later model re-issue displaces only the model slot.
+    const model2 = cmd({ kind: 'model', arg: 'opus', targetLabel: 'opus', ackMessageId: 3 })
+    expect(slots.set(model2)).toBe(model)
+    expect(slots.get('effort')).toBe(effort)
+    expect(slots.size).toBe(2)
   })
 
-  it('clear() drops the queued command without returning it', () => {
-    const slot = createPendingSessionCommandSlot()
-    slot.set(cmd())
-    slot.clear()
-    expect(slot.size).toBe(0)
-    expect(slot.get()).toBeNull()
+  it('take(kind) atomically empties only that slot (the per-kind drain read)', () => {
+    const slots = createPendingSessionCommandSlots()
+    const model = cmd({ kind: 'model' })
+    const effort = cmd({ kind: 'effort', arg: 'high', targetLabel: 'high' })
+    slots.set(model)
+    slots.set(effort)
+    expect(slots.take('model')).toBe(model)
+    expect(slots.size).toBe(1)
+    expect(slots.get('model')).toBeNull()
+    expect(slots.get('effort')).toBe(effort)
+    expect(slots.take('model')).toBeNull() // second drain is a no-op
+  })
+
+  it('takeAll() empties everything in enqueue order; a same-kind re-enqueue moves to the back', () => {
+    const slots = createPendingSessionCommandSlots()
+    const model1 = cmd({ kind: 'model', targetLabel: 'fable', ackMessageId: 1 })
+    const effort = cmd({ kind: 'effort', arg: 'high', targetLabel: 'high', ackMessageId: 2 })
+    const model2 = cmd({ kind: 'model', targetLabel: 'opus', ackMessageId: 3 })
+    slots.set(model1)
+    slots.set(effort)
+    slots.set(model2) // displaces model1 AND moves the model slot behind effort
+    const all = slots.takeAll()
+    expect(all).toEqual([effort, model2])
+    expect(slots.size).toBe(0)
+    expect(slots.takeAll()).toEqual([])
+  })
+
+  it('clear() drops every queued command without returning them', () => {
+    const slots = createPendingSessionCommandSlots()
+    slots.set(cmd({ kind: 'model' }))
+    slots.set(cmd({ kind: 'effort', arg: 'high', targetLabel: 'high' }))
+    slots.clear()
+    expect(slots.size).toBe(0)
+    expect(slots.get('model')).toBeNull()
+    expect(slots.get('effort')).toBeNull()
+  })
+})
+
+describe('drainCapDecision (#3018 finding 1: the cap must never force mid-turn)', () => {
+  const CAP = 60_000
+
+  it('waits when nothing is queued', () => {
+    expect(drainCapDecision([], 1_000_000, CAP, false)).toBe('wait')
+    expect(drainCapDecision([], 1_000_000, CAP, true)).toBe('wait')
+  })
+
+  it('waits while the queued command is younger than the cap', () => {
+    const q = [cmd({ requestedAt: 100_000 })]
+    expect(drainCapDecision(q, 100_000 + CAP, CAP, false)).toBe('wait')
+  })
+
+  it('forces once overdue AND the session is idle (missed idle gate)', () => {
+    const q = [cmd({ requestedAt: 100_000 })]
+    expect(drainCapDecision(q, 100_000 + CAP + 1, CAP, false)).toBe('force')
+  })
+
+  it('DEFERS (keeps waiting) when overdue but a turn is in flight — a forced mid-turn drain would destroy the queued command', () => {
+    const q = [cmd({ requestedAt: 100_000 })]
+    expect(drainCapDecision(q, 100_000 + CAP + 1, CAP, true)).toBe('defer-turn-in-flight')
+    // …even hours overdue: the idle gate at turn end is the drain point.
+    expect(drainCapDecision(q, 100_000 + 100 * CAP, CAP, true)).toBe('defer-turn-in-flight')
+  })
+
+  it('any one overdue command trips the cap (mixed ages)', () => {
+    const q = [
+      cmd({ kind: 'model', requestedAt: 100_000 }),
+      cmd({ kind: 'effort', requestedAt: 100_000 + CAP }),
+    ]
+    expect(drainCapDecision(q, 100_000 + CAP + 1, CAP, false)).toBe('force')
+  })
+})
+
+describe('shutdownResolutionEdits (#3018 finding 3: SIGTERM must not dangle the ack card)', () => {
+  it('empties the slots and yields one restart-superseded edit per queued command', () => {
+    const slots = createPendingSessionCommandSlots()
+    slots.set(cmd({ kind: 'model', targetLabel: 'fable', ackChatId: '100', ackMessageId: 7 }))
+    slots.set(cmd({ kind: 'effort', targetLabel: 'high', ackChatId: '100', ackMessageId: 9 }))
+    const edits = shutdownResolutionEdits(slots, ident)
+    expect(edits).toHaveLength(2)
+    expect(slots.size).toBe(0) // the queue is RESOLVED, not left behind
+    const model = edits.find(e => e.messageId === 7)!
+    expect(model.chatId).toBe('100')
+    expect(model.text).toContain('`fable`')
+    expect(model.text).toContain('re-issue')
+    const effort = edits.find(e => e.messageId === 9)!
+    expect(effort.text).toContain('/effort high')
+  })
+
+  it('returns no edits when nothing is queued', () => {
+    expect(shutdownResolutionEdits(createPendingSessionCommandSlots(), ident)).toEqual([])
   })
 })
 

--- a/telegram-plugin/tests/session-model-file.test.ts
+++ b/telegram-plugin/tests/session-model-file.test.ts
@@ -19,6 +19,9 @@ import {
   clearRelaunchModelIntent,
   readConfiguredDefaultModel,
   intentForRestartReason,
+  readRelaunchModelIntent,
+  clearStaleGatewayShutdownIntent,
+  GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX,
   SESSION_MODEL_FILE,
   RELAUNCH_MODEL_INTENT_FILE,
   CONFIGURED_DEFAULT_MODEL_FILE,
@@ -114,6 +117,47 @@ describe('intentForRestartReason — the triggerSelfRestart per-reason table (RF
 
   it('unknown gateway reasons default to keep (only gateway code calls triggerSelfRestart; crashes never do)', () => {
     expect(intentForRestartReason('some-future-recovery-path')).toBe('keep')
+  })
+})
+
+describe('readRelaunchModelIntent', () => {
+  it('round-trips a stamped intent; null when absent / corrupt / malformed', () => {
+    expect(readRelaunchModelIntent(dir)).toBeNull()
+    writeRelaunchModelIntent(dir, 'keep', 'watchdog recovery')
+    const rec = readRelaunchModelIntent(dir)!
+    expect(rec.intent).toBe('keep')
+    expect(rec.reason).toBe('watchdog recovery')
+    expect(Math.abs(Date.now() - rec.ts)).toBeLessThan(5000)
+    writeFileSync(join(dir, RELAUNCH_MODEL_INTENT_FILE), '{broken')
+    expect(readRelaunchModelIntent(dir)).toBeNull()
+    writeFileSync(join(dir, RELAUNCH_MODEL_INTENT_FILE), '{"intent":"maybe","reason":"x","ts":1}\n')
+    expect(readRelaunchModelIntent(dir)).toBeNull()
+  })
+})
+
+describe('clearStaleGatewayShutdownIntent (#3018 finding 4 — a gateway-only bounce must not leave a keep stamp)', () => {
+  it('clears ONLY a gateway-shutdown-stamped intent and reports it', () => {
+    writeRelaunchModelIntent(
+      dir,
+      'keep',
+      `${GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX} graceful SIGTERM shutdown (deploy/rolling restart) — preserving user-chosen session model`,
+    )
+    expect(clearStaleGatewayShutdownIntent(dir)).toBe(true)
+    expect(existsSync(join(dir, RELAUNCH_MODEL_INTENT_FILE))).toBe(false)
+    // Idempotent: a second call finds nothing.
+    expect(clearStaleGatewayShutdownIntent(dir)).toBe(false)
+  })
+
+  it('never touches a triggerSelfRestart / user-slash stamp (un-prefixed reason)', () => {
+    writeRelaunchModelIntent(dir, 'keep', 'sr-to-claude-model-switch')
+    expect(clearStaleGatewayShutdownIntent(dir)).toBe(false)
+    expect(readRelaunchModelIntent(dir)!.reason).toBe('sr-to-claude-model-switch')
+  })
+
+  it('is a safe no-op on an absent or corrupt intent file', () => {
+    expect(clearStaleGatewayShutdownIntent(dir)).toBe(false)
+    writeFileSync(join(dir, RELAUNCH_MODEL_INTENT_FILE), 'not json')
+    expect(clearStaleGatewayShutdownIntent(dir)).toBe(false)
   })
 })
 


### PR DESCRIPTION
Closes #3017.

## Problem

Telegram session-mutating commands dead-ended when the agent was mid-turn:

- `/model <name>` (typed) refused with `⏳ … Try again in a moment.` and **dropped** the request.
- Model menu taps (alias / sr-* / select) toasted the same refusal and did nothing.
- `/effort` had **no** busy gate — `applyEffort` mid-turn returned `sent, but couldn't confirm it applied` (a silent maybe-fail).

The operator had to notice the dead-end and re-issue. Separately, a Telegram-set `/model` override was silently reverted to the configured default by a graceful **deploy** (external SIGTERM), because that path stamps no keep-intent.

## Fix

Ack-queue-apply-confirm, consistent across model + effort and both typed and menu surfaces:

1. **Idle** → apply + confirm (unchanged).
2. **Mid-turn** → immediately **ACK** (`📥 … the moment this turn finishes`), deterministically **QUEUE** (single-valued slot, **last-write-wins** — a rapid `/model fable` then `/model opus` applies only the latest and edits the stale ack to "superseded"), **APPLY** the moment the agent idles, then **CONFIRM** by editing the ack card into the result (or a failure banner).

Reuses the `pendingRestarts` idle-gate discipline — drained at the same model-idle gate (turn complete) plus a bounded reaper drain-cap (`PENDING_CMD_DRAIN_CAP_MS`) so a session that never cleanly idles still applies-or-reports. If a restart is also pending, the ack reports "restarting — re-issue after boot" rather than falsely confirming. The `/status` honesty invariant is preserved: the session-model override is recorded only on the deferred **positive** confirmation.

New pure module `pending-session-command.ts` holds the slot + ack/superseded/restart-superseded text (unit-tested). The typed and menu recording logic is extracted into `recordTypedModelSwitch` / `recordModelMenuSideEffects` so the live and deferred apply paths record identically.

### Persist model across a graceful deploy

The graceful OS-signal shutdown path now stamps `keep` intent for an active `.session-model` override (respecting an intent an initiator already stamped, e.g. `/restart`'s `revert`). So a graceful deploy/roll preserves the user's chosen model and start.sh re-confirms it via `.session-model-alert` on boot. A crash routes through the non-OS-signal branch and still reverts (deliberate safe side preserved).

## Design decisions beyond the spec

- **Menu alias/sr-* taps are queued as a *typed-equivalent* apply** (the callback carries a real model token), reusing the typed drain + recording. Only the Claude picker **select** tap (`mdl:s:<tag>`, needs idle discovery to resolve) is queued as a menu-origin replay of `handleModelMenuCallback`. Effort menu taps queue as menu-origin.
- **Effort persistence across deploy is NOT included** — effort has no durable carrier (it's session-only, re-pinned from `thinking_effort` on boot). Adding one is a separate carrier + start.sh change; the demonstrated defect was model. Noted in the issue.
- Graceful-deploy keep-intent honors the existing 10-min intent freshness window; a deploy slower than that still reverts (matches current keep semantics).

## Tests

- New `pending-session-command.test.ts` (10) — slot semantics, last-write-wins supersede, take/clear, ack/superseded/restart-superseded text.
- Updated white-box anchors in `gateway-session-model-relaunch.test.ts` to the extracted helpers (invariants unchanged).

Scoped-run locally (green): `pending-session-command`, `gateway-session-model-relaunch`, `model-command`, `effort-command`, `session-model-file`, `session-model-source`, `gateway-clean-shutdown-marker` (bun). `npm run lint` clean. Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)