### PR TITLE
feat(telegram-plugin): deterministic outbound send gate with token buckets (flag-off) — #3084 PR 1/3

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -189,6 +189,7 @@ import {
   isPhotoDimensionRejectError,
   isFloodWaitActiveError,
 } from '../retry-api-call.js'
+import { createSendGate, sendGateEnabledFromEnv } from '../send-gate.js'
 import { classifyPhotoFile, rerouteResultSuffix } from '../photo-precheck.js'
 import { installTgPostLogger, withTgPostTags } from '../shared/bot-runtime.js'
 import {
@@ -5331,7 +5332,7 @@ const PHOTO_EXTS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp'])
 // Declared ABOVE the typing indicator because the typing sends now route
 // through the same policy (#3084) — see nonEssentialApiCall below.
 const FLOOD_STATE_PATH = floodStatePath(STATE_DIR)
-const robustApiCall = createRetryApiCall({
+const rawRobustApiCall = createRetryApiCall({
   log: (line) => process.stderr.write(line),
   onFloodWait: makeFloodWaitRecorder(FLOOD_STATE_PATH),
   // #3094: while a LONG per-bot ban is open, don't issue the call at all.
@@ -5341,6 +5342,20 @@ const robustApiCall = createRetryApiCall({
   // fires thousands of requests into the open window and extends the ban.
   floodWaitRemainingMs: makeFloodWaitProbe(FLOOD_STATE_PATH),
 })
+
+// #3084 PR 1/3 — deterministic outbound send gate (token buckets + per-message
+// edit floor + no-op-edit skip). Wrapped HERE at the robustApiCall layer so
+// every Bot API call routed through the standard retry policy also transits
+// one scheduler (no call site can bypass it). Feature-flagged, default OFF:
+// when SWITCHROOM_TELEGRAM_SEND_GATE !== '1' the gate is a pure passthrough
+// and the retry policy behaves exactly as before. Composes with #3094's
+// pre-call flood gate and #3097's non-essential drop policy — those decide
+// whether a call happens at all; this paces the calls that do.
+const sendGate = createSendGate({ enabled: sendGateEnabledFromEnv() })
+const robustApiCall = <T>(
+  fn: () => Promise<T>,
+  opts?: Parameters<typeof rawRobustApiCall<T>>[1],
+): Promise<T> => sendGate.gate(() => rawRobustApiCall(fn, opts), opts)
 
 // Fire-and-forget wrapper for outbound surfaces that previously had
 // `.catch(() => {})` directly on `bot.api.*` calls. Resolves to undefined

--- a/telegram-plugin/retry-api-call.ts
+++ b/telegram-plugin/retry-api-call.ts
@@ -44,6 +44,22 @@ export interface RetryCallOpts {
    * call sites to self-document. Future: surface in retry logs / metrics.
    */
   verb?: string
+  /**
+   * Chat type of the destination (private / group / supergroup / channel).
+   * Consumed by the outbound send gate (#3084, send-gate.ts) to key the
+   * per-group bucket. Optional and additive — the retry policy ignores it.
+   */
+  chatType?: 'private' | 'group' | 'supergroup' | 'channel'
+  /**
+   * For edit calls: the target message id. Enables the send gate's
+   * per-message edit floor + last-write-wins coalescing. Retry policy ignores.
+   */
+  messageId?: number
+  /**
+   * For edit calls: the rendered payload the send gate hashes to skip no-op
+   * edits (identical → dropped) and to coalesce. Retry policy ignores it.
+   */
+  editPayload?: unknown
 }
 
 export interface RetryObserver {

--- a/telegram-plugin/send-gate.test.ts
+++ b/telegram-plugin/send-gate.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from 'vitest'
+import { createSendGate, sendGateEnabledFromEnv, type Clock } from './send-gate.js'
+
+/**
+ * Deterministic fake clock. `sleep()` registers a wake at `now + ms`;
+ * `advance(ms)` walks time forward, resolving due timers in (time, insertion)
+ * order and flushing microtasks between each so continuations can register the
+ * next sleep before we advance further. No real timers, no `Date.now()` — the
+ * scheduler is fully driven by the test.
+ */
+class FakeClock implements Clock {
+  private cur = 0
+  private seq = 0
+  private timers: { at: number; id: number; resolve: () => void }[] = []
+
+  now(): number {
+    return this.cur
+  }
+
+  sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.timers.push({ at: this.cur + ms, id: this.seq++, resolve })
+    })
+  }
+
+  async advance(ms: number): Promise<void> {
+    const target = this.cur + ms
+    for (;;) {
+      const due = this.timers
+        .filter((t) => t.at <= target)
+        .sort((a, b) => a.at - b.at || a.id - b.id)
+      if (due.length === 0) break
+      const t = due[0]
+      this.timers = this.timers.filter((x) => x !== t)
+      this.cur = t.at
+      t.resolve()
+      await flush()
+    }
+    this.cur = target
+  }
+}
+
+/** Flush all pending microtasks (real macrotask hop; no fake timers involved). */
+function flush(): Promise<void> {
+  return new Promise<void>((r) => setImmediate(r))
+}
+
+interface Rec {
+  label: string
+  at: number
+}
+
+function recorder(clock: FakeClock) {
+  const calls: Rec[] = []
+  const fn = (label: string) => async () => {
+    calls.push({ label, at: clock.now() })
+    return label
+  }
+  return { calls, fn }
+}
+
+describe('send-gate: feature flag', () => {
+  it('passes straight through and never delays when disabled', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({ enabled: false, clock, globalPerSec: 1 })
+
+    // Fire far more than any bucket would allow; all must run immediately.
+    await Promise.all([gate.gate(fn('a')), gate.gate(fn('b')), gate.gate(fn('c'))])
+
+    expect(calls.map((c) => c.label).sort()).toEqual(['a', 'b', 'c'])
+    expect(calls.every((c) => c.at === 0)).toBe(true)
+    // No counters move when the gate is off.
+    expect(gate.stats().global.sent).toBe(0)
+    expect(gate.stats().enabled).toBe(false)
+  })
+
+  it('bypasses the edit floor entirely when disabled', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({ enabled: false, clock })
+
+    await gate.gate(fn('v1'), { messageId: 7, editPayload: 'v1' })
+    await gate.gate(fn('v2'), { messageId: 7, editPayload: 'v2' })
+
+    // Both edits fire at t=0 — no coalescing, no floor.
+    expect(calls.map((c) => c.label)).toEqual(['v1', 'v2'])
+  })
+
+  it('sendGateEnabledFromEnv follows the SWITCHROOM_*=== "1" convention', () => {
+    expect(sendGateEnabledFromEnv({} as NodeJS.ProcessEnv)).toBe(false)
+    expect(
+      sendGateEnabledFromEnv({ SWITCHROOM_TELEGRAM_SEND_GATE: '0' } as unknown as NodeJS.ProcessEnv),
+    ).toBe(false)
+    expect(
+      sendGateEnabledFromEnv({ SWITCHROOM_TELEGRAM_SEND_GATE: '1' } as unknown as NodeJS.ProcessEnv),
+    ).toBe(true)
+  })
+})
+
+describe('send-gate: global bucket', () => {
+  it('admits up to capacity immediately, then paces the rest by refill', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    // 2/sec → capacity 2, one token every 500ms.
+    const gate = createSendGate({ enabled: true, clock, globalPerSec: 2 })
+
+    const p1 = gate.gate(fn('a'))
+    const p2 = gate.gate(fn('b'))
+    const p3 = gate.gate(fn('c'))
+    await flush()
+
+    // First two consume the burst immediately; third is queued.
+    expect(calls.map((c) => c.label)).toEqual(['a', 'b'])
+    expect(gate.stats().global.queued).toBe(1)
+
+    await clock.advance(500)
+    await Promise.all([p1, p2, p3])
+
+    expect(calls.map((c) => c.label)).toEqual(['a', 'b', 'c'])
+    expect(calls.find((c) => c.label === 'c')?.at).toBe(500)
+    expect(gate.stats().global.sent).toBe(3)
+  })
+})
+
+describe('send-gate: per-chat bucket', () => {
+  it('allows a burst of 3 per chat then paces at 1/sec; other chats are independent', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      globalPerSec: 1000, // global not the limiter here
+      perChatPerSec: 1,
+      perChatBurst: 3,
+    })
+
+    const chatA = { chat_id: 'A' }
+    const chatB = { chat_id: 'B' }
+
+    const ps = [
+      gate.gate(fn('a1'), chatA),
+      gate.gate(fn('a2'), chatA),
+      gate.gate(fn('a3'), chatA),
+      gate.gate(fn('a4'), chatA), // 4th on A must wait ~1s
+      gate.gate(fn('b1'), chatB), // different chat → immediate
+    ]
+    await flush()
+
+    const now0 = calls.filter((c) => c.at === 0).map((c) => c.label).sort()
+    expect(now0).toEqual(['a1', 'a2', 'a3', 'b1'])
+    expect(calls.some((c) => c.label === 'a4')).toBe(false)
+
+    await clock.advance(1000)
+    await Promise.all(ps)
+
+    expect(calls.find((c) => c.label === 'a4')?.at).toBe(1000)
+  })
+})
+
+describe('send-gate: per-group bucket', () => {
+  it('keys a per-group ceiling on chat type and paces group traffic by the minute', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      globalPerSec: 1000,
+      perChatPerSec: 1000,
+      perChatBurst: 1000, // neither global nor per-chat is the limiter
+      perGroupPerMin: 2, // 2/min → one token every 30s
+    })
+
+    const group = { chat_id: 'G', chatType: 'supergroup' as const }
+
+    const ps = [
+      gate.gate(fn('g1'), group),
+      gate.gate(fn('g2'), group),
+      gate.gate(fn('g3'), group), // 3rd waits 30s
+    ]
+    await flush()
+
+    expect(calls.map((c) => c.label).sort()).toEqual(['g1', 'g2'])
+
+    await clock.advance(30_000)
+    await Promise.all(ps)
+
+    expect(calls.find((c) => c.label === 'g3')?.at).toBe(30_000)
+  })
+
+  it('does NOT apply the per-group bucket to private chats', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      globalPerSec: 1000,
+      perChatPerSec: 1000,
+      perChatBurst: 1000,
+      perGroupPerMin: 1, // would block the 2nd if it applied
+    })
+
+    const dm = { chat_id: 'P', chatType: 'private' as const }
+    await Promise.all([gate.gate(fn('p1'), dm), gate.gate(fn('p2'), dm)])
+
+    // Both private-chat sends land at t=0 — the group bucket never engages.
+    expect(calls.map((c) => c.at)).toEqual([0, 0])
+  })
+})
+
+describe('send-gate: same-message edit floor + coalescing', () => {
+  it('coalesces edits within the floor and sends ONLY the last payload', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({ enabled: true, clock, editFloorMs: 1500 })
+    const msg = 42
+
+    // First edit fires immediately (no prior edit).
+    await gate.gate(fn('v1'), { messageId: msg, editPayload: 'v1' })
+    expect(calls.map((c) => c.label)).toEqual(['v1'])
+
+    // Two more edits arrive within the 1.5s floor → the second replaces the
+    // first pending payload (last-write-wins), never queues behind it.
+    const p2 = gate.gate(fn('v2'), { messageId: msg, editPayload: 'v2' })
+    const p3 = gate.gate(fn('v3'), { messageId: msg, editPayload: 'v3' })
+    await flush()
+
+    // Nothing new has hit the API yet — still inside the floor.
+    expect(calls.map((c) => c.label)).toEqual(['v1'])
+    expect(gate.stats().global.coalesced).toBe(1)
+
+    await clock.advance(1500)
+    await Promise.all([p2, p3])
+
+    // Exactly ONE additional send, carrying the LAST payload (v3); v2 dropped.
+    expect(calls.map((c) => c.label)).toEqual(['v1', 'v3'])
+    expect(calls.find((c) => c.label === 'v3')?.at).toBe(1500)
+    expect(gate.stats().global.sent).toBe(2)
+  })
+
+  it('spaces sequential distinct edits at least the floor apart', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({ enabled: true, clock, editFloorMs: 1500 })
+    const msg = 5
+
+    await gate.gate(fn('a'), { messageId: msg, editPayload: 'a' })
+    const p = gate.gate(fn('b'), { messageId: msg, editPayload: 'b' })
+    await flush()
+    expect(calls.map((c) => c.label)).toEqual(['a']) // b waits for the floor
+
+    await clock.advance(1500)
+    await p
+    expect(calls.find((c) => c.label === 'b')?.at).toBe(1500)
+  })
+})
+
+describe('send-gate: no-op edit skip', () => {
+  it('drops an identical repeat payload without calling the API', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({ enabled: true, clock, editFloorMs: 1500 })
+    const msg = 9
+
+    await gate.gate(fn('x1'), { messageId: msg, editPayload: { text: 'same' } })
+    await clock.advance(1500) // clear the floor
+
+    // Identical rendered payload → dropped before the API.
+    const r = await gate.gate(fn('x2'), { messageId: msg, editPayload: { text: 'same' } })
+    expect(r).toBeUndefined()
+    expect(calls.map((c) => c.label)).toEqual(['x1'])
+    expect(gate.stats().global.dropped).toBe(1)
+    expect(gate.stats().global.sent).toBe(1)
+  })
+
+  it('drops a repeat of the on-screen payload even while another edit is queued', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({ enabled: true, clock, editFloorMs: 1500 })
+    const msg = 11
+
+    await gate.gate(fn('A'), { messageId: msg, editPayload: 'A' }) // sends A (on screen)
+    const p2 = gate.gate(fn('B'), { messageId: msg, editPayload: 'B' }) // queued within floor
+    // A repeat of the on-screen payload (A) is a no-op → dropped immediately,
+    // and must NOT clobber the genuinely-different queued edit (B).
+    const p3 = await gate.gate(fn('A2'), { messageId: msg, editPayload: 'A' })
+    expect(p3).toBeUndefined()
+
+    await clock.advance(1500)
+    await p2
+
+    // A ran, the no-op repeat dropped, B still sends after the floor.
+    expect(calls.map((c) => c.label)).toEqual(['A', 'B'])
+    expect(gate.stats().global.sent).toBe(2)
+    expect(gate.stats().global.dropped).toBe(1)
+  })
+})
+
+describe('send-gate: stats getter', () => {
+  it('exposes counters and live bucket fill', async () => {
+    const clock = new FakeClock()
+    const { fn } = recorder(clock)
+    const gate = createSendGate({ enabled: true, clock, globalPerSec: 25 })
+
+    await gate.gate(fn('a'), { chat_id: 'Z' })
+    const s = gate.stats()
+    expect(s.enabled).toBe(true)
+    expect(s.global.sent).toBe(1)
+    // One token consumed from a 25-capacity global bucket.
+    expect(s.fill.global).toBeCloseTo(24, 5)
+    expect(s.fill.perChat['Z']).toBeCloseTo(2, 5) // burst 3, one consumed
+  })
+})

