### PR TITLE
fix(gateway): snapshot restart-pending once per session-command drain pass

### DIFF
--- a/telegram-plugin/gateway/pending-session-command.ts
+++ b/telegram-plugin/gateway/pending-session-command.ts
@@ -162,14 +162,26 @@ export interface DrainIo {
  * both a model AND an effort command; breaking after re-enqueueing only the
  * current one would silently drop the other with its ack card stuck at
  * "queued" forever.
+ *
+ * Restart-pending is SNAPSHOTTED once at drain entry (#3021): the caller's
+ * `restartPending()` reads a `pendingRestarts` map that the turn-end idle gate
+ * empties in a synchronous loop dispatched right alongside this (async) drain.
+ * For the FIRST command the per-iteration read still sees the entry, but by the
+ * time an `await` yields to the second command the sync loop has emptied the
+ * map — so a naive per-command re-check would let the second command apply live
+ * into a session that is ~100ms from triggerSelfRestart and falsely confirm.
+ * Latching the entry state fixes that. We still OR in the live re-check so a
+ * restart that BECOMES pending mid-drain (a model apply can itself enqueue one)
+ * is honored for the commands that follow it.
  */
 export async function drainTakenCommands(
   taken: readonly PendingSessionCommand[],
   io: DrainIo,
 ): Promise<void> {
+  const restartPendingAtEntry = io.restartPending()
   for (let i = 0; i < taken.length; i++) {
     const cmd = taken[i]
-    if (io.restartPending()) {
+    if (restartPendingAtEntry || io.restartPending()) {
       // The live session is going away — carry the choice across the bounce
       // via the durable carriers (or the re-issue fallback).
       await io.editCard(cmd, io.resolveForRestartText(cmd))

--- a/telegram-plugin/tests/pending-session-command.test.ts
+++ b/telegram-plugin/tests/pending-session-command.test.ts
@@ -319,4 +319,25 @@ describe('drainTakenCommands (#3042 blocker 1: an early stop must not drop the r
     await drainTakenCommands(batch(), io)
     expect(events).toEqual(['edit:model:persisted:model', 'edit:effort:persisted:effort'])
   })
+
+  it('#3021: restart-pending is snapshotted at entry → sync loop emptying pendingRestarts mid-drain still defers the SECOND command', async () => {
+    // Reproduces the turn-end idle-gate race: the drain is void-dispatched while
+    // a synchronous pendingRestarts loop empties the map right after. The first
+    // read sees the entry; by the second command the map has been emptied. A
+    // naive per-command re-check would let the second command apply live into a
+    // session ~100ms from triggerSelfRestart and falsely confirm.
+    let restartPresent = true
+    const { io, events } = makeIo({
+      // takeAll() first read latches true; the sync loop then empties the map,
+      // so every subsequent live read returns false.
+      restartPending: () => {
+        const was = restartPresent
+        restartPresent = false // the sync loop deleted the entry after dispatch
+        return was
+      },
+    })
+    await drainTakenCommands(batch(), io)
+    // BOTH commands must ride the carriers — the second must NOT apply live.
+    expect(events).toEqual(['edit:model:persisted:model', 'edit:effort:persisted:effort'])
+  })
 })


### PR DESCRIPTION
## Summary
Fixes the #3021 race: the turn-end idle gate void-dispatches the session-command drain while a synchronous `pendingRestarts` loop empties the map right after. `drainTakenCommands` re-read `restartPending()` per queued command inside its async loop, so with two commands queued (e.g. `/model` + `/effort`) plus a pending restart, the first command saw the entry but by the time an `await` yielded to the second the map was empty — the second command applied live into a session ~100ms from `triggerSelfRestart` and confirmed falsely.

## Why snapshot + OR
`restartPending()` is snapshotted ONCE at drain entry (latches the state across the sync deletion), then OR-ed with the live per-command re-check — so a restart that BECOMES pending mid-drain (a model apply can itself enqueue one) is still honored for the commands that follow. Behavior otherwise identical.

## Test plan
- New outcome test: queues TWO commands, `restartPending` returns true on the first read then false forever (simulating the sync loop emptying the map after dispatch), asserts BOTH commands ride the boot carriers.
- **Pre-fix failure proven**: against the unfixed drain the test fails with the second command applying live (`apply:effort` + `edit:effort:✅ effort done` instead of `edit:effort:persisted:effort`).
- Scoped: `vitest run telegram-plugin/tests/pending-session-command.test.ts` → 29/29 pass. `npm run lint` clean.
- Whole-repo grep: only one `DrainIo` builder exists outside the gateway wiring (the test's `makeIo`); interface unchanged.

## Risk
Low — pure narrowing of an already-conservative branch; only affects multi-command drains coinciding with a pending restart.

Job spec: `reference/jobs/` — model/effort session-command reliability (same job as #3017/#3042 lineage: operator commands are never falsely confirmed).

Closes #3021

🤖 Generated with [Claude Code](https://claude.com/claude-code)