### PR TITLE
feat(hindsight): redirect direct mental-model writes to mental_model_propose

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -234,6 +234,16 @@ RUN chmod 0755 /opt/switchroom/hooks/notion-write-pretool.mjs
 COPY dist/cli/skill-validate-pretool.mjs /opt/switchroom/hooks/skill-validate-pretool.mjs
 RUN chmod 0755 /opt/switchroom/hooks/skill-validate-pretool.mjs
 
+# Hindsight mental-model write redirect (#2974). A PreToolUse hook scoped
+# to `^mcp__hindsight__` that DENIES the four mental-model WRITE tools with
+# an instructive message pointing at mcp__switchroom-telegram__mental_model_propose,
+# so a direct call self-corrects in the same turn instead of wedging on a
+# permission prompt. Read tools pass through. Not in the security-plugin:
+# it's a routing nudge toward the sanctioned approval path, not a
+# load-bearing safety control (the least-privilege gate in scaffold.ts is).
+COPY dist/cli/hindsight-mental-model-pretool.mjs /opt/switchroom/hooks/hindsight-mental-model-pretool.mjs
+RUN chmod 0755 /opt/switchroom/hooks/hindsight-mental-model-pretool.mjs
+
 # Agent self-improvement Stop gate (RFC reference/rfcs/agent-self-improvement.md
 # slice 1). A cheap deterministic per-turn triage; on a learning signal
 # it injects a forked review turn via the gateway socket (inject_inbound,

--- a/profiles/coding/CLAUDE.md.hbs
+++ b/profiles/coding/CLAUDE.md.hbs
@@ -43,7 +43,7 @@ Claude Code's file-based auto-memory is disabled. Use **Hindsight** MCP tools:
 - `mcp__hindsight__recall` — search past memories. Auto-fires on every message.
 - `mcp__hindsight__retain` — store important facts. Auto-retains every turn (chunked, a small ~3-turn window each time), so it's prompt and cheap.
 - `mcp__hindsight__reflect` — synthesize across memories for complex queries.
-- `mcp__hindsight__create_mental_model` — maintain semantic summaries (e.g. "codebase architecture").
+- `mcp__switchroom-telegram__mental_model_propose` — propose a mental model: a standing semantic summary refreshed over the bank (e.g. "codebase architecture"). Mental-model writes are operator-approved: this posts an approval card and persists on approval. Don't call `mcp__hindsight__create_mental_model`/`update_mental_model` directly (they're denied and redirected here).
 
 Save proactively: architecture decisions, codebase patterns, conventions, known issues, user preferences. Your session may be compacted at any time — only Hindsight memories survive.
 

--- a/profiles/default/CLAUDE.md.hbs
+++ b/profiles/default/CLAUDE.md.hbs
@@ -45,14 +45,14 @@ Hindsight is a memory bank with semantic search, knowledge graph, entity resolut
 ### Mental Models
 A mental model is a pre-computed semantic summary backed by reflection over the bank — a way to maintain a standing answer to a recurring question, semantically populated and refreshed.
 
-- `mcp__hindsight__create_mental_model(name, source_query)` — create one for a recurring synthesis you need. When the user shares a fact about themselves (preferences, background, goals), don't write a file — just **retain** the fact. You do NOT need to build or maintain a per-agent "user profile": who the user is lives in dedicated per-user profile banks that the operator curates out-of-band, and recall surfaces it automatically.
+Creating, updating, or refreshing a mental model is **operator-approved** — don't call `create_mental_model` / `update_mental_model` / `refresh_mental_model` / `delete_mental_model` directly (a direct call is denied and redirected). Use `mcp__switchroom-telegram__mental_model_propose(name, source_query)` when you need a recurring synthesis: it posts an approval card and persists the model on approval. When the user shares a fact about themselves (preferences, background, goals), don't write a file and don't propose a model — just **retain** the fact. You do NOT need to build or maintain a per-agent "user profile": who the user is lives in dedicated per-user profile banks that the operator curates out-of-band, and recall surfaces it automatically.
 
 ### Directives (replaces feedback rules)
 Hard rules the agent must follow during reflect — guardrails that are always applied.
 
 - `mcp__hindsight__create_directive(text)` — e.g., `create_directive("Always prefer TypeScript over JavaScript for this user's projects")`. When the user gives you a correction or "always do X" rule, create a directive instead of writing a feedback `.md` file.
 
