### PR TITLE
fix(crash-reports): tighten perms to 0600/0700 (#741)

### DIFF
--- a/src/agents/tmux.ts
+++ b/src/agents/tmux.ts
@@ -14,7 +14,7 @@
 // removed.)
 
 import { execFileSync } from "node:child_process";
-import { mkdirSync, readdirSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readdirSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 export interface CapturePaneOptions {
@@ -48,11 +48,24 @@ export function captureAgentPane(opts: CapturePaneOptions): CaptureResult {
   const outPath = resolve(outDir, `${ts}-${reasonSlug}.txt`);
 
   try {
-    mkdirSync(outDir, { recursive: true, mode: 0o755 });
+    // 0o700: crash reports contain tmux pane scrollback, which may hold
+    // secrets. Keep the directory owner-only.
+    mkdirSync(outDir, { recursive: true, mode: 0o700 });
   } catch (err) {
     const msg = `mkdir crash-reports failed: ${(err as Error).message}`;
     console.error(`[tmux-capture] ${agentName}: ${msg}`);
     return { error: msg };
+  }
+
+  // mkdirSync's mode is ignored when the dir already exists, so a
+  // pre-existing 0o755 crash-reports dir would keep its loose perms.
+  // Best-effort chmod to tighten it; non-fatal if it fails.
+  try {
+    chmodSync(outDir, 0o700);
+  } catch (err) {
+    console.error(
+      `[tmux-capture] ${agentName}: chmod crash-reports 0700 failed: ${(err as Error).message}`,
+    );
   }
 
   const args = ["-L", socket, "capture-pane", "-p"];
@@ -90,8 +103,10 @@ export function captureAgentPane(opts: CapturePaneOptions): CaptureResult {
     `\n`;
 
   try {
+    // 0o600: the report body is raw pane scrollback and may contain
+    // secrets — keep it owner-read/write only.
     writeFileSync(outPath, Buffer.concat([Buffer.from(header, "utf8"), body]), {
-      mode: 0o644,
+      mode: 0o600,
     });
   } catch (err) {
     const msg = `write crash-report failed: ${(err as Error).message}`;

--- a/tests/tmux-capture.test.ts
+++ b/tests/tmux-capture.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync, statSync, utimesSync } from "node:fs";
+import { mkdtempSync, mkdirSync, chmodSync, readdirSync, readFileSync, rmSync, writeFileSync, statSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 
@@ -113,6 +113,35 @@ describe("captureAgentPane", () => {
     // Header is ~100 bytes; body capped at 10MB. Allow generous header room.
     expect(size).toBeLessThan(10 * 1024 * 1024 + 1024);
     expect(size).toBeGreaterThan(10 * 1024 * 1024 - 1024);
+  });
+
+  it("writes the crash-report file with owner-only perms (0o600)", () => {
+    mockedExec.mockReturnValue(Buffer.from("secret pane content\n"));
+    const result = captureAgentPane({ agentName: "a", agentDir, reason: "r" });
+    expect("path" in result).toBe(true);
+    if (!("path" in result)) return;
+    const mode = statSync(result.path).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("creates the crash-reports dir with owner-only perms (0o700)", () => {
+    mockedExec.mockReturnValue(Buffer.from("x"));
+    const result = captureAgentPane({ agentName: "a", agentDir, reason: "r" });
+    expect("path" in result).toBe(true);
+    const dir = resolve(agentDir, "crash-reports");
+    const mode = statSync(dir).mode & 0o777;
+    expect(mode).toBe(0o700);
+  });
+
+  it("tightens a pre-existing loose (0o755) crash-reports dir to 0o700", () => {
+    mockedExec.mockReturnValue(Buffer.from("x"));
+    const dir = resolve(agentDir, "crash-reports");
+    mkdirSync(dir, { recursive: true, mode: 0o755 });
+    chmodSync(dir, 0o755);
+    const result = captureAgentPane({ agentName: "a", agentDir, reason: "r" });
+    expect("path" in result).toBe(true);
+    const mode = statSync(dir).mode & 0o777;
+    expect(mode).toBe(0o700);
   });
 
   it("sanitizes weird reason strings into a slug", () => {


### PR DESCRIPTION
## Summary

Crash-report files written by `src/agents/tmux.ts` (`captureAgentPane`) snapshot raw tmux pane scrollback, which may contain secrets. This tightens their filesystem permissions:

- crash-reports dir created `0o700` (was `0o755`)
- report files written `0o600` (was `0o644`)
- best-effort `chmodSync(outDir, 0o700)` after `mkdirSync`, because `mkdirSync`'s `mode` is ignored when the directory already exists — so a pre-existing `0o755` dir gets tightened too. Non-fatal `try/catch`.

## Why

Pane scrollback can hold tokens/secrets; world-readable perms leaked them to any local reader.

## The bash mirror is moot

The issue also referenced the old bash mirror `bin/bridge-watchdog.sh` (`capture_pane_before_restart`). That file was **deleted in commit `43f193d9`** (#2803 — "referenced deleted files (bin/bridge-watchdog.sh, ...)"), and `bin/bridge-watchdog.sh` no longer exists. A repo-wide `grep "crash-report"` confirms `src/agents/tmux.ts` is now the **sole** writer of crash-reports, so the TS fix here fully covers the issue.

## Test plan

- Extended `tests/tmux-capture.test.ts`: asserts file mode `0o600`, dir mode `0o700`, and that a pre-existing `0o755` dir is tightened to `0o700` (`statSync(...).mode & 0o777`).
- Scoped vitest: `./node_modules/.bin/vitest run tests/tmux-capture.test.ts` → 11 passed.
- Verified the 3 new assertions **fail** against the old perms (stash src, keep tests → 3 failed).
- `npm run lint` → clean.

## Risk

Low. Perms-only change to best-effort crash capture; the write path already soft-fails and never throws.

Fixes #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)