### PR TITLE
fix(gateway): reap orphaned queued/busy-ack cards on boot (#3002)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -503,6 +503,12 @@ import {
   type ActivityCardStoreFsSeam,
 } from './activity-card-store.js'
 import {
+  writeQueuedCardRecord,
+  clearQueuedCardRecord,
+  runQueuedCardBootReaper,
+  type QueuedCardStoreFsSeam,
+} from './queued-card-store.js'
+import {
   decideWorkerPinReaps,
   WORKER_PIN_TTL_MS_DEFAULT,
 } from './worker-pin-reaper.js'
@@ -3659,6 +3665,9 @@ function postQueuedStatus(chatId: string, bufferedThread: number, inFlightThread
       return
     }
     queuedStatusMsgIds.set(key, { chatId, threadId: bufferedThread, messageId })
+    // #3002: write through to the durable store so a gateway restart before the
+    // in-process reap can still delete this orphaned card on boot.
+    persistQueuedCard(key, chatId, bufferedThread, messageId)
   })()
 }
 
@@ -3695,6 +3704,9 @@ function reapQueuedStatus(chatId: string, thread: number | undefined): void {
   const entry = queuedStatusMsgIds.get(key)
   if (entry == null) return
   queuedStatusMsgIds.delete(key)
+  // #3002: drop the durable row too, scoped to this exact message id (reap-race
+  // guard) so a fresh live card under the same key keeps its own protection.
+  clearQueuedCard(key, entry.messageId)
   void swallowingApiCall(
     () => bot.api.deleteMessage(chatId, entry.messageId),
     { chat_id: chatId, verb: 'queued-status.reap', ...(entry.threadId != null ? { threadId: entry.threadId } : {}) },
@@ -3807,6 +3819,8 @@ function postBusyAck(chatId: string, threadId: number | undefined, text: string)
       return
     }
     queuedStatusMsgIds.set(key, { chatId, threadId: threadId ?? null, messageId })
+    // #3002: write through to the durable store (see postQueuedStatus).
+    persistQueuedCard(key, chatId, threadId ?? null, messageId)
   })()
 }
 
@@ -7228,6 +7242,48 @@ const activityCardStoreFs: ActivityCardStoreFsSeam = {
 }
 const activityCardPersistEnabled = !STATIC
 
+// Durable handle for the component-5 queued-status placeholder + #2995 busy-ack
+// card (#3002). Both track their sent message id only in the in-memory
+// `queuedStatusMsgIds` Map, so a restart between posting a card and its
+// promote/reap strands a permanent stale "⏳ Queued…" line. Persisted on POST,
+// cleared on in-process reap; a boot-time reaper (wired alongside
+// `activityCardBootReaper`, same startup-mutex ordering constraint) DELETES any
+// leftover card and clears the store — a "Queued" claim is always wrong after a
+// restart, so deletion is the honest terminal (reap-on-boot only, no
+// promote-across-restart). STATIC mode skips disk — same gate as the sibling
+// stores.
+const QUEUED_CARD_STORE_PATH = join(STATE_DIR, 'queued-cards-pending.json')
+const queuedCardStoreFs: QueuedCardStoreFsSeam = {
+  readFileSync: (p: string) => readFileSync(p, 'utf8'),
+  writeFileSync: (p: string, d: string) => writeFileSync(p, d),
+  renameSync: (a: string, b: string) => renameSync(a, b),
+  existsSync: (p: string) => existsSync(p),
+}
+const queuedCardPersistEnabled = !STATIC
+
+// Write-through helpers (#3002) — mirror the in-memory `queuedStatusMsgIds`
+// set/delete onto the durable store. Best-effort + gated: no-op when the store
+// isn't usable (STATIC = no durable volume). Called from postQueuedStatus /
+// postBusyAck (post) and reapQueuedStatus (delete).
+function persistQueuedCard(
+  key: string,
+  chatId: string,
+  threadId: number | null,
+  messageId: number,
+): void {
+  if (!queuedCardPersistEnabled) return
+  writeQueuedCardRecord(QUEUED_CARD_STORE_PATH, queuedCardStoreFs, {
+    key,
+    chatId,
+    threadId,
+    messageId,
+  })
+}
+function clearQueuedCard(key: string, messageId?: number): void {
+  if (!queuedCardPersistEnabled) return
+  clearQueuedCardRecord(QUEUED_CARD_STORE_PATH, queuedCardStoreFs, key, messageId)
+}
+
 // Slot-banner pin persistence (#421 crash-recovery). The slot banner is pinned
 // in the owner chat when the agent is on a non-default OAuth slot. Rather than a
 // parallel store + second boot hook, its pin is persisted in the SAME
