### PR TITLE
feat(web): surface agents blocked on an undeliverable approval

### DIFF
--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.16.49";
-export const COMMIT_SHA: string | null = "de33dcbf";
-export const COMMIT_DATE: string | null = "2026-07-05T09:57:29+10:00";
-export const LATEST_PR: number | null = 2782;
-export const COMMITS_AHEAD_OF_TAG: number | null = 0;
+export const VERSION: string = "0.18.0";
+export const COMMIT_SHA: string | null = "5584bf20";
+export const COMMIT_DATE: string | null = "2026-07-11T19:02:16+10:00";
+export const LATEST_PR: number | null = 3097;
+export const COMMITS_AHEAD_OF_TAG: number | null = 42;

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -32,8 +32,10 @@ import {
 } from "../setup/hindsight.js";
 import {
   formatBlockedFor,
-  handleGetBlockedApprovals,
+  readBlockedApprovalsWithErrors,
+  blockedApprovalsDir,
   type BlockedApproval,
+  type BlockedApprovalsRead,
 } from "./blocked-approvals-read.js";
 import {
   defaultAuditLogPath,
@@ -2254,6 +2256,11 @@ export interface SummaryDashboard {
    *  Summary "needs attention" rows and the blocked count on the services
    *  rail: a held agent must be visible WITHOUT Telegram. */
   blockedApprovals: BlockedApproval[];
+  /** How many blocked-approval records could NOT be read (0600, IO error).
+   *  `> 0` means an empty `blockedApprovals` does NOT mean "nothing is
+   *  blocked" — it means we failed to look. Nothing may claim health while
+   *  this is non-zero. */
+  blockedApprovalsUnreadable: number;
   /** Server-derived triage list — the things that genuinely need the
    *  operator's eye right now, sorted critical→warn→info and capped. Empty
    *  when nothing is wrong. Each item points at the tab to investigate. */
@@ -2303,10 +2310,30 @@ export function deriveAttention(
     systemHealth?: SystemHealth | null;
     agents?: AgentInfo[] | null;
     blockedApprovals?: BlockedApproval[] | null;
+    /** Records we failed to READ (not records that were absent). */
+    blockedApprovalsUnreadable?: number | null;
   },
   now: number,
 ): AttentionItem[] {
   const items: AttentionItem[] = [];
+
+  // ── unreadable blocked-approval records ──────────────────────────────
+  // We could not read a record, so we do NOT know that nothing is blocked.
+  // This must be louder than silence: a held agent hiding behind a 0600 file
+  // is precisely the failure this surface exists to prevent, and an "all
+  // clear" that actually means "I couldn't look" is the bug wearing the
+  // fix's clothes.
+  const unreadable = parts.blockedApprovalsUnreadable ?? 0;
+  if (unreadable > 0) {
+    items.push({
+      severity: "critical",
+      title: `Cannot read ${unreadable} blocked-approval record(s)`,
+      detail:
+        "An agent may be held on an approval right now and this dashboard " +
+        "cannot see it. Records must be mode 0644 in ~/.switchroom/blocked-approvals.",
+      tab: "approvals",
+    });
+  }
 
   // ── blocked approvals ────────────────────────────────────────────────
   // An agent held on an approval that could not be delivered to Telegram.
@@ -2474,8 +2501,10 @@ export async function handleGetSummary(
      *  round-trip, so it takes no `SummaryPart` stamp and never gates the
      *  summary's freshness. Defaults to the real reader: the dangerous
      *  failure here is a held agent going SILENTLY invisible, so the
-     *  default must be "wired", not "empty". Injectable for tests. */
-    blockedApprovals?: () => BlockedApproval[];
+     *  default must be "wired", not "empty". Injectable for tests. Returns
+     *  the unreadable count too — an empty list alone cannot be trusted to
+     *  mean "nothing is blocked". */
+    blockedApprovals?: () => BlockedApprovalsRead;
   },
   now: number = Date.now(),
 ): Promise<SummaryDashboard> {
@@ -2508,15 +2537,18 @@ export async function handleGetSummary(
     .filter((d): d is number => typeof d === "number");
   const dataAsOf = stamps.length > 0 ? Math.min(...stamps) : 0;
 
-  // Blocked approvals: a local 0644-file read that already degrades to `[]`
-  // on every failure. Wrapped anyway so it can never take the summary down —
-  // the surface that makes a held agent visible must itself be unkillable.
-  let blockedApprovals: BlockedApproval[] = [];
+  // Blocked approvals: a local file read that already degrades on its own.
+  // Wrapped anyway so it can never take the summary down — the surface that
+  // makes a held agent visible must itself be unkillable. If the whole read
+  // throws we report ONE unreadable record rather than an empty list, so the
+  // summary still refuses to claim health it hasn't verified.
+  let blocked: BlockedApprovalsRead = { blocked: [], unreadable: 0 };
   try {
-    blockedApprovals =
-      (deps.blockedApprovals ?? handleGetBlockedApprovals)() ?? [];
+    const read = (deps.blockedApprovals ??
+      (() => readBlockedApprovalsWithErrors(blockedApprovalsDir())))();
+    if (read) blocked = read;
   } catch {
-    blockedApprovals = [];
+    blocked = { blocked: [], unreadable: 1 };
   }
 
   // Server-side triage from the parts already aggregated — pure derivation,
@@ -2528,7 +2560,8 @@ export async function handleGetSummary(
       schedule: schedule.value,
       systemHealth: systemHealth.value,
       agents: agents.value,
-      blockedApprovals,
+      blockedApprovals: blocked.blocked,
+      blockedApprovalsUnreadable: blocked.unreadable,
     },
     now,
   );
@@ -2540,7 +2573,8 @@ export async function handleGetSummary(
     schedule: schedule.value,
     accounts: accounts.value,
     memoryHealth: memoryHealth.value,
-    blockedApprovals,
+    blockedApprovals: blocked.blocked,
+    blockedApprovalsUnreadable: blocked.unreadable,
     attention,
     dataAsOf,
   };

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -31,6 +31,11 @@ import {
   getHindsightStatus,
 } from "../setup/hindsight.js";
 import {
+  formatBlockedFor,
+  handleGetBlockedApprovals,
+  type BlockedApproval,
+} from "./blocked-approvals-read.js";
+import {
   defaultAuditLogPath,
   readAndFilter,
   type AuditEntry,
@@ -2243,6 +2248,12 @@ export interface SummaryDashboard {
    *  Memory tab uses. Powers the "needs attention" memory rows. null when
    *  hindsight was unreachable / the producer threw. */
   memoryHealth: MemoryHealth | null;
+  /** Agents held on an approval that could not be delivered to Telegram.
+   *  Always an array — honest empty `[]` when nothing is blocked (and while
+   *  the gateway-side record producer is not yet deployed). Powers the
+   *  Summary "needs attention" rows and the blocked count on the services
+   *  rail: a held agent must be visible WITHOUT Telegram. */
+  blockedApprovals: BlockedApproval[];
   /** Server-derived triage list — the things that genuinely need the
    *  operator's eye right now, sorted critical→warn→info and capped. Empty
    *  when nothing is wrong. Each item points at the tab to investigate. */
@@ -2262,7 +2273,7 @@ export interface AttentionItem {
   severity: "critical" | "warn" | "info";
   title: string;
   detail?: string;
-  tab: "memory" | "accounts" | "schedule" | "system" | "agents";
+  tab: "memory" | "accounts" | "schedule" | "system" | "agents" | "approvals";
 }
 
 /** Severity ordering for the triage sort — lower sorts first. */
@@ -2291,10 +2302,34 @@ export function deriveAttention(
     schedule?: ScheduleDashboard | null;
     systemHealth?: SystemHealth | null;
     agents?: AgentInfo[] | null;
+    blockedApprovals?: BlockedApproval[] | null;
   },
   now: number,
 ): AttentionItem[] {
   const items: AttentionItem[] = [];
+
+  // ── blocked approvals ────────────────────────────────────────────────
+  // An agent held on an approval that could not be delivered to Telegram.
+  // It HOLDS (never auto-approves, never auto-denies), so it will wait
+  // indefinitely — which is only safe if the operator can SEE it. This row
+  // is the Telegram-independent surface: it must show up on the default tab
+  // without anyone going looking (#3084 — overlord sat blocked 50 minutes
+  // behind a flood ban and nobody knew).
+  for (const b of parts.blockedApprovals ?? []) {
+    if (!b) continue;
+    const held = formatBlockedFor(now - b.blockedSince);
+    const what = b.action?.trim() || b.toolName || "an approval";
+    const retry =
+      typeof b.retryableAt === "number" && b.retryableAt > now
+        ? ` Retry in ${formatBlockedFor(b.retryableAt - now)}.`
+        : "";
+    items.push({
+      severity: "critical",
+      title: `${b.agent} — blocked ${held}`,
+      detail: `Waiting on approval to ${what}. Could not deliver the card (${b.reason}).${retry}`,
+      tab: "approvals",
+    });
+  }
 
   // ── memory ───────────────────────────────────────────────────────────
   const mem = parts.memoryHealth;
@@ -2435,6 +2470,12 @@ export async function handleGetSummary(
     schedule: () => Promise<SummaryPart<ScheduleDashboard>>;
     accounts: () => Promise<SummaryPart<AccountDashboardInfo[]>>;
     memoryHealth: () => Promise<SummaryPart<MemoryHealth>>;
+    /** Blocked approvals — a plain local dir read, not a cached host
+     *  round-trip, so it takes no `SummaryPart` stamp and never gates the
+     *  summary's freshness. Defaults to the real reader: the dangerous
+     *  failure here is a held agent going SILENTLY invisible, so the
+     *  default must be "wired", not "empty". Injectable for tests. */
+    blockedApprovals?: () => BlockedApproval[];
   },
   now: number = Date.now(),
 ): Promise<SummaryDashboard> {
@@ -2467,6 +2508,17 @@ export async function handleGetSummary(
     .filter((d): d is number => typeof d === "number");
   const dataAsOf = stamps.length > 0 ? Math.min(...stamps) : 0;
 
+  // Blocked approvals: a local 0644-file read that already degrades to `[]`
+  // on every failure. Wrapped anyway so it can never take the summary down —
+  // the surface that makes a held agent visible must itself be unkillable.
+  let blockedApprovals: BlockedApproval[] = [];
+  try {
+    blockedApprovals =
+      (deps.blockedApprovals ?? handleGetBlockedApprovals)() ?? [];
+  } catch {
+    blockedApprovals = [];
+  }
+
   // Server-side triage from the parts already aggregated — pure derivation,
   // no extra reads. Each null part simply contributes nothing.
   const attention = deriveAttention(
@@ -2476,6 +2528,7 @@ export async function handleGetSummary(
       schedule: schedule.value,
       systemHealth: systemHealth.value,
       agents: agents.value,
+      blockedApprovals,
     },
     now,
   );
@@ -2487,6 +2540,7 @@ export async function handleGetSummary(
     schedule: schedule.value,
     accounts: accounts.value,
     memoryHealth: memoryHealth.value,
+    blockedApprovals,
     attention,
     dataAsOf,
   };

--- a/src/web/blocked-approvals-read.ts
+++ b/src/web/blocked-approvals-read.ts
@@ -1,0 +1,186 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { homedir } from "node:os";
+
+/**
+ * Blocked approvals — the Telegram-independent view of an agent stuck on an
+ * approval it cannot deliver.
+ *
+ * Serves the job spec `reference/jobs/approve-what-my-agent-can-touch.md`
+ * (outcome `hold-the-leash`).
+ *
+ * Why this exists: on 2026-07-11 the `overlord` bot took a 4.6h Telegram
+ * flood ban (#3084). A permission prompt fired during it, the approval card
+ * could not be sent, and the operator had no idea — the agent sat blocked for
+ * 50 minutes and was only found by someone going looking. The agent now HOLDS
+ * (never auto-approves, never auto-denies), which is correct but useless if a
+ * held agent is invisible. So the block has to be visible on a surface that
+ * does NOT depend on Telegram: this reader, the `/api/blocked-approvals`
+ * route, and the dashboard.
+ *
+ * The record is written by the gateway on each blocked approval, one file per
+ * agent, at `~/.switchroom/blocked-approvals/<agent>.json` (dir 0755, files
+ * 0644). Two hard constraints on that contract, both learned the hard way:
+ *
+ *  1. **The web container runs as uid 1000 and cannot read the agent's own
+ *     0600 state.** `~/.switchroom/agents/<agent>/telegram/*.json` is mode
+ *     0600, root/agent-owned; `docker exec switchroom-web cat` on it returns
+ *     "Permission denied". A dashboard built on those files renders a silently
+ *     empty page (the same bug as Hermes' 0600 `registry.db` → empty history
+ *     tab). Hence a SHARED, world-readable record in a shared dir — the same
+ *     posture as `~/.switchroom/fleet-health/ledger.json` (0644 in a 0755
+ *     dir), which the web container demonstrably reads today.
+ *  2. **Metadata only.** The record NEVER carries raw tool input. This reader
+ *     hard-whitelists the fields below and drops everything else, so an
+ *     unexpected field on disk can never reach the render side.
+ *
+ * Everything degrades to an honest empty list: absent dir (record producer
+ * not deployed yet), unreadable file (wrong mode), malformed JSON, or a
+ * record missing its required fields. Never throws, never renders a lie.
+ */
+
+/** One agent held on an approval that could not be delivered. Metadata only —
+ *  never the tool's input. Extra on-disk fields are untrusted and dropped. */
+export interface BlockedApproval {
+  /** The held agent. */
+  agent: string;
+  /** The approval request id — the join key to the gateway log. */
+  requestId: string;
+  /** The tool the agent is asking to use (e.g. "Bash"). */
+  toolName: string;
+  /** Short human text: what it wants to do. Not the raw tool input. */
+  action: string;
+  /** Unix ms — when the agent started waiting on this approval. */
+  blockedSince: number;
+  /** Unix ms — when delivery to Telegram started failing. null if unknown. */
+  undeliverableSince: number | null;
+  /** Unix ms — earliest the gateway may retry delivery (e.g. the flood-wait
+   *  expiry). null when the producer can't say. */
+  retryableAt: number | null;
+  /** Why it could not be delivered, e.g. "flood_wait". */
+  reason: string;
+}
+
+/**
+ * Resolve the record directory. `~/.switchroom/blocked-approvals` by default;
+ * the `home` arg (or `SWITCHROOM_HOME` / `HOME`) is injectable so tests point
+ * at a tmpdir and never touch the operator's live tree. Same idiom as
+ * `fleetHealthLedgerPath()`. In the web container `HOME=/host-home`, which the
+ * compose file binds to the operator's home — so this resolves to the same
+ * host path the gateway writes.
+ */
+export function blockedApprovalsDir(
+  home: string = process.env.SWITCHROOM_HOME ?? process.env.HOME ?? homedir(),
+): string {
+  return resolve(home, ".switchroom", "blocked-approvals");
+}
+
+/** A finite number or null — a malformed timestamp must never reach the UI as
+ *  NaN/Infinity/string (that renders "blocked NaNm", a lie). */
+function finiteOrNull(v: unknown): number | null {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Non-empty string or null. */
+function stringOrNull(v: unknown): string | null {
+  return typeof v === "string" && v.trim().length > 0 ? v : null;
+}
+
+/**
+ * Coerce one on-disk record into the typed shape, hard-whitelisting fields.
+ * Returns null when a REQUIRED field is missing or unusable — a record we
+ * can't honestly describe is dropped rather than half-rendered. `agent` falls
+ * back to the filename stem so a record that lost its own name still surfaces
+ * (an agent held and invisible is the exact failure this module exists to
+ * prevent; better to name it from the file than to drop it).
+ */
+function coerce(raw: unknown, fallbackAgent: string): BlockedApproval | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+
+  const agent = stringOrNull(r.agent) ?? fallbackAgent;
+  const blockedSince = finiteOrNull(r.blockedSince);
+  // Without an agent and a start time there is nothing honest to say.
+  if (!agent || blockedSince === null) return null;
+
+  return {
+    agent,
+    requestId: stringOrNull(r.requestId) ?? "unknown",
+    toolName: stringOrNull(r.toolName) ?? "unknown",
+    action: stringOrNull(r.action) ?? "",
+    blockedSince,
+    undeliverableSince: finiteOrNull(r.undeliverableSince),
+    retryableAt: finiteOrNull(r.retryableAt),
+    reason: stringOrNull(r.reason) ?? "unknown",
+  };
+}
+
+/**
+ * Read every `<agent>.json` in `dir` and return the blocked agents,
+ * longest-blocked first (worst-first, same posture as the fleet-health
+ * ranking). ALWAYS an array — honest empty `[]`, never null, never an
+ * object wrapper (the Hermes Desktop adapter consumes this API; a shape
+ * surprise crashes that client).
+ *
+ * Degrades per-file: one unreadable (0600) or malformed record never hides
+ * the others, and no failure escapes as a throw.
+ */
+export function readBlockedApprovals(dir: string): BlockedApproval[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    // Dir absent (record producer not deployed yet) or unreadable → nothing
+    // is known to be blocked. Honest empty, not an error page.
+    return [];
+  }
+
+  const out: BlockedApproval[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".json")) continue;
+    let record: BlockedApproval | null;
+    try {
+      const raw = JSON.parse(readFileSync(join(dir, name), "utf-8")) as unknown;
+      record = coerce(raw, name.slice(0, -".json".length));
+    } catch {
+      // Malformed JSON, or EACCES on a wrongly-moded file. Skip this record;
+      // the others still render.
+      continue;
+    }
+    if (record) out.push(record);
+  }
+
+  // Longest-blocked first — the one that has been waiting on the operator
+  // the longest is the one that most needs them.
+  return out.sort((a, b) => a.blockedSince - b.blockedSince);
+}
+
+/**
+ * How long the agent has been held, as short human text: "35s", "47m",
+ * "2h 13m", "3d 4h". Pure; `now` is injected so it's testable. A future
+ * `blockedSince` (clock skew) clamps to 0 rather than emitting "-3m".
+ * Used for the Summary attention row ("overlord — blocked 47m") and the
+ * Approvals table, so both read identically.
+ */
+export function formatBlockedFor(ms: number): string {
+  const t = Math.max(0, Math.floor(ms / 1000));
+  if (t < 60) return `${t}s`;
+  const m = Math.floor(t / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return h > 0 && m % 60 > 0 ? `${h}h ${m % 60}m` : `${h}h`;
+  const d = Math.floor(h / 24);
+  return h % 24 > 0 ? `${d}d ${h % 24}h` : `${d}d`;
+}
+
+/**
+ * Route handler — resolves the default record dir and reads it. `dir` is
+ * injectable for tests. Read-only: no model call, no host mutation, no
+ * network (mirrors handleGetFleetHealth).
+ */
+export function handleGetBlockedApprovals(
+  dir: string = blockedApprovalsDir(),
+): BlockedApproval[] {
+  return readBlockedApprovals(dir);
+}

--- a/src/web/blocked-approvals-read.ts
+++ b/src/web/blocked-approvals-read.ts
@@ -117,43 +117,109 @@ function coerce(raw: unknown, fallbackAgent: string): BlockedApproval | null {
 }
 
 /**
- * Read every `<agent>.json` in `dir` and return the blocked agents,
- * longest-blocked first (worst-first, same posture as the fleet-health
- * ranking). ALWAYS an array — honest empty `[]`, never null, never an
- * object wrapper (the Hermes Desktop adapter consumes this API; a shape
- * surprise crashes that client).
+ * The result of a read: the blocked agents PLUS how many records we could
+ * not read at all.
+ *
+ * `unreadable` exists because "there is nothing there" and "I failed to
+ * look" are different facts, and collapsing them is the worst bug this
+ * surface can have. An EACCES on a 0600 record means an agent may well be
+ * held right now; reporting that as an empty list makes the page print "No
+ * agent is blocked", which is a positive claim the code has NOT verified.
+ * That is the reassuring-lie failure the whole feature exists to kill, and
+ * it is a live risk: the record producer is a separate change, and the
+ * per-agent Telegram state files sitting next to these records are written
+ * 0600 TODAY (the same way the Hermes `registry.db` bug happened).
+ *
+ * So: `unreadable > 0` means the surface must say "I could not read the
+ * records; an agent may be held", never "nothing is blocked".
+ */
+export interface BlockedApprovalsRead {
+  /** The records we could read and parse, longest-blocked first. */
+  blocked: BlockedApproval[];
+  /** How many records existed but could NOT be read (EACCES on a 0600 file,
+   *  EISDIR, IO error), or 1 when the directory itself existed but could not
+   *  be enumerated. 0 means every record present was read successfully — the
+   *  only state in which an empty `blocked` honestly means "nothing is
+   *  blocked". */
+  unreadable: number;
+}
+
+/**
+ * Read every `<agent>.json` in `dir`, returning the blocked agents AND the
+ * count we failed to read. Never throws.
  *
  * Degrades per-file: one unreadable (0600) or malformed record never hides
- * the others, and no failure escapes as a throw.
+ * the others. A read FAILURE is counted in `unreadable` rather than being
+ * silently swallowed; a clean parse-miss (malformed JSON, missing required
+ * fields) is a drop, because there we DID look and there was nothing usable.
  */
-export function readBlockedApprovals(dir: string): BlockedApproval[] {
+export function readBlockedApprovalsWithErrors(
+  dir: string,
+): BlockedApprovalsRead {
   let entries: string[];
   try {
     entries = readdirSync(dir);
-  } catch {
-    // Dir absent (record producer not deployed yet) or unreadable → nothing
-    // is known to be blocked. Honest empty, not an error page.
-    return [];
+  } catch (err) {
+    // ENOENT: the dir genuinely isn't there (the record producer hasn't
+    // landed, or nothing has ever blocked). That is an honest empty.
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return { blocked: [], unreadable: 0 };
+    }
+    // Anything else (EACCES on the dir, EIO): the dir EXISTS and we could
+    // not look inside it. We do not know that nothing is blocked, and we
+    // must not imply it. Count it as one unreadable record.
+    return { blocked: [], unreadable: 1 };
   }
 
   const out: BlockedApproval[] = [];
+  let unreadable = 0;
+
   for (const name of entries) {
     if (!name.endsWith(".json")) continue;
+
+    // Read and parse are SEPARATE steps so the two failures stay
+    // distinguishable: a read error means we couldn't look, a parse error
+    // means we looked and found nothing usable.
+    let text: string;
+    try {
+      text = readFileSync(join(dir, name), "utf-8");
+    } catch {
+      // EACCES (record written 0600 root/agent-owned — the trap), EISDIR, IO.
+      // An agent may be held behind this file and we cannot see it. Count it.
+      unreadable++;
+      continue;
+    }
+
     let record: BlockedApproval | null;
     try {
-      const raw = JSON.parse(readFileSync(join(dir, name), "utf-8")) as unknown;
-      record = coerce(raw, name.slice(0, -".json".length));
+      record = coerce(JSON.parse(text) as unknown, name.slice(0, -".json".length));
     } catch {
-      // Malformed JSON, or EACCES on a wrongly-moded file. Skip this record;
-      // the others still render.
+      // Malformed JSON. We read it; there is nothing honest to render.
       continue;
     }
     if (record) out.push(record);
   }
 
-  // Longest-blocked first — the one that has been waiting on the operator
-  // the longest is the one that most needs them.
-  return out.sort((a, b) => a.blockedSince - b.blockedSince);
+  return {
+    // Longest-blocked first — the one that has been waiting on the operator
+    // the longest is the one that most needs them.
+    blocked: out.sort((a, b) => a.blockedSince - b.blockedSince),
+    unreadable,
+  };
+}
+
+/**
+ * The blocked agents alone, longest-blocked first. ALWAYS an array — honest
+ * empty `[]`, never null, never an object wrapper (the Hermes Desktop
+ * adapter consumes `/api/blocked-approvals`; a shape surprise crashes that
+ * client, so this endpoint's contract is a bare array and stays one).
+ *
+ * Read failures are NOT visible through this function. Anything that renders
+ * an "all clear" to the operator must use {@link readBlockedApprovalsWithErrors}
+ * and check `unreadable` first.
+ */
+export function readBlockedApprovals(dir: string): BlockedApproval[] {
+  return readBlockedApprovalsWithErrors(dir).blocked;
 }
 
 /**
@@ -183,4 +249,19 @@ export function handleGetBlockedApprovals(
   dir: string = blockedApprovalsDir(),
 ): BlockedApproval[] {
   return readBlockedApprovals(dir);
+}
+
+/**
+ * Status handler for `GET /api/blocked-approvals/status` — the out-of-band
+ * companion to the bare-array endpoint. The Approvals tab needs to know
+ * whether a read FAILED (so it can warn instead of printing "nothing is
+ * blocked"), and the bare-array contract has nowhere to carry that without
+ * breaking Hermes. So it rides here instead of being synthesized as a fake
+ * row in the array, which would defeat the field whitelist.
+ */
+export function handleGetBlockedApprovalsStatus(
+  dir: string = blockedApprovalsDir(),
+): { blocked: number; unreadable: number } {
+  const { blocked, unreadable } = readBlockedApprovalsWithErrors(dir);
+  return { blocked: blocked.length, unreadable };
 }

--- a/src/web/blocked-approvals.test.ts
+++ b/src/web/blocked-approvals.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readBlockedApprovals,
+  handleGetBlockedApprovals,
+  blockedApprovalsDir,
+  formatBlockedFor,
+  type BlockedApproval,
+} from "./blocked-approvals-read.js";
+import { deriveAttention } from "./api.js";
+
+/**
+ * The blocked-approvals surface: an agent held on an approval it could not
+ * deliver to Telegram must be VISIBLE without Telegram. These pin the reader
+ * and the Summary triage row it feeds.
+ *
+ * The failure being guarded against is a SILENTLY EMPTY page — the web
+ * container runs as uid 1000 and cannot read the agent's own 0600 state, so a
+ * reader that hits an unreadable file must degrade honestly (and, crucially,
+ * must not hide the records it CAN read).
+ */
+describe("readBlockedApprovals (Telegram-independent view of a held agent)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sr-blocked-appr-"));
+  });
+  afterEach(() => {
+    // chmod back first — a 0000 file inside can defeat the recursive rm.
+    try {
+      chmodSync(join(dir, "locked.json"), 0o644);
+    } catch {
+      /* not every case writes it */
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const NOW = 1783756731607;
+
+  function write(agent: string, rec: unknown): void {
+    writeFileSync(join(dir, `${agent}.json`), JSON.stringify(rec));
+  }
+
+  const overlord: BlockedApproval = {
+    agent: "overlord",
+    requestId: "req-abc123",
+    toolName: "Bash",
+    action: "restart the gateway supervisor",
+    // 47 minutes before NOW
+    blockedSince: NOW - 47 * 60_000,
+    undeliverableSince: NOW - 47 * 60_000,
+    retryableAt: NOW + 13 * 60_000,
+    reason: "flood_wait",
+  };
+
+  it("returns a blocked record written to disk, with every operator-facing field", () => {
+    write("overlord", overlord);
+    const blocked = readBlockedApprovals(dir);
+
+    expect(blocked).toHaveLength(1);
+    const b = blocked[0];
+    // which agent
+    expect(b.agent).toBe("overlord");
+    // what it's blocked on
+    expect(b.action).toBe("restart the gateway supervisor");
+    expect(b.toolName).toBe("Bash");
+    // how long (derived) — "blocked for 47 minutes", legible at a glance
+    expect(formatBlockedFor(NOW - b.blockedSince)).toBe("47m");
+    // when it can retry
+    expect(b.retryableAt).toBe(NOW + 13 * 60_000);
+    // and why
+    expect(b.reason).toBe("flood_wait");
+    expect(b.requestId).toBe("req-abc123");
+  });
+
+  it("is an ARRAY endpoint — honest empty [] when nothing is blocked, never null", () => {
+    // dir exists, no records in it
+    const blocked = readBlockedApprovals(dir);
+    expect(Array.isArray(blocked)).toBe(true);
+    expect(blocked).toEqual([]);
+  });
+
+  it("degrades to an honest empty [] when the record dir is absent", () => {
+    // The record producer (gateway side) lands separately — until then the
+    // dir simply does not exist. That is not an error state.
+    const blocked = readBlockedApprovals(join(dir, "does-not-exist"));
+    expect(blocked).toEqual([]);
+  });
+
+  it("degrades to empty on malformed JSON — no crash", () => {
+    writeFileSync(join(dir, "overlord.json"), "{ not json");
+    expect(() => readBlockedApprovals(dir)).not.toThrow();
+    expect(readBlockedApprovals(dir)).toEqual([]);
+  });
+
+  it("drops a record with no usable blockedSince rather than rendering NaN", () => {
+    // A "blocked NaNm" row is a lie; drop the record instead.
+    write("overlord", { ...overlord, blockedSince: "whenever" });
+    expect(readBlockedApprovals(dir)).toEqual([]);
+  });
+
+  it("normalizes malformed retryableAt / undeliverableSince to null, not NaN", () => {
+    write("overlord", {
+      ...overlord,
+      retryableAt: "soon",
+      undeliverableSince: undefined,
+    });
+    const [b] = readBlockedApprovals(dir);
+    expect(b.retryableAt).toBeNull();
+    expect(b.undeliverableSince).toBeNull();
+  });
+
+  it("hard-whitelists fields — an extra on-disk field never reaches the render side", () => {
+    // The record is metadata only and must NEVER carry raw tool input. If a
+    // producer bug ever put one there, the reader must not pass it through.
+    write("overlord", {
+      ...overlord,
+      toolInput: { command: "rm -rf /" },
+      secret: "sk-ant-" + "fake",
+    });
+    const [b] = readBlockedApprovals(dir);
+    expect(b).not.toHaveProperty("toolInput");
+    expect(b).not.toHaveProperty("secret");
+    expect(Object.keys(b).sort()).toEqual([
+      "action",
+      "agent",
+      "blockedSince",
+      "reason",
+      "requestId",
+      "retryableAt",
+      "toolName",
+      "undeliverableSince",
+    ]);
+  });
+
+  it("an unreadable record never hides the readable ones (the 0600 trap)", () => {
+    // THE failure this guards against: the web container is uid 1000 and the
+    // agent's own state files are 0600. A reader that throws on the first
+    // unreadable file renders a silently empty page. Use a directory named
+    // `<agent>.json` — readFileSync on it fails with EISDIR for EVERY uid
+    // (including root in CI), so this is deterministic, unlike a chmod.
+    mkdirSync(join(dir, "unreadable.json"));
+    write("overlord", overlord);
+
+    const blocked = readBlockedApprovals(dir);
+    expect(blocked).toHaveLength(1);
+    expect(blocked[0].agent).toBe("overlord");
+  });
+
+  it.skipIf(process.getuid?.() === 0)(
+    "degrades honestly on a real 0600/0000 file instead of exploding",
+    () => {
+      writeFileSync(join(dir, "locked.json"), JSON.stringify(overlord));
+      chmodSync(join(dir, "locked.json"), 0o000);
+      write("clerk", { ...overlord, agent: "clerk" });
+
+      expect(() => readBlockedApprovals(dir)).not.toThrow();
+      const blocked = readBlockedApprovals(dir);
+      // The unreadable one is skipped; the readable one still surfaces.
+      expect(blocked.map((b) => b.agent)).toEqual(["clerk"]);
+    },
+  );
+
+  it("ranks longest-blocked first", () => {
+    write("overlord", overlord); // 47m
+    write("clerk", { ...overlord, agent: "clerk", blockedSince: NOW - 5 * 60_000 }); // 5m
+    write("marko", { ...overlord, agent: "marko", blockedSince: NOW - 3 * 3600_000 }); // 3h
+
+    expect(readBlockedApprovals(dir).map((b) => b.agent)).toEqual([
+      "marko", // 3h — waiting longest
+      "overlord", // 47m
+      "clerk", // 5m
+    ]);
+  });
+
+  it("ignores non-.json files in the dir", () => {
+    writeFileSync(join(dir, "README"), "not a record");
+    write("overlord", overlord);
+    expect(readBlockedApprovals(dir)).toHaveLength(1);
+  });
+
+  it("names the agent from the filename when the record lost its own name", () => {
+    // A held-and-invisible agent is the exact failure this exists to prevent:
+    // name it from the file rather than dropping it.
+    write("overlord", { ...overlord, agent: undefined });
+    expect(readBlockedApprovals(dir)[0].agent).toBe("overlord");
+  });
+
+  it("resolves the default dir under ~/.switchroom/blocked-approvals", () => {
+    // Mirrors fleetHealthLedgerPath: the web container sets HOME=/host-home,
+    // bound to the operator home, so this is the same path the gateway writes.
+    const home = mkdtempSync(join(tmpdir(), "sr-home-"));
+    expect(blockedApprovalsDir(home)).toBe(
+      join(home, ".switchroom", "blocked-approvals"),
+    );
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("handleGetBlockedApprovals reads the dir it is given", () => {
+    write("overlord", overlord);
+    expect(handleGetBlockedApprovals(dir).map((b) => b.agent)).toEqual(["overlord"]);
+  });
+});
+
+describe("formatBlockedFor (humanized hold duration)", () => {
+  it("reads legibly at a glance across the range", () => {
+    expect(formatBlockedFor(35_000)).toBe("35s");
+    expect(formatBlockedFor(47 * 60_000)).toBe("47m");
+    expect(formatBlockedFor(60 * 60_000)).toBe("1h");
+    expect(formatBlockedFor(133 * 60_000)).toBe("2h 13m");
+    expect(formatBlockedFor(28 * 3600_000)).toBe("1d 4h");
+  });
+
+  it("clamps a future blockedSince (clock skew) to 0 instead of emitting a negative", () => {
+    expect(formatBlockedFor(-5000)).toBe("0s");
+  });
+});
+
+describe("deriveAttention — a blocked agent reaches the Summary tab", () => {
+  const NOW = 1783756731607;
+
+  const blocked: BlockedApproval = {
+    agent: "overlord",
+    requestId: "req-abc123",
+    toolName: "Bash",
+    action: "restart the gateway supervisor",
+    blockedSince: NOW - 47 * 60_000,
+    undeliverableSince: NOW - 47 * 60_000,
+    retryableAt: NOW + 13 * 60_000,
+    reason: "flood_wait",
+  };
+
+  it("raises a critical row naming the agent and how long it has been held", () => {
+    // The whole point: Ken SEES a blocked agent on the default tab, rather
+    // than discovering one an hour later.
+    const items = deriveAttention({ blockedApprovals: [blocked] }, NOW);
+    const row = items.find((i) => i.title.includes("overlord"));
+
+    expect(row).toBeDefined();
+    expect(row!.severity).toBe("critical");
+    expect(row!.title).toBe("overlord — blocked 47m");
+    // it points at the tab that shows the detail
+    expect(row!.tab).toBe("approvals");
+    // and says what it's blocked on, and why
+    expect(row!.detail).toContain("restart the gateway supervisor");
+    expect(row!.detail).toContain("flood_wait");
+  });
+
+  it("contributes nothing when nothing is blocked (no false alarm)", () => {
+    expect(deriveAttention({ blockedApprovals: [] }, NOW)).toEqual([]);
+    expect(deriveAttention({ blockedApprovals: null }, NOW)).toEqual([]);
+    expect(deriveAttention({}, NOW)).toEqual([]);
+  });
+
+  it("raises one row per held agent", () => {
+    const items = deriveAttention(
+      {
+        blockedApprovals: [
+          blocked,
+          { ...blocked, agent: "clerk", blockedSince: NOW - 5 * 60_000 },
+        ],
+      },
+      NOW,
+    );
+    expect(items.map((i) => i.title)).toEqual([
+      "overlord — blocked 47m",
+      "clerk — blocked 5m",
+    ]);
+  });
+});

--- a/src/web/blocked-approvals.test.ts
+++ b/src/web/blocked-approvals.test.ts
@@ -4,12 +4,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   readBlockedApprovals,
+  readBlockedApprovalsWithErrors,
   handleGetBlockedApprovals,
+  handleGetBlockedApprovalsStatus,
   blockedApprovalsDir,
   formatBlockedFor,
   type BlockedApproval,
 } from "./blocked-approvals-read.js";
-import { deriveAttention } from "./api.js";
+import { deriveAttention, handleGetSummary } from "./api.js";
 
 /**
  * The blocked-approvals surface: an agent held on an approval it could not
@@ -163,6 +165,110 @@ describe("readBlockedApprovals (Telegram-independent view of a held agent)", () 
     },
   );
 
+  // ── "I could not look" must never render as "nothing is blocked" ──────
+  //
+  // THE blocker this feature must not have. An unreadable record (0600 —
+  // exactly how pending-perm-cards.json is written today, and exactly how the
+  // Hermes registry.db bug happened) means an agent MAY be held right now.
+  // Reporting that as an empty list makes the page print a confident
+  // "No agent is blocked on an undeliverable approval" over a hanging agent.
+  describe("an unreadable record is never reported as an honest empty", () => {
+    it("counts a record it could not read, separately from one that isn't there", () => {
+      // EISDIR: unreadable for EVERY uid including root in CI, so this is
+      // deterministic where a chmod is not.
+      mkdirSync(join(dir, "overlord.json"));
+
+      const { blocked, unreadable } = readBlockedApprovalsWithErrors(dir);
+      expect(blocked).toEqual([]);
+      // The list is empty, but we did NOT verify that nothing is blocked.
+      expect(unreadable).toBe(1);
+    });
+
+    it("an absent dir is a TRUE empty — unreadable 0 (nothing to warn about)", () => {
+      const { blocked, unreadable } = readBlockedApprovalsWithErrors(
+        join(dir, "does-not-exist"),
+      );
+      expect(blocked).toEqual([]);
+      // ENOENT is honest emptiness, not blindness. It must NOT warn — a
+      // permanent false alarm would train the operator to ignore the surface.
+      expect(unreadable).toBe(0);
+    });
+
+    it("an empty dir is a TRUE empty — unreadable 0", () => {
+      expect(readBlockedApprovalsWithErrors(dir)).toEqual({
+        blocked: [],
+        unreadable: 0,
+      });
+    });
+
+    it("malformed JSON is a parse-miss, not blindness — we looked", () => {
+      writeFileSync(join(dir, "overlord.json"), "{ not json");
+      expect(readBlockedApprovalsWithErrors(dir).unreadable).toBe(0);
+    });
+
+    it("an unreadable record still reports the readable ones AND the blind spot", () => {
+      mkdirSync(join(dir, "clerk.json"));
+      write("overlord", overlord);
+
+      const { blocked, unreadable } = readBlockedApprovalsWithErrors(dir);
+      expect(blocked.map((b) => b.agent)).toEqual(["overlord"]);
+      expect(unreadable).toBe(1);
+    });
+
+    it.skipIf(process.getuid?.() === 0)(
+      "a real 0600 root-owned-style record counts as unreadable, not as absent",
+      () => {
+        writeFileSync(join(dir, "locked.json"), JSON.stringify(overlord));
+        chmodSync(join(dir, "locked.json"), 0o000);
+
+        const { blocked, unreadable } = readBlockedApprovalsWithErrors(dir);
+        expect(blocked).toEqual([]);
+        expect(unreadable).toBe(1);
+      },
+    );
+
+    it("the status endpoint surfaces the blind spot out-of-band", () => {
+      // It cannot ride on /api/blocked-approvals (bare array, Hermes
+      // contract) and must NOT be a synthesized fake row in that array.
+      mkdirSync(join(dir, "overlord.json"));
+      expect(handleGetBlockedApprovalsStatus(dir)).toEqual({
+        blocked: 0,
+        unreadable: 1,
+      });
+    });
+
+    it("the bare-array endpoint keeps its Hermes contract even when blind", () => {
+      mkdirSync(join(dir, "overlord.json"));
+      const arr = handleGetBlockedApprovals(dir);
+      expect(Array.isArray(arr)).toBe(true);
+      expect(arr).toEqual([]); // no fake row synthesized into the array
+    });
+
+    it("deriveAttention raises a CRITICAL row when records are unreadable", () => {
+      // The surface must not claim health. This is the assertion that goes
+      // RED if the read ever silently returns [] again.
+      const items = deriveAttention(
+        { blockedApprovals: [], blockedApprovalsUnreadable: 1 },
+        NOW,
+      );
+      expect(items).toHaveLength(1);
+      expect(items[0].severity).toBe("critical");
+      expect(items[0].title).toContain("Cannot read");
+      expect(items[0].tab).toBe("approvals");
+      expect(items[0].detail).toContain("may be held");
+    });
+
+    it("deriveAttention stays silent when the read was clean and empty", () => {
+      // No false alarm on the honest-empty path (the pre-producer state).
+      expect(
+        deriveAttention(
+          { blockedApprovals: [], blockedApprovalsUnreadable: 0 },
+          NOW,
+        ),
+      ).toEqual([]);
+    });
+  });
+
   it("ranks longest-blocked first", () => {
     write("overlord", overlord); // 47m
     write("clerk", { ...overlord, agent: "clerk", blockedSince: NOW - 5 * 60_000 }); // 5m
@@ -252,6 +358,51 @@ describe("deriveAttention — a blocked agent reaches the Summary tab", () => {
     expect(deriveAttention({ blockedApprovals: [] }, NOW)).toEqual([]);
     expect(deriveAttention({ blockedApprovals: null }, NOW)).toEqual([]);
     expect(deriveAttention({}, NOW)).toEqual([]);
+  });
+
+  it("carries the unreadable count through handleGetSummary to the Summary tab", async () => {
+    // The services rail reads `blockedApprovalsUnreadable` to decide whether
+    // it may print "all nominal". Pin that it actually arrives.
+    const nullPart = <T,>(value: T) => async () => ({ value, dataAsOf: NOW });
+    const summary = await handleGetSummary(
+      {
+        agents: nullPart(null as never),
+        systemHealth: nullPart(null as never),
+        approvals: nullPart(null as never),
+        schedule: nullPart(null as never),
+        accounts: nullPart(null as never),
+        memoryHealth: nullPart(null as never),
+        blockedApprovals: () => ({ blocked: [], unreadable: 2 }),
+      },
+      NOW,
+    );
+
+    expect(summary.blockedApprovals).toEqual([]);
+    expect(summary.blockedApprovalsUnreadable).toBe(2);
+    // and it must surface as a critical row, not as silence
+    expect(summary.attention.some((i) => i.severity === "critical")).toBe(true);
+  });
+
+  it("reports a blind spot (not an all-clear) if the whole read throws", async () => {
+    const nullPart = <T,>(value: T) => async () => ({ value, dataAsOf: NOW });
+    const summary = await handleGetSummary(
+      {
+        agents: nullPart(null as never),
+        systemHealth: nullPart(null as never),
+        approvals: nullPart(null as never),
+        schedule: nullPart(null as never),
+        accounts: nullPart(null as never),
+        memoryHealth: nullPart(null as never),
+        blockedApprovals: () => {
+          throw new Error("disk exploded");
+        },
+      },
+      NOW,
+    );
+
+    // Degrades without taking the summary down, but does NOT claim health.
+    expect(summary.blockedApprovals).toEqual([]);
+    expect(summary.blockedApprovalsUnreadable).toBe(1);
   });
 
   it("raises one row per held agent", () => {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -57,7 +57,10 @@ import {
 } from "./api.js";
 import type { CachedResult } from "./cache.js";
 import { handleGetFleetHealth } from "./fleet-health-read.js";
-import { handleGetBlockedApprovals } from "./blocked-approvals-read.js";
+import {
+  handleGetBlockedApprovals,
+  handleGetBlockedApprovalsStatus,
+} from "./blocked-approvals-read.js";
 import { fetchAgentLogsViaHostd } from "./hostd-read-client.js";
 import { handleWebhookIngest } from "./webhook-handler.js";
 import { loadEdgeSecret } from "./webhook-edge.js";
@@ -604,6 +607,16 @@ function parseRoute(
     return { handler: "getBlockedApprovals", params: {} };
   }
 
+  // GET /api/blocked-approvals/status — out-of-band companion carrying the
+  // count of records we FAILED to read (0600, IO error). It cannot ride on
+  // the bare-array endpoint above without breaking the Hermes contract, and
+  // it must not be synthesized as a fake row in that array. Without it the
+  // page cannot tell "nothing is blocked" from "I could not look", and would
+  // print a reassuring all-clear over a held agent.
+  if (method === "GET" && pathname === "/api/blocked-approvals/status") {
+    return { handler: "getBlockedApprovalsStatus", params: {} };
+  }
+
   // GET /api/fleet-health — job-spec-anchored issue tracker (RFC
   // fleet-health.md). Reads the owner agent's health ledger, ranked
   // worst-first by priority_score. Read-only; degrades to an empty state
@@ -982,6 +995,9 @@ export function startWebServer(
             // to see through a stale cache. Bare array response, no stamp
             // wrap (see getAgents / getAccounts).
             return jsonResponse(handleGetBlockedApprovals());
+
+          case "getBlockedApprovalsStatus":
+            return jsonResponse(handleGetBlockedApprovalsStatus());
 
           case "getFleetHealth":
             // Local, always-available read of the health ledger. Not routed

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -57,6 +57,7 @@ import {
 } from "./api.js";
 import type { CachedResult } from "./cache.js";
 import { handleGetFleetHealth } from "./fleet-health-read.js";
+import { handleGetBlockedApprovals } from "./blocked-approvals-read.js";
 import { fetchAgentLogsViaHostd } from "./hostd-read-client.js";
 import { handleWebhookIngest } from "./webhook-handler.js";
 import { loadEdgeSecret } from "./webhook-edge.js";
@@ -592,6 +593,17 @@ function parseRoute(
     return { handler: "getApprovals", params: {} };
   }
 
+  // GET /api/blocked-approvals — agents HELD on an approval whose card could
+  // not be delivered to Telegram (flood ban, API outage). The agent never
+  // auto-approves and never auto-denies, so it waits indefinitely; this is
+  // the surface that makes that wait VISIBLE without Telegram (#3084).
+  // Bare ARRAY, honest empty `[]` — the Hermes Desktop adapter consumes this
+  // API and a shape surprise crashes it. Degrades to `[]` until the
+  // gateway-side record producer lands.
+  if (method === "GET" && pathname === "/api/blocked-approvals") {
+    return { handler: "getBlockedApprovals", params: {} };
+  }
+
   // GET /api/fleet-health — job-spec-anchored issue tracker (RFC
   // fleet-health.md). Reads the owner agent's health ledger, ranked
   // worst-first by priority_score. Read-only; degrades to an empty state
@@ -962,6 +974,14 @@ export function startWebServer(
           case "getApprovals":
             return (async () =>
               jsonResponse(withStamp(await cachedApprovals())))();
+
+          case "getBlockedApprovals":
+            // Local, always-available read of the blocked-approval records.
+            // Not cached, same reasoning as getFleetHealth (small local file
+            // reads) — and a held agent is exactly the thing you never want
+            // to see through a stale cache. Bare array response, no stamp
+            // wrap (see getAgents / getAccounts).
+            return jsonResponse(handleGetBlockedApprovals());
 
           case "getFleetHealth":
             // Local, always-available read of the health ledger. Not routed

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -1685,15 +1685,22 @@
       const safe = (p, fallback) =>
         p.then(r => r.ok ? r.json() : fallback).catch(() => fallback);
       try {
-        const [blocked, approvals, grants] = await Promise.all([
+        const [blocked, blockedStatus, approvals, grants] = await Promise.all([
           // Blocked approvals lead the tab — an agent held with no way to ask
           // is the only thing here that is actively costing the operator.
-          safe(fetch(`${API}/api/blocked-approvals`, { headers: authHeaders() }), []),
+          // The fallback is a `null` SENTINEL, never `[]`: a 500 / auth
+          // failure / network error must not render as "nothing is blocked".
+          // That would be a positive claim we did not verify, over an agent
+          // that may be hanging right now.
+          safe(fetch(`${API}/api/blocked-approvals`, { headers: authHeaders() }), null),
+          // Companion read: how many records we FAILED to read (0600 files).
+          // Same rule — null means we don't know, which is not "all clear".
+          safe(fetch(`${API}/api/blocked-approvals/status`, { headers: authHeaders() }), null),
           safe(fetch(`${API}/api/approvals`, { headers: authHeaders() }), null),
           safe(fetch(`${API}/api/grants`, { headers: authHeaders() }),
             { reachable: false, grants: [], error: 'Failed to fetch standing grants.' }),
         ]);
-        renderApprovals(blocked, approvals, grants);
+        renderApprovals(blocked, blockedStatus, approvals, grants);
         clearError();
       } catch (err) {
         showError(`Failed to fetch approvals: ${err.message}`);
@@ -2071,20 +2078,45 @@
       // above (server-derived), and as a count here — a blocked agent must be
       // visible on the default tab without drilling in (#3084).
       const blockedAppr = Array.isArray(summary.blockedApprovals) ? summary.blockedApprovals : [];
+      // Records that EXIST but could not be read (0600, IO error). Non-zero
+      // means an empty `blockedAppr` proves nothing, so nothing below may
+      // claim "none blocked" or "all nominal".
+      const blockedUnreadable = Number(summary.blockedApprovalsUnreadable) || 0;
       const schedEntries = (sched && Array.isArray(sched.entries)) ? sched.entries : [];
       const schedAgents = new Set(schedEntries.map(e => e.agent)).size;
-      const services = [
-        svc('auth-broker', !!b.reachable, b.reachable ? `active ${escapeHtml(b.active || '—')} · ${b.accounts ?? '?'} accts` : 'unreachable'),
-        svc('hindsight', !!hs.running, hs.running ? `${escapeHtml(hs.model || '?')} · ${hs.mcpStateless ? 'stateless' : 'stateful'}` : 'not running'),
-        svc('hostd', !!hd.auditLogPresent, hd.auditLogPresent ? `${(hd.recent || []).length} recent verbs` : 'no audit log'),
-        svc('schedule', schedEntries.length > 0, `${schedEntries.length} crons · ${schedAgents} agents`),
-        // A blocked agent makes this service NOT ok, however reachable the
-        // kernel is — the leash is jammed and someone is waiting on Ken.
-        svc('approvals', apprReachable && blockedAppr.length === 0,
-          blockedAppr.length > 0
-            ? `<b>${blockedAppr.length} agent${blockedAppr.length === 1 ? '' : 's'} blocked</b> — ${escapeHtml(blockedAppr.map(b => b.agent).join(', '))}`
-            : apprReachable ? `${activeGrants} active grants · none blocked` : 'unreachable'),
-      ].join('');
+      // Approvals is NOT ok if an agent is blocked (the leash is jammed and
+      // someone is waiting on Ken) OR if we could not read the records at all
+      // (we cannot claim "none blocked" without having looked).
+      const apprOk = apprReachable && blockedAppr.length === 0 && blockedUnreadable === 0;
+      const apprMeta = blockedUnreadable > 0
+        ? `<b>cannot read ${blockedUnreadable} blocked record(s)</b> · an agent may be held`
+        : blockedAppr.length > 0
+          ? `<b>${blockedAppr.length} agent${blockedAppr.length === 1 ? '' : 's'} blocked</b> — ${escapeHtml(blockedAppr.map(b => b.agent).join(', '))}`
+          : apprReachable ? `${activeGrants} active grants · none blocked` : 'unreachable';
+
+      // Build the rail from specs so the BAND can be derived from whether
+      // every service is actually ok. The band used to hardcode "all nominal"
+      // even with hindsight down and hostd red — the same claim-health-you-
+      // haven't-verified bug this PR exists to kill, so it dies here too
+      // rather than being carved out for one service.
+      const svcSpecs = [
+        { name: 'auth-broker', ok: !!b.reachable, meta: b.reachable ? `active ${escapeHtml(b.active || '—')} · ${b.accounts ?? '?'} accts` : 'unreachable' },
+        { name: 'hindsight', ok: !!hs.running, meta: hs.running ? `${escapeHtml(hs.model || '?')} · ${hs.mcpStateless ? 'stateless' : 'stateful'}` : 'not running' },
+        { name: 'hostd', ok: !!hd.auditLogPresent, meta: hd.auditLogPresent ? `${(hd.recent || []).length} recent verbs` : 'no audit log' },
+        { name: 'schedule', ok: schedEntries.length > 0, meta: `${schedEntries.length} crons · ${schedAgents} agents` },
+        { name: 'approvals', ok: apprOk, meta: apprMeta },
+      ];
+      const services = svcSpecs.map(s => svc(s.name, s.ok, s.meta)).join('');
+      const badSvcs = svcSpecs.filter(s => !s.ok);
+      // Blocked/unreadable approvals get named explicitly in the band — that
+      // is the one the operator has to act on right now.
+      const bandNote = blockedUnreadable > 0
+        ? `cannot read ${blockedUnreadable} blocked record(s)`
+        : blockedAppr.length > 0
+          ? `${blockedAppr.length} blocked on approval`
+          : badSvcs.length > 0
+            ? `${badSvcs.length} degraded — ${escapeHtml(badSvcs.map(s => s.name).join(', '))}`
+            : 'all nominal';
 
       el.innerHTML = `
         ${verdict}${asOf}
@@ -2092,7 +2124,7 @@
         <div class="sm-attn-list">${attnHtml}</div>
         <div class="sm-band">Fleet vitals</div>
         <div class="sm-vitals">${agentsCard}${quotaCard}</div>
-        <div class="sm-band">Services <span class="n">${blockedAppr.length > 0 ? `${blockedAppr.length} blocked on approval` : 'all nominal'}</span></div>
+        <div class="sm-band">Services <span class="n">${bandNote}</span></div>
         <div class="sm-services">${services}</div>`;
     }
 
@@ -3150,7 +3182,7 @@
       container.innerHTML = degradedBanner + truncatedNote + posture + cards;
     }
 
-    function renderApprovals(blocked, data, grants) {
+    function renderApprovals(blocked, blockedStatus, data, grants) {
       const container = document.getElementById('approvals');
       // Three independent sections, most-urgent first: agents HELD on an
       // approval they couldn't deliver (the only live, costing thing here),
@@ -3159,7 +3191,7 @@
       // installs). They degrade independently — one being unreachable never
       // blanks the others.
       container.innerHTML =
-        renderBlockedApprovals(blocked) +
+        renderBlockedApprovals(blocked, blockedStatus) +
         renderStandingGrants(grants) +
         renderApprovalDecisions(data);
     }
@@ -3187,13 +3219,45 @@
     // The record is metadata only; it never carries the raw tool input, and
     // the server hard-whitelists the fields. Empty is stated plainly rather
     // than implying health we haven't verified.
-    function renderBlockedApprovals(blocked) {
+    function renderBlockedApprovals(blocked, blockedStatus) {
       const dim = (s) => `<span style="color:var(--text-dim)">${escapeHtml(s)}</span>`;
       const rows = Array.isArray(blocked) ? blocked : [];
       const heading = `<h3 style="margin:0 0 0.5rem;font-size:0.95rem">Blocked approvals${rows.length ? ` <span class="usage-pill primary">${rows.length}</span>` : ''}</h3>`;
+
+      // Did we actually LOOK? Three distinct states, and only one of them may
+      // print an all-clear:
+      //   - fetch failed (`blocked` is the null sentinel)  → we don't know
+      //   - status says records were unreadable (0600, IO) → we don't know
+      //   - read clean and empty                           → nothing is blocked
+      // Collapsing the first two into the third is the failure this whole
+      // surface exists to prevent: a confident "all clear" that really means
+      // "I couldn't look", printed over an agent that is hanging.
+      const fetchFailed = !Array.isArray(blocked);
+      const unreadable = (blockedStatus && Number(blockedStatus.unreadable)) || 0;
+      const blind = fetchFailed || unreadable > 0;
+
+      // The warning is a BANNER, not an early return: an unreadable record
+      // must never hide the records we CAN read. Both can be true at once.
+      const warning = blind
+        ? renderProblem({
+            title: 'Could not read the blocked-approval records. An agent may be held.',
+            detail: (fetchFailed
+              ? 'The dashboard could not fetch the blocked-approval records. '
+              : `${unreadable} blocked-approval record(s) exist but could not be read (wrong file mode, or an IO error). `) +
+              'This is not an all-clear: an agent may be blocked on an approval right now and this page cannot see it.',
+            remediation: {
+              kind: 'command',
+              label: 'Records must be mode 0644. Check on the host:',
+              value: 'ls -l ~/.switchroom/blocked-approvals/',
+            },
+          })
+        : '';
+
       if (rows.length === 0) {
-        return heading +
-          '<div class="loading" style="color:var(--text-dim)">No agent is blocked on an undeliverable approval.</div>';
+        // Only an unblinded, clean read may print an all-clear.
+        return heading + warning + (blind
+          ? ''
+          : '<div class="loading" style="color:var(--text-dim)">No agent is blocked on an undeliverable approval.</div>');
       }
       const now = Date.now();
       const body = rows.map(b => {
@@ -3214,7 +3278,7 @@
           <td title="${escapeHtml(b.requestId || '')}">${b.requestId ? escapeHtml(b.requestId) : dim('—')}</td>
         </tr>`;
       }).join('');
-      return heading + `
+      return heading + warning + `
         <div style="margin-bottom:0.6rem;font-size:0.8rem;color:var(--text-dim)">
           These agents are waiting on you and cannot ask. The approval card could not be delivered to Telegram.
           Nothing is auto-approved and nothing is auto-denied; each one holds until it can reach you.

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -1685,12 +1685,15 @@
       const safe = (p, fallback) =>
         p.then(r => r.ok ? r.json() : fallback).catch(() => fallback);
       try {
-        const [approvals, grants] = await Promise.all([
+        const [blocked, approvals, grants] = await Promise.all([
+          // Blocked approvals lead the tab — an agent held with no way to ask
+          // is the only thing here that is actively costing the operator.
+          safe(fetch(`${API}/api/blocked-approvals`, { headers: authHeaders() }), []),
           safe(fetch(`${API}/api/approvals`, { headers: authHeaders() }), null),
           safe(fetch(`${API}/api/grants`, { headers: authHeaders() }),
             { reachable: false, grants: [], error: 'Failed to fetch standing grants.' }),
         ]);
-        renderApprovals(approvals, grants);
+        renderApprovals(blocked, approvals, grants);
         clearError();
       } catch (err) {
         showError(`Failed to fetch approvals: ${err.message}`);
@@ -2063,6 +2066,11 @@
       const apprReachable = !!(appr && appr.reachable !== false);
       const apprDecisions = (appr && appr.decisions) || [];
       const activeGrants = apprDecisions.filter(x => !x.revoked_at && !(x.ttl_expires_at && x.ttl_expires_at < Date.now())).length;
+      // Agents HELD on an approval that couldn't be delivered to Telegram.
+      // Surfaced twice on purpose: as critical rows in "Needs attention"
+      // above (server-derived), and as a count here — a blocked agent must be
+      // visible on the default tab without drilling in (#3084).
+      const blockedAppr = Array.isArray(summary.blockedApprovals) ? summary.blockedApprovals : [];
       const schedEntries = (sched && Array.isArray(sched.entries)) ? sched.entries : [];
       const schedAgents = new Set(schedEntries.map(e => e.agent)).size;
       const services = [
@@ -2070,7 +2078,12 @@
         svc('hindsight', !!hs.running, hs.running ? `${escapeHtml(hs.model || '?')} · ${hs.mcpStateless ? 'stateless' : 'stateful'}` : 'not running'),
         svc('hostd', !!hd.auditLogPresent, hd.auditLogPresent ? `${(hd.recent || []).length} recent verbs` : 'no audit log'),
         svc('schedule', schedEntries.length > 0, `${schedEntries.length} crons · ${schedAgents} agents`),
-        svc('approvals', apprReachable, apprReachable ? `${activeGrants} active grants` : 'unreachable'),
+        // A blocked agent makes this service NOT ok, however reachable the
+        // kernel is — the leash is jammed and someone is waiting on Ken.
+        svc('approvals', apprReachable && blockedAppr.length === 0,
+          blockedAppr.length > 0
+            ? `<b>${blockedAppr.length} agent${blockedAppr.length === 1 ? '' : 's'} blocked</b> — ${escapeHtml(blockedAppr.map(b => b.agent).join(', '))}`
+            : apprReachable ? `${activeGrants} active grants · none blocked` : 'unreachable'),
       ].join('');
 
       el.innerHTML = `
@@ -2079,7 +2092,7 @@
         <div class="sm-attn-list">${attnHtml}</div>
         <div class="sm-band">Fleet vitals</div>
         <div class="sm-vitals">${agentsCard}${quotaCard}</div>
-        <div class="sm-band">Services <span class="n">all nominal</span></div>
+        <div class="sm-band">Services <span class="n">${blockedAppr.length > 0 ? `${blockedAppr.length} blocked on approval` : 'all nominal'}</span></div>
         <div class="sm-services">${services}</div>`;
     }
 
@@ -3137,15 +3150,84 @@
       container.innerHTML = degradedBanner + truncatedNote + posture + cards;
     }
 
-    function renderApprovals(data, grants) {
+    function renderApprovals(blocked, data, grants) {
       const container = document.getElementById('approvals');
-      // Two independent sections: the operator's REAL standing capability
-      // grants (broker grants DB — the actually-useful one), then the
-      // kernel decision ledger (honestly empty on most installs). They
-      // degrade independently — one being unreachable never blanks the
-      // other.
+      // Three independent sections, most-urgent first: agents HELD on an
+      // approval they couldn't deliver (the only live, costing thing here),
+      // then the operator's REAL standing capability grants (broker grants
+      // DB), then the kernel decision ledger (honestly empty on most
+      // installs). They degrade independently — one being unreachable never
+      // blanks the others.
       container.innerHTML =
-        renderStandingGrants(grants) + renderApprovalDecisions(data);
+        renderBlockedApprovals(blocked) +
+        renderStandingGrants(grants) +
+        renderApprovalDecisions(data);
+    }
+
+    // Humanized hold duration. Mirrors formatBlockedFor() in
+    // src/web/blocked-approvals-read.ts so the Summary row and this table
+    // read identically ("blocked 47m"). Clamps a future timestamp to 0.
+    function formatBlockedFor(ms) {
+      const t = Math.max(0, Math.floor(ms / 1000));
+      if (t < 60) return `${t}s`;
+      const m = Math.floor(t / 60);
+      if (m < 60) return `${m}m`;
+      const h = Math.floor(m / 60);
+      if (h < 24) return (m % 60 > 0) ? `${h}h ${m % 60}m` : `${h}h`;
+      const d = Math.floor(h / 24);
+      return (h % 24 > 0) ? `${d}d ${h % 24}h` : `${d}d`;
+    }
+
+    // Agents held on an approval whose card could not be delivered to
+    // Telegram (flood ban, API outage). The agent HOLDS — it never
+    // auto-approves and never auto-denies — so it waits indefinitely. This
+    // section is the whole point: a held agent has to be SEEN here, not
+    // discovered an hour later (#3084).
+    //
+    // The record is metadata only; it never carries the raw tool input, and
+    // the server hard-whitelists the fields. Empty is stated plainly rather
+    // than implying health we haven't verified.
+    function renderBlockedApprovals(blocked) {
+      const dim = (s) => `<span style="color:var(--text-dim)">${escapeHtml(s)}</span>`;
+      const rows = Array.isArray(blocked) ? blocked : [];
+      const heading = `<h3 style="margin:0 0 0.5rem;font-size:0.95rem">Blocked approvals${rows.length ? ` <span class="usage-pill primary">${rows.length}</span>` : ''}</h3>`;
+      if (rows.length === 0) {
+        return heading +
+          '<div class="loading" style="color:var(--text-dim)">No agent is blocked on an undeliverable approval.</div>';
+      }
+      const now = Date.now();
+      const body = rows.map(b => {
+        const held = formatBlockedFor(now - (Number(b.blockedSince) || now));
+        const retryCell = (typeof b.retryableAt === 'number')
+          ? (b.retryableAt > now
+              ? `in ${escapeHtml(formatBlockedFor(b.retryableAt - now))} <span style="color:var(--text-dim)">(${escapeHtml(formatTimestamp(b.retryableAt))})</span>`
+              : `${escapeHtml(formatTimestamp(b.retryableAt))} <span style="color:var(--text-dim)">(due)</span>`)
+          : dim('unknown');
+        return `
+        <tr>
+          <td><span class="status-dot inactive" style="display:inline-block;vertical-align:middle"></span> ${escapeHtml(b.agent || '—')}</td>
+          <td><b>blocked ${escapeHtml(held)}</b></td>
+          <td>${b.action ? escapeHtml(b.action) : dim('—')}</td>
+          <td><span class="chip">${escapeHtml(b.toolName || '—')}</span></td>
+          <td>${escapeHtml(b.reason || '—')}</td>
+          <td>${retryCell}</td>
+          <td title="${escapeHtml(b.requestId || '')}">${b.requestId ? escapeHtml(b.requestId) : dim('—')}</td>
+        </tr>`;
+      }).join('');
+      return heading + `
+        <div style="margin-bottom:0.6rem;font-size:0.8rem;color:var(--text-dim)">
+          These agents are waiting on you and cannot ask. The approval card could not be delivered to Telegram.
+          Nothing is auto-approved and nothing is auto-denied; each one holds until it can reach you.
+        </div>
+        <div class="accounts-table-wrap">
+          <table class="accounts-table">
+            <thead><tr>
+              <th>Agent</th><th>Held for</th><th>Waiting to</th>
+              <th>Tool</th><th>Why undelivered</th><th>Retry</th><th>Request</th>
+            </tr></thead>
+            <tbody>${body}</tbody>
+          </table>
+        </div>`;
     }
 
     // Standing capability grants from the vault-broker grants DB — what


### PR DESCRIPTION
## Summary

When an approval card cannot be delivered to Telegram (flood ban, API outage), the agent **HOLDS**: it never auto-approves and never auto-denies. That is the right call, and it is useless if nobody can see it. This PR is the operator's view of that hold, on a surface that does not depend on Telegram.

- **`src/web/blocked-approvals-read.ts`** — reader over the shared record at `~/.switchroom/blocked-approvals/<agent>.json`. Mirrors `src/web/fleet-health-read.ts` (same path-resolution idiom, same degrade-to-empty posture). Hard-whitelists the fields, so an unexpected field on disk can never reach the render side; the record is metadata only and never carries raw tool input.
- **`GET /api/blocked-approvals`** — bare ARRAY, honest empty `[]`.
- **Approvals tab** leads with the blocked agents: which agent, what it is waiting to do, how long it has been held ("blocked 47m"), when it can retry, and why. The tab's other two sections (standing grants, the kernel decision ledger that is "honestly empty on most installs") are unchanged and still degrade independently.
- **Summary tab** raises a critical `overlord — blocked 47m` row in the existing "needs attention" triage strip (server-derived, clickable through to Approvals), plus a count on the services rail. A blocked agent is visible without drilling in.

## Why

On 2026-07-11 the `overlord` bot took a 4.6h Telegram flood ban (#3084). A permission prompt fired during it, the card could not be sent, and the operator had no idea: the agent sat blocked for 50 minutes and was only found because someone went looking. Worse, the gateway would have silently auto-denied that approval at the 60-minute TTL, an approval no human ever saw.

Job spec: **`reference/jobs/approve-what-my-agent-can-touch.md`** (outcome `hold-the-leash`). Its Good/bad section requires that a request is "never left parked forever waiting on a card" and that silence is never treated as a "no". Holding satisfies the second; this PR is what makes the first observable. Invariants: crosses none. `chat-is-the-single-source-of-truth` is not breached: this is an operator/admin read-only view, not a principal channel, and it introduces no new decision surface (there is no Allow/Deny button here; the card still lands in Telegram when delivery recovers).

**Depends on the gateway-side record producer, which lands separately (parallel PR). This reader degrades to an honest empty `[]` until then, so it is shippable independently.**

## The permissions trap, verified live

The web container runs as **uid 1000**, and the per-agent Telegram state files are **0600**. Verified against the running container:

```
$ docker exec switchroom-web cat /host-home/.switchroom/agents/overlord/telegram/pending-perm-cards.json
cat: ...: Permission denied                     # 0600, agent/root-owned

$ docker exec switchroom-web head -c 60 /host-home/.switchroom/fleet-health/ledger.json
{ "generated_at": "2026-07-11T05:01:05.947Z",   # 0644 in a 0755 dir -> readable
```

A design that read the agent's own 0600 state would render a **silently empty page** (the same bug as Hermes' 0600 `registry.db` and its empty history tab). Hence the shared 0644-in-0755 record, matching the fleet-health ledger posture the web container demonstrably reads today.

**Mount: no compose change needed.** `~/.switchroom/web/docker-compose.yml` binds the whole tree (`/home/<op>/.switchroom:/host-home/.switchroom:rw`) and sets `HOME=/host-home`, so `blockedApprovalsDir()` resolves to `/host-home/.switchroom/blocked-approvals` inside the container and to the same host dir the gateway writes. Confirmed the dir is simply absent today (producer not landed), which is exactly the honest-empty path.

## Test plan

`src/web/blocked-approvals.test.ts` (19 tests), asserting outcomes rather than code paths:

- record on disk -> the API returns it with every operator-facing field, and `formatBlockedFor` renders `47m`
- absent dir -> honest empty `[]` (this is the pre-producer state)
- **malformed JSON -> honest empty, no crash**
- **an unreadable record never hides the readable ones** (the 0600 trap; uses an `EISDIR` entry so it is deterministic under every uid including root in CI, plus a real `chmod 0000` case skipped only when running as root)
- extra on-disk fields (e.g. a stray `toolInput`) are dropped, not rendered
- malformed timestamps normalize to `null`, never `NaN` ("blocked NaNm" is a lie)
- longest-blocked ranks first; `deriveAttention` raises the critical Summary row

Local: `npm run lint` green (tsc + all 8 guards, `check-web-subscription-honest` included). Scoped vitest green (175 tests across the web suites).

Full suite run locally: 14 files fail. Classified per CLAUDE.md by re-running the **exact same 15 files on pristine `origin/main`** in a throwaway worktree: **13 failed / 2 passed on baseline, identical 13 failed / 2 passed on this branch** (259 vs 260 tests, a 1-test delta that is itself the flake). All are `EADDRINUSE` on unix sockets, broker/vault passphrase, docker, and hook suites. **Bucket 3, environment-only, not this diff.** CI is the arbiter for those paths.

## Risk

Low. Purely additive and read-only: one new file, one new route, one new UI section. No model call, no host mutation, no network.

- **Hermes Desktop adapter** consumes this web API. The new endpoint is a bare array with an honest empty `[]` (never `null`, never object-wrapped). The one shared-type change is additive: `AttentionItem["tab"]` gains `"approvals"`, and `SummaryDashboard` gains a `blockedApprovals: BlockedApproval[]` field. Existing fields and shapes are untouched.
- The summary aggregate wraps the read so it can never take the Summary tab down; the reader itself never throws.
- Worst case if the producer never lands: the section reads "No agent is blocked on an undeliverable approval", which is true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mQR9UordBs4nJ797bxxod