### PR TITLE
fix(gateway): idle-clear means "nothing happened", not "no turn started"

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -475,7 +475,7 @@ import { resolveOutboundTopic as resolveOutboundTopicHelper, topicForRecipient, 
 import { readTurnUsages } from '../../src/agents/perf.js'
 import { buildContextOccupancy, writeContextOccupancySnapshot } from './context-occupancy.js'
 import { decideProactiveCompact, initialCompactState, type CompactState } from './proactive-compact.js'
-import { decideIdleClear, idleDurationToMs, DEFAULT_IDLE_CLEAR_MS } from './idle-clear.js'
+import { decideIdleClear, classifyIdleEvent, idleDurationToMs, DEFAULT_IDLE_CLEAR_MS } from './idle-clear.js'
 import { nextCompactNotify, idleCompactNotifyState, type CompactNotifyState } from './compact-notify.js'
 import {
   tryHostdDispatch,
@@ -4853,10 +4853,18 @@ function maybeProactiveCompact(): void {
 // ─── Idle auto-clear ──────────────────────────────────────────────────────
 // Wall-clock idle → /clear (idle-clear.ts). Independent of proactive-compact
 // (occupancy-driven at the turn-end gate): a fully-idle agent never ends a
-// turn, so this runs on its own interval. Any activity (inbound / turn start /
-// cron fire) resets the timer via markIdleActivity(); fires once per idle
-// period; never mid-turn (turnInFlightForGate, the same gate compaction uses).
+// turn, so this runs on its own interval. "Idle" means NOTHING HAS HAPPENED
+// since the last thing happened — inbound, cron fire, or ANY claude session
+// event (turn start, tool call, tool result, text, sub-agent event, turn end)
+// resets the timer via markIdleActivity(); a turn ending additionally stamps
+// markIdleTurnEnd(). Fires once per idle period; never mid-turn
+// (turnInFlightForGate, the same gate compaction uses).
+//
+// It is emphatically NOT "no turn has *started* recently" — that reading wiped
+// overlord's 3h of working context on 2026-07-11 for the crime of being busy.
+// See the idle-clear.ts header.
 let lastIdleActivityAt = Date.now();
+let lastIdleTurnEndAt: number | null = null;
 let idleAutoCleared = false;
 let idleClearDispatching = false;
 
@@ -4864,6 +4872,15 @@ let idleClearDispatching = false;
 function markIdleActivity(): void {
   lastIdleActivityAt = Date.now();
   idleAutoCleared = false;
+}
+
+/**
+ * Stamp "a turn just ended". The idle window is measured from
+ * max(lastActivityAt, lastTurnEndedAt), so a turn that ran LONGER than the
+ * window can't be cleared on the first tick after `turnInFlight` goes false.
+ */
+function markIdleTurnEnd(): void {
+  lastIdleTurnEndAt = Date.now();
 }
 
 /** Idle window in ms: env override → per-agent config → 3h default. 0 disables. */
@@ -4897,6 +4914,7 @@ function maybeIdleClear(): void {
   const decision = decideIdleClear(
     {
       lastActivityAt: lastIdleActivityAt,
+      lastTurnEndedAt: lastIdleTurnEndAt,
       idleClearMs,
       alreadyCleared: idleAutoCleared,
       turnInFlight: turnInFlightForGate(),
@@ -15474,6 +15492,21 @@ function handleSessionEvent(ev: SessionEvent): void {
       liveTurn.liveness.onStreamEvent(ev.kind, durationMs, Date.now())
     }
   }
+  // Idle-clear clocks (#3084 follow-up). EVERY genuine session event is
+  // activity — an agent that is thinking, calling a tool, streaming text or
+  // driving a sub-agent is NOT idle, whether or not the gateway currently has a
+  // turn open. Stamping only at turn START (the old behaviour) is what let a
+  // 3-hour working stretch be scored as zero activity and `/clear`ed the moment
+  // the window elapsed. A turn ending stamps the turn-end clock too, so a turn
+  // that outran the window is not wiped the instant `turnInFlight` goes false.
+  // This runs for the whole event stream, including every `sub_agent_*` kind —
+  // background workers keep the timer warm exactly as long as they are working.
+  {
+    const durationMs = ev.kind === 'turn_end' ? ev.durationMs : undefined
+    const signal = classifyIdleEvent(ev.kind, durationMs)
+    if (signal.activity) markIdleActivity()
+    if (signal.turnEnded) markIdleTurnEnd()
+  }
   switch (ev.kind) {
     case 'enqueue': {
       // Drain any orphaned typing-wrap entries left over from a crashed
@@ -15612,7 +15645,9 @@ function handleSessionEvent(ev: SessionEvent): void {
         // per-topic `byKey[statusKey]` entry AND the most-recent mirror. The key is
         // the SAME statusKey the ctor's façade was constructed with just above.
         setCurrentTurn(next, statusKey(ev.chatId, enqThreadIdNum))
-        markIdleActivity() // any turn start (main session) is activity — re-arm idle clear
+        // (turn start already stamped the idle clock at the top of
+        // handleSessionEvent, along with every other session event — see the
+        // idle-clear block there.)
         // Early-open the "Working…" liveness card at turn start so narration /
         // thinking emitted BEFORE the first tool surfaces within ~a second
         // instead of after the old 12 s threshold (the dead-air gap). Fires the

--- a/telegram-plugin/gateway/idle-clear.ts
+++ b/telegram-plugin/gateway/idle-clear.ts
@@ -4,22 +4,63 @@
  * instead of resuming a stale, context-heavy thread. Long-term memory lives in
  * Hindsight, so a clear loses only the in-session scratch.
  *
+ * WHAT "IDLE" MEANS HERE (the #3084/#3107 semantics, fixed 2026-07-11):
+ *
+ *   Idle = nothing has happened since the last thing happened.
+ *
+ * "Something happened" is ANY observable event on this agent:
+ *   - an inbound Telegram message,
+ *   - a cron / inject_inbound fire,
+ *   - ANY event off the claude session stream — turn start, thinking, a tool
+ *     call, a tool result, streamed text, a sub-agent event, turn end.
+ *
+ * It emphatically does NOT mean "no turn has *started* recently". That was the
+ * original reading and it inverted the invariant: the idle window was measured
+ * from a turn's START, so the longer and harder an agent worked, the more
+ * certain the wipe. On 2026-07-11 `overlord` worked for three hours straight
+ * (subagents, ~25 PRs) after its last recorded turn boundary and was `/clear`ed
+ * the moment the window elapsed — its whole working context destroyed for being
+ * productive. See `reference/jobs/always-available.md`.
+ *
+ * Two independent clocks feed the decision, and the window is measured from
+ * whichever is later:
+ *   - `lastActivityAt`  — stamped on every event above (the load-bearing fix:
+ *     an agent that is DOING something is not idle, turn boundaries or not).
+ *   - `lastTurnEndedAt` — stamped when a turn ends (defence in depth: the
+ *     instant a turn ends, `turnInFlight` stops suppressing the clear, so a
+ *     turn that ran longer than the window would otherwise be wiped on the very
+ *     next tick — the timer must never be "already expired" at turn end).
+ *
+ * A genuinely idle session — no inbound, no cron, no model activity for the
+ * whole window — is still cleared. That is the feature and it stays.
+ *
  * Sibling of proactive-compact.ts (occupancy-driven /compact at the turn-end
  * idle gate). This one is wall-clock-driven: it fires `/clear` from a periodic
  * interval because a fully-idle agent never ends a turn, so the turn-end gate
  * alone would never see it. Both inject via the same primitive and both refuse
  * to fire mid-turn (turnInFlight guard).
  *
- * The decider is pure so the fire-once / re-arm / not-mid-turn / disabled logic
- * is unit-tested without the gateway.
+ * The decider and the event classifier are pure so the whole
+ * fire-once / re-arm / not-mid-turn / not-just-worked / disabled logic is
+ * unit-tested without the gateway.
  */
 
 /** Default idle window when `session.idle_clear_after` is unset (3h). ON by default. */
 export const DEFAULT_IDLE_CLEAR_MS = 3 * 60 * 60 * 1000;
 
 export interface IdleClearState {
-  /** Epoch ms of the last activity (inbound, turn start, cron fire). */
+  /**
+   * Epoch ms of the last activity: inbound, cron fire, or ANY claude session
+   * stream event (turn start, tool call, tool result, text, sub-agent event,
+   * turn end). Not just turn starts — see the header.
+   */
   lastActivityAt: number;
+  /**
+   * Epoch ms when a turn last ended (null = no turn has ended this process).
+   * The window is measured from `max(lastActivityAt, lastTurnEndedAt)` so a turn
+   * that outran the idle window is not cleared the instant it finishes.
+   */
+  lastTurnEndedAt: number | null;
   /** Idle window in ms. <= 0 disables auto-clear. */
   idleClearMs: number;
   /** Already auto-cleared since the last activity? Prevents re-clearing every tick. */
@@ -32,11 +73,17 @@ export interface IdleClearDecision {
   clear: boolean;
 }
 
+/** Epoch ms of the last thing that happened — activity or a turn ending. */
+export function lastEventAt(state: IdleClearState): number {
+  return Math.max(state.lastActivityAt, state.lastTurnEndedAt ?? 0);
+}
+
 /**
  * Decide whether to auto-clear this evaluation. Fires exactly once per idle
  * period: only when enabled, not mid-turn, not already cleared, and the idle
- * window has elapsed. The caller sets `alreadyCleared` on fire and resets it
- * (with `lastActivityAt`) on the next activity to re-arm.
+ * window has elapsed since the last thing that happened. The caller sets
+ * `alreadyCleared` on fire and resets it (with `lastActivityAt`) on the next
+ * activity to re-arm.
  */
 export function decideIdleClear(
   state: IdleClearState,
@@ -45,8 +92,45 @@ export function decideIdleClear(
   if (state.idleClearMs <= 0) return { clear: false }; // disabled
   if (state.turnInFlight) return { clear: false }; // never mid-turn
   if (state.alreadyCleared) return { clear: false }; // once per idle period
-  if (now - state.lastActivityAt < state.idleClearMs) return { clear: false };
+  // Measured from the LAST thing that happened — activity or a turn ending —
+  // never from a turn's start. A turn that ran longer than the window ends with
+  // a fresh turn-end stamp, so it is not idle the moment it finishes.
+  if (now - lastEventAt(state) < state.idleClearMs) return { clear: false };
   return { clear: true };
+}
+
+/** What a claude session-stream event means for the idle clocks. */
+export interface IdleEventSignal {
+  /** Genuine agent activity → stamp `lastActivityAt` (and re-arm). */
+  activity: boolean;
+  /** A turn ended → stamp `lastTurnEndedAt`. */
+  turnEnded: boolean;
+}
+
+/**
+ * Classify a session-stream event for the idle clocks. Pure, so the gateway's
+ * dispatcher stays a one-liner and the semantics are testable.
+ *
+ * EVERY genuine stream event is activity — thinking, tool_use, tool_result,
+ * text, model, enqueue (turn start), turn_end, and all `sub_agent_*` kinds.
+ * The claude session emits nothing at all while the agent is truly idle, so
+ * "any event = activity" is exactly the intended reading and cannot keep a
+ * dormant session alive forever.
+ *
+ * The one exception is the gateway's OWN synthetic `turn_end` (durationMs ===
+ * -1), re-dispatched by the orphaned-reply backstop: it is the gateway talking
+ * to itself, not the model doing something, so it does not stamp activity — but
+ * it DOES end the turn (the in-flight gate opens), so it stamps the turn-end
+ * clock. Same `!(turn_end && durationMs === -1)` predicate the per-turn liveness
+ * stamp already uses for "genuine stream event".
+ */
+export function classifyIdleEvent(
+  kind: string,
+  durationMs?: number,
+): IdleEventSignal {
+  const turnEnded = kind === "turn_end";
+  const synthetic = turnEnded && durationMs === -1;
+  return { activity: !synthetic, turnEnded };
 }
 
 /**

--- a/telegram-plugin/tests/idle-clear.test.ts
+++ b/telegram-plugin/tests/idle-clear.test.ts
@@ -11,8 +11,12 @@
  * These tests assert the OUTCOME: an agent that is doing things is not idle,
  * and an agent that is doing nothing still gets cleared.
  *
- * Deterministic virtual clock only (`T + n * H`) — no fake timers: this file is
- * DUAL-RUN (vitest + bun) and bun's `vi` shim has no `useFakeTimers`.
+ * Deterministic virtual clock only (`T + n * H`) — no fake timers, no
+ * `Date.now()`. Everything schedulable takes the clock as an argument, so the
+ * whole 3h window is exercised in microseconds and the suite stays portable if
+ * this file is ever moved to the bun runner. (It runs under vitest today: it is
+ * not in `package.json`'s `test:bun` list and not excluded in
+ * `vitest.config.ts`.)
  */
 
 import { describe, it, expect } from 'vitest'

--- a/telegram-plugin/tests/idle-clear.test.ts
+++ b/telegram-plugin/tests/idle-clear.test.ts
@@ -1,17 +1,227 @@
+/**
+ * Idle auto-clear — what "idle" MEANS.
+ *
+ * On 2026-07-11 `overlord` worked for three hours straight (sub-agents, ~25 PRs
+ * merged) and was `/clear`ed 12 s after the window elapsed — three hours of
+ * session context destroyed. Root cause: the idle window was measured from the
+ * last turn START, and nothing in a turn (tool calls, sub-agent work, the turn
+ * ENDING) counted as activity. The invariant was inverted: the longer and more
+ * productive the work, the more certain the wipe.
+ *
+ * These tests assert the OUTCOME: an agent that is doing things is not idle,
+ * and an agent that is doing nothing still gets cleared.
+ *
+ * Deterministic virtual clock only (`T + n * H`) — no fake timers: this file is
+ * DUAL-RUN (vitest + bun) and bun's `vi` shim has no `useFakeTimers`.
+ */
+
 import { describe, it, expect } from 'vitest'
 import {
   decideIdleClear,
+  classifyIdleEvent,
   idleDurationToMs,
   DEFAULT_IDLE_CLEAR_MS,
   type IdleClearState,
 } from '../gateway/idle-clear.js'
 
 const H = 3_600_000
+const M = 60_000
+/** Gateway's IDLE_CLEAR_CHECK_MS default. */
+const TICK = 60_000
+
 function state(p: Partial<IdleClearState>): IdleClearState {
-  return { lastActivityAt: 0, idleClearMs: 3 * H, alreadyCleared: false, turnInFlight: false, ...p }
+  return {
+    lastActivityAt: 0,
+    lastTurnEndedAt: null,
+    idleClearMs: 3 * H,
+    alreadyCleared: false,
+    turnInFlight: false,
+    ...p,
+  }
 }
 
-describe('decideIdleClear', () => {
+/**
+ * A minimal model of the gateway's idle bookkeeping, driven by a virtual clock.
+ * Mirrors gateway.ts: `markIdleActivity()` on inbound / cron / ANY session
+ * event, `markIdleTurnEnd()` on a turn ending, `decideIdleClear()` on each
+ * IDLE_CLEAR_CHECK_MS tick, `alreadyCleared` latched on fire.
+ */
+class IdleModel {
+  lastActivityAt: number
+  lastTurnEndedAt: number | null = null
+  alreadyCleared = false
+  turnInFlight = false
+  clears: number[] = []
+
+  constructor(
+    startedAt: number,
+    readonly idleClearMs = 3 * H,
+  ) {
+    this.lastActivityAt = startedAt
+  }
+
+  /** A claude session-stream event (the gateway's handleSessionEvent stamp). */
+  sessionEvent(kind: string, now: number, durationMs?: number): void {
+    const signal = classifyIdleEvent(kind, durationMs)
+    if (signal.activity) {
+      this.lastActivityAt = now
+      this.alreadyCleared = false
+    }
+    if (signal.turnEnded) this.lastTurnEndedAt = now
+  }
+
+  /** Inbound / cron fire. */
+  activity(now: number): void {
+    this.lastActivityAt = now
+    this.alreadyCleared = false
+  }
+
+  tick(now: number): boolean {
+    const { clear } = decideIdleClear(
+      {
+        lastActivityAt: this.lastActivityAt,
+        lastTurnEndedAt: this.lastTurnEndedAt,
+        idleClearMs: this.idleClearMs,
+        alreadyCleared: this.alreadyCleared,
+        turnInFlight: this.turnInFlight,
+      },
+      now,
+    )
+    if (clear) {
+      this.alreadyCleared = true
+      this.clears.push(now)
+    }
+    return clear
+  }
+
+  /** Run the interval from `from` to `to` inclusive, one tick per TICK. */
+  ticksThrough(from: number, to: number): void {
+    for (let t = from; t <= to; t += TICK) this.tick(t)
+  }
+}
+
+describe('idle-clear: a working agent is not idle', () => {
+  it('HEADLINE — a turn that runs LONGER than the idle window is not cleared when it ends', () => {
+    // The overlord incident, replayed. Window 3h. Turn starts at T, runs 3h08m
+    // of real work (sub-agents, tool calls), ends at T+3h08m.
+    const T = 100 * H
+    const m = new IdleModel(T)
+
+    m.turnInFlight = true
+    m.sessionEvent('enqueue', T) // turn start
+
+    // ... 3h08m of work. The gate suppresses the clear while in flight.
+    m.ticksThrough(T, T + 3 * H + 8 * M)
+    expect(m.clears).toEqual([])
+
+    // Turn ends. `turnInFlight` flips false — the moment of truth.
+    const end = T + 3 * H + 8 * M
+    m.sessionEvent('turn_end', end, 11_314_000)
+    m.turnInFlight = false
+
+    // The very next tick (12 s later in production) must NOT clear...
+    expect(m.tick(end + 12_000)).toBe(false)
+    // ...nor the next several ticks, nor anything short of a full fresh window.
+    m.ticksThrough(end, end + 3 * H - TICK)
+    expect(m.clears).toEqual([])
+  })
+
+  it('in-turn work keeps the timer warm even when the gateway sees no turn boundary', () => {
+    // What ACTUALLY happened to overlord: the last turn ended at 07:05 and the
+    // agent then worked for ~3h under stop-hook continuations that opened no new
+    // turn. `turnInFlight` was false the whole time, so only the per-event stamp
+    // can save it.
+    const T = 100 * H
+    const m = new IdleModel(T)
+    m.sessionEvent('turn_end', T, 34_596) // last turn boundary
+    m.turnInFlight = false
+
+    // 3h30m of real work with no turn boundary: tool calls + sub-agent activity
+    // every ~10 min, and a tick between each.
+    for (let t = T; t <= T + 3 * H + 30 * M; t += 10 * M) {
+      m.sessionEvent('tool_use', t)
+      m.sessionEvent('sub_agent_tool_use', t + 60_000)
+      m.ticksThrough(t, t + 10 * M - TICK)
+    }
+    expect(m.clears).toEqual([])
+  })
+
+  it('every genuine session event counts as activity (sub-agents included)', () => {
+    for (const kind of [
+      'enqueue',
+      'thinking',
+      'model',
+      'tool_use',
+      'tool_result',
+      'text',
+      'sub_agent_started',
+      'sub_agent_tool_use',
+      'sub_agent_text',
+      'sub_agent_turn_end',
+    ]) {
+      expect(classifyIdleEvent(kind).activity).toBe(true)
+      expect(classifyIdleEvent(kind).turnEnded).toBe(false)
+    }
+    // A real turn_end is activity AND a turn boundary.
+    expect(classifyIdleEvent('turn_end', 5_000)).toEqual({ activity: true, turnEnded: true })
+    // The gateway's own synthetic turn_end (orphaned-reply backstop) is not the
+    // model doing something — but it still ends the turn.
+    expect(classifyIdleEvent('turn_end', -1)).toEqual({ activity: false, turnEnded: true })
+  })
+
+  it('a background sub-agent still emitting events after the main turn ends holds off the clear', () => {
+    const T = 100 * H
+    const m = new IdleModel(T)
+    m.sessionEvent('turn_end', T, 30_000)
+    m.turnInFlight = false
+    // Worker grinds for 4h past the main turn end.
+    for (let t = T; t <= T + 4 * H; t += 5 * M) {
+      m.sessionEvent('sub_agent_tool_use', t)
+      m.ticksThrough(t, t + 5 * M - TICK)
+    }
+    expect(m.clears).toEqual([])
+  })
+})
+
+describe('idle-clear: a genuinely idle agent is still cleared', () => {
+  it('no turn, no inbound, no session event for a full window → cleared exactly once', () => {
+    const T = 100 * H
+    const m = new IdleModel(T)
+    m.ticksThrough(T, T + 6 * H)
+    expect(m.clears).toEqual([T + 3 * H])
+  })
+
+  it('cleared once per idle period, and re-arms on the next inbound', () => {
+    const T = 100 * H
+    const m = new IdleModel(T)
+    m.ticksThrough(T, T + 5 * H)
+    expect(m.clears).toEqual([T + 3 * H])
+
+    const inbound = T + 5 * H
+    m.activity(inbound) // operator comes back
+    m.ticksThrough(inbound, inbound + 3 * H - TICK)
+    expect(m.clears).toEqual([T + 3 * H]) // not yet
+    m.ticksThrough(inbound, inbound + 3 * H)
+    expect(m.clears).toEqual([T + 3 * H, inbound + 3 * H])
+  })
+
+  it('a turn that ends is cleared one full window after it ended (not before)', () => {
+    const T = 100 * H
+    const m = new IdleModel(T)
+    m.turnInFlight = true
+    m.sessionEvent('enqueue', T)
+    const end = T + 3 * H + 8 * M
+    m.sessionEvent('turn_end', end, 11_314_000)
+    m.turnInFlight = false
+
+    m.ticksThrough(end, end + 3 * H - TICK)
+    expect(m.clears).toEqual([]) // still warm
+    m.ticksThrough(end, end + 3 * H + TICK)
+    expect(m.clears).toEqual([end + 3 * H]) // now genuinely idle → cleared
+  })
+})
+
+describe('decideIdleClear (pure gate)', () => {
   it('fires once the idle window has elapsed', () => {
     expect(decideIdleClear(state({ lastActivityAt: 0 }), 3 * H).clear).toBe(true)
     expect(decideIdleClear(state({ lastActivityAt: 0 }), 3 * H + 1).clear).toBe(true)
@@ -32,10 +242,26 @@ describe('decideIdleClear', () => {
   it('is disabled when idleClearMs <= 0', () => {
     expect(decideIdleClear(state({ lastActivityAt: 0, idleClearMs: 0 }), 10 * H).clear).toBe(false)
     expect(decideIdleClear(state({ lastActivityAt: 0, idleClearMs: -1 }), 10 * H).clear).toBe(false)
+    // ...even with a fresh turn end in play.
+    expect(
+      decideIdleClear(state({ lastActivityAt: 0, lastTurnEndedAt: 9 * H, idleClearMs: 0 }), 10 * H).clear,
+    ).toBe(false)
+  })
+
+  it('measures the window from max(lastActivityAt, lastTurnEndedAt)', () => {
+    // Turn started at 0 (lastActivityAt), ended at 5h. At 5h the window has long
+    // "elapsed" against the START — it must not be treated as idle.
+    const justEnded = state({ lastActivityAt: 0, lastTurnEndedAt: 5 * H })
+    expect(decideIdleClear(justEnded, 5 * H).clear).toBe(false)
+    expect(decideIdleClear(justEnded, 8 * H - 1).clear).toBe(false)
+    expect(decideIdleClear(justEnded, 8 * H).clear).toBe(true) // a full window after the END
+    // Symmetric: activity newer than the turn end wins.
+    const activeSince = state({ lastActivityAt: 6 * H, lastTurnEndedAt: 5 * H })
+    expect(decideIdleClear(activeSince, 8 * H).clear).toBe(false)
+    expect(decideIdleClear(activeSince, 9 * H).clear).toBe(true)
   })
 
   it('re-arms after activity (fresh lastActivityAt + alreadyCleared=false → waits again)', () => {
-    // Simulated: after a clear, activity resets lastActivityAt to `now` and the flag.
     const now = 100 * H
     const reArmed = state({ lastActivityAt: now, alreadyCleared: false })
     expect(decideIdleClear(reArmed, now + 3 * H - 1).clear).toBe(false) // not yet


### PR DESCRIPTION
## Summary

The idle auto-clear window was measured from the last turn **START**, and nothing that happened *inside* a turn — tool calls, sub-agent work, streamed text, or the turn **ending** — counted as activity. The invariant was inverted: **the longer and more productive a turn, the more certain the wipe, and the more there was to lose.**

`decideIdleClear` now measures from `max(lastActivityAt, lastTurnEndedAt)` (`telegram-plugin/gateway/idle-clear.ts:83-101`), and `handleSessionEvent` stamps the activity clock on **every genuine session-stream event** — `enqueue`, `thinking`, `model`, `tool_use`, `tool_result`, `text`, `turn_end`, and every `sub_agent_*` kind (`telegram-plugin/gateway/gateway.ts:15484-15497`). A turn ending stamps the turn-end clock too (`markIdleTurnEnd`, `gateway.ts:4890-4897`).

### What "idle" now means, and why

> **Idle = nothing has happened since the last thing happened.**

Not "no turn has *started* recently." The feature's intent is *"the operator wandered off and this session is stale"* — never *"this agent has been busy."* An agent that is thinking, calling a tool, streaming text, or driving a sub-agent is **not idle**, whether or not the gateway currently has a turn open. An agent with no inbound, no cron and no model activity for the whole window **is** idle and is still cleared — the feature is not defeated (pinned by tests).

Two clocks, window measured from the later of the two:

| clock | stamped by | why |
|---|---|---|
| `lastActivityAt` | inbound, cron/`inject_inbound`, **any** session event | the load-bearing fix — doing work *is* activity |
| `lastTurnEndedAt` | any `turn_end` | defence in depth — the instant a turn ends, `turnInFlight` stops suppressing the clear, so a turn that outran the window would otherwise be wiped on the very next tick |

The one exception: the gateway's own **synthetic** `turn_end` (`durationMs === -1`, re-dispatched by the orphaned-reply backstop, `gateway.ts:14568`) is the gateway talking to itself, so it stamps the *turn-end* clock but not the *activity* clock. Same `!(turn_end && durationMs === -1)` predicate the per-turn liveness stamp already uses (`gateway.ts:15473-15482`).

## Why — the production incident (overlord, 2026-07-11)

`~/.switchroom/logs/overlord/gateway-supervisor.log:610273`:
```
[2026-07-11T10:04:46.091Z] telegram gateway: idle auto-/clear for overlord (idle >= 180m)
```
Three hours of session context destroyed after a stretch of maximum activity (sub-agents, ~25 PRs merged in the window).

**One correction to the reported timeline, from the logs — it makes the bug *worse*, not better.** The gateway's last main-session turn boundary was **07:05:03**, not 10:04:34:

- `gateway-supervisor.log:606978` — `turn-lifecycle clear reason=turn_end turnId=8248703757:_#synthetic-1783753469215 tools=3`
- `~/.switchroom/agents/overlord/turns.jsonl` (last record) — `{"ts":1783753503,"duration_ms":34596,"tools":1,"status":"no_reply"}` → **07:05:03Z**, a 34.6 s turn
- every `gw-trace` line from then to the clear reads `global=bridge_alive_idle` — i.e. **`turnInFlight` was false for the entire three hours**

So the agent worked for ~3 h under stop-hook `NO_REPLY` continuations that opened **no new turn**, `markIdleActivity()` was last called at that turn's start (~07:04:46), and the clear fired at 10:04:46 — exactly one 180 m window later, to the tick.

That matters for the fix: **`lastTurnEndedAt` alone would NOT have prevented this incident** (the turn end was 3 h *before* the clear). Only the per-event activity stamp saves it. Both failure modes are real and both are fixed:

1. **What actually happened** — work with no turn boundary → per-event stamping (headline test #2).
2. **The hypothesised mode** — one turn longer than the window, wiped the instant it ends → `lastTurnEndedAt` (headline test #1).

The flood ban (#3084) made the turn enormous and stopped inbound from re-arming the timer, but **the bug needs no flood ban** — only an agent working longer than `idle_clear_after`.

## Test plan

`telegram-plugin/tests/idle-clear.test.ts` — outcome-asserting, deterministic virtual clock — no fake timers, no `Date.now()` in schedulable logic. (Runs under vitest; the no-fake-timers discipline keeps it portable to the bun runner.)

- **HEADLINE:** a turn that runs 3 h 08 m against a 3 h window is **not** cleared when it ends — not on the next tick (12 s, as in production), nor on any tick short of a full fresh window.
- in-turn work with **no turn boundary** (the real overlord sequence) keeps the timer warm across 3 h 30 m.
- a background sub-agent still emitting events 4 h after the main turn ended holds off the clear.
- every genuine event kind counts as activity; the synthetic `turn_end` does not (but still ends the turn).
- **feature not defeated:** a genuinely idle session (no turn, no inbound, no event) **is** still cleared, exactly once, at the window; and a turn that ends *is* cleared one full window after it ended.
- existing guards kept green: never mid-turn, `alreadyCleared` = once-per-idle-period, `idleClearMs <= 0` disables.

**Mutation test** (fix reverted to `origin/main`'s `idle-clear.ts`): **6 tests RED**, headline first —
```
× HEADLINE — a turn that runs LONGER than the idle window is not cleared when it ends
  → expected true to be false
× in-turn work keeps the timer warm even when the gateway sees no turn boundary
  → expected [ 370800000 ] to deeply equal []
Tests  6 failed | 11 passed (17)
```

**Full suite, not scoped:** `npm run test:vitest` → **884 files / 14008 tests passed, 0 failed** (after `npm run build`; 9 dist-dependent files fail without it — `pretest` builds in CI). `npm run test:bun` → **1156 pass / 1 fail**: `src/vault/broker/client-token.test.ts:407`, a broker-socket test failing on `EPERM chown … (CAP_CHOWN missing?)` in this sandbox. `git diff --stat origin/main -- src/` is empty — that code is byte-identical to main; environment-only, CI is the arbiter. `npm run lint` clean, including `check-bot-api-wrapping` (gateway.ts line shift absorbed).

## Risk

Low, and asymmetric in the right direction. The change only ever makes a clear *less* likely, never more. Worst case: an agent whose session stream is chattering keeps its context longer than 3 h — which is precisely the intended semantics. The three existing guards (mid-turn, fire-once, disable) are untouched and still pinned. No Telegram surface, no delivery path, no compose/image change.

## Secondary verdicts (asked for; not fixed here)

**1. Should `/clear` fire with in-flight background sub-agents? No — and `turnInFlightForGate()` does not cover them.** It reads `claudeBusyKeys` / the delivery machine's single `activeTurn` plus `pendingPermissions` (`gateway.ts:2618-2638`) — the *main* turn only. The per-key background signal already exists (`isLegitimatelyWorking` → `pendingProgress.hasPendingAsyncDispatch`, `gateway.ts:8490-8506`) but is not wired to the idle gate. This PR fixes it *as activity* rather than as a hard suppressor: `sub_agent_*` events flow through `handleSessionEvent`, so a live worker keeps the timer warm for as long as it is working (test #4). I deliberately did **not** add an unbounded `backgroundWorkInFlight` boolean to the gate: a stuck pending flag would silently disable idle-clear forever, trading a loud bug for a quiet one. The residual hole — a background worker that is alive but emits nothing for a full window — is bounded and self-healing (a worker silent for 3 h is stalled; the subagent-watcher already synthesises terminal states for exactly that, `gateway-supervisor.log:607632`). If we want a hard gate, it needs a TTL; worth a follow-up issue, not this PR.

**2. The check-to-send race (`gateway.ts:4923-4925`): latent, real, and now much narrower — leave it, file it.** An inbound landing between the gate check and the tmux send means `/clear` sits in claude's prompt buffer and executes at the *next* idle prompt, against a session that is no longer idle. This PR shrinks the exposure a lot (the clear now only fires after a genuinely quiet window, so the race needs an inbound in the millisecond gap rather than in the seconds after a turn ends) but does not close it. Closing it properly means `injectSlashCommandImpl` taking a precondition re-evaluated immediately before the tmux write — a change to the inject primitive shared with proactive-compact, which deserves its own PR and its own test rather than riding along here.

## Follow-ups filed (non-blocking, from review)

- **#3115** — the gateway *wiring* is unpinned: the tests drive a re-implemented `IdleModel` that mirrors the gateway's bookkeeping, so deleting the stamp block at `gateway.ts:15503` would leave all 17 tests green while re-introducing this exact bug. The durable fix is a stateful `IdleTracker` in `idle-clear.ts` that the gateway holds and the tests drive directly.
- **#3114** — pre-existing on `main` (not a regression from this diff): `onInjectInbound` stamps activity on **every** cron fire (`gateway.ts:10788`), so an agent whose cron cadence is shorter than its idle window can never be idle-cleared. Idle-clear is effectively off for cron-heavy agents.

## Job spec

`reference/jobs/remember-across-sessions.md` (serves: **standing-team**) — *"An agent with no memory is a stranger every time. The relationship never compounds."* An agent that loses three hours of working context **because it worked hard for three hours** is not a colleague. Also serves **always-available**: the session that comes back after a long autonomous stretch must be the same session that did the work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mQR9UordBs4nJ797bxxod
