### PR TITLE
test(telegram): make the approval-leash test able to fail

### DIFF
--- a/telegram-plugin/gateway/approval-hold.ts
+++ b/telegram-plugin/gateway/approval-hold.ts
@@ -460,6 +460,30 @@ export function holdReasonFor(err: unknown): UndeliverableReason | null {
 }
 
 /**
+ * THE LEASH, as one shared decision — used by `sweepPermissionTtl`, which BOTH
+ * gateway.ts and the outcome test's harness call.
+ *
+ * The harness used to keep a PRIVATE copy of this check (a `ttlFreeze` flag), so
+ * deleting the real guard left every behavioural assertion GREEN — including the
+ * flagship "no deny verdict is ever dispatched". Only a source-text grep noticed,
+ * and greps drift. A test that cannot fail is not a test, and this is the test for
+ * the `no-self-escalation` invariant.
+ *
+ * A HELD entry NEVER expires. The TTL answers one question: "how long did the
+ * operator have to answer?" For a card that never landed — flood ban, 5xx, network
+ * partition — the answer is ZERO SECONDS.
+ */
+export function shouldExpirePermission(
+  pend: { undeliverable?: UndeliverableMark | null; startedAt: number },
+  now: number,
+  ttlMs: number,
+): boolean {
+  // Never auto-deny an ask no human ever saw. Not even on a deadline.
+  if (isHeldUndeliverable(pend)) return false
+  return now - pend.startedAt > ttlMs
+}
+
+/**
  * The TTL freeze predicate (PR 3).
  *
  * An entry marked undeliverable NEVER expires. The TTL answers "how long did

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -155,6 +155,7 @@ import {
   computeBootSweepStripTargets,
   distinctRequestIds,
 } from './permission-rearm.js'
+import { sweepPermissionTtl } from './permission-ttl-sweep.js'
 import { createMissedApprovalsStore, type MissedApproval } from './missed-approvals-store.js'
 import {
   createAlwaysAllowPersistQueue,
@@ -173,7 +174,6 @@ import {
   safeActionForRecord,
   selectOldestHeld,
   selectHeldForRedelivery,
-  isHeldUndeliverable,
   holdReasonFor,
   heldRetryBackoffMs,
   type UndeliverableMark,
@@ -7228,34 +7228,19 @@ const pendingStateReaper = setInterval(() => {
     if (now >= v.expiresAt) pendingAuthRmFlows.delete(k)
   }
   pendingVaultOps.sweep(now)
-  for (const [k, v] of pendingPermissions) {
-    // ─── THE LEASH (#3084 follow-up) ──────────────────────────────────────
-    // A HELD entry never expires. The TTL answers one question: "how long did
-    // the operator have to answer?" For a card that never landed — the send
-    // failed against a Telegram flood ban, a network partition, a 5xx — the
-    // answer is ZERO SECONDS. Running a clock the operator was never shown, and
-    // then reporting that silence to the agent as a denial, is the operator's
-    // own leash deciding for them.
-    //
-    // This is the exact 2026-07-11 overlord incident: a 4.6h ban against a
-    // 60-min TTL made the auto-deny below GUARANTEED to fire on an approval no
-    // human had ever seen. We escaped only because someone answered in tmux at
-    // ~50 minutes.
-    //
-    // Ken's call, explicit: hold, and make the block visible. Never auto-approve.
-    // Never auto-deny — not even on a deadline. The agent stays blocked; the card
-    // is re-delivered by sweepHeldPermissionCards() above once the channel
-    // reopens, and on delivery `startedAt` resets so the operator gets their full
-    // decision window starting from when they could first act.
-    //
-    // An indefinite block is BY DESIGN — /pending and tmux remain the escape
-    // hatches, and the block is surfaced off-Telegram in blocked-approvals/.
-    // reference/invariants.md § no-self-escalation, § on-leash.
-    if (isHeldUndeliverable(v)) continue
-    // hostd gated fleet-mutation verbs get a longer (30-min) human-scale
-    // decision window than the 10-min default (Bug 2 fix #2).
-    const ttl = ttlForTool(v.tool_name)
-    if (now - v.startedAt > ttl) {
+  // THE LEASH. The sweep — the guard AND the auto-deny it gates — now lives in
+  // permission-ttl-sweep.ts, and the outcome test's harness drives that exact
+  // function. It used to be an inline loop here while the harness kept a PRIVATE
+  // copy of the guard, so deleting the real check left every behavioural assertion
+  // GREEN and only a source-text grep noticed. A test that cannot fail is not a
+  // test, and this is the test for `no-self-escalation`. One implementation, two
+  // callers: there is no longer a gateway-side line whose deletion restores the
+  // auto-deny without removing the sweep entirely.
+  sweepPermissionTtl({
+    entries: pendingPermissions,
+    now,
+    ttlForTool,
+    onExpire: (k, v, ttl) => {
       // Don't just drop it: the claude turn is suspended INSIDE the MCP
       // permission call waiting for a verdict. A silent delete left it
       // wedged forever when the operator never tapped — permanent
@@ -7334,8 +7319,8 @@ const pendingStateReaper = setInterval(() => {
       pendingPermissions.delete(k)
       permCardStore.remove(k)
       reconcileBlockedApprovals()
-    }
-  }
+    },
+  })
   // Drop no-repeat suppression entries past the safety-cap window (the primary
   // bound is the operator-activity reset; this just keeps the map from growing).
   for (const [sig, at] of permissionTimeoutSignatures) {

--- a/telegram-plugin/gateway/permission-ttl-sweep.ts
+++ b/telegram-plugin/gateway/permission-ttl-sweep.ts
@@ -1,0 +1,66 @@
+/**
+ * The permission TTL sweep — the code path that used to auto-deny approvals the
+ * operator never saw.
+ *
+ * WHY THIS IS A MODULE AND NOT A LOOP INSIDE gateway.ts:
+ *
+ * gateway.ts has top-level side effects and is not importable from a test. The
+ * first version of the outcome test worked around that by letting its harness
+ * carry a PRIVATE re-implementation of this sweep. The result was a placebo:
+ * deleting the real guard from gateway.ts left every behavioural assertion GREEN,
+ * because the double silently compensated — only a source-text grep noticed.
+ *
+ * A test that cannot fail is not a test, and this is the sweep that implements the
+ * `no-self-escalation` / `on-leash` invariant. So the DECISION lives here, in one
+ * importable place, and both gateway.ts and the outcome test drive this exact
+ * function. Delete the leash check inside `shouldExpirePermission` and the outcome
+ * test goes red — because there is only one implementation to delete.
+ *
+ * @see reference/jobs/approve-what-my-agent-can-touch.md
+ * @see reference/invariants.md § no-self-escalation, § on-leash
+ */
+
+import { shouldExpirePermission, type UndeliverableMark } from './approval-hold.js'
+
+/** The fields of a pending permission this sweep actually reads. */
+export interface TtlSweepEntry {
+  tool_name: string
+  startedAt: number
+  undeliverable?: UndeliverableMark | null
+}
+
+export interface TtlSweepDeps<T extends TtlSweepEntry> {
+  /** The live pending-permission map. */
+  entries: Iterable<readonly [string, T]>
+  now: number
+  /** Per-tool TTL (hostd fleet-mutation verbs get a longer human-scale window). */
+  ttlForTool: (toolName: string) => number
+  /**
+   * Expire this request: dispatch the deny verdict, strip the card's keyboard,
+   * wake the parked turn, record the miss, and drop the entry. Everything the
+   * gateway does on a timeout — the sweep decides WHETHER, the caller decides HOW.
+   */
+  onExpire: (requestId: string, pend: T, ttlMs: number) => void
+}
+
+/**
+ * Expire every pending permission past its TTL — except the HELD ones, which
+ * never expire.
+ *
+ * Returns the ids it expired (for logging/tests).
+ */
+export function sweepPermissionTtl<T extends TtlSweepEntry>(
+  deps: TtlSweepDeps<T>,
+): string[] {
+  const expired: string[] = []
+  for (const [requestId, pend] of deps.entries) {
+    const ttlMs = deps.ttlForTool(pend.tool_name)
+    // THE LEASH. `shouldExpirePermission` returns false for any entry marked
+    // undeliverable — an ask the operator was never shown. Never auto-approve,
+    // never auto-deny, not even on a deadline.
+    if (!shouldExpirePermission(pend, deps.now, ttlMs)) continue
+    deps.onExpire(requestId, pend, ttlMs)
+    expired.push(requestId)
+  }
+  return expired
+}

