### PR TITLE
fix(telegram): cap typing pings per chat so they can't earn a flood ban

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -187,6 +187,7 @@ import {
   createSwallowingRetryApiCall,
   retryWithThreadFallback,
   isPhotoDimensionRejectError,
+  isFloodWaitActiveError,
 } from '../retry-api-call.js'
 import { classifyPhotoFile, rerouteResultSuffix } from '../photo-precheck.js'
 import { installTgPostLogger, withTgPostTags } from '../shared/bot-runtime.js'
@@ -5362,17 +5363,25 @@ const swallowingApiCall = createSwallowingRetryApiCall(
  * which only learns about 429s through `createRetryApiCall`'s `onFloodWait`
  * hook — was blind to 429s from the biggest source of them.
  *
- * `maxRetries: 1` + a no-op sleep gives exactly one attempt: a 429 still runs
- * `onFloodWait` (recording the window to the breaker), then the call gives up
- * immediately instead of sleeping out a 4-hour retry_after. The swallowing
- * wrapper logs and drops the failure.
+ * `maxRetries: 1` + a no-op sleep gives exactly one attempt at the API, whatever
+ * the outcome: a 429 still runs `onFloodWait` (recording the window to the
+ * breaker), and then the call ends — a SHORT ban falls out of the loop as
+ * `max retries exceeded`, a LONG one throws #3094's `FLOOD_WAIT_ACTIVE`. Either
+ * way the ping is dropped, never slept and never retried. That is the whole
+ * point: a retried non-essential send is what feeds a ban.
+ *
+ * Composes cleanly on top of #3094 (`bbe14471`): that PR bounded the in-process
+ * flood sleep and added a pre-call gate for LONG open windows. This wrapper
+ * pre-dates neither mechanism nor fights them — it sits under the emitter's own
+ * flood gate, which short-circuits earlier still (a typing ping during a ban
+ * never even reaches the retry layer). Defense in depth, in that order.
  */
 // No `log` hook: retryApiCall's flood line reads "waiting Ns", which would be a
-// lie here — we never wait, we drop. And the error the caller finally sees is
-// `retryApiCall: max retries exceeded` (retry-api-call.ts replaces the original
-// on give-up), which would hide the retry_after — the single number an operator
-// needs during a flood ban. So the honest 429 line is written HERE, in the
-// onFloodWait hook, where the real retry_after is still in hand.
+// lie here — we never wait, we drop. And the error the caller finally sees names
+// neither the code nor the retry_after (retryApiCall replaces the original on
+// give-up) — and retry_after is the single number an operator needs during a
+// ban. So the honest 429 line is written HERE, in the onFloodWait hook, where
+// the real value is still in hand.
 const recordTypingFloodWait = makeFloodWaitRecorder(FLOOD_STATE_PATH)
 const nonEssentialApiCall = createRetryApiCall({
   maxRetries: 1,
@@ -5466,11 +5475,15 @@ const typingEmitter = createTypingEmitter({
           typingRetryTimers.set(key, retry)
           return
         }
-        // A 429 already logged its retry_after (and hit the breaker) in
-        // onFloodWait above; by the time it lands here retryApiCall has
-        // replaced it with the opaque give-up error, so don't double-log a
-        // line that names neither the code nor the retry_after.
-        if (msg.includes('max retries exceeded')) return
+        // A flood-wait already logged its retry_after (and hit the breaker) in
+        // onFloodWait above. What lands here is either retryApiCall's opaque
+        // give-up error (short ban) or #3094's FLOOD_WAIT_ACTIVE marker (long
+        // ban / pre-call gate) — neither names the retry_after, so don't
+        // double-log a strictly less informative line. Both are DROPS: a
+        // typing ping is never retried, and the marker is caught here (this is
+        // an onRejected handler), so it can't surface as an unhandled rejection
+        // out of a fire-and-forget ping.
+        if (isFloodWaitActiveError(err) || msg.includes('max retries exceeded')) return
         // Everything else is DROPPED, never retried — but logged, so the
         // largest outbound emitter is no longer silent (#3084).
         process.stderr.write(

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5367,12 +5367,23 @@ const swallowingApiCall = createSwallowingRetryApiCall(
  * immediately instead of sleeping out a 4-hour retry_after. The swallowing
  * wrapper logs and drops the failure.
  */
-// No `log` hook: retryApiCall's flood line reads "waiting Ns", which would be
-// a lie here — we never wait, we drop. The callsite logs the drop itself.
+// No `log` hook: retryApiCall's flood line reads "waiting Ns", which would be a
+// lie here — we never wait, we drop. And the error the caller finally sees is
+// `retryApiCall: max retries exceeded` (retry-api-call.ts replaces the original
+// on give-up), which would hide the retry_after — the single number an operator
+// needs during a flood ban. So the honest 429 line is written HERE, in the
+// onFloodWait hook, where the real retry_after is still in hand.
+const recordTypingFloodWait = makeFloodWaitRecorder(FLOOD_STATE_PATH)
 const nonEssentialApiCall = createRetryApiCall({
   maxRetries: 1,
   sleep: async () => {},
-  onFloodWait: makeFloodWaitRecorder(FLOOD_STATE_PATH),
+  onFloodWait: (retryAfterSec) => {
+    recordTypingFloodWait(retryAfterSec)
+    process.stderr.write(
+      `telegram gateway: 429 flood-wait on a NON-ESSENTIAL send (retry_after=${retryAfterSec}s) — ` +
+        `recorded to the flood breaker; the send is DROPPED, not retried (#3084)\n`,
+    )
+  },
 })
 
 // ─── Typing indicator ─────────────────────────────────────────────────────
@@ -5421,8 +5432,16 @@ type ChatAction = typeof CHAT_ACTION_WHITELIST extends Set<infer T> ? T : never
  * what decouples the typing rate from the agent's TOOL-CALL rate — the
  * regression that earned a 4.6-hour flood ban. A cold start (no ping inside
  * the floor) still fires instantly, so "typing…" lands the moment a turn
- * begins; only redundant restarts are dropped. And while a flood window is
- * open, typing — non-essential by definition — is not emitted at all.
+ * begins; only redundant restarts are dropped — and a dropped tick arms a
+ * coalesced catch-up, so the indicator never goes dark for longer than the
+ * floor. While a flood window is open, typing — non-essential by definition —
+ * is not emitted at all.
+ *
+ * (`sendChatAction` is outside `check-bot-api-wrapping`'s pattern by design —
+ * chat actions take no `message_thread_id`, so they were never in the
+ * THREAD_NOT_FOUND blast radius the guard polices. It's routed through the
+ * retry module anyway, because that is where the flood breaker's `onFloodWait`
+ * hook lives and typing is the largest 429 source there is.)
  */
 const typingEmitter = createTypingEmitter({
   chatKey: (chat_id, thread_id) => chatKey(chat_id, thread_id) as string,
@@ -5430,7 +5449,6 @@ const typingEmitter = createTypingEmitter({
   send: (chat_id, thread_id, action) => {
     const sendOpts = thread_id != null ? { message_thread_id: thread_id } : undefined
     void nonEssentialApiCall(
-      // allow-raw-bot-api: routed through nonEssentialApiCall — records a 429 to the flood breaker (#2923) and NEVER retries (a retried typing ping is what feeds a ban, #3084).
       () => bot.api.sendChatAction(chat_id, action as ChatAction, sendOpts),
       { chat_id, verb: 'sendChatAction' },
     ).then(
@@ -5448,8 +5466,12 @@ const typingEmitter = createTypingEmitter({
           typingRetryTimers.set(key, retry)
           return
         }
-        // Everything else (including a 429 — already recorded to the flood
-        // breaker by onFloodWait) is DROPPED, never retried. Logged so the
+        // A 429 already logged its retry_after (and hit the breaker) in
+        // onFloodWait above; by the time it lands here retryApiCall has
+        // replaced it with the opaque give-up error, so don't double-log a
+        // line that names neither the code nor the retry_after.
+        if (msg.includes('max retries exceeded')) return
+        // Everything else is DROPPED, never retried — but logged, so the
         // largest outbound emitter is no longer silent (#3084).
         process.stderr.write(
           `telegram gateway: sendChatAction dropped (non-essential, not retried): ${msg}\n`,
@@ -5524,6 +5546,11 @@ function startTurnTypingLoop(chat_id: string, thread_id: number | null = null): 
 
 function stopTurnTypingLoop(chat_id: string, thread_id: number | null = null): void {
   turnTypingLoop.stop(chat_id, thread_id)
+  // Canonical turn-end: cancel any catch-up the floor armed, so a tick dropped
+  // in the last seconds of the turn can't resurrect "typing…" after the reply
+  // has landed. Deliberately NOT done in `stopTypingLoop` — the tool loop stops
+  // on every tool result, which is exactly the churn the catch-up covers.
+  typingEmitter.cancelPending(chat_id, thread_id)
 }
 
 const typingWrapper = createTypingWrapper({
@@ -9844,7 +9871,12 @@ const ipcServer: IpcServer = createIpcServer({
       // hits the canonical turn-end stop, leaving a stale "typing…" until the
       // next turn. Sweep every live loop here (gated to registered-agent
       // disconnect inside flushOnAgentDisconnect).
-      stopTurnTypingLoops: () => turnTypingLoop.stopAll(),
+      stopTurnTypingLoops: () => {
+        turnTypingLoop.stopAll()
+        // Shutdown drain: also cancel every armed catch-up so no typing ping
+        // fires after the gateway has stopped.
+        typingEmitter.reset()
+      },
       // When dangling activeTurnStartedAt keys were swept (setDone raced
       // disconnect), the module-scope `currentTurn` may also point at the
       // dead bridge's turn. Null it so the next inbound starts a fresh

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -177,6 +177,7 @@ import { REPLY_TOOLS, isDraftOfReply } from '../narrative-dedup.js'
 import { toolLabel } from '../tool-labels.js'
 import { createTypingWrapper } from '../typing-wrap.js'
 import { createTurnTypingLoop } from './turn-typing-loop.js'
+import { createTypingEmitter, TYPING_REFRESH_MS } from '../typing-emitter.js'
 import { type DraftStreamHandle } from '../draft-stream.js'
 import { handlePtyPartialPure, type PtyHandlerState } from '../pty-partial-handler.js'
 import { handleStreamReply } from '../stream-reply-handler.js'
@@ -193,6 +194,7 @@ import {
   floodStatePath,
   makeFloodWaitRecorder,
   makeFloodWaitProbe,
+  suppressNonEssentialSendMs,
 } from '../flood-circuit-breaker.js'
 import { buildAttachmentPath, assertInsideInbox } from '../attachment-path.js'
 import { logStreamingEvent } from '../streaming-metrics.js'
@@ -5316,6 +5318,63 @@ const PHOTO_EXTS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp'])
 // The length/newline text splitter moved to outbound-send-path.ts (#2996) as
 // `chunkText`; the sole gateway caller now goes through `computeReplyChunks`.
 
+// ─── Robust API call wrapper ──────────────────────────────────────────────
+// Extracted to telegram-plugin/retry-api-call.ts so it's unit-testable in
+// isolation; the gateway just composes the pure policy with its own logger.
+// #2923: the shared flood-wait marker. Every observed 429 retry_after window
+// is persisted here via onFloodWait, and both boot-card callsites consult the
+// SAME file to suppress a restart card while a per-bot flood ban is open (so a
+// restart doesn't post into the window and extend the ban). Falls back to a
+// no-op recorder when TELEGRAM_STATE_DIR is unset (dev/one-shot contexts).
+// STATE_DIR always resolves (env or a ~/.claude fallback), so this is live.
+// Declared ABOVE the typing indicator because the typing sends now route
+// through the same policy (#3084) — see nonEssentialApiCall below.
+const FLOOD_STATE_PATH = floodStatePath(STATE_DIR)
+const robustApiCall = createRetryApiCall({
+  log: (line) => process.stderr.write(line),
+  onFloodWait: makeFloodWaitRecorder(FLOOD_STATE_PATH),
+  // #3094: while a LONG per-bot ban is open, don't issue the call at all.
+  // retryApiCall no longer sleeps a multi-hour retry_after (it throws
+  // FLOOD_WAIT_ACTIVE instead), and the card surfaces re-drive on a 5-6s
+  // heartbeat — without this gate that turns the fix into an amplifier that
+  // fires thousands of requests into the open window and extends the ban.
+  floodWaitRemainingMs: makeFloodWaitProbe(FLOOD_STATE_PATH),
+})
+
+// Fire-and-forget wrapper for outbound surfaces that previously had
+// `.catch(() => {})` directly on `bot.api.*` calls. Resolves to undefined
+// (instead of crashing the gateway) on THREAD_NOT_FOUND, give-up, 403,
+// and any non-benign error — logs a one-liner so the failure isn't
+// completely silent. See #1075.
+const swallowingApiCall = createSwallowingRetryApiCall(
+  robustApiCall,
+  (line) => process.stderr.write(line),
+)
+
+/**
+ * The wrapper for NON-ESSENTIAL sends that must NEVER retry (#3084).
+ *
+ * A typing indicator is disposable: if it fails, the correct answer is to drop
+ * it, because a retry spends more of the per-bot flood budget the REPLIES need
+ * — retrying is what feeds a ban. But it must not be SILENT either: the typing
+ * loop was the single largest emitter (55% of outbound volume) and it called
+ * `bot.api` raw with `.catch(() => {})`, so the #2923 flood circuit breaker —
+ * which only learns about 429s through `createRetryApiCall`'s `onFloodWait`
+ * hook — was blind to 429s from the biggest source of them.
+ *
+ * `maxRetries: 1` + a no-op sleep gives exactly one attempt: a 429 still runs
+ * `onFloodWait` (recording the window to the breaker), then the call gives up
+ * immediately instead of sleeping out a 4-hour retry_after. The swallowing
+ * wrapper logs and drops the failure.
+ */
+// No `log` hook: retryApiCall's flood line reads "waiting Ns", which would be
+// a lie here — we never wait, we drop. The callsite logs the drop itself.
+const nonEssentialApiCall = createRetryApiCall({
+  maxRetries: 1,
+  sleep: async () => {},
+  onFloodWait: makeFloodWaitRecorder(FLOOD_STATE_PATH),
+})
+
 // ─── Typing indicator ─────────────────────────────────────────────────────
 // All four state maps re-keyed from `chat_id` to `chatKey(chat, thread)`
 // in PR3 of the supergroup-mode rollout. In supergroup mode one agent
@@ -5352,6 +5411,63 @@ const CHAT_ACTION_WHITELIST = new Set([
 ] as const)
 type ChatAction = typeof CHAT_ACTION_WHITELIST extends Set<infer T> ? T : never
 
+/**
+ * The ONE seam every chat action in this gateway goes through (#3084).
+ *
+ * Both typing loops (tool-use `typingIntervals` below and the turn-level
+ * `turnTypingLoop`) and the one-shot inbound pings share this emitter, so the
+ * per-chat-key floor holds ACROSS them: at most one `sendChatAction` per chat
+ * key per ~4 s window, no matter how many times a loop is restarted. That is
+ * what decouples the typing rate from the agent's TOOL-CALL rate — the
+ * regression that earned a 4.6-hour flood ban. A cold start (no ping inside
+ * the floor) still fires instantly, so "typing…" lands the moment a turn
+ * begins; only redundant restarts are dropped. And while a flood window is
+ * open, typing — non-essential by definition — is not emitted at all.
+ */
+const typingEmitter = createTypingEmitter({
+  chatKey: (chat_id, thread_id) => chatKey(chat_id, thread_id) as string,
+  isSuppressed: () => suppressNonEssentialSendMs(FLOOD_STATE_PATH, Date.now()) > 0,
+  send: (chat_id, thread_id, action) => {
+    const sendOpts = thread_id != null ? { message_thread_id: thread_id } : undefined
+    void nonEssentialApiCall(
+      // allow-raw-bot-api: routed through nonEssentialApiCall — records a 429 to the flood breaker (#2923) and NEVER retries (a retried typing ping is what feeds a ban, #3084).
+      () => bot.api.sendChatAction(chat_id, action as ChatAction, sendOpts),
+      { chat_id, verb: 'sendChatAction' },
+    ).then(
+      () => { typingBackoffMs = 0 },
+      (err) => {
+        const msg = err instanceof Error ? err.message : String(err)
+        if (msg.includes('401') || msg.includes('Unauthorized')) {
+          const key = chatKey(chat_id, thread_id) as string
+          typingBackoffMs = Math.min(Math.max(typingBackoffMs * 2 || 1000, 1000), TYPING_BACKOFF_MAX)
+          stopTypingLoop(chat_id, thread_id)
+          const retry = setTimeout(() => {
+            typingRetryTimers.delete(key)
+            startTypingLoop(chat_id, thread_id, action as ChatAction)
+          }, typingBackoffMs)
+          typingRetryTimers.set(key, retry)
+          return
+        }
+        // Everything else (including a 429 — already recorded to the flood
+        // breaker by onFloodWait) is DROPPED, never retried. Logged so the
+        // largest outbound emitter is no longer silent (#3084).
+        process.stderr.write(
+          `telegram gateway: sendChatAction dropped (non-essential, not retried): ${msg}\n`,
+        )
+      },
+    )
+  },
+})
+
+/** Fire one chat action for (chat, thread), subject to the shared floor. */
+function emitChatAction(
+  chat_id: string,
+  thread_id: number | null = null,
+  action: ChatAction = 'typing',
+): void {
+  typingEmitter.emit(chat_id, thread_id, action)
+}
+
 function startTypingLoop(
   chat_id: string,
   thread_id: number | null = null,
@@ -5359,26 +5475,15 @@ function startTypingLoop(
 ): void {
   stopTypingLoop(chat_id, thread_id)
   const key = chatKey(chat_id, thread_id) as string
-  const sendOpts = thread_id != null ? { message_thread_id: thread_id } : undefined
-  const send = () => {
-    bot.api.sendChatAction(chat_id, action, sendOpts).then(
-      () => { typingBackoffMs = 0 },
-      (err) => {
-        const msg = err instanceof Error ? err.message : String(err)
-        if (msg.includes('401') || msg.includes('Unauthorized')) {
-          typingBackoffMs = Math.min(Math.max(typingBackoffMs * 2 || 1000, 1000), TYPING_BACKOFF_MAX)
-          stopTypingLoop(chat_id, thread_id)
-          const retry = setTimeout(() => {
-            typingRetryTimers.delete(key)
-            startTypingLoop(chat_id, thread_id, action)
-          }, typingBackoffMs)
-          typingRetryTimers.set(key, retry)
-        }
-      },
-    )
-  }
+  // The immediate fire is FLOOR-GATED (it was not, and that is #3084): the
+  // tool-use wrapper restarts this loop on every tool call, so an unguarded
+  // immediate send made the ping rate equal the tool-call rate and the 4 s
+  // interval decorative. The emitter drops the restart's ping when this key
+  // already pinged inside the window, and lets it straight through on a cold
+  // start — so a turn still lights up "typing…" instantly.
+  const send = () => emitChatAction(chat_id, thread_id, action)
   send()
-  typingIntervals.set(key, setInterval(send, 4000))
+  typingIntervals.set(key, setInterval(send, TYPING_REFRESH_MS))
 }
 
 function stopTypingLoop(chat_id: string, thread_id: number | null = null): void {
@@ -5398,14 +5503,19 @@ function stopTypingLoop(chat_id: string, thread_id: number | null = null): void 
 // kill it and the chat would go dark for the rest of the turn — the exact
 // black-box gap this closes. The dedicated map (private to the factory) makes
 // the turn loop structurally immune to those stops: only the canonical turn-end
-// stop clears it. The redundant `typing` pings while a reply is mid-flight are
-// harmless — same action, and sendChatAction is cheap.
+// stop clears it.
+//
+// The interval map stays separate — but the SENDS do not (#3084). This loop and
+// `typingIntervals` target the SAME chat key, and the old comment here claimed
+// the redundant pings were "harmless — same action, and sendChatAction is
+// cheap". They are not cheap: they spend the per-bot flood budget the replies
+// need, and two independently-restarting loops on one key is exactly how the
+// rate compounded. Both loops now emit through `typingEmitter`, so the
+// per-chat-key floor is SHARED and neither loop can out-shout the other.
 const turnTypingLoop = createTurnTypingLoop({
-  sendChatAction: (chat_id, thread_id) => {
-    const sendOpts = thread_id != null ? { message_thread_id: thread_id } : undefined
-    void bot.api.sendChatAction(chat_id, 'typing', sendOpts).catch(() => {})
-  },
+  sendChatAction: (chat_id, thread_id) => emitChatAction(chat_id, thread_id, 'typing'),
   chatKey: (chat_id, thread_id) => chatKey(chat_id, thread_id) as string,
+  refreshMs: TYPING_REFRESH_MS,
 })
 
 function startTurnTypingLoop(chat_id: string, thread_id: number | null = null): void {
@@ -5421,37 +5531,6 @@ const typingWrapper = createTypingWrapper({
   stopTypingLoop,
   isSurfaceTool: isTelegramSurfaceTool,
 })
-
-// ─── Robust API call wrapper ──────────────────────────────────────────────
-// Extracted to telegram-plugin/retry-api-call.ts so it's unit-testable in
-// isolation; the gateway just composes the pure policy with its own logger.
-// #2923: the shared flood-wait marker. Every observed 429 retry_after window
-// is persisted here via onFloodWait, and both boot-card callsites consult the
-// SAME file to suppress a restart card while a per-bot flood ban is open (so a
-// restart doesn't post into the window and extend the ban). Falls back to a
-// no-op recorder when TELEGRAM_STATE_DIR is unset (dev/one-shot contexts).
-// STATE_DIR always resolves (env or a ~/.claude fallback), so this is live.
-const FLOOD_STATE_PATH = floodStatePath(STATE_DIR)
-const robustApiCall = createRetryApiCall({
-  log: (line) => process.stderr.write(line),
-  onFloodWait: makeFloodWaitRecorder(FLOOD_STATE_PATH),
-  // #3084: while a LONG per-bot ban is open, don't issue the call at all.
-  // retryApiCall no longer sleeps a multi-hour retry_after (it throws
-  // FLOOD_WAIT_ACTIVE instead), and the card surfaces re-drive on a 5-6s
-  // heartbeat — without this gate that turns the fix into an amplifier that
-  // fires thousands of requests into the open window and extends the ban.
-  floodWaitRemainingMs: makeFloodWaitProbe(FLOOD_STATE_PATH),
-})
-
-// Fire-and-forget wrapper for outbound surfaces that previously had
-// `.catch(() => {})` directly on `bot.api.*` calls. Resolves to undefined
-// (instead of crashing the gateway) on THREAD_NOT_FOUND, give-up, 403,
-// and any non-benign error — logs a one-liner so the failure isn't
-// completely silent. See #1075.
-const swallowingApiCall = createSwallowingRetryApiCall(
-  robustApiCall,
-  (line) => process.stderr.write(line),
-)
 
 /**
  * Adapter factory for `startBootCard`'s `BotApiForBootCard` interface.
@@ -17373,7 +17452,9 @@ function maybeEarlyAckReaction(ctx: Context, from: NonNullable<Context['from']>)
   // model text. No fake content — Telegram clients render this natively
   // and it auto-expires after ~5s if not refreshed (the answer-lane
   // first edit will land long before then under the new defaults).
-  void bot.api.sendChatAction(chatId, 'typing').catch(() => {})
+  // Through the shared emitter (#3084): a cold chat still lights up
+  // instantly; a chat already pinged inside the floor doesn't pay twice.
+  emitChatAction(chatId, null, 'typing')
 }
 
 /**
@@ -18158,11 +18239,8 @@ async function handleInbound(
   // Typing indicator in the ORIGINATING topic — on a supergroup-topic inbound,
   // an un-threaded sendChatAction shows "typing" in General, not the topic the
   // user is in. messageThreadId is the inbound's thread (undefined in a DM).
-  void bot.api.sendChatAction(
-    chat_id,
-    'typing',
-    messageThreadId != null ? { message_thread_id: messageThreadId } : {},
-  ).catch(() => {})
+  // Floor-gated through the shared emitter (#3084).
+  emitChatAction(chat_id, messageThreadId ?? null, 'typing')
 
   // Parse explicit prefixes first. `/steer ` / `/s ` opts IN to steering;
   // `/queue ` / `/q ` are legacy aliases that opt in to the new default (queued).

--- a/telegram-plugin/gateway/turn-typing-loop.ts
+++ b/telegram-plugin/gateway/turn-typing-loop.ts
@@ -16,8 +16,16 @@
  * a mid-turn reply's `finally { stopTypingLoop }` would kill it and the chat
  * would go dark for the rest of the turn. A dedicated map makes the turn loop
  * structurally immune to those stops — only `stop` (the canonical turn-end)
- * clears it. The redundant `typing` pings while a reply is mid-flight are
- * harmless (same action, and `sendChatAction` is cheap).
+ * clears it.
+ *
+ * The map is separate; the SENDS are not (#3084). This file used to claim the
+ * redundant pings were "harmless — same action, and `sendChatAction` is cheap".
+ * They are not cheap: they spend the per-bot flood budget the REPLIES need, and
+ * on 2026-07-11 the two loops together earned a 4.6-hour flood ban. The gateway
+ * now injects a `sendChatAction` that routes through the SHARED typing emitter
+ * (`typing-emitter.ts`), which enforces one action per chat key per refresh
+ * window across BOTH loops. This factory keeps its lifecycle semantics —
+ * fire-on-start, refresh, stop-at-turn-end — and the floor lives in the emitter.
  *
  * Extracted into a factory so the lifecycle (fires on start, refreshes on the
  * interval, stops on turn-end, NEVER leaks a refresh interval after the turn

--- a/telegram-plugin/tests/typing-emitter.test.ts
+++ b/telegram-plugin/tests/typing-emitter.test.ts
@@ -207,67 +207,159 @@ interface Schedule {
   count: number
 }
 
+/**
+ * A VIRTUAL CLOCK + event queue — no `vi` fake timers anywhere in this file.
+ *
+ * This suite is DUAL-RUN: CI's `bun-test-run` executes the whole
+ * `telegram-plugin/tests` directory, and bun's `vi` shim has no
+ * `setSystemTime` / `useFakeTimers` (CLAUDE.md: dual-run files must avoid
+ * bun-incompatible vitest APIs). A test that throws on startup is not a weaker
+ * test, it is NOT A TEST — and this file is the entire guard for #3084, so it
+ * has to bite in BOTH runners.
+ *
+ * The emitter already takes injected `now` / `schedule` / `cancel`, so it needs
+ * no timer mocking at all. `createTurnTypingLoop` reaches for the global
+ * `setInterval`, so `withVirtualTimers` swaps the global for the queue below for
+ * the duration of one simulation and restores it after. Fully deterministic and
+ * runner-agnostic.
+ */
+interface VTimer {
+  id: number
+  at: number
+  fn: () => void
+  every: number | null
+}
+
+function createVirtualClock(start = 0) {
+  let t = start
+  let seq = 1
+  const timers = new Map<number, VTimer>()
+
+  function schedule(fn: () => void, ms: number, every: number | null = null): number {
+    const id = seq++
+    timers.set(id, { id, at: t + Math.max(0, ms), fn, every })
+    return id
+  }
+
+  return {
+    now: () => t,
+    schedule: (fn: () => void, ms: number) => schedule(fn, ms),
+    scheduleEvery: (fn: () => void, ms: number) => schedule(fn, ms, ms),
+    cancel: (h: unknown) => {
+      timers.delete(h as number)
+    },
+    /** Run every timer due at or before `target`, in (time, insertion) order. */
+    advanceTo(target: number): void {
+      for (;;) {
+        let next: VTimer | null = null
+        for (const tm of timers.values()) {
+          if (tm.at > target) continue
+          if (next === null || tm.at < next.at || (tm.at === next.at && tm.id < next.id)) {
+            next = tm
+          }
+        }
+        if (next === null) break
+        t = next.at
+        if (next.every != null) next.at = t + next.every
+        else timers.delete(next.id)
+        next.fn()
+      }
+      t = target
+    },
+    advanceBy(ms: number): void {
+      this.advanceTo(t + ms)
+    },
+    pending: () => timers.size,
+  }
+}
+
+type VirtualClock = ReturnType<typeof createVirtualClock>
+
+/** Run `body` with the GLOBAL setInterval/clearInterval bound to `clock`. */
+function withVirtualTimers<T>(clock: VirtualClock, body: () => T): T {
+  const realSetInterval = globalThis.setInterval
+  const realClearInterval = globalThis.clearInterval
+  globalThis.setInterval = ((fn: () => void, ms: number) =>
+    clock.scheduleEvery(fn, ms)) as unknown as typeof globalThis.setInterval
+  globalThis.clearInterval = ((h: unknown) =>
+    clock.cancel(h)) as unknown as typeof globalThis.clearInterval
+  try {
+    return body()
+  } finally {
+    globalThis.setInterval = realSetInterval
+    globalThis.clearInterval = realClearInterval
+  }
+}
+
 /** Run one schedule; return the emission times over the turn. */
 function simulateTurn(sch: Schedule): number[] {
-  vi.setSystemTime(0)
+  const clock = createVirtualClock(0)
   const sent: number[] = []
-  const emitter = createTypingEmitter({
-    chatKey,
-    now: () => Date.now(),
-    schedule: (fn, ms) => setTimeout(fn, ms),
-    cancel: (h) => clearTimeout(h as ReturnType<typeof setTimeout>),
-    send: () => sent.push(Date.now()),
+
+  return withVirtualTimers(clock, () => {
+    const emitter = createTypingEmitter({
+      chatKey,
+      now: clock.now,
+      schedule: clock.schedule,
+      cancel: clock.cancel,
+      send: () => sent.push(clock.now()),
+    })
+
+    // Loop A — the turn-level loop: fixed cadence for the WHOLE turn. The REAL
+    // factory, driving the REAL global setInterval (bound to the virtual clock).
+    const turnLoop = createTurnTypingLoop({
+      chatKey,
+      sendChatAction: (chatId, threadId) => {
+        emitter.emit(chatId, threadId, 'typing')
+      },
+      refreshMs: TYPING_REFRESH_MS,
+    })
+
+    // Loop B — the tool-use loop, as gateway.ts drives it: restarts (and fires
+    // immediately) per serial tool call, stops on the tool result when the
+    // ref-count hits zero.
+    let toolInterval: unknown = null
+    const startToolLoop = () => {
+      if (toolInterval != null) clearInterval(toolInterval as ReturnType<typeof setInterval>)
+      const send = () => emitter.emit('chat-1', null, 'typing')
+      send()
+      toolInterval = setInterval(send, TYPING_REFRESH_MS)
+    }
+    const stopToolLoop = () => {
+      if (toolInterval != null) clearInterval(toolInterval as ReturnType<typeof setInterval>)
+      toolInterval = null
+    }
+
+    // Build the tool start/stop timeline, then advance the clock through it.
+    const events: Array<{ at: number; fn: () => void }> = []
+    let cursor = sch.phase
+    for (let i = 0; i < sch.count && cursor < TURN_MS; i++) {
+      const start = cursor
+      const end = Math.min(start + sch.dur, TURN_MS)
+      events.push({ at: start, fn: startToolLoop })
+      events.push({ at: end, fn: stopToolLoop })
+      cursor = end + sch.gap
+    }
+    events.sort((a, b) => a.at - b.at)
+
+    turnLoop.start('chat-1', null) // turn enqueue — the cold-start ping
+    for (const ev of events) {
+      clock.advanceTo(ev.at)
+      ev.fn()
+    }
+    clock.advanceTo(TURN_MS)
+
+    turnLoop.stop('chat-1', null) // canonical turn-end
+    emitter.cancelPending('chat-1', null) // …as the gateway does
+    stopToolLoop()
+
+    // Nothing may fire after the turn ends — no zombie "typing…" on a dead turn.
+    const afterTurn = sent.length
+    clock.advanceTo(TURN_MS + 30_000)
+    expect(sent.length).toBe(afterTurn)
+
+    return sent
   })
-
-  // Loop A — the turn-level loop: fixed cadence for the WHOLE turn.
-  const turnLoop = createTurnTypingLoop({
-    chatKey,
-    sendChatAction: (chatId, threadId) => {
-      emitter.emit(chatId, threadId, 'typing')
-    },
-    refreshMs: TYPING_REFRESH_MS,
-  })
-
-  // Loop B — the tool-use loop: restarts (and fires immediately) per serial
-  // tool call, stops on the tool result when the ref-count hits zero.
-  let toolInterval: ReturnType<typeof setInterval> | null = null
-  const startToolLoop = () => {
-    if (toolInterval) clearInterval(toolInterval)
-    const send = () => emitter.emit('chat-1', null, 'typing')
-    send()
-    toolInterval = setInterval(send, TYPING_REFRESH_MS)
-  }
-  const stopToolLoop = () => {
-    if (toolInterval) clearInterval(toolInterval)
-    toolInterval = null
-  }
-
-  // Build the tool start/stop event timeline, then advance the clock through it.
-  const events: Array<{ at: number; fn: () => void }> = []
-  let cursor = sch.phase
-  for (let i = 0; i < sch.count && cursor < TURN_MS; i++) {
-    const start = cursor
-    const end = Math.min(start + sch.dur, TURN_MS)
-    events.push({ at: start, fn: startToolLoop })
-    events.push({ at: end, fn: stopToolLoop })
-    cursor = end + sch.gap
-  }
-  events.sort((a, b) => a.at - b.at)
-
-  turnLoop.start('chat-1', null) // turn enqueue — the cold-start ping
-  let t = 0
-  for (const ev of events) {
-    vi.advanceTimersByTime(ev.at - t)
-    t = ev.at
-    ev.fn()
-  }
-  vi.advanceTimersByTime(TURN_MS - t)
-
-  turnLoop.stop('chat-1', null) // canonical turn-end
-  emitter.cancelPending('chat-1', null) // …as the gateway does
-  stopToolLoop()
-  vi.clearAllTimers()
-  return sent
 }
 
 /** Longest stretch of the turn with no live "typing…", including the head. */
@@ -278,15 +370,6 @@ function maxDarkMs(sent: number[]): number {
 }
 
 describe('typing emitter — BOTH loops share one floor (#3084)', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-    vi.setSystemTime(0)
-  })
-  afterEach(() => {
-    vi.clearAllTimers()
-    vi.useRealTimers()
-  })
-
   it('the reviewer counterexample (phase=3500 dur=3400 n=6) never goes dark', () => {
     // Before the catch-up timer this schedule left a 7000 ms gap (emissions at
     // 21000 → 28000): a tool ping eats the turn loop's tick, the tool loop then
@@ -297,9 +380,9 @@ describe('typing emitter — BOTH loops share one floor (#3084)', () => {
     expect(sent.length).toBeLessThanOrEqual(MAX_EMISSIONS_PER_TURN)
   })
 
-  it('a 120-tool-call storm over 60 s emits ≤20 actions (the ban shape)', () => {
+  it('a 120-tool-call storm over 60 s emits <=20 actions (the ban shape)', () => {
     // The incident shape: serial tool calls firing every ~500 ms into ONE DM for
-    // a whole minute. Pre-fix this emitted ~135 actions (one per tool call, the
+    // a whole minute. Pre-fix this emitted ~136 actions (one per tool call, the
     // 8,729-pings-for-203-messages ratio). The cap is absolute, so it goes red
     // the moment the floor stops holding.
     const sent = simulateTurn({ phase: 0, dur: 250, gap: 250, count: 120 })
@@ -309,7 +392,7 @@ describe('typing emitter — BOTH loops share one floor (#3084)', () => {
   })
 
   it('ADVERSARIAL sweep: no schedule floods, and no schedule goes dark', () => {
-    // Sweep the tool-call phase/duration/count space — the point is that the
+    // Sweep the tool-call phase/duration/gap/count space — the point is that the
     // bound holds across schedules, not on one hand-picked one.
     let worstDark = 0
     let worstDarkSch: Schedule | null = null
@@ -335,14 +418,17 @@ describe('typing emitter — BOTH loops share one floor (#3084)', () => {
               worstCountSch = sch
             }
             // Floor still holds under every schedule — the flood cap is intact.
-            assertFloorHeld(sent.map((at) => ({ chatId: 'chat-1', threadId: null, action: 'typing', at })))
+            assertFloorHeld(
+              sent.map((at) => ({ chatId: 'chat-1', threadId: null, action: 'typing', at })),
+            )
           }
         }
       }
     }
 
     expect(schedules).toBeGreaterThan(500)
-    // The two outcomes, both absolute:
+    // The two outcomes, both absolute — neither is expressed in terms of the
+    // constants under test, so both go red when the mechanism is removed.
     expect(
       worstDark,
       `worst dark gap ${worstDark}ms on ${JSON.stringify(worstDarkSch)}`,
@@ -356,21 +442,22 @@ describe('typing emitter — BOTH loops share one floor (#3084)', () => {
   })
 
   it('a dropped tick arms exactly ONE coalesced catch-up, and never leaks', () => {
+    const clock = createVirtualClock(0)
     const sent: Sent[] = []
     const emitter = createTypingEmitter({
       chatKey,
-      now: () => Date.now(),
-      schedule: (fn, ms) => setTimeout(fn, ms),
-      cancel: (h) => clearTimeout(h as ReturnType<typeof setTimeout>),
+      now: clock.now,
+      schedule: clock.schedule,
+      cancel: clock.cancel,
       send: (chatId, threadId, action) =>
-        sent.push({ chatId, threadId, action, at: Date.now() }),
+        sent.push({ chatId, threadId, action, at: clock.now() }),
     })
 
     emitter.emit('chat-1') // t=0, sent
-    for (let i = 0; i < 20; i++) emitter.emit('chat-1') // 20 drops, one window
+    for (let i = 0; i < 20; i++) emitter.emit('chat-1') // 20 drops, ONE window
     expect(emitter.pendingCatchUps()).toBe(1) // coalesced — never 20 timers
 
-    vi.advanceTimersByTime(TYPING_FLOOR_MS)
+    clock.advanceBy(TYPING_FLOOR_MS)
     expect(sent.map((s) => s.at)).toEqual([0, TYPING_FLOOR_MS]) // catch-up fired
     expect(emitter.pendingCatchUps()).toBe(0) // …and did not re-arm itself
 
@@ -380,21 +467,23 @@ describe('typing emitter — BOTH loops share one floor (#3084)', () => {
     expect(emitter.pendingCatchUps()).toBe(1)
     emitter.cancelPending('chat-1')
     expect(emitter.pendingCatchUps()).toBe(0)
-    vi.advanceTimersByTime(10_000)
+    clock.advanceBy(10_000)
     expect(sent).toHaveLength(2) // nothing fired after the turn ended
+    expect(clock.pending()).toBe(0) // no timer leaked
   })
 
   it('a flood window cancels the catch-up instead of deferring a ping into the ban', () => {
+    const clock = createVirtualClock(0)
     let floodOpen = false
     const sent: Sent[] = []
     const emitter = createTypingEmitter({
       chatKey,
-      now: () => Date.now(),
+      now: clock.now,
       isSuppressed: () => floodOpen,
-      schedule: (fn, ms) => setTimeout(fn, ms),
-      cancel: (h) => clearTimeout(h as ReturnType<typeof setTimeout>),
+      schedule: clock.schedule,
+      cancel: clock.cancel,
       send: (chatId, threadId, action) =>
-        sent.push({ chatId, threadId, action, at: Date.now() }),
+        sent.push({ chatId, threadId, action, at: clock.now() }),
     })
 
     emitter.emit('chat-1')
@@ -402,11 +491,11 @@ describe('typing emitter — BOTH loops share one floor (#3084)', () => {
     expect(emitter.pendingCatchUps()).toBe(1)
 
     floodOpen = true
-    vi.advanceTimersByTime(TYPING_FLOOR_MS) // catch-up fires INTO the ban…
+    clock.advanceBy(TYPING_FLOOR_MS) // catch-up fires INTO the ban…
     expect(sent).toHaveLength(1) // …and is suppressed, not sent
     expect(emitter.pendingCatchUps()).toBe(0)
 
-    vi.advanceTimersByTime(60_000)
+    clock.advanceBy(60_000)
     expect(sent).toHaveLength(1)
   })
 })

--- a/telegram-plugin/tests/typing-emitter.test.ts
+++ b/telegram-plugin/tests/typing-emitter.test.ts
@@ -175,71 +175,239 @@ describe('typing emitter — per-chat-key emission floor (#3084)', () => {
   })
 })
 
+/**
+ * A 60 s turn, the REAL `createTurnTypingLoop`, and a faithful reproduction of
+ * the tool-use loop as gateway.ts drives it (stop → restart → fire immediately
+ * → re-arm a fixed interval), both emitting through ONE emitter.
+ *
+ * The bounds below are ABSOLUTE — derived from the incident and from Telegram's
+ * action expiry, never from the implementation constants. A test whose bound is
+ * expressed in terms of the thing it tests cannot fail when that thing is
+ * removed: with the floor disabled, `ceil(60_000 / floorMs)` is Infinity. These
+ * numbers go red on the unfixed code (~135 emissions in 60 s), which is the
+ * only property that makes them worth having.
+ */
+const TURN_MS = 60_000
+/** 60 s at the enforced floor is ~17 emissions. 20 is the slack-adjusted cap;
+ *  the pre-fix code emits ~135 (one per tool call) and fails this loudly. */
+const MAX_EMISSIONS_PER_TURN = 20
+/** Telegram's `typing` chat action expires at ~5 s. A longer gap = a DARK chat
+ *  mid-turn, which breaches know-what-my-agent-is-doing ("stays present from
+ *  receipt to turn end"). This is the assertion the catch-up timer exists for. */
+const MAX_DARK_MS = 5000
+
+interface Schedule {
+  /** ms into the turn before the first tool call fires. */
+  phase: number
+  /** how long each tool call runs (loop stops on the tool result). */
+  dur: number
+  /** quiet gap between tool calls (agent thinking / streaming text). */
+  gap: number
+  /** number of serial tool calls. */
+  count: number
+}
+
+/** Run one schedule; return the emission times over the turn. */
+function simulateTurn(sch: Schedule): number[] {
+  vi.setSystemTime(0)
+  const sent: number[] = []
+  const emitter = createTypingEmitter({
+    chatKey,
+    now: () => Date.now(),
+    schedule: (fn, ms) => setTimeout(fn, ms),
+    cancel: (h) => clearTimeout(h as ReturnType<typeof setTimeout>),
+    send: () => sent.push(Date.now()),
+  })
+
+  // Loop A — the turn-level loop: fixed cadence for the WHOLE turn.
+  const turnLoop = createTurnTypingLoop({
+    chatKey,
+    sendChatAction: (chatId, threadId) => {
+      emitter.emit(chatId, threadId, 'typing')
+    },
+    refreshMs: TYPING_REFRESH_MS,
+  })
+
+  // Loop B — the tool-use loop: restarts (and fires immediately) per serial
+  // tool call, stops on the tool result when the ref-count hits zero.
+  let toolInterval: ReturnType<typeof setInterval> | null = null
+  const startToolLoop = () => {
+    if (toolInterval) clearInterval(toolInterval)
+    const send = () => emitter.emit('chat-1', null, 'typing')
+    send()
+    toolInterval = setInterval(send, TYPING_REFRESH_MS)
+  }
+  const stopToolLoop = () => {
+    if (toolInterval) clearInterval(toolInterval)
+    toolInterval = null
+  }
+
+  // Build the tool start/stop event timeline, then advance the clock through it.
+  const events: Array<{ at: number; fn: () => void }> = []
+  let cursor = sch.phase
+  for (let i = 0; i < sch.count && cursor < TURN_MS; i++) {
+    const start = cursor
+    const end = Math.min(start + sch.dur, TURN_MS)
+    events.push({ at: start, fn: startToolLoop })
+    events.push({ at: end, fn: stopToolLoop })
+    cursor = end + sch.gap
+  }
+  events.sort((a, b) => a.at - b.at)
+
+  turnLoop.start('chat-1', null) // turn enqueue — the cold-start ping
+  let t = 0
+  for (const ev of events) {
+    vi.advanceTimersByTime(ev.at - t)
+    t = ev.at
+    ev.fn()
+  }
+  vi.advanceTimersByTime(TURN_MS - t)
+
+  turnLoop.stop('chat-1', null) // canonical turn-end
+  emitter.cancelPending('chat-1', null) // …as the gateway does
+  stopToolLoop()
+  vi.clearAllTimers()
+  return sent
+}
+
+/** Longest stretch of the turn with no live "typing…", including the head. */
+function maxDarkMs(sent: number[]): number {
+  let worst = sent.length > 0 ? sent[0]! : TURN_MS
+  for (let i = 1; i < sent.length; i++) worst = Math.max(worst, sent[i]! - sent[i - 1]!)
+  return worst
+}
+
 describe('typing emitter — BOTH loops share one floor (#3084)', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(0)
   })
   afterEach(() => {
+    vi.clearAllTimers()
     vi.useRealTimers()
   })
 
-  it('a tool-call storm alongside the turn loop cannot outrun the floor', () => {
+  it('the reviewer counterexample (phase=3500 dur=3400 n=6) never goes dark', () => {
+    // Before the catch-up timer this schedule left a 7000 ms gap (emissions at
+    // 21000 → 28000): a tool ping eats the turn loop's tick, the tool loop then
+    // stops, and the turn loop's NEXT fixed tick is floor+refresh away. ~2 s of
+    // a dead indicator mid-turn. Red before the fix, green after.
+    const sent = simulateTurn({ phase: 3500, dur: 3400, gap: 300, count: 6 })
+    expect(maxDarkMs(sent)).toBeLessThanOrEqual(MAX_DARK_MS)
+    expect(sent.length).toBeLessThanOrEqual(MAX_EMISSIONS_PER_TURN)
+  })
+
+  it('a 120-tool-call storm over 60 s emits ≤20 actions (the ban shape)', () => {
+    // The incident shape: serial tool calls firing every ~500 ms into ONE DM for
+    // a whole minute. Pre-fix this emitted ~135 actions (one per tool call, the
+    // 8,729-pings-for-203-messages ratio). The cap is absolute, so it goes red
+    // the moment the floor stops holding.
+    const sent = simulateTurn({ phase: 0, dur: 250, gap: 250, count: 120 })
+    expect(sent.length).toBeLessThanOrEqual(MAX_EMISSIONS_PER_TURN)
+    expect(sent.length).toBeGreaterThan(10) // still lit for the whole minute
+    expect(maxDarkMs(sent)).toBeLessThanOrEqual(MAX_DARK_MS)
+  })
+
+  it('ADVERSARIAL sweep: no schedule floods, and no schedule goes dark', () => {
+    // Sweep the tool-call phase/duration/count space — the point is that the
+    // bound holds across schedules, not on one hand-picked one.
+    let worstDark = 0
+    let worstDarkSch: Schedule | null = null
+    let worstCount = 0
+    let worstCountSch: Schedule | null = null
+    let schedules = 0
+
+    for (let phase = 0; phase <= 4000; phase += 250) {
+      for (let dur = 200; dur <= 4200; dur += 400) {
+        for (const gap of [150, 900, 2600]) {
+          for (const count of [3, 6, 12]) {
+            const sch: Schedule = { phase, dur, gap, count }
+            const sent = simulateTurn(sch)
+            schedules++
+
+            const dark = maxDarkMs(sent)
+            if (dark > worstDark) {
+              worstDark = dark
+              worstDarkSch = sch
+            }
+            if (sent.length > worstCount) {
+              worstCount = sent.length
+              worstCountSch = sch
+            }
+            // Floor still holds under every schedule — the flood cap is intact.
+            assertFloorHeld(sent.map((at) => ({ chatId: 'chat-1', threadId: null, action: 'typing', at })))
+          }
+        }
+      }
+    }
+
+    expect(schedules).toBeGreaterThan(500)
+    // The two outcomes, both absolute:
+    expect(
+      worstDark,
+      `worst dark gap ${worstDark}ms on ${JSON.stringify(worstDarkSch)}`,
+    ).toBeLessThanOrEqual(MAX_DARK_MS) // never a dark chat
+    expect(
+      worstCount,
+      `worst emission count ${worstCount} on ${JSON.stringify(worstCountSch)}`,
+    ).toBeLessThanOrEqual(MAX_EMISSIONS_PER_TURN) // never a flood
+    // …and the indicator is genuinely live, not merely "not flooding".
+    expect(worstCount).toBeGreaterThan(10)
+  })
+
+  it('a dropped tick arms exactly ONE coalesced catch-up, and never leaks', () => {
     const sent: Sent[] = []
     const emitter = createTypingEmitter({
       chatKey,
       now: () => Date.now(),
+      schedule: (fn, ms) => setTimeout(fn, ms),
+      cancel: (h) => clearTimeout(h as ReturnType<typeof setTimeout>),
       send: (chatId, threadId, action) =>
         sent.push({ chatId, threadId, action, at: Date.now() }),
     })
 
-    // Loop A: the turn-level loop (real factory, real interval semantics).
-    const turnLoop = createTurnTypingLoop({
+    emitter.emit('chat-1') // t=0, sent
+    for (let i = 0; i < 20; i++) emitter.emit('chat-1') // 20 drops, one window
+    expect(emitter.pendingCatchUps()).toBe(1) // coalesced — never 20 timers
+
+    vi.advanceTimersByTime(TYPING_FLOOR_MS)
+    expect(sent.map((s) => s.at)).toEqual([0, TYPING_FLOOR_MS]) // catch-up fired
+    expect(emitter.pendingCatchUps()).toBe(0) // …and did not re-arm itself
+
+    // Turn-end cancellation: a drop in the last moments of a turn must not
+    // resurrect "typing…" after the reply has landed.
+    emitter.emit('chat-1')
+    expect(emitter.pendingCatchUps()).toBe(1)
+    emitter.cancelPending('chat-1')
+    expect(emitter.pendingCatchUps()).toBe(0)
+    vi.advanceTimersByTime(10_000)
+    expect(sent).toHaveLength(2) // nothing fired after the turn ended
+  })
+
+  it('a flood window cancels the catch-up instead of deferring a ping into the ban', () => {
+    let floodOpen = false
+    const sent: Sent[] = []
+    const emitter = createTypingEmitter({
       chatKey,
-      sendChatAction: (chatId, threadId) => {
-        emitter.emit(chatId, threadId, 'typing')
-      },
-      refreshMs: TYPING_REFRESH_MS,
+      now: () => Date.now(),
+      isSuppressed: () => floodOpen,
+      schedule: (fn, ms) => setTimeout(fn, ms),
+      cancel: (h) => clearTimeout(h as ReturnType<typeof setTimeout>),
+      send: (chatId, threadId, action) =>
+        sent.push({ chatId, threadId, action, at: Date.now() }),
     })
 
-    // Loop B: the tool-use loop, reproduced exactly as gateway.ts drives it —
-    // stop, restart, fire immediately, re-arm the interval.
-    let toolInterval: ReturnType<typeof setInterval> | null = null
-    const startToolLoop = (chatId: string) => {
-      if (toolInterval) clearInterval(toolInterval)
-      const send = () => emitter.emit(chatId, null, 'typing')
-      send()
-      toolInterval = setInterval(send, TYPING_REFRESH_MS)
-    }
-    const stopToolLoop = () => {
-      if (toolInterval) clearInterval(toolInterval)
-      toolInterval = null
-    }
+    emitter.emit('chat-1')
+    emitter.emit('chat-1') // dropped by the floor → catch-up armed
+    expect(emitter.pendingCatchUps()).toBe(1)
 
-    turnLoop.start('chat-1', null)
+    floodOpen = true
+    vi.advanceTimersByTime(TYPING_FLOOR_MS) // catch-up fires INTO the ban…
+    expect(sent).toHaveLength(1) // …and is suppressed, not sent
+    expect(emitter.pendingCatchUps()).toBe(0)
 
-    // 120 tool calls over 60 s — 3-4 parallel subagents hammering one DM, the
-    // exact shape that produced 8,729 pings for 203 messages.
-    for (let i = 0; i < 120; i++) {
-      startToolLoop('chat-1')
-      vi.advanceTimersByTime(250)
-      stopToolLoop() // tool result — ref-count hits zero, loop stops
-      vi.advanceTimersByTime(250)
-    }
-    turnLoop.stop('chat-1', null)
-    stopToolLoop()
-
-    // OUTCOME: 60 s elapsed. Before the fix this emitted 120+ actions
-    // (one per tool call, ~2/s). The floor caps it at one per 3.5 s.
-    const maxAllowed = Math.ceil(60_000 / TYPING_FLOOR_MS) + 1
-    expect(sent.length).toBeLessThanOrEqual(maxAllowed)
-    expect(sent.length).toBeGreaterThan(10) // …and the chat is still lit
-    assertFloorHeld(sent)
-
-    // The chat never goes dark: no gap exceeds Telegram's ~5 s action expiry.
-    for (let i = 1; i < sent.length; i++) {
-      expect(sent[i]!.at - sent[i - 1]!.at).toBeLessThan(5000)
-    }
+    vi.advanceTimersByTime(60_000)
+    expect(sent).toHaveLength(1)
   })
 })
 

--- a/telegram-plugin/tests/typing-emitter.test.ts
+++ b/telegram-plugin/tests/typing-emitter.test.ts
@@ -1,0 +1,310 @@
+/**
+ * #3084 — the typing indicator must be structurally incapable of earning a
+ * per-bot flood ban.
+ *
+ * On 2026-07-11 `overlord` emitted 8,729 sendChatAction calls (55% of ALL
+ * outbound volume, bursting 200-300/min into ONE DM) to deliver 203 messages,
+ * and Telegram banned the bot token for 4.6 hours (429 retry_after=16739s).
+ * Root cause: both typing loops fire an action IMMEDIATELY on (re)start, and
+ * the tool-use wrapper restarts the loop on every tool call — so the ping rate
+ * equalled the agent's TOOL-CALL rate and the "4 s interval" was decorative.
+ *
+ * These tests assert the OUTCOME the fix owes: no matter how the loops are
+ * driven, at most ~one chat action per chat key per refresh window.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  createTypingEmitter,
+  TYPING_FLOOR_MS,
+  TYPING_REFRESH_MS,
+} from '../typing-emitter.js'
+import { createTurnTypingLoop } from '../gateway/turn-typing-loop.js'
+import { createRetryApiCall } from '../retry-api-call.js'
+import {
+  floodStatePath,
+  makeFloodWaitRecorder,
+  suppressNonEssentialSendMs,
+} from '../flood-circuit-breaker.js'
+import { errors } from './fake-bot-api.js'
+
+const chatKey = (chatId: string, threadId: number | null) =>
+  `${chatId}:${threadId ?? '_'}`
+
+/** Deterministic clock — no real timers anywhere in the emitter tests. */
+function fakeClock(start = 1_000_000) {
+  let t = start
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms
+    },
+    set: (ms: number) => {
+      t = ms
+    },
+  }
+}
+
+interface Sent {
+  chatId: string
+  threadId: number | null
+  action: string
+  at: number
+}
+
+function harness(opts: { suppressed?: () => boolean } = {}) {
+  const clock = fakeClock()
+  const sent: Sent[] = []
+  const emitter = createTypingEmitter({
+    chatKey,
+    now: clock.now,
+    isSuppressed: opts.suppressed ?? (() => false),
+    send: (chatId, threadId, action) =>
+      sent.push({ chatId, threadId, action, at: clock.now() }),
+  })
+  return { clock, sent, emitter }
+}
+
+/** The invariant the ban owes us: no two emissions on one key inside the floor. */
+function assertFloorHeld(sent: Sent[], floorMs = TYPING_FLOOR_MS): void {
+  const lastByKey = new Map<string, number>()
+  for (const s of sent) {
+    const k = chatKey(s.chatId, s.threadId)
+    const prev = lastByKey.get(k)
+    if (prev != null) {
+      expect(s.at - prev).toBeGreaterThanOrEqual(floorMs)
+    }
+    lastByKey.set(k, s.at)
+  }
+}
+
+describe('typing emitter — per-chat-key emission floor (#3084)', () => {
+  it('50 loop restarts in 2 s emit exactly ONE chat action (the regression)', () => {
+    const { clock, sent, emitter } = harness()
+
+    // Mirrors the production driver: the tool-use typing wrapper restarts the
+    // loop on every tool call, and each restart fired an immediate ping.
+    for (let i = 0; i < 50; i++) {
+      emitter.emit('chat-1', null, 'typing')
+      clock.advance(40) // 50 restarts across 2 s — the observed burst shape
+    }
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]?.at).toBe(1_000_000)
+    assertFloorHeld(sent)
+  })
+
+  it('a cold start still pings IMMEDIATELY — the UX intent survives', () => {
+    const { sent, emitter } = harness()
+    expect(emitter.emit('chat-1')).toBe(true)
+    expect(sent).toHaveLength(1)
+  })
+
+  it('the floor releases after the window, so the indicator stays lit', () => {
+    const { clock, sent, emitter } = harness()
+    emitter.emit('chat-1')
+    clock.advance(TYPING_FLOOR_MS - 1)
+    expect(emitter.emit('chat-1')).toBe(false)
+    clock.advance(1)
+    expect(emitter.emit('chat-1')).toBe(true)
+    expect(sent).toHaveLength(2)
+  })
+
+  it('the floor is UNDER the refresh cadence, so an on-time refresh is never eaten', () => {
+    const { clock, sent, emitter } = harness()
+    // A loop refreshing on its own 4 s cadence must never be dropped, or the
+    // chat goes dark (Telegram's typing action expires at ~5 s).
+    for (let i = 0; i < 15; i++) {
+      expect(emitter.emit('chat-1')).toBe(true)
+      clock.advance(TYPING_REFRESH_MS)
+    }
+    expect(sent).toHaveLength(15)
+    expect(TYPING_FLOOR_MS).toBeLessThan(TYPING_REFRESH_MS)
+  })
+
+  it('two chats (and two topics in one chat) are independent lanes', () => {
+    const { sent, emitter } = harness()
+    expect(emitter.emit('chat-1', null)).toBe(true)
+    expect(emitter.emit('chat-2', null)).toBe(true)
+    expect(emitter.emit('chat-1', 77)).toBe(true) // supergroup topic = own lane
+    expect(emitter.emit('chat-1', null)).toBe(false) // same lane, inside floor
+    expect(sent).toHaveLength(3)
+  })
+
+  it('emits NOTHING while a flood window is open (typing is non-essential)', () => {
+    let floodOpen = true
+    const { clock, sent, emitter } = harness({ suppressed: () => floodOpen })
+
+    for (let i = 0; i < 40; i++) {
+      expect(emitter.emit('chat-1')).toBe(false)
+      clock.advance(1000)
+    }
+    expect(sent).toHaveLength(0)
+
+    floodOpen = false
+    expect(emitter.emit('chat-1')).toBe(true)
+    expect(sent).toHaveLength(1)
+  })
+
+  it('checks the flood state at most once per floor per chat (no read storm)', () => {
+    const suppressed = vi.fn(() => false)
+    const clock = fakeClock()
+    const emitter = createTypingEmitter({
+      chatKey,
+      now: clock.now,
+      isSuppressed: suppressed,
+      send: () => {},
+    })
+    for (let i = 0; i < 50; i++) {
+      emitter.emit('chat-1')
+      clock.advance(40)
+    }
+    // 2 s of restarts, floor 3.5 s → one window claimed → one flood check.
+    expect(suppressed).toHaveBeenCalledTimes(1)
+  })
+
+  it('a backwards clock step does not wedge the indicator off', () => {
+    const { clock, sent, emitter } = harness()
+    emitter.emit('chat-1')
+    clock.set(500) // NTP step backwards
+    expect(emitter.emit('chat-1')).toBe(true)
+    expect(sent).toHaveLength(2)
+  })
+})
+
+describe('typing emitter — BOTH loops share one floor (#3084)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('a tool-call storm alongside the turn loop cannot outrun the floor', () => {
+    const sent: Sent[] = []
+    const emitter = createTypingEmitter({
+      chatKey,
+      now: () => Date.now(),
+      send: (chatId, threadId, action) =>
+        sent.push({ chatId, threadId, action, at: Date.now() }),
+    })
+
+    // Loop A: the turn-level loop (real factory, real interval semantics).
+    const turnLoop = createTurnTypingLoop({
+      chatKey,
+      sendChatAction: (chatId, threadId) => {
+        emitter.emit(chatId, threadId, 'typing')
+      },
+      refreshMs: TYPING_REFRESH_MS,
+    })
+
+    // Loop B: the tool-use loop, reproduced exactly as gateway.ts drives it —
+    // stop, restart, fire immediately, re-arm the interval.
+    let toolInterval: ReturnType<typeof setInterval> | null = null
+    const startToolLoop = (chatId: string) => {
+      if (toolInterval) clearInterval(toolInterval)
+      const send = () => emitter.emit(chatId, null, 'typing')
+      send()
+      toolInterval = setInterval(send, TYPING_REFRESH_MS)
+    }
+    const stopToolLoop = () => {
+      if (toolInterval) clearInterval(toolInterval)
+      toolInterval = null
+    }
+
+    turnLoop.start('chat-1', null)
+
+    // 120 tool calls over 60 s — 3-4 parallel subagents hammering one DM, the
+    // exact shape that produced 8,729 pings for 203 messages.
+    for (let i = 0; i < 120; i++) {
+      startToolLoop('chat-1')
+      vi.advanceTimersByTime(250)
+      stopToolLoop() // tool result — ref-count hits zero, loop stops
+      vi.advanceTimersByTime(250)
+    }
+    turnLoop.stop('chat-1', null)
+    stopToolLoop()
+
+    // OUTCOME: 60 s elapsed. Before the fix this emitted 120+ actions
+    // (one per tool call, ~2/s). The floor caps it at one per 3.5 s.
+    const maxAllowed = Math.ceil(60_000 / TYPING_FLOOR_MS) + 1
+    expect(sent.length).toBeLessThanOrEqual(maxAllowed)
+    expect(sent.length).toBeGreaterThan(10) // …and the chat is still lit
+    assertFloorHeld(sent)
+
+    // The chat never goes dark: no gap exceeds Telegram's ~5 s action expiry.
+    for (let i = 1; i < sent.length; i++) {
+      expect(sent[i]!.at - sent[i - 1]!.at).toBeLessThan(5000)
+    }
+  })
+})
+
+describe('typing sends record 429s to the flood breaker (#3084 / #2923)', () => {
+  let dir: string
+  let path: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'typing-flood-'))
+    path = floodStatePath(dir)
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  /** The gateway's `nonEssentialApiCall`: records the flood, never retries. */
+  const nonEssentialApiCall = () =>
+    createRetryApiCall({
+      maxRetries: 1,
+      sleep: async () => {},
+      onFloodWait: makeFloodWaitRecorder(path),
+    })
+
+  it('a 429 on a typing ping is RECORDED, not swallowed', async () => {
+    const call = nonEssentialApiCall()
+    const fn = vi.fn().mockRejectedValue(errors.floodWait(16739))
+
+    await expect(call(fn, { verb: 'sendChatAction' })).rejects.toThrow()
+
+    // Recorded: the breaker now knows the bot is banned — before the fix the
+    // typing path called bot.api raw with `.catch(() => {})`, so the breaker
+    // was blind to 429s from the LARGEST emitter of them.
+    expect(suppressNonEssentialSendMs(path, Date.now())).toBeGreaterThan(0)
+  })
+
+  it('a typing ping is NEVER retried (a retry is what feeds the ban)', async () => {
+    const call = nonEssentialApiCall()
+    const fn = vi.fn().mockRejectedValue(errors.floodWait(16739))
+    await expect(call(fn)).rejects.toThrow()
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('the recorded window then suppresses further typing end-to-end', async () => {
+    const call = nonEssentialApiCall()
+    const sent: Sent[] = []
+    const clock = fakeClock()
+    const emitter = createTypingEmitter({
+      chatKey,
+      now: clock.now,
+      isSuppressed: () => suppressNonEssentialSendMs(path, Date.now()) > 0,
+      send: (chatId, threadId, action) =>
+        sent.push({ chatId, threadId, action, at: clock.now() }),
+    })
+
+    expect(emitter.emit('chat-1')).toBe(true) // healthy: pings
+
+    // The bot earns a flood ban on some other send.
+    await expect(
+      call(vi.fn().mockRejectedValue(errors.floodWait(600))),
+    ).rejects.toThrow()
+
+    clock.advance(TYPING_FLOOR_MS)
+    expect(emitter.emit('chat-1')).toBe(false) // banned: silent
+    clock.advance(TYPING_FLOOR_MS)
+    expect(emitter.emit('chat-1')).toBe(false)
+    expect(sent).toHaveLength(1)
+  })
+})

--- a/telegram-plugin/tests/typing-emitter.test.ts
+++ b/telegram-plugin/tests/typing-emitter.test.ts
@@ -23,7 +23,7 @@ import {
   TYPING_REFRESH_MS,
 } from '../typing-emitter.js'
 import { createTurnTypingLoop } from '../gateway/turn-typing-loop.js'
-import { createRetryApiCall } from '../retry-api-call.js'
+import { createRetryApiCall, isFloodWaitActiveError } from '../retry-api-call.js'
 import {
   floodStatePath,
   makeFloodWaitRecorder,
@@ -537,6 +537,25 @@ describe('typing sends record 429s to the flood breaker (#3084 / #2923)', () => 
     const fn = vi.fn().mockRejectedValue(errors.floodWait(16739))
     await expect(call(fn)).rejects.toThrow()
     expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('composes with #3094: a long ban surfaces FLOOD_WAIT_ACTIVE, still ONE call', async () => {
+    // #3094 bounded the in-process flood sleep: above the ceiling retryApiCall
+    // throws the FLOOD_WAIT_ACTIVE marker instead of sleeping out a multi-hour
+    // retry_after. For a typing ping that changes nothing that matters — the
+    // window is still recorded, the API is still hit exactly once, nothing is
+    // slept. The gateway's onRejected handler drops the marker, so a
+    // fire-and-forget ping can't surface it as an unhandled rejection.
+    const call = nonEssentialApiCall()
+    const fn = vi.fn().mockRejectedValue(errors.floodWait(16739))
+
+    const err = await call(fn).then(
+      () => null,
+      (e: unknown) => e,
+    )
+    expect(isFloodWaitActiveError(err)).toBe(true)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(suppressNonEssentialSendMs(path, Date.now())).toBeGreaterThan(0)
   })
 
   it('the recorded window then suppresses further typing end-to-end', async () => {

--- a/telegram-plugin/typing-emitter.ts
+++ b/telegram-plugin/typing-emitter.ts
@@ -1,0 +1,132 @@
+/**
+ * The single gate every `sendChatAction` in the gateway passes through (#3084).
+ *
+ * WHY THIS EXISTS — the 2026-07-11 flood ban
+ * ------------------------------------------
+ * The typing indicator used to be "a 4 s interval", which sounds rate-limited
+ * and is not. Both typing loops (`startTypingLoop` in gateway.ts and the
+ * turn-level `createTurnTypingLoop`) are restart-safe by design: a re-start
+ * clears the old interval and fires ONE action immediately so "typing…" lands
+ * instantly. The tool-use wrapper restarts the loop on every tool call, so the
+ * ping rate tracked the AGENT'S TOOL-CALL RATE, not the 4 s cadence — the
+ * interval was decorative. On 2026-07-11 `overlord` emitted 8,729
+ * sendChatAction calls (55% of all outbound volume, bursting at 200-300/min
+ * into ONE DM) to deliver 203 messages, and earned a per-bot-token flood ban:
+ * `429 retry_after=16739s` — 4.6 hours with every outbound reply rejected.
+ *
+ * The old code comment said the redundant pings were "harmless — same action,
+ * and sendChatAction is cheap." They are not cheap. They spend the per-bot
+ * flood budget the REPLIES need.
+ *
+ * WHAT THIS ENFORCES
+ * ------------------
+ *   1. A per-chat-key emission FLOOR. At most one chat action per key per
+ *      `floorMs` (~4 s refresh window), no matter how many loops restart, from
+ *      which caller, on which surface. Both loops share ONE emitter, so the
+ *      floor holds ACROSS them — they target the same chat key and neither can
+ *      out-shout the other. This is what structurally decouples ping rate from
+ *      tool-call rate.
+ *   2. The UX intent survives: a COLD start (no ping for this key inside the
+ *      floor) still fires immediately, so "typing…" lands the moment a turn
+ *      begins. Only the REDUNDANT restarts are dropped.
+ *   3. NON-ESSENTIAL by definition: while a flood-wait window is open
+ *      (`isSuppressed`, wired to the #2923 circuit breaker) no typing is
+ *      emitted at all. It cannot succeed, and sending into an open window can
+ *      extend the ban.
+ *
+ * The window is claimed on every attempt that PASSES the floor, including one
+ * suppressed by a flood window. That is deliberate: it bounds the flood-state
+ * read to once per floor per chat instead of once per tool call.
+ *
+ * Pure + injectable (clock, send, chat-key, suppression) so the whole gate is
+ * unit-testable on a fake clock without a bot — `tests/typing-emitter.test.ts`.
+ */
+
+/** Refresh cadence of the typing loops. Telegram's `typing` expires at ~5 s. */
+export const TYPING_REFRESH_MS = 4000
+
+/**
+ * Minimum gap between two chat actions on one chat key. Deliberately a hair
+ * UNDER `TYPING_REFRESH_MS` so a loop's own on-time refresh is never eaten by
+ * timer jitter (a 3999 ms tick would be dropped by a 4000 ms floor, and the
+ * indicator would go dark for a whole window). The gap between successive
+ * emissions therefore stays under Telegram's ~5 s action expiry, while the
+ * worst-case rate falls from the observed ~300/min to ~17/min per chat.
+ */
+export const TYPING_FLOOR_MS = 3500
+
+export interface TypingEmitterDeps {
+  /** Perform the actual chat action. Errors are the caller's concern — the
+   *  emitter never throws and never awaits. */
+  send: (chatId: string, threadId: number | null, action: string) => void
+  /** Canonical chat:thread key (the gateway's `chatKey`) — a supergroup topic
+   *  is its own lane and gets its own floor. */
+  chatKey: (chatId: string, threadId: number | null) => string
+  /** True while a flood-wait window is open. Typing is non-essential: while
+   *  this is true nothing is emitted. Defaults to "never suppressed". */
+  isSuppressed?: () => boolean
+  /** Injected clock (tests pass a fake). */
+  now?: () => number
+  /** Per-key emission floor in ms. */
+  floorMs?: number
+  /** Observability hook — fires for each dropped emission. */
+  onDrop?: (info: { key: string; reason: 'floor' | 'flood' }) => void
+}
+
+export interface TypingEmitter {
+  /**
+   * Emit one chat action for (chatId, threadId), subject to the floor and the
+   * flood gate. Returns true iff the action was actually handed to `send`.
+   */
+  emit: (chatId: string, threadId?: number | null, action?: string) => boolean
+  /** Test/observability: number of chat keys currently tracked. */
+  trackedKeys: () => number
+  /** Drop all floor state (shutdown / tests). */
+  reset: () => void
+}
+
+/** Keep the floor map from growing without bound in a long-lived gateway. */
+const PRUNE_AFTER_FACTOR = 10
+const PRUNE_SIZE_THRESHOLD = 64
+
+export function createTypingEmitter(deps: TypingEmitterDeps): TypingEmitter {
+  const floorMs = deps.floorMs ?? TYPING_FLOOR_MS
+  const now = deps.now ?? Date.now
+  const isSuppressed = deps.isSuppressed ?? (() => false)
+  /** chat key → epoch ms at which the current emission window was claimed. */
+  const windowClaimedAt = new Map<string, number>()
+
+  function prune(t: number): void {
+    if (windowClaimedAt.size <= PRUNE_SIZE_THRESHOLD) return
+    const cutoff = t - floorMs * PRUNE_AFTER_FACTOR
+    for (const [k, ts] of [...windowClaimedAt.entries()]) {
+      if (ts < cutoff) windowClaimedAt.delete(k)
+    }
+  }
+
+  return {
+    emit(chatId, threadId = null, action = 'typing') {
+      const key = deps.chatKey(chatId, threadId ?? null)
+      const t = now()
+      const claimed = windowClaimedAt.get(key)
+      // `t >= claimed` guards a backwards clock step (NTP): a stale future
+      // timestamp must not wedge the indicator off, so treat it as expired.
+      if (claimed != null && t >= claimed && t - claimed < floorMs) {
+        deps.onDrop?.({ key, reason: 'floor' })
+        return false
+      }
+      // Claim the window BEFORE the flood check so a burst of restarts costs
+      // one flood-state read per floor, not one per restart.
+      windowClaimedAt.set(key, t)
+      prune(t)
+      if (isSuppressed()) {
+        deps.onDrop?.({ key, reason: 'flood' })
+        return false
+      }
+      deps.send(chatId, threadId ?? null, action)
+      return true
+    },
+    trackedKeys: () => windowClaimedAt.size,
+    reset: () => windowClaimedAt.clear(),
+  }
+}

--- a/telegram-plugin/typing-emitter.ts
+++ b/telegram-plugin/typing-emitter.ts
@@ -28,7 +28,13 @@
  *      tool-call rate.
  *   2. The UX intent survives: a COLD start (no ping for this key inside the
  *      floor) still fires immediately, so "typing…" lands the moment a turn
- *      begins. Only the REDUNDANT restarts are dropped.
+ *      begins. Only the REDUNDANT restarts are dropped — and a dropped tick is
+ *      never silently lost: it arms a COALESCED catch-up at the instant the
+ *      window opens, so the worst-case gap between two emissions is `floorMs`
+ *      (3.5 s), comfortably inside Telegram's ~5 s action expiry. Without it,
+ *      an eaten tick on a fixed-cadence loop pushes the next emission out to
+ *      `floorMs + refreshMs` = 7.5 s and the chat goes DARK mid-turn — trading
+ *      a flood ban for a dead indicator, which is not a trade we make.
  *   3. NON-ESSENTIAL by definition: while a flood-wait window is open
  *      (`isSuppressed`, wired to the #2923 circuit breaker) no typing is
  *      emitted at all. It cannot succeed, and sending into an open window can
@@ -69,6 +75,10 @@ export interface TypingEmitterDeps {
   now?: () => number
   /** Per-key emission floor in ms. */
   floorMs?: number
+  /** Injected timer for the catch-up (tests pass fake timers). */
+  schedule?: (fn: () => void, ms: number) => unknown
+  /** Cancel a handle returned by `schedule`. */
+  cancel?: (handle: unknown) => void
   /** Observability hook — fires for each dropped emission. */
   onDrop?: (info: { key: string; reason: 'floor' | 'flood' }) => void
 }
@@ -77,11 +87,23 @@ export interface TypingEmitter {
   /**
    * Emit one chat action for (chatId, threadId), subject to the floor and the
    * flood gate. Returns true iff the action was actually handed to `send`.
+   * A floor-dropped emission arms a coalesced catch-up (see below), so the
+   * caller's cadence is never silently lost.
    */
   emit: (chatId: string, threadId?: number | null, action?: string) => boolean
+  /**
+   * Cancel any pending catch-up for a chat key. The canonical turn-end calls
+   * this so a dropped tick can't resurrect "typing…" after the turn is over.
+   * Does NOT clear the floor — the floor must survive loop stops, because the
+   * tool loop stops on every tool result and that is precisely the churn the
+   * floor exists to absorb.
+   */
+  cancelPending: (chatId: string, threadId?: number | null) => void
   /** Test/observability: number of chat keys currently tracked. */
   trackedKeys: () => number
-  /** Drop all floor state (shutdown / tests). */
+  /** Test/observability: number of catch-ups currently armed (0 ⇒ none leaked). */
+  pendingCatchUps: () => number
+  /** Drop all floor state and cancel every catch-up (shutdown / tests). */
   reset: () => void
 }
 
@@ -93,40 +115,110 @@ export function createTypingEmitter(deps: TypingEmitterDeps): TypingEmitter {
   const floorMs = deps.floorMs ?? TYPING_FLOOR_MS
   const now = deps.now ?? Date.now
   const isSuppressed = deps.isSuppressed ?? (() => false)
+  const schedule =
+    deps.schedule ??
+    ((fn: () => void, ms: number) => {
+      const h = setTimeout(fn, ms)
+      ;(h as { unref?: () => void }).unref?.()
+      return h
+    })
+  const cancel =
+    deps.cancel ?? ((h: unknown) => clearTimeout(h as ReturnType<typeof setTimeout>))
+
   /** chat key → epoch ms at which the current emission window was claimed. */
   const windowClaimedAt = new Map<string, number>()
+  /** chat key → the single armed catch-up timer (coalesced; never two). */
+  const catchUps = new Map<string, unknown>()
 
   function prune(t: number): void {
     if (windowClaimedAt.size <= PRUNE_SIZE_THRESHOLD) return
     const cutoff = t - floorMs * PRUNE_AFTER_FACTOR
     for (const [k, ts] of [...windowClaimedAt.entries()]) {
-      if (ts < cutoff) windowClaimedAt.delete(k)
+      if (ts < cutoff && !catchUps.has(k)) windowClaimedAt.delete(k)
     }
   }
 
+  function clearCatchUp(key: string): void {
+    const h = catchUps.get(key)
+    if (h !== undefined) {
+      cancel(h)
+      catchUps.delete(key)
+    }
+  }
+
+  /**
+   * A dropped tick MUST NOT become silence. Both loops re-arm a FIXED-cadence
+   * interval, so a tick eaten by the floor is simply lost: the next emission
+   * for that key could land as late as `floorMs + refreshMs` (7.5 s) after the
+   * last one — past Telegram's ~5 s chat-action expiry, and the chat goes dark
+   * mid-turn. That would trade a flood ban for a dead "typing…" indicator,
+   * which breaches `know-what-my-agent-is-doing` ("stays present from receipt
+   * to turn end").
+   *
+   * So a floor drop arms ONE coalesced catch-up at the exact moment the window
+   * opens (`claimedAt + floorMs`). Effect: the worst-case gap between two
+   * emissions is bounded by `floorMs`, while the emission CAP is untouched (the
+   * catch-up fires only once the floor has expired, so it can never emit early).
+   * A second drop inside the same window must not arm a second timer — hence
+   * the coalesce.
+   */
+  function armCatchUp(
+    key: string,
+    chatId: string,
+    threadId: number | null,
+    action: string,
+    delayMs: number,
+  ): void {
+    if (catchUps.has(key)) return // coalesced — one timer per key, always
+    const h = schedule(() => {
+      catchUps.delete(key)
+      // Re-enters `emit`, which re-checks the floor (now expired) and the flood
+      // gate. A send here cancels nothing — there is nothing left to cancel.
+      emit(chatId, threadId, action)
+    }, Math.max(0, delayMs))
+    catchUps.set(key, h)
+  }
+
+  function emit(chatId: string, threadId: number | null = null, action = 'typing'): boolean {
+    const key = deps.chatKey(chatId, threadId ?? null)
+    const t = now()
+    const claimed = windowClaimedAt.get(key)
+    // `t >= claimed` guards a backwards clock step (NTP): a stale future
+    // timestamp must not wedge the indicator off, so treat it as expired.
+    if (claimed != null && t >= claimed && t - claimed < floorMs) {
+      armCatchUp(key, chatId, threadId ?? null, action, claimed + floorMs - t)
+      deps.onDrop?.({ key, reason: 'floor' })
+      return false
+    }
+    // Claim the window BEFORE the flood check so a burst of restarts costs
+    // one flood-state read per floor, not one per restart.
+    windowClaimedAt.set(key, t)
+    prune(t)
+    if (isSuppressed()) {
+      // A flood window is open. Don't arm a catch-up — the goal is silence, not
+      // a deferred ping into the ban.
+      clearCatchUp(key)
+      deps.onDrop?.({ key, reason: 'flood' })
+      return false
+    }
+    // This send satisfies whatever a pending catch-up was going to deliver.
+    // Cancelling it here is what keeps a catch-up from re-arming itself into a
+    // self-sustaining heartbeat after the loops have stopped.
+    clearCatchUp(key)
+    deps.send(chatId, threadId ?? null, action)
+    return true
+  }
+
   return {
-    emit(chatId, threadId = null, action = 'typing') {
-      const key = deps.chatKey(chatId, threadId ?? null)
-      const t = now()
-      const claimed = windowClaimedAt.get(key)
-      // `t >= claimed` guards a backwards clock step (NTP): a stale future
-      // timestamp must not wedge the indicator off, so treat it as expired.
-      if (claimed != null && t >= claimed && t - claimed < floorMs) {
-        deps.onDrop?.({ key, reason: 'floor' })
-        return false
-      }
-      // Claim the window BEFORE the flood check so a burst of restarts costs
-      // one flood-state read per floor, not one per restart.
-      windowClaimedAt.set(key, t)
-      prune(t)
-      if (isSuppressed()) {
-        deps.onDrop?.({ key, reason: 'flood' })
-        return false
-      }
-      deps.send(chatId, threadId ?? null, action)
-      return true
+    emit,
+    cancelPending(chatId, threadId = null) {
+      clearCatchUp(deps.chatKey(chatId, threadId ?? null))
     },
     trackedKeys: () => windowClaimedAt.size,
-    reset: () => windowClaimedAt.clear(),
+    pendingCatchUps: () => catchUps.size,
+    reset: () => {
+      for (const key of [...catchUps.keys()]) clearCatchUp(key)
+      windowClaimedAt.clear()
+    },
   }
 }


### PR DESCRIPTION
## Summary

Makes the Telegram typing indicator structurally incapable of earning a per-bot flood ban (#3084).

- **New `telegram-plugin/typing-emitter.ts`** — one shared per-chat-key emission floor (`TYPING_FLOOR_MS = 3500`, deliberately just under the 4s refresh so a loop's own on-time refresh is never eaten by timer jitter). **Both** typing loops (`startTypingLoop`/`typingIntervals` and `turnTypingLoop`) plus the two one-shot inbound pings now emit through it, so the floor holds *across* them — they target the same chat key and neither can out-shout the other. A **cold start still pings instantly** (the UX intent); only *redundant* restarts are dropped.
- **Typing sends stop bypassing the retry policy.** They no longer call `bot.api.sendChatAction` raw with `.catch(() => {})`. They route through a new `nonEssentialApiCall` (`createRetryApiCall({ maxRetries: 1, sleep: noop })`) which still fires `onFloodWait`, so the #2923 flood circuit breaker finally observes 429s from the single largest source of them. A typing ping is **never retried** — retrying a non-essential send is what feeds a ban, and we are not going to sleep out a 16,739s `retry_after` on a typing indicator.
- **No typing at all while a flood window is open.** `suppressNonEssentialSendMs` gained its second callsite (it had exactly one: `boot-card.ts`). Typing is non-essential by definition; sending into an open window cannot succeed and can extend the ban.
- Fixed the two comments that encoded the wrong assumption ("the redundant `typing` pings ... are harmless — same action, and `sendChatAction` is cheap"). That assumption is what earned the ban.

## Why

On 2026-07-11 06:24 UTC `overlord` earned `429 retry_after=16739s` — a **4.6-hour** per-bot-token ban that killed every outbound reply until 11:03 UTC (#3084).

Measured outbound mix for that agent that day:

| call | count |
|---|---|
| `sendChatAction` | **8,729** (55% of all outbound volume) |
| `editMessageText` | 6,443 |
| `sendRichMessage` | **203** (actual messages delivered) |

8,729 typing pings to deliver 203 messages, bursting at 200-300/min into a **single DM**.

Root cause: `startTypingLoop()` fires an action *immediately* on every (re)start, and the tool-use wrapper restarts the loop on **every tool call**. So the ping rate equalled the agent's **tool-call rate**, not one per 4s — the 4000ms interval was decorative. With parallel subagents hammering tools this hit ~5/sec. A second loop (`turnTypingLoop`) with its own interval map targets the same chat key and also fires immediately on start, compounding it.

**This is the gap PR #3092 (`feat/telegram-send-gate`) does NOT cover.** That token-bucket send gate is composed around `robustApiCall` — and typing called `bot.api` **raw**, so the gate would never have seen 55% of outbound volume. This PR does not depend on or merge into #3092; it just stops typing from bypassing the wrapper, so it benefits automatically when #3092 lands. Same story for the #2923 breaker, whose `onFloodWait` hook only fires inside `createRetryApiCall` — it was blind to 429s from the biggest emitter.

Job spec: `reference/jobs/talk-to-agents-from-anywhere.md` (**always-available**; "Bad looks like" — the surface going dead). The typing indicator itself serves `know-what-my-agent-is-doing`, and its Good behaviour is preserved: "typing…" still lands the instant a turn begins, and the emitter's floor sits under Telegram's ~5s action expiry so the chat never goes dark mid-turn (asserted in the tests).

## Test plan

New `telegram-plugin/tests/typing-emitter.test.ts` (vitest, **fully deterministic fake clock**, no real timers), 12 tests asserting outcomes:

- **The regression:** 50 loop restarts across 2s emit **exactly 1** chat action (was 50).
- **The compound case:** the *real* `createTurnTypingLoop` running alongside a faithful reproduction of the tool-use loop (stop → restart → immediate fire → re-arm interval), driven by 120 tool calls over 60s into one DM — the shape that produced the ban. Asserts total emissions ≤ `ceil(60s / floor) + 1`, that no two emissions on a key are inside the floor, **and** that no gap exceeds Telegram's 5s action expiry (the chat stays lit).
- Cold start still pings immediately; the floor releases on schedule; an on-time 4s refresh is never dropped.
- Two chats — and two topics in one chat — are independent lanes.
- **Nothing** is emitted while a flood window is open; emission resumes when it closes.
- A 429 **is recorded** to the flood breaker and the ping is **not retried** (`fn` called exactly once); the recorded window then suppresses further typing end-to-end.
- Flood state is read at most once per floor per chat (no fs read-storm under a restart burst).

Ran green:
- `vitest run telegram-plugin/tests` — **358 files / 5844 tests passed**.
- `npm run lint` — clean (tsc + all 8 guards, including `check-bot-api-wrapping`; the one remaining raw call carries a drift-proof `// allow-raw-bot-api:` marker, no line-range allowlist edits needed).

## Risk

Low-moderate, UX-surface-touching.

- **Ping volume drops ~20x** by design (worst case ~17/min per chat, was 200-300/min). The visible risk is a *dark* chat, and it is bounded: the floor (3.5s) is strictly under both the refresh cadence (4s) and Telegram's action expiry (~5s), and a cold start is never delayed. The 5s-gap assertion in the loop-integration test pins this.
- Behaviour change on failure: a failing typing ping is now **logged and dropped** instead of silently swallowed (a 429 additionally trips the breaker). One extra stderr line per failed ping — rare, and it is exactly the signal that was missing for months.
- The 401 → exponential-backoff restart path is preserved unchanged.
- No change to reply/edit delivery paths. Not an invariant crossing; deterministic mechanism, no model-dependent behaviour.

Closes #3084.