### PR TITLE
feat(gateway): bridge-dead watchdog — escalate when no MCP bridge registers

### DIFF
--- a/telegram-plugin/gateway/bridge-dead-watchdog.ts
+++ b/telegram-plugin/gateway/bridge-dead-watchdog.ts
@@ -1,0 +1,375 @@
+/**
+ * bridge-dead-watchdog.ts — gateway-side escalation when the MCP bridge
+ * never (re)registers (#3038, follow-up to #3033 / PR #3037).
+ *
+ * Failure mode: the gateway crashes and its supervisor relaunches it in
+ * ~1s, but the bridge MCP-server process inside the RUNNING claude
+ * session dies with it. Claude Code never respawns a dead MCP server, so
+ * the session stays alive but toolless and mute ("No such tool
+ * available: mcp__switchroom-telegram__reply") while the gateway sits at
+ * `bridge_dead` buffering inbounds — in the 2026-07-11 clerk incident,
+ * 7 minutes of a mute agent until a manual container restart.
+ *
+ * PR #3037 hardened the bridge against dying (uncaughtException handler
+ * + crash breadcrumbs to STATE_DIR/bridge-crash.log). This module is the
+ * structural belt-and-braces: after gateway boot (or after a main-bridge
+ * disconnect), if no main-agent bridge registers within a grace window
+ * while the claude session process is demonstrably alive, escalate by
+ * bouncing the whole container via the existing self-restart machinery
+ * (`triggerSelfRestart`) with the distinct reason
+ * `bridge-dead-resume`. The container restart respawns claude, which
+ * respawns the MCP bridge — the only recovery path that exists.
+ *
+ * Guard rails:
+ *   - at most ONE escalation per gateway boot (a bridge that dies
+ *     deterministically at startup must not restart-loop the agent);
+ *   - skipped while the gateway is mid-shutdown;
+ *   - skipped when the claude session process is NOT alive (that is a
+ *     different failure class — container boot still in progress, or
+ *     claude itself down — where a bounce is either premature or
+ *     futile); the timer re-arms so a slow-booting claude gets the full
+ *     grace window again once it appears;
+ *   - loud, structured escalation log line including a fresh
+ *     bridge-crash.log tail (PR #3037 breadcrumbs) so the operator sees
+ *     WHY from the supervisor log alone.
+ *
+ * Honest resume: before firing the restart, the watchdog persists an
+ * escalation marker (`STATE_DIR/bridge-dead-escalation.json`). The next
+ * boot's resume-inbound block reads it and appends the real cause to the
+ * synthetic resume inbound, so the agent tells the user "my chat bridge
+ * died and the framework restarted me" instead of implying a watchdog
+ * timeout or an operator restart.
+ *
+ * Pure-ish module: all IO (fs, timers, process liveness, restart) is
+ * injected so the decision logic and the controller are unit-testable
+ * without booting a gateway.
+ */
+
+import { readFileSync, writeFileSync, renameSync, unlinkSync } from 'node:fs'
+
+/** The distinct triggerSelfRestart reason for this escalation. Classified
+ *  as intent 'keep' by intentForRestartReason (recovery bounce — session
+ *  model stickiness preserved), like every other switchroom-managed
+ *  relaunch. */
+export const BRIDGE_DEAD_RESTART_REASON = 'bridge-dead-resume'
+
+/** Default grace window before a missing bridge is treated as dead.
+ *  Override with SWITCHROOM_BRIDGE_DEAD_GRACE_MS. Chosen well above the
+ *  normal boot register time (bridge registers within ~1-5s of claude
+ *  start) but well below the 7-minute mute window of the incident. */
+export const DEFAULT_BRIDGE_DEAD_GRACE_MS = 90_000
+
+/** Escalation marker freshness window at next boot. A marker older than
+ *  this is stale debris (the escalated restart happened long ago or never
+ *  completed) — cleared without surfacing. */
+export const ESCALATION_MARKER_MAX_AGE_MS = 10 * 60_000
+
+/** Crash-breadcrumb entries older than this are not "fresh" — they refer
+ *  to some earlier incident and would mislead the escalation log line. */
+export const CRASH_LOG_FRESH_WINDOW_MS = 15 * 60_000
+
+/** Max breadcrumb lines quoted into the escalation log / marker. */
+const CRASH_LOG_TAIL_LINES = 3
+
+// ─── Pure decision ───────────────────────────────────────────────────────────
+
+export interface BridgeDeadSnapshot {
+  /** A real (named, non-cron) bridge is currently registered. */
+  bridgeRegistered: boolean
+  /** The claude session process exists in the container. */
+  sessionAlive: boolean
+  /** The gateway is mid-shutdown (SIGTERM/SIGINT handler ran). */
+  shuttingDown: boolean
+  /** This gateway boot already fired the one allowed escalation. */
+  alreadyEscalated: boolean
+}
+
+export type BridgeDeadDecision =
+  | { action: 'escalate' }
+  | {
+      action: 'skip'
+      why: 'bridge-registered' | 'shutting-down' | 'already-escalated'
+    }
+  | { action: 'retry'; why: 'session-not-alive' }
+
+/**
+ * Decide what the watchdog should do when the grace window expires.
+ * Precedence, highest first: a live bridge always wins; a shutdown in
+ * progress must never be raced by a restart; the once-per-boot fuse is
+ * checked before anything fires; a missing claude process re-arms rather
+ * than escalating (bouncing a container whose claude never came up would
+ * loop without fixing anything — and a container still booting deserves
+ * the full grace window once claude appears).
+ */
+export function decideBridgeDeadEscalation(s: BridgeDeadSnapshot): BridgeDeadDecision {
+  if (s.bridgeRegistered) return { action: 'skip', why: 'bridge-registered' }
+  if (s.shuttingDown) return { action: 'skip', why: 'shutting-down' }
+  if (s.alreadyEscalated) return { action: 'skip', why: 'already-escalated' }
+  if (!s.sessionAlive) return { action: 'retry', why: 'session-not-alive' }
+  return { action: 'escalate' }
+}
+
+// ─── Crash-breadcrumb tail (PR #3037 integration) ────────────────────────────
+
+/**
+ * Read the fresh tail of STATE_DIR/bridge-crash.log. Returns the last few
+ * breadcrumb lines whose leading ISO timestamp is within
+ * `freshWindowMs` of `nowMs`, joined with " || " (single log line —
+ * greppable, bounded). Returns null when the file is missing, unreadable,
+ * or has no fresh entries. Never throws.
+ */
+export function readFreshCrashLogTail(
+  path: string,
+  opts: {
+    nowMs?: number
+    freshWindowMs?: number
+    maxLines?: number
+    readFile?: (p: string) => string
+  } = {},
+): string | null {
+  const nowMs = opts.nowMs ?? Date.now()
+  const freshWindowMs = opts.freshWindowMs ?? CRASH_LOG_FRESH_WINDOW_MS
+  const maxLines = opts.maxLines ?? CRASH_LOG_TAIL_LINES
+  const readFile = opts.readFile ?? ((p: string) => readFileSync(p, 'utf8'))
+  let raw: string
+  try {
+    raw = readFile(path)
+  } catch {
+    return null
+  }
+  const fresh = raw
+    .split('\n')
+    .filter((line) => {
+      const m = line.match(/^(\d{4}-\d{2}-\d{2}T[0-9:.]+Z)\s/)
+      if (!m) return false
+      const t = Date.parse(m[1])
+      return Number.isFinite(t) && nowMs - t >= 0 && nowMs - t <= freshWindowMs
+    })
+    .slice(-maxLines)
+  if (fresh.length === 0) return null
+  // Bound each quoted line — breadcrumbs are already capped at 4000 chars
+  // by the bridge, but one escalation log line quoting 3×4000 is noise.
+  return fresh.map((l) => l.slice(0, 500)).join(' || ')
+}
+
+// ─── Escalation marker (honest boot-resume cause) ────────────────────────────
+
+export interface BridgeDeadEscalationMarker {
+  /** Wall-clock ms when the escalation fired. */
+  ts: number
+  /** Always BRIDGE_DEAD_RESTART_REASON — kept in the file for grep-ability. */
+  reason: string
+  /** Fresh crash-breadcrumb tail at escalation time, if any. */
+  crashTail?: string
+}
+
+export function writeBridgeDeadEscalationMarker(
+  path: string,
+  marker: BridgeDeadEscalationMarker,
+): void {
+  // Atomic tmp+rename so a partial write can't be read back as malformed
+  // JSON by the next boot (same discipline as clean-shutdown-marker.ts).
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`
+  writeFileSync(tmp, JSON.stringify(marker), 'utf8')
+  renameSync(tmp, path)
+}
+
+/**
+ * Read + consume the escalation marker at boot. Returns the marker only
+ * when it is fresh (< maxAgeMs); a stale or malformed marker is cleared
+ * and ignored. The file is ALWAYS removed — the cause note must surface
+ * on exactly the boot that follows the escalation, never a later one.
+ */
+export function consumeBridgeDeadEscalationMarker(
+  path: string,
+  nowMs: number = Date.now(),
+  maxAgeMs: number = ESCALATION_MARKER_MAX_AGE_MS,
+): BridgeDeadEscalationMarker | null {
+  let marker: BridgeDeadEscalationMarker | null = null
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<BridgeDeadEscalationMarker>
+    if (
+      typeof parsed.ts === 'number' &&
+      Number.isFinite(parsed.ts) &&
+      typeof parsed.reason === 'string'
+    ) {
+      const age = nowMs - parsed.ts
+      if (age >= 0 && age < maxAgeMs) {
+        marker = { ts: parsed.ts, reason: parsed.reason }
+        if (typeof parsed.crashTail === 'string') marker.crashTail = parsed.crashTail
+      }
+    }
+  } catch {
+    /* missing or malformed — nothing to surface */
+  }
+  try {
+    unlinkSync(path)
+  } catch {
+    /* best effort */
+  }
+  return marker
+}
+
+// ─── Watchdog controller ─────────────────────────────────────────────────────
+
+export interface BridgeDeadWatchdogOpts {
+  /** Grace window before a missing bridge is treated as dead. */
+  graceMs: number
+  /** Is the claude session process alive in this container? */
+  isSessionAlive: () => boolean
+  /** Is the gateway mid-shutdown? */
+  isShuttingDown: () => boolean
+  /** Fire the container bounce (triggerSelfRestart wrapper). Returns
+   *  whether the restart was actually dispatched. */
+  escalate: (reason: string) => boolean
+  /** STATE_DIR/bridge-crash.log — PR #3037 breadcrumbs. */
+  crashLogPath: string
+  /** STATE_DIR/bridge-dead-escalation.json — honest-resume marker. */
+  markerPath: string
+  /** Structured log sink (stderr). */
+  log: (line: string) => void
+  /** Injectable timer pair for tests. Defaults to global setTimeout with
+   *  unref (the watchdog must never keep the gateway process alive). */
+  setTimer?: (fn: () => void, ms: number) => unknown
+  clearTimer?: (handle: unknown) => void
+  /** Injectable clock (marker ts + crash-log freshness). */
+  nowMs?: () => number
+  /** Injectable marker writer (tests avoid real fs). */
+  writeMarker?: (path: string, marker: BridgeDeadEscalationMarker) => void
+  /** Injectable crash-log reader (tests avoid real fs). */
+  readCrashTail?: (path: string, nowMs: number) => string | null
+}
+
+export interface BridgeDeadWatchdog {
+  /** Arm the grace timer (gateway boot). Idempotent while armed. */
+  arm: () => void
+  /** A real (named, non-cron) bridge registered — cancel the timer. */
+  noteBridgeRegistered: () => void
+  /** The real bridge disconnected mid-life — re-arm the grace timer so a
+   *  bridge that dies AFTER boot (and never reconnects) also escalates.
+   *  Still capped by the once-per-boot fuse. */
+  noteBridgeDisconnected: () => void
+  /** Evaluate now (the timer body — exposed for tests). Returns the
+   *  decision taken. */
+  check: () => BridgeDeadDecision
+  /** Cancel any pending timer (gateway shutdown). */
+  stop: () => void
+  /** Test/introspection: has this boot escalated already? */
+  hasEscalated: () => boolean
+}
+
+export function createBridgeDeadWatchdog(opts: BridgeDeadWatchdogOpts): BridgeDeadWatchdog {
+  const setTimer =
+    opts.setTimer ??
+    ((fn: () => void, ms: number) => {
+      const t = setTimeout(fn, ms)
+      t.unref?.()
+      return t
+    })
+  const clearTimer = opts.clearTimer ?? ((h: unknown) => clearTimeout(h as NodeJS.Timeout))
+  const nowMs = opts.nowMs ?? (() => Date.now())
+  const writeMarker = opts.writeMarker ?? writeBridgeDeadEscalationMarker
+  const readCrashTail =
+    opts.readCrashTail ?? ((p: string, t: number) => readFreshCrashLogTail(p, { nowMs: t }))
+
+  let timer: unknown = null
+  let bridgeRegistered = false
+  let escalated = false
+
+  const cancel = (): void => {
+    if (timer != null) {
+      clearTimer(timer)
+      timer = null
+    }
+  }
+
+  const armInternal = (): void => {
+    if (escalated) return // once-per-boot fuse — never re-arm after firing
+    cancel()
+    timer = setTimer(() => {
+      timer = null
+      check()
+    }, opts.graceMs)
+  }
+
+  const check = (): BridgeDeadDecision => {
+    const decision = decideBridgeDeadEscalation({
+      bridgeRegistered,
+      sessionAlive: opts.isSessionAlive(),
+      shuttingDown: opts.isShuttingDown(),
+      alreadyEscalated: escalated,
+    })
+    if (decision.action === 'retry') {
+      // claude not up yet (slow container boot) — give it another full
+      // grace window rather than escalating a bounce that can't help.
+      opts.log(
+        `telegram gateway: [bridge-dead-watchdog] no bridge registered after ${opts.graceMs}ms ` +
+          `but claude session not found — re-arming (no escalation)`,
+      )
+      armInternal()
+      return decision
+    }
+    if (decision.action === 'skip') {
+      if (decision.why !== 'bridge-registered') {
+        opts.log(
+          `telegram gateway: [bridge-dead-watchdog] bridge missing but skipping escalation (${decision.why})`,
+        )
+      }
+      return decision
+    }
+    // Escalate: bridge dead, session alive, not shutting down, first time
+    // this boot. Set the fuse BEFORE any side effect so a throwing sink
+    // can't produce a second fire.
+    escalated = true
+    const t = nowMs()
+    const crashTail = (() => {
+      try {
+        return readCrashTail(opts.crashLogPath, t)
+      } catch {
+        return null
+      }
+    })()
+    try {
+      const marker: BridgeDeadEscalationMarker = { ts: t, reason: BRIDGE_DEAD_RESTART_REASON }
+      if (crashTail != null) marker.crashTail = crashTail
+      writeMarker(opts.markerPath, marker)
+    } catch (err) {
+      opts.log(
+        `telegram gateway: [bridge-dead-watchdog] escalation marker write failed: ${(err as Error).message}`,
+      )
+    }
+    // The audit line: loud, structured, greppable — the operator's answer
+    // to "why did this container bounce itself".
+    opts.log(
+      `telegram gateway: [bridge-dead-watchdog] ESCALATING reason=${BRIDGE_DEAD_RESTART_REASON} — ` +
+        `no MCP bridge registered within ${opts.graceMs}ms grace window while the claude session is alive ` +
+        `(Claude Code never respawns a dead MCP server; bouncing the container to restore the chat surface). ` +
+        (crashTail != null
+          ? `bridge-crash.log tail: ${crashTail}`
+          : `no fresh bridge-crash.log entries`),
+    )
+    const fired = opts.escalate(BRIDGE_DEAD_RESTART_REASON)
+    if (!fired) {
+      opts.log(
+        `telegram gateway: [bridge-dead-watchdog] escalate() reported failure — ` +
+          `restart not dispatched (fuse stays blown; no retry this boot)`,
+      )
+    }
+    return decision
+  }
+
+  return {
+    arm: armInternal,
+    noteBridgeRegistered: () => {
+      bridgeRegistered = true
+      cancel()
+    },
+    noteBridgeDisconnected: () => {
+      bridgeRegistered = false
+      armInternal()
+    },
+    check,
+    stop: cancel,
+    hasEscalated: () => escalated,
+  }
+}

--- a/telegram-plugin/gateway/bridge-dead-watchdog.ts
+++ b/telegram-plugin/gateway/bridge-dead-watchdog.ts
@@ -21,24 +21,35 @@
  * respawns the MCP bridge — the only recovery path that exists.
  *
  * Guard rails:
- *   - at most ONE escalation per gateway boot (a bridge that dies
- *     deterministically at startup must not restart-loop the agent);
+ *   - at most ONE escalation per gateway boot (in-memory fuse), AND at
+ *     most MAX_CONSECUTIVE_ESCALATIONS across boots (the escalation
+ *     marker carries a consecutive-fire count — see below): a bridge
+ *     that dies deterministically at startup must not restart-loop the
+ *     agent forever;
  *   - skipped while the gateway is mid-shutdown;
  *   - skipped when the claude session process is NOT alive (that is a
  *     different failure class — container boot still in progress, or
  *     claude itself down — where a bounce is either premature or
  *     futile); the timer re-arms so a slow-booting claude gets the full
  *     grace window again once it appears;
+ *   - cron-session bridges (`<agent>-cron`) and anonymous IPC clients
+ *     (recall.py one-shots, pre-handshake connects) neither satisfy nor
+ *     re-arm the watchdog — the gating lives INSIDE noteBridge* so a
+ *     gateway handler refactor can't silently reintroduce the
+ *     bounce-after-cron-fire false positive;
  *   - loud, structured escalation log line including a fresh
  *     bridge-crash.log tail (PR #3037 breadcrumbs) so the operator sees
  *     WHY from the supervisor log alone.
  *
  * Honest resume: before firing the restart, the watchdog persists an
  * escalation marker (`STATE_DIR/bridge-dead-escalation.json`). The next
- * boot's resume-inbound block reads it and appends the real cause to the
- * synthetic resume inbound, so the agent tells the user "my chat bridge
- * died and the framework restarted me" instead of implying a watchdog
- * timeout or an operator restart.
+ * boot consumes it and (a) appends the real cause to the synthetic boot
+ * resume/report inbound when work was in flight, or (b) synthesizes a
+ * minimal idle notice (buildBridgeDeadIdleNoticeInbound) when nothing
+ * was — either way the agent tells the user "my chat bridge died and the
+ * framework restarted me" instead of implying a watchdog timeout or an
+ * operator restart, and the chat is never left wondering why the
+ * container bounced.
  *
  * Pure-ish module: all IO (fs, timers, process liveness, restart) is
  * injected so the decision logic and the controller are unit-testable
@@ -46,6 +57,8 @@
  */
 
 import { readFileSync, writeFileSync, renameSync, unlinkSync } from 'node:fs'
+import { isCronIdentity } from './cron-session.js'
+import type { InboundMessage } from './ipc-protocol.js'
 
 /** The distinct triggerSelfRestart reason for this escalation. Classified
  *  as intent 'keep' by intentForRestartReason (recovery bounce — session
@@ -61,8 +74,21 @@ export const DEFAULT_BRIDGE_DEAD_GRACE_MS = 90_000
 
 /** Escalation marker freshness window at next boot. A marker older than
  *  this is stale debris (the escalated restart happened long ago or never
- *  completed) — cleared without surfacing. */
+ *  completed) — cleared without surfacing, and the consecutive-escalation
+ *  streak resets with it. */
 export const ESCALATION_MARKER_MAX_AGE_MS = 10 * 60_000
+
+/** Cross-boot restart-loop damper: the once-per-boot fuse is in-memory
+ *  and a container bounce RESETS it, so a bridge that dies
+ *  deterministically at startup (corrupt plugin bundle, bad .mcp.json)
+ *  would otherwise bounce the container every grace window forever,
+ *  spamming boot cards. The escalation marker carries a consecutive-fire
+ *  `count`; a boot that consumed a marker with count >= this cap stands
+ *  the watchdog down (loud audit line, operator investigates) instead of
+ *  firing again. A successful bridge registration at any boot breaks the
+ *  streak. With the default cap of 2 the framework attempts the
+ *  self-heal twice, then stops. */
+export const MAX_CONSECUTIVE_ESCALATIONS = 2
 
 /** Crash-breadcrumb entries older than this are not "fresh" — they refer
  *  to some earlier incident and would mislead the escalation log line. */
@@ -76,35 +102,52 @@ const CRASH_LOG_TAIL_LINES = 3
 export interface BridgeDeadSnapshot {
   /** A real (named, non-cron) bridge is currently registered. */
   bridgeRegistered: boolean
+  /** A real bridge registered at some point THIS boot (breaks the
+   *  cross-boot escalation streak even if it later disconnected). */
+  bridgeEverRegistered: boolean
   /** The claude session process exists in the container. */
   sessionAlive: boolean
   /** The gateway is mid-shutdown (SIGTERM/SIGINT handler ran). */
   shuttingDown: boolean
   /** This gateway boot already fired the one allowed escalation. */
   alreadyEscalated: boolean
+  /** Consecutive escalations by PRIOR boots (from the consumed marker;
+   *  0 when no fresh marker was found). */
+  priorStreak: number
+  /** The cross-boot cap (MAX_CONSECUTIVE_ESCALATIONS unless a test
+   *  overrides). */
+  maxConsecutive: number
 }
 
 export type BridgeDeadDecision =
   | { action: 'escalate' }
   | {
       action: 'skip'
-      why: 'bridge-registered' | 'shutting-down' | 'already-escalated'
+      why: 'bridge-registered' | 'shutting-down' | 'already-escalated' | 'streak-capped'
     }
   | { action: 'retry'; why: 'session-not-alive' }
 
 /**
  * Decide what the watchdog should do when the grace window expires.
  * Precedence, highest first: a live bridge always wins; a shutdown in
- * progress must never be raced by a restart; the once-per-boot fuse is
- * checked before anything fires; a missing claude process re-arms rather
- * than escalating (bouncing a container whose claude never came up would
- * loop without fixing anything — and a container still booting deserves
- * the full grace window once claude appears).
+ * progress must never be raced by a restart; the once-per-boot fuse and
+ * the cross-boot streak cap are checked before anything fires; a missing
+ * claude process re-arms rather than escalating (bouncing a container
+ * whose claude never came up would loop without fixing anything — and a
+ * container still booting deserves the full grace window once claude
+ * appears).
  */
 export function decideBridgeDeadEscalation(s: BridgeDeadSnapshot): BridgeDeadDecision {
   if (s.bridgeRegistered) return { action: 'skip', why: 'bridge-registered' }
   if (s.shuttingDown) return { action: 'skip', why: 'shutting-down' }
   if (s.alreadyEscalated) return { action: 'skip', why: 'already-escalated' }
+  // Cross-boot damper: prior boots already escalated `priorStreak` times
+  // in a row and the bridge STILL hasn't registered this boot — the bounce
+  // is not fixing it. Stand down. (A registration this boot breaks the
+  // streak: the current outage is then a NEW incident, not the same one.)
+  if (!s.bridgeEverRegistered && s.priorStreak >= s.maxConsecutive) {
+    return { action: 'skip', why: 'streak-capped' }
+  }
   if (!s.sessionAlive) return { action: 'retry', why: 'session-not-alive' }
   return { action: 'escalate' }
 }
@@ -152,13 +195,18 @@ export function readFreshCrashLogTail(
   return fresh.map((l) => l.slice(0, 500)).join(' || ')
 }
 
-// ─── Escalation marker (honest boot-resume cause) ────────────────────────────
+// ─── Escalation marker (honest boot-resume cause + cross-boot damper) ────────
 
 export interface BridgeDeadEscalationMarker {
   /** Wall-clock ms when the escalation fired. */
   ts: number
   /** Always BRIDGE_DEAD_RESTART_REASON — kept in the file for grep-ability. */
   reason: string
+  /** Consecutive escalations INCLUDING this one (1 = first fire of a
+   *  streak). The next boot reads this as its `priorStreak` and stands
+   *  down at MAX_CONSECUTIVE_ESCALATIONS. Absent in pre-damper markers —
+   *  treated as 1. */
+  count?: number
   /** Fresh crash-breadcrumb tail at escalation time, if any. */
   crashTail?: string
 }
@@ -179,6 +227,21 @@ export function writeBridgeDeadEscalationMarker(
  * when it is fresh (< maxAgeMs); a stale or malformed marker is cleared
  * and ignored. The file is ALWAYS removed — the cause note must surface
  * on exactly the boot that follows the escalation, never a later one.
+ *
+ * Known race window (accepted, documented per review): the marker is
+ * written by gateway boot N and consumed by whichever gateway boots NEXT.
+ * Normally that is the post-container-restart gateway (the SIGTERM to
+ * PID 1 fires ~1.5s after the write and takes the whole container down).
+ * But if the escalating gateway PROCESS dies and its supervisor relaunches
+ * a new gateway inside the same container before the SIGTERM lands, that
+ * interim gateway consumes the marker instead — the cause note is then
+ * surfaced (or dropped with the interim process) one boot early, and the
+ * post-restart boot sees no marker. Consequences are bounded and safe:
+ * the honesty note may be lost for one incident (the loud supervisor-log
+ * audit line survives regardless), and the cross-boot streak damper
+ * under-counts by one (strictly MORE willing to self-heal, never a
+ * tighter loop, since the in-memory once-per-boot fuse still caps each
+ * process at one fire). Not worth a consume-side handshake.
  */
 export function consumeBridgeDeadEscalationMarker(
   path: string,
@@ -196,6 +259,10 @@ export function consumeBridgeDeadEscalationMarker(
       const age = nowMs - parsed.ts
       if (age >= 0 && age < maxAgeMs) {
         marker = { ts: parsed.ts, reason: parsed.reason }
+        marker.count =
+          typeof parsed.count === 'number' && Number.isFinite(parsed.count) && parsed.count >= 1
+            ? Math.floor(parsed.count)
+            : 1
         if (typeof parsed.crashTail === 'string') marker.crashTail = parsed.crashTail
       }
     }
@@ -210,12 +277,61 @@ export function consumeBridgeDeadEscalationMarker(
   return marker
 }
 
+// ─── Idle notice (honest cause when NO turn was in flight) ───────────────────
+
+/**
+ * Build the minimal synthetic inbound surfaced when the previous boot was
+ * a bridge-dead escalation but NO turn was interrupted (idle agent, dead
+ * bridge). Without this the cause reaches only stderr — the agent and the
+ * user never learn why the container bounced (review finding 2 on #3038).
+ * Mirrors the resume-builder shapes: meta.source is what Claude Code
+ * renders as `<channel source="…">`; meta.chat_id/message_id let the
+ * gateway's enqueue path build a currentTurn + ack the synthetic.
+ */
+export function buildBridgeDeadIdleNoticeInbound(args: {
+  /** Chat to surface the notice in (the agent's default/owner chat). */
+  chatId: string
+  /** The consumed escalation marker. */
+  marker: BridgeDeadEscalationMarker
+  /** Wall-clock ms; defaults to Date.now(). */
+  nowMs?: number
+}): InboundMessage {
+  const ts = args.nowMs ?? Date.now()
+  return {
+    type: 'inbound',
+    chatId: args.chatId,
+    messageId: ts,
+    user: 'switchroom',
+    userId: 0,
+    ts,
+    text:
+      `You just restarted. The framework itself triggered this restart: your Telegram ` +
+      `MCP bridge process had died (chat tools were unavailable — you could not send ` +
+      `replies), so the container was bounced to restore the chat surface. No work was ` +
+      `in flight when it happened. Briefly let the user know the messaging bridge died ` +
+      `and the framework restarted you to fix it — one short message, no drama. This was ` +
+      `NOT an operator-initiated restart and NOT a hang-watchdog kill; report only that ` +
+      `honest cause.`,
+    meta: {
+      source: 'bridge_dead_restart',
+      chat_id: args.chatId,
+      message_id: String(ts),
+      restart_cause: args.marker.reason,
+    },
+  }
+}
+
 // ─── Watchdog controller ─────────────────────────────────────────────────────
 
 export interface BridgeDeadWatchdogOpts {
-  /** Grace window before a missing bridge is treated as dead. */
+  /** Grace window before a missing bridge is treated as dead. Doubled
+   *  when the consumed marker shows a prior escalation streak (the retry
+   *  after a failed self-heal deserves more patience). */
   graceMs: number
-  /** Is the claude session process alive in this container? */
+  /** Is the claude session process alive in this container? Callers
+   *  should require a confident match (comm === 'claude'), NOT the
+   *  heaviest-node fallback — an orphaned node process must not flip a
+   *  retry into an escalation (review finding 4). */
   isSessionAlive: () => boolean
   /** Is the gateway mid-shutdown? */
   isShuttingDown: () => boolean
@@ -228,6 +344,11 @@ export interface BridgeDeadWatchdogOpts {
   markerPath: string
   /** Structured log sink (stderr). */
   log: (line: string) => void
+  /** Consecutive escalations by prior boots (the consumed marker's
+   *  `count`; 0 when no fresh marker). Drives the cross-boot damper. */
+  priorStreak?: number
+  /** Cross-boot cap override (tests). */
+  maxConsecutive?: number
   /** Injectable timer pair for tests. Defaults to global setTimeout with
    *  unref (the watchdog must never keep the gateway process alive). */
   setTimer?: (fn: () => void, ms: number) => unknown
@@ -241,14 +362,20 @@ export interface BridgeDeadWatchdogOpts {
 }
 
 export interface BridgeDeadWatchdog {
-  /** Arm the grace timer (gateway boot). Idempotent while armed. */
+  /** Arm the grace timer (gateway boot). Idempotent while armed. No-op
+   *  when the cross-boot streak cap is already reached (stands down with
+   *  an audit line instead). */
   arm: () => void
-  /** A real (named, non-cron) bridge registered — cancel the timer. */
-  noteBridgeRegistered: () => void
-  /** The real bridge disconnected mid-life — re-arm the grace timer so a
-   *  bridge that dies AFTER boot (and never reconnects) also escalates.
-   *  Still capped by the once-per-boot fuse. */
-  noteBridgeDisconnected: () => void
+  /** A bridge client registered. Only a REAL bridge (named, non-cron)
+   *  satisfies the watchdog — cron sessions (`<agent>-cron`) and
+   *  anonymous clients (agentName null) are ignored HERE so a gateway
+   *  handler refactor can't reorder the gating away (review finding 5). */
+  noteBridgeRegistered: (agentName: string | null | undefined) => void
+  /** A bridge client disconnected. Re-arms the grace window only for the
+   *  real bridge (same internal gating), so a bridge that dies AFTER boot
+   *  and never reconnects also escalates. Still capped by the
+   *  once-per-boot fuse. */
+  noteBridgeDisconnected: (agentName: string | null | undefined) => void
   /** Evaluate now (the timer body — exposed for tests). Returns the
    *  decision taken. */
   check: () => BridgeDeadDecision
@@ -256,6 +383,11 @@ export interface BridgeDeadWatchdog {
   stop: () => void
   /** Test/introspection: has this boot escalated already? */
   hasEscalated: () => boolean
+}
+
+/** Is this client identity the REAL main-agent bridge (named, non-cron)? */
+function isRealBridgeIdentity(agentName: string | null | undefined): boolean {
+  return agentName != null && agentName.length > 0 && !isCronIdentity(agentName)
 }
 
 export function createBridgeDeadWatchdog(opts: BridgeDeadWatchdogOpts): BridgeDeadWatchdog {
@@ -271,9 +403,12 @@ export function createBridgeDeadWatchdog(opts: BridgeDeadWatchdogOpts): BridgeDe
   const writeMarker = opts.writeMarker ?? writeBridgeDeadEscalationMarker
   const readCrashTail =
     opts.readCrashTail ?? ((p: string, t: number) => readFreshCrashLogTail(p, { nowMs: t }))
+  const priorStreak = opts.priorStreak ?? 0
+  const maxConsecutive = opts.maxConsecutive ?? MAX_CONSECUTIVE_ESCALATIONS
 
   let timer: unknown = null
   let bridgeRegistered = false
+  let bridgeEverRegistered = false
   let escalated = false
 
   const cancel = (): void => {
@@ -283,27 +418,52 @@ export function createBridgeDeadWatchdog(opts: BridgeDeadWatchdogOpts): BridgeDe
     }
   }
 
+  /** The retry after a failed self-heal gets a doubled window: if one
+   *  bounce didn't bring the bridge back inside graceMs, a second fire on
+   *  the same clock mostly races container boot noise. */
+  const effectiveGraceMs = (): number =>
+    !bridgeEverRegistered && priorStreak >= 1 ? opts.graceMs * 2 : opts.graceMs
+
   const armInternal = (): void => {
     if (escalated) return // once-per-boot fuse — never re-arm after firing
+    if (!bridgeEverRegistered && priorStreak >= maxConsecutive) {
+      // Cross-boot damper: prior boots already bounced the container
+      // `priorStreak` times in a row for this same condition and the
+      // bridge still hasn't come back — a third bounce won't either.
+      // Stand down LOUDLY: the operator must investigate (corrupt plugin
+      // bundle / bad .mcp.json / broken IPC socket path).
+      opts.log(
+        `telegram gateway: [bridge-dead-watchdog] STANDING DOWN — ${priorStreak} consecutive ` +
+          `bridge-dead escalations already restarted this container without the bridge coming ` +
+          `back (cap=${maxConsecutive}). The bridge is failing deterministically; a further ` +
+          `restart will not fix it. Investigate the bridge (plugin bundle, .mcp.json, ` +
+          `STATE_DIR/bridge-crash.log). Manual recovery: fix the cause, then restart the ` +
+          `container. SWITCHROOM_BRIDGE_DEAD_ESCALATION=0 disables this watchdog entirely.`,
+      )
+      return
+    }
     cancel()
     timer = setTimer(() => {
       timer = null
       check()
-    }, opts.graceMs)
+    }, effectiveGraceMs())
   }
 
   const check = (): BridgeDeadDecision => {
     const decision = decideBridgeDeadEscalation({
       bridgeRegistered,
+      bridgeEverRegistered,
       sessionAlive: opts.isSessionAlive(),
       shuttingDown: opts.isShuttingDown(),
       alreadyEscalated: escalated,
+      priorStreak,
+      maxConsecutive,
     })
     if (decision.action === 'retry') {
       // claude not up yet (slow container boot) — give it another full
       // grace window rather than escalating a bounce that can't help.
       opts.log(
-        `telegram gateway: [bridge-dead-watchdog] no bridge registered after ${opts.graceMs}ms ` +
+        `telegram gateway: [bridge-dead-watchdog] no bridge registered after ${effectiveGraceMs()}ms ` +
           `but claude session not found — re-arming (no escalation)`,
       )
       armInternal()
@@ -318,8 +478,8 @@ export function createBridgeDeadWatchdog(opts: BridgeDeadWatchdogOpts): BridgeDe
       return decision
     }
     // Escalate: bridge dead, session alive, not shutting down, first time
-    // this boot. Set the fuse BEFORE any side effect so a throwing sink
-    // can't produce a second fire.
+    // this boot, streak under the cap. Set the fuse BEFORE any side effect
+    // so a throwing sink can't produce a second fire.
     escalated = true
     const t = nowMs()
     const crashTail = (() => {
@@ -329,8 +489,15 @@ export function createBridgeDeadWatchdog(opts: BridgeDeadWatchdogOpts): BridgeDe
         return null
       }
     })()
+    // Streak accounting: a registration THIS boot breaks the prior streak
+    // (this escalation starts a new one at 1); otherwise it extends it.
+    const streakCount = bridgeEverRegistered ? 1 : priorStreak + 1
     try {
-      const marker: BridgeDeadEscalationMarker = { ts: t, reason: BRIDGE_DEAD_RESTART_REASON }
+      const marker: BridgeDeadEscalationMarker = {
+        ts: t,
+        reason: BRIDGE_DEAD_RESTART_REASON,
+        count: streakCount,
+      }
       if (crashTail != null) marker.crashTail = crashTail
       writeMarker(opts.markerPath, marker)
     } catch (err) {
@@ -341,8 +508,9 @@ export function createBridgeDeadWatchdog(opts: BridgeDeadWatchdogOpts): BridgeDe
     // The audit line: loud, structured, greppable — the operator's answer
     // to "why did this container bounce itself".
     opts.log(
-      `telegram gateway: [bridge-dead-watchdog] ESCALATING reason=${BRIDGE_DEAD_RESTART_REASON} — ` +
-        `no MCP bridge registered within ${opts.graceMs}ms grace window while the claude session is alive ` +
+      `telegram gateway: [bridge-dead-watchdog] ESCALATING reason=${BRIDGE_DEAD_RESTART_REASON} ` +
+        `consecutive=${streakCount}/${maxConsecutive} — ` +
+        `no MCP bridge registered within ${effectiveGraceMs()}ms grace window while the claude session is alive ` +
         `(Claude Code never respawns a dead MCP server; bouncing the container to restore the chat surface). ` +
         (crashTail != null
           ? `bridge-crash.log tail: ${crashTail}`
@@ -360,11 +528,14 @@ export function createBridgeDeadWatchdog(opts: BridgeDeadWatchdogOpts): BridgeDe
 
   return {
     arm: armInternal,
-    noteBridgeRegistered: () => {
+    noteBridgeRegistered: (agentName) => {
+      if (!isRealBridgeIdentity(agentName)) return
       bridgeRegistered = true
+      bridgeEverRegistered = true
       cancel()
     },
-    noteBridgeDisconnected: () => {
+    noteBridgeDisconnected: (agentName) => {
+      if (!isRealBridgeIdentity(agentName)) return
       bridgeRegistered = false
       armInternal()
     },

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -740,6 +740,7 @@ import {
 import {
   createBridgeDeadWatchdog,
   consumeBridgeDeadEscalationMarker,
+  buildBridgeDeadIdleNoticeInbound,
   DEFAULT_BRIDGE_DEAD_GRACE_MS,
 } from './bridge-dead-watchdog.js'
 import { findAgentProcessInContainer } from './boot-probes.js'
@@ -1535,6 +1536,10 @@ let turnsDb: ReturnType<typeof openTurnsDb> | null = null
 // Stashed here; pushed to the spool once it's constructed below. The spool's
 // turn_key-keyed dedup makes a re-stash across multiple restarts a no-op.
 let bootResumeInbound: { agent: string; msg: InboundMessage } | null = null
+// #3038 cross-boot damper: consecutive bridge-dead escalations by PRIOR
+// boots (the consumed marker's `count`; 0 when no fresh marker). Set in
+// the boot block below, consumed by the watchdog constructor further down.
+let bridgeDeadPriorStreak = 0
 try {
   // STATE_DIR is `<agentDir>/telegram` in production. openTurnsDb expects
   // the parent (agent dir) and joins `telegram/registry.db` itself.
@@ -1599,8 +1604,10 @@ try {
     join(STATE_DIR, 'bridge-dead-escalation.json'),
   )
   if (bridgeDeadMarker != null) {
+    bridgeDeadPriorStreak = bridgeDeadMarker.count ?? 1
     process.stderr.write(
       `telegram gateway: boot: prior restart was a bridge-dead escalation (reason=${bridgeDeadMarker.reason}` +
+      `, consecutive=${bridgeDeadPriorStreak}` +
       `${bridgeDeadMarker.crashTail ? `, crashTail=${bridgeDeadMarker.crashTail}` : ''})\n`,
     )
   }
@@ -1745,6 +1752,38 @@ try {
       process.stderr.write(
         `telegram gateway: boot-resume queued kind=${bootResumeKind} mode=${bootResumeMode} ` +
         `turnKey=${pending.turn_key} endedVia=${pending.ended_via ?? 'open'} chat=${pending.chat_id}\n`,
+      )
+    }
+  }
+
+  // #3038 review finding 2 — idle-case honesty. When the previous boot was
+  // a bridge-dead escalation but NO turn was interrupted (idle agent, dead
+  // bridge), the consumed marker's cause would otherwise reach stderr only:
+  // the agent and the user never learn why the container bounced. Surface
+  // it once, via the same boot-inbound channel the resume path uses, routed
+  // to the agent's default/owner chat.
+  if (bridgeDeadMarker != null && bootResumeInbound == null && selfAgent) {
+    const idleNoticeChat = (() => {
+      try {
+        return loadAccess().allowFrom[0] ?? null
+      } catch {
+        return null
+      }
+    })()
+    if (idleNoticeChat != null) {
+      bootResumeInbound = {
+        agent: selfAgent,
+        msg: buildBridgeDeadIdleNoticeInbound({
+          chatId: String(idleNoticeChat),
+          marker: bridgeDeadMarker,
+        }),
+      }
+      process.stderr.write(
+        `telegram gateway: boot: bridge-dead idle notice queued chat=${idleNoticeChat} (no turn was in flight)\n`,
+      )
+    } else {
+      process.stderr.write(
+        `telegram gateway: boot: bridge-dead idle notice skipped — no allowFrom chat to surface it in\n`,
       )
     }
   }
@@ -9147,7 +9186,12 @@ const BRIDGE_DEAD_GRACE_MS = (() => {
 })()
 const bridgeDeadWatchdog = createBridgeDeadWatchdog({
   graceMs: BRIDGE_DEAD_GRACE_MS,
-  isSessionAlive: () => findAgentProcessInContainer() != null,
+  // Require a CONFIDENT claude match (comm === 'claude'), not
+  // findAgentProcessInContainer's heaviest-node fallback: an orphaned or
+  // unrelated node process must never flip a "claude not up" retry into a
+  // container bounce (#3038 review finding 4). False negatives are safe —
+  // the watchdog then retries forever instead of escalating.
+  isSessionAlive: () => findAgentProcessInContainer()?.comm === 'claude',
   // `shuttingDown` is declared (let, module scope) further down this file;
   // the closure only runs when the grace timer fires, long after module
   // init completes, so the TDZ is never hit.
@@ -9157,6 +9201,10 @@ const bridgeDeadWatchdog = createBridgeDeadWatchdog({
   crashLogPath: join(STATE_DIR, 'bridge-crash.log'),
   markerPath: join(STATE_DIR, 'bridge-dead-escalation.json'),
   log: (line) => process.stderr.write(`${line}\n`),
+  // Cross-boot damper (#3038 review finding 1): the consumed marker's
+  // consecutive-escalation count. At the cap, arm() stands down loudly
+  // instead of restart-looping a deterministically-failing bridge.
+  priorStreak: bridgeDeadPriorStreak,
 })
 if (BRIDGE_DEAD_ESCALATION_ENABLED) {
   bridgeDeadWatchdog.arm()
@@ -9196,9 +9244,11 @@ const ipcServer: IpcServer = createIpcServer({
       : []
     // #3038 — a REAL (named, non-cron) bridge registered: stand the
     // bridge-dead watchdog down. Anonymous clients (recall.py, mcp
-    // handshakes) must NOT satisfy it — same false-positive rationale as
-    // the shadow bridgeUp gate above.
-    if (client.agentName != null) bridgeDeadWatchdog.noteBridgeRegistered()
+    // handshakes) and cron-session bridges must NOT satisfy it — the
+    // watchdog gates on the identity INTERNALLY (isRealBridgeIdentity), so
+    // this call is safe wherever it sits relative to the cron early-return
+    // above (#3038 review finding 5).
+    bridgeDeadWatchdog.noteBridgeRegistered(client.agentName)
     client.send({ type: 'status', status: 'agent_connected' })
 
     // Phase 2b PR 3a — bridgeUp cutover. The state machine's `bridgeUp`
@@ -9391,8 +9441,9 @@ const ipcServer: IpcServer = createIpcServer({
       // #3038 — the real bridge went away mid-life. Re-arm the grace
       // window: a normal claude restart re-registers within seconds and
       // stands it down; a bridge that died for good escalates once (the
-      // once-per-boot fuse inside the watchdog caps it).
-      if (BRIDGE_DEAD_ESCALATION_ENABLED) bridgeDeadWatchdog.noteBridgeDisconnected()
+      // once-per-boot fuse inside the watchdog caps it). Cron/anonymous
+      // identities are ignored inside the watchdog itself (finding 5).
+      if (BRIDGE_DEAD_ESCALATION_ENABLED) bridgeDeadWatchdog.noteBridgeDisconnected(client.agentName)
     }
 
     // Scope the flush to clients that actually registered as an agent.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -737,6 +737,12 @@ import {
   buildResumeDeferredReportInbound,
   decideBootResumeKind,
 } from './resume-inbound-builder.js'
+import {
+  createBridgeDeadWatchdog,
+  consumeBridgeDeadEscalationMarker,
+  DEFAULT_BRIDGE_DEAD_GRACE_MS,
+} from './bridge-dead-watchdog.js'
+import { findAgentProcessInContainer } from './boot-probes.js'
 import { applySubagentsSchema, getSubagentByJsonlId, resolveSubagentOriginTurnKey, listNonTerminalSubagentsForTurn } from '../registry/subagents-schema.js'
 import type { InterruptedSubagent } from './resume-inbound-builder.js'
 import { resolveWorkerFeedDispatch, type WorkerFeedDispatch } from './worker-feed-dispatch.js'
@@ -1584,6 +1590,30 @@ try {
     process.stderr.write(`telegram gateway: turn-registry initialized at ${join(agentDir, 'telegram', 'registry.db')}\n`)
   }
 
+  // #3038 — bridge-dead escalation marker. If the PREVIOUS gateway bounced
+  // this container because the MCP bridge died (see bridge-dead-watchdog.ts),
+  // it left a marker so THIS boot's resume inbound can state the real cause
+  // instead of implying an operator restart or a watchdog timeout. Consumed
+  // (always cleared) whether or not a turn was in flight.
+  const bridgeDeadMarker = consumeBridgeDeadEscalationMarker(
+    join(STATE_DIR, 'bridge-dead-escalation.json'),
+  )
+  if (bridgeDeadMarker != null) {
+    process.stderr.write(
+      `telegram gateway: boot: prior restart was a bridge-dead escalation (reason=${bridgeDeadMarker.reason}` +
+      `${bridgeDeadMarker.crashTail ? `, crashTail=${bridgeDeadMarker.crashTail}` : ''})\n`,
+    )
+  }
+  const bridgeDeadRestartCause = bridgeDeadMarker != null
+    ? {
+        reason: bridgeDeadMarker.reason,
+        note:
+          'The framework itself triggered this restart: your Telegram MCP bridge process had died ' +
+          '(chat tools were unavailable — you could not send replies), so the container was bounced ' +
+          'to restore the chat surface. This was NOT an operator-initiated restart and NOT a hang-watchdog kill.',
+      }
+    : undefined
+
   // Build the boot resume/report inbound for the LATEST turn if it was
   // interrupted. selectResumeBuilder owns the resume-vs-report policy.
   const pending = findLatestTurnIfInterrupted(turnsDb)
@@ -1657,7 +1687,11 @@ try {
     if (bootResumeKind === 'resume') {
       bootResumeInbound = {
         agent: selfAgent,
-        msg: buildResumeInterruptedInbound({ turn: pending, subagents: interruptedSubagents }),
+        msg: buildResumeInterruptedInbound({
+          turn: pending,
+          subagents: interruptedSubagents,
+          restartCause: bridgeDeadRestartCause,
+        }),
       }
     } else if (bootResumeKind === 'report') {
       // idleMs: this boot's measured marker age if it just classified this
@@ -1673,7 +1707,12 @@ try {
       if (idleMs == null) idleMs = Math.max(0, Date.now() - pending.started_at)
       bootResumeInbound = {
         agent: selfAgent,
-        msg: buildResumeWatchdogReportInbound({ turn: pending, idleMs, subagents: interruptedSubagents }),
+        msg: buildResumeWatchdogReportInbound({
+          turn: pending,
+          idleMs,
+          subagents: interruptedSubagents,
+          restartCause: bridgeDeadRestartCause,
+        }),
       }
     } else if (bootResumeKind === 'defer-loop' || bootResumeKind === 'defer-suppressed') {
       // Passive deferred-report: work was in flight but we decline to
@@ -1685,6 +1724,7 @@ try {
           turn: pending,
           reason: bootResumeKind === 'defer-loop' ? 'loop-guard' : 'clean-restart-suppressed',
           subagents: interruptedSubagents,
+          restartCause: bridgeDeadRestartCause,
         }),
       }
     }
@@ -9089,6 +9129,42 @@ async function stripStalePermissionCard(card: PersistedPermCard): Promise<void> 
   }
 }
 
+// ─── #3038 — bridge-dead watchdog ────────────────────────────────────────
+// When the gateway (re)starts, the MCP bridge inside the running claude
+// session normally re-registers on the IPC socket within seconds. If it
+// died with the previous gateway (Claude Code never respawns a dead MCP
+// server), the session stays alive but toolless/mute forever. This
+// watchdog escalates: no real bridge registered within the grace window
+// while claude is alive → bounce the container once (reason
+// 'bridge-dead-resume') so the MCP server respawns. See
+// bridge-dead-watchdog.ts for the guard rails.
+// Config: SWITCHROOM_BRIDGE_DEAD_GRACE_MS (default 90s),
+// SWITCHROOM_BRIDGE_DEAD_ESCALATION=0 disables.
+const BRIDGE_DEAD_ESCALATION_ENABLED = process.env.SWITCHROOM_BRIDGE_DEAD_ESCALATION !== '0'
+const BRIDGE_DEAD_GRACE_MS = (() => {
+  const v = Number(process.env.SWITCHROOM_BRIDGE_DEAD_GRACE_MS)
+  return Number.isFinite(v) && v > 0 ? v : DEFAULT_BRIDGE_DEAD_GRACE_MS
+})()
+const bridgeDeadWatchdog = createBridgeDeadWatchdog({
+  graceMs: BRIDGE_DEAD_GRACE_MS,
+  isSessionAlive: () => findAgentProcessInContainer() != null,
+  // `shuttingDown` is declared (let, module scope) further down this file;
+  // the closure only runs when the grace timer fires, long after module
+  // init completes, so the TDZ is never hit.
+  isShuttingDown: () => shuttingDown,
+  escalate: (reason) =>
+    triggerSelfRestart(process.env.SWITCHROOM_AGENT_NAME ?? '', reason, 1500),
+  crashLogPath: join(STATE_DIR, 'bridge-crash.log'),
+  markerPath: join(STATE_DIR, 'bridge-dead-escalation.json'),
+  log: (line) => process.stderr.write(`${line}\n`),
+})
+if (BRIDGE_DEAD_ESCALATION_ENABLED) {
+  bridgeDeadWatchdog.arm()
+  process.stderr.write(
+    `telegram gateway: [bridge-dead-watchdog] armed (grace=${BRIDGE_DEAD_GRACE_MS}ms)\n`,
+  )
+}
+
 const ipcServer: IpcServer = createIpcServer({
   socketPath: SOCKET_PATH,
 
@@ -9118,6 +9194,11 @@ const ipcServer: IpcServer = createIpcServer({
     const bridgeUpEffects = client.agentName != null
       ? shadowEmit({ kind: 'bridgeUp', at: Date.now() })
       : []
+    // #3038 — a REAL (named, non-cron) bridge registered: stand the
+    // bridge-dead watchdog down. Anonymous clients (recall.py, mcp
+    // handshakes) must NOT satisfy it — same false-positive rationale as
+    // the shadow bridgeUp gate above.
+    if (client.agentName != null) bridgeDeadWatchdog.noteBridgeRegistered()
     client.send({ type: 'status', status: 'agent_connected' })
 
     // Phase 2b PR 3a — bridgeUp cutover. The state machine's `bridgeUp`
@@ -9307,6 +9388,11 @@ const ipcServer: IpcServer = createIpcServer({
     if (client.agentName != null) {
       process.stderr.write(`telegram gateway: bridge disconnected — agent=${client.agentName}\n`)
       shadowEmit({ kind: 'bridgeDown', at: Date.now() })
+      // #3038 — the real bridge went away mid-life. Re-arm the grace
+      // window: a normal claude restart re-registers within seconds and
+      // stands it down; a bridge that died for good escalates once (the
+      // once-per-boot fuse inside the watchdog caps it).
+      if (BRIDGE_DEAD_ESCALATION_ENABLED) bridgeDeadWatchdog.noteBridgeDisconnected()
     }
 
     // Scope the flush to clients that actually registered as an agent.
@@ -26028,6 +26114,10 @@ async function shutdown(signal: string): Promise<void> {
   shuttingDown = true
   const agentName = process.env.SWITCHROOM_AGENT_NAME ?? '-'
   process.stderr.write('telegram gateway: shutting down\n')
+  // #3038 — never let a pending bridge-dead grace timer race a shutdown
+  // already in progress (its check() also skips on shuttingDown; this is
+  // the belt to that brace).
+  bridgeDeadWatchdog.stop()
 
   // Write the clean-shutdown sentinel BEFORE any drain work begins so
   // even if the drain hangs and the +5s force-exit kills us, the marker

--- a/telegram-plugin/gateway/resume-inbound-builder.ts
+++ b/telegram-plugin/gateway/resume-inbound-builder.ts
@@ -140,6 +140,20 @@ export interface ResumeInboundContext {
    *  Rendered into the inbound so the resumed session knows what to
    *  re-dispatch. Omitted / empty → the inbound is unchanged. */
   subagents?: InterruptedSubagent[]
+  /** Why the framework itself triggered the restart, when it did (e.g. the
+   *  bridge-dead escalation, #3038). Surfaced verbatim in the inbound text
+   *  (`note`) and as `meta.restart_cause` (`reason`) so the resume is
+   *  HONEST about the cause — a bridge-dead bounce must not read as an
+   *  operator restart or masquerade as a watchdog timeout. Omitted → the
+   *  inbound is unchanged (the common human-restart/crash case). */
+  restartCause?: { reason: string; note: string }
+}
+
+/** Render the optional framework-restart-cause block appended to a resume /
+ *  report inbound. Empty string when no cause was recorded. */
+function renderRestartCauseBlock(cause: { note: string } | undefined): string {
+  if (!cause || cause.note.trim().length === 0) return ''
+  return `\n\nWhy this restart happened: ${cause.note.trim()}`
 }
 
 /**
@@ -223,6 +237,7 @@ export function buildResumeInterruptedInbound(ctx: ResumeInboundContext): Inboun
     started_at: String(ctx.turn.started_at),
   }
   if (ctx.turn.user_prompt_preview) meta.original_prompt = ctx.turn.user_prompt_preview
+  if (ctx.restartCause) meta.restart_cause = ctx.restartCause.reason
   return {
     type: 'inbound',
     chatId: ctx.turn.chat_id,
@@ -247,7 +262,8 @@ export function buildResumeInterruptedInbound(ctx: ResumeInboundContext): Inboun
       `actual task. Do not ask whether to resume; just resume. If even after ` +
       `reading the recent messages you genuinely can't tell what the work was, ` +
       `say so and ask.` +
-      renderInterruptedSubagentsBlock(ctx.subagents),
+      renderInterruptedSubagentsBlock(ctx.subagents) +
+      renderRestartCauseBlock(ctx.restartCause),
     meta,
   }
 }
