### PR TITLE
Delivery-path hardening: turn_end gate backstop, reaction-flush gate, bridge messageId dedup (#2094 findings 1,3,4)

### DIFF
--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -32,6 +32,7 @@ import type { InboundMessage, PermissionEvent, StatusEvent } from '../gateway/ip
 import { matchesAllowRule } from '../permission-rule.js'
 import { createOutstandingPermissionLedger } from './permission-ledger.js'
 import { appendCrashBreadcrumb } from './crash-breadcrumb.js'
+import { InboundDedup, shouldDedupInbound, dedupChatKey } from './inbound-dedup.js'
 
 installPluginLogger()
 
@@ -563,6 +564,18 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       }
     }
 
+    // #2094 finding 4 — turn-complete reset. A successful reply / stream_reply
+    // is the bridge's turn-complete proxy: the agent delivered its answer for
+    // this chat, so the per-chat inbound-dedup set can be cleared (thread-
+    // agnostic — the reply may omit message_thread_id). Bounds memory and lets
+    // a genuinely NEW turn re-use ids the sweep might legitimately resend.
+    if (inboundDedupEnabled && (tool === 'reply' || tool === 'stream_reply')) {
+      const replyChatId = args.chat_id
+      if (typeof replyChatId === 'string' && replyChatId.length > 0) {
+        inboundDedup.clearChat(replyChatId)
+      }
+    }
+
     // The gateway returns the same shape as the legacy server.ts handlers:
     // { content: [{ type: 'text', text: '...' }] }
     if (result.result && typeof result.result === 'object' && 'content' in (result.result as object)) {
@@ -709,7 +722,30 @@ mcp.setNotificationHandler(
 
 let ipc: IpcClientHandle | null = null
 
+// #2094 finding 4 — bridge-side messageId dedup. Guards against the
+// stranded-message sweep re-delivering a genuine user message that was
+// already forwarded to claude (double-executing side-effectful commands,
+// double 👀). Cleared per-chat on turn-complete (a successful reply /
+// stream_reply, below) and capped defensively. Kill switch:
+// SWITCHROOM_INBOUND_DEDUP=0.
+const inboundDedup = new InboundDedup()
+const inboundDedupEnabled = process.env.SWITCHROOM_INBOUND_DEDUP !== '0'
+
 function onInbound(msg: InboundMessage): void {
+  // Drop a re-delivered duplicate of a plain user message before it reaches
+  // the claude session. Only genuine re-deliverable messages are eligible
+  // (see shouldDedupInbound) — synthetic / button / structured-event inbounds
+  // are always forwarded.
+  if (inboundDedupEnabled && shouldDedupInbound(msg)) {
+    const chatKey = dedupChatKey(msg.chatId, msg.threadId)
+    if (inboundDedup.checkAndRecord(chatKey, msg.messageId) === 'duplicate') {
+      process.stderr.write(
+        `telegram bridge: dropping duplicate inbound messageId=${msg.messageId} ` +
+        `chat=${chatKey} (already forwarded this turn — sweep re-delivery, #2094)\n`,
+      )
+      return
+    }
+  }
   // Convert IPC InboundMessage → MCP channel notification
   mcp.notification({
     method: 'notifications/claude/channel',

--- a/telegram-plugin/bridge/inbound-dedup.ts
+++ b/telegram-plugin/bridge/inbound-dedup.ts
@@ -1,0 +1,101 @@
+/**
+ * Bridge-side inbound messageId dedup (#2094 finding 4).
+ *
+ * `onInbound` forwards every IPC inbound to the claude session with no dedup.
+ * A genuine user message that was delivered successfully but slow to ack can
+ * be RE-SENT by the offline/stranded-message sweep — and claude then processes
+ * it twice: a side-effectful slash command double-executes, a 👀 is painted
+ * twice, etc. #2093's idle-gating shrank the window but did not close it.
+ *
+ * Durable fix: a per-chat set of already-forwarded messageIds. A repeat of a
+ * messageId within the same turn is dropped. The set is cleared on
+ * turn-complete (the bridge's turn-complete proxy is a successful
+ * reply/stream_reply for that chat) so memory stays bounded, and it is capped
+ * defensively so a chat that never replies can't grow the set without limit.
+ *
+ * SCOPE — only PLAIN user messages are deduped (see `shouldDedupInbound`).
+ * Synthetic inbounds (meta.source: cron / resume / vault, messageId == a
+ * timestamp), button callbacks, and structured events (checklist task changes,
+ * reactions) are NEVER deduped: they either carry unique ids already or
+ * legitimately repeat the same messageId for genuinely distinct events.
+ */
+
+/** Defensive cap on tracked ids per chat (FIFO-evicted). Bounds memory for a
+ * chat that produces many messages without ever hitting a turn-complete. */
+export const INBOUND_DEDUP_MAX_PER_CHAT = 512
+
+export interface DedupInboundLike {
+  messageId: number
+  meta: Record<string, string>
+}
+
+/**
+ * Only genuine, re-deliverable user messages are eligible for dedup. Excludes:
+ *  - messageId <= 0 (no real Telegram id to key on),
+ *  - meta.source set (synthetic: cron / resume / vault / secret_* — unique
+ *    timestamp ids, and re-delivery is handled upstream),
+ *  - meta.button_callback (a tap; repeats are the user's intent),
+ *  - meta.kind (structured events like checklist_task_changed — the same
+ *    checklist messageId legitimately repeats for distinct state changes),
+ *  - meta.event (reaction-class inbounds).
+ */
+export function shouldDedupInbound(msg: DedupInboundLike): boolean {
+  if (!Number.isFinite(msg.messageId) || msg.messageId <= 0) return false
+  const m = msg.meta ?? {}
+  if (m.source != null) return false
+  if (m.button_callback != null) return false
+  if (m.kind != null) return false
+  if (m.event != null) return false
+  return true
+}
+
+/**
+ * Per-chat forwarded-messageId tracker. Keyed by chatKey (`chatId:threadId`).
+ */
+export class InboundDedup {
+  private readonly byChat = new Map<string, Set<number>>()
+
+  constructor(private readonly maxPerChat: number = INBOUND_DEDUP_MAX_PER_CHAT) {}
+
+  /**
+   * Record `messageId` as forwarded for `chatKey`. Returns 'fresh' the first
+   * time a messageId is seen (caller forwards it) and 'duplicate' on a repeat
+   * (caller drops it). FIFO-evicts the oldest id once the per-chat cap is hit.
+   */
+  checkAndRecord(chatKey: string, messageId: number): 'fresh' | 'duplicate' {
+    let set = this.byChat.get(chatKey)
+    if (set == null) {
+      set = new Set<number>()
+      this.byChat.set(chatKey, set)
+    }
+    if (set.has(messageId)) return 'duplicate'
+    if (set.size >= this.maxPerChat) {
+      // Set iteration order is insertion order — drop the oldest.
+      const oldest = set.values().next().value
+      if (oldest !== undefined) set.delete(oldest)
+    }
+    set.add(messageId)
+    return 'fresh'
+  }
+
+  /** Clear every tracked id for a chat (all threads) — the turn-complete
+   * reset. Thread-agnostic so a reply that omits message_thread_id still
+   * clears the inbound's thread-scoped key. */
+  clearChat(chatId: string): void {
+    const prefix = `${chatId}:`
+    for (const key of this.byChat.keys()) {
+      if (key === chatId || key.startsWith(prefix)) this.byChat.delete(key)
+    }
+  }
+
+  /** Test/introspection helper: number of tracked ids for a chatKey. */
+  size(chatKey: string): number {
+    return this.byChat.get(chatKey)?.size ?? 0
+  }
+}
+
+/** Canonical chat-key derivation (mirrors gateway/chat-key.ts): a null/0
+ * thread collapses to '_'. */
+export function dedupChatKey(chatId: string, threadId?: number): string {
+  return `${chatId}:${threadId == null || threadId === 0 ? '_' : threadId}`
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -511,6 +511,7 @@ import { shouldSuppressRepresent } from './represent-guard.js'
 import { shouldDeferEscalationForBridge } from './escalation-bridge-gate.js'
 import { createInboundSpool } from './inbound-spool.js'
 import { purgeStaleTurnsForChat } from './turn-state-purge.js'
+import { withTurnEndGateBackstop } from './turn-end-gate-backstop.js'
 import { decideInboundDelivery, reserveInboundDelivery } from './inbound-delivery-gate.js'
 import { mayDrainBufferedInbound, shouldArmNoReplyDrain } from './serialize-drain-gate.js'
 import { decideFeedReopen } from './feed-reopen-gate.js'
@@ -15777,6 +15778,24 @@ function handleSessionEvent(ev: SessionEvent): void {
           return
         }
       }
+      // #2094 finding 1 — turn_end gate-wedge backstop. Capture the turn
+      // BEFORE the body runs (the body re-reads currentTurn as `turn`, then
+      // nulls it via endCurrentTurnAtomic on every clean branch). The guarded
+      // finally in withTurnEndGateBackstop forces the canonical purge iff a
+      // throw in a pre-purge op (redactOutboundText, progressDriver?.
+      // takeOverCard, narrative dedup, answer-stream finalize, …) skipped
+      // endCurrentTurnAtomic → purgeReactionTracking, which would otherwise
+      // leave activeTurnStartedAt + claudeBusyKeys populated and wedge the
+      // #1556 inbound gate closed. No-op on the happy path (key already gone).
+      const turnEndBackstopTurn = currentTurn
+      const turnEndBackstopKey =
+        turnEndBackstopTurn != null
+          ? statusKey(turnEndBackstopTurn.sessionChatId, turnEndBackstopTurn.sessionThreadId)
+          : null
+      withTurnEndGateBackstop(
+        turnEndBackstopKey,
+        turnEndBackstopTurn,
+        () => {
       // Drain any still-pending tool dispatch typing entries — covers
       // transcript truncation or a Claude Code crash mid-tool.
       typingWrapper.drainAll()
@@ -16267,9 +16286,12 @@ function handleSessionEvent(ev: SessionEvent): void {
                 // the reaction is only finalized by the `turn_end` IPC
                 // handler — mid-turn delivery proofs (local history,
                 // stream finalize callbacks, executeReply post-send) no
-                // longer transition the emoji. This branch just purges
-                // the per-turn reaction tracking entry and returns.
-                purgeReactionTracking(statusKey(backstopChatId, backstopThreadId))
+                // longer transition the emoji. This branch just returns.
+                // #2094 cosmetic: the per-turn reaction tracking was ALREADY
+                // purged synchronously by endCurrentTurnAtomic (before this
+                // async IIFE ran). The old redundant purgeReactionTracking
+                // here re-fired on an already-cleared key WITHOUT `endingTurn`,
+                // emitting an inconsistent shadow trace. Removed.
                 return
               }
             } catch {}
@@ -16405,9 +16427,13 @@ function handleSessionEvent(ev: SessionEvent): void {
             // #1713: backstop send failed — finalize as error so the
             // turn ends cleanly with 😱 rather than leaving it open.
             if (backstopCtrl) backstopCtrl.finalize('error')
-          } finally {
-            purgeReactionTracking(statusKey(backstopChatId, backstopThreadId))
           }
+          // #2094 cosmetic: the trailing `finally { purgeReactionTracking() }`
+          // was removed. endCurrentTurnAtomic already ran the canonical purge
+          // (with the authoritative `endingTurn`) synchronously before this
+          // async IIFE started, so re-purging here only re-fired on an
+          // already-cleared key without `endingTurn` — an inconsistent shadow
+          // trace. The #2094 finding-1 backstop covers any pre-purge throw.
         })()
         return
       }
@@ -16600,6 +16626,14 @@ function handleSessionEvent(ev: SessionEvent): void {
       // #549 fix — preamble flush already happened at the TOP of this
       // turn_end handler (before turn.answerStream is nulled). See
       // comment near line 3431.
+      return
+        }, // end withTurnEndGateBackstop body (#2094 finding 1)
+        {
+          hasActiveTurn: (k) => activeTurnStartedAt.has(k),
+          purge: (k, endingTurn) => purgeReactionTracking(k, endingTurn),
+          log: (m) => process.stderr.write(m + '\n'),
+        },
+      )
       return
     }
   }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -26083,16 +26083,22 @@ function flushReactionBatch(batch: ReactionBatch): void {
     text,
     meta,
   }
