### PR TITLE
feat(auth): failover messaging cleanup (PR 3/4)

### DIFF
--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -207,6 +207,21 @@ export interface ListStateData {
    * false whenever `auth.allow_overage_accounts` is empty/unset.
    */
   active_overage_serving?: boolean;
+  /**
+   * Most recent BROKER-INITIATED proactive fleet roll (fleetQuotaProbeTick
+   * failover), so gateways can announce the switch to the operator (#3031
+   * PR 3). Absent/null on pre-roll brokers or until the first proactive
+   * roll. Reactive gateway-triggered rolls are NOT recorded here — the
+   * triggering gateway announces those itself.
+   */
+  last_fleet_roll?: {
+    from: string;
+    to: string;
+    at: number;
+    exhausted_until?: number;
+    window?: "5h" | "7d";
+    pct?: number;
+  } | null;
 }
 
 export interface SetActiveData {

--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -221,6 +221,13 @@ export interface ListStateData {
     exhausted_until?: number;
     window?: "5h" | "7d";
     pct?: number;
+    /**
+     * Trigger attribution (#3031 PR 2): "hard-exhaustion" = the probe saw a
+     * genuine quota wall; "soft-avoid" = a proactive serving-preference roll
+     * off an account approaching its limits (no mark, no promote). Absent on
+     * pre-PR-2 brokers (render as hard exhaustion).
+     */
+    reason?: "soft-avoid" | "hard-exhaustion";
   } | null;
 }
 

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -2227,6 +2227,95 @@ describe("AuthBroker — probe-quota", () => {
       broker.stop();
     }
   });