-(Inspection tools like `list_memories`, `list_mental_models`, `update_mental_model`, `refresh_mental_model`, `list_directives`, `delete_directive` are available under the `mcp__hindsight__*` namespace if you ever need them, but you rarely should — Hindsight's own auto-recall surfaces what matters and the operator handles bank curation out-of-band.)
+(Read-only inspection tools like `list_memories`, `list_mental_models`, `get_mental_model`, `list_directives` are available under the `mcp__hindsight__*` namespace if you ever need them, but you rarely should — Hindsight's own auto-recall surfaces what matters and the operator handles bank curation out-of-band. The mental-model WRITE tools — `create`/`update`/`refresh`/`delete_mental_model` — are gated: propose via `mcp__switchroom-telegram__mental_model_propose`, don't call them directly.)
 
 ### What to retain — and what NOT to retain
 

--- a/profiles/executive-assistant/CLAUDE.md.hbs
+++ b/profiles/executive-assistant/CLAUDE.md.hbs
@@ -41,7 +41,7 @@ Claude Code's file-based auto-memory is disabled. Use **Hindsight** MCP tools:
 
 - `mcp__hindsight__recall` — search past memories. Auto-fires every message.
 - `mcp__hindsight__retain` — store important facts. Auto-retains every turn (chunked, a small ~3-turn window each time), so it's prompt and cheap.
-- `mcp__hindsight__create_mental_model` — maintain models for "contacts", "active projects", "user preferences".
+- `mcp__switchroom-telegram__mental_model_propose` — propose a mental model: a standing semantic summary refreshed over the bank (e.g. "contacts", "active projects", "user preferences"). Mental-model writes are operator-approved: this posts an approval card and persists on approval. Don't call `mcp__hindsight__create_mental_model`/`update_mental_model` directly (they're denied and redirected here).
 
 Save proactively: contacts and their roles, scheduling preferences, project status, decisions with rationale, communication templates. Only Hindsight memories survive compaction.
 

--- a/profiles/health-coach/CLAUDE.md.hbs
+++ b/profiles/health-coach/CLAUDE.md.hbs
@@ -35,7 +35,7 @@ Claude Code's file-based auto-memory is disabled. Use **Hindsight** MCP tools:
 
 - `mcp__hindsight__recall` — search past memories. Auto-fires on every message.
 - `mcp__hindsight__retain` — store important facts. Auto-retains every turn (chunked, a small ~3-turn window each time), so it's prompt and cheap.
-- `mcp__hindsight__create_mental_model` — maintain a "fitness profile" mental model.
+- `mcp__switchroom-telegram__mental_model_propose` — propose a mental model (e.g. a "fitness profile" — a standing semantic summary refreshed over the bank). Mental-model writes are operator-approved: this posts an approval card and persists on approval. Don't call `mcp__hindsight__create_mental_model`/`update_mental_model` directly (they're denied and redirected here).
 
 Save proactively: workout logs, goals, PRs, preferences, patterns (e.g. "poor sleep on Sundays"), injuries/limitations. Only Hindsight memories survive session compaction.
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -291,6 +291,23 @@ if (skillHookEscape.changed) {
   console.log(`[build] ASCII-escaped ${skillHookEscape.nonAsciiCount} non-ASCII code units in dist/cli/skill-validate-pretool.mjs`);
 }
 