-  const delivered = ipcServer.sendToAgent(agentName, inbound)
-  if (delivered) markClaudeBusyForInbound(inbound)
+  // #2094 finding 3 — route the reaction flush through the SAME #1556
+  // decideInboundDelivery gate every other synthetic inbound uses (via
+  // deliverResumeSyntheticOrBuffer), instead of a raw ipcServer.sendToAgent.
+  // A reaction that lands WHILE a turn is in flight was previously fired
+  // mid-turn — the bridge typed it into the CLI composer where it stranded
+  // by the turn-completion race (the #1556 composer wedge). Now a mid-turn
+  // reaction buffers-until-idle (the turn-complete hook + idle-drain timer
+  // flush pendingInboundBuffer the instant claude goes idle, landing cleanly
+  // as a fresh turn); an idle reaction delivers now, buffering only on a
+  // genuine bridge-offline miss — the #1150 buffer-on-failure guarantee,
+  // preserved inside the helper.
+  const delivered = deliverResumeSyntheticOrBuffer(agentName, inbound)
   process.stderr.write(
     `telegram gateway: reactions.dispatch agent=${agentName} chat=${batch.chatId} ` +
     `count=${batch.reactions.length} batched=${batch.batched} delivered=${delivered}\n`,
   )
-  // #1150: buffer-on-failure for reaction-triggered wake-ups too.
-  if (!delivered) {
-    pendingInboundBuffer.push(agentName, inbound)
-  }
 }
 
 // ─── Inbound message_reaction handler ────────────────────────────────────

