### PR TITLE
fix(telegram-plugin): redact malformed/expired auth-code pastes (#3084 security audit)

### DIFF
--- a/telegram-plugin/gateway/auth-loopback-relay.ts
+++ b/telegram-plugin/gateway/auth-loopback-relay.ts
@@ -317,13 +317,55 @@ export function parseLoopbackRedirect(input: string): ParsedRedirect {
 }
 
 /**
+ * A loopback host reference (`127.0.0.1` / `localhost`) anywhere in the text.
+ * Anchors the fail-safe detection to the loopback OAuth flow so a bare `code=`
+ * on some foreign host is NOT swept up (preserves the deliberate narrowness).
+ */
+const LOOPBACK_HOST_REF_RE = /(?:127\.0\.0\.1|localhost)/i
+
+/**
+ * A `code=` / token param carrying a non-empty value — the same param shapes
+ * the well-formed loopback-redirect path exchanges. Matched loosely (no strict
+ * URL structure) so a malformed paste — dropped port, missing `/`, stray
+ * surrounding text — that still carries a live OAuth `code` is caught.
+ */
+const AUTH_CODE_PARAM_RE =
+  /[?&#/]?\b(?:code|access_token|refresh_token|id_token)=[^\s&#]+/i
+
+/** A provider-denied `error=` param (the flow should surface + end). */
+const PROVIDER_ERROR_PARAM_RE = /[?&]error=[^\s&]+/i
+
+/**
+ * Fail-safe (security audit #3084, F2): does this text *look like* a loopback
+ * OAuth paste that carries a live `code` (or a provider `error`), even when it
+ * is too malformed to parse as a clean redirect URL? True only when BOTH a
+ * loopback host reference AND a code/token/error param are present — so
+ * unrelated chatter mentioning `localhost` (no `code=`) still flows through.
+ *
+ * This is intentionally broader than {@link parseLoopbackRedirect}: a paste
+ * with a dropped port or a missing `/` won't parse, yet may still hold a live
+ * credential that must be redacted rather than forwarded to the agent.
+ */
+export function looksLikeLoopbackCodePaste(text: string): boolean {
+  const trimmed = (text ?? '').trim()
+  if (trimmed.length === 0) return false
+  if (!LOOPBACK_HOST_REF_RE.test(trimmed)) return false
+  return (
+    AUTH_CODE_PARAM_RE.test(trimmed) || PROVIDER_ERROR_PARAM_RE.test(trimmed)
+  )
+}
+
+/**
  * Decide whether an inbound chat message should be CONSUMED by the loopback
  * paste intercept (and therefore never reach other handlers, and be deleted
  * from history). Deliberately narrow: a message merely *mentioning*
  * `localhost`/`127.0.0.1` ("what's listening on localhost?") must flow
- * through untouched. We consume only when the text actually parses as a
- * loopback redirect URL carrying a `code` — or a loopback URL carrying an
- * `error` param (the provider-denied case, which the flow should surface).
+ * through untouched. We consume when the text parses as a loopback redirect
+ * URL carrying a `code` — or a loopback URL carrying an `error` param (the
+ * provider-denied case, which the flow should surface) — OR, fail-safe, when
+ * it merely *looks like* a loopback code paste that is too malformed to parse
+ * cleanly but still carries a live `code` (security audit #3084, F2). A live
+ * credential must never fall through to the agent session unredacted.
  */
 export function shouldConsumeLoopbackPaste(text: string): boolean {
   const trimmed = (text ?? '').trim()
@@ -336,6 +378,8 @@ export function shouldConsumeLoopbackPaste(text: string): boolean {
   if (!parsed.ok && parsed.reason.startsWith('provider returned error')) {
     return true
   }
+  // Fail-safe: malformed-but-code-bearing loopback paste.
+  if (looksLikeLoopbackCodePaste(trimmed)) return true
   return false
 }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -18340,9 +18340,32 @@ async function handleInbound(
       redactAuthCodeMessage(bot.api as never, chat_id, msgId ?? null, line => process.stderr.write(line))
       return
     }
-    // Stale — kill the child and drop the entry, then fall through.
+    // Stale — the intercept window has closed. Kill the child and drop the
+    // entry, then fall through to the fail-safe below. We deliberately do NOT
+    // let the paste reach the agent: the pasted `code` may still be live
+    // (security audit #3084, F3), so the fail-safe redacts it.
     cancelLoopbackFlow(pendingLoop)
     pendingLoopbackFlows.delete(interceptKey)
+  }
+
+  // Fail-safe redaction (security audit #3084, F2/F3). A message that looks
+  // like a loopback OAuth redirect/code — even one too malformed to parse
+  // cleanly, or one that arrived just after the intercept TTL closed, or one
+  // with no active flow at all — must NEVER reach the (prompt-injectable)
+  // agent session or linger unredacted in chat while carrying a possibly-live
+  // credential. shouldConsumeLoopbackPaste is narrow (requires a loopback host
+  // reference AND a code/error param), so ordinary chatter mentioning
+  // localhost flows through untouched. Redact and drop rather than forward.
+  if (shouldConsumeLoopbackPaste(text)) {
+    redactAuthCodeMessage(bot.api as never, chat_id, msgId ?? null, line => process.stderr.write(line))
+    await switchroomReply(
+      ctx,
+      '_That looked like an OAuth redirect/code, so I removed it from chat and did not forward it. ' +
+        'If a Google/Microsoft account add is in progress, re-run the add command and paste the fresh ' +
+        '`127.0.0.1` URL — the previous code may have expired._',
+      { html: true },
+    )
+    return
   }
 
   // Auth-code intercept

--- a/telegram-plugin/tests/auth-loopback-relay.test.ts
+++ b/telegram-plugin/tests/auth-loopback-relay.test.ts
@@ -29,6 +29,7 @@ import {
   submitLoopbackRedirect,
   scrubSensitive,
   shouldConsumeLoopbackPaste,
+  looksLikeLoopbackCodePaste,
   trackFlowExit,
   cancelLoopbackFlow,
   MAX_PASTE_ATTEMPTS,
@@ -309,6 +310,42 @@ describe('shouldConsumeLoopbackPaste', () => {
     expect(
       shouldConsumeLoopbackPaste(`https://evil.example/?code=abc&state=${STATE}`),
     ).toBe(false)
+  })
+
+  // Fail-safe: malformed-but-code-bearing loopback pastes (security audit
+  // #3084, F2). These do NOT parse as a clean redirect, yet still carry a
+  // possibly-live OAuth `code` and MUST be consumed + redacted, not forwarded.
+  it('consumes a malformed loopback paste that still carries a code', () => {
+    // Dropped port.
+    expect(
+      shouldConsumeLoopbackPaste(`http://127.0.0.1/?code=abc&state=${STATE}`),
+    ).toBe(true)
+    // Missing `/` before the query.
+    expect(
+      shouldConsumeLoopbackPaste(`127.0.0.1:${PORT}?code=abc&state=${STATE}`),
+    ).toBe(true)
+    // Loopback URL buried in surrounding chatter.
+    expect(
+      shouldConsumeLoopbackPaste(`here it is: 127.0.0.1 code=abcdef123&state=${STATE} thanks`),
+    ).toBe(true)
+    // localhost variant, malformed.
+    expect(
+      shouldConsumeLoopbackPaste(`localhost blah code=xyz`),
+    ).toBe(true)
+  })
+})
+
+describe('looksLikeLoopbackCodePaste', () => {
+  it('is true only when BOTH a loopback host ref and a code/error param exist', () => {
+    expect(looksLikeLoopbackCodePaste(`127.0.0.1:${PORT}/?code=abc&state=${STATE}`)).toBe(true)
+    expect(looksLikeLoopbackCodePaste(`localhost/?error=access_denied`)).toBe(true)
+    // Loopback host but no code — ordinary chatter, must NOT match.
+    expect(looksLikeLoopbackCodePaste("what's listening on localhost?")).toBe(false)
+    expect(looksLikeLoopbackCodePaste('is 127.0.0.1 reachable from the container?')).toBe(false)
+    // Code but no loopback host — foreign URL, must NOT match (narrowness).
+    expect(looksLikeLoopbackCodePaste(`https://evil.example/?code=abc&state=${STATE}`)).toBe(false)
+    // Empty.
+    expect(looksLikeLoopbackCodePaste('')).toBe(false)
   })
 })
 

--- a/telegram-plugin/tests/gateway-loopback-paste-redact.test.ts
+++ b/telegram-plugin/tests/gateway-loopback-paste-redact.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+/**
+ * Structural integration test for the loopback-paste fail-safe redaction in
+ * the gateway's inbound handler (security audit #3084, F2/F3).
+ *
+ * Why structural: gateway/gateway.ts does not export its inbound handler, so a
+ * pure-functional invocation would require end-to-end harnessing of
+ * Bot/Grammy/Context. The decision predicate (shouldConsumeLoopbackPaste, incl.
+ * the malformed-paste fail-safe) is exhaustively unit-tested in
+ * `auth-loopback-relay.test.ts`, and the redaction primitive
+ * (redactAuthCodeMessage) in `auth-code-redact.test.ts`. What's left to assert
+ * here is that the gateway actually WIRES a fail-safe so a code-bearing paste
+ * that is malformed, or arrives just after the intercept TTL, or has no active
+ * flow, is redacted + dropped rather than forwarded to the agent.
+ *
+ * The invariants:
+ *   1. The stale (TTL-expired) loopback branch does NOT let the paste fall
+ *      through to the agent — it flows into the fail-safe below.
+ *   2. A fail-safe `if (shouldConsumeLoopbackPaste(text))` block exists that
+ *      redacts (redactAuthCodeMessage) and returns, sitting AFTER the
+ *      pending-flow branch but BEFORE the generic auth-code / agent-forward
+ *      handlers.
+ */
+describe('gateway loopback-paste fail-safe redaction — structural wiring', () => {
+  const src = readFileSync(
+    new URL('../gateway/gateway.ts', import.meta.url),
+    'utf8',
+  )
+
+  it('imports the consume predicate + redaction helper', () => {
+    expect(src).toMatch(/shouldConsumeLoopbackPaste/)
+    expect(src).toMatch(/redactAuthCodeMessage/)
+  })
+
+  it('has a fail-safe redact-and-return block guarded by shouldConsumeLoopbackPaste', () => {
+    // Isolate the fail-safe block: `if (shouldConsumeLoopbackPaste(text)) { ... }`
+    // that is NOT part of the `pendingLoop && ...` pending-flow branch.
+    const failSafe = src.match(
+      /if \(shouldConsumeLoopbackPaste\(text\)\) \{[\s\S]{0,600}?\n {2}\}/g,
+    )
+    expect(failSafe).not.toBeNull()
+    // The standalone fail-safe (the one NOT preceded by `pendingLoop &&`).
+    const standalone = (failSafe ?? []).find(
+      (b) => !b.startsWith('if (pendingLoop'),
+    )
+    expect(standalone).toBeDefined()
+    expect(standalone!).toMatch(/redactAuthCodeMessage/)
+    expect(standalone!).toMatch(/return/)
+  })
+
+  it('the stale loopback branch falls through to the fail-safe (does not forward)', () => {
+    // The stale-path comment must reference the fail-safe, and the fail-safe
+    // block must appear AFTER the pending-loop branch and BEFORE the generic
+    // auth-code intercept (`pendingReauthFlows`).
+    const failSafeIdx = src.indexOf(
+      'Fail-safe redaction (security audit #3084, F2/F3)',
+    )
+    const pendingLoopIdx = src.indexOf('const pendingLoop = pendingLoopbackFlows.get')
+    const reauthIdx = src.indexOf('const pendingReauth = pendingReauthFlows.get')
+    expect(failSafeIdx).toBeGreaterThan(-1)
+    expect(failSafeIdx).toBeGreaterThan(pendingLoopIdx)
+    expect(reauthIdx).toBeGreaterThan(failSafeIdx)
+  })
+})


### PR DESCRIPTION
## Problem

The Telegram-native OAuth loopback relay (`/auth google|microsoft account add`) accepts a `127.0.0.1:<port>/?code=...&state=...` redirect pasted back from the operator's phone. The gateway intercepts that paste so the (prompt-injectable) agent session never sees the OAuth `code` and the message is scrubbed from chat history. The #3084 security audit found two edge cases where a **live** `code` escaped that intercept.

### F2 (LOW/MED) — malformed paste falls through
`shouldConsumeLoopbackPaste` in `telegram-plugin/gateway/auth-loopback-relay.ts` only consumed a **fully well-formed** loopback redirect (it required `parseLoopbackRedirect` to succeed). A malformed-but-code-bearing paste — dropped port (`http://127.0.0.1/?code=...`), missing `/`, or the URL buried in surrounding text — failed the strict parse, was **not** consumed, and fell through to the agent bridge while still carrying a live unredeemed `code`, never redacted from chat.

### F3 (LOW) — post-TTL / no-flow paste falls through
In `gateway.ts` the stale branch (paste arriving after the 10-min `REAUTH_INTERCEPT_TTL_MS`) dropped the pending entry and let the message **fall through to the agent unredacted** — the `code` may still be live. A code-bearing paste with no active flow at all was likewise forwarded.

## Fix (deterministic, fail-safe)

- **`looksLikeLoopbackCodePaste(text)`** (new, exported): true only when the text contains **both** a loopback host reference (`127.0.0.1`/`localhost`) **and** a `code`/`access_token`/`refresh_token`/`id_token`/`error` param — matched loosely so a malformed paste still trips it. `shouldConsumeLoopbackPaste` now also returns true for these. Deliberately narrow: chatter merely mentioning `localhost` (no `code=`) still flows through, and a `code=` on a foreign host is **not** swept up.
- **Gateway fail-safe:** the stale loopback branch no longer forwards the paste — it falls into a new `if (shouldConsumeLoopbackPaste(text))` block that redacts (`redactAuthCodeMessage`: delete + 🔑 breadcrumb) and returns, covering the malformed / post-TTL / no-active-flow cases. A possibly-live credential is scrubbed, never delivered to the agent.
- The `code` is never logged; the single-use latch and bounded-attempts (`MAX_PASTE_ATTEMPTS`) behaviour is unchanged.

## Tests (outcome-asserting)

- `auth-loopback-relay.test.ts`: malformed loopback pastes (dropped port, missing `/`, buried in chatter, `localhost` variant) are consumed; a foreign-host `code` URL and localhost chatter are **not**; happy-path well-formed paste still consumed; new `looksLikeLoopbackCodePaste` unit coverage.
- `gateway-loopback-paste-redact.test.ts` (new, structural — gateway inbound handler is not exported, same pattern as `gateway-secret-detect.test.ts`): asserts the gateway wires the fail-safe `shouldConsumeLoopbackPaste` redact-and-return block **after** the pending-flow branch and **before** the generic auth-code / agent-forward handlers.

Scoped `vitest` (53 tests, 3 files) green; `npm run lint` clean. Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)