### PR TITLE
feat(auth): soft-avoid eligibility tier for proactive failover (PR 1/4)

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -77,6 +77,8 @@ auth:
     - me@example.com
     - work
     - personal
+  proactive_failover_pct: 95            # optional: soft-avoid tier threshold
+                                        # (unset = tier off, behavior unchanged)
   consumers:                            # non-agent peers (hindsight, etc.)
     - name: hindsight
       account: me@example.com
@@ -174,6 +176,32 @@ rediscoveries.
 When `exhausted_until` passes, the broker clears the mark. Agents
 that *prefer* the cleared account (it's first in their effective
 preference order) drift back on next idle.
+
+### Soft-avoid tier — proactive preference before the wall
+
+`auth.proactive_failover_pct` (optional, e.g. `95`) adds a third
+eligibility state between eligible and blocked: **soft-avoid**. An
+account is soft-avoided when a fresh quota probe shows its 7-day
+utilization at/above the pct, or its 5h utilization at/above
+`min(pct + 3, 98)`. Soft-avoid is a *preference ranking* on the
+serving/failover path only:
+
+- The broker prefers a fully-eligible fallback account over a
+  soft-avoided one (`fallback_order` walk, roll-target selection).
+- When *every* healthy candidate is soft-avoided, the broker serves the
+  least-utilized one and does **not** roll — the tier can never shrink
+  availability or produce a false "all accounts blocked".
+- The hard wall is untouched: blocked still means 99.5% utilization or
+  an unexpired exhaustion mark. Attribution (`mark-exhausted`) never
+  follows the preference, so a soft-avoid can never mismark an account.
+- Hysteresis: enter at pct, exit only below pct-5 (both windows) or
+  when the window resets — a probe oscillating 94↔96 does not flap the
+  preference.
+- Accounts serving past the wall via `allow_overage_accounts` are never
+  soft-avoided.
+
+Unset (the default) disables the tier entirely; the broker behaves
+exactly as it did before the field existed.
 
 ## Drift detection
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -720,6 +720,8 @@ auth:
   fallback_order:               # cycle list for `auth rotate` / 429 failover
     - me@example.com
     - work
