### PR TITLE
feat(config): first-class soul persona fields + shape discriminator (closes #1856)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+### First-class `soul:` persona fields + `shape` discriminator (#1856)
+
+`AgentSoulSchema` now types `creature`, `vibe`, `expertise`, and `emoji`
+as first-class optional string fields alongside `name`/`style`/`boundaries`.
+Previously these were referenced by the `SOUL.md` / `IDENTITY.md` templates
+(`{{soul.creature}}` etc.) but the schema — a plain `z.object` that strips
+unknown keys — silently dropped them at config-load time, so they never
+reached the templates. **This is therefore a bug fix as well as a typing
+change:** operator `soul:` blocks that set those fields now actually render.
+
+A new `shape` discriminator (`executive-assistant` | `developer` | `coach`
+| `generalist`, default `generalist`) lets one per-agent `CLAUDE.md`
+template branch on persona shape without forking a profile. No runtime
+behavior uses `shape` yet — the template work lands in a later issue.
+
+Cascade: `generalist` is treated as the neutral/unset shape. A per-agent
+soul that omits `shape` (defaulting to `generalist`) does not stomp an
+explicit profile/defaults-level `shape`; only a per-agent *non-generalist*
+shape overrides the profile. Unknown `shape` values fail config load loudly
+with a message naming `shape` and listing the allowed values.
+
 ### Per-agent CLAUDE.md is now a two-section file with a preserved operator area (#1857)
 
 `<agentDir>/CLAUDE.md` is split by a visible marker line:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,7 @@ Each field type has specific merge behavior when values exist at multiple layers
 | `permission_mode` | override | Permission mode for the agent's Claude session. Drives the `--permission-mode` CLI flag AND the `.claude/settings.json` `permissions.defaultMode`. **The switchroom built-in default is `acceptEdits`** — every agent auto-accepts edits with no yaml needed. Override per-agent here or fleet-wide via `defaults.permission_mode`; per-agent wins. Valid values: `acceptEdits`, `default`, `plan`, `bypassPermissions` (settings.json `defaultMode`), plus `auto`/`dontAsk` (CLI-flag only — these fall back to `acceptEdits` for `defaultMode`). See [Permission mode & auto-accept](#permission-mode--auto-accept). |
 | `extends` | — | Named profile to inherit from |
 | `tools.allow` / `tools.deny` | union | Tool permissions |
-| `soul` | per-field (**seed-time only**) | Agent persona (name, style, boundaries). Cascades per-field, but **only at first scaffold** — it seeds `workspace/SOUL.md`, which is then user-owned (see [Persona & SOUL.md ownership](#persona--soulmd-ownership)). Editing `soul:` later does **not** change an agent whose SOUL.md already exists. |
+| `soul` | per-field (**seed-time only**) | Agent persona (`name`, `style`, `creature`, `vibe`, `expertise`, `emoji`, `boundaries`, `shape`). Cascades per-field, but **only at first scaffold** — it seeds `workspace/SOUL.md`, which is then user-owned (see [Persona & SOUL.md ownership](#persona--soulmd-ownership)). Editing `soul:` later does **not** change an agent whose SOUL.md already exists. |
 | `memory` | per-field | Hindsight collection and recall settings |
 | `hooks` | per-event concat | Claude Code lifecycle hooks (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop, SessionEnd) |
 | `env` | per-key | Environment variables for start.sh |
@@ -585,6 +585,19 @@ Switchroom splits agent customization into two files with **opposite ownership**
 | `workspace/SOUL.md` (persona) | **You** | Seeded **once** — from the setup wizard's persona prompts, or the profile's `SOUL.md.hbs` + `soul:` config when skipped. After that it is a plain user file: `update`/`reconcile` **never** overwrite it. |
 
 This is deliberate. The managed (above-marker) part of `CLAUDE.md` is the operating manual — you want switchroom's updates to reach it — while the below-marker section is your own per-agent rules that survive every apply. `SOUL.md` is who the agent *is* — you want your words to stick, the way they do in OpenClaw/Hermes. The `soul:` config and profile `SOUL.md.hbs` are therefore **seed-time inputs only**; changing them later does not touch an agent whose `SOUL.md` already exists.
+
+**`soul:` fields.** All fields except `name` and `style` are optional:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `name` | string (required) | Persona name (e.g., `Coach`, `Sage`). |
+| `style` | string (required) | Communication style description. |
+| `creature` | string | Persona creature/form (e.g., `owl`, `octopus`). |
+| `vibe` | string | One-line personality vibe (e.g., `calm, precise`). |
+| `expertise` | string | Domain expertise summary rendered into the persona. |
+| `emoji` | string | Signature emoji for the persona. |
+| `boundaries` | string | Behavioral boundaries and disclaimers. |
+| `shape` | `executive-assistant` \| `developer` \| `coach` \| `generalist` | Persona-shape discriminator the per-agent `CLAUDE.md` template can branch on. Defaults to `generalist`. Cascade note: `generalist` is treated as the **neutral/unset** shape, so a per-agent soul that omits `shape` (and thus defaults to `generalist`) does **not** override an explicit profile-level `shape` — only a per-agent *non-generalist* shape overrides the profile. |
 
 **Editing the persona.** Just edit `workspace/SOUL.md` directly (it's tracked in the workspace git repo, so your edits are versioned and recoverable). `switchroom soul path <agent>` prints the path; `switchroom soul show <agent>` prints the current content.
 

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -367,6 +367,24 @@ export function mergeAgentConfig(
     for (const [k, v] of Object.entries(override)) {
       if (v !== undefined) combined[k] = v;
     }
+    // shape cascade (#1856): the per-agent AgentSoulSchema defaults `shape`
+    // to "generalist", so a per-agent soul block that omits shape parses
+    // with shape:"generalist" — which would otherwise stomp an explicit
+    // profile/defaults-level shape during this field-by-field merge. We
+    // treat "generalist" as the NEUTRAL/unset shape: a profile-level
+    // explicit shape wins unless the agent selects a *different*
+    // non-generalist shape. Tradeoff (documented): an operator cannot use
+    // an explicit per-agent `shape: generalist` to override a profile shape
+    // — generalist reads as "no strong shape". Deterministic, no default
+    // sentinel guessing beyond the neutral-value convention.
+    const baseSoul = base as Record<string, unknown>;
+    const overrideSoul = override as Record<string, unknown>;
+    if (
+      baseSoul.shape !== undefined &&
+      (overrideSoul.shape === undefined || overrideSoul.shape === "generalist")
+    ) {
+      combined.shape = baseSoul.shape;
+    }
     // AgentSchema's soul requires name+style; the merged result might be
     // missing one or both if defaults supplies a partial and the agent
     // supplies nothing. That's fine for scaffold.ts which renders soul

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -14,6 +14,7 @@ import {
   AgentDriveConfigSchema,
   AgentGoogleWorkspaceConfigSchema,
   AgentSchema,
+  AgentSoulSchema,
   DriveConfigSchema,
   GoogleWorkspaceConfigSchema,
   GoogleWorkspaceTierSchema,
@@ -1250,5 +1251,57 @@ describe("auth.proactive_failover_pct config field", () => {
         auth: { active: "alice", proactive_failover_pct: "95" },
       }),
     ).toThrow();
+  });
+});
+
+describe("AgentSoulSchema — first-class persona fields + shape (#1856)", () => {
+  it("(a) validates a full soul block with all 8 fields and round-trips values", () => {
+    const soul = {
+      name: "Sage",
+      style: "warm, concise",
+      creature: "owl",
+      vibe: "calm, precise",
+      expertise: "systems engineering",
+      emoji: "🦉",
+      boundaries: "not a doctor",
+      shape: "developer" as const,
+    };
+    const r = AgentSoulSchema.parse(soul);
+    expect(r).toEqual(soul);
+  });
+
+  it("(b) parses a soul block without shape to shape:'generalist'", () => {
+    const r = AgentSoulSchema.parse({ name: "X", style: "Y" });
+    expect(r?.shape).toBe("generalist");
+  });
+
+  it("(c) rejects an unknown shape with a message naming the field + allowed values", () => {
+    const r = AgentSoulSchema.safeParse({ name: "X", style: "Y", shape: "wizard" });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const issue = r.error.issues.find((i) => i.path.join(".") === "shape");
+      expect(issue).toBeDefined();
+      // enum rejection lists the four allowed values
+      expect(issue?.message).toContain("executive-assistant");
+      expect(issue?.message).toContain("developer");
+      expect(issue?.message).toContain("coach");
+      expect(issue?.message).toContain("generalist");
+    }
+  });
+
+  it("(d) still validates a minimal soul (name + style only)", () => {
+    const r = AgentSoulSchema.parse({ name: "X", style: "Y" });
+    expect(r?.name).toBe("X");
+    expect(r?.style).toBe("Y");
+  });
+
+  it("(e) validates a config with no soul block at all", () => {
+    const cfg = {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "123:ABC", forum_chat_id: "-100123" },
+      agents: { bare: { extends: "default", topic_name: "Bare" } },
+    };
+    const r = SwitchroomConfigSchema.parse(cfg);
+    expect(r.agents.bare.soul).toBeUndefined();
   });
 });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -287,10 +287,35 @@ export const AgentSoulSchema = z
   .object({
     name: z.string().describe("Agent persona name (e.g., 'Coach', 'Sage')"),
     style: z.string().describe("Communication style description"),
+    creature: z
+      .string()
+      .optional()
+      .describe("Persona creature/form (e.g., 'owl', 'octopus')"),
+    vibe: z
+      .string()
+      .optional()
+      .describe("One-line personality vibe (e.g., 'calm, precise')"),
+    expertise: z
+      .string()
+      .optional()
+      .describe("Domain expertise summary rendered into the persona"),
+    emoji: z
+      .string()
+      .optional()
+      .describe("Signature emoji for the persona (e.g., '🦉')"),
     boundaries: z
       .string()
       .optional()
       .describe("Behavioral boundaries and disclaimers"),
+    shape: z
+      .enum(["executive-assistant", "developer", "coach", "generalist"])
+      .default("generalist")
+      .describe(
+        "Persona-shape discriminator the per-agent CLAUDE.md template can " +
+        "branch on (e.g., 'you are an executive assistant' vs 'a senior " +
+        "engineer'). No runtime behavior yet — template work lands in a " +
+        "later issue. Cascade: override (per-agent wins over default)."
+      ),
   })
   .optional();
 
@@ -2361,7 +2386,19 @@ const profileFields = {
     .object({
       name: z.string().optional(),
       style: z.string().optional(),
+      creature: z.string().optional(),
+      vibe: z.string().optional(),
+      expertise: z.string().optional(),
+      emoji: z.string().optional(),
       boundaries: z.string().optional(),
+      // No .default() here: a profile/defaults layer fills in fields the
+      // per-agent soul omits, so `shape` stays optional. The "generalist"
+      // default lives on AgentSoulSchema (per-agent). See merge.ts soul
+      // cascade for how a defaulted per-agent "generalist" is treated as
+      // the neutral shape so it does not stomp an explicit profile shape.
+      shape: z
+        .enum(["executive-assistant", "developer", "coach", "generalist"])
+        .optional(),
     })
     .optional(),
   tools: z

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -23,7 +23,12 @@ describe("SwitchroomConfigSchema", () => {
           soul: {
             name: "Coach",
             style: "motivational, direct",
+            creature: "golden retriever",
+            vibe: "warm, high-energy",
+            expertise: "strength training, habit design",
+            emoji: "🏋️",
             boundaries: "not a doctor",
+            shape: "coach",
           },
           tools: {
             allow: ["calendar", "notion"],
@@ -50,6 +55,14 @@ describe("SwitchroomConfigSchema", () => {
     ]);
     expect(result.agents["health-coach"].memory?.collection).toBe("health");
     expect(result.agents["health-coach"].schedule).toHaveLength(1);
+    // #1856: first-class soul persona fields + shape round-trip.
+    expect(result.agents["health-coach"].soul?.creature).toBe("golden retriever");
+    expect(result.agents["health-coach"].soul?.vibe).toBe("warm, high-energy");
+    expect(result.agents["health-coach"].soul?.expertise).toBe(
+      "strength training, habit design",
+    );
+    expect(result.agents["health-coach"].soul?.emoji).toBe("🏋️");
+    expect(result.agents["health-coach"].soul?.shape).toBe("coach");
   });
 
   it("parses a minimal config with defaults", () => {

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -220,6 +220,30 @@ describe("mergeAgentConfig", () => {
     });
   });
 
+  it("soul shape: an explicit profile/default shape is NOT stomped by a per-agent defaulted 'generalist' (#1856)", () => {
+    const defaults: AgentDefaults = {
+      soul: { style: "warm", shape: "developer" },
+    };
+    // Simulates a per-agent soul parsed via AgentSoulSchema: shape defaults
+    // to "generalist" when the operator omits it.
+    const agent = baseAgent({
+      soul: { name: "Dev", style: "direct", shape: "generalist" },
+    });
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.soul?.shape).toBe("developer"); // profile shape survives
+  });
+
+  it("soul shape: a per-agent explicit NON-generalist shape overrides the profile shape (#1856)", () => {
+    const defaults: AgentDefaults = {
+      soul: { style: "warm", shape: "developer" },
+    };
+    const agent = baseAgent({
+      soul: { name: "EA", style: "direct", shape: "executive-assistant" },
+    });
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.soul?.shape).toBe("executive-assistant");
+  });
+
   it("shallow-merges memory field-by-field", () => {
     const defaults: AgentDefaults = {
       memory: { auto_recall: true, isolation: "default" },


### PR DESCRIPTION
Part of epic #1850 (prompt redesign 5/8). Closes #1856.

## What

- Widen `AgentSoulSchema` (`src/config/schema.ts`): promote `creature`, `vibe`, `expertise`, `emoji` to first-class optional string fields alongside `name`/`style`/`boundaries`.
- Add `shape: z.enum(["executive-assistant","developer","coach","generalist"]).default("generalist")` — a persona-shape discriminator the per-agent `CLAUDE.md` template will branch on (template work is epic 6/8; **no runtime behavior change here**).
- Widen the profile/defaults soul schema with the same fields (shape optional, no default) so profiles can declare a shape.
- Handle the cascade so a per-agent defaulted `generalist` does not stomp an explicit profile shape (`src/config/merge.ts`).

## Findings (grounded in main)

**Strip vs passthrough — it was STRIPPING (bug fix).** `AgentSoulSchema` is a plain `z.object` with no `.passthrough()`, so unknown keys are dropped at parse time. Verified empirically against `origin/main`:

```
AgentSoulSchema.parse({name,style,creature:'owl',vibe,expertise,emoji,boundaries})
→ {"name":"X","style":"Y","boundaries":"none"}   // creature/vibe/expertise/emoji GONE
```

`SOUL.md.hbs` / `IDENTITY.md.hbs` reference `{{soul.creature}}`, `{{soul.vibe}}`, `{{soul.expertise}}`, `{{soul.emoji}}` (profiles/default/workspace/), and `loader.ts:191` runs `SwitchroomConfigSchema.parse(parsed)` before scaffold reads the config — so those fields never reached the templates. Promoting them to typed fields fixes that.

**Cascade / merge finding.** There are two soul schemas: `AgentSoulSchema` (per-agent `soul:`, requires name+style) and an inline soul object inside `profileFields`/`defaultsFields` (all-optional, used for `defaults:` + profiles). `merge.ts` does a per-field shallow merge (agent wins field-by-field, `undefined` doesn't clobber). Because `.default("generalist")` makes the per-agent `shape` always present, a per-agent soul that omits shape would otherwise stomp an explicit profile `shape`. Resolution: **`generalist` is treated as the neutral/unset shape** — a profile-level explicit shape wins unless the agent selects a *different* non-generalist shape. Documented tradeoff: an operator cannot use an explicit per-agent `shape: generalist` to override a profile shape (generalist reads as "no strong shape"). Deterministic, no default-sentinel guessing.

**Doctor probe.** Not needed. Zod's enum rejects unknown `shape` at config load; `formatZodErrors` renders `shape: Invalid enum value... 'executive-assistant' | 'developer' | 'coach' | 'generalist'`, which names the field and lists allowed values — an actionable load failure. A schema test asserts this message.

## Files

- `src/config/schema.ts` — widened both soul schemas.
- `src/config/merge.ts` — shape cascade (neutral-generalist rule).
- `src/config/schema.test.ts` — soul describe block (a–e).
- `tests/config.test.ts` — widened operator fixture + round-trip asserts.
- `tests/merge.test.ts` — cascade non-stomp + override tests.
- `docs/configuration.md` — soul fields table + cascade note.
- `CHANGELOG.md` — Unreleased entry.

## Test evidence

`vitest run` scoped (264 passed):

```
✓ src/config/schema.test.ts (137 tests)
✓ tests/config.test.ts (10 tests)
✓ tests/merge.test.ts
✓ tests/scaffold.persona.test.ts
✓ tests/reconcile.persona.test.ts
✓ tests/scaffold.soul-user-owned.test.ts
Tests  264 passed (264)
```

`npm run lint` — clean (tsc + all 8 guards).

## Out of scope

Template render changes, scaffold behavior, migrating operator yamls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)