### PR TITLE
fix(telegram): stop a permissions error from silently blinding the flood breaker

### DIFF
--- a/telegram-plugin/flood-circuit-breaker.ts
+++ b/telegram-plugin/flood-circuit-breaker.ts
@@ -20,7 +20,7 @@
  * logic is pure + injectable so it unit tests without a real clock or bot.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { readFileSync, writeFileSync, mkdirSync, chmodSync, unlinkSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 
 export interface FloodWaitState {
@@ -34,6 +34,43 @@ export interface FloodWaitState {
 
 /** Default marker filename inside the telegram state dir. */
 export const FLOOD_STATE_FILE = 'flood-wait.json'
+
+/**
+ * Marker file mode — 0644, deliberately world-READABLE (#3106).
+ *
+ * The marker was 0600 and that silently defeated the entire breaker. The
+ * telegram state dir is shared by processes running under DIFFERENT uids: a
+ * `root: true` agent's gateway runs as uid 0 (`src/agents/compose.ts:1967`),
+ * a normal agent's as its deterministic uid (`compose.ts:1969`), and the same
+ * bind-mounted dir survives a container being flipped between the two. Whoever
+ * CREATES the marker owns it; at 0600 nobody else can ever read it again. On
+ * the live box `overlord`'s marker is `root:root 0600` while its siblings are
+ * agent-uid — the moment that agent runs non-root, every flood probe EACCESes.
+ *
+ * The payload is three integers (`untilTs`, `retryAfterSec`, `recordedTs`) —
+ * no secret, nothing worth 0600. `fleet-health/ledger.json` is the working
+ * precedent for a state file multiple uids must read: 0644.
+ */
+export const FLOOD_STATE_MODE = 0o644
+
+/**
+ * Outcome of a marker read. The whole point of this type is that "no ban" and
+ * "I cannot tell" stop being the same value (#3106).
+ *
+ *   - `ok`         → a window was read (may be expired; `floodWaitRemainingMs` decides)
+ *   - `absent`     → ENOENT, no marker has ever been written. Genuinely "no ban".
+ *   - `corrupt`    → readable but the JSON/shape is junk. Content problem.
+ *   - `unreadable` → the file exists and we could NOT read it (EACCES/EPERM/EIO).
+ *                    The breaker is BLIND. This is NOT "no ban".
+ */
+export type FloodReadStatus = 'ok' | 'absent' | 'corrupt' | 'unreadable'
+
+export interface FloodReadResult {
+  status: FloodReadStatus
+  state: FloodWaitState | null
+  /** Populated for `unreadable` / `corrupt` — the underlying error message. */
+  error?: string
+}
 
 /**
  * Resolve the flood-wait marker path from a telegram state dir. Kept as a
@@ -70,29 +107,109 @@ export function isFloodWaitActive(state: FloodWaitState | null, now: number): bo
   return floodWaitRemainingMs(state, now) > 0
 }
 
-/** Read persisted flood state; null on absence / parse failure. */
-export function readFloodState(path: string): FloodWaitState | null {
+/**
+ * Read the persisted marker, reporting WHY there is no state (#3106).
+ *
+ * No `existsSync` pre-check: it is a `stat`, not an `access`, so it cannot
+ * tell "missing" from "unreadable" — and pre-checking would race. We read and
+ * classify the error instead. ENOENT (and a missing parent dir, ENOTDIR) is
+ * the only honest "no marker". Everything else that isn't a parse/shape
+ * failure means the breaker could not see its own state.
+ */
+export function readFloodStateResult(path: string): FloodReadResult {
+  let text: string
   try {
-    if (!existsSync(path)) return null
-    const raw = JSON.parse(readFileSync(path, 'utf-8')) as Partial<FloodWaitState>
-    if (typeof raw.untilTs !== 'number') return null
+    text = readFileSync(path, 'utf-8')
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code
+    if (code === 'ENOENT' || code === 'ENOTDIR') return { status: 'absent', state: null }
     return {
-      untilTs: raw.untilTs,
-      retryAfterSec: typeof raw.retryAfterSec === 'number' ? raw.retryAfterSec : 0,
-      recordedTs: typeof raw.recordedTs === 'number' ? raw.recordedTs : 0,
+      status: 'unreadable',
+      state: null,
+      error: `${code ?? 'EUNKNOWN'}: ${(err as Error)?.message ?? String(err)}`,
     }
-  } catch {
-    return null
+  }
+  try {
+    const raw = JSON.parse(text) as Partial<FloodWaitState>
+    if (typeof raw.untilTs !== 'number' || !Number.isFinite(raw.untilTs)) {
+      return { status: 'corrupt', state: null, error: 'untilTs is not a finite number' }
+    }
+    return {
+      status: 'ok',
+      state: {
+        untilTs: raw.untilTs,
+        retryAfterSec: typeof raw.retryAfterSec === 'number' ? raw.retryAfterSec : 0,
+        recordedTs: typeof raw.recordedTs === 'number' ? raw.recordedTs : 0,
+      },
+    }
+  } catch (err) {
+    return { status: 'corrupt', state: null, error: (err as Error)?.message ?? String(err) }
   }
 }
 
-/** Persist flood state (best-effort — a write failure must not crash the send path). */
-export function writeFloodState(path: string, state: FloodWaitState): void {
+/**
+ * Read persisted flood state; null on absence / parse failure / unreadable.
+ *
+ * Kept for callers that only want the window. It CANNOT distinguish "no ban"
+ * from "cannot tell" — that is the bug #3106 exists to fix — so anything
+ * making a suppress/proceed DECISION must use `readFloodStateResult`.
+ */
+export function readFloodState(path: string): FloodWaitState | null {
+  return readFloodStateResult(path).state
+}
+
+/**
+ * Persist flood state (best-effort — a write failure must not crash the send
+ * path), and SELF-HEAL a marker left unreadable by another uid (#3106).
+ *
+ * Two heals, both needed because the `mode` option only applies at CREATE time:
+ *   1. `chmodSync` to 0644 after every write, so a marker created 0600 by an
+ *      earlier build (or by a root gateway) becomes readable to the agent uid.
+ *   2. On EACCES/EPERM (we can't overwrite a file some other uid owns), unlink
+ *      and recreate. The state DIR is owned by the agent uid, so a non-root
+ *      gateway can unlink a root-owned marker inside it even though it cannot
+ *      write through it. Without this the recorder is as blind as the reader.
+ */
+export function writeFloodState(
+  path: string,
+  state: FloodWaitState,
+  log: (line: string) => void = (l) => process.stderr.write(l),
+): void {
+  const payload = JSON.stringify(state)
   try {
     mkdirSync(dirname(path), { recursive: true })
-    writeFileSync(path, JSON.stringify(state), { mode: 0o600 })
   } catch {
     /* best-effort */
+  }
+  try {
+    writeFileSync(path, payload, { mode: FLOOD_STATE_MODE })
+    try {
+      chmodSync(path, FLOOD_STATE_MODE)
+    } catch {
+      /* not the owner — the read path will report it */
+    }
+    return
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code
+    if (code !== 'EACCES' && code !== 'EPERM') {
+      log(`telegram gateway: flood-breaker: could not persist ${path} (${code ?? 'error'})\n`)
+      return
+    }
+    // Owned by a different uid. Unlink + recreate so the CURRENT uid owns it.
+    try {
+      unlinkSync(path)
+      writeFileSync(path, payload, { mode: FLOOD_STATE_MODE })
+      log(
+        `telegram gateway: flood-breaker: recreated ${path} — it was owned by another uid ` +
+          `and could not be updated (${code}); the breaker was blind (issue #3106)\n`,
+      )
+    } catch (err2) {
+      log(
+        `telegram gateway: flood-breaker: BLIND — cannot persist the flood-wait window to ${path} ` +
+          `(${code}, and recreate failed: ${(err2 as Error)?.message ?? String(err2)}). ` +
+          `Flood bans will NOT be recorded. Fix the file's ownership/mode (issue #3106)\n`,
+      )
+    }
   }
 }
 
@@ -104,12 +221,41 @@ export function writeFloodState(path: string, state: FloodWaitState): void {
 export function makeFloodWaitRecorder(
   path: string,
   now: () => number = Date.now,
+  log: (line: string) => void = (l) => process.stderr.write(l),
 ): (retryAfterSec: number) => void {
   return (retryAfterSec: number) => {
     const t = now()
     const next = computeFloodWait(readFloodState(path), retryAfterSec, t)
-    writeFloodState(path, next)
+    writeFloodState(path, next, log)
   }
+}
+
+/**
+ * How long a blind (unreadable-marker) breaker suppresses non-essential sends
+ * for. Nominal — the caller only checks `> 0`. Not a real ban estimate; we
+ * have no idea how long the ban is, that is the whole problem.
+ */
+export const FLOOD_BLIND_SUPPRESS_MS = 60_000
+
+/** Throttle for the BLIND warning: once per path per interval, so a per-call probe can't spam. */
+const BLIND_LOG_INTERVAL_MS = 60_000
+const blindLoggedAt = new Map<string, number>()
+
+/** Test seam — clear the BLIND-warning throttle between cases. */
+export function resetFloodBlindLogThrottle(): void {
+  blindLoggedAt.clear()
+}
+
+function warnBlind(path: string, error: string | undefined, now: number, log: (l: string) => void) {
+  const last = blindLoggedAt.get(path)
+  if (last !== undefined && now - last < BLIND_LOG_INTERVAL_MS) return
+  blindLoggedAt.set(path, now)
+  log(
+    `telegram gateway: flood-breaker: BLIND — cannot read the flood-wait marker ${path} ` +
+      `(${error ?? 'unknown error'}). The breaker cannot tell whether a Telegram flood ban is ` +
+      `open. Essential sends PROCEED (fail-open); non-essential sends (boot card, typing) are ` +
+      `SUPPRESSED. Fix the file's ownership/mode (issue #3106)\n`,
+  )
 }
 
 /**
@@ -121,23 +267,84 @@ export function makeFloodWaitRecorder(
  * fresh each call (the window is written by `makeFloodWaitRecorder`, possibly
  * from another code path in the same process).
  *
- * Fails OPEN: `readFloodState` already returns null on a missing or corrupt
- * marker, which yields 0 = "no window, proceed". A broken state file must
- * never permanently silence the bot.
+ * Fails OPEN on absent / corrupt / UNREADABLE — this probe gates EVERY api
+ * call including the user's reply, and no marker problem may ever mute the
+ * bot. But an unreadable marker is no longer SILENT: it is a blind breaker,
+ * and it says so, loudly and repeatedly (throttled to once a minute), because
+ * a breaker that cannot see its own state while reporting "all clear" is the
+ * worst state this system can be in (#3106).
  */
 export function makeFloodWaitProbe(
   path: string,
   now: () => number = Date.now,
+  log: (line: string) => void = (l) => process.stderr.write(l),
 ): () => number {
-  return () => floodWaitRemainingMs(readFloodState(path), now())
+  return () => {
+    const t = now()
+    const res = readFloodStateResult(path)
+    if (res.status === 'unreadable') {
+      warnBlind(path, res.error, t, log)
+      return 0 // fail OPEN — never gag an essential send on a permissions error
+    }
+    return floodWaitRemainingMs(res.state, t)
+  }
 }
 
 /**
- * Decide whether a NON-ESSENTIAL restart-time send (boot card, config
- * summary) should be suppressed because a flood-wait is active. Returns the
- * remaining ms when suppressed (>0), or 0 to proceed. Reads state fresh so a
- * concurrently-updated window is honoured.
+ * Why a non-essential send is being held back.
+ *
+ *   - `flood_wait` → we can see an open ban window. Suppress (that is #2923).
+ *   - `blind`      → we CANNOT read the marker. Suppress.
  */
-export function suppressNonEssentialSendMs(path: string, now: number): number {
-  return floodWaitRemainingMs(readFloodState(path), now)
+export type NonEssentialSuppression =
+  | { suppress: false }
+  | { suppress: true; reason: 'flood_wait'; remainingMs: number }
+  | { suppress: true; reason: 'blind'; error: string }
+
+/**
+ * Decide whether a NON-ESSENTIAL send (boot card, config summary, typing
+ * indicator) should be held back.
+ *
+ * This is where "cannot tell" is allowed to fail CLOSED, and the asymmetry is
+ * deliberate (#3106):
+ *
+ *   - Absent / corrupt → PROCEED. A missing or junk marker is a content
+ *     problem, and #3094's posture stands: a broken state file must never
+ *     become a silent gag.
+ *   - Unreadable → SUPPRESS. A permissions error means the breaker is blind,
+ *     and blind is not clear. Restarting into an open ban with a boot card is
+ *     exactly the amplification #2923 exists to prevent, and the cost of being
+ *     wrong here is bounded and tiny: the operator misses a courtesy card or a
+ *     typing bubble. It CANNOT mute the agent — every essential send still
+ *     goes through the fail-open probe above. That bound is what makes
+ *     fail-closed safe HERE and unsafe on the probe.
+ */
+export function nonEssentialSendSuppression(path: string, now: number): NonEssentialSuppression {
+  const res = readFloodStateResult(path)
+  if (res.status === 'unreadable') {
+    return { suppress: true, reason: 'blind', error: res.error ?? 'unknown error' }
+  }
+  const remainingMs = floodWaitRemainingMs(res.state, now)
+  if (remainingMs > 0) return { suppress: true, reason: 'flood_wait', remainingMs }
+  return { suppress: false }
+}
+
+/**
+ * Ms-shaped shim over `nonEssentialSendSuppression` for callers that only ask
+ * "> 0?". A blind breaker returns `FLOOD_BLIND_SUPPRESS_MS` (a nominal
+ * non-zero), and warns. Callers that want to explain WHICH reason to the
+ * operator should use `nonEssentialSendSuppression` directly.
+ */
+export function suppressNonEssentialSendMs(
+  path: string,
+  now: number,
+  log: (line: string) => void = (l) => process.stderr.write(l),
+): number {
+  const s = nonEssentialSendSuppression(path, now)
+  if (!s.suppress) return 0
+  if (s.reason === 'blind') {
+    warnBlind(path, s.error, now, log)
+    return FLOOD_BLIND_SUPPRESS_MS
+  }
+  return s.remainingMs
 }

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -69,7 +69,7 @@ import {
 } from './config-snapshot.js'
 import { join } from 'path'
 import { bootCardChatKey, loadBootCardMsgId, saveBootCardMsgId } from './boot-card-msgid.js'
-import { suppressNonEssentialSendMs } from '../flood-circuit-breaker.js'
+import { nonEssentialSendSuppression } from '../flood-circuit-breaker.js'
 import { loadConfig as _loadSwitchroomConfig } from '../../src/config/loader.js'
 import { resolveAgentConfig as _resolveAgentConfig } from '../../src/config/merge.js'
 
@@ -669,11 +669,18 @@ export async function startBootCard(
   // keeps the agent mute for longer. Skip loudly (log) and return a no-op.
   if (opts.floodStatePath != null) {
     const now = (opts.nowMs ?? Date.now)()
-    const remainingMs = suppressNonEssentialSendMs(opts.floodStatePath, now)
-    if (remainingMs > 0) {
+    const s = nonEssentialSendSuppression(opts.floodStatePath, now)
+    if (s.suppress) {
+      // #3106: two reasons, and the operator must be told WHICH. A blind
+      // breaker (unreadable marker) is a bug in the deployment, not a ban.
       logger(
-        `telegram gateway: boot-card: SUPPRESSED — Telegram flood-wait active for ~${Math.round(remainingMs / 1000)}s; ` +
-          `not posting a restart card into the open ban window (issue #2923)\n`,
+        s.reason === 'blind'
+          ? `telegram gateway: boot-card: SUPPRESSED — flood-breaker is BLIND: cannot read ` +
+              `${opts.floodStatePath} (${s.error}). Cannot rule out an open Telegram ban, so the ` +
+              `restart card is held back rather than posted into one. Fix the marker's ` +
+              `ownership/mode (issue #3106)\n`
+          : `telegram gateway: boot-card: SUPPRESSED — Telegram flood-wait active for ~${Math.round(s.remainingMs / 1000)}s; ` +
+              `not posting a restart card into the open ban window (issue #2923)\n`,
       )
       return { messageId: -1, complete: () => {} }
     }

--- a/telegram-plugin/tests/flood-breaker-blindness.test.ts
+++ b/telegram-plugin/tests/flood-breaker-blindness.test.ts
@@ -1,0 +1,213 @@
+/**
+ * #3106 — a permissions error must not silently blind the flood breaker.
+ *
+ * The bug: `readFloodState` swallowed EVERY error and returned `null`, so an
+ * unreadable marker (EACCES) was indistinguishable from "no marker" — the
+ * probe reported "no flood window" forever and every flood protection we ship
+ * (#2923 boot-card suppression, #3084/#3094 pre-call short-circuit, #3097
+ * typing suppression) failed open SILENTLY. A restart would then post a boot
+ * card straight into an open ban.
+ *
+ * Two behaviours pull in OPPOSITE directions and both are pinned here:
+ *
+ *   - ABSENT / CORRUPT marker → still fails OPEN everywhere. A junk state file
+ *     must never become a silent gag (#3094's deliberate posture).
+ *   - UNREADABLE marker → the breaker is BLIND. Essential sends still proceed
+ *     (fail-open, so a chmod accident can never mute the agent), but it says so
+ *     LOUDLY, and non-essential sends (boot card, typing) are held back rather
+ *     than fired into a ban we cannot rule out.
+ *
+ * All paths are under `mkdtempSync(join(tmpdir(), …))` — no production state.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  chmodSync,
+  mkdirSync,
+  statSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  computeFloodWait,
+  writeFloodState,
+  readFloodStateResult,
+  makeFloodWaitProbe,
+  makeFloodWaitRecorder,
+  suppressNonEssentialSendMs,
+  nonEssentialSendSuppression,
+  resetFloodBlindLogThrottle,
+  floodStatePath,
+  FLOOD_STATE_MODE,
+} from '../flood-circuit-breaker.js'
+
+const NOW = 1_800_000_000_000
+const isRoot = typeof process.getuid === 'function' && process.getuid() === 0
+
+/**
+ * Make `path` genuinely unreadable to THIS process and prove it. Returns false
+ * when the process is root (root bypasses DAC — EACCES is unreachable), so the
+ * caller can skip rather than assert a lie.
+ */
+function makeUnreadable(path: string): boolean {
+  writeFileSync(path, JSON.stringify({ untilTs: NOW + 60_000, retryAfterSec: 60, recordedTs: NOW }))
+  chmodSync(path, 0o000)
+  if (isRoot) return false
+  try {
+    readFileSync(path, 'utf-8')
+    return false // somehow still readable — don't pretend we tested EACCES
+  } catch {
+    return true
+  }
+}
+
+describe('#3106 flood breaker — blind is not clear', () => {
+  let dir: string
+  let path: string
+  let logs: string[]
+  const log = (l: string) => {
+    logs.push(l)
+  }
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'flood-blind-'))
+    path = floodStatePath(dir)
+    logs = []
+    resetFloodBlindLogThrottle()
+  })
+  afterEach(() => {
+    try {
+      chmodSync(path, 0o644)
+    } catch {
+      /* may not exist */
+    }
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  // ---------------------------------------------------------------- classify
+
+  it('classifies absent / corrupt / unreadable as DIFFERENT things', () => {
+    expect(readFloodStateResult(path).status).toBe('absent')
+
+    writeFileSync(path, 'not json at all{{{')
+    expect(readFloodStateResult(path).status).toBe('corrupt')
+
+    writeFileSync(path, JSON.stringify({ untilTs: 'soon' }))
+    expect(readFloodStateResult(path).status).toBe('corrupt')
+
+    // A directory where the marker should be: readable-check fails with EISDIR,
+    // not ENOENT. uid-independent (works even under root) — "cannot read".
+    const d = join(dir, 'as-a-dir.json')
+    mkdirSync(d)
+    expect(readFloodStateResult(d).status).toBe('unreadable')
+  })
+
+  // ------------------------------------------------- UNREADABLE → not silent
+
+  it.skipIf(isRoot)(
+    'REGRESSION: an unreadable marker does NOT silently report "no flood window"',
+    () => {
+      expect(makeUnreadable(path)).toBe(true)
+
+      const res = readFloodStateResult(path)
+      // The bug was: status indistinguishable from absent, state null, nobody told.
+      expect(res.status).toBe('unreadable')
+      expect(res.error).toMatch(/EACCES/)
+
+      // The probe still FAILS OPEN (0 = proceed) — an essential reply to the
+      // user must never be gagged by a permissions error...
+      const probe = makeFloodWaitProbe(path, () => NOW, log)
+      expect(probe()).toBe(0)
+
+      // ...but it is no longer SILENT. That is the whole fix.
+      expect(logs.join('')).toMatch(/BLIND/)
+      expect(logs.join('')).toContain(path)
+    },
+  )
+
+  it.skipIf(isRoot)('an unreadable marker SUPPRESSES non-essential sends (boot card, typing)', () => {
+    expect(makeUnreadable(path)).toBe(true)
+
+    // The #2923/#3097 surfaces: we cannot rule out an open ban, so we do not
+    // post a restart card / typing ping into one.
+    expect(suppressNonEssentialSendMs(path, NOW, log)).toBeGreaterThan(0)
+    expect(logs.join('')).toMatch(/BLIND/)
+
+    const s = nonEssentialSendSuppression(path, NOW)
+    expect(s.suppress).toBe(true)
+    expect(s.suppress && s.reason).toBe('blind')
+  })
+
+  it.skipIf(isRoot)('the BLIND warning is throttled — a per-call probe cannot spam the log', () => {
+    expect(makeUnreadable(path)).toBe(true)
+    let t = NOW
+    const probe = makeFloodWaitProbe(path, () => t, log)
+    for (let i = 0; i < 50; i++) probe()
+    expect(logs.length).toBe(1)
+    t = NOW + 61_000
+    probe()
+    expect(logs.length).toBe(2)
+  })
+
+  // --------------------------------------------- ABSENT / CORRUPT → fail OPEN
+
+  it('an ABSENT marker fails OPEN and stays silent (no ban, nothing to say)', () => {
+    const probe = makeFloodWaitProbe(path, () => NOW, log)
+    expect(probe()).toBe(0)
+    expect(suppressNonEssentialSendMs(path, NOW, log)).toBe(0)
+    expect(nonEssentialSendSuppression(path, NOW).suppress).toBe(false)
+    expect(logs.join('')).not.toMatch(/BLIND/)
+  })
+
+  it('a CORRUPT marker still fails OPEN — a junk file must never gag the bot', () => {
+    for (const junk of ['', 'null', '{}', 'not json{{', JSON.stringify({ untilTs: 'x' })]) {
+      writeFileSync(path, junk)
+      const probe = makeFloodWaitProbe(path, () => NOW, log)
+      expect(probe()).toBe(0)
+      // Non-essential sends proceed too: corrupt is a CONTENT problem, and we
+      // deliberately do NOT let it suppress. (Contrast: unreadable, above.)
+      expect(suppressNonEssentialSendMs(path, NOW, log)).toBe(0)
+      expect(nonEssentialSendSuppression(path, NOW).suppress).toBe(false)
+    }
+  })
+
+  it('a REAL open window still suppresses (the #2923 behaviour is intact)', () => {
+    writeFloodState(path, computeFloodWait(null, 68 * 60, NOW), log)
+    const probe = makeFloodWaitProbe(path, () => NOW, log)
+    expect(probe()).toBe(68 * 60 * 1000)
+    const s = nonEssentialSendSuppression(path, NOW)
+    expect(s.suppress && s.reason).toBe('flood_wait')
+    // ...and lifts on its own.
+    expect(makeFloodWaitProbe(path, () => NOW + 68 * 60_000 + 1, log)()).toBe(0)
+  })
+
+  // ------------------------------------------------------- root cause: 0600
+
+  it('ROOT CAUSE: the marker is written 0644, readable by a sibling uid', () => {
+    writeFloodState(path, computeFloodWait(null, 60, NOW), log)
+    expect(statSync(path).mode & 0o777).toBe(FLOOD_STATE_MODE)
+    // Group/other read bits set — the whole point. At 0600 a marker created by
+    // a root gateway (`compose.ts:1967`, `root: true` agents) is unreadable to
+    // the same agent's non-root gateway forever.
+    expect(statSync(path).mode & 0o044).toBe(0o044)
+  })
+
+  it('SELF-HEAL: a pre-existing 0600 marker is chmodded back to 0644 on write', () => {
+    // Simulate the live overlord marker: created 0600 by an earlier build.
+    writeFileSync(path, JSON.stringify({ untilTs: NOW, retryAfterSec: 1, recordedTs: NOW }), {
+      mode: 0o600,
+    })
+    chmodSync(path, 0o600)
+    expect(statSync(path).mode & 0o777).toBe(0o600)
+
+    // The next observed 429 rewrites it — and heals the mode. (writeFileSync's
+    // `mode` option is ignored for an EXISTING file, so the explicit chmod is
+    // load-bearing.)
+    makeFloodWaitRecorder(path, () => NOW, log)(120)
+    expect(statSync(path).mode & 0o777).toBe(FLOOD_STATE_MODE)
+    expect(readFloodStateResult(path).status).toBe('ok')
+  })
+})


### PR DESCRIPTION
## Summary

`readFloodState()` swallowed **every** error and returned `null`. `null` → `floodWaitRemainingMs()` → `0` → **"no flood window"**. So an unreadable marker (EACCES) and "no ban" were the same value, and a breaker that could not see its own state reported *all clear* — silently, forever.

That one `catch { return null }` (flood-circuit-breaker.ts:84, pre-diff) defeats **every flood protection we shipped today**:

| protection | consumer | what it did when blind |
| --- | --- | --- |
| #3094 pre-call short-circuit | `makeFloodWaitProbe` → `gateway.ts:5342` | fired every call into the open ban |
| #3097 typing suppression | `suppressNonEssentialSendMs` → `gateway.ts:5457` | kept pinging |
| #2923 boot-card suppression | `gateway/boot-card.ts:672` | posted a restart card into the ban |

A restart would post a boot card straight into an open ban — exactly the amplification #2923 exists to prevent — and the failure looks identical to "everything is fine".

## Why the marker was unreadable

`writeFloodState` created it `{ mode: 0o600 }`. The telegram state dir is shared across uids: a `root: true` agent's gateway runs as uid 0 (`src/agents/compose.ts:1967`), a normal agent's as its deterministic uid (`compose.ts:1969`), and **whoever creates the marker owns it**. At 0600 no other uid can ever read it again — and `writeFileSync`'s `mode` is ignored for an existing file, so it could never self-heal either. The payload is three integers (`untilTs`, `retryAfterSec`, `recordedTs`) — nothing worth 0600. `fleet-health/ledger.json` is the working precedent for a state file multiple uids must read: **0644**.

**Live evidence (read-only survey of the fleet).** The uid flip is not hypothetical — it is exercised:

```
switchroom-overlord   user=0:0   marker=root:root 600
switchroom-klanker    user=0:0   marker=agent10679:agent10679 600   <-- created when it ran non-root
```

`klanker` proves agents get flipped between root and non-root tiers. **Correction to the original report:** neither agent is blind *today* — both run as uid 0 and root bypasses DAC, so they can read their own 0600 markers. But `overlord`'s marker is `root:root 0600`, so dropping `root: true` from its YAML — a one-line edit — makes its gateway (running as its agent uid) EACCES on read **and** on write: permanently, unrecoverably blind. The bug is armed, not yet detonated.

## The posture, and the tension

Fail-open is deliberate and is **preserved** — but "corrupt" and "cannot read" stop being the same thing.

- **absent / corrupt → fail OPEN, everywhere.** A missing or junk marker is a *content* problem. #3094's posture stands: a broken state file must never become a silent gag.
- **unreadable → the breaker is BLIND.** Blind is not clear. Split by blast radius:
  - **Essential sends (the probe, gating every API call incl. the user's reply): fail OPEN.** A chmod accident must never be able to mute an agent. But it is no longer *silent* — it logs `BLIND`, loudly, throttled to 1/min so a per-call probe can't spam.
  - **Non-essential sends (boot card, typing): fail CLOSED.** We cannot rule out an open ban, and the cost of being wrong is bounded and tiny — a missed courtesy card or typing bubble. It **cannot mute the agent**, because every essential send still goes through the fail-open probe. That bound is exactly what makes fail-closed safe *here* and unsafe on the probe.

Plus self-heal, so this can't silently persist: `writeFloodState` chmods to 0644 on every write, and unlink-recreates a marker owned by a foreign uid (the state dir is agent-owned, so a non-root gateway *can* unlink a root-owned file inside it).

## Test plan

New `telegram-plugin/tests/flood-breaker-blindness.test.ts` (9 tests) — outcomes against a **real** unreadable file (`chmod 000`, proven unreadable before asserting; `it.skipIf(isRoot)` so it can never silently no-op under root, plus a uid-independent EISDIR case that always runs). Pins **both** directions of the tension.

Mutation-tested — each break turns the right tests RED:

| mutation | result |
| --- | --- |
| EACCES swallowed back into `absent` (the original bug) | **4 failed** |
| marker mode back to `0o600` | **1 failed** (root-cause test) |
| probe fails CLOSED on blind (over-correction → could mute the bot) | **1 failed** |
| corrupt fails CLOSED (silent-gag regression) | **2 failed** |

- `vitest run telegram-plugin/` → **380 files, 6207 tests, all pass**
- Full `vitest run` → 23 failing files, **all 23 fail identically on pristine `origin/main`** (src/auth, src/host-control, tests/cli, docker — socket EADDRINUSE / CAP_CHOWN / fake-binary harness). Zero telegram-plugin failures either way.
- `npm run test:bun` → 1156 pass, 1 fail (`src/vault/broker/client-token.test.ts`) — **identical 13 pass / 1 fail on pristine main**; CAP_CHOWN unavailable in this sandbox. CI is the arbiter for those paths.
- `npm run lint` → **clean** (tsc + all 8 guards, incl. `check-bot-api-wrapping` and `check-vault-test-hermeticity`).

## Risk

Low, and the risky direction is the one deliberately *not* taken. The only new fail-closed path is non-essential sends on an unreadable marker — it cannot mute an agent, it is loud, and it self-heals on the next write. Marker goes 0600 → 0644 (non-secret integers). No gateway.ts line movement, so the file:line-keyed bot-api allowlist is untouched.

## Job spec

`reference/jobs/survive-reboots-and-real-life.md` (serves **always-available**) — the *"never left in silence"* half. A silently blind breaker means a restart amplifies a ban the operator can't see; this makes the blindness impossible to miss while guaranteeing the agent still answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mQR9UordBs4nJ797bxxod