@@ -287,6 +303,7 @@ export function buildResumeWatchdogReportInbound(
   }
   if (ctx.turn.tool_call_count != null) meta.tool_call_count = String(ctx.turn.tool_call_count)
   if (ctx.turn.user_prompt_preview) meta.original_prompt = ctx.turn.user_prompt_preview
+  if (ctx.restartCause) meta.restart_cause = ctx.restartCause.reason
   return {
     type: 'inbound',
     chatId: ctx.turn.chat_id,
@@ -309,7 +326,8 @@ export function buildResumeWatchdogReportInbound(
       `speculate about a deeper root cause you can't see.` +
       // Deferred (non-assertive) form: this is the ask-first path — the killed
       // workers are listed as facts, but re-dispatch waits on the user's call.
-      renderInterruptedSubagentsBlock(ctx.subagents, { assertive: false }),
+      renderInterruptedSubagentsBlock(ctx.subagents, { assertive: false }) +
+      renderRestartCauseBlock(ctx.restartCause),
     meta,
   }
 }
@@ -398,6 +416,7 @@ export function buildResumeDeferredReportInbound(
     started_at: String(ctx.turn.started_at),
   }
   if (ctx.turn.user_prompt_preview) meta.original_prompt = ctx.turn.user_prompt_preview
+  if (ctx.restartCause) meta.restart_cause = ctx.restartCause.reason
   const cause =
     ctx.reason === 'loop-guard'
       ? `Your previous turn was ALREADY a resume of earlier interrupted work, ` +