@@ -7392,6 +7448,40 @@ async function activityCardBootReaper(): Promise<void> {
       `telegram gateway: activity-card: finalized ${finalized}/${total} ` +
         `(vanished ${vanished}/${total}), unpinned ${unpinned}/${total} ` +
         `orphaned card(s) from a prior session (at-most-once)\n`,
+    )
+  }
+}
+
+/**
+ * Boot-time reaper for orphaned queued-status / busy-ack cards (#3002). Thin
+ * gateway wrapper over the pure `runQueuedCardBootReaper` — binds the live fs
+ * seam, a robust Telegram delete, and the logger. Deletes any card persisted by
+ * a prior (crashed/restarted) session and clears the store: a "⏳ Queued…" /
+ * "On it" claim is always wrong after a restart, so deletion is the honest
+ * terminal (reap-on-boot only, no promote-across-restart).
+ *
+ * MUST run ONLY after this gateway wins the startup mutex — same shared-file
+ * ordering constraint as `activityCardBootReaper` / `statusPinBootCleanup`.
+ */
+async function queuedCardBootReaper(): Promise<void> {
+  if (!queuedCardPersistEnabled) return
+  const { deleted, total } = await runQueuedCardBootReaper({
+    path: QUEUED_CARD_STORE_PATH,
+    fs: queuedCardStoreFs,
+    deleteCard: (record) =>
+      robustApiCall(
+        () => lockedBot.api.deleteMessage(record.chatId, record.messageId),
+        {
+          chat_id: record.chatId,
+          ...(record.threadId != null ? { threadId: record.threadId } : {}),
+          verb: 'queued-card.boot-reap-delete',
+        },
+      ),
+  })
+  if (total > 0) {
+    process.stderr.write(
+      `telegram gateway: queued-card: deleted ${deleted}/${total} ` +
+        `orphaned queued/busy-ack card(s) from a prior session\n`,
     )
   }
 }
