### PR TITLE
docs(vault): document combined-backup exfil path for machine-id auto-unlock (sec WS2-1 #1449)

### DIFF
--- a/docs/auto-unlock.md
+++ b/docs/auto-unlock.md
@@ -38,12 +38,14 @@ unlock`).
 
 **What the encrypted blob protects against:**
 
-- **Disk theft.** The encryption key is derived from your machine's
-  `/etc/machine-id`, which doesn't travel with the disk image. If
-  someone copies your home directory or grabs the disk and mounts it on
-  another machine, the auto-unlock blob is unrecoverable garbage on the
-  other box. Brute-forcing it requires guessing a 128-bit key — not a
-  threat anyone has the budget for.
+- **Theft of the home directory alone (without `/etc/machine-id`).** The
+  encryption key is derived from your machine's `/etc/machine-id`, which
+  lives under `/etc` and doesn't sit inside your home directory. If
+  someone copies only your home directory and mounts it on another
+  machine, the auto-unlock blob is unrecoverable garbage on the other
+  box. Brute-forcing it requires guessing a 128-bit key — not a threat
+  anyone has the budget for. This protection holds only when the copy
+  leaves `machine-id` behind — see "Combined-backup exfiltration" below.
 - **Other users on the same machine.** The blob lives at mode 0600 in
   your home directory. Other UNIX users on the same box can't read it.
 
@@ -58,6 +60,14 @@ unlock`).
 - **Your user account being compromised.** Same model as the vault
   itself — if an attacker reads your home directory, they can read both
   the auto-unlock blob and the vault file.
+- **Combined-backup exfiltration.** Machine-binding defends only against
+  theft of the home directory *alone*. Any single artifact that captures
+  BOTH `/etc/machine-id` and the blob — a full-disk image, a full-system
+  backup, or `rsync -a /` — carries the key material off-box, so the blob
+  is decryptable on another machine and reduces to passphrase-only
+  protection. Backup hygiene: exclude `~/.switchroom/vault-auto-unlock`
+  or `/etc/machine-id` from off-box backups, or treat any backup that
+  captures both as passphrase-protected only.
 
 ## When it breaks
 

--- a/src/vault/auto-unlock.ts
+++ b/src/vault/auto-unlock.ts
@@ -12,10 +12,12 @@
  * ## Threat model
  *
  * What this protects against:
- *   - **Disk theft.** The encryption key is derived from /etc/machine-id,
- *     which is per-machine and not stored on the data disk in a portable
- *     form. An attacker who steals just the disk image (or copies the home
- *     directory) cannot decrypt the auto-unlock blob on a different machine.
+ *   - **Theft of the home directory alone.** The encryption key is derived
+ *     from /etc/machine-id, which is per-machine and lives under /etc — not
+ *     inside the home directory. An attacker who copies only the home dir
+ *     (or a home-scoped file-level backup that excludes /etc) cannot decrypt
+ *     the auto-unlock blob on a different machine. NOTE: this holds only when
+ *     machine-id is left behind — see "Combined-backup exfiltration" below.
  *   - **Casual snooping by other UNIX users on the same box.** The blob
  *     lives at mode 0600 in the user's home; only the owning user (and root)
  *     can read it.
@@ -26,6 +28,13 @@
  *     ssh-agent, gnome-keyring, systemd-creds host scope).
  *   - **The user account being compromised.** Same as the vault itself —
  *     the attacker who can read your home can read the vault.
+ *   - **Combined-backup exfiltration.** Machine-binding defends only against
+ *     theft of the home directory *alone*. Any single artifact that captures
+ *     BOTH /etc/machine-id and the blob — a full-disk image, a full-system
+ *     backup, `rsync -a /` — carries the key material with it, so the blob is
+ *     decryptable off-box and reduces to passphrase-only protection. Scope
+ *     off-box backups accordingly: exclude ~/.switchroom/vault-auto-unlock or
+ *     /etc/machine-id, or treat any such backup as passphrase-protected only.
  *
  * Why machine-id and not TPM? TPM2 sealing is stronger, but it's also
  * fragile across kernel updates, firmware changes, and bare-metal moves —


### PR DESCRIPTION
## Summary

Documentation-only fix for the machine-id vault auto-unlock threat model, implementing exactly the doc fix requested in the Batch O1 evaluation report on #1449.

The existing threat model claimed disk theft was defeated, but the "steals **just** the disk image" phrasing silently assumed `/etc/machine-id` was absent. A full-disk image, full-system backup, or `rsync -a /` captures BOTH the vault blob and `/etc/machine-id` in one artifact — so the blob is decryptable off-box and reduces to passphrase-only protection.

## Changes

- `src/vault/auto-unlock.ts` header docstring: soften the disk-theft bullet to theft of the **home directory alone** (machine-id lives under `/etc`, not the home dir), and add a **Combined-backup exfiltration** bullet with backup-hygiene guidance.
- `docs/auto-unlock.md`: same softening of the "Disk theft" bullet, a matching **Combined-backup exfiltration** entry in "What it does NOT protect against", and one sentence of backup-hygiene guidance (exclude `~/.switchroom/vault-auto-unlock` or `/etc/machine-id` from off-box backups, or treat the blob as passphrase-protected only).

No code behaviour change — docstring/markdown only.

## Why

Ref #1449 and the Batch O1 coordinator evaluation comment (https://github.com/switchroom/switchroom/issues/1449). That report found the docs half was NOT done (the prior audit overstated it) and the existing wording was actively misleading for the combined-backup case.

The **inode / hardware (DMI) binding** half of #1449 is **analyzed-and-declined** per that evaluation report: inode binding gives ~zero gain against the combined-backup adversary while risking unattended-boot lockout on routine restore/rsync/fs-migration; DMI `product_uuid` binding is root-readable-only and frequently unreadable in the `cap_drop=ALL` broker container. Recommendation was to ship this doc fix as the higher-value mitigation and, at most, offer DMI as a default-OFF opt-in. The operator can reopen if they want the opt-in DMI variant.

## Test plan

- `npm run lint` — clean (tsc + all 8 guard scripts pass).
- No test changes (docs/comments only).

## Risk

None — documentation only, no runtime code path touched.

Job spec: this is a security-hardening/operator-docs change; advances the "subscription-honest / operator trust" surface by making the vault threat model honest about backup exfiltration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)