### PR TITLE
feat(telegram-plugin): send-gate observability + operator flood alerts — #3084 PR 3/3

### DIFF
--- a/telegram-plugin/flood-circuit-breaker.ts
+++ b/telegram-plugin/flood-circuit-breaker.ts
@@ -380,6 +380,12 @@ export interface FloodWindowRecord {
   retryAfterSrc: string
   /** Epoch ms the window was (re)recorded. */
   observedAt: number
+  /**
+   * Epoch ms an operator alert was sent for THIS window (#3084 PR 3, §6). The
+   * at-most-once anchor: persisted so a restart mid-window never re-alerts.
+   * Unset until the observer alerts.
+   */
+  alertedAt?: number
 }
 
 /** Sibling file holding the scoped-window array. */
@@ -400,8 +406,17 @@ export function floodWindowsPath(stateDir: string): string {
  * conservative window — the exact opposite of `flood-wait.json`'s essential-send
  * probe, which must fail OPEN so a marker problem never gags the user's reply.
  * The asymmetry is deliberate: this file drives boot-time shedding, not the
- * user's reply, so failing safe here costs at most a few suppressed cosmetic
- * sends, while failing open resends straight into a ban (H2/M1, #3106 posture).
+ * user's reply, so failing safe here is the right call, while failing open
+ * resends straight into a ban (H2/M1, #3106 posture).
+ *
+ * Note the blast radius is NOT only cosmetic: this conservative window is
+ * `FLOOD_WINDOWS_CORRUPT_SUPPRESS_MS` (5 min), which exceeds the send gate's
+ * `criticalFailFastMs` (60s) ceiling — so while it is open a CRITICAL reply also
+ * fail-fasts with a structured `FLOOD_WAIT_ACTIVE` (a retryable error carrying
+ * `untilTs`, NOT a silent drop and NOT a hang) for up to 5 min after each boot.
+ * That only fires with the send gate flag ON and a genuinely corrupt/unreadable
+ * persisted file; the fail-fast is a real signal to the caller, so the posture
+ * is defensible — but it is fail-fast criticals, not merely suppressed cosmetics.
  */
 export const FLOOD_WINDOWS_CORRUPT_SUPPRESS_MS = 5 * 60_000
 
@@ -462,6 +477,9 @@ export function readFloodWindows(
       untilTs: rec.untilTs,
       retryAfterSrc: typeof rec.retryAfterSrc === 'string' ? rec.retryAfterSrc : 'unknown',
       observedAt: typeof rec.observedAt === 'number' ? rec.observedAt : now,
+      // Preserve the at-most-once alert anchor (#3084 PR 3) across reads so a
+      // restart mid-window does not re-alert.
+      ...(typeof rec.alertedAt === 'number' ? { alertedAt: rec.alertedAt } : {}),
     })
   }
   return out
@@ -488,7 +506,15 @@ export function writeFloodWindow(
       const prior = byScope.get(record.scopeKey)
       // Monotonic: keep the LATER expiry (never shorten an open window).
       const untilTs = prior && prior.untilTs > record.untilTs ? prior.untilTs : record.untilTs
-      byScope.set(record.scopeKey, { ...record, untilTs })
+      // Preserve a prior `alertedAt` when a window is EXTENDED (#3084 PR 3): a
+      // fresh 429 recorder call carries no alertedAt, and dropping it would
+      // re-arm the at-most-once alert for a window we already alerted on.
+      const alertedAt = record.alertedAt ?? prior?.alertedAt
+      byScope.set(record.scopeKey, {
+        ...record,
+        untilTs,
+        ...(alertedAt != null ? { alertedAt } : {}),
+      })
     }
     const arr = [...byScope.values()]
     const tmp = `${path}.tmp-${process.pid}`
@@ -510,6 +536,26 @@ export function writeFloodWindow(
   } catch {
     /* best-effort — a persistence failure must not crash the send path */
   }
+}
+
+/**
+ * Persist an `alertedAt` marker on the window for `scopeKey` (#3084 PR 3, §6).
+ *
+ * The at-most-once anchor for the operator flood alert: once written, a restart
+ * that re-reads the still-open window sees `alertedAt` set and does not re-alert.
+ * Best-effort and a no-op if the scope is no longer open (already pruned) — the
+ * window has closed, so at-most-once still holds. Reuses `writeFloodWindow`'s
+ * merge (it keeps the LATER `untilTs` and now carries `alertedAt` through).
+ */
+export function markFloodWindowAlerted(
+  path: string,
+  scopeKey: string,
+  alertedAt: number,
+  now: number,
+): void {
+  const open = readFloodWindows(path, now).find((w) => w.scopeKey === scopeKey)
+  if (!open) return
+  writeFloodWindow(path, { ...open, alertedAt }, now)
 }
 
 /**

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -190,6 +190,7 @@ import {
   isFloodWaitActiveError,
 } from '../retry-api-call.js'
 import { createSendGate, sendGateEnabledFromEnv } from '../send-gate.js'
+import { createStatsLogger, createFloodWindowObserver } from '../send-gate-observability.js'
 import { classifyPhotoFile, rerouteResultSuffix } from '../photo-precheck.js'
 import { installTgPostLogger, withTgPostTags } from '../shared/bot-runtime.js'
 import {
@@ -199,6 +200,8 @@ import {
   makeFloodWaitProbe,
   makeFloodWindowRecorder,
   loadInitialFloodWindows,
+  readFloodWindows,
+  markFloodWindowAlerted,
   suppressNonEssentialSendMs,
 } from '../flood-circuit-breaker.js'
 import { buildAttachmentPath, assertInsideInbox } from '../attachment-path.js'
@@ -5443,6 +5446,55 @@ const nonEssentialApiCall = createRetryApiCall({
     )
   },
 })
+
+// #3084 PR 3/3 — observability + operator flood alerts (part3-design §6).
+// A low-frequency, change-gated stats line + flood-window open/close snapshots
+// to the gateway-supervisor log, and ONE operator alert per prolonged flood
+// window. All feature-flagged: when the send gate is OFF, `stats().enabled` is
+// false and both `tick()`s are pure no-ops (the interval is not even scheduled).
+const SEND_GATE_OBSERVE_INTERVAL_MS = 15_000
+const sendGateStatsLogger = createStatsLogger({
+  stats: () => sendGate.stats(),
+  log: (line) => process.stderr.write(line),
+  clock: { now: () => Date.now(), sleep: (ms) => new Promise((r) => setTimeout(r, ms)) },
+})
+const floodWindowObserver = createFloodWindowObserver({
+  clock: { now: () => Date.now(), sleep: (ms) => new Promise((r) => setTimeout(r, ms)) },
+  log: (line) => process.stderr.write(line),
+  stats: () => sendGate.stats(),
+  readWindows: (now) => readFloodWindows(FLOOD_WINDOWS_PATH, now),
+  markAlerted: (scopeKey, alertedAt) =>
+    markFloodWindowAlerted(FLOOD_WINDOWS_PATH, scopeKey, alertedAt, Date.now()),
+  operatorChatId: () => loadAccess().allowFrom[0], // resolved per-tick (allowFrom can change)
+  sendAlert: async (text) => {
+    const operator = loadAccess().allowFrom[0]
+    if (operator === undefined) {
+      process.stderr.write(
+        `telegram gateway: send-gate flood alert not sent — no operator chat (allowFrom empty)\n`,
+      )
+      return
+    }
+    await robustApiCall(
+      // allow-raw-bot-api: operator flood alert, routed through robustApiCall.
+      () => bot.api.sendRichMessage(operator, richMessage(text), {}),
+      { chat_id: String(operator), verb: 'send-gate-flood-alert', priorityClass: 'critical' },
+    )
+  },
+})
+if (sendGateEnabledFromEnv()) {
+  const observeTimer = setInterval(() => {
+    try {
+      sendGateStatsLogger.tick()
+    } catch {
+      /* observability must never crash the gateway */
+    }
+    void floodWindowObserver.tick().catch(() => {
+      /* best-effort — a failed observer tick must not surface */
+    })
+  }, SEND_GATE_OBSERVE_INTERVAL_MS)
+  // Don't keep the event loop alive for observability alone.
+  observeTimer.unref?.()
+}
 
 // ─── Typing indicator ─────────────────────────────────────────────────────
 // All four state maps re-keyed from `chat_id` to `chatKey(chat, thread)`
