### PR TITLE
fix(telegram): apply-or-queue contract for session commands; overrides survive restarts/deploys

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1067,21 +1067,21 @@ fi
 
 # --- Session model resolution (durable .session-model + .relaunch-model-intent) ---
 #
-# Contract: reference/rfcs/session-model-stickiness.md. A positively-
-# confirmed `/model X` switch persists as `{{agentDir}}/.session-model`
-# (one-line JSON written by the gateway). Whether THIS boot applies it is
-# decided by the one-shot `.relaunch-model-intent` file, stamped by the
-# gateway immediately before every switchroom-managed bounce:
+# Contract: reference/rfcs/session-model-stickiness.md (#3039 revision). A
+# positively-confirmed `/model X` switch persists as
+# `{{agentDir}}/.session-model` (one-line JSON written by the gateway) and is
+# honored on EVERY boot — deploy, watchdog bounce, raw `docker restart`,
+# host reboot, crash. It is cleared only by:
 #
-#   fresh (<10 min by embedded ts) "keep" intent  → apply the override
-#   anything else (revert / absent / stale / corrupt) → delete the override,
-#     boot the configured default, and (when an override was actually
-#     removed) write a `.session-model-alert` notice naming why.
+#   - explicit user action (`/model default` deletes it live; a fresh
+#     (<10 min) explicit "revert" `.relaunch-model-intent` reverts at boot)
+#   - invalidation: corrupt/malformed file, or the configured yaml `model:`
+#     changed since the switch
 #
-# Default is REVERT (operator decision 2026-07): a crash, OOM, raw
-# `docker restart`, host reboot, or deploy writes no intent and therefore
-# reverts to the yaml model. Watchdog/recovery bounces run gateway code and
-# stamp "keep" before SIGTERM, so a confirmed switch survives them.
+# Every clearing path writes `.session-model-alert`, which the gateway
+# relays to the operator chat once at boot — an override is never dropped
+# silently. Default (no intent / stale / corrupt intent) is KEEP (operator
+# decision 2026-07-11, superseding the earlier revert-by-default).
 #
 # NB {{{modelQ}}} is already shell-single-quoted by the scaffold (it renders as
 # a quoted token, e.g. 'claude-sonnet-5'), so it is assigned BARE here — never
@@ -1117,14 +1117,18 @@ fi
 # Freshness clock is the EMBEDDED ts (ms), never file mtime — same clock the
 # gateway writes with.
 _sm_reason=""
+_sm_revert=""
 if [ -f "{{agentDir}}/.relaunch-model-intent" ]; then
   _int_raw="$(cat "{{agentDir}}/.relaunch-model-intent" 2>/dev/null || true)"
   rm -f "{{agentDir}}/.relaunch-model-intent"
   _int="$(printf '%s' "$_int_raw" | sed -n 's/.*"intent"[[:space:]]*:[[:space:]]*"\([a-z]*\)".*/\1/p')"
   _int_ts="$(printf '%s' "$_int_raw" | sed -n 's/.*"ts"[[:space:]]*:[[:space:]]*\([0-9]\{1,\}\).*/\1/p')"
   _sm_reason="$(printf '%s' "$_int_raw" | sed -n 's/.*"reason"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
-  if [ "$_int" = "keep" ] && [ -n "$_int_ts" ] && [ $(( $(date +%s) * 1000 - _int_ts )) -lt 600000 ]; then
-    _sm_keep="1"
+  # #3039: boot default is KEEP. Only a FRESH explicit "revert" intent
+  # (stamped by an explicit user/gateway revert path) clears the override.
+  # A stale or corrupt intent counts as no intent → keep.
+  if [ "$_int" = "revert" ] && [ -n "$_int_ts" ] && [ $(( $(date +%s) * 1000 - _int_ts )) -lt 600000 ]; then
+    _sm_revert="1"
   fi
   unset _int_raw _int _int_ts
 fi
@@ -1134,13 +1138,13 @@ if [ -f "{{agentDir}}/.session-model" ]; then
   _sm_model="$(printf '%s' "$_smf" | sed -n 's/.*"model"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
   _sm_cfg="$(printf '%s' "$_smf" | sed -n 's/.*"configuredDefaultAtWrite"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
   _sm_ts="$(printf '%s' "$_smf" | sed -n 's/.*"ts"[[:space:]]*:[[:space:]]*\([0-9]\{1,\}\).*/\1/p')"
-  if [ -z "$_sm_keep" ]; then
-    # No fresh keep intent → deliberate restart, crash, external container
-    # restart, or deploy. Revert to the configured default and say so.
+  if [ -n "$_sm_revert" ]; then
+    # Explicit fresh revert intent — the ONLY boot path that clears a valid
+    # override by design (#3039). Everything else keeps.
     rm -f "{{agentDir}}/.session-model"
-    _sm_why="${_sm_reason:-no keep intent — crash, external container restart, or deploy}"
+    _sm_why="${_sm_reason:-explicit revert intent}"
     echo "session-model: reverting to configured default '$_EFFECTIVE_MODEL' — $_sm_why (session override '$_sm_model' cleared)" >&2
-    printf 'Session model override `%s` was cleared — this relaunch reverted to the configured default `%s` (%s). Re-issue /model %s to switch back.\n' "$_sm_model" "$_EFFECTIVE_MODEL" "$_sm_why" "$_sm_model" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+    printf 'Session model override `%s` was cleared as requested (%s) — this relaunch booted the configured default `%s`. Re-issue /model %s to switch back.\n' "$_sm_model" "$_sm_why" "$_EFFECTIVE_MODEL" "$_sm_model" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
     unset _sm_why
   # Shape gate — kept BYTE-IDENTICAL with MODEL_ARG_RE in
   # telegram-plugin/gateway/model-command.ts. `/` is allowed for
@@ -1151,20 +1155,18 @@ if [ -f "{{agentDir}}/.session-model" ]; then
   # passes if ANY line matches — a multiline value must never reach
   # `claude --model` (parity with parseSessionModel's single-string check).
   elif [ "$(printf '%s' "$_sm_model" | wc -c)" -eq 0 ] || [ "$(printf '%s' "$_sm_model" | wc -l)" -ne 0 ] || ! printf '%s' "$_sm_model" | grep -Eq '^[A-Za-z0-9][]A-Za-z0-9._[/-]{0,99}$'; then
+    # Invalid carrier (#3039): fall back to the configured default AND tell
+    # the operator once — never a silent stderr-only drop.
     rm -f "{{agentDir}}/.session-model"
     echo "session-model: ignoring malformed .session-model (failed shape gate) — using configured default '$_EFFECTIVE_MODEL'" >&2
+    printf 'Your saved session model override could not be read (invalid or corrupt), so the agent booted on its configured default `%s`. Re-issue /model <name> if you want a different model.\n' "$_EFFECTIVE_MODEL" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
   elif [ "$_sm_cfg" != "$_EFFECTIVE_MODEL" ]; then
     # switchroom.yaml `model:` changed since the switch → the override is
-    # against a default that no longer exists. Invalidate + announce.
+    # against a default that no longer exists (it may name a retired model).
+    # Invalidate + announce once (#3039 invalid-carrier fallback).
     rm -f "{{agentDir}}/.session-model"
     echo "session-model: configured default changed ('$_sm_cfg' → '$_EFFECTIVE_MODEL') — clearing session override '$_sm_model'" >&2
     printf 'The configured default model changed (`%s` → `%s`), so your session override to `%s` was cleared — the agent booted on the new configured default. Re-issue /model %s if you still want it.\n' "$_sm_cfg" "$_EFFECTIVE_MODEL" "$_sm_model" "$_sm_model" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
-  elif [ -n "$_sm_ts" ] && [ $(( $(date +%s) * 1000 - _sm_ts )) -gt 604800000 ]; then
-    # 7-day staleness bound (belt-and-braces vs version-rollback resurrection
-    # and long-forgotten overrides).
-    rm -f "{{agentDir}}/.session-model"
-    echo "session-model: session override '$_sm_model' is older than 7 days — expiring it, using configured default '$_EFFECTIVE_MODEL'" >&2
-    printf 'Session model override `%s` expired (older than 7 days) — the agent booted on its configured default `%s`. Re-issue /model %s if you still want it.\n' "$_sm_model" "$_EFFECTIVE_MODEL" "$_sm_model" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
   else
     case "$_sm_model" in
       sr-*)
@@ -1183,13 +1185,50 @@ if [ -f "{{agentDir}}/.session-model" ]; then
         ;;
     esac
     if [ "$_EFFECTIVE_MODEL" = "$_sm_model" ]; then
-      echo "session-model: keeping session override '$_sm_model' across this switchroom-managed relaunch${_sm_reason:+ ($_sm_reason)}" >&2
-      printf 'Session model override `%s` kept across this relaunch%s. It reverts on /restart, agent restart, crash, or an external container restart; /model default clears it now.\n' "$_sm_model" "${_sm_reason:+ ($_sm_reason)}" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+      echo "session-model: keeping session override '$_sm_model' across this relaunch${_sm_reason:+ ($_sm_reason)}" >&2
+      printf 'Session model override `%s` kept across this relaunch%s. It persists across restarts and deploys; /model default clears it.\n' "$_sm_model" "${_sm_reason:+ ($_sm_reason)}" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
     fi
   fi
   unset _smf _sm_model _sm_cfg _sm_ts
 fi
