### PR TITLE
feat(hostd): operator-attest 2nd factor on mutating verbs (#1841)

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -845,7 +845,28 @@ describe("HostdConfigSchema (admin-agent-config-edit RFC §3 / §4)", () => {
     expect(result.hostd).toEqual({
       config_edit_enabled: false,
       config_edit_rate_per_hour: 3,
+      // #1841 — operator-attest 2nd factor: off by default, RFC §5.4
+      // fleet-mutation verb set as the default required list.
+      operator_attest_enabled: false,
+      operator_attest_required_verbs: ["update_apply", "apply", "rollout"],
     });
+  });
+
+  it("accepts an explicit operator-attest opt-in with a custom verb list (#1841)", () => {
+    const result = SwitchroomConfigSchema.parse({
+      switchroom: { version: 1 },
+      telegram: { bot_token: "x", forum_chat_id: "1" },
+      hostd: {
+        operator_attest_enabled: true,
+        operator_attest_required_verbs: ["update_apply", "agent_exec"],
+      },
+      agents: {},
+    });
+    expect(result.hostd.operator_attest_enabled).toBe(true);
+    expect(result.hostd.operator_attest_required_verbs).toEqual([
+      "update_apply",
+      "agent_exec",
+    ]);
   });
 
   it("accepts an explicit opt-in with a tuned rate", () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3546,6 +3546,35 @@ export const HostdConfigSchema = z.object({
       "`retry_after` fix) instead of posting another operator approval " +
       "card — so a looping agent is throttled rather than spamming the chat.",
     ),
+  // ── Operator-attest 2nd factor (#1841, RFC host-control-daemon.md §5.4) ──
+  operator_attest_enabled: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Opt-in toggle for the operator-passphrase 2nd factor on hostd's " +
+      "mutating verbs (#1841, RFC host-control-daemon.md §5.4). Default " +
+      "false — attestation is ACCEPTED-and-audited whenever present, but " +
+      "no verb REQUIRES it (behaviour is byte-identical to today, so " +
+      "existing fleets and the Telegram approval-card flow are unchanged). " +
+      "When true, the verbs in `operator_attest_required_verbs` demand a " +
+      "valid operator-passphrase attestation IN ADDITION to admin: hostd " +
+      "forwards the passphrase to the vault broker over its own admin-client " +
+      "connection (`/run/switchroom/broker/hostd/sock`) and treats a broker " +
+      "DENIED as a gate failure. hostd never holds the passphrase. Leave " +
+      "this off until BOTH the gateway passphrase-forward and the " +
+      "cross-compose broker socket are deployed, or gated verbs will fail.",
+    ),
+  operator_attest_required_verbs: z
+    .array(z.string().min(1))
+    .default(["update_apply", "apply", "rollout"])
+    .describe(
+      "Which mutating hostd verbs REQUIRE a valid operator-passphrase " +
+      "attestation when `operator_attest_enabled` is true (#1841). Default " +
+      "is the RFC §5.4 fleet-mutation set (`update_apply`, `apply`, " +
+      "`rollout`). Verbs NOT in this list still accept-and-audit an " +
+      "attestation when one is supplied, but never require it. Ignored " +
+      "entirely when `operator_attest_enabled` is false.",
+    ),
 });
 
 // Cheap-cron operator config — reference/rfcs/cheap-cron-sessions.md §6.1.

--- a/src/host-control/audit-reader.ts
+++ b/src/host-control/audit-reader.ts
@@ -29,6 +29,11 @@ export interface AuditEntry {
    *  hostd's spawn-completion handler. Absent on the synchronous
    *  request-path rows. */
   phase?: string;
+  /** #1841 — attestation attribution. `"passphrase-attest"` on rows where
+   *  an operator-passphrase attestation was verified (or a required
+   *  attestation was missing/rejected). Mirrors the vault broker's
+   *  `method` audit field. Never carries the passphrase itself. */
+  method?: string;
   stdout_tail?: string;
   stderr_tail?: string;
   // ─── Update-flow enrichment (PR B) ─────────────────────────────────
@@ -115,6 +120,7 @@ export function parseAuditLine(line: string): AuditEntry | null {
   };
   if (typeof o.error === "string") entry.error = o.error;
   if (typeof o.phase === "string") entry.phase = o.phase;
+  if (typeof o.method === "string") entry.method = o.method;
   if (typeof o.stdout_tail === "string") entry.stdout_tail = o.stdout_tail;
   if (typeof o.stderr_tail === "string") entry.stderr_tail = o.stderr_tail;
   if (typeof o.channel === "string") entry.channel = o.channel;

--- a/src/host-control/main.ts
+++ b/src/host-control/main.ts
@@ -212,6 +212,17 @@ async function main(): Promise<void> {
               ...(config.hostd.config_edit_enabled !== undefined
                 ? { config_edit_enabled: config.hostd.config_edit_enabled }
                 : {}),
+              // #1841 — operator-attest 2nd factor. Pass through so the
+              // daemon's checkOperatorAttest sees the operator's opt-in.
+              ...(config.hostd.operator_attest_enabled !== undefined
+                ? { operator_attest_enabled: config.hostd.operator_attest_enabled }
+                : {}),
+              ...(config.hostd.operator_attest_required_verbs !== undefined
+                ? {
+                    operator_attest_required_verbs:
+                      config.hostd.operator_attest_required_verbs,
+                  }
+                : {}),
             },
           }
         : {}),

