### PR TITLE
fix(telegram-plugin): photo-reroute polish follow-ups (#3038)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -187,7 +187,7 @@ import {
   retryWithThreadFallback,
   isPhotoDimensionRejectError,
 } from '../retry-api-call.js'
-import { classifyPhotoFile } from '../photo-precheck.js'
+import { classifyPhotoFile, rerouteResultSuffix } from '../photo-precheck.js'
 import { installTgPostLogger, withTgPostTags } from '../shared/bot-runtime.js'
 import { floodStatePath, makeFloodWaitRecorder } from '../flood-circuit-breaker.js'
 import { buildAttachmentPath, assertInsideInbox } from '../attachment-path.js'
@@ -12022,11 +12022,20 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // sends the offender as a document on the first attempt. Probe
   // failures keep the photo route; the reactive #3022 fallback backstops.
   const photoPrecheck = new Map<string, ReturnType<typeof classifyPhotoFile>>()
+  // #3038 polish: files that ultimately went out as documents despite a
+  // photo extension (precheck reroute or reactive fallback). Feeds two
+  // honesty surfaces: the reply tool result suffix (so the agent doesn't
+  // claim an inline image rendered) and attachment_kinds history (record
+  // what was actually sent).
+  const documentReroutes: Array<{ path: string; reason: string }> = []
+  const sentAsDocument = new Set<string>()
   for (const f of files) {
     if (!PHOTO_EXTS.has(extname(f).toLowerCase())) continue
     const cls = classifyPhotoFile(f)
     photoPrecheck.set(f, cls)
     if (cls.route === 'document') {
+      documentReroutes.push({ path: f, reason: cls.reason })
+      sentAsDocument.add(f)
       process.stderr.write(
         `telegram gateway: photo-precheck rerouting ${f} as document (${cls.reason})\n`,
       )
@@ -12040,6 +12049,12 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // user's device fires one notification for the album instead of N
   // (notification-budget protection per the issue's JTBD note). Falls
   // back to the per-file path for any non-all-photo set.
+  //
+  // #3038 known tradeoff: ONE precheck-rerouted photo in the set drops
+  // the WHOLE album to per-file sends — the user gets N notifications
+  // instead of 1. Deliberate: sendMediaGroup can't mix photo and
+  // document media, and a partial album plus a stray document is more
+  // confusing than N files. Revisit only if mixed albums become common.
   const allPhotos = files.length >= 2 && files.length <= 10
     && files.every(sendableAsPhoto)
   // #1075: thread-id-bearing file sends. Mirror the chunk-loop's
@@ -12097,7 +12112,12 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
         `falling back to per-file sendDocument\n`,
       )
       sent = []
-      for (const f of files) sent.push(await sendAsDocument(f))
+      const albumReason = 'Telegram rejected the photo album; whole album re-sent as documents'
+      for (const f of files) {
+        sent.push(await sendAsDocument(f))
+        sentAsDocument.add(f)
+        documentReroutes.push({ path: f, reason: albumReason })
+      }
     }
     if (threadId != null) {
       // If the fallback dropped the thread id, propagate that decision
@@ -12143,6 +12163,8 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
           `falling back to sendDocument\n`,
         )
         sent = await sendAsDocument(f)
+        sentAsDocument.add(f)
+        documentReroutes.push({ path: f, reason: 'Telegram rejected it as a photo; re-sent as document' })
       }
       // Mirror the threadId-clear above so the *next* file in the
       // loop skips the doomed thread without paying for another
@@ -12154,9 +12176,13 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     }
   }
 
