### PR TITLE
fix(status-pin): rights-aware negative cache stops pin-rights 400 log spam

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -112,7 +112,7 @@ import {
 import type { WebhookGatewayRecord } from '../../src/web/webhook-gateway-record.js'
 import { reconcilePin, type PinBotApi } from '../status-pin-driver.js'
 import type { PinState, DesiredPin } from '../status-pin.js'
-import { decidePinAction } from '../status-pin.js'
+import { decidePinAction, PinRightsCache } from '../status-pin.js'
 import { formatTurnLifecycle, detectStatusSurfaceDegraded } from './status-surface-log.js'
 import { parseSourceMessageId } from './source-message-id.js'
 import {
@@ -7210,6 +7210,12 @@ const statusPinChatIds = new Map<string, string>()
 // re-pin of the same key keeps the original timestamp). Feeds the TTL gate of
 // the mid-session `wk:` pin reaper (#3001); cleared alongside the state.
 const statusPinPinnedAt = new Map<string, number>()
+// Rights-aware negative cache (#3024): chats where an auto status-pin attempt
+// failed with the permanent "not enough rights to manage pinned messages" 400.
+// Per-process only — a restart clears it so a later-granted pin right re-enables
+// auto-pin. The explicit `pin_message` MCP tool deliberately does NOT consult
+// this cache (it always attempts and surfaces the error to the agent).
+const statusPinRightsCache = new PinRightsCache()
 
 // Durable snapshot of the pin claim set on the persistent per-agent volume
 // (STATE_DIR = /state/agent/telegram in prod). Closes the crash hole: the
@@ -7743,6 +7749,16 @@ async function reconcileStatusPinInner(
       chatId,
       prevState: prev,
       desired,
+      rightsCache: statusPinRightsCache,
+      onPinRightsDisabled: (chat) => {
+        // Logged ONCE per chat per process (#3024). Every subsequent auto-pin
+        // attempt in this chat is skipped silently until a restart clears the
+        // cache — replacing the 41x/48h `status-pin pin failed` spam marko saw.
+        process.stderr.write(
+          `telegram gateway: status-pin disabled for chat ${chat}: bot lacks ` +
+            `pin rights; grant 'Pin messages' admin right to re-enable after restart\n`,
+        )
+      },
       onError: (phase, err) => {
         const msg = err instanceof Error ? err.message : String(err)
         process.stderr.write(
@@ -13955,6 +13971,12 @@ async function executePinMessage(args: Record<string, unknown>): Promise<unknown
     () => lockedBot.api.pinChatMessage(pinChatId, pinMsgId),
     { chat_id: pinChatId, verb: 'pin_message' },
   )
+  // An explicit pin succeeded here, so the bot demonstrably HAS pin rights in
+  // this chat now — clear any auto-pin negative-cache entry (#3024) so the auto
+  // status-pin path resumes immediately rather than waiting for a restart. The
+  // explicit tool itself never consults the cache; a failure above still
+  // surfaces to the agent as a normal tool error (robustApiCall rethrows).
+  statusPinRightsCache.clear(pinChatId)
   // #3001: register the tool pin in the shared status-pin store under a
   // `tool:` key so it is no longer fire-and-forget. Unlike work-scoped
   // fg:/wk: rows a tool pin has no "work finished" event, so a restart does

--- a/telegram-plugin/status-pin-driver.ts
+++ b/telegram-plugin/status-pin-driver.ts
@@ -29,8 +29,8 @@
  * job spec.
  */
 
-import type { PinState, DesiredPin } from './status-pin.js'
-import { decidePinAction } from './status-pin.js'
+import type { PinState, DesiredPin, PinRightsCache } from './status-pin.js'
+import { decidePinAction, isPinRightsError } from './status-pin.js'
 
 /** Minimal subset of grammy's `bot.api` the pin driver depends on.
  *  Lets tests swap in a fake without dragging in the full Bot type. */
@@ -55,6 +55,16 @@ export interface ReconcilePinArgs {
   desired: DesiredPin
   /** Optional API-failure observer. Default: silent. */
   onError?: (phase: 'pin' | 'unpin', err: unknown) => void
+  /** Optional per-process rights-aware negative cache (issue #3024). When a
+   *  pin attempt fails with the permanent "not enough rights" 400, the chat is
+   *  recorded and all subsequent pin attempts in it are skipped (no API call,
+   *  no log). Omit to disable the cache entirely (the pre-#3024 behaviour). */
+  rightsCache?: PinRightsCache
+  /** Called EXACTLY ONCE per chat, the first time that chat is recorded as
+   *  pin-incapable. Lets the caller emit a single warn line instead of the
+   *  per-attempt `status-pin pin failed` spam. Only fires when `rightsCache`
+   *  is supplied. */
+  onPinRightsDisabled?: (chatId: string) => void
 }
 
 /**
@@ -77,10 +87,15 @@ export async function reconcilePin(
   if (action.kind === 'noop') return args.prevState
 
   if (action.kind === 'unpin') {
-    try {
-      await args.api.unpinChatMessage(args.chatId, action.messageId)
-    } catch (err) {
-      args.onError?.('unpin', err)
+    // Skip the unpin API call in a chat the bot can't manage pins in — the
+    // call would fail with the same rights 400 and spam the log. The claim is
+    // dropped either way (below), so skipping is safe.
+    if (!args.rightsCache?.isBlocked(args.chatId)) {
+      try {
+        await args.api.unpinChatMessage(args.chatId, action.messageId)
+      } catch (err) {
+        args.onError?.('unpin', err)
+      }
     }
     // Drop the claim regardless of the unpin outcome. A stuck claim would
     // leave a permanent pin on a crash / out-of-band unpin — the exact
@@ -89,14 +104,33 @@ export async function reconcilePin(
   }
 
   // action.kind === 'pin' — pin an EXISTING message, silently.
+  // Rights-aware negative cache (issue #3024): if a prior attempt in this chat
+  // already failed with the permanent "not enough rights" 400, skip silently —
+  // no API call, no log. Don't claim the message (the pin never happened), so a
+  // later reconcile after a restart (cache cleared) can retry.
+  if (args.rightsCache?.isBlocked(args.chatId)) {
+    return args.prevState
+  }
   try {
     await args.api.pinChatMessage(args.chatId, action.messageId, {
       disable_notification: true,
     })
   } catch (err) {
-    args.onError?.('pin', err)
+    // A permanent pin-rights failure enters the negative cache and logs ONCE
+    // (via onPinRightsDisabled) — every subsequent attempt in this chat is then
+    // skipped above. Transient failures (429 / 5xx / network) are NOT cached
+    // and route through onError as before, preserving retry behaviour.
+    if (args.rightsCache && isPinRightsError(err)) {
+      const firstTime = args.rightsCache.block(args.chatId)
+      if (firstTime) args.onPinRightsDisabled?.(args.chatId)
+    } else {
+      args.onError?.('pin', err)
+    }
     // Don't claim a message we failed to pin — the next reconcile retries.
     return args.prevState
   }
+  // Pin succeeded — if this chat was previously cached as pin-incapable, rights
+  // were granted since; forget it so we resume normal behaviour immediately.
+  args.rightsCache?.clear(args.chatId)
   return { messageId: action.messageId }
 }

--- a/telegram-plugin/status-pin-driver.ts
+++ b/telegram-plugin/status-pin-driver.ts
@@ -94,7 +94,18 @@ export async function reconcilePin(
       try {
         await args.api.unpinChatMessage(args.chatId, action.messageId)
       } catch (err) {
-        args.onError?.('unpin', err)
+        // Symmetric with the pin path below: a permanent rights 400 on UNPIN
+        // (rights revoked mid-session after we pinned) also enters the
+        // negative cache and logs once via onPinRightsDisabled — otherwise
+        // every later unpin attempt would burn an API call and spam
+        // `status-pin unpin failed` per attempt, the exact class this cache
+        // exists to kill (#3073 review finding). Claim is dropped regardless.
+        if (args.rightsCache && isPinRightsError(err)) {
+          const firstTime = args.rightsCache.block(args.chatId)
+          if (firstTime) args.onPinRightsDisabled?.(args.chatId)
+        } else {
+          args.onError?.('unpin', err)
+        }
       }
     }
     // Drop the claim regardless of the unpin outcome. A stuck claim would

--- a/telegram-plugin/status-pin.ts
+++ b/telegram-plugin/status-pin.ts
@@ -74,3 +74,84 @@ export function decidePinAction(
   // re-pins the new one on the next reconcile.
   return { kind: 'unpin', messageId: prev.messageId }
 }
+
+/** Extract a lowercased human description from any thrown value, preferring
+ *  grammy's structured `.description` (the wire text Telegram returned) and
+ *  falling back to `.message` / String(). Kept dependency-free — matches on
+ *  the wire text, never on a grammy class import. */
+function errorDescription(err: unknown): string {
+  if (err != null && typeof err === 'object') {
+    const o = err as { description?: unknown; message?: unknown }
+    if (typeof o.description === 'string' && o.description.length > 0) {
+      return o.description.toLowerCase()
+    }
+    if (typeof o.message === 'string' && o.message.length > 0) {
+      return o.message.toLowerCase()
+    }
+  }
+  return String(err).toLowerCase()
+}
+
+/**
+ * True when a pin/unpin failure is the PERMANENT "the bot lacks pin rights in
+ * this chat" class — Telegram returns this as a 400 (not a 403):
+ * "not enough rights to manage pinned messages in the chat". This is the one
+ * error class that will NOT self-heal on retry: the bot is simply not an admin
+ * (or lacks the "Pin messages" right) in that supergroup, and every subsequent
+ * pin attempt in the same chat fails identically until an admin grants the
+ * right (which only takes effect after a gateway restart re-reads chat perms).
+ *
+ * Transient classes (429 flood-wait, 5xx, network HttpError) are deliberately
+ * EXCLUDED — they must keep the existing retry behaviour, never enter the
+ * negative cache. Only this permanent-rights class is cacheable.
+ *
+ * The single source of truth for the pin-rights concept: the gateway's
+ * `unhandled-rejection-policy.ts` and the various edit-error classifiers each
+ * fold `not enough rights` into a broader boolean for their own purpose; this
+ * is the one helper dedicated to the pin negative-cache decision.
+ */
+export function isPinRightsError(err: unknown): boolean {
+  return errorDescription(err).includes('not enough rights')
+}
+
+/**
+ * Per-process, per-chat negative cache for chats the bot cannot pin in.
+ *
+ * When an auto status-pin attempt fails with the permanent pin-rights 400
+ * (`isPinRightsError`), the chat is recorded here as pin-incapable so the
+ * driver skips every subsequent auto-pin attempt in that chat — no wasted API
+ * call, no repeated `status-pin pin failed` log line (issue #3024: marko logged
+ * 41 identical pin-rights rejections in 48h, one per attempt).
+ *
+ * Deliberately IN-MEMORY / per-boot only: pin rights may be granted later, and
+ * Telegram surfaces the new permission to the bot only on a fresh chat-member
+ * fetch — a gateway restart. Clearing the cache on restart is therefore the
+ * correct re-enable trigger. An explicit `pin_message` tool success in a chat
+ * also clears its entry (rights were granted mid-session).
+ *
+ * Scope: the AUTO status-pin path only. The explicit `pin_message` MCP tool
+ * never consults this cache — it always attempts and surfaces the error to the
+ * agent as a normal tool error.
+ */
+export class PinRightsCache {
+  private readonly blocked = new Set<string>()
+
+  /** True when auto-pin should be skipped for this chat (already known bad). */
+  isBlocked(chatId: string): boolean {
+    return this.blocked.has(chatId)
+  }
+
+  /** Record a chat as pin-incapable. Returns `true` only the FIRST time a chat
+   *  is added, so the caller can log the warn line exactly once per chat. */
+  block(chatId: string): boolean {
+    if (this.blocked.has(chatId)) return false
+    this.blocked.add(chatId)
+    return true
+  }
+
+  /** Forget a chat (rights re-granted, e.g. an explicit pin later succeeded).
+   *  Returns `true` if an entry was actually removed. */
+  clear(chatId: string): boolean {
+    return this.blocked.delete(chatId)
+  }
+}

--- a/telegram-plugin/tests/status-pin.test.ts
+++ b/telegram-plugin/tests/status-pin.test.ts
@@ -401,6 +401,40 @@ describe('reconcilePin — rights-aware negative cache (#3024)', () => {
     expect(cache.isBlocked('-1009000000004')).toBe(false)
   })
 
+  it('UNPIN rights-failure (rights revoked mid-session) blocks the chat, logs once, second unpin makes no API call', async () => {
+    const cache = new PinRightsCache()
+    const disabled: string[] = []
+    const unpinFails: string[] = []
+    let unpinCalls = 0
+    const api: PinBotApi = {
+      pinChatMessage: async () => {},
+      unpinChatMessage: async () => {
+        unpinCalls += 1
+        throw rightsErr()
+      },
+    }
+    const common = {
+      api,
+      chatId: '-1009000000007',
+      desired: { pinned: false } as const,
+      rightsCache: cache,
+      onPinRightsDisabled: (chat: string) => disabled.push(chat),
+      onError: (phase: 'pin' | 'unpin') => unpinFails.push(phase),
+    }
+
+    const first = await reconcilePin({ ...common, prevState: { messageId: 21 } })
+    expect(first).toBeNull() // claim dropped regardless (drop-on-unpin contract)
+    expect(unpinCalls).toBe(1) // it did try once
+    expect(disabled).toEqual(['-1009000000007']) // logged exactly once
+    expect(unpinFails).toEqual([]) // NOT routed through per-attempt onError
+    expect(cache.isBlocked('-1009000000007')).toBe(true)
+
+    const second = await reconcilePin({ ...common, prevState: { messageId: 22 } })
+    expect(second).toBeNull() // claim still dropped
+    expect(unpinCalls).toBe(1) // second attempt short-circuited before the API
+    expect(disabled).toEqual(['-1009000000007']) // no second log
+  })
+
   it('a blocked chat skips the UNPIN api call too (drops the claim silently)', async () => {
     const cache = new PinRightsCache()
     cache.block('-1009000000005')

--- a/telegram-plugin/tests/status-pin.test.ts
+++ b/telegram-plugin/tests/status-pin.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { GrammyError } from 'grammy'
-import { decidePinAction } from '../status-pin.js'
+import { decidePinAction, isPinRightsError, PinRightsCache } from '../status-pin.js'
 import { reconcilePin, type PinBotApi } from '../status-pin-driver.js'
 import type { PinState } from '../status-pin.js'
 
@@ -193,6 +193,246 @@ describe('reconcilePin — pin-rights 400 must never crash (marko 2026-07-01)', 
         onError: () => {},
       })
       // Let microtasks + a macrotask flush so any leaked rejection would fire.
+      await new Promise((r) => setTimeout(r, 20))
+      expect(rejections).toEqual([])
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
+  })
+})
+
+// ── #3024: rights-aware negative cache ─────────────────────────────────────
+// marko logged 41 identical `pinChatMessage` "not enough rights" rejections in
+// 48h — one per auto status-pin attempt in a group where the bot isn't a pin
+// admin. The permanent-rights class is now cached per-chat so the SECOND and
+// later attempts skip the API call entirely and stop spamming the log. Synthetic
+// chat IDs only (the real ones in the issue are operator PII).
+describe('isPinRightsError (pure classifier)', () => {
+  it('matches the permanent pin-rights 400 (grammy .description)', () => {
+    expect(
+      isPinRightsError(
+        grammyError(400, 'Bad Request: not enough rights to manage pinned messages in the chat'),
+      ),
+    ).toBe(true)
+  })
+
+  it('matches a plain Error carrying the rights text', () => {
+    expect(isPinRightsError(new Error('not enough rights to manage pinned messages'))).toBe(true)
+  })
+
+  it('does NOT match transient classes (429 flood-wait, network)', () => {
+    expect(isPinRightsError(grammyError(429, 'Too Many Requests: retry after 5'))).toBe(false)
+    expect(isPinRightsError(new Error('fetch failed'))).toBe(false)
+    expect(isPinRightsError(grammyError(400, 'Bad Request: message to edit not found'))).toBe(false)
+  })
+})
+
+describe('PinRightsCache (pure)', () => {
+  it('block() returns true only the first time a chat is added (log-once)', () => {
+    const cache = new PinRightsCache()
+    expect(cache.isBlocked('-1009000000001')).toBe(false)
+    expect(cache.block('-1009000000001')).toBe(true)
+    expect(cache.block('-1009000000001')).toBe(false)
+    expect(cache.isBlocked('-1009000000001')).toBe(true)
+  })
+
+  it('clear() forgets a chat (rights re-granted)', () => {
+    const cache = new PinRightsCache()
+    cache.block('-1009000000001')
+    expect(cache.clear('-1009000000001')).toBe(true)
+    expect(cache.isBlocked('-1009000000001')).toBe(false)
+    expect(cache.clear('-1009000000001')).toBe(false)
+  })
+})
+
+/** A fake Bot API counting pin calls, throwing a chosen error on pin. */
+function countingApi(pinError?: unknown) {
+  let pinCalls = 0
+  let unpinCalls = 0
+  const api: PinBotApi = {
+    pinChatMessage: async () => {
+      pinCalls += 1
+      if (pinError) throw pinError
+    },
+    unpinChatMessage: async () => {
+      unpinCalls += 1
+    },
+  }
+  return {
+    api,
+    get pinCalls() {
+      return pinCalls
+    },
+    get unpinCalls() {
+      return unpinCalls
+    },
+  }
+}
+
+describe('reconcilePin — rights-aware negative cache (#3024)', () => {
+  const rightsErr = () =>
+    grammyError(400, 'Bad Request: not enough rights to manage pinned messages in the chat')
+
+  it('first rights failure: attempts once, logs once, records the chat', async () => {
+    const cache = new PinRightsCache()
+    const disabled: string[] = []
+    const pinFails: string[] = []
+    const t = countingApi(rightsErr())
+
+    const next = await reconcilePin({
+      api: t.api,
+      chatId: '-1009000000001',
+      prevState: null,
+      desired: { pinned: true, messageId: 4 },
+      rightsCache: cache,
+      onPinRightsDisabled: (chat) => disabled.push(chat),
+      onError: (phase) => pinFails.push(phase),
+    })
+
+    expect(t.pinCalls).toBe(1) // it did try
+    expect(next).toBeNull() // no claim taken
+    expect(disabled).toEqual(['-1009000000001']) // logged once
+    expect(pinFails).toEqual([]) // NOT routed through the per-attempt onError
+    expect(cache.isBlocked('-1009000000001')).toBe(true)
+  })
+
+  it('second attempt in the same chat makes NO api call and logs nothing', async () => {
+    const cache = new PinRightsCache()
+    const disabled: string[] = []
+    const pinFails: string[] = []
+    const t = countingApi(rightsErr())
+
+    const common = {
+      chatId: '-1009000000001',
+      prevState: null,
+      desired: { pinned: true, messageId: 4 } as const,
+      rightsCache: cache,
+      onPinRightsDisabled: (chat: string) => disabled.push(chat),
+      onError: (phase: 'pin' | 'unpin') => pinFails.push(phase),
+    }
+
+    await reconcilePin({ api: t.api, ...common })
+    await reconcilePin({ api: t.api, ...common })
+
+    expect(t.pinCalls).toBe(1) // second attempt short-circuited before the API
+    expect(disabled).toEqual(['-1009000000001']) // still logged exactly once
+    expect(pinFails).toEqual([])
+  })
+
+  it('a DIFFERENT chat is unaffected by another chat being blocked', async () => {
+    const cache = new PinRightsCache()
+    cache.block('-1009000000001')
+    const t = countingApi() // pin succeeds here
+
+    const next = await reconcilePin({
+      api: t.api,
+      chatId: '-1009000000002',
+      prevState: null,
+      desired: { pinned: true, messageId: 7 },
+      rightsCache: cache,
+      onPinRightsDisabled: () => {
+        throw new Error('should not disable a healthy chat')
+      },
+    })
+
+    expect(t.pinCalls).toBe(1)
+    expect(next).toEqual({ messageId: 7 })
+    expect(cache.isBlocked('-1009000000002')).toBe(false)
+  })
+
+  it('a 429 (transient) does NOT enter the cache — retry behaviour preserved', async () => {
+    const cache = new PinRightsCache()
+    const disabled: string[] = []
+    const pinFails: string[] = []
+    const t = countingApi(grammyError(429, 'Too Many Requests: retry after 5'))
+
+    await reconcilePin({
+      api: t.api,
+      chatId: '-1009000000003',
+      prevState: null,
+      desired: { pinned: true, messageId: 9 },
+      rightsCache: cache,
+      onPinRightsDisabled: (chat) => disabled.push(chat),
+      onError: (phase) => pinFails.push(phase),
+    })
+
+    expect(cache.isBlocked('-1009000000003')).toBe(false) // NOT cached
+    expect(disabled).toEqual([]) // no rights-disable log
+    expect(pinFails).toEqual(['pin']) // routed through onError → normal retry path
+
+    // A follow-up attempt still hits the API (no negative cache in the way).
+    await reconcilePin({
+      api: t.api,
+      chatId: '-1009000000003',
+      prevState: null,
+      desired: { pinned: true, messageId: 9 },
+      rightsCache: cache,
+      onError: (phase) => pinFails.push(phase),
+    })
+    expect(t.pinCalls).toBe(2)
+  })
+
+  it('a later successful pin clears a previously-blocked chat', async () => {
+    const cache = new PinRightsCache()
+    cache.block('-1009000000004')
+    const t = countingApi() // succeeds
+
+    // While blocked, the pin is skipped (no claim, no API call).
+    const skipped = await reconcilePin({
+      api: t.api,
+      chatId: '-1009000000004',
+      prevState: null,
+      desired: { pinned: true, messageId: 3 },
+      rightsCache: cache,
+    })
+    expect(skipped).toBeNull()
+    expect(t.pinCalls).toBe(0)
+
+    // Simulate rights granted: unblock, then a pin succeeds and stays clear.
+    cache.clear('-1009000000004')
+    const next = await reconcilePin({
+      api: t.api,
+      chatId: '-1009000000004',
+      prevState: null,
+      desired: { pinned: true, messageId: 3 },
+      rightsCache: cache,
+    })
+    expect(next).toEqual({ messageId: 3 })
+    expect(cache.isBlocked('-1009000000004')).toBe(false)
+  })
+
+  it('a blocked chat skips the UNPIN api call too (drops the claim silently)', async () => {
+    const cache = new PinRightsCache()
+    cache.block('-1009000000005')
+    const t = countingApi()
+
+    const next = await reconcilePin({
+      api: t.api,
+      chatId: '-1009000000005',
+      prevState: { messageId: 12 },
+      desired: { pinned: false },
+      rightsCache: cache,
+    })
+
+    expect(next).toBeNull() // claim dropped
+    expect(t.unpinCalls).toBe(0) // but no wasted API call
+  })
+
+  it('fire-and-forget with the cache leaks NO unhandledRejection', async () => {
+    const rejections: unknown[] = []
+    const onUnhandled = (err: unknown) => rejections.push(err)
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      const cache = new PinRightsCache()
+      const t = countingApi(rightsErr())
+      void reconcilePin({
+        api: t.api,
+        chatId: '-1009000000006',
+        prevState: null,
+        desired: { pinned: true, messageId: 4 },
+        rightsCache: cache,
+        onPinRightsDisabled: () => {},
+      })
       await new Promise((r) => setTimeout(r, 20))
       expect(rejections).toEqual([])
     } finally {


### PR DESCRIPTION
## Summary

Auto status-pin in a group where the bot is not a pin admin fails with a
permanent `400: not enough rights to manage pinned messages`. marko logged
**41 identical rejections in 48h** — one per attempt — plus a
`status-pin pin failed (key=fg:...)` stderr line on every attempt.

This adds a per-process, per-chat **rights-aware negative cache** so the first
permanent-rights failure in a chat disables auto-pin there (logged once), and
every later attempt skips the API call silently.

## Why

- `#2736` already made the pin-rights 400 non-fatal (`reconcileStatusPin`
  absorbs; the `unhandledRejection` policy downgrades it to `log_only`), so the
  crash is fixed. The **remaining** problem is pure log/API spam: nothing
  remembered that the chat is pin-incapable, so it retried and re-logged on
  every turn.
- Root cause of the origin `unhandledRejection` the issue cites: the
  fire-and-forget `void reconcileStatusPin(...)` auto-pin callsites — already
  guarded by `#2736`'s absorb + the `not enough rights` entry in
  `unhandled-rejection-policy.ts`. This PR closes the log-spam that remained
  after that crash fix, and keeps a fire-and-forget-safe regression test.

## What changed

- `telegram-plugin/status-pin.ts` — pure `isPinRightsError(err)` classifier
  (matches only the permanent `not enough rights` class; excludes 429/5xx/net)
  and a `PinRightsCache` (per-process `Set<chatId>`; `block()` returns
  log-once, `clear()` on re-grant).
- `telegram-plugin/status-pin-driver.ts` — `reconcilePin` consults the cache:
  skip pin/unpin API calls in a blocked chat, cache + fire `onPinRightsDisabled`
  once on the first permanent failure, clear on success. Transient failures
  still route through `onError` (retry unchanged).
- `telegram-plugin/gateway/gateway.ts` — one module-level `statusPinRightsCache`
  wired into the auto-pin path with a single warn line per chat; explicit
  `pin_message` tool clears the entry on success and never consults the cache.
- `telegram-plugin/tests/status-pin.test.ts` — outcome tests: first attempt
  logs once + returns cleanly; second attempt makes NO api call + logs nothing;
  different chat unaffected; 429 not cached; success clears; blocked chat skips
  unpin too; fire-and-forget leaks no `unhandledRejection`. Synthetic chat IDs.

## Test plan

- `vitest run telegram-plugin/tests/status-pin.test.ts` → 24/24 pass.
- `npm run lint` (tsc + 8 guards incl. `check-bot-api-wrapping`,
  `check-no-pii-secrets`) → clean.

## Risk

Low. Behaviour change is scoped to the auto status-pin path (`fg:`/`wk:` keys);
the slot banner and explicit `pin_message` tool are untouched. Cache is
per-boot in-memory only — a restart re-enables auto-pin, which is also when
Telegram re-surfaces a newly granted pin right to the bot.

Job spec: `reference/jobs/know-what-my-agent-is-doing.md`

Fixes #3024

🤖 Generated with [Claude Code](https://claude.com/claude-code)