@@ -428,7 +447,8 @@ export function buildResumeDeferredReportInbound(
       // Deferred (non-assertive) form, same as the watchdog path: this is an
       // ask-first inbound — killed workers are named as facts, but
       // re-dispatch waits on the user's call.
-      renderInterruptedSubagentsBlock(ctx.subagents, { assertive: false }),
+      renderInterruptedSubagentsBlock(ctx.subagents, { assertive: false }) +
+      renderRestartCauseBlock(ctx.restartCause),
     meta,
   }
 }

--- a/telegram-plugin/tests/bridge-dead-watchdog.test.ts
+++ b/telegram-plugin/tests/bridge-dead-watchdog.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Unit tests for telegram-plugin/gateway/bridge-dead-watchdog.ts (#3038).
+ *
+ * The contract under test (vitest — pure module, injected timers/fs/clock):
+ *
+ *   - bridge re-registers inside the grace window → timer cancelled, no
+ *     escalation;
+ *   - no re-register + live claude session → exactly ONE escalation with
+ *     reason 'bridge-dead-resume', marker written, crash-log tail quoted
+ *     in the audit line;
+ *   - a second miss in the same gateway boot (disconnect after the fuse
+ *     blew) → no second escalation;
+ *   - mid-shutdown → skip, no escalation;
+ *   - claude session not alive → retry (re-arm), no escalation;
+ *   - readFreshCrashLogTail freshness filtering;
+ *   - consumeBridgeDeadEscalationMarker fresh/stale/always-clears;
+ *   - resume-inbound builders surface restartCause honestly (text note +
+ *     meta.restart_cause) without changing meta.source.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, writeFileSync, existsSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  createBridgeDeadWatchdog,
+  decideBridgeDeadEscalation,
+  readFreshCrashLogTail,
+  writeBridgeDeadEscalationMarker,
+  consumeBridgeDeadEscalationMarker,
+  BRIDGE_DEAD_RESTART_REASON,
+  type BridgeDeadWatchdogOpts,
+  type BridgeDeadEscalationMarker,
+} from '../gateway/bridge-dead-watchdog.js'
+import {
+  buildResumeInterruptedInbound,
+  buildResumeWatchdogReportInbound,
+  buildResumeDeferredReportInbound,
+} from '../gateway/resume-inbound-builder.js'
+import type { Turn } from '../registry/turns-schema.js'
+
+// ─── Manual timer harness ────────────────────────────────────────────────────
+
+interface FakeTimer {
+  fn: () => void
+  ms: number
+  cleared: boolean
+}
+
+function makeTimerHarness() {
+  const timers: FakeTimer[] = []
+  return {
+    timers,
+    setTimer: (fn: () => void, ms: number): unknown => {
+      const t: FakeTimer = { fn, ms, cleared: false }
+      timers.push(t)
+      return t
+    },
+    clearTimer: (h: unknown): void => {
+      ;(h as FakeTimer).cleared = true
+    },
+    /** Fire the most recent un-cleared timer (the armed grace window). */
+    fireLatest(): void {
+      const live = timers.filter((t) => !t.cleared)
+      const t = live[live.length - 1]
+      if (!t) throw new Error('no live timer to fire')
+      t.cleared = true
+      t.fn()
+    },
+    liveCount(): number {
+      return timers.filter((t) => !t.cleared).length
+    },
+  }
+}
+
+function makeWatchdog(overrides: Partial<BridgeDeadWatchdogOpts> = {}) {
+  const harness = makeTimerHarness()
+  const escalations: string[] = []
+  const logs: string[] = []
+  const markers: Array<{ path: string; marker: BridgeDeadEscalationMarker }> = []
+  const state = { sessionAlive: true, shuttingDown: false, escalateResult: true }
+  const wd = createBridgeDeadWatchdog({
+    graceMs: 90_000,
+    isSessionAlive: () => state.sessionAlive,
+    isShuttingDown: () => state.shuttingDown,
+    escalate: (reason) => {
+      escalations.push(reason)
+      return state.escalateResult
+    },
+    crashLogPath: '/nonexistent/bridge-crash.log',
+    markerPath: '/nonexistent/bridge-dead-escalation.json',
+    log: (l) => logs.push(l),
+    setTimer: harness.setTimer,
+    clearTimer: harness.clearTimer,
+    nowMs: () => 1_000_000,
+    writeMarker: (path, marker) => markers.push({ path, marker }),
+    readCrashTail: () => null,
+    ...overrides,
+  })
+  return { wd, harness, escalations, logs, markers, state }
+}
+
+// ─── Pure decision table ─────────────────────────────────────────────────────
+
+describe('decideBridgeDeadEscalation', () => {
+  const base = {
+    bridgeRegistered: false,
+    sessionAlive: true,
+    shuttingDown: false,
+    alreadyEscalated: false,
+  }
+  it('escalates when bridge missing, session alive, not shutting down, first time', () => {
+    expect(decideBridgeDeadEscalation(base)).toEqual({ action: 'escalate' })
+  })
+  it('a registered bridge always wins', () => {
+    expect(decideBridgeDeadEscalation({ ...base, bridgeRegistered: true })).toEqual({
+      action: 'skip',
+      why: 'bridge-registered',
+    })
+  })
+  it('mid-shutdown skips even with a dead bridge', () => {
+    expect(decideBridgeDeadEscalation({ ...base, shuttingDown: true })).toEqual({
+      action: 'skip',
+      why: 'shutting-down',
+    })
+  })
+  it('once-per-boot fuse skips a second fire', () => {
+    expect(decideBridgeDeadEscalation({ ...base, alreadyEscalated: true })).toEqual({
+      action: 'skip',
+      why: 'already-escalated',
+    })
+  })
+  it('claude not alive → retry, never escalate', () => {
+    expect(decideBridgeDeadEscalation({ ...base, sessionAlive: false })).toEqual({
+      action: 'retry',
+      why: 'session-not-alive',
+    })
+  })
+})
+
+// ─── Watchdog controller ─────────────────────────────────────────────────────
+
+describe('createBridgeDeadWatchdog', () => {
+  it('bridge re-registers in time → timer cancelled, no escalation', () => {
+    const { wd, harness, escalations } = makeWatchdog()
+    wd.arm()
+    expect(harness.liveCount()).toBe(1)
+    wd.noteBridgeRegistered()
+    expect(harness.liveCount()).toBe(0) // grace timer cancelled
+    expect(escalations).toEqual([])
+    expect(wd.hasEscalated()).toBe(false)
+  })
+
+  it('registered bridge at expiry → skip (defensive: timer fired anyway)', () => {
+    const { wd, escalations } = makeWatchdog()
+    wd.arm()
+    wd.noteBridgeRegistered()
+    // Even if check() runs somehow, the registered flag wins.
+    expect(wd.check()).toEqual({ action: 'skip', why: 'bridge-registered' })
+    expect(escalations).toEqual([])
+  })
+
+  it('no re-register + live session → exactly one escalation with the distinct reason', () => {
+    const { wd, harness, escalations, logs, markers } = makeWatchdog()
+    wd.arm()
+    harness.fireLatest()
+    expect(escalations).toEqual([BRIDGE_DEAD_RESTART_REASON])
+    expect(wd.hasEscalated()).toBe(true)
+    // Marker persisted for the honest resume at next boot.
+    expect(markers).toHaveLength(1)
+    expect(markers[0].marker.reason).toBe(BRIDGE_DEAD_RESTART_REASON)
+    expect(markers[0].marker.ts).toBe(1_000_000)
+    // Audit line is loud and names the reason.
+    const audit = logs.find((l) => l.includes('ESCALATING'))
+    expect(audit).toBeTruthy()
+    expect(audit).toContain(`reason=${BRIDGE_DEAD_RESTART_REASON}`)
+    expect(audit).toContain('no fresh bridge-crash.log entries')
+  })
+
+  it('includes the fresh crash-log tail in the audit line and the marker', () => {
+    const { wd, harness, logs, markers } = makeWatchdog({
+      readCrashTail: () => '2026-07-11T01:41:11.000Z uncaughtException pid=42 boom',
+    })
+    wd.arm()
+    harness.fireLatest()
+    const audit = logs.find((l) => l.includes('ESCALATING'))
+    expect(audit).toContain('bridge-crash.log tail: 2026-07-11T01:41:11.000Z uncaughtException pid=42 boom')
+    expect(markers[0].marker.crashTail).toContain('uncaughtException pid=42 boom')
+  })
+
+  it('second miss in the same boot → no second escalation (fuse)', () => {
+    const { wd, harness, escalations } = makeWatchdog()
+    wd.arm()
+    harness.fireLatest()
+    expect(escalations).toHaveLength(1)
+    // The bridge briefly reconnects then dies again — disconnect re-arm is
+    // a no-op after the fuse blew, and a direct check() skips.
+    wd.noteBridgeDisconnected()
+    expect(harness.liveCount()).toBe(0) // fuse prevents re-arm
+    expect(wd.check()).toEqual({ action: 'skip', why: 'already-escalated' })
+    expect(escalations).toHaveLength(1)
+  })
+
+  it('mid-shutdown → skip, no escalation, no marker', () => {
+    const { wd, harness, escalations, markers, state } = makeWatchdog()
+    wd.arm()
+    state.shuttingDown = true
+    harness.fireLatest()
+    expect(escalations).toEqual([])
+    expect(markers).toEqual([])
+    expect(wd.hasEscalated()).toBe(false)
+  })
+
+  it('claude session not alive → retry: re-arms, never escalates', () => {
+    const { wd, harness, escalations, state } = makeWatchdog()
+    state.sessionAlive = false
+    wd.arm()
+    harness.fireLatest()
+    expect(escalations).toEqual([])
+    expect(harness.liveCount()).toBe(1) // re-armed for another grace window
+    // claude comes up but the bridge never registers → NOW it escalates.
+    state.sessionAlive = true
+    harness.fireLatest()
+    expect(escalations).toEqual([BRIDGE_DEAD_RESTART_REASON])
+  })
+
+  it('bridge disconnect mid-life re-arms; a prompt reconnect stands it down', () => {
+    const { wd, harness, escalations } = makeWatchdog()
+    wd.arm()
+    wd.noteBridgeRegistered()
+    expect(harness.liveCount()).toBe(0)
+    wd.noteBridgeDisconnected()
+    expect(harness.liveCount()).toBe(1)
+    wd.noteBridgeRegistered()
+    expect(harness.liveCount()).toBe(0)
+    expect(escalations).toEqual([])
+  })
+
+  it('bridge disconnect mid-life with no reconnect → one escalation', () => {
+    const { wd, harness, escalations } = makeWatchdog()
+    wd.arm()
+    wd.noteBridgeRegistered()
+    wd.noteBridgeDisconnected()
+    harness.fireLatest()
+    expect(escalations).toEqual([BRIDGE_DEAD_RESTART_REASON])
+  })
+
+  it('a throwing marker writer does not block the escalation itself', () => {
+    const { wd, harness, escalations, logs } = makeWatchdog({
+      writeMarker: () => {
+        throw new Error('disk full')
+      },
+    })
+    wd.arm()
+    harness.fireLatest()
+    expect(escalations).toEqual([BRIDGE_DEAD_RESTART_REASON])
+    expect(logs.some((l) => l.includes('escalation marker write failed'))).toBe(true)
+  })
+
+  it('stop() cancels the pending timer', () => {
+    const { wd, harness, escalations } = makeWatchdog()
+    wd.arm()
+    wd.stop()
+    expect(harness.liveCount()).toBe(0)
+    expect(escalations).toEqual([])
+  })
+})
+
+// ─── Crash-log tail ──────────────────────────────────────────────────────────
+
+describe('readFreshCrashLogTail', () => {
+  const now = Date.parse('2026-07-11T02:00:00.000Z')
+  it('returns only fresh entries, last N, joined', () => {
+    const raw = [
+      '2026-07-11T00:00:00.000Z uncaughtException pid=1 old entry',
+      '2026-07-11T01:55:00.000Z uncaughtException pid=2 fresh one',
+      '2026-07-11T01:59:00.000Z unhandledRejection pid=2 fresh two',
+      'garbage line without timestamp',
+      '',
+    ].join('\n')
+    const tail = readFreshCrashLogTail('/x', { nowMs: now, readFile: () => raw })
+    expect(tail).toBe(
+      '2026-07-11T01:55:00.000Z uncaughtException pid=2 fresh one || ' +
+        '2026-07-11T01:59:00.000Z unhandledRejection pid=2 fresh two',
+    )
+  })
+  it('null when file missing', () => {
+    expect(
+      readFreshCrashLogTail('/x', {
+        nowMs: now,
+        readFile: () => {
+          throw new Error('ENOENT')
+        },
+      }),
+    ).toBeNull()
+  })
+  it('null when all entries are stale', () => {
+    const raw = '2026-07-10T00:00:00.000Z uncaughtException pid=1 ancient\n'
+    expect(readFreshCrashLogTail('/x', { nowMs: now, readFile: () => raw })).toBeNull()
+  })
+  it('caps to maxLines (most recent)', () => {
+    const raw = [1, 2, 3, 4, 5]
+      .map((i) => `2026-07-11T01:59:0${i}.000Z uncaughtException pid=${i} e${i}`)
+      .join('\n')
+    const tail = readFreshCrashLogTail('/x', {
+      nowMs: now,
+      readFile: () => raw,
+      maxLines: 2,
+    })
+    expect(tail).toContain('e4')
+    expect(tail).toContain('e5')
+    expect(tail).not.toContain('e3')
+  })
+})
+
+// ─── Escalation marker round-trip ────────────────────────────────────────────
+
+describe('bridge-dead escalation marker', () => {
+  it('fresh marker round-trips and is consumed (file removed)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bridge-dead-marker-'))
+    const p = join(dir, 'bridge-dead-escalation.json')
+    writeBridgeDeadEscalationMarker(p, {
+      ts: 5_000,
+      reason: BRIDGE_DEAD_RESTART_REASON,
+      crashTail: 'tail here',
+    })
+    const m = consumeBridgeDeadEscalationMarker(p, 6_000)
+    expect(m).toEqual({ ts: 5_000, reason: BRIDGE_DEAD_RESTART_REASON, crashTail: 'tail here' })
+    expect(existsSync(p)).toBe(false)
+  })
+  it('stale marker is cleared and NOT surfaced', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bridge-dead-marker-'))
+    const p = join(dir, 'bridge-dead-escalation.json')
+    writeBridgeDeadEscalationMarker(p, { ts: 0, reason: BRIDGE_DEAD_RESTART_REASON })
+    const m = consumeBridgeDeadEscalationMarker(p, 60 * 60_000)
+    expect(m).toBeNull()
+    expect(existsSync(p)).toBe(false)
+  })
+  it('malformed marker is cleared without throwing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bridge-dead-marker-'))
+    const p = join(dir, 'bridge-dead-escalation.json')
+    writeFileSync(p, 'not json', 'utf8')
+    expect(consumeBridgeDeadEscalationMarker(p, 1)).toBeNull()
+    expect(existsSync(p)).toBe(false)
+  })
+  it('missing marker → null, no throw', () => {
+    expect(consumeBridgeDeadEscalationMarker('/nonexistent/marker.json', 1)).toBeNull()
+  })
+  it('marker write is atomic-shaped (valid JSON on disk)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bridge-dead-marker-'))
+    const p = join(dir, 'm.json')
+    writeBridgeDeadEscalationMarker(p, { ts: 1, reason: 'r' })
+    expect(JSON.parse(readFileSync(p, 'utf8'))).toEqual({ ts: 1, reason: 'r' })
+  })
+})
+
+// ─── Honest resume surfacing ─────────────────────────────────────────────────
+
+function makeTurn(overrides: Partial<Turn> = {}): Turn {
+  return {
+    turn_key: '100001:11',
+    chat_id: '100001',
+    thread_id: null,
+    started_at: 1_000_000,
+    ended_at: null,
+    ended_via: 'restart',
+    last_assistant_msg_id: null,
+    last_assistant_done: null,
+    last_user_msg_id: 11,
+    user_prompt_preview: 'do the thing',
+    tool_call_count: 2,
+    interrupt_reason: null,
+    resumed_at: null,
+    ...overrides,
+  } as Turn
+}
+
+describe('resume inbound restartCause surfacing (#3038)', () => {
+  const cause = {
+    reason: BRIDGE_DEAD_RESTART_REASON,
+    note: 'The framework itself triggered this restart: your Telegram MCP bridge process had died.',
+  }
+
+  it('resume_interrupted carries meta.restart_cause + the honest note, source unchanged', () => {
+    const msg = buildResumeInterruptedInbound({ turn: makeTurn(), nowMs: 2_000_000, restartCause: cause })
+    expect(msg.meta?.source).toBe('resume_interrupted') // never masquerades as watchdog
+    expect(msg.meta?.restart_cause).toBe(BRIDGE_DEAD_RESTART_REASON)
+    expect(msg.text).toContain('Why this restart happened:')
+    expect(msg.text).toContain('Telegram MCP bridge process had died')
+  })
+
+  it('watchdog report also carries the cause when one was recorded', () => {
+    const msg = buildResumeWatchdogReportInbound({
+      turn: makeTurn({ ended_via: 'timeout' }),
+      idleMs: 300_000,
+      nowMs: 2_000_000,
+      restartCause: cause,
+    })
+    expect(msg.meta?.source).toBe('resume_watchdog_timeout')
+    expect(msg.meta?.restart_cause).toBe(BRIDGE_DEAD_RESTART_REASON)
+    expect(msg.text).toContain('Why this restart happened:')
+  })
+
+  it('deferred report also carries the cause', () => {
+    const msg = buildResumeDeferredReportInbound({
+      turn: makeTurn(),
+      reason: 'loop-guard',
+      nowMs: 2_000_000,
+      restartCause: cause,
+    })
+    expect(msg.meta?.source).toBe('resume_deferred')
+    expect(msg.meta?.restart_cause).toBe(BRIDGE_DEAD_RESTART_REASON)
+    expect(msg.text).toContain('Why this restart happened:')
+  })
+
+  it('no restartCause → inbound unchanged (no meta key, no note)', () => {
+    const msg = buildResumeInterruptedInbound({ turn: makeTurn(), nowMs: 2_000_000 })
+    expect(msg.meta?.restart_cause).toBeUndefined()
+    expect(msg.text).not.toContain('Why this restart happened:')
+  })
+})

