### PR TITLE
fix(vault): enforce caller-identity cross-check on write-grant path

### DIFF
--- a/src/vault/broker/server-write-grants.test.ts
+++ b/src/vault/broker/server-write-grants.test.ts
@@ -288,3 +288,159 @@ describe("VaultBroker: PUT with write-grant (#969 P1b)", () => {
     expect(resp.ok).toBe(true);
   });
 });
+
+// ─── sec #3084-F4 (write path): identity-bind cross-check on PUT ──────────────
+//
+// The `get` token path cross-checks a capability token's owning agent
+// against the calling socket's bind-time identity and denies a mismatch
+// (server.ts ~line 1297; covered by server-grants.test.ts F4). The write
+// (`put`) token path historically discarded `v.grant.agent_slug`, so a
+// write-grant token leaked to another agent's container could be replayed
+// over that agent's OWN bound socket to overwrite/plant shared secrets,
+// bypassing the path-as-identity ACL. This block asserts the OUTCOME of the
+// mirrored guard:
+//   (a) a write-grant whose agent_slug != the socket bind identity is DENIED
+//       with grant-identity-mismatch (and NOT written);
+//   (b) a matching-identity write still succeeds;
+//   (c) the no-bind-identity (operator/legacy) write path is unchanged.
+describe("VaultBroker: PUT write-grant identity bind (sec #3084-F4 write path)", () => {
+  let socketPath: string;
+  let tmpDir: string;
+  let vaultPath: string;
+  let grantsDb: Database;
+  let auditEntries: AuditEntry[];
+  let prevNonLinuxFlag: string | undefined;
+  let agentsDir: string;
+  let prevAgentsDirEnv: string | undefined;
+  const PASSPHRASE = "test-pass-phrase-for-this-test-only";
+  const brokers: VaultBroker[] = [];
+
+  // Build a broker with a real on-disk vault (PUT calls saveVault) and an
+  // optional bind identity. When `agentName` is passed, the handler defaults
+  // its per-connection identity to it (server.ts _handleDataConnection), which
+  // is exactly what socketPathToAgent would establish at bind time in prod.
+  async function makeBroker(agentName?: string): Promise<string> {
+    const sp = path.join(tmpDir, `${agentName ?? "nobind"}.sock`);
+    const b = new VaultBroker({
+      _testConfig: makeMinimalConfig(),
+      _testGrantsDb: grantsDb,
+      _testAuditLogger: {
+        write: (e: AuditEntry) => { auditEntries.push(e); return true; },
+        failOpenCount: () => 0,
+      },
+      _testVaultPath: vaultPath,
+      ...(agentName !== undefined ? { _testAgentName: agentName } : {}),
+    });
+    await b.start(sp, undefined, vaultPath);
+    b.unlockFromPassphrase(PASSPHRASE);
+    brokers.push(b);
+    return sp;
+  }
+
+  beforeEach(() => {
+    prevNonLinuxFlag = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = "1";
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-write-idbind-test-"));
+    vaultPath = path.join(tmpDir, "vault.enc");
+
+    agentsDir = path.join(tmpDir, "agents");
+    prevAgentsDirEnv = process.env.SWITCHROOM_AGENTS_DIR;
+    process.env.SWITCHROOM_AGENTS_DIR = agentsDir;
+
+    createVault(PASSPHRASE, vaultPath);
+    for (const [k, entry] of Object.entries(TEST_SECRETS)) {
+      if (entry.kind === "string") {
+        setStringSecret(PASSPHRASE, vaultPath, k, entry.value);
+      }
+    }
+
+    grantsDb = makeInMemoryGrantsDb();
+    auditEntries = [];
+  });
+
+  afterEach(() => {
+    for (const b of brokers.splice(0)) { try { b.stop(); } catch { /* ignore */ } }
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    if (prevAgentsDirEnv === undefined) delete process.env.SWITCHROOM_AGENTS_DIR;
+    else process.env.SWITCHROOM_AGENTS_DIR = prevAgentsDirEnv;
+    if (prevNonLinuxFlag === undefined) delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    else process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prevNonLinuxFlag;
+  });
+
+  it("(a) write-grant whose agent_slug != socket bind identity is DENIED (not written)", async () => {
+    // Bind identity is "myagent"; the leaked write-grant belongs to "otheragent".
+    const socketPath = await makeBroker("myagent");
+    const { token } = await mintGrant(
+      grantsDb, "otheragent", [], null, "leaked write grant", ["existing_key"],
+    );
+
+    const resp = await rpc(socketPath, {
+      v: 1,
+      op: "put",
+      key: "existing_key",
+      entry: { kind: "string", value: "planted-by-attacker" },
+      token,
+    });
+
+    expect(resp.ok).toBe(false);
+    if (!resp.ok) {
+      expect(resp.code).toBe("DENIED");
+      expect(resp.msg).toContain("grant-identity-mismatch");
+    }
+    // Audited as an identity-mismatch denial on the put/grant method.
+    const mismatch = auditEntries.find(
+      (e) => e.op === "put" && String(e.result).includes("grant-identity-mismatch"),
+    );
+    expect(mismatch).toBeDefined();
+    expect(mismatch?.method).toBe("grant");
+    // The write must NOT have been served.
+    const served = auditEntries.find((e) => e.op === "put" && e.result === "allowed");
+    expect(served).toBeUndefined();
+  });
+
+  it("(b) write-grant whose agent_slug matches the bind identity still succeeds", async () => {
+    const socketPath = await makeBroker("myagent");
+    const { token } = await mintGrant(
+      grantsDb, "myagent", [], null, undefined, ["existing_key"],
+    );
+
+    const resp = await rpc(socketPath, {
+      v: 1,
+      op: "put",
+      key: "existing_key",
+      entry: { kind: "string", value: "rotated-by-owner" },
+      token,
+    });
+
+    expect(resp.ok).toBe(true);
+    const served = auditEntries.find(
+      (e) => e.op === "put" && e.key === "existing_key" && e.result === "allowed",
+    );
+    expect(served).toBeDefined();
+    expect(served?.method).toBe("grant");
+  });
+
+  it("(c) no-bind-identity (operator/legacy) write path is unchanged — any valid write-grant is served", async () => {
+    // agentName === null: no identity to compare, token remains sole auth.
+    const socketPath = await makeBroker();
+    const { token } = await mintGrant(
+      grantsDb, "otheragent", [], null, undefined, ["existing_key"],
+    );
+
+    const resp = await rpc(socketPath, {
+      v: 1,
+      op: "put",
+      key: "existing_key",
+      entry: { kind: "string", value: "rotated-no-bind" },
+      token,
+    });
+
+    expect(resp.ok).toBe(true);
+    // No identity-mismatch denial when there is no bind identity to compare.
+    const mismatch = auditEntries.find(
+      (e) => e.op === "put" && String(e.result).includes("grant-identity-mismatch"),
+    );
+    expect(mismatch).toBeUndefined();
+  });
+});

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -1727,6 +1727,37 @@ export class VaultBroker {
       if (req.token !== undefined && req.token !== "") {
         const v = await validateGrantForWrite(this.grantsDb, req.token, req.key);
         if (v.ok) {
+          const writeGrantAgentSlug = v.grant.agent_slug;
+          // sec #3084-F4 (write path): tokens are bearer capabilities, but
+          // when the connection ALSO carries a bind-time socket identity
+          // (`agentName` — established by socketPathToAgent, never from a
+          // wire payload), cross-check it against the grant's owning agent
+          // and reject a mismatch — exactly as the `get` path does at
+          // ~line 1297. This closes the write equivalent of the leaked-token
+          // replay: a write-grant token leaked to another agent's container
+          // could otherwise be replayed over that agent's own socket to
+          // overwrite/plant shared secrets, bypassing the path-as-identity
+          // ACL. Only enforced when an identity is present: the legitimate
+          // no-bind-identity flow (agentName === null on legacy / non-Linux /
+          // operator sockets) is unchanged — the token remains the sole auth
+          // there, exactly as before.
+          if (agentName !== null && writeGrantAgentSlug !== agentName) {
+            this.auditLogger.write({
+              ts: new Date().toISOString(),
+              op: "put",
+              key: req.key,
+              caller: auditCaller,
+              pid: auditPid,
+              cgroup: auditCgroup,
+              result: "denied:grant-identity-mismatch",
+              method: "grant",
+              grant_id: v.grant.id,
+            });
+            socket.write(
+              encodeResponse(errorResponse("DENIED", "grant-identity-mismatch")),
+            );
+            return;
+          }
           writeGrantId = v.grant.id;
         } else if (
           v.reason === "grant-expired" ||


### PR DESCRIPTION
## Summary

The token `get` (read) path cross-checks a capability grant's owning agent (`grant.agent_slug`) against the calling socket's **bind-time** identity (`agentName` — set by `socketPathToAgent`, never from a wire payload) and denies a mismatch (`src/vault/broker/server.ts` ~line 1297, `grant-identity-mismatch`, sec #3084-F4). The write (`put`) path did **not** perform the equivalent check: after `validateGrantForWrite` succeeded it captured only `v.grant.id` and discarded `v.grant.agent_slug`.

## Bug

A write-grant token leaked into another agent's container could be replayed over **that agent's own bound socket** to overwrite or plant shared secrets (`shared/*`), bypassing the path-as-identity ACL. This is the exact cross-agent-replay case the read path was already hardened against — the write path was the missing half.

## Fix

Mirror the read-path guard exactly. After a successful `validateGrantForWrite`, when a bind identity is present (`agentName !== null`) and `v.grant.agent_slug !== agentName`, DENY with an audited `grant-identity-mismatch` (op `put`, method `grant`, `grant_id`) before the write is accepted — same error string and audit idiom as the read path.

The no-bind-identity flow (`agentName === null`: operator / legacy / non-Linux sockets) is **unchanged** — the token remains sole auth there, exactly as on the read path. No new identity requirement is introduced where the read path doesn't have one.

## Test

Extends `src/vault/broker/server-write-grants.test.ts` with a write-path mirror of the read-path F4 outcome tests:
- **(a)** a write-grant whose `agent_slug` differs from the socket bind identity is **DENIED** with `grant-identity-mismatch` and is **not** written (asserts the deny + audit row + absence of an `allowed` put row).
- **(b)** a matching-identity write still succeeds.
- **(c)** the no-bind-identity (operator/legacy) write path is unchanged — any valid write-grant is served, with no mismatch denial.

Test (a) **fails without the guard** (the malicious cross-agent write succeeds) — it asserts the outcome, not just the code path. Verified by stashing the `server.ts` change and re-running.

## Test plan

- `bun test src/vault/broker/server-write-grants.test.ts` → **10 pass / 0 fail** (7 pre-existing + 3 new).
- Guard confirmed load-bearing: with the `server.ts` fix reverted, test (a) fails (`expect(resp.ok).toBe(false)` → received `true`).
- `npm run lint` → clean (tsc `--noEmit` + all 8 guard scripts, incl. `check-vault-test-hermeticity`).

_Note: `src/vault/broker/server-token-fallthrough.test.ts` has one failing `list`-path assertion that reproduces identically on pristine `origin/main` with this diff stashed — pre-existing, unrelated to this `put`-path change (likely a `bun:sqlite`/non-Linux env artifact in the sandbox; CI is the authority for that path)._

## Why / Risk

Advances the **on-the-leash** / **single-tenant** invariants: the path-as-identity ACL is the cross-agent isolation boundary, and this closes a replay hole in it. Risk is contained to the write-grant token path; the legitimate owner-writes and operator/no-bind flows are exercised green by tests (b) and (c).

Found in security review of the vault write-grant path (sec #3084 family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)