### PR TITLE
chore(docker): actually digest-pin the voice sidecar CUDA base image

### DIFF
--- a/docker/Dockerfile.voice
+++ b/docker/Dockerfile.voice
@@ -23,7 +23,7 @@
 #
 # sec: pinned by digest — a CUDA `:runtime` tag from nvidia is mutable.
 # Dependabot tracks bumps. (Replace the digest when bumping the tag.)
-FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04
+FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04@sha256:2fcc4280646484290cc50dce5e65f388dd04352b07cbe89a635703bd1f9aedb6
 
 LABEL org.opencontainers.image.title="switchroom-voice" \
       org.opencontainers.image.description="Local GPU speech sidecar (faster-whisper STT + Kokoro TTS)"


### PR DESCRIPTION
## Problem

`docker/Dockerfile.voice` carried a security comment above its `FROM`:

> `# sec: pinned by digest — a CUDA :runtime tag from nvidia is mutable. Dependabot tracks bumps. (Replace the digest when bumping the tag.)`

…but the `FROM` line was `nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04` with **no `@sha256:` digest**. The comment promised digest-pinning; the reality was a mutable tag. A repush of that tag by NVIDIA would silently swap the base layers under our build — exactly the supply-chain risk the comment claims to defend against.

Surfaced as a review note (issue #2884).

## Fix

Pin the `FROM` to the current digest, matching the existing convention already used in this repo:

- `docker/Dockerfile.base` → `node:22-trixie-slim@sha256:…`
- `docker/Dockerfile.hindsight` → `ghcr.io/vectorize-io/hindsight:latest@sha256:…`

New line:

```
FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04@sha256:2fcc4280646484290cc50dce5e65f388dd04352b07cbe89a635703bd1f9aedb6
```

## Digest provenance

`docker buildx` is not available in this environment, so the digest was obtained authoritatively from the Docker Hub registry API:

1. Anonymous pull token from `auth.docker.io` (`scope=repository:nvidia/cuda:pull`).
2. `GET registry-1.docker.io/v2/nvidia/cuda/manifests/12.4.1-cudnn-runtime-ubuntu22.04` with `Accept` headers for the OCI image index + Docker manifest list.
3. Read `Docker-Content-Digest`.

This is the **multi-arch manifest-list (index) digest** — `sha256:2fcc4280646484290cc50dce5e65f388dd04352b07cbe89a635703bd1f9aedb6` (`Content-Type: application/vnd.docker.distribution.manifest.list.v2+json`), preferred because it lets the tag stay portable while still being immutable.

For the record, the linux/amd64 sub-manifest digest is `sha256:0bb88834d973ca1b450fcc2a05333c6fe45510bee289912a5391274c351c4a4d`. The voice image builds amd64-only (`build-voice` in `.github/workflows/docker-images.yml`), so the amd64 digest would also be defensible; I chose the index digest to match the multi-arch pins already in `Dockerfile.base`/`Dockerfile.hindsight`.

## Validation

- `npm run lint` — clean (`tsc --noEmit` + all 8 guard scripts pass).
- Grepped `tests/` and all `.ts`/`.mjs`/`.js` sources for `12.4.1` / `Dockerfile.voice` / `cudnn` — no assertions reference the base image tag or digest, so no test changes were needed.

No `Closes #2884` — this references the review-note origin without auto-closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)