### PR TITLE
fix(host-control): enforce entry scope + identity bind on vault token get (#3084 security audit)

### DIFF
--- a/src/vault/broker/server-grants.test.ts
+++ b/src/vault/broker/server-grants.test.ts
@@ -440,6 +440,148 @@ describe("VaultBroker: token-based get access (issue #225)", () => {
   });
 });
 
+// ─── sec #3084: entry-scope + identity-bind on the token get path ─────────────
+//
+// F3: the capability-token `get` path historically skipped `checkEntryScope`,
+//     so an entry's `scope.deny:[agent]` was silently ineffective against an
+//     outstanding token. OUTCOME: a token whose owning agent is denied by the
+//     entry scope is now refused on the token path (was served before).
+// F4: tokens are bearer capabilities. When the connection ALSO carries a
+//     bind-time socket identity, the broker now cross-checks it against the
+//     grant's `agent_slug` and rejects a mismatch. OUTCOME: a token replayed
+//     over a DIFFERENT agent's bound socket is denied; the matching identity
+//     and the legitimate no-bind-identity flow are unchanged.
+describe("VaultBroker: token get — entry scope + identity bind (sec #3084)", () => {
+  let socketPath: string;
+  let tmpDir: string;
+  let grantsDb: Database;
+  let auditEntries: AuditEntry[];
+  let prevNonLinuxFlag: string | undefined;
+  const brokers: VaultBroker[] = [];
+
+  // Secret with a scope that DENIES "myagent" — used to exercise F3.
+  const scopedSecrets = (): Record<string, VaultEntry> => ({
+    foo: { kind: "string", value: "bar-value" },
+    denied: {
+      kind: "string",
+      value: "top-secret",
+      scope: { deny: ["myagent"] },
+    } as VaultEntry,
+  });
+
+  async function makeBroker(agentName?: string): Promise<string> {
+    const sp = path.join(tmpDir, `${agentName ?? "nobind"}.sock`);
+    const b = new VaultBroker({
+      _testSecrets: scopedSecrets(),
+      _testConfig: makeMinimalConfig(),
+      _testGrantsDb: grantsDb,
+      _testAuditLogger: {
+        write: (e: AuditEntry) => { auditEntries.push(e); return true; },
+        failOpenCount: () => 0,
+      },
+      ...(agentName !== undefined ? { _testAgentName: agentName } : {}),
+    });
+    await b.start(sp, undefined, undefined);
+    brokers.push(b);
+    return sp;
+  }
+
+  beforeEach(() => {
+    prevNonLinuxFlag = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = "1";
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-3084-test-"));
+    socketPath = ""; // set per-test by makeBroker
+    grantsDb = makeInMemoryGrantsDb();
+    auditEntries = [];
+  });
+
+  afterEach(() => {
+    for (const b of brokers.splice(0)) { try { b.stop(); } catch { /* ignore */ } }
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    if (prevNonLinuxFlag === undefined) delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    else process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prevNonLinuxFlag;
+  });
+
+  // ── F3: entry scope enforced on the token path ─────────────────────────────
+
+  it("F3: token for an entry that denies the grant's agent is refused (scope-deny)", async () => {
+    socketPath = await makeBroker(); // no bind identity
+    const { token } = await mintGrant(grantsDb, "myagent", ["denied"], null);
+
+    const resp = await rpc(socketPath, { v: 1, op: "get", key: "denied", token });
+
+    expect(resp.ok).toBe(false);
+    if (!resp.ok) {
+      expect(resp.code).toBe("DENIED");
+      expect(resp.msg).toContain("scope-deny");
+    }
+    // Audited as a scope denial on the grant method, NOT served.
+    const denyEntry = auditEntries.find(
+      (e) => e.op === "get" && e.method === "grant" && String(e.result).includes("scope-deny"),
+    );
+    expect(denyEntry).toBeDefined();
+    const served = auditEntries.find((e) => e.op === "get" && e.result === "allowed");
+    expect(served).toBeUndefined();
+  });
+
+  it("F3: token for an entry with no adverse scope is still served (control)", async () => {
+    socketPath = await makeBroker();
+    const { token } = await mintGrant(grantsDb, "myagent", ["foo"], null);
+
+    const resp = await rpc(socketPath, { v: 1, op: "get", key: "foo", token });
+    expect(resp.ok).toBe(true);
+    if (resp.ok && "entry" in resp) {
+      expect(resp.entry).toEqual({ kind: "string", value: "bar-value" });
+    }
+  });
+
+  // ── F4: identity bind cross-check ──────────────────────────────────────────
+
+  it("F4: token presented on a socket whose bind identity != grant.agent_slug is rejected", async () => {
+    // Bind identity is "myagent"; grant belongs to "otheragent".
+    socketPath = await makeBroker("myagent");
+    const { token } = await mintGrant(grantsDb, "otheragent", ["foo"], null);
+
+    const resp = await rpc(socketPath, { v: 1, op: "get", key: "foo", token });
+    expect(resp.ok).toBe(false);
+    if (!resp.ok) {
+      expect(resp.code).toBe("DENIED");
+      expect(resp.msg).toContain("grant-identity-mismatch");
+    }
+    const mismatch = auditEntries.find(
+      (e) => e.op === "get" && String(e.result).includes("grant-identity-mismatch"),
+    );
+    expect(mismatch).toBeDefined();
+  });
+
+  it("F4: token whose grant.agent_slug matches the bind identity is served", async () => {
+    socketPath = await makeBroker("myagent");
+    const { token } = await mintGrant(grantsDb, "myagent", ["foo"], null);
+
+    const resp = await rpc(socketPath, { v: 1, op: "get", key: "foo", token });
+    expect(resp.ok).toBe(true);
+    if (resp.ok && "entry" in resp) {
+      expect(resp.entry).toEqual({ kind: "string", value: "bar-value" });
+    }
+  });
+
+  it("F4: no-bind-identity connection serves any valid token as before (unchanged flow)", async () => {
+    socketPath = await makeBroker(); // agentName === null
+    const { token } = await mintGrant(grantsDb, "otheragent", ["foo"], null);
+
+    const resp = await rpc(socketPath, { v: 1, op: "get", key: "foo", token });
+    expect(resp.ok).toBe(true);
+    if (resp.ok && "entry" in resp) {
+      expect(resp.entry).toEqual({ kind: "string", value: "bar-value" });
+    }
+    // No identity-mismatch denial when there is no bind identity to compare.
+    const mismatch = auditEntries.find(
+      (e) => e.op === "get" && String(e.result).includes("grant-identity-mismatch"),
+    );
+    expect(mismatch).toBeUndefined();
+  });
+});
+
 // ─── sec WS10-F3 / #1420: audit fail-closed mode ──────────────────────────────
 //
 // OUTCOME assertions: when the audit append for a secret release FAILS, the

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -1284,6 +1284,33 @@ export class VaultBroker {
         const grantResult = await validateGrant(this.grantsDb, req.token, req.key);
         if (grantResult.ok) {
           const grantId = grantResult.grant.id;
+          // sec #3084-F4: tokens are bearer capabilities, but when the
+          // connection ALSO carries a bind-time socket identity
+          // (`agentName` — established by socketPathToAgent, never from a
+          // wire payload), cross-check it against the grant's owning agent
+          // and reject a mismatch. This closes the case where a token
+          // leaked to another agent's container is replayed over that
+          // agent's own socket. Only enforced when an identity is present:
+          // the legitimate no-bind-identity flow (agentName === null on
+          // legacy / non-Linux / operator sockets) is unchanged — the
+          // token remains the sole auth there, exactly as before.
+          if (agentName !== null && grantResult.grant.agent_slug !== agentName) {
+            this.auditLogger.write({
+              ts: new Date().toISOString(),
+              op: "get",
+              key: req.key,
+              caller: auditCaller,
+              pid: auditPid,
+              cgroup: auditCgroup,
+              result: "denied:grant-identity-mismatch",
+              method: "grant",
+              grant_id: grantId,
+            });
+            socket.write(
+              encodeResponse(errorResponse("DENIED", "grant-identity-mismatch")),
+            );
+            return;
+          }
           const entry = this.secrets[req.key];
           if (entry === undefined) {
             this.auditLogger.write({
@@ -1299,6 +1326,31 @@ export class VaultBroker {
             });
             socket.write(
               encodeResponse(errorResponse("UNKNOWN_KEY", `Key not found: ${req.key}`)),
+            );
+            return;
+          }
+          // sec #3084-F3: enforce the per-entry scope on the token path too,
+          // keyed on the grant's OWNING agent (`grant.agent_slug`). The
+          // non-token ACL path checks `checkEntryScope` at line ~1456; the
+          // token path historically skipped it, so an entry's
+          // `scope.deny:[agent]` was silently ineffective against an
+          // outstanding token. Now a deny is honoured regardless of which
+          // path serves the read — defense-in-depth for per-agent scoping.
+          const tokenScope = checkEntryScope(entry.scope, grantResult.grant.agent_slug);
+          if (!tokenScope.allow) {
+            this.auditLogger.write({
+              ts: new Date().toISOString(),
+              op: "get",
+              key: req.key,
+              caller: auditCaller,
+              pid: auditPid,
+              cgroup: auditCgroup,
+              result: `denied:${tokenScope.reason}`,
+              method: "grant",
+              grant_id: grantId,
+            });
+            socket.write(
+              encodeResponse(errorResponse("DENIED", tokenScope.reason)),
             );
             return;
           }


### PR DESCRIPTION
## Summary

Two defense-in-depth hardenings on the vault broker capability-token `get` path (`src/vault/broker/server.ts`), from the #3084 security audit (findings F3/F4).

**F3 — entry scope skipped on the token path.** The non-token ACL path enforces `checkEntryScope` (server.ts ~1456); the capability-token `get` path validated the grant but never called it, so an entry's `scope.deny:[agent]` was silently ineffective against an outstanding token. Fix: the token path now runs `checkEntryScope(entry.scope, grant.agent_slug)` and denies (scope-deny / scope-allow) regardless of which path serves the read, keyed on the grant's owning agent.

**F4 — tokens were unbound bearer capabilities.** `validateGrant` never checked `grant.agent_slug` against the connection's bind identity, so a token leaked into another agent's container could be replayed over that agent's own socket. Fix: when a bind-time socket identity IS present (`agentName`, derived by `socketPathToAgent` from the bind path — never a wire payload), the broker cross-checks it against `grant.agent_slug` and rejects a mismatch (`grant-identity-mismatch`). The check only fires when an identity is available, so the legitimate no-bind-identity flow (legacy / non-Linux / operator sockets, `agentName === null`) is unchanged — the token remains the sole auth there, exactly as before.

## Why

Both are low-severity (F4 needs a container-FS breach to exploit) but cheap to close, and both make per-agent scoping deterministic instead of path-dependent. Aligns the token path's guarantees with the non-token ACL path.

## Test plan

New outcome-asserting tests in `src/vault/broker/server-grants.test.ts`:
- F3: a token whose entry `scope.deny`s the grant's agent is refused on the token path (was served before); a control token with no adverse scope is still served.
- F4: a token presented on a socket whose bind identity != `grant.agent_slug` is rejected; matching identity still serves; the no-bind-identity connection serves any valid token as before.

`bun test src/vault/broker/server-grants.test.ts` → 21 pass / 0 fail. `npm run lint` clean. Scoped run only; CI is the full-suite authority.

## Risk

Additive checks on a single code path; no change to the non-token ACL path or the no-bind-identity token flow. A revoked/expired/key-not-allowed token still falls through exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)