### PR TITLE
fix(web): read the fallback blocked-approval record; pin the compose mount

### DIFF
--- a/src/web/blocked-approvals-read.ts
+++ b/src/web/blocked-approvals-read.ts
@@ -20,7 +20,14 @@ import { homedir } from "node:os";
  *
  * The record is written by the gateway on each blocked approval, one file per
  * agent, at `~/.switchroom/blocked-approvals/<agent>.json` (dir 0755, files
- * 0644). Two hard constraints on that contract, both learned the hard way:
+ * 0644) — and, when that shared dir is not writable by the agent's uid, at the
+ * FALLBACK `~/.switchroom/agents/<agent>/blocked-approval.json`. This reader
+ * scans BOTH. It did not when the feature shipped (#3109), which meant a
+ * fallback record was written to a file nobody ever read: the agent held, the
+ * record on disk, and the dashboard printing "No agent is blocked". Do not drop
+ * the fallback scan — see {@link FALLBACK_RECORD_NAME}.
+ *
+ * Two hard constraints on that contract, both learned the hard way:
  *
  *  1. **The web container runs as uid 1000 and cannot read the agent's own
  *     0600 state.** `~/.switchroom/agents/<agent>/telegram/*.json` is mode
@@ -73,6 +80,42 @@ export function blockedApprovalsDir(
   home: string = process.env.SWITCHROOM_HOME ?? process.env.HOME ?? homedir(),
 ): string {
   return resolve(home, ".switchroom", "blocked-approvals");
+}
+
+/**
+ * The FALLBACK record's filename, inside the agent's own state dir.
+ *
+ * `createBlockedApprovalStore` (telegram-plugin/gateway/approval-hold.ts) writes
+ * the shared record first; when the shared dir is not writable by the agent's
+ * uid (docker auto-created the bind source root-owned; a container predating the
+ * volume) it falls back to `~/.switchroom/agents/<agent>/blocked-approval.json`,
+ * which the scaffold chowns to the agent uid so the write always lands.
+ *
+ * This reader must scan BOTH, or the fallback is a record nobody reads — the
+ * agent is held, the record is on disk, and the dashboard prints "No agent is
+ * blocked". That is the reassuring lie this whole surface exists to kill, and it
+ * shipped that way in #3109: the fallback wrote a DIFFERENT filename in a
+ * DIFFERENT directory from the only one `readdirSync` looked at.
+ *
+ * It is readable. Verified live on the dev host, 2026-07-11:
+ *   - `~/.switchroom/agents/<agent>/` is 0775 (drwxrwxr-x), agent-uid owned —
+ *     traversable and listable by the web container's uid 1000.
+ *   - `docker exec switchroom-web` reads a 0644 file in that dir fine, and gets
+ *     "Permission denied" ONLY on the 0600 files (telegram/access.json). The
+ *     0600 MODE is the blocker, never the directory — and the fallback record is
+ *     written 0644 like the shared one.
+ *   - The web compose binds all of `~/.switchroom` at `/host-home/.switchroom`
+ *     with `HOME=/host-home`, so both locations resolve for this reader.
+ */
+export const FALLBACK_RECORD_NAME = "blocked-approval.json";
+
+/**
+ * Where the per-agent fallback records live: `~/.switchroom/agents`. Derived
+ * from the shared dir (its sibling) so every existing caller — and every test
+ * pointing at a tmpdir — picks the fallback scan up without changing its call.
+ */
+export function agentStateRoot(sharedDir: string): string {
+  return resolve(sharedDir, "..", "agents");
 }
 
 /** A finite number or null — a malformed timestamp must never reach the UI as
@@ -155,7 +198,24 @@ export interface BlockedApprovalsRead {
  */
 export function readBlockedApprovalsWithErrors(
   dir: string,
+  /** Per-agent fallback root. Defaults to the shared dir's `agents` sibling. */
+  agentsRoot: string = agentStateRoot(dir),
 ): BlockedApprovalsRead {
+  const shared = readSharedRecords(dir);
+  const fallback = readFallbackRecords(agentsRoot, new Set(shared.blocked.map((b) => b.agent)));
+
+  return {
+    // Longest-blocked first — the one that has been waiting on the operator
+    // the longest is the one that most needs them.
+    blocked: [...shared.blocked, ...fallback.blocked].sort(
+      (a, b) => a.blockedSince - b.blockedSince,
+    ),
+    unreadable: shared.unreadable + fallback.unreadable,
+  };
+}
+
+/** The shared, canonical surface: `<dir>/<agent>.json`. */
+function readSharedRecords(dir: string): BlockedApprovalsRead {
   let entries: string[];
   try {
     entries = readdirSync(dir);
@@ -200,12 +260,65 @@ export function readBlockedApprovalsWithErrors(
     if (record) out.push(record);
   }
 
-  return {
-    // Longest-blocked first — the one that has been waiting on the operator
-    // the longest is the one that most needs them.
-    blocked: out.sort((a, b) => a.blockedSince - b.blockedSince),
-    unreadable,
-  };
+  return { blocked: out, unreadable };
+}
+
+/**
+ * The FALLBACK surface: `<agentsRoot>/<agent>/blocked-approval.json`, written
+ * when the shared dir was not writable by the agent's uid.
+ *
+ * Skipped for any agent already carrying a shared record: the store unlinks its
+ * fallback the moment a shared write succeeds, so a leftover is stale by
+ * definition and must never double-report a block that is already surfaced.
+ *
+ * Enumeration failures here are counted honestly, on the same rule as the shared
+ * dir: ENOENT is an honest empty (no agents scaffolded on this host), anything
+ * else means we could not look and must not imply "nothing is blocked".
+ */
+function readFallbackRecords(
+  agentsRoot: string,
+  alreadySeen: ReadonlySet<string>,
+): BlockedApprovalsRead {
+  let agents: string[];
+  try {
+    agents = readdirSync(agentsRoot, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return { blocked: [], unreadable: 0 };
+    }
+    return { blocked: [], unreadable: 1 };
+  }
+
+  const out: BlockedApproval[] = [];
+  let unreadable = 0;
+
+  for (const agent of agents) {
+    if (alreadySeen.has(agent)) continue;
+
+    let text: string;
+    try {
+      text = readFileSync(join(agentsRoot, agent, FALLBACK_RECORD_NAME), "utf-8");
+    } catch (err) {
+      // ENOENT is the overwhelmingly normal case: this agent is not blocked, or
+      // its record landed in the shared dir like it should. Only a real read
+      // FAILURE (EACCES on a record written with the wrong mode, EIO) means an
+      // agent may be held behind a file we cannot see.
+      if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") unreadable++;
+      continue;
+    }
+
+    let record: BlockedApproval | null;
+    try {
+      record = coerce(JSON.parse(text) as unknown, agent);
+    } catch {
+      continue; // malformed — we looked, there is nothing honest to render.
+    }
+    if (record) out.push(record);
+  }
+
+  return { blocked: out, unreadable };
 }
 
 /**
@@ -218,8 +331,11 @@ export function readBlockedApprovalsWithErrors(
  * an "all clear" to the operator must use {@link readBlockedApprovalsWithErrors}
  * and check `unreadable` first.
  */
-export function readBlockedApprovals(dir: string): BlockedApproval[] {
-  return readBlockedApprovalsWithErrors(dir).blocked;
+export function readBlockedApprovals(
+  dir: string,
+  agentsRoot: string = agentStateRoot(dir),
+): BlockedApproval[] {
+  return readBlockedApprovalsWithErrors(dir, agentsRoot).blocked;
 }
 
 /**

--- a/src/web/blocked-approvals.test.ts
+++ b/src/web/blocked-approvals.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -12,6 +12,10 @@ import {
   type BlockedApproval,
 } from "./blocked-approvals-read.js";
 import { deriveAttention, handleGetSummary } from "./api.js";
+// The REAL gateway-side writer. The fallback contract below is a two-module
+// contract (writer picks the path, reader has to scan it); testing either half
+// alone is how it shipped broken.
+import { createBlockedApprovalStore } from "../../telegram-plugin/gateway/approval-hold.js";
 
 /**
  * The blocked-approvals surface: an agent held on an approval it could not
@@ -24,10 +28,17 @@ import { deriveAttention, handleGetSummary } from "./api.js";
  * must not hide the records it CAN read).
  */
 describe("readBlockedApprovals (Telegram-independent view of a held agent)", () => {
+  let root: string;
   let dir: string;
 
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "sr-blocked-appr-"));
+    // Mirror the production layout: the shared dir has an `agents` SIBLING (the
+    // per-agent fallback root the reader also scans). A bare mkdtemp dir would
+    // make that sibling resolve to `<tmp>/agents` — outside the fixture, and so
+    // not hermetic.
+    root = mkdtempSync(join(tmpdir(), "sr-blocked-appr-"));
+    dir = join(root, "blocked-approvals");
+    mkdirSync(dir, { recursive: true });
   });
   afterEach(() => {
     // chmod back first — a 0000 file inside can defeat the recursive rm.
@@ -36,7 +47,7 @@ describe("readBlockedApprovals (Telegram-independent view of a held agent)", () 
     } catch {
       /* not every case writes it */
     }
-    rmSync(dir, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
   });
 
   const NOW = 1783756731607;
@@ -307,6 +318,157 @@ describe("readBlockedApprovals (Telegram-independent view of a held agent)", () 
   it("handleGetBlockedApprovals reads the dir it is given", () => {
     write("overlord", overlord);
     expect(handleGetBlockedApprovals(dir).map((b) => b.agent)).toEqual(["overlord"]);
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // THE FALLBACK CONTRACT (#3109 gap). The gateway's store writes the shared
+  // record when it can and falls back to the agent's OWN state dir when the
+  // shared dir isn't writable by the agent's uid. That fallback shipped writing
+  // a DIFFERENT filename in a DIFFERENT directory from the only one this reader
+  // scanned — so the record existed, the agent was held, and the dashboard said
+  // "No agent is blocked". These drive the REAL writer against the REAL reader.
+  // ───────────────────────────────────────────────────────────────────────────
+  describe("the FALLBACK record (agent's own state dir) reaches the dashboard", () => {
+    /**
+     * The production trigger, faithfully: the SHARED dir cannot be written by
+     * this uid. In prod that is docker auto-creating the bind source root-owned
+     * while the agent runs as uid 10001+. A test can't chown, and it can't just
+     * chmod the shared dir either — `tryWrite` chmods its own parent back to
+     * 1777, and in-test we OWN it, so that would succeed and no fallback fires.
+     * So make the shared dir UNCREATABLE by locking its parent (the pattern from
+     * telegram-plugin/tests/approval-hold-record.test.ts). Same `tryWrite` →
+     * false → fallback branch, no root required.
+     */
+    let locked: string; // read-only parent
+    let sharedDir: string; // the (uncreatable) shared dir under it
+    let agentsRoot: string; // its `agents` sibling — the fallback root
+
+    beforeEach(() => {
+      locked = join(root, "locked");
+      sharedDir = join(locked, "blocked-approvals");
+      agentsRoot = join(locked, "agents");
+      mkdirSync(agentsRoot, { recursive: true });
+    });
+    afterEach(() => {
+      try {
+        chmodSync(locked, 0o755);
+      } catch {
+        /* not every case locks it */
+      }
+    });
+
+    /** The real gateway store, pointed at the locked layout. */
+    function heldStore(agent: string) {
+      const ownDir = join(agentsRoot, agent);
+      mkdirSync(ownDir, { recursive: true });
+      const s = createBlockedApprovalStore(sharedDir, agent, ownDir);
+      chmodSync(locked, 0o500); // shared dir now uncreatable — fallback territory
+      return { store: s, ownDir };
+    }
+
+    /** The real gateway store, writing into the WRITABLE outer fixture. */
+    function store(agent: string) {
+      const ownDir = join(root, "agents", agent);
+      mkdirSync(ownDir, { recursive: true });
+      return { store: createBlockedApprovalStore(dir, agent, ownDir), ownDir };
+    }
+
+    const rec = (agent: string) => ({
+      agent,
+      requestId: "req-held-1",
+      toolName: "Bash",
+      action: "run shell commands",
+      blockedSince: NOW - 47 * 60_000,
+      undeliverableSince: NOW - 47 * 60_000,
+      retryableAt: NOW + 13 * 60_000,
+      reason: "flood_wait" as const,
+    });
+
+    it("is READ by the web reader when the shared dir is unwritable", () => {
+      const s = heldStore("overlord");
+      s.store.write(rec("overlord"));
+
+      // The record landed in the agent's OWN dir, not the shared one…
+      expect(s.store.path).toBe(join(s.ownDir, "blocked-approval.json"));
+      // …and the reader finds it anyway. Before this fix: [] — a held agent,
+      // a record on disk, and a dashboard saying "No agent is blocked".
+      const blocked = readBlockedApprovals(sharedDir);
+      expect(blocked.map((b) => b.agent)).toEqual(["overlord"]);
+      expect(blocked[0].requestId).toBe("req-held-1");
+      expect(blocked[0].reason).toBe("flood_wait");
+      // And it is not miscounted as a read FAILURE — the surface must say
+      // "overlord is blocked", not "I could not look".
+      expect(readBlockedApprovalsWithErrors(sharedDir).unreadable).toBe(0);
+    });
+
+    it("is written world-readable — a 0600 fallback would be invisible to web", () => {
+      // The web container is uid 1000 and the agent dir is agent-uid-owned. The
+      // dir is traversable (0775); it is the FILE's mode that decides whether
+      // web can read it. 0600 here = a silently empty dashboard.
+      const s = heldStore("overlord");
+      s.store.write(rec("overlord"));
+      expect(statSync(s.store.path).mode & 0o004).toBe(0o004);
+    });
+
+    it("does not double-report an agent that also has a shared record", () => {
+      // The store unlinks its fallback once a shared write succeeds, so a
+      // leftover fallback is stale by definition. Belt-and-braces: even if both
+      // files exist, the agent surfaces ONCE, from the canonical shared record.
+      const s = store("overlord");
+      mkdirSync(s.ownDir, { recursive: true });
+      writeFileSync(
+        join(s.ownDir, "blocked-approval.json"),
+        JSON.stringify({ ...rec("overlord"), requestId: "req-STALE" }),
+      );
+      write("overlord", { ...rec("overlord"), requestId: "req-LIVE" });
+
+      const blocked = readBlockedApprovals(dir);
+      expect(blocked).toHaveLength(1);
+      expect(blocked[0].requestId).toBe("req-LIVE");
+    });
+
+    it("clears both locations, so a resolved hold leaves nothing behind", () => {
+      const s = heldStore("overlord");
+      s.store.write(rec("overlord"));
+      expect(readBlockedApprovals(sharedDir)).toHaveLength(1);
+      s.store.clear();
+      // A stale record would keep the dashboard shouting about a block that is
+      // over — the mirror image of the invisible-block bug, equally corrosive.
+      expect(readBlockedApprovals(sharedDir)).toEqual([]);
+    });
+
+    it("ranks a fallback record alongside shared ones by hold age", () => {
+      write("clerk", { ...rec("clerk"), blockedSince: NOW - 5 * 60_000 });
+      const s = store("marko");
+      mkdirSync(s.ownDir, { recursive: true });
+      writeFileSync(
+        join(s.ownDir, "blocked-approval.json"),
+        JSON.stringify({ ...rec("marko"), blockedSince: NOW - 3 * 3600_000 }),
+      );
+      // marko (3h, fallback) has been waiting longest and must lead.
+      expect(readBlockedApprovals(dir).map((b) => b.agent)).toEqual(["marko", "clerk"]);
+    });
+
+    it("an agents dir with no held agent is an honest empty, not an 'unreadable'", () => {
+      mkdirSync(join(root, "agents", "clerk"), { recursive: true });
+      mkdirSync(join(root, "agents", "overlord"), { recursive: true });
+      expect(readBlockedApprovalsWithErrors(dir)).toEqual({ blocked: [], unreadable: 0 });
+    });
+
+    it("counts an UNREADABLE fallback record rather than implying all-clear", () => {
+      const s = store("overlord");
+      const f = join(s.ownDir, "blocked-approval.json");
+      writeFileSync(f, JSON.stringify(rec("overlord")));
+      chmodSync(f, 0o000); // the 0600-mode trap, in its extreme form
+      try {
+        const { blocked, unreadable } = readBlockedApprovalsWithErrors(dir);
+        expect(blocked).toEqual([]);
+        // "I could not look" — NEVER "nothing is blocked".
+        expect(unreadable).toBe(1);
+      } finally {
+        chmodSync(f, 0o644);
+      }
+    });
   });
 });
 

--- a/telegram-plugin/gateway/approval-hold.ts
+++ b/telegram-plugin/gateway/approval-hold.ts
@@ -268,12 +268,31 @@ export function createBlockedApprovalStore(
    *
    * This exists so the feature cannot silently no-op. If the shared bind is
    * missing (a container predating the volume), or auto-created root-owned, the
-   * record still lands somewhere the operator and switchroom-web can read —
-   * web mounts all of `~/.switchroom`, so both locations are reachable.
+   * record still lands somewhere the operator and switchroom-web can read.
+   *
+   * **Reachable by mount is not the same as readable, and neither is the same as
+   * READ.** That elision is a bug this comment used to paper over: it claimed
+   * "web mounts all of ~/.switchroom, so both locations are reachable" — true,
+   * and irrelevant, because the reader only ever scanned the shared dir. The
+   * fallback was written to a file nobody read (#3109). Two things must hold, and
+   * both are load-bearing: if either regresses, the record exists, the agent is
+   * held, and the dashboard still prints "No agent is blocked".
+   *
+   *   1. **Mode.** The record is written 0644 into the 0775 agent dir. Verified
+   *      live: `docker exec switchroom-web` reads a 0644 file under
+   *      `~/.switchroom/agents/<agent>/` fine and gets EACCES only on the 0600
+   *      files beside it. The FILE's mode locks web out, never the directory.
+   *   2. **The reader must LOOK here.** It now does —
+   *      `src/web/blocked-approvals-read.ts` scans the shared dir AND
+   *      `agents/<agent>/blocked-approval.json` (its `FALLBACK_RECORD_NAME`,
+   *      which must stay in sync with the filename below).
    */
   fallbackDir?: string,
 ): BlockedApprovalStore {
   const primary = join(dir, `${agent}.json`)
+  // Keep in sync with FALLBACK_RECORD_NAME in src/web/blocked-approvals-read.ts —
+  // the reader matches this filename exactly. Pinned by the fallback-contract
+  // tests in src/web/blocked-approvals.test.ts.
   const fallback = fallbackDir != null ? join(fallbackDir, 'blocked-approval.json') : null
 
   /** Where the last successful write landed — `read`/`clear` must agree with it. */

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -621,6 +621,48 @@ describe("generateCompose", () => {
     expect(out).not.toContain("${HOME}");
   });
 
+  // ───────────────────────────────────────────────────────────────────────────
+  // The blocked-approvals surface (#3084 follow-up). When an approval card
+  // can't be delivered, the gateway HOLDS the approval — it never auto-denies —
+  // and writes a world-readable record into this SHARED dir so the operator can
+  // see the block without Telegram. Every agent gets the mount, which makes it
+  // the highest-blast-radius line in this generator: on 2026-06-23 a bind source
+  // whose root resolved to a CONTAINER path made docker auto-create root-owned
+  // dirs, the brokers crashed, and the fleet stuck in `Created`.
+  //
+  // reference/jobs/approve-what-my-agent-can-touch.md
+  // ───────────────────────────────────────────────────────────────────────────
+  it("mounts the shared blocked-approvals dir for EVERY agent, under the host-home prefix", () => {
+    const out = generateCompose({
+      config: makeConfig({ a: {}, b: {} }),
+      homeDir: "/home/op",
+    });
+
+    // Shared TOP-LEVEL dir, not per-agent state: switchroom-web reads every
+    // agent's record from one place. Writable (:rw) — the agent writes it.
+    const line = "/home/op/.switchroom/blocked-approvals:/state/blocked-approvals:rw";
+    expect(out).toContain(line);
+    // Once per agent. A record the gateway cannot write is a block the operator
+    // never sees, so a missing mount on ANY agent is a silent hole.
+    expect(out.split(line).length - 1).toBe(2);
+
+    // The bind SOURCE is the host-home prefix — never a container path. This is
+    // the 2026-06-23 outage in one assertion: a `/state/...` or `/host-home/...`
+    // source root is what took the fleet down.
+    expect(out).not.toContain("/state/agent/home/.switchroom/blocked-approvals");
+    expect(out).not.toContain("/host-home/.switchroom/blocked-approvals:");
+  });
+
+  it("cannot emit a blocked-approvals mount rooted at a container path", () => {
+    // assertPlausibleHostHome is the guard, and it fires BEFORE any line is
+    // emitted — so the dangerous mount is unrepresentable, not merely unlikely.
+    for (const bad of ["/state/agent/home", "/host-home", "/state"]) {
+      expect(() =>
+        generateCompose({ config: makeConfig({ a: {} }), homeDir: bad }),
+      ).toThrow(/host-home prefix/);
+    }
+  });
+
   it("emits skills (fleet-wide) + PER-AGENT credentials :ro mount (sec WS6-F2)", async () => {
     const { mkdtempSync, mkdirSync, rmSync } = await import("node:fs");
     const { tmpdir } = await import("node:os");


### PR DESCRIPTION
Closes the two review findings left open when the "hold the leash" stack (#3107/#3108/#3109) merged. The third — the placebo leash test — was closed by #3123, so this PR deliberately touches **none** of `gateway.ts`, `approval-hold-harness.ts`, or `approval-hold-outcome.test.ts`.

The shipped hold BEHAVIOUR is correct and unchanged. These are guards around it.

## Summary

**GAP 2 — the fallback blocked-approval record was invisible to the dashboard.**
`createBlockedApprovalStore` writes the shared record at `blocked-approvals/<agent>.json` and, when that dir is not writable by the agent's uid, falls back to `agents/<agent>/blocked-approval.json` — a different filename in a different directory. But `src/web/blocked-approvals-read.ts` only ever `readdirSync`'d the shared dir, so it could **never** see the fallback: agent held, record on disk, dashboard printing "No agent is blocked". That is the reassuring lie this surface exists to kill (the Hermes `registry.db` failure shape). The reader now scans both locations.

**GAP 3 — the fleet-wide `blocked-approvals` bind mount was unpinned.**
`grep -rn blocked-approvals tests/docker/compose-generator.test.ts` → zero hits, on the file CLAUDE.md names as THE pin for compose generation, for the highest-blast-radius line in it: a bad bind-source root took the whole fleet down on 2026-06-23.

## Why — the docblock was wrong, and that's what let the gap ship

The old comment claimed *"web mounts all of `~/.switchroom`, so both locations are reachable."* Reachable-by-mount is not readable, and neither is READ. I checked the live host instead of assuming, and the widely-repeated premise ("web cannot read the agent dir at all") is **false**:

- `~/.switchroom/agents/<agent>/` is **0775**, agent-uid owned → traversable and listable by the web container's uid 1000.
- `docker exec switchroom-web` reads a 0644 file in that dir fine, and gets "Permission denied" **only** on the 0600 files beside it (`telegram/access.json`). It is the FILE's mode that locks web out, never the directory — and the fallback record is written 0644, like the shared one.
- Web's compose binds all of `~/.switchroom` at `/host-home/.switchroom` with `HOME=/host-home`, so both locations resolve for this reader.

So the fix is the real one — make the record visible — rather than a docblock apology. The docblock is corrected to state both load-bearing conditions (the 0644 mode, and the reader actually scanning the location).

## Test plan

**`src/web/blocked-approvals.test.ts`** — 7 new tests driving the REAL gateway store against the REAL web reader. This is a two-module contract, and testing either half alone is exactly how it shipped broken. Covers: the fallback is read; it is written world-readable; no double-report when both records exist; both locations cleared on resolve; ranked by hold age alongside shared records; an agents dir with nothing held is an honest empty (not an "unreadable"); an **unreadable** fallback is COUNTED rather than implying all-clear. Existing fixtures moved to the production layout (shared dir with an `agents` sibling) so the fallback scan is hermetic.

**`tests/docker/compose-generator.test.ts`** — the mount is emitted once per agent, rooted at the host-home prefix, and unrepresentable with a container-path root (`assertPlausibleHostHome` throws first).

**Both guards mutation-tested** (real output, produced on this branch):

Reverting the reader to ignore the fallback — i.e. the shipped bug:
```
 FAIL  src/web/blocked-approvals.test.ts > ... > is READ by the web reader when the shared dir is unwritable
AssertionError: expected [] to deeply equal [ 'overlord' ]
 FAIL  ... > clears both locations, so a resolved hold leaves nothing behind
AssertionError: expected [] to have a length of 1 but got +0
 FAIL  ... > ranks a fallback record alongside shared ones by hold age
AssertionError: expected [ 'clerk' ] to deeply equal [ 'marko', 'clerk' ]
 FAIL  ... > counts an UNREADABLE fallback record rather than implying all-clear
AssertionError: expected +0 to be 1 // Object.is equality
```

Re-rooting the compose mount at `/state/agent/home` (the 2026-06-23 outage shape):
```
 FAIL  tests/docker/compose-generator.test.ts > generateCompose > mounts the shared blocked-approvals dir for EVERY agent, under the host-home prefix
AssertionError: expected '# generated by switchroom — do not ed…' to contain '/home/op/.switchroom/blocked-approval…'
      Tests  1 failed | 200 passed (201)
```

`npm run lint` clean (incl. `check-bot-api-wrapping`). Scoped vitest on the touched files: 252 passed. `npm run test:bun`: 1161 pass / 1 fail — `src/vault/broker/client-token.test.ts`, which reproduces on pristine `origin/main` and is **green in CI at the same SHA** (a local `CAP_CHOWN` sandbox artifact, not this diff).

## Risk

Low. The reader is read-only and degrades to an honest empty on every failure path; the gateway's hold behaviour is untouched. The compose change is test-only.

## Job spec

`reference/jobs/approve-what-my-agent-can-touch.md` (outcome `hold-the-leash`) — a held agent the operator cannot SEE is the job failing quietly. `reference/invariants.md` § no-self-escalation, § on-leash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mQR9UordBs4nJ797bxxod