--- a/telegram-plugin/gateway/turn-end-gate-backstop.ts
+++ b/telegram-plugin/gateway/turn-end-gate-backstop.ts
@@ -1,0 +1,59 @@
+/**
+ * turn-end gate-wedge backstop (#2094 finding 1).
+ *
+ * The `turn_end` session-event handler in `gateway.ts` runs a long
+ * synchronous prelude (narrative dedup, answer-stream finalize,
+ * `redactOutboundText`, `progressDriver?.takeOverCard`, …) before it reaches
+ * the branch that calls `endCurrentTurnAtomic` → `purgeReactionTracking` —
+ * the canonical op that deletes this turn's `activeTurnStartedAt` entry and
+ * re-opens the #1556 inbound buffer gate.
+ *
+ * If ANY of those pre-purge ops throws, the handler exits before the canonical
+ * purge runs, leaving `activeTurnStartedAt` (and the mirrored `claudeBusyKeys`
+ * that `purgeReactionTracking` drains) populated. The #1556 inbound gate then
+ * wedges CLOSED: every subsequent inbound buffers, and only the 300 s
+ * silence-poke fallback eventually recovers it (degraded, not permanent).
+ *
+ * `withTurnEndGateBackstop` wraps the handler body in a guarded `try/finally`.
+ * The `finally` acts ONLY when a throw skipped the canonical purge — detected
+ * by the turn's key still being present in `activeTurnStartedAt`. On the happy
+ * path the canonical purge already deleted the key, so the backstop is a
+ * no-op. The original error is NOT swallowed: `finally` re-raises it after the
+ * backstop purge, so upstream error handling / unhandled-rejection policy is
+ * unchanged.
+ */
+export interface TurnEndGateBackstopDeps<T> {
+  /** True while `key`'s `activeTurnStartedAt` entry is still populated. */
+  hasActiveTurn: (key: string) => boolean
+  /** The canonical purge (production wires this to `purgeReactionTracking`). */
+  purge: (key: string, endingTurn: T | undefined) => void
+  /** Optional structured log emitted only when the backstop actually fires. */
+  log?: (msg: string) => void
+}
+
+/**
+ * Run `body` (the synchronous turn_end handler body) under a guarded finally.
+ *
+ * @param key         the turn's status key, or null when there was no live
+ *                    turn to end (then the backstop can never fire).
+ * @param endingTurn  the captured turn atom, forwarded to `purge` so the
+ *                    shadow trace sees the authoritative `replyCalled` flag.
+ */
+export function withTurnEndGateBackstop<T>(
+  key: string | null,
+  endingTurn: T | null,
+  body: () => void,
+  deps: TurnEndGateBackstopDeps<T>,
+): void {
+  try {
+    body()
+  } finally {
+    if (key != null && deps.hasActiveTurn(key)) {
+      deps.log?.(
+        `telegram gateway: turn_end backstop-purge — a pre-purge throw left ` +
+          `the #1556 inbound gate wedged (key=${key}); forcing purge (#2094)`,
+      )
+      deps.purge(key, endingTurn ?? undefined)
+    }
+  }
+}

