### PR TITLE
feat(hostd): rich checklist rollout narration with per-agent progress

### DIFF
--- a/src/host-control/render-rollout-status.ts
+++ b/src/host-control/render-rollout-status.ts
@@ -10,12 +10,37 @@
  * These functions are pure (input → string) so both the terminal push (Part 1)
  * and the log-tailed narration surface (Part 2) render identically and can be
  * unit-tested without a gateway.
+ *
+ * The render is a MULTI-LINE progress-card-style checklist (GFM: `-` lists,
+ * bold, code spans — matching the telegram-plugin progress-card vocabulary):
+ * a header (version → version, short request id, phase), one checklist line
+ * per known agent (✓ done / ⏳ in progress / · pending / ✗ failed, with
+ * durations), a rough ETA once at least one agent finished, and a terminal
+ * summary incl. elapsed total and the deferred host-side components.
  */
+
+/** Per-agent progress an accumulator (the narrator) feeds the renderer. */
+export type AgentRollStatus = "pending" | "running" | "done" | "failed";
+
+export interface AgentRollProgress {
+  name: string;
+  status: AgentRollStatus;
+  /** True for the canary agent (rolled first, gates the rest). */
+  canary?: boolean;
+  /** Restart wall-time once the agent finished (done/failed). */
+  durationMs?: number;
+  /** ms-since-epoch the agent's restart began (accumulator bookkeeping). */
+  startedAtMs?: number;
+}
 
 /** The rollout progress state a renderer needs — a projection of the latest
  *  durable rollout row / status payload. */
 export interface RolloutRenderState {
   target: string;
+  /** Version that was running before this roll (prior pin), when known. */
+  fromVersion?: string;
+  /** hostd request_id — rendered shortened so the operator can `get_status` it. */
+  requestId?: string;
   /** Current phase name from the latest phase row, or "terminal". */
   phase?: string;
   /** Agents confirmed on the target, in order. */
@@ -26,6 +51,16 @@ export interface RolloutRenderState {
   m?: number;
   /** Agent named in the current phase. */
   agent?: string;
+  /** Per-agent checklist state, in roll order (accumulated by the narrator). */
+  agents?: AgentRollProgress[];
+  /** ms since epoch the roll started (for the elapsed line). */
+  startedAtMs?: number;
+  /** ms since epoch "now" at render time (clock seam — keeps the fn pure). */
+  nowMs?: number;
+  /** Total elapsed ms (terminal rows, where finished_at is known). */
+  elapsedMs?: number;
+  /** True once the hostd/web refresh was deferred to a host-side run. */
+  deferred?: boolean;
   /** Terminal outcome — set only once the roll finished. */
   terminal?: "completed" | "error";
   /** Step that stopped a failed roll. */
@@ -64,27 +99,136 @@ function phaseLine(s: RolloutRenderState): string {
   }
 }
 
+/** Compact human duration: 42s / 3m 10s / 1h 5m. */
+export function formatDurationMs(ms: number): string {
+  const totalSec = Math.max(0, Math.round(ms / 1000));
+  if (totalSec < 60) return `${totalSec}s`;
+  const totalMin = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (totalMin < 60) return sec > 0 ? `${totalMin}m ${sec}s` : `${totalMin}m`;
+  const hr = Math.floor(totalMin / 60);
+  const min = totalMin % 60;
+  return min > 0 ? `${hr}h ${min}m` : `${hr}h`;
+}
+
+/** Shorten a hostd request_id for the header (still get_status-able by prefix
+ *  recall — the full id lives in the durable audit row). */
+function shortRequestId(id: string): string {
+  return id.length > 16 ? id.slice(0, 16) + "…" : id;
+}
+
+/** Header line: icon + version → version + short request id. */
+function headerLine(s: RolloutRenderState, icon: string): string {
+  const arrow = s.fromVersion
+    ? `\`${s.fromVersion}\` → \`${s.target}\``
+    : `→ \`${s.target}\``;
+  const req = s.requestId ? ` · req \`${shortRequestId(s.requestId)}\`` : "";
+  return `${icon} **Rollout** ${arrow}${req}`;
+}
+
+/** One `- <glyph> agent` checklist line per known agent, in roll order. */
+function checklistLines(s: RolloutRenderState): string[] {
+  const agents = s.agents ?? [];
+  const lines: string[] = [];
+  for (const a of agents) {
+    const canary = a.canary ? " (canary)" : "";
+    const dur = a.durationMs !== undefined ? ` — ${formatDurationMs(a.durationMs)}` : "";
+    switch (a.status) {
+      case "done":
+        lines.push(`- ✓ \`${a.name}\`${canary}${dur}`);
+        break;
+      case "running":
+        lines.push(`- ⏳ \`${a.name}\`${canary} — restarting…`);
+        break;
+      case "failed":
+        lines.push(`- ✗ \`${a.name}\`${canary} — failed${dur}`);
+        break;
+      default:
+        lines.push(`- · \`${a.name}\`${canary}`);
+    }
+  }
+  // Agents we haven't seen a phase for yet (names unknown until their
+  // agent-start row): collapse into one pending line.
+  const remaining = s.m !== undefined ? s.m - agents.length : 0;
+  if (remaining > 0 && agents.length > 0) {
+    lines.push(`- · ${remaining} more pending`);
+  }
+  return lines;
+}
+
+/** Rough ETA from the mean per-agent duration so far. */
+function etaLine(s: RolloutRenderState): string | null {
+  if (s.m === undefined) return null;
+  const done = (s.agents ?? []).filter(
+    (a) => a.status === "done" && a.durationMs !== undefined,
+  );
+  if (done.length === 0) return null;
+  const remaining = s.m - done.length;
+  if (remaining <= 0) return null;
+  const meanMs = done.reduce((t, a) => t + (a.durationMs ?? 0), 0) / done.length;
+  return `~${formatDurationMs(meanMs * remaining)} left (rough est.)`;
+}
+
+/** What stays on the prior version after an agent-invoked (hostd) roll, and
+ *  the host-side commands that update each. */
+function deferredLines(target: string): string[] {
+  const bare = target.trim().replace(/^v/, "");
+  return [
+    `**Deferred (still on the prior version — run host-side):**`,
+    `- \`switchroom-web\` — \`switchroom webd install --tag ${target}\``,
+    `- host operator CLI — \`sudo npm i -g switchroom@${bare}\``,
+    `- hostd template regen (only if the release changed hostd mounts/env) — \`switchroom hostd install --tag ${target}\``,
+  ];
+}
+
 /**
  * Render the full status message body. When `terminal` is set, renders the
- * final ✅/❌ line; otherwise the in-flight progress line. Always leads with the
- * target so the message is self-describing when scrolled back to.
+ * final ✅/❌ summary; otherwise the in-flight progress checklist. Always leads
+ * with the target so the message is self-describing when scrolled back to.
  */
 export function renderRolloutStatus(s: RolloutRenderState): string {
-  const head = `Rollout → ${s.target}`;
-  const rolledCount = s.rolled?.length ?? 0;
+  const rolled = s.rolled ?? [];
+  const rolledCount = rolled.length;
+  const checklist = checklistLines(s);
+  const elapsedMs =
+    s.elapsedMs ??
+    (s.startedAtMs !== undefined && s.nowMs !== undefined
+      ? s.nowMs - s.startedAtMs
+      : undefined);
+
   if (s.terminal === "completed") {
-    return `✅ ${head} — done. Rolled ${rolledCount} agent(s): ${(s.rolled ?? []).join(", ") || "none"}.`;
+    const parts = [headerLine(s, "✅")];
+    let summary = `**Done** — rolled ${rolledCount}${s.m !== undefined ? `/${s.m}` : ""} agent(s)`;
+    if (elapsedMs !== undefined) summary += ` in ${formatDurationMs(elapsedMs)}`;
+    summary += `: ${rolled.join(", ") || "none"}.`;
+    parts.push(summary);
+    if (checklist.length > 0) parts.push("", ...checklist);
+    if (s.deferred !== false) parts.push("", ...deferredLines(s.target));
+    return parts.join("\n");
   }
+
   if (s.terminal === "error") {
     const where = s.failedStep
-      ? ` at ${s.failedStep}${s.failedAgent ? ` (${s.failedAgent} → ${s.got ?? "unreachable"})` : ""}`
+      ? ` at \`${s.failedStep}\`${s.failedAgent ? ` (\`${s.failedAgent}\` → ${s.got ?? "unreachable"})` : ""}`
       : "";
-    return (
-      `❌ ${head} — STOPPED${where}. ` +
-      `Rolled before stop: ${(s.rolled ?? []).join(", ") || "none"}.`
-    );
+    const parts = [headerLine(s, "❌")];
+    let summary = `**STOPPED**${where}`;
+    if (elapsedMs !== undefined) summary += ` after ${formatDurationMs(elapsedMs)}`;
+    summary += `. Rolled before stop: ${rolled.join(", ") || "none"}.`;
+    parts.push(summary);
+    if (checklist.length > 0) parts.push("", ...checklist);
+    return parts.join("\n");
   }
+
   // In-flight.
-  const progress = rolledCount > 0 ? ` · ${rolledCount} rolled` : "";
-  return `⏳ ${head} — ${phaseLine(s)}${progress}`;
+  const parts = [headerLine(s, "⏳"), `**Phase:** ${phaseLine(s)}`];
+  if (checklist.length > 0) parts.push("", ...checklist);
+  const footer: string[] = [];
+  if (s.m !== undefined) footer.push(`${rolledCount}/${s.m} rolled`);
+  else if (rolledCount > 0) footer.push(`${rolledCount} rolled`);
+  if (elapsedMs !== undefined) footer.push(`elapsed ${formatDurationMs(elapsedMs)}`);
+  const eta = etaLine(s);
+  if (eta) footer.push(eta);
+  if (footer.length > 0) parts.push("", footer.join(" · "));
+  return parts.join("\n");
 }

--- a/src/host-control/render-rollout-status.ts
+++ b/src/host-control/render-rollout-status.ts
@@ -77,15 +77,15 @@ function phaseLine(s: RolloutRenderState): string {
     case "apply":
       return "applying — regenerating compose";
     case "canary-start":
-      return `canary — restarting ${s.agent ?? "canary agent"}`;
+      return `canary — restarting ${s.agent ? `\`${s.agent}\`` : "canary agent"}`;
     case "canary-pass":
-      return `canary passed (${s.agent ?? "canary"}) — rolling the rest`;
+      return `canary passed (${s.agent ? `\`${s.agent}\`` : "canary"}) — rolling the rest`;
     case "canary-fail":
-      return `canary failed (${s.agent ?? "canary"})`;
+      return `canary failed (${s.agent ? `\`${s.agent}\`` : "canary"})`;
     case "agent-start":
-      return `agent ${s.n ?? "?"}/${s.m ?? "?"} — restarting ${s.agent ?? ""}`.trim();
+      return `agent ${s.n ?? "?"}/${s.m ?? "?"} — restarting ${s.agent ? `\`${s.agent}\`` : ""}`.trim();
     case "agent-done":
-      return `agent ${s.n ?? "?"}/${s.m ?? "?"} — ${s.agent ?? ""} done`.trim();
+      return `agent ${s.n ?? "?"}/${s.m ?? "?"} — ${s.agent ? `\`${s.agent}\`` : ""} done`.trim();
     case "persist-pin":
       return "persisting pin";
     case "hostd-web-deferred":
@@ -126,16 +126,26 @@ function headerLine(s: RolloutRenderState, icon: string): string {
   return `${icon} **Rollout** ${arrow}${req}`;
 }
 
-/** One `- <glyph> agent` checklist line per known agent, in roll order. */
-function checklistLines(s: RolloutRenderState): string[] {
+/**
+ * One `- <glyph> agent` checklist line per known agent, in roll order.
+ *
+ * `compact` is the message-size fallback (see MAX_RENDER_CHARS): completed
+ * and pending agents fold into single count lines so a large fleet can never
+ * push the render past Telegram's edit limit (an oversized edit would be
+ * swallowed by the gateway and silently freeze the narration).
+ */
+function checklistLines(s: RolloutRenderState, compact: boolean): string[] {
   const agents = s.agents ?? [];
   const lines: string[] = [];
+  let doneCount = 0;
+  let pendingNamed = 0;
   for (const a of agents) {
     const canary = a.canary ? " (canary)" : "";
     const dur = a.durationMs !== undefined ? ` — ${formatDurationMs(a.durationMs)}` : "";
     switch (a.status) {
       case "done":
-        lines.push(`- ✓ \`${a.name}\`${canary}${dur}`);
+        if (compact) doneCount += 1;
+        else lines.push(`- ✓ \`${a.name}\`${canary}${dur}`);
         break;
       case "running":
         lines.push(`- ⏳ \`${a.name}\`${canary} — restarting…`);
@@ -144,14 +154,17 @@ function checklistLines(s: RolloutRenderState): string[] {
         lines.push(`- ✗ \`${a.name}\`${canary} — failed${dur}`);
         break;
       default:
-        lines.push(`- · \`${a.name}\`${canary}`);
+        if (compact) pendingNamed += 1;
+        else lines.push(`- · \`${a.name}\`${canary}`);
     }
   }
+  if (doneCount > 0) lines.unshift(`- ✓ ${doneCount} done`);
   // Agents we haven't seen a phase for yet (names unknown until their
   // agent-start row): collapse into one pending line.
-  const remaining = s.m !== undefined ? s.m - agents.length : 0;
-  if (remaining > 0 && agents.length > 0) {
-    lines.push(`- · ${remaining} more pending`);
+  const unseen = s.m !== undefined ? Math.max(0, s.m - agents.length) : 0;
+  const pendingTotal = unseen + pendingNamed;
+  if (pendingTotal > 0 && agents.length > 0) {
+    lines.push(`- · ${pendingTotal} more pending`);
   }
   return lines;
 }
@@ -182,14 +195,26 @@ function deferredLines(target: string): string[] {
 }
 
 /**
- * Render the full status message body. When `terminal` is set, renders the
- * final ✅/❌ summary; otherwise the in-flight progress checklist. Always leads
- * with the target so the message is self-describing when scrolled back to.
+ * Defensive size ceiling for the rendered message. Telegram caps message text
+ * at 4096 chars, and the gateway's edit path deliberately swallows failures
+ * (incl. MESSAGE_TOO_LONG) — an oversized render would therefore freeze the
+ * narration silently. Past this threshold the render retries in compact mode
+ * (completed/pending agents fold into count lines, name lists become counts).
  */
-export function renderRolloutStatus(s: RolloutRenderState): string {
+const MAX_RENDER_CHARS = 3800;
+
+/** Code-span a rolled-agent name list, or a bare count in compact mode
+ *  (names may contain `_`, which italicizes in GFM outside a code span). */
+function rolledList(rolled: string[], compact: boolean): string {
+  if (rolled.length === 0) return "none";
+  if (compact) return `${rolled.length} agent(s)`;
+  return rolled.map((r) => `\`${r}\``).join(", ");
+}
+
+function renderWith(s: RolloutRenderState, compact: boolean): string {
   const rolled = s.rolled ?? [];
   const rolledCount = rolled.length;
-  const checklist = checklistLines(s);
+  const checklist = checklistLines(s, compact);
   const elapsedMs =
     s.elapsedMs ??
     (s.startedAtMs !== undefined && s.nowMs !== undefined
@@ -200,7 +225,7 @@ export function renderRolloutStatus(s: RolloutRenderState): string {
     const parts = [headerLine(s, "✅")];
     let summary = `**Done** — rolled ${rolledCount}${s.m !== undefined ? `/${s.m}` : ""} agent(s)`;
     if (elapsedMs !== undefined) summary += ` in ${formatDurationMs(elapsedMs)}`;
-    summary += `: ${rolled.join(", ") || "none"}.`;
+    summary += compact ? "." : `: ${rolledList(rolled, compact)}.`;
     parts.push(summary);
     if (checklist.length > 0) parts.push("", ...checklist);
     if (s.deferred !== false) parts.push("", ...deferredLines(s.target));
@@ -214,7 +239,7 @@ export function renderRolloutStatus(s: RolloutRenderState): string {
     const parts = [headerLine(s, "❌")];
     let summary = `**STOPPED**${where}`;
     if (elapsedMs !== undefined) summary += ` after ${formatDurationMs(elapsedMs)}`;
-    summary += `. Rolled before stop: ${rolled.join(", ") || "none"}.`;
+    summary += `. Rolled before stop: ${rolledList(rolled, compact)}.`;
     parts.push(summary);
     if (checklist.length > 0) parts.push("", ...checklist);
     return parts.join("\n");
@@ -231,4 +256,17 @@ export function renderRolloutStatus(s: RolloutRenderState): string {
   if (eta) footer.push(eta);
   if (footer.length > 0) parts.push("", footer.join(" · "));
   return parts.join("\n");
+}
+
+/**
+ * Render the full status message body. When `terminal` is set, renders the
+ * final ✅/❌ summary; otherwise the in-flight progress checklist. Always leads
+ * with the target so the message is self-describing when scrolled back to.
+ * Falls back to a compact render (folded checklist, counts instead of name
+ * lists) when the full render would exceed the message-size ceiling.
+ */
+export function renderRolloutStatus(s: RolloutRenderState): string {
+  const full = renderWith(s, /* compact */ false);
+  if (full.length <= MAX_RENDER_CHARS) return full;
+  return renderWith(s, /* compact */ true);
 }

--- a/src/host-control/rollout-narrator.test.ts
+++ b/src/host-control/rollout-narrator.test.ts
@@ -115,6 +115,80 @@ describe("LogTailRolloutNarrator", () => {
     expect(relay.edits[0]!.text).toContain("agent 2/3");
   });
 
+  it("accumulates a per-agent checklist with durations, ETA and the deferred section", async () => {
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });
+    const entry = makeEntry({ started_at: Date.now(), prior_pin: "v1.2.2" });
+
+    n.onPhase(entry, phase("apply"));
+    await vi.runAllTimersAsync();
+
+    // Canary takes 40s.
+    n.onPhase(entry, phase("canary-start", { agent: "test-harness", n: 1, m: 3 }));
+    await vi.advanceTimersByTimeAsync(40_000);
+    n.onPhase(entry, phase("canary-pass", { agent: "test-harness", n: 1, m: 3 }));
+    entry.rolled = ["test-harness"];
+    n.onPhase(entry, phase("agent-start", { agent: "clerk", n: 2, m: 3 }));
+    await vi.advanceTimersByTimeAsync(500);
+
+    const t = relay.edits.at(-1)!.text;
+    // Header: version → version + request id.
+    expect(t).toContain("`v1.2.2` → `v1.2.3`");
+    expect(t).toContain("req `ro-1`");
+    // Checklist: canary done with duration, clerk running, 1 collapsed pending.
+    expect(t).toContain("- ✓ `test-harness` (canary) — 40s");
+    expect(t).toContain("- ⏳ `clerk` — restarting…");
+    expect(t).toContain("- · 1 more pending");
+    // Footer: rolled count + ETA from the canary's duration (40s × 2 left).
+    expect(t).toContain("1/3 rolled");
+    expect(t).toContain("~1m 20s left (rough est.)");
+
+    // Deferral + terminal: the final edit lists what stays on the prior
+    // version and the host-side commands, plus the elapsed total.
+    n.onPhase(entry, phase("agent-done", { agent: "clerk", n: 2, m: 3 }));
+    n.onPhase(entry, phase("agent-start", { agent: "marko", n: 3, m: 3 }));
+    n.onPhase(entry, phase("agent-done", { agent: "marko", n: 3, m: 3 }));
+    n.onPhase(entry, phase("hostd-web-deferred"));
+    n.onTerminal(
+      makeEntry({
+        started_at: entry.started_at,
+        finished_at: entry.started_at + 300_000,
+        result: "completed",
+        rolled: ["test-harness", "clerk", "marko"],
+        prior_pin: "v1.2.2",
+      }),
+    );
+    await vi.runAllTimersAsync();
+    const final = relay.edits.at(-1)!.text;
+    expect(final).toContain("✅");
+    expect(final).toContain("rolled 3/3 agent(s) in 5m");
+    expect(final).toContain("- ✓ `clerk`");
+    expect(final).toContain("- ✓ `marko`");
+    expect(final).toContain("Deferred");
+    expect(final).toContain("switchroom webd install --tag v1.2.3");
+  });
+
+  it("marks the failed agent ✗ on a terminal error", async () => {
+    const relay = makeRelay(100);
+    const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });
+    const entry = makeEntry();
+    n.onPhase(entry, phase("canary-start", { agent: "test-harness", n: 1, m: 2 }));
+    await vi.runAllTimersAsync();
+    n.onTerminal(
+      makeEntry({
+        result: "error",
+        rolled: [],
+        failed_step: "restart-agent",
+        failed_agent: "test-harness",
+        got: null,
+      }),
+    );
+    await vi.runAllTimersAsync();
+    const t = relay.edits.at(-1)!.text;
+    expect(t).toContain("- ✗ `test-harness` (canary) — failed");
+    expect(t).toContain("unreachable");
+  });
+
   it("is monotonic: a stale (earlier) phase after a later one is dropped", async () => {
     const relay = makeRelay(100);
     const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });
@@ -149,7 +223,7 @@ describe("LogTailRolloutNarrator", () => {
     await vi.runAllTimersAsync();
     const finalEdit = relay.edits.at(-1)!;
     expect(finalEdit.text).toContain("✅");
-    expect(finalEdit.text).toContain("done");
+    expect(finalEdit.text).toContain("Done");
     const editCountAtFreeze = relay.edits.length;
 
     // A late phase arriving after terminal is IGNORED (frozen).

--- a/src/host-control/rollout-narrator.test.ts
+++ b/src/host-control/rollout-narrator.test.ts
@@ -115,7 +115,7 @@ describe("LogTailRolloutNarrator", () => {
     expect(relay.edits[0]!.text).toContain("agent 2/3");
   });
 
-  it("accumulates a per-agent checklist with durations, ETA and the deferred section", async () => {
+  it("accumulates a per-agent checklist with durations and ETA; terminal edit omits the Deferred block", async () => {
     const relay = makeRelay(100);
     const n = new LogTailRolloutNarrator(relay, { debounceMs: 500 });
     const entry = makeEntry({ started_at: Date.now(), prior_pin: "v1.2.2" });
@@ -143,8 +143,10 @@ describe("LogTailRolloutNarrator", () => {
     expect(t).toContain("1/3 rolled");
     expect(t).toContain("~1m 20s left (rough est.)");
 
-    // Deferral + terminal: the final edit lists what stays on the prior
-    // version and the host-side commands, plus the elapsed total.
+    // Terminal: the final edit shows the summary + elapsed total, but NOT the
+    // Deferred command block — the fresh terminal ping (pushRolloutTerminal)
+    // carries that, and rendering it on both would duplicate the 3-command
+    // list per successful roll.
     n.onPhase(entry, phase("agent-done", { agent: "clerk", n: 2, m: 3 }));
     n.onPhase(entry, phase("agent-start", { agent: "marko", n: 3, m: 3 }));
     n.onPhase(entry, phase("agent-done", { agent: "marko", n: 3, m: 3 }));
@@ -164,8 +166,8 @@ describe("LogTailRolloutNarrator", () => {
     expect(final).toContain("rolled 3/3 agent(s) in 5m");
     expect(final).toContain("- ✓ `clerk`");
     expect(final).toContain("- ✓ `marko`");
-    expect(final).toContain("Deferred");
-    expect(final).toContain("switchroom webd install --tag v1.2.3");
+    expect(final).not.toContain("Deferred");
+    expect(final).not.toContain("switchroom webd install");
   });
 
   it("marks the failed agent ✗ on a terminal error", async () => {

--- a/src/host-control/rollout-narrator.ts
+++ b/src/host-control/rollout-narrator.ts
@@ -46,6 +46,7 @@ import type { StatusEntry } from "./server.js";
 import type { RolloutPhase } from "../cli/rollout.js";
 import {
   renderRolloutStatus,
+  type AgentRollProgress,
   type RolloutRenderState,
 } from "./render-rollout-status.js";
 
@@ -120,6 +121,8 @@ interface NarrationState {
   postFailed: boolean;
   /** The latest render state (rebuilt as phases arrive). */
   render: RolloutRenderState;
+  /** Per-agent checklist progress, in roll order (fed into render.agents). */
+  agents: AgentRollProgress[];
   /** Frozen once the terminal row is applied — no later edit may un-finalize. */
   frozen: boolean;
   /** Pending debounce timer for a trailing-edge edit. */
@@ -138,8 +141,64 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
 
   constructor(
     private relay: RolloutNarrationRelay,
-    private opts: { debounceMs?: number; log?: (m: string) => void } = {},
+    private opts: {
+      debounceMs?: number;
+      log?: (m: string) => void;
+      /** Clock seam for tests; defaults to Date.now. */
+      now?: () => number;
+    } = {},
   ) {}
+
+  private now(): number {
+    return this.opts.now?.() ?? Date.now();
+  }
+
+  /** Upsert an agent's checklist entry (keyed by name, roll order preserved). */
+  private static upsertAgent(
+    st: NarrationState,
+    name: string,
+    patch: Partial<AgentRollProgress>,
+  ): void {
+    const existing = st.agents.find((a) => a.name === name);
+    if (existing) Object.assign(existing, patch);
+    else st.agents.push({ name, status: "pending", ...patch });
+  }
+
+  /** Fold a phase into the per-agent checklist (✓/⏳/·/✗ + durations). */
+  private trackAgentProgress(st: NarrationState, phase: RolloutPhase): void {
+    const now = this.now();
+    switch (phase.phase) {
+      case "canary-start":
+      case "agent-start":
+        if (phase.agent) {
+          LogTailRolloutNarrator.upsertAgent(st, phase.agent, {
+            status: "running",
+            startedAtMs: now,
+            ...(phase.phase === "canary-start" ? { canary: true } : {}),
+          });
+        }
+        break;
+      case "canary-pass":
+      case "agent-done":
+      case "canary-fail": {
+        if (!phase.agent) break;
+        const a = st.agents.find((x) => x.name === phase.agent);
+        const durationMs =
+          a?.startedAtMs !== undefined ? now - a.startedAtMs : undefined;
+        LogTailRolloutNarrator.upsertAgent(st, phase.agent, {
+          status: phase.phase === "canary-fail" ? "failed" : "done",
+          ...(durationMs !== undefined ? { durationMs } : {}),
+          ...(phase.phase !== "agent-done" ? { canary: true } : {}),
+        });
+        break;
+      }
+      case "hostd-web-deferred":
+        st.render.deferred = true;
+        break;
+      default:
+        break;
+    }
+  }
 
   /**
    * Monotonic sequence for a phase, so out-of-order / duplicate phases drop.
@@ -206,6 +265,9 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
       if (seq < st.lastAppliedSeq) return; // stale — drop.
       st.lastAppliedSeq = seq;
 
+      // Fold the phase into the per-agent checklist (✓/⏳/·/✗ + durations).
+      this.trackAgentProgress(st, phase);
+
       // Rebuild the render state from this phase (pull-shaped: each phase is a
       // projection of the latest durable row hostd just wrote).
       st.render = {
@@ -216,6 +278,10 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
         ...(phase.m !== undefined ? { m: phase.m } : {}),
         ...(phase.agent !== undefined ? { agent: phase.agent } : {}),
         rolled: entry.rolled,
+        agents: st.agents,
+        requestId: entry.request_id,
+        ...(entry.prior_pin ? { fromVersion: entry.prior_pin } : {}),
+        startedAtMs: entry.started_at,
       };
       this.scheduleRenderOrPost(entry.request_id);
     } catch (e) {
@@ -226,6 +292,19 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
   onTerminal(entry: StatusEntry): void {
     try {
       const st = this.ensureState(entry);
+      // Reconcile the checklist against the terminal row: the failed agent is
+      // marked ✗; any other agent still shown "running" (its -done row never
+      // arrived) is downgraded to pending unless the rolled[] list confirms it.
+      const rolled = new Set(entry.rolled ?? []);
+      for (const a of st.agents) {
+        if (entry.failed_agent && a.name === entry.failed_agent) {
+          a.status = "failed";
+        } else if (rolled.has(a.name)) {
+          a.status = "done";
+        } else if (a.status === "running") {
+          a.status = "pending";
+        }
+      }
       // Terminal wins unconditionally and FREEZES the surface.
       st.render = {
         target: entry.pin ?? st.render.target,
@@ -234,6 +313,14 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
         ...(entry.failed_step ? { failedStep: entry.failed_step } : {}),
         ...(entry.failed_agent ? { failedAgent: entry.failed_agent } : {}),
         ...(entry.got !== undefined ? { got: entry.got } : {}),
+        ...(st.agents.length > 0 ? { agents: st.agents } : {}),
+        ...(st.render.m !== undefined ? { m: st.render.m } : {}),
+        requestId: entry.request_id,
+        ...(entry.prior_pin ?? st.render.fromVersion
+          ? { fromVersion: entry.prior_pin ?? st.render.fromVersion }
+          : {}),
+        elapsedMs: (entry.finished_at ?? this.now()) - entry.started_at,
+        ...(st.render.deferred !== undefined ? { deferred: st.render.deferred } : {}),
       };
       st.frozen = true;
       // Cancel any pending debounced edit — the terminal render supersedes it —
@@ -264,6 +351,7 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
         postAttempts: 0,
         postFailed: false,
         render: { target: entry.pin ?? "" },
+        agents: [],
         frozen: false,
         timer: null,
         pendingEditAfterPost: false,
@@ -319,7 +407,7 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
     if (st.postFailed && !terminal) return false;
     st.posting = true;
     st.postAttempts += 1;
-    const text = renderRolloutStatus(st.render);
+    const text = renderRolloutStatus({ ...st.render, nowMs: this.now() });
     void this.relay
       .post({ requestId, agentName: st.agentName, text })
       .then((mid) => {
@@ -384,7 +472,7 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
       return;
     }
     // Edit in place (fire-and-forget; relay swallows failures incl. 429).
-    const text = renderRolloutStatus(st.render);
+    const text = renderRolloutStatus({ ...st.render, nowMs: this.now() });
     this.relay.edit({
       requestId,
       agentName: st.agentName,

--- a/src/host-control/rollout-narrator.ts
+++ b/src/host-control/rollout-narrator.ts
@@ -192,9 +192,6 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
         });
         break;
       }
-      case "hostd-web-deferred":
-        st.render.deferred = true;
-        break;
       default:
         break;
     }
@@ -320,7 +317,10 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
           ? { fromVersion: entry.prior_pin ?? st.render.fromVersion }
           : {}),
         elapsedMs: (entry.finished_at ?? this.now()) - entry.started_at,
-        ...(st.render.deferred !== undefined ? { deferred: st.render.deferred } : {}),
+        // The fresh terminal ping (server.ts pushRolloutTerminal) already
+        // carries the full Deferred command block; suppress it on THIS edited
+        // card so a successful roll doesn't render the 3-command list twice.
+        deferred: false,
       };
       st.frozen = true;
       // Cancel any pending debounced edit — the terminal render supersedes it —

--- a/src/host-control/rollout-observability.test.ts
+++ b/src/host-control/rollout-observability.test.ts
@@ -10,7 +10,10 @@ import {
   latestRolloutRowForRequest,
   parseAuditLine,
 } from "./audit-reader.js";
-import { renderRolloutStatus } from "./render-rollout-status.js";
+import {
+  renderRolloutStatus,
+  formatDurationMs,
+} from "./render-rollout-status.js";
 
 /** Build one JSONL audit row (the shape hostd writes, chain fields elided —
  *  parseAuditLine ignores `_seq`/`_prev`/`_hash`). */
@@ -99,15 +102,37 @@ describe("audit-reader parses rollout phase fields", () => {
   });
 });
 
+describe("formatDurationMs", () => {
+  it("formats seconds / minutes / hours compactly", () => {
+    expect(formatDurationMs(42_000)).toBe("42s");
+    expect(formatDurationMs(190_000)).toBe("3m 10s");
+    expect(formatDurationMs(180_000)).toBe("3m");
+    expect(formatDurationMs(3_900_000)).toBe("1h 5m");
+    expect(formatDurationMs(-5)).toBe("0s");
+  });
+});
+
 describe("renderRolloutStatus", () => {
-  it("renders an in-flight applying line", () => {
+  it("renders an in-flight applying header", () => {
     const out = renderRolloutStatus({ target: "v1.2.3", phase: "apply" });
     expect(out).toContain("v1.2.3");
     expect(out).toContain("applying");
     expect(out.startsWith("⏳")).toBe(true);
   });
 
-  it("renders agent N/M progress", () => {
+  it("headers with from → to versions and the short request id", () => {
+    const out = renderRolloutStatus({
+      target: "v1.2.3",
+      fromVersion: "v1.2.2",
+      requestId: "ro-abcdef1234567890xyz",
+      phase: "apply",
+    });
+    const header = out.split("\n")[0]!;
+    expect(header).toContain("`v1.2.2` → `v1.2.3`");
+    expect(header).toContain("req `ro-abcdef1234567…`");
+  });
+
+  it("renders agent N/M progress with the rolled count footer", () => {
     const out = renderRolloutStatus({
       target: "v1.2.3",
       phase: "agent-start",
@@ -118,21 +143,79 @@ describe("renderRolloutStatus", () => {
     });
     expect(out).toContain("agent 3/8");
     expect(out).toContain("clerk");
-    expect(out).toContain("2 rolled");
+    expect(out).toContain("2/8 rolled");
   });
 
-  it("renders the ✅ terminal-completed line with the rolled list", () => {
+  it("renders the per-agent checklist (✓ done / ⏳ running / ✗ failed / · pending) with durations", () => {
+    const out = renderRolloutStatus({
+      target: "v1.2.3",
+      phase: "agent-start",
+      agent: "clerk",
+      n: 3,
+      m: 5,
+      rolled: ["test-harness", "marko"],
+      agents: [
+        { name: "test-harness", status: "done", canary: true, durationMs: 42_000 },
+        { name: "marko", status: "done", durationMs: 38_000 },
+        { name: "clerk", status: "running" },
+      ],
+    });
+    expect(out).toContain("- ✓ `test-harness` (canary) — 42s");
+    expect(out).toContain("- ✓ `marko` — 38s");
+    expect(out).toContain("- ⏳ `clerk` — restarting…");
+    // 5 total, 3 known → 2 collapsed pending.
+    expect(out).toContain("- · 2 more pending");
+    // No literal • bullets (progress-card vocabulary uses `-` lists).
+    expect(out).not.toContain("•");
+  });
+
+  it("estimates a rough ETA from the mean per-agent duration so far", () => {
+    const out = renderRolloutStatus({
+      target: "v1.2.3",
+      phase: "agent-start",
+      m: 4,
+      rolled: ["a", "b"],
+      agents: [
+        { name: "a", status: "done", durationMs: 30_000 },
+        { name: "b", status: "done", durationMs: 60_000 },
+        { name: "c", status: "running" },
+      ],
+    });
+    // mean 45s × 2 remaining = 1m 30s.
+    expect(out).toContain("~1m 30s left (rough est.)");
+  });
+
+  it("shows elapsed from startedAtMs/nowMs while in flight", () => {
+    const out = renderRolloutStatus({
+      target: "v1.2.3",
+      phase: "agent-start",
+      m: 3,
+      startedAtMs: 1_000_000,
+      nowMs: 1_105_000,
+    });
+    expect(out).toContain("elapsed 1m 45s");
+  });
+
+  it("renders the ✅ terminal summary with rolled list, elapsed total and deferred components", () => {
     const out = renderRolloutStatus({
       target: "v1.2.3",
       terminal: "completed",
       rolled: ["test-harness", "clerk"],
+      m: 2,
+      elapsedMs: 492_000,
     });
     expect(out.startsWith("✅")).toBe(true);
-    expect(out).toContain("done");
+    expect(out).toContain("Done");
+    expect(out).toContain("rolled 2/2 agent(s) in 8m 12s");
     expect(out).toContain("test-harness, clerk");
+    // Deferred host-side components with their exact update commands.
+    expect(out).toContain("Deferred");
+    expect(out).toContain("switchroom webd install --tag v1.2.3");
+    expect(out).toContain("sudo npm i -g switchroom@1.2.3");
+    expect(out).toContain("switchroom hostd install --tag v1.2.3");
   });
 
-  it("renders the ❌ terminal-error line with the failed step + agent", () => {
+  it("renders the ❌ terminal-error summary with the failed step + agent", () => {
     const out = renderRolloutStatus({
       target: "v1.2.3",
       terminal: "error",
@@ -140,6 +223,7 @@ describe("renderRolloutStatus", () => {
       failedAgent: "clerk",
       got: "1.2.2",
       rolled: ["test-harness"],
+      elapsedMs: 65_000,
     });
     expect(out.startsWith("❌")).toBe(true);
     expect(out).toContain("STOPPED");
@@ -147,6 +231,9 @@ describe("renderRolloutStatus", () => {
     expect(out).toContain("clerk");
     expect(out).toContain("1.2.2");
     expect(out).toContain("test-harness");
+    expect(out).toContain("after 1m 5s");
+    // A failed roll must NOT advertise the deferred-update commands.
+    expect(out).not.toContain("Deferred");
   });
 
   it("renders 'unreachable' when the failed agent version is null", () => {

--- a/src/host-control/rollout-observability.test.ts
+++ b/src/host-control/rollout-observability.test.ts
@@ -207,7 +207,7 @@ describe("renderRolloutStatus", () => {
     expect(out.startsWith("✅")).toBe(true);
     expect(out).toContain("Done");
     expect(out).toContain("rolled 2/2 agent(s) in 8m 12s");
-    expect(out).toContain("test-harness, clerk");
+    expect(out).toContain("`test-harness`, `clerk`");
     // Deferred host-side components with their exact update commands.
     expect(out).toContain("Deferred");
     expect(out).toContain("switchroom webd install --tag v1.2.3");
@@ -234,6 +234,91 @@ describe("renderRolloutStatus", () => {
     expect(out).toContain("after 1m 5s");
     // A failed roll must NOT advertise the deferred-update commands.
     expect(out).not.toContain("Deferred");
+  });
+
+  it("code-spans agent names everywhere (underscores must not italicize in GFM)", () => {
+    // Phase line + rolled join, in-flight.
+    const inflight = renderRolloutStatus({
+      target: "v1.2.3",
+      phase: "agent-start",
+      agent: "data_pipeline_bot",
+      n: 2,
+      m: 3,
+      rolled: ["test_harness"],
+    });
+    expect(inflight).toContain("restarting `data_pipeline_bot`");
+    // Terminal joins.
+    const done = renderRolloutStatus({
+      target: "v1.2.3",
+      terminal: "completed",
+      rolled: ["test_harness", "data_pipeline_bot"],
+    });
+    expect(done).toContain("`test_harness`, `data_pipeline_bot`");
+    const err = renderRolloutStatus({
+      target: "v1.2.3",
+      terminal: "error",
+      failedStep: "restart-agent",
+      failedAgent: "data_pipeline_bot",
+      got: null,
+      rolled: ["test_harness"],
+    });
+    expect(err).toContain("Rolled before stop: `test_harness`.");
+    // Canary phase lines.
+    const canary = renderRolloutStatus({
+      target: "v1.2.3",
+      phase: "canary-pass",
+      agent: "test_harness",
+    });
+    expect(canary).toContain("canary passed (`test_harness`)");
+    // No agent name appears outside a code span in any of the renders.
+    for (const out of [inflight, done, err, canary]) {
+      expect(out).not.toMatch(/(^|[^`])(?:test_harness|data_pipeline_bot)([^`]|$)/);
+    }
+  });
+
+  it("collapses the checklist when a big fleet would overflow the message-size ceiling", () => {
+    // Synthetic 60-agent fleet with long names — the full render would exceed
+    // Telegram's edit limit (the gateway swallows MESSAGE_TOO_LONG, silently
+    // freezing the narration), so the render must fall back to compact mode.
+    const names = Array.from(
+      { length: 60 },
+      (_, i) =>
+        `agent-with-a-rather-long-and-quite-descriptive-container-name-${String(i).padStart(2, "0")}`,
+    );
+    const agents = names.map((name, i) => ({
+      name,
+      status: (i < 58 ? "done" : i === 58 ? "running" : "pending") as
+        | "done"
+        | "running"
+        | "pending",
+      ...(i < 58 ? { durationMs: 40_000 } : {}),
+      ...(i === 0 ? { canary: true } : {}),
+    }));
+    const out = renderRolloutStatus({
+      target: "v1.2.3",
+      phase: "agent-start",
+      agent: names[58],
+      n: 59,
+      m: 60,
+      rolled: names.slice(0, 58),
+      agents,
+    });
+    expect(out.length).toBeLessThan(3900);
+    // Completed agents folded into one count line; the active agent survives.
+    expect(out).toContain("- ✓ 58 done");
+    expect(out).toContain(`- ⏳ \`${names[58]}\` — restarting…`);
+    expect(out).toContain("more pending");
+    // Terminal render for the same fleet also stays under the ceiling.
+    const done = renderRolloutStatus({
+      target: "v1.2.3",
+      terminal: "completed",
+      rolled: names,
+      m: 60,
+      elapsedMs: 2_400_000,
+      agents: agents.map((a) => ({ ...a, status: "done" as const })),
+    });
+    expect(done.length).toBeLessThan(3900);
+    expect(done).toContain("- ✓ 60 done");
   });
 
   it("renders 'unreachable' when the failed agent version is null", () => {

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -3110,6 +3110,11 @@ export class HostdServer {
         target: entry.pin ?? "",
         rolled: entry.rolled,
         terminal: entry.result === "completed" ? "completed" : "error",
+        requestId: entry.request_id,
+        ...(entry.prior_pin ? { fromVersion: entry.prior_pin } : {}),
+        ...(entry.finished_at !== null
+          ? { elapsedMs: entry.finished_at - entry.started_at }
+          : {}),
         ...(entry.failed_step ? { failedStep: entry.failed_step } : {}),
         ...(entry.failed_agent ? { failedAgent: entry.failed_agent } : {}),
         ...(entry.got !== undefined ? { got: entry.got } : {}),


### PR DESCRIPTION
## Summary
Upgrades the fleet-rollout progress DM from a one-line edited message to a progress-card-style multi-line checklist, while keeping it an ordinary edited message (NOT pinned) per the chat-is-the-single-source-of-truth invariant and the header contract in `rollout-narrator.ts`.

New render (`src/host-control/render-rollout-status.ts`):
- **Header**: `from-version` → `target` + short `request_id`.
- **Phase line** (existing phase vocabulary, incl. n/m).
- **Per-agent checklist**: ✓ done (with restart duration) / ⏳ in progress / · pending / ✗ failed; canary called out; unknown-yet agents collapse to "N more pending".
- **Footer**: rolled n/m, elapsed, rough ETA from the mean per-agent duration so far.
- **Terminal summary**: counts + total elapsed; ✅ completed rows list the deferred host-side components (switchroom-web, host operator CLI, hostd template regen) each with the exact command that updates it (mirrors the executor's #2645 warning text).
- Terminal relay push (`pushRolloutTerminal`) now carries request_id / prior_pin / elapsed, so the terminal DM includes the summary counts + versions too.

Narrator (`rollout-narrator.ts`) gains a per-agent accumulator (fed off the same phase stream) and a `now()` clock seam for tests. **Unchanged**: debounce (1.5s trailing edge), edit-in-place, monotonic seq gate, freeze-on-terminal, MAX_POST_ATTEMPTS anti-storm cap, fire-and-forget discipline.

## Why
Operator ask: the rollout message should show "more information and details of progress, what is happening, more like our progress card". Job spec: `reference/jobs/operate-the-fleet-from-telegram.md` — phase-by-phase visibility in chat, explicitly WITHOUT re-creating a pinned mirror; this stays an in-chat edited narration message.

## Test plan
- Extended `src/host-control/rollout-observability.test.ts` (renderer: header versions/req-id, checklist glyphs+durations, ETA math, elapsed, deferred commands, ❌ has no deferred section, formatDurationMs) and `rollout-narrator.test.ts` (accumulated checklist end-to-end incl. deferral + terminal, failed-canary ✗ marking). 30/30 pass locally.
- `tests/host-control/server.test.ts`: 32 failures locally, identical count on pristine origin/main — environment-only (noexec /tmp stub binaries); CI is the authority.
- `npm run lint` green (tsc + all 8 guards).

## Risk
Low — pure-render + narrator-internal accumulation; transport, debounce and storm caps untouched. Message is longer but single and edited in place, so no extra Telegram sends.

## Sample render
```
⏳ **Rollout** `v0.18.9` → `v0.18.10` · req `ro-1a2b3c4d5e6f7…`
**Phase:** agent 3/8 — restarting marko

- ✓ `test-harness` (canary) — 42s
- ✓ `clerk` — 38s
- ⏳ `marko` — restarting…
- · 5 more pending

2/8 rolled · elapsed 1m 45s · ~4m left (rough est.)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
