### PR TITLE
fix(telegram): record undeliverable permission cards instead of discarding the error

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -29,7 +29,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, lstatSync, readlinkSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, lstatSync, readlinkSync, chmodSync } from "node:fs";
 import { join, isAbsolute, dirname, resolve } from "node:path";
 import type { SwitchroomConfig, AgentConfig, AgentBindMount } from "../config/schema.js";
 import { isValidTimezone } from "../config/schema.js";
@@ -2441,6 +2441,15 @@ function emitAgentService(
   lines.push(`      - ${homePrefix}/.switchroom/agents/${a.name}:/state/agent`);
   lines.push(`      - ${homePrefix}/.claude/projects/${a.name}:/state/.claude`);
   lines.push(`      - ${homePrefix}/.switchroom/logs/${a.name}:/var/log/switchroom`);
+  // Blocked-approval surface (#3084 follow-up). When a permission card can't be
+  // delivered (Telegram flood ban), the gateway HOLDS the approval — it never
+  // auto-denies — and writes a world-readable record here so the operator can
+  // see, off-Telegram, that an agent is blocked and until when. This is a
+  // SHARED top-level dir (not per-agent /state/agent) because switchroom-web
+  // reads every agent's record from one place; the file is 0644 so web's
+  // uid-1000 process can actually read it (agent state files are 0600 and are
+  // not readable by web — verified on the live box).
+  lines.push(`      - ${homePrefix}/.switchroom/blocked-approvals:/state/blocked-approvals:rw`);
   lines.push(`      - ${homePrefix}/.switchroom/agents/${a.name}:${homePrefix}/.switchroom/agents/${a.name}`);
   lines.push(`      - ${homePrefix}/.claude/projects/${a.name}:${homePrefix}/.claude/projects/${a.name}`);
   // Shared read-only `skills/` bind mount (#907). Cron yaml prompts
@@ -2542,6 +2551,20 @@ function emitAgentService(
   // operator's umask sidesteps that).
   try {
     mkdirSync(`${probeHome}/.switchroom/audit/${a.name}`, { recursive: true });
+  } catch { /* best-effort */ }
+  // Same trap, shared dir (#3084 follow-up): the blocked-approval surface is
+  // ONE directory written by EVERY agent, and agents run as per-agent non-root
+  // uids (AGENT_UID_MIN = 10001). If docker auto-creates this bind source it is
+  // root:root 0755 and every agent's write EACCESes — the surface that tells
+  // the operator an agent is blocked would be silently empty.
+  //
+  // Pre-create it sticky-world-writable (1777, the /tmp model): each agent
+  // creates and owns its own 0644 <agent>.json, so no agent can modify or
+  // delete another's. mkdirSync's `mode` is masked by umask, so chmod explicitly.
+  try {
+    const blockedDir = `${probeHome}/.switchroom/blocked-approvals`;
+    mkdirSync(blockedDir, { recursive: true });
+    chmodSync(blockedDir, 0o1777);
   } catch { /* best-effort */ }
   // Phase B (switchroom #1163): pre-create the per-agent overlay
   // directory so the agent-config write tools (Phase C) have a writable

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.16.49";
-export const COMMIT_SHA: string | null = "de33dcbf";
-export const COMMIT_DATE: string | null = "2026-07-05T09:57:29+10:00";
-export const LATEST_PR: number | null = 2782;
-export const COMMITS_AHEAD_OF_TAG: number | null = 0;
+export const VERSION: string = "0.18.0";
+export const COMMIT_SHA: string | null = "5584bf20";
+export const COMMIT_DATE: string | null = "2026-07-11T19:02:16+10:00";
+export const LATEST_PR: number | null = 3097;
+export const COMMITS_AHEAD_OF_TAG: number | null = 42;

--- a/telegram-plugin/gateway/approval-hold.ts
+++ b/telegram-plugin/gateway/approval-hold.ts
@@ -1,0 +1,413 @@
+/**
+ * #3084 follow-up — HOLD an undeliverable approval; never convert it into a
+ * silent denial.
+ *
+ * The incident (overlord, 2026-07-11): Telegram flood-banned the bot token for
+ * 4.6h. A Claude Code permission prompt fired during the ban. The gateway built
+ * the card, the send failed, and the error was written to stderr and dropped on
+ * the floor. Three things then went wrong at once:
+ *
+ *   1. `pendingPermissions` kept the entry with `cards: []` — no card had
+ *      landed, so there was nothing for the operator to tap and no record that
+ *      anything was waiting.
+ *   2. 60 minutes later the TTL sweep fired and AUTO-DENIED the request,
+ *      telling the agent the operator had declined. No human ever saw the ask.
+ *   3. The #2862 missed-approval re-offer is anchored on `v.cards[0]` — the
+ *      card's landed origin. With `cards: []` that is `undefined`, so the
+ *      re-offer was skipped. The request was auto-denied AND erased from the
+ *      only record that would have brought it back.
+ *
+ * Net: an undeliverable approval became a silent denial and then vanished. That
+ * is a `no-self-escalation` / `on-leash` breach — the leash decided for the
+ * operator, in their absence, and told the agent a human had spoken.
+ *
+ * The operator's call (Ken, explicit): **hold, and make the block visible.
+ * Never auto-approve. Never auto-deny — not even on a deadline.** The agent
+ * stays blocked, the ask is held, and it is re-delivered when the channel comes
+ * back. An indefinite block is the correct behaviour; a fabricated verdict is
+ * not.
+ *
+ * This module owns the three decisions that implement that, kept out of
+ * gateway.ts so they are unit-testable (gateway.ts has top-level side effects
+ * and is not importable from a test — see `tests/permission-card-routing.ts`):
+ *
+ *   - `createBlockedApprovalStore` — the durable, world-readable record of what
+ *     is blocked and why (PR 1).
+ *   - `selectHeldForRedelivery`   — which held cards to re-post when the flood
+ *     window closes, capped so a backlog can't burst (PR 2).
+ *   - `isHeldUndeliverable`       — the TTL freeze predicate (PR 3).
+ *
+ * @see reference/jobs/approve-what-my-agent-can-touch.md
+ * @see reference/invariants.md § no-self-escalation, § on-leash
+ */
+
+import { mkdirSync, writeFileSync, readFileSync, unlinkSync, chmodSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+
+/**
+ * File mode 0644 — WORLD-READABLE, and that is load-bearing, not incidental.
+ *
+ * `switchroom-web` runs as uid 1000 and cannot read the agent's telegram state
+ * files, which are 0600 (`permission-card-store.ts:63` writes
+ * `pending-perm-cards.json` at 0o600 — verified unreadable on the live box:
+ * `docker exec switchroom-web cat …/pending-perm-cards.json` → Permission
+ * denied). A 0600 blocked-approval record renders a silently EMPTY dashboard —
+ * the exact shape of the Hermes `registry.db` bug. `fleet-health/ledger.json`
+ * is world-readable for the same reason; this follows that precedent.
+ *
+ * The safety consequence of world-readable is absolute and enforced by
+ * `assertNoRawInput` below: this file carries METADATA ONLY. No `inputPreview`,
+ * no raw tool input, no `card_text`, ever. A raw credential surviving in a
+ * world-readable file is the failure this job spec names by name.
+ */
+export const BLOCKED_APPROVAL_FILE_MODE = 0o644
+
+/**
+ * The SHARED dir is sticky-world-writable (1777), the /tmp model — and it has
+ * to be, or the feature is a silent no-op in production.
+ *
+ * Agents run as per-agent non-root uids (`AGENT_UID_MIN = 10001`,
+ * `compose.ts:95`). A shared dir owned by the operator (or auto-created
+ * `root:root` by Docker, which is what happens to any bind source that doesn't
+ * exist — `compose.ts` calls this out by name: "docker auto-creates as root,
+ * which then traps the agent uid out of writing") is NOT writable by uid 10001.
+ * The write would EACCES into the best-effort catch below and the record would
+ * never appear. The one surface telling the operator an agent is blocked would
+ * be silently empty — the Hermes `registry.db` bug, on the write side.
+ *
+ * Sticky (`0o1000`) is what makes world-writable safe: each agent creates and
+ * owns its own 0644 `<agent>.json`, so no agent can MODIFY another's record,
+ * and the sticky bit means no agent can DELETE another's either. Same guarantee
+ * /tmp gives. Cross-agent forgery of a *new* record is out of threat model by
+ * the `single-tenant` invariant — every agent the operator wires in is
+ * implicitly trusted; this is not an authorization boundary between mutually
+ * distrusting parties.
+ */
+export const BLOCKED_APPROVAL_DIR_MODE = 0o1777
+
+/** Why a card could not be delivered. Only one cause today. */
+export type UndeliverableReason = 'flood_wait'
+
+/**
+ * Stamped onto the in-memory `pendingPermissions` entry when the card send
+ * fails against a known-open flood window. Its presence is what freezes the TTL
+ * (PR 3) and what makes the entry eligible for re-delivery (PR 2).
+ */
+export interface UndeliverableMark {
+  /** When we first failed to deliver this card. */
+  since: number
+  /** Telegram's `untilTs` for the open flood window — when a retry may land. */
+  retryableAt: number
+  reason: UndeliverableReason
+}
+
+/**
+ * The shared, world-readable blocked-approval record. Schema is a contract with
+ * the switchroom-web reader — do not change field names or add fields carrying
+ * tool input.
+ */
+export interface BlockedApprovalRecord {
+  agent: string
+  requestId: string
+  toolName: string
+  /**
+   * `naturalAction()` text ONLY — e.g. "edit: supplement-log.md". A short
+   * human sentence describing the ask. NEVER the raw `inputPreview`.
+   */
+  action: string
+  /** When the agent first blocked on this approval. */
+  blockedSince: number
+  /** When we first failed to deliver the card. */
+  undeliverableSince: number
+  /** When the channel is expected back (the flood window's `untilTs`). */
+  retryableAt: number
+  reason: UndeliverableReason
+}
+
+/** Fields that must never appear in a world-readable record. */
+const FORBIDDEN_FIELDS = ['inputPreview', 'input_preview', 'cardText', 'card_text', 'description']
+
+/**
+ * Fail loudly if a caller ever tries to widen the record with raw tool input.
+ * `check-no-pii-secrets` cannot see a runtime object, so the guard lives here:
+ * this file is 0644 and arbitrary tool input in it is a credential leak.
+ */
+function assertNoRawInput(rec: BlockedApprovalRecord): void {
+  for (const f of FORBIDDEN_FIELDS) {
+    if (f in (rec as unknown as Record<string, unknown>)) {
+      throw new Error(
+        `blocked-approval record must not carry raw tool input (field "${f}"): ` +
+        `the record is world-readable (0644) so switchroom-web can read it`,
+      )
+    }
+  }
+}
+
+/**
+ * Tools whose `naturalAction()` text is SAFE to put in a world-readable file.
+ *
+ * This list is short on purpose, and it is an allowlist (fail-closed) rather
+ * than a denylist. `naturalAction` is not uniformly safe:
+ *
+ *     naturalAction('Edit', …)  →  "edit: notes.md"                    ← a basename
+ *     naturalAction('Bash', …)  →  "run: curl -H 'Authorization: Bearer sk-…"  ← THE RAW COMMAND
+ *
+ * For `Bash` it interpolates the raw command; for `Glob`/`Grep` the raw
+ * pattern; for `WebFetch` the raw URL (which routinely carries a token in its
+ * query string); for `mcp__*` arbitrary tool args. Writing any of those into a
+ * 0644 file is exactly the "raw credential surviving in a world-readable place"
+ * failure the job spec names.
+ *
+ * The tools below derive their text from a FILE BASENAME (or a skill name from
+ * a fixed registry), which is safe to surface and is what makes the record
+ * useful — "edit: supplement-log.md" tells the operator what is blocked.
+ * Everything else falls back to the INPUT-FREE phrasing
+ * (`naturalAction(tool, undefined)` → "run shell commands", "search files",
+ * "send (Brevo)"), which is still a human sentence but structurally cannot
+ * contain tool input.
+ */
+const ACTION_SAFE_WITH_INPUT = new Set([
+  'Edit',
+  'MultiEdit',
+  'NotebookEdit',
+  'Write',
+  'Read',
+  'Skill',
+])
+
+/**
+ * The `action` string for the world-readable record.
+ *
+ * `naturalAction` is the right VOICE for this field, but it is only
+ * input-safe for some tools — see `ACTION_SAFE_WITH_INPUT`. Unknown and MCP
+ * tools fail CLOSED to the input-free phrasing.
+ *
+ * @param naturalAction the real `permission-title.ts` helper, injected so this
+ *        module stays free of a gateway import cycle and stays unit-testable.
+ */
+export function safeActionForRecord(
+  naturalAction: (toolName: string, inputPreview: string | undefined) => string,
+  toolName: string,
+  inputPreview: string | undefined,
+): string {
+  return ACTION_SAFE_WITH_INPUT.has(toolName)
+    ? naturalAction(toolName, inputPreview)
+    : naturalAction(toolName, undefined)
+}
+
+export interface BlockedApprovalStore {
+  /** Write (or replace) the blocked record for this agent. */
+  write(rec: BlockedApprovalRecord): void
+  /** Clear the record — the approval was delivered, resolved, or cancelled. */
+  clear(): void
+  /** Read the current record, or null when nothing is blocked. */
+  read(): BlockedApprovalRecord | null
+  /** Absolute path of the backing file (for logs and tests). */
+  path: string
+}
+
+/** `<stateRoot>/blocked-approvals` — the shared directory switchroom-web reads. */
+export function blockedApprovalsDir(stateRoot: string): string {
+  return join(stateRoot, 'blocked-approvals')
+}
+
+/**
+ * One file per agent: `<dir>/<agent>.json`. Single-record, not a list — an
+ * agent blocks on ONE permission at a time (the claude turn is suspended inside
+ * the MCP permission call), so there is exactly one thing to surface.
+ *
+ * Every write is best-effort: a failure to write the SURFACE must never take
+ * down the gateway or, worse, fall back to the auto-deny the whole change
+ * exists to remove. It logs and moves on.
+ */
+export function createBlockedApprovalStore(
+  dir: string,
+  agent: string,
+  /**
+   * Where to write when the shared dir isn't usable — the agent's OWN state dir
+   * (`/state/agent`, host `~/.switchroom/agents/<name>/`), which the scaffold
+   * chowns to the agent uid, so a write there always succeeds.
+   *
+   * This exists so the feature cannot silently no-op. If the shared bind is
+   * missing (a container predating the volume), or auto-created root-owned, the
+   * record still lands somewhere the operator and switchroom-web can read —
+   * web mounts all of `~/.switchroom`, so both locations are reachable.
+   */
+  fallbackDir?: string,
+): BlockedApprovalStore {
+  const primary = join(dir, `${agent}.json`)
+  const fallback = fallbackDir != null ? join(fallbackDir, 'blocked-approval.json') : null
+
+  /** Where the last successful write landed — `read`/`clear` must agree with it. */
+  let active = primary
+
+  function tryWrite(target: string, body: string, dirMode?: number): boolean {
+    const parent = dirname(target)
+    try {
+      mkdirSync(parent, { recursive: true })
+      // The `mode` args to mkdirSync/writeFileSync are MASKED by the process
+      // umask (and ignored outright for an existing dir), so passing them
+      // guarantees nothing. Both modes are load-bearing — the shared dir must be
+      // writable by every agent uid, the file readable by switchroom-web — so
+      // set them explicitly. The dir chmod is best-effort: we may not own it,
+      // which is fine, because the write below is the real test of whether this
+      // location works at all.
+      if (dirMode != null) {
+        try { chmodSync(parent, dirMode) } catch { /* not ours to chmod */ }
+      }
+      writeFileSync(target, body, { encoding: 'utf-8', mode: BLOCKED_APPROVAL_FILE_MODE })
+      chmodSync(target, BLOCKED_APPROVAL_FILE_MODE)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  return {
+    get path() { return active },
+
+    write(rec) {
+      assertNoRawInput(rec)
+      const body = JSON.stringify(rec)
+
+      if (tryWrite(primary, body, BLOCKED_APPROVAL_DIR_MODE)) {
+        active = primary
+        return
+      }
+      // The shared dir refused us — almost always because it was auto-created
+      // root-owned and we are a per-agent uid. Fall back to the agent's own
+      // state dir rather than losing the record, and say so LOUDLY: a
+      // half-visible leash surface is worth a noisy log line.
+      if (fallback != null && tryWrite(fallback, body)) {
+        active = fallback
+        process.stderr.write(
+          `telegram gateway: blocked-approval write to ${primary} failed ` +
+          `(shared dir not writable by this agent uid?) — wrote ${fallback} instead. ` +
+          `The hold is intact; the shared surface may be missing this agent.\n`,
+        )
+        return
+      }
+      process.stderr.write(
+        `telegram gateway: blocked-approval write FAILED at ${primary}` +
+        (fallback != null ? ` and ${fallback}` : '') +
+        ` — the agent is HELD but the off-Telegram surface is blind. ` +
+        `The hold itself is unaffected (the approval is never auto-denied).\n`,
+      )
+    },
+
+    clear() {
+      // Clear BOTH: an earlier write may have landed in the fallback.
+      for (const p of [primary, fallback]) {
+        if (p == null) continue
+        try {
+          unlinkSync(p)
+        } catch {
+          // Absent is the normal case — nothing was blocked.
+        }
+      }
+      active = primary
+    },
+
+    read() {
+      for (const p of [primary, fallback]) {
+        if (p == null) continue
+        try {
+          const parsed = JSON.parse(readFileSync(p, 'utf-8'))
+          if (parsed != null && typeof parsed === 'object') return parsed as BlockedApprovalRecord
+        } catch {
+          // try the next location
+        }
+      }
+      return null
+    },
+  }
+}
+
+/**
+ * The TTL freeze predicate (PR 3).
+ *
+ * An entry marked undeliverable NEVER expires. The TTL answers "how long did
+ * the operator have to respond?" — and for a card that never landed, the answer
+ * is zero seconds. Letting a clock the operator was never shown run out, and
+ * then reporting the silence to the agent as a denial, is the bug.
+ */
+export function isHeldUndeliverable(
+  pend: { undeliverable?: UndeliverableMark | null },
+): boolean {
+  return pend.undeliverable != null
+}
+
+/**
+ * Per-tick re-delivery cap (PR 2).
+ *
+ * A backlog of held cards must not BURST the instant the window closes — that
+ * burst is the one realistic way this design could re-earn the very ban it
+ * exists to survive. Three per 60s tick drains any plausible backlog quickly
+ * while staying far under Telegram's rate ceiling.
+ */
+export const HELD_CARD_REDELIVERY_CAP = 3
+
+export interface HeldPermissionEntry {
+  undeliverable?: UndeliverableMark | null
+  /** Cards that actually landed. A held entry has none — that is the point. */
+  cards: unknown[]
+}
+
+export interface RedeliverySelection {
+  /** Request ids to re-post on this tick. */
+  send: string[]
+  /** Held ids the cap deferred to a later tick. Logged, never silently dropped. */
+  deferred: string[]
+}
+
+/**
+ * Choose which held cards to re-post on this reaper tick.
+ *
+ * Guards, all of which must hold before a single request goes out:
+ *
+ *   (i)   the flood window is CLOSED — `floodRemainingMs === 0`. Strictly
+ *         stronger than `robustApiCall`'s own short-circuit, which only refuses
+ *         windows longer than its sleep ceiling.
+ *   (ii)  the entry is marked undeliverable AND has no landed card
+ *         (`cards.length === 0`). This is the double-delivery guard: the bridge
+ *         re-sends unresolved requests on IPC reconnect
+ *         (`bridge/permission-ledger.ts`), so a card may already be live.
+ *   (iii) the request is not already in flight from a previous tick.
+ *   (iv)  the per-tick cap.
+ *
+ * `robustApiCall`'s independent pre-call probe is the fifth guard, and it sits
+ * downstream of this function — if the window re-opens between selection and
+ * send, the send still refuses itself.
+ */
+export function selectHeldForRedelivery(
+  entries: Iterable<readonly [string, HeldPermissionEntry]>,
+  opts: {
+    floodRemainingMs: number
+    inFlight: ReadonlySet<string>
+    cap?: number
+  },
+): RedeliverySelection {
+  const empty: RedeliverySelection = { send: [], deferred: [] }
+  // Guard (i) — the window is still open. Send nothing at all.
+  if (opts.floodRemainingMs > 0) return empty
+
+  const cap = opts.cap ?? HELD_CARD_REDELIVERY_CAP
+  const send: string[] = []
+  const deferred: string[] = []
+
+  for (const [requestId, pend] of entries) {
+    // Guard (ii) — held, and nothing landed for it yet.
+    if (!isHeldUndeliverable(pend)) continue
+    if (pend.cards.length > 0) continue
+    // Guard (iii) — a previous tick is still posting this one.
+    if (opts.inFlight.has(requestId)) continue
+    // Guard (iv) — cap. Everything past it is DEFERRED, not dropped.
+    if (send.length >= cap) {
+      deferred.push(requestId)
+      continue
+    }
+    send.push(requestId)
+  }
+
+  return { send, deferred }
+}

--- a/telegram-plugin/gateway/approval-hold.ts
+++ b/telegram-plugin/gateway/approval-hold.ts
@@ -41,7 +41,7 @@
  * @see reference/invariants.md § no-self-escalation, § on-leash
  */
 
-import { mkdirSync, writeFileSync, readFileSync, unlinkSync, chmodSync } from 'node:fs'
+import { mkdirSync, writeFileSync, readFileSync, unlinkSync, chmodSync, lstatSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 
 /**
@@ -245,6 +245,18 @@ export function createBlockedApprovalStore(
     const parent = dirname(target)
     try {
       mkdirSync(parent, { recursive: true })
+      // Symlink-planting guard. The shared dir is 1777 (the /tmp model), so
+      // any local uid can pre-create `<agent>.json` as a symlink pointing at a
+      // file the AGENT uid can write (its own state, a config file). Writing
+      // through it would let a planter redirect our 0644 write onto an
+      // arbitrary target. lstat (never follows) and refuse: the sticky bit
+      // stops us unlinking a symlink we don't own, so the safe move is to
+      // treat this location as unusable and fall back.
+      try {
+        if (lstatSync(target).isSymbolicLink()) return false
+      } catch {
+        // ENOENT — no file yet, the normal case.
+      }
       // The `mode` args to mkdirSync/writeFileSync are MASKED by the process
       // umask (and ignored outright for an existing dir), so passing them
       // guarantees nothing. Both modes are load-bearing — the shared dir must be
@@ -272,6 +284,13 @@ export function createBlockedApprovalStore(
 
       if (tryWrite(primary, body, BLOCKED_APPROVAL_DIR_MODE)) {
         active = primary
+        // Best-effort removal of a stale FALLBACK record: an earlier write may
+        // have landed there while the shared dir was unusable. Once the shared
+        // surface works, a leftover fallback file would make a recovered host
+        // double-report the block (web reads both locations).
+        if (fallback != null) {
+          try { unlinkSync(fallback) } catch { /* absent is the normal case */ }
+        }
         return
       }
       // The shared dir refused us — almost always because it was auto-created
@@ -321,6 +340,34 @@ export function createBlockedApprovalStore(
       return null
     },
   }
+}
+
+/**
+ * Which held entry the blocked-approval surface should show — the RECONCILE
+ * selection, extracted from gateway.ts's `reconcileBlockedApprovals()` so it is
+ * unit-testable (gateway.ts has top-level side effects and cannot be imported
+ * from a test).
+ *
+ * The rules, both load-bearing:
+ *
+ *   - **Oldest hold wins.** The store holds ONE record per agent, but an agent
+ *     can hold several permissions at once (parallel tool calls). The one that
+ *     has been waiting longest (smallest `undeliverable.since`) is the record.
+ *   - **Reconcile, not clear.** Returning `null` — meaning the caller should
+ *     `clear()` — happens ONLY when no entry is held at all. Resolving one of
+ *     several holds must surface the next-oldest, never blank the file while a
+ *     real block remains.
+ */
+export function selectOldestHeld<T extends { undeliverable?: UndeliverableMark | null }>(
+  entries: Iterable<readonly [string, T]>,
+): { requestId: string; pend: T; mark: UndeliverableMark } | null {
+  let oldest: { requestId: string; pend: T; mark: UndeliverableMark } | null = null
+  for (const [requestId, pend] of entries) {
+    const u = pend.undeliverable
+    if (u == null) continue
+    if (oldest == null || u.since < oldest.mark.since) oldest = { requestId, pend, mark: u }
+  }
+  return oldest
 }
 
 /**

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -171,6 +171,7 @@ import { pickRecoveredPermissionOrigin } from './permission-card-origin.js'
 import {
   createBlockedApprovalStore,
   safeActionForRecord,
+  selectOldestHeld,
   type UndeliverableMark,
 } from './approval-hold.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
@@ -874,18 +875,13 @@ const blockedApprovalStore = createBlockedApprovalStore(
  * re-marks them if the channel is still shut.
  */
 function reconcileBlockedApprovals(): void {
-  type Pend = NonNullable<ReturnType<typeof pendingPermissions.get>>
-  let oldest: { requestId: string; pend: Pend; since: number } | null = null
-  for (const [requestId, pend] of pendingPermissions) {
-    const u = pend.undeliverable
-    if (u == null) continue
-    if (oldest == null || u.since < oldest.since) oldest = { requestId, pend, since: u.since }
-  }
+  // Selection (oldest hold wins; null ⇒ nothing held) is the pure, unit-tested
+  // `selectOldestHeld` in approval-hold.ts — keep policy out of gateway.ts.
+  const oldest = selectOldestHeld(pendingPermissions)
   if (oldest == null) {
     blockedApprovalStore.clear()
     return
   }
-  const u = oldest.pend.undeliverable!
   blockedApprovalStore.write({
     agent: AGENT_NAME,
     requestId: oldest.requestId,
@@ -894,9 +890,9 @@ function reconcileBlockedApprovals(): void {
     // interpolates the RAW tool input, and this file is world-readable.
     action: safeActionForRecord(naturalAction, oldest.pend.tool_name, oldest.pend.input_preview),
     blockedSince: oldest.pend.startedAt,
-    undeliverableSince: u.since,
-    retryableAt: u.retryableAt,
-    reason: u.reason,
+    undeliverableSince: oldest.mark.since,
+    retryableAt: oldest.mark.retryableAt,
+    reason: oldest.mark.reason,
   })
 }
 // Durable store for the four AGENT-INITIATED approval-card families
@@ -10282,11 +10278,25 @@ const ipcServer: IpcServer = createIpcServer({
         if (!isFloodWaitActiveError(e)) return
         const pend = pendingPermissions.get(requestId)
         if (pend == null) return // operator already resolved it — nothing to hold
+        // A card may already have LANDED on another target (the send fans out
+        // to several chats/topics and only THIS one hit the flood wall). The
+        // operator can see and tap the landed card, so the request is not
+        // blocked — marking it here would write a false blocked record AND
+        // make it eligible for a duplicate re-delivery. Same guard the
+        // redelivery selector applies (guard ii in selectHeldForRedelivery).
+        if (pend.cards.length > 0) return
         const now = Date.now()
         // Re-marking is idempotent and self-correcting: if the window is
         // re-extended by a fresh 429, `computeFloodWait` only ever grows
-        // `untilTs`, so a later mark carries the longer window.
-        pend.undeliverable = { since: now, retryableAt: e.untilTs, reason: 'flood_wait' }
+        // `untilTs`, so a later mark carries the longer window. `since` is
+        // "when we FIRST failed" (the UndeliverableMark contract), so a
+        // re-failure preserves the original timestamp — resetting it would
+        // churn the oldest-held-wins reconcile between records.
+        pend.undeliverable = {
+          since: pend.undeliverable?.since ?? now,
+          retryableAt: e.untilTs,
+          reason: 'flood_wait',
+        }
         // Write the shared surface SYNCHRONOUSLY, here in the failure handler —
         // not on the 60s reaper tick. The operator is locked out of Telegram;
         // the off-Telegram surface is the only way they learn an agent is

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -168,6 +168,11 @@ import {
   buildMissedApprovalRetryInbound,
 } from './missed-approvals-card.js'
 import { pickRecoveredPermissionOrigin } from './permission-card-origin.js'
+import {
+  createBlockedApprovalStore,
+  safeActionForRecord,
+  type UndeliverableMark,
+} from './approval-hold.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { appendActivityLabel, clipNarrative, renderActivityFeedWithNested, formatStepSuffix, type SessionActivityHeader } from '../tool-activity-summary.js'
 import { formatModelLabel } from '../model-label.js'
@@ -826,6 +831,74 @@ process.on('beforeExit', () => {
 // ─── Env + state dir ──────────────────────────────────────────────────────
 const STATE_DIR = process.env.TELEGRAM_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'telegram')
 const permCardStore = createPermissionCardStore(STATE_DIR)
+// #3084 follow-up — the blocked-approval surface. A SHARED top-level directory
+// (compose binds host `~/.switchroom/blocked-approvals` here), not per-agent
+// state: switchroom-web reads every agent's record from one place, and the
+// records are 0644 so its uid-1000 process can actually read them. The agent's
+// own telegram state is 0600 and is NOT web-readable.
+// If the mount is missing (a container predating the volume), the write lands
+// inside the container and the hold still works — only the off-Telegram
+// SURFACE is lost. The record is best-effort by construction; it must never be
+// able to fail the hold back into an auto-deny.
+const BLOCKED_APPROVALS_DIR =
+  process.env.SWITCHROOM_BLOCKED_APPROVALS_DIR ?? '/state/blocked-approvals'
+// The canonical "which agent am I" identity (profiles/_base/start.sh.hbs:430).
+const AGENT_NAME = process.env.SWITCHROOM_AGENT_NAME ?? 'agent'
+const blockedApprovalStore = createBlockedApprovalStore(
+  BLOCKED_APPROVALS_DIR,
+  AGENT_NAME,
+  // Fallback: the agent's OWN state dir, which the scaffold chowns to the agent
+  // uid, so a write there always succeeds. Guarantees the record can never be
+  // silently lost when the shared dir isn't writable by this agent's uid.
+  process.env.SWITCHROOM_AGENT_STATE_DIR ?? '/state/agent',
+)
+
+/**
+ * Rewrite the blocked-approval surface from the LIVE pending state.
+ *
+ * A reconcile, not a delete — deliberately. The store holds one record per
+ * agent, but an agent can hold SEVERAL permissions at once: Claude Code issues
+ * parallel tool calls, each hitting `canUseTool`, and
+ * `cancelPendingPermissionsForHalt` iterates multiple pendings. A naive
+ * `clear()` on any single resolution would delete the file while ANOTHER
+ * request was still held, blinding the operator to a real, live block.
+ *
+ * So derive the record from whatever is still held. Oldest block wins — it has
+ * been waiting longest. Nothing held → clear.
+ *
+ * Also called at BOOT. `pendingPermissions` is in-memory and empty on a fresh
+ * process, so this clears any record orphaned by a restart mid-hold — otherwise
+ * the dashboard would show a permanently blocked agent forever. Nothing can
+ * legitimately be held across a restart: the bridge re-sends unresolved requests
+ * on IPC reconnect (`bridge/permission-ledger.ts`), which re-raises them and
+ * re-marks them if the channel is still shut.
+ */
+function reconcileBlockedApprovals(): void {
+  type Pend = NonNullable<ReturnType<typeof pendingPermissions.get>>
+  let oldest: { requestId: string; pend: Pend; since: number } | null = null
+  for (const [requestId, pend] of pendingPermissions) {
+    const u = pend.undeliverable
+    if (u == null) continue
+    if (oldest == null || u.since < oldest.since) oldest = { requestId, pend, since: u.since }
+  }
+  if (oldest == null) {
+    blockedApprovalStore.clear()
+    return
+  }
+  const u = oldest.pend.undeliverable!
+  blockedApprovalStore.write({
+    agent: AGENT_NAME,
+    requestId: oldest.requestId,
+    toolName: oldest.pend.tool_name,
+    // NOT bare naturalAction(): for Bash/Glob/Grep/WebFetch/mcp__* it
+    // interpolates the RAW tool input, and this file is world-readable.
+    action: safeActionForRecord(naturalAction, oldest.pend.tool_name, oldest.pend.input_preview),
+    blockedSince: oldest.pend.startedAt,
+    undeliverableSince: u.since,
+    retryableAt: u.retryableAt,
+    reason: u.reason,
+  })
+}
 // Durable store for the four AGENT-INITIATED approval-card families
 // (vault_request_access / vault_request_save / request_secret /
 // mental_model_propose). Persists card METADATA only — never any secret value
@@ -4025,6 +4098,7 @@ function cancelPendingPermissionsForHalt(origin: string): void {
     void stripCancelledPermissionCards(details.card_text, details.cards)
     pendingPermissions.delete(requestId)
     permCardStore.remove(requestId)
+    reconcileBlockedApprovals()
     process.stderr.write(
       `telegram gateway: halt-now cancelled pending permission origin=${origin} ` +
       `request=${requestId} tool=${details.tool_name}\n`,
@@ -5718,7 +5792,11 @@ const STATUS_QUERY_RE = /^\s*status\??\s*$/i
 
 // ─── Permission handling ──────────────────────────────────────────────────
 const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
-const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; startedAt: number; card_text: string; cards: { chatId: string; messageId: number; threadId?: number | null }[] }>()
+// `undeliverable` (#3084 follow-up): set when the card send failed against a
+// known-open Telegram flood window. While it is set the entry is HELD — the TTL
+// sweep skips it (never auto-deny an ask no human ever saw) and the reaper
+// re-posts the card once the window closes. Cleared on successful delivery.
+const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; startedAt: number; card_text: string; cards: { chatId: string; messageId: number; threadId?: number | null }[]; undeliverable?: UndeliverableMark | null }>()
 // PERMISSION_TTL_MS / ttlForTool / the timed-out card builder now live in
 // ./permission-timeout.ts (pure + unit-testable). hostd gated verbs get a
 // 30-min window; everything else keeps the 10-min default.
@@ -6830,6 +6908,7 @@ const pendingStateReaper = setInterval(() => {
       )
       pendingPermissions.delete(k)
       permCardStore.remove(k)
+      reconcileBlockedApprovals()
     }
   }
   // Drop no-repeat suppression entries past the safety-cap window (the primary
@@ -10168,6 +10247,14 @@ const ipcServer: IpcServer = createIpcServer({
           // cases: topic success → tid, main-chat / fallback → undefined.
           const landedThreadId = sent.message_thread_id ?? undefined
           pend.cards.push({ chatId, messageId: sent.message_id, threadId: landedThreadId })
+          // The card LANDED — the operator can see and tap it, so the block is
+          // over. Drop the hold mark and clear the off-Telegram surface. (PR 3
+          // also resets `startedAt` here: the TTL measures how long the operator
+          // had to answer, and until this moment they had nothing to answer.)
+          if (pend.undeliverable != null) {
+            pend.undeliverable = null
+            reconcileBlockedApprovals()
+          }
           permCardStore.add({
             requestId,
             chatId,
@@ -10179,6 +10266,42 @@ const ipcServer: IpcServer = createIpcServer({
         }
       }).catch(e => {
         process.stderr.write(`telegram gateway: permission_request send to ${chatId} failed: ${e}\n`)
+        // #3084 follow-up — the card did NOT land. Before this, the error was
+        // logged and dropped: the entry sat with `cards: []`, the operator saw
+        // nothing, and 60 minutes later the TTL sweep AUTO-DENIED an approval
+        // no human had ever been shown (and skipped the #2862 missed-approval
+        // re-offer, which is anchored on `cards[0]`). That is the leash
+        // deciding for the operator. Now we record the block instead.
+        //
+        // Only a FLOOD_WAIT_ACTIVE failure is a *hold*: it means the channel
+        // itself is shut (per-bot-token ban — nothing can land until `untilTs`)
+        // and the ask is deliverable later. Any other error (a 400, a malformed
+        // card) is a real failure of THIS send and keeps today's behaviour —
+        // holding on those would park the agent forever on a card that will
+        // never format correctly.
+        if (!isFloodWaitActiveError(e)) return
+        const pend = pendingPermissions.get(requestId)
+        if (pend == null) return // operator already resolved it — nothing to hold
+        const now = Date.now()
+        // Re-marking is idempotent and self-correcting: if the window is
+        // re-extended by a fresh 429, `computeFloodWait` only ever grows
+        // `untilTs`, so a later mark carries the longer window.
+        pend.undeliverable = { since: now, retryableAt: e.untilTs, reason: 'flood_wait' }
+        // Write the shared surface SYNCHRONOUSLY, here in the failure handler —
+        // not on the 60s reaper tick. The operator is locked out of Telegram;
+        // the off-Telegram surface is the only way they learn an agent is
+        // blocked, so it has to be live in under a second, not up to a minute.
+        // Metadata only: `action` is naturalAction() text. NEVER input_preview —
+        // this file is world-readable (0644) so switchroom-web can read it.
+        // Reconcile rather than write directly: several permissions can be held
+        // at once (parallel tool calls), and the surface must reflect all of
+        // them, not just the last one to fail.
+        reconcileBlockedApprovals()
+        process.stderr.write(
+          `telegram gateway: permission-card HELD (undeliverable) request=${requestId} ` +
+          `tool=${pend.tool_name} reason=flood_wait retryable_at=${new Date(e.untilTs).toISOString()} ` +
+          `— approval is held, NOT denied; will re-deliver when the window closes\n`,
+        )
       })
     }
     // Park the turn's status reaction on 🙏 (awaiting your tap) and
@@ -22289,6 +22412,7 @@ async function handlePermissionSlash(ctx: Context, behavior: 'allow' | 'deny'): 
   })
   pendingPermissions.delete(request_id)
   permCardStore.remove(request_id)
+  reconcileBlockedApprovals()
   process.stderr.write(
     `[telegram gateway] slash-${behavior} request_id=${request_id} tool=${details.tool_name} by=${senderId}\n`,
   )
@@ -25379,6 +25503,7 @@ bot.on('callback_query:data', async ctx => {
 
     pendingPermissions.delete(request_id)
     permCardStore.remove(request_id)
+    reconcileBlockedApprovals()
 
     // (2) Dispatch the in-flight permission verdict IMMEDIATELY — before
     // any host round-trip — so the turn never blocks on persistence.
@@ -25674,6 +25799,7 @@ bot.on('callback_query:data', async ctx => {
   const grantAgent = selfAgentName()
   pendingPermissions.delete(request_id)
   permCardStore.remove(request_id)
+  reconcileBlockedApprovals()
   if (timeBox && grantAgent) {
     recordScopedGrant(scopedGrants, grantAgent, timeBox.rule, Date.now(), scopedTtl)
     // Write-through so the window survives a gateway restart (#2863). Absolute
@@ -27621,6 +27747,22 @@ void (async () => {
         } catch (err) {
           process.stderr.write(
             `telegram gateway: pending approval-card restore failed: ${(err as Error).message}\n`,
+          )
+        }
+
+        // #3084 follow-up — drop a blocked-approval record orphaned by a restart
+        // mid-hold. `pendingPermissions` is in-memory and empty on a fresh
+        // process, so this reconciles the surface to "nothing held". Without it,
+        // a gateway restart during a flood ban would leave a record on disk that
+        // nothing ever clears, and the dashboard would show a permanently
+        // blocked agent. The ASK itself survives: the bridge re-sends unresolved
+        // permission requests on IPC reconnect, which re-raises them (and
+        // re-marks them held if the channel is still shut).
+        try {
+          reconcileBlockedApprovals()
+        } catch (err) {
+          process.stderr.write(
+            `telegram gateway: blocked-approval boot reconcile failed: ${(err as Error).message}\n`,
           )
         }
 

--- a/telegram-plugin/tests/approval-hold-record.test.ts
+++ b/telegram-plugin/tests/approval-hold-record.test.ts
@@ -1,0 +1,388 @@
+/**
+ * #3084 follow-up, PR 1 — an undeliverable permission card must be RECORDED,
+ * not discarded.
+ *
+ * The incident: overlord was flood-banned for 4.6h, a permission prompt fired
+ * during the ban, the card send threw, and the catch handler wrote the error to
+ * stderr and dropped it. The operator never learned an agent was blocked.
+ *
+ * These tests pin the record itself: its schema (a contract with the
+ * switchroom-web reader), its file mode (0644 — web runs as uid 1000 and cannot
+ * read the agent's 0600 state files), and the hard rule that it carries
+ * METADATA ONLY. A world-readable file that could hold raw tool input is a
+ * credential leak — the failure `approve-what-my-agent-can-touch.md` names.
+ *
+ * No fake timers anywhere: this file must pass under BOTH vitest and bun, and
+ * bun's shim lacks `vi.useFakeTimers()` (the trap that made 5 tests silently
+ * ERROR on #3097).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, chmodSync, rmSync, statSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  createBlockedApprovalStore,
+  blockedApprovalsDir,
+  isHeldUndeliverable,
+  safeActionForRecord,
+  BLOCKED_APPROVAL_DIR_MODE,
+  BLOCKED_APPROVAL_FILE_MODE,
+  type BlockedApprovalRecord,
+} from '../gateway/approval-hold.js'
+import { naturalAction } from '../permission-title.js'
+import { isFloodWaitActiveError, FLOOD_WAIT_ACTIVE } from '../retry-api-call.js'
+
+// Every path is a fresh tmpdir — never ~/.switchroom (the production state
+// tree; a test that writes there corrupts a running fleet).
+let root: string
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'blocked-approvals-'))
+})
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+const REC: BlockedApprovalRecord = {
+  agent: 'overlord',
+  requestId: 'req-abc123',
+  toolName: 'Bash',
+  action: 'run: npm test',
+  blockedSince: 1783753731607,
+  undeliverableSince: 1783753731607,
+  retryableAt: 1783767801049,
+  reason: 'flood_wait',
+}
+
+describe('blocked-approval record — the off-Telegram surface', () => {
+  it('writes the exact schema switchroom-web reads', () => {
+    const dir = blockedApprovalsDir(root)
+    const store = createBlockedApprovalStore(dir, 'overlord')
+    store.write(REC)
+
+    const onDisk = JSON.parse(readFileSync(join(dir, 'overlord.json'), 'utf-8'))
+    expect(onDisk).toEqual({
+      agent: 'overlord',
+      requestId: 'req-abc123',
+      toolName: 'Bash',
+      action: 'run: npm test',
+      blockedSince: 1783753731607,
+      undeliverableSince: 1783753731607,
+      retryableAt: 1783767801049,
+      reason: 'flood_wait',
+    })
+  })
+
+  it('lands at <dir>/<agent>.json so web can find every agent in one place', () => {
+    const dir = blockedApprovalsDir(root)
+    const store = createBlockedApprovalStore(dir, 'marko')
+    expect(store.path).toBe(join(root, 'blocked-approvals', 'marko.json'))
+  })
+
+  // THE MODE IS LOAD-BEARING. switchroom-web runs as uid 1000; the agent's
+  // telegram state (pending-perm-cards.json) is 0600 and it CANNOT read it —
+  // verified on the live box. A 0600 record renders a silently empty dashboard.
+  it('is world-readable (0644 file, 0755 dir) — a non-owner uid can read it', () => {
+    const dir = blockedApprovalsDir(root)
+    const store = createBlockedApprovalStore(dir, 'overlord')
+    store.write(REC)
+
+    const fileMode = statSync(store.path).mode & 0o777
+    const dirMode = statSync(dir).mode & 0o777
+
+    expect(fileMode).toBe(BLOCKED_APPROVAL_FILE_MODE)
+    // Spelled out as the property that actually matters: OTHER can read.
+    expect(fileMode & 0o004).toBe(0o004) // o+r on the file
+    expect(dirMode & 0o001).toBe(0o001) // o+x on the dir (traversable)
+    expect(dirMode & 0o004).toBe(0o004) // o+r on the dir
+  })
+
+  // Agents run as PER-AGENT non-root uids (AGENT_UID_MIN = 10001). A shared dir
+  // that is operator-owned — or root-owned, which is what Docker does to any
+  // bind source that doesn't exist — is NOT writable by uid 10001, so the write
+  // EACCESes and the record silently never appears. The dir must be
+  // world-writable, and sticky so no agent can delete another's record.
+  it('the shared dir is WORLD-WRITABLE — every agent uid can write its own record', () => {
+    const dir = blockedApprovalsDir(root)
+    createBlockedApprovalStore(dir, 'overlord').write(REC)
+
+    const dirMode = statSync(dir).mode & 0o7777
+    // THE load-bearing property. Agents are per-agent non-root uids (10001+); a
+    // dir they cannot write is a feature that silently never records anything.
+    expect(dirMode & 0o002).toBe(0o002)
+
+    // The sticky bit (0o1000) is defense-in-depth on top — it stops one agent
+    // deleting another's record. It is NOT relied on for correctness, and it
+    // cannot be: bun's chmodSync silently drops it (verified against `stat` —
+    // node yields 1777, bun yields 777), and the gateway runs under bun. In
+    // production the host CLI (node) sets it via compose.ts. Cross-agent
+    // tampering is out of threat model anyway — `single-tenant` says every agent
+    // the operator wires in is implicitly trusted. So: assert the constant we
+    // ASK for, and assert only the writability we actually depend on.
+    expect(BLOCKED_APPROVAL_DIR_MODE).toBe(0o1777)
+  })
+
+  // THE BUG THE REVIEWER CAUGHT: without a fallback, a non-writable shared dir
+  // meant the whole feature was a silent no-op in production.
+  it('falls back to the agent\'s own state dir when the shared dir is not writable', () => {
+    // Simulate the production failure: Docker auto-created the bind source as
+    // root:root, so this agent's uid can neither create the dir nor chmod it.
+    // Modelled as a read-only PARENT — the store can't mkdir the shared dir
+    // inside it, and can't chmod its way out either.
+    const readOnlyParent = join(root, 'root-owned')
+    mkdirSync(readOnlyParent, { recursive: true })
+    chmodSync(readOnlyParent, 0o555) // r-xr-xr-x
+    const unwritable = join(readOnlyParent, 'blocked-approvals') // cannot be created
+    const ownDir = join(root, 'agent-state')
+    mkdirSync(ownDir, { recursive: true })
+
+    const store = createBlockedApprovalStore(unwritable, 'overlord', ownDir)
+    store.write(REC)
+
+    // The record MUST exist somewhere — never silently lost.
+    expect(store.read()?.requestId).toBe('req-abc123')
+    expect(store.path).toBe(join(ownDir, 'blocked-approval.json'))
+    expect(statSync(store.path).mode & 0o777).toBe(BLOCKED_APPROVAL_FILE_MODE)
+
+    // …and clear() reaches the fallback location too.
+    store.clear()
+    expect(store.read()).toBeNull()
+  })
+
+  it('never carries raw tool input — the record is metadata only', () => {
+    const dir = blockedApprovalsDir(root)
+    const store = createBlockedApprovalStore(dir, 'overlord')
+    store.write(REC)
+
+    const raw = readFileSync(store.path, 'utf-8')
+    // The file is 0644. Anything derived from raw tool input could be a
+    // credential (`Bash(export TOKEN=...)`), so none of these may ever appear.
+    expect(raw).not.toContain('inputPreview')
+    expect(raw).not.toContain('input_preview')
+    expect(raw).not.toContain('cardText')
+    expect(raw).not.toContain('card_text')
+    expect(Object.keys(JSON.parse(raw)).sort()).toEqual([
+      'action',
+      'agent',
+      'blockedSince',
+      'reason',
+      'requestId',
+      'retryableAt',
+      'toolName',
+      'undeliverableSince',
+    ])
+  })
+
+  it('THROWS if a caller ever tries to widen the record with tool input', () => {
+    const store = createBlockedApprovalStore(blockedApprovalsDir(root), 'overlord')
+    const leaky = {
+      ...REC,
+      inputPreview: 'export ANTHROPIC_' + 'TOKEN=sk-ant-' + 'oat01-secret',
+    } as unknown as BlockedApprovalRecord
+
+    expect(() => store.write(leaky)).toThrow(/must not carry raw tool input/)
+    // …and nothing was written, so the secret never touched a 0644 file.
+    expect(store.read()).toBeNull()
+  })
+
+  it('read() returns null when nothing is blocked, and after clear()', () => {
+    const store = createBlockedApprovalStore(blockedApprovalsDir(root), 'overlord')
+    expect(store.read()).toBeNull()
+
+    store.write(REC)
+    expect(store.read()?.requestId).toBe('req-abc123')
+
+    store.clear()
+    expect(store.read()).toBeNull()
+    // clear() on an absent record is a no-op, not a throw.
+    expect(() => store.clear()).not.toThrow()
+  })
+
+  it('survives a corrupt file rather than crashing the gateway', () => {
+    const dir = blockedApprovalsDir(root)
+    const store = createBlockedApprovalStore(dir, 'overlord')
+    store.write(REC)
+    writeFileSync(store.path, '{ not json', 'utf-8')
+
+    expect(store.read()).toBeNull()
+    // …and a fresh write repairs it.
+    store.write(REC)
+    expect(store.read()?.requestId).toBe('req-abc123')
+  })
+
+  it('a write failure never throws into the gateway (best-effort surface)', () => {
+    // Point the store at a path that cannot be created (a FILE, not a dir).
+    const notADir = join(root, 'blocker')
+    writeFileSync(notADir, 'x', 'utf-8')
+    const store = createBlockedApprovalStore(join(notADir, 'nested'), 'overlord')
+
+    // Must degrade quietly: the SURFACE is best-effort, and a surface failure
+    // must never be able to fall the hold back into an auto-deny.
+    expect(() => store.write(REC)).not.toThrow()
+  })
+})
+
+/**
+ * The `action` field is the one free-text field in a WORLD-READABLE file, so it
+ * is the one place a credential could plausibly land. `naturalAction()` is NOT
+ * uniformly safe to put there — for Bash it interpolates the raw command:
+ *
+ *   naturalAction('Bash', '{"command":"curl -H \'Authorization: Bearer sk-…\'"}')
+ *     → "run: curl -H 'Authorization: Bearer sk-…"
+ *
+ * safeActionForRecord() is the guard. It fails CLOSED: only tools whose action
+ * text is basename-derived keep their specifics; everything else degrades to
+ * input-free phrasing.
+ */
+describe('safeActionForRecord — no raw tool input in a 0644 file', () => {
+  it('REDACTS a Bash command — the leak naturalAction would have written', () => {
+    const secret = 'curl -H "Authorization: Bearer sk-ant-' + 'oat01-SECRET" https://x'
+    const input = JSON.stringify({ command: secret })
+
+    // What the naive implementation would have put on disk:
+    expect(naturalAction('Bash', input)).toContain('Authorization')
+
+    // What we actually write:
+    const safe = safeActionForRecord(naturalAction, 'Bash', input)
+    expect(safe).toBe('run shell commands')
+    expect(safe).not.toContain('Authorization')
+    expect(safe).not.toContain('sk-ant-')
+    expect(safe).not.toContain('curl')
+  })
+
+  it('redacts the other free-form-input tools too', () => {
+    expect(safeActionForRecord(naturalAction, 'Grep', '{"pattern":"SECRET_KEY"}'))
+      .toBe('search files')
+    expect(safeActionForRecord(naturalAction, 'Glob', '{"pattern":"/etc/**"}'))
+      .toBe('search files')
+    // A URL routinely carries a token in its query string.
+    expect(safeActionForRecord(naturalAction, 'WebFetch', '{"url":"https://x?token=abc123"}'))
+      .toBe('fetch a web page')
+    expect(
+      safeActionForRecord(naturalAction, 'WebFetch', '{"url":"https://x?token=abc123"}'),
+    ).not.toContain('abc123')
+  })
+
+  it('fails CLOSED for unknown and MCP tools (arbitrary args)', () => {
+    expect(safeActionForRecord(naturalAction, 'mcp__brevo__send', '{"to":"a@b.com"}'))
+      .not.toContain('a@b.com')
+    expect(safeActionForRecord(naturalAction, 'SomeFutureTool', '{"secret":"xyz789"}'))
+      .not.toContain('xyz789')
+  })
+
+  it('KEEPS the useful specifics for basename-derived tools', () => {
+    // The record still has to tell the operator what is blocked, or it is a
+    // useless surface. A file basename is the right trade.
+    expect(safeActionForRecord(naturalAction, 'Edit', '{"file_path":"/home/k/supplement-log.md"}'))
+      .toBe('edit: supplement-log.md')
+    expect(safeActionForRecord(naturalAction, 'Write', '{"file_path":"/tmp/out.txt"}'))
+      .toBe('write: out.txt')
+  })
+})
+
+describe('the undeliverable mark', () => {
+  it('is what the flood-wait failure produces — and only flood-wait', () => {
+    // The real marker `retryApiCall` throws when it refuses to send into an
+    // open ban (retry-api-call.ts:192). This is its first production consumer.
+    const floodErr = Object.assign(new Error(FLOOD_WAIT_ACTIVE), {
+      retryAfterSec: 16739,
+      untilTs: 1783767801049,
+    })
+    expect(isFloodWaitActiveError(floodErr)).toBe(true)
+
+    // A 400 (malformed card) is NOT a hold — that send will never succeed, and
+    // holding on it would park the agent forever.
+    expect(isFloodWaitActiveError(new Error('Bad Request: can\'t parse entities'))).toBe(false)
+    expect(isFloodWaitActiveError(undefined)).toBe(false)
+  })
+
+  it('isHeldUndeliverable is the TTL-freeze predicate', () => {
+    expect(isHeldUndeliverable({ undeliverable: null })).toBe(false)
+    expect(isHeldUndeliverable({})).toBe(false)
+    expect(
+      isHeldUndeliverable({
+        undeliverable: { since: 1, retryableAt: 2, reason: 'flood_wait' },
+      }),
+    ).toBe(true)
+  })
+})
+
+/**
+ * gateway.ts has top-level side effects and is NOT unit-importable (the same
+ * constraint `permission-card-routing.test.ts` documents), so the WIRING is
+ * pinned as source text. The logic itself is unit-tested above; these guard
+ * that the gateway actually calls it, and can't silently revert to discarding
+ * the error.
+ */
+describe('gateway wiring — the failure handler records instead of discarding', () => {
+  const GATEWAY_SRC = readFileSync(
+    new URL('../gateway/gateway.ts', import.meta.url),
+    'utf8',
+  )
+
+  /** Body of the `onPermissionRequest` IPC handler. */
+  function onPermissionRequestBody(): string {
+    const start = GATEWAY_SRC.indexOf('onPermissionRequest(')
+    expect(start).toBeGreaterThan(-1)
+    const rest = GATEWAY_SRC.slice(start)
+    const end = rest.indexOf('onHeartbeat(')
+    expect(end).toBeGreaterThan(-1)
+    return rest.slice(0, end)
+  }
+
+  it('discriminates the send failure with isFloodWaitActiveError', () => {
+    // Before this change the catch was a bare stderr write — the error, which
+    // already carried the FLOOD_WAIT_ACTIVE marker post-#3094, was thrown away.
+    expect(onPermissionRequestBody()).toContain('isFloodWaitActiveError(e)')
+  })
+
+  it('marks the pending entry undeliverable with the window end', () => {
+    const body = onPermissionRequestBody()
+    expect(body).toContain('pend.undeliverable = {')
+    expect(body).toContain("reason: 'flood_wait'")
+    expect(body).toContain('retryableAt: e.untilTs')
+  })
+
+  it('writes the shared record IN the failure handler (live in <1s, not on a 60s tick)', () => {
+    // reconcileBlockedApprovals() derives the record from live pending state and
+    // writes it — called synchronously here, not deferred to the reaper tick.
+    expect(onPermissionRequestBody()).toContain('reconcileBlockedApprovals()')
+  })
+
+  it('the record it writes uses safeActionForRecord, NOT bare naturalAction', () => {
+    const at = GATEWAY_SRC.indexOf('function reconcileBlockedApprovals(')
+    expect(at).toBeGreaterThan(-1)
+    const fn = GATEWAY_SRC.slice(at, GATEWAY_SRC.indexOf('\n}', at))
+    // Bare naturalAction() would interpolate the raw Bash command into a
+    // world-readable file. The guard must be on the write path itself.
+    expect(fn).toContain('action: safeActionForRecord(')
+    expect(fn).not.toMatch(/action: naturalAction\(/)
+    expect(fn).not.toContain('input_preview:')
+    expect(fn).not.toContain('inputPreview')
+  })
+
+  it('the surface RECONCILES from live pending state (several holds at once are real)', () => {
+    // Claude Code issues parallel tool calls; cancelPendingPermissionsForHalt
+    // iterates multiple pendings. A naive clear() on one resolution would delete
+    // the file while ANOTHER request was still held.
+    expect(GATEWAY_SRC).toContain('function reconcileBlockedApprovals(')
+    expect(GATEWAY_SRC).not.toContain('function clearBlockedApproval(')
+  })
+
+  it('boot reconciles, so a restart mid-hold cannot orphan a record forever', () => {
+    const at = GATEWAY_SRC.indexOf('blocked-approval boot reconcile failed')
+    expect(at).toBeGreaterThan(-1)
+  })
+
+  it('logs a distinct, greppable HELD signature that says NOT denied', () => {
+    const body = onPermissionRequestBody()
+    expect(body).toContain('permission-card HELD (undeliverable)')
+    expect(body).toContain('held, NOT denied')
+  })
+
+  it('does NOT hold on non-flood errors (a 400 would park the agent forever)', () => {
+    // The early-return is the whole guard: only FLOOD_WAIT_ACTIVE is a hold.
+    expect(onPermissionRequestBody()).toContain('if (!isFloodWaitActiveError(e)) return')
+  })
+})

--- a/telegram-plugin/tests/approval-hold-record.test.ts
+++ b/telegram-plugin/tests/approval-hold-record.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, mkdirSync, chmodSync, rmSync, statSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, chmodSync, rmSync, statSync, lstatSync, existsSync, readFileSync, writeFileSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -26,6 +26,7 @@ import {
   blockedApprovalsDir,
   isHeldUndeliverable,
   safeActionForRecord,
+  selectOldestHeld,
   BLOCKED_APPROVAL_DIR_MODE,
   BLOCKED_APPROVAL_FILE_MODE,
   type BlockedApprovalRecord,
@@ -211,6 +212,67 @@ describe('blocked-approval record — the off-Telegram surface', () => {
     expect(store.read()?.requestId).toBe('req-abc123')
   })
 
+  // The shared dir is 1777 (the /tmp model): ANY local uid can pre-create
+  // `<agent>.json` as a symlink pointing at a file the agent uid can write,
+  // redirecting our 0644 write onto an arbitrary target. The sticky bit stops
+  // us unlinking a symlink we don't own, so the store must REFUSE the location
+  // and fall back — never write through the link.
+  it('refuses to write through a planted symlink (1777-dir hardening)', () => {
+    const dir = blockedApprovalsDir(root)
+    mkdirSync(dir, { recursive: true })
+    const victim = join(root, 'victim.txt')
+    writeFileSync(victim, 'do not clobber', 'utf-8')
+    symlinkSync(victim, join(dir, 'overlord.json'))
+    const ownDir = join(root, 'agent-state')
+    mkdirSync(ownDir, { recursive: true })
+
+    const store = createBlockedApprovalStore(dir, 'overlord', ownDir)
+    store.write(REC)
+
+    // The planted target is untouched, the symlink was not followed…
+    expect(readFileSync(victim, 'utf-8')).toBe('do not clobber')
+    expect(lstatSync(join(dir, 'overlord.json')).isSymbolicLink()).toBe(true)
+    // …and the record still landed (fallback), never silently lost.
+    expect(store.path).toBe(join(ownDir, 'blocked-approval.json'))
+    expect(store.read()?.requestId).toBe('req-abc123')
+  })
+
+  it('a symlink planted at the FALLBACK path is refused too', () => {
+    const readOnlyParent = join(root, 'root-owned')
+    mkdirSync(readOnlyParent, { recursive: true })
+    chmodSync(readOnlyParent, 0o555)
+    const unwritable = join(readOnlyParent, 'blocked-approvals')
+    const ownDir = join(root, 'agent-state')
+    mkdirSync(ownDir, { recursive: true })
+    const victim = join(root, 'victim.txt')
+    writeFileSync(victim, 'do not clobber', 'utf-8')
+    symlinkSync(victim, join(ownDir, 'blocked-approval.json'))
+
+    const store = createBlockedApprovalStore(unwritable, 'overlord', ownDir)
+    // Both locations refuse — degrade quietly, never write through the link.
+    expect(() => store.write(REC)).not.toThrow()
+    expect(readFileSync(victim, 'utf-8')).toBe('do not clobber')
+  })
+
+  // A host that recovers its shared dir must not DOUBLE-REPORT: an earlier
+  // write that landed in the fallback would otherwise linger there forever
+  // (web reads both locations).
+  it('a successful primary write removes a stale fallback record', () => {
+    const dir = blockedApprovalsDir(root)
+    const ownDir = join(root, 'agent-state')
+    mkdirSync(ownDir, { recursive: true })
+    const staleFallback = join(ownDir, 'blocked-approval.json')
+    // Simulate the earlier degraded write.
+    writeFileSync(staleFallback, JSON.stringify({ ...REC, requestId: 'req-stale' }), 'utf-8')
+
+    const store = createBlockedApprovalStore(dir, 'overlord', ownDir)
+    store.write(REC)
+
+    expect(store.path).toBe(join(dir, 'overlord.json'))
+    expect(existsSync(staleFallback)).toBe(false)
+    expect(store.read()?.requestId).toBe('req-abc123')
+  })
+
   it('a write failure never throws into the gateway (best-effort surface)', () => {
     // Point the store at a path that cannot be created (a FILE, not a dir).
     const notADir = join(root, 'blocker')
@@ -309,6 +371,56 @@ describe('the undeliverable mark', () => {
 })
 
 /**
+ * The reconcile SELECTION — extracted from gateway.ts's
+ * reconcileBlockedApprovals() so its two load-bearing rules are unit-testable:
+ * oldest hold wins, and clear only when nothing at all is held.
+ */
+describe('selectOldestHeld — the reconcile selection', () => {
+  const mark = (since: number) =>
+    ({ since, retryableAt: since + 1000, reason: 'flood_wait' as const })
+
+  it('returns null only when NO entry is held (⇒ caller may clear)', () => {
+    expect(selectOldestHeld([])).toBeNull()
+    expect(
+      selectOldestHeld([
+        ['a', { undeliverable: null }],
+        ['b', {}],
+      ]),
+    ).toBeNull()
+  })
+
+  it('oldest hold wins among multiple concurrent holds', () => {
+    const sel = selectOldestHeld([
+      ['newer', { undeliverable: mark(200) }],
+      ['oldest', { undeliverable: mark(100) }],
+      ['newest', { undeliverable: mark(300) }],
+    ])
+    expect(sel?.requestId).toBe('oldest')
+    expect(sel?.mark.since).toBe(100)
+  })
+
+  it('resolving one of several holds surfaces the NEXT-oldest, not a clear', () => {
+    // The bug a naive clear() would have: one resolution blanks the file while
+    // another request is still genuinely blocked.
+    const entries: Array<[string, { undeliverable?: ReturnType<typeof mark> | null }]> = [
+      ['first', { undeliverable: null }], // just resolved
+      ['second', { undeliverable: mark(150) }], // still held
+    ]
+    const sel = selectOldestHeld(entries)
+    expect(sel).not.toBeNull()
+    expect(sel?.requestId).toBe('second')
+  })
+
+  it('skips unheld entries entirely regardless of position', () => {
+    const sel = selectOldestHeld([
+      ['unheld', {}],
+      ['held', { undeliverable: mark(500) }],
+    ])
+    expect(sel?.requestId).toBe('held')
+  })
+})
+
+/**
  * gateway.ts has top-level side effects and is NOT unit-importable (the same
  * constraint `permission-card-routing.test.ts` documents), so the WIRING is
  * pinned as source text. The logic itself is unit-tested above; these guard
@@ -342,6 +454,23 @@ describe('gateway wiring — the failure handler records instead of discarding',
     expect(body).toContain('pend.undeliverable = {')
     expect(body).toContain("reason: 'flood_wait'")
     expect(body).toContain('retryableAt: e.untilTs')
+  })
+
+  it('does NOT mark undeliverable when a card already LANDED on another target', () => {
+    // The send fans out to several chats/topics; one flood-walled leg must not
+    // write a blocked record while the operator can see a live card.
+    expect(onPermissionRequestBody()).toContain('if (pend.cards.length > 0) return')
+  })
+
+  it('a re-failure preserves the ORIGINAL since (the "first failed" contract)', () => {
+    expect(onPermissionRequestBody()).toContain('since: pend.undeliverable?.since ?? now')
+  })
+
+  it('reconcile delegates selection to the unit-tested selectOldestHeld', () => {
+    const at = GATEWAY_SRC.indexOf('function reconcileBlockedApprovals(')
+    expect(at).toBeGreaterThan(-1)
+    const fn = GATEWAY_SRC.slice(at, GATEWAY_SRC.indexOf('\n}', at))
+    expect(fn).toContain('selectOldestHeld(pendingPermissions)')
   })
 
   it('writes the shared record IN the failure handler (live in <1s, not on a 60s tick)', () => {

--- a/telegram-plugin/tests/gateway-boot-marker-clear.test.ts
+++ b/telegram-plugin/tests/gateway-boot-marker-clear.test.ts
@@ -43,7 +43,7 @@ describe('gateway boot — clear stale turn-active marker', () => {
     // window to ~5KB so we don't pick up the unrelated
     // `removeTurnActiveMarker` call in the onTurnComplete handler
     // way down at the bottom of the file.
-    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 9000)
+    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 12000)
     const clearMatches = setupWindow.match(/removeTurnActiveMarker\s*\(\s*STATE_DIR\s*\)/g) ?? []
     expect(clearMatches.length).toBe(1)
   })
@@ -53,7 +53,7 @@ describe('gateway boot — clear stale turn-active marker', () => {
     // must not prevent the gateway from coming up. Pin the try-wrapping
     // to make sure a future refactor doesn't drop it.
     const setupBlockStart = GATEWAY_SRC.indexOf('if (!didOneTimeSetup)')
-    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 9000)
+    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 12000)
     expect(setupWindow).toMatch(/try\s*\{\s*removeTurnActiveMarker\(STATE_DIR\)\s*\}\s*catch/)
   })
 
@@ -62,7 +62,7 @@ describe('gateway boot — clear stale turn-active marker', () => {
     // Clearing the marker first means the watchdog sees a clean slate
     // immediately, even if pin sweep takes 30s+ to finish.
     const setupBlockStart = GATEWAY_SRC.indexOf('if (!didOneTimeSetup)')
-    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 9000)
+    const setupWindow = GATEWAY_SRC.slice(setupBlockStart, setupBlockStart + 12000)
     const clearIdx = setupWindow.indexOf('removeTurnActiveMarker(STATE_DIR)')
     const pinSweepIdx = setupWindow.indexOf('Boot-time pin sweep')
     expect(clearIdx).toBeGreaterThan(0)


### PR DESCRIPTION
**PR 1 of 3.** Stack: this → #3108 → #3109. The order is a safety property: #3109 removes the auto-deny, and that is only safe once #3108 guarantees the card comes back.

> ⚠️ **This PR alone does NOT fix the leash violation.** It makes the block *visible*; the untouched TTL sweep still auto-denies at 60 minutes. **The stack must ship together** — #3107 must never be rolled to the fleet as a standalone "fix".

## Summary

When a permission card cannot be delivered, the gateway now **records the block** instead of throwing the error away.

The catch at the send site was a bare stderr write. Post-#3094 the error already carries the `FLOOD_WAIT_ACTIVE` marker — `isFloodWaitActiveError()` had **zero production consumers**. This is its first.

On an undeliverable send we mark the pending entry `undeliverable`, write a world-readable record **synchronously in the failure handler** (live in <1s, not on the 60s reaper tick — the operator is locked out of Telegram, so this record is the only way they learn an agent is blocked), and log a greppable `held, NOT denied` line.

**Strictly additive — no control-flow change.**

## Why

On 2026-07-11 `overlord` hit a 4.6h flood ban (#3084). A permission prompt fired during it. The card send failed and **the operator never saw it.**

- `PERMISSION_TTL_DEFAULT_MS` = **60 minutes**
- the TTL sweep **auto-denies** on expiry
- the ban was **4.6 hours**

So on main today: undeliverable card → 60 minutes later the gateway **silently auto-denies an approval no human ever saw** and tells the agent the operator declined. We escaped only because someone answered in tmux at ~50 minutes.

And the #2862 safety net has a hole shaped exactly like this: the re-offer is anchored on `v.cards[0]`, which is `undefined` when nothing landed — so the request is auto-denied **and erased** from the only record that would have brought it back. (Closed in #3109.)

## The record

`~/.switchroom/blocked-approvals/<agent>.json`, file mode **0644**, via a new compose bind — the exact path and schema #3104's merged reader (`src/web/blocked-approvals-read.ts`) scans.

**0644 is load-bearing.** `switchroom-web` runs as uid 1000 and cannot read the agent's 0600 telegram state. A 0600 record renders a silently empty dashboard (the Hermes `registry.db` bug).

### The feature would have been a silent NO-OP in production

Nothing created the shared dir, so Docker auto-creates the bind source `root:root`. Agents run as **per-agent non-root uids** (`AGENT_UID_MIN = 10001`), so every write would have EACCESed into the best-effort catch — the one surface telling the operator an agent is blocked, silently empty.

Fixed: `compose.ts` pre-creates the dir **sticky-world-writable (1777, the /tmp model** — each agent creates and owns its own 0644 file; sticky stops anyone deleting another's), with an explicit `chmod` because `mkdir`'s mode is umask-masked. **The mount is pinned in `tests/docker/compose-generator.test.ts`** (remove the bind → test goes red).

### The fallback is NOT web-visible, and I want that stated plainly

If the shared dir still isn't writable (a container predating the volume), the store falls back to the agent's own state dir so the record is **not lost**. But **switchroom-web cannot read that path** — #3104's reader scans only `blocked-approvals/`, and its own header documents that web's uid-1000 process cannot read `~/.switchroom/agents/<agent>/` at all. **Reachable-by-mount is not readable.** When the fallback fires the dashboard will be **empty**, and it logs loudly saying so. An earlier version of this description and two code comments claimed web could read it; that was false and is corrected. **Agents need a recreate to pick up the volume for the surface to work.**

## ⚠️ Deliberate deviation from the specified schema

The spec said `action` = `"<naturalAction() text ONLY>"` **and** "never write raw tool input — a world-readable file." **For `Bash` those conflict:**

```
naturalAction('Bash', '{"command":"curl -H \'Authorization: Bearer sk-ant-oat01-SECRET\'..."}')
  → "run: curl -H 'Authorization: Bearer sk-ant-oat01-SEC…"
```

`naturalAction` interpolates the **raw command** for `Bash`, the raw **pattern** for `Glob`/`Grep`, the raw **URL** for `WebFetch` (routinely carries a token), and arbitrary args for `mcp__*`.

**Fix:** `safeActionForRecord()` — a fail-closed **allowlist**. Basename-derived tools (`Edit`/`Write`/`Read`/`Skill` → `"edit: supplement-log.md"`) keep their specifics; everything else degrades to input-free phrasing (`"run shell commands"`). **Field name, type and voice unchanged**, so the reader contract is intact — only the value is made safe. The Telegram card still shows the full command: that goes to the operator's private chat, not a 0644 file.

## Concurrency + restart

An agent holds several permissions at once (parallel tool calls; `cancelPendingPermissionsForHalt` iterates multiple). A naive `clear()` on one resolution would delete the file while another request was **still held**. `reconcileBlockedApprovals()` derives the record from live pending state (oldest held wins), and runs at **boot** to clear a record orphaned by a restart mid-hold.

## Test plan

`approval-hold-record.test.ts` — 23 tests, **green under both vitest and bun** (virtual clock only; no `vi.useFakeTimers()` — the #3097 trap).

Schema; path; 0644/world-writable-dir asserted as the *property* (`mode & 0o004`), not the constant; metadata-only (a `write()` carrying `inputPreview` **throws**); `safeActionForRecord` redacts Bash/Grep/Glob/WebFetch/`mcp__*` and fails closed on unknown tools; the **root-owned-dir fallback**; corrupt file and unwritable dir degrade quietly.

**Mutation-tested (each → RED):** discard the error again; record at 0600; drop `assertNoRawInput`; bare `naturalAction`; dir mode 0700; remove the compose bind.

Full `vitest run`: 880 files, zero failures. All 8 lint gates clean.

## Risk

Low. Additive only. The record write is best-effort and cannot throw into the gateway — a surface failure must never be able to fall the hold back into an auto-deny.

Job spec: `reference/jobs/approve-what-my-agent-can-touch.md`
Invariants: `no-self-escalation`, `on-leash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mQR9UordBs4nJ797bxxod