-  const result = sentIds.length === 1
+  // #3038: surface photo→document reroutes in the tool result — the
+  // agent otherwise only "sees" success and may tell the user an inline
+  // image rendered when it went out as a file attachment.
+  const result = (sentIds.length === 1
     ? `sent (id: ${sentIds[0]})`
-    : `sent ${sentIds.length} parts (ids: ${sentIds.join(', ')})`
+    : `sent ${sentIds.length} parts (ids: ${sentIds.join(', ')})`)
+    + rerouteResultSuffix(documentReroutes)
 
   if (HISTORY_ENABLED && sentIds.length > 0) {
     try {
@@ -12166,9 +12192,14 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
       const attachKinds: (string | null)[] = []
       for (let i = 0; i < textCount; i++) { texts.push(chunks[i] ?? ''); attachKinds.push(null) }
       for (let i = 0; i < fileCount; i++) {
-        const ext = extname(files[i] ?? '').toLowerCase()
-        texts.push(`(${PHOTO_EXTS.has(ext) ? 'photo' : 'document'}: ${files[i]})`)
-        attachKinds.push(PHOTO_EXTS.has(ext) ? 'photo' : 'document')
+        const f = files[i] ?? ''
+        const ext = extname(f).toLowerCase()
+        // #3038: record what was ACTUALLY sent — a photo-extension file
+        // rerouted to sendDocument (precheck or reactive fallback) is a
+        // 'document' in history, not a 'photo' from its raw extension.
+        const kind = PHOTO_EXTS.has(ext) && !sentAsDocument.has(f) ? 'photo' : 'document'
+        texts.push(`(${kind}: ${f})`)
+        attachKinds.push(kind)
       }
       recordOutbound({ chat_id, thread_id: threadId ?? null, message_ids: sentIds, texts, attachment_kinds: attachKinds })
     } catch (err) {

--- a/telegram-plugin/photo-precheck.ts
+++ b/telegram-plugin/photo-precheck.ts
@@ -27,7 +27,7 @@
  * WebP, the formats behind the gateway's PHOTO_EXTS set.
  */
 
-import { readFileSync, statSync } from 'node:fs'
+import { closeSync, fstatSync, openSync, readSync } from 'node:fs'
 
 export interface ImageProbe {
   width: number
@@ -112,15 +112,44 @@ export function probeImageDimensions(buf: Buffer): { width: number; height: numb
   return pngDimensions(buf) ?? jpegDimensions(buf) ?? gifDimensions(buf) ?? webpDimensions(buf)
 }
 
+/**
+ * Fixed-size header reads — never readFileSync the whole image (a 10MB
+ * screenshot would be a multi-MB sync read on the event loop for a
+ * ~30-byte probe). PNG needs 24 bytes, GIF 10, WebP (VP8X/VP8L/VP8 )
+ * tops out at offset 30 — so 32 bytes covers every fixed-offset format.
+ * JPEG is the exception: SOFn sits past variable-length APPn segments
+ * (EXIF/ICC metadata), so when the 32-byte sniff says JPEG we re-read a
+ * 64KB window. If SOFn is buried deeper than that, the probe returns
+ * null and the caller keeps the photo route (#3022 reactive backstop).
+ */
+const HEADER_PROBE_BYTES = 32
+const JPEG_PROBE_BYTES = 64 * 1024
+
 /** Probe an image file on disk. Returns null on read failure or unknown format. */
 export function probeImageFile(path: string): ImageProbe | null {
+  let fd: number | undefined
   try {
-    const bytes = statSync(path).size
-    const dims = probeImageDimensions(readFileSync(path))
+    fd = openSync(path, 'r')
+    const bytes = fstatSync(fd).size
+    const headBuf = Buffer.alloc(HEADER_PROBE_BYTES)
+    const headRead = readSync(fd, headBuf, 0, HEADER_PROBE_BYTES, 0)
+    let probe = headBuf.subarray(0, headRead)
+    if (headRead >= 2 && probe[0] === 0xff && probe[1] === 0xd8) {
+      // JPEG: extend to a 64KB window so the marker walk can skip
+      // APPn metadata segments and reach SOFn.
+      const jpegBuf = Buffer.alloc(Math.min(JPEG_PROBE_BYTES, bytes))
+      const jpegRead = readSync(fd, jpegBuf, 0, jpegBuf.length, 0)
+      probe = jpegBuf.subarray(0, jpegRead)
+    }
+    const dims = probeImageDimensions(probe)
     if (!dims || dims.width <= 0 || dims.height <= 0) return null
     return { ...dims, bytes }
   } catch {
     return null
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd) } catch { /* best-effort */ }
+    }
   }
 }
 
@@ -142,6 +171,21 @@ export function photoSendViolation(probe: ImageProbe): string | null {
     return `file size ${(bytes / (1024 * 1024)).toFixed(1)}MB exceeds ${PHOTO_MAX_BYTES / (1024 * 1024)}MB photo ceiling`
   }
   return null