@@ -20775,6 +20827,30 @@ async function buildAgentMetadata(agentName: string): Promise<AgentMetadata> {
     auth: authSummary,
     audit: buildAgentAudit(agentName),
     live: await buildLiveProbeRows(agentName),
+    sendGate: buildSendGateStatus(),
+  }
+}
+
+/**
+ * Build the `/status` send-gate block (#3084 PR 3, part3-design §6). Returns
+ * `undefined` when the gate flag is OFF so `/status` renders exactly as it did
+ * before the gate existed. Queued / shed totals come from the live counters;
+ * open flood windows are read from the persisted sibling file (already pruned).
+ */
+function buildSendGateStatus(): AgentMetadata['sendGate'] {
+  const s = sendGate.stats()
+  if (!s.enabled) return undefined
+  const openWindows = readFloodWindows(FLOOD_WINDOWS_PATH, Date.now()).map((w) => ({
+    scopeKey: w.scopeKey,
+    untilTs: w.untilTs,
+  }))
+  return {
+    queued: s.global.queued,
+    shed: s.global.shed,
+    expired: s.global.expired,
+    failedFast: s.global.failedFast,
+    dropped: s.global.dropped,
+    openWindows,
   }
 }
 

--- a/telegram-plugin/send-gate-observability.test.ts
+++ b/telegram-plugin/send-gate-observability.test.ts
@@ -145,8 +145,13 @@ describe('createFloodWindowObserver — snapshots', () => {
       operatorChatId: () => 'op',
     })
 
-    // Open a global window.
-    windows = [{ scopeKey: 'global', untilTs: 30_000, retryAfterSrc: '429', observedAt: 0 }]
+    // First (boot) tick with no windows establishes the baseline.
+    await obs.tick()
+    expect(logs).toHaveLength(0)
+
+    // A NEW window opens on a later tick (post-boot) → OPENED snapshot.
+    clock.cur = 5_000
+    windows = [{ scopeKey: 'global', untilTs: 30_000, retryAfterSrc: '429', observedAt: 5_000 }]
     await obs.tick()
     expect(logs.some((l) => l.includes('flood window OPENED scope=global'))).toBe(true)
     expect(logs.some((l) => l.includes('shed=2'))).toBe(true)
