### PR TITLE
fix(gateway): pre-send photo validation; MCP bridge crash hardening (fixes #3033)

### DIFF
--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -31,6 +31,7 @@ import { buildEffectiveToolSchemas, LINEAR_ENV } from './tool-filter.js'
 import type { InboundMessage, PermissionEvent, StatusEvent } from '../gateway/ipc-protocol.js'
 import { matchesAllowRule } from '../permission-rule.js'
 import { createOutstandingPermissionLedger } from './permission-ledger.js'
+import { appendCrashBreadcrumb } from './crash-breadcrumb.js'
 
 installPluginLogger()
 
@@ -107,7 +108,7 @@ const TOOL_SCHEMAS = [
         quote: { type: 'boolean', description: 'Opt out of the default quote-reply behavior. Default: true. Pass false to send a bare message with no quote reference. Ignored when reply_to is explicitly set.' },
         message_thread_id: { type: 'string', description: 'Forum topic thread ID. Auto-applied from the last inbound message in the same chat if not specified.' },
         origin_turn_id: { type: 'string', description: 'In a forum supergroup, pass back the origin_turn_id attribute from the <channel> message you are answering. It pins the reply to that message\'s topic even if another topic\'s turn started meanwhile. Omit in DMs / single-topic chats.' },
-        files: { type: 'array', items: { type: 'string' }, description: 'Absolute file paths to attach. Images send as photos; other types as documents. Max 50MB each.' },
+        files: { type: 'array', items: { type: 'string' }, description: 'Absolute file paths to attach. Images send as photos; other types as documents. Max 50MB each. Telegram rejects photos with extreme dimensions (aspect ratio over ~10:1, width+height over 10000px, or over 10MB) — very tall images like full-page screenshots are auto-rerouted as documents; crop or split them first if the user should see them inline as photos.' },
         format: { type: 'string', enum: ['html', 'markdownv2', 'text'], description: "Rendering mode. 'html' (default) converts markdown to Telegram HTML." },
         disable_web_page_preview: { type: 'boolean', description: 'Disable link preview thumbnails. Default: true.' },
         protect_content: { type: 'boolean', description: 'When true, Telegram prevents the message from being forwarded or saved.' },
@@ -895,8 +896,29 @@ process.on('SIGINT', () => {
   setTimeout(() => process.exit(0), 500)
 })
 
+// #3033 — the bridge process must survive stray errors, and when it can't,
+// it must leave a diagnosable trace. Claude Code NEVER respawns a dead MCP
+// server: if this process exits, the reply tool vanishes from the session
+// (`No such tool available`) and only a full container restart recovers the
+// chat surface (2026-07-11 clerk incident — the gateway crashed, its
+// supervisor brought it back in 1s, but the bridge had died in the same
+// window and the agent was mute for 7 minutes until the operator bounced
+// the container). Claude Code also drops MCP-server stderr after startup,
+// so both handlers persist a breadcrumb to STATE_DIR/bridge-crash.log.
+const CRASH_LOG_PATH = join(STATE_DIR, 'bridge-crash.log')
+
 process.on('unhandledRejection', (err) => {
   process.stderr.write(`telegram bridge: unhandled rejection: ${err}\n`)
+  appendCrashBreadcrumb(CRASH_LOG_PATH, 'unhandledRejection', err)
+})
+
+process.on('uncaughtException', (err) => {
+  // Log-and-continue, mirroring the unhandledRejection posture. Risky in
+  // general, but the alternative is strictly worse here: process death is
+  // unrecoverable by design (see above), while the IPC client's reconnect
+  // loop can heal any gateway-connection damage on its own.
+  process.stderr.write(`telegram bridge: uncaught exception (continuing): ${(err as Error)?.stack ?? err}\n`)
+  appendCrashBreadcrumb(CRASH_LOG_PATH, 'uncaughtException', err)
 })
 
 async function main(): Promise<void> {

--- a/telegram-plugin/bridge/crash-breadcrumb.ts
+++ b/telegram-plugin/bridge/crash-breadcrumb.ts
@@ -1,0 +1,42 @@
+/**
+ * crash-breadcrumb.ts — persistent last-gasp diagnostics for the MCP
+ * bridge process (#3033).
+ *
+ * Why this exists: Claude Code captures an MCP server's stderr only
+ * around connection startup — anything the bridge writes later is
+ * dropped. In the 2026-07-11 clerk incident the bridge process died
+ * within seconds of a gateway crash and the cause was unrecoverable:
+ * no stderr, no log, nothing. And a dead bridge is terminal — Claude
+ * Code never respawns a failed MCP server, so the chat surface stays
+ * down (`No such tool available: mcp__switchroom-telegram__reply`)
+ * until a full container restart.
+ *
+ * This module appends a bounded breadcrumb line to
+ * `STATE_DIR/bridge-crash.log` from the bridge's uncaughtException /
+ * unhandledRejection handlers so the NEXT incident is diagnosable.
+ * Append-only, best-effort, never throws.
+ */
+
+import { appendFileSync, statSync, renameSync } from 'node:fs'
+
+/** Rotate once past ~1MB — a crash-looping bridge must not fill the disk. */
+const MAX_LOG_BYTES = 1024 * 1024
+
+export function appendCrashBreadcrumb(
+  logPath: string,
+  kind: 'uncaughtException' | 'unhandledRejection',
+  err: unknown,
+  now: Date = new Date(),
+): void {
+  try {
+    try {
+      if (statSync(logPath).size > MAX_LOG_BYTES) renameSync(logPath, `${logPath}.1`)
+    } catch { /* first write, or rotation raced — append anyway */ }
+    const detail = err instanceof Error ? (err.stack ?? err.message) : String(err)
+    // Single line per event (stack newlines folded) — greppable, bounded.
+    const folded = detail.replace(/\s*\n\s*/g, ' | ').slice(0, 4000)
+    appendFileSync(logPath, `${now.toISOString()} ${kind} pid=${process.pid} ${folded}\n`)
+  } catch {
+    /* best-effort: a failing breadcrumb must never make the crash worse */
+  }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -187,6 +187,7 @@ import {
   retryWithThreadFallback,
   isPhotoDimensionRejectError,
 } from '../retry-api-call.js'
+import { classifyPhotoFile } from '../photo-precheck.js'
 import { installTgPostLogger, withTgPostTags } from '../shared/bot-runtime.js'
 import { floodStatePath, makeFloodWaitRecorder } from '../flood-circuit-breaker.js'
 import { buildAttachmentPath, assertInsideInbox } from '../attachment-path.js'
@@ -11986,13 +11987,34 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     }
   }
 
+  // #3033 layer-2 (pre-send validation): probe each photo-extension file
+  // BEFORE it hits the wire and pre-route any that Telegram's photo path
+  // would reject (extreme aspect ratio, width+height over cap, >10MB) as
+  // documents. One bad photo fails a WHOLE sendMediaGroup album with an
+  // opaque 400 — catching it here keeps the good files deliverable and
+  // sends the offender as a document on the first attempt. Probe
+  // failures keep the photo route; the reactive #3022 fallback backstops.
+  const photoPrecheck = new Map<string, ReturnType<typeof classifyPhotoFile>>()
+  for (const f of files) {
+    if (!PHOTO_EXTS.has(extname(f).toLowerCase())) continue
+    const cls = classifyPhotoFile(f)
+    photoPrecheck.set(f, cls)
+    if (cls.route === 'document') {
+      process.stderr.write(
+        `telegram gateway: photo-precheck rerouting ${f} as document (${cls.reason})\n`,
+      )
+    }
+  }
+  const sendableAsPhoto = (f: string) =>
+    PHOTO_EXTS.has(extname(f).toLowerCase()) && photoPrecheck.get(f)?.route !== 'document'
+
   // #273: when files is 2-10 photos, batch them into a single
   // sendMediaGroup album rather than N separate sendPhoto calls. The
   // user's device fires one notification for the album instead of N
   // (notification-budget protection per the issue's JTBD note). Falls
   // back to the per-file path for any non-all-photo set.
   const allPhotos = files.length >= 2 && files.length <= 10
-    && files.every((f) => PHOTO_EXTS.has(extname(f).toLowerCase()))
+    && files.every(sendableAsPhoto)
   // #1075: thread-id-bearing file sends. Mirror the chunk-loop's
   // THREAD_NOT_FOUND fallback (deleted topic → drop the thread and
   // resend on the main chat) so an attachment-bearing reply doesn't
@@ -12062,9 +12084,10 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     for (const m of sent) sentIds.push(m.message_id)
   } else {
     for (const f of files) {
-      const ext = extname(f).toLowerCase()
       const input = new InputFile(f)
-      const isPhoto = PHOTO_EXTS.has(ext)
+      // Photo-ext files that failed the pre-send probe route straight to
+      // sendDocument (see photoPrecheck above) instead of bouncing a 400.
+      const isPhoto = sendableAsPhoto(f)
       let sent: { message_id: number; message_thread_id?: number }
       try {
         sent = await retryWithThreadFallback<{ message_id: number; message_thread_id?: number }>(

--- a/telegram-plugin/photo-precheck.ts
+++ b/telegram-plugin/photo-precheck.ts
@@ -1,0 +1,157 @@
+/**
+ * photo-precheck.ts — pre-send validation for images attached via the
+ * reply tool's `files` param (#3033, layer 2 of the media-dimension
+ * defense-in-depth).
+ *
+ * Telegram's photo path (sendPhoto / sendMediaGroup type:photo) rejects
+ * images it can't store as photos with a 400 PHOTO_INVALID_DIMENSIONS /
+ * PHOTO_SAVE_FILE_INVALID. One bad photo fails a WHOLE sendMediaGroup
+ * album. The reactive fallback (#3022) re-sends as documents after the
+ * 400 bounces back — this module catches the offenders BEFORE the wire
+ * so good photos still ship as an album and the bad one goes out as a
+ * document on the first attempt.
+ *
+ * Bounds (deterministic, documented):
+ *   - width + height ≤ 10000 px      (Bot API documented cap)
+ *   - aspect ratio   ≤ 10 : 1        (docs say 20:1, but the 2026-07-11
+ *     clerk incident had 600x8717 — ratio 14.5:1, sum 9317 — rejected
+ *     with PHOTO_INVALID_DIMENSIONS, so the documented limit is not what
+ *     the server enforces for uploads. 10:1 is conservative: real phone
+ *     screenshots are ≤ ~2.5:1; only page-length capture strips exceed
+ *     10:1 territory, and those are better as documents anyway.)
+ *   - file size      ≤ 10 MB         (photo-path ceiling; documents 50MB)
+ *
+ * Probe failures (unknown/truncated format) return null and the caller
+ * keeps the photo path — the reactive #3022 fallback still backstops.
+ * No image decoding, no deps: header-only parsers for PNG / JPEG / GIF /
+ * WebP, the formats behind the gateway's PHOTO_EXTS set.
+ */
+
+import { readFileSync, statSync } from 'node:fs'
+
+export interface ImageProbe {
+  width: number
+  height: number
+  bytes: number
+}
+
+/** Photo-path bounds — see module header for provenance. */
+export const PHOTO_MAX_DIMENSION_SUM = 10000
+export const PHOTO_MAX_ASPECT_RATIO = 10
+export const PHOTO_MAX_BYTES = 10 * 1024 * 1024
+
+/** Parse PNG dimensions: 8-byte signature then IHDR (width/height BE at 16/20). */
+function pngDimensions(buf: Buffer): { width: number; height: number } | null {
+  if (buf.length < 24) return null
+  if (buf.readUInt32BE(0) !== 0x89504e47 || buf.readUInt32BE(4) !== 0x0d0a1a0a) return null
+  if (buf.toString('ascii', 12, 16) !== 'IHDR') return null
+  return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) }
+}
+
+/** Parse JPEG dimensions: walk markers to the first SOFn frame header. */
+function jpegDimensions(buf: Buffer): { width: number; height: number } | null {
+  if (buf.length < 4 || buf[0] !== 0xff || buf[1] !== 0xd8) return null
+  let off = 2
+  while (off + 9 < buf.length) {
+    if (buf[off] !== 0xff) { off++; continue }
+    const marker = buf[off + 1]!
+    // Standalone markers without a length segment.
+    if (marker === 0xd8 || (marker >= 0xd0 && marker <= 0xd7) || marker === 0x01 || marker === 0xff) {
+      off += 2
+      continue
+    }
+    const len = buf.readUInt16BE(off + 2)
+    // SOF0-SOF15 (excluding DHT 0xc4, JPG 0xc8, DAC 0xcc) carry dimensions.
+    if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
+      return { height: buf.readUInt16BE(off + 5), width: buf.readUInt16BE(off + 7) }
+    }
+    if (len < 2) return null
+    off += 2 + len
+  }
+  return null
+}
+
+/** Parse GIF dimensions (logical screen descriptor, LE at offset 6/8). */
+function gifDimensions(buf: Buffer): { width: number; height: number } | null {
+  if (buf.length < 10) return null
+  const sig = buf.toString('ascii', 0, 6)
+  if (sig !== 'GIF87a' && sig !== 'GIF89a') return null
+  return { width: buf.readUInt16LE(6), height: buf.readUInt16LE(8) }
+}
+
+/** Parse WebP dimensions (VP8 / VP8L / VP8X chunk variants). */
+function webpDimensions(buf: Buffer): { width: number; height: number } | null {
+  if (buf.length < 30) return null
+  if (buf.toString('ascii', 0, 4) !== 'RIFF' || buf.toString('ascii', 8, 12) !== 'WEBP') return null
+  const chunk = buf.toString('ascii', 12, 16)
+  if (chunk === 'VP8X') {
+    // 24-bit LE minus-one canvas dimensions at 24/27.
+    const width = 1 + (buf[24]! | (buf[25]! << 8) | (buf[26]! << 16))
+    const height = 1 + (buf[27]! | (buf[28]! << 8) | (buf[29]! << 16))
+    return { width, height }
+  }
+  if (chunk === 'VP8L') {
+    if (buf[20] !== 0x2f) return null
+    const b0 = buf[21]!, b1 = buf[22]!, b2 = buf[23]!, b3 = buf[24]!
+    const width = 1 + (((b1 & 0x3f) << 8) | b0)
+    const height = 1 + (((b3 & 0x0f) << 10) | (b2 << 2) | ((b1 & 0xc0) >> 6))
+    return { width, height }
+  }
+  if (chunk === 'VP8 ') {
+    // Lossy: frame tag at 20; sync code 9d 01 2a then 14-bit LE dims.
+    if (buf[23] !== 0x9d || buf[24] !== 0x01 || buf[25] !== 0x2a) return null
+    const width = buf.readUInt16LE(26) & 0x3fff
+    const height = buf.readUInt16LE(28) & 0x3fff
+    return { width, height }
+  }
+  return null
+}
+
+/** Header-only dimension probe. Returns null when the format is unrecognized. */
+export function probeImageDimensions(buf: Buffer): { width: number; height: number } | null {
+  return pngDimensions(buf) ?? jpegDimensions(buf) ?? gifDimensions(buf) ?? webpDimensions(buf)
+}
+
+/** Probe an image file on disk. Returns null on read failure or unknown format. */
+export function probeImageFile(path: string): ImageProbe | null {
+  try {
+    const bytes = statSync(path).size
+    const dims = probeImageDimensions(readFileSync(path))
+    if (!dims || dims.width <= 0 || dims.height <= 0) return null
+    return { ...dims, bytes }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Why this image cannot go down Telegram's photo path — or null when it
+ * fits the bounds. The reason string is operator/agent-legible (it lands
+ * in the gateway log and, via the reactive path, in tool errors).
+ */
+export function photoSendViolation(probe: ImageProbe): string | null {
+  const { width, height, bytes } = probe
+  if (width + height > PHOTO_MAX_DIMENSION_SUM) {
+    return `dimensions ${width}x${height} exceed width+height<=${PHOTO_MAX_DIMENSION_SUM}`
+  }
+  const ratio = Math.max(width, height) / Math.min(width, height)
+  if (ratio > PHOTO_MAX_ASPECT_RATIO) {
+    return `aspect ratio ${ratio.toFixed(1)}:1 (${width}x${height}) exceeds ${PHOTO_MAX_ASPECT_RATIO}:1 photo bound`
+  }
+  if (bytes > PHOTO_MAX_BYTES) {
+    return `file size ${(bytes / (1024 * 1024)).toFixed(1)}MB exceeds ${PHOTO_MAX_BYTES / (1024 * 1024)}MB photo ceiling`
+  }
+  return null
+}
+
+/**
+ * Decide the send route for a photo-extension file. `photo` = safe for
+ * sendPhoto/sendMediaGroup; `document` = pre-route as document (reason
+ * says why); probe failure = `photo` (reactive #3022 fallback backstops).
+ */
+export function classifyPhotoFile(path: string): { route: 'photo' } | { route: 'document'; reason: string } {
+  const probe = probeImageFile(path)
+  if (!probe) return { route: 'photo' }
+  const violation = photoSendViolation(probe)
+  return violation ? { route: 'document', reason: violation } : { route: 'photo' }
+}

--- a/telegram-plugin/tests/crash-breadcrumb.test.ts
+++ b/telegram-plugin/tests/crash-breadcrumb.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Pins the #3033 bridge crash-breadcrumb contract: uncaughtException /
+ * unhandledRejection in the bridge process persist a bounded, greppable
+ * line to bridge-crash.log (Claude Code drops MCP stderr after startup,
+ * so this file is the only durable trace of why a bridge died).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { appendCrashBreadcrumb } from '../bridge/crash-breadcrumb.js'
+
+function tmpLog(): string {
+  return join(mkdtempSync(join(tmpdir(), 'crash-bc-')), 'bridge-crash.log')
+}
+
+describe('appendCrashBreadcrumb', () => {
+  it('appends a single line with kind, pid and folded stack', () => {
+    const log = tmpLog()
+    const err = new Error('boom')
+    appendCrashBreadcrumb(log, 'uncaughtException', err, new Date('2026-07-11T01:40:59Z'))
+    const content = readFileSync(log, 'utf8')
+    const lines = content.trimEnd().split('\n')
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain('2026-07-11T01:40:59')
+    expect(lines[0]).toContain('uncaughtException')
+    expect(lines[0]).toContain(`pid=${process.pid}`)
+    expect(lines[0]).toContain('Error: boom')
+    expect(lines[0]).not.toContain('\n')
+  })
+
+  it('handles non-Error rejections and appends across calls', () => {
+    const log = tmpLog()
+    appendCrashBreadcrumb(log, 'unhandledRejection', 'string reason')
+    appendCrashBreadcrumb(log, 'unhandledRejection', { odd: true })
+    const lines = readFileSync(log, 'utf8').trimEnd().split('\n')
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toContain('string reason')
+  })
+
+  it('rotates once past the size cap instead of growing unbounded', () => {
+    const log = tmpLog()
+    writeFileSync(log, 'x'.repeat(1024 * 1024 + 1))
+    appendCrashBreadcrumb(log, 'uncaughtException', new Error('after rotation'))
+    expect(existsSync(`${log}.1`)).toBe(true)
+    const content = readFileSync(log, 'utf8')
+    expect(content).toContain('after rotation')
+    expect(content.length).toBeLessThan(5000)
+  })
+
+  it('never throws when the path is unwritable', () => {
+    expect(() =>
+      appendCrashBreadcrumb('/nonexistent-dir-xyz/bridge-crash.log', 'uncaughtException', new Error('x')),
+    ).not.toThrow()
+  })
+})

--- a/telegram-plugin/tests/photo-precheck.test.ts
+++ b/telegram-plugin/tests/photo-precheck.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Pins the #3033 layer-2 pre-send photo validation:
+ *   1. header-only dimension probes for PNG / JPEG / GIF / WebP
+ *   2. the photo-path bounds (width+height cap, aspect-ratio cap, size cap)
+ *   3. classifyPhotoFile routing (violation → document; probe miss → photo)
+ *
+ * Incident anchor: clerk 2026-07-11 sent a 600x8717 newsletter screenshot
+ * in a media group — ratio 14.5:1, WITHIN the documented 20:1 Bot API
+ * limit — and Telegram rejected it with PHOTO_INVALID_DIMENSIONS, failing
+ * the whole album. The bounds here must classify that image as a document.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  probeImageDimensions,
+  probeImageFile,
+  photoSendViolation,
+  classifyPhotoFile,
+  PHOTO_MAX_BYTES,
+} from '../photo-precheck.js'
+
+function pngBuffer(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(33)
+  buf.writeUInt32BE(0x89504e47, 0)
+  buf.writeUInt32BE(0x0d0a1a0a, 4)
+  buf.writeUInt32BE(13, 8) // IHDR length
+  buf.write('IHDR', 12, 'ascii')
+  buf.writeUInt32BE(width, 16)
+  buf.writeUInt32BE(height, 20)
+  return buf
+}
+
+function jpegBuffer(width: number, height: number): Buffer {
+  // SOI, APP0 (JFIF stub), SOF0 with dimensions.
+  const app0 = Buffer.from([0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00])
+  const sof0 = Buffer.alloc(2 + 2 + 5 + 3)
+  sof0[0] = 0xff; sof0[1] = 0xc0
+  sof0.writeUInt16BE(10, 2) // segment length
+  sof0[4] = 8 // precision
+  sof0.writeUInt16BE(height, 5)
+  sof0.writeUInt16BE(width, 7)
+  sof0[9] = 1
+  return Buffer.concat([Buffer.from([0xff, 0xd8]), app0, sof0])
+}
+
+function gifBuffer(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(13)
+  buf.write('GIF89a', 0, 'ascii')
+  buf.writeUInt16LE(width, 6)
+  buf.writeUInt16LE(height, 8)
+  return buf
+}
+
+function webpVp8xBuffer(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(30)
+  buf.write('RIFF', 0, 'ascii')
+  buf.writeUInt32LE(22, 4)
+  buf.write('WEBP', 8, 'ascii')
+  buf.write('VP8X', 12, 'ascii')
+  buf.writeUInt32LE(10, 16)
+  const w = width - 1
+  const h = height - 1
+  buf[24] = w & 0xff; buf[25] = (w >> 8) & 0xff; buf[26] = (w >> 16) & 0xff
+  buf[27] = h & 0xff; buf[28] = (h >> 8) & 0xff; buf[29] = (h >> 16) & 0xff
+  return buf
+}
+
+describe('probeImageDimensions', () => {
+  it('reads PNG IHDR dimensions', () => {
+    expect(probeImageDimensions(pngBuffer(600, 8717))).toEqual({ width: 600, height: 8717 })
+  })
+
+  it('reads JPEG SOF0 dimensions past an APP0 segment', () => {
+    expect(probeImageDimensions(jpegBuffer(1179, 2556))).toEqual({ width: 1179, height: 2556 })
+  })
+
+  it('reads GIF logical screen dimensions', () => {
+    expect(probeImageDimensions(gifBuffer(320, 240))).toEqual({ width: 320, height: 240 })
+  })
+
+  it('reads WebP VP8X canvas dimensions', () => {
+    expect(probeImageDimensions(webpVp8xBuffer(1920, 1080))).toEqual({ width: 1920, height: 1080 })
+  })
+
+  it('returns null for unknown formats and truncated buffers', () => {
+    expect(probeImageDimensions(Buffer.from('not an image at all, sorry'))).toBeNull()
+    expect(probeImageDimensions(Buffer.from([0x89, 0x50]))).toBeNull()
+    expect(probeImageDimensions(Buffer.alloc(0))).toBeNull()
+  })
+})
+
+describe('photoSendViolation bounds', () => {
+  it('accepts a normal phone screenshot (1179x2556)', () => {
+    expect(photoSendViolation({ width: 1179, height: 2556, bytes: 500_000 })).toBeNull()
+  })
+
+  it('rejects the clerk incident image 600x8717 (ratio 14.5:1, within documented 20:1)', () => {
+    const v = photoSendViolation({ width: 600, height: 8717, bytes: 400_000 })
+    expect(v).toMatch(/aspect ratio/)
+  })
+
+  it('rejects width+height over 10000', () => {
+    const v = photoSendViolation({ width: 6000, height: 5000, bytes: 400_000 })
+    expect(v).toMatch(/width\+height/)
+  })
+
+  it('rejects files over the 10MB photo ceiling', () => {
+    const v = photoSendViolation({ width: 1000, height: 1000, bytes: PHOTO_MAX_BYTES + 1 })
+    expect(v).toMatch(/exceeds 10MB/)
+  })
+
+  it('accepts exactly-at-bound values', () => {
+    expect(photoSendViolation({ width: 5000, height: 5000, bytes: PHOTO_MAX_BYTES })).toBeNull()
+    expect(photoSendViolation({ width: 800, height: 8800, bytes: 1 })).toMatch(/aspect ratio/) // 11:1
+    expect(photoSendViolation({ width: 900, height: 9000, bytes: 1 })).toBeNull() // exactly 10:1
+  })
+})
+
+describe('probeImageFile + classifyPhotoFile', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'photo-precheck-'))
+
+  it('probes a PNG file on disk', () => {
+    const p = join(dir, 'tall.png')
+    writeFileSync(p, pngBuffer(600, 8717))
+    expect(probeImageFile(p)).toEqual({ width: 600, height: 8717, bytes: 33 })
+  })
+
+  it('routes an out-of-bounds photo to document with a reason', () => {
+    const p = join(dir, 'tall2.png')
+    writeFileSync(p, pngBuffer(600, 8717))
+    const cls = classifyPhotoFile(p)
+    expect(cls.route).toBe('document')
+    if (cls.route === 'document') expect(cls.reason).toMatch(/aspect ratio 14\.5:1/)
+  })
+
+  it('keeps an in-bounds photo on the photo route', () => {
+    const p = join(dir, 'ok.png')
+    writeFileSync(p, pngBuffer(1179, 2556))
+    expect(classifyPhotoFile(p)).toEqual({ route: 'photo' })
+  })
+
+  it('keeps the photo route when the file is unreadable or unrecognized (reactive fallback backstops)', () => {
+    expect(classifyPhotoFile(join(dir, 'missing.png'))).toEqual({ route: 'photo' })
+    const junk = join(dir, 'junk.png')
+    writeFileSync(junk, Buffer.from('definitely not a png'))
+    expect(classifyPhotoFile(junk)).toEqual({ route: 'photo' })
+  })
+})


