### PR TITLE
fix(gateway): case-fold offline model token + clear crashloop counter on bridge register

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -408,6 +408,7 @@ import {
   readSessionModelFileRaw,
   restoreSessionModelFileRaw,
   clearSessionModelFile,
+  clearSessionModelBootAttempts,
   readConfiguredDefaultModel,
   writeRelaunchModelIntent,
   clearRelaunchModelIntent,
@@ -9256,6 +9257,16 @@ const ipcServer: IpcServer = createIpcServer({
     // this call is safe wherever it sits relative to the cron early-return
     // above (#3038 review finding 5).
     bridgeDeadWatchdog.noteBridgeRegistered(client.agentName)
+    // #3043 item 2: a REAL bridge registering is proof the boot came all the
+    // way up healthy — clear start.sh's crashloop boot-attempts counter so only
+    // boots that genuinely fail BEFORE the bridge registers accumulate toward
+    // the 3-strike override clear. Without this, three quick operator
+    // hand-bounces of a healthy agent (each <150s apart) spuriously wipe a
+    // working model override. Best-effort; no-op when the file is absent.
+    if (client.agentName != null) {
+      const smBootDir = resolveAgentDirFromEnv()
+      if (smBootDir != null) clearSessionModelBootAttempts(smBootDir)
+    }
     client.send({ type: 'status', status: 'agent_connected' })
 
     // Phase 2b PR 3a — bridgeUp cutover. The state machine's `bridgeUp`

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -521,9 +521,15 @@ export const SR_MODEL_ALIASES: Record<string, string> = {
  * session to verify, so the operator is asked to re-issue after boot.
  */
 export function isOfflineTrustedModelToken(token: string): boolean {
-  if ((MODEL_ALIASES as readonly string[]).includes(token)) return true
-  if (token in SR_MODEL_ALIASES) return true
-  return Object.values(SR_MODEL_ALIASES).includes(token)
+  // #3043 item 1: the live accept path normalizes case (isClaudeModel /
+  // expandSrAlias lowercase before matching), so a queued `/model OPUS` is
+  // accepted live — but this persist-time gate compared case-sensitively and
+  // then refused it with the over-conservative "couldn't verify" card. Lowercase
+  // once so the persist decision matches what the live path already accepted.
+  const lower = token.toLowerCase()
+  if ((MODEL_ALIASES as readonly string[]).includes(lower)) return true
+  if (lower in SR_MODEL_ALIASES) return true
+  return Object.values(SR_MODEL_ALIASES).includes(lower)
 }
 
 export function expandSrAlias(arg: string): string {

--- a/telegram-plugin/gateway/session-model-file.ts
+++ b/telegram-plugin/gateway/session-model-file.ts
@@ -40,6 +40,8 @@ import { isValidModelArg } from './model-command.js'
 export const SESSION_MODEL_FILE = '.session-model'
 export const RELAUNCH_MODEL_INTENT_FILE = '.relaunch-model-intent'
 export const CONFIGURED_DEFAULT_MODEL_FILE = '.configured-default-model'
+/** Crashloop self-heal counter (start.sh stamps `<count> <epoch>` per fast boot). */
+export const SESSION_MODEL_BOOT_ATTEMPTS_FILE = '.session-model-boot-attempts'
 
 export type RelaunchModelIntent = 'keep' | 'revert'
 
@@ -142,7 +144,30 @@ export function clearSessionModelFile(agentDir: string): void {
     // #3042 item 4: also drop the kept-alert dedup sentinel so a future
     // override of the same name re-alerts on its first kept boot.
     rmSync(join(agentDir, '.session-model-kept-notified'), { force: true })
-    rmSync(join(agentDir, '.session-model-boot-attempts'), { force: true })
+    rmSync(join(agentDir, SESSION_MODEL_BOOT_ATTEMPTS_FILE), { force: true })
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * #3043 item 2: clear ONLY the crashloop boot-attempts counter — a positive
+ * health signal from the gateway, not a carrier change.
+ *
+ * start.sh's self-heal (start.sh.hbs "Override crashloop self-heal") increments
+ * the counter on every boot that re-enters within 150s with the override still
+ * active, and clears a healthy override after 3 fast boots. That window can't
+ * tell a genuine crashloop from three quick OPERATOR hand-bounces of a healthy
+ * agent — both look like fast successive boots — so three deliberate restarts
+ * would spuriously wipe a working override. A boot that reaches bridge
+ * registration is proven healthy (the session came all the way up and the
+ * bridge connected), so the gateway deletes the counter there. Only boots that
+ * genuinely FAIL before the bridge registers now accumulate toward the 3-strike
+ * clear. Best-effort; absent file is fine.
+ */
+export function clearSessionModelBootAttempts(agentDir: string): void {
+  try {
+    rmSync(join(agentDir, SESSION_MODEL_BOOT_ATTEMPTS_FILE), { force: true })
   } catch {
     /* best-effort */
   }

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -1359,4 +1359,18 @@ describe("isOfflineTrustedModelToken (#3042 blocker 2a)", () => {
     expect(isOfflineTrustedModelToken("sr-made-up/model")).toBe(false);
     expect(isOfflineTrustedModelToken("")).toBe(false);
   });
+
+  it("#3043 item 1: accepts case-variant aliases the live path already normalizes (OPUS, Sonnet)", () => {
+    // The live accept path lowercases (isClaudeModel / expandSrAlias) so a
+    // queued `/model OPUS` is accepted live — the persist gate must not then
+    // refuse it with the over-conservative "couldn't verify" card.
+    for (const a of MODEL_ALIASES) {
+      expect(isOfflineTrustedModelToken(a.toUpperCase())).toBe(true);
+    }
+    expect(isOfflineTrustedModelToken("OPUS")).toBe(true);
+    expect(isOfflineTrustedModelToken("Sonnet")).toBe(true);
+    // Curated sr-* alias, upper-cased, still resolves.
+    const [alias] = Object.entries(SR_MODEL_ALIASES)[0];
+    expect(isOfflineTrustedModelToken(alias.toUpperCase())).toBe(true);
+  });
 });

--- a/telegram-plugin/tests/session-model-file.test.ts
+++ b/telegram-plugin/tests/session-model-file.test.ts
@@ -15,6 +15,8 @@ import {
   readSessionModelFileRaw,
   restoreSessionModelFileRaw,
   clearSessionModelFile,
+  clearSessionModelBootAttempts,
+  SESSION_MODEL_BOOT_ATTEMPTS_FILE,
   writeRelaunchModelIntent,
   clearRelaunchModelIntent,
   readConfiguredDefaultModel,
@@ -227,5 +229,53 @@ describe('intentForRestartReason is keep-for-everything (#3039)', () => {
     ]) {
       expect(intentForRestartReason(reason)).toBe('keep')
     }
+  })
+})
+
+describe('clearSessionModelBootAttempts (#3043 item 2: bridge-register clears the crashloop counter)', () => {
+  const bootAttemptsPath = () => join(dir, SESSION_MODEL_BOOT_ATTEMPTS_FILE)
+
+  // Faithful model of start.sh.hbs "Override crashloop self-heal": each boot
+  // within 150s of the previous stamp bumps the count; a stale stamp resets to
+  // 1. Reproduced here so the accumulate-vs-reset OUTCOME is asserted, not just
+  // the delete call.
+  function simulateBootStamp(nowSec: number): number {
+    let count = 0
+    let prev = 0
+    if (existsSync(bootAttemptsPath())) {
+      const [c, p] = readFileSync(bootAttemptsPath(), 'utf8').trim().split(/\s+/)
+      count = Number(c) || 0
+      prev = Number(p) || 0
+    }
+    count = nowSec - prev < 150 ? count + 1 : 1
+    writeFileSync(bootAttemptsPath(), `${count} ${nowSec}\n`)
+    return count
+  }
+
+  it('WITHOUT a bridge register, three fast boots accumulate toward the 3-strike clear', () => {
+    // Three operator hand-bounces, each <150s apart, with no register between.
+    expect(simulateBootStamp(1000)).toBe(1)
+    expect(simulateBootStamp(1010)).toBe(2)
+    expect(simulateBootStamp(1020)).toBe(3) // start.sh would now clear a HEALTHY override — the false positive
+  })
+
+  it('a bridge register between boots resets the counter, so a healthy agent never reaches 3', () => {
+    expect(simulateBootStamp(1000)).toBe(1)
+    // Boot 1 came all the way up and the bridge registered → gateway clears it.
+    clearSessionModelBootAttempts(dir)
+    expect(existsSync(bootAttemptsPath())).toBe(false)
+
+    // Next fast boot starts fresh at 1 (no accumulation), and register clears again.
+    expect(simulateBootStamp(1010)).toBe(1)
+    clearSessionModelBootAttempts(dir)
+    expect(simulateBootStamp(1020)).toBe(1)
+    // The healthy agent's counter never climbs to the 3-strike clear.
+    const [count] = readFileSync(bootAttemptsPath(), 'utf8').trim().split(/\s+/)
+    expect(Number(count)).toBeLessThan(3)
+  })
+
+  it('is best-effort — no throw when the counter file is absent', () => {
+    expect(existsSync(bootAttemptsPath())).toBe(false)
+    expect(() => clearSessionModelBootAttempts(dir)).not.toThrow()
   })
 })


### PR DESCRIPTION
## Summary
Two fail-safe follow-ups from the PR #3042 re-review.

Note on locations: the issue's pointers were approximate — `isOfflineTrustedModelToken` lives in `telegram-plugin/gateway/model-command.ts:523` (not `session-command-persist.ts`), and the boot-attempts logic is `telegram-plugin/gateway/session-model-file.ts` + `profiles/_base/start.sh.hbs:1213-1236` (not `session-model-store.ts`). Fixes landed at the real sites.

### Item 1 — case-sensitive persist gate
`isOfflineTrustedModelToken` compared the token case-sensitively against `MODEL_ALIASES` / curated sr-* aliases while the live accept path lowercases (`isClaudeModel`, `expandSrAlias`) — so a queued `/model OPUS` was accepted live but refused at persist with the over-conservative "couldn't verify" card. Fix: lowercase once before the three lookups.

### Item 2 — boot self-heal false positive
start.sh's crashloop self-heal increments `.session-model-boot-attempts` on every boot <150s apart and clears a healthy override at 3 strikes — it can't distinguish a genuine crashloop from three quick operator hand-bounces. A boot that reaches bridge registration is proven healthy, so the gateway now deletes the counter at `onClientRegistered` (real, non-cron bridge) via a new `clearSessionModelBootAttempts()` helper. Only boots that fail before the bridge registers accumulate toward the 3-strike clear.

## Test plan
- Item 1: uppercase-alias acceptance test (`OPUS`, `Sonnet`, all aliases upper-cased, curated sr-* alias upper-cased). **Pre-fix failure proven** — against the unfixed gate `isOfflineTrustedModelToken("OPUS")` returned false.
- Item 2: outcome tests with a faithful model of start.sh's stamp logic — three fast boots WITHOUT a register reach the 3-strike count; a register between boots resets so a healthy agent never reaches 3; best-effort no-throw on absent file. (Helper is net-new, so "pre-fix" is the without-register accumulation case.)
- Scoped: `vitest run telegram-plugin/tests/model-command.test.ts telegram-plugin/tests/session-model-file.test.ts` → 140/140 pass. `npm run lint` clean (incl. bot-api allowlist despite the gateway.ts insertion).
- Whole-repo grep of the `.session-model-boot-attempts` literal: remaining sites are `start.sh.hbs` (shell producer, semantics untouched) and `tests/scaffold.session-model.test.ts` (scaffold cleanup assertions, unaffected).

## Risk
Low — both fixes fail toward safety and only widen acceptance / narrow a spurious clear.

Job spec: `reference/jobs/` — session-model stickiness (#3039/#3042 lineage: a confirmed model choice survives restarts and is never spuriously cleared or refused).

Closes #3043

🤖 Generated with [Claude Code](https://claude.com/claude-code)