### PR TITLE
fix(cron): close 5-min floor bypass for CSV/range/step minute forms (#1783)

### DIFF
--- a/src/agents/reconcile-dry-run.test.ts
+++ b/src/agents/reconcile-dry-run.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { violatesMinInterval } from "./reconcile-dry-run.js";
+
+// #1783 — violatesMinInterval used to recognise only `*/N` and the bare
+// every-minute form, so CSV / range / step-on-range minute fields bypassed
+// the 5-minute floor at the reconcile layer. It now delegates to the shared
+// cron-gap helper. Assert the rejection BOOLEAN outcome directly.
+describe("violatesMinInterval (#1783)", () => {
+  it.each([
+    ["every minute `*`", "* * * * *"],
+    ["CSV clustered `0,1,2`", "0,1,2 * * * *"],
+    ["range `0-4`", "0-4 * * * *"],
+    ["step-on-range `0-30/2`", "0-30/2 * * * *"],
+    ["stepped `*/4`", "*/4 * * * *"],
+    ["wraparound `58,59`", "58,59 * * * *"],
+    ["every-minute-during-hour `* 1 * * *`", "* 1 * * *"],
+  ])("rejects sub-floor cadence: %s", (_label, expr) => {
+    expect(violatesMinInterval(expr)).toBe(true);
+  });
+
+  it.each([
+    ["`0,30` (30-min)", "0,30 * * * *"],
+    ["`*/5` (== floor)", "*/5 * * * *"],
+    ["single minute `15` (hourly)", "15 * * * *"],
+    ["daily `0 9 * * *`", "0 9 * * *"],
+  ])("accepts at-or-above-floor cadence: %s", (_label, expr) => {
+    expect(violatesMinInterval(expr)).toBe(false);
+  });
+
+  it.each([
+    ["unknown shape `bogus`", "bogus"],
+    ["out-of-range minute `75`", "75 * * * *"],
+    ["too-few fields `* *`", "* *"],
+  ])("passes through unparseable / out-of-range form: %s", (_label, expr) => {
+    expect(violatesMinInterval(expr)).toBe(false);
+  });
+});

--- a/src/agents/reconcile-dry-run.test.ts
+++ b/src/agents/reconcile-dry-run.test.ts
@@ -22,6 +22,7 @@ describe("violatesMinInterval (#1783)", () => {
     ["`0,30` (30-min)", "0,30 * * * *"],
     ["`*/5` (== floor)", "*/5 * * * *"],
     ["single minute `15` (hourly)", "15 * * * *"],
+    ["`*/7` (nominal 7 ≥ floor; wraparound seam not policed)", "*/7 * * * *"],
     ["daily `0 9 * * *`", "0 9 * * *"],
   ])("accepts at-or-above-floor cadence: %s", (_label, expr) => {
     expect(violatesMinInterval(expr)).toBe(false);

--- a/src/agents/reconcile-dry-run.ts
+++ b/src/agents/reconcile-dry-run.ts
@@ -27,6 +27,7 @@ import { OverlayDocSchema, type OverlayDoc } from "../config/overlay-schema.js";
 import { ScheduleEntrySchema } from "../config/schema.js";
 import { cronUnitName } from "./cron-unit-name.js";
 import { classifyChangeKind } from "./lifecycle.js";
+import { cronMinuteSmallestGapMin } from "../scheduler/cron-gap.js";
 
 export interface DryRunOk {
   ok: true;
@@ -52,26 +53,20 @@ export type DryRunResult = DryRunOk | DryRunErr;
 const MIN_CRON_INTERVAL_SECS = 5 * 60;
 
 /**
- * Best-effort cron-interval check. We parse the simple star-slash-n minute form
- * and reject anything tighter than every-5-minutes. More elaborate
- * expressions pass through this check (we don't bring in a full cron
- * parser here); operator-approved entries via switchroom.yaml are
- * unaffected.
+ * Cron-interval floor check. Delegates to the shared minute-cadence helper
+ * (`cronMinuteSmallestGapMin`, src/scheduler/cron-gap.ts), which expands the
+ * minute field to the set of matched minutes and computes the smallest
+ * circular gap. This covers `*`, `*\/N`, single values, CSV lists, ranges
+ * (`0-4`), and step-on-range/list (`0-30/2`) — closing the earlier bypass
+ * where CSV/range forms slipped past the floor (switchroom #1783).
+ *
+ * A gap of 0 means "unknown / unparseable minute field" and passes through
+ * (we don't bring in a full cron parser); operator-approved entries via
+ * switchroom.yaml are unaffected.
  */
 export function violatesMinInterval(cron: string): boolean {
-  const parts = cron.trim().split(/\s+/);
-  if (parts.length < 5) return false;
-  const minuteField = parts[0];
-  const m = /^\*\/(\d+)$/.exec(minuteField);
-  if (m) {
-    const n = parseInt(m[1], 10);
-    if (Number.isFinite(n) && n > 0 && n * 60 < MIN_CRON_INTERVAL_SECS) {
-      return true;
-    }
-  }
-  // every-minute form: star star star star star
-  if (minuteField === "*" && parts[1] === "*") return true;
-  return false;
+  const gapMin = cronMinuteSmallestGapMin(cron);
+  return gapMin > 0 && gapMin * 60 < MIN_CRON_INTERVAL_SECS;
 }
 
 export function dryRunReconcile(input: {

--- a/src/cli/agent-config-write.test.ts
+++ b/src/cli/agent-config-write.test.ts
@@ -103,6 +103,32 @@ describe("scheduleAdd — security gates", () => {
     expect(r.exit).toBe(9);
   });
 
+  // #1783 — CSV / range / step-on-range forms previously bypassed the
+  // 5-min floor. Assert they are now rejected with E_CRON_TOO_FREQUENT.
+  it.each([
+    ["CSV clustered `0,1,2`", "0,1,2 * * * *"],
+    ["range `0-4`", "0-4 * * * *"],
+    ["step-on-range `0-30/2`", "0-30/2 * * * *"],
+    ["wraparound `58,59`", "58,59 * * * *"],
+    ["every-minute-during-hour `* 1 * * *`", "* 1 * * *"],
+  ])("rejects sub-floor cadence %s (#1783)", (_label, cronExpr) => {
+    const r = scheduleAdd({ cronExpr, prompt: "spammy", root });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.code).toBe("E_CRON_TOO_FREQUENT");
+    expect(r.exit).toBe(9);
+  });
+
+  // #1783 — legal cadences at/above the floor must still be accepted.
+  it.each([
+    ["`0,30` (30-min)", "0,30 * * * *"],
+    ["`*/5` (== floor)", "*/5 * * * *"],
+    ["single minute `15` (hourly)", "15 * * * *"],
+  ])("accepts at-or-above-floor cadence %s (#1783)", (_label, cronExpr) => {
+    const r = scheduleAdd({ cronExpr, prompt: "fine", root });
+    expect(r.ok).toBe(true);
+  });
+
   // #1770 Phase 3 — envelope shape assertions parallel to the Phase 2
   // tests in tests/host-control/. The ScheduleErrorResult now carries
   // a `meta` side-channel that the CLI's emitError lifts into the
@@ -366,8 +392,25 @@ describe("extractCronSmallestGapMin (#1779)", () => {
   it("`*` → 1 (every minute)", () => {
     expect(extractCronSmallestGapMin("* * * * *")).toBe(1);
   });
-  it("range / unknown forms → 0", () => {
-    expect(extractCronSmallestGapMin("0-30 * * * *")).toBe(0);
+  // #1783 — range / step-on-range / single-value forms are now expanded
+  // (previously returned 0 and bypassed the floor).
+  it("range `0-4` → 1 (fires every minute for 5 mins)", () => {
+    expect(extractCronSmallestGapMin("0-4 * * * *")).toBe(1);
+  });
+  it("range `0-30` → 1", () => {
+    expect(extractCronSmallestGapMin("0-30 * * * *")).toBe(1);
+  });
+  it("step-on-range `0-30/2` → 2", () => {
+    expect(extractCronSmallestGapMin("0-30/2 * * * *")).toBe(2);
+  });
+  it("single value `15` → 60 (hourly)", () => {
+    expect(extractCronSmallestGapMin("15 * * * *")).toBe(60);
+  });
+  it("wraparound CSV `58,59` → 1 (circular gap)", () => {
+    expect(extractCronSmallestGapMin("58,59 * * * *")).toBe(1);
+  });
+  it("unparseable / out-of-range forms → 0 (unknown, pass through)", () => {
     expect(extractCronSmallestGapMin("bogus")).toBe(0);
+    expect(extractCronSmallestGapMin("75 * * * *")).toBe(0);
   });
 });

--- a/src/cli/agent-config-write.test.ts
+++ b/src/cli/agent-config-write.test.ts
@@ -124,6 +124,7 @@ describe("scheduleAdd — security gates", () => {
     ["`0,30` (30-min)", "0,30 * * * *"],
     ["`*/5` (== floor)", "*/5 * * * *"],
     ["single minute `15` (hourly)", "15 * * * *"],
+    ["`*/7` (nominal 7 ≥ floor; wraparound seam not policed)", "*/7 * * * *"],
   ])("accepts at-or-above-floor cadence %s (#1783)", (_label, cronExpr) => {
     const r = scheduleAdd({ cronExpr, prompt: "fine", root });
     expect(r.ok).toBe(true);

--- a/src/cli/agent-config-write.ts
+++ b/src/cli/agent-config-write.ts
@@ -70,6 +70,7 @@ import {
   summarizeScheduleReport,
 } from "../scheduler/schedule-report.js";
 import { buildEnvelope, type ErrorEnvelope } from "../host-control/protocol.js";
+import { cronMinuteSmallestGapMin } from "../scheduler/cron-gap.js";
 
 const MAX_ENTRIES_PER_AGENT = 20;
 
@@ -83,41 +84,30 @@ const MIN_CRON_INTERVAL_MIN = 5;
  * gap is below `MIN_CRON_INTERVAL_MIN`, the schedule fires too fast
  * and is refused.
  *
- * Semantics by minute-field shape:
- *   - `*`        → 1  (fires every minute)
- *   - `*\/N`     → N  (stepped cadence)
- *   - CSV list   → smallest pairwise gap between sorted values
- *                  (e.g. `0,1,2` → 1, `0,30` → 30, `0,15,30,45` → 15)
- *   - anything else (ranges, mixed) → 0 (unknown)
+ * Delegates to the shared `cronMinuteSmallestGapMin` helper
+ * (src/scheduler/cron-gap.ts), which expands the minute field to the set
+ * of matched minutes and takes the smallest **circular** gap. Coverage:
+ *   - `*`            → 1   (fires every minute)
+ *   - `*\/N`         → N   (stepped cadence)
+ *   - single value   → 60  (hourly; e.g. `15`)
+ *   - CSV list       → smallest circular pairwise gap
+ *                      (e.g. `0,1,2` → 1, `0,30` → 30, `58,59` → 1)
+ *   - range `A-B`    → 1   (e.g. `0-4` fires every minute for 5 mins)
+ *   - step-on-range  → step (e.g. `0-30/2` → 2)
+ *   - unparseable / out-of-range → 0 (unknown → pass through)
  *
- * NOTE: this is **not** the worst-case wait between fires. For CSV
- * lists clustered at the top of the hour like `0,1,2 * * * *`, the
- * worst-case wait is ~58 min (minute 2 → next hour's minute 0), but
- * the *smallest* gap is 1 — which is what the floor cares about.
- * Surfaced as `requested_interval_min` in the error envelope's
- * `quota_exceeded.current` field; receivers should read it as "the
- * tightest cadence the schedule implies", not "the user's wait time".
+ * Earlier this returned 0 for ranges and step-on-range/list forms, letting
+ * them bypass the floor (switchroom #1783); the shared helper closes that.
+ *
+ * NOTE: this is **not** the worst-case wait between fires. For CSV lists
+ * clustered at the top of the hour like `0,1,2 * * * *`, the worst-case
+ * wait is ~58 min, but the *smallest* gap is 1 — which is what the floor
+ * cares about. Surfaced as `requested_interval_min` in the error
+ * envelope's `quota_exceeded.current` field; receivers should read it as
+ * "the tightest cadence the schedule implies", not "the user's wait time".
  */
 export function extractCronSmallestGapMin(expr: string): number {
-  const fields = expr.trim().split(/\s+/);
-  if (fields.length < 5) return 0;
-  const min = fields[0];
-  if (min === "*") return 1;
-  const step = min.match(/^\*\/(\d+)$/);
-  if (step) return Number(step[1]);
-  if (min.includes(",")) {
-    const parts = min.split(",").map((s) => Number(s)).filter((n) => Number.isFinite(n));
-    if (parts.length >= 2) {
-      const sorted = [...parts].sort((a, b) => a - b);
-      let smallest = Infinity;
-      for (let i = 1; i < sorted.length; i++) {
-        const gap = sorted[i] - sorted[i - 1];
-        if (gap > 0 && gap < smallest) smallest = gap;
-      }
-      return Number.isFinite(smallest) ? smallest : 0;
-    }
-  }
-  return 0;
+  return cronMinuteSmallestGapMin(expr);
 }
 
 /**

--- a/src/scheduler/cron-gap.test.ts
+++ b/src/scheduler/cron-gap.test.ts
@@ -8,6 +8,8 @@ describe("cronMinuteSmallestGapMin (#1783)", () => {
     ["every minute `*`", "* * * * *", 1],
     ["stepped `*/5`", "*/5 * * * *", 5],
     ["stepped `*/4`", "*/4 * * * *", 4],
+    ["stepped `*/7` → nominal 7, not the 56→00 wraparound seam (4)", "*/7 * * * *", 7],
+    ["stepped `*/14` → nominal 14", "*/14 * * * *", 14],
     ["single value `15` → hourly", "15 * * * *", 60],
     ["CSV `0,1,2`", "0,1,2 * * * *", 1],
     ["CSV `0,30`", "0,30 * * * *", 30],

--- a/src/scheduler/cron-gap.test.ts
+++ b/src/scheduler/cron-gap.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { cronMinuteSmallestGapMin, expandMinuteField } from "./cron-gap.js";
+
+// #1783 — shared minute-cadence helper backing both the reconcile-layer
+// `violatesMinInterval` and the write-path `extractCronSmallestGapMin`.
+describe("cronMinuteSmallestGapMin (#1783)", () => {
+  it.each([
+    ["every minute `*`", "* * * * *", 1],
+    ["stepped `*/5`", "*/5 * * * *", 5],
+    ["stepped `*/4`", "*/4 * * * *", 4],
+    ["single value `15` → hourly", "15 * * * *", 60],
+    ["CSV `0,1,2`", "0,1,2 * * * *", 1],
+    ["CSV `0,30`", "0,30 * * * *", 30],
+    ["CSV `0,15,30,45`", "0,15,30,45 * * * *", 15],
+    ["wraparound `58,59`", "58,59 * * * *", 1],
+    ["range `0-4`", "0-4 * * * *", 1],
+    ["range `0-30`", "0-30 * * * *", 1],
+    ["step-on-range `0-30/2`", "0-30/2 * * * *", 2],
+    ["step-on-list `0,10,20/1` (list ∪ 20-59)", "0,10,20/1 * * * *", 1],
+    ["bare-N step `5/10` → 5,15,25,35,45,55", "5/10 * * * *", 10],
+    ["every-minute-during-hour `* 1 * * *`", "* 1 * * *", 1],
+  ])("%s → %d", (_label, expr, expected) => {
+    expect(cronMinuteSmallestGapMin(expr)).toBe(expected);
+  });
+
+  it.each([
+    ["unknown shape `bogus`", "bogus"],
+    ["out-of-range minute `75`", "75 * * * *"],
+    ["out-of-range in CSV `0,75`", "0,75 * * * *"],
+    ["out-of-range in range `0-75`", "0-75 * * * *"],
+    ["too-few fields `* *`", "* *"],
+    ["zero step `*/0`", "*/0 * * * *"],
+  ])("returns 0 (unknown) for %s", (_label, expr) => {
+    expect(cronMinuteSmallestGapMin(expr)).toBe(0);
+  });
+});
+
+describe("expandMinuteField (#1783)", () => {
+  it("expands a CSV of mixed terms, de-duped and sorted", () => {
+    expect(expandMinuteField("0-4,30,58,59")).toEqual([0, 1, 2, 3, 4, 30, 58, 59]);
+  });
+  it("returns null on an out-of-range value", () => {
+    expect(expandMinuteField("60")).toBeNull();
+  });
+});

--- a/src/scheduler/cron-gap.ts
+++ b/src/scheduler/cron-gap.ts
@@ -118,12 +118,27 @@ function smallestCircularGap(minutes: number[]): number {
  *
  * Returns 0 when the expression has fewer than 5 fields or the minute field
  * is unparseable / out of range ("unknown → pass through"). Otherwise the
- * smallest circular gap over the hour (single value → 60, hourly).
+ * smallest circular gap over the hour (single value → 60, hourly), except
+ * for the pure `*\/S` form which returns its nominal step S (see below).
  */
 export function cronMinuteSmallestGapMin(expr: string): number {
   const fields = expr.trim().split(/\s+/);
   if (fields.length < 5) return 0;
-  const minutes = expandMinuteField(fields[0]);
+  const minuteField = fields[0];
+
+  // Pure `*/S` keeps its long-standing NOMINAL semantics: return S, not the
+  // set-expansion circular gap. For steps that don't divide 60 (`*/7`,
+  // `*/8`, `*/14`), expansion would find one short wraparound seam per hour
+  // (e.g. `*/7` → …,56 → next hour's minute 0 = gap 4) and wrongly reject a
+  // cadence both call sites have always accepted. That single sub-S seam is
+  // not what the floor polices. Deliberate — see PR #3063 review.
+  const pureStep = minuteField.match(/^\*\/(\d+)$/);
+  if (pureStep) {
+    const s = Number(pureStep[1]);
+    return s > 0 && s <= 59 ? s : 0;
+  }
+
+  const minutes = expandMinuteField(minuteField);
   if (minutes === null) return 0;
   return smallestCircularGap(minutes);
 }

--- a/src/scheduler/cron-gap.ts
+++ b/src/scheduler/cron-gap.ts
@@ -1,0 +1,129 @@
+/**
+ * Shared cron minute-cadence helper (switchroom #1783).
+ *
+ * The 5-minute min-interval floor is enforced at two call sites that used
+ * to carry their own, weaker minute-field parsers:
+ *
+ *   - `violatesMinInterval` (src/agents/reconcile-dry-run.ts) recognised only
+ *     `*\/N` and the bare every-minute form, so CSV (`0,1,2`), ranges
+ *     (`0-4`), and step-on-range (`0-30/2`) all slipped past the floor.
+ *   - `extractCronSmallestGapMin` (src/cli/agent-config-write.ts) handled
+ *     `*`, `*\/N`, and plain CSV but returned 0 (unknown → pass) for ranges,
+ *     step-on-range, and step-on-list.
+ *
+ * Both now delegate here. The approach is exhaustive rather than
+ * pattern-by-pattern: expand the minute field to the concrete SET of
+ * minutes (0–59) it matches, then take the smallest **circular** gap over
+ * the 60-minute cycle. That closes the bypass for every standard cron
+ * minute form in one place.
+ *
+ * Semantics:
+ *   - Returns the smallest gap in minutes between consecutive fires implied
+ *     by the minute field (and, for a `*` minute, the fact that it fires
+ *     every minute of every matched hour → gap 1).
+ *   - A single matched minute (e.g. `15`) → 60 (hourly): the only wrap is
+ *     this-hour's minute to next-hour's same minute.
+ *   - Wraparound is honoured: `58,59` → 1 (58→59 = 1), not 58.
+ *   - An **unparseable** minute field (unknown shape, or any out-of-range
+ *     value like `75`) → 0, meaning "unknown — pass through". Callers keep
+ *     their existing permissive behaviour for exotic-but-legal forms rather
+ *     than rejecting blindly.
+ *
+ * This is intentionally distinct from `estimateCronGapMin` in
+ * cron-cadence.ts: that estimator serves *tier selection*, reads the HOUR
+ * field to distinguish hourly from daily, and is conservative in the
+ * opposite direction (unknown → Infinity → "treat as infrequent"). The
+ * floor wants unknown → 0 → "let it pass"; consolidating the two would
+ * force one policy onto both. See cron-cadence.ts for that rationale.
+ */
+
+/**
+ * Expand a single cron minute-field term into the set of matched minutes.
+ * Supported term shapes: `*`, `*\/S`, `N`, `A-B`, `A-B/S`.
+ * Returns `null` if the term is malformed or references an out-of-range
+ * minute (outside 0–59).
+ */
+function expandMinuteTerm(term: string): number[] | null {
+  // Step form: BASE/S where BASE is `*` or a range `A-B` (or a bare `A`,
+  // treated as `A-59` per cron convention: `5/10` → 5,15,25,...).
+  const slash = term.indexOf("/");
+  let base = term;
+  let step = 1;
+  if (slash !== -1) {
+    const stepStr = term.slice(slash + 1);
+    if (!/^\d+$/.test(stepStr)) return null;
+    step = Number(stepStr);
+    if (step <= 0) return null;
+    base = term.slice(0, slash);
+  }
+
+  let lo: number;
+  let hi: number;
+  if (base === "*") {
+    lo = 0;
+    hi = 59;
+  } else if (/^\d+$/.test(base)) {
+    lo = Number(base);
+    // A bare number with a step means "from N to end of range".
+    hi = slash !== -1 ? 59 : lo;
+  } else {
+    const range = base.match(/^(\d+)-(\d+)$/);
+    if (!range) return null;
+    lo = Number(range[1]);
+    hi = Number(range[2]);
+  }
+
+  if (lo < 0 || hi > 59 || lo > hi) return null;
+
+  const out: number[] = [];
+  for (let m = lo; m <= hi; m += step) out.push(m);
+  return out;
+}
+
+/**
+ * Expand a full cron minute field (a CSV of terms, or a single term) to the
+ * sorted, de-duplicated set of matched minutes. Returns `null` if any term
+ * is unparseable / out of range.
+ */
+export function expandMinuteField(field: string): number[] | null {
+  if (field.length === 0) return null;
+  const set = new Set<number>();
+  for (const term of field.split(",")) {
+    const expanded = expandMinuteTerm(term);
+    if (expanded === null) return null;
+    for (const m of expanded) set.add(m);
+  }
+  if (set.size === 0) return null;
+  return [...set].sort((a, b) => a - b);
+}
+
+/**
+ * Smallest **circular** gap (minutes) between consecutive matched minutes
+ * over the 60-minute cycle. A single matched minute → 60 (fires hourly).
+ */
+function smallestCircularGap(minutes: number[]): number {
+  if (minutes.length === 1) return 60;
+  let smallest = Infinity;
+  for (let i = 0; i < minutes.length; i++) {
+    const next = minutes[(i + 1) % minutes.length];
+    const gap = i + 1 < minutes.length ? next - minutes[i] : next + 60 - minutes[i];
+    if (gap > 0 && gap < smallest) smallest = gap;
+  }
+  return Number.isFinite(smallest) ? smallest : 60;
+}
+
+/**
+ * Smallest gap, in minutes, between consecutive fires implied by the MINUTE
+ * field of a 5-field cron expression.
+ *
+ * Returns 0 when the expression has fewer than 5 fields or the minute field
+ * is unparseable / out of range ("unknown → pass through"). Otherwise the
+ * smallest circular gap over the hour (single value → 60, hourly).
+ */
+export function cronMinuteSmallestGapMin(expr: string): number {
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length < 5) return 0;
+  const minutes = expandMinuteField(fields[0]);
+  if (minutes === null) return 0;
+  return smallestCircularGap(minutes);
+}


### PR DESCRIPTION
## What

`violatesMinInterval` (`src/agents/reconcile-dry-run.ts`) and `extractCronSmallestGapMin` (`src/cli/agent-config-write.ts`) each carried their own weak minute-field parser recognising only `*/N` and the bare every-minute form. CSV (`0,1,2`), ranges (`0-4`), and step-on-range (`0-30/2`) all bypassed the 5-minute floor at **both** the reconcile and write layers.

## Fix

- New shared helper **`cronMinuteSmallestGapMin`** in `src/scheduler/cron-gap.ts` (neutral location — both `agents` and `cli` already import from `scheduler`; no layering violation). It expands the minute field to the concrete set of matched minutes (`*`, `N`, `*/S`, `A-B`, `A-B/S`, CSV of any, step-on-list) and returns the smallest **circular** gap over the 60-minute cycle. Single value → 60 (hourly); wraparound `58,59` → 1. Unparseable / out-of-range (e.g. minute `75`) → 0 = "unknown, pass through".
- `violatesMinInterval` now delegates: violation iff `0 < gap*60 < MIN_CRON_INTERVAL_SECS`.
- `extractCronSmallestGapMin` delegates too, preserving its exported signature (still feeds `requested_interval_min` in the error envelope).
- Doc comments documenting the old blindspot updated.

### `estimateCronGapMin` left separate (deliberate)

`estimateCronGapMin` (`src/scheduler/cron-cadence.ts`) is a third parallel implementation but serves **tier selection**, not the floor. It reads the HOUR field to distinguish hourly (60) from daily (1440) and is conservative in the **opposite** direction: unknown → `Infinity` ("treat as infrequent", never strip context from an unreadable cron). The floor wants unknown → 0 ("let it pass"). Consolidating would force one policy onto both, so it stays separate; the distinction is documented in `cron-gap.ts`.

## Tests

Outcome-asserting tests at all three layers (79 in the scoped files, all green):
- **Helper** (`cron-gap.test.ts`): CSV/range/step-on-range/step-on-list/wraparound gaps; unknown/out-of-range → 0.
- **Reconcile** (`reconcile-dry-run.test.ts`, new): `violatesMinInterval` boolean — `0,1,2` / `0-4` / `0-30/2` / `58,59` / `* 1 * * *` rejected; `0,30` / `*/5` / `15` / daily accepted; unparseable passes through.
- **Write** (`agent-config-write.test.ts`): `scheduleAdd` returns `E_CRON_TOO_FREQUENT` (exit 9) for the sub-floor forms; accepts at/above floor. Updated the `#1779` helper test that previously asserted the `0-30 → 0` blindspot.

`npm run lint` (tsc + repo guards) clean.

Fixes #1783

🤖 Generated with [Claude Code](https://claude.com/claude-code)