### PR TITLE
feat(compose): wire consumer mirror_dir push-failover volume (#2578)

### DIFF
--- a/src/agents/compose-mirror-dir.test.ts
+++ b/src/agents/compose-mirror-dir.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for the #2578 wiring: when an `auth.consumers[]` entry sets
+ * `mirror_dir`, the compose generator must create a shared `consumer-creds-
+ * <name>` named volume, mount it on the auth-broker at the consumer's
+ * `mirror_dir` path, and declare it with a canonical (unprefixed) name so
+ * the out-of-project consumer container can mount the same volume. Consumers
+ * WITHOUT `mirror_dir` must be byte-identical to pre-#2578 output (no volume).
+ */
+
+import { describe, expect, it } from "vitest";
+import { generateCompose } from "./compose.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+const AGENTS_DIR = "/home/op/.switchroom/agents";
+
+function baseConfig(
+  consumers?: Array<{ name: string; account?: string; uid?: number; mirror_dir?: string }>,
+): SwitchroomConfig {
+  return {
+    agents: {
+      alice: { profile: "engineer", claudeAccount: "default" },
+    },
+    profiles: {},
+    defaults: {},
+    switchroom: { agents_dir: AGENTS_DIR },
+    telegram: { forum_chat_id: "0" },
+    ...(consumers ? { auth: { consumers } } : {}),
+  } as unknown as SwitchroomConfig;
+}
+
+function gen(config: SwitchroomConfig): string {
+  return generateCompose({
+    config,
+    homeDir: "/home/op",
+    warn: () => {},
+  });
+}
+
+describe("compose generator — consumer mirror_dir wiring (#2578)", () => {
+  it("consumer WITH mirror_dir: declares the shared volume, mounts it on the broker, and gives it a canonical name", () => {
+    const yaml = gen(
+      baseConfig([{ name: "hindsight", uid: 11000, mirror_dir: "/run/consumer-creds/hindsight" }]),
+    );
+
+    // Broker mounts the shared volume at the operator-chosen mirror_dir path.
+    expect(yaml).toContain("- consumer-creds-hindsight:/run/consumer-creds/hindsight");
+
+    // The volume is declared with a canonical (unprefixed) name so the
+    // cross-project consumer container can reference it by name.
+    expect(yaml).toMatch(/ {2}consumer-creds-hindsight:\n {4}name: consumer-creds-hindsight/);
+  });
+
+  it("consumer WITHOUT mirror_dir: emits NO shared creds volume (pre-#2578 output)", () => {
+    const yaml = gen(baseConfig([{ name: "hindsight", uid: 11000 }]));
+
+    expect(yaml).not.toContain("consumer-creds-");
+    // Socket volume is still present — only the creds mirror is gated.
+    expect(yaml).toContain("auth-broker-hindsight-sock");
+  });
+
+  it("no consumers at all: no consumer-creds volume, output stable", () => {
+    const yaml = gen(baseConfig());
+    expect(yaml).not.toContain("consumer-creds-");
+  });
+
+  it("multiple consumers: only the mirror_dir one gets a shared volume", () => {
+    const yaml = gen(
+      baseConfig([
+        { name: "hindsight", uid: 11000, mirror_dir: "/run/consumer-creds/hindsight" },
+        { name: "scribe", uid: 12000 },
+      ]),
+    );
+
+    expect(yaml).toContain("- consumer-creds-hindsight:/run/consumer-creds/hindsight");
+    expect(yaml).toContain("name: consumer-creds-hindsight");
+    // scribe has no mirror_dir → no creds volume for it.
+    expect(yaml).not.toContain("consumer-creds-scribe");
+  });
+
+  it("mirror_dir output is a strict superset — the no-mirror output is a substring-free of the mirror volume", () => {
+    const withMirror = gen(
+      baseConfig([{ name: "hindsight", uid: 11000, mirror_dir: "/run/consumer-creds/hindsight" }]),
+    );
+    const without = gen(baseConfig([{ name: "hindsight", uid: 11000 }]));
+
+    // The only creds-mirror lines appear exclusively in the mirror variant.
+    expect(without).not.toContain("consumer-creds-hindsight");
+    expect(withMirror).toContain("consumer-creds-hindsight");
+  });
+});

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1818,6 +1818,20 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // `mirror_dir`. Canonical (unprefixed) name so the cross-project
   // consumer container can mount the same volume by name. Absent when
   // no consumer sets `mirror_dir`, keeping legacy output byte-identical.
+  //
+  // Creation-order note (verified live, docker compose v5.1.3, 2026-07-11):
+  // if `startHindsight()`'s docker-run path executes BEFORE the next
+  // `apply` of this project, `docker run -v consumer-creds-<name>:…`
+  // auto-creates the volume WITHOUT compose labels. `docker compose up`
+  // on this project then emits a warning ("already exists but was not
+  // created by Docker Compose. Use `external: true`…") but SUCCEEDS with
+  // exit 0 and REUSES the existing volume unchanged (labels/CreatedAt
+  // untouched) — an explicit `name:` adopts a same-named pre-existing
+  // volume rather than erroring. So ordering between `memory setup` and
+  // `apply` is safe in both directions; do not re-litigate. (The
+  // hindsight compose SNIPPET is stricter — it declares the volume
+  // `external: true`, so that path does require this project, or a
+  // prior docker run, to have created the volume first.)
   for (const c of authConsumers) {
     if (c.mirror_dir) {
       lines.push(`  consumer-creds-${c.name}:`);

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1716,6 +1716,24 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   for (const c of authConsumers) {
     lines.push(`      - auth-broker-${c.name}-sock:/run/switchroom/auth-broker/${c.name}`);
   }
+  // Per-consumer creds mirror (#2578). When a consumer declares
+  // `mirror_dir`, the broker actively pushes the effective-account
+  // `.credentials.json` there the instant it detects exhaustion (see
+  // mirrorAccountToConsumer in src/auth/broker/server.ts). That only
+  // reaches the consumer if broker and consumer share a volume: mount
+  // it here at the operator-chosen `mirror_dir` path, and the consumer
+  // container (e.g. hindsight, started out-of-project) mounts the SAME
+  // named volume at its creds-read path. The volume name is canonical
+  // (unprefixed, declared below) so the cross-project consumer can
+  // reference it. Consumers WITHOUT `mirror_dir` emit nothing here —
+  // output is byte-identical to pre-#2578. The broker reads the
+  // `mirror_dir` value straight from SWITCHROOM_CONFIG, so no extra env
+  // is duplicated.
+  for (const c of authConsumers) {
+    if (c.mirror_dir) {
+      lines.push(`      - consumer-creds-${c.name}:${c.mirror_dir}`);
+    }
+  }
   // Operator socket — host-mounted bind so `switchroom auth …` from a
   // shell on the host can reach the broker. Path is the operator-
   // socket bind documented in the RFC §4.2. Only emitted when an
@@ -1795,6 +1813,16 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
     // compose project, so the prefix is invisible.
     lines.push(`  auth-broker-${c.name}-sock:`);
     lines.push(`    name: auth-broker-${c.name}-sock`);
+  }
+  // Shared creds-mirror volume (#2578) — one per consumer with a
+  // `mirror_dir`. Canonical (unprefixed) name so the cross-project
+  // consumer container can mount the same volume by name. Absent when
+  // no consumer sets `mirror_dir`, keeping legacy output byte-identical.
+  for (const c of authConsumers) {
+    if (c.mirror_dir) {
+      lines.push(`  consumer-creds-${c.name}:`);
+      lines.push(`    name: consumer-creds-${c.name}`);
+    }
   }
   // Named volume for the voice sidecar's fetch-once model weights —
   // only declared when the sidecar service is emitted (local verdict).

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -14,6 +14,7 @@ import {
   isHindsightRunning,
   isHindsightContainerExists,
   startHindsight,
+  hindsightConsumerMirrorDir,
   stopHindsight,
   getHindsightStatus,
   generateHindsightComposeSnippet,
@@ -468,7 +469,13 @@ export function registerMemoryCommand(program: Command): void {
       try {
         const hindsightConfig = getConfig(program);
         const litellmCfg = await resolveLiteLLMForHindsight(hindsightConfig);
-        startHindsight(ports, litellmCfg, opts.tag, hindsightConfig.hindsight?.llm);
+        startHindsight(
+          ports,
+          litellmCfg,
+          opts.tag,
+          hindsightConfig.hindsight?.llm,
+          hindsightConsumerMirrorDir(hindsightConfig),
+        );
         if (litellmCfg) {
           console.log(chalk.gray("  LiteLLM routing enabled for hindsight (--network host)."));
         }
@@ -523,7 +530,15 @@ export function registerMemoryCommand(program: Command): void {
     .description("Output a docker-compose snippet for Hindsight (broker-fed mode)")
     .action(() => {
       console.log(chalk.bold("\n# Add this to your docker-compose.yml:\n"));
-      console.log(generateHindsightComposeSnippet(getConfig(program).hindsight?.llm));
+      {
+        const snippetConfig = getConfig(program);
+        console.log(
+          generateHindsightComposeSnippet(
+            snippetConfig.hindsight?.llm,
+            hindsightConsumerMirrorDir(snippetConfig),
+          ),
+        );
+      }
       console.log();
     });
 

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -33,6 +33,7 @@ import {
   isHindsightRunning,
   isHindsightContainerExists,
   startHindsight,
+  hindsightConsumerMirrorDir,
   stopHindsight,
   ensureHindsightConsumer,
   HINDSIGHT_CONSUMER_NAME,
@@ -1101,7 +1102,13 @@ async function stepMemoryBackend(
   const spin = spinner("Starting Hindsight Docker container...");
   try {
     const litellmCfg = await resolveLiteLLMForHindsight(config);
-    startHindsight(ports, litellmCfg, undefined, config.hindsight?.llm);
+    startHindsight(
+      ports,
+      litellmCfg,
+      undefined,
+      config.hindsight?.llm,
+      hindsightConsumerMirrorDir(config),
+    );
     if (litellmCfg) {
       console.log(chalk.gray("  LiteLLM routing enabled (--network host, ANTHROPIC_BASE_URL set)."));
     }

--- a/src/setup/hindsight-mirror-dir.test.ts
+++ b/src/setup/hindsight-mirror-dir.test.ts
@@ -128,4 +128,36 @@ describe("generateHindsightComposeSnippet — mirror mode (#2578)", () => {
     // Volume declared external (owned by the broker's compose project).
     expect(snippet).toMatch(new RegExp(`${HINDSIGHT_CREDS_MIRROR_VOLUME}:\\n {4}external: true`));
   });
+
+  it("both branches emit structurally valid YAML (parse + shape asserts)", async () => {
+    const { parse } = await import("yaml");
+
+    // Mirror OFF — tmpfs list present under the hindsight service.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const off = parse(generateHindsightComposeSnippet()) as Record<string, any>;
+    const offSvc = off.services["switchroom-hindsight"];
+    expect(offSvc).toBeDefined();
+    expect(Array.isArray(offSvc.tmpfs)).toBe(true);
+    expect(offSvc.tmpfs[0]).toContain(HINDSIGHT_CRED_DIR);
+    expect(off.services["switchroom-hindsight-creds-init"]).toBeUndefined();
+    expect(off.volumes[HINDSIGHT_CREDS_MIRROR_VOLUME]).toBeUndefined();
+
+    // Mirror ON — no tmpfs key; shared volume mounted; init service + dep
+    // + external volume all parse into the expected structure.
+    const on = parse(
+      generateHindsightComposeSnippet(undefined, "/run/consumer-creds/hindsight"),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) as Record<string, any>;
+    const onSvc = on.services["switchroom-hindsight"];
+    expect(onSvc.tmpfs).toBeUndefined();
+    expect(onSvc.volumes).toContain(`${HINDSIGHT_CREDS_MIRROR_VOLUME}:${HINDSIGHT_CRED_DIR}`);
+    expect(onSvc.depends_on["switchroom-hindsight-creds-init"]).toEqual({
+      condition: "service_completed_successfully",
+    });
+    const init = on.services["switchroom-hindsight-creds-init"];
+    expect(init).toBeDefined();
+    expect(init.user).toBe("0");
+    expect(init.volumes).toContain(`${HINDSIGHT_CREDS_MIRROR_VOLUME}:${HINDSIGHT_CRED_DIR}`);
+    expect(on.volumes[HINDSIGHT_CREDS_MIRROR_VOLUME]).toMatchObject({ external: true });
+  });
 });

--- a/src/setup/hindsight-mirror-dir.test.ts
+++ b/src/setup/hindsight-mirror-dir.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for the #2578 hindsight startup path: when the hindsight
+ * consumer declares `mirror_dir`, `startHindsight` must back the creds dir
+ * with the shared `consumer-creds-hindsight` volume (pre-chowned to the
+ * consumer UID) instead of a private tmpfs, and `generateHindsightCompose
+ * Snippet` must emit the same volume + a chown init service. Without
+ * `mirror_dir`, output is unchanged (tmpfs, pull-only).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execFileSyncMock } = vi.hoisted(() => ({ execFileSyncMock: vi.fn() }));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, execFileSync: execFileSyncMock };
+});
+
+import {
+  startHindsight,
+  generateHindsightComposeSnippet,
+  hindsightConsumerMirrorDir,
+  HINDSIGHT_CREDS_MIRROR_VOLUME,
+  HINDSIGHT_CRED_DIR,
+  HINDSIGHT_DEFAULT_UID,
+} from "./hindsight.js";
+
+beforeEach(() => {
+  execFileSyncMock.mockReset();
+  execFileSyncMock.mockReturnValue(Buffer.from(""));
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+/** All `docker run` argv arrays captured, joined per-call for substring asserts. */
+function dockerCalls(): string[][] {
+  return execFileSyncMock.mock.calls
+    .filter((c) => c[0] === "docker")
+    .map((c) => c[1] as string[]);
+}
+
+describe("hindsightConsumerMirrorDir", () => {
+  it("returns the hindsight consumer's mirror_dir when set", () => {
+    const cfg = {
+      auth: { consumers: [{ name: "hindsight", mirror_dir: "/run/consumer-creds/hindsight" }] },
+    };
+    expect(hindsightConsumerMirrorDir(cfg)).toBe("/run/consumer-creds/hindsight");
+  });
+
+  it("returns undefined when the consumer has no mirror_dir", () => {
+    expect(hindsightConsumerMirrorDir({ auth: { consumers: [{ name: "hindsight" }] } })).toBeUndefined();
+  });
+
+  it("returns undefined when there is no hindsight consumer", () => {
+    expect(hindsightConsumerMirrorDir({ auth: { consumers: [{ name: "other", mirror_dir: "/x" }] } })).toBeUndefined();
+    expect(hindsightConsumerMirrorDir({})).toBeUndefined();
+  });
+});
+
+describe("startHindsight — mirror mode (#2578)", () => {
+  it("mirror OFF: creds dir is a private tmpfs, no shared volume, no chown init", () => {
+    startHindsight();
+    const calls = dockerCalls();
+    // Exactly one docker call (the `run -d`); no pre-chown container.
+    expect(calls).toHaveLength(1);
+    const argv = calls[0]!;
+    expect(argv).toContain("--tmpfs");
+    expect(argv.join(" ")).toContain(`${HINDSIGHT_CRED_DIR}:rw,mode=0700`);
+    expect(argv.join(" ")).not.toContain(HINDSIGHT_CREDS_MIRROR_VOLUME);
+  });
+
+  it("mirror ON: creds dir is the shared volume, tmpfs replaced, and a chown init runs first", () => {
+    startHindsight(undefined, undefined, undefined, undefined, "/run/consumer-creds/hindsight");
+    const calls = dockerCalls();
+    // Two docker calls: the chown init THEN the `run -d`.
+    expect(calls).toHaveLength(2);
+
+    const [initArgv, runArgv] = calls;
+
+    // 1. chown init: root user, mounts the shared volume, chowns to the UID.
+    expect(initArgv).toContain("--user");
+    expect(initArgv).toContain("0");
+    expect(initArgv.join(" ")).toContain(`${HINDSIGHT_CREDS_MIRROR_VOLUME}:${HINDSIGHT_CRED_DIR}`);
+    expect(initArgv.join(" ")).toContain(
+      `chown ${HINDSIGHT_DEFAULT_UID}:${HINDSIGHT_DEFAULT_UID} ${HINDSIGHT_CRED_DIR}`,
+    );
+
+    // 2. run: shared volume mounted at the creds path; NO tmpfs.
+    expect(runArgv).toContain("-v");
+    expect(runArgv.join(" ")).toContain(`${HINDSIGHT_CREDS_MIRROR_VOLUME}:${HINDSIGHT_CRED_DIR}`);
+    expect(runArgv).not.toContain("--tmpfs");
+
+    // Ordering: init before run.
+    const initIdx = execFileSyncMock.mock.calls.findIndex(
+      (c) => Array.isArray(c[1]) && (c[1] as string[]).some((a) => typeof a === "string" && a.includes("chown")),
+    );
+    const runIdx = execFileSyncMock.mock.calls.findIndex(
+      (c) => Array.isArray(c[1]) && (c[1] as string[])[0] === "run" && (c[1] as string[])[1] === "-d",
+    );
+    expect(initIdx).toBeGreaterThanOrEqual(0);
+    expect(runIdx).toBeGreaterThan(initIdx);
+  });
+});
+
+describe("generateHindsightComposeSnippet — mirror mode (#2578)", () => {
+  it("mirror OFF: tmpfs creds, no init service, no external creds volume", () => {
+    const snippet = generateHindsightComposeSnippet();
+    expect(snippet).toContain("tmpfs:");
+    expect(snippet).toContain(`${HINDSIGHT_CRED_DIR}:rw,mode=0700`);
+    expect(snippet).not.toContain(HINDSIGHT_CREDS_MIRROR_VOLUME);
+    expect(snippet).not.toContain("switchroom-hindsight-creds-init");
+  });
+
+  it("mirror ON: shared volume creds, init service with completed-successfully dep, external volume declared", () => {
+    const snippet = generateHindsightComposeSnippet(undefined, "/run/consumer-creds/hindsight");
+
+    // Creds dir backed by the shared volume, tmpfs gone.
+    expect(snippet).toContain(`- ${HINDSIGHT_CREDS_MIRROR_VOLUME}:${HINDSIGHT_CRED_DIR}`);
+    expect(snippet).not.toContain("tmpfs:");
+
+    // One-shot chown init service + dependency gate.
+    expect(snippet).toContain("switchroom-hindsight-creds-init:");
+    expect(snippet).toContain("condition: service_completed_successfully");
+    expect(snippet).toContain(
+      `chown ${HINDSIGHT_DEFAULT_UID}:${HINDSIGHT_DEFAULT_UID} ${HINDSIGHT_CRED_DIR}`,
+    );
+
+    // Volume declared external (owned by the broker's compose project).
+    expect(snippet).toMatch(new RegExp(`${HINDSIGHT_CREDS_MIRROR_VOLUME}:\\n {4}external: true`));
+  });
+});

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -222,6 +222,46 @@ export const HINDSIGHT_DEFAULT_MCP_STATELESS = true;
 export const HINDSIGHT_BROKER_SOCK_VOLUME = `auth-broker-${HINDSIGHT_CONSUMER_NAME}-sock`;
 
 /**
+ * Shared creds-mirror volume for the hindsight consumer (#2578).
+ *
+ * When the hindsight `auth.consumers[]` entry declares `mirror_dir`, the
+ * auth-broker pushes the effective-account `.credentials.json` there the
+ * instant it detects exhaustion (see `mirrorAccountToConsumer` in
+ * src/auth/broker/server.ts, landed in #2577). For that push to reach
+ * hindsight, broker and hindsight must share a volume: the broker mounts
+ * it at the operator-chosen `mirror_dir`, hindsight mounts the SAME named
+ * volume at its creds-read path (`/run/claude-creds`, the entrypoint's
+ * `CLAUDE_CONFIG_DIR`), REPLACING the private per-container tmpfs. This
+ * closes the up-to-30-min pull-latency gap for failover.
+ *
+ * Name is canonical (unprefixed) so it matches what `src/agents/compose.ts`
+ * declares on the switchroom compose project (`consumer-creds-<name>`) —
+ * the two projects are separate but reference the same volume by name.
+ */
+export const HINDSIGHT_CREDS_MIRROR_VOLUME = `consumer-creds-${HINDSIGHT_CONSUMER_NAME}`;
+
+/**
+ * The consumer-side creds-read path — hindsight's `CLAUDE_CONFIG_DIR`, where
+ * the entrypoint fetches `.credentials.json` and the claude subprocess reads
+ * it. In mirror mode the broker's pushed file lands here via the shared
+ * volume; otherwise it is a per-container tmpfs.
+ */
+export const HINDSIGHT_CRED_DIR = "/run/claude-creds";
+
+/**
+ * Resolve the hindsight consumer's `mirror_dir` from a loaded config, or
+ * `undefined` when unset (mirror-mode off → tmpfs, pull-only — unchanged
+ * pre-#2578 behavior). Callers pass the result to `startHindsight` /
+ * `generateHindsightComposeSnippet` to decide tmpfs-vs-shared-volume.
+ */
+export function hindsightConsumerMirrorDir(config: {
+  auth?: { consumers?: Array<{ name: string; mirror_dir?: string }> };
+}): string | undefined {
+  return config.auth?.consumers?.find((c) => c.name === HINDSIGHT_CONSUMER_NAME)
+    ?.mirror_dir;
+}
+
+/**
  * Reranker smart-defaults (v0.13.22).
  *
  * The hindsight server's cross-encoder reranker is the single biggest
@@ -696,6 +736,15 @@ export function startHindsight(
   litellm?: LiteLLMHindsightConfig,
   imageTag?: string,
   llm?: HindsightLlmConfig,
+  /**
+   * When set (the hindsight consumer's `mirror_dir`, #2578), hindsight's
+   * creds dir `/run/claude-creds` is backed by the shared named volume
+   * `consumer-creds-hindsight` instead of a private tmpfs, so the broker's
+   * push-failover writes reach it immediately. Absent ⇒ tmpfs, pull-only
+   * (unchanged pre-#2578 behavior). The value itself is the broker-side
+   * path; the consumer-side mount path is always HINDSIGHT_CRED_DIR.
+   */
+  mirrorDir?: string,
 ): void {
   const apiPort = ports?.apiPort ?? HINDSIGHT_DEFAULT_API_PORT;
   const uiPort = ports?.uiPort ?? HINDSIGHT_DEFAULT_UI_PORT;
@@ -842,18 +891,45 @@ export function startHindsight(
     // the declared consumer UID); inside this container the socket is
     // visible at /run/switchroom/auth-broker/sock.
     "-v", `${HINDSIGHT_BROKER_SOCK_VOLUME}:/run/switchroom/auth-broker`,
-    // Tmpfs for the dotfile written by the entrypoint shim. Lives in RAM
-    // only — the broker remains the single writer of OAuth state on disk.
-    // `uid=` + `gid=` are required because the image's `USER hindsight`
-    // (UID 11000, pinned in Dockerfile.hindsight) runs the entrypoint;
-    // without explicit ownership, tmpfs mounts root-owned and the
-    // entrypoint's `chmod 0700` fails EACCES → restart-loop.
-    "--tmpfs", `/run/claude-creds:rw,mode=0700,uid=${HINDSIGHT_DEFAULT_UID},gid=${HINDSIGHT_DEFAULT_UID}`,
+    // Creds dir. Two modes:
+    //  - mirror OFF (default): a private tmpfs, RAM-only, pull-only. `uid=`
+    //    + `gid=` are required because the image's `USER hindsight` (UID
+    //    11000, pinned in Dockerfile.hindsight) runs the entrypoint;
+    //    without explicit ownership tmpfs mounts root-owned and the
+    //    entrypoint's `chmod 0700` fails EACCES → restart-loop.
+    //  - mirror ON (#2578): the shared named volume the broker also mounts
+    //    at `mirror_dir`, so push-failover creds land here immediately.
+    //    Emitted below with the rest of args (needs the -v flag form).
+    ...(mirrorDir
+      ? ["-v", `${HINDSIGHT_CREDS_MIRROR_VOLUME}:${HINDSIGHT_CRED_DIR}`]
+      : ["--tmpfs", `${HINDSIGHT_CRED_DIR}:rw,mode=0700,uid=${HINDSIGHT_DEFAULT_UID},gid=${HINDSIGHT_DEFAULT_UID}`]),
     ...envArgs,
     // Pinned tag when a rollout target is threaded through; floating
     // `:latest` for the standalone `memory setup` path (imageTag undefined).
     hindsightImageRef(imageTag),
   );
+
+  // Mirror mode (#2578): a fresh named volume mounts root:root, but the
+  // entrypoint runs as UID 11000 and does `mkdir -p CRED_DIR; chmod 0700`
+  // → EACCES on a root-owned dir → crash-loop. Pre-chown the volume to the
+  // consumer UID with a throwaway root container (the hindsight image is
+  // already present locally). Idempotent + deterministic: safe to re-run
+  // on every start. No-op when mirror is off (tmpfs handles its own
+  // ownership via uid=/gid=).
+  if (mirrorDir) {
+    execFileSync(
+      "docker",
+      [
+        "run", "--rm", "--user", "0",
+        "-v", `${HINDSIGHT_CREDS_MIRROR_VOLUME}:${HINDSIGHT_CRED_DIR}`,
+        "--entrypoint", "sh",
+        hindsightImageRef(imageTag),
+        "-c",
+        `chown ${HINDSIGHT_DEFAULT_UID}:${HINDSIGHT_DEFAULT_UID} ${HINDSIGHT_CRED_DIR} && chmod 0700 ${HINDSIGHT_CRED_DIR}`,
+      ],
+      { stdio: "pipe" },
+    );
+  }
 
   execFileSync("docker", args, { stdio: "pipe" });
 }
@@ -1010,7 +1086,18 @@ export function getHindsightMcpUrl(): {
  * container chowns and binds the per-consumer socket inside it). The
  * hindsight compose project is separate; it consumes the volume.
  */
-export function generateHindsightComposeSnippet(llm?: HindsightLlmConfig): string {
+export function generateHindsightComposeSnippet(
+  llm?: HindsightLlmConfig,
+  /**
+   * The hindsight consumer's `mirror_dir` (#2578). When set, the creds dir
+   * is backed by the shared `consumer-creds-hindsight` volume (broker
+   * push-failover reaches hindsight immediately) instead of a private
+   * tmpfs, with a one-shot init service that chowns the fresh volume to the
+   * consumer UID before hindsight starts. Absent ⇒ tmpfs, pull-only —
+   * output identical to pre-#2578.
+   */
+  mirrorDir?: string,
+): string {
   const { provider: llmProvider, model: llmModel } = resolveHindsightLlm(llm);
   const perOpLlm = resolveHindsightPerOpLlm(llm);
   const environment = [
@@ -1032,11 +1119,37 @@ export function generateHindsightComposeSnippet(llm?: HindsightLlmConfig): strin
     // moved-off API port to dodge the squatted-8888 → 502 dashboard bug.
     `      - HINDSIGHT_CP_DATAPLANE_API_URL=http://localhost:8888`,
   ];
+  // Mirror mode (#2578): a one-shot init service chowns the fresh shared
+  // creds volume to the consumer UID (a named volume mounts root:root, but
+  // hindsight's entrypoint runs as UID 11000 and would EACCES on its
+  // `chmod 0700` → crash-loop). Hindsight then depends_on it completing.
+  const initService = mirrorDir
+    ? [
+        "  switchroom-hindsight-creds-init:",
+        `    image: ${HINDSIGHT_IMAGE}`,
+        "    container_name: switchroom-hindsight-creds-init",
+        "    user: \"0\"",
+        "    entrypoint: [\"sh\", \"-c\"]",
+        `    command: ["chown ${HINDSIGHT_DEFAULT_UID}:${HINDSIGHT_DEFAULT_UID} ${HINDSIGHT_CRED_DIR} && chmod 0700 ${HINDSIGHT_CRED_DIR}"]`,
+        "    volumes:",
+        `      - ${HINDSIGHT_CREDS_MIRROR_VOLUME}:${HINDSIGHT_CRED_DIR}`,
+        "    restart: \"no\"",
+      ]
+    : [];
+  const dependsOn = mirrorDir
+    ? [
+        "    depends_on:",
+        "      switchroom-hindsight-creds-init:",
+        "        condition: service_completed_successfully",
+      ]
+    : [];
   return [
     "services:",
+    ...initService,
     "  switchroom-hindsight:",
     `    image: ${HINDSIGHT_IMAGE}`,
     "    container_name: switchroom-hindsight",
+    ...dependsOn,
     "    ports:",
     // Host side 18888/19999 → container 8888/9999. The host port MUST match
     // HINDSIGHT_DEFAULT_API_PORT / the scaffolded memory.config.url or agents
@@ -1077,8 +1190,14 @@ export function generateHindsightComposeSnippet(llm?: HindsightLlmConfig): strin
     // volume is lost/corrupted. Written by the entrypoint maintenance loop.
     "      - switchroom-hindsight-backups:/backups",
     `      - ${HINDSIGHT_BROKER_SOCK_VOLUME}:/run/switchroom/auth-broker`,
-    "    tmpfs:",
-    `      - /run/claude-creds:rw,mode=0700,uid=${HINDSIGHT_DEFAULT_UID},gid=${HINDSIGHT_DEFAULT_UID}`,
+    // Creds dir: mirror ON → shared volume (broker push-failover reaches
+    // hindsight immediately); mirror OFF → private tmpfs (pull-only).
+    ...(mirrorDir
+      ? [`      - ${HINDSIGHT_CREDS_MIRROR_VOLUME}:${HINDSIGHT_CRED_DIR}`]
+      : [
+          "    tmpfs:",
+          `      - ${HINDSIGHT_CRED_DIR}:rw,mode=0700,uid=${HINDSIGHT_DEFAULT_UID},gid=${HINDSIGHT_DEFAULT_UID}`,
+        ]),
     "    restart: always",
     "",
     "volumes:",
@@ -1089,6 +1208,17 @@ export function generateHindsightComposeSnippet(llm?: HindsightLlmConfig): strin
     "    # Bound by the switchroom-auth-broker singleton in the main",
     "    # switchroom compose project. Declare an `auth.consumers[]`",
     `    # entry named "${HINDSIGHT_CONSUMER_NAME}" in switchroom.yaml.`,
+    // Shared creds-mirror volume (#2578) — external because the broker in
+    // the main switchroom compose project owns/mounts it at `mirror_dir`.
+    ...(mirrorDir
+      ? [
+          `  ${HINDSIGHT_CREDS_MIRROR_VOLUME}:`,
+          "    external: true",
+          "    # Mounted by switchroom-auth-broker at the consumer's",
+          `    # \`mirror_dir\`. Set \`mirror_dir\` on the "${HINDSIGHT_CONSUMER_NAME}"`,
+          "    # auth.consumers[] entry in switchroom.yaml + `apply`.",
+        ]
+      : []),
   ].join("\n");
 }
 

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -641,13 +641,14 @@ describe("Hindsight port-collision regression", () => {
   // launch through the SAME pick+preflight helpers.
   it("setup.ts routes its Hindsight launch through the pick+preflight guard", () => {
     const src = readFileSync(resolve(import.meta.dirname, "../src/cli/setup.ts"), "utf-8");
-    // Must no longer blind-launch on the default port.
-    expect(src).not.toContain("startHindsight(undefined");
+    // Must no longer blind-launch on the default port. Whitespace-tolerant:
+    // the call site may be formatted multi-line (#2578 added trailing args).
+    expect(src).not.toMatch(/startHindsight\(\s*undefined/);
     // Must use the shared guard helpers (not a parallel implementation) and
-    // hand the chosen ports to startHindsight.
+    // hand the chosen ports to startHindsight (first argument = `ports`).
     expect(src).toContain("pickHindsightPorts");
     expect(src).toContain("preflightHindsightPorts");
-    expect(src).toContain("startHindsight(ports");
+    expect(src).toMatch(/startHindsight\(\s*ports\b/);
   });
 
   it("setup's port guard selects a free port instead of binding the occupied default", async () => {


### PR DESCRIPTION
Fixes #2578.

## What this does
Activates the auth-broker push-failover creds mirror landed in #2577. That code writes a consumer's effective-account `.credentials.json` to its `mirror_dir` the instant it detects exhaustion (sensor tick / mark-exhausted RPC), but was **inert**: `src/agents/compose.ts` mounted no shared volume between the broker and the consumer (hindsight), so the broker had nowhere the consumer could read from — manual compose edits got wiped by the next `switchroom apply`.

## Changes
For a consumer with `mirror_dir` set, the generator now:
1. Declares a shared named volume `consumer-creds-<name>` with a canonical (unprefixed) `name:` so the out-of-project consumer container can mount the same volume by name (same pattern as `auth-broker-<name>-sock`).
2. Mounts it on the `switchroom-auth-broker` service at the consumer's `mirror_dir` path. The broker still reads the `mirror_dir` value straight from `SWITCHROOM_CONFIG` — no env duplication.
3. On the hindsight startup path (`startHindsight` + `generateHindsightComposeSnippet`), backs `/run/claude-creds` (the entrypoint's `CLAUDE_CONFIG_DIR`, verified against `docker/hindsight-entrypoint.sh`) with the same shared volume instead of the private tmpfs, and **pre-chowns** the fresh volume to the consumer UID (11000): a one-shot root container before `docker run` in the docker-run path, a `service_completed_successfully` init service in the compose-snippet path. Required because a fresh named volume mounts `root:root` while hindsight runs as UID 11000 — its entrypoint's `chmod 0700 /run/claude-creds` would `EACCES` → crash-loop otherwise.

Consumers **without** `mirror_dir` are byte-identical to pre-#2578 output (tmpfs, pull-only) — no default-on behavior change.

## Tests
- `src/agents/compose-mirror-dir.test.ts` — volume declared + broker-mounted + canonically named only when `mirror_dir` is set; absent for no-mirror / no-consumer / non-mirror sibling consumers.
- `src/setup/hindsight-mirror-dir.test.ts` — tmpfs↔shared-volume swap, chown-init presence + ordering (init before run), external-volume + `depends_on` in the snippet, and the `hindsightConsumerMirrorDir` resolver.

All assert generated YAML/argv content, not just that generation succeeds. Scoped tests green (`src/agents` 374 pass, new suites 12 pass); `npm run lint` clean.

## Operator follow-up (required to arm the safety net)
This ships the wiring **off by default**. To activate for hindsight: set `mirror_dir` on the `hindsight` `auth.consumers[]` entry in `switchroom.yaml` (e.g. `/run/consumer-creds/hindsight`), then `switchroom apply` + recreate the auth-broker and hindsight containers. The hindsight consumer entry already carries `uid: 11000`, which the broker chowns the pushed file to.

**Ordering note (verified live, compose v5.1.3):** apply the main switchroom project (broker) before/with hindsight start. If `switchroom memory setup`'s docker-run path happens to create the volume first (unlabeled), the next `docker compose up` on the main project still succeeds — it warns and adopts the pre-existing volume (explicit `name:` reuses it; verified live, documented in compose.ts). The hindsight compose *snippet* is stricter: it declares the volume `external: true`, so the main project (or a prior docker run) must have created it first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