--- a/telegram-plugin/tests/inbound-dedup.test.ts
+++ b/telegram-plugin/tests/inbound-dedup.test.ts
@@ -1,0 +1,93 @@
+/**
+ * #2094 finding 4 — bridge-side messageId dedup.
+ *
+ * Outcome contract: a genuine user message re-delivered by the stranded-
+ * message sweep within one turn is forwarded to claude exactly ONCE; after
+ * the turn-complete clear (a successful reply for that chat) forwarding
+ * resumes. Synthetic / button / structured-event inbounds are never deduped,
+ * and per-chat memory is capped.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  InboundDedup,
+  shouldDedupInbound,
+  dedupChatKey,
+  INBOUND_DEDUP_MAX_PER_CHAT,
+  type DedupInboundLike,
+} from '../bridge/inbound-dedup.js'
+
+function userMsg(messageId: number, extra: Record<string, string> = {}): DedupInboundLike {
+  return { messageId, meta: { chat_id: '12345', message_id: String(messageId), ...extra } }
+}
+
+describe('shouldDedupInbound gate', () => {
+  it('dedups a plain user message', () => {
+    expect(shouldDedupInbound(userMsg(500))).toBe(true)
+  })
+  it('never dedups synthetic (meta.source), button, structured, or reaction inbounds', () => {
+    expect(shouldDedupInbound(userMsg(500, { source: 'cron' }))).toBe(false)
+    expect(shouldDedupInbound(userMsg(500, { button_callback: 'true' }))).toBe(false)
+    expect(shouldDedupInbound(userMsg(500, { kind: 'checklist_task_changed' }))).toBe(false)
+    expect(shouldDedupInbound(userMsg(500, { event: 'reaction' }))).toBe(false)
+  })
+  it('never dedups a non-positive messageId (no real Telegram id)', () => {
+    expect(shouldDedupInbound(userMsg(0))).toBe(false)
+    expect(shouldDedupInbound({ messageId: -1, meta: {} })).toBe(false)
+  })
+})
+
+describe('InboundDedup checkAndRecord + clearChat', () => {
+  it('processes a duplicate messageId within one turn exactly once', () => {
+    const d = new InboundDedup()
+    const key = dedupChatKey('12345')
+    expect(d.checkAndRecord(key, 500)).toBe('fresh')
+    // Sweep re-delivers the SAME messageId before the turn completes.
+    expect(d.checkAndRecord(key, 500)).toBe('duplicate')
+    expect(d.checkAndRecord(key, 500)).toBe('duplicate')
+    // A different message in the same turn is still forwarded.
+    expect(d.checkAndRecord(key, 501)).toBe('fresh')
+  })
+
+  it('resumes processing the same messageId after the turn-complete clear', () => {
+    const d = new InboundDedup()
+    const key = dedupChatKey('12345')
+    expect(d.checkAndRecord(key, 500)).toBe('fresh')
+    expect(d.checkAndRecord(key, 500)).toBe('duplicate')
+    // reply fired for the chat → turn-complete reset.
+    d.clearChat('12345')
+    expect(d.size(key)).toBe(0)
+    // A genuinely new turn may re-see the id (fresh again).
+    expect(d.checkAndRecord(key, 500)).toBe('fresh')
+  })
+
+  it('clearChat is thread-agnostic — clears every thread key for the chat', () => {
+    const d = new InboundDedup()
+    const dm = dedupChatKey('12345')
+    const topic = dedupChatKey('12345', 42)
+    d.checkAndRecord(dm, 500)
+    d.checkAndRecord(topic, 700)
+    d.checkAndRecord(dedupChatKey('999', 1), 800) // unrelated chat, untouched
+    d.clearChat('12345')
+    expect(d.size(dm)).toBe(0)
+    expect(d.size(topic)).toBe(0)
+    expect(d.size(dedupChatKey('999', 1))).toBe(1)
+  })
+
+  it('caps per-chat memory (FIFO-evicts the oldest id)', () => {
+    const d = new InboundDedup(3)
+    const key = dedupChatKey('12345')
+    d.checkAndRecord(key, 1)
+    d.checkAndRecord(key, 2)
+    d.checkAndRecord(key, 3)
+    d.checkAndRecord(key, 4) // evicts id 1
+    expect(d.size(key)).toBe(3)
+    // id 1 was evicted → treated as fresh again (bounded memory, accepted).
+    expect(d.checkAndRecord(key, 1)).toBe('fresh')
+    // ids still tracked are duplicates.
+    expect(d.checkAndRecord(key, 4)).toBe('duplicate')
+  })
+
+  it('default cap is a sane bound', () => {
+    expect(INBOUND_DEDUP_MAX_PER_CHAT).toBeGreaterThanOrEqual(128)
+  })
+})

--- a/telegram-plugin/tests/reaction-flush-turn-gated.test.ts
+++ b/telegram-plugin/tests/reaction-flush-turn-gated.test.ts
@@ -1,0 +1,100 @@
+/**
+ * #2094 finding 3 — reaction-flush uses the #1556 turn gate.
+ *
+ * THE BUG: flushReactionBatch delivered its synthetic reaction inbound with a
+ * bare `ipcServer.sendToAgent` + busy-mark, buffering ONLY on a bridge-offline
+ * miss. It never ran the #1556 decideInboundDelivery gate. So a reaction that
+ * landed WHILE a turn was in flight fired the MCP channel notification mid-turn
+ * — the unmodified CLI typed it into its TUI composer and the auto-submit raced
+ * turn-completion, re-creating the composer wedge.
+ *
+ * THE FIX: route the flush through deliverResumeSyntheticOrBuffer, the shared
+ * helper that consults the gate (mid-turn → buffer-until-idle, flushed by the
+ * turn-complete hook + idle-drain timer; idle → deliver now; buffer only on a
+ * genuine miss).
+ *
+ * gateway.ts is a large side-effecting module that can't be imported into a
+ * unit test, so this file pins (a) the gate decision for a reaction inbound's
+ * shape via the pure gate + a modeled buffer/drain, and (b) that
+ * flushReactionBatch wires the turn-safe helper structurally — the same
+ * strategy button-tap-turn-gated.test.ts uses.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { decideInboundDelivery } from '../gateway/inbound-delivery-gate.js'
+import { planBufferedRedelivery } from '../gateway/pending-inbound-buffer.js'
+import type { InboundMessage } from '../gateway/ipc-protocol.js'
+
+const gatewaySrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf-8',
+)
+
+// A reaction inbound as flushReactionBatch builds it: synthetic messageId (ts),
+// never steering, never an interrupt — the exact inputs the shared helper
+// (deliverResumeSyntheticOrBuffer) passes to the gate.
+function reactionInbound(ts: number): InboundMessage {
+  return {
+    type: 'inbound',
+    chatId: 'c1',
+    messageId: ts,
+    user: 'u',
+    userId: 42,
+    ts,
+    text: `[user reacted 👍 to your message]`,
+    meta: { chat_id: 'c1', count: '1' },
+  }
+}
+
+describe('reaction flush uses the turn-gate (mid-turn → buffer)', () => {
+  it('buffers a reaction that lands mid-turn, delivers when idle, never mid-turn', () => {
+    const shape = { isSteering: false as const, isInterrupt: false as const }
+    // Reaction lands WHILE a turn is in flight → HELD, not sent (the wedge the
+    // raw sendToAgent used to cause).
+    expect(decideInboundDelivery({ ...shape, turnInFlight: true })).toBe(
+      'buffer-until-idle',
+    )
+    // Reaction lands at an idle prompt → delivered immediately.
+    expect(decideInboundDelivery({ ...shape, turnInFlight: false })).toBe(
+      'deliver',
+    )
+  })
+
+  it('a mid-turn-buffered reaction drains as a fresh turn after turn end', () => {
+    // Model the buffer→drain: the reaction was held mid-turn; on turn-complete
+    // the buffer is planned for redelivery and the reaction lands cleanly as
+    // its own turn (never merged away / dropped).
+    const plan = planBufferedRedelivery([reactionInbound(1000)])
+    expect(plan).toHaveLength(1)
+    expect(plan[0]!.merged.text).toBe('[user reacted 👍 to your message]')
+  })
+})
+
+describe('flushReactionBatch wires the turn-safe helper', () => {
+  const start = gatewaySrc.indexOf('function flushReactionBatch(batch: ReactionBatch)')
+  // Bound the body by the next top-level declaration (the message_reaction
+  // handler block).
+  const body = gatewaySrc.slice(
+    start,
+    gatewaySrc.indexOf("bot.on('message_reaction'", start),
+  )
+
+  it('exists', () => {
+    expect(start, 'flushReactionBatch missing').toBeGreaterThan(0)
+  })
+
+  it('delivers via deliverResumeSyntheticOrBuffer, not a raw ungated sendToAgent', () => {
+    expect(body).toMatch(/deliverResumeSyntheticOrBuffer\(agentName, inbound\)/)
+    // The regressed path — a raw ungated send of the reaction inbound + an
+    // out-of-helper busy-mark — is gone.
+    expect(body).not.toMatch(/ipcServer\.sendToAgent\(agentName, inbound\)/)
+    expect(body).not.toMatch(/markClaudeBusyForInbound\(inbound\)/)
+  })
+
+  it('no longer open-codes the buffer-on-failure push (the helper owns it)', () => {
+    // The #1150 buffer-on-failure guarantee now lives inside
+    // deliverResumeSyntheticOrBuffer, so the flush body must not push directly.
+    expect(body).not.toMatch(/pendingInboundBuffer\.push\(/)
+  })
+})

--- a/telegram-plugin/tests/turn-end-gate-backstop.test.ts
+++ b/telegram-plugin/tests/turn-end-gate-backstop.test.ts
@@ -1,0 +1,92 @@
+/**
+ * #2094 finding 1 — turn_end gate-wedge backstop.
+ *
+ * Outcome contract: if a pre-purge op in the turn_end handler body THROWS
+ * before the canonical purge (endCurrentTurnAtomic → purgeReactionTracking)
+ * runs, the guarded finally must still clear this turn's gate state
+ * (activeTurnStartedAt + the mirrored claudeBusyKeys) so the #1556 inbound
+ * gate re-opens for the next inbound. On the happy path — where the body
+ * clears the key itself — the backstop must be a no-op (no double purge), and
+ * the original error must always propagate.
+ */
+import { describe, it, expect } from 'vitest'
+import { withTurnEndGateBackstop } from '../gateway/turn-end-gate-backstop.js'
+
+interface Turn {
+  sessionChatId: string
+  sessionThreadId?: number
+}
+
+function statusKey(chatId: string, threadId?: number): string {
+  return `${chatId}:${threadId ?? '_'}`
+}
+
+/** Mirror of the production gate state + a purge that clears it, as
+ * purgeReactionTracking does (activeTurnStartedAt.delete + claudeBusyKeys
+ * drain for the key). */
+function freshGate(turn: Turn) {
+  const key = statusKey(turn.sessionChatId, turn.sessionThreadId)
+  const activeTurnStartedAt = new Map<string, number>([[key, Date.now()]])
+  const claudeBusyKeys = new Set<string>([key])
+  const purgeCalls: Array<{ key: string; endingTurn: Turn | undefined }> = []
+  const purge = (k: string, endingTurn: Turn | undefined) => {
+    purgeCalls.push({ key: k, endingTurn })
+    activeTurnStartedAt.delete(k)
+    claudeBusyKeys.delete(k)
+  }
+  return { key, activeTurnStartedAt, claudeBusyKeys, purge, purgeCalls }
+}
+
+function deps(gate: ReturnType<typeof freshGate>) {
+  return {
+    hasActiveTurn: (k: string) => gate.activeTurnStartedAt.has(k),
+    purge: gate.purge,
+    log: () => {},
+  }
+}
+
+describe('withTurnEndGateBackstop (#2094 finding 1)', () => {
+  it('a throw in a pre-purge op still clears the gate for the next inbound', () => {
+    const turn: Turn = { sessionChatId: '12345' }
+    const gate = freshGate(turn)
+
+    // The body throws BEFORE it reaches endCurrentTurnAtomic → purge (models
+    // a throw in redactOutboundText / progressDriver?.takeOverCard).
+    expect(() =>
+      withTurnEndGateBackstop(gate.key, turn, () => {
+        throw new Error('redactOutboundText blew up')
+      }, deps(gate)),
+    ).toThrow('redactOutboundText blew up')
+
+    // Outcome: gate is OPEN again — both maps cleared, so the #1556 inbound
+    // gate no longer wedges the next inbound.
+    expect(gate.activeTurnStartedAt.has(gate.key)).toBe(false)
+    expect(gate.claudeBusyKeys.has(gate.key)).toBe(false)
+    // The backstop fired exactly once, forwarding the ending turn.
+    expect(gate.purgeCalls).toEqual([{ key: gate.key, endingTurn: turn }])
+  })
+
+  it('is a no-op on the happy path (body already purged) — no double purge', () => {
+    const turn: Turn = { sessionChatId: '12345', sessionThreadId: 7 }
+    const gate = freshGate(turn)
+
+    withTurnEndGateBackstop(gate.key, turn, () => {
+      // Model the canonical clean branch: endCurrentTurnAtomic → purge ran.
+      gate.purge(gate.key, turn)
+    }, deps(gate))
+
+    // Purge happened exactly once (the canonical one); the finally saw the
+    // key already gone and did NOT re-fire the inconsistent shadow trace.
+    expect(gate.purgeCalls).toHaveLength(1)
+    expect(gate.activeTurnStartedAt.has(gate.key)).toBe(false)
+  })
+
+  it('does nothing when there was no live turn (null key)', () => {
+    const gate = freshGate({ sessionChatId: '12345' })
+    // A different, unrelated gate state; null key means no turn to end.
+    let ran = false
+    withTurnEndGateBackstop(null, null, () => { ran = true }, deps(gate))
+    expect(ran).toBe(true)
+    expect(gate.purgeCalls).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Implements #2094 findings 1, 3, 4. Finding 2 (centralize drain-path tracking via a shared `deliverAndTrack` helper) is **stale — already covered by `trackRedeliveredInbound` on main**: the buffer-drain / bridgeUp / idle-drain callbacks route through `trackRedeliveredInbound` (`telegram-plugin/gateway/gateway.ts:8490`), which calls `trackDelivery` at `gateway.ts:8523` after the merge, so a drained-then-stranded inbound is visible to the sweep. It is wired as the drain callback (`onUserInboundDelivered: trackRedeliveredInbound`, `gateway.ts:9287`; also `4224` / `8448` / `10690`). No code change needed for finding 2.

Three separable concerns, one commit each, each with its own tests. The gateway IIFE is un-instantiable in-process, so tests follow the repo convention (`button-tap-turn-gated.test.ts`, `buffer-gate-broadened.test.ts`): pure extracted-helper outcome assertions + structural source assertions binding the fix to the handler.

## Finding 1 — turn_end gate-wedge backstop (`15f114d6`)
The `turn_end` handler runs a long synchronous prelude (`redactOutboundText`, `progressDriver?.takeOverCard`, narrative dedup, answer-stream finalize) before reaching `endCurrentTurnAtomic → purgeReactionTracking` — the canonical op that deletes `activeTurnStartedAt` and re-opens the #1556 inbound gate. A throw in any pre-purge op left `activeTurnStartedAt` + `claudeBusyKeys` populated and wedged the gate closed.

- New `telegram-plugin/gateway/turn-end-gate-backstop.ts`: `withTurnEndGateBackstop` wraps the handler body in a guarded `try/finally` that forces the canonical purge ONLY when a throw skipped it (key still in `activeTurnStartedAt`); re-raises the original error; no-op on the happy path.
- Wired into the handler in `telegram-plugin/gateway/gateway.ts`.
- Cosmetic (folded in per the issue): removed the redundant double `purgeReactionTracking` in the turn-flush IIFE — `endCurrentTurnAtomic` already purged synchronously with the authoritative `endingTurn`, so the IIFE re-purges re-fired on an already-cleared key without `endingTurn`, emitting an inconsistent shadow trace.
- Test `telegram-plugin/tests/turn-end-gate-backstop.test.ts`: an injected throw in a pre-purge op still clears `activeTurnStartedAt` + `claudeBusyKeys` (gate open for next inbound); happy path does not double-purge.

## Finding 3 — reaction-flush gate (`a8c1b91e`)
`flushReactionBatch` sent its synthetic reaction inbound via a raw `ipcServer.sendToAgent`, bypassing the #1556 `decideInboundDelivery` gate — a mid-turn reaction fired into the CLI composer and re-created the wedge.

- `gateway.ts`: route the flush through `deliverResumeSyntheticOrBuffer` (the shared gated helper used by vault-resume + button taps). Mid-turn → buffer-until-idle; idle → deliver now; buffer only on a genuine bridge-offline miss (#1150 guarantee, now owned by the helper).
- Test `telegram-plugin/tests/reaction-flush-turn-gated.test.ts`: reaction buffered mid-turn, delivered when idle (never sent mid-turn), drains as a fresh turn after turn end; source assertions that the flush routes through the helper and no longer open-codes `sendToAgent`/busy-mark/buffer-push.

## Finding 4 — bridge-side messageId dedup (`f29a78da`)
`bridge.ts` `onInbound` had no dedup; a delivered-but-slow-to-ack message re-sent by the sweep was processed twice (double-executed side-effectful commands, double 👀).

- New `telegram-plugin/bridge/inbound-dedup.ts`: per-chat `Map<chatKey, Set<messageId>>` with FIFO cap; `shouldDedupInbound` gates to genuine re-deliverable user messages only (synthetic / button / structured-event inbounds always forwarded).
- `bridge.ts`: drop a duplicate in `onInbound`; clear per-chat on turn-complete (a successful `reply`/`stream_reply`). Kill switch `SWITCHROOM_INBOUND_DEDUP=0`.
- Test `telegram-plugin/tests/inbound-dedup.test.ts`: duplicate messageId processed once; forwarding resumes after the turn-complete clear; thread-agnostic clear; FIFO cap; gate exclusions.

## Test + lint evidence
- `vitest run` new suites: turn-end-gate-backstop 3/3, inbound-dedup 8/8, reaction-flush-turn-gated 5/5 — all pass.
- Related regressions green: `turn-flush-safety` 45/45, `buffer-gate-broadened` 4/4, `turn-flush-dedup-controller` 3/3, `status-reactions` 31/31 (vitest); `gateway-bridge` 24/24, `reaction-trigger` + `reaction-trigger-flow` 44/44 (bun test).
- `npm run lint`: clean (tsc --noEmit + all 8 guard scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)