### PR TITLE
fix(gateway): retry rate-limited operator-approved mental-model persist (#2975 Stage 1)

### DIFF
--- a/telegram-plugin/gateway/callback-query-handlers.ts
+++ b/telegram-plugin/gateway/callback-query-handlers.ts
@@ -83,6 +83,7 @@ import { getAuthBrokerClient } from './auth-broker-client.js'
 import { chatKey } from './chat-key.js'
 import { tryHostdDispatch, hostdRequestId } from './hostd-dispatch.js'
 import type { HostdRequest } from '../../src/host-control/protocol.js'
+import type { OperatorEvent } from '../operator-events.js'
 import type { InboundMessage } from './ipc-protocol.js'
 import type { SweepableCardStore } from './approval-card-stores.js'
 import type { SweepableStore } from './pending-state-stores.js'
@@ -389,6 +390,13 @@ export interface CallbackQueryHandlersDeps {
   vaultKeyRegex: RegExp
   /** MENTAL_MODEL_PROPOSE_TTL_MS (config-driven approval-card lifetime). */
   mentalModelProposeTtlMs: number
+  /**
+   * Emit an operator-visible event through the gateway's single funnel
+   * (`emitGatewayOperatorEvent`: cooldown + record + broadcast). Used by the
+   * #2975 Stage-1 backstop to loudly surface an approved mental-model persist
+   * whose rate-window retry also failed.
+   */
+  emitOperatorEvent: (event: OperatorEvent) => void
 }
 
 // Freshness throttle for the /auth dashboard ↻ refresh button — one live
@@ -435,6 +443,7 @@ export function createCallbackQueryHandlers(deps: CallbackQueryHandlersDeps) {
     getAdminOnlyKeys,
     vaultKeyRegex: VAULT_KEY_REGEX,
     mentalModelProposeTtlMs: MENTAL_MODEL_PROPOSE_TTL_MS,
+    emitOperatorEvent,
   } = deps
   const bot = deps.bot as CallbackBotApi
   const lockedBot = deps.lockedBot as CallbackBotApi
@@ -1035,7 +1044,20 @@ async function handleMentalModelProposeCallback(ctx: Context, data: string): Pro
         return { state: 'error' as const, reason: 'hostd config-edit is not configured (host_control disabled or socket absent)' }
       }
       if (resp.result === 'completed') return { state: 'applied' as const }
-      if (resp.result === 'denied') return { state: 'denied' as const, reason: resp.error ?? 'operator/host denied the edit' }
+      if (resp.result === 'denied') {
+        // #2975 Stage 1 — a rate-limit denial carries a structured
+        // `fix.retry_after` (hostd server.ts ~2270-2280). Surface it as a
+        // distinct `rate_limited` state so the resolver schedules ONE retry
+        // at the window-open time instead of dropping the approved change.
+        const env = resp.error_envelope
+        if (env?.code === 'E_RATE_LIMITED' && env.fix?.kind === 'retry_after') {
+          const retryAtMs = Date.parse(env.fix.retry_at)
+          if (!Number.isNaN(retryAtMs)) {
+            return { state: 'rate_limited' as const, reason: resp.error ?? 'config_propose_edit rate limit exceeded', retryAtMs }
+          }
+        }
+        return { state: 'denied' as const, reason: resp.error ?? 'operator/host denied the edit' }
+      }
       return { state: 'error' as const, reason: resp.error ?? `hostd returned '${resp.result}'` }
     },
     // Ensure is delegated to reconcile: config_propose_edit's apply triggers a
