### PR TITLE
fix(telegram): gate auth: callback family behind allowFrom (fleet account-swap bypass)

### DIFF
--- a/telegram-plugin/gateway/callback-query-handlers.ts
+++ b/telegram-plugin/gateway/callback-query-handlers.ts
@@ -2534,6 +2534,18 @@ async function handleOperatorEventCallback(ctx: Context, data: string): Promise<
 // stub so any stale pinned message that fires an `auth:*` tap is
 // silently dismissed instead of crashing the gateway.
 async function handleAuthDashboardCallback(ctx: Context): Promise<void> {
+  // Strict allowFrom gate, identical to every other mutating handler in
+  // this file (handleOperatorEventCallback, the vra:/vrs:/vd:/vg: families).
+  // Its absence was a security hole: `auth:use:<label>` drives
+  // `client.setActive(label)` — a fleet-wide OAuth account swap — so an
+  // ungated handler let any tapper (e.g. a member of an admin forum/
+  // supergroup with an empty group allowFrom) swap the active account.
+  const senderId = String(ctx.from?.id ?? '')
+  const access = loadAccess()
+  if (!access.allowFrom.includes(senderId)) {
+    await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+    return
+  }
   const data = ctx.callbackQuery?.data ?? ''
   const currentAgent = getMyAgentName()
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -24905,7 +24905,18 @@ bot.command('usage', async ctx => {
         // /auth snapshot does. switchroomReply routes through the rich path
         // (replyWithRichMessage), which accepts reply_markup. Build a grammy
         // InlineKeyboard so the markup type matches switchroomReply's contract.
-        const kbRows = buildSnapshotKeyboard(snapshots, { now: new Date(), demo })
+        // Defense-in-depth (mirrors the operator-private `/auth` treatment,
+        // gateway.ts ~24036): outside a private chat, strip the
+        // `auth:use:<label>` "Switch fleet" rows so the fleet-wide account-
+        // swap button is never even offered in a group/forum. The dispatch-
+        // site allowFrom gate is the load-bearing control; this just avoids
+        // dangling a privileged button in front of non-operators.
+        let kbRows = buildSnapshotKeyboard(snapshots, { now: new Date(), demo })
+        if (ctx.chat?.type !== 'private') {
+          kbRows = kbRows.filter(
+            (row) => !row.some((b) => b.callbackData?.startsWith('auth:use:')),
+          )
+        }
         const keyboard = new InlineKeyboard()
         kbRows.forEach((row, ri) => {
           if (ri > 0) keyboard.row()
@@ -25033,7 +25044,19 @@ bot.on('callback_query:data', async ctx => {
   // Auth dashboard buttons (`auth:<verb>:<agent>[:<slot>]`). Route
   // through a dedicated handler that maps each action onto the
   // existing CLI invocations plus dashboard refresh.
+  //
+  // Strict allowFrom gate like every other mutating callback family
+  // (`eff:`/`apv:`/`cfg:`/`cn:`/`mdl:`). Its absence was a vulnerability:
+  // `auth:use:<label>` drives `client.setActive(label)`, a fleet-wide
+  // OAuth account swap — on an admin forum/supergroup agent with an empty
+  // group allowFrom, any member could tap it and swap the active account.
   if (data.startsWith('auth:')) {
+    const access = loadAccess()
+    const senderId = String(ctx.from?.id ?? '')
+    if (!access.allowFrom.includes(senderId)) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' })
+      return
+    }
     await handleAuthDashboardCallback(ctx)
     return
   }

--- a/telegram-plugin/tests/callback-query-handlers.test.ts
+++ b/telegram-plugin/tests/callback-query-handlers.test.ts
@@ -41,6 +41,16 @@ import { createSweepableStore } from '../gateway/pending-state-stores.js'
 import { StagingMap } from '../secret-detect/staging.js'
 import { InlineKeyboard } from 'grammy'
 
+// Mock the auth-broker client so the `auth:use:` swap path is observable
+// (spy on setActive) without a live UDS broker. Only handleAuthDashboardCallback
+// touches getAuthBrokerClient, so this is inert for every other family here.
+const brokerMock = vi.hoisted(() => ({
+  setActive: vi.fn(async () => ({ active: 'acct-b', fanned: ['a1'] })),
+}))
+vi.mock('../gateway/auth-broker-client.js', () => ({
+  getAuthBrokerClient: vi.fn(async () => ({ setActive: brokerMock.setActive })),
+}))
+
 // ── Fakes ────────────────────────────────────────────────────────────────
 
 interface FakeCtxOpts {
@@ -567,6 +577,34 @@ describe('handleAuthDashboardCallback', () => {
       text: 'Missing account label.',
       show_alert: false,
     })
+  })
+
+  // Security gate (found in an adversarial security review): the auth: family
+  // is a mutating callback family (auth:use:<label> → broker.setActive, a
+  // fleet-wide OAuth account swap) and MUST enforce the same allowFrom gate as
+  // every sibling family. Without the gate, any tapper on an admin forum/
+  // supergroup with an empty group allowFrom could swap the active account.
+  it('rejects an auth:use swap from a sender not on allowFrom (never reaches setActive)', async () => {
+    const { deps } = makeDeps() // allowFrom = ['111','222']
+    const h = createCallbackQueryHandlers(deps)
+    brokerMock.setActive.mockClear()
+    const { ctx, raw } = makeCtx({ senderId: '999', data: 'auth:use:acct-b' })
+    await h.handleAuthDashboardCallback(ctx)
+    expect(raw.answerCallbackQuery).toHaveBeenCalledWith({ text: 'Not authorized.' })
+    // The load-bearing assertion: the swap must not fire for an unauthorized tap.
+    expect(brokerMock.setActive).not.toHaveBeenCalled()
+  })
+
+  it('lets an allowFrom sender through to the setActive swap path', async () => {
+    const { deps } = makeDeps()
+    const h = createCallbackQueryHandlers(deps)
+    brokerMock.setActive.mockClear()
+    const { ctx, raw } = makeCtx({ senderId: '111', data: 'auth:use:acct-b' })
+    await h.handleAuthDashboardCallback(ctx)
+    expect(brokerMock.setActive).toHaveBeenCalledWith('acct-b')
+    expect(raw.answerCallbackQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('Switched fleet → acct-b') }),
+    )
   })
 })
 

--- a/telegram-plugin/tests/callback-query-handlers.test.ts
+++ b/telegram-plugin/tests/callback-query-handlers.test.ts
@@ -44,12 +44,39 @@ import { InlineKeyboard } from 'grammy'
 // Mock the auth-broker client so the `auth:use:` swap path is observable
 // (spy on setActive) without a live UDS broker. Only handleAuthDashboardCallback
 // touches getAuthBrokerClient, so this is inert for every other family here.
-const brokerMock = vi.hoisted(() => ({
-  setActive: vi.fn(async () => ({ active: 'acct-b', fanned: ['a1'] })),
-}))
-vi.mock('../gateway/auth-broker-client.js', () => ({
-  getAuthBrokerClient: vi.fn(async () => ({ setActive: brokerMock.setActive })),
-}))
+//
+// The spy is created *inside* the factory and re-exported as a test-only
+// handle (`__setActiveSpy`) rather than closed over from a `vi.hoisted`
+// binding: bun's vitest-compat layer implements `vi.mock`/`vi.fn` but NOT
+// `vi.hoisted`, so a hoisted-closure mock throws `vi.hoisted is not a
+// function` under `bun test` (CI's bun-test-run shard runs this whole dir).
+// A single `setActive` instance is closed over and returned by every
+// `getAuthBrokerClient()` call, so the handler and the tests observe the
+// same spy.
+vi.mock('../gateway/auth-broker-client.js', () => {
+  const setActive = vi.fn(async () => ({ active: 'acct-b', fanned: ['a1'] }))
+  return {
+    getAuthBrokerClient: vi.fn(async () => ({ setActive })),
+  }
+})
+import { getAuthBrokerClient } from '../gateway/auth-broker-client.js'
+// The mocked getAuthBrokerClient closes over one shared `setActive` spy and
+// returns it on every call, so resolving the client here yields the SAME spy
+// the handler observes. A getter defers the read to test-run time (after the
+// mock is live under both runners); a beforeEach caches the resolved spy.
+let resolvedSetActiveSpy: ReturnType<typeof vi.fn> | undefined
+const brokerMock = {
+  get setActive(): ReturnType<typeof vi.fn> {
+    if (!resolvedSetActiveSpy) throw new Error('setActive spy not resolved yet')
+    return resolvedSetActiveSpy
+  },
+}
+beforeEach(async () => {
+  const client = (await getAuthBrokerClient('test-agent')) as {
+    setActive: ReturnType<typeof vi.fn>
+  }
+  resolvedSetActiveSpy = client.setActive
+})
 
 // ── Fakes ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

The Telegram `auth:*` callback family had **no per-user authorization gate**, unlike every sibling callback family. Found in an adversarial security review (confirmed HIGH).

Every other mutating callback family gates at the dispatch site — `eff:` (`EFFORT_CALLBACK_PREFIX`), `apv:`, `cfg:`, `cn:`, `mdl:` all do `loadAccess()` + `allowFrom.includes(senderId)` + a "Not authorized." toast + `return`. In `telegram-plugin/gateway/gateway.ts` the `auth:` dispatch went straight into `handleAuthDashboardCallback(ctx)` with no check, and the handler itself (`telegram-plugin/gateway/callback-query-handlers.ts`) had no internal gate either — the only handler in that file lacking one.

## Why it matters

`auth:use:<label>` drives `client.setActive(label)` — a **fleet-wide OAuth account swap**. On an `admin: true` forum/supergroup agent with an empty group `allowFrom`, any group member could tap the "Switch fleet" button and swap the active account for the entire fleet.

## Fix

Mirrors the exact idiom the sibling families already use:

1. **Primary / load-bearing** — allowFrom gate at the `auth:` dispatch site in `gateway.ts`, byte-for-byte the same shape as the neighboring `eff:`/`apv:`/`cfg:` branches.
2. **Defense-in-depth** — the same gate inside `handleAuthDashboardCallback`, matching its immediate sibling `handleOperatorEventCallback` and every other handler in that file (they all self-gate).
3. **Defense-in-depth** — `/usage` strips the `auth:use:<label>` "Switch fleet" rows from the keyboard in non-private chats, matching the operator-private `/auth` treatment, so the privileged button is never even rendered in a group/forum.

## Test plan

- Extended `telegram-plugin/tests/callback-query-handlers.test.ts`:
  - an `auth:use:` tap from a sender NOT on `allowFrom` is rejected with "Not authorized." and **never reaches `setActive`** (the load-bearing assertion, via a mocked auth-broker client spy);
  - an `allowFrom` sender passes through to the `setActive` swap.
- Verified the new test **fails with the gate removed** (unauthorized sender reaches `setActive` and gets "Switched fleet → acct-b") — proving the test asserts the outcome, not just the code path.
- `./node_modules/.bin/vitest run telegram-plugin/tests/callback-query-handlers.test.ts` → 43 passed.
- `npm run lint` → clean (tsc + all 8 guard scripts, incl. `check-bot-api-wrapping`).

## Risk

Low. The change only adds an authorization check to a family that had none, plus a group-chat keyboard trim. Authorized operators (private DM, on `allowFrom`) are unaffected — existing `/auth` and `/usage` flows retain full behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)