### PR TITLE
feat(hindsight): host-side autoheal sidecar for restart-on-unhealthy (#2910)

### DIFF
--- a/docker/Dockerfile.hostd
+++ b/docker/Dockerfile.hostd
@@ -100,6 +100,16 @@ COPY dist/host-control/main.js /opt/switchroom/dist/host-control/main.js
 COPY profiles/ /opt/switchroom/profiles/
 COPY vendor/hindsight-memory/ /opt/switchroom/vendor/hindsight-memory/
 
+# hindsight autoheal loop (#2910). The hostd compose adds a tiny
+# `switchroom-hindsight-autoheal` sidecar that runs THIS script on the hostd
+# image (chosen because it already carries the docker CLI + routes through the
+# docker-socket-proxy). It polls the standalone `switchroom-hindsight`
+# container's health and issues `docker restart` on `unhealthy` with a
+# sliding-window cap + exponential backoff — the host-side restart-on-unhealthy
+# mechanism the container cannot do for itself. Pure /bin/sh, no extra deps.
+COPY docker/hindsight-autoheal.sh /opt/switchroom/docker/hindsight-autoheal.sh
+RUN chmod 0755 /opt/switchroom/docker/hindsight-autoheal.sh
+
 # Tiny wrapper so `switchroom <verb>` invocations from hostd resolve
 # to the bundled CLI. Uses `bun` (not `node`) because the CLI bundle
 # imports bun-specific modules (bun:sqlite, bun:test, etc. — produced

--- a/docker/hindsight-autoheal.sh
+++ b/docker/hindsight-autoheal.sh
@@ -1,0 +1,182 @@
+#!/bin/sh
+# switchroom/hindsight HOST-SIDE autoheal loop (#2910).
+#
+# The problem this closes: the standalone `switchroom-hindsight` container
+# (started by `startHindsight()` / `switchroom memory --start`) carries a
+# docker healthcheck that marks it `unhealthy` in `docker inspect` when the
+# API wedges. But vanilla Docker NEVER restarts a container on health status
+# — `--restart always` acts on process EXIT only. And the in-container
+# `hindsight-maintenance.sh` runs inside that same container with no docker
+# binary/socket, so it cannot restart itself. So a wedged-but-not-exited API
+# stayed `unhealthy` forever and the fleet went silently amnesiac.
+#
+# This script is the missing host-side mechanism. It runs in a TINY sidecar
+# (the hostd image, which already carries the docker CLI) that talks to the
+# docker daemon through the EXISTING hostd `docker-socket-proxy` over
+# DOCKER_HOST=tcp://docker-socket-proxy:2375 — least-privilege: the proxy
+# already allowlists GET /containers (inspect) + POST restart (ALLOW_RESTARTS)
+# for hostd, so no new socket mount and no widened surface are introduced.
+#
+# It polls the target's `.State.Health.Status` and, on `unhealthy`, issues a
+# `docker restart` — but GUARDED against restart loops: at most
+# MAX_RESTARTS within a sliding WINDOW_S window, with exponential backoff
+# between restarts. When the cap is hit it GIVES UP loudly (structured log
+# line `switchroom doctor` reads back) and enters a cooldown before it will
+# try again, so a genuinely-broken hindsight can't be restart-looped forever.
+#
+# Every decision is logged as a single structured line prefixed
+# `hindsight-autoheal` so `switchroom doctor` (classifyAutohealStatus in
+# src/cli/doctor-memory.ts) can report "hindsight was auto-restarted N times /
+# autoheal gave up" from `docker logs`.
+#
+# Env knobs (all defaulted):
+#   SWITCHROOM_HINDSIGHT_AUTOHEAL              master switch (1=on, 0=off). default 1
+#   SWITCHROOM_HINDSIGHT_AUTOHEAL_TARGET       container name. default switchroom-hindsight
+#   SWITCHROOM_HINDSIGHT_AUTOHEAL_POLL_S       seconds between polls. default 30
+#   SWITCHROOM_HINDSIGHT_AUTOHEAL_MAX_RESTARTS restarts allowed per window. default 3
+#   SWITCHROOM_HINDSIGHT_AUTOHEAL_WINDOW_S     sliding window seconds. default 3600 (1h)
+#   SWITCHROOM_HINDSIGHT_AUTOHEAL_BACKOFF_BASE_S exp-backoff base seconds. default 30
+#   SWITCHROOM_HINDSIGHT_AUTOHEAL_COOLDOWN_S   pause after giving up. default 900 (15m)
+#
+# Sourcing for tests: set SWITCHROOM_HINDSIGHT_AUTOHEAL_LIB_ONLY=1 to load the
+# pure decision functions WITHOUT entering the poll loop.
+set -u
+
+# ── Pure decision core (unit-tested; no docker, no clock side-effects) ───────
+#
+# autoheal_prune STATE NOW WINDOW
+#   STATE is a space-separated list of past restart epoch-seconds. Echoes the
+#   subset still inside [NOW-WINDOW, NOW]. Deterministic, no side effects.
+autoheal_prune() {
+  _state="$1"; _now="$2"; _window="$3"
+  _cutoff=$((_now - _window))
+  _out=""
+  for _ts in $_state; do
+    if [ "$_ts" -ge "$_cutoff" ] 2>/dev/null; then
+      _out="${_out:+$_out }$_ts"
+    fi
+  done
+  printf '%s' "$_out"
+}
+
+# autoheal_count STATE
+#   Echoes how many timestamps are in STATE.
+autoheal_count() {
+  set -- $1
+  printf '%d' "$#"
+}
+
+# autoheal_decide HEALTH STATE NOW WINDOW MAX
+#   THE decision function. Echoes "<verb>|<new-state>" where verb is:
+#     ok       — target is not unhealthy; nothing to do (state pruned).
+#     restart  — unhealthy AND under the cap; NOW appended to the new state.
+#     capped   — unhealthy AND already at/over MAX restarts in the window.
+#   new-state is the pruned (and, for restart, NOW-appended) timestamp list.
+autoheal_decide() {
+  _health="$1"; _st="$2"; _now="$3"; _win="$4"; _max="$5"
+  _pruned=$(autoheal_prune "$_st" "$_now" "$_win")
+  _n=$(autoheal_count "$_pruned")
+  if [ "$_health" != "unhealthy" ]; then
+    printf 'ok|%s' "$_pruned"
+    return 0
+  fi
+  if [ "$_n" -ge "$_max" ]; then
+    printf 'capped|%s' "$_pruned"
+    return 0
+  fi
+  printf 'restart|%s' "${_pruned:+$_pruned }$_now"
+}
+
+# autoheal_backoff BASE COUNT
+#   Exponential backoff seconds = BASE * 2^COUNT, capped at 8*BASE so it can
+#   never grow unbounded. COUNT is the number of restarts already done this
+#   window (0-based → first restart waits BASE).
+autoheal_backoff() {
+  _base="$1"; _c="$2"
+  _mult=1
+  _i=0
+  while [ "$_i" -lt "$_c" ]; do
+    _mult=$((_mult * 2))
+    _i=$((_i + 1))
+    if [ "$_mult" -ge 8 ]; then _mult=8; break; fi
+  done
+  printf '%d' $((_base * _mult))
+}
+
+# autoheal_log EVENT KEY=VAL ...
+#   Emit one structured line doctor can grep. Stable prefix + flat k=v pairs.
+autoheal_log() {
+  _ev="$1"; shift
+  _ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || printf 'na')
+  printf 'hindsight-autoheal event=%s ts=%s %s\n' "$_ev" "$_ts" "$*"
+}
+
+# ── Runtime loop (skipped when sourced with LIB_ONLY=1) ──────────────────────
+autoheal_main() {
+  ENABLED="${SWITCHROOM_HINDSIGHT_AUTOHEAL:-1}"
+  TARGET="${SWITCHROOM_HINDSIGHT_AUTOHEAL_TARGET:-switchroom-hindsight}"
+  POLL_S="${SWITCHROOM_HINDSIGHT_AUTOHEAL_POLL_S:-30}"
+  MAX="${SWITCHROOM_HINDSIGHT_AUTOHEAL_MAX_RESTARTS:-3}"
+  WINDOW_S="${SWITCHROOM_HINDSIGHT_AUTOHEAL_WINDOW_S:-3600}"
+  BACKOFF_BASE_S="${SWITCHROOM_HINDSIGHT_AUTOHEAL_BACKOFF_BASE_S:-30}"
+  COOLDOWN_S="${SWITCHROOM_HINDSIGHT_AUTOHEAL_COOLDOWN_S:-900}"
+
+  if [ "$ENABLED" = "0" ]; then
+    autoheal_log disabled target="$TARGET"
+    return 0
+  fi
+
+  autoheal_log started target="$TARGET" poll_s="$POLL_S" max_restarts="$MAX" window_s="$WINDOW_S"
+
+  STATE=""
+  gave_up=0
+  while true; do
+    now=$(date +%s)
+    # Health status; "missing" if the container/daemon can't be inspected
+    # (target recreating, daemon blip) — treated as NOT unhealthy so we never
+    # fight a legitimate recreate. python3-free: pure docker CLI.
+    health=$(docker inspect -f '{{.State.Health.Status}}' "$TARGET" 2>/dev/null) || health="missing"
+    [ -z "$health" ] && health="missing"
+
+    decision=$(autoheal_decide "$health" "$STATE" "$now" "$WINDOW_S" "$MAX")
+    verb="${decision%%|*}"
+    STATE="${decision#*|}"
+
+    case "$verb" in
+      restart)
+        gave_up=0
+        # count BEFORE this restart = entries minus the one just appended
+        newcount=$(autoheal_count "$STATE")
+        priorcount=$((newcount - 1))
+        autoheal_log restart_issued target="$TARGET" health="$health" attempt="$newcount" window_restarts="$newcount"
+        if docker restart "$TARGET" >/dev/null 2>&1; then
+          autoheal_log restart_ok target="$TARGET" attempt="$newcount"
+        else
+          autoheal_log restart_failed target="$TARGET" attempt="$newcount"
+        fi
+        backoff=$(autoheal_backoff "$BACKOFF_BASE_S" "$priorcount")
+        sleep "$backoff"
+        continue
+        ;;
+      capped)
+        if [ "$gave_up" = "0" ]; then
+          autoheal_log gave_up target="$TARGET" health="$health" restarts="$(autoheal_count "$STATE")" window_s="$WINDOW_S" cooldown_s="$COOLDOWN_S"
+          gave_up=1
+        fi
+        sleep "$COOLDOWN_S"
+        # Cooldown elapsed: clear the window so a since-recovered target can be
+        # healed again, but a still-broken one just re-trips the cap next tick.
+        STATE=""
+        continue
+        ;;
+      ok|*)
+        gave_up=0
+        ;;
+    esac
+    sleep "$POLL_S"
+  done
+}
+
+if [ "${SWITCHROOM_HINDSIGHT_AUTOHEAL_LIB_ONLY:-0}" != "1" ]; then
+  autoheal_main
+fi

