### PR TITLE
fix(doctor): generalize operator-ownership probe to full sweep set (#1476)

### DIFF
--- a/src/cli/doctor-secret-access.ts
+++ b/src/cli/doctor-secret-access.ts
@@ -40,6 +40,10 @@ import { join } from "node:path";
 
 import { resolveStatePath } from "../config/paths.js";
 import { resolveAgentConfig } from "../config/merge.js";
+import {
+  operatorOwnedPaths,
+  walkOperatorOwnedTargets,
+} from "./operator-uid.js";
 import { openVault, type VaultEntry } from "../vault/vault.js";
 import { checkAclByAgent, checkEntryScope } from "../vault/broker/acl.js";
 import { rpcRaw } from "../vault/broker/client.js";
@@ -70,6 +74,24 @@ export interface SecretAccessDeps {
   passphrase?: string;
   /** Probe the vault file as the operator. Default: realpath + stat + access(R_OK). */
   statVault?: (path: string) => VaultFileStat;
+  /**
+   * Probe any operator-owned path as the operator (Check A sweep).
+   * Default: realpath + stat + access(R_OK) — same shim as statVault.
+   */
+  statPath?: (path: string) => VaultFileStat;
+  /** Operator home for the ownership sweep. Default: os.homedir(). */
+  operatorHome?: string;
+  /**
+   * Top-level operator-owned roots to probe (Check A). Default:
+   * `operatorOwnedPaths(home)` — vault/, vault-auto-unlock,
+   * vault-audit.log, host-control-audit.log, accounts/, compose/.
+   */
+  ownedRoots?: string[];
+  /**
+   * Resolve one root to its real target set (symlinks resolved, dirs
+   * recursed). Default: `walkOperatorOwnedTargets(home, {}, [root])`.
+   */
+  walkOwned?: (root: string) => string[];
   /** Decrypt + load the vault. Default: real `openVault`. */
   openVault?: (passphrase: string, path: string) => Record<string, VaultEntry>;
   /** Current operator uid (default process uid). */
@@ -234,6 +256,69 @@ export async function defaultPreflight(
   };
 }
 
+/** Human label for an operator-owned root (its final path segment). */
+function ownedLabel(root: string): string {
+  const segs = root.split("/").filter(Boolean);
+  return segs[segs.length - 1] ?? root;
+}
+
+/**
+ * Check A, generalized: probe one operator-owned root (and everything
+ * under it) as the operator. A root-mode `apply`/hostd/broker write can
+ * leave any of these root-owned; the broker keeps working via
+ * CAP_DAC_READ_SEARCH, so nothing looks broken until the operator
+ * touches the artifact directly and gets EACCES.
+ *
+ *  - root absent (no targets) → `null` (skip silently — not every
+ *    install has every artifact)
+ *  - any path under it unreadable by the operator → `fail` with a
+ *    `sudo chown -R` remediation on the resolved root
+ *  - all present + readable → `ok`
+ *
+ * `targets` is the resolved sweep set from `walkOperatorOwnedTargets`
+ * (symlinks already resolved, dirs recursed), so this reuses the
+ * ownership walker's resolution instead of duplicating it.
+ */
+export function probeOwnedRoot(
+  root: string,
+  targets: string[],
+  statPath: (path: string) => VaultFileStat,
+  selfUid: number,
+  selfUser: string,
+): CheckResult | null {
+  if (targets.length === 0) return null; // root absent → skip silently
+  const rootReal = targets[0]!;
+  const name = `operator readable: ${ownedLabel(root)}`;
+
+  const bad: VaultFileStat[] = [];
+  for (const path of targets) {
+    const s = statPath(path);
+    if (!s.exists) continue; // raced delete mid-walk — skip
+    if (!s.readable) bad.push(s);
+  }
+
+  if (bad.length === 0) {
+    return { name, status: "ok", detail: `operator can read ${rootReal}` };
+  }
+
+  const first = bad[0]!;
+  const eg =
+    bad.length === 1
+      ? `${first.realPath} (mode 0${first.mode.toString(8)})`
+      : `e.g. ${first.realPath} (mode 0${first.mode.toString(8)})`;
+  return {
+    name,
+    status: "fail",
+    detail:
+      `${bad.length} path(s) under ${rootReal} are owned by uid ${first.uid} — ${eg} — ` +
+      `so the operator (uid ${selfUid} ${selfUser}) cannot read them and every ` +
+      `\`switchroom …\` that touches this artifact fails. A root-mode ` +
+      `apply/hostd/broker write left it root-owned; the broker still works ` +
+      `(CAP_DAC_READ_SEARCH), which masks this until you touch it directly.`,
+    fix: `sudo chown -R ${selfUser}:${selfUser} ${rootReal}`,
+  };
+}
+
 export async function runSecretAccessChecks(
   config: SwitchroomConfig,
   deps: SecretAccessDeps = {},
@@ -251,32 +336,31 @@ export async function runSecretAccessChecks(
     }
   }
 
-  // ---- Check A: operator can read the vault file --------------------
-  const vf = statVault(vaultPath);
-  if (!vf.exists) {
-    results.push({
-      name: "vault: operator readable",
-      status: "ok",
-      detail: `vault file not present at ${vaultPath} — see the Vault section`,
-    });
-  } else if (!vf.readable) {
-    results.push({
-      name: "vault: operator readable",
-      status: "fail",
-      detail:
-        `${vf.realPath} is owned by uid ${vf.uid} (mode 0${vf.mode.toString(8)}) — ` +
-        `the operator (uid ${selfUid} ${selfUser}) cannot read it, so every ` +
-        `\`switchroom vault …\` fails. The broker still works (CAP_DAC_READ_SEARCH), ` +
-        `which masks this until you touch the vault directly.`,
-      fix: `sudo chown ${selfUser}:${selfUser} ${vf.realPath}`,
-    });
-  } else {
-    results.push({
-      name: "vault: operator readable",
-      status: "ok",
-      detail: `operator can read ${vf.realPath}`,
-    });
+  // ---- Check A: operator can read every operator-owned artifact -----
+  // Generalized from the vault-only check: sweep the full operator-owned
+  // set (operatorOwnedPaths) so a root-mode apply/hostd/broker write that
+  // leaves ANY of them root-owned surfaces here with a chown remediation,
+  // not just vault.enc. Missing artifacts skip silently.
+  const statPath = deps.statPath ?? statVault;
+  const home = deps.operatorHome ?? homedir();
+  const ownedRoots = deps.ownedRoots ?? operatorOwnedPaths(home);
+  const walkOwned =
+    deps.walkOwned ?? ((root: string) => walkOperatorOwnedTargets(home, {}, [root]));
+  for (const root of ownedRoots) {
+    const res = probeOwnedRoot(
+      root,
+      walkOwned(root),
+      statPath,
+      selfUid,
+      selfUser,
+    );
+    if (res) results.push(res);
   }
+
+  // vf drives the vault-open fail-vs-warn branch below (a readable-but-
+  // unopenable vault is a bad passphrase; an unreadable one is an
+  // ownership problem Check A already flagged).
+  const vf = statVault(vaultPath);
 
   // ---- Check B: per-agent secret existence + ACL --------------------
   const pushAgentResult = (

--- a/src/cli/operator-uid.ts
+++ b/src/cli/operator-uid.ts
@@ -92,6 +92,94 @@ export function operatorOwnedPaths(home: string): string[] {
   ];
 }
 
+/** Resolve the injectable IO shims once, applying the real-fs defaults. */
+function resolveWalkDeps(deps: OwnershipRestoreDeps): Required<
+  Pick<OwnershipRestoreDeps, "exists" | "isDir" | "isSymlink" | "realpath" | "readdir">
+> {
+  return {
+    exists: deps.exists ?? ((p) => existsSync(p)),
+    isSymlink:
+      deps.isSymlink ??
+      ((p) => {
+        try {
+          return lstatSync(p).isSymbolicLink();
+        } catch {
+          return false;
+        }
+      }),
+    isDir:
+      deps.isDir ??
+      ((p) => {
+        try {
+          return statSync(p).isDirectory();
+        } catch {
+          return false;
+        }
+      }),
+    realpath:
+      deps.realpath ??
+      ((p) => {
+        try {
+          return realpathSync(p);
+        } catch {
+          return p;
+        }
+      }),
+    readdir:
+      deps.readdir ??
+      ((p) => {
+        try {
+          return readdirSync(p);
+        } catch {
+          return [];
+        }
+      }),
+  };
+}
+
+/**
+ * Walk the operator-owned `~/.switchroom` subtree and return the real
+ * targets (symlinks resolved, directories recursed, deduped, in
+ * parent-before-child order). Missing paths are skipped silently — not
+ * every install has every artifact.
+ *
+ * This is the single source of truth for "which paths should the
+ * operator own": both `restoreOperatorOwnership` (chown-back after a
+ * root-mode apply) and the doctor's ownership probe consume it, so the
+ * sweep set and the symlink-resolution rules can't drift between the
+ * fix and the diagnostic.
+ *
+ * Symlinks resolve to their real target (the v0.7.12 `vault.enc ->
+ * vault/vault.enc` legacy link, accounts symlinks, …) so callers act on
+ * the actual file, not the link entry.
+ */
+export function walkOperatorOwnedTargets(
+  home: string,
+  deps: OwnershipRestoreDeps = {},
+  roots: string[] = operatorOwnedPaths(home),
+): string[] {
+  const { exists, isSymlink, isDir, realpath, readdir } = resolveWalkDeps(deps);
+
+  const targets: string[] = [];
+  const seen = new Set<string>();
+
+  const visit = (path: string): void => {
+    if (!exists(path)) return;
+    const target = isSymlink(path) ? realpath(path) : path;
+    if (seen.has(target)) return;
+    seen.add(target);
+    targets.push(target);
+    if (isDir(target)) {
+      for (const entry of readdir(target)) {
+        visit(join(target, entry));
+      }
+    }
+  };
+
+  for (const p of roots) visit(p);
+  return targets;
+}
+
 /**
  * Best-effort: chown the operator-owned `~/.switchroom` subtree back to
  * `operatorUid:operatorUid`. Recurses into directories. Every chown is
@@ -108,68 +196,15 @@ export function restoreOperatorOwnership(
   deps: OwnershipRestoreDeps = {},
 ): string[] {
   const chown = deps.chown ?? ((p, u, g) => chownSync(p, u, g));
-  const exists = deps.exists ?? ((p) => existsSync(p));
-  const isSymlink =
-    deps.isSymlink ??
-    ((p) => {
-      try {
-        return lstatSync(p).isSymbolicLink();
-      } catch {
-        return false;
-      }
-    });
-  const isDir =
-    deps.isDir ??
-    ((p) => {
-      try {
-        return statSync(p).isDirectory();
-      } catch {
-        return false;
-      }
-    });
-  const realpath =
-    deps.realpath ??
-    ((p) => {
-      try {
-        return realpathSync(p);
-      } catch {
-        return p;
-      }
-    });
-  const readdir =
-    deps.readdir ??
-    ((p) => {
-      try {
-        return readdirSync(p);
-      } catch {
-        return [];
-      }
-    });
 
   const chowned: string[] = [];
-  const seen = new Set<string>();
-
-  const visit = (path: string): void => {
-    if (!exists(path)) return;
-    // Resolve symlinks to the real target (the v0.7.12 vault.enc
-    // legacy link, accounts symlinks, …) so we chown the actual file,
-    // not the link entry.
-    const target = isSymlink(path) ? realpath(path) : path;
-    if (seen.has(target)) return;
-    seen.add(target);
+  for (const target of walkOperatorOwnedTargets(home, deps)) {
     try {
       chown(target, operatorUid, operatorUid);
       chowned.push(target);
     } catch {
       /* best-effort: dev/no CAP_CHOWN/raced; keep going */
     }
-    if (isDir(target)) {
-      for (const entry of readdir(target)) {
-        visit(join(target, entry));
-      }
-    }
-  };
-
-  for (const p of operatorOwnedPaths(home)) visit(p);
+  }
   return chowned;
 }