+// Bundle the hindsight-mental-model-pretool hook — #2974. Same pattern:
+// a self-contained .mjs the agent container runs via node from the
+// bundled-hooks path. It has no src/ imports (a pure tool_name gate), but
+// we bundle it for consistency with the other pretool hooks and so it
+// ships to /opt/switchroom/hooks/ via Dockerfile.agent.
+console.log("[build] bundling src/cli/hindsight-mental-model-pretool.ts -> dist/cli/hindsight-mental-model-pretool.mjs");
+execSync(
+  `bun build ${JSON.stringify(resolve(root, "src/cli/hindsight-mental-model-pretool.ts"))} --outfile ${JSON.stringify(resolve(outDir, "hindsight-mental-model-pretool.mjs"))} --target node`,
+  { stdio: "inherit", cwd: root }
+);
+const mmHookOutFile = resolve(outDir, "hindsight-mental-model-pretool.mjs");
+chmodSync(mmHookOutFile, 0o755);
+const mmHookEscape = escapeBundleNonAscii(mmHookOutFile);
+if (mmHookEscape.changed) {
+  console.log(`[build] ASCII-escaped ${mmHookEscape.nonAsciiCount} non-ASCII code units in dist/cli/hindsight-mental-model-pretool.mjs`);
+}
+
 // Bundle the self-improve-stop hook — RFC reference/rfcs/agent-self-improvement.md
 // slice 1. Turn-end GATE: a self-contained .mjs the agent container runs
 // via node from the bundled-hooks path. It imports the src/self-improve/*

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -5109,6 +5109,33 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
           ],
         },
         {
+          // #2974 — redirect direct hindsight mental-model WRITE calls to
+          // the sanctioned mcp__switchroom-telegram__mental_model_propose
+          // path. The four write tools (HINDSIGHT_MENTAL_MODEL_WRITE_TOOLS)
+          // are un-preapproved by design (#2911), so a direct call would
+          // otherwise fall through to a TUI permission prompt that wedges
+          // the turn. This hook DENIES them instantly with an instructive
+          // message so the agent self-corrects in the same turn; every
+          // read tool (get_mental_model, list_mental_models, recall, …)
+          // passes through. Matcher scoped to `^mcp__hindsight__` so the
+          // hook only spends a stdin parse on hindsight tools.
+          //
+          // DOCKER_BUNDLED_HOOKS_PATH (not DOCKER_HOOKS_PATH): bundled via
+          // scripts/build.mjs from src/cli/hindsight-mental-model-pretool.ts,
+          // mirroring skill-validate-pretool.
+          matcher: "^mcp__hindsight__",
+          hooks: [
+            {
+              type: "command",
+              command: wrap(
+                "hook:hindsight-mental-model-pretool",
+                `node "${join(DOCKER_BUNDLED_HOOKS_PATH, "hindsight-mental-model-pretool.mjs")}"`,
+              ),
+              timeout: 10,
+            },
+          ],
+        },
+        {
           // Agent self-improvement APPLY-GUARD — RFC
           // reference/rfcs/agent-self-improvement.md slice 2. The
           // DETERMINISTIC T1 gate: when a self-improve review is pending

--- a/src/cli/hindsight-mental-model-pretool.ts
+++ b/src/cli/hindsight-mental-model-pretool.ts
@@ -1,0 +1,81 @@
+/**
+ * PreToolUse hook — #2974: redirect direct hindsight mental-model writes.
+ *
+ * The four hindsight mental-model WRITE tools
+ * (`create_mental_model` / `update_mental_model` / `delete_mental_model` /
+ * `refresh_mental_model`) are deliberately un-preapproved (#2911
+ * least-privilege — see HINDSIGHT_MENTAL_MODEL_WRITE_TOOLS in
+ * src/agents/scaffold.ts). A direct call therefore falls through to a TUI
+ * permission prompt that wedges the turn (and, until the watchdog card-race
+ * fix lands, gets auto-denied). The sanctioned path is
+ * `mcp__switchroom-telegram__mental_model_propose`, which posts an approval
+ * card and persists on approval.
+ *
+ * This hook makes that redirect MECHANICAL: it DENIES exactly those four
+ * write tools with a deterministic, instructive message so the agent
+ * self-corrects in the same turn — no prompt renders, no watchdog fires.
+ * Every other tool (all hindsight READ tools — get_mental_model,
+ * list_mental_models, recall, retain, reflect, … — and every non-hindsight
+ * tool) passes through untouched.
+ *
+ * Claude Code PreToolUse protocol (v1), mirrors skill-validate-pretool:
+ *   Input:  JSON on stdin — { session_id, tool_name, tool_input, ... }
+ *   Output: exit 0 + empty stdout                       → allow.
+ *           exit 0 + {"decision":"block","reason":...}  → block (deny).
+ *
+ * Fail-OPEN on any stdin parse error / unknown shape: a redirect hook must
+ * never be the reason a legitimate tool call fails. The only non-allow
+ * outcome is the explicit block on the four write tools.
+ */
+
+import { readFileSync } from "node:fs";
+
+/** The four gated hindsight mental-model write tools. Kept in lockstep with
+ *  HINDSIGHT_MENTAL_MODEL_WRITE_TOOLS in src/agents/scaffold.ts. */
+const MENTAL_MODEL_WRITE_TOOLS = new Set([
+  "mcp__hindsight__create_mental_model",
+  "mcp__hindsight__update_mental_model",
+  "mcp__hindsight__delete_mental_model",
+  "mcp__hindsight__refresh_mental_model",
+]);
+
+const DENY_MESSAGE =
+  "Mental-model writes are operator-approved. Use " +
+  "`mcp__switchroom-telegram__mental_model_propose` instead — it posts an " +
+  "approval card and persists on approval.";
+
+function readStdin(): string {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function allow(): never {
+  process.exit(0);
+}
+
+function block(reason: string): never {
+  process.stdout.write(JSON.stringify({ decision: "block", reason }));
+  process.exit(0);
+}
+
+function main(): void {
+  const raw = readStdin().trim();
+  if (!raw) allow();
+
+  let event: { tool_name?: unknown };
+  try {
+    event = JSON.parse(raw);
+  } catch {
+    allow(); // Claude protocol error — not ours to police.
+  }
+
+  const toolName = typeof event.tool_name === "string" ? event.tool_name : "";
+  if (MENTAL_MODEL_WRITE_TOOLS.has(toolName)) block(DENY_MESSAGE);
+
+  allow();
+}
+
+main();

--- a/tests/hindsight-mental-model-pretool.test.ts
+++ b/tests/hindsight-mental-model-pretool.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+// The hook is a .ts that bundles to .mjs at build time; drive it through
+// `bun` against source so the test doesn't depend on build order (mirrors
+// skill-validate-pretool.test.ts). Skip cleanly if bun absent.
+const bunOk = spawnSync("which", ["bun"], { encoding: "utf-8" }).status === 0;
+const HOOK = join(
+  process.cwd(),
+  "src",
+  "cli",
+  "hindsight-mental-model-pretool.ts",
+);
+
+const DENY_MESSAGE =
+  "Mental-model writes are operator-approved. Use " +
+  "`mcp__switchroom-telegram__mental_model_propose` instead — it posts an " +
+  "approval card and persists on approval.";
+
+const WRITE_TOOLS = [
+  "mcp__hindsight__create_mental_model",
+  "mcp__hindsight__update_mental_model",
+  "mcp__hindsight__delete_mental_model",
+  "mcp__hindsight__refresh_mental_model",
+];
+
+function run(payload: unknown): {
+  status: number;
+  stdout: string;
+  stderr: string;
+} {
+  const r = spawnSync("bun", [HOOK], {
+    input: typeof payload === "string" ? payload : JSON.stringify(payload),
+    encoding: "utf-8",
+    timeout: 30000,
+  });
+  return {
+    status: r.status ?? 1,
+    stdout: (r.stdout ?? "").trim(),
+    stderr: r.stderr ?? "",
+  };
+}
+
+describe("hindsight-mental-model-pretool hook", () => {
+  it("DENIES each of the four write tools with the redirect message", () => {
+    if (!bunOk) return;
+    for (const tool of WRITE_TOOLS) {
+      const r = run({ tool_name: tool, tool_input: { name: "x" } });
+      expect(r.status).toBe(0);
+      const out = JSON.parse(r.stdout);
+      expect(out.decision).toBe("block");
+      expect(out.reason).toBe(DENY_MESSAGE);
+    }
+  });
+
+  it("ALLOWS hindsight read tools untouched", () => {
+    if (!bunOk) return;
+    for (const tool of [
+      "mcp__hindsight__get_mental_model",
+      "mcp__hindsight__list_mental_models",
+      "mcp__hindsight__recall",
+      "mcp__hindsight__retain",
+      "mcp__hindsight__reflect",
+      "mcp__hindsight__list_memories",
+    ]) {
+      const r = run({ tool_name: tool, tool_input: {} });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toBe("");
+    }
+  });
+
+  it("ALLOWS arbitrary non-hindsight tools untouched", () => {
+    if (!bunOk) return;
+    for (const tool of [
+      "Bash",
+      "Read",
+      "mcp__switchroom-telegram__mental_model_propose",
+      "mcp__switchroom-telegram__reply",
+      // A lookalike on a different server must NOT be caught (matcher
+      // scopes to hindsight in scaffold, but the hook itself is exact-match).
+      "mcp__other__create_mental_model",
+    ]) {
+      const r = run({ tool_name: tool, tool_input: { command: "ls" } });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toBe("");
+    }
+  });
+
+  it("fails open on empty / non-JSON / unknown-shape stdin", () => {
+    if (!bunOk) return;
+    for (const bad of ["", "not-json", "{}", '{"tool_name":123}']) {
+      const r = run(bad);
+      expect(r.status).toBe(0);
+      expect(r.stdout).toBe("");
+    }
+  });
+});

--- a/tests/reconcile-hooks-drift.test.ts
+++ b/tests/reconcile-hooks-drift.test.ts
@@ -142,6 +142,15 @@ describe("buildSettingsHooksBlock", () => {
       e.hooks.some(h => h.command.includes("self-improve-apply-guard-pretool.mjs")),
     );
     expect(applyGuardEntry?.matcher).toBe("^(Write|Edit|MultiEdit)$");
+
+    // #2974: the mental-model write redirect PreToolUse hook is registered
+    // and scoped to hindsight tools; it denies the four write tools and
+    // passes reads through.
+    expect(preCmds.some(c => c.includes("hindsight-mental-model-pretool.mjs"))).toBe(true);
+    const mmEntry = preHooks.find(e =>
+      e.hooks.some(h => h.command.includes("hindsight-mental-model-pretool.mjs")),
+    );
+    expect(mmEntry?.matcher).toBe("^mcp__hindsight__");
   });
 
   it("with user hooks declared merges them with switchroom-owned hooks", () => {

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -4347,6 +4347,41 @@ describe("secret-detect hook wiring", () => {
     expect(reaper!.async).toBe(true);
   });
 
+  it("wires hindsight-mental-model-pretool.mjs scoped to ^mcp__hindsight__ (#2974)", () => {
+    const agentConfig = makeAgentConfig();
+    const result = scaffoldAgent(
+      "sd-mm-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+      makeConfig("sd-mm-agent", agentConfig),
+    );
+    const settings = JSON.parse(
+      readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+    );
+    const pre = settings.hooks.PreToolUse as Array<{
+      matcher?: string;
+      hooks: Array<{ command: string; timeout?: number }>;
+    }>;
+    const entry = pre.find((e) =>
+      e.hooks.some((h) =>
+        h.command.includes("hindsight-mental-model-pretool.mjs"),
+      ),
+    );
+    expect(entry).toBeDefined();
+    // Scoped so the stdin parse cost only lands on hindsight tools.
+    expect(entry!.matcher).toBe("^mcp__hindsight__");
+    const hook = entry!.hooks.find((h) =>
+      h.command.includes("hindsight-mental-model-pretool.mjs"),
+    )!;
+    // Bundled hook path + node invocation, wrapped via run-hook.sh.
+    expect(hook.command).toMatch(/run-hook\.sh/);
+    expect(hook.command).toContain("node ");
+    expect(hook.command).toContain("/opt/switchroom/hooks/");
+    // Explicit short timeout — a pure tool_name gate never needs long.
+    expect(hook.timeout).toBe(10);
+  });
+
   it("preserves user-declared PreToolUse hooks alongside secret-guard", () => {
     const agentConfig = makeAgentConfig({
       hooks: { PreToolUse: [{ command: "/opt/audit.sh", timeout: 5 }] },


### PR DESCRIPTION
## Summary

Adds a PreToolUse hook `src/cli/hindsight-mental-model-pretool.ts` that DENIES the four gated hindsight mental-model WRITE tools (`create_mental_model`, `update_mental_model`, `delete_mental_model`, `refresh_mental_model`) with a deterministic, instructive message:

> Mental-model writes are operator-approved. Use `mcp__switchroom-telegram__mental_model_propose` instead — it posts an approval card and persists on approval.

Every other tool — all hindsight READ tools (`get_mental_model`, `list_mental_models`, `recall`, `retain`, `reflect`, …) and every non-hindsight tool — passes through untouched. The hook is registered in `scaffold.ts` (the actual settings.json PreToolUse wiring path — `settings.json.hbs` carries no PreToolUse hooks), matcher-scoped to `^mcp__hindsight__`, bundled via `build.mjs` and shipped to `/opt/switchroom/hooks/` by `Dockerfile.agent`, mirroring `skill-validate-pretool`.

Also rewrites the profile CLAUDE.md templates (`default`, `coding`, `health-coach`, `executive-assistant`) that previously instructed agents to call `create_mental_model` directly — they now recommend `mcp__switchroom-telegram__mental_model_propose`, keeping the explanation of what mental models are. `grep -r "create_mental_model" profiles/` now shows only don't-call-directly guidance.

## Why

The four write tools are deliberately un-preapproved (#2911 least-privilege). A direct call falls through to a TUI permission prompt that wedges the turn (and, until the watchdog card-race fix lands, gets auto-denied). Our own profile docs manufactured these prompts by telling agents to call the tools directly. This makes the redirect mechanical (hook deny is instant, agent self-corrects in-turn) and fixes the docs. Job spec: `reference/jobs/approve-what-my-agent-can-touch.md`.

## Test plan

- New unit test `tests/hindsight-mental-model-pretool.test.ts` (driven through `bun` against source, mirroring `skill-validate-pretool.test.ts`): denies each of the four write tools with the exact redirect message; allows hindsight read tools and arbitrary non-hindsight tools (including a lookalike `mcp__other__create_mental_model`); fails open on empty/non-JSON/unknown-shape stdin.
- `tests/scaffold.test.ts`: new assertion that the hook is registered with matcher `^mcp__hindsight__`, bundled path, node invocation, timeout 10.
- `tests/reconcile-hooks-drift.test.ts`: drift assertion that the hook is present with the hindsight matcher.
- Scoped run: `vitest run tests/hindsight-mental-model-pretool.test.ts tests/reconcile-hooks-drift.test.ts tests/scaffold.test.ts` → 223 passed.
- `npm run lint` → clean (tsc + all 8 guard scripts).
- Bundled `.mjs` smoke-tested: deny tool emits the block JSON, read tool emits nothing.
- Live test-harness verification (deploy + direct-call scenario) is deferred to the operator — no deploys from this batch.

## Risk

Low. The hook is a pure `tool_name` gate with no src/ imports, fail-open on any stdin error (a redirect hook must never fail a legitimate call). Only the four exact write-tool names are blocked; the `^mcp__hindsight__` matcher keeps the stdin-parse cost off non-hindsight tools. Docs-only changes otherwise.

Closes #2974

🤖 Generated with [Claude Code](https://claude.com/claude-code)