### PR TITLE
fix(scaffold): allowlist Workflow tool alongside Task/Agent (#2464)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1946,6 +1946,7 @@ const ALL_BUILTIN_TOOLS = [
   "TodoWrite",
   "Task",
   "Agent",
+  "Workflow",
   "ExitPlanMode",
 ];
 

--- a/telegram-plugin/permission-rule.ts
+++ b/telegram-plugin/permission-rule.ts
@@ -62,6 +62,7 @@ const BROAD_ONLY_TOOLS = new Set([
   "WebSearch",
   "Task",
   "Agent",
+  "Workflow",
   "TodoWrite",
   "ExitPlanMode",
 ]);

--- a/telegram-plugin/permission-title.ts
+++ b/telegram-plugin/permission-title.ts
@@ -212,6 +212,7 @@ export function naturalAction(
     }
     case "Task":
     case "Agent":
+    case "Workflow":
       return "dispatch a sub-agent";
     case "TodoWrite":
       return "update its task list";

--- a/tests/scaffold.all-wildcard-keeps-explicit.test.ts
+++ b/tests/scaffold.all-wildcard-keeps-explicit.test.ts
@@ -96,6 +96,12 @@ describe("scaffold: tools.allow [all] keeps explicit additions (klanker re-ask f
 
     expect(allow).toContain("Bash");
     expect(allow).toContain("Edit");
+    // Sub-agent / orchestration built-ins are auto-allowlisted for parity —
+    // Workflow must be present alongside Task/Agent so its launches don't
+    // raise an operator approval prompt (#2464).
+    expect(allow).toContain("Task");
+    expect(allow).toContain("Agent");
+    expect(allow).toContain("Workflow");
     expect(allow).not.toContain("all");
     // acceptEdits is the switchroom built-in default (now decoupled from the
     // wildcard) — an [all] agent with no override still gets it.


### PR DESCRIPTION
## Summary

Add `"Workflow"` to `ALL_BUILTIN_TOOLS` in `src/agents/scaffold.ts` so a generated agent's `settings.json` `permissions.allow` auto-grants the `Workflow` tool, giving it parity with its sibling orchestration tools `Task`/`Agent`. Also adds `Workflow` to the two telegram-plugin permission maps that carry Task/Agent parity.

## Why

With `defaultMode: "acceptEdits"`, any non-edit, non-allowlisted tool falls through to a permission prompt — an operator approval card. `Workflow` was absent from `ALL_BUILTIN_TOOLS` while `Task`/`Agent` were present, so every `Workflow` launch prompted for operator approval (observed live in #2464). Multi-agent orchestration is a standard agent capability that shouldn't need per-launch approval.

The `Workflow` tool name is corroborated in-repo by `telegram-plugin/subagent-watcher.ts:2382` ("Workflow sub-agents (spawned by the Workflow tool)") and its dedicated test `subagent-watcher-workflow-visibility.test.ts`.

## Files changed

- `src/agents/scaffold.ts` — add `"Workflow"` to `ALL_BUILTIN_TOOLS` (adjacent to `Task`/`Agent`). **The load-bearing fix.**
- `telegram-plugin/permission-rule.ts` — add `"Workflow"` to `BROAD_ONLY_TOOLS` (whole-tool grant scope, Task/Agent parity).
- `telegram-plugin/permission-title.ts` — add `case "Workflow"` to the `Task`/`Agent` → "dispatch a sub-agent" title, so any prompt in a restricted-allow agent reads correctly.
- `tests/scaffold.all-wildcard-keeps-explicit.test.ts` — extend the generated-output assertion to require `Workflow` (plus `Task`/`Agent`) in `permissions.allow`.

## Test plan

- `vitest run tests/scaffold.all-wildcard-keeps-explicit.test.ts telegram-plugin/tests/permission-rule.test.ts telegram-plugin/tests/permission-title.test.ts` — 104 passed. The scaffold test asserts the generated `settings.json` `permissions.allow` contains `Workflow`, i.e. the real output, not just the constant.
- `npm run lint` — clean (tsc + all 8 guard scripts).

## Risk

Low. Additive one-item change to an allowlist; broadens what an agent may invoke without a prompt. `Workflow` is an orchestration sibling of already-allowlisted `Task`/`Agent`, so no new escalation surface. Running agents pick it up on reconcile + restart.

Job spec: `reference/jobs/approve-what-my-agent-can-touch.md`.

Closes #2464

🤖 Generated with [Claude Code](https://claude.com/claude-code)