### PR TITLE
feat(telegram): re-deliver held permission cards when the flood window closes

### DIFF
--- a/telegram-plugin/gateway/approval-hold.ts
+++ b/telegram-plugin/gateway/approval-hold.ts
@@ -43,6 +43,7 @@
 
 import { mkdirSync, writeFileSync, readFileSync, unlinkSync, chmodSync, lstatSync } from 'node:fs'
 import { join, dirname } from 'node:path'
+import { isFloodWaitActiveError } from '../retry-api-call.js'
 
 /**
  * File mode 0644 — WORLD-READABLE, and that is load-bearing, not incidental.
@@ -85,8 +86,45 @@ export const BLOCKED_APPROVAL_FILE_MODE = 0o644
  */
 export const BLOCKED_APPROVAL_DIR_MODE = 0o1777
 
-/** Why a card could not be delivered. Only one cause today. */
-export type UndeliverableReason = 'flood_wait'
+/**
+ * Why a card could not be delivered — and every one of these is TRANSIENT.
+ *
+ * `flood_wait` is the incident cause: a per-bot-token ban, nothing can land until
+ * `untilTs`. But it is not the only way a card goes undeliverable through no
+ * fault of the operator, and the leash rule ("never auto-deny an approval no
+ * human saw") does not care WHICH transient fault shut the channel — only
+ * whether the operator ever got a chance to answer.
+ */
+export type UndeliverableReason = 'flood_wait' | 'transient'
+
+/**
+ * How long to wait before re-trying a card held for a NON-flood transient fault.
+ * A flood-wait carries its own `untilTs`; a network blip has no such signal, so
+ * back off a minute and let the reaper's next tick try again.
+ */
+export const HELD_RETRY_BACKOFF_MS = 60_000
+
+/**
+ * Ceiling on the exponential re-delivery backoff: 30 minutes.
+ *
+ * A held card that keeps failing must not be re-sent every 60s forever — that is
+ * the request amplifier this series exists to avoid. But it must ALSO never stop
+ * being retried entirely: a terminal give-up strands the card even after the
+ * channel recovers, and because `turnInFlightForGate()` holds the inbound gate
+ * while a permission is pending, that would silently buffer the operator's normal
+ * messages forever with no signal.
+ *
+ * So the retry interval BACKS OFF (1m, 2m, 4m … capped at 30m) instead of
+ * stopping. The rate is bounded; the retry never is. A recovered channel always
+ * gets the card back within 30 minutes.
+ */
+export const HELD_RETRY_MAX_BACKOFF_MS = 30 * 60_000
+
+/** Backoff for the Nth consecutive failure: 1m, 2m, 4m … capped. */
+export function heldRetryBackoffMs(failures: number): number {
+  const n = Math.max(1, failures)
+  return Math.min(HELD_RETRY_BACKOFF_MS * 2 ** (n - 1), HELD_RETRY_MAX_BACKOFF_MS)
+}
 
 /**
  * Stamped onto the in-memory `pendingPermissions` entry when the card send
@@ -371,6 +409,57 @@ export function selectOldestHeld<T extends { undeliverable?: UndeliverableMark |
 }
 
 /**
+ * Classify a card-send failure: is this ask HELD, or does it fall through?
+ *
+ * This is the leash rule in one function, and its POLARITY is the whole point:
+ * it FAILS CLOSED. Anything we do not positively recognise as permanent is HELD.
+ *
+ * The first version of this function was an allowlist of marker strings
+ * (FLOOD_WAIT_ACTIVE / GIVE_UP_MESSAGE / LOCAL_RESOURCE_EXHAUSTED) on the
+ * premise that a network partition or a Telegram 5xx would surface as a
+ * give-up. **That premise was false, and the allowlist failed OPEN into
+ * auto-deny** — the exact breach this series exists to close, with a different
+ * first cause. Driving real errors through the real `retryApiCall`:
+ *
+ *   Telegram 502 / 500   → raw GrammyError      ← the network-retry branch is
+ *                                                 guarded by `!isGrammyErr`
+ *                                                 (retry-api-call.ts:377), so a
+ *                                                 5xx is re-thrown on attempt 0
+ *   ECONNRESET / fetch failed → raw Error       ← on the LAST attempt the
+ *                                                 backoff branch is skipped and
+ *                                                 the raw error is re-thrown
+ *                                                 (retry-api-call.ts:384-396)
+ *   short-but-persistent 429  → GIVE_UP_MESSAGE ← the only path that reaches it
+ *   long 429                  → FLOOD_WAIT_ACTIVE
+ *   ENOSPC                    → LOCAL_RESOURCE_EXHAUSTED
+ *
+ * A single routine 502 at the instant the card is posted was therefore enough to
+ * reproduce 2026-07-11 in full: no card, no mark, TTL fires, agent told the
+ * operator declined. The send is ONE-SHOT — without a mark there is no
+ * re-delivery path at all.
+ *
+ * So the default is HOLD. Only a status we KNOW is permanent — a 400 (a card
+ * that will never parse) or a 403 (the bot is blocked/removed from that chat) —
+ * falls through to the TTL, because holding on those would park the agent
+ * forever on a card that can never render. And even that is safe now: PR 3 gives
+ * the no-card timeout a missed-approvals fallback, so a permanent failure is
+ * re-offered to the operator rather than vanishing.
+ *
+ * If a future error class is unrecognised, it is HELD. A held approval is
+ * visible and recoverable; a fabricated denial is neither.
+ */
+export function holdReasonFor(err: unknown): UndeliverableReason | null {
+  if (isFloodWaitActiveError(err)) return 'flood_wait'
+  // PERMANENT — and only these. Note 429 is deliberately NOT in this list: a
+  // rate-limit is the most transient failure there is.
+  const code = (err as { error_code?: unknown } | null | undefined)?.error_code
+  if (code === 400 || code === 403) return null
+  // Everything else — 5xx, raw network errors, give-ups, local-resource
+  // exhaustion, and anything we have never seen — is transient. FAIL CLOSED.
+  return 'transient'
+}
+
+/**
  * The TTL freeze predicate (PR 3).
  *
  * An entry marked undeliverable NEVER expires. The TTL answers "how long did
@@ -398,6 +487,8 @@ export interface HeldPermissionEntry {
   undeliverable?: UndeliverableMark | null
   /** Cards that actually landed. A held entry has none — that is the point. */
   cards: unknown[]
