### PR TITLE
feat(hooks): Stop-hook guard for narrate-without-execute dispatch claims (#396)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -4937,6 +4937,18 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
       timeout: 5,
       async: false,
     });
+    // Narrate-without-execute guard (#396): re-prompt once when a reply
+    // claims a dispatch the turn never actually made (no Agent/Task call,
+    // no backgrounded Bash). Sync so it can block the stop; fail-open.
+    stopHooks.push({
+      type: "command",
+      command: wrap(
+        "hook:dispatch-claim-stop",
+        `node "${join(DOCKER_HOOKS_PATH, "dispatch-claim-stop.mjs")}"`,
+      ),
+      timeout: 5,
+      async: false,
+    });
     // Reaper for the PreToolUse tool-label sidecar files (#783).
     // Runs on every Stop; idempotent age + count rotation.
     stopHooks.push({

--- a/telegram-plugin/hooks/dispatch-claim-scan.mjs
+++ b/telegram-plugin/hooks/dispatch-claim-scan.mjs
@@ -1,0 +1,259 @@
+/**
+ * Pure helpers for the dispatch-claim Stop hook (#396) — extracted so
+ * unit tests can exercise the scan logic without spawning the .mjs
+ * subprocess (mirrors the `silent-end-scan.mjs` extraction pattern).
+ *
+ * The defect (#396): the model sends a reply that TELLS the user it has
+ * dispatched work ("Dispatching a worker now to fix this") but the turn
+ * contains no `Agent`/`Task` tool call and no backgrounded `Bash` — the
+ * narration was never backed by an actual dispatch. The silent-end Stop
+ * gate (#1664) does not catch this: that turn HAS a qualifying final
+ * reply, so it passes untouched.
+ *
+ * Mechanism (Stop-hook only — the design comment on #396 drops the
+ * 2026-04 PreToolUse deny; a pre-send deny would fire before the Agent
+ * call exists and block legitimate reply-then-dispatch flows):
+ *   1. Walk the current turn's transcript slice (same turn-anchor walk as
+ *      `silent-end-scan.mjs:scanTurnForFinalReply`), skipping
+ *      `isSidechain:true` lines. A sub-agent's own reply/dispatch lines
+ *      leak into the parent transcript with that marker; they are neither
+ *      the parent's claim NOR the parent's dispatch, so they are skipped
+ *      for BOTH detections.
+ *   2. Collect the text of qualifying `reply`/`stream_reply` tool_use
+ *      calls (reuse `REPLY_TOOLS`).
+ *   3. Detect whether the turn actually dispatched: any non-sidechain
+ *      `Agent`/`Task` tool_use, OR a `Bash` tool_use with
+ *      `run_in_background: true`.
+ *   4. Block only when a reply text makes a first-person dispatch
+ *      commitment AND the turn dispatched nothing.
+ *
+ * Registry-check decision (design comment "belt-and-braces" step 4):
+ * The design offered two options — (a) query the subagent-tracker
+ * `registry.db` for a dispatch row in this turn window, or (b) skip the
+ * registry and rely on transcript-only detection, in which case
+ * "past-tense phrasing must be excluded by the regex". We take (b). The
+ * transcript already carries the ground truth for THIS turn's dispatches
+ * (the `Agent`/`Task` tool_use blocks are in the same JSONL slice we
+ * walk), so a second sqlite round-trip from a dependency-free .mjs hook
+ * would be redundant and awkward. The registry's real value in the design
+ * was clearing PAST-tense references to earlier-turn dispatches; we
+ * achieve the same by EXCLUDING pure past-tense verb forms from the
+ * commitment regex (see DISPATCH_COMMIT_RE below) so "the worker I
+ * dispatched earlier" never trips the gate in the first place. This keeps
+ * the hook self-contained and deterministic (no cross-process DB read on
+ * the reply path).
+ */
+
+// Same two MCP tools whose payload is the model's free-text answer text
+// reaching the user (verified complete in silent-end-scan.mjs's header).
+const REPLY_TOOLS = new Set([
+  'mcp__switchroom-telegram__reply',
+  'mcp__switchroom-telegram__stream_reply',
+])
+
+// Dispatch tool names — Claude Code emits the sub-agent dispatch tool under
+// either the legacy `Agent` or the newer `Task` name depending on version
+// (same dual-name recognition subagent-tracker-pretool.mjs uses).
+const DISPATCH_TOOLS = new Set(['Agent', 'Task'])
+
+// Silent marker (NO_REPLY / HEARTBEAT_OK + optional trailing punct) — a turn
+// whose only reply is a bare silent marker made no claim about anything.
+// Matches silent-end-scan.mjs SILENT_MARKER_RE.
+const SILENT_MARKER_RE = /^(NO_REPLY|HEARTBEAT_OK)[\s.!?]*$/i
+
+// First-person dispatch-commitment regex. Seed list from the #396 design
+// comment:
+//   \b(dispatch(ing|ed)?|launch(ing|ed)?|spinning up|kick(ing|ed) off|
+//     delegat(ing|ed)|spawn(ing|ed)?)\b[^.?!]{0,60}\b(worker|researcher|
+//     reviewer|sub-?agent|agent|task)\b
+//
+// DEVIATION (documented above): because we skip the registry belt-and-
+// braces check, we drop the PURE PAST-TENSE alternatives (`dispatched`,
+// `launched`, `kicked off`, `delegated`, `spawned`) from the verb group.
+// Present/progressive/bare-infinitive forms ("dispatching a worker",
+// "I'll dispatch a worker", "spinning up a researcher") are commitments
+// about THIS turn; a bare past-tense reference ("the worker I dispatched
+// earlier") is about a prior turn and must not trip the gate. Keeping only
+// the non-past forms is the transcript-only substitute for the registry's
+// past-tense clearing.
+const DISPATCH_COMMIT_RE =
+  /\b(?:dispatch(?:ing)?|launch(?:ing)?|spinning up|kick(?:ing)? off|delegat(?:e|ing)|spawn(?:ing)?)\b[^.?!]{0,60}?\b(?:worker|researcher|reviewer|sub-?agent|agent|task)\b/i
+
+// Interrogative / conditional exclusion. A sentence offering to dispatch
+// ("want me to dispatch a worker?", "I could spin up a reviewer if you
+// like") is not a commitment that a dispatch HAPPENED — it is a question
+// or a conditional, so it must not block. Seed list from the design
+// comment: '?', could|should|would|want me to|shall I|if you.
+const CONDITIONAL_RE = /\?|\b(?:could|should|would|want me to|shall i|if you)\b/i
+
+/**
+ * True when `text` (one reply's payload) contains at least one SENTENCE
+ * that makes a first-person dispatch commitment and is not interrogative
+ * or conditional.
+ *
+ * Split into sentences first (retaining the trailing `.?!` terminator) so
+ * the conditional exclusion is scoped to the sentence carrying the verb —
+ * a later unrelated sentence with a '?' must not amnesty a real earlier
+ * commitment, and vice versa.
+ *
+ * @param {string} text
+ * @returns {boolean}
+ */
+export function replyClaimsDispatch(text) {
+  if (typeof text !== 'string' || text.length === 0) return false
+  // Bare silent markers carry no claim.
+  if (SILENT_MARKER_RE.test(text.trim())) return false
+  const sentences = text.match(/[^.?!]+[.?!]*/g) || [text]
+  for (const sentence of sentences) {
+    if (!DISPATCH_COMMIT_RE.test(sentence)) continue
+    if (CONDITIONAL_RE.test(sentence)) continue
+    return true
+  }
+  return false
+}
+
+/**
+ * Compute a stable per-turn signature from the enqueue anchor line's raw
+ * content string (the inbound message envelope). Used by the hook's
+ * 1-retry budget so the budget resets on a genuinely new turn (a new
+ * enqueue line with a new message_id) but is preserved across the
+ * re-prompt of the SAME turn (same enqueue anchor — no new inbound).
+ *
+ * A tiny djb2 hash keeps the state file small and dependency-free.
+ *
+ * @param {string} content
+ * @returns {string}
+ */
+export function turnSignature(content) {
+  const s = typeof content === 'string' ? content : ''
+  let h = 5381
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) + h + s.charCodeAt(i)) >>> 0
+  }
+  return `t${h.toString(36)}`
+}
+
+/**
+ * Scan a JSONL transcript and decide whether the current turn told the
+ * user it dispatched work without actually dispatching anything.
+ *
+ * Returns:
+ *   { decided: 'allow',  reason }             — no unbacked dispatch claim
+ *   { decided: 'block',  reason, turnSig }    — a reply claimed a dispatch
+ *                                               but the turn dispatched
+ *                                               nothing; `turnSig` anchors
+ *                                               the hook's retry budget
+ *   { decided: 'unknown', reason }            — no turn-start anchor found;
+ *                                               caller fails open
+ *
+ * Turn-start anchor: the most recent `queue-operation`/`enqueue` line
+ * (identical to `scanTurnForFinalReply`). Fail-open on any structural
+ * miss — a mis-firing gate must never wedge the reply path.
+ *
+ * @param {string} jsonl
+ * @returns {{ decided: 'allow' | 'block' | 'unknown', reason: string, turnSig?: string }}
+ */
+export function scanTurnForDispatchClaim(jsonl) {
+  if (typeof jsonl !== 'string' || jsonl.length === 0) {
+    return { decided: 'unknown', reason: 'empty-transcript' }
+  }
+  const lines = jsonl.split('\n')
+
+  // 1. Walk backward to the most-recent enqueue (the turn-start anchor).
+  let startIdx = -1
+  let enqueueContent = ''
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]
+    if (!line || line[0] !== '{') continue
+    let obj
+    try { obj = JSON.parse(line) } catch { continue }
+    if (obj?.type === 'queue-operation' && obj.operation === 'enqueue') {
+      startIdx = i
+      enqueueContent = typeof obj.content === 'string' ? obj.content : ''
+      break
+    }
+  }
+  if (startIdx < 0) {
+    return { decided: 'unknown', reason: 'no-turn-start' }
+  }
+
+  // 2. Walk the turn forward, skipping sub-agent (isSidechain) lines for
+  //    BOTH claim detection and dispatch detection. Collect reply texts;
+  //    note whether the turn dispatched anything real.
+  let dispatched = false
+  const replyTexts = []
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (!line || line[0] !== '{') continue
+    let obj
+    try { obj = JSON.parse(line) } catch { continue }
+    // Sidechain (sub-agent) lines are not the parent's claim NOR the
+    // parent's dispatch — skip entirely.
+    if (obj?.isSidechain === true) continue
+    if (obj?.type !== 'assistant') continue
+    const content = obj?.message?.content
+    if (!Array.isArray(content)) continue
+    for (const c of content) {
+      if (c?.type !== 'tool_use') continue
+      const name = c.name
+      if (DISPATCH_TOOLS.has(name)) {
+        dispatched = true
+        continue
+      }
+      if (name === 'Bash') {
+        const input = c.input ?? {}
+        if (input.run_in_background === true) dispatched = true
+        continue
+      }
+      if (REPLY_TOOLS.has(name)) {
+        const input = c.input ?? {}
+        replyTexts.push(String(input.text ?? ''))
+        continue
+      }
+    }
+  }
+
+  // 3. If the turn actually dispatched work, the claim (if any) is backed
+  //    — allow, regardless of reply phrasing.
+  if (dispatched) {
+    return { decided: 'allow', reason: 'dispatched' }
+  }
+
+  // 4. No dispatch happened. Block iff a reply made a first-person
+  //    dispatch commitment that was neither interrogative nor conditional.
+  const claimed = replyTexts.some((t) => replyClaimsDispatch(t))
+  if (claimed) {
+    return { decided: 'block', reason: 'claim-without-dispatch', turnSig: turnSignature(enqueueContent) }
+  }
+  return { decided: 'allow', reason: 'no-claim' }
+}
+
+/**
+ * Pure 1-retry-budget helper for the Stop hook. Mirrors the
+ * `silent-end-interrupt-stop.mjs` MAX_RETRIES pattern but with its own
+ * state shape, keyed on the per-turn signature so the budget resets on a
+ * new turn and is honoured across the re-prompt of the same turn.
+ *
+ * Returns:
+ *   { block: true,  nextState }  — budget available; write nextState and block
+ *   { block: false }             — budget exhausted for this turn; fail open
+ *
+ * @param {{ turnSig?: string, retryCount?: number } | null | undefined} existingState
+ * @param {string} turnSig
+ * @param {number} maxRetries
+ * @returns {{ block: boolean, nextState?: { turnSig: string, retryCount: number, timestamp: number } }}
+ */
+export function applyRetryBudget(existingState, turnSig, maxRetries) {
+  const prev = existingState && typeof existingState === 'object' ? existingState : {}
+  // Only carry the counter forward when it belongs to the SAME turn;
+  // otherwise this is a fresh turn and the budget starts at 0.
+  const prevCount =
+    prev.turnSig === turnSig && typeof prev.retryCount === 'number' ? prev.retryCount : 0
+  if (prevCount >= maxRetries) {
+    return { block: false }
+  }
+  return {
+    block: true,
+    nextState: { turnSig, retryCount: prevCount + 1, timestamp: Date.now() },
+  }
+}

