### PR TITLE
feat(telegram-plugin): priority shedding, degraded mode, restart-proof flood windows — #3084 PR 2/3

### DIFF
--- a/telegram-plugin/flood-circuit-breaker.ts
+++ b/telegram-plugin/flood-circuit-breaker.ts
@@ -20,7 +20,15 @@
  * logic is pure + injectable so it unit tests without a real clock or bot.
  */
 
-import { readFileSync, writeFileSync, mkdirSync, chmodSync, unlinkSync } from 'node:fs'
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  chmodSync,
+  unlinkSync,
+  renameSync,
+} from 'node:fs'
 import { dirname, join } from 'node:path'
 
 export interface FloodWaitState {
@@ -347,4 +355,133 @@ export function suppressNonEssentialSendMs(
     return FLOOD_BLIND_SUPPRESS_MS
   }
   return s.remainingMs
+}
+
+// ─── Restart-proof SCOPED flood windows (#3084 PR 2, part3-design §7) ────────
+//
+// The single-object `flood-wait.json` above records ONE global per-bot window
+// (all #3094's `makeFloodWaitProbe` needs). PR 2's send gate opens windows at
+// finer scopes (`global` | `chat:<id>` | `group:<id>` | `msg-edit:<id>`) and
+// must survive a restart so a container that boots mid-ban does not immediately
+// resend into the open flood — exactly the retry-storm that escalates bans.
+//
+// Rather than overload the single-object schema (which would break #3094's
+// probe), scoped windows live in a SIBLING file `flood-windows.json` — an array
+// of `{ scopeKey, untilTs, retryAfterSrc, observedAt }`. `flood-wait.json` is
+// left untouched, so the existing probe keeps working unchanged.
+
+/** One persisted scoped flood window (part3-design §7). */
+export interface FloodWindowRecord {
+  /** `global` | `chat:<id>` | `group:<id>` | `msg-edit:<id>`. */
+  scopeKey: string
+  /** Epoch ms until which the scope admits nothing. */
+  untilTs: number
+  /** Provenance of the window (`429` retry_after, `boot`, …) for diagnostics. */
+  retryAfterSrc: string
+  /** Epoch ms the window was (re)recorded. */
+  observedAt: number
+}
+
+/** Sibling file holding the scoped-window array. */
+export const FLOOD_WINDOWS_FILE = 'flood-windows.json'
+
+/** Resolve the scoped-windows file path from a telegram state dir. */
+export function floodWindowsPath(stateDir: string): string {
+  return join(stateDir, FLOOD_WINDOWS_FILE)
+}
+
+/**
+ * Read persisted scoped windows, pruning any whose `untilTs` is already in the
+ * past. Returns `[]` on absence / parse failure (fails OPEN — a corrupt file
+ * must never silence the bot).
+ */
+export function readFloodWindows(path: string, now: number): FloodWindowRecord[] {
+  try {
+    if (!existsSync(path)) return []
+    const raw = JSON.parse(readFileSync(path, 'utf-8')) as unknown
+    if (!Array.isArray(raw)) return []
+    const out: FloodWindowRecord[] = []
+    for (const r of raw) {
+      const rec = r as Partial<FloodWindowRecord>
+      if (typeof rec.scopeKey !== 'string' || typeof rec.untilTs !== 'number') continue
+      if (rec.untilTs <= now) continue // prune expired
+      out.push({
+        scopeKey: rec.scopeKey,
+        untilTs: rec.untilTs,
+        retryAfterSrc: typeof rec.retryAfterSrc === 'string' ? rec.retryAfterSrc : 'unknown',
+        observedAt: typeof rec.observedAt === 'number' ? rec.observedAt : now,
+      })
+    }
+    return out
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Write-through a single scoped window (best-effort, atomic rename). Merges
+ * with the on-disk set: EXTENDS an existing scope's window (never shortens — a
+ * restart must not shrink a ban), prunes expired scopes, and drops the scope
+ * entirely if the new window is already in the past. Atomic via temp-file +
+ * rename so a concurrent reader never sees a half-written file.
+ */
+export function writeFloodWindow(
+  path: string,
+  record: FloodWindowRecord,
+  now: number,
+): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true })
+    const existing = readFloodWindows(path, now)
+    const byScope = new Map<string, FloodWindowRecord>()
+    for (const r of existing) byScope.set(r.scopeKey, r)
+    if (record.untilTs > now) {
+      const prior = byScope.get(record.scopeKey)
+      // Monotonic: keep the LATER expiry (never shorten an open window).
+      const untilTs = prior && prior.untilTs > record.untilTs ? prior.untilTs : record.untilTs
+      byScope.set(record.scopeKey, { ...record, untilTs })
+    }
+    const arr = [...byScope.values()]
+    const tmp = `${path}.tmp-${process.pid}`
+    writeFileSync(tmp, JSON.stringify(arr), { mode: 0o600 })
+    renameSync(tmp, path)
+  } catch {
+    /* best-effort — a persistence failure must not crash the send path */
+  }
+}
+
+/**
+ * Build the `onWindowOpen` callback the send gate calls whenever it opens /
+ * extends a scope window (on a 429, or at boot). Persists write-through so the
+ * window survives a restart (part3-design §7).
+ */
+export function makeFloodWindowRecorder(
+  path: string,
+  now: () => number = Date.now,
+): (scopeKey: string, untilTs: number, retryAfterSrc?: string) => void {
+  return (scopeKey: string, untilTs: number, retryAfterSrc = '429') => {
+    const t = now()
+    writeFloodWindow(path, { scopeKey, untilTs, retryAfterSrc, observedAt: t }, t)
+  }
+}
+
+/**
+ * Assemble the `initialWindows` the send gate is constructed with at boot
+ * (part3-design §7). Combines the global window from the single-object
+ * `flood-wait.json` (#3094 / #2923) with every future-dated scoped window from
+ * the sibling `flood-windows.json`, pruning expired ones. The gate applies
+ * these BEFORE any outbound call so a boot mid-ban does not resend into it.
+ */
+export function loadInitialFloodWindows(
+  floodStateFilePath: string,
+  floodWindowsFilePath: string,
+  now: number,
+): { scopeKey: string; untilTs: number }[] {
+  const out: { scopeKey: string; untilTs: number }[] = []
+  const global = readFloodState(floodStateFilePath)
+  if (global && global.untilTs > now) out.push({ scopeKey: 'global', untilTs: global.untilTs })
+  for (const w of readFloodWindows(floodWindowsFilePath, now)) {
+    out.push({ scopeKey: w.scopeKey, untilTs: w.untilTs })
+  }
+  return out
 }

--- a/telegram-plugin/flood-circuit-breaker.ts
+++ b/telegram-plugin/flood-circuit-breaker.ts
@@ -391,31 +391,80 @@ export function floodWindowsPath(stateDir: string): string {
 }
 
 /**
- * Read persisted scoped windows, pruning any whose `untilTs` is already in the
- * past. Returns `[]` on absence / parse failure (fails OPEN — a corrupt file
- * must never silence the bot).
+ * How long a fail-SAFE conservative global window suppresses for when the
+ * scoped-windows file exists but cannot be trusted (unreadable/corrupt/junk).
+ *
+ * The scoped-windows file gates whether a booting gateway resends into an open
+ * ban. If we cannot tell what windows are open, the ONLY safe move is to assume
+ * a ban may be open and hold non-essential/coalesced traffic for a bounded
+ * conservative window — the exact opposite of `flood-wait.json`'s essential-send
+ * probe, which must fail OPEN so a marker problem never gags the user's reply.
+ * The asymmetry is deliberate: this file drives boot-time shedding, not the
+ * user's reply, so failing safe here costs at most a few suppressed cosmetic
+ * sends, while failing open resends straight into a ban (H2/M1, #3106 posture).
  */
-export function readFloodWindows(path: string, now: number): FloodWindowRecord[] {
-  try {
-    if (!existsSync(path)) return []
-    const raw = JSON.parse(readFileSync(path, 'utf-8')) as unknown
-    if (!Array.isArray(raw)) return []
-    const out: FloodWindowRecord[] = []
-    for (const r of raw) {
-      const rec = r as Partial<FloodWindowRecord>
-      if (typeof rec.scopeKey !== 'string' || typeof rec.untilTs !== 'number') continue
-      if (rec.untilTs <= now) continue // prune expired
-      out.push({
-        scopeKey: rec.scopeKey,
-        untilTs: rec.untilTs,
-        retryAfterSrc: typeof rec.retryAfterSrc === 'string' ? rec.retryAfterSrc : 'unknown',
-        observedAt: typeof rec.observedAt === 'number' ? rec.observedAt : now,
-      })
-    }
-    return out
-  } catch {
-    return []
+export const FLOOD_WINDOWS_CORRUPT_SUPPRESS_MS = 5 * 60_000
+
+/**
+ * Read persisted scoped windows, pruning any whose `untilTs` is already in the
+ * past.
+ *
+ * Fail-SAFE, not fail-open (M1/H2): a genuinely ABSENT file (ENOENT) is the
+ * only "no windows" answer. If the file exists but is unreadable (EACCES/EIO),
+ * corrupt, or not a JSON array, we CANNOT tell whether a ban is open — so we
+ * synthesize a conservative `global` window (`FLOOD_WINDOWS_CORRUPT_SUPPRESS_MS`)
+ * and log loudly, rather than booting into an open flood with no windows.
+ */
+export function readFloodWindows(
+  path: string,
+  now: number,
+  log: (line: string) => void = (l) => process.stderr.write(l),
+): FloodWindowRecord[] {
+  // ENOENT is the ONLY honest "no windows". Anything else = we can't tell.
+  if (!existsSync(path)) return []
+  const failSafe = (why: string): FloodWindowRecord[] => {
+    log(
+      `telegram gateway: flood-breaker: scoped-windows file ${path} is ${why} — ` +
+        `failing SAFE: opening a conservative ${FLOOD_WINDOWS_CORRUPT_SUPPRESS_MS}ms global ` +
+        `window rather than booting into a possible open ban with no windows (issue #3106)\n`,
+    )
+    return [
+      {
+        scopeKey: 'global',
+        untilTs: now + FLOOD_WINDOWS_CORRUPT_SUPPRESS_MS,
+        retryAfterSrc: `failsafe:${why}`,
+        observedAt: now,
+      },
+    ]
   }
+  let text: string
+  try {
+    text = readFileSync(path, 'utf-8')
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code
+    if (code === 'ENOENT' || code === 'ENOTDIR') return [] // vanished between stat and read
+    return failSafe(`unreadable (${code ?? 'error'})`)
+  }
+  let raw: unknown
+  try {
+    raw = JSON.parse(text)
+  } catch {
+    return failSafe('corrupt (invalid JSON)')
+  }
+  if (!Array.isArray(raw)) return failSafe('corrupt (not an array)')
+  const out: FloodWindowRecord[] = []
+  for (const r of raw) {
+    const rec = r as Partial<FloodWindowRecord>
+    if (typeof rec.scopeKey !== 'string' || typeof rec.untilTs !== 'number') continue
+    if (rec.untilTs <= now) continue // prune expired
+    out.push({
+      scopeKey: rec.scopeKey,
+      untilTs: rec.untilTs,
+      retryAfterSrc: typeof rec.retryAfterSrc === 'string' ? rec.retryAfterSrc : 'unknown',
+      observedAt: typeof rec.observedAt === 'number' ? rec.observedAt : now,
+    })
+  }
+  return out
 }
 
 /**
@@ -443,8 +492,21 @@ export function writeFloodWindow(
     }
     const arr = [...byScope.values()]
     const tmp = `${path}.tmp-${process.pid}`
-    writeFileSync(tmp, JSON.stringify(arr), { mode: 0o600 })
+    // 0o644, NOT 0o600 (H2, #3106): the telegram state dir is shared by
+    // processes running under DIFFERENT uids; a 0600 marker created by whoever
+    // wrote first is unreadable to every other uid, which silently defeats the
+    // restart-proof windows — a restart under a different uid boots blind and
+    // resends into the ban. Match `flood-wait.json` (FLOOD_STATE_MODE).
+    writeFileSync(tmp, JSON.stringify(arr), { mode: FLOOD_STATE_MODE })
     renameSync(tmp, path)
+    // `mode:` only applies at CREATE; chmod so a marker left 0600 by an earlier
+    // build (or a root gateway) becomes readable to the agent uid. Best-effort:
+    // if we don't own it, the read path fails SAFE rather than silently open.
+    try {
+      chmodSync(path, FLOOD_STATE_MODE)
+    } catch {
+      /* not the owner — read path fails safe */
+    }
   } catch {
     /* best-effort — a persistence failure must not crash the send path */
   }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -194,8 +194,11 @@ import { classifyPhotoFile, rerouteResultSuffix } from '../photo-precheck.js'
 import { installTgPostLogger, withTgPostTags } from '../shared/bot-runtime.js'
 import {
   floodStatePath,
+  floodWindowsPath,
   makeFloodWaitRecorder,
   makeFloodWaitProbe,
+  makeFloodWindowRecorder,
+  loadInitialFloodWindows,
   suppressNonEssentialSendMs,
 } from '../flood-circuit-breaker.js'
 import { buildAttachmentPath, assertInsideInbox } from '../attachment-path.js'