+
+  // #3031 PR 3 — broker-roll visibility: a proactive fleetQuotaProbeTick roll
+  // records `last_fleet_roll` (exposed via list-state) so gateways can announce
+  // it; the reactive mark-exhausted path deliberately does NOT (the triggering
+  // gateway announces that swap itself).
+  it("fleetQuotaProbeTick roll records last_fleet_roll in list-state (and persists across restart)", async () => {
+    const clock = Date.UTC(2026, 6, 11, 8, 0, 0);
+    const resetAt = new Date(clock + 2 * 3600_000);
+    const h = makeHarness();
+    const mkConfig = () => makeConfig(h, {
+      active: "default",
+      fallback_order: ["default", "secondary"],
+      agents: { ziggy: {} },
+    });
+    seedAccount(h, "default", { expiresAt: 9_999_999_999_999 });
+    seedAccount(h, "secondary", { expiresAt: 9_999_999_999_999 });
+    const fetchQuota = async ({ accessToken }: { accessToken: string }) => {
+      const label = accessToken.replace(/^at-/, "");
+      return label === "default"
+        ? { ok: true as const, data: { fiveHourUtilizationPct: 100, sevenDayUtilizationPct: 40, fiveHourResetAt: resetAt, sevenDayResetAt: null, representativeClaim: null, overageStatus: null, overageDisabledReason: null } }
+        : { ok: true as const, data: { fiveHourUtilizationPct: 5, sevenDayUtilizationPct: 10, fiveHourResetAt: null, sevenDayResetAt: null, representativeClaim: null, overageStatus: null, overageDisabledReason: null } };
+    };
+    const brokerOpts = {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      now: () => clock,
+      _testFetchQuota: fetchQuota,
+    };
+    const broker = new AuthBroker(mkConfig(), brokerOpts);
+    const client = new AuthBrokerClient({ socket: join(h.socketRoot, "ziggy", "sock") });
+    try {
+      await broker.start();
+      await broker.fleetQuotaProbeTick();
+      const roll = (await client.listState()).last_fleet_roll;
+      expect(roll).toBeTruthy();
+      expect(roll!.from).toBe("default");
+      expect(roll!.to).toBe("secondary");
+      expect(roll!.at).toBe(clock);
+      expect(roll!.window).toBe("5h");
+      expect(roll!.pct).toBeCloseTo(100, 1);
+      expect(roll!.exhausted_until).toBe(resetAt.getTime());
+    } finally {
+      await client.close();
+      broker.stop();
+    }
+    // Persisted: a fresh broker on the same stateDir still serves the roll.
+    const broker2 = new AuthBroker(mkConfig(), brokerOpts);
+    const client2 = new AuthBrokerClient({ socket: join(h.socketRoot, "ziggy", "sock") });
+    try {
+      await broker2.start();
+      const roll2 = (await client2.listState()).last_fleet_roll;
+      expect(roll2?.from).toBe("default");
+      expect(roll2?.to).toBe("secondary");
+      expect(roll2?.at).toBe(clock);
+    } finally {
+      await client2.close();
+      broker2.stop();
+    }
+  });
+
+  it("reactive mark-exhausted does NOT record last_fleet_roll (gateway announces that swap itself)", async () => {
+    const clock = Date.UTC(2026, 6, 11, 8, 0, 0);
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      fallback_order: ["default", "secondary"],
+      agents: { ziggy: {} },
+    });
+    seedAccount(h, "default", { expiresAt: 9_999_999_999_999 });
+    seedAccount(h, "secondary", { expiresAt: 9_999_999_999_999 });
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      now: () => clock,
+      _testFetchQuota: async ({ accessToken }: { accessToken: string }) =>
+        accessToken === "at-default"
+          ? { ok: true as const, data: { fiveHourUtilizationPct: 100, sevenDayUtilizationPct: 40, fiveHourResetAt: null, sevenDayResetAt: null, representativeClaim: null, overageStatus: null, overageDisabledReason: null } }
+          : { ok: true as const, data: { fiveHourUtilizationPct: 5, sevenDayUtilizationPct: 10, fiveHourResetAt: null, sevenDayResetAt: null, representativeClaim: null, overageStatus: null, overageDisabledReason: null } },
+    });
+    const sock = join(h.socketRoot, "ziggy", "sock");
+    const client = new AuthBrokerClient({ socket: sock });
+    try {
+      await broker.start();
+      const resp = (await rpc(sock, { v: 1, id: "1", op: "mark-exhausted", until: clock + 3600_000 })) as { data: { rolledTo: string | null } };
+      expect(resp.data.rolledTo).toBe("secondary"); // the roll happened…
+      expect((await client.listState()).last_fleet_roll ?? null).toBeNull(); // …but is not broker-announced
+    } finally {
+      await client.close();
+      broker.stop();
+    }
+  });
 });
 
 describe("AuthBroker — drift detection", () => {

--- a/telegram-plugin/fallback-card-collapse.ts
+++ b/telegram-plugin/fallback-card-collapse.ts
@@ -1,0 +1,122 @@
+/**
+ * Reactive-path message collapse (#3031 PR 3).
+ *
+ * Pre-fix, a mid-turn 429 emitted up to three separate operator messages:
+ *   1. the ⚠️ model-unavailable card (sent BEFORE the fallback outcome is
+ *      known — deliberate, see the promise-honesty note below),
+ *   2. the fleet-fallback success announcement ("Switched to <account> …"),
+ *   3. the resume/boot notice.
+ *
+ * This module owns the SAFE part of collapsing that flow: when the swap
+ * SUCCEEDS, the announcement is folded into an EDIT of the just-sent
+ * model-unavailable card (one evolving card) instead of a second message.
+ *
+ * CRITICAL constraint (2026-06-06→07 incident): the card is deliberately
+ * sent before the outcome is known, and a FAILURE notice must arrive as its
+ * own message on EVERY error path — the card promised an announcement, and
+ * an edit that never happens (or a swallowed failure) breaks that promise.
+ * Therefore:
+ *   - `decideAnnouncementDelivery` returns 'edit' ONLY for a successful
+ *     'switched' outcome with a fresh, fallback-promising card on record.
+ *     Every other outcome kind ('all-blocked', 'no-old-active',
+ *     'no-eligible-target', errors) is 'send' — a separate message, exactly
+ *     the pre-fix behaviour.
+ *   - The gateway falls back to a plain send when the edit itself throws.
+ *
+ * Pure module (injected clock, no Telegram/bot imports) so the decision
+ * logic is unit-testable at the seam.
+ */
+
+/** One recorded model-unavailable card, per chat. */
+export interface ModelUnavailableCardRecord {
+  /** Telegram message id of the sent card (null until the send resolves —
+   *  callers should record only after the send succeeds). */
+  messageId: number;
+  /** The rendered card text as sent, so the edit can append to it. */
+  text: string;
+  /** Unix ms the card send resolved. */
+  atMs: number;
+  /** Did the card promise an in-flight auto-failover? Only such cards may
+   *  absorb the announcement — a manual-hint card never promised one. */
+  promisedFallback: boolean;
+}
+
+/**
+ * Freshness ceiling for folding into a card. The fallback dispatcher runs
+ * seconds after the card in the normal case; a card older than this belongs
+ * to a previous incident and must not absorb an unrelated announcement.
+ */
+export const CARD_COLLAPSE_MAX_AGE_MS = 5 * 60_000;
+
+export interface ModelUnavailableCardRegistry {
+  /** Record the card most recently sent to `chatId` (replaces any prior). */
+  record(chatId: string, rec: ModelUnavailableCardRecord): void;
+  /**
+   * One-shot take: return the fresh, fallback-promising card for `chatId`
+   * and remove it (a card absorbs at most one announcement). Returns null —
+   * and clears the entry — when the record is stale or never promised a
+   * fallback.
+   */
+  take(chatId: string, now: number): ModelUnavailableCardRecord | null;
+  /** Number of chats with a recorded card (test/introspection helper). */
+  size(): number;
+}
+
+export function createModelUnavailableCardRegistry(
+  maxAgeMs: number = CARD_COLLAPSE_MAX_AGE_MS,
+): ModelUnavailableCardRegistry {
+  const cards = new Map<string, ModelUnavailableCardRecord>();
+  return {
+    record(chatId, rec) {
+      cards.set(chatId, rec);
+    },
+    take(chatId, now) {
+      const rec = cards.get(chatId);
+      if (!rec) return null;
+      cards.delete(chatId);
+      if (!rec.promisedFallback) return null;
+      if (now - rec.atMs > maxAgeMs) return null;
+      return rec;
+    },
+    size() {
+      return cards.size;
+    },
+  };
+}
+
+/**
+ * The outcome kinds `runFleetAutoFallback` can produce, plus 'error' for
+ * the dispatcher-threw path (broker unreachable, listState/markExhausted
+ * throw). Kept as a plain string union so this module stays import-free.
+ */
+export type FallbackDeliveryOutcomeKind =
+  | 'switched'
+  | 'all-blocked'
+  | 'no-old-active'
+  | 'no-eligible-target'
+  | 'error';
+
+/**
+ * Should the announcement for `outcomeKind` be delivered by EDITING the
+ * recorded model-unavailable card, or by SENDING a separate message?
+ *
+ * 'edit' is returned ONLY when the swap succeeded AND a fresh
+ * fallback-promising card exists for the chat. Every failure / no-op
+ * outcome is 'send' — the promise-honesty contract: a failure notice must
+ * arrive as its own message on every error path.
+ */
+export function decideAnnouncementDelivery(
+  outcomeKind: FallbackDeliveryOutcomeKind,
+  card: ModelUnavailableCardRecord | null,
+): 'edit' | 'send' {
+  if (outcomeKind !== 'switched') return 'send';
+  return card !== null ? 'edit' : 'send';
+}
+
+/**
+ * The single evolving card: original card text plus the announcement,
+ * separated by a rule so the "before/after" reads as one incident timeline.
+ */
+export function foldAnnouncementIntoCard(cardText: string, announcement: string): string {
+  return `${cardText}\n\n${announcement}`;
+}

--- a/telegram-plugin/fallback-card-collapse.ts
+++ b/telegram-plugin/fallback-card-collapse.ts
@@ -45,6 +45,15 @@ export interface ModelUnavailableCardRecord {
  * Freshness ceiling for folding into a card. The fallback dispatcher runs
  * seconds after the card in the normal case; a card older than this belongs
  * to a previous incident and must not absorb an unrelated announcement.
+ *
+ * Known accepted race (#3035 review, finding 4): the record lands only
+ * AFTER the card send resolves, and stays editable for this whole window —
+ * so a LATER 'switched' outcome (a second dispatch inside the window) can
+ * edit a card whose incident was already answered. Bounded by this 5-min
+ * ceiling plus the one-shot `take` semantics (a card absorbs at most one
+ * announcement); worst case is one announcement folded into a slightly
+ * older card instead of arriving as a separate message — never a lost
+ * announcement.
  */
 export const CARD_COLLAPSE_MAX_AGE_MS = 5 * 60_000;
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -21800,9 +21800,14 @@ async function doFireFleetAutoFallback(triggerAgent: string, untilMs?: number): 
       // #3031 PR 3 — collapse: on a SUCCESSFUL swap, fold the announcement
       // into an EDIT of the model-unavailable card this gateway just sent to
       // this chat (single evolving card). One-shot `take` clears the record
-      // either way. Every non-switched outcome — and any edit failure —
-      // falls through to the pre-fix separate send, so an announcement
-      // ALWAYS arrives (promise-honesty on all error paths).
+      // either way. Every non-switched outcome that REACHES this loop — and
+      // any edit failure — falls through to the pre-fix separate send.
+      // Known PRE-EXISTING hole, unchanged by the collapse (#3035 review,
+      // finding 2): the all-blocked cooldown early-return above exits before
+      // this loop, so a cooldown-suppressed all-blocked REPEAT delivers
+      // neither edit nor message even when a promising card exists. The
+      // first all-blocked card of a window does arrive and answers the
+      // promise; only the repeats inside the 30-min window are silent.
       const card = modelUnavailableCardRegistry.take(String(chat_id), Date.now())
       if (decideAnnouncementDelivery(outcome.kind, card) === 'edit' && card) {
         try {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -675,7 +675,14 @@ import {
   buildQuotaClaimKey,
   QUOTA_WATCH_CLAIM_WINDOW_MS,
   isLiveCorroboration,
+  evaluateFleetRollAnnounce,
+  FLEET_ROLL_ANNOUNCE_KEY,
 } from '../quota-watch.js'
+import {
+  createModelUnavailableCardRegistry,
+  decideAnnouncementDelivery,
+  foldAnnouncementIntoCard,
+} from '../fallback-card-collapse.js'
 import { buildSnapshotsFromState, buildSnapshotsFromCachedState, zipProbeResults } from '../auth-snapshot-format.js'
 import { maskUsername } from '../demo-mask.js'
 import {
@@ -6832,6 +6839,10 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
   const modelUnavailable = resolveModelUnavailableFromOperatorEvent(event)
   let renderedText: string
   let renderedKeyboard: ReturnType<typeof renderOperatorEvent>['keyboard'] | undefined
+  // #3031 PR 3 — when the card promises an in-flight auto-failover, record
+  // each per-chat send in the collapse registry so a SUCCESSFUL swap edits
+  // the card (single evolving message) instead of sending a second one.
+  let cardPromisedFallback = false
   if (modelUnavailable) {
     // Two questions, asked synchronously to avoid the "card promises
     // an announcement that never arrives" trap:
@@ -6856,6 +6867,7 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
       autoFallbackInFlight: willActuallyFire,
     })
     renderedKeyboard = undefined
+    cardPromisedFallback = willActuallyFire
     // Trigger fleet-wide auto-fallback. Pre-fix this branch only
     // rendered the card; the fallback machinery was unreachable from
     // here. We fire-and-forget so card delivery is never blocked on
@@ -6926,11 +6938,26 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
     // very next line is what unlocks the raw bot.api call.
     // Opts now includes message_thread_id when supergroup mode is on.
     // allow-raw-bot-api: operator-event broadcast loop; topic-aware opts
-    void bot.api.sendRichMessage(chat_id, richMessage(renderedText), opts as never).catch(e => {
-      process.stderr.write(
-        `telegram gateway: operator-event send to ${chat_id} failed agent=${agent} kind=${kind}: ${e}\n`,
-      )
-    })
+    void bot.api.sendRichMessage(chat_id, richMessage(renderedText), opts as never)
+      .then((sent: { message_id: number }) => {
+        // #3031 PR 3 — remember the fallback-promising card so the swap
+        // announcement can EDIT it (collapse) instead of sending anew.
+        // Recorded only after the send resolves (we need the message_id);
+        // the collapse path degrades to a plain send when no record exists.
+        if (cardPromisedFallback) {
+          modelUnavailableCardRegistry.record(String(chat_id), {
+            messageId: sent.message_id,
+            text: renderedText,
+            atMs: Date.now(),
+            promisedFallback: true,
+          })
+        }
+      })
+      .catch(e => {
+        process.stderr.write(
+          `telegram gateway: operator-event send to ${chat_id} failed agent=${agent} kind=${kind}: ${e}\n`,
+        )
+      })
   }
 }
 
@@ -21552,6 +21579,16 @@ const fleetFallbackGate = createFleetFallbackGate({
 })
 
 /**
+ * #3031 PR 3 — per-chat registry of the most recent model-unavailable card
+ * that promised an in-flight auto-failover. On a SUCCESSFUL swap the
+ * announcement is folded into an EDIT of that card (single evolving card);
+ * on every failure / no-op outcome the notice stays a separate message
+ * (promise-honesty: the 2026-06-06→07 incident contract). See
+ * fallback-card-collapse.ts for the decision seam.
+ */
+const modelUnavailableCardRegistry = createModelUnavailableCardRegistry()
+
+/**
  * Resume-after-swap gate (auth-failover-stall fix). Owns the single-flight +
  * staleness decision for re-running the turn a mid-turn 429 killed. See
  * fleet-fallback-resume.ts. Wired into doFireFleetAutoFallback below: on a
@@ -21760,6 +21797,29 @@ async function doFireFleetAutoFallback(triggerAgent: string, untilMs?: number): 
     // not the user's answer — silence the open ping.
     const opts = { disable_notification: true }
     for (const chat_id of access.allowFrom) {
+      // #3031 PR 3 — collapse: on a SUCCESSFUL swap, fold the announcement
+      // into an EDIT of the model-unavailable card this gateway just sent to
+      // this chat (single evolving card). One-shot `take` clears the record
+      // either way. Every non-switched outcome — and any edit failure —
+      // falls through to the pre-fix separate send, so an announcement
+      // ALWAYS arrives (promise-honesty on all error paths).
+      const card = modelUnavailableCardRegistry.take(String(chat_id), Date.now())
+      if (decideAnnouncementDelivery(outcome.kind, card) === 'edit' && card) {
+        try {
+          // allow-raw-bot-api: guarded edit; failure falls through to the wrapped send below
+          await bot.api.editMessageText(
+            chat_id,
+            card.messageId,
+            richMessage(foldAnnouncementIntoCard(card.text, outcome.announcement)),
+            {},
+          )
+          continue
+        } catch (err) {
+          process.stderr.write(
+            `telegram gateway: [fleet-fallback] card edit failed chat=${chat_id} — sending announcement separately: ${(err as Error)?.message ?? err}\n`,
+          )
+        }
+      }
       void swallowingApiCall(
         // allow-raw-bot-api: wrapped in swallowingApiCall (retry policy)
         () => bot.api.sendRichMessage(chat_id, richMessage(outcome.announcement), opts),
@@ -22011,6 +22071,61 @@ async function runQuotaWatch(opts: { bootTick?: boolean } = {}): Promise<void> {
     }
   }
 
+  // #3031 PR 3 — broker-initiated proactive roll announcement. The broker's
+  // fleetQuotaProbeTick roll previously emitted stdout + audit only (zero
+  // operator Telegram visibility); it now records `last_fleet_roll` in
+  // list-state. Edge-triggered on the roll's `at` timestamp; deduped across
+  // the multi-gateway fan-in via the same broker claim-notification verb the
+  // per-account pushes use — one card per roll per chat, fleet-wide.
+  {
+    const rollPrev = watchState[FLEET_ROLL_ANNOUNCE_KEY] ?? emptyAccountState()
+    const rollDecision = evaluateFleetRollAnnounce({
+      roll: listStateData.last_fleet_roll ?? null,
+      prev: rollPrev,
+      now,
+    })
+    if (rollDecision.kind === 'notify') {
+      for (const chat_id of access.allowFrom) {
+        if (tuning.fleetDedup) {
+          const granted = await claimQuotaNotification(
+            brokerClient,
+            buildQuotaClaimKey(
+              FLEET_ROLL_ANNOUNCE_KEY,
+              String(listStateData.last_fleet_roll!.at),
+              chat_id,
+            ),
+          )
+          if (!granted) {
+            process.stderr.write(
+              `telegram gateway: quota-watch: fleet-roll claim denied chat=${chat_id} — another agent notified\n`,
+            )
+            continue
+          }
+        }
+        await swallowingApiCall(
+          () =>
+            bot.api.sendRichMessage(chat_id, richMessage(rollDecision.message), {
+              // Reassuring status notice, not the user's answer — silent.
+              disable_notification: true,
+            }),
+          { chat_id, verb: 'quota-watch.fleet-roll' },
+        )
+      }
+      // Persist immediately — mirrors the all-exhausted block's rationale:
+      // a per-account early return below must not drop the latch advance.
+      watchState = patchQuotaWatchState(watchState, FLEET_ROLL_ANNOUNCE_KEY, rollDecision.newState)
+      try {
+        saveQuotaWatchState(stateDir, watchState)
+      } catch (err) {
+        process.stderr.write(`telegram gateway: quota-watch: fleet-roll state save failed: ${err}\n`)
+      }
+      process.stderr.write(
+        `telegram gateway: quota-watch: announced broker fleet roll ` +
+          `${listStateData.last_fleet_roll!.from} → ${listStateData.last_fleet_roll!.to}\n`,
+      )
+    }
+  }
+
   // First pass: evaluate all accounts against cached state. Collect
   // labels that need a live probe (i.e. accounts with a detected transition
   // that we're about to notify about). We probe those to get fresh
@@ -22030,9 +22145,13 @@ async function runQuotaWatch(opts: { bootTick?: boolean } = {}): Promise<void> {
   let reconciledCount = 0
   let mutatedState = watchState
 
+  // #3031 PR 3 — thread the last broker roll so a 🟡 throttling push for the
+  // just-rolled-off account is latched silently (the roll card covered it).
+  const lastRoll = listStateData.last_fleet_roll ?? null
+
   for (const snap of snapshots) {
     const prev = watchState[snap.label] ?? emptyAccountState()
-    const decision = evaluateQuotaWatchAccount({ agentName, snap, prev, now, bootTick, tuning })
+    const decision = evaluateQuotaWatchAccount({ agentName, snap, prev, now, bootTick, tuning, lastRoll })
     if (decision.kind === 'reconcile') {
       mutatedState = patchQuotaWatchState(mutatedState, decision.accountLabel, decision.newAccountState)
       reconciledCount++
@@ -22127,7 +22246,7 @@ async function runQuotaWatch(opts: { bootTick?: boolean } = {}): Promise<void> {
       // staleness gate never misfires on data we JUST probed.
       const enrichedSnap = { ...snapshots[snapIndex]!, quota: freshEntry!.result.data, capturedAtMs: undefined }
       const prev = watchState[accountLabel] ?? emptyAccountState()
-      const re = evaluateQuotaWatchAccount({ agentName, snap: enrichedSnap, prev, now, bootTick, tuning })
+      const re = evaluateQuotaWatchAccount({ agentName, snap: enrichedSnap, prev, now, bootTick, tuning, lastRoll })
       // If the fresh probe still shows the same transition, use the
       // enriched message. If it no longer shows a transition (e.g. the
       // account recovered in the 100ms between listState and probe),

--- a/telegram-plugin/quota-watch.ts
+++ b/telegram-plugin/quota-watch.ts
@@ -162,10 +162,15 @@ export const FLEET_ROLL_ANNOUNCE_KEY = "__fleet_roll_announce__";
 /**
  * Don't announce a roll older than this — a gateway booting hours after a
  * roll would otherwise resurrect stale news (mirrors the late-recovery
- * discipline). One hour comfortably covers the 15-min poll cadence plus
- * boot-stagger while staying inside the roll's operational relevance.
+ * discipline). CLAMPED to the broker claim window (#3035 review, finding 1):
+ * if this ceiling exceeded the claim window, a gateway with an empty
+ * quota-watch.json running its boot tick after the claim expired but before
+ * this ceiling (e.g. T+40m under the old 60m/30m split) would pass both the
+ * latch AND the expired claim → duplicate roll card. Equal horizons close
+ * that gap by construction: any roll still young enough to announce is
+ * still inside the claim window that deduped the first announcement.
  */
-export const FLEET_ROLL_MAX_AGE_MS = 60 * 60_000;
+export const FLEET_ROLL_MAX_AGE_MS = QUOTA_WATCH_CLAIM_WINDOW_MS;
 
 /**
  * Suppress the per-account 🟡 throttling push when a roll announcement for
@@ -396,12 +401,18 @@ export function evaluateQuotaWatchAccount(args: {
       lastNotifiedAt: now,
     };
     // Roll-dedupe (#3031 PR 3): a fresh broker-roll announcement for this
-    // same account already covered the news — latch silently.
+    // same account already covered the news — latch silently. FIRST
+    // post-roll episode only (#3035 review, finding 3): if this account's
+    // watch state has already advanced SINCE the roll (prev.lastNotifiedAt
+    // >= roll.at — e.g. it recovered to healthy post-roll and is now
+    // re-entering throttling), that is a genuinely NEW episode the roll
+    // card said nothing about, so it must notify normally.
     const lastRoll = args.lastRoll;
     if (
       lastRoll &&
       lastRoll.from === label &&
-      now - lastRoll.at <= QUOTA_WATCH_ROLL_DEDUP_MS
+      now - lastRoll.at <= QUOTA_WATCH_ROLL_DEDUP_MS &&
+      prev.lastNotifiedAt < lastRoll.at
     ) {
       return {
         kind: "reconcile",

--- a/telegram-plugin/quota-watch.ts
+++ b/telegram-plugin/quota-watch.ts
@@ -189,6 +189,13 @@ export interface FleetRollInfo {
   exhausted_until?: number;
   window?: "5h" | "7d";
   pct?: number;
+  /**
+   * Trigger attribution (#3031 PR 2): "soft-avoid" = proactive
+   * serving-preference roll off an account APPROACHING its limits;
+   * "hard-exhaustion" = the probe saw a genuine quota wall. Absent on
+   * pre-PR-2 brokers — rendered as hard exhaustion.
+   */
+  reason?: "soft-avoid" | "hard-exhaustion";
 }
 
 export type FleetRollAnnounceDecision =
@@ -220,8 +227,10 @@ export function evaluateFleetRollAnnounce(args: {
 
 /**
  * Causal + reassuring announcement for a broker-initiated proactive roll.
- * Shape: "Switched fleet to <new> — <window> at <pct>% on <old>
+ * Hard exhaustion: "Switched fleet to <new> — <window> at <pct>% on <old>
  * (resets <time>). Work continues uninterrupted."
+ * Soft-avoid (#3031 PR 2 `reason`): reads as PROACTIVE — the old account is
+ * approaching its limits, not walled; no mark/reset framing.
  */
 export function buildFleetRollMessage(roll: FleetRollInfo, now: number): string {
   const winLabel =
@@ -231,13 +240,17 @@ export function buildFleetRollMessage(roll: FleetRollInfo, now: number): string 
     typeof roll.exhausted_until === "number" && roll.exhausted_until > now
       ? ` (resets ${formatRelative(new Date(roll.exhausted_until), new Date(now))})`
       : "";
+  const softAvoid = roll.reason === "soft-avoid";
+  const causeLine = softAvoid
+    ? `Proactive switch — \`${codeSpanSafe(roll.from)}\` is approaching its limits (${winLabel}${pctPart})${resetPart}, so the fleet moved early instead of hitting the wall.`
+    : `${winLabel}${pctPart} on \`${codeSpanSafe(roll.from)}\`${resetPart}.`;
   return [
     `🔁 **Switched fleet to \`${codeSpanSafe(roll.to)}\`**`,
     ``,
-    `${winLabel}${pctPart} on \`${codeSpanSafe(roll.from)}\`${resetPart}.`,
+    causeLine,
     `Work continues uninterrupted — agents and scheduled jobs now serve from \`${codeSpanSafe(roll.to)}\`.`,
     ``,
-    `_Automatic broker failover. Run /auth for fleet status; \`/auth use ${codeSpanSafe(roll.from)}\` to switch back once it refills._`,
+    `_Automatic broker failover${softAvoid ? " (proactive, before exhaustion)" : ""}. Run /auth for fleet status; \`/auth use ${codeSpanSafe(roll.from)}\` to switch back once it ${softAvoid ? "has headroom again" : "refills"}._`,
   ].join("\n");
 }
 

--- a/telegram-plugin/quota-watch.ts
+++ b/telegram-plugin/quota-watch.ts
@@ -149,6 +149,93 @@ export function buildQuotaClaimKey(
   return `quota-watch:${accountLabel}:${transition}:${chatId}`;
 }
 
+// ─── Broker-initiated fleet-roll announcement (#3031 PR 3) ───────────────────
+
+/**
+ * Reserved state-map key for the last-announced broker roll. Same reserved-key
+ * trick as FLEET_ALL_EXHAUSTED_KEY: not a valid account label, so it never
+ * collides with per-account entries, and the per-account loop never sees it.
+ * `lastNotifiedAt` stores the roll's `at` timestamp (edge-trigger latch).
+ */
+export const FLEET_ROLL_ANNOUNCE_KEY = "__fleet_roll_announce__";
+
+/**
+ * Don't announce a roll older than this — a gateway booting hours after a
+ * roll would otherwise resurrect stale news (mirrors the late-recovery
+ * discipline). One hour comfortably covers the 15-min poll cadence plus
+ * boot-stagger while staying inside the roll's operational relevance.
+ */
+export const FLEET_ROLL_MAX_AGE_MS = 60 * 60_000;
+
+/**
+ * Suppress the per-account 🟡 throttling push when a roll announcement for
+ * the SAME account fired this recently — the roll card already told the
+ * operator that account walled and the fleet moved off it; a trailing
+ * "approaching limit" push for it is noise. Matches the broker claim window
+ * so the two dedup horizons agree.
+ */
+export const QUOTA_WATCH_ROLL_DEDUP_MS = QUOTA_WATCH_CLAIM_WINDOW_MS;
+
+/** Shape of `listState().last_fleet_roll` as the watch consumes it. */
+export interface FleetRollInfo {
+  from: string;
+  to: string;
+  at: number;
+  exhausted_until?: number;
+  window?: "5h" | "7d";
+  pct?: number;
+}
+
+export type FleetRollAnnounceDecision =
+  | { kind: "notify"; message: string; newState: QuotaWatchAccountState }
+  | { kind: "skip"; reason: string };
+
+/**
+ * Edge-triggered decision for the broker-roll announcement. Fires at most
+ * once per roll event (latched on the roll's `at` timestamp), never for
+ * rolls older than `maxAgeMs`, and never re-fires in steady state.
+ */
+export function evaluateFleetRollAnnounce(args: {
+  roll: FleetRollInfo | null | undefined;
+  prev: QuotaWatchAccountState;
+  now: number;
+  maxAgeMs?: number;
+}): FleetRollAnnounceDecision {
+  const { roll, prev, now } = args;
+  const maxAgeMs = args.maxAgeMs ?? FLEET_ROLL_MAX_AGE_MS;
+  if (!roll) return { kind: "skip", reason: "no-roll" };
+  if (prev.lastNotifiedAt >= roll.at) return { kind: "skip", reason: "already-announced" };
+  if (now - roll.at > maxAgeMs) return { kind: "skip", reason: "stale-roll" };
+  return {
+    kind: "notify",
+    message: buildFleetRollMessage(roll, now),
+    newState: { lastNotifiedHealth: "healthy", lastNotifiedAt: roll.at },
+  };
+}
+
+/**
+ * Causal + reassuring announcement for a broker-initiated proactive roll.
+ * Shape: "Switched fleet to <new> — <window> at <pct>% on <old>
+ * (resets <time>). Work continues uninterrupted."
+ */
+export function buildFleetRollMessage(roll: FleetRollInfo, now: number): string {
+  const winLabel =
+    roll.window === "5h" ? "5-hour window" : roll.window === "7d" ? "7-day window" : "quota window";
+  const pctPart = typeof roll.pct === "number" ? ` at ${fmtPct(roll.pct)}` : "";
+  const resetPart =
+    typeof roll.exhausted_until === "number" && roll.exhausted_until > now
+      ? ` (resets ${formatRelative(new Date(roll.exhausted_until), new Date(now))})`
+      : "";
+  return [
+    `🔁 **Switched fleet to \`${codeSpanSafe(roll.to)}\`**`,
+    ``,
+    `${winLabel}${pctPart} on \`${codeSpanSafe(roll.from)}\`${resetPart}.`,
+    `Work continues uninterrupted — agents and scheduled jobs now serve from \`${codeSpanSafe(roll.to)}\`.`,
+    ``,
+    `_Automatic broker failover. Run /auth for fleet status; \`/auth use ${codeSpanSafe(roll.from)}\` to switch back once it refills._`,
+  ].join("\n");
+}
+
 // ─── Decision logic ───────────────────────────────────────────────────────────
 
 export type QuotaWatchTransition =
@@ -177,7 +264,7 @@ export type QuotaWatchDecision =
       accountLabel: string;
       newAccountState: QuotaWatchAccountState;
       transition: QuotaWatchTransition;
-      reason: "boot-tick-recovery" | "late-recovery";
+      reason: "boot-tick-recovery" | "late-recovery" | "roll-announced";
     }
   | { kind: "skip"; accountLabel: string; reason: string };
 
@@ -257,6 +344,14 @@ export function evaluateQuotaWatchAccount(args: {
   bootTick?: boolean;
   /** Staleness / late-recovery thresholds; 0 disables each. */
   tuning?: Pick<QuotaWatchTuning, "maxStaleMs" | "lateRecoveryMs">;
+  /**
+   * Most recent broker-initiated fleet roll, if any (#3031 PR 3). A fresh
+   * roll OFF this account suppresses the 🟡 entered-throttling push — the
+   * roll announcement already told the operator this account walled, so a
+   * trailing "approaching limit" for it is redundant. Latched silently
+   * (reconcile) so edge-trigger semantics hold: no steady-state re-notify.
+   */
+  lastRoll?: Pick<FleetRollInfo, "from" | "at"> | null;
 }): QuotaWatchDecision {
   const { agentName, snap, prev, now } = args;
   const bootTick = args.bootTick ?? false;
@@ -300,6 +395,22 @@ export function evaluateQuotaWatchAccount(args: {
       lastNotifiedHealth: "throttling",
       lastNotifiedAt: now,
     };
+    // Roll-dedupe (#3031 PR 3): a fresh broker-roll announcement for this
+    // same account already covered the news — latch silently.
+    const lastRoll = args.lastRoll;
+    if (
+      lastRoll &&
+      lastRoll.from === label &&
+      now - lastRoll.at <= QUOTA_WATCH_ROLL_DEDUP_MS
+    ) {
+      return {
+        kind: "reconcile",
+        accountLabel: label,
+        newAccountState: newState,
+        transition: "entered-throttling",
+        reason: "roll-announced",
+      };
+    }
     return {
       kind: "notify",
       accountLabel: label,
@@ -536,8 +647,12 @@ export function buildThrottlingMessage(agentName: string, snap: AccountSnapshot)
     ? ""
     : `\nThis is a non-active account. Consider \`/auth use ${codeSpanSafe(snap.label)}\` to switch, or keep it as a fallback reserve.`;
 
+  // Early warning, not an incident (#3031 PR 3): say what happens NEXT so
+  // the operator knows no action is required — if utilization keeps climbing
+  // to the failover threshold, the broker rolls the fleet to another account
+  // automatically and announces the switch.
   const altNote = snap.isActive
-    ? `\nConsider \`/auth use <other-account>\` if you have a healthier account, or wait for the ${winLabel} window to refill${resetStr}.`
+    ? `\nNo action needed: if usage keeps climbing, the fleet will prefer another account once this reaches the failover threshold (you'll get a switch announcement). Or switch early with \`/auth use <other-account>\`, or wait for the ${winLabel} window to refill${resetStr}.`
     : "";
 
   return [

--- a/telegram-plugin/tests/fallback-card-collapse.test.ts
+++ b/telegram-plugin/tests/fallback-card-collapse.test.ts
@@ -1,0 +1,104 @@
+/**
+ * #3031 PR 3 — reactive-path message collapse.
+ *
+ * The model-unavailable card is deliberately sent BEFORE the fallback
+ * outcome is known; on a SUCCESSFUL swap the announcement is folded into an
+ * EDIT of that card (single evolving card). CRITICAL promise-honesty
+ * constraint (2026-06-06→07 incident): every failure / no-op path must still
+ * deliver a SEPARATE message — these tests pin that the collapse decision
+ * can never eat a failure notice.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  createModelUnavailableCardRegistry,
+  decideAnnouncementDelivery,
+  foldAnnouncementIntoCard,
+  CARD_COLLAPSE_MAX_AGE_MS,
+  type ModelUnavailableCardRecord,
+  type FallbackDeliveryOutcomeKind,
+} from "../fallback-card-collapse.js";
+
+const NOW = 1_780_000_000_000;
+
+function rec(overrides: Partial<ModelUnavailableCardRecord> = {}): ModelUnavailableCardRecord {
+  return {
+    messageId: 4242,
+    text: "⚠️ Model unavailable — auto-failover in progress",
+    atMs: NOW - 5_000,
+    promisedFallback: true,
+    ...overrides,
+  };
+}
+
+describe("createModelUnavailableCardRegistry", () => {
+  it("take returns a fresh fallback-promising card exactly once (one edit per card)", () => {
+    const reg = createModelUnavailableCardRegistry();
+    reg.record("123", rec());
+    const first = reg.take("123", NOW);
+    expect(first?.messageId).toBe(4242);
+    // One-shot: a second take finds nothing (a card absorbs one announcement).
+    expect(reg.take("123", NOW)).toBeNull();
+    expect(reg.size()).toBe(0);
+  });
+
+  it("a stale card is not editable (belongs to a previous incident) and is cleared", () => {
+    const reg = createModelUnavailableCardRegistry();
+    reg.record("123", rec({ atMs: NOW - CARD_COLLAPSE_MAX_AGE_MS - 1 }));
+    expect(reg.take("123", NOW)).toBeNull();
+    expect(reg.size()).toBe(0);
+  });
+
+  it("a card that never promised auto-failover never absorbs the announcement", () => {
+    const reg = createModelUnavailableCardRegistry();
+    reg.record("123", rec({ promisedFallback: false }));
+    expect(reg.take("123", NOW)).toBeNull();
+  });
+
+  it("cards are per-chat: taking one chat's card leaves the other's intact", () => {
+    const reg = createModelUnavailableCardRegistry();
+    reg.record("123", rec({ messageId: 1 }));
+    reg.record("456", rec({ messageId: 2 }));
+    expect(reg.take("123", NOW)?.messageId).toBe(1);
+    expect(reg.take("456", NOW)?.messageId).toBe(2);
+  });
+
+  it("a newer card replaces the prior record for the same chat", () => {
+    const reg = createModelUnavailableCardRegistry();
+    reg.record("123", rec({ messageId: 1 }));
+    reg.record("123", rec({ messageId: 2 }));
+    expect(reg.take("123", NOW)?.messageId).toBe(2);
+  });
+});
+
+describe("decideAnnouncementDelivery — promise-honesty on every error path", () => {
+  it("edits ONLY on a successful swap with a fresh promising card", () => {
+    expect(decideAnnouncementDelivery("switched", rec())).toBe("edit");
+  });
+
+  it("sends separately on a successful swap when no card was recorded (e.g. card-less quota_wall_detected trigger)", () => {
+    expect(decideAnnouncementDelivery("switched", null)).toBe("send");
+  });
+
+  it("EVERY failure / no-op outcome is a separate send — even with a fresh card on record", () => {
+    const failureKinds: FallbackDeliveryOutcomeKind[] = [
+      "all-blocked",
+      "no-old-active",
+      "no-eligible-target",
+      "error",
+    ];
+    for (const kind of failureKinds) {
+      expect(decideAnnouncementDelivery(kind, rec()), `kind=${kind}`).toBe("send");
+      expect(decideAnnouncementDelivery(kind, null), `kind=${kind} (no card)`).toBe("send");
+    }
+  });
+});
+
+describe("foldAnnouncementIntoCard", () => {
+  it("keeps the original card text and appends the announcement (single evolving card)", () => {
+    const folded = foldAnnouncementIntoCard("CARD", "ANNOUNCEMENT");
+    expect(folded.startsWith("CARD")).toBe(true);
+    expect(folded).toContain("ANNOUNCEMENT");
+    expect(folded.indexOf("CARD")).toBeLessThan(folded.indexOf("ANNOUNCEMENT"));
+  });
+});

--- a/telegram-plugin/tests/quota-watch.test.ts
+++ b/telegram-plugin/tests/quota-watch.test.ts
@@ -1099,3 +1099,47 @@ describe("evaluateQuotaWatchAccount — roll-announcement dedupe (#3031 PR 3)", 
     expect(d.message).toContain("fleet will prefer another account");
   });
 });
+
+// ── #3035 review fixes ───────────────────────────────────────────────────────
+
+describe("#3035 review fixes", () => {
+  it("finding 1 — roll announce ceiling never exceeds the broker claim window (no duplicate-card gap)", async () => {
+    const mod = await import("../quota-watch.js");
+    expect(FLEET_ROLL_MAX_AGE_MS).toBeLessThanOrEqual(mod.QUOTA_WATCH_CLAIM_WINDOW_MS);
+  });
+
+  it("finding 3 — roll-dedupe suppresses ONLY the first post-roll episode: a recover-then-re-throttle after the roll notifies", () => {
+    const rollAt = NOW - 20 * 60_000; // inside the 30-min dedup window
+    // Post-roll, the account recovered to healthy and the watch state
+    // advanced (lastNotifiedAt AFTER roll.at). A fresh throttling entry is
+    // a genuinely NEW episode the roll card said nothing about.
+    const prevRecoveredPostRoll = {
+      lastNotifiedHealth: "healthy" as const,
+      lastNotifiedAt: rollAt + 5 * 60_000,
+    };
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: THROTTLING_5H,
+      prev: prevRecoveredPostRoll,
+      now: NOW,
+      lastRoll: { from: "alice@example.com", at: rollAt },
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    expect(d.transition).toBe("entered-throttling");
+  });
+
+  it("finding 3 — first post-roll episode (state pre-dates the roll) still latches silently", () => {
+    const rollAt = NOW - 60_000;
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: THROTTLING_5H,
+      prev: { lastNotifiedHealth: "healthy" as const, lastNotifiedAt: rollAt - 3600_000 },
+      now: NOW,
+      lastRoll: { from: "alice@example.com", at: rollAt },
+    });
+    expect(d.kind).toBe("reconcile");
+    if (d.kind !== "reconcile") return;
+    expect(d.reason).toBe("roll-announced");
+  });
+});

--- a/telegram-plugin/tests/quota-watch.test.ts
+++ b/telegram-plugin/tests/quota-watch.test.ts
@@ -20,6 +20,11 @@ import {
   emptyAccountState,
   isLiveCorroboration,
   type CorroborationProbe,
+  evaluateFleetRollAnnounce,
+  buildFleetRollMessage,
+  FLEET_ROLL_MAX_AGE_MS,
+  QUOTA_WATCH_ROLL_DEDUP_MS,
+  type FleetRollInfo,
 } from "../quota-watch.js";
 import type { AccountSnapshot } from "../auth-snapshot-format.js";
 import type { QuotaUtilization } from "../quota-check.js";
@@ -944,5 +949,153 @@ describe("evaluateQuotaWatchAccount — total enumeration (144 cells)", () => {
       }
     }
     expect(cells).toBe(144);
+  });
+});
+
+// ── #3031 PR 3 — broker-roll announcement ────────────────────────────────────
+
+describe("evaluateFleetRollAnnounce (#3031 PR 3)", () => {
+  const ROLL: FleetRollInfo = {
+    from: "alice@example.com",
+    to: "bob@example.com",
+    at: NOW - 60_000,
+    exhausted_until: NOW + 2 * 3600_000,
+    window: "5h",
+    pct: 99.8,
+  };
+
+  it("fires once for a fresh, never-announced roll (latched on roll.at)", () => {
+    const d = evaluateFleetRollAnnounce({ roll: ROLL, prev: emptyAccountState(), now: NOW });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    expect(d.newState.lastNotifiedAt).toBe(ROLL.at);
+  });
+
+  it("skips when already announced (edge trigger — no steady-state re-notify)", () => {
+    const d1 = evaluateFleetRollAnnounce({ roll: ROLL, prev: emptyAccountState(), now: NOW });
+    expect(d1.kind).toBe("notify");
+    if (d1.kind !== "notify") return;
+    const d2 = evaluateFleetRollAnnounce({ roll: ROLL, prev: d1.newState, now: NOW + 15 * 60_000 });
+    expect(d2.kind).toBe("skip");
+    if (d2.kind !== "skip") return;
+    expect(d2.reason).toBe("already-announced");
+  });
+
+  it("re-fires for a NEW roll event (later at) after a prior announce", () => {
+    const d1 = evaluateFleetRollAnnounce({ roll: ROLL, prev: emptyAccountState(), now: NOW });
+    if (d1.kind !== "notify") throw new Error("expected notify");
+    const later: FleetRollInfo = { ...ROLL, at: NOW + 6 * 3600_000, from: "bob@example.com", to: "carol@example.com" };
+    const d2 = evaluateFleetRollAnnounce({ roll: later, prev: d1.newState, now: NOW + 6 * 3600_000 + 5_000 });
+    expect(d2.kind).toBe("notify");
+  });
+
+  it("skips a stale roll (boot long after the event resurrects no old news)", () => {
+    const d = evaluateFleetRollAnnounce({
+      roll: { ...ROLL, at: NOW - FLEET_ROLL_MAX_AGE_MS - 1 },
+      prev: emptyAccountState(),
+      now: NOW,
+    });
+    expect(d.kind).toBe("skip");
+    if (d.kind !== "skip") return;
+    expect(d.reason).toBe("stale-roll");
+  });
+
+  it("skips when the broker reports no roll (old broker / never rolled)", () => {
+    expect(evaluateFleetRollAnnounce({ roll: null, prev: emptyAccountState(), now: NOW }).kind).toBe("skip");
+    expect(evaluateFleetRollAnnounce({ roll: undefined, prev: emptyAccountState(), now: NOW }).kind).toBe("skip");
+  });
+});
+
+describe("buildFleetRollMessage (#3031 PR 3) — causal + reassuring shape", () => {
+  it("names the new account, the binding window + pct on the old account, and the reset", () => {
+    const msg = buildFleetRollMessage(
+      {
+        from: "alice@example.com",
+        to: "bob@example.com",
+        at: NOW - 60_000,
+        exhausted_until: NOW + 2 * 3600_000,
+        window: "5h",
+        pct: 99.8,
+      },
+      NOW,
+    );
+    expect(msg).toContain("Switched fleet to");
+    expect(msg).toContain("bob@example.com");
+    expect(msg).toContain("alice@example.com");
+    expect(msg).toContain("5-hour window");
+    expect(msg).toContain("100%"); // fmtPct rounds 99.8
+    expect(msg).toContain("resets");
+    expect(msg).toContain("Work continues uninterrupted");
+  });
+
+  it("degrades gracefully without window/pct/reset data", () => {
+    const msg = buildFleetRollMessage(
+      { from: "alice@example.com", to: "bob@example.com", at: NOW - 60_000 },
+      NOW,
+    );
+    expect(msg).toContain("quota window");
+    expect(msg).not.toContain("resets");
+    expect(msg).toContain("Work continues uninterrupted");
+  });
+});
+
+describe("evaluateQuotaWatchAccount — roll-announcement dedupe (#3031 PR 3)", () => {
+  it("latches entered-throttling SILENTLY when a fresh roll off the same account was announced", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: THROTTLING_5H,
+      prev: PREV_NEVER_NOTIFIED,
+      now: NOW,
+      lastRoll: { from: "alice@example.com", at: NOW - 60_000 },
+    });
+    expect(d.kind).toBe("reconcile");
+    if (d.kind !== "reconcile") return;
+    expect(d.reason).toBe("roll-announced");
+    expect(d.transition).toBe("entered-throttling");
+    // Latch advances — no steady-state re-notify on the next tick.
+    expect(d.newAccountState.lastNotifiedHealth).toBe("throttling");
+    const next = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: THROTTLING_5H,
+      prev: d.newAccountState,
+      now: NOW + 15 * 60_000,
+      lastRoll: { from: "alice@example.com", at: NOW - 60_000 },
+    });
+    expect(next.kind).toBe("skip");
+  });
+
+  it("does NOT dedupe a roll for a DIFFERENT account", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: THROTTLING_5H,
+      prev: PREV_NEVER_NOTIFIED,
+      now: NOW,
+      lastRoll: { from: "someone-else@example.com", at: NOW - 60_000 },
+    });
+    expect(d.kind).toBe("notify");
+  });
+
+  it("does NOT dedupe a roll older than the dedup window", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: THROTTLING_5H,
+      prev: PREV_NEVER_NOTIFIED,
+      now: NOW,
+      lastRoll: { from: "alice@example.com", at: NOW - QUOTA_WATCH_ROLL_DEDUP_MS - 1 },
+    });
+    expect(d.kind).toBe("notify");
+  });
+
+  it("throttling message says what happens next (early warning, not incident)", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: makeSnap("alice@example.com", makeQuota(85, 40), /*isActive*/ true),
+      prev: PREV_NEVER_NOTIFIED,
+      now: NOW,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    expect(d.message).toContain("No action needed");
+    expect(d.message).toContain("fleet will prefer another account");
   });
 });

--- a/telegram-plugin/tests/quota-watch.test.ts
+++ b/telegram-plugin/tests/quota-watch.test.ts
@@ -1143,3 +1143,31 @@ describe("#3035 review fixes", () => {
     expect(d.reason).toBe("roll-announced");
   });
 });
+
+describe("buildFleetRollMessage — reason attribution (#3031 PR 2 reason field)", () => {
+  const BASE: FleetRollInfo = {
+    from: "alice@example.com",
+    to: "bob@example.com",
+    at: NOW - 60_000,
+    window: "7d",
+    pct: 96,
+  };
+
+  it("soft-avoid reads as proactive 'approaching limits', not exhaustion", () => {
+    const msg = buildFleetRollMessage({ ...BASE, reason: "soft-avoid" }, NOW);
+    expect(msg).toContain("Proactive switch");
+    expect(msg).toContain("approaching its limits");
+    expect(msg).toContain("proactive, before exhaustion");
+    expect(msg).toContain("7-day window at 96%");
+    expect(msg).toContain("Work continues uninterrupted");
+  });
+
+  it("hard-exhaustion (explicit or absent reason — pre-PR-2 broker) keeps the walled framing", () => {
+    for (const roll of [{ ...BASE, reason: "hard-exhaustion" as const }, BASE]) {
+      const msg = buildFleetRollMessage(roll, NOW);
+      expect(msg).not.toContain("Proactive switch");
+      expect(msg).not.toContain("approaching its limits");
+      expect(msg).toContain("7-day window at 96% on");
+    }
+  });
+});


### PR DESCRIPTION
Part of #3031 (proactive auth-failover plan). This is PR 3 of 4, scoped to the messaging-cleanup work that is **independent of the soft-avoid tier** (PR 1 `feat/soft-avoid-eligibility-tier`, PR 2 proactive roll). The announcement for the soft-avoid *proactive* roll itself will land with PR 2 — it rides the same `last_fleet_roll` channel this PR builds, so PR 2 only has to write the record.

## 1. Broker-roll visibility (previously ZERO operator messages)

Before: a broker-side roll (`fleetQuotaProbeTick` → `markExhaustedAndRoll`) emitted stdout + audit only. The operator's fleet silently switched accounts.

After: the broker records the roll as `last_fleet_roll` (`src/auth/broker/server.ts`, persisted to `last-fleet-roll.json` so a broker restart doesn't drop it) and exposes it via `list-state`. Each gateway's quota-watch tick picks it up, and exactly ONE operator card per roll lands per chat, deduped across the multi-gateway fan-in via the existing `claim-notification` verb:

> 🔁 **Switched fleet to `bob@…`** — 5-hour window at 100% on `alice@…` (resets in 2h). Work continues uninterrupted…

Edge-triggered (latched on the roll's `at` timestamp), stale-roll guarded (no resurrection >1h after the event), never re-notifies in steady state. The reactive `mark-exhausted` path deliberately does **not** write the record — the gateway that 429'd already announces that swap, so no double-announce (test pins this).

## 2. Reactive-path message collapse (3 messages → 1 evolving card + resume notice)

Before: a mid-turn 429 produced the model-unavailable card, then a separate fallback announcement, then the resume notice.

After: when the swap **succeeds**, the announcement is folded into an **edit** of the model-unavailable card (new pure module `telegram-plugin/fallback-card-collapse.ts`: per-chat one-shot registry, 5-min freshness ceiling, only cards that promised auto-failover).

**Promise-honesty preserved (2026-06-06→07 incident constraint):** the card is still sent before the outcome is known, and a failure notice arrives as its own message on EVERY error path — `decideAnnouncementDelivery` returns `send` for every non-`switched` outcome even with a fresh card on record (enumerated in tests), the gateway falls back to a plain send if the edit itself throws, and `broadcastFleetFallbackFailure` on the dispatcher-throw path is untouched.

## 3. quota-watch 80% push: forward-looking + roll-deduped

- Reworded active-account 🟡 to say what happens next: "No action needed: … the fleet will prefer another account once this reaches the failover threshold (you'll get a switch announcement)."
- If a roll announcement for the same account fired within the dedup window (30 min, matches the claim window), the entered-throttling push is latched **silently** (`reconcile: roll-announced`) — edge-triggered semantics unchanged, no steady-state re-notifies (144-cell enumeration suite still green).

## Message flow before/after

| Event | Before | After |
|---|---|---|
| Broker proactive roll | *(nothing)* | 1 card, fleet-deduped |
| Mid-turn 429, swap succeeds | card + announcement (+ resume) | card **edited** into announcement (+ resume) |
| Mid-turn 429, swap fails | card + failure notice | unchanged — card + separate failure notice |
| 80% crossing right after a roll | 🟡 push | silent latch (roll card covered it) |
| 80% crossing, no roll | 🟡 push | 🟡 push, reworded |

## Tests

- Scoped vitest: **194 passed** (`quota-watch.test.ts` incl. 9 new roll tests, new `fallback-card-collapse.test.ts` with 9 tests, `auto-fallback-fleet.test.ts` failure-notice suite kept green, `src/auth/broker/server.test.ts` incl. 2 new broker tests: roll recording+persistence, reactive-path non-recording).
- `npm run lint` clean (tsc + all 8 guard scripts, incl. bot-api-wrapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)