@@ -1045,6 +1067,52 @@ async function handleMentalModelProposeCallback(ctx: Context, data: string): Pro
     // the agent's bank id + a reachable Hindsight endpoint from the gateway).
     injectInbound: (inbound: InboundMessage) => {
       deliverResumeSyntheticOrBuffer(pending.agent, inbound)
+    },
+    // #2975 Stage 1 — schedule EXACTLY ONE re-dispatch of a rate-limited but
+    // operator-approved persist. A bare setTimeout (bounded, single-shot; the
+    // resolver never re-schedules). Stage-1 caveat: this timer lives only in
+    // gateway memory, so a gateway restart before it fires LOSES the retry —
+    // acceptable for Stage 1 (Stage 2's hostd checkPreApproved bypass removes
+    // the collision). Clamp the delay to a signed-32-bit setTimeout ceiling so
+    // a far-future window doesn't overflow into an immediate fire.
+    scheduleRetry: (delayMs: number, fn: () => void | Promise<void>) => {
+      const clamped = Math.min(Math.max(0, delayMs), 2_147_483_647)
+      setTimeout(() => {
+        void (async () => {
+          try {
+            await fn()
+          } catch (err) {
+            process.stderr.write(
+              `telegram gateway: mental_model_propose retry threw: ${(err as Error).message}\n`,
+            )
+          }
+        })()
+      }, clamped)
+    },
+    editProposalCardRateWindow: (retryAtMs: number) => {
+      if (pending.card_message_id == null) return
+      const at = new Date(retryAtMs)
+      const hh = String(at.getHours()).padStart(2, '0')
+      const mm = String(at.getMinutes()).padStart(2, '0')
+      void ctx.api
+        .editMessageText(
+          pending.chat_id,
+          pending.card_message_id,
+          richMessage(
+            `⏳ _Approved — applying **${escapeHtmlForTg(pending.agent)}**'s mental model \`${pending.spec.name}\` at ${hh}:${mm} (config-edit rate window). It isn't lost; it'll persist automatically when the window opens._`,
+          ),
+          { reply_markup: { inline_keyboard: [] }, link_preview_options: { is_disabled: true } },
+        )
+        .catch(() => {})
+    },
+    notifyPersistFailed: (reason: string) => {
+      emitOperatorEvent({
+        kind: 'mental-model-persist-failed',
+        agent: pending.agent,
+        detail: `Mental model "${pending.spec.name}" — ${reason}`,
+        suggestedActions: [],
+        firstSeenAt: new Date(),
+      })
     },
     log: (m: string) => process.stderr.write(`telegram gateway: ${m}\n`),
   }