+  proactive_failover_pct: 95    # optional soft-avoid tier: prefer away from an
+                                # account nearing its quota wall (unset = off)
 ```
 
 Bootstrap and day-to-day verbs:
@@ -747,6 +749,17 @@ account from `fallback_order`, and atomically rewrites their per-agent
 `.credentials.json`. Failover propagates in seconds without per-agent
 restarts. When the exhaustion window passes the broker clears the mark
 and agents that prefer the cleared account drift back on next idle.
+
+### Proactive soft-avoid (`auth.proactive_failover_pct`)
+
+Optional. When set (e.g. `95`), an account whose fresh 7-day
+utilization reaches the pct (or 5h utilization reaches
+`min(pct + 3, 98)`) is *soft-avoided*: the broker prefers a
+fully-eligible fallback on the serving path, with hysteresis so the
+preference does not flap between probe ticks. Soft-avoid never blocks —
+if every candidate is soft-avoided the least-utilized one still serves.
+Unset means the tier is off and behavior is unchanged. Details in
+[`docs/auth.md`](auth.md).
 
 ### Broker-internal token refresh
 

--- a/src/auth/broker/account-eligibility.ts
+++ b/src/auth/broker/account-eligibility.ts
@@ -372,6 +372,16 @@ export function softAvoidThresholds(pct: number): { sevenDay: number; fiveHour: 
  */
 export interface SoftAvoidState {
   softAvoided: boolean;
+  /**
+   * Which window(s) latched the current soft-avoid. Only a TRIGGERING
+   * window's reset (or its util dropping clear of the exit threshold) may
+   * release the latch — the 5h epoch advances every ≤5h, so letting ANY
+   * window's reset clear a 7d-driven latch would cap the 7d hysteresis at
+   * ~5h and reintroduce the flapping the latch exists to prevent.
+   * Absent (legacy state written before this field) → treated as
+   * both-triggered, the conservative/stickier direction.
+   */
+  triggeredBy?: { fiveHour: boolean; sevenDay: boolean };
   fiveHourResetAt?: number | null;
   sevenDayResetAt?: number | null;
 }
@@ -397,10 +407,15 @@ export interface SoftAvoidSnapshot extends QuotaSnapshot {
  *    soft-avoided: the operator explicitly opted them into serving past the
  *    wall, so pre-wall avoidance would be nonsense.
  *  - ENTER when a fresh snapshot shows 7d ≥ pct, or 5h ≥ min(pct+3, 98).
- *  - EXIT (hysteresis) only when BOTH windows are below their entry
- *    threshold minus {@link SOFT_AVOID_EXIT_MARGIN}, or when a window whose
- *    utilization latched the state has visibly reset (reset epoch advanced,
- *    or the snapshot's own reset time has passed → window refilled).
+ *    The state records WHICH window(s) triggered ({@link SoftAvoidState}
+ *    `triggeredBy`).
+ *  - EXIT (hysteresis) only when EVERY triggering window has released:
+ *    a triggering window releases when its utilization drops below its
+ *    entry threshold minus {@link SOFT_AVOID_EXIT_MARGIN}, or when THAT
+ *    window has visibly reset (its reset epoch advanced, or the snapshot's
+ *    own reset time has passed → window refilled). A non-triggering
+ *    window's reset never releases the latch — the 5h epoch rolls every
+ *    ≤5h, which would cap a 7d-driven latch at ~5h.
  *  - No fresh snapshot → carry the previous state unchanged (no evidence to
  *    flip either way; a never-measured account is not soft-avoided).
  *
@@ -434,33 +449,47 @@ export function evaluateSoftAvoid(opts: {
   const five = fiveRefilled ? 0 : s.fiveHourUtilizationPct;
   const seven = sevenRefilled ? 0 : s.sevenDayUtilizationPct;
 
-  const nextState = (softAvoided: boolean): SoftAvoidState => ({
+  const nextState = (
+    softAvoided: boolean,
+    triggeredBy?: { fiveHour: boolean; sevenDay: boolean },
+  ): SoftAvoidState => ({
     softAvoided,
+    ...(softAvoided && triggeredBy ? { triggeredBy } : {}),
     fiveHourResetAt: s.fiveHourResetAtMs ?? prev?.fiveHourResetAt ?? null,
     sevenDayResetAt: s.sevenDayResetAtMs ?? prev?.sevenDayResetAt ?? null,
   });
 
-  const entered = seven >= thresholds.sevenDay || five >= thresholds.fiveHour;
-  if (entered) return nextState(true);
+  const fiveTriggered = five >= thresholds.fiveHour;
+  const sevenTriggered = seven >= thresholds.sevenDay;
+  if (fiveTriggered || sevenTriggered) {
+    return nextState(true, { fiveHour: fiveTriggered, sevenDay: sevenTriggered });
+  }
 
   if (prev?.softAvoided) {
-    // Latch is set. It clears on an observed window reset (epoch advanced
-    // since the state was written, or refill boundary crossed), else only
-    // when BOTH windows sit below entry-threshold minus the exit margin.
-    const resetAdvanced =
+    // Latch is set. It clears only when EVERY window that triggered it has
+    // released: released = that window's reset epoch advanced since the
+    // state was written (or its refill boundary crossed), OR its util now
+    // sits below entry-threshold minus the exit margin. A non-triggering
+    // window's reset must NOT release the latch — the 5h epoch advances
+    // every ≤5h, which would cap a 7d-driven latch at ~5h. Legacy states
+    // without `triggeredBy` are treated as both-triggered (stickier).
+    const trig = prev.triggeredBy ?? { fiveHour: true, sevenDay: true };
+    const fiveReleased =
+      !trig.fiveHour ||
+      fiveRefilled ||
       (prev.fiveHourResetAt != null &&
         s.fiveHourResetAtMs != null &&
         s.fiveHourResetAtMs > prev.fiveHourResetAt) ||
+      five < thresholds.fiveHour - SOFT_AVOID_EXIT_MARGIN;
+    const sevenReleased =
+      !trig.sevenDay ||
+      sevenRefilled ||
       (prev.sevenDayResetAt != null &&
         s.sevenDayResetAtMs != null &&
         s.sevenDayResetAtMs > prev.sevenDayResetAt) ||
-      fiveRefilled ||
-      sevenRefilled;
-    if (resetAdvanced) return nextState(false);
-    const clearlyBelow =
-      seven < thresholds.sevenDay - SOFT_AVOID_EXIT_MARGIN &&
-      five < thresholds.fiveHour - SOFT_AVOID_EXIT_MARGIN;
-    return nextState(!clearlyBelow);
+      seven < thresholds.sevenDay - SOFT_AVOID_EXIT_MARGIN;
+    if (fiveReleased && sevenReleased) return nextState(false);
+    return nextState(true, trig);
   }
   return nextState(false);
 }

--- a/src/auth/broker/account-eligibility.ts
+++ b/src/auth/broker/account-eligibility.ts
@@ -340,3 +340,127 @@ export function clampMarkExpiry(opts: {
     snapshotFresh(snapshot, now) && snapshot.sevenDayUtilizationPct < WALL_PCT;
   return liveContradictsWeeklyWall ? shortCeil : proposedUntil;
 }
+
+/* ───────────────────────── Soft-avoid tier (#3031, PR 1/4) ───────────────── */
+
+/**
+ * The 5h-window soft-avoid threshold is `pct + 3`, capped here. The 5h window
+ * refills fast, so it gets a little more headroom than the weekly window
+ * before we start preferring away — but never so close to WALL_PCT that the
+ * preference and the hard wall collapse into the same event.
+ */
+export const SOFT_AVOID_FIVE_HOUR_CAP = 98;
+
+/**
+ * Hysteresis exit margin: once soft-avoided, an account only re-earns full
+ * preference when utilization drops this many points BELOW the entry
+ * threshold (or its window resets). Stops the preference flapping when a
+ * probe oscillates around pct (e.g. 94↔96 across 10-min ticks with pct=95).
+ */
+export const SOFT_AVOID_EXIT_MARGIN = 5;
+
+/** Entry thresholds for the soft-avoid tier at a given operator pct. */
+export function softAvoidThresholds(pct: number): { sevenDay: number; fiveHour: number } {
+  return { sevenDay: pct, fiveHour: Math.min(pct + 3, SOFT_AVOID_FIVE_HOUR_CAP) };
+}
+
+/**
+ * Per-account hysteresis state the caller carries between evaluations.
+ * `fiveHourResetAt` / `sevenDayResetAt` are the window-reset epochs (unix ms)
+ * observed when the state was last written — an ADVANCED reset epoch on a
+ * newer snapshot means the window rolled, which clears the hysteresis latch.
+ */
+export interface SoftAvoidState {
+  softAvoided: boolean;
+  fiveHourResetAt?: number | null;
+  sevenDayResetAt?: number | null;
+}
+
+/** The snapshot shape soft-avoid needs: utilization + optional reset epochs. */
+export interface SoftAvoidSnapshot extends QuotaSnapshot {
+  /** Unix ms of the 5h window's next reset, when the probe carried it. */
+  fiveHourResetAtMs?: number | null;
+  /** Unix ms of the 7d window's next reset, when the probe carried it. */
+  sevenDayResetAtMs?: number | null;
+}
+
+/**
+ * THE soft-avoid decision — a PREFERENCE tier between `eligible` and
+ * `blocked` (#3031). An account in this tier still serves; callers merely
+ * rank fully-eligible candidates ahead of it. It MUST NEVER be treated as a
+ * block, and it MUST NEVER affect attribution (mark-exhausted).
+ *
+ * Semantics:
+ *  - `pct` unset (config `auth.proactive_failover_pct` absent) → NEVER
+ *    soft-avoided. This is the structural no-behavior-change guarantee.
+ *  - Overage-lifted accounts (see {@link overageLiftsWall}) are NEVER
+ *    soft-avoided: the operator explicitly opted them into serving past the
+ *    wall, so pre-wall avoidance would be nonsense.
+ *  - ENTER when a fresh snapshot shows 7d ≥ pct, or 5h ≥ min(pct+3, 98).
+ *  - EXIT (hysteresis) only when BOTH windows are below their entry
+ *    threshold minus {@link SOFT_AVOID_EXIT_MARGIN}, or when a window whose
+ *    utilization latched the state has visibly reset (reset epoch advanced,
+ *    or the snapshot's own reset time has passed → window refilled).
+ *  - No fresh snapshot → carry the previous state unchanged (no evidence to
+ *    flip either way; a never-measured account is not soft-avoided).
+ *
+ * PURE — no I/O, no clock except the injected `now`.
+ */
+export function evaluateSoftAvoid(opts: {
+  snapshot?: SoftAvoidSnapshot;
+  now: number;
+  /** `auth.proactive_failover_pct`; undefined = feature off. */
+  pct?: number;
+  /** True when {@link overageLiftsWall} holds for this account right now. */
+  overageLifted?: boolean;
+  /** Previous hysteresis state for this account, if any. */
+  prev?: SoftAvoidState;
+}): SoftAvoidState {
+  const { snapshot, now, pct, overageLifted = false, prev } = opts;
+  if (pct === undefined) return { softAvoided: false };
+  if (overageLifted) return { softAvoided: false };
+  if (!snapshotFresh(snapshot, now)) {
+    // No usable live evidence — hold the previous verdict (latch included).
+    return prev ?? { softAvoided: false };
+  }
+  const s = snapshot as SoftAvoidSnapshot;
+  const thresholds = softAvoidThresholds(pct);
+
+  // Refill-normalize: a window whose reset time has already passed rolled
+  // after capture — its stale utilization reads as 0 (matches quota.ts's
+  // refillNormalizedUtils semantics without importing the Date-based shape).
+  const fiveRefilled = s.fiveHourResetAtMs != null && s.fiveHourResetAtMs <= now;
+  const sevenRefilled = s.sevenDayResetAtMs != null && s.sevenDayResetAtMs <= now;
+  const five = fiveRefilled ? 0 : s.fiveHourUtilizationPct;
+  const seven = sevenRefilled ? 0 : s.sevenDayUtilizationPct;
+
+  const nextState = (softAvoided: boolean): SoftAvoidState => ({
+    softAvoided,
+    fiveHourResetAt: s.fiveHourResetAtMs ?? prev?.fiveHourResetAt ?? null,
+    sevenDayResetAt: s.sevenDayResetAtMs ?? prev?.sevenDayResetAt ?? null,
+  });
+
+  const entered = seven >= thresholds.sevenDay || five >= thresholds.fiveHour;
+  if (entered) return nextState(true);
+
+  if (prev?.softAvoided) {
+    // Latch is set. It clears on an observed window reset (epoch advanced
+    // since the state was written, or refill boundary crossed), else only
+    // when BOTH windows sit below entry-threshold minus the exit margin.
+    const resetAdvanced =
+      (prev.fiveHourResetAt != null &&
+        s.fiveHourResetAtMs != null &&
+        s.fiveHourResetAtMs > prev.fiveHourResetAt) ||
+      (prev.sevenDayResetAt != null &&
+        s.sevenDayResetAtMs != null &&
+        s.sevenDayResetAtMs > prev.sevenDayResetAt) ||
+      fiveRefilled ||
+      sevenRefilled;
+    if (resetAdvanced) return nextState(false);
+    const clearlyBelow =
+      seven < thresholds.sevenDay - SOFT_AVOID_EXIT_MARGIN &&
+      five < thresholds.fiveHour - SOFT_AVOID_EXIT_MARGIN;
+    return nextState(!clearlyBelow);
+  }
+  return nextState(false);
+}

--- a/src/auth/broker/server-soft-avoid.test.ts
+++ b/src/auth/broker/server-soft-avoid.test.ts
@@ -97,9 +97,14 @@ function makeBroker(opts: {
       consumers: opts.consumers,
     },
   } as unknown as SwitchroomConfig;
+  // The broker mkdirs its stateDir in start(); these tests exercise private
+  // selection paths without starting listeners, so create it here (the
+  // rm/re-add ops persist their indexes into it).
+  const stateDir = join(home, ".switchroom", "state", "auth-broker");
+  mkdirSync(stateDir, { recursive: true });
   const broker = new AuthBroker(config, {
     home,
-    stateDir: join(home, ".switchroom", "state", "auth-broker"),
+    stateDir,
     now: () => NOW,
     disableRefreshLoop: true,
     skipHealthyMarker: true,
@@ -325,6 +330,167 @@ describe("overage exemption", () => {
     seedSnap(b, "bob", 0, 0);
     expect(b.isAccountSoftAvoided("alice")).toBe(true);
     expect(b.accountWithFailover("alice")).toBe("bob");
+  });
+});
+
+describe("stale-snapshot latched accounts in the tie-break", () => {
+  it("a latched-then-stale account LOSES the all-soft-avoid tie-break to a fresh one", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      pct: 95,
+      accounts: ["alice", "bob"],
+    });
+    // alice latches on fresh evidence…
+    seedSnap(b, "alice", 10, 96);
+    expect(b.isAccountSoftAvoided("alice")).toBe(true);
+    // …then her snapshot goes stale (>24h) — the latch carries (no fresh
+    // evidence to flip it) but her util score must now be WORST, not best.
+    seedSnap(b, "alice", 10, 96, { capturedAt: NOW - 25 * 3_600_000 });
+    expect(b.isAccountSoftAvoided("alice")).toBe(true);
+    // bob is freshly measured and soft-avoided at 97.
+    seedSnap(b, "bob", 10, 97);
+    expect(b.isAccountSoftAvoided("bob")).toBe(true);
+    // All-soft-avoid tie-break: freshly-measured bob (97) must beat
+    // stale-latched alice (unknown headroom), in BOTH selectors.
+    expect(b.accountWithFailover("alice")).toBe("bob");
+    expect(b.nextHealthyAccount("alice", ["alice", "bob"])).toBe("bob");
+  });
+
+  it("all soft-avoided candidates stale → still never null (first candidate wins)", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      pct: 95,
+      accounts: ["alice", "bob"],
+    });
+    for (const label of ["alice", "bob"]) {
+      seedSnap(b, label, 10, 96);
+      expect(b.isAccountSoftAvoided(label)).toBe(true);
+      seedSnap(b, label, 10, 96, { capturedAt: NOW - 25 * 3_600_000 });
+    }
+    expect(b.nextHealthyAccount("alice", ["alice", "bob"])).toBe("bob");
+    expect(b.accountWithFailover("alice")).toBe("alice");
+  });
+});
+
+describe("soft-avoid state lifecycle (rm / re-add)", () => {
+  const operator = { kind: "operator" } as const;
+  const fakeSocket = () => ({ write: () => true }) as any;
+
+  it("rm-account prunes the label's soft-avoid hysteresis state", async () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      pct: 95,
+      accounts: ["alice", "bob"],
+    });
+    seedSnap(b, "bob", 10, 96);
+    expect(b.isAccountSoftAvoided("bob")).toBe(true);
+    expect(b.softAvoidState["bob"]).toBeDefined();
+    await b.opRmAccount(fakeSocket(), "req-1", operator, "bob");
+    expect(b.softAvoidState["bob"]).toBeUndefined();
+  });
+
+  it("re-adding a label starts with a fresh latch (no ghost soft-avoid)", async () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      pct: 95,
+      accounts: ["alice", "bob"],
+    });
+    seedSnap(b, "bob", 10, 96);
+    expect(b.isAccountSoftAvoided("bob")).toBe(true);
+    await b.opAddAccount(
+      fakeSocket(),
+      "req-2",
+      operator,
+      "bob",
+      {
+        claudeAiOauth: {
+          accessToken: "at-" + "bob2",
+          refreshToken: "rt-" + "bob2",
+          expiresAt: NOW + 24 * 60 * 60 * 1000,
+          scopes: ["user:inference"],
+          subscriptionType: "max",
+        },
+      },
+      true, // replace
+    );
+    expect(b.softAvoidState["bob"]).toBeUndefined();
+    // With the stale latch gone and no fresh over-threshold snapshot for the
+    // new credentials, the label is not soft-avoided until re-measured hot.
+    delete b.lastQuotaCache["bob"];
+    expect(b.isAccountSoftAvoided("bob")).toBe(false);
+  });
+});
+
+describe("accountWithFailover edge cases", () => {
+  it("empty-string account returns null (deliberate change from returning '')", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice"],
+      accounts: ["alice"],
+    });
+    expect(b.accountWithFailover("")).toBe(null);
+    expect(b.accountWithFailover(null)).toBe(null);
+    expect(b.accountWithFailover(undefined)).toBe(null);
+  });
+});
+
+describe("live-wins interplay with exhaustion marks (most-recent-signal-wins)", () => {
+  it("unexpired mark + FRESHER 95% snapshot → eligible AND soft-avoided simultaneously", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      pct: 95,
+      accounts: ["alice", "bob"],
+    });
+    // Mark says exhausted until tomorrow, written 2h ago…
+    b.quota["alice"] = { exhausted_until: NOW + 24 * 3_600_000, marked_at: NOW - 2 * 3_600_000 };
+    // …but a FRESHER live probe (60s ago) shows 95% — below the wall.
+    seedSnap(b, "alice", 10, 95);
+    seedSnap(b, "bob", 10, 10);
+    // Live wins: not blocked (eligible to serve)…
+    expect(b.isAccountExhausted("alice")).toBe(false);
+    expect(b.accountEligibilityOf("alice")).toBe("eligible");
+    // …AND simultaneously in the soft-avoid preference tier (95 ≥ pct).
+    expect(b.isAccountSoftAvoided("alice")).toBe(true);
+    // Net effect: serveable but out-ranked by the fully-eligible fallback.
+    expect(b.accountWithFailover("alice")).toBe("bob");
+  });
+});
+
+describe("7d latch vs advancing 5h reset epoch (server-level)", () => {
+  it("holds a 7d-driven latch across a real fiveHourResetAt roll", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      pct: 95,
+      accounts: ["alice", "bob"],
+    });
+    seedSnap(b, "bob", 0, 0);
+    // Enter on 7d=96 with real ISO reset stamps on both windows.
+    seedSnap(b, "alice", 10, 96, {
+      fiveHourResetAt: new Date(NOW + 3_600_000).toISOString(),
+      sevenDayResetAt: new Date(NOW + 86_400_000).toISOString(),
+    });
+    expect(b.isAccountSoftAvoided("alice")).toBe(true);
+    // Next probe: 7d dips into the hysteresis band (93) and the 5h reset
+    // epoch ADVANCED (the 5h window rolled). The 7d-driven latch must hold.
+    seedSnap(b, "alice", 10, 93, {
+      fiveHourResetAt: new Date(NOW + 5 * 3_600_000).toISOString(),
+      sevenDayResetAt: new Date(NOW + 86_400_000).toISOString(),
+    });
+    expect(b.isAccountSoftAvoided("alice")).toBe(true);
+    expect(b.accountWithFailover("alice")).toBe("bob");
+    // Only the 7d window's own reset releases it.
+    seedSnap(b, "alice", 10, 93, {
+      fiveHourResetAt: new Date(NOW + 5 * 3_600_000).toISOString(),
+      sevenDayResetAt: new Date(NOW + 8 * 86_400_000).toISOString(),
+    });
+    expect(b.isAccountSoftAvoided("alice")).toBe(false);
+    expect(b.accountWithFailover("alice")).toBe("alice");
   });
 });
 

--- a/src/auth/broker/server-soft-avoid.test.ts
+++ b/src/auth/broker/server-soft-avoid.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Soft-avoid tier (#3031, PR 1/4) — broker serving-path preference tests.
+ *
+ * Exercises the private selection paths (`accountWithFailover`,
+ * `nextHealthyAccount`, `isAccountSoftAvoided`, `callerAccount`) on a real
+ * AuthBroker with a tmpdir home/state (never touches `~/.switchroom`),
+ * seeding the quota cache directly. Pins:
+ *
+ *  - config-unset ⇒ selection identical to pre-#3031 (near-wall snapshots
+ *    are ignored by the preference layer);
+ *  - a soft-avoided pin/active prefers the first fully-eligible
+ *    fallback_order candidate;
+ *  - when ALL candidates are soft-avoided: serve the least-utilized, never
+ *    null (no availability loss, no roll);
+ *  - hard-exhausted account still fails over to a soft-avoided fallback
+ *    (preference never blocks);
+ *  - the auth.active last-resort escape for exhausted pins is preserved;
+ *  - attribution (`callerAccount`) NEVER follows the preference — the
+ *    anti-cascade invariant;
+ *  - overage-lifted accounts are never soft-avoided;
+ *  - hysteresis holds across oscillating probe ticks.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { AuthBroker } from "./server.js";
+import type { SwitchroomConfig } from "../../config/schema.js";
+import { writeAccountCredentials } from "../account-store.js";
+
+const NOW = 1_800_000_000_000;
+
+interface Harness {
+  tmp: string;
+  home: string;
+}
+
+let harnesses: Harness[] = [];
+
+afterEach(() => {
+  for (const h of harnesses) {
+    try {
+      rmSync(h.tmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+  harnesses = [];
+});
+
+function seedAccount(home: string, label: string): void {
+  writeAccountCredentials(
+    label,
+    {
+      claudeAiOauth: {
+        accessToken: "at-" + label,
+        refreshToken: "rt-" + label,
+        expiresAt: NOW + 24 * 60 * 60 * 1000,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+      },
+    },
+    home,
+  );
+}
+
+function makeBroker(opts: {
+  active: string;
+  fallbackOrder?: string[];
+  pct?: number;
+  allowOverage?: string[];
+  accounts: string[];
+  consumers?: Array<{ name: string; account?: string }>;
+  pinnedAgentOverride?: string;
+}): { broker: AuthBroker; b: any; home: string } {
+  const tmp = mkdtempSync(join(tmpdir(), "auth-broker-softavoid-"));
+  const home = join(tmp, "home");
+  const agentsDir = join(home, ".switchroom", "agents");
+  mkdirSync(agentsDir, { recursive: true });
+  harnesses.push({ tmp, home });
+  for (const label of opts.accounts) seedAccount(home, label);
+  const agents: Record<string, object> = { ziggy: {} };
+  if (opts.pinnedAgentOverride) {
+    agents["pinner"] = { auth: { override: opts.pinnedAgentOverride } };
+  }
+  const config = {
+    switchroom: { version: 1, agents_dir: agentsDir },
+    telegram: {},
+    agents,
+    auth: {
+      active: opts.active,
+      fallback_order: opts.fallbackOrder,
+      proactive_failover_pct: opts.pct,
+      allow_overage_accounts: opts.allowOverage,
+      consumers: opts.consumers,
+    },
+  } as unknown as SwitchroomConfig;
+  const broker = new AuthBroker(config, {
+    home,
+    stateDir: join(home, ".switchroom", "state", "auth-broker"),
+    now: () => NOW,
+    disableRefreshLoop: true,
+    skipHealthyMarker: true,
+  });
+  return { broker, b: broker as any, home };
+}
+
+/** Seed a fresh quota-cache snapshot for `label`. */
+function seedSnap(
+  b: any,
+  label: string,
+  fiveHour: number,
+  sevenDay: number,
+  extra: Record<string, unknown> = {},
+): void {
+  b.lastQuotaCache[label] = {
+    fiveHourUtilizationPct: fiveHour,
+    sevenDayUtilizationPct: sevenDay,
+    fiveHourResetAt: null,
+    sevenDayResetAt: null,
+    representativeClaim: null,
+    overageStatus: null,
+    overageDisabledReason: null,
+    capturedAt: NOW - 60_000,
+    fiveHourUtilPresent: true,
+    sevenDayUtilPresent: true,
+    ...extra,
+  };
+}
+
+describe("config unset — byte-identical selection to today", () => {
+  it("a near-wall (96%) active is served untouched and never soft-avoided", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      accounts: ["alice", "bob"],
+    });
+    seedSnap(b, "alice", 10, 96);
+    seedSnap(b, "bob", 0, 0);
+    expect(b.isAccountSoftAvoided("alice")).toBe(false);
+    expect(b.accountWithFailover("alice")).toBe("alice");
+    expect(b.nextHealthyAccount("alice", ["alice", "bob"])).toBe("bob");
+    // No hysteresis state is even recorded when the knob is off.
+    expect(Object.keys(b.softAvoidState)).toHaveLength(0);
+  });
+
+  it("hard-wall failover still works exactly as before", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      accounts: ["alice", "bob"],
+    });
+    seedSnap(b, "alice", 100, 100); // walled ≥ 99.5
+    seedSnap(b, "bob", 0, 0);
+    expect(b.accountWithFailover("alice")).toBe("bob");
+  });
+});
+
+describe("soft-avoid serving preference (pct=95)", () => {
+  it("a soft-avoided account prefers the first fully-eligible fallback", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob", "carol"],
+      pct: 95,
+      accounts: ["alice", "bob", "carol"],
+    });
+    seedSnap(b, "alice", 10, 96); // soft-avoid (7d ≥ 95)
+    seedSnap(b, "bob", 20, 30); // fully eligible
+    seedSnap(b, "carol", 0, 0);
+    expect(b.isAccountSoftAvoided("alice")).toBe(true);
+    expect(b.accountWithFailover("alice")).toBe("bob");
+  });
+
+  it("5h window at min(pct+3,98) also triggers the preference", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      pct: 95,
+      accounts: ["alice", "bob"],
+    });
+    seedSnap(b, "alice", 98, 10);
+    seedSnap(b, "bob", 20, 30);
+    expect(b.accountWithFailover("alice")).toBe("bob");
+  });
+
+  it("pinned account soft-avoided → serving prefers fallback_order (agent pin path)", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob", "pin"],
+      pct: 95,
+      accounts: ["alice", "bob", "pin"],
+      pinnedAgentOverride: "pin",
+    });
+    seedSnap(b, "pin", 10, 97); // the pin is soft-avoided
+    seedSnap(b, "alice", 10, 10);
+    seedSnap(b, "bob", 10, 10);
+    // Serving for the pinned account walks fallback_order (skipping itself).
+    expect(b.accountWithFailover("pin")).toBe("alice");
+    // Attribution NEVER follows the preference — anti-cascade invariant.
+    expect(b.callerAccount({ kind: "agent", name: "pinner", admin: false })).toBe("pin");
+  });
+
+  it("all candidates soft-avoided → serve the least-utilized, never null, no roll", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob", "carol"],
+      pct: 95,
+      accounts: ["alice", "bob", "carol"],
+    });
+    seedSnap(b, "alice", 10, 97); // worst window 97
+    seedSnap(b, "bob", 10, 95.5); // worst window 95.5 ← least utilized
+    seedSnap(b, "carol", 98.5, 40); // worst window 98.5
+    expect(b.isAccountSoftAvoided("alice")).toBe(true);
+    expect(b.isAccountSoftAvoided("bob")).toBe(true);
+    expect(b.isAccountSoftAvoided("carol")).toBe(true);
+    expect(b.accountWithFailover("alice")).toBe("bob");
+  });
+
+  it("all-soft-avoid where the account itself is least utilized → stays put", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      pct: 95,
+      accounts: ["alice", "bob"],
+    });
+    seedSnap(b, "alice", 10, 95.1);
+    seedSnap(b, "bob", 10, 98);
+    expect(b.accountWithFailover("alice")).toBe("alice");
+  });
+
+  it("hard-exhausted account still fails over to a soft-avoided fallback (never blocks)", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      pct: 95,
+      accounts: ["alice", "bob"],
+    });
+    seedSnap(b, "alice", 100, 100); // hard wall
+    seedSnap(b, "bob", 10, 96); // soft-avoided but serveable
+    expect(b.accountWithFailover("alice")).toBe("bob");
+  });
+
+  it("exhausted pin with soft-avoided fallbacks still reaches the auth.active escape", () => {
+    // active NOT in fallback_order — the 2026-06-19 escape hatch shape.
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["pin", "bob"],
+      pct: 95,
+      accounts: ["alice", "bob", "pin"],
+    });
+    seedSnap(b, "pin", 100, 100); // exhausted pin
+    seedSnap(b, "bob", 100, 100); // exhausted fallback
+    seedSnap(b, "alice", 10, 10); // healthy active
+    expect(b.accountWithFailover("pin")).toBe("alice");
+  });
+});
+
+describe("nextHealthyAccount preference ranking", () => {
+  it("skips a soft-avoided candidate when a fully-eligible one exists later in the ring", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob", "carol"],
+      pct: 95,
+      accounts: ["alice", "bob", "carol"],
+    });
+    seedSnap(b, "bob", 10, 96); // next in ring, but soft-avoided
+    seedSnap(b, "carol", 10, 10); // fully eligible
+    expect(b.nextHealthyAccount("alice", ["alice", "bob", "carol"])).toBe("carol");
+  });
+
+  it("all healthy candidates soft-avoided → returns the least-utilized (never null)", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob", "carol"],
+      pct: 95,
+      accounts: ["alice", "bob", "carol"],
+    });
+    seedSnap(b, "alice", 10, 97); // current wraps in as the last ring candidate
+    seedSnap(b, "bob", 10, 98);
+    seedSnap(b, "carol", 10, 95.2);
+    expect(b.nextHealthyAccount("alice", ["alice", "bob", "carol"])).toBe("carol");
+  });
+
+  it("config unset → first non-exhausted candidate wins regardless of utilization", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob", "carol"],
+      accounts: ["alice", "bob", "carol"],
+    });
+    seedSnap(b, "bob", 10, 98); // near-wall but NOT walled → still first pick
+    seedSnap(b, "carol", 0, 0);
+    expect(b.nextHealthyAccount("alice", ["alice", "bob", "carol"])).toBe("bob");
+  });
+});
+
+describe("overage exemption", () => {
+  it("an overage-lifted account is never soft-avoided even past pct", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      pct: 95,
+      allowOverage: ["alice"],
+      accounts: ["alice", "bob"],
+    });
+    seedSnap(b, "alice", 10, 97, { overageStatus: "allowed" });
+    seedSnap(b, "bob", 0, 0);
+    expect(b.isAccountSoftAvoided("alice")).toBe(false);
+    expect(b.accountWithFailover("alice")).toBe("alice");
+  });
+
+  it("out_of_credits kills the exemption (overage no longer lifts)", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      pct: 95,
+      allowOverage: ["alice"],
+      accounts: ["alice", "bob"],
+    });
+    seedSnap(b, "alice", 10, 97, {
+      overageStatus: "allowed",
+      overageDisabledReason: "out_of_credits",
+    });
+    seedSnap(b, "bob", 0, 0);
+    expect(b.isAccountSoftAvoided("alice")).toBe(true);
+    expect(b.accountWithFailover("alice")).toBe("bob");
+  });
+});
+
+describe("hysteresis across probe ticks", () => {
+  it("94↔96 oscillation does not flip the preference (pct=95)", () => {
+    const { b } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      pct: 95,
+      accounts: ["alice", "bob"],
+    });
+    seedSnap(b, "bob", 0, 0);
+    seedSnap(b, "alice", 10, 96);
+    expect(b.isAccountSoftAvoided("alice")).toBe(true);
+    expect(b.accountWithFailover("alice")).toBe("bob");
+    // Next tick: dips to 94 — hysteresis holds the preference.
+    seedSnap(b, "alice", 10, 94);
+    expect(b.isAccountSoftAvoided("alice")).toBe(true);
+    expect(b.accountWithFailover("alice")).toBe("bob");
+    // Drops clearly below pct-5 → preference releases, alice serves again.
+    seedSnap(b, "alice", 10, 89);
+    expect(b.isAccountSoftAvoided("alice")).toBe(false);
+    expect(b.accountWithFailover("alice")).toBe("alice");
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -54,6 +54,9 @@ import {
   clampMarkExpiry,
   overageLiftsWall,
   snapshotFresh,
+  evaluateSoftAvoid,
+  type SoftAvoidState,
+  type SoftAvoidSnapshot,
   snapshotWalled,
   WALL_PCT,
 } from "./account-eligibility.js";
@@ -1185,6 +1188,64 @@ export class AuthBroker {
     });
   }
 
+  /* ─── Soft-avoid tier (#3031, PR 1/4) ───────────────────────── */
+
+  /** Per-account soft-avoid hysteresis (in-memory; re-derived from the next
+   *  probe after a broker restart — the durable quota cache reseeds it). */
+  private softAvoidState: Record<string, SoftAvoidState> = {};
+
+  /** View a cached quota entry through the soft-avoid snapshot shape (reset
+   *  ISO strings → unix-ms epochs the pure layer compares). */
+  private softAvoidSnapshotOf(account: string): SoftAvoidSnapshot | undefined {
+    const s = this.lastQuotaCache[account];
+    if (!s) return undefined;
+    return {
+      ...s,
+      fiveHourResetAtMs: s.fiveHourResetAt ? Date.parse(s.fiveHourResetAt) : null,
+      sevenDayResetAtMs: s.sevenDayResetAt ? Date.parse(s.sevenDayResetAt) : null,
+    };
+  }
+
+  /**
+   * True when `account` is in the soft-avoid PREFERENCE tier (#3031): its
+   * fresh utilization is at/above `auth.proactive_failover_pct` (7d) or
+   * min(pct+3, 98) (5h), with enter/exit hysteresis. This is a serving-path
+   * RANKING only — it never blocks, never affects attribution
+   * (`callerAccount` / mark-exhausted), and is structurally FALSE whenever
+   * the config knob is unset (the no-behavior-change guarantee).
+   * Overage-lifted accounts are never soft-avoided.
+   */
+  private isAccountSoftAvoided(account: string): boolean {
+    const pct = this.config.auth?.proactive_failover_pct;
+    if (pct === undefined) return false; // feature off — zero state churn
+    const now = this.now();
+    const snapshot = this.softAvoidSnapshotOf(account);
+    const overageLifted =
+      !!snapshot && snapshotFresh(snapshot, now) &&
+      overageLiftsWall(snapshot, this.isOverageAllowed(account));
+    const state = evaluateSoftAvoid({
+      snapshot,
+      now,
+      pct,
+      overageLifted,
+      prev: this.softAvoidState[account],
+    });
+    this.softAvoidState[account] = state;
+    return state.softAvoided;
+  }
+
+  /**
+   * Tie-break score for an all-soft-avoid candidate set: the account's worst
+   * fresh window utilization (lower = more headroom). Accounts with no fresh
+   * snapshot score lowest (an unmeasured account can't be soft-avoided, so it
+   * won't reach this tie-break in practice).
+   */
+  private softAvoidUtilScore(account: string): number {
+    const s = this.lastQuotaCache[account];
+    if (!s || !snapshotFresh(s, this.now())) return -1;
+    return Math.max(s.fiveHourUtilizationPct, s.sevenDayUtilizationPct);
+  }
+
   /**
    * THE single audited signal that authorizes spending Anthropic overage credit.
    * True iff `account` may RIGHT NOW be served past the weekly utilization wall
@@ -1310,8 +1371,18 @@ export class AuthBroker {
     order: readonly string[],
   ): Promise<string | null> {
     // Fast path: a clearly-eligible candidate from cache needs no probe.
+    // Soft-avoid (#3031): a soft-avoided candidate does NOT take the fast
+    // path — fall through to the unknown-probe pass so a never-measured
+    // fallback with real headroom can outrank it. (With the config knob
+    // unset this extra predicate is structurally false — identical path.)
     const cached = this.nextHealthyAccount(current, order);
-    if (cached && this.accountEligibilityOf(cached) === "eligible") return cached;
+    if (
+      cached &&
+      this.accountEligibilityOf(cached) === "eligible" &&
+      !this.isAccountSoftAvoided(cached)
+    ) {
+      return cached;
+    }
 
     // No cache-eligible candidate. Force-probe the `unknown` candidates (the
     // ones with no positive evidence) so a never-probed-but-healthy secondary
@@ -1367,7 +1438,41 @@ export class AuthBroker {
    * hold, and — like the consumer path — auto-reverts once the window passes.
    */
   private accountWithFailover(account: string | null | undefined): string | null {
-    if (!account || !this.isAccountExhausted(account)) return account ?? null;
+    if (!account) return null;
+    const exhausted = this.isAccountExhausted(account);
+    // Soft-avoid (#3031): a non-exhausted account still serves, but when it
+    // sits in the soft-avoid tier we PREFER a fully-eligible fallback. With
+    // `auth.proactive_failover_pct` unset this predicate is structurally
+    // false, so the fast path below is byte-identical to the pre-#3031 code.
+    if (!exhausted && !this.isAccountSoftAvoided(account)) return account;
+    // Pass 1 — first fallback candidate that is neither exhausted nor
+    // soft-avoided (the preference ranking: fully-eligible beats soft-avoid).
+    for (const cand of this.config.auth?.fallback_order ?? []) {
+      if (cand === account || this.isAccountExhausted(cand)) continue;
+      if (this.isAccountSoftAvoided(cand)) continue;
+      if (readAccountCredentials(cand, this.home)) return cand;
+    }
+    if (!exhausted) {
+      // The account is merely soft-avoided and no fully-eligible fallback
+      // exists — every serveable candidate is soft-avoided too. Serve the
+      // least-utilized of them (most headroom) and do NOT roll anything.
+      // Never returns null: `account` itself is always a candidate, so this
+      // branch cannot reduce availability relative to pre-#3031 behavior.
+      let best = account;
+      let bestScore = this.softAvoidUtilScore(account);
+      for (const cand of this.config.auth?.fallback_order ?? []) {
+        if (cand === account || this.isAccountExhausted(cand)) continue;
+        if (!readAccountCredentials(cand, this.home)) continue;
+        const score = this.softAvoidUtilScore(cand);
+        if (score < bestScore) {
+          best = cand;
+          bestScore = score;
+        }
+      }
+      return best;
+    }
+    // Pass 2 — exhausted, and no fully-eligible fallback: the pre-#3031
+    // behavior. A soft-avoided fallback beats retrying a hard-exhausted pin.
     for (const cand of this.config.auth?.fallback_order ?? []) {
       if (cand === account || this.isAccountExhausted(cand)) continue;
       if (readAccountCredentials(cand, this.home)) return cand;
@@ -2968,15 +3073,29 @@ export class AuthBroker {
   private nextHealthyAccount(current: string, order: readonly string[]): string | null {
     const start = order.indexOf(current);
     if (start === -1) return order[0] ?? null;
+    // Soft-avoid (#3031) preference RANKING: the first non-exhausted,
+    // non-soft-avoided candidate wins; when every healthy candidate is
+    // soft-avoided, fall back to the least-utilized of them (never null when
+    // a healthy-but-soft-avoided candidate exists — the tier must not shrink
+    // availability). With `proactive_failover_pct` unset, isAccountSoftAvoided
+    // is structurally false and this is exactly the pre-#3031 selection.
+    let bestSoftAvoided: string | null = null;
+    let bestScore = Number.POSITIVE_INFINITY;
     for (let i = 1; i <= order.length; i++) {
       const cand = order[(start + i) % order.length];
       if (!cand) continue;
       // Live-authoritative: skip a candidate the live probe shows walled even
       // if its mark expired, and accept one the live probe shows healthy even
       // if a stale/bogus mark says exhausted. (The 2026-06-10 root predicate.)
-      if (!this.isAccountExhausted(cand) && accountExists(cand, this.home)) return cand;
+      if (this.isAccountExhausted(cand) || !accountExists(cand, this.home)) continue;
+      if (!this.isAccountSoftAvoided(cand)) return cand;
+      const score = this.softAvoidUtilScore(cand);
+      if (score < bestScore) {
+        bestSoftAvoided = cand;
+        bestScore = score;
+      }
     }
-    return null;
+    return bestSoftAvoided;
   }
 
   /** Compute an agent's effective account and write its mirror. */

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -1214,6 +1214,12 @@ export class AuthBroker {
    * (`callerAccount` / mark-exhausted), and is structurally FALSE whenever
    * the config knob is unset (the no-behavior-change guarantee).
    * Overage-lifted accounts are never soft-avoided.
+   *
+   * DELIBERATE (PR 1/4 scope): a soft-avoid tier FLIP does not proactively
+   * fan out credential mirrors to agents — agents pick up the preference on
+   * their next broker read (get-credentials / refresh-tick fanout, which
+   * already routes through accountWithFailover). Probe-tick-driven rolls +
+   * announcements are PR 2 of the #3031 plan; do not add fanout here.
    */
   private isAccountSoftAvoided(account: string): boolean {
     const pct = this.config.auth?.proactive_failover_pct;
@@ -1237,12 +1243,16 @@ export class AuthBroker {
   /**
    * Tie-break score for an all-soft-avoid candidate set: the account's worst
    * fresh window utilization (lower = more headroom). Accounts with no fresh
-   * snapshot score lowest (an unmeasured account can't be soft-avoided, so it
-   * won't reach this tie-break in practice).
+   * snapshot score WORST (+Infinity): an account CAN reach this tie-break
+   * without fresh evidence — the hysteresis latch carries across a snapshot
+   * going stale (>24h) — and a latched-then-stale account must never beat a
+   * freshly-measured one (we have zero evidence it has headroom). Callers
+   * seed their fold so the first candidate still wins when every score is
+   * +Infinity (the tie-break never returns null / shrinks availability).
    */
   private softAvoidUtilScore(account: string): number {
     const s = this.lastQuotaCache[account];
-    if (!s || !snapshotFresh(s, this.now())) return -1;
+    if (!s || !snapshotFresh(s, this.now())) return Number.POSITIVE_INFINITY;
     return Math.max(s.fiveHourUtilizationPct, s.sevenDayUtilizationPct);
   }
 
@@ -1447,9 +1457,16 @@ export class AuthBroker {
     if (!exhausted && !this.isAccountSoftAvoided(account)) return account;
     // Pass 1 — first fallback candidate that is neither exhausted nor
     // soft-avoided (the preference ranking: fully-eligible beats soft-avoid).
+    // Track whether soft-avoid actually excluded anyone: if it never fired,
+    // pass 2's predicates are identical to this scan, so it can be skipped
+    // (no pointless credential re-reads — identical behavior, less I/O).
+    let softAvoidExcludedAny = false;
     for (const cand of this.config.auth?.fallback_order ?? []) {
       if (cand === account || this.isAccountExhausted(cand)) continue;
-      if (this.isAccountSoftAvoided(cand)) continue;
+      if (this.isAccountSoftAvoided(cand)) {
+        softAvoidExcludedAny = true;
+        continue;
+      }
       if (readAccountCredentials(cand, this.home)) return cand;
     }
     if (!exhausted) {
@@ -1473,9 +1490,14 @@ export class AuthBroker {
     }
     // Pass 2 — exhausted, and no fully-eligible fallback: the pre-#3031
     // behavior. A soft-avoided fallback beats retrying a hard-exhausted pin.
-    for (const cand of this.config.auth?.fallback_order ?? []) {
-      if (cand === account || this.isAccountExhausted(cand)) continue;
-      if (readAccountCredentials(cand, this.home)) return cand;
+    // Only worth scanning when pass 1 actually excluded someone for being
+    // soft-avoided — otherwise the predicates are identical and pass 1
+    // already proved no candidate has credentials.
+    if (softAvoidExcludedAny) {
+      for (const cand of this.config.auth?.fallback_order ?? []) {
+        if (cand === account || this.isAccountExhausted(cand)) continue;
+        if (readAccountCredentials(cand, this.home)) return cand;
+      }
     }
     // Last-resort: if auth.active is set, is different from the exhausted
     // account, is itself not exhausted, and has credentials, use it.
@@ -2172,6 +2194,10 @@ export class AuthBroker {
       socket.write(encodeError(id, "INTERNAL", (err as Error).message));
       return;
     }
+    // A (re-)added label starts with a fresh soft-avoid latch — any state
+    // left over from a previously-removed account of the same name (or a
+    // replace) belongs to the old credentials, not these.
+    delete this.softAvoidState[label];
     // #1447 (WS1-F1): broker runs as root in production (auth-broker
     // container) and the writes above leave the dir + files root:root.
     // The operator's CLI then can't read them — chown back to the
@@ -2228,6 +2254,9 @@ export class AuthBroker {
     delete this.thresholdViolations[label];
     this.lastWrittenExpiresAt.delete(label);
     delete this.lastQuotaCache[label];
+    // Soft-avoid hysteresis is per-label in-memory state — prune it with the
+    // account so a later re-add of the same label starts with a clean latch.
+    delete this.softAvoidState[label];
     this.persistShaIndex();
     this.persistQuota();
     this.persistThresholdViolations();
@@ -3090,7 +3119,10 @@ export class AuthBroker {
       if (this.isAccountExhausted(cand) || !accountExists(cand, this.home)) continue;
       if (!this.isAccountSoftAvoided(cand)) return cand;
       const score = this.softAvoidUtilScore(cand);
-      if (score < bestScore) {
+      // `=== null` seed: even when every candidate scores +Infinity (all
+      // latched with stale snapshots) the first one still wins — the
+      // tie-break must never return null when a serveable candidate exists.
+      if (bestSoftAvoided === null || score < bestScore) {
         bestSoftAvoided = cand;
         bestScore = score;
       }

--- a/src/auth/broker/soft-avoid.test.ts
+++ b/src/auth/broker/soft-avoid.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Soft-avoid tier (#3031, PR 1/4) — pure-layer tests for evaluateSoftAvoid.
+ *
+ * The tier is a PREFERENCE ranking between eligible and blocked. These tests
+ * pin: entry thresholds on both windows, the 5h cap, enter/exit hysteresis
+ * (no flap on 94↔96 with pct=95), window-reset latch clearing, the overage
+ * exemption, stale/absent-snapshot handling, and — critically — that an unset
+ * pct can never soft-avoid anything (the structural no-behavior-change
+ * guarantee for fleets without `auth.proactive_failover_pct`).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateSoftAvoid,
+  softAvoidThresholds,
+  SOFT_AVOID_EXIT_MARGIN,
+  SOFT_AVOID_FIVE_HOUR_CAP,
+  WALL_PCT,
+  type SoftAvoidSnapshot,
+  type SoftAvoidState,
+} from "./account-eligibility.js";
+
+const NOW = 1_800_000_000_000;
+
+function snap(
+  fiveHour: number,
+  sevenDay: number,
+  extra: Partial<SoftAvoidSnapshot> = {},
+): SoftAvoidSnapshot {
+  return {
+    fiveHourUtilizationPct: fiveHour,
+    sevenDayUtilizationPct: sevenDay,
+    capturedAt: NOW - 60_000,
+    ...extra,
+  };
+}
+
+describe("softAvoidThresholds", () => {
+  it("is pct on the 7d window and pct+3 on the 5h window", () => {
+    expect(softAvoidThresholds(95)).toEqual({ sevenDay: 95, fiveHour: 98 });
+    expect(softAvoidThresholds(90)).toEqual({ sevenDay: 90, fiveHour: 93 });
+  });
+
+  it("caps the 5h threshold at 98 so it never collides with the wall", () => {
+    expect(softAvoidThresholds(97).fiveHour).toBe(SOFT_AVOID_FIVE_HOUR_CAP);
+    expect(softAvoidThresholds(99).fiveHour).toBe(98);
+    expect(SOFT_AVOID_FIVE_HOUR_CAP).toBeLessThan(WALL_PCT);
+  });
+});
+
+describe("evaluateSoftAvoid — feature-off guarantee", () => {
+  it("pct unset → never soft-avoided, even at 99/99", () => {
+    expect(
+      evaluateSoftAvoid({ snapshot: snap(99, 99), now: NOW, pct: undefined }),
+    ).toEqual({ softAvoided: false });
+  });
+
+  it("pct unset → a stale latched prev cannot leak through", () => {
+    const prev: SoftAvoidState = { softAvoided: true };
+    expect(
+      evaluateSoftAvoid({ snapshot: snap(99, 99), now: NOW, prev }),
+    ).toEqual({ softAvoided: false });
+  });
+});
+
+describe("evaluateSoftAvoid — entry thresholds", () => {
+  it("enters on 7d ≥ pct", () => {
+    expect(evaluateSoftAvoid({ snapshot: snap(0, 95), now: NOW, pct: 95 }).softAvoided).toBe(true);
+    expect(evaluateSoftAvoid({ snapshot: snap(0, 94.9), now: NOW, pct: 95 }).softAvoided).toBe(false);
+  });
+
+  it("enters on 5h ≥ min(pct+3, 98)", () => {
+    expect(evaluateSoftAvoid({ snapshot: snap(98, 0), now: NOW, pct: 95 }).softAvoided).toBe(true);
+    expect(evaluateSoftAvoid({ snapshot: snap(97.9, 0), now: NOW, pct: 95 }).softAvoided).toBe(false);
+    // pct=90 → 5h threshold 93
+    expect(evaluateSoftAvoid({ snapshot: snap(93, 0), now: NOW, pct: 90 }).softAvoided).toBe(true);
+    expect(evaluateSoftAvoid({ snapshot: snap(92.9, 0), now: NOW, pct: 90 }).softAvoided).toBe(false);
+  });
+
+  it("either window alone is sufficient", () => {
+    expect(evaluateSoftAvoid({ snapshot: snap(98, 10), now: NOW, pct: 95 }).softAvoided).toBe(true);
+    expect(evaluateSoftAvoid({ snapshot: snap(10, 96), now: NOW, pct: 95 }).softAvoided).toBe(true);
+    expect(evaluateSoftAvoid({ snapshot: snap(10, 10), now: NOW, pct: 95 }).softAvoided).toBe(false);
+  });
+});
+
+describe("evaluateSoftAvoid — hysteresis", () => {
+  it("does not flap on 94↔96 oscillation across probe ticks (pct=95)", () => {
+    // Tick 1: 96 → enter.
+    let state = evaluateSoftAvoid({ snapshot: snap(0, 96), now: NOW, pct: 95 });
+    expect(state.softAvoided).toBe(true);
+    // Tick 2: dips to 94 — still ≥ pct-5 (90) → stays soft-avoided.
+    state = evaluateSoftAvoid({ snapshot: snap(0, 94), now: NOW, pct: 95, prev: state });
+    expect(state.softAvoided).toBe(true);
+    // Tick 3: back to 96 → still in.
+    state = evaluateSoftAvoid({ snapshot: snap(0, 96), now: NOW, pct: 95, prev: state });
+    expect(state.softAvoided).toBe(true);
+    // Tick 4: 89.9 < pct-5 → exits.
+    state = evaluateSoftAvoid({ snapshot: snap(0, 89.9), now: NOW, pct: 95, prev: state });
+    expect(state.softAvoided).toBe(false);
+  });
+
+  it("exit requires BOTH windows below their exit thresholds", () => {
+    const prev: SoftAvoidState = { softAvoided: true };
+    // 7d dropped clear but 5h sits above (98-5)=93 → stays in.
+    expect(
+      evaluateSoftAvoid({ snapshot: snap(94, 10), now: NOW, pct: 95, prev }).softAvoided,
+    ).toBe(true);
+    // Both clear → out.
+    expect(
+      evaluateSoftAvoid({ snapshot: snap(92.9, 10), now: NOW, pct: 95, prev }).softAvoided,
+    ).toBe(false);
+    expect(SOFT_AVOID_EXIT_MARGIN).toBe(5);
+  });
+
+  it("without a latched prev, sub-threshold utilization is simply not soft-avoided", () => {
+    expect(evaluateSoftAvoid({ snapshot: snap(0, 94), now: NOW, pct: 95 }).softAvoided).toBe(false);
+  });
+});
+
+describe("evaluateSoftAvoid — window reset clears the latch", () => {
+  it("an advanced reset epoch on a newer snapshot exits soft-avoid", () => {
+    const entered = evaluateSoftAvoid({
+      snapshot: snap(0, 96, { sevenDayResetAtMs: NOW + 86_400_000 }),
+      now: NOW,
+      pct: 95,
+    });
+    expect(entered.softAvoided).toBe(true);
+    // Next probe: util still latch-zone (93), but the 7d reset epoch advanced
+    // — the window rolled, so the latch clears.
+    const after = evaluateSoftAvoid({
+      snapshot: snap(0, 93, { sevenDayResetAtMs: NOW + 8 * 86_400_000 }),
+      now: NOW,
+      pct: 95,
+      prev: entered,
+    });
+    expect(after.softAvoided).toBe(false);
+  });
+
+  it("a snapshot whose reset time has passed reads that window as refilled (0%)", () => {
+    // 7d shows 96 but its reset was an hour ago → treated as 0 → no entry.
+    const state = evaluateSoftAvoid({
+      snapshot: snap(0, 96, { sevenDayResetAtMs: NOW - 3_600_000 }),
+      now: NOW,
+      pct: 95,
+    });
+    expect(state.softAvoided).toBe(false);
+  });
+});
+
+describe("evaluateSoftAvoid — overage exemption", () => {
+  it("an overage-lifted account is NEVER soft-avoided, at any utilization", () => {
+    expect(
+      evaluateSoftAvoid({
+        snapshot: snap(99, 99),
+        now: NOW,
+        pct: 95,
+        overageLifted: true,
+      }).softAvoided,
+    ).toBe(false);
+  });
+
+  it("overage lift also releases an existing latch", () => {
+    const prev: SoftAvoidState = { softAvoided: true };
+    expect(
+      evaluateSoftAvoid({
+        snapshot: snap(99, 99),
+        now: NOW,
+        pct: 95,
+        overageLifted: true,
+        prev,
+      }).softAvoided,
+    ).toBe(false);
+  });
+});
+
+describe("evaluateSoftAvoid — snapshot freshness", () => {
+  it("no snapshot → not soft-avoided (an unmeasured account is not avoided)", () => {
+    expect(evaluateSoftAvoid({ now: NOW, pct: 95 }).softAvoided).toBe(false);
+  });
+
+  it("no snapshot but latched prev → holds the previous verdict", () => {
+    const prev: SoftAvoidState = { softAvoided: true };
+    expect(evaluateSoftAvoid({ now: NOW, pct: 95, prev }).softAvoided).toBe(true);
+  });
+
+  it("a stale (>24h) snapshot is not usable evidence — prev carries", () => {
+    const stale = snap(99, 99, { capturedAt: NOW - 25 * 3_600_000 });
+    expect(
+      evaluateSoftAvoid({ snapshot: stale, now: NOW, pct: 95 }).softAvoided,
+    ).toBe(false);
+    const prev: SoftAvoidState = { softAvoided: true };
+    expect(
+      evaluateSoftAvoid({ snapshot: stale, now: NOW, pct: 95, prev }).softAvoided,
+    ).toBe(true);
+  });
+});

--- a/src/auth/broker/soft-avoid.test.ts
+++ b/src/auth/broker/soft-avoid.test.ts
@@ -138,6 +138,119 @@ describe("evaluateSoftAvoid — window reset clears the latch", () => {
     expect(after.softAvoided).toBe(false);
   });
 
+  it("a 7d-driven latch SURVIVES the 5h reset epoch advancing (7d still in the band)", () => {
+    // Regression: the 5h epoch advances every ≤5h, so if ANY window's reset
+    // cleared the latch, 7d hysteresis would be capped at ~5h → flapping.
+    const entered = evaluateSoftAvoid({
+      snapshot: snap(10, 96, {
+        fiveHourResetAtMs: NOW + 3_600_000,
+        sevenDayResetAtMs: NOW + 86_400_000,
+      }),
+      now: NOW,
+      pct: 95,
+    });
+    expect(entered.softAvoided).toBe(true);
+    expect(entered.triggeredBy).toEqual({ fiveHour: false, sevenDay: true });
+    // Next probe 4h later: 7d dipped into the hysteresis band (93), the 5h
+    // window rolled (epoch advanced) — latch must HOLD; 5h never triggered.
+    const later = NOW + 4 * 3_600_000;
+    const after = evaluateSoftAvoid({
+      snapshot: snap(10, 93, {
+        capturedAt: later - 60_000,
+        fiveHourResetAtMs: later + 3_600_000, // advanced past entry's epoch
+        sevenDayResetAtMs: NOW + 86_400_000, // unchanged
+      }),
+      now: later,
+      pct: 95,
+      prev: entered,
+    });
+    expect(after.softAvoided).toBe(true);
+    // ...and it keeps holding across further 5h rolls until the 7d window
+    // itself resets or drops clear of the band.
+    const evenLater = later + 5 * 3_600_000;
+    const still = evaluateSoftAvoid({
+      snapshot: snap(10, 94, {
+        capturedAt: evenLater - 60_000,
+        fiveHourResetAtMs: evenLater + 3_600_000,
+        sevenDayResetAtMs: NOW + 86_400_000,
+      }),
+      now: evenLater,
+      pct: 95,
+      prev: after,
+    });
+    expect(still.softAvoided).toBe(true);
+    // The 7d window's OWN reset finally releases it.
+    const released = evaluateSoftAvoid({
+      snapshot: snap(10, 93, {
+        capturedAt: evenLater - 30_000,
+        fiveHourResetAtMs: evenLater + 3_600_000,
+        sevenDayResetAtMs: NOW + 8 * 86_400_000, // 7d epoch advanced
+      }),
+      now: evenLater,
+      pct: 95,
+      prev: still,
+    });
+    expect(released.softAvoided).toBe(false);
+  });
+
+  it("a 5h-driven latch is released by the 5h window's own reset", () => {
+    const entered = evaluateSoftAvoid({
+      snapshot: snap(98, 10, {
+        fiveHourResetAtMs: NOW + 3_600_000,
+        sevenDayResetAtMs: NOW + 86_400_000,
+      }),
+      now: NOW,
+      pct: 95,
+    });
+    expect(entered.triggeredBy).toEqual({ fiveHour: true, sevenDay: false });
+    const after = evaluateSoftAvoid({
+      snapshot: snap(94, 10, {
+        // still in the 5h band (≥ 98-5=93), but the 5h epoch advanced
+        fiveHourResetAtMs: NOW + 5 * 3_600_000,
+        sevenDayResetAtMs: NOW + 86_400_000,
+      }),
+      now: NOW,
+      pct: 95,
+      prev: entered,
+    });
+    expect(after.softAvoided).toBe(false);
+  });
+
+  it("a 7d-driven latch is NOT released by the 5h window refilling (reset time passed)", () => {
+    const entered = evaluateSoftAvoid({
+      snapshot: snap(10, 96, { fiveHourResetAtMs: NOW + 3_600_000 }),
+      now: NOW,
+      pct: 95,
+    });
+    expect(entered.softAvoided).toBe(true);
+    // Two hours on: the snapshot's own 5h reset time has passed (refill),
+    // 7d still in the band — the latch holds.
+    const later = NOW + 2 * 3_600_000;
+    const after = evaluateSoftAvoid({
+      snapshot: snap(97, 93, {
+        capturedAt: NOW + 3_000_000, // captured before the 5h reset passed
+        fiveHourResetAtMs: NOW + 3_600_000,
+      }),
+      now: later,
+      pct: 95,
+      prev: entered,
+    });
+    expect(after.softAvoided).toBe(true);
+  });
+
+  it("legacy latched state without triggeredBy needs BOTH windows to release (sticky)", () => {
+    const prev: SoftAvoidState = { softAvoided: true, fiveHourResetAt: NOW + 3_600_000 };
+    // 5h epoch advanced but 7d (treated as a trigger) still in the band → holds.
+    expect(
+      evaluateSoftAvoid({
+        snapshot: snap(10, 93, { fiveHourResetAtMs: NOW + 5 * 3_600_000 }),
+        now: NOW,
+        pct: 95,
+        prev,
+      }).softAvoided,
+    ).toBe(true);
+  });
+
   it("a snapshot whose reset time has passed reads that window as refilled (0%)", () => {
     // 7d shows 96 but its reset was an hour ago → treated as 0 → no entry.
     const state = evaluateSoftAvoid({

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -1170,3 +1170,53 @@ describe("auth.allow_overage_accounts config field", () => {
     ).toThrow();
   });
 });
+
+// ─── auth.proactive_failover_pct config field (#3031) ───────────────────────
+
+describe("auth.proactive_failover_pct config field", () => {
+  const minimalBase = {
+    switchroom: { version: 1 },
+    agents: {},
+    telegram: { bot_token: "123:abc", forum_chat_id: "456" },
+  };
+
+  it("accepts a valid pct and threads through to AuthConfig", () => {
+    const cfg = SwitchroomConfigSchema.parse({
+      ...minimalBase,
+      auth: { active: "alice", proactive_failover_pct: 95 },
+    });
+    expect(cfg.auth?.proactive_failover_pct).toBe(95);
+  });
+
+  it("defaults to undefined when omitted — the soft-avoid tier is off by default", () => {
+    const cfg = SwitchroomConfigSchema.parse({
+      ...minimalBase,
+      auth: { active: "alice" },
+    });
+    expect(cfg.auth?.proactive_failover_pct).toBeUndefined();
+  });
+
+  it("rejects values above 99 (must stay below the hard wall)", () => {
+    expect(() =>
+      SwitchroomConfigSchema.parse({
+        ...minimalBase,
+        auth: { active: "alice", proactive_failover_pct: 99.5 },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects zero/negative and non-numeric values", () => {
+    expect(() =>
+      SwitchroomConfigSchema.parse({
+        ...minimalBase,
+        auth: { active: "alice", proactive_failover_pct: 0 },
+      }),
+    ).toThrow();
+    expect(() =>
+      SwitchroomConfigSchema.parse({
+        ...minimalBase,
+        auth: { active: "alice", proactive_failover_pct: "95" },
+      }),
+    ).toThrow();
+  });
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3740,6 +3740,24 @@ export const SwitchroomConfigSchema = z.object({
           "agent (whether that agent has `admin: true` or not) is a config " +
           "error caught at schema validation.",
         ),
+      proactive_failover_pct: z
+        .number()
+        .min(1)
+        .max(99)
+        .optional()
+        .describe(
+          "Soft-avoid threshold (percent) for proactive auth failover (#3031). " +
+          "When set (e.g. 95), an account whose fresh 7-day utilization is at/" +
+          "above this value — or whose 5h utilization is at/above min(pct+3, " +
+          "98) — enters the SOFT-AVOID preference tier: the broker prefers a " +
+          "fully-eligible fallback account on the serving path, without ever " +
+          "blocking the account (the hard wall stays 99.5). Enter/exit uses " +
+          "hysteresis (exit below pct-5 or on window reset) so the preference " +
+          "does not flap between probe ticks. Accounts serving past the wall " +
+          "via `allow_overage_accounts` are never soft-avoided. UNSET (the " +
+          "default) disables the tier entirely — behavior is identical to a " +
+          "fleet without this field.",
+        ),
       allow_overage_accounts: z
         .array(z.string().min(1))
         .optional()


### PR DESCRIPTION
Part 1 of 4 of the proactive auth-failover plan — #3031.

## Summary

Adds a first-class **soft-avoid** tier to the account-eligibility layer: a *preference ranking* between `eligible` and `blocked`, driven by a new operator knob `auth.proactive_failover_pct` (expected setting: 95).

- **Pure layer** (`src/auth/broker/account-eligibility.ts`): `evaluateSoftAvoid` — enter when fresh 7d util ≥ pct, or 5h util ≥ min(pct+3, 98); exit (hysteresis) only when both windows drop below entry-threshold − 5, or on an observed window reset (reset epoch advanced / refill boundary crossed). Overage-lifted accounts (`overageLiftsWall`) are never soft-avoided.
- **Serving path** (`server.ts`): `accountWithFailover`, `nextHealthyAccount`, and the `nextHealthyAccountLive` fast-path now rank fully-eligible candidates ahead of soft-avoided ones. When **every** serveable candidate is soft-avoided, the least-utilized one serves — never `null`, no roll.
- **Config**: `auth.proactive_failover_pct` (number, 1–99, optional) in the schema; documented in `docs/auth.md` + `docs/configuration.md`.

## The no-op-when-unset guarantee

With `proactive_failover_pct` unset (every existing fleet), `isAccountSoftAvoided` returns `false` before touching any state — the new predicates are structurally false and every selection path reduces to the exact pre-PR code path. Pinned by tests (`config unset — byte-identical selection`, plus a no-state-churn assertion).

## What deliberately does NOT change

- `WALL_PCT` 99.5 / `classifyHealth` / `snapshotWalled` / exhaustion-mark semantics — soft-avoid never blocks.
- **Attribution** (`callerAccount` / `mark-exhausted`) — the anti-cascade invariant; pinned by test.
- Last-resort escapes: the `auth.active` fall-through for exhausted pins and the walled-pin self-return are preserved verbatim.
- No probe-tick roll changes, no announcements, no durable promote — those are PR 2/3 per the plan in #3031.

## Test plan

- `src/auth/broker/soft-avoid.test.ts` — 17 pure-layer tests: both windows' thresholds, the 98 cap, hysteresis/flap (94↔96 @ pct=95), reset-epoch latch clear, refill normalization, overage exemption, stale/absent snapshots, pct-unset.
- `src/auth/broker/server-soft-avoid.test.ts` — 14 broker selection tests on a tmpdir harness: config-unset parity, soft-avoided pin prefers `fallback_order`, all-soft-avoid least-utilized tie-break (both selectors), exhausted→soft-avoided-fallback, `auth.active` escape preserved, attribution invariant, overage exemption incl. `out_of_credits` revocation, cross-tick hysteresis.
- `src/config/schema.test.ts` — new field accepted/optional/range-rejected.
- Local: scoped vitest over `src/auth/broker/` + `src/config/schema.test.ts` → 558 passed; `npm run lint` clean. CI is the full-suite authority.

## Risk

Low. Feature is default-off and structurally inert when unset; when set it can only re-rank among already-serveable accounts (availability can only stay equal or improve).

Vision outcome: **always available** (quota resilience). Job spec: reference/jobs — multi-account failover/quota-resilience surface (#3031 carries the staged plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review round (adversarial findings, all 7 fixed — commit 3a248e15)

- **Per-window hysteresis latch**: `SoftAvoidState.triggeredBy` records which window(s) latched; only a triggering window's reset (or its util dropping below threshold−5) releases the latch. Fixes the 7d hysteresis being capped at ~5h by routine 5h reset-epoch advances.
- **Stale-snapshot tie-break**: `softAvoidUtilScore` now scores missing/stale (>24h) snapshots as +Infinity (least preferred), so a latched-then-stale account never beats a freshly-measured one; fold is null-seeded so the tie-break still never returns null.
- `rm-account` prunes the label's soft-avoid state; `add-account` (re-add/replace) starts the label with a fresh latch.
- Soft-avoid tier flips deliberately do **not** fan out credential mirrors — agents pick up the preference on their next broker read; probe-tick rolls/announcements are PR 2 (documented in code).
- **Deliberate behavior change**: `accountWithFailover("")` now returns `null` (the old code returned `""`). Empty string is not a servable account label; callers already handle the null path. Pinned by test.
- Pass 2 of `accountWithFailover`'s fallback scan is skipped when pass 1 excluded nobody for soft-avoid (identical predicates — no duplicate credential reads, behavior identical).
- New test pins that an unexpired exhaustion mark + a FRESHER 95% snapshot yields **eligible AND soft-avoided simultaneously** (most-recent-signal-wins).

Updated test counts: `soft-avoid.test.ts` 22 pure-layer tests, `server-soft-avoid.test.ts` 21 broker-path tests; scoped vitest over `src/auth/broker/` → 439 passed; `npm run lint` clean.
