### PR TITLE
security(hostd): front docker socket with tecnativa proxy sidecar (#1842)

### DIFF
--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -12,6 +12,7 @@ import { mkdtempSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  DOCKER_SOCKET_PROXY_IMAGE,
   renderHostdComposeFile,
   resolveHostdHostHome,
   resolveHostdImageTag,
@@ -56,8 +57,6 @@ describe("renderHostdComposeFile", () => {
     expect(out).not.toContain(
       "/home/alice/.switchroom/switchroom.yaml:/state/config/switchroom.yaml:ro",
     );
-    // docker.sock is a fixed host path; bind-mount is host-home-agnostic.
-    expect(out).toContain("/var/run/docker.sock:/var/run/docker.sock:rw");
     // machine-id must be mounted so resolveOperatorVaultPassphrase can
     // decrypt the auto-unlock blob and provision LiteLLM keys during rollout.
     expect(out).toContain("/etc/machine-id:/etc/machine-id:ro");
@@ -181,6 +180,117 @@ describe("renderHostdComposeFile", () => {
   it("declares its own network so the hostd project doesn't accidentally join the agent fleet's net", () => {
     const out = renderHostdComposeFile({ hostHome: "/h", imageTag: "latest" });
     expect(out).toContain("name: switchroom-hostd-net");
+  });
+});
+
+describe("renderHostdComposeFile — docker-socket-proxy sidecar (#1842 / #1400 T4)", () => {
+  const render = () =>
+    renderHostdComposeFile({ hostHome: "/home/alice", imageTag: "latest" });
+
+  it("emits a docker-socket-proxy service pinned by digest", () => {
+    const out = render();
+    expect(out).toContain("docker-socket-proxy:");
+    expect(out).toContain(`image: ${DOCKER_SOCKET_PROXY_IMAGE}`);
+    // Pinned by BOTH tag and digest — a moved tag must not swap the binary
+    // guarding the host socket.
+    expect(DOCKER_SOCKET_PROXY_IMAGE).toMatch(
+      /^ghcr\.io\/tecnativa\/docker-socket-proxy:v\d+\.\d+\.\d+@sha256:[0-9a-f]{64}$/,
+    );
+    expect(out).toContain("container_name: switchroom-hostd-docker-proxy");
+  });
+
+  it("gives the RAW socket to the proxy only, mounted :ro", () => {
+    const out = render();
+    // Exactly one raw-socket bind, and it lives on the proxy as :ro.
+    expect(out).toContain("/var/run/docker.sock:/var/run/docker.sock:ro");
+    // Count actual volume-list entries (a YAML "- /var/run/docker.sock:…"
+    // line), not prose mentions in comments.
+    expect(
+      out
+        .split("\n")
+        .filter((l) => /^\s*- \/var\/run\/docker\.sock:/.test(l)).length,
+    ).toBe(1);
+  });
+
+  it("does NOT mount the raw docker socket into hostd (rw or ro)", () => {
+    const out = render();
+    // The whole point of #1842: hostd never touches the raw socket.
+    expect(out).not.toContain("/var/run/docker.sock:/var/run/docker.sock:rw");
+    // And the single :ro mount belongs to the proxy service, above the hostd
+    // service block — assert ordering so it can't drift onto hostd.
+    const proxyIdx = out.indexOf("container_name: switchroom-hostd-docker-proxy");
+    const hostdIdx = out.indexOf("container_name: switchroom-hostd\n");
+    const sockIdx = out.indexOf("/var/run/docker.sock:/var/run/docker.sock:ro");
+    expect(proxyIdx).toBeGreaterThanOrEqual(0);
+    expect(hostdIdx).toBeGreaterThan(proxyIdx);
+    expect(sockIdx).toBeGreaterThan(proxyIdx);
+    expect(sockIdx).toBeLessThan(hostdIdx);
+  });
+
+  it("points hostd at the proxy over TCP via DOCKER_HOST", () => {
+    const out = render();
+    expect(out).toContain("DOCKER_HOST: tcp://docker-socket-proxy:2375");
+  });
+
+  it("makes hostd depend on the proxy so it's up first", () => {
+    const out = render();
+    expect(out).toMatch(/depends_on:[\s\S]*?- docker-socket-proxy/);
+  });
+
+  it("hardens the proxy: read-only rootfs, cap_drop ALL, no-new-privileges", () => {
+    const out = render();
+    // Scope assertions to the proxy service block (everything before hostd).
+    const proxyBlock = out.slice(
+      out.indexOf("docker-socket-proxy:"),
+      out.indexOf("  hostd:"),
+    );
+    expect(proxyBlock).toContain("read_only: true");
+    expect(proxyBlock).toMatch(/cap_drop:\s*\n\s+- ALL/);
+    expect(proxyBlock).toContain("no-new-privileges:true");
+    expect(proxyBlock).toContain("tmpfs:");
+  });
+
+  it("sets the endpoint allowlist to EXACTLY the flags hostd's call set needs", () => {
+    const out = render();
+    const proxyBlock = out.slice(
+      out.indexOf("docker-socket-proxy:"),
+      out.indexOf("  hostd:"),
+    );
+    // The exact allowlist determined by auditing hostd's docker call set
+    // (see PR #1842 justification table). Assert each flag AND its value.
+    const expected: Record<string, string> = {
+      CONTAINERS: "1", // docker ps/inspect/logs/stats, compose create, self-bump run
+      IMAGES: "1", // image inspect, RepoDigest resolve, compose pull
+      NETWORKS: "1", // compose up project network
+      VOLUMES: "1", // compose up per-agent named socket volumes
+      EXEC: "1", // agent_exec + liveness battery
+      INFO: "1", // compose/docker /info preflight
+      VERSION: "1", // docker compose version preflight
+      POST: "1", // master write gate (create/pull/exec-start/wait/rm/run)
+      ALLOW_START: "1", // agent start
+      ALLOW_STOP: "1", // agent stop
+      ALLOW_RESTARTS: "1", // agent restart
+      BUILD: "0", // dev-only path; kept DENIED to keep surface minimal
+    };
+    for (const [flag, val] of Object.entries(expected)) {
+      expect(proxyBlock).toMatch(
+        new RegExp(`^\\s+${flag}: "${val}"$`, "m"),
+      );
+    }
+    // Negative space: swarm/secret/system endpoints hostd never calls must
+    // NOT be enabled.
+    for (const denied of [
+      "SWARM",
+      "SERVICES",
+      "SECRETS",
+      "CONFIGS",
+      "NODES",
+      "TASKS",
+      "PLUGINS",
+      "SYSTEM",
+    ]) {
+      expect(proxyBlock).not.toContain(`${denied}: "1"`);
+    }
   });
 });
 

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -328,7 +328,20 @@ services:
       # issues \`docker run -d -v /var/run/docker.sock:…\` through the proxy
       # (a container-create call), and dockerd resolves that host bind source
       # on the HOST — the helper still gets the real socket to \`compose up\`
-      # the recreated hostd. No path retains a raw socket in hostd itself.
+      # the recreated hostd. hostd itself never mounts the raw socket.
+      #
+      # HONEST LIMIT — blast-surface reduction, NOT a hard boundary. With
+      # CONTAINERS+POST allowed (required for compose up / self-bump), a
+      # FULLY compromised hostd can still create a container that
+      # bind-mounts /var/run/docker.sock (or /) — the same mechanism
+      # self-bump uses legitimately — and take over the host in ONE create
+      # call. What the proxy removes is the STANDING socket and the
+      # accidental / low-effort surface (no GET-me-everything socket lying
+      # in the container; every call is an allowlisted HTTP endpoint).
+      # The real boundary against a determined attacker is the operator
+      # approval-card layer (#1427); closing the residual hole would mean
+      # dropping container-create — i.e. dropping self-bump and
+      # compose-driven rollout — which is out of scope here.
       # /etc/machine-id passthrough — the vault auto-unlock blob
       # (~/.switchroom/vault-auto-unlock) is encrypted with a key derived
       # from the host machine-id. Without this mount, readAutoUnlockFile

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -124,6 +124,16 @@ export function captureHostTimezone(
 const HOSTD_COMPOSE_PROJECT = "switchroom-hostd";
 
 /**
+ * Pinned image for the docker-socket-proxy sidecar (#1842 / #1400 T4).
+ * tecnativa/docker-socket-proxy is a minimal HAProxy that fronts the raw
+ * docker socket with a per-endpoint allowlist. Pinned by tag AND digest so
+ * the generated compose is supply-chain-deterministic (a moved tag can't
+ * silently swap the proxy binary that guards the host socket).
+ */
+export const DOCKER_SOCKET_PROXY_IMAGE =
+  "ghcr.io/tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476";
+
+/**
  * Render the sibling compose file. Pure-string template — the only
  * variable is the host home directory (for the bind mounts that map
  * `~/.switchroom` and `/var/run/docker.sock` into the daemon).
@@ -185,11 +195,87 @@ export function renderHostdComposeFile(opts: {
 # cannot recreate this daemon mid-RPC. See RFC C §5.1.
 
 services:
+  # docker-socket-proxy (#1842 / #1400 T4) — the ONLY container that touches
+  # the raw docker socket. A minimal HAProxy (tecnativa/docker-socket-proxy)
+  # that exposes the docker API over TCP :2375 with a per-endpoint allowlist,
+  # so hostd (and the switchroom CLI it spawns) can drive the fleet without a
+  # host-takeover-grade socket in an attacker-influenceable container. The
+  # image is pinned by digest for supply-chain determinism.
+  docker-socket-proxy:
+    image: ${DOCKER_SOCKET_PROXY_IMAGE}
+    container_name: switchroom-hostd-docker-proxy
+    restart: always
+    read_only: true
+    tmpfs:
+      # HAProxy writes its runtime state/pidfile under /run; read_only rootfs
+      # otherwise makes it crash-loop on boot.
+      - /run
+    cap_drop:
+      - ALL
+    cap_add:
+      # HAProxy master drops privileges to the haproxy user at startup.
+      - SETUID
+      - SETGID
+      - DAC_OVERRIDE
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      # ── Endpoint allowlist — the MINIMUM that covers hostd's real call set.
+      #    Each flag is justified by an actual hostd/CLI call site (see #1842
+      #    PR body). Unset sections default to 0 (denied) in the proxy.
+      #
+      # GET /containers/* — agent_status (docker inspect/stats/ps),
+      # agent_logs (docker logs), self-bump helper create, compose
+      # container lifecycle. server.ts runDocker + getAllAgentStatuses.
+      CONTAINERS: "1"
+      # GET /images/* + POST /images/create — \`docker image inspect\`,
+      # RepoDigest resolution (server.ts:309), \`docker compose pull\`.
+      IMAGES: "1"
+      # /networks/* — \`docker compose up\` creates/inspects the fleet's
+      # project network (compose.ts networks: block).
+      NETWORKS: "1"
+      # /volumes/* — \`docker compose up\` creates/inspects the per-agent
+      # named socket volumes (compose.ts volumes: block, broker-*-sock …).
+      VOLUMES: "1"
+      # /exec/* — agent_exec + the read-only in-agent liveness battery
+      # (server.ts dockerExec, protocol.ts:252/331).
+      EXEC: "1"
+      # /info + /version — compose/docker preflight (\`docker compose version\`,
+      # daemon /info probed by compose up).
+      INFO: "1"
+      VERSION: "1"
+      # POST master gate — enables the mutating calls in the allowed sections:
+      # compose container create, \`docker compose pull\` (POST /images/create),
+      # \`docker exec\` start, \`docker wait\`, \`docker rm\`, self-bump
+      # \`docker run -d\`. Without it every write returns 403.
+      POST: "1"
+      # Fine-grained container lifecycle — \`agent start/stop/restart\`
+      # (server.ts handleAgentStart/Stop/Restart, \`docker compose
+      # start/stop/restart <service>\`).
+      ALLOW_START: "1"
+      ALLOW_STOP: "1"
+      ALLOW_RESTARTS: "1"
+      # BUILD stays DENIED — production rollout uses prebuilt GHCR images;
+      # \`docker compose up --build\` is a dev-only path (apply --build) that
+      # never runs inside hostd. Left off to keep the surface minimal.
+      BUILD: "0"
+    volumes:
+      # The one raw-socket mount in the whole hostd project. :ro is the
+      # tecnativa-recommended mount — the proxy still issues writes over the
+      # socket fd; :ro only prevents replacing the socket file itself.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - default
   hostd:
     image: ghcr.io/switchroom/switchroom-hostd:${imageTag}
     container_name: switchroom-hostd
     restart: always
     user: "0:0"
+    depends_on:
+      # hostd's very first action may be a docker call; make sure the proxy
+      # is up first. (No healthcheck condition — the proxy has no default
+      # healthcheck and restart:always covers transient restarts.)
+      - docker-socket-proxy
     # tini handles SIGTERM forwarding; node's main.ts shutdown handler
     # closes UDS listeners and exits cleanly. 15s grace matches the
     # in-process \`TimeoutStopSec\` and is enough for in-flight async
@@ -228,10 +314,21 @@ services:
       # Agents themselves still mount it ro; only hostd, the tap-gated writer,
       # gets rw. The in-place writer preserves the file's owner/mode.
       - ${hostHome}/.switchroom/switchroom.yaml:/state/config/switchroom.yaml:rw${skillsMount}
-      # docker.sock is the whole reason hostd exists — agents shouldn't
-      # have it, but hostd (auditing every shell-out via run-hook.sh's
-      # pattern) is the controlled chokepoint.
-      - /var/run/docker.sock:/var/run/docker.sock:rw
+      # NOTE: hostd NO LONGER mounts the raw /var/run/docker.sock (#1842 /
+      # #1400 T4). A full-access docker socket in the hostd container is a
+      # host-takeover primitive if hostd is ever compromised (it runs
+      # attacker-influenceable agent shell-outs). Instead the docker API is
+      # reached through the \`docker-socket-proxy\` sidecar below over TCP
+      # (DOCKER_HOST, set in the environment block), which allowlists only
+      # the endpoints hostd actually calls. hostd's own \`docker …\` shellouts
+      # AND the \`switchroom\` CLI subprocesses it spawns (\`agent restart\`,
+      # \`apply\`, rollout → \`docker compose up -d\`) inherit DOCKER_HOST via
+      # runSwitchroom's \`env: {...process.env}\`, so they all route through
+      # the proxy. The self-bump helper (self-bump.ts) is unaffected: hostd
+      # issues \`docker run -d -v /var/run/docker.sock:…\` through the proxy
+      # (a container-create call), and dockerd resolves that host bind source
+      # on the HOST — the helper still gets the real socket to \`compose up\`
+      # the recreated hostd. No path retains a raw socket in hostd itself.
       # /etc/machine-id passthrough — the vault auto-unlock blob
       # (~/.switchroom/vault-auto-unlock) is encrypted with a key derived
       # from the host machine-id. Without this mount, readAutoUnlockFile
@@ -241,6 +338,13 @@ services:
       # Same mount the vault-broker compose carries (compose.ts:1364).
       - /etc/machine-id:/etc/machine-id:ro
     environment:
+      # Route ALL docker access through the docker-socket-proxy sidecar
+      # (#1842). hostd's own \`docker …\` shellouts read this, and every
+      # \`switchroom\` CLI subprocess hostd spawns inherits it via
+      # runSwitchroom's \`env: {...process.env}\` — so \`agent restart\`,
+      # \`apply\` and rollout's \`docker compose up -d\` all talk to the proxy
+      # instead of a raw socket. Service DNS name on the hostd project net.
+      DOCKER_HOST: tcp://docker-socket-proxy:2375
       # Hostd resolves homedir() to set the per-agent socket dir; pin
       # it inside the container to /host-home (which bind-mounts to the
       # operator's home), so the socket paths the agent fleet sees


### PR DESCRIPTION
Closes #1842 (#1400 T4).

## What

hostd's compose (generated in `src/cli/hostd.ts`) mounted the raw host
docker socket `/var/run/docker.sock:rw` directly into the hostd
container. Because hostd runs attacker-influenceable agent shell-outs,
a full-access socket there is a host-takeover primitive.

This replaces it with a **`tecnativa/docker-socket-proxy`** sidecar:

- Proxy service `switchroom-hostd-docker-proxy` is the ONLY container
  that touches the raw socket (mounted `:ro`, the tecnativa-recommended
  mount). Image pinned by tag **and** digest
  (`ghcr.io/tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f3…`).
  Hardened: `read_only` rootfs + `/run` tmpfs, `cap_drop: ALL` (re-add
  only `SETUID`/`SETGID`/`DAC_OVERRIDE` for HAProxy priv-drop),
  `no-new-privileges:true`.
- hostd's raw `docker.sock` mount is **removed**. hostd reaches the
  daemon over `DOCKER_HOST: tcp://docker-socket-proxy:2375`.
- Every `switchroom` CLI subprocess hostd spawns (`agent restart/start/
  stop`, `apply`, `rollout` → `docker compose up -d`) inherits
  `DOCKER_HOST` via `runSwitchroom`'s `env: {...process.env}`
  (server.ts:3512), so they all route through the proxy — verified in
  source, no separate wiring needed.
- hostd `depends_on: docker-socket-proxy`.
- Compose-over-TCP capability confirmed: `docker/Dockerfile.hostd:64-65`
  installs `docker-ce-cli` + `docker-compose-plugin` (compose v2), both
  of which honor `DOCKER_HOST=tcp://…`.

## Endpoint allowlist — minimum for hostd's audited call set

| Flag | Value | Justification (cited call site) |
|---|---|---|
| `CONTAINERS` | 1 | `docker ps/inspect/logs/stats` — `getAllAgentStatuses`, agent_logs, agent_status (server.ts runDocker 2875); compose container create; self-bump `docker run` create (self-bump.ts:236) |
| `IMAGES` | 1 | `docker image inspect`, RepoDigest resolve `docker inspect --format {{.RepoDigests}}` (server.ts:309-327), `docker compose pull` (POST /images/create) |
| `NETWORKS` | 1 | `docker compose up -d` creates/inspects the fleet project network (`compose.ts` `networks:` block ~1819) |
| `VOLUMES` | 1 | `docker compose up -d` creates/inspects per-agent named socket volumes (`compose.ts` `volumes:` block ~1784, `broker-*-sock`…) |
| `EXEC` | 1 | `docker exec` — agent_exec + read-only in-agent liveness battery (server.ts dockerExec, protocol.ts:252/331) |
| `INFO` | 1 | `/info` preflight probed by `docker compose up` / status |
| `VERSION` | 1 | `docker compose version` preflight (self-bump.test.ts references; compose bootstrap) |
| `POST` | 1 | master write gate — container create, `compose pull`, exec-start, `docker wait` (server.ts:1820), `docker rm`, self-bump `docker run -d` (self-bump.ts:245). Without it every write → 403 |
| `ALLOW_START` | 1 | `agent start` / `docker compose start <svc>` (server.ts handleAgentStart, ~1967) |
| `ALLOW_STOP` | 1 | `agent stop` / `docker compose stop <svc>` |
| `ALLOW_RESTARTS` | 1 | `agent restart` / `docker compose restart <svc>` (server.ts, protocol.ts) |
| `BUILD` | **0** | DENIED — production rollout uses prebuilt GHCR images; `docker compose up --build` is a dev-only path (`apply --build`, apply.ts:2281) that never runs inside hostd. Kept off to keep the surface minimal |

Swarm/secret/system endpoints (`SWARM`, `SERVICES`, `SECRETS`,
`CONFIGS`, `NODES`, `TASKS`, `PLUGINS`, `SYSTEM`) stay at their deny
default — hostd never calls them (asserted as negative space in tests).

## Residual risk / honest limits

**This is blast-surface reduction, not a hard security boundary.** With
`CONTAINERS`+`POST` enabled — which compose up, rollout, and self-bump
require — a *fully compromised* hostd can still create a container that
bind-mounts `/var/run/docker.sock` (or `/` itself) into a privileged
container. That is exactly the mechanism self-bump uses legitimately
(`self-bump.ts` `selfBumpHelperArgs`), so it is demonstrably reachable
through the proxy in one create call. What this change removes is the
**standing** raw socket and the accidental / low-effort attack surface:
every docker interaction becomes an allowlisted HTTP endpoint instead of
an unrestricted socket fd sitting in the container.

The real boundary against a determined attacker remains the operator
approval-card layer (#1427) — a human tap gates every mutating hostd
verb before it executes. Closing the residual container-create hole
would require dropping self-bump and compose-driven rollout capability,
which is out of scope for this change. The same limit is stated in the
generated compose comment so operators reading the file on disk see it.

## Paths that keep the raw socket — and why that's correct

- **self-bump helper** (`self-bump.ts` `selfBumpHelperArgs`): hostd issues
  `docker run -d -v /var/run/docker.sock:… <old-hostd-image>` **through
  the proxy** (a `POST /containers/create` + start — covered by
  `CONTAINERS`+`POST`). The `-v` bind SOURCE is resolved by **dockerd on
  the host**, not inside hostd, so the sibling helper still receives the
  real socket to `compose up` the recreated hostd. hostd itself never
  mounts a raw socket. This works unchanged through the proxy — and it is
  also the proof of the residual risk described above.
- The **root debugging agent** mount (`compose.ts:2287`) is deliberately
  out of scope (separate privilege tier).

## Tests (`src/cli/hostd.test.ts`, +7 assertions)

Assert outcomes: proxy service present + digest-pinned; exactly one raw
socket bind and it's on the proxy as `:ro`, ordered before hostd; hostd
has **no** raw socket mount (rw or ro); `DOCKER_HOST` targets the proxy;
`depends_on` the proxy; proxy hardening (read_only/cap_drop/nnp); and the
allowlist env is **exactly** the determined flag/value set with swarm
endpoints in negative space.

- Scoped tests: `vitest run src/cli/hostd.test.ts` → **35 passed**
- `npm run lint` → **clean** (tsc + all 8 guard scripts)

## Deployment verification checklist (runtime NOT verified here)

**Runtime verification has NOT been performed in this environment** —
these are compose-generation changes with unit tests only. Issue #1842
scopes a real test pass; on a canary hostd bounce (`switchroom hostd
install` from the host shell, then verify) the operator must confirm:

- [ ] proxy container up and healthy: `docker ps` shows
      `switchroom-hostd-docker-proxy`; `docker logs` clean of HAProxy
      config errors
- [ ] hostd boots and answers `switchroom hostd status` (operator socket)
- [ ] `agent_exec` — run the read-only liveness battery against one agent
      (exec hijack/attach streams through HAProxy; the known-risky path)
- [ ] `agent_logs` — tail a peer's logs (log streaming over the proxy)
- [ ] `agent_restart` / `agent_start` / `agent_stop` on a canary agent
      (compose start/stop/restart over tcp)
- [ ] `update_check` (read-only) then a rollout dry-run / `apply --only
      <canary>` (compose up -d over tcp, incl. network + volume access)
- [ ] self-bump, if a newer tag is available: verify the helper container
      spawns through the proxy and the recreate completes
      (`selfbump.log` rc=0)
- [ ] negative check: `docker exec switchroom-hostd docker info` works
      via DOCKER_HOST, but a denied endpoint (e.g.
      `docker system df` → /system) returns 403

Do NOT merge — coordinator reviews first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)