-unset _sm_keep _sm_reason
+unset _sm_keep _sm_reason _sm_revert
+
+# --- Session effort resolution (durable .session-effort, #3039) ---
+#
+# The `/effort` sibling of the block above. A positively-confirmed `/effort`
+# apply persists `{{agentDir}}/.session-effort` (one-line JSON
+# {"level","configuredDefaultAtWrite","ts"} written by the gateway). It is
+# honored on every boot and cleared only by `/effort default` (live delete)
+# or invalidation here (corrupt file / configured `thinking_effort:` changed)
+# — each invalidation appends to `.session-model-alert` so the gateway's
+# boot relay tells the operator once.
+_EFFECTIVE_EFFORT={{#if thinkingEffort}}'{{thinkingEffort}}'{{else}}''{{/if}}
+if [ -f "{{agentDir}}/.session-effort" ]; then
+  _sef="$(cat "{{agentDir}}/.session-effort" 2>/dev/null || true)"
+  _se_level="$(printf '%s' "$_sef" | sed -n 's/.*"level"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+  _se_cfg="$(printf '%s' "$_sef" | sed -n 's/.*"configuredDefaultAtWrite"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+  # Allowlist gate — kept in sync with EFFORT_LEVELS in
+  # telegram-plugin/gateway/effort-command.ts. The level is passed verbatim
+  # to `claude --effort`.
+  if [ "$(printf '%s' "$_se_level" | wc -l)" -ne 0 ] || ! printf '%s' "$_se_level" | grep -Eq '^(low|medium|high|xhigh|max)$'; then
+    rm -f "{{agentDir}}/.session-effort"
+    echo "session-effort: ignoring malformed .session-effort (failed allowlist gate) — using configured default '${_EFFECTIVE_EFFORT:-<unset>}'" >&2
+    printf 'Your saved session effort override could not be read (invalid or corrupt), so the agent booted on its configured default effort. Re-issue /effort <level> if you want a different one.\n' >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+  elif [ "$_se_cfg" != "$_EFFECTIVE_EFFORT" ]; then
+    rm -f "{{agentDir}}/.session-effort"
+    echo "session-effort: configured thinking_effort changed ('$_se_cfg' → '${_EFFECTIVE_EFFORT:-<unset>}') — clearing session override '$_se_level'" >&2
+    printf 'The configured default effort changed (`%s` → `%s`), so your session effort override `%s` was cleared — the agent booted on the new configured default. Re-issue /effort %s if you still want it.\n' "${_se_cfg:-<unset>}" "${_EFFECTIVE_EFFORT:-<unset>}" "$_se_level" "$_se_level" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+  else
+    _EFFECTIVE_EFFORT="$_se_level"
+    echo "session-effort: keeping session effort override '$_se_level' across this relaunch" >&2
+  fi
+  unset _sef _se_level _se_cfg
+fi
+if [ -n "$_EFFECTIVE_EFFORT" ]; then
+  _EFFORT_ARG="--effort $_EFFECTIVE_EFFORT"
+else
+  _EFFORT_ARG=""
+fi
 
 # sr-* passthrough→router repoint — ONE post-resolution gate covering BOTH the
 # /model override path AND the configured-default path (`model: sr-*` in
@@ -1222,14 +1261,14 @@ printf '%s\n' "$_EFFECTIVE_MODEL" > "{{agentDir}}/.active-session-model" 2>/dev/
 
 {{#if useSwitchroomPlugin}}
 if [ -n "$APPEND_PROMPT" ]; then
-  exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}} $SR_FLEET_ARG --model "$_EFFECTIVE_MODEL"{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
+  exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}} $SR_FLEET_ARG --model "$_EFFECTIVE_MODEL" $_EFFORT_ARG{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
 else
-  exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}} $SR_FLEET_ARG --model "$_EFFECTIVE_MODEL"{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}}{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
+  exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}} $SR_FLEET_ARG --model "$_EFFECTIVE_MODEL" $_EFFORT_ARG{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}}{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
 fi
 {{else}}
 if [ -n "$APPEND_PROMPT" ]; then
-  exec claude $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}} $SR_FLEET_ARG --model "$_EFFECTIVE_MODEL"{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
+  exec claude $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}} $SR_FLEET_ARG --model "$_EFFECTIVE_MODEL" $_EFFORT_ARG{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
 else
-  exec claude $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}} $SR_FLEET_ARG --model "$_EFFECTIVE_MODEL"{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}}{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
+  exec claude $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}} $SR_FLEET_ARG --model "$_EFFECTIVE_MODEL" $_EFFORT_ARG{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}}{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
 fi
 {{/if}}

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -1141,7 +1141,7 @@ if [ -f "{{agentDir}}/.session-model" ]; then
   if [ -n "$_sm_revert" ]; then
     # Explicit fresh revert intent — the ONLY boot path that clears a valid
     # override by design (#3039). Everything else keeps.
-    rm -f "{{agentDir}}/.session-model"
+    rm -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model-kept-notified"
     _sm_why="${_sm_reason:-explicit revert intent}"
     echo "session-model: reverting to configured default '$_EFFECTIVE_MODEL' — $_sm_why (session override '$_sm_model' cleared)" >&2
     printf 'Session model override `%s` was cleared as requested (%s) — this relaunch booted the configured default `%s`. Re-issue /model %s to switch back.\n' "$_sm_model" "$_sm_why" "$_EFFECTIVE_MODEL" "$_sm_model" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
@@ -1157,14 +1157,14 @@ if [ -f "{{agentDir}}/.session-model" ]; then
   elif [ "$(printf '%s' "$_sm_model" | wc -c)" -eq 0 ] || [ "$(printf '%s' "$_sm_model" | wc -l)" -ne 0 ] || ! printf '%s' "$_sm_model" | grep -Eq '^[A-Za-z0-9][]A-Za-z0-9._[/-]{0,99}$'; then
     # Invalid carrier (#3039): fall back to the configured default AND tell
     # the operator once — never a silent stderr-only drop.
-    rm -f "{{agentDir}}/.session-model"
+    rm -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model-kept-notified"
     echo "session-model: ignoring malformed .session-model (failed shape gate) — using configured default '$_EFFECTIVE_MODEL'" >&2
     printf 'Your saved session model override could not be read (invalid or corrupt), so the agent booted on its configured default `%s`. Re-issue /model <name> if you want a different model.\n' "$_EFFECTIVE_MODEL" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
   elif [ "$_sm_cfg" != "$_EFFECTIVE_MODEL" ]; then
     # switchroom.yaml `model:` changed since the switch → the override is
     # against a default that no longer exists (it may name a retired model).
     # Invalidate + announce once (#3039 invalid-carrier fallback).
-    rm -f "{{agentDir}}/.session-model"
+    rm -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model-kept-notified"
     echo "session-model: configured default changed ('$_sm_cfg' → '$_EFFECTIVE_MODEL') — clearing session override '$_sm_model'" >&2
     printf 'The configured default model changed (`%s` → `%s`), so your session override to `%s` was cleared — the agent booted on the new configured default. Re-issue /model %s if you still want it.\n' "$_sm_cfg" "$_EFFECTIVE_MODEL" "$_sm_model" "$_sm_model" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
   else
@@ -1186,12 +1186,55 @@ if [ -f "{{agentDir}}/.session-model" ]; then
     esac
     if [ "$_EFFECTIVE_MODEL" = "$_sm_model" ]; then
       echo "session-model: keeping session override '$_sm_model' across this relaunch${_sm_reason:+ ($_sm_reason)}" >&2
-      printf 'Session model override `%s` kept across this relaunch%s. It persists across restarts and deploys; /model default clears it.\n' "$_sm_model" "${_sm_reason:+ ($_sm_reason)}" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+      # #3042 item 4: notify the chat ONCE per kept value — a watchdog bounce
+      # loop must not storm the operator with identical "kept" alerts. The
+      # sentinel is cleared on every path that clears the override.
+      if [ "$(cat "{{agentDir}}/.session-model-kept-notified" 2>/dev/null || true)" != "$_sm_model" ]; then
+        printf 'Session model override `%s` kept across this relaunch%s. It persists across restarts and deploys; /model default clears it.\n' "$_sm_model" "${_sm_reason:+ ($_sm_reason)}" > "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+        printf '%s\n' "$_sm_model" > "{{agentDir}}/.session-model-kept-notified" 2>/dev/null || true
+      fi
     fi
   fi
   unset _smf _sm_model _sm_cfg _sm_ts
 fi
 unset _sm_keep _sm_reason _sm_revert
+
+# --- Override crashloop self-heal (#3042 review blocker 2b) ---
+#
+# Under keep-by-default an invalid-but-shape-valid persisted model (a typo
+# persisted at shutdown, or a confirmed model later retired) would make every
+# boot exec `claude --model <bad>` and die with the gateway dead — recovery
+# would need a host shell. Detect the loop from inside: when an override is
+# ACTIVE, stamp a boot-attempt counter just before exec; a healthy run makes
+# the next boot arrive much later (stamp stale → counter resets), while a
+# fast crashloop re-enters here within seconds (docker backoff caps ≈1 min).
+# Three consecutive fast boots with the same override → clear the carrier,
+# boot the configured default, and alert the chat once.
+_SM_CFG_RECORDED="$(cat "{{agentDir}}/.configured-default-model" 2>/dev/null | tr -d '[:space:]' || true)"
+if [ -n "$_SM_CFG_RECORDED" ] && [ "$_EFFECTIVE_MODEL" != "$_SM_CFG_RECORDED" ] && [ -f "{{agentDir}}/.session-model" ]; then
+  _bl_now="$(date +%s)"
+  _bl_cnt=0
+  _bl_prev=0
+  if [ -f "{{agentDir}}/.session-model-boot-attempts" ]; then
+    read -r _bl_cnt _bl_prev < "{{agentDir}}/.session-model-boot-attempts" 2>/dev/null || true
+  fi
+  case "$_bl_cnt" in (''|*[!0-9]*) _bl_cnt=0;; esac
+  case "$_bl_prev" in (''|*[!0-9]*) _bl_prev=0;; esac
+  if [ $(( _bl_now - _bl_prev )) -lt 150 ]; then _bl_cnt=$(( _bl_cnt + 1 )); else _bl_cnt=1; fi
+  if [ "$_bl_cnt" -ge 3 ]; then
+    echo "session-model: override '$_EFFECTIVE_MODEL' appears to be crashlooping the session ($_bl_cnt fast boots) — clearing it, booting configured default '$_SM_CFG_RECORDED'" >&2
+    printf 'Session model override `%s` was cleared automatically: the agent failed to stay up %s boots in a row with it active (the model may be invalid or retired). Booting the configured default `%s`. Re-issue /model <name> if you want a different model.\n' "$_EFFECTIVE_MODEL" "$_bl_cnt" "$_SM_CFG_RECORDED" >> "{{agentDir}}/.session-model-alert" 2>/dev/null || true
+    rm -f "{{agentDir}}/.session-model" "{{agentDir}}/.session-model-boot-attempts" "{{agentDir}}/.session-model-kept-notified"
+    _EFFECTIVE_MODEL="$_SM_CFG_RECORDED"
+  else
+    printf '%s %s\n' "$_bl_cnt" "$_bl_now" > "{{agentDir}}/.session-model-boot-attempts" 2>/dev/null || true
+  fi
+  unset _bl_now _bl_cnt _bl_prev
+else
+  # No active override this boot — a stale counter must not bite a future one.
+  rm -f "{{agentDir}}/.session-model-boot-attempts"
+fi
+unset _SM_CFG_RECORDED
 
 # --- Session effort resolution (durable .session-effort, #3039) ---
 #

--- a/reference/rfcs/session-model-stickiness.md
+++ b/reference/rfcs/session-model-stickiness.md
@@ -50,6 +50,32 @@ rows below. The new contract:
   ack card says "saved — applies as the agent boots" instead of "re-issue".
   Only an unresolvable `mdl:s:<tag>` menu selection still asks for a
   re-issue.
+- **Unconfirmed queued tokens are gated before durable persist** (#3042
+  blocker 2a): a queued typed `/model <arg>` persisted at shutdown was never
+  validated by claude, so only offline-trustable tokens (static Claude
+  aliases, curated sr-* alias targets — `isOfflineTrustedModelToken`) are
+  written to the carrier; anything else gets an honest "couldn't verify —
+  re-issue after restart" card. Belt-and-braces, start.sh self-heals a
+  crashlooping override (#3042 blocker 2b): three consecutive fast boots
+  (<150s apart, tracked in `.session-model-boot-attempts`) with an override
+  active clear the carrier, boot the configured default, and alert once —
+  this also covers a confirmed model later retired upstream.
+- **Kept-alert dedup** (#3042 item 4): the "override kept across this
+  relaunch" chat notice fires once per kept value
+  (`.session-model-kept-notified` sentinel), so a watchdog bounce loop
+  cannot storm the chat; every clearing path drops the sentinel.
+- **Version skew** (#3042 item 3): `.session-effort` boot resolution and the
+  crashloop self-heal live in the RE-SCAFFOLDED `start.sh` — until the
+  operator runs `switchroom apply` (or the agent is re-scaffolded), "applies
+  at boot" holds only for the model path on switchroom-managed bounces; a
+  persisted effort override is honored from the first boot on the new
+  scaffold.
+- **Quota-failover interaction** (#3042 item 7): keep-by-default means a
+  pinned expensive model now survives quota-exhaustion restarts indefinitely
+  — the fleet-fallback flow still switches the LIVE session, but the boot
+  carrier re-asserts the pinned model on the next relaunch until the user
+  runs `/model default`. Operators relying on exhaustion restarts to shed an
+  expensive pin must clear it explicitly.
 - **No user-visible dead-ends.** The idle drain re-enqueues on a
   turn-in-flight race or a handler busy-refusal instead of stamping the
   refusal onto the ack card; the mid-turn `/model` menu renders a static

--- a/reference/rfcs/session-model-stickiness.md
+++ b/reference/rfcs/session-model-stickiness.md
@@ -8,12 +8,53 @@ status: Accepted — revised per adversarial review + operator decision (default
 
 # RFC — Session-scoped `/model` stickiness
 
-**Status:** Accepted (rev 2 — adversarial-review revision)
+**Status:** Accepted (rev 3 — #3039 keep-by-default amendment; rev 2 semantics below are superseded where §0 says so)
 **Author:** (agent-authored, operator-directed; semantics decided by the operator 2026-07)
 **Targets:** `origin/main` @ v0.18.7
 **Builds on:** #2982 (in-memory `sessionModelSource` + one-shot `.session-model-override` carrier), #2983 (live model on progress cards)
 
 ---
+
+## 0. Rev 3 amendment (#3039, operator decision 2026-07-11) — keep by default
+
+The operator requirement (verbatim intent): *"a user-set session model/effort
+override must survive agent restarts and deploys, and is cleared only on
+explicit user action; if it can't apply, ack, apply deterministically when
+possible, and confirm."* This **supersedes** the rev-2 revert-by-default
+rows below. The new contract:
+
+- **Boot default is KEEP.** `.session-model` is honored on every boot —
+  deploy, `/restart`, inline restart button, hostd/CLI restart, watchdog
+  bounce, raw `docker restart`, host reboot, crash. Rows 8, 9, 10, 12, 14,
+  15 and 20 of the §6 table now read **kept**.
+- `.relaunch-model-intent` remains, but only a **fresh explicit "revert"**
+  intent reverts at boot. Current gateway code never stamps revert
+  (`intentForRestartReason` always returns keep); the path exists for
+  compatibility and future explicit-revert flows.
+- **The 7-day staleness expiry is removed** (row 21). An override the user
+  never revoked is never silently dropped.
+- **Clearing paths** are exactly: `/model default` (live delete), a
+  configured `model:` change (invalidation, row 16 — unchanged), and a
+  corrupt file (row 19 — now also writes a `.session-model-alert` chat
+  notice instead of a stderr-only drop). Every clearing path notifies the
+  operator chat once at boot via the existing alert relay.
+- **`/effort` gains the same contract** via a sibling `.session-effort`
+  carrier (`{"level","configuredDefaultAtWrite","ts"}`, allowlist-gated
+  low|medium|high|xhigh|max): written on every positively-confirmed effort
+  apply, resolved by start.sh into `--effort`, cleared only by the new
+  `/effort default` or invalidation (with a boot alert appended to
+  `.session-model-alert`).
+- **Queued commands survive the bounce.** When the gateway shuts down (or a
+  session relaunch is already pending) with a queued mid-turn `/model` /
+  `/effort`, the typed choice is persisted to the durable carriers and the
+  ack card says "saved — applies as the agent boots" instead of "re-issue".
+  Only an unresolvable `mdl:s:<tag>` menu selection still asks for a
+  re-issue.
+- **No user-visible dead-ends.** The idle drain re-enqueues on a
+  turn-in-flight race or a handler busy-refusal instead of stamping the
+  refusal onto the ack card; the mid-turn `/model` menu renders a static
+  alias/external keyboard whose taps queue, instead of "try again in a
+  moment".
 
 ## 1. Problem
 

--- a/telegram-plugin/gateway/effort-command.ts
+++ b/telegram-plugin/gateway/effort-command.ts
@@ -47,6 +47,7 @@ export function isValidEffortArg(arg: string): boolean {
 export type ParsedEffortCommand =
   | { kind: 'show' }
   | { kind: 'set'; level: EffortLevel }
+  | { kind: 'default' }
   | { kind: 'help'; reason?: string }
 
 /**
@@ -64,6 +65,9 @@ export function parseEffortCommand(text: string): ParsedEffortCommand | null {
   }
   const arg = parts[0]
   if (arg.toLowerCase() === 'help') return { kind: 'help' }
+  // `/effort default` — explicit user action that clears the durable
+  // `.session-effort` override and restores the configured default (#3039).
+  if (arg.toLowerCase() === 'default') return { kind: 'default' }
   if (!isValidEffortArg(arg)) {
     return { kind: 'help', reason: `not a valid effort level: ${arg}` }
   }
@@ -86,6 +90,17 @@ export interface EffortCommandDeps {
    * Null when unreadable — rendered as the built-in default.
    */
   getConfiguredEffort: () => string | null
+  /**
+   * Delete the durable `.session-effort` override (#3039). Optional so
+   * gateway-agnostic tests can omit it; the gateway always wires it.
+   */
+  clearSessionEffort?: () => void
+  /**
+   * The active durable `.session-effort` override level, or null when none
+   * (#3039). Optional; used to mark the LIVE level in the menu and the show
+   * text honestly after a restart re-applied the override.
+   */
+  getSessionEffort?: () => string | null
   escapeHtml: (s: string) => string
 }
 
@@ -95,7 +110,7 @@ export interface EffortCommandReply {
 }
 
 const PERSIST_NOTE =
-  '_Session-only — reverts to the configured default on restart. To change the default, set \`thinking_effort:\` in switchroom.yaml and restart._'
+  '_Sticky — persists across restarts and deploys until \`/effort default\` clears it. To change the configured default, set \`thinking_effort:\` in switchroom.yaml._'
 
 const LEVELS_INLINE = EFFORT_LEVELS.map(l => `\`${l}\``).join(' · ')
 
@@ -106,6 +121,7 @@ function helpText(deps: EffortCommandDeps, reason?: string): EffortCommandReply 
     '**/effort** — show or switch the reasoning effort (faster→smarter)',
     '\`/effort\` — show the configured effort + a tap menu',
     `\`/effort <level>\` — switch the live session (${LEVELS_INLINE})`,
+    '\`/effort default\` — clear the override, back to the configured default',
     PERSIST_NOTE,
   )
   return { text: lines.join('\n'), html: true }
@@ -117,13 +133,41 @@ export async function handleEffortCommand(
 ): Promise<EffortCommandReply> {
   if (parsed.kind === 'help') return helpText(deps, parsed.reason)
 
+  if (parsed.kind === 'default') {
+    // Explicit clear: restore the configured default level in the live
+    // session, THEN delete the durable override (order matters — the
+    // gateway's applyEffort wrapper re-persists on a confirmed apply, so
+    // clearing last leaves no file behind).
+    const configured = deps.getConfiguredEffort()
+    const restoreLevel = configured && isValidEffortArg(configured) ? configured.toLowerCase() : 'low'
+    let restored: EffortApplyResult | null = null
+    try {
+      restored = await deps.applyEffort(deps.getAgentName(), restoreLevel)
+    } catch {
+      restored = null
+    }
+    deps.clearSessionEffort?.()
+    const cfgHtml = `\`${deps.escapeHtml(restoreLevel)}\``
+    if (restored?.ok) {
+      return {
+        text: `✅ Effort override cleared — back on the configured default ${cfgHtml}. It will also boot on ${cfgHtml} from now on.`,
+        html: true,
+      }
+    }
+    return {
+      text: `✅ Effort override cleared — the agent boots on the configured default ${cfgHtml} from now on. (Couldn't switch the live session right now; it may already be on ${cfgHtml}, or will be after the next restart.)`,
+      html: true,
+    }
+  }
+
   if (parsed.kind === 'show') {
     const configured = deps.getConfiguredEffort()
     const shown = configured && configured.length > 0 ? configured : 'low'
+    const override = deps.getSessionEffort?.() ?? null
     return {
       text: [
         `**Effort — ${deps.escapeHtml(deps.getAgentName())}**`,
-        `Configured default: \`${deps.escapeHtml(shown)}\``,
+        `Configured default: \`${deps.escapeHtml(shown)}\`${override ? ` · session override: \`${deps.escapeHtml(override)}\`` : ''}`,
         `Switch the live session: ${EFFORT_LEVELS.map(l => `\`/effort ${l}\``).join(' · ')}`,
         PERSIST_NOTE,
       ].join('\n'),
@@ -217,7 +261,7 @@ function menuKeyboard(highlight: string): EffortMenuKeyboardButton[][] {
  */
 export function buildEffortMenu(deps: EffortCommandDeps, highlight?: string): EffortMenuReply {
   const configured = deps.getConfiguredEffort() || 'low'
-  const live = highlight ?? configured
+  const live = highlight ?? deps.getSessionEffort?.() ?? configured
   return {
     text: [
       `**Effort — ${deps.escapeHtml(deps.getAgentName())}**`,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -397,6 +397,7 @@ import {
   srFriendlyLabel,
   expandSrAlias,
   isSrModel,
+  isBusyRefusalText,
   type ModelMenuDeps,
   type ModelCommandDeps,
   type ModelMenuReply,
@@ -414,6 +415,9 @@ import {
   RELAUNCH_MODEL_INTENT_FILE,
   GATEWAY_SHUTDOWN_INTENT_REASON_PREFIX,
   clearStaleGatewayShutdownIntent,
+  writeSessionEffortFile,
+  clearSessionEffortFile,
+  readSessionEffortFile,
 } from './session-model-file.js'
 import { discoverModels, selectModel } from '../../src/agents/model-picker.js'
 import { resolveMainModel } from '../../src/agents/scaffold.js'
@@ -429,10 +433,11 @@ import {
 import {
   createPendingSessionCommandSlots,
   drainCapDecision as pendingCmdDrainCapDecision,
-  shutdownResolutionEdits as pendingCmdShutdownResolutionEdits,
+  shutdownResolutionActions as pendingCmdShutdownResolutionActions,
+  resolveForRestart as pendingCmdResolveForRestart,
+  type ShutdownResolutionAction,
   ackText as pendingCmdAckText,
   supersededText as pendingCmdSupersededText,
-  restartSupersededText as pendingCmdRestartSupersededText,
   type PendingSessionCommand,
 } from './pending-session-command.js'
 import type { EffortLevel } from './effort-command.js'
@@ -20689,8 +20694,82 @@ async function applyQueuedEffortCommand(cmd: PendingSessionCommand): Promise<str
     const outcome = await handleEffortMenuCallback(cmd.arg, deps)
     return outcome.reply.text
   }
-  const reply = await handleEffortCommand({ kind: 'set', level: cmd.arg as EffortLevel }, deps)
+  const parsed =
+    cmd.arg === 'default'
+      ? ({ kind: 'default' } as const)
+      : ({ kind: 'set', level: cmd.arg as EffortLevel } as const)
+  const reply = await handleEffortCommand(parsed, deps)
   return reply.text
+}
+
+/**
+ * Re-enqueue a command the drain took but could not safely apply (a turn
+ * raced in). If a NEWER same-kind command was enqueued while the drain was
+ * mid-flight, the newer one wins (last-write-wins invariant) and this older
+ * card is edited to superseded instead.
+ */
+function reEnqueueUnlessSuperseded(cmd: PendingSessionCommand): void {
+  const newer = pendingSessionCommand.get(cmd.kind)
+  if (newer != null) {
+    void editPendingCommandCard(
+      cmd.ackChatId,
+      cmd.ackMessageId,
+      pendingCmdSupersededText(cmd, newer, escapeHtmlForTg),
+    )
+    return
+  }
+  pendingSessionCommand.set(cmd)
+}
+
+/**
+ * #3039 — execute a shutdown/restart resolution action's durable write:
+ * carry a queued (typed) choice across the bounce via the boot carriers
+ * (`.session-model` / `.session-effort`) instead of asking for a re-issue.
+ * Returns the ack-card text to edit in (persisted vs re-issue fallback).
+ */
+function persistQueuedCommandForRestart(action: ShutdownResolutionAction): string {
+  if (action.persist == null) return action.reissueText
+  const agentDir = resolveAgentDirFromEnv()
+  if (agentDir == null) return action.reissueText
+  try {
+    switch (action.persist) {
+      case 'model': {
+        const configured =
+          readConfiguredDefaultModel(agentDir) ?? resolveMainModel(undefined)
+        writeSessionModelFile(agentDir, expandSrAlias(action.arg), configured)
+        // Boot default is keep (#3039), but stamp explicit keep-intent for
+        // reason-honesty in the boot notice.
+        writeRelaunchModelIntent(agentDir, 'keep', 'queued /model carried across restart')
+        break
+      }
+      case 'clear-model':
+        clearSessionModelFile(agentDir)
+        break
+      case 'effort':
+        writeSessionEffortFile(agentDir, action.arg, getConfiguredEffortForPersist())
+        break
+      case 'clear-effort':
+        clearSessionEffortFile(agentDir)
+        break
+    }
+    return action.persistedText
+  } catch (err) {
+    process.stderr.write(
+      `telegram gateway: queued-command persist-for-restart failed kind=${action.cmd.kind} arg=${action.arg}: ${(err as Error)?.message ?? String(err)}\n`,
+    )
+    return action.reissueText
+  }
+}
+
+/** The cascade-resolved thinking_effort, for `.session-effort`'s configuredDefaultAtWrite. */
+function getConfiguredEffortForPersist(): string | null {
+  try {
+    type AgentListResp = { agents: Array<{ name: string; thinking_effort?: string | null }> }
+    const data = switchroomExecJson<AgentListResp>(['agent', 'list'])
+    return data?.agents?.find(a => a.name === getMyAgentName())?.thinking_effort ?? null
+  } catch {
+    return null
+  }
 }
 
 // Synchronous re-entrancy guard — the idle gate can fire several times per
@@ -20714,12 +20793,22 @@ async function drainPendingSessionCommand(): Promise<void> {
   try {
     for (const cmd of pendingSessionCommand.takeAll()) {
       if (pendingRestarts.size > 0) {
-        await editPendingCommandCard(
-          cmd.ackChatId,
-          cmd.ackMessageId,
-          pendingCmdRestartSupersededText(cmd, escapeHtmlForTg),
-        )
+        // #3039: a session relaunch is scheduled — the live session is going
+        // away, but start.sh honors the durable carriers on boot. Persist the
+        // queued (typed) choice so it still deterministically applies; only an
+        // unresolvable menu-tag selection falls back to the re-issue note.
+        const action = pendingCmdResolveForRestart(cmd, escapeHtmlForTg)
+        await editPendingCommandCard(cmd.ackChatId, cmd.ackMessageId, persistQueuedCommandForRestart(action))
         continue
+      }
+      // #3039 race guard: the idle gate fired, but a NEW turn may have started
+      // before this async drain reached this command. Applying now would hit
+      // the handlers' internal busy refusals and stamp "not applied" onto the
+      // ack card as a false final state. Re-enqueue and let the next idle
+      // gate retry (the ack card stays at its honest "queued" text).
+      if (turnInFlightForGate()) {
+        reEnqueueUnlessSuperseded(cmd)
+        break
       }
       let body: string
       try {
@@ -20734,6 +20823,12 @@ async function drainPendingSessionCommand(): Promise<void> {
           `❌ Couldn’t apply the queued ${cmd.kind} switch to \`${escapeHtmlForTg(cmd.targetLabel)}\`: ${escapeHtmlForTg((err as Error)?.message ?? String(err))}`,
         )
         continue
+      }
+      // #3039: the handler itself refused because a turn raced in — the
+      // choice is NOT applied. Re-enqueue instead of confirming the refusal.
+      if (isBusyRefusalText(body)) {
+        reEnqueueUnlessSuperseded(cmd)
+        break
       }
       await editPendingCommandCard(cmd.ackChatId, cmd.ackMessageId, body)
     }
@@ -20800,12 +20895,36 @@ bot.command('model', async ctx => {
 // effort-command.ts so it's unit-testable without booting the bot.
 function buildEffortDeps(): EffortCommandDeps {
   return {
-    applyEffort: (agent, level) => applyEffort(agent, level),
+    // #3039: single persistence choke point — EVERY positively-confirmed
+    // effort apply (typed, menu tap, queued drain) durably records the level
+    // to `.session-effort`, which start.sh resolves into `--effort` on every
+    // boot. `/effort default` clears it via clearSessionEffort (the handler
+    // clears AFTER its restore-apply, so the wrapper's write is undone).
+    applyEffort: async (agent, level) => {
+      const result = await applyEffort(agent, level)
+      if (result.ok) {
+        const agentDir = resolveAgentDirFromEnv()
+        if (agentDir) {
+          try {
+            writeSessionEffortFile(agentDir, level, getConfiguredEffortForPersist())
+          } catch (err) {
+            process.stderr.write(
+              `telegram gateway: session-effort persist failed level=${level}: ${(err as Error)?.message ?? String(err)}\n`,
+            )
+          }
+        }
+      }
+      return result
+    },
     getAgentName: getMyAgentName,
-    getConfiguredEffort: () => {
-      type AgentListResp = { agents: Array<{ name: string; thinking_effort?: string | null }> }
-      const data = switchroomExecJson<AgentListResp>(['agent', 'list'])
-      return data?.agents?.find(a => a.name === getMyAgentName())?.thinking_effort ?? null
+    getConfiguredEffort: () => getConfiguredEffortForPersist(),
+    clearSessionEffort: () => {
+      const agentDir = resolveAgentDirFromEnv()
+      if (agentDir) clearSessionEffortFile(agentDir)
+    },
+    getSessionEffort: () => {
+      const agentDir = resolveAgentDirFromEnv()
+      return agentDir ? (readSessionEffortFile(agentDir)?.level ?? null) : null
     },
     escapeHtml: escapeHtmlForTg,
   }
@@ -20835,18 +20954,19 @@ bot.command('effort', async ctx => {
   // /model. `applyEffort` mid-turn silently maybe-failed ("couldn't confirm it
   // applied") before this gate existed. `currentTurn !== null` is the same
   // busy signal the model path reads via deps.isBusy().
-  if (parsed.kind === 'set' && currentTurn !== null) {
+  if ((parsed.kind === 'set' || parsed.kind === 'default') && currentTurn !== null) {
+    const requestedLevel = parsed.kind === 'set' ? parsed.level : 'default'
     const chatId = String(ctx.chat!.id)
     const threadId = resolveThreadId(chatId, ctx.message?.message_thread_id)
     const sent = await ctx.replyWithRichMessage(
-      richMessage(hardenCardBreaks(pendingCmdAckText('effort', parsed.level, escapeHtmlForTg))),
+      richMessage(hardenCardBreaks(pendingCmdAckText('effort', requestedLevel, escapeHtmlForTg))),
       threadId != null ? { message_thread_id: threadId } : {},
     )
     enqueueSessionCommand({
       kind: 'effort',
       origin: 'typed',
-      arg: parsed.level,
-      targetLabel: parsed.level,
+      arg: requestedLevel,
+      targetLabel: requestedLevel,
       chatId,
       threadId,
       ackChatId: chatId,
@@ -20950,12 +21070,13 @@ bot.command('restart', async ctx => {
     // greeting card shows "Restarted  user: /restart from chat" instead
     // of whatever reason the downstream CLI would default to.
     stampUserRestartReason('user: /restart from chat')
-    // /restart is a DELIBERATE restart: the session model reverts to the
-    // configured default. Absence of intent would revert anyway (boot
-    // default) — the explicit stamp is reason-honesty for the boot notice.
+    // #3039: /restart is "bounce the session", NOT "clear my model" — the
+    // durable override survives every restart and is cleared only by
+    // `/model default`. Stamp keep for reason-honesty in the boot notice
+    // (absence of intent keeps anyway under the keep-by-default boot).
     {
       const smDir = resolveAgentDirFromEnv()
-      if (smDir) writeRelaunchModelIntent(smDir, 'revert', 'user: /restart from chat')
+      if (smDir) writeRelaunchModelIntent(smDir, 'keep', 'user: /restart from chat')
     }
     await sweepBeforeSelfRestart()
     const hostdResp = await tryHostdDispatch(getMyAgentName(), {
@@ -26236,13 +26357,19 @@ async function shutdown(signal: string): Promise<void> {
     process.stderr.write(`telegram gateway: shutdown.clean_marker_skipped signal=${signal} (crash path — banner will fire on next boot)\n`)
   }
 
-  // #3018 finding 3: resolve any queued /model|/effort ack cards. The gateway
-  // (and with it the queue) is going away — without this the ack card dangles
-  // at "the moment this turn finishes" forever and the operator's choice is
-  // silently lost. Edit each into the restart-superseded text ("re-issue once
-  // the agent is back"). Best-effort and time-bounded so a wedged Telegram
-  // API can't block shutdown.
-  const orphanedCmdEdits = pendingCmdShutdownResolutionEdits(pendingSessionCommand, escapeHtmlForTg)
+  // #3018 finding 3 + #3039: resolve any queued /model|/effort ack cards. The
+  // gateway (and with it the in-memory queue) is going away — persist each
+  // typed choice to the durable boot carriers (`.session-model` /
+  // `.session-effort`) so it still deterministically applies as the agent
+  // boots, and edit the ack card to say so. Only an unresolvable menu-tag
+  // selection falls back to a re-issue note. Best-effort and time-bounded so
+  // a wedged Telegram API can't block shutdown.
+  const orphanedCmdActions = pendingCmdShutdownResolutionActions(pendingSessionCommand, escapeHtmlForTg)
+  const orphanedCmdEdits = orphanedCmdActions.map(a => ({
+    chatId: a.cmd.ackChatId,
+    messageId: a.cmd.ackMessageId,
+    text: persistQueuedCommandForRestart(a),
+  }))
   if (orphanedCmdEdits.length > 0) {
     process.stderr.write(
       `telegram gateway: shutdown.pending_cmd_resolved count=${orphanedCmdEdits.length}\n`,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -398,6 +398,7 @@ import {
   expandSrAlias,
   isSrModel,
   isBusyRefusalText,
+  isOfflineTrustedModelToken,
   type ModelMenuDeps,
   type ModelCommandDeps,
   type ModelMenuReply,
@@ -420,7 +421,7 @@ import {
   readSessionEffortFile,
 } from './session-model-file.js'
 import { discoverModels, selectModel } from '../../src/agents/model-picker.js'
-import { resolveMainModel } from '../../src/agents/scaffold.js'
+import { resolveMainModel, SWITCHROOM_DEFAULT_THINKING_EFFORT } from '../../src/agents/scaffold.js'
 import {
   parseEffortCommand,
   handleEffortCommand,
@@ -435,6 +436,7 @@ import {
   drainCapDecision as pendingCmdDrainCapDecision,
   shutdownResolutionActions as pendingCmdShutdownResolutionActions,
   resolveForRestart as pendingCmdResolveForRestart,
+  drainTakenCommands as pendingCmdDrainTaken,
   type ShutdownResolutionAction,
   ackText as pendingCmdAckText,
   supersededText as pendingCmdSupersededText,
@@ -20734,6 +20736,15 @@ function persistQueuedCommandForRestart(action: ShutdownResolutionAction): strin
   try {
     switch (action.persist) {
       case 'model': {
+        // #3042 blocker 2a: this token was QUEUED, never confirmed by claude.
+        // Under the keep-by-default boot a garbage-but-shape-valid token
+        // persisted here would crashloop `claude --model <garbage>` with the
+        // gateway dead. Only offline-trustable tokens (static Claude aliases,
+        // curated sr-* alias targets) may be persisted unconfirmed; anything
+        // else gets the honest "couldn't verify — re-issue" card instead.
+        if (!isOfflineTrustedModelToken(action.arg)) {
+          return `↩️ Couldn’t verify \`${escapeHtmlForTg(action.cmd.targetLabel || action.arg)}\` as a known model without the live session — it was NOT saved. Re-issue \`/model ${escapeHtmlForTg(action.arg)}\` once the agent is back.`
+        }
         const configured =
           readConfiguredDefaultModel(agentDir) ?? resolveMainModel(undefined)
         writeSessionModelFile(agentDir, expandSrAlias(action.arg), configured)
@@ -20761,14 +20772,23 @@ function persistQueuedCommandForRestart(action: ShutdownResolutionAction): strin
   }
 }
 
-/** The cascade-resolved thinking_effort, for `.session-effort`'s configuredDefaultAtWrite. */
-function getConfiguredEffortForPersist(): string | null {
+/**
+ * The cascade-resolved thinking_effort, for `.session-effort`'s
+ * configuredDefaultAtWrite. #3042 item 5: on a transient `agent list`
+ * failure fall back to the scaffold default rather than null — persisting ''
+ * would trip a bogus "configured default effort changed" clear+alert at the
+ * next boot (start.sh bakes the same default when yaml is unset).
+ */
+function getConfiguredEffortForPersist(): string {
   try {
     type AgentListResp = { agents: Array<{ name: string; thinking_effort?: string | null }> }
     const data = switchroomExecJson<AgentListResp>(['agent', 'list'])
-    return data?.agents?.find(a => a.name === getMyAgentName())?.thinking_effort ?? null
+    return (
+      data?.agents?.find(a => a.name === getMyAgentName())?.thinking_effort ??
+      SWITCHROOM_DEFAULT_THINKING_EFFORT
+    )
   } catch {
-    return null
+    return SWITCHROOM_DEFAULT_THINKING_EFFORT
   }
 }
 
@@ -20791,47 +20811,24 @@ async function drainPendingSessionCommand(): Promise<void> {
   if (pendingSessionCommand.size === 0) return
   pendingCmdDraining = true
   try {
-    for (const cmd of pendingSessionCommand.takeAll()) {
-      if (pendingRestarts.size > 0) {
-        // #3039: a session relaunch is scheduled — the live session is going
-        // away, but start.sh honors the durable carriers on boot. Persist the
-        // queued (typed) choice so it still deterministically applies; only an
-        // unresolvable menu-tag selection falls back to the re-issue note.
-        const action = pendingCmdResolveForRestart(cmd, escapeHtmlForTg)
-        await editPendingCommandCard(cmd.ackChatId, cmd.ackMessageId, persistQueuedCommandForRestart(action))
-        continue
-      }
-      // #3039 race guard: the idle gate fired, but a NEW turn may have started
-      // before this async drain reached this command. Applying now would hit
-      // the handlers' internal busy refusals and stamp "not applied" onto the
-      // ack card as a false final state. Re-enqueue and let the next idle
-      // gate retry (the ack card stays at its honest "queued" text).
-      if (turnInFlightForGate()) {
-        reEnqueueUnlessSuperseded(cmd)
-        break
-      }
-      let body: string
-      try {
-        body =
-          cmd.kind === 'model'
-            ? await applyQueuedModelCommand(cmd)
-            : await applyQueuedEffortCommand(cmd)
-      } catch (err) {
-        await editPendingCommandCard(
-          cmd.ackChatId,
-          cmd.ackMessageId,
-          `❌ Couldn’t apply the queued ${cmd.kind} switch to \`${escapeHtmlForTg(cmd.targetLabel)}\`: ${escapeHtmlForTg((err as Error)?.message ?? String(err))}`,
-        )
-        continue
-      }
-      // #3039: the handler itself refused because a turn raced in — the
-      // choice is NOT applied. Re-enqueue instead of confirming the refusal.
-      if (isBusyRefusalText(body)) {
-        reEnqueueUnlessSuperseded(cmd)
-        break
-      }
-      await editPendingCommandCard(cmd.ackChatId, cmd.ackMessageId, body)
-    }
+    // Iteration + loss-safety invariants live in drainTakenCommands
+    // (pending-session-command.ts, unit-tested): a restart-pending command is
+    // persisted to the boot carriers; an early stop (turn raced in / handler
+    // busy-refusal) re-enqueues EVERY not-yet-applied taken command (#3042
+    // blocker 1) instead of dropping the rest of the batch.
+    await pendingCmdDrainTaken(pendingSessionCommand.takeAll(), {
+      restartPending: () => pendingRestarts.size > 0,
+      turnInFlight: () => turnInFlightForGate(),
+      apply: cmd =>
+        cmd.kind === 'model' ? applyQueuedModelCommand(cmd) : applyQueuedEffortCommand(cmd),
+      isBusyRefusal: isBusyRefusalText,
+      resolveForRestartText: cmd =>
+        persistQueuedCommandForRestart(pendingCmdResolveForRestart(cmd, escapeHtmlForTg)),
+      editCard: (cmd, text) => editPendingCommandCard(cmd.ackChatId, cmd.ackMessageId, text),
+      reEnqueue: reEnqueueUnlessSuperseded,
+      failureText: (cmd, err) =>
+        `❌ Couldn’t apply the queued ${cmd.kind} switch to \`${escapeHtmlForTg(cmd.targetLabel)}\`: ${escapeHtmlForTg((err as Error)?.message ?? String(err))}`,
+    })
   } finally {
     pendingCmdDraining = false
   }

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -506,6 +506,26 @@ export const SR_MODEL_ALIASES: Record<string, string> = {
 }
 
 /** Expand a short alias (case-insensitive) to its full sr-* id, or return the original. */
+/**
+ * #3042 review blocker 2a: can `token` be trusted for a DURABLE, boot-applied
+ * `.session-model` persist WITHOUT a live confirmation from claude?
+ *
+ * A queued typed `/model <arg>` that is persisted at shutdown was never
+ * validated by claude's picker — and under the keep-by-default boot (#3039)
+ * a garbage-but-shape-valid token (e.g. `claude-nonexistnet-9`) would make
+ * every boot run `claude --model <garbage>` with the gateway dead. Only
+ * tokens with a switchroom-known meaning are offline-trustable: the static
+ * Claude aliases (claude resolves them itself) and the curated sr-* alias
+ * TARGETS (present in the LiteLLM config by construction). Full `claude-*` /
+ * arbitrary `sr-*` ids typed by hand are refused — they need the live
+ * session to verify, so the operator is asked to re-issue after boot.
+ */
+export function isOfflineTrustedModelToken(token: string): boolean {
+  if ((MODEL_ALIASES as readonly string[]).includes(token)) return true
+  if (token in SR_MODEL_ALIASES) return true
+  return Object.values(SR_MODEL_ALIASES).includes(token)
+}
+
 export function expandSrAlias(arg: string): string {
   return SR_MODEL_ALIASES[arg.toLowerCase()] ?? arg
 }

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -175,7 +175,7 @@ export interface ModelCommandReply {
 }
 
 const PERSIST_NOTE =
-  '_Sticky across switchroom-managed relaunches (\`/new\`, watchdog recovery); reverts on \`/restart\`, agent restart, crash, or external container restart. \`/model default\` clears it. To persist, set \`model:\` in switchroom.yaml._'
+  '_Sticky — persists across restarts, deploys, and crashes until \`/model default\` clears it (or the configured \`model:\` in switchroom.yaml changes, which resets it and notifies you). To change the default, set \`model:\` in switchroom.yaml._'
 
 function helpText(deps: ModelCommandDeps, reason?: string): ModelCommandReply {
   const srAliasExamples = Object.keys(SR_MODEL_ALIASES).map(a => `\`${a}\``).join(' · ')
@@ -230,7 +230,7 @@ export async function handleModelCommand(
   // and ask the operator to retry (parity with the menu callback's isBusy check).
   if (deps.isBusy()) {
     return {
-      text: '⏳ The agent is mid-turn — a model switch needs an idle session. Try again in a moment.',
+      text: '⏳ The agent is mid-turn — a model switch needs an idle session. The switch was not applied.',
       html: true,
     }
   }
@@ -548,10 +548,67 @@ export function modelSelectCallbackData(label: string): string {
   return `${MODEL_CALLBACK_SELECT}${labelTag(label)}`
 }
 
-function busyReply(deps: Pick<ModelMenuDeps, 'escapeHtml'>): ModelMenuReply {
+const BUSY_REFUSAL_TEXT =
+  '⏳ The agent is mid-turn — the model picker needs an idle prompt. Your tap was not applied.'
+
+/**
+ * Busy-refusal detector (#3039). The gateway's queued-command drain applies a
+ * command believing the session is idle; if a new turn started in the race
+ * window the underlying handler still refuses with one of these texts. The
+ * drain matches on this and RE-ENQUEUES the command instead of stamping the
+ * refusal onto the ack card as a false final state — so no user-visible path
+ * ever ends at "try again".
+ */
+export function isBusyRefusalText(text: string): boolean {
+  return text.includes('The agent is mid-turn')
+}
+
+/**
+ * Mid-turn `/model` menu (#3039): instead of refusing ("try again in a
+ * moment"), render a STATIC keyboard that needs no picker discovery — the
+ * alias rows + the external page. Every switch tap rides the gateway's
+ * mid-turn queue (ack → apply at idle → confirm), so opening the menu during
+ * a long turn still lets the operator lock in a choice.
+ */
+function busyStaticMenu(
+  deps: Pick<ModelMenuDeps, 'escapeHtml'> & Pick<ModelCommandDeps, 'getAgentName'>,
+  page: ModelMenuPage,
+): ModelMenuReply {
+  const externalNames = externalModelNames([])
+  if (page === 'external') {
+    return {
+      text: [
+        `**Model — ${deps.escapeHtml(deps.getAgentName())}** · 🌐 External`,
+        '_Agent is mid-turn — taps are queued and apply the moment the turn ends._',
+        'These models are **billed separately** via OpenRouter. Tap one to switch the **live session**:',
+        PERSIST_NOTE,
+      ].join('\n'),
+      html: true,
+      keyboard: externalPageKeyboard(externalNames),
+    }
+  }
+  const rows: ModelMenuKeyboardButton[][] = []
+  for (const alias of MODEL_ALIASES) {
+    if (alias === 'default') continue
+    rows.push([{
+      text: alias.charAt(0).toUpperCase() + alias.slice(1),
+      callback_data: `${MODEL_CALLBACK_ALIAS}${alias}`,
+    }])
+  }
+  rows.push([{ text: 'Default (configured)', callback_data: `${MODEL_CALLBACK_ALIAS}default` }])
+  if (externalNames.length > 0) {
+    rows.push([{ text: '🌐 External models ▸', callback_data: MODEL_CALLBACK_PAGE_EXTERNAL }])
+  }
+  rows.push([{ text: '🔄 Refresh', callback_data: MODEL_CALLBACK_REFRESH }])
   return {
-    text: '⏳ The agent is mid-turn — the model picker needs an idle prompt. Try again in a moment.',
+    text: [
+      `**Model — ${deps.escapeHtml(deps.getAgentName())}**`,
+      '_Agent is mid-turn, so the live picker can\u2019t be read right now — this is the quick list. A tap is queued and applies the moment the turn ends._',
+      'Tap a model to switch the **live session**:',
+      PERSIST_NOTE,
+    ].join('\n'),
     html: true,
+    keyboard: rows,
   }
 }
 
@@ -654,7 +711,7 @@ export async function buildModelMenu(
   deps: ModelMenuDeps & ModelCommandDeps,
   page: ModelMenuPage = 'main',
 ): Promise<ModelMenuReply> {
-  if (deps.isBusy()) return busyReply(deps)
+  if (deps.isBusy()) return busyStaticMenu(deps, page)
 
   const [discovered, quota, srNames] = await Promise.all([
     deps.discover(deps.getAgentName()),
@@ -735,6 +792,12 @@ export interface ModelCallbackOutcome {
    */
   toastOnly?: boolean
   /**
+   * True when this outcome is the mid-turn refusal (#3039). The queued-command
+   * drain re-enqueues on this instead of stamping the refusal onto the ack
+   * card as a false final state.
+   */
+  busyRefusal?: boolean
+  /**
    * On a successful session switch, the live model name now running (parsed
    * from claude's confirmation, e.g. "Fable 5"). The gateway records this as
    * the session-model override so `/status` reflects what's actually running.
@@ -799,8 +862,9 @@ export async function handleModelMenuCallback(
     if (deps.isBusy()) {
       return {
         answer: '⏳ Agent is mid-turn — tap again when it’s idle',
-        reply: busyReply(deps),
+        reply: { text: BUSY_REFUSAL_TEXT, html: true },
         toastOnly: true,
+        busyRefusal: true,
       }
     }
     let aliasResult: InjectResult
@@ -862,8 +926,9 @@ export async function handleModelMenuCallback(
     if (deps.isBusy()) {
       return {
         answer: '⏳ Agent is mid-turn — tap again when it’s idle',
-        reply: busyReply(deps),
+        reply: { text: BUSY_REFUSAL_TEXT, html: true },
         toastOnly: true,
+        busyRefusal: true,
       }
     }
     try {
@@ -896,8 +961,9 @@ export async function handleModelMenuCallback(
   if (deps.isBusy()) {
     return {
       answer: '⏳ Agent is mid-turn — tap again when it’s idle',
-      reply: busyReply(deps),
+      reply: { text: BUSY_REFUSAL_TEXT, html: true },
       toastOnly: true,
+      busyRefusal: true,
     }
   }
 

--- a/telegram-plugin/gateway/pending-session-command.ts
+++ b/telegram-plugin/gateway/pending-session-command.ts
@@ -131,6 +131,74 @@ export function createPendingSessionCommandSlots(): PendingSessionCommandSlots {
 }
 
 /**
+ * IO seams the drain iteration needs from the gateway. Extracted so the
+ * iteration ORDER + loss-safety invariants (#3042 blocker 1) are unit-testable
+ * without booting the bot.
+ */
+export interface DrainIo {
+  /** Is a session relaunch pending (the live session is going away)? */
+  restartPending: () => boolean
+  /** Is a turn in flight right now (re-checked per command)? */
+  turnInFlight: () => boolean
+  /** Apply the command via the real handler; returns the reply body. */
+  apply: (cmd: PendingSessionCommand) => Promise<string>
+  /** Does this reply body mean "refused because busy" (not applied)? */
+  isBusyRefusal: (text: string) => boolean
+  /** Resolve a command that must ride the restart carriers; returns card text. */
+  resolveForRestartText: (cmd: PendingSessionCommand) => string
+  /** Edit the command's ack card. Best-effort. */
+  editCard: (cmd: PendingSessionCommand, text: string) => Promise<void>
+  /** Re-enqueue a command the drain could not safely apply. */
+  reEnqueue: (cmd: PendingSessionCommand) => void
+  /** Render the apply-threw failure card text. */
+  failureText: (cmd: PendingSessionCommand, err: unknown) => string
+}
+
+/**
+ * Drain iteration over the commands takeAll() returned. The loss-safety
+ * invariant (#3042 blocker 1): when the loop must stop early (turn raced in,
+ * or the handler returned a busy refusal), EVERY not-yet-applied taken
+ * command — including the current one — is re-enqueued. takeAll() can hold
+ * both a model AND an effort command; breaking after re-enqueueing only the
+ * current one would silently drop the other with its ack card stuck at
+ * "queued" forever.
+ */
+export async function drainTakenCommands(
+  taken: readonly PendingSessionCommand[],
+  io: DrainIo,
+): Promise<void> {
+  for (let i = 0; i < taken.length; i++) {
+    const cmd = taken[i]
+    if (io.restartPending()) {
+      // The live session is going away — carry the choice across the bounce
+      // via the durable carriers (or the re-issue fallback).
+      await io.editCard(cmd, io.resolveForRestartText(cmd))
+      continue
+    }
+    // Race guard: a new turn may have started before the drain reached this
+    // command. Applying now would hit the handlers' busy refusals and stamp
+    // "not applied" onto the ack card as a false final state.
+    if (io.turnInFlight()) {
+      for (const rest of taken.slice(i)) io.reEnqueue(rest)
+      return
+    }
+    let body: string
+    try {
+      body = await io.apply(cmd)
+    } catch (err) {
+      await io.editCard(cmd, io.failureText(cmd, err))
+      continue
+    }
+    // The handler itself refused because a turn raced in — not applied.
+    if (io.isBusyRefusal(body)) {
+      for (const rest of taken.slice(i)) io.reEnqueue(rest)
+      return
+    }
+    await io.editCard(cmd, body)
+  }
+}
+
+/**
  * What the reaper's bounded drain-cap should do this tick.
  *
  *   - 'wait'                 — nothing queued long enough; keep waiting.

--- a/telegram-plugin/gateway/pending-session-command.ts
+++ b/telegram-plugin/gateway/pending-session-command.ts
@@ -164,21 +164,87 @@ export interface PendingCommandCardEdit {
 }
 
 /**
- * Gateway-shutdown resolution for queued commands: EMPTY the slots and return
- * the ack-card edits that tell the operator their queued choice cannot apply
- * (the session is going away with the gateway) and must be re-issued after
- * boot. Without this, a SIGTERM leaves the ack card dangling at "the moment
- * this turn finishes" forever and the choice is silently lost.
+ * What the gateway should DURABLY record for a queued command that can't
+ * apply live because the session is going away (gateway shutdown or a pending
+ * session relaunch). #3039: instead of telling the operator to re-issue, the
+ * choice is persisted to the durable carriers (`.session-model` /
+ * `.session-effort`) that start.sh honors on every boot — so the queued
+ * command still deterministically applies, just via the relaunch.
+ *
+ *   - 'model'        — persist `arg` as the `.session-model` override
+ *   - 'effort'       — persist `arg` as the `.session-effort` override
+ *   - 'clear-model'  — the queued command was `/model default`: clear the carrier
+ *   - 'clear-effort' — the queued command was `/effort default`: clear the carrier
+ *   - null           — not offline-resolvable (a `mdl:s:<tag>` menu selection
+ *                      needs live picker discovery to become a token); the
+ *                      operator is asked to re-issue after boot.
  */
-export function shutdownResolutionEdits(
+export type ShutdownPersistKind = 'model' | 'effort' | 'clear-model' | 'clear-effort' | null
+
+export interface ShutdownResolutionAction {
+  cmd: PendingSessionCommand
+  persist: ShutdownPersistKind
+  /** The canonical token / allowlisted level to persist (when persist != null). */
+  arg: string
+  /** Ack-card edit when the durable write succeeds. */
+  persistedText: string
+  /** Ack-card edit when persist is null or the durable write failed. */
+  reissueText: string
+}
+
+const EFFORT_MENU_SELECT_PREFIX = 'eff:s:'
+
+function classifyShutdownPersist(cmd: PendingSessionCommand): { persist: ShutdownPersistKind; arg: string } {
+  if (cmd.kind === 'effort') {
+    const level = cmd.origin === 'menu' && cmd.arg.startsWith(EFFORT_MENU_SELECT_PREFIX)
+      ? cmd.arg.slice(EFFORT_MENU_SELECT_PREFIX.length)
+      : cmd.arg
+    if (level === 'default') return { persist: 'clear-effort', arg: level }
+    return { persist: 'effort', arg: level }
+  }
+  // model
+  if (cmd.origin === 'menu') return { persist: null, arg: cmd.arg } // mdl:s:<tag> — needs live discovery
+  if (cmd.arg === 'default') return { persist: 'clear-model', arg: cmd.arg }
+  return { persist: 'model', arg: cmd.arg }
+}
+
+function persistedText(cmd: PendingSessionCommand, escapeHtml: (s: string) => string): string {
+  const noun = KIND_NOUN[cmd.kind]
+  const isClear = cmd.arg === 'default' || cmd.targetLabel === 'default'
+  if (isClear) {
+    return `💾 The session is restarting — your ${noun} override was cleared as requested; the agent boots on the configured default.`
+  }
+  return `💾 The session is restarting — your \`${escapeHtml(cmd.targetLabel)}\` ${noun} choice is saved and applies as the agent boots.`
+}
+
+/**
+ * Empty the slots and return, per queued command, what to persist and which
+ * ack-card edit to make. The gateway performs the durable writes (this module
+ * stays fs-free and unit-testable) and edits with `persistedText` on success
+ * or `reissueText` on a null/failed persist. Shared by the SIGTERM shutdown
+ * handler AND the drain's pending-restart branch — a queued choice is never
+ * dropped with a bare "re-issue" when it can be carried across the bounce.
+ */
+export function shutdownResolutionActions(
   slots: PendingSessionCommandSlots,
   escapeHtml: (s: string) => string,
-): PendingCommandCardEdit[] {
-  return slots.takeAll().map(cmd => ({
-    chatId: cmd.ackChatId,
-    messageId: cmd.ackMessageId,
-    text: restartSupersededText(cmd, escapeHtml),
-  }))
+): ShutdownResolutionAction[] {
+  return slots.takeAll().map(cmd => resolveForRestart(cmd, escapeHtml))
+}
+
+/** Single-command form of shutdownResolutionActions (the drain's pending-restart branch). */
+export function resolveForRestart(
+  cmd: PendingSessionCommand,
+  escapeHtml: (s: string) => string,
+): ShutdownResolutionAction {
+  const { persist, arg } = classifyShutdownPersist(cmd)
+  return {
+    cmd,
+    persist,
+    arg,
+    persistedText: persistedText(cmd, escapeHtml),
+    reissueText: restartSupersededText(cmd, escapeHtml),
+  }
 }
 
 const KIND_NOUN: Record<PendingCommandKind, string> = {

--- a/telegram-plugin/gateway/session-model-file.ts
+++ b/telegram-plugin/gateway/session-model-file.ts
@@ -139,6 +139,10 @@ export function readSessionModelFile(agentDir: string): SessionModelRecord | nul
 export function clearSessionModelFile(agentDir: string): void {
   try {
     rmSync(join(agentDir, SESSION_MODEL_FILE), { force: true })
+    // #3042 item 4: also drop the kept-alert dedup sentinel so a future
+    // override of the same name re-alerts on its first kept boot.
+    rmSync(join(agentDir, '.session-model-kept-notified'), { force: true })
+    rmSync(join(agentDir, '.session-model-boot-attempts'), { force: true })
   } catch {
     /* best-effort */
   }

--- a/telegram-plugin/gateway/session-model-file.ts
+++ b/telegram-plugin/gateway/session-model-file.ts
@@ -7,17 +7,26 @@
  *   - `.session-model` — the DURABLE session override written on every
  *     positively-confirmed `/model` switch. One-line JSON
  *     `{"model","configuredDefaultAtWrite","ts"}`. It is NOT consumed by a
- *     keep-path boot; start.sh deletes it on revert / invalidation /
- *     corruption / 7-day staleness, and the gateway deletes it on
- *     `/model default`.
+ *     keep-path boot; it survives every restart/deploy/crash and is cleared
+ *     only by explicit user action (`/model default`) or invalidation
+ *     (corruption / the configured yaml default changed) — every clearing
+ *     path notifies the operator chat via `.session-model-alert` (#3039).
  *
  *   - `.relaunch-model-intent` — the ONE-SHOT intent bit for the next boot.
  *     One-line JSON `{"intent":"keep"|"revert","reason","ts"}`, atomic
- *     write, last-writer-wins. Boot default is REVERT (operator decision:
- *     a raw `docker restart` / host reboot / crash must revert to the yaml
- *     model), so every switchroom-managed KEEP path must stamp keep-intent
- *     BEFORE the bounce. start.sh consumes it (rm -f) every boot; a stale
- *     (>10 min by the embedded ts) or corrupt intent counts as no intent.
+ *     write, last-writer-wins. Boot default is KEEP (#3039 — operator
+ *     decision 2026-07-11, superseding the earlier revert-by-default): a
+ *     raw `docker restart` / host reboot / deploy / crash keeps a valid
+ *     override. Only an explicit fresh "revert" intent reverts. start.sh
+ *     consumes the file (rm -f) every boot; a stale (>10 min by the
+ *     embedded ts) or corrupt intent counts as no intent (→ keep).
+ *
+ *   - `.session-effort` — the DURABLE effort override (#3039), same shape
+ *     and lifecycle as `.session-model` with `level` in place of `model`:
+ *     `{"level","configuredDefaultAtWrite","ts"}`. Written on every
+ *     positively-confirmed `/effort` apply, resolved by start.sh into the
+ *     relaunch's `--effort`, cleared only by `/effort default` or
+ *     invalidation (with a boot alert).
  *
  * The `model` token is always a canonical `claude --model` token (alias,
  * `claude-*` id, or `sr-*` id) — NEVER a display label like "Opus 4.8".
@@ -41,20 +50,18 @@ export interface SessionModelRecord {
 }
 
 /**
- * Restart reasons whose semantics are "revert the session model to the
- * configured default". Everything else `triggerSelfRestart` fires with is a
- * switchroom-managed relaunch (watchdog recovery, drain-cap bounce,
- * turn-complete deferred restart, fleet-fallback resume, sr-to-claude model
- * switch, grant restarts) and KEEPS the override — the whole point of the
- * stickiness contract. Enumerated in the RFC §3; default-keep here is safe
- * because only gateway code calls triggerSelfRestart, and a bounce nobody
- * stamped (crash, raw docker restart, deploy) reverts by boot default anyway.
+ * Classify a triggerSelfRestart reason into the intent the boot should honor.
+ *
+ * Since #3039 (operator contract 2026-07-11) EVERY restart reason keeps the
+ * override: a restart — user-tapped, watchdog, deploy, or crash — is not
+ * "clear my model". The override is cleared only by explicit user action
+ * (`/model default`) or invalidation at boot, both of which run their own
+ * paths. The 'revert' intent value remains recognised by start.sh (and this
+ * classifier's signature keeps it) so an older gateway's stamp still parses,
+ * but current code never emits it.
  */
-const REVERT_RESTART_REASONS: ReadonlySet<string> = new Set(['inline-button-restart'])
-
-/** Classify a triggerSelfRestart reason into the intent the boot should honor. */
-export function intentForRestartReason(reason: string): RelaunchModelIntent {
-  return REVERT_RESTART_REASONS.has(reason) ? 'revert' : 'keep'
+export function intentForRestartReason(_reason: string): RelaunchModelIntent {
+  return 'keep'
 }
 
 function atomicWrite(path: string, content: string): void {
@@ -154,8 +161,8 @@ export function restoreSessionModelFileRaw(agentDir: string, raw: string | null)
  * Stamp the one-shot relaunch intent. MUST be called synchronously BEFORE
  * the restart signal/dispatch it describes (write-before-kill invariant —
  * the next start.sh boot reads this to decide keep vs revert). Best-effort:
- * a failed write means the boot falls back to the default (revert), which
- * is the safe side.
+ * a failed write means the boot falls back to the default (keep, #3039) —
+ * the user's choice is preserved either way.
  */
 export function writeRelaunchModelIntent(
   agentDir: string,
@@ -249,5 +256,82 @@ export function readConfiguredDefaultModel(agentDir: string): string | null {
     return v.length > 0 ? v : null
   } catch {
     return null
+  }
+}
+
+// ─── Durable session-effort override (#3039) ────────────────────────────────
+//
+// The `/effort` sibling of `.session-model`. Same lifecycle: written on every
+// positively-confirmed effort apply, honored by start.sh on every boot
+// (`--effort <level>`), cleared only by `/effort default` or invalidation
+// (configured `thinking_effort:` changed / corrupt file — both alert once).
+
+export const SESSION_EFFORT_FILE = '.session-effort'
+
+/**
+ * The level allowlist, duplicated from effort-command.ts to avoid a cycle
+ * (effort-command must stay gateway-agnostic; this module already imports
+ * from model-command). Kept in sync by the cross-check regression test.
+ */
+const EFFORT_LEVEL_RE = /^(low|medium|high|xhigh|max)$/
+
+export interface SessionEffortRecord {
+  level: string
+  /** The cascade-resolved `thinking_effort` at write time ('' when unset). */
+  configuredDefaultAtWrite: string
+  ts: number
+}
+
+/** Parse `.session-effort` content. Null on corrupt JSON / bad shape / non-allowlisted level. */
+export function parseSessionEffort(text: string): SessionEffortRecord | null {
+  try {
+    const raw = JSON.parse(text) as Partial<SessionEffortRecord>
+    if (
+      typeof raw.level !== 'string' ||
+      typeof raw.configuredDefaultAtWrite !== 'string' ||
+      typeof raw.ts !== 'number' ||
+      !EFFORT_LEVEL_RE.test(raw.level)
+    ) {
+      return null
+    }
+    return { level: raw.level, configuredDefaultAtWrite: raw.configuredDefaultAtWrite, ts: raw.ts }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Write the durable effort override. Throws on a non-allowlisted level —
+ * the value is passed verbatim to `claude --effort` at the next boot.
+ */
+export function writeSessionEffortFile(
+  agentDir: string,
+  level: string,
+  configuredDefaultAtWrite: string | null,
+): void {
+  if (!EFFORT_LEVEL_RE.test(level)) {
+    throw new Error(`refusing to persist non-allowlisted effort level: ${JSON.stringify(level)}`)
+  }
+  atomicWrite(
+    join(agentDir, SESSION_EFFORT_FILE),
+    `${JSON.stringify({ level, configuredDefaultAtWrite: configuredDefaultAtWrite ?? '', ts: Date.now() })}\n`,
+  )
+}
+
+/** Parsed durable effort override, or null when absent/corrupt. */
+export function readSessionEffortFile(agentDir: string): SessionEffortRecord | null {
+  try {
+    return parseSessionEffort(readFileSync(join(agentDir, SESSION_EFFORT_FILE), 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+/** Delete the durable effort override (`/effort default`). Best-effort. */
+export function clearSessionEffortFile(agentDir: string): void {
+  try {
+    rmSync(join(agentDir, SESSION_EFFORT_FILE), { force: true })
+  } catch {
+    /* best-effort */
   }
 }

--- a/telegram-plugin/tests/effort-command.test.ts
+++ b/telegram-plugin/tests/effort-command.test.ts
@@ -107,7 +107,7 @@ describe("effort-command: handler", () => {
     const { deps } = makeDeps({ getConfiguredEffort: () => "medium" });
     const r = await handleEffortCommand({ kind: "show" }, deps);
     expect(r.text).toContain("medium");
-    expect(r.text).toMatch(/reverts to the configured default/);
+    expect(r.text).toMatch(/persists across restarts and deploys/);
   });
 
   it("show falls back to low when effort is unreadable", async () => {
@@ -121,7 +121,7 @@ describe("effort-command: handler", () => {
     const r = await handleEffortCommand({ kind: "set", level: "high" }, deps);
     expect(calls).toEqual([{ agent: "carrie", level: "high" }]);
     expect(r.text).toContain("Set effort level to high");
-    expect(r.text).toMatch(/reverts to the configured default/);
+    expect(r.text).toMatch(/persists across restarts and deploys/);
   });
 
   it("set notes the re-read cost when a confirmation was needed", async () => {
@@ -196,5 +196,62 @@ describe("effort-command: menu + callback", () => {
     const out = await handleEffortMenuCallback(`${EFFORT_CALLBACK_PREFIX}s:bogus`, deps);
     expect(calls).toEqual([]);
     expect(out.selectedEffort).toBeUndefined();
+  });
+});
+
+// ─── #3039: /effort default + durable-override surfaces ─────────────────────
+
+describe("effort-command: /effort default (#3039)", () => {
+  it("parses `/effort default` as an explicit clear", () => {
+    expect(parseEffortCommand("/effort default")).toEqual({ kind: "default" });
+    expect(parseEffortCommand("/effort DEFAULT")).toEqual({ kind: "default" });
+  });
+
+  it("default restores the configured level, THEN clears the durable override (order pins the wrapper undo)", async () => {
+    const events: string[] = [];
+    const { deps } = makeDeps({
+      getConfiguredEffort: () => "medium",
+      applyEffort: async (_a, level) => {
+        events.push(`apply:${level}`);
+        return applyOk(level);
+      },
+      clearSessionEffort: () => events.push("clear"),
+    });
+    const r = await handleEffortCommand({ kind: "default" }, deps);
+    expect(events).toEqual(["apply:medium", "clear"]);
+    expect(r.text).toContain("override cleared");
+    expect(r.text).toContain("`medium`");
+  });
+
+  it("default still clears the override when the live apply fails (boots on default from now on)", async () => {
+    let cleared = false;
+    const { deps } = makeDeps({
+      applyEffort: async () => applyFail("apply_unverified"),
+      clearSessionEffort: () => { cleared = true; },
+    });
+    const r = await handleEffortCommand({ kind: "default" }, deps);
+    expect(cleared).toBe(true);
+    expect(r.text).toContain("override cleared");
+    // Honest: does not claim the live session switched.
+    expect(r.text).toContain("Couldn't switch the live session right now");
+  });
+
+  it("show surfaces an active session override next to the configured default", async () => {
+    const { deps } = makeDeps({ getConfiguredEffort: () => "low", getSessionEffort: () => "xhigh" });
+    const r = await handleEffortCommand({ kind: "show" }, deps);
+    expect(r.text).toContain("session override: `xhigh`");
+  });
+
+  it("menu marks the durable override as the live level", () => {
+    const { deps } = makeDeps({ getConfiguredEffort: () => "low", getSessionEffort: () => "max" });
+    const menu = buildEffortMenu(deps);
+    const marked = menu.keyboard!.flat().find((b) => b.text.startsWith("✅"));
+    expect(marked?.text).toBe("✅ max");
+  });
+
+  it("help text advertises /effort default and the sticky contract", async () => {
+    const r = await handleEffortCommand({ kind: "help" }, makeDeps().deps);
+    expect(r.text).toContain("/effort default");
+    expect(r.text).toContain("persists across restarts and deploys");
   });
 });

--- a/telegram-plugin/tests/gateway-pending-command-wiring.test.ts
+++ b/telegram-plugin/tests/gateway-pending-command-wiring.test.ts
@@ -62,17 +62,30 @@ describe('gateway: shutdown resolves queued ack cards (#3018 finding 3)', () => 
   })
 })
 
-describe('gateway: drain never confirms a busy refusal (#3039)', () => {
-  it('drainPendingSessionCommand re-checks turn-in-flight per command and re-enqueues on a busy-refusal reply', () => {
+describe('gateway: drain never confirms a busy refusal and never drops the batch (#3039, #3042 blocker 1)', () => {
+  it('drainPendingSessionCommand routes takeAll() through the unit-tested drainTakenCommands with the loss-safe IO', () => {
     const fnIdx = GATEWAY_SRC.indexOf('async function drainPendingSessionCommand(')
     expect(fnIdx).toBeGreaterThan(0)
-    const win = GATEWAY_SRC.slice(fnIdx, fnIdx + 4000)
-    expect(win).toContain('if (turnInFlightForGate())')
-    expect(win).toContain('isBusyRefusalText(body)')
-    expect(win).toContain('reEnqueueUnlessSuperseded(cmd)')
+    const win = GATEWAY_SRC.slice(fnIdx, fnIdx + 3000)
+    // Iteration + loss-safety invariants live in pending-session-command.ts
+    // (drainTakenCommands, functionally tested); the gateway only supplies IO.
+    expect(win).toContain('pendingCmdDrainTaken(pendingSessionCommand.takeAll()')
+    expect(win).toContain('turnInFlightForGate()')
+    expect(win).toContain('isBusyRefusal: isBusyRefusalText')
+    expect(win).toContain('reEnqueue: reEnqueueUnlessSuperseded')
     // The pending-restart branch persists rather than telling the user to re-issue.
     expect(win).toContain('pendingCmdResolveForRestart(cmd')
-    expect(win).toContain('persistQueuedCommandForRestart(action)')
+    expect(win).toContain('persistQueuedCommandForRestart(')
+  })
+})
+
+describe('gateway: unconfirmed queued model tokens are gated before durable persist (#3042 blocker 2a)', () => {
+  it('persistQueuedCommandForRestart refuses offline-unverifiable tokens', () => {
+    const fnIdx = GATEWAY_SRC.indexOf('function persistQueuedCommandForRestart(')
+    expect(fnIdx).toBeGreaterThan(0)
+    const win = GATEWAY_SRC.slice(fnIdx, fnIdx + 2500)
+    expect(win).toContain('isOfflineTrustedModelToken(action.arg)')
+    expect(win).toContain('NOT saved')
   })
 })
 

--- a/telegram-plugin/tests/gateway-pending-command-wiring.test.ts
+++ b/telegram-plugin/tests/gateway-pending-command-wiring.test.ts
@@ -6,7 +6,7 @@
  * interval, enqueueSessionCommand, drainPendingSessionCommand, and the
  * shutdown() handler), so — mirroring gateway-session-model-relaunch.test.ts —
  * we assert on the source structure. The pure contract (per-kind slots,
- * drainCapDecision, shutdownResolutionEdits) is unit-tested in
+ * drainCapDecision, shutdownResolutionActions) is unit-tested in
  * pending-session-command.test.ts.
  */
 
@@ -47,15 +47,50 @@ describe('gateway: post-enqueue idle kick (#3018 finding 5)', () => {
 })
 
 describe('gateway: shutdown resolves queued ack cards (#3018 finding 3)', () => {
-  it('shutdown() empties the slots via shutdownResolutionEdits and edits each card, before the force-exit timer', () => {
+  it('shutdown() empties the slots via shutdownResolutionActions, PERSISTS each typed choice, and edits each card, before the force-exit timer', () => {
     const fnIdx = GATEWAY_SRC.indexOf('async function shutdown(signal: string)')
     expect(fnIdx).toBeGreaterThan(0)
     const win = GATEWAY_SRC.slice(fnIdx, GATEWAY_SRC.indexOf('forceExitTimer', fnIdx))
-    const resolveIdx = win.indexOf('pendingCmdShutdownResolutionEdits(pendingSessionCommand')
+    const resolveIdx = win.indexOf('pendingCmdShutdownResolutionActions(pendingSessionCommand')
     expect(resolveIdx).toBeGreaterThan(0)
+    // #3039: the queued choice is carried across the bounce via the durable
+    // carriers, not dropped with a "re-issue" note.
+    expect(win.indexOf('persistQueuedCommandForRestart(', resolveIdx)).toBeGreaterThan(resolveIdx)
     expect(win.indexOf('editPendingCommandCard(', resolveIdx)).toBeGreaterThan(resolveIdx)
     // Bounded: raced against a timeout so a wedged Telegram API can't block shutdown.
     expect(win.slice(resolveIdx)).toContain('Promise.race')
+  })
+})
+
+describe('gateway: drain never confirms a busy refusal (#3039)', () => {
+  it('drainPendingSessionCommand re-checks turn-in-flight per command and re-enqueues on a busy-refusal reply', () => {
+    const fnIdx = GATEWAY_SRC.indexOf('async function drainPendingSessionCommand(')
+    expect(fnIdx).toBeGreaterThan(0)
+    const win = GATEWAY_SRC.slice(fnIdx, fnIdx + 4000)
+    expect(win).toContain('if (turnInFlightForGate())')
+    expect(win).toContain('isBusyRefusalText(body)')
+    expect(win).toContain('reEnqueueUnlessSuperseded(cmd)')
+    // The pending-restart branch persists rather than telling the user to re-issue.
+    expect(win).toContain('pendingCmdResolveForRestart(cmd')
+    expect(win).toContain('persistQueuedCommandForRestart(action)')
+  })
+})
+
+describe('gateway: /restart keeps the session-model override (#3039)', () => {
+  it('the /restart chat command stamps keep, never revert', () => {
+    expect(GATEWAY_SRC).toContain("writeRelaunchModelIntent(smDir, 'keep', 'user: /restart from chat')")
+    expect(GATEWAY_SRC).not.toContain("writeRelaunchModelIntent(smDir, 'revert'")
+  })
+})
+
+describe('gateway: /effort persistence choke point (#3039)', () => {
+  it('buildEffortDeps persists a confirmed apply to .session-effort and wires clearSessionEffort', () => {
+    const fnIdx = GATEWAY_SRC.indexOf('function buildEffortDeps(')
+    expect(fnIdx).toBeGreaterThan(0)
+    const win = GATEWAY_SRC.slice(fnIdx, fnIdx + 2500)
+    expect(win).toContain('writeSessionEffortFile(')
+    expect(win).toContain('clearSessionEffortFile(')
+    expect(win).toContain('readSessionEffortFile(')
   })
 })
 

--- a/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
+++ b/telegram-plugin/tests/gateway-session-model-relaunch.test.ts
@@ -114,14 +114,14 @@ describe('gateway: intent writers on the restart verbs', () => {
     expect(clearIdx).toBeGreaterThan(markerIdx)
   })
 
-  it('/restart stamps an explicit revert intent (reason honesty) before dispatch', () => {
+  it('/restart stamps a KEEP intent before dispatch (#3039: a restart is not "clear my model")', () => {
     const idx = GATEWAY_SRC.indexOf("stampUserRestartReason('user: /restart from chat')")
     expect(idx).toBeGreaterThan(0)
     const win = GATEWAY_SRC.slice(idx, idx + 900)
-    const revertIdx = win.indexOf("writeRelaunchModelIntent(smDir, 'revert', 'user: /restart from chat')")
+    const keepIdx = win.indexOf("writeRelaunchModelIntent(smDir, 'keep', 'user: /restart from chat')")
     const dispatchIdx = win.indexOf("hostdRequestId('gw-restart')")
-    expect(revertIdx).toBeGreaterThan(0)
-    expect(dispatchIdx).toBeGreaterThan(revertIdx)
+    expect(keepIdx).toBeGreaterThan(0)
+    expect(dispatchIdx).toBeGreaterThan(keepIdx)
   })
 
   it('/new and /reset stamp keep-intent (fresh conversation, same model — contract row 7)', () => {

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -21,6 +21,7 @@ import {
   isSrModel,
   isClaudeModel,
   isBusyRefusalText,
+  isOfflineTrustedModelToken,
   MODEL_ALIASES,
   type ModelCommandDeps,
 } from "../gateway/model-command.js";
@@ -1339,5 +1340,23 @@ describe("isBusyRefusalText (#3039)", () => {
     expect(isBusyRefusalText("⏺ Set model to Opus 4.8")).toBe(false);
     expect(isBusyRefusalText("✅ `/effort high` — Set effort level to high")).toBe(false);
     expect(isBusyRefusalText("❌ Switch to opus failed: tmux session not found")).toBe(false);
+  });
+});
+
+
+describe("isOfflineTrustedModelToken (#3042 blocker 2a)", () => {
+  it("trusts static Claude aliases and curated sr-* alias names/targets", () => {
+    for (const a of MODEL_ALIASES) expect(isOfflineTrustedModelToken(a)).toBe(true);
+    // Curated sr-* aliases resolve by construction (present in the LiteLLM config).
+    const [alias, target] = Object.entries(SR_MODEL_ALIASES)[0];
+    expect(isOfflineTrustedModelToken(alias)).toBe(true);
+    expect(isOfflineTrustedModelToken(target)).toBe(true);
+  });
+
+  it("refuses hand-typed full ids — shape-valid garbage must never reach a boot carrier unconfirmed", () => {
+    expect(isOfflineTrustedModelToken("claude-nonexistnet-9")).toBe(false);
+    expect(isOfflineTrustedModelToken("claude-opus-4-8")).toBe(false); // real but unverifiable offline
+    expect(isOfflineTrustedModelToken("sr-made-up/model")).toBe(false);
+    expect(isOfflineTrustedModelToken("")).toBe(false);
   });
 });

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -20,6 +20,7 @@ import {
   isValidModelArg,
   isSrModel,
   isClaudeModel,
+  isBusyRefusalText,
   MODEL_ALIASES,
   type ModelCommandDeps,
 } from "../gateway/model-command.js";
@@ -201,7 +202,7 @@ describe("handleModelCommand — set", () => {
     const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
     expect(calls).toEqual([{ agent: "klanker", command: "/model opus" }]);
     expect(reply.text).toContain("<pre>⏺ Set model to sonnet</pre>");
-    expect(reply.text).toContain("Sticky across switchroom-managed relaunches");
+    expect(reply.text).toContain("persists across restarts, deploys, and crashes");
     expect(reply.html).toBe(true);
     // A verified confirmation records the live model so /status stays honest
     // (bug 1: the typed path never recorded the switch before).
@@ -769,12 +770,19 @@ describe("buildModelMenu", () => {
     }
   });
 
-  it("busy agent → no discovery, no keyboard, explanatory text", async () => {
+  it("busy agent → no discovery, STATIC keyboard whose taps ride the queue (#3039)", async () => {
     const { deps, calls } = makeMenuDeps({ isBusy: () => true });
     const menu = await buildModelMenu(deps);
+    // Never drives the picker mid-turn…
     expect(calls.discover).toBe(0);
-    expect(menu.keyboard).toBeUndefined();
     expect(menu.text).toContain("mid-turn");
+    // …but no dead-end either: static alias rows are offered so the operator
+    // can still lock in a choice (the tap queues at the gateway busy gate).
+    expect(menu.keyboard).toBeDefined();
+    const data = menu.keyboard!.flat().map(b => b.callback_data);
+    expect(data).toContain("mdl:alias:opus");
+    expect(data).toContain("mdl:alias:default");
+    expect(menu.text).not.toContain("Try again");
   });
 
   it("discovery failure → static v1 fallback with the reason, no keyboard", async () => {
@@ -1315,5 +1323,21 @@ describe("Fable alias callback injects /model fable", () => {
     const out = await handleModelMenuCallback(`${MODEL_CALLBACK_ALIAS}bad name`, deps);
     expect(injectCalls).toEqual([]);
     expect(out.answer).toContain("Invalid");
+  });
+});
+
+// ─── #3039: busy-refusal detection for the queued-command drain ──────────────
+
+describe("isBusyRefusalText (#3039)", () => {
+  it("matches the typed and menu busy refusals", async () => {
+    const deps = makeDeps({ isBusy: () => true }).deps;
+    const reply = await handleModelCommand({ kind: "set", model: "opus" }, deps);
+    expect(isBusyRefusalText(reply.text)).toBe(true);
+  });
+
+  it("never matches a genuine confirmation or failure", () => {
+    expect(isBusyRefusalText("⏺ Set model to Opus 4.8")).toBe(false);
+    expect(isBusyRefusalText("✅ `/effort high` — Set effort level to high")).toBe(false);
+    expect(isBusyRefusalText("❌ Switch to opus failed: tmux session not found")).toBe(false);
   });
 });

--- a/telegram-plugin/tests/pending-session-command.test.ts
+++ b/telegram-plugin/tests/pending-session-command.test.ts
@@ -14,8 +14,10 @@
  *   - size mirrors the `pendingRestarts.size` gate shape (0..2)
  *   - the reaper's drainCapDecision DEFERS while a turn is in flight — the
  *     60s cap must never force a mid-turn drain (#3018 finding 1)
- *   - shutdownResolutionEdits empties the slots and yields the ack-card edits
- *     telling the operator to re-issue after boot (#3018 finding 3)
+ *   - shutdownResolutionActions empties the slots and yields, per queued
+ *     command, the durable persist the gateway should perform so the choice
+ *     still applies across the bounce (#3039) — with a re-issue fallback only
+ *     for the unresolvable menu-tag case
  *   - the ack / superseded / restart-superseded text names the target so the
  *     operator always sees their choice was captured, replaced, or deferred —
  *     never dropped.
@@ -25,7 +27,8 @@ import { describe, it, expect } from 'vitest'
 import {
   createPendingSessionCommandSlots,
   drainCapDecision,
-  shutdownResolutionEdits,
+  shutdownResolutionActions,
+  resolveForRestart,
   ackText,
   supersededText,
   restartSupersededText,
@@ -167,24 +170,45 @@ describe('drainCapDecision (#3018 finding 1: the cap must never force mid-turn)'
   })
 })
 
-describe('shutdownResolutionEdits (#3018 finding 3: SIGTERM must not dangle the ack card)', () => {
-  it('empties the slots and yields one restart-superseded edit per queued command', () => {
+describe('shutdownResolutionActions (#3018 finding 3 + #3039: SIGTERM persists the queued choice)', () => {
+  it('empties the slots and yields a persist action per queued command', () => {
     const slots = createPendingSessionCommandSlots()
-    slots.set(cmd({ kind: 'model', targetLabel: 'fable', ackChatId: '100', ackMessageId: 7 }))
-    slots.set(cmd({ kind: 'effort', targetLabel: 'high', ackChatId: '100', ackMessageId: 9 }))
-    const edits = shutdownResolutionEdits(slots, ident)
-    expect(edits).toHaveLength(2)
+    slots.set(cmd({ kind: 'model', targetLabel: 'fable', arg: 'fable', ackChatId: '100', ackMessageId: 7 }))
+    slots.set(cmd({ kind: 'effort', targetLabel: 'high', arg: 'high', ackChatId: '100', ackMessageId: 9 }))
+    const actions = shutdownResolutionActions(slots, ident)
+    expect(actions).toHaveLength(2)
     expect(slots.size).toBe(0) // the queue is RESOLVED, not left behind
-    const model = edits.find(e => e.messageId === 7)!
-    expect(model.chatId).toBe('100')
-    expect(model.text).toContain('`fable`')
-    expect(model.text).toContain('re-issue')
-    const effort = edits.find(e => e.messageId === 9)!
-    expect(effort.text).toContain('/effort high')
+    const model = actions.find(a => a.cmd.ackMessageId === 7)!
+    expect(model.persist).toBe('model')
+    expect(model.arg).toBe('fable')
+    expect(model.persistedText).toContain('`fable`')
+    expect(model.persistedText).toContain('saved')
+    // The fallback (persist failed) still names the choice + how to recover.
+    expect(model.reissueText).toContain('re-issue')
+    const effort = actions.find(a => a.cmd.ackMessageId === 9)!
+    expect(effort.persist).toBe('effort')
+    expect(effort.arg).toBe('high')
   })
 
-  it('returns no edits when nothing is queued', () => {
-    expect(shutdownResolutionEdits(createPendingSessionCommandSlots(), ident)).toEqual([])
+  it('typed /model default → clear-model; typed /effort default → clear-effort', () => {
+    expect(resolveForRestart(cmd({ kind: 'model', arg: 'default', targetLabel: 'default' }), ident).persist).toBe('clear-model')
+    expect(resolveForRestart(cmd({ kind: 'effort', arg: 'default', targetLabel: 'default' }), ident).persist).toBe('clear-effort')
+  })
+
+  it('menu model selection (mdl:s:<tag>) is not offline-resolvable → persist null, re-issue fallback', () => {
+    const a = resolveForRestart(cmd({ kind: 'model', origin: 'menu', arg: 'mdl:s:abcd1234', targetLabel: 'the selected model' }), ident)
+    expect(a.persist).toBeNull()
+    expect(a.reissueText).toContain('re-issue')
+  })
+
+  it('menu effort tap (eff:s:<level>) IS resolvable → persist effort with the level', () => {
+    const a = resolveForRestart(cmd({ kind: 'effort', origin: 'menu', arg: 'eff:s:xhigh', targetLabel: 'xhigh' }), ident)
+    expect(a.persist).toBe('effort')
+    expect(a.arg).toBe('xhigh')
+  })
+
+  it('returns no actions when nothing is queued', () => {
+    expect(shutdownResolutionActions(createPendingSessionCommandSlots(), ident)).toEqual([])
   })
 })
 

--- a/telegram-plugin/tests/pending-session-command.test.ts
+++ b/telegram-plugin/tests/pending-session-command.test.ts
@@ -29,6 +29,8 @@ import {
   drainCapDecision,
   shutdownResolutionActions,
   resolveForRestart,
+  drainTakenCommands,
+  type DrainIo,
   ackText,
   supersededText,
   restartSupersededText,
@@ -250,5 +252,71 @@ describe('restartSupersededText', () => {
     expect(t).toContain('restarting')
     expect(t).toContain('/effort max')
     expect(t).toContain('`max`')
+  })
+})
+
+
+// ─── #3042 blocker 1: drain loss-safety across a two-command batch ───────────
+
+describe('drainTakenCommands (#3042 blocker 1: an early stop must not drop the rest of the batch)', () => {
+  function makeIo(overrides: Partial<DrainIo> = {}) {
+    const events: string[] = []
+    const io: DrainIo = {
+      restartPending: () => false,
+      turnInFlight: () => false,
+      apply: async c => { events.push(`apply:${c.kind}`); return `✅ ${c.kind} done` },
+      isBusyRefusal: t => t.includes('BUSY'),
+      resolveForRestartText: c => `persisted:${c.kind}`,
+      editCard: async (c, text) => { events.push(`edit:${c.kind}:${text}`) },
+      reEnqueue: c => { events.push(`requeue:${c.kind}`) },
+      failureText: (c, err) => `fail:${c.kind}:${(err as Error).message}`,
+      ...overrides,
+    }
+    return { io, events }
+  }
+  const batch = () => [cmd({ kind: 'model' }), cmd({ kind: 'effort', arg: 'high', targetLabel: 'high' })]
+
+  it('happy path applies and confirms both commands in order', async () => {
+    const { io, events } = makeIo()
+    await drainTakenCommands(batch(), io)
+    expect(events).toEqual(['apply:model', 'edit:model:✅ model done', 'apply:effort', 'edit:effort:✅ effort done'])
+  })
+
+  it('turn races in before the FIRST command → BOTH are re-enqueued, none applied or confirmed', async () => {
+    const { io, events } = makeIo({ turnInFlight: () => true })
+    await drainTakenCommands(batch(), io)
+    expect(events).toEqual(['requeue:model', 'requeue:effort'])
+  })
+
+  it('turn races in before the SECOND command → first applied, second re-enqueued (not lost)', async () => {
+    let calls = 0
+    const { io, events } = makeIo({ turnInFlight: () => ++calls > 1 })
+    await drainTakenCommands(batch(), io)
+    expect(events).toEqual(['apply:model', 'edit:model:✅ model done', 'requeue:effort'])
+  })
+
+  it('handler busy-refusal on the FIRST command → the refusal never reaches the ack card and BOTH are re-enqueued', async () => {
+    const { io, events } = makeIo({
+      apply: async c => (c.kind === 'model' ? 'BUSY — mid-turn' : '✅ effort done'),
+    })
+    await drainTakenCommands(batch(), io)
+    expect(events).toEqual(['requeue:model', 'requeue:effort'])
+  })
+
+  it('apply throwing on the first command does NOT stop the second (failure is per-command)', async () => {
+    const { io, events } = makeIo({
+      apply: async c => {
+        if (c.kind === 'model') throw new Error('boom')
+        return '✅ effort done'
+      },
+    })
+    await drainTakenCommands(batch(), io)
+    expect(events).toEqual(['edit:model:fail:model:boom', 'edit:effort:✅ effort done'])
+  })
+
+  it('restart pending → every command is resolved via the carriers, none applied live', async () => {
+    const { io, events } = makeIo({ restartPending: () => true })
+    await drainTakenCommands(batch(), io)
+    expect(events).toEqual(['edit:model:persisted:model', 'edit:effort:persisted:effort'])
   })
 })

--- a/telegram-plugin/tests/session-model-file.test.ts
+++ b/telegram-plugin/tests/session-model-file.test.ts
@@ -25,6 +25,10 @@ import {
   SESSION_MODEL_FILE,
   RELAUNCH_MODEL_INTENT_FILE,
   CONFIGURED_DEFAULT_MODEL_FILE,
+  parseSessionEffort,
+  writeSessionEffortFile,
+  readSessionEffortFile,
+  clearSessionEffortFile,
 } from '../gateway/session-model-file.js'
 
 let dir: string
@@ -111,8 +115,8 @@ describe('intentForRestartReason — the triggerSelfRestart per-reason table (RF
     expect(intentForRestartReason(reason)).toBe('keep')
   })
 
-  it('inline-button-restart (operator-deliberate) → revert', () => {
-    expect(intentForRestartReason('inline-button-restart')).toBe('revert')
+  it('inline-button-restart → keep (#3039: a restart is not "clear my model")', () => {
+    expect(intentForRestartReason('inline-button-restart')).toBe('keep')
   })
 
   it('unknown gateway reasons default to keep (only gateway code calls triggerSelfRestart; crashes never do)', () => {
@@ -172,5 +176,56 @@ describe('readConfiguredDefaultModel', () => {
 
   it('clearSessionModelFile is a safe no-op when absent', () => {
     expect(() => clearSessionModelFile(dir)).not.toThrow()
+  })
+})
+
+// ─── #3039: durable session-effort carrier ───────────────────────────────────
+
+describe('session-effort file helpers (#3039)', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'sr-session-effort-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('round-trips a valid level with the configured default at write', () => {
+    writeSessionEffortFile(dir, 'xhigh', 'low')
+    const rec = readSessionEffortFile(dir)
+    expect(rec?.level).toBe('xhigh')
+    expect(rec?.configuredDefaultAtWrite).toBe('low')
+    expect(typeof rec?.ts).toBe('number')
+  })
+
+  it('refuses to persist a non-allowlisted level (verbatim --effort surface)', () => {
+    expect(() => writeSessionEffortFile(dir, 'mega; rm -rf /', 'low')).toThrow(/non-allowlisted/)
+    expect(readSessionEffortFile(dir)).toBeNull()
+  })
+
+  it('parseSessionEffort rejects corrupt JSON, bad shape, and bad levels', () => {
+    expect(parseSessionEffort('{broken')).toBeNull()
+    expect(parseSessionEffort('{"level":"turbo","configuredDefaultAtWrite":"low","ts":1}')).toBeNull()
+    expect(parseSessionEffort('{"level":"high","ts":1}')).toBeNull()
+    expect(parseSessionEffort('{"level":"high","configuredDefaultAtWrite":"low","ts":1}')?.level).toBe('high')
+  })
+
+  it('clearSessionEffortFile removes it; read after clear is null', () => {
+    writeSessionEffortFile(dir, 'high', '')
+    clearSessionEffortFile(dir)
+    expect(readSessionEffortFile(dir)).toBeNull()
+  })
+})
+
+describe('intentForRestartReason is keep-for-everything (#3039)', () => {
+  it('every reason keeps — restarts never clear a user model choice', () => {
+    for (const reason of [
+      'inline-button-restart',
+      'user: /restart from chat',
+      'schedule-restart-immediate',
+      'anything-else',
+    ]) {
+      expect(intentForRestartReason(reason)).toBe('keep')
+    }
   })
 })

--- a/tests/scaffold.session-model.test.ts
+++ b/tests/scaffold.session-model.test.ts
@@ -281,6 +281,39 @@ describe("scaffoldAgent: session-model stickiness boot resolver (start.sh)", () 
     expect(alert).toContain("configured default");
   });
 
+  // ── crashloop self-heal (#3042 blocker 2b) ───────────────────────────────
+  it("three consecutive fast boots with an override active → carrier cleared, default booted, alert once", () => {
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
+    expect(runBlock("1")).toBe("claude-opus-4-8"); // boot 1 (cnt=1)
+    expect(runBlock("1")).toBe("claude-opus-4-8"); // boot 2 (cnt=2)
+    expect(runBlock("1")).toBe(DEFAULT_MODEL);     // boot 3 → self-heal
+    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+    expect(existsSync(join(agentDir, ".session-model-boot-attempts"))).toBe(false);
+    const alert = alertText();
+    expect(alert).toContain("cleared automatically");
+    expect(alert).toContain("`claude-sonnet-5`");
+    // …and the NEXT boot is a clean default boot (no stale counter).
+    expect(runBlock("1")).toBe(DEFAULT_MODEL);
+  });
+
+  it("a boot without an override clears any stale boot-attempt counter", () => {
+    writeFileSync(join(agentDir, ".session-model-boot-attempts"), "2 " + Math.floor(Date.now() / 1000) + "\n");
+    expect(runBlock("1")).toBe(DEFAULT_MODEL);
+    expect(existsSync(join(agentDir, ".session-model-boot-attempts"))).toBe(false);
+  });
+
+  // ── kept-alert dedup (#3042 item 4) ──────────────────────────────────────
+  it("the 'kept' chat alert fires once per kept value — a bounce loop can't storm the chat", () => {
+    writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
+    expect(runBlock("1")).toBe("claude-opus-4-8");
+    expect(alertText()).toContain("kept across this relaunch");
+    rmSync(join(agentDir, ".session-model-alert"));
+    // Second boot, same kept value → no new alert; sentinel remembers.
+    expect(runBlock("1")).toBe("claude-opus-4-8");
+    expect(existsSync(join(agentDir, ".session-model-alert"))).toBe(false);
+    expect(readFileSync(join(agentDir, ".session-model-kept-notified"), "utf-8").trim()).toBe("claude-opus-4-8");
+  });
+
   // ── session-effort resolver (#3039) ───────────────────────────────────────
   function effortJson(level: string, cfg = "low", ts = Date.now()): string {
     return `${JSON.stringify({ level, configuredDefaultAtWrite: cfg, ts })}\n`;

--- a/tests/scaffold.session-model.test.ts
+++ b/tests/scaffold.session-model.test.ts
@@ -11,12 +11,13 @@ import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/confi
 // (reference/rfcs/session-model-stickiness.md). Successor to
 // scaffold.session-model-override.test.ts (one-shot carrier, retired).
 //
-// Contract under test, driven as sh-harness fixtures against the RENDERED
-// block: the durable `.session-model` override is applied ONLY under a fresh
-// (<10 min, embedded ts) "keep" `.relaunch-model-intent`; anything else —
-// revert intent, absent (crash / raw `docker restart` / deploy), stale, or
-// corrupt — deletes the override, boots the configured default, and writes a
-// `.session-model-alert` notice naming why.
+// Contract under test (#3039 rev 3, keep-by-default), driven as sh-harness
+// fixtures against the RENDERED block: the durable `.session-model` override
+// is applied on EVERY boot — crash, deploy, raw `docker restart`, stale or
+// corrupt intent all KEEP it. Only a FRESH (<10 min, embedded ts) explicit
+// "revert" `.relaunch-model-intent`, corruption, or a configured-default
+// change clears it — and every clearing path writes a `.session-model-alert`
+// notice the gateway relays to chat.
 
 const telegramConfig: TelegramConfig = {
   bot_token: "123456:ABC-DEF",
@@ -191,16 +192,14 @@ describe("scaffoldAgent: session-model stickiness boot resolver (start.sh)", () 
     expect(alertText()).toContain("/model default");
   });
 
-  // ── revert paths ──────────────────────────────────────────────────────────
-  it("override + NO intent (crash / raw docker restart / deploy) → reverts, deletes file, announces why", () => {
+  // ── keep-by-default paths (#3039) ────────────────────────────────────────
+  it("override + NO intent (crash / raw docker restart / deploy) → KEEPS the override and announces", () => {
     writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
-    expect(runBlock("1")).toBe(DEFAULT_MODEL);
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+    expect(runBlock("1")).toBe("claude-opus-4-8");
+    expect(existsSync(join(agentDir, ".session-model"))).toBe(true);
     const alert = alertText();
-    expect(alert).toContain("`claude-opus-4-8` was cleared");
-    expect(alert).toContain("reverted to the configured default `claude-sonnet-5`");
-    expect(alert).toContain("no keep intent — crash, external container restart, or deploy");
-    expect(alert).toContain("Re-issue /model claude-opus-4-8");
+    expect(alert).toContain("`claude-opus-4-8` kept across this relaunch");
+    expect(alert).toContain("/model default");
   });
 
   it("override + revert intent → reverts and the notice carries the intent's reason", () => {
@@ -212,18 +211,18 @@ describe("scaffoldAgent: session-model stickiness boot resolver (start.sh)", () 
     expect(alertText()).toContain("user: /restart from chat");
   });
 
-  it("override + STALE keep intent (>10 min by embedded ts) → treated as no intent, reverts", () => {
+  it("override + STALE revert intent (>10 min by embedded ts) → treated as no intent, KEEPS", () => {
     writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
-    writeFileSync(join(agentDir, ".relaunch-model-intent"), intentJson("keep", Date.now() - 11 * 60_000));
-    expect(runBlock("1")).toBe(DEFAULT_MODEL);
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+    writeFileSync(join(agentDir, ".relaunch-model-intent"), intentJson("revert", Date.now() - 11 * 60_000));
+    expect(runBlock("1")).toBe("claude-opus-4-8");
+    expect(existsSync(join(agentDir, ".session-model"))).toBe(true);
   });
 
-  it("override + corrupt intent → treated as no intent, reverts", () => {
+  it("override + corrupt intent → treated as no intent, KEEPS; intent consumed", () => {
     writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8"));
     writeFileSync(join(agentDir, ".relaunch-model-intent"), "not json at all\n");
-    expect(runBlock("1")).toBe(DEFAULT_MODEL);
-    expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
+    expect(runBlock("1")).toBe("claude-opus-4-8");
+    expect(existsSync(join(agentDir, ".session-model"))).toBe(true);
     expect(existsSync(join(agentDir, ".relaunch-model-intent"))).toBe(false);
   });
 
@@ -267,12 +266,57 @@ describe("scaffoldAgent: session-model stickiness boot resolver (start.sh)", () 
     expect(alert).toContain("override to `claude-opus-4-8` was cleared");
   });
 
-  it("keep + override older than 7 days → EXPIRES + announces", () => {
+  it("override older than 7 days → NO expiry (#3039: only explicit user action clears it)", () => {
     writeFileSync(join(agentDir, ".session-model"), sessionModelJson("claude-opus-4-8", DEFAULT_MODEL, Date.now() - 8 * 24 * 3600_000));
-    writeFileSync(join(agentDir, ".relaunch-model-intent"), intentJson("keep"));
+    expect(runBlock("1")).toBe("claude-opus-4-8");
+    expect(existsSync(join(agentDir, ".session-model"))).toBe(true);
+  });
+
+  it("corrupt .session-model → falls back to default AND notifies (never a silent drop)", () => {
+    writeFileSync(join(agentDir, ".session-model"), "{broken\n");
     expect(runBlock("1")).toBe(DEFAULT_MODEL);
     expect(existsSync(join(agentDir, ".session-model"))).toBe(false);
-    expect(alertText()).toContain("expired");
+    const alert = alertText();
+    expect(alert).toContain("could not be read");
+    expect(alert).toContain("configured default");
+  });
+
+  // ── session-effort resolver (#3039) ───────────────────────────────────────
+  function effortJson(level: string, cfg = "low", ts = Date.now()): string {
+    return `${JSON.stringify({ level, configuredDefaultAtWrite: cfg, ts })}\n`;
+  }
+  function runBlockEffort(): { model: string; effortArg: string } {
+    const script = `set -e\n_LITELLM_OK=1\n${block}\necho "EFFECTIVE=$_EFFECTIVE_MODEL"\necho "EFFORTARG=$_EFFORT_ARG"`;
+    const out = execFileSync("bash", ["-c", script], { encoding: "utf-8" });
+    return {
+      model: out.match(/EFFECTIVE=(.*)/)?.[1].trim() ?? "",
+      effortArg: out.match(/EFFORTARG=(.*)/)?.[1].trim() ?? "",
+    };
+  }
+
+  it("no .session-effort → --effort uses the configured default", () => {
+    expect(runBlockEffort().effortArg).toBe("--effort low");
+  });
+
+  it(".session-effort override survives the boot and is applied to --effort", () => {
+    writeFileSync(join(agentDir, ".session-effort"), effortJson("xhigh"));
+    expect(runBlockEffort().effortArg).toBe("--effort xhigh");
+    expect(existsSync(join(agentDir, ".session-effort"))).toBe(true);
+  });
+
+  it("corrupt/non-allowlisted .session-effort → falls back to configured default AND notifies", () => {
+    writeFileSync(join(agentDir, ".session-effort"), effortJson("mega; rm -rf /".replace(/;.*/, "mega")));
+    writeFileSync(join(agentDir, ".session-effort"), `${JSON.stringify({ level: "mega", configuredDefaultAtWrite: "low", ts: Date.now() })}\n`);
+    expect(runBlockEffort().effortArg).toBe("--effort low");
+    expect(existsSync(join(agentDir, ".session-effort"))).toBe(false);
+    expect(alertText()).toContain("effort override could not be read");
+  });
+
+  it("configured thinking_effort changed since the effort switch → cleared + notifies", () => {
+    writeFileSync(join(agentDir, ".session-effort"), effortJson("xhigh", "medium"));
+    expect(runBlockEffort().effortArg).toBe("--effort low");
+    expect(existsSync(join(agentDir, ".session-effort"))).toBe(false);
+    expect(alertText()).toContain("configured default effort changed");
   });
 
   // ── sr-* + LiteLLM guard (row 18) ─────────────────────────────────────────

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -261,7 +261,10 @@ describe("scaffoldAgent", () => {
     const config = makeAgentConfig({ thinking_effort: "xhigh" });
     const result = scaffoldAgent("effort-agent", config, tmpDir, telegramConfig);
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
-    expect(startSh).toContain("--effort xhigh");
+    // #3039: the configured default seeds $_EFFECTIVE_EFFORT; a durable
+    // .session-effort override may replace it at boot.
+    expect(startSh).toContain("_EFFECTIVE_EFFORT='xhigh'");
+    expect(startSh).toContain('--effort $_EFFECTIVE_EFFORT');
   });
 
   it("start.sh defaults --effort to 'low' when thinking_effort is not set in yaml", () => {
@@ -272,15 +275,15 @@ describe("scaffoldAgent", () => {
     const config = makeAgentConfig();
     const result = scaffoldAgent("no-effort-agent", config, tmpDir, telegramConfig);
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
-    expect(startSh).toContain("--effort low");
+    expect(startSh).toContain("_EFFECTIVE_EFFORT='low'");
   });
 
   it("start.sh respects an explicit thinking_effort override", () => {
     const config = makeAgentConfig({ thinking_effort: "high" });
     const result = scaffoldAgent("explicit-effort", config, tmpDir, telegramConfig);
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
-    expect(startSh).toContain("--effort high");
-    expect(startSh).not.toContain("--effort low");
+    expect(startSh).toContain("_EFFECTIVE_EFFORT='high'");
+    expect(startSh).not.toContain("_EFFECTIVE_EFFORT='low'");
   });
 
   it("start.sh defaults --model to claude-sonnet-5 when model is not set in yaml", () => {
@@ -343,7 +346,7 @@ describe("scaffoldAgent", () => {
     scaffoldAgent("effort-reconcile", config, tmpDir, telegramConfig, switchroomConfig);
     reconcileAgent("effort-reconcile", config, tmpDir, telegramConfig, switchroomConfig);
     const startSh = readFileSync(join(tmpDir, "effort-reconcile", "start.sh"), "utf-8");
-    expect(startSh).toContain("--effort medium");
+    expect(startSh).toContain("_EFFECTIVE_EFFORT='medium'");
   });
 
   it("reconcile re-renders start.sh with permission_mode flag", () => {


### PR DESCRIPTION
Closes #3039.

## Contract (operator requirement, 2026-07-11)

For any Telegram command that mutates the running claude session (`/model`, `/effort`): apply immediately and confirm when possible; otherwise ack immediately, deterministically apply when the agent frees up, and confirm when done. A user-set model/effort override survives restarts and deploys and is cleared only by explicit user action (`/model default`, new `/effort default`) or invalidation — which falls back to the configured default and notifies the chat once. No path says "try again in a moment" or silently keeps the old value.

## What changed

**Boot policy flip** (`profiles/_base/start.sh.hbs`, `session-model-file.ts`)
- `.session-model` is honored on every boot (deploy, `/restart`, watchdog, raw `docker restart`, host reboot, crash). Boot default was REVERT-without-intent; it is now KEEP. Only a fresh explicit `revert` intent reverts (nothing stamps it anymore; `intentForRestartReason` is keep-for-everything and `/restart` stamps keep).
- 7-day expiry removed. Corrupt carrier now writes a `.session-model-alert` chat notice (was a silent stderr drop). Configured `model:` change still invalidates + notifies (the invalid/retired-model fallback path).

**`/effort` persistence** (new `.session-effort` carrier)
- Same JSON shape/lifecycle as `.session-model`, allowlist-gated (`low|medium|high|xhigh|max`). Written on every positively-confirmed effort apply via one choke point in `buildEffortDeps.applyEffort`; start.sh resolves it into `--effort` on every boot (`_EFFECTIVE_EFFORT` / `$_EFFORT_ARG` replaces the baked `--effort {{thinkingEffort}}`); invalidation (corrupt / `thinking_effort:` changed) falls back + appends to the boot alert. New `/effort default` clears it (queued like any set when mid-turn). `/effort` show + menu surface the active override.

**Queued choices survive the bounce** (`pending-session-command.ts`, gateway shutdown + drain)
- `shutdownResolutionActions` / `resolveForRestart` replace the "re-issue once the agent is back" edits: typed `/model X`, `/model default`, `/effort X`, `/effort default`, and menu effort taps are persisted to the durable carriers ("saved — applies as the agent boots"). Only an unresolvable `mdl:s:<tag>` menu selection (needs live picker discovery) still asks for a re-issue.

**No dead-ends left**
- Drain race guard: `drainPendingSessionCommand` re-checks turn-in-flight per command and detects handler busy-refusals (`isBusyRefusalText`), re-enqueueing (with last-write-wins supersede handling) instead of stamping the refusal onto the ack card as a false final state.
- Mid-turn `/model` now renders a static alias/external keyboard whose taps ride the existing queue, instead of refusing with "Try again in a moment".

**Docs**: `reference/rfcs/session-model-stickiness.md` gains the rev-3 (#3039) amendment section.

## Review fixes (commit 2b48ebba)

- **Blocker 1** — drain iteration extracted to `drainTakenCommands` (unit-tested): an early stop re-enqueues every not-yet-applied taken command; a two-command batch (model + effort) can no longer lose the second slot.
- **Blocker 2a/2b** — unconfirmed queued model tokens are gated by `isOfflineTrustedModelToken` before durable persist (unknowns get "couldn't verify — re-issue"); start.sh self-heals a crashlooping override (3 fast boots <150s → clear carrier, boot default, alert once), which also covers confirmed-then-retired models.
- **Item 3 (version skew)** — `.session-effort` boot resolution and the crashloop self-heal live in the RE-SCAFFOLDED `start.sh`: until `switchroom apply` re-renders agent scaffolds, "applies at boot" holds only for the model path on switchroom-managed bounces. Noted in the RFC rev-3 amendment.
- **Item 4** — "override kept" boot alert deduped per kept value (`.session-model-kept-notified`); watchdog loops can't storm the chat.
- **Item 5** — `getConfiguredEffortForPersist` falls back to `SWITCHROOM_DEFAULT_THINKING_EFFORT` instead of persisting `''`.
- **Item 7** — RFC notes the quota-failover interaction: a pinned expensive model now survives exhaustion restarts until `/model default`.

Rebased onto latest `origin/main` (`19565eea`).

## Consistency audit

`/model` + `/effort` are the session-mutating command set; both now ride the same enqueue/drain/persist machinery on all four surfaces (typed + menu × model + effort). `/compact` already has its own proactive idle queue; `/restart`, `/new`, `/reset` ride `pendingRestarts`; no other gateway command dead-ends on busy.

## Tests

- `tests/scaffold.session-model.test.ts` — sh-harness pins for keep-on-crash/deploy, stale/corrupt-intent keep, explicit-revert, no 7-day expiry, corrupt-carrier fallback + notify, and the new `.session-effort` resolver (survives boot, invalid → fallback + notify, config-change invalidation).
- `telegram-plugin/tests/pending-session-command.test.ts` — shutdown persist actions per kind/origin incl. `clear-model`/`clear-effort` and the menu-tag re-issue fallback.
- `telegram-plugin/tests/gateway-pending-command-wiring.test.ts` — structural pins: shutdown persists, drain re-enqueues on busy-refusal, `/restart` stamps keep, effort persistence choke point.
- `telegram-plugin/tests/effort-command.test.ts` — `/effort default` parse/apply-then-clear ordering/failure honesty, override surfacing.
- `telegram-plugin/tests/model-command.test.ts` — busy static menu (no discovery, queueable taps, no "Try again"), `isBusyRefusalText`.
- `telegram-plugin/tests/session-model-file.test.ts` — `.session-effort` helpers round-trip/reject, keep-for-everything intent classifier.

Local results: scoped vitest suites for all touched areas green (247/247 + 39/39 rebuild-dependent); `npm run test:bun` 1152 pass / 0 fail; `npm run lint` clean. Full `npm run test:vitest`: failing set is byte-identical to unmodified `origin/main` in this environment (pre-existing env-dependent suites); CI is the full-suite authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