@@ -5332,9 +5335,49 @@ const PHOTO_EXTS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp'])
 // Declared ABOVE the typing indicator because the typing sends now route
 // through the same policy (#3084) — see nonEssentialApiCall below.
 const FLOOD_STATE_PATH = floodStatePath(STATE_DIR)
+// #3084 PR 2/3 — sibling file for SCOPED flood windows (global / chat / group /
+// msg-edit). Kept separate from the single-object flood-wait.json so #3094's
+// makeFloodWaitProbe schema is untouched (part3-design §7).
+const FLOOD_WINDOWS_PATH = floodWindowsPath(STATE_DIR)
+const recordFloodWindow = makeFloodWindowRecorder(FLOOD_WINDOWS_PATH)
+
+// #3084 PR 2/3 — deterministic outbound send gate (token buckets + per-message
+// edit floor + no-op-edit skip + PRIORITY SHEDDING + DEGRADED MODE). Wrapped
+// HERE at the robustApiCall layer so every Bot API call routed through the
+// standard retry policy also transits one scheduler (no call site can bypass
+// it). Feature-flagged, default OFF: when SWITCHROOM_TELEGRAM_SEND_GATE !== '1'
+// the gate is a pure passthrough and the retry policy behaves exactly as
+// before. Composes with #3094's pre-call flood gate and #3097's non-essential
+// drop policy — those decide whether a call happens at all; this paces the
+// calls that do.
+//
+// §7 restart-proof flood state: initialWindows are loaded from disk BEFORE the
+// gate (and thus before ANY outbound call, boot cards included), so a boot mid-
+// ban never resends into an open window. onWindowOpen write-throughs every
+// runtime-opened window to FLOOD_WINDOWS_PATH; bootRamp starts the global
+// bucket at half capacity for 10s to absorb the boot-card burst.
+const sendGate = createSendGate({
+  enabled: sendGateEnabledFromEnv(),
+  initialWindows: loadInitialFloodWindows(FLOOD_STATE_PATH, FLOOD_WINDOWS_PATH, Date.now()),
+  bootRamp: {},
+  onWindowOpen: (scopeKey, untilTs) => recordFloodWindow(scopeKey, untilTs),
+})
+
 const rawRobustApiCall = createRetryApiCall({
   log: (line) => process.stderr.write(line),
-  onFloodWait: makeFloodWaitRecorder(FLOOD_STATE_PATH),
+  onFloodWait: (retryAfterSec) => {
+    // #2923/#3094 — persist the single-object global window (probe reads this).
+    makeFloodWaitRecorder(FLOOD_STATE_PATH)(retryAfterSec)
+    // #3084 PR 2 — also open a GLOBAL send-gate window so cosmetic traffic sheds
+    // for the ban's duration even on a SHORT (slept-and-retried) 429 that never
+    // throws FLOOD_WAIT_ACTIVE. Scope-precise windows are opened by the gate's
+    // own FLOOD_WAIT_ACTIVE catch (which has the call's opts).
+    try {
+      sendGate.openFloodWindow('global', Date.now() + Math.max(0, retryAfterSec) * 1000)
+    } catch {
+      /* best-effort — never let the window hook break the retry path */
+    }
+  },
   // #3094: while a LONG per-bot ban is open, don't issue the call at all.
   // retryApiCall no longer sleeps a multi-hour retry_after (it throws
   // FLOOD_WAIT_ACTIVE instead), and the card surfaces re-drive on a 5-6s
@@ -5343,15 +5386,6 @@ const rawRobustApiCall = createRetryApiCall({
   floodWaitRemainingMs: makeFloodWaitProbe(FLOOD_STATE_PATH),
 })
 
-// #3084 PR 1/3 — deterministic outbound send gate (token buckets + per-message
-// edit floor + no-op-edit skip). Wrapped HERE at the robustApiCall layer so
-// every Bot API call routed through the standard retry policy also transits
-// one scheduler (no call site can bypass it). Feature-flagged, default OFF:
-// when SWITCHROOM_TELEGRAM_SEND_GATE !== '1' the gate is a pure passthrough
-// and the retry policy behaves exactly as before. Composes with #3094's
-// pre-call flood gate and #3097's non-essential drop policy — those decide
-// whether a call happens at all; this paces the calls that do.
-const sendGate = createSendGate({ enabled: sendGateEnabledFromEnv() })
 const robustApiCall = <T>(
   fn: () => Promise<T>,
   opts?: Parameters<typeof rawRobustApiCall<T>>[1],
@@ -5621,7 +5655,8 @@ function wrapBootCardApi(
             richMessage(text),
             sendOpts as Parameters<typeof lockedBot.api.sendRichMessage>[2],
           ),
-        opts(cid),
+        // #3084 PR 2: boot/config card CREATION is USEFUL (queue with TTL).
+        { ...opts(cid), priorityClass: 'useful' },
       )
       return sent as { message_id: number }
     },
@@ -5634,7 +5669,9 @@ function wrapBootCardApi(
             richMessage(text),
             editOpts as Parameters<typeof lockedBot.api.editMessageText>[3],
           ),
-        opts(cid),
+        // A boot-card EDIT is COSMETIC — shed under pressure; pass
+        // messageId/editPayload so the per-message floor + no-op skip engage.
+        { ...opts(cid), priorityClass: 'cosmetic', messageId: mid, editPayload: text },
       ) as Promise<unknown>,
     // Strict edit for the boot-card edit-in-place probe: distinguishes
     // "message gone" (→ 'gone', caller sends fresh) from a landed/identical
@@ -5686,7 +5723,8 @@ function wrapIssuesCardApi(
             richMessage(text),
             sendOpts as Parameters<typeof lockedBot.api.sendRichMessage>[2],
           ),
-        opts(cid),
+        // #3084 PR 2: issues-card creation is USEFUL.
+        { ...opts(cid), priorityClass: 'useful' },
       )
       return sent as { message_id: number }
     },
@@ -5699,7 +5737,8 @@ function wrapIssuesCardApi(
             richMessage(text),
             editOpts as Parameters<typeof lockedBot.api.editMessageText>[3],
           ),
-        opts(cid),
+        // An issues-card EDIT is COSMETIC.
+        { ...opts(cid), priorityClass: 'cosmetic', messageId: mid, editPayload: text },
       ) as Promise<unknown>,
     deleteMessage: (cid, mid) =>
       robustApiCall(() => lockedBot.api.deleteMessage(cid, mid), opts(cid)) as Promise<unknown>,
@@ -9049,6 +9088,13 @@ pendingProgress.startTimer({
         chat_id: ctx.chatId,
         verb: 'pending-progress-edit',
         ...(ctx.threadId != null ? { threadId: ctx.threadId } : {}),
+        // #3084 PR 2 / L1: the progress-card edit is the #1 documented ban
+        // trigger (repeated editMessageText on one message). Tag COSMETIC and
+        // pass messageId/editPayload so the gate's per-message floor + no-op
+        // skip + coalescing engage, and the edit sheds while a window is open.
+        priorityClass: 'cosmetic',
+        messageId: ctx.messageId,
+        editPayload: ctx.literalText ? ctx.newText : richMessage(ctx.newText),
       },
     )
   },
@@ -12418,13 +12464,15 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
       robustApiCall(
         // allow-raw-bot-api: injected chunk-loop adapter — sendRichMessage routed through robustApiCall; THREAD_NOT_FOUND handled by sendReplyChunks' fallback ladder
         () => lockedBot.api.sendRichMessage(chat_id, body as never, opts as never),
-        { threadId: tid, chat_id },
+        // #3084 PR 2: the final reply is CRITICAL — never shed; degraded mode
+        // fails fast (structured flood_wait) instead of blocking the MCP reply.
+        { threadId: tid, chat_id, priorityClass: 'critical' },
       ),
     sendLiteral: (opts, txt, tid) =>
       robustApiCall(
         // allow-raw-bot-api: injected chunk-loop adapter — literal format:'text' send routed through robustApiCall; THREAD_NOT_FOUND handled by sendReplyChunks
         () => lockedBot.api.sendMessage(chat_id, txt, opts as never),
-        { threadId: tid, chat_id },
+        { threadId: tid, chat_id, priorityClass: 'critical' },
       ),
     sendLiteralRaw: (opts, txt) =>
       // allow-raw-bot-api: literal last-resort fallback (plaintext parse-reject / length re-split); wrapping would re-enter the parse/length policy that just rejected the payload
@@ -12436,7 +12484,10 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
       robustApiCall(
         // allow-raw-bot-api: preview edit-in-place routed through robustApiCall; thread fallback handled by sendReplyChunks
         () => lockedBot.api.editMessageText(chat_id, mid, body as never, opts as never),
-        { threadId: tid, chat_id },
+        // Finalizing the reply into the preview message — still CRITICAL (this
+        // IS the answer). Pass messageId/editPayload so the gate's per-message
+        // floor + no-op skip engage on the edit (part3-design §4/§5, PR1 L1).
+        { threadId: tid, chat_id, priorityClass: 'critical', messageId: mid, editPayload: body },
       ),
     richMessage,
     logOutbound,
