### PR TITLE
fix(hostd): surface terminally-failed rollouts instead of phantom "started" (#2972)

### DIFF
--- a/src/host-control/rollout-agent-validation.test.ts
+++ b/src/host-control/rollout-agent-validation.test.ts
@@ -93,6 +93,12 @@ describe("handleRollout — #2972 fail-fast agent validation", () => {
     // The valid agent names are listed so the caller can self-correct.
     expect(resp.error).toMatch(/test-harness/);
     expect(resp.error).toMatch(/clerk/);
+    // #1758 structured envelope: code + fix.kind + human naming the names.
+    expect(resp.error_envelope?.code).toBe("E_UNKNOWN_AGENT");
+    expect(resp.error_envelope?.fix?.kind).toBe("bad_input");
+    expect(resp.error_envelope?.human).toMatch(/switchroom-test-harness/);
+    expect(resp.error_envelope?.human).toMatch(/clerk/);
+    expect(resp.error_envelope?.request_id).toBe("req-2972");
     // No child was spawned.
     expect(launchSpy).not.toHaveBeenCalled();
   });
@@ -108,6 +114,7 @@ describe("handleRollout — #2972 fail-fast agent validation", () => {
     expect(resp.error).toMatch(/ghost-agent/);
     // "clerk" is valid — it must not be named as unknown.
     expect(resp.error).not.toMatch(/unknown agent\(s\): [^.]*clerk/);
+    expect(resp.error_envelope?.code).toBe("E_UNKNOWN_AGENT");
     expect(launchSpy).not.toHaveBeenCalled();
   });
 
@@ -116,6 +123,8 @@ describe("handleRollout — #2972 fail-fast agent validation", () => {
     const resp = await server.handleRollout(rolloutReq([]), caller, Date.now());
     expect(resp.result).toBe("denied");
     expect(resp.error).toMatch(/E_UNKNOWN_AGENT|empty/);
+    expect(resp.error_envelope?.code).toBe("E_UNKNOWN_AGENT");
+    expect(resp.error_envelope?.fix?.kind).toBe("bad_input");
     expect(launchSpy).not.toHaveBeenCalled();
   });
 

--- a/src/host-control/rollout-agent-validation.test.ts
+++ b/src/host-control/rollout-agent-validation.test.ts
@@ -1,0 +1,155 @@
+/**
+ * #2972 — handleRollout must FAIL FAST on a bad `agents` list before it
+ * spawns the rollout child. Pre-fix it returned `result: "started"`
+ * unconditionally; the child then rejected unknown agents on stderr (exit 2)
+ * but hostd had already replied success, so the caller saw a phantom
+ * "started" and no approval card ever appeared (the 2026-07-10
+ * `switchroom-test-harness` incident).
+ *
+ * We drive the private `handleRollout` directly on a bare instance (same
+ * private-method cast pattern as reconcile-rollback-output.test.ts), with the
+ * config loader mocked so validation runs against a deterministic agent set.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const loadConfigMock = vi.fn();
+
+vi.mock("../config/loader.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../config/loader.js")>(
+      "../config/loader.js",
+    );
+  return {
+    ...actual,
+    loadConfig: (...args: unknown[]) => loadConfigMock(...args),
+  };
+});
+
+const { HostdServer } = await import("./server.js");
+import type { ServerOptions } from "./server.js";
+import type { HostdRequest, HostdResponse } from "./protocol.js";
+import type { SocketIdentity } from "./peercred.js";
+
+const caller: SocketIdentity = {
+  kind: "agent",
+  name: "overlord",
+} as SocketIdentity;
+
+type RolloutReq = Extract<HostdRequest, { op: "rollout" }>;
+
+function rolloutReq(agents?: string[]): RolloutReq {
+  return {
+    v: 1,
+    request_id: "req-2972",
+    op: "rollout",
+    args: {
+      pin: "v0.15.18",
+      ...(agents !== undefined ? { agents } : {}),
+    },
+  } as RolloutReq;
+}
+
+/** A bare server with self-bump + asset preflight neutralised, and
+ *  launchRollout stubbed so no real child is ever spawned. Returns both the
+ *  server and a spy that records whether launchRollout was reached. */
+function makeServer() {
+  const server = new HostdServer({
+    selfVersion: "v99.0.0",
+  } as unknown as ServerOptions);
+  const launchSpy = vi.fn(() => ({ request_id: "req-2972" }));
+  const s = server as unknown as {
+    missingApplyAssets: () => string[];
+    launchRollout: unknown;
+    handleRollout: (
+      req: RolloutReq,
+      caller: SocketIdentity,
+      started: number,
+    ) => Promise<HostdResponse>;
+  };
+  s.missingApplyAssets = () => [];
+  s.launchRollout = launchSpy;
+  return { server: s, launchSpy };
+}
+
+beforeEach(() => {
+  loadConfigMock.mockReset();
+  loadConfigMock.mockReturnValue({
+    agents: { "test-harness": {}, clerk: {}, overlord: {} },
+  });
+});
+
+describe("handleRollout — #2972 fail-fast agent validation", () => {
+  it("rejects a single unknown agent with E_UNKNOWN_AGENT and the valid names", async () => {
+    const { server, launchSpy } = makeServer();
+    const resp = await server.handleRollout(
+      rolloutReq(["switchroom-test-harness"]),
+      caller,
+      Date.now(),
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/E_UNKNOWN_AGENT/);
+    expect(resp.error).toMatch(/switchroom-test-harness/);
+    // The valid agent names are listed so the caller can self-correct.
+    expect(resp.error).toMatch(/test-harness/);
+    expect(resp.error).toMatch(/clerk/);
+    // No child was spawned.
+    expect(launchSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a mixed valid+invalid list, naming ONLY the bad one", async () => {
+    const { server, launchSpy } = makeServer();
+    const resp = await server.handleRollout(
+      rolloutReq(["clerk", "ghost-agent"]),
+      caller,
+      Date.now(),
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/ghost-agent/);
+    // "clerk" is valid — it must not be named as unknown.
+    expect(resp.error).not.toMatch(/unknown agent\(s\): [^.]*clerk/);
+    expect(launchSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects an explicitly empty agents list", async () => {
+    const { server, launchSpy } = makeServer();
+    const resp = await server.handleRollout(rolloutReq([]), caller, Date.now());
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/E_UNKNOWN_AGENT|empty/);
+    expect(launchSpy).not.toHaveBeenCalled();
+  });
+
+  it("proceeds (started) when every requested agent is valid — happy path unchanged", async () => {
+    const { server, launchSpy } = makeServer();
+    const resp = await server.handleRollout(
+      rolloutReq(["test-harness", "clerk"]),
+      caller,
+      Date.now(),
+    );
+    expect(resp.result).toBe("started");
+    expect(launchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("proceeds (started) when no agents list is given (roll all)", async () => {
+    const { server, launchSpy } = makeServer();
+    const resp = await server.handleRollout(rolloutReq(), caller, Date.now());
+    expect(resp.result).toBe("started");
+    expect(launchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT convert a config-read failure into a denial — proceeds and lets the child fail", async () => {
+    loadConfigMock.mockImplementation(() => {
+      throw new Error("Invalid YAML in switchroom.yaml");
+    });
+    const { server, launchSpy } = makeServer();
+    const resp = await server.handleRollout(
+      rolloutReq(["switchroom-test-harness"]),
+      caller,
+      Date.now(),
+    );
+    // Malformed config → skip validation, proceed as before (item 2 on the
+    // MCP side catches the child's early death).
+    expect(resp.result).toBe("started");
+    expect(launchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -1517,6 +1517,45 @@ export class HostdServer {
     const assetDenied = this.applyAssetPreflight(req.request_id, started);
     if (assetDenied) return assetDenied;
 
+    // #2972 — fail fast on a bad `agents` list BEFORE spawning the child.
+    // The child rejects unknown agents (stderr, exit 2) but by then hostd
+    // has already replied "started", so the caller sees success and never
+    // gets an approval card. Validate against the SAME config view the
+    // child reads (`config.agents` keys) so there's no stale-view mismatch.
+    if (req.args.agents !== undefined) {
+      let validAgents: string[] | null = null;
+      try {
+        const cfg = loadConfig(this.opts.configPath) as {
+          agents?: Record<string, unknown>;
+        };
+        validAgents = Object.keys(cfg.agents ?? {});
+      } catch {
+        // Malformed yaml: skip validation and proceed as before — the
+        // child will fail and the MCP-side grace-window check surfaces it.
+        validAgents = null;
+      }
+      if (validAgents !== null) {
+        const requested = req.args.agents;
+        if (requested.length === 0) {
+          return deniedResponse(
+            req.request_id,
+            `E_UNKNOWN_AGENT: empty agents list — pass at least one agent, ` +
+              `or omit "agents" to roll all. Valid agents: ${validAgents.join(", ")}`,
+            Date.now() - started,
+          );
+        }
+        const unknown = requested.filter((a) => !validAgents!.includes(a));
+        if (unknown.length > 0) {
+          return deniedResponse(
+            req.request_id,
+            `E_UNKNOWN_AGENT: unknown agent(s): ${unknown.join(", ")}. ` +
+              `Valid agents: ${validAgents.join(", ")}`,
+            Date.now() - started,
+          );
+        }
+      }
+    }
+
     const entry = this.launchRollout(req.args, req.request_id, caller, started);
     return {
       v: 1,

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -1535,22 +1535,30 @@ export class HostdServer {
         validAgents = null;
       }
       if (validAgents !== null) {
+        // #1758 structured envelope alongside the legacy `error` string.
+        // ErrorBuilder synthesises `error` as "<code>: <human>", so the
+        // legacy string stays exactly "E_UNKNOWN_AGENT: …" — the same shape
+        // string-matching decoders already parse.
+        const buildDenied = (human: string): HostdResponse =>
+          err("E_UNKNOWN_AGENT", human)
+            .fixBadInput("agents")
+            .op("rollout")
+            .caller(caller.kind)
+            .agentName(caller.kind === "agent" ? caller.name : undefined)
+            .asDenied()
+            .build(req.request_id, Date.now() - started);
         const requested = req.args.agents;
         if (requested.length === 0) {
-          return deniedResponse(
-            req.request_id,
-            `E_UNKNOWN_AGENT: empty agents list — pass at least one agent, ` +
+          return buildDenied(
+            `empty agents list — pass at least one agent, ` +
               `or omit "agents" to roll all. Valid agents: ${validAgents.join(", ")}`,
-            Date.now() - started,
           );
         }
         const unknown = requested.filter((a) => !validAgents!.includes(a));
         if (unknown.length > 0) {
-          return deniedResponse(
-            req.request_id,
-            `E_UNKNOWN_AGENT: unknown agent(s): ${unknown.join(", ")}. ` +
+          return buildDenied(
+            `unknown agent(s): ${unknown.join(", ")}. ` +
               `Valid agents: ${validAgents.join(", ")}`,
-            Date.now() - started,
           );
         }
       }

--- a/src/mcp/hostd/server.test.ts
+++ b/src/mcp/hostd/server.test.ts
@@ -390,6 +390,36 @@ describe("dispatchTool — happy path", () => {
     expect(hostdRequestMock).toHaveBeenCalledTimes(1);
   });
 
+  it("rollout E_UNKNOWN_AGENT denial surfaces the #1758 structured envelope content item", async () => {
+    hostdRequestMock.mockResolvedValueOnce(
+      ok({
+        result: "denied",
+        error:
+          "E_UNKNOWN_AGENT: unknown agent(s): switchroom-test-harness. Valid agents: test-harness, clerk",
+        error_envelope: {
+          v: 1,
+          code: "E_UNKNOWN_AGENT",
+          human:
+            "unknown agent(s): switchroom-test-harness. Valid agents: test-harness, clerk",
+          fix: { kind: "bad_input", field: "agents" },
+          request_id: "mcp-rollout-denied-1",
+        },
+      }),
+    );
+    const res = await dispatchTool("rollout", {
+      pin: "v0.15.18",
+      agents: ["switchroom-test-harness"],
+    });
+    expect(res.isError).toBe(true);
+    const joined = res.content.map((c) => c.text).join("\n");
+    // The envelope is surfaced as its own content item with the
+    // fix.kind discriminator hint the agent branches on.
+    expect(joined).toMatch(/Structured error — fix\.kind=bad_input/);
+    expect(joined).toMatch(/E_UNKNOWN_AGENT/);
+    expect(joined).toMatch(/Valid agents: test-harness, clerk/);
+    expect(hostdRequestMock).toHaveBeenCalledTimes(1);
+  });
+
   it("update_apply forwards reason when provided and omits it when absent", async () => {
     hostdRequestMock.mockResolvedValueOnce(ok({ result: "started" }));
     await dispatchTool("update_apply", {

--- a/src/mcp/hostd/server.test.ts
+++ b/src/mcp/hostd/server.test.ts
@@ -40,6 +40,9 @@ vi.mock("node:fs", async () => {
 // Import after the mocks. server.ts reads SWITCHROOM_AGENT_NAME at
 // module-load — set it before the import.
 process.env.SWITCHROOM_AGENT_NAME = "klanker";
+// #2972 — short-circuit the rollout post-start grace delay so the
+// get_status re-check round-trips instantly in tests (0ms, not 3s).
+process.env.HOSTD_MCP_ROLLOUT_GRACE_MS = "0";
 const { TOOLS, dispatchTool, UPDATE_APPLY_SEMVER_PIN_ADVISORY } = await import("./server.js");
 
 function ok(resp: Partial<HostdResponse> = {}): HostdResponse {
@@ -303,6 +306,88 @@ describe("dispatchTool — happy path", () => {
     await dispatchTool("rollout", { pin: "v0.15.18" });
     const sent = hostdRequestMock.mock.calls[0]![1];
     expect(sent.args).not.toHaveProperty("reason");
+  });
+
+  // ── #2972 rollout early-terminal-failure surfacing ───────────────────
+  it("rollout that dies within the grace window returns error + stderr_tail (not started)", async () => {
+    // 1st RPC: hostd replies `started` (fire-and-forget spawn accepted).
+    hostdRequestMock.mockResolvedValueOnce(
+      ok({ result: "started", request_id: "mcp-rollout-abc" }),
+    );
+    // 2nd RPC: the post-start get_status finds the child already dead.
+    hostdRequestMock.mockResolvedValueOnce(
+      ok({
+        result: "error",
+        request_id: "mcp-get-status-1",
+        exit_code: 2,
+        error: "rollout child exited 2",
+        stderr_tail: "unknown agent(s): switchroom-test-harness\n",
+      }),
+    );
+    const res = await dispatchTool("rollout", {
+      pin: "v0.15.18",
+      agents: ["test-harness"],
+    });
+    expect(res.isError).toBe(true);
+    // The started JSON must NOT be what the caller sees.
+    expect(res.content[0]!.text).not.toMatch(/"result":"started"/);
+    expect(res.content[0]!.text).toMatch(/"result":"error"/);
+    // stderr_tail surfaced as its own content item.
+    const joined = res.content.map((c) => c.text).join("\n");
+    expect(joined).toMatch(/unknown agent\(s\): switchroom-test-harness/);
+    expect(joined).toMatch(/stderr_tail:/);
+    // Exactly two RPCs: the rollout, then the single get_status re-check.
+    expect(hostdRequestMock).toHaveBeenCalledTimes(2);
+    const poll = hostdRequestMock.mock.calls[1]![1];
+    expect(poll.op).toBe("get_status");
+    expect(poll.args.target_request_id).toBe("mcp-rollout-abc");
+  });
+
+  it("rollout still healthy after the grace window returns started unchanged (happy path)", async () => {
+    hostdRequestMock.mockResolvedValueOnce(
+      ok({ result: "started", request_id: "mcp-rollout-live" }),
+    );
+    // Post-start poll: still running (started) → not a terminal error.
+    hostdRequestMock.mockResolvedValueOnce(
+      ok({ result: "started", request_id: "mcp-get-status-2" }),
+    );
+    const res = await dispatchTool("rollout", {
+      pin: "v0.15.18",
+      agents: ["test-harness"],
+    });
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0]!.text).toMatch(/"result":"started"/);
+    expect(res.content[0]!.text).toMatch(/mcp-rollout-live/);
+  });
+
+  it("rollout survives a wire error on the post-start poll (falls through to started)", async () => {
+    hostdRequestMock.mockResolvedValueOnce(
+      ok({ result: "started", request_id: "mcp-rollout-x" }),
+    );
+    hostdRequestMock.mockRejectedValueOnce(new Error("uds hiccup"));
+    const res = await dispatchTool("rollout", { pin: "v0.15.18" });
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0]!.text).toMatch(/"result":"started"/);
+  });
+
+  it("rollout denied by hostd surfaces stderr_tail in the error envelope", async () => {
+    hostdRequestMock.mockResolvedValueOnce(
+      ok({
+        result: "denied",
+        error: "E_UNKNOWN_AGENT: unknown agent(s): switchroom-test-harness",
+        stderr_tail: "unknown agent(s): switchroom-test-harness\n",
+      }),
+    );
+    const res = await dispatchTool("rollout", {
+      pin: "v0.15.18",
+      agents: ["switchroom-test-harness"],
+    });
+    expect(res.isError).toBe(true);
+    const joined = res.content.map((c) => c.text).join("\n");
+    expect(joined).toMatch(/E_UNKNOWN_AGENT/);
+    expect(joined).toMatch(/stderr_tail:/);
+    // A denied result short-circuits BEFORE the grace poll — one RPC only.
+    expect(hostdRequestMock).toHaveBeenCalledTimes(1);
   });
 
   it("update_apply forwards reason when provided and omits it when absent", async () => {

--- a/src/mcp/hostd/server.ts
+++ b/src/mcp/hostd/server.ts
@@ -74,6 +74,28 @@ export function wireTimeoutForOp(op: HostdRequest["op"]): number {
   return WIRE_TIMEOUT_MS_BY_OP[op] ?? DEFAULT_WIRE_TIMEOUT_MS;
 }
 
+/**
+ * #2972 — grace window before the rollout tool re-checks a `started`
+ * rollout via a single get_status. A rollout child that dies immediately
+ * (e.g. `unknown agent(s): …`, exit 2) leaves hostd having already replied
+ * `started`; without this the caller sees success and never gets a card.
+ * After `started` we wait this long, then poll get_status once — if the
+ * request is already terminal with an error, we surface it (with
+ * stderr_tail) instead of the misleading `started` JSON.
+ *
+ * Overridable via `HOSTD_MCP_ROLLOUT_GRACE_MS` (tests set 0 to short-circuit
+ * the delay while keeping the get_status round-trip).
+ */
+const DEFAULT_ROLLOUT_GRACE_MS = 3_000;
+export function rolloutGraceMs(): number {
+  const raw = process.env.HOSTD_MCP_ROLLOUT_GRACE_MS;
+  if (raw !== undefined) {
+    const n = Number(raw);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  return DEFAULT_ROLLOUT_GRACE_MS;
+}
+
 interface ToolArgs {
   name?: string;
   reason?: string;
@@ -812,6 +834,21 @@ export async function dispatchTool(
     );
   }
 
+  // #2972 — a rollout that reported `started` may already be terminally
+  // dead (child rejected the args and exited before we could observe it).
+  // Wait a short grace window, then poll get_status once; if it's terminal
+  // with an error, surface that (with stderr_tail) instead of the
+  // misleading `started`. Any other outcome (still running, wire hiccup,
+  // no such request) falls through to the normal started path — we never
+  // turn a healthy roll into a failure.
+  if (req.op === "rollout" && resp.result === "started") {
+    const terminal = await checkRolloutEarlyFailure(
+      sockPath,
+      resp.request_id,
+    );
+    if (terminal) return terminal;
+  }
+
   // started/completed: success path. Surface the full response as
   // JSON so the model can correlate later via request_id.
   if (resp.result === "started" || resp.result === "completed") {
@@ -828,6 +865,15 @@ export async function dispatchTool(
   const content: { type: "text"; text: string }[] = [
     { type: "text", text: JSON.stringify(resp) },
   ];
+  // #2972 — plumb the child's stderr tail as its own content item on
+  // every terminal denied/error envelope, so the caller sees the exact
+  // failure ("unknown agent(s): …") without re-parsing the JSON blob.
+  if (resp.stderr_tail) {
+    content.push({
+      type: "text",
+      text: `stderr_tail:\n${resp.stderr_tail}`,
+    });
+  }
   // #1758 Phase 1: when a structured error envelope is present, surface
   // it as a second content item with a leading discriminator hint so
   // the agent can branch on `fix.kind` without re-parsing the legacy
@@ -839,6 +885,58 @@ export async function dispatchTool(
       text:
         `Structured error — fix.kind=${env.fix?.kind ?? "none"}\n` +
         JSON.stringify(env, null, 2),
+    });
+  }
+  return { content, isError: true };
+}
+
+/**
+ * #2972 — after a rollout reports `started`, wait a short grace window and
+ * poll get_status ONCE. If the request is already terminal with an error,
+ * return an isError result carrying the error message AND the child's
+ * stderr_tail. Returns null in every other case (still running, no such
+ * request, wire error) so the caller falls through to the normal `started`
+ * path — a healthy roll is never converted into a failure.
+ */
+async function checkRolloutEarlyFailure(
+  sockPath: string,
+  rolloutRequestId: string,
+): Promise<{
+  content: { type: "text"; text: string }[];
+  isError: boolean;
+} | null> {
+  const graceMs = rolloutGraceMs();
+  if (graceMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, graceMs));
+  }
+  const statusReq: HostdRequest = {
+    v: 1,
+    op: "get_status",
+    request_id: makeRequestId("mcp-rollout-poststart"),
+    args: { target_request_id: rolloutRequestId },
+  };
+  let status: HostdResponse;
+  try {
+    status = await hostdRequest(
+      { socketPath: sockPath, timeoutMs: wireTimeoutForOp(statusReq.op) },
+      statusReq,
+    );
+  } catch {
+    // Wire hiccup on the follow-up poll — don't mask the roll. The caller
+    // still has the request_id from the started response to poll later.
+    return null;
+  }
+  // Only a terminal ERROR short-circuits. "completed" this fast is
+  // implausible for a real roll but is still success; "started"/other
+  // means the roll is proceeding normally → the approval card flow.
+  if (!status || status.result !== "error") return null;
+  const content: { type: "text"; text: string }[] = [
+    { type: "text", text: JSON.stringify(status) },
+  ];
+  if (status.stderr_tail) {
+    content.push({
+      type: "text",
+      text: `stderr_tail:\n${status.stderr_tail}`,
     });
   }
   return { content, isError: true };


### PR DESCRIPTION
## What

`mcp__hostd__rollout` returned `result: "started"` even when the rollout child died immediately (e.g. `unknown agent(s): <name>`, exit 2). The caller saw success, no approval card ever appeared, and the failure was only discoverable in the hostd audit log (cost a real session 4 wasted fire attempts on 2026-07-10 with `switchroom-test-harness` instead of `test-harness`).

Three changes:

1. **Fail fast on a bad `agents` list** — `handleRollout` (`src/host-control/server.ts`) now loads the same config view the child reads and, when `agents` is provided, rejects unknown names or an explicitly empty list with a structured `E_UNKNOWN_AGENT` denial naming the bad names and the valid agent names — **before** spawning the child. A malformed-config read is *not* turned into a denial: validation is skipped and the roll proceeds as before (item 2 catches the child's death).
2. **Surface early terminal failure in the MCP tool** — after receiving `started`, the `rollout` op waits a short grace window (`HOSTD_MCP_ROLLOUT_GRACE_MS`, default 3s; `0` in tests) then issues one `get_status`. If the request is already terminal with an error, it returns an `isError` result carrying `error` + `stderr_tail` instead of the misleading started JSON. Any other outcome (still running, wire hiccup, no such request) falls through to the normal started path — a healthy roll is never converted into a failure.
3. **Plumb `stderr_tail`** into every terminal denied/error envelope the rollout tool returns.

Happy path is byte-identical: valid agents → `started` → approval card flow unchanged.

## Why

Fixes #2972.

## Test evidence

Scoped vitest (run from an exec-capable copy — `/tmp` is `noexec` so native deps can't mmap there):

```
 ✓ src/mcp/hostd/server.test.ts (53 tests) 19ms
 ✓ src/host-control/rollout-agent-validation.test.ts (6 tests) 7ms
 Test Files  2 passed (2)   Tests  59 passed (59)
```

Full host-control suite green (119 tests, 11 files). `tsc --noEmit` clean; all guard scripts clean except a **pre-existing** `check-bot-api-wrapping` false positive in `telegram-plugin/gateway/gateway.ts` (untouched by this PR — the call there IS wrapped in `robustApiCall`; the checker's legacy line-range allowlist has drifted). CI is the authority.

New tests assert outcomes: unknown-agent rejection (single + mixed valid/invalid), empty list, config-read-failure proceeds, valid/all-agents happy path; grace-window terminal-error path returns `error` + `stderr_tail`, wire-error fallthrough stays `started`, `stderr_tail` present in denied envelopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)