### PR TITLE
fix(telegram): bound 429 flood-wait sleep, fail fast on long bans

### DIFF
--- a/telegram-plugin/flood-circuit-breaker.ts
+++ b/telegram-plugin/flood-circuit-breaker.ts
@@ -113,6 +113,26 @@ export function makeFloodWaitRecorder(
 }
 
 /**
+ * Build the `floodWaitRemainingMs` probe for `createRetryApiCall` (#3084).
+ *
+ * Returns the remaining ms of the persisted flood window, so the retry policy
+ * can refuse to issue a call INTO a known-open long ban rather than letting
+ * every 5-6s card heartbeat fire another request at the flood counter. Reads
+ * fresh each call (the window is written by `makeFloodWaitRecorder`, possibly
+ * from another code path in the same process).
+ *
+ * Fails OPEN: `readFloodState` already returns null on a missing or corrupt
+ * marker, which yields 0 = "no window, proceed". A broken state file must
+ * never permanently silence the bot.
+ */
+export function makeFloodWaitProbe(
+  path: string,
+  now: () => number = Date.now,
+): () => number {
+  return () => floodWaitRemainingMs(readFloodState(path), now())
+}
+
+/**
  * Decide whether a NON-ESSENTIAL restart-time send (boot card, config
  * summary) should be suppressed because a flood-wait is active. Returns the
  * remaining ms when suppressed (>0), or 0 to proceed. Reads state fresh so a

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -189,7 +189,11 @@ import {
 } from '../retry-api-call.js'
 import { classifyPhotoFile, rerouteResultSuffix } from '../photo-precheck.js'
 import { installTgPostLogger, withTgPostTags } from '../shared/bot-runtime.js'
-import { floodStatePath, makeFloodWaitRecorder } from '../flood-circuit-breaker.js'
+import {
+  floodStatePath,
+  makeFloodWaitRecorder,
+  makeFloodWaitProbe,
+} from '../flood-circuit-breaker.js'
 import { buildAttachmentPath, assertInsideInbox } from '../attachment-path.js'
 import { logStreamingEvent } from '../streaming-metrics.js'
 import * as signalTracker from '../turn-signal-tracker.js'
@@ -5423,6 +5427,12 @@ const FLOOD_STATE_PATH = floodStatePath(STATE_DIR)
 const robustApiCall = createRetryApiCall({
   log: (line) => process.stderr.write(line),
   onFloodWait: makeFloodWaitRecorder(FLOOD_STATE_PATH),
+  // #3084: while a LONG per-bot ban is open, don't issue the call at all.
+  // retryApiCall no longer sleeps a multi-hour retry_after (it throws
+  // FLOOD_WAIT_ACTIVE instead), and the card surfaces re-drive on a 5-6s
+  // heartbeat — without this gate that turns the fix into an amplifier that
+  // fires thousands of requests into the open window and extends the ban.
+  floodWaitRemainingMs: makeFloodWaitProbe(FLOOD_STATE_PATH),
 })
 
 // Fire-and-forget wrapper for outbound surfaces that previously had

--- a/telegram-plugin/gateway/unhandled-rejection-policy.ts
+++ b/telegram-plugin/gateway/unhandled-rejection-policy.ts
@@ -12,6 +12,8 @@
 
 import { GrammyError, HttpError } from 'grammy'
 
+import { FLOOD_WAIT_ACTIVE } from '../retry-api-call.js'
+
 export type RejectionAction = 'shutdown' | 'log_only'
 
 export interface RejectionPolicyOptions {
@@ -64,6 +66,17 @@ export function classifyRejection(
       ? opts.isHttpError(err)
       : err instanceof HttpError
   if (isHttp) return 'log_only'
+
+  // FLOOD_WAIT_ACTIVE (#3084): retry-api-call throws this plain Error marker
+  // instead of sleeping through a multi-hour per-bot flood ban (overlord saw
+  // retry_after = 16739s ≈ 4.6h). It is the SAME condition as the GrammyError
+  // 429 handled below — just surfaced as a non-retryable marker rather than a
+  // raw grammy error — so it takes the same posture. A leaked one (a
+  // fire-and-forget send that wasn't wrapped in swallowingApiCall) must NOT
+  // crash the gateway: the bot is already rate-limited, and a crash→restart
+  // fires MORE sends into the open window and extends the ban, which is the
+  // exact amplification the #2923 circuit breaker exists to stop.
+  if (err instanceof Error && err.message === FLOOD_WAIT_ACTIVE) return 'log_only'
 
   if (!isGrammy) return 'shutdown'
 

--- a/telegram-plugin/retry-api-call.ts
+++ b/telegram-plugin/retry-api-call.ts
@@ -16,7 +16,8 @@
  *
  *   | Thrown error                                  | This wrapper does                          |
  *   |-----------------------------------------------|--------------------------------------------|
- *   | GrammyError 429                               | sleep retry_after seconds, retry          |
+ *   | GrammyError 429 (retry_after <= ceiling)      | sleep retry_after seconds, retry          |
+ *   | GrammyError 429 (retry_after >  ceiling)      | record window, throw `FLOOD_WAIT_ACTIVE`  |
  *   | GrammyError 400 "message is not modified"     | swallow, return undefined                 |
  *   | GrammyError 400 "message to edit not found"   | swallow, return undefined                 |
  *   | GrammyError 400 "message to delete not found" | swallow, return undefined                 |
@@ -57,6 +58,13 @@ export interface RetryObserver {
 export interface RetryApiCallConfig {
   /** Max retries before giving up. Defaults to 3. */
   maxRetries?: number
+  /**
+   * Ceiling (ms) on how long a single 429 flood-wait may be slept IN-PROCESS.
+   * A `retry_after` above this is not slept at all — the window is recorded and
+   * `FLOOD_WAIT_ACTIVE` is thrown instead (see #3084). Defaults to
+   * `DEFAULT_MAX_FLOOD_SLEEP_MS`.
+   */
+  maxFloodSleepMs?: number
   /** Sleep helper — injected so tests can use fake timers. */
   sleep?: (ms: number) => Promise<void>
   /** Optional observer hooks. */