@@ -16045,6 +16096,14 @@ function handleSessionEvent(ev: SessionEvent): void {
                   chat_id: chatId,
                   verb: 'answer-stream.editMessageText',
                   ...(tid != null ? { threadId: tid } : {}),
+                  // #3084 PR 2 / L1: answer-stream edits are COSMETIC — a
+                  // dropped stream tick costs nothing (the next carries full
+                  // text). messageId/editPayload engage the per-message floor +
+                  // coalescing + no-op skip so rapid stream edits don't storm
+                  // the same message (the top ban trigger).
+                  priorityClass: 'cosmetic',
+                  messageId,
+                  editPayload: richMessage(text),
                 },
               )
             },
@@ -28072,7 +28131,8 @@ void (async () => {
                         richMessage(text),
                         sendOpts as Parameters<typeof lockedBot.api.sendRichMessage>[2],
                       ),
-                    { chat_id: cid, verb: 'worker-feed' },
+                    // #3084 PR 2: worker-feed card CREATION (handback) is USEFUL.
+                    { chat_id: cid, verb: 'worker-feed', priorityClass: 'useful' },
                   )
                   return sent as { message_id: number }
                 },
@@ -28085,7 +28145,15 @@ void (async () => {
                         richMessage(text),
                         editOpts as Parameters<typeof lockedBot.api.editMessageText>[3],
                       ),
-                    { chat_id: cid, verb: 'worker-feed' },
+                    // Worker-feed EDITs are COSMETIC — pass messageId/editPayload
+                    // so the per-message floor + coalescing + no-op skip engage.
+                    {
+                      chat_id: cid,
+                      verb: 'worker-feed',
+                      priorityClass: 'cosmetic',
+                      messageId: mid,
+                      editPayload: text,
+                    },
                   ),
               },
               log: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),