--- a/telegram-plugin/send-gate.test.ts
+++ b/telegram-plugin/send-gate.test.ts
@@ -274,7 +274,7 @@ describe('send-gate: no-op edit skip', () => {
     expect(gate.stats().global.sent).toBe(1)
   })
 
-  it('drops a repeat of the on-screen payload even while another edit is queued', async () => {
+  it('last write reverting to the on-screen payload wins over a queued distinct edit (N1)', async () => {
     const clock = new FakeClock()
     const { calls, fn } = recorder(clock)
     const gate = createSendGate({ enabled: true, clock, editFloorMs: 1500 })
@@ -282,18 +282,39 @@ describe('send-gate: no-op edit skip', () => {
 
     await gate.gate(fn('A'), { messageId: msg, editPayload: 'A' }) // sends A (on screen)
     const p2 = gate.gate(fn('B'), { messageId: msg, editPayload: 'B' }) // queued within floor
-    // A repeat of the on-screen payload (A) is a no-op → dropped immediately,
-    // and must NOT clobber the genuinely-different queued edit (B).
-    const p3 = await gate.gate(fn('A2'), { messageId: msg, editPayload: 'A' })
-    expect(p3).toBeUndefined()
+    // The genuinely-LAST write reverts to the on-screen payload (A). Under
+    // last-write-wins it must REPLACE the queued distinct edit (B), not be
+    // dropped as a no-op while B still renders. The driver's own no-op re-check
+    // then drops the coalesced revert, so nothing needless hits the API and the
+    // final screen stays A — B never renders.
+    const p3 = gate.gate(fn('A2'), { messageId: msg, editPayload: 'A' })
 
     await clock.advance(1500)
-    await p2
+    await Promise.all([p2, p3])
+    expect(await p2).toBeUndefined()
+    expect(await p3).toBeUndefined()
 
-    // A ran, the no-op repeat dropped, B still sends after the floor.
-    expect(calls.map((c) => c.label)).toEqual(['A', 'B'])
-    expect(gate.stats().global.sent).toBe(2)
+    // Only A ever hit the API; B was superseded by the A-revert and dropped.
+    expect(calls.map((c) => c.label)).toEqual(['A'])
+    expect(gate.stats().global.sent).toBe(1)
     expect(gate.stats().global.dropped).toBe(1)
+    expect(gate.stats().global.coalesced).toBe(1)
+  })
+
+  it('a plain repeat with NO queued edit is dropped immediately as a no-op', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({ enabled: true, clock, editFloorMs: 1500 })
+    const msg = 12
+
+    await gate.gate(fn('A'), { messageId: msg, editPayload: 'A' })
+    await clock.advance(1500) // floor cleared, nothing queued
+
+    const r = await gate.gate(fn('A2'), { messageId: msg, editPayload: 'A' })
+    expect(r).toBeUndefined()
+    expect(calls.map((c) => c.label)).toEqual(['A'])
+    expect(gate.stats().global.dropped).toBe(1)
+    expect(gate.stats().global.sent).toBe(1)
   })
 })
 
@@ -374,6 +395,26 @@ describe('send-gate: error / rejection path (H1, M1)', () => {
   })
 })
 
