### PR TITLE
fix(gateway): clear stale stacked pins in DM chats (#3026)

### DIFF
--- a/telegram-plugin/gateway/dm-pin-sweep.test.ts
+++ b/telegram-plugin/gateway/dm-pin-sweep.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  isDmChatId,
+  collectDmChatIdsFromStores,
+  createDmPinSweeper,
+  type DmPinSweeperDeps,
+} from './dm-pin-sweep'
+
+// Synthetic chat IDs only (check-no-pii-secrets): positive = DM, negative =
+// group/supergroup.
+const DM_A = '5000001'
+const DM_B = '5000002'
+const GROUP = '-1002000000001'
+
+describe('isDmChatId', () => {
+  it('true for positive integer DM ids', () => {
+    expect(isDmChatId(DM_A)).toBe(true)
+    expect(isDmChatId('1')).toBe(true)
+  })
+  it('false for group/supergroup (negative), zero, non-integer, non-numeric', () => {
+    expect(isDmChatId(GROUP)).toBe(false)
+    expect(isDmChatId('-1')).toBe(false)
+    expect(isDmChatId('0')).toBe(false)
+    expect(isDmChatId('1.5')).toBe(false)
+    expect(isDmChatId('abc')).toBe(false)
+    expect(isDmChatId('')).toBe(false)
+    expect(isDmChatId('Infinity')).toBe(false)
+  })
+})
+
+describe('collectDmChatIdsFromStores', () => {
+  it('collects distinct DM chat ids across all three stores and drops non-DMs', () => {
+    const ids = collectDmChatIdsFromStores({
+      statusPins: [{ chatId: DM_A }, { chatId: GROUP }, { chatId: DM_A }],
+      activityCards: [{ chatId: DM_B }, { chatId: '0' }],
+      queuedCards: [{ chatId: DM_A }, { chatId: '-77' }],
+    })
+    expect(new Set(ids)).toEqual(new Set([DM_A, DM_B]))
+    expect(ids).toHaveLength(2)
+  })
+  it('handles missing store arrays', () => {
+    expect(collectDmChatIdsFromStores({})).toEqual([])
+    expect(collectDmChatIdsFromStores({ statusPins: [{ chatId: GROUP }] })).toEqual([])
+  })
+})
+
+function makeDeps(overrides: Partial<DmPinSweeperDeps> = {}): {
+  deps: DmPinSweeperDeps
+  unpinAll: ReturnType<typeof vi.fn>
+  pinSilent: ReturnType<typeof vi.fn>
+} {
+  const unpinAll = vi.fn(async () => undefined)
+  const pinSilent = vi.fn(async () => undefined)
+  const deps: DmPinSweeperDeps = {
+    unpinAll,
+    pinSilent,
+    liveTrackedMessageIds: () => [],
+    eligible: () => true,
+    log: () => {},
+    ...overrides,
+  }
+  return { deps, unpinAll, pinSilent }
+}
+
+describe('createDmPinSweeper', () => {
+  it('DM with tracked pins: unpin-all exactly once, then re-pin exactly the live ids', async () => {
+    const { deps, unpinAll, pinSilent } = makeDeps({
+      liveTrackedMessageIds: (chatId) => (chatId === DM_A ? [111, 222] : []),
+    })
+    const sweeper = createDmPinSweeper(deps)
+    await sweeper.sweep(DM_A)
+
+    expect(unpinAll).toHaveBeenCalledTimes(1)
+    expect(unpinAll).toHaveBeenCalledWith(DM_A)
+    expect(pinSilent.mock.calls).toEqual([
+      [DM_A, 111],
+      [DM_A, 222],
+    ])
+    expect(sweeper.hasSwept(DM_A)).toBe(true)
+  })
+
+  it('DM with no tracked pins: unpin-all once, no re-pin', async () => {
+    const { deps, unpinAll, pinSilent } = makeDeps()
+    const sweeper = createDmPinSweeper(deps)
+    await sweeper.sweep(DM_A)
+    expect(unpinAll).toHaveBeenCalledTimes(1)
+    expect(pinSilent).not.toHaveBeenCalled()
+  })
+
+  it('group/supergroup id: never unpin-all (keeps human pins)', async () => {
+    const { deps, unpinAll, pinSilent } = makeDeps()
+    const sweeper = createDmPinSweeper(deps)
+    await sweeper.sweep(GROUP)
+    await sweeper.sweep('-1')
+    expect(unpinAll).not.toHaveBeenCalled()
+    expect(pinSilent).not.toHaveBeenCalled()
+  })
+
+  it('not eligible (lost startup mutex): does nothing', async () => {
+    const { deps, unpinAll } = makeDeps({ eligible: () => false })
+    const sweeper = createDmPinSweeper(deps)
+    await sweeper.sweep(DM_A)
+    expect(unpinAll).not.toHaveBeenCalled()
+    expect(sweeper.hasSwept(DM_A)).toBe(false)
+  })
+
+  it('second sweep of same chat does not re-sweep', async () => {
+    const { deps, unpinAll } = makeDeps()
+    const sweeper = createDmPinSweeper(deps)
+    await sweeper.sweep(DM_A)
+    await sweeper.sweep(DM_A)
+    expect(unpinAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('concurrent triggers on the same chat fire unpin-all only once', async () => {
+    let resolveUnpin: () => void = () => {}
+    const unpinAll = vi.fn(
+      () =>
+        new Promise<void>((res) => {
+          resolveUnpin = res
+        }),
+    )
+    const { deps } = makeDeps({ unpinAll })
+    const sweeper = createDmPinSweeper(deps)
+    const p1 = sweeper.sweep(DM_A)
+    const p2 = sweeper.sweep(DM_A)
+    resolveUnpin()
+    await Promise.all([p1, p2])
+    expect(unpinAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('429 / unpin-all rejects: degrades without throwing, still re-pins live ids', async () => {
+    const unpinAll = vi.fn(async () => {
+      throw new Error('429: Too Many Requests: retry after 30')
+    })
+    const { deps, pinSilent } = makeDeps({
+      unpinAll,
+      liveTrackedMessageIds: () => [333],
+    })
+    const sweeper = createDmPinSweeper(deps)
+    // Must not reject.
+    await expect(sweeper.sweep(DM_A)).resolves.toBeUndefined()
+    expect(unpinAll).toHaveBeenCalledTimes(1)
+    expect(pinSilent).toHaveBeenCalledWith(DM_A, 333)
+  })
+
+  it('re-pin failure is absorbed and does not reject', async () => {
+    const pinSilent = vi.fn(async () => {
+      throw new Error('pin failed')
+    })
+    const { deps } = makeDeps({
+      pinSilent,
+      liveTrackedMessageIds: () => [444],
+    })
+    const sweeper = createDmPinSweeper(deps)
+    await expect(sweeper.sweep(DM_A)).resolves.toBeUndefined()
+  })
+
+  it('no unhandled rejection escapes a failing sweep (fire-and-forget safe)', async () => {
+    const unhandled: unknown[] = []
+    const onUnhandled = (r: unknown): void => {
+      unhandled.push(r)
+    }
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      const { deps } = makeDeps({
+        unpinAll: async () => {
+          throw new Error('boom')
+        },
+        liveTrackedMessageIds: () => [555],
+      })
+      const sweeper = createDmPinSweeper(deps)
+      // Fire-and-forget, as the gateway does.
+      void sweeper.sweep(DM_A)
+      await new Promise((r) => setTimeout(r, 10))
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
+    expect(unhandled).toEqual([])
+  })
+})

--- a/telegram-plugin/gateway/dm-pin-sweep.test.ts
+++ b/telegram-plugin/gateway/dm-pin-sweep.test.ts
@@ -3,6 +3,7 @@ import {
   isDmChatId,
   collectDmChatIdsFromStores,
   createDmPinSweeper,
+  unexpiredStoreRepinIds,
   type DmPinSweeperDeps,
 } from './dm-pin-sweep'
 
@@ -177,5 +178,74 @@ describe('createDmPinSweeper', () => {
       process.off('unhandledRejection', onUnhandled)
     }
     expect(unhandled).toEqual([])
+  })
+})
+
+describe('tool-pin survival (#3001 contract, review blocker on #3074)', () => {
+  const NOW = 1_752_000_000_000
+
+  it('unexpiredStoreRepinIds keeps unexpired tool rows for the chat, drops expired / work-scoped / other-chat rows', () => {
+    const rows = [
+      // Unexpired tool pin in this chat — MUST survive.
+      { chatId: DM_A, messageId: 10, expiresAt: NOW + 60_000 },
+      // Expired tool pin — due for sweeping, NOT re-pinned.
+      { chatId: DM_A, messageId: 11, expiresAt: NOW - 1 },
+      // Work-scoped row (no expiresAt) — stale after restart, NOT re-pinned.
+      { chatId: DM_A, messageId: 12 },
+      // Unexpired tool pin in a DIFFERENT chat — not this chat's re-pin set.
+      { chatId: DM_B, messageId: 13, expiresAt: NOW + 60_000 },
+    ]
+    expect(unexpiredStoreRepinIds(rows, DM_A, NOW)).toEqual([10])
+    expect(unexpiredStoreRepinIds(rows, DM_B, NOW)).toEqual([13])
+  })
+
+  // Composition test mirroring the gateway wiring: liveTrackedMessageIds
+  // unions in-memory claims with unexpired store rows.
+  function gatewayStyleDeps(args: {
+    inMemory: number[]
+    storeRows: { chatId: string; messageId: number; expiresAt?: number }[]
+  }): ReturnType<typeof makeDeps> {
+    return makeDeps({
+      liveTrackedMessageIds: (chatId) => [
+        ...args.inMemory,
+        ...unexpiredStoreRepinIds(args.storeRows, chatId, NOW),
+      ],
+    })
+  }
+
+  it('(a) boot sweep: DM with an unexpired tool: row → unpinAll once, then that messageId re-pinned', async () => {
+    const { deps, unpinAll, pinSilent } = gatewayStyleDeps({
+      inMemory: [], // fresh boot — in-memory claims empty
+      storeRows: [{ chatId: DM_A, messageId: 777, expiresAt: NOW + 60_000 }],
+    })
+    const sweeper = createDmPinSweeper(deps)
+    await sweeper.sweep(DM_A)
+    expect(unpinAll).toHaveBeenCalledTimes(1)
+    expect(pinSilent.mock.calls).toEqual([[DM_A, 777]])
+  })
+
+  it('(b) expired tool: row is NOT re-pinned', async () => {
+    const { deps, unpinAll, pinSilent } = gatewayStyleDeps({
+      inMemory: [],
+      storeRows: [{ chatId: DM_A, messageId: 778, expiresAt: NOW - 1 }],
+    })
+    const sweeper = createDmPinSweeper(deps)
+    await sweeper.sweep(DM_A)
+    expect(unpinAll).toHaveBeenCalledTimes(1)
+    expect(pinSilent).not.toHaveBeenCalled()
+  })
+
+  it('(c) first-inbound sweep preserves an unexpired tool pin alongside a live in-memory claim, deduped', async () => {
+    const { deps, pinSilent } = gatewayStyleDeps({
+      inMemory: [500, 777], // live fg: claim + the tool pin also claimed in-memory
+      storeRows: [{ chatId: DM_A, messageId: 777, expiresAt: NOW + 60_000 }],
+    })
+    const sweeper = createDmPinSweeper(deps)
+    await sweeper.sweep(DM_A)
+    // 777 appears in BOTH sources but is re-pinned exactly once.
+    expect(pinSilent.mock.calls).toEqual([
+      [DM_A, 500],
+      [DM_A, 777],
+    ])
   })
 })

--- a/telegram-plugin/gateway/dm-pin-sweep.ts
+++ b/telegram-plugin/gateway/dm-pin-sweep.ts
@@ -1,0 +1,152 @@
+/**
+ * DM pin sweep (#3026) — durable clearing of stale bot-authored pins in
+ * user DM chats.
+ *
+ * Why this exists (two independent gaps the probe-based boot sweep can't
+ * close for DMs):
+ *
+ *   1. The boot pin sweep (`shouldSweepChatAtBoot`) deliberately SKIPS
+ *      positive (DM) chat IDs — the Bot API returns `400 chat not found`
+ *      for a user who never messaged the bot. So DM chats were never
+ *      boot-swept at all, and stale pins from a prior session lingered
+ *      across restarts (observed fleet-wide 2026-07-11).
+ *
+ *   2. Even when a DM chat IS reachable, `getChat()` exposes ONLY the
+ *      NEWEST pinned message. Telegram DMs STACK pins and the Bot API has
+ *      no list-pins method, so older orphan pins are invisible to a
+ *      probe-based (unpin-one-by-message-id) sweep forever.
+ *
+ * The durable fix, DM-only: call `unpinAllChatMessages` ONCE per DM chat
+ * per gateway boot (clearing the whole stack — safe in a DM, where
+ * virtually every pin is bot-authored), then immediately RE-PIN the live
+ * tracked cards from the in-memory pin claims (silent, `disable_notification`)
+ * so a genuinely in-flight status/worker pin survives the sweep.
+ *
+ * Groups/supergroups (negative IDs) are NOT touched here — an unpin-all
+ * there would nuke human pins. They keep the existing probe-based path.
+ *
+ * This module is the PURE half (chat-id classification, store→DM-chat-id
+ * collection, and a dependency-injected sweeper with the once-per-boot
+ * guard). The gateway binds the live Bot API + in-memory claim map.
+ */
+
+/**
+ * True iff `chatId` is a user DM chat: a positive integer. Group and
+ * supergroup IDs are negative; zero / non-numeric / non-integer are
+ * malformed and never DMs.
+ */
+export function isDmChatId(chatId: string): boolean {
+  const n = Number(chatId)
+  return Number.isFinite(n) && Number.isInteger(n) && n > 0
+}
+
+/**
+ * Collect the DISTINCT DM chat IDs that appear in ANY of the persisted pin
+ * stores — the set of DM chats the gateway has a record of having pinned
+ * something in during a prior session. These are the DM chats worth
+ * sweeping at boot (an unpin-all is wasted on a DM we never pinned in).
+ *
+ * Pure over its input records; callers pass the loaded store snapshots
+ * (status pins, activity cards, queued/busy-ack cards). Non-DM chat IDs
+ * are filtered out.
+ */
+export function collectDmChatIdsFromStores(input: {
+  statusPins?: readonly { chatId: string }[]
+  activityCards?: readonly { chatId: string }[]
+  queuedCards?: readonly { chatId: string }[]
+}): string[] {
+  const out = new Set<string>()
+  const add = (rows?: readonly { chatId: string }[]): void => {
+    if (rows == null) return
+    for (const r of rows) if (isDmChatId(r.chatId)) out.add(r.chatId)
+  }
+  add(input.statusPins)
+  add(input.activityCards)
+  add(input.queuedCards)
+  return [...out]
+}
+
+export interface DmPinSweeperDeps {
+  /** Clear EVERY pinned message in a chat. Bound to the gateway's
+   *  robust/retry API wrapper so a 429 flood-wait is retried, then
+   *  degrades (rejects) rather than crashing — the sweeper absorbs it. */
+  unpinAll: (chatId: string) => Promise<unknown>
+  /** Silently re-pin an EXISTING message (disable_notification). Bound to
+   *  the gateway's robust/retry API wrapper. */
+  pinSilent: (chatId: string, messageId: number) => Promise<unknown>
+  /** Live tracked pin message ids for a chat — the in-memory status-pin
+   *  claims still owned by an in-flight turn/worker. These are re-pinned
+   *  after the unpin-all so an active pin isn't collateral. Empty at boot
+   *  (fresh process, no live claims yet); non-empty on a first-inbound
+   *  sweep landing mid-turn. */
+  liveTrackedMessageIds: (chatId: string) => number[]
+  /** Gate: sweep ONLY when the gateway won the startup mutex. The stores
+   *  and the chat's pins are shared per-agent state; a LOSING double-boot
+   *  must never unpin the live holder's legitimate pins. */
+  eligible: () => boolean
+  /** Optional structured log sink. */
+  log?: (line: string) => void
+}
+
+export interface DmPinSweeper {
+  /**
+   * Sweep a single DM chat: unpin-all then re-pin live tracked cards.
+   * At most ONCE per chat per sweeper lifetime (one gateway boot). No-op
+   * for non-DM chats, when not eligible, or when already swept. Never
+   * throws — a failed unpin-all/re-pin degrades and is logged.
+   */
+  sweep(chatId: string): Promise<void>
+  /** True if this chat has already been swept this boot (test/observability). */
+  hasSwept(chatId: string): boolean
+}
+
+export function createDmPinSweeper(deps: DmPinSweeperDeps): DmPinSweeper {
+  const swept = new Set<string>()
+  return {
+    hasSwept: (chatId) => swept.has(chatId),
+    async sweep(chatId: string): Promise<void> {
+      if (!isDmChatId(chatId)) return
+      if (!deps.eligible()) return
+      if (swept.has(chatId)) return
+      // Claim the once-guard BEFORE the first await so two concurrent
+      // triggers (boot + first-inbound landing in the same tick) can't
+      // both fire the unpin-all.
+      swept.add(chatId)
+
+      // Snapshot live claims BEFORE the unpin-all so we know exactly which
+      // messages to restore.
+      const liveIds = deps.liveTrackedMessageIds(chatId)
+
+      try {
+        await deps.unpinAll(chatId)
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        deps.log?.(
+          `telegram gateway: dm-pin-sweep: unpin-all failed (chat=${chatId}): ${msg}\n`,
+        )
+        // Degrade: the stack may still hold stale pins, but we don't
+        // crash and we don't retry this boot. Fall through to re-pin the
+        // live claims (harmless if the unpin didn't land).
+      }
+
+      for (const messageId of liveIds) {
+        try {
+          await deps.pinSilent(chatId, messageId)
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          deps.log?.(
+            `telegram gateway: dm-pin-sweep: re-pin failed ` +
+              `(chat=${chatId} msg=${messageId}): ${msg}\n`,
+          )
+        }
+      }
+
+      if (liveIds.length > 0) {
+        deps.log?.(
+          `telegram gateway: dm-pin-sweep: cleared stacked pins in DM ${chatId}, ` +
+            `re-pinned ${liveIds.length} live card(s)\n`,
+        )
+      }
+    },
+  }
+}

--- a/telegram-plugin/gateway/dm-pin-sweep.ts
+++ b/telegram-plugin/gateway/dm-pin-sweep.ts
@@ -66,6 +66,31 @@ export function collectDmChatIdsFromStores(input: {
   return [...out]
 }
 
+/**
+ * The messageIds in `chatId` that must SURVIVE a DM unpin-all because they
+ * belong to deliberately-retained store rows: unexpired time-scoped `tool:`
+ * pins (the `pin_message` MCP tool, #3001), which `runStatusPinBootCleanup`
+ * intentionally KEEPS across restarts. Work-scoped rows (no `expiresAt`) are
+ * stale by definition after a restart and are NOT re-pin candidates; expired
+ * time-scoped rows are due for sweeping.
+ *
+ * Pure over a loaded store snapshot; the gateway binds a LIVE store read into
+ * `liveTrackedMessageIds` so BOTH the boot sweep and a first-inbound sweep
+ * see the kept rows (the in-memory claim maps are empty at boot).
+ */
+export function unexpiredStoreRepinIds(
+  rows: readonly { chatId: string; messageId: number; expiresAt?: number }[],
+  chatId: string,
+  now: number,
+): number[] {
+  const out: number[] = []
+  for (const r of rows) {
+    if (r.chatId !== chatId) continue
+    if (r.expiresAt != null && r.expiresAt > now) out.push(r.messageId)
+  }
+  return out
+}
+
 export interface DmPinSweeperDeps {
   /** Clear EVERY pinned message in a chat. Bound to the gateway's
    *  robust/retry API wrapper so a 429 flood-wait is retried, then
@@ -74,11 +99,11 @@ export interface DmPinSweeperDeps {
   /** Silently re-pin an EXISTING message (disable_notification). Bound to
    *  the gateway's robust/retry API wrapper. */
   pinSilent: (chatId: string, messageId: number) => Promise<unknown>
-  /** Live tracked pin message ids for a chat — the in-memory status-pin
-   *  claims still owned by an in-flight turn/worker. These are re-pinned
-   *  after the unpin-all so an active pin isn't collateral. Empty at boot
-   *  (fresh process, no live claims yet); non-empty on a first-inbound
-   *  sweep landing mid-turn. */
+  /** Pin message ids in this chat that must survive the unpin-all: the
+   *  in-memory status-pin claims still owned by an in-flight turn/worker,
+   *  UNIONED with the deliberately-retained store rows (unexpired `tool:`
+   *  pins, #3001 — see unexpiredStoreRepinIds). The gateway binds both
+   *  sources; duplicates are deduped by the sweeper before re-pinning. */
   liveTrackedMessageIds: (chatId: string) => number[]
   /** Gate: sweep ONLY when the gateway won the startup mutex. The stores
    *  and the chat's pins are shared per-agent state; a LOSING double-boot
@@ -114,8 +139,9 @@ export function createDmPinSweeper(deps: DmPinSweeperDeps): DmPinSweeper {
       swept.add(chatId)
 
       // Snapshot live claims BEFORE the unpin-all so we know exactly which
-      // messages to restore.
-      const liveIds = deps.liveTrackedMessageIds(chatId)
+      // messages to restore. Dedupe — the in-memory and store-row sources
+      // can both report the same messageId.
+      const liveIds = [...new Set(deps.liveTrackedMessageIds(chatId))]
 
       try {
         await deps.unpinAll(chatId)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -470,6 +470,11 @@ import { formatUpdateStatusLine } from './update-status-line.js'
 import type { HostdRequest, HostdResponse } from '../../src/host-control/protocol.js'
 import type { AgentAudit } from '../welcome-text.js'
 import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
+import {
+  createDmPinSweeper,
+  collectDmChatIdsFromStores,
+  type DmPinSweeper,
+} from './dm-pin-sweep.js'
 import { startWebhookIngestServer } from './webhook-ingest-server.js'
 import { recordWebhookEvent } from '../../src/web/webhook-gateway-record.js'
 
@@ -496,6 +501,7 @@ import {
   type TrackedStatusPin,
 } from './status-pin-store.js'
 import {
+  loadActivityCards,
   writeActivityCardRecord,
   clearActivityCardRecord,
   runActivityCardBootReaper,
@@ -504,6 +510,7 @@ import {
   type ActivityCardStoreFsSeam,
 } from './activity-card-store.js'
 import {
+  loadQueuedCards,
   writeQueuedCardRecord,
   clearQueuedCardRecord,
   runQueuedCardBootReaper,
@@ -7843,6 +7850,85 @@ async function unpinAllStatusPins(): Promise<void> {
   }
 }
 
+// ─── DM stale-pin sweep (#3026) ─────────────────────────────────────────────
+// In a user DM the Bot API skips the boot getChat() probe (positive chat IDs
+// return `400 chat not found` until the user messages) AND getChat() exposes
+// only the NEWEST pin — DMs STACK pins and there is no list-pins method, so
+// older orphan pins are invisible to the probe-based sweep forever. The durable
+// fix: once per DM chat per boot, `unpinAllChatMessages` (safe in a DM — every
+// pin is bot-authored) then re-pin the live tracked cards. Groups keep the
+// probe path (unpin-all there would nuke human pins).
+//
+// Eligibility mirrors statusPinBootCleanup's mutex gate: set true ONLY after
+// this gateway wins the startup lock, so a losing double-boot never clears the
+// live holder's pins.
+let dmPinSweepEligible = false
+const dmPinSweeper: DmPinSweeper = createDmPinSweeper({
+  unpinAll: (chatId) =>
+    robustApiCall(() => lockedBot.api.unpinAllChatMessages(chatId), {
+      chat_id: chatId,
+      verb: 'dm-pin-sweep.unpin-all',
+    }),
+  pinSilent: (chatId, messageId) =>
+    robustApiCall(
+      () =>
+        lockedBot.api.pinChatMessage(chatId, messageId, {
+          disable_notification: true,
+        }),
+      { chat_id: chatId, verb: 'dm-pin-sweep.repin' },
+    ),
+  // Live in-memory status-pin claims for this chat (fg:/wk:/tool:/banner:) —
+  // the messages still owned by an in-flight turn/worker that must survive the
+  // unpin-all. Empty at boot (fresh process); non-empty for a first-inbound
+  // sweep landing mid-turn.
+  liveTrackedMessageIds: (chatId) => {
+    const ids: number[] = []
+    for (const [key, st] of statusPinState.entries()) {
+      if (statusPinChatIds.get(key) === chatId) ids.push(st.messageId)
+    }
+    return ids
+  },
+  eligible: () => dmPinSweepEligible,
+  log: (line) => process.stderr.write(line),
+})
+
+/**
+ * Boot-time pin cleanup + DM stale-pin sweep, sequenced under the startup
+ * mutex. Collects the DM chat IDs with a prior-session pin record BEFORE the
+ * store reapers empty the stores, runs the three existing boot reapers, marks
+ * the DM sweep eligible (this gateway now owns the shared state), then
+ * unpin-alls each recorded DM chat. Fire-and-forget from the caller — never
+ * blocks boot, never rejects unhandled.
+ */
+async function runBootPinCleanupAndDmSweep(): Promise<void> {
+  let dmChatIds: string[] = []
+  try {
+    dmChatIds = collectDmChatIdsFromStores({
+      statusPins:
+        statusPinPersistEnabled || bannerPinPersistEnabled || toolPinPersistEnabled
+          ? loadStatusPins(STATUS_PIN_STORE_PATH, statusPinStoreFs)
+          : [],
+      activityCards: activityCardPersistEnabled
+        ? loadActivityCards(ACTIVITY_CARD_STORE_PATH, activityCardStoreFs)
+        : [],
+      queuedCards: queuedCardPersistEnabled
+        ? loadQueuedCards(QUEUED_CARD_STORE_PATH, queuedCardStoreFs)
+        : [],
+    })
+  } catch (err) {
+    process.stderr.write(
+      `telegram gateway: dm-pin-sweep: store scan failed: ${(err as Error).message}\n`,
+    )
+  }
+  await statusPinBootCleanup()
+  await activityCardBootReaper()
+  await queuedCardBootReaper()
+  // This gateway now owns the shared per-agent pin state — enable the DM
+  // unpin-all path (both the boot sweep below and lazy first-inbound sweeps).
+  dmPinSweepEligible = true
+  for (const id of dmChatIds) await dmPinSweeper.sweep(id)
+}
+
 // Activity feed. The gateway streams a live "what it's doing" tool-activity
 // feed for every turn. The PreToolUse sidecar emits a `tool_label` per tool
 // call (flush-independent, so it stays real-time on fast/clustered-tool
@@ -7995,9 +8081,9 @@ function ensureIssuesCard(chatId: string, threadId: number | undefined): void {
     // pins from a prior (dead) session. Gated here (not at import time) so a
     // LOSING double-boot never unpins the live holder's legitimate pins.
     // Fire-and-forget: cleanup is best-effort and must not block boot.
-    void statusPinBootCleanup()
-    void activityCardBootReaper()
-    void queuedCardBootReaper()
+    // #3026: sequenced so the DM stale-pin sweep runs after the reapers and
+    // only once this gateway owns the shared state.
+    void runBootPinCleanupAndDmSweep()
   } catch (err) {
     process.stderr.write(
       `telegram gateway: boot.lock_acquire_failed err=${(err as Error).message} agent=${SWITCHROOM_AGENT_NAME}\n`,
@@ -8013,9 +8099,8 @@ function ensureIssuesCard(chatId: string, threadId: number | undefined): void {
       // probe + 409-retry loop is still the liveness guard on this path. A
       // successful writePidFile here means no live holder was detected, so
       // running orphan cleanup is consistent with the pre-mutex behaviour.
-      void statusPinBootCleanup()
-      void activityCardBootReaper()
-      void queuedCardBootReaper()
+      // #3026: same sequenced cleanup + DM stale-pin sweep as the mutex path.
+      void runBootPinCleanupAndDmSweep()
     } catch (writeErr) {
       process.stderr.write(`telegram gateway: writePidFile failed: ${writeErr}\n`)
     }
@@ -17170,6 +17255,16 @@ async function handleInbound(
   clearPermissionTimeoutSuppression('operator inbound')
   // #2862 — operator is back; re-offer any approvals that timed out meanwhile.
   maybePostMissedApprovalDigest('operator inbound')
+
+  // #3026 — first inbound from a DM after boot: clear any stale STACKED pins
+  // the boot getChat() probe can't see (DMs skip the probe AND getChat only
+  // exposes the newest pin). unpin-all once per DM chat per boot, then re-pin
+  // live tracked cards. once-guarded (dedups with the boot sweep); no-op for
+  // groups and until the startup mutex is won. Fire-and-forget.
+  {
+    const inboundChatId = ctx.chat?.id
+    if (inboundChatId != null) void dmPinSweeper.sweep(String(inboundChatId))
+  }
 
   // Capture wall-clock receive time for inbound_ack metric (#203).
   // Must be after gate() so early-exit paths (drop/pair) don't skew the delta.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -473,6 +473,7 @@ import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
 import {
   createDmPinSweeper,
   collectDmChatIdsFromStores,
+  unexpiredStoreRepinIds,
   type DmPinSweeper,
 } from './dm-pin-sweep.js'
 import { startWebhookIngestServer } from './webhook-ingest-server.js'
@@ -7877,14 +7878,34 @@ const dmPinSweeper: DmPinSweeper = createDmPinSweeper({
         }),
       { chat_id: chatId, verb: 'dm-pin-sweep.repin' },
     ),
-  // Live in-memory status-pin claims for this chat (fg:/wk:/tool:/banner:) —
-  // the messages still owned by an in-flight turn/worker that must survive the
-  // unpin-all. Empty at boot (fresh process); non-empty for a first-inbound
-  // sweep landing mid-turn.
+  // Pins that must survive the unpin-all: live in-memory status-pin claims
+  // for this chat (fg:/wk:/tool:/banner: — non-empty for a first-inbound
+  // sweep landing mid-turn) UNIONED with the deliberately-retained store
+  // rows — unexpired `tool:` pins (#3001) survive statusPinBootCleanup by
+  // design and must survive this sweep too. Read LIVE from the store so
+  // both the boot sweep (in-memory maps still empty then) and a later
+  // first-inbound sweep see them. Best-effort: a store read failure
+  // degrades to in-memory-only. The sweeper dedupes.
   liveTrackedMessageIds: (chatId) => {
     const ids: number[] = []
     for (const [key, st] of statusPinState.entries()) {
       if (statusPinChatIds.get(key) === chatId) ids.push(st.messageId)
+    }
+    if (statusPinPersistEnabled || bannerPinPersistEnabled || toolPinPersistEnabled) {
+      try {
+        ids.push(
+          ...unexpiredStoreRepinIds(
+            loadStatusPins(STATUS_PIN_STORE_PATH, statusPinStoreFs),
+            chatId,
+            Date.now(),
+          ),
+        )
+      } catch (err) {
+        process.stderr.write(
+          `telegram gateway: dm-pin-sweep: store repin scan failed ` +
+            `(chat=${chatId}): ${(err as Error).message}\n`,
+        )
+      }
     }
     return ids
   },

--- a/telegram-plugin/tests/activity-card-wiring.test.ts
+++ b/telegram-plugin/tests/activity-card-wiring.test.ts
@@ -66,14 +66,27 @@ describe('activity-card durability wiring', () => {
   })
 
   it('the boot reaper runs ONLY after the startup mutex is won (never at import time)', () => {
-    // Both invocation sites (mutex-won + mutex-fallback) sit AFTER
-    // acquireStartupLock, alongside statusPinBootCleanup.
+    // #3026: the reaper is now invoked via the mutex-gated orchestrator
+    // runBootPinCleanupAndDmSweep() (which awaits it alongside
+    // statusPinBootCleanup + queuedCardBootReaper, then runs the DM
+    // stale-pin sweep). Invariant unchanged: reachable only post-lock.
+    // (1) The orchestrator awaits the reaper.
+    const orchestrator = between(
+      gatewaySrc,
+      'async function runBootPinCleanupAndDmSweep()',
+      'dmPinSweepEligible = true',
+    )
+    expect(orchestrator).toMatch(/await activityCardBootReaper\(\)/)
+    // (2) Both orchestrator invocation sites (mutex-won + mutex-fallback)
+    // sit AFTER acquireStartupLock.
     const afterLock = between(gatewaySrc, 'await acquireStartupLock({', 'catch (err)')
-    expect(afterLock).toMatch(/void activityCardBootReaper\(\)/)
-    // And it must NOT be invoked at module import time — the same losing-double-
-    // boot hazard the NOTE at statusPinBootCleanup documents.
+    expect(afterLock).toMatch(/void runBootPinCleanupAndDmSweep\(\)/)
+    // (3) Neither the reaper nor the orchestrator is invoked at module import
+    // time — the same losing-double-boot hazard the NOTE at
+    // statusPinBootCleanup documents.
     const beforeMain = gatewaySrc.split('await acquireStartupLock({')[0] ?? ''
     expect(beforeMain).not.toMatch(/^\s*void activityCardBootReaper\(\)/m)
+    expect(beforeMain).not.toMatch(/^\s*void runBootPinCleanupAndDmSweep\(\)/m)
   })
 
   it('the reaper wrapper counts a benign-400 as vanished, not finalized (honest boot log)', () => {

--- a/telegram-plugin/tests/status-pin-boot-recovery.test.ts
+++ b/telegram-plugin/tests/status-pin-boot-recovery.test.ts
@@ -232,18 +232,43 @@ describe("status-pin boot cleanup is mutex-gated (structural)", () => {
     );
   });
 
-  it("every statusPinBootCleanup() call site follows the won-lock check", () => {
-    // Find each *invocation* (with parens), excluding the declaration.
+  it("every boot pin-cleanup call site follows the won-lock check", () => {
+    // #3026: boot cleanup is now invoked via the mutex-gated orchestrator
+    // runBootPinCleanupAndDmSweep(), which awaits statusPinBootCleanup()
+    // (+ the other reapers) and then runs the DM stale-pin sweep. The
+    // invariant is unchanged: cleanup must only run after the lock is won.
     const lines = gatewaySrc.split("\n");
     const lockIdx = lines.findIndex((l) => l.includes("acquireStartupLock({"));
     expect(lockIdx).toBeGreaterThan(-1);
 
+    // Every `void runBootPinCleanupAndDmSweep()` invocation must come AFTER
+    // the acquireStartupLock outcome is available (the boot block the winner
+    // — or the link()-unsupported fallback — reaches).
+    const callIdxs = lines
+      .map((l, i) => ({ l, i }))
+      .filter(
+        ({ l }) =>
+          /void runBootPinCleanupAndDmSweep\(\)/.test(l) &&
+          !l.trimStart().startsWith("//"),
+      )
+      .map(({ i }) => i);
+    expect(callIdxs.length).toBeGreaterThan(0);
+    for (const idx of callIdxs) {
+      expect(idx).toBeGreaterThan(lockIdx);
+    }
+
+    // statusPinBootCleanup() itself must only ever be invoked from INSIDE
+    // that orchestrator — never at a bare post-import call site that a
+    // losing double-boot could reach.
     const declIdx = lines.findIndex((l) =>
       /async function statusPinBootCleanup/.test(l),
     );
     expect(declIdx).toBeGreaterThan(-1);
-
-    const callIdxs = lines
+    const orchestratorIdx = lines.findIndex((l) =>
+      /async function runBootPinCleanupAndDmSweep/.test(l),
+    );
+    expect(orchestratorIdx).toBeGreaterThan(-1);
+    const invocationIdxs = lines
       .map((l, i) => ({ l, i }))
       .filter(
         ({ l, i }) =>
@@ -253,25 +278,21 @@ describe("status-pin boot cleanup is mutex-gated (structural)", () => {
           !l.includes("statusPinBootCleanup() is deliberately NOT"),
       )
       .map(({ i }) => i);
-
-    // There must be at least one real call, and every real call must come
-    // AFTER the acquireStartupLock outcome is available (i.e. inside the boot
-    // block that only the winner reaches).
-    expect(callIdxs.length).toBeGreaterThan(0);
-    for (const idx of callIdxs) {
-      expect(idx).toBeGreaterThan(lockIdx);
+    expect(invocationIdxs.length).toBeGreaterThan(0);
+    for (const idx of invocationIdxs) {
+      expect(idx).toBeGreaterThan(orchestratorIdx);
     }
   });
 
   it("the blocked (losing) boot exits before reaching cleanup", () => {
     // In the mutex block, `outcome.status === 'blocked'` must lead to
-    // process.exit(1) BEFORE any statusPinBootCleanup() call in that block —
-    // so a loser never touches the shared store.
+    // process.exit(1) BEFORE the winner's runBootPinCleanupAndDmSweep() call
+    // in that block — so a loser never touches the shared store.
     const blockedIdx = gatewaySrc.indexOf("outcome.status === 'blocked'");
     expect(blockedIdx).toBeGreaterThan(-1);
     const afterBlocked = gatewaySrc.slice(blockedIdx);
     const exitIdx = afterBlocked.indexOf("process.exit(1)");
-    const cleanupIdx = afterBlocked.indexOf("void statusPinBootCleanup()");
+    const cleanupIdx = afterBlocked.indexOf("void runBootPinCleanupAndDmSweep()");
     expect(exitIdx).toBeGreaterThan(-1);
     expect(cleanupIdx).toBeGreaterThan(-1);
     // The exit for the blocked branch appears before the winner's cleanup call.


### PR DESCRIPTION
## Summary
DM chats accumulated stale bot-authored pins that never cleared across gateway restarts. This adds a DM-only stale-pin sweep that runs once per DM chat per boot (and lazily on first inbound from a DM after boot): `unpinAllChatMessages` to clear the whole stack, then re-pin the live tracked cards from the in-memory pin claims (silent, `disable_notification`).

New pure module `telegram-plugin/gateway/dm-pin-sweep.ts` (chat-id classification, store→DM-chat-id collection, DI sweeper with once-per-boot guard); wired into `gateway.ts` at the mutex-gated boot orchestrator (`runBootPinCleanupAndDmSweep`) and at `handleInbound` after the gate passes.

## Why
Two independent gaps made DM pins un-sweepable:
1. `shouldSweepChatAtBoot` skips positive (DM) IDs — the Bot API returns `400 chat not found` for a user who never messaged the bot, so DM chats were never boot-swept. Ken saw stale pins in every DM on 2026-07-11 (fleet on v0.18.9).
2. Even when reachable, `getChat()` exposes only the NEWEST pin; DMs stack pins and the Bot API has no list-pins method, so older orphans are invisible to a probe-based (unpin-one-by-id) sweep forever.

`unpinAllChatMessages` clears the whole stack in one call — safe in a DM where virtually every pin is bot-authored. Groups/supergroups (negative IDs) keep the existing probe path unchanged; an unpin-all there would nuke human pins.

Design details honored:
- Rate-limit aware: unpin-all + re-pins route through the existing `robustApiCall` wrapper (a 429 flood-wait is retried then degrades; the sweeper absorbs the reject — never crashes, never unhandled).
- At most once per DM chat per boot via an in-memory guard (claimed before the first await, so concurrent boot+first-inbound triggers dedupe).
- Never runs on the losing side of the startup mutex: `dmPinSweepEligible` is set true only inside the won-lock boot branches, mirroring `statusPinBootCleanup`'s gate.
- Silent throughout: no messages sent, unpin/re-pin only.

## Test plan
- New `telegram-plugin/gateway/dm-pin-sweep.test.ts` (13 tests, vitest) asserts OUTCOMES: unpin-all called exactly once for a DM with tracked pins followed by re-pin of exactly the live ids; DM with no tracked pins → unpin-all once, no re-pin; groups never get unpin-all; not-eligible does nothing; second sweep no-ops; concurrent triggers fire unpin-all once; 429/unpin-all reject degrades without throwing and still re-pins; re-pin failure absorbed; no unhandled rejection escapes a fire-and-forget failing sweep.
- Updated the two structural mutex-gating tests in `status-pin-boot-recovery.test.ts` to track the new gated orchestrator (invariant preserved: cleanup only runs post-lock).
- Local: `tsc --noEmit` clean, `npm run lint` clean (bot-api-wrapping + no-pii-secrets included), boot-recovery + slot-banner + dm-pin-sweep suites green (22 tests).

## Risk
Low. DM-only behavior change; groups untouched. Worst case a benign extra unpin-all/re-pin in a DM (idempotent, silent). Fire-and-forget with full error absorption — cannot affect turn flow or crash the gateway.

Job spec: `reference/jobs/know-what-my-agent-is-doing.md`.

Fixes #3026

🤖 Generated with [Claude Code](https://claude.com/claude-code)