### PR TITLE
feat(profiles): codify fleet development protocol as shared CLAUDE.md partial + bundled dev-protocol skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,6 +269,31 @@ first.
 7. Code ≠ runtime: a rebuild updates `dist/`; running agents load code at
    boot and change only after restart (`agent restart` reconciles first).
 
+## Development Protocol (fleet standard, Ken 2026-07-11)
+
+The fleet-wide protocol every agent gets via the `_shared/dev-protocol.md.hbs`
+fragment (long form: the bundled `dev-protocol` skill). It binds work on THIS
+repo too — the five parts, condensed:
+
+1. **Orient/ground.** Validate, don't assume; never assert an unchecked fact.
+   Verify root cause in real source (src/, not `dist/` or generated output).
+   If evidence contradicts the plan or the ticket, report the contradiction —
+   don't force-fit. Cite PRs / commits / `file:line`.
+2. **Clarify vs proceed.** Infer from the codebase and history first. If
+   genuinely unsure, ask ONE question at a time — during planning. During
+   execution, act autonomously: make the reasonable call, note the assumption.
+3. **Design-align on larger tasks.** Evidence-grounded design report to the
+   user before implementation; adversarially red-team the plan (per-item
+   verdicts with evidence); stage delivery as focused single-concern PRs.
+4. **Pipeline.** Branch off fresh main. Scoped tests + `npm run lint`
+   locally; CI is the full-suite authority. Adversarial review of the diff;
+   fix ALL findings including lows; re-review the fix; merge only on CI
+   green. Durable fixes over hack patches; deterministic mechanisms over
+   model-dependent behavior; tests assert outcomes, not just code paths.
+5. **Communicate.** Consolidated messages, always-visible progress, no
+   foreground watches over 30s (background + notification), max 15 parallel
+   sub-agents.
+
 ## Docker test discipline (HARD RULES)
 
 Tests run on a host that also runs production (Coolify, hindsight, the live

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -38,6 +38,7 @@ These ship enabled on **every** Switchroom agent — both default `assistant` fl
 | `switchroom-cli` | switchroom (this repo) | Run switchroom CLI operations on existing agents (logs, restart, version, config, schedule) |
 | `switchroom-status` | switchroom (this repo) | Show running agents, uptime, fleet health |
 | `switchroom-health` | switchroom (this repo) | "Something is broken" diagnostic flow |
+| `dev-protocol` | switchroom (this repo) | Fleet development protocol playbook — orient/ground, clarify vs proceed, design-align, pipeline, communication; loaded when starting substantive development work |
 
 The Anthropic skills are vendored under `skills/<name>/` with a `VENDORED.md` recording the upstream pin commit. Resync with the snippet at the bottom of each `VENDORED.md`.
 
@@ -123,6 +124,7 @@ Current `<repo>/skills/` inventory:
 | `switchroom-cli` | bundled-default (every agent) | Logs / restart / version / config / schedule |
 | `switchroom-status` | bundled-default (every agent) | Show running agents + fleet health |
 | `switchroom-health` | bundled-default (every agent) | "Something is broken" diagnostics |
+| `dev-protocol` | bundled-default (every agent) | Fleet development protocol playbook (long-form of the CLAUDE.md "Development Protocol" fragment) |
 | `switchroom-install` | foreman-only (auto when `role: foreman`) | First-time bootstrap on a fresh machine |
 | `switchroom-manage` | foreman-only (auto when `role: foreman`) | Add/remove/reinstall/list agents (fleet-level) |
 | `switchroom-architecture` | foreman-only (auto when `role: foreman`) | Internal design context for fleet-mgmt decisions |

--- a/profiles/_shared/dev-protocol.md.hbs
+++ b/profiles/_shared/dev-protocol.md.hbs
@@ -1,0 +1,42 @@
+## Development Protocol
+
+How development work gets done here — orient, clarify, align, ship, communicate. These are procedural rules for any substantive coding, infra, or debugging task. For the long-form playbook (design reports, adversarial review structure, re-review verdicts), load the bundled `dev-protocol` skill before starting substantive development work.
+
+### Orient — ground before you build
+
+- **Validate, don't assume.** Read the actual code, config, and system state before forming a theory. Never assert a fact you haven't checked this turn.
+- **Root-cause in real source.** Verify against the source of truth — the repo's source files, not build artifacts, caches, or generated output that may be stale.
+- **Contradicting evidence wins.** When what you find contradicts your working theory (or the task description), report the contradiction — don't force-fit the evidence to the plan.
+- **Cite your ground.** Claims about the codebase carry references: PR numbers, commit hashes, `file:line`.
+
+### Clarify vs proceed
+
+- **Infer first.** Mine the codebase, history, and prior context before asking. Most "questions" are answerable by reading.
+- **If genuinely unsure, ask ONE question at a time** — the single question that unblocks the most work — not a questionnaire.
+- **Clarify during planning; act autonomously during execution.** Once the plan is agreed, don't drip questions mid-implementation — make the reasonable call, note the assumption, keep moving.
+
+### Design-align on larger tasks
+
+For tasks that are architecturally significant, cross-cutting, or ambiguous in approach:
+
+- **Design report before implementation.** Present an evidence-grounded design (what exists today with citations, what changes, why this approach) to the user and get alignment before writing the code.
+- **Red-team your own plan.** Adversarially review the design item by item — a per-item verdict backed by evidence, not a rubber stamp.
+- **Stage delivery.** Ship as focused, single-concern PRs rather than one omnibus change.
+
+### Pipeline — how a change ships
+
+- **Branch off fresh main.** Always pull before branching.
+- **Scoped tests + lint locally; CI is the full-suite authority.** Run the tests that cover what you touched plus `npm run lint` before pushing — but the merge gate is CI green, not your local run.
+- **Adversarial review of the diff.** Every change gets reviewed as an adversary would read it: what breaks, what's untested, what's inconsistent.
+- **Fix ALL findings — including lows.** A "low" you skip is a bug you shipped. Then **re-review the fix** before calling it done.
+- **Merge only on CI green.** No exceptions, no "it's probably fine".
+- **Durable fixes over hack patches.** Fix the root cause; a workaround needs an explicit reason and a filed follow-up.
+- **Deterministic mechanisms over model-dependent behavior.** If a guarantee can be enforced by code (a check, a hook, a schema), don't leave it to prompt discipline.
+- **Tests assert outcomes, not just code paths.** A test that exercises the code but wouldn't fail on the bug is not a test.
+
+### Communicate while you work
+
+- **Consolidated messages.** One substantive update beats five fragments — batch related findings and results.
+- **Always-visible progress.** Long-running work surfaces status the user can see; never go dark mid-task.
+- **No foreground watches over 30 seconds.** Anything longer runs in the background with a notification on completion.
+- **Max 15 parallel sub-agents.** Fan out for genuinely parallel work, but cap the swarm.

--- a/skills/dev-protocol/SKILL.md
+++ b/skills/dev-protocol/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: dev-protocol
+description: >
+  Use when starting substantive development work — a code change, refactor,
+  bug fix, infra change, or multi-step debugging task in any repo. Load BEFORE
+  writing code: it is the fleet development protocol (orient/ground, clarify
+  vs proceed, design-align on larger tasks, the branch→test→review→CI
+  pipeline, communication rules). Also use when deciding whether a task needs
+  a design report first, when dispatching an adversarial review of a diff, or
+  when writing a re-review verdict. Do NOT use for: quick lookups, answering
+  questions about code without changing it, or pure conversation.
+---
+
+# Development Protocol — the playbook
+
+The always-loaded CLAUDE.md "Development Protocol" section is the summary.
+This skill is the long-form procedure. Work through the five phases in order;
+they are checkpoints, not vibes.
+
+## 1. Orient — ground before you build
+
+Before forming any theory or plan:
+
+- **Read the real source.** The repo's source files at the current HEAD — not
+  build artifacts (`dist/`, generated files, caches), not your memory of the
+  code, not the task description's paraphrase. If a claim matters, open the
+  file.
+- **Verify the root cause, not the first plausible cause.** Reproduce or trace
+  the failure to a specific mechanism before fixing. "This line looks wrong"
+  is a lead; the fix ships only when you can say *why* it produced the
+  observed symptom.
+- **Report contradicting evidence.** If what you find contradicts the task
+  description, the ticket, or your own working theory — say so explicitly and
+  stop to re-plan. Never force-fit evidence to the plan you already had.
+- **Cite everything.** Claims about the codebase carry `file:line`, commit
+  hashes, or PR numbers. "The scaffold appends fragments at
+  `src/agents/scaffold.ts:4113`" is a claim; "the scaffold appends fragments
+  somewhere" is not.
+
+## 2. Clarify vs proceed
+
+- **Infer first.** Most questions are answerable from the codebase, git
+  history, existing tests, or docs. Exhaust those before asking.
+- **One question at a time.** If genuinely unsure after inferring, ask the
+  single question whose answer unblocks the most work. Phrase it as a
+  decision with a default: state what you found, the 2–3 viable options, which
+  you'd pick and why, and ask for confirmation — e.g. *"The config loader
+  supports both YAML and JSON overlays; the task says 'config file' without
+  specifying. I'd extend the YAML path since all existing overlays are YAML
+  (src/config/merge.ts:88) — confirm, or should JSON be covered too?"* Never
+  send a questionnaire.
+- **Phase discipline.** Clarify during *planning*. Once the plan is agreed,
+  execute autonomously: make the reasonable call on small ambiguities, record
+  the assumption in your report, and keep moving. Mid-execution questions are
+  reserved for discoveries that invalidate the plan.
+
+## 3. Design-align on larger tasks
+
+**Classify the task first.** Treat it as "larger" (design-align before
+implementing) when ANY of these hold:
+
+- It changes a public interface, schema, config shape, or on-disk format.
+- It cuts across 3+ modules or touches a load-bearing invariant.
+- Two or more genuinely different approaches exist and the choice is
+  expensive to reverse.
+- The task description is a goal ("make X reliable") rather than a change
+  ("add flag Y").
+- It will land as more than one PR.
+
+Small, single-concern, obvious-approach changes skip straight to phase 4.
+
+For larger tasks:
+
+1. **Design report before code.** Send the user an evidence-grounded report:
+   what exists today (with citations), what will change, the chosen approach
+   and its rejected alternatives, and the PR staging plan. Get alignment
+   before implementation.
+2. **Red-team your own plan adversarially.** Review the design item by item.
+   Each item gets a verdict — `SOUND`, `RISK`, or `WRONG` — backed by
+   evidence (a file you read, a test you ran, a documented behavior), not
+   intuition. Fix every `WRONG` and address every `RISK` before starting.
+3. **Stage delivery as focused single-concern PRs.** One concern per PR:
+   reviewable in one sitting, revertable in one command. Never bundle a
+   refactor with a behavior change.
+
+## 4. Pipeline — how a change ships
+
+1. **Branch off fresh main.** `git fetch && git checkout -b <branch> origin/main`.
+2. **Implement with durable fixes.** Fix root causes. A workaround is
+   acceptable only with an explicit reason stated and a follow-up filed.
+   Prefer deterministic mechanisms (a check, a hook, a schema, a lint gate)
+   over model-dependent behavior — if code can enforce the guarantee, don't
+   leave it to prompt discipline.
+3. **Tests assert outcomes.** Every test must fail if the bug it guards
+   returns. A test that merely exercises the code path without asserting the
+   observable outcome is not a test.
+4. **Scoped tests + lint locally.** Run the test files covering what you
+   touched, plus the repo's lint gate. Local runs are a fast filter; **CI is
+   the full-suite authority** — never claim done off a local run alone.
+5. **Adversarial review of the diff.** Dispatch a reviewer (sub-agent or
+   fresh pass) with this structure:
+   - Input: the full diff, the task statement, and the design report if one
+     exists.
+   - Charge: *find reasons this change is wrong* — correctness, missed edge
+     cases, untested behavior, inconsistency with surrounding code, docs
+     drift, security/data-loss risk.
+   - Output: a findings list, each with severity (high/medium/low), the
+     evidence (`file:line`), and a concrete fix.
+6. **Fix ALL findings — including lows.** A low you skip is a bug you
+   shipped. If a finding is genuinely invalid, rebut it with evidence in
+   writing; silence is not a rebuttal.
+7. **Re-review the fix.** The re-review verdict must contain, per original
+   finding: the finding ID, what changed (`file:line` of the fix), whether it
+   fully resolves the finding (`RESOLVED` / `PARTIAL` / `REBUTTED` with
+   evidence), and whether the fix introduced anything new. A bare "fixed" is
+   not a verdict.
+8. **Merge only on CI green.** No exceptions. A red or flaky CI run is a
+   blocker to investigate, not to override.
+
+## 5. Communicate while you work
+
+- **Consolidated messages.** Batch related findings and results into one
+  substantive update; never send five fragments where one message serves.
+- **Always-visible progress.** Long-running work surfaces status the user can
+  see (progress card, interim edit, explicit "still running: X"). Never go
+  dark mid-task.
+- **No foreground watches over 30 seconds.** Anything longer — builds, CI
+  waits, deploys — runs in the background with a notification on completion.
+  Don't block a turn polling.
+- **Max 15 parallel sub-agents.** Fan out for genuinely parallel work
+  (independent reviews, independent modules), but cap the swarm at 15.

--- a/src/agents/profiles.test.ts
+++ b/src/agents/profiles.test.ts
@@ -452,11 +452,13 @@ describe("execution-discipline partial — fleet-wide grounding / verify-before-
       renderExecutionDisciplineFragment,
       renderVaultProtocolFragment,
       renderAgentSelfServiceFragment,
+      renderDevProtocolFragment,
     } = await import("./profiles.js");
     const Handlebars = (await import("handlebars")).default;
 
     const groundingMarker = "Grounding — check before you assert";
     const pacingMarker = "Act in-turn";
+    const devProtocolMarker = "## Development Protocol";
 
     const composeForProfile = (profileName: string): string => {
       const profileDir = getProfilePath(profileName);
@@ -464,11 +466,13 @@ describe("execution-discipline partial — fleet-wide grounding / verify-before-
       let rendered = Handlebars.compile(readFileSync(hbsPath, "utf-8"), {
         noEscape: true,
       })({});
-      // Mirror scaffold.ts append order: vault, self-service, discipline.
+      // Mirror scaffold.ts append order: vault, self-service,
+      // discipline, dev-protocol.
       for (const frag of [
         renderVaultProtocolFragment(),
         renderAgentSelfServiceFragment(),
         renderExecutionDisciplineFragment(),
+        renderDevProtocolFragment(),
       ]) {
         if (frag) rendered = rendered.trimEnd() + "\n\n" + frag + "\n";
       }
@@ -488,6 +492,67 @@ describe("execution-discipline partial — fleet-wide grounding / verify-before-
     ] as [string, string][]) {
       expect(rendered, `${name}: grounding marker`).toContain(groundingMarker);
       expect(rendered, `${name}: pacing marker`).toContain(pacingMarker);
+      expect(rendered, `${name}: dev-protocol marker`).toContain(devProtocolMarker);
     }
+  });
+});
+
+describe("renderDevProtocolFragment", () => {
+  // Ken's fleet-wide development protocol (approved 2026-07-11) —
+  // same unconditional-append carrier as execution-discipline so it
+  // reaches EVERY agent on EVERY profile. These tests pin the five
+  // parts of the contract (orient/ground, clarify vs proceed,
+  // design-align, pipeline, communicate).
+
+  it("tells the agent to validate rather than assume and cite sources", async () => {
+    const { renderDevProtocolFragment } = await import("./profiles.js");
+    const fragment = renderDevProtocolFragment();
+    expect(fragment.toLowerCase()).toContain("validate, don't assume");
+    expect(fragment).toContain("file:line");
+  });
+
+  it("mandates one clarifying question at a time, planning-phase only", async () => {
+    const { renderDevProtocolFragment } = await import("./profiles.js");
+    const fragment = renderDevProtocolFragment();
+    expect(fragment).toContain("ONE question at a time");
+    expect(fragment.toLowerCase()).toContain("act autonomously during execution");
+  });
+
+  it("requires design alignment + adversarial red-team on larger tasks", async () => {
+    const { renderDevProtocolFragment } = await import("./profiles.js");
+    const fragment = renderDevProtocolFragment();
+    expect(fragment.toLowerCase()).toContain("design report before implementation");
+    expect(fragment.toLowerCase()).toContain("red-team");
+    expect(fragment.toLowerCase()).toContain("single-concern pr");
+  });
+
+  it("pins the pipeline: CI authority, fix all findings, merge on green", async () => {
+    const { renderDevProtocolFragment } = await import("./profiles.js");
+    const fragment = renderDevProtocolFragment();
+    expect(fragment.toLowerCase()).toContain("ci is the full-suite authority");
+    expect(fragment).toContain("Fix ALL findings");
+    expect(fragment).toContain("Merge only on CI green");
+    expect(fragment.toLowerCase()).toContain("durable fixes over hack patches");
+    expect(fragment.toLowerCase()).toContain("outcomes, not just code paths");
+  });
+
+  it("pins the communication rules: 30s watch cap and 15 sub-agent cap", async () => {
+    const { renderDevProtocolFragment } = await import("./profiles.js");
+    const fragment = renderDevProtocolFragment();
+    expect(fragment).toContain("30 seconds");
+    expect(fragment).toContain("15 parallel sub-agents");
+    expect(fragment.toLowerCase()).toContain("consolidated messages");
+  });
+
+  it("points at the bundled dev-protocol skill for the long form", async () => {
+    const { renderDevProtocolFragment } = await import("./profiles.js");
+    const fragment = renderDevProtocolFragment();
+    expect(fragment).toContain("`dev-protocol` skill");
+  });
+
+  it("is non-empty (file present and rendered)", async () => {
+    const { renderDevProtocolFragment } = await import("./profiles.js");
+    const fragment = renderDevProtocolFragment();
+    expect(fragment.length).toBeGreaterThan(500);
   });
 });