--- a/telegram-plugin/tests/approval-hold-harness.ts
+++ b/telegram-plugin/tests/approval-hold-harness.ts
@@ -39,7 +39,6 @@ import {
   blockedApprovalsDir,
   selectHeldForRedelivery,
   selectOldestHeld,
-  isHeldUndeliverable,
   safeActionForRecord,
   holdReasonFor,
   heldRetryBackoffMs,
@@ -47,6 +46,7 @@ import {
   type BlockedApprovalStore,
 } from '../gateway/approval-hold.js'
 import { ttlForTool } from '../gateway/permission-timeout.js'
+import { sweepPermissionTtl } from '../gateway/permission-ttl-sweep.js'
 import { naturalAction } from '../permission-title.js'
 
 /** A pending permission, shaped exactly like gateway.ts's `pendingPermissions` value. */
@@ -153,10 +153,7 @@ export interface Harness {
   tap: (requestId: string, behavior: 'allow' | 'deny') => void
 }
 
-export function createHarness(opts: { ttlFreeze?: boolean; cap?: number; targets?: string[] } = {}): Harness {
-  // PR 3's TTL freeze. Defaults ON (the shipped behaviour); the outcome test
-  // flips it OFF to reproduce origin/main's auto-deny and prove the red.
-  const ttlFreeze = opts.ttlFreeze ?? true
+export function createHarness(opts: { cap?: number; targets?: string[] } = {}): Harness {
 
   const stateDir = mkdtempSync(join(tmpdir(), 'approval-hold-'))
   const floodPath = floodStatePath(stateDir)
@@ -360,18 +357,20 @@ export function createHarness(opts: { ttlFreeze?: boolean; cap?: number; targets
     }
 
     // The TTL sweep, as gateway.ts runs it.
-    for (const [k, v] of pending) {
-      // PR 3 — THE LEASH. A held entry NEVER expires: the TTL asks "how long
-      // did the operator have to answer?", and for a card that never landed the
-      // answer is zero seconds. With this guard removed we reproduce
-      // origin/main, which auto-denies an approval no human ever saw.
-      if (ttlFreeze && isHeldUndeliverable(v)) continue
-      if (now - v.startedAt > ttlForTool(v.tool_name)) {
+    // The TTL sweep — the REAL production function, not a copy. This is the whole
+    // point: the guard AND the auto-deny it gates live in ONE place that both the
+    // gateway and this harness call, so there is no private copy here that could
+    // silently compensate for a guard deleted from production.
+    sweepPermissionTtl({
+      entries: pending,
+      now,
+      ttlForTool,
+      onExpire: (k) => {
         verdicts.push({ requestId: k, behavior: 'deny', message: 'timed out' })
         pending.delete(k)
         reconcile()
-      }
-    }
+      },
+    })
   }
 
   function tap(requestId: string, behavior: 'allow' | 'deny'): void {

--- a/telegram-plugin/tests/approval-hold-outcome.test.ts
+++ b/telegram-plugin/tests/approval-hold-outcome.test.ts
@@ -31,6 +31,7 @@ import { describe, it, expect, afterEach } from 'vitest'
 import { rmSync, statSync, readFileSync } from 'node:fs'
 import { createHarness } from './approval-hold-harness.js'
 import { PERMISSION_TTL_DEFAULT_MS } from '../gateway/permission-timeout.js'
+import { shouldExpirePermission } from '../gateway/approval-hold.js'
 
 const MINUTE = 60_000
 const FOUR_HOURS = 4 * 60 * 60_000
@@ -40,15 +41,14 @@ afterEach(() => {
   for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
 })
 
-/** `ttlFreeze: false` reproduces origin/main — no hold, the TTL still fires. */
-function harness(opts: { ttlFreeze?: boolean } = {}) {
+function harness(opts: { targets?: string[] } = {}) {
   const h = createHarness(opts)
   dirs.push(h.stateDir)
   return h
 }
 
 /** The incident: a 4h ban is open, and the agent asks to run a command. */
-async function incident(opts: { ttlFreeze?: boolean } = {}) {
+async function incident(opts: { targets?: string[] } = {}) {
   const h = harness(opts)
   h.banFor(FOUR_HOURS)
   await h.raise('req-overlord-1', 'Bash', '{"command":"rm -rf ./build"}')
@@ -126,23 +126,25 @@ describe('an undeliverable approval is HELD, never denied', () => {
     expect(h.blockedStore.read()?.requestId).toBe('req-overlord-1')
   })
 
-  it('(c-counterfactual) WITHOUT the TTL freeze — origin/main — the same run auto-denies', async () => {
-    // This is the bug, reproduced. It is what test (c) above asserts against,
-    // and it is why the freeze is load-bearing rather than defensive. If this
-    // test ever goes green, the freeze has been removed and (c) is a lie.
-    const h = await incident({ ttlFreeze: false })
-
-    for (let elapsed = 0; elapsed <= 61 * MINUTE; elapsed += MINUTE) {
-      await h.tickSettled()
-      h.clock.advance(MINUTE)
+  it('(c-proof) the entry IS past its TTL — only the leash saves it', () => {
+    // Documents origin/main's behaviour WITHOUT re-implementing it. The pending
+    // entry is genuinely past the 60-minute TTL; the ONLY reason it survives is the
+    // held check inside `shouldExpirePermission`. Delete that check and (c) above
+    // goes RED — there is exactly one implementation, and both the gateway sweep
+    // and this harness call it.
+    const held = {
+      startedAt: 0,
+      undeliverable: { since: 0, retryableAt: 9e15, reason: 'flood_wait' as const },
     }
+    const seen = { startedAt: 0 }
+    const past = PERMISSION_TTL_DEFAULT_MS + 1
 
-    // A denial the operator never made, for a card they never saw.
-    expect(h.verdicts.length).toBe(1)
-    expect(h.verdicts[0]!.behavior).toBe('deny')
-    expect(h.pending.has('req-overlord-1')).toBe(false)
-    // …and it never landed a card, so it never sent one either.
-    expect(h.sends.length).toBe(0)
+    // A card the operator COULD see, left unanswered past the TTL → expires. That is
+    // the normal, correct timeout, and it is untouched.
+    expect(shouldExpirePermission(seen, past, PERMISSION_TTL_DEFAULT_MS)).toBe(true)
+    // The SAME clock, on a card that never landed → never expires.
+    expect(shouldExpirePermission(held, past, PERMISSION_TTL_DEFAULT_MS)).toBe(false)
+    expect(shouldExpirePermission(held, 9e15, PERMISSION_TTL_DEFAULT_MS)).toBe(false)
   })
 
   it('(d) past the ban, the card lands EXACTLY once — no loss, no duplicate', async () => {
@@ -259,16 +261,19 @@ describe('gateway wiring — the leash', () => {
     'utf8',
   )
 
-  it('the TTL sweep skips held entries entirely', () => {
-    const sweepStart = GATEWAY_SRC.indexOf('for (const [k, v] of pendingPermissions) {')
+  it('the TTL sweep routes through the SHARED shouldExpirePermission()', () => {
+    // This pin is no longer the safety net — the behavioural tests above are, and
+    // they now drive the same `shouldExpirePermission` the gateway does, so deleting
+    // the leash turns them RED. This only guards the WIRING: that the sweep can't
+    // regrow a private inline check that drifts from what the test exercises.
+    const sweepStart = GATEWAY_SRC.indexOf('sweepPermissionTtl({')
     expect(sweepStart).toBeGreaterThan(-1)
-    const sweep = GATEWAY_SRC.slice(sweepStart, sweepStart + 2500)
-    // The freeze must come BEFORE the TTL comparison, or it does nothing.
-    const freeze = sweep.indexOf('if (isHeldUndeliverable(v)) continue')
-    const ttlCheck = sweep.indexOf('if (now - v.startedAt > ttl)')
-    expect(freeze).toBeGreaterThan(-1)
-    expect(ttlCheck).toBeGreaterThan(-1)
-    expect(freeze).toBeLessThan(ttlCheck)
+    const sweep = GATEWAY_SRC.slice(sweepStart, sweepStart + 3500)
+    expect(GATEWAY_SRC).toContain('sweepPermissionTtl({')
+    // …and must NOT carry its own copy of the leash or the raw TTL comparison.
+    // …and the gateway must not regrow a private inline leash check.
+    expect(sweep).not.toContain('if (isHeldUndeliverable(v)) continue')
+    expect(sweep).not.toContain('if (now - v.startedAt > ttl)')
   })
 
   it('successful (re)delivery resets startedAt', () => {

--- a/telegram-plugin/tests/missed-approvals-wiring.test.ts
+++ b/telegram-plugin/tests/missed-approvals-wiring.test.ts
@@ -37,7 +37,7 @@ describe('missed-approvals re-offer wiring (#2862)', () => {
 
   it('appends the miss at TTL auto-deny, anchored to the card origin, gated by the kill switch', () => {
     // Within the pending-permission TTL sweep block.
-    const sweep = slice(GATEWAY, 'for (const [k, v] of pendingPermissions)', 5400)
+    const sweep = slice(GATEWAY, 'sweepPermissionTtl({', 5400)
     expect(sweep).toContain('if (MISSED_APPROVAL_REOFFER_ENABLED) {')
     expect(sweep).toContain('missedApprovalsStore.add({')
     expect(sweep).toContain('const origin = v.cards[0]')

--- a/telegram-plugin/tests/permission-no-repeat-wiring.test.ts
+++ b/telegram-plugin/tests/permission-no-repeat-wiring.test.ts
@@ -45,15 +45,15 @@ describe('no-repeat-on-timeout wiring', () => {
     // when Bug 2 added per-tool TTL + the timed-out keyboard-strip to this
     // block — the signature-record line now sits further down but the wiring
     // is intact.
-    const sweep = slice(GATEWAY, 'for (const [k, v] of pendingPermissions)', 5000)
+    const sweep = slice(GATEWAY, 'sweepPermissionTtl({', 5000)
     expect(sweep).toContain('timeoutDenyMessage(')
     expect(sweep).toContain('permissionTimeoutSignatures.set(')
   })
 
   it('the TTL auto-deny strips the timed-out card keyboard (Bug 2)', () => {
-    const sweep = slice(GATEWAY, 'for (const [k, v] of pendingPermissions)', 5000)
+    const sweep = slice(GATEWAY, 'sweepPermissionTtl({', 5000)
     // Per-tool TTL + keyboard-strip are both wired into the sweep.
-    expect(sweep).toContain('ttlForTool(')
+    expect(sweep).toContain('ttlForTool')
     expect(sweep).toContain('stripTimedOutPermissionCards(')
   })
 


### PR DESCRIPTION
## Summary

**The leash is correctly implemented on main. It is not protected.**

Delete `if (isHeldUndeliverable(v)) continue` from the TTL sweep in `gateway.ts` — restoring the exact auto-deny that caused the 2026-07-11 incident — and the flagship outcome test **stays green**:

```
✓ (c) at T+61min — PAST the 60-minute TTL — NO deny verdict is ever dispatched   3ms
× gateway wiring — the leash > the TTL sweep skips held entries entirely
  Tests  1 failed | 12 passed (13)
```

The only thing that fails is a **grep on source text**. Greps drift within days (CLAUDE.md says so explicitly). This is the test for the `no-self-escalation` invariant — the one that says the leash may never decide for the operator.

## Root cause

`gateway.ts` is not unit-importable (top-level side effects), so `approval-hold-harness.ts` carried its **own private copy** of the leash check:

```ts
// telegram-plugin/tests/approval-hold-harness.ts (main)
const ttlFreeze = opts.ttlFreeze ?? true
...
if (ttlFreeze && isHeldUndeliverable(v)) continue
```

The double silently compensated for a guard deleted from production. **A test that cannot fail is not a test.**

This also means the mutation evidence quoted in #3109's description was measured against the *test double*, not the shipped fix.

## Fix

The sweep — **the guard AND the auto-deny it gates** — moves into `permission-ttl-sweep.ts`. `gateway.ts` and the harness both call that one function.

There is no longer a gateway-side line whose deletion restores the auto-deny without removing the sweep entirely. The `ttlFreeze` flag is gone; the harness has no private copy left to flip.

### Proof — deleting the fix from the ONLY implementation

```
BASELINE:                                              Tests  13 passed (13)

════ DELETE THE LEASH from the shared sweep ════       Tests   6 failed | 7 passed (13)
════ DELETE the held check in shouldExpirePermission ══ Tests   7 failed | 6 passed (13)
```

Compare with main, where the same deletion yields `1 failed | 12 passed` and test (c) is one of the passes.

Also replaces `(c-counterfactual)` — which flipped the harness flag, i.e. mutated the test double rather than the fix — with `(c-proof)`: a direct assertion on the real predicate that the entry *is* genuinely past its TTL and only the leash saves it.

## Why this matters

The leash fix (#3107/#3108/#3109) is good and it is live. But nothing currently stops a future refactor from deleting the guard and shipping green. That is the failure mode that put an auto-denied approval in front of no human on 2026-07-11.

## Risk

**No production behaviour changes.** The sweep does exactly what it did — same guard, same auto-deny, same order — it just lives in a function the test can drive. Behaviour-preserving extraction plus test-integrity.

## Test plan

Full `vitest run`: **892 files / 14,145 tests, zero failures.** `npm run test:bun` green except `src/vault/broker/client-token.test.ts`, which fails identically on pristine `origin/main` (known CAP_CHOWN/sandbox class; this diff touches no vault file). `npm run lint` — all 8 gates clean.

Three neighbouring source-text pins re-anchor from the old inline loop to `sweepPermissionTtl({` — the pinned code is unchanged and still present.

Job spec: `reference/jobs/approve-what-my-agent-can-touch.md`
Invariants: `no-self-escalation`, `on-leash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mQR9UordBs4nJ797bxxod