--- a/src/cli/doctor-memory.ts
+++ b/src/cli/doctor-memory.ts
@@ -180,6 +180,62 @@ export function classifyExtractionLogs(logs: string): CheckResult {
 }
 
 /**
+ * Pure: classify recent `switchroom-hindsight-autoheal` sidecar logs (#2910)
+ * into a doctor result, so `switchroom doctor` can report that the host-side
+ * autoheal loop restarted a wedged hindsight — or gave up after hitting its
+ * restart cap — instead of it hiding in `docker logs`.
+ *
+ * The sidecar emits stable structured lines (`hindsight-autoheal event=<ev>
+ * …`). We count `restart_issued` events and detect a `gave_up` event:
+ *  - `gave_up` present  → FAIL: hit the sliding-window cap; hindsight is
+ *    genuinely broken (loop-guarded, so it's NOT restart-looping — it backed
+ *    off), needs an operator.
+ *  - restarts > 0, no give-up → WARN: it healed a wedge, but a healthy
+ *    hindsight shouldn't need restarting; worth a look.
+ *  - no restarts → OK.
+ *
+ * `logs` is the sidecar's recent stdout. Never throws.
+ */
+export function classifyAutohealStatus(logs: string): CheckResult {
+  const restarts = (logs.match(/event=restart_issued\b/g) ?? []).length;
+  const gaveUp = /event=gave_up\b/.test(logs);
+  const disabled = /event=disabled\b/.test(logs);
+
+  if (disabled && restarts === 0) {
+    return {
+      name: "hindsight autoheal",
+      status: "ok",
+      detail: "disabled (SWITCHROOM_HINDSIGHT_AUTOHEAL=0)",
+    };
+  }
+  if (gaveUp) {
+    return {
+      name: "hindsight autoheal",
+      status: "fail",
+      detail:
+        `autoheal GAVE UP after ${restarts} restart(s) in its window — hindsight ` +
+        `kept coming back unhealthy, so the loop backed off (it is NOT restart-` +
+        `looping) and memory is likely down`,
+      fix:
+        "hindsight is genuinely wedged. Check `docker logs switchroom-hindsight` " +
+        "for the root cause (shm/quota/crash), fix it, then `switchroom memory " +
+        "--restart`. Autoheal resumes on its own after the cooldown.",
+    };
+  }
+  if (restarts > 0) {
+    return {
+      name: "hindsight autoheal",
+      status: "warn",
+      detail:
+        `hindsight was auto-restarted ${restarts} time(s) recently — the wedge was ` +
+        `healed, but a healthy backend shouldn't need restarting`,
+      fix: "Inspect `docker logs switchroom-hindsight` around the restart(s) for the underlying wedge.",
+    };
+  }
+  return { name: "hindsight autoheal", status: "ok", detail: "no auto-restarts" };
+}
+
+/**
  * Best-effort: inspect the local `switchroom-hindsight` container's shm + recent
  * logs. Returns [] (silently skipped) when hindsight isn't a local container —
  * a remote `memory.config.url`, no docker, or running inside an agent container.
@@ -211,6 +267,16 @@ export function checkHindsightContainerHealth(
     results.push(classifyExtractionLogs(logs));
   } catch {
     // logs unavailable — skip the extraction check rather than fail the run
+  }
+
+  // Autoheal sidecar status (#2910). Only surfaces when the sidecar exists
+  // (its logs are readable) — a fleet without hostd/autoheal skips this line
+  // rather than showing a spurious "ok".
+  try {
+    const autohealLogs = exec("docker", ["logs", "--since", "1h", "switchroom-hindsight-autoheal"]);
+    results.push(classifyAutohealStatus(autohealLogs));
+  } catch {
+    // no autoheal sidecar (no hostd project / not deployed) — nothing to report
   }
 
   return results;

--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -8,9 +8,9 @@
  */
 
 import { afterEach, beforeEach, describe, it, expect } from "vitest";
