### PR TITLE
fix(gateway): gate per-poll trace noise + rotate sidecar logs (#3025)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -208,6 +208,12 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
         if cp "$_logfile" "$_logfile.1" 2>/dev/null; then
           : > "$_logfile"
           echo "[supervise] rotated $_logfile (${_size} bytes > ${_max} cap) → ${_logfile}.1" >> "$_logfile"
+        else
+          # cp failed (e.g. ENOSPC — exactly when rotation matters most).
+          # Fall back to truncate-without-backup: dropping the .1 backup
+          # beats a rotator that can never free space (#3025 review).
+          : > "$_logfile"
+          echo "[supervise] rotated $_logfile (${_size} bytes > ${_max} cap) WITHOUT backup — cp to ${_logfile}.1 failed (disk full?)" >> "$_logfile"
         fi
       fi
     done
@@ -219,6 +225,10 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
     # per supervised sidecar; lives for the container lifetime alongside
     # the respawn loop below.
     _switchroom_log_rotator "$_logfile" &
+    # Record the rotator's pid so the oneshot-ok return path below can
+    # reap it — otherwise every completed one-shot sidecar leaks a
+    # background sleep loop for the container lifetime (#3025 review).
+    local _rotator_pid=$!
     # Optional `--oneshot-ok` flag (must directly follow the logfile):
     # marks a sidecar that can LEGITIMATELY complete. For such a sidecar
     # a clean exit 0 means "job done" → stop supervising, no respawn.
@@ -263,6 +273,9 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
       # below — a crash always self-heals.
       if [ $_oneshot_ok -eq 1 ] && [ $_exit -eq 0 ]; then
         echo "[supervise] $_name completed cleanly (exit 0) — one-shot-ok, not respawning." >> "$_logfile"
+        # The sidecar is done — its log stops growing, so reap the
+        # rotator instead of leaking its sleep loop forever (#3025).
+        kill "$_rotator_pid" 2>/dev/null || true
         return 0
       fi
       # A run that stayed up for at least the backoff cap means the

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -165,8 +165,50 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
   # The sidecar's own structured logging is written
   # directly to its log file; this wrapper only handles process
   # lifecycle. Ampersand-backgrounded by callers below.
+  # Size-based log rotation for a supervised sidecar's logfile (#3025).
+  # The gateway sidecar appends per-poll trace lines and can run for
+  # WEEKS without the supervise loop regaining control (it only loops on
+  # child exit), so rotate-at-restart alone let gateway-supervisor.log
+  # grow to 555MB on clerk / 162MB on klanker and fill the host disk.
+  # This background checker runs independently of the child's lifecycle.
+  #
+  # copytruncate (cp + `: >`), NOT `mv`: the supervised child holds an
+  # open fd on $_logfile (its stdout/stderr is redirected there with
+  # `>> "$_logfile"`). A plain `mv` would leave the child writing to the
+  # now-renamed inode, so the live log would silently stop growing and
+  # the rotated file would keep filling. copytruncate preserves the fd —
+  # the child keeps appending to the same (now-empty) inode. Worst-case
+  # race is a few log lines written between the cp and the truncate being
+  # lost; acceptable for a debug trace log. Keeps at most ~2×cap on disk
+  # (live + one .1 generation). Cap + interval are env-overridable.
+  _switchroom_log_rotator() {
+    local _logfile="$1"
+    local _max="${SWITCHROOM_SIDECAR_LOG_MAX_BYTES:-52428800}"   # 50 MiB default
+    local _interval="${SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC:-300}"  # 5 min
+    # A non-positive cap disables rotation entirely (operator escape hatch).
+    [ "$_max" -le 0 ] 2>/dev/null && return 0
+    while true; do
+      sleep "$_interval"
+      [ -f "$_logfile" ] || continue
+      local _size
+      _size=$(wc -c < "$_logfile" 2>/dev/null || echo 0)
+      # `wc -c < file` yields a bare integer; guard against empty/non-numeric.
+      case "$_size" in ''|*[!0-9]*) continue;; esac
+      if [ "$_size" -gt "$_max" ]; then
+        if cp "$_logfile" "$_logfile.1" 2>/dev/null; then
+          : > "$_logfile"
+          echo "[supervise] rotated $_logfile (${_size} bytes > ${_max} cap) → ${_logfile}.1" >> "$_logfile"
+        fi
+      fi
+    done
+  }
+
   _switchroom_supervise() {
     local _name="$1"; local _logfile="$2"; shift 2
+    # Start the size-based rotator for this sidecar's log (#3025). One
+    # per supervised sidecar; lives for the container lifetime alongside
+    # the respawn loop below.
+    _switchroom_log_rotator "$_logfile" &
     # Optional `--oneshot-ok` flag (must directly follow the logfile):
     # marks a sidecar that can LEGITIMATELY complete. For such a sidecar
     # a clean exit 0 means "job done" → stop supervising, no respawn.

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -185,8 +185,18 @@ x-litellm-tags: agent:$SWITCHROOM_AGENT_NAME,profile:${SWITCHROOM_AGENT_PROFILE:
     local _logfile="$1"
     local _max="${SWITCHROOM_SIDECAR_LOG_MAX_BYTES:-52428800}"   # 50 MiB default
     local _interval="${SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC:-300}"  # 5 min
-    # A non-positive cap disables rotation entirely (operator escape hatch).
-    [ "$_max" -le 0 ] 2>/dev/null && return 0
+    # Validate BOTH env overrides up front; garbage falls back to the
+    # default. Unvalidated, a non-numeric interval makes `sleep` fail
+    # instantly and the `while true` loop hot-spins a CPU core for the
+    # container lifetime; a non-numeric cap makes the -gt test below
+    # error (a shell error line to stdout) every cycle forever. A zero
+    # interval would also hot-spin, so it falls back too.
+    case "$_max" in ''|*[!0-9]*) _max=52428800;; esac
+    case "$_interval" in ''|0|*[!0-9]*) _interval=300;; esac
+    # A cap of 0 disables rotation entirely (operator escape hatch).
+    # (Negative values contain '-' → non-numeric per the guard above →
+    # default cap, i.e. rotation stays on.)
+    [ "$_max" -eq 0 ] && return 0
     while true; do
       sleep "$_interval"
       [ -f "$_logfile" ] || continue

