### PR TITLE
test(gateway): pin the #1664 turn_end re-prompt gate against real gateway code (#1667)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -340,6 +340,8 @@ import {
   decideTurnFlush,
   isTurnFlushSafetyEnabled,
 } from '../turn-flush-safety.js'
+// #1667 — pure decision core for the turn_end answer-delivery gate (#1664).
+import { decideTurnEndGate } from './turn-end-gate.js'
 // #1122 PR3: turn-flush-prose-recovery removed with the progress card.
 import { resolveAgentDirFromEnv } from '../agent-dir.js'
 import {
@@ -16161,6 +16163,17 @@ function handleSessionEvent(ev: SessionEvent): void {
             capturedText: turn.capturedText,
             flushEnabled: TURN_FLUSH_SAFETY_ENABLED,
           })
+      // #1667 — resolve the turn_end answer-delivery gate once, here, via the
+      // pure decision core. The three dispositions below (silent-marker,
+      // turn-flush, #1664 re-prompt) delegate to this so the gateway runs the
+      // exact code the regression test exercises. `finalAnswerDelivered` is read
+      // at its tail value: the answer-stream materialize branch above has
+      // already run (and may have set it true); the flush branch, which also
+      // sets it, is not yet entered and does not affect the gate's own outcome.
+      const turnEndDecision = decideTurnEndGate({
+        flushDecision,
+        finalAnswerDelivered: turn.finalAnswerDelivered,
+      })
       if (flushDecision.kind === 'skip' && flushDecision.reason !== 'reply-called') {
         process.stderr.write(
           `telegram gateway: turn-flush skipped — reason=${flushDecision.reason}\n`,
@@ -16199,7 +16212,7 @@ function handleSessionEvent(ev: SessionEvent): void {
       //  2. NOT send any reply message to the user.
       //  3. Unpin the progress card so no orphaned ⚙️ Working… lingers.
       //  4. Log at debug level and fall through to normal state cleanup.
-      if (flushDecision.kind === 'skip' && flushDecision.reason === 'silent-marker') {
+      if (turnEndDecision === 'silent_end') {
         // Don't try to distinguish NO_REPLY vs HEARTBEAT_OK in the log line:
         // `isSilentFlushMarker` accepts trailing punctuation (e.g. "NO_REPLY.")
         // and case variants, so a strict equality check would print the wrong
@@ -16289,7 +16302,7 @@ function handleSessionEvent(ev: SessionEvent): void {
         return
       }
 
-      if (flushDecision.kind === 'flush') {
+      if (turnEndDecision === 'flush' && flushDecision.kind === 'flush') {
         let capturedText = flushDecision.text
         // #2798 — turn-flush delivers the model's terminal prose when it
         // skipped reply/stream_reply, but historically bypassed the reply
@@ -16654,7 +16667,10 @@ function handleSessionEvent(ev: SessionEvent): void {
         // HEARTBEAT_OK silent-marker turns return earlier and never reach
         // this path. The turn-flush 'flush' branch also returns earlier
         // (and sets finalAnswerDelivered=true defensively).
-        if (turn.finalAnswerDelivered === false) {
+        // #1667 — this is the reply-called tail; `turnEndDecision === 'reprompt'`
+        // is exactly `turn.finalAnswerDelivered === false` here (silent-marker
+        // and flush both returned earlier), delegated to the pure gate core.
+        if (turnEndDecision === 'reprompt') {
           // PR #2892 (deterministic-turn-liveness RFC Phase 2) hardening:
           // wire the represent-guard-style staleness
           // check (`recordSilentTurnEnd`'s `hasOutboundDeliveredSince` dep) so

--- a/telegram-plugin/gateway/turn-end-gate.ts
+++ b/telegram-plugin/gateway/turn-end-gate.ts
@@ -1,0 +1,95 @@
+// #1667 — pure decision core for the `turn_end` handler's answer-delivery
+// gate (originally landed inline in `gateway.ts` by #1664).
+//
+// The gateway's `case 'turn_end':` block resolves, in strict order, which of
+// four terminal dispositions a just-ended turn takes:
+//
+//   1. silent-marker suppression  — the model's only output was a silent-turn
+//      sentinel (NO_REPLY / HEARTBEAT_OK, or composite/ trailing silent
+//      noise). `decideTurnFlush` returns `{kind:'skip', reason:'silent-marker'}`.
+//      The gateway suppresses the card without a "Done" edit and returns.
+//   2. turn-flush                 — the model skipped reply/stream_reply but
+//      left substantive terminal prose; `decideTurnFlush` returns
+//      `{kind:'flush', text}`. The gateway delivers that prose as the answer
+//      (setting `finalAnswerDelivered = true`) and returns.
+//   3. re-prompt (#1664 gate)     — the reply-called tail. The turn neither
+//      suppressed nor flushed, and `finalAnswerDelivered === false`: the model
+//      sent only an interim ack (or nothing) and never delivered a real
+//      answer. The silent-end machinery re-prompts so the answer lands.
+//   4. none                       — the reply-called tail with
+//      `finalAnswerDelivered === true`: a genuine final answer was delivered;
+//      no re-prompt.
+//
+// This module hoists that ordering into a single pure function so it is
+// testable against the code the gateway actually runs (the gateway's
+// `turn_end` case delegates to `decideTurnEndGate`). It is a strictly
+// behaviour-preserving extraction — the exact conditionals and their order,
+// no logic change.
+//
+// What deliberately remains inline in the gateway (side effects, not
+// decisions): the synthetic-backstop `durationMs === -1` suppression, the
+// `turn == null` guard, the answer-stream materialize/retract block (which may
+// set `finalAnswerDelivered = true` BEFORE this gate is consulted), and every
+// disposition's actual teardown / send / telemetry. Those are not part of the
+// decision — they are what each decision drives. The gate is computed once,
+// immediately after `flushDecision`, reading `finalAnswerDelivered` at its
+// tail value (the answer-stream branch has already run by then; the flush
+// branch, which also sets it, is not yet entered and does not influence the
+// gate's own outcome).
+
+import type { FlushDecision } from '../turn-flush-safety.js'
+
+/**
+ * The terminal disposition of a `turn_end`, in the gateway's evaluation order.
+ * - `silent_end`  → silent-marker suppression path (no reply, no card edit).
+ * - `flush`       → turn-flush delivers the model's terminal prose as the answer.
+ * - `reprompt`    → #1664 gate: no final answer delivered → silent-end re-prompt.
+ * - `none`        → final answer delivered; normal terminal, no re-prompt.
+ */
+export type TurnEndDecision = 'silent_end' | 'flush' | 'reprompt' | 'none'
+
+export interface TurnEndGateSnapshot {
+  /** The result of `decideTurnFlush(...)` for this turn (or the synthetic
+   * `{kind:'skip', reason:'reply-called'}` the gateway substitutes when the
+   * answer-stream already materialised the answer). */
+  flushDecision: FlushDecision
+  /**
+   * `turn.finalAnswerDelivered` at the point the gate is consulted — i.e. after
+   * the answer-stream materialize branch may have set it true, but reflecting
+   * whether a genuine final answer (not a bare interim ack) has been delivered.
+   * Only consulted on the reply-called tail (neither silent-marker nor flush).
+   */
+  finalAnswerDelivered: boolean
+}
+
+/**
+ * Pure decision core for the `turn_end` answer-delivery gate. Mirrors the
+ * gateway's branch ordering exactly: silent-marker early-return, then
+ * turn-flush early-return, then the `finalAnswerDelivered === false` re-prompt
+ * gate, else no re-prompt. No side effects.
+ */
+export function decideTurnEndGate(snapshot: TurnEndGateSnapshot): TurnEndDecision {
+  const { flushDecision, finalAnswerDelivered } = snapshot
+
+  // 1. Silent-marker suppression takes precedence: the model's only output was
+  //    a silent-turn sentinel. Suppress without a card edit; never re-prompt.
+  if (flushDecision.kind === 'skip' && flushDecision.reason === 'silent-marker') {
+    return 'silent_end'
+  }
+
+  // 2. Turn-flush: the model left substantive terminal prose without calling
+  //    the reply tool. Deliver it as the answer; the turn IS answered.
+  if (flushDecision.kind === 'flush') {
+    return 'flush'
+  }
+
+  // 3. Reply-called tail. #1664: the trigger is "no final answer delivered",
+  //    not "zero outbound". An interim-ack-only turn (reply called, but
+  //    finalAnswerDelivered still false) re-prompts; a delivered final answer
+  //    does not. A zero-outbound turn also lands here with
+  //    finalAnswerDelivered === false and re-prompts.
+  if (finalAnswerDelivered === false) {
+    return 'reprompt'
+  }
+  return 'none'
+}

--- a/telegram-plugin/tests/turn-end-gate.test.ts
+++ b/telegram-plugin/tests/turn-end-gate.test.ts
@@ -1,0 +1,137 @@
+// #1667 — gateway-level regression test for the #1664 turn_end re-prompt gate.
+//
+// This drives the REAL decision core the gateway's `case 'turn_end':` block
+// delegates to (`decideTurnEndGate` in `gateway/turn-end-gate.ts`), plus the
+// REAL `decideTurnFlush` that feeds it — not a re-implementation. A future
+// change to the gateway's gate ordering or the `finalAnswerDelivered` swap is
+// caught here, closing the coverage gap the issue calls out
+// (`silent-end.test.ts`'s `simulateTurnEnd` helper re-implements the decision
+// rather than exercising gateway code).
+//
+// This test is a micro-step of the #2996 gateway decomposition: the gate's
+// pure ordering is now importable and pinned, whereas `gateway.ts` itself is
+// not importable in tests (boot side effects at module load — confirmed during
+// the #2996 work, PR #3010).
+//
+// vitest runner (no bun natives): both `turn-end-gate.ts` and
+// `turn-flush-safety.ts` are pure ES modules.
+import { describe, it, expect } from 'vitest'
+import { decideTurnEndGate } from '../gateway/turn-end-gate.js'
+import { decideTurnFlush, type FlushDecision } from '../turn-flush-safety.js'
+
+// Mirror the gateway's own upstream computation: turn-flush is only consulted
+// when the answer-stream did NOT already materialise the answer. When it did,
+// the gateway substitutes a synthetic `{kind:'skip', reason:'reply-called'}`.
+const STREAM_MATERIALIZED: FlushDecision = { kind: 'skip', reason: 'reply-called' }
+
+// Real `decideTurnFlush` call, matching the gateway's inputs at turn_end.
+function realFlush(opts: {
+  replyCalled: boolean
+  capturedText: string[]
+  chatId?: string | null
+}): FlushDecision {
+  return decideTurnFlush({
+    chatId: opts.chatId === undefined ? 'c:1' : opts.chatId,
+    replyCalled: opts.replyCalled,
+    capturedText: opts.capturedText,
+    flushEnabled: true,
+  })
+}
+
+describe('#1667 — turn_end gate (decideTurnEndGate), driving real gateway code', () => {
+  // (a) Interim-ack-only turn: reply landed (interim ack) but no final answer
+  //     delivered, and no substantive trailing prose to flush → re-prompt.
+  it('interim-ack-only turn (outbound sent, finalAnswerDelivered=false) → reprompt', () => {
+    // reply tool called, so decideTurnFlush skips with reason 'reply-called';
+    // the real answer went out as an ephemeral draft, never finalized, so
+    // finalAnswerDelivered stayed false.
+    const flushDecision = realFlush({ replyCalled: true, capturedText: [] })
+    expect(flushDecision).toEqual({ kind: 'skip', reason: 'reply-called' })
+    const decision = decideTurnEndGate({ flushDecision, finalAnswerDelivered: false })
+    expect(decision).toBe('reprompt')
+  })
+
+  // (b) Final-answer-reply turn: reply landed AND was the genuine final answer
+  //     → finalAnswerDelivered true → no re-prompt.
+  it('final-answer-reply turn (finalAnswerDelivered=true) → none (no reprompt)', () => {
+    const flushDecision = realFlush({ replyCalled: true, capturedText: [] })
+    const decision = decideTurnEndGate({ flushDecision, finalAnswerDelivered: true })
+    expect(decision).toBe('none')
+  })
+
+  // (b') Answer-stream materialised the answer: gateway substitutes the
+  //      synthetic skip AND sets finalAnswerDelivered=true → none.
+  it('answer-stream materialized as answer (finalAnswerDelivered=true) → none', () => {
+    const decision = decideTurnEndGate({
+      flushDecision: STREAM_MATERIALIZED,
+      finalAnswerDelivered: true,
+    })
+    expect(decision).toBe('none')
+  })
+
+  // (c) Zero-outbound turn: no reply, no captured text → decideTurnFlush skips
+  //     with 'empty-text' (NOT flush, NOT silent-marker), and
+  //     finalAnswerDelivered is false → still re-prompts (the original #1122
+  //     case, now the subset of "no final answer delivered").
+  it('zero-outbound turn (no reply, empty text) → reprompt', () => {
+    const flushDecision = realFlush({ replyCalled: false, capturedText: [] })
+    expect(flushDecision).toEqual({ kind: 'skip', reason: 'empty-text' })
+    const decision = decideTurnEndGate({ flushDecision, finalAnswerDelivered: false })
+    expect(decision).toBe('reprompt')
+  })
+
+  // (d) Ordering precedence #1 — silent-marker beats the re-prompt gate. A turn
+  //     whose only output is a NO_REPLY sentinel is legitimately silent and
+  //     must NOT re-prompt, even though finalAnswerDelivered is false.
+  it('silent-marker (NO_REPLY) takes precedence over the reprompt gate', () => {
+    const flushDecision = realFlush({ replyCalled: false, capturedText: ['NO_REPLY'] })
+    expect(flushDecision).toEqual({ kind: 'skip', reason: 'silent-marker' })
+    // finalAnswerDelivered=false would trip 'reprompt' at the tail, but the
+    // silent-marker branch returns first.
+    const decision = decideTurnEndGate({ flushDecision, finalAnswerDelivered: false })
+    expect(decision).toBe('silent_end')
+  })
+
+  it('silent-marker (HEARTBEAT_OK) → silent_end (no reprompt)', () => {
+    const flushDecision = realFlush({ replyCalled: false, capturedText: ['HEARTBEAT_OK'] })
+    expect(flushDecision).toEqual({ kind: 'skip', reason: 'silent-marker' })
+    const decision = decideTurnEndGate({ flushDecision, finalAnswerDelivered: false })
+    expect(decision).toBe('silent_end')
+  })
+
+  // (d) Ordering precedence #2 — turn-flush beats the re-prompt gate. A turn
+  //     that skipped the reply tool but left substantive terminal prose is
+  //     delivered via flush; the gate returns 'flush' even though
+  //     finalAnswerDelivered is still false at that point (the gateway sets it
+  //     true inside the flush branch afterwards).
+  it('turn-flush (substantive terminal prose, no reply) takes precedence over reprompt', () => {
+    const flushDecision = realFlush({
+      replyCalled: false,
+      capturedText: ['Done — all three services are green.'],
+    })
+    expect(flushDecision.kind).toBe('flush')
+    const decision = decideTurnEndGate({ flushDecision, finalAnswerDelivered: false })
+    expect(decision).toBe('flush')
+  })
+
+  // Full documented ordering, asserted as a table so a re-order regresses
+  // loudly: silent-marker > flush > (finalAnswerDelivered===false ? reprompt : none).
+  it('honors the full documented precedence order', () => {
+    const silent: FlushDecision = { kind: 'skip', reason: 'silent-marker' }
+    const flush: FlushDecision = { kind: 'flush', text: 'the answer' }
+    const replyCalled: FlushDecision = { kind: 'skip', reason: 'reply-called' }
+    const emptyText: FlushDecision = { kind: 'skip', reason: 'empty-text' }
+
+    // silent-marker wins regardless of finalAnswerDelivered.
+    expect(decideTurnEndGate({ flushDecision: silent, finalAnswerDelivered: false })).toBe('silent_end')
+    expect(decideTurnEndGate({ flushDecision: silent, finalAnswerDelivered: true })).toBe('silent_end')
+    // flush wins regardless of finalAnswerDelivered.
+    expect(decideTurnEndGate({ flushDecision: flush, finalAnswerDelivered: false })).toBe('flush')
+    expect(decideTurnEndGate({ flushDecision: flush, finalAnswerDelivered: true })).toBe('flush')
+    // reply-called tail: gated purely on finalAnswerDelivered.
+    expect(decideTurnEndGate({ flushDecision: replyCalled, finalAnswerDelivered: false })).toBe('reprompt')
+    expect(decideTurnEndGate({ flushDecision: replyCalled, finalAnswerDelivered: true })).toBe('none')
+    expect(decideTurnEndGate({ flushDecision: emptyText, finalAnswerDelivered: false })).toBe('reprompt')
+    expect(decideTurnEndGate({ flushDecision: emptyText, finalAnswerDelivered: true })).toBe('none')
+  })
+})


### PR DESCRIPTION
## Summary

Closes #1667. Extracts the `turn_end` answer-delivery decision ordering (the #1664 fix) into a pure, testable core and has the gateway delegate to it, then pins it with a real regression test.

- New `telegram-plugin/gateway/turn-end-gate.ts` — `decideTurnEndGate(snapshot)` returns `'silent_end' | 'flush' | 'reprompt' | 'none'`, mirroring the gateway's exact branch ordering: silent-marker early-return, then turn-flush early-return, then the `finalAnswerDelivered === false` re-prompt gate, else none.
- `gateway.ts` `case 'turn_end':` now computes `turnEndDecision` once (right after `flushDecision`) and the three dispositions branch on it, so the gateway runs the exact code the test exercises.
- New `telegram-plugin/tests/turn-end-gate.test.ts` (vitest, 9 tests) drives the real `decideTurnEndGate` **and** the real `decideTurnFlush` that feeds it.

## Why

Per #1667: the #1664 fix's pure pieces are covered (`final-answer-detect`, `silent-end`), but the load-bearing wiring in `gateway.ts` had no regression test against the real handler. `silent-end.test.ts`'s `simulateTurnEnd` *re-implements* the gateway decision, so a future change to the gate or path-ordering would go uncaught. This is a coverage gap on a data-loss fix (undelivered answers).

`gateway.ts` is not importable in tests (boot side effects at module load — confirmed during the #2996 decomposition, PR #3010), so the durable fix is to hoist the pure decision out. This doubles as a **#2996 Phase-6 gateway micro-extraction**.

## Test plan

- `vitest run telegram-plugin/tests/turn-end-gate.test.ts silent-end.test.ts final-answer-detect.test.ts` → **63 passed** (9 new + existing green).
- New assertions: (a) interim-ack-only turn (`finalAnswerDelivered=false`) → `reprompt`; (b) final-answer-reply / answer-stream-materialized (`=true`) → `none`; (c) zero-outbound turn → `reprompt`; (d) silent-marker (NO_REPLY / HEARTBEAT_OK) and turn-flush early-returns take precedence over the gate, plus a full precedence table.
- `npm run lint` → clean (tsc + all 8 guards; `check-bot-api-wrapping` clean — the allowlist is inline-comment-based, no line-shift widening needed).

## Risk

Low. Strictly behaviour-preserving mechanical hoist — the exact conditionals and their order, no logic change. At the reply-called tail, `turnEndDecision === 'reprompt'` is provably identical to the prior `turn.finalAnswerDelivered === false` (silent-marker and flush both return earlier; no synchronous mutation of `finalAnswerDelivered` occurs between the gate computation and the tail).

Job spec: `reference/jobs/feel-like-a-colleague.md` — the re-prompt gate guarantees a user turn ends with a delivered answer rather than a silent drop, which is exactly the "verifies before claiming / doesn't get caught being a chatbot" outcome. Pinning it protects that behaviour from silent regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)