### PR TITLE
feat(auth): probe acts on soft-avoid tier + pinned-account failover (PR-2 of #3031)

### DIFF
--- a/src/auth/broker/account-eligibility.ts
+++ b/src/auth/broker/account-eligibility.ts
@@ -462,7 +462,18 @@ export function evaluateSoftAvoid(opts: {
   const fiveTriggered = five >= thresholds.fiveHour;
   const sevenTriggered = seven >= thresholds.sevenDay;
   if (fiveTriggered || sevenTriggered) {
-    return nextState(true, { fiveHour: fiveTriggered, sevenDay: sevenTriggered });
+    // Re-entry while already latched: UNION with the previous attribution.
+    // A window that latched earlier and hasn't released must keep requiring
+    // release — overwriting with only the currently-over-threshold window(s)
+    // would let the OTHER window's ~5h reset clear a still-hot latch
+    // (PR-1 review carry-over, #3032).
+    const prevTrig = prev?.softAvoided
+      ? (prev.triggeredBy ?? { fiveHour: true, sevenDay: true })
+      : undefined;
+    return nextState(true, {
+      fiveHour: fiveTriggered || (prevTrig?.fiveHour ?? false),
+      sevenDay: sevenTriggered || (prevTrig?.sevenDay ?? false),
+    });
   }
 
   if (prev?.softAvoided) {

--- a/src/auth/broker/server-soft-avoid-probe.test.ts
+++ b/src/auth/broker/server-soft-avoid-probe.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Probe acts on the soft-avoid tier (#3031, PR 2/4).
+ *
+ * Drives `fleetQuotaProbeTick` on a real AuthBroker (tmpdir home/state,
+ * `_testFetchQuota` seam, no listeners) and pins:
+ *
+ *  - a soft-avoided ACTIVE rolls the SERVING preference: agent mirrors get
+ *    the fully-eligible fallback's creds, with NO exhaustion mark, NO
+ *    durable promote of auth.active, and NO active-override.json;
+ *  - NO roll when no strictly-better candidate exists (all serveable
+ *    candidates soft-avoided);
+ *  - a PINNED agent account (auth.override) fails over the same way —
+ *    soft-avoid serving roll AND hard-exhaustion mark + fanout (the
+ *    consumerQuotaProbeTick analog);
+ *  - hard-wall behavior is byte-identical when proactive_failover_pct is
+ *    unset (mark + roll + durable promote still fire; near-wall does nothing);
+ *  - no roll ping-pong across probe ticks (enter/exit hysteresis + the
+ *    roll memo — exactly ONE audited roll while the preference holds);
+ *  - every soft-avoid roll leaves an audit record with reason "soft-avoid",
+ *    distinguished from the probe's hard path (reason "hard-exhaustion").
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { AuthBroker } from "./server.js";
+import type { SwitchroomConfig } from "../../config/schema.js";
+import { writeAccountCredentials } from "../account-store.js";
+import type { QuotaResult } from "../quota.js";
+
+const NOW = 1_800_000_000_000;
+
+interface Harness {
+  tmp: string;
+  home: string;
+  agentsDir: string;
+  stateDir: string;
+}
+
+let harnesses: Harness[] = [];
+
+afterEach(() => {
+  for (const h of harnesses) {
+    try {
+      rmSync(h.tmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+  harnesses = [];
+});
+
+function seedAccount(home: string, label: string): void {
+  writeAccountCredentials(
+    label,
+    {
+      claudeAiOauth: {
+        accessToken: "at-" + label,
+        refreshToken: "rt-" + label,
+        expiresAt: NOW + 24 * 60 * 60 * 1000,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+      },
+    },
+    home,
+  );
+}
+
+/** Per-label utilization the fake fetchQuota serves; mutate between ticks. */
+type QuotaTable = Record<string, { fiveHour: number; sevenDay: number }>;
+
+function quotaFor(table: QuotaTable, accessToken: string): QuotaResult {
+  const label = accessToken.replace(/^at-/, "");
+  const q = table[label];
+  if (!q) return { ok: false, reason: "no fixture for " + label };
+  return {
+    ok: true,
+    data: {
+      fiveHourUtilizationPct: q.fiveHour,
+      sevenDayUtilizationPct: q.sevenDay,
+      fiveHourResetAt: null,
+      sevenDayResetAt: q.sevenDay >= 99.5 ? new Date(NOW + 3 * 86_400_000) : null,
+      representativeClaim: q.sevenDay >= 99.5 ? "seven_day" : null,
+      overageStatus: null,
+      overageDisabledReason: null,
+    },
+  };
+}
+
+function makeBroker(opts: {
+  active: string;
+  fallbackOrder: string[];
+  pct?: number;
+  accounts: string[];
+  agents?: Record<string, { auth?: { override?: string } }>;
+  quotas: QuotaTable;
+}): { broker: AuthBroker; b: any; h: Harness } {
+  const tmp = mkdtempSync(join(tmpdir(), "auth-broker-softavoid-probe-"));
+  const home = join(tmp, "home");
+  const agentsDir = join(home, ".switchroom", "agents");
+  const stateDir = join(home, ".switchroom", "state", "auth-broker");
+  mkdirSync(agentsDir, { recursive: true });
+  mkdirSync(stateDir, { recursive: true });
+  const h: Harness = { tmp, home, agentsDir, stateDir };
+  harnesses.push(h);
+  for (const label of opts.accounts) seedAccount(home, label);
+  const agents = opts.agents ?? { ziggy: {} };
+  // Scaffold each agent dir so mirror fanout has somewhere to land.
+  for (const name of Object.keys(agents)) {
+    mkdirSync(join(agentsDir, name), { recursive: true });
+  }
+  const config = {
+    switchroom: { version: 1, agents_dir: agentsDir },
+    telegram: {},
+    agents,
+    auth: {
+      active: opts.active,
+      fallback_order: opts.fallbackOrder,
+      proactive_failover_pct: opts.pct,
+    },
+  } as unknown as SwitchroomConfig;
+  const broker = new AuthBroker(config, {
+    home,
+    stateDir,
+    now: () => NOW,
+    disableRefreshLoop: true,
+    skipHealthyMarker: true,
+    _testFetchQuota: async ({ accessToken }) => quotaFor(opts.quotas, accessToken),
+  });
+  return { broker, b: broker as any, h };
+}
+
+function mirrorToken(h: Harness, agent: string): string | null {
+  const p = join(h.agentsDir, agent, ".claude", ".credentials.json");
+  if (!existsSync(p)) return null;
+  const parsed = JSON.parse(readFileSync(p, "utf-8"));
+  return parsed.claudeAiOauth?.accessToken ?? null;
+}
+
+function auditRows(h: Harness): Array<{ op: string; account?: string; reason?: string }> {
+  const p = join(h.stateDir, "audit.jsonl");
+  if (!existsSync(p)) return [];
+  return readFileSync(p, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l));
+}
+
+describe("fleetQuotaProbeTick — soft-avoid serving roll for the ACTIVE (pct=95)", () => {
+  it("rolls agent mirrors to the eligible fallback: no mark, no promote, audited as soft-avoid", async () => {
+    const { broker, b, h } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      pct: 95,
+      accounts: ["alice", "bob"],
+      quotas: { alice: { fiveHour: 10, sevenDay: 96 }, bob: { fiveHour: 5, sevenDay: 10 } },
+    });
+    await broker.fleetQuotaProbeTick();
+    // SERVING preference rolled: ziggy's mirror carries bob's creds…
+    expect(mirrorToken(h, "ziggy")).toBe("at-bob");
+    // …but NOTHING durable moved: no exhaustion mark, active untouched,
+    // no active-override.json (yaml-drift semantics preserved).
+    expect(b.quota["alice"]).toBeUndefined();
+    expect(b.config.auth?.active).toBe("alice");
+    expect(existsSync(join(h.stateDir, "active-override.json"))).toBe(false);
+    // Audit record: same shape as probe rolls, reason distinguishes trigger.
+    const rolls = auditRows(h).filter((r) => r.op === "proactive-roll");
+    expect(rolls).toHaveLength(1);
+    expect(rolls[0]).toMatchObject({ account: "alice", reason: "soft-avoid" });
+    expect(auditRows(h).some((r) => r.op === "mark-exhausted")).toBe(false);
+    // last_fleet_roll rides PR-3's announcement channel: same record shape
+    // as the hard path, reason distinguishing the trigger. Persisted.
+    expect(b.lastFleetRoll).toMatchObject({
+      from: "alice",
+      to: "bob",
+      at: NOW,
+      reason: "soft-avoid",
+      window: "7d",
+      pct: 96,
+    });
+    expect(b.lastFleetRoll.exhausted_until).toBeUndefined();
+    expect(existsSync(join(h.stateDir, "last-fleet-roll.json"))).toBe(true);
+  });
+
+  it("does NOT roll when no strictly-better candidate exists (all soft-avoided)", async () => {
+    const { broker, h } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      pct: 95,
+      accounts: ["alice", "bob"],
+      quotas: { alice: { fiveHour: 10, sevenDay: 96 }, bob: { fiveHour: 10, sevenDay: 97 } },
+    });
+    await broker.fleetQuotaProbeTick();
+    expect(mirrorToken(h, "ziggy")).toBe(null); // no push at all
+    expect(auditRows(h).filter((r) => r.op === "proactive-roll")).toHaveLength(0);
+    expect(existsSync(join(h.stateDir, "last-fleet-roll.json"))).toBe(false);
+  });
+
+  it("no ping-pong across ticks: one audited roll while the hysteresis latch holds", async () => {
+    const quotas: QuotaTable = {
+      alice: { fiveHour: 10, sevenDay: 96 },
+      bob: { fiveHour: 5, sevenDay: 10 },
+    };
+    const { broker, h } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      pct: 95,
+      accounts: ["alice", "bob"],
+      quotas,
+    });
+    await broker.fleetQuotaProbeTick();
+    expect(mirrorToken(h, "ziggy")).toBe("at-bob");
+    // Tick 2: alice dips into the hysteresis band (94 ≥ pct-5) — the latch
+    // holds, the preference is unchanged, and the memo dedupes the roll:
+    // no second audit record, mirror stays on bob (no roll back to alice).
+    quotas.alice = { fiveHour: 10, sevenDay: 94 };
+    await broker.fleetQuotaProbeTick();
+    expect(mirrorToken(h, "ziggy")).toBe("at-bob");
+    expect(auditRows(h).filter((r) => r.op === "proactive-roll")).toHaveLength(1);
+    // Tick 3: alice drops clearly below pct-5 → tier releases. The serving
+    // path reverts on the next credential read; the probe must not audit
+    // any further roll.
+    quotas.alice = { fiveHour: 10, sevenDay: 80 };
+    await broker.fleetQuotaProbeTick();
+    expect(auditRows(h).filter((r) => r.op === "proactive-roll")).toHaveLength(1);
+  });
+
+  it("re-rolls (new audit) only when the preference genuinely changes again", async () => {
+    const quotas: QuotaTable = {
+      alice: { fiveHour: 10, sevenDay: 96 },
+      bob: { fiveHour: 5, sevenDay: 10 },
+    };
+    const { broker, h } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      pct: 95,
+      accounts: ["alice", "bob"],
+      quotas,
+    });
+    await broker.fleetQuotaProbeTick(); // roll #1 → bob
+    // alice releases (80), then later re-enters the tier (97): a NEW roll.
+    quotas.alice = { fiveHour: 10, sevenDay: 80 };
+    await broker.fleetQuotaProbeTick();
+    quotas.alice = { fiveHour: 10, sevenDay: 97 };
+    await broker.fleetQuotaProbeTick(); // roll #2 → bob again
+    expect(auditRows(h).filter((r) => r.op === "proactive-roll")).toHaveLength(2);
+  });
+});
+
+describe("fleetQuotaProbeTick — PINNED agent accounts (auth.override)", () => {
+  it("a soft-avoided pin rolls the pinned agent's mirror to an eligible fallback", async () => {
+    const { broker, b, h } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob", "pin"],
+      pct: 95,
+      accounts: ["alice", "bob", "pin"],
+      agents: { ziggy: {}, pinner: { auth: { override: "pin" } } },
+      quotas: {
+        alice: { fiveHour: 5, sevenDay: 10 },
+        bob: { fiveHour: 5, sevenDay: 12 },
+        pin: { fiveHour: 10, sevenDay: 97 },
+      },
+    });
+    await broker.fleetQuotaProbeTick();
+    // The pinned agent fails over (pin is a PRIMARY, not a hard pin)…
+    expect(mirrorToken(h, "pinner")).toBe("at-alice");
+    // …the fleet-active rider is untouched by the pin's roll…
+    expect(mirrorToken(h, "ziggy")).toBe(null);
+    // …and nothing durable moved: no mark, attribution stays on the pin.
+    expect(b.quota["pin"]).toBeUndefined();
+    expect(b.callerAccount({ kind: "agent", name: "pinner", admin: false })).toBe("pin");
+    const rolls = auditRows(h).filter((r) => r.op === "proactive-roll");
+    expect(rolls).toHaveLength(1);
+    expect(rolls[0]).toMatchObject({ account: "pin", reason: "soft-avoid" });
+    // A pinned-only roll is not a FLEET roll — it must not claim the
+    // last_fleet_roll announcement slot.
+    expect(b.lastFleetRoll).toBe(null);
+  });
+
+  it("a hard-walled pin is marked + fanned out (consumer-sensor analog), active NOT promoted", async () => {
+    const { broker, b, h } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob", "pin"],
+      pct: 95,
+      accounts: ["alice", "bob", "pin"],
+      agents: { pinner: { auth: { override: "pin" } } },
+      quotas: {
+        alice: { fiveHour: 5, sevenDay: 10 },
+        bob: { fiveHour: 5, sevenDay: 12 },
+        pin: { fiveHour: 3, sevenDay: 100 },
+      },
+    });
+    await broker.fleetQuotaProbeTick();
+    // Marked exhausted (durable) and the pinned agent got failover creds.
+    expect(b.quota["pin"]?.exhausted_until).toBeGreaterThan(NOW);
+    expect(mirrorToken(h, "pinner")).toBe("at-alice");
+    // The fleet active is NOT promoted off by a pinned-only wall.
+    expect(b.config.auth?.active).toBe("alice");
+    expect(existsSync(join(h.stateDir, "active-override.json"))).toBe(false);
+    const marks = auditRows(h).filter((r) => r.op === "mark-exhausted");
+    expect(marks).toHaveLength(1);
+    expect(marks[0]).toMatchObject({ account: "pin", reason: "hard-exhaustion" });
+  });
+});
+
+describe("fleetQuotaProbeTick — proactive_failover_pct unset (no behavior change)", () => {
+  it("a near-wall (96%) active is left completely alone", async () => {
+    const { broker, b, h } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      accounts: ["alice", "bob"],
+      quotas: { alice: { fiveHour: 10, sevenDay: 96 }, bob: { fiveHour: 5, sevenDay: 10 } },
+    });
+    await broker.fleetQuotaProbeTick();
+    expect(mirrorToken(h, "ziggy")).toBe(null);
+    expect(b.quota["alice"]).toBeUndefined();
+    expect(b.config.auth?.active).toBe("alice");
+    expect(auditRows(h).filter((r) => r.op === "proactive-roll")).toHaveLength(0);
+    expect(Object.keys(b.softAvoidState)).toHaveLength(0);
+  });
+
+  it("hard-wall path unchanged: mark + roll + durable promote still fire", async () => {
+    const { broker, b, h } = makeBroker({
+      active: "alice",
+      fallbackOrder: ["alice", "bob"],
+      accounts: ["alice", "bob"],
+      quotas: { alice: { fiveHour: 3, sevenDay: 100 }, bob: { fiveHour: 5, sevenDay: 10 } },
+    });
+    await broker.fleetQuotaProbeTick();
+    expect(b.quota["alice"]?.exhausted_until).toBeGreaterThan(NOW);
+    expect(mirrorToken(h, "ziggy")).toBe("at-bob");
+    // Durable promote (live-corroborated wall) — the pre-PR-2 semantics.
+    expect(b.config.auth?.active).toBe("bob");
+    const marks = auditRows(h).filter((r) => r.op === "mark-exhausted");
+    expect(marks).toHaveLength(1);
+    expect(marks[0]).toMatchObject({ account: "alice", reason: "hard-exhaustion" });
+    expect(auditRows(h).some((r) => r.op === "auto-promote-active")).toBe(true);
+    expect(auditRows(h).filter((r) => r.op === "proactive-roll")).toHaveLength(0);
+    // The hard fleet roll claims the announcement slot with its own reason.
+    expect(b.lastFleetRoll).toMatchObject({
+      from: "alice",
+      to: "bob",
+      reason: "hard-exhaustion",
+      window: "7d",
+      pct: 100,
+    });
+    expect(b.lastFleetRoll.exhausted_until).toBeGreaterThan(NOW);
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -201,6 +201,37 @@ interface NotificationClaims {
 const NOTIFICATION_CLAIM_MAX_AGE_MS = 86_400_000;
 
 /**
+ * Record of the most recent BROKER-INITIATED fleet roll (proactive
+ * `fleetQuotaProbeTick` failover — hard-exhaustion or soft-avoid). Exposed
+ * via `list-state` as `last_fleet_roll` so gateways can announce the roll to
+ * the operator (the announcement/dedup channel is #3031 PR 3). Deliberately
+ * NOT written by the reactive `mark-exhausted` op: the gateway that 429'd
+ * already announces that swap itself, so recording it here would
+ * double-announce. Persisted as `last-fleet-roll.json` so a broker restart
+ * inside a gateway's poll interval doesn't drop the announcement.
+ */
+export interface LastFleetRoll {
+  /** Account the fleet rolled off (the exhausted/soft-avoided ex-serving). */
+  from: string;
+  /** Account the fleet rolled to. */
+  to: string;
+  /** Unix ms the roll happened (broker clock). */
+  at: number;
+  /** Unix ms the walled account's mark expires, when known. */
+  exhausted_until?: number;
+  /** Which window bound the roll decision, when known. */
+  window?: "5h" | "7d";
+  /** Utilization pct of the binding window at roll time, when known. */
+  pct?: number;
+  /**
+   * Trigger attribution (#3031 PR 2): "hard-exhaustion" = the probe saw a
+   * genuine quota wall (mark + roll, possibly promote); "soft-avoid" = a
+   * serving-preference roll off the soft-avoid tier (no mark, no promote).
+   */
+  reason?: "soft-avoid" | "hard-exhaustion";
+}
+
+/**
  * #2495 Change 2 — probe-on-open TTL. A `probe-quota` request whose cached
  * snapshot is younger than this serves the cache instead of paying for a live
  * upstream call. 45s is short enough that an opened /auth or /usage card is
@@ -428,6 +459,9 @@ export class AuthBroker {
   /** Fleet notification-dedup claims: key → unix-ms of last grant.
    *  Persisted so a broker restart inside the window stays closed. */
   private notificationClaims: NotificationClaims = {};
+  /** Most recent broker-initiated proactive fleet roll (see LastFleetRoll).
+   *  Persisted so a restart doesn't drop a pending announcement. */
+  private lastFleetRoll: LastFleetRoll | null = null;
   /** Last `expiresAt` the broker wrote per label — drives threshold-violation. */
   private lastWrittenExpiresAt = new Map<string, number | undefined>();
   /** Refresh leases held while a POST is in flight (in-process). */
@@ -1194,6 +1228,15 @@ export class AuthBroker {
    *  probe after a broker restart — the durable quota cache reseeds it). */
   private softAvoidState: Record<string, SoftAvoidState> = {};
 
+  /**
+   * Per-label memo of the last probe-tick soft-avoid roll target (PR 2 of
+   * #3031). Dedupes the fanout + audit across ticks while the preference is
+   * unchanged — NOT hysteresis (flap-safety is `isAccountSoftAvoided`'s
+   * enter/exit latch); this only stops an identical roll from re-auditing
+   * every tick. Cleared when the tier releases or the target degrades.
+   */
+  private softAvoidRolledTo: Record<string, string> = {};
+
   /** View a cached quota entry through the soft-avoid snapshot shape (reset
    *  ISO strings → unix-ms epochs the pure layer compares). */
   private softAvoidSnapshotOf(account: string): SoftAvoidSnapshot | undefined {
@@ -1215,11 +1258,11 @@ export class AuthBroker {
    * the config knob is unset (the no-behavior-change guarantee).
    * Overage-lifted accounts are never soft-avoided.
    *
-   * DELIBERATE (PR 1/4 scope): a soft-avoid tier FLIP does not proactively
-   * fan out credential mirrors to agents — agents pick up the preference on
-   * their next broker read (get-credentials / refresh-tick fanout, which
-   * already routes through accountWithFailover). Probe-tick-driven rolls +
-   * announcements are PR 2 of the #3031 plan; do not add fanout here.
+   * A soft-avoid tier FLIP still does not fan out from HERE — this stays a
+   * pure predicate. The probe-tick-driven push (PR 2 of #3031) lives in
+   * `softAvoidProbeRoll`, called from `fleetQuotaProbeTick`; the pull paths
+   * (get-credentials / refresh-tick fanout) already route through
+   * accountWithFailover. Announcements/notifications are PR 3.
    */
   private isAccountSoftAvoided(account: string): boolean {
     const pct = this.config.auth?.proactive_failover_pct;
@@ -1607,6 +1650,9 @@ export class AuthBroker {
         agents,
         consumers,
         active_overage_serving,
+        // #3031 — most recent broker-initiated proactive roll, so gateways
+        // can announce it (null until the first proactive roll).
+        last_fleet_roll: this.lastFleetRoll,
       }),
     );
   }
@@ -1822,6 +1868,12 @@ export class AuthBroker {
    * any fallback's window refills.
    */
   async fleetQuotaProbeTick(): Promise<void> {
+    // Phase 1 — probe + cache EVERY account before acting. The act phase
+    // (hard-exhaustion roll / soft-avoid serving roll) compares the probed
+    // account against its fallback candidates; acting mid-scan would rank
+    // candidates the loop simply hadn't reached yet (stale/absent snapshots)
+    // — most visibly on the boot tick, where nothing is cached at all.
+    const probed: Array<{ label: string; result: QuotaResult }> = [];
     for (const label of listAccounts(this.home)) {
       const creds = readAccountCredentials(label, this.home);
       const token = creds?.claudeAiOauth?.accessToken;
@@ -1834,18 +1886,157 @@ export class AuthBroker {
         continue;
       }
       this.cacheQuotaSnapshot(label, result);
+      probed.push({ label, result });
+    }
+    // Phase 2 — act on the fleet ACTIVE and on PINNED agent accounts.
+    for (const { label, result } of probed) {
       // Re-read active each iteration: a promote earlier in this loop moves it.
       const active = this.config.auth?.active;
-      if (label !== active) continue;
+      // PR 2 of #3031 — the probe acts on PINNED agent accounts too (the
+      // consumerQuotaProbeTick analog for `auth.override`): a pin is a
+      // PRIMARY, not a hard pin, so a pinned agent whose account walls (or
+      // enters the soft-avoid tier) fails over the same way the fleet
+      // active does. Non-active, non-pinned labels stay probe-only.
+      const isPinnedAgentAccount = this.pinnedAgentAccounts().has(label);
+      if (label !== active && !isPinnedAgentAccount) continue;
       const decision = quotaIndicatesExhaustion(result, this.isOverageAllowed(label));
-      if (!decision.exhausted) continue;
-      process.stdout.write(
-        `auth-broker: fleet-quota-probe shows ACTIVE ${label} exhausted — proactive failover\n`,
-      );
-      // Audit parity with the consumer sensor: a proactive mark leaves a
-      // durable audit record, not just a stdout line (#2845 review nit).
-      this.audit({ op: "mark-exhausted", identity: { kind: "operator" }, account: label, accountKind: "claude", ok: true });
-      await this.markExhaustedAndRoll(label, decision.until ?? undefined, { kind: "operator" });
+      if (decision.exhausted) {
+        process.stdout.write(
+          `auth-broker: fleet-quota-probe shows ${label === active ? "ACTIVE" : "PINNED"} ${label} exhausted — proactive failover\n`,
+        );
+        // Audit parity with the consumer sensor: a proactive mark leaves a
+        // durable audit record, not just a stdout line (#2845 review nit).
+        this.audit({ op: "mark-exhausted", identity: { kind: "operator" }, account: label, accountKind: "claude", ok: true, reason: "hard-exhaustion" });
+        // Pinned accounts share the exact roll core: mark + mirror-fanout to
+        // every agent whose raw effective account is `label`. The durable
+        // auto-promote inside is self-gating (`auth.active === account`), so
+        // a pinned-only wall never mutates the fleet active.
+        const { rolledTo } = await this.markExhaustedAndRoll(label, decision.until ?? undefined, { kind: "operator" });
+        // Record the broker-initiated FLEET roll so gateways can announce it
+        // (list-state `last_fleet_roll`; announcement channel is #3031 PR 3).
+        // Only when a target was actually found (an all-blocked no-roll is
+        // the fleet-all-exhausted alert's domain) and only for the fleet
+        // ACTIVE — a pinned-only roll is not a fleet roll and must not
+        // overwrite a pending fleet announcement (it stays audit-only).
+        if (rolledTo && label === active) {
+          this.recordFleetRoll(label, rolledTo, "hard-exhaustion", decision.until ?? undefined);
+        }
+        continue;
+      }
+      // PR 2 of #3031 — not hard-walled: act on the soft-avoid PREFERENCE
+      // tier with a serving-preference roll (mirror push only — no mark, no
+      // durable promote). Structurally a no-op while
+      // `auth.proactive_failover_pct` is unset.
+      this.softAvoidProbeRoll(label);
+    }
+  }
+
+  /**
+   * Write + persist the `last_fleet_roll` record for a broker-initiated
+   * proactive roll of the fleet ACTIVE (`fleetQuotaProbeTick` hard-exhaustion
+   * or soft-avoid path). Gateways read it from `list-state` and announce it
+   * to the operator with claim-notification dedup (#3031 PR 3) — this is the
+   * ONLY notification surface PR 2 touches; the roll stays silent here.
+   * Window/pct attribution comes from the snapshot the tick just cached.
+   */
+  private recordFleetRoll(
+    from: string,
+    to: string,
+    reason: "soft-avoid" | "hard-exhaustion",
+    exhaustedUntil?: number,
+  ): void {
+    const s = this.lastQuotaCache[from];
+    this.lastFleetRoll = {
+      from,
+      to,
+      at: this.now(),
+      reason,
+      ...(exhaustedUntil != null ? { exhausted_until: exhaustedUntil } : {}),
+      ...(s
+        ? {
+            window:
+              s.fiveHourUtilizationPct >= s.sevenDayUtilizationPct
+                ? ("5h" as const)
+                : ("7d" as const),
+            pct: Math.max(s.fiveHourUtilizationPct, s.sevenDayUtilizationPct),
+          }
+        : {}),
+    };
+    this.persistLastFleetRoll();
+  }
+
+  /** Every account some agent is pinned to via per-agent `auth.override`. */
+  private pinnedAgentAccounts(): Set<string> {
+    return new Set(
+      Object.values(this.config.agents ?? {})
+        .map((a) => a.auth?.override)
+        .filter((x): x is string => typeof x === "string" && x.length > 0),
+    );
+  }
+
+  /**
+   * PR 2 of #3031 — probe-tick-driven SERVING-preference roll off a
+   * soft-avoided account (`label` is the fleet active or a pinned agent's
+   * override). When the account sits in the soft-avoid tier AND a strictly
+   * better candidate exists — non-exhausted, NOT itself soft-avoided, with
+   * stored credentials (exactly the pass-1 preference `accountWithFailover`
+   * applies) — push the failover credentials NOW via the same mirror
+   * mechanism the hard-exhaustion roll uses (`fanoutFailoverTo` +
+   * `fanoutToAffectedConsumers`), instead of waiting for each agent's next
+   * credential read.
+   *
+   * Deliberately NOT the hard-exhaustion path:
+   *  - NO exhaustion mark — the account still serves, and attribution
+   *    (`callerAccount` / mark-exhausted) is untouched;
+   *  - NO durable promote of `auth.active` and NO `active-override.json`
+   *    write — the yaml-drift/override semantics are untouched, and the
+   *    preference self-reverts (via the normal refresh-tick fanout, which
+   *    routes through accountWithFailover) once the tier's exit hysteresis
+   *    releases;
+   *  - flap-safety is `isAccountSoftAvoided`'s enter/exit latch — no new
+   *    hysteresis here. `softAvoidRolledTo` only dedupes an identical
+   *    roll's fanout + audit across consecutive ticks.
+   *
+   * When every serveable candidate is soft-avoided too (no strictly better
+   * candidate), this does NOT roll — the least-utilized ranking inside
+   * `accountWithFailover` still shapes pull-path serving, but a proactive
+   * push on a utilization tie-break would ping-pong as scores drift.
+   *
+   * Notification/messaging is PR 3 — this stays silent beyond the audit
+   * record and a stdout line.
+   */
+  private softAvoidProbeRoll(label: string): void {
+    if (!this.isAccountSoftAvoided(label)) {
+      delete this.softAvoidRolledTo[label]; // tier released → memo reset
+      return;
+    }
+    const target = this.accountWithFailover(label);
+    if (!target || target === label || this.isAccountSoftAvoided(target)) {
+      // No strictly-better candidate: don't roll. Clear the memo so a later
+      // genuine improvement (a fallback dropping out of the tier) re-rolls.
+      delete this.softAvoidRolledTo[label];
+      return;
+    }
+    if (this.softAvoidRolledTo[label] === target) return; // already pushed
+    this.softAvoidRolledTo[label] = target;
+    process.stdout.write(
+      `auth-broker: fleet-quota-probe shows ${label} soft-avoided (≥ auth.proactive_failover_pct) — serving-preference roll → ${target}\n`,
+    );
+    // Same audit shape as the probe's hard-exhaustion roll; `reason`
+    // distinguishes the trigger (#3031 PR 2 deliverable).
+    this.audit({ op: "proactive-roll", identity: { kind: "operator" }, account: label, accountKind: "claude", ok: true, reason: "soft-avoid" });
+    // Same mirror mechanism as the hard-exhaustion roll: `target`'s creds
+    // onto every agent whose raw effective account (override ?? active) is
+    // `label` — fleet-active riders and pinned agents alike…
+    this.fanoutFailoverTo(label, target);
+    // …and push consumers bound to `label` (their serving path is already
+    // soft-avoid-aware; this removes the pull-loop latency).
+    this.fanoutToAffectedConsumers(label);
+    // Fleet-ACTIVE rolls ride the `last_fleet_roll` announcement channel
+    // (#3031 PR 3); a pinned-only roll stays audit-only so it can't
+    // overwrite a pending fleet announcement.
+    if (label === this.config.auth?.active) {
+      this.recordFleetRoll(label, target, "soft-avoid");
     }
   }
 
@@ -2198,6 +2389,7 @@ export class AuthBroker {
     // left over from a previously-removed account of the same name (or a
     // replace) belongs to the old credentials, not these.
     delete this.softAvoidState[label];
+    delete this.softAvoidRolledTo[label];
     // #1447 (WS1-F1): broker runs as root in production (auth-broker
     // container) and the writes above leave the dir + files root:root.
     // The operator's CLI then can't read them — chown back to the
@@ -2257,6 +2449,7 @@ export class AuthBroker {
     // Soft-avoid hysteresis is per-label in-memory state — prune it with the
     // account so a later re-add of the same label starts with a clean latch.
     delete this.softAvoidState[label];
+    delete this.softAvoidRolledTo[label];
     this.persistShaIndex();
     this.persistQuota();
     this.persistThresholdViolations();
@@ -3296,6 +3489,7 @@ export class AuthBroker {
     this.shaIndex = this.readJson<ShaIndex>("sha-index.json") ?? {};
     this.thresholdViolations = this.readJson<ThresholdViolations>("threshold-violations.json") ?? {};
     this.notificationClaims = this.readJson<NotificationClaims>("notification-claims.json") ?? {};
+    this.lastFleetRoll = this.readJson<LastFleetRoll>("last-fleet-roll.json") ?? null;
     // #2495 Change 1 — reload the durable utilization cache so a restart
     // serves last-known (age-stamped) quota, not a blank card.
     this.lastQuotaCache = this.readJson<LastQuotaCache>("last-quota.json") ?? {};
@@ -3364,6 +3558,7 @@ export class AuthBroker {
    *  a broker restart. Same atomic-write pattern as the exhaustion ledger. */
   private persistLastQuotaCache(): void { atomicWriteJsonSync(join(this.stateDir, "last-quota.json"), this.lastQuotaCache, 0o600); }
   private persistNotificationClaims(): void { atomicWriteJsonSync(join(this.stateDir, "notification-claims.json"), this.notificationClaims, 0o600); }
+  private persistLastFleetRoll(): void { if (this.lastFleetRoll) atomicWriteJsonSync(join(this.stateDir, "last-fleet-roll.json"), this.lastFleetRoll, 0o600); }
   private persistShaIndex(): void { atomicWriteJsonSync(join(this.stateDir, "sha-index.json"), this.shaIndex, 0o600); }
   private persistThresholdViolations(): void { atomicWriteJsonSync(join(this.stateDir, "threshold-violations.json"), this.thresholdViolations, 0o600); }
 
@@ -3423,6 +3618,13 @@ export class AuthBroker {
     ok: boolean;
     error?: string;
     replace?: boolean;
+    /**
+     * Trigger attribution for probe-driven failover rolls (#3031 PR 2):
+     *   "soft-avoid"       — serving-preference roll off the soft-avoid tier
+     *   "hard-exhaustion"  — the probe saw a genuine quota wall
+     * Omitted for every other op.
+     */
+    reason?: "soft-avoid" | "hard-exhaustion";
   }): void {
     const peer =
       entry.identity.kind === "operator"
@@ -3437,6 +3639,7 @@ export class AuthBroker {
       ok: entry.ok,
       error: entry.error,
       replace: entry.replace,
+      reason: entry.reason,
     });
     const auditPath = join(this.stateDir, "audit.jsonl");
     try {


### PR DESCRIPTION
PR 2 of the #3031 proactive auth-failover plan (follows #3032; coordinated with #3035).

## What

`fleetQuotaProbeTick` now ACTS on the soft-avoid tier and on pinned agent accounts, instead of only rolling on hard exhaustion of the fleet active:

- **Two-phase tick** — probe + cache every account, then act, so roll decisions rank candidates over uniformly fresh snapshots (the boot tick previously had nothing cached for later-in-scan candidates).
- **Soft-avoid serving roll** (`softAvoidProbeRoll`) — when the active (or a pinned `auth.override`) is soft-avoided AND a strictly better candidate exists (non-exhausted, not soft-avoided, has creds — exactly `accountWithFailover`'s pass-1 preference), push failover creds now via the same mirror mechanism as the hard-exhaustion roll (`fanoutFailoverTo` + `fanoutToAffectedConsumers`). **No exhaustion mark, no durable promote, `active-override.json` untouched** — the preference self-reverts through the existing exit hysteresis. No new hysteresis; a per-label memo only dedupes identical fanout/audit across ticks.
- **Pinned agent accounts** — the `consumerQuotaProbeTick` analog for `auth.override`: a hard-walled pin is marked + rolled through `markExhaustedAndRoll` (the durable promote self-gates on `active === account`, so a pinned-only wall never moves the fleet active); a soft-avoided pin gets the serving roll. A pin is a PRIMARY, not a hard pin. Implements the fanout deferred by the PR-1 comment in `isAccountSoftAvoided`.
- **Audit** — every probe-driven roll carries `reason: "soft-avoid" | "hard-exhaustion"`; soft rolls audit as `op: "proactive-roll"`.
- **`last_fleet_roll`** (coordinated with #3035): fleet-ACTIVE rolls write the same `{from,to,at,exhausted_until?,window?,pct?}` record plus `reason`, persisted to `last-fleet-roll.json` and exposed via `list-state`, so operator announcements ride PR-3's claim-notification channel — no separate notification path in this PR. Pinned-only rolls stay audit-only so they can't overwrite a pending fleet announcement.
- **PR-1 review carry-over** — `evaluateSoftAvoid` re-entry while latched now UNIONs `triggeredBy` with the previous attribution instead of overwriting it.

## No-behavior-change guarantee

With `auth.proactive_failover_pct` unset the new paths are structurally inert; the hard-wall path (mark + roll + corroborated durable promote) is byte-equivalent, pins excepted (in scope for this PR).

## Tests

`src/auth/broker/server-soft-avoid-probe.test.ts` (8 tests): active soft roll (mirror pushed, no mark, no promote, audited + `last_fleet_roll` with `reason:"soft-avoid"`); no roll without a strictly better candidate; tick-to-tick no-ping-pong (one audited roll while the latch holds) and legit re-roll after release+re-entry; pinned soft + hard failover (attribution untouched, active not promoted); pct-unset parity (near-wall untouched, hard wall marks/rolls/promotes exactly as before).

Local: `vitest run src/auth/broker/` — 25 files / 447 tests green; `npm run lint` clean. CI is the full-suite authority.

Refs #3031.

🤖 Generated with [Claude Code](https://claude.com/claude-code)