### PR DESCRIPTION
## Summary
Closes the two defects from the 2026-07-11 clerk incident (#3033): a media-group send failing with `PHOTO_INVALID_DIMENSIONS`, and the agent-side MCP bridge staying dead after the supervisor's 1s gateway restart.

**Note on scope:** the reactive crash fix (tail-of-lane unhandledRejection swallow in chat-lock + photo→document fallback in both the per-file and album paths) already landed in #3022 / `2a9fe32b`. Clerk crashed on v0.18.9, which predates that merge — a deployment gap, not a missing fix. This PR adds the remaining defense layers plus the bridge finding/hardening.

## What's in this PR

**Layer 2 — gateway pre-send validation (`telegram-plugin/photo-precheck.ts`)**
Header-only dimension probes (PNG/JPEG/GIF/WebP, zero deps) run before `sendPhoto`/`sendMediaGroup`; out-of-bounds images are pre-routed as documents so one bad photo can't 400 a whole album. Bounds (documented in the module header): width+height ≤ 10000, aspect ratio ≤ 10:1, ≤ 10MB. Ratio bound is tighter than the documented 20:1 because the incident image (600x8717 — 14.5:1, sum 9317) was **within** the documented limits and Telegram rejected it anyway. Probe failure keeps the photo route; the #3022 reactive fallback backstops.

**Layer 1 — agent guidance**
The reply tool's `files` schema description now states the safe photo bounds and the auto-reroute behavior.

**Bridge-reconnect root cause + hardening**
Finding: the bridge's IPC reconnect loop is sound — reproduced re-registering across an 11s ECONNREFUSED window against a restarted gateway. The real failure: the **bridge process died** within seconds of the gateway crash. Clerk's session transcript shows `No such tool available: mcp__switchroom-telegram__reply` at 01:41:20Z — Claude Code removed the MCP server, which only happens when the server process is gone, and Claude Code never respawns a dead MCP server. The bridge handled `unhandledRejection` but not `uncaughtException`, and Claude Code drops MCP stderr after startup, so the fatal error left no trace. Fix: `uncaughtException` handler (log-and-continue — death is unrecoverable by design, the reconnect loop heals connection damage) + persistent breadcrumbs to `STATE_DIR/bridge-crash.log` (`bridge/crash-breadcrumb.ts`, 1MB rotation) so the next incident is diagnosable.

Gateway-side escalation (bounce the session when no bridge re-registers within a grace window) is structural — split to a follow-up issue.

## Why
An outbound send must never take the chat surface offline (vision: always available). Prevention beats reaction: albums deliver on the first attempt, and a bridge that would have died now survives and reconnects.

## Test plan
- `telegram-plugin/tests/photo-precheck.test.ts` — probe parsers, bounds (incl. the 600x8717 incident image), routing decisions
- `telegram-plugin/tests/crash-breadcrumb.test.ts` — append/rotate/never-throw
- Existing pins re-run green: `photo-dimension-fallback`, `chat-lock-unhandled-rejection` (vitest, 33 tests total), `ipc-server-client` + `gateway-bridge` (bun, 39 tests)
- `npm run lint` clean

## Risk
Low. Pre-check is additive and fails open (probe miss → old behavior). Bridge handlers only add logging/persistence on paths that previously killed the process.

Job spec: `reference/jobs/` — always-available chat surface; a bad outbound must never take the agent offline.

Fixes #3033

🤖 Generated with [Claude Code](https://claude.com/claude-code)