### PR TITLE
fix(agents): least-privilege pass on hindsight MCP allowlist (#2911)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -990,21 +990,20 @@ export const HINDSIGHT_MCP_TOOLS = [
   "mcp__hindsight__retain",
   "mcp__hindsight__sync_retain",
   "mcp__hindsight__reflect",
-  // Directives — captured autonomously (directive-capture nudge/verifier).
+  // Directives — create_directive is captured autonomously (the #2848
+  // directive-capture nudge: recall.py regex-detects correction-shaped
+  // inbound and nudges the model to persist it with create_directive).
   "mcp__hindsight__create_directive",
   "mcp__hindsight__update_bank",
-  "mcp__hindsight__delete_directive",
   "mcp__hindsight__list_directives",
   // Banks.
   "mcp__hindsight__create_bank",
   "mcp__hindsight__get_bank",
   "mcp__hindsight__get_bank_stats",
   "mcp__hindsight__list_banks",
-  "mcp__hindsight__delete_bank",
   // Memories.
   "mcp__hindsight__get_memory",
   "mcp__hindsight__list_memories",
-  "mcp__hindsight__clear_memories",
   // Documents.
   "mcp__hindsight__get_document",
   "mcp__hindsight__list_documents",
@@ -1018,6 +1017,23 @@ export const HINDSIGHT_MCP_TOOLS = [
   "mcp__hindsight__get_operation",
   "mcp__hindsight__list_operations",
   "mcp__hindsight__cancel_operation",
+  //
+  // DELIBERATELY OMITTED — least-privilege (#2911). The destructive tools
+  // below are real server tools but are NOT pre-approved: they fall through
+  // to a normal Claude Code permission prompt (→ a Telegram approval card),
+  // so an agent can't silently wipe a bank / all memories / a standing
+  // guardrail. Confirmed via a whole-repo grep that no automated flow
+  // (host TS callsites, Stop hooks, vendored scripts, or scaffolded prompts)
+  // invokes any of them — every use is user-driven, so a per-call human tap
+  // is the right gate. Do NOT re-add these without re-checking that grep:
+  //   • mcp__hindsight__delete_bank     — destroys an entire memory bank.
+  //   • mcp__hindsight__clear_memories  — wipes every memory in a bank.
+  //   • mcp__hindsight__delete_directive — removes a standing reflect guardrail.
+  //       (The autonomous directive-capture nudge only CREATES directives via
+  //        create_directive; nothing auto-deletes one.)
+  // Note: delete_document IS kept pre-approved on purpose — the scaffolded
+  // MEMORY_GUIDANCE instructs the agent to call it autonomously for user
+  // corrections and "forget that" requests (an automated-flow dependency).
 ];
 
 /**

--- a/tests/hindsight-permission-surface.test.ts
+++ b/tests/hindsight-permission-surface.test.ts
@@ -36,11 +36,8 @@ describe("Hindsight pre-approved permission surface (Fix 1.2, #2903)", () => {
   it("pre-approves exactly this enumerated set (change = deliberate)", () => {
     expect([...HINDSIGHT_MCP_TOOLS].sort()).toEqual([
       "mcp__hindsight__cancel_operation",
-      "mcp__hindsight__clear_memories",
       "mcp__hindsight__create_bank",
       "mcp__hindsight__create_directive",
-      "mcp__hindsight__delete_bank",
-      "mcp__hindsight__delete_directive",
       "mcp__hindsight__delete_document",
       "mcp__hindsight__get_bank",
       "mcp__hindsight__get_bank_stats",
@@ -61,6 +58,25 @@ describe("Hindsight pre-approved permission surface (Fix 1.2, #2903)", () => {
       "mcp__hindsight__sync_retain",
       "mcp__hindsight__update_bank",
     ]);
+  });
+
+  it("NEVER pre-approves the destructive tools demoted to a permission prompt (#2911)", () => {
+    // Least-privilege: these fall through to a Claude Code permission prompt
+    // (→ Telegram approval card) instead of silent pre-approval. No automated
+    // flow depends on their pre-approval (verified by whole-repo grep in #2911).
+    for (const destructive of [
+      "mcp__hindsight__delete_bank",
+      "mcp__hindsight__clear_memories",
+      "mcp__hindsight__delete_directive",
+    ]) {
+      expect(
+        HINDSIGHT_MCP_TOOLS,
+        `${destructive} must NOT be pre-approved — it should require a per-call permission prompt (#2911)`,
+      ).not.toContain(destructive);
+    }
+    // delete_document STAYS pre-approved: MEMORY_GUIDANCE instructs the agent
+    // to call it autonomously for corrections / "forget that" (automated flow).
+    expect(HINDSIGHT_MCP_TOOLS).toContain("mcp__hindsight__delete_document");
   });
 
   it("NEVER pre-approves a mental-model write tool (they route through the propose card)", () => {


### PR DESCRIPTION
Closes #2911.

## What
Removes the destructive `delete_bank`, `clear_memories`, and `delete_directive` tools from the enumerated Hindsight pre-approval allowlist (`HINDSIGHT_MCP_TOOLS` in `src/agents/scaffold.ts`). They remain real, callable server tools, but now fall through to a normal Claude Code permission prompt (→ Telegram approval card) instead of silent auto-approval. An agent can no longer wipe a bank, clear all memories, or delete a standing reflect guardrail without a per-call human tap.

## Dependency-check evidence (issue requirement)
Whole-repo grep for automated invocations of the three tools across `src`, `telegram-plugin`, `vendor/hindsight-memory`, `profiles`, `bin`, `scripts`:

- **`delete_bank`** — only in the scaffold allowlist, the test/fixture, and docs (`reference/rfcs/shared-knowledge-banks.md` explicitly calls bank deletion "an explicit operator act"). No automated caller. An audit note (`audit/2026-05-26/.../escalation-08.md`) confirms neither the vendored client nor `src/memory/hindsight.ts` even exposes a delete-bank call.
- **`clear_memories`** — only in the scaffold allowlist, the test, and the fixture. No caller anywhere.
- **`delete_directive`** — the #2848 directive-capture nudge (recall.py regex → nudges the model) instructs only `create_directive`; the scaffolded prompt (`profiles/default/CLAUDE.md.hbs`) never instructs autonomous deletion. `src/memory/hindsight-tools.ts` lists it only for tool-reality contract checks. No automated flow deletes a directive → user-driven only → demoted per the issue's evidence rule.

**`delete_document` is deliberately KEPT** pre-approved: the scaffolded `MEMORY_GUIDANCE` block instructs the agent to call it autonomously for user corrections and "forget that" requests (a genuine automated-flow dependency).

## Changes
1. `src/agents/scaffold.ts` — drop the three tools; add a `DELIBERATELY OMITTED` comment block documenting the least-privilege rationale so a future edit can't silently re-approve them.
2. `tests/hindsight-permission-surface.test.ts` — update the enumerated-set assertion and add an explicit negative outcome assertion that the three destructive tools are NOT in the allowlist (plus a positive assertion that `delete_document` stays).

The engine-surface fixture (`tests/fixtures/hindsight-tools-list.snapshot.json`) is intentionally unchanged — it enumerates the 29 real *server* tools, not the pre-approval allowlist; the demoted tools are still real tools.

## Testing
- Scoped: `vitest run tests/hindsight-permission-surface.test.ts tests/memory.hindsight-contract.fixture.test.ts tests/memory.hindsight-iserror-guard.test.ts` → 24 passed.
- `npm run lint` → clean (tsc + all 8 guard scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)