-import { mkdtempSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import {
   DOCKER_SOCKET_PROXY_IMAGE,
   renderHostdComposeFile,
@@ -394,5 +394,71 @@ describe("resolveHostdImageTag (honor release.pin like the agent fleet)", () => 
   it("falls back to 'latest' when neither --tag nor release is set", () => {
     expect(resolveHostdImageTag(undefined, undefined)).toBe("latest");
     expect(resolveHostdImageTag(undefined, {})).toBe("latest");
+  });
+});
+
+describe("renderHostdComposeFile — hindsight-autoheal sidecar (#2910)", () => {
+  const render = () =>
+    renderHostdComposeFile({ hostHome: "/home/alice", imageTag: "v1.2.3" });
+
+  it("emits a switchroom-hindsight-autoheal service on the hostd image", () => {
+    const out = render();
+    expect(out).toContain("hindsight-autoheal:");
+    expect(out).toContain("container_name: switchroom-hindsight-autoheal");
+    expect(out).toContain("image: ghcr.io/switchroom/switchroom-hostd:v1.2.3");
+  });
+
+  it("reuses the EXISTING docker-socket-proxy — no new raw-socket mount", () => {
+    const out = render();
+    const block = out.slice(
+      out.indexOf("hindsight-autoheal:"),
+      out.indexOf("\nnetworks:\n  default:"),
+    );
+    // Talks to the daemon only through the proxy over TCP.
+    expect(block).toContain("DOCKER_HOST: tcp://docker-socket-proxy:2375");
+    expect(block).toMatch(/depends_on:[\s\S]*?- docker-socket-proxy/);
+    // It must NOT mount the raw socket — the whole least-privilege point.
+    expect(block).not.toContain("/var/run/docker.sock");
+    // Still exactly ONE raw-socket bind in the whole file (the proxy's).
+    expect(
+      out.split("\n").filter((l) => /^\s*- \/var\/run\/docker\.sock:/.test(l)).length,
+    ).toBe(1);
+  });
+
+  it("hardens the sidecar: cap_drop ALL + no-new-privileges, and no state volumes", () => {
+    const out = render();
+    const block = out.slice(
+      out.indexOf("hindsight-autoheal:"),
+      out.indexOf("\nnetworks:\n  default:"),
+    );
+    expect(block).toMatch(/cap_drop:\s*\n\s+- ALL/);
+    expect(block).toContain("no-new-privileges:true");
+    // No volumes: — it never touches hostd's ~/.switchroom state.
+    expect(block).not.toMatch(/^\s+volumes:/m);
+  });
+
+  it("runs the baked autoheal script and pins the loop-guard knobs", () => {
+    const out = render();
+    const block = out.slice(
+      out.indexOf("hindsight-autoheal:"),
+      out.indexOf("\nnetworks:\n  default:"),
+    );
+    expect(block).toContain("/opt/switchroom/docker/hindsight-autoheal.sh");
+    expect(block).toContain("SWITCHROOM_HINDSIGHT_AUTOHEAL_TARGET: switchroom-hindsight");
+    expect(block).toContain('SWITCHROOM_HINDSIGHT_AUTOHEAL_MAX_RESTARTS: "3"');
+    expect(block).toContain('SWITCHROOM_HINDSIGHT_AUTOHEAL_WINDOW_S: "3600"');
+  });
+});
+
+describe("Dockerfile.hostd bakes the autoheal script (#2910)", () => {
+  it("COPYs docker/hindsight-autoheal.sh into the image and makes it executable", () => {
+    const df = readFileSync(
+      resolve(__dirname, "..", "..", "docker", "Dockerfile.hostd"),
+      "utf-8",
+    );
+    expect(df).toMatch(
+      /COPY docker\/hindsight-autoheal\.sh \/opt\/switchroom\/docker\/hindsight-autoheal\.sh/,
+    );
+    expect(df).toMatch(/chmod 0755 \/opt\/switchroom\/docker\/hindsight-autoheal\.sh/);
   });
 });

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -387,6 +387,51 @@ services:
     networks:
       - default
 
+  # hindsight-autoheal (#2910) — the host-side restart-on-unhealthy loop the
+  # standalone \`switchroom-hindsight\` container can't do for itself. Docker's
+  # \`--restart always\` acts on process EXIT only, never on health status, and
+  # the in-container maintenance loop has no docker binary/socket — so a wedged-
+  # but-not-exited hindsight API stayed \`unhealthy\` forever and the fleet went
+  # silently amnesiac. This tiny sidecar polls the target's health and issues
+  # \`docker restart\` with a sliding-window cap + exponential backoff (guarded
+  # against restart loops), logging every decision for \`switchroom doctor\`.
+  #
+  # Least-privilege: it reuses the SAME docker-socket-proxy above (which already
+  # allowlists GET /containers inspect + POST restart for hostd) over
+  # DOCKER_HOST — no new raw-socket mount, no widened endpoint surface. It runs
+  # on the hostd image purely because that image already carries the docker CLI
+  # and the baked script; it never touches hostd's own state (no volumes).
+  hindsight-autoheal:
+    image: ghcr.io/switchroom/switchroom-hostd:${imageTag}
+    container_name: switchroom-hindsight-autoheal
+    restart: always
+    depends_on:
+      - docker-socket-proxy
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    # Override hostd's node CMD: run the pure-shell poll loop instead. tini
+    # still reaps + forwards SIGTERM so \`docker stop\` is clean.
+    entrypoint: ["/usr/bin/tini", "--", "sh", "/opt/switchroom/docker/hindsight-autoheal.sh"]
+    environment:
+      # All docker access flows through the proxy — same as hostd. The CLI
+      # honors DOCKER_HOST, so \`docker inspect\`/\`docker restart\` hit the
+      # allowlisted TCP endpoint, never a raw socket in this container.
+      DOCKER_HOST: tcp://docker-socket-proxy:2375
+      # Target + guardrails (all have in-script defaults; pinned here so the
+      # operator can see and tune them without reading the script).
+      SWITCHROOM_HINDSIGHT_AUTOHEAL: "1"
+      SWITCHROOM_HINDSIGHT_AUTOHEAL_TARGET: switchroom-hindsight
+      SWITCHROOM_HINDSIGHT_AUTOHEAL_POLL_S: "30"
+      SWITCHROOM_HINDSIGHT_AUTOHEAL_MAX_RESTARTS: "3"
+      SWITCHROOM_HINDSIGHT_AUTOHEAL_WINDOW_S: "3600"
+      SWITCHROOM_HINDSIGHT_AUTOHEAL_BACKOFF_BASE_S: "30"
+      SWITCHROOM_HINDSIGHT_AUTOHEAL_COOLDOWN_S: "900"
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    networks:
+      - default
+
 networks:
   default:
     name: switchroom-hostd-net

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -878,10 +878,14 @@ export function startHindsight(
     // / `docker ps` so operators and the doctor probe can SEE the wedge.
     // NOTE: vanilla Docker does NOT auto-restart an unhealthy container —
     // `--restart always` acts on process EXIT only, never on health status.
-    // So this is visibility, not a self-heal; an unhealthy-but-not-exited
-    // API keeps running until something (operator / an autoheal sidecar)
-    // acts on the status. See PR follow-up for the restart-on-unhealthy
-    // mechanism. python3 is always present in the image; curl/wget are not.
+    // So this flag itself is VISIBILITY, not a self-heal: it marks the
+    // container `unhealthy` so operators, `switchroom doctor`, AND the
+    // host-side autoheal loop can SEE the wedge. The actual restart-on-
+    // unhealthy mechanism is the `switchroom-hindsight-autoheal` sidecar in
+    // the hostd compose (#2910, docker/hindsight-autoheal.sh): it polls this
+    // status through the docker-socket-proxy and issues `docker restart` with
+    // a sliding-window cap + backoff. python3 is always present in the image;
+    // curl/wget are not.
     "--health-cmd", litellm
       ? `python3 -c 'import urllib.request,sys; sys.exit(0 if urllib.request.urlopen("http://localhost:${apiPort}/health",timeout=4).getcode()==200 else 1)'`
       : HINDSIGHT_HEALTHCHECK_CMD,

--- a/tests/cli.doctor.memory-health.test.ts
+++ b/tests/cli.doctor.memory-health.test.ts
@@ -9,6 +9,7 @@ import {
   classifyHindsightHealthProbe,
   checkHindsightHealthEndpoint,
   classifyConsolidationBacklog,
+  classifyAutohealStatus,
   CONSOLIDATION_BACKLOG_WARN,
   CONSOLIDATION_BACKLOG_FAIL,
   type AdvertisedTool,
@@ -164,21 +165,93 @@ describe("classifyExtractionLogs", () => {
   });
 });
 
+describe("classifyAutohealStatus (#2910 host-side autoheal surface)", () => {
+  it("no restart events → ok", () => {
+    const r = classifyAutohealStatus("hindsight-autoheal event=started target=switchroom-hindsight");
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("no auto-restarts");
+  });
+
+  it("disabled → ok with disabled detail", () => {
+    const r = classifyAutohealStatus("hindsight-autoheal event=disabled target=switchroom-hindsight");
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("disabled");
+  });
+
+  it("restart(s) but no give-up → warn with the count", () => {
+    const logs = [
+      "hindsight-autoheal event=restart_issued attempt=1",
+      "hindsight-autoheal event=restart_ok attempt=1",
+      "hindsight-autoheal event=restart_issued attempt=2",
+    ].join("\n");
+    const r = classifyAutohealStatus(logs);
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("2 time(s)");
+  });
+
+  it("give-up event → fail (loop-guarded, not restart-looping)", () => {
+    const logs = [
+      "hindsight-autoheal event=restart_issued attempt=1",
+      "hindsight-autoheal event=restart_issued attempt=2",
+      "hindsight-autoheal event=restart_issued attempt=3",
+      "hindsight-autoheal event=gave_up restarts=3 window_s=3600",
+    ].join("\n");
+    const r = classifyAutohealStatus(logs);
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("GAVE UP after 3");
+    expect(r.detail).toContain("NOT restart-");
+  });
+});
+
 describe("checkHindsightContainerHealth (docker wrapper)", () => {
   it("silently skips when the container isn't a local docker container", () => {
     const exec = () => { throw new Error("No such container"); };
     expect(checkHindsightContainerHealth({ exec })).toEqual([]);
   });
 
-  it("classifies shm + logs when docker is available", () => {
+  it("classifies shm + logs + autoheal when docker is available", () => {
     const exec = (_cmd: string, args: string[]) => {
+      if (args.includes("inspect")) return "2147483648\n";
+      if (args.includes("switchroom-hindsight-autoheal")) return "hindsight-autoheal event=started target=switchroom-hindsight";
+      if (args.includes("logs")) return "Extract facts: 4 facts, 1 chunks from 1 contents in 12s";
+      return "";
+    };
+    const results = checkHindsightContainerHealth({ exec });
+    expect(results.map((r) => r.name)).toEqual([
+      "hindsight shm-size",
+      "hindsight extraction",
+      "hindsight autoheal",
+    ]);
+    expect(results.every((r) => r.status === "ok")).toBe(true);
+  });
+
+  it("skips the autoheal line when the sidecar container isn't present", () => {
+    const exec = (_cmd: string, args: string[]) => {
+      if (args.includes("switchroom-hindsight-autoheal")) throw new Error("No such container");
       if (args.includes("inspect")) return "2147483648\n";
       if (args.includes("logs")) return "Extract facts: 4 facts, 1 chunks from 1 contents in 12s";
       return "";
     };
     const results = checkHindsightContainerHealth({ exec });
     expect(results.map((r) => r.name)).toEqual(["hindsight shm-size", "hindsight extraction"]);
-    expect(results.every((r) => r.status === "ok")).toBe(true);
+  });
+
+  it("surfaces an autoheal give-up as a FAIL line", () => {
+    const exec = (_cmd: string, args: string[]) => {
+      if (args.includes("inspect")) return "2147483648\n";
+      if (args.includes("switchroom-hindsight-autoheal")) {
+        return [
+          "hindsight-autoheal event=restart_issued attempt=1",
+          "hindsight-autoheal event=restart_issued attempt=2",
+          "hindsight-autoheal event=restart_issued attempt=3",
+          "hindsight-autoheal event=gave_up restarts=3",
+        ].join("\n");
+      }
+      if (args.includes("logs")) return "Extract facts: 4 facts, 1 chunks from 1 contents in 12s";
+      return "";
+    };
+    const results = checkHindsightContainerHealth({ exec });
+    expect(results.find((r) => r.name === "hindsight autoheal")?.status).toBe("fail");
   });
 
   it("surfaces a broken backend (small shm + failing extraction) that MCP reachability would miss", () => {

--- a/tests/docker/hindsight-autoheal.test.ts
+++ b/tests/docker/hindsight-autoheal.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for `docker/hindsight-autoheal.sh` (#2910) — the host-side
+ * restart-on-unhealthy loop for the standalone `switchroom-hindsight`
+ * container. Docker's `--restart always` acts on process EXIT only, never on
+ * health status, and the in-container maintenance loop has no docker socket —
+ * so a wedged-but-not-exited API stayed `unhealthy` forever. This sidecar
+ * closes that gap; it must NOT be able to restart-loop a genuinely-broken
+ * hindsight (backoff + sliding-window cap + give-up).
+ *
+ * The pure decision core is sourced with SWITCHROOM_HINDSIGHT_AUTOHEAL_LIB_ONLY=1
+ * (loads the functions without entering the poll loop) and exercised for
+ * OUTCOMES: restart issued vs suppressed-when-healthy vs capped-after-N. The
+ * loop body itself isn't stood up (it needs a live docker daemon); its guards
+ * are pinned statically.
+ */
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const SCRIPT = resolve(__dirname, "..", "..", "docker", "hindsight-autoheal.sh");
+
+/** Source the script lib-only, run `expr`, return trimmed stdout. */
+function sh(expr: string): string {
+  const r = spawnSync(
+    "sh",
+    ["-c", `SWITCHROOM_HINDSIGHT_AUTOHEAL_LIB_ONLY=1 . "${SCRIPT}"; ${expr}`],
+    { encoding: "utf-8", timeout: 10_000 },
+  );
+  if (r.status !== 0) {
+    throw new Error(`sh exited ${r.status}: ${r.stderr}`);
+  }
+  return r.stdout.trim();
+}
+
+describe("hindsight-autoheal.sh — pure decision core", () => {
+  it("does NOT enter the poll loop when sourced lib-only (returns promptly)", () => {
+    // If autoheal_main ran, the 10s timeout would kill it (status !== 0).
+    const out = sh('echo loaded');
+    expect(out).toBe("loaded");
+  });
+
+  it("prune drops timestamps outside the window, keeps those inside", () => {
+    // now=5000, window=3600 → cutoff=1400. 100,200 drop; 1400,5000 keep.
+    expect(sh('autoheal_prune "100 200 1400 5000" 5000 3600')).toBe("1400 5000");
+  });
+
+  it("count returns the number of timestamps", () => {
+    expect(sh('autoheal_count "1 2 3 4"')).toBe("4");
+    expect(sh('autoheal_count ""')).toBe("0");
+  });
+
+  it("decide: a healthy target issues NO restart (verb=ok)", () => {
+    expect(sh('autoheal_decide healthy "" 5000 3600 3')).toBe("ok|");
+    // starting is also not `unhealthy` → ok
+    expect(sh('autoheal_decide starting "" 5000 3600 3')).toBe("ok|");
+    // a missing/unreadable container is treated as not-unhealthy (never fight a recreate)
+    expect(sh('autoheal_decide missing "" 5000 3600 3')).toBe("ok|");
+  });
+
+  it("decide: an unhealthy target UNDER the cap issues a restart (now appended)", () => {
+    expect(sh('autoheal_decide unhealthy "4990" 5000 3600 3')).toBe("restart|4990 5000");
+    expect(sh('autoheal_decide unhealthy "" 5000 3600 3')).toBe("restart|5000");
+  });
+
+  it("decide: an unhealthy target AT the cap is SUPPRESSED (verb=capped) — no restart loop", () => {
+    // 3 restarts already in-window, MAX=3 → capped, and the state is NOT grown.
+    expect(sh('autoheal_decide unhealthy "4990 4995 4998" 5000 3600 3')).toBe("capped|4990 4995 4998");
+  });
+
+  it("decide: stale in-window restarts age out, re-allowing a restart later", () => {
+    // 3 restarts at t=100/200/300, but now=5000 window=3600 → all pruned → restart allowed again.
+    expect(sh('autoheal_decide unhealthy "100 200 300" 5000 3600 3')).toBe("restart|5000");
+  });
+
+  it("backoff is exponential in the restart count and capped at 8x base", () => {
+    expect(sh('autoheal_backoff 30 0')).toBe("30");
+    expect(sh('autoheal_backoff 30 1')).toBe("60");
+    expect(sh('autoheal_backoff 30 2')).toBe("120");
+    expect(sh('autoheal_backoff 30 3')).toBe("240");
+    expect(sh('autoheal_backoff 30 9')).toBe("240"); // capped at 8*30
+  });
+});
+
+describe("hindsight-autoheal.sh — static guards", () => {
+  const raw = readFileSync(SCRIPT, "utf-8");
+
+  it("routes docker access via inspect + restart ONLY (least-privilege, no rm/kill)", () => {
+    expect(raw).toMatch(/docker inspect -f '\{\{\.State\.Health\.Status\}\}'/);
+    expect(raw).toMatch(/docker restart "\$TARGET"/);
+    expect(raw).not.toMatch(/docker\s+(rm|kill|stop)\b/);
+  });
+
+  it("emits stable structured decision lines doctor can grep", () => {
+    // The doctor-side prefix + k=v shape (produced by autoheal_log's printf).
+    expect(raw).toMatch(/printf 'hindsight-autoheal event=%s/);
+    // The two events doctor keys on are actually emitted.
+    expect(raw).toMatch(/autoheal_log restart_issued/);
+    expect(raw).toMatch(/autoheal_log gave_up/);
+  });
+
+  it("honors the master kill-switch and defaults ON", () => {
+    expect(raw).toMatch(/ENABLED="\$\{SWITCHROOM_HINDSIGHT_AUTOHEAL:-1\}"/);
+    expect(raw).toMatch(/if \[ "\$ENABLED" = "0" \]/);
+  });
+
+  it("caps restarts with a sliding window (the loop-guard requirement)", () => {
+    expect(raw).toMatch(/SWITCHROOM_HINDSIGHT_AUTOHEAL_MAX_RESTARTS:-3/);
+    expect(raw).toMatch(/SWITCHROOM_HINDSIGHT_AUTOHEAL_WINDOW_S:-3600/);
+    expect(raw).toMatch(/SWITCHROOM_HINDSIGHT_AUTOHEAL_COOLDOWN_S/);
+  });
+});


### PR DESCRIPTION
Closes #2910. Follow-up from #2903 (P3 Fix 5.1); #2907 corrected the false 'self-heal' claim, this ships the real mechanism.

## Problem
The standalone `switchroom-hindsight` container carries a docker healthcheck that marks it `unhealthy` when the API wedges — but **vanilla Docker never restarts on health status** (`--restart always` acts on process EXIT only), and the in-container `hindsight-maintenance.sh` has no docker binary/socket, so it can't restart itself. A wedged-but-not-exited API stayed `unhealthy` forever and the fleet went silently amnesiac.

## Design decision — chosen shape + why
**A tiny host-side autoheal sidecar in the hostd compose, reusing the existing docker-socket-proxy.** Investigated both sanctioned shapes:

- Hindsight in production is a **standalone `docker run`** container (`startHindsight()`), *not* a switchroom-fleet compose service — the `generateHindsightComposeSnippet` output is only a printed reference for `switchroom memory docker-compose`. So the autoheal must watch an out-of-project container by name.
- There is **no host-side cron/maintenance layer** that already polls docker health; the only host component with docker access is **hostd**, which since #1842 reaches the daemon through a hardened **`docker-socket-proxy`** that already allowlists `GET /containers` (inspect) + `POST restart` (`ALLOW_RESTARTS`).

So shape (a) — an autoheal sidecar — fits cleanly and **least-privilege**: it joins the hostd compose project and reuses that same proxy over `DOCKER_HOST`. **No new raw-socket mount, no widened proxy endpoint surface.** It runs on the hostd image purely because that image already carries the docker CLI and the baked script; it mounts no state volumes and never touches hostd's own state. Shape (b) was rejected — there's no existing host maintenance loop to extend, and adding one to the fleet compose would require standing up a *second* docker-socket-proxy.

## What's in the PR
- **`docker/hindsight-autoheal.sh`** — pure `/bin/sh` poll loop. On `unhealthy` it issues `docker restart`, **guarded against restart loops**: sliding-window cap (default **3 restarts / hour**) + **exponential backoff** (base 30s, capped 8x), then a loud `gave_up` structured log and a cooldown before it will try again. The decision core (`autoheal_prune` / `autoheal_decide` / `autoheal_backoff`) is extracted into pure, sourceable functions.
- **`switchroom-hindsight-autoheal` sidecar** in `renderHostdComposeFile` — proxy-reuse, `cap_drop: ALL`, `no-new-privileges`, no volumes, knobs pinned as env.
- **Doctor probe** — `classifyAutohealStatus()` wired into `checkHindsightContainerHealth`, so `switchroom doctor` reports "hindsight was auto-restarted N times" (warn) / "autoheal gave up" (fail) from the sidecar's logs; skipped silently when the sidecar isn't deployed.
- Corrected the `startHindsight` healthcheck comment to point at the shipped mechanism.

## Tests (all assert outcomes)
`vitest run tests/docker/hindsight-autoheal.test.ts tests/cli.doctor.memory-health.test.ts src/cli/hostd.test.ts` → **84 passed**. `npm run lint` → clean.
- Shell decision core sourced `LIB_ONLY=1`: restart issued under cap, **suppressed when healthy/missing**, **capped after N** (no state growth), aged-out re-allows, exponential+capped backoff.
- Static loop-guard pins (kill-switch, cap, window, inspect+restart only — no rm/kill).
- hostd compose service shape: proxy reuse (still exactly ONE raw-socket bind in the file), hardening, baked-script path + knobs; Dockerfile bake.
- Doctor classifier: ok / disabled / warn(N restarts) / fail(gave-up), plus the docker-wrapper surfacing + skip-when-absent.

## Operator follow-up
`switchroom hostd install` must be re-run to regenerate the hostd compose and `docker compose up -d` the new sidecar. No agent-fleet `apply` needed; the standalone hindsight container is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)