### PR TITLE
feat(scaffold): two-section per-agent CLAUDE.md with preserved operator section (closes #1857)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+### Per-agent CLAUDE.md is now a two-section file with a preserved operator area (#1857)
+
+`<agentDir>/CLAUDE.md` is split by a visible marker line:
+
+```
+# --- Yours (preserved across apply) ---
+```
+
+Everything ABOVE the marker is Switchroom-managed and regenerated on
+every `switchroom apply` / `agent reconcile`; everything BELOW is
+operator-owned and preserved verbatim across applies. A fresh agent gets
+a self-teaching placeholder below the marker. Both the first-scaffold and
+the reconcile write paths compose the file through one shared helper
+(`composeTwoSectionClaudeMd`) so they produce byte-identical output and a
+re-run with unchanged config is a full no-op. Above-marker hand-edits are
+still clobbered under the existing fingerprint/backup regime (a
+`.before-rerender.<ts>` backup is written on the first-scaffold path).
+
+The `workspace/CLAUDE.custom.md` sidecar is deprecated: on the first
+apply post-upgrade its content is migrated below the marker and the file
+is renamed to `workspace/CLAUDE.custom.md.deprecated` (one-time, logged).
+Edit CLAUDE.md below the marker directly from now on.
+
 ## v0.18.11 — Rollouts you can watch, poll, and survive
 
 ### Rich checklist rollout narration with per-agent progress (#3047)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -581,10 +581,10 @@ Switchroom splits agent customization into two files with **opposite ownership**
 
 | File | Owner | Lifecycle |
 |------|-------|-----------|
-| `CLAUDE.md` (agent root) | **Switchroom** | Cascade-rendered from the profile; regenerated on every `apply`/`reconcile`/`update` so machinery + smart-default changes propagate fleet-wide. Hand-edits are backed up to `CLAUDE.md.before-rerender.*` and replaced. |
+| `CLAUDE.md` (agent root) | **Switchroom + You** | Two-section file split by a visible marker line (`# --- Yours (preserved across apply) ---`). ABOVE the marker is Switchroom-managed: cascade-rendered from the profile and regenerated on every `apply`/`reconcile`/`update` so machinery + smart-default changes propagate fleet-wide (above-marker hand-edits are backed up to `CLAUDE.md.before-rerender.*` and replaced). BELOW the marker is **yours** — add per-agent rules there and they are preserved verbatim across every apply. The old `workspace/CLAUDE.custom.md` sidecar is deprecated: its content migrates below the marker on first apply and the file is renamed `.deprecated`. |
 | `workspace/SOUL.md` (persona) | **You** | Seeded **once** — from the setup wizard's persona prompts, or the profile's `SOUL.md.hbs` + `soul:` config when skipped. After that it is a plain user file: `update`/`reconcile` **never** overwrite it. |
 
-This is deliberate. `CLAUDE.md` is the operating manual — you want switchroom's updates to reach it. `SOUL.md` is who the agent *is* — you want your words to stick, the way they do in OpenClaw/Hermes. The `soul:` config and profile `SOUL.md.hbs` are therefore **seed-time inputs only**; changing them later does not touch an agent whose `SOUL.md` already exists.
+This is deliberate. The managed (above-marker) part of `CLAUDE.md` is the operating manual — you want switchroom's updates to reach it — while the below-marker section is your own per-agent rules that survive every apply. `SOUL.md` is who the agent *is* — you want your words to stick, the way they do in OpenClaw/Hermes. The `soul:` config and profile `SOUL.md.hbs` are therefore **seed-time inputs only**; changing them later does not touch an agent whose `SOUL.md` already exists.
 
 **Editing the persona.** Just edit `workspace/SOUL.md` directly (it's tracked in the workspace git repo, so your edits are versioned and recoverable). `switchroom soul path <agent>` prints the path; `switchroom soul show <agent>` prints the current content.
 

--- a/profiles/_shared/vault-protocol.md.hbs
+++ b/profiles/_shared/vault-protocol.md.hbs
@@ -3,7 +3,9 @@
   Rendered automatically by `switchroom apply` / `agent reconcile` from
   profiles/_shared/vault-protocol.md.hbs. Edit there — hand-edits to
   this section will be overwritten on next reconcile. To add agent-
-  specific guidance, put it in workspace/CLAUDE.custom.md (sidecar).
+  specific guidance, edit CLAUDE.md below the "Yours (preserved across
+  apply)" marker line — that section is preserved verbatim across every
+  apply.
 -->
 
 ## Vault & secrets

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -4215,9 +4215,7 @@ export function scaffoldAgent(
       // hand-edits are preserved as a backup at
       // `<filename>.before-rerender.<unix-ms>` so they can be
       // re-merged manually.
-      rerenderWithFingerprint(
-        join(agentDir, dest),
-        () => {
+      const renderManaged = () => {
           let rendered = renderTemplate(srcPath, context);
           if (dest === "CLAUDE.md") {
             // Reply-discipline rides at the TOP (prepended after the
@@ -4266,27 +4264,35 @@ export function scaffoldAgent(
           if (dest === "CLAUDE.md" && agentConfig.claude_md_raw) {
             rendered = rendered.trimEnd() + "\n\n" + agentConfig.claude_md_raw + "\n";
           }
-          if (dest === "CLAUDE.md") {
-            // Two-section composition (#1857): the `rendered` output above is
-            // the Switchroom-managed block; everything below the visible
-            // marker is operator-owned and preserved across applies. Read the
-            // existing file so the below-marker section survives verbatim (or
-            // migrates the legacy workspace/CLAUDE.custom.md sidecar). MUST use
-            // the same shared helper as the reconcile path (Phase 3) so both
-            // produce byte-identical output.
-            const claudeMdPath = join(agentDir, dest);
-            const existing = existsSync(claudeMdPath)
-              ? readFileSync(claudeMdPath, "utf-8")
-              : null;
-            const sidecarPath = join(agentDir, "workspace", "CLAUDE.custom.md");
-            rendered = composeTwoSectionClaudeMd(rendered, existing, sidecarPath);
-          }
           return rendered;
-        },
-        created,
-        skipped,
-        rewrittenWithBackup,
-      );
+      };
+      if (dest === "CLAUDE.md") {
+        // Two-section composition (#1857): the rendered output above is the
+        // Switchroom-managed block; everything below the visible marker is
+        // operator-owned and preserved across applies. Uses a marker-aware
+        // fingerprint writer: only the managed (above-marker) section is
+        // fingerprinted, so a below-marker operator edit — the normal,
+        // encouraged state — is NOT treated as drift and never triggers a
+        // .before-rerender backup. Composition goes through the same shared
+        // helper as the reconcile path (Phase 3) so both paths produce
+        // byte-identical output.
+        writeTwoSectionClaudeMdWithFingerprint(
+          join(agentDir, dest),
+          renderManaged,
+          join(agentDir, "workspace", "CLAUDE.custom.md"),
+          created,
+          skipped,
+          rewrittenWithBackup,
+        );
+      } else {
+        rerenderWithFingerprint(
+          join(agentDir, dest),
+          renderManaged,
+          created,
+          skipped,
+          rewrittenWithBackup,
+        );
+      }
     }
   }
 
@@ -6985,6 +6991,106 @@ function writeIfChanged(
  * Caveat: hashing is SHA-256 (`node:crypto`); cost is microseconds
  * per call. Fingerprint sidecar gets ~64 bytes per file. Trivial.
  */
+/**
+ * The Switchroom-managed section of a two-section CLAUDE.md: everything up to
+ * and INCLUDING the marker line. If the marker is absent (legacy pre-#1857
+ * file) the whole content counts as managed — which reproduces the old
+ * whole-file fingerprint semantics for exactly the files that predate the
+ * two-section regime.
+ */
+function claudeMdManagedSection(content: string): string {
+  const idx = content.indexOf(CLAUDE_MD_YOURS_MARKER);
+  if (idx === -1) return content;
+  return content.slice(0, idx + CLAUDE_MD_YOURS_MARKER.length);
+}
+
+/**
+ * Marker-aware fingerprint writer for the two-section `<agentDir>/CLAUDE.md`
+ * (#1857). Same clobber/backup decision tree as rerenderWithFingerprint, with
+ * one deliberate difference: the fingerprint covers ONLY the Switchroom-managed
+ * (above-marker) section, and drift is judged against the existing file's
+ * above-marker section only.
+ *
+ * Why: below-marker operator edits are a first-class, encouraged state — the
+ * composition preserves them verbatim, so they are NOT drift. Under a
+ * whole-file fingerprint every below-marker edit would mismatch the recorded
+ * hash forever, and every subsequent template change would spuriously write a
+ * `.before-rerender.<ts>` backup on every apply. Above-marker hand-edits still
+ * get the full backup + regenerate treatment; legacy files without the marker
+ * degrade to whole-file semantics (one backup on migration if hand-edited).
+ */
+function writeTwoSectionClaudeMdWithFingerprint(
+  filePath: string,
+  managedFn: () => string,
+  sidecarPath: string,
+  created: string[],
+  skipped: string[],
+  rewrittenWithBackup: string[],
+): void {
+  const prev = existsSync(filePath) ? readFileSync(filePath, "utf-8") : null;
+  const next = composeTwoSectionClaudeMd(managedFn(), prev, sidecarPath);
+  const nextManagedHash = createHash("sha256")
+    .update(claudeMdManagedSection(next), "utf-8")
+    .digest("hex");
+  const fingerprintPath = filePath + ".fingerprint";
+
+  if (prev === null) {
+    writeFileSync(filePath, next, "utf-8");
+    writeFileSync(fingerprintPath, nextManagedHash, "utf-8");
+    created.push(filePath);
+    return;
+  }
+
+  if (prev === next) {
+    // Already exactly what we'd write — refresh the fingerprint (covers
+    // fingerprint deletion and migration from the whole-file regime).
+    try {
+      writeFileSync(fingerprintPath, nextManagedHash, "utf-8");
+    } catch {
+      // best-effort
+    }
+    skipped.push(filePath);
+    return;
+  }
+
+  // Managed section drifted (or the below-marker section normalized). Decide
+  // whether the operator touched the MANAGED section since our last write.
+  const prevManagedHash = createHash("sha256")
+    .update(claudeMdManagedSection(prev), "utf-8")
+    .digest("hex");
+  const recordedFingerprint = existsSync(fingerprintPath)
+    ? readFileSync(fingerprintPath, "utf-8").trim()
+    : null;
+
+  if (recordedFingerprint === prevManagedHash) {
+    // Managed section untouched by the operator — template/config drifted
+    // upstream. Clobber the managed section cleanly; the below-marker
+    // section is preserved by the composition above. No backup.
+    writeFileSync(filePath, next, "utf-8");
+    writeFileSync(fingerprintPath, nextManagedHash, "utf-8");
+    created.push(filePath);
+    return;
+  }
+
+  // Above-marker hand-edit (fingerprint mismatch) or legacy state (no
+  // fingerprint). Back up + overwrite — same regime as rerenderWithFingerprint.
+  const backupPath = `${filePath}.before-rerender.${Date.now()}`;
+  try {
+    writeFileSync(backupPath, prev, "utf-8");
+  } catch (err) {
+    process.stderr.write(
+      `scaffold: refusing to overwrite ${filePath} — backup write failed ` +
+      `(${(err as Error).message}). Operator edits preserved.\n`,
+    );
+    skipped.push(filePath);
+    return;
+  }
+  writeFileSync(filePath, next, "utf-8");
+  writeFileSync(fingerprintPath, nextManagedHash, "utf-8");
+  rewrittenWithBackup.push(filePath);
+  created.push(filePath);
+}
+
 function rerenderWithFingerprint(
   filePath: string,
   contentFn: () => string,

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1403,6 +1403,103 @@ function composeWithSidecar(renderedBase: string, sidecarPath: string): string {
 }
 
 /**
+ * Visible boundary between the Switchroom-managed (scaffold-regenerated)
+ * top of `<agentDir>/CLAUDE.md` and the operator-owned bottom that survives
+ * every `switchroom apply`.
+ *
+ * STRUCTURAL PROMISE — never change this text or its semantics again.
+ * Operators edit below this line; the scaffold rewrites everything above it
+ * on every reconcile and preserves everything below it verbatim. See #1857.
+ */
+export const CLAUDE_MD_YOURS_MARKER = "# --- Yours (preserved across apply) ---";
+
+/**
+ * Placeholder written below the marker for a fresh agent that has neither an
+ * existing below-marker section nor a legacy `workspace/CLAUDE.custom.md`
+ * sidecar to migrate. Self-teaching: the first time an operator opens the
+ * file they see what's editable and why.
+ */
+const CLAUDE_MD_YOURS_PLACEHOLDER =
+  "This space is yours. Add per-agent rules, exceptions, or context the " +
+  "Switchroom template doesn't capture. Everything above the marker line is " +
+  "regenerated on every apply; this section is preserved.";
+
+/**
+ * Resolve the operator-owned "below the marker" section for a two-section
+ * `<agentDir>/CLAUDE.md`, in priority order:
+ *
+ *   (a) the existing file already contains the marker → preserve everything
+ *       after the FIRST marker occurrence verbatim (operator content survives);
+ *   (b) else a legacy `workspace/CLAUDE.custom.md` sidecar exists with content
+ *       → migrate its content below the marker AND rename the sidecar to
+ *       `.deprecated` (one-time migration, logged);
+ *   (c) else the fresh-agent placeholder paragraph.
+ *
+ * Side effect: case (b) renames the sidecar. This is deliberate and lives here
+ * so BOTH write paths (first-scaffold + reconcile) get identical migration
+ * behaviour from the single shared helper.
+ */
+function resolveClaudeMdYoursSection(
+  existingFileContent: string | null,
+  sidecarPath: string,
+): string {
+  // (a) preserve everything after the FIRST marker occurrence, verbatim.
+  if (existingFileContent) {
+    const idx = existingFileContent.indexOf(CLAUDE_MD_YOURS_MARKER);
+    if (idx !== -1) {
+      const afterMarker = existingFileContent
+        .slice(idx + CLAUDE_MD_YOURS_MARKER.length)
+        .replace(/^[\r\n]+/, ""); // drop the blank line(s) between the marker and the content
+      return afterMarker.trimEnd();
+    }
+  }
+
+  // (b) one-time sidecar migration.
+  if (existsSync(sidecarPath)) {
+    const sidecar = readFileSync(sidecarPath, "utf-8").trimEnd();
+    if (sidecar.length > 0) {
+      const deprecatedPath = sidecarPath + ".deprecated";
+      try {
+        renameSync(sidecarPath, deprecatedPath);
+        console.log(
+          chalk.green(
+            `  migrated CLAUDE.custom.md → CLAUDE.md operator section; ` +
+              `renamed sidecar to ${deprecatedPath}`,
+          ),
+        );
+      } catch {
+        /* best-effort — content still migrates below; sidecar retirement retried next run */
+      }
+      return sidecar;
+    }
+  }
+
+  // (c) fresh-agent placeholder.
+  return CLAUDE_MD_YOURS_PLACEHOLDER;
+}
+
+/**
+ * Compose the two-section `<agentDir>/CLAUDE.md`: the Switchroom-managed
+ * `managed` block (rendered template + fragments + `claude_md_raw`), a visible
+ * marker line, and the operator-owned section resolved by
+ * {@link resolveClaudeMdYoursSection}.
+ *
+ * INVARIANT: for identical inputs this is a deterministic pure function of
+ * (`managed`, `existingFileContent`, sidecar state), so the first-scaffold and
+ * reconcile paths produce byte-identical output and a re-run with unchanged
+ * config is a full no-op. The output is a fixed point: feeding it back in as
+ * `existingFileContent` re-derives the same bytes.
+ */
+export function composeTwoSectionClaudeMd(
+  managed: string,
+  existingFileContent: string | null,
+  sidecarPath: string,
+): string {
+  const yours = resolveClaudeMdYoursSection(existingFileContent, sidecarPath);
+  return `${managed.trimEnd()}\n\n${CLAUDE_MD_YOURS_MARKER}\n\n${yours.trimEnd()}\n`;
+}
+
+/**
  * Render the persona SOUL.md for an agent from its profile template +
  * `soul:` config, folding in the SOUL.custom.md sidecar if present.
  * The single source of truth for seed-time and `switchroom soul reset`
@@ -4169,6 +4266,21 @@ export function scaffoldAgent(
           if (dest === "CLAUDE.md" && agentConfig.claude_md_raw) {
             rendered = rendered.trimEnd() + "\n\n" + agentConfig.claude_md_raw + "\n";
           }
+          if (dest === "CLAUDE.md") {
+            // Two-section composition (#1857): the `rendered` output above is
+            // the Switchroom-managed block; everything below the visible
+            // marker is operator-owned and preserved across applies. Read the
+            // existing file so the below-marker section survives verbatim (or
+            // migrates the legacy workspace/CLAUDE.custom.md sidecar). MUST use
+            // the same shared helper as the reconcile path (Phase 3) so both
+            // produce byte-identical output.
+            const claudeMdPath = join(agentDir, dest);
+            const existing = existsSync(claudeMdPath)
+              ? readFileSync(claudeMdPath, "utf-8")
+              : null;
+            const sidecarPath = join(agentDir, "workspace", "CLAUDE.custom.md");
+            rendered = composeTwoSectionClaudeMd(rendered, existing, sidecarPath);
+          }
           return rendered;
         },
         created,
@@ -6006,8 +6118,11 @@ export function reconcileAgent(
   }
 
   // --- Phase 3: regenerate CLAUDE.md by default (unless --preserve-claude-md) ---
-  // CLAUDE.md is regenerated deterministically from the template. CLAUDE.custom.md
-  // sidecar (if present) is appended with a \n\n---\n\n separator.
+  // CLAUDE.md is a two-section file (#1857): the Switchroom-managed block above
+  // the visible marker is regenerated deterministically from the template on
+  // every apply; everything below the marker is operator-owned and preserved
+  // verbatim. A legacy workspace/CLAUDE.custom.md sidecar is migrated below the
+  // marker (and renamed .deprecated) on the first apply post-#1857.
   if (!options.preserveClaudeMd && !options.skipProfileTemplates) {
     const profilePath = getProfilePath(agentConfig.extends ?? DEFAULT_PROFILE);
     const claudeMdSrc = join(profilePath, "CLAUDE.md.hbs");
@@ -6087,22 +6202,27 @@ export function reconcileAgent(
       if (devProtocol) {
         rendered = rendered.trimEnd() + "\n\n" + devProtocol + "\n";
       }
-      let composed = composeWithSidecar(rendered, claudeCustomPath);
-
-      // Legacy claude_md_raw still appends after sidecar (one-shot escape hatch)
+      // claude_md_raw stays in the Switchroom-managed (above-marker) block —
+      // it is yaml-driven, scaffold-owned content, not operator hand-edits.
       if (agentConfig.claude_md_raw) {
-        composed = composed.trimEnd() + "\n\n" + agentConfig.claude_md_raw + "\n";
+        rendered = rendered.trimEnd() + "\n\n" + agentConfig.claude_md_raw + "\n";
       }
 
-      // CLAUDE.md is template-owned: every reconcile regenerates it from
-      // CLAUDE.md.hbs + workspace/CLAUDE.custom.md sidecar. Drift between
-      // on-disk and freshly-rendered bytes is almost always template
-      // churn upstream, not operator hand-edits (operators put custom
-      // content in the sidecar). The previous abort treated those cases
-      // identically and forced --preserve-claude-md on every release.
-      // Preserve mode still exists for operators who genuinely want to
-      // freeze a CLAUDE.md (`reconcile --preserve-claude-md`).
+      // Two-section composition (#1857): `rendered` is the Switchroom-managed
+      // block; everything below the visible marker is operator-owned and
+      // preserved verbatim across applies. The below-marker section is read
+      // from the EXISTING file (or migrated one-time from the legacy
+      // workspace/CLAUDE.custom.md sidecar). MUST use the same shared helper
+      // as the first-scaffold path so both produce byte-identical output —
+      // preservation reads the existing file BEFORE composing so an unchanged
+      // config re-run is a full no-op (composed === before below).
       const before = existsSync(claudeMdDest) ? readFileSync(claudeMdDest, "utf-8") : "";
+      const composed = composeTwoSectionClaudeMd(
+        rendered,
+        before.length > 0 ? before : null,
+        claudeCustomPath,
+      );
+
       if (composed !== before) {
         writeFileSync(claudeMdDest, composed, "utf-8");
         changes.push(claudeMdDest);

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1645,7 +1645,7 @@ export function registerAgentCommand(program: Command): void {
     .option("--graceful-restart", "Wait for active turn to complete before restarting")
     .option(
       "--preserve-claude-md",
-      "Opt out of regenerating CLAUDE.md — use if you have hand-edits you don't want to migrate to CLAUDE.custom.md yet"
+      "Opt out of regenerating the Switchroom-managed section of CLAUDE.md — use if you have hand-edits above the `# --- Yours ---` marker you don't want clobbered yet (edits below the marker are always preserved)"
     )
     .option("--check", "Report drift between yaml and settings.json without writing")
     .action(

--- a/tests/reconcile.persona.test.ts
+++ b/tests/reconcile.persona.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { scaffoldAgent, reconcileAgent } from "../src/agents/scaffold.js";
@@ -108,7 +108,7 @@ describe("reconcileAgent — persona (Phase 3)", () => {
     expect(afterReconcile).toBe(original); // Idempotent when template is the same
   });
 
-  it("appends CLAUDE.custom.md sidecar if present", () => {
+  it("migrates a legacy CLAUDE.custom.md sidecar below the marker + retires it (#1857)", () => {
     const config = makeAgentConfig({
       soul: { name: "Agent", style: "default" },
     });
@@ -117,20 +117,29 @@ describe("reconcileAgent — persona (Phase 3)", () => {
     const claudeMdPath = join(result.agentDir, "CLAUDE.md");
     const claudeCustomPath = join(result.agentDir, "workspace", "CLAUDE.custom.md");
 
-    // Add custom sidecar
+    // Simulate a pre-#1857 agent: a legacy sidecar exists and CLAUDE.md has
+    // no marker yet (strip the marker the fresh scaffold wrote).
+    const MARKER = "# --- Yours (preserved across apply) ---";
+    const fresh = readFileSync(claudeMdPath, "utf-8");
+    const noMarker = fresh.slice(0, fresh.indexOf(MARKER)).trimEnd() + "\n";
+    writeFileSync(claudeMdPath, noMarker, "utf-8");
     writeFileSync(
       claudeCustomPath,
       "## Custom Instructions\n\nThis is my personal addition.",
       "utf-8"
     );
 
-    // Reconcile should append the custom content
+    // Reconcile migrates the sidecar content below the marker.
     reconcileAgent("test-agent", config, tmpDir, telegramConfig, switchroomConfig);
 
     const claudeMd = readFileSync(claudeMdPath, "utf-8");
-    expect(claudeMd).toContain("---");
-    expect(claudeMd).toContain("## Custom Instructions");
-    expect(claudeMd).toContain("This is my personal addition");
+    expect(claudeMd).toContain(MARKER);
+    const below = claudeMd.slice(claudeMd.indexOf(MARKER) + MARKER.length);
+    expect(below).toContain("## Custom Instructions");
+    expect(below).toContain("This is my personal addition");
+    // Sidecar retired.
+    expect(existsSync(claudeCustomPath)).toBe(false);
+    expect(existsSync(claudeCustomPath + ".deprecated")).toBe(true);
   });
 
   it("preserves CLAUDE.md when --preserve-claude-md is set", () => {
@@ -164,18 +173,23 @@ describe("reconcileAgent — persona (Phase 3)", () => {
     const result = scaffoldAgent("test-agent", config, tmpDir, telegramConfig);
     const claudeMdPath = join(result.agentDir, "CLAUDE.md");
 
-    // Simulate template drift (or stray hand-edits) — bytes don't match
-    // what re-rendering the template would produce, no sidecar exists.
+    // Simulate stray hand-edits ABOVE the marker (the Switchroom-managed
+    // section) — this is the drift that must be regenerated. Content BELOW
+    // the marker is operator-owned and preserved, so drift the managed block.
+    const MARKER = "# --- Yours (preserved across apply) ---";
     const original = readFileSync(claudeMdPath, "utf-8");
-    const edited = original + "\n\n## My Custom Section\n\nUser-added content.";
+    const edited = original.replace(
+      MARKER,
+      `## My Custom Section\n\nUser-added content.\n\n${MARKER}`,
+    );
     writeFileSync(claudeMdPath, edited, "utf-8");
 
-    // Reconcile must NOT abort; it should regenerate from template.
+    // Reconcile must NOT abort; it should regenerate the managed section.
     expect(() => {
       reconcileAgent("test-agent", config, tmpDir, telegramConfig, switchroomConfig);
     }).not.toThrow();
 
-    // Drift is gone — file matches what scaffold would have written fresh.
+    // Above-marker drift is gone — managed section matches a fresh render.
     const afterReconcile = readFileSync(claudeMdPath, "utf-8");
     expect(afterReconcile).not.toContain("## My Custom Section");
   });

--- a/tests/scaffold.claude-md-two-section.test.ts
+++ b/tests/scaffold.claude-md-two-section.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  scaffoldAgent,
+  reconcileAgent,
+  CLAUDE_MD_YOURS_MARKER,
+} from "../src/agents/scaffold.js";
+import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+/**
+ * #1857 — `<agentDir>/CLAUDE.md` is a two-section file: everything ABOVE the
+ * visible marker is scaffold-regenerated on every apply; everything BELOW is
+ * operator-owned and preserved verbatim across both write paths
+ * (first-scaffold via scaffoldAgent + reconcile via reconcileAgent).
+ */
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+function makeSwitchroomConfig(name: string, agentConfig: AgentConfig): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+    },
+    telegram: telegramConfig,
+    agents: { [name]: agentConfig },
+  } as SwitchroomConfig;
+}
+
+const PLACEHOLDER = "This space is yours.";
+
+describe("CLAUDE.md two-section marker (#1857)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "scaffold-two-section-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("fresh scaffold renders the marker + placeholder below it", () => {
+    const config = makeAgentConfig();
+    const r = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const claudeMd = join(r.agentDir, "CLAUDE.md");
+    const content = readFileSync(claudeMd, "utf-8");
+
+    expect(content).toContain(CLAUDE_MD_YOURS_MARKER);
+    const markerIdx = content.indexOf(CLAUDE_MD_YOURS_MARKER);
+    const below = content.slice(markerIdx + CLAUDE_MD_YOURS_MARKER.length);
+    expect(below).toContain(PLACEHOLDER);
+  });
+
+  it("operator content below the marker survives a reconcile with changed managed content", () => {
+    const config = makeAgentConfig();
+    const r = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const claudeMd = join(r.agentDir, "CLAUDE.md");
+
+    // Operator edits below the marker.
+    const original = readFileSync(claudeMd, "utf-8");
+    const markerIdx = original.indexOf(CLAUDE_MD_YOURS_MARKER);
+    const aboveWithMarker = original.slice(0, markerIdx + CLAUDE_MD_YOURS_MARKER.length);
+    const edited = `${aboveWithMarker}\n\n## My rules\nAlways speak like a pirate.\n`;
+    writeFileSync(claudeMd, edited, "utf-8");
+
+    // Reconcile with changed managed content (claude_md_raw drift).
+    const drifted = makeAgentConfig({ claude_md_raw: "\n\n## Drift\nNew managed section.\n" });
+    reconcileAgent("a", drifted, tmpDir, telegramConfig, makeSwitchroomConfig("a", drifted));
+
+    const after = readFileSync(claudeMd, "utf-8");
+    // Managed section regenerated...
+    expect(after).toContain("Drift");
+    // ...operator section preserved verbatim.
+    expect(after).toContain("Always speak like a pirate.");
+    // Placeholder gone (operator replaced it).
+    expect(after).not.toContain(PLACEHOLDER);
+    // Exactly one marker.
+    expect(after.split(CLAUDE_MD_YOURS_MARKER)).toHaveLength(2);
+  });
+
+  it("above-marker operator edits are regenerated per fingerprint/backup rules", () => {
+    const config = makeAgentConfig();
+    const r = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const claudeMd = join(r.agentDir, "CLAUDE.md");
+
+    // Operator hand-edits ABOVE the marker.
+    const original = readFileSync(claudeMd, "utf-8");
+    const tampered = original.replace(
+      CLAUDE_MD_YOURS_MARKER,
+      `## SNUCK IN ABOVE\nThis should be clobbered.\n\n${CLAUDE_MD_YOURS_MARKER}`,
+    );
+    writeFileSync(claudeMd, tampered, "utf-8");
+
+    // Second scaffold (path 1) — fingerprint mismatch → backup + overwrite.
+    const r2 = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const after = readFileSync(claudeMd, "utf-8");
+    expect(after).not.toContain("SNUCK IN ABOVE");
+    expect(r2.created).toContain(claudeMd);
+  });
+
+  it("migrates workspace/CLAUDE.custom.md below marker + renames sidecar; second run no duplicate", () => {
+    const config = makeAgentConfig();
+    const r = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const claudeMd = join(r.agentDir, "CLAUDE.md");
+    const sidecar = join(r.agentDir, "workspace", "CLAUDE.custom.md");
+
+    // Seed a legacy sidecar and remove the marker from CLAUDE.md to simulate a
+    // pre-#1857 file that has never been migrated.
+    mkdirSync(join(r.agentDir, "workspace"), { recursive: true });
+    writeFileSync(sidecar, "## Legacy custom\nMigrate me below the line.\n", "utf-8");
+    const pre = readFileSync(claudeMd, "utf-8");
+    const preNoMarker = pre.slice(0, pre.indexOf(CLAUDE_MD_YOURS_MARKER)).trimEnd() + "\n";
+    writeFileSync(claudeMd, preNoMarker, "utf-8");
+
+    reconcileAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+
+    const migrated = readFileSync(claudeMd, "utf-8");
+    expect(migrated).toContain(CLAUDE_MD_YOURS_MARKER);
+    const belowIdx = migrated.indexOf(CLAUDE_MD_YOURS_MARKER) + CLAUDE_MD_YOURS_MARKER.length;
+    expect(migrated.slice(belowIdx)).toContain("Migrate me below the line.");
+    // Sidecar renamed to .deprecated.
+    expect(existsSync(sidecar)).toBe(false);
+    expect(existsSync(sidecar + ".deprecated")).toBe(true);
+
+    // Second reconcile: no duplication of migrated content, still one marker.
+    reconcileAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const twice = readFileSync(claudeMd, "utf-8");
+    expect(twice.split("Migrate me below the line.")).toHaveLength(2);
+    expect(twice.split(CLAUDE_MD_YOURS_MARKER)).toHaveLength(2);
+  });
+
+  it("idempotence: consecutive reconciles are a full no-op", () => {
+    const config = makeAgentConfig();
+    const r = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const claudeMd = join(r.agentDir, "CLAUDE.md");
+
+    reconcileAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const first = readFileSync(claudeMd, "utf-8");
+    reconcileAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const second = readFileSync(claudeMd, "utf-8");
+    expect(second).toBe(first);
+  });
+
+  it("first-scaffold and reconcile produce byte-identical CLAUDE.md for the same inputs", () => {
+    const config = makeAgentConfig({ claude_md_raw: "\n\n## Raw\nManaged raw content.\n" });
+
+    // Path 1: fresh scaffold.
+    const dir1 = mkdtempSync(join(tmpdir(), "two-section-p1-"));
+    const r1 = scaffoldAgent("a", config, dir1, telegramConfig, makeSwitchroomConfig("a", config));
+    const fromScaffold = readFileSync(join(r1.agentDir, "CLAUDE.md"), "utf-8");
+
+    // Path 2: scaffold a bare agent then reconcile. To compare the managed
+    // block deterministically, both start from a fresh placeholder section.
+    const dir2 = mkdtempSync(join(tmpdir(), "two-section-p2-"));
+    const r2 = scaffoldAgent("a", config, dir2, telegramConfig, makeSwitchroomConfig("a", config));
+    reconcileAgent("a", config, dir2, telegramConfig, makeSwitchroomConfig("a", config));
+    const fromReconcile = readFileSync(join(r2.agentDir, "CLAUDE.md"), "utf-8");
+
+    expect(fromReconcile).toBe(fromScaffold);
+
+    rmSync(dir1, { recursive: true, force: true });
+    rmSync(dir2, { recursive: true, force: true });
+  });
+});

