### PR TITLE
test(telegram): revive the dead "never auto-approve" pin

### DIFF
--- a/telegram-plugin/tests/approval-hold-outcome.test.ts
+++ b/telegram-plugin/tests/approval-hold-outcome.test.ts
@@ -261,14 +261,27 @@ describe('gateway wiring — the leash', () => {
     'utf8',
   )
 
+  /**
+   * One anchor + one span for the TTL sweep, shared by every pin below.
+   *
+   * They drifted apart before: one pin still anchored on the inline `for` loop the
+   * shared-sweep extraction had deleted, so it silently matched nothing. A single
+   * definition means a future move breaks every pin at once — loudly — instead of
+   * quietly disarming one of them.
+   *
+   * The span must cover the whole `onExpire` body (~4.2k chars today).
+   */
+  const SWEEP_ANCHOR = 'sweepPermissionTtl({'
+  const SWEEP_SPAN = 6000
+
   it('the TTL sweep routes through the SHARED shouldExpirePermission()', () => {
     // This pin is no longer the safety net — the behavioural tests above are, and
     // they now drive the same `shouldExpirePermission` the gateway does, so deleting
     // the leash turns them RED. This only guards the WIRING: that the sweep can't
     // regrow a private inline check that drifts from what the test exercises.
-    const sweepStart = GATEWAY_SRC.indexOf('sweepPermissionTtl({')
+    const sweepStart = GATEWAY_SRC.indexOf(SWEEP_ANCHOR)
     expect(sweepStart).toBeGreaterThan(-1)
-    const sweep = GATEWAY_SRC.slice(sweepStart, sweepStart + 3500)
+    const sweep = GATEWAY_SRC.slice(sweepStart, sweepStart + SWEEP_SPAN)
     expect(GATEWAY_SRC).toContain('sweepPermissionTtl({')
     // …and must NOT carry its own copy of the leash or the raw TTL comparison.
     // …and the gateway must not regrow a private inline leash check.
@@ -288,9 +301,27 @@ describe('gateway wiring — the leash', () => {
 
   it('nothing in the permission path auto-approves', () => {
     // Never, under any circumstance. A held approval that "times out" into an
-    // allow would be the worst possible reading of Ken's call.
-    const sweepStart = GATEWAY_SRC.indexOf('for (const [k, v] of pendingPermissions) {')
-    const sweep = GATEWAY_SRC.slice(sweepStart, sweepStart + 2500)
+    // ALLOW would be the worst possible reading of Ken's call — the other half of
+    // no-self-escalation.
+    //
+    // This pin was DEAD. It anchored on `for (const [k, v] of pendingPermissions) {`,
+    // the inline loop that the shared-sweep extraction deleted. `indexOf` returned
+    // -1, `slice(-1, 2499)` returned the EMPTY STRING, and `not.toContain` passes on
+    // "" — so the sweep could be changed to dispatch `behavior: 'allow'` and all 13
+    // tests stayed green. Exactly the failure class this file exists to prevent,
+    // inside the file that exists to prevent it.
+    //
+    // Two rules now, and they apply to every grep pin here:
+    //   1. ASSERT THE ANCHOR RESOLVES. A silent -1 is what turns a pin into a lie.
+    //   2. Assert something POSITIVE inside the window, so a window that is too
+    //      small (or empty) fails loudly instead of vacuously passing a `not`.
+    const sweepStart = GATEWAY_SRC.indexOf(SWEEP_ANCHOR)
+    expect(sweepStart).toBeGreaterThan(-1)
+    const sweep = GATEWAY_SRC.slice(sweepStart, sweepStart + SWEEP_SPAN)
+
+    // POSITIVE: proves the window actually covers the verdict dispatch.
+    expect(sweep).toContain("behavior: 'deny',")
+    // …and the sweep may only ever deny. Never allow.
     expect(sweep).not.toContain("behavior: 'allow'")
   })
 })


### PR DESCRIPTION
Follow-up to #3123, found by its adversarial review.

## The bug

#3123 made the leash test able to fail. **It left a pin in the same `describe` block that could not** — of exactly the class it exists to kill.

`nothing in the permission path auto-approves` anchored on `for (const [k, v] of pendingPermissions) {` — the inline loop that #3123's shared-sweep extraction **deleted**:

```js
const sweepStart = GATEWAY_SRC.indexOf('for (const [k, v] of pendingPermissions) {')  // -> -1
const sweep = GATEWAY_SRC.slice(sweepStart, sweepStart + 2500)                        // -> ""  (start > end)
expect(sweep).not.toContain("behavior: 'allow'")                                      // -> passes on ""
```

The guard for the **other half of `no-self-escalation` — never auto-approve** — was structurally dead.

### Proof, on current `main`

Change the TTL sweep to dispatch `behavior: 'allow'` instead of `'deny'`:

```
MUTATION: the TTL sweep now AUTO-APPROVES every timed-out permission
  Tests  13 passed (13)      <- nothing notices
```

A permission the operator never answered would be **granted**, and CI stays green.

Not a runtime bug — production still only dispatches `deny` here. It is a dead guard, and it guards the worst possible failure.

## Fix

Two rules, applied to every grep pin in the file:

1. **Assert the anchor resolves** (`toBeGreaterThan(-1)`). A silent `-1` is what turns a pin into a lie — and `not.toContain` on an empty string *always* passes, so the failure is invisible by construction. That one line is what makes the whole grep-pin idiom fail loudly instead of silently.
2. **Assert something positive inside the window**, so a window that is too small or empty fails loudly instead of vacuously passing a negative.

The anchor and span are now single shared constants, so a future move breaks every pin at once — loudly — instead of quietly disarming one.

## After

```
BASELINE:                                     Tests  13 passed (13)
MUTATION A: sweep auto-approves               Tests   1 failed | 12 passed (13)
MUTATION B: sweep renamed (anchor unresolved) Tests   2 failed | 11 passed (13)
MUTATION C: leash deleted                     Tests   7 failed |  6 passed (13)
```

## Risk

**None. One test file, zero production change** (`git diff --name-only origin/main...HEAD` → `approval-hold-outcome.test.ts` only).

## Test plan

Scoped run of every suite this diff can affect (`approval-hold-*`, `missed-approvals-wiring`, `permission-no-repeat-wiring`): **102/102 pass.** Three mutations verified red, as above. Full local suite is unreliable in this worktree (symlinked `node_modules` can't resolve `@mtcute/node`) — CI is the arbiter.

## Known follow-up (not this PR)

The harness's delivery-time `live.startedAt = clock.now()` reset (`approval-hold-harness.ts`) is *mirrored* from production, not shared — so deleting the gateway's reset would leave the harness green, guarded only by a grep. Same class, smaller blast radius.

Job spec: `reference/jobs/approve-what-my-agent-can-touch.md`
Invariants: `no-self-escalation`, `on-leash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mQR9UordBs4nJ797bxxod