### PR TITLE
feat(inject): expand allowlist + arg-gate for sensitive verbs (#730)

### DIFF
--- a/src/agents/inject.test.ts
+++ b/src/agents/inject.test.ts
@@ -30,8 +30,48 @@ describe("validateInjectCommand", () => {
     }
   });
 
-  it("accepts an allowed command with trailing args (verb-only check)", () => {
-    expect(validateInjectCommand("/cost some-arg")).toBe("/cost");
+  it("#730 arg-gate — rejects trailing args for a bare-verb-only command", () => {
+    // Was previously accepted (verb-only match); the arg-gate now rejects it.
+    for (const cmd of ["/cost some-arg", "/memory edit", "/clear --flag"]) {
+      const err = (() => {
+        try {
+          validateInjectCommand(cmd);
+          return null;
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(err, `${cmd} must be rejected`).toBeInstanceOf(InjectError);
+      expect((err as InjectError).code).toBe("args_not_allowed");
+      expect((err as InjectError).message).toMatch(/args not permitted/i);
+    }
+  });
+
+  it("#730 arg-gate — /model KEEPS args allowed (sanctioned set path, #2566)", () => {
+    // The dedicated /model driver injects `/model <alias|id>` WITH an arg as
+    // the sanctioned session-switch path. Gating it off would break /model.
+    expect(validateInjectCommand("/model claude-sonnet-4-6")).toBe("/model");
+    expect(validateInjectCommand("/model opus")).toBe("/model");
+  });
+
+  it("#730 arg-gate — every non-/model allowlist entry forbids args", () => {
+    for (const [verb, meta] of INJECT_COMMANDS.entries()) {
+      if (verb === "/model") {
+        expect(meta.argsAllowed, "/model must allow args").toBe(true);
+        continue;
+      }
+      expect(meta.argsAllowed, `${verb} must forbid args`).toBe(false);
+      const err = (() => {
+        try {
+          validateInjectCommand(`${verb} extra`);
+          return null;
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(err, `${verb} extra must be rejected`).toBeInstanceOf(InjectError);
+      expect((err as InjectError).code).toBe("args_not_allowed");
+    }
   });
 
   it("is case-insensitive on the verb", () => {
@@ -50,6 +90,33 @@ describe("validateInjectCommand", () => {
       })();
       expect(err).toBeInstanceOf(InjectError);
       expect((err as InjectError).code).toBe("blocked");
+    }
+  });
+
+  it("#730 — new defensive blocklist entries return code 'blocked' (not not_allowed)", () => {
+    const added = [
+      "/upgrade",
+      "/init",
+      "/mcp",
+      "/permissions",
+      "/install-github-app",
+      "/add-dir",
+      "/terminal-setup",
+      "/privacy-settings",
+      "/bug",
+    ];
+    for (const cmd of added) {
+      expect(INJECT_BLOCKED.has(cmd), `${cmd} must be blocklisted`).toBe(true);
+      const err = (() => {
+        try {
+          validateInjectCommand(cmd);
+          return null;
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(err, `${cmd} must throw`).toBeInstanceOf(InjectError);
+      expect((err as InjectError).code, `${cmd} → blocked`).toBe("blocked");
     }
   });
 
@@ -94,7 +161,22 @@ describe("INJECT_COMMANDS metadata", () => {
       expect(verb.startsWith("/")).toBe(true);
       expect(typeof meta.description).toBe("string");
       expect(typeof meta.expectsOutput).toBe("boolean");
+      expect(typeof meta.argsAllowed).toBe("boolean");
     }
+  });
+
+  it("#730 — new read-only additions are on the allowlist (bare verb accepted)", () => {
+    for (const cmd of ["/help", "/context", "/release-notes"]) {
+      expect(INJECT_COMMANDS.has(cmd), `${cmd} must be allowlisted`).toBe(true);
+      expect(validateInjectCommand(cmd)).toBe(cmd);
+    }
+  });
+
+  it("#730 — /help and /release-notes are dialog:true (Escape-dismiss), /context is inline", () => {
+    expect(INJECT_COMMANDS.get("/help")?.dialog).toBe(true);
+    expect(INJECT_COMMANDS.get("/release-notes")?.dialog).toBe(true);
+    // /context renders inline (no modal) — verified via TUI probe, v2.1.205.
+    expect(INJECT_COMMANDS.get("/context")?.dialog).toBeUndefined();
   });
 
   it("/compact carries a silentNote", () => {

--- a/src/agents/inject.ts
+++ b/src/agents/inject.ts
@@ -54,6 +54,19 @@ export interface InjectCommandMeta {
   /** True when injecting this command opens an interactive dialog/picker
    * that must be dismissed with Escape after capture. */
   dialog?: boolean;
+  /**
+   * Whether this command may carry arguments after the bare verb.
+   *
+   * The raw inject primitive types the WHOLE string into the pane, so a
+   * bare-verb allowlist match on the first token alone let mutating
+   * setter forms slip through (`/memory edit`, `/model claude-sonnet-4-6`
+   * — the latter switches the live model). Almost every injectable command
+   * is a read-only display verb that takes no arguments, so this defaults
+   * to a hard `false`: `validateInjectCommand` rejects anything after the
+   * bare verb. Set `true` ONLY where an argument form is a sanctioned,
+   * non-destructive path (currently just `/model` — see its entry).
+   */
+  argsAllowed: boolean;
 }
 
 /**
@@ -67,10 +80,10 @@ export const INJECT_COMMANDS: ReadonlyMap<string, InjectCommandMeta> = new Map([
   // Settings/Status tab-bar dialog for /status; a hooks dialog for /hooks).
   // injectSlashCommandWith sends Escape after capturing the dialog content
   // to dismiss the modal and restore a clean ❯ prompt. (#2566)
-  ["/cost", { description: "Show session cost", expectsOutput: true, dialog: true }],
-  ["/status", { description: "Show session status", expectsOutput: true, dialog: true }],
-  ["/usage", { description: "Show plan quota", expectsOutput: true, dialog: true }],
-  ["/hooks", { description: "List configured hooks", expectsOutput: true, dialog: true }],
+  ["/cost", { description: "Show session cost", expectsOutput: true, dialog: true, argsAllowed: false }],
+  ["/status", { description: "Show session status", expectsOutput: true, dialog: true, argsAllowed: false }],
+  ["/usage", { description: "Show plan quota", expectsOutput: true, dialog: true, argsAllowed: false }],
+  ["/hooks", { description: "List configured hooks", expectsOutput: true, dialog: true, argsAllowed: false }],
   // #2566 — `/memory` is raw-injected (no dedicated driver) and on Claude
   // Code v2.1.185+ opens an interactive memory-file picker. It rides the
   // same dialog:true Escape-dismiss path: inject types `/memory` + Enter
@@ -78,7 +91,25 @@ export const INJECT_COMMANDS: ReadonlyMap<string, InjectCommandMeta> = new Map([
   // picker content, then sends Escape to CANCEL. No row is ever selected
   // (inject sends no arrow keys / no second Enter), so the dismiss is
   // side-effect-free — same safety profile as the /cost & /status dialogs.
-  ["/memory", { description: "Open memory picker", expectsOutput: true, dialog: true }],
+  ["/memory", { description: "Open memory picker", expectsOutput: true, dialog: true, argsAllowed: false }],
+  // Verified read-only additions (disposable TUI probe, claude v2.1.205,
+  // 2026-07-11).
+  // `/help` opens a tabbed help dialog ("Help · General · Commands …")
+  // with an "Esc to cancel" trailer — same dialog family as /cost, so it
+  // rides the dialog:true Escape-dismiss path. Read-only (command
+  // discovery), no arguments.
+  ["/help", { description: "Show help / command discovery", expectsOutput: true, dialog: true, argsAllowed: false }],
+  // `/context` renders the context-window usage breakdown INLINE (no modal,
+  // returns straight to the ❯ prompt) — so NO dialog flag. Read-only; the
+  // `/context all` expand form is an argument we deliberately don't allow
+  // (bare display only).
+  ["/context", { description: "Show context window usage", expectsOutput: true, argsAllowed: false }],
+  // `/release-notes` opens an interactive version PICKER ("Select a version
+  // to view its notes … Enter to confirm · Esc to cancel"), same shape as
+  // the /memory picker — dialog:true so the modal is Escape-dismissed after
+  // the version list is captured. inject never selects a row, so the
+  // dismiss is side-effect-free. Read-only, no arguments.
+  ["/release-notes", { description: "Show release-notes version list", expectsOutput: true, dialog: true, argsAllowed: false }],
   // #2566 — `/model` stays on the allowlist with NO dialog flag. It is
   // NOT raw-injected from Telegram: the dedicated driver
   // (telegram-plugin/gateway/model-command.ts) intercepts every `/model`
@@ -87,7 +118,17 @@ export const INJECT_COMMANDS: ReadonlyMap<string, InjectCommandMeta> = new Map([
   // picker. The set path depends on `/model` being allowlisted (enforced by
   // model-command.test.ts "inject allowlist contract"), so it must not move
   // to the blocklist and needs no Escape handling.
-  ["/model", { description: "Open model picker", expectsOutput: true }],
+  // argsAllowed:true — the ONLY entry that permits arguments, and it MUST.
+  // Since #2566 the dedicated Telegram driver
+  // (telegram-plugin/gateway/model-command.ts) injects `/model <alias|id>`
+  // WITH AN ARGUMENT as the sanctioned session-switch path — a direct set
+  // that opens no picker. That set is gated, busy-checked, and recorded by
+  // the driver before it ever reaches this primitive. Gating args off here
+  // (as the original #730 issue suggested) would break every typed `/model`
+  // switch; the model-command.test.ts "inject allowlist contract" pins that
+  // `/model` stays injectable, and the driver path relies on the arg form.
+  // So `/model` keeps args allowed by design.
+  ["/model", { description: "Open model picker", expectsOutput: true, argsAllowed: true }],
   // #2471 — `/effort` was previously listed here as an allowlisted inject,
   // but injecting it surfaces a blocking "Change effort level? 1. Yes /
   // 2. No" confirmation modal that an agent/headless session can't answer,
@@ -99,6 +140,7 @@ export const INJECT_COMMANDS: ReadonlyMap<string, InjectCommandMeta> = new Map([
       description: "Clear session screen",
       expectsOutput: false,
       silentNote: "context cleared — fresh slate",
+      argsAllowed: false,
     },
   ],
   [
@@ -107,6 +149,7 @@ export const INJECT_COMMANDS: ReadonlyMap<string, InjectCommandMeta> = new Map([
       description: "Compact conversation history",
       expectsOutput: false,
       silentNote: "compaction runs silently",
+      argsAllowed: false,
     },
   ],
 ]);
@@ -132,6 +175,21 @@ export const INJECT_BLOCKED: ReadonlyMap<string, InjectBlockedMeta> = new Map([
   ["/logout", { reason: "would terminate the agent's auth session" }],
   ["/exit", { reason: "would kill the agent process" }],
   ["/quit", { reason: "would kill the agent process" }],
+  // #730 — defensive blocklist expansion. None of these are read-only
+  // display verbs: each either mutates local state, opens an interactive
+  // modal an agent/headless session can't answer (wedging the pane like
+  // #2471's /effort), or performs a network/setup action. Listed here so
+  // an operator gets the specific `blocked` message + reason rather than
+  // the generic `not_allowed`.
+  ["/upgrade", { reason: "mutates the Claude Code installation" }],
+  ["/init", { reason: "generates/overwrites CLAUDE.md and runs a model turn" }],
+  ["/mcp", { reason: "opens an interactive MCP server management dialog" }],
+  ["/permissions", { reason: "opens an interactive permissions editor that mutates tool policy" }],
+  ["/install-github-app", { reason: "runs a network/OAuth install flow" }],
+  ["/add-dir", { reason: "mutates the session's working-directory set" }],
+  ["/terminal-setup", { reason: "mutates terminal keybinding configuration" }],
+  ["/privacy-settings", { reason: "opens an interactive privacy-settings dialog" }],
+  ["/bug", { reason: "submits a bug report over the network" }],
   // #2471 — `/effort` opens a blocking "Change effort level? 1. Yes / 2.
   // No" confirmation modal whenever the session has a cached conversation.
   // The RAW inject primitive types the command and walks away, leaving the
@@ -161,6 +219,7 @@ export const INJECT_BLOCKLIST: ReadonlySet<string> = new Set(INJECT_BLOCKED.keys
 export type InjectErrorCode =
   | "not_allowed"
   | "blocked"
+  | "args_not_allowed"
   | "session_missing"
   | "invalid"
   | "timeout"
@@ -251,11 +310,24 @@ export function validateInjectCommand(command: string): string {
       `${bare} is explicitly blocked from inject (${blockedMeta.reason}).`,
     );
   }
-  if (!INJECT_COMMANDS.has(bare)) {
+  const meta = INJECT_COMMANDS.get(bare);
+  if (!meta) {
     const allowed = [...INJECT_COMMANDS.keys()].sort().join(", ");
     throw new InjectError(
       "not_allowed",
       `${bare} is not in the inject allowlist. Allowed: ${allowed}`,
+    );
+  }
+  // Arg-gate (#730). The raw inject types the WHOLE string into the pane,
+  // so a bare-verb allowlist match let mutating setter forms slip through
+  // (`/memory edit`, `/model claude-sonnet-4-6`). Reject anything after the
+  // bare verb unless the command's metadata explicitly permits arguments
+  // (only `/model`, whose arg form is the sanctioned session-switch path).
+  const hasArgs = trimmed.split(/\s+/).length > 1;
+  if (hasArgs && !meta.argsAllowed) {
+    throw new InjectError(
+      "args_not_allowed",
+      `args not permitted for ${bare} — inject the bare verb only`,
     );
   }
   return bare;

--- a/telegram-plugin/gateway/inject-handler.ts
+++ b/telegram-plugin/gateway/inject-handler.ts
@@ -103,6 +103,14 @@ function shapeReply(
       accent: 'issue',
     }
   }
+  if (code === 'args_not_allowed') {
+    // #730 — a bare-verb-only command was injected with trailing args.
+    // errorMessage is already actionable ("args not permitted for /memory …").
+    return {
+      body: `${verbHtml} — ${deps.escapeHtml(msg)}`,
+      accent: 'issue',
+    }
+  }
   if (code === 'session_missing') {
     return {
       body: 'tmux session not found — agent must be running under the tmux supervisor (the default). Remove \`experimental.legacy_pty: true\` if set.',


### PR DESCRIPTION
## Summary

Followup to epic #725 (Phase 2 inject). Tightens `validateInjectCommand`
so bare-verb allowlist matches can't smuggle mutating setter forms into
the pane, expands the read-only allowlist, and grows the defensive
blocklist.

- **Arg-gate:** new `argsAllowed: boolean` on `InjectCommandMeta`.
  `validateInjectCommand` rejects anything after the bare verb with a new
  `args_not_allowed` code and an actionable message
  (`args not permitted for /memory — inject the bare verb only`). Before,
  `/model claude-sonnet-4-6`, `/memory edit`, `/clear --flag` all passed
  the first-token check and were typed verbatim into the pane.
- **Allowlist additions (all `argsAllowed: false`):**
  - `/help` — `dialog: true`. Opens a tabbed help modal ("Esc to cancel"),
    rides the #2566 Escape-dismiss path.
  - `/context` — inline (no `dialog` flag). Renders the context-window
    usage breakdown and returns straight to `❯`.
  - `/release-notes` — `dialog: true`. Opens a version PICKER
    ("Enter to confirm · Esc to cancel"), same shape as `/memory`;
    inject never selects a row, so the Escape dismiss is side-effect-free.
- **Blocklist additions (`blocked`, not `not_allowed`):** `/upgrade`,
  `/init`, `/mcp`, `/permissions`, `/install-github-app`, `/add-dir`,
  `/terminal-setup`, `/privacy-settings`, `/bug`.

Every allowlist/dialog classification was verified with a **disposable
TUI probe against the installed `claude` v2.1.205** (the repo's grounding
method), not guessed.

## Why

Job spec `reference/jobs/operate-the-fleet-from-telegram.md` (drive an
agent's REPL from Telegram) and `reference/jobs/approve-what-my-agent-can-touch.md`
(the surface an operator can trigger must be safe by construction). The
first-token-only allowlist check let a remote surface mutate live model
state and open unanswerable modals that wedge the pane (the #2471 class).

## Deviation from the issue (important)

The issue suggested `/model { argsAllowed: false }` ("block the setter
form"). **That would break `/model`.** Since #2566 the dedicated driver
(`telegram-plugin/gateway/model-command.ts`) injects `/model <alias|id>`
WITH an argument as the sanctioned, gated, recorded session-switch path,
and `model-command.test.ts` "inject allowlist contract" pins that `/model`
stays injectable. `/model` is therefore the ONLY entry with
`argsAllowed: true`, with a code comment explaining why. A regression
test asserts `/model claude-sonnet-4-6` is accepted while every other
entry rejects args.

## Skipped commands (verified, not added — with reasons)

- `/agents` — verified safe (inline text, no modal) but its only output
  is a static "the /agents wizard has been removed" notice (no agent
  list) → near-zero remote value.
- `/doctor` — in v2.1.205 it is NOT a recognized read-only slash command:
  the probe showed it routing to the model as a prose turn (a "Puttering…"
  spinner). Injecting it would start an unwanted model turn.
- `/diff`, `/todos` — not confirmed as recognized read-only commands; the
  probe run was contaminated by `/doctor`'s model turn, so no clean
  verification. Left pending live TUI re-verification.
- `/config`, `/pr-comments`, `/export` — the issue marks these
  discuss-first; not added.

## Test plan

- `vitest run src/agents/inject.test.ts telegram-plugin/tests/model-command.test.ts telegram-plugin/gateway/inject-handler.test.ts src/web/hermes-adapter.test.ts` → **228 passed**.
- New tests: positive validator test per new allowlist entry; dialog-flag
  assertions; each new blocklist entry returns `blocked`; arg-gate rejects
  `/cost some-arg` / `/memory edit` / `/clear --flag`; `/model <id>`
  accepted (contract); every non-`/model` entry forbids args.
- `npm run lint` → clean (tsc + all 8 guards).

## Risk

Low. Pure validator/allowlist logic; no tmux/runtime path change. The one
behavior change (allowlisted-command-with-args now rejected) is the intent
and only affects non-`/model` verbs, none of which have a caller that
passes args (grepped gateway + hermes + tests). `/model`'s driver path is
unchanged and contract-pinned.

Closes #730