--- a/telegram-plugin/retry-api-call.ts
+++ b/telegram-plugin/retry-api-call.ts
@@ -60,6 +60,23 @@ export interface RetryCallOpts {
    * edits (identical → dropped) and to coalesce. Retry policy ignores it.
    */
   editPayload?: unknown
+  /**
+   * Priority class for the outbound send gate's shedding + degraded mode
+   * (#3084 PR 2, send-gate.ts). The retry policy itself ignores it; it only
+   * governs how the gate treats the call when it is under pressure or a flood
+   * window is open:
+   *   - `critical`  — final reply chunks, approval / vault cards, error
+   *     notices. Never shed; queued unbounded. In degraded mode a critical
+   *     send waits for a short window but fails fast (structured
+   *     `FLOOD_WAIT_ACTIVE`) when the remaining window is long.
+   *   - `useful`    — progress-card creation, worker handbacks, checklists,
+   *     boot/config cards. Queued with a TTL; dropped when stale. DEFAULT
+   *     when unset.
+   *   - `cosmetic`  — typing, reactions, all card EDITS, stream updates,
+   *     heartbeats. Shed immediately when no token is free OR any flood
+   *     window is open.
+   */
+  priorityClass?: 'critical' | 'useful' | 'cosmetic'
 }
 
 export interface RetryObserver {
@@ -189,8 +206,16 @@ export interface FloodWaitActiveError extends Error {
   original: unknown
 }
 
-/** Build the marker with the full Telegram-429 duck-type shape. */
-function makeFloodWaitActiveError(
+/**
+ * Build the marker with the full Telegram-429 duck-type shape.
+ *
+ * Exported so the outbound send gate (#3084 PR 2) can COMPOSE the same
+ * structured error for its own degraded-mode fail-fast (a critical send into a
+ * long open flood window) rather than duplicating the 429 duck-type shape. One
+ * error shape means every downstream cooldown gate + the MCP reply path treat a
+ * gate fail-fast identically to a retry-layer flood-wait.
+ */
+export function makeFloodWaitActiveError(
   retryAfterSec: number,
   untilTs: number,
   original: unknown,

--- a/telegram-plugin/send-gate-degraded.test.ts
+++ b/telegram-plugin/send-gate-degraded.test.ts
@@ -117,10 +117,12 @@ describe('send-gate PR2: cosmetic shedding', () => {
     const gate = createSendGate({
       enabled: true,
       clock,
-      initialWindows: [{ scopeKey: 'msg-edit:42', untilTs: HOUR }],
+      // H1: msg-edit scope is keyed `${chat_id}:${messageId}`.
+      initialWindows: [{ scopeKey: 'msg-edit:5:42', untilTs: HOUR }],
     })
 
     const res = await gate.gate(fn('edit'), {
+      chat_id: '5',
       messageId: 42,
       editPayload: 'v1',
       priorityClass: 'cosmetic',
@@ -299,6 +301,110 @@ describe('send-gate PR2: edit call-site wiring (progress/answer-stream shape)', 
   })
 })
 
+describe('send-gate PR2: H1 cross-chat message_id isolation', () => {
+  it('two chats sharing message_id 100 do NOT collide — both send, no edit lost', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({ enabled: true, clock, editFloorMs: 1500 })
+
+    // Chat A: v1 (cold → sends now), then v2 within the floor → queued for A.
+    const pA1 = gate.gate(fn('A-v1'), { chat_id: 'A', messageId: 100, editPayload: 'A-v1' })
+    await flush()
+    const pA2 = gate.gate(fn('A-v2'), { chat_id: 'A', messageId: 100, editPayload: 'A-v2' })
+    // Chat B edits ITS OWN card, also message_id 100 — must be a SEPARATE state.
+    const pB1 = gate.gate(fn('B-v1'), { chat_id: 'B', messageId: 100, editPayload: 'B-v1' })
+
+    await clock.advance(1600)
+    await Promise.all([pA1, pA2, pB1])
+
+    // With the id-only bug, B-v1 overwrote A's pending (A-v2) → A-v2 silently
+    // dropped. Keyed by chat_id+messageId, all three survive.
+    expect(calls.map((c) => c.label).sort()).toEqual(['A-v1', 'A-v2', 'B-v1'])
+    expect(gate.stats().global.sent).toBe(3)
+    expect(gate.stats().global.dropped).toBe(0)
+  })
+
+  it('chat B cold edit is NOT floored by chat A holding the same message_id', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({ enabled: true, clock, editFloorMs: 1500 })
+
+    // A sends (starts A's floor). B's first edit to the same id must fire at
+    // t=0 — B has its own floor, not A's.
+    const pA = gate.gate(fn('A'), { chat_id: 'A', messageId: 100, editPayload: 'A' })
+    await flush()
+    const pB = gate.gate(fn('B'), { chat_id: 'B', messageId: 100, editPayload: 'B' })
+    await flush()
+    await Promise.all([pA, pB])
+
+    expect(calls.map((c) => c.label).sort()).toEqual(['A', 'B'])
+    expect(calls.every((c) => c.at === 0)).toBe(true)
+  })
+
+  it('a 429 on chat A message 100 does NOT shed chat B message 100 cosmetic edits', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      // Only chat A's msg-edit scope is under a flood window.
+      initialWindows: [{ scopeKey: 'msg-edit:A:100', untilTs: HOUR }],
+    })
+
+    // Chat A cosmetic edit → shed (its scope window is open).
+    const rA = await gate.gate(fn('A-edit'), {
+      chat_id: 'A',
+      messageId: 100,
+      editPayload: 'A-edit',
+      priorityClass: 'cosmetic',
+    })
+    // Chat B cosmetic edit to the SAME message_id → must NOT shed (different scope).
+    const rB = await gate.gate(fn('B-edit'), {
+      chat_id: 'B',
+      messageId: 100,
+      editPayload: 'B-edit',
+      priorityClass: 'cosmetic',
+    })
+
+    expect(rA).toBeUndefined() // A shed
+    expect(rB).toBe('B-edit') // B sent
+    expect(calls.map((c) => c.label)).toEqual(['B-edit'])
+    expect(gate.stats().global.shed).toBe(1)
+  })
+})
+
+describe('send-gate PR2: M2 critical wait re-evaluates the window each iteration', () => {
+  it('a window extended past the ceiling MID-WAIT converts a critical to fail-fast, not a hang', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      criticalFailFastMs: 60_000,
+      jitter: () => 0, // deterministic, no jitter sleep
+      // A SHORT 30s window (<= ceiling) → the critical waits it out.
+      initialWindows: [{ scopeKey: 'global', untilTs: 30_000 }],
+    })
+
+    // Attach the rejection handler synchronously (before advancing time) so the
+    // eventual fail-fast rejection is never an unhandled rejection.
+    const p = gate.gate(fn('critical'), { priorityClass: 'critical' }).catch((e) => e)
+    await flush()
+    // While it waits, a competing 429 EXTENDS the global window to +10min.
+    gate.openFloodWindow('global', 600_000)
+    // Walk past the ORIGINAL short window; the loop re-checks the ceiling and,
+    // seeing the extended window, fails fast instead of blocking ~10 minutes.
+    await clock.advance(31_000)
+
+    const caught = await p
+    expect(isFloodWaitActiveError(caught)).toBe(true)
+    expect((caught as { untilTs: number }).untilTs).toBe(600_000)
+    expect(calls).toHaveLength(0) // never probed the API
+    expect(gate.stats().global.failedFast).toBe(1)
+    expect(gate.stats().global.sent).toBe(0)
+  })
+})
+
 describe('send-gate PR2: opening a window from a 429, and persistence hook', () => {
   it('opens scope windows via onWindowOpen when a non-edit send throws FLOOD_WAIT_ACTIVE', async () => {
     const clock = new FakeClock()
@@ -327,7 +433,8 @@ describe('send-gate PR2: opening a window from a 429, and persistence hook', () 
     ).rejects.toBe(floodErr)
 
     const scopes = opened.map((o) => o.scopeKey).sort()
-    expect(scopes).toEqual(['chat:7', 'global', 'group:7', 'msg-edit:3'])
+    // H1: msg-edit scope carries the chat_id (msg-edit:7:3), not the bare id.
+    expect(scopes).toEqual(['chat:7', 'global', 'group:7', 'msg-edit:7:3'])
     // After the window opens, a later cosmetic on the same chat sheds.
     const shed = await gate.gate(async () => 'x', { chat_id: '7', priorityClass: 'cosmetic' })
     expect(shed).toBeUndefined()

--- a/telegram-plugin/send-gate-degraded.test.ts
+++ b/telegram-plugin/send-gate-degraded.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, it } from 'vitest'
+import { createSendGate, type Clock } from './send-gate.js'
+import { isFloodWaitActiveError } from './retry-api-call.js'
+
+/**
+ * Deterministic tests for #3084 PR 2 — priority shedding, degraded mode, and
+ * restart-proof flood windows (part3-design §2/§3/§7). Same fake-clock pattern
+ * as send-gate.test.ts; every assertion checks an OUTCOME (a send happened /
+ * was shed / expired / failed fast; a window survived a round-trip), not a
+ * code path.
+ */
+class FakeClock implements Clock {
+  private cur = 0
+  private seq = 0
+  private timers: { at: number; id: number; resolve: () => void }[] = []
+
+  now(): number {
+    return this.cur
+  }
+
+  sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.timers.push({ at: this.cur + ms, id: this.seq++, resolve })
+    })
+  }
+
+  async advance(ms: number): Promise<void> {
+    // Flush first so any async chain that hasn't yet registered its next sleep
+    // (e.g. a critical send suspended on the serialize mutex's microtask) gets
+    // a chance to register before we walk time forward.
+    await flush()
+    const target = this.cur + ms
+    for (;;) {
+      const due = this.timers
+        .filter((t) => t.at <= target)
+        .sort((a, b) => a.at - b.at || a.id - b.id)
+      if (due.length === 0) break
+      const t = due[0]
+      this.timers = this.timers.filter((x) => x !== t)
+      this.cur = t.at
+      t.resolve()
+      await flush()
+    }
+    this.cur = target
+  }
+}
+
+function flush(): Promise<void> {
+  return new Promise<void>((r) => setImmediate(r))
+}
+
+function recorder(clock: FakeClock) {
+  const calls: { label: string; at: number }[] = []
+  const fn = (label: string) => async () => {
+    calls.push({ label, at: clock.now() })
+    return label
+  }
+  return { calls, fn }
+}
+
+// A future window well beyond the fail-fast ceiling.
+const HOUR = 3_600_000
+
+describe('send-gate PR2: cosmetic shedding', () => {
+  it('sheds a cosmetic send when a flood window covers its scope', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      initialWindows: [{ scopeKey: 'global', untilTs: HOUR }],
+    })
+
+    const res = await gate.gate(fn('cosmetic'), { priorityClass: 'cosmetic' })
+
+    // Shed resolves undefined; fn never ran; the shed counter moved.
+    expect(res).toBeUndefined()
+    expect(calls).toHaveLength(0)
+    expect(gate.stats().global.shed).toBe(1)
+    expect(gate.stats().global.sent).toBe(0)
+  })
+
+  it('sheds a cosmetic send when no token is immediately free', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    // Per-chat bucket burst 1, so the 2nd immediate cosmetic has no token.
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      perChatBurst: 1,
+      perChatPerSec: 1,
+    })
+
+    await gate.gate(fn('a'), { chat_id: '5', priorityClass: 'cosmetic' })
+    const shed = await gate.gate(fn('b'), { chat_id: '5', priorityClass: 'cosmetic' })
+
+    expect(calls.map((c) => c.label)).toEqual(['a'])
+    expect(shed).toBeUndefined()
+    expect(gate.stats().global.shed).toBe(1)
+  })
+
+  it('does NOT shed a cosmetic send when a token is free and no window is open', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({ enabled: true, clock })
+
+    await gate.gate(fn('a'), { priorityClass: 'cosmetic' })
+
+    expect(calls.map((c) => c.label)).toEqual(['a'])
+    expect(gate.stats().global.shed).toBe(0)
+    expect(gate.stats().global.sent).toBe(1)
+  })
+
+  it('sheds a cosmetic EDIT while the message-edit window is open', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      initialWindows: [{ scopeKey: 'msg-edit:42', untilTs: HOUR }],
+    })
+
+    const res = await gate.gate(fn('edit'), {
+      messageId: 42,
+      editPayload: 'v1',
+      priorityClass: 'cosmetic',
+    })
+
+    expect(res).toBeUndefined()
+    expect(calls).toHaveLength(0)
+    expect(gate.stats().global.shed).toBe(1)
+  })
+})
+
+describe('send-gate PR2: useful TTL expiry', () => {
+  it('drops a useful send that cannot be admitted before its TTL', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    // Global bucket blocked by a 5-minute window; useful TTL is 120s < window.
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      usefulTtlMs: 120_000,
+      initialWindows: [{ scopeKey: 'global', untilTs: 300_000 }],
+    })
+
+    const p = gate.gate(fn('useful'), { priorityClass: 'useful' })
+    // Walk past the TTL but not past the window.
+    await clock.advance(130_000)
+    const res = await p
+
+    expect(res).toBeUndefined()
+    expect(calls).toHaveLength(0)
+    expect(gate.stats().global.expired).toBe(1)
+    expect(gate.stats().global.sent).toBe(0)
+  })
+
+  it('admits a useful send that clears before its TTL', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    // Window clears at 30s, inside the 120s useful TTL.
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      usefulTtlMs: 120_000,
+      initialWindows: [{ scopeKey: 'global', untilTs: 30_000 }],
+    })
+
+    const p = gate.gate(fn('useful'), { priorityClass: 'useful' })
+    await clock.advance(31_000)
+    const res = await p
+
+    expect(res).toBe('useful')
+    expect(calls.map((c) => c.label)).toEqual(['useful'])
+    expect(gate.stats().global.expired).toBe(0)
+    expect(gate.stats().global.sent).toBe(1)
+  })
+})
+
+describe('send-gate PR2: critical degraded mode', () => {
+  it('fails fast with a structured FLOOD_WAIT_ACTIVE when the window exceeds the ceiling', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      criticalFailFastMs: 60_000,
+      // 10-minute window >> 60s ceiling.
+      initialWindows: [{ scopeKey: 'global', untilTs: 600_000 }],
+    })
+
+    let caught: unknown
+    try {
+      await gate.gate(fn('critical'), { priorityClass: 'critical' })
+    } catch (err) {
+      caught = err
+    }
+
+    expect(isFloodWaitActiveError(caught)).toBe(true)
+    const e = caught as { untilTs: number; retryAfterSec: number; error_code: number }
+    expect(e.error_code).toBe(429)
+    expect(e.untilTs).toBe(600_000)
+    expect(e.retryAfterSec).toBe(600)
+    expect(calls).toHaveLength(0) // never probed the API
+    expect(gate.stats().global.failedFast).toBe(1)
+  })
+
+  it('waits out a SHORT window (<= ceiling) then sends the critical, single in-flight with jitter', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      criticalFailFastMs: 60_000,
+      criticalJitterMaxMs: 100,
+      jitter: () => 0.5, // deterministic 50ms jitter
+      // 30s window, under the 60s fail-fast ceiling.
+      initialWindows: [{ scopeKey: 'global', untilTs: 30_000 }],
+    })
+
+    const p = gate.gate(fn('critical'), { priorityClass: 'critical' })
+    await clock.advance(31_000)
+    const res = await p
+
+    expect(res).toBe('critical')
+    expect(calls).toHaveLength(1)
+    // Sent AFTER the window cleared (>= 30s), never during it.
+    expect(calls[0]!.at).toBeGreaterThanOrEqual(30_000)
+    expect(gate.stats().global.failedFast).toBe(0)
+    expect(gate.stats().global.sent).toBe(1)
+  })
+
+  it('never sheds a critical send under mere token pressure (no window)', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      perChatBurst: 1,
+      perChatPerSec: 1,
+    })
+
+    await gate.gate(fn('a'), { chat_id: '9', priorityClass: 'critical' })
+    const p = gate.gate(fn('b'), { chat_id: '9', priorityClass: 'critical' })
+    await clock.advance(1000) // one token refills
+    const res = await p
+
+    expect(res).toBe('b')
+    expect(calls.map((c) => c.label)).toEqual(['a', 'b'])
+    expect(gate.stats().global.shed).toBe(0)
+  })
+})
+
+describe('send-gate PR2: flag-off passthrough of the new machinery', () => {
+  it('never sheds / expires / fails fast when disabled, even with an open window', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    const gate = createSendGate({
+      enabled: false,
+      clock,
+      initialWindows: [{ scopeKey: 'global', untilTs: HOUR }],
+    })
+
+    // Cosmetic (would shed), useful (would risk TTL), critical (would fail fast)
+    // — all must run immediately at t=0 with zero counter movement.
+    const c = await gate.gate(fn('cosmetic'), { priorityClass: 'cosmetic' })
+    const u = await gate.gate(fn('useful'), { priorityClass: 'useful' })
+    const cr = await gate.gate(fn('critical'), { priorityClass: 'critical' })
+
+    expect([c, u, cr]).toEqual(['cosmetic', 'useful', 'critical'])
+    expect(calls.every((x) => x.at === 0)).toBe(true)
+    const s = gate.stats().global
+    expect([s.shed, s.expired, s.failedFast, s.sent]).toEqual([0, 0, 0, 0])
+  })
+})
+
+describe('send-gate PR2: edit call-site wiring (progress/answer-stream shape)', () => {
+  it('coalesces rapid cosmetic edits to one message into a single last-write-wins send', async () => {
+    const clock = new FakeClock()
+    const { calls, fn } = recorder(clock)
+    // Buckets ample; behaviour driven by the per-message edit floor.
+    const gate = createSendGate({ enabled: true, clock, editFloorMs: 1500 })
+
+    // v1 sends immediately (cold message). v2, v3 arrive within the floor and
+    // coalesce — only the LAST (v3) is sent when the floor clears. This is the
+    // exact shape the wired progress-card / answer-stream edit sites produce:
+    // messageId + editPayload + priorityClass:'cosmetic'.
+    const p1 = gate.gate(fn('v1'), { messageId: 99, editPayload: 'v1', priorityClass: 'cosmetic' })
+    await flush()
+    const p2 = gate.gate(fn('v2'), { messageId: 99, editPayload: 'v2', priorityClass: 'cosmetic' })
+    const p3 = gate.gate(fn('v3'), { messageId: 99, editPayload: 'v3', priorityClass: 'cosmetic' })
+    await clock.advance(1600)
+    await Promise.all([p1, p2, p3])
+
+    // Two API calls total: v1 (cold) and v3 (coalesced winner). v2 dropped.
+    expect(calls.map((c) => c.label)).toEqual(['v1', 'v3'])
+    expect(gate.stats().global.coalesced).toBe(1)
+    expect(gate.stats().global.sent).toBe(2)
+  })
+})
+
+describe('send-gate PR2: opening a window from a 429, and persistence hook', () => {
+  it('opens scope windows via onWindowOpen when a non-edit send throws FLOOD_WAIT_ACTIVE', async () => {
+    const clock = new FakeClock()
+    const opened: { scopeKey: string; untilTs: number }[] = []
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      onWindowOpen: (scopeKey, untilTs) => opened.push({ scopeKey, untilTs }),
+    })
+
+    const floodErr = Object.assign(new Error('FLOOD_WAIT_ACTIVE'), {
+      retryAfterSec: 100,
+      untilTs: 100_000,
+      error_code: 429 as const,
+      parameters: { retry_after: 100 },
+      original: null,
+    })
+
+    await expect(
+      gate.gate(
+        async () => {
+          throw floodErr
+        },
+        { chat_id: '7', chatType: 'supergroup', messageId: 3, priorityClass: 'critical' },
+      ),
+    ).rejects.toBe(floodErr)
+
+    const scopes = opened.map((o) => o.scopeKey).sort()
+    expect(scopes).toEqual(['chat:7', 'global', 'group:7', 'msg-edit:3'])
+    // After the window opens, a later cosmetic on the same chat sheds.
+    const shed = await gate.gate(async () => 'x', { chat_id: '7', priorityClass: 'cosmetic' })
+    expect(shed).toBeUndefined()
+    expect(gate.stats().global.shed).toBe(1)
+  })
+})

