### PR TITLE
fix(host-control): close config_propose_edit hunk-relocation window (#3121 follow-up security review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ adds the compensating checks:
 Operator hand-edits remain outside the apply lock (a ~ms residual race,
 accepted and now documented as such — this path is not zero-race).
 
+Mixed-version note: an old gateway paired with a new hostd rejects the new
+`aborted_config_changed` finalize (unknown message type), leaving the approved
+card stale — fail-safe, since the abort means nothing was written.
+
 ### First-class `soul:` persona fields + `shape` discriminator (#1856)
 
 `AgentSoulSchema` now types `creature`, `vibe`, `expertise`, and `emoji`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+### config_propose_edit: hunk-relocation guards at apply time (#3121 follow-up security review)
+
+Follow-up to the #3084 audit fix merged in #3121, closing the relocation
+class its adversarial review demonstrated. Note on #3121's actual semantics:
+it did NOT pin a pre-image hash — it re-applied the stored diff against the
+then-current file, allowing any non-conflicting drift through. This change
+adds the compensating checks:
+
+- **Zero-context hunks are rejected** at intake (`E_PATCH_INVALID_SHAPE`) and
+  `git apply` no longer runs with `--unidiff-zero`. A zero-context hunk is
+  anchored purely by line numbers, so drift during the (up to 60-min)
+  approval window could relocate it into a different region — e.g. another
+  agent's block — while still passing schema validation. Nothing first-party
+  generates zero-context diffs.
+- **Semantic change-set pin (all callers):** the sorted set of YAML paths the
+  operator-approved diff changed at propose time must equal the set the
+  re-applied diff changes at apply time, or the apply aborts with
+  `E_CONFIG_CHANGED` (nothing written).
+- **Self-scope gate re-runs at apply time (non-admin callers):** a non-admin
+  agent's edit must still be self-scoped against the fresh post-image under
+  the apply lock, closing the propose-time-only escalation window
+  demonstrated by the review (relocation into another agent's block).
+- **New card outcome `aborted_config_changed`:** config-changed aborts no
+  longer mislabel the approval card as "reconcile failed; rolled back" when
+  nothing was written.
+
+Operator hand-edits remain outside the apply lock (a ~ms residual race,
+accepted and now documented as such — this path is not zero-race).
+
 ### First-class `soul:` persona fields + `shape` discriminator (#1856)
 
 `AgentSoulSchema` now types `creature`, `vibe`, `expertise`, and `emoji`

--- a/src/host-control/approval-gateway.ts
+++ b/src/host-control/approval-gateway.ts
@@ -33,7 +33,7 @@ export interface ApprovalResult {
   denySource?: "operator" | "dispatch_failure";
   /** Update the approval card with the apply outcome. */
   finalize: (outcome: {
-    outcome: "applied" | "reconcile_failed_rolled_back";
+    outcome: "applied" | "aborted_config_changed" | "reconcile_failed_rolled_back";
     detail?: string;
     /** Agents that must restart for the edit to go live (empty if fleetWide). */
     affectedAgents?: string[];
@@ -205,7 +205,7 @@ export class SocketApprovalGateway implements ApprovalGateway {
       const log = this.opts.log ?? (() => {});
 
       const finalize = async (outcome: {
-        outcome: "applied" | "reconcile_failed_rolled_back";
+        outcome: "applied" | "aborted_config_changed" | "reconcile_failed_rolled_back";
         detail?: string;
         affectedAgents?: string[];
         fleetWide?: boolean;

--- a/src/host-control/config-edit-validator.ts
+++ b/src/host-control/config-edit-validator.ts
@@ -223,6 +223,49 @@ function validateShape(
       };
     }
   }
+  // Zero-context hunks are rejected (#3121 follow-up security review): a hunk
+  // with no context lines is anchored ONLY by its `@@` line numbers, so after
+  // benign drift during the approval window it can silently relocate into a
+  // different region of the file (e.g. another agent's block) and still pass
+  // schema validation. Requiring at least one context line per hunk anchors
+  // the hunk to byte-matched surrounding text. Nothing first-party generates
+  // zero-context diffs (`git diff` defaults to 3 context lines;
+  // telegram-plugin/permission-diff.ts buildHunk uses contextN=3), so this
+  // only rejects hand-rolled `--unified=0` patches.
+  {
+    let inHunk = false;
+    let hunkHasContext = false;
+    const failZeroContext: ValidationFailure = {
+      ok: false,
+      code: "E_PATCH_INVALID_SHAPE",
+      detail:
+        "zero-context hunk not allowed; regenerate the diff with context " +
+        "lines (git diff default of 3)",
+    };
+    // Drop the artifact "" element a trailing newline leaves after split —
+    // it is not a real patch line and must not count as context.
+    const scanLines =
+      lines.length > 0 && lines[lines.length - 1] === ""
+        ? lines.slice(0, -1)
+        : lines;
+    for (const ln of scanLines) {
+      if (ln.startsWith("@@")) {
+        if (inHunk && !hunkHasContext) return failZeroContext;
+        inHunk = true;
+        hunkHasContext = false;
+      } else if (ln.startsWith("--- ") || ln.startsWith("+++ ")) {
+        if (inHunk && !hunkHasContext) return failZeroContext;
+        inHunk = false;
+      } else if (inHunk) {
+        // A ` `-prefixed line is context; a completely empty line is also
+        // treated as context (some emitters strip the single space on blank
+        // context lines, and `git apply --recount` accepts that form). `\`
+        // ("\ No newline at end of file") is metadata, `+`/`-` are edits.
+        if (ln.startsWith(" ") || ln === "") hunkHasContext = true;
+      }
+    }
+    if (inHunk && !hunkHasContext) return failZeroContext;
+  }
   return null;
 }
 
@@ -259,11 +302,15 @@ function applyPatch(
     writeFileSync(patchFile, normalizedDiff);
 
     const bin = gitBin ?? "git";
+    // NO `--unidiff-zero` (#3121 follow-up): a zero-context hunk is anchored
+    // only by its `@@` line numbers, so drift during the approval window
+    // could relocate it into a different region of the file. Stage 1 already
+    // rejects zero-context hunks with a targeted message; omitting the flag
+    // here means git apply itself also refuses them (defense in depth).
     const baseArgs = [
       "apply",
       "--whitespace=nowarn",
       "--recount",
-      "--unidiff-zero",
     ];
     const checkP1 = spawnSync(
       bin,

--- a/src/host-control/config-edit-validator.ts
+++ b/src/host-control/config-edit-validator.ts
@@ -227,8 +227,11 @@ function validateShape(
   // with no context lines is anchored ONLY by its `@@` line numbers, so after
   // benign drift during the approval window it can silently relocate into a
   // different region of the file (e.g. another agent's block) and still pass
-  // schema validation. Requiring at least one context line per hunk anchors
-  // the hunk to byte-matched surrounding text. Nothing first-party generates
+  // schema validation. Requiring at least one context line per hunk is a
+  // first-line filter, not the anchoring guarantee: a hunk whose only context
+  // is a blank line still passes with a near-useless anchor. The actual
+  // relocation guarantee is the apply-time change-set pin (plus the self-scope
+  // re-gate for non-admin callers). Nothing first-party generates
   // zero-context diffs (`git diff` defaults to 3 context lines;
   // telegram-plugin/permission-diff.ts buildHunk uses contextN=3), so this
   // only rejects hand-rolled `--unified=0` patches.

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -2347,11 +2347,16 @@ export class HostdServer {
    *
    * Deliberately OUT of scope per operator decision (single-operator
    * single-host posture, see PR description):
-   * crash-recovery journal, Prometheus metrics, TOCTOU re-validation,
-   * literal `flock` on the config file (the in-process mutex is
-   * sufficient — hostd is the only writer), attachment fallback for
-   * very large diffs, 5s safety-delay button swap, privilege-
-   * escalation detection.
+   * crash-recovery journal, Prometheus metrics, literal `flock` on the
+   * config file (the in-process mutex serializes hostd's own applies;
+   * operator hand-edits are NOT under the lock — a ~ms residual race
+   * remains, accepted), attachment fallback for very large diffs, 5s
+   * safety-delay button swap.
+   *
+   * TOCTOU re-validation and apply-time privilege-escalation checks ARE
+   * in scope since the #3084 audit + the #3121 follow-up: the apply path
+   * re-applies the stored diff under the lock, pins the semantic change
+   * set to what was approved, and re-runs the non-admin self-scope gate.
    */
   private async handleConfigProposeEdit(
     req: Extract<HostdRequest, { op: "config_propose_edit" }>,
@@ -2402,13 +2407,20 @@ export class HostdServer {
     //       own declared-model list (a forged proposal diff smuggling in any
     //       other field is rejected here).
     // Operators and admin agents skip the check (full trust).
+    //
+    // `beforeContent` is read for ALL callers: the apply path compares the
+    // propose-time semantic change set (`proposedChangedPaths`, below) against
+    // the change set the re-applied diff produces after any approval-window
+    // drift (#3121 follow-up). Read failure degrades to "" — the change set
+    // then covers the whole file, and any real apply-time change set will
+    // mismatch, aborting fail-closed.
+    let beforeContent: string;
+    try {
+      beforeContent = readFileSync(configPath, "utf-8");
+    } catch {
+      beforeContent = "";
+    }
     if (caller.kind === "agent" && this.opts.config.agents[caller.name]?.admin !== true) {
-      let beforeContent: string;
-      try {
-        beforeContent = readFileSync(configPath, "utf-8");
-      } catch {
-        beforeContent = "";
-      }
       // A non-admin edit is admitted if it is EITHER a self-scoped tools.allow
       // widen (the "🔁 Always allow" path) OR a self-scoped append to the
       // caller's own memory.mental_models[] (the agent-proposes → human-
@@ -2438,6 +2450,17 @@ export class HostdServer {
           .build(req.request_id, Date.now() - started);
       }
     }
+    // ── Propose-time semantic change set (#3121 follow-up) ─────────
+    // What the operator approves is the RENDERED DIFF's effect against the
+    // config as it stood at propose time. The apply path re-applies the diff
+    // against the then-current file; even with context anchoring, drift during
+    // the approval window could make the same textual hunks land at different
+    // YAML paths. Pin the semantic change set now and require the apply-time
+    // re-application to produce the SAME set, or abort.
+    const proposedChangedPaths = classifyBlastRadius(
+      beforeContent,
+      verdict.postApplyContent,
+    ).changedPaths;
     // ── Approval card ───────────────────────────────────────────────
     if (!this.opts.approvalGateway) {
       // #1761: missing approval-gateway wiring is an operator/infra
@@ -2497,6 +2520,7 @@ export class HostdServer {
       callerName,
       configPath,
       started,
+      proposedChangedPaths,
     );
     this.inflightConfigProposals.set(dedupeKey, run);
     try {
@@ -2520,6 +2544,7 @@ export class HostdServer {
     callerName: string,
     configPath: string,
     started: number,
+    proposedChangedPaths: string[],
   ): Promise<HostdResponse> {
     // ── Pre-approval bypass (#2975 Stage 2) ─────────────────────────
     // Before the rate limit, ask the gateway whether this EXACT (agent, diff)
@@ -2623,6 +2648,7 @@ export class HostdServer {
       callerName,
       configPath,
       started,
+      proposedChangedPaths,
     );
   }
 
@@ -2687,6 +2713,8 @@ export class HostdServer {
     callerName: string,
     configPath: string,
     started: number,
+    /** Sorted semantic change set approved at propose time (#3121 follow-up). */
+    proposedChangedPaths: string[],
   ): Promise<HostdResponse> {
     const approvalId = (this.opts.generateApprovalId ?? defaultApprovalId)();
     const approval = await this.opts.approvalGateway!.requestApproval({
@@ -2748,8 +2776,12 @@ export class HostdServer {
     }
     // ── Apply path (mutex-serialized) ───────────────────────────────
     // Serialize concurrent config-edit applies through a single
-    // in-process promise chain. Hostd is the only writer of
-    // switchroom.yaml; no cross-process flock is needed.
+    // in-process promise chain. Hostd is the only PROGRAMMATIC writer of
+    // switchroom.yaml, so no cross-process flock is used — but operator
+    // hand-edits are NOT under this lock: a hand-edit racing the short
+    // (milliseconds) window between the snapshot read and the write below is
+    // possible, just vanishingly unlikely. This is a known, accepted residual
+    // race — do not describe this path as zero-race.
     const release = await this.acquireConfigApplyLock();
     try {
       // Snapshot the live config so we can rollback if reconcile
@@ -2784,10 +2816,12 @@ export class HostdServer {
       // A unified diff only rewrites its own hunks, so a concurrent change to
       // some OTHER region of the file still applies cleanly and its edit
       // survives (legitimate non-conflicting concurrent edits complete). We
-      // ABORT with E_CONFIG_CHANGED ONLY when the diff no longer applies
-      // cleanly — a REAL conflict where the drift overlaps this diff's hunks.
-      // The config is left untouched on abort (no bytes written yet) — the
-      // agent must re-propose against the new base.
+      // ABORT with E_CONFIG_CHANGED when the diff no longer applies cleanly,
+      // when the re-applied diff would change different YAML paths than the
+      // operator approved, or when a non-admin caller's edit is no longer
+      // self-scoped against the drifted base (checks below). The config is
+      // left untouched on abort (no bytes written yet) — the agent must
+      // re-propose against the new base.
       const reverdict = validateConfigEdit({
         configPath,
         targetPath: req.args.target_path,
@@ -2797,8 +2831,10 @@ export class HostdServer {
         const why =
           `stored diff no longer applies against the current config` +
           `: ${reverdict.detail}`;
+        // Nothing was written — "aborted_config_changed", NOT the
+        // rollback outcome (#3121 follow-up, review finding 4).
         await approval.finalize({
-          outcome: "reconcile_failed_rolled_back",
+          outcome: "aborted_config_changed",
           detail: `config changed since proposal — re-propose (${why})`,
         });
         return this.configChangedSinceProposal(why, req, caller, started);
@@ -2806,6 +2842,58 @@ export class HostdServer {
       // Fresh post-image = current live file + the stored diff (re-applied
       // under the lock), never the propose-time whole-file snapshot.
       const postApplyFresh = reverdict.postApplyContent;
+      // ── #3121 follow-up — the re-applied diff must mean what was approved ──
+      // Even a clean re-apply can land at DIFFERENT YAML paths than the
+      // operator saw at propose time (context lines are not globally unique in
+      // a config full of structurally identical agent blocks). Structurally
+      // compare the semantic change set of (current live file → fresh
+      // post-image) against the propose-time set; any divergence aborts —
+      // nothing has been written yet.
+      const applyChangedPaths = classifyBlastRadius(
+        snapshot,
+        postApplyFresh,
+      ).changedPaths;
+      const sameChangeSet =
+        applyChangedPaths.length === proposedChangedPaths.length &&
+        applyChangedPaths.every((p, i) => p === proposedChangedPaths[i]);
+      if (!sameChangeSet) {
+        const why =
+          `re-applied diff changes different config paths than approved ` +
+          `(approved: [${proposedChangedPaths.join(", ")}]; ` +
+          `would change: [${applyChangedPaths.join(", ")}])`;
+        await approval.finalize({
+          outcome: "aborted_config_changed",
+          detail: `config changed since proposal — re-propose (${why})`,
+        });
+        return this.configChangedSinceProposal(why, req, caller, started);
+      }
+      // ── #3121 follow-up — re-run the self-scope gate at APPLY time ──
+      // The propose-time admitSelfScopedNonAdminEdit call proved the edit was
+      // self-scoped against the propose-time base. After drift, the re-applied
+      // diff could produce a DIFFERENT effect (e.g. relocate into another
+      // agent's block) — so for non-admin callers the gate must hold against
+      // the fresh post-image too, or a non-admin agent escalates across the
+      // approval window. Abort (nothing written) rather than apply.
+      if (
+        caller.kind === "agent" &&
+        this.opts.config.agents[caller.name]?.admin !== true
+      ) {
+        const reAdmission = admitSelfScopedNonAdminEdit(
+          snapshot,
+          postApplyFresh,
+          caller.name,
+        );
+        if (!reAdmission.ok) {
+          const why =
+            `re-applied diff is no longer self-scoped for non-admin caller ` +
+            `"${caller.name}": ${reAdmission.detail}`;
+          await approval.finalize({
+            outcome: "aborted_config_changed",
+            detail: `config changed since proposal — re-propose (${why})`,
+          });
+          return this.configChangedSinceProposal(why, req, caller, started);
+        }
+      }
       // In-place write preserving the inode (bind-mount safe). The old
       // `<path>.tmp` → rename() swap returned EBUSY here because
       // switchroom.yaml is itself a read-only bind-mount source mounted

--- a/src/web/config-diff.ts
+++ b/src/web/config-diff.ts
@@ -2,7 +2,7 @@
  * Generate a git-compatible unified diff for a switchroom.yaml edit.
  *
  * hostd's `config_propose_edit` applies the proposed patch with
- * `git apply --whitespace=nowarn --recount --unidiff-zero` (trying
+ * `git apply --whitespace=nowarn --recount` (trying
  * `-p1` then `-p0`) — see src/host-control/config-edit-validator.ts. To
  * guarantee the patch round-trips, we GENERATE it with the same tool
  * family: `git diff --no-index`. The two versions are written to

--- a/telegram-plugin/gateway/config-approval-handler.ts
+++ b/telegram-plugin/gateway/config-approval-handler.ts
@@ -474,7 +474,12 @@ export async function handleRequestConfigFinalize(
   const body =
     msg.outcome === "applied"
       ? `✅ **Applied**${msg.detail ? `\n${escapeMarkdown(msg.detail)}` : ""}${liveNote}`
-      : `⚠️ **Reconcile failed; rolled back**${msg.detail ? `\n${escapeMarkdown(msg.detail)}` : ""}`;
+      : msg.outcome === "aborted_config_changed"
+        ? // Nothing was written: the config drifted during the approval window
+          // and the apply aborted rather than land a different effect than the
+          // operator approved (#3121 follow-up).
+          `🚫 **Not applied — config changed since proposal**${msg.detail ? `\n${escapeMarkdown(msg.detail)}` : ""}`
+        : `⚠️ **Reconcile failed; rolled back**${msg.detail ? `\n${escapeMarkdown(msg.detail)}` : ""}`;
   try {
     // Finalize is terminal — strip the keyboard so the buttons are gone.
     await deps.editCard({

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -438,7 +438,7 @@ export interface RequestConfigApprovalMessage {
 export interface RequestConfigFinalizeMessage {
   type: "request_config_finalize";
   requestId: string;
-  outcome: "applied" | "reconcile_failed_rolled_back";
+  outcome: "applied" | "aborted_config_changed" | "reconcile_failed_rolled_back";
   /** Optional short diagnostic appended to the card body. */
   detail?: string;
   /**

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -398,6 +398,7 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
         || (m.requestId as string).length === 0
         || (m.requestId as string).length > 64) return false;
       if (m.outcome !== "applied"
+        && m.outcome !== "aborted_config_changed"
         && m.outcome !== "reconcile_failed_rolled_back") return false;
       if (m.detail !== undefined
         && (typeof m.detail !== "string"

--- a/tests/host-control/config-edit-validator.test.ts
+++ b/tests/host-control/config-edit-validator.test.ts
@@ -176,12 +176,16 @@ describe("validateConfigEdit — deep-path header actually APPLIES (#2605 regres
   // because `git apply -p1` stripped only `a/` and looked for
   // `state/config/switchroom.yaml`, which doesn't exist in the scratch dir.
   it("applies a diff whose headers carry the full config path", () => {
+    // Context lines are required since the #3121 follow-up banned
+    // zero-context hunks (relocation guard).
     const deepPathDiff =
       "--- a/state/config/switchroom.yaml\n" +
       "+++ b/state/config/switchroom.yaml\n" +
-      "@@ -4 +4 @@\n" +
+      "@@ -3,3 +3,3 @@\n" +
+      " telegram:\n" +
       '-  bot_token: "x"\n' +
-      '+  bot_token: "y"\n';
+      '+  bot_token: "y"\n' +
+      '   forum_chat_id: "1"\n';
     const result = validateConfigEdit({
       configPath,
       targetPath: "/state/config/switchroom.yaml",
@@ -198,9 +202,11 @@ describe("validateConfigEdit — deep-path header actually APPLIES (#2605 regres
     const bareDiff =
       "--- a/switchroom.yaml\n" +
       "+++ b/switchroom.yaml\n" +
-      "@@ -4 +4 @@\n" +
+      "@@ -3,3 +3,3 @@\n" +
+      " telegram:\n" +
       '-  bot_token: "x"\n' +
-      '+  bot_token: "z"\n';
+      '+  bot_token: "z"\n' +
+      '   forum_chat_id: "1"\n';
     const result = validateConfigEdit({
       configPath,
       targetPath: "/state/config/switchroom.yaml",

--- a/tests/host-control/config-propose-edit.test.ts
+++ b/tests/host-control/config-propose-edit.test.ts
@@ -79,7 +79,7 @@ function makeServer(opts: {
 /** Build a stub ApprovalGateway with a pre-canned verdict + finalize spy. */
 function stubGateway(verdict: "approve" | "deny" | "timeout") {
   const finalizeCalls: Array<{
-    outcome: "applied" | "reconcile_failed_rolled_back";
+    outcome: "applied" | "aborted_config_changed" | "reconcile_failed_rolled_back";
     detail?: string;
   }> = [];
   const requests: ApprovalRequest[] = [];
@@ -860,7 +860,7 @@ describe("hostd config_propose_edit — apply-time re-apply guard (#3084)", () =
   // `approve` (i.e. after propose-time validation, but before the apply runs).
   function driftingGateway(landed: string) {
     const finalizeCalls: Array<{
-      outcome: "applied" | "reconcile_failed_rolled_back";
+      outcome: "applied" | "aborted_config_changed" | "reconcile_failed_rolled_back";
       detail?: string;
     }> = [];
     const gw: ApprovalGateway = {
@@ -953,7 +953,9 @@ describe("hostd config_propose_edit — apply-time re-apply guard (#3084)", () =
     // Nothing was written → reconcile never ran.
     expect(reconcileInvocations).toBe(0);
     expect(finalizeCalls.length).toBe(1);
-    expect(finalizeCalls[0]!.outcome).toBe("reconcile_failed_rolled_back");
+    // Nothing was written, so the finalize outcome is the abort outcome —
+    // NOT the rollback outcome (#3121 follow-up, review finding 4).
+    expect(finalizeCalls[0]!.outcome).toBe("aborted_config_changed");
     expect(finalizeCalls[0]!.detail).toMatch(/config changed since proposal/);
     // The operator's conflicting edit SURVIVES; the proposal's change did NOT
     // land (the diff was never force-written over the drift).
@@ -984,5 +986,191 @@ describe("hostd config_propose_edit — apply-time re-apply guard (#3084)", () =
     expect(reconcileInvocations).toBe(1);
     const live = readFile(configPath, "utf8");
     expect(live).toContain("# touched by apply-path test");
+  });
+});
+
+/**
+ * #3121 follow-up security review — hunk-relocation guards.
+ *
+ * The merged #3084 fix re-applied the stored diff at apply time, but two
+ * relocation vectors remained:
+ *   1. `--unidiff-zero` let a zero-context hunk land purely by line number —
+ *      after benign drift it could relocate into ANOTHER agent's block while
+ *      still passing schema validation (non-admin privilege escalation: the
+ *      self-scope gate only ran at PROPOSE time).
+ *   2. Even WITH context lines, structurally identical agent blocks mean the
+ *      re-applied hunk can anchor in a different agent's block after drift.
+ *
+ * Fixes under test: stage-1 rejection of zero-context hunks (no more
+ * `--unidiff-zero`), the apply-time semantic change-set pin, and the
+ * apply-time re-run of the non-admin self-scope gate. These tests FAIL on the
+ * pre-fix code (the edits landed in the other agent's block / the wrong
+ * outcome was finalized).
+ */
+describe("hostd config_propose_edit — relocation guards (#3121 follow-up)", () => {
+  // bob is the only agent at PROPOSE time, so the generic (agent-name-free)
+  // hunk context below anchors uniquely in bob's block and the self-scope
+  // gate admits the edit.
+  const SINGLE_BOB_CONFIG =
+    "switchroom:\n" +
+    "  version: 1\n" +
+    "telegram:\n" +
+    '  bot_token: "x"\n' +
+    '  forum_chat_id: "1"\n' +
+    "agents:\n" +
+    "  bob:\n" +
+    '    topic_name: "Twin"\n' +
+    "    tools:\n" +
+    "      allow:\n" +
+    "        - mcp__a__one\n";
+
+  // The drift that lands during the approval window: the operator renamed the
+  // agent bob → eve (identical body). The hunk's generic context byte-matches
+  // the renamed block, so `git apply` re-applies the stored diff CLEANLY —
+  // but the edit now lands under agents.eve.*, not the approved agents.bob.*.
+  // (Verified against real git: the re-apply succeeds; only the semantic
+  // change-set pin / self-scope re-gate stop it.)
+  const DRIFTED_BOB_RENAMED_TO_EVE =
+    "switchroom:\n" +
+    "  version: 1\n" +
+    "telegram:\n" +
+    '  bot_token: "x"\n' +
+    '  forum_chat_id: "1"\n' +
+    "agents:\n" +
+    "  eve:\n" +
+    '    topic_name: "Twin"\n' +
+    "    tools:\n" +
+    "      allow:\n" +
+    "        - mcp__a__one\n";
+
+  // Bob widens his OWN tools.allow (self-scoped at propose time). The context
+  // lines carry no agent name, so after the rename drift they anchor in
+  // eve's block instead.
+  const GENERIC_CONTEXT_SELF_DIFF =
+    "--- a/switchroom.yaml\n" +
+    "+++ b/switchroom.yaml\n" +
+    "@@ -9,3 +9,4 @@\n" +
+    "     tools:\n" +
+    "       allow:\n" +
+    "         - mcp__a__one\n" +
+    "+        - mcp__evil__tool\n";
+
+  // The same edit with NO context lines at all — anchored purely by line
+  // numbers. Must be rejected at intake now that --unidiff-zero is gone.
+  const ZERO_CONTEXT_DIFF =
+    "--- a/switchroom.yaml\n" +
+    "+++ b/switchroom.yaml\n" +
+    "@@ -11,0 +12,1 @@\n" +
+    "+        - mcp__evil__tool\n";
+
+  function driftingGatewayTo(landed: string) {
+    const finalizeCalls: Array<{
+      outcome: "applied" | "aborted_config_changed" | "reconcile_failed_rolled_back";
+      detail?: string;
+    }> = [];
+    const gw: ApprovalGateway = {
+      async requestApproval(): Promise<ApprovalResult> {
+        writeFileSync(configPath, landed);
+        return {
+          verdict: "approve",
+          finalize: async (out) => {
+            finalizeCalls.push(out);
+          },
+        };
+      },
+    };
+    return { gw, finalizeCalls };
+  }
+
+  it("rejects a zero-context hunk at propose time with E_PATCH_INVALID_SHAPE and writes nothing", async () => {
+    writeFileSync(configPath, SINGLE_BOB_CONFIG);
+    const { gw, requests } = stubGateway("approve");
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      runReconcile: async () => ({ exit_code: 0, stdout: "", stderr: "" }),
+    });
+    await server.start();
+    const resp = await send({
+      unified_diff: ZERO_CONTEXT_DIFF,
+      request_id: "reloc-1",
+    });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_PATCH_INVALID_SHAPE/);
+    expect(resp.error).toMatch(/zero-context/);
+    // No approval card, no write — the line-number-anchored hunk never got a
+    // chance to relocate anywhere.
+    expect(requests.length).toBe(0);
+    expect(readFile(configPath, "utf8")).toBe(SINGLE_BOB_CONFIG);
+  });
+
+  it("non-admin edit that would relocate into another agent's block after drift ABORTS (no cross-agent write)", async () => {
+    writeFileSync(configPath, SINGLE_BOB_CONFIG);
+    const { gw, finalizeCalls } = driftingGatewayTo(DRIFTED_BOB_RENAMED_TO_EVE);
+    let reconcileInvocations = 0;
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      runReconcile: async () => {
+        reconcileInvocations += 1;
+        return { exit_code: 0, stdout: "", stderr: "" };
+      },
+    });
+    await server.start();
+    // Propose as NON-ADMIN bob: at propose time the hunk lands in bob's own
+    // block, so the self-scope gate admits it and the card goes out. During
+    // the window, the operator renamed bob → eve — the re-applied hunk's generic
+    // context now anchors in EVE's block. Pre-fix this WROTE the rule into
+    // agents.eve.tools.allow (cross-agent escalation). Now it must abort.
+    const resp = await send({
+      sockOwner: "bob",
+      unified_diff: GENERIC_CONTEXT_SELF_DIFF,
+      request_id: "reloc-2",
+    });
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/^E_CONFIG_CHANGED/);
+    expect(resp.error_envelope?.code).toBe("E_CONFIG_CHANGED");
+    // Nothing was written: eve's allow-list did NOT grow, the drifted config
+    // is byte-identical, and reconcile never ran.
+    const live = readFile(configPath, "utf8");
+    expect(live).toBe(DRIFTED_BOB_RENAMED_TO_EVE);
+    expect(live).not.toContain("mcp__evil__tool");
+    expect(reconcileInvocations).toBe(0);
+    expect(finalizeCalls.length).toBe(1);
+    expect(finalizeCalls[0]!.outcome).toBe("aborted_config_changed");
+  });
+
+  it("admin edit whose re-applied hunks land at DIFFERENT yaml paths after drift ABORTS with E_CONFIG_CHANGED", async () => {
+    writeFileSync(configPath, SINGLE_BOB_CONFIG);
+    const { gw, finalizeCalls } = driftingGatewayTo(DRIFTED_BOB_RENAMED_TO_EVE);
+    let reconcileInvocations = 0;
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      runReconcile: async () => {
+        reconcileInvocations += 1;
+        return { exit_code: 0, stdout: "", stderr: "" };
+      },
+    });
+    await server.start();
+    // Same relocation mechanics, but the caller is the ADMIN agent — the
+    // self-scope gate never runs, so the semantic change-set pin is the guard:
+    // the operator approved a change to agents.bob.*, the re-applied diff
+    // would change agents.eve.*. Apply-time effect must match what was
+    // approved, for ALL callers.
+    const resp = await send({
+      unified_diff: GENERIC_CONTEXT_SELF_DIFF,
+      request_id: "reloc-3",
+    });
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/^E_CONFIG_CHANGED/);
+    const live = readFile(configPath, "utf8");
+    expect(live).toBe(DRIFTED_BOB_RENAMED_TO_EVE);
+    expect(live).not.toContain("mcp__evil__tool");
+    expect(reconcileInvocations).toBe(0);
+    expect(finalizeCalls[0]!.outcome).toBe("aborted_config_changed");
   });
 });


### PR DESCRIPTION
## Why

PR #3121 (merged as a149108bf) was squash-merged before its adversarial security review completed. The review verdict was **FIX-FIRST** with a demonstrated blocker. This PR fixes all findings.

**Correcting the record on #3121's semantics:** its PR body claimed it would "pin the pre-image hash… abort if it drifted at all". The shipped code pins **no hash** — it re-applies the stored diff against the then-current file and allows any non-conflicting drift through. That is a deliberate availability trade-off (legitimate concurrent edits survive), but it left a relocation window this PR closes with compensating checks. A correcting comment has been left on #3121.

## Findings → fixes

1. **BLOCKER — self-scope gate not re-run at apply time (non-admin privilege escalation via hunk relocation).** `admitSelfScopedNonAdminEdit` ran only at propose time; the apply path re-ran only `validateConfigEdit`. Fixed: under the apply lock, for non-admin callers, the gate re-runs against `(snapshot, postApplyFresh)`; failure aborts with `E_CONFIG_CHANGED`, nothing written (`src/host-control/server.ts`).

2. **MAJOR — apply-time effect could differ from what the operator approved (all callers).** Fixed with both options, belt and braces:
   - `--unidiff-zero` is dropped and zero-context hunks are rejected at intake with a targeted `E_PATCH_INVALID_SHAPE` (`config-edit-validator.ts`). Verified nothing first-party generates zero-context diffs (`git diff` defaults to 3 context lines; `telegram-plugin/permission-diff.ts` `buildHunk` uses `contextN=3`); the only zero-context fixtures in the tree were in shape-**rejection** tests.
   - Context alone is not sufficient (verified against real git 2.47: a hunk without trailing context anchors at **EOF**, and structurally identical agent blocks are ambiguous anchors), so the apply path also pins the **semantic change set**: the sorted YAML paths changed at propose time must equal the paths the re-applied diff changes at apply time, or the apply aborts with `E_CONFIG_CHANGED`.

3. **MAJOR — merged PR body misdescribed the shipped semantics.** Stated plainly above and in the CHANGELOG; correcting comment left on #3121.

4. **MINOR — wrong finalize outcome on abort.** New `aborted_config_changed` outcome added to the union (`approval-gateway.ts`, `ipc-protocol.ts`, `ipc-server.ts` validation, card rendering in `config-approval-handler.ts`) and used on every nothing-was-written abort. Card renders "🚫 Not applied — config changed since proposal".

5. **MINOR — missing relocation-class tests.** Added in `tests/host-control/config-propose-edit.test.ts`:
   - zero-context hunk → rejected at propose, file byte-identical, no approval card;
   - non-admin proposal + drift (agent renamed during the approval window; the stored diff re-applies **cleanly** into the other agent's block) → aborts `E_CONFIG_CHANGED`, `aborted_config_changed` finalize, no cross-agent write, reconcile never runs;
   - same mechanics with an **admin** caller → change-set pin aborts.
   All three fail on the pre-fix code (the middle one is the review's demonstrated escalation).

6. **NIT — hand-edits aren't under the apply lock.** No code change (pre-existing, ~ms window); comments/docs now state the residual race explicitly instead of implying zero-race.

## Testing

- `vitest run tests/host-control/` — all pass except two pre-existing environment failures also present on unmodified main (`mount --bind` EBUSY repro needs privileged mount; hostd server docker-dependent suites), verified by baseline run on main.
- `vitest run src/mcp/hostd/server.test.ts src/web/config-diff.test.ts src/web/hostd-config-propose.test.ts src/host-control/*.test.ts telegram-plugin/gateway/config-approval-handler.test.ts` — 127/127 pass.
- `npm run lint` — clean (tsc + all 8 guard scripts).
- Two #2605 validator fixtures were updated to carry context lines (they incidentally used zero-context hunks; their header-normalization intent is preserved).

Do **not** auto-merge — this goes through adversarial re-review first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)