### PR TITLE
fix(mcp): get_status accepts request_id, RPCs hostd per-request status

### DIFF
--- a/src/mcp/hostd/server.test.ts
+++ b/src/mcp/hostd/server.test.ts
@@ -469,6 +469,74 @@ describe("dispatchTool — failure modes", () => {
     }
   });
 
+  // ── #2560 — get_status per-request wire lookup ─────────────────────────
+  it("get_status with request_id RPCs hostd's wire get_status (rollout visibility)", async () => {
+    const wireResp = ok({
+      result: "started",
+      request_id: "mcp-get-status-abc",
+      payload: JSON.stringify({
+        rolled: ["test-harness"],
+        phase: "agents-start",
+        n: 2,
+        m: 5,
+        agent: "clerk",
+        pin: "v0.18.10",
+      }),
+    });
+    hostdRequestMock.mockResolvedValueOnce(wireResp);
+    const res = await dispatchTool("get_status", {
+      request_id: "mcp-rollout-1750000000000-deadbeef",
+    });
+    expect(res.isError).toBeFalsy();
+    const sent = hostdRequestMock.mock.calls[0]![1];
+    expect(sent.op).toBe("get_status");
+    expect(sent.args).toEqual({
+      target_request_id: "mcp-rollout-1750000000000-deadbeef",
+    });
+    expect(sent.request_id).toMatch(/^mcp-get-status-/);
+    // The rich per-request payload is surfaced verbatim — phase/n/m intact.
+    const parsed = JSON.parse(res.content[0]!.text);
+    const payload = JSON.parse(parsed.payload);
+    expect(payload.phase).toBe("agents-start");
+    expect(payload.n).toBe(2);
+    expect(payload.m).toBe(5);
+    expect(payload.rolled).toEqual(["test-harness"]);
+  });
+
+  it("get_status with request_id surfaces a hostd denied response as isError", async () => {
+    const denied: HostdResponse = {
+      v: 1,
+      request_id: "x",
+      result: "denied",
+      exit_code: null,
+      duration_ms: 0,
+      error: 'get_status: request_id not found or not visible to caller "klanker"',
+    };
+    hostdRequestMock.mockResolvedValueOnce(denied);
+    const res = await dispatchTool("get_status", { request_id: "nope-123" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain("not found or not visible");
+  });
+
+  it("get_status with request_id requires the socket (no audit-log fallback)", async () => {
+    existsSyncMock.mockReturnValueOnce(false);
+    const res = await dispatchTool("get_status", { request_id: "r-1" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toMatch(/socket not bound/);
+    expect(hostdRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("get_status inputSchema declares the optional request_id", () => {
+    const tool = TOOLS.find((t) => t.name === "get_status")!;
+    const schema = tool.inputSchema as unknown as {
+      required?: string[];
+      properties: Record<string, unknown>;
+    };
+    expect(schema.properties).toHaveProperty("request_id");
+    // Optional — the no-arg audit-log form stays backward compatible.
+    expect(schema.required ?? []).not.toContain("request_id");
+  });
+
   it("unknown tool name returns an error without wire-calling", async () => {
     const res = await dispatchTool("nope", {});
     expect(res.isError).toBe(true);

--- a/src/mcp/hostd/server.ts
+++ b/src/mcp/hostd/server.ts
@@ -541,7 +541,7 @@ export async function dispatchTool(
   // other verb — that path returns the rich per-request status
   // (rollout phase / n / m / rolled[] etc., #2560) which the audit-log
   // shortcut cannot see.
-  if (name === "get_status" && !args.request_id) {
+  if (name === "get_status" && args.request_id === undefined) {
     return getLastUpdateApplyStatus();
   }
 

--- a/src/mcp/hostd/server.ts
+++ b/src/mcp/hostd/server.ts
@@ -93,6 +93,8 @@ interface ToolArgs {
   // config_propose_edit args
   unified_diff?: string;
   target_path?: string;
+  // get_status per-request lookup (#2560)
+  request_id?: string;
 }
 
 /** Semver-only pin matcher for the rollout verb (#2487). Rejects `sha-…`
@@ -354,7 +356,8 @@ export const TOOLS = [
       "container restarts on the target image (~30-60s blip on this MCP " +
       "socket), then the roll resumes AUTOMATICALLY under the SAME " +
       "request_id — do NOT re-issue the rollout during the blip; poll " +
-      "get_status with the returned request_id once the socket is back. " +
+      "get_status (pass the returned request_id as its `request_id` " +
+      "argument) once the socket is back. " +
       "The web refresh stays DEFERRED on this path; the terminal warnings " +
       "name exactly what is still on the prior version (web, host operator " +
       "CLI) and the host-side commands to finish. By default downgrade pins " +
@@ -366,8 +369,8 @@ export const TOOLS = [
       "ALWAYS pass a one-line `reason` explaining why you're rolling the " +
       "fleet to this pin; it renders on the card's `why:` line so the " +
       "operator can decide in context. " +
-      "Returns `started`; poll get_status for the structured outcome " +
-      "(which agents rolled / where it stopped).",
+      "Returns `started`; poll get_status with `request_id` for the " +
+      "structured outcome (which agents rolled / where it stopped).",
     inputSchema: {
       type: "object" as const,
       required: ["pin"],
@@ -482,15 +485,36 @@ export const TOOLS = [
   {
     name: "get_status",
     description:
-      "Read the most recent terminal `update_apply` audit row " +
+      "Look up the status of a prior async fleet mutation. With " +
+      "`request_id` (the id echoed by rollout / update_apply / " +
+      "agent_restart etc.), asks the host-control daemon for that " +
+      "specific request's live status — for an in-flight `rollout` " +
+      "this is the ONLY way to see progress: the response payload " +
+      "carries the current phase, n/m counters, rolled[] agents, " +
+      "failedStep/failedAgent and pin, and it keeps working across a " +
+      "hostd self-bump/restart via the durable audit-log fallback. " +
+      "This is the tool the `rollout` description tells you to poll " +
+      "with the returned request_id. Without `request_id`, falls back " +
+      "to reading the most recent terminal `update_apply` audit row " +
       "(channel, pin, resolved_sha, install_context, result, " +
-      "exit_code, stderr_tail). Use this after issuing an " +
-      "`update_apply` to confirm what actually rolled out, or to " +
-      "report the last update on demand. Returns the parsed audit " +
-      "entry as JSON.",
+      "exit_code, stderr_tail) — use that no-arg form only to report " +
+      "the last blunt update on demand; it CANNOT see rollouts or " +
+      "in-flight work. Read-only; returns JSON.",
     inputSchema: {
       type: "object" as const,
-      properties: {},
+      properties: {
+        request_id: {
+          type: "string",
+          minLength: 1,
+          maxLength: 128,
+          description:
+            "The request_id returned by a prior mutating verb " +
+            "(e.g. `mcp-rollout-…`). When set, the daemon returns " +
+            "that request's rich per-request status (phase, n/m, " +
+            "rolled agents, outcome). Omit to read the last " +
+            "terminal update_apply audit row instead.",
+        },
+      },
       additionalProperties: false,
     },
   },
@@ -510,10 +534,14 @@ export async function dispatchTool(
   content: { type: "text"; text: string }[];
   isError?: boolean;
 }> {
-  // `get_status` reads the audit log directly — no hostd RPC, so it
-  // doesn't need SWITCHROOM_AGENT_NAME or the socket. Handle it
-  // before the wire-checks below.
-  if (name === "get_status") {
+  // No-arg `get_status` reads the audit log directly — no hostd RPC,
+  // so it doesn't need SWITCHROOM_AGENT_NAME or the socket. Handle it
+  // before the wire-checks below. WITH a `request_id` it falls through
+  // to the switch and RPCs hostd's wire-level get_status like every
+  // other verb — that path returns the rich per-request status
+  // (rollout phase / n / m / rolled[] etc., #2560) which the audit-log
+  // shortcut cannot see.
+  if (name === "get_status" && !args.request_id) {
     return getLastUpdateApplyStatus();
   }
 
@@ -682,6 +710,20 @@ export async function dispatchTool(
       };
       break;
     }
+    case "get_status": {
+      // Reached only when args.request_id is set (the no-arg form
+      // short-circuits to the audit-log read above).
+      if (typeof args.request_id !== "string" || !args.request_id) {
+        return errorText("get_status: request_id must be a non-empty string");
+      }
+      req = {
+        v: 1,
+        op: "get_status",
+        request_id: makeRequestId("mcp-get-status"),
+        args: { target_request_id: args.request_id },
+      };
+      break;
+    }
     case "config_propose_edit": {
       // Argument shape validated here before hitting the wire so the
       // disabled-path response is clearly the daemon's, not a
@@ -783,7 +825,8 @@ export function resolveAuditLogPath(): string {
 }
 
 /**
- * Dispatch handler for the `get_status` MCP tool. Reads the audit log
+ * Dispatch handler for the NO-ARG form of the `get_status` MCP tool
+ * (the `request_id` form RPCs hostd instead). Reads the audit log
  * and returns the most recent terminal `update_apply` row as JSON. No
  * hostd RPC needed — the audit log is the durable record.
  *


### PR DESCRIPTION
## Summary
The MCP `get_status` tool (src/mcp/hostd/server.ts) took no arguments and only read the most recent terminal `update_apply` audit row — it was completely blind to rollouts and any in-flight request. Meanwhile the `rollout` tool description explicitly instructed callers to "poll get_status with the returned request_id" — a contradiction: that poll was impossible via MCP. hostd's wire-level `get_status` (src/host-control/server.ts `handleGetStatus`) already supports per-request lookup, including live StatusEntry phase/n/m and the #2726 durable-log fallback for rollouts across a hostd self-bump restart. (Previously filed as #2560; closed but the MCP tool stayed blind.)

## What changed
- `get_status` inputSchema gains an optional `request_id`. When set, the MCP shim builds a wire `get_status` request (`args.target_request_id`) and dispatches it over the agent socket like every other verb, surfacing the rich per-request status (phase, n/m, rolled[], failedStep/failedAgent, pin) and the daemon's denied/error envelopes.
- Without `request_id`, behavior is unchanged (backward compatible): read the last terminal `update_apply` audit row. The wire path has no "latest" lookup (it requires a target_request_id), so the audit read remains the only no-arg option.
- `get_status` and `rollout` tool descriptions rewritten to be consistent: rollout now says to pass the returned request_id as get_status's `request_id` argument; get_status explains both forms and that the no-arg form cannot see rollouts.

## Test plan
- New vitest cases in src/mcp/hostd/server.test.ts: wire dispatch with `target_request_id` + rich payload passthrough, denied surfacing, socket-required guard, schema declares optional `request_id`.
- Scoped run: `vitest run src/mcp/hostd/server.test.ts tests/host-control/hostd-dispatch.test.ts` — 68 passed.
- `npm run lint` — clean (tsc + all 8 guards, incl. check-stale-tool-descriptions).

## Risk
Low. No-arg path byte-identical; new path reuses the existing wire dispatch, gate (admin-or-own-call, wire-side), and 10s read timeout. get_status is read-only and not approval-gated.

Job spec: `reference/jobs/idempotent-update-and-restart.md` — an operator/agent must be able to confirm what actually rolled out; a rollout that cannot be polled from the MCP surface breaks that trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)