### PR TITLE
fix(hindsight): length-aware guard for directive-dedup on terse rules (#2912)

### DIFF
--- a/vendor/hindsight-memory/scripts/lib/directives.py
+++ b/vendor/hindsight-memory/scripts/lib/directives.py
@@ -183,6 +183,27 @@ def parse_active_directives_block(text: str) -> list:
     return contents
 
 
+# Length-aware guard for terse rules (#2912). Forward coverage alone
+# (|rule ∩ directive| / |rule|) is easy to satisfy when the rule has only a
+# couple of significant tokens: any long directive that happens to contain
+# those few words scores ~1.0 and silently swallows a genuinely-new short
+# rule, skipping a legitimate re-prompt. For such short rules we additionally
+# require REVERSE coverage — the matched directive's significant-token set must
+# also be substantially covered by the rule's — which is a Jaccard-style
+# bidirectional check. That fails precisely the "few tokens diluted inside a
+# long unrelated directive" case while still passing a terse rule that restates
+# a comparably terse directive.
+#
+# Constants chosen against the real tokenizer output:
+#   - < 4 significant tokens is "short" (1-3 tokens: the regime where a single
+#     incidental word swings forward coverage past 0.6).
+#   - reverse coverage >= 0.5 keeps near-equal-size restatements deduped
+#     (e.g. a 2-token rule vs a 4-token directive → 2/4 = 0.5) but rejects a
+#     2-token rule diluted inside a 6+-token directive (2/6 ≈ 0.33 < 0.5).
+_SHORT_RULE_TOKEN_LIMIT = 4
+_SHORT_RULE_REVERSE_COVERAGE = 0.5
+
+
 def rule_already_captured(
     rule_text: str, directive_contents: list, threshold: float = 0.6
 ) -> bool:
@@ -193,15 +214,29 @@ def rule_already_captured(
     best-matching directive. A high coverage ratio means the restated rule adds
     (almost) no new significant words over one already stored — i.e. a
     duplicate. Deterministic; no model/API call.
+
+    For terse rules (fewer than ``_SHORT_RULE_TOKEN_LIMIT`` significant tokens)
+    forward coverage is not sufficient — see the module comment above — so a
+    reverse-coverage guard is also required before declaring a match.
     """
     rule_tokens = _dedup_tokens(rule_text)
     if not rule_tokens:
         return False
+    is_short_rule = len(rule_tokens) < _SHORT_RULE_TOKEN_LIMIT
     for content in directive_contents:
         d_tokens = _dedup_tokens(content)
         if not d_tokens:
             continue
-        covered = len(rule_tokens & d_tokens) / len(rule_tokens)
-        if covered >= threshold:
-            return True
+        intersection = len(rule_tokens & d_tokens)
+        covered = intersection / len(rule_tokens)
+        if covered < threshold:
+            continue
+        if is_short_rule:
+            # Bidirectional guard: the directive must not be much larger than
+            # the rule, or those few shared tokens are incidental overlap
+            # rather than a true restatement.
+            reverse_covered = intersection / len(d_tokens)
+            if reverse_covered < _SHORT_RULE_REVERSE_COVERAGE:
+                continue
+        return True
     return False

--- a/vendor/hindsight-memory/scripts/tests/test_directives.py
+++ b/vendor/hindsight-memory/scripts/tests/test_directives.py
@@ -255,6 +255,44 @@ class TestDirectiveDedup(unittest.TestCase):
     def test_empty_rule_is_not_captured(self):
         self.assertFalse(rule_already_captured("", ["Always use British spelling."]))
 
+    # --- #2912: length-aware guard for terse rules -----------------------
+
+    def test_terse_new_rule_not_swallowed_by_long_directive(self):
+        # A genuinely-new terse rule whose few significant tokens all appear
+        # inside a much longer, unrelated directive must NOT be deduped — the
+        # verifier should still re-prompt. Rule tokens {tabs, indentation} are
+        # both present in the long directive, so forward coverage is 1.0, but
+        # they are incidental overlap inside a broader rule.
+        contents = parse_active_directives_block(
+            self._block(
+                "Always use spaces not tabs for indentation and trim "
+                "trailing whitespace on every saved source file."
+            )
+        )
+        self.assertFalse(rule_already_captured("Use tabs for indentation.", contents))
+
+    def test_terse_rule_restating_equally_terse_directive_is_captured(self):
+        # Two comparably terse rules about the same thing → real duplicate.
+        contents = parse_active_directives_block(self._block("Use British spelling."))
+        self.assertTrue(rule_already_captured("Always use British spelling.", contents))
+
+    def test_long_rule_boundary_unchanged_at_0_6(self):
+        # Long rules (>= _SHORT_RULE_TOKEN_LIMIT significant tokens) keep the
+        # plain forward-coverage 0.6 behavior — the guard does not engage.
+        directive = "capital python numeric boolean spelling timezone"
+        # Rule shares 3 of its 5 significant tokens (0.6 exactly) → captured.
+        self.assertTrue(
+            rule_already_captured(
+                "capital python numeric quarterly monthly", [directive]
+            )
+        )
+        # Rule shares 2 of 5 (0.4 < 0.6) → not captured.
+        self.assertFalse(
+            rule_already_captured(
+                "capital python quarterly monthly weekly", [directive]
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #2912.

## Problem
The Stage-C directive verifier (#2909, Fix 6.2) deduped a restated rule when it was >=0.6 token-covered by an existing active directive. Coverage was one-directional (`|rule ∩ directive| / |rule|`), so a genuinely-new but *terse* rule (1-3 significant tokens) whose few tokens all happen to appear inside a much longer, unrelated directive scored ~1.0 and was silently swallowed — skipping a legitimate re-prompt (missed directive capture).

## Fix
`vendor/hindsight-memory/scripts/lib/directives.py` — add a length-aware reverse-coverage guard to `rule_already_captured`:

- `_SHORT_RULE_TOKEN_LIMIT = 4` — rules with < 4 significant tokens are "short".
- For short rules, in addition to forward coverage >= 0.6, require reverse coverage `|rule ∩ directive| / |directive|` >= `_SHORT_RULE_REVERSE_COVERAGE = 0.5` (Jaccard-style bidirectional check). A 2-token rule vs a 4-token directive (2/4 = 0.5) still dedups; a 2-token rule diluted inside a 6+-token directive (~0.33) does not.
- Normal-length rules keep the exact 0.6 forward-coverage behavior — the guard does not engage. Constants documented inline against real tokenizer output. Deterministic, no model/API call.

## Tests (outcomes, `test_directives.py`)
- terse new rule fully token-contained in a longer directive → NOT deduped.
- terse rule restating an equally-terse directive → deduped.
- long-rule behavior unchanged at the 0.6 boundary (captured at exactly 0.6, not at 0.4).

`python3 -m unittest tests.test_directives tests.test_directive_verify` → 62 passed (59 baseline unmodified + 3 new). `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)