### PR TITLE
fix(gateway): sweep turn-typing loops on bridge-death disconnect (#2650)

### DIFF
--- a/telegram-plugin/gateway/disconnect-flush.ts
+++ b/telegram-plugin/gateway/disconnect-flush.ts
@@ -57,6 +57,15 @@ export interface DisconnectFlushDeps<Ctrl extends { finalize: (reason?: 'done' |
   /** Progress driver — disposed with `preservePending: true` for sub-agent JTBDs (#393). */
   disposeProgressDriver: () => void
 
+  /** #2650: stop EVERY live turn-typing loop (the per-(chat,thread)
+   *  `setInterval` started by `turn-typing-loop.ts`). The bridge just died
+   *  mid-turn; its turn-long `typing…` loop is never stopped by the canonical
+   *  turn-end (which will never arrive), so a stale "typing…" shows to the user
+   *  until the next turn's `start()` self-heals it. Wire to
+   *  `() => turnTypingLoop.stopAll()`. Called ONLY on a registered-agent
+   *  disconnect — an anonymous one-shot never owned a turn-typing loop. */
+  stopTurnTypingLoops: () => void
+
   /** Optional: called when the registered-agent disconnect found dangling
    *  `activeTurnStartedAt` entries the controller loop did not clear (i.e.
    *  `finalize()` already ran on the canonical reply path, leaving
@@ -92,6 +101,7 @@ export function flushOnAgentDisconnect<
     activeDraftStreams,
     clearActiveReactions,
     disposeProgressDriver,
+    stopTurnTypingLoops,
     onDanglingTurnsSwept,
     log,
   } = deps
@@ -180,6 +190,15 @@ export function flushOnAgentDisconnect<
   // heartbeat continues for preserved chats so elapsed-time ticks and the
   // deferred-completion-timeout path remain active. Fix for #393.
   disposeProgressDriver()
+
+  // #2650: sweep the turn-typing loops. The bridge died mid-turn, so the
+  // canonical turn-end that would normally call `turnTypingLoop.stop` will
+  // never arrive — every live per-(chat,thread) `typing…` interval is now
+  // orphaned and would show a stale "typing…" to the user until the next
+  // turn's `start()` self-heals it. This is gated to a real registered-agent
+  // disconnect (we returned early above for anonymous clients), so an
+  // anonymous one-shot never triggers the sweep.
+  stopTurnTypingLoops()
 
   // Finalize any open draft streams so they don't hang mid-edit.
   for (const [key, stream] of activeDraftStreams.entries()) {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -9480,6 +9480,11 @@ const ipcServer: IpcServer = createIpcServer({
         // scripts/check-plugin-references.mjs (TS2722).
         progressDriver?.dispose?.({ preservePending: true })
       },
+      // #2650: the bridge died mid-turn — its turn-long `typing…` loop never
+      // hits the canonical turn-end stop, leaving a stale "typing…" until the
+      // next turn. Sweep every live loop here (gated to registered-agent
+      // disconnect inside flushOnAgentDisconnect).
+      stopTurnTypingLoops: () => turnTypingLoop.stopAll(),
       // When dangling activeTurnStartedAt keys were swept (setDone raced
       // disconnect), the module-scope `currentTurn` may also point at the
       // dead bridge's turn. Null it so the next inbound starts a fresh

--- a/telegram-plugin/tests/busy-key-reaper.test.ts
+++ b/telegram-plugin/tests/busy-key-reaper.test.ts
@@ -64,6 +64,7 @@ function flushDeps(claudeBusyKeys: Set<string>, claudeBusyKeySince: Map<string, 
     activeDraftStreams: new Map(),
     clearActiveReactions: vi.fn(),
     disposeProgressDriver: vi.fn(),
+    stopTurnTypingLoops: vi.fn(), // #2650: required dep — turn-typing sweep on bridge death
     log: vi.fn(),
   }
 }

--- a/telegram-plugin/tests/gateway-disconnect-flush.test.ts
+++ b/telegram-plugin/tests/gateway-disconnect-flush.test.ts
@@ -36,6 +36,7 @@ function makeDeps(agentName: string | null) {
   const finalizeB = vi.fn(async () => {})
   const clearActiveReactions = vi.fn()
   const disposeProgressDriver = vi.fn()
+  const stopTurnTypingLoops = vi.fn()
   const log = vi.fn()
 
   const activeStatusReactions = new Map<string, FakeCtrl>([
@@ -72,7 +73,7 @@ function makeDeps(agentName: string | null) {
   // carry or clear it.
 
   return {
-    spies: { setDoneA, setDoneB, finalizeA, finalizeB, clearActiveReactions, disposeProgressDriver, log },
+    spies: { setDoneA, setDoneB, finalizeA, finalizeB, clearActiveReactions, disposeProgressDriver, stopTurnTypingLoops, log },
     deps: {
       agentName,
       activeStatusReactions,
@@ -83,6 +84,7 @@ function makeDeps(agentName: string | null) {
       activeDraftStreams,
       clearActiveReactions,
       disposeProgressDriver,
+      stopTurnTypingLoops,
       log,
     },
   }
@@ -121,6 +123,16 @@ describe('flushOnAgentDisconnect — anonymous clients (the regression scenario)
     expect(spies.setDoneA).toHaveBeenCalledTimes(0)
     expect(spies.setDoneB).toHaveBeenCalledTimes(0)
   })
+
+  it('#2650: does NOT sweep the turn-typing loops for anonymous disconnects', () => {
+    // An anonymous one-shot IPC client (recall.py, etc.) never owned a
+    // turn-typing loop. The sweep MUST be gated by the agentName-null
+    // early-return so a constant stream of anonymous disconnects can't
+    // kill a live agent's typing indicator.
+    const { spies, deps } = makeDeps(null)
+    flushOnAgentDisconnect(deps)
+    expect(spies.stopTurnTypingLoops).not.toHaveBeenCalled()
+  })
 })
 
 describe('flushOnAgentDisconnect — registered agent disconnects (existing behavior preserved)', () => {
@@ -142,6 +154,15 @@ describe('flushOnAgentDisconnect — registered agent disconnects (existing beha
     flushOnAgentDisconnect(deps)
     expect(spies.disposeProgressDriver).toHaveBeenCalledTimes(1)
     expect(spies.clearActiveReactions).toHaveBeenCalledTimes(1)
+  })
+
+  it('#2650: sweeps the turn-typing loops on a real agent disconnect', () => {
+    // The bridge died mid-turn — the canonical turn-end that would stop the
+    // per-(chat,thread) `typing…` interval will never arrive, so the flush
+    // must sweep every live loop or a stale "typing…" shows until next turn.
+    const { spies, deps } = makeDeps('clerk')
+    flushOnAgentDisconnect(deps)
+    expect(spies.stopTurnTypingLoops).toHaveBeenCalledTimes(1)
   })
 
   it('finalizes only non-final draft streams and clears the maps', () => {
@@ -172,6 +193,7 @@ describe('flushOnAgentDisconnect — dangling-turn sweep (2026-05-23 wedge fix)'
     const onDanglingTurnsSwept = vi.fn()
     const clearActiveReactions = vi.fn()
     const disposeProgressDriver = vi.fn()
+    const stopTurnTypingLoops = vi.fn()
     const log = vi.fn()
     const deps = {
       agentName: 'clerk',
@@ -185,6 +207,7 @@ describe('flushOnAgentDisconnect — dangling-turn sweep (2026-05-23 wedge fix)'
       activeDraftStreams: new Map<string, FakeStream>(),
       clearActiveReactions,
       disposeProgressDriver,
+      stopTurnTypingLoops,
       onDanglingTurnsSwept,
       log,
     }
@@ -243,6 +266,7 @@ describe('flushOnAgentDisconnect — dangling-turn sweep (2026-05-23 wedge fix)'
       activeDraftStreams: new Map<string, FakeStream>(),
       clearActiveReactions: vi.fn(),
       disposeProgressDriver: vi.fn(),
+      stopTurnTypingLoops: vi.fn(),
       onDanglingTurnsSwept,
       log: vi.fn(),
     }
@@ -278,6 +302,7 @@ describe('flushOnAgentDisconnect — dangling-turn sweep (2026-05-23 wedge fix)'
       activeDraftStreams: new Map<string, FakeStream>(),
       clearActiveReactions: vi.fn(),
       disposeProgressDriver: vi.fn(),
+      stopTurnTypingLoops: vi.fn(),
       onDanglingTurnsSwept,
       log,
     }
@@ -310,6 +335,7 @@ describe('flushOnAgentDisconnect — dangling-turn sweep (2026-05-23 wedge fix)'
       activeDraftStreams: new Map<string, FakeStream>(),
       clearActiveReactions: vi.fn(),
       disposeProgressDriver: vi.fn(),
+      stopTurnTypingLoops: vi.fn(),
     }
     // Singular form.
     flushOnAgentDisconnect({
@@ -348,6 +374,7 @@ describe('flushOnAgentDisconnect — dangling-turn sweep (2026-05-23 wedge fix)'
       activeDraftStreams: new Map<string, FakeStream>(),
       clearActiveReactions: vi.fn(),
       disposeProgressDriver: vi.fn(),
+      stopTurnTypingLoops: vi.fn(),
       log,
     })
     expect(log.mock.calls.some((c: unknown[]) =>
@@ -368,6 +395,7 @@ describe('flushOnAgentDisconnect — dangling-turn sweep (2026-05-23 wedge fix)'
       activeDraftStreams: new Map<string, FakeStream>(),
       clearActiveReactions: vi.fn(),
       disposeProgressDriver: vi.fn(),
+      stopTurnTypingLoops: vi.fn(),
       // onDanglingTurnsSwept intentionally omitted.
       log: vi.fn(),
     }


### PR DESCRIPTION
## Root cause

When the IPC bridge dies mid-turn, `onClientDisconnected → flushOnAgentDisconnect` (telegram-plugin/gateway/disconnect-flush.ts) nulls `currentTurn` but never stops the per-(chat,thread) turn-typing `setInterval` started by `turn-typing-loop.ts`. The canonical turn-end — the only stop site for that loop — never arrives after a bridge death, so a stale "typing…" shows to the user until the next turn's `start()` self-heals it. `turnTypingLoop.stopAll()` already existed (used at gateway shutdown) but was not invoked on the disconnect flush.

## Fix

- `disconnect-flush.ts`: add a required `stopTurnTypingLoops: () => void` dep to `DisconnectFlushDeps`; call it in the flush path after `disposeProgressDriver()`.
- `gateway.ts` (flushOnAgentDisconnect callsite): wire `stopTurnTypingLoops: () => turnTypingLoop.stopAll()`.

The dep is required (not optional) so the wiring is enforced at the type level.

## Gating rationale

The sweep sits below the existing `agentName == null` early-return, matching the file's documented policy: anonymous one-shot IPC clients (recall.py's `update_placeholder` handshake) disconnect constantly with `agentName=null` and never owned a turn-typing loop. Only a client that completed `register` represents a real bridge death whose turn loop is orphaned — so only those trigger the sweep.

## Why `typingIntervals` (plain `startTypingLoop`) is untouched

Those intervals live in the shared `typingIntervals` map and are mid-turn-reply / tool-use scoped — the reply handler and typing wrapper stop them via `finally` blocks, so they self-clear and do not leak on bridge death. The dedicated turn loop is deliberately immune to those stops (separate map) and only cleared at the canonical turn-end, which is exactly why it needs this disconnect-time sweep.

## Tests

Extended `telegram-plugin/tests/gateway-disconnect-flush.test.ts`:
- registered-agent disconnect → `stopTurnTypingLoops` called exactly once
- anonymous disconnect → `stopTurnTypingLoops` NOT called

Scoped vitest: 14/14 pass. `npm run lint` clean (tsc + all 8 guard scripts).

Closes #2650

🤖 Generated with [Claude Code](https://claude.com/claude-code)