### PR TITLE
fix(hindsight): normalize pin tags identically + honor release.pin in standalone memory setup (#2857)

### DIFF
--- a/src/cli/memory-setup-tag.test.ts
+++ b/src/cli/memory-setup-tag.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { resolveMemorySetupTag } from "./memory.js";
+
+describe("resolveMemorySetupTag", () => {
+  it("defaults to the persisted release.pin when no --tag is given (pinned fleet)", () => {
+    expect(resolveMemorySetupTag({ releasePin: "v0.17.5" })).toEqual({
+      tag: "v0.17.5",
+      reason: "pin",
+    });
+    // Bare pin normalizes to canonical vX.Y.Z, same as the update path.
+    expect(resolveMemorySetupTag({ releasePin: "0.17.5" })).toEqual({
+      tag: "v0.17.5",
+      reason: "pin",
+    });
+  });
+
+  it("floats to :latest when there is no pin", () => {
+    expect(resolveMemorySetupTag({})).toEqual({ tag: undefined, reason: "latest" });
+    expect(resolveMemorySetupTag({ releasePin: "" })).toEqual({
+      tag: undefined,
+      reason: "latest",
+    });
+    // A non-normalizable pin (sha / garbage) can't be pinned → floats.
+    expect(resolveMemorySetupTag({ releasePin: "sha-deadbeef" })).toEqual({
+      tag: undefined,
+      reason: "latest",
+    });
+  });
+
+  it("lets an explicit --tag win over the persisted pin", () => {
+    expect(resolveMemorySetupTag({ explicitTag: "v0.18.0", releasePin: "v0.17.5" })).toEqual({
+      tag: "v0.18.0",
+      reason: "explicit",
+    });
+  });
+
+  it("force-floats when --tag latest is passed explicitly, even on a pinned fleet", () => {
+    expect(resolveMemorySetupTag({ explicitTag: "latest", releasePin: "v0.17.5" })).toEqual({
+      tag: undefined,
+      reason: "explicit-latest",
+    });
+    expect(resolveMemorySetupTag({ explicitTag: "LATEST", releasePin: "v0.17.5" })).toEqual({
+      tag: undefined,
+      reason: "explicit-latest",
+    });
+  });
+});

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -32,6 +32,37 @@ import { join } from "node:path";
 import { resolveAgentsDir } from "../config/loader.js";
 import YAML from "yaml";
 import type { SwitchroomConfig } from "../config/schema.js";
+import { normalizeHindsightVersionTag } from "../setup/hindsight.js";
+
+/**
+ * Decide which hindsight image tag `memory setup` should pull + run, and
+ * why. Pure so it can be unit-tested without touching Docker or config I/O.
+ *
+ * Resolution order:
+ *   1. An explicit `--tag latest` force-floats to `:latest` (the operator
+ *      explicitly asked to un-pin) → `{ tag: undefined, reason: "explicit-latest" }`.
+ *   2. Any other explicit `--tag` always wins → `{ tag, reason: "explicit" }`.
+ *   3. No `--tag`, but the fleet has a persisted `release.pin` that
+ *      normalizes to `vX.Y.Z` → default to it so a manual recreate on a
+ *      pinned fleet doesn't silently un-pin hindsight → `{ tag, reason: "pin" }`.
+ *   4. Otherwise float to `:latest` (the standalone default) →
+ *      `{ tag: undefined, reason: "latest" }`.
+ */
+export function resolveMemorySetupTag(input: {
+  explicitTag?: string;
+  releasePin?: string;
+}): { tag: string | undefined; reason: "explicit" | "explicit-latest" | "pin" | "latest" } {
+  const explicit = input.explicitTag?.trim();
+  if (explicit) {
+    if (explicit.toLowerCase() === "latest") {
+      return { tag: undefined, reason: "explicit-latest" };
+    }
+    return { tag: explicit, reason: "explicit" };
+  }
+  const pin = normalizeHindsightVersionTag(input.releasePin);
+  if (pin) return { tag: pin, reason: "pin" };
+  return { tag: undefined, reason: "latest" };
+}
 
 /**
  * Resolve LiteLLM routing config for the hindsight container. Returns
@@ -320,6 +351,40 @@ export function registerMemoryCommand(program: Command): void {
 
       const recreate = opts.recreate === true;
 
+      // Resolve which image tag to pull + run. Without an explicit --tag,
+      // default to the persisted release.pin when the fleet is pinned, so a
+      // manual `memory setup --recreate` on a pinned fleet doesn't silently
+      // un-pin the hindsight singleton to floating :latest. Explicit --tag
+      // always wins; `--tag latest` force-floats. Best-effort config read
+      // (mirrors resolveHindsightPinTag): fall back to :latest rather than
+      // fail the whole setup if config can't be loaded.
+      let releasePin: string | undefined;
+      try {
+        releasePin = getConfig(program).release?.pin ?? undefined;
+      } catch {
+        releasePin = undefined;
+      }
+      const { tag: effectiveTag, reason: tagReason } = resolveMemorySetupTag({
+        explicitTag: opts.tag,
+        releasePin,
+      });
+      switch (tagReason) {
+        case "explicit":
+          console.log(chalk.gray(`  Using hindsight image tag ${effectiveTag} (explicit --tag).`));
+          break;
+        case "explicit-latest":
+          console.log(chalk.gray("  Using floating hindsight image :latest (explicit --tag latest)."));
+          break;
+        case "pin":
+          console.log(
+            chalk.gray(`  Using hindsight image tag ${effectiveTag} (from persisted release.pin).`),
+          );
+          break;
+        case "latest":
+          console.log(chalk.gray("  Using floating hindsight image :latest (standalone default; no pin)."));
+          break;
+      }
+
       // --recreate rebinds the SAME host ports the running container
       // currently publishes, so memory.config.url never changes under the
       // fleet. Read them before we stop the container. (null → fall back
@@ -336,11 +401,11 @@ export function registerMemoryCommand(program: Command): void {
       if (recreate) {
         console.log(
           chalk.gray(
-            `  Pulling ${opts.tag ? `Hindsight image ${opts.tag}` : "latest Hindsight image"}...`,
+            `  Pulling ${effectiveTag ? `Hindsight image ${effectiveTag}` : "latest Hindsight image"}...`,
           ),
         );
         try {
-          pullHindsightImage(opts.tag);
+          pullHindsightImage(effectiveTag);
         } catch (err) {
           console.error(chalk.red(`\n  Failed to pull Hindsight image: ${(err as Error).message}\n`));
           process.exit(1);
@@ -472,7 +537,7 @@ export function registerMemoryCommand(program: Command): void {
         startHindsight(
           ports,
           litellmCfg,
-          opts.tag,
+          effectiveTag,
           hindsightConfig.hindsight?.llm,
           hindsightConsumerMirrorDir(hindsightConfig),
         );

--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -144,6 +144,18 @@ describe("planUpdate", () => {
       expect(resolveHindsightPinTag({ hindsightPinTag: "", pin: "v0.17.5" })).toBeUndefined();
       expect(resolveHindsightPinTag({ hindsightPinTag: "v0.16.11" })).toBe("v0.16.11");
     });
+
+    it("normalizes a bare X.Y.Z --pin to canonical vX.Y.Z (parity with hindsightImageRef)", () => {
+      // Regression for #2857: a release.pin stored without the leading `v`
+      // used to fall through the strict /^v\d+\.\d+\.\d+$/ gate and float to
+      // :latest, silently un-pinning hindsight while the rest of the fleet
+      // stayed on the pinned tag.
+      expect(resolveHindsightPinTag({ pin: "0.17.5" })).toBe("v0.17.5");
+      // A sha pin has no per-version image published → still floats.
+      expect(resolveHindsightPinTag({ pin: "sha-cafebabe" })).toBeUndefined();
+      // Garbage still floats.
+      expect(resolveHindsightPinTag({ pin: "not-a-version" })).toBeUndefined();
+    });
   });
 
   it("inserts regen-compose-for-release-override BEFORE pull-images when --channel is set", () => {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -48,6 +48,7 @@ import { setReleasePinInConfig } from "./release-yaml.js";
 import { resolveOperatorUid } from "./operator-uid.js";
 import { writeConfigFileSync } from "../util/atomic.js";
 import { validateBindSources, formatPreflightError } from "./preflight-mounts.js";
+import { normalizeHindsightVersionTag } from "../setup/hindsight.js";
 
 /**
  * Default durable-pin persister for `update --pin`: comment-preserving,
@@ -348,8 +349,10 @@ export function parseUpdateResultLine(stdout: string): {
  * `release.pin`. Only a concrete `vX.Y.Z` is returned, because the release
  * workflow publishes the hindsight image per version as `:vX.Y.Z`; a
  * `sha-…` pin (or no pin / unreadable config) yields `undefined` → floating
- * `:latest`, the standalone default. Resolved lazily at run() time so
- * build-time step inspection stays free of config I/O.
+ * `:latest`, the standalone default. A bare `X.Y.Z` pin is normalized to the
+ * canonical `vX.Y.Z` (via {@link normalizeHindsightVersionTag}) so this
+ * gates identically to {@link hindsightImageRef}. Resolved lazily at run()
+ * time so build-time step inspection stays free of config I/O.
  */
 export function resolveHindsightPinTag(opts: UpdateOptions): string | undefined {
   if (typeof opts.hindsightPinTag === "string") {
@@ -368,7 +371,7 @@ export function resolveHindsightPinTag(opts: UpdateOptions): string | undefined 
       candidate = undefined;
     }
   }
-  return candidate && /^v\d+\.\d+\.\d+$/.test(candidate) ? candidate : undefined;
+  return normalizeHindsightVersionTag(candidate);
 }
 
 /**

--- a/src/setup/hindsight-pin-tag.test.ts
+++ b/src/setup/hindsight-pin-tag.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeHindsightVersionTag,
+  hindsightImageRef,
+  HINDSIGHT_IMAGE,
+  HINDSIGHT_IMAGE_REPO,
+} from "./hindsight.js";
+
+describe("normalizeHindsightVersionTag", () => {
+  it("canonicalizes a v-prefixed vX.Y.Z to itself", () => {
+    expect(normalizeHindsightVersionTag("v0.17.5")).toBe("v0.17.5");
+    expect(normalizeHindsightVersionTag("v0.15.18")).toBe("v0.15.18");
+  });
+
+  it("canonicalizes a bare X.Y.Z to vX.Y.Z", () => {
+    expect(normalizeHindsightVersionTag("0.17.5")).toBe("v0.17.5");
+    expect(normalizeHindsightVersionTag("10.2.300")).toBe("v10.2.300");
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    expect(normalizeHindsightVersionTag("  v0.17.5  ")).toBe("v0.17.5");
+    expect(normalizeHindsightVersionTag("\t0.17.5\n")).toBe("v0.17.5");
+  });
+
+  it("returns undefined for empty / undefined input", () => {
+    expect(normalizeHindsightVersionTag(undefined)).toBeUndefined();
+    expect(normalizeHindsightVersionTag("")).toBeUndefined();
+    expect(normalizeHindsightVersionTag("   ")).toBeUndefined();
+  });
+
+  it("returns undefined for sha pins and other non-version strings", () => {
+    expect(normalizeHindsightVersionTag("sha-deadbeef")).toBeUndefined();
+    expect(normalizeHindsightVersionTag("latest")).toBeUndefined();
+    expect(normalizeHindsightVersionTag("0.17")).toBeUndefined();
+    expect(normalizeHindsightVersionTag("v0.17.5-rc1")).toBeUndefined();
+    expect(normalizeHindsightVersionTag("garbage")).toBeUndefined();
+  });
+});
+
+describe("hindsightImageRef (shares normalizeHindsightVersionTag)", () => {
+  it("floats to :latest when no tag is given", () => {
+    expect(hindsightImageRef()).toBe(HINDSIGHT_IMAGE);
+    expect(hindsightImageRef("")).toBe(HINDSIGHT_IMAGE);
+    expect(hindsightImageRef("   ")).toBe(HINDSIGHT_IMAGE);
+  });
+
+  it("pins a bare and a v-prefixed version to the same :vX.Y.Z ref", () => {
+    expect(hindsightImageRef("0.17.5")).toBe(`${HINDSIGHT_IMAGE_REPO}:v0.17.5`);
+    expect(hindsightImageRef("v0.17.5")).toBe(`${HINDSIGHT_IMAGE_REPO}:v0.17.5`);
+  });
+
+  it("floats a non-normalizable tag (sha / garbage) to :latest", () => {
+    expect(hindsightImageRef("sha-deadbeef")).toBe(HINDSIGHT_IMAGE);
+    expect(hindsightImageRef("garbage")).toBe(HINDSIGHT_IMAGE);
+  });
+});

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -112,13 +112,34 @@ export const HINDSIGHT_IMAGE = `${HINDSIGHT_IMAGE_REPO}:latest`;
  * When `tag` is undefined/empty, returns the floating `:latest` image
  * ({@link HINDSIGHT_IMAGE}) — preserving the standalone `memory setup`
  * behavior. Normalizes so a bare `0.15.18` and a `v0.15.18` both resolve to
- * the `:v0.15.18` tag the workflow actually publishes.
+ * the `:v0.15.18` tag the workflow actually publishes. A non-normalizable
+ * tag (e.g. `sha-…`, garbage) also floats to `:latest` — the release
+ * workflow only publishes per-version `:vX.Y.Z` images, so there is no
+ * concrete image to pin to.
  */
 export function hindsightImageRef(tag?: string): string {
-  const t = tag?.trim();
-  if (!t) return HINDSIGHT_IMAGE;
-  const v = t.replace(/^v/, "");
-  return `${HINDSIGHT_IMAGE_REPO}:v${v}`;
+  const normalized = normalizeHindsightVersionTag(tag);
+  if (!normalized) return HINDSIGHT_IMAGE;
+  return `${HINDSIGHT_IMAGE_REPO}:${normalized}`;
+}
+
+/**
+ * Canonicalize a hindsight image version tag to the `vX.Y.Z` form the
+ * release workflow publishes (`TAG_VERSION="${GITHUB_REF#refs/tags/}"` →
+ * `:vX.Y.Z`). Accepts either an already-`v`-prefixed `vX.Y.Z` or a bare
+ * `X.Y.Z` and returns the canonical `vX.Y.Z`. Anything else — an empty /
+ * undefined value, a `sha-…` pin, or garbage — returns `undefined`, which
+ * callers treat as "no concrete version → float to `:latest`".
+ *
+ * This is the single source of truth for pin normalization, shared by
+ * {@link hindsightImageRef} and `resolveHindsightPinTag` (src/cli/update.ts)
+ * so both callsites gate identically.
+ */
+export function normalizeHindsightVersionTag(candidate?: string): string | undefined {
+  const t = candidate?.trim();
+  if (!t) return undefined;
+  const m = /^v?(\d+\.\d+\.\d+)$/.exec(t);
+  return m ? `v${m[1]}` : undefined;
 }
 
 /**


### PR DESCRIPTION
Closes #2857. Two non-blocking follow-ups flagged during review of #2856.

## 1. v-prefix normalization parity
`resolveHindsightPinTag` (`src/cli/update.ts`) gated on strict `/^v\d+\.\d+\.\d+$/`, so a `release.pin` stored **without** the leading `v` (e.g. `0.17.5`) floated to `:latest` on `switchroom update`, whereas `hindsightImageRef` (`src/setup/hindsight.ts`) lenient-normalized bare `0.17.5` → `:v0.17.5`. The two callsites disagreed.

Fix: extracted a single source of truth — `normalizeHindsightVersionTag(candidate): string | undefined` in `src/setup/hindsight.ts` — that accepts `vX.Y.Z` or bare `X.Y.Z` and returns canonical `vX.Y.Z`, else `undefined`. Both `resolveHindsightPinTag` and `hindsightImageRef` now use it, so they gate identically. `sha-…` pins and garbage still yield `undefined` → floating `:latest`. The test-seam `hindsightPinTag` and `channel` overrides are unchanged.

## 2. Standalone `memory setup --recreate` honors `release.pin`
A human running `switchroom memory setup --recreate` directly (no `--tag`) silently floated hindsight to `:latest`, un-pinning it on an otherwise-pinned fleet. Now, when no `--tag` is given, the tag defaults to the persisted `release.pin` (best-effort config read, normalized to `vX.Y.Z`). Explicit `--tag` always wins; `--tag latest` force-floats. The chosen tag and the reason (pin vs latest vs explicit) are printed so the operator sees it. The decision is extracted into a pure exported `resolveMemorySetupTag()` for testability.

## Tests
- Extended the `resolveHindsightPinTag` block in `src/cli/update.test.ts`: bare `0.17.5` pin → `v0.17.5`; sha/garbage still `undefined`.
- New `src/setup/hindsight-pin-tag.test.ts`: unit tests for `normalizeHindsightVersionTag` and `hindsightImageRef` parity.
- New `src/cli/memory-setup-tag.test.ts`: `resolveMemorySetupTag` defaulting (pin, latest, explicit wins, `--tag latest` force-float).

Scoped vitest (80 tests) + `npm run lint` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)