### PR TITLE
fix(test): scrub ambient SWITCHROOM_RICH_RENDER in vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,12 +15,24 @@ import { defineConfig } from "vitest/config";
 // with these set legitimately for production tools won't notice — the
 // host's actual processes read the env independently from their own
 // systemd / shell context.
+//
+// SWITCHROOM_RICH_RENDER (#3014) is the same hazard: agents opt into the
+// Bot API rich renderer per-agent via their `env:` block, so `npm test`
+// run inside such a container inherits `SWITCHROOM_RICH_RENDER=1`. That
+// flips `renderOutboundChunks`' default-OFF passthrough ON, round-trips
+// markdown through mdast (`_italic_` → `*italic*`), and breaks the four
+// stream-reply / status-accent tests that pin the raw flag-OFF body —
+// green in CI (flag unset) but red in a flag-on agent container. Scrub it
+// so the default-OFF path is deterministic; the flag-ON tests
+// (render-outbound-chunks, rich-render, stream-controller-chunk-cap) set
+// it explicitly per-case and delete it in cleanup.
 for (const k of [
   "SWITCHROOM_RUNTIME",
   "SWITCHROOM_CONTAINER",
   "SWITCHROOM_AGENT_NAME",
   "SWITCHROOM_VAULT_BROKER_SOCK",
   "SWITCHROOM_KERNEL_SOCKET",
+  "SWITCHROOM_RICH_RENDER",
 ]) {
   delete process.env[k];
 }


### PR DESCRIPTION
## Summary
Adds `SWITCHROOM_RICH_RENDER` to the existing container-env scrub list at the top of `vitest.config.ts`, fixing the 4 stream-reply/status-accent vitest failures seen on pristine main inside rich-render agent containers.

Closes #3014

## Root cause
Environment leak, not a code regression and not stale pins. The 4 tests pin the flag-OFF passthrough of `renderOutboundChunks` (`telegram-plugin/render/rich-render.ts:113-121`), which returns raw markdown untouched by default. Agents that opt into the Bot API rich renderer export `SWITCHROOM_RICH_RENDER=1` via their `env:` block; `vitest` run inside such a container inherits it, flipping the default-OFF path ON and routing bodies through `parse → renderSafe` (mdast). The mdast round-trip re-serializes emphasis with its default marker: `_there_` → `*there*` — the exact assertion drift.

**CI-green evidence:** `gh pr checks 3053` (the release commit that is current main, 8fbd9574) shows `vitest pass` — CI doesn't set the flag, so the flag-OFF pins are correct and authoritative. Bucket 3 per CLAUDE.md classification (environment-only artifact).

## Why harness, not normalizer/pins
- The renderer's flag-ON behavior is deliberate (#2930) and the `_` → `*` re-serialization is semantically equivalent GFM — nothing to fix there.
- The pins correctly assert the default-OFF contract — updating them would encode the leak.
- `vitest.config.ts` already scrubs the same class of container-injected `SWITCHROOM_*` env for identical determinism reasons; this extends the established mechanism.
- Flag-ON test suites (`render-outbound-chunks`, `rich-render`, `stream-controller-chunk-cap`) set the var explicitly per-case with cleanup — unaffected.

## Test plan
- Scoped vitest with `SWITCHROOM_RICH_RENDER=1` still exported in the shell: `stream-reply-handler`, `status-accent`, `single-mode-stream-reply` + the two flag-ON suites — **76 passed / 0 failed** (previously 4 failed / 64 passed).
- `npm run lint` clean (tsc + all 8 guard scripts).

## Risk
Minimal — test-infra only, no runtime code touched. Production flag reads are unaffected (agents read the env in their own processes, not through vitest).

## Job spec
Test-infrastructure determinism fix; supports `reference/vision.md` standing-team outcome (agents must get identical test verdicts in-container and in CI — the config header documents this contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)