@@ -105,6 +113,46 @@ export function isLocalResourceError(err: unknown): boolean {
  */
 export const LOCAL_RESOURCE_EXHAUSTED = 'LOCAL_RESOURCE_EXHAUSTED'
 
+/**
+ * Marker error thrown when Telegram's reported `retry_after` exceeds the
+ * in-process sleep ceiling (#3084) — i.e. the bot is under a LONG per-bot
+ * flood ban, not a momentary rate-limit blip.
+ *
+ * Carries `{ retryAfterSec, untilTs, original }` so a caller can render a
+ * useful degraded state ("rate-limited by Telegram until HH:MM") instead of
+ * being parked on an await for hours.
+ */
+export const FLOOD_WAIT_ACTIVE = 'FLOOD_WAIT_ACTIVE'
+
+/** Shape of the error thrown for an over-ceiling flood-wait. */
+export interface FloodWaitActiveError extends Error {
+  /** Telegram's reported retry_after, in seconds. */
+  retryAfterSec: number
+  /** Epoch ms at which the flood window is expected to expire. */
+  untilTs: number
+  /** The originating GrammyError. */
+  original: unknown
+}
+
+/** True when `err` is the `FLOOD_WAIT_ACTIVE` marker thrown by `retryApiCall`. */
+export function isFloodWaitActiveError(err: unknown): err is FloodWaitActiveError {
+  return err instanceof Error && err.message === FLOOD_WAIT_ACTIVE
+}
+
+/**
+ * Default ceiling on a single in-process flood-wait sleep: 120s.
+ *
+ * Why 120s and not 30-60s: the flood-waits this bot has historically ridden out
+ * successfully were 28s and 75s — sleeping through those is the RIGHT behaviour
+ * and must not regress, so the ceiling has to sit above 75s with headroom. Why
+ * not higher: the ban this guards against (#3084, overlord 2026-07-11) reported
+ * retry_after = 16739s (~4.6h). A 120s ceiling bounds the worst case in-process
+ * block to maxRetries × 120s (6s→6min at the default 3) instead of hours, which
+ * is short enough that a caller — and the human waiting on a reply — gets a
+ * degraded answer rather than an apparently-wedged agent.
+ */
+export const DEFAULT_MAX_FLOOD_SLEEP_MS = 120_000
+
 const DEFAULT_SLEEP = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
 
 /**
@@ -120,6 +168,7 @@ export function createRetryApiCall(
   config: RetryApiCallConfig = {},
 ): <T>(fn: () => Promise<T>, opts?: RetryCallOpts) => Promise<T> {
   const maxRetries = config.maxRetries ?? 3
+  const maxFloodSleepMs = config.maxFloodSleepMs ?? DEFAULT_MAX_FLOOD_SLEEP_MS
   const sleep = config.sleep ?? DEFAULT_SLEEP
   const observer = config.observer
   const log = config.log
@@ -163,6 +212,27 @@ export function createRetryApiCall(
             onFloodWait?.(retryAfter)
           } catch {
             /* best-effort — never let the breaker hook break the retry path */
+          }
+          // #3084: a LONG ban must not be slept in-process. On 2026-07-11
+          // overlord got retry_after = 16739s (~4.6h); `await sleep(delayMs)`
+          // parked the send path — and every caller awaiting it — for hours.
+          // That is a wedge primitive, not a retry. Above the ceiling we've
+          // already recorded the window (the breaker above suppresses
+          // non-essential sends for its duration); now fail FAST with a
+          // distinct non-retryable marker so the caller can surface a degraded
+          // state. Under the ceiling, behaviour is unchanged: sleep and retry.
+          if (delayMs > maxFloodSleepMs) {
+            log?.(
+              `telegram gateway: 429 flood ban of ${retryAfter}s exceeds the ` +
+                `${Math.round(maxFloodSleepMs / 1000)}s in-process sleep ceiling — ` +
+                `not sleeping it; surfacing degraded state\n`,
+            )
+            observer?.onGiveUp?.({ attempts: attempt + 1, error: err })
+            throw Object.assign(new Error(FLOOD_WAIT_ACTIVE), {
+              retryAfterSec: retryAfter,
+              untilTs: Date.now() + delayMs,
+              original: err,
+            }) as FloodWaitActiveError
           }
           log?.(`telegram gateway: 429 rate limited, waiting ${retryAfter}s\n`)
           observer?.onRetry?.({ attempt, reason: 'flood_wait', delayMs })

