### PR TITLE
fix(memory): fail loudly on explicit non-normalizable --tag instead of silently floating (#2857)

### DIFF
--- a/src/cli/memory-setup-tag.test.ts
+++ b/src/cli/memory-setup-tag.test.ts
@@ -27,11 +27,36 @@ describe("resolveMemorySetupTag", () => {
     });
   });
 
-  it("lets an explicit --tag win over the persisted pin", () => {
+  it("lets an explicit --tag win over the persisted pin (normalized to vX.Y.Z)", () => {
     expect(resolveMemorySetupTag({ explicitTag: "v0.18.0", releasePin: "v0.17.5" })).toEqual({
       tag: "v0.18.0",
       reason: "explicit",
     });
+    // A bare explicit tag is normalized to the canonical published form, so
+    // the tag we print is EXACTLY the tag hindsightImageRef will run.
+    expect(resolveMemorySetupTag({ explicitTag: "0.18.0", releasePin: "v0.17.5" })).toEqual({
+      tag: "v0.18.0",
+      reason: "explicit",
+    });
+  });
+
+  it("rejects an explicit non-normalizable tag as invalid (must fail loudly, never float)", () => {
+    // Regression for the #3088 review finding: hindsightImageRef floats
+    // anything it can't normalize to :latest, so passing sha-deadbeef
+    // through as "explicit" would print one tag and run another — a silent
+    // un-pin. The resolver must flag it so the CLI can exit non-zero.
+    expect(resolveMemorySetupTag({ explicitTag: "sha-deadbeef", releasePin: "v0.17.5" })).toEqual({
+      tag: "sha-deadbeef",
+      reason: "invalid",
+    });
+    expect(resolveMemorySetupTag({ explicitTag: "garbage" })).toEqual({
+      tag: "garbage",
+      reason: "invalid",
+    });
+    // The invalid explicit tag does NOT fall back to the pin or to :latest.
+    expect(resolveMemorySetupTag({ explicitTag: "v0.18", releasePin: "v0.17.5" }).reason).toBe(
+      "invalid",
+    );
   });
 
   it("force-floats when --tag latest is passed explicitly, even on a pinned fleet", () => {

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -41,7 +41,13 @@ import { normalizeHindsightVersionTag } from "../setup/hindsight.js";
  * Resolution order:
  *   1. An explicit `--tag latest` force-floats to `:latest` (the operator
  *      explicitly asked to un-pin) → `{ tag: undefined, reason: "explicit-latest" }`.
- *   2. Any other explicit `--tag` always wins → `{ tag, reason: "explicit" }`.
+ *   2. Any other explicit `--tag` always wins — but it MUST normalize to a
+ *      canonical `vX.Y.Z` → `{ tag: <normalized>, reason: "explicit" }`.
+ *      A non-normalizable explicit tag (sha-…, garbage) returns
+ *      `reason: "invalid"` and the caller must fail loudly: hindsightImageRef
+ *      floats anything it can't normalize to `:latest`, so silently passing
+ *      garbage through would print one tag and run another — the exact
+ *      silent-un-pin footgun #2857 exists to close.
  *   3. No `--tag`, but the fleet has a persisted `release.pin` that
  *      normalizes to `vX.Y.Z` → default to it so a manual recreate on a
  *      pinned fleet doesn't silently un-pin hindsight → `{ tag, reason: "pin" }`.
@@ -51,13 +57,18 @@ import { normalizeHindsightVersionTag } from "../setup/hindsight.js";
 export function resolveMemorySetupTag(input: {
   explicitTag?: string;
   releasePin?: string;
-}): { tag: string | undefined; reason: "explicit" | "explicit-latest" | "pin" | "latest" } {
+}): {
+  tag: string | undefined;
+  reason: "explicit" | "explicit-latest" | "pin" | "latest" | "invalid";
+} {
   const explicit = input.explicitTag?.trim();
   if (explicit) {
     if (explicit.toLowerCase() === "latest") {
       return { tag: undefined, reason: "explicit-latest" };
     }
-    return { tag: explicit, reason: "explicit" };
+    const normalized = normalizeHindsightVersionTag(explicit);
+    if (!normalized) return { tag: explicit, reason: "invalid" };
+    return { tag: normalized, reason: "explicit" };
   }
   const pin = normalizeHindsightVersionTag(input.releasePin);
   if (pin) return { tag: pin, reason: "pin" };
@@ -369,6 +380,21 @@ export function registerMemoryCommand(program: Command): void {
         releasePin,
       });
       switch (tagReason) {
+        case "invalid":
+          // Fail loudly: hindsightImageRef floats anything it can't
+          // normalize to :latest, so proceeding would print one tag and
+          // run another — a silent un-pin (#2857).
+          console.error(
+            chalk.red(
+              `\n  Invalid hindsight image tag: ${effectiveTag}\n` +
+                `  The release workflow only publishes per-version tags. Valid forms:\n` +
+                `    vX.Y.Z  (e.g. v0.17.5)\n` +
+                `    X.Y.Z   (normalized to vX.Y.Z)\n` +
+                `    latest  (explicitly float to :latest)\n`,
+            ),
+          );
+          process.exit(1);
+          break;
         case "explicit":
           console.log(chalk.gray(`  Using hindsight image tag ${effectiveTag} (explicit --tag).`));
           break;


### PR DESCRIPTION
Follow-up to #3088 (which auto-merged before this review fix could land on the branch). Adversarial review finding:

`hindsightImageRef` floats non-normalizable tags to `:latest`, so `switchroom memory setup --tag sha-deadbeef` printed "Using hindsight image tag sha-deadbeef (explicit --tag)" but actually pulled and ran `:latest` — a silent un-pin plus a lying status line, the exact footgun class #2857 exists to close.

## Fix
- `resolveMemorySetupTag` now normalizes an explicit `--tag` to canonical `vX.Y.Z`, so the printed tag is EXACTLY the tag that runs.
- A non-normalizable, non-`latest` explicit tag returns `reason: "invalid"`; the CLI exits 1 with an error naming the valid forms (`vX.Y.Z`, `X.Y.Z`, `latest`) instead of silently floating.
- Other `hindsightImageRef`/`startHindsight` callers audited: `src/cli/setup.ts` passes `undefined`; update/rollout thread tags already validated by `resolveHindsightPinTag`.

## Tests
- Outcome tests in `src/cli/memory-setup-tag.test.ts` for explicit garbage/sha (`reason: "invalid"`, no fallback to pin or `:latest`) and bare explicit tag normalization.

Scoped vitest (81 tests) + `npm run lint` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)