### PR TITLE
fix(telegram): rate-limit the subagent-watcher deferral log (#3092)

### DIFF
--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -2050,6 +2050,19 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       existing.stallNotified = false
       existing.stalledAt = null
       existing.stallTerminalSynthesised = false
+      // Re-arm the deferral log gate alongside its stall siblings (#3092).
+      // Unreachable with stale state TODAY (both routes out of the deferred
+      // state to `done` — the cap-crossing and the un-stall drain — already
+      // null `deferralLoggedAt`), so this is belt-and-braces, not a live fix.
+      // Reset it here anyway: a resurrected entry must be indistinguishable
+      // from a fresh one, so a genuinely NEW stall always logs its FIRST
+      // deferral line immediately. Leaving these to a reachability argument
+      // makes the gate fragile by construction — a later reorder of the drain,
+      // or a third path to `done`, would silently suppress that first line for
+      // up to `deferralLogIntervalMs`, losing the exact signal this gate
+      // exists to preserve.
+      existing.deferralLoggedAt = null
+      existing.deferralSuppressedTicks = 0
       // Re-arm the completion notification INTENTIONALLY (issue #3023). The
       // false synthesized finish already fired `onFinish` once, delivering a
       // (possibly wrong / incomplete) synthesized handback to the parent.

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -156,6 +156,25 @@ export interface WorkerEntry {
    */
   inflightToolUseIds: Set<string>
   /**
+   * Wall-clock ms of the most recent EMITTED "terminal synthesis deferred"
+   * log line for this entry, or null if the entry is not currently in the
+   * deferred state (never entered it, or resumed out of it). Drives the
+   * per-worker log rate-limit (#3092): null ⇒ this is a fresh entry into the
+   * deferred state and MUST log; non-null ⇒ log only once
+   * `deferralLogIntervalMs` has elapsed. Reset to null on the un-stall path
+   * so a stall → resume → stall cycle logs its first deferral again.
+   */
+  deferralLoggedAt: number | null
+  /**
+   * Count of deferral ticks whose log line was SUPPRESSED by the rate-limit
+   * since this entry entered the deferred state (#3092). Carried into the
+   * next emitted line (and into the resume / cap-crossing transition lines)
+   * so the suppression is itself visible and the operator can see the true
+   * tick volume without reading 1,547 lines. Reset alongside
+   * `deferralLoggedAt`.
+   */
+  deferralSuppressedTicks: number
+  /**
    * True if the underlying JSONL file existed before the watcher started.
    * Historical entries are tracked for late state transitions but are
    * excluded from the active-workers card — the sub-agent process is long
@@ -330,6 +349,22 @@ export interface SubagentWatcherConfig {
    * `SWITCHROOM_SUBAGENT_INFLIGHT_TERMINAL_CAP_MS`.
    */
   inflightTerminalCapMs?: number
+  /**
+   * Rate-limit (ms) on the repeated "terminal synthesis deferred" log line
+   * for a single worker (#3092). The deferral decision is re-evaluated on
+   * every ~1s rescan tick; without this gate each re-evaluation logged,
+   * emitting ~1 line/sec for as long as the worker stayed blocked (1,547
+   * lines in 35 min on the live overlord gateway, drowning the concurrent
+   * 429 flood-ban lines of #3084).
+   *
+   * Semantics: the FIRST tick that enters the deferred state always logs;
+   * subsequent ticks log only once this many ms have passed since the last
+   * emitted line. State CHANGES are never suppressed — the cap-crossing
+   * ("proceeding with terminal synthesis") and the resume/un-stall lines
+   * fire regardless. Default 60_000 (1 min). Env override
+   * `SWITCHROOM_SUBAGENT_DEFERRAL_LOG_INTERVAL_MS`.
+   */
+  deferralLogIntervalMs?: number
   /**
    * Freshness window (ms) for promoting a running-at-boot worker file to
    * live. A file whose last write (mtime) is older than this is treated as
@@ -600,6 +635,16 @@ const DEFAULT_SILENT_STALL_TERMINAL_MS = 300_000
 // reaper TTL, so the watcher — not the reaper — still owns the terminal
 // transition for a worker that died mid-tool.
 const DEFAULT_INFLIGHT_TERMINAL_CAP_MS = 45 * 60_000
+// Minimum wall-clock gap between two "terminal synthesis deferred" log lines
+// for the SAME worker (#3092). `checkStalls` runs on the ~1s rescan tick, and
+// the deferral is re-evaluated (and, before this gate, re-logged) on every one
+// of them. A single worker legitimately blocked inside a long tool call
+// produced 1,547 near-identical lines in 35 minutes on the overlord gateway,
+// burying the concurrent Telegram 429 flood-ban lines (#3084). The DECISION is
+// re-made every tick — only the LOGGING is rate-limited: first entry into the
+// deferred state logs immediately, then at most once per this interval, and
+// every state CHANGE (resume, cap-crossing) logs unconditionally.
+const DEFAULT_DEFERRAL_LOG_INTERVAL_MS = 60_000
 
 /**
  * Tools that legitimately run for minutes with ZERO intervening JSONL
@@ -1183,6 +1228,18 @@ export function readSubTail(
               log?.(`subagent-watcher: onUnstall callback error ${entry.agentId}: ${(cbErr as Error).message}`)
             }
           }
+          // STATE CHANGE out of the deferred state (#3092) — never rate-
+          // limited. A worker that was deferring terminal synthesis behind an
+          // in-flight tool call has RESURRECTED; that transition is the
+          // payoff of the deferral and must be visible even though the
+          // intervening per-tick deferral lines were suppressed. Report the
+          // suppressed volume so the quiet window is accounted for, then
+          // re-arm so a subsequent re-stall logs its first deferral again.
+          if (entry.deferralLoggedAt != null) {
+            log?.(`subagent-watcher: in-flight deferral resolved for ${entry.agentId} (worker resumed after ${idleSecBeforeBump}s idle — deferral was correct, not a dead worker; ${entry.deferralSuppressedTicks} deferral tick(s) suppressed since the last deferral line)`)
+            entry.deferralLoggedAt = null
+            entry.deferralSuppressedTicks = 0
+          }
           log?.(`subagent-watcher: stall cleared for ${entry.agentId} (activity resumed after ${idleSecBeforeBump}s — re-arming detection)`)
         }
         if (ev.kind === 'sub_agent_model') {
@@ -1457,6 +1514,10 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     config.inflightTerminalCapMs
     ?? parseEnvMs('SWITCHROOM_SUBAGENT_INFLIGHT_TERMINAL_CAP_MS')
     ?? DEFAULT_INFLIGHT_TERMINAL_CAP_MS
+  const deferralLogIntervalMs =
+    config.deferralLogIntervalMs
+    ?? parseEnvMs('SWITCHROOM_SUBAGENT_DEFERRAL_LOG_INTERVAL_MS')
+    ?? DEFAULT_DEFERRAL_LOG_INTERVAL_MS
   const inflightPromoteMaxAgeMs =
     config.inflightPromoteMaxAgeMs
     ?? parseEnvMs('SWITCHROOM_SUBAGENT_INFLIGHT_MAX_AGE_MS')
@@ -1603,6 +1664,8 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       stalledAt: null,
       completionNotified: false,
       stallTerminalSynthesised: false,
+      deferralLoggedAt: null,
+      deferralSuppressedTicks: 0,
       lastSummaryLine: '',
       lastResultText: '',
       lastProgressBucketIdx: null,
@@ -2212,10 +2275,34 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       if (entry.inflightToolUseIds.size > 0) {
         const totalIdleMs = n - entry.lastActivityAt
         if (totalIdleMs < inflightTerminalCapMs) {
-          log?.(`subagent-watcher: silent-stall terminal synthesis deferred for ${entry.agentId} — ${entry.inflightToolUseIds.size} tool call(s) still in flight, ${Math.floor(totalIdleMs / 1000)}s idle < ${Math.floor(inflightTerminalCapMs / 1000)}s cap (long-running tool, not a dead worker)`)
+          // Log-rate gate (#3092). The deferral DECISION above is re-made on
+          // every ~1s rescan tick and is correct; only its LOGGING is gated.
+          // Emit on first entry into the deferred state, then at most once per
+          // `deferralLogIntervalMs`. Everything else is counted, not printed —
+          // the suppressed count rides the next emitted line so no volume is
+          // lost, just the 1/sec repetition (1,547 lines / 35 min on overlord,
+          // burying the concurrent #3084 flood-ban lines).
+          const lastLoggedAt = entry.deferralLoggedAt
+          const firstEntry = lastLoggedAt == null
+          if (firstEntry || n - lastLoggedAt >= deferralLogIntervalMs) {
+            const suppressed = entry.deferralSuppressedTicks
+            const suffix = firstEntry
+              ? ` — further deferral ticks for this worker are rate-limited to 1 line / ${Math.floor(deferralLogIntervalMs / 1000)}s until it resumes or crosses the cap`
+              : ` — still deferred (${suppressed} tick(s) suppressed since the last line)`
+            log?.(`subagent-watcher: silent-stall terminal synthesis deferred for ${entry.agentId} — ${entry.inflightToolUseIds.size} tool call(s) still in flight, ${Math.floor(totalIdleMs / 1000)}s idle < ${Math.floor(inflightTerminalCapMs / 1000)}s cap (long-running tool, not a dead worker)${suffix}`)
+            entry.deferralLoggedAt = n
+            entry.deferralSuppressedTicks = 0
+          } else {
+            entry.deferralSuppressedTicks++
+          }
           continue
         }
-        log?.(`subagent-watcher: in-flight deferral cap reached for ${entry.agentId} (${Math.floor(totalIdleMs / 1000)}s idle >= ${Math.floor(inflightTerminalCapMs / 1000)}s cap with ${entry.inflightToolUseIds.size} tool call(s) still unresolved) — treating as died-mid-tool, proceeding with terminal synthesis`)
+        // STATE CHANGE — never rate-limited. The deferral ends here and a
+        // terminal synthesis fires; this is the transition an operator needs.
+        const suppressedTotal = entry.deferralSuppressedTicks
+        log?.(`subagent-watcher: in-flight deferral cap reached for ${entry.agentId} (${Math.floor(totalIdleMs / 1000)}s idle >= ${Math.floor(inflightTerminalCapMs / 1000)}s cap with ${entry.inflightToolUseIds.size} tool call(s) still unresolved) — treating as died-mid-tool, proceeding with terminal synthesis (${suppressedTotal} deferral tick(s) suppressed since the last deferral line)`)
+        entry.deferralLoggedAt = null
+        entry.deferralSuppressedTicks = 0
       }
       // TODO(#3023/PR #3029): the cap-reached path above is a SECOND source of
       // possibly-false terminal synthesis (a worker mid-very-long-tool that is

--- a/telegram-plugin/tests/subagent-watcher-deferral-log-ratelimit.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-deferral-log-ratelimit.test.ts
@@ -1,0 +1,316 @@
+/**
+ * #3092 — the "silent-stall terminal synthesis deferred" line must not be
+ * re-emitted on every rescan tick.
+ *
+ * `checkStalls()` runs on the ~1s rescan interval and re-evaluates the
+ * in-flight deferral every time. The DECISION is correct (a worker inside a
+ * long `Bash` is alive, not dead, and must not have its card finalised) — but
+ * before this gate the decision was also RE-LOGGED every tick. Observed on the
+ * live overlord gateway 2026-07-11: 1,547 near-identical lines in ~35 minutes
+ * for a single worker id, differing only in the idle-seconds counter, while
+ * the gateway was concurrently hitting real Telegram 429 flood bans (#3084)
+ * whose lines were buried in the spam.
+ *
+ * Contract asserted here:
+ *   - first entry into the deferred state logs immediately (diagnosability),
+ *   - subsequent ticks are rate-limited to 1 line / `deferralLogIntervalMs`,
+ *   - the cap-crossing STATE CHANGE (deferral → terminal synthesis) always
+ *     logs,
+ *   - the resume STATE CHANGE (worker resurrects) always logs,
+ *   - the emitted lines still carry worker id / in-flight count / idle / cap.
+ *
+ * Deterministic fake clock + injected setInterval — no real timers.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { startSubagentWatcher } from '../subagent-watcher.js'
+import * as fs from 'fs'
+
+function buildJSONL(...lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join('\n') + '\n'
+}
+function subAgentUserMsg(promptText: string) {
+  return { type: 'user', message: { content: [{ type: 'text', text: promptText }] } }
+}
+/** An assistant tool_use with no matching tool_result → the tool call is IN FLIGHT. */
+function bashToolUse(id: string) {
+  return { type: 'assistant', message: { content: [{ type: 'tool_use', id, name: 'Bash', input: { command: 'npm test' } }] } }
+}
+/** The matching tool_result — drains the in-flight set and resurrects the worker. */
+function bashToolResult(id: string) {
+  return { type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: id, content: 'ok' }] } }
+}
+
+const DEFERRED_RE = /silent-stall terminal synthesis deferred/
+const CAP_RE = /in-flight deferral cap reached/
+const RESOLVED_RE = /in-flight deferral resolved/
+
+function makeHarness(opts: {
+  agentId?: string
+  deferralLogIntervalMs?: number
+  inflightTerminalCapMs?: number
+} = {}) {
+  const {
+    agentId = 'a732f61196738da7d', // the real (synthetic-safe) worker id shape from the incident
+    deferralLogIntervalMs,
+    inflightTerminalCapMs = 2_700_000, // 45 min — the cap in the incident log
+  } = opts
+
+  let currentTime = 1000
+  const logs: string[] = []
+
+  const agentDir = '/home/user/.switchroom/agents/myagent'
+  const sessionId = 'mock-session'
+  const projectsRoot = `${agentDir}/.claude/projects`
+  const projectDir = `${projectsRoot}/mock-cwd`
+  const sessionDir = `${projectDir}/${sessionId}`
+  const subagentsDir = `${sessionDir}/subagents`
+  const jsonlPath = `${subagentsDir}/agent-${agentId}.jsonl`
+  const fileContents = new Map<string, Buffer>()
+  fileContents.set(
+    jsonlPath,
+    Buffer.from(buildJSONL(subAgentUserMsg('bg task'), bashToolUse('tool-B')), 'utf-8'),
+  )
+
+  let lastOpenedPath: string | null = null
+  const mockFs = {
+    existsSync: ((p: fs.PathLike) => {
+      const ps = String(p)
+      if (ps === projectsRoot || ps === projectDir || ps === sessionDir || ps === subagentsDir) return true
+      return fileContents.has(ps)
+    }) as typeof fs.existsSync,
+    readdirSync: ((p: fs.PathLike) => {
+      const ps = String(p)
+      if (ps === projectsRoot) return ['mock-cwd']
+      if (ps === projectDir) return [sessionId]
+      if (ps === sessionDir) return ['subagents']
+      if (ps === subagentsDir) return [`agent-${agentId}.jsonl`]
+      return []
+    }) as unknown as typeof fs.readdirSync,
+    statSync: ((p: fs.PathLike) => ({ size: fileContents.get(String(p))?.length ?? 0 }) as fs.Stats) as typeof fs.statSync,
+    openSync: ((p: fs.PathLike) => { lastOpenedPath = String(p); return 42 }) as unknown as typeof fs.openSync,
+    closeSync: (() => { lastOpenedPath = null }) as typeof fs.closeSync,
+    readSync: ((
+      _fd: number, buf: NodeJS.ArrayBufferView, offset: number, length: number, position: number | null,
+    ): number => {
+      const content = lastOpenedPath != null ? fileContents.get(lastOpenedPath) : undefined
+      if (!content) return 0
+      const pos = position ?? 0
+      const src = content.slice(pos, pos + length)
+      ;(src as Buffer).copy(buf as Buffer, offset)
+      return src.length
+    }) as unknown as typeof fs.readSync,
+    watch: (() => ({ close: vi.fn() }) as unknown as fs.FSWatcher) as unknown as typeof fs.watch,
+  }
+
+  const intervals: Array<{ fn: () => void; ms: number; ref: number; fireAt: number }> = []
+  let nextRef = 1
+  const watcher = startSubagentWatcher({
+    agentDir,
+    // Tight windows so the deferral is reachable in a handful of ticks; the
+    // rate-limit under test is orthogonal to how we got into the state.
+    stallThresholdMs: 1000,
+    silentSynthesisStallThresholdMs: 5000,
+    silentStallTerminalMs: 5000,
+    inflightTerminalCapMs,
+    deferralLogIntervalMs,
+    rescanMs: 1000, // the production 1Hz tick — the cadence that produced the spam
+    log: (line) => logs.push(line),
+    now: () => currentTime,
+    setInterval: (fn, ms) => {
+      const ref = nextRef++
+      intervals.push({ fn, ms, ref, fireAt: currentTime + ms })
+      return { ref }
+    },
+    clearInterval: (h) => {
+      const { ref } = h as { ref: number }
+      const idx = intervals.findIndex((i) => i.ref === ref)
+      if (idx !== -1) intervals.splice(idx, 1)
+    },
+    fs: mockFs,
+  })
+
+  const advance = (ms: number): void => {
+    currentTime += ms
+    for (;;) {
+      intervals.sort((a, b) => a.fireAt - b.fireAt)
+      const next = intervals[0]
+      if (!next || next.fireAt > currentTime) break
+      next.fireAt += next.ms
+      next.fn()
+    }
+  }
+
+  /**
+   * Drive N discrete 1s ticks with the clock advancing between each — the
+   * faithful simulation of the production loop. (A single advance(N*1000)
+   * would fire N callbacks all observing the SAME `now`, which would mask a
+   * time-based gate.)
+   */
+  const tick = (n: number): void => { for (let i = 0; i < n; i++) advance(1000) }
+
+  const unmarkHistorical = (): void => {
+    const e = watcher.getRegistry().get(agentId)
+    if (e) e.historical = false
+  }
+
+  /** Land the matching tool_result — the worker resurrects. */
+  const resumeWorker = (): void => {
+    fileContents.set(
+      jsonlPath,
+      Buffer.from(
+        buildJSONL(subAgentUserMsg('bg task'), bashToolUse('tool-B'), bashToolResult('tool-B')),
+        'utf-8',
+      ),
+    )
+  }
+
+  /**
+   * The resumed worker starts a NEW long tool call (no tool_result) — it goes
+   * quiet again with something in flight, so the deferral path is re-entered.
+   */
+  const startNewToolCall = (): void => {
+    fileContents.set(
+      jsonlPath,
+      Buffer.from(
+        buildJSONL(
+          subAgentUserMsg('bg task'),
+          bashToolUse('tool-B'),
+          bashToolResult('tool-B'),
+          bashToolUse('tool-C'),
+        ),
+        'utf-8',
+      ),
+    )
+  }
+
+  return { logs, advance, tick, unmarkHistorical, resumeWorker, startNewToolCall, agentId }
+}
+
+describe('subagent-watcher: deferral log rate-limit (#3092)', () => {
+  it('logs the deferral ONCE on entry, then at most once per interval — not once per 1Hz tick', () => {
+    const h = makeHarness({ deferralLogIntervalMs: 60_000 })
+    h.advance(500)
+    h.unmarkHistorical()
+
+    // Get into the deferred state: cross the long-runner stall window, then
+    // the post-stall terminal window, with `tool-B` still in flight.
+    h.tick(12)
+    const afterEntry = h.logs.filter((l) => DEFERRED_RE.test(l))
+    expect(afterEntry.length).toBe(1) // first entry IS logged — diagnosability preserved
+
+    // The line must still carry the full diagnostic payload.
+    expect(afterEntry[0]).toContain(h.agentId)
+    expect(afterEntry[0]).toContain('1 tool call(s) still in flight')
+    expect(afterEntry[0]).toMatch(/\d+s idle < 2700s cap/)
+
+    // Now 600 more 1Hz ticks = 10 minutes of a persistently-stalled worker.
+    // Pre-fix this emitted ~600 lines. With a 60s interval it may emit at
+    // most ~10 more.
+    h.tick(600)
+    const deferred = h.logs.filter((l) => DEFERRED_RE.test(l))
+    expect(deferred.length).toBeLessThanOrEqual(11) // 1 entry + ≤10 periodic
+    expect(deferred.length).toBeGreaterThanOrEqual(2) // still periodically visible
+    // The regression this guards: NOT one line per tick.
+    expect(deferred.length).toBeLessThan(50)
+  })
+
+  it('reproduces the incident scale: ~35min at 1Hz emits a handful of lines, not ~1500', () => {
+    // The real evidence: 1,547 lines in ~35 minutes for one worker id.
+    const h = makeHarness({ deferralLogIntervalMs: 60_000 })
+    h.advance(500)
+    h.unmarkHistorical()
+    h.tick(2100) // 35 minutes of 1Hz ticks
+
+    const deferred = h.logs.filter((l) => DEFERRED_RE.test(l))
+    // 35 min / 60s ≈ 35 periodic lines + the entry line. Wildly below 1,547.
+    expect(deferred.length).toBeLessThanOrEqual(40)
+    // Every emitted line still names the worker and its in-flight count.
+    for (const line of deferred) {
+      expect(line).toContain(h.agentId)
+      expect(line).toContain('tool call(s) still in flight')
+    }
+  })
+
+  it('STATE CHANGE — a resurrecting worker always logs, even mid-suppression', () => {
+    const h = makeHarness({ deferralLogIntervalMs: 60_000 })
+    h.advance(500)
+    h.unmarkHistorical()
+    h.tick(12) // enter the deferred state (1 line)
+    expect(h.logs.filter((l) => DEFERRED_RE.test(l)).length).toBe(1)
+
+    h.tick(20) // 20 suppressed ticks — well inside the 60s window
+    expect(h.logs.filter((l) => DEFERRED_RE.test(l)).length).toBe(1)
+
+    // The worker resurrects (the incident worker did exactly this).
+    h.resumeWorker()
+    h.tick(2)
+
+    const resolved = h.logs.filter((l) => RESOLVED_RE.test(l))
+    expect(resolved.length).toBe(1) // the transition is NOT suppressed
+    expect(resolved[0]).toContain(h.agentId)
+    expect(resolved[0]).toContain('deferral was correct')
+    // The suppressed volume is accounted for, not silently dropped.
+    expect(resolved[0]).toMatch(/\d+ deferral tick\(s\) suppressed/)
+    expect(h.logs.some((l) => /stall cleared/.test(l))).toBe(true)
+  })
+
+  it('STATE CHANGE — crossing the cap always logs the terminal synthesis', () => {
+    // Compressed cap so the crossing is reachable in a bounded tick count.
+    const h = makeHarness({ deferralLogIntervalMs: 60_000, inflightTerminalCapMs: 120_000 })
+    h.advance(500)
+    h.unmarkHistorical()
+    h.tick(12)
+    expect(h.logs.filter((l) => DEFERRED_RE.test(l)).length).toBe(1)
+
+    h.tick(130) // cross the 120s cap
+    const cap = h.logs.filter((l) => CAP_RE.test(l))
+    expect(cap.length).toBe(1) // the cap-crossing is NOT suppressed
+    expect(cap[0]).toContain(h.agentId)
+    expect(cap[0]).toContain('proceeding with terminal synthesis')
+    expect(cap[0]).toMatch(/\d+ deferral tick\(s\) suppressed/)
+
+    // And the deferral lines over that whole window stayed bounded.
+    expect(h.logs.filter((l) => DEFERRED_RE.test(l)).length).toBeLessThanOrEqual(4)
+  })
+
+  it('a re-stall after a resume logs its first deferral again (gate re-arms)', () => {
+    const h = makeHarness({ deferralLogIntervalMs: 60_000 })
+    h.advance(500)
+    h.unmarkHistorical()
+    h.tick(12)
+    expect(h.logs.filter((l) => DEFERRED_RE.test(l)).length).toBe(1)
+
+    h.resumeWorker()
+    h.tick(2)
+    expect(h.logs.filter((l) => RESOLVED_RE.test(l)).length).toBe(1)
+
+    // The resumed worker goes quiet again inside a NEW tool call. Its first
+    // deferral must log immediately rather than being swallowed by the
+    // still-open 60s window from the previous stall episode.
+    h.startNewToolCall()
+    h.tick(14)
+    expect(h.logs.filter((l) => DEFERRED_RE.test(l)).length).toBe(2)
+  })
+
+  it('env override SWITCHROOM_SUBAGENT_DEFERRAL_LOG_INTERVAL_MS is honored', () => {
+    const saved = process.env.SWITCHROOM_SUBAGENT_DEFERRAL_LOG_INTERVAL_MS
+    process.env.SWITCHROOM_SUBAGENT_DEFERRAL_LOG_INTERVAL_MS = '10000'
+    try {
+      const h = makeHarness() // no config arg → env wins
+      h.advance(500)
+      h.unmarkHistorical()
+      h.tick(12)
+      expect(h.logs.filter((l) => DEFERRED_RE.test(l)).length).toBe(1)
+
+      // 60 ticks at a 10s interval → ~6 more lines, not 60.
+      h.tick(60)
+      const deferred = h.logs.filter((l) => DEFERRED_RE.test(l)).length
+      expect(deferred).toBeGreaterThanOrEqual(5)
+      expect(deferred).toBeLessThanOrEqual(9)
+    } finally {
+      if (saved === undefined) delete process.env.SWITCHROOM_SUBAGENT_DEFERRAL_LOG_INTERVAL_MS
+      else process.env.SWITCHROOM_SUBAGENT_DEFERRAL_LOG_INTERVAL_MS = saved
+    }
+  })
+})


