### PR TITLE
fix(rollout): refresh web in-plan on hostd path; steer update_apply to rollout

### DIFF
--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -329,12 +329,14 @@ describe("planRollout — hostd context (#2487)", () => {
     const kinds = steps.map((s) =>
       s.kind === "restart-agent" ? `r:${s.agent}` : s.kind,
     );
-    // apply → canary (test-harness) → persist-pin → rest → refresh-hindsight → sweep.
+    // apply → canary (test-harness) → persist-pin → rest → refresh-web →
+    // refresh-hindsight → sweep.
     expect(kinds).toEqual([
       "apply",
       "r:test-harness",
       "persist-pin",
       "r:clerk",
+      "refresh-web",
       "refresh-hindsight",
       "sweep",
     ]);
@@ -344,13 +346,40 @@ describe("planRollout — hostd context (#2487)", () => {
     expect(persistIdx).toBeGreaterThan(canaryIdx);
   });
 
-  it("DROPS the hostd/web refresh steps (deferred — would SIGKILL itself)", () => {
+  it("DROPS the hostd refresh step (deferred — would SIGKILL itself) but KEEPS refresh-web", () => {
     const kinds = planRollout(["clerk", "marko"], {
       pinToPersist: TARGET,
       hostdContext: true,
     }).map((s) => s.kind);
-    expect(kinds).not.toContain("refresh-web");
+    // hostd is this process's parent — recreating it mid-roll SIGKILLs the
+    // roll. web is a SEPARATE compose project with no parent/child relation
+    // to hostd, so it's safe to recreate in-plan; dropping it left web
+    // silently stale after every agent-driven roll.
     expect(kinds).not.toContain("refresh-hostd");
+    expect(kinds).toContain("refresh-web");
+  });
+
+  it("refresh-web lands AFTER all agent restarts and BEFORE refresh-hindsight", () => {
+    const steps = planRollout(["clerk", "marko", "test-harness"], {
+      pinToPersist: TARGET,
+      hostdContext: true,
+    });
+    const kinds = steps.map((s) => s.kind);
+    const webIdx = kinds.indexOf("refresh-web");
+    const lastRestartIdx = kinds.lastIndexOf("restart-agent");
+    expect(webIdx).toBeGreaterThan(lastRestartIdx);
+    expect(webIdx).toBeLessThan(kinds.indexOf("refresh-hindsight"));
+  });
+
+  it("skipWeb drops refresh-web on the hostd path too", () => {
+    const kinds = planRollout(["clerk"], {
+      pinToPersist: TARGET,
+      hostdContext: true,
+      skipWeb: true,
+    }).map((s) => s.kind);
+    expect(kinds).not.toContain("refresh-web");
+    // hindsight recreate is independent of --skip-web on the hostd path.
+    expect(kinds).toContain("refresh-hindsight");
   });
 
   it("RECREATES the hindsight singleton (standalone docker run — hostd can recreate it)", () => {
@@ -361,7 +390,7 @@ describe("planRollout — hostd context (#2487)", () => {
     const kinds = steps.map((s) => s.kind);
     // hindsight is a standalone `docker run` hostd owns via the docker
     // socket — it must be rolled so the memory backend isn't left a version
-    // behind (unlike refresh-web/refresh-hostd, separate compose projects).
+    // behind (unlike refresh-hostd, which stays host-side/self-bump).
     expect(kinds).toContain("refresh-hindsight");
     // ...and it lands immediately before the final sweep.
     expect(kinds.indexOf("refresh-hindsight")).toBe(kinds.indexOf("sweep") - 1);
@@ -498,6 +527,41 @@ describe("executeRollout — hostd context (#2487)", () => {
     for (const run of restartRuns) {
       expect(run).not.toContain("--pin");
     }
+  });
+
+  // Web-staleness fix: the hostd plan now includes refresh-web (web is a
+  // separate compose project with no parent/child relation to hostd, so the
+  // recreate cannot SIGKILL the in-flight roll). Assert the executor really
+  // invokes `webd install --tag <target>` on this path.
+  it("runs `webd install --tag <target>` on the hostd path (web no longer left stale)", () => {
+    const steps = planRollout(["test-harness", "clerk"], {
+      pinToPersist: TARGET,
+      hostdContext: true,
+    });
+    const { deps, runs } = harness({
+      versions: { "test-harness": "0.15.18", clerk: "0.15.18" },
+    });
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+    expect(r.ok).toBe(true);
+    expect(runs).toContainEqual(["webd", "install", "--tag", TARGET]);
+    // ...and hostd install is NOT run (deferred — would SIGKILL itself).
+    expect(runs.some((a) => a[0] === "hostd")).toBe(false);
+  });
+
+  it("a failed web refresh on the hostd path stays NON-FATAL and names the host-side command", () => {
+    const steps = planRollout(["clerk"], {
+      pinToPersist: TARGET,
+      hostdContext: true,
+    });
+    const { deps } = harness({
+      versions: { clerk: "0.15.18" },
+      runStatus: (args) => (args[0] === "webd" ? 1 : 0),
+    });
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+    expect(r.ok).toBe(true); // agents already rolled — stale web isn't fatal
+    const w = r.warnings.find((x) => /web refresh FAILED/.test(x));
+    expect(w).toBeTruthy();
+    expect(w).toContain(`switchroom webd install --tag ${TARGET}`);
   });
 });
 

--- a/src/cli/rollout.test.ts
+++ b/src/cli/rollout.test.ts
@@ -124,6 +124,10 @@ function harness(opts: {
    * pre-existing web/hostd tests never trip the hindsight run.
    */
   hindsightExists?: boolean;
+  /** Injected running-web image tag for the refresh-web skew probe.
+   *  Defaults to the roll target shape being unknown (null → probe skipped
+   *  by the isVersionAssertable gate never fires a warning). */
+  webImageTag?: string | null;
 }): {
   deps: RolloutDeps;
   runs: string[][];
@@ -145,6 +149,7 @@ function harness(opts: {
     emitPhase: (p) => phases.push(p),
     persistPin: (pin) => persisted.push(pin),
     hindsightExists: () => opts.hindsightExists ?? false,
+    webImageTag: () => opts.webImageTag ?? null,
   };
   return { deps, runs, logs, persisted, phases };
 }
@@ -546,6 +551,90 @@ describe("executeRollout — hostd context (#2487)", () => {
     expect(runs).toContainEqual(["webd", "install", "--tag", TARGET]);
     // ...and hostd install is NOT run (deferred — would SIGKILL itself).
     expect(runs.some((a) => a[0] === "hostd")).toBe(false);
+  });
+
+  // Rollback rolls must FORWARD --allow-downgrade to the singleton
+  // installers: their downgrade guard otherwise guard-skips with exit 0 and
+  // web/hostd silently stay on the NEWER tag (silent staleness, inverted).
+  it("forwards --allow-downgrade to webd install on a downgrade roll (hostd path)", () => {
+    const steps = planRollout(["clerk"], { pinToPersist: TARGET, hostdContext: true });
+    const { deps, runs } = harness({
+      versions: { clerk: "0.15.18" },
+      webImageTag: TARGET,
+    });
+    const r = executeRollout(steps, TARGET, deps, {
+      hostdContext: true,
+      allowDowngrade: true,
+    });
+    expect(r.ok).toBe(true);
+    expect(runs).toContainEqual([
+      "webd",
+      "install",
+      "--tag",
+      TARGET,
+      "--allow-downgrade",
+    ]);
+  });
+
+  it("forwards --allow-downgrade to webd + hostd install on the host-shell path", () => {
+    const steps = planRollout(["clerk"], { pinToPersist: TARGET });
+    const { deps, runs } = harness({
+      versions: { clerk: "0.15.18" },
+      webImageTag: TARGET,
+    });
+    executeRollout(steps, TARGET, deps, { allowDowngrade: true });
+    expect(runs).toContainEqual(["webd", "install", "--tag", TARGET, "--allow-downgrade"]);
+    expect(runs).toContainEqual(["hostd", "install", "--tag", TARGET, "--allow-downgrade"]);
+  });
+
+  it("does NOT pass --allow-downgrade on a normal (non-rollback) roll", () => {
+    const steps = planRollout(["clerk"], { pinToPersist: TARGET, hostdContext: true });
+    const { deps, runs } = harness({
+      versions: { clerk: "0.15.18" },
+      webImageTag: TARGET,
+    });
+    executeRollout(steps, TARGET, deps, { hostdContext: true });
+    expect(runs).toContainEqual(["webd", "install", "--tag", TARGET]);
+    expect(runs.some((a) => a.includes("--allow-downgrade"))).toBe(false);
+  });
+
+  // Belt-and-braces: webd install exits 0 on a downgrade-guard skip, so the
+  // executor probes the RUNNING web tag after the install and warns loudly
+  // on any skew from the roll target.
+  it("warns LOUDLY when web is left on a different version despite exit 0 (guard.skip)", () => {
+    const steps = planRollout(["clerk"], { pinToPersist: TARGET, hostdContext: true });
+    const { deps } = harness({
+      versions: { clerk: "0.15.18" },
+      // Running web is NEWER than the roll target — the guard.skip case on
+      // a rollback where the flag wasn't honored.
+      webImageTag: "v0.15.19",
+    });
+    const r = executeRollout(steps, TARGET, deps, { hostdContext: true });
+    expect(r.ok).toBe(true);
+    const w = r.warnings.find((x) => /running v0\.15\.19, NOT the roll target/.test(x));
+    expect(w).toBeTruthy();
+    expect(w).toContain(`switchroom webd install --tag ${TARGET} --allow-downgrade`);
+  });
+
+  it("no skew warning when web lands on the target (or the probe is unavailable)", () => {
+    const steps = planRollout(["clerk"], { pinToPersist: TARGET, hostdContext: true });
+    const onTarget = harness({ versions: { clerk: "0.15.18" }, webImageTag: TARGET });
+    const r1 = executeRollout(steps, TARGET, onTarget.deps, { hostdContext: true });
+    expect(r1.warnings.some((w) => /NOT the roll target/.test(w))).toBe(false);
+    // Probe null (web absent/unreadable) → no false-positive warning.
+    const noProbe = harness({ versions: { clerk: "0.15.18" }, webImageTag: null });
+    const r2 = executeRollout(steps, TARGET, noProbe.deps, { hostdContext: true });
+    expect(r2.warnings.some((w) => /NOT the roll target/.test(w))).toBe(false);
+  });
+
+  it("emits a web-refresh phase so narration doesn't go silent during the recreate", () => {
+    const steps = planRollout(["clerk"], { pinToPersist: TARGET, hostdContext: true });
+    const { deps, phases } = harness({
+      versions: { clerk: "0.15.18" },
+      webImageTag: TARGET,
+    });
+    executeRollout(steps, TARGET, deps, { hostdContext: true });
+    expect(phases.some((p) => p.phase === "web-refresh" && p.target === TARGET)).toBe(true);
   });
 
   it("a failed web refresh on the hostd path stays NON-FATAL and names the host-side command", () => {

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -54,6 +54,7 @@ import { compareReleaseTags } from "../config/release-resolve.js";
 import { SWITCHROOM_VERSION } from "./resolve-version.js";
 import { readAndFilter, defaultAuditLogPath } from "../host-control/audit-reader.js";
 import { isHindsightContainerExists } from "../setup/hindsight.js";
+import { deployedImageTag } from "./deploy-version-guard.js";
 
 /** One ordered step of a rollout plan. Pure data so it unit-tests. */
 export type RolloutStep =
@@ -267,6 +268,9 @@ export type RolloutPhaseName =
   | "agent-start"
   | "agent-done"
   | "persist-pin"
+  // In-plan web singleton refresh (webd install) — emitted just before the
+  // spawn so a slow pull/recreate isn't a silent gap in the narration.
+  | "web-refresh"
   | "hostd-web-deferred"
   // #2645 — hostd self-bump. Emitted by the DAEMON directly (never via the
   // child's stdout sentinel): "self-bump" when the old hostd hands its own
@@ -339,6 +343,7 @@ export function parseRolloutPhaseLine(line: string): RolloutPhase | null {
     "agent-start",
     "agent-done",
     "persist-pin",
+    "web-refresh",
     "hostd-web-deferred",
     "self-bump",
     "self-bump-done",
@@ -384,6 +389,17 @@ export interface RolloutDeps {
    * inject it so the executor's hindsight branch runs without docker.
    */
   hindsightExists?(): boolean;
+  /**
+   * Probe the image tag the running `switchroom-web` container was created
+   * from (null when absent/unreadable). Used by the refresh-web step's
+   * belt-and-braces skew check: `webd install` exits 0 on a downgrade-guard
+   * skip (deliberate — see deploy-version-guard.ts), so exit status alone
+   * cannot distinguish "web recreated on the target" from "web silently
+   * left on a different version". Defaults (in production) to
+   * {@link deployedImageTag}("switchroom-web"); tests inject it. Optional —
+   * when absent the skew check is skipped.
+   */
+  webImageTag?(): string | null;
 }
 
 export interface RolloutResult {
@@ -469,7 +485,8 @@ export function shouldRefuseStaleCli(
  * `SWITCHROOM_HOSTD_CONTEXT=1` on the child env. The flag flips three
  * deliberate behaviors versus the host-shell path:
  *   - persist the durable pin AFTER the canary, not before (planRollout);
- *   - defer the hostd/web self-refresh (planRollout drops those steps);
+ *   - defer the hostd self-refresh (planRollout drops that step; the web
+ *     refresh stays in-plan — safe, separate compose project);
  *   - suppress "Run with sudo" guidance + soften the persistPin chown-back
  *     (we're already euid 0 inside the hostd container, not via sudo).
  */
@@ -544,6 +561,15 @@ export interface RolloutExecOpts {
    * persisted, so a bare `apply` reads it from config.
    */
   hostdContext?: boolean;
+  /**
+   * Operator-approved rollback roll (`rollout --allow-downgrade`). Must be
+   * FORWARDED to the singleton installers (`webd install`, `hostd install`):
+   * their downgrade guard (deploy-version-guard.ts) otherwise hits
+   * `guard.skip` with exit 0 on a rollback — the agents roll back but the
+   * singleton silently stays on the NEWER tag with zero warning, the exact
+   * silent-staleness class the refresh steps exist to kill, inverted.
+   */
+  allowDowngrade?: boolean;
 }
 
 export function executeRollout(
@@ -684,20 +710,54 @@ export function executeRollout(
         break;
       }
       case "refresh-web": {
-        deps.log(`ROLL_STEP refresh-web — webd install --tag ${target}`);
-        const r = deps.run(["webd", "install", "--tag", target]);
+        // Forward --allow-downgrade on a rollback roll: webd install's
+        // downgrade guard would otherwise guard.skip with exit 0 — agents
+        // roll back but web silently stays on the NEWER tag, no warning.
+        const downgradeArgs = execOpts.allowDowngrade ? ["--allow-downgrade"] : [];
+        deps.log(
+          `ROLL_STEP refresh-web — webd install --tag ${target}` +
+            (execOpts.allowDowngrade ? " --allow-downgrade" : ""),
+        );
+        emit({ phase: "web-refresh", target });
+        const r = deps.run(["webd", "install", "--tag", target, ...downgradeArgs]);
         if (r.status !== 0) {
           warnings.push(
             `web refresh FAILED (non-fatal — agents already rolled) so ` +
               `switchroom-web is still on the PRIOR version. Finish it ` +
               `host-side: \`switchroom webd install --tag ${target}\`.`,
           );
+          break;
+        }
+        // Belt-and-braces skew check: `webd install` exits 0 on a
+        // downgrade-guard skip (deliberate — deploy-version-guard.ts), so a
+        // zero exit does NOT prove web is on the target. Probe the running
+        // container's image tag and warn LOUDLY on any mismatch.
+        const webTag = deps.webImageTag?.();
+        if (
+          webTag !== undefined &&
+          webTag !== null &&
+          isVersionAssertable(webTag) &&
+          normalizeVersion(webTag) !== targetNorm
+        ) {
+          warnings.push(
+            `web refresh completed but switchroom-web is running ${webTag}, ` +
+              `NOT the roll target ${target} (most likely its downgrade guard ` +
+              `skipped the install). Finish it host-side: \`switchroom webd ` +
+              `install --tag ${target} --allow-downgrade\`.`,
+          );
         }
         break;
       }
       case "refresh-hostd": {
-        deps.log(`ROLL_STEP refresh-hostd — hostd install --tag ${target}`);
-        const r = deps.run(["hostd", "install", "--tag", target]);
+        // Same downgrade-guard forwarding as refresh-web (hostd install
+        // shares deploy-version-guard.ts) — a host-shell rollback must not
+        // leave hostd silently on the newer tag.
+        const downgradeArgs = execOpts.allowDowngrade ? ["--allow-downgrade"] : [];
+        deps.log(
+          `ROLL_STEP refresh-hostd — hostd install --tag ${target}` +
+            (execOpts.allowDowngrade ? " --allow-downgrade" : ""),
+        );
+        const r = deps.run(["hostd", "install", "--tag", target, ...downgradeArgs]);
         if (r.status !== 0) warnings.push(`hostd refresh failed (non-fatal); agents already rolled`);
         break;
       }
@@ -811,7 +871,12 @@ export function registerRolloutCommand(program: Command): void {
       "--agents <list>",
       "Comma-separated subset of agents to roll (default: all configured).",
     )
-    .option("--skip-web", "Skip the web + hostd + hindsight refresh step.")
+    .option(
+      "--skip-web",
+      "Skip the web refresh (host-shell path: also the hostd + hindsight " +
+        "refresh). On the hostd/agent path only the web refresh is skipped — " +
+        "hindsight is still recreated and hostd stays deferred regardless.",
+    )
     .option(
       "--allow-downgrade",
       "Permit rolling to an older semver tag (operator-approved rollback path). " +
@@ -981,6 +1046,9 @@ export function registerRolloutCommand(program: Command): void {
         // writer, preserving the single-writer hash-chain contract.
         emitPhase: (phase) =>
           process.stdout.write(encodeRolloutPhaseLine(phase) + "\n"),
+        // Belt-and-braces skew probe for the refresh-web step (webd install
+        // exits 0 on a downgrade-guard skip — see deploy-version-guard.ts).
+        webImageTag: () => deployedImageTag("switchroom-web"),
         persistPin: (pin) => {
           const before = readFileSync(configPath, "utf8");
           const after = setReleasePinInConfig(before, pin);
@@ -1024,7 +1092,12 @@ export function registerRolloutCommand(program: Command): void {
       process.stdout.write(
         `${opts.allowDowngrade ? "Rolling back" : "Rolling"} ${requested.length} agent(s) to ${target}…\n`,
       );
-      const result = executeRollout(steps, target, deps, { hostdContext: hostdCtx });
+      const result = executeRollout(steps, target, deps, {
+        hostdContext: hostdCtx,
+        // Forwarded to the singleton installers (webd/hostd install) so a
+        // rollback roll doesn't get silently guard-skipped there.
+        allowDowngrade: opts.allowDowngrade,
+      });
 
       // hostd path: the HOSTD refresh was intentionally dropped from the
       // plan (it would SIGKILL this very process). The WEB refresh now runs
@@ -1123,7 +1196,12 @@ export function registerRollbackCommand(program: Command): void {
       "--agents <list>",
       "Comma-separated subset of agents to roll back (default: all configured).",
     )
-    .option("--skip-web", "Skip the web + hostd + hindsight refresh step.")
+    .option(
+      "--skip-web",
+      "Skip the web refresh (host-shell path: also the hostd + hindsight " +
+        "refresh). On the hostd/agent path only the web refresh is skipped — " +
+        "hindsight is still recreated and hostd stays deferred regardless.",
+    )
     .option("--dry-run", "Print the plan and exit without changing anything.")
     .action(async (opts: { to?: string; agents?: string; skipWeb?: boolean; dryRun?: boolean }) => {
       // Delegate entirely to the rollout action with --allow-downgrade.

--- a/src/cli/rollout.ts
+++ b/src/cli/rollout.ts
@@ -86,11 +86,16 @@ export interface RolloutPlanOpts {
    *      brick scenario #2). The canary is rolled on a one-shot `--pin`
    *      image ref via `apply`'s reading of the env-passed target; the
    *      durable pin is only written once the canary is green.
-   *   2. the web + hostd refresh steps are DROPPED entirely — an
-   *      agent-invoked rollout must not synchronously recreate its own
-   *      hostd container (it would SIGKILL the in-flight rollout, which
-   *      is hostd's own child — brick scenario #1). The executor reports
-   *      "hostd/web refresh deferred — run host-side" instead.
+   *   2. the HOSTD refresh step is DROPPED — an agent-invoked rollout
+   *      must not synchronously recreate its own hostd container (it
+   *      would SIGKILL the in-flight rollout, which is hostd's own child
+   *      — brick scenario #1). The executor reports "hostd refresh
+   *      deferred — run host-side" instead. The WEB refresh is KEPT:
+   *      switchroom-web is a separate compose project with no parent/
+   *      child relationship to hostd (it never mounts docker.sock and
+   *      nothing in the roll depends on it), so recreating it from
+   *      hostd is safe — dropping it left web silently stale on the
+   *      prior tag after every agent-driven roll.
    *
    * Gating the new ordering behind this explicit flag (not euid) keeps the
    * host-shell path's persist-first behavior a deliberate choice.
@@ -142,9 +147,9 @@ export function planRollout(
 
   if (opts.hostdContext) {
     // hostd/MCP path (#2487): persist the pin AFTER the canary confirms,
-    // and DROP the hostd/web refresh (defer to host-side). The bare
-    // `apply` reads the env-passed one-shot target, so the canary rolls
-    // on the target image WITHOUT a durable pin write first.
+    // and DROP the hostd self-refresh (defer to host-side / self-bump).
+    // The bare `apply` reads the env-passed one-shot target, so the canary
+    // rolls on the target image WITHOUT a durable pin write first.
     steps.push({ kind: "apply" });
     const [canary, ...rest] = ordered;
     if (canary !== undefined) {
@@ -162,11 +167,23 @@ export function planRollout(
       // the persist intent consistent.
       steps.push({ kind: "persist-pin", pin: opts.pinToPersist });
     }
+    // Recreate the web singleton too: switchroom-web is a SEPARATE compose
+    // project (`switchroom-web`) with no parent/child relationship to hostd
+    // (it never mounts docker.sock; hostd is not its child), so recreating
+    // it from inside hostd cannot SIGKILL this roll — unlike refresh-hostd,
+    // which stays host-side/self-bump because hostd IS this process's
+    // parent. Without this step, web silently stayed on the prior tag after
+    // every agent-driven roll (observed: fleet v0.18.10, web v0.18.9).
+    // `webd install` inside hostd is host-home-safe via SWITCHROOM_HOST_HOME
+    // (resolveWebHostHome refuses a /host-home bind source).
+    if (!opts.skipWeb) {
+      steps.push({ kind: "refresh-web" });
+    }
     // Recreate the hindsight singleton so a hostd/agent-driven roll doesn't
-    // leave the memory backend a version behind (refresh-web/refresh-hostd
-    // stay host-side — separate compose projects; hindsight is a standalone
-    // `docker run` hostd can recreate via the docker socket). The executor's
-    // refresh-hindsight case self-guards via hindsightExists().
+    // leave the memory backend a version behind (refresh-hostd stays
+    // host-side; hindsight is a standalone `docker run` hostd can recreate
+    // via the docker socket). The executor's refresh-hindsight case
+    // self-guards via hindsightExists().
     steps.push({ kind: "refresh-hindsight" });
     steps.push({ kind: "sweep" });
     return steps;
@@ -669,7 +686,13 @@ export function executeRollout(
       case "refresh-web": {
         deps.log(`ROLL_STEP refresh-web — webd install --tag ${target}`);
         const r = deps.run(["webd", "install", "--tag", target]);
-        if (r.status !== 0) warnings.push(`web refresh failed (non-fatal); agents already rolled`);
+        if (r.status !== 0) {
+          warnings.push(
+            `web refresh FAILED (non-fatal — agents already rolled) so ` +
+              `switchroom-web is still on the PRIOR version. Finish it ` +
+              `host-side: \`switchroom webd install --tag ${target}\`.`,
+          );
+        }
         break;
       }
       case "refresh-hostd": {
@@ -1003,31 +1026,41 @@ export function registerRolloutCommand(program: Command): void {
       );
       const result = executeRollout(steps, target, deps, { hostdContext: hostdCtx });
 
-      // hostd path: the hostd/web refresh was intentionally dropped from
-      // the plan (it would SIGKILL this very process). Surface that as a
-      // deferral note so the operator knows to refresh host-side.
+      // hostd path: the HOSTD refresh was intentionally dropped from the
+      // plan (it would SIGKILL this very process). The WEB refresh now runs
+      // in-plan (refresh-web — safe: separate compose project, not hostd's
+      // parent), so it is NOT in the deferred list unless --skip-web
+      // dropped it. Surface the remaining deferral so the operator knows
+      // what to finish host-side.
       if (hostdCtx) {
         // #2645 item 3 — name EXACTLY what is still on the prior version so
         // "rollout done" is never misread as "everything's on the new
         // version". hostd itself is current on this path when the roll was
         // preceded by a self-bump (the daemon tag-bumps its own compose
-        // before spawning this child); web + the host-installed operator
-        // CLI never are.
+        // before spawning this child); the host-installed operator CLI
+        // never is. switchroom-web was refreshed in-plan (or its failure/
+        // skip already produced its own actionable warning above).
         result.warnings.push(
-          `still on the PRIOR version after this roll: switchroom-web ` +
-            `(host-side: \`switchroom webd install --tag ${target}\`) and the ` +
-            `host operator CLI (\`sudo npm i -g switchroom@${normalizeVersion(target)}\`). ` +
+          `still on the PRIOR version after this roll: the host operator ` +
+            `CLI (\`sudo npm i -g switchroom@${normalizeVersion(target)}\`). ` +
             `hostd's compose was tag-bumped by the self-bump when one ran; a ` +
             `full hostd template regen (only needed when a release changes ` +
             `hostd's mounts/env) is \`switchroom hostd install --tag ${target}\` ` +
             `host-side. An agent-invoked rollout cannot recreate its own hostd ` +
-            `container mid-roll without killing itself.`,
+            `container mid-roll without killing itself.` +
+            (opts.skipWeb
+              ? ` --skip-web was set, so switchroom-web is ALSO still on the ` +
+                `prior version (host-side: \`switchroom webd install --tag ${target}\`).`
+              : ""),
         );
         // #2726 — narrate the deferral as a phase so the durable log + the
-        // narration surface show "hostd/web deferred" between the last agent
-        // and the terminal row. Only meaningful on the hostd path (the only
-        // path that defers). Emitted only when the roll got far enough to
-        // matter — i.e. it wasn't refused before executeRollout ran.
+        // narration surface show "hostd deferred" between the last agent
+        // and the terminal row. (Phase name kept as "hostd-web-deferred"
+        // for wire/audit-row compatibility; since the in-plan refresh-web
+        // landed, only hostd is actually deferred.) Only meaningful on the
+        // hostd path (the only path that defers). Emitted only when the
+        // roll got far enough to matter — i.e. it wasn't refused before
+        // executeRollout ran.
         process.stdout.write(
           encodeRolloutPhaseLine({ phase: "hostd-web-deferred", target }) + "\n",
         );

--- a/src/cli/webd.test.ts
+++ b/src/cli/webd.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { renderWebComposeFile, resolveWebImageTag } from "./webd.js";
+import { renderWebComposeFile, resolveWebImageTag, resolveWebHostHome } from "./webd.js";
 
 describe("renderWebComposeFile", () => {
   it("renders a valid yaml-shaped string for the switchroom-web service", () => {
@@ -125,5 +125,32 @@ describe("resolveWebImageTag (honor release.pin like the agent fleet)", () => {
   it("falls back to 'latest' when neither --tag nor release is set", () => {
     expect(resolveWebImageTag(undefined, undefined)).toBe("latest");
     expect(resolveWebImageTag(undefined, {})).toBe("latest");
+  });
+});
+
+describe("resolveWebHostHome (SWITCHROOM_HOST_HOME preference + /host-home poison guard)", () => {
+  // Mirrors resolveHostdHostHome: when `webd install` runs INSIDE the hostd
+  // container (the rollout refresh-web step), homedir() is /host-home — an
+  // in-container mount point, never a valid host bind SOURCE. The env var is
+  // the authoritative host home; a /host-home resolution must fail loud.
+  it("prefers SWITCHROOM_HOST_HOME over homedir()", () => {
+    expect(
+      resolveWebHostHome({ SWITCHROOM_HOST_HOME: "/home/operator" }, "/host-home"),
+    ).toBe("/home/operator");
+  });
+
+  it("falls back to the provided home when the env var is unset or blank", () => {
+    expect(resolveWebHostHome({}, "/home/operator")).toBe("/home/operator");
+    expect(resolveWebHostHome({ SWITCHROOM_HOST_HOME: "  " }, "/home/operator")).toBe(
+      "/home/operator",
+    );
+  });
+
+  it("REFUSES a /host-home resolution (poison bind source) with a recovery hint", () => {
+    expect(() => resolveWebHostHome({}, "/host-home")).toThrow(/refusing to generate/);
+    expect(() =>
+      resolveWebHostHome({ SWITCHROOM_HOST_HOME: "/host-home" }, "/x"),
+    ).toThrow(/SWITCHROOM_HOST_HOME/);
+    expect(() => resolveWebHostHome({}, "/host-home/sub")).toThrow(/host bind source/);
   });
 });

--- a/src/cli/webd.ts
+++ b/src/cli/webd.ts
@@ -39,7 +39,7 @@
 
 import type { Command } from "commander";
 import chalk from "chalk";
-import { existsSync, mkdirSync, writeFileSync, copyFileSync } from "node:fs";
+import { chownSync, existsSync, mkdirSync, writeFileSync, copyFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -72,6 +72,39 @@ export function resolveWebImageTag(
 ): string {
   if (explicitTag) return explicitTag;
   return resolveImageTag(resolveRelease({ root: release }));
+}
+
+/**
+ * Resolve the REAL host home for the web compose bind sources.
+ *
+ * Mirrors `resolveHostdHostHome` (src/cli/hostd.ts) and the agent-fleet
+ * generator (`write-compose.ts`, #2279): prefer `SWITCHROOM_HOST_HOME` over
+ * `homedir()`. When `webd install` runs INSIDE the hostd container (the
+ * rollout refresh-web step — hostd is a separate compose project so it can
+ * safely recreate web), `homedir()` returns `/host-home`, the in-container
+ * mount point of the operator home, NOT a host filesystem path. Emitting it
+ * as a bind SOURCE would make Docker auto-create empty `/host-home/...` dirs
+ * on the host: the receiver would see no webhook secrets, no web-token, no
+ * per-agent webhook.sock — silent total breakage. The backstop refuses to
+ * ever emit a `/host-home` source — fail loud with the recovery path.
+ */
+export function resolveWebHostHome(
+  env: NodeJS.ProcessEnv = process.env,
+  home: string = homedir(),
+): string {
+  const fromEnv = env.SWITCHROOM_HOST_HOME?.trim();
+  const resolved = fromEnv && fromEnv.length > 0 ? fromEnv : home;
+  if (resolved === "/host-home" || resolved.startsWith("/host-home/")) {
+    throw new Error(
+      `switchroom webd install: refusing to generate — the host home resolved to ` +
+        `"${resolved}", the in-container mount point of the operator home (never a ` +
+        `valid host bind source). Emitting it would make Docker create empty ` +
+        `/host-home dirs on the host and break every webhook forward + secret read.\n\n` +
+        `Recovery: run \`switchroom webd install\` from the HOST shell, or set ` +
+        `SWITCHROOM_HOST_HOME to the real host home first.`,
+    );
+  }
+  return resolved;
 }
 
 /**
@@ -276,8 +309,20 @@ async function doInstall(opts: InstallOptions, program: Command): Promise<void> 
     return;
   }
 
+  // Bind-mount SOURCES must be HOST paths. Inside the hostd container
+  // (rollout's refresh-web step) homedir() is /host-home — a poison bind
+  // source (#2279 class). resolveWebHostHome prefers SWITCHROOM_HOST_HOME
+  // and refuses /host-home outright.
+  let hostHome: string;
+  try {
+    hostHome = resolveWebHostHome();
+  } catch (err) {
+    console.error(chalk.red((err as Error).message));
+    process.exit(1);
+  }
+
   const yaml = renderWebComposeFile({
-    hostHome: homedir(),
+    hostHome,
     imageTag,
     operatorUid,
   });
@@ -293,6 +338,19 @@ async function doInstall(opts: InstallOptions, program: Command): Promise<void> 
   if (bak) console.log(chalk.dim(`  Backed up existing compose to ${bak}`));
 
   writeFileSync(composePath, yaml, "utf8");
+  // Root-mode writes (hostd-driven refresh-web runs as euid 0, no sudo)
+  // would leave the compose dir/file root-owned and EACCES-lock the next
+  // host-shell `webd install` run by the operator. Chown back, best-effort
+  // (dev hosts may lack CAP_CHOWN).
+  try {
+    if (typeof process.geteuid === "function" && process.geteuid() === 0) {
+      chownSync(dir, operatorUid, operatorUid);
+      chownSync(composePath, operatorUid, operatorUid);
+      if (bak) chownSync(bak, operatorUid, operatorUid);
+    }
+  } catch {
+    /* best-effort */
+  }
   console.log(chalk.green(`  ✓ Wrote ${composePath}`));
   console.log(chalk.dim(`    running as uid ${operatorUid} (operator), network_mode: host`));
 

--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -173,17 +173,18 @@ export const RolloutRequestSchema = z.object({
       /** Comma-free explicit subset of agents to roll. Omit ⇒ all
        *  configured agents (canary-first ordering still applies). */
       agents: z.array(AgentNameSchema).min(1).optional(),
-      /** Skip the web + hostd refresh step. On the hostd/MCP path the
-       *  hostd/web refresh is ALWAYS deferred regardless (it would
-       *  SIGKILL the in-flight rollout — hostd's own child); this flag
-       *  is forwarded for parity but the deferral is unconditional. */
+      /** Skip the web refresh step (leaves switchroom-web on the prior
+       *  version). On the hostd/MCP path the HOSTD self-refresh is ALWAYS
+       *  deferred regardless of this flag (it would SIGKILL the in-flight
+       *  rollout — hostd's own child); the WEB refresh runs in-plan there
+       *  unless this flag skips it. */
       skip_web: z.boolean().optional(),
       /**
        * Operator-approved rollback to a known-good earlier tag (#2487 PR2).
        * When set, the downgrade guard in `switchroom rollout` is relaxed to
        * permit `--pin <oldtag>` even when that tag is older than the current
        * `release.pin`. All other safety rails (canary order, version-assert,
-       * stop-on-mismatch, persist-after-canary, hostd/web deferral) apply
+       * stop-on-mismatch, persist-after-canary, hostd deferral) apply
        * unchanged. Absent ⇒ false (downgrade rejected as before).
        */
       allow_downgrade: z.boolean().optional(),

--- a/src/host-control/render-rollout-status.ts
+++ b/src/host-control/render-rollout-status.ts
@@ -54,7 +54,9 @@ function phaseLine(s: RolloutRenderState): string {
     case "persist-pin":
       return "persisting pin";
     case "hostd-web-deferred":
-      return "hostd/web refresh deferred (run host-side)";
+      // Legacy phase name: since the in-plan refresh-web step landed, only
+      // the hostd self-refresh is actually deferred on the agent path.
+      return "hostd refresh deferred (run host-side)";
     case "self-bump":
       return "hostd refreshing itself to the target (brief control blip)…";
     case "self-bump-done":

--- a/src/host-control/render-rollout-status.ts
+++ b/src/host-control/render-rollout-status.ts
@@ -53,6 +53,8 @@ function phaseLine(s: RolloutRenderState): string {
       return `agent ${s.n ?? "?"}/${s.m ?? "?"} — ${s.agent ?? ""} done`.trim();
     case "persist-pin":
       return "persisting pin";
+    case "web-refresh":
+      return "refreshing web dashboard (webd install)";
     case "hostd-web-deferred":
       // Legacy phase name: since the in-plan refresh-web step landed, only
       // the hostd self-refresh is actually deferred on the agent path.

--- a/src/host-control/rollout-narrator.ts
+++ b/src/host-control/rollout-narrator.ts
@@ -2,7 +2,7 @@
  * #2726 Part 2 — the log-tailed rollout NARRATION surface.
  *
  * ONE ordinary operator-DM message, edited in place through the phases
- * (`applying → canary → agent N/M → persisting pin → hostd/web deferred →
+ * (`applying → canary → agent N/M → persisting pin → web refresh → hostd deferred →
  * ✅ done`, or `❌` with the failed step/agent). NOT pinned, NOT a bespoke card —
  * in-chat narration, the `chat-is-the-single-source-of-truth` invariant's own
  * prescribed remedy (a plain message the operator can scroll to).
@@ -179,6 +179,10 @@ export class LogTailRolloutNarrator implements RolloutNarrator {
         return 2 * (phase.n ?? 1) + 0;
       case "agent-done":
         return 2 * (phase.n ?? 1) + 1;
+      case "web-refresh":
+        // In-plan web singleton refresh — after every agent restart, before
+        // the deferral note. Anchored just below hostd-web-deferred.
+        return Number.MAX_SAFE_INTEGER - 2;
       case "hostd-web-deferred":
         return Number.MAX_SAFE_INTEGER - 1; // near the end, before terminal
       default:

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -1481,8 +1481,9 @@ export class HostdServer {
    *   1. The spawned CLI runs with `SWITCHROOM_HOSTD_CONTEXT=1`, which
    *      flips the rollout to (a) persist the durable pin AFTER the canary
    *      confirms (not before — brick scenario #2), and (b) DROP the
-   *      hostd/web self-refresh (it would SIGKILL this very rollout, which
-   *      is hostd's own child — brick scenario #1).
+   *      hostd self-refresh (it would SIGKILL this very rollout, which
+   *      is hostd's own child — brick scenario #1). The web refresh runs
+   *      in-plan (separate compose project — safe to recreate from here).
    *   2. The outcome (`rolled[]` / `failedStep` / `failedAgent`) is
    *      preserved into STRUCTURED status fields, parsed from the child's
    *      sentinel line — NOT flattened into a stdout tail.

--- a/src/mcp/hostd/server.test.ts
+++ b/src/mcp/hostd/server.test.ts
@@ -40,7 +40,7 @@ vi.mock("node:fs", async () => {
 // Import after the mocks. server.ts reads SWITCHROOM_AGENT_NAME at
 // module-load — set it before the import.
 process.env.SWITCHROOM_AGENT_NAME = "klanker";
-const { TOOLS, dispatchTool } = await import("./server.js");
+const { TOOLS, dispatchTool, UPDATE_APPLY_SEMVER_PIN_ADVISORY } = await import("./server.js");
 
 function ok(resp: Partial<HostdResponse> = {}): HostdResponse {
   return {
@@ -166,6 +166,47 @@ describe("dispatchTool — happy path", () => {
     await dispatchTool("update_apply", { pin: "sha-abc1234" });
     const sent = hostdRequestMock.mock.calls[0]![1];
     expect(sent.args).toEqual({ pin: "sha-abc1234" });
+  });
+
+  // Soft steer: a SEMVER pin on update_apply is the fleet-version-roll case
+  // the safer `rollout` tool exists for. The call must still dispatch (the
+  // operator may want the blunt path deliberately) but the result carries an
+  // advisory pointing at rollout.
+  it("update_apply with a SEMVER pin still dispatches but appends the rollout advisory", async () => {
+    hostdRequestMock.mockResolvedValueOnce(ok({ result: "started" }));
+    const res = await dispatchTool("update_apply", { pin: "v0.18.10" });
+    expect(res.isError).toBeFalsy();
+    // Dispatched — NOT refused.
+    const sent = hostdRequestMock.mock.calls[0]![1];
+    expect(sent.op).toBe("update_apply");
+    expect(sent.args).toEqual({ pin: "v0.18.10" });
+    // Advisory appended as a second content item.
+    expect(res.content.length).toBe(2);
+    expect(res.content[1]!.text).toBe(UPDATE_APPLY_SEMVER_PIN_ADVISORY);
+    expect(res.content[1]!.text).toMatch(/rollout/);
+  });
+
+  it("update_apply with a sha pin gets NO advisory (rollout can't take sha pins)", async () => {
+    hostdRequestMock.mockResolvedValueOnce(ok({ result: "started" }));
+    const res = await dispatchTool("update_apply", { pin: "sha-abc1234" });
+    expect(res.isError).toBeFalsy();
+    expect(res.content.length).toBe(1);
+  });
+
+  it("update_apply without a pin gets NO advisory", async () => {
+    hostdRequestMock.mockResolvedValueOnce(ok({ result: "started" }));
+    const res = await dispatchTool("update_apply", {});
+    expect(res.isError).toBeFalsy();
+    expect(res.content.length).toBe(1);
+  });
+
+  it("the semver-pin advisory is NOT attached to a denied/error result", async () => {
+    hostdRequestMock.mockResolvedValueOnce(
+      ok({ result: "denied", error: "operator denied" } as Partial<HostdResponse>),
+    );
+    const res = await dispatchTool("update_apply", { pin: "v0.18.10" });
+    expect(res.isError).toBe(true);
+    expect(res.content.every((c) => !c.text.includes("BLUNT path"))).toBe(true);
   });
 
   it("update_apply rejects channel+pin combo without hitting the wire", async () => {

--- a/src/mcp/hostd/server.ts
+++ b/src/mcp/hostd/server.ts
@@ -102,6 +102,20 @@ interface ToolArgs {
  *  version-assertable, so it would stop the staggered roll on agent #1. */
 const ROLLOUT_SEMVER_PIN_RE = /^v\d+\.\d+\.\d+$/;
 
+/**
+ * Advisory appended to a SUCCESSFUL `update_apply` result when it was invoked
+ * with a semver tag pin — the exact fleet-version-roll case the safer
+ * `rollout` tool exists for. A soft steer, deliberately NOT a refusal: the
+ * operator may want the blunt path on purpose. Exported for the unit test.
+ */
+export const UPDATE_APPLY_SEMVER_PIN_ADVISORY =
+  "⚠️ advisory: update_apply with a semver pin is the BLUNT path — all " +
+  "containers recreate at once, with no canary, no per-agent version " +
+  "assert, and no stop-on-mismatch. For fleet version rolls prefer the " +
+  "`rollout` tool (staggered, canary-gated, version-asserted; also " +
+  "refreshes the web + hindsight singletons). This request was still " +
+  "dispatched — this is a steer, not a refusal.";
+
 export const TOOLS = [
   {
     name: "agent_restart",
@@ -290,7 +304,14 @@ export const TOOLS = [
     name: "update_apply",
     description:
       "Execute a fleet-wide update: pull images, regenerate " +
-      "scaffolds, recreate containers. Admin-only at the wire layer. " +
+      "scaffolds, recreate containers. This is the BLUNT all-at-once " +
+      "path — no canary, no per-agent version assert, no stop-on-" +
+      "mismatch. For rolling the fleet to a specific VERSION (a semver " +
+      "pin), prefer the `rollout` tool instead: staggered, canary-gated, " +
+      "version-asserted, and it also refreshes the web + hindsight " +
+      "singletons. Calling update_apply with a semver pin still works " +
+      "(the operator may want the blunt path deliberately) but the " +
+      "result includes an advisory warning. Admin-only at the wire layer. " +
       "Returns `started` once dispatched — the actual work runs " +
       "async on the host and the caller's own agent container will " +
       "be recreated as part of the cycle. This is operator-gated — every " +
@@ -358,9 +379,10 @@ export const TOOLS = [
       "request_id — do NOT re-issue the rollout during the blip; poll " +
       "get_status (pass the returned request_id as its `request_id` " +
       "argument) once the socket is back. " +
-      "The web refresh stays DEFERRED on this path; the terminal warnings " +
-      "name exactly what is still on the prior version (web, host operator " +
-      "CLI) and the host-side commands to finish. By default downgrade pins " +
+      "The web + hindsight singletons are refreshed in-plan on this path " +
+      "(only the hostd template regen + host operator CLI stay host-side; " +
+      "the terminal warnings name exactly what is still on the prior " +
+      "version and the commands to finish). By default downgrade pins " +
       "are rejected — pass `allow_downgrade: true` for the operator-approved " +
       "rollback path to a known-good earlier tag; all other safety rails " +
       "(canary order, version-assert, stop-on-mismatch) apply unchanged. " +
@@ -403,9 +425,10 @@ export const TOOLS = [
         skip_web: {
           type: "boolean",
           description:
-            "Skip the web + hostd refresh step. NB: on this (hostd) path " +
-            "the hostd/web refresh is deferred regardless; this flag is " +
-            "forwarded for parity.",
+            "Skip the web refresh step (leaves switchroom-web on the prior " +
+            "version — the terminal warning names the host-side command to " +
+            "finish). The hostd self-refresh is deferred on this path " +
+            "regardless of this flag.",
         },
         allow_downgrade: {
           type: "boolean",
@@ -564,6 +587,9 @@ export async function dispatchTool(
   }
 
   let req: HostdRequest;
+  // Optional advisory attached to a SUCCESSFUL result (soft steer — e.g.
+  // update_apply invoked with a semver pin when `rollout` is the safer path).
+  let advisory: string | undefined;
   switch (name) {
     case "agent_restart": {
       if (!args.name) return errorText("agent_restart: name is required");
@@ -657,6 +683,15 @@ export async function dispatchTool(
         return errorText(
           `update_apply: pin "${args.pin}" is invalid. Expected sha-<7-40 hex> or v<semver>.`,
         );
+      }
+      // Soft guard (not a refusal — the operator may want the blunt path
+      // deliberately): a SEMVER pin is exactly the fleet-version-roll case
+      // the safer `rollout` tool exists for. Attach an advisory to the
+      // result so the calling agent learns the steer even after the
+      // operator approves the card. sha pins have no rollout equivalent
+      // (rollout is semver-only), so they pass silently.
+      if (args.pin && ROLLOUT_SEMVER_PIN_RE.test(args.pin)) {
+        advisory = UPDATE_APPLY_SEMVER_PIN_ADVISORY;
       }
       req = {
         v: 1,
@@ -780,7 +815,11 @@ export async function dispatchTool(
   // started/completed: success path. Surface the full response as
   // JSON so the model can correlate later via request_id.
   if (resp.result === "started" || resp.result === "completed") {
-    return jsonText(resp);
+    const out = jsonText(resp);
+    if (advisory) {
+      out.content.push({ type: "text" as const, text: advisory });
+    }
+    return out;
   }
 
   // denied/error: tool-error so the model can see it failed but also

--- a/src/mcp/hostd/server.ts
+++ b/src/mcp/hostd/server.ts
@@ -437,7 +437,7 @@ export const TOOLS = [
             "When true, the downgrade guard is relaxed so `pin` may be older " +
             "than the current release.pin. All other safety rails (canary order, " +
             "version-assert, stop-on-mismatch, persist-after-canary, " +
-            "hostd/web deferral) apply unchanged. Still gated by the operator " +
+            "hostd deferral) apply unchanged. Still gated by the operator " +
             "approval card — not pre-approved.",
         },
       },


### PR DESCRIPTION
## Summary
- **Web stale after agent-driven rolls (fixed):** the hostd-context rollout plan dropped `refresh-web` together with `refresh-hostd`, so `switchroom-web` silently stayed on the prior tag after every agent-driven roll (observed today: fleet v0.18.10, web v0.18.9). The plan now includes a `refresh-web` step (after the agent restarts, before `refresh-hindsight`; honors `--skip-web`).
- **Safety verified, not assumed:** `switchroom-web` is a SEPARATE compose project (`switchroom-web`, `src/cli/webd.ts`) with no parent/child relation to hostd — no docker.sock, no cap_add, nothing in the roll depends on it — so recreating it from inside hostd cannot SIGKILL the in-flight roll (unlike `refresh-hostd`, which stays deferred/self-bump).
- **Made `webd install` safe to run inside hostd:** new `resolveWebHostHome()` prefers `SWITCHROOM_HOST_HOME` and refuses a `/host-home` bind source (the #2279 poison class, mirroring `resolveHostdHostHome`), plus operator-uid chown-back of the compose dir/file after a root-mode write.
- **Loud + actionable on failure:** a failed web refresh stays non-fatal but the warning names the exact host command (`switchroom webd install --tag <v>`); the terminal deferred warning no longer lists web (only the host operator CLI + hostd template regen; `--skip-web` re-adds the web line).
- **Steer away from blunt fleet rolls:** `update_apply` MCP description now points version rolls at `rollout`; invoking `update_apply` with a semver tag pin appends an advisory content item to the successful result (soft guard — still dispatched, sha pins pass silently since rollout is semver-only).

## Why
Every agent-driven roll left the dashboard/webhook receiver a version behind with no signal. hostd self-bumps itself (#2645); web had no equivalent.

Job spec: `reference/jobs/idempotent-update-and-restart.md` — a roll should leave the whole installation coherent on the target version, or say loudly what isn't.

## Test plan
- `vitest run src/cli/rollout.test.ts src/cli/webd.test.ts src/mcp/hostd/server.test.ts src/cli/update.test.ts src/host-control/rollout-narrator.test.ts src/host-control/self-bump.test.ts` — 244 tests green.
- New tests: hostd plan contains `refresh-web` (ordering pinned), `--skip-web` drops it, executor invokes `webd install --tag` and never `hostd install` on the hostd path, actionable failure warning; `resolveWebHostHome` env-preference + /host-home refusal; update_apply semver-pin advisory (dispatched, appended, absent for sha/no-pin/denied).
- `npm run lint` green (incl. check-stale-tool-descriptions).

## Risk
Low. Host-shell rollout path unchanged. Phase name `hostd-web-deferred` kept for wire/audit compatibility (render text updated). Worst case a web recreate fails mid-roll: non-fatal, agents already rolled, warning names recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)