### PR TITLE
fix(vault,doctor): configurable audit fail-closed + fail-open counter + approval-attribution alert (sec WS10-F3/F5 #1420)

### DIFF
--- a/src/cli/doctor-approval-attribution.test.ts
+++ b/src/cli/doctor-approval-attribution.test.ts
@@ -1,0 +1,94 @@
+/**
+ * doctor-approval-attribution — WS10-F5 part 1 (#1420). Pins the detection
+ * contract for approval-attribution anomalies over approval_decisions rows.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  detectAttributionAnomalies,
+  runApprovalAttributionChecks,
+  type DecisionRow,
+} from "./doctor-approval-attribution.js";
+import { canonicalizeApproverSet } from "../vault/approvals/canonical.js";
+
+function row(over: Partial<DecisionRow> = {}): DecisionRow {
+  return {
+    id: "d1",
+    granted_by_user_id: 111,
+    approver_set_canonical: canonicalizeApproverSet(["111", "222"]),
+    decision: "allow_always",
+    origin: "operator",
+    revoked_at: null,
+    ...over,
+  };
+}
+
+describe("detectAttributionAnomalies", () => {
+  it("ok when every active grant's granter is in its own approver set", () => {
+    const r = detectAttributionAnomalies([
+      row({ id: "a", granted_by_user_id: 111 }),
+      row({ id: "b", granted_by_user_id: 222 }),
+    ]);
+    const own = r.find((c) => c.name.includes("granter in own approver set"));
+    expect(own?.status).toBe("ok");
+  });
+
+  it("FAILS when a grant's granter is NOT in its own recorded approver set", () => {
+    // uid 999 was never on the allowlist that authorized this row → could not
+    // have come through the gateway's allowFrom gate → forged/bypass.
+    const r = detectAttributionAnomalies([
+      row({ id: "good", granted_by_user_id: 111 }),
+      row({
+        id: "forged",
+        granted_by_user_id: 999,
+        approver_set_canonical: canonicalizeApproverSet(["111", "222"]),
+        origin: "agent",
+      }),
+    ]);
+    const own = r.find((c) => c.name.includes("granter in own approver set"));
+    expect(own?.status).toBe("fail");
+    expect(own?.detail).toContain("forged");
+    expect(own?.detail).toContain("uid=999");
+  });
+
+  it("ignores revoked and non-allow decisions", () => {
+    const r = detectAttributionAnomalies([
+      row({ id: "revoked", granted_by_user_id: 999, revoked_at: 1700000000 }),
+      row({ id: "denied", granted_by_user_id: 999, decision: "deny" }),
+    ]);
+    expect(
+      r.find((c) => c.name.includes("granter in own approver set"))?.status,
+    ).toBe("ok");
+  });
+
+  it("warns (not fails) when the granter left the LIVE allowlist but was valid at grant time", () => {
+    const r = detectAttributionAnomalies(
+      [row({ id: "stale", granted_by_user_id: 222 })], // 222 in own set…
+      ["111"], // …but no longer a live operator
+    );
+    expect(
+      r.find((c) => c.name.includes("granter in own approver set"))?.status,
+    ).toBe("ok");
+    const stale = r.find((c) => c.name.includes("still on live allowlist"));
+    expect(stale?.status).toBe("warn");
+    expect(stale?.detail).toContain("uid=222");
+  });
+});
+
+describe("runApprovalAttributionChecks", () => {
+  it("skips cleanly when the decisions DB can't be read", () => {
+    const r = runApprovalAttributionChecks({ loadDecisions: () => null });
+    expect(r).toHaveLength(1);
+    expect(r[0].status).toBe("skip");
+  });
+
+  it("runs the detector against injected rows", () => {
+    const r = runApprovalAttributionChecks({
+      loadDecisions: () => [row({ granted_by_user_id: 999 })],
+    });
+    expect(
+      r.find((c) => c.name.includes("granter in own approver set"))?.status,
+    ).toBe("fail");
+  });
+});

--- a/src/cli/doctor-approval-attribution.test.ts
+++ b/src/cli/doctor-approval-attribution.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from "vitest";
 
 import {
   detectAttributionAnomalies,
+  loadLiveAllowFromAccessFiles,
   runApprovalAttributionChecks,
   type DecisionRow,
 } from "./doctor-approval-attribution.js";
@@ -77,18 +78,65 @@ describe("detectAttributionAnomalies", () => {
 });
 
 describe("runApprovalAttributionChecks", () => {
-  it("skips cleanly when the decisions DB can't be read", () => {
-    const r = runApprovalAttributionChecks({ loadDecisions: () => null });
+  it("skips cleanly when the decisions DB can't be read", async () => {
+    const r = await runApprovalAttributionChecks({ loadDecisions: () => null });
     expect(r).toHaveLength(1);
     expect(r[0].status).toBe("skip");
   });
 
-  it("runs the detector against injected rows", () => {
-    const r = runApprovalAttributionChecks({
+  it("runs the detector against injected rows", async () => {
+    const r = await runApprovalAttributionChecks({
       loadDecisions: () => [row({ granted_by_user_id: 999 })],
     });
     expect(
       r.find((c) => c.name.includes("granter in own approver set"))?.status,
     ).toBe("fail");
+  });
+
+  it("plumbs liveAllowFrom through to the stale-granter warn (doctor wiring contract)", async () => {
+    // Mirrors the doctor.ts call site: a defined liveAllowFrom must activate
+    // the stale-granter check. Regression guard for the check being wired
+    // with no deps (liveAllowFrom undefined → the warn was dead code).
+    const r = await runApprovalAttributionChecks({
+      loadDecisions: () => [row({ granted_by_user_id: 222 })], // 222 in own set
+      liveAllowFrom: ["111"], // …but not a live operator any more
+    });
+    expect(
+      r.find((c) => c.name.includes("still on live allowlist"))?.status,
+    ).toBe("warn");
+  });
+});
+
+describe("loadLiveAllowFromAccessFiles", () => {
+  const files: Record<string, string> = {
+    "/a/one/telegram/access.json": JSON.stringify({
+      dmPolicy: "allowlist",
+      allowFrom: ["111", "222"],
+    }),
+    "/a/two/telegram/access.json": JSON.stringify({
+      dmPolicy: "allowlist",
+      allowFrom: ["222", 333], // numeric entry → coerced to string
+    }),
+    "/a/broken/telegram/access.json": "{not json",
+  };
+  const read = (p: string) => {
+    if (!(p in files)) throw new Error("ENOENT");
+    return files[p];
+  };
+
+  it("unions allowFrom across every readable agent access.json", () => {
+    const r = loadLiveAllowFromAccessFiles(
+      ["one", "two", "broken", "missing"],
+      "/a",
+      read,
+    );
+    expect(r?.sort()).toEqual(["111", "222", "333"]);
+  });
+
+  it("returns undefined when NO access.json could be read (skip, not empty allowlist)", () => {
+    // An empty-list return would mark EVERY granter stale — undefined must
+    // disable the stale-granter check instead.
+    expect(loadLiveAllowFromAccessFiles(["missing"], "/a", read)).toBeUndefined();
+    expect(loadLiveAllowFromAccessFiles([], "/a", read)).toBeUndefined();
   });
 });

--- a/src/cli/doctor-approval-attribution.ts
+++ b/src/cli/doctor-approval-attribution.ts
@@ -1,0 +1,229 @@
+/**
+ * doctor-approval-attribution — WS10-F5 part 1 (#1420).
+ *
+ * Proactive, forensic detection of approval-attribution anomalies in the
+ * approval kernel's `approval_decisions` table: an active grant whose
+ * recorded `granted_by_user_id` (the operator who tapped [Approve]) is NOT
+ * a member of the operator allowlist that authorized it.
+ *
+ * Why this lives in `doctor` and NOT as a live operator-event card wired
+ * into the approval kernel (the "wire an event there" option the #1420
+ * brief offered):
+ *
+ *   1. EMISSION IS UNREACHABLE FROM THE KERNEL. The operator-event card
+ *      pipeline (classify → render → sendMessage) lives entirely in the
+ *      telegram-plugin GATEWAY process (telegram-plugin/operator-events.ts
+ *      + telegram-plugin/gateway/*.ts). The approval kernel is a separate
+ *      daemon (src/vault/approvals/kernel-server.ts) with ZERO telegram /
+ *      grammy imports — `grep -n "telegram\|grammy\|sendMessage"
+ *      src/vault/approvals/kernel*.ts` returns nothing. The kernel cannot
+ *      emit a card; only the gateway can.
+ *
+ *   2. THE GATEWAY ALREADY FAILS CLOSED AT TAP TIME. Every approval-tap
+ *      handler in telegram-plugin/gateway/callback-query-handlers.ts gates
+ *      on `access.allowFrom.includes(senderId)` BEFORE recording a decision
+ *      (e.g. lines 498, 856, 949, 1109, …). So a non-allowlisted user
+ *      literally cannot mint a grant through the normal path. A decision
+ *      row whose granter is off the allowlist therefore did NOT come through
+ *      that gate — it is a forensic signal of a bypass (direct DB write, a
+ *      forged `origin='agent'` row, a compromised writer), exactly the kind
+ *      of after-the-fact tamper evidence `doctor` exists to surface. A live
+ *      card at grant time would be redundant with the existing gate; a
+ *      standing forensic sweep is the meaningful, non-redundant control.
+ *
+ * The detection core (`detectAttributionAnomalies`) is a pure function over
+ * decision rows + the operator allowlist — DI-testable, no I/O — mirroring
+ * the doctor-audit-integrity / doctor-drive DI pattern.
+ */
+
+import { execFileSync } from "node:child_process";
+
+import { canonicalizeApproverSet } from "../vault/approvals/canonical.js";
+
+import type { CheckStatus } from "./doctor-status.js";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+/**
+ * One approval_decisions row, reduced to the fields attribution detection
+ * needs. Mirrors the columns in src/vault/approvals/schema.ts.
+ */
+export interface DecisionRow {
+  id: string;
+  /** Telegram user_id of the operator who tapped [Approve]. */
+  granted_by_user_id: number;
+  /** Canonicalized JSON array of the operator allowlist at grant time. */
+  approver_set_canonical: string;
+  /** Decision mode, e.g. "allow_always" / "allow_ttl" / "deny". */
+  decision: string;
+  /** Provenance: 'operator' (kernel-verified) or 'agent' (forgeable). */
+  origin: string;
+  /** Unix seconds; non-null ⇒ the grant was revoked (excluded from checks). */
+  revoked_at: number | null;
+}
+
+/** Parse a canonicalized approver set back into a member list. */
+function parseApproverSet(canonical: string): string[] {
+  try {
+    const arr = JSON.parse(canonical);
+    return Array.isArray(arr) ? arr.map((x) => String(x)) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Pure detection core (WS10-F5 part 1). Flags every ACTIVE `allow*` grant
+ * whose `granted_by_user_id` is not a member of the allowlist that
+ * authorized it. Two allowlists are checked:
+ *
+ *   - the decision's OWN recorded `approver_set_canonical` (the set in
+ *     force when it was granted) — a miss here is a hard tamper signal
+ *     (`fail`): the row could not have come through the gateway's
+ *     allowFrom gate.
+ *   - the LIVE operator allowlist (`liveAllowFrom`, from access.allowFrom),
+ *     when supplied — a miss here alone is a softer `warn`: the granter was
+ *     valid at grant time but is no longer an operator (allowlist shrank).
+ */
+export function detectAttributionAnomalies(
+  decisions: readonly DecisionRow[],
+  liveAllowFrom?: readonly string[],
+): CheckResult[] {
+  const active = decisions.filter(
+    (d) => d.revoked_at === null && d.decision.startsWith("allow"),
+  );
+
+  const liveSet =
+    liveAllowFrom !== undefined
+      ? new Set(parseApproverSet(canonicalizeApproverSet([...liveAllowFrom])))
+      : undefined;
+
+  const forged: DecisionRow[] = [];
+  const staleGranter: DecisionRow[] = [];
+
+  for (const d of active) {
+    const granter = String(d.granted_by_user_id);
+    const ownSet = new Set(parseApproverSet(d.approver_set_canonical));
+    if (!ownSet.has(granter)) {
+      forged.push(d);
+      continue; // a self-set miss is the strongest signal — don't double-count
+    }
+    if (liveSet !== undefined && !liveSet.has(granter)) {
+      staleGranter.push(d);
+    }
+  }
+
+  const results: CheckResult[] = [];
+
+  if (forged.length > 0) {
+    const ids = forged.map((d) => `${d.id}(uid=${d.granted_by_user_id},origin=${d.origin})`).join(", ");
+    results.push({
+      name: "approval attribution: granter in own approver set",
+      status: "fail",
+      detail: `${forged.length} active grant(s) recorded a granted_by_user_id that is NOT in the decision's OWN approver_set_canonical — the gateway gates every tap on access.allowFrom, so these rows did not come through it (forged/bypass/direct-DB write; WS10-F5). Affected: ${ids}`,
+      fix: `Treat these grants as unauthorized: revoke them, preserve vault-grants.db for forensics, and investigate how a decision was written bypassing the gateway's allowFrom gate.`,
+    });
+  } else {
+    results.push({
+      name: "approval attribution: granter in own approver set",
+      status: "ok",
+      detail: `every active grant's granted_by_user_id is a member of the approver set that authorized it`,
+    });
+  }
+
+  if (staleGranter.length > 0) {
+    const ids = staleGranter.map((d) => `${d.id}(uid=${d.granted_by_user_id})`).join(", ");
+    results.push({
+      name: "approval attribution: granter still on live allowlist",
+      status: "warn",
+      detail: `${staleGranter.length} active grant(s) were authorized by a user no longer on the live access.allowFrom — valid at grant time, but that operator has since been removed. Affected: ${ids}`,
+      fix: `Review whether these standing grants should persist now that their granter is no longer an operator; revoke if the access should not outlive the operator.`,
+    });
+  }
+
+  return results;
+}
+
+export interface ApprovalAttributionDeps {
+  /**
+   * Loads the approval_decisions rows to inspect. Defaults to a best-effort
+   * `docker exec switchroom-vault-broker sqlite3` read of vault-grants.db;
+   * injectable for tests. Return `null` to signal "could not read" (→ skip).
+   */
+  loadDecisions?: () => DecisionRow[] | null;
+  /** Live operator allowlist (access.allowFrom), for the stale-granter warn. */
+  liveAllowFrom?: readonly string[];
+}
+
+/**
+ * Default loader: read active grant decisions out of the broker container's
+ * vault-grants.db via `docker exec … sqlite3`. Best-effort — any failure
+ * (docker missing, container down, no sqlite3, locked DB) returns `null` so
+ * the caller emits a `skip`, never a false `fail`.
+ */
+function defaultLoadDecisions(): DecisionRow[] | null {
+  try {
+    const sql =
+      "SELECT id, granted_by_user_id, approver_set_canonical, decision, origin, " +
+      "COALESCE(revoked_at, -1) FROM approval_decisions;";
+    const SEP = String.fromCharCode(31); // ASCII unit separator
+    const stdout = execFileSync(
+      "docker",
+      [
+        "exec",
+        "switchroom-vault-broker",
+        "sqlite3",
+        "-separator",
+        SEP,
+        "/state/vault-grants.db",
+        sql,
+      ],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 10_000 },
+    );
+    const rows: DecisionRow[] = [];
+    for (const line of stdout.split("\n")) {
+      if (line.trim().length === 0) continue;
+      const f = line.split(SEP);
+      if (f.length < 6) continue;
+      const revoked = Number(f[5]);
+      rows.push({
+        id: f[0],
+        granted_by_user_id: Number(f[1]),
+        approver_set_canonical: f[2],
+        decision: f[3],
+        origin: f[4],
+        revoked_at: revoked === -1 ? null : revoked,
+      });
+    }
+    return rows;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * doctor entry point (WS10-F5 part 1). Loads the decisions and runs the pure
+ * detector. Degrades to a single `skip` when the DB can't be read.
+ */
+export function runApprovalAttributionChecks(
+  deps: ApprovalAttributionDeps = {},
+): CheckResult[] {
+  const load = deps.loadDecisions ?? defaultLoadDecisions;
+  const decisions = load();
+  if (decisions === null) {
+    return [
+      {
+        name: "approval attribution",
+        status: "skip",
+        detail:
+          "could not read approval_decisions from the vault-broker container (broker down, docker unavailable, or no sqlite3) — attribution not evaluated",
+      },
+    ];
+  }
+  return detectAttributionAnomalies(decisions, deps.liveAllowFrom);
+}

--- a/src/cli/doctor-approval-attribution.ts
+++ b/src/cli/doctor-approval-attribution.ts
@@ -37,6 +37,8 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { readFileSync as fsReadFileSync } from "node:fs";
+import { join } from "node:path";
 
 import { canonicalizeApproverSet } from "../vault/approvals/canonical.js";
 
@@ -151,26 +153,110 @@ export function detectAttributionAnomalies(
 
 export interface ApprovalAttributionDeps {
   /**
-   * Loads the approval_decisions rows to inspect. Defaults to a best-effort
-   * `docker exec switchroom-vault-broker sqlite3` read of vault-grants.db;
-   * injectable for tests. Return `null` to signal "could not read" (→ skip).
+   * Loads the approval_decisions rows to inspect. Defaults to
+   * `defaultLoadDecisions` (host-file bun:sqlite read with docker-exec
+   * fallback); injectable for tests. Return `null` to signal "could not
+   * read" (→ skip).
    */
-  loadDecisions?: () => DecisionRow[] | null;
-  /** Live operator allowlist (access.allowFrom), for the stale-granter warn. */
+  loadDecisions?: () => Promise<DecisionRow[] | null> | DecisionRow[] | null;
+  /**
+   * Live operator allowlist for the stale-granter warn. The list lives in
+   * the per-agent `telegram/access.json` files (`allowFrom`) — NOT in
+   * switchroom.yaml — so the doctor call site derives it with
+   * `loadLiveAllowFromAccessFiles`. Undefined skips the stale-granter check.
+   */
   liveAllowFrom?: readonly string[];
 }
 
+const DECISIONS_SQL =
+  "SELECT id, granted_by_user_id, approver_set_canonical, decision, origin, " +
+  "COALESCE(revoked_at, -1) FROM approval_decisions;";
+
+/** Parse `sqlite3 -separator <US>` output lines into DecisionRows. */
+function parseSqlite3Lines(stdout: string, sep: string): DecisionRow[] {
+  const rows: DecisionRow[] = [];
+  for (const line of stdout.split("\n")) {
+    if (line.trim().length === 0) continue;
+    const f = line.split(sep);
+    if (f.length < 6) continue;
+    const revoked = Number(f[5]);
+    rows.push({
+      id: f[0],
+      granted_by_user_id: Number(f[1]),
+      approver_set_canonical: f[2],
+      decision: f[3],
+      origin: f[4],
+      revoked_at: revoked === -1 ? null : revoked,
+    });
+  }
+  return rows;
+}
+
 /**
- * Default loader: read active grant decisions out of the broker container's
- * vault-grants.db via `docker exec … sqlite3`. Best-effort — any failure
- * (docker missing, container down, no sqlite3, locked DB) returns `null` so
- * the caller emits a `skip`, never a false `fail`.
+ * Default loader: read approval_decisions out of vault-grants.db.
+ *
+ * Primary path — HOST-SIDE bun:sqlite read of the canonical
+ * `~/.switchroom/vault-grants.db` (grants-db.ts DEFAULT_GRANTS_DB_PATH):
+ * doctor runs on the host, and the broker container merely bind-mounts that
+ * same file to `/root/.switchroom/vault-grants.db` (compose.ts — the
+ * `${homePrefix}/.switchroom/vault-grants.db:/root/.switchroom/vault-grants.db`
+ * mount), so the host file IS the authoritative DB and needs neither docker
+ * nor a sqlite3 binary. The built CLI runs under bun (scripts/build.mjs
+ * rewrites the shebang to bun precisely because of `bun:sqlite`), so the
+ * dynamic import resolves; under vitest/node the `typeof Bun` guard skips it.
+ *
+ * Fallback — `docker exec switchroom-vault-broker sqlite3` against the
+ * IN-CONTAINER path `/root/.switchroom/vault-grants.db`. Best-effort only:
+ * requires sqlite3 in the broker image, and the container name assumes the
+ * default compose project prefix ("switchroom-"); a custom prefix makes this
+ * fallback miss and the check degrades to `skip`.
+ *
+ * Any failure on both paths returns `null` so the caller emits a `skip`,
+ * never a false `fail`.
  */
-function defaultLoadDecisions(): DecisionRow[] | null {
+async function defaultLoadDecisions(): Promise<DecisionRow[] | null> {
+  // Path 1: direct host-file read via bun:sqlite (readonly).
   try {
-    const sql =
-      "SELECT id, granted_by_user_id, approver_set_canonical, decision, origin, " +
-      "COALESCE(revoked_at, -1) FROM approval_decisions;";
+    if (typeof Bun !== "undefined") {
+      const os = await import("node:os");
+      const path = await import("node:path");
+      const fs = await import("node:fs");
+      const dbPath = path.join(os.homedir(), ".switchroom", "vault-grants.db");
+      if (fs.existsSync(dbPath)) {
+        const { Database } = await import("bun:sqlite");
+        const db = new Database(dbPath, { readonly: true });
+        try {
+          const raw = db
+            .query(
+              "SELECT id, granted_by_user_id, approver_set_canonical, decision, origin, revoked_at FROM approval_decisions",
+            )
+            .all() as Array<{
+            id: string;
+            granted_by_user_id: number;
+            approver_set_canonical: string;
+            decision: string;
+            origin: string;
+            revoked_at: number | null;
+          }>;
+          return raw.map((r) => ({
+            id: String(r.id),
+            granted_by_user_id: Number(r.granted_by_user_id),
+            approver_set_canonical: String(r.approver_set_canonical),
+            decision: String(r.decision),
+            origin: String(r.origin),
+            revoked_at: r.revoked_at === null ? null : Number(r.revoked_at),
+          }));
+        } finally {
+          db.close();
+        }
+      }
+    }
+  } catch {
+    // fall through to the docker-exec path
+  }
+
+  // Path 2: docker exec into the broker container (in-container mount path).
+  try {
     const SEP = String.fromCharCode(31); // ASCII unit separator
     const stdout = execFileSync(
       "docker",
@@ -180,48 +266,67 @@ function defaultLoadDecisions(): DecisionRow[] | null {
         "sqlite3",
         "-separator",
         SEP,
-        "/state/vault-grants.db",
-        sql,
+        "/root/.switchroom/vault-grants.db",
+        DECISIONS_SQL,
       ],
       { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 10_000 },
     );
-    const rows: DecisionRow[] = [];
-    for (const line of stdout.split("\n")) {
-      if (line.trim().length === 0) continue;
-      const f = line.split(SEP);
-      if (f.length < 6) continue;
-      const revoked = Number(f[5]);
-      rows.push({
-        id: f[0],
-        granted_by_user_id: Number(f[1]),
-        approver_set_canonical: f[2],
-        decision: f[3],
-        origin: f[4],
-        revoked_at: revoked === -1 ? null : revoked,
-      });
-    }
-    return rows;
+    return parseSqlite3Lines(stdout, SEP);
   } catch {
     return null;
   }
 }
 
 /**
+ * Derive the live operator allowlist for the stale-granter check by
+ * unioning `allowFrom` across every agent's `telegram/access.json`
+ * (`<agentsDir>/<agent>/telegram/access.json`). That file — not
+ * switchroom.yaml — is where the gateway reads its tap-authorization list
+ * (telegram-plugin/gateway/callback-query-handlers.ts `loadAccess`), so it
+ * is the ground truth the detector must compare against.
+ *
+ * Returns `undefined` when NO access.json could be read (fresh install /
+ * wrong dir) so the caller skips the stale-granter warn instead of
+ * treating every granter as stale against an empty list.
+ */
+export function loadLiveAllowFromAccessFiles(
+  agentNames: readonly string[],
+  agentsDir: string,
+  readFile: (p: string) => string = (p) => fsReadFileSync(p, "utf8"),
+): string[] | undefined {
+  const union = new Set<string>();
+  let readAny = false;
+  for (const name of agentNames) {
+    try {
+      const raw = readFile(join(agentsDir, name, "telegram", "access.json"));
+      const parsed = JSON.parse(raw) as { allowFrom?: unknown };
+      readAny = true;
+      if (Array.isArray(parsed.allowFrom)) {
+        for (const id of parsed.allowFrom) union.add(String(id));
+      }
+    } catch {
+      // missing/unreadable access.json for this agent — skip it
+    }
+  }
+  return readAny ? Array.from(union) : undefined;
+}
+
+/**
  * doctor entry point (WS10-F5 part 1). Loads the decisions and runs the pure
  * detector. Degrades to a single `skip` when the DB can't be read.
  */
-export function runApprovalAttributionChecks(
+export async function runApprovalAttributionChecks(
   deps: ApprovalAttributionDeps = {},
-): CheckResult[] {
+): Promise<CheckResult[]> {
   const load = deps.loadDecisions ?? defaultLoadDecisions;
-  const decisions = load();
+  const decisions = await load();
   if (decisions === null) {
     return [
       {
         name: "approval attribution",
         status: "skip",
         detail:
-          "could not read approval_decisions from the vault-broker container (broker down, docker unavailable, or no sqlite3) — attribution not evaluated",
+          "could not read approval_decisions from ~/.switchroom/vault-grants.db (host read) or the vault-broker container (docker exec fallback) — attribution not evaluated",
       },
     ];
   }

--- a/src/cli/doctor-audit-integrity.test.ts
+++ b/src/cli/doctor-audit-integrity.test.ts
@@ -155,4 +155,32 @@ describe("runAuditIntegrityChecks", () => {
       r.find((c) => c.name.includes("vault-broker audit tamper-evidence")),
     ).toBeUndefined();
   });
+
+  // ─── fail-open counter (sec WS10-F3 / #1420) ────────────────────────────────
+
+  it("warns when the vault-broker fail-open counter is non-zero", () => {
+    const r = runAuditIntegrityChecks({
+      homeDir: HOME,
+      readFileSync: reader({ [VAULT]: chainedLog([{ ts: "t", op: "get" }]) }),
+      readFailOpenState: () => ({
+        failOpenCount: 3,
+        lastFailureTs: "2026-07-11T00:00:00.000Z",
+        lastError: "EROFS: read-only file system",
+      }),
+    });
+    const c = r.find((x) => x.name === "vault-broker audit fail-open counter");
+    expect(c?.status).toBe("warn");
+    expect(c?.detail).toMatch(/3 audit append\(s\) failed/);
+    expect(c?.detail).toContain("EROFS");
+  });
+
+  it("ok when the fail-open counter is zero (or sidecar absent)", () => {
+    const r = runAuditIntegrityChecks({
+      homeDir: HOME,
+      readFileSync: reader({ [VAULT]: chainedLog([{ ts: "t", op: "get" }]) }),
+      readFailOpenState: () => ({ failOpenCount: 0 }),
+    });
+    const c = r.find((x) => x.name === "vault-broker audit fail-open counter");
+    expect(c?.status).toBe("ok");
+  });
 });

--- a/src/cli/doctor-audit-integrity.ts
+++ b/src/cli/doctor-audit-integrity.ts
@@ -30,6 +30,11 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { verifyAuditLog } from "../util/audit-hashchain.js";
+import {
+  failOpenStatePath,
+  readFailOpenState,
+  type FailOpenState,
+} from "../vault/broker/audit-log.js";
 
 import type { CheckStatus } from "./doctor-status.js";
 
@@ -46,6 +51,12 @@ export interface AuditIntegrityDeps {
   /** Reads a log file's text. Defaults to fs.readFileSync; a thrown
    *  ENOENT is treated as "missing". */
   readFileSync?: (p: string) => string;
+  /**
+   * Reads the vault-broker fail-open counter sidecar (sec WS10-F3 / #1420).
+   * Defaults to the real `readFailOpenState`; injectable for tests. Returns
+   * a zeroed state when the sidecar is absent/unreadable.
+   */
+  readFailOpenState?: (statePath: string) => FailOpenState;
 }
 
 interface LogTarget {
@@ -69,7 +80,33 @@ export function runAuditIntegrityChecks(
   const home = deps.homeDir ?? homedir();
   const read =
     deps.readFileSync ?? ((p: string) => fsReadFileSync(p, "utf8"));
+  const readFailOpen = deps.readFailOpenState ?? readFailOpenState;
   const results: CheckResult[] = [];
+
+  // sec WS10-F3 / #1420 — the vault-broker fail-open counter. A non-zero
+  // count means at least one secret release happened (fail-open) or was
+  // DENIED (fail-closed) while its audit append failed — a durable signal
+  // the operator must not miss. The count lives in a sidecar beside the
+  // vault-broker audit log so a failed append doesn't recursively fail to
+  // record itself.
+  const vaultAuditLog = join(home, ".switchroom", "vault-audit.log");
+  const failOpen = readFailOpen(failOpenStatePath(vaultAuditLog));
+  if (failOpen.failOpenCount > 0) {
+    const when = failOpen.lastFailureTs ? ` (last at ${failOpen.lastFailureTs})` : ``;
+    const why = failOpen.lastError ? ` — last error: ${failOpen.lastError}` : ``;
+    results.push({
+      name: "vault-broker audit fail-open counter",
+      status: "warn",
+      detail: `${failOpen.failOpenCount} audit append(s) failed${when}${why}. Each failure meant a secret release was either NOT durably audited (fail-open) or denied (fail-closed) — investigate the audit volume (mount/permissions/disk) before trusting recent access records (WS10-F3).`,
+      fix: `Check the vault-broker's audit volume is mounted, writable, and not full; review vault-broker stderr for '[vault-audit] ERROR' lines. Once healed, reset the counter by removing ${failOpenStatePath(vaultAuditLog)}.`,
+    });
+  } else {
+    results.push({
+      name: "vault-broker audit fail-open counter",
+      status: "ok",
+      detail: `no failed audit appends recorded (every secret release was durably audited)`,
+    });
+  }
 
   for (const { label, path } of rootWrittenLogs(home)) {
     let text: string;

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -44,7 +44,10 @@ import { runContextChecks } from "./doctor-context.js";
 import { runCredentialsMigrationChecks } from "./doctor-credentials-migration.js";
 import { runSecretAccessChecks } from "./doctor-secret-access.js";
 import { runInlinedSecretChecks } from "./doctor-inlined-secrets.js";
-import { runApprovalAttributionChecks } from "./doctor-approval-attribution.js";
+import {
+  loadLiveAllowFromAccessFiles,
+  runApprovalAttributionChecks,
+} from "./doctor-approval-attribution.js";
 import { runAuditIntegrityChecks } from "./doctor-audit-integrity.js";
 import { runAgentSmokeChecks } from "./doctor-agent-smoke.js";
 import { runVaultBrokerDurabilityChecks } from "./doctor-vault-broker-durability.js";
@@ -2902,7 +2905,15 @@ export function registerDoctorCommand(program: Command): void {
           { title: "Audit integrity (WS10-F4)", results: runAuditIntegrityChecks() },
           {
             title: "Approval attribution (WS10-F5)",
-            results: runApprovalAttributionChecks(),
+            // liveAllowFrom: the operator tap-allowlist lives in the
+            // per-agent telegram/access.json files (the gateway's ground
+            // truth), not in switchroom.yaml — union them across the fleet.
+            results: await runApprovalAttributionChecks({
+              liveAllowFrom: loadLiveAllowFromAccessFiles(
+                Object.keys(config.agents ?? {}),
+                resolveAgentsDir(config),
+              ),
+            }),
           },
           { title: "Docker (Phase 1a)", results: runDockerSection(config) },
           { title: "Auth Broker", results: runAuthBrokerChecks(config) },

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -44,6 +44,7 @@ import { runContextChecks } from "./doctor-context.js";
 import { runCredentialsMigrationChecks } from "./doctor-credentials-migration.js";
 import { runSecretAccessChecks } from "./doctor-secret-access.js";
 import { runInlinedSecretChecks } from "./doctor-inlined-secrets.js";
+import { runApprovalAttributionChecks } from "./doctor-approval-attribution.js";
 import { runAuditIntegrityChecks } from "./doctor-audit-integrity.js";
 import { runAgentSmokeChecks } from "./doctor-agent-smoke.js";
 import { runVaultBrokerDurabilityChecks } from "./doctor-vault-broker-durability.js";
@@ -2899,6 +2900,10 @@ export function registerDoctorCommand(program: Command): void {
           { title: "Agents", results: checkAgents(config, configPath) },
           { title: "Credentials", results: runCredentialsMigrationChecks(config) },
           { title: "Audit integrity (WS10-F4)", results: runAuditIntegrityChecks() },
+          {
+            title: "Approval attribution (WS10-F5)",
+            results: runApprovalAttributionChecks(),
+          },
           { title: "Docker (Phase 1a)", results: runDockerSection(config) },
           { title: "Auth Broker", results: runAuthBrokerChecks(config) },
           { title: "Host control (hostd)", results: runHostdChecks(config) },

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -262,7 +262,18 @@ describe("VaultConfigSchema.broker", () => {
       approvalAuth: "passphrase",
       postureMintAgents: [],
       adminOnlyKeys: [],
+      auditFailClosed: false,
     });
+  });
+
+  it("defaults auditFailClosed to false (fail-open, backward compatible) and accepts true", () => {
+    // sec WS10-F3 / #1420 — the knob must default OFF so upgrading fleets
+    // keep the historical fail-open behaviour until the operator opts in.
+    expect(VaultConfigSchema.parse({}).broker.auditFailClosed).toBe(false);
+    expect(
+      VaultConfigSchema.parse({ broker: { auditFailClosed: true } }).broker
+        .auditFailClosed,
+    ).toBe(true);
   });
 
   it("defaults postureMintAgents to [] (no agent can self-mint via posture)", () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3289,6 +3289,21 @@ export const VaultConfigSchema = z.object({
           "union re-mint but never ADD one. Takes effect on broker + gateway " +
           "restart (broker has no ACL hot-reload)."
         ),
+      auditFailClosed: z
+        .boolean()
+        .default(false)
+        .describe(
+          "sec WS10-F3 (#1420) — fail-CLOSED on an audit-append failure. When " +
+          "`false` (default, backward-compatible) the broker fails OPEN: if a " +
+          "vault-audit.log append fails it logs to stderr, bumps the durable " +
+          "fail-open counter, and STILL releases the secret. When `true`, a " +
+          "failed audit append DENIES the secret release with " +
+          "`AUDIT_UNAVAILABLE` — no secret leaves the broker without a durable " +
+          "audit row. The env var `SWITCHROOM_VAULT_AUDIT_FAIL_CLOSED` " +
+          "(`1`/`true` or `0`/`false`) overrides this at runtime. Either way " +
+          "the fail-open counter is surfaced by `switchroom doctor`. Takes " +
+          "effect on broker restart."
+        ),
     })
     .default({})
     .superRefine((broker, ctx) => {

--- a/src/litellm/provision-apply-e2e.test.ts
+++ b/src/litellm/provision-apply-e2e.test.ts
@@ -102,7 +102,7 @@ describe("provisionLiteLLMKeys — real broker e2e (blocker-1 seam)", () => {
       _testConfig: makeConfig(tmpDir),
       // Isolated audit logger → never touches the production audit log
       // (CLAUDE.md vault-test hermeticity HARD RULE).
-      _testAuditLogger: { write: () => {} },
+      _testAuditLogger: { write: () => true, failOpenCount: () => 0 },
     });
     await broker.start(socketPath, undefined, vaultPath);
 

--- a/src/vault/broker/audit-log.test.ts
+++ b/src/vault/broker/audit-log.test.ts
@@ -18,6 +18,8 @@ import {
   createAuditLogger,
   callerFromPeer,
   defaultAuditLogPath,
+  failOpenStatePath,
+  readFailOpenState,
   type AuditEntry,
 } from "./audit-log.js";
 import { verifyAuditLog } from "../../util/audit-hashchain.js";
@@ -451,5 +453,69 @@ describe("defaultAuditLogPath", () => {
   it("returns a path under os.homedir()/.switchroom/", () => {
     const p = defaultAuditLogPath();
     expect(p).toBe(path.join(os.homedir(), ".switchroom", "vault-audit.log"));
+  });
+});
+
+// ─── fail-open counter (sec WS10-F3 / #1420) ──────────────────────────────────
+
+describe("createAuditLogger fail-open counter", () => {
+  const goodEntry: AuditEntry = {
+    ts: "2026-07-11T00:00:00.000Z",
+    op: "get",
+    key: "k/foo",
+    caller: "agent:test",
+    pid: 1,
+    result: "allowed",
+  };
+
+  it("write() returns true and does not bump the counter on success", () => {
+    const audit = createAuditLogger({ path: logPath });
+    expect(audit.write(goodEntry)).toBe(true);
+    expect(audit.failOpenCount()).toBe(0);
+    // No sidecar is created on the happy path.
+    expect(fs.existsSync(failOpenStatePath(logPath))).toBe(false);
+  });
+
+  it("write() returns false, bumps the counter, and persists a sidecar on append failure", () => {
+    // Make the log path a DIRECTORY so openSync("a") fails with EISDIR —
+    // a stand-in for a broken/read-only/full audit volume.
+    fs.mkdirSync(logPath);
+    const statePath = path.join(tmpDir, "vault-audit.failopen");
+    const audit = createAuditLogger({ path: logPath, statePath });
+
+    expect(audit.write(goodEntry)).toBe(false);
+    expect(audit.failOpenCount()).toBe(1);
+
+    // Second failure keeps incrementing.
+    expect(audit.write(goodEntry)).toBe(false);
+    expect(audit.failOpenCount()).toBe(2);
+
+    // The counter is durable: readable from the sidecar without the logger.
+    const state = readFailOpenState(statePath);
+    expect(state.failOpenCount).toBe(2);
+    expect(state.lastFailureTs).toBeDefined();
+    expect(state.lastError).toBeDefined();
+  });
+
+  it("seeds the in-memory counter from an existing sidecar (survives restart)", () => {
+    const statePath = path.join(tmpDir, "vault-audit.failopen");
+    fs.writeFileSync(statePath, JSON.stringify({ failOpenCount: 5 }));
+    fs.mkdirSync(logPath); // force the next append to fail too
+
+    const audit = createAuditLogger({ path: logPath, statePath });
+    // Starts at the persisted value, not 0.
+    expect(audit.failOpenCount()).toBe(5);
+    expect(audit.write(goodEntry)).toBe(false);
+    expect(audit.failOpenCount()).toBe(6);
+    expect(readFailOpenState(statePath).failOpenCount).toBe(6);
+  });
+
+  it("readFailOpenState returns a zeroed state for a missing/corrupt sidecar", () => {
+    expect(readFailOpenState(path.join(tmpDir, "nope.failopen"))).toEqual({
+      failOpenCount: 0,
+    });
+    const bad = path.join(tmpDir, "bad.failopen");
+    fs.writeFileSync(bad, "{not json");
+    expect(readFailOpenState(bad)).toEqual({ failOpenCount: 0 });
   });
 });

--- a/src/vault/broker/audit-log.ts
+++ b/src/vault/broker/audit-log.ts
@@ -100,7 +100,64 @@ export interface AuditEntry {
 }
 
 export interface AuditLogger {
-  write(entry: AuditEntry): void;
+  /**
+   * Append one audit row. Returns `true` iff the row was durably written
+   * to disk (open + write both succeeded). Returns `false` when the append
+   * failed — the caller (broker) uses this to decide fail-open vs
+   * fail-closed on a secret release (sec WS10-F3 / #1420). Every `false`
+   * also increments the durable fail-open counter (see failOpenCount).
+   */
+  write(entry: AuditEntry): boolean;
+  /**
+   * Current fail-open counter: the number of audit appends that FAILED
+   * over this log's lifetime (seeded from the on-disk sidecar at
+   * construction, incremented + persisted on every failed write). A
+   * non-zero value means at least one access was NOT durably audited —
+   * a WS10-F3 fail-open (or, in fail-closed mode, a denied release). The
+   * doctor audit-integrity probe surfaces this to the operator.
+   */
+  failOpenCount(): number;
+}
+
+/**
+ * Durable fail-open state persisted beside the audit log (sec WS10-F3 /
+ * #1420). Kept in a sidecar rather than inside the chained log so that a
+ * write failure (the very thing we're counting) doesn't recursively fail
+ * to record itself, and so `doctor` can read the count without replaying
+ * the whole hash chain.
+ */
+export interface FailOpenState {
+  /** Total failed audit appends over the log's lifetime. */
+  failOpenCount: number;
+  /** ISO-8601 timestamp of the most recent failure, if any. */
+  lastFailureTs?: string;
+  /** Truncated error message from the most recent failure, if any. */
+  lastError?: string;
+}
+
+/** Sidecar path for the fail-open counter: `<logPath>.failopen`. */
+export function failOpenStatePath(logPath: string): string {
+  return `${logPath}.failopen`;
+}
+
+/**
+ * Read the durable fail-open state sidecar. Returns a zeroed state when the
+ * sidecar is missing or unparseable (a corrupt/absent sidecar must never
+ * throw — doctor treats "can't read" as "no recorded failures").
+ */
+export function readFailOpenState(statePath: string): FailOpenState {
+  try {
+    const raw = fs.readFileSync(statePath, "utf8");
+    const parsed = JSON.parse(raw) as Partial<FailOpenState>;
+    const count = Number(parsed.failOpenCount);
+    return {
+      failOpenCount: Number.isFinite(count) && count > 0 ? count : 0,
+      lastFailureTs: typeof parsed.lastFailureTs === "string" ? parsed.lastFailureTs : undefined,
+      lastError: typeof parsed.lastError === "string" ? parsed.lastError : undefined,
+    };
+  } catch {
+    return { failOpenCount: 0 };
+  }
 }
 
 /** Options for createAuditLogger. */
@@ -124,6 +181,11 @@ export interface AuditLoggerOptions {
    * uses the default. Env override: `SWITCHROOM_VAULT_AUDIT_MAX_FILES`.
    */
   maxFiles?: number;
+  /**
+   * Absolute path to the durable fail-open counter sidecar (sec WS10-F3 /
+   * #1420). Defaults to `<path>.failopen`. Injectable for tests.
+   */
+  statePath?: string;
 }
 
 /**
@@ -343,8 +405,35 @@ export function createAuditLogger(opts: AuditLoggerOptions = {}): AuditLogger {
   // tamper-evidence continuity holds.
   const rotation = resolveRotation(opts);
 
+  // Durable fail-open counter (sec WS10-F3 / #1420). Seeded from the sidecar
+  // so the count survives broker restarts; incremented + persisted on every
+  // failed append. A failed sidecar persist is best-effort (never throws) —
+  // the in-memory count still advances so this process's status op is accurate.
+  const statePath = opts.statePath ?? failOpenStatePath(logPath);
+  let failOpen = readFailOpenState(statePath).failOpenCount;
+
+  const recordFailOpen = (err: Error): void => {
+    failOpen += 1;
+    const state: FailOpenState = {
+      failOpenCount: failOpen,
+      lastFailureTs: new Date().toISOString(),
+      lastError: String(err.message).slice(0, 300),
+    };
+    try {
+      // 0o600 — user-only, same posture as the audit log itself.
+      fs.writeFileSync(statePath, `${JSON.stringify(state)}\n`, { mode: 0o600 });
+    } catch (persistErr) {
+      process.stderr.write(
+        `[vault-audit] ERROR: could not persist fail-open counter ${statePath}: ${(persistErr as Error).message}\n`,
+      );
+    }
+  };
+
   return {
-    write(entry: AuditEntry): void {
+    failOpenCount(): number {
+      return failOpen;
+    },
+    write(entry: AuditEntry): boolean {
       // Size-based rotation check before the append. Best-effort:
       // stat failures leave the file untouched (grow rather than lose).
       if (rotation.maxBytes > 0) {
@@ -374,17 +463,23 @@ export function createAuditLogger(opts: AuditLoggerOptions = {}): AuditLogger {
         process.stderr.write(
           `[vault-audit] ERROR: could not open audit log ${logPath}: ${(err as Error).message}\n`,
         );
-        return;
+        // Fail-open: the row was NOT written. Record it durably so the
+        // operator (via doctor) can see releases went unaudited.
+        recordFailOpen(err as Error);
+        return false;
       }
 
+      let durable = false;
       try {
         fs.writeSync(fd, line);
         // Durable: advance the chain only now.
         chain = next;
+        durable = true;
       } catch (err) {
         process.stderr.write(
           `[vault-audit] ERROR: could not write to audit log ${logPath}: ${(err as Error).message}\n`,
         );
+        recordFailOpen(err as Error);
       } finally {
         try {
           fs.closeSync(fd);
@@ -394,6 +489,7 @@ export function createAuditLogger(opts: AuditLoggerOptions = {}): AuditLogger {
           );
         }
       }
+      return durable;
     },
   };
 }

--- a/src/vault/broker/protocol.ts
+++ b/src/vault/broker/protocol.ts
@@ -427,6 +427,10 @@ export const ErrorCode = z.enum([
   "UNKNOWN_KEY",
   "BAD_REQUEST",
   "INTERNAL",
+  // sec WS10-F3 / #1420: returned when the broker is in fail-closed mode and
+  // the audit append for a secret release failed — the secret is withheld
+  // rather than released without a durable audit row.
+  "AUDIT_UNAVAILABLE",
 ]);
 export type ErrorCode = z.infer<typeof ErrorCode>;
 

--- a/src/vault/broker/server-approvals.test.ts
+++ b/src/vault/broker/server-approvals.test.ts
@@ -71,7 +71,7 @@ describe("VaultBroker: approval-kernel ops", () => {
       _testSecrets: { foo: { kind: "string", value: "bar" } },
       _testConfig: makeMinimalConfig(),
       _testGrantsDb: grantsDb,
-      _testAuditLogger: { write: () => { /* swallow */ } },
+      _testAuditLogger: { write: () => true, failOpenCount: () => 0 },
     });
     await broker.start(socketPath, undefined, undefined);
   });

--- a/src/vault/broker/server-grants.test.ts
+++ b/src/vault/broker/server-grants.test.ts
@@ -122,7 +122,7 @@ describe("VaultBroker: grant operations (mint_grant / list_grants / revoke_grant
     grantsDb = makeInMemoryGrantsDb();
     auditEntries = [];
 
-    const testAuditLogger = { write: (e: AuditEntry) => { auditEntries.push(e); } };
+    const testAuditLogger = { write: (e: AuditEntry) => { auditEntries.push(e); return true; }, failOpenCount: () => 0 };
 
     broker = new VaultBroker({
       _testSecrets: cloneSecrets(),
@@ -310,7 +310,7 @@ describe("VaultBroker: token-based get access (issue #225)", () => {
     grantsDb = makeInMemoryGrantsDb();
     auditEntries = [];
 
-    const testAuditLogger = { write: (e: AuditEntry) => { auditEntries.push(e); } };
+    const testAuditLogger = { write: (e: AuditEntry) => { auditEntries.push(e); return true; }, failOpenCount: () => 0 };
 
     broker = new VaultBroker({
       _testSecrets: cloneSecrets(),
@@ -436,6 +436,98 @@ describe("VaultBroker: token-based get access (issue #225)", () => {
     if (!afterResp.ok) {
       expect(afterResp.code).toBe("DENIED");
       expect(afterResp.msg).toContain("grant-revoked");
+    }
+  });
+});
+
+// ─── sec WS10-F3 / #1420: audit fail-closed mode ──────────────────────────────
+//
+// OUTCOME assertions: when the audit append for a secret release FAILS, the
+// broker must (a) still release the secret in the default fail-OPEN mode, and
+// (b) DENY the release with AUDIT_UNAVAILABLE when fail-CLOSED is enabled — so a
+// blinded audit trail can't be used to exfiltrate a secret silently.
+describe("VaultBroker: audit fail-closed release gate (sec WS10-F3 / #1420)", () => {
+  let broker: VaultBroker;
+  let socketPath: string;
+  let tmpDir: string;
+  let grantsDb: Database;
+  let prevNonLinuxFlag: string | undefined;
+  let prevFailClosedEnv: string | undefined;
+
+  // A logger whose append ALWAYS fails (write → false), simulating a broken /
+  // read-only / full audit volume. Bumps a local counter so the test can assert
+  // the release path actually consulted the return value.
+  let failedWrites: number;
+  const failingLogger = {
+    write: (_e: AuditEntry) => {
+      failedWrites += 1;
+      return false;
+    },
+    failOpenCount: () => failedWrites,
+  };
+
+  async function startBroker(failClosed: boolean): Promise<void> {
+    if (failClosed) {
+      process.env.SWITCHROOM_VAULT_AUDIT_FAIL_CLOSED = "1";
+    } else {
+      delete process.env.SWITCHROOM_VAULT_AUDIT_FAIL_CLOSED;
+    }
+    broker = new VaultBroker({
+      _testSecrets: cloneSecrets(),
+      _testConfig: makeMinimalConfig(),
+      _testGrantsDb: grantsDb,
+      _testAuditLogger: failingLogger,
+    });
+    await broker.start(socketPath, undefined, undefined);
+  }
+
+  beforeEach(() => {
+    prevNonLinuxFlag = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = "1";
+    prevFailClosedEnv = process.env.SWITCHROOM_VAULT_AUDIT_FAIL_CLOSED;
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-failclosed-test-"));
+    socketPath = path.join(tmpDir, "test.sock");
+    grantsDb = makeInMemoryGrantsDb();
+    failedWrites = 0;
+  });
+
+  afterEach(() => {
+    try { broker.stop(); } catch { /* not started */ }
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    if (prevNonLinuxFlag === undefined) delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    else process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prevNonLinuxFlag;
+    if (prevFailClosedEnv === undefined) delete process.env.SWITCHROOM_VAULT_AUDIT_FAIL_CLOSED;
+    else process.env.SWITCHROOM_VAULT_AUDIT_FAIL_CLOSED = prevFailClosedEnv;
+  });
+
+  it("fail-OPEN (default): failed audit append still releases the secret", async () => {
+    await startBroker(false);
+    const { token } = await mintGrant(grantsDb, "myagent", ["foo"], null);
+
+    const resp = await rpc(socketPath, { v: 1, op: "get", key: "foo", token });
+
+    // The audit write failed…
+    expect(failedWrites).toBeGreaterThan(0);
+    // …but the secret was released anyway (historical fail-open behaviour).
+    expect(resp.ok).toBe(true);
+    if (resp.ok && "entry" in resp) {
+      expect(resp.entry).toEqual({ kind: "string", value: "bar-value" });
+    }
+  });
+
+  it("fail-CLOSED: failed audit append DENIES the release with AUDIT_UNAVAILABLE", async () => {
+    await startBroker(true);
+    const { token } = await mintGrant(grantsDb, "myagent", ["foo"], null);
+
+    const resp = await rpc(socketPath, { v: 1, op: "get", key: "foo", token });
+
+    // The audit write failed AND the secret was withheld.
+    expect(failedWrites).toBeGreaterThan(0);
+    expect(resp.ok).toBe(false);
+    if (!resp.ok) {
+      expect(resp.code).toBe("AUDIT_UNAVAILABLE");
+      // The response must NOT leak the secret value.
+      expect(JSON.stringify(resp)).not.toContain("bar-value");
     }
   });
 });

--- a/src/vault/broker/server-mint-grant-passphrase-attest.test.ts
+++ b/src/vault/broker/server-mint-grant-passphrase-attest.test.ts
@@ -135,7 +135,9 @@ describe("VaultBroker: mint_grant passphrase attestation (#1012 Phase 2)", () =>
     const testAuditLogger: AuditLogger = {
       write: (e: AuditEntry) => {
         auditEntries.push(e);
+        return true;
       },
+      failOpenCount: () => 0,
     };
 
     broker = new VaultBroker({

--- a/src/vault/broker/server-passphrase-attest.test.ts
+++ b/src/vault/broker/server-passphrase-attest.test.ts
@@ -80,7 +80,7 @@ describe("VaultBroker: PUT with operator-passphrase attestation (#969 P1a)", () 
 
     const grantsDb = makeInMemoryGrantsDb();
     auditEntries = [];
-    const testAuditLogger = { write: (e: AuditEntry) => { auditEntries.push(e); } };
+    const testAuditLogger = { write: (e: AuditEntry) => { auditEntries.push(e); return true; }, failOpenCount: () => 0 };
 
     broker = new VaultBroker({
       _testConfig: makeMinimalConfig(),

--- a/src/vault/broker/server-token-fallthrough.test.ts
+++ b/src/vault/broker/server-token-fallthrough.test.ts
@@ -100,7 +100,7 @@ describe("VaultBroker: read-path unusable-token fall-through", () => {
       _testSecrets: cloneSecrets(),
       _testConfig: makeMinimalConfig(),
       _testGrantsDb: grantsDb,
-      _testAuditLogger: { write: (e: AuditEntry) => { auditEntries.push(e); } },
+      _testAuditLogger: { write: (e: AuditEntry) => { auditEntries.push(e); return true; }, failOpenCount: () => 0 },
     });
     await broker.start(socketPath, undefined, undefined);
   });

--- a/src/vault/broker/server-write-grants.test.ts
+++ b/src/vault/broker/server-write-grants.test.ts
@@ -118,7 +118,7 @@ describe("VaultBroker: PUT with write-grant (#969 P1b)", () => {
 
     grantsDb = makeInMemoryGrantsDb();
     auditEntries = [];
-    const testAuditLogger = { write: (e: AuditEntry) => { auditEntries.push(e); } };
+    const testAuditLogger = { write: (e: AuditEntry) => { auditEntries.push(e); return true; }, failOpenCount: () => 0 };
 
     broker = new VaultBroker({
       _testConfig: makeMinimalConfig(),

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -223,6 +223,58 @@ export class VaultBroker {
   }
 
   /**
+   * sec WS10-F3 / #1420 — whether the broker fails CLOSED on an audit-append
+   * failure (deny the secret release) rather than the historical fail-OPEN
+   * (release anyway, only stderr-warn). Default is fail-open for backward
+   * compatibility: a broken audit volume must not brick a running fleet
+   * unless the operator has explicitly opted into the stricter posture.
+   *
+   * Resolution order (first that is set wins):
+   *   1. env `SWITCHROOM_VAULT_AUDIT_FAIL_CLOSED` ("1"/"true" → closed,
+   *      "0"/"false" → open) — mirrors the SWITCHROOM_VAULT_AUDIT_* env
+   *      override pattern used for rotation, lets an operator flip the mode
+   *      without a config edit.
+   *   2. config `vault.broker.auditFailClosed`.
+   *   3. default false (fail-open).
+   */
+  private auditFailClosedEnabled(): boolean {
+    const env = process.env.SWITCHROOM_VAULT_AUDIT_FAIL_CLOSED;
+    if (env !== undefined && env !== "") {
+      return env === "1" || env.toLowerCase() === "true";
+    }
+    return this.config?.vault?.broker?.auditFailClosed === true;
+  }
+
+  /**
+   * sec WS10-F3 / #1420 — write the terminal "allowed" audit row for a secret
+   * release and enforce the fail-closed decision. Returns `true` if the caller
+   * may proceed to hand back the secret; when it returns `false` it has ALREADY
+   * written the DENIED response onto the socket (fail-closed: the audit append
+   * failed and the operator opted into denying unaudited releases). In fail-open
+   * mode it always returns `true` (the row-write failure is still counted +
+   * stderr-warned inside the logger).
+   */
+  private auditedReleaseOk(
+    socket: net.Socket,
+    writeAudit: (entry: import("./audit-log.js").AuditEntry) => boolean,
+    entry: import("./audit-log.js").AuditEntry,
+  ): boolean {
+    const durable = writeAudit(entry);
+    if (!durable && this.auditFailClosedEnabled()) {
+      socket.write(
+        encodeResponse(
+          errorResponse(
+            "AUDIT_UNAVAILABLE",
+            "secret release denied: audit append failed and broker is in fail-closed mode (vault.broker.auditFailClosed)",
+          ),
+        ),
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /**
    * Start the broker — bind both sockets, write PID file, notify systemd.
    *
    * @param socketPath   Path for the data socket. Created mode 0600.
@@ -923,8 +975,8 @@ export class VaultBroker {
     // fields under JSON.stringify, so this is purely additive on the wire.
     const writeAudit = (
       entry: import("./audit-log.js").AuditEntry,
-    ): void => {
-      this.auditLogger.write({
+    ): boolean => {
+      return this.auditLogger.write({
         ...entry,
         peer_uid: entry.peer_uid ?? auditPeerUid,
         agent_name: entry.agent_name ?? auditAgentName,
@@ -1246,17 +1298,22 @@ export class VaultBroker {
             );
             return;
           }
-          this.auditLogger.write({
-            ts: new Date().toISOString(),
-            op: "get",
-            key: req.key,
-            caller: auditCaller,
-            pid: auditPid,
-            cgroup: auditCgroup,
-            result: "allowed",
-            method: "grant",
-            grant_id: grantId,
-          });
+          // sec WS10-F3 / #1420: fail-closed guard on the release row.
+          if (
+            !this.auditedReleaseOk(socket, writeAudit, {
+              ts: new Date().toISOString(),
+              op: "get",
+              key: req.key,
+              caller: auditCaller,
+              pid: auditPid,
+              cgroup: auditCgroup,
+              result: "allowed",
+              method: "grant",
+              grant_id: grantId,
+            })
+          ) {
+            return;
+          }
           socket.write(encodeResponse(entryResponse(entry)));
           return;
         } else if (grantResult.reason === "grant-revoked") {
@@ -1428,16 +1485,21 @@ export class VaultBroker {
         return;
       }
 
-      // Successful get — log only the key name, NEVER the value
-      this.auditLogger.write({
-        ts: new Date().toISOString(),
-        op: "get",
-        key: req.key,
-        caller: auditCaller,
-        pid: auditPid,
-        cgroup: auditCgroup,
-        result: "allowed",
-      });
+      // Successful get — log only the key name, NEVER the value.
+      // sec WS10-F3 / #1420: fail-closed guard on the release row.
+      if (
+        !this.auditedReleaseOk(socket, writeAudit, {
+          ts: new Date().toISOString(),
+          op: "get",
+          key: req.key,
+          caller: auditCaller,
+          pid: auditPid,
+          cgroup: auditCgroup,
+          result: "allowed",
+        })
+      ) {
+        return;
+      }
       socket.write(encodeResponse(entryResponse(entry)));
       return;
     }


### PR DESCRIPTION
## Summary — WS10-F3 / F5 remainder of #1420 ("PR-B")

Follows PR #1436 (F6 attribution + F4 doctor detection). Delivers the two remaining higher-risk items.

### F3 — vault audit fail-closed mode (core deliverable)
Historically `src/vault/broker/audit-log.ts` failed **OPEN**: a failed audit open/write logged to stderr and the broker **still released the secret**. This adds an opt-in fail-closed posture:

- `AuditLogger.write()` now returns whether the row was **durably written**, and the logger maintains a durable **fail-open counter** persisted to a `<log>.failopen` sidecar (`failOpenStatePath` / `readFailOpenState`), seeded across broker restarts. The sidecar is separate from the chained log so a write failure can't recursively fail to record itself, and `doctor` can read it without replaying the chain.
- The broker denies a secret release with a new **`AUDIT_UNAVAILABLE`** error when the terminal release-row append fails **and** fail-closed is enabled — enforced at **both** the token-grant and ACL `get` release points (`server.ts` `auditedReleaseOk`). Default remains **fail-open** for backward compatibility.
- Config knob **`vault.broker.auditFailClosed`** (default `false`) plus env override **`SWITCHROOM_VAULT_AUDIT_FAIL_CLOSED`** (mirrors the established `SWITCHROOM_VAULT_AUDIT_*` override pattern).
- `doctor-audit-integrity` gains a check that **warns on a non-zero fail-open counter** (durable, operator-visible — not just stderr).

### F5 part 1 — proactive approval-attribution detection
New DI-testable module `src/cli/doctor-approval-attribution.ts` flags active `allow*` grants whose `granted_by_user_id` is **not** a member of the approver set that authorized them (a gateway-gate bypass / forged row → `fail`), plus a softer `warn` when the granter has since left the live `access.allowFrom`. Wired into `doctor`.

**Loader (post-review, `e5959ad9`):** the default decisions loader reads the **host** `~/.switchroom/vault-grants.db` directly via `bun:sqlite` (the built CLI runs under bun — `scripts/build.mjs:187` rewrites the shebang; the broker container merely bind-mounts that same host file to `/root/.switchroom/vault-grants.db`, `src/agents/compose.ts:1514`), with a `docker exec switchroom-vault-broker sqlite3 /root/.switchroom/vault-grants.db` fallback. The fallback assumes the default compose project prefix; a custom prefix degrades it to `skip` (documented in the module comment). Any failure on both paths → a single `skip`, never a false `fail`.

**Live allowlist (post-review, `e5959ad9`):** the operator tap-allowlist lives in the per-agent `telegram/access.json` files (the gateway's `loadAccess` ground truth), not switchroom.yaml — new `loadLiveAllowFromAccessFiles` unions `allowFrom` across the fleet's access.json files and `doctor.ts` passes it as `liveAllowFrom`, activating the stale-granter warn in production. Returns `undefined` when no access.json is readable so a fresh install doesn't mark every granter stale.

**Why detection in doctor rather than a kernel-emitted operator-event card** (the brief's alternative): the approval **kernel is a separate daemon with zero telegram reach** — `grep -n "telegram\|grammy\|sendMessage" src/vault/approvals/kernel*.ts` returns nothing; the operator-event pipeline lives entirely in the telegram-plugin gateway. Moreover the **gateway already hard-gates every approval tap** on `access.allowFrom.includes(senderId)` before recording a decision (`telegram-plugin/gateway/callback-query-handlers.ts:498,856,949,1109,…`). So a decision row whose granter is off the allowlist did **not** come through that gate — it is after-the-fact forensic evidence of a bypass, exactly what `doctor` exists to surface; a live card would be redundant with the existing gate. Full rationale in the module header.

### F5 part 2 — hook-set divergence vs #1416 baseline: NOT implemented (moot)
Verified against source. Issue #1416 (CLOSED 2026-05-21) moved the load-bearing PreToolUse safety hooks into an **image-baked, read-only** `--plugin-dir /opt/switchroom/security-plugin`:
- `docker/Dockerfile.agent:269-273` COPY the plugin manifest + `hooks.json` + the `*.mjs` into the read-only image path.
- `profiles/_base/start.sh.hbs:1307-1315` add `--plugin-dir "{{securityPluginDir}}"` unconditionally to all 4 `claude` exec variants; `securityPluginDir` = `DOCKER_SECURITY_PLUGIN_PATH` (image path, never `agentDir`) — threaded in `src/agents/scaffold.ts:2966,5829`.
- Plugin-dir hooks **union** with settings.json hooks and cannot be suppressed via settings.json (the Claude Code semantics #1416 verified).

An agent editing its writable `settings.json` therefore **cannot strip** the safety hooks — there is no strippable baseline left to diverge from. Divergence detection would add code for an attack the architecture already forecloses, so per the brief it is deliberately not implemented.

## Tests (assert outcomes)
- `audit-log.test.ts`: failed append → `write()===false`, counter increments, sidecar persisted + seeds across restart; happy path writes no sidecar.
- `server-grants.test.ts`: **fail-open** (default) releases the secret despite a failing audit append; **fail-closed** DENIES with `AUDIT_UNAVAILABLE` and leaks no value.
- `schema.test.ts`: `auditFailClosed` defaults `false`, accepts `true`.
- `doctor-audit-integrity.test.ts`: non-zero counter → warn; zero → ok.
- `doctor-approval-attribution.test.ts`: granter-not-in-own-set → fail; revoked/deny ignored; stale-live-allowlist → warn; unreadable DB → skip; `liveAllowFrom` plumb-through produces the stale warn (regression guard for the dead-code wiring); access-file union incl. numeric coercion + broken/missing files, and undefined when none readable.

Scoped `vitest` + `bun test` broker/doctor/config suites and `npm run lint` green locally. **Do not merge — coordinator reviews first.**

Refs #1420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