### PR DESCRIPTION
## Summary

The subagent-watcher's `silent-stall terminal synthesis deferred` line is re-emitted on **every ~1s rescan tick** for as long as a worker stays blocked inside a long tool call. `checkStalls()` runs on the rescan interval and re-evaluates the in-flight deferral each time — but before this change, every re-evaluation also re-logged.

Real evidence from the live overlord gateway today (`~/.switchroom/logs/overlord/gateway-supervisor.log`) — **1,547 near-identical lines in ~35 minutes for a single worker id**, differing only in the idle-seconds counter:

```
[2026-07-11T07:42:07.387Z] telegram gateway: subagent-watcher: silent-stall terminal synthesis deferred for a732f61196738da7d — 1 tool call(s) still in flight, 1996s idle < 2700s cap (long-running tool, not a dead worker)
[2026-07-11T07:42:08.387Z] telegram gateway: subagent-watcher: silent-stall terminal synthesis deferred for a732f61196738da7d — 1 tool call(s) still in flight, 1997s idle < 2700s cap (long-running tool, not a dead worker)
[2026-07-11T07:42:09.388Z] ... 1998s idle ...
```

The deferral **decision** is correct and is unchanged here — that worker was legitimately blocked and later resurrected. Only the **logging** is gated:

- **First entry** into the deferred state logs immediately — diagnosability preserved.
- Subsequent ticks are rate-limited to **1 line / `deferralLogIntervalMs`** (default 60s; env override `SWITCHROOM_SUBAGENT_DEFERRAL_LOG_INTERVAL_MS`, config arg `deferralLogIntervalMs`).
- **State CHANGES are never suppressed.** The cap-crossing (`in-flight deferral cap reached … proceeding with terminal synthesis`) always fires, and a new `in-flight deferral resolved` line fires when the worker resurrects — the transitions are the valuable events.
- **No information is lost:** every emitted line still carries worker id, in-flight tool count, idle seconds and cap, and the count of ticks suppressed since the last line rides the next emitted line (and both transition lines), so the quiet window is accounted for.
- The gate re-arms on un-stall, so a stall → resume → stall cycle logs its first deferral again.