@@ -1087,6 +1155,13 @@ async function handleMentalModelProposeCallback(ctx: Context, data: string): Pro
     } catch (err) {
       process.stderr.write(`telegram gateway: mental_model_propose approve threw: ${(err as Error).message}\n`)
       result = { outcome: 'failed' as const, reason: (err as Error).message }
+    }
+    // #2975 Stage 1 — a rate-limited persist already edited the card to the
+    // "applying at HH:MM (rate window)" state and scheduled its own retry,
+    // which will resolve the turn via its own inbound. Leave that card intact;
+    // do NOT overwrite it with a success/failure label here.
+    if (result.outcome === 'scheduled_retry') {
+      return
     }
     if (pending.card_message_id != null) {
       const label =

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -23201,6 +23201,9 @@ const callbackQueryHandlers = createCallbackQueryHandlers({
   getAdminOnlyKeys: () => ADMIN_ONLY_KEYS,
   vaultKeyRegex: VAULT_KEY_REGEX,
   mentalModelProposeTtlMs: MENTAL_MODEL_PROPOSE_TTL_MS,
+  // #2975 Stage 1 — loud-failure funnel for a rate-window retry that also
+  // failed (cooldown + record + broadcast in one place).
+  emitOperatorEvent: emitGatewayOperatorEvent,
 })
 const {
   handleVaultRecentDenialCallback,

--- a/telegram-plugin/gateway/mental-model-propose-resolve.ts
+++ b/telegram-plugin/gateway/mental-model-propose-resolve.ts
@@ -46,6 +46,14 @@ export interface MentalModelPendingProposal {
 export type ConfigEditDispatchResult =
   | { state: "applied" }
   | { state: "denied"; reason: string }
+  /**
+   * hostd threw `E_RATE_LIMITED` (the agent's config_propose_edit bucket is
+   * exhausted). `retryAtMs` is the epoch-ms parsed from the structured
+   * `fix.retry_after` hostd emits — the moment the sliding window frees a
+   * slot. #2975 Stage 1 schedules exactly ONE re-dispatch at that time so an
+   * operator-APPROVED persist is never silently lost to the throttle.
+   */
+  | { state: "rate_limited"; reason: string; retryAtMs: number }
   | { state: "error"; reason: string };
 
 export interface ResolveDeps {
@@ -79,6 +87,33 @@ export interface ResolveDeps {
   ensureModel?: (spec: MentalModelProposeSpec) => Promise<void>;
   /** Deliver a synthetic inbound to wake the agent with the outcome. */
   injectInbound: (inbound: InboundMessage) => void;
+  /**
+   * #2975 Stage 1 — schedule EXACTLY ONE bounded re-dispatch of an
+   * operator-approved persist that hostd rate-limited (`E_RATE_LIMITED`).
+   * `delayMs` is the wait until hostd's `fix.retry_after` window opens; `fn`
+   * re-runs the persist ONCE (it never re-schedules — bounded, no loop).
+   * Injectable so tests drive it with a mocked clock. When absent, a rate-
+   * limited persist can't be retried and falls straight to the loud-failure
+   * path (no silent loss).
+   *
+   * Stage-1 caveat (documented, accepted): the timer lives only in gateway
+   * memory. A gateway restart between schedule and fire LOSES the retry —
+   * acceptable for Stage 1; Stage 2 (hostd `checkPreApproved` bypass) removes
+   * the rate-limit collision entirely so no retry is needed.
+   */
+  scheduleRetry?: (delayMs: number, fn: () => void | Promise<void>) => void;
+  /**
+   * #2975 Stage 1 — edit the operator's proposal card to the
+   * "approved — applying at HH:MM (rate window)" state so a rate-deferred
+   * (but approved) change is visibly not lost while the retry is pending.
+   */
+  editProposalCardRateWindow?: (retryAtMs: number) => void;
+  /**
+   * #2975 Stage 1 — loud, operator-visible failure (operator-events path)
+   * when the single scheduled retry ALSO fails, so an approved change is
+   * never silently dropped. Must not throw.
+   */
+  notifyPersistFailed?: (reason: string) => void;
   /** Injectable clock for deterministic tests. */
   now?: () => number;
   /** Injectable git binary for the diff subprocess (tests). */
@@ -90,7 +125,14 @@ export type ResolveOutcome =
   | { outcome: "applied" }
   | { outcome: "denied" }
   | { outcome: "rejected"; reason: string }
-  | { outcome: "failed"; reason: string };
+  | { outcome: "failed"; reason: string }
+  /**
+   * #2975 Stage 1 — the persist was rate-limited but the operator already
+   * approved, so exactly one re-dispatch is scheduled at `retryAtMs`. The
+   * proposal card was edited to the "applying at HH:MM" state; the agent's
+   * turn resolves later when the retry injects its own applied/failed inbound.
+   */
+  | { outcome: "scheduled_retry"; retryAtMs: number };
 
 /**
  * Resolve an operator's Approve / Deny decision on a mental-model proposal.
@@ -145,57 +187,123 @@ export async function resolveMentalModelProposal(
     return { outcome: "rejected", reason: built.detail };
   }
 
-  // Pre-register the single-tap correlation so hostd auto-approves the edit
-  // (operator already approved on this proposal card — no second card).
-  deps.registerPreApproval(pending.agent, built.diff);
-  let dispatch: ConfigEditDispatchResult;
-  try {
-    dispatch = await deps.dispatchConfigEdit({
-      agent: pending.agent,
-      diff: built.diff,
-      reason:
-        `Declare agent-proposed mental model "${pending.spec.name}"` +
-        (pending.reason ? ` — ${pending.reason}` : ""),
-    });
-  } catch (err) {
-    dispatch = { state: "error", reason: (err as Error).message };
-  } finally {
-    // Single-shot: drop the correlation whether or not hostd consumed it.
-    deps.clearPreApproval(pending.agent, built.diff);
-  }
+  const persistReason =
+    `Declare agent-proposed mental model "${pending.spec.name}"` +
+    (pending.reason ? ` — ${pending.reason}` : "");
+  const clock = deps.now ?? Date.now;
 
-  if (dispatch.state !== "applied") {
-    deps.log?.(
-      `mental_model_propose: config edit ${dispatch.state} for ${pending.agent} "${pending.spec.name}": ${dispatch.reason}`,
+  // ONE dispatch attempt. Atomically re-registers the single-tap correlation
+  // with the SAME diff bytes each call BEFORE dispatching — the register and
+  // dispatch MUST use identical bytes (forge-resistance contract, file header
+  // lines 54-63): hostd's config-approval callback auto-resolves only on an
+  // exact byte-match, so a rebuilt/whitespace-drifted diff would fail to
+  // auto-approve and post a SECOND operator card. Because the initial and the
+  // #2975 retry both re-run this closure over the same captured `built.diff`,
+  // they are byte-identical by construction.
+  const dispatchOnce = async (): Promise<ConfigEditDispatchResult> => {
+    deps.registerPreApproval(pending.agent, built.diff);
+    try {
+      return await deps.dispatchConfigEdit({
+        agent: pending.agent,
+        diff: built.diff,
+        reason: persistReason,
+      });
+    } catch (err) {
+      return { state: "error", reason: (err as Error).message };
+    } finally {
+      // Single-shot: drop the correlation whether or not hostd consumed it.
+      deps.clearPreApproval(pending.agent, built.diff);
+    }
+  };
+
+  // Applied — belt-and-suspenders ensure (reconcile already ensures via #2874;
+  // this makes the model available without waiting for the restart). Never let
+  // an ensure failure flip a successful declaration into a "failed" inbound —
+  // the model IS declared and will be ensured at reconcile regardless.
+  const finishApplied = async (): Promise<void> => {
+    if (deps.ensureModel) {
+      try {
+        await deps.ensureModel(pending.spec);
+      } catch (err) {
+        deps.log?.(
+          `mental_model_propose: best-effort ensure threw (declaration still applied) for ${pending.agent} "${pending.spec.name}": ${(err as Error).message}`,
+        );
+      }
+    }
+    deps.injectInbound(
+      buildMentalModelProposeAppliedInbound({
+        ctx,
+        stageId,
+        operatorId,
+        nowMs: clock(),
+      }),
     );
+  };
+
+  const finishFailed = (reason: string, loud: boolean): void => {
+    deps.log?.(
+      `mental_model_propose: config edit failed for ${pending.agent} "${pending.spec.name}": ${reason}`,
+    );
+    // Loud, operator-visible failure only on the RETRY exhaustion path — the
+    // initial-failure path already surfaces via the card edit + agent inbound.
+    if (loud) {
+      try {
+        deps.notifyPersistFailed?.(reason);
+      } catch {
+        // notify must never break the failed-inbound delivery below.
+      }
+    }
     deps.injectInbound(
       buildMentalModelProposeFailedInbound({
         ctx,
         stageId,
         operatorId,
-        reason: dispatch.reason,
-        nowMs,
+        reason,
+        nowMs: clock(),
       }),
     );
+  };
+
+  const dispatch = await dispatchOnce();
+
+  // #2975 Stage 1 backstop — an operator-APPROVED persist that hostd rate-
+  // limited must NOT be silently lost. Schedule EXACTLY ONE re-dispatch at the
+  // window-open time hostd handed back in `fix.retry_after`, and flip the card
+  // to the "applying at HH:MM (rate window)" state so the operator sees it's
+  // deferred, not dropped.
+  if (dispatch.state === "rate_limited") {
+    if (deps.scheduleRetry) {
+      const { retryAtMs } = dispatch;
+      deps.editProposalCardRateWindow?.(retryAtMs);
+      const delayMs = Math.max(0, retryAtMs - clock());
+      deps.log?.(
+        `mental_model_propose: config edit rate-limited for ${pending.agent} "${pending.spec.name}"; scheduling one retry in ${delayMs}ms (window opens ${new Date(retryAtMs).toISOString()})`,
+      );
+      deps.scheduleRetry(delayMs, async () => {
+        // Bounded: this is the ONE and ONLY retry — it never re-schedules.
+        const retryResult = await dispatchOnce();
+        if (retryResult.state === "applied") {
+          await finishApplied();
+        } else {
+          // Every non-applied state (denied / rate_limited / error) carries a
+          // reason. A second rate_limit is treated as a terminal failure — the
+          // retry is bounded to one; we do NOT re-schedule.
+          finishFailed(retryResult.reason, true);
+        }
+      });
+      return { outcome: "scheduled_retry", retryAtMs };
+    }
+    // No scheduler wired — can't defer the retry; fail loudly rather than
+    // silently drop the approved change.
+    finishFailed(dispatch.reason, true);
     return { outcome: "failed", reason: dispatch.reason };
   }
 
-  // Applied. Belt-and-suspenders ensure (reconcile already ensures via #2874;
-  // this makes the model available without waiting for the restart). Never let
-  // an ensure failure flip a successful declaration into a "failed" inbound —
-  // the model IS declared and will be ensured at reconcile regardless.
-  if (deps.ensureModel) {
-    try {
-      await deps.ensureModel(pending.spec);
-    } catch (err) {
-      deps.log?.(
-        `mental_model_propose: best-effort ensure threw (declaration still applied) for ${pending.agent} "${pending.spec.name}": ${(err as Error).message}`,
-      );
-    }
+  if (dispatch.state !== "applied") {
+    finishFailed(dispatch.reason, false);
+    return { outcome: "failed", reason: dispatch.reason };
   }
 
-  deps.injectInbound(
-    buildMentalModelProposeAppliedInbound({ ctx, stageId, operatorId, nowMs }),
-  );
+  await finishApplied();
   return { outcome: "applied" };
 }

--- a/telegram-plugin/operator-events.ts
+++ b/telegram-plugin/operator-events.ts
@@ -28,6 +28,7 @@ export type OperatorEventKind =
   | 'unknown-5xx'
   | 'config-warning'
   | 'always-allow-persist-failed'
+  | 'mental-model-persist-failed'
 
 export interface OperatorEvent {
   kind: OperatorEventKind
@@ -411,6 +412,28 @@ export function renderOperatorEvent(ev: OperatorEvent): RenderResult {
           `⚠️ Your "Always allow" for **${agent}** didn't stick.`,
           detail ? `_${detail}_` : '',
           `It will ask again.`,
+        ]
+          .filter(Boolean)
+          .join('\n'),
+        keyboard: {
+          inline_keyboard: [
+            [{ text: '❌ Dismiss', callback_data: `op:dismiss:${encodeURIComponent(ev.agent)}` }],
+          ],
+        },
+      }
+
+    // #2975 Stage 1 — an operator-APPROVED mental-model persist hit the
+    // config_propose_edit rate limit, and the ONE scheduled retry at the
+    // window-open time ALSO failed. MUST be a NEW message (not a card edit):
+    // the proposal card was already edited to the "applying at HH:MM" state
+    // and card edits don't ping, so a silent edit here would leave the lost
+    // approval unnoticed. Ask the operator to re-propose so it isn't dropped.
+    case 'mental-model-persist-failed':
+      return {
+        text: [
+          `⚠️ **${agent}**'s approved mental model didn't save.`,
+          detail ? `_${detail}_` : '',
+          `The retry after the rate window also failed — ask the agent to re-propose it.`,
         ]
           .filter(Boolean)
           .join('\n'),

--- a/telegram-plugin/tests/mental-model-propose-resolve.test.ts
+++ b/telegram-plugin/tests/mental-model-propose-resolve.test.ts
@@ -138,6 +138,129 @@ describe("resolveMentalModelProposal — APPROVE", () => {
   });
 });
 
+describe("resolveMentalModelProposal — #2975 Stage 1 rate-limit backstop", () => {
+  const NOW = 1_700_000_000_000;
+  const RETRY_AT = NOW + 55 * 60_000; // hostd's window-open time
+
+  /**
+   * Build deps whose dispatchConfigEdit yields `results` in order (one per
+   * attempt), plus a manual single-slot scheduler the test fires by hand — a
+   * mocked clock, no real timers.
+   */
+  function rateDeps(results: Array<Awaited<ReturnType<ResolveDeps["dispatchConfigEdit"]>>>) {
+    let call = 0;
+    let scheduled: { delayMs: number; fn: () => void | Promise<void> } | null = null;
+    const spies = {
+      registerPreApproval: vi.fn(),
+      clearPreApproval: vi.fn(),
+      dispatchConfigEdit: vi.fn(async () => results[Math.min(call++, results.length - 1)]!),
+      ensureModel: vi.fn(async () => {}),
+      injectInbound: vi.fn(),
+      scheduleRetry: vi.fn((delayMs: number, fn: () => void | Promise<void>) => {
+        scheduled = { delayMs, fn };
+      }),
+      editProposalCardRateWindow: vi.fn(),
+      notifyPersistFailed: vi.fn(),
+    };
+    const deps: ResolveDeps = {
+      readConfigText: () => CONFIG_NO_MODELS,
+      registerPreApproval: spies.registerPreApproval,
+      clearPreApproval: spies.clearPreApproval,
+      dispatchConfigEdit: spies.dispatchConfigEdit,
+      ensureModel: spies.ensureModel,
+      injectInbound: spies.injectInbound,
+      scheduleRetry: spies.scheduleRetry,
+      editProposalCardRateWindow: spies.editProposalCardRateWindow,
+      notifyPersistFailed: spies.notifyPersistFailed,
+      now: () => NOW,
+    };
+    return { deps, spies, fireScheduled: () => scheduled!.fn(), getScheduled: () => scheduled };
+  }
+
+  it("schedules EXACTLY ONE retry at retry_after, which persists with a byte-identical diff", async () => {
+    const { deps, spies, fireScheduled, getScheduled } = rateDeps([
+      { state: "rate_limited", reason: "config_propose_edit rate limit exceeded", retryAtMs: RETRY_AT },
+      { state: "applied" },
+    ]);
+
+    const out = await resolveMentalModelProposal("approve", pending(), "stage1", "op-42", deps);
+
+    // The turn is deferred, not lost: a single retry is scheduled at the window.
+    expect(out).toEqual({ outcome: "scheduled_retry", retryAtMs: RETRY_AT });
+    expect(spies.scheduleRetry).toHaveBeenCalledTimes(1);
+    expect(getScheduled()!.delayMs).toBe(RETRY_AT - NOW);
+    // Card flipped to the "applying at HH:MM" state so the operator sees it.
+    expect(spies.editProposalCardRateWindow).toHaveBeenCalledWith(RETRY_AT);
+    // First (rate-limited) attempt already registered+cleared its correlation.
+    expect(spies.dispatchConfigEdit).toHaveBeenCalledTimes(1);
+    const firstDiff = spies.dispatchConfigEdit.mock.calls[0][0].diff;
+    expect(spies.registerPreApproval).toHaveBeenCalledWith("coach", firstDiff);
+    // Nothing applied yet.
+    expect(spies.ensureModel).not.toHaveBeenCalled();
+    expect(spies.injectInbound).not.toHaveBeenCalled();
+
+    // Fire the ONE scheduled retry (mocked clock).
+    await fireScheduled();
+
+    // Persisted on the retry.
+    expect(spies.dispatchConfigEdit).toHaveBeenCalledTimes(2);
+    const retryDiff = spies.dispatchConfigEdit.mock.calls[1][0].diff;
+    // Forge-resistance contract: register + dispatch use IDENTICAL diff bytes,
+    // and the retry re-registers the SAME bytes as the first attempt.
+    expect(retryDiff).toBe(firstDiff);
+    expect(spies.registerPreApproval).toHaveBeenCalledTimes(2);
+    expect(spies.registerPreApproval.mock.calls[1]).toEqual(["coach", retryDiff]);
+    expect(spies.clearPreApproval).toHaveBeenCalledTimes(2);
+    // Applied: ensured + agent woken; NO loud failure.
+    expect(spies.ensureModel).toHaveBeenCalledWith(pending().spec);
+    expect(spies.injectInbound).toHaveBeenCalledTimes(1);
+    expect(spies.injectInbound.mock.calls[0][0].meta.source).toBe(
+      "mental_model_proposal_applied",
+    );
+    expect(spies.notifyPersistFailed).not.toHaveBeenCalled();
+  });
+
+  it("emits a loud operator failure when the single retry ALSO fails — and does NOT re-schedule", async () => {
+    const { deps, spies, fireScheduled } = rateDeps([
+      { state: "rate_limited", reason: "rate limit exceeded", retryAtMs: RETRY_AT },
+      { state: "error", reason: "hostd down" },
+    ]);
+
+    const out = await resolveMentalModelProposal("approve", pending(), "s", "op", deps);
+    expect(out.outcome).toBe("scheduled_retry");
+    expect(spies.scheduleRetry).toHaveBeenCalledTimes(1);
+
+    await fireScheduled();
+
+    // The retry failed: loud operator-events notification, exactly once.
+    expect(spies.notifyPersistFailed).toHaveBeenCalledTimes(1);
+    expect(spies.notifyPersistFailed.mock.calls[0][0]).toContain("hostd down");
+    // No second retry — bounded to exactly one.
+    expect(spies.scheduleRetry).toHaveBeenCalledTimes(1);
+    // Agent woken with the failed inbound; nothing ensured.
+    expect(spies.ensureModel).not.toHaveBeenCalled();
+    expect(spies.injectInbound).toHaveBeenCalledTimes(1);
+    expect(spies.injectInbound.mock.calls[0][0].meta.source).toBe(
+      "mental_model_proposal_failed",
+    );
+  });
+
+  it("with no scheduler wired, a rate-limited persist fails loudly instead of silently dropping", async () => {
+    const { deps, spies } = rateDeps([
+      { state: "rate_limited", reason: "rate limit exceeded", retryAtMs: RETRY_AT },
+    ]);
+    // Simulate a build without the Stage-1 scheduler dep.
+    delete (deps as { scheduleRetry?: unknown }).scheduleRetry;
+
+    const out = await resolveMentalModelProposal("approve", pending(), "s", "op", deps);
+    expect(out).toEqual({ outcome: "failed", reason: "rate limit exceeded" });
+    expect(spies.notifyPersistFailed).toHaveBeenCalledTimes(1);
+    expect(spies.injectInbound.mock.calls[0][0].meta.source).toBe(
+      "mental_model_proposal_failed",
+    );
+  });
+});
+
 describe("resolveMentalModelProposal — DENY writes NOTHING", () => {
   it("never reads config, builds a diff, dispatches an edit, or ensures", async () => {
     const { deps, spies } = makeDeps(CONFIG_NO_MODELS);


### PR DESCRIPTION
## Summary

Stage 1 (gateway-only backstop) of #2975. When an operator taps **Approve** on a mental-model proposal, the gateway persists it via `config_propose_edit` on the agent's hostd socket. hostd counts that persist against the agent's 3/hour `config_propose_edit` bucket and can deny it with `E_RATE_LIMITED` — silently losing an already-approved change (observed: klanker 2026-07-06).

This adds a gateway-only retry backstop:

- `resolveMentalModelProposal` now distinguishes a `rate_limited` dispatch result. The gateway adapter parses hostd's structured `fix.retry_after` (server.ts ~2270-2280) into an epoch-ms window-open time.
- On rate-limit it schedules **exactly ONE** bounded re-dispatch at that time (single-shot `setTimeout`, clamped to the 32-bit ceiling; the resolver never re-schedules).
- The retry re-runs the same closure over the captured `built.diff`, so register + dispatch use **byte-identical** diff bytes — preserving the forge-resistance contract (mental-model-propose-resolve.ts:54-63) that hostd's config-approval callback auto-resolves only on an exact byte-match.
- The proposal card flips to `⏳ Approved — applying at HH:MM (config-edit rate window)` so the operator sees it isn't lost.
- If the single retry ALSO fails, a loud operator-events notification (`mental-model-persist-failed`, mirroring `always-allow-persist-failed`) fires as a new message — no silent loss.

Stage 2 (hostd `checkPreApproved` bypass) is a deliberate separate follow-up and is NOT in this PR.

## Why

An approved operator action must never be silently dropped. The 3/hour throttle exists to cap approval-card spam; the approved-persist path posts zero cards and consumes zero operator attention, yet was subject to the same bucket. Until Stage 2 removes the collision at the hostd layer, this backstop guarantees the approved change either lands at the window or fails loudly.

Cites job specs `reference/jobs/get-better-the-longer-they-run.md` and `reference/jobs/approve-what-my-agent-can-touch.md` — the operator's approval is the source of truth and must be honored durably.

## Test plan

- `vitest run telegram-plugin/tests/mental-model-propose-resolve.test.ts` — 8 passed. New cases (mocked clock, manual scheduler):
  - bucket exhausted → approve → `E_RATE_LIMITED` → asserts one retry scheduled at `retry_after`, card flipped, retry fires, persist succeeds, correlation re-registered with **byte-identical** diff, no loud failure.
  - retry also fails → operator-events notification emitted exactly once, no second retry, agent woken with failed inbound.
  - no scheduler wired → rate-limited persist fails loudly instead of silently dropping.
- `vitest run telegram-plugin/tests/operator-events.test.ts telegram-plugin/tests/mental-model-propose-card.test.ts` — 75 passed.
- `npm run lint` — clean (tsc + all 8 guard scripts).

## Risk

Low, gateway-scoped. No hostd/protocol change. The retry timer is gateway-memory-only — a gateway restart between schedule and fire loses the retry (documented in-code; acceptable for Stage 1, eliminated by Stage 2). Bounded to one retry, so no unbounded loop.

Part of #2975 (Stage 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)