+describe('send-gate: non-edit send stats (N4)', () => {
+  it('does NOT count a throwing non-edit send as sent', async () => {
+    const clock = new FakeClock()
+    const gate = createSendGate({ enabled: true, clock })
+
+    await expect(
+      gate.gate(async () => {
+        throw new Error('send failed')
+      }),
+    ).rejects.toThrow('send failed')
+
+    // The send threw → it must not pollute the `sent` counter.
+    expect(gate.stats().global.sent).toBe(0)
+
+    // A subsequent SUCCESSFUL send is counted normally.
+    await gate.gate(async () => 'ok')
+    expect(gate.stats().global.sent).toBe(1)
+  })
+})
+
 describe('send-gate: per-message serialization (M3, M4)', () => {
   it('serializes two same-tick edits: one now, one after the floor (M3)', async () => {
     const clock = new FakeClock()
@@ -436,12 +477,13 @@ describe('send-gate: bucket burst math (M2)', () => {
   it('bounds burst to capacity and holds sustained rate at the budget over windows', async () => {
     const clock = new FakeClock()
     const { calls, fn } = recorder(clock)
-    // 25/sec sustained, small burst 5 (headroom under Telegram's ~30/s).
+    // 25/sec sustained, small burst 4 (real headroom under Telegram's ~30/s:
+    // worst-case window = 4 + 25 = 29 < 30).
     const gate = createSendGate({
       enabled: true,
       clock,
       globalPerSec: 25,
-      globalBurst: 5,
+      globalBurst: 4,
       perChatPerSec: 1000,
       perChatBurst: 1000,
     })
@@ -451,7 +493,7 @@ describe('send-gate: bucket burst math (M2)', () => {
     await flush()
 
     // Burst: only `globalBurst` admitted at t=0 — NOT a full window's budget.
-    expect(calls.filter((c) => c.at === 0).length).toBe(5)
+    expect(calls.filter((c) => c.at === 0).length).toBe(4)
 
     await clock.advance(6000)
     await Promise.all(ps)
@@ -464,9 +506,11 @@ describe('send-gate: bucket burst math (M2)', () => {
       maxAny = Math.max(maxAny, inWin)
       if (t >= 1000) maxSustained = Math.max(maxSustained, inWin) // past the burst
     }
-    // Any 1s window ≤ budget + burst (never ~2x the budget); sustained windows
-    // hold to the budget (+1 for a fractional token straddling the edge).
-    expect(maxAny).toBeLessThanOrEqual(25 + 5)
+    // Any 1s window ≤ budget + burst = 29 (never ~2x the budget, and strictly
+    // UNDER Telegram's ~30/s ceiling); sustained windows hold to the budget
+    // (+1 for a fractional token straddling the edge).
+    expect(maxAny).toBeLessThanOrEqual(25 + 4)
+    expect(maxAny).toBeLessThan(30)
     expect(maxSustained).toBeLessThanOrEqual(26)
   })
 
@@ -559,6 +603,18 @@ describe('send-gate: perMessage eviction (H2)', () => {
       await gate.gate(fn('m' + i), { messageId: i, editPayload: 'p' + i })
       await clock.advance(2) // clear the tiny floor so each state is idle/evictable
     }
+    expect(gate.stats().messageStates).toBeLessThanOrEqual(3)
+  })
+
+  it('opening per-message flood windows honours the LRU cap (N2)', async () => {
+    const clock = new FakeClock()
+    const gate = createSendGate({ enabled: true, clock, maxMessageStates: 3 })
+
+    // Each openFloodWindow for a distinct msg-edit scope creates a per-message
+    // state; it must go through the same eviction accounting so the map never
+    // grows past the cap. Windows are in the past so the states stay evictable.
+    for (let i = 0; i < 10; i++) gate.openFloodWindow('msg-edit:' + i, -1)
+
     expect(gate.stats().messageStates).toBeLessThanOrEqual(3)
   })
 })

--- a/telegram-plugin/send-gate.test.ts
+++ b/telegram-plugin/send-gate.test.ts
@@ -102,8 +102,8 @@ describe('send-gate: global bucket', () => {
   it('admits up to capacity immediately, then paces the rest by refill', async () => {
     const clock = new FakeClock()
     const { calls, fn } = recorder(clock)
-    // 2/sec → capacity 2, one token every 500ms.
-    const gate = createSendGate({ enabled: true, clock, globalPerSec: 2 })
+    // 2/sec → burst 2, one token every 500ms.
+    const gate = createSendGate({ enabled: true, clock, globalPerSec: 2, globalBurst: 2 })
 
     const p1 = gate.gate(fn('a'))
     const p2 = gate.gate(fn('b'))
@@ -169,6 +169,7 @@ describe('send-gate: per-group bucket', () => {
       perChatPerSec: 1000,
       perChatBurst: 1000, // neither global nor per-chat is the limiter
       perGroupPerMin: 2, // 2/min → one token every 30s
+      perGroupBurst: 2,
     })
 
     const group = { chat_id: 'G', chatType: 'supergroup' as const }
@@ -300,7 +301,7 @@ describe('send-gate: stats getter', () => {
   it('exposes counters and live bucket fill', async () => {
     const clock = new FakeClock()
     const { fn } = recorder(clock)
-    const gate = createSendGate({ enabled: true, clock, globalPerSec: 25 })
+    const gate = createSendGate({ enabled: true, clock, globalPerSec: 25, globalBurst: 25 })
 
     await gate.gate(fn('a'), { chat_id: 'Z' })
     const s = gate.stats()
@@ -309,5 +310,333 @@ describe('send-gate: stats getter', () => {
     // One token consumed from a 25-capacity global bucket.
     expect(s.fill.global).toBeCloseTo(24, 5)
     expect(s.fill.perChat['Z']).toBeCloseTo(2, 5) // burst 3, one consumed
+  })
+})
+
+describe('send-gate: error / rejection path (H1, M1)', () => {
+  it('rejects the failing edit and still sends a newer edit that arrived mid-flight (H1)', async () => {
+    const clock = new FakeClock()
+    const gate = createSendGate({ enabled: true, clock, editFloorMs: 1500 })
+    const msg = 100
+
+    // First edit sends immediately (no prior edit) then suspends on the network
+    // await — a controllable deferred stands in for the in-flight send.
+    let rejectV1!: (e: unknown) => void
+    const v1Fn = () => new Promise<string>((_res, rej) => (rejectV1 = rej))
+    const p1 = gate.gate(v1Fn, { messageId: msg, editPayload: 'v1' })
+    await flush() // v1 admitted, fn() called, now suspended in-flight
+
+    // A DISTINCT edit arrives while v1 is in-flight → must coalesce, not fire.
+    const v2Calls: number[] = []
+    const v2Fn = async () => {
+      v2Calls.push(clock.now())
+      return 'v2-result'
+    }
+    const p2 = gate.gate(v2Fn, { messageId: msg, editPayload: 'v2' })
+    await flush()
+    expect(v2Calls.length).toBe(0) // v2 has NOT fired in parallel
+
+    // v1's send rejects — its OWN promise must reject (never orphaned onto v2).
+    const err = new Error('boom')
+    rejectV1(err)
+    await expect(p1).rejects.toBe(err)
+
+    // After the floor, v2 fires exactly once and resolves with v2's own result.
+    await clock.advance(1500)
+    await expect(p2).resolves.toBe('v2-result')
+    expect(v2Calls.length).toBe(1)
+    expect(gate.stats().global.sent).toBe(1) // only v2 counted as sent (v1 failed)
+  })
+
+  it('retries an identical payload after a FAILED edit (M1)', async () => {
+    const clock = new FakeClock()
+    const gate = createSendGate({ enabled: true, clock, editFloorMs: 1500 })
+    const msg = 200
+
+    const fail = async () => {
+      throw new Error('nope')
+    }
+    await expect(gate.gate(fail, { messageId: msg, editPayload: 'X' })).rejects.toThrow('nope')
+
+    await clock.advance(1500) // clear the floor
+
+    // Identical payload retry MUST hit the API — a failed send never records
+    // lastHash, so it is not dropped as a phantom no-op.
+    const sentAt: number[] = []
+    const ok = async () => {
+      sentAt.push(clock.now())
+      return true
+    }
+    const r = await gate.gate(ok, { messageId: msg, editPayload: 'X' })
+    expect(r).toBe(true)
+    expect(sentAt.length).toBe(1)
+    expect(gate.stats().global.dropped).toBe(0)
+  })
+})
+
+describe('send-gate: per-message serialization (M3, M4)', () => {
+  it('serializes two same-tick edits: one now, one after the floor (M3)', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({ enabled: true, clock, editFloorMs: 1500 })
+    const msg = 300
+
+    const pa = gate.gate(fn('a'), { messageId: msg, editPayload: 'a' })
+    const pb = gate.gate(fn('b'), { messageId: msg, editPayload: 'b' }) // same tick
+    await flush()
+
+    // Only ONE edit fired inside the floor — no same-tick double send.
+    expect(calls.map((c) => c.label)).toEqual(['a'])
+
+    await clock.advance(1500)
+    await Promise.all([pa, pb])
+    expect(calls.map((c) => c.label)).toEqual(['a', 'b'])
+    expect(calls.find((c) => c.label === 'b')?.at).toBe(1500)
+  })
+
+  it('coalesces edits behind an in-flight send sleeping on retry_after (M4)', async () => {
+    const clock = new FakeClock()
+    const gate = createSendGate({ enabled: true, clock, editFloorMs: 1500 })
+    const msg = 400
+
+    // The in-flight send simulates robustApiCall sleeping on a 429 retry_after
+    // INSIDE the wrapped fn.
+    const started: number[] = []
+    const v1 = async () => {
+      started.push(clock.now())
+      await clock.sleep(5000)
+      return 'v1'
+    }
+    const p1 = gate.gate(v1, { messageId: msg, editPayload: 'v1' })
+    await flush()
+    expect(started.length).toBe(1) // v1 in-flight, sleeping on retry_after
+
+    // Two edits arrive while v1 sleeps → must coalesce into ONE follow-up.
+    const seen: string[] = []
+    const mk = (label: string) => async () => {
+      seen.push(label)
+      return label
+    }
+    const p2 = gate.gate(mk('v2'), { messageId: msg, editPayload: 'v2' })
+    const p3 = gate.gate(mk('v3'), { messageId: msg, editPayload: 'v3' })
+    await flush()
+    expect(seen).toEqual([]) // nothing fired in parallel with the in-flight send
+
+    await clock.advance(5000) // v1's retry_after elapses → v1 resolves
+    await p1
+    await Promise.all([p2, p3])
+
+    // Exactly ONE follow-up send carrying the LAST payload (v3); v2 coalesced.
+    expect(seen).toEqual(['v3'])
+    expect(gate.stats().global.coalesced).toBe(1)
+  })
+})
+
+describe('send-gate: bucket burst math (M2)', () => {
+  it('bounds burst to capacity and holds sustained rate at the budget over windows', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    // 25/sec sustained, small burst 5 (headroom under Telegram's ~30/s).
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      globalPerSec: 25,
+      globalBurst: 5,
+      perChatPerSec: 1000,
+      perChatBurst: 1000,
+    })
+
+    const ps: Promise<unknown>[] = []
+    for (let i = 0; i < 120; i++) ps.push(gate.gate(fn(String(i))))
+    await flush()
+
+    // Burst: only `globalBurst` admitted at t=0 — NOT a full window's budget.
+    expect(calls.filter((c) => c.at === 0).length).toBe(5)
+
+    await clock.advance(6000)
+    await Promise.all(ps)
+
+    const times = calls.map((c) => c.at).sort((a, b) => a - b)
+    let maxAny = 0
+    let maxSustained = 0
+    for (const t of times) {
+      const inWin = times.filter((x) => x >= t && x < t + 1000).length
+      maxAny = Math.max(maxAny, inWin)
+      if (t >= 1000) maxSustained = Math.max(maxSustained, inWin) // past the burst
+    }
+    // Any 1s window ≤ budget + burst (never ~2x the budget); sustained windows
+    // hold to the budget (+1 for a fractional token straddling the edge).
+    expect(maxAny).toBeLessThanOrEqual(25 + 5)
+    expect(maxSustained).toBeLessThanOrEqual(26)
+  })
+
+  it('holds a per-group ceiling near budget/min, not ~2x (M2)', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      globalPerSec: 1000,
+      globalBurst: 1000,
+      perChatPerSec: 1000,
+      perChatBurst: 1000,
+      perGroupPerMin: 18,
+      perGroupBurst: 2,
+    })
+    const g = { chat_id: 'G', chatType: 'supergroup' as const }
+
+    const ps: Promise<unknown>[] = []
+    for (let i = 0; i < 50; i++) ps.push(gate.gate(fn(String(i)), g))
+    await flush()
+
+    expect(calls.filter((c) => c.at === 0).length).toBe(2) // burst 2, not 18
+
+    await clock.advance(200_000)
+    await Promise.all(ps)
+
+    const times = calls.map((c) => c.at).sort((a, b) => a - b)
+    let maxMinute = 0
+    for (const t of times) {
+      if (t < 60_000) continue // skip the burst-inclusive first minute
+      const inWin = times.filter((x) => x >= t && x < t + 60_000).length
+      maxMinute = Math.max(maxMinute, inWin)
+    }
+    expect(maxMinute).toBeLessThanOrEqual(19) // ~18/min sustained, never ~35
+  })
+})
+
+describe('send-gate: editPayload undefined (L2)', () => {
+  it('does not throw when editPayload is undefined; treats a repeat as a no-op', async () => {
+    const clock = new FakeClock()
+    const gate = createSendGate({ enabled: true, clock, editFloorMs: 1500 })
+    const sent: number[] = []
+    const fn = async () => {
+      sent.push(1)
+      return 'ok'
+    }
+
+    const r = await gate.gate(fn, { messageId: 7, editPayload: undefined })
+    expect(r).toBe('ok')
+    expect(sent.length).toBe(1)
+
+    await clock.advance(1500)
+    const r2 = await gate.gate(fn, { messageId: 7, editPayload: undefined })
+    expect(r2).toBeUndefined() // identical (undefined) payload → no-op skip
+    expect(gate.stats().global.dropped).toBe(1)
+  })
+})
+
+describe('send-gate: perMessage eviction (H2)', () => {
+  it('evicts idle message states after the TTL', async () => {
+    const clock = new FakeClock()
+    const { fn } = recorder(clock)
+    const gate = createSendGate({ enabled: true, clock, editFloorMs: 1500, messageStateTtlMs: 10_000 })
+
+    await gate.gate(fn('a'), { messageId: 1, editPayload: 'a' })
+    expect(gate.stats().messageStates).toBe(1)
+
+    // Past the TTL, a touch on a DIFFERENT message triggers the sweep.
+    await clock.advance(20_000)
+    await gate.gate(fn('b'), { messageId: 2, editPayload: 'b' })
+
+    // msg 1 is idle + older than the TTL → swept; only msg 2 remains.
+    expect(gate.stats().messageStates).toBe(1)
+  })
+
+  it('enforces a hard LRU cap on live message states', async () => {
+    const clock = new FakeClock()
+    const { fn } = recorder(clock)
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      editFloorMs: 1,
+      globalPerSec: 1000, // global bucket not the limiter here
+      globalBurst: 1000,
+      maxMessageStates: 3,
+    })
+
+    for (let i = 0; i < 10; i++) {
+      await gate.gate(fn('m' + i), { messageId: i, editPayload: 'p' + i })
+      await clock.advance(2) // clear the tiny floor so each state is idle/evictable
+    }
+    expect(gate.stats().messageStates).toBeLessThanOrEqual(3)
+  })
+})
+
+describe('send-gate: flood windows + boot ramp (L3 / §7 hook)', () => {
+  it('an open flood window blocks admission until untilTs (openFloodWindow)', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({ enabled: true, clock })
+
+    gate.openFloodWindow('global', 5000)
+
+    const p = gate.gate(fn('a'))
+    await flush()
+    expect(calls.length).toBe(0) // suppressed despite a full token bucket
+
+    await clock.advance(5000)
+    await p
+    expect(calls.map((c) => c.at)).toEqual([5000]) // fires exactly when the window clears
+  })
+
+  it('re-opens flood windows passed at construction (initialWindows)', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      initialWindows: [{ scopeKey: 'chat:C', untilTs: 3000 }],
+    })
+
+    const p = gate.gate(fn('a'), { chat_id: 'C' })
+    await flush()
+    expect(calls.length).toBe(0) // chat:C suppressed
+
+    // A different chat is unaffected by C's window.
+    await gate.gate(fn('other'), { chat_id: 'D' })
+    expect(calls.map((c) => c.label)).toEqual(['other'])
+
+    await clock.advance(3000)
+    await p
+    expect(calls.find((c) => c.label === 'a')?.at).toBe(3000)
+  })
+
+  it('starts the global bucket at a fraction of capacity during the boot ramp', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    // Burst 10, but ramped to 50% (=5) for the first 10s.
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      globalPerSec: 1000, // rate not the limiter; isolate the ramped burst
+      globalBurst: 10,
+      bootRamp: { fraction: 0.5, durationMs: 10_000 },
+    })
+
+    const ps: Promise<unknown>[] = []
+    for (let i = 0; i < 10; i++) ps.push(gate.gate(fn(String(i))))
+    await flush()
+    // Only the ramped burst (5 = 50% of 10) admits immediately at boot.
+    expect(calls.filter((c) => c.at === 0).length).toBe(5)
+
+    await clock.advance(11_000)
+    await Promise.all(ps)
+
+    // After the ramp window, the full burst capacity is available again.
+    const gate2 = createSendGate({
+      enabled: true,
+      clock,
+      globalPerSec: 1000,
+      globalBurst: 10,
+      // ramp already elapsed relative to this clock's now (11_000 > 10_000)
+      bootRamp: { fraction: 0.5, durationMs: 0 },
+    })
+    const { calls: c2, fn: fn2 } = recorder(clock)
+    const ps2: Promise<unknown>[] = []
+    for (let i = 0; i < 10; i++) ps2.push(gate2.gate(fn2(String(i))))
+    await flush()
+    await Promise.all(ps2)
+    expect(c2.filter((c) => c.at === 11_000).length).toBe(10) // full burst, no ramp
   })
 })