--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -61,6 +61,25 @@ const RequestEnvelope = {
   /** Optional dedup key — daemon swallows duplicate requests within
    *  IDEMPOTENCY_WINDOW_MS. Defaults to `request_id` when omitted. */
   idempotency_key: z.string().min(1).max(128).optional(),
+  /**
+   * Optional operator-passphrase attestation (#1841, RFC
+   * host-control-daemon.md §5.4). Second factor on the mutating verbs:
+   * the gateway caches the operator passphrase after `/vault unlock`
+   * and plaintext-forwards it here when an admin agent invokes a
+   * privileged verb — the SAME plaintext-forward pattern the vault
+   * broker already uses for `vault_request_save` (broker
+   * `server.ts` PUT/list_grants passphrase path). hostd itself NEVER
+   * holds the vault passphrase: it forwards this value over its own
+   * admin-client connection to the broker and treats a broker `DENIED`
+   * as a gate failure (see `AttestVerifier` in `server.ts`).
+   *
+   * Present on the envelope so it applies uniformly to every verb;
+   * read-only verbs ignore it. `checkGate` only CONSUMES it for verbs
+   * the operator has opted into requiring attestation for
+   * (`hostd.operator_attest_*`), and it is NEVER persisted to the audit
+   * log (only the derived `method: "passphrase-attest"` tag is).
+   */
+  operator_passphrase: z.string().min(1).max(1024).optional(),
 };
 
 export const AgentRestartRequestSchema = z.object({

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -95,6 +95,7 @@ import {
   type DispatchResult,
 } from "../scheduler/dispatch.js";
 import { readRecentFires } from "../agent-scheduler/replay.js";
+import { rpcRaw as brokerRpcRaw } from "../vault/broker/client.js";
 
 /** Subset of switchroom.yaml the daemon reads. */
 export interface ServerConfig {
@@ -109,8 +110,51 @@ export interface ServerConfig {
   hostd?: {
     config_edit_enabled?: boolean;
     config_edit_rate_per_hour?: number;
+    /** #1841 — master switch for the operator-passphrase 2nd factor.
+     *  Missing/false ⇒ feature inert (attestation accepted-and-audited
+     *  when present, never required — byte-identical to pre-#1841). */
+    operator_attest_enabled?: boolean;
+    /** #1841 — verbs that REQUIRE attestation when the switch is on.
+     *  Missing ⇒ RFC §5.4 default set (update_apply / apply / rollout). */
+    operator_attest_required_verbs?: string[];
   };
 }
+
+/**
+ * #1841 — operator-passphrase attestation verifier. hostd NEVER holds the
+ * vault passphrase; it forwards the plaintext to the vault broker over its
+ * own admin-client connection and treats a broker DENIED as a gate failure.
+ * Abstracted behind this interface so the gate logic is unit-testable with a
+ * stub, and the real transport (broker `list_grants` with `passphrase`, the
+ * read-only op that already implements the passphrase plaintext-forward per
+ * #1051) is injected in production.
+ */
+export interface AttestVerifier {
+  /**
+   * Verify a forwarded operator passphrase against the broker's currently
+   * unlocked passphrase. Returns `{ ok: true }` on match, `{ ok: false }`
+   * with a human reason on mismatch, broker-locked, or broker-unreachable
+   * (all fail-closed — a verb that requires attestation must not pass when
+   * the verifier cannot positively confirm the passphrase).
+   */
+  verify(passphrase: string): Promise<{ ok: true } | { ok: false; reason: string }>;
+}
+
+/** RFC §5.4 — the broker socket hostd uses for the attestation forward.
+ *  Bound cross-compose (see `src/cli/hostd.ts` + `src/agents/compose.ts`). */
+export const HOSTD_BROKER_SOCKET_PATH = "/run/switchroom/broker/hostd/sock";
+
+/** RFC §5.4 default fleet-mutation verb set that requires operator-attest
+ *  when the feature is enabled and no explicit override is configured. */
+export const DEFAULT_OPERATOR_ATTEST_VERBS: readonly string[] = [
+  "update_apply",
+  "apply",
+  "rollout",
+];
+
+/** Audit `method` tag for attested / attestation-denied rows (#1841),
+ *  mirroring the vault broker's `method: "passphrase"` attribution. */
+export const ATTEST_AUDIT_METHOD = "passphrase-attest";
 
 export interface ServerOptions {
   /** Operator HOME — daemon binds sockets under `<homeDir>/.switchroom/hostd/<agent>/sock`. */
@@ -205,6 +249,15 @@ export interface ServerOptions {
   runReconcile?: (args: {
     requestId: string;
   }) => Promise<{ exit_code: number; stdout: string; stderr: string }>;
+  /**
+   * #1841 — operator-passphrase attestation verifier. Default: a
+   * broker-backed verifier that forwards the passphrase to the vault
+   * broker at `HOSTD_BROKER_SOCKET_PATH`. Tests inject a stub. Only
+   * consulted when `config.hostd.operator_attest_enabled` is true AND the
+   * verb is in the required set — so leaving it unset never changes
+   * behaviour for the default (feature-off) posture.
+   */
+  attestVerifier?: AttestVerifier;
 }
 
 /**
@@ -940,6 +993,21 @@ export class HostdServer {
       return;
     }
 
+    // ── #1841 operator-attest 2nd factor (RFC §5.4) ──────────────────
+    // Runs AFTER the admin/allowlist gate: attestation is an additional
+    // factor, never a replacement. Inert unless the operator opted in
+    // (`hostd.operator_attest_enabled`), so the default posture — and the
+    // Telegram approval-card flow (#1427, layer 1) — is unchanged.
+    const attest = await this.checkOperatorAttest(req, caller);
+    if (attest.denied !== null) {
+      const resp = deniedResponse(req.request_id, attest.denied);
+      await this.writeAudit({ caller, req, resp, method: attest.method });
+      socket.write(encodeResponse(resp));
+      socket.end();
+      return;
+    }
+    const attestMethod = attest.method;
+
     const started = Date.now();
     let resp: HostdResponse;
     try {
@@ -1020,9 +1088,127 @@ export class HostdServer {
       // string-matching decoders.
       resp = { ...resp, error: `hostd dispatch failed: ${msg}` };
     }
-    await this.writeAudit({ caller, req, resp });
+    await this.writeAudit({ caller, req, resp, method: attestMethod });
     socket.write(encodeResponse(resp));
     socket.end();
+  }
+
+  /**
+   * #1841 — operator-passphrase attestation (RFC §5.4, layer 3).
+   *
+   * Called AFTER `checkGate` (the admin/allowlist floor) passes. Returns
+   * `{ denied: null }` to allow, or `{ denied: <reason> }` to reject. The
+   * optional `method` is threaded onto the audit row for attribution.
+   *
+   * Posture:
+   *   - Feature OFF (`operator_attest_enabled` !== true) ⇒ completely inert:
+   *     the `operator_passphrase` field is IGNORED (present or absent), so
+   *     behaviour is byte-identical to pre-#1841. Guarantees existing fleets
+   *     and the Telegram approval-card flow are unaffected.
+   *   - Operator socket caller ⇒ always allowed (already the fully-trusted
+   *     first factor; the 2nd factor is for agent callers).
+   *   - Feature ON + verb in `operator_attest_required_verbs` ⇒ a valid
+   *     operator-passphrase attestation is REQUIRED (missing ⇒ denied;
+   *     wrong/broker-unreachable ⇒ denied, fail-closed).
+   *   - Feature ON + verb NOT required ⇒ accept-and-audit: a supplied
+   *     attestation is verified (wrong ⇒ denied, fail-closed) and tagged;
+   *     an absent one is allowed unchanged.
+   *
+   * hostd never holds the passphrase — verification is delegated to the
+   * vault broker via `attestVerifier()`.
+   */
+  private async checkOperatorAttest(
+    req: HostdRequest,
+    caller: SocketIdentity,
+  ): Promise<{ denied: string | null; method?: string }> {
+    const hostdCfg = this.opts.config.hostd;
+    if (hostdCfg?.operator_attest_enabled !== true) {
+      // Feature inert — ignore any forwarded passphrase entirely.
+      return { denied: null };
+    }
+    // Operator socket already carries the strongest identity; no 2nd factor.
+    if (caller.kind === "operator") return { denied: null };
+
+    const requiredVerbs =
+      hostdCfg.operator_attest_required_verbs ?? DEFAULT_OPERATOR_ATTEST_VERBS;
+    const required = requiredVerbs.includes(req.op);
+    const passphrase = req.operator_passphrase;
+
+    if (!required) {
+      // Accept-and-audit: verify only when one is actually supplied.
+      if (passphrase === undefined) return { denied: null };
+      const v = await this.attestVerifier().verify(passphrase);
+      return v.ok
+        ? { denied: null, method: ATTEST_AUDIT_METHOD }
+        : {
+            denied: `${req.op} operator-attest failed: ${v.reason}`,
+            method: ATTEST_AUDIT_METHOD,
+          };
+    }
+
+    // Required verb — attestation is mandatory.
+    if (passphrase === undefined) {
+      return {
+        denied:
+          `${req.op} requires operator-passphrase attestation ` +
+          `(hostd.operator_attest_enabled is on and ${req.op} is in ` +
+          `operator_attest_required_verbs)`,
+        method: ATTEST_AUDIT_METHOD,
+      };
+    }
+    const v = await this.attestVerifier().verify(passphrase);
+    return v.ok
+      ? { denied: null, method: ATTEST_AUDIT_METHOD }
+      : {
+          denied: `${req.op} operator-attest failed: ${v.reason}`,
+          method: ATTEST_AUDIT_METHOD,
+        };
+  }
+
+  /** Lazily resolve the attestation verifier: the injected test seam, or
+   *  the default broker-backed forwarder. */
+  private attestVerifier(): AttestVerifier {
+    if (this.opts.attestVerifier) return this.opts.attestVerifier;
+    if (!this._defaultAttestVerifier) {
+      this._defaultAttestVerifier = {
+        verify: (passphrase: string) =>
+          this.brokerAttestVerify(passphrase),
+      };
+    }
+    return this._defaultAttestVerifier;
+  }
+  private _defaultAttestVerifier?: AttestVerifier;
+
+  /**
+   * Default verifier — forwards the passphrase to the vault broker over
+   * hostd's admin-client connection at `HOSTD_BROKER_SOCKET_PATH` using the
+   * read-only `list_grants` op (which already implements the
+   * passphrase-plaintext-forward attestation per #1051). A broker `ok`
+   * response ⇒ the passphrase matched the broker's unlocked passphrase; an
+   * error response (e.g. DENIED on mismatch, or broker locked) or an
+   * unreachable socket ⇒ fail-closed. hostd never persists the passphrase.
+   */
+  private async brokerAttestVerify(
+    passphrase: string,
+  ): Promise<{ ok: true } | { ok: false; reason: string }> {
+    const res = await brokerRpcRaw(
+      {
+        v: 1,
+        op: "list_grants",
+        agent: "hostd",
+        passphrase,
+      },
+      { vaultBrokerSocket: HOSTD_BROKER_SOCKET_PATH, timeoutMs: 5_000 },
+    );
+    if (res.kind === "unreachable") {
+      return { ok: false, reason: `broker unreachable: ${res.msg}` };
+    }
+    const resp = res.resp as { ok?: boolean; code?: string; msg?: string };
+    if (resp.ok === true) return { ok: true };
+    return {
+      ok: false,
+      reason: `broker denied attestation (${resp.code ?? "DENIED"})`,
+    };
   }
 
   /**
@@ -3346,10 +3532,16 @@ export class HostdServer {
     caller: SocketIdentity;
     req: HostdRequest;
     resp: HostdResponse;
+    /** #1841 — attestation attribution. `"passphrase-attest"` on rows
+     *  where an operator-passphrase attestation was verified (or a
+     *  required attestation was missing/rejected). NEVER carries the
+     *  passphrase itself — only the method tag. */
+    method?: string;
   }): Promise<void> {
     await this.appendAuditRow({
       ts: new Date().toISOString(),
       op: args.req.op,
+      ...(args.method ? { method: args.method } : {}),
       caller:
         args.caller.kind === "agent"
           ? { kind: "agent", name: args.caller.name }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -463,6 +463,7 @@ import {
   pollHostdStatus,
   hostdGetStatusOnce,
   warnLegacySpawnIfHostdDisabled,
+  withOperatorAttestation,
   _resetHostdEnabledCache,
 } from './hostd-dispatch.js'
 import { formatUpdateStatusLine } from './update-status-line.js'
@@ -21447,15 +21448,25 @@ bot.command('update', async ctx => {
   const skipImages = passthrough.includes('--skip-images')
   const rebuild = passthrough.includes('--rebuild')
   const updateRequestId = hostdRequestId('gw-update')
-  const hostdResp = await tryHostdDispatch(getMyAgentName(), {
-    v: 1,
-    op: 'update_apply',
-    request_id: updateRequestId,
-    args: {
-      ...(skipImages ? { skip_images: true } : {}),
-      ...(rebuild ? { rebuild: true } : {}),
-    },
-  })
+  // #1841 — forward the cached operator passphrase as the 2nd factor when
+  // hostd requires operator-attest on update_apply. No-op when the vault
+  // is locked / no passphrase is cached (feature-off posture unchanged).
+  const updatePassphrase = vaultPassphraseCache.get(chatId)?.passphrase
+  const hostdResp = await tryHostdDispatch(
+    getMyAgentName(),
+    withOperatorAttestation(
+      {
+        v: 1,
+        op: 'update_apply',
+        request_id: updateRequestId,
+        args: {
+          ...(skipImages ? { skip_images: true } : {}),
+          ...(rebuild ? { rebuild: true } : {}),
+        },
+      },
+      updatePassphrase,
+    ),
+  )
   if (hostdResp === 'not-configured') {
     warnLegacySpawnIfHostdDisabled('update_apply')
     spawnSwitchroomDetached(

--- a/telegram-plugin/gateway/hostd-dispatch.ts
+++ b/telegram-plugin/gateway/hostd-dispatch.ts
@@ -126,6 +126,29 @@ export function hostdRequestId(prefix: string): string {
 }
 
 /**
+ * #1841 — attach an operator-passphrase attestation to a hostd request.
+ *
+ * Mirrors the existing gateway→broker plaintext-forward used for
+ * `vault_request_save`: after `/vault unlock` the gateway caches the
+ * operator passphrase per-chat, and forwards it on the wire when an admin
+ * agent invokes a privileged hostd verb. hostd never holds the passphrase —
+ * it re-forwards this value to the vault broker and treats a broker DENIED
+ * as a gate failure (see `AttestVerifier` in `src/host-control/server.ts`).
+ *
+ * Returns the request unchanged when no passphrase is cached (the
+ * feature-off / not-yet-unlocked posture stays byte-identical to today).
+ * Pure — returns a new object rather than mutating in place, so a caller
+ * can pass a request literal.
+ */
+export function withOperatorAttestation<T extends HostdRequest>(
+  req: T,
+  passphrase: string | undefined,
+): T {
+  if (!passphrase) return req;
+  return { ...req, operator_passphrase: passphrase };
+}
+
+/**
  * Single-shot `get_status` snapshot for `targetRequestId` (NOT a
  * poll-until-terminal — {@link pollHostdStatus} does that). Used by
  * the framework silence-fallback to render a deterministic in-flight

--- a/tests/host-control/hostd-dispatch.test.ts
+++ b/tests/host-control/hostd-dispatch.test.ts
@@ -48,6 +48,7 @@ const {
   hostdSocketPath,
   pollHostdStatus,
   warnLegacySpawnIfHostdDisabled,
+  withOperatorAttestation,
   _resetHostdEnabledCache,
   _resetDeprecationSeen,
 } = await import("../../telegram-plugin/gateway/hostd-dispatch.js");
@@ -462,5 +463,33 @@ describe("regression — issue #1305 silent /update apply", () => {
     expect(t.result).toBe("error");
     expect(t.error).toContain("image pull failed");
     expect(t.stderr_tail).toContain("manifest for");
+  });
+});
+
+describe("withOperatorAttestation — gateway passphrase-forward (#1841)", () => {
+  it("attaches the cached passphrase as operator_passphrase", () => {
+    const req = {
+      v: 1 as const,
+      op: "update_apply" as const,
+      request_id: "gw-1",
+      args: {},
+    };
+    const out = withOperatorAttestation(req, "s3cret");
+    expect(out.operator_passphrase).toBe("s3cret");
+    // Pure — original request is not mutated.
+    expect(
+      (req as { operator_passphrase?: string }).operator_passphrase,
+    ).toBeUndefined();
+  });
+
+  it("returns the request unchanged when no passphrase is cached", () => {
+    const req = {
+      v: 1 as const,
+      op: "update_apply" as const,
+      request_id: "gw-2",
+      args: {},
+    };
+    expect(withOperatorAttestation(req, undefined)).toBe(req);
+    expect(withOperatorAttestation(req, "")).toBe(req);
   });
 });

--- a/tests/host-control/operator-attest.test.ts
+++ b/tests/host-control/operator-attest.test.ts
@@ -1,0 +1,230 @@
+/**
+ * #1841 — operator-passphrase attestation (RFC host-control-daemon.md §5.4).
+ *
+ * Drives a real hostd UDS server with an INJECTED attestation verifier
+ * (`attestVerifier` test seam) so the gate logic is exercised end-to-end
+ * without a live vault broker. Assertions are on OUTCOMES: a required verb
+ * with the correct passphrase passes; the wrong passphrase is DENIED and
+ * writes an audit row tagged `method: "passphrase-attest"`; a required verb
+ * with no attestation is denied; non-required verbs are unchanged; and with
+ * the feature OFF a forwarded passphrase is ignored entirely.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import {
+  mkdtempSync,
+  writeFileSync,
+  chmodSync,
+  rmSync,
+  readFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  HostdServer,
+  type AttestVerifier,
+  type ServerConfig,
+} from "../../src/host-control/server.js";
+import { hostdRequest } from "../../src/host-control/client.js";
+import { parseAuditLine } from "../../src/host-control/audit-reader.js";
+
+const GOOD_PASSPHRASE = "correct horse battery staple";
+
+let tmp: string;
+let stubBin: string;
+let server: HostdServer;
+let verifyCalls: string[];
+
+/** Stub verifier: OK iff the forwarded passphrase equals GOOD_PASSPHRASE.
+ *  Mirrors the broker's fail-closed mismatch semantics. */
+const stubVerifier: AttestVerifier = {
+  verify: async (passphrase: string) => {
+    verifyCalls.push(passphrase);
+    return passphrase === GOOD_PASSPHRASE
+      ? { ok: true }
+      : { ok: false, reason: "broker denied attestation (DENIED)" };
+  },
+};
+
+beforeAll(() => {
+  tmp = mkdtempSync(join(tmpdir(), "hostd-attest-"));
+  stubBin = join(tmp, "switchroom-stub.sh");
+  writeFileSync(stubBin, `#!/bin/sh\necho "stub: $@"\nexit 0\n`);
+  chmodSync(stubBin, 0o755);
+});
+
+afterAll(async () => {
+  if (server) await server.stop();
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+async function startServer(hostd: ServerConfig["hostd"]): Promise<void> {
+  if (server) await server.stop();
+  verifyCalls = [];
+  server = new HostdServer({
+    homeDir: tmp,
+    agentUids: { klanker: 10001, bob: 10002 },
+    config: {
+      agents: { klanker: { admin: true }, bob: {} },
+      ...(hostd ? { hostd } : {}),
+    },
+    switchroomBin: stubBin,
+    auditLogPath: join(tmp, "audit.log"),
+    allowNonLinux: true,
+    attestVerifier: stubVerifier,
+  });
+  await server.start();
+  // Truncate the audit log between servers so per-test assertions are clean.
+  writeFileSync(join(tmp, "audit.log"), "");
+}
+
+function klankerSock(): string {
+  return server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+}
+
+function auditRows() {
+  return readFileSync(join(tmp, "audit.log"), "utf8")
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map(parseAuditLine)
+    .filter((r): r is NonNullable<typeof r> => r !== null);
+}
+
+describe("hostd operator-attest — feature ON, verb required", () => {
+  beforeEach(async () => {
+    await startServer({
+      operator_attest_enabled: true,
+      operator_attest_required_verbs: ["update_apply", "apply", "rollout"],
+    });
+  });
+
+  it("required verb + correct passphrase → passes the gate", async () => {
+    const resp = await hostdRequest(
+      { socketPath: klankerSock() },
+      {
+        v: 1,
+        op: "update_apply",
+        request_id: "attest-ok",
+        operator_passphrase: GOOD_PASSPHRASE,
+        args: {},
+      },
+    );
+    expect(resp.result).toBe("started");
+    expect(verifyCalls).toEqual([GOOD_PASSPHRASE]);
+    const row = auditRows().find((r) => r.request_id === "attest-ok");
+    expect(row?.method).toBe("passphrase-attest");
+    expect(row?.result).toBe("started");
+  });
+
+  it("required verb + WRONG passphrase → denied + audit method row", async () => {
+    const resp = await hostdRequest(
+      { socketPath: klankerSock() },
+      {
+        v: 1,
+        op: "update_apply",
+        request_id: "attest-wrong",
+        operator_passphrase: "nope",
+        args: {},
+      },
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/operator-attest failed/);
+    const row = auditRows().find((r) => r.request_id === "attest-wrong");
+    expect(row?.result).toBe("denied");
+    expect(row?.method).toBe("passphrase-attest");
+  });
+
+  it("required verb WITHOUT attestation → denied (no verifier call)", async () => {
+    const resp = await hostdRequest(
+      { socketPath: klankerSock() },
+      { v: 1, op: "update_apply", request_id: "attest-missing", args: {} },
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/requires operator-passphrase attestation/);
+    expect(verifyCalls).toEqual([]);
+    const row = auditRows().find((r) => r.request_id === "attest-missing");
+    expect(row?.method).toBe("passphrase-attest");
+  });
+
+  it("NEVER persists the passphrase to the audit log", async () => {
+    await hostdRequest(
+      { socketPath: klankerSock() },
+      {
+        v: 1,
+        op: "update_apply",
+        request_id: "attest-noleak",
+        operator_passphrase: GOOD_PASSPHRASE,
+        args: {},
+      },
+    );
+    const raw = readFileSync(join(tmp, "audit.log"), "utf8");
+    expect(raw).not.toContain(GOOD_PASSPHRASE);
+  });
+
+  it("non-required verb is unchanged when no attestation is supplied", async () => {
+    // agent_restart is NOT in the required set: an admin caller passes
+    // with no passphrase and the verifier is never consulted.
+    const resp = await hostdRequest(
+      { socketPath: klankerSock() },
+      {
+        v: 1,
+        op: "agent_restart",
+        request_id: "attest-nonreq",
+        args: { name: "bob" },
+      },
+    );
+    expect(resp.result).toBe("started");
+    expect(verifyCalls).toEqual([]);
+    const row = auditRows().find((r) => r.request_id === "attest-nonreq");
+    expect(row?.method).toBeUndefined();
+  });
+
+  it("non-required verb with a WRONG passphrase fails closed (accept-and-audit)", async () => {
+    const resp = await hostdRequest(
+      { socketPath: klankerSock() },
+      {
+        v: 1,
+        op: "agent_restart",
+        request_id: "attest-nonreq-bad",
+        operator_passphrase: "nope",
+        args: { name: "bob" },
+      },
+    );
+    expect(resp.result).toBe("denied");
+    expect(verifyCalls).toEqual(["nope"]);
+    const row = auditRows().find((r) => r.request_id === "attest-nonreq-bad");
+    expect(row?.method).toBe("passphrase-attest");
+  });
+});
+
+describe("hostd operator-attest — feature OFF (default posture)", () => {
+  beforeEach(async () => {
+    await startServer(undefined); // no hostd block at all
+  });
+
+  it("required-by-default verb passes WITHOUT attestation (backward compat)", async () => {
+    const resp = await hostdRequest(
+      { socketPath: klankerSock() },
+      { v: 1, op: "update_apply", request_id: "off-noattest", args: {} },
+    );
+    expect(resp.result).toBe("started");
+    expect(verifyCalls).toEqual([]);
+    const row = auditRows().find((r) => r.request_id === "off-noattest");
+    expect(row?.method).toBeUndefined();
+  });
+
+  it("a forwarded passphrase is IGNORED entirely (verifier never called)", async () => {
+    const resp = await hostdRequest(
+      { socketPath: klankerSock() },
+      {
+        v: 1,
+        op: "update_apply",
+        request_id: "off-withattest",
+        operator_passphrase: "anything-at-all",
+        args: {},
+      },
+    );
+    expect(resp.result).toBe("started");
+    expect(verifyCalls).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #1841 (pending coordinator review — do not merge without wiring the cross-compose socket; see the blocker section).

Implements the operator-passphrase attestation described in `reference/rfcs/host-control-daemon.md` §5.4 ("Auth model", layer 3) — an **opt-in** second factor on hostd's mutating verbs, layered on top of the existing admin gate and the Telegram approval card (layer 1, #1427, which remains unchanged).

## Design choices

**Which verbs require attest.** Reconciled the RFC table (marks `update_apply` + `apply` as `admin + operator-attest`) with the issue's 6-verb list by making the *field* universal and the *requirement* configurable:
- The `operator_passphrase` attestation field is accepted on every request (envelope-level; read-only verbs ignore it).
- `hostd.operator_attest_required_verbs` (default = RFC §5.4 fleet-mutation set: `update_apply`, `apply`, `rollout`) decides which verbs REQUIRE it when the feature is enabled.
- Verbs not in the required set still **accept-and-audit** a supplied attestation (fail-closed on a wrong passphrase) but never require one.
- Master switch `hostd.operator_attest_enabled` defaults **false**. When off, the passphrase field is ignored entirely — behaviour is byte-identical to today, so existing fleets and the approval-card flow are untouched (backward-compat item 5).

**hostd never holds the passphrase.** `checkOperatorAttest` (runs *after* `checkGate`, so attest is additive, never a replacement) delegates verification to the vault broker via the read-only `list_grants` passphrase plaintext-forward — the same pattern the broker already implements (#1051 / #969). A broker `DENIED` (mismatch / locked) or an unreachable socket is treated as a gate failure (fail-closed). Verification is abstracted behind an injectable `AttestVerifier` seam for unit-testing.

**Audit.** Attested and attestation-denied rows carry `method: "passphrase-attest"` (mirrors the broker's `method` field). The passphrase itself is NEVER written to the audit log (asserted by test).

**Gateway forward.** `withOperatorAttestation` mirrors the existing `vault_request_save` gateway→broker plaintext-forward: it stamps the operator passphrase cached after `/vault unlock` onto the `update_apply` dispatch. No-op when the vault is locked / nothing cached.

## Socket topology & the structural blocker (documented, not faked)

Per the development protocol, the cross-compose socket the issue lists as scope is a genuine structural blocker I cannot validate here:

- hostd runs in its **own compose project** (`switchroom-hostd`) with **no vault-broker socket mounted** (`src/cli/hostd.ts` compose template — only `~/.switchroom`, docker.sock, machine-id).
- Broker sockets live in per-agent **named volumes** (`broker-<agent>-sock`) in the `switchroom` project; wiring `/run/switchroom/broker/hostd/sock` needs (a) a `broker-hostd-sock` volume the broker binds a socket into for the reserved `hostd` identity, and (b) that volume mounted cross-compose (external) into the hostd container.
- The reserved `hostd` broker-client identity already exists (`src/host-control/peercred.ts`, `RESERVED_AGENT_NAMES`), but the broker does not yet **bind** a socket for it — that's broker runtime bind-logic, not just compose.

This path can't be exercised without a live multi-container host, and shipping half-correct compose generation risks breaking `switchroom apply` for every fleet. So it is left as the **deployment prerequisite**. Because the feature ships **OFF by default**, nothing breaks until an operator both wires the socket and flips `operator_attest_enabled` — the default verifier only ever runs in that opted-in state. The verifier code targets `HOSTD_BROKER_SOCKET_PATH` = `/run/switchroom/broker/hostd/sock` so the wiring drops in without further server changes.

## Tests (assert outcomes)

`tests/host-control/operator-attest.test.ts` (real UDS server + injected verifier):
- required verb + correct passphrase → passes the gate;
- required verb + wrong passphrase → DENIED + audit row with `method: "passphrase-attest"`;
- required verb without attestation → denied, verifier never called;
- passphrase never persisted to the audit log;
- non-required verb unchanged with no attestation; fails closed on a wrong one;
- feature OFF → a forwarded passphrase is ignored (verifier never called), verb still succeeds.

Plus `withOperatorAttestation` unit tests (pure, no-op without a cache) and an updated schema default test.

**Results:** touched suites green — `operator-attest` (8), `hostd-dispatch` (+2), `schema` (updated) → 164 passed. `npm run lint` fully clean (tsc + all 8 guards). Note: `tests/host-control/server.test.ts` shows 32 pre-existing failures in this sandbox (subprocess-spawn/timing) — verified identical on pristine `origin/main`, unrelated to this change (that file is untouched).

## Files changed
- `src/host-control/protocol.ts` — envelope `operator_passphrase` field
- `src/config/schema.ts` — `operator_attest_enabled` + `operator_attest_required_verbs`
- `src/host-control/server.ts` — `checkOperatorAttest`, `AttestVerifier`, broker-backed default verifier, audit `method` threading
- `src/host-control/main.ts` — config passthrough
- `src/host-control/audit-reader.ts` — parse `method`
- `telegram-plugin/gateway/hostd-dispatch.ts` — `withOperatorAttestation`
- `telegram-plugin/gateway/gateway.ts` — forward on `update_apply`
- tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)