### PR TITLE
fix(doctor): scope pending-retains probe into agent containers (#1094)

### DIFF
--- a/src/cli/doctor-pending-retains.test.ts
+++ b/src/cli/doctor-pending-retains.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for `checkPendingRetainsQueues` — the per-agent pending-retains
+ * probe (#1071 queue, scoping fix #1094).
+ *
+ * The bug class this replaces: the old `checkPendingRetainsQueue` scanned
+ * `~/.hindsight/pending-retains/` on the OPERATOR HOST, but the queue is
+ * written by session_end.py running INSIDE each agent container
+ * (HOME=/state/agent/home). The host dir is always empty, so doctor
+ * reported "ok" even when an agent had a real backlog or dead markers.
+ *
+ * We inject the per-agent probe so these tests exercise only the
+ * aggregation + verdict shape — the real `probePendingRetainsQueue` is
+ * exercised against a live container, not in unit tests (mirrors the
+ * vault-broker socket-pair test seam).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  checkPendingRetainsQueues,
+  type PendingRetainsProbeResult,
+} from "./doctor.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+function cfg(agentNames: string[]): SwitchroomConfig {
+  const agents: Record<string, unknown> = {};
+  for (const n of agentNames) agents[n] = {};
+  return { agents } as unknown as SwitchroomConfig;
+}
+
+function probeFrom(
+  states: Record<string, PendingRetainsProbeResult>,
+): (name: string) => PendingRetainsProbeResult {
+  return (name: string) =>
+    states[name] ?? { state: "unreachable", pending: 0, dead: 0 };
+}
+
+const ok = (): PendingRetainsProbeResult => ({ state: "ok", pending: 0, dead: 0 });
+const backlog = (n: number): PendingRetainsProbeResult => ({
+  state: "backlog",
+  pending: n,
+  dead: 0,
+});
+const dead = (d: number, p = 0): PendingRetainsProbeResult => ({
+  state: "dead",
+  pending: p,
+  dead: d,
+});
+const down = (): PendingRetainsProbeResult => ({
+  state: "unreachable",
+  pending: 0,
+  dead: 0,
+});
+
+describe("checkPendingRetainsQueues (#1071/#1094)", () => {
+  it("ok: all reachable agents have an empty queue", () => {
+    const r = checkPendingRetainsQueues(cfg(["clerk", "ziggy", "carrie"]), {
+      probe: probeFrom({ clerk: ok(), ziggy: ok(), carrie: ok() }),
+    });
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("3/3");
+    expect(r.detail).toContain("empty");
+  });
+
+  it("ok: empty fleet (no agents declared)", () => {
+    const r = checkPendingRetainsQueues(cfg([]), { probe: () => ok() });
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("no agents configured");
+  });
+
+  it("warn: a live backlog names the agent and its count", () => {
+    const r = checkPendingRetainsQueues(cfg(["clerk", "ziggy"]), {
+      probe: probeFrom({ clerk: ok(), ziggy: backlog(4) }),
+    });
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("ziggy (4)");
+    expect(r.detail).toContain("next SessionStart");
+  });
+
+  it("fail: a .dead marker escalates past a warn and points at inspection", () => {
+    const r = checkPendingRetainsQueues(cfg(["clerk", "ziggy"]), {
+      probe: probeFrom({ clerk: ok(), ziggy: dead(2, 1) }),
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("dead markers: ziggy (2 dead, 1 queued)");
+    expect(r.fix).toContain(".json.dead");
+    expect(r.fix).toContain("docker exec switchroom-<agent>");
+  });
+
+  it("fail: a queue at the cap is a distinct, dropping-failures signal", () => {
+    const r = checkPendingRetainsQueues(cfg(["clerk"]), {
+      probe: probeFrom({ clerk: backlog(1000) }),
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("at cap of 1000");
+    expect(r.detail).toContain("clerk (1000)");
+  });
+
+  it("fail: dead on one agent, backlog on another — both surfaced, fail wins", () => {
+    const r = checkPendingRetainsQueues(cfg(["alpha", "bravo", "charlie"]), {
+      probe: probeFrom({ alpha: dead(1), bravo: backlog(3), charlie: ok() }),
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("dead markers: alpha (1 dead)");
+    expect(r.detail).toContain("backlog: bravo (3)");
+  });
+
+  it("skip: every agent container unreachable — one honest skip, not N rows", () => {
+    const r = checkPendingRetainsQueues(cfg(["clerk", "ziggy"]), {
+      probe: probeFrom({ clerk: down(), ziggy: down() }),
+    });
+    expect(r.status).toBe("skip");
+    expect(r.detail).toContain("unreachable");
+  });
+
+  it("partial unreachable (mid-restart) does NOT collapse to skip", () => {
+    const r = checkPendingRetainsQueues(cfg(["clerk", "ziggy"]), {
+      probe: probeFrom({ clerk: ok(), ziggy: down() }),
+    });
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("skipped (unreachable): ziggy");
+  });
+
+  it("partial unreachable is noted alongside a real backlog verdict", () => {
+    const r = checkPendingRetainsQueues(cfg(["a", "b", "c"]), {
+      probe: probeFrom({ a: backlog(2), b: down(), c: ok() }),
+    });
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("a (2)");
+    expect(r.detail).toContain("skipped (unreachable): b");
+  });
+
+  it("names agents in stable sorted order", () => {
+    const r = checkPendingRetainsQueues(cfg(["zeta", "alpha", "mike"]), {
+      probe: probeFrom({ zeta: backlog(1), alpha: backlog(1), mike: ok() }),
+    });
+    expect(r.status).toBe("warn");
+    // alpha before zeta in the joined list.
+    const detail = r.detail ?? "";
+    expect(detail.indexOf("alpha")).toBeLessThan(detail.indexOf("zeta"));
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1306,97 +1306,196 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
     }
   }
 
-  // Pending-retains queue (#1071). When session_end's final retain
-  // fails it stashes the payload in ~/.hindsight/pending-retains/ so
-  // the next SessionStart can drain it. A non-empty queue is normal in
-  // flight, but persistent backlog (or any .dead markers) means
-  // operator attention.
-  results.push(checkPendingRetainsQueue());
+  // Pending-retains queue (#1071, scoping fix #1094). When session_end's
+  // final retain fails it stashes the payload in the agent container's
+  // $HOME/.hindsight/pending-retains/ so the next SessionStart can drain
+  // it. The queue lives INSIDE each agent container — not on the operator
+  // host — so we probe each container via `docker exec` rather than
+  // scanning the host HOME (which is always empty, giving a misleading
+  // "ok"). A non-empty queue is normal in flight, but persistent backlog
+  // (or any .dead markers) means operator attention.
+  results.push(checkPendingRetainsQueues(config));
 
   return results;
 }
 
 /**
- * Probe ``~/.hindsight/pending-retains/`` and report:
- *   ok    — directory missing or empty
- *   warn  — entries present but none marked dead (will retry on next session)
- *   fail  — at least one ``.dead`` marker (gave up after MAX_ATTEMPTS) OR
- *           queue at/over the bounded cap (chronic backlog)
- *
- * Exported for unit testing.
- * @internal
+ * The bounded queue cap — keep in sync with MAX_ENTRIES in
+ * ``vendor/hindsight-memory/scripts/lib/pending.py``. At the cap the
+ * drainer starts dropping new failures, so it escalates warn → fail.
  */
-export function checkPendingRetainsQueue(
-  dir?: string,
+const PENDING_RETAINS_MAX_ENTRIES = 1000;
+
+/**
+ * Per-agent probe result for the pending-retains queue.
+ *   - "ok"          — directory missing or empty (no failed retains)
+ *   - "backlog"     — queued ``.json`` entries, none dead (will retry)
+ *   - "dead"        — one or more ``.json.dead`` markers (retries gave
+ *                     up — permanently-failed retains an operator must
+ *                     inspect by hand)
+ *   - "unreachable" — container not running / docker unavailable
+ * @internal exported for testing
+ */
+export interface PendingRetainsProbeResult {
+  state: "ok" | "backlog" | "dead" | "unreachable";
+  /** count of queued ``*.json`` entries (excludes ``.dead``) */
+  pending: number;
+  /** count of ``*.json.dead`` markers */
+  dead: number;
+}
+
+/**
+ * Probe ONE agent container's ``$HOME/.hindsight/pending-retains/`` via
+ * ``docker exec`` and classify it. The queue is written by session_end.py
+ * running INSIDE the agent container (HOME=``/state/agent/home``), so a
+ * host-side scan of the operator's HOME is always empty and misleading
+ * (the #1094 bug this replaces). A single exec counts both ``*.json`` and
+ * ``*.json.dead`` so we pay one docker-exec round-trip per agent.
+ *
+ * @internal exported for testing
+ */
+export function probePendingRetainsQueue(
+  agentName: string,
+): PendingRetainsProbeResult {
+  // Container HOME per compose.ts (`HOME: "/state/agent/home"`). Same
+  // default relative path as lib/pending.py: $HOME/.hindsight/pending-retains.
+  const dir = "/state/agent/home/.hindsight/pending-retains";
+  // `.json$` matches queued entries but NOT `.json.dead` (which ends in
+  // `.dead`), so the two counts don't overlap. grep -c on empty input
+  // prints 0 and exits 1, so guard with the -d test and swallow status.
+  const script =
+    `P=0; D=0; ` +
+    `if [ -d '${dir}' ]; then ` +
+    `P=$(ls -1 '${dir}' 2>/dev/null | grep -c '\\.json$' || true); ` +
+    `D=$(ls -1 '${dir}' 2>/dev/null | grep -c '\\.json\\.dead$' || true); ` +
+    `fi; ` +
+    `echo "P=$P D=$D"`;
+  const r = spawnSync(
+    "docker",
+    ["exec", `switchroom-${agentName}`, "sh", "-c", script],
+    { stdio: "pipe", timeout: 3000 },
+  );
+  // docker/daemon failure, container absent (exit ≥125), or timeout
+  // (status null) → skip this agent, don't false-alarm.
+  if (r.error || r.status === null || r.status !== 0) {
+    return { state: "unreachable", pending: 0, dead: 0 };
+  }
+  const out = r.stdout.toString();
+  const pm = out.match(/P=(\d+)/);
+  const dm = out.match(/D=(\d+)/);
+  if (!pm || !dm) return { state: "unreachable", pending: 0, dead: 0 };
+  const pending = parseInt(pm[1], 10);
+  const dead = parseInt(dm[1], 10);
+  if (dead > 0) return { state: "dead", pending, dead };
+  if (pending > 0) return { state: "backlog", pending, dead };
+  return { state: "ok", pending, dead };
+}
+
+/**
+ * Aggregate the per-agent pending-retains probe into a single doctor row.
+ *
+ * Fleet-scale rationale (mirrors checkVaultBrokerSocketPairs): agents come
+ * in 5-15 per host, so one row per agent would clobber output. Group the
+ * verdict and name the specific agents that are off.
+ *
+ * Verdict precedence:
+ *   - fail  — any agent has ``.dead`` markers (permanently-failed retains)
+ *             OR any queue is at/over the bounded cap (dropping failures)
+ *   - warn  — any agent has a live backlog (drains on next SessionStart)
+ *   - skip  — every agent container is unreachable (fleet down)
+ *   - ok    — all reachable agents have an empty/missing queue
+ *
+ * Partial unreachability (some agents down mid-restart) does NOT collapse
+ * to skip — the reachable agents' verdicts still stand, and the skipped
+ * ones are named so the operator can re-run.
+ *
+ * @internal exported for testing
+ */
+export function checkPendingRetainsQueues(
+  config: SwitchroomConfig,
+  opts?: { probe?: (agentName: string) => PendingRetainsProbeResult },
 ): CheckResult {
-  // Same default as lib/pending.py: $HOME/.hindsight/pending-retains/.
-  const home = process.env.HOME ?? "";
-  const pendingDir =
-    dir
-    ?? process.env.HINDSIGHT_PENDING_DIR
-    ?? join(home, ".hindsight", "pending-retains");
-
-  if (!existsSync(pendingDir)) {
-    return {
-      name: "pending-retains queue",
-      status: "ok",
-      detail: "empty (no failed retains)",
-    };
+  const name = "pending-retains queue";
+  const agentNames = Object.keys(config.agents ?? {}).sort();
+  if (agentNames.length === 0) {
+    return { name, status: "ok", detail: "no agents configured" };
   }
+  const probe = opts?.probe ?? probePendingRetainsQueue;
+  const results = new Map<string, PendingRetainsProbeResult>();
+  for (const a of agentNames) results.set(a, probe(a));
 
-  let names: string[];
-  try {
-    names = readdirSync(pendingDir);
-  } catch (err) {
+  // All unreachable → the fleet is down (or docker is). One honest skip
+  // row, not N noise rows.
+  const allUnreachable = [...results.values()].every(
+    (r) => r.state === "unreachable",
+  );
+  if (allUnreachable) {
     return {
-      name: "pending-retains queue",
-      status: "warn",
-      detail: `unreadable: ${(err as Error).message}`,
-    };
-  }
-
-  const pending = names.filter((n) => n.endsWith(".json"));
-  const dead = names.filter((n) => n.endsWith(".json.dead"));
-
-  // Keep in sync with MAX_ENTRIES in lib/pending.py.
-  const MAX_ENTRIES = 1000;
-
-  if (dead.length > 0) {
-    return {
-      name: "pending-retains queue",
-      status: "fail",
+      name,
+      status: "skip",
       detail:
-        `${dead.length} dead entries (gave up after retries), ${pending.length} still queued`,
-      fix:
-        `Hindsight has been unreachable long enough that retries gave up. `
-        + `Inspect ~/.hindsight/pending-retains/*.json.dead, fix the upstream, `
-        + `then re-enqueue manually (rename .dead → .json) or discard.`,
+        "all agent containers unreachable — couldn't probe pending-retains queues",
+      fix: "Start the fleet (`switchroom up`) or run this on the host with docker access, then re-check.",
     };
   }
 
-  if (pending.length >= MAX_ENTRIES) {
+  const dead: string[] = [];
+  const capped: string[] = [];
+  const backlog: string[] = [];
+  const unreachable: string[] = [];
+  let okCount = 0;
+  for (const [a, r] of results) {
+    if (r.state === "dead") {
+      dead.push(
+        `${a} (${r.dead} dead${r.pending > 0 ? `, ${r.pending} queued` : ""})`,
+      );
+    } else if (r.state === "backlog") {
+      if (r.pending >= PENDING_RETAINS_MAX_ENTRIES) capped.push(`${a} (${r.pending})`);
+      else backlog.push(`${a} (${r.pending})`);
+    } else if (r.state === "unreachable") {
+      unreachable.push(a);
+    } else {
+      okCount++;
+    }
+  }
+  const skippedNote =
+    unreachable.length > 0 ? `; skipped (unreachable): ${unreachable.join(", ")}` : "";
+
+  // fail: dead markers or a capped queue.
+  if (dead.length > 0 || capped.length > 0) {
+    const parts: string[] = [];
+    if (dead.length > 0) parts.push(`dead markers: ${dead.join(", ")}`);
+    if (capped.length > 0) {
+      parts.push(`at cap of ${PENDING_RETAINS_MAX_ENTRIES} (dropping new failures): ${capped.join(", ")}`);
+    }
+    if (backlog.length > 0) parts.push(`backlog: ${backlog.join(", ")}`);
     return {
-      name: "pending-retains queue",
+      name,
       status: "fail",
-      detail: `${pending.length} entries (queue at cap of ${MAX_ENTRIES}, dropping new failures)`,
+      detail: `${parts.join("; ")}${skippedNote}`,
       fix:
-        `Chronic retain failures. Bring Hindsight up, run `
-        + `\`python3 ~/.claude/plugins/.../scripts/drain_pending.py\`, then re-check.`,
+        `Dead entries mean Hindsight was unreachable long enough that retries gave up. ` +
+        `Inspect them per agent: ` +
+        `\`docker exec switchroom-<agent> ls /state/agent/home/.hindsight/pending-retains/*.json.dead\`. ` +
+        `Fix the upstream (bank health rows above), then re-enqueue (rename .dead → .json) or discard. ` +
+        `Live backlog drains automatically on the agent's next SessionStart.`,
     };
   }
 
-  if (pending.length > 0) {
+  // warn: live backlog only.
+  if (backlog.length > 0) {
     return {
-      name: "pending-retains queue",
+      name,
       status: "warn",
-      detail: `${pending.length} queued (will retry on next SessionStart)`,
+      detail: `queued (drains on next SessionStart): ${backlog.join(", ")}${skippedNote}`,
     };
   }
 
+  // ok: everything reachable is empty.
   return {
-    name: "pending-retains queue",
+    name,
     status: "ok",
-    detail: "empty (no failed retains)",
+    detail: `${okCount}/${agentNames.length} agents: empty (no failed retains)${skippedNote}`,
   };
 }
 

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -784,58 +784,7 @@ describe("checkLeakedHomeSwitchroom (#933)", () => {
   });
 });
 
-describe("checkPendingRetainsQueue (#1071)", () => {
-  let tempDir: string;
-  beforeEach(() => {
-    tempDir = resolve(tmpdir(), `switchroom-doctor-pending-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-  });
-  afterEach(() => rmSync(tempDir, { recursive: true, force: true }));
-
-  it("returns ok when directory does not exist", async () => {
-    const { checkPendingRetainsQueue } = await import("../src/cli/doctor.js");
-    const r = checkPendingRetainsQueue(tempDir);
-    expect(r.status).toBe("ok");
-    expect(r.detail).toContain("empty");
-  });
-
-  it("returns ok when directory exists but is empty", async () => {
-    mkdirSync(tempDir, { recursive: true });
-    const { checkPendingRetainsQueue } = await import("../src/cli/doctor.js");
-    const r = checkPendingRetainsQueue(tempDir);
-    expect(r.status).toBe("ok");
-  });
-
-  it("returns warn when queued entries are present (no dead)", async () => {
-    mkdirSync(tempDir, { recursive: true });
-    writeFileSync(join(tempDir, "1000000000000-aaaaaaaaaaaa.json"), "{}");
-    writeFileSync(join(tempDir, "1000000000001-bbbbbbbbbbbb.json"), "{}");
-    const { checkPendingRetainsQueue } = await import("../src/cli/doctor.js");
-    const r = checkPendingRetainsQueue(tempDir);
-    expect(r.status).toBe("warn");
-    expect(r.detail).toContain("2 queued");
-  });
-
-  it("returns fail when at least one .dead marker exists", async () => {
-    mkdirSync(tempDir, { recursive: true });
-    writeFileSync(join(tempDir, "1000000000000-aaaaaaaaaaaa.json"), "{}");
-    writeFileSync(join(tempDir, "1000000000001-cccccccccccc.json.dead"), "{}");
-    const { checkPendingRetainsQueue } = await import("../src/cli/doctor.js");
-    const r = checkPendingRetainsQueue(tempDir);
-    expect(r.status).toBe("fail");
-    expect(r.detail).toContain("1 dead");
-    expect(r.fix).toContain("retries gave up");
-  });
-
-  it("returns fail when queue reaches the cap", async () => {
-    mkdirSync(tempDir, { recursive: true });
-    // We don't actually need 1000 files — the implementation reads
-    // length >= 1000. Mock by writing 1000 stubs (cheap, ~1 ms).
-    for (let i = 0; i < 1000; i++) {
-      writeFileSync(join(tempDir, `${1000000000000 + i}-x${i}.json`), "{}");
-    }
-    const { checkPendingRetainsQueue } = await import("../src/cli/doctor.js");
-    const r = checkPendingRetainsQueue(tempDir);
-    expect(r.status).toBe("fail");
-    expect(r.detail).toContain("queue at cap");
-  });
-});
+// NOTE (#1094): the old host-scoped `checkPendingRetainsQueue(dir)` was
+// replaced by the per-agent container probe `checkPendingRetainsQueues`.
+// Its aggregation/classification is covered in
+// `src/cli/doctor-pending-retains.test.ts` with the docker-exec seam mocked.


### PR DESCRIPTION
Completes #1094 (item 4); items 1,2,3,5 in #3059.

## Problem

`checkPendingRetainsQueue` scanned `~/.hindsight/pending-retains/` on the operator **host**, but the queue is written by `session_end.py` running **inside** each agent container (`$HOME=/state/agent/home`). The host dir is always empty, so `switchroom doctor` reported `ok` even when an agent had a real backlog or permanently-failed `.dead` retains — the probe was structurally incapable of ever returning a non-`ok` verdict.

## Change

Replaced the host-scoped scan with a per-agent `docker exec` probe, mirroring the existing `checkVaultBrokerSocketPairs` machinery (enumerate configured agents, one exec per agent, 3s timeout, stopped/unreachable container → skip not fail, grouped single row):

- **`probePendingRetainsQueue(agent)`** — one `docker exec switchroom-<agent>` counts `*.json` (queued) and `*.json.dead` (gave-up) entries under the container's `$HOME/.hindsight/pending-retains`.
- **`checkPendingRetainsQueues(config, {probe?})`** — aggregates into one grouped doctor row.

Verdicts:
- `ok` — all reachable agents empty
- `warn` — live backlog (drains automatically on the agent's next SessionStart)
- `fail` — any `.dead` markers (permanently-failed; operator must inspect via `docker exec switchroom-<agent> ls .../pending-retains/*.json.dead`) **or** a queue at the 1000-entry cap (dropping new failures — a distinct signal)
- `skip` — every container unreachable (fleet down). Partial unreachability is **noted** in the detail, not collapsed to skip.

## Host-scope decision (item 2)

**Removed, not kept.** There is no host-run hindsight hook usage — `session_start.py`/`session_end.py`/`drain_pending.py` are claude plugin hooks that only run inside agent containers, so a host-side queue genuinely cannot exist. Keeping the old call would leave a misleading always-`ok` row. Scoping: doctor has no `--agent` flag; it runs all configured agents like the vault-broker probe does.

## Test evidence

New `src/cli/doctor-pending-retains.test.ts` mocks the docker-exec seam (following the vault-broker pattern) and asserts emitted status + message for ok / backlog / dead-markers / cap / all-down / partial-unreachable / stable ordering.

```
✓ src/cli/doctor-pending-retains.test.ts (10 tests)
✓ src/cli/doctor-vault-broker-pairs.test.ts (9 tests)
✓ tests/doctor.test.ts (46 passed | 2 skipped)
```

`npm run lint` — clean (tsc --noEmit + all 8 guard scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)