+}
+
+/**
+ * Suffix for the reply tool's result text when files were rerouted from
+ * the photo path to sendDocument (precheck or reactive fallback). The
+ * agent only sees the tool result — without this it may claim an inline
+ * image rendered when it actually went out as a file attachment.
+ * Returns '' when nothing was rerouted.
+ */
+export function rerouteResultSuffix(reroutes: Array<{ path: string; reason: string }>): string {
+  if (reroutes.length === 0) return ''
+  const details = reroutes
+    .map((r) => `${r.path.split('/').pop() ?? r.path}: ${r.reason}`)
+    .join('; ')
+  return ` (${reroutes.length} file(s) sent as document, not inline photo: ${details})`
 }
 
 /**

--- a/telegram-plugin/tests/photo-precheck.test.ts
+++ b/telegram-plugin/tests/photo-precheck.test.ts
@@ -19,6 +19,7 @@ import {
   probeImageFile,
   photoSendViolation,
   classifyPhotoFile,
+  rerouteResultSuffix,
   PHOTO_MAX_BYTES,
 } from '../photo-precheck.js'
 
@@ -142,10 +143,98 @@ describe('probeImageFile + classifyPhotoFile', () => {
     expect(classifyPhotoFile(p)).toEqual({ route: 'photo' })
   })
 
+  // #3038 item 3 — probeImageFile now does fixed-size header reads
+  // (openSync + 32 bytes; 64KB window for JPEG) instead of readFileSync.
+  // Pin correctness on the same fixture set across every format.
+  it('probes JPEG / GIF / WebP files on disk (fixed-size read path)', () => {
+    const j = join(dir, 'shot.jpg')
+    writeFileSync(j, jpegBuffer(1179, 2556))
+    expect(probeImageFile(j)).toMatchObject({ width: 1179, height: 2556 })
+
+    const g = join(dir, 'anim.gif')
+    writeFileSync(g, gifBuffer(320, 240))
+    expect(probeImageFile(g)).toMatchObject({ width: 320, height: 240 })
+
+    const w = join(dir, 'pic.webp')
+    writeFileSync(w, webpVp8xBuffer(1920, 1080))
+    expect(probeImageFile(w)).toMatchObject({ width: 1920, height: 1080 })
+  })
+
+  it('probes the 600x8717 incident image without reading the whole multi-MB file', () => {
+    // Header + 5MB of body: the probe must report full file size but
+    // still read dimensions from the fixed-size header window.
+    const p = join(dir, 'incident.png')
+    const body = Buffer.alloc(5 * 1024 * 1024)
+    writeFileSync(p, Buffer.concat([pngBuffer(600, 8717), body]))
+    const probe = probeImageFile(p)
+    expect(probe).toEqual({ width: 600, height: 8717, bytes: 33 + body.length })
+    expect(classifyPhotoFile(p).route).toBe('document')
+  })
+
+  it('finds JPEG SOFn past a large metadata segment (within the 64KB window)', () => {
+    // SOI + a 40KB APP1 (EXIF-sized) segment, then SOF0. The 32-byte
+    // sniff alone cannot see SOF0; the JPEG re-read must.
+    const segLen = 40 * 1024
+    const app1 = Buffer.alloc(2 + 2 + segLen)
+    app1[0] = 0xff; app1[1] = 0xe1
+    app1.writeUInt16BE(2 + segLen, 2)
+    const sof0 = Buffer.alloc(10)
+    sof0[0] = 0xff; sof0[1] = 0xc0
+    sof0.writeUInt16BE(8, 2)
+    sof0[4] = 8
+    sof0.writeUInt16BE(2556, 5)
+    sof0.writeUInt16BE(1179, 7)
+    const p = join(dir, 'exif.jpg')
+    writeFileSync(p, Buffer.concat([Buffer.from([0xff, 0xd8]), app1, sof0]))
+    expect(probeImageFile(p)).toMatchObject({ width: 1179, height: 2556 })
+  })
+
+  it('returns null (photo route kept) when JPEG SOFn is beyond the 64KB window', () => {
+    // Two 40KB APPn segments push SOF0 past the 64KB probe window
+    // (a single segment length is 16-bit capped at 65535).
+    const segLen = 40 * 1024
+    const app1 = Buffer.alloc(2 + 2 + segLen)
+    app1[0] = 0xff; app1[1] = 0xe1
+    app1.writeUInt16BE(2 + segLen, 2)
+    const sof0 = Buffer.alloc(10)
+    sof0[0] = 0xff; sof0[1] = 0xc0
+    sof0.writeUInt16BE(8, 2)
+    sof0[4] = 8
+    sof0.writeUInt16BE(8717, 5)
+    sof0.writeUInt16BE(600, 7)
+    const p = join(dir, 'deep-exif.jpg')
+    writeFileSync(p, Buffer.concat([Buffer.from([0xff, 0xd8]), app1, app1, sof0]))
+    expect(probeImageFile(p)).toBeNull()
+    // Probe miss → photo route → #3022 reactive fallback backstops.
+    expect(classifyPhotoFile(p)).toEqual({ route: 'photo' })
+  })
+
   it('keeps the photo route when the file is unreadable or unrecognized (reactive fallback backstops)', () => {
     expect(classifyPhotoFile(join(dir, 'missing.png'))).toEqual({ route: 'photo' })
     const junk = join(dir, 'junk.png')
     writeFileSync(junk, Buffer.from('definitely not a png'))
     expect(classifyPhotoFile(junk)).toEqual({ route: 'photo' })
+  })
+})
+
+describe('rerouteResultSuffix (#3038 — reply result tells the agent about reroutes)', () => {
+  it('returns empty string when nothing was rerouted', () => {
+    expect(rerouteResultSuffix([])).toBe('')
+  })
+
+  it('formats a single reroute with basename and reason', () => {
+    const s = rerouteResultSuffix([
+      { path: '/tmp/x/tall.png', reason: 'aspect ratio 14.5:1 (600x8717) exceeds 10:1 photo bound' },
+    ])
+    expect(s).toBe(' (1 file(s) sent as document, not inline photo: tall.png: aspect ratio 14.5:1 (600x8717) exceeds 10:1 photo bound)')
+  })
+
+  it('joins multiple reroutes and counts them', () => {
+    const s = rerouteResultSuffix([
+      { path: '/a/one.png', reason: 'r1' },
+      { path: '/b/two.jpg', reason: 'r2' },
+    ])
+    expect(s).toMatch(/^ \(2 file\(s\) sent as document/)
+    expect(s).toContain('one.png: r1; two.jpg: r2')
   })
 })

--- a/telegram-plugin/tests/photo-reroute-wiring.test.ts
+++ b/telegram-plugin/tests/photo-reroute-wiring.test.ts
@@ -1,0 +1,85 @@
+/**
+ * #3038 polish — pins the gateway wiring for the photo→document reroute
+ * honesty surfaces added after PR #3037:
+ *
+ *   1. executeReply's tool result appends `rerouteResultSuffix(...)` so
+ *      the agent learns files went out as documents, not inline photos
+ *      (it otherwise only sees "sent (id: N)" and may tell the user an
+ *      inline screenshot rendered).
+ *   2. attachment_kinds history records what was ACTUALLY sent: a
+ *      photo-extension file in the `sentAsDocument` set is recorded as
+ *      'document', covering both the precheck reroute and the #3022
+ *      reactive fallback paths.
+ *
+ * The gateway IIFE is too entangled to instantiate in-process; source-
+ * level assertions follow the `buffer-gate-broadened.test.ts` pattern.
+ * The pure formatting/probe logic is unit-tested in
+ * `photo-precheck.test.ts`.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const gatewaySrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf-8',
+)
+
+// Slice executeReply's file-send + result + history block: from the
+// photo-precheck anchor to the recordOutbound call for replies.
+const sliceStart = gatewaySrc.indexOf('const photoPrecheck = new Map')
+const sliceEnd = gatewaySrc.indexOf('history recordOutbound (reply) failed')
+const slice = gatewaySrc.slice(sliceStart, sliceEnd)
+
+describe('reroute signal reaches the reply tool result (#3038 item 1)', () => {
+  it('slices resolve (anchors present in executeReply)', () => {
+    expect(sliceStart).toBeGreaterThan(-1)
+    expect(sliceEnd).toBeGreaterThan(sliceStart)
+  })
+
+  it('imports rerouteResultSuffix from photo-precheck', () => {
+    expect(gatewaySrc).toMatch(/import \{ classifyPhotoFile, rerouteResultSuffix \} from '\.\.\/photo-precheck\.js'/)
+  })
+
+  it('appends rerouteResultSuffix(documentReroutes) to the result text', () => {
+    // The suffix must be part of the `result` expression the tool returns.
+    const resultIdx = slice.indexOf('const result =')
+    expect(resultIdx).toBeGreaterThan(-1)
+    const resultExpr = slice.slice(resultIdx, slice.indexOf('\n\n', resultIdx))
+    expect(resultExpr).toContain('rerouteResultSuffix(documentReroutes)')
+  })
+
+  it('precheck reroutes populate documentReroutes AND sentAsDocument', () => {
+    const precheckBlock = slice.slice(0, slice.indexOf('sendableAsPhoto ='))
+    expect(precheckBlock).toContain("if (cls.route === 'document')")
+    expect(precheckBlock).toContain('documentReroutes.push({ path: f, reason: cls.reason })')
+    expect(precheckBlock).toContain('sentAsDocument.add(f)')
+  })
+
+  it('reactive fallbacks (album + per-file, #3022) also record the reroute', () => {
+    // Album-wide fallback loop.
+    const albumIdx = slice.indexOf('albumReason')
+    expect(albumIdx).toBeGreaterThan(-1)
+    // Per-file sendPhoto→sendDocument fallback: sendAsDocument followed by
+    // both bookkeeping calls.
+    const perFile = slice.indexOf('sent = await sendAsDocument(f)')
+    expect(perFile).toBeGreaterThan(-1)
+    const afterPerFile = slice.slice(perFile, perFile + 400)
+    expect(afterPerFile).toContain('sentAsDocument.add(f)')
+    expect(afterPerFile).toContain('documentReroutes.push')
+  })
+})
+
+describe('attachment_kinds records what was actually sent (#3038 item 2)', () => {
+  it('history kind consults sentAsDocument, not just the raw extension', () => {
+    const historyIdx = slice.indexOf('const attachKinds')
+    expect(historyIdx).toBeGreaterThan(-1)
+    const historyBlock = slice.slice(historyIdx)
+    expect(historyBlock).toContain("PHOTO_EXTS.has(ext) && !sentAsDocument.has(f) ? 'photo' : 'document'")
+    // Both the human-readable text label and the kinds array use the
+    // resolved kind.
+    expect(historyBlock).toMatch(/texts\.push\(`\(\$\{kind\}/)
+    expect(historyBlock).toContain('attachKinds.push(kind)')
+  })
+})


### PR DESCRIPTION
## Summary
Small polish items from PR #3037's review, recorded on #3038. Does NOT touch the structural bridge-escalation work (separate owner) — no bridge lifecycle, IPC registration, or gateway restart machinery.

## What's in this PR
1. **Reroute signal in the reply tool result** — when the photo-precheck (or the reactive #3022 fallback) reroutes a photo-extension file to `sendDocument`, the tool result now appends `(N file(s) sent as document, not inline photo: <basename>: <reason>)`. Previously the agent only saw `sent (id: N)` and could claim an inline screenshot rendered when it went out as a file.
2. **Honest attachment_kinds history** — a rerouted file is recorded as `document` (what was actually sent), not `photo` from its raw extension. Covers the precheck reroute AND both reactive fallback paths (per-file and album-wide).
3. **Fixed-size probe reads** — `probeImageFile` now uses `openSync` + a 32-byte header read (covers PNG/GIF/WebP max offset 30) with a 64KB re-read for JPEG (SOFn sits past variable APPn metadata), instead of `readFileSync`-ing a potentially multi-MB image synchronously on the event loop. JPEG SOFn beyond 64KB → probe returns null → photo route kept → #3022 reactive backstop (pinned by test).
4. **Album degradation comment** — documents the one-rerouted-photo-drops-album-to-N-notifications tradeoff at the `allPhotos` decision. Behavior unchanged.

## Why
Vision: feel like a colleague — an agent that tells the user 'screenshot attached inline' when Telegram got a file attachment is confabulating its own output. Job spec: `reference/jobs/deliver-files-i-can-open.md` (files land as something the user can open, and the agent describes them honestly).

## Test plan
- `telegram-plugin/tests/photo-precheck.test.ts` — extended: fixed-read probe correctness on the full fixture set (PNG/JPEG/GIF/WebP on disk, the 600x8717 incident image behind 5MB of body, JPEG SOFn past 40KB EXIF, SOFn beyond the 64KB window → null), `rerouteResultSuffix` formatting.
- `telegram-plugin/tests/photo-reroute-wiring.test.ts` — new source-level pins (buffer-gate-broadened pattern): result text appends the suffix; precheck + both reactive fallbacks populate `documentReroutes`/`sentAsDocument`; history kind consults `sentAsDocument`.
- `photo-dimension-fallback.test.ts` re-run green; `npm run lint` clean (37 scoped tests pass).

## Risk
Low. Additive result-text suffix, history-kind correction, and an I/O-shape change in the probe that fails open (probe miss → photo route → reactive backstop).

Refs #3038

🤖 Generated with [Claude Code](https://claude.com/claude-code)