+  /** Consecutive failed re-delivery attempts. Past the cap we stop RE-SENDING. */
+  redeliveryFailures?: number
 }
 
 export interface RedeliverySelection {
@@ -431,6 +522,8 @@ export function selectHeldForRedelivery(
   opts: {
     floodRemainingMs: number
     inFlight: ReadonlySet<string>
+    /** Now, for the per-entry backoff check. */
+    now: number
     cap?: number
   },
 ): RedeliverySelection {
@@ -448,6 +541,12 @@ export function selectHeldForRedelivery(
     if (pend.cards.length > 0) continue
     // Guard (iii) — a previous tick is still posting this one.
     if (opts.inFlight.has(requestId)) continue
+    // Guard (v) — respect the per-entry backoff. A card that keeps failing is
+    // retried on a widening interval (1m, 2m, 4m … 30m) rather than every tick:
+    // bounded RATE, unbounded RETRY. It is never abandoned, so a channel that
+    // recovers always gets the card back — and the approval is never auto-denied.
+    const dueAt = pend.undeliverable?.retryableAt ?? 0
+    if (opts.now < dueAt) continue
     // Guard (iv) — cap. Everything past it is DEFERRED, not dropped.
     if (send.length >= cap) {
       deferred.push(requestId)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6941,6 +6941,20 @@ function postPermissionCard(
   requestId: string,
   pend: NonNullable<ReturnType<typeof pendingPermissions.get>>,
 ): void {
+  // Register the in-flight flag HERE, not at the call sites, so BOTH callers are
+  // covered. The sweep used to add it itself, but the ipcServer initial-delivery
+  // call site did not — so a reaper tick landing between window-close and a slow
+  // in-flight INITIAL send settling could post a duplicate card. One registration
+  // point, one release point (the `.finally` below / the sync-throw catch).
+  heldCardsInFlight.add(requestId)
+
+  // One increment per ATTEMPT, not per failing target. `targets` is N-wide and
+  // every failing target runs the same `.catch` — incrementing there ratcheted
+  // the backoff ladder N× faster than the documented 1m/2m/4m…30m. Compute the
+  // attempt number once, up front; every failing target stamps the SAME value.
+  const attemptFailures = (pend.redeliveryFailures ?? 0) + 1
+
+  try {
   const text = pend.card_text
   const showAlways =
     resolveScopedAllowChoices(pend.tool_name, pend.input_preview) != null
@@ -7044,7 +7058,7 @@ function postPermissionCard(
       // gate while a permission is pending, that would silently buffer the operator's
       // messages forever. Escalate the surface, never the verdict — and never abandon
       // the card.
-      const failures = (live.redeliveryFailures ?? 0) + 1
+      const failures = attemptFailures
       live.redeliveryFailures = failures
       const now = Date.now()
       // A flood-wait carries Telegram's own window end; everything else backs off.
@@ -7072,13 +7086,23 @@ function postPermissionCard(
   void Promise.allSettled(sends).finally(() => {
     heldCardsInFlight.delete(requestId)
   })
+  } catch (e) {
+    // A SYNCHRONOUS throw (resolveScopedAllowChoices / buildPermissionActionRow /
+    // resolvePermissionCardTargets) never reaches the `.finally` above — without
+    // this catch the in-flight flag would leak and the request would never be
+    // re-selected by the sweep. Release the flag, then rethrow so the caller
+    // (the sweep's own try/catch, or the ipc handler) sees the failure.
+    heldCardsInFlight.delete(requestId)
+    throw e
+  }
 }
 
 /**
- * Request ids whose re-delivery is mid-flight. Guard (iii) against
- * double-delivery: the 60s reaper must not re-post a card whose previous
- * re-post hasn't settled yet (a slow send would otherwise be re-issued every
- * tick). Cleared in postPermissionCard's `.finally`.
+ * Request ids whose card post is mid-flight — INITIAL delivery or re-delivery.
+ * Guard (iii) against double-delivery: the 60s reaper must not re-post a card
+ * whose previous post hasn't settled yet (a slow send would otherwise be
+ * re-issued every tick). Registered at the top of postPermissionCard (so both
+ * callers are covered) and cleared in its `.finally` — or its sync-throw catch.
  */
 const heldCardsInFlight = new Set<string>()
 
@@ -7120,8 +7144,22 @@ function sweepHeldPermissionCards(): void {
   for (const requestId of send) {
     const pend = pendingPermissions.get(requestId)
     if (pend == null) continue
-    heldCardsInFlight.add(requestId)
-    postPermissionCard(requestId, pend)
+    try {
+      // postPermissionCard registers the in-flight flag itself (so the ipc
+      // initial-delivery caller is covered too) and releases it once every
+      // target settles — or on a sync throw, in its own catch.
+      postPermissionCard(requestId, pend)
+    } catch (e) {
+      // A synchronous throw must not escape the setInterval callback (it would
+      // kill the whole reaper tick, TTL sweep included). postPermissionCard has
+      // already released the flag; delete again defensively so the entry is
+      // re-selectable on the next tick, and log rather than rethrow.
+      heldCardsInFlight.delete(requestId)
+      process.stderr.write(
+        `telegram gateway: held-card re-delivery for ${requestId} threw ` +
+        `synchronously: ${e} — flag released, will retry on the next tick\n`,
+      )
+    }
   }
 }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -172,6 +172,9 @@ import {
   createBlockedApprovalStore,
   safeActionForRecord,
   selectOldestHeld,
+  selectHeldForRedelivery,
+  holdReasonFor,
+  heldRetryBackoffMs,
   type UndeliverableMark,
 } from './approval-hold.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
@@ -2698,6 +2701,17 @@ function turnInFlightForGate(): boolean {
   // Keeping the gate closed for as long as there is an outstanding approval
   // card prevents that race. The gate reopens when the card is tapped or times
   // out (pendingPermissions.delete in finalizeCallback / TTL sweep).
+  //
+  // #3084 follow-up — ONE case now has no timeout valve: an approval HELD
+  // because its card could not be DELIVERED (a Telegram flood ban) never
+  // expires, by design. The leash may not fabricate a verdict for an ask no
+  // human ever saw, so the entry — and therefore this gate — persists until a
+  // human answers. An agent can consequently buffer normal inbound for the
+  // duration of a channel outage. That is the intended trade: a buffered
+  // message is recoverable, a silently auto-denied approval is not. The escape
+  // hatches are unaffected — /allow, /deny and /pending are grammy command
+  // handlers and do not sit behind this gate — and the block is surfaced
+  // off-Telegram in blocked-approvals/<agent>.json.
   const hasPendingApproval = pendingPermissions.size > 0
   if (!isDeliveryCutoverEnabled()) return claudeBusyKeys.size > 0 || hasPendingApproval
   // Machine is authoritative. Run the log-only drift canary (#2794): the
@@ -5454,6 +5468,11 @@ const sendGate = createSendGate({
   onWindowOpen: (scopeKey, untilTs) => recordFloodWindow(scopeKey, untilTs),
 })
 
+// Hoisted so the held-card re-delivery sweep (#3084 follow-up) asks the SAME
+// probe `robustApiCall` does, off the same on-disk window. The sweep's check and
+// the retry policy's own pre-call short-circuit are then two independent reads
+// of one source of truth, not two notions of "is the channel open".
+const probeFloodWaitRemainingMs = makeFloodWaitProbe(FLOOD_STATE_PATH)
 const rawRobustApiCall = createRetryApiCall({
   log: (line) => process.stderr.write(line),
   onFloodWait: (retryAfterSec) => {
@@ -5474,7 +5493,7 @@ const rawRobustApiCall = createRetryApiCall({
   // FLOOD_WAIT_ACTIVE instead), and the card surfaces re-drive on a 5-6s
   // heartbeat — without this gate that turns the fix into an amplifier that
   // fires thousands of requests into the open window and extends the ban.
-  floodWaitRemainingMs: makeFloodWaitProbe(FLOOD_STATE_PATH),
+  floodWaitRemainingMs: probeFloodWaitRemainingMs,
 })
 
 const robustApiCall = <T>(
@@ -5916,7 +5935,7 @@ const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
 // known-open Telegram flood window. While it is set the entry is HELD — the TTL
 // sweep skips it (never auto-deny an ask no human ever saw) and the reaper
 // re-posts the card once the window closes. Cleared on successful delivery.
-const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; startedAt: number; card_text: string; cards: { chatId: string; messageId: number; threadId?: number | null }[]; undeliverable?: UndeliverableMark | null }>()
+const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; startedAt: number; card_text: string; cards: { chatId: string; messageId: number; threadId?: number | null }[]; undeliverable?: UndeliverableMark | null; redeliveryFailures?: number }>()
 // PERMISSION_TTL_MS / ttlForTool / the timed-out card builder now live in
 // ./permission-timeout.ts (pure + unit-testable). hostd gated verbs get a
 // 30-min window; everything else keeps the 10-min default.
@@ -6906,9 +6925,213 @@ function restorePendingApprovalCards(): number {
   return restored
 }
 
+/**
+ * Post the Approve/Deny card for `requestId` to every permission-card target.
+ *
+ * Extracted from `onPermissionRequest` (#3084 follow-up) so it has TWO callers:
+ * the initial delivery, and the reaper's held-card re-delivery once a flood
+ * window closes. Both paths must behave identically — same routing, same
+ * thread-fallback, same landed-card bookkeeping, same hold-on-flood-wait — so
+ * there is exactly one implementation of "post this card".
+ *
+ * Everything it needs is rebuilt from the pending entry, so a re-delivery an
+ * hour later renders the same card the operator would have seen at T+0.
+ */
+function postPermissionCard(
+  requestId: string,
+  pend: NonNullable<ReturnType<typeof pendingPermissions.get>>,
+): void {
+  const text = pend.card_text
+  const showAlways =
+    resolveScopedAllowChoices(pend.tool_name, pend.input_preview) != null
+  const keyboard = buildPermissionActionRow(requestId, showAlways)
+  // Route the card to the SAME place the post-verdict resume message lands
+  // (resolvePermissionCardTargets): the ORIGINATING chat+topic when there's an
+  // active turn — so a supergroup agent's card appears IN the topic the
+  // operator asked from (marko's "CRM (Brevo)"), not the operator DM — else the
+  // configured operator DMs, thread-stripped. The old code iterated `allowFrom`
+  // unconditionally, so a supergroup card could only ever reach operator DMs
+  // (the topic chat id is never in `allowFrom`) (marko, 2026-06-03).
+  const targets = resolvePermissionCardTargets()
+
+  // ONE settle across ALL targets, not one per target (reviewer F1).
+  //
+  // The in-flight flag (guard iii) exists so the reaper can't re-post a card whose
+  // previous post hasn't settled. `resolvePermissionCardTargets()` returns N
+  // targets — it ends in `allowFrom.map(...)` — and on the RE-delivery path N>1 is
+  // the COMMON case: re-delivery after a multi-hour ban is by construction past the
+  // 30-min origin-recovery window, so it falls through to the operator-DM fan-out.
+  // Clearing the flag per-target released it the moment the FIRST target settled
+  // while others were still in flight, and the next tick re-posted to all of them —
+  // a double delivery. Settle once, when every target is done.
+  const sends = targets.map(({ chatId, threadId }) => {
+    // The rich-markdown path pairs with formatPermissionCardBody (#1790) so its
+    // bold/italic render. retryWithThreadFallback: if the topic was
+    // deleted/recreated (stale thread id → 400 "message thread not found"),
+    // re-send thread-less into the main chat so the card still ARRIVES rather
+    // than vanishing.
+    // allow-raw-bot-api: wrapped in retryWithThreadFallback (retry policy); topic-aware send
+    return retryWithThreadFallback<{ message_id: number; message_thread_id?: number }>(
+      robustApiCall,
+      (tid) =>
+        bot.api.sendRichMessage(chatId, richMessage(text), {
+          reply_markup: keyboard,
+          ...(tid != null ? { message_thread_id: tid } : {}),
+        }),
+      { threadId, chat_id: chatId, verb: 'permission_request' },
+    ).then(sent => {
+      // Record the live card's (chat, message) so the reaper can strip its inline
+      // keyboard — a stale Approve button left tappable dispatches a verdict for a
+      // dead request_id (Bug 2). The entry may already be gone (operator tapped
+      // before this resolved); guard the lookup.
+      const live = pendingPermissions.get(requestId)
+      if (live && sent && typeof sent.message_id === 'number') {
+        // #2787: record where the card ACTUALLY LANDED so the confirm sweep scopes
+        // its re-delivery suspension to the real chat/topic. `sent.message_thread_id`
+        // reflects reality in all three cases: topic success → tid, main-chat /
+        // fallback → undefined.
+        const landedThreadId = sent.message_thread_id ?? undefined
+        live.cards.push({ chatId, messageId: sent.message_id, threadId: landedThreadId })
+        // The card LANDED — the operator can see and tap it, so the block is over.
+        // Drop the hold mark and reconcile the off-Telegram surface. (PR 3 also
+        // resets `startedAt` here: the TTL measures how long the operator had to
+        // answer, and until this moment they had nothing to answer.)
+        if (live.undeliverable != null) {
+          live.undeliverable = null
+          live.redeliveryFailures = 0
+          reconcileBlockedApprovals()
+          process.stderr.write(
+            `telegram gateway: permission-card RE-DELIVERED request=${requestId} ` +
+            `tool=${live.tool_name} chat=${chatId} — the operator can answer now\n`,
+          )
+        }
+        permCardStore.add({
+          requestId,
+          chatId,
+          messageId: sent.message_id,
+          startedAt: live.startedAt,
+          toolName: live.tool_name,
+          cardText: live.card_text,
+        })
+      }
+    }).catch(e => {
+      process.stderr.write(`telegram gateway: permission_request send to ${chatId} failed: ${e}\n`)
+      const live = pendingPermissions.get(requestId)
+      if (live == null) return // operator already resolved it — nothing to hold
+
+      // A card already landed on ANOTHER target, so the ask is NOT undeliverable —
+      // the operator can see and tap it (reviewer F2). Marking it held here would be
+      // a PERMANENT wedge: `selectHeldForRedelivery` skips entries that have cards,
+      // so the mark could never be cleared, and PR 3's TTL freeze would then keep
+      // the entry alive forever with the surface stuck on "blocked".
+      if (live.cards.length > 0) return
+
+      // The card did NOT land anywhere. Before this the error was logged and
+      // dropped: the entry sat with `cards: []`, the operator saw nothing, and 60
+      // minutes later the TTL sweep AUTO-DENIED an approval no human had ever been
+      // shown. Now we hold it — but only for a TRANSIENT cause. `holdReasonFor`
+      // decides; a permanent 400 (a card that will never format) still falls through
+      // to the TTL, which PR 3 makes safe by giving the no-card timeout a
+      // missed-approvals fallback.
+      const reason = holdReasonFor(e)
+      if (reason == null) return
+
+      // Bound the RATE, never the RETRY. A held entry is re-selected every tick, so a
+      // target that keeps failing would otherwise re-send every 60s forever — the
+      // amplifier this series exists to avoid. Back off instead (1m, 2m, 4m … 30m).
+      // We never STOP retrying: a terminal give-up would strand the card even after
+      // the channel recovered, and because turnInFlightForGate() holds the inbound
+      // gate while a permission is pending, that would silently buffer the operator's
+      // messages forever. Escalate the surface, never the verdict — and never abandon
+      // the card.
+      const failures = (live.redeliveryFailures ?? 0) + 1
+      live.redeliveryFailures = failures
+      const now = Date.now()
+      // A flood-wait carries Telegram's own window end; everything else backs off.
+      const retryableAt = isFloodWaitActiveError(e) ? e.untilTs : now + heldRetryBackoffMs(failures)
+      // `since` is set ONCE — it is when the block began, not when we last retried.
+      live.undeliverable = { since: live.undeliverable?.since ?? now, retryableAt, reason }
+      // Reconcile the shared surface SYNCHRONOUSLY, here in the failure handler — not
+      // on the 60s reaper tick. The operator is locked out of Telegram; this record is
+      // the only way they learn an agent is blocked, so it must be live in under a
+      // second, not up to a minute.
+      reconcileBlockedApprovals()
+      process.stderr.write(
+        `telegram gateway: permission-card HELD (undeliverable) request=${requestId} ` +
+        `tool=${live.tool_name} reason=${reason} attempt=${failures} ` +
+        `retryable_at=${new Date(retryableAt).toISOString()}` +
+        ` — approval is held, NOT denied; re-delivering when the channel returns ` +
+        `(backoff ${Math.round(heldRetryBackoffMs(failures) / 60000)}m)\n`,
+      )
+    })
+  })
+
+  // Settle ONCE, after every target. `allSettled` never rejects, so the flag is
+  // always released — including when `targets` is empty (no active turn AND no
+  // configured operator DM), in which case `sends` is [] and this resolves at once.
+  void Promise.allSettled(sends).finally(() => {
+    heldCardsInFlight.delete(requestId)
+  })
+}
+
+/**
+ * Request ids whose re-delivery is mid-flight. Guard (iii) against
+ * double-delivery: the 60s reaper must not re-post a card whose previous
+ * re-post hasn't settled yet (a slow send would otherwise be re-issued every
+ * tick). Cleared in postPermissionCard's `.finally`.
+ */
+const heldCardsInFlight = new Set<string>()
+
+/**
+ * Re-deliver held permission cards once the flood window closes (#3084
+ * follow-up, PR 2).
+ *
+ * The whole point of holding rather than auto-denying is that the ask comes
+ * BACK. This is the half that brings it back.
+ *
+ * `selectHeldForRedelivery` owns the guards (window closed, held, no landed
+ * card, not in flight, per-tick cap). `robustApiCall`'s own pre-call probe is a
+ * further, independent short-circuit downstream — if the window re-opens
+ * between selection and send, the send refuses itself and the entry is simply
+ * re-marked with the longer window.
+ *
+ * The per-tick cap is the ban-safety property: a backlog of held cards must not
+ * BURST the instant the window closes, because that burst is the one realistic
+ * way this design could re-earn the ban it exists to survive. Deferred ids are
+ * LOGGED, never silently dropped — they go out on the next tick.
+ */
+function sweepHeldPermissionCards(): void {
+  const remaining = probeFloodWaitRemainingMs()
+  const { send, deferred } = selectHeldForRedelivery(pendingPermissions.entries(), {
+    floodRemainingMs: remaining,
+    inFlight: heldCardsInFlight,
+    now: Date.now(),
+  })
+  if (send.length === 0) return
+
+  process.stderr.write(
+    `telegram gateway: flood window closed — re-delivering ${send.length} held ` +
+    `permission card(s)` +
+    (deferred.length > 0
+      ? `; ${deferred.length} deferred to the next tick by the per-tick cap ` +
+        `(${deferred.join(', ')}) — deferred, NOT dropped`
+      : '') + '\n',
+  )
+  for (const requestId of send) {
+    const pend = pendingPermissions.get(requestId)
+    if (pend == null) continue
+    heldCardsInFlight.add(requestId)
+    postPermissionCard(requestId, pend)
+  }
+}
+
 // 60-second sweep drops anything past its documented TTL.
 const pendingStateReaper = setInterval(() => {
   const now = Date.now()
+  // #3084 follow-up — bring held cards BACK the moment the channel reopens.
+  // Runs before the TTL sweep below so a card that can be re-delivered on this
+  // tick is re-delivered, not considered for expiry.
+  sweepHeldPermissionCards()
   // OAuth-code state grouped first (pinned by secret-detect-oauth-code.test.ts).
   pendingReauthFlows.sweep(now)
   for (const [k, v] of pendingAuthAddFlows) {
@@ -10318,7 +10541,8 @@ const ipcServer: IpcServer = createIpcServer({
     // `card_text` is retained so the TTL reaper can re-edit the SAME body
     // with a "timed out" footer while stripping the keyboard atomically
     // (Bug 2 fix #1) — the reaper has no grammy ctx to read the live text.
-    pendingPermissions.set(requestId, { tool_name: toolName, description, input_preview: inputPreview, startedAt: Date.now(), card_text: text, cards: [] })
+    const pendEntry = { tool_name: toolName, description, input_preview: inputPreview, startedAt: Date.now(), card_text: text, cards: [] }
+    pendingPermissions.set(requestId, pendEntry)
     // Compact action row: ❌ Deny · ✅ Allow · 🔁 Always… — the scope of an
     // "always" grant stays hidden until the operator taps "🔁 Always…",
     // which swaps the row for a scope choice (this file / any file ⚠️). The
@@ -10326,125 +10550,15 @@ const ipcServer: IpcServer = createIpcServer({
     // rule for this tool; unknown tools get the two-button row only. "Allow"
     // itself auto-grants a 30-min window for narrow non-destructive scopes
     // (decided in the allow handler), so there is no separate time-box button.
-    const showAlways = resolveScopedAllowChoices(toolName, inputPreview) != null
-    const keyboard = buildPermissionActionRow(requestId, showAlways)
-    // Route the card to the SAME place the post-verdict resume message
-    // lands (resolvePermissionCardTargets): the ORIGINATING chat+topic when
-    // there's an active turn — so a supergroup agent's card appears IN the
-    // topic the operator asked from (marko's "CRM (Brevo)"), not the
-    // operator DM — else the configured operator DMs, thread-stripped. The
-    // old code iterated `allowFrom` unconditionally, so a supergroup card
-    // could only ever reach operator DMs (the topic chat id is never in
-    // `allowFrom`) (marko, 2026-06-03).
+    // Captured BEFORE the send: the status-reaction parking below needs the
+    // turn that raised this card, and `currentTurn` can be re-pointed by a
+    // concurrent inbound while the send is in flight.
     const activeTurn = currentTurn
-    const targets = resolvePermissionCardTargets()
-    for (const { chatId, threadId } of targets) {
-      // The rich-markdown path pairs with formatPermissionCardBody (#1790)
-      // so its bold/italic render. retryWithThreadFallback: if the topic was
-      // deleted/recreated (stale thread id → 400 "message thread not
-      // found"), re-send thread-less into the main chat so the card still
-      // ARRIVES rather than vanishing → 10-min TTL auto-deny → wedge.
-      // allow-raw-bot-api: wrapped in retryWithThreadFallback (retry policy); topic-aware send
-      void retryWithThreadFallback<{ message_id: number; message_thread_id?: number }>(
-        robustApiCall,
-        (tid) =>
-          bot.api.sendRichMessage(chatId, richMessage(text), {
-            reply_markup: keyboard,
-            ...(tid != null ? { message_thread_id: tid } : {}),
-          }),
-        { threadId, chat_id: chatId, verb: 'permission_request' },
-      ).then(sent => {
-        // Record the live card's (chat, message) so the TTL reaper can strip
-        // its inline keyboard on auto-deny — a stale Approve button left
-        // tappable dispatches a verdict for a dead request_id (Bug 2). The
-        // entry may already be gone (operator tapped before this resolved);
-        // guard the lookup.
-        const pend = pendingPermissions.get(requestId)
-        if (pend && sent && typeof sent.message_id === 'number') {
-          // #2787: record where the card ACTUALLY LANDED so the confirm sweep
-          // scopes its re-delivery suspension to the real chat/topic. When
-          // retryWithThreadFallback hit THREAD_NOT_FOUND (stale/renumbered
-          // topic) it re-sent thread-less into the main chat — the returned
-          // Message then carries no message_thread_id, so we must record the
-          // landed topic (undefined → suspend by bare chatId), NOT the stale
-          // requested `threadId`. Keying suspension on the stale topic would
-          // leave the main-chat card unsuspended (a re-deliver could clobber
-          // the live card) while needlessly suspending a topic that holds
-          // nothing. `sent.message_thread_id` reflects reality in all three
-          // cases: topic success → tid, main-chat / fallback → undefined.
-          const landedThreadId = sent.message_thread_id ?? undefined
-          pend.cards.push({ chatId, messageId: sent.message_id, threadId: landedThreadId })
-          // The card LANDED — the operator can see and tap it, so the block is
-          // over. Drop the hold mark and clear the off-Telegram surface. (PR 3
-          // also resets `startedAt` here: the TTL measures how long the operator
-          // had to answer, and until this moment they had nothing to answer.)
-          if (pend.undeliverable != null) {
-            pend.undeliverable = null
-            reconcileBlockedApprovals()
-          }
-          permCardStore.add({
-            requestId,
-            chatId,
-            messageId: sent.message_id,
-            startedAt: pend.startedAt,
-            toolName: pend.tool_name,
-            cardText: pend.card_text,
-          })
-        }
-      }).catch(e => {
-        process.stderr.write(`telegram gateway: permission_request send to ${chatId} failed: ${e}\n`)
-        // #3084 follow-up — the card did NOT land. Before this, the error was
-        // logged and dropped: the entry sat with `cards: []`, the operator saw
-        // nothing, and 60 minutes later the TTL sweep AUTO-DENIED an approval
-        // no human had ever been shown (and skipped the #2862 missed-approval
-        // re-offer, which is anchored on `cards[0]`). That is the leash
-        // deciding for the operator. Now we record the block instead.
-        //
-        // Only a FLOOD_WAIT_ACTIVE failure is a *hold*: it means the channel
-        // itself is shut (per-bot-token ban — nothing can land until `untilTs`)
-        // and the ask is deliverable later. Any other error (a 400, a malformed
-        // card) is a real failure of THIS send and keeps today's behaviour —
-        // holding on those would park the agent forever on a card that will
-        // never format correctly.
-        if (!isFloodWaitActiveError(e)) return
-        const pend = pendingPermissions.get(requestId)
-        if (pend == null) return // operator already resolved it — nothing to hold
-        // A card may already have LANDED on another target (the send fans out
-        // to several chats/topics and only THIS one hit the flood wall). The
-        // operator can see and tap the landed card, so the request is not
-        // blocked — marking it here would write a false blocked record AND
-        // make it eligible for a duplicate re-delivery. Same guard the
-        // redelivery selector applies (guard ii in selectHeldForRedelivery).
-        if (pend.cards.length > 0) return
-        const now = Date.now()
-        // Re-marking is idempotent and self-correcting: if the window is
-        // re-extended by a fresh 429, `computeFloodWait` only ever grows
-        // `untilTs`, so a later mark carries the longer window. `since` is
-        // "when we FIRST failed" (the UndeliverableMark contract), so a
-        // re-failure preserves the original timestamp — resetting it would
-        // churn the oldest-held-wins reconcile between records.
-        pend.undeliverable = {
-          since: pend.undeliverable?.since ?? now,
-          retryableAt: e.untilTs,
-          reason: 'flood_wait',
-        }
-        // Write the shared surface SYNCHRONOUSLY, here in the failure handler —
-        // not on the 60s reaper tick. The operator is locked out of Telegram;
-        // the off-Telegram surface is the only way they learn an agent is
-        // blocked, so it has to be live in under a second, not up to a minute.
-        // Metadata only: `action` is naturalAction() text. NEVER input_preview —
-        // this file is world-readable (0644) so switchroom-web can read it.
-        // Reconcile rather than write directly: several permissions can be held
-        // at once (parallel tool calls), and the surface must reflect all of
-        // them, not just the last one to fail.
-        reconcileBlockedApprovals()
-        process.stderr.write(
-          `telegram gateway: permission-card HELD (undeliverable) request=${requestId} ` +
-          `tool=${pend.tool_name} reason=flood_wait retryable_at=${new Date(e.untilTs).toISOString()} ` +
-          `— approval is held, NOT denied; will re-deliver when the window closes\n`,
-        )
-      })
-    }
+    // #3084 follow-up — the send now lives in postPermissionCard() so the
+    // reaper can RE-DRIVE it when a flood window closes. This is the first
+    // delivery attempt; if it fails against an open ban the entry is marked
+    // undeliverable and held, never auto-denied.
+    postPermissionCard(requestId, pendEntry)
     // Park the turn's status reaction on 🙏 (awaiting your tap) and
     // suspend the stall watchdog — a turn blocked on the operator is not
     // stalled, so it must not degrade to 🥱/😨 while the card sits

--- a/telegram-plugin/retry-api-call.ts
+++ b/telegram-plugin/retry-api-call.ts
@@ -158,6 +158,16 @@ export function isLocalResourceError(err: unknown): boolean {
 export const LOCAL_RESOURCE_EXHAUSTED = 'LOCAL_RESOURCE_EXHAUSTED'
 
 /**
+ * Thrown when every retry is exhausted — a network partition, a Telegram 5xx
+ * outage, or a short-but-persistent 429 (only 429s longer than the in-process
+ * sleep ceiling raise FLOOD_WAIT_ACTIVE; shorter ones are slept, retried, and
+ * end here). Exported as a constant because `approval-hold.ts:holdReasonFor`
+ * classifies on it to decide whether an undeliverable approval is HELD — a
+ * string that drifts would silently reopen the auto-deny hole.
+ */
+export const GIVE_UP_MESSAGE = 'retryApiCall: max retries exceeded'
+
+/**
  * Marker error thrown when Telegram's reported `retry_after` exceeds the
  * in-process sleep ceiling (#3084) — i.e. the bot is under a LONG per-bot
  * flood ban, not a momentary rate-limit blip.
@@ -427,7 +437,7 @@ export function createRetryApiCall(
         throw err
       }
     }
-    const giveUpErr = new Error('retryApiCall: max retries exceeded')
+    const giveUpErr = new Error(GIVE_UP_MESSAGE)
     observer?.onGiveUp?.({ attempts: maxRetries, error: giveUpErr })
     throw giveUpErr
   }

--- a/telegram-plugin/tests/approval-hold-harness.ts
+++ b/telegram-plugin/tests/approval-hold-harness.ts
@@ -38,6 +38,7 @@ import {
   createBlockedApprovalStore,
   blockedApprovalsDir,
   selectHeldForRedelivery,
+  selectOldestHeld,
   isHeldUndeliverable,
   safeActionForRecord,
   holdReasonFor,
@@ -225,22 +226,21 @@ export function createHarness(opts: { ttlFreeze?: boolean; cap?: number; targets
     return { message_id: 1000 + sends.length }
   }
 
-  /** Mirrors gateway.ts's reconcileBlockedApprovals: derive from live state. */
+  /**
+   * Mirrors gateway.ts's reconcileBlockedApprovals — and shares its SELECTION
+   * with production via `selectOldestHeld` (extracted in #3107's late fix), so
+   * the harness cannot drift from the real oldest-held-wins rule.
+   */
   function reconcile(): void {
-    let oldest: { id: string; p: Pending; since: number } | null = null
-    for (const [id, p] of pending) {
-      const u = p.undeliverable
-      if (u == null) continue
-      if (oldest == null || u.since < oldest.since) oldest = { id, p, since: u.since }
-    }
+    const oldest = selectOldestHeld(pending)
     if (oldest == null) { blockedStore.clear(); return }
-    const u = oldest.p.undeliverable!
+    const { requestId, pend: p, mark: u } = oldest
     blockedStore.write({
       agent: 'overlord',
-      requestId: oldest.id,
-      toolName: oldest.p.tool_name,
-      action: safeActionForRecord(naturalAction, oldest.p.tool_name, oldest.p.input_preview),
-      blockedSince: oldest.p.startedAt,
+      requestId,
+      toolName: p.tool_name,
+      action: safeActionForRecord(naturalAction, p.tool_name, p.input_preview),
+      blockedSince: p.startedAt,
       undeliverableSince: u.since,
       retryableAt: u.retryableAt,
       reason: u.reason,

--- a/telegram-plugin/tests/approval-hold-harness.ts
+++ b/telegram-plugin/tests/approval-hold-harness.ts
@@ -130,6 +130,8 @@ export interface Harness {
   /** Hang one target's send until `releaseTarget` — lets a tick overlap it. */
   hangTarget: (chatId: string) => void
   releaseTarget: (chatId: string) => void
+  /** Make the NEXT postPermissionCard for `requestId` throw SYNCHRONOUSLY (one-shot). */
+  breakSync: (requestId: string) => void
   /** Remaining ms of the open window, per the real probe. */
   floodRemainingMs: () => number
   /** The gateway's `postPermissionCard` — first delivery AND re-delivery. */
@@ -179,6 +181,8 @@ export function createHarness(opts: { ttlFreeze?: boolean; cap?: number; targets
   const faults = new Map<string, () => unknown>()
   /** Chats banned individually (so one target can flood while another succeeds). */
   const perChatBan = new Map<string, number>()
+  /** Requests whose NEXT postPermissionCard throws SYNCHRONOUSLY (one-shot). */
+  const syncFaults = new Set<string>()
   /** Chats whose send HANGS until released — lets a tick overlap an in-flight send. */
   const gates = new Map<string, Promise<void>>()
   const gateReleases = new Map<string, () => void>()
@@ -248,9 +252,26 @@ export function createHarness(opts: { ttlFreeze?: boolean; cap?: number; targets
   // ends in `allowFrom.map(...)`). N>1 is the COMMON case on the re-delivery
   // path, so a harness pinned at N=1 cannot see the double-delivery and
   // permanent-wedge bugs that live in the multi-target interleaving.
-  async function postPermissionCard(requestId: string): Promise<void> {
+  function postPermissionCard(requestId: string): Promise<void> {
     const pend = pending.get(requestId)
-    if (pend == null) { heldInFlight.delete(requestId); return }
+    if (pend == null) { heldInFlight.delete(requestId); return Promise.resolve() }
+
+    // Mirrors gateway.ts: the flag is registered at the TOP of postPermissionCard
+    // itself, so the initial-delivery caller is covered as well as the sweep —
+    // otherwise a tick landing while a slow INITIAL send is in flight re-posts.
+    heldInFlight.add(requestId)
+
+    try {
+    // A sync throw in the gateway's prologue (resolveScopedAllowChoices /
+    // buildPermissionActionRow / resolvePermissionCardTargets), made drivable.
+    if (syncFaults.delete(requestId)) {
+      throw new Error(`sync fault building card for ${requestId}`)
+    }
+
+    // One increment per ATTEMPT, not per failing target (mirrors gateway.ts):
+    // every failing target in the same fan-out stamps the SAME attempt number,
+    // so N failing targets don't ratchet the backoff ladder N× faster.
+    const attemptFailures = (pend.redeliveryFailures ?? 0) + 1
 
     const sends = targetChats.map(async (chatId) => {
       try {
@@ -278,7 +299,7 @@ export function createHarness(opts: { ttlFreeze?: boolean; cap?: number; targets
         if (live.cards.length > 0) return
         const reason = holdReasonFor(e)
         if (reason == null) return // permanent — falls through to the TTL
-        const failures = (live.redeliveryFailures ?? 0) + 1
+        const failures = attemptFailures
         live.redeliveryFailures = failures
         const now = clock.now()
         const retryableAt = isFloodWaitActiveError(e)
@@ -291,8 +312,13 @@ export function createHarness(opts: { ttlFreeze?: boolean; cap?: number; targets
 
     // ONE settle across ALL targets — the flag must not release while any
     // target is still in flight.
-    await Promise.allSettled(sends)
-    heldInFlight.delete(requestId)
+    return Promise.allSettled(sends).then(() => { heldInFlight.delete(requestId) })
+    } catch (e) {
+      // Mirrors gateway.ts: a sync throw never reaches the settle above, so
+      // release the flag here and rethrow to the caller (raise, or tick's catch).
+      heldInFlight.delete(requestId)
+      throw e
+    }
   }
 
   async function raise(requestId: string, toolName: string, inputPreview: string): Promise<void> {
@@ -322,8 +348,16 @@ export function createHarness(opts: { ttlFreeze?: boolean; cap?: number; targets
     // Awaiting here would make an overlapping tick impossible — and an
     // overlapping tick is precisely how a per-target in-flight clear
     // double-delivers. Tests that need the send settled `await h.settle()`.
-    for (const requestId of send) heldInFlight.add(requestId)
-    for (const id of send) { inFlightSends.push(postPermissionCard(id)) }
+    // postPermissionCard registers the in-flight flag itself; a SYNC throw is
+    // caught here (mirrors gateway's sweep) so it can't kill the tick, and the
+    // flag is deleted defensively so the entry stays re-selectable.
+    for (const id of send) {
+      try {
+        inFlightSends.push(postPermissionCard(id))
+      } catch {
+        heldInFlight.delete(id)
+      }
+    }
 
     // The TTL sweep, as gateway.ts runs it.
     for (const [k, v] of pending) {
@@ -371,6 +405,7 @@ export function createHarness(opts: { ttlFreeze?: boolean; cap?: number; targets
       gates.delete(chatId)
       gateReleases.delete(chatId)
     },
+    breakSync: (requestId: string) => { syncFaults.add(requestId) },
     floodRemainingMs: () => probe(),
     postPermissionCard,
     raise,

--- a/telegram-plugin/tests/approval-hold-harness.ts
+++ b/telegram-plugin/tests/approval-hold-harness.ts
@@ -1,0 +1,391 @@
+/**
+ * Shared harness for the approval-hold outcome tests (#3084 follow-up).
+ *
+ * gateway.ts has top-level side effects and is NOT unit-importable (the same
+ * constraint `permission-card-routing.test.ts:18` documents), so a literal
+ * "boot the gateway" integration test is not available. Instead this harness
+ * composes the REAL primitives the gateway composes, in the same order:
+ *
+ *   - `createRetryApiCall`   — the real retry policy, incl. its pre-call
+ *                              flood-window short-circuit (#3094)
+ *   - `retryWithThreadFallback` — the real send wrapper
+ *   - `makeFloodWaitRecorder` / `makeFloodWaitProbe` — the real on-disk window
+ *   - `selectHeldForRedelivery` / `isHeldUndeliverable` — the real hold decisions
+ *   - `createBlockedApprovalStore` — the real surface record
+ *   - `ttlForTool` — the real TTL
+ *
+ * Only two things are fakes: the Telegram transport (a counting send spy) and
+ * the IPC verdict dispatch (a spy — this is what proves no `deny` was ever
+ * fabricated). Everything that makes a DECISION is production code.
+ *
+ * Deliberately free of `vi.useFakeTimers()` / `vi.setSystemTime()` and of any
+ * import from `fake-bot-api.ts` (which pulls in `vi` at module scope): this
+ * harness must work under BOTH vitest and bun. It uses an explicit virtual
+ * clock instead — the pattern from `typing-emitter.test.ts`.
+ */
+
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { GrammyError } from 'grammy'
+import { createRetryApiCall, retryWithThreadFallback, isFloodWaitActiveError, GIVE_UP_MESSAGE } from '../retry-api-call.js'
+import {
+  floodStatePath,
+  makeFloodWaitRecorder,
+  makeFloodWaitProbe,
+} from '../flood-circuit-breaker.js'
+import {
+  createBlockedApprovalStore,
+  blockedApprovalsDir,
+  selectHeldForRedelivery,
+  isHeldUndeliverable,
+  safeActionForRecord,
+  holdReasonFor,
+  heldRetryBackoffMs,
+  type UndeliverableMark,
+  type BlockedApprovalStore,
+} from '../gateway/approval-hold.js'
+import { ttlForTool } from '../gateway/permission-timeout.js'
+import { naturalAction } from '../permission-title.js'
+
+/** A pending permission, shaped exactly like gateway.ts's `pendingPermissions` value. */
+export interface Pending {
+  tool_name: string
+  description: string
+  input_preview: string
+  startedAt: number
+  card_text: string
+  cards: { chatId: string; messageId: number; threadId?: number | null }[]
+  undeliverable?: UndeliverableMark | null
+  redeliveryFailures?: number
+}
+
+/** An IPC verdict as `dispatchPermissionVerdict` would emit it. */
+export interface Verdict {
+  requestId: string
+  behavior: 'allow' | 'deny'
+  message?: string
+}
+
+/** Build the real 429 GrammyError Telegram sends during a flood ban. */
+export function floodWait429(retryAfterSec: number): GrammyError {
+  return new GrammyError(
+    `Call to 'sendRichMessage' failed! (429: Too Many Requests: retry after ${retryAfterSec})`,
+    {
+      ok: false,
+      error_code: 429,
+      description: `Too Many Requests: retry after ${retryAfterSec}`,
+      parameters: { retry_after: retryAfterSec } as GrammyError['parameters'],
+    },
+    'sendRichMessage',
+    {},
+  )
+}
+
+/**
+ * The REAL failures a card send actually hits. Each throws exactly what Telegram
+ * or the network would; `retryApiCall` then decides what surfaces to the caller.
+ * The point of driving real errors is that our classification of them is the
+ * thing under test.
+ */
+export type FaultKind = 'tg_502' | 'tg_500' | 'econnreset' | 'fetch_failed' | 'tg_400' | 'tg_403'
+
+const grammyErr = (code: number, desc: string) => new GrammyError(
+  `Call to 'sendRichMessage' failed! (${code}: ${desc})`,
+  { ok: false, error_code: code, description: desc } as GrammyError['payload'] & { ok: false },
+  'sendRichMessage',
+  {},
+)
+
+export const FAULTS: Record<FaultKind, () => unknown> = {
+  // TRANSIENT — the operator never got to answer. Must be HELD.
+  tg_502: () => grammyErr(502, 'Bad Gateway'),
+  tg_500: () => grammyErr(500, 'Internal Server Error'),
+  econnreset: () => new Error('socket hang up ECONNRESET'),
+  fetch_failed: () => new Error('fetch failed'),
+  // PERMANENT — this card will never render. Falls through to the TTL.
+  tg_400: () => grammyErr(400, "Bad Request: can't parse entities"),
+  tg_403: () => grammyErr(403, 'Forbidden: bot was blocked by the user'),
+}
+
+export interface Harness {
+  stateDir: string
+  clock: { now: () => number; advance: (ms: number) => void }
+  /** Every send the transport actually saw. Length === card send count. */
+  sends: { chatId: string; requestId: string }[]
+  /** Every IPC verdict dispatched. A `deny` here for an unseen card is THE bug. */
+  verdicts: Verdict[]
+  /** True whenever the transport was invoked while the window was still open. */
+  sentIntoOpenWindow: boolean
+  pending: Map<string, Pending>
+  blockedStore: BlockedApprovalStore
+  /** Simulate Telegram flood-banning the bot for `ms`. */
+  banFor: (ms: number) => void
+  /** Make a target throw a REAL error. `kind` picks which real failure. */
+  breakTarget: (chatId: string, kind: FaultKind) => void
+  /** The channel recovers — the target starts working again. */
+  healTarget: (chatId: string) => void
+  /** Flood-ban ONE target, so another can succeed in the same fan-out. */
+  banTarget: (chatId: string, ms: number) => void
+  /** Hang one target's send until `releaseTarget` — lets a tick overlap it. */
+  hangTarget: (chatId: string) => void
+  releaseTarget: (chatId: string) => void
+  /** Remaining ms of the open window, per the real probe. */
+  floodRemainingMs: () => number
+  /** The gateway's `postPermissionCard` — first delivery AND re-delivery. */
+  postPermissionCard: (requestId: string) => Promise<void>
+  /** Raise a permission request, as `onPermissionRequest` does. */
+  raise: (requestId: string, toolName: string, inputPreview: string) => Promise<void>
+  /** One 60s reaper tick: held-card re-delivery sweep, then the TTL sweep. */
+  tick: () => Promise<void>
+  /** Await every in-flight send (the reaper itself never awaits them). */
+  settle: () => Promise<void>
+  /** tick() then settle() — the common case. */
+  tickSettled: () => Promise<void>
+  /** Is this request still mid-send? (the in-flight guard, made observable) */
+  isInFlight: (requestId: string) => boolean
+  /** Drain the microtask queue so pending .then/.catch chains run to completion. */
+  flush: () => Promise<void>
+  /** Operator taps Allow on a live card. */
+  tap: (requestId: string, behavior: 'allow' | 'deny') => void
+}
+
+export function createHarness(opts: { ttlFreeze?: boolean; cap?: number; targets?: string[] } = {}): Harness {
+  // PR 3's TTL freeze. Defaults ON (the shipped behaviour); the outcome test
+  // flips it OFF to reproduce origin/main's auto-deny and prove the red.
+  const ttlFreeze = opts.ttlFreeze ?? true
+
+  const stateDir = mkdtempSync(join(tmpdir(), 'approval-hold-'))
+  const floodPath = floodStatePath(stateDir)
+
+  // Anchored at real `Date.now()` so the virtual clock and the `untilTs` that
+  // retryApiCall stamps (which uses real Date.now()) stay coherent at T0.
+  let t = Date.now()
+  const clock = { now: () => t, advance: (ms: number) => { t += ms } }
+
+  const sends: { chatId: string; requestId: string }[] = []
+  const verdicts: Verdict[] = []
+  const pending = new Map<string, Pending>()
+  const heldInFlight = new Set<string>()
+  const blockedStore = createBlockedApprovalStore(blockedApprovalsDir(stateDir), 'overlord')
+
+  const targetChats = opts.targets ?? ['-100200']
+  /** Every send promise issued, so a test can await quiescence. */
+  const inFlightSends: Promise<void>[] = []
+  let banUntil = 0
+  let sentIntoOpenWindow = false
+
+  /** Per-chat fault: a factory for the REAL error the transport should throw. */
+  const faults = new Map<string, () => unknown>()
+  /** Chats banned individually (so one target can flood while another succeeds). */
+  const perChatBan = new Map<string, number>()
+  /** Chats whose send HANGS until released — lets a tick overlap an in-flight send. */
+  const gates = new Map<string, Promise<void>>()
+  const gateReleases = new Map<string, () => void>()
+
+  const probe = makeFloodWaitProbe(floodPath, clock.now)
+  const robustApiCall = createRetryApiCall({
+    sleep: async () => {}, // never actually sleep — the clock is virtual
+    onFloodWait: makeFloodWaitRecorder(floodPath, clock.now),
+    floodWaitRemainingMs: probe,
+  })
+
+  /** The fake Telegram transport. Rejects with a real 429 while banned. */
+  async function transport(chatId: string, requestId: string): Promise<{ message_id: number }> {
+    // Did this request reach Telegram while we ALREADY KNEW the window was
+    // open? That is the amplifier #3094 exists to prevent, and the one way this
+    // design could re-earn the ban. (The very FIRST send is how the ban is
+    // discovered — the on-disk window is empty until a 429 records it — so it
+    // is legitimately not "into a known-open window".)
+    if (probe() > 0) sentIntoOpenWindow = true
+
+    // Hang here until the test releases us — models a send still in flight when
+    // the next 60s reaper tick fires.
+    const gate = gates.get(chatId)
+    if (gate != null) { await gate }
+
+    const fault = faults.get(chatId)
+    if (fault != null) {
+      // Throw the REAL error Telegram/the network would produce, and let the REAL
+      // retryApiCall decide what surfaces. The previous harness threw
+      // GIVE_UP_MESSAGE directly — the *conclusion* — which hard-coded a premise
+      // that turned out to be false (a 5xx is re-thrown RAW, not as a give-up) and
+      // made a live auto-deny bug pass green.
+      throw fault()
+    }
+
+    const until = Math.max(banUntil, perChatBan.get(chatId) ?? 0)
+    const remaining = until - clock.now()
+    if (remaining > 0) throw floodWait429(Math.ceil(remaining / 1000))
+    sends.push({ chatId, requestId })
+    return { message_id: 1000 + sends.length }
+  }
+
+  /** Mirrors gateway.ts's reconcileBlockedApprovals: derive from live state. */
+  function reconcile(): void {
+    let oldest: { id: string; p: Pending; since: number } | null = null
+    for (const [id, p] of pending) {
+      const u = p.undeliverable
+      if (u == null) continue
+      if (oldest == null || u.since < oldest.since) oldest = { id, p, since: u.since }
+    }
+    if (oldest == null) { blockedStore.clear(); return }
+    const u = oldest.p.undeliverable!
+    blockedStore.write({
+      agent: 'overlord',
+      requestId: oldest.id,
+      toolName: oldest.p.tool_name,
+      action: safeActionForRecord(naturalAction, oldest.p.tool_name, oldest.p.input_preview),
+      blockedSince: oldest.p.startedAt,
+      undeliverableSince: u.since,
+      retryableAt: u.retryableAt,
+      reason: u.reason,
+    })
+  }
+
+  // ── postPermissionCard — mirrors gateway.ts's extracted send ──────────────
+  // Fans out to N targets, exactly as `resolvePermissionCardTargets()` does (it
+  // ends in `allowFrom.map(...)`). N>1 is the COMMON case on the re-delivery
+  // path, so a harness pinned at N=1 cannot see the double-delivery and
+  // permanent-wedge bugs that live in the multi-target interleaving.
+  async function postPermissionCard(requestId: string): Promise<void> {
+    const pend = pending.get(requestId)
+    if (pend == null) { heldInFlight.delete(requestId); return }
+
+    const sends = targetChats.map(async (chatId) => {
+      try {
+        const sent = await retryWithThreadFallback<{ message_id: number }>(
+          robustApiCall,
+          () => transport(chatId, requestId),
+          { threadId: undefined, chat_id: chatId, verb: 'permission_request' },
+        )
+        const live = pending.get(requestId)
+        if (live && sent) {
+          live.cards.push({ chatId, messageId: sent.message_id })
+          if (live.undeliverable != null) {
+            live.undeliverable = null
+            live.redeliveryFailures = 0
+            // PR 3: the operator's decision window starts NOW — until this
+            // moment they had nothing to answer.
+            live.startedAt = clock.now()
+            reconcile()
+          }
+        }
+      } catch (e) {
+        const live = pending.get(requestId)
+        if (live == null) return
+        // A card landed on ANOTHER target — the ask is NOT undeliverable.
+        if (live.cards.length > 0) return
+        const reason = holdReasonFor(e)
+        if (reason == null) return // permanent — falls through to the TTL
+        const failures = (live.redeliveryFailures ?? 0) + 1
+        live.redeliveryFailures = failures
+        const now = clock.now()
+        const retryableAt = isFloodWaitActiveError(e)
+          ? (e as { untilTs: number }).untilTs
+          : now + heldRetryBackoffMs(failures)
+        live.undeliverable = { since: live.undeliverable?.since ?? now, retryableAt, reason }
+        reconcile()
+      }
+    })
+
+    // ONE settle across ALL targets — the flag must not release while any
+    // target is still in flight.
+    await Promise.allSettled(sends)
+    heldInFlight.delete(requestId)
+  }
+
+  async function raise(requestId: string, toolName: string, inputPreview: string): Promise<void> {
+    pending.set(requestId, {
+      tool_name: toolName,
+      description: '',
+      input_preview: inputPreview,
+      startedAt: clock.now(),
+      card_text: `card for ${requestId}`,
+      cards: [],
+    })
+    await postPermissionCard(requestId)
+  }
+
+  // ── the 60s reaper tick ───────────────────────────────────────────────────
+  async function tick(): Promise<void> {
+    const now = clock.now()
+
+    // PR 2 — re-deliver held cards once the window closes.
+    const { send } = selectHeldForRedelivery(pending.entries(), {
+      floodRemainingMs: probe(),
+      inFlight: heldInFlight,
+      now,
+      ...(opts.cap != null ? { cap: opts.cap } : {}),
+    })
+    // Fire-and-forget, exactly like the real reaper (`void postPermissionCard(...)`).
+    // Awaiting here would make an overlapping tick impossible — and an
+    // overlapping tick is precisely how a per-target in-flight clear
+    // double-delivers. Tests that need the send settled `await h.settle()`.
+    for (const requestId of send) heldInFlight.add(requestId)
+    for (const id of send) { inFlightSends.push(postPermissionCard(id)) }
+
+    // The TTL sweep, as gateway.ts runs it.
+    for (const [k, v] of pending) {
+      // PR 3 — THE LEASH. A held entry NEVER expires: the TTL asks "how long
+      // did the operator have to answer?", and for a card that never landed the
+      // answer is zero seconds. With this guard removed we reproduce
+      // origin/main, which auto-denies an approval no human ever saw.
+      if (ttlFreeze && isHeldUndeliverable(v)) continue
+      if (now - v.startedAt > ttlForTool(v.tool_name)) {
+        verdicts.push({ requestId: k, behavior: 'deny', message: 'timed out' })
+        pending.delete(k)
+        reconcile()
+      }
+    }
+  }
+
+  function tap(requestId: string, behavior: 'allow' | 'deny'): void {
+    const pend = pending.get(requestId)
+    // A tap only resolves a card that actually EXISTS to be tapped.
+    if (pend == null || pend.cards.length === 0) return
+    verdicts.push({ requestId, behavior })
+    pending.delete(requestId)
+    reconcile()
+  }
+
+  return {
+    stateDir,
+    clock,
+    sends,
+    verdicts,
+    get sentIntoOpenWindow() { return sentIntoOpenWindow },
+    pending,
+    blockedStore,
+    banFor: (ms: number) => { banUntil = clock.now() + ms },
+    breakTarget: (chatId: string, kind: FaultKind) => { faults.set(chatId, FAULTS[kind]) },
+    healTarget: (chatId: string) => { faults.delete(chatId) },
+    banTarget: (chatId: string, ms: number) => { perChatBan.set(chatId, clock.now() + ms) },
+    hangTarget: (chatId: string) => {
+      let release!: () => void
+      gates.set(chatId, new Promise<void>(res => { release = res }))
+      gateReleases.set(chatId, release)
+    },
+    releaseTarget: (chatId: string) => {
+      gateReleases.get(chatId)?.()
+      gates.delete(chatId)
+      gateReleases.delete(chatId)
+    },
+    floodRemainingMs: () => probe(),
+    postPermissionCard,
+    raise,
+    tick,
+    settle: async () => { await Promise.allSettled(inFlightSends.splice(0)) },
+    tickSettled: async () => {
+      await tick()
+      await Promise.allSettled(inFlightSends.splice(0))
+    },
+    isInFlight: (requestId: string) => heldInFlight.has(requestId),
+    flush: async () => {
+      // Generous microtask drain — retryApiCall's give-up path hops several
+      // awaits (3 attempts x noop sleep) before its catch finally runs.
+      for (let i = 0; i < 50; i++) await Promise.resolve()
+    },
+    tap,
+  }
+}

--- a/telegram-plugin/tests/approval-hold-record.test.ts
+++ b/telegram-plugin/tests/approval-hold-record.test.ts
@@ -467,11 +467,13 @@ describe('gateway wiring — the failure handler records instead of discarding',
   it('does NOT mark undeliverable when a card already LANDED on another target', () => {
     // The send fans out to several chats/topics; one flood-walled leg must not
     // write a blocked record while the operator can see a live card.
-    expect(onPermissionRequestBody()).toContain('if (pend.cards.length > 0) return')
+    // (#3108 renamed the handler's `pend` to `live` when the send moved into
+    // postPermissionCard — the pin follows the merged code.)
+    expect(onPermissionRequestBody()).toContain('if (live.cards.length > 0) return')
   })
 
   it('a re-failure preserves the ORIGINAL since (the "first failed" contract)', () => {
-    expect(onPermissionRequestBody()).toContain('since: pend.undeliverable?.since ?? now')
+    expect(onPermissionRequestBody()).toContain('since: live.undeliverable?.since ?? now')
   })
 
   it('reconcile delegates selection to the unit-tested selectOldestHeld', () => {

--- a/telegram-plugin/tests/approval-hold-record.test.ts
+++ b/telegram-plugin/tests/approval-hold-record.test.ts
@@ -433,12 +433,16 @@ describe('gateway wiring — the failure handler records instead of discarding',
     'utf8',
   )
 
-  /** Body of the `onPermissionRequest` IPC handler. */
+  /**
+   * Body of `postPermissionCard` — the card emitter, and the owner of the
+   * send-failure handler. (The send was extracted out of `onPermissionRequest`
+   * so the reaper can re-drive it; the failure handler moved with it.)
+   */
   function onPermissionRequestBody(): string {
-    const start = GATEWAY_SRC.indexOf('onPermissionRequest(')
+    const start = GATEWAY_SRC.indexOf('function postPermissionCard(')
     expect(start).toBeGreaterThan(-1)
     const rest = GATEWAY_SRC.slice(start)
-    const end = rest.indexOf('onHeartbeat(')
+    const end = rest.indexOf('\nfunction ', 1)
     expect(end).toBeGreaterThan(-1)
     return rest.slice(0, end)
   }
@@ -451,9 +455,13 @@ describe('gateway wiring — the failure handler records instead of discarding',
 
   it('marks the pending entry undeliverable with the window end', () => {
     const body = onPermissionRequestBody()
-    expect(body).toContain('pend.undeliverable = {')
-    expect(body).toContain("reason: 'flood_wait'")
-    expect(body).toContain('retryableAt: e.untilTs')
+    expect(body).toMatch(/\.undeliverable = \{/)
+    expect(body).toContain('retryableAt, reason')
+    // A flood-wait carries Telegram's own window end; other transient faults
+    // (network, 5xx) have no such signal and back off instead.
+    // A flood-wait carries Telegram's own window end; every other transient
+    // fault has no such signal and backs off instead (1m, 2m, 4m … capped).
+    expect(body).toContain('isFloodWaitActiveError(e) ? e.untilTs : now + heldRetryBackoffMs(failures)')
   })
 
   it('does NOT mark undeliverable when a card already LANDED on another target', () => {
@@ -510,8 +518,12 @@ describe('gateway wiring — the failure handler records instead of discarding',
     expect(body).toContain('held, NOT denied')
   })
 
-  it('does NOT hold on non-flood errors (a 400 would park the agent forever)', () => {
-    // The early-return is the whole guard: only FLOOD_WAIT_ACTIVE is a hold.
-    expect(onPermissionRequestBody()).toContain('if (!isFloodWaitActiveError(e)) return')
+  it('does NOT hold on PERMANENT errors (a 400 would park the agent forever)', () => {
+    // holdReasonFor() is the whole guard: transient causes (flood-wait, give-up,
+    // local-resource) are HELD; a permanent 400/403 returns null and falls
+    // through to the TTL, which PR 3 makes safe with a missed-approvals fallback.
+    const body = onPermissionRequestBody()
+    expect(body).toContain('const reason = holdReasonFor(e)')
+    expect(body).toContain('if (reason == null) return')
   })
 })

--- a/telegram-plugin/tests/approval-hold-redeliver.test.ts
+++ b/telegram-plugin/tests/approval-hold-redeliver.test.ts
@@ -254,15 +254,49 @@ describe('gateway wiring — the reaper re-drives held cards', () => {
 
   // The production code MUST have the same shape the harness models, or the
   // outcome tests above are testing a fiction. These pin the three fan-out fixes.
-  it('F1 — the in-flight flag clears ONCE, after Promise.allSettled over every target', () => {
+  it('F1 — the in-flight flag clears ONCE per outcome, after Promise.allSettled over every target', () => {
     const at = GATEWAY_SRC.indexOf('function postPermissionCard(')
     const fn = GATEWAY_SRC.slice(at, GATEWAY_SRC.indexOf('\n/**', at))
     expect(fn).toContain('Promise.allSettled(sends)')
-    // Exactly one release, and it is the allSettled one — not a per-target
-    // .finally inside the fan-out loop.
-    expect(fn.match(/heldCardsInFlight\.delete\(requestId\)/g)?.length).toBe(1)
+    // Exactly two releases: the allSettled settle (the async path) and the
+    // sync-throw catch (so a throw in the prologue can't leak the flag).
+    // NOT a per-target .finally inside the fan-out loop.
+    expect(fn.match(/heldCardsInFlight\.delete\(requestId\)/g)?.length).toBe(2)
     expect(fn.indexOf('Promise.allSettled(sends)'))
       .toBeLessThan(fn.indexOf('heldCardsInFlight.delete(requestId)'))
+  })
+
+  it('the flag is registered at the TOP of postPermissionCard — both callers covered', () => {
+    const at = GATEWAY_SRC.indexOf('function postPermissionCard(')
+    const fn = GATEWAY_SRC.slice(at, GATEWAY_SRC.indexOf('\n/**', at))
+    // Registered inside postPermissionCard itself, before any send fires, so the
+    // ipc INITIAL-delivery caller is guarded too — not only the sweep.
+    expect(fn).toContain('heldCardsInFlight.add(requestId)')
+    expect(fn.indexOf('heldCardsInFlight.add(requestId)'))
+      .toBeLessThan(fn.indexOf('Promise.allSettled(sends)'))
+    // …and the sweep no longer registers it at the call site.
+    const sweepAt = GATEWAY_SRC.indexOf('function sweepHeldPermissionCards(')
+    const sweep = GATEWAY_SRC.slice(sweepAt, GATEWAY_SRC.indexOf('\n// 60-second sweep', sweepAt))
+    expect(sweep).not.toContain('heldCardsInFlight.add(')
+  })
+
+  it('a SYNC throw in the sweep loop is caught — the reaper tick survives, the flag is freed', () => {
+    const sweepAt = GATEWAY_SRC.indexOf('function sweepHeldPermissionCards(')
+    const sweep = GATEWAY_SRC.slice(sweepAt, GATEWAY_SRC.indexOf('\n// 60-second sweep', sweepAt))
+    expect(sweep).toContain('try {')
+    expect(sweep).toContain('postPermissionCard(requestId, pend)')
+    expect(sweep).toContain('heldCardsInFlight.delete(requestId)')
+  })
+
+  it('the backoff counts once per ATTEMPT, not once per failing target', () => {
+    const at = GATEWAY_SRC.indexOf('function postPermissionCard(')
+    const fn = GATEWAY_SRC.slice(at, GATEWAY_SRC.indexOf('\n/**', at))
+    // The attempt number is computed ONCE, before the fan-out; every failing
+    // target stamps the same value. A per-target `(live.redeliveryFailures ?? 0) + 1`
+    // inside the catch would ratchet the 1m/2m/4m ladder N× faster.
+    expect(fn).toContain('const attemptFailures = (pend.redeliveryFailures ?? 0) + 1')
+    expect(fn).toContain('const failures = attemptFailures')
+    expect(fn).not.toContain('const failures = (live.redeliveryFailures ?? 0) + 1')
   })
 
   it('F2 — the failure handler never re-marks an entry whose card already landed', () => {
@@ -410,6 +444,93 @@ describe('N targets — the fan-out cases a single-target harness cannot see', (
     expect(h.sends.length).toBe(1)
     expect(h.pending.get('req-1')?.undeliverable ?? null).toBeNull()
     expect(h.blockedStore.read()).toBeNull()
+  })
+
+  // Review finding: only the sweep registered the in-flight flag — the ipc
+  // INITIAL-delivery call site did not. So: target A fails transiently (marks
+  // the entry held), target B is still slowly sending, a tick lands past the
+  // backoff — and, unguarded, re-posts the card while the FIRST post is still
+  // in flight. The flag now lives at the top of postPermissionCard itself.
+  it('a tick landing while the INITIAL delivery is still in flight does not duplicate', async () => {
+    const h = createHarness({ targets: TWO })
+    dirs.push(h.stateDir)
+    h.breakTarget('-100200', 'econnreset')
+    h.hangTarget('-100999')
+
+    const first = h.raise('req-1', 'Bash', '{"command":"npm test"}') // NOT awaited
+    await h.flush() // let A's failure chain mark the entry held
+
+    expect(h.pending.get('req-1')?.undeliverable?.reason).toBe('transient')
+    // The INITIAL delivery registered the flag — that is the fix under test.
+    expect(h.isInFlight('req-1')).toBe(true)
+
+    // Past the backoff, with B STILL in flight: the sweep must not re-post.
+    h.clock.advance(2 * MINUTE)
+    await h.tick()
+    await h.flush()
+    await h.tick()
+    await h.flush()
+
+    h.releaseTarget('-100999')
+    await first
+    await h.settle()
+
+    // Exactly ONE card reached B — no duplicate from the overlapping ticks.
+    expect(h.sends.filter(x => x.chatId === '-100999').length).toBe(1)
+    expect(h.isInFlight('req-1')).toBe(false)
+  })
+
+  // Review finding: a SYNC throw in postPermissionCard's prologue leaked the
+  // in-flight flag (never reaching the settle `.finally`) AND escaped the
+  // setInterval callback. The entry would then never be re-selected — a wedge.
+  it('a SYNC throw during re-delivery does not wedge the entry — the next tick retries', async () => {
+    const h = harness()
+    h.banFor(FOUR_HOURS)
+    await h.raise('req-1', 'Bash', '{"command":"npm test"}')
+    expect(h.pending.get('req-1')?.undeliverable?.reason).toBe('flood_wait')
+
+    // Window closes, but the card build throws synchronously on this tick.
+    h.clock.advance(FOUR_HOURS + MINUTE)
+    h.breakSync('req-1')
+    await h.tickSettled()
+    expect(h.sends.length).toBe(0)
+    // The flag did NOT leak — the entry is still re-selectable.
+    expect(h.isInFlight('req-1')).toBe(false)
+
+    // The very next tick re-delivers. No wedge, no operator intervention.
+    await h.tickSettled()
+    expect(h.sends.length).toBe(1)
+    expect(h.pending.get('req-1')?.undeliverable ?? null).toBeNull()
+  })
+
+  // Review finding: `redeliveryFailures` incremented once per failing TARGET per
+  // attempt, so two failing targets walked the documented 1m/2m/4m ladder twice
+  // as fast (rung 2 after one attempt, rung 4 after two…).
+  it('N failing targets count as ONE attempt — the ladder stays 1m/2m/4m', async () => {
+    const h = createHarness({ targets: TWO })
+    dirs.push(h.stateDir)
+    h.breakTarget('-100200', 'econnreset')
+    h.breakTarget('-100999', 'econnreset')
+
+    await h.raise('req-1', 'Bash', '{"command":"npm test"}')
+    await h.settle()
+
+    // BOTH targets failed in one fan-out. That is attempt 1, not attempt 2 —
+    // and the backoff is the ladder's FIRST rung: 1 minute.
+    expect(h.pending.get('req-1')!.redeliveryFailures).toBe(1)
+    expect(h.pending.get('req-1')!.undeliverable!.retryableAt - h.clock.now()).toBe(MINUTE)
+
+    // Attempt 2 (both targets fail again): rung 2 — 2 minutes, not 8.
+    h.clock.advance(MINUTE)
+    await h.tickSettled()
+    expect(h.pending.get('req-1')!.redeliveryFailures).toBe(2)
+    expect(h.pending.get('req-1')!.undeliverable!.retryableAt - h.clock.now()).toBe(2 * MINUTE)
+
+    // Attempt 3: rung 3 — 4 minutes.
+    h.clock.advance(2 * MINUTE)
+    await h.tickSettled()
+    expect(h.pending.get('req-1')!.redeliveryFailures).toBe(3)
+    expect(h.pending.get('req-1')!.undeliverable!.retryableAt - h.clock.now()).toBe(4 * MINUTE)
   })
 })
 

--- a/telegram-plugin/tests/approval-hold-redeliver.test.ts
+++ b/telegram-plugin/tests/approval-hold-redeliver.test.ts
@@ -1,0 +1,481 @@
+/**
+ * #3084 follow-up, PR 2 — a held permission card must COME BACK when the flood
+ * window closes.
+ *
+ * Holding instead of auto-denying is only safe if the ask actually returns.
+ * This is the half that returns it. The risk it introduces is a BURST: a
+ * backlog of held cards all firing the instant the window closes is the one
+ * realistic way this design could re-earn the very ban it exists to survive.
+ * Hence the per-tick cap, and hence these tests.
+ *
+ * No fake timers (bun-compatible) — the harness carries a virtual clock.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { rmSync, readFileSync } from 'node:fs'
+import { createHarness, type FaultKind } from './approval-hold-harness.js'
+import {
+  selectHeldForRedelivery,
+  holdReasonFor,
+  HELD_CARD_REDELIVERY_CAP,
+} from '../gateway/approval-hold.js'
+
+const FOUR_HOURS = 4 * 60 * 60_000
+const MINUTE = 60_000
+
+const dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+function harness(opts?: { cap?: number }) {
+  const h = createHarness(opts)
+  dirs.push(h.stateDir)
+  return h
+}
+
+describe('held permission cards re-deliver when the window closes', () => {
+  it('does not send while the window is open, then sends EXACTLY once when it closes', async () => {
+    const h = harness()
+    h.banFor(FOUR_HOURS)
+
+    await h.raise('req-1', 'Bash', '{"command":"npm test"}')
+
+    // (a) nothing landed during the ban
+    expect(h.sends.length).toBe(0)
+    expect(h.pending.get('req-1')?.undeliverable?.reason).toBe('flood_wait')
+
+    // Ticks throughout the ban must not re-drive the send.
+    for (let i = 0; i < 20; i++) {
+      h.clock.advance(10 * MINUTE)
+      await h.tickSettled()
+    }
+    expect(h.sends.length).toBe(0)
+    expect(h.floodRemainingMs()).toBeGreaterThan(0)
+
+    // Window closes.
+    h.clock.advance(FOUR_HOURS)
+    await h.tickSettled()
+
+    // (d) exactly one card for the whole run — no loss, no duplicate.
+    expect(h.sends.length).toBe(1)
+    expect(h.sends[0]!.requestId).toBe('req-1')
+    // …and we never fired a request into a window we already knew was open.
+    expect(h.sentIntoOpenWindow).toBe(false)
+  })
+
+  it('clears the hold mark and the blocked record once the card lands', async () => {
+    const h = harness()
+    h.banFor(FOUR_HOURS)
+    await h.raise('req-1', 'Bash', '{"command":"npm test"}')
+    expect(h.blockedStore.read()?.requestId).toBe('req-1')
+
+    h.clock.advance(FOUR_HOURS + MINUTE)
+    await h.tickSettled()
+
+    expect(h.pending.get('req-1')?.undeliverable).toBeNull()
+    expect(h.pending.get('req-1')?.cards.length).toBe(1)
+    // The surface must go quiet — the operator can see the card in Telegram now.
+    expect(h.blockedStore.read()).toBeNull()
+  })
+
+  it('further ticks after a successful re-delivery never post a second card', async () => {
+    const h = harness()
+    h.banFor(FOUR_HOURS)
+    await h.raise('req-1', 'Bash', '{"command":"npm test"}')
+
+    h.clock.advance(FOUR_HOURS + MINUTE)
+    await h.tickSettled()
+    expect(h.sends.length).toBe(1)
+
+    // The `cards.length === 0` precondition is the double-delivery guard.
+    for (let i = 0; i < 5; i++) {
+      h.clock.advance(MINUTE)
+      await h.tickSettled()
+    }
+    expect(h.sends.length).toBe(1)
+  })
+
+  it('a ban EXTENSION re-holds with the longer window rather than bursting', async () => {
+    const h = harness()
+    h.banFor(FOUR_HOURS)
+    await h.raise('req-1', 'Bash', '{"command":"npm test"}')
+
+    // The window "closes"… but Telegram re-bans on the retry (computeFloodWait
+    // only ever GROWS untilTs, so this is self-correcting).
+    h.clock.advance(FOUR_HOURS + MINUTE)
+    h.banFor(FOUR_HOURS)
+    await h.tickSettled()
+
+    expect(h.sends.length).toBe(0)
+    expect(h.pending.get('req-1')?.undeliverable?.reason).toBe('flood_wait')
+
+    // The longer window eventually closes and the card lands — once.
+    h.clock.advance(FOUR_HOURS + MINUTE)
+    await h.tickSettled()
+    expect(h.sends.length).toBe(1)
+  })
+
+  it('the operator tap resolves the ORIGINAL requestId and the agent continues', async () => {
+    const h = harness()
+    h.banFor(FOUR_HOURS)
+    await h.raise('req-original', 'Bash', '{"command":"npm test"}')
+
+    h.clock.advance(FOUR_HOURS + MINUTE)
+    await h.tickSettled()
+
+    h.tap('req-original', 'allow')
+
+    expect(h.verdicts).toEqual([{ requestId: 'req-original', behavior: 'allow' }])
+    expect(h.pending.has('req-original')).toBe(false)
+    expect(h.blockedStore.read()).toBeNull()
+  })
+})
+
+describe('the per-tick cap — a backlog must not burst the moment the ban lifts', () => {
+  it('sends at most the cap per tick, and drains the rest on later ticks', async () => {
+    const h = harness()
+    h.banFor(FOUR_HOURS)
+    for (let i = 1; i <= 7; i++) {
+      await h.raise(`req-${i}`, 'Bash', `{"command":"cmd-${i}"}`)
+    }
+    expect(h.sends.length).toBe(0)
+
+    h.clock.advance(FOUR_HOURS + MINUTE)
+
+    await h.tickSettled()
+    expect(h.sends.length).toBe(HELD_CARD_REDELIVERY_CAP) // 3
+
+    await h.tickSettled()
+    expect(h.sends.length).toBe(2 * HELD_CARD_REDELIVERY_CAP) // 6
+
+    await h.tickSettled()
+    expect(h.sends.length).toBe(7) // drained — nothing lost
+
+    // And it settles: no eighth send, no duplicates.
+    await h.tickSettled()
+    expect(h.sends.length).toBe(7)
+    expect(new Set(h.sends.map(s => s.requestId)).size).toBe(7)
+    expect(h.sentIntoOpenWindow).toBe(false)
+  })
+})
+
+describe('selectHeldForRedelivery — the guards, directly', () => {
+  const held = (cards = 0) => ({
+    undeliverable: { since: 1, retryableAt: 2, reason: 'flood_wait' as const },
+    cards: new Array(cards).fill({}),
+  })
+
+  it('(i) sends NOTHING while the window is still open', () => {
+    const sel = selectHeldForRedelivery([['a', held()]], {
+      floodRemainingMs: 1,
+      inFlight: new Set(),
+    })
+    expect(sel).toEqual({ send: [], deferred: [] })
+  })
+
+  it('(ii) skips entries that already have a landed card (double-delivery guard)', () => {
+    const sel = selectHeldForRedelivery([['a', held(1)]], {
+      floodRemainingMs: 0,
+      inFlight: new Set(),
+    })
+    expect(sel.send).toEqual([])
+  })
+
+  it('(ii) skips entries that are not held at all', () => {
+    const sel = selectHeldForRedelivery([['a', { cards: [] }]], {
+      floodRemainingMs: 0,
+      inFlight: new Set(),
+    })
+    expect(sel.send).toEqual([])
+  })
+
+  it('(iii) skips entries already in flight from a previous tick', () => {
+    const sel = selectHeldForRedelivery([['a', held()]], {
+      floodRemainingMs: 0,
+      inFlight: new Set(['a']),
+    })
+    expect(sel.send).toEqual([])
+  })
+
+  it('(iv) caps the tick and DEFERS the overflow — never silently truncates', () => {
+    const entries: Array<[string, ReturnType<typeof held>]> = ['a', 'b', 'c', 'd', 'e'].map(
+      id => [id, held()],
+    )
+    const sel = selectHeldForRedelivery(entries, {
+      floodRemainingMs: 0,
+      inFlight: new Set(),
+      cap: 2,
+    })
+    expect(sel.send).toEqual(['a', 'b'])
+    // The overflow is reported, so the caller can log it. Nothing vanishes.
+    expect(sel.deferred).toEqual(['c', 'd', 'e'])
+    expect(sel.send.length + sel.deferred.length).toBe(entries.length)
+  })
+})
+
+/** Source-text pins — gateway.ts is not importable, so pin the wiring. */
+describe('gateway wiring — the reaper re-drives held cards', () => {
+  const GATEWAY_SRC = readFileSync(
+    new URL('../gateway/gateway.ts', import.meta.url),
+    'utf8',
+  )
+
+  it('the send is extracted into postPermissionCard, with two callers', () => {
+    expect(GATEWAY_SRC).toContain('function postPermissionCard(')
+    // caller 1: the initial delivery in onPermissionRequest
+    expect(GATEWAY_SRC).toContain('postPermissionCard(requestId, pendEntry)')
+    // caller 2: the reaper's held-card sweep
+    expect(GATEWAY_SRC).toContain('postPermissionCard(requestId, pend)')
+  })
+
+  it('the reaper runs the held-card sweep', () => {
+    expect(GATEWAY_SRC).toContain('function sweepHeldPermissionCards()')
+    expect(GATEWAY_SRC).toContain('sweepHeldPermissionCards()')
+  })
+
+  it('the sweep gates on the SAME flood probe robustApiCall uses', () => {
+    // One source of truth for "is the channel open" — the sweep's check and the
+    // retry policy's pre-call short-circuit are two reads of one on-disk window.
+    expect(GATEWAY_SRC).toContain('const probeFloodWaitRemainingMs = makeFloodWaitProbe(FLOOD_STATE_PATH)')
+    expect(GATEWAY_SRC).toContain('floodWaitRemainingMs: probeFloodWaitRemainingMs')
+    expect(GATEWAY_SRC).toContain('const remaining = probeFloodWaitRemainingMs()')
+  })
+
+  it('the sweep carries the in-flight guard', () => {
+    expect(GATEWAY_SRC).toContain('const heldCardsInFlight = new Set<string>()')
+    expect(GATEWAY_SRC).toContain('inFlight: heldCardsInFlight')
+    expect(GATEWAY_SRC).toContain('heldCardsInFlight.delete(requestId)')
+  })
+
+  it('deferred cards are logged, never silently dropped', () => {
+    expect(GATEWAY_SRC).toContain('deferred, NOT dropped')
+  })
+
+  // The production code MUST have the same shape the harness models, or the
+  // outcome tests above are testing a fiction. These pin the three fan-out fixes.
+  it('F1 — the in-flight flag clears ONCE, after Promise.allSettled over every target', () => {
+    const at = GATEWAY_SRC.indexOf('function postPermissionCard(')
+    const fn = GATEWAY_SRC.slice(at, GATEWAY_SRC.indexOf('\n/**', at))
+    expect(fn).toContain('Promise.allSettled(sends)')
+    // Exactly one release, and it is the allSettled one — not a per-target
+    // .finally inside the fan-out loop.
+    expect(fn.match(/heldCardsInFlight\.delete\(requestId\)/g)?.length).toBe(1)
+    expect(fn.indexOf('Promise.allSettled(sends)'))
+      .toBeLessThan(fn.indexOf('heldCardsInFlight.delete(requestId)'))
+  })
+
+  it('F2 — the failure handler never re-marks an entry whose card already landed', () => {
+    const at = GATEWAY_SRC.indexOf('function postPermissionCard(')
+    const fn = GATEWAY_SRC.slice(at, GATEWAY_SRC.indexOf('\n/**', at))
+    expect(fn).toContain('if (live.cards.length > 0) return')
+  })
+
+  it('F3/F6 — holdReasonFor decides, and re-delivery is bounded but the hold is not', () => {
+    const at = GATEWAY_SRC.indexOf('function postPermissionCard(')
+    const fn = GATEWAY_SRC.slice(at, GATEWAY_SRC.indexOf('\n/**', at))
+    expect(fn).toContain('const reason = holdReasonFor(e)')
+    expect(fn).toContain('live.redeliveryFailures = failures')
+    // The cap stops RE-SENDING, never the HOLD. No verdict is ever dispatched here.
+    expect(fn).not.toContain("behavior: 'deny'")
+    expect(fn).not.toContain("behavior: 'allow'")
+  })
+})
+
+/**
+ * The multi-target bugs. `resolvePermissionCardTargets()` ends in
+ * `allowFrom.map(...)` — it returns N targets, and on the RE-delivery path N>1 is
+ * the COMMON case (re-delivery after a multi-hour ban is by construction past the
+ * 30-min origin-recovery window, so it falls through to the operator-DM fan-out).
+ *
+ * A harness pinned at one target cannot see any of these. They were found in
+ * review, not by the tests — so they get tests.
+ */
+describe('N targets — the fan-out cases a single-target harness cannot see', () => {
+  const TWO = ['-100200', '-100999']
+
+  // F1. The reaper is fire-and-forget (`void postPermissionCard(...)`), so a send
+  // can still be in flight when the NEXT 60s tick fires. If the in-flight flag is
+  // cleared per-target, the first target to settle releases it while the second is
+  // still sending — and the next tick re-posts to BOTH.
+  it('the in-flight flag is NOT released until EVERY target settles', async () => {
+    // F1, stated as the invariant it protects. `resolvePermissionCardTargets()`
+    // returns N targets. If the flag is cleared per-target, the FIRST target to
+    // settle releases it while others are still sending — and the next 60s tick
+    // (the reaper is fire-and-forget, so ticks DO overlap in-flight sends)
+    // re-selects the request and posts the card all over again.
+    const h = createHarness({ targets: TWO })
+    dirs.push(h.stateDir)
+    h.banFor(FOUR_HOURS)
+    await h.raise('req-1', 'Bash', '{"command":"npm test"}')
+    await h.settle()
+    expect(h.sends.length).toBe(0)
+
+    // Window closes. Target A fails FAST (a transient give-up — note this does
+    // not re-open the flood window, so the sweep stays armed); target B HANGS.
+    h.clock.advance(FOUR_HOURS + MINUTE)
+    h.breakTarget('-100200', 'econnreset')
+    h.hangTarget('-100999')
+
+    await h.tick()     // fire-and-forget: A settles, B is still in flight
+    await h.flush()    // let A's failure chain run to completion
+
+    // A has settled and B has NOT. The request must STILL be flagged in-flight —
+    // this is the whole guard. A per-target clear releases it here.
+    expect(h.isInFlight('req-1')).toBe(true)
+
+    // …so an overlapping tick cannot re-select it.
+    await h.tick()
+    await h.flush()
+    await h.tick()
+    await h.flush()
+
+    h.releaseTarget('-100999')
+    await h.settle()
+
+    // B received exactly one card, and the flag is finally released.
+    expect(h.sends.filter(x => x.chatId === '-100999').length).toBe(1)
+    expect(h.isInFlight('req-1')).toBe(false)
+  })
+
+  // F2. Target A succeeds, target B flood-fails in the SAME fan-out. If the catch
+  // re-marks the entry without checking cards.length, we get
+  // `cards.length > 0 && undeliverable != null` — which selectHeldForRedelivery
+  // skips forever (it has cards), so the mark can never be cleared. Stacked with
+  // PR 3's TTL freeze that is a PERMANENT wedge: the agent never unblocks and the
+  // dashboard shows "blocked" forever.
+  it('a card landing on ONE target while another floods does NOT wedge the entry', async () => {
+    const h = createHarness({ targets: TWO })
+    dirs.push(h.stateDir)
+    h.banTarget('-100999', FOUR_HOURS)   // only this chat is banned
+    await h.raise('req-1', 'Bash', '{"command":"npm test"}')
+    await h.settle()
+
+    // The card LANDED on the good target — the operator can see and tap it.
+    expect(h.sends.length).toBe(1)
+    expect(h.sends[0]!.chatId).toBe('-100200')
+
+    // So the ask is NOT undeliverable, and there must be NO blocked record.
+    expect(h.pending.get('req-1')?.undeliverable ?? null).toBeNull()
+    expect(h.blockedStore.read()).toBeNull()
+
+    // …and it is not re-delivered forever, nor wedged: a tap resolves it.
+    for (let i = 0; i < 3; i++) { h.clock.advance(MINUTE); await h.tickSettled() }
+    expect(h.sends.length).toBe(1)
+    h.tap('req-1', 'allow')
+    expect(h.verdicts).toEqual([{ requestId: 'req-1', behavior: 'allow' }])
+  })
+
+  it('a PERMANENT failure (400) on every target is NOT held — it falls through', async () => {
+    const h = createHarness({ targets: ['-100999'] })
+    dirs.push(h.stateDir)
+    h.breakTarget('-100999', 'tg_400')
+    await h.raise('req-1', 'Bash', '{"command":"npm test"}')
+    await h.settle()
+
+    // A 400 will never format, whatever we do. Holding would park the agent
+    // forever on a card that can never render.
+    expect(h.sends.length).toBe(0)
+    expect(h.pending.get('req-1')?.undeliverable ?? null).toBeNull()
+    expect(h.blockedStore.read()).toBeNull()
+  })
+
+  // F3. A held entry is re-selected every tick. A target that keeps failing would
+  // otherwise be re-sent every 60s forever — the amplifier this series exists to
+  // avoid. But it must NEVER be abandoned either: a terminal give-up strands the
+  // card even after the channel recovers, and turnInFlightForGate() would buffer
+  // the operator's normal messages forever with no signal. So: bounded RATE,
+  // unbounded RETRY.
+  it('re-delivery BACKS OFF but is never abandoned — and the approval stays HELD', async () => {
+    const h = createHarness({ targets: ['-100999'] })
+    dirs.push(h.stateDir)
+    h.breakTarget('-100999', 'econnreset')   // a network partition
+    await h.raise('req-1', 'Bash', '{"command":"npm test"}')
+    await h.settle()
+
+    expect(h.pending.get('req-1')?.undeliverable?.reason).toBe('transient')
+
+    // Hammer it for two hours of ticks. The backoff must throttle the re-sends…
+    for (let i = 0; i < 120; i++) { h.clock.advance(MINUTE); await h.tickSettled() }
+    const attempts = h.pending.get('req-1')!.redeliveryFailures!
+    expect(attempts).toBeLessThan(20)   // NOT ~120 — the backoff is working
+
+    // …and no verdict was ever fabricated.
+    expect(h.verdicts).toEqual([])
+    expect(h.blockedStore.read()?.requestId).toBe('req-1')
+
+    // THE CHANNEL RECOVERS. The card must come back — never abandoned.
+    h.healTarget('-100999')
+    for (let i = 0; i < 40; i++) { h.clock.advance(MINUTE); await h.tickSettled() }
+    expect(h.sends.length).toBe(1)
+    expect(h.pending.get('req-1')?.undeliverable ?? null).toBeNull()
+    expect(h.blockedStore.read()).toBeNull()
+  })
+})
+
+/**
+ * THE CLASSIFIER, driven end-to-end through the REAL retry policy.
+ *
+ * The first version of holdReasonFor() was an allowlist of marker strings on the
+ * premise that a network partition or a Telegram 5xx would surface as a give-up.
+ * The premise was FALSE — retryApiCall re-throws a 5xx GrammyError raw (its
+ * network-retry branch is guarded by `!isGrammyErr`), and re-throws a raw network
+ * error on the last attempt. So the allowlist FAILED OPEN: a single routine 502 at
+ * send time reproduced 2026-07-11 in full — no card, no mark, TTL fires, agent told
+ * the operator declined.
+ *
+ * These drive the real errors through the real policy. This is the test that would
+ * have caught it, and the reason the harness must throw real faults rather than
+ * the conclusion it expects.
+ */
+describe('holdReasonFor — every real failure class, through the real retry policy', () => {
+  const TRANSIENT: FaultKind[] = ['tg_502', 'tg_500', 'econnreset', 'fetch_failed']
+  const PERMANENT: FaultKind[] = ['tg_400', 'tg_403']
+
+  for (const kind of TRANSIENT) {
+    it(`${kind} is HELD — the operator never got to answer`, async () => {
+      const h = createHarness({ targets: ['-100999'] })
+      dirs.push(h.stateDir)
+      h.breakTarget('-100999', kind)
+      await h.raise('req-1', 'Bash', '{"command":"npm test"}')
+      await h.settle()
+
+      expect(h.sends.length).toBe(0)
+      expect(h.pending.get('req-1')?.undeliverable?.reason).toBe('transient')
+      expect(h.blockedStore.read()?.requestId).toBe('req-1')
+
+      // …and past the 60-minute TTL, still no fabricated verdict.
+      for (let i = 0; i <= 61; i++) { await h.tickSettled(); h.clock.advance(MINUTE) }
+      expect(h.verdicts).toEqual([])
+      expect(h.pending.has('req-1')).toBe(true)
+    })
+  }
+
+  for (const kind of PERMANENT) {
+    it(`${kind} is NOT held — it will never render, so it falls through`, async () => {
+      const h = createHarness({ targets: ['-100999'] })
+      dirs.push(h.stateDir)
+      h.breakTarget('-100999', kind)
+      await h.raise('req-1', 'Bash', '{"command":"npm test"}')
+      await h.settle()
+
+      expect(h.sends.length).toBe(0)
+      expect(h.pending.get('req-1')?.undeliverable ?? null).toBeNull()
+      expect(h.blockedStore.read()).toBeNull()
+    })
+  }
+
+  it('an UNKNOWN error class fails CLOSED — held, not auto-denied', () => {
+    // The whole polarity of the fix. Anything we do not positively recognise as
+    // permanent is held. A held approval is visible and recoverable; a fabricated
+    // denial is neither.
+    expect(holdReasonFor(new Error('something nobody has seen before'))).toBe('transient')
+    expect(holdReasonFor({ weird: true })).toBe('transient')
+    expect(holdReasonFor(undefined)).toBe('transient')
+    // …and a rate-limit is the most transient failure there is — never permanent.
+    expect(holdReasonFor(Object.assign(new Error('x'), { error_code: 429 }))).toBe('transient')
+    // Only these two fall through.
+    expect(holdReasonFor(Object.assign(new Error('x'), { error_code: 400 }))).toBeNull()
+    expect(holdReasonFor(Object.assign(new Error('x'), { error_code: 403 }))).toBeNull()
+  })
+})

--- a/telegram-plugin/tests/permission-card-routing.test.ts
+++ b/telegram-plugin/tests/permission-card-routing.test.ts
@@ -46,6 +46,24 @@ function onPermissionRequestBody(): string {
   return rest.slice(0, end)
 }
 
+/**
+ * Slice the body of `postPermissionCard` — THE card emitter.
+ *
+ * The send used to be inlined in `onPermissionRequest`. The #3084 follow-up
+ * extracted it here so it has two callers (the initial delivery, and the
+ * reaper's re-delivery of a card held through a flood ban). The routing
+ * contract these tests pin is unchanged; it just lives one function over, and
+ * now BOTH delivery paths inherit it — which is the point of the extraction.
+ */
+function postPermissionCardBody(): string {
+  const start = GATEWAY_SRC.indexOf('function postPermissionCard(')
+  expect(start).toBeGreaterThan(-1)
+  const rest = GATEWAY_SRC.slice(start)
+  const end = rest.indexOf('\nfunction ', 1)
+  expect(end).toBeGreaterThan(-1)
+  return rest.slice(0, end)
+}
+
 describe('permission card routing', () => {
   it('the shared target helper exists', () => {
     expect(
@@ -53,19 +71,26 @@ describe('permission card routing', () => {
     ).toBe(true)
   })
 
-  it('the initial card emitter routes via resolvePermissionCardTargets()', () => {
-    expect(onPermissionRequestBody()).toContain('resolvePermissionCardTargets()')
+  it('the card emitter routes via resolvePermissionCardTargets()', () => {
+    expect(postPermissionCardBody()).toContain('resolvePermissionCardTargets()')
   })
 
-  it('the initial card emitter no longer iterates access.allowFrom directly (the bug shape)', () => {
+  it('the card emitter no longer iterates access.allowFrom directly (the bug shape)', () => {
     // The raw fan-out loop is what sent supergroup cards to operator DMs.
-    expect(onPermissionRequestBody()).not.toMatch(
+    expect(postPermissionCardBody()).not.toMatch(
       /for\s*\(\s*const\s+chat_id\s+of\s+access\.allowFrom\s*\)/,
     )
   })
 
   it('the card send is wrapped in retryWithThreadFallback (stale-topic → thread-less, not a silent drop)', () => {
-    expect(onPermissionRequestBody()).toContain('retryWithThreadFallback')
+    expect(postPermissionCardBody()).toContain('retryWithThreadFallback')
+  })
+
+  it('the initial permission request still delivers through that one emitter', () => {
+    // Guards the extraction itself: onPermissionRequest must not regrow its own
+    // send path and drift from the re-delivery path.
+    expect(onPermissionRequestBody()).toContain('postPermissionCard(requestId, pendEntry)')
+    expect(onPermissionRequestBody()).not.toContain('retryWithThreadFallback')
   })
 
   it('the resume message uses the SAME helper, so card + resume cannot drift', () => {

--- a/telegram-plugin/tests/permission-no-repeat-wiring.test.ts
+++ b/telegram-plugin/tests/permission-no-repeat-wiring.test.ts
@@ -91,14 +91,15 @@ describe('inbound gate holds while approval card is outstanding (#2841)', () => 
   // first interim reply. Without this, a new inbound delivered in that window
   // displaces the approval context and orphans the pending MCP call.
   it('turnInFlightForGate includes pendingPermissions.size > 0 on the legacy path', () => {
-    // span 1500: the function has a ~800-char comment block before the code lines.
-    const fn = slice(GATEWAY, 'function turnInFlightForGate()', 1500)
+    // span 2600: the function gained a ~1100-char note (#3084 follow-up) documenting
+    // the one case with no timeout valve — a HELD approval.
+    const fn = slice(GATEWAY, 'function turnInFlightForGate()', 2600)
     // Both paths (legacy claudeBusyKeys + machine-authoritative) must include the check.
     expect(fn).toMatch(/claudeBusyKeys\.size\s*>\s*0\s*\|\|\s*hasPendingApproval/)
   })
 
   it('turnInFlightForGate includes pendingPermissions.size > 0 on the machine path', () => {
-    const fn = slice(GATEWAY, 'function turnInFlightForGate()', 1600)
+    const fn = slice(GATEWAY, 'function turnInFlightForGate()', 2700)
     // probeGateParity(...) || hasPendingApproval — the inner arg contains its own
     // parens (isMachineInTurn()), so match the two tokens independently.
     expect(fn).toContain('probeGateParity(')
@@ -106,7 +107,7 @@ describe('inbound gate holds while approval card is outstanding (#2841)', () => 
   })
 
   it('hasPendingApproval reads pendingPermissions.size', () => {
-    const fn = slice(GATEWAY, 'function turnInFlightForGate()', 1500)
+    const fn = slice(GATEWAY, 'function turnInFlightForGate()', 2600)
     expect(fn).toMatch(/pendingPermissions\.size\s*>\s*0/)
   })
 })

--- a/telegram-plugin/tests/permission-rearm-wiring.test.ts
+++ b/telegram-plugin/tests/permission-rearm-wiring.test.ts
@@ -163,7 +163,7 @@ describe('gateway boot-sweep grace period', () => {
 
 describe('re-armed pending card re-holds the inbound gate (#2840)', () => {
   it('turnInFlightForGate counts pending approvals', () => {
-    const gate = slice(GATEWAY, 'function turnInFlightForGate()', 1200)
+    const gate = slice(GATEWAY, 'function turnInFlightForGate()', 2400)
     expect(gate).toMatch(/pendingPermissions\.size > 0/)
   })
   it('re-arm restores a pendingPermissions entry → gate held automatically', () => {


### PR DESCRIPTION
**PR 2 of 3.** Stacked on #3107. Merge #3107 first.

## Summary

Holding an approval instead of auto-denying it is only safe if the ask actually **comes back**. This is the half that brings it back.

- Extract the card send into **`postPermissionCard()`** — two callers (initial delivery, reaper re-delivery), one implementation. They cannot drift.
- `pendingStateReaper` runs **`sweepHeldPermissionCards()`**: held entries with no landed card are re-posted once the channel returns.

## THE LEASH HOLE THIS CLOSES — `holdReasonFor`

My first version of the classifier was an **allowlist** of marker strings, on the premise that a network partition or a Telegram 5xx would surface as a give-up. **The premise was false and the allowlist FAILED OPEN.** Driving real errors through the real `retryApiCall`:

```
Telegram 502 / 500        -> raw GrammyError       *** NOT HELD -> TTL AUTO-DENY ***
ECONNRESET / fetch failed -> raw Error             *** NOT HELD -> TTL AUTO-DENY ***
429 short, persistent     -> GIVE_UP_MESSAGE       HELD
429 long (16739s)         -> FLOOD_WAIT_ACTIVE     HELD
```

`retryApiCall`'s network-retry branch is guarded by `!isGrammyErr`, so a 5xx is re-thrown **raw on attempt 0**; a network error is re-thrown **raw on the last attempt**. `GIVE_UP_MESSAGE` was reachable only via the short-429 path.

**A single routine 502 at send time reproduced 2026-07-11 in full** — no card, no mark, TTL fires, agent told the operator declined. Same breach, different first cause.

`holdReasonFor` now **fails CLOSED**: anything not positively recognised as permanent is HELD. Only a **400** (a card that will never render) or a **403** (bot blocked) falls through — and #3109 gives even those a missed-approvals fallback so they're re-offered rather than vanishing.

## The guards

| # | Guard |
|---|---|
| (i) | the sweep's own probe — the window must read **closed** |
| (ii) | `cards.length === 0` — the double-delivery guard |
| (iii) | an in-flight flag, registered **inside `postPermissionCard`** so it covers BOTH callers, released **once** after every target settles |
| (iv) | a **per-tick cap of 3** — a backlog must not BURST when the ban lifts |
| (v) | **exponential backoff (1m → 30m ceiling)** — bounded RATE, unbounded RETRY |

> **Correction to a previous version of this description.** It described guard (v) as a "give-up cap (`HELD_REDELIVERY_MAX_FAILURES`)" that stops re-sending past a threshold. **No such constant exists.** The code implements exponential *backoff* and deliberately never abandons the card — a terminal give-up would strand it even after the channel recovered, and since `turnInFlightForGate()` holds the inbound gate while a permission is pending, that would silently buffer the operator's messages forever. The code was right; the description was wrong.

## Three multi-target bugs review caught

`resolvePermissionCardTargets()` ends in **`allowFrom.map(...)` — it returns N targets**, and on the re-delivery path **N>1 is the common case** (re-delivery after a multi-hour ban is by construction past the 30-min origin-recovery window, so it falls through to the operator-DM fan-out).

- **The in-flight flag was cleared PER-TARGET** — the first target to settle released it while others were still sending, so the next tick re-posted. Now: one `Promise.allSettled`, one release.
- **It was registered only on the REAPER path.** An **initial** send still in flight was invisible to the sweep: target B gives up on a short 429 and marks the entry held (that window has long expired, so the open-window gate does *not* save you), target A is still retrying with `cards: []` → next tick re-selects → **two live Approve buttons for one `request_id`**. Now registered inside `postPermissionCard`, covering both callers.
- **The flood re-mark didn't check `cards.length`.** Target A succeeds, target B floods → `cards > 0 && undeliverable != null` → `selectHeldForRedelivery` skips it forever (it has cards) → the mark can never be cleared → with #3109's freeze, a **permanently deaf agent**.

Also: the sweep's call is wrapped in `try/catch` — a synchronous throw in `postPermissionCard` would otherwise strand the id in `heldCardsInFlight` forever **and** escape the `setInterval` callback (no try/catch), killing the entire reaper tick.

## The harness now tests the real thing

Two masking classes, both fixed:

- It was pinned at **one target**, so every multi-target bug above was structurally invisible.
- `raise()` **awaited** the initial send, so no tick could ever overlap it — which is exactly why the initial-delivery in-flight hole survived.
- It threw **`GIVE_UP_MESSAGE` directly** — the *conclusion* — hard-coding the false premise above and making a live auto-deny bug pass green. It now throws **real** errors (a real `GrammyError(502)`, a real `ECONNRESET`) and lets the real retry policy decide what surfaces.

Every guard is mutation-tested: break it, the test goes red. Including the initial-delivery wiring:

```
BASELINE:                                              Tests  31 passed (31)
MUTATION (register in-flight only on the reaper path): Tests   2 failed | 29 passed (31)
```

## Test plan

31 tests in `approval-hold-redeliver.test.ts` (not 23 — a previous version of this description undercounted). Every real failure class is driven end-to-end through the real retry policy. Full `vitest run`: 882 files, zero failures. All 8 lint gates clean.

## Risk

Medium — this moves a live send path. Mitigated by the extraction being behaviour-preserving (routing, thread-fallback, landed-card bookkeeping all pinned) and by six layered guards. Worst case if the sweep misfires: a duplicate card, not a lost or fabricated verdict.

Job spec: `reference/jobs/approve-what-my-agent-can-touch.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mQR9UordBs4nJ797bxxod