--- a/telegram-plugin/retry-api-call.ts
+++ b/telegram-plugin/retry-api-call.ts
@@ -65,6 +65,17 @@ export interface RetryApiCallConfig {
    * `DEFAULT_MAX_FLOOD_SLEEP_MS`.
    */
   maxFloodSleepMs?: number
+  /**
+   * Remaining ms of a KNOWN-OPEN per-bot flood window, or 0 when none.
+   *
+   * Wired to the #2923 circuit-breaker state file (see
+   * `makeFloodWaitProbe`). When the remaining window is LONGER than
+   * `maxFloodSleepMs`, `retryApiCall` short-circuits BEFORE issuing the call:
+   * the ban is per-bot-token, so nothing can succeed while it's open, and
+   * every attempt only feeds the flood counter (#3084). Fails OPEN — a
+   * missing/corrupt/throwing probe means "no window", never a silenced bot.
+   */
+  floodWaitRemainingMs?: () => number
   /** Sleep helper — injected so tests can use fake timers. */
   sleep?: (ms: number) => Promise<void>
   /** Optional observer hooks. */
@@ -124,14 +135,57 @@ export const LOCAL_RESOURCE_EXHAUSTED = 'LOCAL_RESOURCE_EXHAUSTED'
  */
 export const FLOOD_WAIT_ACTIVE = 'FLOOD_WAIT_ACTIVE'
 
-/** Shape of the error thrown for an over-ceiling flood-wait. */
+/**
+ * Shape of the error thrown for an over-ceiling flood-wait.
+ *
+ * It deliberately carries Telegram's OWN 429 field shape (`error_code: 429`,
+ * `parameters.retry_after`) in addition to the friendlier fields. Several
+ * best-effort card surfaces duck-type their rate-limit cooldown on exactly
+ * those two fields rather than on `instanceof GrammyError`:
+ *
+ *   - `worker-activity-feed.ts` `extractRetryAfterSecs` → `noteRateLimited`
+ *   - `issues-card.ts` `extractRetryAfterSecs`
+ *   - `pending-work-progress.ts` (its catch assumes upstream retry_after backoff)
+ *
+ * All three route through `robustApiCall`, so once retryApiCall stops sleeping
+ * a long ban and starts THROWING, they see this marker instead of the raw
+ * GrammyError. Without `error_code`/`parameters` they would classify it as a
+ * generic 'transient' error, arm NO cooldown, and let their 5-6s heartbeats
+ * re-drive a fresh Bot API call into the still-open ban — thousands of requests
+ * over a 4.6h window, feeding the very flood counter #2923 exists to starve.
+ * Carrying the 429 shape makes the existing cooldown gates fire on the full
+ * window with no change to those modules.
+ *
+ * It remains a plain `Error` (NOT a `GrammyError`), so the `instanceof`-based
+ * probes — `isHtmlParseRejectError`, `isMessageTooLongError`,
+ * `isPhotoDimensionRejectError` — still correctly do not match it.
+ */
 export interface FloodWaitActiveError extends Error {
   /** Telegram's reported retry_after, in seconds. */
   retryAfterSec: number
   /** Epoch ms at which the flood window is expected to expire. */
   untilTs: number
-  /** The originating GrammyError. */
+  /** Telegram's 429 code — see the duck-typing note above. */
+  error_code: 429
+  /** Telegram's 429 payload — see the duck-typing note above. */
+  parameters: { retry_after: number }
+  /** The originating GrammyError, or null for a pre-call short-circuit. */
   original: unknown
+}
+
+/** Build the marker with the full Telegram-429 duck-type shape. */
+function makeFloodWaitActiveError(
+  retryAfterSec: number,
+  untilTs: number,
+  original: unknown,
+): FloodWaitActiveError {
+  return Object.assign(new Error(FLOOD_WAIT_ACTIVE), {
+    retryAfterSec,
+    untilTs,
+    error_code: 429 as const,
+    parameters: { retry_after: retryAfterSec },
+    original,
+  })
 }
 
 /** True when `err` is the `FLOOD_WAIT_ACTIVE` marker thrown by `retryApiCall`. */
@@ -173,12 +227,50 @@ export function createRetryApiCall(
   const observer = config.observer
   const log = config.log
   const onFloodWait = config.onFloodWait
+  const floodWaitRemainingMs = config.floodWaitRemainingMs
+
+  /**
+   * Remaining ms of a known-open flood window. FAILS OPEN: any throw from the
+   * probe (unreadable state dir, corrupt JSON, clock weirdness) is treated as
+   * "no window" — a broken marker file must never permanently silence the bot.
+   */
+  function openWindowMs(): number {
+    if (!floodWaitRemainingMs) return 0
+    try {
+      const ms = floodWaitRemainingMs()
+      return Number.isFinite(ms) && ms > 0 ? ms : 0
+    } catch {
+      return 0
+    }
+  }
 
   return async function retryApiCall<T>(
     fn: () => Promise<T>,
     opts?: RetryCallOpts,
   ): Promise<T> {
     for (let attempt = 0; attempt < maxRetries; attempt++) {
+      // #3084 — do not send INTO a known-open long ban. Failing the call fast
+      // (rather than sleeping it) is only safe if the caller can't just turn
+      // around and re-drive it: the card surfaces re-attempt on a 5-6s
+      // heartbeat, which over a 4.6h ban would be thousands of requests into
+      // the open window — the exact ban-extension the #2923 breaker exists to
+      // prevent. So the policy itself refuses to issue the call while the
+      // window is open. The ban is per-bot-TOKEN: nothing can succeed during
+      // it, so short-circuiting loses no delivery that would otherwise land.
+      //
+      // Only LONG windows short-circuit (remaining > the sleep ceiling). A
+      // short window is left to the normal path — it may already have expired
+      // server-side, and today's sleep-and-retry rides it out.
+      const remaining = openWindowMs()
+      if (remaining > maxFloodSleepMs) {
+        const retryAfterSec = Math.ceil(remaining / 1000)
+        log?.(
+          `telegram gateway: flood window still open for ${retryAfterSec}s — ` +
+            `not issuing the ${opts?.verb ?? 'api-call'} (would feed the ban)\n`,
+        )
+        observer?.onGiveUp?.({ attempts: attempt, error: new Error(FLOOD_WAIT_ACTIVE) })
+        throw makeFloodWaitActiveError(retryAfterSec, Date.now() + remaining, null)
+      }
       try {
         return await fn()
       } catch (err) {
@@ -228,11 +320,7 @@ export function createRetryApiCall(
                 `not sleeping it; surfacing degraded state\n`,
             )
             observer?.onGiveUp?.({ attempts: attempt + 1, error: err })
-            throw Object.assign(new Error(FLOOD_WAIT_ACTIVE), {
-              retryAfterSec: retryAfter,
-              untilTs: Date.now() + delayMs,
-              original: err,
-            }) as FloodWaitActiveError
+            throw makeFloodWaitActiveError(retryAfter, Date.now() + delayMs, err)
           }
           log?.(`telegram gateway: 429 rate limited, waiting ${retryAfter}s\n`)
           observer?.onRetry?.({ attempt, reason: 'flood_wait', delayMs })

--- a/telegram-plugin/retry-api-call.ts
+++ b/telegram-plugin/retry-api-call.ts
@@ -268,8 +268,9 @@ export function createRetryApiCall(
           `telegram gateway: flood window still open for ${retryAfterSec}s — ` +
             `not issuing the ${opts?.verb ?? 'api-call'} (would feed the ban)\n`,
         )
-        observer?.onGiveUp?.({ attempts: attempt, error: new Error(FLOOD_WAIT_ACTIVE) })
-        throw makeFloodWaitActiveError(retryAfterSec, Date.now() + remaining, null)
+        const gated = makeFloodWaitActiveError(retryAfterSec, Date.now() + remaining, null)
+        observer?.onGiveUp?.({ attempts: attempt + 1, error: gated })
+        throw gated
       }
       try {
         return await fn()

--- a/telegram-plugin/shared/bot-runtime.ts
+++ b/telegram-plugin/shared/bot-runtime.ts
@@ -29,7 +29,7 @@ import { createHash } from 'crypto'
 import { AsyncLocalStorage } from 'async_hooks'
 import { clearStaleTelegramPollingState } from '../startup-reset.js'
 import { createRetryApiCall } from '../retry-api-call.js'
-import { makeFloodWaitRecorder } from '../flood-circuit-breaker.js'
+import { makeFloodWaitRecorder, makeFloodWaitProbe } from '../flood-circuit-breaker.js'
 import { RICH_MESSAGE_MAX_CHARS } from '../format.js'
 
 // ─── tg-post tag plumbing ─────────────────────────────────────────────────
@@ -156,8 +156,14 @@ export function createRobustApiCall(opts: { floodStatePath?: string } = {}) {
     // #2923: persist every observed 429 flood-wait window so a restart during
     // the ban can suppress non-essential sends (boot cards) instead of feeding
     // the per-bot flood counter and prolonging the ban.
+    // #3084: and refuse to issue a call while that window is still open —
+    // otherwise the card heartbeats re-drive a request into the ban every
+    // few seconds once the policy stops sleeping long waits.
     ...(opts.floodStatePath
-      ? { onFloodWait: makeFloodWaitRecorder(opts.floodStatePath) }
+      ? {
+          onFloodWait: makeFloodWaitRecorder(opts.floodStatePath),
+          floodWaitRemainingMs: makeFloodWaitProbe(opts.floodStatePath),
+        }
       : {}),
   })
 }

--- a/telegram-plugin/tests/boot-card-flood-suppress.test.ts
+++ b/telegram-plugin/tests/boot-card-flood-suppress.test.ts
@@ -11,7 +11,13 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { startBootCard } from '../gateway/boot-card.js'
 import type { BotApiForBootCard } from '../gateway/boot-card.js'
-import { computeFloodWait, writeFloodState, floodStatePath, makeFloodWaitRecorder } from '../flood-circuit-breaker.js'
+import {
+  computeFloodWait,
+  writeFloodState,
+  floodStatePath,
+  makeFloodWaitRecorder,
+  suppressNonEssentialSendMs,
+} from '../flood-circuit-breaker.js'
 import { createRetryApiCall } from '../retry-api-call.js'
 import { errors } from './fake-bot-api.js'
 
@@ -81,9 +87,13 @@ it('POSTS normally when no flood state file exists (back-compat)', async () => {
   expect(sends).toEqual(['chat1'])
 })
 
-it('INTEGRATION: a 429 through the real retry path suppresses a later boot card', async () => {
+it('INTEGRATION: a SHORT 429 through the real retry path suppresses a later boot card', async () => {
   // Wire the two halves exactly as gateway.ts does: the retry wrapper's
   // onFloodWait recorder and the boot card BOTH point at the same file.
+  //
+  // This is the UNDER-ceiling path (#3084): retryApiCall sleeps the wait and
+  // retries, exactly as it always has. The window must still be recorded, and
+  // a restart's boot card must still be suppressed.
   const p = floodStatePath(dir)
   const now = 5_000_000
   const retry = createRetryApiCall({
@@ -91,15 +101,51 @@ it('INTEGRATION: a 429 through the real retry path suppresses a later boot card'
     onFloodWait: makeFloodWaitRecorder(p, () => now),
   })
 
-  // Drive a real GrammyError 429 through the wrapper (first call floods, then
-  // succeeds) — this is what records the window on disk.
   let n = 0
-  await retry(async () => {
-    if (n++ === 0) throw errors.floodWait(4116) // ~68 min ban
+  const out = await retry(async () => {
+    if (n++ === 0) throw errors.floodWait(75) // the historic real-world wait
     return 'ok'
   })
+  expect(out).toBe('ok') // slept and retried — call still succeeded
 
-  // Now a restart's boot card must be suppressed via the SAME file.
+  const { bot, sends } = makeBot()
+  const logs: string[] = []
+  const handle = await startBootCard('chat1', undefined, bot, mkOpts(p, now), undefined, (l) =>
+    logs.push(l),
+  )
+  expect(sends).toEqual([]) // not posted into the open ban window
+  expect(handle.messageId).toBe(-1)
+  expect(logs.join('')).toMatch(/SUPPRESSED/)
+})
+
+it('INTEGRATION: a LONG 429 that FAILS FAST still suppresses a later boot card', async () => {
+  // #3084 changed this path: a ~68min ban is over the in-process sleep ceiling,
+  // so retryApiCall no longer sleeps it — it records the window and THROWS
+  // FLOOD_WAIT_ACTIVE. The behaviour that matters to #2923 is unchanged and is
+  // what this test pins: the window is recorded BEFORE the throw, so a restart
+  // during the ban still suppresses its boot card instead of sending into the
+  // open window and extending the ban.
+  //
+  // If the recording were ever moved below the throw (or skipped on this path),
+  // `sends` would become ['chat1'] and this test goes red — which is exactly
+  // the #2923 regression it exists to catch.
+  const p = floodStatePath(dir)
+  const now = 5_000_000
+  const retry = createRetryApiCall({
+    sleep: async () => {},
+    onFloodWait: makeFloodWaitRecorder(p, () => now),
+  })
+
+  await expect(
+    retry(async () => {
+      throw errors.floodWait(4116) // ~68 min ban — over the ceiling
+    }),
+  ).rejects.toThrow('FLOOD_WAIT_ACTIVE')
+
+  // The window landed on disk despite the throw…
+  expect(suppressNonEssentialSendMs(p, now)).toBe(4116 * 1000)
+
+  // …so the boot card is still suppressed through the SAME file.
   const { bot, sends } = makeBot()
   const logs: string[] = []
   const handle = await startBootCard('chat1', undefined, bot, mkOpts(p, now), undefined, (l) =>

--- a/telegram-plugin/tests/retry-api-call.test.ts
+++ b/telegram-plugin/tests/retry-api-call.test.ts
@@ -15,6 +15,8 @@ import {
   createSwallowingRetryApiCall,
   retryWithThreadFallback,
   isHtmlParseRejectError,
+  isMessageTooLongError,
+  isPhotoDimensionRejectError,
   isLocalResourceError,
   isFloodWaitActiveError,
   LOCAL_RESOURCE_EXHAUSTED,
@@ -781,5 +783,189 @@ describe('#3084 — a long flood ban fails FAST instead of sleeping for hours', 
 
     expect(out).toBeUndefined()
     expect(lines.join('')).toContain(FLOOD_WAIT_ACTIVE)
+  })
+})
+
+describe('#3084 — the fast throw must not become a re-drive amplifier', () => {
+  const REAL_BAN_SEC = 16_739
+
+  /**
+   * EXACT duck-type predicate used by the card surfaces to arm their 429
+   * cooldown — copied verbatim from `worker-activity-feed.ts`
+   * (`extractRetryAfterSecs`) and `issues-card.ts`. They do NOT use
+   * `instanceof GrammyError`. If the marker doesn't satisfy this, they
+   * classify it 'transient', arm no cooldown, and their 5-6s heartbeats
+   * re-drive the send into the open ban.
+   */
+  function extractRetryAfterSecs(err: unknown): number | null {
+    if (err == null || typeof err !== 'object') return null
+    const e = err as { error_code?: unknown; parameters?: { retry_after?: unknown } }
+    if (e.error_code !== 429) return null
+    const ra = e.parameters?.retry_after
+    if (typeof ra === 'number' && Number.isFinite(ra) && ra > 0) return ra
+    return null
+  }
+
+  it('the marker satisfies the card surfaces\' 429 cooldown duck-type', async () => {
+    const retry = createRetryApiCall({ maxRetries: 3, sleep: async () => {} })
+    const err = await retry(async () => {
+      throw errors.floodWait(REAL_BAN_SEC)
+    }).catch((e: unknown) => e)
+
+    // worker-activity-feed / issues-card would now arm a FULL-window cooldown
+    // instead of treating this as a generic 'transient' error.
+    expect(extractRetryAfterSecs(err)).toBe(REAL_BAN_SEC)
+  })
+
+  it('the marker is still NOT a GrammyError (resend-fallback probes must not match)', async () => {
+    const retry = createRetryApiCall({ maxRetries: 3, sleep: async () => {} })
+    const err = await retry(async () => {
+      throw errors.floodWait(REAL_BAN_SEC)
+    }).catch((e: unknown) => e)
+
+    expect(err).not.toBeInstanceOf(GrammyError)
+    expect(isHtmlParseRejectError(err)).toBe(false)
+    expect(isMessageTooLongError(err)).toBe(false)
+    expect(isPhotoDimensionRejectError(err)).toBe(false)
+  })
+
+  it('a card heartbeat ticking across the whole 4.6h ban issues ONE Bot API call', async () => {
+    // The regression that must be impossible. Before the pre-call gate: the
+    // marker throws in ~1ms, the 6s heartbeat re-drives, and we fire ~2,760
+    // fresh requests into the still-open per-bot ban — feeding the exact flood
+    // counter #2923 exists to starve. Strictly worse than the original hang.
+    let now = 1_000_000
+    let state: { untilTs: number } | null = null
+    let apiCalls = 0
+
+    const retry = createRetryApiCall({
+      maxRetries: 3,
+      sleep: async () => {},
+      // The #2923 breaker: record the window...
+      onFloodWait: (sec) => {
+        state = { untilTs: now + sec * 1000 }
+      },
+      // ...and the #3084 gate: refuse to send into it.
+      floodWaitRemainingMs: () => (state ? Math.max(0, state.untilTs - now) : 0),
+    })
+
+    const HEARTBEAT_MS = 6_000
+    const ticks = Math.ceil((REAL_BAN_SEC * 1000) / HEARTBEAT_MS) // ~2,790
+    let markerThrows = 0
+
+    for (let i = 0; i < ticks; i++) {
+      // A worker-feed style heartbeat: best-effort edit, swallow failures,
+      // and (deliberately, to model the WORST case) arm no cooldown of its own.
+      await retry(async () => {
+        apiCalls++
+        throw errors.floodWait(REAL_BAN_SEC)
+      }).catch((e: unknown) => {
+        if (isFloodWaitActiveError(e)) markerThrows++
+      })
+      now += HEARTBEAT_MS
+    }
+
+    expect(ticks).toBeGreaterThan(2_700) // we really did simulate the full ban
+    expect(markerThrows).toBe(ticks) // every tick got a clean degraded state
+    // …and the Bot API was touched a HANDFUL of times, not once per tick.
+    // Without the pre-call gate this is ~2,790 requests fired into an open
+    // per-bot ban. With it: the first tick (which discovers the ban) plus the
+    // few tail ticks that run after the simulated window has elapsed and
+    // legitimately re-probe. Bounded and small is the whole contract.
+    expect(apiCalls).toBeLessThanOrEqual(5)
+    expect(apiCalls).toBeGreaterThanOrEqual(1)
+    expect(apiCalls / ticks).toBeLessThan(0.01) // <1% of ticks reach the API
+  })
+
+  it('resumes issuing calls once the window expires (the gate is not a latch)', async () => {
+    let now = 1_000_000
+    let state: { untilTs: number } | null = null
+    let apiCalls = 0
+
+    const retry = createRetryApiCall({
+      maxRetries: 3,
+      sleep: async () => {},
+      onFloodWait: (sec) => {
+        state = { untilTs: now + sec * 1000 }
+      },
+      floodWaitRemainingMs: () => (state ? Math.max(0, state.untilTs - now) : 0),
+    })
+
+    await expect(
+      retry(async () => {
+        apiCalls++
+        throw errors.floodWait(300)
+      }),
+    ).rejects.toThrow(FLOOD_WAIT_ACTIVE)
+    expect(apiCalls).toBe(1)
+
+    // Mid-window: gated, no call.
+    now += 100_000
+    await expect(retry(async () => 'ok')).rejects.toThrow(FLOOD_WAIT_ACTIVE)
+    expect(apiCalls).toBe(1)
+
+    // Window expired: the very next call goes through and succeeds.
+    now += 300_000
+    expect(
+      await retry(async () => {
+        apiCalls++
+        return 'ok'
+      }),
+    ).toBe('ok')
+    expect(apiCalls).toBe(2)
+  })
+
+  it('a SHORT open window is not short-circuited (sleep-and-retry still rides it out)', async () => {
+    // A 30s window is under the ceiling: the normal path may still succeed
+    // (the server may have cleared it), so we must NOT gate it.
+    let apiCalls = 0
+    let n = 0
+    const retry = createRetryApiCall({
+      maxRetries: 3,
+      sleep: async () => {},
+      floodWaitRemainingMs: () => 30_000,
+    })
+    const out = await retry(async () => {
+      apiCalls++
+      if (n++ === 0) throw errors.floodWait(30)
+      return 'ok'
+    })
+    expect(out).toBe('ok')
+    expect(apiCalls).toBe(2)
+  })
+
+  it('FAILS OPEN — a throwing/garbage flood probe never silences the bot', async () => {
+    const throwing = createRetryApiCall({
+      maxRetries: 3,
+      sleep: async () => {},
+      floodWaitRemainingMs: () => {
+        throw new Error('EACCES: unreadable flood-wait.json')
+      },
+    })
+    expect(await throwing(async () => 'ok')).toBe('ok')
+
+    // Garbage from a corrupt marker file must be treated as "no window".
+    // Infinity in particular would otherwise mute the bot forever.
+    for (const garbage of [NaN, -1, 0, Infinity]) {
+      const retry = createRetryApiCall({
+        maxRetries: 3,
+        sleep: async () => {},
+        floodWaitRemainingMs: () => garbage,
+      })
+      expect(await retry(async () => 'ok')).toBe('ok')
+    }
+  })
+
+  it('with no flood probe wired at all, behaviour is exactly as before', async () => {
+    let apiCalls = 0
+    let n = 0
+    const retry = createRetryApiCall({ maxRetries: 3, sleep: async () => {} })
+    const out = await retry(async () => {
+      apiCalls++
+      if (n++ === 0) throw errors.floodWait(30)
+      return 'ok'
+    })
+    expect(out).toBe('ok')
+    expect(apiCalls).toBe(2)
   })
 })

--- a/telegram-plugin/tests/retry-api-call.test.ts
+++ b/telegram-plugin/tests/retry-api-call.test.ts
@@ -16,7 +16,11 @@ import {
   retryWithThreadFallback,
   isHtmlParseRejectError,
   isLocalResourceError,
+  isFloodWaitActiveError,
   LOCAL_RESOURCE_EXHAUSTED,
+  FLOOD_WAIT_ACTIVE,
+  DEFAULT_MAX_FLOOD_SLEEP_MS,
+  type FloodWaitActiveError,
   type RetryObserver,
 } from '../retry-api-call.js'
 import { errors, makeGrammyError } from './fake-bot-api.js'
@@ -569,5 +573,213 @@ describe('#2923 — LOCAL resource exhaustion is NOT retried (avoids flood ban)'
     })
     expect(out).toBe('ok')
     expect(seen).toEqual([42])
+  })
+})
+
+describe('#3084 — a long flood ban fails FAST instead of sleeping for hours', () => {
+  /**
+   * Deterministic fake clock: `sleep` never waits, it just advances a counter.
+   * Nothing here touches a real timer, so "did we try to sleep 4.6 hours?" is
+   * an assertion on the fake clock, not a stopwatch.
+   */
+  function fakeClock() {
+    let elapsedMs = 0
+    const slept: number[] = []
+    return {
+      get elapsedMs() {
+        return elapsedMs
+      },
+      slept,
+      sleep: async (ms: number) => {
+        slept.push(ms)
+        elapsedMs += ms
+      },
+    }
+  }
+
+  // The real value overlord's gateway logged on 2026-07-11.
+  const REAL_BAN_SEC = 16_739
+
+  it('does NOT sleep a 4.6-hour retry_after (clock never advances past the ceiling)', async () => {
+    const clock = fakeClock()
+    let calls = 0
+    const retry = createRetryApiCall({ maxRetries: 3, sleep: clock.sleep })
+
+    await expect(
+      retry(async () => {
+        calls++
+        throw errors.floodWait(REAL_BAN_SEC)
+      }),
+    ).rejects.toThrow(FLOOD_WAIT_ACTIVE)
+
+    expect(calls).toBe(1) // failed fast on the first 429 — no retry storm
+    expect(clock.slept).toEqual([]) // never even attempted the sleep
+    expect(clock.elapsedMs).toBe(0)
+    expect(clock.elapsedMs).toBeLessThanOrEqual(DEFAULT_MAX_FLOOD_SLEEP_MS)
+  })
+
+  it('carries retry_after / untilTs / original on the thrown marker', async () => {
+    const clock = fakeClock()
+    const before = Date.now()
+    const retry = createRetryApiCall({ maxRetries: 3, sleep: clock.sleep })
+
+    const err = await retry(async () => {
+      throw errors.floodWait(REAL_BAN_SEC)
+    }).catch((e: unknown) => e)
+
+    expect(isFloodWaitActiveError(err)).toBe(true)
+    const flood = err as FloodWaitActiveError
+    expect(flood.retryAfterSec).toBe(REAL_BAN_SEC)
+    expect(flood.untilTs).toBeGreaterThanOrEqual(before + REAL_BAN_SEC * 1000)
+    expect(flood.original).toBeInstanceOf(GrammyError)
+  })
+
+  it('STILL records the flood window via onFloodWait before throwing (#2923 breaker)', async () => {
+    const clock = fakeClock()
+    const seen: number[] = []
+    const order: string[] = []
+    const retry = createRetryApiCall({
+      maxRetries: 3,
+      sleep: clock.sleep,
+      onFloodWait: (s) => {
+        seen.push(s)
+        order.push('recorded')
+      },
+      observer: {
+        onGiveUp: () => {
+          order.push('gave_up')
+        },
+      },
+    })
+
+    await expect(
+      retry(async () => {
+        throw errors.floodWait(REAL_BAN_SEC)
+      }),
+    ).rejects.toThrow(FLOOD_WAIT_ACTIVE)
+
+    // The breaker MUST learn about the window — that is what suppresses the
+    // restart boot-card that would otherwise extend the ban.
+    expect(seen).toEqual([REAL_BAN_SEC])
+    expect(order).toEqual(['recorded', 'gave_up'])
+  })
+
+  it('a throwing onFloodWait hook still yields the marker, not the hook error', async () => {
+    const clock = fakeClock()
+    const retry = createRetryApiCall({
+      maxRetries: 3,
+      sleep: clock.sleep,
+      onFloodWait: () => {
+        throw new Error('disk full while persisting flood state')
+      },
+    })
+    await expect(
+      retry(async () => {
+        throw errors.floodWait(REAL_BAN_SEC)
+      }),
+    ).rejects.toThrow(FLOOD_WAIT_ACTIVE)
+  })
+
+  it('a SHORT retry_after under the ceiling still sleeps-and-retries and succeeds', async () => {
+    const clock = fakeClock()
+    let n = 0
+    const retry = createRetryApiCall({ maxRetries: 3, sleep: clock.sleep })
+
+    // 30s — the everyday rate-limit blip. Behaviour must be unchanged.
+    const out = await retry(async () => {
+      if (n++ === 0) throw errors.floodWait(30)
+      return 'ok'
+    })
+
+    expect(out).toBe('ok')
+    expect(n).toBe(2)
+    expect(clock.slept).toEqual([30_000])
+  })
+
+  it('the historic 28s and 75s waits are still slept through (no regression)', async () => {
+    for (const sec of [28, 75]) {
+      const clock = fakeClock()
+      let n = 0
+      const retry = createRetryApiCall({ maxRetries: 3, sleep: clock.sleep })
+      const out = await retry(async () => {
+        if (n++ === 0) throw errors.floodWait(sec)
+        return 'ok'
+      })
+      expect(out).toBe('ok')
+      expect(clock.slept).toEqual([sec * 1000])
+    }
+  })
+
+  it('sleeps exactly AT the ceiling, throws just above it', async () => {
+    const atCeiling = DEFAULT_MAX_FLOOD_SLEEP_MS / 1000
+
+    const clockAt = fakeClock()
+    let n = 0
+    const retryAt = createRetryApiCall({ maxRetries: 3, sleep: clockAt.sleep })
+    expect(
+      await retryAt(async () => {
+        if (n++ === 0) throw errors.floodWait(atCeiling)
+        return 'ok'
+      }),
+    ).toBe('ok')
+    expect(clockAt.slept).toEqual([DEFAULT_MAX_FLOOD_SLEEP_MS])
+
+    const clockOver = fakeClock()
+    const retryOver = createRetryApiCall({ maxRetries: 3, sleep: clockOver.sleep })
+    await expect(
+      retryOver(async () => {
+        throw errors.floodWait(atCeiling + 1)
+      }),
+    ).rejects.toThrow(FLOOD_WAIT_ACTIVE)
+    expect(clockOver.slept).toEqual([])
+  })
+
+  it('honours a caller-supplied maxFloodSleepMs ceiling', async () => {
+    const clock = fakeClock()
+    const retry = createRetryApiCall({
+      maxRetries: 3,
+      sleep: clock.sleep,
+      maxFloodSleepMs: 5_000,
+    })
+    // 30s would sleep under the DEFAULT ceiling; with a 5s ceiling it throws.
+    await expect(
+      retry(async () => {
+        throw errors.floodWait(30)
+      }),
+    ).rejects.toThrow(FLOOD_WAIT_ACTIVE)
+    expect(clock.slept).toEqual([])
+  })
+
+  it('maxRetries semantics unchanged for sustained SHORT floods', async () => {
+    const clock = fakeClock()
+    let calls = 0
+    const retry = createRetryApiCall({ maxRetries: 3, sleep: clock.sleep })
+
+    await expect(
+      retry(async () => {
+        calls++
+        throw errors.floodWait(10)
+      }),
+    ).rejects.toThrow('retryApiCall: max retries exceeded')
+
+    expect(calls).toBe(3)
+    expect(clock.slept).toEqual([10_000, 10_000, 10_000])
+  })
+
+  it('the swallowing wrapper absorbs the marker (no unhandled rejection)', async () => {
+    const clock = fakeClock()
+    const lines: string[] = []
+    const retry = createRetryApiCall({ maxRetries: 3, sleep: clock.sleep })
+    const swallow = createSwallowingRetryApiCall(retry, (l) => lines.push(l))
+
+    const out = await swallow(
+      async () => {
+        throw errors.floodWait(REAL_BAN_SEC)
+      },
+      { verb: 'sendMessage' },
+    )
+
+    expect(out).toBeUndefined()
+    expect(lines.join('')).toContain(FLOOD_WAIT_ACTIVE)
   })
 })

--- a/telegram-plugin/tests/unhandled-rejection-policy.test.ts
+++ b/telegram-plugin/tests/unhandled-rejection-policy.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect } from 'bun:test'
 import { GrammyError } from 'grammy'
 import { classifyRejection } from '../gateway/unhandled-rejection-policy.js'
+import { FLOOD_WAIT_ACTIVE } from '../retry-api-call.js'
 
 // ── Real GrammyError fixtures ──────────────────────────────────────────────
 
@@ -219,5 +220,24 @@ describe('classifyRejection — duck typing via injected detector', () => {
       isGrammyError: () => false,
     })
     expect(result).toBe('shutdown')
+  })
+})
+
+describe('classifyRejection — FLOOD_WAIT_ACTIVE marker (#3084)', () => {
+  // retry-api-call throws this instead of sleeping through a multi-hour per-bot
+  // flood ban (overlord logged retry_after = 16739s on 2026-07-11). It's a plain
+  // Error, not a GrammyError, so without an explicit entry it would fall into
+  // the `!isGrammy → shutdown` branch — a crash on rate-limiting, which fires
+  // MORE sends into the open window on reboot and extends the ban.
+  it('returns "log_only" for a leaked FLOOD_WAIT_ACTIVE marker', () => {
+    const err = Object.assign(new Error(FLOOD_WAIT_ACTIVE), {
+      retryAfterSec: 16739,
+      untilTs: Date.now() + 16739 * 1000,
+    })
+    expect(classifyRejection(err)).toBe('log_only')
+  })
+
+  it('still returns "shutdown" for an unrelated plain Error', () => {
+    expect(classifyRejection(new Error('FLOOD_WAIT_ACTIVE-ish but not it'))).toBe('shutdown')
   })
 })