--- a/tests/doctor-secret-access.test.ts
+++ b/tests/doctor-secret-access.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 
 import {
   runSecretAccessChecks,
+  probeOwnedRoot,
   type VaultFileStat,
   type SecretAccessDeps,
   type PreflightOutcome,
@@ -22,12 +23,16 @@ const READABLE: VaultFileStat = {
 };
 
 // Default deps: passphrase SET → exercises the (preserved) LOCAL path.
+// ownedRoots empty by default so Check B tests aren't polluted by the
+// Check A sweep (which is exercised directly against probeOwnedRoot and
+// via the dedicated Check A describe block below).
 function deps(over: Partial<SecretAccessDeps> = {}): SecretAccessDeps {
   return {
     vaultPath: "/v",
     selfUid: 1000,
     selfUser: "op",
     statVault: () => READABLE,
+    ownedRoots: [],
     passphrase: "pp",
     openVault: () => ({}),
     ...over,
@@ -44,6 +49,7 @@ function brokerDeps(
     selfUid: 1000,
     selfUser: "op",
     statVault: () => READABLE,
+    ownedRoots: [],
     passphrase: undefined,
     preflight,
     ...over,
@@ -53,47 +59,106 @@ function brokerDeps(
 type R = Awaited<ReturnType<typeof runSecretAccessChecks>>;
 const get = (r: R, name: string) => r.find((x) => x.name === name);
 
-describe("runSecretAccessChecks — Check A (operator readable)", () => {
-  it("ok when the vault file is absent (defers to Vault section)", async () => {
+const ROOT_LOCKED = (real: string): VaultFileStat => ({
+  exists: true,
+  readable: false,
+  uid: 0,
+  mode: 0o600,
+  realPath: real,
+});
+const okStat = (real: string): VaultFileStat => ({
+  exists: true,
+  readable: true,
+  uid: 1000,
+  mode: 0o600,
+  realPath: real,
+});
+const missingStat = (real: string): VaultFileStat => ({
+  exists: false,
+  readable: false,
+  uid: -1,
+  mode: 0,
+  realPath: real,
+});
+
+describe("probeOwnedRoot — generalized Check A probe", () => {
+  it("root-owned path → FAIL with a `sudo chown -R` remediation on the resolved root", () => {
+    const root = "/home/op/.switchroom/vault";
+    const targets = [root, `${root}/vault.enc`];
+    const res = probeOwnedRoot(
+      root,
+      targets,
+      (p) => (p === `${root}/vault.enc` ? ROOT_LOCKED(p) : okStat(p)),
+      1000,
+      "op",
+    );
+    expect(res?.status).toBe("fail");
+    expect(res?.name).toBe("operator readable: vault");
+    expect(res?.detail).toContain("owned by uid 0");
+    expect(res?.detail).toContain(`${root}/vault.enc`);
+    expect(res?.fix).toBe(`sudo chown -R op:op ${root}`);
+  });
+
+  it("correctly-owned path → PASS, no fix", () => {
+    const root = "/home/op/.switchroom/accounts";
+    const targets = [root, `${root}/creds.json`];
+    const res = probeOwnedRoot(root, targets, okStat, 1000, "op");
+    expect(res?.status).toBe("ok");
+    expect(res?.name).toBe("operator readable: accounts");
+    expect(res?.fix).toBeUndefined();
+    expect(res?.detail).toContain(root);
+  });
+
+  it("missing root (empty target set) → SKIP silently (null)", () => {
+    const res = probeOwnedRoot(
+      "/home/op/.switchroom/compose",
+      [],
+      () => missingStat("/x"),
+      1000,
+      "op",
+    );
+    expect(res).toBeNull();
+  });
+
+  it("resolves the fix against the walker's realpath (symlink-resolved root)", () => {
+    // walker already resolved a symlinked root to its real target
+    const linkRoot = "/home/op/.switchroom/vault-audit.log";
+    const realTarget = "/mnt/data/vault-audit.log";
+    const res = probeOwnedRoot(
+      linkRoot,
+      [realTarget],
+      () => ROOT_LOCKED(realTarget),
+      1000,
+      "op",
+    );
+    expect(res?.status).toBe("fail");
+    // label from the logical root, fix from the resolved real target
+    expect(res?.name).toBe("operator readable: vault-audit.log");
+    expect(res?.fix).toBe(`sudo chown -R op:op ${realTarget}`);
+  });
+});
+
+describe("runSecretAccessChecks — Check A sweep integration", () => {
+  it("sweeps the injected owned roots: one FAIL (root-locked) + one OK, missing skipped", async () => {
+    const vaultRoot = "/home/op/.switchroom/vault";
+    const acctRoot = "/home/op/.switchroom/accounts";
+    const composeRoot = "/home/op/.switchroom/compose";
     const r = await runSecretAccessChecks(
       cfg({}),
       deps({
-        statVault: () => ({
-          exists: false,
-          readable: false,
-          uid: -1,
-          mode: 0,
-          realPath: "/v",
-        }),
+        ownedRoots: [vaultRoot, acctRoot, composeRoot],
+        walkOwned: (root) =>
+          root === composeRoot ? [] : [root], // compose absent
+        statPath: (p) => (p === vaultRoot ? ROOT_LOCKED(p) : okStat(p)),
       }),
     );
-    const a = get(r, "vault: operator readable");
-    expect(a?.status).toBe("ok");
-    expect(a?.detail).toContain("not present");
-  });
-
-  it("FAILs with a chown fix when the file is root-locked", async () => {
-    const r = await runSecretAccessChecks(
-      cfg({}),
-      deps({
-        statVault: () => ({
-          exists: true,
-          readable: false,
-          uid: 0,
-          mode: 0o600,
-          realPath: "/home/op/.switchroom/vault/vault.enc",
-        }),
-      }),
+    expect(get(r, "operator readable: vault")?.status).toBe("fail");
+    expect(get(r, "operator readable: vault")?.fix).toBe(
+      `sudo chown -R op:op ${vaultRoot}`,
     );
-    const a = get(r, "vault: operator readable");
-    expect(a?.status).toBe("fail");
-    expect(a?.detail).toContain("uid 0");
-    expect(a?.fix).toBe("sudo chown op:op /home/op/.switchroom/vault/vault.enc");
-  });
-
-  it("ok when the operator can read it", async () => {
-    const r = await runSecretAccessChecks(cfg({}), deps());
-    expect(get(r, "vault: operator readable")?.status).toBe("ok");
+    expect(get(r, "operator readable: accounts")?.status).toBe("ok");
+    // compose absent → no result at all (silent skip)
+    expect(get(r, "operator readable: compose")).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-ups for the post-sudo ownership-lockout bundle (#1476). P1 was already fixed on `main`; this PR lands P2 and records the P3/P4 findings.

### P1 — already fixed (#1519)
Broker `op:put` chown-back is live: `chownVaultToOperator()` runs right after `saveVault()` in the op:put handler (`src/vault/broker/server.ts`), re-rooting `vault.enc` to the operator UID on every write. Not touched here.

### P2 — generalize doctor Check A (the deliverable)
Check A only stat'd `vault.enc`, so a root-mode `apply`/hostd/broker write that left any *other* operator-owned artifact root-owned was invisible until the operator hit EACCES on it.

- Extracted `walkOperatorOwnedTargets()` from `restoreOperatorOwnership()` in `src/cli/operator-uid.ts` — one source of truth for the sweep set + symlink resolution, shared by the fix (chown-back) and the diagnostic (doctor). No duplicated resolution.
- New `probeOwnedRoot()` in `src/cli/doctor-secret-access.ts`: for each root from `operatorOwnedPaths()` (`vault/`, `vault-auto-unlock`, `vault-audit.log`, `host-control-audit.log`, `accounts/`, `compose/`), walk it and:
  - any path unreadable by the operator → **fail** with `sudo chown -R <op> <root>` remediation,
  - all present + readable → **ok**,
  - root absent → **skip silently** (not every install has every artifact).

### P3 — per-agent credentials.json chown — already handled (no change)
Evidence: the broker's `mirrorAccountToAgent` chowns the fanned-out mirror to `allocateAgentUid(agentName)` (`src/auth/broker/server.ts:3473-3474`, best-effort with a CAP_CHOWN warning), and `scaffold.ts` `alignAgentUid` runs `chown -R <agent-uid>` over the whole agent dir, which includes `.claude/.credentials.json`. Double coverage — the per-agent-UID chown is not manual. The old under-sudo fanout referenced by the ticket was deleted with RFC H (`src/auth/account-refresh.ts` header).

### P4 — root-owned compose file cannot block a non-sudo rewrite (no change)
Evidence: `writeComposeFile` (`src/cli/write-compose.ts:410-412`) writes to `<compose>.tmp` and atomically `rename()`s over the target. POSIX rename-replacement is governed by write/exec on the parent **directory**, not by the destination file's ownership or mode — so a root-owned `docker-compose.yml` (0600) does not block the operator's rewrite. A root-owned compose *directory* would, but that is exactly what the P2 probe now surfaces (`compose` is in `operatorOwnedPaths()`). The `.bak` copy is already wrapped best-effort.

## Test plan
- `tests/doctor-secret-access.test.ts`: new `probeOwnedRoot` unit tests (root-owned → fail with chown hint; correctly-owned → pass; missing → skip; symlink-resolved fix path) + a sweep-integration test through `runSecretAccessChecks`.
- `tests/operator-uid.test.ts` unchanged and green (walker refactor preserves behavior).
- Scoped: `vitest run tests/doctor-secret-access.test.ts tests/operator-uid.test.ts tests/doctor.test.ts` → 75 passed / 2 skipped.
- `npm run lint` clean.

## Risk
Low. Behavior-preserving refactor of the ownership walker; the doctor change only broadens an existing diagnostic (more fail coverage, silent skips for absent artifacts).

Job spec: operator-lockout prevention / diagnosability (`reference/` ownership-restore contract in `src/cli/operator-uid.ts`).

Closes #1476

🤖 Generated with [Claude Code](https://claude.com/claude-code)