### PR TITLE
fix(webkite): drop invalid plural render.routes provider field (#3030)

### DIFF
--- a/docker/webkite/config.toml
+++ b/docker/webkite/config.toml
@@ -70,19 +70,24 @@ type = "firecrawl"
 # call webkite_read with wait_for_selector set to the session-times
 # container. See the issue's post-merge verification notes.
 
-[[render.routes]]
-domains = ["palacecinemas.com.au", "www.palacecinemas.com.au"]
-providers = ["cloakbrowser", "cloudflare"]
-mode = "force"
-exclusive = false
-
-# Operator-extensible: add other JS-gated ticketing / booking hosts here
-# (both bare + www forms). Left minimal on purpose — forcing render on a
-# host that doesn't need it only costs latency, but inventing domains that
-# don't exist adds noise. Example shape:
+# NOTE (webkite 0.4.0 schema — switchroom #3030): RouteConfig requires a
+# SINGULAR string `provider = "<name>"`, NOT an array `providers = [...]`.
+# The old `providers = ["cloakbrowser", "cloudflare"]` field is invalid and
+# aborts parsing of the ENTIRE config file, which silently disabled all JS
+# rendering fleet-wide (`has_renderers: false`, `decision: no_renderer`).
+# Two further 0.4.0 constraints made the intended route unshippable as-is:
+#   - `cloakbrowser` is auto_spawn-only and CANNOT be named in a route
+#     (resolves to "route provider not found").
+#   - a route may name only ONE provider.
+# The Palace Cinemas force-route is therefore removed: a content-empty SPA
+# shell is classified `thin_article` and, with renderers configured above,
+# AUTO-ESCALATES to a render on its own (verified: `has_renderers: true`,
+# `provider: cloudflare`, `decision: escalate`) — so the explicit route is
+# not needed for rendering to work. If an operator later needs to pin a
+# forced route, use the singular form naming a DECLARED provider, e.g.:
 #
 # [[render.routes]]
 # domains = ["tickets.example-cinema.com.au", "www.example-cinema.com.au"]
-# providers = ["cloakbrowser", "cloudflare"]
+# provider = "cloudflare"
 # mode = "force"
 # exclusive = false

--- a/tests/docker/webkite-config-parse.test.ts
+++ b/tests/docker/webkite-config-parse.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Guard the fleet-wide webkite render config against the #3030 regression:
+ * webkite 0.4.0's `RouteConfig` requires a SINGULAR string
+ * `provider = "<name>"`. The config previously shipped an ARRAY field
+ * `providers = ["cloakbrowser", "cloudflare"]` inside a `[[render.routes]]`
+ * block. That invalid field aborts parsing of the ENTIRE config file (not
+ * just the route), so no renderer loads at all and all JS rendering is
+ * silently disabled fleet-wide (`has_renderers: false`,
+ * `decision: no_renderer`).
+ *
+ * No TOML parser is a repo dependency, so this is a structural check over
+ * the shipped file: every `[[render.routes]]` entry must use the singular
+ * `provider` key and no route may carry the plural `providers` array. The
+ * test FAILS on the pre-fix file (which had `providers = [...]` on line ~75).
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const config = readFileSync(resolve(root, "docker/webkite/config.toml"), "utf8");
+
+// Strip comments (leading-whitespace `#` lines and inline `# ...` tails) so
+// the check only sees ACTIVE, parser-visible TOML — commented example shapes
+// must not trip or satisfy it.
+function activeLines(toml: string): string[] {
+  return toml
+    .split("\n")
+    .map((line) => {
+      const hash = line.indexOf("#");
+      return hash === -1 ? line : line.slice(0, hash);
+    })
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim().length > 0);
+}
+
+describe("docker/webkite/config.toml — webkite 0.4.0 render.routes schema (#3030)", () => {
+  it("has no active plural `providers =` field anywhere (0.4.0 uses singular `provider`)", () => {
+    const offenders = activeLines(config).filter((line) =>
+      /^\s*providers\s*=/.test(line),
+    );
+    expect(
+      offenders,
+      "webkite 0.4.0 render.routes requires singular `provider = \"<name>\"`; a plural " +
+        "`providers = [...]` array aborts parsing of the WHOLE config and disables all " +
+        "JS rendering fleet-wide (#3030)",
+    ).toEqual([]);
+  });
+
+  it("every active [[render.routes]] block uses a singular `provider` string", () => {
+    const lines = activeLines(config);
+    let inRoute = false;
+    const routeStarts: number[] = [];
+    const providerNamed: boolean[] = [];
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (/^\[\[render\.routes\]\]$/.test(trimmed)) {
+        inRoute = true;
+        routeStarts.push(1);
+        providerNamed.push(false);
+        continue;
+      }
+      // Any other top-level table header ends the current route block.
+      if (/^\[/.test(trimmed)) {
+        inRoute = false;
+        continue;
+      }
+      if (inRoute && /^provider\s*=\s*"[^"]+"/.test(trimmed)) {
+        providerNamed[providerNamed.length - 1] = true;
+      }
+      if (inRoute && /^providers\s*=/.test(trimmed)) {
+        // plural form — invalid; leave providerNamed false so the assert trips
+        providerNamed[providerNamed.length - 1] = false;
+      }
+    }
+
+    // Every declared route (if any) must name exactly one provider via the
+    // singular key. Zero routes is also valid — auto-escalation covers thin
+    // SPAs — so this only asserts on routes that DO exist.
+    for (let i = 0; i < routeStarts.length; i++) {
+      expect(
+        providerNamed[i],
+        `[[render.routes]] block #${i + 1} must declare a singular \`provider = "<name>"\` ` +
+          "field (webkite 0.4.0 schema; #3030)",
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Root cause

webkite 0.4.0's `RouteConfig` requires a singular string `provider = "<name>"`. The shipped fleet config `docker/webkite/config.toml` carried `providers = ["cloakbrowser", "cloudflare"]` (an array) in its `[[render.routes]]` block. The invalid field aborts parsing of the ENTIRE config file — silently disabling all JS rendering fleet-wide (`has_renderers: false`, `decision: no_renderer`).

## Fix

- Remove the Palace Cinemas force-route (issue-verified fix): a content-empty SPA is classified `thin_article` and auto-escalates to a render on its own with renderers configured (`has_renderers: true`, `provider: cloudflare`, `decision: escalate`). The route was also unshippable as written — `cloakbrowser` is auto_spawn-only (not routable) and a route may name only one provider.
- Document the 0.4.0 schema constraint inline and correct the example-shape comment to the singular `provider = "cloudflare"` form.
- Repo-wide grep confirms no other config/template ships the plural field.

## Test

`tests/docker/webkite-config-parse.test.ts` (vitest): asserts no active `providers =` field survives comment-stripping and every `[[render.routes]]` block uses singular `provider`. Verified 2 failed on the pre-fix file, 2 passed post-fix. `npm run lint` clean.

Closes #3030

🤖 Generated with [Claude Code](https://claude.com/claude-code)