### PR TITLE
fix(telegram): gate silent-stall synthesis on in-flight tool calls; reaper cross-checks live registry

### DIFF
--- a/telegram-plugin/registry/subagents-schema.ts
+++ b/telegram-plugin/registry/subagents-schema.ts
@@ -183,6 +183,20 @@ export interface ReapStuckRunningArgs {
   ttlMs: number
   /** Current time (DI for tests). */
   now: number
+  /**
+   * Optional liveness cross-check against the in-memory file-discovery
+   * registry. Called with a candidate row's `jsonl_agent_id` (null when
+   * linkage never happened); return `true` if the watcher is actively
+   * tailing a live worker for that id. When it returns true the row is
+   * NOT reaped — the DB's `last_activity_at` is a *stale* liveness signal
+   * (it's only bumped when the JSONL is linked, and it freezes during a
+   * long in-flight tool call), so a row the watcher knows is alive must
+   * not be independently classified as dead here. The watcher owns that
+   * worker's terminal transition. Incident 2026-07-10: a live, actively-
+   * card-editing worker was reaped as terminal because this cross-check
+   * didn't exist. Omit to preserve the pre-fix unconditional behaviour.
+   */
+  isLive?: (jsonlAgentId: string | null) => boolean
 }
 
 export interface ReapStuckRunningResult {
@@ -524,14 +538,23 @@ export function reapStuckRunningRows(
   args: ReapStuckRunningArgs,
 ): ReapStuckRunningResult {
   const cutoff = args.now - args.ttlMs
-  const candidates = db
+  const rows = db
     .prepare(`
-      SELECT id FROM subagents
+      SELECT id, jsonl_agent_id FROM subagents
       WHERE status = 'running'
         AND background = 1
         AND COALESCE(last_activity_at, started_at) < ?
     `)
-    .all(cutoff) as Array<{ id: string }>
+    .all(cutoff) as Array<{ id: string; jsonl_agent_id: string | null }>
+
+  // Cross-check each stale-by-DB candidate against the live in-memory
+  // registry. A worker the watcher is actively tailing is NOT dead just
+  // because its DB `last_activity_at` is stale/NULL — the watcher owns
+  // its terminal transition. Skipping these prevents the incident where a
+  // live, actively-card-editing worker was reaped as terminal.
+  const candidates = args.isLive
+    ? rows.filter((r) => !args.isLive!(r.jsonl_agent_id))
+    : rows
 
   for (const row of candidates) {
     recordSubagentStall(db, {

--- a/telegram-plugin/registry/subagents.test.ts
+++ b/telegram-plugin/registry/subagents.test.ts
@@ -665,6 +665,73 @@ describe('reapStuckRunningRows', () => {
     expect(result.reaped).toBe(5)
     expect(result.ids.sort()).toEqual(['sa-0', 'sa-1', 'sa-2', 'sa-3', 'sa-4'])
   })
+
+  // Incident 2026-07-10: a live, actively-card-editing worker was reaped as
+  // terminal because the DB `last_activity_at` was stale (linkage never
+  // bumped it) while the in-memory file-discovery registry knew it was
+  // alive. The reaper must cross-check the live registry before reaping.
+  it('does NOT reap a row the live registry reports as an active worker', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, {
+      id: 'sa-live',
+      background: true,
+      startedAt: 1000,
+      jsonlAgentId: 'a3c5b2d5765810114',
+    })
+    // DB liveness is stale (past ttl) — but the watcher is actively tailing
+    // this worker, so isLive returns true and the row is spared.
+    const liveIds = new Set(['a3c5b2d5765810114'])
+    const result = reapStuckRunningRows(db, {
+      ttlMs: 500,
+      now: 5000,
+      isLive: (jid) => jid != null && liveIds.has(jid),
+    })
+    expect(result.reaped).toBe(0)
+    expect(getSubagent(db, 'sa-live')!.status).toBe('running')
+  })
+
+  it('still reaps a stale row that is NOT in the live registry (genuine orphan)', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, {
+      id: 'sa-orphan',
+      background: true,
+      startedAt: 1000,
+      jsonlAgentId: 'dead-worker',
+    })
+    // Also a live one to prove the predicate discriminates per-row.
+    recordSubagentStart(db, {
+      id: 'sa-alive',
+      background: true,
+      startedAt: 1000,
+      jsonlAgentId: 'live-worker',
+    })
+    const liveIds = new Set(['live-worker'])
+    const result = reapStuckRunningRows(db, {
+      ttlMs: 500,
+      now: 5000,
+      isLive: (jid) => jid != null && liveIds.has(jid),
+    })
+    expect(result.reaped).toBe(1)
+    expect(result.ids).toEqual(['sa-orphan'])
+    expect(getSubagent(db, 'sa-orphan')!.status).toBe('stalled')
+    expect(getSubagent(db, 'sa-alive')!.status).toBe('running')
+  })
+
+  it('reaps a stale row with NULL jsonl_agent_id (the watcher predicate never matches an unlinked row)', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'sa-unlinked', background: true, startedAt: 1000 })
+    // Mirror the production predicate shape: a null jsonl_agent_id can't
+    // key into the registry, so it always reports not-live and the reaper
+    // (the safety net for exactly this unlinked-orphan case) still fires.
+    const liveIds = new Set<string>()
+    const result = reapStuckRunningRows(db, {
+      ttlMs: 500,
+      now: 5000,
+      isLive: (jid) => jid != null && liveIds.has(jid),
+    })
+    expect(result.reaped).toBe(1)
+    expect(getSubagent(db, 'sa-unlinked')!.status).toBe('stalled')
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -141,6 +141,21 @@ export interface WorkerEntry {
    */
   lastTool: { name: string; sanitisedArg: string } | null
   /**
+   * Tool-use ids for tool calls this worker has STARTED but not yet
+   * finished — a `sub_agent_tool_use` was observed with no matching
+   * `sub_agent_tool_result` yet. A non-empty set means the worker is
+   * currently *inside* a tool call (e.g. a long-running `Bash` frame-
+   * capture loop that can legally run 10+ minutes with zero JSONL
+   * growth). The silent-stall terminal synthesis (checkStalls Pass 2)
+   * MUST NOT fire while this is non-empty: a frozen `lastActivityAt`
+   * during an in-flight tool call is expected, not a dead worker.
+   * Cleared on the matching `sub_agent_tool_result` and on
+   * `sub_agent_turn_end` (belt-and-braces). Tool-use lines with a null
+   * `toolUseId` can't be paired, so they don't participate — Bash and
+   * every real long-runner always carries a `toolu_…` id.
+   */
+  inflightToolUseIds: Set<string>
+  /**
    * True if the underlying JSONL file existed before the watcher started.
    * Historical entries are tracked for late state transitions but are
    * excluded from the active-workers card — the sub-agent process is long
@@ -1144,6 +1159,14 @@ export function readSubTail(
             entry.lastReplyText = ev.input.text as string
           }
           entry.toolCount++
+          // Track this as an IN-FLIGHT tool call so the silent-stall
+          // terminal synthesis (checkStalls Pass 2) doesn't misread the
+          // frozen JSONL of a long-running tool (a 10-min `Bash` loop) as
+          // a dead worker. Only pairable (non-null id) tool_uses count —
+          // Bash + every real long-runner always carries a `toolu_…` id.
+          if (ev.toolUseId != null && ev.toolUseId !== '') {
+            entry.inflightToolUseIds.add(ev.toolUseId)
+          }
           // P0 of #662: surface the most recent tool name + sanitised
           // arg so the driver's fleet-state shadow can render the
           // last-tool column on the v2 status card. Sanitiser lives in
@@ -1254,7 +1277,17 @@ export function readSubTail(
             fireNarrativeProgress() // prior pending was pure narration → SHOW
           }
           entry.pendingNarrative = { text: ev.text }
+        } else if (ev.kind === 'sub_agent_tool_result') {
+          // The tool call completed — clear it from the in-flight set so
+          // the terminal-synthesis gate re-opens. Idempotent: a result
+          // whose tool_use we never tracked (null id, parallel spill) is
+          // a harmless no-op delete.
+          if (ev.toolUseId != null && ev.toolUseId !== '') {
+            entry.inflightToolUseIds.delete(ev.toolUseId)
+          }
         } else if (ev.kind === 'sub_agent_turn_end') {
+          // Belt-and-braces: a turn boundary means nothing is in flight.
+          entry.inflightToolUseIds.clear()
           // Narrative-dedup gate step 3: a trailing sub_agent_text block with
           // nothing after it. SUPPRESS only when it drafts the foreground
           // sub-agent's delivered reply (entry.lastReplyText, set above on a
@@ -1463,6 +1496,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       lastResultText: '',
       lastProgressBucketIdx: null,
       lastTool: null,
+      inflightToolUseIds: new Set<string>(),
       historical: isHistorical,
     }
     registry.set(agentId, entry)
@@ -1862,6 +1896,20 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       if (entry.stallTerminalSynthesised) continue
       if (entry.stalledAt == null) continue
       if (n - entry.stalledAt < silentStallTerminalMs) continue
+      // In-flight tool-call gate (incident 2026-07-10): a worker whose
+      // transcript ends in a `tool_use` with no matching `tool_result`
+      // yet is NOT silent — it's *inside* a long tool call (a `Bash`
+      // frame-capture loop legally runs 10+ minutes with zero JSONL
+      // growth). Synthesising `sub_agent_turn_end` here finalises a live
+      // worker's card while it keeps running (real incident: card 16201
+      // reaped at t+13min, worker resumed 92ms later with no card). Skip
+      // synthesis until the outstanding tool_result lands; the un-stall
+      // path re-arms detection from scratch, so a genuinely-dead worker
+      // still terminalises once it goes idle with nothing in flight.
+      if (entry.inflightToolUseIds.size > 0) {
+        log?.(`subagent-watcher: silent-stall terminal synthesis deferred for ${entry.agentId} — ${entry.inflightToolUseIds.size} tool call(s) still in flight (long-running tool, not a dead worker)`)
+        continue
+      }
       entry.stallTerminalSynthesised = true
       entry.state = 'done'
       const postStallSec = Math.floor((n - entry.stalledAt) / 1000)
@@ -2103,7 +2151,21 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
   function runReaper(): void {
     if (db == null) return
     try {
-      const result = reapStuckRunningRows(db, { ttlMs: reaperTtlMs, now: nowFn() })
+      const result = reapStuckRunningRows(db, {
+        ttlMs: reaperTtlMs,
+        now: nowFn(),
+        // Liveness cross-check: never reap a row whose worker the watcher
+        // is actively tailing. A live entry is `running`, non-historical,
+        // and still in the in-memory registry (cleanupTerminalAgent drops
+        // it on real termination). The DB `last_activity_at` freezes during
+        // a long in-flight tool call and is NULL when linkage failed — both
+        // would otherwise false-positive a live worker as terminal.
+        isLive: (jsonlAgentId) => {
+          if (jsonlAgentId == null) return false
+          const entry = registry.get(jsonlAgentId)
+          return entry != null && entry.state === 'running' && !entry.historical
+        },
+      })
       if (result.reaped > 0) {
         log?.(`subagent-watcher: reaper transitioned ${result.reaped} stuck-running row(s) to stalled (ttl=${Math.round(reaperTtlMs / 60_000)}min)`)
       }

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -316,6 +316,21 @@ export interface SubagentWatcherConfig {
    */
   silentStallTerminalMs?: number
   /**
+   * Upper bound (ms of total JSONL idle) on the in-flight tool-call
+   * deferral of terminal synthesis. While a tool call is in flight
+   * (tool_use seen, matching tool_result not yet), synthesis is deferred —
+   * a long `Bash` legitimately freezes the JSONL for 10+ min (incident
+   * 2026-07-10). But a worker that DIES mid-tool (process killed; JSONL
+   * stops growing but is never deleted) would otherwise defer forever, and
+   * the reaper's isLive cross-check would shield it from the DB net too —
+   * wedged for the life of the gateway. Past this cap the deferral ends
+   * and synthesis proceeds. Default 45 min
+   * (DEFAULT_INFLIGHT_TERMINAL_CAP_MS) — above any legitimate single tool
+   * call, below the 1h reaper TTL. Env override
+   * `SWITCHROOM_SUBAGENT_INFLIGHT_TERMINAL_CAP_MS`.
+   */
+  inflightTerminalCapMs?: number
+  /**
    * Freshness window (ms) for promoting a running-at-boot worker file to
    * live. A file whose last write (mtime) is older than this is treated as
    * a dead prior-session worker and stays historical/suppressed, NOT
@@ -551,6 +566,12 @@ const DEFAULT_SILENT_SYNTHESIS_STALL_THRESHOLD_MS = 300_000
  * ceiling that closed-out cards used to wait on.
  */
 const DEFAULT_SILENT_STALL_TERMINAL_MS = 300_000
+// Upper bound on the in-flight tool-call deferral of terminal synthesis.
+// 45 min: comfortably above any legitimate single tool call (Bash caps at
+// 10 min per call; the incident loop ran ~10 min) but below the 1h DB
+// reaper TTL, so the watcher — not the reaper — still owns the terminal
+// transition for a worker that died mid-tool.
+const DEFAULT_INFLIGHT_TERMINAL_CAP_MS = 45 * 60_000
 
 /**
  * Tools that legitimately run for minutes with ZERO intervening JSONL
@@ -1220,6 +1241,16 @@ export function readSubTail(
             }
           }
         } else if (ev.kind === 'sub_agent_nested_spawn') {
+          // A nested Agent/Task dispatch is the same frozen-JSONL shape as
+          // a long tool call: a FOREGROUND nested child blocks this worker
+          // until it returns, with the matching tool_result only landing
+          // then — so gate terminal synthesis on it too. The existing
+          // `sub_agent_tool_result` handler clears the id (a background
+          // nested dispatch's "launched" result lands almost immediately,
+          // so it barely defers). Same cap applies.
+          if (ev.toolUseId != null && ev.toolUseId.length > 0) {
+            entry.inflightToolUseIds.add(ev.toolUseId)
+          }
           // Nested (depth-2+) dispatch keying: this worker just dispatched a
           // sub-agent of its own. The PreToolUse hook can't attribute it (the
           // main turn's turn-active.json marker is long gone for a background
@@ -1379,6 +1410,10 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     config.silentStallTerminalMs
     ?? parseEnvMs('SWITCHROOM_SUBAGENT_STALL_TERMINAL_MS')
     ?? DEFAULT_SILENT_STALL_TERMINAL_MS
+  const inflightTerminalCapMs =
+    config.inflightTerminalCapMs
+    ?? parseEnvMs('SWITCHROOM_SUBAGENT_INFLIGHT_TERMINAL_CAP_MS')
+    ?? DEFAULT_INFLIGHT_TERMINAL_CAP_MS
   const inflightPromoteMaxAgeMs =
     config.inflightPromoteMaxAgeMs
     ?? parseEnvMs('SWITCHROOM_SUBAGENT_INFLIGHT_MAX_AGE_MS')
@@ -1902,13 +1937,27 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       // frame-capture loop legally runs 10+ minutes with zero JSONL
       // growth). Synthesising `sub_agent_turn_end` here finalises a live
       // worker's card while it keeps running (real incident: card 16201
-      // reaped at t+13min, worker resumed 92ms later with no card). Skip
-      // synthesis until the outstanding tool_result lands; the un-stall
-      // path re-arms detection from scratch, so a genuinely-dead worker
-      // still terminalises once it goes idle with nothing in flight.
+      // reaped at t+13min, worker resumed 92ms later with no card).
+      //
+      // The deferral is CAPPED, not unconditional (design reconciliation
+      // with #2777/#2782, whose contract is "a bg worker JSONL that
+      // legitimately lacks turn_end must still release the completion
+      // gate"): a worker that DIES mid-tool (process killed; JSONL frozen
+      // but never deleted) would otherwise defer forever, and the reaper's
+      // isLive cross-check would shield it from the DB net too. So: while
+      // a tool call is in flight, defer synthesis up to
+      // `inflightTerminalCapMs` of total JSONL idle (default 45 min — far
+      // above any legitimate single tool call, below the 1h reaper TTL);
+      // past the cap, synthesis proceeds. A tool_result landing at any
+      // point drains the set and re-arms normal detection via the
+      // un-stall path.
       if (entry.inflightToolUseIds.size > 0) {
-        log?.(`subagent-watcher: silent-stall terminal synthesis deferred for ${entry.agentId} — ${entry.inflightToolUseIds.size} tool call(s) still in flight (long-running tool, not a dead worker)`)
-        continue
+        const totalIdleMs = n - entry.lastActivityAt
+        if (totalIdleMs < inflightTerminalCapMs) {
+          log?.(`subagent-watcher: silent-stall terminal synthesis deferred for ${entry.agentId} — ${entry.inflightToolUseIds.size} tool call(s) still in flight, ${Math.floor(totalIdleMs / 1000)}s idle < ${Math.floor(inflightTerminalCapMs / 1000)}s cap (long-running tool, not a dead worker)`)
+          continue
+        }
+        log?.(`subagent-watcher: in-flight deferral cap reached for ${entry.agentId} (${Math.floor(totalIdleMs / 1000)}s idle >= ${Math.floor(inflightTerminalCapMs / 1000)}s cap with ${entry.inflightToolUseIds.size} tool call(s) still unresolved) — treating as died-mid-tool, proceeding with terminal synthesis`)
       }
       entry.stallTerminalSynthesised = true
       entry.state = 'done'

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -1959,6 +1959,16 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
         }
         log?.(`subagent-watcher: in-flight deferral cap reached for ${entry.agentId} (${Math.floor(totalIdleMs / 1000)}s idle >= ${Math.floor(inflightTerminalCapMs / 1000)}s cap with ${entry.inflightToolUseIds.size} tool call(s) still unresolved) — treating as died-mid-tool, proceeding with terminal synthesis`)
       }
+      // TODO(#3023/PR #3029): the cap-reached path above is a SECOND source of
+      // possibly-false terminal synthesis (a worker mid-very-long-tool that is
+      // NOT dead gets finalised here). PR #3029 adds `recordFalseFinish(...)`
+      // to this synthesis block so a later JSONL resumption can resurrect the
+      // card. When #3029 lands, make sure the merge resolution keeps
+      // `recordFalseFinish(entry.agentId, entry.filePath, n)` covering BOTH
+      // the plain silent-stall path and this cap-reached fall-through (they
+      // share this block, so a clean merge does — verify at conflict time).
+      // Intentionally NOT wired here to keep this PR standalone (no
+      // cross-PR dependency; recordFalseFinish does not exist on this branch).
       entry.stallTerminalSynthesised = true
       entry.state = 'done'
       const postStallSec = Math.floor((n - entry.stalledAt) / 1000)

--- a/telegram-plugin/tests/subagent-watcher-env-thresholds.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-env-thresholds.test.ts
@@ -28,6 +28,7 @@ function makeHarness(opts: {
   configStallThresholdMs?: number
   configSilentSynthStallThresholdMs?: number
   configSilentStallTerminalMs?: number
+  configInflightTerminalCapMs?: number
   initialContent?: string
 } = {}) {
   const {
@@ -35,6 +36,7 @@ function makeHarness(opts: {
     configStallThresholdMs,
     configSilentSynthStallThresholdMs,
     configSilentStallTerminalMs,
+    configInflightTerminalCapMs,
     initialContent,
   } = opts
 
@@ -91,6 +93,7 @@ function makeHarness(opts: {
     stallThresholdMs: configStallThresholdMs,
     silentSynthesisStallThresholdMs: configSilentSynthStallThresholdMs ?? configStallThresholdMs,
     silentStallTerminalMs: configSilentStallTerminalMs,
+    inflightTerminalCapMs: configInflightTerminalCapMs,
     rescanMs: 500,
     onStall: (_id, idleMs) => stallCalls.push({ idleMs }),
     onStallTerminal: (id) => stallTerminalCalls.push({ agentId: id }),
@@ -132,6 +135,7 @@ const ENV_KEYS = [
   'SWITCHROOM_SUBAGENT_STALL_MS',
   'SWITCHROOM_SUBAGENT_SILENT_SYNTH_STALL_MS',
   'SWITCHROOM_SUBAGENT_STALL_TERMINAL_MS',
+  'SWITCHROOM_SUBAGENT_INFLIGHT_TERMINAL_CAP_MS',
 ] as const
 
 describe('subagent-watcher env-var threshold overrides', () => {
@@ -219,23 +223,28 @@ describe('subagent-watcher env-var threshold overrides', () => {
     expect(h.stallTerminalCalls).toHaveLength(0)
   })
 
-  it('a Bash-in-flight worker skips the tight stall threshold but still releases the terminal gate', () => {
-    // End-to-end of the long-runner suppression under compressed env-tuned
-    // windows: a worker mid-`Bash` (a) is NOT flagged at the tight active-loop
-    // threshold, (b) IS eventually flagged at the widened silent-synthesis
-    // window, and (c) the pass-2 terminal synthesis STILL fires the fixed
-    // window after that — the load-bearing completion-gate release is intact.
+  it('a Bash-in-flight worker skips the tight stall threshold, DEFERS terminal synthesis while the tool call is in flight, and still releases at the in-flight cap', () => {
+    // Design reconciliation (incident 2026-07-10 vs the #2777/#2782
+    // contract this test used to encode): a worker mid-`Bash` whose
+    // transcript ends in a tool_use with no matching tool_result is NOT
+    // silent — it's inside a legal long tool call — so the pass-2 terminal
+    // synthesis must NOT fire at silentStallTerminalMs (the old contract;
+    // it finalised a live worker's card). But the completion-gate release
+    // from #2777/#2782 is still load-bearing for a worker that DIED
+    // mid-tool, so the deferral is CAPPED at inflightTerminalCapMs of
+    // total idle: deferred while in flight, released at the cap.
     const h = makeHarness({
       agentId: 'env-thresh-bash',
       configStallThresholdMs: 1000, // tight active-loop threshold
       configSilentSynthStallThresholdMs: 10_000, // widened long-runner window
       configSilentStallTerminalMs: 5000, // compressed terminal window
+      configInflightTerminalCapMs: 60_000, // compressed died-mid-tool cap
       initialContent: buildJSONL(
         subAgentUserMsg('bg task'),
         { type: 'assistant', message: { content: [{ type: 'tool_use', id: 'tool-B', name: 'Bash', input: { command: 'npm test' } }] } },
       ),
     })
-    h.advance(500) // register + tail → toolCount=1, lastTool=Bash
+    h.advance(500) // register + tail → toolCount=1, lastTool=Bash, tool-B in flight
     h.unmarkHistorical()
 
     // 5s idle — well past the 1s active-loop threshold, but a Bash worker uses
@@ -248,8 +257,17 @@ describe('subagent-watcher env-var threshold overrides', () => {
     expect(h.stallCalls).toHaveLength(1)
     expect(h.stallTerminalCalls).toHaveLength(0)
 
-    // 5s post-stall → terminal synthesis releases the deferred-completion gate.
-    h.advance(6_000)
+    // 5s+ post-stall — the OLD contract synthesised here. The in-flight
+    // Bash (no tool_result yet) now defers it: a live long-runner must not
+    // have its card finalised under it.
+    h.advance(6_000) // ~17.5s total idle, < 60s cap
+    expect(h.stallTerminalCalls).toHaveLength(0)
+    expect(h.finishCalls).toHaveLength(0)
+
+    // Cross the in-flight cap (total idle ≥ 60s, tool_result still missing)
+    // → died-mid-tool: synthesis proceeds and the completion gate releases.
+    // The #2777/#2782 release guarantee survives, just later.
+    h.advance(50_000)
     expect(h.stallTerminalCalls).toHaveLength(1)
     expect(h.finishCalls).toHaveLength(1)
   })

--- a/telegram-plugin/tests/subagent-watcher-stall-terminal.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-stall-terminal.test.ts
@@ -31,6 +31,25 @@ function subAgentUserMsg(promptText: string) {
 function subAgentTurnEnd() {
   return { type: 'system', subtype: 'turn_duration', duration_ms: 1234 }
 }
+// An assistant message that STARTS a tool call (e.g. a long-running Bash
+// loop). A tool-using turn's stop_reason is 'tool_use', never 'end_turn',
+// so this does NOT terminalise the worker.
+function subAgentToolUse(toolUseId: string, name = 'Bash') {
+  return {
+    type: 'assistant',
+    message: {
+      stop_reason: 'tool_use',
+      content: [{ type: 'tool_use', id: toolUseId, name, input: { command: 'sleep 600' } }],
+    },
+  }
+}
+// A user message carrying the matching tool_result — the tool call is done.
+function subAgentToolResult(toolUseId: string) {
+  return {
+    type: 'user',
+    message: { content: [{ type: 'tool_result', tool_use_id: toolUseId, content: 'ok' }] },
+  }
+}
 
 interface Harness {
   stallCalls: Array<{ agentId: string; idleMs: number }>
@@ -43,6 +62,7 @@ interface Harness {
   fileContents: Map<string, Buffer>
   jsonlPath: string
   appendActivity: () => void
+  appendLines: (...lines: object[]) => void
 }
 
 function makeHarness(opts: {
@@ -168,6 +188,12 @@ function makeHarness(opts: {
     fileContents.set(jsonlPath, Buffer.concat([cur, Buffer.from(more, 'utf-8')]))
   }
 
+  const appendLines = (...lines: object[]): void => {
+    const cur = fileContents.get(jsonlPath) ?? Buffer.alloc(0)
+    const more = buildJSONL(...lines)
+    fileContents.set(jsonlPath, Buffer.concat([cur, Buffer.from(more, 'utf-8')]))
+  }
+
   return {
     stallCalls,
     stallTerminalCalls,
@@ -179,6 +205,7 @@ function makeHarness(opts: {
     fileContents,
     jsonlPath,
     appendActivity,
+    appendLines,
   }
 }
 
@@ -311,5 +338,75 @@ describe('subagent-watcher post-stall terminal synthesis (RFC §Bug 6)', () => {
     h.advance(300_000)
     expect(h.stallTerminalCalls).toHaveLength(0)
     expect(h.finishCalls).toHaveLength(1) // unchanged
+  })
+})
+
+describe('subagent-watcher in-flight tool-call gate (incident 2026-07-10)', () => {
+  it('does NOT synthesise terminal while a tool call is still in flight, even past silentStallTerminalMs', () => {
+    const agentId = 'inflight-no-synth'
+    const h = makeHarness({
+      agentId,
+      stallThresholdMs: 60_000,
+      silentStallTerminalMs: 300_000,
+      rescanMs: 500,
+    })
+
+    h.advance(500) // register
+    unmarkHistorical(h, agentId)
+
+    // Worker starts a long-running Bash tool call (a frame-capture loop).
+    // The transcript ends in a tool_use with NO matching tool_result — the
+    // JSONL then goes silent for the entire duration of the tool call.
+    h.appendLines(subAgentToolUse('toolu_longbash'))
+    h.advance(1_000) // poll reads the tool_use → in-flight set has 1 id
+
+    // Idle far past the stall threshold: the stall badge still fires (the
+    // worker IS quiet), but the entry is inside a legal long tool call.
+    h.advance(62_000)
+    expect(h.stallCalls).toHaveLength(1)
+
+    // Idle well past silentStallTerminalMs — with the OLD code this would
+    // finalise the live worker's card. The in-flight gate must suppress it.
+    h.advance(400_000)
+    expect(h.stallTerminalCalls).toHaveLength(0)
+    expect(h.finishCalls).toHaveLength(0)
+    expect(h.logs.some((l) => l.includes('terminal synthesis deferred'))).toBe(true)
+  })
+
+  it('synthesises terminal once the tool_result lands and idle persists', () => {
+    const agentId = 'inflight-then-synth'
+    const h = makeHarness({
+      agentId,
+      stallThresholdMs: 60_000,
+      silentStallTerminalMs: 300_000,
+      rescanMs: 500,
+    })
+
+    h.advance(500)
+    unmarkHistorical(h, agentId)
+
+    // In-flight tool call, then a long silent window — no synthesis.
+    h.appendLines(subAgentToolUse('toolu_longbash'))
+    h.advance(1_000)
+    h.advance(62_000) // stall fires
+    h.advance(400_000) // gated — no synthesis
+    expect(h.stallTerminalCalls).toHaveLength(0)
+
+    // The tool call finally completes: the matching tool_result lands.
+    // This is JSONL growth, so the un-stall path fires and the in-flight
+    // set drains — the gate re-opens.
+    h.appendLines(subAgentToolResult('toolu_longbash'))
+    h.advance(1_000)
+    expect(h.unstallCalls).toHaveLength(1)
+    expect(h.stallTerminalCalls).toHaveLength(0)
+
+    // Now the worker goes genuinely silent with nothing in flight: re-stall,
+    // then cross the terminal window — synthesis fires exactly as designed.
+    h.advance(62_000) // re-stall
+    h.advance(302_000) // past silentStallTerminalMs from the new stall
+    expect(h.stallTerminalCalls).toHaveLength(1)
+    expect(h.stallTerminalCalls[0].agentId).toBe(agentId)
+    expect(h.finishCalls).toHaveLength(1)
+    expect(h.finishCalls[0].outcome).toBe('completed')
   })
 })

--- a/telegram-plugin/tests/subagent-watcher-stall-terminal.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-stall-terminal.test.ts
@@ -69,12 +69,14 @@ function makeHarness(opts: {
   agentId?: string
   stallThresholdMs?: number
   silentStallTerminalMs?: number
+  inflightTerminalCapMs?: number
   rescanMs?: number
 } = {}): Harness {
   const {
     agentId = 'bug6-agent',
     stallThresholdMs = 60_000,
     silentStallTerminalMs = 300_000,
+    inflightTerminalCapMs,
     rescanMs = 500,
   } = opts
 
@@ -146,6 +148,7 @@ function makeHarness(opts: {
     stallThresholdMs,
     silentSynthesisStallThresholdMs: stallThresholdMs,
     silentStallTerminalMs,
+    inflightTerminalCapMs,
     rescanMs,
     onStall: (id, idleMs) => stallCalls.push({ agentId: id, idleMs }),
     onUnstall: (id) => unstallCalls.push({ agentId: id }),
@@ -408,5 +411,77 @@ describe('subagent-watcher in-flight tool-call gate (incident 2026-07-10)', () =
     expect(h.stallTerminalCalls[0].agentId).toBe(agentId)
     expect(h.finishCalls).toHaveLength(1)
     expect(h.finishCalls[0].outcome).toBe('completed')
+  })
+
+  it('releases terminal synthesis at inflightTerminalCapMs even with the tool call still unresolved (died-mid-tool)', () => {
+    // A worker killed mid-tool never writes the tool_result: without the
+    // cap it would defer forever AND the reaper's isLive cross-check would
+    // shield its DB row — wedged for the life of the gateway. The cap is
+    // the reconciliation with the #2777/#2782 completion-gate contract.
+    const agentId = 'inflight-cap-release'
+    const h = makeHarness({
+      agentId,
+      stallThresholdMs: 60_000,
+      silentStallTerminalMs: 300_000,
+      inflightTerminalCapMs: 600_000, // compressed 10-min cap
+      rescanMs: 500,
+    })
+
+    h.advance(500)
+    unmarkHistorical(h, agentId)
+    h.appendLines(subAgentToolUse('toolu_killed_midtool'))
+    h.advance(1_000) // in-flight set has 1 id
+    h.advance(62_000) // stall fires
+    expect(h.stallCalls).toHaveLength(1)
+
+    // Past silentStallTerminalMs but under the cap → deferred.
+    h.advance(400_000) // ~463s total idle < 600s cap
+    expect(h.stallTerminalCalls).toHaveLength(0)
+
+    // Cross the cap with the tool_result still missing → released.
+    h.advance(150_000) // ~613s total idle >= 600s cap
+    expect(h.stallTerminalCalls).toHaveLength(1)
+    expect(h.finishCalls).toHaveLength(1)
+    expect(h.logs.some((l) => l.includes('in-flight deferral cap reached'))).toBe(true)
+  })
+
+  it('gates on a nested Agent/Task dispatch the same as a plain tool call', () => {
+    // A FOREGROUND nested Agent/Task dispatch blocks this worker with the
+    // same frozen-JSONL shape as a long Bash — its tool_use routes to
+    // sub_agent_nested_spawn (not sub_agent_tool_use), so it needs its own
+    // add into the in-flight set. Cleared by the same tool_result handler.
+    const agentId = 'inflight-nested-spawn'
+    const h = makeHarness({
+      agentId,
+      stallThresholdMs: 60_000,
+      silentStallTerminalMs: 300_000,
+      rescanMs: 500,
+    })
+
+    h.advance(500)
+    unmarkHistorical(h, agentId)
+    h.appendLines({
+      type: 'assistant',
+      message: {
+        stop_reason: 'tool_use',
+        content: [{ type: 'tool_use', id: 'toolu_nested', name: 'Agent', input: { description: 'child task' } }],
+      },
+    })
+    h.advance(1_000)
+    h.advance(62_000) // stall fires (nested child is quiet in OUR jsonl)
+    expect(h.stallCalls).toHaveLength(1)
+
+    // Past silentStallTerminalMs — nested dispatch in flight → deferred.
+    h.advance(400_000)
+    expect(h.stallTerminalCalls).toHaveLength(0)
+
+    // Child returns: tool_result clears the id; after a fresh stall +
+    // terminal window with nothing in flight, synthesis proceeds.
+    h.appendLines(subAgentToolResult('toolu_nested'))
+    h.advance(1_000)
+    h.advance(62_000) // re-stall
+    h.advance(302_000)
+    expect(h.stallTerminalCalls).toHaveLength(1)
+    expect(h.finishCalls).toHaveLength(1)
   })
 })

--- a/telegram-plugin/tests/worker-visibility-prose-silent-harness.test.ts
+++ b/telegram-plugin/tests/worker-visibility-prose-silent-harness.test.ts
@@ -158,6 +158,7 @@ function makeHarness() {
     stallThresholdMs: 60_000, // tight active-loop threshold
     silentSynthesisStallThresholdMs: 300_000, // widened window (also long-runner window)
     silentStallTerminalMs: 300_000, // post-stall terminal-synthesis window (unchanged)
+    inflightTerminalCapMs: 900_000, // died-mid-tool cap (15 min, compressed from the 45-min default)
     rescanMs: 500,
     now: () => currentTime,
     setInterval: sharedSetInterval,
@@ -278,10 +279,23 @@ describe('prose-silent background worker — end-to-end visibility harness (PR 2
     expect(h.stallCalls[0].agentId).toBe(h.agentId)
     expect(h.stallTerminalCalls).toHaveLength(0)
 
-    // (d) TERMINAL GATE RELEASE: 300s past the stall, the silent-stall terminal
-    // synthesis fires — onStallTerminal + onFinish — and the feed finalizes.
-    // This is the untouched, load-bearing completion path.
-    h.advance(310_000)
+    // (d) IN-FLIGHT DEFERRAL: 300s past the stall the OLD contract
+    // (#2777/#2782) synthesised terminal here. But this worker's transcript
+    // ends in a Bash tool_use with NO tool_result — it may still be inside
+    // the tool call (incident 2026-07-10: exactly this shape finalised a
+    // LIVE worker's card mid-Bash). Synthesis is now deferred while the
+    // tool call is in flight...
+    h.advance(310_000) // total idle ~672s — past silentStallTerminalMs, under the 900s cap
+    await h.flush()
+    expect(h.stallTerminalCalls).toHaveLength(0)
+    expect(h.finishCalls).toHaveLength(0)
+
+    // (e) TERMINAL GATE RELEASE AT THE CAP: ...but not forever. A worker
+    // that died mid-tool (JSONL frozen, tool_result never coming) must not
+    // wedge — past inflightTerminalCapMs of total idle the synthesis
+    // proceeds and the completion gate releases. The load-bearing release
+    // from #2777/#2782 survives, bounded instead of at the raw synth window.
+    h.advance(300_000) // total idle ~972s ≥ 900s cap
     await h.flush()
     expect(h.stallTerminalCalls).toHaveLength(1)
     expect(h.finishCalls).toHaveLength(1)


### PR DESCRIPTION
## Summary

Fixes two progress-card bugs surfaced by the 2026-07-10 incident (worker `a3c5b2d5765810114`, card `16201`) in which a **live, actively-editing** background worker had its pinned progress card finalised and unpinned while it was still running. The worker sat inside one long-running `Bash` frame-capture polling loop from 22:52→23:02; real activity resumed 92ms *after* the card was already finalised, leaving the worker running with no card.

### Bug 1 — false "silent stall" for long in-flight tool calls
`subagent-watcher.ts` `checkStalls` Pass 2 (silent-stall terminal synthesis) used JSONL growth (`lastActivityAt`) as its **only** liveness signal. But a sub-agent whose transcript ends in a `tool_use` with no matching `tool_result` yet is not silent — it is *inside* a long tool call (`Bash` can legally run 10+ minutes with zero JSONL growth). Synthesising `sub_agent_turn_end` there terminalised a live worker.

**Fix:** track in-flight `tool_use` ids per entry (`WorkerEntry.inflightToolUseIds`) — added on `sub_agent_tool_use`, cleared on the matching `sub_agent_tool_result` and on `sub_agent_turn_end`. Terminal synthesis is skipped while any are outstanding (logs `terminal synthesis deferred`). The existing un-stall path re-arms detection when the `tool_result` finally lands, so a genuinely-dead worker still terminalises once it goes idle with nothing in flight.

### Bug 2 — stuck-running reaper classified a live worker as terminal
`reapStuckRunningRows` keyed liveness solely on the DB `last_activity_at`, which is only bumped when the JSONL is linked and freezes during a long tool call. A live worker the watcher was actively tailing (but whose DB liveness was stale/NULL because linkage failed) was reaped as terminal.

**Fix:** add an optional `isLive` cross-check to `reapStuckRunningRows`. The watcher passes a predicate backed by its in-memory file-discovery registry, so a row it knows is a live, `running`, non-historical worker is never independently reaped — the watcher owns that worker's terminal transition. Genuine unlinked orphans (null `jsonl_agent_id`) are still reaped (the reaper's original purpose).

## Why
The watcher's liveness signal (`lastActivityAt` / DB `last_activity_at`) legitimately freezes during a long in-flight tool call. Both the terminal-synthesis path and the DB reaper treated that frozen signal as death. The in-flight-tool state is the missing second signal.

## Test plan
- [x] `bun test telegram-plugin/tests/subagent-watcher-stall-terminal.test.ts` — added in-flight gate cases: (a) no synthesis while a tool is in flight past `silentStallTerminalMs`; (b) synthesis fires once the `tool_result` lands and idle persists.
- [x] `bun test telegram-plugin/registry/subagents.test.ts` — added reaper cross-check cases: live row spared, per-row orphan reaped, unlinked (null id) row reaped.
- [x] Adjacent watcher/registry suites green (no regressions).
- [x] `tsc --noEmit` clean on all touched files (pre-existing unrelated `src/` errors are an incomplete-install artifact, identical before/after).

## Risk
Low. The in-flight gate only *defers* synthesis (never suppresses it permanently); the reaper cross-check only *spares* rows the watcher independently knows are live. Both degrade to prior behaviour when the new signal is absent (`isLive` omitted / no in-flight ids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)