Gating keys off the **injected clock** (`config.now`), never an inline `Date.now()` — deterministic and testable with a fake clock.

## Why

This buries real signal. During the exact window above, the gateway was hitting genuine Telegram 429 flood bans (#3084) and those critical lines were drowned in this spam — it materially slowed incident diagnosis. A log that costs the operator attention to read is a log that stops getting read.

Job spec: **`reference/jobs/fleet-stays-healthy.md`** — _"the operator sees the worst-affecting issues first — with frequency, evidence … and never has to hand-audit turns to find what is quietly breaking."_ A 1/sec repetition of a correct, non-actionable decision is the exact anti-pattern that job exists to prevent: it drowns the ranked signal in unranked noise.

Complements (does **not** overlap) open PR #3076, which gates per-poll `tg-post` / `gw-trace shadow` heartbeats and adds sidecar log rotation. #3076 does not touch `subagent-watcher.ts`; this line is a different emitter with different (state-driven, not flag-driven) semantics — a worker's stall deferral must stay visible by default, so an env kill-flag would be the wrong idiom here. No file overlap, no conflict.

## Test plan

New `telegram-plugin/tests/subagent-watcher-deferral-log-ratelimit.test.ts` — deterministic fake clock + injected `setInterval`, **no real timers**, driving discrete 1Hz ticks (each with the clock advanced between callbacks, so a time-based gate can't be masked). Asserts outcomes, not code paths:

- **600 ticks (10 min) over a persistently-stalled worker ⇒ ≤ 11 lines**, not ~600. First-entry line IS emitted and carries worker id / in-flight count / `Ns idle < 2700s cap`.
- **Incident-scale replay: 2,100 ticks (~35 min) ⇒ ≤ 40 lines**, versus the 1,547 observed.
- **State change — resume:** a worker that resurrects mid-suppression always logs `in-flight deferral resolved` + `stall cleared`, with the suppressed-tick count.
- **State change — cap crossing:** always logs `proceeding with terminal synthesis`, never suppressed.
- **Re-arm:** stall → resume → new in-flight tool call logs its first deferral again.
- **Env override** `SWITCHROOM_SUBAGENT_DEFERRAL_LOG_INTERVAL_MS` honored.

Results:
- `./node_modules/.bin/vitest run telegram-plugin/tests/subagent-watcher*` — **13 files, 101 tests, all green** (6 new; the existing `subagent-watcher-env-thresholds.test.ts` and `-stall-terminal.test.ts` stay green — deferral behaviour is unchanged, only its log cadence).
- `npm run lint` — **clean** (tsc --noEmit + all 8 guard scripts). No `gateway.ts` bot-api allowlist shift.

## Risk

**Low.** No change to the deferral decision, the stall thresholds, the cap, or any terminal-synthesis behaviour — a pure logging gate over an unchanged control flow. Both `continue`/fall-through paths are preserved exactly.

The only behavioural surface is log volume. Worst case if the gate misbehaves: a deferral line is under-reported between transitions — bounded by the fact that both state transitions (resume, cap-crossing) log unconditionally, so no deferral episode can begin or end invisibly. Interval is operator-tunable via env without a redeploy.

Two new fields on the in-memory registry entry (`deferralLoggedAt`, `deferralSuppressedTicks`); nothing persisted, no schema change, no DB write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mQR9UordBs4nJ797bxxod