--- a/tests/scaffold.claude-md-two-section.test.ts
+++ b/tests/scaffold.claude-md-two-section.test.ts
@@ -6,6 +6,7 @@ import {
   writeFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -150,6 +151,108 @@ describe("CLAUDE.md two-section marker (#1857)", () => {
     const twice = readFileSync(claudeMd, "utf-8");
     expect(twice.split("Migrate me below the line.")).toHaveLength(2);
     expect(twice.split(CLAUDE_MD_YOURS_MARKER)).toHaveLength(2);
+  });
+
+  it("below-marker operator edit + managed change → content preserved, NO backup file (no churn)", () => {
+    const config = makeAgentConfig();
+    const r = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const claudeMd = join(r.agentDir, "CLAUDE.md");
+
+    // Operator edits BELOW the marker — the normal, encouraged state.
+    const original = readFileSync(claudeMd, "utf-8");
+    const markerIdx = original.indexOf(CLAUDE_MD_YOURS_MARKER);
+    const aboveWithMarker = original.slice(0, markerIdx + CLAUDE_MD_YOURS_MARKER.length);
+    writeFileSync(claudeMd, `${aboveWithMarker}\n\n## My rules\nBe terse.\n`, "utf-8");
+
+    // Managed content changes (simulates a template/release change) —
+    // TWICE, to prove no per-apply backup accumulation.
+    for (const raw of ["\n\n## Drift one\n", "\n\n## Drift two\n"]) {
+      const drifted = makeAgentConfig({ claude_md_raw: raw });
+      scaffoldAgent("a", drifted, tmpDir, telegramConfig, makeSwitchroomConfig("a", drifted));
+    }
+
+    const after = readFileSync(claudeMd, "utf-8");
+    expect(after).toContain("Drift two");
+    expect(after).toContain("Be terse.");
+    // No backup churn: below-marker edits are NOT drift.
+    const backups = readdirSync(r.agentDir).filter((f) =>
+      f.startsWith("CLAUDE.md.before-rerender."),
+    );
+    expect(backups).toHaveLength(0);
+  });
+
+  it("above-marker hand-edit → exactly one backup + managed section regenerated", () => {
+    const config = makeAgentConfig();
+    const r = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const claudeMd = join(r.agentDir, "CLAUDE.md");
+
+    const original = readFileSync(claudeMd, "utf-8");
+    writeFileSync(
+      claudeMd,
+      original.replace(
+        CLAUDE_MD_YOURS_MARKER,
+        `## SNUCK IN ABOVE\n\n${CLAUDE_MD_YOURS_MARKER}`,
+      ),
+      "utf-8",
+    );
+
+    scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    // A second run after regeneration must NOT produce another backup.
+    scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+
+    const after = readFileSync(claudeMd, "utf-8");
+    expect(after).not.toContain("SNUCK IN ABOVE");
+    const backups = readdirSync(r.agentDir).filter((f) =>
+      f.startsWith("CLAUDE.md.before-rerender."),
+    );
+    expect(backups).toHaveLength(1);
+    expect(readFileSync(join(r.agentDir, backups[0]!), "utf-8")).toContain("SNUCK IN ABOVE");
+  });
+
+  it("legacy pre-marker file with hand-edits → exactly one backup on migration", () => {
+    const config = makeAgentConfig();
+    const r = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const claudeMd = join(r.agentDir, "CLAUDE.md");
+
+    // Simulate a pre-#1857 file: no marker, operator hand-edits, no fingerprint.
+    const pre = readFileSync(claudeMd, "utf-8");
+    const noMarker =
+      pre.slice(0, pre.indexOf(CLAUDE_MD_YOURS_MARKER)).trimEnd() +
+      "\n\n## Legacy hand edit\nKeep a copy of me.\n";
+    writeFileSync(claudeMd, noMarker, "utf-8");
+    rmSync(claudeMd + ".fingerprint");
+
+    scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    // Second run: no further backups.
+    scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+
+    const backups = readdirSync(r.agentDir).filter((f) =>
+      f.startsWith("CLAUDE.md.before-rerender."),
+    );
+    expect(backups).toHaveLength(1);
+    expect(readFileSync(join(r.agentDir, backups[0]!), "utf-8")).toContain("Legacy hand edit");
+    expect(readFileSync(claudeMd, "utf-8")).toContain(CLAUDE_MD_YOURS_MARKER);
+  });
+
+  it("scaffold after reconcile-driven managed change is a no-op (fingerprint stays in sync)", () => {
+    const config = makeAgentConfig();
+    const r = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
+    const claudeMd = join(r.agentDir, "CLAUDE.md");
+
+    // Reconcile with changed managed content (writes without a fingerprint
+    // update — Phase 3 is plain diff-write).
+    const drifted = makeAgentConfig({ claude_md_raw: "\n\n## Drift\n" });
+    reconcileAgent("a", drifted, tmpDir, telegramConfig, makeSwitchroomConfig("a", drifted));
+    const afterReconcile = readFileSync(claudeMd, "utf-8");
+
+    // Scaffold with the same config: byte-identical render → skipped, no backup.
+    const r2 = scaffoldAgent("a", drifted, tmpDir, telegramConfig, makeSwitchroomConfig("a", drifted));
+    expect(r2.skipped).toContain(claudeMd);
+    expect(readFileSync(claudeMd, "utf-8")).toBe(afterReconcile);
+    const backups = readdirSync(r.agentDir).filter((f) =>
+      f.startsWith("CLAUDE.md.before-rerender."),
+    );
+    expect(backups).toHaveLength(0);
   });
 
   it("idempotence: consecutive reconciles are a full no-op", () => {

--- a/tests/scaffold.hot-reload-stable.test.ts
+++ b/tests/scaffold.hot-reload-stable.test.ts
@@ -257,13 +257,16 @@ describe("hot-reload stable feature", () => {
 
       const result = scaffoldAgent("test-agent", config, tmpDir, telegramConfig, switchroomConfig);
 
-      // Drop a sidecar so reconcile re-composes CLAUDE.md (and the new
-      // composed != on-disk) — that's how CLAUDE.md gets into `changes`
-      // and then through the classifier. Without a sidecar, reconcile
-      // either aborts on hand-edits or sees no-op.
+      // Force a re-composition of CLAUDE.md so it lands in `changes` and
+      // flows through the classifier. Under the #1857 two-section model, an
+      // edit below the "Yours" marker survives and edits above it are
+      // regenerated — either way the file changes. Strip the marker to
+      // simulate a legacy (pre-#1857) file: reconcile re-adds it, so the
+      // composed output != on-disk and CLAUDE.md enters `changes`.
       const claudeMdPath = join(result.agentDir, "CLAUDE.md");
-      const sidecarPath = join(result.agentDir, "workspace", "CLAUDE.custom.md");
-      writeFileSync(sidecarPath, "# Sidecar appendix\n", "utf-8");
+      const MARKER = "# --- Yours (preserved across apply) ---";
+      const fresh = readFileSync(claudeMdPath, "utf-8");
+      writeFileSync(claudeMdPath, fresh.slice(0, fresh.indexOf(MARKER)).trimEnd() + "\n", "utf-8");
 
       // Reconcile
       const reconcileResult = reconcileAgent("test-agent", config, tmpDir, telegramConfig, switchroomConfig);

--- a/tests/scaffold.rerender-claude-md.test.ts
+++ b/tests/scaffold.rerender-claude-md.test.ts
@@ -126,8 +126,15 @@ describe("scaffoldAgent — CLAUDE.md rerender-on-template-change (#1122)", () =
     const r1 = scaffoldAgent("a", config, tmpDir, telegramConfig, makeSwitchroomConfig("a", config));
     const claudeMd = join(r1.agentDir, "CLAUDE.md");
 
-    // Operator hand-edits the file (this is what bypasses the fingerprint).
-    const handEdited = readFileSync(claudeMd, "utf-8") + "\n\n## Operator note\nKeep this.\n";
+    // Operator hand-edits the MANAGED (above-marker) section — this is what
+    // bypasses the fingerprint. (An edit BELOW the two-section marker is a
+    // first-class preserved state under #1857 and does NOT trigger a backup;
+    // see tests/scaffold.claude-md-two-section.test.ts.)
+    const MARKER = "# --- Yours (preserved across apply) ---";
+    const handEdited = readFileSync(claudeMd, "utf-8").replace(
+      MARKER,
+      `## Operator note\nKeep this.\n\n${MARKER}`,
+    );
     writeFileSync(claudeMd, handEdited, "utf-8");
 
     // Template drift triggers a rerender attempt.


### PR DESCRIPTION
## Summary

Turns `<agentDir>/CLAUDE.md` into a **two-section file** split by a visible, structural marker that must never change again:

```
# --- Yours (preserved across apply) ---
```

Everything ABOVE the marker is Switchroom-managed and regenerated on every `switchroom apply` / `agent reconcile`; everything BELOW is operator-owned and preserved verbatim. This makes the edit surface self-teaching (Principle 1: "if they need the docs, we've failed") — an operator opening the file immediately sees what's editable and what survives.

Part of epic #1850 (L3 ownership model). Closes #1857.

## Design

- **One shared helper** `composeTwoSectionClaudeMd(managed, existingFileContent, sidecarPath)` used by BOTH write paths:
  1. first-scaffold (`rerenderWithFingerprint`, `templateFiles` loop)
  2. reconcile Phase 3
  It reads the existing file **before** composing, so the two paths emit byte-identical output and a re-run with unchanged config is a full no-op (the output is a fixed point).
- **Below-marker resolution priority:** (a) existing file has the marker → preserve everything after the first occurrence verbatim; (b) else a legacy `workspace/CLAUDE.custom.md` sidecar with content → migrate below the marker AND rename the sidecar to `.deprecated` (one-time, logged); (c) else a self-teaching placeholder paragraph.
- `claude_md_raw` (yaml-driven, scaffold-owned) stays ABOVE the marker.
- Above-marker hand-edits are still clobbered under the existing fingerprint/backup regime (`.before-rerender.<ts>` backup on the first-scaffold path).
- `composeWithSidecar`'s old "append with `---`" behavior is retired for CLAUDE.md; the function is kept because `renderSoulMd` still uses it for `SOUL.custom.md`.
- Marker text exported as `CLAUDE_MD_YOURS_MARKER` in `src/agents/scaffold.ts`.

## Why

Today an operator edits `<agentDir>/CLAUDE.md`, runs apply, and watches their edits vanish — recovery requires source-reading to find the `workspace/CLAUDE.custom.md` sidecar. The two-section marker is self-documenting and edits below it survive.

## Files touched

- `src/agents/scaffold.ts` — shared helper + marker constant + both write paths + comments.
- `src/cli/agent.ts` — `--preserve-claude-md` help text.
- `profiles/_shared/vault-protocol.md.hbs` — point operators below the marker (note: deliberately avoids embedding the exact marker string, which would create a false split point in the managed content).
- `docs/configuration.md`, `CHANGELOG.md` — documented + migration note.
- `tests/scaffold.claude-md-two-section.test.ts` — new coverage.
- `tests/reconcile.persona.test.ts`, `tests/scaffold.hot-reload-stable.test.ts` — updated for two-section semantics.

## Test plan

Scoped vitest (247 passed):
`scaffold.claude-md-two-section`, `scaffold.rerender-claude-md`, `reconcile.persona`, `scaffold.hot-reload-stable`, `scaffold`, `scaffold.soul-user-owned`, `workspace.git`.

New tests assert outcomes: fresh render contains marker + placeholder; operator content below the marker survives a reconcile with changed managed content; above-marker edits are regenerated (fingerprint/backup); sidecar migration lands below marker + renames `.deprecated` + no duplication on second run; two consecutive reconciles are a full no-op; first-scaffold and reconcile produce byte-identical output.

`npm run lint` — clean (tsc + all 8 guards).

## Risk

The marker is a structural promise to operators — never change the text or semantics again. A managed-content author must never emit the exact marker string (it would create a false split point); the vault-protocol fragment edit was written with this in mind. Doctor probes to hard-fail on a missing marker are #1858 (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)