@@ -7906,6 +7996,7 @@ function ensureIssuesCard(chatId: string, threadId: number | undefined): void {
     // Fire-and-forget: cleanup is best-effort and must not block boot.
     void statusPinBootCleanup()
     void activityCardBootReaper()
+    void queuedCardBootReaper()
   } catch (err) {
     process.stderr.write(
       `telegram gateway: boot.lock_acquire_failed err=${(err as Error).message} agent=${SWITCHROOM_AGENT_NAME}\n`,
@@ -7923,6 +8014,7 @@ function ensureIssuesCard(chatId: string, threadId: number | undefined): void {
       // running orphan cleanup is consistent with the pre-mutex behaviour.
       void statusPinBootCleanup()
       void activityCardBootReaper()
+      void queuedCardBootReaper()
     } catch (writeErr) {
       process.stderr.write(`telegram gateway: writePidFile failed: ${writeErr}\n`)
     }

--- a/telegram-plugin/gateway/queued-card-store.ts
+++ b/telegram-plugin/gateway/queued-card-store.ts
@@ -1,0 +1,217 @@
+/**
+ * queued-card-store.ts — durable handle for the component-5 queued-status
+ * placeholder and the #2995 mid-flight busy-ack card, so a gateway restart
+ * mid-turn can reap the orphaned card instead of leaving a permanent stale
+ * "⏳ Queued…" line in the chat.
+ *
+ * Why this exists (#3002): both cards track their sent Telegram message id ONLY
+ * in the in-memory `queuedStatusMsgIds` Map in gateway.ts. A gateway/container
+ * restart between posting a card and its in-process promote/reap empties that
+ * Map, so the card is stranded: a permanent "⏳ Queued — replying in another
+ * topic first…" (or busy-ack) line that never gets promoted or deleted, sitting
+ * above the real answer.
+ *
+ * The fix mirrors `activity-card-store.ts` / `status-pin-store.ts` in shape: a
+ * tiny durable snapshot on the per-agent state volume (STATE_DIR), written
+ * whenever a card is POSTED, cleared the moment it is reaped/deleted in-process.
+ * On boot, AFTER this gateway wins the startup mutex (same ordering constraint
+ * as the status-pin/activity-card cleanups — this is a shared per-agent file, so
+ * a losing double-boot must never touch it), a one-shot reaper DELETES any
+ * leftover card via the Bot API and clears the store.
+ *
+ * DELETION is the honest terminal (deliberate — reap-on-boot only, NO
+ * promote-across-restart): a "Queued" / "On it — replying now" claim is ALWAYS
+ * wrong after a restart (the turn it referred to is over or being re-run from
+ * scratch), so the only correct move is to remove the card. We do NOT attempt to
+ * re-promote or re-adopt it across the restart; the resumed/replayed turn owns
+ * fresh surfaces.
+ *
+ * Crash-safety: write-tmp + atomic rename (identical convention to
+ * activity-card-store.ts / status-pin-store.ts). A corrupt or unreadable file
+ * fails open to `[]` — never crashes boot, worst case an orphan isn't reaped
+ * this boot, no worse than pre-fix behaviour.
+ *
+ * IDEMPOTENCY: the reaper deletes each record from the on-disk store BEFORE
+ * attempting its Telegram delete (delete-first, mirroring the activity-card
+ * reaper), so a crash mid-reap or a second boot re-reading the file can never
+ * re-issue a delete for a message already handled. A Telegram delete of an
+ * already-gone message is itself harmless (the caller tolerates "message not
+ * found"); delete-first simply keeps the store honest.
+ */
+
+export interface QueuedCardStoreFsSeam {
+  readFileSync: (path: string) => string
+  writeFileSync: (path: string, data: string) => void
+  /** Atomic same-dir replace (POSIX rename) so a crash mid-write can't tear
+   *  the snapshot. */
+  renameSync: (from: string, to: string) => void
+  existsSync: (path: string) => boolean
+}
+
+/** One persisted queued/busy-ack card: enough to delete the orphaned Telegram
+ *  message on a future boot, without any live turn state. */
+export interface QueuedCardRecord {
+  /** Stable per-topic key (`statusKey(chatId, threadId)` shape) — also the
+   *  upsert key: a fresh post for the same topic replaces any stale row. */
+  key: string
+  chatId: string
+  /** Forum topic id, or null for a DM / General-topic card. */
+  threadId: number | null
+  messageId: number
+}
+
+interface SnapshotEnvelope {
+  v: 1
+  cards: QueuedCardRecord[]
+}
+
+function isCardRow(x: unknown): x is QueuedCardRecord {
+  if (x == null || typeof x !== 'object') return false
+  const o = x as Record<string, unknown>
+  return (
+    typeof o.key === 'string' &&
+    o.key.length > 0 &&
+    typeof o.chatId === 'string' &&
+    o.chatId.length > 0 &&
+    (o.threadId === null || typeof o.threadId === 'number') &&
+    typeof o.messageId === 'number'
+  )
+}
+
+/**
+ * Load the persisted card set. Returns [] on a missing, unreadable, or
+ * malformed file — fail-open, never throws.
+ */
+export function loadQueuedCards(
+  path: string,
+  fs: QueuedCardStoreFsSeam,
+): QueuedCardRecord[] {
+  if (!fs.existsSync(path)) return []
+  let raw = ''
+  try {
+    raw = fs.readFileSync(path)
+  } catch {
+    return []
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  if (parsed == null || typeof parsed !== 'object') return []
+  const env = parsed as Record<string, unknown>
+  if (env.v !== 1 || !Array.isArray(env.cards)) return []
+  return env.cards.filter(isCardRow)
+}
+
+/**
+ * Persist the card set atomically (write sibling tmp → rename). Never throws —
+ * a write failure is logged and the store degrades to in-memory-only for this
+ * process (same contract as `activity-card-store.ts`).
+ */
+export function persistQueuedCards(
+  path: string,
+  fs: QueuedCardStoreFsSeam,
+  snapshot: readonly QueuedCardRecord[],
+  log: (line: string) => void = (l) => process.stderr.write(l),
+): void {
+  const env: SnapshotEnvelope = { v: 1, cards: [...snapshot] }
+  const tmp = path + '.tmp'
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(env))
+    fs.renameSync(tmp, path)
+  } catch (err) {
+    log(
+      `queued-card-store: persist FAILED path=${path}: ${(err as Error).message} — ` +
+        `durability degraded to in-memory\n`,
+    )
+  }
+}
+
+/**
+ * Upsert the card row for `key` (replacing any stale row for the same topic).
+ * Called the moment a queued-status / busy-ack card is POSTED (its message id
+ * is recorded into the in-memory `queuedStatusMsgIds` Map).
+ */
+export function writeQueuedCardRecord(
+  path: string,
+  fs: QueuedCardStoreFsSeam,
+  record: QueuedCardRecord,
+  log: (line: string) => void = (l) => process.stderr.write(l),
+): void {
+  const current = loadQueuedCards(path, fs)
+  const others = current.filter((c) => c.key !== record.key)
+  persistQueuedCards(path, fs, [...others, record], log)
+}
+
+/**
+ * Remove the card row for `key`, if present. Called the moment the card is
+ * reaped/deleted in-process (reapQueuedStatus), and by the boot reaper (BEFORE
+ * attempting the Telegram delete — the idempotency guard).
+ *
+ * When `messageId` is supplied, only a row matching BOTH `key` AND `messageId`
+ * is removed (reap-race guard): during a slow multi-record reap a fresh live
+ * turn could post a NEW card under the same key (its own, different messageId);
+ * a key-only clear would then drop the live card's durable protection. Omit
+ * `messageId` only when you mean "clear whatever row exists for this topic".
+ */
+export function clearQueuedCardRecord(
+  path: string,
+  fs: QueuedCardStoreFsSeam,
+  key: string,
+  messageId?: number,
+  log: (line: string) => void = (l) => process.stderr.write(l),
+): void {
+  const current = loadQueuedCards(path, fs)
+  if (current.length === 0) return
+  const next = current.filter(
+    (c) => c.key !== key || (messageId !== undefined && c.messageId !== messageId),
+  )
+  if (next.length === current.length) return
+  persistQueuedCards(path, fs, next, log)
+}
+
+/**
+ * Boot-time orphan reaper, extracted as a pure routine over injected seams
+ * (mirrors `runActivityCardBootReaper`). The gateway's thin wrapper binds the
+ * live fs, a Telegram delete call, and the logger.
+ *
+ * CRITICAL ordering, identical constraint to the status-pin / activity-card
+ * cleanups: the caller MUST only invoke this AFTER winning the startup mutex.
+ * The store is a shared per-agent file; a losing double-boot running this would
+ * delete a card the still-alive holder's in-flight turn still legitimately owns.
+ *
+ * Deletes each record from disk BEFORE attempting its Telegram delete (not
+ * after), so a crash mid-reap, or a second boot re-reading the file, can never
+ * re-issue a delete. A `deleteCard` failure (message already gone, chat
+ * unreachable, permissions changed) is swallowed — non-fatal, logged, and never
+ * re-attempted since the record is already gone. Returns counts for
+ * logging/testing.
+ */
+export async function runQueuedCardBootReaper(args: {
+  path: string
+  fs: QueuedCardStoreFsSeam
+  deleteCard: (record: QueuedCardRecord) => Promise<unknown>
+  log?: (line: string) => void
+}): Promise<{ deleted: number; total: number }> {
+  const log = args.log ?? ((l: string) => process.stderr.write(l))
+  const persisted = loadQueuedCards(args.path, args.fs)
+  if (persisted.length === 0) return { deleted: 0, total: 0 }
+  let deleted = 0
+  for (const record of persisted) {
+    // Delete BEFORE attempting the Telegram delete — the idempotency guard.
+    clearQueuedCardRecord(args.path, args.fs, record.key, record.messageId, log)
+    try {
+      await args.deleteCard(record)
+      deleted++
+    } catch (err) {
+      log(
+        `queued-card-store: boot reaper delete failed ` +
+          `(chat=${record.chatId} msg=${record.messageId}): ` +
+          `${(err as Error).message}\n`,
+      )
+    }
+  }
+  return { deleted, total: persisted.length }
+}

--- a/telegram-plugin/tests/queued-card-store.test.ts
+++ b/telegram-plugin/tests/queued-card-store.test.ts
@@ -1,0 +1,232 @@
+/**
+ * queued-card-store.test.ts — outcome-based tests for the queued-status /
+ * busy-ack card restart-survivability fix (#3002).
+ *
+ * PRE-FIX PROOF: before this change, no persistence existed for the
+ * `queuedStatusMsgIds` Map at all — `../gateway/queued-card-store.js` did not
+ * exist, so `import` itself failed at collection time and every test below
+ * failed on today's (pre-fix) base — there was no seam to test.
+ *
+ * This file exercises the REAL exported store + boot-reaper functions (not a
+ * structural grep), mirroring `activity-card-store.test.ts`'s in-memory fs seam
+ * convention, proving the exact outcome contract:
+ *   (a) card post persists a record;
+ *   (b) in-process reap clears it;
+ *   (c) a boot reaper against a leftover record performs EXACTLY ONE Telegram
+ *       delete and empties the store;
+ *   (d) a second boot performs ZERO deletes;
+ *   (e) a corrupt state file never crashes boot and is dropped without a delete;
+ *   (f) a delete failure never crashes the reaper and still clears the row.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  loadQueuedCards,
+  persistQueuedCards,
+  writeQueuedCardRecord,
+  clearQueuedCardRecord,
+  runQueuedCardBootReaper,
+  type QueuedCardRecord,
+  type QueuedCardStoreFsSeam,
+} from '../gateway/queued-card-store.js'
+
+/** In-memory fs seam with an atomic rename — same convention as
+ *  activity-card-store.test.ts's memFs, so the tmp→rename crash-safety
+ *  contract is exercised without touching real disk. */
+function memFs(seed: Record<string, string> = {}) {
+  const files = new Map<string, string>(Object.entries(seed))
+  const calls: string[] = []
+  const fs: QueuedCardStoreFsSeam = {
+    readFileSync: (p) => {
+      if (!files.has(p)) throw new Error(`ENOENT ${p}`)
+      return files.get(p)!
+    },
+    writeFileSync: (p, d) => {
+      calls.push(`write:${p}`)
+      files.set(p, d)
+    },
+    renameSync: (a, b) => {
+      calls.push(`rename:${a}->${b}`)
+      if (!files.has(a)) throw new Error(`ENOENT ${a}`)
+      files.set(b, files.get(a)!)
+      files.delete(a)
+    },
+    existsSync: (p) => files.has(p),
+  }
+  return { fs, files, calls }
+}
+
+const PATH = '/state/agent/telegram/queued-cards-pending.json'
+
+function card(over: Partial<QueuedCardRecord> = {}): QueuedCardRecord {
+  return {
+    key: '-100123:42',
+    chatId: '-100123',
+    threadId: 42,
+    messageId: 715,
+    ...over,
+  }
+}
+
+describe('queued-card-store — persistence primitives', () => {
+  it('loads [] when no file exists (fresh boot)', () => {
+    const { fs } = memFs()
+    expect(loadQueuedCards(PATH, fs)).toEqual([])
+  })
+
+  it('(a) card post → state persisted (round-trips a written record)', () => {
+    const { fs } = memFs()
+    const record = card()
+    writeQueuedCardRecord(PATH, fs, record)
+    const loaded = loadQueuedCards(PATH, fs)
+    expect(loaded).toHaveLength(1)
+    expect(loaded[0]).toEqual(record)
+  })
+
+  it('round-trips a DM card (threadId null)', () => {
+    const { fs } = memFs()
+    const record = card({ key: '-100123:', threadId: null })
+    writeQueuedCardRecord(PATH, fs, record)
+    expect(loadQueuedCards(PATH, fs)[0]).toEqual(record)
+  })
+
+  it('a fresh post for the same topic replaces (upserts) the stale row, not appends', () => {
+    const { fs } = memFs()
+    writeQueuedCardRecord(PATH, fs, card({ messageId: 715 }))
+    writeQueuedCardRecord(PATH, fs, card({ messageId: 900 }))
+    const loaded = loadQueuedCards(PATH, fs)
+    expect(loaded).toHaveLength(1)
+    expect(loaded[0]!.messageId).toBe(900)
+  })
+
+  it('keeps rows for distinct keys (different topics) side by side', () => {
+    const { fs } = memFs()
+    writeQueuedCardRecord(PATH, fs, card({ key: '-100123:42', messageId: 715 }))
+    writeQueuedCardRecord(PATH, fs, card({ key: '-100123:43', messageId: 716 }))
+    expect(loadQueuedCards(PATH, fs)).toHaveLength(2)
+  })
+
+  it('(b) in-process reap → state cleared', () => {
+    const { fs } = memFs()
+    writeQueuedCardRecord(PATH, fs, card())
+    expect(loadQueuedCards(PATH, fs)).toHaveLength(1)
+    clearQueuedCardRecord(PATH, fs, '-100123:42')
+    expect(loadQueuedCards(PATH, fs)).toEqual([])
+  })
+
+  it('clearing an absent/mismatched key is a no-op (never throws)', () => {
+    const { fs } = memFs()
+    writeQueuedCardRecord(PATH, fs, card({ key: '-100123:99' }))
+    clearQueuedCardRecord(PATH, fs, '-100123:42')
+    expect(loadQueuedCards(PATH, fs)).toHaveLength(1)
+  })
+
+  it('reap-race guard: clear scoped to messageId leaves a fresh live card intact', () => {
+    const { fs } = memFs()
+    // A live turn posted a NEW card (msg 900) under the same key while a stale
+    // reap tries to clear the OLD one (msg 715) — the new row must survive.
+    writeQueuedCardRecord(PATH, fs, card({ messageId: 900 }))
+    clearQueuedCardRecord(PATH, fs, '-100123:42', 715)
+    const loaded = loadQueuedCards(PATH, fs)
+    expect(loaded).toHaveLength(1)
+    expect(loaded[0]!.messageId).toBe(900)
+  })
+
+  it('writes via tmp + atomic rename (crash-safe)', () => {
+    const { fs, calls } = memFs()
+    persistQueuedCards(PATH, fs, [card()])
+    expect(calls).toEqual([`write:${PATH}.tmp`, `rename:${PATH}.tmp->${PATH}`])
+  })
+
+  it('(e) corrupt state file: boot survives, loads as [] (fail-open, never throws)', () => {
+    const { fs } = memFs({ [PATH]: '{not json' })
+    expect(() => loadQueuedCards(PATH, fs)).not.toThrow()
+    expect(loadQueuedCards(PATH, fs)).toEqual([])
+  })
+
+  it('fail-open: wrong envelope version / malformed shape loads as []', () => {
+    const { fs: f1 } = memFs({ [PATH]: JSON.stringify({ v: 2, cards: [card()] }) })
+    expect(loadQueuedCards(PATH, f1)).toEqual([])
+    const { fs: f2 } = memFs({ [PATH]: JSON.stringify({ v: 1, cards: 'nope' }) })
+    expect(loadQueuedCards(PATH, f2)).toEqual([])
+    const { fs: f3 } = memFs({ [PATH]: JSON.stringify({ v: 1, cards: [{ key: '' }] }) })
+    expect(loadQueuedCards(PATH, f3)).toEqual([])
+  })
+})
+
+describe('queued-card-store — boot reaper (reap-on-boot, delete is the terminal)', () => {
+  it('(c) deletes each persisted card EXACTLY ONCE and empties the store', async () => {
+    const { fs } = memFs()
+    writeQueuedCardRecord(PATH, fs, card({ key: '-100123:42', messageId: 715 }))
+    writeQueuedCardRecord(PATH, fs, card({ key: '-100123:43', messageId: 716 }))
+    const deletes: number[] = []
+    const res = await runQueuedCardBootReaper({
+      path: PATH,
+      fs,
+      deleteCard: async (r) => {
+        deletes.push(r.messageId)
+        return { message_id: r.messageId }
+      },
+    })
+    expect(res).toEqual({ deleted: 2, total: 2 })
+    expect(deletes.sort()).toEqual([715, 716])
+    // Store is emptied — the stale cards can never be re-reaped.
+    expect(loadQueuedCards(PATH, fs)).toEqual([])
+  })
+
+  it('(d) a SECOND boot performs ZERO deletes (store already drained)', async () => {
+    const { fs } = memFs()
+    writeQueuedCardRecord(PATH, fs, card())
+    await runQueuedCardBootReaper({ path: PATH, fs, deleteCard: async () => ({}) })
+    const deletes: number[] = []
+    const res = await runQueuedCardBootReaper({
+      path: PATH,
+      fs,
+      deleteCard: async (r) => {
+        deletes.push(r.messageId)
+        return {}
+      },
+    })
+    expect(res).toEqual({ deleted: 0, total: 0 })
+    expect(deletes).toEqual([])
+  })
+
+  it('deletes the record BEFORE the delete call (idempotency guard — no double-delete on crash)', async () => {
+    const { fs } = memFs()
+    writeQueuedCardRecord(PATH, fs, card({ messageId: 715 }))
+    let storeAtDeleteTime: QueuedCardRecord[] | null = null
+    await runQueuedCardBootReaper({
+      path: PATH,
+      fs,
+      deleteCard: async () => {
+        // At the moment the Telegram delete runs, the row is already gone from
+        // disk — a crash here or a concurrent second boot cannot re-issue it.
+        storeAtDeleteTime = loadQueuedCards(PATH, fs)
+        return {}
+      },
+    })
+    expect(storeAtDeleteTime).toEqual([])
+  })
+
+  it('(f) a delete FAILURE never crashes the reaper and still clears the row (best-effort, tolerate "not found")', async () => {
+    const { fs } = memFs()
+    writeQueuedCardRecord(PATH, fs, card({ messageId: 715 }))
+    const res = await runQueuedCardBootReaper({
+      path: PATH,
+      fs,
+      deleteCard: async () => {
+        throw new Error('Bad Request: message to delete not found')
+      },
+      log: () => {},
+    })
+    // Not counted as deleted, but the row is dropped (delete-first) so it can't
+    // wedge every future boot.
+    expect(res).toEqual({ deleted: 0, total: 1 })
+    expect(loadQueuedCards(PATH, fs)).toEqual([])
+  })
+
+  it('empty store: reaper is a no-op', async () => {
+    const { fs } = memFs()
+    const res = await runQueuedCardBootReaper({ path: PATH, fs, deleteCard: async () => ({}) })
+    expect(res).toEqual({ deleted: 0, total: 0 })
+  })
+})


### PR DESCRIPTION
## Summary

The component-5 queued-status placeholder and the #2995 mid-flight busy-ack card (PR #3000) track their sent Telegram message ids only in the in-memory `queuedStatusMsgIds` Map in `telegram-plugin/gateway/gateway.ts`. A gateway restart between posting a card and its in-process promote/reap empties that Map, stranding a permanent stale "⏳ Queued…" line above the real answer.

Closes #3002.

## Why / design

- **New store `telegram-plugin/gateway/queued-card-store.ts`** persists `{key, chatId, threadId, messageId}` under `TELEGRAM_STATE_DIR` (`queued-cards-pending.json`). It mirrors `activity-card-store.ts` — the closest precedent (a delete/finalize-on-boot orphan, not an unpin) — with the same `v:1` envelope, write-tmp + atomic rename crash-safety, fail-open `[]` load, and delete-record-from-disk-BEFORE-Telegram-call idempotency guard. Simpler than the pin stores by design: a Telegram delete needs no retry counter (deleting an already-gone message is tolerated).
- **Boot sweep** (`queuedCardBootReaper`, wired next to `activityCardBootReaper` at both startup-mutex-won sites): deletes each persisted card via `robustApiCall(deleteMessage)` best-effort, then the store is empty. A "Queued" / "On it" claim is always wrong after a restart, so **deletion is the honest terminal**. Scope is deliberately **reap-on-boot only — no promote-across-restart**, per the issue's direction.
- **Promote vs reap deviation from the issue wording:** the issue said to remove the entry on "promoted/deleted", but in the source `promoteQueuedStatus` only *edits* the card ("On it — replying now") and leaves it in the map; only `reapQueuedStatus` deletes. Clearing the persisted row at promote would strand an "On it" card on a restart-before-reap. So the write-through mirrors the in-memory map exactly: persist at the two `set()` sites (`postQueuedStatus`, `postBusyAck`), clear at the one `delete()` site (`reapQueuedStatus`, scoped to the exact messageId as a reap-race guard).
- Gateway diff is minimal: import block, store path + fs seam + two thin helpers, write-through at the three existing map sites, one boot-reaper wrapper + two call sites.

Job spec: `reference/jobs/restart-and-know-what-im-running.md` / always-available — a restart must not leave stale, dishonest chat surfaces behind.

## Test plan

- `telegram-plugin/tests/queued-card-store.test.ts` — 16 vitest cases against the real exported store + reaper (in-memory fs seam, mirroring `activity-card-store.test.ts`): post persists; DM (null-thread) round-trip; upsert per key; in-process reap clears; messageId-scoped clear leaves a fresh live card intact; tmp+rename ordering; corrupt/malformed file fails open; boot sweep deletes each card exactly once and empties the store; a second boot performs zero deletes; store row is gone before the Telegram delete fires; a delete failure is swallowed and still drains the row.
- Scoped vitest: 16/16 green. `check-bot-api-wrapping`, `check-bun-test-imports`, `check-no-pii-secrets` clean; root `tsc --noEmit` clean.

## Risk

Low. Additive store; write-throughs are best-effort and gated off in STATIC mode; boot sweep only runs after winning the startup mutex (same ordering constraint as the sibling cleanups) and only touches messages this gateway itself persisted.

Refs #3000, #2995.

🤖 Generated with [Claude Code](https://claude.com/claude-code)