--- a/telegram-plugin/hooks/dispatch-claim-stop.mjs
+++ b/telegram-plugin/hooks/dispatch-claim-stop.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Stop hook (#396) — deterministic guardrail against "narrate a dispatch
+ * without executing it".
+ *
+ * The defect: the model replies "Dispatching a worker now to fix this",
+ * the user sees a confident hand-off, but the turn contains no `Agent` /
+ * `Task` tool call and no backgrounded `Bash` — nothing was actually
+ * dispatched. The #1664 silent-end Stop gate does NOT catch this: that
+ * turn HAS a qualifying final reply, so it passes untouched.
+ *
+ * This hook, at Stop, scans the just-finished turn's transcript slice for
+ * a reply that makes a first-person dispatch commitment while the turn
+ * dispatched nothing, and re-prompts the model exactly once to actually
+ * dispatch (or send a correction reply). See `dispatch-claim-scan.mjs`
+ * for the pure decision logic and the registry-check rationale.
+ *
+ * Protocol (Claude Code Stop hook v1):
+ *   Input:  JSON on stdin — { session_id, transcript_path, ... }
+ *   Output: exit 0 + empty stdout → allow stop.
+ *           exit 0 + JSON stdout { decision: "block", reason } → re-prompt.
+ *
+ * Fail-open on EVERY error path (no transcript / unreadable / no
+ * turn-start anchor / state-file failure) — consistent with every sibling
+ * reply-path hook. A mis-firing gate must never loop a session; the
+ * 1-retry budget bounds the block direction on top of that.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+
+import { scanTurnForDispatchClaim, applyRetryBudget } from './dispatch-claim-scan.mjs'
+
+// Exactly one re-prompt per turn (#396 design). A second Stop fire on the
+// same turn (same turnSig) exhausts the budget and fails open.
+const MAX_RETRIES = 1
+
+function readStdin() {
+  try {
+    return readFileSync(0, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+function getStateDir() {
+  return process.env.TELEGRAM_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'telegram')
+}
+
+function main() {
+  const raw = readStdin().trim()
+  if (!raw) process.exit(0)
+
+  let event
+  try {
+    event = JSON.parse(raw)
+  } catch {
+    process.exit(0)
+  }
+
+  const transcriptPath = event?.transcript_path
+  if (!transcriptPath || typeof transcriptPath !== 'string' || !existsSync(transcriptPath)) {
+    process.exit(0)
+  }
+
+  let jsonl
+  try {
+    jsonl = readFileSync(transcriptPath, 'utf8')
+  } catch (err) {
+    process.stderr.write(
+      `[dispatch-claim] failed to read transcript ${transcriptPath}: ${err.message}\n`,
+    )
+    process.exit(0)
+  }
+
+  const decision = scanTurnForDispatchClaim(jsonl)
+
+  // 'allow' (no unbacked claim) and 'unknown' (no turn-start anchor) both
+  // allow the stop.
+  if (decision.decided !== 'block') {
+    process.exit(0)
+  }
+
+  // 1-retry budget, keyed on the per-turn signature so a second Stop fire
+  // on the SAME turn fails open while a genuinely new turn starts fresh.
+  const statePath = join(getStateDir(), 'dispatch-claim-pending.json')
+
+  let state = {}
+  if (existsSync(statePath)) {
+    try {
+      state = JSON.parse(readFileSync(statePath, 'utf8'))
+    } catch {
+      state = {}
+    }
+  }
+
+  const budget = applyRetryBudget(state, decision.turnSig, MAX_RETRIES)
+  if (!budget.block) {
+    process.stderr.write(
+      `[dispatch-claim] retry budget exhausted for turn ${decision.turnSig} — allowing stop\n`,
+    )
+    process.exit(0)
+  }
+
+  try {
+    writeFileSync(statePath, JSON.stringify(budget.nextState), 'utf8')
+  } catch (err) {
+    // Fail-open: a retry-count write failure must not loop the session.
+    process.stderr.write(`[dispatch-claim] failed to update state file: ${err.message}\n`)
+    process.exit(0)
+  }
+
+  process.stderr.write(
+    `[dispatch-claim] blocking stop to re-prompt agent (reason=${decision.reason} turn=${decision.turnSig})\n`,
+  )
+
+  process.stdout.write(
+    JSON.stringify({
+      decision: 'block',
+      reason:
+        'Your reply told the user you dispatched work, but no Agent/Task call ' +
+        'ran this turn. Actually dispatch it now, or send a correction reply.',
+    }),
+  )
+  process.exit(0)
+}
+
+main()

--- a/telegram-plugin/hooks/hooks.json
+++ b/telegram-plugin/hooks/hooks.json
@@ -95,6 +95,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" node \"${CLAUDE_PLUGIN_ROOT}/hooks/dispatch-claim-stop.mjs\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.sh\" node \"${CLAUDE_PLUGIN_ROOT}/hooks/tool-label-stop.mjs\"",
             "timeout": 5,
             "async": true

--- a/telegram-plugin/tests/dispatch-claim-scan.test.ts
+++ b/telegram-plugin/tests/dispatch-claim-scan.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests for the #396 dispatch-claim Stop-hook scan logic — the pure
+ * `dispatch-claim-scan.mjs` helpers (mirrors the silent-end-scan test
+ * style: synthetic JSONL fixtures against a pure function rather than
+ * spawning the .mjs subprocess).
+ *
+ * The defect: a reply that TELLS the user work was dispatched
+ * ("Dispatching a worker now") while the turn contains no Agent/Task call
+ * and no backgrounded Bash. These assert OUTCOMES (block vs allow), not
+ * code paths.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  scanTurnForDispatchClaim,
+  replyClaimsDispatch,
+  applyRetryBudget,
+  turnSignature,
+} from '../hooks/dispatch-claim-scan.mjs'
+
+// ── Fixture builders ────────────────────────────────────────────────
+
+const REPLY = 'mcp__switchroom-telegram__reply'
+
+const ENQUEUE = JSON.stringify({
+  type: 'queue-operation',
+  operation: 'enqueue',
+  content: '<channel source="switchroom-telegram" chat_id="111" message_id="42">fix the bug</channel>',
+})
+
+function assistantToolUse(
+  name: string,
+  input: Record<string, unknown>,
+  opts: { isSidechain?: boolean } = {},
+) {
+  const base: Record<string, unknown> = {
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', name, input }] },
+  }
+  if (opts.isSidechain) base.isSidechain = true
+  return JSON.stringify(base)
+}
+
+function reply(text: string, opts: { isSidechain?: boolean } = {}) {
+  return assistantToolUse(REPLY, { text, chat_id: '111' }, opts)
+}
+
+function jsonl(...lines: string[]) {
+  return lines.join('\n')
+}
+
+// ── (a) claim + no dispatch tool_use → block ────────────────────────
+
+describe('scanTurnForDispatchClaim — narrate-without-execute', () => {
+  it('(a) blocks a dispatch claim with no Agent/Task call in the turn', () => {
+    const t = jsonl(ENQUEUE, reply('Dispatching a worker now to fix this bug.'))
+    const d = scanTurnForDispatchClaim(t)
+    expect(d.decided).toBe('block')
+    expect(d.reason).toBe('claim-without-dispatch')
+    expect(d.turnSig).toBeTruthy()
+  })
+
+  // ── (b) claim + Agent tool_use in turn → allow ────────────────────
+  it('(b) allows when the turn actually dispatched an Agent', () => {
+    const t = jsonl(
+      ENQUEUE,
+      reply('Dispatching a worker now to fix this bug.'),
+      assistantToolUse('Agent', { subagent_type: 'worker', description: 'fix bug' }),
+    )
+    const d = scanTurnForDispatchClaim(t)
+    expect(d.decided).toBe('allow')
+    expect(d.reason).toBe('dispatched')
+  })
+
+  it('(b2) allows when the dispatch tool is the newer Task name', () => {
+    const t = jsonl(
+      ENQUEUE,
+      reply('Spinning up a researcher to dig into this.'),
+      assistantToolUse('Task', { subagent_type: 'researcher' }),
+    )
+    expect(scanTurnForDispatchClaim(t).decided).toBe('allow')
+  })
+
+  // ── (c) claim + backgrounded Bash → allow ─────────────────────────
+  it('(c) allows when the turn launched a backgrounded Bash', () => {
+    const t = jsonl(
+      ENQUEUE,
+      reply('Kicking off the build agent in the background.'),
+      assistantToolUse('Bash', { command: 'npm run build', run_in_background: true }),
+    )
+    const d = scanTurnForDispatchClaim(t)
+    expect(d.decided).toBe('allow')
+    expect(d.reason).toBe('dispatched')
+  })
+
+  it('(c2) a FOREGROUND Bash does not count as a dispatch', () => {
+    const t = jsonl(
+      ENQUEUE,
+      reply('Dispatching a worker to handle this.'),
+      assistantToolUse('Bash', { command: 'ls', run_in_background: false }),
+    )
+    expect(scanTurnForDispatchClaim(t).decided).toBe('block')
+  })
+
+  // ── (d) conditional offer → allow ─────────────────────────────────
+  it('(d) allows a conditional offer to dispatch (question)', () => {
+    const t = jsonl(ENQUEUE, reply('Want me to dispatch a worker to fix this?'))
+    const d = scanTurnForDispatchClaim(t)
+    expect(d.decided).toBe('allow')
+    expect(d.reason).toBe('no-claim')
+  })
+
+  it('(d2) allows a conditional "I could spin up a reviewer if you like"', () => {
+    const t = jsonl(ENQUEUE, reply('I could spin up a reviewer if you want me to.'))
+    expect(scanTurnForDispatchClaim(t).decided).toBe('allow')
+  })
+
+  // ── (e) non-dispatch reply → allow ────────────────────────────────
+  it('(e) allows an ordinary non-dispatch reply', () => {
+    const t = jsonl(ENQUEUE, reply('Here is the answer: the bug is a null deref on line 12.'))
+    const d = scanTurnForDispatchClaim(t)
+    expect(d.decided).toBe('allow')
+    expect(d.reason).toBe('no-claim')
+  })
+
+  // ── (f) NO_REPLY-only turn → allow ────────────────────────────────
+  it('(f) allows a NO_REPLY-only turn', () => {
+    const t = jsonl(ENQUEUE, reply('NO_REPLY'))
+    expect(scanTurnForDispatchClaim(t).decided).toBe('allow')
+  })
+
+  // ── (g) sidechain lines ───────────────────────────────────────────
+  it('(g) sidechain Agent lines do NOT count as the parent dispatching', () => {
+    // A sub-agent's own Agent tool_use leaks in with isSidechain — it must
+    // not satisfy the PARENT's dispatch obligation. Parent reply claims a
+    // dispatch, parent itself dispatched nothing → block.
+    const t = jsonl(
+      ENQUEUE,
+      reply('Dispatching a worker now.'),
+      assistantToolUse('Agent', { subagent_type: 'worker' }, { isSidechain: true }),
+    )
+    expect(scanTurnForDispatchClaim(t).decided).toBe('block')
+  })
+
+  it('(g2) sidechain replies do NOT count as the parent making a claim', () => {
+    // A sub-agent's own reply narrating a dispatch leaks in with
+    // isSidechain; the parent made no claim → allow.
+    const t = jsonl(
+      ENQUEUE,
+      reply('Working on the fix directly.'),
+      reply('Dispatching a worker to handle the subtask.', { isSidechain: true }),
+    )
+    const d = scanTurnForDispatchClaim(t)
+    expect(d.decided).toBe('allow')
+    expect(d.reason).toBe('no-claim')
+  })
+
+  // ── (i) malformed / missing transcript → allow (fail-open) ────────
+  it('(i) fails open on an empty transcript', () => {
+    expect(scanTurnForDispatchClaim('').decided).toBe('unknown')
+  })
+
+  it('(i2) fails open when no turn-start anchor is present', () => {
+    const t = jsonl(reply('Dispatching a worker now.'))
+    expect(scanTurnForDispatchClaim(t).decided).toBe('unknown')
+  })
+
+  it('(i3) tolerates malformed JSONL lines mixed in', () => {
+    const t = jsonl(ENQUEUE, '{ not valid json', reply('Dispatching a worker now.'))
+    const d = scanTurnForDispatchClaim(t)
+    expect(d.decided).toBe('block')
+  })
+
+  // ── past-tense reference (registry-check substitute) ──────────────
+  it('does NOT block a bare past-tense reference to an earlier dispatch', () => {
+    const t = jsonl(
+      ENQUEUE,
+      reply('The worker I dispatched earlier finished; here are its results.'),
+    )
+    const d = scanTurnForDispatchClaim(t)
+    expect(d.decided).toBe('allow')
+    expect(d.reason).toBe('no-claim')
+  })
+})
+
+// ── replyClaimsDispatch unit coverage ───────────────────────────────
+
+describe('replyClaimsDispatch', () => {
+  it('matches present/progressive commitments', () => {
+    expect(replyClaimsDispatch('Dispatching a worker now.')).toBe(true)
+    expect(replyClaimsDispatch("I'll dispatch a reviewer to check this.")).toBe(true)
+    expect(replyClaimsDispatch('Spinning up a sub-agent for the research.')).toBe(true)
+    expect(replyClaimsDispatch('Kicking off a worker on that task.')).toBe(true)
+    expect(replyClaimsDispatch('Delegating this to a researcher.')).toBe(true)
+  })
+
+  it('excludes interrogative / conditional sentences', () => {
+    expect(replyClaimsDispatch('Want me to dispatch a worker?')).toBe(false)
+    expect(replyClaimsDispatch('I could dispatch a reviewer if you like.')).toBe(false)
+    expect(replyClaimsDispatch('Should I spin up a worker for this?')).toBe(false)
+  })
+
+  it('excludes pure past-tense references', () => {
+    expect(replyClaimsDispatch('The worker I dispatched earlier is done.')).toBe(false)
+    expect(replyClaimsDispatch('I launched a reviewer last turn.')).toBe(false)
+  })
+
+  it('ignores unrelated prose and bare silent markers', () => {
+    expect(replyClaimsDispatch('The fix is a null-deref guard on line 12.')).toBe(false)
+    expect(replyClaimsDispatch('NO_REPLY')).toBe(false)
+    expect(replyClaimsDispatch('')).toBe(false)
+  })
+
+  it('scopes conditional exclusion to the sentence carrying the verb', () => {
+    // First sentence is a real commitment; a later unrelated question must
+    // not amnesty it.
+    expect(
+      replyClaimsDispatch('Dispatching a worker now. Anything else you need?'),
+    ).toBe(true)
+  })
+})
+
+// ── (h) retry budget: exactly one re-prompt per turn ────────────────
+
+describe('applyRetryBudget — exactly one re-prompt per turn', () => {
+  const sig = turnSignature(ENQUEUE)
+
+  it('(h) blocks on the first Stop, then fails open on the second same-turn Stop', () => {
+    const first = applyRetryBudget({}, sig, 1)
+    expect(first.block).toBe(true)
+    expect(first.nextState?.retryCount).toBe(1)
+    expect(first.nextState?.turnSig).toBe(sig)
+
+    // Second Stop fire on the SAME turn reads back the persisted state.
+    const second = applyRetryBudget(first.nextState, sig, 1)
+    expect(second.block).toBe(false)
+  })
+
+  it('resets the budget for a genuinely new turn (different signature)', () => {
+    const spent = { turnSig: sig, retryCount: 1 }
+    const newTurn = applyRetryBudget(spent, turnSignature('a different inbound'), 1)
+    expect(newTurn.block).toBe(true)
+    expect(newTurn.nextState?.retryCount).toBe(1)
+  })
+
+  it('tolerates a null / corrupt prior state', () => {
+    expect(applyRetryBudget(null, sig, 1).block).toBe(true)
+    expect(applyRetryBudget(undefined, sig, 1).block).toBe(true)
+  })
+})

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2635,6 +2635,12 @@ describe("scaffoldAgent with global defaults cascade", () => {
           },
           {
             type: "command",
+            command: expect.stringContaining("dispatch-claim-stop.mjs"),
+            timeout: 5,
+            async: false,
+          },
+          {
+            type: "command",
             command: expect.stringContaining("tool-label-stop.mjs"),
             timeout: 5,
             async: true,

--- a/tests/telegram-plugin-manifest.test.ts
+++ b/tests/telegram-plugin-manifest.test.ts
@@ -87,6 +87,7 @@ describe("telegram-plugin manifest (#229)", () => {
     expect(all).toContain("sandbox-hint-posttool.mjs");
     expect(all).toContain("secret-scrub-stop.mjs");
     expect(all).toContain("silent-end-interrupt-stop.mjs");
+    expect(all).toContain("dispatch-claim-stop.mjs");
   });
 
   it("subagent-tracker hooks gate on Agent or Task (regex matcher)", () => {


### PR DESCRIPTION
## Summary

Adds a deterministic Stop hook that catches the "narrate a dispatch without executing it" defect (#396): a reply that tells the user work was dispatched ("Dispatching a worker now to fix this") while the turn contains **no** `Agent`/`Task` tool call and **no** backgrounded `Bash`. When that happens the hook re-prompts the model exactly once to actually dispatch, or send a correction reply.

- New pure module `telegram-plugin/hooks/dispatch-claim-scan.mjs` (mirrors the `silent-end-scan.mjs` extraction pattern) + Stop hook `telegram-plugin/hooks/dispatch-claim-stop.mjs`.
- Registered as one new Stop entry after `silent-end-interrupt` in `telegram-plugin/hooks/hooks.json` **and** the hand-wired `src/agents/scaffold.ts` stop-hooks list (both registration sites, kept in lockstep). Scaffold/manifest pin tests updated.

Implements the approved design in the #396 "Design/investigation report (2026-07-11, main @ 8fbd9574)" comment, which supersedes the 2026-04 Hook A/Hook B body proposal.

## Why

The #1664 silent-end Stop gate blocks turns with **no** qualifying final reply. A narrate-without-execute turn HAS a qualifying reply, so it sails through — the user sees a confident hand-off that never happened. This closes that gap deterministically instead of relying on model discipline. Cites `reference/jobs/know-what-my-agent-is-doing.md` (hold-the-leash: if the user can't trust what the card says the agent is doing, they stop using it).

**Stop-hook only — no PreToolUse deny** (per the design): the correct pattern is reply-then-dispatch in the same response; a pre-send deny fires before the Agent call exists and would block legitimate flows. A wrong Stop block costs one invisible re-prompt; a wrong deny kills a real answer.

**Registry-check decision:** the design's belt-and-braces step 4 offered either querying the subagent-tracker `registry.db` for a dispatch row, or skipping it and relying on transcript-only detection with past-tense exclusion. I took the **transcript-only** option. The `Agent`/`Task` tool_use blocks for THIS turn are already in the same JSONL slice the hook walks, so a second sqlite round-trip from a dependency-free `.mjs` hook is redundant and awkward. The registry's real value was clearing PAST-tense references to earlier dispatches; I get the same by dropping pure past-tense verb forms (`dispatched`, `launched`, `kicked off`, `delegated`, `spawned`) from the commitment regex, so "the worker I dispatched earlier" never trips the gate. Documented in the module header.

## Test plan

- `telegram-plugin/tests/dispatch-claim-scan.test.ts` (23 cases, vitest — pure module, matches the sibling `silent-end-interrupt-stop-scan.test.ts` style): (a) claim+no dispatch → block; (b/b2) Agent/Task in turn → allow; (c) backgrounded Bash → allow, (c2) foreground Bash → block; (d/d2) conditional offer → allow; (e) ordinary reply → allow; (f) NO_REPLY-only → allow; (g) sidechain Agent doesn't count as dispatch, (g2) sidechain reply doesn't count as claim; (i/i2/i3) empty/anchor-less/malformed transcript → fail open; past-tense earlier-turn reference → allow; (h) retry budget: first Stop blocks, second same-turn Stop fails open, new turn resets.
- `tests/scaffold.test.ts` + `tests/telegram-plugin-manifest.test.ts` updated and green (210 tests).
- `npm run lint` clean (tsc + all 8 guards).

## Risk

Low. Fails open on every error path (missing/unreadable/anchor-less/malformed transcript, state-file failure) consistent with every sibling reply-path hook; the 1-retry budget bounds the block direction to exactly one invisible re-prompt per turn. No PreToolUse deny, so no legitimate reply is ever blocked pre-send.

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)