### PR TITLE
fix(cli): pin personal-skill verbs to caller agent identity (#3084 security audit)

### DIFF
--- a/src/cli/skill-personal.test.ts
+++ b/src/cli/skill-personal.test.ts
@@ -244,6 +244,77 @@ describe("initPersonalAction", () => {
   });
 });
 
+describe("cross-agent identity pin (#3084 security audit)", () => {
+  // Parity with agent-config.ts (resolveTargetAgent) and
+  // agent-config-skill-write.ts (resolveAgentName): when the calling
+  // environment pins an identity via SWITCHROOM_AGENT_NAME, a
+  // caller-supplied --agent that differs must be refused across every
+  // personal-skill verb, not silently honored.
+  let root: string;
+  let orig: string | undefined;
+
+  beforeEach(() => {
+    root = tmpAgentsRoot();
+    orig = process.env.SWITCHROOM_AGENT_NAME;
+    process.env.SWITCHROOM_AGENT_NAME = AGENT;
+  });
+
+  afterEach(() => {
+    if (orig === undefined) delete process.env.SWITCHROOM_AGENT_NAME;
+    else process.env.SWITCHROOM_AGENT_NAME = orig;
+    try { rmSync(root, { recursive: true, force: true }); } catch { /**/ }
+  });
+
+  it("rejects init-personal when --agent differs from the pinned identity", () => {
+    const skillFile = join(root, "input.md");
+    writeFileSync(skillFile, validSkillMd("pinme"));
+    // Pinned to AGENT, but caller asks to write as "victim" — deny.
+    expectExitCode(() => {
+      initPersonalAction("pinme", { agent: "victim", from: skillFile, root });
+    }, 2);
+    // Nothing was written into either agent's workspace.
+    expect(existsSync(join(root, "victim", ".claude/skills/personal-pinme"))).toBe(false);
+    expect(existsSync(join(root, AGENT, ".claude/skills/personal-pinme"))).toBe(false);
+  });
+
+  it("rejects edit/remove/list/clone when --agent differs from the pinned identity", () => {
+    const skillFile = join(root, "input.md");
+    writeFileSync(skillFile, validSkillMd("pinme"));
+    expectExitCode(() => {
+      editPersonalAction("pinme", { agent: "victim", from: skillFile, root });
+    }, 2);
+    expectExitCode(() => {
+      removePersonalAction("pinme", { agent: "victim", root });
+    }, 2);
+    expectExitCode(() => {
+      listPersonalAction({ agent: "victim", root });
+    }, 2);
+    expectExitCode(() => {
+      clonePersonalAction("bundled:whatever", { agent: "victim", root });
+    }, 2);
+  });
+
+  it("proceeds when --agent matches the pinned identity", () => {
+    const skillFile = join(root, "input.md");
+    writeFileSync(skillFile, validSkillMd("matches"));
+    const out = captureStdout(() => {
+      initPersonalAction("matches", { agent: AGENT, from: skillFile, root });
+    });
+    expect(JSON.parse(out).ok).toBe(true);
+    expect(existsSync(join(root, AGENT, ".claude/skills/personal-matches/SKILL.md"))).toBe(true);
+  });
+
+  it("proceeds when --agent is omitted (falls back to the pinned identity)", () => {
+    const skillFile = join(root, "input.md");
+    writeFileSync(skillFile, validSkillMd("omitted"));
+    const out = captureStdout(() => {
+      initPersonalAction("omitted", { from: skillFile, root });
+    });
+    expect(JSON.parse(out).ok).toBe(true);
+    expect(existsSync(join(root, AGENT, ".claude/skills/personal-omitted/SKILL.md"))).toBe(true);
+  });
+});
+
 describe("editPersonalAction", () => {
   let root: string;
   beforeEach(() => { root = tmpAgentsRoot(); });

--- a/src/cli/skill-personal.ts
+++ b/src/cli/skill-personal.ts
@@ -271,6 +271,18 @@ function resolveAgent(opts: AgentOpts): string {
   if (!SKILL_SLUG_RE.test(agent)) {
     fail(`agent name has invalid shape: ${JSON.stringify(agent)}`);
   }
+  // Cross-agent denial — parity with agent-config.ts (resolveTargetAgent)
+  // and agent-config-skill-write.ts (resolveAgentName). When the calling
+  // environment pins an identity, a caller-supplied --agent must match it;
+  // a mismatch is a cross-agent write attempt and is refused. Previously
+  // this leaned on container mount topology (agents mount only their own
+  // dir) rather than an explicit control.
+  if (fromEnv && opts.agent && opts.agent !== fromEnv) {
+    fail(
+      `cross-agent skill writes are denied: agent=${opts.agent} but ` +
+        `identity is pinned to ${fromEnv}`,
+    );
+  }
   return agent;
 }
 


### PR DESCRIPTION
## Parity gap

`resolveAgent()` in `src/cli/skill-personal.ts` accepted a caller-supplied `--agent` with only a shape (slug-regex) check. It did **not** reject when `opts.agent` differs from the pinned `$SWITCHROOM_AGENT_NAME`.

Every sibling write path enforces this pin:
- `src/cli/agent-config.ts` — `resolveTargetAgent()` throws `cross-agent read denied` on mismatch.
- `src/cli/agent-config-skill-write.ts` — `resolveAgentName()` throws `cross-agent skill writes are denied` on mismatch.

The MCP shim (`src/mcp/agent-config/server.ts`) forwards `agent` via `--agent` to all five personal-skill verbs (`skill_{init,edit,remove,list,clone}_personal`). So the stated "cross-agent writes rejected" invariant leaned on container mount topology (agents mount only their own dir) rather than an explicit control — not exploitable in-container today, but the invariant should be enforced by code, not topology.

## Fix

Add the same deterministic pin check at `resolveAgent()` — the single choke point through which all five verbs resolve identity. When the environment pins an identity, a mismatched `--agent` is refused (`exit 2`); a matching or omitted `--agent` proceeds exactly as before. Wording mirrors the sibling in `agent-config-skill-write.ts`.

`additionalProperties:false` is **not** used by any sibling MCP `inputSchema` in `server.ts` (verified: zero occurrences), so it was intentionally not added — the CLI pin is the enforcement boundary, matching the existing pattern.

## Tests

`src/cli/skill-personal.test.ts` — new `cross-agent identity pin (#3084 security audit)` block asserts outcomes:
- init/edit/remove/list/clone-personal each rejected (exit 2) when `--agent` differs from the pinned identity, and no workspace is written.
- init proceeds when `--agent` matches the pin, and when `--agent` is omitted (falls back to the pin).

## Validation (scoped; CI is authority)

- `vitest run src/cli/skill-personal.test.ts` — 49 passed
- `vitest run src/cli/agent-config.test.ts src/mcp/agent-config/server.test.ts` — 40 passed
- `npm run lint` (tsc --noEmit + repo guards) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)