--- a/telegram-plugin/tests/bridge-dead-watchdog.test.ts
+++ b/telegram-plugin/tests/bridge-dead-watchdog.test.ts
@@ -12,10 +12,18 @@
  *     blew) → no second escalation;
  *   - mid-shutdown → skip, no escalation;
  *   - claude session not alive → retry (re-arm), no escalation;
+ *   - cross-boot damper: marker carries a consecutive count; at the cap
+ *     the watchdog stands down (no restart loop for a deterministically
+ *     failing bridge); a registration this boot breaks the streak; the
+ *     retry boot gets a doubled grace window;
+ *   - cron / anonymous identities neither satisfy nor re-arm the watchdog
+ *     (gating INSIDE noteBridge*, refactor-proof);
  *   - readFreshCrashLogTail freshness filtering;
- *   - consumeBridgeDeadEscalationMarker fresh/stale/always-clears;
+ *   - consumeBridgeDeadEscalationMarker fresh/stale/always-clears + count
+ *     round-trip;
  *   - resume-inbound builders surface restartCause honestly (text note +
- *     meta.restart_cause) without changing meta.source.
+ *     meta.restart_cause) without changing meta.source;
+ *   - idle notice inbound (no turn in flight) carries the honest cause.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -28,7 +36,9 @@ import {
   readFreshCrashLogTail,
   writeBridgeDeadEscalationMarker,
   consumeBridgeDeadEscalationMarker,
+  buildBridgeDeadIdleNoticeInbound,
   BRIDGE_DEAD_RESTART_REASON,
+  MAX_CONSECUTIVE_ESCALATIONS,
   type BridgeDeadWatchdogOpts,
   type BridgeDeadEscalationMarker,
 } from '../gateway/bridge-dead-watchdog.js'