--- a/telegram-plugin/send-gate.ts
+++ b/telegram-plugin/send-gate.ts
@@ -1,0 +1,416 @@
+/**
+ * Deterministic outbound send gate for the Telegram Bot API (#3084, PR 1/3).
+ *
+ * WHY
+ * ---
+ * Each agent's gateway drives MANY outbound surfaces (reply chunks, answer /
+ * draft stream edits, typing, worker-feed edits, reactions, cards). Each has
+ * its own local throttle, but nothing composes them into a global or per-chat
+ * ceiling — so during a busy turn the per-surface throttles ADD UP with no cap
+ * and trip a per-bot-token flood ban (429 retry_after ~hours). See
+ * `part2-audit.md` §3 and issue #3084.
+ *
+ * This module is the core control from `part3-design.md` §1: ONE token-bucket
+ * scheduler that every Bot API call passes through (wired at the robustApiCall
+ * layer so no call site can bypass it). It enforces:
+ *
+ *   - Global bucket:      25/sec  (headroom under Telegram's ~30/sec).
+ *   - Per-chat bucket:    1/sec sustained, burst 3.
+ *   - Per-group bucket:   18/min  (headroom under 20), keyed on chat type.
+ *   - Per-message edit:   >=1.5s between edits of the same message_id, with
+ *                         LAST-WRITE-WINS coalescing (an edit queued while one
+ *                         is pending REPLACES the pending payload; it never
+ *                         queues behind it — the next edit carries full state).
+ *
+ * It also skips no-op edits: identical rendered payload for the same
+ * message_id is dropped before hitting the API (Telegram 400s "message is not
+ * modified" today, which still costs flood budget).
+ *
+ * SAFETY / ROLLOUT
+ * ----------------
+ * Feature-flagged and default-OFF (`SWITCHROOM_TELEGRAM_SEND_GATE=1` to enable,
+ * following the `SWITCHROOM_*=== '1'` gateway flag convention). When disabled,
+ * `gate()` is a pure passthrough to the wrapped call — zero behaviour change.
+ * This is PR 1 of 3; priority-class shedding + degraded mode (PR 2) and
+ * observability + operator alert (PR 3) build on the counters exposed here.
+ *
+ * DETERMINISM / TESTABILITY
+ * -------------------------
+ * All time comes from an injectable `Clock` (`now()` + `sleep()`); there is no
+ * inline `Date.now()` / `setTimeout()` in the scheduling logic, so a fake clock
+ * makes the buckets fully deterministic under test. Token consumption happens
+ * in a synchronous critical section (no `await` between reading the clock and
+ * consuming), so concurrent admissions on a single-threaded runtime never
+ * double-spend a token.
+ */
+
+import { createHash } from 'node:crypto'
+
+/** Injectable time source. Default binds to real wall clock + setTimeout. */
+export interface Clock {
+  /** Milliseconds since epoch (monotonic-enough for bucket refill math). */
+  now(): number
+  /** Resolve after `ms` milliseconds. */
+  sleep(ms: number): Promise<void>
+}
+
+export const systemClock: Clock = {
+  now: () => Date.now(),
+  sleep: (ms: number) => new Promise<void>((r) => setTimeout(r, ms)),
+}
+
+/** Chat type as reported by Telegram, used to key the per-group bucket. */
+export type ChatType = 'private' | 'group' | 'supergroup' | 'channel'
+
+/**
+ * Extra metadata a call site can attach so the gate can key the right buckets.
+ * All fields optional — a call with none still passes the global bucket. These
+ * mirror (a superset of) `RetryCallOpts` so the gate can wrap `robustApiCall`
+ * transparently.
+ */
+export interface SendGateOpts {
+  /** Destination chat id — keys the per-chat and (for groups) per-group bucket. */
+  chat_id?: string
+  /** Chat type — a group/supergroup additionally passes the per-group bucket. */
+  chatType?: ChatType
+  /** For edits: the target message id. Enables the edit floor + coalescing. */
+  messageId?: number
+  /**
+   * For edits: the rendered payload (any stable-stringifiable value). Used for
+   * the no-op skip (hash equal to last sent → dropped) and last-write-wins
+   * coalescing. Only meaningful together with `messageId`.
+   */
+  editPayload?: unknown
+  /** Informational label (e.g. "editMessageText"); surfaced in stats/logs. */
+  verb?: string
+}
+
+/** Per-bucket counters, snapshotted by `stats()`. */
+export interface BucketCounters {
+  /** Calls that executed the wrapped fn. */
+  sent: number
+  /** Calls that had to wait on at least one bucket before executing. */
+  queued: number
+  /** Edits whose payload replaced a still-pending edit for the same message. */
+  coalesced: number
+  /** Calls dropped without hitting the API (no-op edit skip). */
+  dropped: number
+}
+
+export interface SendGateStats {
+  enabled: boolean
+  global: BucketCounters
+  /** Current token fill of each live bucket (for observability, PR 3). */
+  fill: {
+    global: number
+    perChat: Record<string, number>
+    perGroup: Record<string, number>
+  }
+}
+
+export interface SendGateConfig {
+  /** Master switch. When false, `gate()` is a straight passthrough. */
+  enabled: boolean
+  /** Injected clock; defaults to the real system clock. */
+  clock?: Clock
+  /** Global bucket rate (tokens/sec). Default 25. */
+  globalPerSec?: number
+  /** Per-chat sustained rate (tokens/sec). Default 1. */
+  perChatPerSec?: number
+  /** Per-chat burst capacity. Default 3. */
+  perChatBurst?: number
+  /** Per-group rate (tokens/min). Default 18. */
+  perGroupPerMin?: number
+  /** Minimum ms between edits of the same message_id. Default 1500. */
+  editFloorMs?: number
+}
+
+/**
+ * Classic token bucket. `tokens` refills continuously at `refillPerMs` up to
+ * `capacity`. `consume` and `msUntilAvailable` both refill lazily against the
+ * supplied `now`, so there is no timer per bucket — refill is computed on
+ * demand from the injected clock.
+ */
+class TokenBucket {
+  private tokens: number
+  private lastRefillMs: number
+
+  constructor(
+    readonly capacity: number,
+    private readonly refillPerMs: number,
+    now: number,
+  ) {
+    this.tokens = capacity
+    this.lastRefillMs = now
+  }
+
+  private refill(now: number): void {
+    if (now <= this.lastRefillMs) return
+    const elapsed = now - this.lastRefillMs
+    this.tokens = Math.min(this.capacity, this.tokens + elapsed * this.refillPerMs)
+    this.lastRefillMs = now
+  }
+
+  /** Milliseconds until at least one token is available (0 if available now). */
+  msUntilAvailable(now: number): number {
+    this.refill(now)
+    if (this.tokens >= 1) return 0
+    return Math.ceil((1 - this.tokens) / this.refillPerMs)
+  }
+
+  /** Consume one token. Caller must have checked availability in the SAME tick. */
+  consume(now: number): void {
+    this.refill(now)
+    this.tokens -= 1
+  }
+
+  fill(now: number): number {
+    this.refill(now)
+    return this.tokens
+  }
+}
+
+interface PendingEdit {
+  hash: string
+  fn: () => Promise<unknown>
+  promise: Promise<unknown>
+  resolve: (v: unknown) => void
+  reject: (e: unknown) => void
+}
+
+interface MessageEditState {
+  /** Wall time of the last edit actually sent for this message. */
+  lastSentMs: number
+  /** Hash of the last payload actually sent (for the no-op skip). */
+  lastHash: string | undefined
+  /** At most one in-flight/queued coalesced edit per message. */
+  pending: PendingEdit | null
+}
+
+function hashPayload(payload: unknown): string {
+  const s = typeof payload === 'string' ? payload : stableStringify(payload)
+  return createHash('sha256').update(s).digest('hex')
+}
+
+/** Deterministic JSON stringify (sorted keys) so equal payloads hash equal. */
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_k, v) => {
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      return Object.keys(v as Record<string, unknown>)
+        .sort()
+        .reduce<Record<string, unknown>>((acc, k) => {
+          acc[k] = (v as Record<string, unknown>)[k]
+          return acc
+        }, {})
+    }
+    return v
+  })
+}
+
+export interface SendGate {
+  /**
+   * Run `fn` (a single Bot API call) through the gate. Returns whatever `fn`
+   * resolves to. For a dropped no-op edit, resolves to `undefined` without
+   * calling `fn`. For a coalesced edit, resolves when the coalesced send
+   * completes (with that send's result).
+   */
+  gate<T>(fn: () => Promise<T>, opts?: SendGateOpts): Promise<T>
+  /** Snapshot of counters + current bucket fill. */
+  stats(): SendGateStats
+}
+
+const GROUP_TYPES = new Set<ChatType>(['group', 'supergroup'])
+
+export function createSendGate(config: SendGateConfig): SendGate {
+  const enabled = config.enabled
+  const clock = config.clock ?? systemClock
+  const globalPerSec = config.globalPerSec ?? 25
+  const perChatPerSec = config.perChatPerSec ?? 1
+  const perChatBurst = config.perChatBurst ?? 3
+  const perGroupPerMin = config.perGroupPerMin ?? 18
+  const editFloorMs = config.editFloorMs ?? 1500
+
+  const counters: BucketCounters = { sent: 0, queued: 0, coalesced: 0, dropped: 0 }
+
+  const globalBucket = new TokenBucket(globalPerSec, globalPerSec / 1000, clock.now())
+  const perChat = new Map<string, TokenBucket>()
+  const perGroup = new Map<string, TokenBucket>()
+  const perMessage = new Map<number, MessageEditState>()
+
+  function chatBucket(chatId: string): TokenBucket {
+    let b = perChat.get(chatId)
+    if (!b) {
+      b = new TokenBucket(perChatBurst, perChatPerSec / 1000, clock.now())
+      perChat.set(chatId, b)
+    }
+    return b
+  }
+
+  function groupBucket(chatId: string): TokenBucket {
+    let b = perGroup.get(chatId)
+    if (!b) {
+      b = new TokenBucket(perGroupPerMin, perGroupPerMin / 60000, clock.now())
+      perGroup.set(chatId, b)
+    }
+    return b
+  }
+
+  function bucketsFor(opts?: SendGateOpts): TokenBucket[] {
+    const buckets: TokenBucket[] = [globalBucket]
+    if (opts?.chat_id) {
+      buckets.push(chatBucket(opts.chat_id))
+      if (opts.chatType && GROUP_TYPES.has(opts.chatType)) {
+        buckets.push(groupBucket(opts.chat_id))
+      }
+    }
+    return buckets
+  }
+
+  /**
+   * Wait until every bucket has a token, then consume one from each. The
+   * check-and-consume block runs synchronously (no `await` after reading the
+   * clock), so concurrent admissions never double-spend. Loops because a
+   * competing admission may drain a bucket during our sleep.
+   */
+  async function admit(buckets: TokenBucket[]): Promise<void> {
+    let counted = false
+    for (;;) {
+      const now = clock.now()
+      let wait = 0
+      for (const b of buckets) wait = Math.max(wait, b.msUntilAvailable(now))
+      if (wait <= 0) {
+        for (const b of buckets) b.consume(now)
+        return
+      }
+      if (!counted) {
+        counters.queued++
+        counted = true
+      }
+      await clock.sleep(wait)
+    }
+  }
+
+  async function handleEdit<T>(fn: () => Promise<T>, opts: SendGateOpts): Promise<T> {
+    const messageId = opts.messageId as number
+    const hash = hashPayload(opts.editPayload)
+    let state = perMessage.get(messageId)
+    if (!state) {
+      state = { lastSentMs: Number.NEGATIVE_INFINITY, lastHash: undefined, pending: null }
+      perMessage.set(messageId, state)
+    }
+
+    // No-op skip: identical to the last payload we actually sent → drop.
+    if (hash === state.lastHash) {
+      counters.dropped++
+      return undefined as unknown as T
+    }
+
+    const now = clock.now()
+    const elapsed = now - state.lastSentMs
+
+    // Free to send now: no queued edit AND the edit floor has elapsed.
+    if (!state.pending && elapsed >= editFloorMs) {
+      await admit(bucketsFor(opts))
+      state.lastSentMs = clock.now()
+      state.lastHash = hash
+      counters.sent++
+      return fn()
+    }
+
+    // An edit is already queued for this message → last-write-wins: replace its
+    // payload in place rather than queuing behind it. Both callers share the
+    // single pending promise, which resolves with the coalesced send's result.
+    if (state.pending) {
+      // Payload identical to the already-queued one → nothing to do.
+      if (state.pending.hash !== hash) {
+        counters.coalesced++
+        state.pending.hash = hash
+        state.pending.fn = fn as () => Promise<unknown>
+      }
+      return state.pending.promise as Promise<T>
+    }
+
+    // Within the edit floor and nothing queued yet → schedule one pending edit
+    // that fires when the floor elapses, carrying whatever payload is latest.
+    let resolve!: (v: unknown) => void
+    let reject!: (e: unknown) => void
+    const promise = new Promise<unknown>((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+    const pending: PendingEdit = {
+      hash,
+      fn: fn as () => Promise<unknown>,
+      promise,
+      resolve,
+      reject,
+    }
+    state.pending = pending
+
+    const waitMs = editFloorMs - elapsed
+    void (async () => {
+      try {
+        if (waitMs > 0) await clock.sleep(waitMs)
+        const p = state.pending
+        state.pending = null
+        if (!p) return
+        // Re-check the no-op skip against the last sent payload — the latest
+        // coalesced payload may have reverted to what's already on screen.
+        if (p.hash === state.lastHash) {
+          counters.dropped++
+          p.resolve(undefined)
+          return
+        }
+        await admit(bucketsFor(opts))
+        state.lastSentMs = clock.now()
+        state.lastHash = p.hash
+        counters.sent++
+        p.resolve(await p.fn())
+      } catch (err) {
+        const p = state.pending
+        state.pending = null
+        ;(p ?? pending).reject(err)
+      }
+    })()
+
+    return promise as Promise<T>
+  }
+
+  async function gate<T>(fn: () => Promise<T>, opts?: SendGateOpts): Promise<T> {
+    // Flag OFF → pure passthrough, zero behaviour change.
+    if (!enabled) return fn()
+
+    // Edit path (floor + coalescing + no-op skip) only when we can key it.
+    if (opts && opts.messageId != null && 'editPayload' in opts) {
+      return handleEdit(fn, opts)
+    }
+
+    await admit(bucketsFor(opts))
+    counters.sent++
+    return fn()
+  }
+
+  function stats(): SendGateStats {
+    const now = clock.now()
+    const perChatFill: Record<string, number> = {}
+    for (const [k, b] of perChat) perChatFill[k] = b.fill(now)
+    const perGroupFill: Record<string, number> = {}
+    for (const [k, b] of perGroup) perGroupFill[k] = b.fill(now)
+    return {
+      enabled,
+      global: { ...counters },
+      fill: {
+        global: globalBucket.fill(now),
+        perChat: perChatFill,
+        perGroup: perGroupFill,
+      },
+    }
+  }
+
+  return { gate, stats }
+}
+
+/** Read the feature flag using the standard `SWITCHROOM_*=== '1'` convention. */
+export function sendGateEnabledFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.SWITCHROOM_TELEGRAM_SEND_GATE === '1'
+}

--- a/telegram-plugin/send-gate.ts
+++ b/telegram-plugin/send-gate.ts
@@ -14,17 +14,39 @@
  * scheduler that every Bot API call passes through (wired at the robustApiCall
  * layer so no call site can bypass it). It enforces:
  *
- *   - Global bucket:      25/sec  (headroom under Telegram's ~30/sec).
+ *   - Global bucket:      25/sec sustained, small burst (headroom under ~30/s).
  *   - Per-chat bucket:    1/sec sustained, burst 3.
- *   - Per-group bucket:   18/min  (headroom under 20), keyed on chat type.
+ *   - Per-group bucket:   18/min sustained, small burst (headroom under 20),
+ *                         keyed on chat type.
  *   - Per-message edit:   >=1.5s between edits of the same message_id, with
  *                         LAST-WRITE-WINS coalescing (an edit queued while one
  *                         is pending REPLACES the pending payload; it never
- *                         queues behind it — the next edit carries full state).
+ *                         queues behind it — the next edit carries full state)
+ *                         AND in-flight serialization (only one send per
+ *                         message runs at a time; edits that arrive while a
+ *                         send is mid-flight — including one sleeping on a
+ *                         429 retry_after — coalesce behind it rather than
+ *                         firing a second overlapping edit).
+ *
+ * Nested buckets like PTB's AIORateLimiter; grammY's Bottleneck numbers are the
+ * sanity reference. Sustained rate is the refill rate (= budget); the burst
+ * capacity is a small headroom under Telegram's hard window ceiling, NOT a full
+ * extra window's worth of budget (that would double the effective rate — see
+ * the M2 finding on #3092).
  *
  * It also skips no-op edits: identical rendered payload for the same
  * message_id is dropped before hitting the API (Telegram 400s "message is not
  * modified" today, which still costs flood budget).
+ *
+ * RESTART-PROOF FLOOD STATE (part3-design §7, PR 2 hook)
+ * -----------------------------------------------------
+ * `createSendGate` accepts `initialWindows` (flood windows loaded from
+ * `flood-wait.json` on boot) and `bootRamp` (start the global bucket at a
+ * fraction of capacity for the first N ms to absorb boot-card bursts).
+ * `openFloodWindow(scopeKey, untilTs)` lets PR 2 re-open a window at runtime
+ * on a 429. A bucket under an open window admits NOTHING until `untilTs`,
+ * regardless of token fill — a token bucket alone cannot express a
+ * "blocked until" suppression, so the buckets consult a per-scope window too.
  *
  * SAFETY / ROLLOUT
  * ----------------
@@ -100,6 +122,8 @@ export interface BucketCounters {
 export interface SendGateStats {
   enabled: boolean
   global: BucketCounters
+  /** Number of live per-message edit states (watch for the H2 leak). */
+  messageStates: number
   /** Current token fill of each live bucket (for observability, PR 3). */
   fill: {
     global: number
@@ -108,54 +132,119 @@ export interface SendGateStats {
   }
 }
 
+/** A flood window: a scope suppressed until `untilTs` (part3-design §7). */
+export interface FloodWindow {
+  /** `global` | `chat:<id>` | `group:<id>` | `msg-edit:<id>`. */
+  scopeKey: string
+  /** Epoch ms until which the scope admits nothing. */
+  untilTs: number
+}
+
+/**
+ * Boot ramp for the global bucket (part3-design §7): start at a fraction of
+ * capacity for `durationMs` after boot so a burst of boot/config cards can't
+ * immediately saturate the freshly-full bucket.
+ */
+export interface BootRamp {
+  /** Fraction of the global burst capacity during the ramp (0..1). Default 0.5. */
+  fraction?: number
+  /** Ramp duration in ms from gate construction. Default 10_000. */
+  durationMs?: number
+}
+
 export interface SendGateConfig {
   /** Master switch. When false, `gate()` is a straight passthrough. */
   enabled: boolean
   /** Injected clock; defaults to the real system clock. */
   clock?: Clock
-  /** Global bucket rate (tokens/sec). Default 25. */
+  /** Global bucket sustained rate (tokens/sec). Default 25. */
   globalPerSec?: number
+  /** Global burst capacity (headroom under Telegram's ~30/s). Default 5. */
+  globalBurst?: number
   /** Per-chat sustained rate (tokens/sec). Default 1. */
   perChatPerSec?: number
   /** Per-chat burst capacity. Default 3. */
   perChatBurst?: number
-  /** Per-group rate (tokens/min). Default 18. */
+  /** Per-group sustained rate (tokens/min). Default 18. */
   perGroupPerMin?: number
+  /** Per-group burst capacity (headroom under 20/min). Default 2. */
+  perGroupBurst?: number
   /** Minimum ms between edits of the same message_id. Default 1500. */
   editFloorMs?: number
+  /**
+   * Flood windows to re-open at construction (part3-design §7). PR 2 loads
+   * these from `flood-wait.json` BEFORE the first outbound call so a restart
+   * during an active ban does not immediately resend into the flood.
+   */
+  initialWindows?: FloodWindow[]
+  /** Global-bucket boot ramp (part3-design §7). Omit to start full. */
+  bootRamp?: BootRamp
+  /**
+   * TTL (ms) after which an idle per-message edit state is evicted. Default
+   * 60_000. Prevents unbounded growth of the perMessage map (#3092 H2).
+   */
+  messageStateTtlMs?: number
+  /**
+   * Hard cap on live per-message edit states; oldest-idle are evicted (LRU)
+   * once exceeded. Default 5_000.
+   */
+  maxMessageStates?: number
 }
 
 /**
- * Classic token bucket. `tokens` refills continuously at `refillPerMs` up to
- * `capacity`. `consume` and `msUntilAvailable` both refill lazily against the
- * supplied `now`, so there is no timer per bucket — refill is computed on
- * demand from the injected clock.
+ * Classic token bucket with an optional per-scope suppression window and an
+ * optional boot ramp. `tokens` refills continuously at `refillPerMs` up to
+ * `capacity` (or `rampCapacity` while inside the ramp). `consume` and
+ * `msUntilAvailable` both refill lazily against the supplied `now`, so there is
+ * no timer per bucket. A suppression window (`suppressUntil`) blocks all
+ * admission until its `untilTs`, regardless of token fill — a token bucket
+ * alone cannot represent "blocked until T" (part3-design §7).
  */
 class TokenBucket {
   private tokens: number
   private lastRefillMs: number
+  private suppressedUntilMs = 0
+  private readonly rampCapacity: number
+  private readonly rampUntilMs: number
 
   constructor(
     readonly capacity: number,
     private readonly refillPerMs: number,
     now: number,
+    ramp?: { capacity: number; untilMs: number },
   ) {
-    this.tokens = capacity
+    this.rampCapacity = ramp?.capacity ?? capacity
+    this.rampUntilMs = ramp?.untilMs ?? 0
+    this.tokens = this.capAt(now)
     this.lastRefillMs = now
+  }
+
+  /** Effective capacity ceiling at `now` (lower during the boot ramp). */
+  private capAt(now: number): number {
+    return now < this.rampUntilMs ? this.rampCapacity : this.capacity
   }
 
   private refill(now: number): void {
     if (now <= this.lastRefillMs) return
     const elapsed = now - this.lastRefillMs
-    this.tokens = Math.min(this.capacity, this.tokens + elapsed * this.refillPerMs)
+    this.tokens = Math.min(this.capAt(now), this.tokens + elapsed * this.refillPerMs)
     this.lastRefillMs = now
   }
 
-  /** Milliseconds until at least one token is available (0 if available now). */
+  /** Open/extend a suppression window (part3-design §7). */
+  suppressUntil(untilTs: number): void {
+    if (untilTs > this.suppressedUntilMs) this.suppressedUntilMs = untilTs
+  }
+
+  /**
+   * Milliseconds until at least one token is available AND no suppression
+   * window is open (0 if admissible now).
+   */
   msUntilAvailable(now: number): number {
+    const windowWait = this.suppressedUntilMs > now ? this.suppressedUntilMs - now : 0
     this.refill(now)
-    if (this.tokens >= 1) return 0
-    return Math.ceil((1 - this.tokens) / this.refillPerMs)
+    const tokenWait = this.tokens >= 1 ? 0 : Math.ceil((1 - this.tokens) / this.refillPerMs)
+    return Math.max(windowWait, tokenWait)
   }
 
   /** Consume one token. Caller must have checked availability in the SAME tick. */
@@ -179,21 +268,34 @@ interface PendingEdit {
 }
 
 interface MessageEditState {
-  /** Wall time of the last edit actually sent for this message. */
+  /** Wall time of the last edit SEND START for this message. */
   lastSentMs: number
-  /** Hash of the last payload actually sent (for the no-op skip). */
+  /** Hash of the last payload SUCCESSFULLY sent (for the no-op skip). */
   lastHash: string | undefined
-  /** At most one in-flight/queued coalesced edit per message. */
+  /** At most one queued coalesced edit per message (last-write-wins). */
   pending: PendingEdit | null
+  /** True while a driver is actively sending / waiting for this message. */
+  running: boolean
+  /** Per-message flood suppression window (part3-design §7). */
+  suppressedUntilMs: number
 }
 
 function hashPayload(payload: unknown): string {
-  const s = typeof payload === 'string' ? payload : stableStringify(payload)
+  let s: string
+  if (typeof payload === 'string') {
+    s = payload
+  } else {
+    const j = stableStringify(payload)
+    // `stableStringify(undefined)` (and any value that JSON.stringify drops)
+    // returns undefined; hash a fixed sentinel so createHash never throws
+    // (#3092 L2 — a caller may set editPayload: undefined alongside messageId).
+    s = j === undefined ? ' undefined' : j
+  }
   return createHash('sha256').update(s).digest('hex')
 }
 
 /** Deterministic JSON stringify (sorted keys) so equal payloads hash equal. */
-function stableStringify(value: unknown): string {
+function stableStringify(value: unknown): string | undefined {
   return JSON.stringify(value, (_k, v) => {
     if (v && typeof v === 'object' && !Array.isArray(v)) {
       return Object.keys(v as Record<string, unknown>)
@@ -215,6 +317,11 @@ export interface SendGate {
    * completes (with that send's result).
    */
   gate<T>(fn: () => Promise<T>, opts?: SendGateOpts): Promise<T>
+  /**
+   * Open/extend a flood-suppression window on a scope (part3-design §7). Used
+   * by PR 2 on a 429 and at boot from the persisted `flood-wait.json`.
+   */
+  openFloodWindow(scopeKey: string, untilTs: number): void
   /** Snapshot of counters + current bucket fill. */
   stats(): SendGateStats
 }
@@ -225,17 +332,30 @@ export function createSendGate(config: SendGateConfig): SendGate {
   const enabled = config.enabled
   const clock = config.clock ?? systemClock
   const globalPerSec = config.globalPerSec ?? 25
+  const globalBurst = config.globalBurst ?? 5
   const perChatPerSec = config.perChatPerSec ?? 1
   const perChatBurst = config.perChatBurst ?? 3
   const perGroupPerMin = config.perGroupPerMin ?? 18
+  const perGroupBurst = config.perGroupBurst ?? 2
   const editFloorMs = config.editFloorMs ?? 1500
+  const messageStateTtlMs = config.messageStateTtlMs ?? 60_000
+  const maxMessageStates = config.maxMessageStates ?? 5_000
 
   const counters: BucketCounters = { sent: 0, queued: 0, coalesced: 0, dropped: 0 }
 
-  const globalBucket = new TokenBucket(globalPerSec, globalPerSec / 1000, clock.now())
+  const bootStart = clock.now()
+  const globalRamp = config.bootRamp
+    ? {
+        capacity: Math.max(1, Math.floor(globalBurst * (config.bootRamp.fraction ?? 0.5))),
+        untilMs: bootStart + (config.bootRamp.durationMs ?? 10_000),
+      }
+    : undefined
+
+  const globalBucket = new TokenBucket(globalBurst, globalPerSec / 1000, bootStart, globalRamp)
   const perChat = new Map<string, TokenBucket>()
   const perGroup = new Map<string, TokenBucket>()
   const perMessage = new Map<number, MessageEditState>()
+  let lastSweepMs = bootStart
 
   function chatBucket(chatId: string): TokenBucket {
     let b = perChat.get(chatId)
@@ -249,11 +369,29 @@ export function createSendGate(config: SendGateConfig): SendGate {
   function groupBucket(chatId: string): TokenBucket {
     let b = perGroup.get(chatId)
     if (!b) {
-      b = new TokenBucket(perGroupPerMin, perGroupPerMin / 60000, clock.now())
+      b = new TokenBucket(perGroupBurst, perGroupPerMin / 60000, clock.now())
       perGroup.set(chatId, b)
     }
     return b
   }
+
+  function messageState(messageId: number): MessageEditState {
+    let state = perMessage.get(messageId)
+    if (!state) {
+      state = {
+        lastSentMs: Number.NEGATIVE_INFINITY,
+        lastHash: undefined,
+        pending: null,
+        running: false,
+        suppressedUntilMs: 0,
+      }
+      perMessage.set(messageId, state)
+    }
+    return state
+  }
+
+  /** Apply any flood windows that were injected at construction (§7 boot load). */
+  for (const w of config.initialWindows ?? []) openFloodWindow(w.scopeKey, w.untilTs)
 
   function bucketsFor(opts?: SendGateOpts): TokenBucket[] {
     const buckets: TokenBucket[] = [globalBucket]
@@ -267,10 +405,67 @@ export function createSendGate(config: SendGateConfig): SendGate {
   }
 
   /**
-   * Wait until every bucket has a token, then consume one from each. The
-   * check-and-consume block runs synchronously (no `await` after reading the
-   * clock), so concurrent admissions never double-spend. Loops because a
-   * competing admission may drain a bucket during our sleep.
+   * Open/extend a flood window on a scope. `global` suppresses the global
+   * bucket; `chat:<id>` / `group:<id>` the per-chat / per-group buckets;
+   * `msg-edit:<id>` the per-message edit floor. Idempotent + monotonic
+   * (only ever extends).
+   */
+  function openFloodWindow(scopeKey: string, untilTs: number): void {
+    if (scopeKey === 'global') {
+      globalBucket.suppressUntil(untilTs)
+    } else if (scopeKey.startsWith('chat:')) {
+      chatBucket(scopeKey.slice('chat:'.length)).suppressUntil(untilTs)
+    } else if (scopeKey.startsWith('group:')) {
+      groupBucket(scopeKey.slice('group:'.length)).suppressUntil(untilTs)
+    } else if (scopeKey.startsWith('msg-edit:')) {
+      const id = Number(scopeKey.slice('msg-edit:'.length))
+      if (Number.isFinite(id)) {
+        const st = messageState(id)
+        if (untilTs > st.suppressedUntilMs) st.suppressedUntilMs = untilTs
+      }
+    }
+  }
+
+  function isEvictable(s: MessageEditState, now: number): boolean {
+    return !s.pending && !s.running && s.suppressedUntilMs <= now
+  }
+
+  /**
+   * Bound the perMessage map (#3092 H2). Two mechanisms: a TTL sweep of idle
+   * states older than `messageStateTtlMs`, and a hard LRU cap. An entry with a
+   * pending/running send or an open suppression window is never evicted.
+   */
+  function maybeEvict(now: number, reserving: boolean): void {
+    // Leave room for the entry about to be created so the map never settles
+    // ABOVE the cap (evicting AFTER the insert would perpetually sit at cap+1).
+    const target = Math.max(0, maxMessageStates - (reserving ? 1 : 0))
+    if (perMessage.size > target) {
+      const evictable = [...perMessage.entries()]
+        .filter(([, s]) => isEvictable(s, now))
+        .sort((a, b) => a[1].lastSentMs - b[1].lastSentMs)
+      let over = perMessage.size - target
+      for (const [k] of evictable) {
+        if (over <= 0) break
+        perMessage.delete(k)
+        over--
+      }
+    }
+    if (now - lastSweepMs >= messageStateTtlMs) {
+      lastSweepMs = now
+      for (const [k, s] of perMessage) {
+        if (isEvictable(s, now) && now - s.lastSentMs > messageStateTtlMs) {
+          perMessage.delete(k)
+        }
+      }
+    }
+  }
+
+  /**
+   * Wait until every bucket has a token (and no scope window is open), then
+   * consume one from each. The check-and-consume block runs synchronously (no
+   * `await` after reading the clock), so concurrent admissions never
+   * double-spend. Loops because a competing admission may drain a bucket during
+   * our sleep.
    */
   async function admit(buckets: TokenBucket[]): Promise<void> {
     let counted = false
@@ -290,38 +485,83 @@ export function createSendGate(config: SendGateConfig): SendGate {
     }
   }
 
-  async function handleEdit<T>(fn: () => Promise<T>, opts: SendGateOpts): Promise<T> {
+  /**
+   * The single serialized driver for one message. Only ONE driver runs per
+   * message at a time (`state.running`); every edit that arrives while it runs
+   * — whether it is sleeping on the floor, waiting on a bucket, or mid-flight
+   * on the network (e.g. a 429 retry_after sleep INSIDE `fn`) — coalesces into
+   * `state.pending` rather than firing a second overlapping send. This closes
+   * the same-tick double-send (M3) and the in-flight parallelism (M4).
+   */
+  async function drive(state: MessageEditState, opts: SendGateOpts): Promise<void> {
+    state.running = true
+    try {
+      while (state.pending) {
+        const now = clock.now()
+        const readyAt = Math.max(state.lastSentMs + editFloorMs, state.suppressedUntilMs)
+        const waitMs = readyAt - now
+        if (waitMs > 0) {
+          // Still inside the floor / an open window — sleep, then re-read
+          // state.pending (a newer edit may have replaced it in the meantime).
+          await clock.sleep(waitMs)
+          continue
+        }
+
+        // Floor cleared: take the current pending edit. A newer edit arriving
+        // from here on lands in a FRESH state.pending and is handled next loop.
+        const p = state.pending
+        state.pending = null
+
+        // Re-check the no-op skip against the last SUCCESSFULLY-sent payload —
+        // the latest coalesced payload may have reverted to what's on screen.
+        if (p.hash === state.lastHash) {
+          counters.dropped++
+          p.resolve(undefined)
+          continue
+        }
+
+        await admit(bucketsFor(opts))
+        // Reserve the send-start time BEFORE awaiting the network so the floor
+        // is measured from send start (matches the per-message serialization).
+        state.lastSentMs = clock.now()
+        try {
+          const res = await p.fn()
+          // M1: only record the payload as on-screen AFTER a successful send,
+          // so a FAILED edit can be retried with the same payload (not dropped
+          // as a phantom no-op).
+          state.lastHash = p.hash
+          counters.sent++
+          p.resolve(res)
+        } catch (err) {
+          // H1: reject THIS edit's own promise (the closure-local `p`), never
+          // state.pending — a distinct newer edit that arrived during the send
+          // owns state.pending and must survive to be sent on the next loop.
+          p.reject(err)
+        }
+      }
+    } finally {
+      state.running = false
+    }
+  }
+
+  function handleEdit<T>(fn: () => Promise<T>, opts: SendGateOpts): Promise<T> {
     const messageId = opts.messageId as number
     const hash = hashPayload(opts.editPayload)
-    let state = perMessage.get(messageId)
-    if (!state) {
-      state = { lastSentMs: Number.NEGATIVE_INFINITY, lastHash: undefined, pending: null }
-      perMessage.set(messageId, state)
-    }
+    const now = clock.now()
+    const existing = perMessage.get(messageId)
+    maybeEvict(now, existing === undefined)
+    const state = existing ?? messageState(messageId)
 
     // No-op skip: identical to the last payload we actually sent → drop.
     if (hash === state.lastHash) {
       counters.dropped++
-      return undefined as unknown as T
-    }
-
-    const now = clock.now()
-    const elapsed = now - state.lastSentMs
-
-    // Free to send now: no queued edit AND the edit floor has elapsed.
-    if (!state.pending && elapsed >= editFloorMs) {
-      await admit(bucketsFor(opts))
-      state.lastSentMs = clock.now()
-      state.lastHash = hash
-      counters.sent++
-      return fn()
+      return Promise.resolve(undefined as unknown as T)
     }
 
     // An edit is already queued for this message → last-write-wins: replace its
-    // payload in place rather than queuing behind it. Both callers share the
+    // payload in place rather than queuing behind it. All callers share the
     // single pending promise, which resolves with the coalesced send's result.
     if (state.pending) {
-      // Payload identical to the already-queued one → nothing to do.
       if (state.pending.hash !== hash) {
         counters.coalesced++
         state.pending.hash = hash
@@ -330,8 +570,10 @@ export function createSendGate(config: SendGateConfig): SendGate {
       return state.pending.promise as Promise<T>
     }
 
-    // Within the edit floor and nothing queued yet → schedule one pending edit
-    // that fires when the floor elapses, carrying whatever payload is latest.
+    // Otherwise create a fresh pending edit. If no driver is currently running
+    // for this message, start one; if one IS running (mid-flight send, floor
+    // sleep, or bucket wait), it will pick this up on its next loop — this is
+    // what serializes sends per message (M3/M4).
     let resolve!: (v: unknown) => void
     let reject!: (e: unknown) => void
     const promise = new Promise<unknown>((res, rej) => {
@@ -346,33 +588,7 @@ export function createSendGate(config: SendGateConfig): SendGate {
       reject,
     }
     state.pending = pending
-
-    const waitMs = editFloorMs - elapsed
-    void (async () => {
-      try {
-        if (waitMs > 0) await clock.sleep(waitMs)
-        const p = state.pending
-        state.pending = null
-        if (!p) return
-        // Re-check the no-op skip against the last sent payload — the latest
-        // coalesced payload may have reverted to what's already on screen.
-        if (p.hash === state.lastHash) {
-          counters.dropped++
-          p.resolve(undefined)
-          return
-        }
-        await admit(bucketsFor(opts))
-        state.lastSentMs = clock.now()
-        state.lastHash = p.hash
-        counters.sent++
-        p.resolve(await p.fn())
-      } catch (err) {
-        const p = state.pending
-        state.pending = null
-        ;(p ?? pending).reject(err)
-      }
-    })()
-
+    if (!state.running) void drive(state, opts)
     return promise as Promise<T>
   }
 
@@ -399,6 +615,7 @@ export function createSendGate(config: SendGateConfig): SendGate {
     return {
       enabled,
       global: { ...counters },
+      messageStates: perMessage.size,
       fill: {
         global: globalBucket.fill(now),
         perChat: perChatFill,
@@ -407,7 +624,7 @@ export function createSendGate(config: SendGateConfig): SendGate {
     }
   }
 
-  return { gate, stats }
+  return { gate, openFloodWindow, stats }
 }
 
 /** Read the feature flag using the standard `SWITCHROOM_*=== '1'` convention. */

--- a/telegram-plugin/send-gate.ts
+++ b/telegram-plugin/send-gate.ts
@@ -159,7 +159,12 @@ export interface SendGateConfig {
   clock?: Clock
   /** Global bucket sustained rate (tokens/sec). Default 25. */
   globalPerSec?: number
-  /** Global burst capacity (headroom under Telegram's ~30/s). Default 5. */
+  /**
+   * Global burst capacity (headroom under Telegram's ~30/s). Default 4.
+   * Worst-case sliding-window admissions = capacity + rate·T, so a full 1s
+   * window admits at most `globalBurst + globalPerSec` = 4 + 25 = 29 < 30 —
+   * a real margin under the ceiling (#3092 M2 residual: burst 5 hit exactly 30).
+   */
   globalBurst?: number
   /** Per-chat sustained rate (tokens/sec). Default 1. */
   perChatPerSec?: number
@@ -332,7 +337,7 @@ export function createSendGate(config: SendGateConfig): SendGate {
   const enabled = config.enabled
   const clock = config.clock ?? systemClock
   const globalPerSec = config.globalPerSec ?? 25
-  const globalBurst = config.globalBurst ?? 5
+  const globalBurst = config.globalBurst ?? 4
   const perChatPerSec = config.perChatPerSec ?? 1
   const perChatBurst = config.perChatBurst ?? 3
   const perGroupPerMin = config.perGroupPerMin ?? 18
@@ -420,7 +425,14 @@ export function createSendGate(config: SendGateConfig): SendGate {
     } else if (scopeKey.startsWith('msg-edit:')) {
       const id = Number(scopeKey.slice('msg-edit:'.length))
       if (Number.isFinite(id)) {
-        const st = messageState(id)
+        // N2: creating a per-message edit state here must go through the same
+        // eviction accounting (maybeEvict / LRU cap) as normal state creation,
+        // so opening many per-message flood windows can't grow perMessage past
+        // the cap.
+        const now = clock.now()
+        const existing = perMessage.get(id)
+        maybeEvict(now, existing === undefined)
+        const st = existing ?? messageState(id)
         if (untilTs > st.suppressedUntilMs) st.suppressedUntilMs = untilTs
       }
     }
@@ -525,6 +537,12 @@ export function createSendGate(config: SendGateConfig): SendGate {
         // is measured from send start (matches the per-message serialization).
         state.lastSentMs = clock.now()
         try {
+          // N3 (liveness): this awaits `p.fn()` with no watchdog. A `fn` that
+          // NEVER settles would keep `state.running` true forever, making the
+          // state unevictable and hanging every coalesced caller. We rely on
+          // the fact that the only production caller is `robustApiCall`, whose
+          // own request/retry timeouts bound every send — so `p.fn()` is
+          // guaranteed to settle. No separate watchdog is needed here.
           const res = await p.fn()
           // M1: only record the payload as on-screen AFTER a successful send,
           // so a FAILED edit can be retried with the same payload (not dropped
@@ -552,14 +570,13 @@ export function createSendGate(config: SendGateConfig): SendGate {
     maybeEvict(now, existing === undefined)
     const state = existing ?? messageState(messageId)
 
-    // No-op skip: identical to the last payload we actually sent → drop.
-    if (hash === state.lastHash) {
-      counters.dropped++
-      return Promise.resolve(undefined as unknown as T)
-    }
-
-    // An edit is already queued for this message → last-write-wins: replace its
-    // payload in place rather than queuing behind it. All callers share the
+    // N1: the coalesce (last-write-wins) check runs BEFORE the no-op skip. When
+    // a distinct edit is already queued, the newest payload always replaces it —
+    // even if that payload reverts to the on-screen one (hash === lastHash).
+    // Otherwise a revert-to-on-screen edit would be dropped as a no-op while the
+    // stale queued edit still rendered, violating last-write-wins. When the
+    // driver dequeues, its own no-op re-check (`p.hash === state.lastHash`) drops
+    // a coalesced revert so nothing needless hits the API. All callers share the
     // single pending promise, which resolves with the coalesced send's result.
     if (state.pending) {
       if (state.pending.hash !== hash) {
@@ -568,6 +585,13 @@ export function createSendGate(config: SendGateConfig): SendGate {
         state.pending.fn = fn as () => Promise<unknown>
       }
       return state.pending.promise as Promise<T>
+    }
+
+    // No edit queued → a repeat of the last payload we actually sent is a plain
+    // no-op skip: drop it before the API.
+    if (hash === state.lastHash) {
+      counters.dropped++
+      return Promise.resolve(undefined as unknown as T)
     }
 
     // Otherwise create a fresh pending edit. If no driver is currently running
@@ -602,8 +626,12 @@ export function createSendGate(config: SendGateConfig): SendGate {
     }
 
     await admit(bucketsFor(opts))
+    // N4: count `sent` only AFTER a successful send, mirroring the edit path
+    // (which increments on success at drive()). A throwing send is not counted
+    // as sent — it propagates without polluting the stat.
+    const res = await fn()
     counters.sent++
-    return fn()
+    return res
   }
 
   function stats(): SendGateStats {


### PR DESCRIPTION
## Summary

PR **1 of 3** in the Telegram flood-safety series (issue #3084). Introduces a deterministic token-bucket outbound send gate wired at the `robustApiCall` layer so **every** Bot API call the plugin makes routes through one scheduler — no call site can bypass it. Feature-flagged and **default-OFF**; when off the gate is a pure passthrough with zero behaviour change.

Design: `part3-design.md` §1 (central token-bucket send gate) and §4 (same-message edit hygiene). Audit input: `part2-audit.md` §3 (no global/per-chat token bucket; per-surface throttles don't compose into a ceiling).

## Why

Each agent's gateway drives many outbound surfaces (reply chunks, answer/draft stream edits, typing, worker-feed edits, reactions, cards). Each has its own local throttle but nothing composes them into a global or per-chat ceiling, so during a busy turn the per-surface throttles add up with no cap and trip a per-bot-token flood ban (429 `retry_after` ~hours, #3084). The #1 documented ban trigger is rapid repeated `editMessageText` on the same message — exactly switchroom's progress/worker/answer-card pattern.

## What changed

- **`telegram-plugin/send-gate.ts`** (new) — nested token buckets:
  - Global **25/sec** (headroom under Telegram's ~30/sec).
  - Per-chat **1/sec sustained, burst 3**.
  - Per-group **18/min** (headroom under 20), keyed on chat type (group/supergroup only).
  - Per-message edit floor **1.5s** with **last-write-wins coalescing** — an edit arriving while one is pending replaces the pending payload rather than queuing behind it; the next edit carries full state.
  - **No-op edit skip** — hash the rendered payload per `message_id`; identical → dropped before the API (Telegram 400s "message is not modified" today, still costing flood budget).
  - **Injectable clock** (`now()` + `sleep()`); no inline `Date.now()`/`setTimeout()` in the scheduling logic. Token consumption is a synchronous critical section so concurrent admissions never double-spend.
  - **Stats getter** exposes `sent`/`queued`/`coalesced`/`dropped` counters + live bucket fill for the observability PR (PR 3).
- **`telegram-plugin/retry-api-call.ts`** — `RetryCallOpts` gains optional `chatType` / `messageId` / `editPayload` so call sites can key the buckets. The retry policy itself ignores them (additive, backward compatible).
- **`telegram-plugin/gateway/gateway.ts`** — compose the gate around the retry wrapper at the single `robustApiCall` definition. Everything already routing through `robustApiCall` / `swallowingApiCall` / the boot-card adapter now transits the gate when enabled.

## Feature flag

`SWITCHROOM_TELEGRAM_SEND_GATE=1` enables it (follows the `SWITCHROOM_*=== '1'` gateway flag convention). **Default OFF** → `gate()` passes straight through to the retry wrapper; buckets never engage; no timers; identical behaviour to today.

## Scope note (1 of 3)

- **PR 1 (this):** send gate + buckets + no-op-edit skip, pure gateway, flag-off.
- **PR 2:** priority classes + shedding + degraded mode wired to the #2923 flood breaker; structured `flood_wait` error on the MCP reply path.
- **PR 3:** observability + operator alert (builds on the counters exposed here).

When the flag flips on in PR 2/3, call sites will start passing `chatType`/`messageId`/`editPayload` to fully engage the per-group bucket and edit coalescing; PR 1 wires the plumbing and the global/per-chat buckets that key off the `chat_id` call sites already pass.

## Test plan

- New vitest suite `telegram-plugin/send-gate.test.ts` (12 tests) driven by a **deterministic fake clock** — asserts outcomes, not code paths:
  - global bucket admits burst then paces the rest by refill (3rd call runs at t=500ms under 2/sec);
  - per-chat burst-3-then-1/sec with **independent** other chats;
  - per-group ceiling keyed on chat type (3rd group send at t=30s under 2/min); private chats never engage the group bucket;
  - edit coalescing sends **only the last payload** (v1 immediate, v2/v3 within floor → only v3 fires at t=1.5s);
  - no-op skip drops an identical repeat and doesn't clobber a genuinely-different queued edit;
  - flag-off passthrough (no delay, counters untouched, edit floor bypassed).
- Existing `retry-api-call.test.ts` (37 tests) still green.
- `npm run lint` (tsc --noEmit + all 8 guard scripts, incl. `check-bot-api-wrapping`) clean.

Scoped tests + lint locally per repo protocol; CI is the full-suite authority.

## Risk

Low. Default-off feature flag; when off the code path is `if (!enabled) return fn()`. No raw `bot.api.*` calls added (lint guard clean). Additive `RetryCallOpts` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Adversarial review follow-up (commit ba9fa88b)

All findings from the DO-NOT-MERGE review fixed; flag remains default-OFF and flag-off passthrough is unchanged. The send gate now uses a **serialized per-message driver** (one send per `message_id` in flight at a time) as the durable mechanism behind H1/M3/M4.

| Finding | Fix | Test |
|---|---|---|
| **H1** coalescing error path orphaned the wrong pending edit | Driver rejects the closure-local `p`, never `state.pending`; a newer edit that arrived mid-flight survives and sends on the next loop | `rejects the failing edit and still sends a newer edit that arrived mid-flight (H1)` |
| **H2** unbounded `perMessage` map | TTL sweep of idle states + hard LRU cap (`messageStateTtlMs`, `maxMessageStates`); never evicts pending/running/window-open states; `stats().messageStates` exposes size | `evicts idle message states after the TTL`, `enforces a hard LRU cap on live message states` |
| **M1** failed edit poisoned the no-op skip | `lastHash` set only AFTER a successful send | `retries an identical payload after a FAILED edit (M1)` |
| **M2** buckets permitted ~2x sustained rate as burst | Split burst capacity from sustained rate (`globalBurst` default 5, `perGroupBurst` default 2); rate = budget | `bounds burst to capacity and holds sustained rate at the budget over windows`, `holds a per-group ceiling near budget/min, not ~2x` |
| **M3** same-tick double-send on the immediate path | Per-message serialization — second same-tick edit coalesces behind the first | `serializes two same-tick edits: one now, one after the floor (M3)` |
| **M4** parallel edits while a send sleeps on `retry_after` | Edits arriving during an in-flight send coalesce (last-write-wins); exactly one follow-up fires | `coalesces edits behind an in-flight send sleeping on retry_after (M4)` |
| **L2** `hashPayload(undefined)` threw | Fixed sentinel for undefined/non-stringifiable payloads | `does not throw when editPayload is undefined; treats a repeat as a no-op` |
| **L3 / §7** no restart-proof flood hook | Added `initialWindows` + `bootRamp` config and `openFloodWindow(scopeKey, untilTs)`; buckets consult a per-scope "suppressed until" window so PR 2 can load/persist `flood-wait.json` and re-open windows without refactoring this module | `an open flood window blocks admission until untilTs`, `re-opens flood windows passed at construction`, `starts the global bucket at a fraction of capacity during the boot ramp` |
| **L1** edit hygiene dormant in PR 1 | Scope acknowledgement only — call sites start passing `messageId`/`editPayload`/`chatType` in **PR 2**, so the per-group bucket, edit floor, coalescing, and no-op skip engage in production then. No code change in PR 1 beyond the above. | n/a |

Scoped `send-gate.test.ts` (24 tests) + `retry-api-call.test.ts` (37) green; `npm run lint` clean. CI is the full-suite authority.