### PR TITLE
feat(auth): Telegram-native OAuth loopback relay for Google/Microsoft account add (#2582)

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -302,6 +302,23 @@ it, and unblock the fleet — entirely from chat:
 
 `/auth cancel` aborts an in-flight `/auth add`.
 
+**Google / Microsoft accounts add over Telegram too (issue #2582).** The
+Drive/Graph loopback OAuth flow is fully relayable — no SSH port-forward,
+no keyboard:
+
+- `/auth google add <email> [--replace] [--write]`
+- `/auth microsoft add <email> [--replace] [--org-mode]`
+
+The agent runs the loopback flow in its own container, relays the consent
+URL to chat, and you approve on your phone. The redirect to `127.0.0.1`
+fails to load — expected — so you paste the full address-bar URL
+(`?code=...&state=...`) back into chat; the gateway validates `state` and
+hands the code to the waiting listener. The pasted URL is redacted from
+history on completion. `/auth google cancel` / `/auth microsoft cancel`
+abort. Run it against the agent that should hold the grant
+(`google/client-secret` is admin-only and can't be minted to the root
+agent).
+
 ### Full surface
 
 | Chat command | Equivalent CLI verb |
@@ -309,6 +326,8 @@ it, and unblock the fleet — entirely from chat:
 | `/auth show [<agent>]` | `switchroom auth show [<agent>]` |
 | `/auth list` | `switchroom auth list` |
 | `/auth add <label>` | `switchroom auth add <label> --from-oauth` (chat-native OAuth flow) |
+| `/auth google add <email>` | `switchroom auth google account add <email>` (Telegram-native loopback relay) |
+| `/auth microsoft add <email>` | `switchroom auth microsoft account add <email>` (Telegram-native loopback relay) |
 | `/auth cancel` | (chat-only: aborts an in-flight `/auth add`) |
 | `/auth use <label>` | `switchroom auth use <label>` |
 | `/auth rotate` | `switchroom auth rotate` |

--- a/docs/google-workspace.md
+++ b/docs/google-workspace.md
@@ -140,11 +140,14 @@ If you'd rather do it by hand (the wizard automates exactly this):
    > flows are dead ends for Drive: **device-code** returns
    > `invalid_scope` for Drive scopes (Google does not allow Drive on
    > device flow), and **OOB** was retired by Google in 2022. On a
-   > **headless server** you complete the single browser step over an
+   > **headless server** you can complete the single browser step over an
    > SSH port-forward — `switchroom auth google account add` prints the
    > exact URL and `localhost` port; you `ssh -L <port>:127.0.0.1:<port>`,
-   > open the URL, approve. Same Desktop+loopback shape the
-   > `examples/personal-google-workspace-mcp/` host MCP uses.
+   > open the URL, approve. Or skip SSH entirely and run it from Telegram
+   > with `/auth google add <email>` (issue #2582) — the agent relays the
+   > consent URL to chat and you paste the redirect back. Same
+   > Desktop+loopback shape the `examples/personal-google-workspace-mcp/`
+   > host MCP uses.
 2. **Vault the secrets** so they never land in YAML:
 
    ```bash
@@ -189,6 +192,27 @@ above):
    broker (encrypted at rest — same machine-bound vault posture as the
    rest of switchroom).
 4. Account is now visible in `switchroom auth google account list`.
+
+**No SSH needed — do it from Telegram instead (issue #2582).** The
+loopback flow is fully relayable over chat, so you never need the
+keyboard or an SSH port-forward. From a chat with the admin agent that
+holds (or will hold) the grant:
+
+```
+/auth google add you@gmail.com            # add or re-auth
+/auth google add you@gmail.com --replace  # re-consent an existing account
+/auth google add you@gmail.com --write    # request Drive write scope
+```
+
+The agent runs the loopback flow **in its own container**, relays the
+consent URL to chat, you approve on your phone (the redirect to
+`127.0.0.1` fails to load — that's expected), then paste the full URL
+from your address bar (`?code=...&state=...`) back into chat. The
+gateway validates `state` and hands the code to the waiting listener.
+`/auth google cancel` aborts. Run it against the agent that should hold
+the grant — `google/client-secret` is an admin-only vault key that
+can't be minted to the root agent, so "the agent that holds the grant"
+is the right place to run it.
 
 If you have multiple Google accounts to attach, repeat with each
 account's email. Agents reference accounts by that email everywhere

--- a/docs/microsoft-workspace.md
+++ b/docs/microsoft-workspace.md
@@ -185,6 +185,22 @@ Flow (auto-detected from host environment):
 Override the auto-detection: `SWITCHROOM_MICROSOFT_OAUTH_TIER=device_code`
 or `=desktop_loopback`.
 
+**Telegram-native — no SSH, no keyboard (issue #2582).** You can add or
+re-auth a Microsoft account entirely over chat with the admin agent that
+holds the grant:
+
+```
+/auth microsoft add you@outlook.com             # add or re-auth
+/auth microsoft add you@outlook.com --replace   # re-consent
+/auth microsoft add you@outlook.com --org-mode  # tenant/org app
+```
+
+The agent runs the loopback flow in its own container, relays the
+consent URL to chat, you approve on your phone (the `127.0.0.1` redirect
+fails to load — expected), then paste the full address-bar URL
+(`?code=...&state=...`) back. The gateway validates `state` and completes
+the exchange. `/auth microsoft cancel` aborts.
+
 Per RFC §4.3, the scope set requested at consent time:
 
 ```

--- a/telegram-plugin/gateway/auth-command.ts
+++ b/telegram-plugin/gateway/auth-command.ts
@@ -46,6 +46,17 @@ export type ParsedAuthCommand =
   | { kind: 'rotate' }
   | { kind: 'add'; label: string }
   | { kind: 'cancel' }
+  | {
+      kind: 'provider-add'
+      provider: 'google' | 'microsoft'
+      email: string
+      replace: boolean
+      /** Google `--write` (Drive write scope). */
+      write: boolean
+      /** Microsoft `--org-mode`. */
+      orgMode: boolean
+    }
+  | { kind: 'provider-cancel'; provider: 'google' | 'microsoft' }
   | { kind: 'rm-prompt'; label: string }
   | { kind: 'rm-confirmed'; label: string }
   | { kind: 'refresh'; label?: string }
@@ -147,6 +158,9 @@ export function parseAuthCommand(text: string): ParsedAuthCommand | null {
     }
     case 'cancel':
       return { kind: 'cancel' }
+    case 'google':
+    case 'microsoft':
+      return parseProviderVerb(verb, parts.slice(1))
     case 'rm': {
       const label = parts[1]
       if (!label) return { kind: 'help', reason: 'Usage: /auth rm <label> [confirm]' }
@@ -203,6 +217,69 @@ export function parseAuthCommand(text: string): ParsedAuthCommand | null {
       return { kind: 'help' }
     default:
       return { kind: 'help', reason: `Unknown verb: \`${codeSpanSafe(verb)}\`` }
+  }
+}
+
+/**
+ * Parse `/auth google …` and `/auth microsoft …` — the Telegram-native OAuth
+ * loopback relay verbs (issue #2582). Only `add <email>` and `cancel` are
+ * wired; anything else is a help-with-reason so the operator sees the shape.
+ *
+ * Flags mirror the CLI:
+ *   google:    `add <email> [--replace] [--write]`
+ *   microsoft: `add <email> [--replace] [--org-mode]`
+ */
+export function parseProviderVerb(
+  provider: 'google' | 'microsoft',
+  rest: string[],
+): ParsedAuthCommand {
+  const sub = (rest[0] ?? '').toLowerCase()
+  if (sub === 'cancel') {
+    return { kind: 'provider-cancel', provider }
+  }
+  if (sub !== 'add') {
+    const usage =
+      provider === 'google'
+        ? 'Usage: /auth google add <email> [--replace] [--write]'
+        : 'Usage: /auth microsoft add <email> [--replace] [--org-mode]'
+    return {
+      kind: 'help',
+      reason: `Unknown \`${provider}\` subcommand: \`${codeSpanSafe(sub || '(none)')}\`. ${usage}`,
+    }
+  }
+  // Split positional email from `--flag` tokens.
+  const args = rest.slice(1)
+  const flags = new Set(args.filter((a) => a.startsWith('--')).map((a) => a.toLowerCase()))
+  const positional = args.filter((a) => !a.startsWith('--'))
+  const email = positional[0]
+  if (!email) {
+    const usage =
+      provider === 'google'
+        ? 'Usage: /auth google add <email> [--replace] [--write]'
+        : 'Usage: /auth microsoft add <email> [--replace] [--org-mode]'
+    return { kind: 'help', reason: usage }
+  }
+  const emailErr = validateAuthAddLabel(email)
+  if (emailErr) return { kind: 'help', reason: emailErr }
+  // Reject unknown flags so a typo (`--replaced`) isn't silently dropped.
+  const allowed = provider === 'google'
+    ? new Set(['--replace', '--write'])
+    : new Set(['--replace', '--org-mode'])
+  for (const f of flags) {
+    if (!allowed.has(f)) {
+      return {
+        kind: 'help',
+        reason: `Unknown flag \`${codeSpanSafe(f)}\` for \`/auth ${provider} add\`.`,
+      }
+    }
+  }
+  return {
+    kind: 'provider-add',
+    provider,
+    email,
+    replace: flags.has('--replace'),
+    write: provider === 'google' && flags.has('--write'),
+    orgMode: provider === 'microsoft' && flags.has('--org-mode'),
   }
 }
 
@@ -359,8 +436,10 @@ export async function handleAuthCommand(
         `  \`/auth list\` — alias of \`/auth show\`\n` +
         `  \`/auth use <label>\` — admin: swap the fleet to <label>\n` +
         `  \`/auth rotate\` — admin: cycle to next non-exhausted fallback\n` +
-        `  \`/auth add <label>\` — admin: OAuth-add a new account from chat\n` +
-        `  \`/auth cancel\` — abort an \`/auth add\` in progress\n` +
+        `  \`/auth add <label>\` — admin: OAuth-add a new Anthropic account from chat\n` +
+        `  \`/auth google add <email>\` — admin: Telegram-native Google account add/re-auth\n` +
+        `  \`/auth microsoft add <email>\` — admin: Telegram-native Microsoft account add/re-auth\n` +
+        `  \`/auth cancel\` — abort an \`/auth add\` or provider add in progress\n` +
         `  \`/auth rm <label>\` — admin: remove an account (two-step confirm)\n` +
         `  \`/auth refresh [<label>]\` — admin: force a refresh tick\n` +
         `  \`/auth agent override <agent> <label|clear>\` — admin: per-agent account override\n` +
@@ -468,6 +547,17 @@ export async function handleAuthCommand(
     return {
       text:
         `**/auth ${parsed.kind} not routed.** Internal error — gateway should dispatch this verb directly. Report this.`,
+      html: true,
+    }
+  }
+
+  // `/auth google|microsoft add|cancel` are likewise gateway-routed (they
+  // drive the loopback-relay child-process lifecycle — see
+  // auth-loopback-relay.ts). Defensive: never reach here in production.
+  if (parsed.kind === 'provider-add' || parsed.kind === 'provider-cancel') {
+    return {
+      text:
+        `**/auth ${parsed.provider} not routed.** Internal error — gateway should dispatch this verb directly. Report this.`,
       html: true,
     }
   }

--- a/telegram-plugin/gateway/auth-loopback-relay.ts
+++ b/telegram-plugin/gateway/auth-loopback-relay.ts
@@ -166,7 +166,24 @@ export interface PendingLoopbackFlow {
    * or racing the first (single-use).
    */
   submitting: boolean
+  /**
+   * Retryable-rejection counter (bad paste, wrong state, wrong port). The
+   * flow is ended after {@link MAX_PASTE_ATTEMPTS} rejections rather than
+   * waiting for the TTL — an operator repeatedly pasting the wrong thing
+   * should get a decisive stop, not a silent 10-minute window.
+   */
+  attempts: number
+  /** Set by {@link trackFlowExit} once the CLI child has exited. */
+  exited?: boolean
+  /** Exit code recorded by {@link trackFlowExit} (null = signal-killed). */
+  exitCode?: number | null
 }
+
+/**
+ * Bounded paste attempts — after this many retryable rejections the flow is
+ * ended (non-retryable) so a confused paste loop can't run to the TTL.
+ */
+export const MAX_PASTE_ATTEMPTS = 5
 
 export const pendingLoopbackFlows = new Map<string, PendingLoopbackFlow>()
 
@@ -297,6 +314,43 @@ export function parseLoopbackRedirect(input: string): ParsedRedirect {
   if (!code) return { ok: false, reason: 'missing code parameter' }
   if (!state) return { ok: false, reason: 'missing state parameter' }
   return { ok: true, host: url.hostname, port, code, state }
+}
+
+/**
+ * Decide whether an inbound chat message should be CONSUMED by the loopback
+ * paste intercept (and therefore never reach other handlers, and be deleted
+ * from history). Deliberately narrow: a message merely *mentioning*
+ * `localhost`/`127.0.0.1` ("what's listening on localhost?") must flow
+ * through untouched. We consume only when the text actually parses as a
+ * loopback redirect URL carrying a `code` — or a loopback URL carrying an
+ * `error` param (the provider-denied case, which the flow should surface).
+ */
+export function shouldConsumeLoopbackPaste(text: string): boolean {
+  const trimmed = (text ?? '').trim()
+  if (trimmed.length === 0) return false
+  const parsed = parseLoopbackRedirect(trimmed)
+  if (parsed.ok) return true
+  // parseLoopbackRedirect rejects the error-param case with a
+  // "provider returned error" reason — that IS a redirect paste and the
+  // intercept should consume it to end/inform the flow.
+  if (!parsed.ok && parsed.reason.startsWith('provider returned error')) {
+    return true
+  }
+  return false
+}
+
+/**
+ * Attach an exit tracker to a pending flow so a child that dies BEFORE the
+ * operator pastes (crash, listener error) is observable: `flow.exited` /
+ * `flow.exitCode` are set, and {@link submitLoopbackRedirect} fails fast with
+ * a clear message instead of hanging out its completion timeout waiting for
+ * an `exit` event that already fired.
+ */
+export function trackFlowExit(flow: PendingLoopbackFlow): void {
+  flow.child.on('exit', (code) => {
+    flow.exited = true
+    flow.exitCode = code
+  })
 }
 
 /* ── Flow lifecycle ───────────────────────────────────────────────────────── */
@@ -441,31 +495,52 @@ export async function submitLoopbackRedirect(
   const fetchImpl = opts.fetchImpl ?? fetch
   const completionTimeoutMs = opts.completionTimeoutMs ?? 60_000
 
-  const parsed = parseLoopbackRedirect(pastedText)
-  if (!parsed.ok) {
-    return { ok: false, reason: parsed.reason, retryable: true }
-  }
-  if (parsed.state !== flow.state) {
-    // CSRF guard — keep waiting; the operator may have pasted a stale URL.
-    return {
-      ok: false,
-      reason: 'state parameter does not match this flow (CSRF guard)',
-      retryable: true,
+  // A retryable rejection that would exceed the attempt budget becomes a
+  // non-retryable flow-ending one (bounded paste attempts — see
+  // MAX_PASTE_ATTEMPTS).
+  const rejectRetryable = (reason: string): SubmitResult => {
+    flow.attempts += 1
+    if (flow.attempts >= MAX_PASTE_ATTEMPTS) {
+      return {
+        ok: false,
+        reason:
+          `${reason} — ${MAX_PASTE_ATTEMPTS} rejected pastes; ending this flow. ` +
+          `Start over with a fresh add command.`,
+        retryable: false,
+      }
     }
+    return { ok: false, reason, retryable: true }
   }
-  if (parsed.port !== flow.port) {
-    return {
-      ok: false,
-      reason: `redirect port ${parsed.port} does not match this flow's listener`,
-      retryable: true,
-    }
-  }
+
   if (flow.submitting) {
     return {
       ok: false,
       reason: 'this flow has already been completed',
       retryable: false,
     }
+  }
+  if (flow.exited) {
+    // Child died before the paste (crash, port bind error). The listener is
+    // gone — no paste can ever succeed; fail fast instead of timing out.
+    return {
+      ok: false,
+      reason: `the CLI exited (code ${flow.exitCode ?? 'null'}) before the paste — start a new flow`,
+      retryable: false,
+    }
+  }
+
+  const parsed = parseLoopbackRedirect(pastedText)
+  if (!parsed.ok) {
+    return rejectRetryable(parsed.reason)
+  }
+  if (parsed.state !== flow.state) {
+    // CSRF guard — keep waiting; the operator may have pasted a stale URL.
+    return rejectRetryable('state parameter does not match this flow (CSRF guard)')
+  }
+  if (parsed.port !== flow.port) {
+    return rejectRetryable(
+      `redirect port ${parsed.port} does not match this flow's listener`,
+    )
   }
   // Single-use latch — set before any await so a racing second paste bounces.
   flow.submitting = true
@@ -484,6 +559,13 @@ export async function submitLoopbackRedirect(
   flow.child.stderr?.on('data', onErrChunk)
 
   const exitPromise = new Promise<number | null>((resolve) => {
+    // Guard the tiny race where the child exits between the upfront
+    // `flow.exited` check and this listener registration — an `exit` event
+    // that already fired never re-fires, which would hang us to the timeout.
+    if (flow.exited) {
+      resolve(flow.exitCode ?? null)
+      return
+    }
     flow.child.on('exit', (code) => resolve(code))
   })
 

--- a/telegram-plugin/gateway/auth-loopback-relay.ts
+++ b/telegram-plugin/gateway/auth-loopback-relay.ts
@@ -1,0 +1,544 @@
+/**
+ * Telegram-native OAuth loopback relay for Google / Microsoft account add
+ * (issue #2582).
+ *
+ * The problem: `switchroom auth google|microsoft account add <email>` mints
+ * credentials via the desktop-loopback OAuth flow — the CLI binds an ephemeral
+ * `127.0.0.1:<port>` listener, prints a consent URL whose `redirect_uri`
+ * points at that port, and waits for the browser to redirect back with
+ * `?code=...&state=...`. On a headless fleet host the redirect target isn't
+ * reachable from the operator's phone, which *looks* un-relayable — but isn't.
+ * The operator can open the consent URL on their phone, approve, and although
+ * the redirect to `127.0.0.1:<port>` fails to load there, their address bar
+ * holds the `?code=...&state=...`. Paste that back over Telegram and the
+ * gateway can hand it to the still-waiting loopback listener.
+ *
+ * This module owns that relay end-to-end, mirroring `auth-add-flow.ts`:
+ *
+ *   1. Operator sends `/auth google add <email>` (or `/auth microsoft add`).
+ *   2. Gateway calls {@link startLoopbackFlow} → spawns the real
+ *      `switchroom auth <provider> account add` CLI as a child process with
+ *      **piped stdout**, scrapes the consent URL the CLI prints, extracts the
+ *      CSRF `state` + loopback `port` from it, and stashes a
+ *      {@link PendingLoopbackFlow} keyed by chat.
+ *   3. Gateway replies to chat with the consent URL + paste instructions.
+ *   4. Operator approves on their phone, copies the failed-redirect URL from
+ *      the address bar, pastes it into chat. The gateway's message intercept
+ *      catches the paste and calls {@link submitLoopbackRedirect}.
+ *   5. Helper validates `state` against the pending flow, then HTTP-GETs the
+ *      live loopback listener at `127.0.0.1:<port>` with the pasted query
+ *      string. The CLI's own listener re-validates `state`, exchanges the
+ *      code, registers the account with the auth-broker, and exits 0.
+ *   6. Success = the child process exits 0. Confirmed to chat; the pasted
+ *      redirect (which carries the `code`) is redacted by the gateway.
+ *
+ * Why the CLI subprocess (vs. importing `runLoopbackOAuth` in-process):
+ *
+ *   - The gateway *can* import `src/` modules (auth-add-flow.ts already
+ *     imports `src/auth/manager.js`), so an in-process drive is technically
+ *     possible. But `runLoopbackOAuth` only returns a `TokenResponse` — the
+ *     large, security-sensitive registration surface (scope selection, vault
+ *     client-secret resolution, `buildGoogleCredentials`, broker `addAccount`,
+ *     `--replace` semantics) lives in `src/cli/auth-google.ts` /
+ *     `src/cli/auth-microsoft.ts`. Reproducing it in the gateway would
+ *     duplicate that surface and drift from the CLI. Driving the CLI keeps it
+ *     the single source of truth for registration.
+ *   - Unlike `claude setup-token` (which writes to `/dev/tty` and needs a
+ *     tmux pty — see auth-add-flow.ts), the switchroom CLI prints the consent
+ *     URL via `console.log` to stdout. A plain piped child process captures
+ *     it — no tmux, no pty. This is the incident-validated mechanism
+ *     (2026-06-26): run the flow in the agent container that holds the grant,
+ *     feed the listener a loopback GET.
+ *
+ * **Security invariants (must hold):**
+ *   - The `code` and any token are NEVER logged or echoed to chat. This module
+ *     does not log. Confirmations name only the account label. The gateway
+ *     redacts the pasted redirect message.
+ *   - `state` is validated in-process before the loopback GET, AND the CLI's
+ *     own listener re-validates it — defence in depth.
+ *   - Single-use: a flow that has begun submitting or completed rejects any
+ *     further paste (no code accepted after completion). TTL sweep drops
+ *     abandoned flows.
+ */
+
+import { spawn } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
+
+export type LoopbackProvider = 'google' | 'microsoft'
+
+/* ── Injectable child-process seam (unit tests mock this) ─────────────────── */
+
+/**
+ * The narrow slice of `ChildProcess` the relay drives. Injected in tests as a
+ * fake so no real CLI is spawned; satisfied by a real `ChildProcess` in prod.
+ */
+export interface RelayChild {
+  stdout: NodeJS.ReadableStream | null
+  stderr: NodeJS.ReadableStream | null
+  on(event: 'exit', cb: (code: number | null) => void): void
+  on(event: 'error', cb: (err: Error) => void): void
+  kill(signal?: NodeJS.Signals | number): boolean
+}
+
+export interface SpawnRelayOpts {
+  replace?: boolean
+  /** Google `--write` (Drive write scope). */
+  write?: boolean
+  /** Microsoft `--org-mode`. */
+  orgMode?: boolean
+  /** Override the CLI binary (tests / non-default install). */
+  binary?: string
+}
+
+export type SpawnRelay = (
+  provider: LoopbackProvider,
+  email: string,
+  opts: SpawnRelayOpts,
+) => RelayChild
+
+/**
+ * Default spawn: the real `switchroom` CLI, stdout+stderr piped, stdin
+ * ignored. `BROWSER=/bin/true` suppresses any browser auto-open; the Drive
+ * tier is pinned to desktop-loopback (the only Drive-viable flow — see
+ * src/drive/oauth.ts). stdin is `ignore` so a stray interactive prompt gets
+ * EOF and the child exits with an error rather than hanging forever.
+ */
+export function defaultSpawnRelay(
+  provider: LoopbackProvider,
+  email: string,
+  opts: SpawnRelayOpts,
+): RelayChild {
+  const binary = opts.binary ?? 'switchroom'
+  const args =
+    provider === 'google'
+      ? [
+          'auth',
+          'google',
+          'account',
+          'add',
+          email,
+          ...(opts.replace ? ['--replace'] : []),
+          ...(opts.write ? ['--write'] : []),
+        ]
+      : [
+          'auth',
+          'microsoft',
+          'account',
+          'add',
+          email,
+          ...(opts.replace ? ['--replace'] : []),
+          ...(opts.orgMode ? ['--org-mode'] : []),
+        ]
+  const child: ChildProcess = spawn(binary, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      BROWSER: '/bin/true',
+      SWITCHROOM_DRIVE_OAUTH_TIER:
+        process.env.SWITCHROOM_DRIVE_OAUTH_TIER ?? 'desktop_loopback',
+    },
+  })
+  return child
+}
+
+/* ── Pending-state map ────────────────────────────────────────────────────── */
+
+/**
+ * In-flight loopback relay keyed by Telegram chat/thread key. The gateway's
+ * generic message intercept reads this map to decide whether a pasted
+ * `127.0.0.1:<port>/?...` redirect belongs to a loopback relay flow.
+ */
+export interface PendingLoopbackFlow {
+  provider: LoopbackProvider
+  email: string
+  /** CSRF state parsed from the consent URL — the paste must echo it. */
+  state: string
+  /** Ephemeral loopback port the CLI listener is bound to. */
+  port: number
+  /** The consent URL surfaced to chat (never contains the code). */
+  consentUrl: string
+  /** The live CLI child process (its listener awaits the loopback GET). */
+  child: RelayChild
+  startedAt: number
+  /**
+   * Set once a valid paste has been accepted and the loopback GET is in
+   * flight / the flow has completed. Guards against a second paste replaying
+   * or racing the first (single-use).
+   */
+  submitting: boolean
+}
+
+export const pendingLoopbackFlows = new Map<string, PendingLoopbackFlow>()
+
+/* ── ANSI stripping ───────────────────────────────────────────────────────── */
+
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1b\[[0-9;]*m/g
+
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, '')
+}
+
+/* ── Consent-URL extraction + parsing ─────────────────────────────────────── */
+
+const CONSENT_HOST: Record<LoopbackProvider, RegExp> = {
+  // Google: https://accounts.google.com/o/oauth2/auth?...
+  google: /https:\/\/accounts\.google\.com\/o\/oauth2\/[^\s"'<>]+/,
+  // Microsoft: https://login.microsoftonline.com/<tenant>/oauth2/v2.0/authorize?...
+  microsoft: /https:\/\/login\.microsoftonline\.com\/[^\s"'<>]+/,
+}
+
+/**
+ * Scrape the provider's consent URL out of a chunk of CLI stdout. Returns the
+ * first match that carries both a `redirect_uri` and a `state` param (the
+ * loopback consent URL), or `null` if none is present yet.
+ */
+export function extractConsentUrl(
+  text: string,
+  provider: LoopbackProvider,
+): string | null {
+  const clean = stripAnsi(text)
+  const re = new RegExp(CONSENT_HOST[provider].source, 'g')
+  let m: RegExpExecArray | null
+  while ((m = re.exec(clean)) !== null) {
+    const candidate = m[0]
+    // Trim trailing punctuation the terminal may append (rare, but the
+    // regex class already excludes whitespace/quotes/angle-brackets).
+    let url: URL
+    try {
+      url = new URL(candidate)
+    } catch {
+      continue
+    }
+    if (url.searchParams.has('redirect_uri') && url.searchParams.has('state')) {
+      return candidate
+    }
+  }
+  return null
+}
+
+export interface ParsedConsentUrl {
+  state: string
+  port: number
+  redirectUri: string
+}
+
+/**
+ * Pull the CSRF `state` and the loopback `port` out of a consent URL. Throws
+ * if the URL is malformed or is not a loopback (`127.0.0.1` / `localhost`)
+ * redirect — a non-loopback redirect means this isn't a relayable flow.
+ */
+export function parseConsentUrl(consentUrl: string): ParsedConsentUrl {
+  const url = new URL(consentUrl)
+  const state = url.searchParams.get('state')
+  const redirectUri = url.searchParams.get('redirect_uri')
+  if (!state) throw new Error('consent URL missing state parameter')
+  if (!redirectUri) throw new Error('consent URL missing redirect_uri parameter')
+  let redir: URL
+  try {
+    redir = new URL(redirectUri)
+  } catch {
+    throw new Error('consent URL redirect_uri is not a valid URL')
+  }
+  if (redir.hostname !== '127.0.0.1' && redir.hostname !== 'localhost') {
+    throw new Error(
+      `redirect_uri host is ${redir.hostname}, not a loopback address — not a relayable flow`,
+    )
+  }
+  const port = Number(redir.port)
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`redirect_uri has no usable port (got ${redir.port || '(none)'})`)
+  }
+  return { state, port, redirectUri }
+}
+
+/* ── Pasted-redirect parsing ──────────────────────────────────────────────── */
+
+export type ParsedRedirect =
+  | { ok: true; host: string; port: number; code: string; state: string }
+  | { ok: false; reason: string }
+
+/**
+ * Parse the redirect URL the operator pastes back from their phone's address
+ * bar. Tolerant of surrounding whitespace and a missing scheme
+ * (`127.0.0.1:1234/?code=...` → treated as `http://`). Rejects non-loopback
+ * hosts and anything missing `code` or `state`.
+ *
+ * The `code` is returned so the caller can forward it to the loopback
+ * listener — it is NEVER logged.
+ */
+export function parseLoopbackRedirect(input: string): ParsedRedirect {
+  const trimmed = (input ?? '').trim()
+  if (trimmed.length === 0) return { ok: false, reason: 'empty input' }
+  // Accept a bare `127.0.0.1:port/?...` (no scheme) by prepending http://.
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`
+  let url: URL
+  try {
+    url = new URL(withScheme)
+  } catch {
+    return { ok: false, reason: 'not a URL' }
+  }
+  if (url.hostname !== '127.0.0.1' && url.hostname !== 'localhost') {
+    return {
+      ok: false,
+      reason: `host is ${url.hostname || '(none)'}, expected 127.0.0.1`,
+    }
+  }
+  const port = Number(url.port)
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    return { ok: false, reason: 'missing or invalid port' }
+  }
+  const err = url.searchParams.get('error')
+  if (err) {
+    return { ok: false, reason: `provider returned error: ${err}` }
+  }
+  const code = url.searchParams.get('code')
+  const state = url.searchParams.get('state')
+  if (!code) return { ok: false, reason: 'missing code parameter' }
+  if (!state) return { ok: false, reason: 'missing state parameter' }
+  return { ok: true, host: url.hostname, port, code, state }
+}
+
+/* ── Flow lifecycle ───────────────────────────────────────────────────────── */
+
+export interface StartLoopbackResult {
+  consentUrl: string
+  state: string
+  port: number
+  child: RelayChild
+}
+
+export interface StartLoopbackOpts extends SpawnRelayOpts {
+  spawnImpl?: SpawnRelay
+  /** How long to wait for the CLI to print its consent URL. Default 20s. */
+  urlTimeoutMs?: number
+}
+
+/**
+ * Spawn the CLI account-add flow and resolve once its consent URL has been
+ * scraped from stdout. On timeout or premature child exit the child is killed
+ * and the promise rejects. The caller stashes the returned handle in
+ * {@link pendingLoopbackFlows} and keeps the child alive until the operator
+ * pastes the redirect (or the flow is cancelled / reaped).
+ */
+export async function startLoopbackFlow(
+  provider: LoopbackProvider,
+  email: string,
+  opts: StartLoopbackOpts = {},
+): Promise<StartLoopbackResult> {
+  const spawnImpl = opts.spawnImpl ?? defaultSpawnRelay
+  const urlTimeoutMs = opts.urlTimeoutMs ?? 20_000
+  const child = spawnImpl(provider, email, {
+    replace: opts.replace,
+    write: opts.write,
+    orgMode: opts.orgMode,
+    binary: opts.binary,
+  })
+
+  return await new Promise<StartLoopbackResult>((resolve, reject) => {
+    let settled = false
+    let buffer = ''
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    const cleanup = () => {
+      if (timer) clearTimeout(timer)
+      timer = null
+    }
+    const finishOk = (result: StartLoopbackResult) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(result)
+    }
+    const finishErr = (err: Error) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      try {
+        child.kill()
+      } catch {
+        /* best-effort */
+      }
+      reject(err)
+    }
+
+    timer = setTimeout(() => {
+      finishErr(
+        new Error(
+          `CLI did not print a consent URL within ${Math.round(urlTimeoutMs / 1000)}s`,
+        ),
+      )
+    }, urlTimeoutMs)
+
+    const onChunk = (chunk: Buffer | string) => {
+      // Cap the buffer so a chatty CLI can't grow it unbounded before the URL.
+      buffer = (buffer + chunk.toString()).slice(-16_384)
+      const consentUrl = extractConsentUrl(buffer, provider)
+      if (!consentUrl) return
+      let parsed: ParsedConsentUrl
+      try {
+        parsed = parseConsentUrl(consentUrl)
+      } catch (e) {
+        finishErr(e instanceof Error ? e : new Error(String(e)))
+        return
+      }
+      finishOk({ consentUrl, state: parsed.state, port: parsed.port, child })
+    }
+
+    child.stdout?.on('data', onChunk)
+    // Some CLIs print prompts to stderr; scan it too.
+    child.stderr?.on('data', onChunk)
+    child.on('error', (err) => finishErr(err))
+    child.on('exit', (code) => {
+      finishErr(
+        new Error(
+          `CLI exited (code ${code ?? 'null'}) before printing a consent URL`,
+        ),
+      )
+    })
+  })
+}
+
+export type SubmitResult =
+  | { ok: true }
+  | { ok: false; reason: string; retryable: boolean }
+
+export interface SubmitOpts {
+  fetchImpl?: typeof fetch
+  /** How long to wait for the child to exit 0 after the loopback GET. Default 60s. */
+  completionTimeoutMs?: number
+}
+
+const CODE_LIKE_RE = /\b(code|access_token|refresh_token|id_token)=[^\s&]+/gi
+const LOOPBACK_URL_RE = /https?:\/\/(127\.0\.0\.1|localhost):\d+\/\S*/gi
+
+/**
+ * Scrub anything code/token/loopback-URL-shaped out of a string before it is
+ * shown to the operator. Defence in depth — the CLI does not print the code,
+ * but stderr tails are attacker-adjacent text.
+ */
+export function scrubSensitive(s: string): string {
+  return s
+    .replace(LOOPBACK_URL_RE, '[redirect-url-redacted]')
+    .replace(CODE_LIKE_RE, (_m, k) => `${k}=[redacted]`)
+}
+
+/**
+ * Validate the pasted redirect against the pending flow and, on success,
+ * hand the code to the live loopback listener. Resolves `{ ok: true }` once
+ * the CLI child exits 0 (account registered).
+ *
+ * Retryable failures (bad paste, state mismatch, wrong port) leave the flow
+ * pending so the operator can paste again. Non-retryable failures
+ * (already-submitted, listener/registration error) end the flow — the caller
+ * removes it from the pending map.
+ */
+export async function submitLoopbackRedirect(
+  flow: PendingLoopbackFlow,
+  pastedText: string,
+  opts: SubmitOpts = {},
+): Promise<SubmitResult> {
+  const fetchImpl = opts.fetchImpl ?? fetch
+  const completionTimeoutMs = opts.completionTimeoutMs ?? 60_000
+
+  const parsed = parseLoopbackRedirect(pastedText)
+  if (!parsed.ok) {
+    return { ok: false, reason: parsed.reason, retryable: true }
+  }
+  if (parsed.state !== flow.state) {
+    // CSRF guard — keep waiting; the operator may have pasted a stale URL.
+    return {
+      ok: false,
+      reason: 'state parameter does not match this flow (CSRF guard)',
+      retryable: true,
+    }
+  }
+  if (parsed.port !== flow.port) {
+    return {
+      ok: false,
+      reason: `redirect port ${parsed.port} does not match this flow's listener`,
+      retryable: true,
+    }
+  }
+  if (flow.submitting) {
+    return {
+      ok: false,
+      reason: 'this flow has already been completed',
+      retryable: false,
+    }
+  }
+  // Single-use latch — set before any await so a racing second paste bounces.
+  flow.submitting = true
+
+  // Forward the code + state to the live loopback listener. The listener
+  // re-validates state, exchanges the code, registers the account, exits 0.
+  const loopbackUrl = new URL(`http://127.0.0.1:${flow.port}/`)
+  loopbackUrl.searchParams.set('state', parsed.state)
+  loopbackUrl.searchParams.set('code', parsed.code)
+
+  // Collect a bounded stderr tail for error reporting (scrubbed before use).
+  let stderrTail = ''
+  const onErrChunk = (chunk: Buffer | string) => {
+    stderrTail = (stderrTail + chunk.toString()).slice(-2_048)
+  }
+  flow.child.stderr?.on('data', onErrChunk)
+
+  const exitPromise = new Promise<number | null>((resolve) => {
+    flow.child.on('exit', (code) => resolve(code))
+  })
+
+  try {
+    await fetchImpl(loopbackUrl.toString(), { method: 'GET' })
+  } catch (e) {
+    // The listener typically closes the socket immediately after accepting
+    // the code, which can surface as a fetch error even on success — so we
+    // do NOT treat a fetch error as fatal here; the child exit code is the
+    // real signal. Fall through to await the exit.
+    void e
+  }
+
+  const timeout = new Promise<'timeout'>((resolve) =>
+    setTimeout(() => resolve('timeout'), completionTimeoutMs),
+  )
+  const outcome = await Promise.race([exitPromise, timeout])
+
+  if (outcome === 'timeout') {
+    try {
+      flow.child.kill()
+    } catch {
+      /* best-effort */
+    }
+    return {
+      ok: false,
+      reason: `registration did not complete within ${Math.round(
+        completionTimeoutMs / 1000,
+      )}s`,
+      retryable: false,
+    }
+  }
+
+  if (outcome === 0) {
+    return { ok: true }
+  }
+  const tail = scrubSensitive(stripAnsi(stderrTail)).trim()
+  return {
+    ok: false,
+    reason: tail
+      ? `CLI exited with code ${outcome}: ${tail}`
+      : `CLI exited with code ${outcome}`,
+    retryable: false,
+  }
+}
+
+/**
+ * Cancel an in-flight loopback relay: kill the CLI child. Idempotent — safe to
+ * call after the child has already exited. The caller removes the pending map
+ * entry.
+ */
+export function cancelLoopbackFlow(flow: PendingLoopbackFlow): void {
+  try {
+    flow.child.kill()
+  } catch {
+    /* best-effort */
+  }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -17895,7 +17895,12 @@ async function handleInbound(
         redactAuthCodeMessage(bot.api as never, chat_id, msgId ?? null, line => process.stderr.write(line))
         return
       }
-      // Non-retryable — the flow is spent.
+      // Non-retryable — the flow is spent. Kill the CLI child before
+      // dropping the entry (re-review finding, PR #3100): on the attempts-
+      // exhausted path the child is still alive with a bound 127.0.0.1
+      // listener and nothing else would ever reap it. cancelLoopbackFlow is
+      // idempotent — safe on the already-exited / timed-out paths too.
+      cancelLoopbackFlow(pendingLoop)
       pendingLoopbackFlows.delete(interceptKey)
       await switchroomReply(
         ctx,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -254,6 +254,12 @@ import {
   cleanScratchDir as cleanAuthAddScratchDir,
 } from './auth-add-flow.js'
 import {
+  pendingLoopbackFlows,
+  startLoopbackFlow,
+  submitLoopbackRedirect,
+  cancelLoopbackFlow,
+} from './auth-loopback-relay.js'
+import {
   initHistory, recordInbound, recordOutbound, recordEdit,
   deleteFromHistory, query as queryHistory, getLatestInboundMessageId,
   recordReaction, lookupMessageRoleAndText,
@@ -6580,6 +6586,14 @@ const pendingStateReaper = setInterval(() => {
     if (now - v.startedAt > REAUTH_INTERCEPT_TTL_MS) {
       cancelAccountAuthSession(v)
       pendingAuthAddFlows.delete(k)
+    }
+  }
+  // Loopback OAuth relay flows (issue #2582) — same TTL. Kill the waiting
+  // CLI child so an abandoned consent never lingers with a bound listener.
+  for (const [k, v] of pendingLoopbackFlows) {
+    if (now - v.startedAt > REAUTH_INTERCEPT_TTL_MS) {
+      cancelLoopbackFlow(v)
+      pendingLoopbackFlows.delete(k)
     }
   }
   for (const [k, v] of awaitingAuthCodeAt) {
@@ -17820,6 +17834,56 @@ async function handleInbound(
     pendingAuthAddFlows.delete(interceptKey)
   }
 
+  // Loopback OAuth relay paste-back intercept (issue #2582) — sibling to
+  // the /auth add intercept above. When a Google/Microsoft loopback relay is
+  // pending for this chat and the operator pastes their `127.0.0.1:<port>`
+  // redirect URL, validate `state` and hand the code to the waiting CLI
+  // listener. The LLM never sees the code (same hygiene rationale as above).
+  const pendingLoop = pendingLoopbackFlows.get(interceptKey)
+  if (pendingLoop && /(?:127\.0\.0\.1|localhost)/.test(text)) {
+    const elapsed = Date.now() - pendingLoop.startedAt
+    if (elapsed < REAUTH_INTERCEPT_TTL_MS) {
+      const result = await submitLoopbackRedirect(pendingLoop, text.trim())
+      if (result.ok) {
+        pendingLoopbackFlows.delete(interceptKey)
+        await switchroomReply(
+          ctx,
+          `✓ ${pendingLoop.provider === 'google' ? 'Google' : 'Microsoft'} account ` +
+            `\`${escapeHtmlForTg(pendingLoop.email)}\` registered with the auth-broker.`,
+          { html: true },
+        )
+        // Redact the pasted redirect (carries the OAuth code) from history.
+        redactAuthCodeMessage(bot.api as never, chat_id, msgId ?? null, line => process.stderr.write(line))
+        return
+      }
+      if (result.retryable) {
+        // Keep the flow pending so the operator can paste again.
+        await switchroomReply(
+          ctx,
+          `**Paste not accepted:** ${escapeHtmlForTg(result.reason)}\n` +
+            `Re-open the consent URL, approve, and paste the full ` +
+            `\`127.0.0.1\` URL from your address bar. \`/auth ${pendingLoop.provider} cancel\` to abort.`,
+          { html: true },
+        )
+        // Redact even a rejected paste — it may still carry a live code.
+        redactAuthCodeMessage(bot.api as never, chat_id, msgId ?? null, line => process.stderr.write(line))
+        return
+      }
+      // Non-retryable — the flow is spent.
+      pendingLoopbackFlows.delete(interceptKey)
+      await switchroomReply(
+        ctx,
+        `**/auth ${pendingLoop.provider} add failed:** ${escapeHtmlForTg(result.reason)}`,
+        { html: true },
+      )
+      redactAuthCodeMessage(bot.api as never, chat_id, msgId ?? null, line => process.stderr.write(line))
+      return
+    }
+    // Stale — kill the child and drop the entry, then fall through.
+    cancelLoopbackFlow(pendingLoop)
+    pendingLoopbackFlows.delete(interceptKey)
+  }
+
   // Auth-code intercept
   const pendingReauth = pendingReauthFlows.get(interceptKey)
   if (pendingReauth && looksLikeAuthCode(text)) {
@@ -23364,6 +23428,79 @@ bot.command("auth", async ctx => {
     return
   }
 
+  // `/auth google add|cancel` and `/auth microsoft add|cancel` — the
+  // Telegram-native OAuth loopback relay (issue #2582). Gateway-routed for the
+  // same reason as `/auth add`: they drive a child-process listener lifecycle
+  // the broker client can't model. Admin-gated identically.
+  if (parsed.kind === 'provider-add' || parsed.kind === 'provider-cancel') {
+    if (!isAuthAdmin({ isAdmin })) {
+      await switchroomReply(
+        ctx,
+        `**Not authorized.** \`/auth ${parsed.provider}\` is admin-only.\n` +
+          `Set \`admin: true\` on this agent in switchroom.yaml to unlock.`,
+        { html: true },
+      )
+      return
+    }
+    const loopKey = chatKey(chatId, ctx.message?.message_thread_id ?? null) as string
+    if (parsed.kind === 'provider-cancel') {
+      const existing = pendingLoopbackFlows.get(loopKey)
+      if (!existing) {
+        await switchroomReply(ctx, `_No pending \`/auth ${parsed.provider} add\` flow in this chat._`, { html: true })
+        return
+      }
+      cancelLoopbackFlow(existing)
+      pendingLoopbackFlows.delete(loopKey)
+      await switchroomReply(ctx, 'Cancelled.', { html: true })
+      return
+    }
+    // parsed.kind === 'provider-add'
+    if (pendingLoopbackFlows.has(loopKey)) {
+      await switchroomReply(
+        ctx,
+        `_An \`/auth ${parsed.provider} add\` flow is already in progress for this chat. ` +
+          `Finish the paste, or send \`/auth ${parsed.provider} cancel\` to abort._`,
+        { html: true },
+      )
+      return
+    }
+    try {
+      const { consentUrl, state, port, child } = await startLoopbackFlow(
+        parsed.provider,
+        parsed.email,
+        { replace: parsed.replace, write: parsed.write, orgMode: parsed.orgMode },
+      )
+      pendingLoopbackFlows.set(loopKey, {
+        provider: parsed.provider,
+        email: parsed.email,
+        state,
+        port,
+        consentUrl,
+        child,
+        startedAt: Date.now(),
+        submitting: false,
+      })
+      const providerName = parsed.provider === 'google' ? 'Google' : 'Microsoft'
+      await switchroomReply(
+        ctx,
+        `**Adding ${providerName} account** \`${escapeHtmlForTg(parsed.email)}\`\n\n` +
+          `1. Open this URL on your phone and approve:\n${consentUrl}\n\n` +
+          `2. The redirect to \`127.0.0.1\` will fail to load — that's expected.\n` +
+          `3. Copy the **full URL** from your browser's address bar (it holds ` +
+          `\`?code=...&state=...\`) and paste it back here.\n\n` +
+          `Send \`/auth ${parsed.provider} cancel\` to abort.`,
+        { html: true },
+      )
+    } catch (err) {
+      await switchroomReply(
+        ctx,
+        `**/auth ${parsed.provider} add failed:** ${escapeHtmlForTg((err as Error)?.message ?? String(err))}`,
+        { html: true },
+      )
+    }
+    return
+  }
+
   const client = await getAuthBrokerClient(currentAgent)
   if (!client) {
     await switchroomReply(ctx, "**/auth unavailable:** auth-broker client is not loaded (post-RFC-H rewire in progress?).", { html: true })
@@ -26871,6 +27008,10 @@ async function shutdown(signal: string): Promise<void> {
   // Now finish the cleanup the drain didn't touch.
   inboundCoalescer.reset()
   pendingReauthFlows.clear()
+  // Kill any in-flight loopback relay CLI children so they don't outlive the
+  // gateway with a bound 127.0.0.1 listener (issue #2582).
+  for (const [, v] of pendingLoopbackFlows) cancelLoopbackFlow(v)
+  pendingLoopbackFlows.clear()
   pendingVaultOps.clear()
   pendingPermissions.clear()
   permissionTimeoutSignatures.clear()

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -258,6 +258,8 @@ import {
   startLoopbackFlow,
   submitLoopbackRedirect,
   cancelLoopbackFlow,
+  shouldConsumeLoopbackPaste,
+  trackFlowExit,
 } from './auth-loopback-relay.js'
 import {
   initHistory, recordInbound, recordOutbound, recordEdit,
@@ -6588,16 +6590,23 @@ const pendingStateReaper = setInterval(() => {
       pendingAuthAddFlows.delete(k)
     }
   }
+  for (const [k, v] of awaitingAuthCodeAt) {
+    if (now - v > AUTH_CODE_CONTEXT_TTL_MS) awaitingAuthCodeAt.delete(k)
+  }
   // Loopback OAuth relay flows (issue #2582) — same TTL. Kill the waiting
   // CLI child so an abandoned consent never lingers with a bound listener.
+  // Placed AFTER the OAuth-code cluster above, which secret-detect-oauth-
+  // code.test.ts pins as contiguous within the first 800 chars of the
+  // reaper (same precedent as the Microsoft connect sweep below). A flow
+  // with a submit in flight is skipped (PR #3100 review finding 3): a paste
+  // near the TTL boundary must not have its child killed mid-registration —
+  // the submit path owns cleanup once `submitting` is set.
   for (const [k, v] of pendingLoopbackFlows) {
+    if (v.submitting) continue
     if (now - v.startedAt > REAUTH_INTERCEPT_TTL_MS) {
       cancelLoopbackFlow(v)
       pendingLoopbackFlows.delete(k)
     }
-  }
-  for (const [k, v] of awaitingAuthCodeAt) {
-    if (now - v > AUTH_CODE_CONTEXT_TTL_MS) awaitingAuthCodeAt.delete(k)
   }
   // Microsoft connect flows self-expire at the device code's own expiry
   // (~15 min) — sweep past that + grace so an abandoned card doesn't pin
@@ -17839,10 +17848,27 @@ async function handleInbound(
   // pending for this chat and the operator pastes their `127.0.0.1:<port>`
   // redirect URL, validate `state` and hand the code to the waiting CLI
   // listener. The LLM never sees the code (same hygiene rationale as above).
+  // Consume-gate is deliberately narrow (PR #3100 review finding 1): only a
+  // message that actually parses as a loopback redirect — carrying a code,
+  // or a provider `error` param — is consumed and deleted. Unrelated chatter
+  // that merely mentions localhost/127.0.0.1 flows through untouched.
   const pendingLoop = pendingLoopbackFlows.get(interceptKey)
-  if (pendingLoop && /(?:127\.0\.0\.1|localhost)/.test(text)) {
+  if (pendingLoop && shouldConsumeLoopbackPaste(text)) {
     const elapsed = Date.now() - pendingLoop.startedAt
     if (elapsed < REAUTH_INTERCEPT_TTL_MS) {
+      if (pendingLoop.submitting) {
+        // A submit is already in flight (double-paste race). Don't call
+        // submitLoopbackRedirect — it would answer a non-retryable "already
+        // completed" and we'd delete the entry out from under the first
+        // submit. Benign ack; still redact (the paste carries a live code).
+        await switchroomReply(
+          ctx,
+          '_Still finishing the previous paste — one moment._',
+          { html: true },
+        )
+        redactAuthCodeMessage(bot.api as never, chat_id, msgId ?? null, line => process.stderr.write(line))
+        return
+      }
       const result = await submitLoopbackRedirect(pendingLoop, text.trim())
       if (result.ok) {
         pendingLoopbackFlows.delete(interceptKey)
@@ -23470,7 +23496,7 @@ bot.command("auth", async ctx => {
         parsed.email,
         { replace: parsed.replace, write: parsed.write, orgMode: parsed.orgMode },
       )
-      pendingLoopbackFlows.set(loopKey, {
+      const newFlow = {
         provider: parsed.provider,
         email: parsed.email,
         state,
@@ -23479,7 +23505,12 @@ bot.command("auth", async ctx => {
         child,
         startedAt: Date.now(),
         submitting: false,
-      })
+        attempts: 0,
+      }
+      // Record child exit on the flow so a pre-paste crash fails fast
+      // instead of hanging out the completion timeout (PR #3100 finding 4).
+      trackFlowExit(newFlow)
+      pendingLoopbackFlows.set(loopKey, newFlow)
       const providerName = parsed.provider === 'google' ? 'Google' : 'Microsoft'
       await switchroomReply(
         ctx,

--- a/telegram-plugin/tests/auth-loopback-relay.test.ts
+++ b/telegram-plugin/tests/auth-loopback-relay.test.ts
@@ -30,6 +30,7 @@ import {
   scrubSensitive,
   shouldConsumeLoopbackPaste,
   trackFlowExit,
+  cancelLoopbackFlow,
   MAX_PASTE_ATTEMPTS,
   type RelayChild,
   type PendingLoopbackFlow,
@@ -363,6 +364,26 @@ describe('submitLoopbackRedirect — bounded attempts', () => {
       expect(last.reason).toMatch(/ending this flow/i)
     }
     expect(flow.attempts).toBe(MAX_PASTE_ATTEMPTS)
+  })
+
+  it('attempts-exhausted child is killed by cancelLoopbackFlow (no listener leak)', async () => {
+    // The gateway's non-retryable branch calls cancelLoopbackFlow before
+    // deleting the entry — pin that the cancel actually kills a child that
+    // is still alive on the attempts-exhausted path (re-review finding).
+    const child = makeChild()
+    const flow = makePendingFlow(child)
+    const fetchImpl = (async () => {
+      throw new Error('never called')
+    }) as unknown as typeof fetch
+    let last: Awaited<ReturnType<typeof submitLoopbackRedirect>> | undefined
+    for (let i = 0; i < MAX_PASTE_ATTEMPTS; i++) {
+      last = await submitLoopbackRedirect(flow, 'garbage', { fetchImpl })
+    }
+    expect(last!.ok).toBe(false)
+    if (!last!.ok) expect(last!.retryable).toBe(false)
+    expect(child.killed).toBe(false) // still alive — the leak the gateway must close
+    cancelLoopbackFlow(flow)
+    expect(child.killed).toBe(true)
   })
 
   it('a valid paste after some rejections still succeeds', async () => {

--- a/telegram-plugin/tests/auth-loopback-relay.test.ts
+++ b/telegram-plugin/tests/auth-loopback-relay.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Telegram-native OAuth loopback relay coverage (issue #2582).
+ *
+ * Pins the deterministic contracts that make Google/Microsoft account
+ * add/re-auth completable entirely over Telegram — no SSH, no keyboard:
+ *
+ *   1. Redirect-URL parser: valid / no-scheme / missing-state / missing-code /
+ *      wrong-host / wrong-port / provider-error.
+ *   2. Consent-URL extraction + parse: state + loopback port pulled out;
+ *      non-loopback redirect rejected.
+ *   3. startLoopbackFlow surfaces the consent URL scraped from CLI stdout.
+ *   4. A valid paste completes the (mocked) exchange and resolves ok.
+ *   5. A wrong-state paste is REJECTED and the flow stays pending (retryable).
+ *   6. A second paste after completion is rejected (single-use).
+ *   7. Verb parser: `/auth google add` / `/auth microsoft add` + flags.
+ *
+ * Outcome-asserting (not code-path-touching): each test checks the ok/reason
+ * the relay returns, and that pending state is or isn't cleared.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { EventEmitter } from 'node:events'
+
+import {
+  parseLoopbackRedirect,
+  extractConsentUrl,
+  parseConsentUrl,
+  startLoopbackFlow,
+  submitLoopbackRedirect,
+  scrubSensitive,
+  type RelayChild,
+  type PendingLoopbackFlow,
+} from '../gateway/auth-loopback-relay.js'
+import { parseAuthCommand } from '../gateway/auth-command.js'
+
+// A fake child process satisfying the narrow RelayChild seam. Emits stdout /
+// stderr / exit on demand so tests drive the relay with no real CLI.
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
+  killed = false
+  kill(): boolean {
+    this.killed = true
+    return true
+  }
+}
+
+function makeChild(): FakeChild {
+  const c = new FakeChild()
+  // The relay reads child.stdout / child.stderr as ReadableStream; the
+  // EventEmitter satisfies the `.on('data', …)` usage.
+  return c
+}
+
+const STATE = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4'
+const PORT = 43117
+const GOOGLE_CONSENT = `https://accounts.google.com/o/oauth2/auth?client_id=x.apps.googleusercontent.com&redirect_uri=${encodeURIComponent(
+  `http://127.0.0.1:${PORT}`,
+)}&response_type=code&scope=drive&state=${STATE}`
+
+// ─── Redirect-URL parser ─────────────────────────────────────────────────────
+
+describe('parseLoopbackRedirect', () => {
+  it('accepts a full loopback redirect with code + state', () => {
+    const r = parseLoopbackRedirect(
+      `http://127.0.0.1:${PORT}/?code=4/abc-DEF_ghi&state=${STATE}`,
+    )
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      expect(r.port).toBe(PORT)
+      expect(r.state).toBe(STATE)
+      expect(r.code).toBe('4/abc-DEF_ghi')
+    }
+  })
+
+  it('tolerates a missing scheme and surrounding whitespace', () => {
+    const r = parseLoopbackRedirect(`  127.0.0.1:${PORT}/?code=xyz&state=${STATE}  `)
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.host).toBe('127.0.0.1')
+  })
+
+  it('rejects a non-loopback host', () => {
+    const r = parseLoopbackRedirect(`http://evil.example/?code=xyz&state=${STATE}`)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toMatch(/127\.0\.0\.1/)
+  })
+
+  it('rejects a missing state parameter', () => {
+    const r = parseLoopbackRedirect(`http://127.0.0.1:${PORT}/?code=xyz`)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toMatch(/state/)
+  })
+
+  it('rejects a missing code parameter', () => {
+    const r = parseLoopbackRedirect(`http://127.0.0.1:${PORT}/?state=${STATE}`)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toMatch(/code/)
+  })
+
+  it('surfaces a provider error param', () => {
+    const r = parseLoopbackRedirect(`http://127.0.0.1:${PORT}/?error=access_denied`)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toMatch(/access_denied/)
+  })
+
+  it('rejects a missing port', () => {
+    const r = parseLoopbackRedirect(`http://127.0.0.1/?code=xyz&state=${STATE}`)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toMatch(/port/)
+  })
+})
+
+// ─── Consent-URL extraction + parse ──────────────────────────────────────────
+
+describe('extractConsentUrl + parseConsentUrl', () => {
+  it('pulls the Google consent URL out of noisy CLI stdout', () => {
+    const stdout = `Opening your browser to authorize this agent...\n  ${GOOGLE_CONSENT}\n\nWaiting for browser callback...`
+    const url = extractConsentUrl(stdout, 'google')
+    expect(url).toBe(GOOGLE_CONSENT)
+    const parsed = parseConsentUrl(url!)
+    expect(parsed.state).toBe(STATE)
+    expect(parsed.port).toBe(PORT)
+  })
+
+  it('extracts a Microsoft consent URL', () => {
+    const ms = `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?redirect_uri=${encodeURIComponent(
+      'http://127.0.0.1:5000',
+    )}&state=deadbeefdeadbeefdeadbeefdeadbeef&client_id=y`
+    const url = extractConsentUrl(`visit:\n  ${ms}\n`, 'microsoft')
+    expect(url).toBe(ms)
+    expect(parseConsentUrl(url!).port).toBe(5000)
+  })
+
+  it('returns null when no consent URL is present yet', () => {
+    expect(extractConsentUrl('Connecting Google account...', 'google')).toBeNull()
+  })
+
+  it('rejects a non-loopback redirect_uri', () => {
+    const bad = `https://accounts.google.com/o/oauth2/auth?redirect_uri=${encodeURIComponent(
+      'https://evil.example/cb',
+    )}&state=${STATE}`
+    expect(() => parseConsentUrl(bad)).toThrow(/loopback/)
+  })
+})
+
+// ─── Flow lifecycle ──────────────────────────────────────────────────────────
+
+describe('startLoopbackFlow', () => {
+  it('resolves with the consent URL scraped from stdout', async () => {
+    const child = makeChild()
+    const p = startLoopbackFlow('google', 'user@example.com', {
+      spawnImpl: () => child as unknown as RelayChild,
+      urlTimeoutMs: 1000,
+    })
+    // Emit the consent URL as the CLI would.
+    child.stdout.emit('data', Buffer.from(`  ${GOOGLE_CONSENT}\n`))
+    const res = await p
+    expect(res.consentUrl).toBe(GOOGLE_CONSENT)
+    expect(res.state).toBe(STATE)
+    expect(res.port).toBe(PORT)
+  })
+
+  it('rejects and kills the child if it exits before a URL', async () => {
+    const child = makeChild()
+    const p = startLoopbackFlow('google', 'user@example.com', {
+      spawnImpl: () => child as unknown as RelayChild,
+      urlTimeoutMs: 1000,
+    })
+    child.emit('exit', 1)
+    await expect(p).rejects.toThrow(/before printing a consent URL/)
+    expect(child.killed).toBe(true)
+  })
+})
+
+// Build a pending flow around a fake child for submit tests.
+function makePendingFlow(child: FakeChild): PendingLoopbackFlow {
+  return {
+    provider: 'google',
+    email: 'user@example.com',
+    state: STATE,
+    port: PORT,
+    consentUrl: GOOGLE_CONSENT,
+    child: child as unknown as RelayChild,
+    startedAt: Date.now(),
+    submitting: false,
+  }
+}
+
+describe('submitLoopbackRedirect', () => {
+  it('completes the mocked exchange on a valid paste (child exits 0)', async () => {
+    const child = makeChild()
+    const flow = makePendingFlow(child)
+    let fetched: string | null = null
+    const fetchImpl = (async (url: string) => {
+      fetched = url
+      // The real listener closes the socket after accepting the code, then the
+      // CLI registers the account and exits 0. Simulate the exit.
+      setTimeout(() => child.emit('exit', 0), 0)
+      return new Response('ok')
+    }) as unknown as typeof fetch
+
+    const res = await submitLoopbackRedirect(
+      flow,
+      `http://127.0.0.1:${PORT}/?code=4/secret-CODE&state=${STATE}`,
+      { fetchImpl, completionTimeoutMs: 1000 },
+    )
+    expect(res.ok).toBe(true)
+    // The code reached the loopback listener, on the right port.
+    expect(fetched).toContain(`127.0.0.1:${PORT}`)
+    expect(fetched).toContain('code=4%2Fsecret-CODE')
+    expect(flow.submitting).toBe(true)
+  })
+
+  it('rejects a wrong-state paste and keeps the flow pending (retryable)', async () => {
+    const child = makeChild()
+    const flow = makePendingFlow(child)
+    let fetchCalls = 0
+    const fetchImpl = (async () => {
+      fetchCalls++
+      return new Response('ok')
+    }) as unknown as typeof fetch
+
+    const res = await submitLoopbackRedirect(
+      flow,
+      `http://127.0.0.1:${PORT}/?code=xyz&state=WRONGSTATE`,
+      { fetchImpl },
+    )
+    expect(res.ok).toBe(false)
+    if (!res.ok) {
+      expect(res.retryable).toBe(true)
+      expect(res.reason).toMatch(/state/i)
+    }
+    // Never contacted the listener; flow is still usable.
+    expect(fetchCalls).toBe(0)
+    expect(flow.submitting).toBe(false)
+  })
+
+  it('rejects a bad paste as retryable without touching the listener', async () => {
+    const child = makeChild()
+    const flow = makePendingFlow(child)
+    const res = await submitLoopbackRedirect(flow, 'not a url at all', {
+      fetchImpl: (async () => {
+        throw new Error('should not be called')
+      }) as unknown as typeof fetch,
+    })
+    expect(res.ok).toBe(false)
+    if (!res.ok) expect(res.retryable).toBe(true)
+    expect(flow.submitting).toBe(false)
+  })
+
+  it('rejects a second paste after completion (single-use)', async () => {
+    const child = makeChild()
+    const flow = makePendingFlow(child)
+    const fetchImpl = (async () => {
+      setTimeout(() => child.emit('exit', 0), 0)
+      return new Response('ok')
+    }) as unknown as typeof fetch
+    const first = await submitLoopbackRedirect(
+      flow,
+      `http://127.0.0.1:${PORT}/?code=abc&state=${STATE}`,
+      { fetchImpl, completionTimeoutMs: 1000 },
+    )
+    expect(first.ok).toBe(true)
+    // Second valid paste on the spent flow.
+    const second = await submitLoopbackRedirect(
+      flow,
+      `http://127.0.0.1:${PORT}/?code=abc&state=${STATE}`,
+      { fetchImpl, completionTimeoutMs: 1000 },
+    )
+    expect(second.ok).toBe(false)
+    if (!second.ok) {
+      expect(second.retryable).toBe(false)
+      expect(second.reason).toMatch(/completed/i)
+    }
+  })
+})
+
+// ─── Secret scrubbing ────────────────────────────────────────────────────────
+
+describe('scrubSensitive', () => {
+  it('redacts codes, tokens, and loopback URLs', () => {
+    const s = scrubSensitive(
+      `error at http://127.0.0.1:9000/?code=4/secret&state=x with access_token=tok123`,
+    )
+    expect(s).not.toContain('4/secret')
+    expect(s).not.toContain('tok123')
+    expect(s).not.toContain('127.0.0.1:9000')
+  })
+})
+
+// ─── Verb parser ─────────────────────────────────────────────────────────────
+
+describe('parseAuthCommand — provider verbs (#2582)', () => {
+  it('parses /auth google add <email>', () => {
+    const p = parseAuthCommand('/auth google add user@example.com')
+    expect(p).toEqual({
+      kind: 'provider-add',
+      provider: 'google',
+      email: 'user@example.com',
+      replace: false,
+      write: false,
+      orgMode: false,
+    })
+  })
+
+  it('parses google flags --replace --write', () => {
+    const p = parseAuthCommand('/auth google add user@example.com --replace --write')
+    expect(p).toMatchObject({ kind: 'provider-add', replace: true, write: true })
+  })
+
+  it('parses /auth microsoft add with --org-mode', () => {
+    const p = parseAuthCommand('/auth microsoft add user@corp.com --org-mode')
+    expect(p).toMatchObject({
+      kind: 'provider-add',
+      provider: 'microsoft',
+      orgMode: true,
+    })
+  })
+
+  it('rejects an unknown flag with help', () => {
+    const p = parseAuthCommand('/auth google add user@example.com --nope')
+    expect(p).toMatchObject({ kind: 'help' })
+  })
+
+  it('parses provider cancel', () => {
+    expect(parseAuthCommand('/auth google cancel')).toEqual({
+      kind: 'provider-cancel',
+      provider: 'google',
+    })
+  })
+
+  it('help on missing email', () => {
+    expect(parseAuthCommand('/auth microsoft add')).toMatchObject({ kind: 'help' })
+  })
+
+  it('does not treat --write as a Microsoft flag', () => {
+    const p = parseAuthCommand('/auth microsoft add user@corp.com --write')
+    expect(p).toMatchObject({ kind: 'help' })
+  })
+})

--- a/telegram-plugin/tests/auth-loopback-relay.test.ts
+++ b/telegram-plugin/tests/auth-loopback-relay.test.ts
@@ -28,6 +28,9 @@ import {
   startLoopbackFlow,
   submitLoopbackRedirect,
   scrubSensitive,
+  shouldConsumeLoopbackPaste,
+  trackFlowExit,
+  MAX_PASTE_ATTEMPTS,
   type RelayChild,
   type PendingLoopbackFlow,
 } from '../gateway/auth-loopback-relay.js'
@@ -183,6 +186,7 @@ function makePendingFlow(child: FakeChild): PendingLoopbackFlow {
     child: child as unknown as RelayChild,
     startedAt: Date.now(),
     submitting: false,
+    attempts: 0,
   }
 }
 
@@ -272,6 +276,137 @@ describe('submitLoopbackRedirect', () => {
       expect(second.retryable).toBe(false)
       expect(second.reason).toMatch(/completed/i)
     }
+  })
+})
+
+// ─── Consume gate (PR #3100 review finding 1) ───────────────────────────────
+
+describe('shouldConsumeLoopbackPaste', () => {
+  it('does NOT consume unrelated chatter mentioning localhost', () => {
+    expect(shouldConsumeLoopbackPaste("what's listening on localhost?")).toBe(false)
+    expect(shouldConsumeLoopbackPaste('is 127.0.0.1 reachable from the container?')).toBe(false)
+    expect(shouldConsumeLoopbackPaste('curl http://localhost:3000/health please')).toBe(false)
+  })
+
+  it('consumes a valid loopback redirect carrying a code', () => {
+    expect(
+      shouldConsumeLoopbackPaste(`http://127.0.0.1:${PORT}/?code=abc&state=${STATE}`),
+    ).toBe(true)
+    // Scheme-less + whitespace variant too.
+    expect(
+      shouldConsumeLoopbackPaste(`  127.0.0.1:${PORT}/?code=abc&state=${STATE}  `),
+    ).toBe(true)
+  })
+
+  it('consumes a loopback redirect carrying a provider error param', () => {
+    expect(
+      shouldConsumeLoopbackPaste(`http://127.0.0.1:${PORT}/?error=access_denied`),
+    ).toBe(true)
+  })
+
+  it('does not consume a non-loopback URL with a code', () => {
+    expect(
+      shouldConsumeLoopbackPaste(`https://evil.example/?code=abc&state=${STATE}`),
+    ).toBe(false)
+  })
+})
+
+// ─── Pre-paste child exit (PR #3100 review finding 4) ───────────────────────
+
+describe('submitLoopbackRedirect — child exited before paste', () => {
+  it('fails fast (non-retryable) instead of hanging out the timeout', async () => {
+    const child = makeChild()
+    const flow = makePendingFlow(child)
+    trackFlowExit(flow)
+    child.emit('exit', 1) // CLI died before the operator pasted
+    const started = Date.now()
+    const res = await submitLoopbackRedirect(
+      flow,
+      `http://127.0.0.1:${PORT}/?code=abc&state=${STATE}`,
+      {
+        fetchImpl: (async () => {
+          throw new Error('listener is gone — must not be called')
+        }) as unknown as typeof fetch,
+        completionTimeoutMs: 5_000,
+      },
+    )
+    expect(res.ok).toBe(false)
+    if (!res.ok) {
+      expect(res.retryable).toBe(false)
+      expect(res.reason).toMatch(/exited/i)
+    }
+    // Fast fail, not a completion-timeout wait.
+    expect(Date.now() - started).toBeLessThan(1_000)
+  })
+})
+
+// ─── Bounded paste attempts (PR #3100 review finding 5) ─────────────────────
+
+describe('submitLoopbackRedirect — bounded attempts', () => {
+  it(`ends the flow (non-retryable) after ${MAX_PASTE_ATTEMPTS} rejected pastes`, async () => {
+    const child = makeChild()
+    const flow = makePendingFlow(child)
+    const fetchImpl = (async () => {
+      throw new Error('must never be called on rejected pastes')
+    }) as unknown as typeof fetch
+
+    for (let i = 1; i < MAX_PASTE_ATTEMPTS; i++) {
+      const r = await submitLoopbackRedirect(flow, 'garbage paste', { fetchImpl })
+      expect(r.ok).toBe(false)
+      if (!r.ok) expect(r.retryable).toBe(true)
+    }
+    // The Nth rejection ends the flow.
+    const last = await submitLoopbackRedirect(flow, 'garbage paste', { fetchImpl })
+    expect(last.ok).toBe(false)
+    if (!last.ok) {
+      expect(last.retryable).toBe(false)
+      expect(last.reason).toMatch(/ending this flow/i)
+    }
+    expect(flow.attempts).toBe(MAX_PASTE_ATTEMPTS)
+  })
+
+  it('a valid paste after some rejections still succeeds', async () => {
+    const child = makeChild()
+    const flow = makePendingFlow(child)
+    const badFetch = (async () => {
+      throw new Error('not called')
+    }) as unknown as typeof fetch
+    await submitLoopbackRedirect(flow, 'garbage', { fetchImpl: badFetch })
+    await submitLoopbackRedirect(flow, 'more garbage', { fetchImpl: badFetch })
+    const goodFetch = (async () => {
+      setTimeout(() => child.emit('exit', 0), 0)
+      return new Response('ok')
+    }) as unknown as typeof fetch
+    const res = await submitLoopbackRedirect(
+      flow,
+      `http://127.0.0.1:${PORT}/?code=abc&state=${STATE}`,
+      { fetchImpl: goodFetch, completionTimeoutMs: 1000 },
+    )
+    expect(res.ok).toBe(true)
+  })
+})
+
+// ─── In-flight submit guard (PR #3100 review finding 2, module contract) ────
+
+describe('submitLoopbackRedirect — submitting flag', () => {
+  it('a flow with submitting=true rejects non-retryably without contacting the listener', async () => {
+    const child = makeChild()
+    const flow = makePendingFlow(child)
+    flow.submitting = true // first submit in flight
+    let fetchCalls = 0
+    const res = await submitLoopbackRedirect(
+      flow,
+      `http://127.0.0.1:${PORT}/?code=abc&state=${STATE}`,
+      {
+        fetchImpl: (async () => {
+          fetchCalls++
+          return new Response('ok')
+        }) as unknown as typeof fetch,
+      },
+    )
+    expect(res.ok).toBe(false)
+    if (!res.ok) expect(res.retryable).toBe(false)
+    expect(fetchCalls).toBe(0)
   })
 })
 


### PR DESCRIPTION
## Summary

Admin agents can now complete a Google or Microsoft account add/re-auth **entirely over Telegram** — no SSH port-forward, no keyboard. This makes the incident-validated 2026-06-26 relay a first-class, deterministic capability so agents stop falsely asserting "OAuth can't be done over Telegram."

Flow: the gateway runs the CLI loopback flow in the agent container that holds the grant, relays the consent URL to chat, the operator approves on their phone (the redirect to `127.0.0.1:<port>` fails to load — expected), then pastes the full address-bar URL (`?code=...&state=...`) back into chat. The gateway validates `state` and hands the code to the still-waiting loopback listener.

## In scope
- New gateway module `telegram-plugin/gateway/auth-loopback-relay.ts` (pending-flow map, TTL reaper reuse, paste intercept), modeled on `auth-add-flow.ts`.
- New chat verbs (extend `auth-command.ts`): `/auth google add <email> [--replace] [--write]`, `/auth microsoft add <email> [--replace] [--org-mode]`, and `/auth <provider> cancel`. Anthropic `/auth add` untouched.
- Gateway wiring: state-validated single-use paste-back intercept (code redacted from chat history via `redactAuthCodeMessage`), reaper sweep, shutdown cleanup that kills in-flight CLI children.
- Docs updated (`docs/auth.md`, `docs/google-workspace.md`, `docs/microsoft-workspace.md`) to document the Telegram-native path, replacing/augmenting the SSH-port-forward framing.

## Out of scope (deliberate, per spec)
- A **generic capability-probe registry** (part b's runtime mechanism) — greenfield, no primitive exists; the deterministic relay + docs satisfy the issue's acceptance. Noted here explicitly.
- Cross-container relay orchestration and any Anthropic `/auth add` changes.

## Design choice: CLI subprocess (piped stdout), not in-process `runLoopbackOAuth`
The gateway **can** import `src/` modules (`auth-add-flow.ts` already imports `src/auth/manager.js`), so an in-process drive was on the table. I chose to drive the CLI subprocess because:
- `runLoopbackOAuth` (`src/drive/oauth.ts:418`, `src/microsoft/oauth.ts:412`) only returns a `TokenResponse`. The large, security-sensitive **registration** surface (scope selection, vault client-secret resolution, `buildGoogleCredentials`, broker `addAccount`, `--replace` semantics) lives in `src/cli/auth-google.ts` / `auth-microsoft.ts`. Reproducing it in the gateway would duplicate that surface and drift from the CLI. Driving the CLI keeps it the single source of truth.
- Unlike `claude setup-token` (writes to `/dev/tty`, needs a tmux pty), the switchroom CLI prints the consent URL via `console.log` to stdout (`src/cli/drive.ts:357`). A plain piped child process captures it — **no tmux required**. This is exactly the incident-validated mechanism (run in the agent container that holds the grant, feed the listener a loopback GET).

## Accepted residual lows (deliberate)
Two narrow gaps are accepted rather than widened: (a) a code-bearing but malformed paste (one that fails `parseLoopbackRedirect`, e.g. mangled by a phone keyboard) falls through un-consumed and un-redacted — the gateway's secret-scrub hooks are the backstop there; (b) the same applies to a paste arriving after the flow's TTL has expired (stale path). Widening the consume-gate to catch these would reintroduce review finding 1 (consuming/deleting unrelated messages).

## Security invariants held
- `state` validated in-process before the loopback GET, AND re-validated by the CLI's own listener (defence in depth).
- The `code`/tokens are never logged or echoed; the pasted redirect is scrubbed (`scrubSensitive`) and redacted from chat history.
- Single-use: a submitting/completed flow rejects further pastes; TTL sweep drops abandoned flows and kills their child.
- No `claude -p`, no API keys.

## Test evidence
- New `telegram-plugin/tests/auth-loopback-relay.test.ts` — 25 tests, all green. Asserts outcomes: valid paste completes the mocked exchange (code reaches the right loopback port); wrong-`state` paste is rejected and the flow stays pending; second paste after completion is rejected (single-use); bad paste rejected without touching the listener; parser valid/invalid/missing-state/wrong-port/provider-error cases; verb parser + flag handling.
- Related suites re-run green: `auth-add-flow`, `auth-command-vernacular`, `secret-detect-oauth-code` (reaper-structure pin) — 140 tests passed.
- `npm run lint` clean (tsc + all 8 guards, including `check-bot-api-wrapping` — no new raw `bot.api` calls).

Local scope only; CI is the full-suite authority.

Closes #2582

🤖 Generated with [Claude Code](https://claude.com/claude-code)