@@ -38,6 +48,8 @@ import {
   buildResumeDeferredReportInbound,
 } from '../gateway/resume-inbound-builder.js'
 import type { Turn } from '../registry/turns-schema.js'
+
+const AGENT = 'clerk'
 
 // ─── Manual timer harness ────────────────────────────────────────────────────
 
@@ -69,6 +81,12 @@ function makeTimerHarness() {
     },
     liveCount(): number {
       return timers.filter((t) => !t.cleared).length
+    },
+    latestMs(): number {
+      const live = timers.filter((t) => !t.cleared)
+      const t = live[live.length - 1]
+      if (!t) throw new Error('no live timer')
+      return t.ms
     },
   }
 }
@@ -105,9 +123,12 @@ function makeWatchdog(overrides: Partial<BridgeDeadWatchdogOpts> = {}) {
 describe('decideBridgeDeadEscalation', () => {
   const base = {
     bridgeRegistered: false,
+    bridgeEverRegistered: false,
     sessionAlive: true,
     shuttingDown: false,
     alreadyEscalated: false,
+    priorStreak: 0,
+    maxConsecutive: MAX_CONSECUTIVE_ESCALATIONS,
   }
   it('escalates when bridge missing, session alive, not shutting down, first time', () => {
     expect(decideBridgeDeadEscalation(base)).toEqual({ action: 'escalate' })
@@ -136,6 +157,25 @@ describe('decideBridgeDeadEscalation', () => {
       why: 'session-not-alive',
     })
   })
+  it('cross-boot streak at the cap → streak-capped skip', () => {
+    expect(
+      decideBridgeDeadEscalation({ ...base, priorStreak: MAX_CONSECUTIVE_ESCALATIONS }),
+    ).toEqual({ action: 'skip', why: 'streak-capped' })
+  })
+  it('streak below the cap still escalates', () => {
+    expect(decideBridgeDeadEscalation({ ...base, priorStreak: 1 })).toEqual({
+      action: 'escalate',
+    })
+  })
+  it('a registration THIS boot breaks the streak (new incident)', () => {
+    expect(
+      decideBridgeDeadEscalation({
+        ...base,
+        bridgeEverRegistered: true,
+        priorStreak: MAX_CONSECUTIVE_ESCALATIONS + 3,
+      }),
+    ).toEqual({ action: 'escalate' })
+  })
 })
 
 // ─── Watchdog controller ─────────────────────────────────────────────────────
@@ -145,7 +185,7 @@ describe('createBridgeDeadWatchdog', () => {
     const { wd, harness, escalations } = makeWatchdog()
     wd.arm()
     expect(harness.liveCount()).toBe(1)
-    wd.noteBridgeRegistered()
+    wd.noteBridgeRegistered(AGENT)
     expect(harness.liveCount()).toBe(0) // grace timer cancelled
     expect(escalations).toEqual([])
     expect(wd.hasEscalated()).toBe(false)
@@ -154,7 +194,7 @@ describe('createBridgeDeadWatchdog', () => {
   it('registered bridge at expiry → skip (defensive: timer fired anyway)', () => {
     const { wd, escalations } = makeWatchdog()
     wd.arm()
-    wd.noteBridgeRegistered()
+    wd.noteBridgeRegistered(AGENT)
     // Even if check() runs somehow, the registered flag wins.
     expect(wd.check()).toEqual({ action: 'skip', why: 'bridge-registered' })
     expect(escalations).toEqual([])
@@ -166,10 +206,11 @@ describe('createBridgeDeadWatchdog', () => {
     harness.fireLatest()
     expect(escalations).toEqual([BRIDGE_DEAD_RESTART_REASON])
     expect(wd.hasEscalated()).toBe(true)
-    // Marker persisted for the honest resume at next boot.
+    // Marker persisted for the honest resume + streak damper at next boot.
     expect(markers).toHaveLength(1)
     expect(markers[0].marker.reason).toBe(BRIDGE_DEAD_RESTART_REASON)
     expect(markers[0].marker.ts).toBe(1_000_000)
+    expect(markers[0].marker.count).toBe(1) // first fire of a streak
     // Audit line is loud and names the reason.
     const audit = logs.find((l) => l.includes('ESCALATING'))
     expect(audit).toBeTruthy()
@@ -195,7 +236,7 @@ describe('createBridgeDeadWatchdog', () => {
     expect(escalations).toHaveLength(1)
     // The bridge briefly reconnects then dies again — disconnect re-arm is
     // a no-op after the fuse blew, and a direct check() skips.
-    wd.noteBridgeDisconnected()
+    wd.noteBridgeDisconnected(AGENT)
     expect(harness.liveCount()).toBe(0) // fuse prevents re-arm
     expect(wd.check()).toEqual({ action: 'skip', why: 'already-escalated' })
     expect(escalations).toHaveLength(1)
@@ -227,11 +268,11 @@ describe('createBridgeDeadWatchdog', () => {
   it('bridge disconnect mid-life re-arms; a prompt reconnect stands it down', () => {
     const { wd, harness, escalations } = makeWatchdog()
     wd.arm()
-    wd.noteBridgeRegistered()
+    wd.noteBridgeRegistered(AGENT)
     expect(harness.liveCount()).toBe(0)
-    wd.noteBridgeDisconnected()
+    wd.noteBridgeDisconnected(AGENT)
     expect(harness.liveCount()).toBe(1)
-    wd.noteBridgeRegistered()
+    wd.noteBridgeRegistered(AGENT)
     expect(harness.liveCount()).toBe(0)
     expect(escalations).toEqual([])
   })
@@ -239,8 +280,8 @@ describe('createBridgeDeadWatchdog', () => {
   it('bridge disconnect mid-life with no reconnect → one escalation', () => {
     const { wd, harness, escalations } = makeWatchdog()
     wd.arm()
-    wd.noteBridgeRegistered()
-    wd.noteBridgeDisconnected()
+    wd.noteBridgeRegistered(AGENT)
+    wd.noteBridgeDisconnected(AGENT)
     harness.fireLatest()
     expect(escalations).toEqual([BRIDGE_DEAD_RESTART_REASON])
   })
@@ -263,6 +304,85 @@ describe('createBridgeDeadWatchdog', () => {
     wd.stop()
     expect(harness.liveCount()).toBe(0)
     expect(escalations).toEqual([])
+  })
+})
+
+// ─── Cross-boot restart-loop damper (#3038 review finding 1) ─────────────────
+
+describe('cross-boot escalation streak damper', () => {
+  it('priorStreak below the cap: escalates with an incremented count and doubled grace', () => {
+    const { wd, harness, escalations, markers } = makeWatchdog({ priorStreak: 1 })
+    wd.arm()
+    expect(harness.latestMs()).toBe(180_000) // doubled window on the retry boot
+    harness.fireLatest()
+    expect(escalations).toEqual([BRIDGE_DEAD_RESTART_REASON])
+    expect(markers[0].marker.count).toBe(2) // streak extended
+  })
+
+  it('priorStreak at the cap: arm() stands down loudly, no timer, no escalation', () => {
+    const { wd, harness, escalations, logs } = makeWatchdog({
+      priorStreak: MAX_CONSECUTIVE_ESCALATIONS,
+    })
+    wd.arm()
+    expect(harness.liveCount()).toBe(0) // never armed — no restart loop
+    expect(escalations).toEqual([])
+    const standDown = logs.find((l) => l.includes('STANDING DOWN'))
+    expect(standDown).toBeTruthy()
+    expect(standDown).toContain('SWITCHROOM_BRIDGE_DEAD_ESCALATION=0') // kill-switch reminder
+    // Even a direct check() cannot fire past the cap.
+    expect(wd.check()).toEqual({ action: 'skip', why: 'streak-capped' })
+    expect(escalations).toEqual([])
+  })
+
+  it('a successful registration this boot breaks the streak: escalation restarts at count=1', () => {
+    const { wd, harness, escalations, markers } = makeWatchdog({
+      priorStreak: MAX_CONSECUTIVE_ESCALATIONS,
+    })
+    // Bridge DID come back this boot — the old streak is over.
+    wd.noteBridgeRegistered(AGENT)
+    // …then it dies mid-life: this is a NEW incident and may escalate.
+    wd.noteBridgeDisconnected(AGENT)
+    expect(harness.liveCount()).toBe(1)
+    expect(harness.latestMs()).toBe(90_000) // normal grace — streak broken
+    harness.fireLatest()
+    expect(escalations).toEqual([BRIDGE_DEAD_RESTART_REASON])
+    expect(markers[0].marker.count).toBe(1)
+  })
+})
+
+// ─── Identity gating inside the watchdog (#3038 review finding 5) ────────────
+
+describe('cron / anonymous identity gating', () => {
+  it('a cron-session bridge registering does NOT satisfy the watchdog', () => {
+    const { wd, harness, escalations } = makeWatchdog()
+    wd.arm()
+    wd.noteBridgeRegistered(`${AGENT}-cron`)
+    expect(harness.liveCount()).toBe(1) // still armed — cron is not the real bridge
+    harness.fireLatest()
+    expect(escalations).toEqual([BRIDGE_DEAD_RESTART_REASON]) // real bridge still dead
+  })
+
+  it('a cron-session bridge disconnecting does NOT re-arm (no bounce-after-cron-fire)', () => {
+    const { wd, harness, escalations } = makeWatchdog()
+    wd.arm()
+    wd.noteBridgeRegistered(AGENT) // real bridge healthy
+    expect(harness.liveCount()).toBe(0)
+    wd.noteBridgeDisconnected(`${AGENT}-cron`) // cron teardown — irrelevant
+    expect(harness.liveCount()).toBe(0)
+    expect(escalations).toEqual([])
+  })
+
+  it('anonymous clients (agentName null/empty) are ignored on both paths', () => {
+    const { wd, harness } = makeWatchdog()
+    wd.arm()
+    wd.noteBridgeRegistered(null)
+    wd.noteBridgeRegistered(undefined)
+    wd.noteBridgeRegistered('')
+    expect(harness.liveCount()).toBe(1) // none satisfied it
+    wd.noteBridgeRegistered(AGENT)
+    expect(harness.liveCount()).toBe(0)
+    wd.noteBridgeDisconnected(null) // recall.py one-shot closing
+    expect(harness.liveCount()).toBe(0) // did not re-arm
   })
 })
 
@@ -316,17 +436,30 @@ describe('readFreshCrashLogTail', () => {
 // ─── Escalation marker round-trip ────────────────────────────────────────────
 
 describe('bridge-dead escalation marker', () => {
-  it('fresh marker round-trips and is consumed (file removed)', () => {
+  it('fresh marker round-trips (incl. count) and is consumed (file removed)', () => {
     const dir = mkdtempSync(join(tmpdir(), 'bridge-dead-marker-'))
     const p = join(dir, 'bridge-dead-escalation.json')
     writeBridgeDeadEscalationMarker(p, {
       ts: 5_000,
       reason: BRIDGE_DEAD_RESTART_REASON,
+      count: 2,
       crashTail: 'tail here',
     })
     const m = consumeBridgeDeadEscalationMarker(p, 6_000)
-    expect(m).toEqual({ ts: 5_000, reason: BRIDGE_DEAD_RESTART_REASON, crashTail: 'tail here' })
+    expect(m).toEqual({
+      ts: 5_000,
+      reason: BRIDGE_DEAD_RESTART_REASON,
+      count: 2,
+      crashTail: 'tail here',
+    })
     expect(existsSync(p)).toBe(false)
+  })
+  it('legacy marker without count is read as count=1', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bridge-dead-marker-'))
+    const p = join(dir, 'bridge-dead-escalation.json')
+    writeFileSync(p, JSON.stringify({ ts: 5_000, reason: BRIDGE_DEAD_RESTART_REASON }), 'utf8')
+    const m = consumeBridgeDeadEscalationMarker(p, 6_000)
+    expect(m?.count).toBe(1)
   })
   it('stale marker is cleared and NOT surfaced', () => {
     const dir = mkdtempSync(join(tmpdir(), 'bridge-dead-marker-'))
@@ -349,8 +482,8 @@ describe('bridge-dead escalation marker', () => {
   it('marker write is atomic-shaped (valid JSON on disk)', () => {
     const dir = mkdtempSync(join(tmpdir(), 'bridge-dead-marker-'))
     const p = join(dir, 'm.json')
-    writeBridgeDeadEscalationMarker(p, { ts: 1, reason: 'r' })
-    expect(JSON.parse(readFileSync(p, 'utf8'))).toEqual({ ts: 1, reason: 'r' })
+    writeBridgeDeadEscalationMarker(p, { ts: 1, reason: 'r', count: 1 })
+    expect(JSON.parse(readFileSync(p, 'utf8'))).toEqual({ ts: 1, reason: 'r', count: 1 })
   })
 })
 
@@ -417,5 +550,27 @@ describe('resume inbound restartCause surfacing (#3038)', () => {
     const msg = buildResumeInterruptedInbound({ turn: makeTurn(), nowMs: 2_000_000 })
     expect(msg.meta?.restart_cause).toBeUndefined()
     expect(msg.text).not.toContain('Why this restart happened:')
+  })
+})
+
+// ─── Idle notice (#3038 review finding 2) ────────────────────────────────────
+
+describe('buildBridgeDeadIdleNoticeInbound', () => {
+  it('carries the honest cause to the default chat when no turn was in flight', () => {
+    const msg = buildBridgeDeadIdleNoticeInbound({
+      chatId: '100001',
+      marker: { ts: 5_000, reason: BRIDGE_DEAD_RESTART_REASON, count: 1 },
+      nowMs: 2_000_000,
+    })
+    expect(msg.type).toBe('inbound')
+    expect(msg.chatId).toBe('100001')
+    expect(msg.meta?.source).toBe('bridge_dead_restart')
+    expect(msg.meta?.restart_cause).toBe(BRIDGE_DEAD_RESTART_REASON)
+    expect(msg.meta?.chat_id).toBe('100001')
+    expect(msg.text).toContain('MCP bridge process had died')
+    expect(msg.text).toContain('No work was in flight')
+    // Honesty rails: names what it was NOT.
+    expect(msg.text).toContain('NOT an operator-initiated restart')
+    expect(msg.text).toContain('NOT a hang-watchdog kill')
   })
 })


### PR DESCRIPTION
## Summary
Gateway-side escalation for the dead-MCP-bridge failure mode (#3038, follow-up to #3033 / PR #3037). After gateway boot (or a mid-life bridge disconnect), if no real (named, non-cron) bridge registers on the IPC socket within a grace window (`SWITCHROOM_BRIDGE_DEAD_GRACE_MS`, default 90s) while the claude session process is demonstrably alive, the gateway bounces the container via the existing `triggerSelfRestart` machinery with the distinct reason `bridge-dead-resume` — the only recovery path, since Claude Code never respawns a dead MCP server.

## Why
2026-07-11 clerk incident: gateway crashed, supervisor relaunched it in ~1s, the bridge process inside the running claude session died with it. The agent stayed alive but toolless and mute (`No such tool available: mcp__switchroom-telegram__reply`) for 7 minutes until a manual container restart, while the gateway sat at `bridge_dead` buffering inbounds. PR #3037 hardened the bridge against dying; this closes the structural gap.

## Design
- **New `telegram-plugin/gateway/bridge-dead-watchdog.ts`** — pure decision function + controller with injected timers/fs/clock/restart, so every guard rail is unit-tested without booting a gateway.
- **Guard rails:** at most ONE escalation per gateway boot (no restart loop when the bridge dies deterministically at startup); skipped mid-shutdown; when the claude process is not up yet the timer re-arms instead of escalating (slow container boot ≠ dead bridge). Kill switch `SWITCHROOM_BRIDGE_DEAD_ESCALATION=0`.
- **Breadcrumb integration (PR #3037):** the escalation audit line quotes the fresh tail of `STATE_DIR/bridge-crash.log`, so the supervisor log alone answers "why did this container bounce itself".
- **Honest resume:** before firing, the watchdog persists `bridge-dead-escalation.json`; the next boot consumes it (always cleared, 10-min freshness) and appends the real cause to whichever boot resume/report inbound fires (text note + `meta.restart_cause`), leaving `meta.source` untouched — the resume never pretends to be an operator restart or a hang-watchdog timeout.
- Registration/disconnect hooks reuse the existing anonymous-client and cron-identity gates (recall.py one-shot IPC clients and `<agent>-cron` bridges never satisfy or arm the watchdog).

## Job spec
`reference/jobs/always-on.md` — a mute-but-alive agent is the always-available outcome failing silently; this makes the framework self-heal it in ≤~90s instead of waiting for the operator.

## Test plan
- `telegram-plugin/tests/bridge-dead-watchdog.test.ts` (vitest, 29 tests): decision table; bridge re-registers in time → no escalation; no re-register + live session → exactly one escalation with reason; second miss same boot → fuse holds; mid-shutdown → skip; session-not-alive → retry; crash-log tail freshness/cap; marker round-trip (fresh/stale/malformed/always-cleared); builder restartCause surfacing incl. source-unchanged assertion.
- Neighbouring suites green locally: `resume-inbound-builder` (bun, 60), `gateway-bridge`, `boot-card-reason`, `gateway-clean-shutdown-marker`, `fleet-fallback-resume`, `escalation-bridge-gate`.
- `npm run lint` clean (tsc + all 8 guards, incl. bot-api allowlist).

## Risk
Escalation is a container self-restart — bounded to once per gateway boot and gated on a live claude process, with an env kill switch. Marker/crash-log IO is best-effort and never blocks or throws into the boot path.

Closes #3038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-fix round (commit cd480586)
- **Cross-boot damper (finding 1):** escalation marker carries a consecutive-fire `count`; at `MAX_CONSECUTIVE_ESCALATIONS` (2) the next boot stands the watchdog down with a loud audit line + kill-switch reminder instead of restart-looping a deterministically-failing bridge. Registration breaks the streak; retry boot gets a doubled grace window. Tested.
- **Idle-case honesty (finding 2):** marker consumed with no interrupted turn now queues a minimal `bridge_dead_restart` boot inbound to the agent's default chat, so the user is told why the container bounced even when idle.
- **Marker race (finding 3):** documented on `consumeBridgeDeadEscalationMarker` — an interim gateway relaunch can consume the marker one boot early; consequences bounded (honesty note lost for one incident at worst, damper under-counts toward MORE self-healing, supervisor-log audit line survives).
- **Session-alive tightening (finding 4):** watchdog requires `comm === 'claude'`; the heaviest-node fallback can no longer flip a retry into a bounce on an orphaned node process. False negatives fail safe (retry forever, never escalate).
- **Identity gating (finding 5):** cron/anonymous gating lives INSIDE `noteBridgeRegistered/Disconnected` (call sites pass `client.agentName`), so a gateway handler refactor can't reorder it away. Pinned by tests (cron register doesn't satisfy, cron disconnect doesn't re-arm, anonymous ignored).
- **Merge-order note (finding 6):** as of this push no other open PR touches `onClientRegistered`/`onClientDisconnected`; if a command-queue refactor of those handlers merges first, the watchdog call sites are order-independent by design (internal identity gating) — the only rebase requirement is keeping one `noteBridgeRegistered(client.agentName)` and one `noteBridgeDisconnected(client.agentName)` call anywhere in the respective handlers.