--- a/src/agents/profiles.ts
+++ b/src/agents/profiles.ts
@@ -171,7 +171,7 @@ Handlebars.registerHelper("isNumber", (value: unknown) => {
 // The _shared/ directory is underscore-prefixed (like _base/) and is not
 // listed by listAvailableProfiles() — it's framework-internal.
 const SHARED_FRAGMENTS_DIR = resolve(PROFILES_ROOT, "_shared");
-const SHARED_FRAGMENTS = ["vault-protocol", "agent-self-service", "execution-discipline", "reply-discipline"] as const;
+const SHARED_FRAGMENTS = ["vault-protocol", "agent-self-service", "execution-discipline", "reply-discipline", "dev-protocol"] as const;
 for (const name of SHARED_FRAGMENTS) {
   const fragPath = join(SHARED_FRAGMENTS_DIR, `${name}.md.hbs`);
   if (existsSync(fragPath)) {
@@ -246,6 +246,34 @@ export function renderExecutionDisciplineFragment(
   profilesRoot: string = PROFILES_ROOT,
 ): string {
   const fragPath = join(resolve(profilesRoot, "_shared"), "execution-discipline.md.hbs");
+  if (!existsSync(fragPath)) return "";
+  const source = readFileSync(fragPath, "utf-8");
+  const template = Handlebars.compile(source, { noEscape: true });
+  return template(context).trimEnd();
+}
+
+/**
+ * Render the dev-protocol fragment standalone for unconditional append
+ * to every agent's CLAUDE.md. Same unconditional-carrier pattern as
+ * {@link renderExecutionDisciplineFragment} — Ken's fleet-wide
+ * development protocol (approved 2026-07-11): orient/ground, clarify
+ * vs proceed, design-align on larger tasks, the branch→test→review→CI
+ * pipeline, and communication rules (consolidated messages, no long
+ * foreground watches, sub-agent cap). It must reach EVERY agent on
+ * EVERY profile, so it rides the append carrier rather than living in
+ * a single profile template. The long-form playbook lives in the
+ * bundled `dev-protocol` skill (loaded on demand); this fragment is
+ * the always-loaded summary that points at it.
+ *
+ * Returns the rendered Markdown, or an empty string if the fragment
+ * file is missing (e.g. partial install).
+ */
+export function renderDevProtocolFragment(
+  context: Record<string, unknown> = {},
+  /** Override the profiles root; used by tests. */
+  profilesRoot: string = PROFILES_ROOT,
+): string {
+  const fragPath = join(resolve(profilesRoot, "_shared"), "dev-protocol.md.hbs");
   if (!existsSync(fragPath)) return "";
   const source = readFileSync(fragPath, "utf-8");
   const template = Handlebars.compile(source, { noEscape: true });

--- a/src/agents/reconcile-default-skills.test.ts
+++ b/src/agents/reconcile-default-skills.test.ts
@@ -277,6 +277,7 @@ describe("getBuiltinDefaultSkillEntries", () => {
     const entries = getBuiltinDefaultSkillEntries();
     const keys = entries.map((e) => e.key).sort();
     expect(keys).toEqual([
+      "dev-protocol",
       "docx",
       "mcp-builder",
       "mental-model-curator",
@@ -297,6 +298,7 @@ describe("getBuiltinDefaultSkillEntries", () => {
     // Source attribution is honest about provenance.
     const switchroomEntries = entries.filter((e) => e.source === "switchroom").map((e) => e.key);
     expect(switchroomEntries.sort()).toEqual([
+      "dev-protocol",
       "mental-model-curator",
       "switchroom-cli",
       "switchroom-health",

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -614,6 +614,7 @@ import {
   renderVaultProtocolFragment,
   renderAgentSelfServiceFragment,
   renderExecutionDisciplineFragment,
+  renderDevProtocolFragment,
   renderReplyDisciplineFragment,
 } from "./profiles.js";
 import {
@@ -4138,6 +4139,15 @@ export function scaffoldAgent(
             if (executionDiscipline) {
               rendered = rendered.trimEnd() + "\n\n" + executionDiscipline + "\n";
             }
+            // Dev-protocol fragment — Ken's fleet-wide development
+            // protocol (orient/ground, clarify vs proceed, design-align,
+            // pipeline, communication). Same unconditional-append
+            // pattern so it reaches EVERY agent on EVERY profile; the
+            // long-form playbook is the bundled `dev-protocol` skill.
+            const devProtocol = renderDevProtocolFragment(context);
+            if (devProtocol) {
+              rendered = rendered.trimEnd() + "\n\n" + devProtocol + "\n";
+            }
           }
           if (dest === "CLAUDE.md" && agentConfig.claude_md_raw) {
             rendered = rendered.trimEnd() + "\n\n" + agentConfig.claude_md_raw + "\n";
@@ -6012,6 +6022,14 @@ export function reconcileAgent(
       const executionDiscipline = renderExecutionDisciplineFragment(claudeContext);
       if (executionDiscipline) {
         rendered = rendered.trimEnd() + "\n\n" + executionDiscipline + "\n";
+      }
+      // Dev-protocol fragment — fleet-wide development protocol. ORDER
+      // must mirror the first-scaffold path above (vault protocol, then
+      // agent-self-service, then execution-discipline, then
+      // dev-protocol) or the diff-abort below trips on every reconcile.
+      const devProtocol = renderDevProtocolFragment(claudeContext);
+      if (devProtocol) {
+        rendered = rendered.trimEnd() + "\n\n" + devProtocol + "\n";
       }
       let composed = composeWithSidecar(rendered, claudeCustomPath);
 

--- a/src/memory/scaffold-integration.ts
+++ b/src/memory/scaffold-integration.ts
@@ -387,6 +387,7 @@ export function getBuiltinDefaultSkillEntries(): BuiltinSkillEntry[] {
     "switchroom-health",
     "switchroom-runtime",
     "mental-model-curator",
+    "dev-protocol",
   ] as const;
   return [
     ...anthropic.map((key) => ({ key, optOutKey: key, source: "anthropic" as const })),

--- a/tests/scaffold.persona.test.ts
+++ b/tests/scaffold.persona.test.ts
@@ -145,7 +145,12 @@ describe("scaffoldAgent — persona (Phase 2)", () => {
     // future fragments, so we step back up to a comparable point.
     // Each block is load-bearing. Future bumps should justify themselves
     // similarly.
-    expect(claudeMd.length).toBeLessThan(33500); // +vault sub-agent fallback guidance (PR #1632)
+    // RAISED 33500 → 37500 for the unconditional dev-protocol fragment
+    // (~3.6KB): Ken's fleet-wide development protocol (orient/ground,
+    // clarify vs proceed, design-align, pipeline, communication) —
+    // always-loaded summary pointing at the bundled `dev-protocol`
+    // skill for the long-form playbook.
+    expect(claudeMd.length).toBeLessThan(37500);
   });
 
   it("root: true renders the root-tier host-access block + the admin surface", () => {


### PR DESCRIPTION
## Summary
- New shared fragment `profiles/_shared/dev-protocol.md.hbs` — Ken's fleet development protocol (orient/ground, clarify vs proceed, design-align on larger tasks, pipeline, communication), appended unconditionally to every agent's CLAUDE.md on every profile via the same carrier as vault-protocol / agent-self-service / execution-discipline (`SHARED_FRAGMENTS` + `renderDevProtocolFragment` in `src/agents/profiles.ts`, both scaffold paths in `src/agents/scaffold.ts` with mirrored append order).
- New bundled skill `skills/dev-protocol/SKILL.md` — the long-form playbook (larger-task classification criteria, adversarial review dispatch structure, re-review verdict format, one-clarifying-question phrasing). Added to `getBuiltinDefaultSkillEntries` switchroomCore, so `reconcileAgentDefaultSkills` auto-symlinks it fleet-wide with no opt-in.
- Root `CLAUDE.md` gains a matching "Development Protocol (fleet standard, Ken 2026-07-11)" section so agents working ON this repo get the same guidance.
- `docs/skills.md` tables updated.

## Why
Codifies Ken's fleet-wide development protocol (approved 2026-07-11) as durable prompt + skill infrastructure instead of per-agent tribal knowledge.

## Test plan
- `vitest run src/agents/profiles.test.ts src/agents/reconcile-default-skills.test.ts tests/scaffold.persona.test.ts tests/scaffold.test.ts` — 270 + 202 passing locally (new tests pin the five-part fragment contract, the all-profiles compose, and the default-skill list).
- `npm run lint` clean.
- CI is the full-suite authority.

## Risk
Low. Additive fragment/skill; persona CLAUDE.md size cap bumped 33500 → 37500 with in-comment justification. Reconcile order mirrored in both scaffold paths to avoid diff-abort churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)