### PR TITLE
fix(telegram): sendPhoto failure no longer crashes gateway; photo→document fallback

### DIFF
--- a/telegram-plugin/chat-lock.ts
+++ b/telegram-plugin/chat-lock.ts
@@ -70,6 +70,19 @@ export function createChatLock(): ChatLock {
     const tracked = next.finally(() => {
       if (chains.get(key) === tracked) chains.delete(key)
     })
+    // `tracked` is a SECOND promise derived from `next`, retained only in
+    // the `chains` map for ordering. The caller awaits `next` (and handles
+    // its rejection); `tracked` is picked up by the NEXT queued call via
+    // `prior.then(fn, fn)`. But when this is the TAIL call on the key —
+    // the common single-reply case — nothing ever attaches a handler to
+    // `tracked`, so a rejected `next` surfaces as an UNHANDLED REJECTION
+    // and (per the gateway's unhandledRejection policy) crashes + reboots
+    // the whole gateway. This bit any failing send that was last in its
+    // (chat,thread) lane: sendPhoto PHOTO_INVALID_DIMENSIONS, sendMediaGroup,
+    // editMessageText MESSAGE_TOO_LONG, deleteMessage "can't be deleted",
+    // etc. Swallow the rejection on the internal tracking promise ONLY —
+    // the caller's `next` still carries the real error for normal handling.
+    tracked.catch(() => {})
     chains.set(key, tracked)
     return next
   }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -183,6 +183,7 @@ import {
   createRetryApiCall,
   createSwallowingRetryApiCall,
   retryWithThreadFallback,
+  isPhotoDimensionRejectError,
 } from '../retry-api-call.js'
 import { installTgPostLogger, withTgPostTags } from '../shared/bot-runtime.js'
 import { floodStatePath, makeFloodWaitRecorder } from '../flood-circuit-breaker.js'
@@ -11805,22 +11806,57 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // crash when the user deletes the topic mid-flight.
   const replyParams =
     reply_to != null && replyMode !== 'off' ? { reply_parameters: { message_id: reply_to } } : {}