@@ -157,6 +162,35 @@ describe('createFloodWindowObserver — snapshots', () => {
     windows = []
     await obs.tick()
     expect(logs.some((l) => l.includes('flood window CLOSED scope=global'))).toBe(true)
+  })
+
+  it('logs ONE "loaded" line for boot-loaded windows, not per-scope OPENED spam (L3)', async () => {
+    const clock = new TestClock()
+    const logs: string[] = []
+    // Three windows already on disk at boot (a real 429 opens global+chat+group).
+    const windows: FloodWindowRecord[] = [
+      { scopeKey: 'global', untilTs: 300_000, retryAfterSrc: '429', observedAt: 0 },
+      { scopeKey: 'chat:op', untilTs: 300_000, retryAfterSrc: '429', observedAt: 0 },
+      { scopeKey: 'group:g', untilTs: 300_000, retryAfterSrc: '429', observedAt: 0 },
+    ]
+    const obs = createFloodWindowObserver({
+      clock,
+      log: (l) => logs.push(l),
+      stats: () => makeStats(),
+      readWindows: () => windows,
+      markAlerted: () => {},
+      sendAlert: async () => {},
+      operatorChatId: () => 'op',
+    })
+    await obs.tick()
+    // No OPENED spam for pre-existing windows.
+    expect(logs.some((l) => l.includes('flood window OPENED'))).toBe(false)
+    // Exactly one "loaded" line naming the count and every scope.
+    const loaded = logs.filter((l) => l.includes('loaded 3 open flood window(s) at boot'))
+    expect(loaded).toHaveLength(1)
+    expect(loaded[0]).toContain('global')
+    expect(loaded[0]).toContain('chat:op')
+    expect(loaded[0]).toContain('group:g')
   })
 
   it('does not run when the gate is disabled', async () => {
@@ -184,6 +218,13 @@ describe('createFloodWindowObserver — snapshots', () => {
 })
 
 describe('createFloodWindowObserver — alerting', () => {
+  // FORWARD-LOOKING (#3111): this exercises the immediate-delivery branch with a
+  // hand-built `chat:other`-only window. In production today that state never
+  // occurs — `openScopedWindowsForOpts` opens a coincident `global` window on
+  // every 429, so the operator is always "covered" and every alert defers to
+  // close (see M1 in the #3112 review). This test guards the branch so it is
+  // correct the moment #3111 makes `onFloodWait` scope-precise; the live path
+  // today is the deferred-close test below.
   it('alerts immediately for a chat-scoped ban on a DIFFERENT chat, at most once', async () => {
     const clock = new TestClock()
     const alerts: string[] = []
@@ -258,6 +299,52 @@ describe('createFloodWindowObserver — alerting', () => {
     expect(alerts).toHaveLength(1)
     expect(alerts[0]).toContain('flood ban cleared')
     expect(alerts[0]).toContain('was banned from')
+
+    // No re-alert afterwards.
+    clock.cur = 200_000
+    await obs.tick()
+    expect(alerts).toHaveLength(1)
+  })
+
+  it('coalesces one incident (global+chat+group) into ONE cleared card listing every scope (M1)', async () => {
+    const clock = new TestClock()
+    const alerts: string[] = []
+    // A single 429 opens all three scopes with the SAME untilTs (the live
+    // recorder behavior — see #3111). They all defer (global covers the
+    // operator) and all close in the same tick.
+    let windows: FloodWindowRecord[] = [
+      { scopeKey: 'global', untilTs: 120_000, retryAfterSrc: '429', observedAt: 0 },
+      { scopeKey: 'chat:op', untilTs: 120_000, retryAfterSrc: '429', observedAt: 0 },
+      { scopeKey: 'group:g', untilTs: 120_000, retryAfterSrc: '429', observedAt: 0 },
+    ]
+    const obs = createFloodWindowObserver({
+      clock,
+      log: () => {},
+      stats: () => makeStats(),
+      readWindows: () => windows,
+      markAlerted: () => {},
+      sendAlert: async (t) => {
+        alerts.push(t)
+      },
+      operatorChatId: () => 'op',
+      alertThresholdMs: 60_000,
+    })
+
+    // Past threshold, all scopes covered by the global window → nothing during.
+    clock.cur = 61_000
+    await obs.tick()
+    expect(alerts).toHaveLength(0)
+
+    // All three close in the same tick → EXACTLY ONE cleared card, not three.
+    clock.cur = 121_000
+    windows = []
+    await obs.tick()
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0]).toContain('flood ban cleared')
+    expect(alerts[0]).toContain('scopes') // plural — multiple scopes listed
+    expect(alerts[0]).toContain('global')
+    expect(alerts[0]).toContain('chat:op')
+    expect(alerts[0]).toContain('group:g')
 
     // No re-alert afterwards.
     clock.cur = 200_000

--- a/telegram-plugin/send-gate-observability.test.ts
+++ b/telegram-plugin/send-gate-observability.test.ts
@@ -1,0 +1,383 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  formatStatsLine,
+  countersChanged,
+  createStatsLogger,
+  createFloodWindowObserver,
+} from './send-gate-observability.js'
+import type { SendGateStats, Clock } from './send-gate.js'
+import {
+  writeFloodWindow,
+  readFloodWindows,
+  markFloodWindowAlerted,
+  floodWindowsPath,
+  type FloodWindowRecord,
+} from './flood-circuit-breaker.js'
+import { statusPairedText } from './welcome-text.js'
+
+/** Minimal settable clock. Observer/logger never actually sleep in these tests. */
+class TestClock implements Clock {
+  cur = 0
+  now(): number {
+    return this.cur
+  }
+  async sleep(): Promise<void> {
+    /* unused by the observability tick loops */
+  }
+}
+
+function makeStats(over: Partial<SendGateStats['global']> = {}, enabled = true): SendGateStats {
+  return {
+    enabled,
+    global: {
+      sent: 0,
+      queued: 0,
+      coalesced: 0,
+      dropped: 0,
+      shed: 0,
+      expired: 0,
+      failedFast: 0,
+      ...over,
+    },
+    messageStates: 0,
+    fill: { global: 4, perChat: {}, perGroup: {} },
+  }
+}
+
+describe('formatStatsLine', () => {
+  it('renders every counter + fill on one trailing-newline line', () => {
+    const line = formatStatsLine(
+      makeStats({ sent: 12, queued: 3, coalesced: 5, dropped: 2, shed: 8, expired: 1, failedFast: 4 }),
+    )
+    expect(line).toBe(
+      'telegram gateway: send-gate stats: sent=12 queued=3 coalesced=5 dropped=2 ' +
+        'shed=8 expired=1 failedFast=4 msgStates=0 chatBuckets=0 globalFill=4\n',
+    )
+    expect(line.endsWith('\n')).toBe(true)
+    expect(line.split('\n').filter((l) => l.length > 0)).toHaveLength(1)
+  })
+
+  it('rounds globalFill to one decimal', () => {
+    const s = makeStats()
+    s.fill.global = 23.14159
+    expect(formatStatsLine(s)).toContain('globalFill=23.1')
+  })
+})
+
+describe('countersChanged', () => {
+  it('is false for identical counters, true when any field differs', () => {
+    const a = makeStats().global
+    expect(countersChanged(a, { ...a })).toBe(false)
+    expect(countersChanged(a, { ...a, shed: 1 })).toBe(true)
+    expect(countersChanged(a, { ...a, failedFast: 1 })).toBe(true)
+  })
+})
+
+describe('createStatsLogger', () => {
+  it('logs at most once per interval AND only when a counter changed', async () => {
+    const clock = new TestClock()
+    const logs: string[] = []
+    let counters = makeStats().global
+    const logger = createStatsLogger({
+      stats: () => makeStats(counters),
+      log: (l) => logs.push(l),
+      clock,
+      intervalMs: 60_000,
+    })
+
+    // First tick with a fresh baseline logs immediately.
+    logger.tick()
+    expect(logs).toHaveLength(1)
+
+    // Changed counters but interval NOT elapsed (30s since the log at t=0) →
+    // no log (rate limit).
+    counters = { ...counters, sent: 5 }
+    clock.cur = 30_000
+    logger.tick()
+    expect(logs).toHaveLength(1)
+
+    // Interval elapsed but counters unchanged since the last logged snapshot →
+    // no log (no spam). Note the last LOG was at t=0 (t=30_000 didn't log).
+    counters = { ...counters, sent: 5 }
+    clock.cur = 70_000
+    // First make sure an UNCHANGED snapshot stays silent: temporarily revert.
+    // (Left as-is: counters already differ from the baseline, so this ticks.)
+    logger.tick()
+    expect(logs).toHaveLength(2)
+    expect(logs[1]).toContain('sent=5')
+
+    // Now unchanged since last log + interval elapsed → still silent.
+    clock.cur = 200_000
+    logger.tick()
+    expect(logs).toHaveLength(2)
+  })
+
+  it('is a no-op when the gate is disabled', () => {
+    const clock = new TestClock()
+    const logs: string[] = []
+    const logger = createStatsLogger({
+      stats: () => makeStats({ sent: 99 }, false),
+      log: (l) => logs.push(l),
+      clock,
+    })
+    logger.tick()
+    clock.cur = 1_000_000
+    logger.tick()
+    expect(logs).toHaveLength(0)
+  })
+})
+
+describe('createFloodWindowObserver — snapshots', () => {
+  it('logs a snapshot on window open and on window close', async () => {
+    const clock = new TestClock()
+    const logs: string[] = []
+    let windows: FloodWindowRecord[] = []
+    const obs = createFloodWindowObserver({
+      clock,
+      log: (l) => logs.push(l),
+      stats: () => makeStats({ shed: 2 }),
+      readWindows: () => windows,
+      markAlerted: () => {},
+      sendAlert: async () => {},
+      operatorChatId: () => 'op',
+    })
+
+    // Open a global window.
+    windows = [{ scopeKey: 'global', untilTs: 30_000, retryAfterSrc: '429', observedAt: 0 }]
+    await obs.tick()
+    expect(logs.some((l) => l.includes('flood window OPENED scope=global'))).toBe(true)
+    expect(logs.some((l) => l.includes('shed=2'))).toBe(true)
+
+    // Window gone (expired/pruned) → close snapshot.
+    logs.length = 0
+    clock.cur = 31_000
+    windows = []
+    await obs.tick()
+    expect(logs.some((l) => l.includes('flood window CLOSED scope=global'))).toBe(true)
+  })
+
+  it('does not run when the gate is disabled', async () => {
+    const clock = new TestClock()
+    const logs: string[] = []
+    const alerts: string[] = []
+    const obs = createFloodWindowObserver({
+      clock,
+      log: (l) => logs.push(l),
+      stats: () => makeStats({}, false),
+      readWindows: () => [
+        { scopeKey: 'chat:other', untilTs: 999_999, retryAfterSrc: '429', observedAt: 0 },
+      ],
+      markAlerted: () => {},
+      sendAlert: async (t) => {
+        alerts.push(t)
+      },
+      operatorChatId: () => 'op',
+    })
+    clock.cur = 500_000
+    await obs.tick()
+    expect(logs).toHaveLength(0)
+    expect(alerts).toHaveLength(0)
+  })
+})
+
+describe('createFloodWindowObserver — alerting', () => {
+  it('alerts immediately for a chat-scoped ban on a DIFFERENT chat, at most once', async () => {
+    const clock = new TestClock()
+    const alerts: string[] = []
+    const marked: { scope: string; at: number }[] = []
+    let windows: FloodWindowRecord[] = [
+      { scopeKey: 'chat:other', untilTs: 300_000, retryAfterSrc: '429', observedAt: 0 },
+    ]
+    const obs = createFloodWindowObserver({
+      clock,
+      log: () => {},
+      stats: () => makeStats(),
+      readWindows: () => windows,
+      markAlerted: (scope, at) => {
+        marked.push({ scope, at })
+        // simulate persistence: the next read carries alertedAt
+        windows = windows.map((w) => (w.scopeKey === scope ? { ...w, alertedAt: at } : w))
+      },
+      sendAlert: async (t) => {
+        alerts.push(t)
+      },
+      operatorChatId: () => 'op',
+      alertThresholdMs: 60_000,
+    })
+
+    // Below threshold → no alert yet.
+    clock.cur = 30_000
+    await obs.tick()
+    expect(alerts).toHaveLength(0)
+
+    // Past threshold, operator chat is clear → immediate alert + persisted marker.
+    clock.cur = 61_000
+    await obs.tick()
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0]).toContain('flood ban active')
+    expect(alerts[0]).toContain('chat:other')
+    expect(marked).toHaveLength(1)
+
+    // Subsequent ticks must NOT re-alert (alertedAt now set).
+    clock.cur = 120_000
+    await obs.tick()
+    expect(alerts).toHaveLength(1)
+  })
+
+  it('defers a GLOBAL ban alert until the window closes ("was banned from X to Y")', async () => {
+    const clock = new TestClock()
+    const alerts: string[] = []
+    let windows: FloodWindowRecord[] = [
+      { scopeKey: 'global', untilTs: 120_000, retryAfterSrc: '429', observedAt: 0 },
+    ]
+    const obs = createFloodWindowObserver({
+      clock,
+      log: () => {},
+      stats: () => makeStats(),
+      readWindows: () => windows,
+      markAlerted: () => {},
+      sendAlert: async (t) => {
+        alerts.push(t)
+      },
+      operatorChatId: () => 'op',
+      alertThresholdMs: 60_000,
+    })
+
+    // Past threshold but global → operator unreachable → NO alert during window.
+    clock.cur = 61_000
+    await obs.tick()
+    expect(alerts).toHaveLength(0)
+
+    // Window closes → deferred alert fires once, with the banned-from/to wording.
+    clock.cur = 121_000
+    windows = []
+    await obs.tick()
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0]).toContain('flood ban cleared')
+    expect(alerts[0]).toContain('was banned from')
+
+    // No re-alert afterwards.
+    clock.cur = 200_000
+    await obs.tick()
+    expect(alerts).toHaveLength(1)
+  })
+
+  it('does not alert for msg-edit (cosmetic) scopes', async () => {
+    const clock = new TestClock()
+    const alerts: string[] = []
+    const obs = createFloodWindowObserver({
+      clock,
+      log: () => {},
+      stats: () => makeStats(),
+      readWindows: () => [
+        { scopeKey: 'msg-edit:op:100', untilTs: 999_999, retryAfterSrc: '429', observedAt: 0 },
+      ],
+      markAlerted: () => {},
+      sendAlert: async (t) => {
+        alerts.push(t)
+      },
+      operatorChatId: () => 'op',
+    })
+    clock.cur = 500_000
+    await obs.tick()
+    expect(alerts).toHaveLength(0)
+  })
+})
+
+describe('alertedAt persistence (restart safety)', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'flood-windows-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('markFloodWindowAlerted persists alertedAt and readFloodWindows preserves it', () => {
+    const path = floodWindowsPath(dir)
+    writeFloodWindow(path, { scopeKey: 'chat:x', untilTs: 300_000, retryAfterSrc: '429', observedAt: 0 }, 0)
+    markFloodWindowAlerted(path, 'chat:x', 61_000, 61_000)
+    const [w] = readFloodWindows(path, 62_000)
+    expect(w.alertedAt).toBe(61_000)
+  })
+
+  it('preserves alertedAt when the window is later EXTENDED by a fresh 429', () => {
+    const path = floodWindowsPath(dir)
+    writeFloodWindow(path, { scopeKey: 'chat:x', untilTs: 300_000, retryAfterSrc: '429', observedAt: 0 }, 0)
+    markFloodWindowAlerted(path, 'chat:x', 61_000, 61_000)
+    // A later 429 extends the window (recorder carries no alertedAt).
+    writeFloodWindow(path, { scopeKey: 'chat:x', untilTs: 600_000, retryAfterSrc: '429', observedAt: 62_000 }, 62_000)
+    const [w] = readFloodWindows(path, 63_000)
+    expect(w.untilTs).toBe(600_000)
+    expect(w.alertedAt).toBe(61_000)
+  })
+
+  it('a restart mid-window (alertedAt already on disk) does not re-alert', async () => {
+    const path = floodWindowsPath(dir)
+    writeFloodWindow(
+      path,
+      { scopeKey: 'chat:other', untilTs: 300_000, retryAfterSrc: '429', observedAt: 0, alertedAt: 61_000 },
+      0,
+    )
+    const clock = new TestClock()
+    const alerts: string[] = []
+    const obs = createFloodWindowObserver({
+      clock,
+      log: () => {},
+      stats: () => makeStats(),
+      readWindows: (now) => readFloodWindows(path, now),
+      markAlerted: (scope, at) => markFloodWindowAlerted(path, scope, at, clock.cur),
+      sendAlert: async (t) => {
+        alerts.push(t)
+      },
+      operatorChatId: () => 'op',
+    })
+    clock.cur = 120_000 // well past threshold, window still open
+    await obs.tick()
+    expect(alerts).toHaveLength(0)
+  })
+})
+
+describe('/status send-gate block', () => {
+  const meta = {
+    agentName: 'a',
+    model: null,
+    extendsProfile: null,
+    topicName: null,
+    topicEmoji: null,
+    uptime: null,
+    status: null,
+    auth: null,
+  }
+
+  it('renders queued/shed totals and open flood windows when the gate is on', () => {
+    const text = statusPairedText({
+      user: '@op',
+      meta: {
+        ...meta,
+        sendGate: {
+          queued: 4,
+          shed: 9,
+          expired: 1,
+          failedFast: 2,
+          dropped: 3,
+          openWindows: [{ scopeKey: 'global', untilTs: Date.now() + 45_000 }],
+        },
+      },
+    })
+    expect(text).toContain('Send gate')
+    expect(text).toContain('queued 4')
+    expect(text).toContain('shed 9')
+    expect(text).toContain('fail-fast 2')
+    expect(text).toContain('flood window')
+    expect(text).toContain('global')
+  })
+
+  it('omits the send-gate block entirely when the gate is off (no sendGate field)', () => {
+    const text = statusPairedText({ user: '@op', meta })
+    expect(text).not.toContain('Send gate')
+  })
+})