--- a/telegram-plugin/send-gate.ts
+++ b/telegram-plugin/send-gate.ts
@@ -67,6 +67,10 @@
  */
 
 import { createHash } from 'node:crypto'
+import {
+  makeFloodWaitActiveError,
+  isFloodWaitActiveError,
+} from './retry-api-call.js'
 
 /** Injectable time source. Default binds to real wall clock + setTimeout. */
 export interface Clock {
@@ -83,6 +87,20 @@ export const systemClock: Clock = {
 
 /** Chat type as reported by Telegram, used to key the per-group bucket. */
 export type ChatType = 'private' | 'group' | 'supergroup' | 'channel'
+
+/**
+ * Priority class governing shedding + degraded mode (part3-design §2/§3):
+ *   - `critical` — final reply chunks, approval / vault cards, error notices.
+ *     Never shed; queued unbounded. Degraded mode: waits a short window,
+ *     fails fast with a structured `FLOOD_WAIT_ACTIVE` for a long one.
+ *   - `useful`   — progress-card creation, worker handbacks, checklists,
+ *     boot/config cards. Queued with a TTL; dropped (counted) when stale.
+ *     DEFAULT when a call is untagged.
+ *   - `cosmetic` — typing, reactions, all card EDITS, stream updates,
+ *     heartbeats. Shed immediately (counted) when no token is free OR any
+ *     flood window covering the scope is open.
+ */
+export type PriorityClass = 'critical' | 'useful' | 'cosmetic'
 
 /**
  * Extra metadata a call site can attach so the gate can key the right buckets.
@@ -105,6 +123,11 @@ export interface SendGateOpts {
   editPayload?: unknown
   /** Informational label (e.g. "editMessageText"); surfaced in stats/logs. */
   verb?: string
+  /**
+   * Priority class for shedding + degraded mode (part3-design §2/§3). Untagged
+   * calls default to `useful`.
+   */
+  priorityClass?: PriorityClass
 }
 
 /** Per-bucket counters, snapshotted by `stats()`. */
@@ -117,6 +140,19 @@ export interface BucketCounters {
   coalesced: number
   /** Calls dropped without hitting the API (no-op edit skip). */
   dropped: number
+  /**
+   * Cosmetic calls shed under pressure — no token free OR a flood window open
+   * (part3-design §2). A shed resolves as `undefined`; the next send carries
+   * full state.
+   */
+  shed: number
+  /** Useful calls dropped because they exceeded their queue TTL (part3-design §2). */
+  expired: number
+  /**
+   * Critical calls that failed fast with a structured `FLOOD_WAIT_ACTIVE`
+   * because the open window exceeded the fail-fast ceiling (part3-design §3).
+   */
+  failedFast: number
 }
 
 export interface SendGateStats {
@@ -194,6 +230,36 @@ export interface SendGateConfig {
    * once exceeded. Default 5_000.
    */
   maxMessageStates?: number
+  /**
+   * TTL (ms) a `useful` call may wait in the admission queue before it is
+   * dropped as stale (part3-design §2). Default 120_000 (~2 min).
+   */
+  usefulTtlMs?: number
+  /**
+   * Ceiling (ms) on an open flood window under which a `critical` send WAITS
+   * (single in-flight, jitter); above it, the send fails fast with a structured
+   * `FLOOD_WAIT_ACTIVE` carrying `untilTs` so the MCP reply path surfaces a real
+   * error instead of a long opaque block (part3-design §3). Default 60_000.
+   */
+  criticalFailFastMs?: number
+  /**
+   * Max jitter (ms) added before a `critical` send probes the API during an
+   * open (short) window, so serialized criticals don't thunder at the exact
+   * window edge. Default 250.
+   */
+  criticalJitterMaxMs?: number
+  /**
+   * Injectable 0..1 source for the critical jitter (tests pass `() => 0` for
+   * determinism). Default `Math.random`.
+   */
+  jitter?: () => number
+  /**
+   * Called whenever `openFloodWindow` opens / extends a window at RUNTIME (on a
+   * 429). Write-through persistence hook (part3-design §7) — the gateway wires
+   * this to `flood-windows.json` so a window survives a restart. NOT called for
+   * `initialWindows` applied at construction (those already came from disk).
+   */
+  onWindowOpen?: (scopeKey: string, untilTs: number) => void
 }
 
 /**
@@ -239,6 +305,11 @@ class TokenBucket {
   /** Open/extend a suppression window (part3-design §7). */
   suppressUntil(untilTs: number): void {
     if (untilTs > this.suppressedUntilMs) this.suppressedUntilMs = untilTs
+  }
+
+  /** Remaining ms of an open suppression window (0 when none). */
+  windowRemainingMs(now: number): number {
+    return this.suppressedUntilMs > now ? this.suppressedUntilMs - now : 0
   }
 
   /**
@@ -345,8 +416,21 @@ export function createSendGate(config: SendGateConfig): SendGate {
   const editFloorMs = config.editFloorMs ?? 1500
   const messageStateTtlMs = config.messageStateTtlMs ?? 60_000
   const maxMessageStates = config.maxMessageStates ?? 5_000
+  const usefulTtlMs = config.usefulTtlMs ?? 120_000
+  const criticalFailFastMs = config.criticalFailFastMs ?? 60_000
+  const criticalJitterMaxMs = config.criticalJitterMaxMs ?? 250
+  const jitter = config.jitter ?? Math.random
+  const onWindowOpen = config.onWindowOpen
 
-  const counters: BucketCounters = { sent: 0, queued: 0, coalesced: 0, dropped: 0 }
+  const counters: BucketCounters = {
+    sent: 0,
+    queued: 0,
+    coalesced: 0,
+    dropped: 0,
+    shed: 0,
+    expired: 0,
+    failedFast: 0,
+  }
 
   const bootStart = clock.now()
   const globalRamp = config.bootRamp
@@ -395,8 +479,12 @@ export function createSendGate(config: SendGateConfig): SendGate {
     return state
   }
 
-  /** Apply any flood windows that were injected at construction (§7 boot load). */
-  for (const w of config.initialWindows ?? []) openFloodWindow(w.scopeKey, w.untilTs)
+  /**
+   * Apply any flood windows injected at construction (§7 boot load) WITHOUT
+   * re-persisting them (they already came from disk). Applied before the first
+   * outbound call so a boot mid-ban never resends into an open window.
+   */
+  for (const w of config.initialWindows ?? []) applyWindow(w.scopeKey, w.untilTs, false)
 
   function bucketsFor(opts?: SendGateOpts): TokenBucket[] {
     const buckets: TokenBucket[] = [globalBucket]
@@ -413,9 +501,40 @@ export function createSendGate(config: SendGateConfig): SendGate {
    * Open/extend a flood window on a scope. `global` suppresses the global
    * bucket; `chat:<id>` / `group:<id>` the per-chat / per-group buckets;
    * `msg-edit:<id>` the per-message edit floor. Idempotent + monotonic
-   * (only ever extends).
+   * (only ever extends). Persists write-through via `onWindowOpen` (part3-design
+   * §7) so the window survives a restart.
    */
   function openFloodWindow(scopeKey: string, untilTs: number): void {
+    applyWindow(scopeKey, untilTs, true)
+  }
+
+  /**
+   * Open all scope windows implied by a call's `opts` at `untilTs` — global,
+   * plus per-chat / per-group / per-message where keyed. Called when a wrapped
+   * send surfaces a `FLOOD_WAIT_ACTIVE` (a real 429 or a pre-call
+   * short-circuit) so the ban is remembered at the finest scope we know
+   * (part3-design §7). Global is always opened as the conservative floor.
+   */
+  function openScopedWindowsForOpts(opts: SendGateOpts | undefined, untilTs: number): void {
+    applyWindow('global', untilTs, true)
+    if (opts?.chat_id) {
+      applyWindow(`chat:${opts.chat_id}`, untilTs, true)
+      if (opts.chatType && GROUP_TYPES.has(opts.chatType)) {
+        applyWindow(`group:${opts.chat_id}`, untilTs, true)
+      }
+    }
+    if (opts?.messageId != null) applyWindow(`msg-edit:${opts.messageId}`, untilTs, true)
+  }
+
+  /** Core window application; `persist` gates the write-through hook. */
+  function applyWindow(scopeKey: string, untilTs: number, persist: boolean): void {
+    if (persist && onWindowOpen) {
+      try {
+        onWindowOpen(scopeKey, untilTs)
+      } catch {
+        /* best-effort — persistence must not break the send path */
+      }
+    }
     if (scopeKey === 'global') {
       globalBucket.suppressUntil(untilTs)
     } else if (scopeKey.startsWith('chat:')) {
@@ -477,9 +596,11 @@ export function createSendGate(config: SendGateConfig): SendGate {
    * consume one from each. The check-and-consume block runs synchronously (no
    * `await` after reading the clock), so concurrent admissions never
    * double-spend. Loops because a competing admission may drain a bucket during
-   * our sleep.
+   * our sleep. When `deadline` is set (a `useful` call's TTL), returns `false`
+   * without consuming if admission cannot happen before it — the caller drops
+   * the call as stale (part3-design §2).
    */
-  async function admit(buckets: TokenBucket[]): Promise<void> {
+  async function admitLoop(buckets: TokenBucket[], deadline?: number): Promise<boolean> {
     let counted = false
     for (;;) {
       const now = clock.now()
@@ -487,14 +608,91 @@ export function createSendGate(config: SendGateConfig): SendGate {
       for (const b of buckets) wait = Math.max(wait, b.msUntilAvailable(now))
       if (wait <= 0) {
         for (const b of buckets) b.consume(now)
-        return
+        return true
       }
+      if (deadline !== undefined && now + wait > deadline) return false
       if (!counted) {
         counters.queued++
         counted = true
       }
-      await clock.sleep(wait)
+      await clock.sleep(deadline !== undefined ? Math.min(wait, deadline - now) : wait)
     }
+  }
+
+  /** Back-compat unbounded admission (used by the per-message edit driver). */
+  function admit(buckets: TokenBucket[]): Promise<boolean> {
+    return admitLoop(buckets)
+  }
+
+  // Serializes `critical` sends that must probe the API during an open (short)
+  // flood window: only ONE in-flight at a time so a burst of criticals doesn't
+  // thunder at the window edge (part3-design §3, "single in-flight, jitter").
+  let criticalTail: Promise<void> = Promise.resolve()
+  function criticalSerialize<R>(job: () => Promise<R>): Promise<R> {
+    const prev = criticalTail
+    let release!: () => void
+    criticalTail = new Promise<void>((r) => {
+      release = r
+    })
+    return (async () => {
+      await prev
+      try {
+        return await job()
+      } finally {
+        release()
+      }
+    })()
+  }
+
+  type AdmitOutcome =
+    | { result: 'ok' }
+    | { result: 'shed' }
+    | { result: 'expired' }
+    | { result: 'failfast'; untilTs: number }
+
+  /**
+   * Priority-aware admission (part3-design §2/§3):
+   *   - cosmetic — shed immediately when any bucket has a wait (no token OR a
+   *     window open); otherwise consume and go.
+   *   - useful   — queue with a TTL; drop as stale past the deadline.
+   *   - critical — never shed. If a window covering the scope exceeds the
+   *     fail-fast ceiling, fail fast with `untilTs` (caller throws a structured
+   *     FLOOD_WAIT_ACTIVE). A short window → wait single-in-flight with jitter.
+   *     No window → queue unbounded.
+   */
+  async function admitPriority(
+    buckets: TokenBucket[],
+    priority: PriorityClass,
+  ): Promise<AdmitOutcome> {
+    const now = clock.now()
+    if (priority === 'cosmetic') {
+      let wait = 0
+      for (const b of buckets) wait = Math.max(wait, b.msUntilAvailable(now))
+      if (wait > 0) return { result: 'shed' }
+      for (const b of buckets) b.consume(now)
+      return { result: 'ok' }
+    }
+    if (priority === 'critical') {
+      let remaining = 0
+      for (const b of buckets) remaining = Math.max(remaining, b.windowRemainingMs(now))
+      if (remaining > criticalFailFastMs) {
+        return { result: 'failfast', untilTs: now + remaining }
+      }
+      if (remaining > 0) {
+        // Degraded but short window: serialize + jitter, then wait it out.
+        await criticalSerialize(async () => {
+          const j = Math.floor(jitter() * criticalJitterMaxMs)
+          if (j > 0) await clock.sleep(j)
+          await admitLoop(buckets)
+        })
+        return { result: 'ok' }
+      }
+      await admitLoop(buckets)
+      return { result: 'ok' }
+    }
+    // useful (default): TTL-bounded queue.
+    const admitted = await admitLoop(buckets, now + usefulTtlMs)
+    return admitted ? { result: 'ok' } : { result: 'expired' }
   }
 
   /**
@@ -551,6 +749,11 @@ export function createSendGate(config: SendGateConfig): SendGate {
           counters.sent++
           p.resolve(res)
         } catch (err) {
+          // A 429 surfaced from the edit send opens the flood windows at this
+          // scope so later cosmetic edits shed and the window persists (§3/§7).
+          if (isFloodWaitActiveError(err)) {
+            openScopedWindowsForOpts(opts, err.untilTs)
+          }
           // H1: reject THIS edit's own promise (the closure-local `p`), never
           // state.pending — a distinct newer edit that arrived during the send
           // owns state.pending and must survive to be sent on the next loop.
@@ -569,6 +772,21 @@ export function createSendGate(config: SendGateConfig): SendGate {
     const existing = perMessage.get(messageId)
     maybeEvict(now, existing === undefined)
     const state = existing ?? messageState(messageId)
+
+    // Cosmetic edits (part3-design §2) shed under pressure — a flood window
+    // covering the scope is open, or a bucket has no token free right now. A
+    // dropped edit costs nothing: the next edit carries the full state. Only an
+    // EXPLICITLY-cosmetic edit sheds; untagged edits keep PR 1's coalescing
+    // behaviour (default = useful), so this never changes an untagged caller.
+    if ((opts.priorityClass ?? 'useful') === 'cosmetic') {
+      let wait = 0
+      for (const b of bucketsFor(opts)) wait = Math.max(wait, b.msUntilAvailable(now))
+      const msgWait = state.suppressedUntilMs > now ? state.suppressedUntilMs - now : 0
+      if (wait > 0 || msgWait > 0) {
+        counters.shed++
+        return Promise.resolve(undefined as unknown as T)
+      }
+    }
 
     // N1: the coalesce (last-write-wins) check runs BEFORE the no-op skip. When
     // a distinct edit is already queued, the newest payload always replaces it —
@@ -625,13 +843,37 @@ export function createSendGate(config: SendGateConfig): SendGate {
       return handleEdit(fn, opts)
     }
 
-    await admit(bucketsFor(opts))
-    // N4: count `sent` only AFTER a successful send, mirroring the edit path
-    // (which increments on success at drive()). A throwing send is not counted
-    // as sent — it propagates without polluting the stat.
-    const res = await fn()
-    counters.sent++
-    return res
+    // Priority-aware admission (part3-design §2/§3). Untagged → useful.
+    const priority = opts?.priorityClass ?? 'useful'
+    const outcome = await admitPriority(bucketsFor(opts), priority)
+    if (outcome.result === 'shed') {
+      counters.shed++
+      return undefined as unknown as T
+    }
+    if (outcome.result === 'expired') {
+      counters.expired++
+      return undefined as unknown as T
+    }
+    if (outcome.result === 'failfast') {
+      counters.failedFast++
+      // Compose #3094's structured error so the MCP reply path surfaces a real
+      // flood_wait (untilTs / retry_after) instead of an opaque long block.
+      const retryAfterSec = Math.ceil((outcome.untilTs - clock.now()) / 1000)
+      openScopedWindowsForOpts(opts, outcome.untilTs)
+      throw makeFloodWaitActiveError(retryAfterSec, outcome.untilTs, null)
+    }
+
+    try {
+      // N4: count `sent` only AFTER a successful send, mirroring the edit path.
+      const res = await fn()
+      counters.sent++
+      return res
+    } catch (err) {
+      // A 429 surfaced from a non-edit send opens the scope's flood windows so
+      // subsequent cosmetic traffic sheds and the window persists (§3/§7).
+      if (isFloodWaitActiveError(err)) openScopedWindowsForOpts(opts, err.untilTs)
+      throw err
+    }
   }
 
   function stats(): SendGateStats {

--- a/telegram-plugin/send-gate.ts
+++ b/telegram-plugin/send-gate.ts
@@ -95,12 +95,26 @@ export type ChatType = 'private' | 'group' | 'supergroup' | 'channel'
  *     fails fast with a structured `FLOOD_WAIT_ACTIVE` for a long one.
  *   - `useful`   — progress-card creation, worker handbacks, checklists,
  *     boot/config cards. Queued with a TTL; dropped (counted) when stale.
- *     DEFAULT when a call is untagged.
  *   - `cosmetic` — typing, reactions, all card EDITS, stream updates,
  *     heartbeats. Shed immediately (counted) when no token is free OR any
  *     flood window covering the scope is open.
+ *
+ * UNTAGGED default (L2, review PR #3106): an untagged NON-EDIT send defaults to
+ * `critical` — NON-droppable (queued unbounded, fail-fast only on a long
+ * window), NOT `useful`. Rationale: most call sites are untagged, and a `useful`
+ * default silently TTL-drops an untagged-but-important send under pressure
+ * (a resolved `undefined` a caller reads as "sent"). Conservative posture:
+ * nothing is droppable unless a call site OPTS IN by tagging `useful`/`cosmetic`.
+ * (Untagged EDITS keep coalescing — the latest payload always wins, never
+ * dropped — so their default is non-droppable already.)
  */
 export type PriorityClass = 'critical' | 'useful' | 'cosmetic'
+
+/**
+ * Priority class an UNTAGGED non-edit send is admitted as. `critical` =
+ * non-droppable (L2). See the `PriorityClass` doc above.
+ */
+export const UNTAGGED_SEND_CLASS: PriorityClass = 'critical'
 
 /**
  * Extra metadata a call site can attach so the gate can key the right buckets.
@@ -125,7 +139,8 @@ export interface SendGateOpts {
   verb?: string
   /**
    * Priority class for shedding + degraded mode (part3-design §2/§3). Untagged
-   * calls default to `useful`.
+   * NON-EDIT calls default to `critical` (non-droppable — see
+   * `UNTAGGED_SEND_CLASS`); untagged edits coalesce (also non-droppable).
    */
   priorityClass?: PriorityClass
 }
@@ -443,7 +458,13 @@ export function createSendGate(config: SendGateConfig): SendGate {
   const globalBucket = new TokenBucket(globalBurst, globalPerSec / 1000, bootStart, globalRamp)
   const perChat = new Map<string, TokenBucket>()
   const perGroup = new Map<string, TokenBucket>()
-  const perMessage = new Map<number, MessageEditState>()
+  // H1 (review PR #3106): keyed by `${chat_id}:${messageId}`, NOT messageId
+  // alone. Telegram `message_id` is per-chat, not globally unique — two chats
+  // routinely both hold a low-numbered card (id 3, 100, …). Keying on the id
+  // alone collides cross-chat: chat B's edit overwrites chat A's pending edit
+  // (A's real update silently lost), and the edit floor / msg-edit suppression
+  // window of one chat sheds an unrelated card in another.
+  const perMessage = new Map<string, MessageEditState>()
   let lastSweepMs = bootStart
 
   function chatBucket(chatId: string): TokenBucket {
@@ -464,8 +485,18 @@ export function createSendGate(config: SendGateConfig): SendGate {
     return b
   }
 
-  function messageState(messageId: number): MessageEditState {
-    let state = perMessage.get(messageId)
+  /**
+   * Per-message state key: `${chat_id}:${messageId}` (H1). A missing chat_id
+   * degrades to `:${messageId}` — still unique per call site, and edits always
+   * carry a chat_id in production. This is ALSO the `msg-edit:` scope suffix, so
+   * the boot-reloaded scoped windows and the runtime edit floor agree.
+   */
+  function messageKey(chatId: string | undefined, messageId: number): string {
+    return `${chatId ?? ''}:${messageId}`
+  }
+
+  function messageState(key: string): MessageEditState {
+    let state = perMessage.get(key)
     if (!state) {
       state = {
         lastSentMs: Number.NEGATIVE_INFINITY,
@@ -474,7 +505,7 @@ export function createSendGate(config: SendGateConfig): SendGate {
         running: false,
         suppressedUntilMs: 0,
       }
-      perMessage.set(messageId, state)
+      perMessage.set(key, state)
     }
     return state
   }
@@ -505,6 +536,14 @@ export function createSendGate(config: SendGateConfig): SendGate {
    * §7) so the window survives a restart.
    */
   function openFloodWindow(scopeKey: string, untilTs: number): void {
+    // M3 (review PR #3106): flag-OFF is a PURE no-op. The gateway wires
+    // `onFloodWait` → `openFloodWindow('global', …)` unconditionally, so without
+    // this guard a 429 would mutate in-memory suppression AND write a new
+    // `flood-windows.json` even while the feature is disabled — a real fs side
+    // effect and behaviour change before the flag is ever enabled. When
+    // disabled the gate must open no window and write no file (the separate
+    // #2923 `flood-wait.json` recorder is unaffected — it is not wired here).
+    if (!enabled) return
     applyWindow(scopeKey, untilTs, true)
   }
 
@@ -523,7 +562,11 @@ export function createSendGate(config: SendGateConfig): SendGate {
         applyWindow(`group:${opts.chat_id}`, untilTs, true)
       }
     }
-    if (opts?.messageId != null) applyWindow(`msg-edit:${opts.messageId}`, untilTs, true)
+    if (opts?.messageId != null) {
+      // H1: msg-edit scope keyed by chat_id+messageId so a 429 on one chat's
+      // card never sheds another chat's same-id card.
+      applyWindow(`msg-edit:${messageKey(opts.chat_id, opts.messageId)}`, untilTs, true)
+    }
   }
 
   /** Core window application; `persist` gates the write-through hook. */
@@ -542,16 +585,17 @@ export function createSendGate(config: SendGateConfig): SendGate {
     } else if (scopeKey.startsWith('group:')) {
       groupBucket(scopeKey.slice('group:'.length)).suppressUntil(untilTs)
     } else if (scopeKey.startsWith('msg-edit:')) {
-      const id = Number(scopeKey.slice('msg-edit:'.length))
-      if (Number.isFinite(id)) {
+      // H1: the suffix is the composite `${chat_id}:${messageId}` state key.
+      const key = scopeKey.slice('msg-edit:'.length)
+      if (key) {
         // N2: creating a per-message edit state here must go through the same
         // eviction accounting (maybeEvict / LRU cap) as normal state creation,
         // so opening many per-message flood windows can't grow perMessage past
         // the cap.
         const now = clock.now()
-        const existing = perMessage.get(id)
+        const existing = perMessage.get(key)
         maybeEvict(now, existing === undefined)
-        const st = existing ?? messageState(id)
+        const st = existing ?? messageState(key)
         if (untilTs > st.suppressedUntilMs) st.suppressedUntilMs = untilTs
       }
     }
@@ -679,20 +723,52 @@ export function createSendGate(config: SendGateConfig): SendGate {
         return { result: 'failfast', untilTs: now + remaining }
       }
       if (remaining > 0) {
-        // Degraded but short window: serialize + jitter, then wait it out.
-        await criticalSerialize(async () => {
+        // Degraded but short window: serialize + jitter, then wait it out —
+        // re-checking the ceiling EACH loop (admitCriticalLoop) so a window
+        // extended past `criticalFailFastMs` while we wait converts to fail-fast
+        // instead of blocking the reply path unbounded (M2, review PR #3106).
+        return await criticalSerialize(async () => {
           const j = Math.floor(jitter() * criticalJitterMaxMs)
           if (j > 0) await clock.sleep(j)
-          await admitLoop(buckets)
+          return await admitCriticalLoop(buckets)
         })
-        return { result: 'ok' }
       }
-      await admitLoop(buckets)
-      return { result: 'ok' }
+      return await admitCriticalLoop(buckets)
     }
     // useful (default): TTL-bounded queue.
     const admitted = await admitLoop(buckets, now + usefulTtlMs)
     return admitted ? { result: 'ok' } : { result: 'expired' }
+  }
+
+  /**
+   * Unbounded critical admission that RE-EVALUATES the covering window on every
+   * iteration (M2, review PR #3106). If a competing 429 extends the window past
+   * the fail-fast ceiling while a critical waits out a short window, this stops
+   * blocking and returns `failfast` (the caller throws a structured
+   * `FLOOD_WAIT_ACTIVE`) rather than blocking the MCP reply path for the whole
+   * extended ban — exactly the "opaque long block" part3-design §3 forbids.
+   */
+  async function admitCriticalLoop(buckets: TokenBucket[]): Promise<AdmitOutcome> {
+    let counted = false
+    for (;;) {
+      const now = clock.now()
+      let remaining = 0
+      let wait = 0
+      for (const b of buckets) {
+        remaining = Math.max(remaining, b.windowRemainingMs(now))
+        wait = Math.max(wait, b.msUntilAvailable(now))
+      }
+      if (remaining > criticalFailFastMs) return { result: 'failfast', untilTs: now + remaining }
+      if (wait <= 0) {
+        for (const b of buckets) b.consume(now)
+        return { result: 'ok' }
+      }
+      if (!counted) {
+        counters.queued++
+        counted = true
+      }
+      await clock.sleep(wait)
+    }
   }
 
   /**
@@ -767,11 +843,12 @@ export function createSendGate(config: SendGateConfig): SendGate {
 
   function handleEdit<T>(fn: () => Promise<T>, opts: SendGateOpts): Promise<T> {
     const messageId = opts.messageId as number
+    const key = messageKey(opts.chat_id, messageId)
     const hash = hashPayload(opts.editPayload)
     const now = clock.now()
-    const existing = perMessage.get(messageId)
+    const existing = perMessage.get(key)
     maybeEvict(now, existing === undefined)
-    const state = existing ?? messageState(messageId)
+    const state = existing ?? messageState(key)
 
     // Cosmetic edits (part3-design §2) shed under pressure — a flood window
     // covering the scope is open, or a bucket has no token free right now. A
@@ -843,8 +920,10 @@ export function createSendGate(config: SendGateConfig): SendGate {
       return handleEdit(fn, opts)
     }
 
-    // Priority-aware admission (part3-design §2/§3). Untagged → useful.
-    const priority = opts?.priorityClass ?? 'useful'
+    // Priority-aware admission (part3-design §2/§3). Untagged → critical
+    // (non-droppable — L2, review PR #3106); tag `useful`/`cosmetic` to opt into
+    // shedding.
+    const priority = opts?.priorityClass ?? UNTAGGED_SEND_CLASS
     const outcome = await admitPriority(bucketsFor(opts), priority)
     if (outcome.result === 'shed') {
       counters.shed++

--- a/telegram-plugin/tests/flood-windows-persistence.test.ts
+++ b/telegram-plugin/tests/flood-windows-persistence.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -11,6 +11,8 @@ import {
   floodStatePath,
   writeFloodState,
   computeFloodWait,
+  FLOOD_STATE_MODE,
+  FLOOD_WINDOWS_CORRUPT_SUPPRESS_MS,
 } from '../flood-circuit-breaker.js'
 import { createSendGate, type Clock } from '../send-gate.js'
 
@@ -125,6 +127,84 @@ describe('#3084 scoped flood-window persistence', () => {
     await expect(
       gate2.gate(async () => 'nope', { chat_id: '7', priorityClass: 'critical' }),
     ).rejects.toThrow('FLOOD_WAIT_ACTIVE')
+  })
+
+  it('H2: writes flood-windows.json world-READABLE (0o644), not 0o600', () => {
+    // A 0o600 marker is unreadable to a gateway running under a DIFFERENT uid
+    // (root vs agent uid share the state dir), which silently defeats the
+    // restart-proof windows — a restart under the other uid boots blind and
+    // resends into the ban. Must match `flood-wait.json` (FLOOD_STATE_MODE).
+    const path = floodWindowsPath(dir)
+    const now = 2_000_000
+    writeFloodWindow(path, { scopeKey: 'global', untilTs: now + 60_000, retryAfterSrc: '429', observedAt: now }, now)
+    expect(statSync(path).mode & 0o777).toBe(FLOOD_STATE_MODE)
+    expect(FLOOD_STATE_MODE).toBe(0o644)
+  })
+
+  it('M1: a CORRUPT flood-windows.json fails SAFE (conservative global window), not open', () => {
+    const path = floodWindowsPath(dir)
+    const now = 3_000_000
+    writeFileSync(path, '{ this is not valid json ][', 'utf-8')
+    const logs: string[] = []
+    const windows = readFloodWindows(path, now, (l) => logs.push(l))
+    // NOT [] (fail-open) — a bounded conservative global window instead.
+    expect(windows).toHaveLength(1)
+    expect(windows[0]!.scopeKey).toBe('global')
+    expect(windows[0]!.untilTs).toBe(now + FLOOD_WINDOWS_CORRUPT_SUPPRESS_MS)
+    // Logged loudly.
+    expect(logs.join('')).toMatch(/failing SAFE/)
+  })
+
+  it('M1: a non-array flood-windows.json fails SAFE', () => {
+    const path = floodWindowsPath(dir)
+    const now = 3_500_000
+    writeFileSync(path, '{"scopeKey":"global"}', 'utf-8') // object, not array
+    const windows = readFloodWindows(path, now, () => {})
+    expect(windows).toEqual([
+      {
+        scopeKey: 'global',
+        untilTs: now + FLOOD_WINDOWS_CORRUPT_SUPPRESS_MS,
+        retryAfterSrc: expect.stringContaining('failsafe'),
+        observedAt: now,
+      },
+    ])
+  })
+
+  it('M1: an UNREADABLE flood-windows.json (read error, not ENOENT) fails SAFE', () => {
+    // Root bypasses file-mode EACCES, so simulate a non-ENOENT read failure
+    // deterministically by making the windows path a DIRECTORY — readFileSync
+    // throws EISDIR, the same "file exists but I can't read it" class as EACCES.
+    const path = floodWindowsPath(dir)
+    const now = 4_000_000
+    mkdirSync(path)
+    const logs: string[] = []
+    const windows = readFloodWindows(path, now, (l) => logs.push(l))
+    expect(windows).toHaveLength(1)
+    expect(windows[0]!.scopeKey).toBe('global')
+    expect(windows[0]!.untilTs).toBe(now + FLOOD_WINDOWS_CORRUPT_SUPPRESS_MS)
+    expect(logs.join('')).toMatch(/unreadable/)
+  })
+
+  it('M1: a genuinely ABSENT file is still "no windows" (ENOENT ≠ corrupt)', () => {
+    const path = floodWindowsPath(dir) // never written
+    expect(readFloodWindows(path, 5_000_000, () => {})).toEqual([])
+  })
+
+  it('M3: flag-OFF gate opens NO window and writes NO flood-windows.json', () => {
+    // The gateway wires onFloodWait → openFloodWindow('global', …)
+    // unconditionally; with the flag OFF that must be a pure no-op — no in-memory
+    // suppression, no fs side effect (a poison-perms file created before the
+    // feature is ever enabled).
+    const path = floodWindowsPath(dir)
+    const recorder = makeFloodWindowRecorder(path, () => 0)
+    const clock: Clock = { now: () => 0, sleep: () => Promise.resolve() }
+    const gate = createSendGate({
+      enabled: false,
+      clock,
+      onWindowOpen: (scopeKey, untilTs) => recorder(scopeKey, untilTs),
+    })
+    gate.openFloodWindow('global', 600_000)
+    expect(existsSync(path)).toBe(false)
   })
 
   it('a boot loading initial windows never shortens an on-disk window', async () => {

--- a/telegram-plugin/tests/flood-windows-persistence.test.ts
+++ b/telegram-plugin/tests/flood-windows-persistence.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  readFloodWindows,
+  writeFloodWindow,
+  makeFloodWindowRecorder,
+  loadInitialFloodWindows,
+  floodWindowsPath,
+  floodStatePath,
+  writeFloodState,
+  computeFloodWait,
+} from '../flood-circuit-breaker.js'
+import { createSendGate, type Clock } from '../send-gate.js'
+
+/**
+ * #3084 PR 2 — restart-proof SCOPED flood windows (part3-design §7). Verifies
+ * the write-through/round-trip contract on real temp files (isolated per the
+ * repo's vault/shared-state test discipline) and that a gate reconstructed from
+ * disk is STILL blocked — the whole point of §7 (a boot mid-ban must not resend
+ * into the open window).
+ */
+describe('#3084 scoped flood-window persistence', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'flood-win-'))
+  })
+  afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('round-trips a scoped window and prunes expired entries', () => {
+    const path = floodWindowsPath(dir)
+    const now = 1_000_000
+    writeFloodWindow(path, { scopeKey: 'chat:5', untilTs: now + 60_000, retryAfterSrc: '429', observedAt: now }, now)
+    writeFloodWindow(path, { scopeKey: 'global', untilTs: now + 10_000, retryAfterSrc: '429', observedAt: now }, now)
+
+    // Before either expires: both present.
+    const live = readFloodWindows(path, now + 5_000)
+    expect(live.map((w) => w.scopeKey).sort()).toEqual(['chat:5', 'global'])
+
+    // After the global one expires: only chat:5 survives (prune-on-read).
+    const later = readFloodWindows(path, now + 20_000)
+    expect(later.map((w) => w.scopeKey)).toEqual(['chat:5'])
+  })
+
+  it('EXTENDS never shortens a window on a later, shorter re-record (boot-never-shortens)', () => {
+    const path = floodWindowsPath(dir)
+    const now = 1_000_000
+    // A long ban is recorded.
+    writeFloodWindow(path, { scopeKey: 'global', untilTs: now + 600_000, retryAfterSrc: '429', observedAt: now }, now)
+    // A later, SHORTER 429 (or a restart re-observing a smaller retry_after)
+    // must not pull the expiry earlier.
+    writeFloodWindow(
+      path,
+      { scopeKey: 'global', untilTs: now + 1_000 + 5_000, retryAfterSrc: '429', observedAt: now + 1_000 },
+      now + 1_000,
+    )
+    const w = readFloodWindows(path, now + 2_000).find((x) => x.scopeKey === 'global')
+    expect(w?.untilTs).toBe(now + 600_000)
+  })
+
+  it('loadInitialFloodWindows combines the global flood-wait.json window with scoped windows', () => {
+    const now = 1_000_000
+    const statePath = floodStatePath(dir)
+    const winPath = floodWindowsPath(dir)
+    writeFloodState(statePath, computeFloodWait(null, 300, now)) // global, +300s
+    writeFloodWindow(winPath, { scopeKey: 'chat:9', untilTs: now + 120_000, retryAfterSrc: '429', observedAt: now }, now)
+
+    const initial = loadInitialFloodWindows(statePath, winPath, now)
+    const scopes = initial.map((w) => w.scopeKey).sort()
+    expect(scopes).toEqual(['chat:9', 'global'])
+    expect(initial.find((w) => w.scopeKey === 'global')?.untilTs).toBe(now + 300_000)
+  })
+
+  it('gate opens a window on a 429 → persists → a NEW gate built from disk is still blocked', async () => {
+    const winPath = floodWindowsPath(dir)
+    const statePath = floodStatePath(dir)
+    const recorder = makeFloodWindowRecorder(winPath, () => 0)
+
+    // Gate 1: a critical send hits a 429 (FLOOD_WAIT_ACTIVE) which opens +
+    // persists scope windows via onWindowOpen.
+    const clock1: Clock = { now: () => 0, sleep: () => Promise.resolve() }
+    const gate1 = createSendGate({
+      enabled: true,
+      clock: clock1,
+      onWindowOpen: (scopeKey, untilTs) => recorder(scopeKey, untilTs),
+    })
+    const floodErr = Object.assign(new Error('FLOOD_WAIT_ACTIVE'), {
+      retryAfterSec: 600,
+      untilTs: 600_000,
+      error_code: 429 as const,
+      parameters: { retry_after: 600 },
+      original: null,
+    })
+    await expect(
+      gate1.gate(
+        async () => {
+          throw floodErr
+        },
+        { chat_id: '7', priorityClass: 'critical' },
+      ),
+    ).rejects.toBe(floodErr)
+
+    // The window is on disk.
+    const persisted = readFloodWindows(winPath, 0)
+    expect(persisted.map((w) => w.scopeKey).sort()).toEqual(['chat:7', 'global'])
+
+    // Gate 2 (simulated restart): built BEFORE any outbound call from the
+    // persisted windows. A cosmetic send on chat:7 must still shed.
+    const clock2: Clock = { now: () => 0, sleep: () => Promise.resolve() }
+    const gate2 = createSendGate({
+      enabled: true,
+      clock: clock2,
+      initialWindows: loadInitialFloodWindows(statePath, winPath, 0),
+    })
+    const res = await gate2.gate(async () => 'should-not-run', {
+      chat_id: '7',
+      priorityClass: 'cosmetic',
+    })
+    expect(res).toBeUndefined()
+    expect(gate2.stats().global.shed).toBe(1)
+
+    // And a critical into the still-long window fails fast — restart did not
+    // reset the ban.
+    await expect(
+      gate2.gate(async () => 'nope', { chat_id: '7', priorityClass: 'critical' }),
+    ).rejects.toThrow('FLOOD_WAIT_ACTIVE')
+  })
+
+  it('a boot loading initial windows never shortens an on-disk window', async () => {
+    const clock: Clock = { now: () => 0, sleep: () => Promise.resolve() }
+    // Boot with a long window applied at construction.
+    const gate = createSendGate({
+      enabled: true,
+      clock,
+      initialWindows: [{ scopeKey: 'global', untilTs: 600_000 }],
+    })
+    // Re-opening the SAME scope with a shorter untilTs must not shorten it.
+    gate.openFloodWindow('global', 10_000)
+    // A critical still fails fast against the ORIGINAL long window.
+    const e = await gate.gate(async () => 'x', { priorityClass: 'critical' }).catch((err) => err)
+    expect((e as { untilTs: number }).untilTs).toBe(600_000)
+  })
+})


### PR DESCRIPTION
## Summary

PR 2/3 of the Telegram flood-safety work (#3084): priority-class shedding,
degraded mode wired to the #2923 flood breaker, and restart-proof scoped flood
windows (part3-design.md §2/§3/§7). Feature-flagged, default-OFF
(`SWITCHROOM_TELEGRAM_SEND_GATE=1`).

Job spec: `reference/jobs/*` — keeps the agent *always available* (vision
outcome 4) by preventing the outbound path from earning a per-bot flood ban.

## Why

A busy turn fans out many outbound surfaces (reply chunks, answer/draft streams,
typing, worker-feed edits, cards). Per-surface throttles add up with no global
ceiling and can trip a per-bot 429 ban (retry_after ~hours). This PR sheds
low-value traffic under pressure, degrades gracefully on a 429, surfaces a
structured `FLOOD_WAIT_ACTIVE` on the reply path instead of an opaque block, and
persists open windows so a restart never resends into an open ban.

## Adversarial review — all findings resolved

Rebased onto fresh `origin/main` first (adopting main's flood-circuit-breaker
conventions: `FLOOD_STATE_MODE = 0o644`, `readFloodStateResult`). Per-finding:

- **H1 — cross-chat message_id collision (edit LOSS).** `perMessage` state and
  the `msg-edit:` suppression scope are now keyed by `${chat_id}:${messageId}`
  everywhere (state map, 1.5s edit floor, last-write-wins coalescing, no-op
  skip, per-message flood window). Telegram `message_id` is per-chat, not
  global — id-only keying let chat B's edit overwrite chat A's pending edit
  (silent loss, caller's promise resolved as "sent") and cross-shed unrelated
  cards. Regression test: two chats sharing `message_id 100`, edits do not
  collide (all send, none dropped), no cross-chat floor or suppression bleed.
- **H2 — flood-windows.json written 0o600 (cross-uid fail-open).** Now written
  `0o644` (`FLOOD_STATE_MODE`) with a `chmod` self-heal after the atomic rename,
  matching the sibling `flood-wait.json` fix main just landed. A 0600 marker is
  unreadable to a gateway running under a different uid (root vs agent uid share
  the state dir) — it silently defeats the restart-proof windows. Regression
  test asserts the file mode.
- **M1 — corrupt/unreadable flood-windows.json failed OPEN.** `readFloodWindows`
  now fails SAFE: only a genuinely ABSENT file (ENOENT) is "no windows"; a
  corrupt / non-array / unreadable (non-ENOENT read error) file opens a
  conservative 5-min global window (`FLOOD_WINDOWS_CORRUPT_SUPPRESS_MS`) and logs
  loudly, rather than returning `[]` and booting into a possible open ban.
  Regression tests: corrupt JSON, non-array, unreadable (EISDIR-simulated read
  failure), and the ABSENT-is-still-empty case.
- **M2 — critical fail-fast evaluated once.** The critical wait now runs through
  `admitCriticalLoop`, which re-evaluates the covering window on every
  iteration. If a competing 429 extends the window past the fail-fast ceiling
  while a critical is waiting out a short window, it converts to a structured
  `FLOOD_WAIT_ACTIVE` (with `untilTs`) instead of blocking the reply path
  unbounded. Regression test: window extended mid-wait → structured error, not a
  hang.
- **M3 — flag-off was not a pure passthrough.** `openFloodWindow` is now guarded
  on the `enabled` flag, so with the flag OFF a 429 (wired via the gateway's
  `onFloodWait`) opens no in-memory window and writes no `flood-windows.json` —
  no poison-perms file created before the feature is ever enabled. The separate
  #2923 `flood-wait.json` recorder is unchanged. Regression test: flag off +
  `openFloodWindow` → no file written.
- **LOW L2 — untagged default was droppable.** Untagged NON-EDIT sends now
  default to `critical` (`UNTAGGED_SEND_CLASS`) — non-droppable (queued, never
  TTL-shed) — instead of `useful`. Conservative posture: nothing important is
  silently dropped for lack of a tag; a call site must OPT IN to shedding by
  tagging `useful`/`cosmetic`. Untagged edits already coalesce (non-droppable).
- **N2 — msg-edit window eviction accounting.** The per-message state created by
  the `msg-edit:` window path goes through the same `maybeEvict` / LRU
  accounting as normal edit-state creation; carried through the H1 rekey.

### Acknowledged follow-ups (out of scope for this PR)

- **L1 — global over-suppression.** `openScopedWindowsForOpts` always opens the
  `global` window, so a single chat/message 429 fails-fast criticals across all
  chats. Usually fine (429s are per-bot-token) but aggressive; a future PR can
  scope this more finely.
- **L3 — draft-stream edit path.** `stream-controller.ts` still uses its
  per-surface throttle, so its rapid same-message edits are not yet under the
  per-message floor during a flood. Wiring it in is deferred to a follow-up
  (top ban trigger remains partially unmitigated for that surface).

## Test plan

Scoped vitest (all green): `send-gate.test.ts` (27), `send-gate-degraded.test.ts`
(16), `flood-windows-persistence.test.ts` (11), `flood-circuit-breaker.test.ts`
(6), `retry-api-call.test.ts` (54), `flood-breaker-blindness.test.ts` (9) = 120
pass / 3 skipped. `npm run lint`: clean. CI is the full-suite authority.

## Risk

All new code is flag-OFF-dormant (`SWITCHROOM_TELEGRAM_SEND_GATE` default off),
so production blast radius today is zero. H1/H2/M1/M2/M3 are the correctness
fixes required before the flag is ever enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