-  if (allPhotos) {
-    const media = files.map((f) => ({
-      type: 'photo' as const,
-      media: new InputFile(f),
-    }))
-    const sent = await retryWithThreadFallback(
+  // Send one file as a document, routed through the same thread-fallback
+  // policy as the photo path. `InputFile` streams are single-use, so a
+  // document retry after a failed sendPhoto must build a FRESH InputFile
+  // from the path. Returns the sent message (with its echoed thread id).
+  const sendAsDocument = (f: string) =>
+    retryWithThreadFallback<{ message_id: number; message_thread_id?: number }>(
       robustApiCall,
       (tid) => {
         const baseOpts = {
           ...replyParams,
           ...(tid != null ? { message_thread_id: tid } : {}),
         }
-        return lockedBot.api.sendMediaGroup(chat_id, media, baseOpts)
+        // allow-raw-bot-api: wrapped in retryWithThreadFallback (retry policy); topic-aware document fallback
+        return lockedBot.api.sendDocument(chat_id, new InputFile(f), baseOpts)
       },
-      { threadId, chat_id, verb: 'sendMediaGroup' },
+      { threadId, chat_id, verb: 'sendDocument' },
     )
+
+  if (allPhotos) {
+    const media = files.map((f) => ({
+      type: 'photo' as const,
+      media: new InputFile(f),
+    }))
+    let sent: Array<{ message_id: number; message_thread_id?: number }>
+    try {
+      sent = await retryWithThreadFallback(
+        robustApiCall,
+        (tid) => {
+          const baseOpts = {
+            ...replyParams,
+            ...(tid != null ? { message_thread_id: tid } : {}),
+          }
+          return lockedBot.api.sendMediaGroup(chat_id, media, baseOpts)
+        },
+        { threadId, chat_id, verb: 'sendMediaGroup' },
+      )
+    } catch (err) {
+      // Graceful fallback: one bad photo in the album (e.g. a tall phone
+      // screenshot → PHOTO_INVALID_DIMENSIONS) fails the WHOLE media group.
+      // Rather than surface an error, re-send each file individually as a
+      // document so the user still receives all of them. See #klanker
+      // 2026-07-10 incident + isPhotoDimensionRejectError.
+      if (!isPhotoDimensionRejectError(err)) throw err
+      process.stderr.write(
+        `telegram gateway: sendMediaGroup rejected the photo album ` +
+        `(${err instanceof Error ? err.message : String(err)}); ` +
+        `falling back to per-file sendDocument\n`,
+      )
+      sent = []
+      for (const f of files) sent.push(await sendAsDocument(f))
+    }
     if (threadId != null) {
       // If the fallback dropped the thread id, propagate that decision
       // to subsequent calls in this reply (no further retries needed).
@@ -11836,19 +11872,35 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
       const ext = extname(f).toLowerCase()
       const input = new InputFile(f)
       const isPhoto = PHOTO_EXTS.has(ext)
-      const sent = await retryWithThreadFallback<{ message_id: number; message_thread_id?: number }>(
-        robustApiCall,
-        (tid) => {
-          const baseOpts = {
-            ...replyParams,
-            ...(tid != null ? { message_thread_id: tid } : {}),
-          }
-          return isPhoto
-            ? lockedBot.api.sendPhoto(chat_id, input, baseOpts)
-            : lockedBot.api.sendDocument(chat_id, input, baseOpts)
-        },
-        { threadId, chat_id, verb: isPhoto ? 'sendPhoto' : 'sendDocument' },
-      )
+      let sent: { message_id: number; message_thread_id?: number }
+      try {
+        sent = await retryWithThreadFallback<{ message_id: number; message_thread_id?: number }>(
+          robustApiCall,
+          (tid) => {
+            const baseOpts = {
+              ...replyParams,
+              ...(tid != null ? { message_thread_id: tid } : {}),
+            }
+            return isPhoto
+              ? lockedBot.api.sendPhoto(chat_id, input, baseOpts)
+              : lockedBot.api.sendDocument(chat_id, input, baseOpts)
+          },
+          { threadId, chat_id, verb: isPhoto ? 'sendPhoto' : 'sendDocument' },
+        )
+      } catch (err) {
+        // Graceful fallback: an image Telegram won't accept as a photo
+        // (dimensions out of range / too large — a tall phone screenshot
+        // is the canonical trigger, PHOTO_INVALID_DIMENSIONS) is re-sent
+        // as a document so the user still receives the file instead of
+        // getting nothing. Non-photo-dimension errors propagate as before.
+        if (!(isPhoto && isPhotoDimensionRejectError(err))) throw err
+        process.stderr.write(
+          `telegram gateway: sendPhoto rejected ${f} ` +
+          `(${err instanceof Error ? err.message : String(err)}); ` +
+          `falling back to sendDocument\n`,
+        )
+        sent = await sendAsDocument(f)
+      }
       // Mirror the threadId-clear above so the *next* file in the
       // loop skips the doomed thread without paying for another
       // round trip + retry.

--- a/telegram-plugin/retry-api-call.ts
+++ b/telegram-plugin/retry-api-call.ts
@@ -371,3 +371,34 @@ export function isMessageTooLongError(err: unknown): boolean {
     d.includes('text is too long')
   )
 }
+
+/**
+ * True when Telegram rejected a `sendPhoto` / `sendMediaGroup` because the
+ * image is unusable AS A PHOTO — dimensions out of range (Telegram caps
+ * photos at width+height ≤ 10000 and aspect ratio ≤ 20), the file can't be
+ * saved as a photo, or it exceeds the photo-path size ceiling (~10MB;
+ * documents allow ~50MB). A tall phone screenshot is the canonical trigger
+ * (PHOTO_INVALID_DIMENSIONS in the #klanker 2026-07-10 incident).
+ *
+ * These 400s are deliberately NOT swallowed or retried by `retryApiCall`
+ * (only not-modified / not-found / thread-not-found are) — they surface to
+ * the caller, which recovers by re-sending the SAME file as a document
+ * (`sendDocument`) so the user still receives it. Same "caller-level
+ * fallback" shape as the THREAD_NOT_FOUND and isHtmlParseRejectError
+ * contracts above.
+ */
+export function isPhotoDimensionRejectError(err: unknown): boolean {
+  if (!(err instanceof GrammyError) || err.error_code !== 400) return false
+  const d = (err.description || '').toLowerCase()
+  return (
+    d.includes('photo_invalid_dimensions') ||
+    d.includes('photo_save_file_invalid') ||
+    d.includes('photo dimensions') ||
+    d.includes('image_process_failed') ||
+    // size-driven rejections of the photo path
+    d.includes('photo is too big') ||
+    d.includes('too big for a photo') ||
+    d.includes('image is too big') ||
+    d.includes('file is too big')
+  )
+}

--- a/telegram-plugin/tests/chat-lock-unhandled-rejection.test.ts
+++ b/telegram-plugin/tests/chat-lock-unhandled-rejection.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression test for the #klanker 2026-07-10 gateway crash.
+ *
+ * A `sendPhoto` that failed with PHOTO_INVALID_DIMENSIONS took the WHOLE
+ * gateway down with an `unhandledRejection`, even though the reply-tool
+ * call site `await`s the send and `onToolCall` wraps it in try/catch.
+ *
+ * Root cause was in `chat-lock.ts`'s `run()`: it stores a SECOND promise
+ * (`tracked = next.finally(...)`) in the per-key chain map and returns the
+ * separate `next` to the caller. The caller handles `next`'s rejection, but
+ * `tracked` — which rejects with the same reason — is only ever handled by
+ * the NEXT queued call chaining onto it. On the TAIL call of a lane (the
+ * common single-reply case) nothing attaches a handler to `tracked`, so its
+ * rejection escapes as an `unhandledRejection` and crashes the process.
+ *
+ * These tests assert:
+ *   1. a rejecting TAIL call does NOT emit an `unhandledRejection`, and
+ *   2. the caller STILL receives the real error (so error handling / the
+ *      photo→document fallback still runs).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createChatLock } from '../chat-lock.js'
+
+/** Run `body`, capturing any process-level unhandledRejection during it. */
+async function captureUnhandledRejections(
+  body: () => Promise<void>,
+): Promise<unknown[]> {
+  const seen: unknown[] = []
+  const onUnhandled = (reason: unknown) => { seen.push(reason) }
+  process.on('unhandledRejection', onUnhandled)
+  try {
+    await body()
+    // Let any orphaned rejections surface: unhandledRejection fires on a
+    // later microtask/macrotask tick, so flush both.
+    await new Promise((r) => setTimeout(r, 0))
+    await Promise.resolve()
+  } finally {
+    process.off('unhandledRejection', onUnhandled)
+  }
+  return seen
+}
+
+describe('chat-lock run() — tail-call rejection safety', () => {
+  it('does NOT emit an unhandledRejection when the tail call rejects', async () => {
+    const boom = new Error('PHOTO_INVALID_DIMENSIONS')
+    const unhandled = await captureUnhandledRejections(async () => {
+      const lock = createChatLock()
+      // Single call on this key → it IS the tail. Caller handles the error.
+      await expect(lock.run('chat:1', () => Promise.reject(boom))).rejects.toBe(boom)
+    })
+    expect(unhandled).toEqual([])
+  })
+
+  it('still surfaces the real error to the caller', async () => {
+    const lock = createChatLock()
+    const boom = new Error('boom')
+    await expect(lock.run('k', () => Promise.reject(boom))).rejects.toBe(boom)
+  })
+
+  it('is quiet even when the failing call is the last of a burst', async () => {
+    const boom = new Error('PHOTO_INVALID_DIMENSIONS')
+    const unhandled = await captureUnhandledRejections(async () => {
+      const lock = createChatLock()
+      // First call succeeds, second (tail) rejects — mirrors the incident:
+      // a document then a photo on the same (chat,thread) lane.
+      const okP = lock.run('chat:9', () => Promise.resolve('doc-sent'))
+      const failP = lock.run('chat:9', () => Promise.reject(boom))
+      await expect(okP).resolves.toBe('doc-sent')
+      await expect(failP).rejects.toBe(boom)
+    })
+    expect(unhandled).toEqual([])
+  })
+
+  it('one failure does not poison later work on the same key', async () => {
+    const lock = createChatLock()
+    await expect(lock.run('k2', () => Promise.reject(new Error('x')))).rejects.toThrow('x')
+    // A subsequent call on the same key must still run and resolve.
+    await expect(lock.run('k2', () => Promise.resolve('ok'))).resolves.toBe('ok')
+  })
+
+  it('wrapBot surfaces a bot.api rejection without crashing (tail call)', async () => {
+    const boom = new Error('PHOTO_INVALID_DIMENSIONS')
+    const unhandled = await captureUnhandledRejections(async () => {
+      const lock = createChatLock()
+      const bot = {
+        api: {
+          sendPhoto: (_chatId: string, _file: unknown, _opts?: unknown) =>
+            Promise.reject(boom),
+        },
+      }
+      const wrapped = lock.wrapBot(bot)
+      await expect(
+        (wrapped.api.sendPhoto as (c: string, f: unknown, o?: unknown) => Promise<unknown>)(
+          '123', {}, {},
+        ),
+      ).rejects.toBe(boom)
+    })
+    expect(unhandled).toEqual([])
+  })
+})

--- a/telegram-plugin/tests/photo-dimension-fallback.test.ts
+++ b/telegram-plugin/tests/photo-dimension-fallback.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Covers the photo→document graceful fallback contract (#klanker
+ * 2026-07-10 incident: a tall phone screenshot sent via the reply tool's
+ * `files` param threw PHOTO_INVALID_DIMENSIONS).
+ *
+ * Two production pieces make the gateway's fallback work:
+ *   1. `isPhotoDimensionRejectError` classifies the 400s that mean "not
+ *      usable AS a photo" (dimensions / save-file / too-large).
+ *   2. `retryApiCall` must NOT swallow or retry those 400s — they have to
+ *      reach the caller's catch so it can re-send as a document.
+ *
+ * The final block exercises the EXACT try/catch shape the gateway's reply
+ * file-send loop uses (`retryWithThreadFallback` + the predicate), proving
+ * the file is still delivered as a document.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import {
+  createRetryApiCall,
+  retryWithThreadFallback,
+  isPhotoDimensionRejectError,
+} from '../retry-api-call.js'
+import { errors } from './fake-bot-api.js'
+
+describe('isPhotoDimensionRejectError', () => {
+  it('is true for PHOTO_INVALID_DIMENSIONS', () => {
+    expect(isPhotoDimensionRejectError(errors.badRequest('PHOTO_INVALID_DIMENSIONS', 'sendPhoto'))).toBe(true)
+  })
+
+  it('is true for PHOTO_SAVE_FILE_INVALID', () => {
+    expect(isPhotoDimensionRejectError(errors.badRequest('PHOTO_SAVE_FILE_INVALID', 'sendPhoto'))).toBe(true)
+  })
+
+  it('is true for the mediagroup-wrapped variant', () => {
+    const err = errors.badRequest(
+      'failed to send message #2 with the error message "PHOTO_INVALID_DIMENSIONS"',
+      'sendMediaGroup',
+    )
+    expect(isPhotoDimensionRejectError(err)).toBe(true)
+  })
+
+  it('is true for photo-too-big size rejections', () => {
+    expect(isPhotoDimensionRejectError(errors.badRequest('PHOTO_SAVE_FILE_INVALID: photo is too big', 'sendPhoto'))).toBe(true)
+    expect(isPhotoDimensionRejectError(errors.badRequest('Image is too big', 'sendPhoto'))).toBe(true)
+  })
+
+  it('is false for unrelated 400s', () => {
+    expect(isPhotoDimensionRejectError(errors.badRequest('chat not found', 'sendPhoto'))).toBe(false)
+    expect(isPhotoDimensionRejectError(errors.threadNotFound('sendPhoto'))).toBe(false)
+  })
+
+  it('is false for non-400 and non-grammy errors', () => {
+    expect(isPhotoDimensionRejectError(errors.forbidden('sendPhoto'))).toBe(false)
+    expect(isPhotoDimensionRejectError(errors.floodWait(3, 'sendPhoto'))).toBe(false)
+    expect(isPhotoDimensionRejectError(new Error('PHOTO_INVALID_DIMENSIONS'))).toBe(false)
+    expect(isPhotoDimensionRejectError(null)).toBe(false)
+  })
+})
+
+describe('retryApiCall does not swallow photo-dimension rejects', () => {
+  it('rethrows PHOTO_INVALID_DIMENSIONS so the caller can fall back', async () => {
+    const retry = createRetryApiCall()
+    const err = errors.badRequest('PHOTO_INVALID_DIMENSIONS', 'sendPhoto')
+    await expect(retry(() => Promise.reject(err))).rejects.toBe(err)
+  })
+
+  it('propagates through retryWithThreadFallback (not treated as THREAD_NOT_FOUND)', async () => {
+    const retry = createRetryApiCall()
+    const err = errors.badRequest('PHOTO_INVALID_DIMENSIONS', 'sendPhoto')
+    await expect(
+      retryWithThreadFallback(retry, () => Promise.reject(err), {
+        threadId: 42,
+        chat_id: '123',
+        verb: 'sendPhoto',
+      }),
+    ).rejects.toBe(err)
+  })
+})
+
+describe('photo→document fallback (gateway reply-loop shape)', () => {
+  it('re-sends as a document when sendPhoto is rejected for dimensions', async () => {
+    const retry = createRetryApiCall()
+    const err = errors.badRequest('PHOTO_INVALID_DIMENSIONS', 'sendPhoto')
+    const sendPhoto = vi.fn(() => Promise.reject(err))
+    const sendDocument = vi.fn(() => Promise.resolve({ message_id: 555 }))
+
+    // Mirror gateway.ts executeReply's per-file try/catch.
+    let sent: { message_id: number }
+    try {
+      sent = await retryWithThreadFallback(retry, () => sendPhoto(), {
+        threadId: undefined,
+        chat_id: '123',
+        verb: 'sendPhoto',
+      })
+    } catch (caught) {
+      expect(isPhotoDimensionRejectError(caught)).toBe(true)
+      sent = await retryWithThreadFallback(retry, () => sendDocument(), {
+        threadId: undefined,
+        chat_id: '123',
+        verb: 'sendDocument',
+      })
+    }
+
+    expect(sendPhoto).toHaveBeenCalledTimes(1)
+    expect(sendDocument).toHaveBeenCalledTimes(1)
+    expect(sent!.message_id).toBe(555)
+  })
+
+  it('does NOT fall back for non-dimension errors (they propagate)', async () => {
+    const retry = createRetryApiCall()
+    const err = errors.forbidden('sendPhoto')
+    const sendDocument = vi.fn(() => Promise.resolve({ message_id: 1 }))
+
+    let threw = false
+    try {
+      await retryWithThreadFallback(retry, () => Promise.reject(err), {
+        threadId: undefined,
+        chat_id: '123',
+        verb: 'sendPhoto',
+      })
+    } catch (caught) {
+      threw = true
+      // The gateway only falls back when this predicate holds.
+      expect(isPhotoDimensionRejectError(caught)).toBe(false)
+    }
+    expect(threw).toBe(true)
+    expect(sendDocument).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Incident

klanker gateway-supervisor.log, **2026-07-10T22:11:54Z**:

```
unhandledRejection: GrammyError: Call to 'sendPhoto' failed! (400: Bad Request: PHOTO_INVALID_DIMENSIONS)
unhandled rejection (shutdown): ...
```

The agent sent a large phone-screenshot PNG via the reply tool's `files` param. Telegram rejected it with `PHOTO_INVALID_DIMENSIONS`, the rejection escaped as an `unhandledRejection`, and the gateway's policy treated it as a crash — the **whole gateway went down and rebooted** (boot card reason=crash at 22:12:18).

## Root cause (not the obvious one)

It is **not** a missing await at the reply call site: `executeReply` awaits the send and `onToolCall` wraps `executeToolCall` in try/catch. The floating promise lives in `chat-lock.ts`'s `run()`:

```ts
const next = prior.then(fn, fn)
const tracked = next.finally(() => { if (chains.get(key) === tracked) chains.delete(key) })
chains.set(key, tracked)
return next   // caller awaits THIS
```

The caller awaits `next` and handles its rejection. But `tracked` (a second promise derived from `next`) rejects with the same reason and is only handled by the **next** queued call chaining onto it. On the **tail call** of a `(chat,thread)` lane — the common single-reply case — nothing attaches a handler to `tracked`, so its rejection surfaces as `unhandledRejection`. This explains every historical crash of this shape in the log (sendPhoto, sendMediaGroup, editMessageText MESSAGE_TOO_LONG, deleteMessage) — all tail-of-lane failures.

## Fixes

1. **Crash (general).** `chat-lock.ts` — attach a no-op `.catch()` to the internal `tracked` promise so its rejection can never surface unhandled. The caller's `next` still carries the real error. Covers every verb.
2. **Graceful fallback.** New `isPhotoDimensionRejectError()` in `retry-api-call.ts`. In `executeReply`'s file-send loop — both the per-file path and the `sendMediaGroup` album path — catch PHOTO_INVALID_DIMENSIONS / PHOTO_SAVE_FILE_INVALID / too-large rejects and re-send the file as a **document** (Telegram: photos ≤ ~10MB and width+height ≤ 10000, aspect ≤ 20; documents allow ~50MB) so the user still receives it. Mirrors the existing THREAD_NOT_FOUND / `isHtmlParseRejectError` caller-level fallback pattern.

## Tests / lint

- `tests/chat-lock-unhandled-rejection.test.ts` — a tail-call rejection emits no `unhandledRejection`; caller still gets the error.
- `tests/photo-dimension-fallback.test.ts` — predicate coverage, retry-policy propagation (not swallowed / not treated as THREAD_NOT_FOUND), and the gateway reply-loop fallback shape.
- Scoped `bun test` (two new files + `retry-api-call.test.ts`): **52 pass, 0 fail**. `npm run lint`: clean (tsc + all guard scripts). CI runs the full suite as authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