--- a/telegram-plugin/send-gate-observability.ts
+++ b/telegram-plugin/send-gate-observability.ts
@@ -29,6 +29,15 @@
  *     "was banned from X to Y" alert when the window CLOSES (or as soon as the
  *     operator chat becomes reachable again).
  *
+ * STATUS OF THE IMMEDIATE PATH (today vs. after #3111)
+ * ----------------------------------------------------
+ * The immediate-delivery branch is present and unit-tested, but it does NOT
+ * fire in production yet: `openScopedWindowsForOpts` opens a coincident `global`
+ * window on every 429, so the operator chat is always "covered" while any ban is
+ * active and every alert defers to close. It becomes live once #3111 makes
+ * `onFloodWait` scope-precise. Until then the operator is alerted at window
+ * CLOSE — once per incident, all scopes coalesced into one card (M1, #3112).
+ *
  * At-most-once is anchored by the persisted `alertedAt` (survives restart). The
  * deferred close-alert is best-effort at-least-once: if the gateway is down for
  * the entire tail of the window and the record is pruned before it is seen
@@ -153,7 +162,9 @@ export interface FloodWindowObserver {
 
 /** Human-readable ISO-ish timestamp (UTC, second precision) for alert wording. */
 function fmtTs(ms: number): string {
-  return new Date(ms).toISOString().replace('.000', '').replace(/\.\d{3}/, '')
+  // Strip the milliseconds (`.\d{3}`) for second precision — this also covers
+  // the `.000` case, so no separate replace is needed.
+  return new Date(ms).toISOString().replace(/\.\d{3}/, '')
 }
 
 function fmtDur(ms: number): string {
@@ -177,10 +188,29 @@ export function createFloodWindowObserver(
   const alertThresholdMs = config.alertThresholdMs ?? 60_000
   // Full records seen on the previous tick, keyed by scope (close detection).
   let lastSeen = new Map<string, FloodWindowRecord>()
+  // First tick after boot: any window already present was loaded from disk
+  // (a ban that predates this process), NOT freshly opened — so we log a single
+  // "loaded N windows" line instead of a per-scope OPENED snapshot (L3, #3112).
+  let firstTick = true
   // Scopes whose alert could not be delivered during the window → owed on close.
   const owedOnClose = new Set<string>()
-  // Close alerts queued but not yet deliverable (operator chat still covered).
-  const pendingClose = new Map<string, FloodWindowRecord>()
+  // Close alerts owed but not yet deliverable, grouped per INCIDENT (an approx
+  // untilTs bucket). One real 429 opens several scopes (global + chat:<id> +
+  // group:<id>, all sharing one untilTs — see #3111's global over-suppression),
+  // which all close in the same tick; grouping collapses them into ONE operator
+  // "flood ban cleared" card listing every scope, instead of 2–3 near-identical
+  // cards per incident (M1, #3112).
+  // NOTE (L2, #3112): owedOnClose / pendingCloseByIncident are IN-MEMORY only —
+  // a restart during an open window drops the "owed" state and the deferred
+  // close-alert may be lost. This is the accepted at-least-once tradeoff
+  // documented in the module header; the invariant that matters (never RE-alert)
+  // is anchored on the persisted `alertedAt`, not on this state.
+  const pendingCloseByIncident = new Map<number, FloodWindowRecord[]>()
+
+  /** Bucket windows of one incident together by ~1s-rounded expiry. */
+  function incidentBucket(untilTs: number): number {
+    return Math.round(untilTs / 1000)
+  }
 
   function coversOperator(w: FloodWindowRecord, operatorChatId: string | undefined): boolean {
     if (w.scopeKey === 'global') return true
@@ -207,11 +237,21 @@ export function createFloodWindowObserver(
     )
   }
 
-  function closeAlertText(w: FloodWindowRecord): string {
+  /**
+   * ONE close-alert card for a whole incident. `recs` are the scopes of a
+   * single 429 (they share an ~untilTs bucket); we list every scope and span
+   * the interval as [earliest observedAt, latest untilTs] so the operator gets
+   * one card per incident rather than one per scope (M1, #3112).
+   */
+  function closeAlertText(recs: FloodWindowRecord[]): string {
+    const observedAt = Math.min(...recs.map((r) => r.observedAt))
+    const untilTs = Math.max(...recs.map((r) => r.untilTs))
+    const scopes = recs.map((r) => `\`${r.scopeKey}\``).join(', ')
+    const plural = recs.length > 1 ? 's' : ''
     return (
-      `⚠️ Telegram flood ban cleared (scope \`${w.scopeKey}\`). ` +
-      `The bot was banned from ${fmtTs(w.observedAt)} to ${fmtTs(w.untilTs)} UTC ` +
-      `(~${fmtDur(w.untilTs - w.observedAt)}). Some outbound messages during that ` +
+      `⚠️ Telegram flood ban cleared (scope${plural} ${scopes}). ` +
+      `The bot was banned from ${fmtTs(observedAt)} to ${fmtTs(untilTs)} UTC ` +
+      `(~${fmtDur(untilTs - observedAt)}). Some outbound messages during that ` +
       `window were suppressed.`
     )
   }
@@ -226,17 +266,31 @@ export function createFloodWindowObserver(
     for (const w of windows) current.set(w.scopeKey, w)
     const operatorReachable = !windows.some((w) => coversOperator(w, operatorChatId))
 
-    // Newly-opened scopes → snapshot.
-    for (const w of windows) {
-      if (!lastSeen.has(w.scopeKey)) {
+    if (firstTick) {
+      // Windows present on the very first tick were loaded at boot, not opened
+      // now — log ONE "loaded" line rather than a misleading OPENED snapshot per
+      // window (L3, #3112). Alerting for these still runs below (alertedAt-gated).
+      if (windows.length > 0) {
         config.log(
-          `telegram gateway: send-gate flood window OPENED scope=${w.scopeKey} ` +
-            `untilTs=${w.untilTs} src=${w.retryAfterSrc} — ${snapshotSuffix()}\n`,
+          `telegram gateway: send-gate flood observer loaded ${windows.length} ` +
+            `open flood window(s) at boot: ${windows.map((w) => w.scopeKey).join(', ')} ` +
+            `— ${snapshotSuffix()}\n`,
         )
+      }
+    } else {
+      // Newly-opened scopes → snapshot.
+      for (const w of windows) {
+        if (!lastSeen.has(w.scopeKey)) {
+          config.log(
+            `telegram gateway: send-gate flood window OPENED scope=${w.scopeKey} ` +
+              `untilTs=${w.untilTs} src=${w.retryAfterSrc} — ${snapshotSuffix()}\n`,
+          )
+        }
       }
     }
 
-    // Closed scopes → snapshot, and queue any owed close-alert.
+    // Closed scopes → snapshot, and queue any owed close-alert (grouped per
+    // incident so the operator gets ONE card listing all scopes — M1, #3112).
     for (const [scope, prev] of lastSeen) {
       if (current.has(scope)) continue
       config.log(
@@ -244,7 +298,10 @@ export function createFloodWindowObserver(
           `(was open ${fmtDur(now - prev.observedAt)}) — ${snapshotSuffix()}\n`,
       )
       if (owedOnClose.has(scope) && isAlertableScope(scope) && prev.alertedAt == null) {
-        pendingClose.set(scope, prev)
+        const bucket = incidentBucket(prev.untilTs)
+        const list = pendingCloseByIncident.get(bucket) ?? []
+        list.push(prev)
+        pendingCloseByIncident.set(bucket, list)
       }
       owedOnClose.delete(scope)
     }
@@ -255,6 +312,15 @@ export function createFloodWindowObserver(
       if (w.alertedAt != null) continue
       if (now - w.observedAt < alertThresholdMs) continue
       if (operatorReachable && !coversOperator(w, operatorChatId)) {
+        // NOTE (M1, #3112): this immediate-delivery branch is currently
+        // UNREACHABLE for recorder-produced state — `openScopedWindowsForOpts`
+        // opens a coincident `global` window on every 429, so `operatorReachable`
+        // is always false while any ban is active. It goes live once #3111 makes
+        // `onFloodWait` scope-precise. Kept + unit-tested as forward-looking.
+        // NOTE (L1, #3112): send-first, then persist `alertedAt`. A crash between
+        // the delivered card and the disk write re-alerts on restart — a benign
+        // duplicate. Deliberate: send-first guarantees an alert is never LOST,
+        // and never RE-alerting is the weaker of the two guarantees.
         try {
           await config.sendAlert(openAlertText(w, now))
           config.markAlerted(w.scopeKey, now)
@@ -268,12 +334,13 @@ export function createFloodWindowObserver(
       }
     }
 
-    // Flush deferred close alerts once the operator chat is reachable again.
-    if (operatorReachable && pendingClose.size > 0) {
-      for (const [scope, rec] of [...pendingClose]) {
+    // Flush deferred close alerts once the operator chat is reachable again —
+    // ONE card per incident, listing every scope (M1, #3112).
+    if (operatorReachable && pendingCloseByIncident.size > 0) {
+      for (const [bucket, recs] of [...pendingCloseByIncident]) {
         try {
-          await config.sendAlert(closeAlertText(rec))
-          pendingClose.delete(scope)
+          await config.sendAlert(closeAlertText(recs))
+          pendingCloseByIncident.delete(bucket)
         } catch {
           /* keep it pending; retry next tick */
         }
@@ -281,6 +348,7 @@ export function createFloodWindowObserver(
     }
 
     lastSeen = current
+    firstTick = false
   }
 
   return { tick }

--- a/telegram-plugin/send-gate-observability.ts
+++ b/telegram-plugin/send-gate-observability.ts
@@ -1,0 +1,287 @@
+/**
+ * Observability + operator alerting for the Telegram send gate (#3084, PR 3/3).
+ *
+ * WHY
+ * ---
+ * PRs 1 and 2 built the gate (token buckets, priority shedding, degraded mode,
+ * restart-proof scoped flood windows) but a live ban is still SILENT: the
+ * counters sit in memory and a prolonged flood window is invisible until a user
+ * notices dead air. part3-design §6 closes that gap:
+ *
+ *   1. A low-frequency one-line stats summary to the gateway-supervisor stderr
+ *      log (only when a counter changed — no log spam), plus a snapshot on every
+ *      flood-window open / close.
+ *   2. An operator alert when a flood window has been open past a threshold
+ *      (~60s), at-most-once per window.
+ *
+ * DELIVERABILITY OF THE ALERT (the tricky part)
+ * ---------------------------------------------
+ * The alert is a `critical` send, but it must NOT fight the very window it is
+ * reporting: sending a "you're flood-banned" card straight into an open GLOBAL
+ * ban just feeds the ban. So the observer distinguishes:
+ *
+ *   - The operator chat is NOT covered by any open window (e.g. a `chat:<other>`
+ *     ban while the operator's own chat is clear) → deliver IMMEDIATELY, and
+ *     persist an `alertedAt` marker on the window record so a restart mid-window
+ *     never re-alerts.
+ *   - The operator chat IS covered (a `global` ban, or a ban on the operator's
+ *     own chat) → do NOT send during the window. Remember it is owed and send a
+ *     "was banned from X to Y" alert when the window CLOSES (or as soon as the
+ *     operator chat becomes reachable again).
+ *
+ * At-most-once is anchored by the persisted `alertedAt` (survives restart). The
+ * deferred close-alert is best-effort at-least-once: if the gateway is down for
+ * the entire tail of the window and the record is pruned before it is seen
+ * again, the close alert is dropped — acceptable, because the invariant that
+ * matters is "never RE-alert" (which `alertedAt` guarantees), not "always alert".
+ *
+ * DETERMINISM / TESTABILITY
+ * -------------------------
+ * Everything is driven by an injectable `Clock` and manual `tick()` calls; the
+ * gateway wires `tick()` to a periodic timer. Window IO and the alert send are
+ * injected, so the module unit-tests with no disk, timer, or bot.
+ */
+
+import type { Clock, SendGateStats } from './send-gate.js'
+import type { FloodWindowRecord } from './flood-circuit-breaker.js'
+
+/** One-line, human-scannable summary of the gate counters + global fill. */
+export function formatStatsLine(stats: SendGateStats): string {
+  const c = stats.global
+  const globalFill = Math.round(stats.fill.global * 10) / 10
+  const perChat = Object.keys(stats.fill.perChat).length
+  return (
+    `telegram gateway: send-gate stats: ` +
+    `sent=${c.sent} queued=${c.queued} coalesced=${c.coalesced} dropped=${c.dropped} ` +
+    `shed=${c.shed} expired=${c.expired} failedFast=${c.failedFast} ` +
+    `msgStates=${stats.messageStates} chatBuckets=${perChat} globalFill=${globalFill}\n`
+  )
+}
+
+/** True when any of the seven gate counters differ between two snapshots. */
+export function countersChanged(a: SendGateStats['global'], b: SendGateStats['global']): boolean {
+  return (
+    a.sent !== b.sent ||
+    a.queued !== b.queued ||
+    a.coalesced !== b.coalesced ||
+    a.dropped !== b.dropped ||
+    a.shed !== b.shed ||
+    a.expired !== b.expired ||
+    a.failedFast !== b.failedFast
+  )
+}
+
+export interface StatsLoggerConfig {
+  /** Snapshot source (the gate's `stats()`). */
+  stats: () => SendGateStats
+  /** Where the one-line summary goes (gateway-supervisor stderr). */
+  log: (line: string) => void
+  /** Injectable clock. */
+  clock: Clock
+  /** Minimum ms between logged lines. Default 60_000. */
+  intervalMs?: number
+}
+
+export interface StatsLogger {
+  /**
+   * Emit the summary IFF (a) the gate is enabled, (b) at least `intervalMs`
+   * has elapsed since the last logged line, and (c) a counter changed since
+   * the last logged line. All three must hold — so a quiet gate is silent and
+   * a busy gate logs at most once per interval.
+   */
+  tick(): void
+}
+
+/** Low-frequency, change-gated stats logger (part3-design §6, item 1). */
+export function createStatsLogger(config: StatsLoggerConfig): StatsLogger {
+  const intervalMs = config.intervalMs ?? 60_000
+  let lastLoggedMs = Number.NEGATIVE_INFINITY
+  let lastCounters: SendGateStats['global'] | null = null
+
+  return {
+    tick() {
+      const s = config.stats()
+      if (!s.enabled) return
+      const now = config.clock.now()
+      if (now - lastLoggedMs < intervalMs) return
+      // First-ever log always fires (no baseline); afterwards only on a change.
+      if (lastCounters && !countersChanged(lastCounters, s.global)) return
+      lastLoggedMs = now
+      lastCounters = { ...s.global }
+      config.log(formatStatsLine(s))
+    },
+  }
+}
+
+// ─── Flood-window observer: open/close snapshots + operator alerting ─────────
+
+/** Alert-worthy scopes. `msg-edit:` windows are cosmetic and never alerted. */
+function isAlertableScope(scopeKey: string): boolean {
+  return scopeKey === 'global' || scopeKey.startsWith('chat:') || scopeKey.startsWith('group:')
+}
+
+export interface FloodWindowObserverConfig {
+  /** Injectable clock. */
+  clock: Clock
+  /** Where snapshot lines go. */
+  log: (line: string) => void
+  /** Gate stats source (for the open/close snapshot line). */
+  stats: () => SendGateStats
+  /** Read the persisted scoped windows (expired pruned), e.g. `readFloodWindows`. */
+  readWindows: (now: number) => FloodWindowRecord[]
+  /** Persist an `alertedAt` marker on a window record (at-most-once anchor). */
+  markAlerted: (scopeKey: string, alertedAt: number) => void
+  /**
+   * Send ONE operator alert (a `critical` send to the operator chat). Rejections
+   * are swallowed by the observer so a failed alert never breaks the tick loop.
+   */
+  sendAlert: (text: string) => Promise<void>
+  /**
+   * Resolve the operator chat id (`allowFrom[0]`) fresh each tick — `allowFrom`
+   * can change at runtime. When it returns undefined, no chat is "covered", so
+   * every alertable window is treated as immediately deliverable to the operator.
+   */
+  operatorChatId?: () => string | undefined
+  /** Ms a window must be open before it earns an alert. Default 60_000. */
+  alertThresholdMs?: number
+}
+
+export interface FloodWindowObserver {
+  /** Poll persisted windows once: emit open/close snapshots + drive alerts. */
+  tick(): Promise<void>
+}
+
+/** Human-readable ISO-ish timestamp (UTC, second precision) for alert wording. */
+function fmtTs(ms: number): string {
+  return new Date(ms).toISOString().replace('.000', '').replace(/\.\d{3}/, '')
+}
+
+function fmtDur(ms: number): string {
+  const s = Math.round(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  const rem = s % 60
+  return rem ? `${m}m${rem}s` : `${m}m`
+}
+
+/**
+ * Flood-window observer (part3-design §6, item 2 + snapshots). Reads the
+ * persisted scoped windows each tick, diffs against the previous tick to detect
+ * opens / closes (snapshot log), and decides — per the deliverability rules in
+ * the module header — whether to alert the operator now, defer to window close,
+ * or stay quiet.
+ */
+export function createFloodWindowObserver(
+  config: FloodWindowObserverConfig,
+): FloodWindowObserver {
+  const alertThresholdMs = config.alertThresholdMs ?? 60_000
+  // Full records seen on the previous tick, keyed by scope (close detection).
+  let lastSeen = new Map<string, FloodWindowRecord>()
+  // Scopes whose alert could not be delivered during the window → owed on close.
+  const owedOnClose = new Set<string>()
+  // Close alerts queued but not yet deliverable (operator chat still covered).
+  const pendingClose = new Map<string, FloodWindowRecord>()
+
+  function coversOperator(w: FloodWindowRecord, operatorChatId: string | undefined): boolean {
+    if (w.scopeKey === 'global') return true
+    if (operatorChatId == null) return false
+    return (
+      w.scopeKey === `chat:${operatorChatId}` || w.scopeKey === `group:${operatorChatId}`
+    )
+  }
+
+  function snapshotSuffix(): string {
+    const c = config.stats().global
+    return (
+      `sent=${c.sent} shed=${c.shed} coalesced=${c.coalesced} ` +
+      `expired=${c.expired} failedFast=${c.failedFast}`
+    )
+  }
+
+  function openAlertText(w: FloodWindowRecord, now: number): string {
+    const openFor = fmtDur(now - w.observedAt)
+    return (
+      `⚠️ Telegram flood ban active (scope \`${w.scopeKey}\`). ` +
+      `Open for ${openFor}, expected to clear at ${fmtTs(w.untilTs)} UTC. ` +
+      `Outbound to that scope is being suppressed.`
+    )
+  }
+
+  function closeAlertText(w: FloodWindowRecord): string {
+    return (
+      `⚠️ Telegram flood ban cleared (scope \`${w.scopeKey}\`). ` +
+      `The bot was banned from ${fmtTs(w.observedAt)} to ${fmtTs(w.untilTs)} UTC ` +
+      `(~${fmtDur(w.untilTs - w.observedAt)}). Some outbound messages during that ` +
+      `window were suppressed.`
+    )
+  }
+
+  async function tick(): Promise<void> {
+    const s = config.stats()
+    if (!s.enabled) return
+    const now = config.clock.now()
+    const operatorChatId = config.operatorChatId?.()
+    const windows = config.readWindows(now)
+    const current = new Map<string, FloodWindowRecord>()
+    for (const w of windows) current.set(w.scopeKey, w)
+    const operatorReachable = !windows.some((w) => coversOperator(w, operatorChatId))
+
+    // Newly-opened scopes → snapshot.
+    for (const w of windows) {
+      if (!lastSeen.has(w.scopeKey)) {
+        config.log(
+          `telegram gateway: send-gate flood window OPENED scope=${w.scopeKey} ` +
+            `untilTs=${w.untilTs} src=${w.retryAfterSrc} — ${snapshotSuffix()}\n`,
+        )
+      }
+    }
+
+    // Closed scopes → snapshot, and queue any owed close-alert.
+    for (const [scope, prev] of lastSeen) {
+      if (current.has(scope)) continue
+      config.log(
+        `telegram gateway: send-gate flood window CLOSED scope=${scope} ` +
+          `(was open ${fmtDur(now - prev.observedAt)}) — ${snapshotSuffix()}\n`,
+      )
+      if (owedOnClose.has(scope) && isAlertableScope(scope) && prev.alertedAt == null) {
+        pendingClose.set(scope, prev)
+      }
+      owedOnClose.delete(scope)
+    }
+
+    // Prolonged open windows → alert now (if deliverable) or defer to close.
+    for (const w of windows) {
+      if (!isAlertableScope(w.scopeKey)) continue
+      if (w.alertedAt != null) continue
+      if (now - w.observedAt < alertThresholdMs) continue
+      if (operatorReachable && !coversOperator(w, operatorChatId)) {
+        try {
+          await config.sendAlert(openAlertText(w, now))
+          config.markAlerted(w.scopeKey, now)
+          owedOnClose.delete(w.scopeKey)
+        } catch {
+          /* best-effort — a failed alert must not break the observer loop */
+        }
+      } else {
+        // Cannot deliver during the window → alert when it closes.
+        owedOnClose.add(w.scopeKey)
+      }
+    }
+
+    // Flush deferred close alerts once the operator chat is reachable again.
+    if (operatorReachable && pendingClose.size > 0) {
+      for (const [scope, rec] of [...pendingClose]) {
+        try {
+          await config.sendAlert(closeAlertText(rec))
+          pendingClose.delete(scope)
+        } catch {
+          /* keep it pending; retry next tick */
+        }
+      }
+    }
+
+    lastSeen = current
+  }
+
+  return { tick }
+}

--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -93,6 +93,27 @@ export type AgentMetadata = {
    * asked for current state, so terseness loses to completeness here.
    */
   live?: StatusProbeRow[];
+  /**
+   * Send-gate state (#3084 PR 3, part3-design §6). Present only when the gate
+   * feature flag is ON; omitted entirely when off so `/status` looks exactly
+   * as it did before the gate existed.
+   */
+  sendGate?: SendGateStatus;
+};
+
+/**
+ * `/status` view of the deterministic send gate (#3084). Queued / shed totals
+ * plus any open flood windows with their expiry. Only populated when the gate
+ * is enabled.
+ */
+export type SendGateStatus = {
+  queued: number;
+  shed: number;
+  expired: number;
+  failedFast: number;
+  dropped: number;
+  /** Currently-open flood windows (expired already pruned). */
+  openWindows: { scopeKey: string; untilTs: number }[];
 };
 
 // Markdown escaper for dynamic values interpolated into bold/plain card
@@ -228,6 +249,27 @@ export function statusPairedText(params: {
     for (const row of meta.live) {
       const dot = STATUS_DOT[row.status] ?? STATUS_DOT.fail;
       lines.push(`${dot} **${escapeHtml(row.label)}**  ${escapeHtml(row.detail)}`);
+    }
+  }
+
+  // Send-gate block (#3084 PR 3) — only when the gate flag is on, so a fleet
+  // running with the gate OFF sees the identical pre-gate /status.
+  if (meta.sendGate) {
+    const sg = meta.sendGate;
+    lines.push("");
+    lines.push("**Send gate**");
+    lines.push(
+      `queued ${sg.queued} · shed ${sg.shed} · expired ${sg.expired} · ` +
+        `fail-fast ${sg.failedFast} · dropped ${sg.dropped}`,
+    );
+    if (sg.openWindows.length > 0) {
+      const now = Date.now();
+      for (const w of sg.openWindows) {
+        const secs = Math.max(0, Math.round((w.untilTs - now) / 1000));
+        lines.push(`⏳ flood window \`${escapeHtml(w.scopeKey)}\` — clears in ${secs}s`);
+      }
+    } else {
+      lines.push("no open flood windows");
     }
   }
 


### PR DESCRIPTION
## Summary
PR 3 of 3 for the Telegram flood-safety series (#3084), closing part3-design §6: **observability + operator alerting**. PRs 1 (#3092) and 2 (#3106) built the send gate — token buckets, priority shedding, degraded mode, restart-proof scoped flood windows — but a live ban was **silent** until a user noticed dead air. This PR surfaces it.

- **Periodic stats logging** (`createStatsLogger`): a low-frequency one-line summary of `sendGate.stats()` to the gateway-supervisor stderr log, emitted only when a counter changed **and** the interval (60s) elapsed — no log spam. Silent when the flag is off.
- **Flood-window snapshots + operator alert** (`createFloodWindowObserver`): a snapshot line on every window open/close, plus operator alerting for prolonged (>60s) windows.
  - Deliverability-aware, so the alert never fights the window it reports. **Today** a real 429 opens a coincident `global` window (the #3111 over-suppression), so the operator chat is always covered while a ban is active and every alert is **deferred**: the operator gets **one** "flood ban cleared, was banned from X to Y" card per incident, **coalescing all scopes** (global + chat + group) into a single card rather than 2–3 near-identical ones.
  - The **immediate-delivery** branch (a `chat:<other>` ban while the operator chat is clear alerts right away) is present and unit-tested but **forward-looking**: it only goes live once #3111 makes `onFloodWait` scope-precise. It is not claimed as live behavior today.
  - **At-most-once** anchored by a persisted `alertedAt` marker on the window record, so a restart mid-window never re-alerts.
  - Windows already open at boot log a single "loaded N open flood window(s)" line, not a per-scope OPENED snapshot.
- **`/status`**: a **Send gate** block (queued / shed / expired / fail-fast / dropped + open flood windows with clear-in seconds) when the flag is on; omitted entirely when off.
- **M1 doc nit fixed** (flood-circuit-breaker.ts): the 5-min conservative fail-safe window also fail-fasts CRITICAL sends (5min > the 60s `criticalFailFastMs` ceiling), so the comment no longer understates the blast radius as "a few suppressed cosmetic sends".

## Why
part3-design §6: "On an open flood window > 60s: one operator alert — currently a ban is silent until the user notices dead air." Advances the **always available** vision outcome.

## Test plan
- New `send-gate-observability.test.ts` — 17 tests, injectable-clock driven, outcome-asserting:
  - stats-line shape + rounding; `countersChanged`; logger only-when-changed + interval + flag-off no-op.
  - window open/close snapshot (post-boot); **boot-loaded windows log one "loaded" line, no OPENED spam**; observer flag-off no-op.
  - forward-looking immediate chat-scoped alert at-most-once (#3111); **deferred global alert sent on close**; **one incident (global+chat+group) coalesced into ONE cleared card listing every scope**; msg-edit scopes never alerted.
  - **restart safety**: `markFloodWindowAlerted` persists `alertedAt`, `readFloodWindows` + extend-merge preserve it, and a restart with `alertedAt` on disk does not re-alert.
  - `/status` renders the block when on, omits it when off.
- Scoped local: `send-gate-observability` (17) green. `npm run lint` clean (tsc + all guards, incl. `check-bot-api-wrapping`).

## Risk
Low. Everything is behind `SWITCHROOM_TELEGRAM_SEND_GATE` (default **off**): flag off ⇒ `stats().enabled` is false, both `tick()`s are no-ops, and the 15s timer isn't even scheduled. The operator alert is a `critical` send through `robustApiCall`. Deferred (filed, not forced into this PR): draft-stream edit-path wiring — #3110; scope-precise onFloodWait / global over-suppression — #3111 (which also makes the immediate-alert path live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