--- a/telegram-plugin/gateway/inbound-delivery-machine-shadow.ts
+++ b/telegram-plugin/gateway/inbound-delivery-machine-shadow.ts
@@ -27,6 +27,16 @@
  * buffer: agent=X buffered ...` etc.) is the validation that the
  * machine is bit-identical with reality.
  *
+ * Trace verbosity (#3025): the TTL `tick` event fires every ~30s and on a
+ * healthy idle agent emits a zero-signal `event=tick effects=[]
+ * global=bridge_alive_idle` line. Those no-op ticks are SUPPRESSED by
+ * default (they filled gateway-supervisor.log to 555MB on clerk). Set
+ * `SWITCHROOM_GW_TRACE=1` to restore the full firehose — every tick, poll,
+ * and event line — when debugging the delivery/poll path. The gate lives
+ * in `../shared/gw-trace-gate.ts` and also governs the `tg-post` poll
+ * heartbeats. Real events, turn-expiring ticks, and in-turn ticks always
+ * log regardless of the flag.
+ *
  * Toggle off via `SWITCHROOM_DELIVERY_MACHINE_SHADOW=0` — a kill
  * switch for the case where the shadow emits prove problematic
  * (e.g., trace volume too high). The default is ON.
@@ -39,6 +49,7 @@ import {
   initialState,
   transition,
 } from './inbound-delivery-machine.js'
+import { shouldEmitShadowTrace } from '../shared/gw-trace-gate.js'
 
 let state: State = initialState()
 const enabled = process.env.SWITCHROOM_DELIVERY_MACHINE_SHADOW !== '0'
@@ -101,11 +112,21 @@ export function shadowEmit(event: Event): readonly Effect[] {
     // low volume (one line per gateway event, not per effect). The
     // format matches gateway.ts's existing `tg-post method=...` shape
     // so log aggregation can pick it up without a new parser.
-    const effectKinds = result.effects.map((e) => e.kind).join(',')
-    const eventDetail = formatEventDetail(event)
-    process.stderr.write(
-      `gw-trace shadow event=${event.kind}${eventDetail} effects=[${effectKinds}] global=${state.global.kind} perKeySize=${state.perKey.size}\n`,
-    )
+    // #3025: the TTL `tick` event fires every ~30s. On a healthy idle
+    // agent it produces no effects and leaves the machine idle — a
+    // zero-signal heartbeat that (unrotated) grew this log to 555MB on
+    // clerk. Suppress those no-op ticks unless the operator opted into
+    // the full firehose (SWITCHROOM_GW_TRACE=1). Real events, ticks that
+    // expire a turn (non-empty effects), and in-turn ticks still log.
+    if (
+      shouldEmitShadowTrace(event.kind, result.effects.length, state.global.kind)
+    ) {
+      const effectKinds = result.effects.map((e) => e.kind).join(',')
+      const eventDetail = formatEventDetail(event)
+      process.stderr.write(
+        `gw-trace shadow event=${event.kind}${eventDetail} effects=[${effectKinds}] global=${state.global.kind} perKeySize=${state.perKey.size}\n`,
+      )
+    }
     return result.effects
   } catch (err) {
     process.stderr.write(

--- a/telegram-plugin/shared/bot-runtime.ts
+++ b/telegram-plugin/shared/bot-runtime.ts
@@ -31,6 +31,7 @@ import { clearStaleTelegramPollingState } from '../startup-reset.js'
 import { createRetryApiCall } from '../retry-api-call.js'
 import { makeFloodWaitRecorder } from '../flood-circuit-breaker.js'
 import { RICH_MESSAGE_MAX_CHARS } from '../format.js'
+import { shouldEmitTgPost } from './gw-trace-gate.js'
 
 // ─── tg-post tag plumbing ─────────────────────────────────────────────────
 
@@ -115,9 +116,14 @@ export function installTgPostLogger(bot: Bot): void {
     const tagSuffix = formatTgPostTags(_getTgPostTags())
     try {
       const res = await prev(method, payload, signal)
-      process.stderr.write(
-        `tg-post method=${method} chat=${chat} thread=${thread} parse_mode=${parseMode} bytes=${bytes} hash=${hash} status=ok err=- code=- desc=-${tagSuffix}\n`,
-      )
+      // #3025: suppress zero-signal per-poll heartbeats (getUpdates/getMe
+      // status=ok, one line per ~30s long-poll tick) unless the operator
+      // set SWITCHROOM_GW_TRACE. Errors and all other methods still log.
+      if (shouldEmitTgPost(method, 'ok')) {
+        process.stderr.write(
+          `tg-post method=${method} chat=${chat} thread=${thread} parse_mode=${parseMode} bytes=${bytes} hash=${hash} status=ok err=- code=- desc=-${tagSuffix}\n`,
+        )
+      }
       return res
     } catch (err) {
       const errClass = err instanceof GrammyError

--- a/telegram-plugin/shared/gw-trace-gate.ts
+++ b/telegram-plugin/shared/gw-trace-gate.ts
@@ -20,8 +20,8 @@
  * decision behind a single debug env flag so operators can turn the full
  * firehose back on when actually debugging the delivery/poll path.
  *
- * Flag: set `SWITCHROOM_GW_TRACE=1` (or `true`) to restore every trace
- * line unconditionally. Unset / any other value → zero-signal polling
+ * Flag: set `SWITCHROOM_GW_TRACE=1` (or `true`/`yes`/`on`, any case) to
+ * restore every trace line unconditionally. Unset / any other value → zero-signal polling
  * success + idle-tick lines are suppressed, while ALL error lines, all
  * non-poll methods (sendMessage, editMessageText, ...), and every tick or
  * event that produced a real effect or state change are still emitted.
@@ -39,7 +39,8 @@
  * flag variants must be testable via explicit arguments.
  */
 export function computeGwTraceVerbose(flag: string | undefined): boolean {
-  return flag === '1' || flag === 'true'
+  const v = (flag ?? '').trim().toLowerCase()
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on'
 }
 
 /** True when the operator opted into the full gateway trace firehose. */

--- a/telegram-plugin/shared/gw-trace-gate.ts
+++ b/telegram-plugin/shared/gw-trace-gate.ts
@@ -1,0 +1,88 @@
+/**
+ * Gateway trace verbosity gate (#3025).
+ *
+ * The gateway emits two families of high-frequency stderr trace lines that
+ * are pure per-poll noise on a healthy, idle agent:
+ *
+ *   - `tg-post method=getUpdates ... status=ok` / `method=getMe ... status=ok`
+ *     — one line per long-poll tick (~every 30s) from the tg-post
+ *     observability transformer in `bot-runtime.ts`.
+ *   - `gw-trace shadow event=tick effects=[] global=bridge_alive_idle ...`
+ *     — one line per delivery-machine TTL tick (~every 30s) from
+ *     `inbound-delivery-machine-shadow.ts`.
+ *
+ * With no log rotation these ungated lines grew gateway-supervisor.log to
+ * 555MB on clerk / 162MB on klanker and filled the host disk. They carry
+ * zero signal when nothing happened: a successful empty long-poll and an
+ * idle no-op tick.
+ *
+ * This module centralises the "should I emit a zero-signal trace line?"
+ * decision behind a single debug env flag so operators can turn the full
+ * firehose back on when actually debugging the delivery/poll path.
+ *
+ * Flag: set `SWITCHROOM_GW_TRACE=1` (or `true`) to restore every trace
+ * line unconditionally. Unset / any other value → zero-signal polling
+ * success + idle-tick lines are suppressed, while ALL error lines, all
+ * non-poll methods (sendMessage, editMessageText, ...), and every tick or
+ * event that produced a real effect or state change are still emitted.
+ *
+ * Read once at module init — the flag is a boot-time debug switch, not a
+ * hot-reloadable knob, so a cached read keeps the per-line cost at a
+ * single boolean check.
+ */
+
+/** True when the operator opted into the full gateway trace firehose. */
+export const gwTraceVerbose: boolean =
+  process.env.SWITCHROOM_GW_TRACE === '1' ||
+  process.env.SWITCHROOM_GW_TRACE === 'true'
+
+/**
+ * Bot API methods whose successful long-poll ticks are zero-signal:
+ * `getUpdates` is the long-poll itself and `getMe` is the periodic
+ * identity refresh. A `status=ok` on either says only "polling is alive",
+ * which the gateway already reports once at startup. Errors on these
+ * methods are NOT suppressed (see `shouldEmitTgPost`).
+ */
+const ZERO_SIGNAL_POLL_METHODS = new Set(['getUpdates', 'getMe'])
+
+/**
+ * Decide whether a `tg-post` line should be written.
+ *
+ * Suppressed (unless `SWITCHROOM_GW_TRACE` is set):
+ *   - `status=ok` for `getUpdates` / `getMe` — the per-poll heartbeat.
+ *
+ * Always emitted:
+ *   - any `status=err` (real failures — the whole point of the log),
+ *   - every other method's `ok` line (sendMessage/editMessageText/... are
+ *     genuine outbound observability, #656/#657).
+ */
+export function shouldEmitTgPost(method: string, status: 'ok' | 'err'): boolean {
+  if (gwTraceVerbose) return true
+  if (status === 'err') return true
+  return !ZERO_SIGNAL_POLL_METHODS.has(method)
+}
+
+/**
+ * Decide whether a `gw-trace shadow` line should be written.
+ *
+ * Suppressed (unless `SWITCHROOM_GW_TRACE` is set):
+ *   - `event=tick` that produced NO effects AND left the machine in an
+ *     idle global state (`bridge_alive_idle` / `bridge_dead`) — the
+ *     no-op TTL heartbeat.
+ *
+ * Always emitted:
+ *   - any non-tick event (real inbound/turn/bridge activity),
+ *   - any tick that produced effects (e.g. a TTL turn expiry) or that
+ *     landed the machine in `bridge_alive_in_turn`.
+ */
+export function shouldEmitShadowTrace(
+  eventKind: string,
+  effectCount: number,
+  globalKind: string,
+): boolean {
+  if (gwTraceVerbose) return true
+  if (eventKind !== 'tick') return true
+  if (effectCount > 0) return true
+  const idle = globalKind === 'bridge_alive_idle' || globalKind === 'bridge_dead'
+  return !idle
+}

--- a/telegram-plugin/shared/gw-trace-gate.ts
+++ b/telegram-plugin/shared/gw-trace-gate.ts
@@ -31,10 +31,21 @@
  * single boolean check.
  */
 
+/**
+ * Pure env-flag parse — exported so tests can exercise the parsing
+ * directly. Kept separate from the module-init read because the dual
+ * vitest/bun runner boundary means module-cache tricks
+ * (`vi.resetModules()` + re-import) don't work under bun's vitest shim;
+ * flag variants must be testable via explicit arguments.
+ */
+export function computeGwTraceVerbose(flag: string | undefined): boolean {
+  return flag === '1' || flag === 'true'
+}
+
 /** True when the operator opted into the full gateway trace firehose. */
-export const gwTraceVerbose: boolean =
-  process.env.SWITCHROOM_GW_TRACE === '1' ||
-  process.env.SWITCHROOM_GW_TRACE === 'true'
+export const gwTraceVerbose: boolean = computeGwTraceVerbose(
+  process.env.SWITCHROOM_GW_TRACE,
+)
 
 /**
  * Bot API methods whose successful long-poll ticks are zero-signal:
@@ -56,8 +67,12 @@ const ZERO_SIGNAL_POLL_METHODS = new Set(['getUpdates', 'getMe'])
  *   - every other method's `ok` line (sendMessage/editMessageText/... are
  *     genuine outbound observability, #656/#657).
  */
-export function shouldEmitTgPost(method: string, status: 'ok' | 'err'): boolean {
-  if (gwTraceVerbose) return true
+export function shouldEmitTgPost(
+  method: string,
+  status: 'ok' | 'err',
+  verbose: boolean = gwTraceVerbose,
+): boolean {
+  if (verbose) return true
   if (status === 'err') return true
   return !ZERO_SIGNAL_POLL_METHODS.has(method)
 }
@@ -79,8 +94,9 @@ export function shouldEmitShadowTrace(
   eventKind: string,
   effectCount: number,
   globalKind: string,
+  verbose: boolean = gwTraceVerbose,
 ): boolean {
-  if (gwTraceVerbose) return true
+  if (verbose) return true
   if (eventKind !== 'tick') return true
   if (effectCount > 0) return true
   const idle = globalKind === 'bridge_alive_idle' || globalKind === 'bridge_dead'

--- a/telegram-plugin/tests/gw-trace-gate.test.ts
+++ b/telegram-plugin/tests/gw-trace-gate.test.ts
@@ -4,99 +4,101 @@
  * only when SWITCHROOM_GW_TRACE is truthy. Error lines and real
  * (non-poll / non-idle-tick) activity ALWAYS emit regardless of the flag.
  *
- * The gate reads the env flag once at module init, so each state is
- * exercised via vi.resetModules() + a fresh dynamic import with the env
- * set — mirroring how the module is loaded in the running gateway.
+ * DUAL-RUNNER NOTE (vitest + bun): this file runs under BOTH runners, and
+ * bun's vitest shim does not honor `vi.resetModules()` — a re-import
+ * returns the originally-cached module, so flag variants CANNOT be tested
+ * via env + fresh import. Instead the gate exposes pure paths: the env
+ * parse is `computeGwTraceVerbose(flag)` and both should-emit functions
+ * take an explicit `verbose` argument (defaulting to the module-init
+ * read). Tests pass verbosity explicitly.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
+import {
+  computeGwTraceVerbose,
+  shouldEmitTgPost,
+  shouldEmitShadowTrace,
+} from '../shared/gw-trace-gate.js'
 
-type Gate = typeof import('../shared/gw-trace-gate.js')
-
-async function loadGate(flag: string | undefined): Promise<Gate> {
-  vi.resetModules()
-  if (flag === undefined) delete process.env.SWITCHROOM_GW_TRACE
-  else process.env.SWITCHROOM_GW_TRACE = flag
-  return import('../shared/gw-trace-gate.js')
-}
-
-const savedFlag = process.env.SWITCHROOM_GW_TRACE
-
-beforeEach(() => {
-  delete process.env.SWITCHROOM_GW_TRACE
-})
-
-afterEach(() => {
-  if (savedFlag === undefined) delete process.env.SWITCHROOM_GW_TRACE
-  else process.env.SWITCHROOM_GW_TRACE = savedFlag
-})
-
-describe('shouldEmitTgPost — default (flag unset): suppress poll heartbeats', () => {
-  it('suppresses status=ok for getUpdates and getMe', async () => {
-    const gate = await loadGate(undefined)
-    expect(gate.gwTraceVerbose).toBe(false)
-    expect(gate.shouldEmitTgPost('getUpdates', 'ok')).toBe(false)
-    expect(gate.shouldEmitTgPost('getMe', 'ok')).toBe(false)
+describe('computeGwTraceVerbose — env flag parsing', () => {
+  it('is OFF when unset', () => {
+    expect(computeGwTraceVerbose(undefined)).toBe(false)
   })
 
-  it('ALWAYS emits error lines, even for the poll methods', async () => {
-    const gate = await loadGate(undefined)
-    expect(gate.shouldEmitTgPost('getUpdates', 'err')).toBe(true)
-    expect(gate.shouldEmitTgPost('getMe', 'err')).toBe(true)
+  it('opts IN only on "1" or "true"', () => {
+    expect(computeGwTraceVerbose('1')).toBe(true)
+    expect(computeGwTraceVerbose('true')).toBe(true)
   })
 
-  it('keeps status=ok for real outbound methods', async () => {
-    const gate = await loadGate(undefined)
+  it('stays OFF for falsey / unrecognized values', () => {
+    for (const v of ['', '0', 'false', 'yes', 'on', 'TRUE', ' 1', 'x']) {
+      expect(computeGwTraceVerbose(v)).toBe(false)
+    }
+  })
+})
+
+describe('shouldEmitTgPost — default (verbose=false): suppress poll heartbeats', () => {
+  it('suppresses status=ok for getUpdates and getMe', () => {
+    expect(shouldEmitTgPost('getUpdates', 'ok', false)).toBe(false)
+    expect(shouldEmitTgPost('getMe', 'ok', false)).toBe(false)
+  })
+
+  it('ALWAYS emits error lines, even for the poll methods', () => {
+    expect(shouldEmitTgPost('getUpdates', 'err', false)).toBe(true)
+    expect(shouldEmitTgPost('getMe', 'err', false)).toBe(true)
+  })
+
+  it('keeps status=ok for real outbound methods', () => {
     for (const m of ['sendMessage', 'editMessageText', 'sendChatAction', 'answerCallbackQuery']) {
-      expect(gate.shouldEmitTgPost(m, 'ok')).toBe(true)
+      expect(shouldEmitTgPost(m, 'ok', false)).toBe(true)
     }
   })
 })
 
-describe('shouldEmitShadowTrace — default (flag unset): suppress idle no-op ticks', () => {
-  it('suppresses a tick with no effects in an idle global state', async () => {
-    const gate = await loadGate(undefined)
-    expect(gate.shouldEmitShadowTrace('tick', 0, 'bridge_alive_idle')).toBe(false)
-    expect(gate.shouldEmitShadowTrace('tick', 0, 'bridge_dead')).toBe(false)
+describe('shouldEmitShadowTrace — default (verbose=false): suppress idle no-op ticks', () => {
+  it('suppresses a tick with no effects in an idle global state', () => {
+    expect(shouldEmitShadowTrace('tick', 0, 'bridge_alive_idle', false)).toBe(false)
+    expect(shouldEmitShadowTrace('tick', 0, 'bridge_dead', false)).toBe(false)
   })
 
-  it('emits a tick that produced effects (e.g. a TTL turn expiry)', async () => {
-    const gate = await loadGate(undefined)
-    expect(gate.shouldEmitShadowTrace('tick', 1, 'bridge_alive_idle')).toBe(true)
+  it('emits a tick that produced effects (e.g. a TTL turn expiry)', () => {
+    expect(shouldEmitShadowTrace('tick', 1, 'bridge_alive_idle', false)).toBe(true)
   })
 
-  it('emits a tick while a turn is in flight', async () => {
-    const gate = await loadGate(undefined)
-    expect(gate.shouldEmitShadowTrace('tick', 0, 'bridge_alive_in_turn')).toBe(true)
+  it('emits a tick while a turn is in flight', () => {
+    expect(shouldEmitShadowTrace('tick', 0, 'bridge_alive_in_turn', false)).toBe(true)
   })
 
-  it('ALWAYS emits non-tick events (real inbound/turn/bridge activity)', async () => {
-    const gate = await loadGate(undefined)
+  it('ALWAYS emits non-tick events (real inbound/turn/bridge activity)', () => {
     for (const ev of ['inbound', 'turnStart', 'turnEnd', 'bridgeUp', 'bridgeDown', 'permVerdict']) {
-      expect(gate.shouldEmitShadowTrace(ev, 0, 'bridge_alive_idle')).toBe(true)
+      expect(shouldEmitShadowTrace(ev, 0, 'bridge_alive_idle', false)).toBe(true)
     }
   })
 })
 
-describe('SWITCHROOM_GW_TRACE truthy — full firehose restored', () => {
-  for (const flag of ['1', 'true']) {
-    it(`emits every line when flag=${flag}`, async () => {
-      const gate = await loadGate(flag)
-      expect(gate.gwTraceVerbose).toBe(true)
-      // The two lines suppressed by default are now emitted.
-      expect(gate.shouldEmitTgPost('getUpdates', 'ok')).toBe(true)
-      expect(gate.shouldEmitTgPost('getMe', 'ok')).toBe(true)
-      expect(gate.shouldEmitShadowTrace('tick', 0, 'bridge_alive_idle')).toBe(true)
-      expect(gate.shouldEmitShadowTrace('tick', 0, 'bridge_dead')).toBe(true)
-    })
-  }
+describe('verbose=true — full firehose restored', () => {
+  it('emits every line, including the two suppressed-by-default families', () => {
+    expect(shouldEmitTgPost('getUpdates', 'ok', true)).toBe(true)
+    expect(shouldEmitTgPost('getMe', 'ok', true)).toBe(true)
+    expect(shouldEmitShadowTrace('tick', 0, 'bridge_alive_idle', true)).toBe(true)
+    expect(shouldEmitShadowTrace('tick', 0, 'bridge_dead', true)).toBe(true)
+  })
+})
 
-  it('leaves the gate OFF for falsey/unrecognized values', async () => {
-    for (const flag of ['0', 'false', '', 'yes', 'on']) {
-      const gate = await loadGate(flag)
-      expect(gate.gwTraceVerbose).toBe(false)
-      expect(gate.shouldEmitTgPost('getUpdates', 'ok')).toBe(false)
-      expect(gate.shouldEmitShadowTrace('tick', 0, 'bridge_alive_idle')).toBe(false)
-    }
+describe('default verbose argument wiring', () => {
+  it('the defaulted call form works and matches the module-init env read', () => {
+    // Env-agnostic assertion: the defaulted form must agree with the
+    // explicit form using the parsed CURRENT env — proving the default
+    // parameter is wired to the module-init flag, whatever its value in
+    // the test process.
+    const envVerbose = computeGwTraceVerbose(process.env.SWITCHROOM_GW_TRACE)
+    expect(shouldEmitTgPost('getUpdates', 'ok')).toBe(
+      shouldEmitTgPost('getUpdates', 'ok', envVerbose),
+    )
+    expect(shouldEmitShadowTrace('tick', 0, 'bridge_alive_idle')).toBe(
+      shouldEmitShadowTrace('tick', 0, 'bridge_alive_idle', envVerbose),
+    )
+    // Regardless of the flag, an error line always emits via the default form.
+    expect(shouldEmitTgPost('getUpdates', 'err')).toBe(true)
   })
 })

--- a/telegram-plugin/tests/gw-trace-gate.test.ts
+++ b/telegram-plugin/tests/gw-trace-gate.test.ts
@@ -25,13 +25,14 @@ describe('computeGwTraceVerbose — env flag parsing', () => {
     expect(computeGwTraceVerbose(undefined)).toBe(false)
   })
 
-  it('opts IN only on "1" or "true"', () => {
-    expect(computeGwTraceVerbose('1')).toBe(true)
-    expect(computeGwTraceVerbose('true')).toBe(true)
+  it('opts IN on the truthy set, case-insensitively (1/true/yes/on)', () => {
+    for (const v of ['1', 'true', 'TRUE', 'True', 'yes', 'Yes', 'YES', 'on', 'ON', 'On', ' 1', 'true ']) {
+      expect(computeGwTraceVerbose(v)).toBe(true)
+    }
   })
 
   it('stays OFF for falsey / unrecognized values', () => {
-    for (const v of ['', '0', 'false', 'yes', 'on', 'TRUE', ' 1', 'x']) {
+    for (const v of ['', '0', 'false', 'FALSE', 'off', 'No', 'x', 'enabled']) {
       expect(computeGwTraceVerbose(v)).toBe(false)
     }
   })

--- a/telegram-plugin/tests/gw-trace-gate.test.ts
+++ b/telegram-plugin/tests/gw-trace-gate.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Pin the gateway trace verbosity gate (#3025): zero-signal per-poll
+ * heartbeats are suppressed by default and the full firehose is restored
+ * only when SWITCHROOM_GW_TRACE is truthy. Error lines and real
+ * (non-poll / non-idle-tick) activity ALWAYS emit regardless of the flag.
+ *
+ * The gate reads the env flag once at module init, so each state is
+ * exercised via vi.resetModules() + a fresh dynamic import with the env
+ * set — mirroring how the module is loaded in the running gateway.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+type Gate = typeof import('../shared/gw-trace-gate.js')
+
+async function loadGate(flag: string | undefined): Promise<Gate> {
+  vi.resetModules()
+  if (flag === undefined) delete process.env.SWITCHROOM_GW_TRACE
+  else process.env.SWITCHROOM_GW_TRACE = flag
+  return import('../shared/gw-trace-gate.js')
+}
+
+const savedFlag = process.env.SWITCHROOM_GW_TRACE
+
+beforeEach(() => {
+  delete process.env.SWITCHROOM_GW_TRACE
+})
+
+afterEach(() => {
+  if (savedFlag === undefined) delete process.env.SWITCHROOM_GW_TRACE
+  else process.env.SWITCHROOM_GW_TRACE = savedFlag
+})
+
+describe('shouldEmitTgPost — default (flag unset): suppress poll heartbeats', () => {
+  it('suppresses status=ok for getUpdates and getMe', async () => {
+    const gate = await loadGate(undefined)
+    expect(gate.gwTraceVerbose).toBe(false)
+    expect(gate.shouldEmitTgPost('getUpdates', 'ok')).toBe(false)
+    expect(gate.shouldEmitTgPost('getMe', 'ok')).toBe(false)
+  })
+
+  it('ALWAYS emits error lines, even for the poll methods', async () => {
+    const gate = await loadGate(undefined)
+    expect(gate.shouldEmitTgPost('getUpdates', 'err')).toBe(true)
+    expect(gate.shouldEmitTgPost('getMe', 'err')).toBe(true)
+  })
+
+  it('keeps status=ok for real outbound methods', async () => {
+    const gate = await loadGate(undefined)
+    for (const m of ['sendMessage', 'editMessageText', 'sendChatAction', 'answerCallbackQuery']) {
+      expect(gate.shouldEmitTgPost(m, 'ok')).toBe(true)
+    }
+  })
+})
+
+describe('shouldEmitShadowTrace — default (flag unset): suppress idle no-op ticks', () => {
+  it('suppresses a tick with no effects in an idle global state', async () => {
+    const gate = await loadGate(undefined)
+    expect(gate.shouldEmitShadowTrace('tick', 0, 'bridge_alive_idle')).toBe(false)
+    expect(gate.shouldEmitShadowTrace('tick', 0, 'bridge_dead')).toBe(false)
+  })
+
+  it('emits a tick that produced effects (e.g. a TTL turn expiry)', async () => {
+    const gate = await loadGate(undefined)
+    expect(gate.shouldEmitShadowTrace('tick', 1, 'bridge_alive_idle')).toBe(true)
+  })
+
+  it('emits a tick while a turn is in flight', async () => {
+    const gate = await loadGate(undefined)
+    expect(gate.shouldEmitShadowTrace('tick', 0, 'bridge_alive_in_turn')).toBe(true)
+  })
+
+  it('ALWAYS emits non-tick events (real inbound/turn/bridge activity)', async () => {
+    const gate = await loadGate(undefined)
+    for (const ev of ['inbound', 'turnStart', 'turnEnd', 'bridgeUp', 'bridgeDown', 'permVerdict']) {
+      expect(gate.shouldEmitShadowTrace(ev, 0, 'bridge_alive_idle')).toBe(true)
+    }
+  })
+})
+
+describe('SWITCHROOM_GW_TRACE truthy — full firehose restored', () => {
+  for (const flag of ['1', 'true']) {
+    it(`emits every line when flag=${flag}`, async () => {
+      const gate = await loadGate(flag)
+      expect(gate.gwTraceVerbose).toBe(true)
+      // The two lines suppressed by default are now emitted.
+      expect(gate.shouldEmitTgPost('getUpdates', 'ok')).toBe(true)
+      expect(gate.shouldEmitTgPost('getMe', 'ok')).toBe(true)
+      expect(gate.shouldEmitShadowTrace('tick', 0, 'bridge_alive_idle')).toBe(true)
+      expect(gate.shouldEmitShadowTrace('tick', 0, 'bridge_dead')).toBe(true)
+    })
+  }
+
+  it('leaves the gate OFF for falsey/unrecognized values', async () => {
+    for (const flag of ['0', 'false', '', 'yes', 'on']) {
+      const gate = await loadGate(flag)
+      expect(gate.gwTraceVerbose).toBe(false)
+      expect(gate.shouldEmitTgPost('getUpdates', 'ok')).toBe(false)
+      expect(gate.shouldEmitShadowTrace('tick', 0, 'bridge_alive_idle')).toBe(false)
+    }
+  })
+})

--- a/tests/gateway-supervisor-backoff.test.ts
+++ b/tests/gateway-supervisor-backoff.test.ts
@@ -19,22 +19,27 @@ const TEMPLATE = join(__dirname, "..", "profiles", "_base", "start.sh.hbs");
 // Extract the pure-shell _switchroom_supervise function from the
 // handlebars template (the function body contains no {{ }} tokens —
 // asserted below so this test fails loudly if that ever changes).
-function extractSupervisor(): string {
+// Extract a named 2-space-indented shell function body from the template.
+function extractFn(name: string): string {
   const src = readFileSync(TEMPLATE, "utf-8");
   const lines = src.split("\n");
-  const start = lines.findIndex((l) => l.includes("_switchroom_supervise() {"));
-  expect(start, "_switchroom_supervise() not found in start.sh.hbs").toBeGreaterThanOrEqual(0);
+  const start = lines.findIndex((l) => l.includes(`${name}() {`));
+  expect(start, `${name}() not found in start.sh.hbs`).toBeGreaterThanOrEqual(0);
   // Function ends at the first subsequent line that is exactly the
   // 2-space-indented closing brace.
   let end = -1;
   for (let i = start + 1; i < lines.length; i++) {
     if (lines[i] === "  }") { end = i; break; }
   }
-  expect(end, "closing brace of _switchroom_supervise not found").toBeGreaterThan(start);
+  expect(end, `closing brace of ${name} not found`).toBeGreaterThan(start);
   // De-indent two spaces so it's a valid top-level function.
   const fn = lines.slice(start, end + 1).map((l) => l.replace(/^ {2}/, "")).join("\n");
   expect(fn).not.toContain("{{"); // no handlebars inside the function
   return fn;
+}
+
+function extractSupervisor(): string {
+  return extractFn("_switchroom_supervise");
 }
 
 let dir: string;
@@ -45,8 +50,15 @@ beforeAll(() => {
   // Shrink the 60s cap to 4s so exponential backoff (1,2,4,4) is
   // observable in a fast test without changing the logic under test.
   const fn = extractSupervisor().replace("local _cap=60", "local _cap=4");
+  // _switchroom_supervise now backgrounds _switchroom_log_rotator (#3025).
+  // These tests exercise the RESPAWN/backoff logic, not rotation, so stub
+  // the rotator as a no-op: the real one is a `while sleep; do` loop that
+  // — backgrounded — would inherit the driver's stdout pipe and hang the
+  // test past its child's exit. Rotation itself is covered end-to-end in
+  // gateway-supervisor-log-rotation.test.ts.
+  const rotatorStub = "_switchroom_log_rotator() { :; }";
   fnPath = join(dir, "sup.fn");
-  writeFileSync(fnPath, fn);
+  writeFileSync(fnPath, rotatorStub + "\n" + fn);
 });
 
 function runBash(script: string, timeoutMs: number): string {

--- a/tests/gateway-supervisor-log-rotation.test.ts
+++ b/tests/gateway-supervisor-log-rotation.test.ts
@@ -122,7 +122,57 @@ describe("_switchroom_log_rotator — #3025 size-based copytruncate", () => {
     expect(readFileSync(log, "utf-8")).toContain("SENTINEL_AFTER_ROTATE");
   }, 15_000);
 
-  it("a non-positive cap disables rotation (operator escape hatch)", () => {
+  it("non-numeric interval falls back to the 300s default (no hot-spin)", () => {
+    // Unvalidated, a garbage interval makes `sleep` fail instantly and the
+    // `while true` loop spins tight — checking (and rotating) nonstop.
+    // With the entry guard the interval falls back to 300s, so over a 2s
+    // window NO check fires: the over-cap log must remain unrotated, which
+    // is only possible if the fallback took effect (a spinning loop would
+    // have rotated it within milliseconds).
+    const log = join(dir, "garbage-interval.log");
+    writeFileSync(log, "v".repeat(2000) + "\n");
+    const stderrFile = join(dir, "garbage-interval.stderr");
+    runBash(
+      // stdout → /dev/null: killing the rotator subshell leaves its
+      // in-flight external `sleep 300` child alive, and an inherited
+      // stdout pipe would make execFileSync wait the full 300s on it.
+      `_switchroom_log_rotator ${JSON.stringify(log)} > /dev/null 2> ${JSON.stringify(stderrFile)} & RPID=$!
+       sleep 2; kill "$RPID" 2>/dev/null; wait "$RPID" 2>/dev/null; true`,
+      {
+        SWITCHROOM_SIDECAR_LOG_MAX_BYTES: "1000",
+        SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC: "bogus",
+      },
+      15_000,
+    );
+    expect(existsSync(log + ".1")).toBe(false);
+    expect(statSync(log).size).toBeGreaterThanOrEqual(2000);
+    // No sleep/test shell errors — the loop slept cleanly on the default.
+    expect(readFileSync(stderrFile, "utf-8")).toBe("");
+  }, 15_000);
+
+  it("non-numeric cap falls back to the 50MiB default (no per-cycle shell errors)", () => {
+    // Unvalidated, a garbage cap makes `[ size -gt max ]` error every
+    // cycle, spamming a shell error line to the container stdout forever.
+    // With the guard the cap falls back to 50MiB: a small log is left
+    // alone and the checker runs its cycles silently.
+    const log = join(dir, "garbage-cap.log");
+    writeFileSync(log, "u".repeat(2000) + "\n");
+    const stderrFile = join(dir, "garbage-cap.stderr");
+    runBash(
+      `_switchroom_log_rotator ${JSON.stringify(log)} 2> ${JSON.stringify(stderrFile)} & RPID=$!
+       sleep 2; kill "$RPID" 2>/dev/null; wait "$RPID" 2>/dev/null; true`,
+      {
+        SWITCHROOM_SIDECAR_LOG_MAX_BYTES: "not-a-number",
+        SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC: "1",
+      },
+      15_000,
+    );
+    expect(existsSync(log + ".1")).toBe(false);
+    expect(statSync(log).size).toBeGreaterThanOrEqual(2000);
+    expect(readFileSync(stderrFile, "utf-8")).toBe("");
+  }, 15_000);
+
+  it("a cap of 0 disables rotation (operator escape hatch)", () => {
     const log = join(dir, "disabled.log");
     writeFileSync(log, "w".repeat(5000) + "\n");
     runBash(

--- a/tests/gateway-supervisor-log-rotation.test.ts
+++ b/tests/gateway-supervisor-log-rotation.test.ts
@@ -105,13 +105,20 @@ describe("_switchroom_log_rotator — #3025 size-based copytruncate", () => {
     // and appends a sentinel AFTER the rotate window. copytruncate keeps
     // that fd pointing at the (now-truncated) live inode, so the sentinel
     // must land in the live file — not vanish into an orphaned inode.
+    // Timing margins are deliberately wide (interval 1s, sentinel at
+    // t+3s, kill at t+5s): with the old t+2s sentinel a first check
+    // that slipped past ~2s under CI load rotated AFTER the sentinel
+    // was written and truncated it away — a pure-timing flake. Three
+    // full intervals of slack before the sentinel makes that slip
+    // practically impossible while keeping the test well under the
+    // 15s timeout.
     runBash(
       `exec 9>> ${JSON.stringify(log)}
        _switchroom_log_rotator ${JSON.stringify(log)} & RPID=$!
-       sleep 2
+       sleep 3
        echo "SENTINEL_AFTER_ROTATE" >&9
        exec 9>&-
-       sleep 1; kill "$RPID" 2>/dev/null; wait "$RPID" 2>/dev/null; true`,
+       sleep 2; kill "$RPID" 2>/dev/null; wait "$RPID" 2>/dev/null; true`,
       {
         SWITCHROOM_SIDECAR_LOG_MAX_BYTES: "1000",
         SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC: "1",

--- a/tests/gateway-supervisor-log-rotation.test.ts
+++ b/tests/gateway-supervisor-log-rotation.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync, existsSync, statSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// #3025: the gateway sidecar appends per-poll trace lines and the
+// supervise loop only regains control on child EXIT — so a gateway that
+// runs for weeks let gateway-supervisor.log grow to 555MB and fill the
+// host disk. `_switchroom_log_rotator` is a background size checker that
+// copytruncates the logfile when it exceeds SWITCHROOM_SIDECAR_LOG_MAX_BYTES.
+//
+// copytruncate (cp + `: >`) NOT `mv`: the supervised child holds an open
+// fd on the logfile (`>> "$_logfile"`). A plain mv would orphan that fd —
+// the child would keep writing to the renamed inode and the live path
+// would stop growing. This test asserts the copytruncate outcome: the
+// live file is truncated, a `.1` generation captures the old bytes, and
+// a process still appending to the ORIGINAL fd keeps landing in the live
+// file (proving the fd was preserved).
+
+const TEMPLATE = join(__dirname, "..", "profiles", "_base", "start.sh.hbs");
+
+// Extract the pure-shell _switchroom_log_rotator function from the
+// handlebars template (its body contains no {{ }} tokens — asserted).
+function extractRotator(): string {
+  const src = readFileSync(TEMPLATE, "utf-8");
+  const lines = src.split("\n");
+  const start = lines.findIndex((l) => l.includes("_switchroom_log_rotator() {"));
+  expect(start, "_switchroom_log_rotator() not found in start.sh.hbs").toBeGreaterThanOrEqual(0);
+  let end = -1;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (lines[i] === "  }") { end = i; break; }
+  }
+  expect(end, "closing brace of _switchroom_log_rotator not found").toBeGreaterThan(start);
+  const fn = lines.slice(start, end + 1).map((l) => l.replace(/^ {2}/, "")).join("\n");
+  expect(fn).not.toContain("{{");
+  return fn;
+}
+
+let dir: string;
+let fnPath: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "rot-test-"));
+  fnPath = join(dir, "rot.fn");
+  writeFileSync(fnPath, extractRotator());
+});
+
+function runBash(script: string, env: Record<string, string>, timeoutMs: number): string {
+  const p = join(dir, `drv-${Math.random().toString(36).slice(2)}.sh`);
+  writeFileSync(p, `set -u\nsource ${JSON.stringify(fnPath)}\n${script}\n`);
+  try {
+    return execFileSync("bash", [p], {
+      encoding: "utf-8",
+      timeout: timeoutMs,
+      env: { ...process.env, ...env },
+    });
+  } finally {
+    rmSync(p, { force: true });
+  }
+}
+
+describe("_switchroom_log_rotator — #3025 size-based copytruncate", () => {
+  it("rotates when the log exceeds the cap and keeps at most ~2x cap on disk", () => {
+    const log = join(dir, "gw.log");
+    // Start ~2000 bytes — over the 1000-byte cap below.
+    writeFileSync(log, "x".repeat(2000) + "\n");
+    runBash(
+      `_switchroom_log_rotator ${JSON.stringify(log)} & RPID=$!
+       sleep 2; kill "$RPID" 2>/dev/null; wait "$RPID" 2>/dev/null; true`,
+      {
+        SWITCHROOM_SIDECAR_LOG_MAX_BYTES: "1000",
+        SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC: "1",
+      },
+      15_000,
+    );
+    // .1 generation captured the old (over-cap) content.
+    expect(existsSync(log + ".1"), "expected rotated .1 generation").toBe(true);
+    expect(statSync(log + ".1").size).toBeGreaterThanOrEqual(2000);
+    // Live file was truncated (only the small rotation-notice line remains).
+    expect(statSync(log).size).toBeLessThan(1000);
+    expect(readFileSync(log, "utf-8")).toContain("rotated");
+  }, 15_000);
+
+  it("does NOT rotate a log under the cap", () => {
+    const log = join(dir, "small.log");
+    writeFileSync(log, "y".repeat(100) + "\n");
+    runBash(
+      `_switchroom_log_rotator ${JSON.stringify(log)} & RPID=$!
+       sleep 2; kill "$RPID" 2>/dev/null; wait "$RPID" 2>/dev/null; true`,
+      {
+        SWITCHROOM_SIDECAR_LOG_MAX_BYTES: "1000",
+        SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC: "1",
+      },
+      15_000,
+    );
+    expect(existsSync(log + ".1")).toBe(false);
+    expect(readFileSync(log, "utf-8")).not.toContain("rotated");
+  }, 15_000);
+
+  it("copytruncate preserves an already-open writer fd (mv would orphan it)", () => {
+    const log = join(dir, "fd.log");
+    writeFileSync(log, "z".repeat(2000) + "\n");
+    // A background writer holds an fd open on the ORIGINAL path via `>>`
+    // and appends a sentinel AFTER the rotate window. copytruncate keeps
+    // that fd pointing at the (now-truncated) live inode, so the sentinel
+    // must land in the live file — not vanish into an orphaned inode.
+    runBash(
+      `exec 9>> ${JSON.stringify(log)}
+       _switchroom_log_rotator ${JSON.stringify(log)} & RPID=$!
+       sleep 2
+       echo "SENTINEL_AFTER_ROTATE" >&9
+       exec 9>&-
+       sleep 1; kill "$RPID" 2>/dev/null; wait "$RPID" 2>/dev/null; true`,
+      {
+        SWITCHROOM_SIDECAR_LOG_MAX_BYTES: "1000",
+        SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC: "1",
+      },
+      15_000,
+    );
+    expect(existsSync(log + ".1")).toBe(true);
+    expect(readFileSync(log, "utf-8")).toContain("SENTINEL_AFTER_ROTATE");
+  }, 15_000);
+
+  it("a non-positive cap disables rotation (operator escape hatch)", () => {
+    const log = join(dir, "disabled.log");
+    writeFileSync(log, "w".repeat(5000) + "\n");
+    runBash(
+      `_switchroom_log_rotator ${JSON.stringify(log)} & RPID=$!
+       sleep 2; kill "$RPID" 2>/dev/null; wait "$RPID" 2>/dev/null; true`,
+      {
+        SWITCHROOM_SIDECAR_LOG_MAX_BYTES: "0",
+        SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC: "1",
+      },
+      15_000,
+    );
+    expect(existsSync(log + ".1")).toBe(false);
+    expect(statSync(log).size).toBeGreaterThanOrEqual(5000);
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary
Two-part fix for the unbounded `gateway-supervisor.log` growth (555MB on clerk, 162MB on klanker):

1. **Gate per-poll trace noise** behind `SWITCHROOM_GW_TRACE` (`telegram-plugin/shared/gw-trace-gate.ts`):
   - `tg-post method=getUpdates/getMe ... status=ok` heartbeats (one per ~30s long-poll) suppressed by default.
   - `gw-trace shadow event=tick effects=[] global=bridge_alive_idle` idle no-op ticks suppressed by default.
   - **Always emitted:** any `status=err`, every other API method's `ok` line (sendMessage/edit/... real observability, #656/#657), and any tick that produced effects or landed the machine `bridge_alive_in_turn`. Dispatch trace lines (`gw-trace dispatch ...`) fire only on real inbound activity, so they are left untouched.
   - Set `SWITCHROOM_GW_TRACE=1` (or `true`) to restore the full firehose when debugging the delivery/poll path.

2. **Size-based log rotation** in `_switchroom_supervise` (`profiles/_base/start.sh.hbs`):
   - A background checker copytruncates the sidecar logfile when it exceeds `SWITCHROOM_SIDECAR_LOG_MAX_BYTES` (default 50 MiB), checked every `SWITCHROOM_SIDECAR_LOG_ROTATE_INTERVAL_SEC` (default 300s).
   - **copytruncate, not `mv`:** the supervised child holds an open fd on the logfile (`>> "$_logfile"`); `mv` would orphan it. `cp + : >` preserves the fd. Keeps at most ~2×cap on disk (live + one `.1`).
   - Runs independently of the respawn loop, which only regains control on child exit — the gateway can run for weeks, so rotate-at-restart alone was insufficient.
   - `SWITCHROOM_SIDECAR_LOG_MAX_BYTES=0` disables rotation (operator escape hatch); both env overrides are validated at entry — garbage values (and a zero interval) fall back to the defaults instead of hot-spinning or erroring per cycle.

## Why
Ungated per-poll trace lines + zero rotation filled the host disk. A silently full disk degrades every always-on agent — exactly the recurring, invisible failure the fleet-stays-healthy job exists to prevent.

## Test plan
- `telegram-plugin/tests/gw-trace-gate.test.ts` — flag on/off, error lines always emitted, poll-method + idle-tick suppression, real events/ticks kept.
- `tests/gateway-supervisor-log-rotation.test.ts` — rotates over cap, skips under cap, copytruncate preserves an open writer fd, `cap<=0` disables.
- Existing `tests/gateway-supervisor-backoff.test.ts` updated (rotator stub, since supervise now depends on it) — still green.
- Related shadow/dispatch suites (gate-parity-probe, dispatch-equivalence, cutover-gate, emit-after-intercepts) green.
- `npm run lint` clean (tsc + all 8 guards; no `gateway.ts` bot-api allowlist shift).

## Risk
Low. Default-off firehose is fully reversible via env. Rotation keeps the same path, so `src/fleet-health/scan.ts` + `detect.ts` readers are unaffected (they read the live file, now bounded rather than reading a 555MB blob).

## Job spec
`reference/jobs/fleet-stays-healthy.md` — operator pain: silent disk fill on always-on agents.

Fixes #3025

🤖 Generated with [Claude Code](https://claude.com/claude-code)