### PR DESCRIPTION
## Summary

`retryApiCall`'s 429 branch slept `retry_after` seconds unbounded. On 2026-07-11 `overlord` hit a real Telegram per-bot flood ban with `retry_after = 16739s` (~4.6 hours) — logged in `gateway-supervisor.log` — so the send path did `await sleep(16_739_000)` and parked itself, plus every caller awaiting it, for hours. With `maxRetries = 3` that compounds. A latent wedge primitive.

The fix is in three parts. Parts 2 and 3 exist because **making the throw fast, on its own, is worse than the bug** — see below.

**1. Bound the in-process sleep.** New `maxFloodSleepMs`, default `DEFAULT_MAX_FLOOD_SLEEP_MS = 120_000`. Over the ceiling: the flood window is **still recorded via `onFloodWait`** (the #2923 breaker depends on it), then a non-retryable `FLOOD_WAIT_ACTIVE` marker is thrown — same shape as the existing `LOCAL_RESOURCE_EXHAUSTED` path. At or under the ceiling: unchanged sleep-and-retry.

**2. The marker carries Telegram's own 429 shape.** `worker-activity-feed.ts` (`extractRetryAfterSecs`), `issues-card.ts` (identical), and `pending-work-progress.ts` all duck-type their rate-limit cooldown on `error_code === 429` + `parameters.retry_after` — **not** on `instanceof GrammyError` — and all three route through `robustApiCall`. A marker without those fields classifies as generic `'transient'`, arms **no cooldown**, and their heartbeats (6s / 6s / 5s) re-drive a fresh Bot API call into the still-open ban: **~2,700 requests over a 4.6h window**, feeding the exact flood counter #2923 exists to starve. So the marker carries `error_code: 429` and `parameters: { retry_after }` and the existing gates fire on the full window with zero change to those modules. It remains a plain `Error`, so the `instanceof`-based resend-fallback probes (`isHtmlParseRejectError` / `isMessageTooLongError` / `isPhotoDimensionRejectError`) still correctly do not match it.

**3. Durable: the policy refuses to SEND INTO an open window.** `createRetryApiCall` now takes a `floodWaitRemainingMs` probe (`makeFloodWaitProbe`, wired to the #2923 breaker state file in `gateway.ts` and `bot-runtime.ts`). While a **long** window is open it short-circuits *before* issuing the call. This protects every caller, including ones neither the reviewer nor I found — point 2 alone only fixes the three loops we know about. The ban is per-bot-**token**: nothing can succeed while it's open, so short-circuiting loses no delivery that would otherwise land. **Fails open** — missing, corrupt, `NaN`/`Infinity`, or throwing probe all mean "no window, proceed"; a broken marker file must never permanently silence the bot. Short windows are not gated (they may already have cleared server-side; today's sleep-and-retry rides them out).

**4. `classifyRejection` → `log_only` for a leaked `FLOOD_WAIT_ACTIVE`.** The marker is a plain `Error`, so it would otherwise hit `!isGrammy → shutdown` and crash the gateway on rate-limiting — the opposite of the posture that file already takes for `GrammyError` 429, and a crash-restart fires more sends into the open window.

## Why 120s (not 30-60s)

Two-sided. The flood-waits this bot has historically ridden out successfully were **28s and 75s** — sleeping through those is right and must not regress, so the ceiling must sit above 75s with headroom. On the other side the ban being guarded against is hours. 120s bounds the worst-case in-process block to `maxRetries × 120s` (6 min at the default 3) instead of 4.6h+. Configurable per instance.

PR #3092 (`feat/telegram-send-gate`) does **not** address this: it touches `retry-api-call.ts` only to add optional `RetryCallOpts` fields, and its own body states the retry policy ignores them. Independent and additive.

## Job spec

`reference/jobs/survive-reboots-and-real-life.md` (serves **always-available**) — but claimed honestly: this diff delivers the *"transient failures ... work resumes"* half, **not** the *"never left in silence"* half. `isFloodWaitActiveError` has no production consumer yet; `createSwallowingRetryApiCall` logs and returns `undefined`, so the operator still gets silence — just fast silence instead of a 4.6h hang, and without a self-inflicted ban extension. Surfacing a user-visible degraded state ("rate-limited by Telegram until HH:MM") is the follow-up the marker's payload (`retryAfterSec` / `untilTs`) is designed to feed; I did not want to smuggle a UX surface into a wedge fix.

## Test plan

`telegram-plugin/tests/retry-api-call.test.ts` — **54 passed** (37 pre-existing, all green + 17 new across two blocks; deterministic injected fake clock, no real timers):

*Ceiling / marker*
- a 16739s `retry_after` does **not** sleep — fake clock never advances (`slept === []`), fails on the first attempt, throws `FLOOD_WAIT_ACTIVE`
- marker carries `retryAfterSec` / `untilTs` / `original`; `onFloodWait` **is** fired before the throw (asserted on ordering: `recorded` then `gave_up`); a throwing hook still yields the marker
- a 30s wait still sleeps-and-retries and succeeds; the historic **28s and 75s** waits still sleep through; boundary — sleeps exactly at the ceiling, throws one second above; caller `maxFloodSleepMs` honoured; `maxRetries` semantics unchanged (3 calls, 3 sleeps, `max retries exceeded`); swallowing wrapper absorbs the marker

*Anti-amplifier (the regression that must be impossible)*
- **a card heartbeat ticking across the whole 4.6h ban issues ≤5 Bot API calls, not ~2,790**: 2,790 six-second ticks against an open window, modelling the worst case (a caller that arms no cooldown of its own). Asserts `apiCalls <= 5` and `apiCalls / ticks < 1%`; every tick still gets a clean degraded state
- the marker satisfies the card surfaces' exact 429 cooldown duck-type (predicate copied verbatim from `worker-activity-feed.ts` / `issues-card.ts`)
- the marker is still not a `GrammyError`; the three resend-fallback probes don't match it
- the gate is not a latch — calls resume the moment the window expires
- a **short** open window is not short-circuited
- **fails open** — throwing probe, `NaN`, `-1`, `0`, `Infinity` all proceed with the call
- with no probe wired at all, behaviour is byte-for-byte as before

`telegram-plugin/tests/unhandled-rejection-policy.test.ts` (bun suite) — **24 passed**; leaked marker is `log_only`, unrelated plain `Error` still `shutdown`.

`npm run lint` → clean (tsc + all 8 guards).

## Risk

Low, with two deliberate behaviour changes stated plainly:

- **Dropped-message band.** For `retry_after` in (120s, ∞) where the flood *would* eventually have cleared, the send is now **dropped** where it previously (eventually) delivered. There is no store-and-forward requeue. This is the intended trade — the alternative is holding the send path hostage for the full window — but it is a real delivery loss in that band, not a free win.
- **Sends are refused while a long window is open**, including would-be-essential ones. They could not have succeeded anyway (per-bot-token ban), so nothing that would have landed is lost.

Under-ceiling behaviour is bit-for-bit unchanged. The `onFloodWait` / #2923 contract is strictly preserved — the window is recorded on **every** 429, over-ceiling included. Callers route through `createSwallowingRetryApiCall` (logs + `undefined`) or handle thrown markers, and the unhandled-rejection policy makes a leak log-only rather than a crash.

Follow-up filed: #3099 (`LOCAL_RESOURCE_EXHAUSTED` has the identical leak-to-`shutdown` hazard — pre-existing, out of scope here).

Refs #3084